### PR TITLE
Fix two small issues for notifications

### DIFF
--- a/apps/src/aiDifferentiation/AiDiffContainer.tsx
+++ b/apps/src/aiDifferentiation/AiDiffContainer.tsx
@@ -20,6 +20,7 @@ interface AiDiffContainerProps {
   open: boolean;
   scriptName?: string;
   curriculumCourses?: string[];
+  unreadNotificationCount: number;
 }
 
 const MIN_VISIBLE = 40;
@@ -49,6 +50,7 @@ const AiDiffContainer: React.FC<AiDiffContainerProps> = ({
   open,
   scriptName,
   curriculumCourses,
+  unreadNotificationCount,
 }) => {
   const [showWelcomeExperience, setShowWelcomeExperience] = useState(true);
 
@@ -138,6 +140,7 @@ const AiDiffContainer: React.FC<AiDiffContainerProps> = ({
                     context={context}
                     scriptName={scriptName}
                     curriculumCourses={curriculumCourses}
+                    unreadNotificationCount={unreadNotificationCount}
                   />
                 )}
           </div>

--- a/apps/src/aiDifferentiation/AiDiffFloatingActionButton.tsx
+++ b/apps/src/aiDifferentiation/AiDiffFloatingActionButton.tsx
@@ -2,7 +2,6 @@ import {Badge} from '@mui/material';
 import classNames from 'classnames';
 import React, {useEffect, useState} from 'react';
 
-import experiments from '@cdo/apps/util/experiments';
 import {
   tryGetSessionStorage,
   trySetSessionStorage,
@@ -10,9 +9,7 @@ import {
   trySetLocalStorage,
 } from '@cdo/apps/utils';
 import i18n from '@cdo/locale';
-import aiFabWithIconBase from '@cdo/static/ai-bot-ta-base.png';
 import aiFabWithoutText from '@cdo/static/ai-bot-ta-no-text.png';
-import aiFabWithIconTag from '@cdo/static/ai-bot-ta-tag-cyan.png';
 
 import {EVENTS, PLATFORMS} from '../metrics/AnalyticsConstants';
 import analyticsReporter from '../metrics/AnalyticsReporter';
@@ -163,65 +160,49 @@ const AiDiffFloatingActionButton: React.FC<AiDiffFloatingActionButtonProps> = ({
         onClick={handleClick}
         type="button"
       >
-        {experiments.isEnabled('teacher-notifications') ? (
-          <Badge
-            badgeContent={
-              unreadNotificationCount === 'loading'
-                ? 0
-                : unreadNotificationCount > 0
-                ? unreadNotificationCount
-                : 'TA'
-            }
-            color="error"
-            overlap="circular"
-            aria-label={
-              unreadNotificationCount &&
-              i18n.unreadNotificationsCount({
-                unreadCount: unreadNotificationCount,
-              })
-            }
-            sx={{
-              height: '48px',
-              width: '48px',
-              '& .MuiBadge-badge': {
-                backgroundColor:
-                  unreadNotificationCount === 'loading' ||
-                  unreadNotificationCount > 0
-                    ? 'var(--background-error-primary)'
-                    : '#3CFFF8',
-                color:
-                  unreadNotificationCount === 'loading' ||
-                  unreadNotificationCount > 0
-                    ? 'var(--text-neutral-white-fixed)'
-                    : 'var(--text-neutral-black-fixed)',
-                top: '5%',
-                right: '5%',
-              },
-            }}
-            className={style.badge}
-          >
-            <img
-              alt="AI bot - unread notifications"
-              src={aiFabWithoutText}
-              onLoad={() => !isFabImageLoaded && setIsFabImageLoaded(true)}
-              className={style.fabImageWithBadge}
-            />
-          </Badge>
-        ) : (
-          <div>
-            <img
-              alt="AI bot"
-              src={aiFabWithIconBase}
-              onLoad={() => !isFabImageLoaded && setIsFabImageLoaded(true)}
-            />
-            <img
-              alt="TA tag"
-              src={aiFabWithIconTag}
-              className={style.floatingActionButtonTag}
-              onLoad={() => !isFabImageLoaded && setIsFabImageLoaded(true)}
-            />
-          </div>
-        )}
+        <Badge
+          badgeContent={
+            unreadNotificationCount === 'loading'
+              ? 0
+              : unreadNotificationCount > 0
+              ? unreadNotificationCount
+              : 'TA'
+          }
+          color="error"
+          overlap="circular"
+          aria-label={
+            unreadNotificationCount &&
+            i18n.unreadNotificationsCount({
+              unreadCount: unreadNotificationCount,
+            })
+          }
+          sx={{
+            height: '48px',
+            width: '48px',
+            '& .MuiBadge-badge': {
+              backgroundColor:
+                unreadNotificationCount === 'loading' ||
+                unreadNotificationCount > 0
+                  ? 'var(--background-error-primary)'
+                  : '#3CFFF8',
+              color:
+                unreadNotificationCount === 'loading' ||
+                unreadNotificationCount > 0
+                  ? 'var(--text-neutral-white-fixed)'
+                  : 'var(--text-neutral-black-fixed)',
+              top: '5%',
+              right: '5%',
+            },
+          }}
+          className={style.badge}
+        >
+          <img
+            alt="AI bot - unread notifications"
+            src={aiFabWithoutText}
+            onLoad={() => !isFabImageLoaded && setIsFabImageLoaded(true)}
+            className={style.fabImageWithBadge}
+          />
+        </Badge>
       </button>
       <AiDiffContainer
         open={isOpen}

--- a/apps/src/aiDifferentiation/AiDiffFloatingActionButton.tsx
+++ b/apps/src/aiDifferentiation/AiDiffFloatingActionButton.tsx
@@ -210,6 +210,9 @@ const AiDiffFloatingActionButton: React.FC<AiDiffFloatingActionButtonProps> = ({
         closeTutor={handleClick}
         scriptName={scriptName}
         curriculumCourses={curriculumCourses}
+        unreadNotificationCount={
+          unreadNotificationCount === 'loading' ? 0 : unreadNotificationCount
+        }
       />
     </div>
   );

--- a/apps/src/aiDifferentiation/AiDiffFloatingActionButton.tsx
+++ b/apps/src/aiDifferentiation/AiDiffFloatingActionButton.tsx
@@ -2,6 +2,7 @@ import {Badge} from '@mui/material';
 import classNames from 'classnames';
 import React, {useEffect, useState} from 'react';
 
+import experiments from '@cdo/apps/util/experiments';
 import {
   tryGetSessionStorage,
   trySetSessionStorage,
@@ -9,7 +10,9 @@ import {
   trySetLocalStorage,
 } from '@cdo/apps/utils';
 import i18n from '@cdo/locale';
+import aiFabWithIconBase from '@cdo/static/ai-bot-ta-base.png';
 import aiFabWithoutText from '@cdo/static/ai-bot-ta-no-text.png';
+import aiFabWithIconTag from '@cdo/static/ai-bot-ta-tag-cyan.png';
 
 import {EVENTS, PLATFORMS} from '../metrics/AnalyticsConstants';
 import analyticsReporter from '../metrics/AnalyticsReporter';
@@ -160,49 +163,65 @@ const AiDiffFloatingActionButton: React.FC<AiDiffFloatingActionButtonProps> = ({
         onClick={handleClick}
         type="button"
       >
-        <Badge
-          badgeContent={
-            unreadNotificationCount === 'loading'
-              ? 0
-              : unreadNotificationCount > 0
-              ? unreadNotificationCount
-              : 'TA'
-          }
-          color="error"
-          overlap="circular"
-          aria-label={
-            unreadNotificationCount &&
-            i18n.unreadNotificationsCount({
-              unreadCount: unreadNotificationCount,
-            })
-          }
-          sx={{
-            height: '48px',
-            width: '48px',
-            '& .MuiBadge-badge': {
-              backgroundColor:
-                unreadNotificationCount === 'loading' ||
-                unreadNotificationCount > 0
-                  ? 'var(--background-error-primary)'
-                  : '#3CFFF8',
-              color:
-                unreadNotificationCount === 'loading' ||
-                unreadNotificationCount > 0
-                  ? 'var(--text-neutral-white-fixed)'
-                  : 'var(--text-neutral-black-fixed)',
-              top: '5%',
-              right: '5%',
-            },
-          }}
-          className={style.badge}
-        >
-          <img
-            alt="AI bot - unread notifications"
-            src={aiFabWithoutText}
-            onLoad={() => !isFabImageLoaded && setIsFabImageLoaded(true)}
-            className={style.fabImageWithBadge}
-          />
-        </Badge>
+        {experiments.isEnabled('teacher-notifications') ? (
+          <Badge
+            badgeContent={
+              unreadNotificationCount === 'loading'
+                ? 0
+                : unreadNotificationCount > 0
+                ? unreadNotificationCount
+                : 'TA'
+            }
+            color="error"
+            overlap="circular"
+            aria-label={
+              unreadNotificationCount &&
+              i18n.unreadNotificationsCount({
+                unreadCount: unreadNotificationCount,
+              })
+            }
+            sx={{
+              height: '48px',
+              width: '48px',
+              '& .MuiBadge-badge': {
+                backgroundColor:
+                  unreadNotificationCount === 'loading' ||
+                  unreadNotificationCount > 0
+                    ? 'var(--background-error-primary)'
+                    : '#3CFFF8',
+                color:
+                  unreadNotificationCount === 'loading' ||
+                  unreadNotificationCount > 0
+                    ? 'var(--text-neutral-white-fixed)'
+                    : 'var(--text-neutral-black-fixed)',
+                top: '5%',
+                right: '5%',
+              },
+            }}
+            className={style.badge}
+          >
+            <img
+              alt="AI bot - unread notifications"
+              src={aiFabWithoutText}
+              onLoad={() => !isFabImageLoaded && setIsFabImageLoaded(true)}
+              className={style.fabImageWithBadge}
+            />
+          </Badge>
+        ) : (
+          <div>
+            <img
+              alt="AI bot"
+              src={aiFabWithIconBase}
+              onLoad={() => !isFabImageLoaded && setIsFabImageLoaded(true)}
+            />
+            <img
+              alt="TA tag"
+              src={aiFabWithIconTag}
+              className={style.floatingActionButtonTag}
+              onLoad={() => !isFabImageLoaded && setIsFabImageLoaded(true)}
+            />
+          </div>
+        )}
       </button>
       <AiDiffContainer
         open={isOpen}

--- a/apps/src/aiDifferentiation/AiDiffSidebar.tsx
+++ b/apps/src/aiDifferentiation/AiDiffSidebar.tsx
@@ -18,6 +18,7 @@ interface AiDiffSidebarProps {
   threadSelectCallback?: (thread: number) => void;
   setShowNotifications: (show: boolean) => void;
   showNotifications: boolean;
+  unreadNotificationCount: number;
 }
 
 const now = new Date();
@@ -64,6 +65,7 @@ const AiDiffSidebar: React.FC<AiDiffSidebarProps> = ({
   threadSelectCallback = () => {},
   setShowNotifications,
   showNotifications,
+  unreadNotificationCount,
 }) => {
   const handleListItemClick = (chatId: number) => {
     setShowNotifications(false);
@@ -118,12 +120,15 @@ const AiDiffSidebar: React.FC<AiDiffSidebarProps> = ({
         >
           <FontAwesomeV6Icon iconName="bell" />
           <span>{commonI18n.notifications()}</span>
-          <FontAwesomeV6Icon
-            iconName="circle"
-            iconStyle="solid"
-            className={styles.readAt}
-            aria-label={i18n.unread()}
-          />
+
+          {unreadNotificationCount > 0 && (
+            <FontAwesomeV6Icon
+              iconName="circle"
+              iconStyle="solid"
+              className={styles.readAt}
+              aria-label={i18n.unread()}
+            />
+          )}
         </button>
         <div className={styles.sidebarContent}>
           <List disablePadding={true}>

--- a/apps/src/aiDifferentiation/AiDiffSidebar.tsx
+++ b/apps/src/aiDifferentiation/AiDiffSidebar.tsx
@@ -5,6 +5,8 @@ import {Box, List, ListItem, ListItemButton, ListItemText} from '@mui/material';
 import classNames from 'classnames';
 import React from 'react';
 
+import {EVENTS} from '@cdo/apps/metrics/AnalyticsConstants';
+import analyticsReporter from '@cdo/apps/metrics/AnalyticsReporter';
 import {commonI18n} from '@cdo/apps/types/locale';
 import i18n from '@cdo/locale';
 
@@ -111,7 +113,13 @@ const AiDiffSidebar: React.FC<AiDiffSidebarProps> = ({
           className={styles.sidebarButton}
         />
         <button
-          onClick={() => setShowNotifications(true)}
+          onClick={() => {
+            setShowNotifications(true);
+
+            analyticsReporter.sendEvent(EVENTS.AI_DIFF_NOTIFICATIONS_OPENED, {
+              unreadNotificationCount: unreadNotificationCount,
+            });
+          }}
           className={classNames(styles.notificationsButton, {
             [styles.selected]: showNotifications,
           })}

--- a/apps/src/aiDifferentiation/AiDiffSidebar.tsx
+++ b/apps/src/aiDifferentiation/AiDiffSidebar.tsx
@@ -8,6 +8,7 @@ import React from 'react';
 import {EVENTS} from '@cdo/apps/metrics/AnalyticsConstants';
 import analyticsReporter from '@cdo/apps/metrics/AnalyticsReporter';
 import {commonI18n} from '@cdo/apps/types/locale';
+import experiments from '@cdo/apps/util/experiments';
 import i18n from '@cdo/locale';
 
 import {ChatThread} from './types';
@@ -112,32 +113,33 @@ const AiDiffSidebar: React.FC<AiDiffSidebarProps> = ({
           text={commonI18n.aiDifferentiation_new_chat()}
           className={styles.sidebarButton}
         />
-        <button
-          onClick={() => {
-            setShowNotifications(true);
+        {experiments.isEnabled('teacher-notifications') && (
+          <button
+            onClick={() => {
+              setShowNotifications(true);
 
-            analyticsReporter.sendEvent(EVENTS.AI_DIFF_NOTIFICATIONS_OPENED, {
-              unreadNotificationCount: unreadNotificationCount,
-            });
-          }}
-          className={classNames(styles.notificationsButton, {
-            [styles.selected]: showNotifications,
-          })}
-          id="ui-notificationsButton"
-          type="button"
-        >
-          <FontAwesomeV6Icon iconName="bell" />
-          <span>{commonI18n.notifications()}</span>
-
-          {unreadNotificationCount > 0 && (
-            <FontAwesomeV6Icon
-              iconName="circle"
-              iconStyle="solid"
-              className={styles.readAt}
-              aria-label={i18n.unread()}
-            />
-          )}
-        </button>
+              analyticsReporter.sendEvent(EVENTS.AI_DIFF_NOTIFICATIONS_OPENED, {
+                unreadNotificationCount: unreadNotificationCount,
+              });
+            }}
+            className={classNames(styles.notificationsButton, {
+              [styles.selected]: showNotifications,
+            })}
+            id="ui-notificationsButton"
+            type="button"
+          >
+            <FontAwesomeV6Icon iconName="bell" />
+            <span>{commonI18n.notifications()}</span>
+            {unreadNotificationCount > 0 && (
+              <FontAwesomeV6Icon
+                iconName="circle"
+                iconStyle="solid"
+                className={styles.readAt}
+                aria-label={i18n.unread()}
+              />
+            )}
+          </button>
+        )}
         <div className={styles.sidebarContent}>
           <List disablePadding={true}>
             {todayChats.length > 0 && (

--- a/apps/src/aiDifferentiation/AiDiffSidebar.tsx
+++ b/apps/src/aiDifferentiation/AiDiffSidebar.tsx
@@ -6,7 +6,6 @@ import classNames from 'classnames';
 import React from 'react';
 
 import {commonI18n} from '@cdo/apps/types/locale';
-import experiments from '@cdo/apps/util/experiments';
 import i18n from '@cdo/locale';
 
 import {ChatThread} from './types';
@@ -109,25 +108,23 @@ const AiDiffSidebar: React.FC<AiDiffSidebarProps> = ({
           text={commonI18n.aiDifferentiation_new_chat()}
           className={styles.sidebarButton}
         />
-        {experiments.isEnabled('teacher-notifications') && (
-          <button
-            onClick={() => setShowNotifications(true)}
-            className={classNames(styles.notificationsButton, {
-              [styles.selected]: showNotifications,
-            })}
-            id="ui-notificationsButton"
-            type="button"
-          >
-            <FontAwesomeV6Icon iconName="bell" />
-            <span>{commonI18n.notifications()}</span>
-            <FontAwesomeV6Icon
-              iconName="circle"
-              iconStyle="solid"
-              className={styles.readAt}
-              aria-label={i18n.unread()}
-            />
-          </button>
-        )}
+        <button
+          onClick={() => setShowNotifications(true)}
+          className={classNames(styles.notificationsButton, {
+            [styles.selected]: showNotifications,
+          })}
+          id="ui-notificationsButton"
+          type="button"
+        >
+          <FontAwesomeV6Icon iconName="bell" />
+          <span>{commonI18n.notifications()}</span>
+          <FontAwesomeV6Icon
+            iconName="circle"
+            iconStyle="solid"
+            className={styles.readAt}
+            aria-label={i18n.unread()}
+          />
+        </button>
         <div className={styles.sidebarContent}>
           <List disablePadding={true}>
             {todayChats.length > 0 && (

--- a/apps/src/aiDifferentiation/AiDiffWorkspace.tsx
+++ b/apps/src/aiDifferentiation/AiDiffWorkspace.tsx
@@ -20,12 +20,14 @@ interface AiDiffWorkSpaceProps {
   context: Context;
   scriptName?: string;
   curriculumCourses?: string[];
+  unreadNotificationCount: number;
 }
 
 const AiDiffWorkSpace: React.FC<AiDiffWorkSpaceProps> = ({
   context,
   scriptName,
   curriculumCourses,
+  unreadNotificationCount,
 }) => {
   const [threads, setThreads] = useState<ChatThread[]>();
   const [threadMessages, setThreadMessages] = useState<ChatItem[]>();
@@ -113,6 +115,7 @@ const AiDiffWorkSpace: React.FC<AiDiffWorkSpaceProps> = ({
         threadSelectCallback={fetchThreadMessages}
         setShowNotifications={setShowNotifications}
         showNotifications={showNotifications}
+        unreadNotificationCount={unreadNotificationCount}
       />
       {showNotifications ? (
         <AiDiffNotificationList aiPromptClick={aiPromptOutsideChatClicked} />

--- a/apps/src/aiDifferentiation/AiDiffWorkspace.tsx
+++ b/apps/src/aiDifferentiation/AiDiffWorkspace.tsx
@@ -1,7 +1,5 @@
 import React, {useCallback, useEffect, useState} from 'react';
 
-import experiments from '@cdo/apps/util/experiments';
-
 import HttpClient from '../util/HttpClient';
 
 import AiDiffChat from './AiDiffChat';
@@ -116,7 +114,7 @@ const AiDiffWorkSpace: React.FC<AiDiffWorkSpaceProps> = ({
         setShowNotifications={setShowNotifications}
         showNotifications={showNotifications}
       />
-      {showNotifications && experiments.isEnabled('teacher-notifications') ? (
+      {showNotifications ? (
         <AiDiffNotificationList aiPromptClick={aiPromptOutsideChatClicked} />
       ) : (
         <AiDiffChat

--- a/apps/src/aiDifferentiation/AiDiffWorkspace.tsx
+++ b/apps/src/aiDifferentiation/AiDiffWorkspace.tsx
@@ -1,5 +1,7 @@
 import React, {useCallback, useEffect, useState} from 'react';
 
+import experiments from '@cdo/apps/util/experiments';
+
 import HttpClient from '../util/HttpClient';
 
 import AiDiffChat from './AiDiffChat';
@@ -117,7 +119,7 @@ const AiDiffWorkSpace: React.FC<AiDiffWorkSpaceProps> = ({
         showNotifications={showNotifications}
         unreadNotificationCount={unreadNotificationCount}
       />
-      {showNotifications ? (
+      {showNotifications && experiments.isEnabled('teacher-notifications') ? (
         <AiDiffNotificationList aiPromptClick={aiPromptOutsideChatClicked} />
       ) : (
         <AiDiffChat

--- a/apps/src/aiDifferentiation/notifications/Notification.tsx
+++ b/apps/src/aiDifferentiation/notifications/Notification.tsx
@@ -123,7 +123,7 @@ const Notification: React.FC<NotificationProps> = ({
           notificationOrPlaceholder.publishedAt
         ).toLocaleUpperCase()}
       </BodyThreeText>
-      {notificationOrPlaceholder.readAt === null && notification !== null ? (
+      {!notificationOrPlaceholder.readAt && notification !== null ? (
         <FontAwesomeV6Icon
           iconName="circle"
           iconStyle="solid"

--- a/apps/src/aiDifferentiation/notifications/Notification.tsx
+++ b/apps/src/aiDifferentiation/notifications/Notification.tsx
@@ -6,6 +6,8 @@ import {
 import classNames from 'classnames';
 import React from 'react';
 
+import {EVENTS} from '@cdo/apps/metrics/AnalyticsConstants';
+import analyticsReporter from '@cdo/apps/metrics/AnalyticsReporter';
 import i18n from '@cdo/locale';
 
 import {AiDiffNotification, IconColor} from './types';
@@ -89,7 +91,20 @@ const Notification: React.FC<NotificationProps> = ({
           {notificationOrPlaceholder.hrefLinks?.length > 0 &&
             notificationOrPlaceholder.hrefLinks.map((link, index) => (
               <li key={'url-' + index} className={styles.hrefLink}>
-                <a href={link.url} target="_blank" rel="noreferrer noopener">
+                <a
+                  href={link.url}
+                  target="_blank"
+                  rel="noreferrer noopener"
+                  onClick={() => {
+                    analyticsReporter.sendEvent(
+                      EVENTS.AI_DIFF_NOTIFICATION_URL_CLICKED,
+                      {
+                        notificationId: notificationOrPlaceholder.id,
+                        externalId: notificationOrPlaceholder.externalId,
+                      }
+                    );
+                  }}
+                >
                   {link.text}
                 </a>
               </li>
@@ -101,6 +116,14 @@ const Notification: React.FC<NotificationProps> = ({
                   onClick={() => {
                     if (aiPromptClick) {
                       aiPromptClick(prompt.text, prompt.prompt);
+
+                      analyticsReporter.sendEvent(
+                        EVENTS.AI_DIFF_NOTIFICATION_AI_PROMPT_CLICKED,
+                        {
+                          notificationId: notificationOrPlaceholder.id,
+                          externalId: notificationOrPlaceholder.externalId,
+                        }
+                      );
                     }
                   }}
                   className={styles.aiButton}

--- a/apps/src/aiDifferentiation/notifications/notifications.module.scss
+++ b/apps/src/aiDifferentiation/notifications/notifications.module.scss
@@ -74,7 +74,7 @@ p.text {
 }
 
 li.hrefLink {
-  & a:link {
+  & a {
     border: 1px solid var(--borders-neutral-strong);
     border-radius: 4px;
     padding: 0 8px;

--- a/apps/src/metrics/AnalyticsConstants.js
+++ b/apps/src/metrics/AnalyticsConstants.js
@@ -318,6 +318,12 @@ const EVENTS = {
   AI_DIFF_101: 'AI Teaching Assistant AI 101 CTA',
   AI_DIFF_SKIP_WELCOME: 'AI Teaching Assistant Skip Welcome',
 
+  AI_DIFF_NOTIFICATIONS_OPENED: 'AI Differentiation Notifications Opened',
+  AI_DIFF_NOTIFICATION_URL_CLICKED:
+    'AI Differentiation Notification URL Clicked',
+  AI_DIFF_NOTIFICATION_AI_PROMPT_CLICKED:
+    'AI Differentiation Notification AI Prompt Clicked',
+
   // AI Tutor
   AI_TUTOR_DISABLED: 'Teacher disabled AI Tutor for a section',
   AI_TUTOR_ENABLED: 'Teacher enabled AI Tutor for a section',

--- a/dashboard/test/ui/features/teacher_tools/ai_diff/ai_differentitation_chat.feature
+++ b/dashboard/test/ui/features/teacher_tools/ai_diff/ai_differentitation_chat.feature
@@ -146,7 +146,7 @@ Feature: Send and receive messages in the AI differentiation chat
     # Teacher views lesson page and floating action button
     When I sign in as "Stilgar"
     And I get debug info for the current user
-    And I am on "http://studio.code.org/teacher_dashboard/home?enableExperiments=teacher-notifications"
+    And I am on "http://studio.code.org/teacher_dashboard/home"
     And I wait until element "h2:contains(Welcome, Stilgar)" is visible
     And element "#sign_in_or_user" contains text "Stilgar"
     And I wait until element "#ui-floatingActionButton" is visible

--- a/dashboard/test/ui/features/teacher_tools/ai_diff/ai_differentitation_chat.feature
+++ b/dashboard/test/ui/features/teacher_tools/ai_diff/ai_differentitation_chat.feature
@@ -146,7 +146,7 @@ Feature: Send and receive messages in the AI differentiation chat
     # Teacher views lesson page and floating action button
     When I sign in as "Stilgar"
     And I get debug info for the current user
-    And I am on "http://studio.code.org/teacher_dashboard/home"
+    And I am on "http://studio.code.org/teacher_dashboard/home?enableExperiments=teacher-notifications"
     And I wait until element "h2:contains(Welcome, Stilgar)" is visible
     And element "#sign_in_or_user" contains text "Stilgar"
     And I wait until element "#ui-floatingActionButton" is visible


### PR DESCRIPTION
Fixes two issues:
The notification red dot showing up in the sidebar always
Missing feature logging

Without unread notifications:
<img width="274" height="227" alt="image" src="https://github.com/user-attachments/assets/b195554f-2970-4850-abf9-19b883b0f2dc" />
<img width="724" height="728" alt="image" src="https://github.com/user-attachments/assets/2177d99b-b1df-427d-a826-fd238cd6fdf7" />


With unread notifications:
<img width="728" height="749" alt="image" src="https://github.com/user-attachments/assets/cd36b106-e63c-4919-9bc9-41ee4ca4c789" />
<img width="271" height="780" alt="image" src="https://github.com/user-attachments/assets/ca48512d-9834-40c5-b777-d4cdd287c687" />


Adding logging: note- in production externalId is a hash provided by contentful.
<img width="755" height="234" alt="image" src="https://github.com/user-attachments/assets/4e7f7b09-0819-4260-b46b-5bee5d20db01" />

https://codedotorg.atlassian.net/browse/AITT-1144?atlOrigin=eyJpIjoiNDJmNzliYmJlMTQwNGNmYTg5OWU4ZmM2YTczMGY1NzkiLCJwIjoiamlyYS1zbGFjay1pbnQifQ