### PR TITLE
Sketch Lab: serialize scroll, show context menu

### DIFF
--- a/apps/src/sketchlab/SketchlabView.tsx
+++ b/apps/src/sketchlab/SketchlabView.tsx
@@ -1,7 +1,11 @@
 import {Excalidraw, serializeAsJSON} from '@excalidraw/excalidraw';
 import {ExcalidrawElement} from '@excalidraw/excalidraw/types/element/types';
-import {AppState, BinaryFiles} from '@excalidraw/excalidraw/types/types';
-import React, {useEffect, useCallback, useRef} from 'react';
+import {
+  AppState,
+  BinaryFiles,
+  ExcalidrawImperativeAPI,
+} from '@excalidraw/excalidraw/types/types';
+import React, {useEffect, useCallback, useRef, useState} from 'react';
 
 import {useVerticalLayout} from '@cdo/apps/lab2/hooks/useVerticalLayout';
 import {setHasRun} from '@cdo/apps/lab2/redux/systemRedux';
@@ -31,6 +35,8 @@ const DEBOUNCED_WORKSPACE_SERIALIZATION_MS = 500;
 const SketchlabView: React.FC<LabProps<LevelProperties>> = ({
   levelProperties,
 }) => {
+  const [excalidrawApi, setExcalidrawApi] =
+    useState<ExcalidrawImperativeAPI | null>();
   const {currentSources, updateSources} = useSources<ProjectSources>();
   const saveSourcesTimeoutRef = useRef<NodeJS.Timeout | null>(null);
 
@@ -73,10 +79,23 @@ const SketchlabView: React.FC<LabProps<LevelProperties>> = ({
         const serializedData = JSON.parse(
           serializeAsJSON(elements, state, files, 'local')
         );
+
+        if (excalidrawApi) {
+          // serializeAsJSON exports an extremely limited set of properties from appState,
+          // and excludes the chosen scroll position (scrollX/Y) and zoom,
+          // so we use the API to serialize those manually.
+          // Serializing the whole appState is extremely lengthy and threw errors on page load, unfortunately,
+          // but we may want to serialize additional properties in the future.
+          const appState = excalidrawApi.getAppState();
+          serializedData.appState.scrollX = appState.scrollX;
+          serializedData.appState.scrollY = appState.scrollY;
+          serializedData.appState.zoom = appState.zoom;
+        }
+
         updateSources({source: serializedData});
       }, DEBOUNCED_WORKSPACE_SERIALIZATION_MS);
     },
-    [updateSources]
+    [updateSources, excalidrawApi]
   );
 
   useEffect(() => {
@@ -123,6 +142,7 @@ const SketchlabView: React.FC<LabProps<LevelProperties>> = ({
           <Excalidraw
             initialData={currentSources.source as SketchlabSource}
             onChange={debouncedSerializeAndSaveWorkspace}
+            excalidrawAPI={api => setExcalidrawApi(api)}
           />
         </PanelContainer>
       </div>

--- a/apps/src/sketchlab/styles/sketchlab-view.module.scss
+++ b/apps/src/sketchlab/styles/sketchlab-view.module.scss
@@ -7,3 +7,8 @@
 :global(.excalidraw .dropdown-menu) {
   display: block;
 }
+
+
+:global(.excalidraw .popover) {
+  display: block;
+}


### PR DESCRIPTION
Two (basically unrelated) Excalidraw improvements:
- Dani noticed that scroll position wasn't being saved across page loads. The `appState` property (includes scroll position and zoom) is included in what gets serialized to JSON, but for some reason "...most properties from AppState are removed from the resulting JSON." ([docs link](https://docs.excalidraw.com/docs/@excalidraw/excalidraw/api/utils#serializeasjson), which are out of date / don't match the current method signature 🙃 ). This change explicitly serializes the scroll position and zoom -- there are a lot of AppState properties, we may want to add more down the line.
- The right click context menu is hidden by some global CSS -- adding an override for that.

## Testing story

Tested manually.