### PR TITLE
Sketch Lab: reset across level changes

### DIFF
--- a/apps/src/lab2/types.ts
+++ b/apps/src/lab2/types.ts
@@ -71,7 +71,7 @@ export interface ProjectSources {
 
 export type LabConfig = {[key: string]: {[key: string]: string}};
 
-export type Source = BlocklySource | MultiFileSource | SketchlabSource;
+export type Source = BlocklySource | MultiFileSource;
 
 export interface SaveSourceOptions {
   projectType?: string;
@@ -83,11 +83,6 @@ export interface UpdateSourceOptions extends SaveSourceOptions {
   firstSaveTimestamp: string;
   tabId: string | null;
 }
-
-// -- SKETCH LAB -- //
-
-// Sketch Lab currently serialized/deserializes into a generic object
-export type SketchlabSource = {[key: string]: unknown};
 
 // -- BLOCKLY -- //
 

--- a/apps/src/sketchlab/SketchlabView.tsx
+++ b/apps/src/sketchlab/SketchlabView.tsx
@@ -5,6 +5,7 @@ import {
   BinaryFiles,
   ExcalidrawImperativeAPI,
 } from '@excalidraw/excalidraw/types/types';
+import {isEqual, cloneDeep} from 'lodash';
 import React, {useEffect, useCallback, useRef, useState} from 'react';
 
 import {useVerticalLayout} from '@cdo/apps/lab2/hooks/useVerticalLayout';
@@ -105,6 +106,28 @@ const SketchlabView: React.FC<LabProps<LevelProperties>> = ({
       }
     };
   }, []);
+
+  useEffect(() => {
+    // to do: compare other properties (appState, etc)
+    // load necessary things rather than using key approach
+    if (
+      excalidrawApi &&
+      !isEqual(
+        excalidrawApi.getSceneElements(),
+        (currentSources.source as SketchlabSource).elements
+      )
+    ) {
+      console.log(currentSources.source);
+      excalidrawApi.updateScene({
+        appState: (currentSources.source as SketchlabSource)
+          .appState as AppState,
+        elements: cloneDeep(
+          (currentSources.source as SketchlabSource)
+            .elements as ExcalidrawElement[]
+        ),
+      });
+    }
+  }, [currentSources.source, excalidrawApi]);
 
   // Since there's no run button in Sketch Lab, set it to true by default
   // to enable the Submit button on edit on submittable levels.

--- a/apps/src/sketchlab/SketchlabView.tsx
+++ b/apps/src/sketchlab/SketchlabView.tsx
@@ -4,18 +4,14 @@ import {
   AppState,
   BinaryFiles,
   ExcalidrawImperativeAPI,
+  ExcalidrawInitialDataState,
 } from '@excalidraw/excalidraw/types/types';
 import {isEqual} from 'lodash';
 import React, {useEffect, useCallback, useRef, useState} from 'react';
 
 import {useVerticalLayout} from '@cdo/apps/lab2/hooks/useVerticalLayout';
 import {setHasRun} from '@cdo/apps/lab2/redux/systemRedux';
-import {
-  LabProps,
-  LevelProperties,
-  ProjectSources,
-  SketchlabSource,
-} from '@cdo/apps/lab2/types';
+import {LabProps, LevelProperties, ProjectSources} from '@cdo/apps/lab2/types';
 import ResourcePanel from '@cdo/apps/lab2/views/components/Instructions/ResourcePanel';
 import ResizeBar from '@cdo/apps/lab2/views/components/layout/ResizeBar';
 import PanelContainer from '@cdo/apps/lab2/views/components/PanelContainer';
@@ -33,11 +29,15 @@ const INITIAL_WORKSPACE_WIDTH = 800;
 
 const DEBOUNCED_WORKSPACE_SERIALIZATION_MS = 500;
 
+interface SketchlabSources extends ProjectSources {
+  source: ExcalidrawInitialDataState;
+}
+
 const SketchlabView: React.FC<LabProps<LevelProperties>> = ({
   levelProperties,
 }) => {
   const excalidrawApiRef = useRef<ExcalidrawImperativeAPI | null>();
-  const {currentSources, updateSources} = useSources<ProjectSources>();
+  const {currentSources, updateSources} = useSources<SketchlabSources>();
   const saveSourcesTimeoutRef = useRef<NodeJS.Timeout | null>(null);
   const [excalidrawMountKey, setExcalidrawMountKey] = useState(0);
 
@@ -116,12 +116,9 @@ const SketchlabView: React.FC<LabProps<LevelProperties>> = ({
       excalidrawApi &&
       (!isEqual(
         excalidrawApi.getSceneElements(),
-        (currentSources.source as SketchlabSource).elements
+        currentSources.source.elements
       ) ||
-        !isEqual(
-          excalidrawApi.getFiles(),
-          (currentSources.source as SketchlabSource).files
-        ))
+        !isEqual(excalidrawApi.getFiles(), currentSources.source.files))
     ) {
       setExcalidrawMountKey(key => key + 1);
     }
@@ -161,7 +158,7 @@ const SketchlabView: React.FC<LabProps<LevelProperties>> = ({
           headerContent="Workspace"
         >
           <Excalidraw
-            initialData={currentSources.source as SketchlabSource}
+            initialData={currentSources.source}
             onChange={debouncedSerializeAndSaveWorkspace}
             excalidrawAPI={api => (excalidrawApiRef.current = api)}
             key={excalidrawMountKey}

--- a/apps/src/sketchlab/SketchlabView.tsx
+++ b/apps/src/sketchlab/SketchlabView.tsx
@@ -5,7 +5,7 @@ import {
   BinaryFiles,
   ExcalidrawImperativeAPI,
 } from '@excalidraw/excalidraw/types/types';
-import {isEqual, cloneDeep} from 'lodash';
+import {isEqual} from 'lodash';
 import React, {useEffect, useCallback, useRef, useState} from 'react';
 
 import {useVerticalLayout} from '@cdo/apps/lab2/hooks/useVerticalLayout';
@@ -36,10 +36,10 @@ const DEBOUNCED_WORKSPACE_SERIALIZATION_MS = 500;
 const SketchlabView: React.FC<LabProps<LevelProperties>> = ({
   levelProperties,
 }) => {
-  const [excalidrawApi, setExcalidrawApi] =
-    useState<ExcalidrawImperativeAPI | null>();
+  const excalidrawApiRef = useRef<ExcalidrawImperativeAPI | null>();
   const {currentSources, updateSources} = useSources<ProjectSources>();
   const saveSourcesTimeoutRef = useRef<NodeJS.Timeout | null>(null);
+  const [excalidrawMountKey, setExcalidrawMountKey] = useState(0);
 
   const hasRun = useAppSelector(state => state.lab2System.hasRun);
 
@@ -81,6 +81,7 @@ const SketchlabView: React.FC<LabProps<LevelProperties>> = ({
           serializeAsJSON(elements, state, files, 'local')
         );
 
+        const excalidrawApi = excalidrawApiRef.current;
         if (excalidrawApi) {
           // serializeAsJSON exports an extremely limited set of properties from appState,
           // and excludes the chosen scroll position (scrollX/Y) and zoom,
@@ -96,7 +97,7 @@ const SketchlabView: React.FC<LabProps<LevelProperties>> = ({
         updateSources({source: serializedData});
       }, DEBOUNCED_WORKSPACE_SERIALIZATION_MS);
     },
-    [updateSources, excalidrawApi]
+    [updateSources]
   );
 
   useEffect(() => {
@@ -108,26 +109,23 @@ const SketchlabView: React.FC<LabProps<LevelProperties>> = ({
   }, []);
 
   useEffect(() => {
-    // to do: compare other properties (appState, etc)
-    // load necessary things rather than using key approach
+    // Note that we do not compare appState, as Excalidraw tracks a lot of app state properties
+    // that we do not store to S3.
+    const excalidrawApi = excalidrawApiRef.current;
     if (
       excalidrawApi &&
-      !isEqual(
+      (!isEqual(
         excalidrawApi.getSceneElements(),
         (currentSources.source as SketchlabSource).elements
-      )
+      ) ||
+        !isEqual(
+          excalidrawApi.getFiles(),
+          (currentSources.source as SketchlabSource).files
+        ))
     ) {
-      console.log(currentSources.source);
-      excalidrawApi.updateScene({
-        appState: (currentSources.source as SketchlabSource)
-          .appState as AppState,
-        elements: cloneDeep(
-          (currentSources.source as SketchlabSource)
-            .elements as ExcalidrawElement[]
-        ),
-      });
+      setExcalidrawMountKey(key => key + 1);
     }
-  }, [currentSources.source, excalidrawApi]);
+  }, [currentSources.source]);
 
   // Since there's no run button in Sketch Lab, set it to true by default
   // to enable the Submit button on edit on submittable levels.
@@ -165,7 +163,8 @@ const SketchlabView: React.FC<LabProps<LevelProperties>> = ({
           <Excalidraw
             initialData={currentSources.source as SketchlabSource}
             onChange={debouncedSerializeAndSaveWorkspace}
-            excalidrawAPI={api => setExcalidrawApi(api)}
+            excalidrawAPI={api => (excalidrawApiRef.current = api)}
+            key={excalidrawMountKey}
           />
         </PanelContainer>
       </div>

--- a/apps/src/sketchlab/SketchlabView.tsx
+++ b/apps/src/sketchlab/SketchlabView.tsx
@@ -108,6 +108,11 @@ const SketchlabView: React.FC<LabProps<LevelProperties>> = ({
     };
   }, []);
 
+  // This effect runs on each source change,
+  // but the full remount (via key change) is only intended when
+  // Excalidraw state diverges from the saved source state.
+  // This happens when a user switches levels, or a teachers switches
+  // between viewing different students on the same level.
   useEffect(() => {
     // Note that we do not compare appState, as Excalidraw tracks a lot of app state properties
     // that we do not store to S3.


### PR DESCRIPTION
This PR adds support for resetting the canvas when a change to the current sources are observed (eg, when navigating between levels).

[An earlier version of this PR](https://github.com/code-dot-org/code-dot-org/pull/68685/commits/fb73a47384ff17f50820e5edfd888c2e76aee594) used a more targeted approach of updating only specific bits of state on the existing Excalidraw canvas, vs. a full remount of the canvas (via a `key` prop). I was torn on which was preferable, but landed on a full remount (for now). There were a couple of problems with the more targeted approach:
- There's a `files` property (ie, images) that we serialize and deserialize from S3. The Excalidraw API appears to offer mechanisms to `addFiles` and to `getFiles`, but no explicit "I want to set the files available to something else" (ie, `setFiles`)?
- Relatedly, the helper that I tried to use to update a "scene" (`updateScene`) accepts the "elements" of your sketch (which I needed to deep clone to get to work, I am not sure why) and "app state", but not files.

Handily, thanks to the `SourcesContainer` component, this appears to also give support for updating the Excalidraw canvas when a teacher switches between students, not just when switching between levels as a single user.

## Links

- Jira: https://codedotorg.atlassian.net/browse/AFL-249

## Testing story

I tested manually navigating between levels as an individual user, as well as navigating between students as a teacher.