### PR TITLE
Remove Old MysqlCheckIndexUsed Transitional Logic

### DIFF
--- a/dashboard/config/initializers/mysql_check_index_used.rb
+++ b/dashboard/config/initializers/mysql_check_index_used.rb
@@ -11,13 +11,7 @@ module MysqlCheckIndexUsed
 
   # Copy/extend logic in AbstractMySQLAdapter#execute, and AbstractAdapter#log.
   def execute(sql, name = nil)
-    # Rails 6 added both the materialize_transactions method and a call to it
-    # right here, so to preserve compatibility between 5 and 6 we call the
-    # method if and only if it exists. The if clause can be removed once we've
-    # fully upgraded to Rails 6.
-    #
-    # See https://github.com/rails/rails/pull/32647/files#diff-868f1dccfcbed26a288bf9f3fd8a39c863a4413ab0075e12b6805d9798f556d1
-    materialize_transactions if respond_to?(:materialize_transactions)
+    materialize_transactions
 
     options = {
       sql:               sql,


### PR DESCRIPTION
Planned follow-up to https://github.com/code-dot-org/code-dot-org/pull/44552, which added some logic to smooth the transition from Rails 5 to 6. We're now fully on Rails 6 and prepping for an upgrade to 7, so it's more than safe to remove this.
