### PR TITLE
feat(HofAI): allow searching by language

### DIFF
--- a/frontend/apps/marketing/src/components/contentful/activityCatalog/ActivityCatalog.tsx
+++ b/frontend/apps/marketing/src/components/contentful/activityCatalog/ActivityCatalog.tsx
@@ -158,7 +158,7 @@ const ActivityCatalog = ({
     // Perform the search with the current term and selected facets
     const searchResults = await search(db, {
       term,
-      properties: ['title'],
+      properties: ['title', 'languagesText'],
       where: {
         ...facetFilters,
       },


### PR DESCRIPTION
The catalog allows users to search for activities that are available in their own language (not as a dropdown because that list may be too long). So they can search for `German` or `French` (for example) directly in the search box and see those respective results.