### PR TITLE
feat(HofAI): clean up the catalog UX

### DIFF
--- a/frontend/apps/marketing/src/app/[brand]/[locale]/activities/[activityType]/page.tsx
+++ b/frontend/apps/marketing/src/app/[brand]/[locale]/activities/[activityType]/page.tsx
@@ -1,4 +1,3 @@
-import Box from '@mui/material/Box';
 import {Results, search} from '@orama/orama';
 import {persist} from '@orama/plugin-data-persistence';
 import {Metadata} from 'next';
@@ -142,20 +141,11 @@ export default async function ActivitiesPage({
     <main>
       <ActivitiesHero activityType={activityType as ActivityType} />
       <Suspense>
-        <Box
-          sx={{
-            maxWidth: 1200,
-            mx: 'auto',
-            px: {xs: 2, md: 4},
-            pb: {xs: 2, md: 8},
-          }}
-        >
-          <ActivityCatalog
-            serializedOramaDb={await getSerializedOramaDatabase()}
-            activities={await getAllActivities()}
-            facets={await getSearchFacets()}
-          />
-        </Box>
+        <ActivityCatalog
+          serializedOramaDb={await getSerializedOramaDatabase()}
+          activities={await getAllActivities()}
+          facets={await getSearchFacets()}
+        />
       </Suspense>
     </main>
   );

--- a/frontend/apps/marketing/src/components/contentful/activityCatalog/activityCatalog.tsx
+++ b/frontend/apps/marketing/src/components/contentful/activityCatalog/activityCatalog.tsx
@@ -1,7 +1,9 @@
 'use client';
 import FilterAltOutlinedIcon from '@mui/icons-material/FilterAltOutlined';
+import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
 import Grid from '@mui/material/Grid';
+import TextField from '@mui/material/TextField';
 import {FacetResult, InternalTypedDocument, Orama, search} from '@orama/orama';
 import {restore} from '@orama/plugin-data-persistence';
 import {useSearchParams} from 'next/navigation';
@@ -10,7 +12,6 @@ import {useDebouncedCallback} from 'use-debounce';
 
 import FacetBar from '@/components/contentful/activityCatalog/facetBar/facetBar';
 import FacetDrawer from '@/components/contentful/activityCatalog/facetDrawer/facetDrawer';
-import Section from '@/components/contentful/section';
 import ActivityCollection from '@/components/csforall/activityCollection/ActivityCollection';
 import {ActivitySchema} from '@/modules/activityCatalog/orama/schema/ActivitySchema';
 import {OramaActivity} from '@/modules/activityCatalog/types/Activity';
@@ -243,34 +244,56 @@ const ActivityCatalog = ({
   };
 
   return (
-    <Section>
+    <Box sx={{p: 1}}>
       <FacetDrawer
         {...facetBarProps}
         isOpen={isFacetDrawerOpen}
         onClose={() => toggleFacetDrawer(false)}
       />
-      <Grid container spacing={6} sx={{justifyContent: 'center', mb: 5}}>
-        <Grid size={10} sx={{display: {xs: 'none', sm: 'none', md: 'block'}}}>
+
+      <Grid container justifyContent="center" flexWrap={'nowrap'}>
+        <Grid
+          size={3}
+          sx={{
+            display: {xs: 'none', sm: 'none', md: 'block'},
+            maxWidth: 275,
+            flexBasis: 275,
+          }}
+        >
           <FacetBar {...facetBarProps} />
         </Grid>
-
-        <Grid
-          container
-          justifyContent="center"
-          sx={{display: {xs: 'flex', md: 'none'}}}
-        >
-          <Button
-            onClick={() => toggleFacetDrawer(true)}
-            color={'secondary'}
-            variant={'contained'}
-            size={'small'}
-          >
-            <FilterAltOutlinedIcon /> Filters
-          </Button>
+        <Grid size={9}>
+          <Box sx={{display: 'flex', mb: 2, gap: 2}}>
+            <TextField
+              fullWidth
+              variant="outlined"
+              size="small"
+              placeholder="Search..."
+              aria-label="Search activities"
+              value={searchTerm}
+              onChange={handleSearchTermChange}
+              sx={{
+                backgroundColor: 'background.paper',
+                borderRadius: 2,
+              }}
+            />
+            <Button
+              onClick={() => toggleFacetDrawer(true)}
+              color={'secondary'}
+              variant={'contained'}
+              size={'small'}
+              sx={{
+                display: {xs: 'inline-flex', sm: 'inline-flex', md: 'none'},
+                flexShrink: 0,
+              }}
+            >
+              <FilterAltOutlinedIcon /> Filters
+            </Button>
+          </Box>
+          <ActivityCollection activities={results} />
         </Grid>
       </Grid>
-      <ActivityCollection activities={results} />
-    </Section>
+    </Box>
   );
 };
 

--- a/frontend/apps/marketing/src/components/contentful/activityCatalog/facetBar/facetBar.tsx
+++ b/frontend/apps/marketing/src/components/contentful/activityCatalog/facetBar/facetBar.tsx
@@ -1,13 +1,17 @@
 'use client';
-import CloseRoundedIcon from '@mui/icons-material/CloseRounded';
-import SearchIcon from '@mui/icons-material/Search';
-import {Chip, MenuItem, Select} from '@mui/material';
-import Button from '@mui/material/Button';
-import FormControl from '@mui/material/FormControl';
-import Grid from '@mui/material/Grid';
-import Input from '@mui/material/Input';
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
+import {
+  Accordion,
+  AccordionDetails,
+  AccordionSummary,
+  Box,
+  Checkbox,
+  FormControlLabel,
+  FormGroup,
+  Typography,
+} from '@mui/material';
 import {FacetResult} from '@orama/orama';
-import {ChangeEvent, useState} from 'react';
+import {ChangeEvent} from 'react';
 
 import {FACET_LABELS} from '@/components/contentful/activityCatalog/config/facets';
 
@@ -20,15 +24,7 @@ interface FacetPanelProps {
   onSearchTermChange: (e: ChangeEvent<HTMLInputElement>) => void;
   onClearAll: () => void;
 }
-const FacetBar = ({
-  isInDrawer,
-  facets,
-  selectedFacets,
-  searchTerm,
-  onFacetChange,
-  onClearAll,
-  onSearchTermChange,
-}: FacetPanelProps) => {
+const FacetBar = ({facets, selectedFacets, onFacetChange}: FacetPanelProps) => {
   if (!facets) {
     return null;
   }
@@ -37,185 +33,68 @@ const FacetBar = ({
     onFacetChange(facet, facetValue);
   };
 
-  const [openFacet, setOpenFacet] = useState<string | null>(null);
-
-  const getDropdownMenuItem = (
-    selectedFacetValues: Set<string>,
-    facet: string,
-    facetValue: string,
-  ) => {
-    const isSelected = selectedFacetValues?.has(facetValue);
-    return (
-      <MenuItem
-        key={facetValue}
-        value={facetValue}
-        disableRipple
-        sx={{
-          '&, &:hover, &.Mui-focusVisible, &.Mui-selected, &.Mui-selected:hover':
-            {
-              backgroundColor: 'transparent',
-            },
-        }}
-      >
-        <Chip
-          key={facetValue}
-          label={facetValue}
-          onDelete={
-            isSelected ? () => handleChange(facet, facetValue) : undefined
-          }
-          deleteIcon={
-            isSelected ? <CloseRoundedIcon fontSize="small" /> : undefined
-          }
-          variant={isSelected ? 'filled' : 'outlined'}
-          color={isSelected ? 'primary' : 'default'}
-          sx={{
-            backgroundColor: !isSelected ? '#fff' : undefined,
-            '&:hover': {backgroundColor: !isSelected ? '#fff' : undefined},
-          }}
-        />
-      </MenuItem>
-    );
-  };
-
   const getDropdowns = () => {
     return Object.entries(facets).map(([facet, facetDetails]) => {
       // Sort using localeCompare with numeric option for mixed strings/numbers
       const facetValues = Object.keys(facetDetails.values).sort((a, b) =>
         a.localeCompare(b, undefined, {numeric: true}),
       );
-      const hasSelectedValue =
-        selectedFacets[facet] && selectedFacets[facet].size > 0;
 
       return (
-        <FormControl
-          key={facet}
+        <Accordion
+          defaultExpanded
           sx={{
-            minWidth: 0,
-            mr: 2,
-            mb: 1.25,
+            bgcolor: 'card.main',
+            color: 'card.contrastText',
+            width: '100%',
           }}
         >
-          <Select
-            aria-label={FACET_LABELS[facet]}
-            multiple
-            onChange={e => handleChange(facet, e.target.value[0])}
-            value={[]}
-            open={openFacet === facet}
-            onOpen={() => setOpenFacet(facet)}
-            onClose={() => setOpenFacet(null)}
-            MenuProps={{
-              disableScrollLock: true,
-              anchorOrigin: {vertical: 'bottom', horizontal: 'left'},
-              transformOrigin: {vertical: 'top', horizontal: 'left'},
-              PaperProps: {
-                onMouseLeave: () => setOpenFacet(null),
-                sx: theme => ({
-                  p: {xs: 1, sm: 2},
-                  pb: {xs: 1, sm: 2},
-                  boxShadow: 2,
-                  paddingBottom: 1,
-                  backgroundColor: '#E9FAFF',
-                  borderRadius: 0.5,
-                  boxSizing: 'border-box',
-                  overflow: 'auto',
-                  zIndex: theme.zIndex.modal + 1,
-                }),
-              },
-              MenuListProps: {
-                dense: true,
-                disablePadding: true,
-                sx: {p: 0, m: 0, width: '100%'},
-              },
-            }}
-            sx={theme => ({
-              width: 'auto',
-              minWidth: 'fit-content',
-              '.MuiSelect-select': {
-                minWidth: 'fit-content',
-                padding: 1.8,
-                fontSize: 19,
-                display: 'inline-flex',
-                verticalAlign: 'top',
-                '.MuiSelect-select': {
-                  display: 'inline-flex',
-                  alignItems: 'center',
-                  whiteSpace: 'nowrap',
-                  minWidth: 'max-content',
-
-                  backgroundColor: hasSelectedValue
-                    ? theme.palette.primary.main
-                    : 'inherit',
-                  color: hasSelectedValue
-                    ? theme.palette.common.white
-                    : 'inherit',
-                },
-                '& .MuiSelect-icon': {
-                  color: hasSelectedValue
-                    ? theme.palette.common.white
-                    : theme.palette.action.active,
-                },
-              },
-            })}
-            displayEmpty
-            renderValue={() => (
-              <span style={{whiteSpace: 'nowrap'}}>{FACET_LABELS[facet]}</span>
-            )}
+          <AccordionSummary
+            expandIcon={<ExpandMoreIcon sx={{color: 'foreground.main'}} />}
+            sx={{padding: 1}}
           >
-            {facetValues.map(facetValue => {
-              return getDropdownMenuItem(
-                selectedFacets[facet],
-                facet,
-                facetValue,
-              );
-            })}
-          </Select>
-        </FormControl>
+            <Typography variant="subtitle1" sx={{fontWeight: 600}}>
+              {FACET_LABELS[facet]}
+            </Typography>
+          </AccordionSummary>
+          <AccordionDetails>
+            <FormGroup>
+              {facetValues.map(facetValue => {
+                return (
+                  <FormControlLabel
+                    key={facetValue}
+                    control={
+                      <Checkbox
+                        checked={
+                          selectedFacets[facet]?.has(facetValue) || false
+                        }
+                        onChange={() => handleChange(facet, facetValue)}
+                        sx={{color: 'muted.contrastText'}}
+                      />
+                    }
+                    label={
+                      <Typography variant="body4">{facetValue}</Typography>
+                    }
+                  />
+                );
+              })}
+            </FormGroup>
+          </AccordionDetails>
+        </Accordion>
       );
     });
   };
 
   return (
-    <Grid
-      container
-      spacing={isInDrawer ? 1 : 2}
-      flexDirection={isInDrawer ? 'column' : 'row'}
+    <Box
+      sx={{
+        display: 'flex',
+        flexDirection: 'column',
+        padding: 2,
+      }}
     >
-      <Grid size={isInDrawer ? 12 : 2}>
-        <Input
-          disableUnderline
-          onChange={onSearchTermChange}
-          value={searchTerm}
-          placeholder="Search..."
-          startAdornment={<SearchIcon fontSize="small" />}
-          sx={{
-            px: 2,
-            py: 1.4,
-            borderRadius: 999,
-            border: '1px solid',
-            borderColor: 'grey.400',
-            backgroundColor: 'background.paper',
-            fontSize: 19,
-            width: 'calc(100% + 5px)',
-          }}
-        />
-      </Grid>
-
-      <Grid size={isInDrawer ? 12 : 10}>
-        {getDropdowns()}
-        <Button
-          onClick={onClearAll}
-          sx={{
-            borderRadius: 999,
-            py: 3,
-            mr: {xs: 0, sm: 'auto'},
-            ml: {xs: 0, sm: 0},
-            pl: 4,
-          }}
-        >
-          Clear All
-        </Button>
-      </Grid>
-    </Grid>
+      {getDropdowns()}
+    </Box>
   );
 };
 

--- a/frontend/apps/marketing/src/components/contentful/activityCatalog/facetDrawer/facetDrawer.tsx
+++ b/frontend/apps/marketing/src/components/contentful/activityCatalog/facetDrawer/facetDrawer.tsx
@@ -58,24 +58,7 @@ const FacetDrawer = ({isOpen, onClose, ...props}: FacetDrawerProps) => {
           pb: 2,
         }}
       >
-        <Box
-          sx={{
-            display: 'grid',
-            gridTemplateColumns: {
-              xs: '1fr',
-              sm: 'repeat(2, minmax(0, 1fr))',
-            },
-            columnGap: 2,
-            rowGap: 3,
-            '& .MuiFormControl-root': {
-              width: '100%',
-              m: 0,
-              pb: 1,
-              boxSizing: 'border-box',
-              '&:not(:last-of-type)': {mb: 0, mr: 0},
-            },
-          }}
-        >
+        <Box>
           <FacetBar {...props} isInDrawer />
         </Box>
       </Box>

--- a/frontend/apps/marketing/src/components/contentful/card/Card.tsx
+++ b/frontend/apps/marketing/src/components/contentful/card/Card.tsx
@@ -3,6 +3,7 @@ import CardMui from '@mui/material/Card';
 import CardActions from '@mui/material/CardActions';
 import CardContent from '@mui/material/CardContent';
 import CardMedia from '@mui/material/CardMedia';
+import Chip from '@mui/material/Chip';
 import Typography from '@mui/material/Typography';
 import {HTMLAttributes, useMemo} from 'react';
 
@@ -38,11 +39,14 @@ export interface CardProps extends HTMLAttributes<HTMLDivElement> {
   eventMetadata?: Record<string, string>;
   /** Card custom className */
   className?: string;
+  /** Card chips */
+  chipLabels?: string[];
 }
 
 const Card: React.FC<CardProps> = ({
   id,
   title,
+  chipLabels,
   description,
   imageSrc,
   imageHeight,
@@ -88,20 +92,33 @@ const Card: React.FC<CardProps> = ({
     if (imageHeight) {
       return `${imageHeight}px`;
     }
-    return '300px';
+    return '245px';
   }, [imageHeight]);
 
   return (
-    <CardMui className={className} raised={false}>
+    <CardMui
+      className={className}
+      raised={false}
+      sx={{
+        border: '1px solid #f5f5f5',
+        boxShadow: 'none',
+        borderRadius: '12px',
+        minWidth: 275,
+      }}
+    >
       {imageSource && (
         <CardMedia
-          sx={{height: setImageHeight, position: 'relative'}}
+          sx={{
+            height: setImageHeight,
+            position: 'relative',
+            backgroundColor: '#f5f5f5',
+          }}
           component={'div'}
         >
           <NextImage
             alt={title || ''}
             src={imageSource}
-            style={{objectFit: 'cover'}}
+            style={{objectFit: 'contain'}}
           />
         </CardMedia>
       )}
@@ -111,10 +128,19 @@ const Card: React.FC<CardProps> = ({
             {overline}
           </Overline>
         )}
-        <Typography variant="h5" component="h3" gutterBottom>
+        <Typography variant="h6" component="h3" gutterBottom>
           {title}
         </Typography>
-        <Typography variant="body3">{description}</Typography>
+        {chipLabels && chipLabels.length > 0 && (
+          <div
+            style={{marginBottom: 8, display: 'flex', gap: 4, flexWrap: 'wrap'}}
+          >
+            {chipLabels.map((label, idx) => (
+              <Chip key={idx} label={label} size="small" />
+            ))}
+          </div>
+        )}
+        <Typography variant="body4">{description}</Typography>
       </CardContent>
       <CardActions disableSpacing>
         {primaryButton?.fields && (

--- a/frontend/apps/marketing/src/components/contentful/card/Card.tsx
+++ b/frontend/apps/marketing/src/components/contentful/card/Card.tsx
@@ -12,6 +12,7 @@ import Overline from '@/components/contentful/overline';
 import NextImage from '@/components/nextImage/NextImage';
 import {useStatsigLogger} from '@/providers/statsig/client';
 import {getAbsoluteImageUrl} from '@/selectors/contentful/getImage';
+import theme from '@/themes/csforall';
 import {LinkEntry} from '@/types/contentful/entries/Link';
 
 export interface CardProps extends HTMLAttributes<HTMLDivElement> {
@@ -100,7 +101,7 @@ const Card: React.FC<CardProps> = ({
       className={className}
       raised={false}
       sx={{
-        border: '1px solid #f5f5f5',
+        border: `1px solid ${theme.palette.common.black}`,
         boxShadow: 'none',
         borderRadius: '12px',
         minWidth: 275,
@@ -111,7 +112,7 @@ const Card: React.FC<CardProps> = ({
           sx={{
             height: setImageHeight,
             position: 'relative',
-            backgroundColor: '#f5f5f5',
+            backgroundColor: theme.palette.common.black,
           }}
           component={'div'}
         >

--- a/frontend/apps/marketing/src/components/contentful/carousels/activityCarousel/ActivityCarousel.tsx
+++ b/frontend/apps/marketing/src/components/contentful/carousels/activityCarousel/ActivityCarousel.tsx
@@ -1,0 +1,75 @@
+'use client';
+
+import React from 'react';
+
+import DSCOCarousel from '@code-dot-org/component-library/carousel';
+
+import Card from '@/components/contentful/card';
+import {resolveContentfulLink} from '@/contentful/resolveLink';
+import {Activity} from '@/modules/activityCatalog/types/Activity';
+import {EVENT} from '@/providers/statsig/statsigConstants';
+import {getAbsoluteImageUrl} from '@/selectors/contentful/getImage';
+import {LinkEntry} from '@/types/contentful/entries/Link';
+import {Entry} from '@/types/contentful/Entry';
+import {ExperienceAsset} from '@/types/contentful/ExperienceAsset';
+
+type ActivityCarouselEntry = Entry<Activity>;
+
+export type ActivityCarouselProps = {
+  /** Carousel content w/ fields from Contentful */
+  slides: ActivityCarouselEntry[];
+};
+
+const ActivityCarousel: React.FC<ActivityCarouselProps> = ({slides}) => {
+  if (!slides) {
+    return (
+      <div style={{color: 'var(--text-neutral-primary)'}}>
+        <em>
+          <strong>🎠 Activity carousel placeholder.</strong> Please add a
+          "Carousel" content type entry in the Content sidebar, save, and open
+          the preview tab to see the carousel in action.
+        </em>
+      </div>
+    );
+  }
+
+  const slidesData = slides.map(activity => {
+    const {title, shortDescription, image, primaryLinkRef, tutorialID, topic} =
+      activity.fields;
+    const resolvedImage = resolveContentfulLink<ExperienceAsset>(image);
+    const primaryButton = resolveContentfulLink<LinkEntry>(primaryLinkRef);
+
+    return {
+      id: title,
+      key: tutorialID,
+      slide: (
+        <Card
+          style={{display: 'inline-block'}}
+          className="cardWrapper"
+          id={tutorialID}
+          title={title}
+          description={shortDescription}
+          primaryButton={primaryButton}
+          imageSrc={getAbsoluteImageUrl(resolvedImage)}
+          primaryButtonEventName={EVENT.CARD_PRIMARY_BUTTON_CLICKED}
+          secondaryButtonEventName={EVENT.CARD_SECONDARY_BUTTON_CLICKED}
+          eventMetadata={{
+            cardId: tutorialID,
+            cardTitle: title,
+          }}
+          chipLabels={[...topic]}
+        />
+      ),
+    };
+  });
+  return (
+    <DSCOCarousel
+      showNavArrows={true}
+      slidesPerView={slidesData.length === 2 ? 2 : 3}
+      slidesPerGroup={slidesData.length === 2 ? 2 : 3}
+      slides={slidesData}
+    />
+  );
+};
+
+export default ActivityCarousel;

--- a/frontend/apps/marketing/src/components/contentful/carousels/activityCarousel/activityCarouselContentfulDefinition.ts
+++ b/frontend/apps/marketing/src/components/contentful/carousels/activityCarousel/activityCarouselContentfulDefinition.ts
@@ -1,0 +1,30 @@
+// Creates a definition for the Carousel component to be used in Contentful Studio
+import {ComponentDefinition} from '@contentful/experiences-sdk-react';
+
+export const ActivityCarouselContentfulComponentDefinition: ComponentDefinition =
+  {
+    id: 'carousel-activity',
+    name: 'Activity Carousel',
+    category: '05: Carousels',
+    thumbnailUrl:
+      'https://contentful-images.code.org/90t6bu6vlf76/2FJZgRPkYkJIKwr46SLPX0/02afd1439ea6f0f4cb8f48a27afb231b/component_carousel_action_block_thumbnail.png',
+    tooltip: {
+      description:
+        'A rotating display for showcasing activities with media, text, and a call-to-action.',
+      imageUrl:
+        'https://contentful-images.code.org/90t6bu6vlf76/cpJZaOkkG3bV3yk6qXAou/bd14dd5733c13f6b483ca03b48783be7/component_carousel_action_block_tooltip.png',
+    },
+    // Adding an empty array here so no default style options show in the Design tab.
+    builtInStyles: [],
+    children: false,
+    variables: {
+      slides: {
+        displayName: 'Activity slides',
+        type: 'Array',
+        validations: {
+          required: true,
+          bindingSourceType: ['entry'],
+        },
+      },
+    },
+  };

--- a/frontend/apps/marketing/src/components/contentful/carousels/activityCarousel/index.ts
+++ b/frontend/apps/marketing/src/components/contentful/carousels/activityCarousel/index.ts
@@ -1,0 +1,3 @@
+// Export the Component Definition for use in Contentful Studio
+export {ActivityCarouselContentfulComponentDefinition} from './activityCarouselContentfulDefinition';
+export {default} from './ActivityCarousel';

--- a/frontend/apps/marketing/src/components/csforall/activityCollection/ActivityCollection.tsx
+++ b/frontend/apps/marketing/src/components/csforall/activityCollection/ActivityCollection.tsx
@@ -23,7 +23,7 @@ const ActivityCollection: React.FC<ActivityCollectionProps> = ({
   activities,
 }) => {
   const data = activities.map(activity => {
-    const {title, shortDescription, image, primaryLinkRef, tutorialID} =
+    const {title, shortDescription, image, primaryLinkRef, tutorialID, topic} =
       activity;
 
     return {
@@ -44,6 +44,7 @@ const ActivityCollection: React.FC<ActivityCollectionProps> = ({
               cardId: tutorialID,
               cardTitle: title,
             }}
+            chipLabels={[...topic]}
           />
         </Box>
       ),
@@ -51,10 +52,10 @@ const ActivityCollection: React.FC<ActivityCollectionProps> = ({
   });
 
   return (
-    <Grid container spacing={4}>
+    <Grid container spacing={1}>
       {data.length > 0 ? (
         data.map(card => (
-          <Grid key={card.key} size={{xs: 12, md: 6, lg: 4}}>
+          <Grid key={card.key} size={{xs: 12, sm: 12, md: 6, lg: 4, xl: 3}}>
             {card.item}
           </Grid>
         ))

--- a/frontend/apps/marketing/src/components/csforall/activityCollection/ActivityCollection.tsx
+++ b/frontend/apps/marketing/src/components/csforall/activityCollection/ActivityCollection.tsx
@@ -52,7 +52,7 @@ const ActivityCollection: React.FC<ActivityCollectionProps> = ({
   });
 
   return (
-    <Grid container spacing={1}>
+    <Grid container spacing={3}>
       {data.length > 0 ? (
         data.map(card => (
           <Grid key={card.key} size={{xs: 12, sm: 12, md: 6, lg: 4, xl: 3}}>

--- a/frontend/apps/marketing/src/contentful/registration/csforall/index.ts
+++ b/frontend/apps/marketing/src/contentful/registration/csforall/index.ts
@@ -4,6 +4,9 @@ import Button, {
 import Card, {
   CardContentfulComponentDefinition,
 } from '@/components/contentful/card';
+import ActivityCarousel, {
+  ActivityCarouselContentfulComponentDefinition,
+} from '@/components/contentful/carousels/activityCarousel';
 import CardCollection, {
   CardCollectionContentfulComponentDefinition,
 } from '@/components/contentful/collections/cardCollection';
@@ -55,6 +58,10 @@ import Video, {
 
 const contentfulRegistration = {
   componentRegistrations: [
+    {
+      component: ActivityCarousel,
+      definition: ActivityCarouselContentfulComponentDefinition,
+    },
     {
       component: AdoptionMap,
       definition: AdoptionMapContentfulComponentDefinition,


### PR DESCRIPTION
This PR changes the facet filtering system to use the side bar model based on user feedback. It also widens the screen and adds more cards per row depending on screen size (see attached video).

This UX is compatible with the existing backend, in that deep links previously created will continue to work. In mobile mode, chip based filters are also replaced with accordion checkboxes instead which is similar to other shopping experiences.

[Screencast From 2025-10-10 16-31-34.webm](https://github.com/user-attachments/assets/4c3839e3-0012-4115-a342-758ed5b23cd8)

This PR also introduces the Activity Carousel to studio on CSForAll which allows for the creation of curated landing pages.

<img width="1396" height="1345" alt="image" src="https://github.com/user-attachments/assets/08a52de2-3ac8-4425-b7c2-4798ba1db08b" />
