### PR TITLE
AI Tutor: feature flag for legacy lab AI Tutor 

### DIFF
--- a/apps/src/util/experiments.js
+++ b/apps/src/util/experiments.js
@@ -64,6 +64,8 @@ experiments.LOCALIZEJS = 'localizejs';
 experiments.LAB2_INSTRUCTIONS_V2 = 'lab2-instructions-v2';
 // Use the new lab2 tabbed resource panel
 experiments.LAB2_RESOURCE_PANEL = 'lab2-resource-panel';
+// Show AI Tutor in legacy labs
+experiments.LEGACY_LAB_AI_TUTOR = 'legacy-lab-ai-tutor';
 
 /**
  * This was a gamified version of the finish dialog, built in 2018,


### PR DESCRIPTION
Set up the feature flag for AI Tutor in legacy labs (App Lab, Game Lab, Web Lab). Keeping it very tiny just to help split up work across engineers. 

`enableExperiments=legacy-lab-ai-tutor`

