### PR TITLE
dashboard-server: pass --no-log-to-stdout to rails server

### DIFF
--- a/bin/dashboard-server-puma
+++ b/bin/dashboard-server-puma
@@ -1,17 +1,29 @@
 #!/usr/bin/env ruby
 require_relative '../deployment'
+require "optparse"
 
 def main
-  dirs = [deploy_dir('lib'), deploy_dir('shared/middleware'), deploy_dir('dashboard/legacy')]
-  dirs += [pegasus_dir] if CDO.dashboard_enable_pegasus
+  options = {
+    verbose: false,
+  }
+  OptionParser.new do |opts|
+    opts.banner = "Usage: bin/dashboard-server [options]"
+
+    opts.on("-v", "--verbose", "Print rails logs to stdout") {options[:verbose] = true}
+  end.parse!
+
+  rerun_dirs = [deploy_dir('lib'), deploy_dir('shared/middleware'), deploy_dir('dashboard/legacy')]
+  rerun_dirs += [pegasus_dir] if CDO.dashboard_enable_pegasus
   rerun = ['rerun']
   rerun << "-p '**/*.{rb,ru,yml}'"
-  rerun << "-d '#{dirs.join(',')}'"
+  rerun << "-d '#{rerun_dirs.join(',')}'"
   rerun << "-i '**/migrations/*.rb'"
   rerun << "-i 'test/**/*.rb'"
   rerun << "-i '**/public/fonts'"
-  rerun << "#{ARGV.join(' ')} --"
+  rerun << "--"
   rerun = rerun.join(' ')
+
+  pids = []
 
   unless CDO.use_my_apps
     # Note: This will report "apps-watcher Launch Failed" because it expects something
@@ -19,12 +31,10 @@ def main
     pids.push spawn("rerun -x -d #{apps_dir}/src --background -n apps-watcher -- rake package:apps")
   end
 
-  rails_server_args = if CDO.rack_env == :development && CDO.https_development
-                        "-b ssl://#{CDO.dashboard_host} -p #{CDO.dashboard_port}"
-                      else
-                        "-b #{CDO.dashboard_host} -p #{CDO.dashboard_port}"
-                      end
-
+  protocol = CDO.rack_env == :development && CDO.https_development ? 'ssl://' : ''
+  rails_server_args = "-b #{protocol}#{CDO.dashboard_host} -p #{CDO.dashboard_port}"
+  rails_server_args += options[:verbose] ? " --log-to-stdout" : " --no-log-to-stdout"
+  puts "Running: rails server #{rails_server_args}"
   Dir.chdir(dashboard_dir) do
     system "RAILS_ENV=#{CDO.rack_env} bundle exec #{rerun} rails server #{rails_server_args}"
   end


### PR DESCRIPTION
Thin was passing `puts` to stdout, but Rails.logger messages to dashboard/log/development.log. 

To emulate this behavior with 1`rails server`, we pass in --no-log-to-stdout. Otherwise Rails takes config.logger, and does monkeypatching on it to inject a broadcast logger that tees log output to stdout.

Tested with both a puts and a Rails.logger in a controller. Puts goes to stdout, the Rails.logger output goes to file.

Additionally this PR adds flag -v, as in `bin/dashboard-server -v`, which DOES log everything to stdout.