### PR TITLE
Music: resource panel instructions width

### DIFF
--- a/apps/src/music/views/music-view.module.scss
+++ b/apps/src/music/views/music-view.module.scss
@@ -80,7 +80,7 @@ $default-spacing: 2px;
   &.instructionsSide {
     flex-direction: column;
     height: 100%;
-    width: 20%;
+    width: calc(20% + 3.5rem);
   }
 }
 

--- a/apps/src/music/views/music-view.module.scss
+++ b/apps/src/music/views/music-view.module.scss
@@ -80,7 +80,7 @@ $default-spacing: 2px;
   &.instructionsSide {
     flex-direction: column;
     height: 100%;
-    width: calc(20% + 3.5rem);
+    width: calc(3.5rem + 20%);
   }
 }
 


### PR DESCRIPTION
With this change, Music Lab instructions will retain their previous width after the resource panel is turned on.

Here are examples at 1024px width:

### pre-Resource Panel

<img width="1020" height="499" alt="Screenshot 2025-10-03 at 9 37 19 AM" src="https://github.com/user-attachments/assets/82db9f7c-bdc6-453b-bb13-dc4782edb79a" />

### with Resource Panel, before

<img width="1020" height="499" alt="Screenshot 2025-10-03 at 9 34 57 AM" src="https://github.com/user-attachments/assets/95ff35d3-4d8d-4d0a-8acb-3ff6e9f547dd" />

### with Resource Panel, after

<img width="1020" height="499" alt="Screenshot 2025-10-03 at 9 35 39 AM" src="https://github.com/user-attachments/assets/8fa7ff42-2b0f-4e24-b96e-6efc59f2f920" />

