### PR TITLE
Add back in entrypoints for feedback and parent letter

### DIFF
--- a/apps/webpackEntryPoints.js
+++ b/apps/webpackEntryPoints.js
@@ -116,6 +116,8 @@ const CODE_STUDIO_ENTRIES = {
   'sections/show': './src/sites/studio/pages/sections/show.js',
   'shared/_school_info': './src/sites/studio/pages/shared/_school_info.js',
   'teacher_dashboard/show': './src/sites/studio/pages/teacher_dashboard/show.js',
+  'teacher_dashboard/parent_letter': './src/sites/studio/pages/teacher_dashboard/parent_letter.js',
+  'teacher_feedbacks/index': './src/sites/studio/pages/teacher_feedbacks/index.js',
   'vocabularies/edit': './src/sites/studio/pages/vocabularies/edit.js',
   'weblab_host/network_check': './src/sites/studio/pages/weblab_host/network_check.js',
 };


### PR DESCRIPTION
These were unintentionally deleted in t[his PR](https://github.com/code-dot-org/code-dot-org/pull/68031/files#diff-094beb96d0665f4ce3be5a461e84ae1b060be3c432d63739518cfaff3baabfa6L117), which caused issues with the parent letter and feedbacks.


## Links
[Slack convo](https://codedotorg.slack.com/archives/C045UAX4WKH/p1758061237933989)
