### PR TITLE
AI Tutor: Deprecate UserPermission::AI_TUTOR_ACCESS

### DIFF
--- a/dashboard/app/controllers/aichat_events_controller.rb
+++ b/dashboard/app/controllers/aichat_events_controller.rb
@@ -115,7 +115,7 @@ class AichatEventsController < ApplicationController
   end
 
   private def can_log_aichat_events?(client_type)
-    current_user.has_aichat_access? || current_user.can_access_ai_tutor?(client_type)
+    current_user.has_aichat_access? || current_user.trust_chat_client?(client_type)
   end
 
   private def can_view_chat_history?(user_id)

--- a/dashboard/app/controllers/aichat_requests_controller.rb
+++ b/dashboard/app/controllers/aichat_requests_controller.rb
@@ -103,7 +103,7 @@ class AichatRequestsController < ApplicationController
 
   private def can_access_ai_tutor_chat_completion?(client_type)
     return false if DCDO.get("block_ai_tutor_chat_completion", false)
-    current_user.can_access_ai_tutor?(client_type)
+    current_user.trust_chat_client?(client_type)
   end
 
   private def can_access_aichat_chat_completion?

--- a/dashboard/app/models/concerns/user/ai_accessible.rb
+++ b/dashboard/app/models/concerns/user/ai_accessible.rb
@@ -11,16 +11,17 @@ module User::AiAccessible
   AI_TUTOR_EXPERIMENT_NAME = 'ai-tutor'
 
   # Chat apis trust the client to decide if it can access chat features
-  # This enables us to do things like turn on the tutor UI with a url param, or
-  # experiment with new lab types (flow lab) with low friction.
+  # This allows us the flexibility to do things like turn on the tutor UI
+  # with a url param, or experiment with new lab types with low friction.
   def trust_chat_client?(client_type)
     return true if client_type == SharedConstants::AI_CHAT_CLIENT_TYPES[:AI_TUTOR]
     return true if client_type == SharedConstants::AI_CHAT_CLIENT_TYPES[:FLOW_LAB]
     false
   end
 
-  # This should be used to inform the UI of when to set Tutor to "sleeping"
-  # on a level that would otherwise show Tutor.
+  # This was originally meant to be used to inform the UI of when to set Tutor to "sleeping"
+  # on a level that would otherwise show Tutor. It is currently unused while the
+  # permissions features for tutor and ai chat features in general are being shaped.
   def has_ai_tutor_access?
     return false if ai_tutor_access_denied || ai_tutor_feature_globally_disabled?
     teacher_in_ai_tutor_pilot? || in_ai_tutor_enabled_section_with_pilot_teacher?
@@ -45,13 +46,6 @@ module User::AiAccessible
 
   def has_aichat_access?
     teacher_can_access_ai_chat? || student_can_access_ai_chat?
-  end
-
-  def can_access_ai_tutor?(client_type)
-    # If the request is coming from AiTutor or FlowLab, trust the client to decide
-    # if it can access the chat backend. This allows easy testing of AiTutor using a url param.
-    client_type == SharedConstants::AI_CHAT_CLIENT_TYPES[:AI_TUTOR] ||
-      client_type == SharedConstants::AI_CHAT_CLIENT_TYPES[:FLOW_LAB]
   end
 
   private def ai_tutor_feature_globally_disabled?

--- a/dashboard/app/models/concerns/user/ai_accessible.rb
+++ b/dashboard/app/models/concerns/user/ai_accessible.rb
@@ -24,11 +24,11 @@ module User::AiAccessible
   # permissions features for tutor and ai chat features in general are being shaped.
   def has_ai_tutor_access?
     return false if ai_tutor_access_denied || ai_tutor_feature_globally_disabled?
-    teacher_in_ai_tutor_pilot? || in_ai_tutor_enabled_section_with_pilot_teacher?
+    in_ai_tutor_pilot? || in_ai_tutor_enabled_section_with_pilot_teacher?
   end
 
   def can_enable_ai_tutor?
-    !ai_tutor_feature_globally_disabled? && teacher_in_ai_tutor_pilot?
+    !ai_tutor_feature_globally_disabled? && in_ai_tutor_pilot?
   end
 
   def can_use_ai_iteration_tools?
@@ -57,7 +57,7 @@ module User::AiAccessible
       sections_as_student.any?(&:ai_tutor_enabled)
   end
 
-  private def teacher_in_ai_tutor_pilot?
-    teacher? && SingleUserExperiment.enabled?(user: self, experiment_name: AI_TUTOR_EXPERIMENT_NAME)
+  private def in_ai_tutor_pilot?
+    SingleUserExperiment.enabled?(user: self, experiment_name: AI_TUTOR_EXPERIMENT_NAME)
   end
 end

--- a/dashboard/app/models/concerns/user/ai_accessible.rb
+++ b/dashboard/app/models/concerns/user/ai_accessible.rb
@@ -10,30 +10,28 @@ module User::AiAccessible
 
   AI_TUTOR_EXPERIMENT_NAME = 'ai-tutor'
 
-  # TODO-AITUTOR: It looks like the only utility UserPermission::AI_TUTOR_ACCESS
-  # gives us at the moment is the ability for teachers to use AI Tutor on a level
-  # without impersonating a student. We could let teachers
-  # in the pilot use AI Tutor without a separate user permission.
-  def has_ai_tutor_access?
-    return false if ai_tutor_access_denied || ai_tutor_feature_globally_disabled?
-    permission?(UserPermission::AI_TUTOR_ACCESS) || in_ai_tutor_experiment_with_enabled_section?
+  # Chat apis trust the client to decide if it can access chat features
+  # This enables us to do things like turn on the tutor UI with a url param, or
+  # experiment with new lab types (flow lab) with low friction.
+  def trust_chat_client?(client_type)
+    return true if client_type == SharedConstants::AI_CHAT_CLIENT_TYPES[:AI_TUTOR]
+    return true if client_type == SharedConstants::AI_CHAT_CLIENT_TYPES[:FLOW_LAB]
+    false
   end
 
-  # TODO-AITUTOR: Decide if we need a different experiment
+  # This should be used to inform the UI of when to set Tutor to "sleeping"
+  # on a level that would otherwise show Tutor.
+  def has_ai_tutor_access?
+    return false if ai_tutor_access_denied || ai_tutor_feature_globally_disabled?
+    teacher_in_ai_tutor_pilot? || in_ai_tutor_enabled_section_with_pilot_teacher?
+  end
+
   def can_enable_ai_tutor?
-    !ai_tutor_feature_globally_disabled? && (permission?(UserPermission::AI_TUTOR_ACCESS) ||
-      SingleUserExperiment.enabled?(user: self, experiment_name: AI_TUTOR_EXPERIMENT_NAME))
+    !ai_tutor_feature_globally_disabled? && teacher_in_ai_tutor_pilot?
   end
 
   def can_use_ai_iteration_tools?
-    permission?(UserPermission::AI_TUTOR_ACCESS) && levelbuilder?
-  end
-
-  # TODO-AITUTOR: Remove this method when cleaning up tutor code.
-  def can_view_student_ai_chat_messages?
-    ai_tutor_courses = ['programming-fundamentals-aitutor-2024']
-    (sections.any?(&:assigned_csa?) || sections.any? {|s| ai_tutor_courses.include?(s.unit_group&.name)}) &&
-      SingleUserExperiment.enabled?(user: self, experiment_name: AI_TUTOR_EXPERIMENT_NAME)
+    levelbuilder?
   end
 
   def teacher_can_access_ai_chat?
@@ -60,8 +58,12 @@ module User::AiAccessible
     DCDO.get('ai-tutor-disabled', false)
   end
 
-  private def in_ai_tutor_experiment_with_enabled_section?
+  private def in_ai_tutor_enabled_section_with_pilot_teacher?
     Queries::User::TeacherEnabledExperiments.call(self).include?(AI_TUTOR_EXPERIMENT_NAME) &&
       sections_as_student.any?(&:ai_tutor_enabled)
+  end
+
+  private def teacher_in_ai_tutor_pilot?
+    teacher? && SingleUserExperiment.enabled?(user: self, experiment_name: AI_TUTOR_EXPERIMENT_NAME)
   end
 end

--- a/dashboard/app/models/user_permission.rb
+++ b/dashboard/app/models/user_permission.rb
@@ -44,6 +44,9 @@ class UserPermission < ApplicationRecord
     PROGRAM_MANAGER = 'program_manager'.freeze,
     # Grants ability to be the instructor of any course no matter instructor_audience
     UNIVERSAL_INSTRUCTOR = 'universal_instructor'.freeze,
+    # DEPRECATED. DO NOT USE.
+    # TODO: Clean up artifacts of this permission in all envs before removing it from the model.
+    AI_TUTOR_ACCESS = 'ai_tutor_access'.freeze,
     #  Grants access to an internal tool to pull AI-evaluated samples of student work
     STUDENT_WORK_ACCESS = 'student_work_access'.freeze,
   ].freeze

--- a/dashboard/app/models/user_permission.rb
+++ b/dashboard/app/models/user_permission.rb
@@ -44,8 +44,6 @@ class UserPermission < ApplicationRecord
     PROGRAM_MANAGER = 'program_manager'.freeze,
     # Grants ability to be the instructor of any course no matter instructor_audience
     UNIVERSAL_INSTRUCTOR = 'universal_instructor'.freeze,
-    # Grants access to use AI Tutor which uses AI Chat API
-    AI_TUTOR_ACCESS = 'ai_tutor_access'.freeze,
     #  Grants access to an internal tool to pull AI-evaluated samples of student work
     STUDENT_WORK_ACCESS = 'student_work_access'.freeze,
   ].freeze

--- a/dashboard/test/controllers/ai_iteration_controller_test.rb
+++ b/dashboard/test/controllers/ai_iteration_controller_test.rb
@@ -29,24 +29,10 @@ class AiIterationControllerTest < ActionController::TestCase
   method: :get,
   response: :forbidden
 
-  # Levelbuiilder cannot access the tools page
+  # Levelbuilder cannot access the tools page
   test_user_gets_response_for :tools,
   name: "levelbuilder_no_access_test",
   user: :levelbuilder,
   method: :get,
   response: :forbidden
-
-  # AI Tutor Access cannot access the tools page
-  test_user_gets_response_for :tools,
-  name: "ai_tutor_permissions_no_access_test",
-  user: :ai_tutor_access,
-  method: :get,
-  response: :forbidden
-
-  # AI Tutor Access + Levelbuilder can access the tools page
-  test_user_gets_response_for :tools,
-  name: "ai_iteration_tools_user_can_access_test",
-  user: :ai_iteration_tools_user,
-  method: :get,
-  response: :ok
 end

--- a/dashboard/test/controllers/ai_iteration_controller_test.rb
+++ b/dashboard/test/controllers/ai_iteration_controller_test.rb
@@ -29,10 +29,10 @@ class AiIterationControllerTest < ActionController::TestCase
   method: :get,
   response: :forbidden
 
-  # Levelbuilder cannot access the tools page
+  # Levelbuilder can access the tools page
   test_user_gets_response_for :tools,
-  name: "levelbuilder_no_access_test",
+  name: "levelbuilder_access_test",
   user: :levelbuilder,
   method: :get,
-  response: :forbidden
+  response: :success
 end

--- a/dashboard/test/controllers/student_work_sample_controller_test.rb
+++ b/dashboard/test/controllers/student_work_sample_controller_test.rb
@@ -38,18 +38,10 @@ class StudentWorkSampleControllerTest < ActionController::TestCase
   params: {level_id: 123, unit_id: 456},
   response: :forbidden
 
-  # Levelbuiilder cannot fetch student code samples
+  # Levelbuilder cannot fetch student code samples
   test_user_gets_response_for :fetch_student_code_samples,
   name: "levelbuilder_no_access_test",
   user: :levelbuilder,
-  method: :get,
-  params: {level_id: 123, unit_id: 456},
-  response: :forbidden
-
-  # AI Tutor Access cannot fetch student code samples
-  test_user_gets_response_for :fetch_student_code_samples,
-  name: "ai_tutor_permissions_no_access_test",
-  user: :ai_tutor_access,
   method: :get,
   params: {level_id: 123, unit_id: 456},
   response: :forbidden

--- a/dashboard/test/factories/factories.rb
+++ b/dashboard/test/factories/factories.rb
@@ -256,15 +256,8 @@ FactoryBot.define do
           authorized_teacher.save
         end
       end
-      factory :ai_tutor_access do
-        after(:create) do |ai_tutor_access|
-          ai_tutor_access.permission = UserPermission::AI_TUTOR_ACCESS
-          ai_tutor_access.save
-        end
-      end
       factory :ai_iteration_tools_user do
         after(:create) do |ai_iteration_tools_user|
-          ai_iteration_tools_user.permission = UserPermission::AI_TUTOR_ACCESS
           ai_iteration_tools_user.permission = UserPermission::LEVELBUILDER
           ai_iteration_tools_user.save
         end

--- a/dashboard/test/models/concerns/user/ai_accessible_test.rb
+++ b/dashboard/test/models/concerns/user/ai_accessible_test.rb
@@ -35,7 +35,13 @@ class UserAiAccessibleTest < ActiveSupport::TestCase
       _has_ai_tutor_access?.must_equal false
     end
 
-    it 'returns true if in experiment and section is enabled' do
+    it 'returns true if in pilot teachers enabled section' do
+      _has_ai_tutor_access?.must_equal true
+    end
+
+    it 'returns true if SingleUserExperiment is enabled' do
+      allow(Queries::User::TeacherEnabledExperiments).to receive(:call).with(user).and_return([])
+      allow(SingleUserExperiment).to receive(:enabled?).with(user: user, experiment_name: 'ai-tutor').and_return(true)
       _has_ai_tutor_access?.must_equal true
     end
   end
@@ -49,6 +55,7 @@ class UserAiAccessibleTest < ActiveSupport::TestCase
     end
 
     it 'returns true if SingleUserExperiment is enabled' do
+      allow(Queries::User::TeacherEnabledExperiments).to receive(:call).with(user).and_return([])
       allow(SingleUserExperiment).to receive(:enabled?).with(user: user, experiment_name: 'ai-tutor').and_return(true)
       _can_enable_ai_tutor?.must_equal true
     end

--- a/dashboard/test/models/concerns/user/ai_accessible_test.rb
+++ b/dashboard/test/models/concerns/user/ai_accessible_test.rb
@@ -9,7 +9,6 @@ class UserAiAccessibleTest < ActiveSupport::TestCase
   before do
     user.extend(User::AiAccessible)
 
-    allow(user).to receive(:permission?).with(UserPermission::AI_TUTOR_ACCESS).and_return(false)
     allow(user).to receive(:teachers).and_return([])
     allow(user).to receive(:sections_as_student).and_return([section])
     allow(user).to receive(:teacher?).and_return(false)
@@ -36,11 +35,6 @@ class UserAiAccessibleTest < ActiveSupport::TestCase
       _has_ai_tutor_access?.must_equal false
     end
 
-    it 'returns true if user has AI tutor permission' do
-      allow(user).to receive(:permission?).with(UserPermission::AI_TUTOR_ACCESS).and_return(true)
-      _has_ai_tutor_access?.must_equal true
-    end
-
     it 'returns true if in experiment and section is enabled' do
       _has_ai_tutor_access?.must_equal true
     end
@@ -54,11 +48,6 @@ class UserAiAccessibleTest < ActiveSupport::TestCase
       _can_enable_ai_tutor?.must_equal false
     end
 
-    it 'returns true if permission is present' do
-      allow(user).to receive(:permission?).with(UserPermission::AI_TUTOR_ACCESS).and_return(true)
-      _can_enable_ai_tutor?.must_equal true
-    end
-
     it 'returns true if SingleUserExperiment is enabled' do
       allow(SingleUserExperiment).to receive(:enabled?).with(user: user, experiment_name: 'ai-tutor').and_return(true)
       _can_enable_ai_tutor?.must_equal true
@@ -69,7 +58,6 @@ class UserAiAccessibleTest < ActiveSupport::TestCase
     subject(:can_use_ai_iteration_tools?) {user.can_use_ai_iteration_tools?}
 
     it 'returns true if user has permission and is a levelbuilder' do
-      allow(user).to receive(:permission?).with(UserPermission::AI_TUTOR_ACCESS).and_return(true)
       allow(user).to receive(:levelbuilder?).and_return(true)
       _can_use_ai_iteration_tools?.must_equal true
     end

--- a/dashboard/test/models/concerns/user_permission_grantee_test.rb
+++ b/dashboard/test/models/concerns/user_permission_grantee_test.rb
@@ -123,13 +123,6 @@ class UserPermissionGranteeTest < ActiveSupport::TestCase
     assert user.workshop_organizer?
   end
 
-  test 'ai_tutor_access?' do
-    user = create(:teacher)
-    refute user.ai_tutor_access?
-    user.permission = UserPermission::AI_TUTOR_ACCESS
-    assert user.ai_tutor_access?
-  end
-
   test 'grant admin permission logs to infrasecurity' do
     teacher = create(:teacher, :google_sso_provider, password: nil)
 


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

Cleans up the user permissions for ai tutor

 - Refactors ai_accessible to remove references to `UserPermission::AI_TUTOR_ACCESS` and rely on the `SingleUserExperiment` and enablement via `TeacherEnabledExperiments`. 
 - Refactors function naming to better match usage (`can_access_ai_tutor` -> `trust_chat_client`)
 - Update `can_use_ai_iteration_tools` and rely only on `levelbuilder?` for permission
 - Comment `AI_TUTOR_ACCESS` def to be removed later, since there are artifacts in dbs that need cleanup first.
 - Update UTs

## Links
<!--  Links to relevant external resources.
      - spec docs, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- Jira: https://codedotorg.atlassian.net/browse/LABS-1548

## Testing story
<!--  Does your change include appropriate tests?
      - If so, please describe how the tests included in this PR are sufficient.
      - If not, please explain why this change does not need to be tested. -->

Tested via UTs. Tutor permissions aren't currently hooked up to the frontend, since the original spec has gotten out of date given the new applications of tutor. 

## Follow-up work
<!--  List any clean-up or technical debt that will be addressed in future work.
      - Include Jira links where applicable.
      - Are there any known limitations or improvements planned? -->

 - clean up artifacts and remove from model https://codedotorg.atlassian.net/browse/LABS-1637
    