### PR TITLE
Fix sign_up_clever, enable clever signups for LAUSD

### DIFF
--- a/dashboard/app/controllers/omniauth_callbacks_controller.rb
+++ b/dashboard/app/controllers/omniauth_callbacks_controller.rb
@@ -297,7 +297,7 @@ class OmniauthCallbacksController < Devise::OmniauthCallbacksController
   private def register_new_user(user, provider)
     # Disallow sign up with email addresses from disallowed domains
     domain = user.email&.split('@', 2)&.last
-    if Policies::Devise::EmailDomains::DISALLOWED_DOMAINS.include?(domain)
+    if disallowed_login?(domain:, provider:)
       flash.alert = I18n.t('devise.registrations.disallowed_domain', domain: domain)
       return redirect_to user_session_path
     end
@@ -311,6 +311,13 @@ class OmniauthCallbacksController < Devise::OmniauthCallbacksController
     }
     sign_up_url = determine_sign_up_url(user)
     render 'omniauth/redirect', layout: false, locals: {sign_up_url: sign_up_url}
+  end
+
+  # Custom handling for the LAUSD email domain
+  # Clever is an exception to the disallowed domain rule
+  # TODO: refactor this into district-level configuration
+  private def disallowed_login?(domain:, provider:)
+    Policies::Devise::EmailDomains::DISALLOWED_DOMAINS.include?(domain) && Policies::Devise::EmailDomains::PROVIDER_EXCEPTIONS.exclude?(provider)
   end
 
   private def determine_sign_up_url(user)

--- a/dashboard/app/controllers/omniauth_callbacks_controller.rb
+++ b/dashboard/app/controllers/omniauth_callbacks_controller.rb
@@ -254,6 +254,9 @@ class OmniauthCallbacksController < Devise::OmniauthCallbacksController
     params[:user_type] = cookies['sign_up_user_type'] unless params[:user_type]
     user = User.new.tap do |u|
       User.initialize_new_oauth_user(u, auth_hash, params)
+      u.oauth_token = auth_hash.credentials&.token
+      u.oauth_token_expiration = auth_hash.credentials&.expires_at
+      u.oauth_refresh_token = auth_hash.credentials&.refresh_token
       prepare_locale_cookie u
     end
 

--- a/dashboard/app/controllers/omniauth_callbacks_controller.rb
+++ b/dashboard/app/controllers/omniauth_callbacks_controller.rb
@@ -240,23 +240,23 @@ class OmniauthCallbacksController < Devise::OmniauthCallbacksController
     session[:sign_up_type] = AuthenticationOption::CLEVER
 
     auth_hash = inject_clever_data(auth_hash())
+    # If the user's creds match an existing Clever account, they should have been signed
+    # in already. If not, check for a non-Clever account with a matching email. If it exists,
+    # display an interim page prompting the user to either log in to that account or create a new one
+    # with a different email.
+    email = auth_hash.info&.email
+    if email.present?
+      email_already_exists = User.find_by_email_or_hashed_email(email).present?
+      return redirect_to users_existing_account_path({provider: auth_hash.provider, email: email}) if email_already_exists
+    end
+
     params = auth_params.presence || {}
     params[:user_type] = cookies['sign_up_user_type'] unless params[:user_type]
-    user = User.from_omniauth(auth_hash, params, request)
-    prepare_locale_cookie user
+    user = User.new.tap do |u|
+      User.initialize_new_oauth_user(u, auth_hash, params)
+      prepare_locale_cookie u
+    end
 
-    # if the registration credentials identify us as an existing user, simply
-    # sign in as that user.
-    return sign_in_user user if user.persisted?
-
-    # if a user account with the same email (that could not be authenticated
-    # with the given registration credentals) exists, display an interim page
-    # prompting the user to either log in to that account or create a new one
-    # with a manually-provided email.
-    existing_account = User.find_by_email_or_hashed_email(user.email).present?
-    return redirect_to users_existing_account_path({provider: auth_hash.provider, email: user.email}) if existing_account
-
-    # otherwise, this is a new registration
     register_new_user(user, AuthenticationOption::CLEVER)
   end
 

--- a/dashboard/app/controllers/omniauth_callbacks_controller.rb
+++ b/dashboard/app/controllers/omniauth_callbacks_controller.rb
@@ -300,7 +300,7 @@ class OmniauthCallbacksController < Devise::OmniauthCallbacksController
   private def register_new_user(user, provider)
     # Disallow sign up with email addresses from disallowed domains
     domain = user.email&.split('@', 2)&.last
-    if disallowed_login?(domain:, provider:)
+    if Policies::Devise::EmailDomains.disallowed_login?(domain: domain, provider: provider)
       flash.alert = I18n.t('devise.registrations.disallowed_domain', domain: domain)
       return redirect_to user_session_path
     end
@@ -314,13 +314,6 @@ class OmniauthCallbacksController < Devise::OmniauthCallbacksController
     }
     sign_up_url = determine_sign_up_url(user)
     render 'omniauth/redirect', layout: false, locals: {sign_up_url: sign_up_url}
-  end
-
-  # Custom handling for the LAUSD email domain
-  # Clever is an exception to the disallowed domain rule
-  # TODO: refactor this into district-level configuration
-  private def disallowed_login?(domain:, provider:)
-    Policies::Devise::EmailDomains::DISALLOWED_DOMAINS.include?(domain) && Policies::Devise::EmailDomains::PROVIDER_EXCEPTIONS.exclude?(provider)
   end
 
   private def determine_sign_up_url(user)

--- a/dashboard/app/controllers/registrations_controller.rb
+++ b/dashboard/app/controllers/registrations_controller.rb
@@ -38,7 +38,7 @@ class RegistrationsController < Devise::RegistrationsController
   #
   def begin_sign_up
     domain = params[:user][:email].split('@')[1] if params[:user][:email].present?
-    if Policies::Devise::EmailDomains::DISALLOWED_DOMAINS.keys.include?(domain)
+    if Policies::Devise::EmailDomains::DISALLOWED_DOMAINS.key?(domain)
       render json: {
         error: I18n.t('devise.registrations.disallowed_domain', domain: domain)
       }, status: :forbidden

--- a/dashboard/app/controllers/registrations_controller.rb
+++ b/dashboard/app/controllers/registrations_controller.rb
@@ -38,7 +38,7 @@ class RegistrationsController < Devise::RegistrationsController
   #
   def begin_sign_up
     domain = params[:user][:email].split('@')[1] if params[:user][:email].present?
-    if Policies::Devise::EmailDomains::DISALLOWED_DOMAINS.include?(domain)
+    if Policies::Devise::EmailDomains::DISALLOWED_DOMAINS.keys.include?(domain)
       render json: {
         error: I18n.t('devise.registrations.disallowed_domain', domain: domain)
       }, status: :forbidden

--- a/dashboard/lib/policies/devise/email_domains.rb
+++ b/dashboard/lib/policies/devise/email_domains.rb
@@ -1,12 +1,22 @@
 class Policies::Devise::EmailDomains
-  DISALLOWED_DOMAINS = [
-    'mymail.lausd.net',
-    'lausd.net',
-  ].freeze
+  DISALLOWED_DOMAINS = {
+    'mymail.lausd.net' => {
+      provider_exceptions: [
+        AuthenticationOption::CLEVER,
+      ]
+    },
+    'lausd.net' => {
+      provider_exceptions: [
+        AuthenticationOption::CLEVER,
+      ]
+    },
+  }.freeze
 
-  # Providers that are allowed to create logins even for
-  # email addresses on the DISALLOWED_DOMAINS list
-  PROVIDER_EXCEPTIONS = [
-    'clever'
-  ].freeze
+  # Check if a provider is allowed to create logins for a blocked domain
+  # TODO: refactor this into district-level configuration
+  # @param domain [String] The email domain to check
+  # @param provider [String] The authentication provider
+  def self.disallowed_login?(domain:, provider:)
+    DISALLOWED_DOMAINS.key?(domain) && DISALLOWED_DOMAINS[domain][:provider_exceptions].exclude?(provider)
+  end
 end

--- a/dashboard/lib/policies/devise/email_domains.rb
+++ b/dashboard/lib/policies/devise/email_domains.rb
@@ -3,4 +3,10 @@ class Policies::Devise::EmailDomains
     'mymail.lausd.net',
     'lausd.net',
   ].freeze
+
+  # Providers that are allowed to create logins even for
+  # email addresses on the DISALLOWED_DOMAINS list
+  PROVIDER_EXCEPTIONS = [
+    'clever'
+  ].freeze
 end

--- a/dashboard/test/controllers/omniauth_callbacks_controller_test.rb
+++ b/dashboard/test/controllers/omniauth_callbacks_controller_test.rb
@@ -144,17 +144,15 @@ class OmniauthCallbacksControllerTest < ActionController::TestCase
     @request.env['omniauth.auth'] = auth
     @request.env['omniauth.params'] = {}
 
-    assert_creates(User) do
+    assert_does_not_create(User) do
       get :clever
     end
 
-    user = User.last
-    assert_equal 'clever', user.primary_contact_info.credential_type
-    assert_equal 'Hat Cat', user.name
-    assert_equal User::TYPE_TEACHER, user.user_type
-    assert_equal "21+", user.age # we know you're an adult if you are a teacher on clever
-    assert_nil user.gender
-    assert_equal user.id, signed_in_user_id
+    assert_equal 200, @response.status
+    assert_template 'omniauth/redirect'
+    partial_user = User.new_from_partial_registration(session)
+    assert_equal AuthenticationOption::CLEVER, partial_user.provider
+    assert_equal auth.uid, partial_user.uid
   end
 
   test "login: authorizing with unknown clever district admin account creates teacher" do
@@ -256,35 +254,6 @@ class OmniauthCallbacksControllerTest < ActionController::TestCase
     assert_equal "21+", user.age
     assert_equal 'm', user.gender
     assert_equal 'M', user.gender_third_party_input
-    assert_equal user.id, signed_in_user_id
-  end
-
-  # NOTE: Though this test really tests the User model, specifically the
-  # before_save action hide_email_and_full_address_for_students, we include this
-  # test here as there was concern authentication through clever could be a
-  # workflow where we persist student email addresses.
-  test "login: authorizing with unknown clever student account does not save email" do
-    auth = OmniAuth::AuthHash.new(
-      uid: '111133',
-      provider: 'clever',
-      info: {
-        nickname: '',
-        name: {'first' => 'Hat', 'last' => 'Cat'},
-        email: 'hat.cat@example.com',
-        user_type: 'student',
-        dob: Time.zone.today - 10.years,
-        gender: 'f'
-      },
-    )
-    @request.env['omniauth.auth'] = auth
-    @request.env['omniauth.params'] = {}
-
-    assert_creates(User) do
-      get :clever
-    end
-
-    user = User.last
-    assert_equal '', user.email
     assert_equal user.id, signed_in_user_id
   end
 
@@ -1055,18 +1024,16 @@ class OmniauthCallbacksControllerTest < ActionController::TestCase
     email = 'test@foo.xyz'
     uid = '654321'
     user = create(:student, email: email)
-    auth = generate_auth_user_hash(provider: 'clever', uid: uid, user_type: User::TYPE_STUDENT, email: email)
+    auth = generate_auth_user_hash(provider: AuthenticationOption::CLEVER, uid: uid, user_type: User::TYPE_STUDENT, email: email)
     @request.env['omniauth.auth'] = auth
     @request.env['omniauth.params'] = {}
-    assert_creates(User) do
+    refute_creates(User) do
       get :clever
     end
     user.reload
     assert_equal 'migrated', user.provider
     found_clever = user.authentication_options.any? {|auth_option| auth_option.credential_type == AuthenticationOption::CLEVER}
     refute found_clever
-    assert_equal 'clever', User.last.authentication_options.last.credential_type
-    assert_equal User.last.id, signed_in_user_id
   end
 
   test 'sign_up_clever: email conflict redirect if any users are already using your email address' do
@@ -1833,11 +1800,12 @@ class OmniauthCallbacksControllerTest < ActionController::TestCase
       end
 
       it 'creates a new user and redirects to complete registration' do
-        # This test asserts must_change instead of wont_change because sign_up_clever calls User.from_omniauth,
-        # which creates a user. sign_up_google_oauth2 instead calls User.initialize_new_oauth_user, which calls
-        # new but does not save the user.
-        _(-> {get :clever}).must_change -> {User.count}
-        assert_redirected_to home_path
+        _(-> {get :clever}).wont_change -> {User.count}
+        _(@response.status).must_equal 200
+        assert_template 'omniauth/redirect'
+        partial_user = User.new_from_partial_registration(session)
+        _(partial_user.provider).must_equal provider_exceptions.first
+        _(partial_user.uid).must_equal auth.uid
       end
     end
 

--- a/dashboard/test/controllers/omniauth_callbacks_controller_test.rb
+++ b/dashboard/test/controllers/omniauth_callbacks_controller_test.rb
@@ -1782,13 +1782,15 @@ class OmniauthCallbacksControllerTest < ActionController::TestCase
 
   describe '#register_new_user' do
     let(:disallowed_domains) {['testdomain.com']}
+    let(:provider_exceptions) {['clever']}
+    let(:email) {Faker::Internet.email(domain: disallowed_domains.first)}
 
     before do
       stub_const('Policies::Devise::EmailDomains::DISALLOWED_DOMAINS', disallowed_domains)
+      stub_const('Policies::Devise::EmailDomains::PROVIDER_EXCEPTIONS', provider_exceptions)
     end
 
     context 'when a user has an email domain that is disallowed' do
-      let(:email) {"user@#{disallowed_domains.first}"}
       let(:auth) {generate_auth_user_hash(provider: AuthenticationOption::GOOGLE, uid: 'some-uid', email: email)}
 
       before do
@@ -1804,8 +1806,8 @@ class OmniauthCallbacksControllerTest < ActionController::TestCase
     end
 
     context 'when a user has an email domain that is allowed' do
-      let(:allowed_email) {"user@alloweddomain.com"}
-      let(:auth) {generate_auth_user_hash(provider: AuthenticationOption::GOOGLE, uid: 'other-uid', email: allowed_email)}
+      let(:email) {"user@alloweddomain.com"}
+      let(:auth) {generate_auth_user_hash(provider: AuthenticationOption::GOOGLE, uid: 'other-uid', email: email)}
 
       before do
         @request.env['omniauth.auth'] = auth
@@ -1819,6 +1821,23 @@ class OmniauthCallbacksControllerTest < ActionController::TestCase
         partial_user = User.new_from_partial_registration(session)
         _(partial_user.provider).must_equal AuthenticationOption::GOOGLE
         _(partial_user.uid).must_equal 'other-uid'
+      end
+    end
+
+    context 'when email is disallowed but provider is on the exceptions list' do
+      let(:auth) {generate_auth_user_hash(provider: provider_exceptions.first, uid: 'some-uid', email: email)}
+
+      before do
+        @request.env['omniauth.auth'] = auth
+        @request.env['omniauth.params'] = {}
+      end
+
+      it 'creates a new user and redirects to complete registration' do
+        # This test asserts must_change instead of wont_change because sign_up_clever calls User.from_omniauth,
+        # which creates a user. sign_up_google_oauth2 instead calls User.initialize_new_oauth_user, which calls
+        # new but does not save the user.
+        _(-> {get :clever}).must_change -> {User.count}
+        assert_redirected_to home_path
       end
     end
 

--- a/dashboard/test/controllers/omniauth_callbacks_controller_test.rb
+++ b/dashboard/test/controllers/omniauth_callbacks_controller_test.rb
@@ -1655,13 +1655,12 @@ class OmniauthCallbacksControllerTest < ActionController::TestCase
   end
 
   describe '#register_new_user' do
-    let(:disallowed_domains) {['testdomain.com']}
-    let(:provider_exceptions) {['clever']}
-    let(:email) {Faker::Internet.email(domain: disallowed_domains.first)}
+    let(:domain) {'testdomain.com'}
+    let(:disallowed_domains) {{domain => {provider_exceptions: ['clever']}}}
+    let(:email) {Faker::Internet.email(domain: disallowed_domains.keys.first)}
 
     before do
       stub_const('Policies::Devise::EmailDomains::DISALLOWED_DOMAINS', disallowed_domains)
-      stub_const('Policies::Devise::EmailDomains::PROVIDER_EXCEPTIONS', provider_exceptions)
     end
 
     context 'when a user has an email domain that is disallowed' do
@@ -1675,7 +1674,7 @@ class OmniauthCallbacksControllerTest < ActionController::TestCase
       it 'does not create a new user and redirects to the sign in page with an alert' do
         _(-> {post :google_oauth2, params: {omniauth: auth}}).wont_change -> {User.count}
         assert_redirected_to user_session_path
-        _(flash[:alert]).must_equal I18n.t('devise.registrations.disallowed_domain', domain: disallowed_domains.first)
+        _(flash[:alert]).must_equal I18n.t('devise.registrations.disallowed_domain', domain: domain)
       end
     end
 
@@ -1699,7 +1698,7 @@ class OmniauthCallbacksControllerTest < ActionController::TestCase
     end
 
     context 'when email is disallowed but provider is on the exceptions list' do
-      let(:auth) {generate_auth_user_hash(provider: provider_exceptions.first, uid: 'some-uid', email: email)}
+      let(:auth) {generate_auth_user_hash(provider: disallowed_domains[domain][:provider_exceptions].first, uid: 'some-uid', email: email)}
 
       before do
         @request.env['omniauth.auth'] = auth
@@ -1711,7 +1710,7 @@ class OmniauthCallbacksControllerTest < ActionController::TestCase
         _(@response.status).must_equal 200
         assert_template 'omniauth/redirect'
         partial_user = User.new_from_partial_registration(session)
-        _(partial_user.provider).must_equal provider_exceptions.first
+        _(partial_user.provider).must_equal disallowed_domains[domain][:provider_exceptions].first
         _(partial_user.uid).must_equal auth.uid
       end
     end

--- a/dashboard/test/controllers/omniauth_callbacks_controller_test.rb
+++ b/dashboard/test/controllers/omniauth_callbacks_controller_test.rb
@@ -444,7 +444,7 @@ class OmniauthCallbacksControllerTest < ActionController::TestCase
       user_type: 'teacher'
     @request.env['omniauth.auth'] = auth
     @request.env['omniauth.params'] = {}
-    
+
     get :clever
     partial_user = User.new_from_partial_registration(session)
     assert_equal auth[:credentials][:token], partial_user.oauth_token

--- a/dashboard/test/controllers/omniauth_callbacks_controller_test.rb
+++ b/dashboard/test/controllers/omniauth_callbacks_controller_test.rb
@@ -155,64 +155,6 @@ class OmniauthCallbacksControllerTest < ActionController::TestCase
     assert_equal auth.uid, partial_user.uid
   end
 
-  test "login: authorizing with unknown clever district admin account creates teacher" do
-    auth = OmniAuth::AuthHash.new(
-      uid: '1111',
-      provider: 'clever',
-      info: {
-        nickname: '',
-        name: {'first' => 'Hat', 'last' => 'Cat'},
-        email: 'first_last@clever-district-admin.xx',
-        user_type: 'district_admin',
-        dob: nil,
-        gender: nil
-      },
-    )
-    @request.env['omniauth.auth'] = auth
-    @request.env['omniauth.params'] = {}
-
-    assert_creates(User) do
-      get :clever
-    end
-
-    user = User.last
-    assert_equal 'clever', user.primary_contact_info.credential_type
-    assert_equal 'Hat Cat', user.name
-    assert_equal User::TYPE_TEACHER, user.user_type
-    assert_equal "21+", user.age # we know you're an adult if you are a teacher on clever
-    assert_nil user.gender
-    assert_equal user.id, signed_in_user_id
-  end
-
-  test "login: authorizing with unknown clever school admin account creates teacher" do
-    auth = OmniAuth::AuthHash.new(
-      uid: '1111',
-      provider: 'clever',
-      info: {
-        nickname: '',
-        name: {'first' => 'Hat', 'last' => 'Cat'},
-        email: 'first_last@clever-school-admin.xx',
-        user_type: 'school_admin',
-        dob: nil,
-        gender: nil
-      },
-    )
-    @request.env['omniauth.auth'] = auth
-    @request.env['omniauth.params'] = {}
-
-    assert_creates(User) do
-      get :clever
-    end
-
-    user = User.last
-    assert_equal 'clever', user.primary_contact_info.credential_type
-    assert_equal 'Hat Cat', user.name
-    assert_equal User::TYPE_TEACHER, user.user_type
-    assert_equal "21+", user.age # we know you're an adult if you are a teacher on clever
-    assert_nil user.gender
-    assert_equal user.id, signed_in_user_id
-  end
-
   test "login: authorizing with unknown clever teacher account needs additional information" do
     auth = OmniAuth::AuthHash.new(
       uid: '1111',
@@ -243,18 +185,16 @@ class OmniauthCallbacksControllerTest < ActionController::TestCase
     @request.env['omniauth.auth'] = TEST_CLEVER_STUDENT_DATA
     @request.env['omniauth.params'] = {}
 
-    assert_creates(User) do
+    assert_does_not_create(User) do
       get :clever
     end
 
-    user = User.last
-    assert_equal 'clever', user.primary_contact_info.credential_type
-    assert_equal 'Elizabeth Smith', user.name
-    assert_equal User::TYPE_STUDENT, user.user_type
-    assert_equal "21+", user.age
-    assert_equal 'm', user.gender
-    assert_equal 'M', user.gender_third_party_input
-    assert_equal user.id, signed_in_user_id
+    assert_equal 200, @response.status
+    assert_template 'omniauth/redirect'
+    partial_user = User.new_from_partial_registration(session)
+    assert_equal AuthenticationOption::CLEVER, partial_user.provider
+    assert_equal TEST_CLEVER_STUDENT_DATA.uid, partial_user.uid
+    assert partial_user.student?
   end
 
   test "login: authorizing with known clever student account does not alter email or hashed email" do
@@ -471,7 +411,7 @@ class OmniauthCallbacksControllerTest < ActionController::TestCase
     assert_equal user.primary_contact_info.data_hash[:oauth_token_expiration], auth[:credentials][:expires_at]
   end
 
-  test 'clever: creates user if user is not found by credentials' do
+  test 'clever: redirects to omniauth/redirect if user is not found by credentials' do
     # Given I do not have a Code.org account
     uid = "nonexistent-clever"
 
@@ -482,45 +422,15 @@ class OmniauthCallbacksControllerTest < ActionController::TestCase
       user_type: 'teacher'
     @request.env['omniauth.auth'] = auth
     @request.env['omniauth.params'] = {}
-    assert_creates User do
+    assert_does_not_create(User) do
       get :clever
     end
 
-    # Then my account is created
-    # And I'm signed in
-    # And I go to my dashboard
-    user = User.find_by_credential(
-      type: AuthenticationOption::CLEVER,
-      id: uid
-    )
-    assert_redirected_to 'http://test-studio.code.org/home'
-    assert_equal user.id, signed_in_user_id
-  end
-
-  test 'clever: does not direct user to finish sign-up (new_sign_up_experience)' do
-    # Given I do not have a Code.org account
-    uid = "nonexistent-clever"
-
-    # When I hit the clever oauth callback
-    auth = generate_auth_user_hash \
-      provider: AuthenticationOption::CLEVER,
-      uid: uid,
-      user_type: 'teacher'
-    @request.env['omniauth.auth'] = auth
-    @request.env['omniauth.params'] = {}
-    assert_creates User do
-      get :clever
-    end
-
-    # Then my account is created
-    # And I'm signed in
-    # And I go to my dashboard
-    user = User.find_by_credential(
-      type: AuthenticationOption::CLEVER,
-      id: uid
-    )
-    assert_redirected_to 'http://test-studio.code.org/home'
-    assert_equal user.id, signed_in_user_id
+    assert_response :ok
+    assert_template 'omniauth/redirect'
+    partial_user = User.new_from_partial_registration(session)
+    assert_equal partial_user.provider, AuthenticationOption::CLEVER
+    assert_equal partial_user.uid, uid
   end
 
   test 'clever: sets tokens on new user' do
@@ -534,15 +444,12 @@ class OmniauthCallbacksControllerTest < ActionController::TestCase
       user_type: 'teacher'
     @request.env['omniauth.auth'] = auth
     @request.env['omniauth.params'] = {}
+    
     get :clever
-
-    # Then I go to the registration page to finish signing up
-    user = User.find_by_credential(
-      type: AuthenticationOption::CLEVER,
-      id: uid
-    )
-    assert_equal user.primary_contact_info.data_hash[:oauth_token], auth[:credentials][:token]
-    assert_equal user.primary_contact_info.data_hash[:oauth_token_expiration], auth[:credentials][:expires_at]
+    partial_user = User.new_from_partial_registration(session)
+    assert_equal auth[:credentials][:token], partial_user.oauth_token
+    assert_equal auth[:credentials][:expires_at], partial_user.oauth_token_expiration
+    assert_equal auth[:credentials][:refresh_token], partial_user.oauth_refresh_token
   end
 
   test 'google_oauth2: signs in user if user is found by credentials' do

--- a/dashboard/test/integration/omniauth/clever_test.rb
+++ b/dashboard/test/integration/omniauth/clever_test.rb
@@ -15,14 +15,23 @@ module OmniauthCallbacksControllerTests
     test "student sign-up" do
       auth_hash = mock_oauth user_type: User::TYPE_STUDENT
 
-      assert_creates(User) {sign_in_through_clever}
-      assert_redirected_to '/'
-      follow_redirect!
-      assert_redirected_to '/home'
-      assert_equal I18n.t('auth.signed_in'), flash[:notice]
+      # Initiate Clever OAuth and hit the callback, which will render the omniauth redirect
+      # template, but does not save the user to the db.
+      post user_clever_omniauth_authorize_path
+      assert_does_not_create(User) do
+        get user_clever_omniauth_callback_path
+      end
+      assert_response :success
+      assert_template 'omniauth/redirect'
+      assert PartialRegistration.in_progress? session
+
+      # Simulate submitting the finish signup page form, which actually creates the user.
+      assert_creates(User) {finish_sign_up auth_hash, User::TYPE_STUDENT}
+      refute PartialRegistration.in_progress? session
 
       created_user = User.find signed_in_user_id
-      assert_valid_student created_user
+      assert created_user.valid?
+      assert created_user.student?
       assert_credentials auth_hash, created_user
     ensure
       created_user&.destroy!
@@ -31,9 +40,19 @@ module OmniauthCallbacksControllerTests
     test "teacher sign-up" do
       auth_hash = mock_oauth user_type: User::TYPE_TEACHER
 
-      assert_creates(User) {sign_in_through_clever}
-      assert_redirected_to '/home'
-      assert_equal I18n.t('auth.signed_in'), flash[:notice]
+      # Initiate Clever OAuth and hit the callback, which will render the omniauth redirect
+      # template, but does not save the user to the db.
+      post user_clever_omniauth_authorize_path
+      assert_does_not_create(User) do
+        get user_clever_omniauth_callback_path
+      end
+      assert_response :success
+      assert_template 'omniauth/redirect'
+      assert PartialRegistration.in_progress? session
+
+      # Simulate submitting the finish signup page form, which actually creates the user.
+      assert_creates(User) {finish_sign_up auth_hash, User::TYPE_TEACHER}
+      refute PartialRegistration.in_progress? session
 
       created_user = User.find signed_in_user_id
       assert_valid_teacher created_user, expected_email: auth_hash.info.email
@@ -70,29 +89,6 @@ module OmniauthCallbacksControllerTests
       assert_equal teacher.id, signed_in_user_id
       teacher.reload
       assert_credentials auth_hash, teacher
-    end
-
-    test 'user_type queryparam has no effect on Clever sign-up' do
-      # This shouldn't be common, because we don't link to Clever from
-      # our sign-up page. But there's no reason someone couldn't hit
-      # these routes in this order, so this test ensures we respect
-      # Clever's user types.
-
-      # Clever says this account is a STUDENT
-      mock_oauth user_type: User::TYPE_STUDENT
-
-      # User visits a page that sets the sign-up type to TEACHER
-      get '/users/sign_up?user[user_type]=teacher'
-
-      # User signs in with their student clever account
-      assert_creates(User) {sign_in_through_clever}
-      follow_redirect!
-
-      # Ensure we created a student
-      created_user = User.find signed_in_user_id
-      assert_valid_student created_user
-    ensure
-      created_user&.destroy!
     end
 
     private def mock_oauth(override_params = {})

--- a/dashboard/test/integration/registration/email_test.rb
+++ b/dashboard/test/integration/registration/email_test.rb
@@ -58,8 +58,9 @@ module RegistrationsControllerTests
     end
 
     describe "disallowed email domain" do
-      let(:disallowed_domains) {['testdomain.com']}
-      let(:email) {"user@#{disallowed_domains.first}"}
+      let(:domain) {'testdomain.com'}
+      let(:disallowed_domains) {{domain => {provider_exceptions: []}}}
+      let(:email) {"user@#{domain}"}
 
       before do
         stub_const('Policies::Devise::EmailDomains::DISALLOWED_DOMAINS', disallowed_domains)
@@ -77,7 +78,7 @@ module RegistrationsControllerTests
       it "forbids sign up" do
         _(response.status).must_equal 403
         _(response.body).must_match(
-          /Emails from #{Regexp.escape(disallowed_domains.first)} are not allowed to sign up with email and password\. Please use your LMS to sign in\./
+          /Emails from #{Regexp.escape(domain)} are not allowed to sign up with email and password\. Please use your LMS to sign in\./
         )
       end
     end


### PR DESCRIPTION
When doing the work to restrict oauth-based signups for LAUSD emails except for Clever, we discovered that `sign_up_clever` works differently from equivalent methods for other providers:
- It calls `User::from_omniauth`, which internally calls `create`, saving a user record to the db earlier than expected. Other omniauth_callbacks_controller methods, like the Google one, call `User::initialize_new_oauth_user` instead. This method sets attributes on a user object but doesn't call `create` or `save`.
- After calling `create`, there is a check for the user being `persisted?`, which will always return true except in the event of an error during the create. When this check passes, which happens for all successful Clever signups, the user is immediately logged in, bypassing the normal `register_new_user` method call, which includes the `omniauth/redirect` template that normally lands the user on the finish signup page.

This PR fixes the `sign_up_clever` method to match the other providers and go through the normal omniauth redirect and the finish signup page. Clever signups for LAUSD emails were accidentally allowed by this bug. We want to continue allowing them, so this PR also accounts for that by creating an exception to the email block for Clever. Multiple tests were changed or removed from `omniauth_callbacks_controller_test.rb`. Lots of outdated tests were testing that a new user is created during the initial `clever` omniauth callback, which isn't correct. Also, I removed two tests that were testing invalid scenarios for staff and admin users, which we do not currently allow through Clever.

Before fix, the user is immediately created and signed in without ever visiting the finish signup page:

https://github.com/user-attachments/assets/2b772036-ecf1-4c0c-b25c-50c1dae3227a

After fix, the user visits the finish signup screen, just like with other identity providers:

https://github.com/user-attachments/assets/54af5b66-7ff6-4285-87fd-7fdba9995b30

In the event that an account already exists with the user's email, the user is still redirected to the email conflict page:

https://github.com/user-attachments/assets/ea095210-3498-4d49-aedd-63f476c4f81d


## Links
[JIRA](https://codedotorg.atlassian.net/browse/P20-1607)
[JIRA](https://codedotorg.atlassian.net/browse/P20-1610)

## Testing story
<!--  Does your change include appropriate tests?
      - If so, please describe how the tests included in this PR are sufficient.
      - If not, please explain why this change does not need to be tested. -->



## Deployment strategy
<!--  Any special steps required to deploy this, besides merging?
      - Are there database migrations or manual steps?
      - Does this require coordination with other teams or systems? -->



## Follow-up work
<!--  List any clean-up or technical debt that will be addressed in future work.
      - Include Jira links where applicable.
      - Are there any known limitations or improvements planned? -->



## Privacy
<!--  How does this change impact Student & Teacher privacy?
      - Does this collect, use, share, or modify PII, either new or existing? -->



## Security
<!--  How does this change impact our security surface-area?
      - Do API's touched have the right auth?
      - Do infra changes impact our attack surface or encryption?
-->



## Caching
<!--  How does this change impact caching behavior?
      - Are cache keys or invalidation strategies affected?
      - Will this require cache warming or invalidation after deployment? -->



## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
