### PR TITLE
Fix text on rubric unread notification badge

### DIFF
--- a/apps/src/templates/rubrics/rubrics.module.scss
+++ b/apps/src/templates/rubrics/rubrics.module.scss
@@ -79,7 +79,7 @@
   background: var(--sentiment-error-50, #e5311a);
 }
 
-.countText {
+p.countText {
   margin-top: 1px;
   margin-bottom: 0 !important;
   padding: 0 2px;


### PR DESCRIPTION

Before:
<img width="168" height="180" alt="image" src="https://github.com/user-attachments/assets/7e577203-da5d-454a-8795-28e6403a872c" />


After:
<img width="73" height="96" alt="image" src="https://github.com/user-attachments/assets/231f49fd-5cc2-422a-8b30-29eec9d64596" />

The styles were getting overridden by DSCO, we just needed to increase specificity of the selector to order styles correctly.

## Links
- Jira: https://codedotorg.atlassian.net/browse/AITT-1112
