### PR TITLE
chore: upgrade AMI Manager lambda runtime from Node 6.10 to Node 22

### DIFF
--- a/aws/cloudformation/lambda.yml.erb
+++ b/aws/cloudformation/lambda.yml.erb
@@ -281,7 +281,7 @@ Resources:
       FunctionName: SQLUser
       Code: <%=package_node_lambda 'sql-user' %>
       Handler: index.handler
-      Runtime: nodejs18.x
+      Runtime: nodejs22.x
       MemorySize: 1024
       Timeout: 30
       Role: !GetAtt SQLUserLambdaRole.Arn


### PR DESCRIPTION
upgrade AMI Manager lambda runtime from Node 6.10 to Node 22