### PR TITLE
P20-1634/enable enter key for lti dynamic registration

### DIFF
--- a/apps/src/simpleSignUp/lti/registration/LtiDynamicRegistrationPage.tsx
+++ b/apps/src/simpleSignUp/lti/registration/LtiDynamicRegistrationPage.tsx
@@ -70,7 +70,7 @@ export const LtiDynamicRegistrationPage = ({
           {hasError ? errorMsg : i18n.ltiDynamicRegistrationDescription()}
         </Typography>
         <div>
-          <form>
+          <form onSubmit={handleSubmit}>
             <div className={styles.inputContainer}>
               <label className={styles.formLabel}>
                 <strong>{i18n.email()}</strong>


### PR DESCRIPTION
A teacher recently reported that hitting enter on the `dynamic_registration` page rendered a sad bee instead of completing dynamic registration. The error it was returning was `{"error":"Error getting LMS openid_configuration"}`

This PR fixes the form, so that it submits the data when the user hits Enter.



## Links
- Jira: [P20-1634](https://codedotorg.atlassian.net/browse/P20-1634)

## Testing story
Manually verified that hitting enter on the `dynamic_registration` page correctly completes dynamic registration

