### PR TITLE
AI Tutor / AI Chat - Separate API keys by client and environment

### DIFF
--- a/config.yml.erb
+++ b/config.yml.erb
@@ -641,7 +641,8 @@ openai_student_learning_api_key: !Secret
 openai_measures_of_learning_api_key: !Secret
 
 # Credentials for Google Gemini API
-google_gemini_student_learning_api_key: !Secret
+google_gemini_ai_chat_api_key: !Secret
+google_gemini_ai_tutor_api_key: !Secret
 
 # AI Proxy for OpenAI API
 ai_proxy_origin: https://aiproxy-test.code.org

--- a/config.yml.erb
+++ b/config.yml.erb
@@ -641,7 +641,7 @@ openai_student_learning_api_key: !Secret
 openai_measures_of_learning_api_key: !Secret
 
 # Credentials for Google Gemini API
-google_gemini_ai_chat_api_key: !Secret
+google_gemini_ai_chat_lab_api_key: !Secret
 google_gemini_ai_tutor_api_key: !Secret
 
 # AI Proxy for OpenAI API

--- a/config/development.yml.erb
+++ b/config/development.yml.erb
@@ -73,7 +73,7 @@ openai_evaluate_rubric_api_key:
 openai_student_learning_api_key: !Secret
 openai_measures_of_learning_api_key: !Secret
 
-google_gemini_ai_chat_api_key: !Secret
+google_gemini_ai_chat_lab_api_key: !Secret
 google_gemini_ai_tutor_api_key: !Secret
 
 # Enables DCDO settings via cookies

--- a/config/development.yml.erb
+++ b/config/development.yml.erb
@@ -73,7 +73,8 @@ openai_evaluate_rubric_api_key:
 openai_student_learning_api_key: !Secret
 openai_measures_of_learning_api_key: !Secret
 
-google_gemini_student_learning_api_key: !Secret
+google_gemini_ai_chat_api_key: !Secret
+google_gemini_ai_tutor_api_key: !Secret
 
 # Enables DCDO settings via cookies
 use_cookie_dcdo: true

--- a/dashboard/app/helpers/aichat_ai_client.rb
+++ b/dashboard/app/helpers/aichat_ai_client.rb
@@ -2,17 +2,6 @@
 # that is never instantiated directly. The derived classes hold implementation details in required overridden
 # methods. Currently the two implemented APIs (OpenAI and Gemini) are POST based REST APIs.
 class AichatAiClient
-  # Create an instance of the appropriate derived class based on model id.
-  def self.create_instance(model_id, usage_reporter = nil)
-    #TODO make model api mode and this check based on SharedConstants::AICHAT_MODEL_VERSION
-    # For now we just assume it's one of the gemini models if not 'gpt-4o-mini'.
-    if model_id == "gpt-4o-mini"
-      return AichatOpenaiResponsesClient.new(CDO.openai_student_learning_api_key, SharedConstants::AICHAT_MODEL_VERSION, usage_reporter)
-    else
-      return AichatGeminiClient.new(CDO.google_gemini_student_learning_api_key, model_id, usage_reporter)
-    end
-  end
-
   # Call the API (through methods overridden in derived class) and get response text to send back to user.
   # Accept a config hash, request array and optional context array.  These types are defined and documented
   # in `aichat_ai_client_types.rb``.
@@ -60,8 +49,7 @@ class AichatAiClient
 
   attr_accessor :api_key, :model, :usage_reporter
 
-  # Private initializer - all instances should be created with `create_instance` factory.
-  private def initialize(api_key, model, usage_reporter = nil)
+  def initialize(api_key, model, usage_reporter = nil)
     @api_key = api_key
     @model = model
     @usage_reporter = usage_reporter

--- a/dashboard/app/helpers/aichat_ai_helper.rb
+++ b/dashboard/app/helpers/aichat_ai_helper.rb
@@ -159,7 +159,9 @@ module AichatAiHelper
     if model_id == "gpt-4o-mini"
       return AichatOpenaiResponsesClient.new(CDO.openai_student_learning_api_key, SharedConstants::AICHAT_MODEL_VERSION, usage_reporter)
     else
-      # We assume AI Chat if not tutor - todo: rename FLOW_LAB to EXPERIMENTS and create a key for it.
+      # We use separate keys per-client for Gemini so that we can more easily allocate donated credits appropriately.
+      # In the longer term, we should consider adding per-client keys for OpenAI as well in order to more easily differentiate between use cases.
+      # Also note that we assume AI Chat Lab if not AI Tutor here, which is not strictly true because of Flow Lab. We could add an EXPERIMENT client type and add an explicit key to handle those use cases (eg, Flow Lab). 
       api_key = client_type == SharedConstants::AI_CHAT_CLIENT_TYPES[:AI_TUTOR] ?
         CDO.google_gemini_ai_tutor_api_key : CDO.google_gemini_ai_chat_lab_api_key
       return AichatGeminiClient.new(api_key, model_id, usage_reporter)

--- a/dashboard/app/helpers/aichat_ai_helper.rb
+++ b/dashboard/app/helpers/aichat_ai_helper.rb
@@ -153,6 +153,19 @@ module AichatAiHelper
     return config, request, context
   end
 
+  # Create an instance of the appropriate ai-client-derived class based on model id.
+  def self.create_ai_client_instance(client_type, model_id, usage_reporter = nil)
+    # We assume it's one of the gemini models if not 'gpt-4o-mini'.
+    if model_id == "gpt-4o-mini"
+      return AichatOpenaiResponsesClient.new(CDO.openai_student_learning_api_key, SharedConstants::AICHAT_MODEL_VERSION, usage_reporter)
+    else
+      # We assume AI Chat if not tutor - todo: rename FLOW_LAB to EXPERIMENTS and create a key for it.
+      api_key = client_type == SharedConstants::AI_CHAT_CLIENT_TYPES[:AI_TUTOR] ?
+        CDO.google_gemini_ai_tutor_api_key : CDO.google_gemini_ai_chat_api_key
+      return AichatGeminiClient.new(api_key, model_id, usage_reporter)
+    end
+  end
+
   def self.get_openai_assistant_response(aichat_model_customizations, stored_messages, new_message, level_id, project_id, user_id)
     encrypted_channel_id = storage_encrypt_channel_id(storage_id_for_user_id(user_id), project_id) if project_id
 
@@ -169,7 +182,7 @@ module AichatAiHelper
     retrieval_contexts = aichat_model_customizations['retrievalContexts']
 
     usage_reporter = AichatAiUsageReporter.new(model_id, user_id, project_id, level_id)
-    client = AichatAiClient.create_instance(model_id, usage_reporter)
+    client = create_ai_client_instance(client_type, model_id, usage_reporter)
 
     config, request, context = get_config_request_context(stored_messages, new_message, temperature, system_prompt, retrieval_contexts,  model_id, level_id, encrypted_channel_id, user_id, project_id, client_type)
 

--- a/dashboard/app/helpers/aichat_ai_helper.rb
+++ b/dashboard/app/helpers/aichat_ai_helper.rb
@@ -161,7 +161,7 @@ module AichatAiHelper
     else
       # We use separate keys per-client for Gemini so that we can more easily allocate donated credits appropriately.
       # In the longer term, we should consider adding per-client keys for OpenAI as well in order to more easily differentiate between use cases.
-      # Also note that we assume AI Chat Lab if not AI Tutor here, which is not strictly true because of Flow Lab. We could add an EXPERIMENT client type and add an explicit key to handle those use cases (eg, Flow Lab). 
+      # Also note that we assume AI Chat Lab if not AI Tutor here, which is not strictly true because of Flow Lab. We could add an EXPERIMENT client type and add an explicit key to handle those use cases (eg, Flow Lab).
       api_key = client_type == SharedConstants::AI_CHAT_CLIENT_TYPES[:AI_TUTOR] ?
         CDO.google_gemini_ai_tutor_api_key : CDO.google_gemini_ai_chat_lab_api_key
       return AichatGeminiClient.new(api_key, model_id, usage_reporter)

--- a/dashboard/app/helpers/aichat_ai_helper.rb
+++ b/dashboard/app/helpers/aichat_ai_helper.rb
@@ -161,7 +161,7 @@ module AichatAiHelper
     else
       # We assume AI Chat if not tutor - todo: rename FLOW_LAB to EXPERIMENTS and create a key for it.
       api_key = client_type == SharedConstants::AI_CHAT_CLIENT_TYPES[:AI_TUTOR] ?
-        CDO.google_gemini_ai_tutor_api_key : CDO.google_gemini_ai_chat_api_key
+        CDO.google_gemini_ai_tutor_api_key : CDO.google_gemini_ai_chat_lab_api_key
       return AichatGeminiClient.new(api_key, model_id, usage_reporter)
     end
   end

--- a/dashboard/test/helpers/aichat_ai_client_test.rb
+++ b/dashboard/test/helpers/aichat_ai_client_test.rb
@@ -181,7 +181,7 @@ class AichatAiClientTest < ActionView::TestCase
       json_schema
     )
 
-    AichatAiClient.create_instance(model_id, usage_reporter).get_response(
+    AichatAiHelper.create_ai_client_instance(@client_type, model_id, usage_reporter).get_response(
       config, request, context
     )
   end


### PR DESCRIPTION
This PR replaces the general `CDO.google_gemini_student_learning_api_key` (which was the same key for development, test, and production) with client (AI Tutor / AI Chat) specific `CDO.google_gemini_ai_chat_api_key` and `CDO.google_gemini_ai_tutor_api_key` keys backed  by environment specific (development / test / production) keys in GCP (Google Cloud Platform) [cloud console](https://console.cloud.google.com/apis/credentials) and AWS [Secrets Manager](https://us-east-1.console.aws.amazon.com/secretsmanager).

## Links
The Jira ticket is [here](https://codedotorg.atlassian.net/browse/LABS-1556?atlOrigin=eyJpIjoiM2VlYmZlZTgwN2E5NGRmMjgzYmM4NjY2ZjEwODVhYmMiLCJwIjoiaiJ9) and this has been discussed in various slack threads including this [one](https://codedotorg.slack.com/archives/C06FELVTV0Q/p1758315431672639).  

## Testing story
The change to how `AichatAiClient` instances are created (moved factory method to helper), required an update to `aichat_ai_client_test.rb`, otherwise tests are not affected.

## Follow-up work
The old key (CDO.google_gemini_student_learning_api_key) should be removed from AWS Secrets Manager.

This PR addresses the two main AI clients (AI Tutor and Chat) but does not address Flow Lab. As it seems the `FLOW_LAB` client id is used for experimentation, perhaps we should rename it as EXPERIMENTS or EXPERIMENTAL and add additional keys (per env) for use in experiments.  Currently flow lab and any experiments identifying as flow lab are using the AI Chat key.

## PR Creation Checklist:
- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
