### PR TITLE
Fix new Authorized GH Logic for non-Adhocs

### DIFF
--- a/cookbooks/cdo-github-access/recipes/default.rb
+++ b/cookbooks/cdo-github-access/recipes/default.rb
@@ -34,7 +34,7 @@ end
 
 apt_package 'git-lfs'
 
-github_token = node['cdo-github-access']['github_token']
+github_token = node['cdo-github-access']['github_token'].to_s
 
 template "#{node[:home]}/.gitconfig" do
   source 'gitconfig.erb'


### PR DESCRIPTION
Follow-up to https://github.com/code-dot-org/code-dot-org/pull/68266

That change worked just fine on adhocs, but failed in staging and test with `NoMethodError: undefined method 'empty?' for nil:NilClass`. Because we don't define the new token in those environments, we need to accommodate the possibility that it might be `nil`

## Links

- https://codedotorg.slack.com/archives/C0T0PNTM3/p1758584898739839?thread_ts=1758565101.287569&cid=C0T0PNTM3
- https://codedotorg.slack.com/archives/C03CK8E51/p1758576349016879