### PR TITLE
Sketch Lab: fix remounting

### DIFF
--- a/apps/src/sketchlab/SketchlabView.tsx
+++ b/apps/src/sketchlab/SketchlabView.tsx
@@ -6,7 +6,6 @@ import {
   ExcalidrawImperativeAPI,
   ExcalidrawInitialDataState,
 } from '@excalidraw/excalidraw/types/types';
-import {isEqual} from 'lodash';
 import React, {useEffect, useCallback, useRef, useState} from 'react';
 
 import useLevelEditMode from '@cdo/apps/lab2/hooks/useLevelEditMode';
@@ -134,11 +133,10 @@ const SketchlabView: React.FC<LabProps<LevelProperties>> = ({
     const excalidrawApi = excalidrawApiRef.current;
     if (
       excalidrawApi &&
-      (!isEqual(
-        excalidrawApi.getSceneElements(),
-        currentSources.source.elements
-      ) ||
-        !isEqual(excalidrawApi.getFiles(), currentSources.source.files))
+      (JSON.stringify(excalidrawApi.getSceneElements()) !==
+        JSON.stringify(currentSources.source.elements) ||
+        JSON.stringify(excalidrawApi.getFiles()) !==
+          JSON.stringify(currentSources.source.files))
     ) {
       setExcalidrawMountKey(key => key + 1);
     }


### PR DESCRIPTION
Sketch Lab was remounting too aggressively -- object comparison didn't work when we are de/stringifying the canvas state from Excalidraw 🤦‍♂️ . String comparison works instead. 

I think this fixes the short term issue, but I think it might be a bit fragile longer term. This approach relies on the fact that our saving to sources handler stores exactly what Excalidraw passes to us (at least for canvas elements and files).

https://github.com/code-dot-org/code-dot-org/blob/2b28c5be9205481538551a5f0523fe95c7785e28/apps/src/sketchlab/SketchlabView.tsx#L95-L112

Instead of comparing sources to decide whether to remount, we could remount explicitly on changes to level ID, switching between students, etc. Downside is that it's nice that SourcesContainer manages all of these possible changes for us currently!

## Links

- Slack discussion: https://codedotorg.slack.com/archives/C09EHQE4DGD/p1759768640866149

## Testing story

We observed focus being removed when trying to type into a textbox on the canvas (this happened when the component remounted). After this change, focus remained with the textbox (and the component did not remount).