### PR TITLE
Update TA floating action button to have circular pulse shadow rather than square

### DIFF
--- a/apps/src/aiDifferentiation/AiDiffFloatingActionButton.tsx
+++ b/apps/src/aiDifferentiation/AiDiffFloatingActionButton.tsx
@@ -10,8 +10,9 @@ import {
   trySetLocalStorage,
 } from '@cdo/apps/utils';
 import i18n from '@cdo/locale';
+import aiFabWithIconBase from '@cdo/static/ai-bot-ta-base.png';
 import aiFabWithoutText from '@cdo/static/ai-bot-ta-no-text.png';
-import aiFabWithIcon from '@cdo/static/ai-bot-ta.png';
+import aiFabWithIconTag from '@cdo/static/ai-bot-ta-tag-cyan.png';
 
 import {EVENTS, PLATFORMS} from '../metrics/AnalyticsConstants';
 import analyticsReporter from '../metrics/AnalyticsReporter';
@@ -206,11 +207,19 @@ const AiDiffFloatingActionButton: React.FC<AiDiffFloatingActionButtonProps> = ({
             />
           </Badge>
         ) : (
-          <img
-            alt="AI bot"
-            src={aiFabWithIcon}
-            onLoad={() => !isFabImageLoaded && setIsFabImageLoaded(true)}
-          />
+          <div>
+            <img
+              alt="AI bot"
+              src={aiFabWithIconBase}
+              onLoad={() => !isFabImageLoaded && setIsFabImageLoaded(true)}
+            />
+            <img
+              alt="AI bot TA tag"
+              src={aiFabWithIconTag}
+              className={style.floatingActionButtonTag}
+              onLoad={() => !isFabImageLoaded && setIsFabImageLoaded(true)}
+            />
+          </div>
         )}
       </button>
       <AiDiffContainer

--- a/apps/src/aiDifferentiation/AiDiffFloatingActionButton.tsx
+++ b/apps/src/aiDifferentiation/AiDiffFloatingActionButton.tsx
@@ -214,7 +214,7 @@ const AiDiffFloatingActionButton: React.FC<AiDiffFloatingActionButtonProps> = ({
               onLoad={() => !isFabImageLoaded && setIsFabImageLoaded(true)}
             />
             <img
-              alt="AI bot TA tag"
+              alt="TA tag"
               src={aiFabWithIconTag}
               className={style.floatingActionButtonTag}
               onLoad={() => !isFabImageLoaded && setIsFabImageLoaded(true)}

--- a/apps/src/aiDifferentiation/ai-differentiation.module.scss
+++ b/apps/src/aiDifferentiation/ai-differentiation.module.scss
@@ -9,11 +9,10 @@
   }
   70% {
     transform: scale(1);
-    box-shadow: 0 0 0 50px rgba(90 153 212 / 0);
+    filter: drop-shadow(0 0 20px rgb(90 153 212));
   }
   100% {
     transform: scale(0.9);
-    box-shadow: 0 0 0 0 rgba(90 153 212 / 0);
   }
 }
 

--- a/apps/src/aiDifferentiation/ai-differentiation.module.scss
+++ b/apps/src/aiDifferentiation/ai-differentiation.module.scss
@@ -9,19 +9,20 @@
   }
   70% {
     transform: scale(1);
-    filter: drop-shadow(0 0 20px rgb(90 153 212));
+    box-shadow: 0 0 0 50px rgba(90 153 212 / 0);
   }
   100% {
     transform: scale(0.9);
+    box-shadow: 0 0 0 0 rgba(90 153 212 / 0);
   }
 }
 
 $container-width: 512;
 $header-height: 40;
 $body-height: 612;
-$fab-left: 10;
-$fab-bottom: 33;
-$fab-height: 60;
+$fab-left: 11;
+$fab-bottom: 35;
+$fab-height: 48;
 
 :export {
   containerHeight: $header-height + $body-height;
@@ -271,15 +272,23 @@ $fab-height: 60;
   bottom: $fab-bottom * 1px;
 
   height: $fab-height * 1px;
-  width: 60px;
+  width: 48px;
   background-size: 60px;
   padding: 0;
   background-color: transparent;
 
   border-width: 0;
+  border-radius: 50%;
 
   img {
     opacity: 1;
+  }
+
+  .floatingActionButtonTag {
+    position: absolute;
+    width: 25px;
+    left: 33px;
+    top: -8px;
   }
 }
 

--- a/apps/static/ai-bot-ta-base.png
+++ b/apps/static/ai-bot-ta-base.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:29175df07762109a9d758f9493889a40ce0349570dd84c049d8efd268907f240
+size 4269

--- a/apps/static/ai-bot-ta-tag-cyan.png
+++ b/apps/static/ai-bot-ta-tag-cyan.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b62aaeb9c236f72b0eca909acfab99ea07981fd3656f858f33df6471573fd25b
+size 1211


### PR DESCRIPTION
Currently, to get the user's attention, the AI TA button has a pulse animation that appears as a square with what appears to be a white background within:
![square](https://github.com/user-attachments/assets/149200f7-0fb3-4a2a-9547-b5a0b4f4527c)

An initial quick fix of just adding a `border-radius` fixed the shape of the pulse animation but still left that white "background" (the background is actually invisible, but the box-shadow doesn't appear behind the invisible parts of a `.png` so it's just showing the white background of our site):
![circle](https://github.com/user-attachments/assets/3ecda428-e523-4983-a492-9d3f98369276)

I then tried a drop-shadow which could fill in the area behind the image but was harder to see:
![aligned faded](https://github.com/user-attachments/assets/77d82888-5fdf-4c8a-8e62-5663dc327c35)

So, the final solution to get the best of both worlds was Molly split up the AI TA image into its two parts (the base and the "TA" tag) and the pulse animation was centered on the base:
![with change](https://github.com/user-attachments/assets/b258e5e6-e96a-482d-ad56-5d827aa71c69)

## Links
Jira ticket: [here](https://codedotorg.atlassian.net/jira/software/projects/AITT/boards/70?jql=assignee%20%3D%2060d62161f65054006980bd71&selectedIssue=AITT-958)

## Testing story
Local testing.
