### PR TITLE
Use reporting role for Inactive Teacher mailer query

### DIFF
--- a/dashboard/app/jobs/user/inactive_teacher_deletion_warning_job.rb
+++ b/dashboard/app/jobs/user/inactive_teacher_deletion_warning_job.rb
@@ -60,8 +60,10 @@ class User
     end
 
     private def mark_warning_email_sent(teacher_id)
-      user_data_retention_status = ::User::DataRetentionStatus.find_or_initialize_by(user_id: teacher_id)
-      user_data_retention_status.update!(deletion_warning_email_sent_at: Time.current)
+      ActiveRecord::Base.connected_to(role: :writing) do
+        user_data_retention_status = ::User::DataRetentionStatus.find_or_initialize_by(user_id: teacher_id)
+        user_data_retention_status.update!(deletion_warning_email_sent_at: Time.current)
+      end
     end
   end
 end

--- a/dashboard/app/jobs/user/inactive_teacher_deletion_warning_job.rb
+++ b/dashboard/app/jobs/user/inactive_teacher_deletion_warning_job.rb
@@ -30,9 +30,11 @@ class User
         scope: ::Teacher.all,
         inactive_since: inactive_since,
       )
-      result = inactive_query.call.left_outer_joins(:user_data_retention_status)
-      @inactive_teachers ||= result.where(user_data_retention_status: {deletion_warning_email_sent_at: nil}).
-        or(result.where(user_data_retention_status: {deletion_warning_email_sent_at: ..inactive_since}))
+      ActiveRecord::Base.connected_to(role: :reporting) do
+        result = inactive_query.call.left_outer_joins(:user_data_retention_status)
+        @inactive_teachers ||= result.where(user_data_retention_status: {deletion_warning_email_sent_at: nil}).
+          or(result.where(user_data_retention_status: {deletion_warning_email_sent_at: ..inactive_since}))
+      end
     end
 
     private def send_warning_email(user)

--- a/dashboard/app/jobs/user/inactive_teacher_deletion_warning_job.rb
+++ b/dashboard/app/jobs/user/inactive_teacher_deletion_warning_job.rb
@@ -7,8 +7,10 @@ class User
     EVENT_NAME = 'inactive_teacher_deletion_warning_sent'
 
     rescue_from StandardError, with: :report_exception
+    attr_reader :processed_teacher_ids
 
     def perform
+      @processed_teacher_ids = []
       inactive_teachers.find_each do |teacher|
         next if teacher.email.blank?
         send_warning_email(teacher)
@@ -21,6 +23,8 @@ class User
             teacher_id: teacher.id,
           }
         )
+      ensure
+        processed_teacher_ids << teacher.id
       end
     end
 
@@ -33,7 +37,8 @@ class User
       ActiveRecord::Base.connected_to(role: :reporting) do
         result = inactive_query.call.left_outer_joins(:user_data_retention_status)
         @inactive_teachers ||= result.where(user_data_retention_status: {deletion_warning_email_sent_at: nil}).
-          or(result.where(user_data_retention_status: {deletion_warning_email_sent_at: ..inactive_since}))
+          or(result.where(user_data_retention_status: {deletion_warning_email_sent_at: ..inactive_since})).
+          where.not(id: processed_teacher_ids)
       end
     end
 

--- a/dashboard/app/jobs/user/inactive_teacher_deletion_warning_job.rb
+++ b/dashboard/app/jobs/user/inactive_teacher_deletion_warning_job.rb
@@ -52,7 +52,7 @@ class User
           :inactive_teacher_deletion_warning,
           user.email,
           user.name,
-          vars: {first_name: user.given_name || user.name},
+          vars: {first_name: user.given_name.presence || user.name.presence || "Code.org user"},
         )
       end
     end

--- a/dashboard/app/jobs/user/inactive_teacher_deletion_warning_job.rb
+++ b/dashboard/app/jobs/user/inactive_teacher_deletion_warning_job.rb
@@ -7,25 +7,29 @@ class User
     EVENT_NAME = 'inactive_teacher_deletion_warning_sent'
 
     rescue_from StandardError, with: :report_exception
-    attr_reader :processed_teacher_ids
 
     def perform
-      @processed_teacher_ids = []
-      inactive_teachers.find_each do |teacher|
-        next if teacher.email.blank?
-        send_warning_email(teacher)
-        # Set email sent at field
-        mark_warning_email_sent(teacher.id)
+      ActiveRecord::Base.connected_to(role: :reporting) do
+        inactive_teachers.find_each do |teacher|
+          next if teacher.email.blank?
+          send_warning_email(teacher)
+          # Set email sent at field
+          mark_warning_email_sent(teacher.id)
 
-        Metrics::Events.log_event(
-          event_name: EVENT_NAME,
-          metadata: {
-            teacher_id: teacher.id,
-          }
-        )
-      ensure
-        processed_teacher_ids << teacher.id
+          Metrics::Events.log_event(
+            event_name: EVENT_NAME,
+            metadata: {
+              teacher_id: teacher.id,
+            }
+          )
+        ensure
+          processed_teacher_ids << teacher.id
+        end
       end
+    end
+
+    def processed_teacher_ids
+      @processed_teacher_ids ||= []
     end
 
     private def inactive_teachers
@@ -34,12 +38,10 @@ class User
         scope: ::Teacher.all,
         inactive_since: inactive_since,
       )
-      ActiveRecord::Base.connected_to(role: :reporting) do
-        result = inactive_query.call.left_outer_joins(:user_data_retention_status)
-        @inactive_teachers ||= result.where(user_data_retention_status: {deletion_warning_email_sent_at: nil}).
-          or(result.where(user_data_retention_status: {deletion_warning_email_sent_at: ..inactive_since})).
-          where.not(id: processed_teacher_ids)
-      end
+      result = inactive_query.call.left_outer_joins(:user_data_retention_status)
+      @inactive_teachers ||= result.where(user_data_retention_status: {deletion_warning_email_sent_at: nil}).
+        or(result.where(user_data_retention_status: {deletion_warning_email_sent_at: ..inactive_since})).
+        where.not(id: processed_teacher_ids)
     end
 
     private def send_warning_email(user)

--- a/dashboard/test/lib/services/user/inactive_teacher_deletion_warning_job_test.rb
+++ b/dashboard/test/lib/services/user/inactive_teacher_deletion_warning_job_test.rb
@@ -121,7 +121,6 @@ class User::InactiveTeacherDeletionWarningJobTest < ActiveJob::TestCase
     end
 
     it 'does not include accounts from processed_teacher_ids' do
-      described_instance.instance_variable_set(:@processed_teacher_ids, [])
       user = create(:teacher, current_sign_in_at: inactive_since - 1.day, user_data_retention_status: create(:user_data_retention_status))
       described_instance.processed_teacher_ids << user.id
       _(inactive_teachers).wont_include user

--- a/dashboard/test/lib/services/user/inactive_teacher_deletion_warning_job_test.rb
+++ b/dashboard/test/lib/services/user/inactive_teacher_deletion_warning_job_test.rb
@@ -100,7 +100,8 @@ class User::InactiveTeacherDeletionWarningJobTest < ActiveJob::TestCase
   end
 
   describe '#inactive_teachers' do
-    let(:inactive_teachers) {described_class.new.send(:inactive_teachers)}
+    subject(:described_instance) {described_class.new}
+    let(:inactive_teachers) {described_instance.send(:inactive_teachers)}
     let(:inactive_since) {42.months.ago}
     it 'returns inactive users who have not been sent deletion warning email' do
       expected_user = create(:teacher, current_sign_in_at: inactive_since - 1.day, user_data_retention_status: create(:user_data_retention_status))
@@ -117,6 +118,13 @@ class User::InactiveTeacherDeletionWarningJobTest < ActiveJob::TestCase
       expected_user = create(:teacher, current_sign_in_at: inactive_since - 1.day, user_data_retention_status: create(:user_data_retention_status))
       expected_user.user_data_retention_status.update!(deletion_warning_email_sent_at: 40.months.ago)
       _(inactive_teachers).wont_include expected_user
+    end
+
+    it 'does not include accounts from processed_teacher_ids' do
+      described_instance.instance_variable_set(:@processed_teacher_ids, [])
+      user = create(:teacher, current_sign_in_at: inactive_since - 1.day, user_data_retention_status: create(:user_data_retention_status))
+      described_instance.processed_teacher_ids << user.id
+      _(inactive_teachers).wont_include user
     end
   end
 end


### PR DESCRIPTION
Use reproting role for `inactive_teachers` query to avoid timeouts.

This PR also adds the `processed_teacher_ids` array, which is used in the query so that users are not reprocessed.

Checks for presence of both `given_name` and `name` so empty strings are not passed to MailJet. Also adds a fallback string in "Code.org user" when both are nil.

## Links


- Jira: 



