### PR TITLE
CMS-951: Fix redirect errors from invalid HOC Tutorial codes

### DIFF
--- a/pegasus/helpers/hoc_helpers.rb
+++ b/pegasus/helpers/hoc_helpers.rb
@@ -211,7 +211,7 @@ def launch_tutorial_pixel(tutorial)
 end
 
 def redirect_to_studio(path, path_params = {})
-  dashboard_uri = URI(CDO.studio_url(path, CDO.default_scheme))
+  dashboard_uri = URI CDO.studio_url(URI::DEFAULT_PARSER.escape(path), CDO.default_scheme)
 
   redirect_params = URI.decode_www_form(dashboard_uri.query.to_s).to_h
   redirect_params.merge!(path_params)

--- a/pegasus/helpers/hoc_helpers.rb
+++ b/pegasus/helpers/hoc_helpers.rb
@@ -211,7 +211,7 @@ def launch_tutorial_pixel(tutorial)
 end
 
 def redirect_to_studio(path, path_params = {})
-  dashboard_uri = URI CDO.studio_url(URI::DEFAULT_PARSER.escape(path), CDO.default_scheme)
+  dashboard_uri = URI.parse CDO.studio_url(URI::DEFAULT_PARSER.escape(path), CDO.default_scheme)
 
   redirect_params = URI.decode_www_form(dashboard_uri.query.to_s).to_h
   redirect_params.merge!(path_params)

--- a/pegasus/test/test_hoc_routes.rb
+++ b/pegasus/test/test_hoc_routes.rb
@@ -395,6 +395,17 @@ class HocRoutesTest < Minitest::Test
         _(@pegasus.last_response['Location']).must_equal CDO.studio_url(api_request_path, CDO.default_scheme)
       end
 
+      it 'redirects to studio when starting tutorial with corrupted png image code' do
+        api_request_path = '/api/hour/begin_codewards%20.png'
+
+        @pegasus.expects(:launch_tutorial_pixel).never
+
+        @pegasus.get api_request_path
+
+        _(@pegasus.last_response.status).must_equal 301
+        _(@pegasus.last_response['Location']).must_equal CDO.studio_url(api_request_path, CDO.default_scheme)
+      end
+
       it 'redirects to studio when ending tutorial with png image' do
         api_request_path = '/api/hour/finish_mc.png'
 


### PR DESCRIPTION
Because the tutorial code in a path like `/api/hour/begin_codewards%20.png` is parsed as `codewards ` (with a trailing space), the original Pegasus endpoint returns HTTP `404` since no tutorial exists with that code. Prevent errors on invalid URLs when redirecting to Dashboard and let it handle them:

https://github.com/code-dot-org/code-dot-org/blob/5cde3bb67592b6612b6004ca1c8c8ea28fab50c8/dashboard/engines/hoc_legacy/app/controllers/hoc_legacy/tutorials_controller.rb#L10

https://github.com/code-dot-org/code-dot-org/blob/5cde3bb67592b6612b6004ca1c8c8ea28fab50c8/dashboard/engines/hoc_legacy/app/controllers/hoc_legacy/tutorials_controller.rb#L85-L87

## Links
- JIRA task: [CMS-951](https://codedotorg.atlassian.net/browse/CMS-951)
- Related PR: https://github.com/code-dot-org/code-dot-org/pull/67655