### PR TITLE
Localizes droplet data via the StudioApp entrypoint.

### DIFF
--- a/apps/src/StudioApp.js
+++ b/apps/src/StudioApp.js
@@ -2443,6 +2443,28 @@ StudioApp.prototype.currentlyUsingBlocks = function () {
   );
 };
 
+/**
+ * Localize comments within the starting code.
+ */
+StudioApp.prototype.localizeCode = function (code) {
+  if (!code) {
+    return code;
+  }
+
+  return code
+    .split('\n')
+    .map(line =>
+      // Find comments, but not urls. So look for "// ..." or "... //..."
+      line
+        .split(/^\/\/|\s\/\//)
+        .map((part, i) =>
+          i === 1 ? ' ' + localization.translate(part.trim()) : part
+        )
+        .join(`${line.startsWith('//') ? '' : ' '}//`)
+    )
+    .join('\n');
+};
+
 StudioApp.prototype.handleEditCode_ = function (config) {
   if (this.hideSource) {
     // In hide source mode, just call afterInject and exit immediately
@@ -2629,24 +2651,9 @@ StudioApp.prototype.handleEditCode_ = function (config) {
 
   this.resizeToolboxHeader();
 
-  // Localize comments within the starting code
-  const localizeJS = code =>
-    code
-      .split('\n')
-      .map(line =>
-        // Find comments
-        line
-          .split('//')
-          .map((part, i) =>
-            i === 1 ? ' ' + localization.translate(part.trim()) : part
-          )
-          .join('//')
-      )
-      .join('\n');
-
   // Localize the start code
   config.level.startBlocks = config.level.startBlocks
-    ? localizeJS(config.level.startBlocks)
+    ? this.localizeCode(config.level.startBlocks)
     : config.level.startBlocks;
 
   var startBlocks = config.level.lastAttempt || config.level.startBlocks;

--- a/apps/src/StudioApp.js
+++ b/apps/src/StudioApp.js
@@ -16,6 +16,7 @@ import {addCallouts} from '@cdo/apps/code-studio/callouts';
 import {createLibraryClosure} from '@cdo/apps/code-studio/components/libraries/libraryParser';
 import WorkspaceAlert from '@cdo/apps/code-studio/components/WorkspaceAlert';
 import {queryParams} from '@cdo/apps/code-studio/utils';
+import localization from '@cdo/apps/localization';
 import {EVENTS, PLATFORMS} from '@cdo/apps/metrics/AnalyticsConstants';
 import analyticsReporter from '@cdo/apps/metrics/AnalyticsReporter';
 import {userAlreadyReportedAbuse} from '@cdo/apps/reportAbuse';
@@ -2039,7 +2040,16 @@ StudioApp.prototype.setConfigValues_ = function (config) {
     config.level.minWorkspaceHeight = config.level.minWorkspaceHeight || 1250;
   }
 
-  this.appMsg = config.appMsg;
+  // Localize the app messages
+
+  const msg = Object.entries(config.appMsg).reduce(
+    (acc, [key, msgFunction]) => {
+      acc[key] = (...args) => localization.translate(msgFunction(...args));
+      return acc;
+    },
+    {}
+  );
+  this.appMsg = msg;
   this.IDEAL_BLOCK_NUM = config.level.ideal || Infinity;
   if (experiments.isEnabled(experiments.BUBBLE_DIALOG)) {
     // This seems to break levels that start in the animation/costume tab.
@@ -2472,7 +2482,24 @@ StudioApp.prototype.handleEditCode_ = function (config) {
   const codeTextbox = document.getElementById('codeTextbox');
   const dropletCodeTextbox = document.createElement('div');
   dropletCodeTextbox.setAttribute('id', 'dropletCodeTextbox');
+  dropletCodeTextbox.setAttribute('data-notranslate', '');
   codeTextbox.appendChild(dropletCodeTextbox);
+
+  // Localize the droplet palette
+  fullDropletPalette.forEach(paletteInfo => {
+    if (paletteInfo.name) {
+      paletteInfo.name = localization.translate(paletteInfo.name);
+    }
+  });
+
+  // Localize the palette block parameters
+  for (const blockInfo of config.dropletConfig?.blocks || []) {
+    if (blockInfo.paletteParams) {
+      blockInfo.paletteParams = blockInfo.paletteParams.map(param =>
+        localization.translate(param)
+      );
+    }
+  }
 
   this.editor = new droplet.Editor(dropletCodeTextbox, {
     mode: 'javascript',
@@ -2602,6 +2629,26 @@ StudioApp.prototype.handleEditCode_ = function (config) {
   }
 
   this.resizeToolboxHeader();
+
+  // Localize comments within the starting code
+  const localizeJS = code =>
+    code
+      .split('\n')
+      .map(line =>
+        // Find comments
+        line
+          .split('//')
+          .map((part, i) =>
+            i === 1 ? ' ' + localization.translate(part.trim()) : part
+          )
+          .join('//')
+      )
+      .join('\n');
+
+  // Localize the start code
+  config.level.startBlocks = config.level.startBlocks
+    ? localizeJS(config.level.startBlocks)
+    : config.level.startBlocks;
 
   var startBlocks = config.level.lastAttempt || config.level.startBlocks;
   if (startBlocks) {

--- a/apps/src/StudioApp.js
+++ b/apps/src/StudioApp.js
@@ -2041,15 +2041,14 @@ StudioApp.prototype.setConfigValues_ = function (config) {
   }
 
   // Localize the app messages
-
-  const msg = Object.entries(config.appMsg).reduce(
-    (acc, [key, msgFunction]) => {
-      acc[key] = (...args) => localization.translate(msgFunction(...args));
-      return acc;
-    },
-    {}
-  );
+  const msg = config.appMsg
+    ? Object.entries(config.appMsg).reduce((acc, [key, msgFunction]) => {
+        acc[key] = (...args) => localization.translate(msgFunction(...args));
+        return acc;
+      }, {})
+    : config.appMsg;
   this.appMsg = msg;
+
   this.IDEAL_BLOCK_NUM = config.level.ideal || Infinity;
   if (experiments.isEnabled(experiments.BUBBLE_DIALOG)) {
     // This seems to break levels that start in the animation/costume tab.

--- a/apps/test/unit/StudioAppTest.js
+++ b/apps/test/unit/StudioAppTest.js
@@ -5,6 +5,7 @@ import {assets as assetsApi} from '@cdo/apps/clientApi';
 import {listStore} from '@cdo/apps/code-studio/assets';
 import {createLibraryClosure} from '@cdo/apps/code-studio/components/libraries/libraryParser';
 import project from '@cdo/apps/code-studio/initApp/project';
+import localization from '@cdo/apps/localization';
 import * as redux from '@cdo/apps/redux';
 import * as commonReducers from '@cdo/apps/redux/commonReducers';
 import {resetIdleTime} from '@cdo/apps/redux/studioAppActivity';
@@ -392,6 +393,103 @@ describe('StudioApp', () => {
       var footItems = makeFooterMenuItems();
       var itemKeys = footItems.map(item => item.key);
       expect(itemKeys).to.include('try-hoc');
+    });
+  });
+
+  describe('The StudioApp.localizeCode function', () => {
+    let stubLocalization;
+
+    beforeEach(() => {
+      stubLocalization = sinon.stub(localization, 'translate');
+      stubLocalization.returns('translated');
+      stubStudioApp();
+    });
+    afterEach(() => {
+      restoreStudioApp();
+      stubLocalization.restore();
+    });
+
+    it('returns the code untouched when it has no comments', () => {
+      const code = `
+        dosomething("ok");
+      `;
+      const result = studioApp().localizeCode(code);
+      expect(result).to.equal(code);
+    });
+
+    it('returns translated code for comments within the given string', () => {
+      const code = `
+        // hello
+      `;
+      const result = studioApp().localizeCode(code);
+      expect(result).to.equal(`
+        // translated
+      `);
+    });
+
+    it('returns translated code for comments that happen after code', () => {
+      const code = `
+        dosomething("ok");
+        somethingelse(); // hello
+      `;
+      const result = studioApp().localizeCode(code);
+      expect(result).to.equal(`
+        dosomething("ok");
+        somethingelse(); // translated
+      `);
+    });
+
+    it('returns code with URLs unaffected', () => {
+      const code = `
+        dosomething("ok");
+        image("http://studio.code.org/blockly/media/logo.png");
+      `;
+      const result = studioApp().localizeCode(code);
+      expect(result).to.equal(code);
+    });
+
+    it('returns code with comments not preceded with spaces unaffected', () => {
+      const code = `
+        dosomething("ok");// untranslated
+      `;
+      const result = studioApp().localizeCode(code);
+      expect(result).to.equal(code);
+    });
+
+    it('returns code with URLs unaffected but comments afterward translated', () => {
+      const code = `
+        dosomething("ok");
+        image("http://studio.code.org/blockly/media/logo.png"); // comment
+      `;
+      const result = studioApp().localizeCode(code);
+      expect(result).to.equal(`
+        dosomething("ok");
+        image("http://studio.code.org/blockly/media/logo.png"); // translated
+      `);
+    });
+
+    it('handles code that starts with a comment', () => {
+      const code = '// comment';
+      const result = studioApp().localizeCode(code);
+      expect(result).to.equal('// translated');
+    });
+
+    it('handles being passed an empty string', () => {
+      const code = '';
+      const result = studioApp().localizeCode(code);
+      expect(result).to.equal('');
+    });
+
+    it('handles being passed an undefined', () => {
+      const code = undefined;
+      const result = studioApp().localizeCode(code);
+      expect(result).to.equal(undefined);
+    });
+
+    it('handles being passed a null', () => {
+      const code = null;
+      const result = studioApp().localizeCode(code);
+      expect(result).to.equal(null);
     });
   });
 


### PR DESCRIPTION
This tokenizes the JavaScript for Droplet levels (AppLab / CSD Game Unit) to localize the comments in the code, some non-code parameter names, and disable DOM translation.

## Links
<!--  Links to relevant external resources.
      - spec docs, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- Jira: 

## Testing story
<!--  Does your change include appropriate tests?
      - If so, please describe how the tests included in this PR are sufficient.
      - If not, please explain why this change does not need to be tested. -->

Adds new StudioApp tests for the new `localizeCode` function.

## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
