### PR TITLE
Tune puma for local dev mode

### DIFF
--- a/config/development.yml.erb
+++ b/config/development.yml.erb
@@ -3,6 +3,9 @@
 
 dashboard_enable_pegasus: true
 
+# In local dev, start Puma in single mode (no workers) rather than cluster mode:
+dashboard_workers: 0
+
 db_cluster_id: localhost
 db_endpoint_writer: localhost
 db_endpoint_writer_port: 3306

--- a/dashboard/config/puma.rb
+++ b/dashboard/config/puma.rb
@@ -7,18 +7,23 @@ if CDO.dashboard_sock
 else
   bind "tcp://#{CDO.dashboard_host}:#{CDO.dashboard_port}"
 end
+
 workers CDO.dashboard_workers
 threads 1, 5
 
-drain_on_shutdown
-
-# nginx already buffers/queues requests so disable Puma's own queue.
-queue_requests false
-
-pidfile "#{File.expand_path(__FILE__)}.pid"
-preload_app!
-stdout_redirect dashboard_dir('log', 'puma_stdout.log'), dashboard_dir('log', 'puma_stderr.log'), true
 directory deploy_dir('dashboard')
+
+unless CDO.rack_env == :development
+  drain_on_shutdown
+
+  # nginx already buffers/queues requests so disable Puma's own queue.
+  queue_requests false
+
+  pidfile "#{File.expand_path(__FILE__)}.pid"
+  preload_app!
+
+  stdout_redirect dashboard_dir('log', 'puma_stdout.log'), dashboard_dir('log', 'puma_stderr.log'), true
+end
 
 require 'cdo/app_server_hooks'
 before_fork do

--- a/dashboard/config/puma.rb
+++ b/dashboard/config/puma.rb
@@ -13,7 +13,7 @@ threads 1, 5
 
 directory deploy_dir('dashboard')
 
-unless CDO.rack_env == :development
+unless CDO.rack_env?(:development)
   drain_on_shutdown
 
   # nginx already buffers/queues requests so disable Puma's own queue.


### PR DESCRIPTION
Followup to https://github.com/code-dot-org/code-dot-org/pull/68286

We switched to Puma in #68286, but we didn't tune the settings very well for local development, because we already had puma.rb setup for a "real deployment" cluster mode.

This PR changes it so puma.rb is setup very similar in in RAILS_ENV=development to an out of the box rails apps's puma.rb:
1. Logs to stdout and stderr
2. Runs puma in single mode (no workers) rather than cluster mode
3. etc