### PR TITLE
CMS-65: Fix flaky `User::FacilitatorInfoTest`

### DIFF
--- a/dashboard/test/models/user/facilitator_info_test.rb
+++ b/dashboard/test/models/user/facilitator_info_test.rb
@@ -5,13 +5,13 @@ class User::FacilitatorInfoTest < ActiveSupport::TestCase
     subject(:user_facilitator_info) {build(:user_facilitator_info, user: user, bio: bio)}
 
     let(:user) {create(:facilitator)}
-    let(:bio) do
-      Faker::Lorem.
-        paragraph(sentence_count: User::FacilitatorInfo::BIO_MIN_LENGTH).
-        truncate(User::FacilitatorInfo::BIO_MAX_LENGTH)
-    end
+    let(:bio) {Faker::Lorem.paragraph_by_chars(number: User::FacilitatorInfo::BIO_MAX_LENGTH)}
 
     let(:error_messages) {user_facilitator_info.errors.full_messages}
+
+    before do
+      ProfanityFilter.stubs(:find_potential_profanity)
+    end
 
     it 'is valid' do
       _user_facilitator_info.must_be :valid?
@@ -41,7 +41,7 @@ class User::FacilitatorInfoTest < ActiveSupport::TestCase
     end
 
     context 'when bio is too long' do
-      let(:bio) {Faker::Lorem.paragraph(sentence_count: User::FacilitatorInfo::BIO_MAX_LENGTH.next)}
+      let(:bio) {Faker::Lorem.paragraph_by_chars(number: User::FacilitatorInfo::BIO_MAX_LENGTH.next)}
 
       it 'contains bio too long error' do
         _user_facilitator_info.wont_be :valid?


### PR DESCRIPTION
Fixes the flaky validation test caused by the profanity check

## Issue
```bash
 FAIL["test_0001_is valid", "User::FacilitatorInfoTest::validations", 3.023964999942109]
 test_0001_is valid#User::FacilitatorInfoTest::validations (3.02s)
        Expected #<User::FacilitatorInfo id: nil, user_id: 222, bio: "Iure necessitatibus repellendus. Animi consectetur...", created_at: nil, updated_at: nil> to be valid?.
        test/models/user/facilitator_info_test.rb:22:in `block (3 levels) in <class:FacilitatorInfoTest>'
        test/models/user/facilitator_info_test.rb:13:in `times'
        test/models/user/facilitator_info_test.rb:13:in `block (2 levels) in <class:FacilitatorInfoTest>'
        test/testing/setup_all_and_teardown_all.rb:36:in `run'
```

## Links
- JIRA task: [CMS-65](https://codedotorg.atlassian.net/browse/CMS-65)
- Related PR: https://github.com/code-dot-org/code-dot-org/pull/67039