### PR TITLE
CMS-951: Fix cdo_contentful.gemspec

### DIFF
--- a/dashboard/engines/cdo_contentful/cdo_contentful.gemspec
+++ b/dashboard/engines/cdo_contentful/cdo_contentful.gemspec
@@ -11,11 +11,15 @@ Gem::Specification.new do |spec|
 
   spec.metadata['rubygems_mfa_required'] = 'true'
 
+  spec.required_ruby_version = '>= 3.1'
+
   spec.add_dependency 'contentful', '~> 2.18'
   spec.add_dependency 'rails', '~> 6.1.7'
   spec.add_dependency 'zeitwerk', '~> 2.6.7'
 
+  # rubocop:disable Gemspec/DevelopmentDependencies
   spec.add_development_dependency 'minitest', '~> 5.15'
   spec.add_development_dependency 'vcr', '~> 6.2.0'
   spec.add_development_dependency 'webmock', '~> 3.8'
+  # rubocop:enable Gemspec/DevelopmentDependencies
 end


### PR DESCRIPTION
## Issue
```bash
Offenses:

dashboard/engines/cdo_contentful/cdo_contentful.gemspec:18:3: C: Gemspec/DevelopmentDependencies: Specify development dependencies in Gemfile.
  spec.add_development_dependency 'minitest', '~> 5.15'
  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
dashboard/engines/cdo_contentful/cdo_contentful.gemspec:19:3: C: Gemspec/DevelopmentDependencies: Specify development dependencies in Gemfile.
  spec.add_development_dependency 'vcr', '~> 6.2.0'
  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
dashboard/engines/cdo_contentful/cdo_contentful.gemspec:20:3: C: Gemspec/DevelopmentDependencies: Specify development dependencies in Gemfile.
  spec.add_development_dependency 'webmock', '~> 3.8'
  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```

## Links
- JIRA task: [CMS-951](https://codedotorg.atlassian.net/browse/CMS-951)
- Plan: [Hour of Code/AI Event Tracking without Pegasus](https://docs.google.com/document/d/1gM_RB28D4wPimw-Rguyh4jvbJvXHHmqthjYDtKSrTtw/edit) 
- Related PR: https://github.com/code-dot-org/code-dot-org/pull/67655