### PR TITLE
AI Tutor: Separate source code into multiple files with filenames.

### DIFF
--- a/apps/src/pythonlab/aiTutorHelper.ts
+++ b/apps/src/pythonlab/aiTutorHelper.ts
@@ -13,37 +13,25 @@ export const getAiTutorContextPromise = async (
   longInstructions: string | undefined,
   miniAppName: string | undefined
 ): Promise<AiTutorContext> => {
-  const sourceFiles = source
+  const sourceCode = source
     ? Object.entries(source.files)
         .filter(
           ([_, file]) =>
-            file.type !== ProjectFileType.VALIDATION &&
-            file.type !== ProjectFileType.SYSTEM_SUPPORT &&
-            file.type !== ProjectFileType.SUPPORT
+            (file.type !== ProjectFileType.VALIDATION &&
+              file.type !== ProjectFileType.SYSTEM_SUPPORT &&
+              file.type !== ProjectFileType.SUPPORT) ||
+            (file.type === ProjectFileType.SUPPORT && file.contents)
         )
         .map(([_, file]) => {
-          return [file.name, `\`\`\`${file.contents}\`\`\``].join('\n');
-        })
-    : [];
+          let prefix = '';
+          if (file.type === ProjectFileType.SUPPORT) {
+            prefix = `${file.name} is not visible to the student: \n`;
+          }
 
-  // Support files are not likely to have contents in python lab curriculum levels.
-  // We'll include them if they do, with the caveat that they are not visible to the student.
-  const supportFiles = source
-    ? Object.entries(source.files)
-        .filter(
-          ([_, file]) => file.type === ProjectFileType.SUPPORT && file.contents
-        )
-        .map(([_, file]) => {
-          return [
-            `${file.name} is not visible to the student: `,
-            file.name,
-            `\`\`\`${file.contents}\`\`\``,
-          ].join('\n');
+          return `${prefix}filename: ${file.name}\n\`\`\`${file.contents}\`\`\``;
         })
-    : [];
-
-  const sourceCode =
-    [...sourceFiles, ...supportFiles].join('\n\n') || undefined;
+        .join('\n\n')
+    : undefined;
 
   const validationContents = validationFile?.contents;
 

--- a/apps/src/pythonlab/aiTutorHelper.ts
+++ b/apps/src/pythonlab/aiTutorHelper.ts
@@ -13,18 +13,37 @@ export const getAiTutorContextPromise = async (
   longInstructions: string | undefined,
   miniAppName: string | undefined
 ): Promise<AiTutorContext> => {
-  const sourceCode = source
+  const sourceFiles = source
     ? Object.entries(source.files)
         .filter(
           ([_, file]) =>
             file.type !== ProjectFileType.VALIDATION &&
-            file.type !== ProjectFileType.SYSTEM_SUPPORT
+            file.type !== ProjectFileType.SYSTEM_SUPPORT &&
+            file.type !== ProjectFileType.SUPPORT
         )
         .map(([_, file]) => {
           return [file.name, `\`\`\`${file.contents}\`\`\``].join('\n');
         })
-        .join('\n\n')
-    : undefined;
+    : [];
+
+  // Support files are not likely to have contents in python lab curriculum levels.
+  // We'll include them if they do, with the caveat that they are not visible to the student.
+  const supportFiles = source
+    ? Object.entries(source.files)
+        .filter(
+          ([_, file]) => file.type === ProjectFileType.SUPPORT && file.contents
+        )
+        .map(([_, file]) => {
+          return [
+            `${file.name} is not visible to the student: `,
+            file.name,
+            `\`\`\`${file.contents}\`\`\``,
+          ].join('\n');
+        })
+    : [];
+
+  const sourceCode =
+    [...sourceFiles, ...supportFiles].join('\n\n') || undefined;
 
   const validationContents = validationFile?.contents;
 
@@ -57,7 +76,7 @@ export const buildHiddenContextString = (context: AiTutorContext) => {
 
   const hiddenContextString = [
     "Here is the student's current code:",
-    `\`\`\`${sourceCode}\`\`\``,
+    sourceCode,
     ...(validationContents
       ? ['Here is the validation code:', `\`\`\`${validationContents}\`\`\``]
       : []),

--- a/apps/src/pythonlab/aiTutorHelper.ts
+++ b/apps/src/pythonlab/aiTutorHelper.ts
@@ -20,8 +20,10 @@ export const getAiTutorContextPromise = async (
             file.type !== ProjectFileType.VALIDATION &&
             file.type !== ProjectFileType.SYSTEM_SUPPORT
         )
-        .map(([_, file]) => file.contents)
-        .join('\n')
+        .map(([_, file]) => {
+          return [file.name, `\`\`\`${file.contents}\`\`\``].join('\n');
+        })
+        .join('\n\n')
     : undefined;
 
   const validationContents = validationFile?.contents;


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->



## Links
<!--  Links to relevant external resources.
      - spec docs, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- Jira: [LABS-1564 Support multiple files as separate files with filenames](https://codedotorg.atlassian.net/browse/LABS-1564)

## Testing story
<!--  Does your change include appropriate tests?
      - If so, please describe how the tests included in this PR are sufficient.
      - If not, please explain why this change does not need to be tested. -->

<img width="2084" height="1251" alt="image" src="https://github.com/user-attachments/assets/736742a4-2478-4cc5-b8e8-d4d10ac39c00" />



## Deployment strategy
<!--  Any special steps required to deploy this, besides merging?
      - Are there database migrations or manual steps?
      - Does this require coordination with other teams or systems? -->



## Follow-up work
<!--  List any clean-up or technical debt that will be addressed in future work.
      - Include Jira links where applicable.
      - Are there any known limitations or improvements planned? -->

 - support files we think aren't used right now. I think I'll filter them out if empty, otherwise include them with a note that the file is hidden from the student in the editor.
 - system_support file i.e. the grid we'll add in a separate pr (tracked here https://codedotorg.atlassian.net/browse/LABS-1565)

