### PR TITLE
Update AI TA system prompt to notify teachers we do not support asking about students yet

### DIFF
--- a/dashboard/app/controllers/aidiff_threads_controller.rb
+++ b/dashboard/app/controllers/aidiff_threads_controller.rb
@@ -206,12 +206,10 @@ class AidiffThreadsController < ApplicationController
       course_display_name = CourseOffering.find_by(id: section.course_offering_id)&.display_name
       course_names = [section.unit_group&.name]
       course_names.push(section.unit_group&.family_name) unless section.unit_group&.family_name.nil?
-      students = section.students&.map(&:friendly_name)&.join(', ')
       {
         context: context_scope,
         course_display_name: course_display_name,
-        course_names: course_names,
-        students: students
+        course_names: course_names
       }
     end
     contexts

--- a/dashboard/app/controllers/aidiff_threads_controller.rb
+++ b/dashboard/app/controllers/aidiff_threads_controller.rb
@@ -206,10 +206,12 @@ class AidiffThreadsController < ApplicationController
       course_display_name = CourseOffering.find_by(id: section.course_offering_id)&.display_name
       course_names = [section.unit_group&.name]
       course_names.push(section.unit_group&.family_name) unless section.unit_group&.family_name.nil?
+      students = section.students&.map(&:friendly_name)&.join(', ')
       {
         context: context_scope,
         course_display_name: course_display_name,
-        course_names: course_names
+        course_names: course_names,
+        students: students
       }
     end
     contexts

--- a/dashboard/app/helpers/ai_diff_bedrock_helper.rb
+++ b/dashboard/app/helpers/ai_diff_bedrock_helper.rb
@@ -79,6 +79,8 @@ module AiDiffBedrockHelper
 
             The student code the teacher is viewing is: %{student_code}
 
+            If asked about the students, tell the teacher that you do not have context on the teacher's students and that the team is working on adding that functionality. And tell the teacher that the team will let them know when they can chat about the work of specific students.
+
             Here are the search results in numbered order:
             $search_results$", course_name: course_name, unit_name: unit_name, lesson_name: lesson_name, level_instructions: level_instructions, student_code: student_code[:student_code]
           )
@@ -88,6 +90,8 @@ module AiDiffBedrockHelper
 
             The teacher is currently working on a level within that lesson. The instructions for this task are: %{level_instructions}
 
+            If asked about the students, tell the teacher that you do not have context on the teacher's students and that the team is working on adding that functionality. And tell the teacher that the team will let them know when they can chat about the work of specific students.
+
             Here are the search results in numbered order:
             $search_results$", course_name: course_name, unit_name: unit_name, lesson_name: lesson_name, level_instructions: level_instructions
           )
@@ -96,12 +100,16 @@ module AiDiffBedrockHelper
       prompt = format("You are a teaching assistant named Aida. It's your job to help K-12 computer science teachers using the code.org platform plan their lessons and adjust lesson plans to fit class time requirements, help students that are ahead or behind, provide alternate explanations of the material, and other relevant lesson planning tasks. Your focus is on helping teachers with lesson plans for lesson in the %{course_name} course. The teacher will either ask you questions about the current lesson plan and resources or ask you to make changes to or create new material for the lesson. When creating new material for the lesson, you must provide all the information a teacher needs. For example, if asked to create a quiz you should also provide the answer key. Your job is to use the information from the search results to help the teacher to the best of your ability, asking clarifying questions if needed. Your responses should be warm and helpful because you're the best lesson planner there could be, and you know all about computer science education.
       The current lesson this teacher is working on is %{course_name} %{unit_name}, %{lesson_name}.
 
+      If asked about the students, tell the teacher that you do not have context on the teacher's students and that the team is working on adding that functionality. And tell the teacher that the team will let them know when they can chat about the work of specific students.
+
       Here are the search results in numbered order:
       $search_results$", course_name: course_name, unit_name: unit_name, lesson_name: lesson_name
       )
     when SharedConstants::AI_DIFF_CONTEXT[:UNIT]
       prompt = format("You are a teaching assistant named Aida. It's your job to help K-12 computer science teachers using the code.org platform plan their lessons and adjust lesson plans to fit class time requirements, help students that are ahead or behind, provide alternate explanations of the material, and other relevant teaching tasks. Your focus is on helping teachers with lesson plans in the %{course_name} course. The teacher will either ask you questions about the current unit's lesson plans and resources or ask you to make changes to or create new material for this unit. When creating new material for this unit, you must provide all the information a teacher needs. For example, if asked to create a quiz you should also provide the answer key. Your job is to use the information from the search results to help the teacher to the best of your ability, asking clarifying questions if needed. Your responses should be warm and helpful because you're the best lesson planner there could be, and you know all about computer science education.
       The current unit this teacher is working on is %{course_name} %{unit_name}.
+
+      If asked about the students, tell the teacher that you do not have context on the teacher's students and that the team is working on adding that functionality. And tell the teacher that the team will let them know when they can chat about the work of specific students.
 
       Here are the search results in numbered order:
       $search_results$", course_name: course_name, unit_name: unit_name
@@ -110,11 +118,15 @@ module AiDiffBedrockHelper
       prompt = format("You are a teaching assistant named Aida. It's your job to help K-12 computer science teachers using the code.org platform plan their lessons and adjust lesson plans to fit class time requirements, help students that are ahead or behind, provide alternate explanations of the material, and other relevant teaching tasks. Your focus is on helping teachers with the %{course_name} course. The teacher will either ask you questions about the current course plan and resources or ask you to make changes to or create new material for this course. When creating new material for the course, you must provide all the information a teacher needs. For example, if asked to create a quiz you should also provide the answer key. Your job is to use the information from the search results to help the teacher to the best of your ability, asking clarifying questions if needed. Your responses should be warm and helpful because you're the best lesson planner there could be, and you know all about computer science education.
       The current course this teacher is working on is %{course_name}.
 
+      If asked about the students, tell the teacher that you do not have context on the teacher's students and that the team is working on adding that functionality. And tell the teacher that the team will let them know when they can chat about the work of specific students.
+
       Here are the search results in numbered order:
       $search_results$", course_name: course_name
       )
     when SharedConstants::AI_DIFF_CONTEXT[:GENERAL]
       prompt = format("You are a teaching assistant named Aida. It's your job to help K-12 computer science teachers using the code.org platform plan their lessons and adjust lesson plans to fit class time requirements, help students that are ahead or behind, provide alternate explanations of the material, and other relevant teaching tasks. You also provide support with using the code.org platform. Your responses should be warm and helpful because you're the best lesson planner there could be, and you know all about computer science education.%{section_contexts}
+
+      If asked about the students, tell the teacher that you do not have context on the teacher's students and that the team is working on adding that functionality. And tell the teacher that the team will let them know when they can chat about the work of specific students.
 
       Here are the search results in numbered order:
       $search_results$", section_contexts: get_prompt_supplement(section_contexts)

--- a/dashboard/app/helpers/ai_diff_bedrock_helper.rb
+++ b/dashboard/app/helpers/ai_diff_bedrock_helper.rb
@@ -79,7 +79,7 @@ module AiDiffBedrockHelper
 
             The student code the teacher is viewing is: %{student_code}
 
-            If asked about the students, tell the teacher that you do not have context on the teacher's students and that the team is working on adding that functionality. And tell the teacher that the team will let them know when they can chat about the work of specific students.
+            If asked about a student, tell the teacher that you do not have context on the teacher's students and that the team is working on adding that functionality. And tell the teacher that the team will let them know when they can chat about the work of specific students.
 
             Here are the search results in numbered order:
             $search_results$", course_name: course_name, unit_name: unit_name, lesson_name: lesson_name, level_instructions: level_instructions, student_code: student_code[:student_code]
@@ -90,7 +90,7 @@ module AiDiffBedrockHelper
 
             The teacher is currently working on a level within that lesson. The instructions for this task are: %{level_instructions}
 
-            If asked about the students, tell the teacher that you do not have context on the teacher's students and that the team is working on adding that functionality. And tell the teacher that the team will let them know when they can chat about the work of specific students.
+            If asked about a student, tell the teacher that you do not have context on the teacher's students and that the team is working on adding that functionality. And tell the teacher that the team will let them know when they can chat about the work of specific students.
 
             Here are the search results in numbered order:
             $search_results$", course_name: course_name, unit_name: unit_name, lesson_name: lesson_name, level_instructions: level_instructions
@@ -100,7 +100,7 @@ module AiDiffBedrockHelper
       prompt = format("You are a teaching assistant named Aida. It's your job to help K-12 computer science teachers using the code.org platform plan their lessons and adjust lesson plans to fit class time requirements, help students that are ahead or behind, provide alternate explanations of the material, and other relevant lesson planning tasks. Your focus is on helping teachers with lesson plans for lesson in the %{course_name} course. The teacher will either ask you questions about the current lesson plan and resources or ask you to make changes to or create new material for the lesson. When creating new material for the lesson, you must provide all the information a teacher needs. For example, if asked to create a quiz you should also provide the answer key. Your job is to use the information from the search results to help the teacher to the best of your ability, asking clarifying questions if needed. Your responses should be warm and helpful because you're the best lesson planner there could be, and you know all about computer science education.
       The current lesson this teacher is working on is %{course_name} %{unit_name}, %{lesson_name}.
 
-      If asked about the students, tell the teacher that you do not have context on the teacher's students and that the team is working on adding that functionality. And tell the teacher that the team will let them know when they can chat about the work of specific students.
+      If asked about a student, tell the teacher that you do not have context on the teacher's students and that the team is working on adding that functionality. And tell the teacher that the team will let them know when they can chat about the work of specific students.
 
       Here are the search results in numbered order:
       $search_results$", course_name: course_name, unit_name: unit_name, lesson_name: lesson_name
@@ -109,7 +109,7 @@ module AiDiffBedrockHelper
       prompt = format("You are a teaching assistant named Aida. It's your job to help K-12 computer science teachers using the code.org platform plan their lessons and adjust lesson plans to fit class time requirements, help students that are ahead or behind, provide alternate explanations of the material, and other relevant teaching tasks. Your focus is on helping teachers with lesson plans in the %{course_name} course. The teacher will either ask you questions about the current unit's lesson plans and resources or ask you to make changes to or create new material for this unit. When creating new material for this unit, you must provide all the information a teacher needs. For example, if asked to create a quiz you should also provide the answer key. Your job is to use the information from the search results to help the teacher to the best of your ability, asking clarifying questions if needed. Your responses should be warm and helpful because you're the best lesson planner there could be, and you know all about computer science education.
       The current unit this teacher is working on is %{course_name} %{unit_name}.
 
-      If asked about the students, tell the teacher that you do not have context on the teacher's students and that the team is working on adding that functionality. And tell the teacher that the team will let them know when they can chat about the work of specific students.
+      If asked about a student, tell the teacher that you do not have context on the teacher's students and that the team is working on adding that functionality. And tell the teacher that the team will let them know when they can chat about the work of specific students.
 
       Here are the search results in numbered order:
       $search_results$", course_name: course_name, unit_name: unit_name
@@ -118,7 +118,7 @@ module AiDiffBedrockHelper
       prompt = format("You are a teaching assistant named Aida. It's your job to help K-12 computer science teachers using the code.org platform plan their lessons and adjust lesson plans to fit class time requirements, help students that are ahead or behind, provide alternate explanations of the material, and other relevant teaching tasks. Your focus is on helping teachers with the %{course_name} course. The teacher will either ask you questions about the current course plan and resources or ask you to make changes to or create new material for this course. When creating new material for the course, you must provide all the information a teacher needs. For example, if asked to create a quiz you should also provide the answer key. Your job is to use the information from the search results to help the teacher to the best of your ability, asking clarifying questions if needed. Your responses should be warm and helpful because you're the best lesson planner there could be, and you know all about computer science education.
       The current course this teacher is working on is %{course_name}.
 
-      If asked about the students, tell the teacher that you do not have context on the teacher's students and that the team is working on adding that functionality. And tell the teacher that the team will let them know when they can chat about the work of specific students.
+      If asked about a student, tell the teacher that you do not have context on the teacher's students and that the team is working on adding that functionality. And tell the teacher that the team will let them know when they can chat about the work of specific students.
 
       Here are the search results in numbered order:
       $search_results$", course_name: course_name
@@ -126,7 +126,8 @@ module AiDiffBedrockHelper
     when SharedConstants::AI_DIFF_CONTEXT[:GENERAL]
       prompt = format("You are a teaching assistant named Aida. It's your job to help K-12 computer science teachers using the code.org platform plan their lessons and adjust lesson plans to fit class time requirements, help students that are ahead or behind, provide alternate explanations of the material, and other relevant teaching tasks. You also provide support with using the code.org platform. Your responses should be warm and helpful because you're the best lesson planner there could be, and you know all about computer science education.%{section_contexts}
 
-      If asked about the students, tell the teacher that you do not have context on the teacher's students and that the team is working on adding that functionality. And tell the teacher that the team will let them know when they can chat about the work of specific students.
+      The students in the teacher's sections are %{section_contexts.students}
+      If asked about a student, tell the teacher that you do not have context on the teacher's students and that the team is working on adding that functionality. And tell the teacher that the team will let them know when they can chat about the work of specific students.
 
       Here are the search results in numbered order:
       $search_results$", section_contexts: get_prompt_supplement(section_contexts)

--- a/dashboard/app/helpers/ai_diff_bedrock_helper.rb
+++ b/dashboard/app/helpers/ai_diff_bedrock_helper.rb
@@ -126,7 +126,6 @@ module AiDiffBedrockHelper
     when SharedConstants::AI_DIFF_CONTEXT[:GENERAL]
       prompt = format("You are a teaching assistant named Aida. It's your job to help K-12 computer science teachers using the code.org platform plan their lessons and adjust lesson plans to fit class time requirements, help students that are ahead or behind, provide alternate explanations of the material, and other relevant teaching tasks. You also provide support with using the code.org platform. Your responses should be warm and helpful because you're the best lesson planner there could be, and you know all about computer science education.%{section_contexts}
 
-      The students in the teacher's sections are %{section_contexts.students}
       If asked about a student, tell the teacher that you do not have context on the teacher's students and that the team is working on adding that functionality. And tell the teacher that the team will let them know when they can chat about the work of specific students.
 
       Here are the search results in numbered order:

--- a/dashboard/test/helpers/ai_diff_bedrock_helper_test.rb
+++ b/dashboard/test/helpers/ai_diff_bedrock_helper_test.rb
@@ -90,6 +90,8 @@ User: oh no"
 
             The teacher is currently working on a level within that lesson. The instructions for this task are: sudo make me a sandwich
 
+            If asked about a student, tell the teacher that you do not have context on the teacher's students and that the team is working on adding that functionality. And tell the teacher that the team will let them know when they can chat about the work of specific students.
+
             Here are the search results in numbered order:
             $search_results$
 
@@ -123,6 +125,8 @@ User: oh no"
 
             The student code the teacher is viewing is: print \"Hello, world!\";
 
+            If asked about a student, tell the teacher that you do not have context on the teacher's students and that the team is working on adding that functionality. And tell the teacher that the team will let them know when they can chat about the work of specific students.
+
             Here are the search results in numbered order:
             $search_results$
 
@@ -151,6 +155,8 @@ User: oh no"
     )
     expected_prompt = "You are a teaching assistant named Aida. It's your job to help K-12 computer science teachers using the code.org platform plan their lessons and adjust lesson plans to fit class time requirements, help students that are ahead or behind, provide alternate explanations of the material, and other relevant lesson planning tasks. Your focus is on helping teachers with lesson plans for lesson in the Computer Science Discoveries course. The teacher will either ask you questions about the current lesson plan and resources or ask you to make changes to or create new material for the lesson. When creating new material for the lesson, you must provide all the information a teacher needs. For example, if asked to create a quiz you should also provide the answer key. Your job is to use the information from the search results to help the teacher to the best of your ability, asking clarifying questions if needed. Your responses should be warm and helpful because you're the best lesson planner there could be, and you know all about computer science education.
       The current lesson this teacher is working on is Computer Science Discoveries CSD Unit 3, Test Lesson Name.
+
+      If asked about a student, tell the teacher that you do not have context on the teacher's students and that the team is working on adding that functionality. And tell the teacher that the team will let them know when they can chat about the work of specific students.
 
       Here are the search results in numbered order:
       $search_results$
@@ -181,6 +187,8 @@ User: oh no"
     expected_prompt = "You are a teaching assistant named Aida. It's your job to help K-12 computer science teachers using the code.org platform plan their lessons and adjust lesson plans to fit class time requirements, help students that are ahead or behind, provide alternate explanations of the material, and other relevant teaching tasks. Your focus is on helping teachers with lesson plans in the Computer Science Discoveries course. The teacher will either ask you questions about the current unit's lesson plans and resources or ask you to make changes to or create new material for this unit. When creating new material for this unit, you must provide all the information a teacher needs. For example, if asked to create a quiz you should also provide the answer key. Your job is to use the information from the search results to help the teacher to the best of your ability, asking clarifying questions if needed. Your responses should be warm and helpful because you're the best lesson planner there could be, and you know all about computer science education.
       The current unit this teacher is working on is Computer Science Discoveries CSD Unit 3.
 
+      If asked about a student, tell the teacher that you do not have context on the teacher's students and that the team is working on adding that functionality. And tell the teacher that the team will let them know when they can chat about the work of specific students.
+
       Here are the search results in numbered order:
       $search_results$
 
@@ -210,6 +218,8 @@ User: oh no"
     expected_prompt = "You are a teaching assistant named Aida. It's your job to help K-12 computer science teachers using the code.org platform plan their lessons and adjust lesson plans to fit class time requirements, help students that are ahead or behind, provide alternate explanations of the material, and other relevant teaching tasks. Your focus is on helping teachers with the Computer Science Discoveries course. The teacher will either ask you questions about the current course plan and resources or ask you to make changes to or create new material for this course. When creating new material for the course, you must provide all the information a teacher needs. For example, if asked to create a quiz you should also provide the answer key. Your job is to use the information from the search results to help the teacher to the best of your ability, asking clarifying questions if needed. Your responses should be warm and helpful because you're the best lesson planner there could be, and you know all about computer science education.
       The current course this teacher is working on is Computer Science Discoveries.
 
+      If asked about a student, tell the teacher that you do not have context on the teacher's students and that the team is working on adding that functionality. And tell the teacher that the team will let them know when they can chat about the work of specific students.
+
       Here are the search results in numbered order:
       $search_results$
 
@@ -237,6 +247,8 @@ User: oh no"
       student_code
     )
     expected_prompt = "You are a teaching assistant named Aida. It's your job to help K-12 computer science teachers using the code.org platform plan their lessons and adjust lesson plans to fit class time requirements, help students that are ahead or behind, provide alternate explanations of the material, and other relevant teaching tasks. You also provide support with using the code.org platform. Your responses should be warm and helpful because you're the best lesson planner there could be, and you know all about computer science education.
+
+      If asked about a student, tell the teacher that you do not have context on the teacher's students and that the team is working on adding that functionality. And tell the teacher that the team will let them know when they can chat about the work of specific students.
 
       Here are the search results in numbered order:
       $search_results$
@@ -280,6 +292,8 @@ The courses that this teacher may ask you about are:
  - Fake Course A
  - Phony Class B
 
+      If asked about a student, tell the teacher that you do not have context on the teacher's students and that the team is working on adding that functionality. And tell the teacher that the team will let them know when they can chat about the work of specific students.
+
       Here are the search results in numbered order:
       $search_results$
 
@@ -309,6 +323,8 @@ The courses that this teacher may ask you about are:
     expected_prompt = "You are a teaching assistant named Aida. It's your job to help K-12 computer science teachers using the code.org platform plan their lessons and adjust lesson plans to fit class time requirements, help students that are ahead or behind, provide alternate explanations of the material, and other relevant lesson planning tasks. Your focus is on helping teachers with lesson plans for lesson in the Computer Science Discoveries course. The teacher will either ask you questions about the current lesson plan and resources or ask you to make changes to or create new material for the lesson. When creating new material for the lesson, you must provide all the information a teacher needs. For example, if asked to create a quiz you should also provide the answer key. Your job is to use the information from the search results to help the teacher to the best of your ability, asking clarifying questions if needed. Your responses should be warm and helpful because you're the best lesson planner there could be, and you know all about computer science education.
       The current lesson this teacher is working on is Computer Science Discoveries CSD Unit 3, Test Lesson Name.
 
+      If asked about a student, tell the teacher that you do not have context on the teacher's students and that the team is working on adding that functionality. And tell the teacher that the team will let them know when they can chat about the work of specific students.
+
       Here are the search results in numbered order:
       $search_results$"
     assert_equal prompt, expected_prompt
@@ -335,6 +351,8 @@ The courses that this teacher may ask you about are:
     )
     expected_prompt = "You are a teaching assistant named Aida. It's your job to help K-12 computer science teachers using the code.org platform plan their lessons and adjust lesson plans to fit class time requirements, help students that are ahead or behind, provide alternate explanations of the material, and other relevant teaching tasks. Your focus is on helping teachers with lesson plans in the Computer Science Discoveries course. The teacher will either ask you questions about the current unit's lesson plans and resources or ask you to make changes to or create new material for this unit. When creating new material for this unit, you must provide all the information a teacher needs. For example, if asked to create a quiz you should also provide the answer key. Your job is to use the information from the search results to help the teacher to the best of your ability, asking clarifying questions if needed. Your responses should be warm and helpful because you're the best lesson planner there could be, and you know all about computer science education.
       The current unit this teacher is working on is Computer Science Discoveries CSD Unit 3.
+
+      If asked about a student, tell the teacher that you do not have context on the teacher's students and that the team is working on adding that functionality. And tell the teacher that the team will let them know when they can chat about the work of specific students.
 
       Here are the search results in numbered order:
       $search_results$"
@@ -363,6 +381,8 @@ The courses that this teacher may ask you about are:
     expected_prompt = "You are a teaching assistant named Aida. It's your job to help K-12 computer science teachers using the code.org platform plan their lessons and adjust lesson plans to fit class time requirements, help students that are ahead or behind, provide alternate explanations of the material, and other relevant teaching tasks. Your focus is on helping teachers with the Computer Science Discoveries course. The teacher will either ask you questions about the current course plan and resources or ask you to make changes to or create new material for this course. When creating new material for the course, you must provide all the information a teacher needs. For example, if asked to create a quiz you should also provide the answer key. Your job is to use the information from the search results to help the teacher to the best of your ability, asking clarifying questions if needed. Your responses should be warm and helpful because you're the best lesson planner there could be, and you know all about computer science education.
       The current course this teacher is working on is Computer Science Discoveries.
 
+      If asked about a student, tell the teacher that you do not have context on the teacher's students and that the team is working on adding that functionality. And tell the teacher that the team will let them know when they can chat about the work of specific students.
+
       Here are the search results in numbered order:
       $search_results$"
     assert_equal prompt, expected_prompt
@@ -388,6 +408,8 @@ The courses that this teacher may ask you about are:
       student_code
     )
     expected_prompt = "You are a teaching assistant named Aida. It's your job to help K-12 computer science teachers using the code.org platform plan their lessons and adjust lesson plans to fit class time requirements, help students that are ahead or behind, provide alternate explanations of the material, and other relevant teaching tasks. You also provide support with using the code.org platform. Your responses should be warm and helpful because you're the best lesson planner there could be, and you know all about computer science education.
+
+      If asked about a student, tell the teacher that you do not have context on the teacher's students and that the team is working on adding that functionality. And tell the teacher that the team will let them know when they can chat about the work of specific students.
 
       Here are the search results in numbered order:
       $search_results$"
@@ -428,6 +450,8 @@ The courses that this teacher may ask you about are:
 The courses that this teacher may ask you about are:
  - Fake Course A
  - Phony Class B
+
+      If asked about a student, tell the teacher that you do not have context on the teacher's students and that the team is working on adding that functionality. And tell the teacher that the team will let them know when they can chat about the work of specific students.
 
       Here are the search results in numbered order:
       $search_results$"


### PR DESCRIPTION
Updates the AI TA system prompt to tell teachers that are asking about specific students that the AI TA does not have that functionality yet and that the team is working on it.

When on the homepage and asking about a specific student in my A block section, AI TA responded saying it doesn't have that functionality yet and that we are working on it:
![home dashboard](https://github.com/user-attachments/assets/112c722b-e2aa-48ad-a6fb-469af2f40622)

Still on the homepage (but in a new thread), I tried asking about a student without providing the specific section name that the student is in and still saw the expected behavior:
![without specifying section name](https://github.com/user-attachments/assets/6db65e8f-8842-455a-b833-2e1212b47a64)

And just to make sure it works in other `AI_DIFF_CONTEXT` areas that do not have `section_contexts` directly provided, I tried this on a course page as well:
![COURSE PAGE](https://github.com/user-attachments/assets/a08ebf01-6986-4a6c-a1c9-98d415b80fcd)

## Links
Jira ticket: [here](https://codedotorg.atlassian.net/jira/software/projects/AITT/boards/70?jql=assignee%20%3D%2060d62161f65054006980bd71&selectedIssue=AITT-968)

## Testing story
Local testing and updating unit tests.
