### PR TITLE
Deflake AppServerMetricsTest

### DIFF
--- a/lib/test/cdo/test_app_server_metrics.rb
+++ b/lib/test/cdo/test_app_server_metrics.rb
@@ -6,6 +6,11 @@ class AppServerMetricsTest < Minitest::Test
   TCP_LISTENER = '0.0.0.0:0000'.freeze
   SOCKET_LISTENER = '/tmp/sock'.freeze
 
+  # Make sure we don't leak metrics to other tests.
+  def teardown
+    Cdo::Metrics.flush!
+  end
+
   def app
     ok = lambda do |_|
       @app.collect_metrics
@@ -23,7 +28,9 @@ class AppServerMetricsTest < Minitest::Test
   def expect_metrics(*metrics)
     @sequence ||= sequence('metrics')
     metrics.each do |name, value|
-      Cdo::Metrics.expects(:put).with("App Server", name, value, {}, {storage_resolution: 1, unit: 'Count'}).in_sequence(@sequence)
+      Cdo::Metrics.expects(:put).with(
+        "App Server", name, value, {}, {storage_resolution: 1, unit: 'Count'}
+      ).in_sequence(@sequence)
     end
   end
 
@@ -51,18 +58,46 @@ class AppServerMetricsTest < Minitest::Test
     get '/'
   end
 
+  # We want to test functionality within AppServerMetrics that depends on a
+  # concurrent task. This simple Observer class will let us block until that
+  # task has executed at least once.
+  #
+  # See https://www.rubydoc.info/gems/concurrent-ruby/1.2.3/Concurrent/Concern/Observable
+  class TaskExecutionObserver
+    def initialize
+      @task_executed = Concurrent::Event.new
+    end
+
+    def update(time, result, ex)
+      @task_executed.set
+    end
+
+    def wait_until_task_executed
+      @task_executed.wait(1)
+    end
+  end
+
   def test_reporting_task
     # Note: this test only passes on Linux systems, since it relies on Raindrops reading from /proc/net/unix.
     skip "Skip on non-Linux system" unless File.file? Raindrops::Linux::PROC_NET_UNIX_ARGS.first
 
     listener = Cdo::AppServerMetrics.new(nil,
-      interval: 0.1,
+      interval: 0.01,
       listeners: [TCP_LISTENER, SOCKET_LISTENER]
     )
-    listener.spawn_reporting_task
+    observer = TaskExecutionObserver.new
+    task = listener.spawn_reporting_task
+    task.add_observer(observer)
     Cdo::Metrics.expects(:put).at_least(1)
-    sleep 1
+    observer.wait_until_task_executed
   ensure
     listener&.shutdown
+    task.wait_for_termination(1)
+
+    # Because it's possible for a thread spawned by the task prior to
+    # termination to execute even after wait_for_termination has returned, we
+    # delay for a couple extra intervals to ensure that this test's threads
+    # will not interefere with test_app_server_metrics
+    sleep 0.02
   end
 end


### PR DESCRIPTION
## Backstory

We started seeing spontaneous inconsistent failures of two related tests only on the test server itself last week; either `CdoMetricsTest` or `AppServerMetricsTest` would frequently fail when run together as part of a full test suite. Specifically, `CdoMetricsTest` would occasionally fail only when it was run after `AppServerMetricsTest` and `AppServerMetricsTest` would occasionally fail when its own `test_app_server_metrics` test ran after its `test_reporting_task` test.

We'd either see

    AppServerMetricsTest
      test_app_server_metrics                                         PASS (0.01s)
      test_reporting_task                                             PASS (1.00s)

    CdoMetricsTest
      test_put                                                        FAIL (0.07s)
    Minitest::Assertion:         --- expected
	    +++ actual
	    @@ -1 +1 @@
	    -{:namespace=>"App Server", :metric_data=>[{:metric_name=>"WorkerBoot", :dimensions=>[{:name=>"Host", :value=>"localhost.code.org"}], :value=>1.0}]}
	    +{:namespace=>"App Server", :metric_data=>[{:metric_name=>"active", :dimensions=>[], :value=>0.0, :storage_resolution=>1, :unit=>"Count"}, {:metric_name=>"queued", :dimensions=>[], :value=>0.0, :timestamp=>2025-10-01 01:22:24.001626312 UTC, :storage_resolution=>1, :unit=>"Count"}, {:metric_name=>"calling", :dimensions=>[], :value=>0.0, :timestamp=>2025-10-01 01:22:24.001697706 UTC, :storage_resolution=>1, :unit=>"Count"}, {:metric_name=>"WorkerBoot", :dimensions=>[{:name=>"Host", :value=>"localhost.code.org"}], :value=>1.0, :timestamp=>2025-10-01 01:22:24.016676739 UTC}]}
	    /home/ubuntu/test/lib/test/cdo/aws/test_metrics.rb:13:in `test_put'

    Finished in 1.15064s
    3 tests, 12 assertions, 1 failures, 0 errors, 0 skips

or

    AppServerMetricsTest
      test_reporting_task                                             PASS (1.00s)
      test_app_server_metrics                                         FAIL (0.02s)
    Minitest::Assertion:         unexpected invocation: Raindrops::Linux.unix_listener_stats(['/tmp/sock'])
	    unsatisfied expectations:
	    - expected exactly twice, invoked 3 times: Raindrops::Linux.unix_listener_stats(['/tmp/sock'])
	    - expected exactly once, not yet invoked: Cdo::Metrics.put('App Server', :calling, 1, {}, {:storage_resolution => 1, :unit => 'Count'}); in sequence 'metrics'
	    - expected exactly once, not yet invoked: Cdo::Metrics.put('App Server', :queued, 4, {}, {:storage_resolution => 1, :unit => 'Count'}); in sequence 'metrics'
	    - expected exactly once, not yet invoked: Cdo::Metrics.put('App Server', :active, 3, {}, {:storage_resolution => 1, :unit => 'Count'}); in sequence 'metrics'
	    satisfied expectations:
	    - expected exactly twice, invoked twice: Raindrops::Linux.tcp_listener_stats(['0.0.0.0:0000'])
	    - expected exactly once, invoked once: Cdo::Metrics.put('App Server', :calling, 1, {}, {:storage_resolution => 1, :unit => 'Count'}); in sequence 'metrics'
	    - expected exactly once, invoked once: Cdo::Metrics.put('App Server', :queued, 2, {}, {:storage_resolution => 1, :unit => 'Count'}); in sequence 'metrics'
	    - expected exactly once, invoked once: Cdo::Metrics.put('App Server', :active, 1, {}, {:storage_resolution => 1, :unit => 'Count'}); in sequence 'metrics'
	    /home/ubuntu/test/lib/cdo/app_server_metrics.rb:70:in `collect_listener_stats'
	    /home/ubuntu/test/lib/cdo/app_server_metrics.rb:53:in `collect_metrics'
	    /home/ubuntu/test/lib/test/cdo/test_app_server_metrics.rb:11:in `block in app'
	    /home/ubuntu/test/vendor/bundle/ruby/3.1.0/gems/raindrops-0.20.0/lib/raindrops/middleware.rb:116:in `call'
	    /home/ubuntu/test/vendor/bundle/ruby/3.1.0/gems/rack-test-2.0.2/lib/rack/test.rb:358:in `process_request'
	    /home/ubuntu/test/vendor/bundle/ruby/3.1.0/gems/rack-test-2.0.2/lib/rack/test.rb:165:in `custom_request'
	    /home/ubuntu/test/vendor/bundle/ruby/3.1.0/gems/rack-test-2.0.2/lib/rack/test.rb:114:in `get'
	    /usr/local/lib/ruby/3.1.0/forwardable.rb:238:in `get'
	    /home/ubuntu/test/lib/test/cdo/test_app_server_metrics.rb:51:in `test_app_server_metrics'

    CdoMetricsTest
      test_put                                                        PASS (0.06s)

    Finished in 1.15993s
    3 tests, 4 assertions, 1 failures, 0 errors, 0 skips

Our investigation revealed that this is a race condition which only manifests on quite fast machines, hence why we were unable to reproduce in Drone or on an adhoc. We confirmed that we are able to get the test passing consistently on the test server when it was under high CPU load. We're still not certain why or how the server suddenly got faster, but at this point we feel confident that none of this is of concern for the stability of our actual product; we just need to make the tests more reliable.

## Description

This PR includes a total of three fixes, two of which were necessary and one which is just an optimization:

1. Explicitly flush `Cdo::Metrics` after `AppServerMetricsTest`, so it stops leaking its state to `CdoMetricsTest`.

2. Add a short static wait after terminating the TimerTask in `test_reporting_task`, so if it has a lingering thread still yet to execute it will do so before we move on to `test_app_server_metrics`. I don't love relying on a static wait for this rather than a dynamic wait; but in this case we're waiting for something which relies on a statically-scheduled interval anyway, so I feel at least *okay* about it.

3. Use a dynamic rather than a static wait in `test_reporting_task` after initiating the TimerTask and before terminating it. This one is just for the sake of cleanup; the static wait of 1 second we were relying on worked just fine, but it added a full second to the execution time of the test. This new approach is much faster.

## Links

[Slack thread](https://codedotorg.slack.com/archives/C03CK49G9/p1758648099019379)

## Testing story
<!--  Does your change include appropriate tests?
      - If so, please describe how the tests included in this PR are sufficient.
      - If not, please explain why this change does not need to be tested. -->

Verified locally and on the test server itself by temporarily editing Rakefile to run just these two tests and running them both on a loop with `i=0; while RAILS_ENV=test RAKE_ENV=test bundle exec rake test; do echo $((i=i+1)); done`

I gave it a good 100 iterations, and it passed every time:

    AppServerMetricsTest
      test_reporting_task                                             PASS (0.02s)
      test_app_server_metrics                                         PASS (0.01s)

    CdoMetricsTest
      test_put                                                        PASS (0.05s)

    Finished in 0.08499s
    3 tests, 12 assertions, 0 failures, 0 errors, 0 skips