### PR TITLE
perf(HofAI): Use Next Image component

### DIFF
--- a/frontend/apps/marketing-storybook/stories/Card.story.tsx
+++ b/frontend/apps/marketing-storybook/stories/Card.story.tsx
@@ -58,7 +58,7 @@ export const CustomImageHeight: Story = {
     const cardTitle = canvas.getByText('Card Title');
     await expect(cardTitle).toBeInTheDocument();
 
-    const imageElement = canvas.getByRole('presentation');
+    const imageElement = canvas.getByAltText('Card Title');
     await expect(imageElement).toBeInTheDocument();
   },
 };

--- a/frontend/apps/marketing-storybook/stories/collections/CardCollection.story.tsx
+++ b/frontend/apps/marketing-storybook/stories/collections/CardCollection.story.tsx
@@ -64,6 +64,8 @@ export const SortedAlphabetically: Story = {
     // Check that blocks are sorted alphabetically by title
     titles.forEach(title => {
       expect(canvas.getByText(title)).toBeInTheDocument();
+      // Check that images are rendered
+      expect(canvas.getByAltText(title)).toBeInTheDocument();
     });
     const renderedTitles = canvas
       .queryAllByRole('heading', {level: 3})
@@ -71,9 +73,6 @@ export const SortedAlphabetically: Story = {
       .filter(Boolean);
     const sortedTitles = [...renderedTitles].sort((a, b) => a.localeCompare(b));
     expect(renderedTitles).toEqual(sortedTitles);
-
-    // Check that images are rendered
-    expect(canvas.getAllByRole('presentation').length).toBe(titles.length);
 
     // Check that buttons are rendered
     primaryButtons.forEach(button => {

--- a/frontend/apps/marketing/src/components/contentful/card/Card.tsx
+++ b/frontend/apps/marketing/src/components/contentful/card/Card.tsx
@@ -99,7 +99,7 @@ const Card: React.FC<CardProps> = ({
           component={'div'}
         >
           <NextImage
-            alt={title}
+            alt={title || ''}
             src={imageSource}
             style={{objectFit: 'cover'}}
           />

--- a/frontend/apps/marketing/src/components/contentful/card/Card.tsx
+++ b/frontend/apps/marketing/src/components/contentful/card/Card.tsx
@@ -8,6 +8,7 @@ import {HTMLAttributes, useMemo} from 'react';
 
 import Button from '@/components/contentful/button';
 import Overline from '@/components/contentful/overline';
+import NextImage from '@/components/nextImage/NextImage';
 import {useStatsigLogger} from '@/providers/statsig/client';
 import {getAbsoluteImageUrl} from '@/selectors/contentful/getImage';
 import {LinkEntry} from '@/types/contentful/entries/Link';
@@ -92,14 +93,17 @@ const Card: React.FC<CardProps> = ({
 
   return (
     <CardMui className={className} raised={false}>
-      {imageSrc && (
+      {imageSource && (
         <CardMedia
-          src={imageSource}
-          component="img"
-          alt=""
-          loading="lazy"
-          sx={{height: setImageHeight}}
-        />
+          sx={{height: setImageHeight, position: 'relative'}}
+          component={'div'}
+        >
+          <NextImage
+            alt={title}
+            src={imageSource}
+            style={{objectFit: 'cover'}}
+          />
+        </CardMedia>
       )}
       <CardContent>
         {overline && (

--- a/frontend/apps/marketing/src/components/contentful/card/__tests__/Card.test.tsx
+++ b/frontend/apps/marketing/src/components/contentful/card/__tests__/Card.test.tsx
@@ -14,7 +14,7 @@ jest.mock('@/providers/statsig/client', () => ({
 const defaultProps: CardProps = {
   title: 'Test Title',
   description: 'Test Description',
-  imageSrc: 'test-image.jpg',
+  imageSrc: '//images.code.org/test-image.jpg',
   imageHeight: '250',
   overline: 'Test Overline',
   primaryButton: {
@@ -50,18 +50,18 @@ describe('Card', () => {
 
   it('renders image with correct src and height', () => {
     render(<Card {...defaultProps} />);
-    const img = screen.getByRole('presentation');
+    const img = screen.getByAltText(defaultProps.title!);
     expect(img).toHaveAttribute(
       'src',
       expect.stringContaining('test-image.jpg'),
     );
-    expect(img).toHaveStyle({height: '250px'});
+    expect(img).toHaveStyle({height: '100%'});
   });
 
   it('uses default image height if imageHeight is not provided', () => {
     render(<Card {...defaultProps} imageHeight={undefined} />);
-    const img = screen.getByRole('presentation');
-    expect(img).toHaveStyle({height: '300px'});
+    const img = screen.getByAltText(defaultProps.title!);
+    expect(img).toHaveStyle({height: '100%'});
   });
 
   it('renders primary and secondary buttons with correct labels and hrefs', () => {

--- a/frontend/apps/marketing/src/components/contentful/collections/cardCollection/__tests__/CardCollection.test.tsx
+++ b/frontend/apps/marketing/src/components/contentful/collections/cardCollection/__tests__/CardCollection.test.tsx
@@ -10,12 +10,6 @@ jest.mock('@contentful/experiences-sdk-react', () => ({
   }),
 }));
 
-// Mock the getAbsoluteImageUrl function
-jest.mock('@/selectors/contentful/getImage', () => ({
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  getAbsoluteImageUrl: (image: any) => image?.fields?.file?.url || '',
-}));
-
 const createMockCard = (title: string): CardCollectionProps['cards'][number] =>
   ({
     fields: {
@@ -64,7 +58,9 @@ describe('CardCollection', () => {
       />,
     );
     // Check that images are showing
-    expect(screen.getAllByRole('presentation')).toHaveLength(3);
+    expect(screen.getByAltText('Title 1')).toBeInTheDocument();
+    expect(screen.getByAltText('Title 2')).toBeInTheDocument();
+    expect(screen.getByAltText('Title 3')).toBeInTheDocument();
     // Check that overlines are showing
     expect(screen.getAllByText('Test Overline')).toHaveLength(3);
     // Check that titles are showing


### PR DESCRIPTION
This PR updates the activity catalog to use the Next.js image component to offload image hosting to our self-hosted CDN instead. The component will also auto-optimize images to AVIF/WEBP.

To support this, the CardMedia component is updated to use a div instead of `img` component directly. The div allows Next.js to calculate the appropriate aspect ratio for the image and provide the same object fit that exists today.

## Before

<img width="1262" height="1269" alt="Screenshot From 2025-09-30 16-55-38" src="https://github.com/user-attachments/assets/f736a3b2-c188-4bb4-840f-3311074345e7" />


## After

<img width="1262" height="1269" alt="Screenshot From 2025-09-30 16-55-47" src="https://github.com/user-attachments/assets/25b2980d-2ad5-412e-a636-d16359c1ab72" />
