### PR TITLE
Lab2 Dance: generate dance from music code

### DIFF
--- a/apps/src/blockly/types.ts
+++ b/apps/src/blockly/types.ts
@@ -50,6 +50,7 @@ export interface BlockConfig {
 export interface arg {
   customInput: string;
   name: string;
+  options?: [string, string][];
 }
 
 export interface SerializedFields {

--- a/apps/src/dance/blockly/buildDanceBlockly.ts
+++ b/apps/src/dance/blockly/buildDanceBlockly.ts
@@ -1,0 +1,202 @@
+// AI generated file.
+
+import {
+  BlockDefinition,
+  JsonBlockConfig,
+  WorkspaceSerialization,
+} from '@cdo/apps/blockly/types';
+
+import getBlockOptions from './getBlockOptions';
+
+const SET_BACKGROUND = 'Dancelab_setBackgroundEffectWithPaletteAI';
+const SET_FOREGROUND = 'Dancelab_setForegroundEffectExtended';
+const CHANGE_MOVE = 'Dancelab_changeMoveEachLR';
+
+function randomElement<T>(array: readonly T[]): T {
+  return array[Math.floor(Math.random() * array.length)];
+}
+
+function uidFactory(prefix: string): () => string {
+  let i = 0;
+  return () => `${prefix}_${++i}`;
+}
+
+function randomField(name: string, options: string[]): string {
+  return `<field name="${name}">${randomElement(options)}</field>`;
+}
+
+function groupSpritesField(): string {
+  return '<field name="GROUP">sprites</field>';
+}
+
+function dirLeftRightField(value: -1 | 1): string {
+  // -1 means both or "left/right" depending on block impl; matches your example
+  return `<field name="DIR">${value}</field>`;
+}
+
+function unitMeasuresField(): string {
+  return '<field name="UNIT">"measures"</field>';
+}
+
+function makeSetBackgroundBlock(
+  id: string,
+  effects: string[],
+  palettes: string[]
+): JsonBlockConfig {
+  return {
+    type: SET_BACKGROUND,
+    id,
+    fields: {
+      PALETTE: randomField('PALETTE', palettes),
+      EFFECT: randomField('EFFECT', effects),
+    },
+  };
+}
+
+function makeSetForegroundBlock(
+  id: string,
+  effects: string[]
+): JsonBlockConfig {
+  return {
+    type: SET_FOREGROUND,
+    id,
+    fields: {
+      EFFECT: randomField('EFFECT', effects),
+    },
+  };
+}
+
+function makeChangeMoveEachLRBlock(
+  id: string,
+  moves: string[]
+): JsonBlockConfig {
+  return {
+    type: CHANGE_MOVE,
+    id,
+    fields: {
+      GROUP: groupSpritesField(),
+      MOVE: randomField('MOVE', moves),
+      DIR: dirLeftRightField(randomElement([-1, 1])),
+    },
+  };
+}
+
+function chainBlocks(
+  head: JsonBlockConfig,
+  ...rest: JsonBlockConfig[]
+): JsonBlockConfig {
+  let current = head;
+  for (const b of rest) {
+    current.next = {block: b};
+    current = b;
+  }
+  return head;
+}
+
+/**
+ * Build Blockly JSON for a simple dance that reacts at given measures.
+ * - Creates a CAT sprite at center on setup
+ * - Starts background & foreground effects
+ * - At each measure, changes background/foreground and starts a new random move
+ */
+export default function buildDanceBlockly(
+  measures: number[],
+  blockDefinitions: BlockDefinition[]
+): WorkspaceSerialization {
+  const makeId = uidFactory('id');
+
+  const validMoves = getBlockOptions(
+    blockDefinitions,
+    CHANGE_MOVE,
+    'MOVE'
+  ).filter(option => !['"next"', '"prev"', '"rand"'].includes(option));
+
+  const validBackgrounds = getBlockOptions(
+    blockDefinitions,
+    SET_BACKGROUND,
+    'EFFECT'
+  ).filter(option => !['"none"', '"rand"'].includes(option));
+
+  const validForegrounds = getBlockOptions(
+    blockDefinitions,
+    SET_FOREGROUND,
+    'EFFECT'
+  ).filter(option => !['"none"', '"rand"'].includes(option));
+
+  const validPalettes = getBlockOptions(
+    blockDefinitions,
+    SET_BACKGROUND,
+    'PALETTE'
+  );
+
+  // Setup: create sprite → change move → start background → start foreground
+  const makeSprite: JsonBlockConfig = {
+    type: 'Dancelab_makeAnonymousDanceSprite',
+    id: makeId(),
+    fields: {
+      COSTUME: '<field name="COSTUME">"CAT"</field>',
+      LOCATION: '<field name="LOCATION">{x: 200, y: 200}</field>',
+    },
+  };
+
+  const initialChangeMove = makeChangeMoveEachLRBlock(makeId(), validMoves);
+  const initialBg = makeSetBackgroundBlock(
+    makeId(),
+    validBackgrounds,
+    validPalettes
+  );
+  const initialFg = makeSetForegroundBlock(makeId(), validForegrounds);
+
+  const setupDoChain = chainBlocks(
+    makeSprite,
+    initialChangeMove,
+    initialBg,
+    initialFg
+  );
+
+  const setupBlock: JsonBlockConfig = {
+    type: 'Dancelab_whenSetup',
+    id: 'setup',
+    x: 16,
+    y: 16,
+    deletable: false,
+    movable: false,
+    inputs: {
+      DO: {block: setupDoChain},
+    },
+  };
+
+  // Event blocks for each measure
+  const eventBlocks: JsonBlockConfig[] = measures.map(
+    (m, idx): JsonBlockConfig => {
+      const bg = makeSetBackgroundBlock(
+        makeId(),
+        validBackgrounds,
+        validPalettes
+      );
+      const fg = makeSetForegroundBlock(makeId(), validForegrounds);
+      const move = makeChangeMoveEachLRBlock(makeId(), validMoves);
+      const chain = chainBlocks(bg, fg, move);
+
+      return {
+        type: 'Dancelab_atTimestampNotAfter',
+        id: makeId(),
+        x: 24 + (idx % 2) * 6, // tiny stagger to avoid exact overlap
+        y: 200 + idx * 180, // vertical spacing between event stacks
+        fields: {
+          TIMESTAMP: m,
+          UNIT: unitMeasuresField(),
+        },
+        next: {block: chain},
+      };
+    }
+  );
+
+  const blocks: JsonBlockConfig[] = [setupBlock, ...eventBlocks];
+
+  return {
+    blocks: {
+      blocks,
+    },
+  };
+}

--- a/apps/src/dance/blockly/getBlockOptions.ts
+++ b/apps/src/dance/blockly/getBlockOptions.ts
@@ -1,0 +1,17 @@
+import {BlockDefinition} from '@cdo/apps/blockly/types';
+
+/**
+ * Returns the list of option keys for a given dropdown field in a block.
+ */
+export default function (
+  blocks: BlockDefinition[],
+  name: string,
+  field: string
+) {
+  return (
+    blocks
+      .find(block => block.name === name)
+      ?.config?.args?.find(arg => arg.name === field)
+      ?.options?.map(([_, key]) => key) || []
+  );
+}

--- a/apps/src/dance/lab2/views/DanceView.tsx
+++ b/apps/src/dance/lab2/views/DanceView.tsx
@@ -1,4 +1,5 @@
 import {Button} from '@code-dot-org/component-library/button';
+import {useTheme} from '@code-dot-org/component-library/common/contexts';
 import {BlocklyOptions, Events, WorkspaceSvg} from 'blockly/core';
 import classNames from 'classnames';
 import {isEqual} from 'lodash';
@@ -6,6 +7,8 @@ import React, {useCallback, useEffect, useMemo, useRef, useState} from 'react';
 
 import {loadBlocksToWorkspace} from '@cdo/apps/blockly/addons/cdoUtils';
 import {BLOCK_TYPES} from '@cdo/apps/blockly/constants';
+import cdoDark from '@cdo/apps/blockly/themes/cdoDark';
+import cdoTheme from '@cdo/apps/blockly/themes/cdoTheme';
 import {WorkspaceSerialization} from '@cdo/apps/blockly/types';
 import {
   applyBlockIdOverrides,
@@ -49,6 +52,7 @@ import {
 } from '@cdo/apps/lab2/projects/utils';
 import {isReadOnlyWorkspace} from '@cdo/apps/lab2/redux/lab2ReduxSelectors';
 import {BlocklySource, LabProps} from '@cdo/apps/lab2/types';
+import Guide from '@cdo/apps/lab2/views/components/guide/Guide';
 import ResourcePanel from '@cdo/apps/lab2/views/components/Instructions/ResourcePanel';
 import PanelContainer from '@cdo/apps/lab2/views/components/PanelContainer';
 import ProjectPlayer from '@cdo/apps/music/ProjectPlayer';
@@ -59,6 +63,7 @@ import {commonI18n} from '@cdo/apps/types/locale';
 import {useAppDispatch, useAppSelector} from '@cdo/apps/util/reduxHooks';
 import loadingGif from '@cdo/static/dance/DancePartyLoading.gif';
 
+import buildDanceBlockly from '../../blockly/buildDanceBlockly';
 import danceI18n from '../locale';
 import ProgramExecutor from '../ProgramExecutor';
 
@@ -74,8 +79,8 @@ const BLOCKLY_DIV_ID = 'dance-blockly-div';
 registerReducers(reducers);
 
 const isToolboxMode = getAppOptionsEditBlocks() === TOOLBOX_BLOCKS;
-const usingMusicProject =
-  queryParams('music-channel') || queryParams('ai-generate');
+const aiGenerateMode = queryParams('ai-generate') === 'true';
+const usingMusicProject = queryParams('music-channel') || aiGenerateMode;
 
 const mode =
   queryParams('ai-generate-dancer') === 'true' ? 'ai-generate-dancer' : false;
@@ -108,6 +113,14 @@ const DanceView: React.FunctionComponent<{
   const workspace = useRef<WorkspaceSvg | null>(null);
   const musicProjectPlayer = useRef<ProjectPlayer | null>(null);
   const [loadedMusicProject, setLoadedMusicProject] = useState(false);
+  const [generatedAiDance, setGeneratedAiDance] = useState(false);
+
+  const {setTheme} = useTheme();
+  useEffect(() => {
+    if (aiGenerateMode) {
+      setTheme('Dark');
+    }
+  }, [setTheme]);
 
   const metadataToUse: SongMetadata | undefined = useMemo(() => {
     if (!musicProjectPlayer.current || !loadedMusicProject) {
@@ -302,7 +315,8 @@ const DanceView: React.FunctionComponent<{
       : levelProperties.toolboxDefinition;
 
     workspace.current = Blockly.inject(blocklyDiv, {
-      toolbox,
+      toolbox: aiGenerateMode ? undefined : toolbox,
+      theme: aiGenerateMode ? cdoDark : cdoTheme,
       readOnly: readonlyWorkspace,
       editBlocks: getAppOptionsEditBlocks(),
     } as BlocklyOptions);
@@ -365,7 +379,7 @@ const DanceView: React.FunctionComponent<{
           // just pass a dummy string as we expect to find a music
           // project in local storage.
           (queryParams('music-channel') as string) || 'local-storage',
-          queryParams('ai-generate') === 'true'
+          aiGenerateMode
         )
         .then(() => setLoadedMusicProject(true));
     }
@@ -418,27 +432,58 @@ const DanceView: React.FunctionComponent<{
     readonlyWorkspace,
   ]);
 
+  const generateAiDance = useCallback(() => {
+    if (
+      !usingMusicProject ||
+      !musicProjectPlayer.current ||
+      !loadedMusicProject
+    ) {
+      return;
+    }
+
+    setGeneratedAiDance(false);
+    const resultBlockly = buildDanceBlockly(
+      musicProjectPlayer.current.getEventMeasures(),
+      levelProperties.sharedBlocks || []
+    );
+    updateSources({
+      ...currentSources,
+      source: resultBlockly,
+    });
+    setGeneratedAiDance(true);
+  }, [
+    currentSources,
+    updateSources,
+    loadedMusicProject,
+    levelProperties.sharedBlocks,
+  ]);
+
   const settings = useBlocklySettings();
 
   return (
     <div id="dance-lab" className={moduleStyles.danceLab}>
       {!getIsShareView() && <AgeDialog turnOffFilter={turnOffFilter} />}
-      <ResourcePanel
-        isRunning={isRunning}
-        hasRun={hasRun}
-        hasEdited={hasEdited}
-        levelProperties={levelProperties}
-        headerClassName={moduleStyles.panelHeader}
-        className={moduleStyles.instructionsArea}
-        settings={settings}
-      />
+      {!aiGenerateMode && (
+        <ResourcePanel
+          isRunning={isRunning}
+          hasRun={hasRun}
+          hasEdited={hasEdited}
+          levelProperties={levelProperties}
+          headerClassName={moduleStyles.panelHeader}
+          className={moduleStyles.instructionsArea}
+          settings={settings}
+        />
+      )}
       <div className={moduleStyles.divider} />
       {!isToolboxMode && (
         <PanelContainer
           id="visualization"
           headerContent="Dance Party!"
           headerClassName={moduleStyles.panelHeader}
-          className={moduleStyles.visualizationArea}
+          className={classNames(
+            moduleStyles.visualizationArea,
+            aiGenerateMode && moduleStyles.jumbo
+          )}
         >
           <div className={moduleStyles.visualizationColumn}>
             {!usingMusicProject && currentSources.selectedSong && (
@@ -506,6 +551,28 @@ const DanceView: React.FunctionComponent<{
         {WorkspaceAlert}
         <div id={BLOCKLY_DIV_ID} />
       </PanelContainer>
+      {aiGenerateMode && (
+        <Guide id="generate-panel">
+          {
+            <>
+              <div>
+                {generatedAiDance
+                  ? "Let's dance!"
+                  : "Now, let's generate a dance sequence to go with your song!"}
+              </div>
+              <Button
+                ariaLabel={'Generate dance'}
+                text={generatedAiDance ? 'Generate again!' : 'Generate dance'}
+                type="primary"
+                color="purple"
+                size="s"
+                iconLeft={{iconName: 'sparkles'}}
+                onClick={generateAiDance}
+              />
+            </>
+          }
+        </Guide>
+      )}
     </div>
   );
 };

--- a/apps/src/dance/lab2/views/dance-view.module.scss
+++ b/apps/src/dance/lab2/views/dance-view.module.scss
@@ -10,9 +10,7 @@
 }
 
 .visualization {
-  // TODO: support resizing
-  width: 400px;
-  height: 400px;
+  width: 100%;
   background-color: var(--background-neutral-secondary);
   position: relative;
   border: 1px solid var(--borders-neutral-primary);
@@ -32,6 +30,16 @@
 .visualizationArea {
   flex: 0;
   background-color: var(--background-neutral-primary);
+  
+  &.jumbo {
+    flex: initial;
+    width: min(50vw, calc(100vh - 240px));
+    
+    canvas {
+      width: 100% !important;
+      height: 100% !important;
+    }
+  }
 }
 
 .workspaceArea {


### PR DESCRIPTION
Adapting the rest of https://github.com/code-dot-org/code-dot-org/pull/68188: Generates a Dance Party dance from music code. The generation algorithm uses the "event measures" from the music project (where a significant number of sounds change) to add a new background, foreground, and dance move change at each point. We can definitely tweak/enhance this generation algorithm to add more dancers, moves etc, as needed.

<img width="1512" height="828" alt="Screenshot 2025-09-15 at 10 33 34 AM" src="https://github.com/user-attachments/assets/0e226a30-82fd-48eb-81d6-fd0c4a2945a6" />


## Testing story
Tested locally with Dance Lab2 (using `ai-generate=true`)

