### PR TITLE
Fix join section success notification when joining non-PL section on PL page

### DIFF
--- a/apps/src/templates/studioHomepages/JoinSectionNotifications.jsx
+++ b/apps/src/templates/studioHomepages/JoinSectionNotifications.jsx
@@ -66,18 +66,7 @@ const JoinSectionSuccessNotification = ({
   joiningPlSection,
 }) => {
   let notificationMessage = null;
-  if (showingPlSections && !joiningPlSection) {
-    // Notify user if they are joining a non-PL section on the My PL page so they'll have to
-    // go to the Teacher Homepage if they want to view it.
-    notificationMessage = (
-      <SafeMarkdown
-        markdown={i18n.sectionsNotificationJoinSuccessForNonPlWrongPage({
-          sectionName: sectionName,
-          teacherHomepageUrl: studio('/home'),
-        })}
-      />
-    );
-  } else if (!showingPlSections && joiningPlSection) {
+  if (!showingPlSections && joiningPlSection) {
     // Notify user if they are joining a Professional Learning section not on the My PL page
     // so they'll have to go to the My PL page if they want to view it.
     notificationMessage = (


### PR DESCRIPTION
Currently, if a user joins a non-PL section on the My PL page, they are told they've successfully joined but must view the teacher dashboard to view the section. This is no longer how the teacher dashboard is set up so this case is removed, so now it just shows the "You joined [section name]" message.

<img width="760" height="338" alt="non pl success" src="https://github.com/user-attachments/assets/5bb144d4-bcae-47c8-8840-c6e54e9830d9" />

## Links
Jira ticket: [here](https://codedotorg.atlassian.net/jira/software/projects/AITT/boards/70?jql=assignee%20%3D%2060d62161f65054006980bd71&selectedIssue=AITT-1145)

## Testing story
Local testing.
