### PR TITLE
Web Lab 2: add an edge when preview is in full screen mode

### DIFF
--- a/apps/src/codebridge/FilePreview/HTMLPreview.tsx
+++ b/apps/src/codebridge/FilePreview/HTMLPreview.tsx
@@ -258,7 +258,12 @@ export const HTMLPreview: React.FC = () => {
       headerContent={codebridgeI18n.preview()}
       hideHeaders
     >
-      <div className={moduleStyles.previewContainer}>
+      <div
+        className={classNames(
+          moduleStyles.previewContainer,
+          isFullScreenView && moduleStyles.fullScreenPreviewContainer
+        )}
+      >
         <HTMLPreviewHeader
           value={inputValue}
           onChange={setInputValue}

--- a/apps/src/codebridge/FilePreview/HTMLPreviewHeader.tsx
+++ b/apps/src/codebridge/FilePreview/HTMLPreviewHeader.tsx
@@ -3,6 +3,7 @@ import SegmentedButtons, {
   SegmentedButtonsProps,
 } from '@code-dot-org/component-library/segmentedButtons';
 import TextField from '@code-dot-org/component-library/textField';
+import classNames from 'classnames';
 import React from 'react';
 
 import {useAppSelector} from '@cdo/apps/util/reduxHooks';
@@ -72,7 +73,12 @@ export const HTMLPreviewHeader: React.FC<HTMLPreviewHeaderProps> = ({
   };
 
   return (
-    <div className={moduleStyles.previewHeaderContainer}>
+    <div
+      className={classNames(
+        moduleStyles.previewHeaderContainer,
+        isFullScreenView && moduleStyles.fullScreenPreviewHeaderContainer
+      )}
+    >
       <div className={moduleStyles.urlBarContent}>
         <div className={moduleStyles.navButtonsWrapper}>
           <Button

--- a/apps/src/codebridge/FilePreview/styles/html-preview-header.module.scss
+++ b/apps/src/codebridge/FilePreview/styles/html-preview-header.module.scss
@@ -72,3 +72,8 @@
     }
   }
 }
+
+// Styles applied when in full screen view mode
+.fullScreenPreviewHeaderContainer {
+  border-radius: 0.25rem 0.25rem 0 0;
+}

--- a/apps/src/codebridge/FilePreview/styles/html-preview.module.scss
+++ b/apps/src/codebridge/FilePreview/styles/html-preview.module.scss
@@ -9,6 +9,16 @@
   grid-template-rows: 40px 1fr;
 }
 
+// Styles applied when in full screen view mode
+.fullScreenPreviewContainer {
+  padding: 1rem;
+
+  & > .previewWrapper {
+    border-radius: 0 0 0.25rem 0.25rem;
+    overflow: hidden;
+  }
+}
+
 .previewHeader {
   display: flex;
   justify-content: space-between;

--- a/apps/src/lab2/views/components/layout/full-screen-view-layout.module.scss
+++ b/apps/src/lab2/views/components/layout/full-screen-view-layout.module.scss
@@ -1,5 +1,6 @@
 .fullScreenViewContainer {
   color: var(--text-neutral-primary);
+  background: var(--neutral-black-alpha-80);
   height: 100%;
   width: 100%;
 }


### PR DESCRIPTION
Adds padding, border, and background styles when the Preview panel is in full screen mode.

## Links
Jira ticket: [AFL-151](https://codedotorg.atlassian.net/browse/AFL-151)
Figma mock: [here](https://www.figma.com/file/tDzVjyvhfkF8lyGROENOAD?type=design&node-id=3769%3A32063&mode=dev)

----

## Before

https://github.com/user-attachments/assets/cc3e0401-45c6-4c68-8ebe-147dc9296a1b



## After

https://github.com/user-attachments/assets/2bb0ebc4-a56d-48bd-856a-677fb3d5c888

