### PR TITLE
fix(router): allowlist `/_next/image*`

### DIFF
--- a/aws/cloudformation/lambdas/marketing-router/index.js
+++ b/aws/cloudformation/lambdas/marketing-router/index.js
@@ -787,7 +787,7 @@ const marketingPaths = {
 
 const pathPatterns = [
   /^\/_next\/static\//, // Next.js static assets
-  /^\/_next\/image\//,  // Next.js dynamic images
+  /^\/_next\/image/,  // Next.js dynamic images, /_next/image*
   /^\/forms\//,         // /forms/*
   /^\/schools\//,       // /schools/*
   /^\/applab\/docs\//,  // /applab/docs/*


### PR DESCRIPTION
The dynamic image API uses `/_next/image?url=`, so adjust the marketing router to allow `/_next/image*` instead of `/_next/image/*`.