### PR TITLE
Revert "Use Consistent Volume Size Across All Prod Instances"

### DIFF
--- a/aws/cloudformation/cloud_formation_stack.yml.erb
+++ b/aws/cloudformation/cloud_formation_stack.yml.erb
@@ -261,7 +261,7 @@ Resources:
   subnets: subnets(azs(AVAILABILITY_ZONES - ['us-east-1e'])), # us-east-1e doesn't support m5 instance types.
   frontend_policies: [{Ref: 'CDOPolicy'}, {'Fn::ImportValue': 'IAM-SessionPermissions'}],
   frontend_properties: {TargetGroupARNs: [Ref: 'ALBTargetGroup']},
-  frontend_volume_size: 128,
+  frontend_volume_size: 64,
   ami_timeout: 'PT120M',
   build_ami: erb_file(BOOTSTRAP_CHEF,
     resource_id: "AMICreate#{commit_hash}",

--- a/aws/cloudformation/components/ami.yml.erb
+++ b/aws/cloudformation/components/ami.yml.erb
@@ -177,7 +177,7 @@ frontend_device_name ||= '/dev/sda1'
         BlockDeviceMappings:
           - DeviceName: <%=frontend_device_name%>
             Ebs:
-              VolumeSize: <%=frontend_volume_size%>
+              VolumeSize: <%=frontend_volume_size * 2%> # Double volume size to leave room for logs written to disk
               VolumeType: gp2
         TagSpecifications:
           - ResourceType: instance


### PR DESCRIPTION
Reverts code-dot-org/code-dot-org#68176

The change itself applied cleanly, but in the process of getting the new AMI server updated we accidentally allowed an image to be taken of it in a nonworking state, which requires a second DTP to fix. In the interest of not working even later today than we already have, we are electing to revert the change and try again another day.