### PR TITLE
Skip Database Snapshot When Deleting an Adhoc Stack

### DIFF
--- a/aws/cloudformation/components/database.yml.erb
+++ b/aws/cloudformation/components/database.yml.erb
@@ -324,6 +324,9 @@
       DBClusterIdentifier: !Sub "${AWS::StackName}-cluster"
       DBClusterParameterGroupName: !Ref Aurora3ClusterDBParameters
       Engine: aurora-mysql
+      # Updating a Stack with a change to EngineVersion causes "Some Interruption".
+      # Each Database Instance in the cluster is restarted.
+      # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-rds-dbcluster.html#cfn-rds-dbcluster-engineversion
       EngineVersion: 8.0.mysql_aurora.3.08.0
       MasterUsername: !Sub "{{resolve:secretsmanager:${DatabaseSecretAdmin}:SecretString:username}}"
       MasterUserPassword: !Sub "{{resolve:secretsmanager:${DatabaseSecretAdmin}:SecretString:password}}"

--- a/aws/cloudformation/components/database.yml.erb
+++ b/aws/cloudformation/components/database.yml.erb
@@ -314,17 +314,18 @@
       DBCredentialSecret: !Ref DatabaseSecretReader
       Privileges: ['SELECT']
 
-# We don't provision these in production via CloudFormation ... yet!
-<%  unless rack_env?(:production)%>
+<% # We don't provision DB Cluster and Instances in production via CloudFormation ... yet!
+  unless rack_env?(:production)
+    is_adhoc = rack_env?(:adhoc)
+    deletion_policy = is_adhoc ? "Delete" : "Snapshot"
+-%>
   AuroraCluster:
     Type: AWS::RDS::DBCluster
+    DeletionPolicy: <%= deletion_policy %>
     Properties:
       DBClusterIdentifier: !Sub "${AWS::StackName}-cluster"
       DBClusterParameterGroupName: !Ref Aurora3ClusterDBParameters
       Engine: aurora-mysql
-      # Updating a Stack with a change to EngineVersion causes "Some Interruption".
-      # Each Database Instance in the cluster is restarted.
-      # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-rds-dbcluster.html#cfn-rds-dbcluster-engineversion
       EngineVersion: 8.0.mysql_aurora.3.08.0
       MasterUsername: !Sub "{{resolve:secretsmanager:${DatabaseSecretAdmin}:SecretString:username}}"
       MasterUserPassword: !Sub "{{resolve:secretsmanager:${DatabaseSecretAdmin}:SecretString:password}}"
@@ -336,8 +337,8 @@
         - audit
         - error
         - slowquery
-      DeletionProtection: <%= rack_env?(:adhoc) ? false : true %>
-<%    unless rack_env?(:adhoc) -%>
+      DeletionProtection: <%= deletion_protection %>
+<%    unless is_adhoc -%>
       BackupRetentionPeriod: !Ref DBBackupRetention
 <%    end -%>
 <%    DB_INSTANCE_RANGE.each do |i| %>

--- a/aws/cloudformation/components/database.yml.erb
+++ b/aws/cloudformation/components/database.yml.erb
@@ -316,12 +316,10 @@
 
 <% # We don't provision DB Cluster and Instances in production via CloudFormation ... yet!
   unless rack_env?(:production)
-    is_adhoc = rack_env?(:adhoc)
-    deletion_policy = is_adhoc ? "Delete" : "Snapshot"
 -%>
   AuroraCluster:
     Type: AWS::RDS::DBCluster
-    DeletionPolicy: <%= deletion_policy %>
+    DeletionPolicy: <%= rack_env?(:adhoc) ? "Delete" : "Snapshot" %> # Don't take a final Snapshot when deleting adhoc clusters.
     Properties:
       DBClusterIdentifier: !Sub "${AWS::StackName}-cluster"
       DBClusterParameterGroupName: !Ref Aurora3ClusterDBParameters
@@ -337,8 +335,8 @@
         - audit
         - error
         - slowquery
-      DeletionProtection: <%= deletion_protection %>
-<%    unless is_adhoc -%>
+      DeletionProtection: <%= rack_env?(:adhoc) ? false : true %>
+<%    unless rack_env?(:adhoc) -%>
       BackupRetentionPeriod: !Ref DBBackupRetention
 <%    end -%>
 <%    DB_INSTANCE_RANGE.each do |i| %>


### PR DESCRIPTION
Default AWS quota is 100 Manual RDS Snapshots so our adhocs that use Aurora cluster are consuming excess Manual Snapshot Resources when we delete the Stacks.

## Links
<!--  Links to relevant external resources.
      - spec docs, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- Jira: 

## Testing story
`bundle exec rake adhoc:start RAILS_ENV=adhoc DATABASE=true`



## Deployment strategy
<!--  Any special steps required to deploy this, besides merging?
      - Are there database migrations or manual steps?
      - Does this require coordination with other teams or systems? -->



## Follow-up work
<!--  List any clean-up or technical debt that will be addressed in future work.
      - Include Jira links where applicable.
      - Are there any known limitations or improvements planned? -->



## Privacy
<!--  How does this change impact Student & Teacher privacy?
      - Does this collect, use, share, or modify PII, either new or existing? -->



## Security
<!--  How does this change impact our security surface-area?
      - Do API's touched have the right auth?
      - Do infra changes impact our attack surface or encryption?
-->



## Caching
<!--  How does this change impact caching behavior?
      - Are cache keys or invalidation strategies affected?
      - Will this require cache warming or invalidation after deployment? -->



## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
