### PR TITLE
AI Tutor - Hardcode Gemini thinking budget to 0

### DIFF
--- a/dashboard/app/helpers/aichat_gemini_client.rb
+++ b/dashboard/app/helpers/aichat_gemini_client.rb
@@ -44,7 +44,11 @@ class AichatGeminiClient < AichatAiClient
       generationConfig: {
         temperature: config[:temperature],
         responseMimeType: response_mime_type,
-        responseJsonSchema: response_json_schema
+        responseJsonSchema: response_json_schema,
+        # Set thinking budget to 0 to disable "thinking".
+        thinkingConfig: {
+          thinkingBudget: 0
+        }
       }.compact, # Use compact to remove null responseMimeType / responseJsonSchema
       system_instruction: {
         parts: format_parts(config[:systemInstructions])

--- a/dashboard/test/helpers/aichat_gemini_client_test.rb
+++ b/dashboard/test/helpers/aichat_gemini_client_test.rb
@@ -10,7 +10,10 @@ class AichatGeminiClientTest < AichatAiClientTest
 
   let(:generation_config) do
     {
-      temperature: 1.0
+      temperature: 1.0,
+      thinkingConfig: {
+        thinkingBudget: 0
+      }
     }
   end
 


### PR DESCRIPTION
This PR hardcodes the Gemini [thinking budget ](https://ai.google.dev/gemini-api/docs/thinking)setting to 0.  The default value is a dynamic thinking budget which can lead to very long delays when doing coding tasks.  An internal default of 0 will ensure quick responses (very noticeable speedup in basic questions!), and we can follow this up with the ability to adjust the setting in various contexts.

## Links
This was discussed in depth in this [slack thread](https://codedotorg.slack.com/archives/C08S29NDZ5E/p1758105644630229) and captured in 
this [Jira ticket](https://codedotorg.atlassian.net/browse/LABS-1579?atlOrigin=eyJpIjoiMjlmODZjYWNlYjg1NGZjMmE0NjRjOGEwNDRmNzkwNGQiLCJwIjoiaiJ9).

## Testing story
This PR updates tests to stub gemini requests with the thinking budget setting set to 0.

## Follow-up work
This PR will be followed up with additional work to bring the thinking budget setting to the frontend and expose it through a query param for addition exploration.

## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
