### PR TITLE
Adding LevelActivity metric for Dance and Music levels

### DIFF
--- a/apps/src/dance/lab2/views/DanceView.tsx
+++ b/apps/src/dance/lab2/views/DanceView.tsx
@@ -58,6 +58,8 @@ import PanelContainer from '@cdo/apps/lab2/views/components/PanelContainer';
 import SourcesContainer, {
   useSources,
 } from '@cdo/apps/lab2/views/SourcesContainer';
+import {EVENTS, PLATFORMS} from '@cdo/apps/metrics/AnalyticsConstants';
+import analyticsReporter from '@cdo/apps/metrics/AnalyticsReporter';
 import ProjectPlayer from '@cdo/apps/music/ProjectPlayer';
 import MusicProjectBar from '@cdo/apps/music/views/MusicProjectBar';
 import {registerReducers} from '@cdo/apps/redux';
@@ -102,6 +104,8 @@ const DanceView: React.FunctionComponent<{
   const hasRun = useAppSelector(state => state.dance.hasRun);
   const hasEdited = useAppSelector(state => state.dance.hasEdited);
   const isLoading = useAppSelector(state => state.dance.isLoading);
+  const signedIn = useAppSelector(state => state.currentUser.signInState);
+  const scriptName = useAppSelector(state => state.progress.scriptName);
 
   const {currentSources, updateSources, showStartOverDialog} =
     useSources<DanceProjectSources>();
@@ -111,6 +115,7 @@ const DanceView: React.FunctionComponent<{
   const musicProjectPlayer = useRef<ProjectPlayer | null>(null);
   const [loadedMusicProject, setLoadedMusicProject] = useState(false);
   const [generatedAiDance, setGeneratedAiDance] = useState(false);
+  const [runButtonWasClicked, setRunButtonWasClicked] = useState(false);
 
   const aiGenerateMode =
     levelProperties.aiCodeGenerate || queryParams('ai-generate') === 'true';
@@ -200,6 +205,24 @@ const DanceView: React.FunctionComponent<{
   );
 
   const runProgram = useCallback(async () => {
+    if (!runButtonWasClicked) {
+      const eventName = levelProperties.isProjectLevel
+        ? EVENTS.PROJECT_ACTIVITY
+        : EVENTS.LEVEL_ACTIVITY;
+
+      analyticsReporter.sendEvent(
+        eventName,
+        {
+          signedIn: signedIn,
+          unitName: scriptName,
+          levelId: levelProperties.id,
+          levelName: levelProperties.name,
+        },
+        PLATFORMS.BOTH
+      );
+      setRunButtonWasClicked(true);
+    }
+
     if (!programExecutor.current || !metadataToUse) {
       return;
     }
@@ -216,7 +239,17 @@ const DanceView: React.FunctionComponent<{
     dispatch(setIsRunning(true));
     dispatch(setHasRun(true));
     saveBlocks(true);
-  }, [programExecutor, metadataToUse, saveBlocks, dispatch]);
+  }, [
+    runButtonWasClicked,
+    metadataToUse,
+    dispatch,
+    saveBlocks,
+    levelProperties.isProjectLevel,
+    levelProperties.id,
+    levelProperties.name,
+    signedIn,
+    scriptName,
+  ]);
 
   const resetProgram = useCallback(() => {
     programExecutor.current?.reset();
@@ -276,6 +309,7 @@ const DanceView: React.FunctionComponent<{
   useEffect(() => {
     dispatch(setHasRun(false));
     dispatch(setHasEdited(false));
+    setRunButtonWasClicked(false);
   }, [levelProperties.id, dispatch]);
 
   // Load or update song manifest when level properties change.

--- a/apps/src/dance/lab2/views/DanceView.tsx
+++ b/apps/src/dance/lab2/views/DanceView.tsx
@@ -115,7 +115,6 @@ const DanceView: React.FunctionComponent<{
   const musicProjectPlayer = useRef<ProjectPlayer | null>(null);
   const [loadedMusicProject, setLoadedMusicProject] = useState(false);
   const [generatedAiDance, setGeneratedAiDance] = useState(false);
-  const [runButtonWasClicked, setRunButtonWasClicked] = useState(false);
 
   const aiGenerateMode =
     levelProperties.aiCodeGenerate || queryParams('ai-generate') === 'true';
@@ -205,7 +204,7 @@ const DanceView: React.FunctionComponent<{
   );
 
   const runProgram = useCallback(async () => {
-    if (!runButtonWasClicked) {
+    if (!hasRun) {
       const eventName = levelProperties.isProjectLevel
         ? EVENTS.PROJECT_ACTIVITY
         : EVENTS.LEVEL_ACTIVITY;
@@ -220,7 +219,6 @@ const DanceView: React.FunctionComponent<{
         },
         PLATFORMS.BOTH
       );
-      setRunButtonWasClicked(true);
     }
 
     if (!programExecutor.current || !metadataToUse) {
@@ -240,7 +238,7 @@ const DanceView: React.FunctionComponent<{
     dispatch(setHasRun(true));
     saveBlocks(true);
   }, [
-    runButtonWasClicked,
+    hasRun,
     metadataToUse,
     dispatch,
     saveBlocks,
@@ -309,7 +307,6 @@ const DanceView: React.FunctionComponent<{
   useEffect(() => {
     dispatch(setHasRun(false));
     dispatch(setHasEdited(false));
-    setRunButtonWasClicked(false);
   }, [levelProperties.id, dispatch]);
 
   // Load or update song manifest when level properties change.

--- a/apps/src/dance/lab2/views/DanceView.tsx
+++ b/apps/src/dance/lab2/views/DanceView.tsx
@@ -58,7 +58,7 @@ import PanelContainer from '@cdo/apps/lab2/views/components/PanelContainer';
 import SourcesContainer, {
   useSources,
 } from '@cdo/apps/lab2/views/SourcesContainer';
-import {EVENTS, PLATFORMS} from '@cdo/apps/metrics/AnalyticsConstants';
+import {EVENTS} from '@cdo/apps/metrics/AnalyticsConstants';
 import analyticsReporter from '@cdo/apps/metrics/AnalyticsReporter';
 import ProjectPlayer from '@cdo/apps/music/ProjectPlayer';
 import MusicProjectBar from '@cdo/apps/music/views/MusicProjectBar';
@@ -209,16 +209,12 @@ const DanceView: React.FunctionComponent<{
         ? EVENTS.PROJECT_ACTIVITY
         : EVENTS.LEVEL_ACTIVITY;
 
-      analyticsReporter.sendEvent(
-        eventName,
-        {
-          signedIn: signedIn,
-          unitName: scriptName,
-          levelId: levelProperties.id,
-          levelName: levelProperties.name,
-        },
-        PLATFORMS.BOTH
-      );
+      analyticsReporter.sendEvent(eventName, {
+        signedIn: signedIn,
+        unitName: scriptName,
+        levelId: levelProperties.id,
+        levelName: levelProperties.name,
+      });
     }
 
     if (!programExecutor.current || !metadataToUse) {

--- a/apps/src/music/views/MusicView.jsx
+++ b/apps/src/music/views/MusicView.jsx
@@ -23,7 +23,7 @@ import {
 } from '@cdo/apps/lab2/projects/utils';
 import {isReadOnlyWorkspace} from '@cdo/apps/lab2/redux/lab2ReduxSelectors';
 import {LifecycleEvent} from '@cdo/apps/lab2/utils/LifecycleNotifier';
-import {EVENTS, PLATFORMS} from '@cdo/apps/metrics/AnalyticsConstants';
+import {EVENTS} from '@cdo/apps/metrics/AnalyticsConstants';
 import analyticsReporter from '@cdo/apps/metrics/AnalyticsReporter';
 import AnalyticsReporter from '@cdo/apps/music/analytics/AnalyticsReporter';
 import {setExtraCopyrightContent} from '@cdo/apps/sharedComponents/footer/CopyrightDialog/index';
@@ -882,26 +882,22 @@ class UnconnectedMusicView extends React.Component {
   };
 
   playSong = async () => {
+    if (!this.state.hasRun) {
+      const eventName = this.props.levelProperties.isProjectLevel
+        ? EVENTS.PROJECT_ACTIVITY
+        : EVENTS.LEVEL_ACTIVITY;
+      analyticsReporter.sendEvent(eventName, {
+        signedIn: this.props.signInState,
+        unitName: this.props.scriptName,
+        levelId: this.props.levelProperties.id,
+        levelName: this.props.levelProperties.name,
+      });
+    }
     this.setState({
       hasRun: true,
     });
     if (this.props.isFirstAttempt) {
       this.props.sendAttemptReport();
-
-      const eventName = this.props.levelProperties.isProjectLevel
-        ? EVENTS.PROJECT_ACTIVITY
-        : EVENTS.LEVEL_ACTIVITY;
-
-      analyticsReporter.sendEvent(
-        eventName,
-        {
-          signedIn: this.props.signInState,
-          unitName: this.props.scriptName,
-          levelId: this.props.levelProperties.id,
-          levelName: this.props.levelProperties.name,
-        },
-        PLATFORMS.BOTH
-      );
     }
     this.player.stopSong();
     this.playingTriggers = [];

--- a/apps/src/music/views/MusicView.jsx
+++ b/apps/src/music/views/MusicView.jsx
@@ -23,6 +23,8 @@ import {
 } from '@cdo/apps/lab2/projects/utils';
 import {isReadOnlyWorkspace} from '@cdo/apps/lab2/redux/lab2ReduxSelectors';
 import {LifecycleEvent} from '@cdo/apps/lab2/utils/LifecycleNotifier';
+import {EVENTS, PLATFORMS} from '@cdo/apps/metrics/AnalyticsConstants';
+import analyticsReporter from '@cdo/apps/metrics/AnalyticsReporter';
 import AnalyticsReporter from '@cdo/apps/music/analytics/AnalyticsReporter';
 import {setExtraCopyrightContent} from '@cdo/apps/sharedComponents/footer/CopyrightDialog/index';
 import {SignInState} from '@cdo/apps/templates/currentUserRedux';
@@ -130,6 +132,7 @@ class UnconnectedMusicView extends React.Component {
     canUndo: PropTypes.bool,
     canRedo: PropTypes.bool,
     codeToLoad: PropTypes.string,
+    scriptName: PropTypes.string,
     clearCodeToLoad: PropTypes.func,
     sendAttemptReport: PropTypes.func,
     isFirstAttempt: PropTypes.bool,
@@ -884,6 +887,21 @@ class UnconnectedMusicView extends React.Component {
     });
     if (this.props.isFirstAttempt) {
       this.props.sendAttemptReport();
+
+      const eventName = this.props.levelProperties.isProjectLevel
+        ? EVENTS.PROJECT_ACTIVITY
+        : EVENTS.LEVEL_ACTIVITY;
+
+      analyticsReporter.sendEvent(
+        eventName,
+        {
+          signedIn: this.props.signInState,
+          unitName: this.props.scriptName,
+          levelId: this.props.levelProperties.id,
+          levelName: this.props.levelProperties.name,
+        },
+        PLATFORMS.BOTH
+      );
     }
     this.player.stopSong();
     this.playingTriggers = [];
@@ -1014,6 +1032,7 @@ const MusicView = connect(
     canUndo: state.music.canUndo,
     canRedo: state.music.canRedo,
     codeToLoad: state.music.codeToLoad,
+    scriptName: state.progress.scriptName,
     isFirstAttempt: getCurrentLevel(state)?.status === LevelStatus.not_tried,
   }),
   dispatch => ({


### PR DESCRIPTION
There is a [LEVEL_ACTIVITY metric which is logged in studio.js](https://github.com/code-dot-org/code-dot-org/blob/7823c6618721efdb2debe41c948e17ccd2313d1a/apps/src/StudioApp.js#L2177) which we also want to be logged in Lab 2 levels because these levels will be part of Hour of AI. This PR adds a similar metric of Lab 2 Dance and Music levels first since these specific level types will be using in Hour of AI. A follow up PR will add the metric to the other level types.


## Links
* [Jira](https://codedotorg.atlassian.net/browse/LABS-1558)

## Testing story
* Pressed the Run button for both lab 2 dance and music levels and confirmed in the developer console that the Statsig metric was logged.


## Follow-up work
Update the other Lab 2 level types to have a LEVEL_ACTIVITY metric.

## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
