### PR TITLE
P20-1635/adding korean certificates

### DIFF
--- a/apps/src/templates/certificates/Congrats.jsx
+++ b/apps/src/templates/certificates/Congrats.jsx
@@ -69,8 +69,8 @@ export default function Congrats(props) {
    */
   const getExtraLinkData = (language, tutorial, currentDate) => {
     // https://codedotorg.atlassian.net/browse/P20-1144
-    const codingPartyStart = new Date('2025-06-16:00:00+09:00');
-    const codingPartyEnd = new Date('2025-07-27:00:00+09:00');
+    const codingPartyStart = new Date('2025-10-15:00:00+09:00');
+    const codingPartyEnd = new Date('2025-11-25:00:00+09:00');
     const codingPartyActive =
       codingPartyStart <= currentDate && currentDate < codingPartyEnd;
     if (language === 'ko' && codingPartyActive) {
@@ -78,22 +78,22 @@ export default function Congrats(props) {
         '온라인 코딩 파티 인증서 받으러 가기! (과학기술정보통신부 인증)';
       if (/oceans/.test(tutorial)) {
         return {
-          extraLinkUrl: pegasus('/files/online-coding-party-2025-1-oceans.png'),
+          extraLinkUrl: pegasus('/files/online-coding-party-2025-2-oceans.png'),
           extraLinkText: extraLinkText,
         };
       } else if (/hero/.test(tutorial)) {
         return {
-          extraLinkUrl: pegasus('/files/online-coding-party-2025-1-hero.png'),
+          extraLinkUrl: pegasus('/files/online-coding-party-2025-2-hero.png'),
           extraLinkText: extraLinkText,
         };
       } else if (/dance-ai/.test(tutorial)) {
         return {
-          extraLinkUrl: pegasus('/files/online-coding-party-2025-1-dance.png'),
+          extraLinkUrl: pegasus('/files/online-coding-party-2025-2-dance.png'),
           extraLinkText: extraLinkText,
         };
       } else if (/music-jam/.test(tutorial)) {
         return {
-          extraLinkUrl: pegasus('/files/online-coding-party-2025-1-music.png'),
+          extraLinkUrl: pegasus('/files/online-coding-party-2025-2-music.png'),
           extraLinkText: extraLinkText,
         };
       }

--- a/apps/src/templates/certificates/Congrats.jsx
+++ b/apps/src/templates/certificates/Congrats.jsx
@@ -79,28 +79,28 @@ export default function Congrats(props) {
       if (/oceans/.test(tutorial)) {
         return {
           extraLinkUrl: studio(
-            '/blockly/media/certificates/online-coding-party-2025-2-oceans.png'
+            '/blockly/media/certificates/ko/online-coding-party-2025-2-oceans.png'
           ),
           extraLinkText: extraLinkText,
         };
       } else if (/hero/.test(tutorial)) {
         return {
           extraLinkUrl: studio(
-            '/blockly/media/certificates/online-coding-party-2025-2-hero.png'
+            '/blockly/media/certificates/ko/online-coding-party-2025-2-hero.png'
           ),
           extraLinkText: extraLinkText,
         };
       } else if (/dance-ai/.test(tutorial)) {
         return {
           extraLinkUrl: studio(
-            '/blockly/media/certificates/online-coding-party-2025-2-dance.png'
+            '/blockly/media/certificates/ko/online-coding-party-2025-2-dance.png'
           ),
           extraLinkText: extraLinkText,
         };
       } else if (/music-jam/.test(tutorial)) {
         return {
           extraLinkUrl: studio(
-            '/blockly/media/certificates/online-coding-party-2025-2-music.png'
+            '/blockly/media/certificates/ko/online-coding-party-2025-2-music.png'
           ),
           extraLinkText: extraLinkText,
         };

--- a/apps/src/templates/certificates/Congrats.jsx
+++ b/apps/src/templates/certificates/Congrats.jsx
@@ -68,7 +68,7 @@ export default function Congrats(props) {
    * @returns {Object} extraLinkUrl, extraLinkText
    */
   const getExtraLinkData = (language, tutorial, currentDate) => {
-    // https://codedotorg.atlassian.net/browse/P20-1144
+    // https://codedotorg.atlassian.net/browse/P20-1635
     const codingPartyStart = new Date('2025-10-15:00:00+09:00');
     const codingPartyEnd = new Date('2025-11-25:00:00+09:00');
     const codingPartyActive =
@@ -78,22 +78,30 @@ export default function Congrats(props) {
         '온라인 코딩 파티 인증서 받으러 가기! (과학기술정보통신부 인증)';
       if (/oceans/.test(tutorial)) {
         return {
-          extraLinkUrl: pegasus('/files/online-coding-party-2025-2-oceans.png'),
+          extraLinkUrl: studio(
+            '/blockly/media/certificates/online-coding-party-2025-2-oceans.png'
+          ),
           extraLinkText: extraLinkText,
         };
       } else if (/hero/.test(tutorial)) {
         return {
-          extraLinkUrl: pegasus('/files/online-coding-party-2025-2-hero.png'),
+          extraLinkUrl: studio(
+            '/blockly/media/certificates/online-coding-party-2025-2-hero.png'
+          ),
           extraLinkText: extraLinkText,
         };
       } else if (/dance-ai/.test(tutorial)) {
         return {
-          extraLinkUrl: pegasus('/files/online-coding-party-2025-2-dance.png'),
+          extraLinkUrl: studio(
+            '/blockly/media/certificates/online-coding-party-2025-2-dance.png'
+          ),
           extraLinkText: extraLinkText,
         };
       } else if (/music-jam/.test(tutorial)) {
         return {
-          extraLinkUrl: pegasus('/files/online-coding-party-2025-2-music.png'),
+          extraLinkUrl: studio(
+            '/blockly/media/certificates/online-coding-party-2025-2-music.png'
+          ),
           extraLinkText: extraLinkText,
         };
       }

--- a/apps/static/certificates/ko/online-coding-party-2025-2-dance.png
+++ b/apps/static/certificates/ko/online-coding-party-2025-2-dance.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e4ad1ebf9699deb6ab214d95d537b68cd3ba2f1b2d1958b603dddd77c53c4ef0
+size 155398

--- a/apps/static/certificates/ko/online-coding-party-2025-2-hero.png
+++ b/apps/static/certificates/ko/online-coding-party-2025-2-hero.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fc746318f6a93da3180057b74deb290f31de3ff849191c9b0d2cc2a5bdeeb1ac
+size 156637

--- a/apps/static/certificates/ko/online-coding-party-2025-2-music.png
+++ b/apps/static/certificates/ko/online-coding-party-2025-2-music.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ce3beec26ff904084c12c1e620a65565ae7868ed99b30743d244e29bce5a98cb
+size 154016

--- a/apps/static/certificates/ko/online-coding-party-2025-2-oceans.png
+++ b/apps/static/certificates/ko/online-coding-party-2025-2-oceans.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:35348b6b41c15a7eab78fe1e073fbd599d73398c6e0c685500ac393d817e8153
+size 155962

--- a/apps/static/certificates/online-coding-party-2025-2-dance.png
+++ b/apps/static/certificates/online-coding-party-2025-2-dance.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e4ad1ebf9699deb6ab214d95d537b68cd3ba2f1b2d1958b603dddd77c53c4ef0
+size 155398

--- a/apps/static/certificates/online-coding-party-2025-2-dance.png
+++ b/apps/static/certificates/online-coding-party-2025-2-dance.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:e4ad1ebf9699deb6ab214d95d537b68cd3ba2f1b2d1958b603dddd77c53c4ef0
-size 155398

--- a/apps/static/certificates/online-coding-party-2025-2-hero.png
+++ b/apps/static/certificates/online-coding-party-2025-2-hero.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fc746318f6a93da3180057b74deb290f31de3ff849191c9b0d2cc2a5bdeeb1ac
+size 156637

--- a/apps/static/certificates/online-coding-party-2025-2-hero.png
+++ b/apps/static/certificates/online-coding-party-2025-2-hero.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:fc746318f6a93da3180057b74deb290f31de3ff849191c9b0d2cc2a5bdeeb1ac
-size 156637

--- a/apps/static/certificates/online-coding-party-2025-2-music.png
+++ b/apps/static/certificates/online-coding-party-2025-2-music.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ce3beec26ff904084c12c1e620a65565ae7868ed99b30743d244e29bce5a98cb
+size 154016

--- a/apps/static/certificates/online-coding-party-2025-2-music.png
+++ b/apps/static/certificates/online-coding-party-2025-2-music.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ce3beec26ff904084c12c1e620a65565ae7868ed99b30743d244e29bce5a98cb
-size 154016

--- a/apps/static/certificates/online-coding-party-2025-2-oceans.png
+++ b/apps/static/certificates/online-coding-party-2025-2-oceans.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:35348b6b41c15a7eab78fe1e073fbd599d73398c6e0c685500ac393d817e8153
+size 155962

--- a/apps/static/certificates/online-coding-party-2025-2-oceans.png
+++ b/apps/static/certificates/online-coding-party-2025-2-oceans.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:35348b6b41c15a7eab78fe1e073fbd599d73398c6e0c685500ac393d817e8153
-size 155962


### PR DESCRIPTION
Our Korean partners would like us to show a custom certificate for Korean students. This PR adds a link to a certificate provided by our partner when the language is in Korean. The links will be removed once their campaign is over.

1. AI for Oceans
2. Minecraft Hero's Journey
3. Dance Party AI Edition
3. Music Lab:Jam Session (updated):

Due to the change in pegasus since the last campaign, we had to add the certificates to the codebase instead of dropbox. Below are the certificate file names. The Korean-linked text remains the same.
/files/online-coding-party-2025-2-oceans.png
/files/online-coding-party-2025-2-hero.png
/files/online-coding-party-2025-2-dance.png
/files/online-coding-party-2025-2-music.png


Campaign Start and End Dates:
Start date: Wednesday, October 15, 2025, Korea Time (UTC/GMT +9) 
End Date: Tuesday, November 25, 2025, Korea Time (UTC/GMT +9)



## Links

- Jira: [P20-1635](https://codedotorg.atlassian.net/browse/P20-1635)

## Testing story
I modified the event date and tested on the following courses in Korean:

- /courses/oceans/units/1/lessons/1/levels/8
<img width="1824" height="559" alt="Screenshot 2025-09-30 at 1 36 54 PM" src="https://github.com/user-attachments/assets/54a6232b-f747-445c-a32f-6a199965709e" />


- /courses/hero/units/1/lessons/1/levels/12
<img width="1822" height="551" alt="Screenshot 2025-09-30 at 1 37 47 PM" src="https://github.com/user-attachments/assets/4c368781-dd5c-491f-be0c-8cc7f36e722c" />

- /courses/dance-ai-2023/units/1/lessons/1/levels/10
<img width="1822" height="551" alt="Screenshot 2025-09-30 at 1 38 49 PM" src="https://github.com/user-attachments/assets/d5aac30a-834f-4332-a355-26e55d0be05e" />

- /courses/music-jam-2024/units/1/lessons/1/levels/17
<img width="1824" height="559" alt="Screenshot 2025-09-30 at 1 36 54 PM" src="https://github.com/user-attachments/assets/e0514d75-e7ef-4d7f-9d43-9540d9b2fb87" />

- It doesn't show on another course: 
<img width="1285" height="606" alt="Screenshot 2025-09-29 at 5 00 41 PM" src="https://github.com/user-attachments/assets/979e418c-01be-4d5b-b011-ddbbcba4971e" />


- Or outside of campaign dates: 
<img width="1050" height="534" alt="Screenshot 2025-09-29 at 5 01 35 PM" src="https://github.com/user-attachments/assets/25d2d44d-8ae7-4c22-a632-71235d95eae0" />
