### PR TITLE
HoAI: Standalone multi-project

### DIFF
--- a/apps/src/bubbleChoice/BackToParentProject.tsx
+++ b/apps/src/bubbleChoice/BackToParentProject.tsx
@@ -1,0 +1,16 @@
+import {Button, ButtonProps} from '@code-dot-org/component-library/button';
+import React from 'react';
+
+import {useMultiProject} from '../lab2/projects/MultiProjectContainer';
+
+const BackToParentProject: React.FC<ButtonProps> = props => {
+  const multiProject = useMultiProject();
+
+  if (!multiProject) {
+    return null;
+  }
+
+  return <Button {...props} onClick={() => multiProject.backToParent()} />;
+};
+
+export default BackToParentProject;

--- a/apps/src/bubbleChoice/BubbleChoice.tsx
+++ b/apps/src/bubbleChoice/BubbleChoice.tsx
@@ -9,7 +9,10 @@ import classNames from 'classnames';
 import _ from 'lodash';
 import React, {useEffect, useMemo, useRef} from 'react';
 
-import {navigateToLevelId} from '@cdo/apps/code-studio/progressRedux';
+import {
+  navigateToLevelId,
+  setCurrentLevelId,
+} from '@cdo/apps/code-studio/progressRedux';
 import {levelById} from '@cdo/apps/code-studio/progressReduxSelectors';
 import continueOrFinishLesson from '@cdo/apps/lab2/progress/continueOrFinishLesson';
 import {
@@ -22,6 +25,7 @@ import ProgressBubble from '@cdo/apps/templates/progress/ProgressBubble';
 import {useAppDispatch, useAppSelector} from '@cdo/apps/util/reduxHooks';
 import {LevelStatus} from '@cdo/generated-scripts/sharedConstants';
 
+import notifyLevelChange from '../lab2/utils/notifyLevelChange';
 import {commonI18n} from '../types/locale';
 
 import styles from './BubbleChoice.module.scss';
@@ -126,6 +130,14 @@ const BubbleChoice: React.FC<LabProps> = ({levelProperties}) => {
   const navigateToSublevel = (sublevel: BubbleChoiceSublevel) => {
     if (currentLessonId) {
       dispatch(navigateToLevelId(sublevel.level_id));
+    } else if (levelProperties.isProjectLevel) {
+      // For BubbleChoice project levels, set the level ID in redux, and let the
+      // MultiProjectContainer handle switching projects. The standard progress redux
+      // system does not work for project levels since there is no progress, lesson, etc.
+      dispatch(setCurrentLevelId(sublevel.level_id));
+      // TODO: This is a dupe of code in navigateToLevelId(). Can we consolidate?
+      notifyLevelChange(String(levelProperties.id), sublevel.level_id);
+      // TODO: Handle browser navigation.
     } else {
       window.location.href = sublevel.url;
     }

--- a/apps/src/dance/lab2/views/DanceView.tsx
+++ b/apps/src/dance/lab2/views/DanceView.tsx
@@ -18,6 +18,7 @@ import {
   getToolboxDefinition,
   workspaceToToolboxDefinition,
 } from '@cdo/apps/blockly/utils/toolbox';
+import BackToParentProject from '@cdo/apps/bubbleChoice/BackToParentProject';
 import {saveReplayLog} from '@cdo/apps/code-studio/components/shareDialogRedux';
 import {queryParams} from '@cdo/apps/code-studio/utils';
 import defaultSources from '@cdo/apps/dance/blockly/defaultSources.json';
@@ -508,6 +509,14 @@ const DanceView: React.FunctionComponent<{
             moduleStyles.visualizationArea,
             aiGenerateMode && moduleStyles.jumbo
           )}
+          leftHeaderContent={
+            <BackToParentProject
+              text="Go to Hub"
+              iconLeft={{iconName: 'home'}}
+              type="secondary"
+              size="s"
+            />
+          }
         >
           <div className={moduleStyles.visualizationColumn}>
             {!usingMusicProject && currentSources.selectedSong && (

--- a/apps/src/dance/lab2/views/GenerateDancer.tsx
+++ b/apps/src/dance/lab2/views/GenerateDancer.tsx
@@ -3,6 +3,7 @@ import {useTheme} from '@code-dot-org/component-library/common/contexts';
 import {Heading5} from '@code-dot-org/component-library/typography';
 import React, {useCallback, useEffect, useState} from 'react';
 
+import BackToParentProject from '@cdo/apps/bubbleChoice/BackToParentProject';
 import {getGeneratedDancerAssets} from '@cdo/apps/dance/lottie/LottieDancerUtils';
 import useLifecycleNotifier from '@cdo/apps/lab2/hooks/useLifecycleNotifier';
 import continueOrFinishLesson from '@cdo/apps/lab2/progress/continueOrFinishLesson';
@@ -221,6 +222,12 @@ const GenerateDancer: React.FunctionComponent<DancerGenerateProps> = ({
             />
           </>
         )}
+        <BackToParentProject
+          text="Go to Hub"
+          iconLeft={{iconName: 'home'}}
+          type="secondary"
+          size="s"
+        />
       </Guide>
 
       <div className={moduleStyles.dancerContainer}>

--- a/apps/src/lab2/lab2Redux.ts
+++ b/apps/src/lab2/lab2Redux.ts
@@ -161,8 +161,6 @@ export const setUpWithLevel = createAsyncThunk<
       .getMetricsReporter()
       .updateProperties({appName: levelProperties.appName});
 
-    const {isProjectLevel, usesProjects} = levelProperties;
-
     Lab2Registry.getInstance().setAppName(levelProperties.appName);
 
     // If we are cached, and there is a user app options path because we are in a script
@@ -179,7 +177,7 @@ export const setUpWithLevel = createAsyncThunk<
       }
     }
 
-    if (!usesProjects) {
+    if (!levelProperties.usesProjects) {
       // If projects are disabled on this level, we can skip loading projects data.
       setProjectAndLevelData(
         {levelProperties},
@@ -219,18 +217,17 @@ export const setUpWithLevel = createAsyncThunk<
     // Create a new project manager. If we have a channel id,
     // default to loading the project for that channel. Otherwise
     // create a project manager for the given level and script id.
-    const projectManager =
-      payload.channelId && isProjectLevel
-        ? ProjectManagerFactory.getProjectManager(
-            payload.channelId,
-            thunkAPI.getState().lab.isShareView
-          )
-        : await ProjectManagerFactory.getProjectManagerForLevel(
-            payload.levelId,
-            payload.userId,
-            payload.scriptId,
-            payload.scriptLevelId
-          );
+    const projectManager = payload.channelId
+      ? ProjectManagerFactory.getProjectManager(
+          payload.channelId,
+          thunkAPI.getState().lab.isShareView
+        )
+      : await ProjectManagerFactory.getProjectManagerForLevel(
+          payload.levelId,
+          payload.userId,
+          payload.scriptId,
+          payload.scriptLevelId
+        );
 
     // Only set the project manager and initiate load
     // if this request hasn't been cancelled.

--- a/apps/src/lab2/projects/MultiProjectContainer.tsx
+++ b/apps/src/lab2/projects/MultiProjectContainer.tsx
@@ -1,0 +1,97 @@
+import React, {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useState,
+} from 'react';
+
+import {setCurrentLevelId} from '@cdo/apps/code-studio/progressRedux';
+import {useAppDispatch, useAppSelector} from '@cdo/apps/util/reduxHooks';
+
+import notifyLevelChange from '../utils/notifyLevelChange';
+
+import ProjectContainer from './ProjectContainer';
+import {getStandaloneProjectId} from './utils';
+
+const MultiProjectContext = createContext<{
+  backToParent: () => void;
+} | null>(null);
+
+export function useMultiProject() {
+  return useContext(MultiProjectContext);
+}
+
+/**
+ * Wrapper around {@link ProjectContainer} that allows the Lab2 system to switch between
+ * projects in a multi-project context. This is currently only supported for standalone
+ * BubbleChoice projects. If the current level/project is not one of these, the context
+ * is not rendered and we pass through to {@link ProjectContainer} directly.
+ */
+const MultiProjectContainer: React.FC<{children: React.ReactNode}> = ({
+  children,
+}) => {
+  const [currentProjectId, setCurrentProjectId] = useState(
+    getStandaloneProjectId()
+  );
+  const [parentLevelId, setParentLevelId] = useState<number>();
+  const [levelProjectMap, setLevelProjectMap] = useState<{
+    [levelId: number]: string;
+  }>();
+
+  const levelProperties = useAppSelector(state => state.lab.levelProperties);
+  const channel = useAppSelector(state => state.lab.channel);
+  const currentLevelId = useAppSelector(state => state.progress.currentLevelId);
+
+  useEffect(() => {
+    if (
+      levelProperties?.appName === 'bubble_choice' &&
+      levelProperties?.isProjectLevel &&
+      !!channel?.subprojects
+    ) {
+      const map = {
+        [levelProperties.id]: channel.id,
+      };
+      channel.subprojects.forEach(subproject => {
+        map[subproject.level_id] = subproject.project_id;
+      });
+      setLevelProjectMap(map);
+      setParentLevelId(levelProperties.id);
+    }
+  }, [levelProperties, channel]);
+
+  // When the level ID changes, update the current project ID if we have a mapping for it.
+  useEffect(() => {
+    if (levelProjectMap && currentLevelId) {
+      setCurrentProjectId(levelProjectMap[parseInt(currentLevelId)]);
+    }
+  }, [currentLevelId, setCurrentProjectId, levelProjectMap]);
+
+  const dispatch = useAppDispatch();
+
+  const backToParent = useCallback(() => {
+    if (parentLevelId) {
+      // Duplicated from navigateToLevelId(). Can we consolidate?
+      notifyLevelChange(currentLevelId, String(parentLevelId));
+      dispatch(setCurrentLevelId(String(parentLevelId)));
+    }
+  }, [parentLevelId, dispatch, currentLevelId]);
+
+  if (!parentLevelId || !levelProjectMap) {
+    return (
+      <ProjectContainer channelId={currentProjectId}>
+        {children}
+      </ProjectContainer>
+    );
+  }
+
+  return (
+    <MultiProjectContext.Provider value={{backToParent}}>
+      <ProjectContainer channelId={currentProjectId}>
+        {children}
+      </ProjectContainer>
+    </MultiProjectContext.Provider>
+  );
+};
+
+export default MultiProjectContainer;

--- a/apps/src/lab2/types.ts
+++ b/apps/src/lab2/types.ts
@@ -40,6 +40,8 @@ export interface Channel {
   hidden?: boolean;
   thumbnailUrl?: string;
   frozen?: boolean;
+  // Certain project types (like bubble choice standalone projects) can have subprojects.
+  subprojects?: {level_id: number; project_id: string}[];
   // Optional lab-specific configuration for this project.  If provided, this will be saved
   // to the Project model in the database along with the other entries in this interface,
   // inside the value field JSON.

--- a/apps/src/lab2/views/Lab2.tsx
+++ b/apps/src/lab2/views/Lab2.tsx
@@ -8,11 +8,10 @@ import React from 'react';
 import {Provider} from 'react-redux';
 
 import {AiChatDisabledProvider} from '@cdo/apps/aichat/context/aiChatDisabledContext';
-import {getStandaloneProjectId} from '@cdo/apps/lab2/projects/utils';
 import {getStore} from '@cdo/apps/redux';
 import BrowserTextToSpeechWrapper from '@cdo/apps/sharedComponents/BrowserTextToSpeechWrapper';
 
-import ProjectContainer from '../projects/ProjectContainer';
+import MultiProjectContainer from '../projects/MultiProjectContainer';
 
 import RubricFABContainer from './components/rubrics/RubricFABContainer';
 import RubricWrapper from './components/rubrics/RubricWrapper';
@@ -32,11 +31,11 @@ const Lab2: React.FunctionComponent = () => {
               <DialogManager>
                 <MetricsAdapter />
                 <Lab2IdleTimer />
-                <ProjectContainer channelId={getStandaloneProjectId()}>
+                <MultiProjectContainer>
                   <AiChatDisabledProvider>
                     <LabViewsRenderer />
                   </AiChatDisabledProvider>
-                </ProjectContainer>
+                </MultiProjectContainer>
                 <RubricFABContainer />
               </DialogManager>
             </Lab2Wrapper>

--- a/apps/src/music/views/MusicLabView.tsx
+++ b/apps/src/music/views/MusicLabView.tsx
@@ -5,6 +5,7 @@ import {useSelector} from 'react-redux';
 
 import {WorkspaceSerialization} from '@cdo/apps/blockly/types';
 import {applyBlockIdOverrides} from '@cdo/apps/blockly/utils';
+import BackToParentProject from '@cdo/apps/bubbleChoice/BackToParentProject';
 import header from '@cdo/apps/code-studio/header';
 import {
   START_SOURCES,
@@ -394,6 +395,14 @@ const MusicLabView: React.FunctionComponent<MusicLabViewProps> = ({
               />
             }
             headerClassName={moduleStyles.headerWithBorder}
+            leftHeaderContent={
+              <BackToParentProject
+                text="Go to Hub"
+                iconLeft={{iconName: 'home'}}
+                type="secondary"
+                size="s"
+              />
+            }
           >
             {isStartMode && (
               <div

--- a/apps/src/templates/projects/projectConstants.ts
+++ b/apps/src/templates/projects/projectConstants.ts
@@ -83,4 +83,6 @@ export const PROJECT_DEFAULT_THUMBNAIL_IMAGE_OVERRIDE: {
 } = {
   music: '/shared/images/fill-70x70/courses/logo_music.png',
   pythonlab: '/shared/images/fill-70x70/courses/logo_pythonlab.png',
+  // Temporary placeholder
+  music_dance_ai: '/blockly/media/dance/placeholder.png',
 };

--- a/apps/src/templates/projects/projectTypeMap.js
+++ b/apps/src/templates/projects/projectTypeMap.js
@@ -45,6 +45,7 @@ export const PROJECT_TYPE_MAP = {
   story: i18n.projectTypeStory(),
   time_capsule: i18n.projectTypeTimeCapsule(),
   transformers: i18n.projectTypeTransformers(),
+  music_dance_ai: 'Music Dance AI Mashup',
 };
 
 export const FEATURED_PROJECT_TYPE_MAP = {

--- a/dashboard/app/controllers/projects_controller.rb
+++ b/dashboard/app/controllers/projects_controller.rb
@@ -189,6 +189,9 @@ class ProjectsController < ApplicationController
     },
     weblab2: {
       name: 'New Web Lab 2 Project',
+    },
+    music_dance_ai: {
+      name: "New Music Dance AI Project"
     }
     # Note: When adding to this list, remember that project level files must include "is_project_level": true
   }.with_indifferent_access.freeze
@@ -316,10 +319,29 @@ class ProjectsController < ApplicationController
 
   def create_new
     return if redirect_under_13_without_tos_teacher(@level)
+    project_data = initial_data
+
+    # Bubble Choice standalone project types allow multiple sub-projects to be associated with one parent project.
+    # Create new projects for each sublevel
+    if @level.is_a?(BubbleChoice)
+      project_data[:subprojects] =  @level.sublevels.map do |sublevel|
+        {
+          level_id: sublevel.id,
+          project_id: ChannelToken.create_channel(
+            request.ip,
+            Projects.new(get_storage_id),
+            data: {hidden: true},
+            level: sublevel.host_level,
+            standalone: false
+          )
+        }
+      end
+    end
+
     channel = ChannelToken.create_channel(
       request.ip,
       Projects.new(get_storage_id),
-      data: initial_data,
+      data: project_data,
       type: params[:key]
     )
     redirect_to(

--- a/dashboard/app/dsl/bubble_choice_dsl.rb
+++ b/dashboard/app/dsl/bubble_choice_dsl.rb
@@ -15,6 +15,13 @@ class BubbleChoiceDSL < ContentDSL
 
   def description(text) @hash[:description] = text end
 
+  def standalone
+    unless @hash[:uses_lab2]
+      raise "BubbleChoice standalone projects are only available with Lab2"
+    end
+    @hash[:is_project_level] = true
+  end
+
   def sublevels
     @hash[:sublevels]
   end

--- a/dashboard/app/dsl/bubble_choice_dsl.rb
+++ b/dashboard/app/dsl/bubble_choice_dsl.rb
@@ -17,7 +17,7 @@ class BubbleChoiceDSL < ContentDSL
 
   def standalone
     unless @hash[:uses_lab2]
-      raise "BubbleChoice standalone projects are only available with Lab2"
+      raise "BubbleChoice standalone projects are only available with Lab2."
     end
     @hash[:is_project_level] = true
   end

--- a/dashboard/app/helpers/levels_helper.rb
+++ b/dashboard/app/helpers/levels_helper.rb
@@ -375,8 +375,7 @@ module LevelsHelper
 
     @app_options =
       if @level.uses_lab2?
-        # Return early and only include Lab2 options. Lab2 attempts to limit reliance on App Options as much as possible in favor of async server calls.
-        return lab2_options
+        lab2_options
       elsif @level.is_a? Blockly
         blockly_options
       elsif @level.is_a?(Weblab) || @level.is_a?(Fish) || @level.is_a?(Ailab) || @level.is_a?(Javalab)

--- a/dashboard/app/helpers/levels_helper.rb
+++ b/dashboard/app/helpers/levels_helper.rb
@@ -375,7 +375,8 @@ module LevelsHelper
 
     @app_options =
       if @level.uses_lab2?
-        lab2_options
+        # Return early and only include Lab2 options. Lab2 attempts to limit reliance on App Options as much as possible in favor of async server calls.
+        return lab2_options
       elsif @level.is_a? Blockly
         blockly_options
       elsif @level.is_a?(Weblab) || @level.is_a?(Fish) || @level.is_a?(Ailab) || @level.is_a?(Javalab)
@@ -756,7 +757,8 @@ module LevelsHelper
 
   def lab2_options
     raise ArgumentError.new("#{@level} is not a Lab2 level") unless @level.uses_lab2?
-    app_options = {channel: view_options[:channel], level_id: @level.id}
+    app_options = {level_id: @level.id}
+    app_options[:channel] = view_options[:channel] if @level.try(:is_project_level)
     level_options = level_view_options(@level.id)
     # Add edit_blocks to app_options if it exists in level_options
     if level_options[:edit_blocks]

--- a/dashboard/app/models/levels/bubble_choice.rb
+++ b/dashboard/app/models/levels/bubble_choice.rb
@@ -173,7 +173,6 @@ class BubbleChoice < DSLDefined
           icon: level.try(:icon),
           uses_lab2: level.uses_lab2?,
           parent_level_id: id,
-          app_name: level.game&.app
         }
       )
 

--- a/dashboard/app/models/levels/bubble_choice.rb
+++ b/dashboard/app/models/levels/bubble_choice.rb
@@ -34,6 +34,7 @@ class BubbleChoice < DSLDefined
     display_name
     description
     uses_lab2
+    is_project_level
   )
 
   ALPHABET = ('a'..'z').to_a
@@ -172,6 +173,7 @@ class BubbleChoice < DSLDefined
           icon: level.try(:icon),
           uses_lab2: level.uses_lab2?,
           parent_level_id: id,
+          app_name: level.game&.app
         }
       )
 

--- a/dashboard/config/levels/custom/dance/Dance AI Subproject.level
+++ b/dashboard/config/levels/custom/dance/Dance AI Subproject.level
@@ -1,0 +1,49 @@
+<Dancelab>
+  <config><![CDATA[{
+  "published": true,
+  "game_id": 63,
+  "created_at": "2025-09-18T17:57:09.000Z",
+  "level_num": "custom",
+  "user_id": 1,
+  "properties": {
+    "encrypted": "false",
+    "skin": "dance",
+    "block_pools": [
+      "Dancelab"
+    ],
+    "helper_libraries": [
+      "DanceLab"
+    ],
+    "hide_animation_mode": true,
+    "show_type_hints": true,
+    "embed": "false",
+    "instructions_important": "false",
+    "submittable": "false",
+    "never_autoplay_video": "false",
+    "disable_param_editing": "true",
+    "use_modal_function_editor": "false",
+    "hide_share_and_remix": "false",
+    "disable_if_else_editing": "false",
+    "free_play": "false",
+    "validation_enabled": "false",
+    "show_debug_watch": "false",
+    "expand_debugger": "false",
+    "debugger_disabled": "false",
+    "hide_pause_button": "false",
+    "default_song": "introtoshamstep_47SOUL",
+    "uses_lab2": "true",
+    "ai_code_generate": true,
+    "bubble_choice_description": "Use your AI generated dancer and song to create the ultimate Dance Party!",
+    "display_name": "Create a dance!",
+    "thumbnail_url": "/blockly/media/dance/placeholder.png",
+    "preload_asset_list": null,
+    "encrypted_examples": [
+
+    ]
+  },
+  "audit_log": "[{\"changed_at\":\"2025-09-18T17:57:09.492+00:00\",\"changed\":[\"cloned from \\\"New Dance AI Project\\\"\"],\"cloned_from\":\"New Dance AI Project\"},{\"changed_at\":\"2025-09-18 17:57:41 +0000\",\"changed\":[\"preload_asset_list\"],\"changed_by_id\":1,\"changed_by_email\":\"sanchit+localhost@code.org\"}]",
+  "level_concept_difficulty": {
+  }
+}]]></config>
+  <blocks/>
+</Dancelab>

--- a/dashboard/config/levels/custom/dance/Dancer AI Subproject.level
+++ b/dashboard/config/levels/custom/dance/Dancer AI Subproject.level
@@ -1,0 +1,47 @@
+<Dancelab>
+  <config><![CDATA[{
+  "game_id": 63,
+  "created_at": "2025-10-01T21:15:27.000Z",
+  "level_num": "custom",
+  "user_id": 1,
+  "properties": {
+    "skin": "dance",
+    "block_pools": [
+      "Dancelab"
+    ],
+    "helper_libraries": [
+      "DanceLab"
+    ],
+    "hide_animation_mode": true,
+    "show_type_hints": true,
+    "encrypted": "false",
+    "embed": "false",
+    "instructions_important": "false",
+    "submittable": "false",
+    "never_autoplay_video": "false",
+    "disable_param_editing": "true",
+    "use_modal_function_editor": "false",
+    "hide_share_and_remix": "true",
+    "disable_if_else_editing": "false",
+    "free_play": "false",
+    "validation_enabled": "false",
+    "show_debug_watch": "false",
+    "expand_debugger": "false",
+    "debugger_disabled": "false",
+    "hide_pause_button": "false",
+    "default_song": "introtoshamstep_47SOUL",
+    "uses_lab2": "true",
+    "generate_dancer_mode": "true",
+    "ai_dancer_generate_adlib": "adjective-animal-attire",
+    "bubble_choice_description": "With the help of generative AI, create your custom dancer!",
+    "thumbnail_url": "/blockly/media/dance/placeholder.png",
+    "display_name": "Create a dancer!",
+    "preload_asset_list": null
+  },
+  "published": true,
+  "audit_log": "[{\"changed_at\":\"2025-10-01T21:15:27.345+00:00\",\"changed\":[\"cloned from \\\"hoai2025-dancer-adlib3\\\"\"],\"cloned_from\":\"hoai2025-dancer-adlib3\"},{\"changed_at\":\"2025-10-01 21:15:39 +0000\",\"changed\":[\"preload_asset_list\"],\"changed_by_id\":1,\"changed_by_email\":\"sanchit+localhost@code.org\"},{\"changed_at\":\"2025-10-02 20:26:10 +0000\",\"changed\":[],\"changed_by_id\":1,\"changed_by_email\":\"sanchit+localhost@code.org\"},{\"changed_at\":\"2025-10-03 19:09:42 +0000\",\"changed\":[],\"changed_by_id\":1,\"changed_by_email\":\"sanchit+localhost@code.org\"}]",
+  "level_concept_difficulty": {
+  }
+}]]></config>
+  <blocks/>
+</Dancelab>

--- a/dashboard/config/levels/custom/music/Music AI Subproject.level
+++ b/dashboard/config/levels/custom/music/Music AI Subproject.level
@@ -1,0 +1,34 @@
+<Music>
+  <config><![CDATA[{
+  "published": true,
+  "game_id": 70,
+  "created_at": "2025-09-18T17:51:22.000Z",
+  "level_num": "custom",
+  "user_id": 1,
+  "properties": {
+    "encrypted": "false",
+    "offer_browser_tts": "false",
+    "use_secondary_finish_button": "false",
+    "submittable": "false",
+    "hide_share_and_remix": "false",
+    "disable_edit_run_for_submission": "false",
+    "level_data": {
+      "library": "launch2024",
+      "aiCodeGenerate": true
+    },
+    "predict_settings": {
+      "isPredictLevel": false
+    },
+    "exemplar_settings": {
+      "playerEnabled": false,
+      "validationEnabled": false
+    },
+    "bubble_choice_description": "With the help of generative AI, create the ultimate remix!",
+    "thumbnail_url": "/shared/images/fill-70x70/courses/logo_music.png",
+    "display_name": "Create a song!",
+    "preload_asset_list": null
+  },
+  "audit_log": "[{\"changed_at\":\"2025-09-18T17:51:22.247+00:00\",\"changed\":[\"cloned from \\\"New Music AI Project\\\"\"],\"cloned_from\":\"New Music AI Project\"},{\"changed_at\":\"2025-09-18 17:52:09 +0000\",\"changed\":[\"predict_settings\"],\"changed_by_id\":1,\"changed_by_email\":\"sanchit+localhost@code.org\"}]"
+}]]></config>
+  <blocks/>
+</Music>

--- a/dashboard/config/scripts/new_music_dance_ai_project.bubble_choice
+++ b/dashboard/config/scripts/new_music_dance_ai_project.bubble_choice
@@ -1,0 +1,10 @@
+name 'New Music Dance AI Project'
+display_name 'Music Dance AI Test'
+description 'Generate a song, dance, or dancer using AI!'
+
+sublevels
+level 'Music AI Subproject'
+level 'Dancer AI Subproject'
+level 'Dance AI Subproject'
+uses_lab2
+standalone

--- a/dashboard/test/helpers/levels_helper_test.rb
+++ b/dashboard/test/helpers/levels_helper_test.rb
@@ -1130,12 +1130,9 @@ class LevelsHelperTest < ActionView::TestCase
   test "lab2_options generates options for Lab2 levels" do
     @level = create(:music)
 
-    channel = 'channel123'
-    view_options(channel: channel)
     level_view_options(@level.id, share: true)
 
     options = lab2_options
-    assert_equal channel, options["channel"]
     assert_equal @level.id, options["levelId"]
     assert_equal true, options["share"]
 


### PR DESCRIPTION
This PR introduces a new standalone "multi-project" experience built using a bubble choice level as a project level. This is needed for Hour of AI but I think has some really interesting utility and potential beyond as well. Much of the diff is just the four new levels (bubble choice + 3 sublevels) needed to support this; the actual code that powers this isn't huge. Read below for background and some implementation details.

### Background
For Hour of AI 2025, the team is building a "mashup" activity that has students use AI to generate a custom dancer, a custom Music Lab remix, and a custom dance party dance, and put it all together. This means that we need a way to share data between labs and combine lab features in a way we really haven't before. For the freeplay/standalone experience, this also poses a challenge. Traditionally, the last level of an HoC tutorial is a "free play" level where students get the full power of the toolbox/code for the lab they've been using, and when they're done, we link them out to a project level (usually via remix), which ports their freeplay code over to a new project at `projects/<app name>/<channel ID>`. For this tutorial however, a single "project" involves multiple levels and multiple lab experience to complete. 

### Implementation
To solve this, we propose a few simple but interesting changes:

1) Allow bubble choice levels to be standalone project levels (add `standalone` to the DSL)
2) Add a custom mapping in `ProjectsController::STANDALONE_PROJECTS` from a custom url path (here, `music_dance_ai`) to a given standalone bubble choice level.
3) Add a new `subprojects` field in the project table's `value` JSON field, only for these specific project types.

This allows us to associate a given standalone project level (bubble choice) with any number of "sub-projects" that correspond to its sublevels. Because we're using Lab2, we can seamlessly transition between parent project and subprojects using the system we've already built, without page reloads.

The most relevant files here are probably `projects_controller` (backend), and `MultiProjectContainer` (frontend). These are the components that are mostly facilitating the new behavior.

### Future Implications
While this is primarily geared towards HoAI 2025, there are some interesting paradigms here that we might be able to leverage for future use cases:
1) Flexible/arbitrary standalone project mapping: notice that the new standalone project type isn't called "New Bubble Choice Project.level" as it would be if we were following the existing pattern. The existing mapping in ProjectsController technically allows us to associate _any_ url path (`projects/<something>/<channel>`) with _any_ level template. For example, today, any new Music Lab project created via projects/music/new starts with the same toolbox, starting code, etc. But if we wanted to create an AI-specific variant that showed the AI generation modal, we could add a mapping like `music_ai => New Music AI Project.level` and direct new projects at projects/music_ai/new to this new level template. Of course, we'd want to be intentional and careful with new additions, but it gives us a flexibility we haven't really used in the past.
2) Bubble choice projects as a data structure: this is something we're still exploring in HoAI 2025, but now that we have a system to associate a given project with sub-projects, we might consider different types of "modes"/"skins" as alternatives to the traditional bubble choice layout. We could have custom modes that pull data or render features from the various sub-projects. This idea will make more sense with some concrete examples (if we end up getting that far for HoAI), but could be interesting

### Screenshots/Video

Note that the UI is definitely not final (and there are some quirks with theming to work out still)

<img width="1512" height="982" alt="Screenshot 2025-10-03 at 12 23 31 PM (2)" src="https://github.com/user-attachments/assets/0890b9fa-7185-4553-8a31-9d6cd2b99d18" />
<img width="1512" height="982" alt="Screenshot 2025-10-03 at 1 11 12 PM (2)" src="https://github.com/user-attachments/assets/d914749f-4588-495e-9120-3c470daaca1b" />
<img width="1512" height="982" alt="Screenshot 2025-10-03 at 1 11 40 PM (2)" src="https://github.com/user-attachments/assets/a563aaf0-c75f-4ba1-a651-4daa9c1d1134" />
<img width="1512" height="982" alt="Screenshot 2025-10-03 at 1 11 55 PM (2)" src="https://github.com/user-attachments/assets/be9e2519-5cc9-4c4a-9931-22cbefb3a58c" />

https://github.com/user-attachments/assets/848830b0-daf9-4276-825d-846be0c02d34