### PR TITLE
Lab2 resource panel: Update condition to show validation tab

### DIFF
--- a/apps/src/lab2/views/components/Instructions/ResourcePanel/index.tsx
+++ b/apps/src/lab2/views/components/Instructions/ResourcePanel/index.tsx
@@ -108,6 +108,9 @@ const ResourcePanel: React.FC<ResourcePanelProps> = ({
   const isWidgetView = instructionsProps.levelProperties.widgetView || false;
 
   const levelId = instructionsProps.levelProperties.id;
+  const hasValidationConditions = useAppSelector(
+    state => state.lab.validationState?.hasConditions
+  );
 
   // Build available tabs based on level information.
   const availableTabs = useMemo(() => {
@@ -120,7 +123,7 @@ const ResourcePanel: React.FC<ResourcePanelProps> = ({
       );
     }
 
-    if (instructionsProps.validationSettings) {
+    if (instructionsProps.validationSettings && hasValidationConditions) {
       tabMap[Tabs.Validation] = (
         <ValidationPanel {...instructionsProps.validationSettings} />
       );
@@ -175,6 +178,7 @@ const ResourcePanel: React.FC<ResourcePanelProps> = ({
     return tabMap;
   }, [
     instructionsProps,
+    hasValidationConditions,
     isUserTeacher,
     aiTutorContextPromise,
     isReadOnly,


### PR DESCRIPTION
Follow up to #68218.
I noticed the validation tab was always showing up in Python lab and Web Lab 2, regardless of if the level had validation. The logic to include the tab was too permissive; we should check if the lab has validation settings and it has conditions.

Music Lab was not showing the tab (it had no validation settings), and still is not showing it after this change.


## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
