### PR TITLE
Add missing role switch to pii query

### DIFF
--- a/dashboard/lib/expired_deleted_account_pii_scrubber.rb
+++ b/dashboard/lib/expired_deleted_account_pii_scrubber.rb
@@ -54,9 +54,11 @@ class ExpiredDeletedAccountPiiScrubber
   def call
     reset_metrics
 
-    total_size = accounts_to_scrub.size
-    if total_size > limit
-      raise SafetyConstraintViolation, "Too many accounts to scrub: #{total_size} exceeds limit of #{limit}"
+    ActiveRecord::Base.connected_to(role: :reporting) do
+      total_size = accounts_to_scrub.size
+      if total_size > limit
+        raise SafetyConstraintViolation, "Too many accounts to scrub: #{total_size} exceeds limit of #{limit}"
+      end
     end
 
     # Process individual batches in a loop to avoid issues with find_each, which imposes


### PR DESCRIPTION
Forgot to add this the reporting role block around the initial check for the size of the query. Since we're calling `.size` it is actually running the SQL at this point.

## Links
<!--  Links to relevant external resources.
      - spec docs, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- Jira: 

## Testing story
<!--  Does your change include appropriate tests?
      - If so, please describe how the tests included in this PR are sufficient.
      - If not, please explain why this change does not need to be tested. -->



## Deployment strategy
<!--  Any special steps required to deploy this, besides merging?
      - Are there database migrations or manual steps?
      - Does this require coordination with other teams or systems? -->



## Follow-up work
<!--  List any clean-up or technical debt that will be addressed in future work.
      - Include Jira links where applicable.
      - Are there any known limitations or improvements planned? -->



## Privacy
<!--  How does this change impact Student & Teacher privacy?
      - Does this collect, use, share, or modify PII, either new or existing? -->



## Security
<!--  How does this change impact our security surface-area?
      - Do API's touched have the right auth?
      - Do infra changes impact our attack surface or encryption?
-->



## Caching
<!--  How does this change impact caching behavior?
      - Are cache keys or invalidation strategies affected?
      - Will this require cache warming or invalidation after deployment? -->



## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
