### PR TITLE
[MusicLab] Adds arrow key navigation for instrument grid blocks

### DIFF
--- a/apps/src/music/views/InstrumentGrid/index.tsx
+++ b/apps/src/music/views/InstrumentGrid/index.tsx
@@ -289,13 +289,20 @@ const InstrumentGrid: React.FunctionComponent<Props> = ({
             Math.floor(currentIndex / numCols) * numCols +
             ((currentIndex + 1) % numCols);
         }
+        // Notes and drums move up/down in opposite directions
         if (key === 'ArrowDown') {
           nextIndex =
-            (currentIndex - numCols + focusableCells.length) %
-            focusableCells.length;
+            editorType === 'notes'
+              ? (currentIndex - numCols + focusableCells.length) %
+                focusableCells.length
+              : (currentIndex + numCols) % focusableCells.length;
         }
         if (key === 'ArrowUp') {
-          nextIndex = (currentIndex + numCols) % focusableCells.length;
+          nextIndex =
+            editorType === 'notes'
+              ? (currentIndex + numCols) % focusableCells.length
+              : (currentIndex - numCols + focusableCells.length) %
+                focusableCells.length;
         }
 
         focusableCells[nextIndex]?.focus();

--- a/apps/src/music/views/InstrumentGrid/index.tsx
+++ b/apps/src/music/views/InstrumentGrid/index.tsx
@@ -230,7 +230,8 @@ const InstrumentGrid: React.FunctionComponent<Props> = ({
   // Otherwise, we are focused on a selectable cell, which means we call the
   // corresponding click event. Escape exits the grid, moving focus back to the
   // parent container. StopPropagation is called on Tab events to keep the focus
-  // from moving beyond the parent container when focus is inside it.
+  // from moving beyond the parent container when focus is inside it. Arrows
+  // navigate between cells, wrapping within rows and columns.
   const handleKeyDown = (
     event: React.KeyboardEvent,
     note: number,
@@ -260,6 +261,44 @@ const InstrumentGrid: React.FunctionComponent<Props> = ({
       }
       case 'Tab': {
         event.stopPropagation();
+        break;
+      }
+      case 'ArrowLeft':
+      case 'ArrowRight':
+      case 'ArrowUp':
+      case 'ArrowDown': {
+        event.preventDefault();
+        // Find all focusable cells in tab order
+        const focusableCells = Array.from(
+          document.querySelectorAll<HTMLElement>('.showing')
+        );
+        const currentIndex = focusableCells.indexOf(
+          document.activeElement as HTMLElement
+        );
+        const numCols = ticks.length + 1; // Add one for label column at start
+
+        let nextIndex = currentIndex;
+        // Arrow keys wrap within columns and rows
+        if (key === 'ArrowLeft') {
+          nextIndex =
+            Math.floor(currentIndex / numCols) * numCols +
+            ((currentIndex - 1 + numCols) % numCols);
+        }
+        if (key === 'ArrowRight') {
+          nextIndex =
+            Math.floor(currentIndex / numCols) * numCols +
+            ((currentIndex + 1) % numCols);
+        }
+        if (key === 'ArrowDown') {
+          nextIndex =
+            (currentIndex - numCols + focusableCells.length) %
+            focusableCells.length;
+        }
+        if (key === 'ArrowUp') {
+          nextIndex = (currentIndex + numCols) % focusableCells.length;
+        }
+
+        focusableCells[nextIndex]?.focus();
         break;
       }
       default:

--- a/apps/src/music/views/InstrumentGrid/index.tsx
+++ b/apps/src/music/views/InstrumentGrid/index.tsx
@@ -410,7 +410,7 @@ const InstrumentGrid: React.FunctionComponent<Props> = ({
           scrollEnd={scrollEnd}
           className={classNames(styles[`sequence-editor-${interfaceMode}`])}
           ariaLabel="Instrument Grid"
-          focusableChildren={focusableRefs.current}
+          focusableChildren={focusableRefs.current.flat()}
         >
           {allNotes.map(({note, name}, rowIndex) => {
             const {

--- a/apps/src/music/views/InstrumentGrid/index.tsx
+++ b/apps/src/music/views/InstrumentGrid/index.tsx
@@ -35,6 +35,8 @@ import {getInstruments} from './util';
 
 import styles from './styles.module.scss';
 
+const SHOWING = 'showing';
+
 interface Props {
   initialValue: InstrumentEventValue;
   onChange: (value: InstrumentEventValue) => void;
@@ -225,6 +227,45 @@ const InstrumentGrid: React.FunctionComponent<Props> = ({
     ];
   }, [editorType, scaleMode]);
 
+  // Helper function for key handler of arrow keys
+  function getNextIndex({
+    key,
+    currentIndex,
+    numCols,
+    numCells,
+    editorType,
+  }: {
+    key: string;
+    currentIndex: number;
+    numCols: number;
+    numCells: number;
+    editorType: string;
+  }) {
+    if (key === 'ArrowLeft') {
+      return (
+        Math.floor(currentIndex / numCols) * numCols +
+        ((currentIndex - 1 + numCols) % numCols)
+      );
+    }
+    if (key === 'ArrowRight') {
+      return (
+        Math.floor(currentIndex / numCols) * numCols +
+        ((currentIndex + 1) % numCols)
+      );
+    }
+    if (key === 'ArrowDown') {
+      return editorType === 'notes'
+        ? (currentIndex - numCols + numCells) % numCells
+        : (currentIndex + numCols) % numCells;
+    }
+    if (key === 'ArrowUp') {
+      return editorType === 'notes'
+        ? (currentIndex + numCols) % numCells
+        : (currentIndex - numCols + numCells) % numCells;
+    }
+    return currentIndex;
+  }
+
   // This handles keyboard interactions for the cells. If an instrument is sent
   // in, we are focused on the label, which means we play a preview of the note.
   // Otherwise, we are focused on a selectable cell, which means we call the
@@ -270,40 +311,20 @@ const InstrumentGrid: React.FunctionComponent<Props> = ({
         event.preventDefault();
         // Find all focusable cells in tab order
         const focusableCells = Array.from(
-          document.querySelectorAll<HTMLElement>('.showing')
+          document.querySelectorAll<HTMLElement>(`.${SHOWING}`)
         );
         const currentIndex = focusableCells.indexOf(
           document.activeElement as HTMLElement
         );
         const numCols = ticks.length + 1; // Add one for label column at start
 
-        let nextIndex = currentIndex;
-        // Arrow keys wrap within columns and rows
-        if (key === 'ArrowLeft') {
-          nextIndex =
-            Math.floor(currentIndex / numCols) * numCols +
-            ((currentIndex - 1 + numCols) % numCols);
-        }
-        if (key === 'ArrowRight') {
-          nextIndex =
-            Math.floor(currentIndex / numCols) * numCols +
-            ((currentIndex + 1) % numCols);
-        }
-        // Notes and drums move up/down in opposite directions
-        if (key === 'ArrowDown') {
-          nextIndex =
-            editorType === 'notes'
-              ? (currentIndex - numCols + focusableCells.length) %
-                focusableCells.length
-              : (currentIndex + numCols) % focusableCells.length;
-        }
-        if (key === 'ArrowUp') {
-          nextIndex =
-            editorType === 'notes'
-              ? (currentIndex + numCols) % focusableCells.length
-              : (currentIndex - numCols + focusableCells.length) %
-                focusableCells.length;
-        }
+        const nextIndex = getNextIndex({
+          key,
+          currentIndex,
+          numCols,
+          numCells: focusableCells.length,
+          editorType,
+        });
 
         focusableCells[nextIndex]?.focus();
         break;
@@ -397,7 +418,7 @@ const InstrumentGrid: React.FunctionComponent<Props> = ({
                 <button
                   type="button"
                   className={`${styles['cell-outer']} ${
-                    showing ? 'showing' : ''
+                    showing ? SHOWING : ''
                   }`}
                   onClick={() =>
                     MusicRegistry.player.previewNote(
@@ -429,7 +450,7 @@ const InstrumentGrid: React.FunctionComponent<Props> = ({
                       <button
                         type="button"
                         className={`${styles[`cell-outer-${interfaceMode}`]} ${
-                          showing ? 'showing' : ''
+                          showing ? SHOWING : ''
                         }`}
                         key={tick}
                         onClick={() => onClickCell(note, tick)}

--- a/apps/src/music/views/InstrumentGrid/index.tsx
+++ b/apps/src/music/views/InstrumentGrid/index.tsx
@@ -6,6 +6,7 @@ import React, {
   useCallback,
   useEffect,
   useMemo,
+  useRef,
   useState,
 } from 'react';
 import FocusLock from 'react-focus-lock';
@@ -175,6 +176,15 @@ const InstrumentGrid: React.FunctionComponent<Props> = ({
 
   const ticks = integers(lengthMeasures * 16, 1);
 
+  const numRows = allNotes.length;
+  const numCols = ticks.length + 1; // +1 for the label button
+
+  // Because we need allNotes and ticks to be defined to create this grid
+  // of refs, this useRef is further down the component body than usual.
+  const focusableRefs = useRef<Array<Array<HTMLButtonElement | null>>>(
+    Array.from({length: numRows}, () => Array(numCols).fill(null))
+  );
+
   const interfaceMode =
     editorType === 'drums' ? 'drums' : scaleMode || 'simple';
 
@@ -227,43 +237,22 @@ const InstrumentGrid: React.FunctionComponent<Props> = ({
     ];
   }, [editorType, scaleMode]);
 
-  // Helper function for key handler of arrow keys
-  function getNextIndex({
-    key,
-    currentIndex,
-    numCols,
-    numCells,
-    editorType,
-  }: {
-    key: string;
-    currentIndex: number;
-    numCols: number;
-    numCells: number;
-    editorType: string;
-  }) {
-    if (key === 'ArrowLeft') {
-      return (
-        Math.floor(currentIndex / numCols) * numCols +
-        ((currentIndex - 1 + numCols) % numCols)
-      );
+  // Because the notes render hidden rows, we end up with empty rows in the
+  // 2D array of refs. This function is a helper to find the next non-empty
+  // row when a user is navigating with the up/down arrows.
+  function findNextNonEmptyRow(startRow: number, direction: number) {
+    const numRows = focusableRefs.current.length;
+    let row = startRow;
+    for (let i = 0; i < numRows; i++) {
+      row = (row + direction + numRows) % numRows;
+      if (
+        focusableRefs.current[row] &&
+        focusableRefs.current[row].some(Boolean)
+      ) {
+        return row;
+      }
     }
-    if (key === 'ArrowRight') {
-      return (
-        Math.floor(currentIndex / numCols) * numCols +
-        ((currentIndex + 1) % numCols)
-      );
-    }
-    if (key === 'ArrowDown') {
-      return editorType === 'notes'
-        ? (currentIndex - numCols + numCells) % numCells
-        : (currentIndex + numCols) % numCells;
-    }
-    if (key === 'ArrowUp') {
-      return editorType === 'notes'
-        ? (currentIndex + numCols) % numCells
-        : (currentIndex - numCols + numCells) % numCells;
-    }
-    return currentIndex;
+    return startRow; // fallback if all rows are empty
   }
 
   // This handles keyboard interactions for the cells. If an instrument is sent
@@ -309,24 +298,48 @@ const InstrumentGrid: React.FunctionComponent<Props> = ({
       case 'ArrowUp':
       case 'ArrowDown': {
         event.preventDefault();
-        // Find all focusable cells in tab order
-        const focusableCells = Array.from(
-          document.querySelectorAll<HTMLElement>(`.${SHOWING}`)
-        );
-        const currentIndex = focusableCells.indexOf(
-          document.activeElement as HTMLElement
-        );
-        const numCols = ticks.length + 1; // Add one for label column at start
 
-        const nextIndex = getNextIndex({
-          key,
-          currentIndex,
-          numCols,
-          numCells: focusableCells.length,
-          editorType,
-        });
+        // Find the current focus position
+        let currentRow = -1;
+        let currentCol = -1;
+        currentRow = focusableRefs.current.findIndex(row =>
+          row.includes(document.activeElement as HTMLButtonElement)
+        );
+        if (currentRow !== -1) {
+          currentCol = focusableRefs.current[currentRow].indexOf(
+            document.activeElement as HTMLButtonElement
+          );
+        }
 
-        focusableCells[nextIndex]?.focus();
+        // If we couldn't find the current position, do nothing.
+        if (currentRow === -1 || currentCol === -1) {
+          return;
+        }
+
+        const numCols = focusableRefs.current[0]?.length || 0;
+        let nextRow = currentRow;
+        let nextCol = currentCol;
+
+        if (key === 'ArrowLeft') {
+          nextCol = (currentCol - 1 + numCols) % numCols;
+        }
+        if (key === 'ArrowRight') {
+          nextCol = (currentCol + 1) % numCols;
+        }
+
+        // Notes render in the opposite up/down direction as drums
+        const upArrowDirection = editorType === 'notes' ? 1 : -1;
+        const downArrowDirection = editorType === 'notes' ? -1 : 1;
+
+        if (key === 'ArrowUp') {
+          nextRow = findNextNonEmptyRow(currentRow, upArrowDirection);
+        }
+        if (key === 'ArrowDown') {
+          nextRow = findNextNonEmptyRow(currentRow, downArrowDirection);
+        }
+
+        // Focus the next element if it exists and is not null
+        focusableRefs.current[nextRow][nextCol]?.focus();
         break;
       }
       default:
@@ -397,8 +410,9 @@ const InstrumentGrid: React.FunctionComponent<Props> = ({
           scrollEnd={scrollEnd}
           className={classNames(styles[`sequence-editor-${interfaceMode}`])}
           ariaLabel="Instrument Grid"
+          focusableChildren={focusableRefs.current}
         >
-          {allNotes.map(({note, name}) => {
+          {allNotes.map(({note, name}, rowIndex) => {
             const {
               pitchRowClass,
               style,
@@ -416,6 +430,11 @@ const InstrumentGrid: React.FunctionComponent<Props> = ({
                 key={note}
               >
                 <button
+                  ref={element =>
+                    showing
+                      ? (focusableRefs.current[rowIndex][0] = element)
+                      : null
+                  }
                   type="button"
                   className={`${styles['cell-outer']} ${
                     showing ? SHOWING : ''
@@ -445,9 +464,15 @@ const InstrumentGrid: React.FunctionComponent<Props> = ({
                 </button>
 
                 <div className={styles.cellRow}>
-                  {ticks.map(tick => (
+                  {ticks.map((tick, colIndex) => (
                     <Fragment key={tick}>
                       <button
+                        ref={element =>
+                          showing
+                            ? (focusableRefs.current[rowIndex][colIndex + 1] =
+                                element)
+                            : null
+                        }
                         type="button"
                         className={`${styles[`cell-outer-${interfaceMode}`]} ${
                           showing ? SHOWING : ''

--- a/apps/src/music/views/util/EaseIntoView.tsx
+++ b/apps/src/music/views/util/EaseIntoView.tsx
@@ -29,8 +29,8 @@ interface EaseIntoViewProps {
   ariaLabel?: string;
   /** Child elements to be rendered within the container */
   children: React.ReactNode;
-  /** A 2D array of refs for direct a11y reference */
-  focusableChildren: Array<Array<HTMLButtonElement | null>>;
+  /** An array of refs for direct a11y reference */
+  focusableChildren: Array<HTMLButtonElement | null>;
 }
 
 const EaseIntoView: React.FunctionComponent<EaseIntoViewProps> = ({
@@ -126,20 +126,19 @@ const EaseIntoView: React.FunctionComponent<EaseIntoViewProps> = ({
   // instrumentGrid/index.tsx for the (only) example of this component in use.
   const handleKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
     const container = containerRef.current;
-    const flatRefs = focusableChildren.flat();
     if (!container) return;
 
     switch (event.key) {
       case 'Enter':
         event.preventDefault();
         // Make children that should be showing focusable and focus the first child.
-        flatRefs.forEach(ref => ref?.setAttribute('tabindex', '0'));
-        flatRefs[0]?.focus();
+        focusableChildren.forEach(ref => ref?.setAttribute('tabindex', '0'));
+        focusableChildren[0]?.focus();
         break;
 
       case 'Tab':
         // Make all children unfocusable.
-        flatRefs.forEach(ref => ref?.setAttribute('tabindex', '-1'));
+        focusableChildren.forEach(ref => ref?.setAttribute('tabindex', '-1'));
         break;
 
       default:

--- a/apps/src/music/views/util/EaseIntoView.tsx
+++ b/apps/src/music/views/util/EaseIntoView.tsx
@@ -27,7 +27,10 @@ interface EaseIntoViewProps {
   scrollEnd?: number;
   /** Aria label for the container */
   ariaLabel?: string;
+  /** Child elements to be rendered within the container */
   children: React.ReactNode;
+  /** A 2D array of refs for direct a11y reference */
+  focusableChildren: Array<Array<HTMLButtonElement | null>>;
 }
 
 const EaseIntoView: React.FunctionComponent<EaseIntoViewProps> = ({
@@ -40,6 +43,7 @@ const EaseIntoView: React.FunctionComponent<EaseIntoViewProps> = ({
   scrollEnd = 0,
   ariaLabel = 'Scrollable content',
   children,
+  focusableChildren = [],
 }) => {
   const scrollStep = useRef<number | undefined>(0);
   const lastScrollPosition = useRef<number | undefined>(undefined);
@@ -122,24 +126,20 @@ const EaseIntoView: React.FunctionComponent<EaseIntoViewProps> = ({
   // instrumentGrid/index.tsx for the (only) example of this component in use.
   const handleKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
     const container = containerRef.current;
+    const flatRefs = focusableChildren.flat();
     if (!container) return;
-    const focusableChildren = Array.from(
-      container.querySelectorAll<HTMLElement>('.showing')
-    );
 
     switch (event.key) {
       case 'Enter':
         event.preventDefault();
         // Make children that should be showing focusable and focus the first child.
-        focusableChildren.forEach(child => child.setAttribute('tabindex', '0'));
-        focusableChildren[0]?.focus();
+        flatRefs.forEach(ref => ref?.setAttribute('tabindex', '0'));
+        flatRefs[0]?.focus();
         break;
 
       case 'Tab':
         // Make all children unfocusable.
-        focusableChildren.forEach(child =>
-          child.setAttribute('tabindex', '-1')
-        );
+        flatRefs.forEach(ref => ref?.setAttribute('tabindex', '-1'));
         break;
 
       default:


### PR DESCRIPTION
This adds math logic for users to navigate the play tune and play drums blocks with the arrow keys. 

This includes a refactor to maintaining a 2d array of refs for the instrument grid buttons. I updated the EaseIntoView key handler to use the refs (and am now passing them as a prop).

Because we are rendering hidden rows, the 2d grid will include empty rows when we are rendering notes (not drums). This requires the use of a helper function to skip those rows when we are navigating with up and down arrows. 

Additionally, because notes render the opposite direction up/down, the key navigation has to be flipped. Here is a video showing that the navigation works as expected in both cases:


https://github.com/user-attachments/assets/5b89e0be-aaf9-43e4-966b-4386a48facae



## Links

- Jira: https://codedotorg.atlassian.net/browse/SL-1413

## Testing story
<!--  Does your change include appropriate tests?
      - If so, please describe how the tests included in this PR are sufficient.
      - If not, please explain why this change does not need to be tested. -->



## Deployment strategy
<!--  Any special steps required to deploy this, besides merging?
      - Are there database migrations or manual steps?
      - Does this require coordination with other teams or systems? -->



## Follow-up work
<!--  List any clean-up or technical debt that will be addressed in future work.
      - Include Jira links where applicable.
      - Are there any known limitations or improvements planned? -->



## Privacy
<!--  How does this change impact Student & Teacher privacy?
      - Does this collect, use, share, or modify PII, either new or existing? -->



## Security
<!--  How does this change impact our security surface-area?
      - Do API's touched have the right auth?
      - Do infra changes impact our attack surface or encryption?
-->



## Caching
<!--  How does this change impact caching behavior?
      - Are cache keys or invalidation strategies affected?
      - Will this require cache warming or invalidation after deployment? -->



## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
