### PR TITLE
HOAI - Loosen access check to always allow flow lab client for testing

### DIFF
--- a/dashboard/app/models/concerns/user/ai_accessible.rb
+++ b/dashboard/app/models/concerns/user/ai_accessible.rb
@@ -50,9 +50,10 @@ module User::AiAccessible
   end
 
   def can_access_ai_tutor?(client_type)
-    # If the request is coming from AiTutor, trust the client to decide
-    # if it can access AiTutor. This allows easy testing of AiTutor using a url param.
-    client_type == SharedConstants::AI_CHAT_CLIENT_TYPES[:AI_TUTOR]
+    # If the request is coming from AiTutor or FlowLab, trust the client to decide
+    # if it can access the chat backend. This allows easy testing of AiTutor using a url param.
+    client_type == SharedConstants::AI_CHAT_CLIENT_TYPES[:AI_TUTOR] ||
+      client_type == SharedConstants::AI_CHAT_CLIENT_TYPES[:FLOW_LAB]
   end
 
   private def ai_tutor_feature_globally_disabled?


### PR DESCRIPTION
This PR loosens the chat backend access check to allow the `FLOW_LAB` client id similar to how the `AI_TUTOR` id is allowed without an additional check.  This is needed to simplify testing of the HOAI tutorial as this uses the `FLOW_LAB` id.

## Links
This was discussed in [this](https://codedotorg.slack.com/archives/C0T0PNTM3/p1758832130572809) slack thread.

## Testing story
This PR does not update tests as the `FLOW_LAB` client id is not currently dealt with in `aichat_requests_controller_test.rb` as this was never an actual product (see Follow-up).


## Follow-up work
The `FLOW_LAB` client id should be renamed to `EXPERIMENTS` and its intended access should be documented through explicit tests in `aichat_requests_controller_test.rb`.  The check for an `EXPERIMENTS` id should be removed from the `can_access_ai_tutor` method or this method should be renamed/reworked as it deals with general (not just AI Tutor) access.

## PR Creation Checklist:
- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
