### PR TITLE
fix(cache): add cache behavior for images

### DIFF
--- a/lib/cdo/http_cache.rb
+++ b/lib/cdo/http_cache.rb
@@ -152,6 +152,14 @@ class HttpCache
             cookies: default_cookies,
             include_marketing_router_lambda: true,
           },
+          # NextJS dynamic image api
+          {
+            path: '/_next/image',
+            proxy: 'marketing',
+            headers: ALLOWLISTED_HEADERS,
+            cookies: 'none',
+            include_marketing_router_lambda: true,
+          },
           {
             # Serve Sprockets-bundled assets directly from the S3 bucket synced via `assets:precompile`.
             #


### PR DESCRIPTION
This PR adds a cache behavior for `/_next/image*` on the Pegasus distribution allowing cache variance on the `Accept` header to determine whether a client can accept webp or avif image formats. Currently, this header is not passed causing the application to mistakenly believe that the client does not support webp or avif causing images to be sent out as jpegs. Unfortunately, jpeg does not support alpha transparency and therefore causes a black background to appear where the alpha transparency is. To fix this, ensure that the accept header is passed down. This fixes it for most clients, all the way down to chrome 65. For older clients, they will see a degraded experience with the black background as mentioned before. However, this can be fixed (if needed) in the future by adjusting the application.