### PR TITLE
Fix broken doc link

### DIFF
--- a/apps/src/applab/ImportProjectDialog.jsx
+++ b/apps/src/applab/ImportProjectDialog.jsx
@@ -2,6 +2,8 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import {connect} from 'react-redux';
 
+import {studio} from '@cdo/apps/lib/util/urlHelpers';
+
 import Dialog, {Body, Buttons, Confirm} from '../legacySharedComponents/Dialog';
 import color from '../util/color';
 
@@ -32,7 +34,9 @@ export class ImportProjectDialog extends React.Component {
             Copy the share link of the app you would like to import screens
             from. Paste in the URL of that app below and click "Next."{' '}
             <a
-              href={`${window.dashboard.CODE_ORG_URL}/applab/docs/import`}
+              href={studio(
+                '/docs/concepts/app-lab/design-mode/importing-screens/'
+              )}
               target="_blank"
               rel="noopener noreferrer"
             >


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

Fix broken "Learn More" link for Importing Screens in App Lab.  Point to https://studio.code.org/docs/concepts/app-lab/design-mode/importing-screens/ instead.

## Links
<!--  Links to relevant external resources.
      - spec docs, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- [Zendesk ticket](https://codeorg.zendesk.com/agent/tickets/556014) where someone was confused about how to use the feature. They don't mention it, but I noticed the "Learn more" link is broken. Maybe if it pointed to the right docs, they wouldn't have needed to ask the question :)  

## Testing story
<!--  Does your change include appropriate tests?
      - If so, please describe how the tests included in this PR are sufficient.
      - If not, please explain why this change does not need to be tested. -->

### BEFORE

<img width="682" height="564" alt="image" src="https://github.com/user-attachments/assets/4bc4aa00-b844-489d-a69b-40c9aad330b4" />

`code.org/docs/applab/import` redirects to `studio.code.org/docs/applab/import` which gives 404

### AFTER

<img width="648" height="451" alt="image" src="https://github.com/user-attachments/assets/fe908987-6dee-467e-8aad-05c6774956e9" />

-> `/docs/concepts/app-lab/design-mode/importing-screens/`

<img width="988" height="568" alt="image" src="https://github.com/user-attachments/assets/2c272283-62d3-4f43-ab94-c59e7f6c847f" />
