### PR TITLE
Lab2: Disable ai tutor if predict response has not been submitted

### DIFF
--- a/apps/i18n/lab2/en_us.json
+++ b/apps/i18n/lab2/en_us.json
@@ -16,6 +16,7 @@
   "page": "Page",
   "pages": "Pages",
   "pass": "Pass",
+  "predictTutorDisabledMessage": "AI Tutor is disabled until you submit your prediction.",
   "result": "Result",
   "resourcePanelOnboarding_title": "Resource area",
   "resourcePanelOnboarding_text": "All your helpful resources can be found in the resource area. When starting a level it will always show the instructions tab first.",

--- a/apps/src/aichat/views/chatWorkspace.module.scss
+++ b/apps/src/aichat/views/chatWorkspace.module.scss
@@ -62,6 +62,7 @@ $tabs-default-spacing: 4px;
 
   p {
     color: var(--text-neutral-quaternary);
+    text-align: center;
   }
 
   .chatDisabledIcon {

--- a/apps/src/lab2/views/Lab2.tsx
+++ b/apps/src/lab2/views/Lab2.tsx
@@ -7,6 +7,7 @@ import {ThemeProvider} from '@code-dot-org/component-library/common/contexts';
 import React from 'react';
 import {Provider} from 'react-redux';
 
+import {AiChatDisabledProvider} from '@cdo/apps/aichat/context/aiChatDisabledContext';
 import {getStandaloneProjectId} from '@cdo/apps/lab2/projects/utils';
 import {getStore} from '@cdo/apps/redux';
 import BrowserTextToSpeechWrapper from '@cdo/apps/sharedComponents/BrowserTextToSpeechWrapper';
@@ -32,7 +33,9 @@ const Lab2: React.FunctionComponent = () => {
                 <MetricsAdapter />
                 <Lab2IdleTimer />
                 <ProjectContainer channelId={getStandaloneProjectId()}>
-                  <LabViewsRenderer />
+                  <AiChatDisabledProvider>
+                    <LabViewsRenderer />
+                  </AiChatDisabledProvider>
                 </ProjectContainer>
                 <RubricFABContainer />
               </DialogManager>

--- a/apps/src/lab2/views/LabViewsRenderer.tsx
+++ b/apps/src/lab2/views/LabViewsRenderer.tsx
@@ -5,10 +5,11 @@
  */
 import React, {Suspense, useEffect} from 'react';
 
-import {AiChatDisabledProvider} from '@cdo/apps/aichat/context/aiChatDisabledContext';
+import {useAiChatDisabled} from '@cdo/apps/aichat/context/aiChatDisabledContext';
 import {queryParams} from '@cdo/apps/code-studio/utils';
 import {PERMISSIONS} from '@cdo/apps/lab2/constants';
 import {useInitialLabTheme} from '@cdo/apps/lab2/hooks/useInitialLabTheme';
+import lab2I18n from '@cdo/apps/lab2/locale';
 import ProgressContainer from '@cdo/apps/lab2/progress/ProgressContainer';
 import {getAppOptionsViewingExemplar} from '@cdo/apps/lab2/projects/utils';
 import {
@@ -58,6 +59,24 @@ const LabViewsRenderer: React.FunctionComponent = () => {
     currentAppName,
     levelProperties,
   });
+  const isPredictLevel = useAppSelector(
+    state => state.lab.levelProperties?.predictSettings?.isPredictLevel || false
+  );
+  const hasSubmittedPredictResponse = useAppSelector(
+    state => state.predictLevel.hasSubmittedResponse
+  );
+
+  const {setChatDisabledState} = useAiChatDisabled();
+  useEffect(() => {
+    if (isPredictLevel && !hasSubmittedPredictResponse) {
+      setChatDisabledState({
+        chatDisabled: true,
+        chatDisabledMessage: lab2I18n.predictTutorDisabledMessage(),
+      });
+    } else {
+      setChatDisabledState({chatDisabled: false});
+    }
+  }, [isPredictLevel, hasSubmittedPredictResponse, setChatDisabledState]);
 
   useEffect(() => {
     const footer = document.getElementById('page-small-footer');
@@ -102,27 +121,22 @@ const LabViewsRenderer: React.FunctionComponent = () => {
 
   const LabView = properties.view;
   return (
-    <AiChatDisabledProvider>
-      <ProgressContainer key={currentAppName} appType={currentAppName}>
-        <div
-          id={`lab2-${currentAppName}`}
-          className={moduleStyles.labContainer}
-        >
-          <Suspense fallback={<Loading isLoading={true} />}>
-            <LabView
-              levelProperties={levelProperties}
-              initialSources={initialSources}
-            />
-          </Suspense>
-          {!hideExtraLinks && levelId && (
-            <ExtraLinks
-              levelId={levelId}
-              positionRightOfFooter={extraLinksButtonRightOfFooter}
-            />
-          )}
-        </div>
-      </ProgressContainer>
-    </AiChatDisabledProvider>
+    <ProgressContainer key={currentAppName} appType={currentAppName}>
+      <div id={`lab2-${currentAppName}`} className={moduleStyles.labContainer}>
+        <Suspense fallback={<Loading isLoading={true} />}>
+          <LabView
+            levelProperties={levelProperties}
+            initialSources={initialSources}
+          />
+        </Suspense>
+        {!hideExtraLinks && levelId && (
+          <ExtraLinks
+            levelId={levelId}
+            positionRightOfFooter={extraLinksButtonRightOfFooter}
+          />
+        )}
+      </div>
+    </ProgressContainer>
   );
 };
 


### PR DESCRIPTION
This PR puts AI tutor in a disabled state if the user is currently on a predict level and the response has not yet been submitted. I made a couple very minor tweaks to the disabled state setup created by #68419 
- I moved the context wrapper into `Lab2.tsx`, as that is where all the wrappers are defined. It also allows us to reference the context in `LabViewsRenderer` and do Lab2-level logic there.
- I centered the text indicating why the panel is disabled, as requested by design.

## Screen shot
<img width="398" height="955" alt="Screenshot 2025-10-01 at 8 20 40 AM" src="https://github.com/user-attachments/assets/4a611bb8-3ff2-44b7-9131-caca664b093b" />


## Screen recording (Web Lab 2)

https://github.com/user-attachments/assets/7b65dff5-0c45-44d7-a60f-92489ebdc995


## Screen recording (Python Lab)

https://github.com/user-attachments/assets/140e889a-505a-4472-a05b-61148490c67c




## Links
- Jira: [AFL-159](https://codedotorg.atlassian.net/browse/AFL-159)

## Testing Story
Tested locally on python lab and web lab 2. I confirmed that when switching levels the disabled state is reset appropriately.


## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
