### PR TITLE
Skip any UI tests that reference hourofcode.com

### DIFF
--- a/dashboard/test/ui/features/acquisition_products/hour_of_code/hour_of_code_dot_com.feature
+++ b/dashboard/test/ui/features/acquisition_products/hour_of_code/hour_of_code_dot_com.feature
@@ -1,4 +1,5 @@
 @eyes
+@skip
 Feature: Looking at hourofcode.com with Applitools Eyes
 
 Scenario Outline: Simple page view

--- a/dashboard/test/ui/features/acquisition_products/pegasus_landing_pages.feature
+++ b/dashboard/test/ui/features/acquisition_products/pegasus_landing_pages.feature
@@ -1,6 +1,7 @@
 @eyes
 @single_session
 @pegasus_content
+@skip
 Feature: Looking at tutorial landing pages on Pegasus
 
 Scenario Outline: Simple page view

--- a/dashboard/test/ui/features/platform/global_edition/region_switch_confirm.feature
+++ b/dashboard/test/ui/features/platform/global_edition/region_switch_confirm.feature
@@ -15,6 +15,7 @@ Feature: Global Edition - Region Switch Confirm Modal
     And I reload the page
     Then I wait until element "#global-edition-region-switch-confirm.fade.in[role='dialog']" is visible
 
+  @skip
   Scenario: The modal is not shown on hourofcode.com domain
     Given I am on "http://hourofcode.com/us"
     And I am in Iran

--- a/dashboard/test/ui/features/platform/one_trust.feature
+++ b/dashboard/test/ui/features/platform/one_trust.feature
@@ -2,6 +2,7 @@
 Feature: OneTrust integration
   @eyes
   @pegasus_content
+  @skip
   Scenario: User sees OneTrust cookie pop-up when self-hosting OneTrust libraries on hourofcode
     Given I am in Europe
     Given I am on "http://hourofcode.com/es?otreset=true&otgeo=es"
@@ -25,6 +26,7 @@ Feature: OneTrust integration
     And I close my eyes
 
   @pegasus_content
+  @skip
   Scenario: OneTrust cookie pop-up shows when self-hosting OneTrust libraries on hourofocode
     Given I am in Europe
     Given I am on "http://hourofcode.com/es?otreset=true&otgeo=es"


### PR DESCRIPTION
In preparation for the deprecation of hourofcode.com (😢), we should skip all UI tests that reference that domain to limit pipeline disruptions.

Jira task to fully clean these up: https://codedotorg.atlassian.net/browse/CMS-1025

I'm prepping this PR now because we may deprecate hourofcode.com as early as this week but will hold off on merging until we have clarity on that timeline (it may end up waiting until after Fallchella).



