### PR TITLE
CMS-951: Fix VCR cassette gem configs

### DIFF
--- a/dashboard/test/testing/vcr_cassettes.rb
+++ b/dashboard/test/testing/vcr_cassettes.rb
@@ -4,4 +4,5 @@ VCR.configure do |config|
   config.cassette_library_dir = File.expand_path('../fixtures/vcr_cassettes', __dir__)
   config.hook_into :webmock
   config.default_cassette_options = {record: :once}
+  config.allow_http_connections_when_no_cassette = true
 end


### PR DESCRIPTION
## Issue
```bash
ERROR["test_0001_is valid", "User::FacilitatorInfoTest::validations", 1.2070890001486987]
 test_0001_is valid#User::FacilitatorInfoTest::validations (1.21s)
Minitest::UnexpectedError:         RuntimeError: Neutered Exception VCR::Errors::UnhandledHTTPRequestError: 
        
        ================================================================================
        An HTTP request has been made that VCR does not know how to handle:
          POST http://api1.webpurify.com/services/rest
        
        There is currently no cassette in use. There are a few ways
        you can configure VCR to handle this request:
        
          * If you're surprised VCR is raising this error
            and want insight about how VCR attempted to handle the request,
            you can use the debug_logger configuration option to log more details [1].
          * If you want VCR to record this request and play it back during future test
            runs, you should wrap your test (or this portion of your test) in a
            `VCR.use_cassette` block [2].
          * If you only want VCR to handle requests made while a cassette is in use,
            configure `allow_http_connections_when_no_cassette = true`. VCR will
            ignore this request since it is made when there is no cassette [3].
          * If you want VCR to ignore this request (and others like it), you can
            set an `ignore_request` callback [4].
        
        [1] https://www.relishapp.com/vcr/vcr/v/6-2-0/docs/configuration/debug-logging
        [2] https://www.relishapp.com/vcr/vcr/v/6-2-0/docs/getting-started
        [3] https://www.relishapp.com/vcr/vcr/v/6-2-0/docs/configuration/allow-http-connections-when-no-cassette
        [4] https://www.relishapp.com/vcr/vcr/v/6-2-0/docs/configuration/ignore-request
        ================================================================================
        
        
            app/models/user/facilitator_info.rb:35:in `bio_has_no_profanity'
            test/models/user/facilitator_info_test.rb:17:in `block (2 levels) in <class:FacilitatorInfoTest>'
            test/testing/setup_all_and_teardown_all.rb:36:in `run'
```

## Links
- JIRA task: [CMS-951](https://codedotorg.atlassian.net/browse/CMS-951)
- Related PR: https://github.com/code-dot-org/code-dot-org/pull/67655