### PR TITLE
Fix bug in progress view

### DIFF
--- a/apps/src/templates/sectionProgressV2/SectionProgressSelector.jsx
+++ b/apps/src/templates/sectionProgressV2/SectionProgressSelector.jsx
@@ -153,7 +153,13 @@ function SectionProgressSelector({
   };
 
   return (
-    <div className={classNames(styles.pageContent, styles.navView)}>
+    <div
+      className={classNames(
+        styles.pageContent,
+        styles.navView,
+        !displayV2 && styles.v1
+      )}
+    >
       {!displayV2 && (
         <Alert
           text={i18n.progressDeprecationWarning()}

--- a/apps/src/templates/sectionProgressV2/SectionProgressSelector.jsx
+++ b/apps/src/templates/sectionProgressV2/SectionProgressSelector.jsx
@@ -33,7 +33,6 @@ function SectionProgressSelector({
   progressTableV2ClosedBeta,
   sectionId,
   hasSeenProgressTableInvite,
-  isInV1Navigaton,
 }) {
   const [hasJustToggledViews, setHasJustToggledViews] = useState(false);
 
@@ -154,12 +153,7 @@ function SectionProgressSelector({
   };
 
   return (
-    <div
-      className={classNames(
-        styles.pageContent,
-        !isInV1Navigaton && styles.navView
-      )}
-    >
+    <div className={classNames(styles.pageContent, styles.navView)}>
       {!displayV2 && (
         <Alert
           text={i18n.progressDeprecationWarning()}
@@ -175,7 +169,7 @@ function SectionProgressSelector({
         componentId="ProgressV1OrV2ToggleLink"
       />
       {displayV2 ? (
-        <SectionProgressV2 hideTopHeading={!isInV1Navigaton} />
+        <SectionProgressV2 />
       ) : (
         <>
           {includeModalIfAvailable()}

--- a/apps/src/templates/sectionProgressV2/SectionProgressV2.jsx
+++ b/apps/src/templates/sectionProgressV2/SectionProgressV2.jsx
@@ -1,4 +1,4 @@
-import {Heading1, Heading6} from '@code-dot-org/component-library/typography';
+import {Heading6} from '@code-dot-org/component-library/typography';
 import PropTypes from 'prop-types';
 import React from 'react';
 import {connect} from 'react-redux';
@@ -39,7 +39,6 @@ function SectionProgressV2({
   isLoadingSectionData,
   expandedLessonIds,
   loadExpandedLessonsFromLocalStorage,
-  hideTopHeading,
 }) {
   const params = useParams();
   React.useEffect(() => {
@@ -126,7 +125,6 @@ function SectionProgressV2({
   return (
     // eslint-disable-next-line react/forbid-dom-props
     <div className={styles.progressV2Page} data-testid="section-progress-v2">
-      {!hideTopHeading && <Heading1>{i18n.progressBeta()}</Heading1>}
       <IconKey
         isViewingValidatedLevel={isViewingValidatedLevel}
         expandedLessonIds={expandedLessonIds}

--- a/apps/src/templates/sectionProgressV2/floatingScrollbar/floating-scrollbar.module.scss
+++ b/apps/src/templates/sectionProgressV2/floatingScrollbar/floating-scrollbar.module.scss
@@ -5,12 +5,23 @@
 }
 
 .scrollBar {
-  overflow-x: auto;
+  overflow-x: hidden;
   overflow-y: visible;
-  scrollbar-color: var(--borders-neutral-strong) transparent;
+  margin-bottom: 4px;
 }
 
-.bottomScrollBar {
+.scrollBar::-webkit-scrollbar {
+  -webkit-appearance: none;
+  height: 7px;
+}
+
+.scrollBar::-webkit-scrollbar-thumb {
+  border-radius: 4px;
+  background-color: var(--neutral-gray-60);
+}
+
+div .bottomScrollBar {
+  overflow-x: auto;
   position: fixed;
   bottom: 0;
 }
@@ -24,15 +35,18 @@
 .scrollingContent {
   width: 100%;
   height: 100%;
-  // Add an invisible scroll bar to the content in order to enable two-finger scrolling.
   overflow-x: scroll;
-  scrollbar-width: none; /* Firefox */
-  -ms-overflow-style: none; /* Internet Explorer 10+ */
+  scrollbar-width: 7px;
 }
+
 .scrollingContent::-webkit-scrollbar {
-  /* WebKit */
-  width: 0;
-  height: 0;
+  -webkit-appearance: none;
+  height: 7px;
+}
+
+.scrollingContent::-webkit-scrollbar-thumb {
+  border-radius: 4px;
+  background-color: var(--neutral-gray-60);
 }
 
 .defaultScroll {

--- a/apps/src/templates/sectionProgressV2/floatingScrollbar/floating-scrollbar.module.scss
+++ b/apps/src/templates/sectionProgressV2/floatingScrollbar/floating-scrollbar.module.scss
@@ -1,4 +1,3 @@
-
 .scrollingContainer {
   overflow: hidden;
   width: 100%;
@@ -8,6 +7,7 @@
 .scrollBar {
   overflow-x: auto;
   overflow-y: visible;
+  scrollbar-color: var(--borders-neutral-strong) transparent;
 }
 
 .bottomScrollBar {
@@ -27,9 +27,10 @@
   // Add an invisible scroll bar to the content in order to enable two-finger scrolling.
   overflow-x: scroll;
   scrollbar-width: none; /* Firefox */
-  -ms-overflow-style: none;  /* Internet Explorer 10+ */
+  -ms-overflow-style: none; /* Internet Explorer 10+ */
 }
-.scrollingContent::-webkit-scrollbar { /* WebKit */
+.scrollingContent::-webkit-scrollbar {
+  /* WebKit */
   width: 0;
   height: 0;
 }

--- a/apps/src/templates/sectionProgressV2/progress-header.module.scss
+++ b/apps/src/templates/sectionProgressV2/progress-header.module.scss
@@ -23,7 +23,6 @@
 
   &.navView {
     padding: 0;
-    max-width: 970px;
   }
 }
 

--- a/apps/src/templates/sectionProgressV2/progress-header.module.scss
+++ b/apps/src/templates/sectionProgressV2/progress-header.module.scss
@@ -23,6 +23,10 @@
 
   &.navView {
     padding: 0;
+
+    &.v1 {
+      max-width: 970px;
+    }
   }
 }
 

--- a/apps/src/templates/teacherNavigation/TeacherNavigationRouter.tsx
+++ b/apps/src/templates/teacherNavigation/TeacherNavigationRouter.tsx
@@ -228,9 +228,7 @@ const TeacherNavigationRouter: React.FC<TeacherNavigationRouterProps> = ({
                     <GlobalEditionWrapper
                       component={SectionProgressSelector}
                       componentId="SectionProgressSelector"
-                      props={{
-                        isInV1Navigaton: false,
-                      }}
+                      props={{}}
                     />
                   }
                 />

--- a/apps/test/unit/templates/sectionProgressV2/SectionProgressV2Test.jsx
+++ b/apps/test/unit/templates/sectionProgressV2/SectionProgressV2Test.jsx
@@ -74,7 +74,7 @@ describe('SectionProgressV2', () => {
     renderDefault();
     store.dispatch(startLoadingProgress());
 
-    screen.getByText('Progress (beta)');
+    screen.getByText('Icon Key');
     screen.getByText('Students');
     // eslint-disable-next-line no-restricted-properties
     screen.getAllByTestId('skeleton-cell');
@@ -86,7 +86,7 @@ describe('SectionProgressV2', () => {
 
     store.dispatch(setStudentsForCurrentSection(1, STUDENTS));
 
-    screen.getByText('Progress (beta)');
+    screen.getByText('Icon Key');
     screen.getByText('Students');
 
     expect(screen.getAllByText(/Student [1-9]/).length).toBe(STUDENTS.length);


### PR DESCRIPTION
When adding the deprecation banner to the v1 progress page, I unintentionally set a max width on the v2 page. This should only apply to the v1 progress page. This probably wasn't caught by eyes tests because our test browser width was not big enough.

Before:
<img width="1229" height="549" alt="image" src="https://github.com/user-attachments/assets/6e6c0677-1c43-4df3-94c0-150f779d7c93" />


After:
<img width="2420" height="1238" alt="image" src="https://github.com/user-attachments/assets/fcbe15e7-64fd-43ab-9692-d28ff97dca7e" />
no changes to v1 progress:
<img width="1059" height="465" alt="image" src="https://github.com/user-attachments/assets/798e83a4-f89a-48db-a349-dd6fccac8409" />



This also makes the background for the progress scroll-bar transparent. A small UI improvement:
Before:
<img width="1396" height="200" alt="image" src="https://github.com/user-attachments/assets/8473ca4f-5911-4376-9019-c6bde37e0ff1" />

After:
[

https://github.com/user-attachments/assets/645b6877-8695-48b3-8c0e-dd13d338d957

](url)

