### PR TITLE
AI Chat/Tutor: update chat input container background color and spacing

### DIFF
--- a/apps/src/aiComponentLibrary/userMessageEditor/user-message-editor.module.scss
+++ b/apps/src/aiComponentLibrary/userMessageEditor/user-message-editor.module.scss
@@ -1,22 +1,21 @@
 .textArea {
-    min-height: 42px;
-    max-height: 250px;
-    box-sizing: border-box;
-    resize: none;
-    margin: 0;
-    flex: 1;
+  min-height: 42px;
+  max-height: 250px;
+  box-sizing: border-box;
+  resize: none;
+  margin: 0;
+  flex: 1;
 }
 
 .editorContainer {
-    padding: 10px;
-    display: flex;
-    width: 100%;
-    box-sizing: border-box;
-    gap: 5px;
+  display: flex;
+  width: 100%;
+  box-sizing: border-box;
+  gap: 5px;
 }
 
 .endSingleItemContainer {
-    display: flex;
-    justify-content: center;
-    align-items: end;
+  display: flex;
+  justify-content: center;
+  align-items: end;
 }

--- a/apps/src/aichat/views/ChatWorkspace.tsx
+++ b/apps/src/aichat/views/ChatWorkspace.tsx
@@ -300,16 +300,16 @@ const ChatWorkspace: React.FunctionComponent<ChatWorkspaceProps> = ({
             multimodalAvailable={multimodalAvailable}
           />
         )}
-        <div className={moduleStyles.buttonRow}>
-          {multimodalAvailable && (
+        {multimodalAvailable && (
+          <div className={moduleStyles.buttonRow}>
             <UploadButton
               isDisabled={!canChatWithModel || !!selectedStudent}
               levelName={levelName}
               hasStarterAssets={hasStarterAssets}
               buildAssetUrl={buildAssetUrl}
             />
-          )}
-        </div>
+          </div>
+        )}
       </div>
     </div>
   );

--- a/apps/src/aichat/views/UserChatMessageEditor.module.scss
+++ b/apps/src/aichat/views/UserChatMessageEditor.module.scss
@@ -5,5 +5,4 @@
   row-gap: 8px;
   column-gap: 5px;
   align-items: center;
-  padding: 0 10px;
 }

--- a/apps/src/aichat/views/chatWorkspace.module.scss
+++ b/apps/src/aichat/views/chatWorkspace.module.scss
@@ -81,15 +81,15 @@ $tabs-default-spacing: 4px;
   display: flex;
   flex-wrap: wrap;
   gap: 8px;
-  padding: 0 10px;
 }
 
 .footer {
   display: flex;
   flex-direction: column;
-  gap: 2px;
-  padding: 16px 6px;
+  gap: 0.5rem;
+  padding: 0.625rem;
   border-top: variables.$default-border;
+  background: var(--background-neutral-secondary);
 }
 
 .alertLink {
@@ -116,6 +116,5 @@ $tabs-default-spacing: 4px;
 }
 
 .modeDropdown {
-  margin-inline-start: 10px;
   width: fit-content;
 }

--- a/apps/src/lab2/views/components/Instructions/ResourcePanel/styles.module.scss
+++ b/apps/src/lab2/views/components/Instructions/ResourcePanel/styles.module.scss
@@ -130,5 +130,6 @@
 
 .navigationFooter {
   padding: 10px;
-  background-color: var(--background-neutral-secondary)
+  background-color: var(--background-neutral-secondary);
+  border-top: variables.$default-border;
 }


### PR DESCRIPTION
Doing some minor UI updates on the chat input container before updating the elements in this container further. 

## Links
Jira ticket: [AFL-253](https://codedotorg.atlassian.net/browse/AFL-253)
Figma mock: [here](https://www.figma.com/design/tDzVjyvhfkF8lyGROENOAD/Web-Lab-2?node-id=4748-20267&m=dev)

----

## Before

### Web Lab 2
<img width="1366" height="768" alt="Screenshot 2025-09-30 at 1 48 27 PM" src="https://github.com/user-attachments/assets/486522f4-4be9-4868-96cb-a1e56973e644" />


### Python Lab
<img width="1366" height="768" alt="Screenshot 2025-09-30 at 1 48 30 PM" src="https://github.com/user-attachments/assets/cc022f4f-db9a-40e7-b9c9-27ebe8aa68f8" />


### AI Chat Lab
<img width="1366" height="768" alt="Screenshot 2025-09-30 at 1 48 33 PM" src="https://github.com/user-attachments/assets/37380f4b-69e9-4390-9a8e-c88f666b2016" />


## After

### Web Lab 2
<img width="1366" height="768" alt="Screenshot 2025-09-30 at 1 37 01 PM" src="https://github.com/user-attachments/assets/75e8167e-bc69-4a5b-8287-7070ece357ea" />


### Python Lab
<img width="1366" height="768" alt="Screenshot 2025-09-30 at 1 37 06 PM" src="https://github.com/user-attachments/assets/70f03248-c142-4c85-ac76-be77388fd294" />


### AI Chat Lab
<img width="1366" height="768" alt="Screenshot 2025-09-30 at 1 37 11 PM" src="https://github.com/user-attachments/assets/09361679-cc5d-4dd6-9e06-9d78dbea803c" />
