### PR TITLE
fix(HofAI): add cache behavior for images

### DIFF
--- a/frontend/apps/marketing/cicd/3-app/template.yml.erb
+++ b/frontend/apps/marketing/cicd/3-app/template.yml.erb
@@ -304,6 +304,21 @@ Resources:
             TargetOriginId: marketing-sites-static-assets-origin
             ViewerProtocolPolicy: redirect-to-https
             ResponseHeadersPolicyId: !Ref DefaultResponseHeadersPolicy
+          # Path: /_next/image
+          # Description: Marketing _application_ dynamic image optimization
+          - AllowedMethods:
+              - GET
+              - HEAD
+              - OPTIONS
+            CachePolicyId: !If
+              - IsCorporateSite
+              - 4135ea2d-6df8-44a3-9df3-4b5a84be39ad # Managed-CachingDisabled (Disabled until this distribution becomes the main one instead of daisy chained)
+              - 1c6db51a-a33f-469a-8245-dae26771f530 # Managed-Amplify-ImageOptimization (Optimized for image optimization)
+            Compress: true
+            PathPattern: /_next/image
+            TargetOriginId: marketing-sites-application-origin
+            ViewerProtocolPolicy: redirect-to-https
+            ResponseHeadersPolicyId: !Ref DefaultResponseHeadersPolicy
 
   ####################################
   # Load Balancer Resources          #

--- a/frontend/apps/marketing/cicd/3-app/template.yml.erb
+++ b/frontend/apps/marketing/cicd/3-app/template.yml.erb
@@ -319,6 +319,7 @@ Resources:
             TargetOriginId: marketing-sites-application-origin
             ViewerProtocolPolicy: redirect-to-https
             ResponseHeadersPolicyId: !Ref DefaultResponseHeadersPolicy
+            OriginRequestPolicyId: 216adef6-5c7f-47e4-b989-5492eafa07d3 # AllViewer
 
   ####################################
   # Load Balancer Resources          #


### PR DESCRIPTION
This PR adds a missing cache behavior for `/_next/image` to support dynamic images on CSForAll.org. On Code.org, this didn't have an issue because `/_next/image` was handled on the outer cloudfront distribution. Additionally, CSForAll did not previously have dynamic images.