### PR TITLE
AI Tutor - Web Lab 2 support via query param

### DIFF
--- a/dashboard/app/controllers/aichat_events_controller.rb
+++ b/dashboard/app/controllers/aichat_events_controller.rb
@@ -10,7 +10,7 @@ class AichatEventsController < ApplicationController
       return render status: :bad_request, json: {}
     end
 
-    unless can_log_aichat_events?(params[:aichatContext][:currentLevelId])
+    unless can_log_aichat_events?(params[:aichatContext][:clientType])
       return render status: :forbidden, json: {user_type: current_user.user_type}
     end
 
@@ -105,8 +105,8 @@ class AichatEventsController < ApplicationController
     render status: :ok, json: {}
   end
 
-  private def can_log_aichat_events?(level_id)
-    current_user.has_aichat_access? || current_user.can_access_ai_tutor?(level_id)
+  private def can_log_aichat_events?(client_type)
+    current_user.has_aichat_access? || current_user.can_access_ai_tutor?(client_type)
   end
 
   private def can_view_chat_history?(user_id)

--- a/dashboard/app/controllers/aichat_events_controller.rb
+++ b/dashboard/app/controllers/aichat_events_controller.rb
@@ -1,8 +1,17 @@
 class AichatEventsController < ApplicationController
   authorize_resource class: false
 
-  # params are newChatEvent: ChatEvent, aichatContext: {currentLevelId: number; scriptId: number; channelId: string;}
   # POST /aichat_events/log_chat_event
+  # ----------------------------------
+  # params are:
+  #   newChatEvent: ChatEvent
+  #   aichatContext: {
+  #     clientType: AiChatClientType;
+  #     currentLevelId: number | null;
+  #     scriptId: number | null;
+  #     channelId: string | undefined;
+  #  }
+
   def log_chat_event
     begin
       params.require([:newChatEvent, :aichatContext])

--- a/dashboard/app/controllers/aichat_events_controller.rb
+++ b/dashboard/app/controllers/aichat_events_controller.rb
@@ -106,7 +106,7 @@ class AichatEventsController < ApplicationController
   end
 
   private def can_log_aichat_events?(level_id)
-    current_user.has_aichat_access? || current_user.can_access_ai_tutor2?(level_id)
+    current_user.has_aichat_access? || current_user.can_access_ai_tutor?(level_id)
   end
 
   private def can_view_chat_history?(user_id)

--- a/dashboard/app/controllers/aichat_requests_controller.rb
+++ b/dashboard/app/controllers/aichat_requests_controller.rb
@@ -28,7 +28,7 @@ class AichatRequestsController < ApplicationController
     unless chat_completion_has_required_params?
       return render status: :bad_request, json: {}
     end
-    unless can_access_aichat_chat_completion? || can_access_ai_tutor_chat_completion?(params[:aichatContext][:currentLevelId])
+    unless can_access_aichat_chat_completion? || can_access_ai_tutor_chat_completion?(params[:aichatContext][:clientType])
       return render status: :forbidden, json: {user_type: current_user.user_type}
     end
     return head :too_many_requests if should_throttle_request_count?
@@ -95,9 +95,9 @@ class AichatRequestsController < ApplicationController
     render(status: :ok, json: response_body)
   end
 
-  private def can_access_ai_tutor_chat_completion?(level_id)
+  private def can_access_ai_tutor_chat_completion?(client_type)
     return false if DCDO.get("block_ai_tutor_chat_completion", false)
-    current_user.can_access_ai_tutor?(level_id)
+    current_user.can_access_ai_tutor?(client_type)
   end
 
   private def can_access_aichat_chat_completion?

--- a/dashboard/app/controllers/aichat_requests_controller.rb
+++ b/dashboard/app/controllers/aichat_requests_controller.rb
@@ -23,7 +23,13 @@ class AichatRequestsController < ApplicationController
   #   storedMessages: Array of {role: <'user', 'system', or 'assistant'>; chatMessageText: string; status: string}
   #     - does not include user's new message
   #   modelParameters: {temperature: number; retrievalContexts: string[]; systemPrompt: string;}
-  #.  aichatContext: {currentLevelId: number; scriptId: number; channelId: string;}
+  #   aichatContext: {
+  #     clientType: AiChatClientType;
+  #     currentLevelId: number | null;
+  #     scriptId: number | null;
+  #     channelId: string | undefined;
+  #   }
+
   def start_chat_completion
     unless chat_completion_has_required_params?
       return render status: :bad_request, json: {}

--- a/dashboard/app/controllers/aichat_requests_controller.rb
+++ b/dashboard/app/controllers/aichat_requests_controller.rb
@@ -28,7 +28,7 @@ class AichatRequestsController < ApplicationController
     unless chat_completion_has_required_params?
       return render status: :bad_request, json: {}
     end
-    unless can_access_aichat_chat_completion? || can_access_ai_tutor2_chat_completion?(params[:aichatContext][:currentLevelId])
+    unless can_access_aichat_chat_completion? || can_access_ai_tutor_chat_completion?(params[:aichatContext][:currentLevelId])
       return render status: :forbidden, json: {user_type: current_user.user_type}
     end
     return head :too_many_requests if should_throttle_request_count?
@@ -95,9 +95,9 @@ class AichatRequestsController < ApplicationController
     render(status: :ok, json: response_body)
   end
 
-  private def can_access_ai_tutor2_chat_completion?(level_id)
-    return false if DCDO.get("block_ai_tutor2_chat_completion", false)
-    current_user.can_access_ai_tutor2?(level_id)
+  private def can_access_ai_tutor_chat_completion?(level_id)
+    return false if DCDO.get("block_ai_tutor_chat_completion", false)
+    current_user.can_access_ai_tutor?(level_id)
   end
 
   private def can_access_aichat_chat_completion?

--- a/dashboard/app/models/concerns/user/ai_accessible.rb
+++ b/dashboard/app/models/concerns/user/ai_accessible.rb
@@ -49,11 +49,10 @@ module User::AiAccessible
     teacher_can_access_ai_chat? || student_can_access_ai_chat?
   end
 
-  def can_access_ai_tutor?(level_id)
-    # If the request is coming from a python lab level, trust the client to decide
+  def can_access_ai_tutor?(client_type)
+    # If the request is coming from AiTutor, trust the client to decide
     # if it can access AiTutor. This allows easy testing of AiTutor using a url param.
-    return false if level_id.nil?
-    Level.find(level_id).is_a? Pythonlab
+    client_type == SharedConstants::AI_CHAT_CLIENT_TYPES[:AI_TUTOR]
   end
 
   private def ai_tutor_feature_globally_disabled?

--- a/dashboard/app/models/concerns/user/ai_accessible.rb
+++ b/dashboard/app/models/concerns/user/ai_accessible.rb
@@ -49,9 +49,9 @@ module User::AiAccessible
     teacher_can_access_ai_chat? || student_can_access_ai_chat?
   end
 
-  def can_access_ai_tutor2?(level_id)
+  def can_access_ai_tutor?(level_id)
     # If the request is coming from a python lab level, trust the client to decide
-    # if it can access AiTutor2. This allows easy testing of AiTutor2 using a url param.
+    # if it can access AiTutor. This allows easy testing of AiTutor using a url param.
     return false if level_id.nil?
     Level.find(level_id).is_a? Pythonlab
   end

--- a/dashboard/test/controllers/aichat_events_controller_test.rb
+++ b/dashboard/test/controllers/aichat_events_controller_test.rb
@@ -26,7 +26,8 @@ class AichatEventsControllerTest < ActionController::TestCase
       aichatContext: {
         currentLevelId: @level.id,
         scriptId: @script.id,
-        channelId: "test"
+        channelId: "test",
+        clientType: SharedConstants::AI_CHAT_CLIENT_TYPES[:AI_CHAT_LAB]
       }
     }
 
@@ -62,11 +63,11 @@ class AichatEventsControllerTest < ActionController::TestCase
     assert_response :forbidden
   end
 
-  test 'unauthorized users can access log_chat_event from python lab levels' do
+  test 'unauthorized users can access log_chat_event from ai tutor levels' do
     sign_in(@unauthorized_student)
-    python_lab_level = create(:pythonlab)
-    params_with_python_level = @valid_params_log_chat_event.merge(aichatContext: @valid_params_log_chat_event[:aichatContext].merge(currentLevelId: python_lab_level.id))
-    post :log_chat_event, params: params_with_python_level, as: :json
+    ai_tutor_client_type = SharedConstants::AI_CHAT_CLIENT_TYPES[:AI_TUTOR]
+    params_with_ai_tutor_client_type = @valid_params_log_chat_event.merge(aichatContext: @valid_params_log_chat_event[:aichatContext].merge(clientType: ai_tutor_client_type))
+    post :log_chat_event, params: params_with_ai_tutor_client_type, as: :json
     assert_response :success
   end
 

--- a/dashboard/test/controllers/aichat_requests_controller_test.rb
+++ b/dashboard/test/controllers/aichat_requests_controller_test.rb
@@ -36,7 +36,7 @@ class AichatRequestsControllerTest < ActionController::TestCase
 
   setup do
     @controller.stubs(:storage_decrypt_channel_id).returns([123, @project_id])
-    DCDO.stubs(:get).with('block_ai_tutor2_chat_completion', anything).returns(false)
+    DCDO.stubs(:get).with('block_ai_tutor_chat_completion', anything).returns(false)
     DCDO.stubs(:get).with('block_aichat_chat_completion', anything).returns(false)
     DCDO.stubs(:get).with('aichat_request_limit_per_min', anything).returns(AichatRequestsController::DEFAULT_REQUEST_LIMIT_PER_MIN)
     DCDO.stubs(:get).with('aichat_polling_interval_ms', anything).returns(AichatRequestsController::DEFAULT_POLLING_INTERVAL_MS)
@@ -62,40 +62,40 @@ class AichatRequestsControllerTest < ActionController::TestCase
     assert_response :forbidden
   end
 
-  test 'unauthorized users can access start_chat_completion from python lab levels' do
+  test 'unauthorized users can access start_chat_completion from ai tutor levels' do
     sign_in(@unauthorized_student)
-    python_lab_level = create(:pythonlab)
-    params_with_python_level = @valid_params_chat_completion.merge(aichatContext: @default_aichat_context.merge(currentLevelId: python_lab_level.id))
-    post :start_chat_completion, params: params_with_python_level, as: :json
+    ai_tutor_client_type = SharedConstants::AI_CHAT_CLIENT_TYPES[:AI_TUTOR]
+    params_with_ai_tutor_client_type = @valid_params_chat_completion.merge(aichatContext: @default_aichat_context.merge(clientType: ai_tutor_client_type))
+    post :start_chat_completion, params: params_with_ai_tutor_client_type, as: :json
     assert_response :success
   end
 
-  test 'ai_tutor2 DCDO flag blocks access to start_chat_completion from python lab levels' do
+  test 'ai_tutor DCDO flag blocks access to start_chat_completion from ai tutor levels' do
     sign_in(@unauthorized_student)
-    DCDO.stubs(:get).with('block_ai_tutor2_chat_completion', anything).returns(true)
-    python_lab_level = create(:pythonlab)
-    params_with_python_level = @valid_params_chat_completion.merge(aichatContext: @default_aichat_context.merge(currentLevelId: python_lab_level.id))
-    post :start_chat_completion, params: params_with_python_level, as: :json
+    DCDO.stubs(:get).with('block_ai_tutor_chat_completion', anything).returns(true)
+    ai_tutor_client_type = SharedConstants::AI_CHAT_CLIENT_TYPES[:AI_TUTOR]
+    params_with_ai_tutor_client_type = @valid_params_chat_completion.merge(aichatContext: @default_aichat_context.merge(clientType: ai_tutor_client_type))
+    post :start_chat_completion, params: params_with_ai_tutor_client_type, as: :json
     assert_response :forbidden
   end
 
-  test 'ai_tutor2 DCDO flag does not block start_chat_completion from non python lab levels' do
+  test 'ai_tutor DCDO flag does not block start_chat_completion from ai chat levels' do
     sign_in(@authorized_teacher1)
-    DCDO.stubs(:get).with('block_ai_tutor2_chat_completion', anything).returns(true)
+    DCDO.stubs(:get).with('block_ai_tutor_chat_completion', anything).returns(true)
     post :start_chat_completion, params: @valid_params_chat_completion, as: :json
     assert_response :success
   end
 
-  test 'aichat DCDO flag does not block access to start_chat_completion from python lab levels' do
+  test 'aichat DCDO flag does not block access to start_chat_completion from ai tutor levels' do
     sign_in(@unauthorized_student)
     DCDO.stubs(:get).with('block_aichat_chat_completion', anything).returns(true)
-    python_lab_level = create(:pythonlab)
-    params_with_python_level = @valid_params_chat_completion.merge(aichatContext: @default_aichat_context.merge(currentLevelId: python_lab_level.id))
-    post :start_chat_completion, params: params_with_python_level, as: :json
+    ai_tutor_client_type = SharedConstants::AI_CHAT_CLIENT_TYPES[:AI_TUTOR]
+    params_with_ai_tutor_client_type = @valid_params_chat_completion.merge(aichatContext: @default_aichat_context.merge(clientType: ai_tutor_client_type))
+    post :start_chat_completion, params: params_with_ai_tutor_client_type, as: :json
     assert_response :success
   end
 
-  test 'aichat DCDO flag blocks start_chat_completion from non python lab levels' do
+  test 'aichat DCDO flag blocks start_chat_completion from ai chat levels' do
     sign_in(@authorized_teacher1)
     DCDO.stubs(:get).with('block_aichat_chat_completion', anything).returns(true)
     post :start_chat_completion, params: @valid_params_chat_completion, as: :json


### PR DESCRIPTION
This PR changes the backend AI Tutor access control to use `client_type` instead of `level_id` so that any page that shows a tutor (via level setting or query param) can access the APi.

## Links
This PR partly completes this [Jira ticket](https://codedotorg.atlassian.net/browse/LABS-1559?atlOrigin=eyJpIjoiYzA3ZjdmMDlhNTlmNDM3OGJiZjU4ZDg5YzkxODgzODEiLCJwIjoiaiJ9).

## Testing story
This PR updates access tests to be based on client type (`AI_TUTOR`) rather than level type (`PythonLab`), and updates to the DCDO kill switch to remove `2` from `ai_tutor2`.

## Follow-up work
Initial WebLab2 support in AI Tutor will be completed with additional context updates in a follow-on PR.

## PR Creation Checklist:
- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
