### PR TITLE
AI Tutor: swap the order of suggested prompts in Lab2

### DIFF
--- a/apps/src/lab2/views/components/AiTutor2Chat.tsx
+++ b/apps/src/lab2/views/components/AiTutor2Chat.tsx
@@ -48,8 +48,8 @@ const modelParameters: ModelParameters = {
 
 // Some pre-canned chat buttons.
 const defaultChatButtonData: ChatButtonData[] = [
-  ...defaultPrompts,
   ...levelPrompts,
+  ...defaultPrompts,
 ] as const;
 interface AiTutor2ChatProps {
   hiddenContextCallback: () => Promise<string>;


### PR DESCRIPTION
Updates the order of the suggested prompts in AI Tutor in Python Lab.

## Links
Slack convo: [here](https://codedotorg.slack.com/archives/C0T0PNTM3/p1759433847991449?thread_ts=1759342737.574899&cid=C0T0PNTM3)

----

<img width="340" height="192" alt="Screenshot 2025-10-02 at 12 50 37 PM" src="https://github.com/user-attachments/assets/2cb958e0-d51b-4ed7-9dc9-53e9e9a18241" />
