### PR TITLE
AI Tutor - further refactor context formatting

### DIFF
--- a/apps/src/aiTutor/docContextApi.ts
+++ b/apps/src/aiTutor/docContextApi.ts
@@ -35,3 +35,8 @@ export const tryFetchDocsForClass = async (programmingClassKey: string) => {
 
   return await docsCache.get(programmingClassKey);
 };
+
+// Pre-fetch docs but don't return them.
+export const preFetchDocsForClass = async (programmingClassKey: string) => {
+  await tryFetchDocsForClass(programmingClassKey);
+};

--- a/apps/src/aiTutor/docContextApi.ts
+++ b/apps/src/aiTutor/docContextApi.ts
@@ -36,7 +36,7 @@ export const tryFetchDocsForClass = async (programmingClassKey: string) => {
   return await docsCache.get(programmingClassKey);
 };
 
-// Pre-fetch docs but don't return them.
+// Pre-fetch docs but don't return them (syntactic sugar around `tryFetchDocsForClass`).
 export const preFetchDocsForClass = async (programmingClassKey: string) => {
   await tryFetchDocsForClass(programmingClassKey);
 };

--- a/apps/src/aiTutor/helpers/aiTutorContextHelper.ts
+++ b/apps/src/aiTutor/helpers/aiTutorContextHelper.ts
@@ -5,12 +5,12 @@ import {AiTutorContext, MaybePromise} from '../types';
  * extend this class, but conversion to a system prompt string should be kept here for coordination and
  * consistency.
  */
-export abstract class AiTutorContextHelper<Params extends object> {
-  // Can't find a way for TypeScript to allow us to set this to `{}` here with the
-  // generic `<Params extends object>` type. Initialize this to `{}` in derived class.
-  protected abstract params: Params;
+export abstract class AiTutorContextHelper<AiTutorParams extends object> {
+  // Can't find a way for TypeScript to allow us to set this to `{}` here with the generic
+  // `<AiTutorParams extends object>` type. Initialize this to `{}` in derived class.
+  protected abstract params: AiTutorParams;
 
-  setAiTutorContext(params: Params): void {
+  setAiTutorContext(params: AiTutorParams): void {
     this.params = params;
   }
 

--- a/apps/src/aiTutor/helpers/aiTutorContextHelper.ts
+++ b/apps/src/aiTutor/helpers/aiTutorContextHelper.ts
@@ -1,4 +1,4 @@
-import {AiTutorContext} from '../types';
+import {AiTutorContext, MaybePromise} from '../types';
 
 /*
  * Abstract base class used to provide lab specific context to AI Tutor.  Each lab will inherit from and
@@ -6,13 +6,16 @@ import {AiTutorContext} from '../types';
  * consistency.
  */
 export abstract class AiTutorContextHelper<T extends object> {
-  protected abstract getAiTutorContext():
-    | Promise<AiTutorContext>
-    | AiTutorContext;
+  protected abstract getAiTutorContext(): MaybePromise<AiTutorContext>;
 
   protected abstract setAiTutorContext(params: T): void;
 
-  private async getHiddenContextString() {
+  // override in subclass for formatting tasks needed on ai tutor context
+  protected formatAiTutorContext(): MaybePromise<void> {}
+
+  private async getHiddenContextString(): Promise<string> {
+    await this.formatAiTutorContext();
+
     const {
       sourceCode,
       validationContents,

--- a/apps/src/aiTutor/helpers/aiTutorContextHelper.ts
+++ b/apps/src/aiTutor/helpers/aiTutorContextHelper.ts
@@ -5,17 +5,18 @@ import {AiTutorContext, MaybePromise} from '../types';
  * extend this class, but conversion to a system prompt string should be kept here for coordination and
  * consistency.
  */
-export abstract class AiTutorContextHelper<T extends object> {
+export abstract class AiTutorContextHelper<Params extends object> {
+  // Can't find a way for TypeScript to allow us to set this to `{}` here with the
+  // generic `<Params extends object>` type. Initialize this to `{}` in derived class.
+  protected abstract params: Params;
+
+  setAiTutorContext(params: Params): void {
+    this.params = params;
+  }
+
   protected abstract getAiTutorContext(): MaybePromise<AiTutorContext>;
 
-  protected abstract setAiTutorContext(params: T): void;
-
-  // override in subclass for formatting tasks needed on ai tutor context
-  protected formatAiTutorContext(): MaybePromise<void> {}
-
   private async getHiddenContextString(): Promise<string> {
-    await this.formatAiTutorContext();
-
     const {
       sourceCode,
       validationContents,

--- a/apps/src/aiTutor/types.ts
+++ b/apps/src/aiTutor/types.ts
@@ -18,3 +18,5 @@ export interface AiTutorContext {
   documentation?: string;
   userSelection?: string;
 }
+
+export type MaybePromise<T> = T | Promise<T>;

--- a/apps/src/aiTutor/views/legacyLabs/aiTutorContextHelper.ts
+++ b/apps/src/aiTutor/views/legacyLabs/aiTutorContextHelper.ts
@@ -2,19 +2,15 @@ import {AiTutorContextHelper} from '@cdo/apps/aiTutor/helpers/aiTutorContextHelp
 import {AiTutorContext} from '@cdo/apps/aiTutor/types';
 
 interface AiTutorLegacyLabParams {
-  source: string | undefined;
+  source?: string;
 }
 
 export class AiTutorLegacyLabContextHelper extends AiTutorContextHelper<AiTutorLegacyLabParams> {
-  private aiTutorContext: AiTutorContext = {};
+  params: AiTutorLegacyLabParams = {};
 
   protected getAiTutorContext(): AiTutorContext {
-    return this.aiTutorContext;
-  }
-
-  setAiTutorContext({source}: AiTutorLegacyLabParams) {
-    this.aiTutorContext = {
-      sourceCode: source,
+    return {
+      sourceCode: this.params.source,
     };
   }
 }

--- a/apps/src/pythonlab/helpers/aiTutorContextHelper.ts
+++ b/apps/src/pythonlab/helpers/aiTutorContextHelper.ts
@@ -1,4 +1,7 @@
-import {tryFetchDocsForClass} from '@cdo/apps/aiTutor/docContextApi';
+import {
+  preFetchDocsForClass,
+  tryFetchDocsForClass,
+} from '@cdo/apps/aiTutor/docContextApi';
 import {AiTutorContextHelper} from '@cdo/apps/aiTutor/helpers/aiTutorContextHelper';
 import {AiTutorContext} from '@cdo/apps/aiTutor/types';
 import {ProjectFile} from '@cdo/apps/codebridge/types';
@@ -7,26 +10,26 @@ import {MultiFileSource, ProjectFileType} from '@cdo/apps/lab2/types';
 import PythonValidationTracker from '../progress/PythonValidationTracker';
 
 interface AiTutorPythonLabParams {
-  source: MultiFileSource | undefined;
-  validationFile: ProjectFile | undefined;
-  longInstructions: string | undefined;
-  miniAppName: string | undefined;
+  source?: MultiFileSource;
+  validationFile?: ProjectFile;
+  longInstructions?: string;
+  miniAppName?: string;
 }
 export class AiTutorPythonLabContextHelper extends AiTutorContextHelper<AiTutorPythonLabParams> {
-  private aiTutorContext: AiTutorContext = {};
-  private params?: AiTutorPythonLabParams;
+  params: AiTutorPythonLabParams = {};
 
-  protected override getAiTutorContext(): AiTutorContext {
-    return this.aiTutorContext;
+  override async setAiTutorContext(
+    params: AiTutorPythonLabParams
+  ): Promise<void> {
+    if (params.miniAppName === 'neighborhood') {
+      // Prefetch painter docs so they are ready immediately when user interacts with tutor.
+      await preFetchDocsForClass('painter');
+    }
+
+    super.setAiTutorContext(params);
   }
 
-  override setAiTutorContext(params: AiTutorPythonLabParams): void {
-    this.params = params;
-  }
-
-  protected override async formatAiTutorContext() {
-    if (!this.params) return;
-
+  protected override async getAiTutorContext(): Promise<AiTutorContext> {
     const {source, validationFile, longInstructions, miniAppName} = this.params;
     const sourceCode = source
       ? Object.values(source.files)
@@ -59,7 +62,7 @@ export class AiTutorPythonLabContextHelper extends AiTutorContextHelper<AiTutorP
         ? await tryFetchDocsForClass('painter')
         : undefined;
 
-    this.aiTutorContext = {
+    return {
       sourceCode,
       validationContents,
       validationResults,

--- a/apps/src/pythonlab/helpers/aiTutorContextHelper.ts
+++ b/apps/src/pythonlab/helpers/aiTutorContextHelper.ts
@@ -13,22 +13,21 @@ interface AiTutorPythonLabParams {
   miniAppName: string | undefined;
 }
 export class AiTutorPythonLabContextHelper extends AiTutorContextHelper<AiTutorPythonLabParams> {
-  private documentationPromise?: Promise<string | undefined>;
   private aiTutorContext: AiTutorContext = {};
+  private params?: AiTutorPythonLabParams;
 
-  protected async getAiTutorContext(): Promise<AiTutorContext> {
-    return {
-      ...this.aiTutorContext,
-      documentation: await this.documentationPromise,
-    };
+  protected override getAiTutorContext(): AiTutorContext {
+    return this.aiTutorContext;
   }
 
-  setAiTutorContext({
-    source,
-    validationFile,
-    longInstructions,
-    miniAppName,
-  }: AiTutorPythonLabParams) {
+  override setAiTutorContext(params: AiTutorPythonLabParams): void {
+    this.params = params;
+  }
+
+  protected override async formatAiTutorContext() {
+    if (!this.params) return;
+
+    const {source, validationFile, longInstructions, miniAppName} = this.params;
     const sourceCode = source
       ? Object.values(source.files)
           .filter(
@@ -55,9 +54,9 @@ export class AiTutorPythonLabContextHelper extends AiTutorContextHelper<AiTutorP
       PythonValidationTracker.getInstance().getValidationResults()
     );
 
-    this.documentationPromise =
+    const documentation =
       miniAppName === 'neighborhood'
-        ? tryFetchDocsForClass('painter')
+        ? await tryFetchDocsForClass('painter')
         : undefined;
 
     this.aiTutorContext = {
@@ -65,6 +64,7 @@ export class AiTutorPythonLabContextHelper extends AiTutorContextHelper<AiTutorP
       validationContents,
       validationResults,
       longInstructions,
+      documentation,
     };
   }
 }

--- a/apps/src/weblab2/helpers/aiTutorContextHelper.ts
+++ b/apps/src/weblab2/helpers/aiTutorContextHelper.ts
@@ -11,16 +11,20 @@ interface AiTutorWebLab2Params {
 
 export class AiTutorWebLab2ContextHelper extends AiTutorContextHelper<AiTutorWebLab2Params> {
   private aiTutorContext: AiTutorContext = {};
+  private params?: AiTutorWebLab2Params;
 
-  protected getAiTutorContext(): AiTutorContext {
+  protected override getAiTutorContext(): AiTutorContext {
     return this.aiTutorContext;
   }
 
-  setAiTutorContext({
-    source,
-    longInstructions,
-    selection,
-  }: AiTutorWebLab2Params) {
+  override setAiTutorContext(params: AiTutorWebLab2Params): void {
+    this.params = params;
+  }
+
+  protected override formatAiTutorContext() {
+    if (!this.params) return;
+
+    const {source, longInstructions, selection} = this.params;
     const sourceCode = source
       ? Object.values(source.files)
           .filter(

--- a/apps/src/weblab2/helpers/aiTutorContextHelper.ts
+++ b/apps/src/weblab2/helpers/aiTutorContextHelper.ts
@@ -1,29 +1,21 @@
 import {UserAddedSelectionContext} from '@cdo/apps/aichat/types';
 import {AiTutorContextHelper} from '@cdo/apps/aiTutor/helpers/aiTutorContextHelper';
-import {AiTutorContext} from '@cdo/apps/aiTutor/types';
 import {MultiFileSource, ProjectFileType} from '@cdo/apps/lab2/types';
 
 interface AiTutorWebLab2Params {
-  source: MultiFileSource | undefined;
-  longInstructions: string | undefined;
-  selection: UserAddedSelectionContext;
+  source?: MultiFileSource | undefined;
+  longInstructions?: string | undefined;
+  selection?: UserAddedSelectionContext;
 }
 
 export class AiTutorWebLab2ContextHelper extends AiTutorContextHelper<AiTutorWebLab2Params> {
-  private aiTutorContext: AiTutorContext = {};
-  private params?: AiTutorWebLab2Params;
-
-  protected override getAiTutorContext(): AiTutorContext {
-    return this.aiTutorContext;
-  }
+  params: AiTutorWebLab2Params = {};
 
   override setAiTutorContext(params: AiTutorWebLab2Params): void {
     this.params = params;
   }
 
-  protected override formatAiTutorContext() {
-    if (!this.params) return;
-
+  protected override getAiTutorContext() {
     const {source, longInstructions, selection} = this.params;
     const sourceCode = source
       ? Object.values(source.files)
@@ -53,7 +45,7 @@ export class AiTutorWebLab2ContextHelper extends AiTutorContextHelper<AiTutorWeb
             .join('\n\n')
         : undefined;
 
-    this.aiTutorContext = {
+    return {
       sourceCode,
       longInstructions,
       userSelection,


### PR DESCRIPTION
This PR further refactors AI Tutor context formatting from [this PR](https://github.com/code-dot-org/code-dot-org/pull/68735/files).  This approach moves the formatting to `getAiTutorContext` where all derived classes will handle formatting and removes a separate (opt-in) `formatAiTutorContext`.

This PR also sets properties as optional (`?`) rather than a required property that can be `undefined` (`type | undefined`) and introduces a `preFetchDocsForClass` (introduced for clarity of intent) function allowing the docs API call can be made as soon as the documentation class is known (in `setAiTutorContext`) rather than waiting until it is needed after the user sends makes a message to tutor (in `getAiTutorContext`).

