### PR TITLE
P20-1401/add-tooltip-to-disabled-lms-sync-button

### DIFF
--- a/apps/src/accounts/SyncOmniAuthSectionControl.jsx
+++ b/apps/src/accounts/SyncOmniAuthSectionControl.jsx
@@ -1,6 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import {connect} from 'react-redux';
+import ReactTooltip from 'react-tooltip';
 
 import {OAuthSectionTypes} from '@cdo/apps/accounts/constants';
 import Button from '@cdo/apps/legacySharedComponents/Button';
@@ -233,26 +234,34 @@ export function SyncOmniAuthSectionButton({
   buttonState,
   onClick,
 }) {
+  const tooltipId = `sync-button-tooltip`;
   return (
-    <Button
-      text={buttonText(buttonState, provider, providerName)}
-      color={Button.ButtonColor.gray}
-      size={Button.ButtonSize.default}
-      disabled={[IN_PROGRESS, DISABLED].includes(buttonState)}
-      onClick={onClick}
-      {...iconProps(buttonState)}
-      style={{float: 'left', margin: '0'}}
-      title={
-        buttonState === DISABLED
-          ? i18n.ltiSectionSyncButtonDisabledAltText()
-          : undefined
-      }
-      aria-label={
-        buttonState === DISABLED
-          ? i18n.ltiSectionSyncButtonDisabledAltText()
-          : undefined
-      }
-    />
+    <span data-for={tooltipId} data-tip style={{float: 'left'}}>
+      <Button
+        text={buttonText(buttonState, provider, providerName)}
+        color={Button.ButtonColor.gray}
+        size={Button.ButtonSize.default}
+        disabled={[IN_PROGRESS, DISABLED].includes(buttonState)}
+        onClick={onClick}
+        {...iconProps(buttonState)}
+        style={{margin: '0'}}
+        title={
+          buttonState === DISABLED
+            ? i18n.ltiSectionSyncButtonDisabledAltText()
+            : undefined
+        }
+        aria-label={
+          buttonState === DISABLED
+            ? i18n.ltiSectionSyncButtonDisabledAltText()
+            : undefined
+        }
+      />
+      {buttonState === DISABLED && (
+        <ReactTooltip id={tooltipId} role="tooltip" effect="solid">
+          <div> {i18n.ltiSectionSyncButtonDisabledAltText()} </div>
+        </ReactTooltip>
+      )}
+    </span>
   );
 }
 SyncOmniAuthSectionButton.propTypes = {

--- a/apps/test/unit/accounts/SyncOmniAuthSectionControlTest.jsx
+++ b/apps/test/unit/accounts/SyncOmniAuthSectionControlTest.jsx
@@ -1,5 +1,6 @@
-import {shallow} from 'enzyme'; // eslint-disable-line no-restricted-imports
+import {shallow, mount} from 'enzyme'; // eslint-disable-line no-restricted-imports
 import React from 'react';
+import ReactTooltip from 'react-tooltip';
 import {stub} from 'sinon'; // eslint-disable-line no-restricted-imports
 
 import {OAuthSectionTypes} from '@cdo/apps/accounts/constants';
@@ -216,7 +217,7 @@ describe('SyncOmniAuthSectionControl', () => {
   });
 
   it('Disables the button when the section is of type LTI and syncEnabled is false', () => {
-    const wrapper = shallow(
+    const wrapper = mount(
       <SyncOmniAuthSectionControl
         {...defaultProps}
         sectionProvider={SectionLoginType.lti_v1}
@@ -225,5 +226,7 @@ describe('SyncOmniAuthSectionControl', () => {
     );
     const button = wrapper.find(SyncOmniAuthSectionButton);
     expect(button.prop('buttonState')).to.equal(DISABLED);
+
+    expect(wrapper.find(ReactTooltip)).to.have.lengthOf(1);
   });
 });


### PR DESCRIPTION
In the past, we've gotten a Zendesk ticket expressing confusion over a disabled LMS sync button. This PR adds a tooltip when the button is disabled explaining how to re-enabled roster sync.


<img width="528" height="177" alt="Screenshot 2025-10-01 at 1 05 37 PM" src="https://github.com/user-attachments/assets/a0792d18-7688-4f70-bb20-207582c661cf" />

## Links
- Jira: https://codedotorg.atlassian.net/browse/P20-1401

## Testing story
Added to the unit test to check that the tooltip is rendered. Additionally, manually verified:

- [x] Tooltip appears when the button is disabled
- [x] No tooltip appears when roster sync is enabled

