### PR TITLE
Fix adhocs: set contentful_api_key as `!Secret` in adhoc.yml.erb

### DIFF
--- a/config/adhoc.yml.erb
+++ b/config/adhoc.yml.erb
@@ -36,3 +36,5 @@ db_credential_writer: !StackSecret
 db_credential_reader: !StackSecret
 
 openai_student_learning_api_key: !Secret
+
+contentful_api_key: !Secret

--- a/dashboard/engines/marketing/lib/marketing/engine.rb
+++ b/dashboard/engines/marketing/lib/marketing/engine.rb
@@ -6,7 +6,7 @@ module Marketing
 
     config.to_prepare do
       # Register the Contentful source for notifications in the Dashboard app
-      contentful_client = if (Rails.application.config.respond_to?(:stub_contentful_notifications) && Rails.application.config.stub_contentful_notifications) || [:development, :test, :adhoc].include?(rack_env)
+      contentful_client = if (Rails.application.config.respond_to?(:stub_contentful_notifications) && Rails.application.config.stub_contentful_notifications) || [:development, :test].include?(rack_env)
                             Marketing::StubbedContentfulClient.instance
                           else
                             Marketing::ContentfulClient.instance

--- a/dashboard/engines/marketing/lib/marketing/engine.rb
+++ b/dashboard/engines/marketing/lib/marketing/engine.rb
@@ -6,7 +6,7 @@ module Marketing
 
     config.to_prepare do
       # Register the Contentful source for notifications in the Dashboard app
-      contentful_client = if (Rails.application.config.respond_to?(:stub_contentful_notifications) && Rails.application.config.stub_contentful_notifications) || [:development, :test].include?(rack_env)
+      contentful_client = if (Rails.application.config.respond_to?(:stub_contentful_notifications) && Rails.application.config.stub_contentful_notifications) || [:development, :test, :adhoc].include?(rack_env)
                             Marketing::StubbedContentfulClient.instance
                           else
                             Marketing::ContentfulClient.instance


### PR DESCRIPTION
Adhocs were failing to start with `'RAILS_ENV=staging RACK_ENV=staging bundle exec rake db:setup_or_migrate' returned 1`. The issue was that while a secret was set in AWS Secrets manager as `cdo/adhoc/contentful_api_key`, and was also declared as `!Secret` in config.yml.erb, it needed to be re-declared as `!Secret` in adhoc.yml.erb because adhocs reset secret declarations.