### PR TITLE
Sketch Lab: explicitly track/react to source initialization

### DIFF
--- a/apps/src/lab2/views/SourcesContainer.tsx
+++ b/apps/src/lab2/views/SourcesContainer.tsx
@@ -61,12 +61,28 @@ const SourcesContainer: React.FC<
   // via level change, a teacher switching between viewing different students, etc.
   const [sourceInitializationCount, setSourceInitializationCount] = useState(0);
 
+  const [startOverProps, setStartOverProps] = useState<{
+    type: MessageType;
+    message?: string;
+  }>();
+
+  const reinitializeSources = useCallback(
+    (sources: ProjectSources, save: boolean) => {
+      setCurrentSources(sources);
+      if (save) {
+        Lab2Registry.getInstance().getProjectManager()?.save(sources, true);
+      }
+      setSourceInitializationCount(count => count + 1);
+    },
+    [setCurrentSources, setSourceInitializationCount]
+  );
+
   useEffect(() => {
-    setCurrentSources(
-      getInitialSources(levelProperties, initialSources) || defaultSources
+    reinitializeSources(
+      getInitialSources(levelProperties, initialSources) || defaultSources,
+      false
     );
-    setSourceInitializationCount(count => count + 1);
-  }, [levelProperties, initialSources, defaultSources]);
+  }, [reinitializeSources, levelProperties, initialSources, defaultSources]);
 
   // Sources to reset to when starting over. Depends on the level edit mode.
   const startOverSources: ProjectSources = useMemo(() => {
@@ -92,7 +108,6 @@ const SourcesContainer: React.FC<
         }
         return newSources;
       });
-      setSourceInitializationCount(count => count + 1);
       Lab2Registry.getInstance()
         .getProjectManager()
         ?.save(newSources, forceSave);
@@ -101,14 +116,9 @@ const SourcesContainer: React.FC<
   );
 
   const onStartOver = useCallback(() => {
-    updateSources(startOverSources as ProjectSources, true);
+    reinitializeSources(startOverSources as ProjectSources, true);
     setStartOverProps(undefined);
-  }, [startOverSources, updateSources]);
-
-  const [startOverProps, setStartOverProps] = useState<{
-    type: MessageType;
-    message?: string;
-  }>();
+  }, [reinitializeSources, startOverSources]);
 
   const showStartOverDialog = useCallback(
     (type: MessageType, message?: string) => {

--- a/apps/src/lab2/views/SourcesContainer.tsx
+++ b/apps/src/lab2/views/SourcesContainer.tsx
@@ -31,7 +31,7 @@ interface SourcesContextType<T extends ProjectSources = ProjectSources> {
   currentSources: T;
   updateSources: (newSources: T, forceSave?: boolean) => void;
   showStartOverDialog: (type: MessageType, message?: string) => void;
-  sourceInitializationCounter: number;
+  sourceInitializationCount: number;
 }
 
 const SourcesContext = createContext<SourcesContextType | null>(null);
@@ -56,14 +56,16 @@ const SourcesContainer: React.FC<
   const [currentSources, setCurrentSources] = useState<ProjectSources>(
     () => getInitialSources(levelProperties, initialSources) || defaultSources
   );
-  const [sourceInitializationCounter, setSourceInitializationCounter] =
-    useState(0);
+
+  // Gives an explicit signal to track when we are resetting sources
+  // via level change, a teacher switching between viewing different students, etc.
+  const [sourceInitializationCount, setSourceInitializationCount] = useState(0);
 
   useEffect(() => {
     setCurrentSources(
       getInitialSources(levelProperties, initialSources) || defaultSources
     );
-    setSourceInitializationCounter(count => count + 1);
+    setSourceInitializationCount(count => count + 1);
   }, [levelProperties, initialSources, defaultSources]);
 
   // Sources to reset to when starting over. Depends on the level edit mode.
@@ -90,6 +92,7 @@ const SourcesContainer: React.FC<
         }
         return newSources;
       });
+      setSourceInitializationCount(count => count + 1);
       Lab2Registry.getInstance()
         .getProjectManager()
         ?.save(newSources, forceSave);
@@ -120,7 +123,7 @@ const SourcesContainer: React.FC<
         currentSources,
         updateSources,
         showStartOverDialog,
-        sourceInitializationCounter,
+        sourceInitializationCount,
       }}
     >
       {children}

--- a/apps/src/lab2/views/SourcesContainer.tsx
+++ b/apps/src/lab2/views/SourcesContainer.tsx
@@ -56,13 +56,7 @@ const SourcesContainer: React.FC<
     children: ReactNode;
     defaultSources: ProjectSources;
   }
-> = ({
-  levelProperties,
-  initialSources,
-  defaultSources,
-
-  children,
-}) => {
+> = ({levelProperties, initialSources, defaultSources, children}) => {
   const [currentSources, setCurrentSources] = useState<ProjectSources>(
     () => getInitialSources(levelProperties, initialSources) || defaultSources
   );
@@ -72,9 +66,10 @@ const SourcesContainer: React.FC<
     message?: string;
   }>();
 
-  const reinitializationHandler = useRef<() => void>(() => {});
-  const setReinitializationHandler = (handler: () => void) =>
-    (reinitializationHandler.current = handler);
+  const reinitializationHandler = useRef<() => void>();
+  const setReinitializationHandler = useCallback((handler: () => void) => {
+    reinitializationHandler.current = handler;
+  }, []);
 
   const reinitializeSources = useCallback(
     (sources: ProjectSources, save: boolean = false) => {
@@ -82,7 +77,10 @@ const SourcesContainer: React.FC<
       if (save) {
         Lab2Registry.getInstance().getProjectManager()?.save(sources, true);
       }
-      reinitializationHandler?.current();
+
+      if (reinitializationHandler.current) {
+        reinitializationHandler.current();
+      }
     },
     [setCurrentSources, reinitializationHandler]
   );

--- a/apps/src/lab2/views/SourcesContainer.tsx
+++ b/apps/src/lab2/views/SourcesContainer.tsx
@@ -7,6 +7,7 @@ import React, {
   useEffect,
   useMemo,
   useState,
+  useRef,
 } from 'react';
 
 import {toolboxToWorkspaceBlocks} from '@cdo/apps/blockly/utils/toolbox';
@@ -31,7 +32,7 @@ interface SourcesContextType<T extends ProjectSources = ProjectSources> {
   currentSources: T;
   updateSources: (newSources: T, forceSave?: boolean) => void;
   showStartOverDialog: (type: MessageType, message?: string) => void;
-  sourceInitializationCount: number;
+  setReinitializationHandler: (handler: () => void) => void;
 }
 
 const SourcesContext = createContext<SourcesContextType | null>(null);
@@ -51,20 +52,29 @@ export function useSources<T extends ProjectSources = ProjectSources>() {
  * Manages sources for a Lab.
  */
 const SourcesContainer: React.FC<
-  LabProps & {children: ReactNode; defaultSources: ProjectSources}
-> = ({levelProperties, initialSources, defaultSources, children}) => {
+  LabProps & {
+    children: ReactNode;
+    defaultSources: ProjectSources;
+  }
+> = ({
+  levelProperties,
+  initialSources,
+  defaultSources,
+
+  children,
+}) => {
   const [currentSources, setCurrentSources] = useState<ProjectSources>(
     () => getInitialSources(levelProperties, initialSources) || defaultSources
   );
-
-  // Gives an explicit signal to track when we are resetting sources
-  // via level change, a teacher switching between viewing different students, etc.
-  const [sourceInitializationCount, setSourceInitializationCount] = useState(0);
 
   const [startOverProps, setStartOverProps] = useState<{
     type: MessageType;
     message?: string;
   }>();
+
+  const reinitializationHandler = useRef<() => void>(() => {});
+  const setReinitializationHandler = (handler: () => void) =>
+    (reinitializationHandler.current = handler);
 
   const reinitializeSources = useCallback(
     (sources: ProjectSources, save: boolean = false) => {
@@ -72,9 +82,9 @@ const SourcesContainer: React.FC<
       if (save) {
         Lab2Registry.getInstance().getProjectManager()?.save(sources, true);
       }
-      setSourceInitializationCount(count => count + 1);
+      reinitializationHandler?.current();
     },
-    [setCurrentSources, setSourceInitializationCount]
+    [setCurrentSources, reinitializationHandler]
   );
 
   useEffect(() => {
@@ -132,7 +142,7 @@ const SourcesContainer: React.FC<
         currentSources,
         updateSources,
         showStartOverDialog,
-        sourceInitializationCount,
+        setReinitializationHandler,
       }}
     >
       {children}

--- a/apps/src/lab2/views/SourcesContainer.tsx
+++ b/apps/src/lab2/views/SourcesContainer.tsx
@@ -67,7 +67,7 @@ const SourcesContainer: React.FC<
   }>();
 
   const reinitializeSources = useCallback(
-    (sources: ProjectSources, save: boolean) => {
+    (sources: ProjectSources, save: boolean = false) => {
       setCurrentSources(sources);
       if (save) {
         Lab2Registry.getInstance().getProjectManager()?.save(sources, true);
@@ -79,8 +79,7 @@ const SourcesContainer: React.FC<
 
   useEffect(() => {
     reinitializeSources(
-      getInitialSources(levelProperties, initialSources) || defaultSources,
-      false
+      getInitialSources(levelProperties, initialSources) || defaultSources
     );
   }, [reinitializeSources, levelProperties, initialSources, defaultSources]);
 

--- a/apps/src/lab2/views/SourcesContainer.tsx
+++ b/apps/src/lab2/views/SourcesContainer.tsx
@@ -31,6 +31,7 @@ interface SourcesContextType<T extends ProjectSources = ProjectSources> {
   currentSources: T;
   updateSources: (newSources: T, forceSave?: boolean) => void;
   showStartOverDialog: (type: MessageType, message?: string) => void;
+  sourceInitializationCounter: number;
 }
 
 const SourcesContext = createContext<SourcesContextType | null>(null);
@@ -55,11 +56,14 @@ const SourcesContainer: React.FC<
   const [currentSources, setCurrentSources] = useState<ProjectSources>(
     () => getInitialSources(levelProperties, initialSources) || defaultSources
   );
+  const [sourceInitializationCounter, setSourceInitializationCounter] =
+    useState(0);
 
   useEffect(() => {
     setCurrentSources(
       getInitialSources(levelProperties, initialSources) || defaultSources
     );
+    setSourceInitializationCounter(count => count + 1);
   }, [levelProperties, initialSources, defaultSources]);
 
   // Sources to reset to when starting over. Depends on the level edit mode.
@@ -112,7 +116,12 @@ const SourcesContainer: React.FC<
 
   return (
     <SourcesContext.Provider
-      value={{currentSources, updateSources, showStartOverDialog}}
+      value={{
+        currentSources,
+        updateSources,
+        showStartOverDialog,
+        sourceInitializationCounter,
+      }}
     >
       {children}
       {startOverProps && (

--- a/apps/src/sketchlab/SketchlabView.tsx
+++ b/apps/src/sketchlab/SketchlabView.tsx
@@ -42,6 +42,9 @@ const SketchlabView: React.FC<LabProps<LevelProperties>> = ({
   const saveSourcesTimeoutRef = useRef<NodeJS.Timeout | null>(null);
 
   const hasRun = useAppSelector(state => state.lab2System.hasRun);
+  // We remount (ie, reset) Excalidraw any time we observe
+  // sources being initialized (eg, when level changes, teacher views a student's project, etc).
+  const [excalidrawMountKey, setExcalidrawMountKey] = useState(0);
 
   const WorkspaceAlert = useLevelEditMode<LevelProperties>(
     levelProperties.id,
@@ -122,11 +125,9 @@ const SketchlabView: React.FC<LabProps<LevelProperties>> = ({
     };
   }, []);
 
-  // We remount (ie, reset) Excalidraw any time we observe
-  // sources being initialized (eg, when level changes, teacher views a student's project, etc).
-  const [excalidrawMountKey, setExcalidrawMountKey] = useState(0);
-
-  setReinitializationHandler(() => () => setExcalidrawMountKey(key => key + 1));
+  useEffect(() => {
+    setReinitializationHandler(() => setExcalidrawMountKey(key => key + 1));
+  }, [setReinitializationHandler]);
 
   // Since there's no run button in Sketch Lab, set it to true by default
   // to enable the Submit button on edit on submittable levels.

--- a/apps/src/sketchlab/SketchlabView.tsx
+++ b/apps/src/sketchlab/SketchlabView.tsx
@@ -37,7 +37,7 @@ const SketchlabView: React.FC<LabProps<LevelProperties>> = ({
   levelProperties,
 }) => {
   const excalidrawApiRef = useRef<ExcalidrawImperativeAPI | null>();
-  const {currentSources, updateSources, sourceInitializationCounter} =
+  const {currentSources, updateSources, sourceInitializationCount} =
     useSources<SketchlabSources>();
   const saveSourcesTimeoutRef = useRef<NodeJS.Timeout | null>(null);
   const [excalidrawMountKey, setExcalidrawMountKey] = useState(0);
@@ -123,9 +123,11 @@ const SketchlabView: React.FC<LabProps<LevelProperties>> = ({
     };
   }, []);
 
+  // We remount (ie, reset) Excalidraw any time we observe
+  // sources being initialized (eg, when level changes, teacher views a student's project, etc).
   useEffect(() => {
     setExcalidrawMountKey(key => key + 1);
-  }, [sourceInitializationCounter]);
+  }, [sourceInitializationCount]);
 
   // Since there's no run button in Sketch Lab, set it to true by default
   // to enable the Submit button on edit on submittable levels.

--- a/apps/src/sketchlab/SketchlabView.tsx
+++ b/apps/src/sketchlab/SketchlabView.tsx
@@ -37,10 +37,9 @@ const SketchlabView: React.FC<LabProps<LevelProperties>> = ({
   levelProperties,
 }) => {
   const excalidrawApiRef = useRef<ExcalidrawImperativeAPI | null>();
-  const {currentSources, updateSources, sourceInitializationCount} =
+  const {currentSources, updateSources, setReinitializationHandler} =
     useSources<SketchlabSources>();
   const saveSourcesTimeoutRef = useRef<NodeJS.Timeout | null>(null);
-  const [excalidrawMountKey, setExcalidrawMountKey] = useState(0);
 
   const hasRun = useAppSelector(state => state.lab2System.hasRun);
 
@@ -125,9 +124,9 @@ const SketchlabView: React.FC<LabProps<LevelProperties>> = ({
 
   // We remount (ie, reset) Excalidraw any time we observe
   // sources being initialized (eg, when level changes, teacher views a student's project, etc).
-  useEffect(() => {
-    setExcalidrawMountKey(key => key + 1);
-  }, [sourceInitializationCount]);
+  const [excalidrawMountKey, setExcalidrawMountKey] = useState(0);
+
+  setReinitializationHandler(() => () => setExcalidrawMountKey(key => key + 1));
 
   // Since there's no run button in Sketch Lab, set it to true by default
   // to enable the Submit button on edit on submittable levels.

--- a/apps/src/sketchlab/SketchlabView.tsx
+++ b/apps/src/sketchlab/SketchlabView.tsx
@@ -37,7 +37,8 @@ const SketchlabView: React.FC<LabProps<LevelProperties>> = ({
   levelProperties,
 }) => {
   const excalidrawApiRef = useRef<ExcalidrawImperativeAPI | null>();
-  const {currentSources, updateSources} = useSources<SketchlabSources>();
+  const {currentSources, updateSources, sourceInitializationCounter} =
+    useSources<SketchlabSources>();
   const saveSourcesTimeoutRef = useRef<NodeJS.Timeout | null>(null);
   const [excalidrawMountKey, setExcalidrawMountKey] = useState(0);
 
@@ -122,25 +123,9 @@ const SketchlabView: React.FC<LabProps<LevelProperties>> = ({
     };
   }, []);
 
-  // This effect runs on each source change,
-  // but the full remount (via key change) is only intended when
-  // Excalidraw state diverges from the saved source state.
-  // This happens when a user switches levels, or a teachers switches
-  // between viewing different students on the same level.
   useEffect(() => {
-    // Note that we do not compare appState, as Excalidraw tracks a lot of app state properties
-    // that we do not store to S3.
-    const excalidrawApi = excalidrawApiRef.current;
-    if (
-      excalidrawApi &&
-      (JSON.stringify(excalidrawApi.getSceneElements()) !==
-        JSON.stringify(currentSources.source.elements) ||
-        JSON.stringify(excalidrawApi.getFiles()) !==
-          JSON.stringify(currentSources.source.files))
-    ) {
-      setExcalidrawMountKey(key => key + 1);
-    }
-  }, [currentSources.source]);
+    setExcalidrawMountKey(key => key + 1);
+  }, [sourceInitializationCounter]);
 
   // Since there's no run button in Sketch Lab, set it to true by default
   // to enable the Submit button on edit on submittable levels.


### PR DESCRIPTION
Follow-up to some discussion kicked off in this PR: https://github.com/code-dot-org/code-dot-org/pull/68770

This PR ~~adds a bit of state that increments when we attempt to reinitialize sources (eg, when a user switches levels, etc.)~~

Updated approach: allows setting a reinitialization handler that will be called when reinitialization events occur (eg, user switching levels, etc).

This is useful In Sketch Lab, where we currently depend on doing a deep comparison of objects to decide when to reinitialize when one of these "reinitialization" events occur. With this change, we can just reinitialize when this counter is incremented.

## Testing story

I tested manually switching between levels and adding new content to a single level in Sketch Lab.

I also tested the "start over" feature in lab2 Dance, which got reworked a little bit in this PR.