### PR TITLE
Truncate student code in prompt to stay under length limit

### DIFF
--- a/dashboard/app/helpers/ai_diff_bedrock_helper.rb
+++ b/dashboard/app/helpers/ai_diff_bedrock_helper.rb
@@ -80,7 +80,10 @@ module AiDiffBedrockHelper
             The student code the teacher is viewing is: %{student_code}
 
             Here are the search results in numbered order:
-            $search_results$", course_name: course_name, unit_name: unit_name, lesson_name: lesson_name, level_instructions: level_instructions, student_code: student_code[:student_code]
+            $search_results$",
+            course_name:, unit_name:, lesson_name:, level_instructions:,
+            # Truncate student code to 75,000 characters to stay comfortably under AWS 100,000 character limit.
+            student_code: format("%.75000s", student_code[:student_code])
           )
         else
           format("You are a teaching assistant named Aida. It's your job to help K-12 computer science teachers using the code.org platform plan their lessons and adjust lesson plans to fit class time requirements, help students that are ahead or behind, provide alternate explanations of the material, and other relevant lesson planning tasks. Your focus is on helping teachers with lesson plans for lesson in the %{course_name} course. The teacher will either ask you questions about the current lesson plan and resources or ask you to make changes to or create new material for the lesson. When creating new material for the lesson, you must provide all the information a teacher needs. For example, if asked to create a quiz you should also provide the answer key. Your job is to use the information from the search results to help the teacher to the best of your ability, asking clarifying questions if needed. Your responses should be warm and helpful because you're the best lesson planner there could be, and you know all about computer science education.

--- a/dashboard/test/helpers/ai_diff_bedrock_helper_test.rb
+++ b/dashboard/test/helpers/ai_diff_bedrock_helper_test.rb
@@ -130,6 +130,39 @@ User: oh no"
     assert_equal prompt, expected_prompt
   end
 
+  test 'Testing prompt formatting for level, not preset, with very long student code' do
+    context = SharedConstants::AI_DIFF_CONTEXT[:LEVEL]
+    course_display_name = "Computer Science Discoveries"
+    unit_name = "CSD Unit 3"
+    lesson_name = "Test Lesson Name"
+    is_preset = false
+    section_contexts = nil
+    level_instructions = 'sudo make me a sandwich'
+    student_code = {student_code: 'a' * 100000}
+    prompt = AiDiffBedrockHelper.get_prompt_for_context(
+      context,
+      course_display_name,
+      unit_name,
+      lesson_name,
+      is_preset,
+      section_contexts,
+      level_instructions,
+      student_code
+    )
+    expected_prompt = "You are a teaching assistant named Aida. It's your job to help K-12 computer science teachers using the code.org platform plan their lessons and adjust lesson plans to fit class time requirements, help students that are ahead or behind, provide alternate explanations of the material, and other relevant lesson planning tasks. Your focus is on helping teachers with lesson plans for lesson in the Computer Science Discoveries course. The teacher will either ask you questions about the current lesson plan and resources or ask you to make changes to or create new material for the lesson. When creating new material for the lesson, you must provide all the information a teacher needs. For example, if asked to create a quiz you should also provide the answer key. Your job is to use the information from the search results to help the teacher to the best of your ability, asking clarifying questions if needed. Your responses should be warm and helpful because you're the best lesson planner there could be, and you know all about computer science education.
+            The current lesson this teacher is working on is Computer Science Discoveries CSD Unit 3, Test Lesson Name.
+
+            The teacher is currently working on a level within that lesson. The instructions for this task are: sudo make me a sandwich
+
+            The student code the teacher is viewing is: #{'a' * 75000}
+
+            Here are the search results in numbered order:
+            $search_results$
+
+      $output_format_instructions$"
+    assert_equal prompt, expected_prompt
+  end
+
   test 'Testing prompt formatting for lesson, not preset' do
     context = SharedConstants::AI_DIFF_CONTEXT[:LESSON]
     course_display_name = "Computer Science Discoveries"


### PR DESCRIPTION
I noticed [this new Honeybadger error](https://app.honeybadger.io/projects/3240/faults/123705654#notice-history) happening when creating a new AI TA thread in level context. The generated prompt was over the 100k character limit imposed by AWS. 

The prompt contains a couple of strings that could be very large: the level instructions and the student code. A quick search on the console shows the longest level instructions are currently ~16k characters long. This change truncates the student code to 75k characters so there's still room for even the longest level instructions and everything else that goes into the prompt.



## Links
[Honeybadger](https://app.honeybadger.io/projects/3240/faults/123705654#notice-history) 

## Testing story
New unit test verifying desired truncation behavior. Existing tests show no change for shorter code.
<!--  Does your change include appropriate tests?
      - If so, please describe how the tests included in this PR are sufficient.
      - If not, please explain why this change does not need to be tested. -->





## Follow-up work
Could hone this truncation strategy by calculating exactly how much length is remaining so that a little bit more of the very very huge code sample will be sent in, but this seems like enough of an edge case that I'm not too concerned about it.
<!--  List any clean-up or technical debt that will be addressed in future work.
      - Include Jira links where applicable.
      - Are there any known limitations or improvements planned? -->

