### PR TITLE
Resource panel: tooltip improvements

### DIFF
--- a/apps/src/lab2/views/components/Instructions/ResourcePanel/ButtonWithDialog.tsx
+++ b/apps/src/lab2/views/components/Instructions/ResourcePanel/ButtonWithDialog.tsx
@@ -22,6 +22,9 @@ const ButtonWithDialog: React.FunctionComponent<ButtonWithDialogProps> = ({
   iconName,
   setIsDialogOpen,
 }) => {
+  // Tooltip should disappear quickly.
+  const hideTooltipDelay = 10;
+
   return (
     <>
       <WithTooltip
@@ -32,6 +35,7 @@ const ButtonWithDialog: React.FunctionComponent<ButtonWithDialogProps> = ({
           size: 'xs',
           'data-theme': theme,
         }}
+        hideDelay={hideTooltipDelay}
       >
         <Button
           className={styles.bottomButton}

--- a/apps/src/lab2/views/components/Instructions/ResourcePanel/ButtonWithDialog.tsx
+++ b/apps/src/lab2/views/components/Instructions/ResourcePanel/ButtonWithDialog.tsx
@@ -23,7 +23,7 @@ const ButtonWithDialog: React.FunctionComponent<ButtonWithDialogProps> = ({
   setIsDialogOpen,
 }) => {
   // Tooltip should disappear quickly.
-  const hideTooltipDelay = 10;
+  const hideTooltipDelayMs = 10;
 
   return (
     <>
@@ -35,7 +35,7 @@ const ButtonWithDialog: React.FunctionComponent<ButtonWithDialogProps> = ({
           size: 'xs',
           'data-theme': theme,
         }}
-        hideDelay={hideTooltipDelay}
+        hideDelayMs={hideTooltipDelayMs}
         hideOnFirstLeave={true}
       >
         <Button

--- a/apps/src/lab2/views/components/Instructions/ResourcePanel/ButtonWithDialog.tsx
+++ b/apps/src/lab2/views/components/Instructions/ResourcePanel/ButtonWithDialog.tsx
@@ -36,6 +36,7 @@ const ButtonWithDialog: React.FunctionComponent<ButtonWithDialogProps> = ({
           'data-theme': theme,
         }}
         hideDelay={hideTooltipDelay}
+        hideOnFirstLeave={true}
       >
         <Button
           className={styles.bottomButton}

--- a/apps/src/lab2/views/components/Instructions/ResourcePanel/index.tsx
+++ b/apps/src/lab2/views/components/Instructions/ResourcePanel/index.tsx
@@ -120,6 +120,9 @@ const ResourcePanel: React.FC<ResourcePanelProps> = ({
   const levelName = instructionsProps.levelProperties.name;
   const channelId = useAppSelector(state => state.lab.channel?.id);
 
+  // Tooltip should disappear quickly.
+  const hideTooltipDelay = 10;
+
   // Build available tabs based on level information.
   const availableTabs = useMemo(() => {
     const tabMap: {[key in Tabs]?: React.ReactNode} = {};
@@ -236,6 +239,7 @@ const ResourcePanel: React.FC<ResourcePanelProps> = ({
                 size: 'xs',
                 'data-theme': theme,
               }}
+              hideDelay={hideTooltipDelay}
               key={`tooltip-${tab}`}
             >
               <Button
@@ -269,6 +273,7 @@ const ResourcePanel: React.FC<ResourcePanelProps> = ({
               size: 'xs',
               'data-theme': theme,
             }}
+            hideDelay={hideTooltipDelay}
           >
             <Button
               className={styles.bottomButton}

--- a/apps/src/lab2/views/components/Instructions/ResourcePanel/index.tsx
+++ b/apps/src/lab2/views/components/Instructions/ResourcePanel/index.tsx
@@ -121,7 +121,7 @@ const ResourcePanel: React.FC<ResourcePanelProps> = ({
   const channelId = useAppSelector(state => state.lab.channel?.id);
 
   // Tooltip should disappear quickly.
-  const hideTooltipDelay = 10;
+  const hideTooltipDelayMs = 10;
 
   // Build available tabs based on level information.
   const availableTabs = useMemo(() => {
@@ -239,7 +239,7 @@ const ResourcePanel: React.FC<ResourcePanelProps> = ({
                 size: 'xs',
                 'data-theme': theme,
               }}
-              hideDelay={hideTooltipDelay}
+              hideDelayMs={hideTooltipDelayMs}
               hideOnFirstLeave={true}
               key={`tooltip-${tab}`}
             >
@@ -274,7 +274,7 @@ const ResourcePanel: React.FC<ResourcePanelProps> = ({
               size: 'xs',
               'data-theme': theme,
             }}
-            hideDelay={hideTooltipDelay}
+            hideDelayMs={hideTooltipDelayMs}
             hideOnFirstLeave={true}
           >
             <Button

--- a/apps/src/lab2/views/components/Instructions/ResourcePanel/index.tsx
+++ b/apps/src/lab2/views/components/Instructions/ResourcePanel/index.tsx
@@ -240,6 +240,7 @@ const ResourcePanel: React.FC<ResourcePanelProps> = ({
                 'data-theme': theme,
               }}
               hideDelay={hideTooltipDelay}
+              hideOnFirstLeave={true}
               key={`tooltip-${tab}`}
             >
               <Button
@@ -274,6 +275,7 @@ const ResourcePanel: React.FC<ResourcePanelProps> = ({
               'data-theme': theme,
             }}
             hideDelay={hideTooltipDelay}
+            hideOnFirstLeave={true}
           >
             <Button
               className={styles.bottomButton}

--- a/frontend/packages/component-library/src/tooltip/WithTooltip.tsx
+++ b/frontend/packages/component-library/src/tooltip/WithTooltip.tsx
@@ -34,10 +34,11 @@ export interface WithTooltipProps {
   children: ReactNode;
   tooltipOverlayClassName?: string;
   tooltipProps: TooltipProps;
+  hideDelay?: number;
 }
 
 const WithTooltip = forwardRef<WithTooltipHandle, WithTooltipProps>(
-  ({children, tooltipOverlayClassName, tooltipProps}, ref) => {
+  ({children, tooltipOverlayClassName, tooltipProps, hideDelay}, ref) => {
     const [nodePosition, setNodePosition] = useState<HTMLElement | null>(null);
     const [showTooltip, setShowTooltip] = useState<boolean>(false);
     const [actualDirection, setActualDirection] =
@@ -78,7 +79,7 @@ const WithTooltip = forwardRef<WithTooltipHandle, WithTooltipProps>(
       hideTimeoutRef.current = window.setTimeout(() => {
         setShowTooltip(false);
         setNodePosition(null);
-      }, 100); // Allows for small but visible close delay
+      }, hideDelay || 100); // Allows for small but visible close delay.
     };
 
     // Use useImperativeHandle hook to let the parent control visibility in certain cases

--- a/frontend/packages/component-library/src/tooltip/WithTooltip.tsx
+++ b/frontend/packages/component-library/src/tooltip/WithTooltip.tsx
@@ -35,10 +35,20 @@ export interface WithTooltipProps {
   tooltipOverlayClassName?: string;
   tooltipProps: TooltipProps;
   hideDelay?: number;
+  hideOnFirstLeave?: boolean;
 }
 
 const WithTooltip = forwardRef<WithTooltipHandle, WithTooltipProps>(
-  ({children, tooltipOverlayClassName, tooltipProps, hideDelay}, ref) => {
+  (
+    {
+      children,
+      tooltipOverlayClassName,
+      tooltipProps,
+      hideDelay,
+      hideOnFirstLeave,
+    },
+    ref,
+  ) => {
     const [nodePosition, setNodePosition] = useState<HTMLElement | null>(null);
     const [showTooltip, setShowTooltip] = useState<boolean>(false);
     const [actualDirection, setActualDirection] =
@@ -192,7 +202,9 @@ const WithTooltip = forwardRef<WithTooltipHandle, WithTooltipProps>(
               direction={actualDirection}
               ref={tooltipRef}
               style={tooltipStyleProps}
-              onMouseEnter={event => handleShowTooltip(true, event, true)}
+              onMouseEnter={event =>
+                !hideOnFirstLeave && handleShowTooltip(true, event, true)
+              }
               onMouseLeave={handleHideTooltip}
             />,
             document.body,

--- a/frontend/packages/component-library/src/tooltip/WithTooltip.tsx
+++ b/frontend/packages/component-library/src/tooltip/WithTooltip.tsx
@@ -34,7 +34,7 @@ export interface WithTooltipProps {
   children: ReactNode;
   tooltipOverlayClassName?: string;
   tooltipProps: TooltipProps;
-  hideDelay?: number;
+  hideDelayMs?: number;
   hideOnFirstLeave?: boolean;
 }
 
@@ -44,7 +44,7 @@ const WithTooltip = forwardRef<WithTooltipHandle, WithTooltipProps>(
       children,
       tooltipOverlayClassName,
       tooltipProps,
-      hideDelay,
+      hideDelayMs,
       hideOnFirstLeave,
     },
     ref,
@@ -89,7 +89,7 @@ const WithTooltip = forwardRef<WithTooltipHandle, WithTooltipProps>(
       hideTimeoutRef.current = window.setTimeout(() => {
         setShowTooltip(false);
         setNodePosition(null);
-      }, hideDelay || 100); // Allows for small but visible close delay.
+      }, hideDelayMs || 100); // Allows for small but visible close delay.
     };
 
     // Use useImperativeHandle hook to let the parent control visibility in certain cases


### PR DESCRIPTION
This change proposes two improvements to the tooltip experience in the resource panel.  These improvements can also be used elsewhere if desired.

## Delay

Due to a delay added when hiding a tooltip, it was easy to see many tooltips at the same time, which is not standard practice.  I began implementing a more comprehensive `TooltipContext` which would enforce only one tooltip showing at a time, but it was going to get complicated, and the cross-library limitation that @edcodedotorg documented in https://github.com/code-dot-org/code-dot-org/pull/67279 made things even worse.  So, instead, this change just allows the consumer of `WithTooltip` to provide an optional shorter delay before hiding a tooltip.

### before

https://github.com/user-attachments/assets/b1e0794f-2de5-42ef-b912-c25bfd799fb1

### after

https://github.com/user-attachments/assets/f7c30784-bd43-4603-9dc0-ea4349fa7910

## Leave 

A second issue was that moving the mouse over a tooltip was often causing it to stay in view, causing the tooltip to stay in view when the user had already navigated away from the tab that caused it to show in the first place.  This change just allows the consumer of `WithTooltip` to hide the tooltip on the "first leave".

### before

https://github.com/user-attachments/assets/6054d6af-f68a-44d3-93d5-fbac8315e0db

### after

https://github.com/user-attachments/assets/66993bee-232f-4d88-bf1b-e947e71a2dc6
