### PR TITLE
Web Lab 2: Turn on AI Tutor universally

### DIFF
--- a/apps/src/lab2/ai/aiTutorConstants.ts
+++ b/apps/src/lab2/ai/aiTutorConstants.ts
@@ -1,5 +1,0 @@
-// A list of labs for which AI Tutor is always on, regardless of
-// level properties or experiment flags. Usage of AI tutor is still
-// constrained by user permissions; if the user cannot use AI Tutor
-// they will see an error message when trying to chat with it.
-export const LABS_ALWAYS_USING_AI_TUTOR = ['weblab2'];

--- a/apps/src/lab2/ai/aiTutorConstants.ts
+++ b/apps/src/lab2/ai/aiTutorConstants.ts
@@ -1,0 +1,5 @@
+// A list of labs for which AI Tutor is always on, regardless of
+// level properties or experiment flags. Usage of AI tutor is still
+// constrained by user permissions; if the user cannot use AI Tutor
+// they will see an error message when trying to chat with it.
+export const LABS_ALWAYS_USING_AI_TUTOR = ['weblab2'];

--- a/apps/src/lab2/ai/shouldShowAiTutor.ts
+++ b/apps/src/lab2/ai/shouldShowAiTutor.ts
@@ -1,0 +1,14 @@
+import {queryParams} from '@cdo/apps/code-studio/utils';
+
+import {LABS_ALWAYS_USING_AI_TUTOR} from './aiTutorConstants';
+
+export const shouldShowAiTutor = (
+  appName: string,
+  aiTutorAvailable: boolean | undefined
+) => {
+  return (
+    LABS_ALWAYS_USING_AI_TUTOR.includes(appName) ||
+    aiTutorAvailable ||
+    queryParams('show-ai-tutor2') === 'true'
+  );
+};

--- a/apps/src/lab2/ai/shouldShowAiTutor.ts
+++ b/apps/src/lab2/ai/shouldShowAiTutor.ts
@@ -1,13 +1,17 @@
 import {queryParams} from '@cdo/apps/code-studio/utils';
 
-import {LABS_ALWAYS_USING_AI_TUTOR} from './aiTutorConstants';
+// A list of app names for which AI Tutor is always on, regardless of
+// level properties or experiment flags. Usage of AI tutor is still
+// constrained by user permissions; if the user cannot use AI Tutor
+// they will see an error message when trying to chat with it.
+export const APPS_ALWAYS_USING_AI_TUTOR = ['weblab2'];
 
 export const shouldShowAiTutor = (
   appName: string,
   aiTutorAvailable: boolean | undefined
 ) => {
   return (
-    LABS_ALWAYS_USING_AI_TUTOR.includes(appName) ||
+    APPS_ALWAYS_USING_AI_TUTOR.includes(appName) ||
     aiTutorAvailable ||
     queryParams('show-ai-tutor2') === 'true'
   );

--- a/apps/src/lab2/views/components/Instructions/ResourcePanel/index.tsx
+++ b/apps/src/lab2/views/components/Instructions/ResourcePanel/index.tsx
@@ -6,8 +6,7 @@ import classNames from 'classnames';
 import React, {useEffect, useMemo, useState} from 'react';
 
 import {ChatButtonData, SystemPromptSettings} from '@cdo/apps/aichat/types';
-import {queryParams} from '@cdo/apps/code-studio/utils';
-import {LABS_ALWAYS_USING_AI_TUTOR} from '@cdo/apps/lab2/ai/aiTutorConstants';
+import {shouldShowAiTutor} from '@cdo/apps/lab2/ai/shouldShowAiTutor';
 import {isReadOnlyWorkspace} from '@cdo/apps/lab2/redux/lab2ReduxSelectors';
 import {ProjectSources} from '@cdo/apps/lab2/types';
 import AiTutor2Chat from '@cdo/apps/lab2/views/components/AiTutor2Chat';
@@ -154,9 +153,7 @@ const ResourcePanel: React.FC<ResourcePanelProps> = ({
 
     if (
       hiddenContextCallback &&
-      (LABS_ALWAYS_USING_AI_TUTOR.includes(appName) ||
-        levelProperties.aiTutorAvailable ||
-        queryParams('show-ai-tutor2') === 'true')
+      shouldShowAiTutor(appName, levelProperties.aiTutorAvailable)
     ) {
       tabMap[Tabs.AiTutor] = (
         <AiTutor2Chat

--- a/apps/src/lab2/views/components/Instructions/ResourcePanel/index.tsx
+++ b/apps/src/lab2/views/components/Instructions/ResourcePanel/index.tsx
@@ -199,6 +199,7 @@ const ResourcePanel: React.FC<ResourcePanelProps> = ({
     hasValidationConditions,
     isUserTeacher,
     hiddenContextCallback,
+    appName,
     isReadOnly,
     isViewingOldVersion,
     viewAsUserId,

--- a/apps/src/lab2/views/components/Instructions/ResourcePanel/index.tsx
+++ b/apps/src/lab2/views/components/Instructions/ResourcePanel/index.tsx
@@ -7,6 +7,7 @@ import React, {useEffect, useMemo, useState} from 'react';
 
 import {ChatButtonData, SystemPromptSettings} from '@cdo/apps/aichat/types';
 import {queryParams} from '@cdo/apps/code-studio/utils';
+import {LABS_ALWAYS_USING_AI_TUTOR} from '@cdo/apps/lab2/ai/aiTutorConstants';
 import {isReadOnlyWorkspace} from '@cdo/apps/lab2/redux/lab2ReduxSelectors';
 import {ProjectSources} from '@cdo/apps/lab2/types';
 import AiTutor2Chat from '@cdo/apps/lab2/views/components/AiTutor2Chat';
@@ -119,6 +120,7 @@ const ResourcePanel: React.FC<ResourcePanelProps> = ({
   );
   const levelName = instructionsProps.levelProperties.name;
   const channelId = useAppSelector(state => state.lab.channel?.id);
+  const appName = instructionsProps.levelProperties.appName;
 
   // Build available tabs based on level information.
   const availableTabs = useMemo(() => {
@@ -151,9 +153,10 @@ const ResourcePanel: React.FC<ResourcePanelProps> = ({
     }
 
     if (
-      (levelProperties.aiTutorAvailable ||
-        queryParams('show-ai-tutor2') === 'true') &&
-      hiddenContextCallback
+      hiddenContextCallback &&
+      (LABS_ALWAYS_USING_AI_TUTOR.includes(appName) ||
+        levelProperties.aiTutorAvailable ||
+        queryParams('show-ai-tutor2') === 'true')
     ) {
       tabMap[Tabs.AiTutor] = (
         <AiTutor2Chat


### PR DESCRIPTION
This puts AI Tutor in the resource panel for all Web Lab 2 levels. There is no change to other lab types.

Right now you can use AI Tutor if you are a teacher or in a teacher's section. I believe that will be loosened by #68393.

## Testing story
Tested that web lab 2 has ai tutor always on, but python lab is still based on level configuration.



## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
