### PR TITLE
Use reporting role for accounts_to_scrub

### DIFF
--- a/dashboard/lib/expired_deleted_account_pii_scrubber.rb
+++ b/dashboard/lib/expired_deleted_account_pii_scrubber.rb
@@ -88,8 +88,13 @@ class ExpiredDeletedAccountPiiScrubber
     log_to_slack(summary, SLACK_CHANNEL_FOR_ERRORS) if num_errors.positive?
   end
 
+  # This query sometimes exceeds the timeout for the prod database. The reporting database is only seconds
+  # behind the prod database, and the default timeframe for expired accounts is 28 days, so we can use it here without much risk.
+  # This helps avoid timeouts and reduces load on the production database.
   def accounts_to_scrub
-    Queries::User::ExpiredDeletedAccounts.call(deleted_before: deleted_since).where.not(id: processed_user_ids)
+    ActiveRecord::Base.connected_to(role: :reporting) do
+      Queries::User::ExpiredDeletedAccounts.call(deleted_before: deleted_since).where.not(id: processed_user_ids)
+    end
   end
 
   def summary


### PR DESCRIPTION
Uses the reporting role for the `accounts_to_scrub` query, to avoid timeouts.


## Links
<!--  Links to relevant external resources.
      - spec docs, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- Jira: 

## Testing story
<!--  Does your change include appropriate tests?
      - If so, please describe how the tests included in this PR are sufficient.
      - If not, please explain why this change does not need to be tested. -->



## Deployment strategy
<!--  Any special steps required to deploy this, besides merging?
      - Are there database migrations or manual steps?
      - Does this require coordination with other teams or systems? -->



## Follow-up work
<!--  List any clean-up or technical debt that will be addressed in future work.
      - Include Jira links where applicable.
      - Are there any known limitations or improvements planned? -->



## Privacy
<!--  How does this change impact Student & Teacher privacy?
      - Does this collect, use, share, or modify PII, either new or existing? -->



## Security
<!--  How does this change impact our security surface-area?
      - Do API's touched have the right auth?
      - Do infra changes impact our attack surface or encryption?
-->



## Caching
<!--  How does this change impact caching behavior?
      - Are cache keys or invalidation strategies affected?
      - Will this require cache warming or invalidation after deployment? -->



## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
