### PR TITLE
Web Lab 2: Allow text-based files in backpack

### DIFF
--- a/dashboard/legacy/middleware/helpers/library_bucket.rb
+++ b/dashboard/legacy/middleware/helpers/library_bucket.rb
@@ -7,7 +7,9 @@ class LibraryBucket < BucketHelper
   end
 
   def allowed_file_types
-    %w(.json .java .py .csv .txt .js)
+    # The Library bucket is used by App Lab (json), Java Lab (java, csv, txt),
+    # Python Lab (py, csv, txt), and Web Lab 2 (html, css, js, md).
+    %w(.json .java .py .csv .txt .js .html .css .md)
   end
 
   def cache_duration_seconds


### PR DESCRIPTION
This updates the list of allowed file types in the backpack (which uses the library bucket), to include html, css and md (a file type coming soon to Web Lab 2). js was already supported.


## Links

- Jira: [AFL-177](https://codedotorg.atlassian.net/browse/AFL-177)

## Testing story
Confirmed you can now upload html and css files to the backpack.


## Follow-up work
We also want to support images, but that is a more involved work item. That is tracked by [AFL-182](https://codedotorg.atlassian.net/browse/AFL-182). In addition, the backpack code needs some clean-up so it's clear it supports more than just python, which is tracked by [AFL-183](https://codedotorg.atlassian.net/browse/AFL-183)



## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
