### PR TITLE
hoai2025: generate dancer updates variants

### DIFF
--- a/apps/src/dance/lab2/views/GenerateDancer.tsx
+++ b/apps/src/dance/lab2/views/GenerateDancer.tsx
@@ -32,7 +32,7 @@ const adlibs: AdlibsType = {
     options: {
       animal: ['wolf', 'moose', 'frog', 'tiger', 'panda'],
     },
-    variantCount: 3,
+    variantCount: 5,
   },
   'animal-attire-02': {
     template:
@@ -41,7 +41,7 @@ const adlibs: AdlibsType = {
       animal: ['wolf', 'moose', 'frog', 'tiger', 'panda'],
       attire: ['headscarf', 'sunglasses', 'headphones', 'crown', 'beanie'],
     },
-    variantCount: 3,
+    variantCount: 5,
   },
   'adjective-animal-attire-02': {
     template:
@@ -51,7 +51,7 @@ const adlibs: AdlibsType = {
       animal: ['wolf', 'moose', 'frog', 'tiger', 'panda'],
       attire: ['headscarf', 'sunglasses', 'headphones', 'crown', 'beanie'],
     },
-    variantCount: 3,
+    variantCount: 5,
   },
   // Earlier adlibs which will be removed soon:
   animal: {


### PR DESCRIPTION
This small folllow-up to https://github.com/code-dot-org/code-dot-org/pull/68557 increases the number of variants for the three new dancer adlibs to 5.

