### PR TITLE
chore(Web Lab 2): move CopyrightButton above Settings button in sidebar

### DIFF
--- a/apps/src/lab2/views/components/Instructions/ResourcePanel/index.tsx
+++ b/apps/src/lab2/views/components/Instructions/ResourcePanel/index.tsx
@@ -236,6 +236,7 @@ const ResourcePanel: React.FC<ResourcePanelProps> = ({
         </div>
         <div className={classNames(styles.bottomTabs)}>
           <ResourcePanelExtraLinks levelId={levelId} theme={theme} />
+          <CopyrightButton theme={theme} />
           <WithTooltip
             tooltipProps={{
               text: commonI18n.settings(),
@@ -256,7 +257,6 @@ const ResourcePanel: React.FC<ResourcePanelProps> = ({
               type={'tertiary'}
             />
           </WithTooltip>
-          <CopyrightButton theme={theme} />
         </div>
       </div>
       <div className={styles.panels}>


### PR DESCRIPTION
Swaps the Copyright button and Settings button so the copyright is covered by the AI TA button instead of settings. 

## Links
Jira ticket: [AFL-153](https://codedotorg.atlassian.net/browse/AFL-153)

## Testing story
Tested locally, will likely have Eyes diffs

----

## Before
<img width="1365" height="768" alt="Screenshot 2025-09-10 at 11 31 33 AM" src="https://github.com/user-attachments/assets/ea5956cc-3cc6-4169-8809-255bc76dedfa" />

## After

https://github.com/user-attachments/assets/c85b629b-d9c1-4381-b5fd-513a8bd2f9bc



