### PR TITLE
Lab2: Hide the AI DIff FAB if the rubric FAB is showing

### DIFF
--- a/apps/src/lab2/views/components/rubrics/RubricFABContainer.tsx
+++ b/apps/src/lab2/views/components/rubrics/RubricFABContainer.tsx
@@ -62,26 +62,15 @@ const RubricFABContainer: React.FC = () => {
     [unitName, courseName, currentLevelName]
   );
 
-  const canShow = useMemo(() => {
-    return (
-      appName &&
-      isTeacher &&
-      showRubric &&
-      !labLoading &&
-      !isLoadingRubric &&
-      rubricData &&
-      // Only show the rubric FAB is the resource panel is enabled
-      isUsingResourcePanel(appName, isProjectLevel || false)
-    );
-  }, [
-    appName,
-    isTeacher,
-    showRubric,
-    labLoading,
-    isLoadingRubric,
-    rubricData,
-    isProjectLevel,
-  ]);
+  const canShow =
+    appName &&
+    isTeacher &&
+    showRubric &&
+    !labLoading &&
+    !isLoadingRubric &&
+    rubricData &&
+    // Only show the rubric FAB is the resource panel is enabled
+    isUsingResourcePanel(appName, isProjectLevel || false);
 
   // Temporary hack: show/hide the AI Differentiation FAB based on if the Rubric FAB is showing.
   // Note that currently, the AI Diff FAB will be out of date on Lab2 levels since it relies on

--- a/apps/src/lab2/views/components/rubrics/RubricFABContainer.tsx
+++ b/apps/src/lab2/views/components/rubrics/RubricFABContainer.tsx
@@ -1,4 +1,4 @@
-import React, {useMemo} from 'react';
+import React, {useEffect, useMemo} from 'react';
 
 import {isLabLoading} from '@cdo/apps/lab2/redux/lab2ReduxSelectors';
 import {isUsingResourcePanel} from '@cdo/apps/lab2/utils';
@@ -62,20 +62,48 @@ const RubricFABContainer: React.FC = () => {
     [unitName, courseName, currentLevelName]
   );
 
-  if (
-    !appName ||
-    !isTeacher ||
-    !showRubric ||
-    labLoading ||
-    isLoadingRubric ||
-    !rubricData ||
-    // Only show the rubric FAB is the resource panel is enabled
-    !isUsingResourcePanel(appName, isProjectLevel || false)
-  ) {
+  const canShow = useMemo(() => {
+    return (
+      appName &&
+      isTeacher &&
+      showRubric &&
+      !labLoading &&
+      !isLoadingRubric &&
+      rubricData &&
+      // Only show the rubric FAB is the resource panel is enabled
+      isUsingResourcePanel(appName, isProjectLevel || false)
+    );
+  }, [
+    appName,
+    isTeacher,
+    showRubric,
+    labLoading,
+    isLoadingRubric,
+    rubricData,
+    isProjectLevel,
+  ]);
+
+  // Temporary hack: show/hide the AI Differentiation FAB based on if the Rubric FAB is showing.
+  // Note that currently, the AI Diff FAB will be out of date on Lab2 levels since it relies on
+  // script data only fetched on page load.
+  // Longer term, we should fetch data for the AI Diff FAB asynchronously and conditionally mount it
+  // like we do for the Rubric FAB.
+  useEffect(() => {
+    const aiDiffFab = document.getElementById(
+      'ai-differentiation-fab-mount-point'
+    );
+    if (!aiDiffFab || aiDiffFab.children.length === 0) {
+      return;
+    }
+
+    aiDiffFab.style.visibility = canShow ? 'hidden' : 'visible';
+  }, [canShow]);
+
+  if (!canShow) {
     return null;
   }
 
-  const {rubric, canShowTaScoresAlert} = rubricData;
+  const {rubric, canShowTaScoresAlert} = rubricData!;
 
   return (
     // Force light mode for the rubric FAB and dialog as they are not fully themed currently.


### PR DESCRIPTION
Temporary mitigation to unblock rubrics launch in Music Lab. In legacy labs, the mount point for the AI Diff and Rubric FABs are controlled through the same set of logic so only one is ever shown at once. In Lab2, since we render the Rubric FAB through a different pathway (conditionally showing it based on level and asynchronously fetching data on level and/or student change), we have situations where both FABs are showing at once, overlapping each other. This short term fix just manually shows or hides the FAB through DOM manipulation when the Rubric FAB is showing. However, as noted, we'll probably want to also create a different conditional rendering pathway for the AI Diff FAB since it relies on some server-provided data  that will get out of date on Lab2 since we switch levels without page reload (at least current level ID).

https://github.com/user-attachments/assets/a57d320f-d6a3-4cce-b018-5e9e4b0480f3

## Testing story
Tested locally on allthethings

## Deployment strategy
<!--  Any special steps required to deploy this, besides merging?
      - Are there database migrations or manual steps?
      - Does this require coordination with other teams or systems? -->