### PR TITLE
feat(Image): use next image for image

### DIFF
--- a/frontend/apps/marketing/cicd/3-app/template.yml.erb
+++ b/frontend/apps/marketing/cicd/3-app/template.yml.erb
@@ -570,7 +570,7 @@ Resources:
       EnableECSManagedTags: false
       HealthCheckGracePeriodSeconds: 60
       LaunchType: FARGATE
-      DesiredCount: 3
+      DesiredCount: 5
       AvailabilityZoneRebalancing: ENABLED
       LoadBalancers:
         - ContainerName: web

--- a/frontend/apps/marketing/cicd/3-app/template.yml.erb
+++ b/frontend/apps/marketing/cicd/3-app/template.yml.erb
@@ -570,7 +570,7 @@ Resources:
       EnableECSManagedTags: false
       HealthCheckGracePeriodSeconds: 60
       LaunchType: FARGATE
-      DesiredCount: 5
+      DesiredCount: 3
       AvailabilityZoneRebalancing: ENABLED
       LoadBalancers:
         - ContainerName: web

--- a/frontend/apps/marketing/cicd/3-app/template.yml.erb
+++ b/frontend/apps/marketing/cicd/3-app/template.yml.erb
@@ -566,7 +566,7 @@ Resources:
       Cluster: !Ref EcsCluster
       DeploymentConfiguration:
         MaximumPercent: 200
-        MinimumHealthyPercent: 50
+        MinimumHealthyPercent: 100
       EnableECSManagedTags: false
       HealthCheckGracePeriodSeconds: 60
       LaunchType: FARGATE

--- a/frontend/apps/marketing/src/components/contentful/card/Card.tsx
+++ b/frontend/apps/marketing/src/components/contentful/card/Card.tsx
@@ -26,6 +26,8 @@ export interface CardProps extends HTMLAttributes<HTMLDivElement> {
   imageSrc?: string;
   /** Height of the image */
   imageHeight?: string;
+  /** Image object fit */
+  imageObjectFit?: 'cover' | 'contain' | 'fill' | 'none' | 'scale-down';
   /** Card overline */
   overline?: string;
   /** Primary button props */
@@ -51,6 +53,7 @@ const Card: React.FC<CardProps> = ({
   description,
   imageSrc,
   imageHeight,
+  imageObjectFit = 'cover',
   overline,
   primaryButton,
   secondaryButton,
@@ -119,7 +122,7 @@ const Card: React.FC<CardProps> = ({
           <NextImage
             alt={title || ''}
             src={imageSource}
-            style={{objectFit: 'contain'}}
+            style={{objectFit: imageObjectFit}}
           />
         </CardMedia>
       )}

--- a/frontend/apps/marketing/src/components/contentful/carousels/activityCarousel/ActivityCarousel.tsx
+++ b/frontend/apps/marketing/src/components/contentful/carousels/activityCarousel/ActivityCarousel.tsx
@@ -51,6 +51,7 @@ const ActivityCarousel: React.FC<ActivityCarouselProps> = ({slides}) => {
           description={shortDescription}
           primaryButton={primaryButton}
           imageSrc={getAbsoluteImageUrl(resolvedImage)}
+          imageObjectFit={'contain'}
           primaryButtonEventName={EVENT.CARD_PRIMARY_BUTTON_CLICKED}
           secondaryButtonEventName={EVENT.CARD_SECONDARY_BUTTON_CLICKED}
           eventMetadata={{

--- a/frontend/apps/marketing/src/components/contentful/image/Image.tsx
+++ b/frontend/apps/marketing/src/components/contentful/image/Image.tsx
@@ -4,7 +4,11 @@ import Typography from '@mui/material/Typography';
 import classNames from 'classnames';
 import React, {ImgHTMLAttributes, useMemo} from 'react';
 
-import {getAbsoluteImageUrl} from '@/selectors/contentful/getImage';
+import NextImage from '@/components/nextImage/NextImage';
+import {
+  getAbsoluteImageUrl,
+  getImageEntityFromImageUrl,
+} from '@/selectors/contentful/getImage';
 
 export interface ImageProps
   extends Omit<ImgHTMLAttributes<HTMLImageElement>, 'width' | 'height'> {
@@ -31,16 +35,29 @@ const ImageRoot = styled('figure', {
   margin: 0,
 }));
 
-const ImageElement = styled('img', {
-  name: 'MuiImage',
-  slot: 'imageElement',
-})(() => ({
+const imageStyles: object = {
   display: 'block',
   width: '100%',
   height: '100%',
   objectFit: 'cover',
   margin: 0,
   padding: 0,
+};
+
+/** Raw HTML img element styled component */
+const RawImageElement = styled('img', {
+  name: 'MuiImage',
+  slot: 'imageElement',
+})(() => ({
+  ...imageStyles,
+}));
+
+/** Next.js image element styled component */
+const NextImageElement = styled(NextImage, {
+  name: 'MuiImage',
+  slot: 'imageElement',
+})(() => ({
+  ...imageStyles,
 }));
 
 const Image: React.FC<ImageProps> = ({
@@ -52,6 +69,10 @@ const Image: React.FC<ImageProps> = ({
 }) => {
   // Get the image source URL from Contentful
   const imageSource = useMemo(() => src && getAbsoluteImageUrl(src), [src]);
+  const imageEntity = getImageEntityFromImageUrl(imageSource);
+
+  const imageHeight = imageEntity?.fields?.file?.details?.image?.height;
+  const imageWidth = imageEntity?.fields?.file?.details?.image?.width;
 
   // Show placeholder text until a content entry is added
   if (!src || !imageSource) {
@@ -74,7 +95,19 @@ const Image: React.FC<ImageProps> = ({
         className,
       )}
     >
-      <ImageElement alt={altText || ''} loading="lazy" src={imageSource} />
+      {/* Use Next.js Image component if we have image dimensions to prevent layout shift */}
+      {imageHeight && imageWidth ? (
+        <NextImageElement
+          alt={altText || ''}
+          loading="lazy"
+          src={imageSource}
+          fill={false}
+          height={imageHeight}
+          width={imageWidth}
+        />
+      ) : (
+        <RawImageElement alt={altText || ''} loading="lazy" src={imageSource} />
+      )}
     </ImageRoot>
   );
 };

--- a/frontend/apps/marketing/src/components/csforall/activityCollection/ActivityCollection.tsx
+++ b/frontend/apps/marketing/src/components/csforall/activityCollection/ActivityCollection.tsx
@@ -38,6 +38,7 @@ const ActivityCollection: React.FC<ActivityCollectionProps> = ({
             description={shortDescription}
             primaryButton={primaryLinkRef && JSON.parse(primaryLinkRef)}
             imageSrc={image}
+            imageObjectFit={'contain'}
             primaryButtonEventName={EVENT.CARD_PRIMARY_BUTTON_CLICKED}
             secondaryButtonEventName={EVENT.CARD_SECONDARY_BUTTON_CLICKED}
             eventMetadata={{

--- a/frontend/apps/marketing/src/selectors/contentful/getImage.ts
+++ b/frontend/apps/marketing/src/selectors/contentful/getImage.ts
@@ -1,3 +1,5 @@
+import {useInMemoryEntities} from '@contentful/experiences-sdk-react';
+
 import {ExperienceAsset} from '@/types/contentful/ExperienceAsset';
 
 export function getRelativeImageUrl(asset: ExperienceAsset | undefined) {
@@ -58,4 +60,30 @@ export function getAbsoluteImageUrl(
     console.error(e);
     return imgUrl;
   }
+}
+
+function getAssetIdFromImageUrl(imgUrl: string | undefined) {
+  if (!imgUrl) return undefined;
+
+  // Example URL: https://contentful-images.code.org/27jkibac934d/6twVI3a8N6IoRIvwGuPMDq/c96010513f029b80a86e193b7a098135/hourofai_logo_og.jpg
+  // This regex captures the asset ID segment (6twVI3a8N6IoRIvwGuPMDq) from the URL
+  const match = imgUrl.match(/\/[^/]+\/([^/]+)\/[^/]+\/[^/]+$/);
+  return match ? match[1] : undefined;
+}
+
+export function getImageEntityFromImageUrl(imageSource: string | undefined) {
+  if (!imageSource) {
+    return undefined;
+  }
+
+  // Retrieve metadata about the image from the entity store
+  const imageAssetId = getAssetIdFromImageUrl(imageSource);
+
+  if (!imageAssetId) {
+    return undefined;
+  }
+
+  const entities = useInMemoryEntities();
+
+  return entities.maybeResolveByAssetId(imageAssetId) as ExperienceAsset;
 }

--- a/frontend/apps/marketing/tests/e2e/pom/marketing.ts
+++ b/frontend/apps/marketing/tests/e2e/pom/marketing.ts
@@ -78,7 +78,10 @@ export class MarketingPage {
   async goto(subPath: string) {
     const response = await this.page.goto(`${this.getBasePath()}${subPath}`);
 
-    await this.page.waitForFunction(() => typeof window.__ENV !== 'undefined');
+    // If there's a challenge page, wait for it to clear
+    await this.page.waitForFunction(
+      () => typeof window.awsWafCookieDomainList === 'undefined',
+    );
     await this.loadFonts();
 
     return response;

--- a/frontend/apps/marketing/tests/e2e/pom/marketing.ts
+++ b/frontend/apps/marketing/tests/e2e/pom/marketing.ts
@@ -78,6 +78,8 @@ export class MarketingPage {
   async goto(subPath: string) {
     const response = await this.page.goto(`${this.getBasePath()}${subPath}`);
 
+    // We may encounter a Cloudfront challenge page which has no title. Wait for a title to be set.
+    await this.page.waitForFunction(() => document.title.trim().length > 0);
     await this.loadFonts();
 
     return response;

--- a/frontend/apps/marketing/tests/e2e/pom/marketing.ts
+++ b/frontend/apps/marketing/tests/e2e/pom/marketing.ts
@@ -78,8 +78,7 @@ export class MarketingPage {
   async goto(subPath: string) {
     const response = await this.page.goto(`${this.getBasePath()}${subPath}`);
 
-    // We may encounter a Cloudfront challenge page which has no title. Wait for a title to be set.
-    await this.page.waitForFunction(() => document.title.trim().length > 0);
+    await this.page.waitForFunction(() => typeof window.__ENV !== 'undefined');
     await this.loadFonts();
 
     return response;


### PR DESCRIPTION
This PR updates the Image component to use Next.js dynamic image component. This offloads images from Contentful's CDN to our self-hosted one. To accomplish this, the asset id is retrieved from the image url[1] which is fed into the `useInMemoryEntities` helper tool to retrieve the entire Contentful data structure for the width and height (without needing to add it to the definition itself). This then allows Next.js to reserve image space to eliminate content layout shifting (because the height and width is fixed). Currently, images are loaded without a fixed height/width resulting in a CLS score reduction.

In the case we are unable to get the height and width, the regular `<img>` element will be used instead.

[1] https://www.contentful.com/developers/docs/concepts/links/