### PR TITLE
Remove deprecated courses from UI tests pass 2

### DIFF
--- a/dashboard/test/ui/features/star_labs/artist.feature
+++ b/dashboard/test/ui/features/star_labs/artist.feature
@@ -1,14 +1,14 @@
 Feature: Playing the Artist Game
 
 Background:
-  Given I am on "http://studio.code.org/courses/20-hour/units/1/lessons/5/levels/1?noautoplay=true"
+  Given I am on "http://studio.code.org/courses/allthethingscourse/units/1/lessons/3/levels/2?noautoplay=true"
   And I wait for the lab page to fully load
   And I dismiss the login reminder
   Then element "#runButton" is visible
   And element "#resetButton" is hidden
 
 Scenario: Loading the first level
-  Then there's an image "video_thumbnails/artist_intro"
+  Then there's an image "video_thumbnails/C2_artist_intro"
   Then there's an image "artist/small_static_avatar"
 
 Scenario: Winning the first level
@@ -17,7 +17,7 @@ Scenario: Winning the first level
   And element "#resetButton" is visible
   And I wait until element ".congrats" is visible
   And I press "continue-button"
-  And I wait until I am on "http://studio.code.org/courses/20-hour/units/1/lessons/5/levels/2"
+  And I wait until I am on "http://studio.code.org/courses/allthethingscourse/units/1/lessons/3/levels/3"
 
 Scenario: Losing the first level
   Then I've initialized the workspace with losing artist blocks
@@ -25,7 +25,7 @@ Scenario: Losing the first level
   And element "#resetButton" is visible
   And I wait until element ".uitest-topInstructions-inline-feedback" is visible
   And element ".uitest-topInstructions-inline-feedback" is visible
-  And element ".uitest-topInstructions-inline-feedback" has escaped text "Keep coding! Something's not quite right yet."
+  And element ".uitest-topInstructions-inline-feedback" has escaped text "Not quite. Try using a block you aren’t using yet."
   And I press "resetButton"
   And element "#runButton" is visible
   And element "#resetButton" is hidden

--- a/dashboard/test/ui/features/star_labs/bee.feature
+++ b/dashboard/test/ui/features/star_labs/bee.feature
@@ -1,7 +1,7 @@
 Feature: Complete a bee level
 
 Scenario: Complete Bee Conditions 4-5 Level 3
-  Given I am on "http://studio.code.org/courses/course3/units/1/lessons/7/levels/3?noautoplay=true"
+  Given I am on "http://studio.code.org/courses/allthethingscourse/units/1/lessons/4/levels/4?noautoplay=true"
   And I wait for the lab page to fully load
   When I dismiss the login reminder
   # repeat to when run
@@ -9,4 +9,4 @@ Scenario: Complete Bee Conditions 4-5 Level 3
   And I press "runButton"
   And I wait to see ".congrats"
   And element ".congrats" is visible
-  And element ".congrats" has text "Congratulations! You completed Puzzle 3."
+  And element ".congrats" has text "Congratulations! You completed Puzzle 4."

--- a/dashboard/test/ui/features/star_labs/bounce.feature
+++ b/dashboard/test/ui/features/star_labs/bounce.feature
@@ -40,7 +40,7 @@ Scenario: Complete Level 5
   And element ".congrats" has text "Congratulations! You completed Puzzle 5."
 
 Scenario: Complete Bounce freeplay level
-  Given I am on "http://studio.code.org/courses/course3/units/1/lessons/15/levels/10?noautoplay=true"
+  Given I am on "http://studio.code.org/courses/events/units/1/lessons/1/levels/10?noautoplay=true"
   And I wait for the lab page to fully load
   And I dismiss the login reminder
   And element "#finishButton" is not visible

--- a/dashboard/test/ui/features/star_labs/signin_callout.feature
+++ b/dashboard/test/ui/features/star_labs/signin_callout.feature
@@ -1,14 +1,9 @@
 Feature: Viewing and dismissing the login callout
 # Build errors on clearing cookies on mobile, ie
 
-Scenario: Should see callout on 20-hour farmer lesson
-  Given I am on "http://studio.code.org/courses/20-hour/units/1/lessons/9/levels/1?noautoplay=true"
-  And I wait for the lab page to fully load
-  And element ".uitest-signincallout" is visible
-
 @no_mobile
 Scenario: Should be able to clear cookies and session storage to see callout again
-  Given I am on "http://studio.code.org/courses/20-hour/units/1/lessons/9/levels/1?noautoplay=true"
+  Given I am on "http://studio.code.org/courses/coursea-2020/units/1/lessons/4/levels/2?noautoplay=true"
   And I wait for the lab page to fully load
   And element ".uitest-signincallout" is visible
   And I dismiss the login reminder
@@ -18,12 +13,6 @@ Scenario: Should be able to clear cookies and session storage to see callout aga
   And I reload the page
   And I wait for the lab page to fully load
   And element ".uitest-signincallout" is visible
-
-@as_student
-Scenario: Should not see callout on farmer lesson if logged in
-  Given I am on "http://studio.code.org/courses/20-hour/units/1/lessons/9/levels/1?noautoplay=true"
-  And I wait for the lab page to fully load
-  And element ".uitest-signincallout" is not visible
 
 @as_student
 Scenario: Should not see callout on CSF coursea lesson if logged in

--- a/dashboard/test/ui/features/star_labs/signin_callout2.feature
+++ b/dashboard/test/ui/features/star_labs/signin_callout2.feature
@@ -2,11 +2,11 @@ Feature: Viewing and dismissing the login callout
 
   @no_mobile
   Scenario: Clicking anywhere should dismiss the login reminder
-    Given I am on "http://studio.code.org/courses/20-hour/units/1/lessons/9/levels/1?noautoplay=true"
+    Given I am on "http://studio.code.org/courses/coursea-2020/units/1/lessons/5/levels/3?noautoplay=true"
     And I wait for the lab page to fully load
     And element ".uitest-signincallout" is visible
     And I dismiss the login reminder
-    And element ".instructions-markdown p" has text "Hi, I'm a farmer. I need your help to flatten the field on my farm so it's ready for planting. Move me to the pile of dirt and use the \"remove\" block to remove it."
+    And element ".instructions-markdown p" has text "Use 2 movement blocks to get the Scrat to the acorn."
     Then element "#runButton" is visible
     And I delete the cookie named "hide_signin_callout"
     And I clear session storage
@@ -20,7 +20,7 @@ Feature: Viewing and dismissing the login callout
 
   @no_mobile
   Scenario: After dismissing the callout, it should not reappear upon refresh
-    Given I am on "http://studio.code.org/courses/20-hour/units/1/lessons/9/levels/1?noautoplay=true"
+    Given I am on "http://studio.code.org/courses/coursea-2020/units/1/lessons/5/levels/3?noautoplay=true"
     And I wait for the lab page to fully load
     And element ".uitest-signincallout" is visible
     And I dismiss the login reminder
@@ -40,7 +40,7 @@ Feature: Viewing and dismissing the login callout
     And I clear session storage
 
   Scenario: Should be immediately redirected to sign in if pressing sign in button
-    Given I am on "http://studio.code.org/courses/20-hour/units/1/lessons/9/levels/1?noautoplay=true"
+    Given I am on "http://studio.code.org/courses/coursea-2020/units/1/lessons/2/levels/2?noautoplay=true"
     And I wait for the lab page to fully load
     And element ".uitest-signincallout" is visible
     And I click selector ".header_button" if I see it

--- a/dashboard/test/ui/features/step_definitions/blockly_initialization_blocks.rb
+++ b/dashboard/test/ui/features/step_definitions/blockly_initialization_blocks.rb
@@ -19,7 +19,7 @@ And /^I've initialized the workspace with losing artist blocks$/ do
 end
 
 And /^I've initialized the workspace with bee blocks$/ do
-  load_json_blocks('{"blocks":{"languageVersion":0,"blocks":[{"type":"when_run","x":16,"y":16,"next":{"block":{"type":"controls_repeat","id":"repeat","fields":{"TIMES":2},"inputs":{"DO":{"block":{"type":"maze_moveForward","next":{"block":{"type":"maze_moveForward","next":{"block":{"type":"bee_ifFlower","fields":{"LOC":"<field name=\"LOC\">atHoneycomb</field>"},"inputs":{"DO":{"block":{"type":"maze_honey"}}},"next":{"block":{"type":"maze_turn","fields":{"DIR":"<field name=\"DIR\">turnLeft</field>"}}}}}}}}}}}}}]}}')
+  load_json_blocks('{"blocks":{"languageVersion":0,"blocks":[{"type":"when_run","id":"AP;28]6Q8Q{IuPRO!Et@","x":16,"y":16,"deletable":false,"movable":false,"extraState":{},"next":{"block":{"type":"controls_repeat_dropdown","id":"B,oYg{6VhYF3_.B2Fx6D","fields":{"TIMES":"<field name=\\"TIMES\\" config=\\"3-10\\">3</field>"},"inputs":{"DO":{"block":{"type":"maze_moveForward","id":"is`0CmOudl^S_O!ubIdB"}}},"next":{"block":{"type":"bee_ifNectarAmount","id":"ifNectar","fields":{"ARG1":"<field name=\\"ARG1\\">nectarRemaining</field>","OP":"<field name=\\"OP\\">==</field>","ARG2":"1"},"inputs":{"DO":{"block":{"type":"maze_nectar","id":"getNectar"}}}}}}}}]}}')
 end
 
 And /^I've initialized the workspace with level 1 bounce blocks$/ do

--- a/dashboard/test/ui/features/teacher_tools/built_level.feature
+++ b/dashboard/test/ui/features/teacher_tools/built_level.feature
@@ -1,8 +1,0 @@
-Feature: Open a level built with level builder
-
-Background:
-  Given I am on "http://studio.code.org/courses/course1/units/1/lessons/4/levels/2"
-
-Scenario: The level loads
-  When I wait for the lab page to fully load
-  Then element "#codeWorkspace" is visible

--- a/dashboard/test/ui/features/teacher_tools/course_versions.feature
+++ b/dashboard/test/ui/features/teacher_tools/course_versions.feature
@@ -90,16 +90,6 @@ Scenario: Versions warning announcement on script overview page
   And element "#uitest-version-selector" is visible
   Then element ".announcement-notification:contains(newer version)" is not visible
 
-  # Generate progress in course 2
-  When I am on "http://studio.code.org/courses/course2/units/1/lessons/1/levels/1"
-  And I click selector ".next-lesson" once I see it
-  And I wait until current URL contains "/courses/course2/units/1/lessons/1/levels/2"
-
-  When I am on "http://studio.code.org/courses/course1/units/1"
-  And I wait until element "#script-title" is visible
-  And element "#uitest-version-selector" is not visible
-  Then element ".announcement-notification:contains(newer version)" is not visible
-
 @as_student
 @no_mobile
 Scenario: Switch versions using dropdown on script overview page


### PR DESCRIPTION
Another set of UI tests being moved off courses 1-4/20-hour and onto other curriculum. Where possible I tried to use allthethingscourse, but there are a couple exceptions.

I put some inline comments where I made particular decisions on tests.



