### PR TITLE
Increase ForkTsCheckerWebpackPlugin memory limit to 2560

### DIFF
--- a/apps/webpack.config.js
+++ b/apps/webpack.config.js
@@ -237,6 +237,7 @@ const WEBPACK_BASE_CONFIG = {
     // Run TypeScript type checking in parallel with the build
     new ForkTsCheckerWebpackPlugin({
       // tsconfig.build.json only type-checks TypeScript files.
+      // We manually set a memoryLimit here to avoid a JavaScript heap out of memory error in yarn start.
       typescript: {configFile: 'tsconfig.build.json', memoryLimit: 2560},
     }),
   ],

--- a/apps/webpack.config.js
+++ b/apps/webpack.config.js
@@ -237,7 +237,7 @@ const WEBPACK_BASE_CONFIG = {
     // Run TypeScript type checking in parallel with the build
     new ForkTsCheckerWebpackPlugin({
       // tsconfig.build.json only type-checks TypeScript files.
-      typescript: {configFile: 'tsconfig.build.json'},
+      typescript: {configFile: 'tsconfig.build.json', memoryLimit: 2560},
     }),
   ],
   resolve: {


### PR DESCRIPTION
Some of us have started to see errors in our `yarn start` due to `ForkTsCheckerWebpackPlugin` running out of memory. The [default value](https://www.npmjs.com/package/fork-ts-checker-webpack-plugin) for the limit is 2048, so I bumped it up to 2560. Before this change I would consistently see this error after 5 hot reloads; after I did 20 hot reloads and did not see the error anymore.


## Links
- [slack thread](https://codedotorg.slack.com/archives/C0T0PNTM3/p1757962297362149)


## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
