### PR TITLE
Fix notifications broken except on localhost

### DIFF
--- a/dashboard/engines/marketing/lib/services/contentful_notification_formatter.rb
+++ b/dashboard/engines/marketing/lib/services/contentful_notification_formatter.rb
@@ -59,14 +59,13 @@ module Services
           error: exception.message,
         }
       )
-      puts exception
       nil
     end
 
     private def parse_published_at(contentful_notification)
-      if contentful_notification.respond_to?(:first_published_at)
+      if contentful_notification.try(:first_published_at).present?
         Time.parse(contentful_notification.first_published_at)
-      elsif contentful_notification.respond_to?(:created_at)
+      elsif contentful_notification.try(:created_at).present?
         if contentful_notification.created_at.is_a?(DateTime)
           contentful_notification.created_at
         else

--- a/dashboard/engines/marketing/lib/services/contentful_notification_formatter.rb
+++ b/dashboard/engines/marketing/lib/services/contentful_notification_formatter.rb
@@ -9,7 +9,7 @@ module Services
     def call
       fields = contentful_notification.fields || {}
 
-      published_at = Time.parse(contentful_notification.first_published_at)
+      published_at = parse_published_at(contentful_notification)
 
       formatted_notification = {
         external_id: contentful_notification.id,
@@ -41,7 +41,7 @@ module Services
 
       # Ensure data types are correct
       formatted_notification[:priority] = formatted_notification[:priority].to_i
-      formatted_notification[:published_at] = formatted_notification[:published_at].is_a?(Time) ? formatted_notification[:published_at].iso8601 : nil
+      formatted_notification[:published_at] = formatted_notification[:published_at].is_a?(Time) || formatted_notification[:published_at].is_a?(DateTime) ? formatted_notification[:published_at].iso8601 : nil
       formatted_notification[:expires_at] = formatted_notification[:expires_at].is_a?(Time) ? formatted_notification[:expires_at].iso8601 : nil
       formatted_notification[:href_links] = formatted_notification[:href_links].filter_map do |link|
         link['url'].present? && link['text'].present? ? {url: link['url'], text: link['text']} : nil
@@ -59,7 +59,22 @@ module Services
           error: exception.message,
         }
       )
+      puts exception
       nil
+    end
+
+    private def parse_published_at(contentful_notification)
+      if contentful_notification.respond_to?(:first_published_at)
+        Time.parse(contentful_notification.first_published_at)
+      elsif contentful_notification.respond_to?(:created_at)
+        if contentful_notification.created_at.is_a?(DateTime)
+          contentful_notification.created_at
+        else
+          Time.parse(contentful_notification.created_at)
+        end
+      else
+        Time.current
+      end
     end
   end
 end


### PR DESCRIPTION
On production, we use the Contentful [Content Delivery API](https://www.contentful.com/developers/docs/references/content-delivery-api/#/introduction/common-resource-attributes), which does not return a firstPublishedAt and instead returns createdAt. On localhost we use the [Content Preview API](https://www.contentful.com/developers/docs/references/content-preview-api/), which has both.

I was originally using the firstPublishedAt and it was working fine on my machine :\ 

This PR switches to using createdAt when necessary and also adds some better logs and safety for the publishedAt returned time.
