### PR TITLE
AI TA Chat: fix chat input padding

### DIFF
--- a/apps/src/aiDifferentiation/ai-differentiation.module.scss
+++ b/apps/src/aiDifferentiation/ai-differentiation.module.scss
@@ -205,15 +205,14 @@ $fab-height: 48;
 
   &Footer {
     display: flex;
-    padding: 6px;
+    padding: 1rem 1.25rem 0.875rem;
     flex-direction: column;
     align-items: flex-start;
     gap: 2px;
     border-top: 2px solid $neutral_gray10;
 
     &Buttons {
-      margin-inline-start: 10px;
-      margin-bottom: 10px;
+      margin-block: 0.625rem 0.25rem;
       display: flex;
       flex-direction: row;
       align-items: flex-start;


### PR DESCRIPTION
This fixes (and improves) the padding around the AI TA chat input that regressed yesterday due to this PR: https://github.com/code-dot-org/code-dot-org/pull/68645. 

## Links
Jira ticket: [AFL-258](https://codedotorg.atlassian.net/browse/AFL-258)
Slack convo: [here](https://codedotorg.slack.com/archives/C0T0PNTM3/p1759275318720219?thread_ts=1759274446.186469&cid=C0T0PNTM3)

----

## Before (Eyes diffs)

<img width="3416" height="1312" alt="Screenshot 2025-09-30 at 4 34 08 PM" src="https://github.com/user-attachments/assets/826d3e40-b53f-4502-ba3f-a8ebe0e14939" />

<img width="2768" height="1318" alt="Screenshot 2025-09-30 at 4 34 31 PM" src="https://github.com/user-attachments/assets/b970e042-1437-4278-a03f-2ac6238f580f" />


## After

<img width="500" height="1432" alt="Screenshot 2025-10-01 at 10 15 01 AM" src="https://github.com/user-attachments/assets/07d36a7d-49ad-43ef-b8d7-ff6a3ae931a3" />

<img width="500" height="1432" alt="Screenshot 2025-10-01 at 10 20 26 AM" src="https://github.com/user-attachments/assets/3308202b-9906-4cee-a157-1d42057f49ef" />
