### PR TITLE
Update Codebridge file icons

### DIFF
--- a/apps/src/codebridge/utils/fileUtils.ts
+++ b/apps/src/codebridge/utils/fileUtils.ts
@@ -28,14 +28,21 @@ export function getFileIconNameAndStyle(file: ProjectFile): {
 } {
   const isStartMode = getAppOptionsEditBlocks() === START_SOURCES;
   if (!isStartMode) {
-    if (file.name.endsWith('.py')) {
+    const [, fileType] = file.name.split('.');
+    if (fileType === 'py') {
       return {iconName: 'python', iconStyle: 'regular', isBrand: true};
-    } else if (file.name.endsWith('.html')) {
-      return {iconName: 'file-code', iconStyle: 'regular', isBrand: true}; // not working
-    } else if (file.name.endsWith('.js')) {
+    } else if (fileType === 'html') {
+      return {iconName: 'file-code', iconStyle: 'regular', isBrand: false};
+    } else if (fileType === 'js') {
       return {iconName: 'js', iconStyle: 'regular', isBrand: true};
-    } else if (file.name.endsWith('.css')) {
+    } else if (fileType === 'css') {
       return {iconName: 'css', iconStyle: 'regular', isBrand: true};
+    } else if (fileType === 'jpg' || fileType === 'png') {
+      return {iconName: 'image', iconStyle: 'regular', isBrand: false};
+    } else if (fileType === 'txt') {
+      return {iconName: 'file-lines', iconStyle: 'regular', isBrand: false};
+    } else if (fileType === 'csv') {
+      return {iconName: 'file-csv', iconStyle: 'regular', isBrand: false};
     }
     return {iconName: 'file', iconStyle: 'regular'};
   }

--- a/apps/src/codebridge/utils/fileUtils.ts
+++ b/apps/src/codebridge/utils/fileUtils.ts
@@ -31,19 +31,20 @@ export function getFileIconNameAndStyle(file: ProjectFile): {
     const [, fileType] = file.name.split('.');
     if (fileType === 'py') {
       return {iconName: 'python', iconStyle: 'regular', isBrand: true};
+    } else if (fileType === 'csv') {
+      return {iconName: 'file-csv', iconStyle: 'solid', isBrand: false};
+    } else if (fileType === 'txt') {
+      return {iconName: 'file-lines', iconStyle: 'solid', isBrand: false};
     } else if (fileType === 'html') {
-      return {iconName: 'file-code', iconStyle: 'regular', isBrand: false};
+      return {iconName: 'file-code', iconStyle: 'solid', isBrand: false};
     } else if (fileType === 'js') {
       return {iconName: 'js', iconStyle: 'regular', isBrand: true};
     } else if (fileType === 'css') {
       return {iconName: 'css', iconStyle: 'regular', isBrand: true};
-    } else if (fileType === 'jpg' || fileType === 'png') {
-      return {iconName: 'image', iconStyle: 'regular', isBrand: false};
-    } else if (fileType === 'txt') {
-      return {iconName: 'file-lines', iconStyle: 'regular', isBrand: false};
-    } else if (fileType === 'csv') {
-      return {iconName: 'file-csv', iconStyle: 'regular', isBrand: false};
+    } else if (['jpg', 'png', 'jpeg'].includes(fileType)) {
+      return {iconName: 'image', iconStyle: 'solid', isBrand: false};
     }
+
     return {iconName: 'file', iconStyle: 'regular'};
   }
   if (file.type === ProjectFileType.VALIDATION) {

--- a/apps/src/codebridge/utils/fileUtils.ts
+++ b/apps/src/codebridge/utils/fileUtils.ts
@@ -30,6 +30,12 @@ export function getFileIconNameAndStyle(file: ProjectFile): {
   if (!isStartMode) {
     if (file.name.endsWith('.py')) {
       return {iconName: 'python', iconStyle: 'regular', isBrand: true};
+    } else if (file.name.endsWith('.html')) {
+      return {iconName: 'file-code', iconStyle: 'regular', isBrand: true}; // not working
+    } else if (file.name.endsWith('.js')) {
+      return {iconName: 'js', iconStyle: 'regular', isBrand: true};
+    } else if (file.name.endsWith('.css')) {
+      return {iconName: 'css', iconStyle: 'regular', isBrand: true};
     }
     return {iconName: 'file', iconStyle: 'regular'};
   }

--- a/apps/src/codebridge/utils/fileUtils.ts
+++ b/apps/src/codebridge/utils/fileUtils.ts
@@ -4,6 +4,18 @@ import {MultiFileSource, ProjectFileType} from '@cdo/apps/lab2/types';
 
 import {ProjectFile} from '../types';
 
+const FILE_TYPE_ICON_MAP = {
+  py: {iconName: 'python', iconStyle: 'regular' as const, isBrand: true},
+  csv: {iconName: 'file-csv', iconStyle: 'solid' as const, isBrand: false},
+  txt: {iconName: 'file-lines', iconStyle: 'solid' as const, isBrand: false},
+  html: {iconName: 'file-code', iconStyle: 'solid' as const, isBrand: false},
+  js: {iconName: 'js', iconStyle: 'regular' as const, isBrand: true},
+  css: {iconName: 'css', iconStyle: 'regular' as const, isBrand: true},
+  jpg: {iconName: 'image', iconStyle: 'solid' as const, isBrand: false},
+  png: {iconName: 'image', iconStyle: 'solid' as const, isBrand: false},
+  jpeg: {iconName: 'image', iconStyle: 'solid' as const, isBrand: false},
+} as const;
+
 export function shouldShowFile(file?: ProjectFile) {
   // We could have an undefined file if the file referenced is a validation file.
   if (!file) {
@@ -29,22 +41,11 @@ export function getFileIconNameAndStyle(file: ProjectFile): {
   const isStartMode = getAppOptionsEditBlocks() === START_SOURCES;
   if (!isStartMode) {
     const [, fileType] = file.name.split('.');
-    if (fileType === 'py') {
-      return {iconName: 'python', iconStyle: 'regular', isBrand: true};
-    } else if (fileType === 'csv') {
-      return {iconName: 'file-csv', iconStyle: 'solid', isBrand: false};
-    } else if (fileType === 'txt') {
-      return {iconName: 'file-lines', iconStyle: 'solid', isBrand: false};
-    } else if (fileType === 'html') {
-      return {iconName: 'file-code', iconStyle: 'solid', isBrand: false};
-    } else if (fileType === 'js') {
-      return {iconName: 'js', iconStyle: 'regular', isBrand: true};
-    } else if (fileType === 'css') {
-      return {iconName: 'css', iconStyle: 'regular', isBrand: true};
-    } else if (['jpg', 'png', 'jpeg'].includes(fileType)) {
-      return {iconName: 'image', iconStyle: 'solid', isBrand: false};
+    const iconConfig =
+      FILE_TYPE_ICON_MAP[fileType as keyof typeof FILE_TYPE_ICON_MAP];
+    if (iconConfig) {
+      return iconConfig;
     }
-
     return {iconName: 'file', iconStyle: 'regular'};
   }
   if (file.type === ProjectFileType.VALIDATION) {

--- a/apps/test/unit/codebridge/utils/fileUtilsTest.ts
+++ b/apps/test/unit/codebridge/utils/fileUtilsTest.ts
@@ -77,7 +77,49 @@ describe('fileUtils', () => {
         name: 'test.txt',
         type: ProjectFileType.STARTER,
       })
-    ).toEqual({iconName: 'file', iconStyle: 'regular'});
+    ).toEqual({iconName: 'file-lines', iconStyle: 'solid', isBrand: false});
+    expect(
+      getFileIconNameAndStyle({
+        ...defaultFile,
+        name: 'test.html',
+        type: ProjectFileType.STARTER,
+      })
+    ).toEqual({iconName: 'file-code', iconStyle: 'solid', isBrand: false});
+    expect(
+      getFileIconNameAndStyle({
+        ...defaultFile,
+        name: 'test.css',
+        type: ProjectFileType.STARTER,
+      })
+    ).toEqual({iconName: 'css', iconStyle: 'regular', isBrand: true});
+    expect(
+      getFileIconNameAndStyle({
+        ...defaultFile,
+        name: 'test.jpg',
+        type: ProjectFileType.STARTER,
+      })
+    ).toEqual({iconName: 'image', iconStyle: 'solid', isBrand: false});
+    expect(
+      getFileIconNameAndStyle({
+        ...defaultFile,
+        name: 'test.png',
+        type: ProjectFileType.STARTER,
+      })
+    ).toEqual({iconName: 'image', iconStyle: 'solid', isBrand: false});
+    expect(
+      getFileIconNameAndStyle({
+        ...defaultFile,
+        name: 'test.jpeg',
+        type: ProjectFileType.STARTER,
+      })
+    ).toEqual({iconName: 'image', iconStyle: 'solid', isBrand: false});
+    expect(
+      getFileIconNameAndStyle({
+        ...defaultFile,
+        name: 'test.csv',
+        type: ProjectFileType.STARTER,
+      })
+    ).toEqual({iconName: 'file-csv', iconStyle: 'solid', isBrand: false});
   });
 
   it('shows levelbuilder icons in start mode', () => {


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
This PR updates the file icons of supported files in Codebridge. The icons worked as-is without having to [update FontAwesome files](https://github.com/code-dot-org/code-dot-org/blob/staging/shared/css/README.md#updating-fontawesome-files).

Just noting that I had to look carefully at the figma to see whether to set `isBrand` to `true` or `false` based on whether the icon's `font-family` is set to `'Font Awesome 7 Pro'` or `'Font Awesome 7 Brands'`. Thanks @moshebaricdo for your help with this.


## Before update

Web Lab 2 (light and dark theme)
<img width="200" alt="before-weblab2-lt" src="https://github.com/user-attachments/assets/f65899d1-23ed-470a-ad8f-ed5fc0c965df" />  <img width="200"  alt="before-weblab2-dark" src="https://github.com/user-attachments/assets/f1e3fd1d-6a00-4ec7-b333-e801bcb52f2e" />

Python Lab (light and dark theme)
<img width="200"  alt="before-pythonlab-light" src="https://github.com/user-attachments/assets/e3f0b56f-88c8-4692-bb51-29acef633fc9" /> <img width="200"  alt="before-pythonlab-dark" src="https://github.com/user-attachments/assets/5a3425e1-5ca0-4bb1-bd61-45111e68d2aa" />


## After update

Web Lab 2 (light and dark theme)
<img width="200"  alt="after-weblab2-light" src="https://github.com/user-attachments/assets/8f8b8d6b-c54b-4b6f-a87a-693d5c25b01b" /> <img width="200" alt="after-weblab2-dark" src="https://github.com/user-attachments/assets/4f30e8ca-b375-4eb8-93f2-fc121a56cfdf" />



Python Lab (light and dark theme)
<img width="200"  alt="after-pythonlab-light" src="https://github.com/user-attachments/assets/c5df5ed3-4bdc-4d41-a5e1-bcc70fa24e59" /> <img width="200"  alt="after-python-dark" src="https://github.com/user-attachments/assets/4c5b6a8f-d1bc-4925-af54-405968772320" />


## Links
<!--  Links to relevant external resources.
      - spec docs, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- Jira: https://codedotorg.atlassian.net/browse/AFL-42

## Testing story
<!--  Does your change include appropriate tests?
      - If so, please describe how the tests included in this PR are sufficient.
      - If not, please explain why this change does not need to be tested. -->

Tested locally on `pythonlab` and `weblab2` levels in both dark/light themes.
Updated unit tests in `fileUtilsTest.ts`.

## Deployment strategy
<!--  Any special steps required to deploy this, besides merging?
      - Are there database migrations or manual steps?
      - Does this require coordination with other teams or systems? -->



## Follow-up work
<!--  List any clean-up or technical debt that will be addressed in future work.
      - Include Jira links where applicable.
      - Are there any known limitations or improvements planned? -->



## Privacy
<!--  How does this change impact Student & Teacher privacy?
      - Does this collect, use, share, or modify PII, either new or existing? -->



## Security
<!--  How does this change impact our security surface-area?
      - Do API's touched have the right auth?
      - Do infra changes impact our attack surface or encryption?
-->



## Caching
<!--  How does this change impact caching behavior?
      - Are cache keys or invalidation strategies affected?
      - Will this require cache warming or invalidation after deployment? -->



## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
