### PR TITLE
AI Tutor - Refactor PR #68567 to align with AiTutorContextHelper class intentions

### DIFF
--- a/apps/src/aiTutor/helpers/aiTutorContextHelper.ts
+++ b/apps/src/aiTutor/helpers/aiTutorContextHelper.ts
@@ -12,13 +12,14 @@ export abstract class AiTutorContextHelper<T extends object> {
 
   protected abstract setAiTutorContext(params: T): void;
 
-  protected async getHiddenContextString() {
+  private async getHiddenContextString() {
     const {
       sourceCode,
       validationContents,
       validationResults,
       longInstructions,
       documentation,
+      userSelection,
     } = await this.getAiTutorContext();
 
     const hiddenContextString = [
@@ -40,6 +41,12 @@ export abstract class AiTutorContextHelper<T extends object> {
         ? [
             'Here is the documentation. (The student can view the documentation by clicking the book icon at the top of the workspace.):',
             documentation,
+          ]
+        : []),
+      ...(userSelection
+        ? [
+            'The student would like to focus on this subset of their current code:',
+            userSelection,
           ]
         : []),
     ].join('\n\n');

--- a/apps/src/aiTutor/types.ts
+++ b/apps/src/aiTutor/types.ts
@@ -16,4 +16,5 @@ export interface AiTutorContext {
   validationResults?: string;
   longInstructions?: string;
   documentation?: string;
+  userSelection?: string;
 }

--- a/apps/src/aichat/redux/slice.ts
+++ b/apps/src/aichat/redux/slice.ts
@@ -24,7 +24,7 @@ import {
   ChatAsset,
   SaveError,
   AiChatClientType,
-  UserAddedContextItem,
+  UserAddedSelectionContextItem,
 } from '../types';
 import {
   DEFAULT_VISIBILITIES,
@@ -56,7 +56,7 @@ const initialState: AichatState = {
   saveError: undefined,
   showResetMessage: false,
   hasSetStartingCustomizations: false,
-  userAddedContext: {},
+  userAddedSelectionContext: {},
 };
 
 const aichatSlice = createSlice({
@@ -330,18 +330,22 @@ const aichatSlice = createSlice({
     setSaveError(state, action: PayloadAction<SaveError | undefined>) {
       state.saveError = action.payload;
     },
-    addItemToUserAddedContext(
+    addItemToUserAddedSelectionContext(
       state,
-      action: PayloadAction<UserAddedContextItem>
+      action: PayloadAction<UserAddedSelectionContextItem>
     ) {
-      state.userAddedContext[action.payload.displayName] = action.payload;
+      state.userAddedSelectionContext[action.payload.displayName] =
+        action.payload;
     },
-    removeItemFromUserAddedContext(state, action: PayloadAction<string>) {
-      state.userAddedContext[action.payload] &&
-        delete state.userAddedContext[action.payload];
+    removeItemFromUserAddedSelectionContext(
+      state,
+      action: PayloadAction<string>
+    ) {
+      state.userAddedSelectionContext[action.payload] &&
+        delete state.userAddedSelectionContext[action.payload];
     },
-    clearUserAddedContext(state) {
-      state.userAddedContext = {};
+    clearUserAddedSelectionContext(state) {
+      state.userAddedSelectionContext = {};
     },
   },
 });
@@ -401,7 +405,7 @@ export const {
   clearStagedFilesAlert,
   setSaveError,
   clearHasSetStartingCustomizations,
-  addItemToUserAddedContext,
-  removeItemFromUserAddedContext,
-  clearUserAddedContext,
+  addItemToUserAddedSelectionContext,
+  removeItemFromUserAddedSelectionContext,
+  clearUserAddedSelectionContext,
 } = aichatSlice.actions;

--- a/apps/src/aichat/redux/state.ts
+++ b/apps/src/aichat/redux/state.ts
@@ -10,7 +10,7 @@ import {
   ServerChatEvent,
   ViewMode,
   AiChatClientType,
-  UserAddedContext,
+  UserAddedSelectionContext,
 } from '../types';
 
 export interface AichatState {
@@ -58,5 +58,5 @@ export interface AichatState {
   saveError: SaveError | undefined;
   // If the model customizations were just reset to the default level values.
   showResetMessage: boolean;
-  userAddedContext: UserAddedContext;
+  userAddedSelectionContext: UserAddedSelectionContext;
 }

--- a/apps/src/aichat/redux/thunks/submitChatContents.ts
+++ b/apps/src/aichat/redux/thunks/submitChatContents.ts
@@ -3,7 +3,7 @@ import {createAsyncThunk} from '@reduxjs/toolkit';
 import {
   clearChatMessagePending,
   clearStagedFiles,
-  clearUserAddedContext,
+  clearUserAddedSelectionContext,
   setChatMessagePending,
 } from '@cdo/apps/aichat/redux/slice';
 import {Role} from '@cdo/apps/aiComponentLibrary/chatMessage/types';
@@ -27,7 +27,7 @@ import {
   ModelParameters,
   AiChatClientType,
   AnalyticsProperties,
-  UserAddedContextItem,
+  UserAddedSelectionContextItem,
 } from '../../types';
 import {getNewRemoveId} from '../utils';
 
@@ -48,7 +48,7 @@ export const submitChatContents = createAsyncThunk(
       hiddenContext?: string;
       assets?: ChatAsset[];
       analyticsProperties?: AnalyticsProperties;
-      userAddedContext?: UserAddedContextItem[];
+      userAddedSelectionContext?: UserAddedSelectionContextItem[];
     },
     thunkAPI
   ) => {
@@ -62,13 +62,13 @@ export const submitChatContents = createAsyncThunk(
       modelParameters,
       clientType,
       analyticsProperties,
-      userAddedContext,
+      userAddedSelectionContext,
     } = newUserMessageInput;
 
     // Clear any staged files if present (used with multimodal models)
     thunkAPI.dispatch(clearStagedFiles());
     // Clear any user added context if present.
-    thunkAPI.dispatch(clearUserAddedContext());
+    thunkAPI.dispatch(clearUserAddedSelectionContext());
 
     const aichatContext: AichatContext = {
       clientType,
@@ -83,7 +83,7 @@ export const submitChatContents = createAsyncThunk(
       chatMessageText: text,
       hiddenContext,
       assets,
-      userAddedContext,
+      userAddedSelectionContext,
       timestamp: Date.now(),
     };
     dispatch(setChatMessagePending(newUserMessage));

--- a/apps/src/aichat/types/chatEvents.ts
+++ b/apps/src/aichat/types/chatEvents.ts
@@ -5,7 +5,7 @@ import {AiInteractionStatus} from '@cdo/generated-scripts/sharedConstants';
 import {ChatAsset} from './assets';
 import {ModelParameters} from './customizations';
 import {FeedbackValue} from './toxicity';
-import {UserAddedContextItem} from './userAddedContext';
+import {UserAddedSelectionContextItem} from './userAddedSelectionContext';
 
 export type ChatEventDescriptionKey = 'CLEAR_CHAT' | 'LOAD_LEVEL';
 
@@ -23,7 +23,7 @@ interface BaseChatMessage extends BaseChatEvent {
   assets?: ChatAsset[];
   role: Role;
   status: ValueOf<typeof AiInteractionStatus>;
-  userAddedContext?: UserAddedContextItem[];
+  userAddedSelectionContext?: UserAddedSelectionContextItem[];
 }
 
 /** Chat message that is being sent to the server for chat completion. Status and request ID are yet undetermined. */

--- a/apps/src/aichat/types/index.ts
+++ b/apps/src/aichat/types/index.ts
@@ -6,4 +6,4 @@ export * from './customizations';
 export * from './levelProperties';
 export * from './systemPrompt';
 export * from './toxicity';
-export * from './userAddedContext';
+export * from './userAddedSelectionContext';

--- a/apps/src/aichat/types/userAddedContext.ts
+++ b/apps/src/aichat/types/userAddedContext.ts
@@ -1,8 +1,0 @@
-export interface UserAddedContextItem {
-  sourceCode: string;
-  filename: string;
-  lineReference?: {start: number; end: number};
-  displayName: string;
-}
-
-export type UserAddedContext = {[key: string]: UserAddedContextItem};

--- a/apps/src/aichat/types/userAddedSelectionContext.ts
+++ b/apps/src/aichat/types/userAddedSelectionContext.ts
@@ -1,0 +1,10 @@
+export interface UserAddedSelectionContextItem {
+  sourceCode: string;
+  filename: string;
+  lineReference?: {start: number; end: number};
+  displayName: string;
+}
+
+export type UserAddedSelectionContext = {
+  [key: string]: UserAddedSelectionContextItem;
+};

--- a/apps/src/aichat/views/ChatMessageView.tsx
+++ b/apps/src/aichat/views/ChatMessageView.tsx
@@ -32,9 +32,10 @@ const ChatMessageView: React.FunctionComponent<ChatMessageViewProps> = ({
   buildAssetUrl,
 }) => {
   const [showProfaneUserMessage, setShowProfaneUserMessage] = useState(false);
-  const {status, role, chatMessageText, assets, userAddedContext} = chatMessage;
+  const {status, role, chatMessageText, assets, userAddedSelectionContext} =
+    chatMessage;
   const hasAssets = assets && buildAssetUrl;
-  const hasUserAddedContext = !!userAddedContext?.length;
+  const hasUserAddedSelectionContext = !!userAddedSelectionContext?.length;
 
   const displayText = getChatMessageDisplayText(
     status,
@@ -90,7 +91,7 @@ const ChatMessageView: React.FunctionComponent<ChatMessageViewProps> = ({
   }
 
   let header;
-  if (!isAssistant && (hasAssets || hasUserAddedContext)) {
+  if (!isAssistant && (hasAssets || hasUserAddedSelectionContext)) {
     header = (
       <div className={styles.assetCol}>
         {hasAssets &&
@@ -112,8 +113,8 @@ const ChatMessageView: React.FunctionComponent<ChatMessageViewProps> = ({
               </button>
             );
           })}
-        {hasUserAddedContext &&
-          userAddedContext.map(contextItem => (
+        {hasUserAddedSelectionContext &&
+          userAddedSelectionContext.map(contextItem => (
             <FilePreview type="text" filename={contextItem.displayName} />
           ))}
       </div>

--- a/apps/src/aichat/views/ChatWorkspace.tsx
+++ b/apps/src/aichat/views/ChatWorkspace.tsx
@@ -35,7 +35,7 @@ import {getAssetUrl, getShortName} from '../utils';
 
 import StagedFilesPreview from './assets/StagedFilesPreview';
 import UploadButton from './assets/UploadButton';
-import UserAddedContextPreview from './assets/UserAddedContextPreview';
+import UserAddedSelectionContextPreview from './assets/UserAddedSelectionContextPreview';
 import ChatEventsList from './ChatEventsList';
 import ChatModeDropdown from './ChatModeDropdown';
 import CopyChatHistoryButton from './CopyChatHistoryButton';
@@ -301,7 +301,7 @@ const ChatWorkspace: React.FunctionComponent<ChatWorkspaceProps> = ({
         {multimodalAvailable && (
           <StagedFilesPreview buildAssetUrl={buildAssetUrl} />
         )}
-        <UserAddedContextPreview />
+        <UserAddedSelectionContextPreview />
         <ChatModeDropdown
           className={moduleStyles.modeDropdown}
           systemPromptSettings={systemPromptSettings}

--- a/apps/src/aichat/views/UserChatMessageEditor.tsx
+++ b/apps/src/aichat/views/UserChatMessageEditor.tsx
@@ -46,8 +46,8 @@ const UserChatMessageEditor: React.FunctionComponent<
   const uploadsPending = useAppSelector(state =>
     state.aichat.stagedFiles.some(file => file.status === 'uploading')
   );
-  const userAddedContext = useAppSelector(
-    state => state.aichat.userAddedContext
+  const userAddedSelectionContext = useAppSelector(
+    state => state.aichat.userAddedSelectionContext
   );
   const dispatch = useAppDispatch();
 
@@ -70,9 +70,9 @@ const UserChatMessageEditor: React.FunctionComponent<
               multimodalAvailable && chatAssets.length > 0
                 ? chatAssets
                 : undefined,
-            userAddedContext:
-              Object.values(userAddedContext).length > 0
-                ? Object.values(userAddedContext)
+            userAddedSelectionContext:
+              Object.values(userAddedSelectionContext).length > 0
+                ? Object.values(userAddedSelectionContext)
                 : undefined,
           })
         );
@@ -86,7 +86,7 @@ const UserChatMessageEditor: React.FunctionComponent<
       clientType,
       multimodalAvailable,
       chatAssets,
-      userAddedContext,
+      userAddedSelectionContext,
     ]
   );
 

--- a/apps/src/aichat/views/assets/UserAddedSelectionContextPreview.tsx
+++ b/apps/src/aichat/views/assets/UserAddedSelectionContextPreview.tsx
@@ -1,32 +1,35 @@
 import React from 'react';
 
-import {removeItemFromUserAddedContext} from '@cdo/apps/aichat/redux/slice';
+import {removeItemFromUserAddedSelectionContext} from '@cdo/apps/aichat/redux/slice';
 import FilePreview from '@cdo/apps/aichat/views/assets/FilePreview';
 import {useAppDispatch, useAppSelector} from '@cdo/apps/util/reduxHooks';
 
 import styles from './staged-files-preview.module.scss';
 
-const UserAddedContextPreview: React.FunctionComponent = () => {
-  const userAddedContext = useAppSelector(
-    state => state.aichat.userAddedContext
+const UserAddedSelectionContextPreview: React.FunctionComponent = () => {
+  const userAddedSelectionContext = useAppSelector(
+    state => state.aichat.userAddedSelectionContext
   );
   const dispatch = useAppDispatch();
 
-  if (!userAddedContext || Object.keys(userAddedContext).length === 0) {
+  if (
+    !userAddedSelectionContext ||
+    Object.keys(userAddedSelectionContext).length === 0
+  ) {
     return null;
   }
 
   return (
     <div className={styles.container}>
       <div className={styles.row}>
-        {Object.keys(userAddedContext).map(displayName => (
+        {Object.keys(userAddedSelectionContext).map(displayName => (
           <FilePreview
             key={displayName}
             type={'text'}
             filename={displayName}
             isUploading={false}
             onRemove={() =>
-              dispatch(removeItemFromUserAddedContext(displayName))
+              dispatch(removeItemFromUserAddedSelectionContext(displayName))
             }
           />
         ))}
@@ -35,4 +38,4 @@ const UserAddedContextPreview: React.FunctionComponent = () => {
   );
 };
 
-export default UserAddedContextPreview;
+export default UserAddedSelectionContextPreview;

--- a/apps/src/codebridge/FileBrowser/FileBrowserRow/hooks/useFileRowOptions.ts
+++ b/apps/src/codebridge/FileBrowser/FileBrowserRow/hooks/useFileRowOptions.ts
@@ -2,7 +2,7 @@ import {useCodebridgeContext} from '@codebridge/codebridgeContext';
 import {usePrompts} from '@codebridge/FileBrowser/hooks';
 import {ProjectFile} from '@codebridge/types';
 import {
-  enableUserAddedContext,
+  enableUserAddedSelectionContext,
   getFolderPath,
   getPossibleDestinationFoldersForFile,
   sendCodebridgeAnalyticsEvent,
@@ -10,7 +10,7 @@ import {
 import fileDownload from 'js-file-download';
 import {useMemo} from 'react';
 
-import {addItemToUserAddedContext} from '@cdo/apps/aichat/redux/slice';
+import {addItemToUserAddedSelectionContext} from '@cdo/apps/aichat/redux/slice';
 import codebridgeI18n from '@cdo/apps/codebridge/locale';
 import {START_SOURCES} from '@cdo/apps/lab2/constants';
 import {getAppOptionsEditBlocks} from '@cdo/apps/lab2/projects/utils';
@@ -95,7 +95,7 @@ export const useFileRowOptions = (
         clickHandler: () => openRenameFilePrompt({fileId: file.id}),
       },
       {
-        condition: enableUserAddedContext(appName, file),
+        condition: enableUserAddedSelectionContext(appName, file),
         iconName: 'message-code',
         labelText: codebridgeI18n.addToAiTutorContext(),
         clickHandler: () => {
@@ -105,7 +105,7 @@ export const useFileRowOptions = (
             fullFilename = (folderPath + '/' + file.name).substring(1); // remove leading slash
           }
           dispatch(
-            addItemToUserAddedContext({
+            addItemToUserAddedSelectionContext({
               displayName: fullFilename,
               sourceCode: file.contents,
               filename: fullFilename,

--- a/apps/src/codebridge/utils/aiTutorUtils.ts
+++ b/apps/src/codebridge/utils/aiTutorUtils.ts
@@ -1,6 +1,9 @@
 import {ProjectFile} from '@codebridge/types';
 
-export const enableUserAddedContext = (appName: string, file: ProjectFile) => {
+export const enableUserAddedSelectionContext = (
+  appName: string,
+  file: ProjectFile
+) => {
   // If the file has a url, that means it is not a text file, and therefore we cannot
   // currently add it as user added context.
   return appName === 'weblab2' && !file.url;

--- a/apps/src/weblab2/Weblab2View.tsx
+++ b/apps/src/weblab2/Weblab2View.tsx
@@ -93,8 +93,8 @@ const Weblab2View: React.FC<
   const [systemPromptOptions, setSystemPromptOptions] = useState<
     SystemPromptOption[] | undefined
   >(undefined);
-  const userAddedContext = useAppSelector(
-    state => state.aichat.userAddedContext
+  const userAddedSelectionContext = useAppSelector(
+    state => state.aichat.userAddedSelectionContext
   );
 
   const {startSources} = useSource(
@@ -138,8 +138,9 @@ const Weblab2View: React.FC<
     aiTutorHelper.setAiTutorContext({
       source,
       longInstructions: levelProperties.longInstructions,
+      selection: userAddedSelectionContext,
     });
-  }, [source, levelProperties.longInstructions]);
+  }, [source, levelProperties.longInstructions, userAddedSelectionContext]);
 
   // Since there's no run button in Weblab2, set it to true by default
   // to enable the Submit button on edit on submittable levels.
@@ -165,9 +166,7 @@ const Weblab2View: React.FC<
           setConfig={setConfig}
           startSources={startSources}
           levelProperties={levelProperties}
-          hiddenContextCallback={aiTutorHelper.getHiddenContextCallbackWebLab2(
-            userAddedContext
-          )}
+          hiddenContextCallback={aiTutorHelper.getHiddenContextCallback()}
           aiTutorSystemPromptSettings={aiTutorSystemPromptSettings}
           aiTutorMultimodalEnabled={true}
           aiTutorChatButtonData={[]}

--- a/apps/src/weblab2/helpers/aiTutorContextHelper.ts
+++ b/apps/src/weblab2/helpers/aiTutorContextHelper.ts
@@ -1,4 +1,4 @@
-import {UserAddedContext} from '@cdo/apps/aichat/types';
+import {UserAddedSelectionContext} from '@cdo/apps/aichat/types';
 import {AiTutorContextHelper} from '@cdo/apps/aiTutor/helpers/aiTutorContextHelper';
 import {AiTutorContext} from '@cdo/apps/aiTutor/types';
 import {MultiFileSource, ProjectFileType} from '@cdo/apps/lab2/types';
@@ -6,6 +6,7 @@ import {MultiFileSource, ProjectFileType} from '@cdo/apps/lab2/types';
 interface AiTutorWebLab2Params {
   source: MultiFileSource | undefined;
   longInstructions: string | undefined;
+  selection: UserAddedSelectionContext;
 }
 
 export class AiTutorWebLab2ContextHelper extends AiTutorContextHelper<AiTutorWebLab2Params> {
@@ -15,7 +16,11 @@ export class AiTutorWebLab2ContextHelper extends AiTutorContextHelper<AiTutorWeb
     return this.aiTutorContext;
   }
 
-  setAiTutorContext({source, longInstructions}: AiTutorWebLab2Params) {
+  setAiTutorContext({
+    source,
+    longInstructions,
+    selection,
+  }: AiTutorWebLab2Params) {
     const sourceCode = source
       ? Object.values(source.files)
           .filter(
@@ -27,33 +32,20 @@ export class AiTutorWebLab2ContextHelper extends AiTutorContextHelper<AiTutorWeb
           .join('\n\n')
       : undefined;
 
+    const userSelection =
+      selection && Object.values(selection).length > 0
+        ? Object.values(selection)
+            .map(
+              context =>
+                `filename: ${context.filename}\n\`\`\`${context.sourceCode}}\`\`\``
+            )
+            .join('\n\n')
+        : undefined;
+
     this.aiTutorContext = {
       sourceCode,
       longInstructions,
+      userSelection,
     };
-  }
-
-  getHiddenContextCallbackWebLab2(userAddedContext: UserAddedContext) {
-    return this.getHiddenContextStringWeblab2.bind(this, userAddedContext);
-  }
-
-  protected async getHiddenContextStringWeblab2(
-    userAddedContext: UserAddedContext
-  ) {
-    const baseString = await super.getHiddenContextString();
-    const userAddedContextData = Object.values(userAddedContext).map(
-      context =>
-        `Filename: ${context.filename}\n\`\`\`${context.sourceCode}}\`\`\``
-    );
-    if (userAddedContextData.length > 0) {
-      const userAddedContextString = [
-        'The student would like to focus on this subset of their current code:',
-        ...userAddedContextData,
-      ].join('\n\n');
-      const combinedString = [userAddedContextString, baseString].join('\n\n');
-      console.log(`🤖: Tutor context with user added context:`, combinedString);
-      return combinedString;
-    }
-    return baseString;
   }
 }


### PR DESCRIPTION
This PR is a small refactor to align PR #68567 with the intentions of `AiTutorContextHelper`.  A secondary nit that was addressed was to change `UserAddedContext` to `UserAddedSelectionContext` to further describe the additional context (code that the user "selects") that the user is adding.

### Re: intentions of AiTutorContextHelper
The `AiTutorContextHelper` class is designed to be aware of a uniform set of context items that can be opted into by each lab / use-case.  How the context item is formatted / added to the final context string is handled by `getHiddenContextString`, so the idea is that if something is only opted-into by a given lab that is fine, but if opted-in, it should be handled uniformly without having to provide any new lab-specific methods in the derived class. 

The class is already pretty flexible in that it is a templated class and each use-case can provide its own internal data structure as a generic type parameter (`T`).   Rather than defining a use-case specific `getHiddenContextCallbackWebLab2`, the additional context has been added to the WebLab2 specific type and its `setAiTutorContext` turns this specific context into a generic `userSelection` that is now an optional property of `AiTutorContext` and can be handled in the base class:

```
interface AiTutorWebLab2Params {
  source: MultiFileSource | undefined;
  longInstructions: string | undefined;
  selection: UserAddedSelectionContext;
}
```
I will cut the explanation short in the interest of time (the original PR is somewhat urgent), but if anyone has any questions or concerns, just let me know. 

## PR Creation Checklist:
- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
