### PR TITLE
fix(coteachers): disable co-teacher input if LTI

### DIFF
--- a/apps/src/templates/sectionsRefresh/SectionsSetUpContainer.jsx
+++ b/apps/src/templates/sectionsRefresh/SectionsSetUpContainer.jsx
@@ -21,7 +21,10 @@ import Spinner from '@cdo/apps/sharedComponents/Spinner';
 import GlobalEditionWrapper from '@cdo/apps/templates/GlobalEditionWrapper';
 import CoteacherSettings from '@cdo/apps/templates/sectionsRefresh/coteacherSettings/CoteacherSettings';
 import {navigateToHref} from '@cdo/apps/utils';
-import {CapLinks} from '@cdo/generated-scripts/sharedConstants';
+import {
+  CapLinks,
+  SectionLoginType,
+} from '@cdo/generated-scripts/sharedConstants';
 import i18n from '@cdo/locale';
 
 import AdvancedSettingToggles from './AdvancedSettingToggles';
@@ -398,7 +401,7 @@ export default function SectionsSetUpContainer({
   const renderCoteacherSection = () => {
     const isCoTeacherManagementDisabled =
       sections[0].primaryInstructor?.ltiRosterSyncEnabled === true &&
-      sections[0].loginType === 'ltiV1';
+      sections[0].loginType === SectionLoginType.lti_v1;
 
     return renderExpandableSection(
       'uitest-expandable-coteacher',


### PR DESCRIPTION
At some point, the API response for section login type changed from camel to snake case. This PR fixes the issue by using the shared constant which is in snake case.

# Before

<img width="949" height="367" alt="Screenshot From 2025-09-15 16-04-08" src="https://github.com/user-attachments/assets/290e5d48-720e-4698-869f-f08c7486a6d8" />


# After

<img width="949" height="367" alt="Screenshot From 2025-09-15 16-00-49" src="https://github.com/user-attachments/assets/11a58525-36e9-4389-93d8-501ebd943fbb" />
