### PR TITLE
AI Tutor: update the background color on tabs when teacher views chat as a student

### DIFF
--- a/apps/src/aichat/views/chatWorkspace.module.scss
+++ b/apps/src/aichat/views/chatWorkspace.module.scss
@@ -54,7 +54,7 @@ $tabs-default-spacing: 4px;
 }
 
 .tabsContainer {
-  background-color: #eaebeb;
+  background-color: var(--background-neutral-secondary);
   padding: $tabs-default-spacing $tabs-default-spacing 0 $tabs-default-spacing;
 
   ul {


### PR DESCRIPTION
Updates the background color on the tab selector to work with light and dark themes in AI Tutor.

## Links
Jira ticket: [AFL-242](https://codedotorg.atlassian.net/browse/AFL-242)
Slack convo: [here](https://codedotorg.slack.com/archives/C043ZKQ4BS6/p1758840549689199?thread_ts=1758838387.953889&cid=C043ZKQ4BS6)

----

| Before | After |
| ---- | ---- |
| <img width="561" height="200" alt="Before" src="https://github.com/user-attachments/assets/fd477f04-c395-4ddd-b8d0-7f8a9eb3a37c" /> | <img width="561" height="200" alt="After" src="https://github.com/user-attachments/assets/0e99f044-1f82-490f-b3f2-60eb60291828" /> |


