### PR TITLE
AI Tutor - Fix react warning about missing key

### DIFF
--- a/apps/src/aichat/types/chatButton.ts
+++ b/apps/src/aichat/types/chatButton.ts
@@ -19,3 +19,8 @@ export type ChatButtonProps = {
 };
 
 export type ChatButtonComponent = React.ComponentType<ChatButtonProps>;
+
+export interface ChatButtonAndKey {
+  ChatButton: ChatButtonComponent;
+  key: string;
+}

--- a/apps/src/aichat/views/ChatWorkspace.tsx
+++ b/apps/src/aichat/views/ChatWorkspace.tsx
@@ -26,7 +26,7 @@ import {findChangedProperties, getNewRemoveId} from '../redux/utils';
 import {
   AiChatClientType,
   ChatAsset,
-  ChatButtonComponent,
+  ChatButtonAndKey,
   ModelParameters,
 } from '../types';
 import {getAssetUrl, getShortName} from '../utils';
@@ -42,7 +42,7 @@ import moduleStyles from './chatWorkspace.module.scss';
 interface ChatWorkspaceProps {
   modelParameters: ModelParameters;
   clientType: AiChatClientType;
-  chatButtons?: ChatButtonComponent[];
+  chatButtons?: ChatButtonAndKey[];
   hiddenContext?: string;
   onClear: () => void;
 

--- a/apps/src/aichat/views/UserChatMessageEditor.tsx
+++ b/apps/src/aichat/views/UserChatMessageEditor.tsx
@@ -6,7 +6,7 @@ import {useAppDispatch, useAppSelector} from '@cdo/apps/util/reduxHooks';
 import {submitChatContents} from '../redux';
 import {
   AiChatClientType,
-  ChatButtonComponent,
+  ChatButtonAndKey,
   ModelParameters,
   AnalyticsProperties,
 } from '../types';
@@ -17,7 +17,7 @@ interface UserChatMessageEditorProps {
   modelParameters: ModelParameters;
   clientType: AiChatClientType;
   editorContainerClassName?: string;
-  chatButtons?: ChatButtonComponent[];
+  chatButtons?: ChatButtonAndKey[];
   hiddenContext?: string;
   multimodalAvailable?: boolean;
 }
@@ -93,8 +93,8 @@ const UserChatMessageEditor: React.FunctionComponent<
     <>
       {chatButtons && (
         <div className={moduleStyles.chatButtonsContainer}>
-          {chatButtons.map(ChatButton => (
-            <ChatButton onClick={handleSubmit} />
+          {chatButtons.map(({ChatButton, key}) => (
+            <ChatButton key={key} onClick={handleSubmit} />
           ))}
         </div>
       )}

--- a/apps/src/lab2/views/components/AiTutor2Chat.tsx
+++ b/apps/src/lab2/views/components/AiTutor2Chat.tsx
@@ -82,31 +82,29 @@ const chatButtonData: ChatButtonData[] = [
   },
 ] as const;
 
-const chatButtons = chatButtonData.map(
-  button =>
-    ({onClick}: {onClick: ChatButtonClickHandler}) =>
-      (
-        <Button
-          className={moduleStyles.chatButton}
-          key={button.label}
-          aria-label={button.label}
-          iconLeft={
-            {
-              ...button.icon,
-              className: classNames({
-                [moduleStyles['icon']]: true,
-                [moduleStyles[`icon-${button.icon?.iconName}`]]: button.icon,
-              }),
-            } as FontAwesomeV6IconProps
-          }
-          onClick={() => onClick(button.value, button.analyticsProperties)}
-          text={button.label}
-          size="s"
-          type="secondary"
-          color="black"
-        />
-      )
-);
+const chatButtons = chatButtonData.map(button => ({
+  ChatButton: ({onClick}: {onClick: ChatButtonClickHandler}) => (
+    <Button
+      className={moduleStyles.chatButton}
+      aria-label={button.label}
+      iconLeft={
+        {
+          ...button.icon,
+          className: classNames({
+            [moduleStyles['icon']]: true,
+            [moduleStyles[`icon-${button.icon?.iconName}`]]: button.icon,
+          }),
+        } as FontAwesomeV6IconProps
+      }
+      onClick={() => onClick(button.value, button.analyticsProperties)}
+      text={button.label}
+      size="s"
+      type="secondary"
+      color="black"
+    />
+  ),
+  key: button.label,
+}));
 interface AiTutor2ChatProps {
   aiTutorContextPromise: Promise<AiTutorContext>;
 }


### PR DESCRIPTION
This PR fixes a bug in a previous [PR](https://github.com/code-dot-org/code-dot-org/pull/67889) that resulted in a react warning: `Each child in a list should have a unique 'key' prop` when rendering AI Tutor's suggested prompt buttons.

We were adding the key to the button components (functions) that were passed down as props (in an array) and the keys were present in react dev tools.  But react expects the key to be added directly when the component function is _used_, not in its _definition_.  The fix passes down an array of button + key pairs and then adds the key to the component in the final `map()`.