### PR TITLE
Use blocks from generated dancer pool, if available

### DIFF
--- a/apps/src/dance/blockly/buildDanceBlockly.ts
+++ b/apps/src/dance/blockly/buildDanceBlockly.ts
@@ -8,17 +8,34 @@ import {
 
 import getBlockOptions from './getBlockOptions';
 
-const SET_BACKGROUND = 'Dancelab_setBackgroundEffectWithPaletteAI';
-const SET_FOREGROUND = 'Dancelab_setForegroundEffectExtended';
-const CHANGE_MOVE = 'Dancelab_changeMoveEachLR';
+const DANCELAB_PREFIX = 'Dancelab_';
+const GENERATED_PREFIX = 'GeneratedDancers_';
+
+// Try to find a block definition by type string.
+// We don't rely on the exact shape of BlockDefinition; cover common keys.
+function hasBlockType(defs: BlockDefinition[], name: string): boolean {
+  return defs.some(d => d.name === name);
+}
+
+// Given a block type (without block prefix), get the preferred, defined type.
+// Prefers blocks from the GeneratedDancers pool over the standard Dancelab pool.
+// Block pools may vary by level, but all Dance level use the Dancelab pool.
+function getPreferredBlockType(
+  defs: BlockDefinition[],
+  blockType: string
+): string {
+  return hasBlockType(defs, GENERATED_PREFIX + blockType)
+    ? GENERATED_PREFIX + blockType
+    : DANCELAB_PREFIX + blockType;
+}
+
+const MAKE_SPRITE = 'makeAnonymousDanceSprite';
+const CHANGE_MOVE = 'changeMoveEachLR';
+const SET_BACKGROUND = 'setBackgroundEffectWithPalette';
+const SET_FOREGROUND = 'setForegroundEffectExtended';
 
 function randomElement<T>(array: readonly T[]): T {
   return array[Math.floor(Math.random() * array.length)];
-}
-
-function uidFactory(prefix: string): () => string {
-  let i = 0;
-  return () => `${prefix}_${++i}`;
 }
 
 function randomField(name: string, options: string[]): string {
@@ -30,7 +47,6 @@ function groupSpritesField(): string {
 }
 
 function dirLeftRightField(value: -1 | 1): string {
-  // -1 means both or "left/right" depending on block impl; matches your example
   return `<field name="DIR">${value}</field>`;
 }
 
@@ -39,13 +55,12 @@ function unitMeasuresField(): string {
 }
 
 function makeSetBackgroundBlock(
-  id: string,
+  type: string,
   effects: string[],
   palettes: string[]
 ): JsonBlockConfig {
   return {
-    type: SET_BACKGROUND,
-    id,
+    type,
     fields: {
       PALETTE: randomField('PALETTE', palettes),
       EFFECT: randomField('EFFECT', effects),
@@ -54,12 +69,11 @@ function makeSetBackgroundBlock(
 }
 
 function makeSetForegroundBlock(
-  id: string,
+  type: string,
   effects: string[]
 ): JsonBlockConfig {
   return {
-    type: SET_FOREGROUND,
-    id,
+    type,
     fields: {
       EFFECT: randomField('EFFECT', effects),
     },
@@ -67,12 +81,11 @@ function makeSetForegroundBlock(
 }
 
 function makeChangeMoveEachLRBlock(
-  id: string,
+  type: string,
   moves: string[]
 ): JsonBlockConfig {
   return {
-    type: CHANGE_MOVE,
-    id,
+    type,
     fields: {
       GROUP: groupSpritesField(),
       MOVE: randomField('MOVE', moves),
@@ -103,49 +116,69 @@ export default function buildDanceBlockly(
   measures: number[],
   blockDefinitions: BlockDefinition[]
 ): WorkspaceSerialization {
-  const makeId = uidFactory('id');
+  const changeMoveBlockType = getPreferredBlockType(
+    blockDefinitions,
+    CHANGE_MOVE
+  );
+  const setBackgroundBlockType = getPreferredBlockType(
+    blockDefinitions,
+    SET_BACKGROUND
+  );
+  const setForegroundBlockType = getPreferredBlockType(
+    blockDefinitions,
+    SET_FOREGROUND
+  );
+  const makeSpriteBlockType = getPreferredBlockType(
+    blockDefinitions,
+    MAKE_SPRITE
+  );
 
   const validMoves = getBlockOptions(
     blockDefinitions,
-    CHANGE_MOVE,
+    changeMoveBlockType,
     'MOVE'
   ).filter(option => !['"next"', '"prev"', '"rand"'].includes(option));
 
   const validBackgrounds = getBlockOptions(
     blockDefinitions,
-    SET_BACKGROUND,
+    setBackgroundBlockType,
     'EFFECT'
   ).filter(option => !['"none"', '"rand"'].includes(option));
 
   const validForegrounds = getBlockOptions(
     blockDefinitions,
-    SET_FOREGROUND,
+    setForegroundBlockType,
     'EFFECT'
   ).filter(option => !['"none"', '"rand"'].includes(option));
 
   const validPalettes = getBlockOptions(
     blockDefinitions,
-    SET_BACKGROUND,
+    setBackgroundBlockType,
     'PALETTE'
   );
 
   // Setup: create sprite → change move → start background → start foreground
   const makeSprite: JsonBlockConfig = {
-    type: 'Dancelab_makeAnonymousDanceSprite',
-    id: makeId(),
+    type: makeSpriteBlockType,
     fields: {
       COSTUME: '<field name="COSTUME">"CAT"</field>',
       LOCATION: '<field name="LOCATION">{x: 200, y: 200}</field>',
     },
   };
 
-  const initialChangeMove = makeChangeMoveEachLRBlock(makeId(), validMoves);
+  const initialChangeMove = makeChangeMoveEachLRBlock(
+    changeMoveBlockType,
+    validMoves
+  );
   const initialBg = makeSetBackgroundBlock(
-    makeId(),
+    setBackgroundBlockType,
     validBackgrounds,
     validPalettes
   );
-  const initialFg = makeSetForegroundBlock(makeId(), validForegrounds);
+  const initialFg = makeSetForegroundBlock(
+    setForegroundBlockType,
+    validForegrounds
+  );
 
   const setupDoChain = chainBlocks(
     makeSprite,
@@ -170,19 +203,19 @@ export default function buildDanceBlockly(
   const eventBlocks: JsonBlockConfig[] = measures.map(
     (m, idx): JsonBlockConfig => {
       const bg = makeSetBackgroundBlock(
-        makeId(),
+        setBackgroundBlockType,
         validBackgrounds,
         validPalettes
       );
-      const fg = makeSetForegroundBlock(makeId(), validForegrounds);
-      const move = makeChangeMoveEachLRBlock(makeId(), validMoves);
+      const fg = makeSetForegroundBlock(
+        setForegroundBlockType,
+        validForegrounds
+      );
+      const move = makeChangeMoveEachLRBlock(changeMoveBlockType, validMoves);
       const chain = chainBlocks(bg, fg, move);
 
       return {
         type: 'Dancelab_atTimestampNotAfter',
-        id: makeId(),
-        x: 24 + (idx % 2) * 6, // tiny stagger to avoid exact overlap
-        y: 200 + idx * 180, // vertical spacing between event stacks
         fields: {
           TIMESTAMP: m,
           UNIT: unitMeasuresField(),

--- a/apps/src/dance/lab2/views/DanceView.tsx
+++ b/apps/src/dance/lab2/views/DanceView.tsx
@@ -275,6 +275,14 @@ const DanceView: React.FunctionComponent<{
         validateBlockCategories(workspace.current);
       }
 
+      if (e.type === Events.FINISHED_LOADING) {
+        // Ensure all blocks have valid, non-overlapping positions on the workspace.
+        Blockly.Events.disable();
+        workspace.current?.cleanUp();
+        Blockly.Events.enable();
+        return;
+      }
+
       if (e.type !== Events.BLOCK_DRAG && e.type !== Events.BLOCK_CHANGE) {
         return;
       }


### PR DESCRIPTION
This updates the flow for generating a Dance based on an existing Music project. The change here is to begin preferring the new block pool when available. These blocks allow creating and modifying generated dancers and were introduced here:
- https://github.com/code-dot-org/code-dot-org/pull/68711

 Now, if a block from the standard `Dancelab` block pool has been redefined in the new `GeneratedDancers` block pool AND the level has both pools included, we will use the block from the latter pool. If not, we will gracefully fall back to using the original blocks.

Right now we are only using the new blocks to create a dancer and change moves. However, some basic groundwork is laid here that will allow us to easily switch between versions of other block types if/when we are interested.

Level with added pool:


https://github.com/user-attachments/assets/5fbeea1c-d0b7-4f65-9ba3-b987fa957f82


Level without added pool:


https://github.com/user-attachments/assets/b5b6beb0-cbbd-4de3-9f39-692aa88be301






Additionally, I removed some specifications for block ids and x/y positions of top blocks. The ids were in fact just being used to vertically position the blocks (using a magic number). Without ids, Blockly will generate ids automatically. Without x/y positions, we will rely on our custom `workspace.cleanUp()` method to nice arrange the blocks on the workspace.

Overall, this change should be safe to merge any time as it only impacts levels with the new block pool. As we add the block pool to those levels, they will automatically begin using the new blocks upon code generation, but older versions of the tutorial will continue to work exactly as they had. (We are currently on pilot script number four.)

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->



## Links
<!--  Links to relevant external resources.
      - spec docs, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- Jira: 

## Testing story
<!--  Does your change include appropriate tests?
      - If so, please describe how the tests included in this PR are sufficient.
      - If not, please explain why this change does not need to be tested. -->



## Deployment strategy
<!--  Any special steps required to deploy this, besides merging?
      - Are there database migrations or manual steps?
      - Does this require coordination with other teams or systems? -->



## Follow-up work
<!--  List any clean-up or technical debt that will be addressed in future work.
      - Include Jira links where applicable.
      - Are there any known limitations or improvements planned? -->



## Privacy
<!--  How does this change impact Student & Teacher privacy?
      - Does this collect, use, share, or modify PII, either new or existing? -->



## Security
<!--  How does this change impact our security surface-area?
      - Do API's touched have the right auth?
      - Do infra changes impact our attack surface or encryption?
-->



## Caching
<!--  How does this change impact caching behavior?
      - Are cache keys or invalidation strategies affected?
      - Will this require cache warming or invalidation after deployment? -->



## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
