### PR TITLE
Update secrets.yml.template to match guidance from discussion in slack

### DIFF
--- a/config/secrets.yml.template
+++ b/config/secrets.yml.template
@@ -1,7 +1,10 @@
 # Sample secrets.yml file; consumed by test_secrets_config.rb
 ---
-# Publish AWS Secrets Manager Secrets named `[environment type]/cdo/acme_api_key` that can be used to populate `CDO.acme_api_key`.
-# Comments (e.g. "#Development || Production API key") list key usage preference order per environment type. Use the first key you have.
+# Publish AWS Secrets Manager Secrets named `[environment type]/cdo/acme_api_key`
+# that can be used to populate `CDO.acme_api_key`.
+# Ideally we use unique secrets per environment, but that's not always possible.
+# The comments below (e.g. "#Development || Production API key") list key usage
+# preference order per environment type. Use the first key you have.
 acme_api_key:
   development: 123ABC      # Development || Production API key
   adhoc: 123ABC            # Development || Production API key

--- a/config/secrets.yml.template
+++ b/config/secrets.yml.template
@@ -1,12 +1,13 @@
 # Sample secrets.yml file; consumed by test_secrets_config.rb
 ---
-# Publish AWS Secrets Manager Secrets named `[environment type]/cdo/acme_api_key` that can be used to populate `CDO.acme_api_key`
+# Publish AWS Secrets Manager Secrets named `[environment type]/cdo/acme_api_key` that can be used to populate `CDO.acme_api_key`.
+# Comments (e.g. "#Development || Production API key") list key usage preference order per environment type. Use the first key you have.
 acme_api_key:
-  development: 123ABC      # Development API key
-  adhoc: 123ABC            # Development API key
-  staging: 123ABC          # Development API key
-  test: ZYX987             # Test API key
-  levelbuilder: ZYX987     # Test API key
+  development: 123ABC      # Development || Production API key
+  adhoc: 123ABC            # Development || Production API key
+  staging: 456DEF          # Staging || Development || Production API key
+  test: ZYX987             # Test || Development || Production API key
+  levelbuilder: LSDP012    # Levelbuilder || Staging || Development || Production API key
   production: a1b2c3d4e5f6 # Production API key
 
 # Publish AWS Secrets Manager Secrets named `[environment type]/cdo/wile_e_coyote_credentials` that can be used to

--- a/lib/test/cdo/test_secrets_config.rb
+++ b/lib/test/cdo/test_secrets_config.rb
@@ -20,7 +20,7 @@ class SecretsConfigTest < Minitest::Test
   def test_load
     secrets_file = CDO.dir('config/secrets.yml.template')
     secrets = Cdo::SecretsConfig.load(secrets_file)
-    assert_equal '123ABC', secrets['staging/cdo/acme_api_key']
+    assert_equal '456DEF', secrets['staging/cdo/acme_api_key']
     complex_secret = secrets['development/cdo/wile_e_coyote_credentials']
     assert_equal 'dev@code.org', complex_secret["username"]
     assert_equal 'Q3rt^', complex_secret["password"]


### PR DESCRIPTION
This PR updates the comments in `secrets.yml.template` to provide guidance that encourages more granular secrets/keys while providing a fallback approach when more granular secrets/keys are not available.

## Links
This approach was discussed/proposed in this [slack thread](https://codedotorg.slack.com/archives/C03CK49G9/p1758643419538119).

## Follow-up work
This PR does not suggest per-human (developer) keys as this likely needs more thought.  This can be added in a later PR once fleshed out.

## PR Creation Checklist:
- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
