### PR TITLE
Move connected_to block in pii_scrubber

### DIFF
--- a/dashboard/lib/expired_deleted_account_pii_scrubber.rb
+++ b/dashboard/lib/expired_deleted_account_pii_scrubber.rb
@@ -63,9 +63,15 @@ class ExpiredDeletedAccountPiiScrubber
     # an order by id, causing an inefficient scan on the id index. Order does not matter
     # for this operation, so we can use a simple limit approach.
     loop do
-      account_batch = accounts_to_scrub.limit(BATCH_SIZE)
+      # Execute batch selection on the reporting replica and materialize results.
+      account_batch = ActiveRecord::Base.connected_to(role: :reporting) do
+        accounts_to_scrub.limit(BATCH_SIZE).to_a
+      end
+
       account_batch.each do |user|
-        scrub_user(user)
+        ActiveRecord::Base.connected_to(role: :writing) do
+          scrub_user(user)
+        end
         self.num_accounts_scrubbed += 1
       rescue StandardError => exception
         self.num_errors += 1
@@ -74,6 +80,7 @@ class ExpiredDeletedAccountPiiScrubber
       ensure
         processed_user_ids << user.id
       end
+
       break if account_batch.size < BATCH_SIZE
     end
 
@@ -88,13 +95,8 @@ class ExpiredDeletedAccountPiiScrubber
     log_to_slack(summary, SLACK_CHANNEL_FOR_ERRORS) if num_errors.positive?
   end
 
-  # This query sometimes exceeds the timeout for the prod database. The reporting database is only seconds
-  # behind the prod database, and the default timeframe for expired accounts is 28 days, so we can use it here without much risk.
-  # This helps avoid timeouts and reduces load on the production database.
   def accounts_to_scrub
-    ActiveRecord::Base.connected_to(role: :reporting) do
-      Queries::User::ExpiredDeletedAccounts.call(deleted_before: deleted_since).where.not(id: processed_user_ids)
-    end
+    Queries::User::ExpiredDeletedAccounts.call(deleted_before: deleted_since).where.not(id: processed_user_ids)
   end
 
   def summary

--- a/dashboard/test/lib/expired_deleted_account_pii_scrubber_test.rb
+++ b/dashboard/test/lib/expired_deleted_account_pii_scrubber_test.rb
@@ -22,32 +22,6 @@ class ExpiredDeletedAccountPiiScrubberTest < ActiveSupport::TestCase
       Honeybadger.stubs(:notify)
     end
 
-    it 'uses the reporting role for batch queries' do
-      roles_seen = []
-
-      subscriber = ActiveSupport::Notifications.subscribe('sql.active_record') do |*args|
-        payload = args.last
-        sql = payload[:sql]
-        # Capture only the batch SELECT from the loop (has LIMIT against users)
-        if sql =~ /FROM\s+`users`/i && sql =~ /LIMIT/i
-          roles_seen << ActiveRecord::Base.current_role
-        end
-      end
-
-      begin
-        # Run in dry_run mode to avoid writes; ensure at least one eligible record exists
-        # described_instance = described_class.new(dry_run: true, deleted_since: described_instance.deleted_since, limit: described_class::ACCOUNT_SCRUB_LIMIT)
-        expect(Services::User::PiiScrubber).to receive(:call).with(user: user)
-        # described_instance.call
-        scrub_pii
-      ensure
-        ActiveSupport::Notifications.unsubscribe(subscriber)
-      end
-
-      _(roles_seen).wont_be_empty
-      _(roles_seen.uniq).must_equal [:reporting]
-    end
-
     it 'runs the PII scrub service on expired deleted accounts' do
       expect(Services::User::PiiScrubber).to receive(:call).with(user: user)
       scrub_pii

--- a/dashboard/test/lib/expired_deleted_account_pii_scrubber_test.rb
+++ b/dashboard/test/lib/expired_deleted_account_pii_scrubber_test.rb
@@ -22,6 +22,32 @@ class ExpiredDeletedAccountPiiScrubberTest < ActiveSupport::TestCase
       Honeybadger.stubs(:notify)
     end
 
+    it 'uses the reporting role for batch queries' do
+      roles_seen = []
+
+      subscriber = ActiveSupport::Notifications.subscribe('sql.active_record') do |*args|
+        payload = args.last
+        sql = payload[:sql]
+        # Capture only the batch SELECT from the loop (has LIMIT against users)
+        if sql =~ /FROM\s+`users`/i && sql =~ /LIMIT/i
+          roles_seen << ActiveRecord::Base.current_role
+        end
+      end
+
+      begin
+        # Run in dry_run mode to avoid writes; ensure at least one eligible record exists
+        # described_instance = described_class.new(dry_run: true, deleted_since: described_instance.deleted_since, limit: described_class::ACCOUNT_SCRUB_LIMIT)
+        expect(Services::User::PiiScrubber).to receive(:call).with(user: user)
+        # described_instance.call
+        scrub_pii
+      ensure
+        ActiveSupport::Notifications.unsubscribe(subscriber)
+      end
+
+      _(roles_seen).wont_be_empty
+      _(roles_seen.uniq).must_equal [:reporting]
+    end
+
     it 'runs the PII scrub service on expired deleted accounts' do
       expect(Services::User::PiiScrubber).to receive(:call).with(user: user)
       scrub_pii


### PR DESCRIPTION
The `connected_to` block was not actually causing the query to execute against the reporting replica. This moves the `connected_to` block and calls to_a on the result to actually execute the query. To ensure we still write using the `:writing` role, this is explicitly set inside the processing loop.

## Links
<!--  Links to relevant external resources.
      - spec docs, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- Jira: 

## Testing story
<!--  Does your change include appropriate tests?
      - If so, please describe how the tests included in this PR are sufficient.
      - If not, please explain why this change does not need to be tested. -->



## Deployment strategy
<!--  Any special steps required to deploy this, besides merging?
      - Are there database migrations or manual steps?
      - Does this require coordination with other teams or systems? -->



## Follow-up work
<!--  List any clean-up or technical debt that will be addressed in future work.
      - Include Jira links where applicable.
      - Are there any known limitations or improvements planned? -->



## Privacy
<!--  How does this change impact Student & Teacher privacy?
      - Does this collect, use, share, or modify PII, either new or existing? -->



## Security
<!--  How does this change impact our security surface-area?
      - Do API's touched have the right auth?
      - Do infra changes impact our attack surface or encryption?
-->



## Caching
<!--  How does this change impact caching behavior?
      - Are cache keys or invalidation strategies affected?
      - Will this require cache warming or invalidation after deployment? -->



## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
