### PR TITLE
Fix Violations of and Enable `FactoryBot/AssociationStyle`

### DIFF
--- a/.config/rubocop/new.yml
+++ b/.config/rubocop/new.yml
@@ -12,6 +12,8 @@ Lint/MixedCaseRange: # new in 1.53
   Enabled: true
 Lint/RedundantRegexpQuantifiers: # new in 1.53
   Enabled: true
+FactoryBot/AssociationStyle:
+  Enabled: true
 FactoryBot/ConsistentParenthesesStyle:
   Enabled: true
 FactoryBot/ExcessiveCreateList: # new in 2.25

--- a/.config/rubocop/todo.yml
+++ b/.config/rubocop/todo.yml
@@ -470,10 +470,6 @@ FactoryBot/FactoryClassName:
 FactoryBot/FactoryAssociationWithStrategy: # new in 2.23
   Enabled: false
 
-# Offense count: 111
-FactoryBot/AssociationStyle: # new in 2.23
-  Enabled: false
-
 # Offense count: 6
 FactoryBot/RedundantFactoryOption: # new in 2.23
   Enabled: false

--- a/dashboard/test/factories/curriculum_factories.rb
+++ b/dashboard/test/factories/curriculum_factories.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :reference_guide do
-    association :course_version
+    course_version
 
     sequence(:key) {|n| "bogus-reference-guide-#{n}"}
     display_name {"Sample Reference Guide"}

--- a/dashboard/test/factories/factories.rb
+++ b/dashboard/test/factories/factories.rb
@@ -37,19 +37,19 @@ FactoryBot.define do
   factory :course_version do
     sequence(:key) {|n| "202#{n - 1}"}
     sequence(:display_name) {|n| "2#{n - 1}-2#{n}"}
-    association :course_offering
+    course_offering
     with_unit_group
 
     trait :with_unit_group do
-      association(:content_root, factory: :unit_group)
+      content_root factory: %i[unit_group]
     end
 
     trait :with_single_unit_course do
-      association(:content_root, factory: :single_unit_course)
+      content_root factory: %i[single_unit_course]
     end
 
     trait :with_csp_unit_group do
-      association(:content_root, factory: :csp_course)
+      content_root factory: %i[csp_course]
     end
   end
 
@@ -777,12 +777,12 @@ FactoryBot.define do
   end
 
   factory :user_facilitator_info, class: User::FacilitatorInfo do
-    association :user, factory: :facilitator
+    user factory: %i[facilitator]
     bio {Faker::Lorem.paragraph(sentence_count: 5).truncate(User::FacilitatorInfo::BIO_MAX_LENGTH)}
   end
 
   factory :authentication_option do
-    association :user
+    user
     sequence(:email) {|n| "testuser#{n}@example.com.xx"}
     credential_type {AuthenticationOption::EMAIL}
     authentication_id {SecureRandom.uuid}
@@ -1153,8 +1153,8 @@ FactoryBot.define do
   end
 
   factory :levels_skill do
-    association :level
-    association :skill
+    level
+    skill
   end
 
   factory :unit, aliases: [:script] do
@@ -1415,7 +1415,7 @@ FactoryBot.define do
   end
 
   factory :resource do
-    association :course_version
+    course_version
     url {'fake.url'}
     name {'fake name'}
   end
@@ -1426,7 +1426,7 @@ FactoryBot.define do
   end
 
   factory :vocabulary do
-    association :course_version
+    course_version
     sequence(:key, 'a') {|char| "vocab_#{char}"}
     word {'word'}
     definition {'definition'}
@@ -1444,19 +1444,19 @@ FactoryBot.define do
   end
 
   factory :programming_expression do
-    association :programming_environment
+    programming_environment
     sequence(:name) {|n| "programming expression #{n}"}
     sequence(:key) {|n| "programming-expression-#{n}"}
   end
 
   factory :programming_class do
-    association :programming_environment
+    programming_environment
     sequence(:name) {|n| "programming class #{n}"}
     sequence(:key) {|n| "programming-class-#{n}"}
   end
 
   factory :programming_method do
-    association :programming_class
+    programming_class
     sequence(:name) {|n| "programming method #{n}"}
     sequence(:key) {|n| "programming-method-#{n}"}
   end
@@ -1526,7 +1526,7 @@ FactoryBot.define do
   end
 
   factory :follower do
-    association :student_user, factory: %i[student sponsored]
+    student_user factory: %i[student sponsored]
 
     transient do
       section {nil}
@@ -1555,7 +1555,7 @@ FactoryBot.define do
     user {create(:teacher)}
     start_date {DateTime.now}
     last_confirmation_date {DateTime.now}
-    association :school_info
+    school_info
   end
 
   factory :peer_review do
@@ -1669,7 +1669,7 @@ FactoryBot.define do
   factory :school_info_without_country, class: SchoolInfo do
     school_type {SchoolInfo::SCHOOL_TYPE_PUBLIC}
     state {'WA'}
-    association :school_district
+    school_district
   end
 
   factory :school_info_non_us, class: SchoolInfo do
@@ -1693,7 +1693,7 @@ FactoryBot.define do
     country {'US'}
 
     trait :with_district do
-      association :school_district
+      school_district
     end
 
     trait :with_school do
@@ -1721,15 +1721,15 @@ FactoryBot.define do
   end
 
   factory :school_info_with_public_school_only, class: SchoolInfo do
-    association :school, factory: :public_school
+    school factory: %i[public_school]
   end
 
   factory :school_info_with_private_school_only, class: SchoolInfo do
-    association :school, factory: :private_school
+    school factory: %i[private_school]
   end
 
   factory :school_info_with_charter_school_only, class: SchoolInfo do
-    association :school, factory: :charter_school
+    school factory: %i[charter_school]
   end
 
   factory :school_info_us_public, parent: :school_info_us do
@@ -1821,7 +1821,7 @@ FactoryBot.define do
     zip {"98122"}
 
     trait :with_district do
-      association :school_district
+      school_district
     end
 
     trait :is_high_school do
@@ -1909,8 +1909,8 @@ FactoryBot.define do
   end
 
   factory :regional_partners_school_district do
-    association :school_district
-    association :regional_partner
+    school_district
+    regional_partner
   end
 
   factory :channel_token do
@@ -1918,7 +1918,7 @@ FactoryBot.define do
     # Note: This creates channel_tokens where the channel is NOT an accurately
     # encrypted version of storage_app_id/app_id
     storage_app_id {1}
-    association :level
+    level
     storage_id {storage_user.try(:id) || 2}
   end
 
@@ -1960,10 +1960,10 @@ FactoryBot.define do
   end
 
   factory :teacher_feedback do
-    association :student
-    association :teacher
-    association :level
-    association :script
+    student
+    teacher
+    level
+    script
 
     trait :with_script_level do
       after(:build) do |tf|
@@ -1983,8 +1983,8 @@ FactoryBot.define do
   end
 
   factory :code_review_comment do
-    association :commenter, factory: :student
-    association :code_review
+    commenter factory: %i[student]
+    code_review
 
     is_resolved {false}
     comment {'a note about the project'}
@@ -1992,12 +1992,12 @@ FactoryBot.define do
 
   factory :code_review_group do
     sequence(:name) {|n| "group_name_#{n}"}
-    association :section
+    section
   end
 
   factory :code_review_group_member do
-    association :follower
-    association :code_review_group
+    follower
+    code_review_group
   end
 
   factory :project_commit do
@@ -2007,8 +2007,8 @@ FactoryBot.define do
   end
 
   factory :teacher_score do
-    association :user_level
-    association :teacher
+    user_level
+    teacher
   end
 
   factory :contact_rollups_raw do
@@ -2045,7 +2045,7 @@ FactoryBot.define do
   end
 
   factory :lti_feedback, class: 'Lti::Feedback' do
-    association :user, factory: :teacher
+    user factory: %i[teacher]
 
     locale {I18n.locale.to_s}
     satisfied {true}
@@ -2114,7 +2114,7 @@ FactoryBot.define do
   end
 
   factory :new_feature_feedback do
-    association :user, factory: :teacher
+    user factory: %i[teacher]
 
     form_key {'progress_v2'}
     satisfied {true}
@@ -2138,8 +2138,8 @@ FactoryBot.define do
   end
 
   factory :rubric do
-    association :lesson
-    association :level
+    lesson
+    level
 
     trait :with_learning_goals do
       transient do
@@ -2177,7 +2177,7 @@ FactoryBot.define do
   end
 
   factory :learning_goal do
-    association :rubric
+    rubric
     position {0}
     learning_goal {"Test Learning Goal"}
     ai_enabled {false}
@@ -2203,15 +2203,15 @@ FactoryBot.define do
   end
 
   factory :learning_goal_evidence_level do
-    association :learning_goal
+    learning_goal
     understanding {0}
     teacher_description {"Description for teacher"}
   end
 
   factory :learning_goal_teacher_evaluation do
-    association :learning_goal
-    association :teacher, factory: :teacher
-    association :user, factory: :student
+    learning_goal
+    teacher factory: %i[teacher]
+    user factory: %i[student]
     understanding {0}
   end
 
@@ -2222,21 +2222,21 @@ FactoryBot.define do
 
     user {student}
     project_id {789}
-    association :requester, factory: :teacher
-    association :rubric
+    requester factory: %i[teacher]
+    rubric
     status {1}
     project_version {"1"}
   end
 
   factory :learning_goal_ai_evaluation do
-    association :learning_goal
-    association :rubric_ai_evaluation
+    learning_goal
+    rubric_ai_evaluation
     understanding {0}
     ai_confidence {1}
   end
 
   factory :learning_goal_ai_evaluation_feedback do
-    association :learning_goal_ai_evaluation
+    learning_goal_ai_evaluation
     teacher_id {0}
     ai_feedback_approval {false}
     false_positive {false}
@@ -2252,9 +2252,9 @@ FactoryBot.define do
   end
 
   factory :user_level_skill_evaluation do
-    association :student, factory: :student
-    association :level
-    association :unit
+    student factory: %i[student]
+    level
+    unit
     evaluator {"AI"}
     evaluation {"Great"}
     evaluation_criteria {"Does the student's work on this level demonstrate the skill?"}
@@ -2262,9 +2262,9 @@ FactoryBot.define do
   end
 
   factory :user_level_evaluation do
-    association :student, factory: :student
-    association :level
-    association :unit
+    student factory: %i[student]
+    level
+    unit
     code_version {"4s&7ya"}
     evaluator {"AI"}
     evaluation {"Ok"}
@@ -2273,18 +2273,18 @@ FactoryBot.define do
   end
 
   factory :potential_teacher do
-    association :script
+    script
     name {"foosbars"}
     email {"foobar@example.com"}
     receives_marketing {true}
   end
 
   factory :aichat_event do
-    association :user
+    user
   end
 
   factory :aichat_request do
-    association :user
+    user
     model_customizations {{temperature: 0.5, retrievalContexts: ["test"], systemPrompt: "test", selectedModelId: "test"}}
     new_message {{chatMessageText: "hello", role: 'user', status: 'unknown', timestamp: Time.now.to_i}}
     stored_messages {[]}
@@ -2294,14 +2294,14 @@ FactoryBot.define do
   end
 
   factory :aidiff_thread do
-    association :user
+    user
     external_id {"1234"}
     llm_version {"dummy_llm"}
     context_type {"general"}
   end
 
   factory :aidiff_message do
-    association :aidiff_thread, factory: :aidiff_thread
+    aidiff_thread factory: %i[aidiff_thread]
     external_id {"1234"}
     role {:assistant}
     content {"Lorem ipsum"}
@@ -2333,13 +2333,13 @@ FactoryBot.define do
   end
 
   factory :sign_in do
-    association :user
+    user
     sign_in_at {Time.now.utc}
     sign_in_count {1}
   end
 
   factory :user_data_retention_status, class: 'User::DataRetentionStatus' do
-    association :user
+    user
   end
 
   factory :foorm_submission, class: 'Foorm::Submission' do
@@ -2355,12 +2355,12 @@ FactoryBot.define do
   end
 
   factory :simple_survey_submission, class: 'Foorm::SimpleSurveySubmission' do
-    association :user
-    association :simple_survey_form
+    user
+    simple_survey_form
   end
 
   factory :misc_survey, class: 'Pd::MiscSurvey' do
-    association :user
+    user
     form_id {1}
   end
 end

--- a/dashboard/test/factories/foorm_factories.rb
+++ b/dashboard/test/factories/foorm_factories.rb
@@ -103,22 +103,22 @@ FactoryBot.define do
   end
 
   factory :pd_workshop_foorm_submission, class: 'Pd::WorkshopSurveyFoormSubmission' do
-    association :pd_workshop, factory: :csd_summer_workshop
-    association :user, factory: :teacher
-    association :foorm_submission, factory: :basic_foorm_submission
+    pd_workshop factory: %i[csd_summer_workshop]
+    user factory: %i[teacher]
+    foorm_submission factory: %i[basic_foorm_submission]
   end
 
   factory :day_5_workshop_foorm_submission, class: 'Pd::WorkshopSurveyFoormSubmission' do
-    association :pd_workshop, factory: :csd_summer_workshop
-    association :user, factory: :teacher
+    pd_workshop factory: %i[csd_summer_workshop]
+    user factory: %i[teacher]
     day {5}
 
     trait :answers_low do
-      association :foorm_submission, factory: [:daily_workshop_day_5_foorm_submission, :answers_low]
+      foorm_submission factory: %i[daily_workshop_day_5_foorm_submission answers_low]
     end
 
     trait :answers_high do
-      association :foorm_submission, factory: [:daily_workshop_day_5_foorm_submission, :answers_high]
+      foorm_submission factory: %i[daily_workshop_day_5_foorm_submission answers_high]
     end
   end
 
@@ -207,11 +207,11 @@ FactoryBot.define do
   end
 
   factory :pd_pre_workshop_foorm_submission, class: 'Pd::WorkshopSurveyFoormSubmission' do
-    association :pd_workshop, factory: :csd_summer_workshop
-    association :user, factory: :teacher
+    pd_workshop factory: %i[csd_summer_workshop]
+    user factory: %i[teacher]
     day {0}
 
-    association :foorm_submission, factory: :pre_workshop_foorm_submission
+    foorm_submission factory: %i[pre_workshop_foorm_submission]
   end
 
   # this factory uses the real summer workshop pre survey.
@@ -231,16 +231,16 @@ FactoryBot.define do
   end
 
   factory :day_0_workshop_foorm_submission, class: 'Pd::WorkshopSurveyFoormSubmission' do
-    association :pd_workshop, factory: :csd_summer_workshop
-    association :user, factory: :teacher
+    pd_workshop factory: %i[csd_summer_workshop]
+    user factory: %i[teacher]
     day {0}
 
     trait :answers_low do
-      association :foorm_submission, factory: [:daily_workshop_day_0_foorm_submission, :answers_low]
+      foorm_submission factory: %i[daily_workshop_day_0_foorm_submission answers_low]
     end
 
     trait :answers_high do
-      association :foorm_submission, factory: [:daily_workshop_day_0_foorm_submission, :answers_high]
+      foorm_submission factory: %i[daily_workshop_day_0_foorm_submission answers_high]
     end
   end
 
@@ -301,20 +301,20 @@ FactoryBot.define do
   end
 
   factory :csf_intro_post_workshop_submission, class: 'Pd::WorkshopSurveyFoormSubmission' do
-    association :user, factory: :teacher
-    association :pd_workshop, factory: :csf_101_workshop
+    user factory: %i[teacher]
+    pd_workshop factory: %i[csf_101_workshop]
 
     trait :answers_low do
-      association :foorm_submission, factory: [:csf_intro_post_foorm_submission, :answers_low]
+      foorm_submission factory: %i[csf_intro_post_foorm_submission answers_low]
     end
 
     trait :answers_high do
-      association :foorm_submission, factory: [:csf_intro_post_foorm_submission, :answers_high]
+      foorm_submission factory: %i[csf_intro_post_foorm_submission answers_high]
     end
   end
 
   factory :facilitator_post_survey_workshop_submission, class: 'Pd::WorkshopSurveyFoormSubmission' do
-    association :foorm_submission, factory: :facilitator_post_survey_foorm_submission
+    foorm_submission factory: %i[facilitator_post_survey_foorm_submission]
   end
 
   factory :facilitator_post_survey_foorm_submission, class: 'Foorm::Submission' do
@@ -374,15 +374,15 @@ FactoryBot.define do
 
   factory :csf_intro_post_facilitator_workshop_submission, class: 'Pd::WorkshopSurveyFoormSubmission' do
     facilitator_id {1}
-    association :pd_workshop, factory: :csf_101_workshop
-    association :user, factory: :teacher
+    pd_workshop factory: %i[csf_101_workshop]
+    user factory: %i[teacher]
 
     trait :answers_low do
-      association :foorm_submission, factory: [:csf_intro_post_facilitator_foorm_submission, :answers_low]
+      foorm_submission factory: %i[csf_intro_post_facilitator_foorm_submission answers_low]
     end
 
     trait :answers_high do
-      association :foorm_submission, factory: [:csf_intro_post_facilitator_foorm_submission, :answers_high]
+      foorm_submission factory: %i[csf_intro_post_facilitator_foorm_submission answers_high]
     end
   end
 
@@ -1254,21 +1254,21 @@ FactoryBot.define do
   end
 
   factory :foorm_simple_survey_submission, class: 'Foorm::SimpleSurveySubmission' do
-    association :foorm_submission, factory: :basic_foorm_submission
-    association :simple_survey_form, factory: :foorm_simple_survey_form
+    foorm_submission factory: %i[basic_foorm_submission]
+    simple_survey_form factory: %i[foorm_simple_survey_form]
   end
 
   # Build Your Own Workshop survey submission factory
   factory :build_your_own_workshop_foorm_submission, class: 'Pd::WorkshopSurveyFoormSubmission' do
-    association :pd_workshop, factory: :csd_summer_workshop
-    association :user, factory: :teacher
+    pd_workshop factory: %i[csd_summer_workshop]
+    user factory: %i[teacher]
 
     trait :answers_low do
-      association :foorm_submission, factory: [:build_your_own_workshop_post_foorm_submission, :answers_low]
+      foorm_submission factory: %i[build_your_own_workshop_post_foorm_submission answers_low]
     end
 
     trait :answers_high do
-      association :foorm_submission, factory: [:build_your_own_workshop_post_foorm_submission, :answers_high]
+      foorm_submission factory: %i[build_your_own_workshop_post_foorm_submission answers_high]
     end
   end
 

--- a/dashboard/test/factories/pd_factories.rb
+++ b/dashboard/test/factories/pd_factories.rb
@@ -58,7 +58,7 @@ FactoryBot.define do
     transient do
       duration_hours {6}
     end
-    association :workshop, factory: :workshop
+    workshop factory: %i[workshop]
     start {Time.zone.today + 9.hours}
     self.end {start + duration_hours.hours}
     session_format {Pd::SharedWorkshopConstants::PD_SESSION_FORMATS.first[:value]}
@@ -69,7 +69,7 @@ FactoryBot.define do
   end
 
   factory :pd_teachercon_survey, class: 'Pd::TeacherconSurvey' do
-    association :pd_enrollment, factory: :pd_enrollment, strategy: :create
+    pd_enrollment factory: %i[pd_enrollment], strategy: :create
 
     after(:build) do |survey, _|
       if survey.form_data.presence.nil?
@@ -152,17 +152,17 @@ FactoryBot.define do
   end
 
   factory :pd_facilitator_teachercon_attendance, class: 'Pd::FacilitatorTeacherconAttendance' do
-    association :user, factory: :facilitator, strategy: :create
+    user factory: %i[facilitator], strategy: :create
     tc1_arrive {Date.new(2017, 8, 23)}
     tc1_depart {Date.new(2017, 8, 29)}
   end
 
   factory :pd_enrollment, class: 'Pd::Enrollment' do
-    association :workshop
+    workshop
     sequence(:first_name) {|n| "Participant#{n}"}
     last_name {'Codeberg'}
     email {"participant_#{SecureRandom.hex(10)}@example.com.xx"}
-    association :school_info
+    school_info
     code {SecureRandom.hex(10)}
 
     trait :from_user do
@@ -179,7 +179,7 @@ FactoryBot.define do
   end
 
   factory :pd_scholarship_info, class: 'Pd::ScholarshipInfo' do
-    association :user, factory: :teacher
+    user factory: %i[teacher]
 
     course {Pd::Workshop::COURSE_KEY_MAP[Pd::Workshop::COURSE_CSP]}
     application_year {Pd::SharedApplicationConstants::YEAR_19_20}
@@ -187,13 +187,13 @@ FactoryBot.define do
   end
 
   factory :pd_attendance, class: 'Pd::Attendance' do
-    association :session, factory: :pd_session
-    association :teacher
+    session factory: %i[pd_session]
+    teacher
   end
 
   factory :pd_attendance_no_account, class: 'Pd::Attendance' do
-    association :session, factory: :pd_session
-    association :enrollment, factory: :pd_enrollment
+    session factory: %i[pd_session]
+    enrollment factory: %i[pd_enrollment]
   end
 
   # Creates a teacher optionally enrolled in a workshop,
@@ -233,14 +233,18 @@ FactoryBot.define do
   end
 
   factory :pd_course_facilitator, class: 'Pd::CourseFacilitator' do
-    association :facilitator
+    facilitator
     course {Pd::Workshop::COURSES.first}
   end
 
   factory :pd_pre_workshop_survey, class: 'Pd::PreWorkshopSurvey' do
     # Always create (never build) the associated Enrollment to guarantee that
-    # the through association to workshops will work
+    # the through association to workshops will work.
+    # rubocop:disable FactoryBot/AssociationStyle
+    # The `strategy` option necessitates an explicit `association`; see
+    # https://github.com/thoughtbot/factory_bot/blob/v6.2.1/GETTING_STARTED.md#build-strategies-1
     association :pd_enrollment, strategy: :create
+    # rubocop:enable FactoryBot/AssociationStyle
   end
 
   factory :pd_regional_partner_contact, class: 'Pd::RegionalPartnerContact' do
@@ -310,7 +314,7 @@ FactoryBot.define do
   end
 
   factory :pd_regional_partner_mapping, class: 'Pd::RegionalPartnerMapping' do
-    association :regional_partner
+    regional_partner
     state {'WA'}
   end
 
@@ -413,7 +417,7 @@ FactoryBot.define do
   end
 
   factory :pd_teacher_application, class: 'Pd::Application::TeacherApplication' do
-    association :user, factory: [:teacher, :with_school_info], strategy: :create
+    user factory: %i[teacher with_school_info], strategy: :create
     course {'csp'}
     transient do
       form_data_hash {build(:pd_teacher_application_hash_common, course.to_sym)}
@@ -472,7 +476,7 @@ FactoryBot.define do
   end
 
   factory :pd_principal_approval_application, class: 'Pd::Application::PrincipalApprovalApplication' do
-    association :teacher_application, factory: :pd_teacher_application
+    teacher_application factory: %i[pd_teacher_application]
     course {'csp'}
     transient do
       approved {'Yes'}
@@ -492,18 +496,18 @@ FactoryBot.define do
   factory :pd_workshop_daily_survey, class: 'Pd::WorkshopDailySurvey' do
     form_id {12345}
     submission_id {(Pd::WorkshopDailySurvey.maximum(:submission_id) || 0) + 1}
-    association :pd_workshop
-    association :user
+    pd_workshop
+    user
     day {5}
   end
 
   factory :pd_workshop_facilitator_daily_survey, class: 'Pd::WorkshopFacilitatorDailySurvey' do
     form_id {12345}
     submission_id {(Pd::WorkshopFacilitatorDailySurvey.maximum(:submission_id) || 0) + 1}
-    association :pd_session
+    pd_session
     pd_workshop {pd_session.workshop}
-    association :user
-    association :facilitator
+    user
+    facilitator
     day {5}
   end
 
@@ -513,7 +517,7 @@ FactoryBot.define do
   end
 
   factory :pd_application_email, class: 'Pd::Application::Email' do
-    association :application, factory: :pd_teacher_application
+    application factory: %i[pd_teacher_application]
     email_type {'confirmation'}
     application_status {'confirmation'}
     to {application.user.email}

--- a/dashboard/test/factories/workshop_factories.rb
+++ b/dashboard/test/factories/workshop_factories.rb
@@ -29,7 +29,7 @@ FactoryBot.define do
       assign_session_code {false}
     end
 
-    association :organizer, factory: :workshop_organizer
+    organizer factory: %i[workshop_organizer]
     course {Pd::Workshop::COURSE_CSP}
     subject {Pd::Workshop::SUBJECTS[course].try(&:second)}
     capacity {10}


### PR DESCRIPTION
Follow-up to https://github.com/code-dot-org/code-dot-org/pull/67451, which added `rubocop-factory_bot` and enabled a subset of the rules. This PR simply enables one more rule in that set.

Specifically, it enables `FactoryBot/AssociationStyle`, which by default encourages us to define associations using implicit rather than explicit syntax; see https://github.com/thoughtbot/factory_bot/blob/v6.2.1/GETTING_STARTED.md#inline-definition

TBH, I personally prefer explicit over implicit as a general rule; but what I prefer even more than that is following recommended standards and avoiding unnecessary exceptions. I'm inclined to say it's worth enabling the rule with its default configuration for that reason, but I'm very open to feedback if anyone thinks otherwise.

What do y'all think?

## Links

https://www.rubydoc.info/gems/rubocop-factory_bot/RuboCop/Cop/FactoryBot/AssociationStyle