### PR TITLE
fix(prettier): do not prettier transient files

### DIFF
--- a/frontend/packages/component-library/.gitignore
+++ b/frontend/packages/component-library/.gitignore
@@ -1,1 +1,3 @@
 dist
+# tsup generated files
+tsup.config.bundled_*.mjs

--- a/frontend/packages/fonts/.gitignore
+++ b/frontend/packages/fonts/.gitignore
@@ -1,1 +1,3 @@
 dist
+# tsup generated files
+tsup.config.bundled_*.mjs


### PR DESCRIPTION
When a concurrent build and lint step occurs, if the build is still ongoing, prettier may pick up and attempt to fix the transient tsup build file. This causes a build failure if the transient file was picked up but could not later be read for processing. Since these are transient files, there is no need to include them in git nor prettier them.