### PR TITLE
feat(HofAI): implement basic HofAI activity catalog

### DIFF
--- a/frontend/apps/marketing/package.json
+++ b/frontend/apps/marketing/package.json
@@ -57,6 +57,8 @@
     "@opentelemetry/exporter-metrics-otlp-proto": "^0.202.0",
     "@opentelemetry/sdk-logs": "^0.201.1",
     "@opentelemetry/sdk-metrics": "^2.0.1",
+    "@orama/orama": "^3.1.14",
+    "@orama/plugin-data-persistence": "^3.1.14",
     "@statsig/react-bindings": "^3.14.1",
     "@statsig/statsig-node-core": "^0.0.8",
     "@statsig/web-analytics": "^3.14.1",

--- a/frontend/apps/marketing/src/components/contentful/activityCatalog/ActivityCatalog.tsx
+++ b/frontend/apps/marketing/src/components/contentful/activityCatalog/ActivityCatalog.tsx
@@ -1,0 +1,248 @@
+'use client';
+import Input from '@mui/material/Input';
+import {FacetResult, InternalTypedDocument, Orama, search} from '@orama/orama';
+import {restore} from '@orama/plugin-data-persistence';
+import {useRouter, useSearchParams} from 'next/navigation';
+import {ChangeEvent, useEffect, useState} from 'react';
+
+import FacetPanel from '@/components/contentful/activityCatalog/facetPanel/FacetPanel';
+import Section from '@/components/contentful/section';
+import ActivityCollection from '@/components/csforall/activityCollection/ActivityCollection';
+import {ActivitySchema} from '@/modules/activityCatalog/orama/schema/ActivitySchema';
+import {Activity} from '@/modules/activityCatalog/types/Activity';
+
+interface ActivityCatalogProps {
+  serializedOramaDb: string | ArrayBuffer | Buffer<ArrayBuffer>;
+  activities: InternalTypedDocument<Activity>[];
+  facets: FacetResult | undefined;
+}
+
+const ActivityCatalog = ({
+  serializedOramaDb,
+  activities,
+  facets,
+}: ActivityCatalogProps) => {
+  const allowedFacetSet = new Set(facets ? Object.keys(facets) : []);
+
+  const [results, setResults] =
+    useState<InternalTypedDocument<Activity>[]>(activities);
+  const [db, setDb] = useState<Orama<typeof ActivitySchema> | undefined>(
+    undefined,
+  );
+  const [selectedFacets, setSelectedFacets] = useState<
+    Record<string, Set<string>>
+  >({});
+  const [searchTerm, setSearchTerm] = useState<string>('');
+
+  const router = useRouter();
+  const searchParams = useSearchParams();
+
+  // On load, restore the Orama database from the serialized data from the server on the browser.
+  useEffect(() => {
+    restore<Orama<typeof ActivitySchema>>('json', serializedOramaDb).then(
+      restoredDb => {
+        setDb(restoredDb);
+        deserializeClientState();
+      },
+    );
+  }, []);
+
+  // Populate selected facets and search term from the URL search params on load and when they change.
+  useEffect(() => {
+    // The database may not be loaded yet, only hydrate when it is.
+    if (db) {
+      deserializeClientState();
+    }
+  }, [db, searchParams]);
+
+  /**
+   * Hydrates the client state (search term and selected facets) from the URL search params.
+   * This allows for sharing links with specific search terms and facets selected.
+   */
+  const deserializeClientState = () => {
+    // Restore the search term
+    const termFromSearchParam = searchParams.get('term') || '';
+    setSearchTerm(termFromSearchParam);
+
+    // Restore selected facets
+    const facetsFromUrl = deserializeSelectedFacets(searchParams.toString());
+    setSelectedFacets(facetsFromUrl);
+
+    // Restore the search results based on the restored state
+    updateSearchResults(termFromSearchParam, facetsFromUrl);
+  };
+
+  /**
+   * Serializes the client state (search term and selected facets) to the URL search params.
+   * This allows for sharing links with specific search terms and facets selected.
+   * @param searchTerm - The current search term to serialize.
+   * @param selectedFacets - The currently selected facets to serialize.
+   */
+  const serializeClientState = (
+    searchTerm: string,
+    selectedFacets: Record<string, Set<string>>,
+  ) => {
+    const params = new URLSearchParams();
+
+    /**
+     * For each selected facet, add it to the URL search params as a comma-separated list.
+     * Each value is individually encoded to handle commas and special characters.
+     */
+    Object.entries(selectedFacets).forEach(([facet, values]) => {
+      if (values.size > 0) {
+        // The value may contain commas, so encode each value individually.
+        const encodedValues = Array.from(values).map(v =>
+          encodeURIComponent(v),
+        );
+        params.set(facet, encodedValues.join(','));
+      }
+    });
+
+    router.push(`?term=${encodeURIComponent(searchTerm)}&${params.toString()}`);
+  };
+
+  /**
+   * Deserializes the selected facets from the URL search params.
+   * Each facet value is expected to be a comma-separated list of values.
+   * Each value is individually decoded to handle commas and special characters.
+   * @param query - The URL query string to deserialize.
+   * @returns An object mapping facet names to sets of selected values.
+   */
+  const deserializeSelectedFacets = (
+    query: string,
+  ): Record<string, Set<string>> => {
+    const params = new URLSearchParams(query);
+    const facets: Record<string, Set<string>> = {};
+
+    params.forEach((value, key) => {
+      // Exclude non-allowed facets, such as a malicious user adding arbitrary params.
+      if (!allowedFacetSet.has(key)) {
+        return;
+      }
+
+      // Restore each facet value by splitting on commas and decoding each value.
+      const decodedValues = value
+        .split(',')
+        .map(v => decodeURIComponent(v))
+        .filter(Boolean);
+
+      facets[key] = new Set(decodedValues);
+    });
+
+    return facets;
+  };
+
+  const updateSearchResults = async (
+    term: string,
+    searchFacets: Record<string, Set<string>>,
+  ) => {
+    if (!db) {
+      return;
+    }
+
+    /**
+     * Convert the selected facets from sets to arrays for Orama query.
+     * Example: {ages: Set{'5-7', '8-10'}} becomes {ages: ['5-7', '8-10']}
+     */
+    const facetFilters = Object.entries(searchFacets).reduce(
+      (acc, [facetName, _facetValues]) => {
+        const facetValues = _facetValues as Set<string>;
+        if (facetValues.size > 0) {
+          acc[facetName] = [...facetValues];
+        }
+        return acc;
+      },
+      Object.create({}),
+    );
+
+    // Perform the search with the current term and selected facets
+    const searchResults = await search(db, {
+      term,
+      properties: ['title'],
+      where: {
+        ...facetFilters,
+      },
+    });
+
+    const nextResults = searchResults.hits.map(hit => hit.document);
+    setResults(nextResults);
+  };
+
+  /**
+   * Updates the search term state and triggers a new search when the user types in the search input.
+   * @param e - The change event from the search input.
+   */
+  const handleSearchTermChange = (e: ChangeEvent<HTMLInputElement>) => {
+    const nextSearchTerm = e.target.value;
+
+    // Update the search term state
+    setSearchTerm(nextSearchTerm);
+
+    // Update the URL query parameters
+    serializeClientState(nextSearchTerm, selectedFacets);
+
+    // Update the search results based on the new search term
+    updateSearchResults(nextSearchTerm, selectedFacets);
+  };
+
+  /**
+   * Handles changes to facet selections when a user checks or unchecks a facet checkbox.
+   * Updates the selected facets state, serializes the new state to the URL, and triggers a new search.
+   * @param facetName - The name of the facet being changed.
+   * @param e - The change event from the checkbox input.
+   */
+  const handleFacetChange = (
+    facetName: string,
+    e: ChangeEvent<HTMLInputElement>,
+  ) => {
+    const newSelectedFacets = {...selectedFacets};
+
+    // Initialize the set for this facet if it doesn't exist yet
+    // Note: A set is used to avoid duplicate values
+    if (!newSelectedFacets[facetName]) {
+      newSelectedFacets[facetName] = new Set<string>();
+    }
+
+    // Add or remove the facet value based on whether the checkbox is checked or unchecked
+    if (e.target.checked) {
+      newSelectedFacets[facetName].add(e.target.name);
+    } else {
+      newSelectedFacets[facetName].delete(e.target.name);
+    }
+
+    // Update the selected facets state
+    setSelectedFacets(newSelectedFacets);
+    // Update the URL query parameters
+    serializeClientState(searchTerm, newSelectedFacets);
+
+    // Update the search results based on the new selected facets
+    updateSearchResults(searchTerm, newSelectedFacets);
+  };
+
+  return (
+    <>
+      <Section>
+        <section style={{display: 'flex', gap: '20px'}}>
+          <div>
+            <Input
+              onChange={handleSearchTermChange}
+              value={searchTerm}
+              placeholder={'Search...'}
+            />
+
+            <FacetPanel
+              facets={facets}
+              selectedFacets={selectedFacets}
+              onFacetChange={handleFacetChange}
+            />
+          </div>
+          <div style={{width: '100%'}}>
+            <ActivityCollection activities={results} />
+          </div>
+        </section>
+      </Section>
+    </>
+  );
+};
+
+export default ActivityCatalog;

--- a/frontend/apps/marketing/src/components/contentful/activityCatalog/facetPanel/FacetPanel.tsx
+++ b/frontend/apps/marketing/src/components/contentful/activityCatalog/facetPanel/FacetPanel.tsx
@@ -1,0 +1,52 @@
+import {FormControlLabel} from '@mui/material';
+import Checkbox from '@mui/material/Checkbox';
+import FormGroup from '@mui/material/FormGroup';
+import Typography from '@mui/material/Typography';
+import {FacetResult} from '@orama/orama';
+import {ChangeEvent} from 'react';
+
+interface FacetPanelProps {
+  facets: FacetResult | undefined;
+  selectedFacets: Record<string, Set<string>>;
+  onFacetChange: (facet: string, e: ChangeEvent<HTMLInputElement>) => void;
+}
+const FacetPanel = ({
+  facets,
+  selectedFacets,
+  onFacetChange,
+}: FacetPanelProps) => {
+  if (!facets) {
+    return null;
+  }
+
+  return Object.entries(facets).map(([facet, facetDetails]) => {
+    return (
+      <div key={facet}>
+        <Typography variant={'body2'}>{facet}</Typography>
+
+        <FormGroup
+          onChange={(e: ChangeEvent<HTMLInputElement>) =>
+            onFacetChange(facet, e)
+          }
+        >
+          {Object.keys(facetDetails.values).map(facetValue => {
+            return (
+              <FormControlLabel
+                control={<Checkbox />}
+                label={facetValue}
+                name={facetValue}
+                checked={
+                  selectedFacets[facet]
+                    ? selectedFacets[facet].has(facetValue)
+                    : false
+                }
+              />
+            );
+          })}
+        </FormGroup>
+      </div>
+    );
+  });
+};
+
+export default FacetPanel;

--- a/frontend/apps/marketing/src/components/contentful/activityCatalog/facetPanel/styles.module.scss
+++ b/frontend/apps/marketing/src/components/contentful/activityCatalog/facetPanel/styles.module.scss
@@ -1,0 +1,3 @@
+.activityContainer {
+  display: flex;
+}

--- a/frontend/apps/marketing/src/components/contentful/activityCatalog/index.ts
+++ b/frontend/apps/marketing/src/components/contentful/activityCatalog/index.ts
@@ -1,0 +1,1 @@
+export {default} from './ActivityCatalog';

--- a/frontend/apps/marketing/src/components/csforall/activityCollection/ActivityCollection.tsx
+++ b/frontend/apps/marketing/src/components/csforall/activityCollection/ActivityCollection.tsx
@@ -1,0 +1,68 @@
+import Box from '@mui/material/Box';
+import Grid from '@mui/material/Grid';
+import Typography from '@mui/material/Typography';
+
+import Card from '@/components/contentful/card';
+import {Activity} from '@/modules/activityCatalog/types/Activity';
+import {EVENT} from '@/providers/statsig/statsigConstants';
+
+export type ActivityCollectionProps = {
+  activities: Activity[];
+};
+
+const styles = {
+  gridItem: {
+    height: '100%',
+    '& .cardWrapper': {
+      height: '100%',
+    },
+  },
+};
+
+const ActivityCollection: React.FC<ActivityCollectionProps> = ({
+  activities,
+}) => {
+  const data = activities.map(activity => {
+    const {title, shortDescription, image, primaryLinkRef, tutorialID} =
+      activity;
+
+    return {
+      id: title,
+      key: tutorialID,
+      item: (
+        <Box sx={[{...styles.gridItem}]}>
+          <Card
+            className="cardWrapper"
+            id={tutorialID}
+            title={title}
+            description={shortDescription}
+            primaryButton={primaryLinkRef && JSON.parse(primaryLinkRef)}
+            imageSrc={image}
+            primaryButtonEventName={EVENT.CARD_PRIMARY_BUTTON_CLICKED}
+            secondaryButtonEventName={EVENT.CARD_SECONDARY_BUTTON_CLICKED}
+            eventMetadata={{
+              cardId: tutorialID,
+              cardTitle: title,
+            }}
+          />
+        </Box>
+      ),
+    };
+  });
+
+  return (
+    <Grid container spacing={4}>
+      {data.length > 0 ? (
+        data.map(card => (
+          <Grid key={card.key} size={{xs: 12, md: 6, lg: 4}}>
+            {card.item}
+          </Grid>
+        ))
+      ) : (
+        <Typography variant={'body2'}>No activities found</Typography>
+      )}
+    </Grid>
+  );
+};
+
+export default ActivityCollection;

--- a/frontend/apps/marketing/src/components/csforall/activityCollection/index.ts
+++ b/frontend/apps/marketing/src/components/csforall/activityCollection/index.ts
@@ -1,0 +1,1 @@
+export {default} from './ActivityCollection';

--- a/frontend/apps/marketing/src/modules/activityCatalog/contentful/__tests__/getContentfulActivities.test.ts
+++ b/frontend/apps/marketing/src/modules/activityCatalog/contentful/__tests__/getContentfulActivities.test.ts
@@ -1,0 +1,45 @@
+import {getContentfulClient} from '@/contentful/client';
+import {getAllEntriesForContentType} from '@/contentful/get-entries';
+
+import {getContentfulActivities} from '../getContentfulActivities';
+
+jest.mock('@/contentful/client');
+jest.mock('@/contentful/get-entries');
+
+describe('getContentfulActivities', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns activities when client is available', async () => {
+    const mockClient = {};
+    const mockActivities = [{id: 1}, {id: 2}];
+    (getContentfulClient as jest.Mock).mockReturnValue(mockClient);
+    (getAllEntriesForContentType as jest.Mock).mockResolvedValue(
+      mockActivities,
+    );
+
+    const result = await getContentfulActivities();
+
+    expect(getContentfulClient).toHaveBeenCalled();
+    expect(getAllEntriesForContentType).toHaveBeenCalledWith(
+      mockClient,
+      'curriculum',
+    );
+    expect(result).toEqual(mockActivities);
+  });
+
+  it('returns empty array and warns when client is not available', async () => {
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    (getContentfulClient as jest.Mock).mockReturnValue(undefined);
+
+    const result = await getContentfulActivities();
+
+    expect(getContentfulClient).toHaveBeenCalled();
+    expect(warnSpy).toHaveBeenCalledWith(
+      '⚠️ Contentful client is not available. Please check that frontend/apps/marketing/.env is populated.',
+    );
+    expect(result).toEqual([]);
+    warnSpy.mockRestore();
+  });
+});

--- a/frontend/apps/marketing/src/modules/activityCatalog/contentful/getContentfulActivities.ts
+++ b/frontend/apps/marketing/src/modules/activityCatalog/contentful/getContentfulActivities.ts
@@ -1,0 +1,24 @@
+import {getContentfulClient} from '@/contentful/client';
+import {getAllEntriesForContentType} from '@/contentful/get-entries';
+import {Activity} from '@/modules/activityCatalog/types/Activity';
+import {Entry} from '@/types/contentful/Entry';
+
+/**
+ * Retrieves all activities from Contentful.
+ * @returns A promise that resolves to an array of activity entries.
+ */
+export async function getContentfulActivities() {
+  const contentfulClient = getContentfulClient();
+
+  if (!contentfulClient) {
+    console.warn(
+      '⚠️ Contentful client is not available. Please check that frontend/apps/marketing/.env is populated.',
+    );
+    return [];
+  }
+
+  return getAllEntriesForContentType<Entry<Activity>>(
+    contentfulClient,
+    'curriculum',
+  );
+}

--- a/frontend/apps/marketing/src/modules/activityCatalog/orama/__tests__/createDatabase.test.ts
+++ b/frontend/apps/marketing/src/modules/activityCatalog/orama/__tests__/createDatabase.test.ts
@@ -1,0 +1,111 @@
+/**
+ * @jest-environment node
+ */
+import {search} from '@orama/orama';
+
+import {Activity} from '@/modules/activityCatalog/types/Activity';
+import {Entry} from '@/types/contentful/Entry';
+
+import {createDatabase} from '../createDatabase';
+
+jest.mock('@/selectors/contentful/getImage', () => ({
+  getAbsoluteImageUrl: jest.fn(img =>
+    img ? `https://cdn.example.com/${img}` : '',
+  ),
+}));
+
+const mockActivities = [
+  {
+    fields: {
+      title: 'Activity 1',
+      image: 'img1.png',
+      organization: 'Org1',
+      ages: ['8-10'],
+      languageProgramming: ['JavaScript'],
+      shortDescription: 'Short desc 1',
+      longDescription: 'Long desc 1',
+      technologyClassroom: ['Tablet'],
+      topic: ['Math'],
+      activityType: ['Game'],
+      length: ['30min'],
+      accessibilitys: ['Screen Reader'],
+      languagesText: 'English',
+      standards: 'CCSS',
+      tutorialID: 'tut1',
+      primaryLinkRef: 'https://studio.code.org/1',
+    },
+  },
+  {
+    fields: {
+      title: 'Activity 2',
+      organization: 'Org2',
+      ages: [],
+      languageProgramming: [],
+      shortDescription: '',
+      longDescription: '',
+      technologyClassroom: [],
+      topic: [],
+      activityType: [],
+      length: [],
+      accessibilitys: [],
+      languagesText: '',
+      standards: '',
+      tutorialID: '',
+      primaryLinkRef: '',
+    },
+  },
+] as unknown as Entry<Activity>[];
+
+describe('createDatabase', () => {
+  it('should create a database and insert activities', async () => {
+    const db = createDatabase(mockActivities);
+
+    const result = await search(db, {term: 'Activity', properties: ['title']});
+    expect(result.hits.length).toBe(2);
+    expect(result.hits[0].document.title).toBe('Activity 1');
+    expect(result.hits[1].document.title).toBe('Activity 2');
+  });
+
+  it('should handle missing fields and default values', async () => {
+    const db = createDatabase([mockActivities[1]]);
+    const result = await search(db, {
+      term: 'Activity 2',
+      properties: ['title'],
+    });
+    expect(result.hits.length).toBe(1);
+    const doc = result.hits[0].document;
+    expect(doc.image).toBe('');
+    expect(doc.ages).toEqual([]);
+    expect(doc.languageProgramming).toEqual([]);
+    expect(doc.shortDescription).toBe('');
+  });
+
+  it('should stringify primaryLinkRef', async () => {
+    const db = createDatabase([mockActivities[0]]);
+    const result = await search(db, {
+      term: 'Activity 1',
+      properties: ['title'],
+    });
+    expect(result.hits.length).toBe(1);
+    expect(result.hits[0].document.primaryLinkRef).toBe(
+      JSON.stringify('https://studio.code.org/1'),
+    );
+  });
+
+  it('should use getAbsoluteImageUrl for image field', async () => {
+    const db = createDatabase([mockActivities[0]]);
+    const result = await search(db, {
+      term: 'Activity 1',
+      properties: ['title'],
+    });
+    expect(result.hits[0].document.image).toBe(
+      'https://cdn.example.com/img1.png',
+    );
+  });
+
+  it('should return an Orama database instance', () => {
+    const db = createDatabase([]);
+    expect(db).toBeDefined();
+    expect(typeof db).toBe('object');
+  });
+});

--- a/frontend/apps/marketing/src/modules/activityCatalog/orama/createDatabase.ts
+++ b/frontend/apps/marketing/src/modules/activityCatalog/orama/createDatabase.ts
@@ -1,0 +1,46 @@
+import {create, insertMultiple, Orama} from '@orama/orama';
+
+import {ActivitySchema} from '@/modules/activityCatalog/orama/schema/ActivitySchema';
+import {Activity} from '@/modules/activityCatalog/types/Activity';
+import {getAbsoluteImageUrl} from '@/selectors/contentful/getImage';
+import {Entry} from '@/types/contentful/Entry';
+
+/**
+ * Creates an Orama database from an array of Contentful activity entries.
+ * @param activities - An array of Contentful activity entries.
+ * @returns An Orama database instance populated with the provided activities.
+ */
+export function createDatabase(
+  activities: Entry<Activity>[],
+): Orama<typeof ActivitySchema> {
+  const db = create({schema: ActivitySchema});
+
+  const oramaEntries: Activity[] = activities.map(activity => {
+    const fields = activity.fields;
+
+    return {
+      title: fields.title || '',
+      image: getAbsoluteImageUrl(fields.image) || '',
+      organization: fields.organization || '',
+      ages: fields.ages || [],
+      languageProgramming: fields.languageProgramming || [],
+      shortDescription: fields.shortDescription || '',
+      longDescription: fields.longDescription || '',
+      technologyClassroom: fields.technologyClassroom || [],
+      topic: fields.topic || [],
+      activityType: fields.activityType || [],
+      length: fields.length || [],
+      accessibilitys: fields.accessibilitys || [],
+      languagesText: fields.languagesText || '',
+      standards: fields.standards || '',
+      tutorialID: fields.tutorialID || '',
+      // This is passed as a stringified JSON to allow the entry to be passed directly into the ActivityCollection component
+      // It will be deserialized there
+      primaryLinkRef: JSON.stringify(fields.primaryLinkRef),
+    };
+  });
+
+  insertMultiple(db, oramaEntries);
+
+  return db;
+}

--- a/frontend/apps/marketing/src/modules/activityCatalog/orama/schema/ActivitySchema.ts
+++ b/frontend/apps/marketing/src/modules/activityCatalog/orama/schema/ActivitySchema.ts
@@ -1,0 +1,22 @@
+/**
+ * Schema for an activity in the activity catalog. This is directly sourced from the Tutorial content type on Contentful.
+ */
+export const ActivitySchema = {
+  title: 'string',
+  image: 'string',
+  organization: 'string',
+  ages: 'string[]',
+  languageProgramming: 'string[]',
+  shortDescription: 'string',
+  longDescription: 'string',
+  primaryLinkRef: 'string',
+  technologyClassroom: 'string[]',
+  topic: 'string[]',
+  activityType: 'string[]',
+  length: 'string[]',
+  accessibilitys: 'string[]',
+  languagesText: 'string',
+  standards: 'string',
+  tutorialID: 'string',
+  primaryButton: 'string',
+} as const;

--- a/frontend/apps/marketing/src/modules/activityCatalog/types/Activity.ts
+++ b/frontend/apps/marketing/src/modules/activityCatalog/types/Activity.ts
@@ -1,0 +1,18 @@
+export interface Activity {
+  title: string;
+  image: string;
+  organization: string;
+  ages: string[];
+  languageProgramming: string[];
+  shortDescription: string;
+  longDescription: string;
+  primaryLinkRef: string;
+  technologyClassroom: string[];
+  topic: string[];
+  activityType: string[];
+  length: string[];
+  accessibilitys: string[];
+  languagesText: string;
+  standards: string;
+  tutorialID: string;
+}

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -1504,6 +1504,8 @@ __metadata:
     "@opentelemetry/exporter-metrics-otlp-proto": "npm:^0.202.0"
     "@opentelemetry/sdk-logs": "npm:^0.201.1"
     "@opentelemetry/sdk-metrics": "npm:^2.0.1"
+    "@orama/orama": "npm:^3.1.14"
+    "@orama/plugin-data-persistence": "npm:^3.1.14"
     "@playwright/test": "npm:~1.49.1"
     "@statsig/react-bindings": "npm:^3.14.1"
     "@statsig/statsig-node-core": "npm:^0.0.8"
@@ -4342,6 +4344,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@msgpack/msgpack@npm:^3.1.2":
+  version: 3.1.2
+  resolution: "@msgpack/msgpack@npm:3.1.2"
+  checksum: 10c0/4fee6dbea70a485d3a787ac76dd43687f489d662f22919237db1f2abbc3c88070c1d3ad78417ce6e764bcd041051680284654021f52068e0aff82d570cb942d5
+  languageName: node
+  linkType: hard
+
 "@mui/core-downloads-tracker@npm:^7.1.2":
   version: 7.1.2
   resolution: "@mui/core-downloads-tracker@npm:7.1.2"
@@ -5950,6 +5959,25 @@ __metadata:
   peerDependencies:
     "@opentelemetry/api": ^1.1.0
   checksum: 10c0/3611fa2766be809d3f19f1c032373349962c3203cbc77839ea59d78a4ce2bf6954da9b163efdde386f3f4a8ec77c50c985f9e5b8b3df6e7fccd2990cf861bca4
+  languageName: node
+  linkType: hard
+
+"@orama/orama@npm:3.1.14, @orama/orama@npm:^3.1.14":
+  version: 3.1.14
+  resolution: "@orama/orama@npm:3.1.14"
+  checksum: 10c0/ae3605613331117aa426a544f0b50d6e4293e703e851e4b2f7f8c9400e597475aec80c662ed3db8a68d22d8f36fe5a65aa9c45870a3508bfd13c4b44032eb53a
+  languageName: node
+  linkType: hard
+
+"@orama/plugin-data-persistence@npm:^3.1.14":
+  version: 3.1.14
+  resolution: "@orama/plugin-data-persistence@npm:3.1.14"
+  dependencies:
+    "@msgpack/msgpack": "npm:^3.1.2"
+    "@orama/orama": "npm:3.1.14"
+    dpack: "npm:^0.6.22"
+    seqproto: "npm:^0.2.3"
+  checksum: 10c0/e72b46a4f7c505f42a11c166f5a0c89b9029413771e71616d003c8ba94163bb07b76795154076786165997da8f6c50ff00664b61786be347895eefc70b991c51
   languageName: node
   linkType: hard
 
@@ -11947,6 +11975,13 @@ __metadata:
   version: 16.4.7
   resolution: "dotenv@npm:16.4.7"
   checksum: 10c0/be9f597e36a8daf834452daa1f4cc30e5375a5968f98f46d89b16b983c567398a330580c88395069a77473943c06b877d1ca25b4afafcdd6d4adb549e8293462
+  languageName: node
+  linkType: hard
+
+"dpack@npm:^0.6.22":
+  version: 0.6.22
+  resolution: "dpack@npm:0.6.22"
+  checksum: 10c0/ca4d74a6b437d9f4dd0cb5beee1bc501272a20ac524ec6d4b6c01d7b3d86fc164f6cc648c0c18057c337c1225aca05985b75bda94d4f28adabdeb2bb4c9bcfe3
   languageName: node
   linkType: hard
 
@@ -20722,6 +20757,13 @@ __metadata:
   bin:
     semver: bin/semver.js
   checksum: 10c0/aca305edfbf2383c22571cb7714f48cadc7ac95371b4b52362fb8eeffdfbc0de0669368b82b2b15978f8848f01d7114da65697e56cd8c37b0dab8c58e543f9ea
+  languageName: node
+  linkType: hard
+
+"seqproto@npm:^0.2.3":
+  version: 0.2.3
+  resolution: "seqproto@npm:0.2.3"
+  checksum: 10c0/d0f8c133c495261d08563bbf253b8f29736b02b7add33f2c72bcdb97821cb41b4d6231ec2986fac596685e5b9312e4366242536ab5cb551c405a13402a1f1e1a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This PR adds a basic version of the Hour of AI activity catalog. This catalog pulls activities from Contentful. These activities are then inserted into an isomorphic browser/server full-text orama database. The database is then used to provide facet and term searching.

To improve availability, this page is built to follow incremental static regeneration to ensure that the CDN caches pages and prevent hits to the server. As an optimization, a static build of the page can be created at a later point in time.

