### PR TITLE
fix(HofAI): show up to 200 activities at once

### DIFF
--- a/frontend/apps/marketing/src/app/[brand]/[locale]/activities/[activityType]/page.tsx
+++ b/frontend/apps/marketing/src/app/[brand]/[locale]/activities/[activityType]/page.tsx
@@ -73,6 +73,7 @@ export default async function ActivitiesPage({
         accessibilitys: {},
         technologyClassroom: {},
       },
+      limit: 100,
     });
 
     return facetResults.facets;
@@ -82,7 +83,7 @@ export default async function ActivitiesPage({
    * Fetches all activities from the Orama database.
    */
   const getAllActivities = async () => {
-    const allActivityResults = await search(db, {term: ''});
+    const allActivityResults = await search(db, {term: '', limit: 200});
 
     return allActivityResults.hits.map(hit => hit.document);
   };

--- a/frontend/apps/marketing/src/components/contentful/activityCatalog/ActivityCatalog.tsx
+++ b/frontend/apps/marketing/src/components/contentful/activityCatalog/ActivityCatalog.tsx
@@ -162,6 +162,7 @@ const ActivityCatalog = ({
       where: {
         ...facetFilters,
       },
+      limit: 200,
     });
 
     const nextResults = searchResults.hits.map(hit => hit.document);


### PR DESCRIPTION
Orama defaults to 10 results, show up to 500 activities at once instead. A future follow up could be to implement pagination.