### PR TITLE
Lab2 Dance: stop program when song ends

### DIFF
--- a/apps/src/dance/lab2/ProgramExecutor.ts
+++ b/apps/src/dance/lab2/ProgramExecutor.ts
@@ -38,6 +38,7 @@ interface ProgramExecutorOptions {
     onEnded: () => void
   ) => void;
   stopSound?: () => void;
+  onSoundEnded?: () => void;
 }
 
 /**
@@ -52,6 +53,7 @@ export default class ProgramExecutor {
   private validationCode?: string;
   private onEventsChanged?: () => void;
   private stopSound?: () => void;
+  private onSoundEnded?: () => void;
 
   private livePreviewActive = false;
   private currentlyPlayingSong: string | null = null;
@@ -61,6 +63,7 @@ export default class ProgramExecutor {
     this.validationCode = options.validationCode;
     this.onEventsChanged = options.onEventsChanged;
     this.stopSound = options.stopSound;
+    this.onSoundEnded = options.onSoundEnded;
     this.nativeAPI =
       nativeAPI ||
       new DanceParty({
@@ -307,6 +310,7 @@ export default class ProgramExecutor {
     const onEndedWrapper = () => {
       this.currentlyPlayingSong = null;
       onEnded();
+      this.onSoundEnded?.();
     };
 
     audioCommands.playSound({

--- a/apps/src/dance/lab2/entrypoint.ts
+++ b/apps/src/dance/lab2/entrypoint.ts
@@ -3,7 +3,7 @@ import {lazy} from 'react';
 import {Lab2EntryPoint} from '@cdo/apps/lab2/types';
 
 export const DanceEntryPoint: Lab2EntryPoint = {
-  themes: ['Light'],
+  themes: ['Light', 'Dark'],
   view: lazy(() =>
     import(/* webpackChunkName: "danceLab2" */ './index.js').then(
       ({DanceView}) => ({

--- a/apps/src/dance/lab2/views/DanceView.tsx
+++ b/apps/src/dance/lab2/views/DanceView.tsx
@@ -79,8 +79,6 @@ const BLOCKLY_DIV_ID = 'dance-blockly-div';
 registerReducers(reducers);
 
 const isToolboxMode = getAppOptionsEditBlocks() === TOOLBOX_BLOCKS;
-const aiGenerateMode = queryParams('ai-generate') === 'true';
-const usingMusicProject = queryParams('music-channel') || aiGenerateMode;
 
 /**
  * Renders the Lab2 version of Dance Lab. This separate container
@@ -112,12 +110,16 @@ const DanceView: React.FunctionComponent<{
   const [loadedMusicProject, setLoadedMusicProject] = useState(false);
   const [generatedAiDance, setGeneratedAiDance] = useState(false);
 
+  const aiGenerateMode =
+    levelProperties.aiCodeGenerate || queryParams('ai-generate') === 'true';
+  const usingMusicProject = queryParams('music-channel') || aiGenerateMode;
+
   const {setTheme} = useTheme();
   useEffect(() => {
     if (aiGenerateMode) {
       setTheme('Dark');
     }
-  }, [setTheme]);
+  }, [setTheme, aiGenerateMode]);
 
   const metadataToUse: SongMetadata | undefined = useMemo(() => {
     if (!musicProjectPlayer.current || !loadedMusicProject) {
@@ -319,7 +321,7 @@ const DanceView: React.FunctionComponent<{
     } as BlocklyOptions);
 
     return () => workspace.current?.dispose();
-  }, [dispatch, readonlyWorkspace, levelProperties]);
+  }, [dispatch, readonlyWorkspace, levelProperties, aiGenerateMode]);
 
   useEffect(() => {
     if (!workspace.current) {
@@ -380,7 +382,7 @@ const DanceView: React.FunctionComponent<{
         )
         .then(() => setLoadedMusicProject(true));
     }
-  }, []);
+  }, [usingMusicProject, aiGenerateMode]);
 
   // Set up the ProgramExecutor
   useEffect(() => {
@@ -403,14 +405,14 @@ const DanceView: React.FunctionComponent<{
       onEventsChanged,
       playSound: musicProjectPlayer.current
         ? (_url, callback) => {
-            console.log('play called at ', Date.now());
-            musicProjectPlayer.current?.play();
+            musicProjectPlayer.current?.play(resetProgram);
             callback(true);
           }
         : undefined,
       stopSound: musicProjectPlayer.current
         ? () => musicProjectPlayer.current?.stop()
         : undefined,
+      onSoundEnded: resetProgram,
     });
 
     if (recordReplayLog) {
@@ -453,6 +455,7 @@ const DanceView: React.FunctionComponent<{
     updateSources,
     loadedMusicProject,
     levelProperties.sharedBlocks,
+    usingMusicProject,
   ]);
 
   const settings = useBlocklySettings();

--- a/apps/src/dance/lab2/views/DanceView.tsx
+++ b/apps/src/dance/lab2/views/DanceView.tsx
@@ -114,12 +114,7 @@ const DanceView: React.FunctionComponent<{
     levelProperties.aiCodeGenerate || queryParams('ai-generate') === 'true';
   const usingMusicProject = queryParams('music-channel') || aiGenerateMode;
 
-  const {setTheme} = useTheme();
-  useEffect(() => {
-    if (aiGenerateMode) {
-      setTheme('Dark');
-    }
-  }, [setTheme, aiGenerateMode]);
+  const {theme} = useTheme();
 
   const metadataToUse: SongMetadata | undefined = useMemo(() => {
     if (!musicProjectPlayer.current || !loadedMusicProject) {
@@ -315,13 +310,13 @@ const DanceView: React.FunctionComponent<{
 
     workspace.current = Blockly.inject(blocklyDiv, {
       toolbox: aiGenerateMode ? undefined : toolbox,
-      theme: aiGenerateMode ? cdoDark : cdoTheme,
+      theme: theme === 'Dark' ? cdoDark : cdoTheme,
       readOnly: readonlyWorkspace,
       editBlocks: getAppOptionsEditBlocks(),
     } as BlocklyOptions);
 
     return () => workspace.current?.dispose();
-  }, [dispatch, readonlyWorkspace, levelProperties, aiGenerateMode]);
+  }, [dispatch, readonlyWorkspace, levelProperties, aiGenerateMode, theme]);
 
   useEffect(() => {
     if (!workspace.current) {

--- a/apps/src/dance/types.ts
+++ b/apps/src/dance/types.ts
@@ -36,4 +36,5 @@ export interface DanceLevelProperties extends BlocklyLevelProperties {
   useRestrictedSongs?: boolean;
   songSelection?: string[];
   generateDancerMode?: boolean;
+  aiCodeGenerate?: boolean;
 }

--- a/apps/src/lab2/views/components/guide/Guide.module.scss
+++ b/apps/src/lab2/views/components/guide/Guide.module.scss
@@ -1,3 +1,5 @@
+@use '../layout/variables.scss' as variables;
+
 .guide {
   gap: 20px;
   width: 40%;
@@ -8,7 +10,7 @@
   border: solid 2px black;
   filter: drop-shadow(0 0 0.75rem black);
   position: absolute;
-  z-index: 71;
+  z-index: variables.$z-index-floating-ui;
   background: #4802AA;
   background: linear-gradient(49deg, rgba(72 2 170 / 1) 0%, rgba(176 14 229 / 1) 52%, rgba(77 202 239 / 1) 100%);
   flex-direction: column;

--- a/apps/src/lab2/views/components/layout/variables.scss
+++ b/apps/src/lab2/views/components/layout/variables.scss
@@ -2,3 +2,10 @@
 
 // Default border style
 $default-border: 1px solid var(--borders-neutral-primary);
+
+/** z-indices */
+
+// UI elements that float above main content but below overlays
+$z-index-floating-ui: 60;
+// Full screen overlays (e.g. loading screen)
+$z-index-overlay: 70;

--- a/apps/src/lab2/views/loading.module.scss
+++ b/apps/src/lab2/views/loading.module.scss
@@ -1,3 +1,4 @@
+@use './components/layout/variables.scss' as variables;
 @import 'color.scss';
 @import './common.scss';
 
@@ -51,7 +52,7 @@
   bottom: 0;
   pointer-events: none;
   opacity: 0;
-  z-index: 70;
+  z-index: variables.$z-index-overlay;
   background-color: var(--background-neutral-lab);
 
   &.noFadeLoading {

--- a/apps/src/music/ProjectPlayer.ts
+++ b/apps/src/music/ProjectPlayer.ts
@@ -4,7 +4,6 @@ import {SourcesStore} from '../lab2/projects/SourcesStore';
 
 import MusicBlocklyWorkspace from './blockly/MusicBlocklyWorkspace';
 import {setUpBlocklyForMusicLab} from './blockly/setup';
-import {PlaybackEvent} from './player/interfaces/PlaybackEvent';
 import MusicLibrary from './player/MusicLibrary';
 import MusicPlayer from './player/MusicPlayer';
 import {MusicLabConfig} from './types';
@@ -14,8 +13,9 @@ import {cacheKey, computeEventMeasures, MusicMetadata} from './utils/Generate';
  * Given information about a student project, manages loading code and playing the project song.
  */
 class ProjectPlayer {
-  private currentPlaybackEvents: PlaybackEvent[] | null = null;
+  private currentMetadata: MusicMetadata | null = null;
   private eventMeasures: number[] | null = null;
+  private stopIntervalId: number | null = null;
 
   constructor(
     private readonly player = new MusicPlayer(),
@@ -27,14 +27,12 @@ class ProjectPlayer {
 
   // TODO: Support fetching by level + user ID?
   async loadProject(channelId: string, useLocalStorage = false) {
-    this.currentPlaybackEvents = null;
+    this.currentMetadata = null;
     this.eventMeasures = null;
     this.workspace.initHeadless();
 
-    const {playbackEvents, packId, libraryName} = await this.loadMetadata(
-      channelId,
-      useLocalStorage
-    );
+    this.currentMetadata = await this.loadMetadata(channelId, useLocalStorage);
+    const {libraryName, packId, playbackEvents} = this.currentMetadata;
 
     let library = MusicLibrary.getInstance();
     if (!library) {
@@ -46,21 +44,35 @@ class ProjectPlayer {
     }
 
     this.player.updateConfiguration(library.getBPM(), library.getKey());
-    this.currentPlaybackEvents = playbackEvents;
     this.eventMeasures = computeEventMeasures(playbackEvents);
 
     await this.player.preloadSounds(playbackEvents);
   }
 
-  play() {
-    if (this.currentPlaybackEvents === null) {
+  play(onEnded?: () => void) {
+    if (this.currentMetadata === null) {
       throw new Error('No project loaded!');
     }
-    this.player.playSong(this.currentPlaybackEvents);
+    const {playbackEvents, lastMeasure} = this.currentMetadata;
+    this.player.playSong(playbackEvents);
+
+    // Stop the song after the last measure.
+    this.stopIntervalId = window.setInterval(() => {
+      if (
+        this.stopIntervalId &&
+        this.player.getCurrentPlayheadPosition() >= lastMeasure
+      ) {
+        onEnded?.();
+        this.stop();
+      }
+    }, (60 / this.player.getBPM()) * 1000);
   }
 
   stop() {
     this.player.stopSong();
+    if (this.stopIntervalId) {
+      clearInterval(this.stopIntervalId);
+    }
   }
 
   getEventMeasures() {
@@ -71,7 +83,7 @@ class ProjectPlayer {
   }
 
   getBpm() {
-    if (this.currentPlaybackEvents === null) {
+    if (this.currentMetadata === null) {
       throw new Error('No project loaded!');
     }
     return this.player.getBPM();
@@ -94,10 +106,11 @@ class ProjectPlayer {
     const labConfig = sources.labConfig as MusicLabConfig;
     this.workspace.loadCode(JSON.parse(sources.source as string));
     this.workspace.compileSong(labConfig.music.blockMode);
-    const playbackEvents = this.workspace.executeCompiledSong().playbackEvents;
+    const {playbackEvents, lastMeasure} = this.workspace.executeCompiledSong();
 
     return {
       playbackEvents,
+      lastMeasure,
       packId: labConfig.music.packId,
       libraryName: labConfig.music.library,
     };

--- a/apps/src/music/utils/Generate.ts
+++ b/apps/src/music/utils/Generate.ts
@@ -9,6 +9,7 @@ export const cacheKey = () => `music-ai-generate`;
 
 export interface MusicMetadata {
   playbackEvents: PlaybackEvent[];
+  lastMeasure: number;
   packId?: string;
   libraryName?: string;
 }
@@ -17,12 +18,14 @@ export interface MusicMetadata {
 export const saveGeneratedSongMetadata = (
   channelId: string,
   packId: string,
-  events: PlaybackEvent[]
+  events: PlaybackEvent[],
+  lastMeasure: number
 ) => {
   trySetLocalStorage(
     cacheKey(),
     JSON.stringify({
       playbackEvents: events,
+      lastMeasure,
       packId,
       libraryName: MusicLibrary.getInstance()?.name,
     })

--- a/apps/src/music/views/MusicView.jsx
+++ b/apps/src/music/views/MusicView.jsx
@@ -861,7 +861,8 @@ class UnconnectedMusicView extends React.Component {
       saveGeneratedSongMetadata(
         Lab2Registry.getInstance().getProjectManager().getChannelId(),
         this.props.packId,
-        this.props.playbackEvents
+        this.props.playbackEvents,
+        this.props.lastMeasure
       );
     }
   };


### PR DESCRIPTION
Stops the Dance party animation when the song ends (for both regular and AI modes). This is an existing bug in legacy Dance party as well, but this fix just affects Lab2 dance as they use different components.

Also includes a few minor unrelated (but generally HoAI-related) changes:
- Adjust the z-index of the Guide component so it's not shown between level changes
- Hook Lab2 Dance up to the new `aiCodeGenerate` level property
- Enable dark mode support for Lab2 dance so the theme is preserved between level changes.

## Testing story
Tested locally on HoAI dev progression
