### PR TITLE
Lab2 Resource Panel: add teal border to selected tab

### DIFF
--- a/apps/src/lab2/views/components/Instructions/ResourcePanel/styles.module.scss
+++ b/apps/src/lab2/views/components/Instructions/ResourcePanel/styles.module.scss
@@ -49,6 +49,17 @@
         width: 1px;
         background-color: var(--background-neutral-primary);
       }
+
+      // Add a border to the start of the selected tab.
+      &::before {
+        content: '';
+        position: absolute;
+        inset-inline-start: 0;
+        top: 0;
+        height: 100%;
+        width: 3px;
+        background-color: var(--borders-brand-teal-primary);
+      }
     }
 
     i {

--- a/apps/src/lab2/views/components/Instructions/ResourcePanel/styles.module.scss
+++ b/apps/src/lab2/views/components/Instructions/ResourcePanel/styles.module.scss
@@ -1,5 +1,5 @@
-@use '../../layout/variables.scss' as variables;
-@use '../../../../../mixins.scss' as mixins;
+@use '@cdo/apps/lab2/views/components/layout/variables.scss' as variables;
+@use '@cdo/apps/mixins.scss' as mixins;
 
 .resourcePanel {
   display: flex;


### PR DESCRIPTION
Adds a teal border to the start of the selected tab.

## Links
Jira ticket: [AFL-269](https://codedotorg.atlassian.net/browse/AFL-269)
Figma mock: [here](https://www.figma.com/design/ahYTsb3I7rsJNW0n2vnXm6/DSCO-Components?node-id=11637-5268&t=SelVqgbI5iMFOnVY-1)

----


https://github.com/user-attachments/assets/7b702ab7-e784-4dad-8d49-98deac82fc10

