### PR TITLE
Music Lab: log attempt on first run

### DIFF
--- a/apps/src/music/views/MusicView.jsx
+++ b/apps/src/music/views/MusicView.jsx
@@ -9,6 +9,9 @@ import {connect} from 'react-redux';
 import './small-footer-music-overrides.scss';
 
 import {validateBlockCategories} from '@cdo/apps/blockly/utils';
+import {sendProgressReport} from '@cdo/apps/code-studio/progressRedux';
+import {getCurrentLevel} from '@cdo/apps/code-studio/progressReduxSelectors';
+import {TestResults} from '@cdo/apps/constants';
 import DCDO from '@cdo/apps/dcdo';
 import {START_SOURCES, TOOLBOX_BLOCKS} from '@cdo/apps/lab2/constants';
 import {setIsLoading, setPageError} from '@cdo/apps/lab2/lab2Redux';
@@ -23,6 +26,7 @@ import {LifecycleEvent} from '@cdo/apps/lab2/utils/LifecycleNotifier';
 import AnalyticsReporter from '@cdo/apps/music/analytics/AnalyticsReporter';
 import {setExtraCopyrightContent} from '@cdo/apps/sharedComponents/footer/CopyrightDialog/index';
 import {SignInState} from '@cdo/apps/templates/currentUserRedux';
+import {LevelStatus} from '@cdo/generated-scripts/sharedConstants';
 
 import AppConfig from '../appConfig';
 import {TRIGGER_FIELD} from '../blockly/constants';
@@ -127,6 +131,8 @@ class UnconnectedMusicView extends React.Component {
     canRedo: PropTypes.bool,
     codeToLoad: PropTypes.string,
     clearCodeToLoad: PropTypes.func,
+    sendAttemptReport: PropTypes.func,
+    isFirstAttempt: PropTypes.bool,
   };
 
   constructor(props) {
@@ -876,6 +882,9 @@ class UnconnectedMusicView extends React.Component {
     this.setState({
       hasRun: true,
     });
+    if (this.props.isFirstAttempt) {
+      this.props.sendAttemptReport();
+    }
     this.player.stopSong();
     this.playingTriggers = [];
 
@@ -1005,6 +1014,7 @@ const MusicView = connect(
     canUndo: state.music.canUndo,
     canRedo: state.music.canRedo,
     codeToLoad: state.music.codeToLoad,
+    isFirstAttempt: getCurrentLevel(state)?.status === LevelStatus.not_tried,
   }),
   dispatch => ({
     setPackId: packId => dispatch(setPackId(packId)),
@@ -1041,6 +1051,8 @@ const MusicView = connect(
       dispatch(setLastMeasure(data.lastMeasure));
     },
     clearCodeToLoad: () => dispatch(setCodeToLoad(undefined)),
+    sendAttemptReport: () =>
+      dispatch(sendProgressReport('music', TestResults.LEVEL_STARTED)),
   })
 )(UnconnectedMusicView);
 


### PR DESCRIPTION
Currently in Music Lab, we only submit a progress report when the level is completed (validation has passed). However in other labs, we also track when the level is first attempted (LEVEL_STARTED status), which displays the green outline on the progress bubble. This adds the same reporting to Music Lab. More context: https://codedotorg.slack.com/archives/C07UT279KM1/p1758130932430879

https://github.com/user-attachments/assets/da7ca7d1-4894-4550-ba65-bb11d9f7c3d6

## Testing story
Tested locally on allthethings Music Lab