### PR TITLE
Update Korean campaign start date

### DIFF
--- a/apps/src/templates/certificates/Congrats.jsx
+++ b/apps/src/templates/certificates/Congrats.jsx
@@ -69,7 +69,7 @@ export default function Congrats(props) {
    */
   const getExtraLinkData = (language, tutorial, currentDate) => {
     // https://codedotorg.atlassian.net/browse/P20-1635
-    const codingPartyStart = new Date('2025-10-15:00:00+09:00');
+    const codingPartyStart = new Date('2025-10-13:00:00+09:00');
     const codingPartyEnd = new Date('2025-11-25:00:00+09:00');
     const codingPartyActive =
       codingPartyStart <= currentDate && currentDate < codingPartyEnd;


### PR DESCRIPTION
Global requested starting the campaign a few days earlier than originally listed to give our partners time to test before it officially starts. 

New "start" date: 10/13/2025
Official start date: 10/15/2025
Official end date: 11/25/2025



## Links

- Jira: https://codedotorg.atlassian.net/browse/P20-1635
- Original PR: https://github.com/code-dot-org/code-dot-org/pull/68621
