### PR TITLE
Dance: AI generate dancer update

### DIFF
--- a/apps/src/dance/lab2/views/DanceView.tsx
+++ b/apps/src/dance/lab2/views/DanceView.tsx
@@ -578,7 +578,9 @@ export default (props: LabProps<DanceLevelProperties, DanceProjectSources>) => (
   <SourcesContainer {...props} defaultSources={defaultSources}>
     {queryParams('ai-generate-dancer') === 'true' ||
     props.levelProperties.generateDancerMode ? (
-      <DancerGenerate />
+      <DancerGenerate
+        adlibOption={(queryParams('ai-generate-adlib') as string) || 'basic2'}
+      />
     ) : (
       <DanceView levelProperties={props.levelProperties} />
     )}

--- a/apps/src/dance/lab2/views/DancerGenerate.tsx
+++ b/apps/src/dance/lab2/views/DancerGenerate.tsx
@@ -3,20 +3,14 @@ import {useTheme} from '@code-dot-org/component-library/common/contexts';
 import React, {useCallback, useEffect, useState} from 'react';
 
 import {getGeneratedDancerAssets} from '@cdo/apps/lab2/utils/GeneratedDancer';
-import Adlib from '@cdo/apps/lab2/views/components/guide/Adlib';
+import Adlib, {AdlibsType} from '@cdo/apps/lab2/views/components/guide/Adlib';
 import Guide from '@cdo/apps/lab2/views/components/guide/Guide';
 import getRandomInt from '@cdo/apps/util/getRandomInt';
 import {trySetLocalStorage} from '@cdo/apps/utils';
 
 import moduleStyles from './dancer-generate.module.scss';
 
-const adlibs: {
-  [key: string]: {
-    template: string;
-    options: {[key: string]: string[]};
-    variantCount: number;
-  };
-} = {
+const adlibs: AdlibsType = {
   basic: {
     template:
       'Please generate a dancer.  It should look like a {animal} with {appearance}.',
@@ -111,8 +105,7 @@ const DancerGenerate: React.FunctionComponent<DancerGenerateProps> = ({
         {aiGenerateState === 'none' && (
           <>
             <Adlib
-              template={adlibs[adlibOption].template}
-              options={adlibs[adlibOption].options}
+              adlib={adlibs[adlibOption]}
               onChange={(adlibText, choices) => {
                 setAdlibText(adlibText);
                 setChoices(choices);

--- a/apps/src/dance/lab2/views/DancerGenerate.tsx
+++ b/apps/src/dance/lab2/views/DancerGenerate.tsx
@@ -10,7 +10,13 @@ import {trySetLocalStorage} from '@cdo/apps/utils';
 
 import moduleStyles from './dancer-generate.module.scss';
 
-const adlibs = {
+const adlibs: {
+  [key: string]: {
+    template: string;
+    options: {[key: string]: string[]};
+    variantCount: number;
+  };
+} = {
   basic: {
     template:
       'Please generate a dancer.  It should look like a {animal} with {appearance}.',
@@ -18,16 +24,39 @@ const adlibs = {
       animal: ['frog', 'moose'],
       appearance: ['hair', 'glasses'],
     },
+    variantCount: 2,
+  },
+  basic2: {
+    template:
+      'Please generate a dancer.  It should look like a {adjective} {animal} wearing a {attire}.',
+    options: {
+      adjective: ['basic', 'goth'],
+      animal: ['frog', 'moose', 'wolf'],
+      attire: [
+        'headphones',
+        'sunglasses',
+        'crown',
+        'headscarf',
+        'baseball-cap',
+        'beanie',
+        'headband',
+      ],
+    },
+    variantCount: 3,
   },
 };
+
+interface DancerGenerateProps {
+  adlibOption: string;
+}
 
 // This UI takes over the entire lab area and allows the user to generate a dancer using
 // a Guide UI component containing an Adlib UI component.  Pre-generated dancer assets are
 // retrieved from an online cache.  Information about the generated dancer is written to local
 // storage.
-const DancerGenerate: React.FunctionComponent = () => {
-  const adlibOption = 'basic';
-
+const DancerGenerate: React.FunctionComponent<DancerGenerateProps> = ({
+  adlibOption,
+}) => {
   const {setTheme} = useTheme();
 
   useEffect(() => {
@@ -47,7 +76,7 @@ const DancerGenerate: React.FunctionComponent = () => {
 
   const generateDancerCache = useCallback(async () => {
     const startTime = Date.now();
-    const variant = getRandomInt(0, 1);
+    const variant = getRandomInt(0, adlibs[adlibOption].variantCount - 1);
     const {head} = await getGeneratedDancerAssets(
       adlibOption,
       choices,
@@ -58,14 +87,14 @@ const DancerGenerate: React.FunctionComponent = () => {
 
     trySetLocalStorage(
       'dancer-ai-generate',
-      JSON.stringify({adlibOption: 'basic', choices, variant})
+      JSON.stringify({adlibOption, choices, variant})
     );
 
     const elapsedTime = Date.now() - startTime;
     const delayDuration = 2000; // 2 seconds.
     const remainingDelayDuration = Math.max(delayDuration - elapsedTime, 0);
     await new Promise(res => setTimeout(res, remainingDelayDuration));
-  }, [choices]);
+  }, [adlibOption, choices]);
 
   const generateDancer = useCallback(async () => {
     setAiGenerateState('generating');
@@ -82,8 +111,8 @@ const DancerGenerate: React.FunctionComponent = () => {
         {aiGenerateState === 'none' && (
           <>
             <Adlib
-              template={adlibs['basic'].template}
-              options={adlibs['basic'].options}
+              template={adlibs[adlibOption].template}
+              options={adlibs[adlibOption].options}
               onChange={(adlibText, choices) => {
                 setAdlibText(adlibText);
                 setChoices(choices);

--- a/apps/src/lab2/utils/GeneratedDancer.ts
+++ b/apps/src/lab2/utils/GeneratedDancer.ts
@@ -7,7 +7,7 @@ const getGeneratedDancerAssets = async (
   variant: number
 ) => {
   const joinedChoices = choices?.join('-');
-  const cacheFilePath = `${baseAssetUrl}generate/dancer/${adlibOption}-${joinedChoices}-${variant
+  const cacheFilePath = `${baseAssetUrl}generate/dancer/${adlibOption}/${joinedChoices}-${variant
     .toString()
     .padStart(2, '0')}.png`;
 

--- a/apps/src/lab2/views/components/guide/Adlib.tsx
+++ b/apps/src/lab2/views/components/guide/Adlib.tsx
@@ -4,9 +4,18 @@ import reactStringReplace from 'react-string-replace';
 
 import styles from './Adlib.module.scss';
 
-interface AdlibProps {
+export type AdlibType = {
   template: string;
   options: {[key: string]: string[]};
+  variantCount: number;
+};
+
+export type AdlibsType = {
+  [key: string]: AdlibType;
+};
+
+interface AdlibProps {
+  adlib: AdlibType;
   onChange: (value: string, choices: string[]) => void;
   className?: string;
 }
@@ -16,12 +25,12 @@ interface AdlibProps {
 // dropdowns to select the options.  When the selected options change, it calls
 // onChange with the filled-in text.
 const Adlib: React.FunctionComponent<AdlibProps> = ({
-  template,
-  options,
+  adlib,
   onChange,
   className,
 }) => {
   const [adlibOptions, setAdlibOptions] = useState<{[key: string]: string}>({});
+  const {template, options} = adlib;
 
   // Initialize defaults.
   useEffect(() => {

--- a/apps/src/music/ai/generate/GenerateAdlibs.json
+++ b/apps/src/music/ai/generate/GenerateAdlibs.json
@@ -21,7 +21,8 @@
         "A-B-A-C-A",
         "A-A-B-A"
       ]
-    }
+    },
+    "variantCount": 3
   },
   "length": {
     "template": "Please generate a new song.  Around {length} measures in duration is good.",
@@ -31,7 +32,8 @@
         "30",
         "40"
       ]
-    }
+    },
+    "variantCount": 3
   },
   "sounds": {
     "template": "Please make a song with {sounds} sounds in order.",
@@ -42,7 +44,8 @@
         "4",
         "5"
       ]
-    }
+    },
+    "variantCount": 3
   },
   "layers": {
     "template": "Please make a song that layers {type1} and {type2} together. Around 10 measures is good.",
@@ -59,6 +62,7 @@
         "beats",
         "vocals"
       ]
-    }
+    },
+    "variantCount": 3
   }
 }

--- a/apps/src/music/views/Generate.tsx
+++ b/apps/src/music/views/Generate.tsx
@@ -1,7 +1,7 @@
 import {Button} from '@code-dot-org/component-library/button';
 import React, {useCallback, useState} from 'react';
 
-import Adlib from '@cdo/apps/lab2/views/components/guide/Adlib';
+import Adlib, {AdlibsType} from '@cdo/apps/lab2/views/components/guide/Adlib';
 import Guide from '@cdo/apps/lab2/views/components/guide/Guide';
 import getRandomInt from '@cdo/apps/util/getRandomInt';
 import HttpClient from '@cdo/apps/util/HttpClient';
@@ -19,9 +19,7 @@ import {setCodeToLoad, setAiGenerateState} from '../redux/musicRedux';
 
 import styles from './Generate.module.scss';
 
-const adlibs = adlibsUntyped as {
-  [key: string]: {template: string; options: {[key: string]: string[]}};
-};
+const adlibs = adlibsUntyped as AdlibsType;
 
 interface GenerateProps {
   adlibOption?: string;
@@ -81,7 +79,10 @@ const Generate: React.FunctionComponent<GenerateProps> = ({adlibOption}) => {
   }, [contextGenerateMusicPsuedocodeFromDescription, useText]);
 
   const generateSongCache = useCallback(async () => {
-    const variant = getRandomInt(0, 2);
+    const variant = getRandomInt(
+      0,
+      adlibs[adlibOption || 'complex'].variantCount - 1
+    );
     const joinedChoices = choices?.join('-');
     const cacheFilePath = `${baseAssetUrl}generate/music/${packId}-${adlibOption}-${joinedChoices}-${variant
       .toString()
@@ -141,8 +142,7 @@ const Generate: React.FunctionComponent<GenerateProps> = ({adlibOption}) => {
           )}
           {adlibOption && (
             <Adlib
-              template={adlibs[adlibOption].template}
-              options={adlibs[adlibOption].options}
+              adlib={adlibs[adlibOption]}
               onChange={(adlibText, choices) => {
                 setAdlibText(adlibText);
                 setChoices(choices);


### PR DESCRIPTION
This small follow-up to https://github.com/code-dot-org/code-dot-org/pull/68219 uses a new adlib by default, though the older one can be used by adding an `ai-generate-adlib=basic` URL parameter. 

This also introduces a change to the S3 structure, so that each adlib has its own directory, like so:

```
https://curriculum.code.org/media/musiclab/generate/dancer/basic/moose-glasses-00.png
```
