### PR TITLE
Revert "Explicitly define some auto-loaded submodules"

### DIFF
--- a/dashboard/app/models/census.rb
+++ b/dashboard/app/models/census.rb
@@ -1,2 +1,0 @@
-module Census
-end

--- a/dashboard/app/models/concerns/curriculum.rb
+++ b/dashboard/app/models/concerns/curriculum.rb
@@ -1,2 +1,0 @@
-module Curriculum
-end

--- a/dashboard/lib/api.rb
+++ b/dashboard/lib/api.rb
@@ -1,2 +1,0 @@
-module Api
-end

--- a/dashboard/lib/policies.rb
+++ b/dashboard/lib/policies.rb
@@ -1,2 +1,0 @@
-module Policies
-end

--- a/dashboard/lib/queries.rb
+++ b/dashboard/lib/queries.rb
@@ -1,2 +1,0 @@
-module Queries
-end

--- a/dashboard/lib/services.rb
+++ b/dashboard/lib/services.rb
@@ -1,2 +1,0 @@
-module Services
-end


### PR DESCRIPTION
Reverts code-dot-org/code-dot-org#43733. See https://github.com/code-dot-org/code-dot-org/pull/68100 for context. empty module declarations were added to work around an issue specific to an older version of rails, and are no longer needed now that we use zeitwerk.