### PR TITLE
feat(HofAI): add activity sorting

### DIFF
--- a/frontend/apps/marketing/src/app/[brand]/[locale]/activities/[activityType]/page.tsx
+++ b/frontend/apps/marketing/src/app/[brand]/[locale]/activities/[activityType]/page.tsx
@@ -82,7 +82,11 @@ export default async function ActivitiesPage({
    * Fetches all activities from the Orama database.
    */
   const getAllActivities = async () => {
-    const allActivityResults = await search(db, {term: '', limit: 200});
+    const allActivityResults = await search(db, {
+      term: '',
+      limit: 200,
+      sortBy: {property: 'sortKey', order: 'ASC'},
+    });
 
     return allActivityResults.hits.map(hit => hit.document);
   };

--- a/frontend/apps/marketing/src/components/contentful/activityCatalog/activityCatalog.tsx
+++ b/frontend/apps/marketing/src/components/contentful/activityCatalog/activityCatalog.tsx
@@ -12,11 +12,11 @@ import FacetDrawer from '@/components/contentful/activityCatalog/facetDrawer/fac
 import Section from '@/components/contentful/section';
 import ActivityCollection from '@/components/csforall/activityCollection/ActivityCollection';
 import {ActivitySchema} from '@/modules/activityCatalog/orama/schema/ActivitySchema';
-import {Activity} from '@/modules/activityCatalog/types/Activity';
+import {OramaActivity} from '@/modules/activityCatalog/types/Activity';
 
 interface ActivityCatalogProps {
   serializedOramaDb: string | ArrayBuffer | Buffer<ArrayBuffer>;
-  activities: InternalTypedDocument<Activity>[];
+  activities: InternalTypedDocument<OramaActivity>[];
   facets: FacetResult | undefined;
 }
 
@@ -28,7 +28,7 @@ const ActivityCatalog = ({
   const allowedFacetSet = new Set(facets ? Object.keys(facets) : []);
 
   const [results, setResults] =
-    useState<InternalTypedDocument<Activity>[]>(activities);
+    useState<InternalTypedDocument<OramaActivity>[]>(activities);
   const [db, setDb] = useState<Orama<typeof ActivitySchema> | undefined>(
     undefined,
   );
@@ -172,6 +172,7 @@ const ActivityCatalog = ({
       where: {
         ...facetFilters,
       },
+      sortBy: {property: 'sortKey', order: 'ASC'},
       limit: 200,
     });
 

--- a/frontend/apps/marketing/src/modules/activityCatalog/orama/schema/ActivitySchema.ts
+++ b/frontend/apps/marketing/src/modules/activityCatalog/orama/schema/ActivitySchema.ts
@@ -19,4 +19,6 @@ export const ActivitySchema = {
   standards: 'string',
   tutorialID: 'string',
   primaryButton: 'string',
+  featuredPosition: 'number',
+  sortKey: 'string',
 } as const;

--- a/frontend/apps/marketing/src/modules/activityCatalog/types/Activity.ts
+++ b/frontend/apps/marketing/src/modules/activityCatalog/types/Activity.ts
@@ -15,6 +15,11 @@ export interface Activity {
   languagesText: string;
   standards: string;
   tutorialID: string;
+  featuredPosition: number;
+}
+
+export interface OramaActivity extends Activity {
+  sortKey: string;
 }
 
 export enum ActivityType {


### PR DESCRIPTION
This PR adds the ability to sort the activities in the catalog by introducing a sort key that is calculated prior to populating the client-side database. The sort key is constructed by taking the number from the Contentful provided field `featuredPosition` and using that as a prefix to the title. If there is no such field, the position `999` is assumed.

Effectively, this causes the items to be sorted by the featuredPosition first and then the title of the activity.