### PR TITLE
chore(cache): ensure cache control header on home page

### DIFF
--- a/frontend/apps/marketing/tests/e2e/cache.spec.ts
+++ b/frontend/apps/marketing/tests/e2e/cache.spec.ts
@@ -1,21 +1,25 @@
 import {expect} from '@playwright/test';
 
+import {getAllTheThingsPagePath} from './config/path';
 import {test} from './fixtures/base';
 import {AllTheThingsPage} from './pom/all-the-things';
+import {MarketingPage} from './pom/marketing';
 import {getTestStage} from './utils/stage';
 
-test.describe('Caching Tests', () => {
-  test('should cache by default', async ({page, browserName}) => {
-    test.skip(browserName !== 'chromium', 'Only runs in Chromium');
-    test.skip(getTestStage() === 'development', 'Only runs in Docker mode');
+test.describe('Caching Tests', async () => {
+  ['/', await getAllTheThingsPagePath()].forEach(path => {
+    test(`should cache by default - ${path}`, async ({page, browserName}) => {
+      test.skip(browserName !== 'chromium', 'Only runs in Chromium');
+      test.skip(getTestStage() === 'development', 'Only runs in Docker mode');
 
-    const allTheThingsPage = new AllTheThingsPage(page, {locale: 'en-US'});
-    const response = await allTheThingsPage.goto();
+      const marketingPage = new MarketingPage(page, {locale: 'en-US'});
+      const response = await marketingPage.goto(path);
 
-    const cacheControlHeader = response?.headers()['cache-control'];
-    expect(cacheControlHeader).toMatch(
-      /^s-maxage=900, stale-while-revalidate=\d+$/,
-    );
+      const cacheControlHeader = response?.headers()['cache-control'];
+      expect(cacheControlHeader).toMatch(
+        /^s-maxage=900, stale-while-revalidate=\d+$/,
+      );
+    });
   });
 
   test('should disable cache if draft mode is enabled', async ({


### PR DESCRIPTION
This PR adds a UI test to ensure that the home page has the necessary cache-control header to ensure the website is cached. This helps to prevent regressions like the one we had today where a Next.js upgrade caused the Cache-Control header to be dropped.