### PR TITLE
Music AI: adjust prompt

### DIFF
--- a/apps/src/music/ai/generate/GenerateCodeContent.ts
+++ b/apps/src/music/ai/generate/GenerateCodeContent.ts
@@ -14,7 +14,7 @@ Indenting is important.  In this example, when the code is run, it plays "hiphop
 
 Don't include any comments in the generated pseudocode.
 
-The valid sounds to use are: {sounds}.  (The length of each sound is in parentheses.)  You can use any of these sounds in your pseudocode.
+The valid sounds to use are: {sounds}.  (The length of each sound is in parentheses.)  You can use any of these sounds in your pseudocode. DO NOT include the sound length in the pseudocode.
 `;
 
 export const DefaultPrompt =


### PR DESCRIPTION
We seem to be getting back a lot of responses where the sound length is included in the sample name, which causes our parser to fail and fallback to the default sound. This is a minor prompt adjustment that hopes to reduce the occurrence of that.

### Testing
Tested locally, anecdotally; meant to improve confidence for playtest and experimentation but not a long term fix since our strategy for HoAI will be different.
