### PR TITLE
AI Chat: improve scroll

### DIFF
--- a/apps/src/aichat/views/chatWorkspace.module.scss
+++ b/apps/src/aichat/views/chatWorkspace.module.scss
@@ -30,6 +30,7 @@ $tabs-default-spacing: 4px;
 
 .scrollToBottomButton {
   border-radius: 50%;
+  pointer-events: auto;
 }
 
 .messageArea {
@@ -49,6 +50,7 @@ $tabs-default-spacing: 4px;
   display: flex;
   justify-content: center;
   width: 100%;
+  pointer-events: none;
 }
 
 .tabsContainer {


### PR DESCRIPTION
Before this change, when hovering to the left or right of the "scroll to bottom" button in AI Chat (in the regions highlighted in yellow in the below screenshot), it was not possible to scroll the chat.
 
<img width="307" height="83" alt="Screenshot 2025-09-19 at 8 43 06 AM" src="https://github.com/user-attachments/assets/d9cf72c0-ab3a-44aa-8874-bc229abbc2dd" />

###

This change restricts pointer events to the button itself, enabling the scroll when hovering to the left or right of it.
