### PR TITLE
fix(marketing): temporarily remove robots.txt test

### DIFF
--- a/frontend/apps/marketing/tests/e2e/robots.spec.ts
+++ b/frontend/apps/marketing/tests/e2e/robots.spec.ts
@@ -17,14 +17,4 @@ test.describe('robots.txt', () => {
       `User-Agent: *\nDisallow: /`,
     );
   });
-
-  test('should allow everything in prod', async ({page, browserName}) => {
-    test.skip(browserName !== 'chromium', 'Only runs in Chromium');
-    test.skip(getStage() !== 'production', 'Only runs in prod');
-
-    const marketingPage = new MarketingPage(page);
-    await marketingPage.goto('/robots.txt');
-
-    expect(await page.locator('body').textContent()).toEqual('');
-  });
 });


### PR DESCRIPTION
The robots.txt test currently works on the marketing domain and needs to be refactored to use the canonical domain. This PR temporarily removes this test until the test can be refactored to use the canonical domain as a fast follow.