### PR TITLE
Web Lab 2: small updates to including snippets/files as context

### DIFF
--- a/apps/src/aiTutor/helpers/aiTutorContextHelper.ts
+++ b/apps/src/aiTutor/helpers/aiTutorContextHelper.ts
@@ -23,6 +23,12 @@ export abstract class AiTutorContextHelper<T extends object> {
     } = await this.getAiTutorContext();
 
     const hiddenContextString = [
+      ...(userSelection
+        ? [
+            'The student is asking about this part of their current code:',
+            userSelection,
+          ]
+        : []),
       "Here is the student's current code:",
       sourceCode,
       ...(validationContents
@@ -41,12 +47,6 @@ export abstract class AiTutorContextHelper<T extends object> {
         ? [
             'Here is the documentation. (The student can view the documentation by clicking the book icon at the top of the workspace.):',
             documentation,
-          ]
-        : []),
-      ...(userSelection
-        ? [
-            'The student would like to focus on this subset of their current code:',
-            userSelection,
           ]
         : []),
     ].join('\n\n');

--- a/apps/src/codebridge/Editor/addToAiTutorField.tsx
+++ b/apps/src/codebridge/Editor/addToAiTutorField.tsx
@@ -36,7 +36,11 @@ export const getAddToAiTutorField = (
           startingPosition,
           endingPosition
         );
-        const selectionDisplayName = `${filename} (${startingLine.number}-${endingLine.number})`;
+        const lineIndicator =
+          startingLine.number === endingLine.number
+            ? startingLine.number
+            : `${startingLine.number}-${endingLine.number}`;
+        const selectionDisplayName = `${filename} (${lineIndicator})`;
         const saveSelection = () =>
           dispatch(
             addItemToUserAddedSelectionContext({

--- a/apps/src/weblab2/helpers/aiTutorContextHelper.ts
+++ b/apps/src/weblab2/helpers/aiTutorContextHelper.ts
@@ -37,7 +37,11 @@ export class AiTutorWebLab2ContextHelper extends AiTutorContextHelper<AiTutorWeb
         ? Object.values(selection)
             .map(context => {
               if (context.lineReference) {
-                return `snippet of file ${context.filename}, lines ${context.lineReference.start} - ${context.lineReference.end}\nContents of snippet:\n\`\`\`${context.sourceCode}}\`\`\``;
+                const lineString =
+                  context.lineReference.start === context.lineReference.end
+                    ? `line ${context.lineReference.start}`
+                    : `lines ${context.lineReference.start} - ${context.lineReference.end}`;
+                return `snippet of file ${context.filename}, ${lineString}\nContents of snippet:\n\`\`\`${context.sourceCode}}\`\`\``;
               } else {
                 return `entirety of file ${context.filename}\nContents of file:\n\`\`\`${context.sourceCode}}\`\`\``;
               }

--- a/apps/src/weblab2/helpers/aiTutorContextHelper.ts
+++ b/apps/src/weblab2/helpers/aiTutorContextHelper.ts
@@ -41,7 +41,7 @@ export class AiTutorWebLab2ContextHelper extends AiTutorContextHelper<AiTutorWeb
                   context.lineReference.start === context.lineReference.end
                     ? `line ${context.lineReference.start}`
                     : `lines ${context.lineReference.start} - ${context.lineReference.end}`;
-                return `snippet of file ${context.filename}, ${lineString}\nContents of snippet:\n\`\`\`${context.sourceCode}}\`\`\``;
+                return `snippet of file ${context.filename}, ${lineString}\nContents of snippet:\n\`\`\`${context.sourceCode}\`\`\``;
               } else {
                 return `entirety of file ${context.filename}\nContents of file:\n\`\`\`${context.sourceCode}}\`\`\``;
               }


### PR DESCRIPTION
This makes a few small changes to how we include snippets/files as context in web lab 2:
- If the included snippet is only a single line, only display the single line number (for example `(5)` rather than a confusing range `(5-5)`.
- Move the included snippet/file to the beginning of the hidden context. From my googling it seems like the most important information should go first.

## Before
<img width="203" height="122" alt="Screenshot 2025-10-01 at 1 29 18 PM" src="https://github.com/user-attachments/assets/abb358ec-5d29-425c-bc1a-abc29dff7b2e" />

## After
<img width="203" height="122" alt="Screenshot 2025-10-01 at 3 12 47 PM" src="https://github.com/user-attachments/assets/8d9b95d7-9d5b-4536-82a9-c15dc2182a6c" />


## Links

- Jira: [AFL-250](https://codedotorg.atlassian.net/browse/AFL-250)

## Testing story
I am not super confident in the context string yet. It always knows what was included in the first message, but after a few messages with included snippets it can start making up what line/lines you are asking about. I wonder if we need a way to indicate that the AI should ignore previously included snippets? I'm not sure how we would do that.


## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
