### PR TITLE
Lab2: play Music Lab project in Dance Party

### DIFF
--- a/apps/src/dance/ai/AiVisualizationPreview.tsx
+++ b/apps/src/dance/ai/AiVisualizationPreview.tsx
@@ -27,13 +27,11 @@ const AiVisualizationPreview: React.FunctionComponent<
   const executorRef = useRef<ProgramExecutor | null>(null);
   // Create the executor on mount to make sure the preview div exists.
   useEffect(() => {
-    executorRef.current = new ProgramExecutor(
-      id,
-      () => undefined, // no-op on puzzle complete
-      true, // treat this as a readonly workspace
-      false, // no replay log
-      danceMetricsReporter
-    );
+    executorRef.current = new ProgramExecutor({
+      container: id,
+      isReadOnlyWorkspace: true,
+      metricsReporter: danceMetricsReporter,
+    });
   }, [id]);
 
   useEffect(() => {

--- a/apps/src/dance/blockly/blockDefinitions/when_run.ts
+++ b/apps/src/dance/blockly/blockDefinitions/when_run.ts
@@ -7,7 +7,7 @@ import {
 import {commonI18n} from '@cdo/apps/types/locale';
 
 const definition: BlockJson = {
-  type: 'when_run',
+  type: 'Dancelab_whenRun',
   message0: commonI18n.whenRun(),
   nextStatement: null,
   style: BlockStyles.SETUP,

--- a/apps/src/dance/blockly/defaultSources.json
+++ b/apps/src/dance/blockly/defaultSources.json
@@ -4,7 +4,7 @@
       "blocks": [
         {
           "id": "when-run-block",
-          "type": "when_run",
+          "type": "Dancelab_whenRun",
           "deletable": false,
           "movable": false
         }

--- a/apps/src/dance/lab2/ProgramExecutor.ts
+++ b/apps/src/dance/lab2/ProgramExecutor.ts
@@ -23,6 +23,23 @@ const allEvents: {[name in HookName]: Handler} = {
   getCueList: {code: 'return getCueList();'},
 };
 
+interface ProgramExecutorOptions {
+  container: string;
+  metricsReporter: LabMetricsReporter;
+  isReadOnlyWorkspace?: boolean;
+  onPuzzleComplete?: (result: boolean, message: string) => void;
+  onEventsChanged?: () => void;
+  customHelperLibrary?: string;
+  validationCode?: string;
+  readonlyCode?: string;
+  playSound?: (
+    url: string,
+    callback: (playSuccess: boolean) => void,
+    onEnded: () => void
+  ) => void;
+  stopSound?: () => void;
+}
+
 /**
  * Handles program execution for Dance Party and wraps the native Dance Party API.
  *
@@ -34,46 +51,42 @@ export default class ProgramExecutor {
   private hooks: {[name in HookName]?: (args?: unknown[]) => unknown};
   private validationCode?: string;
   private onEventsChanged?: () => void;
+  private stopSound?: () => void;
 
   private livePreviewActive = false;
   private currentlyPlayingSong: string | null = null;
 
-  constructor(
-    container: string,
-    onPuzzleComplete: (result: boolean, message: string) => void,
-    isReadOnlyWorkspace: boolean,
-    recordReplayLog: boolean,
-    metricsReporter: LabMetricsReporter,
-    customHelperLibrary?: string,
-    validationCode?: string,
-    onEventsChanged?: () => void,
-    readonlyCode?: string, // Allows us to supply the student code early if we're in a read-only workspace.
-    nativeAPI: typeof DanceParty = undefined // For testing
-  ) {
+  constructor(options: ProgramExecutorOptions, nativeAPI?: typeof DanceParty) {
     this.hooks = {};
-    this.validationCode = validationCode;
-    this.onEventsChanged = onEventsChanged;
+    this.validationCode = options.validationCode;
+    this.onEventsChanged = options.onEventsChanged;
+    this.stopSound = options.stopSound;
     this.nativeAPI =
       nativeAPI ||
       new DanceParty({
-        onPuzzleComplete,
-        playSound: (...args: Parameters<typeof this.playSong>) =>
-          this.playSong(...args),
-        recordReplayLog,
-        showMeasureLabel: !isReadOnlyWorkspace,
+        onPuzzleComplete: options.onPuzzleComplete || (() => undefined),
+        playSound:
+          options.playSound ||
+          ((...args: Parameters<typeof this.playSong>) =>
+            this.playSong(...args)),
+        showMeasureLabel: !options.isReadOnlyWorkspace,
         onHandleEvents: (currentFrameEvents: object[]) =>
           this.handleEvents(currentFrameEvents),
         onInit: async (nativeAPI: typeof DanceParty) => {
-          this.init(nativeAPI, isReadOnlyWorkspace, readonlyCode);
+          this.init(
+            nativeAPI,
+            options.isReadOnlyWorkspace || false,
+            options.readonlyCode
+          );
         },
-        spriteConfig: new Function('World', customHelperLibrary || ''),
-        container,
+        spriteConfig: new Function('World', options.customHelperLibrary || ''),
+        container: options.container,
         i18n: danceMsg,
         resourceLoader: new ResourceLoader(ASSET_BASE),
-        logger: metricsReporter,
+        logger: options.metricsReporter,
       });
     this.nativeAPI.reset();
-    this.metricsReporter = metricsReporter;
+    this.metricsReporter = options.metricsReporter;
   }
 
   /**
@@ -188,6 +201,7 @@ export default class ProgramExecutor {
       audioCommands.stopSound({url: this.currentlyPlayingSong});
       this.currentlyPlayingSong = null;
     }
+    this.stopSound?.();
     this.nativeAPI.reset();
     this.livePreviewActive = false;
   }

--- a/apps/src/dance/lab2/views/DanceControls.tsx
+++ b/apps/src/dance/lab2/views/DanceControls.tsx
@@ -8,6 +8,7 @@ import moduleStyles from './dance-view.module.scss';
 interface DanceControlsProps {
   onRun: () => void;
   onReset: () => void;
+  disabled?: boolean;
 }
 
 /**
@@ -17,11 +18,13 @@ interface DanceControlsProps {
 const DanceControls: React.FunctionComponent<DanceControlsProps> = ({
   onRun,
   onReset,
+  disabled,
 }) => {
   const isRunning = useAppSelector(state => state.dance.isRunning);
-  const disabled = useAppSelector(
-    state => state.dance.isLoading || state.dance.runIsStarting
-  );
+  const isDisabled =
+    useAppSelector(
+      state => state.dance.isLoading || state.dance.runIsStarting
+    ) || disabled;
 
   const props = isRunning
     ? {
@@ -33,7 +36,7 @@ const DanceControls: React.FunctionComponent<DanceControlsProps> = ({
 
   return (
     <div className={moduleStyles.controlsContainer}>
-      <Button {...props} disabled={disabled} />
+      <Button {...props} disabled={isDisabled} />
     </div>
   );
 };

--- a/apps/src/dance/lab2/views/DanceView.tsx
+++ b/apps/src/dance/lab2/views/DanceView.tsx
@@ -360,7 +360,8 @@ const DanceView: React.FunctionComponent<{
           // Use the specific channel if provided. Otherwise
           // just pass a dummy string as we expect to find a music
           // project in local storage.
-          (queryParams('music-channel') as string) || 'local-storage'
+          (queryParams('music-channel') as string) || 'local-storage',
+          queryParams('ai-generate') === 'true'
         )
         .then(() => setLoadedMusicProject(true));
     }

--- a/apps/src/dance/lab2/views/DanceView.tsx
+++ b/apps/src/dance/lab2/views/DanceView.tsx
@@ -2,7 +2,7 @@ import {Button} from '@code-dot-org/component-library/button';
 import {BlocklyOptions, Events, WorkspaceSvg} from 'blockly/core';
 import classNames from 'classnames';
 import {isEqual} from 'lodash';
-import React, {useCallback, useEffect, useRef, useState} from 'react';
+import React, {useCallback, useEffect, useMemo, useRef, useState} from 'react';
 
 import {loadBlocksToWorkspace} from '@cdo/apps/blockly/addons/cdoUtils';
 import {BLOCK_TYPES} from '@cdo/apps/blockly/constants';
@@ -16,6 +16,7 @@ import {
   workspaceToToolboxDefinition,
 } from '@cdo/apps/blockly/utils/toolbox';
 import {saveReplayLog} from '@cdo/apps/code-studio/components/shareDialogRedux';
+import {queryParams} from '@cdo/apps/code-studio/utils';
 import defaultSources from '@cdo/apps/dance/blockly/defaultSources.json';
 import {
   installSharedBlocks,
@@ -32,7 +33,11 @@ import {
 } from '@cdo/apps/dance/danceRedux';
 import {getFilterStatus} from '@cdo/apps/dance/songs';
 import SongSelector from '@cdo/apps/dance/SongSelector';
-import {DanceLevelProperties, DanceProjectSources} from '@cdo/apps/dance/types';
+import {
+  DanceLevelProperties,
+  DanceProjectSources,
+  SongMetadata,
+} from '@cdo/apps/dance/types';
 import {TOOLBOX_BLOCKS} from '@cdo/apps/lab2/constants';
 import {useBlocklySettings} from '@cdo/apps/lab2/hooks/useBlocklySettings';
 import useLevelEditMode from '@cdo/apps/lab2/hooks/useLevelEditMode';
@@ -46,6 +51,8 @@ import {isReadOnlyWorkspace} from '@cdo/apps/lab2/redux/lab2ReduxSelectors';
 import {BlocklySource, LabProps} from '@cdo/apps/lab2/types';
 import ResourcePanel from '@cdo/apps/lab2/views/components/Instructions/ResourcePanel';
 import PanelContainer from '@cdo/apps/lab2/views/components/PanelContainer';
+import ProjectPlayer from '@cdo/apps/music/ProjectPlayer';
+import MusicProjectBar from '@cdo/apps/music/views/MusicProjectBar';
 import {registerReducers} from '@cdo/apps/redux';
 import AgeDialog from '@cdo/apps/templates/AgeDialog';
 import {commonI18n} from '@cdo/apps/types/locale';
@@ -66,6 +73,8 @@ const BLOCKLY_DIV_ID = 'dance-blockly-div';
 registerReducers(reducers);
 
 const isToolboxMode = getAppOptionsEditBlocks() === TOOLBOX_BLOCKS;
+const usingMusicProject =
+  queryParams('music-channel') || queryParams('ai-generate');
 
 /**
  * Renders the Lab2 version of Dance Lab. This separate container
@@ -93,6 +102,25 @@ const DanceView: React.FunctionComponent<{
 
   const programExecutor = useRef<ProgramExecutor | null>(null);
   const workspace = useRef<WorkspaceSvg | null>(null);
+  const musicProjectPlayer = useRef<ProjectPlayer | null>(null);
+  const [loadedMusicProject, setLoadedMusicProject] = useState(false);
+
+  const metadataToUse: SongMetadata | undefined = useMemo(() => {
+    if (!musicProjectPlayer.current || !loadedMusicProject) {
+      return currentSongMetadata;
+    }
+
+    return {
+      analysis: [],
+      artist: 'AI Bot', // TODO: user's name? AI?
+      bpm: musicProjectPlayer.current.getBpm().toString(),
+      delay: '0',
+      duration: 0, // Unused
+      file: '', // Unused
+      title: 'My AI Remix', // TODO: what should this be?
+      peaks: {},
+    };
+  }, [currentSongMetadata, loadedMusicProject]);
 
   const WorkspaceAlert = useLevelEditMode<DanceLevelProperties>(
     levelProperties.id,
@@ -159,7 +187,7 @@ const DanceView: React.FunctionComponent<{
   );
 
   const runProgram = useCallback(async () => {
-    if (!programExecutor.current || !currentSongMetadata) {
+    if (!programExecutor.current || !metadataToUse) {
       return;
     }
 
@@ -169,13 +197,13 @@ const DanceView: React.FunctionComponent<{
     programExecutor.current.reset();
     await programExecutor.current.execute(
       Blockly.getWorkspaceCode(),
-      currentSongMetadata
+      metadataToUse
     );
     dispatch(setRunIsStarting(false));
     dispatch(setIsRunning(true));
     dispatch(setHasRun(true));
     saveBlocks(true);
-  }, [programExecutor, currentSongMetadata, saveBlocks, dispatch]);
+  }, [programExecutor, metadataToUse, saveBlocks, dispatch]);
 
   const resetProgram = useCallback(() => {
     programExecutor.current?.reset();
@@ -324,6 +352,20 @@ const DanceView: React.FunctionComponent<{
     return () => workspace.current?.removeChangeListener(onBlockSpaceChange);
   }, [onBlockSpaceChange]);
 
+  useEffect(() => {
+    if (usingMusicProject) {
+      musicProjectPlayer.current = new ProjectPlayer();
+      musicProjectPlayer.current
+        .loadProject(
+          // Use the specific channel if provided. Otherwise
+          // just pass a dummy string as we expect to find a music
+          // project in local storage.
+          (queryParams('music-channel') as string) || 'local-storage'
+        )
+        .then(() => setLoadedMusicProject(true));
+    }
+  }, []);
+
   // Set up the ProgramExecutor
   useEffect(() => {
     // Skip setting up the ProgramExecutor in toolbox mode as we are not running code.
@@ -335,16 +377,25 @@ const DanceView: React.FunctionComponent<{
     // record a replay log (and generate a video) for both project levels and any
     // course levels that have sharing enabled
     const recordReplayLog = isProjectLevel || freePlay || false;
-    programExecutor.current = new ProgramExecutor(
-      DANCE_VISUALIZATION_ID,
+    programExecutor.current = new ProgramExecutor({
+      container: DANCE_VISUALIZATION_ID,
       onPuzzleComplete,
-      readonlyWorkspace,
-      recordReplayLog,
-      Lab2Registry.getInstance().getMetricsReporter(),
+      isReadOnlyWorkspace: readonlyWorkspace,
+      metricsReporter: Lab2Registry.getInstance().getMetricsReporter(),
       customHelperLibrary,
       validationCode,
-      onEventsChanged
-    );
+      onEventsChanged,
+      playSound: musicProjectPlayer.current
+        ? (_url, callback) => {
+            console.log('play called at ', Date.now());
+            musicProjectPlayer.current?.play();
+            callback(true);
+          }
+        : undefined,
+      stopSound: musicProjectPlayer.current
+        ? () => musicProjectPlayer.current?.stop()
+        : undefined,
+    });
 
     if (recordReplayLog) {
       dispatch(saveReplayLog(programExecutor.current.getReplayLog()));
@@ -361,6 +412,7 @@ const DanceView: React.FunctionComponent<{
     onPuzzleComplete,
     readonlyWorkspace,
   ]);
+
   const settings = useBlocklySettings();
 
   return (
@@ -384,7 +436,7 @@ const DanceView: React.FunctionComponent<{
           className={moduleStyles.visualizationArea}
         >
           <div className={moduleStyles.visualizationColumn}>
-            {currentSources.selectedSong && (
+            {!usingMusicProject && currentSources.selectedSong && (
               <SongSelector
                 enableSongSelection={!isRunning}
                 setSong={onSetSong}
@@ -394,6 +446,13 @@ const DanceView: React.FunctionComponent<{
                 levelIsRunning={isRunning}
               />
             )}
+            {usingMusicProject &&
+              (loadedMusicProject && metadataToUse ? (
+                <MusicProjectBar title={metadataToUse.title} />
+              ) : (
+                // Temp UI
+                'Loading your Music Lab project...'
+              ))}
             <div
               id={DANCE_VISUALIZATION_ID}
               className={moduleStyles.visualization}
@@ -411,7 +470,11 @@ const DanceView: React.FunctionComponent<{
                 />
               </div>
             </div>
-            <DanceControls onRun={runProgram} onReset={resetProgram} />
+            <DanceControls
+              onRun={runProgram}
+              onReset={resetProgram}
+              disabled={(usingMusicProject && !loadedMusicProject) || false}
+            />
           </div>
         </PanelContainer>
       )}

--- a/apps/src/dance/lab2/views/DanceView.tsx
+++ b/apps/src/dance/lab2/views/DanceView.tsx
@@ -112,12 +112,12 @@ const DanceView: React.FunctionComponent<{
 
     return {
       analysis: [],
-      artist: 'AI Bot', // TODO: user's name? AI?
+      artist: 'A.I.', // TODO: user's name?
       bpm: musicProjectPlayer.current.getBpm().toString(),
       delay: '0',
       duration: 0, // Unused
       file: '', // Unused
-      title: 'My AI Remix', // TODO: what should this be?
+      title: 'My A.I. Remix', // TODO: what should this be?
       peaks: {},
     };
   }, [currentSongMetadata, loadedMusicProject]);

--- a/apps/src/music/ProjectPlayer.ts
+++ b/apps/src/music/ProjectPlayer.ts
@@ -1,0 +1,101 @@
+// TODO: Better name?
+
+import {SourcesStore} from '../lab2/projects/SourcesStore';
+
+import MusicBlocklyWorkspace from './blockly/MusicBlocklyWorkspace';
+import {setUpBlocklyForMusicLab} from './blockly/setup';
+import {PlaybackEvent} from './player/interfaces/PlaybackEvent';
+import MusicLibrary from './player/MusicLibrary';
+import MusicPlayer from './player/MusicPlayer';
+import {MusicLabConfig} from './types';
+import {cacheKey, computeEventMeasures, MusicMetadata} from './utils/Generate';
+
+/**
+ * Given information about a student project, manages loading code and playing the project song.
+ */
+class ProjectPlayer {
+  private currentPlaybackEvents: PlaybackEvent[] | null = null;
+  private eventMeasures: number[] | null = null;
+
+  constructor(
+    private readonly player = new MusicPlayer(),
+    private readonly sourcesStore: SourcesStore = new SourcesStore(),
+    private readonly workspace: MusicBlocklyWorkspace = new MusicBlocklyWorkspace()
+  ) {
+    setUpBlocklyForMusicLab();
+  }
+
+  // TODO: Support fetching by level + user ID?
+  async loadProject(channelId: string) {
+    this.currentPlaybackEvents = null;
+    this.eventMeasures = null;
+    this.workspace.initHeadless();
+
+    const {playbackEvents, packId, libraryName} = await this.loadMetadata(
+      channelId
+    );
+
+    let library = MusicLibrary.getInstance();
+    if (!library) {
+      library = await MusicLibrary.loadLibrary(libraryName || 'launch2024');
+    }
+
+    if (packId) {
+      library.setCurrentPackId(packId);
+    }
+
+    this.player.updateConfiguration(library.getBPM(), library.getKey());
+    this.currentPlaybackEvents = playbackEvents;
+    this.eventMeasures = computeEventMeasures(playbackEvents);
+
+    await this.player.preloadSounds(playbackEvents);
+  }
+
+  play() {
+    if (this.currentPlaybackEvents === null) {
+      throw new Error('No project loaded!');
+    }
+    this.player.playSong(this.currentPlaybackEvents);
+  }
+
+  stop() {
+    this.player.stopSong();
+  }
+
+  getEventMeasures() {
+    if (this.eventMeasures === null) {
+      throw new Error('No project loaded!');
+    }
+    return this.eventMeasures;
+  }
+
+  getBpm() {
+    if (this.currentPlaybackEvents === null) {
+      throw new Error('No project loaded!');
+    }
+    return this.player.getBPM();
+  }
+
+  private async loadMetadata(channelId: string): Promise<MusicMetadata> {
+    // Try to load from local storage if it exists
+    const metadataString = localStorage.getItem(cacheKey());
+    if (metadataString) {
+      return JSON.parse(metadataString) as MusicMetadata;
+    }
+
+    // Otherwise, load from server
+    const sources = await this.sourcesStore.load(channelId);
+    const labConfig = sources.labConfig as MusicLabConfig;
+    this.workspace.loadCode(JSON.parse(sources.source as string));
+    this.workspace.compileSong(labConfig.music.blockMode);
+    const playbackEvents = this.workspace.executeCompiledSong().playbackEvents;
+
+    return {
+      playbackEvents,
+      packId: labConfig.music.packId,
+      libraryName: labConfig.music.library,
+    };
+  }
+}
+
+export default ProjectPlayer;

--- a/apps/src/music/ProjectPlayer.ts
+++ b/apps/src/music/ProjectPlayer.ts
@@ -26,13 +26,14 @@ class ProjectPlayer {
   }
 
   // TODO: Support fetching by level + user ID?
-  async loadProject(channelId: string) {
+  async loadProject(channelId: string, useLocalStorage = false) {
     this.currentPlaybackEvents = null;
     this.eventMeasures = null;
     this.workspace.initHeadless();
 
     const {playbackEvents, packId, libraryName} = await this.loadMetadata(
-      channelId
+      channelId,
+      useLocalStorage
     );
 
     let library = MusicLibrary.getInstance();
@@ -76,11 +77,16 @@ class ProjectPlayer {
     return this.player.getBPM();
   }
 
-  private async loadMetadata(channelId: string): Promise<MusicMetadata> {
+  private async loadMetadata(
+    channelId: string,
+    useLocalStorage = false
+  ): Promise<MusicMetadata> {
     // Try to load from local storage if it exists
-    const metadataString = localStorage.getItem(cacheKey());
-    if (metadataString) {
-      return JSON.parse(metadataString) as MusicMetadata;
+    if (useLocalStorage) {
+      const metadataString = localStorage.getItem(cacheKey());
+      if (metadataString) {
+        return JSON.parse(metadataString) as MusicMetadata;
+      }
     }
 
     // Otherwise, load from server

--- a/apps/src/music/types.ts
+++ b/apps/src/music/types.ts
@@ -1,6 +1,6 @@
 import * as GoogleBlockly from 'blockly/core';
 
-import {ExemplarSettings, ProjectLevelData} from '../lab2/types';
+import {ExemplarSettings, LabConfig, ProjectLevelData} from '../lab2/types';
 import {ValueOf} from '../types/utils';
 
 import {ToolboxData} from './blockly/toolbox/types';
@@ -41,3 +41,11 @@ export type SoundLoadCallbacks = {
   onLoadFinished?: LoadFinishedCallback;
   updateLoadProgress?: UpdateLoadProgressCallback;
 };
+
+export interface MusicLabConfig extends LabConfig {
+  music: {
+    blockMode: ValueOf<typeof BlockMode>;
+    packId?: string;
+    library?: string;
+  };
+}

--- a/apps/src/music/utils/Generate.ts
+++ b/apps/src/music/utils/Generate.ts
@@ -1,14 +1,35 @@
 import {trySetLocalStorage} from '@cdo/apps/utils';
 
 import {PlaybackEvent} from '../player/interfaces/PlaybackEvent';
+import MusicLibrary from '../player/MusicLibrary';
+
+// Using a constant cache key for now for experimentation.
+// We may extend this to be channel/level + user specific.
+export const cacheKey = () => `music-ai-generate`;
+
+export interface MusicMetadata {
+  playbackEvents: PlaybackEvent[];
+  packId?: string;
+  libraryName?: string;
+}
 
 // Save some information about the generated song, for consumption by dance party.
 export const saveGeneratedSongMetadata = (
   channelId: string,
   packId: string,
-  bpm: number,
   events: PlaybackEvent[]
 ) => {
+  trySetLocalStorage(
+    cacheKey(),
+    JSON.stringify({
+      playbackEvents: events,
+      packId,
+      libraryName: MusicLibrary.getInstance()?.name,
+    })
+  );
+};
+
+export const computeEventMeasures = (events: PlaybackEvent[]) => {
   // simpleEvents is an array of measures that have a significant number of sound events
   // starting at them.  For now, only measures that have more than 2 sounds starting at them
   // should be stored.  Note that measures might be fractional (e.g. 0.5).
@@ -28,9 +49,5 @@ export const saveGeneratedSongMetadata = (
       eventMeasures.push(measureNumber);
     }
   });
-
-  trySetLocalStorage(
-    'music-ai-generate',
-    JSON.stringify({channelId, packId, bpm, eventMeasures})
-  );
+  return eventMeasures;
 };

--- a/apps/src/music/views/MusicProjectBar.tsx
+++ b/apps/src/music/views/MusicProjectBar.tsx
@@ -1,0 +1,51 @@
+import {
+  BodyFourText,
+  BodyThreeText,
+} from '@code-dot-org/component-library/typography';
+import React from 'react';
+
+import MusicLibrary from '@cdo/apps/music/player/MusicLibrary';
+
+import {DEFAULT_PACK} from '../constants';
+
+import styles from './music-project-bar.module.scss';
+
+/**
+ * Temporary UI for displaying information about a Music Lab project. Used in
+ * Dance Party when using a Music Lab project.
+ */
+const MusicProjectBar: React.FC<{title: string}> = ({title}) => {
+  const library = MusicLibrary.getInstance();
+  if (!library) {
+    return null;
+  }
+
+  const packImageUrl = library.getPackImageUrl(
+    library.getCurrentPackId() || DEFAULT_PACK
+  );
+  const packFolder = library.getFolderForFolderId(
+    library.getCurrentPackId() || DEFAULT_PACK
+  );
+
+  return (
+    <div className={styles.container}>
+      {packImageUrl && (
+        <img
+          src={packImageUrl}
+          className={styles.image}
+          alt={packFolder?.name}
+        />
+      )}
+      <div className={styles.text}>
+        <BodyThreeText>{title}</BodyThreeText>
+        {packFolder && (
+          <BodyFourText>
+            {`${packFolder.name} - ${packFolder.artist}`}
+          </BodyFourText>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default MusicProjectBar;

--- a/apps/src/music/views/MusicView.jsx
+++ b/apps/src/music/views/MusicView.jsx
@@ -858,7 +858,6 @@ class UnconnectedMusicView extends React.Component {
       saveGeneratedSongMetadata(
         Lab2Registry.getInstance().getProjectManager().getChannelId(),
         this.props.packId,
-        this.library.getBPM(),
         this.props.playbackEvents
       );
     }

--- a/apps/src/music/views/music-project-bar.module.scss
+++ b/apps/src/music/views/music-project-bar.module.scss
@@ -1,0 +1,21 @@
+.container {
+  display: flex;
+  background-color: var(--background-neutral-tertiary);
+  border: 1px solid var(--borders-neutral-primary);
+  padding: 4px;
+  gap: 8px;
+  margin: 4px 0;
+  align-items: center;
+
+  > img {
+    height: 50px;
+  }
+}
+
+.text {
+  display: flex;
+  flex-direction: column;
+  > p {
+    margin: 0;
+  }
+}

--- a/apps/test/unit/dance/lab2/ProgramExecutorTest.ts
+++ b/apps/test/unit/dance/lab2/ProgramExecutorTest.ts
@@ -104,15 +104,12 @@ describe('ProgramExecutor', () => {
     metricsReporter = sinon.createStubInstance(LabMetricsReporter);
 
     programExecutor = new ProgramExecutor(
-      'container',
-      () => undefined,
-      false,
-      false,
-      metricsReporter,
-      undefined,
-      validationCode,
-      onEventsChanged,
-      '',
+      {
+        container: 'container',
+        metricsReporter: metricsReporter,
+        validationCode,
+        onEventsChanged,
+      },
       nativeAPI
     );
   });

--- a/dashboard/config/levels/custom/dance/Dance Lab2 Level 1.level
+++ b/dashboard/config/levels/custom/dance/Dance Lab2 Level 1.level
@@ -42,22 +42,19 @@
     "validation_enabled": "false",
     "hide_pause_button": "false",
     "start_sources": {
-      "selectedSong": "butter_bts",
       "source": {
         "blocks": {
-          "languageVersion": 0,
           "blocks": [
             {
-              "type": "when_run",
               "id": "when-run-block",
-              "x": 16,
-              "y": 16,
+              "type": "Dancelab_whenRun",
               "deletable": false,
               "movable": false
             }
           ]
         }
-      }
+      },
+      "selectedSong": "butter_bts"
     },
     "exemplar_sources": {
       "selectedSong": "good4u_oliviarodrigo",
@@ -144,22 +141,22 @@
         },
         {
           "kind": "block",
-          "type": "Dancelab_changeMoveEachLR_slothcat",
-          "id": ")ib*n^o5OYR}R[mXad51",
+          "type": "Dancelab_doMoveEachLR",
+          "id": "xTmotz3im4nyO3t9)1fD",
           "fields": {
-            "GROUP": "<field name=\"GROUP\">\"CAT\"</field>",
-            "MOVE": "<field name=\"MOVE\">MOVES.Roll</field>",
+            "GROUP": "<field name=\"GROUP\">sprites</field>",
+            "MOVE": "<field name=\"MOVE\">\"rand\"</field>",
             "DIR": "<field name=\"DIR\">-1</field>"
           },
           "enabled": true
         },
         {
           "kind": "block",
-          "type": "Dancelab_doMoveEachLR",
-          "id": "xTmotz3im4nyO3t9)1fD",
+          "type": "Dancelab_changeMoveEachLR",
+          "id": "M.`6cmZT~{NMq8h:aeZv",
           "fields": {
             "GROUP": "<field name=\"GROUP\">sprites</field>",
-            "MOVE": "<field name=\"MOVE\">\"rand\"</field>",
+            "MOVE": "<field name=\"MOVE\">\"next\"</field>",
             "DIR": "<field name=\"DIR\">-1</field>"
           },
           "enabled": true
@@ -209,7 +206,7 @@
   },
   "published": true,
   "notes": "",
-  "audit_log": "[{\"changed_at\":\"2023-09-05T12:46:08.190-07:00\",\"changed\":[\"cloned from \\\"allthethings HOC Dance 1\\\"\"],\"cloned_from\":\"allthethings HOC Dance 1\"},{\"changed_at\":\"2025-08-20 23:36:05 +0000\",\"changed\":[\"start_blocks\",\"toolbox_blocks\",\"skin\",\"validation_code\",\"default_song\",\"preload_asset_list\",\"contained_level_names\"],\"changed_by_id\":1,\"changed_by_email\":\"sanchit+localhost@code.org\"},{\"changed_at\":\"2025-08-20 23:41:21 +0000\",\"changed\":[\"start_blocks\",\"toolbox_blocks\",\"free_play\",\"preload_asset_list\",\"encrypted_examples\"],\"changed_by_id\":1,\"changed_by_email\":\"sanchit+localhost@code.org\"},{\"changed_at\":\"2025-08-22 22:53:47 +0000\",\"changed\":[\"start_blocks\",\"toolbox_blocks\",\"preload_asset_list\",\"encrypted_examples\"],\"changed_by_id\":1,\"changed_by_email\":\"sanchit+localhost@code.org\"},{\"changed_at\":\"2025-08-26 21:05:16 +0000\",\"changed\":[],\"changed_by_id\":1,\"changed_by_email\":\"sanchit+localhost@code.org\"},{\"changed_at\":\"2025-08-27 22:54:36 +0000\",\"changed\":[],\"changed_by_id\":1,\"changed_by_email\":\"sanchit+localhost@code.org\"},{\"changed_at\":\"2025-08-28 18:07:26 +0000\",\"changed\":[\"exemplar_sources\"],\"changed_by_id\":1,\"changed_by_email\":\"sanchit+localhost@code.org\"},{\"changed_at\":\"2025-08-28 18:09:07 +0000\",\"changed\":[\"exemplar_sources\"],\"changed_by_id\":1,\"changed_by_email\":\"sanchit+localhost@code.org\"},{\"changed_at\":\"2025-08-28 18:15:17 +0000\",\"changed\":[\"start_sources\"],\"changed_by_id\":1,\"changed_by_email\":\"sanchit+localhost@code.org\"},{\"changed_at\":\"2025-08-28 18:16:16 +0000\",\"changed\":[\"start_sources\"],\"changed_by_id\":1,\"changed_by_email\":\"sanchit+localhost@code.org\"},{\"changed_at\":\"2025-09-03 23:34:57 +0000\",\"changed\":[],\"changed_by_id\":1,\"changed_by_email\":\"sanchit+localhost@code.org\"},{\"changed_at\":\"2025-09-03 23:36:58 +0000\",\"changed\":[\"toolbox_definition\"],\"changed_by_id\":1,\"changed_by_email\":\"sanchit+localhost@code.org\"}]",
+  "audit_log": "[{\"changed_at\":\"2023-09-05T12:46:08.190-07:00\",\"changed\":[\"cloned from \\\"allthethings HOC Dance 1\\\"\"],\"cloned_from\":\"allthethings HOC Dance 1\"},{\"changed_at\":\"2025-08-20 23:36:05 +0000\",\"changed\":[\"start_blocks\",\"toolbox_blocks\",\"skin\",\"validation_code\",\"default_song\",\"preload_asset_list\",\"contained_level_names\"],\"changed_by_id\":1,\"changed_by_email\":\"sanchit+localhost@code.org\"},{\"changed_at\":\"2025-08-20 23:41:21 +0000\",\"changed\":[\"start_blocks\",\"toolbox_blocks\",\"free_play\",\"preload_asset_list\",\"encrypted_examples\"],\"changed_by_id\":1,\"changed_by_email\":\"sanchit+localhost@code.org\"},{\"changed_at\":\"2025-08-22 22:53:47 +0000\",\"changed\":[\"start_blocks\",\"toolbox_blocks\",\"preload_asset_list\",\"encrypted_examples\"],\"changed_by_id\":1,\"changed_by_email\":\"sanchit+localhost@code.org\"},{\"changed_at\":\"2025-08-26 21:05:16 +0000\",\"changed\":[],\"changed_by_id\":1,\"changed_by_email\":\"sanchit+localhost@code.org\"},{\"changed_at\":\"2025-08-27 22:54:36 +0000\",\"changed\":[],\"changed_by_id\":1,\"changed_by_email\":\"sanchit+localhost@code.org\"},{\"changed_at\":\"2025-08-28 18:07:26 +0000\",\"changed\":[\"exemplar_sources\"],\"changed_by_id\":1,\"changed_by_email\":\"sanchit+localhost@code.org\"},{\"changed_at\":\"2025-08-28 18:09:07 +0000\",\"changed\":[\"exemplar_sources\"],\"changed_by_id\":1,\"changed_by_email\":\"sanchit+localhost@code.org\"},{\"changed_at\":\"2025-08-28 18:15:17 +0000\",\"changed\":[\"start_sources\"],\"changed_by_id\":1,\"changed_by_email\":\"sanchit+localhost@code.org\"},{\"changed_at\":\"2025-08-28 18:16:16 +0000\",\"changed\":[\"start_sources\"],\"changed_by_id\":1,\"changed_by_email\":\"sanchit+localhost@code.org\"},{\"changed_at\":\"2025-09-03 23:34:57 +0000\",\"changed\":[],\"changed_by_id\":1,\"changed_by_email\":\"sanchit+localhost@code.org\"},{\"changed_at\":\"2025-09-03 23:36:58 +0000\",\"changed\":[\"toolbox_definition\"],\"changed_by_id\":1,\"changed_by_email\":\"sanchit+localhost@code.org\"},{\"changed_at\":\"2025-09-10 21:17:07 +0000\",\"changed\":[\"start_sources\"],\"changed_by_id\":1,\"changed_by_email\":\"sanchit+localhost@code.org\"},{\"changed_at\":\"2025-09-10 21:17:52 +0000\",\"changed\":[\"start_sources\"],\"changed_by_id\":1,\"changed_by_email\":\"sanchit+localhost@code.org\"},{\"changed_at\":\"2025-09-10 21:32:17 +0000\",\"changed\":[\"toolbox_definition\"],\"changed_by_id\":1,\"changed_by_email\":\"sanchit+localhost@code.org\"}]",
   "level_concept_difficulty": {
   }
 }]]></config>


### PR DESCRIPTION
This extracts the Music Lab playback portion of the "generate AI dance" work in https://github.com/code-dot-org/code-dot-org/pull/68188. Instead of using the existing MiniMusicPlayer, I effectively split out the non-UI parts into a separate unit (project loading + code compilation/execution + sound preload + player APIs) so that we could give playback controls over to Dance Party and let it track loading state. Later on, we could reuse this new unit (`ProjectPlayer`) inside the existing MiniMusicPlayer, but that can be a future refactor.

Note that we don't _explicitly_ sync Music Lab's transport to the Dance Party animation, but because we preload all the sounds, playback starts instantly. In my testing, there's just about a 30ms lag between when the Dance Party animation starts and when transport start callback fires, but this feels pretty negligible, and we can always adjust later if it feels off. Note that in current/legacy dance party, we don't perform any sort of audio-animation syncing and some dance moves do seem more synced than others overall.

I also created a temporary little UI bar in place of the song selector (effectively a low fi version of Mini Music Player, but purely visual) just to show the loaded song. Next, as I hook up the AI generate flow, I'll do a proper pass on UI including dark mode, jumbo visualization, hiding toolbox/instructions, etc.

<img width="1512" height="824" alt="Screenshot 2025-09-10 at 3 33 16 PM" src="https://github.com/user-attachments/assets/fafaa884-0c6f-4adb-a992-0c19450cb26f" />

### Usage

Works with `?ai-generate=true` if you just AI generated a Music Lab project (read from local storage). You can also supply a custom channel ID with `?music-channel=<channel ID>`. This does not have to an AI generated song; any should work.