### PR TITLE
[MusicLab] Making AIDrums keyboard navigable

### DIFF
--- a/apps/src/music/views/PatternAiPanel.tsx
+++ b/apps/src/music/views/PatternAiPanel.tsx
@@ -636,6 +636,14 @@ const PatternAiPanel: React.FunctionComponent<PatternAiPanelProps> = ({
                               className={getOuterCellClasses(tick)}
                               onClick={() => toggleEvent(tick, index)}
                               key={tick}
+                              role="button"
+                              tabIndex={0}
+                              onKeyDown={e => {
+                                if (e.key === 'Enter') {
+                                  toggleEvent(tick, index);
+                                  e.preventDefault();
+                                }
+                              }}
                             >
                               <div className={getInnerCellClasses(tick)}>
                                 <div


### PR DESCRIPTION
This approach is not a perfect solution. Rather, it is meant to at least bring ai drums to parity with the play drums and play tunes blocks. 

A user still has to tab through the entire grid to get to the generate button, but at least they can access the grid now:


https://github.com/user-attachments/assets/f3b1e1bb-afb1-49ec-be74-c41e993319ae


Future work: We still need to figure out the spacebar shortcut for the run button. I only enabled this for the enter key (instead of both) because the spacebar currently closes flyouts to play the song (and then the flyout reopens if you press space again to stop)


## Links

- Jira: https://codedotorg.atlassian.net/browse/SL-1412

## Testing story
<!--  Does your change include appropriate tests?
      - If so, please describe how the tests included in this PR are sufficient.
      - If not, please explain why this change does not need to be tested. -->



## Deployment strategy
<!--  Any special steps required to deploy this, besides merging?
      - Are there database migrations or manual steps?
      - Does this require coordination with other teams or systems? -->



## Follow-up work
<!--  List any clean-up or technical debt that will be addressed in future work.
      - Include Jira links where applicable.
      - Are there any known limitations or improvements planned? -->



## Privacy
<!--  How does this change impact Student & Teacher privacy?
      - Does this collect, use, share, or modify PII, either new or existing? -->



## Security
<!--  How does this change impact our security surface-area?
      - Do API's touched have the right auth?
      - Do infra changes impact our attack surface or encryption?
-->



## Caching
<!--  How does this change impact caching behavior?
      - Are cache keys or invalidation strategies affected?
      - Will this require cache warming or invalidation after deployment? -->



## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
