### PR TITLE
Fix flaky ui test for teacher homepage

### DIFF
--- a/dashboard/test/ui/features/teacher_tools/teacher_dashboard/teacher_homepage_v2.feature
+++ b/dashboard/test/ui/features/teacher_tools/teacher_dashboard/teacher_homepage_v2.feature
@@ -66,7 +66,7 @@ Scenario: Teacher can delete a section from the section options dropdown
     Given I am a teacher
     And I create a new student section
     And I am on "http://studio.code.org/teacher_dashboard/home"
-    And I click "#ui-test-empty-state-button-Assign-a-course" once it exists
+    And I click "#ui-test-empty-state-button-Assign-a-course" once it exists to load a new page
     Then I wait until element "h4:contains(AI for Oceans)" is visible
     And I click selector "[aria-label='Assign AI for Oceans to your classroom']"
     And element "span:contains(Untitled Section)" is visible


### PR DESCRIPTION
This fixes an issue with the teacher homepage UI tests that would sometimes cause the "assign a course" test to fail, because it would not wait for a new page to load.

## Links
[Slack thread](https://codedotorg.slack.com/archives/C045UAX4WKH/p1759167582601629)

## Testing story
<!--  Does your change include appropriate tests?
      - If so, please describe how the tests included in this PR are sufficient.
      - If not, please explain why this change does not need to be tested. -->



## Deployment strategy
<!--  Any special steps required to deploy this, besides merging?
      - Are there database migrations or manual steps?
      - Does this require coordination with other teams or systems? -->



## Follow-up work
<!--  List any clean-up or technical debt that will be addressed in future work.
      - Include Jira links where applicable.
      - Are there any known limitations or improvements planned? -->



## Privacy
<!--  How does this change impact Student & Teacher privacy?
      - Does this collect, use, share, or modify PII, either new or existing? -->



## Security
<!--  How does this change impact our security surface-area?
      - Do API's touched have the right auth?
      - Do infra changes impact our attack surface or encryption?
-->



## Caching
<!--  How does this change impact caching behavior?
      - Are cache keys or invalidation strategies affected?
      - Will this require cache warming or invalidation after deployment? -->



## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
