### PR TITLE
AI Tutor: fix labels and documentation icon

### DIFF
--- a/apps/src/aiTutor/suggestedPrompts.ts
+++ b/apps/src/aiTutor/suggestedPrompts.ts
@@ -6,7 +6,7 @@ export const defaultPrompts: AiTutorSuggestedPrompt[] = [
   {
     id: 'documentation',
     icon: {
-      iconName: 'file-code',
+      iconName: 'book',
     },
     label: 'Show documentation',
     value: 'Can you give me some documentation?',
@@ -22,7 +22,7 @@ export const levelPrompts: AiTutorSuggestedPrompt[] = [
     icon: {
       iconName: 'code',
     },
-    label: 'Show me an example',
+    label: 'Give an example',
     value: 'Can you give me an example?',
     analyticsProperties: {
       cannedPrompt: 'example',
@@ -33,7 +33,7 @@ export const levelPrompts: AiTutorSuggestedPrompt[] = [
     icon: {
       iconName: 'lightbulb',
     },
-    label: 'Give me a hint',
+    label: 'Give a hint',
     value: 'Can you give me a hint?',
     analyticsProperties: {
       cannedPrompt: 'hint',


### PR DESCRIPTION
Broad Tutor and AIF Tutor need to match. I think I inadvertently clobbered in-flight changes to the AI Tutor chat interface while refactoring to share suggested prompts with the AI Tutor sidebar. This edits the shared suggested prompts to match the desired shorter text and uses the correct documentation icon. 
