### PR TITLE
Lab2 Dance: enable project saving by default

### DIFF
--- a/dashboard/app/models/levels/level.rb
+++ b/dashboard/app/models/levels/level.rb
@@ -398,7 +398,7 @@ class Level < ApplicationRecord
   def channel_backed?
     return false if try(:is_project_level)
     free_response_upload = is_a?(FreeResponse) && allow_user_uploads
-    dance_party_free_play = is_a?(Dancelab) && try(:free_play?)
+    dance_party_free_play = is_a?(Dancelab) && (try(:free_play?) || try(:uses_lab2?))
     project_template_level || free_response_upload || game.channel_backed? || dance_party_free_play
   end
 


### PR DESCRIPTION
Enable channel-backed project loading/saving on Lab2 dance levels by default, replacing the older system of saving blocks XML to the database directly.

## Testing story
- Tested locally; confirmed that a channel ID gets created for non freeplay Dance Lab2 levels.