### PR TITLE
P20-1623/cap exemption for rostered students

### DIFF
--- a/dashboard/lib/policies/child_account.rb
+++ b/dashboard/lib/policies/child_account.rb
@@ -118,10 +118,6 @@ class Policies::ChildAccount
   # the student attends because the school has admin control of the account.
   SCHOOL_OWNED_TYPES = Set[AuthenticationOption::CLEVER, AuthenticationOption::LTI_V1].freeze
 
-  # Login types that are considered school owned only if the user is in a section or was created via
-  # roster sync from an LMS.
-  CONDITIONALLY_SCHOOL_OWNED_TYPES = Set[AuthenticationOption::GOOGLE, AuthenticationOption::MICROSOFT].freeze
-
   # Login types that are always considered personal logins.
   PERSONAL_LOGIN_TYPES = Set[AuthenticationOption::EMAIL, AuthenticationOption::FACEBOOK].freeze
 
@@ -131,23 +127,21 @@ class Policies::ChildAccount
     # Sponsored accounts are always managed by the teacher.
     return false if user.sponsored?
 
-    # Email + password logins are always personal logins.
+    # Any account is considered school owned for users who are in sections and/or
+    # if the user was created via a roster sync.
+    return false if conditionally_school_managed?(user)
+
+    # Email + password logins are personal logins.
     return true if user.encrypted_password.present?
 
     providers = user.migrated? ? Set.new(user.authentication_options.pluck(:credential_type)) : Set.new([user.provider])
     return true if providers.empty?
 
-    # Email and Facebook are always personal logins.
+    # Email and Facebook are personal logins.
     return true if providers.intersect?(PERSONAL_LOGIN_TYPES)
 
     # Clever and LTI are never personal logins if no other login types are present.
     return false if providers.subset?(SCHOOL_OWNED_TYPES)
-
-    # Google and Microsoft are considered school owned for users who are in sections and/or
-    # if the user was created via a roster sync.
-    if providers.intersect?(CONDITIONALLY_SCHOOL_OWNED_TYPES)
-      return !conditionally_school_managed?(user)
-    end
 
     return true
   end

--- a/dashboard/lib/services/child_account/lockout_handler.rb
+++ b/dashboard/lib/services/child_account/lockout_handler.rb
@@ -10,8 +10,8 @@ module Services
 
       # @return [true,false] true if the user is locked out, false otherwise
       def call
-        return true if Policies::ChildAccount::ComplianceState.locked_out?(user)
         return false if Policies::ChildAccount.compliant?(user)
+        return true if Policies::ChildAccount::ComplianceState.locked_out?(user)
 
         user_lockout_date = Policies::ChildAccount.lockout_date(user)
         return false if user_lockout_date.nil? || user_lockout_date > DateTime.now

--- a/dashboard/test/lib/policies/child_account_test.rb
+++ b/dashboard/test/lib/policies/child_account_test.rb
@@ -446,15 +446,21 @@ class Policies::ChildAccountTest < ActiveSupport::TestCase
       [[:student, :with_lti_authentication_option, :without_encrypted_password], true],
       [[:student, :with_lti_authentication_option, :without_email_auth_option], true],
 
-      # Conditionally school-managed accounts that have email logins or passwords, tainting them as personal accounts
-      [[:student, :with_google_authentication_option, :without_email_auth_option, {roster_synced: true}], true],
-      [[:student, :with_google_authentication_option, :without_encrypted_password, {roster_synced: true}], true],
-      [[:student, :with_google_authentication_option, :without_email_auth_option, :in_google_section], true],
-      [[:student, :with_google_authentication_option, :without_encrypted_password, :in_google_section], true],
-      [[:student, :with_microsoft_authentication_option, :without_email_auth_option, {roster_synced: true}], true],
-      [[:student, :with_microsoft_authentication_option, :without_encrypted_password, {roster_synced: true}], true],
-      [[:student, :with_microsoft_authentication_option, :without_email_auth_option, :in_email_section], true],
-      [[:student, :with_microsoft_authentication_option, :without_encrypted_password, :in_email_section], true],
+      # Conditionally school-managed accounts that have email logins or passwords should still be considered school-managed
+      [[:student, :with_google_authentication_option, :without_email_auth_option, {roster_synced: true}], false],
+      [[:student, :with_google_authentication_option, :without_encrypted_password, {roster_synced: true}], false],
+      [[:student, :with_google_authentication_option, :without_email_auth_option, :in_google_section], false],
+      [[:student, :with_google_authentication_option, :without_encrypted_password, :in_google_section], false],
+      [[:student, :with_microsoft_authentication_option, :without_email_auth_option, {roster_synced: true}], false],
+      [[:student, :with_microsoft_authentication_option, :without_encrypted_password, {roster_synced: true}], false],
+      [[:student, :with_microsoft_authentication_option, :without_email_auth_option, :in_email_section], false],
+      [[:student, :with_microsoft_authentication_option, :without_encrypted_password, :in_email_section], false],
+
+      # Personal accounts in sections or roster synced should still be considered school-managed
+      [[:student, :in_email_section], false],
+      [[:student, {roster_synced: true}], false],
+      [[:student, :with_facebook_authentication_option, :without_email_auth_option, :without_encrypted_password, :in_email_section], false],
+      [[:student, :with_facebook_authentication_option, :without_email_auth_option, :without_encrypted_password, {roster_synced: true}], false],
 
       # Unmigrated
       [[:student, :without_email_auth_option, :demigrated], true],

--- a/dashboard/test/lib/services/child_account/lockout_handler_test.rb
+++ b/dashboard/test/lib/services/child_account/lockout_handler_test.rb
@@ -90,7 +90,7 @@ class Services::ChildAccount::LockoutHandlerTest < ActiveSupport::TestCase
         _(handle_user_lockout).must_equal true
       end
 
-      context 'but also CAP compliant now' do
+      context 'when CAP compliant' do
         let(:user_is_cap_compliant?) {true}
 
         it 'returns false' do

--- a/dashboard/test/lib/services/child_account/lockout_handler_test.rb
+++ b/dashboard/test/lib/services/child_account/lockout_handler_test.rb
@@ -93,8 +93,8 @@ class Services::ChildAccount::LockoutHandlerTest < ActiveSupport::TestCase
       context 'but also CAP compliant now' do
         let(:user_is_cap_compliant?) {true}
 
-        it 'still returns true' do
-          _(handle_user_lockout).must_equal true
+        it 'returns false' do
+          _(handle_user_lockout).must_equal false
         end
       end
     end

--- a/dashboard/test/ui/features/teacher_tools/teacher_dashboard/age_gated_sections_modal.feature
+++ b/dashboard/test/ui/features/teacher_tools/teacher_dashboard/age_gated_sections_modal.feature
@@ -10,3 +10,15 @@ Feature: Age Gated Sections Modal and Banner
     When I sign in as "Teacher_Sally" and go home
     And I wait until element "#ui-test-section-list" is visible
     And I wait until element "#uitest-age-gated-sections-banner" is not visible
+
+    # All students in sections are no longer considered at risk because they can not be locked out unless they are removed from their section
+  Scenario: Teacher viewing their sections with at risk age gated students should not see age gated sections banner
+    Given I am on "http://studio.code.org"
+    Given CPA all user lockout phase
+
+    Given I create an authorized teacher-associated under-13 student in Colorado named "Sally" after CAP start
+    Given I am assigned to course "allthethingscourse" unit 1
+
+    When I sign in as "Teacher_Sally" and go home
+    And I wait until element "#ui-test-section-list" is visible
+    And I wait until element "#uitest-age-gated-sections-banner" is not visible

--- a/dashboard/test/ui/features/teacher_tools/teacher_dashboard/age_gated_sections_modal.feature
+++ b/dashboard/test/ui/features/teacher_tools/teacher_dashboard/age_gated_sections_modal.feature
@@ -30,20 +30,3 @@ Feature: Age Gated Sections Modal and Banner
     When I sign in as "Teacher_Sally" and go home
     And I wait until element "#ui-test-section-list" is visible
     And I wait until element "#uitest-age-gated-sections-banner" is not visible
-
-  Scenario: Teacher viewing their sections with at risk age gated students should see age gated sections banner and can click and see modal
-    Given I am on "http://studio.code.org"
-    Given CPA all user lockout phase
-
-    Given I create an authorized teacher-associated under-13 student in Colorado named "Sally" after CAP start
-    Given I am assigned to course "allthethingscourse" unit 1
-
-    When I sign in as "Teacher_Sally" and go home
-    And I wait until element "#ui-test-section-list" is visible
-    # Click on Age Gated Banner Sections button to view Age Gated Sections Modal
-    And I wait until element "#uitest-age-gated-sections-banner" is visible
-    And I click selector "a:contains(Sections)"
-    And I wait until element "#uitest-age-gated-sections-modal" is visible
-    And I wait until element "div:contains(Sally)" is visible
-    And I click selector "button:contains(Close)"
-    And I wait until element "#uitest-age-gated-sections-modal" is not visible

--- a/dashboard/test/ui/features/teacher_tools/teacher_dashboard/age_gated_sections_modal.feature
+++ b/dashboard/test/ui/features/teacher_tools/teacher_dashboard/age_gated_sections_modal.feature
@@ -1,24 +1,4 @@
 Feature: Age Gated Sections Modal and Banner
-  @eyes
-  Scenario: Age gated sections banner and modal for Teachers
-    Given I am on "http://studio.code.org"
-    Given CPA all user lockout phase
-
-    Given I create an authorized teacher-associated under-13 student in Colorado named "Sally" after CAP start
-    Given I am assigned to course "allthethingscourse" unit 1
-
-    When I sign in as "Teacher_Sally" and go home
-    And I wait until element "#ui-test-section-list" is visible
-
-    # Click on Age Gated Banner Sections button to view Age Gated Sections Modal
-    When I open my eyes to test "Age Gated Sections Banner and Modal"
-    And I wait until element "#uitest-age-gated-sections-banner" is visible
-    Then I see no difference for "age gated sections banner"
-
-    And I click selector "a:contains(Sections)"
-    And I wait until element "#uitest-age-gated-sections-modal" is visible
-    Then I see no difference for "age gated sections modal"
-    And I close my eyes
 
   Scenario: Teacher viewing their section with no at risk age gated students should not see age gated sections banner
     Given I am on "http://studio.code.org"

--- a/dashboard/test/ui/features/teacher_tools/teacher_dashboard/age_gated_students_modal.feature
+++ b/dashboard/test/ui/features/teacher_tools/teacher_dashboard/age_gated_students_modal.feature
@@ -11,3 +11,16 @@ Feature: Age Gated Students Modal and Banner
     And I wait until element "#ui-test-section-list" is visible
     Then I click selector "#task-button-View-progress-CAP-Section" once I see it
     And I wait until element "#uitest-age-gated-banner" is not visible
+
+  # All students in sections are no longer considered at risk because they cannot be locked out unless they are removed from their section
+  Scenario: Teacher viewing a section with at risk age gated students should see age gated students banner and can click and see modal
+    Given I am on "http://studio.code.org"
+    Given CPA all user lockout phase
+
+    Given I create an authorized teacher-associated under-13 student in Colorado named "Sally" after CAP start
+    Given I am assigned to course "allthethingscourse" unit 1
+
+    When I sign in as "Teacher_Sally" and go home
+    And I wait until element "#ui-test-section-list" is visible
+    Then I click selector "#task-button-View-progress-CAP-Section" once I see it
+    And I wait until element "#uitest-age-gated-banner" is not visible

--- a/dashboard/test/ui/features/teacher_tools/teacher_dashboard/age_gated_students_modal.feature
+++ b/dashboard/test/ui/features/teacher_tools/teacher_dashboard/age_gated_students_modal.feature
@@ -1,27 +1,4 @@
 Feature: Age Gated Students Modal and Banner
-  @eyes
-  Scenario: Age gated students banner and modal for Teachers
-    Given I am on "http://studio.code.org"
-    Given CPA all user lockout phase
-
-    Given I create an authorized teacher-associated under-13 student in Colorado named "Sally" after CAP start
-    Given I am assigned to course "allthethingscourse" unit 1 with teacher "Teacher_Sally"
-
-    When I sign in as "Teacher_Sally" and go home
-    And I wait until element "#ui-test-section-list" is visible
-    Then I click selector "#section-options-dropdown-dropdown-button" once I see it
-    And I click selector "#ui-test-Section-settings" once I see it
-    Then I click selector "a:contains(Progress)" once I see it
-
-    # Click on Age Gated Banner Students button to view Age Gated Students Modal
-    When I open my eyes to test "Age Gated Students Banner and Modal"
-    And I wait until element "#uitest-age-gated-banner" is visible
-    Then I see no difference for "age gated students banner"
-
-    And I click selector "a:contains(Students)"
-    And I wait until element "#uitest-age-gated-students-modal" is visible
-    Then I see no difference for "age gated students modal"
-    And I close my eyes
 
   Scenario: Teacher viewing a section with no at risk age gated students should not see age gated students banner
     Given I am on "http://studio.code.org"
@@ -34,26 +11,3 @@ Feature: Age Gated Students Modal and Banner
     And I wait until element "#ui-test-section-list" is visible
     Then I click selector "#task-button-View-progress-CAP-Section" once I see it
     And I wait until element "#uitest-age-gated-banner" is not visible
-
-  Scenario: Teacher viewing a section with at risk age gated students should see age gated students banner and can click and see modal
-    Given I am on "http://studio.code.org"
-    Given CPA all user lockout phase
-
-    Given I create an authorized teacher-associated under-13 student in Colorado named "Sally" after CAP start
-    Given I am assigned to course "allthethingscourse" unit 1
-
-    When I sign in as "Teacher_Sally" and go home
-    And I wait until element "#ui-test-section-list" is visible
-    Then I click selector "#section-options-dropdown-dropdown-button" once I see it
-    Then I click selector "#ui-test-Section-settings" once I see it
-    Then I click selector "a:contains(Progress)" once I see it
-    And I wait until element "#uitest-age-gated-banner" is visible
-    And I wait until element "h3" contains text "It's a bit empty here..."
-
-    # Click on Age Gated Banner Students button to view Age Gated Students Modal
-    And I wait until element "#uitest-age-gated-banner" is visible
-    And I click selector "a:contains(Students)"
-    And I wait until element "#uitest-age-gated-students-modal" is visible
-    And I wait until element "div:contains(Sally)" is visible
-    And I click selector "button:contains(Close)"
-    And I wait until element "#uitest-age-gated-students-modal" is not visible

--- a/dashboard/test/ui/features/teacher_tools/teacher_dashboard/age_gated_students_modal.feature
+++ b/dashboard/test/ui/features/teacher_tools/teacher_dashboard/age_gated_students_modal.feature
@@ -22,5 +22,7 @@ Feature: Age Gated Students Modal and Banner
 
     When I sign in as "Teacher_Sally" and go home
     And I wait until element "#ui-test-section-list" is visible
-    Then I click selector "#task-button-View-progress-CAP-Section" once I see it
+    Then I click selector "#section-options-dropdown-dropdown-button" once I see it
+    Then I click selector "#ui-test-Section-settings" once I see it
+    Then I click selector "a:contains(Progress)" once I see it
     And I wait until element "#uitest-age-gated-banner" is not visible


### PR DESCRIPTION
Legal's guidance on school-managed accounts now include any student account that is in a section. This PR makes it so that any student in a section can use Code.org unlocked, but still have some account settings, such as state, age, and connected accounts restricted. 

## Links
- Jira: [P20-1623](https://codedotorg.atlassian.net/browse/P20-1623)

## Testing story
Added some new unit test cases to cover the new scenarios. Altered/removed some UI tests that don't make sense anymore now that no sections will have students 'at-risk' of being locked.
Manually verified:

- Email/password user
  - Created in CAP violation
    - Doesn't get parental permission
      - [x] joins a section and is no longer locked out, but still has settings restrictions
      - [x] removed from the section and is locked out again
    - Does get parental permission
      - [x] joins a section and is still not locked out
      - [x] removed from the section and is still not locked out 
  - Created not in CAP violation
    -  Joins a section and updates account settings to now be in CAP violation
      - [x] not locked out, but has settings restrictions
      - [x] removed from the section and is now locked out  with a `cap_status` of `l`

 
- Google OAuth user
  - Created in CAP violation
    - Doesn't get parental permission
      - [x] joins a section and is no longer locked out, but still has settings restrictions
      - [x] removed from the section and is locked out again
    - Does get parental permission
      - [x] joins a section and is still not locked out
      - [x] removed from the section and is still not locked out 
  - Created not in CAP violation
    -  Joins a section and updates account settings to now be in CAP violation
      - [x] not locked out, but has settings restrictions
      - [x] removed from the section and is now locked out  with a `cap_status` of `l`

