### PR TITLE
perf(HofAI): remove duplicate callbacks and add debounce

### DIFF
--- a/frontend/apps/marketing/package.json
+++ b/frontend/apps/marketing/package.json
@@ -79,6 +79,7 @@
     "react-schemaorg": "^2.0.0",
     "redis": "^4.7.1",
     "sitemap": "^8.0.0",
+    "use-debounce": "^10.0.6",
     "uuid": "^11.1.0"
   },
   "devDependencies": {

--- a/frontend/apps/marketing/src/components/contentful/activityCatalog/activityCatalog.tsx
+++ b/frontend/apps/marketing/src/components/contentful/activityCatalog/activityCatalog.tsx
@@ -6,6 +6,7 @@ import {FacetResult, InternalTypedDocument, Orama, search} from '@orama/orama';
 import {restore} from '@orama/plugin-data-persistence';
 import {useSearchParams} from 'next/navigation';
 import {ChangeEvent, ComponentProps, useEffect, useState} from 'react';
+import {useDebouncedCallback} from 'use-debounce';
 
 import FacetBar from '@/components/contentful/activityCatalog/facetBar/facetBar';
 import FacetDrawer from '@/components/contentful/activityCatalog/facetDrawer/facetDrawer';
@@ -81,35 +82,35 @@ const ActivityCatalog = ({
    * @param searchTerm - The current search term to serialize.
    * @param selectedFacets - The currently selected facets to serialize.
    */
-  const serializeClientState = (
-    searchTerm: string,
-    selectedFacets: Record<string, Set<string>>,
-  ) => {
-    const params = new URLSearchParams();
+  const serializeClientState = useDebouncedCallback(
+    (searchTerm: string, selectedFacets: Record<string, Set<string>>) => {
+      const params = new URLSearchParams();
 
-    /**
-     * For each selected facet, add it to the URL search params as a comma-separated list.
-     * Each value is individually encoded to handle commas and special characters.
-     */
-    Object.entries(selectedFacets).forEach(([facet, values]) => {
-      if (values.size > 0) {
-        // The value may contain commas, so encode each value individually.
-        const encodedValues = Array.from(values).map(v =>
-          encodeURIComponent(v),
-        );
-        params.set(facet, encodedValues.join(','));
-      }
-    });
+      /**
+       * For each selected facet, add it to the URL search params as a comma-separated list.
+       * Each value is individually encoded to handle commas and special characters.
+       */
+      Object.entries(selectedFacets).forEach(([facet, values]) => {
+        if (values.size > 0) {
+          // The value may contain commas, so encode each value individually.
+          const encodedValues = Array.from(values).map(v =>
+            encodeURIComponent(v),
+          );
+          params.set(facet, encodedValues.join(','));
+        }
+      });
 
-    // Update the URL without reloading the page
-    // Note: Using pushState instead of router.push to avoid extraneous RSC requests
-    // See: https://nextjs.org/docs/app/guides/single-page-applications#shallow-routing-on-the-client
-    window.history.pushState(
-      null,
-      '',
-      `?term=${encodeURIComponent(searchTerm)}&${params.toString()}`,
-    );
-  };
+      // Update the URL without reloading the page
+      // Note: Using pushState instead of router.push to avoid extraneous RSC requests
+      // See: https://nextjs.org/docs/app/guides/single-page-applications#shallow-routing-on-the-client
+      window.history.pushState(
+        null,
+        '',
+        `?term=${encodeURIComponent(searchTerm)}&${params.toString()}`,
+      );
+    },
+    250, // Debounce by 250ms to avoid excessive URL updates while typing
+  );
 
   /**
    * Deserializes the selected facets from the URL search params.
@@ -191,9 +192,6 @@ const ActivityCatalog = ({
 
     // Update the URL query parameters
     serializeClientState(nextSearchTerm, selectedFacets);
-
-    // Update the search results based on the new search term
-    updateSearchResults(nextSearchTerm, selectedFacets);
   };
 
   /**
@@ -222,16 +220,12 @@ const ActivityCatalog = ({
     setSelectedFacets(newSelectedFacets);
     // Update the URL query parameters
     serializeClientState(searchTerm, newSelectedFacets);
-
-    // Update the search results based on the new selected facets
-    updateSearchResults(searchTerm, newSelectedFacets);
   };
 
   const handleClearAll = () => {
     setSelectedFacets({});
     setSearchTerm('');
     serializeClientState('', {});
-    updateSearchResults('', {});
   };
 
   const toggleFacetDrawer = (isOpen: boolean) => {

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -1562,6 +1562,7 @@ __metadata:
     ts-node: "npm:^10.9.2"
     tsx: "npm:^4.19.3"
     typescript: "npm:^5"
+    use-debounce: "npm:^10.0.6"
     uuid: "npm:^11.1.0"
   languageName: unknown
   linkType: soft
@@ -23251,6 +23252,15 @@ __metadata:
   peerDependencies:
     react: "*"
   checksum: 10c0/73494fc44b2bd58a7ec799a528fc20077c45fe2e94fedff6dcd88d136f7a39f417d77f584d5613aac615ed32aeb2ea393797ae1f7d5b2645eab57cb497a6d0cb
+  languageName: node
+  linkType: hard
+
+"use-debounce@npm:^10.0.6":
+  version: 10.0.6
+  resolution: "use-debounce@npm:10.0.6"
+  peerDependencies:
+    react: "*"
+  checksum: 10c0/f0745de48fc344e6f90ea24384f3c79bf0733d06649827241135847abd67ee8db32f523d490c3276bce9f5a6867194ab1c0187bf6b84cabe1dd679037f4a527e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
The activity catalog updates search results on search paramter change via the useEffect hook. However, we also made search result updates based on the state change of facets and the search term. This results in a duplicated search which degrades performance.

Additionally, while entering a search term, a debounce should be used because typing quickly will result in many searches. Instead, debounce by 250ms which will prevent searching until 250ms of no input which is a reasonable compromise for perceived performance and multiple re-renders due to quick typing.