### PR TITLE
Update `activerecord-import` Gem to 1.3.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -343,7 +343,7 @@ install_if require_pg do
   gem 'pg', '~> 1.3.0', require: false
 end
 
-gem 'activerecord-import', '~> 1.0.3'
+gem 'activerecord-import', '~> 1.3.0'
 gem 'active_record_union'
 gem 'scenic'
 gem 'scenic-mysql_adapter'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -974,7 +974,7 @@ DEPENDENCIES
   active_model_serializers (~> 0.10.13)
   active_record_query_trace
   active_record_union
-  activerecord-import (~> 1.0.3)
+  activerecord-import (~> 1.3.0)
   acts_as_list
   addressable
   annotate (~> 3.1.1)


### PR DESCRIPTION
To pick up support for ActiveRecord 7.0, added in https://github.com/zdennis/activerecord-import/pull/749. Part of our ongoing preparation to upgrade to Rails 7.0

## Links

- [changelog](https://github.com/zdennis/activerecord-import/blob/master/CHANGELOG.md#changes-in-130)

## Testing story

Verified locally that I can still successfully `rake seed:scripts` on the updated version of the gem. Also verified that with this change in place, we no longer get an `undefined method 'raw_filter'` error from this gem on Rails 7.