### PR TITLE
[MusicLab] Match PythonLab shortcuts - potentially temporary

### DIFF
--- a/apps/src/music/views/KeyHandler.tsx
+++ b/apps/src/music/views/KeyHandler.tsx
@@ -105,12 +105,40 @@ const KeyHandler: React.FunctionComponent<KeyHandlerProps> = ({
     ]
   );
 
+  // Multi-key presses require an additional keyDown handler.
+  const handleKeyDown = useCallback(
+    (event: KeyboardEvent) => {
+      // We don't have direct access to the workspace until Blockly injects it
+      // into the DOM, so we use a query selector to find it.
+      const workspaceElement: HTMLElement | null = document.querySelector(
+        '[aria-label="Blockly Workspace"]'
+      );
+      if (event.metaKey || event.ctrlKey) {
+        if (event.key === '1') {
+          event.preventDefault();
+          workspaceElement?.focus();
+        } else if (event.key === '2') {
+          event.preventDefault();
+          togglePlaying();
+        }
+      }
+    },
+    [togglePlaying]
+  );
+
   useEffect(() => {
     document.body.addEventListener('keyup', handleKeyUp);
     return () => {
       document.body.removeEventListener('keyup', handleKeyUp);
     };
   }, [handleKeyUp]);
+
+  useEffect(() => {
+    document.body.addEventListener('keydown', handleKeyDown);
+    return () => {
+      document.body.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [handleKeyDown]);
 
   return null;
 };


### PR DESCRIPTION
For the MusicLab keyboard nav rollout, we have decided to match the first two shortcuts in PythonLab for now: ctrl/meta + 1 for workspace, and ctrl/meta + 2 for 'run'. 

I wish I could've done this in a more 'reacty' way, but we do not have access to the actual workplace until Blockly injects it. I considered adding a ref to the div that it is injected under, but then we would have had to make that div keyboard navigable, and right now it is not navigable because it would be an extraneous/additional tab stop. 


https://github.com/user-attachments/assets/53214da7-af7b-48c0-b533-f86a0cfcb78a




## Links

- Jira: https://codedotorg.atlassian.net/browse/SL-1444

## Testing story
<!--  Does your change include appropriate tests?
      - If so, please describe how the tests included in this PR are sufficient.
      - If not, please explain why this change does not need to be tested. -->



## Deployment strategy
<!--  Any special steps required to deploy this, besides merging?
      - Are there database migrations or manual steps?
      - Does this require coordination with other teams or systems? -->



## Follow-up work
<!--  List any clean-up or technical debt that will be addressed in future work.
      - Include Jira links where applicable.
      - Are there any known limitations or improvements planned? -->



## Privacy
<!--  How does this change impact Student & Teacher privacy?
      - Does this collect, use, share, or modify PII, either new or existing? -->



## Security
<!--  How does this change impact our security surface-area?
      - Do API's touched have the right auth?
      - Do infra changes impact our attack surface or encryption?
-->



## Caching
<!--  How does this change impact caching behavior?
      - Are cache keys or invalidation strategies affected?
      - Will this require cache warming or invalidation after deployment? -->



## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
