### PR TITLE
Don't Provision CodeProjects Support in Adhocs unless CloudFront is Enabled

### DIFF
--- a/aws/cloudformation/cloud_formation_stack.yml.erb
+++ b/aws/cloudformation/cloud_formation_stack.yml.erb
@@ -873,9 +873,11 @@ Outputs:
   PegasusURL:
     Value: "https://<%=subdomain%>"
     Description: Pegasus URL
+<% if cdn_enabled -%>
   PreviewCodeprojectsURL:
     Description: Codeprojects URL
     Value: !Sub preview.${CodeprojectsBaseDomainName}
+<% end -%>
 # display information about how to ssh to console if this is a single instance adhoc environment
 <% if rack_env?(:adhoc) && !frontends -%>
   SSHServerName:

--- a/aws/cloudformation/cloud_formation_stack.yml.erb
+++ b/aws/cloudformation/cloud_formation_stack.yml.erb
@@ -845,11 +845,12 @@ Resources:
   # ---------------------------------------------
 <%=  component 'database'%>
 
+<% if cdn_enabled -%>
   # ---------------------------------------------
   # Codeprojects Resources
   # ---------------------------------------------
 <%= resource_component 'codeprojects_resources' %>
-
+<% end -%>
   # ---------------------------------------------
   # Custom Chef Configuration Secret
   #


### PR DESCRIPTION
We don't need to enable all CodeProjects features on every adhoc, and by default CloudFront is NOT enabled on adhocs. Stop provisioning CodeProjects resources by default because it takes longer and also we're regularly exceeding our quota on our AWS Account for CloudFront OriginRequestPolicy resources. Engineers frequently find their attempts to create an adhoc fail due to us exhausing our OriginRequestPolicy quota.

## Testing story
`bundle exec rake adhoc:start RAILS_ENV=adhoc STACK_NAME=adhoc-no-cloudfront-no-codeprojects`

`bundle exec rake adhoc:cdn:start RAILS_ENV=adhoc STACK_NAME=adhoc-yes-cloudfront-yes-codeprojects`



## Deployment strategy
<!--  Any special steps required to deploy this, besides merging?
      - Are there database migrations or manual steps?
      - Does this require coordination with other teams or systems? -->



## Follow-up work
<!--  List any clean-up or technical debt that will be addressed in future work.
      - Include Jira links where applicable.
      - Are there any known limitations or improvements planned? -->



## Privacy
<!--  How does this change impact Student & Teacher privacy?
      - Does this collect, use, share, or modify PII, either new or existing? -->



## Security
<!--  How does this change impact our security surface-area?
      - Do API's touched have the right auth?
      - Do infra changes impact our attack surface or encryption?
-->



## Caching
<!--  How does this change impact caching behavior?
      - Are cache keys or invalidation strategies affected?
      - Will this require cache warming or invalidation after deployment? -->



## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
