### PR TITLE
Sketch Lab: add bubble choice and teacher-only markdown to level editing

### DIFF
--- a/dashboard/app/views/levels/editors/_sketchlab.html.haml
+++ b/dashboard/app/views/levels/editors/_sketchlab.html.haml
@@ -1,3 +1,4 @@
-= render partial: 'levels/editors/fields/sketchlab_fields', locals: {f: f}
 = render partial: 'levels/editors/fields/long_instructions', locals: {f: f}
+= render partial: 'levels/editors/fields/teacher_only_markdown', locals: {f: f}
+= render partial: 'levels/editors/fields/bubble_choice_sublevel', locals: {f: f}
 = render partial: 'levels/editors/fields/audit_log', locals: {f: f}

--- a/dashboard/app/views/levels/editors/fields/_sketchlab_fields.html.haml
+++ b/dashboard/app/views/levels/editors/fields/_sketchlab_fields.html.haml
@@ -1,1 +1,0 @@
-%h1 Sketch Lab Fields

--- a/dashboard/config/scripts/test_sketchlab_bubble_choice.bubble_choice
+++ b/dashboard/config/scripts/test_sketchlab_bubble_choice.bubble_choice
@@ -1,0 +1,9 @@
+name 'test sketchlab bubble choice'
+display_name 'level display_name here'
+description 'level description here'
+
+sublevels
+level 'allthethings sketchlab 1'
+level 'allthethings sketchlab 2'
+
+uses_lab2

--- a/dashboard/config/scripts/test_sketchlab_bubble_choice.bubble_choice
+++ b/dashboard/config/scripts/test_sketchlab_bubble_choice.bubble_choice
@@ -1,9 +1,0 @@
-name 'test sketchlab bubble choice'
-display_name 'level display_name here'
-description 'level description here'
-
-sublevels
-level 'allthethings sketchlab 1'
-level 'allthethings sketchlab 2'
-
-uses_lab2


### PR DESCRIPTION
Adds a couple core levelbuilder editing fields (bubble choice and teacher-only markdown) to Sketch Lab level edit pages.

Also deletes the "Sketchlab Fields" partial because it doesn't hold anything currently.

## Links

- Jira: https://codedotorg.atlassian.net/browse/AFL-220

## Testing story

I tested manually adding teacher-only markdown to a level, as well as adding a Sketch Lab level as a choice in a bubble choice level (legacy and lab2 version).