### PR TITLE
convert autoload_paths to string last

### DIFF
--- a/dashboard/config/application.rb
+++ b/dashboard/config/application.rb
@@ -185,15 +185,6 @@ module Dashboard
 
     config.autoload_paths += runtime_load_paths
 
-    # Make sure to explicitly cast all autoload paths to strings; the gem we use to
-    # annotate model files with schema descriptions doesn't know how to deal with
-    # Pathnames. See https://github.com/ctran/annotate_models/issues/758
-    #
-    # We have a PR opened with a fix at https://github.com/ctran/annotate_models/pull/848;
-    # once a version of the gem is released which includes that change, we can get rid of
-    # this line.
-    config.autoload_paths.map!(&:to_s)
-
     # Also make sure these directories are always loaded up front in production
     # environments.
     #
@@ -212,6 +203,15 @@ module Dashboard
     # still be autoloaded as needed without being explicitly required.
     config.autoload_paths << Rails.root.join('lib', 'devtools')
     Rails.autoloaders.main.do_not_eager_load(Rails.root.join('lib', 'devtools'))
+
+    # Make sure to explicitly cast all autoload paths to strings; the gem we use to
+    # annotate model files with schema descriptions doesn't know how to deal with
+    # Pathnames. See https://github.com/ctran/annotate_models/issues/758
+    #
+    # We have a PR opened with a fix at https://github.com/ctran/annotate_models/pull/848;
+    # once a version of the gem is released which includes that change, we can get rid of
+    # this line.
+    config.autoload_paths.map!(&:to_s)
 
     # use https://(*-)studio.code.org urls in mails
     config.action_mailer.default_url_options = {host: CDO.canonical_hostname('studio.code.org'), protocol: 'https'}


### PR DESCRIPTION
fixes issue with the annotate gem needing autoload_paths to all be strings. this issue was introduced in https://github.com/code-dot-org/code-dot-org/pull/68241 . 
