### PR TITLE
Add 3-/10-Day Workshop Reminder email for Regional Partners

### DIFF
--- a/dashboard/app/mailers/pd/workshop_mailjet_mailer.rb
+++ b/dashboard/app/mailers/pd/workshop_mailjet_mailer.rb
@@ -3,28 +3,20 @@ require 'pd/certificate_renderer'
 
 class Pd::WorkshopMailjetMailer
   def self.send_teacher_workshop_reminder(enrollment, user, use_alternate_email, days)
-    workshop = enrollment.workshop
-    organizer = workshop.organizer
-    regional_partner = workshop.regional_partner
     email = use_alternate_email ? user.alternate_email : user.email
-    email_vars = {
-      email_to: email,
-      name: user.given_name || user.name,
-      cancel_registration_link: CDO.studio_url("pd/workshop_enrollment/#{enrollment.code}/cancel", CDO.default_scheme),
-      pre_survey_link: enrollment.pre_workshop_survey_url,
-      facilitator_name: workshop_facilitator_names(workshop),
-      rp_email: contact_email_with_fallback(regional_partner&.contact_email_with_backup),
-      rp_name: contact_name_with_fallback(regional_partner&.name),
-      organizer_email: contact_email_with_fallback(organizer&.email),
-      organizer_name: contact_name_with_fallback(organizer&.name),
-      workshop_notes: workshop.notes || 'No additional information at this time.',
-      sessions: workshop.sessions.map(&:session_info_for_emails),
-      workshop_subjects: workshop.course_offerings.present? ? workshop.course_offerings.map(&:display_name)&.join(', ') : workshop.subject,
-      workshop_name: workshop_name_with_fallback(workshop),
-      num_days: days
-    }
+    name = user.given_name || user.name
+    email_vars = build_workshop_reminder_email_vars(enrollment.workshop, name, email, days, enrollment)
 
     retryable_send_email('teacher_workshop_reminder', email, user.friendly_name, email_vars)
+  end
+
+  def self.send_rp_workshop_reminder(workshop, days)
+    rp = workshop.regional_partner
+    rp_email = contact_email_with_fallback(rp&.contact_email_with_backup)
+    rp_name = contact_name_with_fallback(rp&.name)
+    email_vars = build_workshop_reminder_email_vars(workshop, rp_name, rp_email, days)
+
+    retryable_send_email('regional_partner_workshop_reminder', rp_email, rp_name, email_vars)
   end
 
   def self.send_teacher_workshop_detail_change_notification(enrollment, user, use_alternate_email, general_detail_changes, sessions_have_changed, pre_update_session_info, post_update_session_info)
@@ -113,5 +105,27 @@ class Pd::WorkshopMailjetMailer
 
   private_class_method def self.contact_name_with_fallback(name)
     name.presence || 'Code.org'
+  end
+
+  private_class_method def self.build_workshop_reminder_email_vars(workshop, name, email, days, enrollment = nil)
+    organizer = workshop.organizer
+    regional_partner = workshop.regional_partner
+
+    {
+      email_to: email,
+      name: name,
+      cancel_registration_link: enrollment&.code ? CDO.studio_url("pd/workshop_enrollment/#{enrollment.code}/cancel", CDO.default_scheme) : '',
+      pre_survey_link: enrollment&.pre_workshop_survey_url.presence || '',
+      facilitator_name: workshop_facilitator_names(workshop),
+      rp_email: contact_email_with_fallback(regional_partner&.contact_email_with_backup),
+      rp_name: contact_name_with_fallback(regional_partner&.name),
+      organizer_email: contact_email_with_fallback(organizer&.email),
+      organizer_name: contact_name_with_fallback(organizer&.name),
+      workshop_notes: workshop.notes || 'No additional information at this time.',
+      sessions: workshop.sessions.map(&:session_info_for_emails),
+      workshop_subjects: workshop.course_offerings.present? ? workshop.course_offerings.map(&:display_name)&.join(', ') : workshop.subject,
+      workshop_name: workshop_name_with_fallback(workshop),
+      num_days: days
+    }
   end
 end

--- a/dashboard/app/models/pd/workshop.rb
+++ b/dashboard/app/models/pd/workshop.rb
@@ -538,7 +538,7 @@ class Pd::Workshop < ApplicationRecord
     scheduled_start_in_days(days).each do |workshop|
       next if workshop.suppress_reminders?
 
-      # Send reminder emails to enrollees
+      # Send reminder email to workshop enrollees
       workshop.enrollments.each do |enrollment|
         user = enrollment.user
         Pd::WorkshopMailjetMailer.send_teacher_workshop_reminder(enrollment, user, false, days)
@@ -551,7 +551,7 @@ class Pd::Workshop < ApplicationRecord
         errors << "teacher enrollment #{enrollment.id} - #{exception.message}"
       end
 
-      # Send reminder email to Regional Partner
+      # Send reminder email to the workshop Regional Partner (if available)
       if workshop.regional_partner.present?
         begin
           Pd::WorkshopMailjetMailer.send_rp_workshop_reminder(workshop, days)
@@ -560,6 +560,7 @@ class Pd::Workshop < ApplicationRecord
         end
       end
 
+      # Send reminder email to facilitators (if available)
       workshop.facilitators.each do |facilitator|
         next if facilitator == workshop.organizer
         begin
@@ -569,6 +570,7 @@ class Pd::Workshop < ApplicationRecord
         end
       end
 
+      # Send reminder email to the workshop organizer
       begin
         Pd::WorkshopMailer.organizer_enrollment_reminder(workshop).deliver_now
       rescue => exception

--- a/dashboard/app/models/pd/workshop.rb
+++ b/dashboard/app/models/pd/workshop.rb
@@ -538,6 +538,7 @@ class Pd::Workshop < ApplicationRecord
     scheduled_start_in_days(days).each do |workshop|
       next if workshop.suppress_reminders?
 
+      # Send reminder emails to enrollees
       workshop.enrollments.each do |enrollment|
         user = enrollment.user
         Pd::WorkshopMailjetMailer.send_teacher_workshop_reminder(enrollment, user, false, days)
@@ -548,6 +549,15 @@ class Pd::Workshop < ApplicationRecord
         end
       rescue => exception
         errors << "teacher enrollment #{enrollment.id} - #{exception.message}"
+      end
+
+      # Send reminder email to Regional Partner
+      if workshop.regional_partner.present?
+        begin
+          Pd::WorkshopMailjetMailer.send_rp_workshop_reminder(workshop, days)
+        rescue => exception
+          errors << "regional partner #{workshop.regional_partner.id} - #{exception.message}"
+        end
       end
 
       workshop.facilitators.each do |facilitator|

--- a/dashboard/test/models/pd/workshop_test.rb
+++ b/dashboard/test/models/pd/workshop_test.rb
@@ -719,6 +719,50 @@ class Pd::WorkshopTest < ActiveSupport::TestCase
     assert_includes(e.message, 'bad email')
   end
 
+  test 'does not send regional_partner_workshop_reminder if suppress_reminders? is true' do
+    Pd::WorkshopMailjetMailer.expects(:send_rp_workshop_reminder).never
+
+    regional_partner = create(:regional_partner)
+    program_manager = create(:program_manager, regional_partner: regional_partner)
+    workshop = create(:workshop, organizer: program_manager, suppress_email: true)
+    teacher = create(:teacher)
+    create(:pd_enrollment, workshop: workshop, user: teacher)
+    Pd::Workshop.expects(:scheduled_start_in_days).returns([workshop])
+
+    Pd::Workshop.send_reminder_for_upcoming_in_days(10)
+  end
+
+  test 'sends regional_partner_workshop_reminder if suppress_reminders? is false' do
+    Pd::WorkshopMailjetMailer.expects(:send_rp_workshop_reminder).times(1)
+
+    regional_partner = create(:regional_partner)
+    program_manager = create(:program_manager, regional_partner: regional_partner)
+    workshop = create(:workshop, organizer: program_manager, suppress_email: false)
+    teacher = create(:teacher)
+    create(:pd_enrollment, workshop: workshop, user: teacher)
+    Pd::Workshop.expects(:scheduled_start_in_days).returns([workshop])
+
+    Pd::Workshop.send_reminder_for_upcoming_in_days(10)
+  end
+
+  test 'errors in regional partner reminders in send_reminder_for_upcoming_in_days do not stop batch' do
+    Pd::WorkshopMailjetMailer.stubs(:send_rp_workshop_reminder).raises(RuntimeError, 'regional partner workshop bad email')
+
+    regional_partner = create(:regional_partner)
+    program_manager = create(:program_manager, regional_partner: regional_partner)
+    workshop = create(:workshop, organizer: program_manager, suppress_email: false)
+    teacher = create(:teacher)
+    create(:pd_enrollment, workshop: workshop, user: teacher)
+    Pd::Workshop.expects(:scheduled_start_in_days).returns([workshop])
+
+    e = assert_raises RuntimeError do
+      Pd::Workshop.send_reminder_for_upcoming_in_days(10)
+    end
+    assert_includes(e.message, 'Failed to send 10 day workshop reminders:')
+    assert_includes(e.message, 'regional partner')
+    assert_includes(e.message, 'bad email')
+  end
+
   test 'errors in organizer reminders in send_reminder_for_upcoming_in_days do not stop batch' do
     mock_mail = stub
     mock_mail.stubs(:deliver_now).returns(nil).then.returns(nil).then.returns(nil).then.returns(nil).then.returns(nil).then.raises(RuntimeError, 'bad email')

--- a/lib/cdo/shared_constants/mailjet_constants.rb
+++ b/lib/cdo/shared_constants/mailjet_constants.rb
@@ -47,6 +47,15 @@ module MailjetConstants
       from_address: 'noreply@code.org',
       from_name: 'Code.org',
     },
+    regional_partner_workshop_reminder: {
+      template_id: {
+        production: {
+          default: 7_243_794,
+        }
+      },
+      from_address: 'noreply@code.org',
+      from_name: 'Code.org',
+    },
     teacher_workshop_detail_change_notification: {
       template_id: {
         production: {


### PR DESCRIPTION
Sends Regional Partners a similar workshop reminder email to the one sent to enrollees. Note: since regional partners don't have their own enrollment, the "Take pre-survey" and "Cancel registration" buttons are disabled with a note stating that participants will be able to use these buttons.

<img width="719" height="557" alt="1" src="https://github.com/user-attachments/assets/ae206309-109a-4c01-8d99-a25bb2a89982" />

<img width="736" height="572" alt="2" src="https://github.com/user-attachments/assets/3b64dbc6-b8f0-4f15-bc94-51993630c557" />


## Links
Jira ticket: [here](https://codedotorg.atlassian.net/jira/software/projects/AITT/boards/70?jql=assignee%20%3D%2060d62161f65054006980bd71&selectedIssue=AITT-1238)
MailJet email template: [here](https://app.mailjet.com/template/13234463/build)

## Testing story
Local testing and adding unit tests.
