### PR TITLE
Web Lab 2: adjust left and right panel widths

### DIFF
--- a/apps/src/weblab2/layout/VerticalLayout.tsx
+++ b/apps/src/weblab2/layout/VerticalLayout.tsx
@@ -24,11 +24,11 @@ import lab2Styles from '@cdo/apps/lab2/views/components/layout/layout.module.scs
 import weblab2Styles from '@cdo/apps/weblab2/layout/vertical-layout.module.scss';
 
 const MIN_INFO_PANEL_WIDTH = 150;
-const INITIAL_INFO_PANEL_WIDTH = 300;
+const INITIAL_INFO_PANEL_WIDTH = 400;
 const INITIAL_INFO_PANEL_WIDTH_WIDGET = 500;
 const MIN_EDITOR_WIDTH = 300;
 const MIN_PREVIEW_WIDTH = 200;
-const INITIAL_PREVIEW_WIDTH = 600;
+const INITIAL_PREVIEW_WIDTH = 400;
 const INITIAL_PREVIEW_WIDTH_WIDGET = 900;
 
 const VerticalLayout: React.FunctionComponent<LayoutProps> = ({


### PR DESCRIPTION
Increases the size of the Resources left side panel to better accommodate AI Tutor, and decreases the size of the Preview right side panel.

## Links
Jira ticket: [AFL-157](https://codedotorg.atlassian.net/browse/AFL-157)

## Testing story
Tested locally

----

## Before
<img width="1382" height="839" alt="Screenshot 2025-09-18 at 12 53 38 PM" src="https://github.com/user-attachments/assets/5efb8589-c6a9-4a6b-bc6c-b6cdd68574a4" />


## After
<img width="1382" height="839" alt="Screenshot 2025-09-18 at 12 54 27 PM" src="https://github.com/user-attachments/assets/bd04365f-a5b0-4cf7-a0ec-68cb5eb2c6a4" />

