### PR TITLE
AI Chat/Tutor: update chat input textarea and button UI

### DIFF
--- a/apps/src/aiComponentLibrary/userMessageEditor/UserMessageEditor.tsx
+++ b/apps/src/aiComponentLibrary/userMessageEditor/UserMessageEditor.tsx
@@ -38,7 +38,7 @@ const UserMessageEditor = React.forwardRef<
     const internalInputRef = useRef<HTMLTextAreaElement | null>(null);
     const [userMessage, setUserMessage] = useState<string>('');
     // Track focus state on textarea to apply focus styles to container since
-    // :focus-visible doesn't work on divs and :has() is not supported in all browsers.
+    // :focus-visible doesn't work on divs and :has() is not supported in Firefox.
     const [focused, setFocused] = useState(false);
 
     const userMessageIsEmpty = useMemo(() => {

--- a/apps/src/aiComponentLibrary/userMessageEditor/UserMessageEditor.tsx
+++ b/apps/src/aiComponentLibrary/userMessageEditor/UserMessageEditor.tsx
@@ -67,7 +67,7 @@ const UserMessageEditor = React.forwardRef<
         internalInputRef.current.scrollHeight + 2 + 'px'; // Add a couple of pixels to avoid scrollbars.
     }, [userMessage]);
 
-    const icon = {iconName: 'paper-plane'};
+    const icon = {iconName: 'arrow-up'};
 
     return (
       <div
@@ -98,13 +98,14 @@ const UserMessageEditor = React.forwardRef<
           onKeyDown={e => handleKeyPress(e, userMessage)}
           maxLength={MAX_MESSAGE_LENGTH}
           rows={1}
+          aria-label={commonI18n.aiUserMessagePlaceholder()}
         />
-
-        <div className={moduleStyles.endSingleItemContainer}>
+        <div className={moduleStyles.chatActionsContainer}>
           <Button
             aria-label={commonI18n.submit()}
             id="uitest-chat-submit"
             isIconOnly={!showSubmitLabel}
+            size="xs"
             onClick={() => handleSubmit(userMessage)}
             disabled={disabled || !userMessage || userMessageIsEmpty}
             text={showSubmitLabel ? commonI18n.submit() : undefined}

--- a/apps/src/aiComponentLibrary/userMessageEditor/UserMessageEditor.tsx
+++ b/apps/src/aiComponentLibrary/userMessageEditor/UserMessageEditor.tsx
@@ -37,6 +37,9 @@ const UserMessageEditor = React.forwardRef<
   ) => {
     const internalInputRef = useRef<HTMLTextAreaElement | null>(null);
     const [userMessage, setUserMessage] = useState<string>('');
+    // Track focus state on textarea to apply focus styles to container since
+    // :focus-visible doesn't work on divs and :has() is not supported in all browsers.
+    const [focused, setFocused] = useState(false);
 
     const userMessageIsEmpty = useMemo(() => {
       return userMessage.trim() === '';
@@ -73,6 +76,7 @@ const UserMessageEditor = React.forwardRef<
       <div
         className={classnames(
           moduleStyles.editorContainer,
+          focused && moduleStyles.focused,
           editorContainerClassName
         )}
       >
@@ -99,6 +103,8 @@ const UserMessageEditor = React.forwardRef<
           maxLength={MAX_MESSAGE_LENGTH}
           rows={1}
           aria-label={commonI18n.aiUserMessagePlaceholder()}
+          onFocus={() => setFocused(true)}
+          onBlur={() => setFocused(false)}
         />
         <div className={moduleStyles.chatActionsContainer}>
           <Button

--- a/apps/src/aiComponentLibrary/userMessageEditor/user-message-editor.module.scss
+++ b/apps/src/aiComponentLibrary/userMessageEditor/user-message-editor.module.scss
@@ -1,21 +1,38 @@
-.textArea {
-  min-height: 42px;
-  max-height: 250px;
-  box-sizing: border-box;
-  resize: none;
-  margin: 0;
-  flex: 1;
-}
+@use '@code-dot-org/component-library-styles/mixins.scss' as mixins;
 
 .editorContainer {
-  display: flex;
+  background: var(--background-neutral-primary);
+  padding: 0.625rem;
   width: 100%;
   box-sizing: border-box;
-  gap: 5px;
-}
-
-.endSingleItemContainer {
   display: flex;
-  justify-content: center;
-  align-items: end;
+  flex-direction: column;
+  gap: 0.5rem;
+  transition: outline 0.2s ease-in;
+
+  @include mixins.border-styles($border-color: var(--borders-neutral-strong));
+
+  // Add focus styles to the container when the textArea is focused
+  &:has(.textArea:focus-visible) {
+    @include mixins.focus-styles;
+  }
+
+  // Input styles
+  .textArea {
+    min-height: 22px;
+    max-height: 250px;
+    box-sizing: border-box;
+    resize: none;
+    margin: 0;
+    padding: 0;
+    width: 100%;
+    border: none;
+    box-shadow: none;
+  }
+
+  // Chat Actions container styles
+  .chatActionsContainer {
+    display: flex;
+    justify-content: flex-end;
+  }
 }

--- a/apps/src/aiComponentLibrary/userMessageEditor/user-message-editor.module.scss
+++ b/apps/src/aiComponentLibrary/userMessageEditor/user-message-editor.module.scss
@@ -28,6 +28,8 @@
     width: 100%;
     border: none;
     box-shadow: none;
+    background: var(--background-neutral-primary);
+    color: var(--text-neutral-primary);
 
     &:disabled {
       opacity: 0.5;

--- a/apps/src/aiComponentLibrary/userMessageEditor/user-message-editor.module.scss
+++ b/apps/src/aiComponentLibrary/userMessageEditor/user-message-editor.module.scss
@@ -12,8 +12,8 @@
 
   @include mixins.border-styles($border-color: var(--borders-neutral-strong));
 
-  // Add focus styles to the container when the textArea is focused
-  &:has(.textArea:focus-visible) {
+  // Add focus styles to the container when the textarea is focused
+  &.focused {
     @include mixins.focus-styles;
   }
 

--- a/apps/src/aiComponentLibrary/userMessageEditor/user-message-editor.module.scss
+++ b/apps/src/aiComponentLibrary/userMessageEditor/user-message-editor.module.scss
@@ -17,7 +17,7 @@
     @include mixins.focus-styles;
   }
 
-  // Input styles
+  // Textarea styles
   .textArea {
     min-height: 22px;
     max-height: 250px;

--- a/apps/src/aiComponentLibrary/userMessageEditor/user-message-editor.module.scss
+++ b/apps/src/aiComponentLibrary/userMessageEditor/user-message-editor.module.scss
@@ -28,6 +28,11 @@
     width: 100%;
     border: none;
     box-shadow: none;
+
+    &:disabled {
+      opacity: 0.5;
+      background: none;
+    }
   }
 
   // Chat Actions container styles


### PR DESCRIPTION
Updates the UI on the chat input textarea and button in the `UserMessageEditor` component that's shared by AI Chat, AI Tutor, and AI TA. 

## Links
Jira ticket: [AFL-263](https://codedotorg.atlassian.net/browse/AFL-263)
Figma mock: [here](https://www.figma.com/design/tDzVjyvhfkF8lyGROENOAD/Web-Lab-2?node-id=4748-20267&m=dev)

----

## Before


https://github.com/user-attachments/assets/6c38a16e-e67e-4bd0-9975-88c5991ba4e8



## After

### Web Lab 2

https://github.com/user-attachments/assets/1791f781-8e95-4415-859b-1b2687d74291

### Python Lab

https://github.com/user-attachments/assets/67f16452-0d3d-48c2-b806-e8b6af31d93b

### AI Chat Lab

https://github.com/user-attachments/assets/398d987b-aade-42ff-b192-dc01d5d986fb

### AI TA

https://github.com/user-attachments/assets/6be47fd3-63f2-4710-a6f8-74738c46d410

### Dark mode


https://github.com/user-attachments/assets/dd595283-d3fb-4eb7-b223-d0db13e987df

