### PR TITLE
index user_scripts table on unit_group_id

### DIFF
--- a/dashboard/app/models/user_script.rb
+++ b/dashboard/app/models/user_script.rb
@@ -18,6 +18,7 @@
 # Indexes
 #
 #  index_user_scripts_on_script_id                              (script_id)
+#  index_user_scripts_on_unit_group_id                          (unit_group_id)
 #  index_user_scripts_on_user_script_unit_group_deleted_unique  (user_id,script_id,unit_group_id,deleted_at) UNIQUE
 #
 

--- a/dashboard/db/migrate/20251002211355_index_user_scripts_on_unit_group_id.rb
+++ b/dashboard/db/migrate/20251002211355_index_user_scripts_on_unit_group_id.rb
@@ -1,0 +1,8 @@
+class IndexUserScriptsOnUnitGroupId < ActiveRecord::Migration[6.1]
+  def change
+    # Skip production because the database migration will be done manually.
+    return if Rails.env.production?
+
+    add_index :user_scripts, :unit_group_id
+  end
+end

--- a/dashboard/db/schema.rb
+++ b/dashboard/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2025_10_01_182525) do
+ActiveRecord::Schema.define(version: 2025_10_02_211355) do
 
   create_table "activities", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "user_id"
@@ -2553,6 +2553,7 @@ ActiveRecord::Schema.define(version: 2025_10_01_182525) do
     t.datetime "deleted_at"
     t.integer "unit_group_id"
     t.index ["script_id"], name: "index_user_scripts_on_script_id"
+    t.index ["unit_group_id"], name: "index_user_scripts_on_unit_group_id"
     t.index ["user_id", "script_id", "unit_group_id", "deleted_at"], name: "index_user_scripts_on_user_script_unit_group_deleted_unique", unique: true
   end
 


### PR DESCRIPTION
Creates an index that we will need for backfilling the `user_scripts.unit_group_id` field. In particular, we want to be able to count the number of rows which still have a null unit_group id. For more context, see [data migration proposal doc](https://docs.google.com/document/d/1Opuyvm8AcAmT-N-l3NRF2dD8rfLoDyYj3yPUG6_9HI8/edit) 

## Testing story

The manual index creation succeeded on adhoc with production DB clone in 7 minutes:
```
mysql> select id, username, updated_at from dashboard_production.users where id = (select max(id) from users);
+-----------+------------+---------------------+
| id        | username   | updated_at          |
+-----------+------------+---------------------+
| 131924682 | abcde12345 | 2025-10-02 17:00:23 |
+-----------+------------+---------------------+
1 row in set (0.00 sec)

mysql> CREATE INDEX idx_user_scripts_unit_group_id ON user_scripts(unit_group_id);
Query OK, 0 rows affected (7 min 17.34 sec)
Records: 0  Duplicates: 0  Warnings: 0
```

After doing so, the following query can run in under 60 seconds (but not under 30 seconds):
```
mysql> select count(*) from user_scripts where unit_group_id is null;
+-----------+
| count(*)  |
+-----------+
| 250320186 |
+-----------+
1 row in set (35.54 sec)
```

## Deployment strategy

Borrowing from #67430 which added a new index to the same table:
- wait for a low usage time period (e.g. after 4pm)
- add index manually on production
```sh
ubuntu@production-daemon:~/production$ bin/mysql-client-dashboard-writer
mysql> CREATE INDEX index_user_scripts_on_unit_group_id ON user_scripts(unit_group_id);
```