### PR TITLE
Update RubyTypes to not raise exceptions in production

### DIFF
--- a/dashboard/app/helpers/aichat_ruby_types.rb
+++ b/dashboard/app/helpers/aichat_ruby_types.rb
@@ -10,6 +10,7 @@ module AichatRubyTypes
   def self.raise_or_notify_type_error(message)
     if rack_env?(:production)
       Honeybadger.notify(
+        error_class: AichatRubyTypesWarning,
         error_message: message
       )
     else

--- a/dashboard/app/helpers/aichat_ruby_types.rb
+++ b/dashboard/app/helpers/aichat_ruby_types.rb
@@ -6,6 +6,17 @@
 # will eliminate some things needed to get around rubocop settings in the helper directory.
 
 module AichatRubyTypes
+  # Notify if production or raise an exception otherwise.
+  def self.raise_or_notify_type_error(message)
+    if rack_env?(:production)
+      Honeybadger.notify(
+        error_message: message
+      )
+    else
+      raise StandardError.new(message)
+    end
+  end
+
   # Stringify the type of a value.
   def self.stringify_type(value)
     if value.nil?
@@ -40,12 +51,12 @@ module AichatRubyTypes
 
     # Helper to determint if a value is this type. Needs to be implemented in derived classes.
     def value_is_type?(value)
-      raise StandardError.new("not implmemented")
+      raise_or_notify_type_error("not implmemented")
     end
 
     # Assert whether a value is this type.  Relies on `value_is_type?` helper.
     def assert_value_is_type(value, key = nil)
-      raise StandardError.new("#{AichatRubyTypes.stringify_type(value)} does not match type: #{type_string}#{key.nil? ? "" : " for key=#{key}"}") unless value_is_type?(value)
+      raise_or_notify_type_error("#{AichatRubyTypes.stringify_type(value)} does not match type: #{type_string}#{key.nil? ? "" : " for key=#{key}"}") unless value_is_type?(value)
     end
   end
 
@@ -55,7 +66,7 @@ module AichatRubyTypes
     # so we use is_a?(Class to catch this case.
     if type.is_a?(Class)
       # If an interface, we check that the value is an instance of that stuct.
-      raise StandardError.new("#{AichatRubyTypes.stringify_type_local.call(value)} does not match type: #{type}#{key.nil? ? "" : " for key=#{key}"}") unless value.is_a?(type)
+      raise_or_notify_type_error("#{AichatRubyTypes.stringify_type_local.call(value)} does not match type: #{type}#{key.nil? ? "" : " for key=#{key}"}") unless value.is_a?(type)
 
     # For all instances of Type-derived classes, we call its assert_value_is_type
     # to do the assertion.
@@ -64,7 +75,7 @@ module AichatRubyTypes
       type.assert_value_is_type(value, key)
     else
       # Any other Type is unexpected.
-      raise StandardError.new("Tried to assert value is a type, with an unexpected type: #{type}")
+      raise_or_notify_type_error("Tried to assert value is a type, with an unexpected type: #{type}")
     end
   end
 
@@ -112,7 +123,7 @@ module AichatRubyTypes
       # Iterate through them and build an array of field names and a hash of field name
       # to type.
       fields_and_types.each_slice(2) do |field, type|
-        raise StandardError.new("interface must be created with even number of properties and types") if type.nil?
+        raise_or_notify_type_error("interface must be created with even number of properties and types") if type.nil?
         fields << field
         types[field] = type
       end


### PR DESCRIPTION
This PR updates RubyTypes to raise errors only in non-production environments.  In production, type errors will be logged to Honeybadger.

## Links

This was discussed in slack in [this thread](https://codedotorg.slack.com/archives/C0T0PNTM3/p1757352447268119) as we don't want type errors to potentially be the cause of something breaking in production, but still want visibility.