### PR TITLE
Fix test stubbing permanently

### DIFF
--- a/dashboard/engines/marketing/test/dashboard_notifications/contentful_notification_source_test.rb
+++ b/dashboard/engines/marketing/test/dashboard_notifications/contentful_notification_source_test.rb
@@ -52,9 +52,12 @@ class ContentfulNotificationSourceTest < ActionDispatch::IntegrationTest
   end
 
   before do
-    Marketing::ContentfulClient.stubs(:instance).returns(marketing_contentful_client_mock)
     CDO.shared_cache.clear
     sign_in user
+  end
+
+  after do
+    CDO.shared_cache.clear
   end
 
   describe 'get_contentful_notifications_for_user' do


### PR DESCRIPTION
The UI test on test is failing https://cucumber-logs.s3.amazonaws.com/test/test/Chrome_teacher_tools_ai_diff_ai_differentitation_chat_output.html?versionId=wsz6IVU5Q8A111L34dSB6PrOgLbRXQ5G

This is showing in the logs a notification with `Notification 2: Description 2`. The only place that this notification is set is in the `contentful_notification_source_test.rb`. I determined the unit test stubbing and not removing the stub on a static instance call.

This PR removes the stub entirely and also makes sure the cache is clear.

## Links


- Jira: https://codedotorg.slack.com/archives/C0T0PNTM3/p1758070053995499
