### PR TITLE
Remove deprecated course from UI tests pass 4

### DIFF
--- a/dashboard/config/scripts_json/allthethings.script_json
+++ b/dashboard/config/scripts_json/allthethings.script_json
@@ -12,7 +12,7 @@
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2025-09-18 20:00:51 UTC",
+    "serialized_at": "2025-10-03 15:43:09 UTC",
     "hide_within_course": false,
     "published_state": null,
     "instruction_type": null,
@@ -877,21 +877,6 @@
         "lesson_group.key": "",
         "script.name": "allthethings"
       }
-    },
-    {
-      "key": "lesson-57",
-      "name": "Sketch Lab",
-      "absolute_position": 57,
-      "lockable": false,
-      "has_lesson_plan": true,
-      "relative_position": 54,
-      "properties": {
-      },
-      "seeding_key": {
-        "lesson.key": "lesson-57",
-        "lesson_group.key": "",
-        "script.name": "allthethings"
-      }
     }
   ],
   "lesson_activities": [
@@ -1612,18 +1597,6 @@
         "lesson_group.key": "",
         "script.name": "allthethings"
       }
-    },
-    {
-      "key": "9561e8ad-5eb9-4cca-8279-f9cabb9867d1",
-      "position": 1,
-      "properties": {
-      },
-      "seeding_key": {
-        "lesson_activity.key": "9561e8ad-5eb9-4cca-8279-f9cabb9867d1",
-        "lesson.key": "lesson-57",
-        "lesson_group.key": "",
-        "script.name": "allthethings"
-      }
     }
   ],
   "activity_sections": [
@@ -2186,16 +2159,6 @@
         "activity_section.key": "781a45ef-23bb-4d6c-905a-a421acc0752b",
         "lesson_activity.key": "e109ba15-02bd-458f-9adf-31f75dc9d531"
       }
-    },
-    {
-      "key": "b0e19c6d-9bd3-4227-93b2-397e925b9139",
-      "position": 1,
-      "properties": {
-      },
-      "seeding_key": {
-        "activity_section.key": "b0e19c6d-9bd3-4227-93b2-397e925b9139",
-        "lesson_activity.key": "9561e8ad-5eb9-4cca-8279-f9cabb9867d1"
-      }
     }
   ],
   "script_levels": [
@@ -2205,9 +2168,27 @@
       "activity_section_position": 1,
       "assessment": false,
       "properties": {
-        "level_keys": [
-          "blockly:Jigsaw:3"
-        ]
+      },
+      "bonus": false,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Jigsaw:2"
+        ],
+        "lesson.key": "Jigsaw",
+        "lesson_group.key": "",
+        "script.name": "allthethings",
+        "activity_section.key": "758f6dfd-efa4-4432-bdab-61708582e703"
+      },
+      "level_keys": [
+        "blockly:Jigsaw:2"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "activity_section_position": 2,
+      "assessment": false,
+      "properties": {
       },
       "bonus": false,
       "seeding_key": {
@@ -2224,7 +2205,7 @@
       ]
     },
     {
-      "chapter": 2,
+      "chapter": 3,
       "position": 1,
       "activity_section_position": 1,
       "assessment": false,
@@ -2248,7 +2229,7 @@
       ]
     },
     {
-      "chapter": 3,
+      "chapter": 4,
       "position": 2,
       "activity_section_position": 2,
       "assessment": false,
@@ -2272,7 +2253,7 @@
       ]
     },
     {
-      "chapter": 4,
+      "chapter": 5,
       "position": 3,
       "activity_section_position": 3,
       "assessment": false,
@@ -2296,7 +2277,7 @@
       ]
     },
     {
-      "chapter": 5,
+      "chapter": 6,
       "position": 4,
       "activity_section_position": 4,
       "assessment": false,
@@ -2320,7 +2301,7 @@
       ]
     },
     {
-      "chapter": 6,
+      "chapter": 7,
       "position": 5,
       "activity_section_position": 5,
       "assessment": false,
@@ -2344,7 +2325,7 @@
       ]
     },
     {
-      "chapter": 7,
+      "chapter": 8,
       "position": 6,
       "activity_section_position": 6,
       "assessment": false,
@@ -2369,7 +2350,7 @@
       ]
     },
     {
-      "chapter": 8,
+      "chapter": 9,
       "position": 7,
       "activity_section_position": 7,
       "assessment": false,
@@ -2393,7 +2374,7 @@
       ]
     },
     {
-      "chapter": 9,
+      "chapter": 10,
       "position": 1,
       "activity_section_position": 1,
       "assessment": false,
@@ -2417,7 +2398,7 @@
       ]
     },
     {
-      "chapter": 10,
+      "chapter": 11,
       "position": 2,
       "activity_section_position": 2,
       "assessment": false,
@@ -2441,7 +2422,7 @@
       ]
     },
     {
-      "chapter": 11,
+      "chapter": 12,
       "position": 3,
       "activity_section_position": 3,
       "assessment": false,
@@ -2465,7 +2446,7 @@
       ]
     },
     {
-      "chapter": 12,
+      "chapter": 13,
       "position": 4,
       "activity_section_position": 4,
       "assessment": false,
@@ -2489,7 +2470,7 @@
       ]
     },
     {
-      "chapter": 13,
+      "chapter": 14,
       "position": 5,
       "activity_section_position": 5,
       "assessment": false,
@@ -2513,7 +2494,7 @@
       ]
     },
     {
-      "chapter": 14,
+      "chapter": 15,
       "position": 6,
       "activity_section_position": 6,
       "assessment": false,
@@ -2537,7 +2518,7 @@
       ]
     },
     {
-      "chapter": 15,
+      "chapter": 16,
       "position": 7,
       "activity_section_position": 7,
       "assessment": false,
@@ -2561,7 +2542,7 @@
       ]
     },
     {
-      "chapter": 16,
+      "chapter": 17,
       "position": 8,
       "activity_section_position": 8,
       "assessment": false,
@@ -2585,7 +2566,7 @@
       ]
     },
     {
-      "chapter": 17,
+      "chapter": 18,
       "position": 9,
       "activity_section_position": 9,
       "assessment": false,
@@ -2609,7 +2590,7 @@
       ]
     },
     {
-      "chapter": 18,
+      "chapter": 19,
       "position": 1,
       "activity_section_position": 1,
       "assessment": false,
@@ -2633,7 +2614,7 @@
       ]
     },
     {
-      "chapter": 19,
+      "chapter": 20,
       "position": 2,
       "activity_section_position": 2,
       "assessment": false,
@@ -2657,7 +2638,7 @@
       ]
     },
     {
-      "chapter": 20,
+      "chapter": 21,
       "position": 3,
       "activity_section_position": 3,
       "assessment": false,
@@ -2681,7 +2662,7 @@
       ]
     },
     {
-      "chapter": 21,
+      "chapter": 22,
       "position": 4,
       "activity_section_position": 4,
       "assessment": false,
@@ -2705,7 +2686,7 @@
       ]
     },
     {
-      "chapter": 22,
+      "chapter": 23,
       "position": 5,
       "activity_section_position": 5,
       "assessment": false,
@@ -2729,7 +2710,7 @@
       ]
     },
     {
-      "chapter": 23,
+      "chapter": 24,
       "position": 6,
       "activity_section_position": 6,
       "assessment": false,
@@ -2753,7 +2734,7 @@
       ]
     },
     {
-      "chapter": 24,
+      "chapter": 25,
       "position": 1,
       "activity_section_position": 1,
       "assessment": false,
@@ -2777,7 +2758,7 @@
       ]
     },
     {
-      "chapter": 25,
+      "chapter": 26,
       "position": 2,
       "activity_section_position": 2,
       "assessment": false,
@@ -2801,7 +2782,7 @@
       ]
     },
     {
-      "chapter": 26,
+      "chapter": 27,
       "position": 3,
       "activity_section_position": 3,
       "assessment": false,
@@ -2825,7 +2806,7 @@
       ]
     },
     {
-      "chapter": 27,
+      "chapter": 28,
       "position": 4,
       "activity_section_position": 4,
       "assessment": false,
@@ -2849,7 +2830,7 @@
       ]
     },
     {
-      "chapter": 28,
+      "chapter": 29,
       "position": 5,
       "activity_section_position": 5,
       "assessment": false,
@@ -2873,7 +2854,7 @@
       ]
     },
     {
-      "chapter": 29,
+      "chapter": 30,
       "position": 6,
       "activity_section_position": 6,
       "assessment": false,
@@ -2897,7 +2878,7 @@
       ]
     },
     {
-      "chapter": 30,
+      "chapter": 31,
       "position": 1,
       "activity_section_position": 1,
       "assessment": false,
@@ -2921,7 +2902,7 @@
       ]
     },
     {
-      "chapter": 31,
+      "chapter": 32,
       "position": 2,
       "activity_section_position": 2,
       "assessment": false,
@@ -2945,7 +2926,7 @@
       ]
     },
     {
-      "chapter": 32,
+      "chapter": 33,
       "position": 3,
       "activity_section_position": 3,
       "assessment": false,
@@ -2969,7 +2950,7 @@
       ]
     },
     {
-      "chapter": 33,
+      "chapter": 34,
       "position": 1,
       "activity_section_position": 1,
       "assessment": false,
@@ -2993,7 +2974,7 @@
       ]
     },
     {
-      "chapter": 34,
+      "chapter": 35,
       "position": 1,
       "activity_section_position": 1,
       "assessment": false,
@@ -3017,7 +2998,7 @@
       ]
     },
     {
-      "chapter": 35,
+      "chapter": 36,
       "position": 1,
       "activity_section_position": 1,
       "assessment": false,
@@ -3041,7 +3022,7 @@
       ]
     },
     {
-      "chapter": 36,
+      "chapter": 37,
       "position": 2,
       "activity_section_position": 2,
       "assessment": false,
@@ -3065,7 +3046,7 @@
       ]
     },
     {
-      "chapter": 37,
+      "chapter": 38,
       "position": 3,
       "activity_section_position": 3,
       "assessment": false,
@@ -3089,7 +3070,7 @@
       ]
     },
     {
-      "chapter": 38,
+      "chapter": 39,
       "position": 4,
       "activity_section_position": 4,
       "assessment": false,
@@ -3113,7 +3094,7 @@
       ]
     },
     {
-      "chapter": 39,
+      "chapter": 40,
       "position": 5,
       "activity_section_position": 5,
       "assessment": false,
@@ -3137,7 +3118,7 @@
       ]
     },
     {
-      "chapter": 40,
+      "chapter": 41,
       "position": 1,
       "activity_section_position": 1,
       "assessment": false,
@@ -3161,7 +3142,7 @@
       ]
     },
     {
-      "chapter": 41,
+      "chapter": 42,
       "position": 1,
       "activity_section_position": 1,
       "assessment": false,
@@ -3185,7 +3166,7 @@
       ]
     },
     {
-      "chapter": 42,
+      "chapter": 43,
       "position": 1,
       "activity_section_position": 1,
       "assessment": false,
@@ -3209,7 +3190,7 @@
       ]
     },
     {
-      "chapter": 43,
+      "chapter": 44,
       "position": 2,
       "activity_section_position": 2,
       "assessment": false,
@@ -3233,7 +3214,7 @@
       ]
     },
     {
-      "chapter": 44,
+      "chapter": 45,
       "position": 1,
       "activity_section_position": 1,
       "assessment": false,
@@ -3257,7 +3238,7 @@
       ]
     },
     {
-      "chapter": 45,
+      "chapter": 46,
       "position": 1,
       "activity_section_position": 1,
       "assessment": false,
@@ -3281,7 +3262,7 @@
       ]
     },
     {
-      "chapter": 46,
+      "chapter": 47,
       "position": 2,
       "activity_section_position": 2,
       "assessment": false,
@@ -3305,7 +3286,7 @@
       ]
     },
     {
-      "chapter": 47,
+      "chapter": 48,
       "position": 3,
       "activity_section_position": 3,
       "assessment": false,
@@ -3329,7 +3310,7 @@
       ]
     },
     {
-      "chapter": 48,
+      "chapter": 49,
       "position": 4,
       "activity_section_position": 4,
       "assessment": false,
@@ -3353,7 +3334,7 @@
       ]
     },
     {
-      "chapter": 49,
+      "chapter": 50,
       "position": 5,
       "activity_section_position": 5,
       "assessment": false,
@@ -3377,7 +3358,7 @@
       ]
     },
     {
-      "chapter": 50,
+      "chapter": 51,
       "position": 1,
       "activity_section_position": 1,
       "assessment": false,
@@ -3401,7 +3382,7 @@
       ]
     },
     {
-      "chapter": 51,
+      "chapter": 52,
       "position": 1,
       "activity_section_position": 1,
       "assessment": false,
@@ -3425,7 +3406,7 @@
       ]
     },
     {
-      "chapter": 52,
+      "chapter": 53,
       "position": 1,
       "activity_section_position": 1,
       "assessment": false,
@@ -3449,7 +3430,7 @@
       ]
     },
     {
-      "chapter": 53,
+      "chapter": 54,
       "position": 2,
       "activity_section_position": 2,
       "assessment": false,
@@ -3473,7 +3454,7 @@
       ]
     },
     {
-      "chapter": 54,
+      "chapter": 55,
       "position": 3,
       "activity_section_position": 3,
       "assessment": false,
@@ -3497,7 +3478,7 @@
       ]
     },
     {
-      "chapter": 55,
+      "chapter": 56,
       "position": 4,
       "activity_section_position": 4,
       "assessment": false,
@@ -3521,7 +3502,7 @@
       ]
     },
     {
-      "chapter": 56,
+      "chapter": 57,
       "position": 5,
       "activity_section_position": 5,
       "assessment": false,
@@ -3545,7 +3526,7 @@
       ]
     },
     {
-      "chapter": 57,
+      "chapter": 58,
       "position": 1,
       "activity_section_position": 1,
       "assessment": false,
@@ -3569,7 +3550,7 @@
       ]
     },
     {
-      "chapter": 58,
+      "chapter": 59,
       "position": 2,
       "activity_section_position": 2,
       "assessment": false,
@@ -3593,7 +3574,7 @@
       ]
     },
     {
-      "chapter": 59,
+      "chapter": 60,
       "position": 3,
       "activity_section_position": 3,
       "assessment": false,
@@ -3617,7 +3598,7 @@
       ]
     },
     {
-      "chapter": 60,
+      "chapter": 61,
       "position": 4,
       "activity_section_position": 4,
       "assessment": false,
@@ -3641,7 +3622,7 @@
       ]
     },
     {
-      "chapter": 61,
+      "chapter": 62,
       "position": 5,
       "activity_section_position": 5,
       "assessment": false,
@@ -3665,7 +3646,7 @@
       ]
     },
     {
-      "chapter": 62,
+      "chapter": 63,
       "position": 6,
       "activity_section_position": 6,
       "assessment": false,
@@ -3689,7 +3670,7 @@
       ]
     },
     {
-      "chapter": 63,
+      "chapter": 64,
       "position": 7,
       "activity_section_position": 7,
       "assessment": false,
@@ -3713,7 +3694,7 @@
       ]
     },
     {
-      "chapter": 64,
+      "chapter": 65,
       "position": 8,
       "activity_section_position": 8,
       "assessment": false,
@@ -3737,7 +3718,7 @@
       ]
     },
     {
-      "chapter": 65,
+      "chapter": 66,
       "position": 9,
       "activity_section_position": 9,
       "assessment": false,
@@ -3761,7 +3742,7 @@
       ]
     },
     {
-      "chapter": 66,
+      "chapter": 67,
       "position": 10,
       "activity_section_position": 10,
       "assessment": false,
@@ -3785,7 +3766,7 @@
       ]
     },
     {
-      "chapter": 67,
+      "chapter": 68,
       "position": 11,
       "activity_section_position": 11,
       "assessment": false,
@@ -3809,7 +3790,7 @@
       ]
     },
     {
-      "chapter": 68,
+      "chapter": 69,
       "position": 12,
       "activity_section_position": 12,
       "assessment": false,
@@ -3833,7 +3814,7 @@
       ]
     },
     {
-      "chapter": 69,
+      "chapter": 70,
       "position": 13,
       "activity_section_position": 13,
       "assessment": false,
@@ -3857,7 +3838,7 @@
       ]
     },
     {
-      "chapter": 70,
+      "chapter": 71,
       "position": 14,
       "activity_section_position": 14,
       "assessment": false,
@@ -3881,7 +3862,7 @@
       ]
     },
     {
-      "chapter": 71,
+      "chapter": 72,
       "position": 15,
       "activity_section_position": 15,
       "assessment": false,
@@ -3905,7 +3886,7 @@
       ]
     },
     {
-      "chapter": 72,
+      "chapter": 73,
       "position": 16,
       "activity_section_position": 16,
       "assessment": false,
@@ -3929,7 +3910,7 @@
       ]
     },
     {
-      "chapter": 73,
+      "chapter": 74,
       "position": 17,
       "activity_section_position": 17,
       "assessment": false,
@@ -3953,7 +3934,7 @@
       ]
     },
     {
-      "chapter": 74,
+      "chapter": 75,
       "position": 18,
       "activity_section_position": 18,
       "assessment": false,
@@ -3977,7 +3958,7 @@
       ]
     },
     {
-      "chapter": 75,
+      "chapter": 76,
       "position": 19,
       "activity_section_position": 19,
       "assessment": false,
@@ -4001,7 +3982,7 @@
       ]
     },
     {
-      "chapter": 76,
+      "chapter": 77,
       "position": 20,
       "activity_section_position": 20,
       "assessment": false,
@@ -4025,7 +4006,7 @@
       ]
     },
     {
-      "chapter": 77,
+      "chapter": 78,
       "position": 21,
       "activity_section_position": 21,
       "assessment": false,
@@ -4049,7 +4030,7 @@
       ]
     },
     {
-      "chapter": 78,
+      "chapter": 79,
       "position": 22,
       "activity_section_position": 22,
       "assessment": false,
@@ -4073,7 +4054,7 @@
       ]
     },
     {
-      "chapter": 79,
+      "chapter": 80,
       "position": 1,
       "activity_section_position": 1,
       "assessment": false,
@@ -4097,7 +4078,7 @@
       ]
     },
     {
-      "chapter": 80,
+      "chapter": 81,
       "position": 2,
       "activity_section_position": 2,
       "assessment": false,
@@ -4121,7 +4102,7 @@
       ]
     },
     {
-      "chapter": 81,
+      "chapter": 82,
       "position": 3,
       "activity_section_position": 3,
       "assessment": false,
@@ -4145,7 +4126,7 @@
       ]
     },
     {
-      "chapter": 82,
+      "chapter": 83,
       "position": 4,
       "activity_section_position": 4,
       "assessment": false,
@@ -4169,7 +4150,7 @@
       ]
     },
     {
-      "chapter": 83,
+      "chapter": 84,
       "position": 1,
       "activity_section_position": 1,
       "assessment": false,
@@ -4193,7 +4174,7 @@
       ]
     },
     {
-      "chapter": 84,
+      "chapter": 85,
       "position": 2,
       "activity_section_position": 2,
       "assessment": false,
@@ -4217,7 +4198,7 @@
       ]
     },
     {
-      "chapter": 85,
+      "chapter": 86,
       "position": 1,
       "activity_section_position": 1,
       "assessment": false,
@@ -4241,7 +4222,7 @@
       ]
     },
     {
-      "chapter": 86,
+      "chapter": 87,
       "position": 2,
       "activity_section_position": 2,
       "assessment": false,
@@ -4265,7 +4246,7 @@
       ]
     },
     {
-      "chapter": 87,
+      "chapter": 88,
       "position": 3,
       "activity_section_position": 3,
       "assessment": false,
@@ -4289,7 +4270,7 @@
       ]
     },
     {
-      "chapter": 88,
+      "chapter": 89,
       "position": 1,
       "activity_section_position": 1,
       "assessment": false,
@@ -4313,7 +4294,7 @@
       ]
     },
     {
-      "chapter": 89,
+      "chapter": 90,
       "position": 1,
       "activity_section_position": 1,
       "assessment": false,
@@ -4337,7 +4318,7 @@
       ]
     },
     {
-      "chapter": 90,
+      "chapter": 91,
       "position": 2,
       "activity_section_position": 2,
       "assessment": true,
@@ -4361,7 +4342,7 @@
       ]
     },
     {
-      "chapter": 91,
+      "chapter": 92,
       "position": 1,
       "activity_section_position": 1,
       "assessment": false,
@@ -4385,7 +4366,7 @@
       ]
     },
     {
-      "chapter": 92,
+      "chapter": 93,
       "position": 2,
       "activity_section_position": 2,
       "assessment": false,
@@ -4409,7 +4390,7 @@
       ]
     },
     {
-      "chapter": 93,
+      "chapter": 94,
       "position": 1,
       "activity_section_position": 1,
       "assessment": false,
@@ -4433,7 +4414,7 @@
       ]
     },
     {
-      "chapter": 94,
+      "chapter": 95,
       "position": 2,
       "activity_section_position": 2,
       "assessment": false,
@@ -4457,7 +4438,7 @@
       ]
     },
     {
-      "chapter": 95,
+      "chapter": 96,
       "position": 3,
       "activity_section_position": 3,
       "assessment": false,
@@ -4481,7 +4462,7 @@
       ]
     },
     {
-      "chapter": 96,
+      "chapter": 97,
       "position": 1,
       "activity_section_position": 1,
       "assessment": true,
@@ -4505,7 +4486,7 @@
       ]
     },
     {
-      "chapter": 97,
+      "chapter": 98,
       "position": 1,
       "activity_section_position": 1,
       "assessment": false,
@@ -4530,7 +4511,7 @@
       ]
     },
     {
-      "chapter": 98,
+      "chapter": 99,
       "position": 2,
       "activity_section_position": 2,
       "assessment": false,
@@ -4554,7 +4535,7 @@
       ]
     },
     {
-      "chapter": 99,
+      "chapter": 100,
       "position": 3,
       "activity_section_position": 3,
       "assessment": false,
@@ -4578,7 +4559,7 @@
       ]
     },
     {
-      "chapter": 100,
+      "chapter": 101,
       "position": 4,
       "activity_section_position": 4,
       "assessment": false,
@@ -4602,7 +4583,7 @@
       ]
     },
     {
-      "chapter": 101,
+      "chapter": 102,
       "position": 1,
       "activity_section_position": 1,
       "assessment": true,
@@ -4626,7 +4607,7 @@
       ]
     },
     {
-      "chapter": 102,
+      "chapter": 103,
       "position": 1,
       "activity_section_position": 1,
       "assessment": false,
@@ -4658,7 +4639,7 @@
       ]
     },
     {
-      "chapter": 103,
+      "chapter": 104,
       "position": 2,
       "activity_section_position": 2,
       "assessment": false,
@@ -4690,7 +4671,7 @@
       ]
     },
     {
-      "chapter": 104,
+      "chapter": 105,
       "position": 3,
       "activity_section_position": 3,
       "assessment": false,
@@ -4722,7 +4703,7 @@
       ]
     },
     {
-      "chapter": 105,
+      "chapter": 106,
       "position": 4,
       "activity_section_position": 4,
       "assessment": false,
@@ -4754,7 +4735,7 @@
       ]
     },
     {
-      "chapter": 106,
+      "chapter": 107,
       "position": 5,
       "activity_section_position": 5,
       "assessment": false,
@@ -4786,7 +4767,7 @@
       ]
     },
     {
-      "chapter": 107,
+      "chapter": 108,
       "position": 6,
       "activity_section_position": 6,
       "assessment": false,
@@ -4818,7 +4799,7 @@
       ]
     },
     {
-      "chapter": 108,
+      "chapter": 109,
       "position": 7,
       "activity_section_position": 7,
       "assessment": false,
@@ -4850,7 +4831,7 @@
       ]
     },
     {
-      "chapter": 109,
+      "chapter": 110,
       "position": 8,
       "activity_section_position": 8,
       "assessment": false,
@@ -4882,7 +4863,7 @@
       ]
     },
     {
-      "chapter": 110,
+      "chapter": 111,
       "position": 9,
       "activity_section_position": 9,
       "assessment": false,
@@ -4914,7 +4895,7 @@
       ]
     },
     {
-      "chapter": 111,
+      "chapter": 112,
       "position": 1,
       "activity_section_position": 1,
       "assessment": true,
@@ -4938,7 +4919,7 @@
       ]
     },
     {
-      "chapter": 112,
+      "chapter": 113,
       "position": 1,
       "activity_section_position": 1,
       "assessment": true,
@@ -4962,7 +4943,7 @@
       ]
     },
     {
-      "chapter": 113,
+      "chapter": 114,
       "position": 1,
       "activity_section_position": 1,
       "assessment": false,
@@ -4986,7 +4967,7 @@
       ]
     },
     {
-      "chapter": 114,
+      "chapter": 115,
       "position": 2,
       "activity_section_position": 2,
       "assessment": false,
@@ -5010,7 +4991,7 @@
       ]
     },
     {
-      "chapter": 115,
+      "chapter": 116,
       "position": 1,
       "activity_section_position": 1,
       "assessment": false,
@@ -5034,7 +5015,7 @@
       ]
     },
     {
-      "chapter": 116,
+      "chapter": 117,
       "position": 1,
       "activity_section_position": 1,
       "assessment": true,
@@ -5058,7 +5039,7 @@
       ]
     },
     {
-      "chapter": 117,
+      "chapter": 118,
       "position": 1,
       "activity_section_position": 1,
       "assessment": false,
@@ -5082,7 +5063,7 @@
       ]
     },
     {
-      "chapter": 118,
+      "chapter": 119,
       "position": 1,
       "activity_section_position": 1,
       "assessment": false,
@@ -5106,7 +5087,7 @@
       ]
     },
     {
-      "chapter": 119,
+      "chapter": 120,
       "position": 2,
       "activity_section_position": 2,
       "assessment": false,
@@ -5130,7 +5111,7 @@
       ]
     },
     {
-      "chapter": 120,
+      "chapter": 121,
       "position": 1,
       "activity_section_position": 1,
       "assessment": false,
@@ -5154,7 +5135,7 @@
       ]
     },
     {
-      "chapter": 121,
+      "chapter": 122,
       "position": 2,
       "activity_section_position": 2,
       "assessment": false,
@@ -5178,7 +5159,7 @@
       ]
     },
     {
-      "chapter": 122,
+      "chapter": 123,
       "position": 3,
       "activity_section_position": 3,
       "assessment": false,
@@ -5202,7 +5183,7 @@
       ]
     },
     {
-      "chapter": 123,
+      "chapter": 124,
       "position": 4,
       "activity_section_position": 4,
       "assessment": false,
@@ -5226,7 +5207,7 @@
       ]
     },
     {
-      "chapter": 124,
+      "chapter": 125,
       "position": 1,
       "activity_section_position": 1,
       "assessment": false,
@@ -5250,7 +5231,7 @@
       ]
     },
     {
-      "chapter": 125,
+      "chapter": 126,
       "position": 2,
       "activity_section_position": 2,
       "assessment": false,
@@ -5274,7 +5255,7 @@
       ]
     },
     {
-      "chapter": 126,
+      "chapter": 127,
       "position": 3,
       "activity_section_position": 3,
       "assessment": false,
@@ -5298,7 +5279,7 @@
       ]
     },
     {
-      "chapter": 127,
+      "chapter": 128,
       "position": 4,
       "activity_section_position": 4,
       "assessment": false,
@@ -5322,7 +5303,7 @@
       ]
     },
     {
-      "chapter": 128,
+      "chapter": 129,
       "position": 1,
       "activity_section_position": 1,
       "assessment": true,
@@ -5346,7 +5327,7 @@
       ]
     },
     {
-      "chapter": 129,
+      "chapter": 130,
       "position": 2,
       "activity_section_position": 2,
       "assessment": true,
@@ -5370,7 +5351,7 @@
       ]
     },
     {
-      "chapter": 130,
+      "chapter": 131,
       "position": 3,
       "activity_section_position": 3,
       "assessment": true,
@@ -5394,7 +5375,7 @@
       ]
     },
     {
-      "chapter": 131,
+      "chapter": 132,
       "position": 1,
       "activity_section_position": 1,
       "assessment": true,
@@ -5418,7 +5399,7 @@
       ]
     },
     {
-      "chapter": 132,
+      "chapter": 133,
       "position": 1,
       "activity_section_position": 1,
       "assessment": false,
@@ -5442,7 +5423,7 @@
       ]
     },
     {
-      "chapter": 133,
+      "chapter": 134,
       "position": 2,
       "activity_section_position": 2,
       "assessment": false,
@@ -5466,7 +5447,7 @@
       ]
     },
     {
-      "chapter": 134,
+      "chapter": 135,
       "position": 1,
       "activity_section_position": 1,
       "assessment": false,
@@ -5490,7 +5471,7 @@
       ]
     },
     {
-      "chapter": 135,
+      "chapter": 136,
       "position": 1,
       "activity_section_position": 1,
       "assessment": false,
@@ -5514,7 +5495,7 @@
       ]
     },
     {
-      "chapter": 136,
+      "chapter": 137,
       "position": 2,
       "activity_section_position": 2,
       "assessment": false,
@@ -5538,7 +5519,7 @@
       ]
     },
     {
-      "chapter": 137,
+      "chapter": 138,
       "position": 3,
       "activity_section_position": 3,
       "assessment": false,
@@ -5562,7 +5543,7 @@
       ]
     },
     {
-      "chapter": 138,
+      "chapter": 139,
       "position": 4,
       "activity_section_position": 4,
       "assessment": false,
@@ -5586,7 +5567,7 @@
       ]
     },
     {
-      "chapter": 139,
+      "chapter": 140,
       "position": 5,
       "activity_section_position": 5,
       "assessment": false,
@@ -5610,7 +5591,7 @@
       ]
     },
     {
-      "chapter": 140,
+      "chapter": 141,
       "position": 6,
       "activity_section_position": 6,
       "assessment": false,
@@ -5634,7 +5615,7 @@
       ]
     },
     {
-      "chapter": 141,
+      "chapter": 142,
       "position": 7,
       "activity_section_position": 7,
       "assessment": false,
@@ -5658,7 +5639,7 @@
       ]
     },
     {
-      "chapter": 142,
+      "chapter": 143,
       "position": 8,
       "activity_section_position": 8,
       "assessment": false,
@@ -5682,7 +5663,7 @@
       ]
     },
     {
-      "chapter": 143,
+      "chapter": 144,
       "position": 9,
       "activity_section_position": 9,
       "assessment": false,
@@ -5706,7 +5687,7 @@
       ]
     },
     {
-      "chapter": 144,
+      "chapter": 145,
       "position": 10,
       "activity_section_position": 10,
       "assessment": false,
@@ -5730,7 +5711,7 @@
       ]
     },
     {
-      "chapter": 145,
+      "chapter": 146,
       "position": 1,
       "activity_section_position": 1,
       "assessment": false,
@@ -5754,7 +5735,7 @@
       ]
     },
     {
-      "chapter": 146,
+      "chapter": 147,
       "position": 1,
       "activity_section_position": 1,
       "assessment": false,
@@ -5778,7 +5759,7 @@
       ]
     },
     {
-      "chapter": 147,
+      "chapter": 148,
       "position": 2,
       "activity_section_position": 2,
       "assessment": false,
@@ -5802,7 +5783,7 @@
       ]
     },
     {
-      "chapter": 148,
+      "chapter": 149,
       "position": 1,
       "activity_section_position": 1,
       "assessment": false,
@@ -5826,7 +5807,7 @@
       ]
     },
     {
-      "chapter": 149,
+      "chapter": 150,
       "position": 2,
       "activity_section_position": 2,
       "assessment": false,
@@ -5850,7 +5831,7 @@
       ]
     },
     {
-      "chapter": 150,
+      "chapter": 151,
       "position": 3,
       "activity_section_position": 3,
       "assessment": false,
@@ -5874,7 +5855,7 @@
       ]
     },
     {
-      "chapter": 151,
+      "chapter": 152,
       "position": 4,
       "activity_section_position": 4,
       "assessment": false,
@@ -5898,7 +5879,7 @@
       ]
     },
     {
-      "chapter": 152,
+      "chapter": 153,
       "position": 5,
       "activity_section_position": 5,
       "assessment": false,
@@ -5922,7 +5903,7 @@
       ]
     },
     {
-      "chapter": 153,
+      "chapter": 154,
       "position": 6,
       "activity_section_position": 6,
       "assessment": false,
@@ -5946,7 +5927,7 @@
       ]
     },
     {
-      "chapter": 154,
+      "chapter": 155,
       "position": 7,
       "activity_section_position": 7,
       "assessment": false,
@@ -5970,7 +5951,7 @@
       ]
     },
     {
-      "chapter": 155,
+      "chapter": 156,
       "position": 8,
       "activity_section_position": 8,
       "assessment": false,
@@ -5994,7 +5975,7 @@
       ]
     },
     {
-      "chapter": 156,
+      "chapter": 157,
       "position": 9,
       "activity_section_position": 10,
       "assessment": false,
@@ -6018,7 +5999,7 @@
       ]
     },
     {
-      "chapter": 157,
+      "chapter": 158,
       "position": 10,
       "activity_section_position": 11,
       "assessment": false,
@@ -6042,7 +6023,7 @@
       ]
     },
     {
-      "chapter": 158,
+      "chapter": 159,
       "position": 11,
       "activity_section_position": 12,
       "assessment": false,
@@ -6066,7 +6047,7 @@
       ]
     },
     {
-      "chapter": 159,
+      "chapter": 160,
       "position": 12,
       "activity_section_position": 13,
       "assessment": false,
@@ -6090,7 +6071,7 @@
       ]
     },
     {
-      "chapter": 160,
+      "chapter": 161,
       "position": 1,
       "activity_section_position": 1,
       "assessment": true,
@@ -6114,7 +6095,7 @@
       ]
     },
     {
-      "chapter": 161,
+      "chapter": 162,
       "position": 1,
       "activity_section_position": 1,
       "assessment": false,
@@ -6138,7 +6119,7 @@
       ]
     },
     {
-      "chapter": 162,
+      "chapter": 163,
       "position": 2,
       "activity_section_position": 2,
       "assessment": false,
@@ -6162,7 +6143,7 @@
       ]
     },
     {
-      "chapter": 163,
+      "chapter": 164,
       "position": 3,
       "activity_section_position": 3,
       "assessment": false,
@@ -6186,7 +6167,7 @@
       ]
     },
     {
-      "chapter": 164,
+      "chapter": 165,
       "position": 4,
       "activity_section_position": 4,
       "assessment": false,
@@ -6210,7 +6191,7 @@
       ]
     },
     {
-      "chapter": 165,
+      "chapter": 166,
       "position": 1,
       "activity_section_position": 1,
       "assessment": false,
@@ -6234,7 +6215,7 @@
       ]
     },
     {
-      "chapter": 166,
+      "chapter": 167,
       "position": 2,
       "activity_section_position": 2,
       "assessment": false,
@@ -6258,7 +6239,7 @@
       ]
     },
     {
-      "chapter": 167,
+      "chapter": 168,
       "position": 3,
       "activity_section_position": 3,
       "assessment": false,
@@ -6282,7 +6263,7 @@
       ]
     },
     {
-      "chapter": 168,
+      "chapter": 169,
       "position": 4,
       "activity_section_position": 4,
       "assessment": false,
@@ -6306,7 +6287,7 @@
       ]
     },
     {
-      "chapter": 169,
+      "chapter": 170,
       "position": 5,
       "activity_section_position": 5,
       "assessment": false,
@@ -6330,7 +6311,7 @@
       ]
     },
     {
-      "chapter": 170,
+      "chapter": 171,
       "position": 6,
       "activity_section_position": 6,
       "assessment": false,
@@ -6354,7 +6335,7 @@
       ]
     },
     {
-      "chapter": 171,
+      "chapter": 172,
       "position": 7,
       "activity_section_position": 7,
       "assessment": false,
@@ -6378,7 +6359,7 @@
       ]
     },
     {
-      "chapter": 172,
+      "chapter": 173,
       "position": 8,
       "activity_section_position": 8,
       "assessment": false,
@@ -6402,7 +6383,7 @@
       ]
     },
     {
-      "chapter": 173,
+      "chapter": 174,
       "position": 9,
       "activity_section_position": 9,
       "assessment": false,
@@ -6426,7 +6407,7 @@
       ]
     },
     {
-      "chapter": 174,
+      "chapter": 175,
       "position": 10,
       "activity_section_position": 10,
       "assessment": false,
@@ -6450,7 +6431,7 @@
       ]
     },
     {
-      "chapter": 175,
+      "chapter": 176,
       "position": 11,
       "activity_section_position": 11,
       "assessment": false,
@@ -6474,7 +6455,7 @@
       ]
     },
     {
-      "chapter": 176,
+      "chapter": 177,
       "position": 1,
       "activity_section_position": 1,
       "assessment": false,
@@ -6498,7 +6479,7 @@
       ]
     },
     {
-      "chapter": 177,
+      "chapter": 178,
       "position": 2,
       "activity_section_position": 2,
       "assessment": false,
@@ -6522,7 +6503,7 @@
       ]
     },
     {
-      "chapter": 178,
+      "chapter": 179,
       "position": 3,
       "activity_section_position": 3,
       "assessment": false,
@@ -6546,7 +6527,7 @@
       ]
     },
     {
-      "chapter": 179,
+      "chapter": 180,
       "position": 4,
       "activity_section_position": 4,
       "assessment": false,
@@ -6570,7 +6551,7 @@
       ]
     },
     {
-      "chapter": 180,
+      "chapter": 181,
       "position": 5,
       "activity_section_position": 5,
       "assessment": false,
@@ -6594,7 +6575,7 @@
       ]
     },
     {
-      "chapter": 181,
+      "chapter": 182,
       "position": 6,
       "activity_section_position": 6,
       "assessment": false,
@@ -6618,7 +6599,7 @@
       ]
     },
     {
-      "chapter": 182,
+      "chapter": 183,
       "position": 7,
       "activity_section_position": 7,
       "assessment": false,
@@ -6642,7 +6623,7 @@
       ]
     },
     {
-      "chapter": 183,
+      "chapter": 184,
       "position": 1,
       "activity_section_position": 1,
       "assessment": false,
@@ -6666,7 +6647,7 @@
       ]
     },
     {
-      "chapter": 184,
+      "chapter": 185,
       "position": 2,
       "activity_section_position": 2,
       "assessment": true,
@@ -6690,7 +6671,7 @@
       ]
     },
     {
-      "chapter": 185,
+      "chapter": 186,
       "position": 1,
       "activity_section_position": 1,
       "assessment": false,
@@ -6714,7 +6695,7 @@
       ]
     },
     {
-      "chapter": 186,
+      "chapter": 187,
       "position": 2,
       "activity_section_position": 2,
       "assessment": false,
@@ -6738,7 +6719,7 @@
       ]
     },
     {
-      "chapter": 187,
+      "chapter": 188,
       "position": 1,
       "activity_section_position": 1,
       "assessment": false,
@@ -6762,7 +6743,7 @@
       ]
     },
     {
-      "chapter": 188,
+      "chapter": 189,
       "position": 2,
       "activity_section_position": 2,
       "assessment": false,
@@ -6786,7 +6767,7 @@
       ]
     },
     {
-      "chapter": 189,
+      "chapter": 190,
       "position": 3,
       "activity_section_position": 3,
       "assessment": false,
@@ -6810,7 +6791,7 @@
       ]
     },
     {
-      "chapter": 190,
+      "chapter": 191,
       "position": 4,
       "activity_section_position": 4,
       "assessment": false,
@@ -6834,7 +6815,7 @@
       ]
     },
     {
-      "chapter": 191,
+      "chapter": 192,
       "position": 5,
       "activity_section_position": 5,
       "assessment": false,
@@ -6858,7 +6839,7 @@
       ]
     },
     {
-      "chapter": 192,
+      "chapter": 193,
       "position": 6,
       "activity_section_position": 6,
       "assessment": false,
@@ -6882,7 +6863,7 @@
       ]
     },
     {
-      "chapter": 193,
+      "chapter": 194,
       "position": 7,
       "activity_section_position": 7,
       "assessment": false,
@@ -6906,7 +6887,7 @@
       ]
     },
     {
-      "chapter": 194,
+      "chapter": 195,
       "position": 8,
       "activity_section_position": 8,
       "assessment": false,
@@ -6930,7 +6911,7 @@
       ]
     },
     {
-      "chapter": 195,
+      "chapter": 196,
       "position": 9,
       "activity_section_position": 9,
       "assessment": false,
@@ -6954,7 +6935,7 @@
       ]
     },
     {
-      "chapter": 196,
+      "chapter": 197,
       "position": 10,
       "activity_section_position": 10,
       "assessment": false,
@@ -6978,7 +6959,7 @@
       ]
     },
     {
-      "chapter": 197,
+      "chapter": 198,
       "position": 11,
       "activity_section_position": 11,
       "assessment": false,
@@ -7002,7 +6983,7 @@
       ]
     },
     {
-      "chapter": 198,
+      "chapter": 199,
       "position": 12,
       "activity_section_position": 12,
       "assessment": false,
@@ -7026,7 +7007,7 @@
       ]
     },
     {
-      "chapter": 199,
+      "chapter": 200,
       "position": 1,
       "activity_section_position": 1,
       "assessment": false,
@@ -7050,7 +7031,7 @@
       ]
     },
     {
-      "chapter": 200,
+      "chapter": 201,
       "position": 2,
       "activity_section_position": 2,
       "assessment": false,
@@ -7074,7 +7055,7 @@
       ]
     },
     {
-      "chapter": 201,
+      "chapter": 202,
       "position": 3,
       "activity_section_position": 3,
       "assessment": false,
@@ -7098,7 +7079,7 @@
       ]
     },
     {
-      "chapter": 202,
+      "chapter": 203,
       "position": 4,
       "activity_section_position": 4,
       "assessment": false,
@@ -7122,7 +7103,7 @@
       ]
     },
     {
-      "chapter": 203,
+      "chapter": 204,
       "position": 5,
       "activity_section_position": 5,
       "assessment": false,
@@ -7146,7 +7127,7 @@
       ]
     },
     {
-      "chapter": 204,
+      "chapter": 205,
       "position": 6,
       "activity_section_position": 6,
       "assessment": false,
@@ -7170,7 +7151,7 @@
       ]
     },
     {
-      "chapter": 205,
+      "chapter": 206,
       "position": 7,
       "activity_section_position": 7,
       "assessment": false,
@@ -7194,7 +7175,7 @@
       ]
     },
     {
-      "chapter": 206,
+      "chapter": 207,
       "position": 8,
       "activity_section_position": 8,
       "assessment": false,
@@ -7218,7 +7199,7 @@
       ]
     },
     {
-      "chapter": 207,
+      "chapter": 208,
       "position": 9,
       "activity_section_position": 9,
       "assessment": false,
@@ -7239,27 +7220,6 @@
       },
       "level_keys": [
         "Allthethings Weblab2 9"
-      ]
-    },
-    {
-      "chapter": 208,
-      "position": 10,
-      "activity_section_position": 10,
-      "assessment": false,
-      "properties": {
-      },
-      "bonus": false,
-      "seeding_key": {
-        "script_level.level_keys": [
-          "Allthethings Weblab2 10"
-        ],
-        "lesson.key": "lesson-54",
-        "lesson_group.key": "",
-        "script.name": "allthethings",
-        "activity_section.key": "b26e8309-b1a7-486a-9490-96d4ddd8b9aa"
-      },
-      "level_keys": [
-        "Allthethings Weblab2 10"
       ]
     },
     {
@@ -7501,30 +7461,21 @@
       "level_keys": [
         "test-levelgroup-activityguide-2"
       ]
-    },
-    {
-      "chapter": 218,
-      "position": 1,
-      "activity_section_position": 1,
-      "assessment": false,
-      "properties": {
-      },
-      "bonus": false,
-      "seeding_key": {
-        "script_level.level_keys": [
-          "allthethings sketchlab 1"
-        ],
-        "lesson.key": "lesson-57",
-        "lesson_group.key": "",
-        "script.name": "allthethings",
-        "activity_section.key": "b0e19c6d-9bd3-4227-93b2-397e925b9139"
-      },
-      "level_keys": [
-        "allthethings sketchlab 1"
-      ]
     }
   ],
   "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "blockly:Jigsaw:2",
+        "script_level.level_keys": [
+          "blockly:Jigsaw:2"
+        ],
+        "lesson.key": "Jigsaw",
+        "lesson_group.key": "",
+        "script.name": "allthethings",
+        "activity_section.key": "758f6dfd-efa4-4432-bdab-61708582e703"
+      }
+    },
     {
       "seeding_key": {
         "level.key": "blockly:Jigsaw:3",
@@ -10137,18 +10088,6 @@
     },
     {
       "seeding_key": {
-        "level.key": "Allthethings Weblab2 10",
-        "script_level.level_keys": [
-          "Allthethings Weblab2 10"
-        ],
-        "lesson.key": "lesson-54",
-        "lesson_group.key": "",
-        "script.name": "allthethings",
-        "activity_section.key": "b26e8309-b1a7-486a-9490-96d4ddd8b9aa"
-      }
-    },
-    {
-      "seeding_key": {
         "level.key": "Music Lab2 Showcase",
         "script_level.level_keys": [
           "Music Lab2 Showcase"
@@ -10265,18 +10204,6 @@
         "lesson_group.key": "",
         "script.name": "allthethings",
         "activity_section.key": "781a45ef-23bb-4d6c-905a-a421acc0752b"
-      }
-    },
-    {
-      "seeding_key": {
-        "level.key": "allthethings sketchlab 1",
-        "script_level.level_keys": [
-          "allthethings sketchlab 1"
-        ],
-        "lesson.key": "lesson-57",
-        "lesson_group.key": "",
-        "script.name": "allthethings",
-        "activity_section.key": "b0e19c6d-9bd3-4227-93b2-397e925b9139"
       }
     }
   ],

--- a/dashboard/config/scripts_json/allthethings.script_json
+++ b/dashboard/config/scripts_json/allthethings.script_json
@@ -877,6 +877,21 @@
         "lesson_group.key": "",
         "script.name": "allthethings"
       }
+    },
+    {
+      "key": "lesson-57",
+      "name": "Sketch Lab",
+      "absolute_position": 57,
+      "lockable": false,
+      "has_lesson_plan": true,
+      "relative_position": 54,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "lesson-57",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      }
     }
   ],
   "lesson_activities": [
@@ -1597,6 +1612,18 @@
         "lesson_group.key": "",
         "script.name": "allthethings"
       }
+    },
+    {
+      "key": "9561e8ad-5eb9-4cca-8279-f9cabb9867d1",
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_activity.key": "9561e8ad-5eb9-4cca-8279-f9cabb9867d1",
+        "lesson.key": "lesson-57",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      }
     }
   ],
   "activity_sections": [
@@ -2158,6 +2185,16 @@
       "seeding_key": {
         "activity_section.key": "781a45ef-23bb-4d6c-905a-a421acc0752b",
         "lesson_activity.key": "e109ba15-02bd-458f-9adf-31f75dc9d531"
+      }
+    },
+    {
+      "key": "b0e19c6d-9bd3-4227-93b2-397e925b9139",
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "activity_section.key": "b0e19c6d-9bd3-4227-93b2-397e925b9139",
+        "lesson_activity.key": "9561e8ad-5eb9-4cca-8279-f9cabb9867d1"
       }
     }
   ],
@@ -10088,6 +10125,18 @@
     },
     {
       "seeding_key": {
+        "level.key": "Allthethings Weblab2 10",
+        "script_level.level_keys": [
+          "Allthethings Weblab2 10"
+        ],
+        "lesson.key": "lesson-54",
+        "lesson_group.key": "",
+        "script.name": "allthethings",
+        "activity_section.key": "b26e8309-b1a7-486a-9490-96d4ddd8b9aa"
+      }
+    },
+    {
+      "seeding_key": {
         "level.key": "Music Lab2 Showcase",
         "script_level.level_keys": [
           "Music Lab2 Showcase"
@@ -10204,6 +10253,18 @@
         "lesson_group.key": "",
         "script.name": "allthethings",
         "activity_section.key": "781a45ef-23bb-4d6c-905a-a421acc0752b"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "allthethings sketchlab 1",
+        "script_level.level_keys": [
+          "allthethings sketchlab 1"
+        ],
+        "lesson.key": "lesson-57",
+        "lesson_group.key": "",
+        "script.name": "allthethings",
+        "activity_section.key": "b0e19c6d-9bd3-4227-93b2-397e925b9139"
       }
     }
   ],

--- a/dashboard/config/scripts_json/allthethings.script_json
+++ b/dashboard/config/scripts_json/allthethings.script_json
@@ -7261,6 +7261,27 @@
     },
     {
       "chapter": 209,
+      "position": 10,
+      "activity_section_position": 10,
+      "assessment": false,
+      "properties": {
+      },
+      "bonus": false,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Allthethings Weblab2 10"
+        ],
+        "lesson.key": "lesson-54",
+        "lesson_group.key": "",
+        "script.name": "allthethings",
+        "activity_section.key": "b26e8309-b1a7-486a-9490-96d4ddd8b9aa"
+      },
+      "level_keys": [
+        "Allthethings Weblab2 10"
+      ]
+    },
+    {
+      "chapter": 210,
       "position": 1,
       "activity_section_position": 1,
       "assessment": false,
@@ -7284,7 +7305,7 @@
       ]
     },
     {
-      "chapter": 210,
+      "chapter": 211,
       "position": 2,
       "activity_section_position": 2,
       "assessment": false,
@@ -7308,7 +7329,7 @@
       ]
     },
     {
-      "chapter": 211,
+      "chapter": 212,
       "position": 3,
       "activity_section_position": 3,
       "assessment": false,
@@ -7332,7 +7353,7 @@
       ]
     },
     {
-      "chapter": 212,
+      "chapter": 213,
       "position": 4,
       "activity_section_position": 4,
       "assessment": false,
@@ -7356,7 +7377,7 @@
       ]
     },
     {
-      "chapter": 213,
+      "chapter": 214,
       "position": 5,
       "activity_section_position": 5,
       "assessment": false,
@@ -7380,7 +7401,7 @@
       ]
     },
     {
-      "chapter": 214,
+      "chapter": 215,
       "position": 6,
       "activity_section_position": 6,
       "assessment": false,
@@ -7404,7 +7425,7 @@
       ]
     },
     {
-      "chapter": 215,
+      "chapter": 216,
       "position": 7,
       "activity_section_position": 7,
       "assessment": false,
@@ -7428,7 +7449,7 @@
       ]
     },
     {
-      "chapter": 216,
+      "chapter": 217,
       "position": 8,
       "activity_section_position": 8,
       "assessment": false,
@@ -7452,7 +7473,7 @@
       ]
     },
     {
-      "chapter": 217,
+      "chapter": 218,
       "position": 1,
       "activity_section_position": 1,
       "assessment": false,
@@ -7476,7 +7497,7 @@
       ]
     },
     {
-      "chapter": 218,
+      "chapter": 219,
       "position": 2,
       "activity_section_position": 2,
       "assessment": true,
@@ -7497,6 +7518,27 @@
       },
       "level_keys": [
         "test-levelgroup-activityguide-2"
+      ]
+    },
+    {
+      "chapter": 219,
+      "position": 1,
+      "activity_section_position": 1,
+      "assessment": false,
+      "properties": {
+      },
+      "bonus": false,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "allthethings sketchlab 1"
+        ],
+        "lesson.key": "lesson-57",
+        "lesson_group.key": "",
+        "script.name": "allthethings",
+        "activity_section.key": "b0e19c6d-9bd3-4227-93b2-397e925b9139"
+      },
+      "level_keys": [
+        "allthethings sketchlab 1"
       ]
     }
   ],

--- a/dashboard/test/ui/features/star_labs/jigsaw.feature
+++ b/dashboard/test/ui/features/star_labs/jigsaw.feature
@@ -1,7 +1,7 @@
 Feature: Visiting a jigsaw page
 
 Background:
-  Given I am on "http://studio.code.org/courses/course1/units/1/lessons/3/levels/1?noautoplay=1"
+  Given I am on "http://studio.code.org/courses/allthethingscourse/units/1/lessons/1/levels/1?noautoplay=1"
   And I wait for the lab page to fully load
 
 Scenario: Loading the first jigsaw level

--- a/dashboard/test/ui/features/star_labs/jigsaw2.feature
+++ b/dashboard/test/ui/features/star_labs/jigsaw2.feature
@@ -1,7 +1,7 @@
 Feature: Solving a jigsaw puzzle
 
 Background:
-  Given I am on "http://studio.code.org/courses/allthethingscourse/units/1/lessons/1/levels/1?noautoplay=1"
+  Given I am on "http://studio.code.org/courses/allthethingscourse/units/1/lessons/1/levels/2?noautoplay=1"
   And I wait for the lab page to fully load
 
 Scenario: Solving puzzle


### PR DESCRIPTION
Another pass at removing Courses 1-4 and Accelerated from our UI tests (tracked in [this spreadsheet](https://docs.google.com/spreadsheets/d/1c5xWmlPPXZG7f6TP2bk1WaZnlwIa5fSO8tP1aOrZnhs/edit?gid=0#gid=0)).

## Links
Jira ticket: [here](https://codedotorg.atlassian.net/jira/software/projects/AITT/boards/70?jql=assignee%20%3D%2060d62161f65054006980bd71&selectedIssue=AITT-1231)
Previous UI test pass from Bethany: [here](https://github.com/code-dot-org/code-dot-org/pull/68694)

## Testing story
Passing drone build.
