### PR TITLE
feat(cdn): scope down cache behavior for static assets

### DIFF
--- a/frontend/apps/marketing/cicd/3-app/template.yml.erb
+++ b/frontend/apps/marketing/cicd/3-app/template.yml.erb
@@ -289,7 +289,7 @@ Resources:
             PathPattern: /api/*
             TargetOriginId: marketing-sites-application-origin
             ViewerProtocolPolicy: redirect-to-https
-          # Path: /_next/*
+          # Path: /_next/static/*
           # Description: Marketing _application_ static assets
           - AllowedMethods:
               - GET
@@ -300,7 +300,7 @@ Resources:
               - 4135ea2d-6df8-44a3-9df3-4b5a84be39ad # Managed-CachingDisabled (Disabled until this distribution becomes the main one instead of daisy chained)
               - 658327ea-f89d-4fab-a63d-7e88639e58f6 # Managed-CachingOptimized
             Compress: true
-            PathPattern: /_next/*
+            PathPattern: /_next/static/*
             TargetOriginId: marketing-sites-static-assets-origin
             ViewerProtocolPolicy: redirect-to-https
             ResponseHeadersPolicyId: !Ref DefaultResponseHeadersPolicy


### PR DESCRIPTION
This PR limits the cache behavior for `/_next` to only `/_next/static` to ensure `/_next/images` can be handled by the application. Per the Next.js documentation[1], only `/_next/static/*` is used for static assets.

[1] https://nextjs.org/docs/app/api-reference/config/next-config-js/assetPrefix#set-up-a-cdn