### PR TITLE
reduce single_unit_course? query count

### DIFF
--- a/dashboard/app/models/unit_group.rb
+++ b/dashboard/app/models/unit_group.rb
@@ -638,7 +638,7 @@ class UnitGroup < ApplicationRecord
   # rubocop:enable Naming/PredicateName
 
   def single_unit_course?
-    default_unit_group_units.one?
+    cached.default_unit_group_units.one?
   end
 
   def first_unit

--- a/dashboard/test/integration/caching_test.rb
+++ b/dashboard/test/integration/caching_test.rb
@@ -15,28 +15,28 @@ class CachingTest < ActionDispatch::IntegrationTest
     create_hourofcode_unit_and_levels
     setup_script_cache
 
-    assert_cached_queries(1) do
+    assert_cached_queries(0) do
       get '/hoc/1'
     end
     assert_response :success
   end
 
   test "should get other hoc course unit overview" do
-    assert_cached_queries(1) do
+    assert_cached_queries(0) do
       get "/courses/#{@other_hoc_course.name}/units/1"
     end
     assert_response :success
   end
-  #TODO: Figure out if we can bring single_unit_course? down to 0 queries again
+
   test "should get show of other hoc course level 1" do
-    assert_cached_queries(1) do
+    assert_cached_queries(0) do
       get "/courses/#{@other_hoc_course.name}/units/1/lessons/1/levels/1"
     end
     assert_response :success
   end
 
   test "should get show of other hoc course level 10 twice" do
-    assert_cached_queries(1) do
+    assert_cached_queries(0) do
       get "/courses/#{@other_hoc_course.name}/units/1/lessons/1/levels/10"
     end
     assert_response :success
@@ -46,7 +46,7 @@ class CachingTest < ActionDispatch::IntegrationTest
     get "/courses/#{@other_hoc_course.name}/units/1/lessons/1/levels/1"
     assert_response :success
 
-    assert_cached_queries(1) do
+    assert_cached_queries(0) do
       get "/courses/#{@other_hoc_course.name}/units/1/lessons/1/levels/10"
     end
     assert_response :success
@@ -79,14 +79,14 @@ class CachingTest < ActionDispatch::IntegrationTest
   # end
 
   test "should get show of lesson 3 level 1 twice" do
-    assert_cached_queries(1) do
+    assert_cached_queries(0) do
       get "/courses/#{@multi_lesson_unit_group.name}/units/1/lessons/3/levels/1"
     end
     assert_response :success
   end
 
   test "should get show of lesson 3 level 1 and then level 10" do
-    assert_cached_queries(1) do
+    assert_cached_queries(0) do
       get "/courses/#{@multi_lesson_unit_group.name}/units/1/lessons/3/levels/10"
     end
     assert_response :success

--- a/dashboard/test/integration/db_query_test.rb
+++ b/dashboard/test/integration/db_query_test.rb
@@ -22,8 +22,8 @@ class DBQueryTest < ActionDispatch::IntegrationTest
       level: level,
       level_source: create(:level_source, level: level)
 )
-    #TODO: Figure out if we can bring single_unit_course? down to 0 queries again
-    assert_cached_queries(19) do
+
+    assert_cached_queries(18) do
       get course_unit_lesson_script_level_path(
         course_course_name: script.get_original_unit_group.name,
         unit_position: 1,
@@ -178,7 +178,7 @@ class DBQueryTest < ActionDispatch::IntegrationTest
     student.assign_script(unit)
     sign_in student
 
-    assert_cached_queries(22) do
+    assert_cached_queries(21) do
       get "/courses/#{course.name}/units/1/lessons/1/levels/1"
       assert_response :success
     end


### PR DESCRIPTION
This PR is to try and reduce the `unit_group.single_unit_course?` function once and for all. It was discovered during #68264 that the query count had increased for some tests. 

### Background
There have been a couple attempts to fix this issue in the past. 
- [Attempt 1](https://github.com/code-dot-org/code-dot-org/pull/65957/files#diff-e2172d22099b0f25366646fc780a03cad5198af1e0f0e74b87c58499558e4ce4): Use `default_unit_group_units` instead of `default_units`
- [Attempt 2](https://github.com/code-dot-org/code-dot-org/pull/67540/files): This is the same change that this PR is making, but it had to be [reverted](https://github.com/code-dot-org/code-dot-org/pull/67602) due to differences in environments. 

## Links

- Jira: [TEACH-2164](https://codedotorg.atlassian.net/browse/TEACH-2164)

## Testing story
Tests passing locally and on drone


## Deployment strategy
- Because query count tests seem to vary from environment to environment sometimes, I will be watching this closely as it goes through staging.

