### PR TITLE
Fix "Add File" dropdown in AI Chat

### DIFF
--- a/apps/src/aichat/views/assets/UploadButton.tsx
+++ b/apps/src/aichat/views/assets/UploadButton.tsx
@@ -1,6 +1,5 @@
 import {Button, ButtonProps} from '@code-dot-org/component-library/button';
 import {ActionDropdown} from '@code-dot-org/component-library/dropdown';
-import classNames from 'classnames';
 import React, {ChangeEvent, useState} from 'react';
 
 import Lab2Registry from '@cdo/apps/lab2/Lab2Registry';
@@ -25,8 +24,6 @@ import {
   stagedFileUploadFinished,
 } from '../../redux';
 import {AssetSource, ChatAsset} from '../../types';
-
-import styles from './upload-button.module.scss';
 
 interface UploadButtonProps {
   isDisabled: boolean;
@@ -186,7 +183,7 @@ const UploadButton: React.FC<UploadButtonProps> = ({
       name="uploadDropdown"
       labelText={aichatI18n.upload()}
       triggerButtonProps={buttonProps}
-      className={classNames(styles.upload, styles.dropdown)}
+      menuVerticalPlacement="top"
       options={[
         {
           value: 'fromLibrary',

--- a/apps/src/aichat/views/assets/upload-button.module.scss
+++ b/apps/src/aichat/views/assets/upload-button.module.scss
@@ -1,6 +1,0 @@
-// Using multiple classnames to override ActionDropdown CSS specificity
-// so that the dropdown menu appears above the button.
-// TODO: Probably better if ActionDropdown supports this natively.
-div.upload.dropdown > div {
-  bottom: 35px;
-}


### PR DESCRIPTION
After #68291, the AI Chat "Add File" dropdown was no longer "dropping up". The fix for this was to get rid of the custom styling and use the new menu vertical placement prop.

## Before
<img width="526" height="138" alt="Screenshot 2025-09-16 at 11 20 21 AM" src="https://github.com/user-attachments/assets/43064c27-ba7f-4d09-8c83-a3529d829504" />


## After
<img width="526" height="138" alt="Screenshot 2025-09-16 at 11 20 09 AM" src="https://github.com/user-attachments/assets/99cb929e-deb0-450e-b25e-95c9b79be277" />


## Links

- [slack thread](https://codedotorg.slack.com/archives/C03DBDN67B7/p1758045487242469)

## Testing story
Tested locally.


## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
