### PR TITLE
Instructions: adjust padding tweak

### DIFF
--- a/apps/src/lab2/views/components/Instructions/InstructionsV2.tsx
+++ b/apps/src/lab2/views/components/Instructions/InstructionsV2.tsx
@@ -82,6 +82,10 @@ const Instructions: React.FunctionComponent<InstructionsProps> = ({
   hideContinueIfDisabled = false,
   ...feedbackProps
 }) => {
+  const hasValidationConditions = useAppSelector(
+    state => state.lab.validationState?.hasConditions
+  );
+
   const validationResults = useAppSelector(
     state => state.lab.validationState?.validationResults
   );
@@ -145,7 +149,7 @@ const Instructions: React.FunctionComponent<InstructionsProps> = ({
               <TextToSpeech text={longInstructions} />
             </div>
           )}
-          {includeValidation && (
+          {includeValidation && hasValidationConditions && (
             <div className={moduleStyles.nonScrollingSubContent}>
               <ValidationButton
                 onValidate={validationSettings.onValidate}


### PR DESCRIPTION
This fixes a tiny regression introduced in https://github.com/code-dot-org/code-dot-org/pull/68440, in which levels that have validation but no conditions saw their instructions height increase by `10px` due to the rendering of an empty `div` that led to a `gap` being rendered.

This might not be common, but it occurs in https://studio.code.org/courses/original-allthethings-course/units/1/lessons/50/levels/1 and was picked up by some Eyes tests.

### before

<img width="301" height="371" alt="Screenshot 2025-10-01 at 1 14 10 PM" src="https://github.com/user-attachments/assets/f364ce43-3510-412c-b26b-75823e9223e6" />

### after

<img width="301" height="371" alt="Screenshot 2025-10-01 at 1 12 25 PM" src="https://github.com/user-attachments/assets/51864b2f-e977-4687-9a87-fd810ce5d30e" />
