### PR TITLE
destroy failed delayed_jobs by default

### DIFF
--- a/dashboard/app/jobs/mail_delivery_job.rb
+++ b/dashboard/app/jobs/mail_delivery_job.rb
@@ -13,4 +13,8 @@ class MailDeliveryJob < ActionMailer::MailDeliveryJob
   include ActiveJobReporting
 
   rescue_from StandardError, with: :report_exception
+
+  def destroy_failed_jobs?
+    false
+  end
 end

--- a/dashboard/app/jobs/mailjet_delivery_job.rb
+++ b/dashboard/app/jobs/mailjet_delivery_job.rb
@@ -20,4 +20,8 @@ class MailjetDeliveryJob < ApplicationJob
   def perform(...)
     MailJet.send_email(...)
   end
+
+  def destroy_failed_jobs?
+    false
+  end
 end

--- a/dashboard/app/jobs/user/pii_scrubber_job.rb
+++ b/dashboard/app/jobs/user/pii_scrubber_job.rb
@@ -5,4 +5,8 @@ class User::PiiScrubberJob < ApplicationJob
   def perform(dry_run: false, deleted_since: nil, limit: nil)
     ExpiredDeletedAccountPiiScrubber.new(dry_run:, deleted_since:, limit:).call
   end
+
+  def destroy_failed_jobs?
+    false
+  end
 end

--- a/dashboard/config/initializers/delayed_job_config.rb
+++ b/dashboard/config/initializers/delayed_job_config.rb
@@ -1,6 +1,6 @@
 # Prevents auto-deletion of failed jobs.
 # The failed jobs will be marked with non-null `failed_at`.
-Delayed::Worker.destroy_failed_jobs = false
+Delayed::Worker.destroy_failed_jobs = true
 
 # Turn off "delayed_job" retry behavior, relying only on ActiveJob's own retry
 # behavior. When you're using delayed_job as a backend to ActiveJob, you end up


### PR DESCRIPTION
destroy failed Delayed Job jobs by default, and explicitly mark a few jobs as exceptions in cases where we want to keep failed jobs. for context, see [slack](https://codedotorg.slack.com/archives/C0T0PNTM3/p1758140001021799?thread_ts=1758136264.858079&cid=C0T0PNTM3).

here are the docs which describe the per-job setting: https://github.com/collectiveidea/delayed_job?tab=readme-ov-file
> To set a per-job default for destroying failed jobs that overrides the Delayed::Worker.destroy_failed_jobs you can define a destroy_failed_jobs? method on the job

```ruby
NewsletterJob = Struct.new(:text, :emails) do
  def perform
    emails.each { |e| NewsletterMailer.deliver_text_to_email(text, e) }
  end

  def destroy_failed_jobs?
    false
  end
end
```

## Testing Story

doesn't work! tested out via:
```diff
Dave-MBP:~/src/cdo (destroy-most-failed-job-types *)$ git diff
diff --git a/dashboard/app/jobs/sample_job.rb b/dashboard/app/jobs/sample_job.rb
index b7ed5564599..816cbc45bf8 100644
--- a/dashboard/app/jobs/sample_job.rb
+++ b/dashboard/app/jobs/sample_job.rb
@@ -35,10 +35,16 @@ class SampleJob < ApplicationJob
     puts "In #{job.class.name} - after_perform"
   end

+  def destroy_failed_jobs?
+    puts "In #{self.class.name} - destroy_failed_jobs?"
+    false
+  end
+
   # Primary Job Method
   def perform(*message)
     puts "In #{self.class.name} - perform"
     sleep(rand(1..5))
     puts "Hello, #{message}"
+    raise 'job failed for no reason'
   end
 end
```

```
[development] dashboard > SampleJob.perform_later('world')
```

```
mysql> select failed_at from delayed_jobs;
```