### PR TITLE
Authenticate GitHub Read Requests in Continuous Integration Builds

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -57,6 +57,9 @@ steps:
       GITHUB_TOKEN:
         from_secret: GITHUB_TOKEN
     commands:
+      # Configure git to use the token for all GitHub operations
+      - git config --global credential.helper store
+      - echo "https://${GITHUB_TOKEN}:x-oauth-basic@github.com" > ~/.git-credentials
       - git lfs install --skip-repo
       # Construct authenticated GitHub URL.
       # DRONE_REPO_OWNER = organization name (e.g., "code-dot-org")
@@ -199,6 +202,9 @@ steps:
       GITHUB_TOKEN:
         from_secret: GITHUB_TOKEN
     commands:
+      # Configure git to use the token for all GitHub operations
+      - git config --global credential.helper store
+      - echo "https://${GITHUB_TOKEN}:x-oauth-basic@github.com" > ~/.git-credentials
       - git lfs install --skip-repo
       # Construct authenticated URL.
       # DRONE_REPO_OWNER = organization name (e.g., "code-dot-org")
@@ -311,6 +317,9 @@ steps:
       GITHUB_TOKEN:
         from_secret: GITHUB_TOKEN
     commands:
+      # Configure git to use the token for all GitHub operations
+      - git config --global credential.helper store
+      - echo "https://${GITHUB_TOKEN}:x-oauth-basic@github.com" > ~/.git-credentials
       - git lfs install
       # Construct authenticated GitHub URL
       # DRONE_REPO_OWNER = organization name (e.g., "code-dot-org")
@@ -378,6 +387,6 @@ trigger:
     - push
 ---
 kind: signature
-hmac: b4f2db52f74f39157edd481e017b3c13b969af36028678c5ee0a6ab787438283
+hmac: 72a93f7f4b0f546c11da14256289517c006e0168db6519cd00b1b772fdabe3d9
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -310,9 +310,10 @@ steps:
         from_secret: GITHUB_TOKEN
     commands:
       - git lfs install
-      # Extract repo info from DRONE_GIT_HTTP_URL and construct authenticated URL
-      - REPO_URL=$(echo $DRONE_GIT_HTTP_URL | sed 's|https://||')
-      - AUTH_URL="https://${GITHUB_TOKEN}@${REPO_URL}"
+      # Construct authenticated URL by inserting token into the DRONE_GIT_HTTP_URL
+      # DRONE_GIT_HTTP_URL format: https://github.com/owner/repo.git
+      # AUTH_URL format: https://TOKEN@github.com/owner/repo.git
+      - AUTH_URL=$(echo $DRONE_GIT_HTTP_URL | sed "s|https://|https://${GITHUB_TOKEN}@|")
       - git clone --branch $DRONE_BRANCH $AUTH_URL .
 
   - name: cache-staging-clone
@@ -375,6 +376,6 @@ trigger:
     - push
 ---
 kind: signature
-hmac: ce69954bb74895420492e8513c41c47eae31a308e8bc6ca1093881da936b0140
+hmac: 31cee1760cc05aacc5414e90085d5771bb68576eeb2aa7532eebcc1cfe2ec531
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -60,11 +60,11 @@ steps:
       - git lfs install --skip-repo
       # Extract repo info from DRONE_GIT_HTTP_URL and construct authenticated URL
       - REPO_URL=$(echo $DRONE_GIT_HTTP_URL | sed 's|https://||')
-      - AUTH_URL="https://${GITHUB_TOKEN}@${REPO_URL}"
+      - AUTHENTICATED_GITHUB_URL="https://${GITHUB_TOKEN}@${REPO_URL}"
       # We should be in a cached git repo, but clone if the cache failed
-      - "[ -d .git ] || (echo 'WARNING: get-cached-staging failed: checkout will be SLOW and LFS $$$!' && git clone --branch $DRONE_BRANCH $AUTH_URL .)"
+      - "[ -d .git ] || (echo 'WARNING: get-cached-staging failed: checkout will be SLOW and LFS $$$!' && git clone --branch $DRONE_BRANCH $AUTHENTICATED_GITHUB_URL .)"
       # Update the remote URL to use authentication
-      - git remote set-url origin $AUTH_URL
+      - git remote set-url origin $AUTHENTICATED_GITHUB_URL
       # Checkout our source branch (=the PR)
       - git fetch origin $DRONE_SOURCE_BRANCH
       - git checkout $DRONE_SOURCE_BRANCH
@@ -199,13 +199,14 @@ steps:
         from_secret: GITHUB_TOKEN
     commands:
       - git lfs install --skip-repo
-      # Extract repo info from DRONE_GIT_HTTP_URL and construct authenticated URL
-      - REPO_URL=$(echo $DRONE_GIT_HTTP_URL | sed 's|https://||')
-      - AUTH_URL="https://${GITHUB_TOKEN}@${REPO_URL}"
+      # Construct authenticated URL using Drone's built-in environment variables
+      # DRONE_REPO_OWNER = organization name (e.g., "code-dot-org")
+      # DRONE_REPO_NAME = repository name (e.g., "code-dot-org")
+      - AUTHENTICATED_GITHUB_URL="https://${GITHUB_TOKEN}@github.com/${DRONE_REPO_OWNER}/${DRONE_REPO_NAME}.git"
       # We should be in a cached git repo, but clone if the cache failed
-      - "[ -d .git ] || (echo 'get-cached-staging failed: checkout will be SLOW and LFS $$$!' && git clone --branch $DRONE_BRANCH $AUTH_URL .)"
+      - "[ -d .git ] || (echo 'get-cached-staging failed: checkout will be SLOW and LFS $$!' && git clone --branch $DRONE_BRANCH $AUTHENTICATED_GITHUB_URL .)"
       # Update the remote URL to use authentication
-      - git remote set-url origin $AUTH_URL
+      - git remote set-url origin $AUTHENTICATED_GITHUB_URL
       # Checkout our source branch (the PR's branch).
       - git fetch origin $DRONE_SOURCE_BRANCH
       - git checkout $DRONE_SOURCE_BRANCH
@@ -310,11 +311,11 @@ steps:
         from_secret: GITHUB_TOKEN
     commands:
       - git lfs install
-      # Construct authenticated URL by inserting token into the DRONE_GIT_HTTP_URL
-      # DRONE_GIT_HTTP_URL format: https://github.com/owner/repo.git
-      # AUTH_URL format: https://TOKEN@github.com/owner/repo.git
-      - AUTH_URL=$(echo $DRONE_GIT_HTTP_URL | sed "s|https://|https://${GITHUB_TOKEN}@|")
-      - git clone --branch $DRONE_BRANCH $AUTH_URL .
+      # Construct authenticated URL using Drone's built-in environment variables
+      # DRONE_REPO_OWNER = organization name (e.g., "code-dot-org")
+      # DRONE_REPO_NAME = repository name (e.g., "code-dot-org")
+      - AUTHENTICATED_GITHUB_URL="https://${GITHUB_TOKEN}@github.com/${DRONE_REPO_OWNER}/${DRONE_REPO_NAME}.git"
+      - git clone --branch $DRONE_BRANCH $AUTHENTICATED_GITHUB_URL .
 
   - name: cache-staging-clone
     image: plugins/s3-cache
@@ -376,6 +377,6 @@ trigger:
     - push
 ---
 kind: signature
-hmac: 31cee1760cc05aacc5414e90085d5771bb68576eeb2aa7532eebcc1cfe2ec531
+hmac: 88f601477a02f8e63f96137ed6a5b1b7ba85f3226f3e027586fd8f1781f9b98c
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -377,6 +377,6 @@ trigger:
     - push
 ---
 kind: signature
-hmac: 88f601477a02f8e63f96137ed6a5b1b7ba85f3226f3e027586fd8f1781f9b98c
+hmac: ea8bbcea3c513e2eb228029353f0ca38482ff725fbde89dbfb9aa864f5903e57
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -53,10 +53,18 @@ steps:
 
   - name: checkout
     image: bitnamilegacy/git
+    environment:
+      GITHUB_TOKEN:
+        from_secret: GITHUB_TOKEN
     commands:
       - git lfs install --skip-repo
+      # Extract repo info from DRONE_GIT_HTTP_URL and construct authenticated URL
+      - REPO_URL=$(echo $DRONE_GIT_HTTP_URL | sed 's|https://||')
+      - AUTH_URL="https://${GITHUB_TOKEN}@${REPO_URL}"
       # We should be in a cached git repo, but clone if the cache failed
-      - "[ -d .git ] || (echo 'WARNING: get-cached-staging failed: checkout will be SLOW and LFS $$$!' && git clone --branch $DRONE_BRANCH $DRONE_GIT_HTTP_URL .)"
+      - "[ -d .git ] || (echo 'WARNING: get-cached-staging failed: checkout will be SLOW and LFS $$$!' && git clone --branch $DRONE_BRANCH $AUTH_URL .)"
+      # Update the remote URL to use authentication
+      - git remote set-url origin $AUTH_URL
       # Checkout our source branch (=the PR)
       - git fetch origin $DRONE_SOURCE_BRANCH
       - git checkout $DRONE_SOURCE_BRANCH
@@ -186,10 +194,18 @@ steps:
 
   - name: checkout
     image: bitnamilegacy/git
+    environment:
+      GITHUB_TOKEN:
+        from_secret: GITHUB_TOKEN
     commands:
       - git lfs install --skip-repo
+      # Extract repo info from DRONE_GIT_HTTP_URL and construct authenticated URL
+      - REPO_URL=$(echo $DRONE_GIT_HTTP_URL | sed 's|https://||')
+      - AUTH_URL="https://${GITHUB_TOKEN}@${REPO_URL}"
       # We should be in a cached git repo, but clone if the cache failed
-      - "[ -d .git ] || (echo 'get-cached-staging failed: checkout will be SLOW and LFS $$$!' && git clone --branch $DRONE_BRANCH $DRONE_GIT_HTTP_URL .)"
+      - "[ -d .git ] || (echo 'get-cached-staging failed: checkout will be SLOW and LFS $$$!' && git clone --branch $DRONE_BRANCH $AUTH_URL .)"
+      # Update the remote URL to use authentication
+      - git remote set-url origin $AUTH_URL
       # Checkout our source branch (the PR's branch).
       - git fetch origin $DRONE_SOURCE_BRANCH
       - git checkout $DRONE_SOURCE_BRANCH
@@ -289,9 +305,15 @@ clone:
 steps:
   - name: clone
     image: bitnamilegacy/git
+    environment:
+      GITHUB_TOKEN:
+        from_secret: GITHUB_TOKEN
     commands:
       - git lfs install
-      - git clone --branch $DRONE_BRANCH $DRONE_GIT_HTTP_URL . 
+      # Extract repo info from DRONE_GIT_HTTP_URL and construct authenticated URL
+      - REPO_URL=$(echo $DRONE_GIT_HTTP_URL | sed 's|https://||')
+      - AUTH_URL="https://${GITHUB_TOKEN}@${REPO_URL}"
+      - git clone --branch $DRONE_BRANCH $AUTH_URL .
 
   - name: cache-staging-clone
     image: plugins/s3-cache

--- a/.drone.yml
+++ b/.drone.yml
@@ -58,9 +58,10 @@ steps:
         from_secret: GITHUB_TOKEN
     commands:
       - git lfs install --skip-repo
-      # Extract repo info from DRONE_GIT_HTTP_URL and construct authenticated URL
-      - REPO_URL=$(echo $DRONE_GIT_HTTP_URL | sed 's|https://||')
-      - AUTHENTICATED_GITHUB_URL="https://${GITHUB_TOKEN}@${REPO_URL}"
+      # Construct authenticated GitHub URL.
+      # DRONE_REPO_OWNER = organization name (e.g., "code-dot-org")
+      # DRONE_REPO_NAME = repository name (e.g., "code-dot-org")
+      - AUTHENTICATED_GITHUB_URL="https://${GITHUB_TOKEN}@github.com/${DRONE_REPO_OWNER}/${DRONE_REPO_NAME}.git"
       # We should be in a cached git repo, but clone if the cache failed
       - "[ -d .git ] || (echo 'WARNING: get-cached-staging failed: checkout will be SLOW and LFS $$$!' && git clone --branch $DRONE_BRANCH $AUTHENTICATED_GITHUB_URL .)"
       # Update the remote URL to use authentication
@@ -199,7 +200,7 @@ steps:
         from_secret: GITHUB_TOKEN
     commands:
       - git lfs install --skip-repo
-      # Construct authenticated URL using Drone's built-in environment variables
+      # Construct authenticated URL.
       # DRONE_REPO_OWNER = organization name (e.g., "code-dot-org")
       # DRONE_REPO_NAME = repository name (e.g., "code-dot-org")
       - AUTHENTICATED_GITHUB_URL="https://${GITHUB_TOKEN}@github.com/${DRONE_REPO_OWNER}/${DRONE_REPO_NAME}.git"
@@ -311,7 +312,7 @@ steps:
         from_secret: GITHUB_TOKEN
     commands:
       - git lfs install
-      # Construct authenticated URL using Drone's built-in environment variables
+      # Construct authenticated GitHub URL
       # DRONE_REPO_OWNER = organization name (e.g., "code-dot-org")
       # DRONE_REPO_NAME = repository name (e.g., "code-dot-org")
       - AUTHENTICATED_GITHUB_URL="https://${GITHUB_TOKEN}@github.com/${DRONE_REPO_OWNER}/${DRONE_REPO_NAME}.git"
@@ -377,6 +378,6 @@ trigger:
     - push
 ---
 kind: signature
-hmac: ea8bbcea3c513e2eb228029353f0ca38482ff725fbde89dbfb9aa864f5903e57
+hmac: b4f2db52f74f39157edd481e017b3c13b969af36028678c5ee0a6ab787438283
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -375,6 +375,6 @@ trigger:
     - push
 ---
 kind: signature
-hmac: 00ca47ae7662acfdeaa0032ce47719f2f003245624d2da2ba08753165ca57af0
+hmac: ce69954bb74895420492e8513c41c47eae31a308e8bc6ca1093881da936b0140
 
 ...


### PR DESCRIPTION
https://codedotorg.atlassian.net/browse/INF-1822

GitHub is increasingly rate limiting high volume read-only requests to public repositories, particularly for Git LFS objects.
https://docs.github.com/en/rest/using-the-rest-api/rate-limits-for-the-rest-api?apiVersion=2022-11-28#primary-rate-limit-for-git-lfs-access

 Authenticate git `clone`, `fetch`, `checkout`, `pull`, etc. requests with a token owned by the `deploy-code-org` system GitHub user in our Organization.


## Testing story
<!--  Does your change include appropriate tests?
      - If so, please describe how the tests included in this PR are sufficient.
      - If not, please explain why this change does not need to be tested. -->



## Deployment strategy
The `GITHUB_TOKEN` secret is configured manually in the Drone web interface for repository at the path `/code-dot-org/code-dot-org/settings`

<img width="948" height="901" alt="image" src="https://github.com/user-attachments/assets/9fe0807f-fc38-4e7e-ba51-ca7a74c71545" />




## Follow-up work
<!--  List any clean-up or technical debt that will be addressed in future work.
      - Include Jira links where applicable.
      - Are there any known limitations or improvements planned? -->



## Privacy
<!--  How does this change impact Student & Teacher privacy?
      - Does this collect, use, share, or modify PII, either new or existing? -->



## Security
<!--  How does this change impact our security surface-area?
      - Do API's touched have the right auth?
      - Do infra changes impact our attack surface or encryption?
-->



## Caching
<!--  How does this change impact caching behavior?
      - Are cache keys or invalidation strategies affected?
      - Will this require cache warming or invalidation after deployment? -->



## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
