### PR TITLE
Revert "reduce single_unit_course? query count"

### DIFF
--- a/dashboard/app/models/unit_group.rb
+++ b/dashboard/app/models/unit_group.rb
@@ -638,7 +638,7 @@ class UnitGroup < ApplicationRecord
   # rubocop:enable Naming/PredicateName
 
   def single_unit_course?
-    cached.default_unit_group_units.one?
+    default_unit_group_units.one?
   end
 
   def first_unit

--- a/dashboard/test/integration/caching_test.rb
+++ b/dashboard/test/integration/caching_test.rb
@@ -15,28 +15,28 @@ class CachingTest < ActionDispatch::IntegrationTest
     create_hourofcode_unit_and_levels
     setup_script_cache
 
-    assert_cached_queries(0) do
+    assert_cached_queries(1) do
       get '/hoc/1'
     end
     assert_response :success
   end
 
   test "should get other hoc course unit overview" do
-    assert_cached_queries(0) do
+    assert_cached_queries(1) do
       get "/courses/#{@other_hoc_course.name}/units/1"
     end
     assert_response :success
   end
-
+  #TODO: Figure out if we can bring single_unit_course? down to 0 queries again
   test "should get show of other hoc course level 1" do
-    assert_cached_queries(0) do
+    assert_cached_queries(1) do
       get "/courses/#{@other_hoc_course.name}/units/1/lessons/1/levels/1"
     end
     assert_response :success
   end
 
   test "should get show of other hoc course level 10 twice" do
-    assert_cached_queries(0) do
+    assert_cached_queries(1) do
       get "/courses/#{@other_hoc_course.name}/units/1/lessons/1/levels/10"
     end
     assert_response :success
@@ -46,7 +46,7 @@ class CachingTest < ActionDispatch::IntegrationTest
     get "/courses/#{@other_hoc_course.name}/units/1/lessons/1/levels/1"
     assert_response :success
 
-    assert_cached_queries(0) do
+    assert_cached_queries(1) do
       get "/courses/#{@other_hoc_course.name}/units/1/lessons/1/levels/10"
     end
     assert_response :success
@@ -79,14 +79,14 @@ class CachingTest < ActionDispatch::IntegrationTest
   # end
 
   test "should get show of lesson 3 level 1 twice" do
-    assert_cached_queries(0) do
+    assert_cached_queries(1) do
       get "/courses/#{@multi_lesson_unit_group.name}/units/1/lessons/3/levels/1"
     end
     assert_response :success
   end
 
   test "should get show of lesson 3 level 1 and then level 10" do
-    assert_cached_queries(0) do
+    assert_cached_queries(1) do
       get "/courses/#{@multi_lesson_unit_group.name}/units/1/lessons/3/levels/10"
     end
     assert_response :success

--- a/dashboard/test/integration/db_query_test.rb
+++ b/dashboard/test/integration/db_query_test.rb
@@ -22,8 +22,8 @@ class DBQueryTest < ActionDispatch::IntegrationTest
       level: level,
       level_source: create(:level_source, level: level)
 )
-
-    assert_cached_queries(18) do
+    #TODO: Figure out if we can bring single_unit_course? down to 0 queries again
+    assert_cached_queries(19) do
       get course_unit_lesson_script_level_path(
         course_course_name: script.get_original_unit_group.name,
         unit_position: 1,
@@ -178,7 +178,7 @@ class DBQueryTest < ActionDispatch::IntegrationTest
     student.assign_script(unit)
     sign_in student
 
-    assert_cached_queries(21) do
+    assert_cached_queries(22) do
       get "/courses/#{course.name}/units/1/lessons/1/levels/1"
       assert_response :success
     end


### PR DESCRIPTION
Reverts code-dot-org/code-dot-org#68404

Dashboard test failure: 
```
====[0m[1000D[K FAIL["test_cached_query_test_for_hoc_course", "CongratsControllerTest", 85.62345476355404]
 test_cached_query_test_for_hoc_course#CongratsControllerTest (85.62s)
        Wrong query count:
          [1m[35m (0.0ms)[0m  [1m[34mSELECT COUNT(*) FROM `course_scripts` WHERE `course_scripts`.`course_id` = 1491[0m
        config/initializers/mysql_check_index_used.rb:24:in `execute'
        app/models/unit_group.rb:641:in `single_unit_course?'
        app/controllers/congrats_controller.rb:23:in `index'
        app/controllers/application_controller.rb:431:in `with_global_current_user'
        test/controllers/congrats_controller_test.rb:36:in `block (2 levels) in <class:CongratsControllerTest>'
        test/controllers/congrats_controller_test.rb:33:in `block in <class:CongratsControllerTest>'
        .
        Expected: 0
          Actual: 1
        test/testing/capture_queries.rb:29:in `assert_queries'
        test/testing/capture_queries.rb:34:in `block in assert_cached_queries'
        test/testing/capture_queries.rb:33:in `assert_cached_queries'
        test/controllers/congrats_controller_test.rb:33:in `block in <class:CongratsControllerTest>'
        test/testing/setup_all_and_teardown_all.rb:36:in `run'

=========|
```