### PR TITLE
fix: conditionally show the link to legacy survey results or the outlet with the new results

### DIFF
--- a/apps/src/code-studio/pd/workshop_dashboard/workshops/WorkshopLayout.tsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/workshops/WorkshopLayout.tsx
@@ -224,12 +224,7 @@ export const WorkshopLayout: FC<WorkshopLayoutProps> = ({
           {showSurveyElements && (
             <SurveyTypeSelection surveyTypeOptions={surveyTypeOptions} />
           )}
-          {showLegacySurveyLinkButton && (
-            <LinkButton
-              href={`/pd/workshop_dashboard/workshop_daily_survey_results/${workshopId}`}
-              text="Survey results"
-            />
-          )}
+
           {showSurveyCategorySelection && (
             <>
               <div className={styles.divider} />
@@ -245,8 +240,17 @@ export const WorkshopLayout: FC<WorkshopLayoutProps> = ({
         )}
       </nav>
       <main>
-        {showNoSurveyResponses && <NoSurveyResponses />}
-        <Outlet />
+        {showLegacySurveyLinkButton ? (
+          <LinkButton
+            href={`/pd/workshop_dashboard/workshop_daily_survey_results/${workshopId}`}
+            text="Survey results"
+          />
+        ) : (
+          <>
+            {showNoSurveyResponses && <NoSurveyResponses />}
+            <Outlet />
+          </>
+        )}
       </main>
     </WorkshopContext.Provider>
   );


### PR DESCRIPTION
This pull request updates the rendering logic for the legacy survey link in the `WorkshopLayout` component. The main change moves the display of the "Survey results" link from the navigation section to the main content area, ensuring it appears in the correct context alongside other main content elements.

**UI layout adjustments:**

* Moved the rendering of the `LinkButton` for legacy survey results from the navigation section to the main content area, so it now appears as part of the main workshop content rather than in the navigation bar.
* Updated the conditional rendering logic to display either the legacy survey link or, if not shown, the `NoSurveyResponses` component and the main `Outlet` content.

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->



## Links
<!--  Links to relevant external resources.
      - spec docs, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- Jira: 

## Testing story
<!--  Does your change include appropriate tests?
      - If so, please describe how the tests included in this PR are sufficient.
      - If not, please explain why this change does not need to be tested. -->



## Deployment strategy
<!--  Any special steps required to deploy this, besides merging?
      - Are there database migrations or manual steps?
      - Does this require coordination with other teams or systems? -->



## Follow-up work
<!--  List any clean-up or technical debt that will be addressed in future work.
      - Include Jira links where applicable.
      - Are there any known limitations or improvements planned? -->



## Privacy
<!--  How does this change impact Student & Teacher privacy?
      - Does this collect, use, share, or modify PII, either new or existing? -->



## Security
<!--  How does this change impact our security surface-area?
      - Do API's touched have the right auth?
      - Do infra changes impact our attack surface or encryption?
-->



## Caching
<!--  How does this change impact caching behavior?
      - Are cache keys or invalidation strategies affected?
      - Will this require cache warming or invalidation after deployment? -->



## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
