### PR TITLE
CMS-951: Fix cache-disabling tests for `HocLegacy::TutorialsController`

### DIFF
--- a/dashboard/engines/hoc_legacy/test/controllers/hoc_legacy/tutorials_controller_test.rb
+++ b/dashboard/engines/hoc_legacy/test/controllers/hoc_legacy/tutorials_controller_test.rb
@@ -36,7 +36,7 @@ class HocLegacy::TutorialsControllerTest < ActionDispatch::IntegrationTest
 
     it 'disables caching' do
       begin_tutorial_request
-      _(response.headers['Cache-Control']).must_equal 'must-revalidate, private, max-age=0'
+      must_disable_caching
     end
 
     it 'redirects to tutorial URL' do
@@ -106,7 +106,7 @@ class HocLegacy::TutorialsControllerTest < ActionDispatch::IntegrationTest
 
       it 'disables caching' do
         begin_tutorial_request
-        _(response.headers['Cache-Control']).must_equal 'must-revalidate, private, max-age=0'
+        must_disable_caching
       end
 
       it 'redirects to tutorial URL' do
@@ -147,7 +147,7 @@ class HocLegacy::TutorialsControllerTest < ActionDispatch::IntegrationTest
 
     it 'disables caching' do
       begin_tutorial_pixel_request
-      _(response.headers['Cache-Control']).must_equal 'must-revalidate, private, max-age=0'
+      must_disable_caching
     end
 
     context 'when no tutorial is found' do
@@ -182,7 +182,7 @@ class HocLegacy::TutorialsControllerTest < ActionDispatch::IntegrationTest
 
       it 'disables caching' do
         begin_tutorial_pixel_request
-        _(response.headers['Cache-Control']).must_equal 'must-revalidate, private, max-age=0'
+        must_disable_caching
       end
     end
   end
@@ -212,7 +212,7 @@ class HocLegacy::TutorialsControllerTest < ActionDispatch::IntegrationTest
 
     it 'disables caching' do
       finish_current_tutorial_request
-      _(response.headers['Cache-Control']).must_equal 'must-revalidate, private, max-age=0'
+      must_disable_caching
     end
 
     context 'when no tutorial is launched' do
@@ -246,7 +246,7 @@ class HocLegacy::TutorialsControllerTest < ActionDispatch::IntegrationTest
 
       it 'disables caching' do
         finish_current_tutorial_request
-        _(response.headers['Cache-Control']).must_equal 'must-revalidate, private, max-age=0'
+        must_disable_caching
       end
     end
   end
@@ -285,7 +285,7 @@ class HocLegacy::TutorialsControllerTest < ActionDispatch::IntegrationTest
 
     it 'disables caching' do
       finish_tutorial_request
-      _(response.headers['Cache-Control']).must_equal 'must-revalidate, private, max-age=0'
+      must_disable_caching
     end
 
     context 'when no tutorial is launched' do
@@ -331,7 +331,7 @@ class HocLegacy::TutorialsControllerTest < ActionDispatch::IntegrationTest
 
       it 'disables caching' do
         finish_tutorial_request
-        _(response.headers['Cache-Control']).must_equal 'must-revalidate, private, max-age=0'
+        must_disable_caching
       end
     end
   end
@@ -366,7 +366,7 @@ class HocLegacy::TutorialsControllerTest < ActionDispatch::IntegrationTest
 
     it 'disables caching' do
       finish_tutorial_pixel_request
-      _(response.headers['Cache-Control']).must_equal 'must-revalidate, private, max-age=0'
+      must_disable_caching
     end
 
     context 'when no tutorial is found' do
@@ -401,7 +401,7 @@ class HocLegacy::TutorialsControllerTest < ActionDispatch::IntegrationTest
 
       it 'disables caching' do
         finish_tutorial_pixel_request
-        _(response.headers['Cache-Control']).must_equal 'must-revalidate, private, max-age=0'
+        must_disable_caching
       end
     end
   end
@@ -548,5 +548,12 @@ class HocLegacy::TutorialsControllerTest < ActionDispatch::IntegrationTest
         end
       end
     end
+  end
+
+  private def must_disable_caching
+    cache_control = response.headers['Cache-Control']
+    _(cache_control).must_include 'max-age=0'
+    _(cache_control).must_include 'must-revalidate'
+    _(cache_control).must_include 'private'
   end
 end


### PR DESCRIPTION
## Issue
```bash
=[0m[1000D[K FAIL["test_0002_disables caching", "HocLegacy::TutorialsControllerTest::GET /api/hour/begin/:code", 0.30844834353774786]
 test_0002_disables caching#HocLegacy::TutorialsControllerTest::GET /api/hour/begin/:code (0.31s)
        --- expected
        +++ actual
        @@ -1 +1 @@
        -"must-revalidate, private, max-age=0"
        +"max-age=0, private, must-revalidate"
        test/testing/setup_all_and_teardown_all.rb:36:in `run'
```

## Links
- JIRA task: [CMS-951](https://codedotorg.atlassian.net/browse/CMS-951)
- Plan: [Hour of Code/AI Event Tracking without Pegasus](https://docs.google.com/document/d/1gM_RB28D4wPimw-Rguyh4jvbJvXHHmqthjYDtKSrTtw/edit) 
- Related PR: https://github.com/code-dot-org/code-dot-org/pull/67655