### PR TITLE
Instructions: adjust padding

### DIFF
--- a/apps/src/lab2/views/components/Instructions/instructions.module.scss
+++ b/apps/src/lab2/views/components/Instructions/instructions.module.scss
@@ -98,6 +98,7 @@
 .ttsContainer {
   display: flex;
   justify-content: flex-end;
+  padding-right: 12px;
 }
 
 .bubbleNoSlide {

--- a/apps/src/lab2/views/components/Instructions/instructions.module.scss
+++ b/apps/src/lab2/views/components/Instructions/instructions.module.scss
@@ -54,7 +54,7 @@
 
 .bubble {
   position: relative;
-  padding: 12px;
+  padding: 12px 0;
   border-radius: 4px;
   animation: slidein 0.5s;
   background-color: var(--background-neutral-secondary);
@@ -232,6 +232,7 @@
   flex: 1;
   overflow-y: auto;
   min-height: 70px;
+  padding: 0 12px;
 }
 
 .scrollingContent {


### PR DESCRIPTION
This applies a small styling adjustment from the original Lab2 Instructions component, used in Music Lab, to the second version used in other Lab2 labs, so that the scrollbar is further to the right, making use of space left available by existing padding.

Screenshots show the macOS Chrome scrollbar after it appears and has been hovered over.

### before

<img width="429" height="509" alt="Screenshot 2025-09-15 at 12 32 55 PM" src="https://github.com/user-attachments/assets/7d828370-25dc-447f-96be-d7a70c71cdf2" />

### after

<img width="429" height="509" alt="Screenshot 2025-09-15 at 12 34 49 PM" src="https://github.com/user-attachments/assets/4fb2f6f7-1306-4779-a387-0b38f80be0d1" />
