### PR TITLE
Switch `bin/dashboard-server` to puma via `rails server`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -77,6 +77,7 @@ group :development do
   # Bootsnap pre-caches Ruby require paths + bytecode and speeds up boot time significantly.
   # We only use it in development atm to get a feel for it, and the benefit is greatest here.
   gem 'bootsnap', '>= 1.14.0', require: false
+  gem 'localhost'
 end
 
 # Rack::Cache middleware used in development/test;

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -553,6 +553,7 @@ GEM
     llhttp-ffi (0.5.0)
       ffi-compiler (~> 1.0)
       rake (~> 13.0)
+    localhost (1.5.0)
     logger (1.6.1)
     loofah (2.19.1)
       crass (~> 1.0.2)
@@ -1064,6 +1065,7 @@ DEPENDENCIES
   jumphash
   jwt (~> 2.7.0)
   kaminari
+  localhost
   lograge!
   loofah (~> 2.19.1)
   mailgun-ruby (~> 1.2.14)

--- a/bin/dashboard-server
+++ b/bin/dashboard-server
@@ -19,8 +19,11 @@ def main
     pids.push spawn("rerun -x -d #{apps_dir}/src --background -n apps-watcher -- rake package:apps")
   end
 
-  rails_server_args = "-b #{CDO.dashboard_host} -p #{CDO.dashboard_port}"
-  # rails_server_args += " --ssl" if CDO.rack_env == :development && CDO.https_development
+  rails_server_args = if CDO.rack_env == :development && CDO.https_development
+                        "-b ssl://#{CDO.dashboard_host} -p #{CDO.dashboard_port}"
+                      else
+                        "-b #{CDO.dashboard_host} -p #{CDO.dashboard_port}"
+                      end
 
   Dir.chdir(dashboard_dir) do
     system "RAILS_ENV=#{CDO.rack_env} bundle exec #{rerun} rails server #{rails_server_args}"

--- a/bin/dashboard-server
+++ b/bin/dashboard-server
@@ -1,8 +1,6 @@
 #!/usr/bin/env ruby
 require_relative '../deployment'
 
-# Any arguments to bin/dashboard-server will get passed through to the rerun command, for example -b to run in background,
-# which allows for pry debugging.
 def main
   dirs = [deploy_dir('lib'), deploy_dir('shared/middleware'), deploy_dir('dashboard/legacy')]
   dirs += [pegasus_dir] if CDO.dashboard_enable_pegasus
@@ -14,7 +12,6 @@ def main
   rerun << "-i '**/public/fonts'"
   rerun << "#{ARGV.join(' ')} --"
   rerun = rerun.join(' ')
-  pids = []
 
   unless CDO.use_my_apps
     # Note: This will report "apps-watcher Launch Failed" because it expects something
@@ -22,11 +19,11 @@ def main
     pids.push spawn("rerun -x -d #{apps_dir}/src --background -n apps-watcher -- rake package:apps")
   end
 
-  thin_args = "-a #{CDO.dashboard_host} -p #{CDO.dashboard_port}"
-  thin_args += " --ssl" if CDO.rack_env == :development && CDO.https_development
+  rails_server_args = "-b #{CDO.dashboard_host} -p #{CDO.dashboard_port}"
+  # rails_server_args += " --ssl" if CDO.rack_env == :development && CDO.https_development
 
   Dir.chdir(dashboard_dir) do
-    system "RAILS_ENV=#{CDO.rack_env} bundle exec #{rerun} thin start #{thin_args}"
+    system "RAILS_ENV=#{CDO.rack_env} bundle exec #{rerun} rails server #{rails_server_args}"
   end
 
   pids.each do |pid|
@@ -35,5 +32,4 @@ def main
     Process.wait(pid)
   end
 end
-
 main


### PR DESCRIPTION
When launching a web server for local development, we use `bin/dashboard-server`. We are switching that from [thin](https://github.com/macournoyer/thin) to running `rails server`, which in turn runs [puma](https://github.com/puma/puma).

Reasons we're switching to puma:
1. Thin is relatively unused and only lightly maintained
2. Thin doesn't support websockets
3. Puma is the rails default for a web server
4. We already use puma on adhocs and our "real servers", so this makes dev slightly more like prod.

Co-authored-by: Seth Nickell <snickell@gmail.com>