### PR TITLE
Enable resource panel in Music Lab

### DIFF
--- a/apps/src/lab2/utils/isUsingResourcePanel.ts
+++ b/apps/src/lab2/utils/isUsingResourcePanel.ts
@@ -22,6 +22,7 @@ export function isUsingResourcePanel(
     appName === 'weblab2' ||
     appName === 'dance' ||
     appName === 'sketchlab' ||
+    appName === 'music' ||
     experiments.isEnabledAllowingQueryString(experiments.LAB2_RESOURCE_PANEL)
   );
 }

--- a/apps/src/music/views/MusicLabView.tsx
+++ b/apps/src/music/views/MusicLabView.tsx
@@ -151,9 +151,6 @@ const MusicLabView: React.FunctionComponent<MusicLabViewProps> = ({
   const isViewingExemplar = getAppOptionsViewingExemplar();
   const projectTemplateLevel = useAppSelector(isProjectTemplateLevel);
   const blockMode = useSelector(getBlockMode);
-  const useNewInstructions = experiments.isEnabled(
-    experiments.LAB2_INSTRUCTIONS_V2
-  );
 
   // Pass music validator to Progress Manager
   useEffect(() => {

--- a/apps/src/music/views/MusicLabView.tsx
+++ b/apps/src/music/views/MusicLabView.tsx
@@ -25,7 +25,6 @@ import ResourcePanel from '@cdo/apps/lab2/views/components/Instructions/Resource
 import PanelContainer from '@cdo/apps/lab2/views/components/PanelContainer';
 import {DialogType, useDialogControl} from '@cdo/apps/lab2/views/dialogs';
 import ProjectTemplateWorkspaceIconV2 from '@cdo/apps/templates/ProjectTemplateWorkspaceIconV2';
-import experiments from '@cdo/apps/util/experiments';
 import {useAppDispatch, useAppSelector} from '@cdo/apps/util/reduxHooks';
 
 import AnalyticsReporter from '../analytics/AnalyticsReporter';

--- a/apps/src/music/views/MusicLabView.tsx
+++ b/apps/src/music/views/MusicLabView.tsx
@@ -21,8 +21,6 @@ import {
 import {isProjectTemplateLevel} from '@cdo/apps/lab2/redux/lab2ReduxSelectors';
 import {LevelProperties} from '@cdo/apps/lab2/types';
 import CodeEditor from '@cdo/apps/lab2/views/components/editor/CodeEditor';
-import Instructions from '@cdo/apps/lab2/views/components/Instructions';
-import InstructionsV2 from '@cdo/apps/lab2/views/components/Instructions/InstructionsV2';
 import ResourcePanel from '@cdo/apps/lab2/views/components/Instructions/ResourcePanel';
 import PanelContainer from '@cdo/apps/lab2/views/components/PanelContainer';
 import {DialogType, useDialogControl} from '@cdo/apps/lab2/views/dialogs';
@@ -347,93 +345,32 @@ const MusicLabView: React.FunctionComponent<MusicLabViewProps> = ({
               moduleStyles.instructionsSide
             )}
           >
-            {experiments.isEnabledAllowingQueryString(
-              experiments.LAB2_RESOURCE_PANEL
-            ) ? (
-              <ResourcePanel
-                isRunning={isPlaying}
-                handleInstructionsTextClick={onInstructionsTextClick}
-                bottomComponent={
-                  exemplarPlayerInsideInstructions &&
-                  showExemplarPlayer && (
-                    <ExemplarPlayerView
-                      playbackEvents={exemplarPlaybackEvents}
-                      title={exemplarSettings.playerTitle!}
-                      player={player}
-                      insideInstructions={exemplarPlayerInsideInstructions}
-                    />
-                  )
-                }
-                hasRun={hasRun}
-                hasEdited={hasEdited}
-                fixedDarkBackground={true}
-                overrideTheme={'Light'}
-                includeFooterSpacing={false}
-                levelProperties={levelProperties}
-                headerClassName={moduleStyles.headerWithBorder}
-                settings={settings}
-                hideContinueIfDisabled={true}
-                hideNavigation={false}
-                styleNavigationAsBubble={true}
-              />
-            ) : (
-              <PanelContainer
-                id="instructions-panel"
-                headerContent={musicI18n.panelHeaderInstructions()}
-                hideHeaders={hideHeaders}
-                headerClassName={moduleStyles.panelContainerHeader}
-              >
-                {useNewInstructions ? (
-                  <InstructionsV2
-                    isRunning={isPlaying}
-                    handleInstructionsTextClick={onInstructionsTextClick}
-                    bottomComponent={
-                      exemplarPlayerInsideInstructions &&
-                      showExemplarPlayer && (
-                        <ExemplarPlayerView
-                          playbackEvents={exemplarPlaybackEvents}
-                          title={exemplarSettings.playerTitle!}
-                          player={player}
-                          insideInstructions={exemplarPlayerInsideInstructions}
-                        />
-                      )
-                    }
-                    hasRun={hasRun}
-                    hasEdited={hasEdited}
-                    fixedDarkBackground={true}
-                    overrideTheme={'Light'}
-                    levelProperties={levelProperties}
-                    hideContinueIfDisabled={true}
-                  />
-                ) : (
-                  <Instructions
-                    isRunning={isPlaying}
-                    handleInstructionsTextClick={onInstructionsTextClick}
-                    bottomComponent={
-                      exemplarPlayerInsideInstructions &&
-                      showExemplarPlayer && (
-                        <ExemplarPlayerView
-                          playbackEvents={exemplarPlaybackEvents}
-                          title={exemplarSettings.playerTitle!}
-                          player={player}
-                          insideInstructions={exemplarPlayerInsideInstructions}
-                        />
-                      )
-                    }
-                    hasRun={hasRun}
-                    hasEdited={hasEdited}
-                  />
-                )}
-                {!exemplarPlayerInsideInstructions && showExemplarPlayer && (
+            <ResourcePanel
+              isRunning={isPlaying}
+              handleInstructionsTextClick={onInstructionsTextClick}
+              bottomComponent={
+                exemplarPlayerInsideInstructions &&
+                showExemplarPlayer && (
                   <ExemplarPlayerView
                     playbackEvents={exemplarPlaybackEvents}
                     title={exemplarSettings.playerTitle!}
                     player={player}
                     insideInstructions={exemplarPlayerInsideInstructions}
                   />
-                )}
-              </PanelContainer>
-            )}
+                )
+              }
+              hasRun={hasRun}
+              hasEdited={hasEdited}
+              fixedDarkBackground={true}
+              overrideTheme={'Light'}
+              includeFooterSpacing={false}
+              levelProperties={levelProperties}
+              headerClassName={moduleStyles.headerWithBorder}
+              settings={settings}
+              hideContinueIfDisabled={true}
+              hideNavigation={false}
+              styleNavigationAsBubble={true}
+            />
           </div>
         )}
 
@@ -460,13 +397,7 @@ const MusicLabView: React.FunctionComponent<MusicLabViewProps> = ({
                 hideChaff={hideChaff}
               />
             }
-            headerClassName={
-              experiments.isEnabledAllowingQueryString(
-                experiments.LAB2_RESOURCE_PANEL
-              )
-                ? moduleStyles.headerWithBorder
-                : moduleStyles.panelContainerHeader
-            }
+            headerClassName={moduleStyles.headerWithBorder}
           >
             {isStartMode && (
               <div


### PR DESCRIPTION
This PR graduates the Resource Panel feature in Music Lab by removing the LAB2_RESOURCE_PANEL experiment flag and enabling it by default.

Previously, instructions would conditionally render either the legacy Instructions/InstructionsV2 components or the new ResourcePanel depending on the experiment flag. With this change, ResourcePanel is always shown.

Key updates:
- Removed experiment flag check for ResourcePanel.
- Deleted unused Instructions and InstructionsV2 imports.
- Simplified headerClassName logic to consistently use headerWithBorder.
- Cleaned up conditional rendering paths that are no longer needed.


## Testing story

- Confirmed resource panel appears by default, even when experiment is disabled:

<img width="1513" height="944" alt="Screenshot 2025-10-03 at 9 55 10 AM" src="https://github.com/user-attachments/assets/7668713f-4dc6-4b71-a0aa-7d7c09da7516" />


<img width="1513" height="944" alt="Screenshot 2025-10-03 at 9 59 22 AM" src="https://github.com/user-attachments/assets/e21d2411-c8ef-4b07-bedf-fb64ef08b1b0" />
