### PR TITLE
feat(tutor): add disabled state for ai chat

### DIFF
--- a/apps/i18n/aichat/en_us.json
+++ b/apps/i18n/aichat/en_us.json
@@ -11,7 +11,6 @@
   "aiCustomizations_selectedModel": "Selected model",
   "aiCustomizations_systemPrompt": "System prompt",
   "aiCustomizations_temperature": "Temperature",
-  "aiTutorDisabled": "AI Tutor is disabled for this level",
   "aiChatDisabled": "AI chat is currently disabled",
   "aria_flag": "flag",
   "aria_unflag": "unflag",

--- a/apps/i18n/aichat/en_us.json
+++ b/apps/i18n/aichat/en_us.json
@@ -11,6 +11,8 @@
   "aiCustomizations_selectedModel": "Selected model",
   "aiCustomizations_systemPrompt": "System prompt",
   "aiCustomizations_temperature": "Temperature",
+  "aiTutorDisabled": "AI Tutor is disabled for this level",
+  "aiChatDisabled": "AI chat is currently disabled",
   "aria_flag": "flag",
   "aria_unflag": "unflag",
   "aria_hideMessage": "hide message",

--- a/apps/src/aichat/context/aiChatDisabledContext.tsx
+++ b/apps/src/aichat/context/aiChatDisabledContext.tsx
@@ -3,11 +3,10 @@ import React, {
   FC,
   PropsWithChildren,
   useContext,
+  useCallback,
   useMemo,
   useState,
 } from 'react';
-
-import {queryParams} from '@cdo/apps/code-studio/utils';
 
 export interface AiChatDisabledContextValue {
   chatDisabled: boolean;
@@ -51,34 +50,51 @@ export const AiChatDisabledProvider: FC<AiChatDisabledProviderProps> = ({
   chatDisabledMessage,
   children,
 }) => {
-  // TODO: remove disabling chat via query param
-  const chatDisabledParam = !!queryParams('disable-ai-chat');
-  const chatDisabledMessageParam = queryParams('disable-ai-chat-message') as
-    | string
-    | undefined;
-
   const [state, setState] = useState<{
     chatDisabled: boolean;
     chatDisabledMessage?: string;
   }>(() => ({
-    chatDisabled: chatDisabled || chatDisabledParam,
-    chatDisabledMessage: chatDisabledMessage ?? chatDisabledMessageParam,
+    chatDisabled,
+    chatDisabledMessage,
   }));
+
+  const setChatDisabled = useCallback((chatDisabled: boolean) => {
+    setState(prevState =>
+      prevState.chatDisabled === chatDisabled
+        ? prevState
+        : {...prevState, chatDisabled}
+    );
+  }, []);
+
+  const setChatDisabledMessage = useCallback((chatDisabledMessage?: string) => {
+    setState(prevState =>
+      prevState.chatDisabledMessage === chatDisabledMessage
+        ? prevState
+        : {...prevState, chatDisabledMessage}
+    );
+  }, []);
+
+  const setChatDisabledState = useCallback(
+    (newState: {chatDisabled: boolean; chatDisabledMessage?: string}) => {
+      setState(prevState =>
+        prevState.chatDisabled === newState.chatDisabled &&
+        prevState.chatDisabledMessage === newState.chatDisabledMessage
+          ? prevState
+          : newState
+      );
+    },
+    []
+  );
 
   const value = useMemo<AiChatDisabledContextValue>(
     () => ({
       chatDisabled: state.chatDisabled,
       chatDisabledMessage: state.chatDisabledMessage,
-      setChatDisabled: (chatDisabled: boolean) =>
-        setState(prevState => ({...prevState, chatDisabled})),
-      setChatDisabledMessage: (chatDisabledMessage?: string) =>
-        setState(prevState => ({...prevState, chatDisabledMessage})),
-      setChatDisabledState: (newState: {
-        chatDisabled: boolean;
-        chatDisabledMessage?: string;
-      }) => setState(newState),
+      setChatDisabled,
+      setChatDisabledMessage,
+      setChatDisabledState,
     }),
-    [state]
+    [state, setChatDisabled, setChatDisabledMessage, setChatDisabledState]
   );
 
   return (

--- a/apps/src/aichat/context/aiChatDisabledContext.tsx
+++ b/apps/src/aichat/context/aiChatDisabledContext.tsx
@@ -1,0 +1,90 @@
+import React, {
+  createContext,
+  FC,
+  PropsWithChildren,
+  useContext,
+  useMemo,
+  useState,
+} from 'react';
+
+import {queryParams} from '@cdo/apps/code-studio/utils';
+
+export interface AiChatDisabledContextValue {
+  chatDisabled: boolean;
+  chatDisabledMessage?: string;
+  setChatDisabled: (chatDisabled: boolean) => void;
+  setChatDisabledMessage: (chatDisabledMessage?: string) => void;
+  setChatDisabledState: (state: {
+    chatDisabled: boolean;
+    chatDisabledMessage?: string;
+  }) => void;
+}
+
+const throwIfNoProvider = (fnName: string) => {
+  if (process.env.NODE_ENV !== 'production') {
+    throw new Error(
+      `useAiChatDisabled ${fnName} called without an AiChatDisabledProvider in the tree.`
+    );
+  }
+};
+
+// reading state values when not wrapped in a provider is okay, default is not disabled
+// but setting state will throw an error in non-production environments to ensure provider has been added
+const defaultContextValue: AiChatDisabledContextValue = {
+  chatDisabled: false,
+  chatDisabledMessage: undefined,
+  setChatDisabled: () => throwIfNoProvider('setChatDisabled'),
+  setChatDisabledMessage: () => throwIfNoProvider('setChatDisabledMessage'),
+  setChatDisabledState: () => throwIfNoProvider('setChatDisabledState'),
+};
+
+export const AiChatDisabledContext =
+  createContext<AiChatDisabledContextValue>(defaultContextValue);
+
+export type AiChatDisabledProviderProps = PropsWithChildren<{
+  chatDisabled?: boolean;
+  chatDisabledMessage?: string;
+}>;
+
+export const AiChatDisabledProvider: FC<AiChatDisabledProviderProps> = ({
+  chatDisabled = false,
+  chatDisabledMessage,
+  children,
+}) => {
+  // TODO: remove disabling chat via query param
+  const chatDisabledParam = !!queryParams('disable-ai-chat');
+  const chatDisabledMessageParam = queryParams('disable-ai-chat-message') as
+    | string
+    | undefined;
+
+  const [state, setState] = useState<{
+    chatDisabled: boolean;
+    chatDisabledMessage?: string;
+  }>(() => ({
+    chatDisabled: chatDisabled || chatDisabledParam,
+    chatDisabledMessage: chatDisabledMessage ?? chatDisabledMessageParam,
+  }));
+
+  const value = useMemo<AiChatDisabledContextValue>(
+    () => ({
+      chatDisabled: state.chatDisabled,
+      chatDisabledMessage: state.chatDisabledMessage,
+      setChatDisabled: (d: boolean) => setState(s => ({...s, chatDisabled: d})),
+      setChatDisabledMessage: (m?: string) =>
+        setState(s => ({...s, chatDisabledMessage: m})),
+      setChatDisabledState: (s: {
+        chatDisabled: boolean;
+        chatDisabledMessage?: string;
+      }) => setState(s),
+    }),
+    [state]
+  );
+
+  return (
+    <AiChatDisabledContext.Provider value={value}>
+      {children}
+    </AiChatDisabledContext.Provider>
+  );
+};
+
+export const useAiChatDisabled = () => useContext(AiChatDisabledContext);

--- a/apps/src/aichat/context/aiChatDisabledContext.tsx
+++ b/apps/src/aichat/context/aiChatDisabledContext.tsx
@@ -69,13 +69,14 @@ export const AiChatDisabledProvider: FC<AiChatDisabledProviderProps> = ({
     () => ({
       chatDisabled: state.chatDisabled,
       chatDisabledMessage: state.chatDisabledMessage,
-      setChatDisabled: (d: boolean) => setState(s => ({...s, chatDisabled: d})),
-      setChatDisabledMessage: (m?: string) =>
-        setState(s => ({...s, chatDisabledMessage: m})),
-      setChatDisabledState: (s: {
+      setChatDisabled: (chatDisabled: boolean) =>
+        setState(prevState => ({...prevState, chatDisabled})),
+      setChatDisabledMessage: (chatDisabledMessage?: string) =>
+        setState(prevState => ({...prevState, chatDisabledMessage})),
+      setChatDisabledState: (newState: {
         chatDisabled: boolean;
         chatDisabledMessage?: string;
-      }) => setState(s),
+      }) => setState(newState),
     }),
     [state]
   );

--- a/apps/src/aichat/views/AichatView.tsx
+++ b/apps/src/aichat/views/AichatView.tsx
@@ -6,7 +6,6 @@ import SegmentedButtons, {
 } from '@code-dot-org/component-library/segmentedButtons';
 import React, {useCallback, useEffect, useMemo} from 'react';
 
-import {AiChatDisabledProvider} from '@cdo/apps/aichat/context/aiChatDisabledContext';
 import TeacherOnboardingModal from '@cdo/apps/aichat/views/TeacherOnboardingModal';
 import ChatWarningModal from '@cdo/apps/aiComponentLibrary/warningModal/ChatWarningModal';
 import {queryParams} from '@cdo/apps/code-studio/utils';
@@ -309,133 +308,130 @@ const AichatView: React.FunctionComponent<LabProps<AichatLevelProperties>> = ({
 
   return (
     <LevelPropertiesContext.Provider value={levelProperties}>
-      <AiChatDisabledProvider>
-        <div id="aichat-lab" className={moduleStyles.aichatLab}>
-          {ChatModal && <ChatModal onClose={onCloseModal} />}
-          {showPresentationToggle() && (
-            <div
-              id="uitest-view-mode-toggle-container"
-              className={moduleStyles.viewModeButtons}
-            >
-              <SegmentedButtons {...viewModeButtonsProps} />
-            </div>
-          )}
-          <div className={moduleStyles.labCoreContainer}>
-            {viewMode === ViewMode.EDIT && (
-              <>
-                <div className={moduleStyles.instructionsArea}>
-                  {experiments.isEnabledAllowingQueryString(
-                    experiments.LAB2_RESOURCE_PANEL
-                  ) ? (
-                    <ResourcePanel
-                      className={moduleStyles.panelContainer}
-                      headerClassName={moduleStyles.panelHeader}
+      <div id="aichat-lab" className={moduleStyles.aichatLab}>
+        {ChatModal && <ChatModal onClose={onCloseModal} />}
+        {showPresentationToggle() && (
+          <div
+            id="uitest-view-mode-toggle-container"
+            className={moduleStyles.viewModeButtons}
+          >
+            <SegmentedButtons {...viewModeButtonsProps} />
+          </div>
+        )}
+        <div className={moduleStyles.labCoreContainer}>
+          {viewMode === ViewMode.EDIT && (
+            <>
+              <div className={moduleStyles.instructionsArea}>
+                {experiments.isEnabledAllowingQueryString(
+                  experiments.LAB2_RESOURCE_PANEL
+                ) ? (
+                  <ResourcePanel
+                    className={moduleStyles.panelContainer}
+                    headerClassName={moduleStyles.panelHeader}
+                    /** AI Chat doesn't have a traditional "run" state, so this is always false. */
+                    isRunning={false}
+                    hasRun={hasSentMessage}
+                    hasEdited={hasUpdatedCustomizations}
+                    levelProperties={levelProperties}
+                    rightHeaderContent={renderInstructionsHeaderRight(
+                      isUserTeacher,
+                      () => {
+                        dispatch(
+                          setShowModalType(ModalTypes.TEACHER_ONBOARDING)
+                        );
+                      }
+                    )}
+                  />
+                ) : (
+                  <PanelContainer
+                    id="aichat-instructions-panel"
+                    headerContent={commonI18n.instructions()}
+                    className={moduleStyles.panelContainer}
+                    headerClassName={moduleStyles.panelHeader}
+                    rightHeaderContent={renderInstructionsHeaderRight(
+                      isUserTeacher,
+                      () => {
+                        dispatch(
+                          setShowModalType(ModalTypes.TEACHER_ONBOARDING)
+                        );
+                      }
+                    )}
+                  >
+                    <InstructionsV2
+                      className={moduleStyles.instructions}
                       /** AI Chat doesn't have a traditional "run" state, so this is always false. */
                       isRunning={false}
                       hasRun={hasSentMessage}
                       hasEdited={hasUpdatedCustomizations}
                       levelProperties={levelProperties}
-                      rightHeaderContent={renderInstructionsHeaderRight(
-                        isUserTeacher,
-                        () => {
-                          dispatch(
-                            setShowModalType(ModalTypes.TEACHER_ONBOARDING)
-                          );
-                        }
-                      )}
                     />
-                  ) : (
-                    <PanelContainer
-                      id="aichat-instructions-panel"
-                      headerContent={commonI18n.instructions()}
-                      className={moduleStyles.panelContainer}
-                      headerClassName={moduleStyles.panelHeader}
-                      rightHeaderContent={renderInstructionsHeaderRight(
-                        isUserTeacher,
-                        () => {
-                          dispatch(
-                            setShowModalType(ModalTypes.TEACHER_ONBOARDING)
-                          );
-                        }
-                      )}
-                    >
-                      <InstructionsV2
-                        className={moduleStyles.instructions}
-                        /** AI Chat doesn't have a traditional "run" state, so this is always false. */
-                        isRunning={false}
-                        hasRun={hasSentMessage}
-                        hasEdited={hasUpdatedCustomizations}
-                        levelProperties={levelProperties}
-                      />
-                    </PanelContainer>
-                  )}
-                </div>
-                {!allFieldsHidden && (
-                  <div className={moduleStyles.customizationArea}>
-                    <PanelContainer
-                      id="aichat-model-customization-panel"
-                      headerContent={aichatI18n.modelCustomizationHeader()}
-                      className={moduleStyles.panelContainer}
-                      headerClassName={moduleStyles.panelHeader}
-                      rightHeaderContent={
-                        !viewAsUserId &&
-                        renderModelCustomizationHeaderRight(() => {
-                          onClickStartOver();
-                          dispatch(
-                            sendAnalytics(EVENTS.AICHAT_START_OVER, {
-                              levelPath: window.location.pathname,
-                            })
-                          );
-                        })
-                      }
-                    >
-                      <ModelCustomizationWorkspace />
-                    </PanelContainer>
-                  </div>
+                  </PanelContainer>
                 )}
-              </>
-            )}
-            {viewMode === ViewMode.PRESENTATION && (
-              <div
-                id="uitest-presentation-view-container"
-                className={moduleStyles.presentationArea}
-              >
-                <PanelContainer
-                  id="aichat-presentation-panel"
-                  headerContent={aichatI18n.modelCardPanelHeader()}
-                  className={moduleStyles.panelContainer}
-                  headerClassName={moduleStyles.panelHeader}
-                >
-                  <PresentationView />
-                </PanelContainer>
               </div>
-            )}
-
-            <div className={moduleStyles.chatWorkspaceArea}>
+              {!allFieldsHidden && (
+                <div className={moduleStyles.customizationArea}>
+                  <PanelContainer
+                    id="aichat-model-customization-panel"
+                    headerContent={aichatI18n.modelCustomizationHeader()}
+                    className={moduleStyles.panelContainer}
+                    headerClassName={moduleStyles.panelHeader}
+                    rightHeaderContent={
+                      !viewAsUserId &&
+                      renderModelCustomizationHeaderRight(() => {
+                        onClickStartOver();
+                        dispatch(
+                          sendAnalytics(EVENTS.AICHAT_START_OVER, {
+                            levelPath: window.location.pathname,
+                          })
+                        );
+                      })
+                    }
+                  >
+                    <ModelCustomizationWorkspace />
+                  </PanelContainer>
+                </div>
+              )}
+            </>
+          )}
+          {viewMode === ViewMode.PRESENTATION && (
+            <div
+              id="uitest-presentation-view-container"
+              className={moduleStyles.presentationArea}
+            >
               <PanelContainer
-                id="aichat-workspace-panel"
-                headerContent={chatWorkspaceHeader}
+                id="aichat-presentation-panel"
+                headerContent={aichatI18n.modelCardPanelHeader()}
                 className={moduleStyles.panelContainer}
                 headerClassName={moduleStyles.panelHeader}
                 rightHeaderContent={<AiChatHeaderButtons />}
               >
-                {hasSetStartingCustomizations && (
-                  <ChatWorkspace
-                    modelParameters={modelParameters}
-                    clientType={AiChatClientTypes.AI_CHAT_LAB}
-                    levelName={levelName}
-                    channelId={channelId}
-                    hasStarterAssets={
-                      starterAssets && Object.keys(starterAssets).length > 0
-                    }
-                    multimodalEnabled={levelAichatSettings?.multimodalEnabled}
-                  />
-                )}
+                <PresentationView />
               </PanelContainer>
             </div>
+          )}
+          <div className={moduleStyles.chatWorkspaceArea}>
+            <PanelContainer
+              id="aichat-workspace-panel"
+              headerContent={chatWorkspaceHeader}
+              className={moduleStyles.panelContainer}
+              headerClassName={moduleStyles.panelHeader}
+            >
+              {hasSetStartingCustomizations && (
+                <ChatWorkspace
+                  modelParameters={modelParameters}
+                  clientType={AiChatClientTypes.AI_CHAT_LAB}
+                  levelName={levelName}
+                  channelId={channelId}
+                  hasStarterAssets={
+                    starterAssets && Object.keys(starterAssets).length > 0
+                  }
+                  multimodalEnabled={levelAichatSettings?.multimodalEnabled}
+                />
+              )}
+            </PanelContainer>
           </div>
         </div>
-      </AiChatDisabledProvider>
+      </div>
     </LevelPropertiesContext.Provider>
   );
 };

--- a/apps/src/aichat/views/AichatView.tsx
+++ b/apps/src/aichat/views/AichatView.tsx
@@ -6,6 +6,7 @@ import SegmentedButtons, {
 } from '@code-dot-org/component-library/segmentedButtons';
 import React, {useCallback, useEffect, useMemo} from 'react';
 
+import {AiChatDisabledProvider} from '@cdo/apps/aichat/context/aiChatDisabledContext';
 import TeacherOnboardingModal from '@cdo/apps/aichat/views/TeacherOnboardingModal';
 import ChatWarningModal from '@cdo/apps/aiComponentLibrary/warningModal/ChatWarningModal';
 import {queryParams} from '@cdo/apps/code-studio/utils';
@@ -308,130 +309,133 @@ const AichatView: React.FunctionComponent<LabProps<AichatLevelProperties>> = ({
 
   return (
     <LevelPropertiesContext.Provider value={levelProperties}>
-      <div id="aichat-lab" className={moduleStyles.aichatLab}>
-        {ChatModal && <ChatModal onClose={onCloseModal} />}
-        {showPresentationToggle() && (
-          <div
-            id="uitest-view-mode-toggle-container"
-            className={moduleStyles.viewModeButtons}
-          >
-            <SegmentedButtons {...viewModeButtonsProps} />
-          </div>
-        )}
-        <div className={moduleStyles.labCoreContainer}>
-          {viewMode === ViewMode.EDIT && (
-            <>
-              <div className={moduleStyles.instructionsArea}>
-                {experiments.isEnabledAllowingQueryString(
-                  experiments.LAB2_RESOURCE_PANEL
-                ) ? (
-                  <ResourcePanel
-                    className={moduleStyles.panelContainer}
-                    headerClassName={moduleStyles.panelHeader}
-                    /** AI Chat doesn't have a traditional "run" state, so this is always false. */
-                    isRunning={false}
-                    hasRun={hasSentMessage}
-                    hasEdited={hasUpdatedCustomizations}
-                    levelProperties={levelProperties}
-                    rightHeaderContent={renderInstructionsHeaderRight(
-                      isUserTeacher,
-                      () => {
-                        dispatch(
-                          setShowModalType(ModalTypes.TEACHER_ONBOARDING)
-                        );
-                      }
-                    )}
-                  />
-                ) : (
-                  <PanelContainer
-                    id="aichat-instructions-panel"
-                    headerContent={commonI18n.instructions()}
-                    className={moduleStyles.panelContainer}
-                    headerClassName={moduleStyles.panelHeader}
-                    rightHeaderContent={renderInstructionsHeaderRight(
-                      isUserTeacher,
-                      () => {
-                        dispatch(
-                          setShowModalType(ModalTypes.TEACHER_ONBOARDING)
-                        );
-                      }
-                    )}
-                  >
-                    <InstructionsV2
-                      className={moduleStyles.instructions}
+      <AiChatDisabledProvider>
+        <div id="aichat-lab" className={moduleStyles.aichatLab}>
+          {ChatModal && <ChatModal onClose={onCloseModal} />}
+          {showPresentationToggle() && (
+            <div
+              id="uitest-view-mode-toggle-container"
+              className={moduleStyles.viewModeButtons}
+            >
+              <SegmentedButtons {...viewModeButtonsProps} />
+            </div>
+          )}
+          <div className={moduleStyles.labCoreContainer}>
+            {viewMode === ViewMode.EDIT && (
+              <>
+                <div className={moduleStyles.instructionsArea}>
+                  {experiments.isEnabledAllowingQueryString(
+                    experiments.LAB2_RESOURCE_PANEL
+                  ) ? (
+                    <ResourcePanel
+                      className={moduleStyles.panelContainer}
+                      headerClassName={moduleStyles.panelHeader}
                       /** AI Chat doesn't have a traditional "run" state, so this is always false. */
                       isRunning={false}
                       hasRun={hasSentMessage}
                       hasEdited={hasUpdatedCustomizations}
                       levelProperties={levelProperties}
+                      rightHeaderContent={renderInstructionsHeaderRight(
+                        isUserTeacher,
+                        () => {
+                          dispatch(
+                            setShowModalType(ModalTypes.TEACHER_ONBOARDING)
+                          );
+                        }
+                      )}
                     />
-                  </PanelContainer>
-                )}
-              </div>
-              {!allFieldsHidden && (
-                <div className={moduleStyles.customizationArea}>
-                  <PanelContainer
-                    id="aichat-model-customization-panel"
-                    headerContent={aichatI18n.modelCustomizationHeader()}
-                    className={moduleStyles.panelContainer}
-                    headerClassName={moduleStyles.panelHeader}
-                    rightHeaderContent={
-                      !viewAsUserId &&
-                      renderModelCustomizationHeaderRight(() => {
-                        onClickStartOver();
-                        dispatch(
-                          sendAnalytics(EVENTS.AICHAT_START_OVER, {
-                            levelPath: window.location.pathname,
-                          })
-                        );
-                      })
-                    }
-                  >
-                    <ModelCustomizationWorkspace />
-                  </PanelContainer>
+                  ) : (
+                    <PanelContainer
+                      id="aichat-instructions-panel"
+                      headerContent={commonI18n.instructions()}
+                      className={moduleStyles.panelContainer}
+                      headerClassName={moduleStyles.panelHeader}
+                      rightHeaderContent={renderInstructionsHeaderRight(
+                        isUserTeacher,
+                        () => {
+                          dispatch(
+                            setShowModalType(ModalTypes.TEACHER_ONBOARDING)
+                          );
+                        }
+                      )}
+                    >
+                      <InstructionsV2
+                        className={moduleStyles.instructions}
+                        /** AI Chat doesn't have a traditional "run" state, so this is always false. */
+                        isRunning={false}
+                        hasRun={hasSentMessage}
+                        hasEdited={hasUpdatedCustomizations}
+                        levelProperties={levelProperties}
+                      />
+                    </PanelContainer>
+                  )}
                 </div>
-              )}
-            </>
-          )}
-          {viewMode === ViewMode.PRESENTATION && (
-            <div
-              id="uitest-presentation-view-container"
-              className={moduleStyles.presentationArea}
-            >
+                {!allFieldsHidden && (
+                  <div className={moduleStyles.customizationArea}>
+                    <PanelContainer
+                      id="aichat-model-customization-panel"
+                      headerContent={aichatI18n.modelCustomizationHeader()}
+                      className={moduleStyles.panelContainer}
+                      headerClassName={moduleStyles.panelHeader}
+                      rightHeaderContent={
+                        !viewAsUserId &&
+                        renderModelCustomizationHeaderRight(() => {
+                          onClickStartOver();
+                          dispatch(
+                            sendAnalytics(EVENTS.AICHAT_START_OVER, {
+                              levelPath: window.location.pathname,
+                            })
+                          );
+                        })
+                      }
+                    >
+                      <ModelCustomizationWorkspace />
+                    </PanelContainer>
+                  </div>
+                )}
+              </>
+            )}
+            {viewMode === ViewMode.PRESENTATION && (
+              <div
+                id="uitest-presentation-view-container"
+                className={moduleStyles.presentationArea}
+              >
+                <PanelContainer
+                  id="aichat-presentation-panel"
+                  headerContent={aichatI18n.modelCardPanelHeader()}
+                  className={moduleStyles.panelContainer}
+                  headerClassName={moduleStyles.panelHeader}
+                >
+                  <PresentationView />
+                </PanelContainer>
+              </div>
+            )}
+
+            <div className={moduleStyles.chatWorkspaceArea}>
               <PanelContainer
-                id="aichat-presentation-panel"
-                headerContent={aichatI18n.modelCardPanelHeader()}
+                id="aichat-workspace-panel"
+                headerContent={chatWorkspaceHeader}
                 className={moduleStyles.panelContainer}
                 headerClassName={moduleStyles.panelHeader}
+                rightHeaderContent={<AiChatHeaderButtons />}
               >
-                <PresentationView />
+                {hasSetStartingCustomizations && (
+                  <ChatWorkspace
+                    modelParameters={modelParameters}
+                    clientType={AiChatClientTypes.AI_CHAT_LAB}
+                    levelName={levelName}
+                    channelId={channelId}
+                    hasStarterAssets={
+                      starterAssets && Object.keys(starterAssets).length > 0
+                    }
+                    multimodalEnabled={levelAichatSettings?.multimodalEnabled}
+                  />
+                )}
               </PanelContainer>
             </div>
-          )}
-          <div className={moduleStyles.chatWorkspaceArea}>
-            <PanelContainer
-              id="aichat-workspace-panel"
-              headerContent={chatWorkspaceHeader}
-              className={moduleStyles.panelContainer}
-              headerClassName={moduleStyles.panelHeader}
-              rightHeaderContent={<AiChatHeaderButtons />}
-            >
-              {hasSetStartingCustomizations && (
-                <ChatWorkspace
-                  modelParameters={modelParameters}
-                  clientType={AiChatClientTypes.AI_CHAT_LAB}
-                  levelName={levelName}
-                  channelId={channelId}
-                  hasStarterAssets={
-                    starterAssets && Object.keys(starterAssets).length > 0
-                  }
-                  multimodalEnabled={levelAichatSettings?.multimodalEnabled}
-                />
-              )}
-            </PanelContainer>
           </div>
         </div>
-      </div>
+      </AiChatDisabledProvider>
     </LevelPropertiesContext.Provider>
   );
 };

--- a/apps/src/aichat/views/AichatView.tsx
+++ b/apps/src/aichat/views/AichatView.tsx
@@ -403,7 +403,6 @@ const AichatView: React.FunctionComponent<LabProps<AichatLevelProperties>> = ({
                 headerContent={aichatI18n.modelCardPanelHeader()}
                 className={moduleStyles.panelContainer}
                 headerClassName={moduleStyles.panelHeader}
-                rightHeaderContent={<AiChatHeaderButtons />}
               >
                 <PresentationView />
               </PanelContainer>
@@ -415,6 +414,7 @@ const AichatView: React.FunctionComponent<LabProps<AichatLevelProperties>> = ({
               headerContent={chatWorkspaceHeader}
               className={moduleStyles.panelContainer}
               headerClassName={moduleStyles.panelHeader}
+              rightHeaderContent={<AiChatHeaderButtons />}
             >
               {hasSetStartingCustomizations && (
                 <ChatWorkspace

--- a/apps/src/aichat/views/ChatDisabled.tsx
+++ b/apps/src/aichat/views/ChatDisabled.tsx
@@ -3,13 +3,17 @@ import React, {FC} from 'react';
 
 import aiBotLockedIcon from '@cdo/static/aichat/ai-bot-locked-icon.png';
 
+import aichatI18n from '../locale';
+
 import styles from './chatWorkspace.module.scss';
 
-export const ChatDisabled: FC<{text: string}> = ({text}) => {
+export const ChatDisabled: FC<{message?: string}> = ({
+  message = aichatI18n.aiChatDisabled(),
+}) => {
   return (
     <div className={styles.chatDisabledContainer}>
       <img src={aiBotLockedIcon} alt="" className={styles.chatDisabledIcon} />
-      <BodyThreeText>{text}</BodyThreeText>
+      <BodyThreeText>{message}</BodyThreeText>
     </div>
   );
 };

--- a/apps/src/aichat/views/ChatDisabled.tsx
+++ b/apps/src/aichat/views/ChatDisabled.tsx
@@ -1,0 +1,15 @@
+import {BodyThreeText} from '@code-dot-org/component-library/typography';
+import React, {FC} from 'react';
+
+import aiBotLockedIcon from '@cdo/static/aichat/ai-bot-locked-icon.png';
+
+import styles from './chatWorkspace.module.scss';
+
+export const ChatDisabled: FC<{text: string}> = ({text}) => {
+  return (
+    <div className={styles.chatDisabledContainer}>
+      <img src={aiBotLockedIcon} alt="" className={styles.chatDisabledIcon} />
+      <BodyThreeText>{text}</BodyThreeText>
+    </div>
+  );
+};

--- a/apps/src/aichat/views/ChatEventsList.tsx
+++ b/apps/src/aichat/views/ChatEventsList.tsx
@@ -2,11 +2,10 @@ import Button from '@code-dot-org/component-library/button';
 import classNames from 'classnames';
 import React, {useEffect, useRef, useState} from 'react';
 
+import {useAiChatDisabled} from '@cdo/apps/aichat/context/aiChatDisabledContext';
 import {useAppSelector} from '@cdo/apps/util/reduxHooks';
-import {AiChatClientTypes} from '@cdo/generated-scripts/sharedConstants';
 
-import aichatI18n from '../locale';
-import {AiChatClientType, ChatAsset, ChatEvent} from '../types';
+import {ChatAsset, ChatEvent} from '../types';
 
 import {ChatDisabled} from './ChatDisabled';
 import ChatEventView from './ChatEventView';
@@ -17,8 +16,6 @@ import moduleStyles from './chatWorkspace.module.scss';
 interface ChatEventsListProps {
   events: ChatEvent[];
   isTeacherView?: boolean;
-  disabled?: boolean;
-  clientType?: AiChatClientType;
   buildAssetUrl?: (asset: ChatAsset) => string;
 }
 
@@ -28,10 +25,9 @@ interface ChatEventsListProps {
 const ChatEventsList: React.FunctionComponent<ChatEventsListProps> = ({
   events,
   isTeacherView,
-  disabled = false,
-  clientType,
   buildAssetUrl,
 }) => {
+  const {chatDisabled, chatDisabledMessage} = useAiChatDisabled();
   const [inProgrammaticScroll, setInProgrammaticScroll] = useState(false);
   const [showScrollToBottom, setShowScrollToBottom] = useState(true);
   const isWaitingForChatResponse = useAppSelector(
@@ -100,11 +96,6 @@ const ChatEventsList: React.FunctionComponent<ChatEventsListProps> = ({
 
   useEffect(scrollToBottom, [events.length, isWaitingForChatResponse]);
 
-  const disabledMessage =
-    clientType === AiChatClientTypes.AI_TUTOR
-      ? aichatI18n.aiTutorDisabled()
-      : aichatI18n.aiChatDisabled();
-
   return (
     <div
       id="chat-workspace-conversation"
@@ -114,8 +105,8 @@ const ChatEventsList: React.FunctionComponent<ChatEventsListProps> = ({
       )}
     >
       <div className={moduleStyles.messageArea} ref={conversationContainerRef}>
-        {disabled ? (
-          <ChatDisabled text={disabledMessage} />
+        {chatDisabled ? (
+          <ChatDisabled message={chatDisabledMessage} />
         ) : (
           <>
             {events.map(event => (

--- a/apps/src/aichat/views/ChatEventsList.tsx
+++ b/apps/src/aichat/views/ChatEventsList.tsx
@@ -3,9 +3,12 @@ import classNames from 'classnames';
 import React, {useEffect, useRef, useState} from 'react';
 
 import {useAppSelector} from '@cdo/apps/util/reduxHooks';
+import {AiChatClientTypes} from '@cdo/generated-scripts/sharedConstants';
 
-import {ChatAsset, ChatEvent} from '../types';
+import aichatI18n from '../locale';
+import {AiChatClientType, ChatAsset, ChatEvent} from '../types';
 
+import {ChatDisabled} from './ChatDisabled';
 import ChatEventView from './ChatEventView';
 import WaitingAnimation from './WaitingAnimation';
 
@@ -14,6 +17,8 @@ import moduleStyles from './chatWorkspace.module.scss';
 interface ChatEventsListProps {
   events: ChatEvent[];
   isTeacherView?: boolean;
+  disabled?: boolean;
+  clientType?: AiChatClientType;
   buildAssetUrl?: (asset: ChatAsset) => string;
 }
 
@@ -23,6 +28,8 @@ interface ChatEventsListProps {
 const ChatEventsList: React.FunctionComponent<ChatEventsListProps> = ({
   events,
   isTeacherView,
+  disabled = false,
+  clientType,
   buildAssetUrl,
 }) => {
   const [inProgrammaticScroll, setInProgrammaticScroll] = useState(false);
@@ -93,6 +100,11 @@ const ChatEventsList: React.FunctionComponent<ChatEventsListProps> = ({
 
   useEffect(scrollToBottom, [events.length, isWaitingForChatResponse]);
 
+  const disabledMessage =
+    clientType === AiChatClientTypes.AI_TUTOR
+      ? aichatI18n.aiTutorDisabled()
+      : aichatI18n.aiChatDisabled();
+
   return (
     <div
       id="chat-workspace-conversation"
@@ -102,15 +114,21 @@ const ChatEventsList: React.FunctionComponent<ChatEventsListProps> = ({
       )}
     >
       <div className={moduleStyles.messageArea} ref={conversationContainerRef}>
-        {events.map(event => (
-          <ChatEventView
-            event={event}
-            key={event.timestamp}
-            isTeacherView={isTeacherView}
-            buildAssetUrl={buildAssetUrl}
-          />
-        ))}
-        <WaitingAnimation shouldDisplay={isWaitingForChatResponse} />
+        {disabled ? (
+          <ChatDisabled text={disabledMessage} />
+        ) : (
+          <>
+            {events.map(event => (
+              <ChatEventView
+                event={event}
+                key={event.timestamp}
+                isTeacherView={isTeacherView}
+                buildAssetUrl={buildAssetUrl}
+              />
+            ))}
+            <WaitingAnimation shouldDisplay={isWaitingForChatResponse} />
+          </>
+        )}
       </div>
       {showScrollToBottom && (
         <div className={moduleStyles.floatingScrollToBottomButtonContainer}>

--- a/apps/src/aichat/views/ChatWorkspace.tsx
+++ b/apps/src/aichat/views/ChatWorkspace.tsx
@@ -2,6 +2,7 @@ import {FontAwesomeV6IconProps} from '@code-dot-org/component-library/fontAwesom
 import Tabs, {TabsProps} from '@code-dot-org/component-library/tabs';
 import React, {useCallback, useEffect, useMemo} from 'react';
 
+import {useAiChatDisabled} from '@cdo/apps/aichat/context/aiChatDisabledContext';
 import {
   isModelUpdate,
   SystemPromptSettings,
@@ -49,7 +50,6 @@ interface ChatWorkspaceProps {
   modelParameters: ModelParameters;
   clientType: AiChatClientType;
   chatButtons?: ChatButtonAndKey[];
-  disabled?: boolean;
   hiddenContextCallback?: () => Promise<string>;
   hideModelChangeMessage?: boolean;
 
@@ -70,7 +70,6 @@ const ChatWorkspace: React.FunctionComponent<ChatWorkspaceProps> = ({
   modelParameters,
   clientType,
   chatButtons,
-  disabled = false,
   hiddenContextCallback,
   multimodalEnabled = false,
   levelName,
@@ -79,6 +78,7 @@ const ChatWorkspace: React.FunctionComponent<ChatWorkspaceProps> = ({
   systemPromptSettings,
   hideModelChangeMessage = false,
 }) => {
+  const {chatDisabled} = useAiChatDisabled();
   if (multimodalEnabled && (!levelName || !channelId)) {
     console.warn(
       'Multimodal support requires level name and channel ID. Multimodal features will not be available.'
@@ -272,7 +272,7 @@ const ChatWorkspace: React.FunctionComponent<ChatWorkspaceProps> = ({
     tabPanelsContainerClassName: moduleStyles.tabPanelsContainer,
   };
 
-  const uploadDisabled = !canChatWithModel || !!selectedStudent || disabled;
+  const uploadDisabled = !canChatWithModel || !!selectedStudent || chatDisabled;
 
   return (
     <div id="chat-workspace-area" className={moduleStyles.chatWorkspace}>
@@ -282,8 +282,6 @@ const ChatWorkspace: React.FunctionComponent<ChatWorkspaceProps> = ({
         <ChatEventsList
           events={visibleItems}
           buildAssetUrl={multimodalAvailable ? buildAssetUrl : undefined}
-          clientType={clientType}
-          disabled={disabled}
         />
       )}
 
@@ -304,7 +302,6 @@ const ChatWorkspace: React.FunctionComponent<ChatWorkspaceProps> = ({
             chatButtons={chatButtons}
             hiddenContextCallback={hiddenContextCallback}
             multimodalAvailable={multimodalAvailable}
-            disabled={disabled}
           />
         )}
         <div className={moduleStyles.buttonRow}>

--- a/apps/src/aichat/views/ChatWorkspace.tsx
+++ b/apps/src/aichat/views/ChatWorkspace.tsx
@@ -49,6 +49,7 @@ interface ChatWorkspaceProps {
   modelParameters: ModelParameters;
   clientType: AiChatClientType;
   chatButtons?: ChatButtonAndKey[];
+  disabled?: boolean;
   hiddenContextCallback?: () => Promise<string>;
   hideModelChangeMessage?: boolean;
 
@@ -69,6 +70,7 @@ const ChatWorkspace: React.FunctionComponent<ChatWorkspaceProps> = ({
   modelParameters,
   clientType,
   chatButtons,
+  disabled = false,
   hiddenContextCallback,
   multimodalEnabled = false,
   levelName,
@@ -270,6 +272,8 @@ const ChatWorkspace: React.FunctionComponent<ChatWorkspaceProps> = ({
     tabPanelsContainerClassName: moduleStyles.tabPanelsContainer,
   };
 
+  const uploadDisabled = !canChatWithModel || !!selectedStudent || disabled;
+
   return (
     <div id="chat-workspace-area" className={moduleStyles.chatWorkspace}>
       {selectedStudent ? (
@@ -278,6 +282,8 @@ const ChatWorkspace: React.FunctionComponent<ChatWorkspaceProps> = ({
         <ChatEventsList
           events={visibleItems}
           buildAssetUrl={multimodalAvailable ? buildAssetUrl : undefined}
+          clientType={clientType}
+          disabled={disabled}
         />
       )}
 
@@ -298,12 +304,13 @@ const ChatWorkspace: React.FunctionComponent<ChatWorkspaceProps> = ({
             chatButtons={chatButtons}
             hiddenContextCallback={hiddenContextCallback}
             multimodalAvailable={multimodalAvailable}
+            disabled={disabled}
           />
         )}
         <div className={moduleStyles.buttonRow}>
           {multimodalAvailable && (
             <UploadButton
-              isDisabled={!canChatWithModel || !!selectedStudent}
+              isDisabled={uploadDisabled}
               levelName={levelName}
               hasStarterAssets={hasStarterAssets}
               buildAssetUrl={buildAssetUrl}

--- a/apps/src/aichat/views/UserChatMessageEditor.tsx
+++ b/apps/src/aichat/views/UserChatMessageEditor.tsx
@@ -1,5 +1,6 @@
 import React, {useCallback, useEffect, useRef} from 'react';
 
+import {useAiChatDisabled} from '@cdo/apps/aichat/context/aiChatDisabledContext';
 import UserMessageEditor from '@cdo/apps/aiComponentLibrary/userMessageEditor/UserMessageEditor';
 import {useAppDispatch, useAppSelector} from '@cdo/apps/util/reduxHooks';
 
@@ -20,7 +21,6 @@ interface UserChatMessageEditorProps {
   chatButtons?: ChatButtonAndKey[];
   hiddenContextCallback?: () => Promise<string>;
   multimodalAvailable?: boolean;
-  disabled?: boolean;
 }
 
 /**
@@ -35,8 +35,8 @@ const UserChatMessageEditor: React.FunctionComponent<
   chatButtons,
   hiddenContextCallback,
   multimodalAvailable,
-  disabled = false,
 }) => {
+  const {chatDisabled} = useAiChatDisabled();
   const isWaitingForChatResponse = useAppSelector(
     state => !!state.aichat.chatMessagePending
   );
@@ -55,12 +55,15 @@ const UserChatMessageEditor: React.FunctionComponent<
 
   const inputRef = useRef<HTMLTextAreaElement>(null);
 
-  const chatDisabled =
-    isWaitingForChatResponse || saveInProgress || uploadsPending || disabled;
+  const disabled =
+    isWaitingForChatResponse ||
+    saveInProgress ||
+    uploadsPending ||
+    chatDisabled;
 
   const handleSubmit = useCallback(
     async (userMessage: string, analyticsProperties?: AnalyticsProperties) => {
-      if (!chatDisabled) {
+      if (!disabled) {
         const hiddenContext = await hiddenContextCallback?.();
         dispatch(
           submitChatContents({
@@ -82,7 +85,7 @@ const UserChatMessageEditor: React.FunctionComponent<
       }
     },
     [
-      chatDisabled,
+      disabled,
       dispatch,
       hiddenContextCallback,
       modelParameters,
@@ -94,16 +97,16 @@ const UserChatMessageEditor: React.FunctionComponent<
   );
 
   useEffect(() => {
-    if (!chatDisabled) {
+    if (!disabled) {
       // Return focus to user input textarea after user submits chat message and response displayed
       // or after user updates model customizations.
       inputRef.current?.focus();
     }
-  }, [chatDisabled]);
+  }, [disabled]);
 
   return (
     <>
-      {chatButtons && !disabled && (
+      {chatButtons && !chatDisabled && (
         <div className={moduleStyles.chatButtonsContainer}>
           {chatButtons.map(({ChatButton, key}) => (
             <ChatButton key={key} onClick={handleSubmit} />
@@ -112,7 +115,7 @@ const UserChatMessageEditor: React.FunctionComponent<
       )}
       <UserMessageEditor
         onSubmit={handleSubmit}
-        disabled={chatDisabled}
+        disabled={disabled}
         editorContainerClassName={editorContainerClassName}
         ref={inputRef}
       />

--- a/apps/src/aichat/views/UserChatMessageEditor.tsx
+++ b/apps/src/aichat/views/UserChatMessageEditor.tsx
@@ -86,8 +86,8 @@ const UserChatMessageEditor: React.FunctionComponent<
     },
     [
       disabled,
-      dispatch,
       hiddenContextCallback,
+      dispatch,
       modelParameters,
       clientType,
       multimodalAvailable,

--- a/apps/src/aichat/views/UserChatMessageEditor.tsx
+++ b/apps/src/aichat/views/UserChatMessageEditor.tsx
@@ -20,6 +20,7 @@ interface UserChatMessageEditorProps {
   chatButtons?: ChatButtonAndKey[];
   hiddenContextCallback?: () => Promise<string>;
   multimodalAvailable?: boolean;
+  disabled?: boolean;
 }
 
 /**
@@ -34,6 +35,7 @@ const UserChatMessageEditor: React.FunctionComponent<
   chatButtons,
   hiddenContextCallback,
   multimodalAvailable,
+  disabled = false,
 }) => {
   const isWaitingForChatResponse = useAppSelector(
     state => !!state.aichat.chatMessagePending
@@ -53,11 +55,12 @@ const UserChatMessageEditor: React.FunctionComponent<
 
   const inputRef = useRef<HTMLTextAreaElement>(null);
 
-  const disabled = isWaitingForChatResponse || saveInProgress || uploadsPending;
+  const chatDisabled =
+    isWaitingForChatResponse || saveInProgress || uploadsPending || disabled;
 
   const handleSubmit = useCallback(
     async (userMessage: string, analyticsProperties?: AnalyticsProperties) => {
-      if (!disabled) {
+      if (!chatDisabled) {
         const hiddenContext = await hiddenContextCallback?.();
         dispatch(
           submitChatContents({
@@ -79,9 +82,9 @@ const UserChatMessageEditor: React.FunctionComponent<
       }
     },
     [
-      disabled,
-      hiddenContextCallback,
+      chatDisabled,
       dispatch,
+      hiddenContextCallback,
       modelParameters,
       clientType,
       multimodalAvailable,
@@ -91,16 +94,16 @@ const UserChatMessageEditor: React.FunctionComponent<
   );
 
   useEffect(() => {
-    if (!disabled) {
+    if (!chatDisabled) {
       // Return focus to user input textarea after user submits chat message and response displayed
       // or after user updates model customizations.
       inputRef.current?.focus();
     }
-  }, [disabled]);
+  }, [chatDisabled]);
 
   return (
     <>
-      {chatButtons && (
+      {chatButtons && !disabled && (
         <div className={moduleStyles.chatButtonsContainer}>
           {chatButtons.map(({ChatButton, key}) => (
             <ChatButton key={key} onClick={handleSubmit} />
@@ -109,7 +112,7 @@ const UserChatMessageEditor: React.FunctionComponent<
       )}
       <UserMessageEditor
         onSubmit={handleSubmit}
-        disabled={disabled}
+        disabled={chatDisabled}
         editorContainerClassName={editorContainerClassName}
         ref={inputRef}
       />

--- a/apps/src/aichat/views/chatWorkspace.module.scss
+++ b/apps/src/aichat/views/chatWorkspace.module.scss
@@ -53,6 +53,22 @@ $tabs-default-spacing: 4px;
   pointer-events: none;
 }
 
+.chatDisabledContainer {
+  margin: auto;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.5rem;
+
+  p {
+    color: var(--text-neutral-quaternary);
+  }
+
+  .chatDisabledIcon {
+    width: 2rem;
+  }
+}
+
 .tabsContainer {
   background-color: var(--background-neutral-secondary);
   padding: $tabs-default-spacing $tabs-default-spacing 0 $tabs-default-spacing;

--- a/apps/src/codebridge/Codebridge.tsx
+++ b/apps/src/codebridge/Codebridge.tsx
@@ -13,6 +13,7 @@ import {
 import classNames from 'classnames';
 import React, {useEffect, useMemo} from 'react';
 
+import {AiChatDisabledProvider} from '@cdo/apps/aichat/context/aiChatDisabledContext';
 import {ChatButtonData, SystemPromptSettings} from '@cdo/apps/aichat/types';
 import {AiTutorContextHelper} from '@cdo/apps/aiTutor/helpers/aiTutorContextHelper';
 import {START_SOURCES} from '@cdo/apps/lab2/constants';
@@ -197,18 +198,20 @@ export const Codebridge = React.memo(
         }}
       >
         <BackpackAPIContext.Provider value={backpackApi}>
-          <div className={classNames(moduleStyles.codebridgeContainer)}>
-            {flaggedImageData && (
-              <FlaggedImageModal
-                onAccept={handleAcceptFlaggedImage}
-                onCancel={handleCancelFlaggedImage}
+          <AiChatDisabledProvider>
+            <div className={classNames(moduleStyles.codebridgeContainer)}>
+              {flaggedImageData && (
+                <FlaggedImageModal
+                  onAccept={handleAcceptFlaggedImage}
+                  onCancel={handleCancelFlaggedImage}
+                />
+              )}
+              <InnerLayout
+                isProjectLevel={levelProperties.isProjectLevel}
+                isWidgetView={levelProperties.widgetView}
               />
-            )}
-            <InnerLayout
-              isProjectLevel={levelProperties.isProjectLevel}
-              isWidgetView={levelProperties.widgetView}
-            />
-          </div>
+            </div>
+          </AiChatDisabledProvider>
         </BackpackAPIContext.Provider>
       </CodebridgeContextProvider>
     );

--- a/apps/src/codebridge/Codebridge.tsx
+++ b/apps/src/codebridge/Codebridge.tsx
@@ -13,7 +13,6 @@ import {
 import classNames from 'classnames';
 import React, {useEffect, useMemo} from 'react';
 
-import {AiChatDisabledProvider} from '@cdo/apps/aichat/context/aiChatDisabledContext';
 import {ChatButtonData, SystemPromptSettings} from '@cdo/apps/aichat/types';
 import {AiTutorContextHelper} from '@cdo/apps/aiTutor/helpers/aiTutorContextHelper';
 import {START_SOURCES} from '@cdo/apps/lab2/constants';
@@ -198,20 +197,18 @@ export const Codebridge = React.memo(
         }}
       >
         <BackpackAPIContext.Provider value={backpackApi}>
-          <AiChatDisabledProvider>
-            <div className={classNames(moduleStyles.codebridgeContainer)}>
-              {flaggedImageData && (
-                <FlaggedImageModal
-                  onAccept={handleAcceptFlaggedImage}
-                  onCancel={handleCancelFlaggedImage}
-                />
-              )}
-              <InnerLayout
-                isProjectLevel={levelProperties.isProjectLevel}
-                isWidgetView={levelProperties.widgetView}
+          <div className={classNames(moduleStyles.codebridgeContainer)}>
+            {flaggedImageData && (
+              <FlaggedImageModal
+                onAccept={handleAcceptFlaggedImage}
+                onCancel={handleCancelFlaggedImage}
               />
-            </div>
-          </AiChatDisabledProvider>
+            )}
+            <InnerLayout
+              isProjectLevel={levelProperties.isProjectLevel}
+              isWidgetView={levelProperties.widgetView}
+            />
+          </div>
         </BackpackAPIContext.Provider>
       </CodebridgeContextProvider>
     );

--- a/apps/src/lab2/views/LabViewsRenderer.tsx
+++ b/apps/src/lab2/views/LabViewsRenderer.tsx
@@ -5,6 +5,7 @@
  */
 import React, {Suspense, useEffect} from 'react';
 
+import {AiChatDisabledProvider} from '@cdo/apps/aichat/context/aiChatDisabledContext';
 import {queryParams} from '@cdo/apps/code-studio/utils';
 import {PERMISSIONS} from '@cdo/apps/lab2/constants';
 import {useInitialLabTheme} from '@cdo/apps/lab2/hooks/useInitialLabTheme';
@@ -101,22 +102,27 @@ const LabViewsRenderer: React.FunctionComponent = () => {
 
   const LabView = properties.view;
   return (
-    <ProgressContainer key={currentAppName} appType={currentAppName}>
-      <div id={`lab2-${currentAppName}`} className={moduleStyles.labContainer}>
-        <Suspense fallback={<Loading isLoading={true} />}>
-          <LabView
-            levelProperties={levelProperties}
-            initialSources={initialSources}
-          />
-        </Suspense>
-        {!hideExtraLinks && levelId && (
-          <ExtraLinks
-            levelId={levelId}
-            positionRightOfFooter={extraLinksButtonRightOfFooter}
-          />
-        )}
-      </div>
-    </ProgressContainer>
+    <AiChatDisabledProvider>
+      <ProgressContainer key={currentAppName} appType={currentAppName}>
+        <div
+          id={`lab2-${currentAppName}`}
+          className={moduleStyles.labContainer}
+        >
+          <Suspense fallback={<Loading isLoading={true} />}>
+            <LabView
+              levelProperties={levelProperties}
+              initialSources={initialSources}
+            />
+          </Suspense>
+          {!hideExtraLinks && levelId && (
+            <ExtraLinks
+              levelId={levelId}
+              positionRightOfFooter={extraLinksButtonRightOfFooter}
+            />
+          )}
+        </div>
+      </ProgressContainer>
+    </AiChatDisabledProvider>
   );
 };
 

--- a/apps/src/lab2/views/components/AiTutor2Chat.tsx
+++ b/apps/src/lab2/views/components/AiTutor2Chat.tsx
@@ -99,6 +99,9 @@ const AiTutor2Chat: React.FunctionComponent<AiTutor2ChatProps> = ({
 }) => {
   const [systemPrompt, setSystemPrompt] = useState<string>();
 
+  // Temporarily use query param to disable ai chat
+  const disableAiChat = queryParams('disable-ai-chat');
+
   const fetchPrompt = (promptName: string) => {
     fetchCustomPrompt(promptName)
       .then(prompt => {
@@ -186,6 +189,7 @@ const AiTutor2Chat: React.FunctionComponent<AiTutor2ChatProps> = ({
         levelName={levelName}
         channelId={channelId}
         hideModelChangeMessage={true}
+        disabled={!!disableAiChat}
       />
     </div>
   ) : (

--- a/apps/src/lab2/views/components/AiTutor2Chat.tsx
+++ b/apps/src/lab2/views/components/AiTutor2Chat.tsx
@@ -99,9 +99,6 @@ const AiTutor2Chat: React.FunctionComponent<AiTutor2ChatProps> = ({
 }) => {
   const [systemPrompt, setSystemPrompt] = useState<string>();
 
-  // Temporarily use query param to disable ai chat
-  const disableAiChat = queryParams('disable-ai-chat');
-
   const fetchPrompt = (promptName: string) => {
     fetchCustomPrompt(promptName)
       .then(prompt => {
@@ -189,7 +186,6 @@ const AiTutor2Chat: React.FunctionComponent<AiTutor2ChatProps> = ({
         levelName={levelName}
         channelId={channelId}
         hideModelChangeMessage={true}
-        disabled={!!disableAiChat}
       />
     </div>
   ) : (

--- a/apps/src/pythonlab/PythonlabView.tsx
+++ b/apps/src/pythonlab/PythonlabView.tsx
@@ -6,7 +6,6 @@ import {python} from '@codemirror/lang-python';
 import {LanguageSupport} from '@codemirror/language';
 import React, {useContext, useEffect, useMemo, useState} from 'react';
 
-import {AiChatDisabledProvider} from '@cdo/apps/aichat/context/aiChatDisabledContext';
 import {sendProgressReport} from '@cdo/apps/code-studio/progressRedux';
 import {getCurrentLevel} from '@cdo/apps/code-studio/progressReduxSelectors';
 import {queryParams} from '@cdo/apps/code-studio/utils';
@@ -32,6 +31,7 @@ import {
 } from '@cdo/apps/util/reduxHooks';
 import {LevelStatus} from '@cdo/generated-scripts/sharedConstants';
 
+import {useAiChatDisabled} from '../aichat/context/aiChatDisabledContext';
 import CodebridgeRegistry from '../codebridge/CodebridgeRegistry';
 
 import ProjectTypePicker from './components/ProjectTypePicker';
@@ -88,6 +88,21 @@ const PythonlabView: React.FunctionComponent<
   const progressManager = useContext(ProgressManagerContext);
   const isStartMode = getAppOptionsEditBlocks() === START_SOURCES;
   const [showProjectPicker, setShowProjectPicker] = useState(false);
+
+  // TODO: remove disabling chat via query param
+  const {setChatDisabledState} = useAiChatDisabled();
+
+  const chatDisabledParam = !!queryParams('disable-ai-chat');
+  const chatDisabledMessageParam = queryParams('disable-ai-chat-message') as
+    | string
+    | undefined;
+
+  useEffect(() => {
+    setChatDisabledState({
+      chatDisabled: chatDisabledParam,
+      chatDisabledMessage: chatDisabledMessageParam,
+    });
+  }, [chatDisabledParam, chatDisabledMessageParam, setChatDisabledState]);
 
   const currentLevelStatus = useAppSelector(
     state => getCurrentLevel(state)?.status

--- a/apps/src/pythonlab/PythonlabView.tsx
+++ b/apps/src/pythonlab/PythonlabView.tsx
@@ -237,34 +237,32 @@ const PythonlabView: React.FunctionComponent<
   };
 
   return (
-    <AiChatDisabledProvider>
-      <div className={moduleStyles.pythonlab}>
-        {hasSource && (
-          <Codebridge
-            config={config}
-            setConfig={setConfig}
-            startSources={levelStartSources}
-            onRun={onRun}
-            onStop={stopPythonCode}
-            sendConsoleInput={sendInput}
-            levelProperties={levelProperties}
-            projectPickerSettings={projectPickerSettings}
-            hiddenContextCallback={aiTutorHelper.getHiddenContextCallback()}
-          />
-        )}
-        {showProjectPickerModal && (
-          <ProjectTypePicker
-            setProjectCallback={handleProjectTypeChange}
-            currentProjectType={
-              initialSources || labConfig?.standaloneSettings?.projectType
-                ? currentProjectType
-                : undefined
-            }
-            closeDialog={() => setShowProjectPicker(false)}
-          />
-        )}
-      </div>
-    </AiChatDisabledProvider>
+    <div className={moduleStyles.pythonlab}>
+      {hasSource && (
+        <Codebridge
+          config={config}
+          setConfig={setConfig}
+          startSources={levelStartSources}
+          onRun={onRun}
+          onStop={stopPythonCode}
+          sendConsoleInput={sendInput}
+          levelProperties={levelProperties}
+          projectPickerSettings={projectPickerSettings}
+          hiddenContextCallback={aiTutorHelper.getHiddenContextCallback()}
+        />
+      )}
+      {showProjectPickerModal && (
+        <ProjectTypePicker
+          setProjectCallback={handleProjectTypeChange}
+          currentProjectType={
+            initialSources || labConfig?.standaloneSettings?.projectType
+              ? currentProjectType
+              : undefined
+          }
+          closeDialog={() => setShowProjectPicker(false)}
+        />
+      )}
+    </div>
   );
 };
 

--- a/apps/src/pythonlab/PythonlabView.tsx
+++ b/apps/src/pythonlab/PythonlabView.tsx
@@ -6,6 +6,7 @@ import {python} from '@codemirror/lang-python';
 import {LanguageSupport} from '@codemirror/language';
 import React, {useContext, useEffect, useMemo, useState} from 'react';
 
+import {AiChatDisabledProvider} from '@cdo/apps/aichat/context/aiChatDisabledContext';
 import {sendProgressReport} from '@cdo/apps/code-studio/progressRedux';
 import {getCurrentLevel} from '@cdo/apps/code-studio/progressReduxSelectors';
 import {queryParams} from '@cdo/apps/code-studio/utils';
@@ -236,32 +237,34 @@ const PythonlabView: React.FunctionComponent<
   };
 
   return (
-    <div className={moduleStyles.pythonlab}>
-      {hasSource && (
-        <Codebridge
-          config={config}
-          setConfig={setConfig}
-          startSources={levelStartSources}
-          onRun={onRun}
-          onStop={stopPythonCode}
-          sendConsoleInput={sendInput}
-          levelProperties={levelProperties}
-          projectPickerSettings={projectPickerSettings}
-          hiddenContextCallback={aiTutorHelper.getHiddenContextCallback()}
-        />
-      )}
-      {showProjectPickerModal && (
-        <ProjectTypePicker
-          setProjectCallback={handleProjectTypeChange}
-          currentProjectType={
-            initialSources || labConfig?.standaloneSettings?.projectType
-              ? currentProjectType
-              : undefined
-          }
-          closeDialog={() => setShowProjectPicker(false)}
-        />
-      )}
-    </div>
+    <AiChatDisabledProvider>
+      <div className={moduleStyles.pythonlab}>
+        {hasSource && (
+          <Codebridge
+            config={config}
+            setConfig={setConfig}
+            startSources={levelStartSources}
+            onRun={onRun}
+            onStop={stopPythonCode}
+            sendConsoleInput={sendInput}
+            levelProperties={levelProperties}
+            projectPickerSettings={projectPickerSettings}
+            hiddenContextCallback={aiTutorHelper.getHiddenContextCallback()}
+          />
+        )}
+        {showProjectPickerModal && (
+          <ProjectTypePicker
+            setProjectCallback={handleProjectTypeChange}
+            currentProjectType={
+              initialSources || labConfig?.standaloneSettings?.projectType
+                ? currentProjectType
+                : undefined
+            }
+            closeDialog={() => setShowProjectPicker(false)}
+          />
+        )}
+      </div>
+    </AiChatDisabledProvider>
   );
 };
 

--- a/apps/src/weblab2/Weblab2View.tsx
+++ b/apps/src/weblab2/Weblab2View.tsx
@@ -8,6 +8,7 @@ import {markdown} from '@codemirror/lang-markdown';
 import {LanguageSupport} from '@codemirror/language';
 import React, {useEffect, useMemo, useState} from 'react';
 
+import {AiChatDisabledProvider} from '@cdo/apps/aichat/context/aiChatDisabledContext';
 import {SystemPromptOption} from '@cdo/apps/aichat/types';
 import {setHasRun} from '@cdo/apps/lab2/redux/systemRedux';
 import {LabProps, MultiFileSource, ProjectSources} from '@cdo/apps/lab2/types';
@@ -159,21 +160,23 @@ const Weblab2View: React.FC<
   }, [dispatch, levelProperties?.initialViewMode]);
 
   return (
-    <div className={moduleStyles.weblab2Container}>
-      {hasSource && (
-        <Codebridge
-          config={config}
-          setConfig={setConfig}
-          startSources={startSources}
-          levelProperties={levelProperties}
-          hiddenContextCallback={aiTutorHelper.getHiddenContextCallback()}
-          aiTutorSystemPromptSettings={aiTutorSystemPromptSettings}
-          aiTutorMultimodalEnabled={true}
-          aiTutorChatButtonData={[]}
-          aiTutorContextHelper={aiTutorHelper}
-        />
-      )}
-    </div>
+    <AiChatDisabledProvider>
+      <div className={moduleStyles.weblab2Container}>
+        {hasSource && (
+          <Codebridge
+            config={config}
+            setConfig={setConfig}
+            startSources={startSources}
+            levelProperties={levelProperties}
+            hiddenContextCallback={aiTutorHelper.getHiddenContextCallback()}
+            aiTutorSystemPromptSettings={aiTutorSystemPromptSettings}
+            aiTutorMultimodalEnabled={true}
+            aiTutorChatButtonData={[]}
+            aiTutorContextHelper={aiTutorHelper}
+          />
+        )}
+      </div>
+    </AiChatDisabledProvider>
   );
 };
 

--- a/apps/src/weblab2/Weblab2View.tsx
+++ b/apps/src/weblab2/Weblab2View.tsx
@@ -8,7 +8,6 @@ import {markdown} from '@codemirror/lang-markdown';
 import {LanguageSupport} from '@codemirror/language';
 import React, {useEffect, useMemo, useState} from 'react';
 
-import {AiChatDisabledProvider} from '@cdo/apps/aichat/context/aiChatDisabledContext';
 import {SystemPromptOption} from '@cdo/apps/aichat/types';
 import {setHasRun} from '@cdo/apps/lab2/redux/systemRedux';
 import {LabProps, MultiFileSource, ProjectSources} from '@cdo/apps/lab2/types';
@@ -160,23 +159,21 @@ const Weblab2View: React.FC<
   }, [dispatch, levelProperties?.initialViewMode]);
 
   return (
-    <AiChatDisabledProvider>
-      <div className={moduleStyles.weblab2Container}>
-        {hasSource && (
-          <Codebridge
-            config={config}
-            setConfig={setConfig}
-            startSources={startSources}
-            levelProperties={levelProperties}
-            hiddenContextCallback={aiTutorHelper.getHiddenContextCallback()}
-            aiTutorSystemPromptSettings={aiTutorSystemPromptSettings}
-            aiTutorMultimodalEnabled={true}
-            aiTutorChatButtonData={[]}
-            aiTutorContextHelper={aiTutorHelper}
-          />
-        )}
-      </div>
-    </AiChatDisabledProvider>
+    <div className={moduleStyles.weblab2Container}>
+      {hasSource && (
+        <Codebridge
+          config={config}
+          setConfig={setConfig}
+          startSources={startSources}
+          levelProperties={levelProperties}
+          hiddenContextCallback={aiTutorHelper.getHiddenContextCallback()}
+          aiTutorSystemPromptSettings={aiTutorSystemPromptSettings}
+          aiTutorMultimodalEnabled={true}
+          aiTutorChatButtonData={[]}
+          aiTutorContextHelper={aiTutorHelper}
+        />
+      )}
+    </div>
   );
 };
 

--- a/apps/static/aichat/ai-bot-locked-icon.png
+++ b/apps/static/aichat/ai-bot-locked-icon.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:23552417dbc15bcdace02738945d95e9b4915c1dd1dd0e4c8067266c7f5bc01d
+size 5275

--- a/apps/test/unit/aichat/AiChatDisabledProviderTest.tsx
+++ b/apps/test/unit/aichat/AiChatDisabledProviderTest.tsx
@@ -34,6 +34,7 @@ const UpdaterComponent: React.FC = () => {
     chatDisabledMessage,
     setChatDisabled,
     setChatDisabledMessage,
+    setChatDisabledState,
   } = useAiChatDisabled();
   return (
     <div>
@@ -42,8 +43,22 @@ const UpdaterComponent: React.FC = () => {
       <button type="button" onClick={() => setChatDisabled(!chatDisabled)}>
         toggle disabled
       </button>
-      <button type="button" onClick={() => setChatDisabledMessage('custom')}>
+      <button
+        type="button"
+        onClick={() => setChatDisabledMessage('custom message')}
+      >
         set message
+      </button>
+      <button
+        type="button"
+        onClick={() =>
+          setChatDisabledState({
+            chatDisabled: true,
+            chatDisabledMessage: 'both disabled and custom message',
+          })
+        }
+      >
+        set message and state
       </button>
     </div>
   );
@@ -65,18 +80,34 @@ describe('AiChatDisabledContext', () => {
 
   it('uses provided values from provider and allows updating via setters', () => {
     const {getByText, getByLabelText} = render(
-      <AiChatDisabledProvider chatDisabled={true} chatDisabledMessage="hello">
+      <AiChatDisabledProvider
+        chatDisabled={true}
+        chatDisabledMessage="default message"
+      >
         <UpdaterComponent />
       </AiChatDisabledProvider>
     );
 
-    expect(getByLabelText('chat disabled')).toHaveTextContent('true');
-    expect(getByLabelText('chat disabled message')).toHaveTextContent('hello');
+    expect(getByLabelText('chat disabled')).toHaveTextContent(/true/);
+    expect(getByLabelText('chat disabled message')).toHaveTextContent(
+      /default message/
+    );
 
+    // setChatDisabled
     getByText('toggle disabled').click();
-    expect(getByLabelText('chat disabled')).toHaveTextContent('false');
+    expect(getByLabelText('chat disabled')).toHaveTextContent(/false/);
 
+    // setChatDisabledMessage
     getByText('set message').click();
-    expect(getByLabelText('chat disabled message')).toHaveTextContent('custom');
+    expect(getByLabelText('chat disabled message')).toHaveTextContent(
+      /custom message/
+    );
+
+    // setChatDisabledState
+    getByText('set message and state').click();
+    expect(getByLabelText('chat disabled')).toHaveTextContent('true');
+    expect(getByLabelText('chat disabled message')).toHaveTextContent(
+      /both disabled and custom message/
+    );
   });
 });

--- a/apps/test/unit/aichat/AiChatDisabledProviderTest.tsx
+++ b/apps/test/unit/aichat/AiChatDisabledProviderTest.tsx
@@ -1,0 +1,82 @@
+import {render, screen} from '@testing-library/react';
+import React, {FC} from 'react';
+import '@testing-library/jest-dom';
+
+import {
+  AiChatDisabledProvider,
+  useAiChatDisabled,
+} from '@cdo/apps/aichat/context/aiChatDisabledContext';
+
+const ReaderComponent: FC = () => {
+  const {chatDisabled, chatDisabledMessage} = useAiChatDisabled();
+  return (
+    <div>
+      <div aria-label="chat disabled">{String(chatDisabled)}</div>
+      <div aria-label="chat disabled message">{chatDisabledMessage ?? ''}</div>
+    </div>
+  );
+};
+
+const SetterComponent: FC = () => {
+  const {setChatDisabled} = useAiChatDisabled();
+  // Invoke on render to validate error behavior when no provider
+  try {
+    setChatDisabled(true);
+  } catch (e) {
+    return <div aria-label="threw">true</div>;
+  }
+  return <div aria-label="threw">false</div>;
+};
+
+const UpdaterComponent: React.FC = () => {
+  const {
+    chatDisabled,
+    chatDisabledMessage,
+    setChatDisabled,
+    setChatDisabledMessage,
+  } = useAiChatDisabled();
+  return (
+    <div>
+      <div aria-label="chat disabled">{String(chatDisabled)}</div>
+      <div aria-label="chat disabled message">{chatDisabledMessage ?? ''}</div>
+      <button type="button" onClick={() => setChatDisabled(!chatDisabled)}>
+        toggle disabled
+      </button>
+      <button type="button" onClick={() => setChatDisabledMessage('custom')}>
+        set message
+      </button>
+    </div>
+  );
+};
+
+describe('AiChatDisabledContext', () => {
+  it('provides safe defaults without a provider', () => {
+    render(<ReaderComponent />);
+    expect(screen.getByLabelText('chat disabled')).toHaveTextContent('false');
+    expect(screen.getByLabelText('chat disabled message')).toHaveTextContent(
+      ''
+    );
+  });
+
+  it('throws in test/dev if setters are used without a provider', () => {
+    render(<SetterComponent />);
+    expect(screen.getByLabelText('threw')).toHaveTextContent('true');
+  });
+
+  it('uses provided values from provider and allows updating via setters', () => {
+    const {getByText, getByLabelText} = render(
+      <AiChatDisabledProvider chatDisabled={true} chatDisabledMessage="hello">
+        <UpdaterComponent />
+      </AiChatDisabledProvider>
+    );
+
+    expect(getByLabelText('chat disabled')).toHaveTextContent('true');
+    expect(getByLabelText('chat disabled message')).toHaveTextContent('hello');
+
+    getByText('toggle disabled').click();
+    expect(getByLabelText('chat disabled')).toHaveTextContent('false');
+
+    getByText('set message').click();
+    expect(getByLabelText('chat disabled message')).toHaveTextContent('custom');
+  });
+});

--- a/apps/test/unit/aichat/ChatEventsListTest.tsx
+++ b/apps/test/unit/aichat/ChatEventsListTest.tsx
@@ -1,0 +1,136 @@
+import {render, screen, waitFor} from '@testing-library/react';
+import React from 'react';
+
+import '@testing-library/jest-dom';
+import aichatI18n from '@cdo/apps/aichat/locale';
+import {CompletedChatMessage} from '@cdo/apps/aichat/types';
+import ChatEventsList from '@cdo/apps/aichat/views/ChatEventsList';
+import {Role} from '@cdo/apps/aiComponentLibrary/chatMessage/types';
+import {commonI18n} from '@cdo/apps/types/locale';
+import {
+  AiChatClientTypes,
+  AiInteractionStatus,
+} from '@cdo/generated-scripts/sharedConstants';
+
+const mockWaitingText = 'Waiting...';
+
+// Mock WaitingAnimation to render visible, queryable text
+jest.mock('@cdo/apps/aichat/views/WaitingAnimation', () => {
+  const React = require('react');
+  const Waiting = ({shouldDisplay}: {shouldDisplay: boolean}) =>
+    shouldDisplay ? React.createElement('div', null, mockWaitingText) : null;
+  return {__esModule: true, default: Waiting, WaitingAnimation: Waiting};
+});
+
+// Mock redux hooks to avoid real store; only selector value matters here
+let mockPending = false;
+jest.mock('@cdo/apps/util/reduxHooks', () => ({
+  __esModule: true,
+  useAppSelector: () => mockPending,
+  useAppDispatch: () => () => {},
+}));
+
+describe('ChatEventsList', () => {
+  it('renders disabled state message for ai tutor client type when disabled', () => {
+    render(
+      <ChatEventsList
+        events={[]}
+        clientType={AiChatClientTypes.AI_TUTOR}
+        disabled={true}
+      />
+    );
+
+    expect(screen.getByText(aichatI18n.aiTutorDisabled())).toBeInTheDocument();
+
+    // No chat messages or waiting animation should render
+    expect(screen.queryByLabelText(commonI18n.aiChatMessageUser())).toBeNull();
+    expect(screen.queryByLabelText(commonI18n.aiChatMessageBot())).toBeNull();
+    expect(screen.queryByText(mockWaitingText)).not.toBeInTheDocument();
+  });
+
+  it('renders general disabled state message for other client types when disabled', () => {
+    render(
+      <ChatEventsList
+        events={[]}
+        clientType={AiChatClientTypes.AI_CHAT_LAB}
+        disabled={true}
+      />
+    );
+
+    expect(screen.getByText(aichatI18n.aiChatDisabled())).toBeInTheDocument();
+
+    // No chat messages or waiting animation should render
+    expect(screen.queryByLabelText(commonI18n.aiChatMessageUser())).toBeNull();
+    expect(screen.queryByLabelText(commonI18n.aiChatMessageBot())).toBeNull();
+    expect(screen.queryByText(mockWaitingText)).not.toBeInTheDocument();
+  });
+
+  it('renders chat events (user and ai assistant messages)', () => {
+    const events: CompletedChatMessage[] = [
+      {
+        timestamp: Date.now() - 1000,
+        chatMessageText: 'Hello there!',
+        role: Role.USER,
+        status: AiInteractionStatus.OK,
+        requestId: 1,
+      },
+      {
+        timestamp: Date.now(),
+        chatMessageText: 'Hi! How can I help?',
+        role: Role.ASSISTANT,
+        status: AiInteractionStatus.OK,
+        requestId: 2,
+      },
+    ];
+
+    render(
+      <ChatEventsList
+        events={events}
+        clientType={AiChatClientTypes.AI_CHAT_LAB}
+      />
+    );
+
+    // Messages render with aria-labels from common strings
+    expect(
+      screen.getByLabelText(commonI18n.aiChatMessageUser())
+    ).toHaveTextContent('Hello there!');
+    expect(
+      screen.getByLabelText(commonI18n.aiChatMessageBot())
+    ).toHaveTextContent('Hi! How can I help?');
+  });
+
+  it('shows waiting animation when a chat message is pending', async () => {
+    const events: CompletedChatMessage[] = [
+      {
+        timestamp: Date.now() - 1000,
+        chatMessageText: 'Question for the bot',
+        role: Role.USER,
+        status: AiInteractionStatus.OK,
+        requestId: 100,
+      },
+    ];
+
+    const {rerender} = render(
+      <ChatEventsList
+        events={events}
+        clientType={AiChatClientTypes.AI_CHAT_LAB}
+      />
+    );
+
+    // Initially, waiting animation should not be present
+    expect(screen.queryByText(mockWaitingText)).not.toBeInTheDocument();
+
+    // Simulate a pending message via mocked selector and re-render
+    mockPending = true;
+    rerender(
+      <ChatEventsList
+        events={events}
+        clientType={AiChatClientTypes.AI_CHAT_LAB}
+      />
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText(mockWaitingText)).toBeInTheDocument();
+    });
+  });
+});

--- a/apps/test/unit/aichat/ChatEventsListTest.tsx
+++ b/apps/test/unit/aichat/ChatEventsListTest.tsx
@@ -2,15 +2,13 @@ import {render, screen, waitFor} from '@testing-library/react';
 import React from 'react';
 
 import '@testing-library/jest-dom';
+import {AiChatDisabledProvider} from '@cdo/apps/aichat/context/aiChatDisabledContext';
 import aichatI18n from '@cdo/apps/aichat/locale';
 import {CompletedChatMessage} from '@cdo/apps/aichat/types';
 import ChatEventsList from '@cdo/apps/aichat/views/ChatEventsList';
 import {Role} from '@cdo/apps/aiComponentLibrary/chatMessage/types';
 import {commonI18n} from '@cdo/apps/types/locale';
-import {
-  AiChatClientTypes,
-  AiInteractionStatus,
-} from '@cdo/generated-scripts/sharedConstants';
+import {AiInteractionStatus} from '@cdo/generated-scripts/sharedConstants';
 
 const mockWaitingText = 'Waiting...';
 
@@ -31,16 +29,14 @@ jest.mock('@cdo/apps/util/reduxHooks', () => ({
 }));
 
 describe('ChatEventsList', () => {
-  it('renders disabled state message for ai tutor client type when disabled', () => {
+  it('renders general disabled state message when disabled', () => {
     render(
-      <ChatEventsList
-        events={[]}
-        clientType={AiChatClientTypes.AI_TUTOR}
-        disabled={true}
-      />
+      <AiChatDisabledProvider chatDisabled>
+        <ChatEventsList events={[]} />
+      </AiChatDisabledProvider>
     );
 
-    expect(screen.getByText(aichatI18n.aiTutorDisabled())).toBeInTheDocument();
+    expect(screen.getByText(aichatI18n.aiChatDisabled())).toBeInTheDocument();
 
     // No chat messages or waiting animation should render
     expect(screen.queryByLabelText(commonI18n.aiChatMessageUser())).toBeNull();
@@ -48,16 +44,18 @@ describe('ChatEventsList', () => {
     expect(screen.queryByText(mockWaitingText)).not.toBeInTheDocument();
   });
 
-  it('renders general disabled state message for other client types when disabled', () => {
+  it('renders a custom disabled state message when provided', () => {
+    const customMessage = 'Ai chat is disabled for this student';
     render(
-      <ChatEventsList
-        events={[]}
-        clientType={AiChatClientTypes.AI_CHAT_LAB}
-        disabled={true}
-      />
+      <AiChatDisabledProvider chatDisabled chatDisabledMessage={customMessage}>
+        <ChatEventsList events={[]} />
+      </AiChatDisabledProvider>
     );
 
-    expect(screen.getByText(aichatI18n.aiChatDisabled())).toBeInTheDocument();
+    expect(screen.getByText(customMessage)).toBeInTheDocument();
+    expect(
+      screen.queryByText(aichatI18n.aiChatDisabled())
+    ).not.toBeInTheDocument();
 
     // No chat messages or waiting animation should render
     expect(screen.queryByLabelText(commonI18n.aiChatMessageUser())).toBeNull();
@@ -83,12 +81,7 @@ describe('ChatEventsList', () => {
       },
     ];
 
-    render(
-      <ChatEventsList
-        events={events}
-        clientType={AiChatClientTypes.AI_CHAT_LAB}
-      />
-    );
+    render(<ChatEventsList events={events} />);
 
     // Messages render with aria-labels from common strings
     expect(
@@ -110,24 +103,14 @@ describe('ChatEventsList', () => {
       },
     ];
 
-    const {rerender} = render(
-      <ChatEventsList
-        events={events}
-        clientType={AiChatClientTypes.AI_CHAT_LAB}
-      />
-    );
+    const {rerender} = render(<ChatEventsList events={events} />);
 
     // Initially, waiting animation should not be present
     expect(screen.queryByText(mockWaitingText)).not.toBeInTheDocument();
 
     // Simulate a pending message via mocked selector and re-render
     mockPending = true;
-    rerender(
-      <ChatEventsList
-        events={events}
-        clientType={AiChatClientTypes.AI_CHAT_LAB}
-      />
-    );
+    rerender(<ChatEventsList events={events} />);
 
     await waitFor(() => {
       expect(screen.getByText(mockWaitingText)).toBeInTheDocument();

--- a/apps/test/unit/aichat/UserChatMessageEditorTest.tsx
+++ b/apps/test/unit/aichat/UserChatMessageEditorTest.tsx
@@ -3,6 +3,7 @@ import userEvent from '@testing-library/user-event';
 import React from 'react';
 import '@testing-library/jest-dom';
 
+import {AiChatDisabledProvider} from '@cdo/apps/aichat/context/aiChatDisabledContext';
 import {AichatState} from '@cdo/apps/aichat/redux';
 import {
   AssetSource,
@@ -60,8 +61,12 @@ describe('UserChatMessageEditor', () => {
     };
   });
 
-  it('disables editor when disabled prop is true', async () => {
-    render(<UserChatMessageEditor {...baseProps} disabled />);
+  it('disables editor when disabled via context', async () => {
+    render(
+      <AiChatDisabledProvider chatDisabled>
+        <UserChatMessageEditor {...baseProps} />
+      </AiChatDisabledProvider>
+    );
 
     const textarea = screen.getByPlaceholderText(
       commonI18n.aiUserMessagePlaceholder()

--- a/apps/test/unit/aichat/UserChatMessageEditorTest.tsx
+++ b/apps/test/unit/aichat/UserChatMessageEditorTest.tsx
@@ -24,6 +24,7 @@ let mockState: {aichat: Partial<AichatState>} = {
     chatMessagePending: undefined,
     saveInProgress: false,
     stagedFiles: [],
+    userAddedSelectionContext: {},
   },
 };
 
@@ -57,6 +58,7 @@ describe('UserChatMessageEditor', () => {
         chatMessagePending: undefined,
         saveInProgress: false,
         stagedFiles: [],
+        userAddedSelectionContext: {},
       },
     };
   });

--- a/apps/test/unit/aichat/UserChatMessageEditorTest.tsx
+++ b/apps/test/unit/aichat/UserChatMessageEditorTest.tsx
@@ -1,0 +1,164 @@
+import {render, screen} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+import '@testing-library/jest-dom';
+
+import {AichatState} from '@cdo/apps/aichat/redux';
+import {
+  AssetSource,
+  ChatButtonComponent,
+  PendingChatMessage,
+} from '@cdo/apps/aichat/types';
+import UserChatMessageEditor from '@cdo/apps/aichat/views/UserChatMessageEditor';
+import {commonI18n} from '@cdo/apps/types/locale';
+import {
+  AiChatClientTypes,
+  AiChatModelIds,
+} from '@cdo/generated-scripts/sharedConstants';
+
+const mockDispatch = jest.fn();
+const mockSubmitChatContents = jest.fn();
+let mockState: {aichat: Partial<AichatState>} = {
+  aichat: {
+    chatMessagePending: undefined,
+    saveInProgress: false,
+    stagedFiles: [],
+  },
+};
+
+jest.mock('@cdo/apps/util/reduxHooks', () => ({
+  __esModule: true,
+  useAppSelector: (selector: (s: unknown) => unknown) => selector(mockState),
+  useAppDispatch: () => mockDispatch,
+}));
+
+jest.mock('@cdo/apps/aichat/redux', () => ({
+  __esModule: true,
+  submitChatContents: (...args: unknown[]) => mockSubmitChatContents(...args),
+}));
+
+describe('UserChatMessageEditor', () => {
+  const baseProps = {
+    modelParameters: {
+      selectedModelId: AiChatModelIds.GEMINI_2_0_FLASH,
+      temperature: 0.5,
+      systemPrompt: '',
+      retrievalContexts: [],
+    },
+    clientType: AiChatClientTypes.AI_TUTOR,
+  };
+
+  beforeEach(() => {
+    mockDispatch.mockReset();
+    mockSubmitChatContents.mockReset();
+    mockState = {
+      aichat: {
+        chatMessagePending: undefined,
+        saveInProgress: false,
+        stagedFiles: [],
+      },
+    };
+  });
+
+  it('disables editor when disabled prop is true', async () => {
+    render(<UserChatMessageEditor {...baseProps} disabled />);
+
+    const textarea = screen.getByPlaceholderText(
+      commonI18n.aiUserMessagePlaceholder()
+    );
+    const submit = screen.getByLabelText(commonI18n.submit());
+
+    expect(textarea).toBeDisabled();
+    expect(submit).toBeDisabled();
+  });
+
+  it('disables editor when chat response is pending', async () => {
+    mockState.aichat.chatMessagePending = {
+      status: 'unknown',
+    } as PendingChatMessage;
+
+    render(<UserChatMessageEditor {...baseProps} />);
+
+    const textarea = screen.getByPlaceholderText(
+      commonI18n.aiUserMessagePlaceholder()
+    );
+    expect(textarea).toBeDisabled();
+  });
+
+  it('submits on Enter and clears the input when enabled', async () => {
+    const user = userEvent.setup();
+    render(<UserChatMessageEditor {...baseProps} />);
+
+    const textarea = screen.getByPlaceholderText(
+      commonI18n.aiUserMessagePlaceholder()
+    );
+
+    await user.click(textarea);
+    await user.type(textarea, 'Hello bot');
+    await user.keyboard('{Enter}');
+
+    expect(mockSubmitChatContents).toHaveBeenCalledTimes(1);
+    // First arg is the payload object
+    expect(mockSubmitChatContents.mock.calls[0][0]).toMatchObject({
+      text: 'Hello bot',
+    });
+    // Input clears after submit
+    expect(textarea).toHaveValue('');
+  });
+
+  it('renders canned prompt chat buttons and clicking one triggers submit with analytics', async () => {
+    const user = userEvent.setup();
+    const ExampleButton: ChatButtonComponent = ({onClick}) => (
+      <button
+        type="button"
+        onClick={() =>
+          onClick('Can you give me an example?', {
+            cannedPrompt: 'example',
+          })
+        }
+      >
+        Give an example
+      </button>
+    );
+
+    render(
+      <UserChatMessageEditor
+        {...baseProps}
+        chatButtons={[{ChatButton: ExampleButton, key: 'Give an example'}]}
+      />
+    );
+
+    await user.click(screen.getByRole('button', {name: 'Give an example'}));
+    expect(mockSubmitChatContents).toHaveBeenCalledTimes(1);
+    expect(mockSubmitChatContents.mock.calls[0][0]).toMatchObject({
+      text: 'Can you give me an example?',
+      analyticsProperties: {cannedPrompt: 'example'},
+    });
+  });
+
+  it('includes uploaded assets when multimodal is available', async () => {
+    const user = userEvent.setup();
+    const file = {filename: 'a.png', source: AssetSource.PROJECT};
+    mockState.aichat.stagedFiles = [
+      {
+        key: '1',
+        asset: file,
+        status: 'uploaded',
+      },
+    ];
+
+    render(<UserChatMessageEditor {...baseProps} multimodalAvailable={true} />);
+
+    const textarea = screen.getByPlaceholderText(
+      commonI18n.aiUserMessagePlaceholder()
+    );
+    await user.type(textarea, 'Use my image');
+    await user.keyboard('{Enter}');
+
+    expect(mockSubmitChatContents).toHaveBeenCalledTimes(1);
+    expect(mockSubmitChatContents.mock.calls[0][0]).toMatchObject({
+      text: 'Use my image',
+      assets: [file],
+    });
+  });
+});

--- a/apps/test/unit/pythonlab/PythonlabViewTest.tsx
+++ b/apps/test/unit/pythonlab/PythonlabViewTest.tsx
@@ -4,6 +4,7 @@ import React from 'react';
 import {Provider} from 'react-redux';
 import {Store} from 'redux';
 
+import {AiChatDisabledProvider} from '@cdo/apps/aichat/context/aiChatDisabledContext';
 import progress from '@cdo/apps/code-studio/progressRedux';
 import lab from '@cdo/apps/lab2/lab2Redux';
 import lab2Project from '@cdo/apps/lab2/redux/lab2ProjectRedux';
@@ -63,10 +64,12 @@ describe('PythonLabView', () => {
     return render(
       <Provider store={store}>
         <ThemeProvider>
-          <PythonlabView
-            levelProperties={levelProperties}
-            initialSources={initialSources}
-          />
+          <AiChatDisabledProvider>
+            <PythonlabView
+              levelProperties={levelProperties}
+              initialSources={initialSources}
+            />
+          </AiChatDisabledProvider>
         </ThemeProvider>
       </Provider>
     );


### PR DESCRIPTION
This pull request introduces a new context for managing the AI chat disabled state and integrates it throughout the AI chat feature. The main goal is to allow the application to globally disable AI chat and display a user-friendly message when chat is unavailable. Several components have been updated to respect this state, and a new visual indicator is added for disabled chat. Unit tests are also included to verify correct behavior.

**AI Chat Disabled State Management**

* Added `AiChatDisabledContext` and `AiChatDisabledProvider` in `aiChatDisabledContext.tsx`, enabling global state management for disabling AI chat and customizing the disabled message.
* Integrated `AiChatDisabledProvider` into the main component trees for both Aichat and Codebridge views, ensuring all child components can access the disabled state.

**Component Updates for Disabled State**

* Updated `ChatEventsList`, `ChatWorkspace`, and `UserChatMessageEditor` to use the new context, disabling interactions and hiding controls when chat is disabled.

**User Experience Improvements**

* Added a new `ChatDisabled` component that displays a message and a locked bot icon when chat is disabled, with corresponding styling and a new icon asset.
* Added a new localization string for the default disabled message.

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

<img width="743" height="890" alt="Screenshot 2025-09-18 at 11 43 08 AM" src="https://github.com/user-attachments/assets/778dfbe2-8803-4be7-a661-2623520c30fe" />


## Links
<!--  Links to relevant external resources.
      - spec docs, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- Jira: https://codedotorg.atlassian.net/browse/LABS-1555

## Testing story
<!--  Does your change include appropriate tests?
      - If so, please describe how the tests included in this PR are sufficient.
      - If not, please explain why this change does not need to be tested. -->
 
* Added unit tests for `ChatEventsList` to verify correct rendering when chat is disabled, including custom messages and hiding of chat events and waiting animation.
* Added unit tests for `UserChatMessageEditor` to ensure chat editor controls are disabled, along with a back fill testing some existing functionality
* Added unit tests for `AiChatDisabledProvider` ensuring that consumers of the context hook that set values throw an error in non-production environments if not wrapped in the provider, and consumers that just receive the state values get the default, non-disabled values. This ensures flexibility to use the chat components without the provider, but with a warning if trying to manipulate the state without wrapping in the provider.



## Deployment strategy
<!--  Any special steps required to deploy this, besides merging?
      - Are there database migrations or manual steps?
      - Does this require coordination with other teams or systems? -->



## Follow-up work
<!--  List any clean-up or technical debt that will be addressed in future work.
      - Include Jira links where applicable.
      - Are there any known limitations or improvements planned? -->



## Privacy
<!--  How does this change impact Student & Teacher privacy?
      - Does this collect, use, share, or modify PII, either new or existing? -->



## Security
<!--  How does this change impact our security surface-area?
      - Do API's touched have the right auth?
      - Do infra changes impact our attack surface or encryption?
-->



## Caching
<!--  How does this change impact caching behavior?
      - Are cache keys or invalidation strategies affected?
      - Will this require cache warming or invalidation after deployment? -->



## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
