### PR TITLE
feat(image): use next/image for hero

### DIFF
--- a/frontend/apps/marketing/next.config.ts
+++ b/frontend/apps/marketing/next.config.ts
@@ -17,6 +17,15 @@ const nextConfig: NextConfig = {
     '@contentful/experiences-core',
     'lodash-es',
   ],
+  images: {
+    remotePatterns: [
+      {
+        protocol: 'https',
+        hostname: 'contentful-images.code.org',
+      },
+    ],
+    formats: ['image/avif', 'image/webp'],
+  },
 };
 
 export default nextConfig;

--- a/frontend/apps/marketing/src/components/contentful/heroBanner/HeroBanner.tsx
+++ b/frontend/apps/marketing/src/components/contentful/heroBanner/HeroBanner.tsx
@@ -5,6 +5,7 @@ import {Theme} from '@code-dot-org/component-library/common/contexts';
 
 import {externalLinkIconProps} from '@/components/common/constants';
 import Video from '@/components/contentful/video';
+import NextImage from '@/components/nextImage/NextImage';
 import {getAbsoluteImageUrl} from '@/selectors/contentful/getImage';
 import {LinkEntry} from '@/types/contentful/entries/Link';
 import {ExperienceAsset} from '@/types/contentful/ExperienceAsset';
@@ -157,6 +158,7 @@ const HeroBanner: React.FunctionComponent<HeroBannerProps> = ({
           : undefined
       }
       VideoComponent={Video}
+      ImageComponent={NextImage}
     />
   );
 };

--- a/frontend/apps/marketing/src/components/contentful/image/__tests__/Image.test.tsx
+++ b/frontend/apps/marketing/src/components/contentful/image/__tests__/Image.test.tsx
@@ -2,6 +2,11 @@ import {render, screen} from '@testing-library/react';
 
 import Image from '../Image';
 
+jest.mock('@/selectors/contentful/getImage', () => ({
+  getAbsoluteImageUrl: (src: string) =>
+    src ? `https://cdn.example.com/${src}` : undefined,
+}));
+
 describe('Image Component', () => {
   it('renders Image component', () => {
     render(<Image src="test.jpg" altText={'This is an image'} />);

--- a/frontend/apps/marketing/src/components/nextImage/NextImage.tsx
+++ b/frontend/apps/marketing/src/components/nextImage/NextImage.tsx
@@ -1,0 +1,12 @@
+import BaseNextImage, {ImageProps} from 'next/image';
+
+const NextImage = (props: ImageProps) => {
+  const baseImageProps: ImageProps = {
+    ...props,
+    fill: props?.fill ? props.fill : true, // Fill by default to make responsive and avoid absolute width/height
+  };
+
+  return <BaseNextImage {...baseImageProps} />;
+};
+
+export default NextImage;

--- a/frontend/apps/marketing/src/components/nextImage/NextImage.tsx
+++ b/frontend/apps/marketing/src/components/nextImage/NextImage.tsx
@@ -1,12 +1,7 @@
 import BaseNextImage, {ImageProps} from 'next/image';
 
-const NextImage = (props: ImageProps) => {
-  const baseImageProps: ImageProps = {
-    ...props,
-    fill: props?.fill ? props.fill : true, // Fill by default to make responsive and avoid absolute width/height
-  };
-
-  return <BaseNextImage {...baseImageProps} />;
+const NextImage = ({fill = true, ...props}: ImageProps) => {
+  return <BaseNextImage fill={fill} {...props} />;
 };
 
 export default NextImage;

--- a/frontend/packages/component-library-styles/cms/cmsMixins.scss
+++ b/frontend/packages/component-library-styles/cms/cmsMixins.scss
@@ -13,7 +13,6 @@
 
   figure {
     max-width: 10rem;
-    width: auto;
     height: 2rem;
     display: flex;
 

--- a/frontend/packages/component-library/src/cms/heroBanner/HeroBanner.tsx
+++ b/frontend/packages/component-library/src/cms/heroBanner/HeroBanner.tsx
@@ -135,7 +135,7 @@ const HeroBanner: React.FC<HeroBannerProps> = ({
                 {partner.title}
                 <Image
                   {...partner.logo}
-                  imageComponent={ImageComponent}
+                  ImageComponent={ImageComponent}
                   hasRoundedCorners={false}
                 />
               </span>
@@ -152,7 +152,7 @@ const HeroBanner: React.FC<HeroBannerProps> = ({
             {imageProps && !videoProps && (
               <Image
                 {...imageProps}
-                imageComponent={ImageComponent}
+                ImageComponent={ImageComponent}
                 className={classNames(
                   imageProps.className,
                   moduleStyles.heroBannerMediaImage,

--- a/frontend/packages/component-library/src/cms/heroBanner/HeroBanner.tsx
+++ b/frontend/packages/component-library/src/cms/heroBanner/HeroBanner.tsx
@@ -1,5 +1,5 @@
 import classNames from 'classnames';
-import {ReactNode, HTMLAttributes} from 'react';
+import {ReactNode, HTMLAttributes, JSX} from 'react';
 
 import Alert from '@/alert';
 import {LinkButton, LinkButtonProps} from '@/button';
@@ -36,6 +36,7 @@ export interface HeroBannerProps extends HTMLAttributes<HTMLElement> {
    * More context can be found in this slack thread: https://codedotorg.slack.com/archives/C07UW4ED66Q/p1744640489709969
    * */
   VideoComponent?: typeof Video;
+  ImageComponent?: JSX.ElementType;
   /** HeroBanner video */
   videoProps?: VideoProps;
   /** HeroBanner link */
@@ -81,6 +82,7 @@ const HeroBanner: React.FC<HeroBannerProps> = ({
   imageProps,
   hideImageOnSmallScreen = false,
   VideoComponent,
+  ImageComponent,
   videoProps,
   buttonProps,
   announcementBannerProps,
@@ -131,7 +133,11 @@ const HeroBanner: React.FC<HeroBannerProps> = ({
             {partner && (
               <span className={moduleStyles.heroBannerPartnerContainer}>
                 {partner.title}
-                <Image {...partner.logo} hasRoundedCorners={false} />
+                <Image
+                  {...partner.logo}
+                  imageComponent={ImageComponent}
+                  hasRoundedCorners={false}
+                />
               </span>
             )}
           </div>
@@ -146,6 +152,7 @@ const HeroBanner: React.FC<HeroBannerProps> = ({
             {imageProps && !videoProps && (
               <Image
                 {...imageProps}
+                imageComponent={ImageComponent}
                 className={classNames(
                   imageProps.className,
                   moduleStyles.heroBannerMediaImage,

--- a/frontend/packages/component-library/src/image/Image.tsx
+++ b/frontend/packages/component-library/src/image/Image.tsx
@@ -22,7 +22,7 @@ export interface ImageProps
   /** Image onError callback */
   onError?: () => void;
   /** Custom image component to replace the default <img> element */
-  imageComponent?: JSX.ElementType;
+  ImageComponent?: JSX.ElementType;
 }
 
 /**
@@ -48,11 +48,9 @@ const Image: React.FC<ImageProps> = ({
   className,
   onLoad,
   onError,
-  imageComponent,
+  ImageComponent = 'img',
   ...ImageHTMLAttributes
 }) => {
-  const ImageComponent = imageComponent ? imageComponent : 'img';
-
   return (
     <figure
       className={classNames(

--- a/frontend/packages/component-library/src/image/Image.tsx
+++ b/frontend/packages/component-library/src/image/Image.tsx
@@ -1,5 +1,5 @@
 import classNames from 'classnames';
-import {ImgHTMLAttributes} from 'react';
+import {ImgHTMLAttributes, JSX} from 'react';
 
 import moduleStyles from './image.module.scss';
 
@@ -21,6 +21,8 @@ export interface ImageProps
   onLoad?: () => void;
   /** Image onError callback */
   onError?: () => void;
+  /** Custom image component to replace the default <img> element */
+  imageComponent?: JSX.ElementType;
 }
 
 /**
@@ -46,31 +48,36 @@ const Image: React.FC<ImageProps> = ({
   className,
   onLoad,
   onError,
+  imageComponent,
   ...ImageHTMLAttributes
-}) => (
-  <figure
-    className={classNames(
-      moduleStyles.figureContainer,
-      {
-        [moduleStyles['figure-hasBorder']]: decoration === 'border',
-        [moduleStyles['figure-hasBoxShadow']]: decoration === 'shadow',
-        [moduleStyles['figure-hasRoundedCorners']]: hasRoundedCorners,
-      },
-      className,
-    )}
-    // Only use inline styles if there's no way to add custom className with needed styles.
-    style={style}
-  >
-    <img
-      className={classNames(moduleStyles.image)}
-      alt={altText}
-      loading={loading}
-      src={src}
-      onLoad={onLoad}
-      onError={onError}
-      {...ImageHTMLAttributes}
-    />
-  </figure>
-);
+}) => {
+  const ImageComponent = imageComponent ? imageComponent : 'img';
+
+  return (
+    <figure
+      className={classNames(
+        moduleStyles.figureContainer,
+        {
+          [moduleStyles['figure-hasBorder']]: decoration === 'border',
+          [moduleStyles['figure-hasBoxShadow']]: decoration === 'shadow',
+          [moduleStyles['figure-hasRoundedCorners']]: hasRoundedCorners,
+        },
+        className,
+      )}
+      // Only use inline styles if there's no way to add custom className with needed styles.
+      style={style}
+    >
+      <ImageComponent
+        className={classNames(moduleStyles.image)}
+        alt={altText}
+        loading={loading}
+        src={src}
+        onLoad={onLoad}
+        onError={onError}
+        {...ImageHTMLAttributes}
+      />
+    </figure>
+  );
+};
 
 export default Image;

--- a/frontend/packages/component-library/src/image/__tests__/Image.test.tsx
+++ b/frontend/packages/component-library/src/image/__tests__/Image.test.tsx
@@ -95,4 +95,17 @@ describe('Image Component', () => {
     const img = screen.getByRole('img');
     expect(img).toHaveAttribute('loading', 'eager');
   });
+
+  it('renders with a custom ImageComponent if provided', () => {
+    // Simulate a custom ImageComponent prop
+    const CustomImg = (props: React.ImgHTMLAttributes<HTMLImageElement>) => (
+      <img alt="abc" data-testid="custom-img" {...props} />
+    );
+
+    render(
+      <Image src="test.jpg" altText="Custom" ImageComponent={CustomImg} />,
+    );
+    // If ImageComponent is supported, this should pass
+    expect(screen.getByTestId('custom-img')).toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
This PR is a first of several to convert usages of <img> to [next/image](https://nextjs.org/docs/app/api-reference/components/image) to proxy and optimize images using Next.js rather than directly accessing images from Contentful to prevent high asset bandwidth consumption and to lessen the risk of images being blocked by firewalls.