### PR TITLE
[Blockly] Got shortcuts menu working alongside data-theme Dark

### DIFF
--- a/apps/src/blockly/addons/cdoKeyboardNavigation.ts
+++ b/apps/src/blockly/addons/cdoKeyboardNavigation.ts
@@ -28,13 +28,14 @@ export function preInjectRegistrations() {
 }
 
 export function initializeKeyboardNavigation(
-  workspace: GoogleBlockly.WorkspaceSvg
+  workspace: GoogleBlockly.WorkspaceSvg,
+  isDarkTheme: boolean
 ) {
   if (Blockly.KeyboardNavigation) {
     Blockly.KeyboardNavigation.dispose();
   }
   unregisterCrossTabPluginOptions();
-  createShortcutsModalContainer();
+  createShortcutsModalContainer(isDarkTheme);
   Blockly.KeyboardNavigation = new KeyboardNavigation(workspace, {
     allowCrossWorkspacePaste: true,
   });
@@ -43,13 +44,16 @@ export function initializeKeyboardNavigation(
   enableShortcutModalEscape();
 }
 
-function createShortcutsModalContainer() {
+function createShortcutsModalContainer(isDarkTheme: boolean) {
   // Add the shortcuts div prior to keyboard navigation initialization
   // so the dialog has a place to land.
   if (!document.getElementById('shortcuts')) {
     const shortcutDialog = document.createElement('div');
     shortcutDialog.id = 'shortcuts';
     shortcutDialog.className = 'shortcut-dialog';
+    if (isDarkTheme) {
+      shortcutDialog.setAttribute('data-theme', 'Dark');
+    }
     document.body.appendChild(shortcutDialog);
   }
 }

--- a/apps/src/blockly/addons/shortcutMenuStyles.scss
+++ b/apps/src/blockly/addons/shortcutMenuStyles.scss
@@ -3,10 +3,17 @@
 @import 'color.scss';
 
 .shortcut-dialog {
+  .shortcut-modal {
+    background-color: var(--background-neutral-primary);
+
+    .close-modal {
+      color: var(--text-neutral-secondary);
+    }
+  }
   h1 {
     @include typography.heading-lg;
     font-size: revert;
-    color: unset;
+    color: var(--text-neutral-primary);
     margin: 0;
   }
   h2 {
@@ -14,12 +21,22 @@
     color: var(--text-neutral-tertiary);
     margin: revert;
     padding-block-end: revert;
+    border-bottom: 1px solid var(--borders-neutral-primary);
+  }
+  tr:not(.category, :last-child) {
+    border: unset;
+    border-bottom: 1px solid var(--borders-neutral-light);
+  }
+  .key {
+    border-color: var(--borders-neutral-light);
   }
   th {
     background-color: unset;
     padding: 0;
+    border: unset;
   }
   td {
     @include typography.body-two;
+    color: var(--text-neutral-tertiary);
   }
 }

--- a/apps/src/blockly/googleBlocklyWrapper.ts
+++ b/apps/src/blockly/googleBlocklyWrapper.ts
@@ -922,7 +922,10 @@ function initializeBlocklyWrapper(blocklyInstance: GoogleBlocklyInstance) {
         experiments.BLOCKLY_KEYBOARD_NAVIGATION
       )
     ) {
-      initializeKeyboardNavigation(workspace);
+      initializeKeyboardNavigation(
+        workspace,
+        blocklyWrapper.isDarkTheme || false
+      );
     }
 
     // Typically, we need to handle disabling blocks that are not connected to an


### PR DESCRIPTION
I got the Blockly shortcuts menu working in dark mode! In addition to passing in isDarkMode from the googleBlocklyWrapper, this required adding some styles to light mode (which were previously unset) so that the data-theme could determine the correct color in dark vs light mode.

Light mode (unchanged):

<img width="1693" height="846" alt="Screenshot 2025-09-29 at 12 35 48 PM" src="https://github.com/user-attachments/assets/a93278d8-87b0-49d0-9a67-e5eb308ff71c" />


Dark mode (new):

<img width="1642" height="839" alt="Screenshot 2025-09-29 at 12 36 07 PM" src="https://github.com/user-attachments/assets/1b64f9b5-af32-4a2b-8c74-704aa6a097d2" />





## Links

- Jira: https://codedotorg.atlassian.net/browse/SL-1407
- Figma: https://www.figma.com/design/liPou77RuNL0Ik7YujsEjN/One-Time-Projects?node-id=1911-1385&t=JZkltTA4h1IoUOT5-0

## Testing story
<!--  Does your change include appropriate tests?
      - If so, please describe how the tests included in this PR are sufficient.
      - If not, please explain why this change does not need to be tested. -->



## Deployment strategy
<!--  Any special steps required to deploy this, besides merging?
      - Are there database migrations or manual steps?
      - Does this require coordination with other teams or systems? -->



## Follow-up work
<!--  List any clean-up or technical debt that will be addressed in future work.
      - Include Jira links where applicable.
      - Are there any known limitations or improvements planned? -->



## Privacy
<!--  How does this change impact Student & Teacher privacy?
      - Does this collect, use, share, or modify PII, either new or existing? -->



## Security
<!--  How does this change impact our security surface-area?
      - Do API's touched have the right auth?
      - Do infra changes impact our attack surface or encryption?
-->



## Caching
<!--  How does this change impact caching behavior?
      - Are cache keys or invalidation strategies affected?
      - Will this require cache warming or invalidation after deployment? -->



## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
