### PR TITLE
remove set-last-dtt-green dev api route

### DIFF
--- a/pegasus/routes/dev/dev_routes.rb
+++ b/pegasus/routes/dev/dev_routes.rb
@@ -38,13 +38,6 @@ post '/api/dev/start-build' do
   )
 end
 
-post '/api/dev/set-last-dtt-green' do
-  forbidden! unless rack_env == :test
-  dont_cache
-  forbidden! unless params[:token] == CDO.slack_set_last_dtt_green_token
-  TestServerStatus.mark_green GitHub.sha('test')
-end
-
 post '/api/dev/check-dts' do
   forbidden! unless rack_env == :staging || rack_env == :development
   forbidden! unless verify_signature(CDO.github_webhook_secret)

--- a/pegasus/test/test_dev_routes.rb
+++ b/pegasus/test/test_dev_routes.rb
@@ -149,36 +149,6 @@ class DevRoutesTest < Minitest::Test
       end
     end
 
-    describe 'api/dev/set-last-dtt-green' do
-      before do
-        $log.level = Logger::ERROR
-
-        CDO.stubs(slack_set_last_dtt_green_token: FAKE_SLACK_SLASH_TOKEN)
-      end
-
-      it 'is forbidden on non-test environments' do
-        [:development, :staging, :adhoc, :levelbuilder, :production].each do |env|
-          with_rack_env(env) do
-            pegasus = make_test_pegasus
-            pegasus.post '/api/dev/set-last-dtt-green', DEFAULT_PARAMS
-            assert_equal 403, pegasus.last_response.status
-          end
-        end
-      end
-
-      it 'succeeds on test environment' do
-        with_rack_env(:test) do
-          fake_sha = 'abcdef'
-          GitHub.expects(:sha).returns(fake_sha)
-          DevelopersTopic.expects(:set_dtt).with('yes')
-          InfraTestTopic.expects(:set_green_commit).with(fake_sha)
-          pegasus = make_test_pegasus
-          pegasus.post '/api/dev/set-last-dtt-green', DEFAULT_PARAMS
-          assert_equal 200, pegasus.last_response.status
-        end
-      end
-    end
-
     describe 'api/dev/check-dts' do
       GITHUB_PAYLOAD = {
         action: 'opened',


### PR DESCRIPTION
This was used by a Slack slash-command, but it's far less reliable than using the DOTD script, and far less secure. So we're deleting it.

## Links
<!--  Links to relevant external resources.
      - spec docs, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- Jira: 

## Testing story
<!--  Does your change include appropriate tests?
      - If so, please describe how the tests included in this PR are sufficient.
      - If not, please explain why this change does not need to be tested. -->



## Deployment strategy
<!--  Any special steps required to deploy this, besides merging?
      - Are there database migrations or manual steps?
      - Does this require coordination with other teams or systems? -->



## Follow-up work
<!--  List any clean-up or technical debt that will be addressed in future work.
      - Include Jira links where applicable.
      - Are there any known limitations or improvements planned? -->



## Privacy
<!--  How does this change impact Student & Teacher privacy?
      - Does this collect, use, share, or modify PII, either new or existing? -->



## Security
<!--  How does this change impact our security surface-area?
      - Do API's touched have the right auth?
      - Do infra changes impact our attack surface or encryption?
-->



## Caching
<!--  How does this change impact caching behavior?
      - Are cache keys or invalidation strategies affected?
      - Will this require cache warming or invalidation after deployment? -->



## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [x] Tests provide adequate coverage
- [x] Privacy impacts have been documented
- [x] Security impacts have been documented
- [x] Code is well-commented
- [x] New features are translatable or updates will not break translations
- [x] Relevant documentation has been added or updated
- [x] User impact is well-understood and desirable
- [x] Follow-up work items (including potential tech debt) are tracked and linked
