### PR TITLE
refactor: codemod some sinon & chai imports to jest

### DIFF
--- a/apps/test/unit/AzureTextToSpeechTest.js
+++ b/apps/test/unit/AzureTextToSpeechTest.js
@@ -2,19 +2,14 @@ import sinon from 'sinon'; // eslint-disable-line no-restricted-imports
 
 import AzureTextToSpeech from '@cdo/apps/AzureTextToSpeech';
 
-import {assert, expect} from '../util/reconfiguredChai'; // eslint-disable-line no-restricted-imports
-
 const assertSoundResponsesEqual = (expected, actual) => {
-  assert.deepEqual(expected.bytes, actual.bytes);
+  expect(expected.bytes).toEqual(actual.bytes);
   const playbackOptions = ['volume', 'loop', 'forceHTML5', 'allowHTML5Mobile'];
   playbackOptions.forEach(opt => {
-    assert.deepEqual(
-      expected.playbackOptions[opt],
-      actual.playbackOptions[opt]
-    );
+    expect(expected.playbackOptions[opt]).toEqual(actual.playbackOptions[opt]);
   });
-  assert.deepEqual(expected.profaneWords, actual.profaneWords);
-  assert.equal(expected.error, actual.error);
+  expect(expected.profaneWords).toEqual(actual.profaneWords);
+  expect(expected.error).toBe(actual.error);
 };
 
 describe('AzureTextToSpeech', () => {
@@ -29,7 +24,7 @@ describe('AzureTextToSpeech', () => {
     let onFailureSpy;
 
     beforeEach(() => {
-      onFailureSpy = sinon.spy();
+      onFailureSpy = jest.fn();
     });
 
     describe('with a cached sound', () => {
@@ -62,7 +57,7 @@ describe('AzureTextToSpeech', () => {
 
         it('calls onFailure', async () => {
           await soundPromise();
-          expect(onFailureSpy).to.have.been.calledOnce;
+          expect(onFailureSpy).toHaveBeenCalledTimes(1);
         });
       });
 
@@ -94,7 +89,7 @@ describe('AzureTextToSpeech', () => {
 
         it('does not call onFailure', async () => {
           await soundPromise();
-          expect(onFailureSpy).not.to.have.been.called;
+          expect(onFailureSpy).not.toHaveBeenCalled();
         });
       });
     });
@@ -136,7 +131,7 @@ describe('AzureTextToSpeech', () => {
 
         it('calls onFailure', async () => {
           await soundPromise();
-          expect(onFailureSpy).to.have.been.calledOnce;
+          expect(onFailureSpy).toHaveBeenCalledTimes(1);
         });
 
         it('caches the response', async () => {
@@ -227,12 +222,12 @@ describe('AzureTextToSpeech', () => {
                 options.gender,
                 options.text
               )
-            ).to.be.undefined;
+            ).toBeUndefined();
           });
 
           it('calls onFailure', async () => {
             await soundPromise();
-            expect(onFailureSpy).to.have.been.calledOnce;
+            expect(onFailureSpy).toHaveBeenCalledTimes(1);
           });
 
           it('resolves with error', async () => {
@@ -248,7 +243,7 @@ describe('AzureTextToSpeech', () => {
     let playSpy, successfulResponse;
 
     beforeEach(() => {
-      playSpy = sinon.spy();
+      playSpy = jest.fn();
       successfulResponse = azureTTS.createSoundResponse_({
         bytes: new ArrayBuffer(),
       });
@@ -259,8 +254,8 @@ describe('AzureTextToSpeech', () => {
       azureTTS.playing = true;
 
       await azureTTS.asyncPlayFromQueue_(playSpy);
-      expect(dequeueStub.mock.calls.length).to.equal(0);
-      expect(playSpy).not.to.have.been.called;
+      expect(dequeueStub.mock.calls.length).toBe(0);
+      expect(playSpy).not.toHaveBeenCalled();
     });
 
     it('no-ops if queue is empty', async () => {
@@ -269,8 +264,8 @@ describe('AzureTextToSpeech', () => {
         .mockReturnValue(undefined);
 
       await azureTTS.asyncPlayFromQueue_(playSpy);
-      expect(dequeueStub.mock.calls.length).to.equal(1);
-      expect(playSpy).not.to.have.been.called;
+      expect(dequeueStub.mock.calls.length).toBe(1);
+      expect(playSpy).not.toHaveBeenCalled();
     });
 
     it('plays sound if response was successful', async () => {
@@ -279,22 +274,23 @@ describe('AzureTextToSpeech', () => {
         .mockReturnValue(() => Promise.resolve(successfulResponse));
 
       await azureTTS.asyncPlayFromQueue_(playSpy);
-      expect(playSpy).to.have.been.calledOnce;
+      expect(playSpy).toHaveBeenCalledTimes(1);
     });
 
     it('ends sound if response was unsuccessful', async () => {
       const unsuccessfulResponse = azureTTS.createSoundResponse_({
         error: new Error(),
       });
-      unsuccessfulResponse.playbackOptions.onEnded = sinon.spy();
+      unsuccessfulResponse.playbackOptions.onEnded = jest.fn();
       jest
         .spyOn(azureTTS, 'dequeue_')
         .mockReturnValue(() => Promise.resolve(unsuccessfulResponse));
 
       await azureTTS.asyncPlayFromQueue_(playSpy);
-      expect(unsuccessfulResponse.playbackOptions.onEnded).to.have.been
-        .calledOnce;
-      expect(playSpy).not.to.have.been.called;
+      expect(
+        unsuccessfulResponse.playbackOptions.onEnded
+      ).toHaveBeenCalledTimes(1);
+      expect(playSpy).not.toHaveBeenCalled();
     });
   });
 });

--- a/apps/test/unit/MusicControllerTest.js
+++ b/apps/test/unit/MusicControllerTest.js
@@ -1,9 +1,5 @@
-import sinon from 'sinon'; // eslint-disable-line no-restricted-imports
-
 import MusicController from '@cdo/apps/MusicController';
 import Sounds from '@cdo/apps/Sounds';
-
-import {expect} from '../util/reconfiguredChai'; // eslint-disable-line no-restricted-imports
 
 import winMp3 from '!!file-loader!../audio/assets/win.mp3';
 
@@ -26,13 +22,15 @@ describe('MusicController', () => {
       mp3: winMp3,
     });
     sound = sounds.soundsById[sourceURL];
-    sinon.spy(sound, 'play');
-    sinon.stub(Sounds.prototype, 'registerByFilenamesAndID').returns(sound);
+    jest.spyOn(sound, 'play');
+    jest
+      .spyOn(Sounds.prototype, 'registerByFilenamesAndID')
+      .mockReturnValue(sound);
   });
 
   afterEach(() => {
-    Sounds.prototype.registerByFilenamesAndID.restore();
-    sound.play.restore();
+    Sounds.prototype.registerByFilenamesAndID.mockRestore();
+    sound.play.mockRestore();
   });
 
   function musicControllerSetup(isMutedToStart) {
@@ -53,10 +51,10 @@ describe('MusicController', () => {
     sound.onLoad();
     musicController.setMuteMusic(true);
 
-    expect(musicController.muteMusic_).to.be.true;
+    expect(musicController.muteMusic_).toBe(true);
     // Make sure attempts to play do not work since muting
     musicController.play();
-    expect(sound.play).to.not.have.been.called;
+    expect(sound.play).not.toHaveBeenCalled();
   });
 
   it('updates status and plays music when unmuted', () => {
@@ -65,9 +63,9 @@ describe('MusicController', () => {
     musicController.preload();
     sound.onLoad();
 
-    expect(sound.play).to.not.have.been.called;
+    expect(sound.play).not.toHaveBeenCalled();
     musicController.setMuteMusic(false);
-    expect(musicController.muteMusic_).to.be.false;
-    expect(sound.play).to.have.been.called;
+    expect(musicController.muteMusic_).toBe(false);
+    expect(sound.play).toHaveBeenCalled();
   });
 });

--- a/apps/test/unit/SoundsTest.js
+++ b/apps/test/unit/SoundsTest.js
@@ -1,8 +1,4 @@
-import sinon from 'sinon'; // eslint-disable-line no-restricted-imports
-
 import Sounds from '@cdo/apps/Sounds';
-
-import {expect} from '../util/reconfiguredChai'; // eslint-disable-line no-restricted-imports
 
 import winMp3 from '!!file-loader!../audio/assets/win.mp3';
 
@@ -14,28 +10,28 @@ describe('Sounds', () => {
     sourceURL = winMp3;
     sounds.register({id: sourceURL, mp3: sourceURL});
     sound = sounds.soundsById[sourceURL];
-    sinon.stub(sound, 'playAfterLoad');
+    jest.spyOn(sound, 'playAfterLoad').mockImplementation();
   });
 
   afterEach(() => {
-    sinon.restore();
+    jest.restoreAllMocks();
     sounds.unmuteURLs();
   });
 
   it('does not play URLs when muted', () => {
     sounds.muteURLs();
     sounds.playURL(sourceURL);
-    expect(sound.playAfterLoad).to.not.have.been.called;
+    expect(sound.playAfterLoad).not.toHaveBeenCalled();
   });
 
   it('does play URLs when unmuted', () => {
     sounds.playURL(sourceURL);
-    expect(sound.playAfterLoad).to.have.been.calledOnce;
+    expect(sound.playAfterLoad).toHaveBeenCalledTimes(1);
 
     sounds.muteURLs();
     sounds.unmuteURLs();
     sounds.playURL(sourceURL);
-    expect(sound.playAfterLoad).to.have.been.calledTwice;
+    expect(sound.playAfterLoad).toHaveBeenCalledTimes(2);
   });
 
   it('does play sounds by ID when muted', () => {
@@ -44,8 +40,8 @@ describe('Sounds', () => {
     sounds.muteURLs();
 
     let soundFromId = sounds.soundsById['testSound'];
-    sinon.stub(soundFromId, 'play');
+    jest.spyOn(soundFromId, 'play').mockImplementation();
     sounds.play(soundId);
-    expect(soundFromId.play).to.have.been.calledOnce;
+    expect(soundFromId.play).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/test/unit/applab/ChartApiTest.js
+++ b/apps/test/unit/applab/ChartApiTest.js
@@ -1,5 +1,3 @@
-import {assert} from '../../util/reconfiguredChai'; // eslint-disable-line no-restricted-imports
-
 var ChartApi = require('@cdo/apps/applab/ChartApi');
 var GoogleChart = require('@cdo/apps/applab/GoogleChart');
 
@@ -74,10 +72,7 @@ describe('ChartApi', function () {
     it('only contains supported types', function () {
       Object.getOwnPropertyNames(ChartType).forEach(function (key) {
         var typeName = ChartType[key];
-        assert.isTrue(
-          ChartApi.supportsType(typeName),
-          "Supports type '" + typeName + "'."
-        );
+        expect(ChartApi.supportsType(typeName)).toBe(true);
       });
     });
 
@@ -90,46 +85,45 @@ describe('ChartApi', function () {
       });
 
       supportedTypes.forEach(function (typeName) {
-        assert.isTrue(
+        expect(
           enumTypeNames.some(function (enumName) {
             return enumName === typeName;
-          }),
-          "Found supported type '" + typeName + "' in enum."
-        );
+          })
+        ).toBe(true);
       });
     });
   });
 
   it('supports type BAR', function () {
-    assert.isTrue(ChartApi.supportsType(ChartApi.ChartType.BAR));
-    assert.isTrue(ChartApi.supportsType('BAR'));
-    assert.isTrue(ChartApi.supportsType('Bar'));
-    assert.isTrue(ChartApi.supportsType('bar'));
+    expect(ChartApi.supportsType(ChartApi.ChartType.BAR)).toBe(true);
+    expect(ChartApi.supportsType('BAR')).toBe(true);
+    expect(ChartApi.supportsType('Bar')).toBe(true);
+    expect(ChartApi.supportsType('bar')).toBe(true);
   });
 
   it('supports type PIE', function () {
-    assert.isTrue(ChartApi.supportsType(ChartApi.ChartType.PIE));
-    assert.isTrue(ChartApi.supportsType('PIE'));
-    assert.isTrue(ChartApi.supportsType('Pie'));
-    assert.isTrue(ChartApi.supportsType('pie'));
+    expect(ChartApi.supportsType(ChartApi.ChartType.PIE)).toBe(true);
+    expect(ChartApi.supportsType('PIE')).toBe(true);
+    expect(ChartApi.supportsType('Pie')).toBe(true);
+    expect(ChartApi.supportsType('pie')).toBe(true);
   });
 
   it('supports type LINE', function () {
-    assert.isTrue(ChartApi.supportsType(ChartApi.ChartType.LINE));
-    assert.isTrue(ChartApi.supportsType('LINE'));
-    assert.isTrue(ChartApi.supportsType('Line'));
-    assert.isTrue(ChartApi.supportsType('line'));
+    expect(ChartApi.supportsType(ChartApi.ChartType.LINE)).toBe(true);
+    expect(ChartApi.supportsType('LINE')).toBe(true);
+    expect(ChartApi.supportsType('Line')).toBe(true);
+    expect(ChartApi.supportsType('line')).toBe(true);
   });
 
   it('supports type SCATTER', function () {
-    assert.isTrue(ChartApi.supportsType(ChartApi.ChartType.SCATTER));
-    assert.isTrue(ChartApi.supportsType('SCATTER'));
-    assert.isTrue(ChartApi.supportsType('Scatter'));
-    assert.isTrue(ChartApi.supportsType('scatter'));
+    expect(ChartApi.supportsType(ChartApi.ChartType.SCATTER)).toBe(true);
+    expect(ChartApi.supportsType('SCATTER')).toBe(true);
+    expect(ChartApi.supportsType('Scatter')).toBe(true);
+    expect(ChartApi.supportsType('scatter')).toBe(true);
   });
 
   it('quotes and alphabetizes types for dropdown', function () {
-    assert.deepEqual(ChartApi.getChartTypeDropdown(), [
+    expect(ChartApi.getChartTypeDropdown()).toEqual([
       '"bar"',
       '"line"',
       '"pie"',
@@ -162,56 +156,27 @@ describe('ChartApi', function () {
 
     var assertRejects = function (rejectionRegexp) {
       var rejectionFound = rejectionRegexp.test(rejection);
-      var receivedRejection = rejection
-        ? 'Got ' + rejection.message
-        : 'Did not reject.';
-      assert(
-        rejectionFound,
-        'Expected rejection ' +
-          rejectionRegexp.toString() +
-          '\n' +
-          receivedRejection
-      );
+      expect(rejectionFound).toBeTruthy();
     };
 
     var assertWarns = function (chartApi, warningRegexp) {
-      assert.isNull(rejection);
+      expect(rejection).toBeNull();
       var warningFound = chartApi.warnings.some(function (e) {
         return warningRegexp.test(e.message);
       });
-      assert(
-        warningFound,
-        'Expected warning ' +
-          warningRegexp.toString() +
-          '\nGot warnings:\n' +
-          chartApi.warnings
-            .map(function (e) {
-              return e.message;
-            })
-            .join('\n')
-      );
+      expect(warningFound).toBeTruthy();
     };
 
     var assertNotWarns = function (chartApi, warningRegexp) {
-      assert.isNull(rejection);
+      expect(rejection).toBeNull();
       var warningFound = chartApi.warnings.some(function (e) {
         return warningRegexp.test(e.message);
       });
-      assert(
-        !warningFound,
-        'Expected no warning ' +
-          warningRegexp.toString() +
-          '\nGot warnings:\n' +
-          chartApi.warnings
-            .map(function (e) {
-              return e.message;
-            })
-            .join('\n')
-      );
+      expect(warningFound).toBeFalsy();
     };
 
     it('returns a Promise', function () {
-      assert.instanceOf(testMethod(), Promise);
+      expect(testMethod()).toBeInstanceOf(Promise);
     });
 
     it('rejects if element is not found', function (testDone) {
@@ -437,12 +402,12 @@ describe('ChartApi', function () {
 
     it('extracts all columns from data', function () {
       var rawData = [{x: 12}, {x: 10, y: 14}, {z: 144}];
-      assert.deepEqual(inferColumnsFromRawData(rawData), ['x', 'y', 'z']);
+      expect(inferColumnsFromRawData(rawData)).toEqual(['x', 'y', 'z']);
     });
 
     it('adds columns in the order they are encountered', function () {
       var rawData = [{z: 144}, {y: 10, x: 14}, {x: 12, z: 1492}];
-      assert.deepEqual(inferColumnsFromRawData(rawData), ['z', 'y', 'x']);
+      expect(inferColumnsFromRawData(rawData)).toEqual(['z', 'y', 'x']);
     });
   });
 

--- a/apps/test/unit/authoredHintUtilsTest.js
+++ b/apps/test/unit/authoredHintUtilsTest.js
@@ -1,7 +1,5 @@
 import $ from 'jquery';
 
-import {assert} from '../util/reconfiguredChai'; // eslint-disable-line no-restricted-imports
-
 var authoredHintUtils = require('@cdo/apps/authoredHintUtils');
 
 describe('Authored Hint Utils', function () {
@@ -56,7 +54,7 @@ describe('Authored Hint Utils', function () {
         'nonexistent_key',
         defaultValue
       );
-      assert.equal(result, defaultValue);
+      expect(result).toBe(defaultValue);
     });
 
     it('can recover from bad JSON', function () {
@@ -66,7 +64,7 @@ describe('Authored Hint Utils', function () {
         'bad_json',
         defaultValue
       );
-      assert.equal(result, defaultValue);
+      expect(result).toBe(defaultValue);
     });
 
     it('retrieves the set value if all else goes well', function () {
@@ -76,7 +74,7 @@ describe('Authored Hint Utils', function () {
         'good_json',
         undefined
       );
-      assert.equal(result, expectedValue);
+      expect(result).toBe(expectedValue);
     });
   });
 
@@ -89,7 +87,7 @@ describe('Authored Hint Utils', function () {
       );
       authoredHintUtils.recordFinishedHints_([4, 5]);
       var newHints = authoredHintUtils.getFinishedHints_();
-      assert.deepEqual(newHints, [1, 2, 3, 4, 5]);
+      expect(newHints).toEqual([1, 2, 3, 4, 5]);
     });
   });
 
@@ -101,7 +99,7 @@ describe('Authored Hint Utils', function () {
         JSON.stringify(hints)
       );
       var finalizedHints = authoredHintUtils.finalizeHints_();
-      assert.deepEqual(finalizedHints, [1, 2, 3]);
+      expect(finalizedHints).toEqual([1, 2, 3]);
     });
 
     it('if last_attempt_record is set, extends all finished hints without overriding', function () {
@@ -114,7 +112,7 @@ describe('Authored Hint Utils', function () {
       localStorage.setItem('last_attempt_record', JSON.stringify(record));
 
       var finalizedHints = authoredHintUtils.finalizeHints_();
-      assert.deepEqual(finalizedHints, [
+      expect(finalizedHints).toEqual([
         {
           id: 'first',
           prevTime: 'something decent',
@@ -141,7 +139,7 @@ describe('Authored Hint Utils', function () {
     it('if no last_attempt_record is set, simply records the given value', function () {
       authoredHintUtils.recordUnfinishedHint(hintOne);
       var unfinishedHints = authoredHintUtils.getUnfinishedHints_();
-      assert.deepEqual(unfinishedHints, [hintOne]);
+      expect(unfinishedHints).toEqual([hintOne]);
     });
 
     it('if last_attempt_record is set, extends the given hint without overriding', function () {
@@ -150,7 +148,7 @@ describe('Authored Hint Utils', function () {
       authoredHintUtils.recordUnfinishedHint(hintOne);
       var unfinishedHints = authoredHintUtils.getUnfinishedHints_();
 
-      assert.deepEqual(unfinishedHints, [
+      expect(unfinishedHints).toEqual([
         {
           id: 'first',
           prevTime: 'something decent',
@@ -166,37 +164,33 @@ describe('Authored Hint Utils', function () {
 
   describe('finishHints', function () {
     it('sets last_attempt_record', function () {
-      assert.isNull(localStorage.getItem('last_attempt_record'));
+      expect(localStorage.getItem('last_attempt_record')).toBeNull();
       authoredHintUtils.finishHints(record);
-      assert.equal(
-        localStorage.getItem('last_attempt_record'),
+      expect(localStorage.getItem('last_attempt_record')).toBe(
         JSON.stringify(record)
       );
     });
 
     it('clears unfinished_hints', function () {
       authoredHintUtils.recordUnfinishedHint(hintOne);
-      assert.equal(
-        localStorage.getItem('unfinished_authored_hint_views'),
+      expect(localStorage.getItem('unfinished_authored_hint_views')).toBe(
         JSON.stringify([hintOne])
       );
       authoredHintUtils.finishHints(record);
-      assert.equal(
-        localStorage.getItem('unfinished_authored_hint_views'),
+      expect(localStorage.getItem('unfinished_authored_hint_views')).toBe(
         JSON.stringify([])
       );
     });
 
     it('extends unfinished_hints and moves them to finished_hints', function () {
       authoredHintUtils.recordUnfinishedHint(hintOne);
-      assert.equal(
-        localStorage.getItem('unfinished_authored_hint_views'),
+      expect(localStorage.getItem('unfinished_authored_hint_views')).toBe(
         JSON.stringify([hintOne])
       );
       authoredHintUtils.finishHints(record);
       var finishedHints = authoredHintUtils.getFinishedHints_();
 
-      assert.deepEqual(finishedHints, [
+      expect(finishedHints).toEqual([
         {
           id: 'first',
           prevTime: 'something decent',
@@ -224,7 +218,7 @@ describe('Authored Hint Utils', function () {
 
       var finishedHints = authoredHintUtils.getFinishedHints_();
 
-      assert.deepEqual(finishedHints, [
+      expect(finishedHints).toEqual([
         {
           id: 'first',
           finalTime: 'something awesome',
@@ -266,8 +260,7 @@ describe('Authored Hint Utils', function () {
 
       authoredHintUtils.submitHints('/url');
 
-      assert.deepEqual(
-        data,
+      expect(data).toEqual(
         JSON.stringify({
           hints: finalizedHints,
         })
@@ -282,7 +275,7 @@ describe('Authored Hint Utils', function () {
       authoredHintUtils.finishHints(record);
       authoredHintUtils.submitHints('/url');
       var finishedHints = authoredHintUtils.getFinishedHints_();
-      assert.deepEqual(finishedHints, []);
+      expect(finishedHints).toEqual([]);
     });
   });
 });

--- a/apps/test/unit/craft/utilsTest.js
+++ b/apps/test/unit/craft/utilsTest.js
@@ -1,58 +1,54 @@
-// We have to include the locale files below as translations must be loaded in the global
-// scope for HeadlessChrome to run properly.
-import sinon from 'sinon'; // eslint-disable-line no-restricted-imports
-
 import craftI18n from '@cdo/apps/craft/locale'; // eslint-disable-line no-unused-vars
 import * as craftRedux from '@cdo/apps/craft/redux';
 import * as utils from '@cdo/apps/craft/utils';
 import commonI18n from '@cdo/locale'; // eslint-disable-line no-unused-vars
-
-import {expect} from '../../util/reconfiguredChai'; // eslint-disable-line no-restricted-imports
 
 describe('craft utils', () => {
   describe('handlePlayerSelection', () => {
     const defaultPlayer = 'Alex';
 
     beforeEach(() => {
-      sinon.stub(craftRedux, 'closePlayerSelectionDialog');
+      jest.spyOn(craftRedux, 'closePlayerSelectionDialog').mockImplementation();
     });
 
     afterEach(() => {
-      sinon.restore();
+      jest.restoreAllMocks();
     });
 
     it('closes dialog after selecting a player', () => {
-      sinon
-        .stub(craftRedux, 'openPlayerSelectionDialog')
-        .callsFake(callback => callback('Steve'));
+      jest
+        .spyOn(craftRedux, 'openPlayerSelectionDialog')
+        .mockImplementation(callback => callback('Steve'));
 
       utils.handlePlayerSelection(defaultPlayer, () => {});
 
-      expect(craftRedux.openPlayerSelectionDialog).to.have.been.calledOnce;
-      expect(craftRedux.closePlayerSelectionDialog).to.have.been.calledOnce;
+      expect(craftRedux.openPlayerSelectionDialog).toHaveBeenCalledTimes(1);
+      expect(craftRedux.closePlayerSelectionDialog).toHaveBeenCalledTimes(1);
     });
 
     it('invokes onComplete with selectedPlayer', () => {
       const selectedPlayer = 'Tom';
-      sinon
-        .stub(craftRedux, 'openPlayerSelectionDialog')
-        .callsFake(callback => callback(selectedPlayer));
-      const onCompleteSpy = sinon.spy();
+      jest
+        .spyOn(craftRedux, 'openPlayerSelectionDialog')
+        .mockImplementation(callback => callback(selectedPlayer));
+      const onCompleteSpy = jest.fn();
 
       utils.handlePlayerSelection(defaultPlayer, onCompleteSpy);
 
-      expect(onCompleteSpy).to.have.been.calledOnceWith(selectedPlayer);
+      expect(onCompleteSpy).toHaveBeenCalledTimes(1);
+      expect(onCompleteSpy).toHaveBeenCalledWith(selectedPlayer);
     });
 
     it('invokes callback with default player if no selectedPlayer is given', () => {
-      sinon
-        .stub(craftRedux, 'openPlayerSelectionDialog')
-        .callsFake(callback => callback(undefined));
-      const onCompleteSpy = sinon.spy();
+      jest
+        .spyOn(craftRedux, 'openPlayerSelectionDialog')
+        .mockImplementation(callback => callback(undefined));
+      const onCompleteSpy = jest.fn();
 
       utils.handlePlayerSelection(defaultPlayer, onCompleteSpy);
 
-      expect(onCompleteSpy).to.have.been.calledOnceWith(defaultPlayer);
+      expect(onCompleteSpy).toHaveBeenCalledTimes(1);
+      expect(onCompleteSpy).toHaveBeenCalledWith(defaultPlayer);
     });
   });
 });

--- a/apps/test/unit/craft/utilsTest.js
+++ b/apps/test/unit/craft/utilsTest.js
@@ -1,3 +1,5 @@
+// We have to include the locale files below as translations must be loaded in the global
+// scope for HeadlessChrome to run properly.
 import craftI18n from '@cdo/apps/craft/locale'; // eslint-disable-line no-unused-vars
 import * as craftRedux from '@cdo/apps/craft/redux';
 import * as utils from '@cdo/apps/craft/utils';

--- a/apps/test/unit/dontMarshalApiTest.js
+++ b/apps/test/unit/dontMarshalApiTest.js
@@ -1,9 +1,5 @@
-import sinon from 'sinon'; // eslint-disable-line no-restricted-imports
-
 import * as dontMarshalApi from '@cdo/apps/dontMarshalApi';
 import {injectErrorHandler} from '@cdo/apps/lib/util/javascriptMode';
-
-import {expect} from '../util/reconfiguredChai'; // eslint-disable-line no-restricted-imports
 
 /*
  * These tests verify the behavior of dontMarshalApi.js list APIs when called
@@ -20,49 +16,49 @@ describe('insertItem', () => {
   it('inserts an item at the beginning of an empty array', () => {
     const array = [];
     dontMarshalApi.insertItem(array, 0, 'foo');
-    expect(array).to.eql(['foo']);
+    expect(array).toEqual(['foo']);
   });
 
   it('inserts an item at the beginning of an existing array', () => {
     const array = ['bar'];
     dontMarshalApi.insertItem(array, 0, 'foo');
-    expect(array).to.eql(['foo', 'bar']);
+    expect(array).toEqual(['foo', 'bar']);
   });
 
   it('inserts an item at the end of an existing array', () => {
     const array = ['bar'];
     dontMarshalApi.insertItem(array, array.length, 'foo');
-    expect(array).to.eql(['bar', 'foo']);
+    expect(array).toEqual(['bar', 'foo']);
   });
 
   it('inserts an item at the end of an existing array when passed a large index', () => {
     const array = ['bar'];
     dontMarshalApi.insertItem(array, 1000, 'foo');
-    expect(array).to.eql(['bar', 'foo']);
+    expect(array).toEqual(['bar', 'foo']);
   });
 
   it('inserts an item in the middle of an existing array', () => {
     const array = ['foo', 'bar'];
     dontMarshalApi.insertItem(array, array.length - 1, 'and');
-    expect(array).to.eql(['foo', 'and', 'bar']);
+    expect(array).toEqual(['foo', 'and', 'bar']);
   });
 
   it('inserts an item right before the last item of an existing array when passed -1', () => {
     const array = ['foo', 'bar'];
     dontMarshalApi.insertItem(array, -1, 'and');
-    expect(array).to.eql(['foo', 'and', 'bar']);
+    expect(array).toEqual(['foo', 'and', 'bar']);
   });
 
   it('inserts an item at the beginning of an existing array when passed -array.length', () => {
     const array = ['foo', 'bar'];
     dontMarshalApi.insertItem(array, -array.length, 'and');
-    expect(array).to.eql(['and', 'foo', 'bar']);
+    expect(array).toEqual(['and', 'foo', 'bar']);
   });
 
   it('inserts an item at the beginning of an existing array when passed a large negative index', () => {
     const array = ['foo', 'bar'];
     dontMarshalApi.insertItem(array, -1000, 'and');
-    expect(array).to.eql(['and', 'foo', 'bar']);
+    expect(array).toEqual(['and', 'foo', 'bar']);
   });
 });
 
@@ -70,13 +66,13 @@ describe('appendItem', () => {
   it('appends an item at the end of an empty array', () => {
     const array = [];
     dontMarshalApi.appendItem(array, 'foo');
-    expect(array).to.eql(['foo']);
+    expect(array).toEqual(['foo']);
   });
 
   it('appends an item at the end of an existing array', () => {
     const array = ['bar'];
     dontMarshalApi.appendItem(array, 'foo');
-    expect(array).to.eql(['bar', 'foo']);
+    expect(array).toEqual(['bar', 'foo']);
   });
 });
 
@@ -84,19 +80,21 @@ describe('removeItem', () => {
   it('removes an item at the end of an existing array', () => {
     const array = ['foo', 'bar'];
     dontMarshalApi.removeItem(array, array.length - 1);
-    expect(array).to.eql(['foo']);
+    expect(array).toEqual(['foo']);
   });
 
   it('warns and does nothing when passed a large index', () => {
     const errorHandler = {
-      outputWarning: sinon.spy(),
+      outputWarning: jest.fn(),
     };
     injectErrorHandler(errorHandler);
 
     const array = ['foo', 'bar'];
     dontMarshalApi.removeItem(array, 1000);
-    expect(array).to.eql(['foo', 'bar']);
-    expect(errorHandler.outputWarning).to.have.been.calledOnce.and.calledWith(
+    expect(array).toEqual(['foo', 'bar']);
+    expect(errorHandler.outputWarning).toHaveBeenCalledTimes(1);
+
+    expect(errorHandler.outputWarning).toHaveBeenCalledWith(
       'removeItem() index parameter value (1000) is larger than the number of items in the list (2).'
     );
   });
@@ -104,30 +102,30 @@ describe('removeItem', () => {
   it('removes an item at the beginning of an existing array', () => {
     const array = ['foo', 'bar'];
     dontMarshalApi.removeItem(array, 0);
-    expect(array).to.eql(['bar']);
+    expect(array).toEqual(['bar']);
   });
 
   it('removes an item at the beginning of an existing array when passed a large negative index', () => {
     const array = ['foo', 'bar'];
     dontMarshalApi.removeItem(array, -1000);
-    expect(array).to.eql(['bar']);
+    expect(array).toEqual(['bar']);
   });
 
   it('removes an item in the middle of an existing array', () => {
     const array = ['foo', 'and', 'bar'];
     dontMarshalApi.removeItem(array, 1);
-    expect(array).to.eql(['foo', 'bar']);
+    expect(array).toEqual(['foo', 'bar']);
   });
 
   it('removes the last item of an existing array when passed -1', () => {
     const array = ['foo', 'and', 'bar'];
     dontMarshalApi.removeItem(array, -1);
-    expect(array).to.eql(['foo', 'and']);
+    expect(array).toEqual(['foo', 'and']);
   });
 
   it('removes an item at the beginning of an existing array when passed -array.length', () => {
     const array = ['foo', 'bar'];
     dontMarshalApi.removeItem(array, -array.length);
-    expect(array).to.eql(['bar']);
+    expect(array).toEqual(['bar']);
   });
 });

--- a/apps/test/unit/ejsTest.js
+++ b/apps/test/unit/ejsTest.js
@@ -1,8 +1,7 @@
-import {assert} from '../util/reconfiguredChai'; // eslint-disable-line no-restricted-imports
 // nonstandard EJS behavior we rely upon in our templates
 describe('ejs test', function () {
   it('renders empty string on undefined object property access', function () {
     var ejs = require('./empty-data.ejs')({data: {}});
-    assert.equal(ejs.trim(), '');
+    expect(ejs.trim()).toBe('');
   });
 });

--- a/apps/test/unit/feedbackTest.js
+++ b/apps/test/unit/feedbackTest.js
@@ -1,10 +1,6 @@
-import sinon from 'sinon'; // eslint-disable-line no-restricted-imports
-
 import {TestResults} from '@cdo/apps/constants';
 import FeedbackUtils from '@cdo/apps/feedback';
 import msg from '@cdo/locale';
-
-import {assert} from '../util/reconfiguredChai'; // eslint-disable-line no-restricted-imports
 
 describe('FeedbackUtils', () => {
   describe('getFeedbackMessage', () => {
@@ -33,36 +29,33 @@ describe('FeedbackUtils', () => {
             },
           };
 
-          sinon.stub(msg, 'finalStage').callsFake(() => finalStageMsg);
-          sinon.stub(msg, 'endOfLesson').callsFake(() => endOfLesson);
-          sinon.stub(msg, 'nextStage').callsFake(() => nextStageMsg);
-          sinon.stub(msg, 'nextLevel').callsFake(() => nextLevelMsg);
+          jest.spyOn(msg, 'finalStage').mockImplementation(() => finalStageMsg);
+          jest.spyOn(msg, 'endOfLesson').mockImplementation(() => endOfLesson);
+          jest.spyOn(msg, 'nextStage').mockImplementation(() => nextStageMsg);
+          jest.spyOn(msg, 'nextLevel').mockImplementation(() => nextLevelMsg);
         });
 
         afterEach(() => {
-          sinon.restore();
+          jest.restoreAllMocks();
         });
 
         describe('with sharing enabled', () => {
           it('returns appStrings.reinfFeedbackMsg if final lesson message disabled', () => {
             options.level.disableFinalLessonMessage = true;
-            assert.equal(
-              feedbackUtils.getFeedbackMessage(options),
+            expect(feedbackUtils.getFeedbackMessage(options)).toBe(
               options.appStrings.reinfFeedbackMsg
             );
           });
 
           it('returns final stage and appStrings.reinfFeedbackMsg if final level', () => {
             options.level.isLastLevelInLesson = true;
-            assert.equal(
-              feedbackUtils.getFeedbackMessage(options),
+            expect(feedbackUtils.getFeedbackMessage(options)).toBe(
               `${finalStageMsg} ${options.appStrings.reinfFeedbackMsg}`
             );
 
             // Gracefully handles missing reinfFeedbackMsg.
             options.appStrings.reinfFeedbackMsg = null;
-            assert.equal(
-              feedbackUtils.getFeedbackMessage(options),
+            expect(feedbackUtils.getFeedbackMessage(options)).toBe(
               `${finalStageMsg} `
             );
           });
@@ -70,15 +63,11 @@ describe('FeedbackUtils', () => {
           it('returns end of lesson message if final level and level.showEndOfLessonMsgs is true', () => {
             options.level.isLastLevelInLesson = true;
             options.level.showEndOfLessonMsgs = true;
-            assert.equal(
-              feedbackUtils.getFeedbackMessage(options),
-              endOfLesson
-            );
+            expect(feedbackUtils.getFeedbackMessage(options)).toBe(endOfLesson);
           });
 
           it('returns appStrings.reinfFeedbackMsg if not final level', () => {
-            assert.equal(
-              feedbackUtils.getFeedbackMessage(options),
+            expect(feedbackUtils.getFeedbackMessage(options)).toBe(
               options.appStrings.reinfFeedbackMsg
             );
           });
@@ -91,8 +80,7 @@ describe('FeedbackUtils', () => {
 
           it('returns final stage message if final level', () => {
             options.level.isLastLevelInLesson = true;
-            assert.equal(
-              feedbackUtils.getFeedbackMessage(options),
+            expect(feedbackUtils.getFeedbackMessage(options)).toBe(
               finalStageMsg
             );
           });
@@ -100,25 +88,20 @@ describe('FeedbackUtils', () => {
           it('returns final stage message if final level and level.showEndOfLessonMsgs is true', () => {
             options.level.isLastLevelInLesson = true;
             options.level.showEndOfLessonMsgs = true;
-            assert.equal(
-              feedbackUtils.getFeedbackMessage(options),
-              endOfLesson
-            );
+            expect(feedbackUtils.getFeedbackMessage(options)).toBe(endOfLesson);
           });
 
           it('returns next stage message if lesson completed', () => {
             options.response = {
               lesson_changing: {previous: {name: 'Lesson Name'}},
             };
-            assert.equal(
-              feedbackUtils.getFeedbackMessage(options),
+            expect(feedbackUtils.getFeedbackMessage(options)).toBe(
               nextStageMsg
             );
           });
 
           it('returns next level message if lesson not completed', () => {
-            assert.equal(
-              feedbackUtils.getFeedbackMessage(options),
+            expect(feedbackUtils.getFeedbackMessage(options)).toBe(
               nextLevelMsg
             );
           });

--- a/apps/test/unit/gamelab/GameLabTest.js
+++ b/apps/test/unit/gamelab/GameLabTest.js
@@ -1,5 +1,4 @@
 import ReactDOM from 'react-dom';
-import sinon from 'sinon'; // eslint-disable-line no-restricted-imports
 
 import {isOpen as isDebuggerOpen} from '@cdo/apps/lib/tools/jsdebugger/redux';
 import GameLab from '@cdo/apps/p5lab/gamelab/GameLab';
@@ -13,7 +12,6 @@ import {
 import commonReducers from '@cdo/apps/redux/commonReducers';
 import Sounds from '@cdo/apps/Sounds';
 
-import {expect} from '../../util/reconfiguredChai'; // eslint-disable-line no-restricted-imports
 import {setExternalGlobals} from '../../util/testUtils';
 import 'script-loader!@code-dot-org/p5.play/examples/lib/p5';
 import 'script-loader!@code-dot-org/p5.play/lib/p5.play';
@@ -21,8 +19,8 @@ import 'script-loader!@code-dot-org/p5.play/lib/p5.play';
 describe('GameLab', () => {
   setExternalGlobals();
 
-  beforeAll(() => sinon.stub(ReactDOM, 'render'));
-  afterAll(() => ReactDOM.render.restore());
+  beforeAll(() => jest.spyOn(ReactDOM, 'render').mockImplementation());
+  afterAll(() => ReactDOM.render.mockRestore());
 
   beforeEach(stubRedux);
   afterEach(restoreRedux);
@@ -53,17 +51,17 @@ describe('GameLab', () => {
       registerReducers({...commonReducers, ...reducers});
       instance = new GameLab();
       studioApp = {
-        setCheckForEmptyBlocks: sinon.spy(),
-        setPageConstants: sinon.spy(),
-        init: sinon.spy(),
+        setCheckForEmptyBlocks: jest.fn(),
+        setPageConstants: jest.fn(),
+        init: jest.fn(),
         isUsingBlockly: () => false,
         loadLibraries: () => Promise.resolve(),
-        loadLibraryBlocks: sinon.spy(),
+        loadLibraryBlocks: jest.fn(),
       };
     });
 
     it('Must have studioApp injected first', () => {
-      expect(() => instance.init({})).to.throw('GameLab requires a StudioApp');
+      expect(() => instance.init({})).toThrow('GameLab requires a StudioApp');
     });
 
     describe('After being injected with a studioApp instance', () => {
@@ -72,30 +70,32 @@ describe('GameLab', () => {
       describe('Muting', () => {
         let unmuteSpy;
         beforeEach(() => {
-          unmuteSpy = sinon.stub(Sounds.getSingleton(), 'unmuteURLs');
-          instance.p5Wrapper.p5 = sinon.spy();
-          instance.p5Wrapper.p5.allSprites = sinon.spy();
-          instance.p5Wrapper.p5.allSprites.removeSprites = sinon.spy();
-          instance.p5Wrapper.p5.redraw = sinon.spy();
-          instance.p5Wrapper.p5.World = sinon.spy();
-          instance.p5Wrapper.setLoop = sinon.spy();
-          instance.p5Wrapper.startExecution = sinon.spy();
-          instance.initInterpreter = sinon.spy();
-          instance.onP5Setup = sinon.spy();
-          instance.reset = sinon.spy();
-          instance.studioApp_.clearAndAttachRuntimeAnnotations = sinon.spy();
-          instance.JSInterpreter = sinon.spy();
-          instance.JSInterpreter.deinitialize = sinon.spy();
-          instance.JSInterpreter.initialized = sinon.spy();
+          unmuteSpy = jest
+            .spyOn(Sounds.getSingleton(), 'unmuteURLs')
+            .mockImplementation();
+          instance.p5Wrapper.p5 = jest.fn();
+          instance.p5Wrapper.p5.allSprites = jest.fn();
+          instance.p5Wrapper.p5.allSprites.removeSprites = jest.fn();
+          instance.p5Wrapper.p5.redraw = jest.fn();
+          instance.p5Wrapper.p5.World = jest.fn();
+          instance.p5Wrapper.setLoop = jest.fn();
+          instance.p5Wrapper.startExecution = jest.fn();
+          instance.initInterpreter = jest.fn();
+          instance.onP5Setup = jest.fn();
+          instance.reset = jest.fn();
+          instance.studioApp_.clearAndAttachRuntimeAnnotations = jest.fn();
+          instance.JSInterpreter = jest.fn();
+          instance.JSInterpreter.deinitialize = jest.fn();
+          instance.JSInterpreter.initialized = jest.fn();
         });
 
         afterEach(() => {
-          unmuteSpy.restore();
+          unmuteSpy.mockRestore();
         });
 
         it('Execute unmutes URLs', () => {
           instance.execute();
-          expect(Sounds.getSingleton().unmuteURLs).to.have.been.calledOnce;
+          expect(Sounds.getSingleton().unmuteURLs).toHaveBeenCalledTimes(1);
         });
       });
 
@@ -109,18 +109,18 @@ describe('GameLab', () => {
                 editCode: false,
               },
             })
-          ).not.to.throw;
-          expect(() => instance.init(config)).not.to.throw;
+          ).not.toThrow();
+          expect(() => instance.init(config)).not.toThrow();
         });
 
         describe('the expandDebugger level option', () => {
           it('will leave the debugger closed when false', () => {
-            expect(config.level.expandDebugger).not.to.be.true;
+            expect(config.level.expandDebugger).not.toBe(true);
             instance.init(config);
-            expect(isDebuggerOpen(getStore().getState())).to.be.false;
+            expect(isDebuggerOpen(getStore().getState())).toBe(false);
           });
           it('will open the debugger when true', () => {
-            expect(isDebuggerOpen(getStore().getState())).to.be.false;
+            expect(isDebuggerOpen(getStore().getState())).toBe(false);
             instance.init({
               ...config,
               level: {
@@ -128,7 +128,7 @@ describe('GameLab', () => {
                 expandDebugger: true,
               },
             });
-            expect(isDebuggerOpen(getStore().getState())).to.be.true;
+            expect(isDebuggerOpen(getStore().getState())).toBe(true);
           });
         });
       });

--- a/apps/test/unit/gridUtilsTest.js
+++ b/apps/test/unit/gridUtilsTest.js
@@ -1,74 +1,28 @@
-import {assert} from '../util/reconfiguredChai'; // eslint-disable-line no-restricted-imports
-
 var gridUtils = require('@cdo/apps/applab/gridUtils');
 
 describe('snapToGridSize', function () {
   it('rounds to the nearest GRID_SIZE', function () {
     // our GRID_SIZE is 5
-    assert.equal(gridUtils.snapToGridSize(0), 0);
-    assert.equal(gridUtils.snapToGridSize(1), 0);
-    assert.equal(gridUtils.snapToGridSize(5), 5);
-    assert.equal(gridUtils.snapToGridSize(6), 5);
-    assert.equal(gridUtils.snapToGridSize(9), 10);
+    expect(gridUtils.snapToGridSize(0)).toBe(0);
+    expect(gridUtils.snapToGridSize(1)).toBe(0);
+    expect(gridUtils.snapToGridSize(5)).toBe(5);
+    expect(gridUtils.snapToGridSize(6)).toBe(5);
+    expect(gridUtils.snapToGridSize(9)).toBe(10);
   });
 });
 
 describe('isPointInBounds', function () {
   it('determines if a coordinate is in bounds or not', function () {
-    assert.equal(
-      gridUtils.isPointInBounds(1, 1, 100, 100),
-      true,
-      '(1, 1) is in bounds of a 100x100 container'
-    );
-    assert.equal(
-      gridUtils.isPointInBounds(0, 0, 100, 100),
-      true,
-      '(0, 0) is in bounds of a 100x100 container'
-    );
-    assert.equal(
-      gridUtils.isPointInBounds(0, 100, 100, 100),
-      true,
-      '(0, 100) is in bounds of a 100x100 container'
-    );
-    assert.equal(
-      gridUtils.isPointInBounds(100, 0, 100, 100),
-      true,
-      '(100, 0) is in bounds of a 100x100 container'
-    );
-    assert.equal(
-      gridUtils.isPointInBounds(100, 100, 100, 100),
-      true,
-      '(100, 100) is in bounds of a 100x100 container'
-    );
-    assert.equal(
-      gridUtils.isPointInBounds(-1, 1, 100, 100),
-      false,
-      '(-1, 1) is not in bounds of a 100x100 container'
-    );
-    assert.equal(
-      gridUtils.isPointInBounds(1, -1, 100, 100),
-      false,
-      '(1, -1) is not in bounds of a 100x100 container'
-    );
-    assert.equal(
-      gridUtils.isPointInBounds(-1, -1, 100, 100),
-      false,
-      '(-1, -1) is not in bounds of a 100x100 container'
-    );
-    assert.equal(
-      gridUtils.isPointInBounds(1, 101, 100, 100),
-      false,
-      '(1, 101) is not in bounds of a 100x100 container'
-    );
-    assert.equal(
-      gridUtils.isPointInBounds(101, 1, 100, 100),
-      false,
-      '(101, 1) is not in bounds of a 100x100 container'
-    );
-    assert.equal(
-      gridUtils.isPointInBounds(101, 101, 100, 100),
-      false,
-      '(101, 101) is not in bounds of a 100x100 container'
-    );
+    expect(gridUtils.isPointInBounds(1, 1, 100, 100)).toBe(true);
+    expect(gridUtils.isPointInBounds(0, 0, 100, 100)).toBe(true);
+    expect(gridUtils.isPointInBounds(0, 100, 100, 100)).toBe(true);
+    expect(gridUtils.isPointInBounds(100, 0, 100, 100)).toBe(true);
+    expect(gridUtils.isPointInBounds(100, 100, 100, 100)).toBe(true);
+    expect(gridUtils.isPointInBounds(-1, 1, 100, 100)).toBe(false);
+    expect(gridUtils.isPointInBounds(1, -1, 100, 100)).toBe(false);
+    expect(gridUtils.isPointInBounds(-1, -1, 100, 100)).toBe(false);
+    expect(gridUtils.isPointInBounds(1, 101, 100, 100)).toBe(false);
+    expect(gridUtils.isPointInBounds(101, 1, 100, 100)).toBe(false);
+    expect(gridUtils.isPointInBounds(101, 101, 100, 100)).toBe(false);
   });
 });

--- a/apps/test/unit/instructionsTest.js
+++ b/apps/test/unit/instructionsTest.js
@@ -6,8 +6,6 @@ import instructions, {
   determineInstructionsConstants,
 } from '@cdo/apps/redux/instructions';
 
-import {assert} from '../util/reconfiguredChai'; // eslint-disable-line no-restricted-imports
-
 var testUtils = require('./../util/testUtils');
 
 const ENGLISH_LOCALE = 'en_us';
@@ -20,7 +18,7 @@ describe('instructions', () => {
 
     it('starts out uncollapsed', () => {
       var state = reducer(undefined, {});
-      assert.strictEqual(state.isCollapsed, false);
+      expect(state.isCollapsed).toBe(false);
     });
 
     it('toggles isCollapsed', () => {
@@ -32,7 +30,7 @@ describe('instructions', () => {
         longInstructions: 'foo',
       };
       newState = reducer(initialState, toggleInstructionsCollapsed());
-      assert.strictEqual(newState.isCollapsed, true);
+      expect(newState.isCollapsed).toBe(true);
 
       // start uncollapsed
       initialState = {
@@ -40,7 +38,7 @@ describe('instructions', () => {
         longInstructions: 'foo',
       };
       newState = reducer(initialState, toggleInstructionsCollapsed());
-      assert.strictEqual(newState.isCollapsed, false);
+      expect(newState.isCollapsed).toBe(false);
     });
 
     it('will collapse even if no long instructions', () => {
@@ -53,7 +51,7 @@ describe('instructions', () => {
         longInstructions: undefined,
       };
       newState = reducer(initialState, toggleInstructionsCollapsed());
-      assert.strictEqual(newState.isCollapsed, true);
+      expect(newState.isCollapsed).toBe(true);
     });
 
     it('setInstructionsRenderedHeight updates rendered and expanded height if not collapsed', () => {
@@ -65,7 +63,7 @@ describe('instructions', () => {
         allowResize: true,
       };
       newState = reducer(initialState, setInstructionsRenderedHeight(200));
-      assert.deepEqual(newState, {
+      expect(newState).toEqual({
         isCollapsed: false,
         renderedHeight: 200,
         expandedHeight: 200,
@@ -81,7 +79,7 @@ describe('instructions', () => {
         expandedHeight: 0,
       };
       newState = reducer(initialState, setInstructionsRenderedHeight(200));
-      assert.deepEqual(newState, {
+      expect(newState).toEqual({
         isCollapsed: false,
         renderedHeight: 0,
         expandedHeight: 0,
@@ -97,7 +95,7 @@ describe('instructions', () => {
         allowResize: true,
       };
       newState = reducer(initialState, setInstructionsRenderedHeight(200));
-      assert.deepEqual(newState, {
+      expect(newState).toEqual({
         isCollapsed: true,
         renderedHeight: 200,
         expandedHeight: 0,
@@ -112,7 +110,7 @@ describe('instructions', () => {
         allowResize: true,
       };
       newState = reducer(initialState, setInstructionsMaxHeightNeeded(200));
-      assert.deepEqual(newState, {
+      expect(newState).toEqual({
         maxNeededHeight: 200,
         allowResize: true,
       });
@@ -127,7 +125,7 @@ describe('instructions', () => {
         allowResize: true,
       };
       newState = reducer(initialState, setInstructionsMaxHeightAvailable(300));
-      assert.deepEqual(newState, {
+      expect(newState).toEqual({
         maxAvailableHeight: 300,
         renderedHeight: 0,
         expandedHeight: 0,
@@ -144,7 +142,7 @@ describe('instructions', () => {
         allowResize: true,
       };
       newState = reducer(initialState, setInstructionsMaxHeightAvailable(300));
-      assert.deepEqual(newState, {
+      expect(newState).toEqual({
         maxAvailableHeight: 300,
         renderedHeight: 300,
         expandedHeight: 300,
@@ -178,7 +176,7 @@ describe('instructions', () => {
         );
 
         results.forEach(result => {
-          assert.equal(result.longInstructions, 'markdown');
+          expect(result.longInstructions).toBe('markdown');
         });
       });
 
@@ -196,7 +194,7 @@ describe('instructions', () => {
           overlayVisible,
         });
 
-        assert.equal(result.longInstructions, 'non-markdown');
+        expect(result.longInstructions).toBe('non-markdown');
       });
 
       it('never sets shortInstructions', () => {
@@ -214,7 +212,7 @@ describe('instructions', () => {
           overlayVisible,
         });
 
-        assert.equal(result.shortInstructions, undefined);
+        expect(result.shortInstructions).toBe(undefined);
 
         // only given markdown
         const result2 = determineInstructionsConstants({
@@ -230,7 +228,7 @@ describe('instructions', () => {
           overlayVisible,
         });
 
-        assert.equal(result2.shortInstructions, undefined);
+        expect(result2.shortInstructions).toBe(undefined);
 
         // given both
         const result3 = determineInstructionsConstants({
@@ -246,7 +244,7 @@ describe('instructions', () => {
           overlayVisible,
         });
 
-        assert.equal(result3.shortInstructions, undefined);
+        expect(result3.shortInstructions).toBe(undefined);
       });
     });
 
@@ -270,7 +268,7 @@ describe('instructions', () => {
             showInstructionsInTopPane,
             hasContainedLevels,
           });
-          assert.deepEqual(result, {
+          expect(result).toEqual({
             noInstructionsWhenCollapsed,
             shortInstructions: 'non-markdown',
             shortInstructions2: undefined,
@@ -305,7 +303,7 @@ describe('instructions', () => {
             hasContainedLevels,
             overlayVisible,
           });
-          assert.deepEqual(result, {
+          expect(result).toEqual({
             noInstructionsWhenCollapsed,
             shortInstructions: 'non-markdown',
             shortInstructions2: undefined,
@@ -342,7 +340,7 @@ describe('instructions', () => {
           hasContainedLevels,
           overlayVisible,
         });
-        assert.equal(result.longInstructions, 'non-markdown');
+        expect(result.longInstructions).toBe('non-markdown');
 
         const result2 = determineInstructionsConstants({
           level: {
@@ -357,7 +355,7 @@ describe('instructions', () => {
           hasContainedLevels,
           overlayVisible,
         });
-        assert.equal(result2.longInstructions, 'markdown');
+        expect(result2.longInstructions).toBe('markdown');
       });
 
       it('substitutes images in instructions', () => {
@@ -379,14 +377,8 @@ describe('instructions', () => {
           overlayVisible,
         });
 
-        assert(
-          /image1\.png/.test(result.shortInstructions),
-          'image 1 is replaced'
-        );
-        assert(
-          /image2\.png/.test(result.shortInstructions2),
-          'image 2 is replaced'
-        );
+        expect(/image1\.png/.test(result.shortInstructions)).toBeTruthy();
+        expect(/image2\.png/.test(result.shortInstructions2)).toBeTruthy();
       });
 
       it('instructions outputs levelVideos data when it is associated with the given level', () => {
@@ -401,7 +393,7 @@ describe('instructions', () => {
           overlayVisible,
         });
 
-        assert.deepEqual(result, {
+        expect(result).toEqual({
           noInstructionsWhenCollapsed: false,
           overlayVisible: false,
           shortInstructions: undefined,
@@ -431,7 +423,7 @@ describe('instructions', () => {
           overlayVisible,
         });
 
-        assert.deepEqual(result, {
+        expect(result).toEqual({
           noInstructionsWhenCollapsed: false,
           overlayVisible: false,
           shortInstructions: undefined,
@@ -461,7 +453,7 @@ describe('instructions', () => {
           overlayVisible,
         });
 
-        assert.deepEqual(result, {
+        expect(result).toEqual({
           noInstructionsWhenCollapsed: false,
           overlayVisible: false,
           shortInstructions: undefined,

--- a/apps/test/unit/javalab/JavalabSettingsTest.js
+++ b/apps/test/unit/javalab/JavalabSettingsTest.js
@@ -4,8 +4,6 @@ import React from 'react';
 import {DisplayTheme} from '@cdo/apps/javalab/DisplayTheme';
 import {UnconnectedJavalabSettings} from '@cdo/apps/javalab/JavalabSettings';
 
-import {assert} from '../../util/reconfiguredChai'; // eslint-disable-line no-restricted-imports
-
 describe('JavalabSettings', () => {
   let setDisplayTheme,
     increaseEditorFontSize,
@@ -36,29 +34,29 @@ describe('JavalabSettings', () => {
 
   it('is initially just a button', () => {
     const wrapper = createWrapper();
-    assert.strictEqual(wrapper.children().length, 1);
-    assert.strictEqual(wrapper.childAt(0).name(), 'JavalabButton');
+    expect(wrapper.children().length).toBe(1);
+    expect(wrapper.childAt(0).name()).toBe('JavalabButton');
   });
 
   it('shows dropdown when clicked', () => {
     const wrapper = createWrapper();
     wrapper.instance().toggleDropdown();
     // 3 buttons: settings theme toggle, increase font, decrease font
-    assert.strictEqual(wrapper.find('button').length, 3);
+    expect(wrapper.find('button').length).toBe(3);
   });
 
   it('toggles theme and closes dropdown when switch theme button is clicked', () => {
     const wrapper = createWrapper();
     wrapper.instance().toggleDropdown();
     const switchThemeButton = wrapper.find('#javalab-settings-switch-theme');
-    assert.equal(switchThemeButton.length, 1);
+    expect(switchThemeButton.length).toBe(1);
 
     switchThemeButton.first().props().onClick();
 
     expect(setDisplayTheme).toHaveBeenCalledWith(DisplayTheme.LIGHT);
 
     // Assert dropdown is closed
-    assert.equal(wrapper.find('#javalab-settings-switch-theme').length, 0);
+    expect(wrapper.find('#javalab-settings-switch-theme').length).toBe(0);
   });
 
   it('displays current font size in font size selector', () => {
@@ -68,10 +66,10 @@ describe('JavalabSettings', () => {
     const fontSizeSelector = wrapper.find(
       '#javalab-settings-font-size-selector'
     );
-    assert.equal(fontSizeSelector.length, 1);
-    assert.isTrue(
+    expect(fontSizeSelector.length).toBe(1);
+    expect(
       fontSizeSelector.first().text().includes(`${editorFontSize}px`)
-    );
+    ).toBe(true);
   });
 
   it('increases or decreases font when increase/decrease buttons are clicked', () => {
@@ -82,12 +80,12 @@ describe('JavalabSettings', () => {
     wrapper.instance().toggleDropdown();
 
     const decreaseButton = wrapper.find('#javalab-settings-decrease-font');
-    assert.equal(decreaseButton.length, 1);
+    expect(decreaseButton.length).toBe(1);
     decreaseButton.first().props().onClick();
     expect(decreaseEditorFontSize).toHaveBeenCalledTimes(1);
 
     const increaseButton = wrapper.find('#javalab-settings-increase-font');
-    assert.equal(increaseButton.length, 1);
+    expect(increaseButton.length).toBe(1);
     increaseButton.first().props().onClick();
     expect(increaseEditorFontSize).toHaveBeenCalledTimes(1);
   });
@@ -100,8 +98,8 @@ describe('JavalabSettings', () => {
     wrapper.instance().toggleDropdown();
     let decreaseButton = wrapper.find('#javalab-settings-decrease-font');
     let increaseButton = wrapper.find('#javalab-settings-increase-font');
-    assert.isFalse(decreaseButton.first().props().disabled);
-    assert.isTrue(increaseButton.first().props().disabled);
+    expect(decreaseButton.first().props().disabled).toBe(false);
+    expect(increaseButton.first().props().disabled).toBe(true);
 
     wrapper = createWrapper({
       canIncreaseFontSize: true,
@@ -110,7 +108,7 @@ describe('JavalabSettings', () => {
     wrapper.instance().toggleDropdown();
     decreaseButton = wrapper.find('#javalab-settings-decrease-font');
     increaseButton = wrapper.find('#javalab-settings-increase-font');
-    assert.isTrue(decreaseButton.first().props().disabled);
-    assert.isFalse(increaseButton.first().props().disabled);
+    expect(decreaseButton.first().props().disabled).toBe(true);
+    expect(increaseButton.first().props().disabled).toBe(false);
   });
 });

--- a/apps/test/unit/legacySharedComponents/ButtonTest.js
+++ b/apps/test/unit/legacySharedComponents/ButtonTest.js
@@ -1,6 +1,5 @@
 import {shallow} from 'enzyme'; // eslint-disable-line no-restricted-imports
 import React from 'react';
-import sinon from 'sinon'; // eslint-disable-line no-restricted-imports
 
 import Button from '@cdo/apps/legacySharedComponents/Button';
 
@@ -49,7 +48,7 @@ describe('Button', () => {
   });
 
   it('renders a div when button has an onClick', () => {
-    const onClick = sinon.spy();
+    const onClick = jest.fn();
     const wrapper = shallow(
       <Button
         __useDeprecatedTag
@@ -63,7 +62,7 @@ describe('Button', () => {
     expect(wrapper.props().href).toBe(undefined);
     expect(wrapper.props().onClick).toEqual(onClick);
     wrapper.simulate('click');
-    expect(onClick.calledOnce).toBeTruthy();
+    expect(onClick).toHaveBeenCalledTimes(1);
   });
 
   it('doesnt respond to clicks when disabled', () => {

--- a/apps/test/unit/levelbuilder/announcementsEditor/AnnouncementsEditorTests.js
+++ b/apps/test/unit/levelbuilder/announcementsEditor/AnnouncementsEditorTests.js
@@ -1,11 +1,8 @@
 import {shallow} from 'enzyme'; // eslint-disable-line no-restricted-imports
 import React from 'react';
-import sinon from 'sinon'; // eslint-disable-line no-restricted-imports
 
 import AnnouncementsEditor from '@cdo/apps/levelbuilder/announcementsEditor/AnnouncementsEditor';
 import * as utils from '@cdo/apps/utils';
-
-import {assert} from '../../../../util/reconfiguredChai'; // eslint-disable-line no-restricted-imports
 
 const sampleAnnouncement = {
   key: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
@@ -19,10 +16,10 @@ const sampleAnnouncement = {
 describe('AnnouncementsEditor', () => {
   let defaultProps, updateAnnouncements, createUuid;
   beforeEach(() => {
-    updateAnnouncements = sinon.spy();
-    createUuid = sinon
-      .stub(utils, 'createUuid')
-      .returns('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa');
+    updateAnnouncements = jest.fn();
+    createUuid = jest
+      .spyOn(utils, 'createUuid')
+      .mockReturnValue('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa');
     defaultProps = {
       announcements: [],
       inputStyle: {},
@@ -41,7 +38,7 @@ describe('AnnouncementsEditor', () => {
         announcements={[sampleAnnouncement]}
       />
     );
-    assert.equal(wrapper.find('Announcement').length, 1);
+    expect(wrapper.find('Announcement').length).toBe(1);
   });
 
   it('shows a preview for teacher and student when we have at least one announcement', () => {
@@ -51,18 +48,18 @@ describe('AnnouncementsEditor', () => {
         announcements={[sampleAnnouncement]}
       />
     );
-    assert.equal(wrapper.find('Announcements').length, 2);
+    expect(wrapper.find('Announcements').length).toBe(2);
   });
 
   it('show no preview if we have no announcements', () => {
     const wrapper = shallow(<AnnouncementsEditor {...defaultProps} />);
-    assert.equal(wrapper.find('Announcements').length, 0);
+    expect(wrapper.find('Announcements').length).toBe(0);
   });
 
   it('adds an empty Announce when we click add', () => {
     const wrapper = shallow(<AnnouncementsEditor {...defaultProps} />);
     wrapper.find('button').simulate('click');
-    expect(updateAnnouncements).to.have.been.calledWith([
+    expect(updateAnnouncements).toHaveBeenCalledWith([
       {
         key: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
         details: '',
@@ -84,11 +81,11 @@ describe('AnnouncementsEditor', () => {
       />
     );
     const announce = wrapper.find('Announcement');
-    assert.equal(announce.length, 1);
-    assert.equal(announce.first().dive().find('button').length, 1);
+    expect(announce.length).toBe(1);
+    expect(announce.first().dive().find('button').length).toBe(1);
 
     announce.first().dive().find('button').simulate('click');
-    expect(updateAnnouncements).to.have.been.calledWith([]);
+    expect(updateAnnouncements).toHaveBeenCalledWith([]);
   });
 
   it('updates notice', () => {
@@ -105,7 +102,7 @@ describe('AnnouncementsEditor', () => {
       .find('input')
       .at(0)
       .simulate('change', {target: {value: 'notice'}});
-    expect(updateAnnouncements).to.have.been.calledWith([
+    expect(updateAnnouncements).toHaveBeenCalledWith([
       {
         key: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
         details: 'See what changed and how it may affect your classroom.',
@@ -131,7 +128,7 @@ describe('AnnouncementsEditor', () => {
       .find('input')
       .at(1)
       .simulate('change', {target: {value: 'details'}});
-    expect(updateAnnouncements).to.have.been.calledWith([
+    expect(updateAnnouncements).toHaveBeenCalledWith([
       {
         key: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
         details: 'details',
@@ -157,7 +154,7 @@ describe('AnnouncementsEditor', () => {
       .find('input')
       .at(2)
       .simulate('change', {target: {value: 'link'}});
-    expect(updateAnnouncements).to.have.been.calledWith([
+    expect(updateAnnouncements).toHaveBeenCalledWith([
       {
         key: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
         details: 'details',
@@ -182,7 +179,7 @@ describe('AnnouncementsEditor', () => {
       .dive()
       .find('.uitest-announcement-type')
       .simulate('change', {target: {value: 'bullhorn'}});
-    expect(updateAnnouncements).to.have.been.calledWith([
+    expect(updateAnnouncements).toHaveBeenCalledWith([
       {
         key: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
         details: 'details',
@@ -207,7 +204,7 @@ describe('AnnouncementsEditor', () => {
       .dive()
       .find('.uitest-announcement-visibility')
       .simulate('change', {target: {value: 'Student-only'}});
-    expect(updateAnnouncements).to.have.been.calledWith([
+    expect(updateAnnouncements).toHaveBeenCalledWith([
       {
         key: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
         details: 'details',
@@ -240,7 +237,7 @@ describe('AnnouncementsEditor', () => {
       .dive()
       .find('.uitest-announcement-visibility')
       .simulate('change', {target: {value: 'Student-only'}});
-    expect(updateAnnouncements).to.have.been.calledWith([
+    expect(updateAnnouncements).toHaveBeenCalledWith([
       {
         key: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
         details: "So I don't have a visibility",
@@ -260,8 +257,7 @@ describe('AnnouncementsEditor', () => {
         announcements={[sampleAnnouncement]}
       />
     );
-    assert.equal(
-      wrapper.find('input[type="hidden"]').props().value,
+    expect(wrapper.find('input[type="hidden"]').props().value).toBe(
       JSON.stringify([sampleAnnouncement])
     );
   });

--- a/apps/test/unit/lib/tools/jsinterpreter/CustomMarshalingInterpreter.karma.test.js
+++ b/apps/test/unit/lib/tools/jsinterpreter/CustomMarshalingInterpreter.karma.test.js
@@ -1,10 +1,7 @@
 import Interpreter from '@code-dot-org/js-interpreter';
-import sinon from 'sinon'; // eslint-disable-line no-restricted-imports
 
 import CustomMarshaler from '@cdo/apps/lib/tools/jsinterpreter/CustomMarshaler';
 import CustomMarshalingInterpreter from '@cdo/apps/lib/tools/jsinterpreter/CustomMarshalingInterpreter';
-
-import {expect} from '../../../../util/reconfiguredChai'; // eslint-disable-line no-restricted-imports
 
 import {
   makeAssertableObj,
@@ -16,14 +13,14 @@ describe('The CustomMarshalingInterpreter', () => {
   beforeEach(() => {
     customMarshaler = new CustomMarshaler({});
     interpreter = new CustomMarshalingInterpreter('', customMarshaler);
-    sinon.spy(Interpreter.prototype, 'getProperty');
-    sinon.spy(Interpreter.prototype, 'setProperty');
-    sinon.spy(Interpreter.prototype, 'hasProperty');
+    jest.spyOn(Interpreter.prototype, 'getProperty');
+    jest.spyOn(Interpreter.prototype, 'setProperty');
+    jest.spyOn(Interpreter.prototype, 'hasProperty');
   });
   afterEach(() => {
-    Interpreter.prototype.getProperty.restore();
-    Interpreter.prototype.setProperty.restore();
-    Interpreter.prototype.hasProperty.restore();
+    Interpreter.prototype.getProperty.mockRestore();
+    Interpreter.prototype.setProperty.mockRestore();
+    Interpreter.prototype.hasProperty.mockRestore();
   });
 
   describe('when given an object that should be custom marshaled', () => {
@@ -50,24 +47,24 @@ describe('The CustomMarshalingInterpreter', () => {
     });
 
     it('will create a custom marshal object', () => {
-      expect(value.interpreterValue.isCustomMarshal).to.be.true;
+      expect(value.interpreterValue.isCustomMarshal).toBe(true);
     });
 
     describe('the custom marshal object', () => {
       it('will have a data property set to the original native value', () => {
-        expect(value.interpreterValue.data).to.equal(value.nativeValue);
+        expect(value.interpreterValue.data).toBe(value.nativeValue);
       });
 
       it('is not a primitive', () => {
-        expect(value.interpreterValue.isPrimitive).to.be.false;
+        expect(value.interpreterValue.isPrimitive).toBe(false);
       });
 
       it('is the same type as the native object', () => {
-        expect(value.interpreterValue.type).to.equal('object');
+        expect(value.interpreterValue.type).toBe('object');
       });
 
       it('will have a valueOf method that returns the original native value', () => {
-        expect(value.interpreterValue.valueOf()).to.equal(value.nativeValue);
+        expect(value.interpreterValue.valueOf()).toBe(value.nativeValue);
       });
     });
 
@@ -99,10 +96,10 @@ describe('The CustomMarshalingInterpreter', () => {
     });
 
     it('will only custom marshal the object when the requiredMethod is present', () => {
-      expect(value.interpreterValue.isCustomMarshal).to.be.true;
+      expect(value.interpreterValue.isCustomMarshal).toBe(true);
       expect(
         makeAssertableObj(interpreter, []).interpreterValue.isCustomMarshal
-      ).not.to.be.true;
+      ).not.toBe(true);
     });
 
     it('will make sure the required method gets included in the custom marshaled object', () => {
@@ -112,7 +109,7 @@ describe('The CustomMarshalingInterpreter', () => {
 
   describe('the constructor', () => {
     it('requires passing in a custom marshaler instance', () => {
-      expect(() => new CustomMarshalingInterpreter('foo = true;')).to.throw(
+      expect(() => new CustomMarshalingInterpreter('foo = true;')).toThrow(
         'You must provide a CustomMarshaler to CustomMarshalingInterpreter'
       );
     });
@@ -125,12 +122,12 @@ describe('The CustomMarshalingInterpreter', () => {
         customMarshaler
       );
       interpreter.run();
-      expect(Interpreter.prototype.setProperty).to.have.been.calledWith(
+      expect(Interpreter.prototype.setProperty).toHaveBeenCalledWith(
         interpreter.global,
         'foo',
         interpreter.TRUE
       );
-      expect(Interpreter.prototype.setProperty).to.have.been.calledWith(
+      expect(Interpreter.prototype.setProperty).toHaveBeenCalledWith(
         interpreter.getProperty(interpreter.global, 'foo'),
         'bar',
         interpreter.FALSE
@@ -157,7 +154,7 @@ describe('The CustomMarshalingInterpreter', () => {
 
       it('will set the property on the native object', () => {
         interpreter.run();
-        expect(nativeObject.fromInterpreter).to.equal('hello');
+        expect(nativeObject.fromInterpreter).toBe('hello');
       });
 
       describe('and the property name is in the list of properties blocked from custom marshaling', () => {
@@ -178,7 +175,7 @@ describe('The CustomMarshalingInterpreter', () => {
 
         it('will not set the property on the native object', () => {
           interpreter.run();
-          expect(nativeObject.fromInterpreter).to.be.undefined;
+          expect(nativeObject.fromInterpreter).toBeUndefined();
         });
       });
 
@@ -264,33 +261,33 @@ describe('The CustomMarshalingInterpreter', () => {
 
       it('will not set a new function property on the native object', () => {
         interpreter.run();
-        expect(nativeObject.newFunction).to.be.undefined;
+        expect(nativeObject.newFunction).toBeUndefined();
       });
 
       it('will not set a new array property on the native object', () => {
         interpreter.run();
-        expect(nativeObject.newArray).to.be.undefined;
+        expect(nativeObject.newArray).toBeUndefined();
       });
 
       it('will not set a new object property on the native object', () => {
         interpreter.run();
-        expect(nativeObject.newObject).to.be.undefined;
+        expect(nativeObject.newObject).toBeUndefined();
       });
 
       it('will set an existing function property on the native object', () => {
         interpreter.run();
-        expect(nativeObject.existingFunction).not.to.equal(existingFunction);
+        expect(nativeObject.existingFunction).not.toBe(existingFunction);
       });
 
       it('will set an existing array property on the native object', () => {
         interpreter.run();
-        expect(nativeObject.existingArray.length).to.equal(1);
-        expect(nativeObject.existingArray[0]).to.equal(1);
+        expect(nativeObject.existingArray.length).toBe(1);
+        expect(nativeObject.existingArray[0]).toBe(1);
       });
 
       it('will set an existing object property on the native object', () => {
         interpreter.run();
-        expect(nativeObject.existingObject.prop).to.equal(1);
+        expect(nativeObject.existingObject.prop).toBe(1);
       });
     });
 
@@ -307,7 +304,7 @@ describe('The CustomMarshalingInterpreter', () => {
 
       it('will set the property on the global for the given name', () => {
         new CustomMarshalingInterpreter('name = "Paul"', customMarshaler).run();
-        expect(player.name).to.equal('Paul');
+        expect(player.name).toBe('Paul');
       });
 
       it('will correctly walk the scope chain if necessary to set the property', () => {
@@ -322,7 +319,7 @@ describe('The CustomMarshalingInterpreter', () => {
           `,
           customMarshaler
         ).run();
-        expect(player.name).to.equal('Paul');
+        expect(player.name).toBe('Paul');
       });
 
       describe('when used to set properties that are blocked from custom marshaling', () => {
@@ -337,7 +334,7 @@ describe('The CustomMarshalingInterpreter', () => {
             'name = "Paul"',
             customMarshaler
           ).run();
-          expect(player.name).to.be.undefined;
+          expect(player.name).toBeUndefined();
         });
       });
     });
@@ -356,9 +353,9 @@ describe('The CustomMarshalingInterpreter', () => {
       customMarshaler
     );
     interpreter.run();
-    expect(
-      interpreter.getProperty(interpreter.global, 'name').toString()
-    ).to.equal('Paul');
+    expect(interpreter.getProperty(interpreter.global, 'name').toString()).toBe(
+      'Paul'
+    );
   });
 
   it('will throw an exception when trying to set an undeclared variabled in strict mode', () => {
@@ -373,7 +370,7 @@ describe('The CustomMarshalingInterpreter', () => {
        setNameToPaul();`,
       customMarshaler
     );
-    expect(() => interpreter.run()).to.throw('Unknown identifier: name');
+    expect(() => interpreter.run()).toThrow('Unknown identifier: name');
   });
 
   it('will throw an exception when trying to reference an undeclared variable', () => {
@@ -381,7 +378,7 @@ describe('The CustomMarshalingInterpreter', () => {
       `parseInt(someUndeclaredVariable)`,
       customMarshaler
     );
-    expect(() => interpreter.run()).to.throw(
+    expect(() => interpreter.run()).toThrow(
       'someUndeclaredVariable is not defined'
     );
   });
@@ -410,7 +407,7 @@ describe('The CustomMarshalingInterpreter', () => {
         interpreter.marshalInterpreterToNative(
           interpreter.getValueFromScope('myArray')
         )
-      ).to.eql(expectedSortedArray);
+      ).toEqual(expectedSortedArray);
     });
   });
 
@@ -420,8 +417,8 @@ describe('The CustomMarshalingInterpreter', () => {
         interpreter.global,
         'undefined'
       );
-      expect(Interpreter.prototype.getProperty).to.have.been.called;
-      expect(interpreterUndefined).to.equal(interpreter.UNDEFINED);
+      expect(Interpreter.prototype.getProperty).toHaveBeenCalled();
+      expect(interpreterUndefined).toBe(interpreter.UNDEFINED);
     });
   });
 
@@ -456,44 +453,47 @@ describe('The CustomMarshalingInterpreter', () => {
 
     it("delegates to the base class's hasProperty method by default", () => {
       const retVal = interpreter.hasProperty(interpreter.global, 'undefined');
-      expect(retVal).to.be.true;
-      expect(Interpreter.prototype.hasProperty).to.have.been.called;
+      expect(retVal).toBe(true);
+      expect(Interpreter.prototype.hasProperty).toHaveBeenCalled();
     });
 
     it("does not find globals that don't exist", () => {
-      expect(interpreter.hasProperty(interpreter.global, 'notAGlobalProperty'))
-        .to.be.false;
+      expect(
+        interpreter.hasProperty(interpreter.global, 'notAGlobalProperty')
+      ).toBe(false);
     });
 
     it('finds custom-marshaled globals', () => {
-      expect(interpreter.hasProperty(interpreter.global, 'age')).to.be.true;
+      expect(interpreter.hasProperty(interpreter.global, 'age')).toBe(true);
     });
 
     it('does not find blocked custom-marshaled globals', () => {
-      expect(interpreter.hasProperty(interpreter.global, 'name')).to.be.false;
+      expect(interpreter.hasProperty(interpreter.global, 'name')).toBe(false);
     });
 
     it('finds properties on custom-marshaled objects', () => {
       const customMarshaledObject = interpreter.marshalNativeToInterpreter(
         new Foo('hello world')
       );
-      expect(interpreter.hasProperty(customMarshaledObject, 'whatsMyName')).to
-        .be.true;
+      expect(
+        interpreter.hasProperty(customMarshaledObject, 'whatsMyName')
+      ).toBe(true);
     });
 
     it("does not find properties that don't exist on custom-marshaled objects", () => {
       const customMarshaledObject = interpreter.marshalNativeToInterpreter(
         new Foo('hello world')
       );
-      expect(interpreter.hasProperty(customMarshaledObject, 'notARealProperty'))
-        .to.be.false;
+      expect(
+        interpreter.hasProperty(customMarshaledObject, 'notARealProperty')
+      ).toBe(false);
     });
 
     it('does not find blocked properties on custom-marshaled objects', () => {
       const value = interpreter.marshalNativeToInterpreter(
         new Foo('hello world')
       );
-      expect(interpreter.hasProperty(value, 'name')).to.be.false;
+      expect(interpreter.hasProperty(value, 'name')).toBe(false);
     });
   });
 
@@ -501,22 +501,22 @@ describe('The CustomMarshalingInterpreter', () => {
     let hooks, globals;
     beforeEach(() => {
       globals = {
-        a: sinon.spy(),
-        b: sinon.spy(),
-        c: sinon.spy(),
+        a: jest.fn(),
+        b: jest.fn(),
+        c: jest.fn(),
       };
     });
 
     it('will return an empty array of hooks if no events are provided', () => {
-      expect(
-        CustomMarshalingInterpreter.evalWithEvents({}, {}).hooks
-      ).to.deep.equal([]);
+      expect(CustomMarshalingInterpreter.evalWithEvents({}, {}).hooks).toEqual(
+        []
+      );
     });
 
     it('will return the interpreter that was created to run the code', () => {
       expect(
         CustomMarshalingInterpreter.evalWithEvents({}, {}).interpreter
-      ).to.be.an.instanceOf(CustomMarshalingInterpreter);
+      ).toBeInstanceOf(CustomMarshalingInterpreter);
     });
 
     describe('when given event handlers that accept arguments', () => {
@@ -527,7 +527,7 @@ describe('The CustomMarshalingInterpreter', () => {
       });
       it('will pass the args provided to the hook along to the event handler', () => {
         hooks[0].func(5, 6);
-        expect(globals.c).to.have.been.calledWith(10, 2);
+        expect(globals.c).toHaveBeenCalledWith(10, 2);
       });
     });
 
@@ -538,7 +538,7 @@ describe('The CustomMarshalingInterpreter', () => {
         }).hooks;
       });
       it('will return the values returned by the event handler back to the caller of the hook', () => {
-        expect(hooks[0].func()).to.equal(5);
+        expect(hooks[0].func()).toBe(5);
       });
     });
 
@@ -554,12 +554,12 @@ describe('The CustomMarshalingInterpreter', () => {
       });
 
       it('will evaluate that code immediately', () => {
-        expect(globals.a).to.have.been.called;
+        expect(globals.a).toHaveBeenCalled();
       });
 
       it('will continue waiting for the various hooks to be called', () => {
         hooks[0].func();
-        expect(globals.b).to.have.been.called;
+        expect(globals.b).toHaveBeenCalled();
       });
 
       it('will throw an unexpected token exception when given code that does not end with a semicolon', () => {
@@ -569,7 +569,7 @@ describe('The CustomMarshalingInterpreter', () => {
             {someEvent: {code: 'b()'}},
             'a()'
           )
-        ).to.throw('Unexpected token');
+        ).toThrow('Unexpected token');
       });
     });
 
@@ -582,11 +582,11 @@ describe('The CustomMarshalingInterpreter', () => {
       });
 
       it('will return a hook for each event handler of each event type that was given', () => {
-        expect(hooks.length).to.equal(3);
+        expect(hooks.length).toBe(3);
       });
 
       it('each returned hook will have a name property corresponding to the event name it is connected to', () => {
-        expect(hooks.map(hook => hook.name)).to.deep.equal([
+        expect(hooks.map(hook => hook.name)).toEqual([
           'someEvent',
           'someEvent',
           'someOtherEvent',
@@ -594,13 +594,13 @@ describe('The CustomMarshalingInterpreter', () => {
       });
 
       it('will call the appropriate event handlers when those hooks get called', () => {
-        expect(hooks[0].name).to.equal('someEvent');
+        expect(hooks[0].name).toBe('someEvent');
         hooks[0].func();
-        expect(globals.a).to.have.been.called;
-        expect(globals.b).not.to.have.been.called;
-        expect(globals.c).not.to.have.been.called;
+        expect(globals.a).toHaveBeenCalled();
+        expect(globals.b).not.toHaveBeenCalled();
+        expect(globals.c).not.toHaveBeenCalled();
         hooks[2].func();
-        expect(globals.c).to.have.been.called;
+        expect(globals.c).toHaveBeenCalled();
       });
     });
   });
@@ -623,7 +623,7 @@ describe('The CustomMarshalingInterpreter', () => {
           );
         }
       );
-      sinon.spy(interpreter, 'createPrimitive');
+      jest.spyOn(interpreter, 'createPrimitive');
     });
 
     function boundMakeAssertableObj(nativeVar, nativeParentObj, maxDepth) {
@@ -636,20 +636,18 @@ describe('The CustomMarshalingInterpreter', () => {
     }
 
     it('when given an undefined native variable, will return an undefined interpreter variable', () => {
-      expect(interpreter.marshalNativeToInterpreter(undefined)).to.equal(
+      expect(interpreter.marshalNativeToInterpreter(undefined)).toBe(
         interpreter.UNDEFINED
       );
     });
 
     it("will delegate to the interpreter's createPrimitive function for booleans, numbers, and strings", () => {
       interpreter.marshalNativeToInterpreter(true);
-      expect(interpreter.createPrimitive).to.have.been.calledWith(true);
+      expect(interpreter.createPrimitive).toHaveBeenCalledWith(true);
       interpreter.marshalNativeToInterpreter(5);
-      expect(interpreter.createPrimitive).to.have.been.calledWith(5);
+      expect(interpreter.createPrimitive).toHaveBeenCalledWith(5);
       interpreter.marshalNativeToInterpreter('some string');
-      expect(interpreter.createPrimitive).to.have.been.calledWith(
-        'some string'
-      );
+      expect(interpreter.createPrimitive).toHaveBeenCalledWith('some string');
     });
 
     describe('when given an empty object to marshal, the corresponding interpreter object', () => {
@@ -751,9 +749,9 @@ describe('The CustomMarshalingInterpreter', () => {
           interpreter.getScope(),
           'isNaN'
         );
-        expect(
-          interpreter.marshalNativeToInterpreter(interpreterFunc)
-        ).to.equal(interpreterFunc);
+        expect(interpreter.marshalNativeToInterpreter(interpreterFunc)).toBe(
+          interpreterFunc
+        );
       });
     });
 
@@ -812,10 +810,12 @@ describe('The CustomMarshalingInterpreter', () => {
 
     describe('when given an object that should be custom marshaled', () => {
       beforeEach(() => {
-        sinon
-          .stub(interpreter.customMarshaler, 'shouldCustomMarshalObject')
-          .returns(true);
-        sinon.stub(interpreter.customMarshaler, 'createCustomMarshalObject');
+        jest
+          .spyOn(interpreter.customMarshaler, 'shouldCustomMarshalObject')
+          .mockReturnValue(true);
+        jest
+          .spyOn(interpreter.customMarshaler, 'createCustomMarshalObject')
+          .mockImplementation();
       });
       it("will delegate to the custom marshaler's createCustomMarshalObject", () => {
         const nativeParentObj = {foo: 'bar'};
@@ -823,7 +823,7 @@ describe('The CustomMarshalingInterpreter', () => {
         interpreter.marshalNativeToInterpreter(nativeVar, nativeParentObj);
         expect(
           interpreter.customMarshaler.createCustomMarshalObject
-        ).to.have.been.calledWith(interpreter, nativeVar, nativeParentObj);
+        ).toHaveBeenCalledWith(interpreter, nativeVar, nativeParentObj);
       });
     });
   });
@@ -832,10 +832,10 @@ describe('The CustomMarshalingInterpreter', () => {
     let options;
     beforeEach(() => {
       options = {
-        add: sinon.spy(),
+        add: jest.fn(),
         a: 3,
       };
-      window.nativeAdd = sinon.spy();
+      window.nativeAdd = jest.fn();
     });
 
     afterEach(() => {
@@ -844,15 +844,15 @@ describe('The CustomMarshalingInterpreter', () => {
 
     it('evaluates a string of code, prepopulating the scope with whatever is in options', () => {
       CustomMarshalingInterpreter.evalWith('add(1,2)', options);
-      expect(options.add).to.have.been.calledWith(1, 2);
+      expect(options.add).toHaveBeenCalledWith(1, 2);
       CustomMarshalingInterpreter.evalWith('add(a,2)', options);
-      expect(options.add).to.have.been.calledWith(3, 2);
+      expect(options.add).toHaveBeenCalledWith(3, 2);
     });
 
     it('does not give the evaluated code access to native functions', () => {
       expect(() =>
         CustomMarshalingInterpreter.evalWith('nativeAdd(1,2)', options)
-      ).to.throw('nativeAdd is not defined');
+      ).toThrow('nativeAdd is not defined');
     });
 
     describe('when running with legacy=true', () => {
@@ -861,33 +861,33 @@ describe('The CustomMarshalingInterpreter', () => {
           CustomMarshalingInterpreter.evalWith('nativeAdd(1,2)', options, {
             legacy: true,
           })
-        ).not.to.throw;
+        ).not.toThrow();
         CustomMarshalingInterpreter.evalWith('nativeAdd(1,2)', options, {
           legacy: true,
         });
-        expect(window.nativeAdd).to.have.been.calledWith(1, 2);
+        expect(window.nativeAdd).toHaveBeenCalledWith(1, 2);
         CustomMarshalingInterpreter.evalWith('nativeAdd(1,2)', options, {
           legacy: true,
         });
-        expect(window.nativeAdd).to.have.been.calledWith(1, 2);
+        expect(window.nativeAdd).toHaveBeenCalledWith(1, 2);
       });
 
       it('the evaluated code will have access to functions passed in through options', () => {
         CustomMarshalingInterpreter.evalWith('add(1,2)', options, {
           legacy: true,
         });
-        expect(options.add).to.have.been.calledWith(1, 2);
+        expect(options.add).toHaveBeenCalledWith(1, 2);
       });
 
       it('the evaluated code will have access to variables passed in through options', () => {
         CustomMarshalingInterpreter.evalWith('add(a,2)', options, {
           legacy: true,
         });
-        expect(options.add).to.have.been.calledWith(3, 2);
+        expect(options.add).toHaveBeenCalledWith(3, 2);
         CustomMarshalingInterpreter.evalWith('nativeAdd(a,2)', options, {
           legacy: true,
         });
-        expect(window.nativeAdd).to.have.been.calledWith(3, 2);
+        expect(window.nativeAdd).toHaveBeenCalledWith(3, 2);
       });
     });
   });
@@ -906,7 +906,7 @@ describe('The CustomMarshalingInterpreter', () => {
     }
 
     it('correctly marshals arrays', () => {
-      expect(evalExpression(`["one", 2, ["three"]]`)).to.deep.equal([
+      expect(evalExpression(`["one", 2, ["three"]]`)).toEqual([
         'one',
         2,
         ['three'],
@@ -915,20 +915,20 @@ describe('The CustomMarshalingInterpreter', () => {
 
     it('correctly marshals objects', () => {
       const value = evalExpression(`{one: 1, two: "two", three: {four: 4}}`);
-      expect(value.one).to.equal(1);
-      expect(value.two).to.equal('two');
-      expect(value.three.four).to.equal(4);
-      expect(Object.keys(value)).to.deep.equal(['one', 'two', 'three']);
-      expect(value).to.deep.equal({one: 1, two: 'two', three: {four: 4}});
+      expect(value.one).toBe(1);
+      expect(value.two).toBe('two');
+      expect(value.three.four).toBe(4);
+      expect(Object.keys(value)).toEqual(['one', 'two', 'three']);
+      expect(value).toEqual({one: 1, two: 'two', three: {four: 4}});
     });
 
     it('marshals functions by delegating to CustomMarshalingInterpreter.createNativeFunctionFromInterpreterFunction', () => {
       CustomMarshalingInterpreter.createNativeFunctionFromInterpreterFunction =
-        sinon.stub().returns('foo');
-      expect(evalExpression(`function (a,b) { return a+b; }`)).to.equal('foo');
+        jest.fn().mockReturnValue('foo');
+      expect(evalExpression(`function (a,b) { return a+b; }`)).toBe('foo');
       expect(
         CustomMarshalingInterpreter.createNativeFunctionFromInterpreterFunction
-      ).to.have.been.calledOnce;
+      ).toHaveBeenCalledTimes(1);
       CustomMarshalingInterpreter.createNativeFunctionFromInterpreterFunction =
         null;
     });
@@ -936,8 +936,8 @@ describe('The CustomMarshalingInterpreter', () => {
     it('marshals functions by doing nothing when CustomMarshalingInterpreter.createNativeFunctionFromInterpreterFunction is not set', () => {
       expect(
         CustomMarshalingInterpreter.createNativeFunctionFromInterpreterFunction
-      ).to.be.null;
-      expect(evalExpression(`function (a,b) { return a+b; }`)).to.equal(
+      ).toBeNull();
+      expect(evalExpression(`function (a,b) { return a+b; }`)).toBe(
         interpreter.getValueFromScope('result')
       );
     });
@@ -949,7 +949,7 @@ describe('The CustomMarshalingInterpreter', () => {
       );
       expect(() =>
         interpreter.marshalInterpreterToNative({notAnInterpreterObject: true})
-      ).to.throw("Can't marshal type object");
+      ).toThrow("Can't marshal type object");
     });
   });
 
@@ -958,16 +958,14 @@ describe('The CustomMarshalingInterpreter', () => {
 
     function testTheBasics() {
       it('will call the nativeFunc', () => {
-        expect(options.nativeFunc).to.have.been.called;
+        expect(options.nativeFunc).toHaveBeenCalled();
       });
       it("will call the nativeFunc with the nativeParentObj as the 'this'", () => {
-        expect(options.nativeFunc.thisValues[0]).to.equal(
-          options.nativeParentObj
-        );
+        expect(options.nativeFunc.thisValues[0]).toBe(options.nativeParentObj);
       });
       it('will marshal the native return value back to an interpreter value', () => {
-        expect(result).to.be.an.instanceOf(Interpreter.Primitive);
-        expect(result.toNumber()).to.equal(6);
+        expect(result).toBeInstanceOf(Interpreter.Primitive);
+        expect(result.toNumber()).toBe(6);
       });
     }
 
@@ -997,7 +995,7 @@ describe('The CustomMarshalingInterpreter', () => {
     describe('when dontMarshal=true', () => {
       runWithOptions('var result = memberFunc(1,2,3)', () => ({
         dontMarshal: true,
-        nativeFunc: sinon.stub().returns(6),
+        nativeFunc: jest.fn().mockReturnValue(6),
         nativeParentObj: {},
         maxDepth: 5,
       }));
@@ -1006,18 +1004,18 @@ describe('The CustomMarshalingInterpreter', () => {
 
       it('will pass along the unmarshaled interpreter arguments to the nativeFunc', () => {
         const args = options.nativeFunc.firstCall.args;
-        expect(args.length).to.equal(3);
-        expect(args[0]).to.be.an.instanceOf(Interpreter.Primitive);
-        expect(args[0].toNumber()).to.equal(1);
-        expect(args[1].toNumber()).to.equal(2);
-        expect(args[2].toNumber()).to.equal(3);
+        expect(args.length).toBe(3);
+        expect(args[0]).toBeInstanceOf(Interpreter.Primitive);
+        expect(args[0].toNumber()).toBe(1);
+        expect(args[1].toNumber()).toBe(2);
+        expect(args[2].toNumber()).toBe(3);
       });
     });
 
     describe('when dontMarshal=false', () => {
       runWithOptions('var result = memberFunc(1,2,3)', () => ({
         dontMarshal: false,
-        nativeFunc: sinon.stub().returns(6),
+        nativeFunc: jest.fn().mockReturnValue(6),
         nativeParentObj: {},
         maxDepth: 5,
       }));
@@ -1025,51 +1023,49 @@ describe('The CustomMarshalingInterpreter', () => {
 
       it('will pass along marshaled arguments to the nativeFunc', () => {
         const args = options.nativeFunc.firstCall.args;
-        expect(args.length).to.equal(3);
-        expect(args[0]).to.equal(1);
-        expect(args[1]).to.equal(2);
-        expect(args[2]).to.equal(3);
+        expect(args.length).toBe(3);
+        expect(args[0]).toBe(1);
+        expect(args[1]).toBe(2);
+        expect(args[2]).toBe(3);
       });
     });
 
     describe('when dontMarshal=false and nativeIsAsync=true', () => {
       runWithOptions('var result = memberFunc(1,2)', () => ({
         dontMarshal: false,
-        nativeFunc: sinon.stub().returns(6),
+        nativeFunc: jest.fn().mockReturnValue(6),
         nativeParentObj: {},
         maxDepth: 5,
         nativeIsAsync: true,
       }));
 
       it('will call the nativeFunc', () => {
-        expect(options.nativeFunc).to.have.been.called;
+        expect(options.nativeFunc).toHaveBeenCalled();
       });
       it("will call the nativeFunc with the nativeParentObj as the 'this'", () => {
-        expect(options.nativeFunc.thisValues[0]).to.equal(
-          options.nativeParentObj
-        );
+        expect(options.nativeFunc.thisValues[0]).toBe(options.nativeParentObj);
       });
       it('will not return a result immediately, since the native function is asynchronous', () => {
-        expect(result).to.equal(interpreter.UNDEFINED);
+        expect(result).toBe(interpreter.UNDEFINED);
       });
       it('will pause the interpreter until the function is called', () => {
-        expect(isPaused).to.be.true;
+        expect(isPaused).toBe(true);
       });
 
       it('will automatically tack on an extra callback argument to be passed to the native func', () => {
         const args = options.nativeFunc.firstCall.args;
-        expect(args.length).to.equal(3);
+        expect(args.length).toBe(3);
       });
 
       it('will pass along marshaled arguments to the nativeFunc', () => {
         const args = options.nativeFunc.firstCall.args;
-        expect(args[0]).to.equal(1);
-        expect(args[1]).to.equal(2);
+        expect(args[0]).toBe(1);
+        expect(args[1]).toBe(2);
       });
 
       it('will make the last marshaled argument a native callback function', () => {
         const args = options.nativeFunc.firstCall.args;
-        expect(args[args.length - 1]).to.be.an.instanceOf(Function);
+        expect(args[args.length - 1]).toBeInstanceOf(Function);
       });
 
       describe('when the native callback function is eventually called', () => {
@@ -1078,12 +1074,12 @@ describe('The CustomMarshalingInterpreter', () => {
           window.setTimeout(() => {
             args[args.length - 1]('new value');
             result = interpreter.getProperty(interpreter.global, 'result');
-            expect(result).to.equal(interpreter.UNDEFINED);
+            expect(result).toBe(interpreter.UNDEFINED);
 
             isPaused = interpreter.run();
-            expect(isPaused).to.be.false;
+            expect(isPaused).toBe(false);
             result = interpreter.getProperty(interpreter.global, 'result');
-            expect(result.toString()).to.equal('new value');
+            expect(result.toString()).toBe('new value');
             done();
           }, 100);
         });
@@ -1105,7 +1101,7 @@ describe('The CustomMarshalingInterpreter', () => {
         `,
         () => ({
           dontMarshal: false,
-          nativeFunc: sinon.stub().returns(6),
+          nativeFunc: jest.fn().mockReturnValue(6),
           nativeParentObj: {},
           maxDepth: 5,
           nativeCallsBackInterpreter: true,
@@ -1116,13 +1112,13 @@ describe('The CustomMarshalingInterpreter', () => {
 
       it('will pass along marshaled arguments to the nativeFunc', () => {
         const args = options.nativeFunc.firstCall.args;
-        expect(args[0]).to.equal(1);
-        expect(args[1]).to.equal(2);
+        expect(args[0]).toBe(1);
+        expect(args[1]).toBe(2);
       });
 
       it('will wrap any interpreter function arguments into a native function', () => {
         const args = options.nativeFunc.firstCall.args;
-        expect(args[2]).to.be.an.instanceOf(Function);
+        expect(args[2]).toBeInstanceOf(Function);
       });
 
       describe('when the interpreter function passed to the native func is called', () => {
@@ -1134,30 +1130,30 @@ describe('The CustomMarshalingInterpreter', () => {
         it('will call the interpreter function the next time the interpreter is run', () => {
           returnToInterpreter('a new result');
           result = interpreter.getProperty(interpreter.global, 'result');
-          expect(result).to.be.an.instanceOf(Interpreter.Primitive);
-          expect(result.toNumber()).to.equal(6);
+          expect(result).toBeInstanceOf(Interpreter.Primitive);
+          expect(result.toNumber()).toBe(6);
           interpreter.run();
           result = interpreter.getProperty(interpreter.global, 'result');
-          expect(result).to.be.an.instanceOf(Interpreter.Primitive);
-          expect(result.toString()).to.equal('a new result');
+          expect(result).toBeInstanceOf(Interpreter.Primitive);
+          expect(result.toString()).toBe('a new result');
         });
 
         it('will marshal all the arguments that were passed', () => {
           returnToInterpreter('a new result', 'another result');
           interpreter.run();
           result = interpreter.getProperty(interpreter.global, 'result');
-          expect(result).to.be.an.instanceOf(Interpreter.Primitive);
-          expect(result.toString()).to.equal('a new result');
+          expect(result).toBeInstanceOf(Interpreter.Primitive);
+          expect(result.toString()).toBe('a new result');
           result = interpreter.getProperty(interpreter.global, 'otherResult');
-          expect(result).to.be.an.instanceOf(Interpreter.Primitive);
-          expect(result.toString()).to.equal('another result');
+          expect(result).toBeInstanceOf(Interpreter.Primitive);
+          expect(result.toString()).toBe('another result');
         });
 
         it('will marshall no arguments if none were passed', () => {
           returnToInterpreter();
           interpreter.run();
           result = interpreter.getProperty(interpreter.global, 'result');
-          expect(result).to.equal(interpreter.UNDEFINED);
+          expect(result).toBe(interpreter.UNDEFINED);
         });
       });
     });

--- a/apps/test/unit/lib/util/AnalyticsReporterTest.js
+++ b/apps/test/unit/lib/util/AnalyticsReporterTest.js
@@ -1,76 +1,76 @@
-import {stub} from 'sinon'; // eslint-disable-line no-restricted-imports
-
 import analyticsReporter from '@cdo/apps/metrics/AnalyticsReporter';
 import * as utils from '@cdo/apps/utils';
-
-import {expect} from '../../../util/reconfiguredChai'; // eslint-disable-line no-restricted-imports
 
 describe('AnalyticsReporter', () => {
   describe('formatUserId', () => {
     it('prepends environment in development', () => {
-      stub(utils, 'getEnvironment').returns('development');
-      expect(analyticsReporter.formatUserId('0').startsWith('development')).to
-        .be.true;
-      utils.getEnvironment.restore();
+      jest.spyOn(utils, 'getEnvironment').mockReturnValue('development');
+      expect(
+        analyticsReporter.formatUserId('0').startsWith('development')
+      ).toBe(true);
+      utils.getEnvironment.mockRestore();
     });
 
     it('prepends environment in staging', () => {
-      stub(utils, 'getEnvironment').returns('staging');
-      expect(analyticsReporter.formatUserId('0').startsWith('staging')).to.be
-        .true;
-      utils.getEnvironment.restore();
+      jest.spyOn(utils, 'getEnvironment').mockReturnValue('staging');
+      expect(analyticsReporter.formatUserId('0').startsWith('staging')).toBe(
+        true
+      );
+      utils.getEnvironment.mockRestore();
     });
 
     it('prepends environment in test', () => {
-      stub(utils, 'getEnvironment').returns('test');
-      expect(analyticsReporter.formatUserId('0').startsWith('test')).to.be.true;
-      utils.getEnvironment.restore();
+      jest.spyOn(utils, 'getEnvironment').mockReturnValue('test');
+      expect(analyticsReporter.formatUserId('0').startsWith('test')).toBe(true);
+      utils.getEnvironment.mockRestore();
     });
 
     it('prepends environment in adhoc', () => {
-      stub(utils, 'getEnvironment').returns('adhoc');
-      expect(analyticsReporter.formatUserId('0').startsWith('adhoc')).to.be
-        .true;
-      utils.getEnvironment.restore();
+      jest.spyOn(utils, 'getEnvironment').mockReturnValue('adhoc');
+      expect(analyticsReporter.formatUserId('0').startsWith('adhoc')).toBe(
+        true
+      );
+      utils.getEnvironment.mockRestore();
     });
 
     it('does not prepend environment in production', () => {
-      stub(utils, 'isProductionEnvironment').returns(true);
-      expect(analyticsReporter.formatUserId('0').startsWith('prod')).to.be
-        .false;
-      utils.isProductionEnvironment.restore();
+      jest.spyOn(utils, 'isProductionEnvironment').mockReturnValue(true);
+      expect(analyticsReporter.formatUserId('0').startsWith('prod')).toBe(
+        false
+      );
+      utils.isProductionEnvironment.mockRestore();
     });
 
     it('formats short user ids to be five character', () => {
-      stub(utils, 'isProductionEnvironment').returns(true);
-      expect(analyticsReporter.formatUserId('1')).to.equal('00001');
-      utils.isProductionEnvironment.restore();
+      jest.spyOn(utils, 'isProductionEnvironment').mockReturnValue(true);
+      expect(analyticsReporter.formatUserId('1')).toBe('00001');
+      utils.isProductionEnvironment.mockRestore();
     });
 
     it('does not change long user ids in production', () => {
-      stub(utils, 'isProductionEnvironment').returns(true);
-      expect(analyticsReporter.formatUserId('88888')).to.equal('88888');
-      utils.isProductionEnvironment.restore();
+      jest.spyOn(utils, 'isProductionEnvironment').mockReturnValue(true);
+      expect(analyticsReporter.formatUserId('88888')).toBe('88888');
+      utils.isProductionEnvironment.mockRestore();
     });
   });
 
   describe('shouldPutRecord', () => {
     it('shouldPutRecord return true if alwaysPut is true', () => {
-      stub(utils, 'getEnvironment').returns('development');
-      expect(analyticsReporter.shouldPutRecord(true)).to.be.true;
-      utils.getEnvironment.restore();
+      jest.spyOn(utils, 'getEnvironment').mockReturnValue('development');
+      expect(analyticsReporter.shouldPutRecord(true)).toBe(true);
+      utils.getEnvironment.mockRestore();
     });
 
     it('shouldPutRecord returns true if production', () => {
-      stub(utils, 'isProductionEnvironment').returns(true);
-      expect(analyticsReporter.shouldPutRecord(false)).to.be.true;
-      utils.isProductionEnvironment.restore();
+      jest.spyOn(utils, 'isProductionEnvironment').mockReturnValue(true);
+      expect(analyticsReporter.shouldPutRecord(false)).toBe(true);
+      utils.isProductionEnvironment.mockRestore();
     });
 
     it('shouldPutRecord returns false if development', () => {
-      stub(utils, 'getEnvironment').returns('development');
-      expect(analyticsReporter.shouldPutRecord(false)).to.be.false;
-      utils.getEnvironment.restore();
+      jest.spyOn(utils, 'getEnvironment').mockReturnValue('development');
+      expect(analyticsReporter.shouldPutRecord(false)).toBe(false);
+      utils.getEnvironment.mockRestore();
     });
   });
 });

--- a/apps/test/unit/lib/util/statsigHelpersTest.js
+++ b/apps/test/unit/lib/util/statsigHelpersTest.js
@@ -1,34 +1,30 @@
-import {stub} from 'sinon'; // eslint-disable-line no-restricted-imports
-
 import {formatUserId} from '@cdo/apps/metrics/statsigHelpers';
 import * as utils from '@cdo/apps/utils';
-
-import {expect} from '../../../util/reconfiguredChai'; // eslint-disable-line no-restricted-imports
 
 describe('StatsigReporter', () => {
   describe('formatUserId', () => {
     it('prepends environment in test', () => {
-      stub(utils, 'getEnvironment').returns('test');
-      expect(formatUserId('0').startsWith('test')).to.be.true;
-      utils.getEnvironment.restore();
+      jest.spyOn(utils, 'getEnvironment').mockReturnValue('test');
+      expect(formatUserId('0').startsWith('test')).toBe(true);
+      utils.getEnvironment.mockRestore();
     });
 
     it('does not prepend environment in production', () => {
-      stub(utils, 'isProductionEnvironment').returns(true);
-      expect(formatUserId('0').startsWith('prod')).to.be.false;
-      utils.isProductionEnvironment.restore();
+      jest.spyOn(utils, 'isProductionEnvironment').mockReturnValue(true);
+      expect(formatUserId('0').startsWith('prod')).toBe(false);
+      utils.isProductionEnvironment.mockRestore();
     });
 
     it('formats short user ids to be five character', () => {
-      stub(utils, 'isProductionEnvironment').returns(true);
-      expect(formatUserId('1')).to.equal('00001');
-      utils.isProductionEnvironment.restore();
+      jest.spyOn(utils, 'isProductionEnvironment').mockReturnValue(true);
+      expect(formatUserId('1')).toBe('00001');
+      utils.isProductionEnvironment.mockRestore();
     });
 
     it('does not change long user ids in production', () => {
-      stub(utils, 'isProductionEnvironment').returns(true);
-      expect(formatUserId('88888')).to.equal('88888');
-      utils.isProductionEnvironment.restore();
+      jest.spyOn(utils, 'isProductionEnvironment').mockReturnValue(true);
+      expect(formatUserId('88888')).toBe('88888');
+      utils.isProductionEnvironment.mockRestore();
     });
   });
 });

--- a/apps/test/unit/logConditionsTest.js
+++ b/apps/test/unit/logConditionsTest.js
@@ -1,14 +1,12 @@
 import {TestResults} from '@cdo/apps/constants';
 
-import {assert} from '../util/reconfiguredChai'; // eslint-disable-line no-restricted-imports
-
 var executionLog = require('@cdo/apps/executionLog');
 
 describe('logConditions: getResultsFromLog', function () {
   it('returns ALL_PASS with empty logConditions and executionLog', function () {
     var results = executionLog.getResultsFromLog([], []);
 
-    assert.equal(results.testResult, TestResults.ALL_PASS);
+    expect(results.testResult).toBe(TestResults.ALL_PASS);
   });
 
   it('returns ALL_PASS with empty logConditions', function () {
@@ -17,7 +15,7 @@ describe('logConditions: getResultsFromLog', function () {
       ['function1', 'function2']
     );
 
-    assert.equal(results.testResult, TestResults.ALL_PASS);
+    expect(results.testResult).toBe(TestResults.ALL_PASS);
   });
 
   it('returns ALL_PASS with simple one-item logCondition', function () {
@@ -33,7 +31,7 @@ describe('logConditions: getResultsFromLog', function () {
       ['function1:0', 'function2:0']
     );
 
-    assert.equal(results.testResult, TestResults.ALL_PASS);
+    expect(results.testResult).toBe(TestResults.ALL_PASS);
   });
 
   it('returns failure and message with simple one-item logCondition', function () {
@@ -49,7 +47,7 @@ describe('logConditions: getResultsFromLog', function () {
       ['function1:0', 'function2:0']
     );
 
-    assert.deepEqual(results, {
+    expect(results).toEqual({
       testResult: TestResults.LOG_CONDITION_FAIL,
       message: 'test-2',
     });
@@ -74,7 +72,7 @@ describe('logConditions: getResultsFromLog', function () {
       ['function1:0', 'function2:0']
     );
 
-    assert.equal(results.testResult, TestResults.ALL_PASS);
+    expect(results.testResult).toBe(TestResults.ALL_PASS);
   });
 
   it('returns failure and message with mixed logConditions', function () {
@@ -96,7 +94,7 @@ describe('logConditions: getResultsFromLog', function () {
       ['function1:0', 'function2:0']
     );
 
-    assert.deepEqual(results, {
+    expect(results).toEqual({
       testResult: TestResults.LOG_CONDITION_FAIL,
       message: 'test-6',
     });
@@ -115,7 +113,7 @@ describe('logConditions: getResultsFromLog', function () {
       ['function1:0', 'function2:0']
     );
 
-    assert.equal(results.testResult, TestResults.ALL_PASS);
+    expect(results.testResult).toBe(TestResults.ALL_PASS);
   });
 
   it('returns failure and message with insufficient minTimes logCondition', function () {
@@ -131,7 +129,7 @@ describe('logConditions: getResultsFromLog', function () {
       ['function1:0', 'function2:0']
     );
 
-    assert.deepEqual(results, {
+    expect(results).toEqual({
       testResult: TestResults.LOG_CONDITION_FAIL,
       message: 'test-8',
     });
@@ -150,7 +148,7 @@ describe('logConditions: getResultsFromLog', function () {
       ['function1:0', 'other:0', 'function2:0']
     );
 
-    assert.equal(results.testResult, TestResults.ALL_PASS);
+    expect(results.testResult).toBe(TestResults.ALL_PASS);
   });
 
   it('returns failure and message with insufficient minTimes inexact logCondition', function () {
@@ -166,7 +164,7 @@ describe('logConditions: getResultsFromLog', function () {
       ['function1:0', 'other:0', 'function2:0', 'function2:0', 'function1:0']
     );
 
-    assert.deepEqual(results, {
+    expect(results).toEqual({
       testResult: TestResults.LOG_CONDITION_FAIL,
       message: 'test-10',
     });
@@ -185,7 +183,7 @@ describe('logConditions: getResultsFromLog', function () {
       ['function1:0', 'other:0', 'function2:0', 'function1:0', 'function2:0']
     );
 
-    assert.equal(results.testResult, TestResults.ALL_PASS);
+    expect(results.testResult).toBe(TestResults.ALL_PASS);
   });
 
   it('returns failure and message with two item inexact logCondition exceeding maxTimes', function () {
@@ -210,7 +208,7 @@ describe('logConditions: getResultsFromLog', function () {
       ]
     );
 
-    assert.deepEqual(results, {
+    expect(results).toEqual({
       testResult: TestResults.LOG_CONDITION_FAIL,
       message: 'test-12',
     });
@@ -229,7 +227,7 @@ describe('logConditions: getResultsFromLog', function () {
       ['function1:3', 'other:1', 'function2:0']
     );
 
-    assert.equal(results.testResult, TestResults.ALL_PASS);
+    expect(results.testResult).toBe(TestResults.ALL_PASS);
   });
 
   it('returns failure and message with insufficient arguments logCondition', function () {
@@ -254,7 +252,7 @@ describe('logConditions: getResultsFromLog', function () {
       ]
     );
 
-    assert.deepEqual(results, {
+    expect(results).toEqual({
       testResult: TestResults.LOG_CONDITION_FAIL,
       message: 'test-14',
     });

--- a/apps/test/unit/p5lab/poetry/PoemSelectorTest.js
+++ b/apps/test/unit/p5lab/poetry/PoemSelectorTest.js
@@ -1,12 +1,10 @@
 import {mount} from 'enzyme'; // eslint-disable-line no-restricted-imports
 import $ from 'jquery';
 import React from 'react';
-import sinon from 'sinon'; // eslint-disable-line no-restricted-imports
 
 import {PoemEditor} from '@cdo/apps/p5lab/poetry/PoemSelector';
 import * as utils from '@cdo/apps/utils';
 
-import {expect} from '../../../util/reconfiguredChai'; // eslint-disable-line no-restricted-imports
 import {replaceOnWindow, restoreOnWindow} from '../../../util/testUtils';
 
 describe('PoemEditor', () => {
@@ -27,9 +25,9 @@ describe('PoemEditor', () => {
         />
       );
 
-      expect(wrapper.find('input').at(0).props().value).to.equal('My title');
-      expect(wrapper.find('input').at(1).props().value).to.be.empty;
-      expect(wrapper.find('textarea').at(0).props().value).to.equal(
+      expect(wrapper.find('input').at(0).props().value).toBe('My title');
+      expect(wrapper.find('input').at(1).props().value).toHaveLength(0);
+      expect(wrapper.find('textarea').at(0).props().value).toBe(
         'this is\na good poem'
       );
     });
@@ -44,28 +42,35 @@ describe('PoemEditor', () => {
         authenticityToken: '123',
       };
       replaceOnWindow('appOptions', mockAppOptions);
-      handleCloseSpy = sinon.spy();
+      handleCloseSpy = jest.fn();
     });
 
     afterEach(() => {
       restoreOnWindow('appOptions');
-      sinon.restore();
+      jest.restoreAllMocks();
     });
 
     it('is successful if no profanity', () => {
-      sinon.stub(utils, 'findProfanity').returns($.Deferred().resolve(null));
+      jest
+        .spyOn(utils, 'findProfanity')
+        .mockReturnValue($.Deferred().resolve(null));
       const wrapper = mount(<PoemEditor isOpen handleClose={handleCloseSpy} />);
 
       // Update title, author, and poem and save.
       updatePoemInputs(wrapper, 'title', 'author', 'my\npoem');
       wrapper.find('FooterButton').simulate('click');
 
-      expect(utils.findProfanity).to.have.been.calledOnceWith(
+      expect(utils.findProfanity).toHaveBeenCalledTimes(1);
+
+      expect(utils.findProfanity).toHaveBeenCalledWith(
         'title author my\npoem',
         mockAppOptions.locale,
         mockAppOptions.authenticityToken
       );
-      expect(handleCloseSpy).to.have.been.calledOnceWith({
+
+      expect(handleCloseSpy).toHaveBeenCalledTimes(1);
+
+      expect(handleCloseSpy).toHaveBeenCalledWith({
         key: enterMyOwn,
         title: 'title',
         author: 'author',
@@ -74,19 +79,24 @@ describe('PoemEditor', () => {
     });
 
     it('is successful on server failure', () => {
-      sinon.stub(utils, 'findProfanity').returns($.Deferred().reject());
+      jest.spyOn(utils, 'findProfanity').mockReturnValue($.Deferred().reject());
       const wrapper = mount(<PoemEditor isOpen handleClose={handleCloseSpy} />);
 
       // Update title, author, and poem and save.
       updatePoemInputs(wrapper, 'title', 'author', 'poem');
       wrapper.find('FooterButton').simulate('click');
 
-      expect(utils.findProfanity).to.have.been.calledOnceWith(
+      expect(utils.findProfanity).toHaveBeenCalledTimes(1);
+
+      expect(utils.findProfanity).toHaveBeenCalledWith(
         'title author poem',
         mockAppOptions.locale,
         mockAppOptions.authenticityToken
       );
-      expect(handleCloseSpy).to.have.been.calledOnceWith({
+
+      expect(handleCloseSpy).toHaveBeenCalledTimes(1);
+
+      expect(handleCloseSpy).toHaveBeenCalledWith({
         key: enterMyOwn,
         title: 'title',
         author: 'author',
@@ -95,21 +105,24 @@ describe('PoemEditor', () => {
     });
 
     it('is unsuccessful if profanity', () => {
-      sinon
-        .stub(utils, 'findProfanity')
-        .returns($.Deferred().resolve(['swear']));
+      jest
+        .spyOn(utils, 'findProfanity')
+        .mockReturnValue($.Deferred().resolve(['swear']));
       const wrapper = mount(<PoemEditor isOpen handleClose={handleCloseSpy} />);
 
       // Update title and attempt a save.
       updatePoemInputs(wrapper, 'swear', 'in', 'my poem');
       wrapper.find('FooterButton').simulate('click');
 
-      expect(utils.findProfanity).to.have.been.calledOnceWith(
+      expect(utils.findProfanity).toHaveBeenCalledTimes(1);
+
+      expect(utils.findProfanity).toHaveBeenCalledWith(
         'swear in my poem',
         mockAppOptions.locale,
         mockAppOptions.authenticityToken
       );
-      expect(handleCloseSpy).to.not.have.been.called;
+
+      expect(handleCloseSpy).not.toHaveBeenCalled();
     });
   });
 });

--- a/apps/test/unit/p5lab/spritelab/actionCommandsTest.js
+++ b/apps/test/unit/p5lab/spritelab/actionCommandsTest.js
@@ -1,11 +1,8 @@
-import sinon from 'sinon'; // eslint-disable-line no-restricted-imports
-
 import {commands} from '@cdo/apps/p5lab/spritelab/commands/actionCommands';
 import {commands as spriteCommands} from '@cdo/apps/p5lab/spritelab/commands/spriteCommands';
 import CoreLibrary from '@cdo/apps/p5lab/spritelab/CoreLibrary';
 
 import createP5Wrapper from '../../../util/gamelab/TestableP5Wrapper';
-import {expect} from '../../../util/reconfiguredChai'; // eslint-disable-line no-restricted-imports
 
 describe('Action Commands', () => {
   let coreLibrary;
@@ -20,19 +17,19 @@ describe('Action Commands', () => {
     it('adds targets to follow', () => {
       coreLibrary.addSprite({name: spriteName});
       const sprite = coreLibrary.getSpriteArray({name: spriteName})[0];
-      expect(sprite.targetSet).to.be.undefined;
+      expect(sprite.targetSet).toBeUndefined();
       commands.addTarget.apply(coreLibrary, [
         {name: spriteName},
         'costume1',
         'follow',
       ]);
-      expect(sprite.targetSet).to.deep.equal({follow: ['costume1'], avoid: []});
+      expect(sprite.targetSet).toEqual({follow: ['costume1'], avoid: []});
       commands.addTarget.apply(coreLibrary, [
         {name: spriteName},
         'costume2',
         'follow',
       ]);
-      expect(sprite.targetSet).to.deep.equal({
+      expect(sprite.targetSet).toEqual({
         follow: ['costume1', 'costume2'],
         avoid: [],
       });
@@ -41,19 +38,19 @@ describe('Action Commands', () => {
     it('adds targets to avoid', () => {
       coreLibrary.addSprite({name: spriteName});
       const sprite = coreLibrary.getSpriteArray({name: spriteName})[0];
-      expect(sprite.targetSet).to.be.undefined;
+      expect(sprite.targetSet).toBeUndefined();
       commands.addTarget.apply(coreLibrary, [
         {name: spriteName},
         'costume1',
         'avoid',
       ]);
-      expect(sprite.targetSet).to.deep.equal({follow: [], avoid: ['costume1']});
+      expect(sprite.targetSet).toEqual({follow: [], avoid: ['costume1']});
       commands.addTarget.apply(coreLibrary, [
         {name: spriteName},
         'costume2',
         'avoid',
       ]);
-      expect(sprite.targetSet).to.deep.equal({
+      expect(sprite.targetSet).toEqual({
         follow: [],
         avoid: ['costume1', 'costume2'],
       });
@@ -62,7 +59,7 @@ describe('Action Commands', () => {
     it('can follow and avoid at the same time', () => {
       coreLibrary.addSprite({name: spriteName});
       const sprite = coreLibrary.getSpriteArray({name: spriteName})[0];
-      expect(sprite.targetSet).to.be.undefined;
+      expect(sprite.targetSet).toBeUndefined();
       commands.addTarget.apply(coreLibrary, [
         {name: spriteName},
         'costume1',
@@ -73,27 +70,26 @@ describe('Action Commands', () => {
         'costume2',
         'avoid',
       ]);
-      expect(sprite.targetSet).to.deep.equal({
+      expect(sprite.targetSet).toEqual({
         follow: ['costume1'],
         avoid: ['costume2'],
       });
     });
 
     it('console.warn on unknown target types', () => {
-      sinon.stub(console, 'warn');
+      jest.spyOn(console, 'warn').mockImplementation();
       coreLibrary.addSprite({name: spriteName});
       const sprite = coreLibrary.getSpriteArray({name: spriteName})[0];
-      expect(sprite.targetSet).to.be.undefined;
+      expect(sprite.targetSet).toBeUndefined();
       commands.addTarget.apply(coreLibrary, [
         {name: spriteName},
         'costume1',
         'other',
       ]);
-      expect(console.warn).to.have.been.calledOnceWith(
-        'unkknown targetType: other'
-      );
-      expect(sprite.targetSet).to.be.undefined;
-      console.warn.restore();
+      expect(console.warn).toHaveBeenCalledTimes(1);
+      expect(console.warn).toHaveBeenCalledWith('unkknown targetType: other');
+      expect(sprite.targetSet).toBeUndefined();
+      console.warn.mockRestore();
     });
   });
 
@@ -116,10 +112,10 @@ describe('Action Commands', () => {
           {name: 'spriteName1'},
           'direction',
         ])
-      ).to.equal(0);
+      ).toBe(0);
       expect(
         spriteCommands.getProp.apply(coreLibrary, [{name: 'spriteName1'}, 'x'])
-      ).to.equal(189);
+      ).toBe(189);
     });
 
     it('does not change direction if sprites are not touching', () => {
@@ -139,19 +135,19 @@ describe('Action Commands', () => {
           {name: 'spriteName1'},
           'direction',
         ])
-      ).to.equal(180);
+      ).toBe(180);
       expect(
         spriteCommands.getProp.apply(coreLibrary, [{name: 'spriteName1'}, 'x'])
-      ).to.equal(0);
+      ).toBe(0);
       expect(
         spriteCommands.getProp.apply(coreLibrary, [
           {name: 'spriteName2'},
           'direction',
         ])
-      ).to.equal(0);
+      ).toBe(0);
       expect(
         spriteCommands.getProp.apply(coreLibrary, [{name: 'spriteName2'}, 'x'])
-      ).to.equal(400);
+      ).toBe(400);
     });
   });
 
@@ -160,19 +156,19 @@ describe('Action Commands', () => {
     commands.changePropBy.apply(coreLibrary, [{name: spriteName}, 'x', 100]);
     expect(
       spriteCommands.getProp.apply(coreLibrary, [{name: spriteName}, 'x'])
-    ).to.equal(223);
+    ).toBe(223);
 
     commands.changePropBy.apply(coreLibrary, [{name: spriteName}, 'y', 100]);
     expect(
       spriteCommands.getProp.apply(coreLibrary, [{name: spriteName}, 'y'])
-    ).to.equal(400 - 221);
+    ).toBe(400 - 221);
 
     expect(
       spriteCommands.getProp.apply(coreLibrary, [
         {name: spriteName},
         'direction',
       ])
-    ).to.equal(0);
+    ).toBe(0);
     commands.changePropBy.apply(coreLibrary, [
       {name: spriteName},
       'direction',
@@ -183,7 +179,7 @@ describe('Action Commands', () => {
         {name: spriteName},
         'direction',
       ])
-    ).to.equal(200);
+    ).toBe(200);
     commands.changePropBy.apply(coreLibrary, [
       {name: spriteName},
       'direction',
@@ -194,7 +190,7 @@ describe('Action Commands', () => {
         {name: spriteName},
         'direction',
       ])
-    ).to.equal(40);
+    ).toBe(40);
   });
 
   it('isTouchingSprite', () => {
@@ -207,13 +203,13 @@ describe('Action Commands', () => {
         {name: 'spriteName1'},
         {name: 'spriteName2'},
       ])
-    ).to.be.false;
+    ).toBe(false);
     expect(
       commands.isTouchingSprite.apply(coreLibrary, [
         {name: 'spriteName3'},
         {name: 'spriteName2'},
       ])
-    ).to.be.true;
+    ).toBe(true);
   });
 
   it('jumpTo', () => {
@@ -221,10 +217,10 @@ describe('Action Commands', () => {
     commands.jumpTo.apply(coreLibrary, [{name: spriteName}, {x: 321, y: 123}]);
     expect(
       spriteCommands.getProp.apply(coreLibrary, [{name: spriteName}, 'x'])
-    ).to.equal(321);
+    ).toBe(321);
     expect(
       spriteCommands.getProp.apply(coreLibrary, [{name: spriteName}, 'y'])
-    ).to.equal(400 - 123);
+    ).toBe(400 - 123);
   });
 
   describe('moveForward', () => {
@@ -235,14 +231,14 @@ describe('Action Commands', () => {
           {name: spriteName},
           'direction',
         ])
-      ).to.equal(0);
+      ).toBe(0);
       commands.moveForward.apply(coreLibrary, [{name: spriteName}, 100]);
       expect(
         spriteCommands.getProp.apply(coreLibrary, [{name: spriteName}, 'x'])
-      ).to.equal(100);
+      ).toBe(100);
       expect(
         spriteCommands.getProp.apply(coreLibrary, [{name: spriteName}, 'y'])
-      ).to.equal(400 - 0);
+      ).toBe(400 - 0);
     });
 
     it('can move vertically', () => {
@@ -258,7 +254,7 @@ describe('Action Commands', () => {
       ).to.be.within(0, 0.1);
       expect(
         spriteCommands.getProp.apply(coreLibrary, [{name: spriteName}, 'y'])
-      ).to.equal(400 - 100);
+      ).toBe(400 - 100);
     });
 
     it('can move diagonally', () => {
@@ -288,10 +284,10 @@ describe('Action Commands', () => {
     ]);
     expect(
       spriteCommands.getProp.apply(coreLibrary, [{name: spriteName}, 'x'])
-    ).to.equal(0);
+    ).toBe(0);
     expect(
       spriteCommands.getProp.apply(coreLibrary, [{name: spriteName}, 'y'])
-    ).to.equal(400 - 50);
+    ).toBe(400 - 50);
 
     commands.moveInDirection.apply(coreLibrary, [
       {name: spriteName},
@@ -300,10 +296,10 @@ describe('Action Commands', () => {
     ]);
     expect(
       spriteCommands.getProp.apply(coreLibrary, [{name: spriteName}, 'x'])
-    ).to.equal(-50);
+    ).toBe(-50);
     expect(
       spriteCommands.getProp.apply(coreLibrary, [{name: spriteName}, 'y'])
-    ).to.equal(400 - 50);
+    ).toBe(400 - 50);
 
     commands.moveInDirection.apply(coreLibrary, [
       {name: spriteName},
@@ -312,10 +308,10 @@ describe('Action Commands', () => {
     ]);
     expect(
       spriteCommands.getProp.apply(coreLibrary, [{name: spriteName}, 'x'])
-    ).to.equal(-50);
+    ).toBe(-50);
     expect(
       spriteCommands.getProp.apply(coreLibrary, [{name: spriteName}, 'y'])
-    ).to.equal(400);
+    ).toBe(400);
 
     commands.moveInDirection.apply(coreLibrary, [
       {name: spriteName},
@@ -324,10 +320,10 @@ describe('Action Commands', () => {
     ]);
     expect(
       spriteCommands.getProp.apply(coreLibrary, [{name: spriteName}, 'x'])
-    ).to.equal(0);
+    ).toBe(0);
     expect(
       spriteCommands.getProp.apply(coreLibrary, [{name: spriteName}, 'y'])
-    ).to.equal(400);
+    ).toBe(400);
   });
 
   describe('moveToward', () => {
@@ -354,11 +350,11 @@ describe('Action Commands', () => {
       commands.moveToward.apply(coreLibrary, [{name: spriteName}, 100, target]);
       expect(
         spriteCommands.getProp.apply(coreLibrary, [{name: spriteName}, 'x'])
-      ).to.equal(110);
+      ).toBe(110);
       const expectedY = 400 - target.y;
       expect(
         spriteCommands.getProp.apply(coreLibrary, [{name: spriteName}, 'y'])
-      ).to.equal(expectedY);
+      ).toBe(expectedY);
     });
   });
 
@@ -377,7 +373,7 @@ describe('Action Commands', () => {
           {name: spriteName},
           'direction',
         ])
-      ).to.equal(100);
+      ).toBe(100);
       commands.setProp.apply(coreLibrary, [
         {name: spriteName},
         'direction',
@@ -388,7 +384,7 @@ describe('Action Commands', () => {
           {name: spriteName},
           'direction',
         ])
-      ).to.equal(40);
+      ).toBe(40);
     });
 
     it('sets arbitrary properties', () => {
@@ -402,7 +398,7 @@ describe('Action Commands', () => {
           {name: spriteName},
           'someProp',
         ])
-      ).to.equal(100);
+      ).toBe(100);
     });
 
     it('sets scale, height, and width', () => {
@@ -414,11 +410,11 @@ describe('Action Commands', () => {
       coreLibrary.addSprite({name: spriteName, animation: 'costume_label'});
       expect(
         spriteCommands.getProp.apply(coreLibrary, [{name: spriteName}, 'scale'])
-      ).to.equal(100);
+      ).toBe(100);
       commands.setProp.apply(coreLibrary, [{name: spriteName}, 'scale', 50]);
       expect(
         spriteCommands.getProp.apply(coreLibrary, [{name: spriteName}, 'scale'])
-      ).to.equal(50);
+      ).toBe(50);
 
       commands.setProp.apply(coreLibrary, [{name: spriteName}, 'height', 500]);
       expect(
@@ -426,12 +422,12 @@ describe('Action Commands', () => {
           {name: spriteName},
           'height',
         ])
-      ).to.equal(250);
+      ).toBe(250);
 
       commands.setProp.apply(coreLibrary, [{name: spriteName}, 'width', 500]);
       expect(
         spriteCommands.getProp.apply(coreLibrary, [{name: spriteName}, 'width'])
-      ).to.equal(250);
+      ).toBe(250);
     });
   });
 
@@ -443,7 +439,7 @@ describe('Action Commands', () => {
         {name: spriteName},
         'rotation',
       ])
-    ).to.equal(90);
+    ).toBe(90);
 
     commands.turn.apply(coreLibrary, [{name: spriteName}, 180, 'left']);
     expect(
@@ -451,7 +447,7 @@ describe('Action Commands', () => {
         {name: spriteName},
         'rotation',
       ])
-    ).to.equal(-90);
+    ).toBe(-90);
   });
 
   // tests copied from dance party repo here:
@@ -488,14 +484,14 @@ describe('Action Commands', () => {
       });
 
       const spritesBeforeLayout = coreLibrary.getSpriteArray({costume: 'cat'});
-      expect(spritesBeforeLayout.length).to.equal(1);
-      expect(spritesBeforeLayout[0].getScale()).to.equal(1);
+      expect(spritesBeforeLayout.length).toBe(1);
+      expect(spritesBeforeLayout[0].getScale()).toBe(1);
 
       commands.layoutSprites.apply(coreLibrary, ['cat', 'border']);
 
       const spritesAfterLayout = coreLibrary.getSpriteArray({costume: 'cat'});
-      expect(spritesAfterLayout.length).to.equal(1);
-      expect(spritesAfterLayout[0].getScale()).to.equal(0.3);
+      expect(spritesAfterLayout.length).toBe(1);
+      expect(spritesAfterLayout[0].getScale()).toBe(0.3);
     });
 
     it('circle layout works with 1 sprite', () => {
@@ -507,8 +503,8 @@ describe('Action Commands', () => {
       const sprites = coreLibrary.getSpriteArray({costume: 'cat'});
 
       // one sprite, facing upwards
-      expect(sprites.length).to.equal(1);
-      expect(sprites[0].x).to.equal(200);
+      expect(sprites.length).toBe(1);
+      expect(sprites[0].x).toBe(200);
     });
 
     it('circle layout works with 2 sprites', () => {
@@ -517,13 +513,13 @@ describe('Action Commands', () => {
       commands.layoutSprites.apply(coreLibrary, ['cat', 'circle']);
       const sprites = coreLibrary.getSpriteArray({costume: 'cat'});
 
-      expect(sprites.length).to.equal(2);
-      expect(sprites[0].x).to.equal(200);
+      expect(sprites.length).toBe(2);
+      expect(sprites[0].x).toBe(200);
 
-      expect(sprites[1].x).to.equal(200);
+      expect(sprites[1].x).toBe(200);
 
       // fairly weak test that they just have different y values
-      expect(sprites[0].y).to.not.equal(sprites[1].y);
+      expect(sprites[0].y).not.toBe(sprites[1].y);
     });
 
     it('circle changes radius/scale as we add more sprites', () => {
@@ -545,14 +541,14 @@ describe('Action Commands', () => {
       expect(cats[0].scale).to.be.greaterThan(ducks[0].scale);
 
       // we should stop getting bigger after count 10
-      expect(aliens[0].scale).to.equal(ducks[0].scale);
+      expect(aliens[0].scale).toBe(ducks[0].scale);
 
       // radius should be smaller when we have fewer (so y should be bigger)
       expect(cats[0].y).to.be.greaterThan(aliens[0].y);
       expect(cats[0].y).to.be.greaterThan(ducks[0].y);
 
       // again, this should be unaffected after count 10
-      expect(aliens[0].y).to.equal(ducks[0].y);
+      expect(aliens[0].y).toBe(ducks[0].y);
     });
 
     it('border works with 5 sprites', () => {
@@ -562,20 +558,20 @@ describe('Action Commands', () => {
       const sprites = coreLibrary.getSpriteArray({costume: 'cat'});
 
       // first four are at the corners
-      expect(sprites[0].x).to.equal(minX);
-      expect(sprites[0].y).to.equal(minY);
+      expect(sprites[0].x).toBe(minX);
+      expect(sprites[0].y).toBe(minY);
 
-      expect(sprites[1].x).to.equal(maxX);
-      expect(sprites[1].y).to.equal(minY);
+      expect(sprites[1].x).toBe(maxX);
+      expect(sprites[1].y).toBe(minY);
 
-      expect(sprites[2].x).to.equal(maxX);
-      expect(sprites[2].y).to.equal(maxY);
+      expect(sprites[2].x).toBe(maxX);
+      expect(sprites[2].y).toBe(maxY);
 
-      expect(sprites[3].x).to.equal(minX);
-      expect(sprites[3].y).to.equal(maxY);
+      expect(sprites[3].x).toBe(minX);
+      expect(sprites[3].y).toBe(maxY);
 
-      expect(sprites[4].x).to.equal((minX + maxX) / 2);
-      expect(sprites[4].y).to.equal(minY);
+      expect(sprites[4].x).toBe((minX + maxX) / 2);
+      expect(sprites[4].y).toBe(minY);
     });
 
     it('border works with > 10 sprites', () => {
@@ -584,19 +580,19 @@ describe('Action Commands', () => {
       commands.layoutSprites.apply(coreLibrary, ['cat', 'border']);
       const sprites = coreLibrary.getSpriteArray({costume: 'cat'});
 
-      expect(sprites.length).to.equal(11);
+      expect(sprites.length).toBe(11);
 
       // top row should contain first, second, and then 2 more
-      [0, 1, 4, 5].forEach(i => expect(sprites[i].y).to.equal(minY));
+      [0, 1, 4, 5].forEach(i => expect(sprites[i].y).toBe(minY));
 
       // right column contains second, third, and 2 others
-      [1, 2, 6, 7].forEach(i => expect(sprites[i].x).to.equal(maxX));
+      [1, 2, 6, 7].forEach(i => expect(sprites[i].x).toBe(maxX));
 
       // bottom row contains third, fourth, and 2 others
-      [2, 3, 8, 9].forEach(i => expect(sprites[i].y).to.equal(maxY));
+      [2, 3, 8, 9].forEach(i => expect(sprites[i].y).toBe(maxY));
 
       // left column contains fourth, first and 1 other
-      [3, 0, 10].forEach(i => expect(sprites[i].x).to.equal(minX));
+      [3, 0, 10].forEach(i => expect(sprites[i].x).toBe(minX));
     });
 
     it('grid layout with perfect square count', () => {
@@ -607,17 +603,17 @@ describe('Action Commands', () => {
 
       expect(sprites.length, 4);
 
-      expect(sprites[0].x).to.equal(minX);
-      expect(sprites[0].y).to.equal(minY);
+      expect(sprites[0].x).toBe(minX);
+      expect(sprites[0].y).toBe(minY);
 
-      expect(sprites[1].x).to.equal(maxX);
-      expect(sprites[1].y).to.equal(minY);
+      expect(sprites[1].x).toBe(maxX);
+      expect(sprites[1].y).toBe(minY);
 
-      expect(sprites[2].x).to.equal(minX);
-      expect(sprites[2].y).to.equal(maxY);
+      expect(sprites[2].x).toBe(minX);
+      expect(sprites[2].y).toBe(maxY);
 
-      expect(sprites[3].x).to.equal(maxX);
-      expect(sprites[3].y).to.equal(maxY);
+      expect(sprites[3].x).toBe(maxX);
+      expect(sprites[3].y).toBe(maxY);
     });
 
     it('grid layout without perfect square count', () => {
@@ -626,24 +622,24 @@ describe('Action Commands', () => {
       commands.layoutSprites.apply(coreLibrary, ['cat', 'grid']);
       const sprites = coreLibrary.getSpriteArray({costume: 'cat'});
 
-      expect(sprites.length).to.equal(5);
+      expect(sprites.length).toBe(5);
 
       // size 5 means we're filling up a 3x3 grid, except that we don't end up
       // needing the 3rd row, and so we instead fill a 3x2 grid
-      expect(sprites[0].x).to.equal(minX);
-      expect(sprites[0].y).to.equal(minY);
+      expect(sprites[0].x).toBe(minX);
+      expect(sprites[0].y).toBe(minY);
 
-      expect(sprites[1].x).to.equal((minX + maxX) / 2);
-      expect(sprites[1].y).to.equal(minY);
+      expect(sprites[1].x).toBe((minX + maxX) / 2);
+      expect(sprites[1].y).toBe(minY);
 
-      expect(sprites[2].x).to.equal(maxX);
-      expect(sprites[2].y).to.equal(minY);
+      expect(sprites[2].x).toBe(maxX);
+      expect(sprites[2].y).toBe(minY);
 
-      expect(sprites[3].x).to.equal(minX);
-      expect(sprites[3].y).to.equal(maxY);
+      expect(sprites[3].x).toBe(minX);
+      expect(sprites[3].y).toBe(maxY);
 
-      expect(sprites[4].x).to.equal((minX + maxX) / 2);
-      expect(sprites[4].y).to.equal(maxY);
+      expect(sprites[4].x).toBe((minX + maxX) / 2);
+      expect(sprites[4].y).toBe(maxY);
     });
 
     it('grid layout of size 2', () => {
@@ -654,11 +650,11 @@ describe('Action Commands', () => {
 
       expect(sprites.length, 2);
 
-      expect(sprites[0].x).to.equal(minX);
-      expect(sprites[0].y).to.equal(minY);
+      expect(sprites[0].x).toBe(minX);
+      expect(sprites[0].y).toBe(minY);
 
-      expect(sprites[1].x).to.equal(maxX);
-      expect(sprites[1].y).to.equal(minY);
+      expect(sprites[1].x).toBe(maxX);
+      expect(sprites[1].y).toBe(minY);
     });
   });
 });

--- a/apps/test/unit/propTypesTest.js
+++ b/apps/test/unit/propTypesTest.js
@@ -1,7 +1,5 @@
 import React from 'react';
 
-import {expect} from '../util/reconfiguredChai'; // eslint-disable-line no-restricted-imports
-
 var propTypes = require('@cdo/apps/propTypes');
 
 describe('propTypes module', () => {
@@ -22,19 +20,19 @@ describe('propTypes module', () => {
 
     describe('does not return an error when', () => {
       it('no children are given', () => {
-        expect(check({someProp: 'foo'})).not.to.be.an.instanceOf(Error);
+        expect(check({someProp: 'foo'})).not.toBeInstanceOf(Error);
       });
 
       it('no prop is given', () => {
-        expect(check({children: [<Foo />]})).not.to.be.an.instanceOf(Error);
+        expect(check({children: [<Foo />]})).not.toBeInstanceOf(Error);
       });
     });
 
     describe('does return an error when', () => {
       it('both a prop and child are given', () => {
         const error = check({children: [<Foo />], someProp: 'foo'});
-        expect(error).to.be.an.instanceOf(Error);
-        expect(error.message).to.equal(
+        expect(error).toBeInstanceOf(Error);
+        expect(error.message).toBe(
           'SomeComponent was given a someProp prop and a <Foo> child, ' +
             'but only one of those is allowed.'
         );
@@ -55,16 +53,16 @@ describe('propTypes module', () => {
 
     describe('does not return an error when', () => {
       it('no children are given', () => {
-        expect(check()).not.to.be.an.instanceOf(Error);
+        expect(check()).not.toBeInstanceOf(Error);
       });
 
       it('only some children are given in the correct order', () => {
-        expect(check(<Foo />)).not.to.be.an.instanceOf(Error);
-        expect(check(<Bar />)).not.to.be.an.instanceOf(Error);
+        expect(check(<Foo />)).not.toBeInstanceOf(Error);
+        expect(check(<Bar />)).not.toBeInstanceOf(Error);
       });
 
       it('all children are given in the correct order', () => {
-        expect(check(<Foo />, <Bar />)).not.to.be.an.instanceOf(Error);
+        expect(check(<Foo />, <Bar />)).not.toBeInstanceOf(Error);
       });
     });
 
@@ -76,31 +74,31 @@ describe('propTypes module', () => {
             'nonChildrenProp',
             'SomeComponent'
           );
-        expect(check(<Baz />)).to.be.an.instanceOf(Error);
-        expect(check(<Baz />).message).to.equal(
+        expect(check(<Baz />)).toBeInstanceOf(Error);
+        expect(check(<Baz />).message).toBe(
           'The childrenOfType prop type should only be used on the children prop.'
         );
       });
 
       it('children of an invalid type are give', () => {
-        expect(check(<Baz />)).to.be.an.instanceOf(Error);
-        expect(check(<Baz />).message).to.equal(
+        expect(check(<Baz />)).toBeInstanceOf(Error);
+        expect(check(<Baz />).message).toBe(
           'SomeComponent was given children of types <Baz> ' +
             'but only accepts one of each child in the following order: <Foo>, <Bar>.'
         );
       });
 
       it('more than one child of the same type are given', () => {
-        expect(check(<Bar />, <Bar />)).to.be.an.instanceOf(Error);
-        expect(check(<Bar />, <Bar />).message).to.equal(
+        expect(check(<Bar />, <Bar />)).toBeInstanceOf(Error);
+        expect(check(<Bar />, <Bar />).message).toBe(
           'SomeComponent was given children of types <Bar>, <Bar> ' +
             'but only accepts one of each child in the following order: <Foo>, <Bar>.'
         );
       });
 
       it('children of the correct types are given in the incorrect order', () => {
-        expect(check(<Bar />, <Foo />)).to.be.an.instanceOf(Error);
-        expect(check(<Bar />, <Foo />).message).to.equal(
+        expect(check(<Bar />, <Foo />)).toBeInstanceOf(Error);
+        expect(check(<Bar />, <Foo />).message).toBe(
           'SomeComponent was given children of types <Bar>, <Foo> ' +
             'but only accepts one of each child in the following order: <Foo>, <Bar>.'
         );

--- a/apps/test/unit/puzzleRatingUtilsTest.js
+++ b/apps/test/unit/puzzleRatingUtilsTest.js
@@ -1,7 +1,5 @@
 import $ from 'jquery';
 
-import {assert} from '../util/reconfiguredChai'; // eslint-disable-line no-restricted-imports
-
 var puzzleRatingUtils = require('@cdo/apps/puzzleRatingUtils');
 
 describe('Puzzle Rating Utils', function () {
@@ -36,8 +34,7 @@ describe('Puzzle Rating Utils', function () {
       puzzleRatingUtils.setPuzzleRatings_(sampleRatings);
       for (var i = 0; i < sampleRatings.length; i++) {
         puzzleRatingUtils.removePuzzleRating_(sampleRatings[i]);
-        assert.equal(
-          localStorage.getItem('puzzleRatings'),
+        expect(localStorage.getItem('puzzleRatings')).toBe(
           JSON.stringify(sampleRatings.slice(i + 1))
         );
       }
@@ -52,7 +49,7 @@ describe('Puzzle Rating Utils', function () {
 
     it('does nothing if no button is enabled', function () {
       puzzleRatingUtils.cachePuzzleRating(container, {});
-      assert.equal(localStorage.getItem('puzzleRatings'), null);
+      expect(localStorage.getItem('puzzleRatings')).toBe(null);
     });
 
     it('saves the rating if a button is enabled', function () {
@@ -61,8 +58,7 @@ describe('Puzzle Rating Utils', function () {
         .querySelectorAll('.puzzle-rating-btn')[0]
         .classList.add('enabled');
       puzzleRatingUtils.cachePuzzleRating(container, {});
-      assert.equal(
-        localStorage.getItem('puzzleRatings'),
+      expect(localStorage.getItem('puzzleRatings')).toBe(
         JSON.stringify([{rating: '1'}])
       );
     });
@@ -74,8 +70,7 @@ describe('Puzzle Rating Utils', function () {
         .querySelectorAll('.puzzle-rating-btn')[0]
         .classList.add('enabled');
       puzzleRatingUtils.cachePuzzleRating(container, {});
-      assert.equal(
-        localStorage.getItem('puzzleRatings'),
+      expect(localStorage.getItem('puzzleRatings')).toBe(
         JSON.stringify(sampleRatings.concat([{rating: '1'}]))
       );
     });
@@ -98,14 +93,13 @@ describe('Puzzle Rating Utils', function () {
         opts.complete();
       };
       puzzleRatingUtils.setPuzzleRatings_(sampleRatings);
-      assert.equal(
-        localStorage.getItem('puzzleRatings'),
+      expect(localStorage.getItem('puzzleRatings')).toBe(
         JSON.stringify(sampleRatings)
       );
 
       puzzleRatingUtils.submitCachedPuzzleRatings('/');
-      assert.equal(localStorage.getItem('puzzleRatings'), '[]');
-      assert.equal(postCount, sampleRatings.length);
+      expect(localStorage.getItem('puzzleRatings')).toBe('[]');
+      expect(postCount).toBe(sampleRatings.length);
     });
 
     it('only removes the ratings that have been submitted', function () {
@@ -115,27 +109,23 @@ describe('Puzzle Rating Utils', function () {
         complete = opts.complete;
       };
       puzzleRatingUtils.setPuzzleRatings_(sampleRatings.slice(0, 1));
-      assert.equal(
-        localStorage.getItem('puzzleRatings'),
+      expect(localStorage.getItem('puzzleRatings')).toBe(
         JSON.stringify(sampleRatings.slice(0, 1))
       );
       puzzleRatingUtils.submitCachedPuzzleRatings('/');
-      assert.equal(
-        localStorage.getItem('puzzleRatings'),
+      expect(localStorage.getItem('puzzleRatings')).toBe(
         JSON.stringify(sampleRatings.slice(0, 1))
       );
       puzzleRatingUtils.setPuzzleRatings_(sampleRatings.slice(0, 2));
-      assert.equal(
-        localStorage.getItem('puzzleRatings'),
+      expect(localStorage.getItem('puzzleRatings')).toBe(
         JSON.stringify(sampleRatings.slice(0, 2))
       );
 
       complete();
-      assert.equal(
-        localStorage.getItem('puzzleRatings'),
+      expect(localStorage.getItem('puzzleRatings')).toBe(
         JSON.stringify(sampleRatings.slice(1, 2))
       );
-      assert.equal(postCount, 1);
+      expect(postCount).toBe(1);
     });
   });
 });

--- a/apps/test/unit/shareWarningsDialogTest.js
+++ b/apps/test/unit/shareWarningsDialogTest.js
@@ -1,16 +1,13 @@
 import {mount} from 'enzyme'; // eslint-disable-line no-restricted-imports
 import React from 'react';
-import sinon from 'sinon'; // eslint-disable-line no-restricted-imports
 
 import ShareWarningsDialog from '@cdo/apps/templates/ShareWarningsDialog';
 import commonMsg from '@cdo/locale';
 
-import {expect} from '../util/deprecatedChai'; // eslint-disable-line no-restricted-imports
-
 describe('ShareWarningsDialog', () => {
   it('renders ShareWarnings with age prompt', () => {
-    const closeSpy = sinon.spy();
-    const tooYoungSpy = sinon.spy();
+    const closeSpy = jest.fn();
+    const tooYoungSpy = jest.fn();
     const dialog = mount(
       <ShareWarningsDialog
         showStoreDataAlert={false}
@@ -19,21 +16,23 @@ describe('ShareWarningsDialog', () => {
         handleTooYoung={tooYoungSpy}
       />
     );
-    expect(dialog.state('modalIsOpen')).to.be.true;
+    expect(dialog.state('modalIsOpen')).toBe(true);
     const shareWarnings = dialog.find('ShareWarnings');
-    expect(shareWarnings).to.have.length(1);
-    expect(shareWarnings.props().promptForAge).to.be.true;
-    expect(shareWarnings.props().showStoreDataAlert).to.be.false;
+    expect(shareWarnings).toHaveLength(1);
+    expect(shareWarnings.props().promptForAge).toBe(true);
+    expect(shareWarnings.props().showStoreDataAlert).toBe(false);
     const ageDropdown = shareWarnings.find('AgeDropdown');
-    expect(ageDropdown).to.have.length(1);
-    expect(shareWarnings).to.containMatchingElement(
-      <div>{commonMsg.shareWarningsAge()}</div>
-    );
+    expect(ageDropdown).toHaveLength(1);
+    expect(
+      shareWarnings.containsMatchingElement(
+        <div>{commonMsg.shareWarningsAge()}</div>
+      )
+    ).toBe(true);
   });
 
   it('renders ShareWarnings with data alert', () => {
-    const closeSpy = sinon.spy();
-    const tooYoungSpy = sinon.spy();
+    const closeSpy = jest.fn();
+    const tooYoungSpy = jest.fn();
     const dialog = mount(
       <ShareWarningsDialog
         showStoreDataAlert={true}
@@ -42,24 +41,26 @@ describe('ShareWarningsDialog', () => {
         handleTooYoung={tooYoungSpy}
       />
     );
-    expect(dialog.state('modalIsOpen')).to.be.true;
+    expect(dialog.state('modalIsOpen')).toBe(true);
     const shareWarnings = dialog.find('ShareWarnings');
-    expect(shareWarnings).to.have.length(1);
-    expect(shareWarnings.props().showStoreDataAlert).to.be.true;
-    expect(shareWarnings.props().promptForAge).to.be.false;
-    expect(shareWarnings).to.containMatchingElement(
-      <div>
-        {commonMsg.shareWarningsStoreDataBeforeHighlight()}
-        <span>{commonMsg.shareWarningsStoreDataHighlight()}</span>
-        {commonMsg.shareWarningsStoreDataAfterHighlight()}
-      </div>
-    );
-    expect(shareWarnings.find('AgeDropdown')).to.have.length(0);
+    expect(shareWarnings).toHaveLength(1);
+    expect(shareWarnings.props().showStoreDataAlert).toBe(true);
+    expect(shareWarnings.props().promptForAge).toBe(false);
+    expect(
+      shareWarnings.containsMatchingElement(
+        <div>
+          {commonMsg.shareWarningsStoreDataBeforeHighlight()}
+          <span>{commonMsg.shareWarningsStoreDataHighlight()}</span>
+          {commonMsg.shareWarningsStoreDataAfterHighlight()}
+        </div>
+      )
+    ).toBe(true);
+    expect(shareWarnings.find('AgeDropdown')).toHaveLength(0);
   });
 
   it('renders ShareWarnings with both data alert and age prompt', () => {
-    const closeSpy = sinon.spy();
-    const tooYoungSpy = sinon.spy();
+    const closeSpy = jest.fn();
+    const tooYoungSpy = jest.fn();
     const dialog = mount(
       <ShareWarningsDialog
         showStoreDataAlert={true}
@@ -68,28 +69,32 @@ describe('ShareWarningsDialog', () => {
         handleTooYoung={tooYoungSpy}
       />
     );
-    expect(dialog.state('modalIsOpen')).to.be.true;
+    expect(dialog.state('modalIsOpen')).toBe(true);
     const shareWarnings = dialog.find('ShareWarnings');
-    expect(shareWarnings).to.have.length(1);
-    expect(shareWarnings.props().showStoreDataAlert).to.be.true;
-    expect(shareWarnings.props().promptForAge).to.be.true;
+    expect(shareWarnings).toHaveLength(1);
+    expect(shareWarnings.props().showStoreDataAlert).toBe(true);
+    expect(shareWarnings.props().promptForAge).toBe(true);
     const ageDropdown = shareWarnings.find('AgeDropdown');
-    expect(ageDropdown).to.have.length(1);
-    expect(shareWarnings).to.containMatchingElement(
-      <div>{commonMsg.shareWarningsAge()}</div>
-    );
-    expect(shareWarnings).to.containMatchingElement(
-      <div>
-        {commonMsg.shareWarningsStoreDataBeforeHighlight()}
-        <span>{commonMsg.shareWarningsStoreDataHighlight()}</span>
-        {commonMsg.shareWarningsStoreDataAfterHighlight()}
-      </div>
-    );
+    expect(ageDropdown).toHaveLength(1);
+    expect(
+      shareWarnings.containsMatchingElement(
+        <div>{commonMsg.shareWarningsAge()}</div>
+      )
+    ).toBe(true);
+    expect(
+      shareWarnings.containsMatchingElement(
+        <div>
+          {commonMsg.shareWarningsStoreDataBeforeHighlight()}
+          <span>{commonMsg.shareWarningsStoreDataHighlight()}</span>
+          {commonMsg.shareWarningsStoreDataAfterHighlight()}
+        </div>
+      )
+    ).toBe(true);
   });
 
   it('does not show the dialog if not needed', () => {
-    const closeSpy = sinon.spy();
-    const tooYoungSpy = sinon.spy();
+    const closeSpy = jest.fn();
+    const tooYoungSpy = jest.fn();
     const dialog = mount(
       <ShareWarningsDialog
         showStoreDataAlert={false}
@@ -98,12 +103,12 @@ describe('ShareWarningsDialog', () => {
         handleTooYoung={tooYoungSpy}
       />
     );
-    expect(dialog.state('modalIsOpen')).to.be.false;
+    expect(dialog.state('modalIsOpen')).toBe(false);
   });
 
   it('calls handleClose if we click OK when age is known', () => {
-    const closeSpy = sinon.spy();
-    const tooYoungSpy = sinon.spy();
+    const closeSpy = jest.fn();
+    const tooYoungSpy = jest.fn();
     const dialog = mount(
       <ShareWarningsDialog
         showStoreDataAlert={true}
@@ -112,19 +117,21 @@ describe('ShareWarningsDialog', () => {
         handleTooYoung={tooYoungSpy}
       />
     );
-    expect(dialog.state('modalIsOpen')).to.be.true;
-    expect(dialog).to.containMatchingElement(
-      <button type="button">{commonMsg.dialogOK()}</button>
-    );
-    expect(closeSpy).not.to.have.been.called;
+    expect(dialog.state('modalIsOpen')).toBe(true);
+    expect(
+      dialog.containsMatchingElement(
+        <button type="button">{commonMsg.dialogOK()}</button>
+      )
+    ).toBe(true);
+    expect(closeSpy).not.toHaveBeenCalled();
     dialog.find('button').simulate('click');
-    expect(closeSpy).to.have.been.called;
-    expect(dialog.state('modalIsOpen')).to.be.false;
+    expect(closeSpy).toHaveBeenCalled();
+    expect(dialog.state('modalIsOpen')).toBe(false);
   });
 
   it('does not calls handleClose if we click OK when age is unknown', () => {
-    const closeSpy = sinon.spy();
-    const tooYoungSpy = sinon.spy();
+    const closeSpy = jest.fn();
+    const tooYoungSpy = jest.fn();
     const dialog = mount(
       <ShareWarningsDialog
         showStoreDataAlert={true}
@@ -133,19 +140,21 @@ describe('ShareWarningsDialog', () => {
         handleTooYoung={tooYoungSpy}
       />
     );
-    expect(dialog.state('modalIsOpen')).to.be.true;
-    expect(dialog).to.containMatchingElement(
-      <button type="button">{commonMsg.dialogOK()}</button>
-    );
-    expect(closeSpy).not.to.have.been.called;
+    expect(dialog.state('modalIsOpen')).toBe(true);
+    expect(
+      dialog.containsMatchingElement(
+        <button type="button">{commonMsg.dialogOK()}</button>
+      )
+    ).toBe(true);
+    expect(closeSpy).not.toHaveBeenCalled();
     dialog.find('button').simulate('click');
-    expect(closeSpy).not.to.have.been.called;
-    expect(dialog.state('modalIsOpen')).to.be.true;
+    expect(closeSpy).not.toHaveBeenCalled();
+    expect(dialog.state('modalIsOpen')).toBe(true);
   });
 
   it('calls handleClose if we specify age >=13, then click OK', () => {
-    const closeSpy = sinon.spy();
-    const tooYoungSpy = sinon.spy();
+    const closeSpy = jest.fn();
+    const tooYoungSpy = jest.fn();
     const dialog = mount(
       <ShareWarningsDialog
         showStoreDataAlert={true}
@@ -154,25 +163,27 @@ describe('ShareWarningsDialog', () => {
         handleTooYoung={tooYoungSpy}
       />
     );
-    expect(dialog.state('modalIsOpen')).to.be.true;
-    expect(dialog).to.containMatchingElement(
-      <button type="button">{commonMsg.dialogOK()}</button>
-    );
-    expect(closeSpy).not.to.have.been.called;
+    expect(dialog.state('modalIsOpen')).toBe(true);
+    expect(
+      dialog.containsMatchingElement(
+        <button type="button">{commonMsg.dialogOK()}</button>
+      )
+    ).toBe(true);
+    expect(closeSpy).not.toHaveBeenCalled();
     const ageDropdown = dialog.find('AgeDropdown');
     const select = ageDropdown.find('select');
     const selectDOMNode = select.getDOMNode();
     selectDOMNode.value = '15';
     select.simulate('change', {target: selectDOMNode});
     dialog.find('button').simulate('click');
-    expect(closeSpy).to.have.been.called;
-    expect(tooYoungSpy).not.to.have.been.called;
-    expect(dialog.state('modalIsOpen')).to.be.false;
+    expect(closeSpy).toHaveBeenCalled();
+    expect(tooYoungSpy).not.toHaveBeenCalled();
+    expect(dialog.state('modalIsOpen')).toBe(false);
   });
 
   it('calls handleTooYoung if we specify age < 13, then click OK', () => {
-    const closeSpy = sinon.spy();
-    const tooYoungSpy = sinon.spy();
+    const closeSpy = jest.fn();
+    const tooYoungSpy = jest.fn();
     const dialog = mount(
       <ShareWarningsDialog
         showStoreDataAlert={true}
@@ -181,20 +192,22 @@ describe('ShareWarningsDialog', () => {
         handleTooYoung={tooYoungSpy}
       />
     );
-    expect(dialog.state('modalIsOpen')).to.be.true;
-    expect(dialog).to.containMatchingElement(
-      <button type="button">{commonMsg.dialogOK()}</button>
-    );
-    expect(closeSpy).not.to.have.been.called;
-    expect(tooYoungSpy).not.to.have.been.called;
+    expect(dialog.state('modalIsOpen')).toBe(true);
+    expect(
+      dialog.containsMatchingElement(
+        <button type="button">{commonMsg.dialogOK()}</button>
+      )
+    ).toBe(true);
+    expect(closeSpy).not.toHaveBeenCalled();
+    expect(tooYoungSpy).not.toHaveBeenCalled();
     const ageDropdown = dialog.find('AgeDropdown');
     const select = ageDropdown.find('select');
     const selectDOMNode = select.getDOMNode();
     selectDOMNode.value = '10';
     select.simulate('change', {target: selectDOMNode});
     dialog.find('button').simulate('click');
-    expect(tooYoungSpy).to.have.been.called;
-    expect(closeSpy).not.to.have.been.called;
-    expect(dialog.state('modalIsOpen')).to.be.false;
+    expect(tooYoungSpy).toHaveBeenCalled();
+    expect(closeSpy).not.toHaveBeenCalled();
+    expect(dialog.state('modalIsOpen')).toBe(false);
   });
 });

--- a/apps/test/unit/testUtilsTest.js
+++ b/apps/test/unit/testUtilsTest.js
@@ -1,5 +1,3 @@
-/** @file Who watches the watchers? */
-import {expect} from '../util/reconfiguredChai'; // eslint-disable-line no-restricted-imports
 import {forEveryBooleanPermutation} from '../util/testUtils';
 
 describe('forEveryBooleanPermutation', function () {
@@ -8,16 +6,16 @@ describe('forEveryBooleanPermutation', function () {
     forEveryBooleanPermutation(() => {
       invocationCount++;
     });
-    expect(invocationCount).to.equal(1);
+    expect(invocationCount).toBe(1);
   });
 
   it('invokes a function with one argument twice, once with true and once with false', function () {
     let expectedInvocations = [[false], [true]];
     forEveryBooleanPermutation(a => {
-      expect([a]).to.deep.equal(expectedInvocations[0]);
+      expect([a]).toEqual(expectedInvocations[0]);
       expectedInvocations.shift();
     });
-    expect(expectedInvocations).to.be.empty;
+    expect(expectedInvocations).toHaveLength(0);
   });
 
   it('invokes a function with two arguments four times...', function () {
@@ -28,10 +26,10 @@ describe('forEveryBooleanPermutation', function () {
       [true, true],
     ];
     forEveryBooleanPermutation((a, b) => {
-      expect([a, b]).to.deep.equal(expectedInvocations[0]);
+      expect([a, b]).toEqual(expectedInvocations[0]);
       expectedInvocations.shift();
     });
-    expect(expectedInvocations).to.be.empty;
+    expect(expectedInvocations).toHaveLength(0);
   });
 
   it('invokes a function with three arguments eight times...', function () {
@@ -46,9 +44,9 @@ describe('forEveryBooleanPermutation', function () {
       [true, true, true],
     ];
     forEveryBooleanPermutation((a, b, c) => {
-      expect([a, b, c]).to.deep.equal(expectedInvocations[0]);
+      expect([a, b, c]).toEqual(expectedInvocations[0]);
       expectedInvocations.shift();
     });
-    expect(expectedInvocations).to.be.empty;
+    expect(expectedInvocations).toHaveLength(0);
   });
 });

--- a/apps/test/unit/util/dataStructures/WeakMapPlusTest.js
+++ b/apps/test/unit/util/dataStructures/WeakMapPlusTest.js
@@ -1,7 +1,5 @@
 import {WeakMapPlus} from '@cdo/apps/util/dataStructures/WeakMapPlus';
 
-import {assert} from '../../../util/reconfiguredChai'; // eslint-disable-line no-restricted-imports
-
 describe('WeakMapPlus', function () {
   let populatedMap, emptyMap;
   const object = {};
@@ -16,60 +14,60 @@ describe('WeakMapPlus', function () {
   });
 
   it('can be instantiated', function () {
-    assert(emptyMap instanceof WeakMapPlus);
+    expect(emptyMap instanceof WeakMapPlus).toBeTruthy();
   });
 
   it('is derived from WeakMap', function () {
-    assert(emptyMap instanceof WeakMap);
+    expect(emptyMap instanceof WeakMap).toBeTruthy();
   });
 
   it('does not contain value for object key if never added', function () {
-    assert(!emptyMap.has({}));
-    assert(!populatedMap.has({}));
-    assert(emptyMap.get({}) === undefined);
-    assert(populatedMap.get({}) === undefined);
+    expect(emptyMap.has({})).toBeFalsy();
+    expect(populatedMap.has({})).toBeFalsy();
+    expect(emptyMap.get({})).toBe(undefined);
+    expect(populatedMap.get({})).toBe(undefined);
   });
 
   it('does allow setting of value for object key', function () {
     const newObject = {};
     emptyMap.set(newObject, objectValue);
     populatedMap.set(newObject, objectValue);
-    assert(emptyMap.has(newObject));
-    assert(populatedMap.has(newObject));
-    assert(emptyMap.get(newObject) === objectValue);
-    assert(populatedMap.get(newObject) === objectValue);
+    expect(emptyMap.has(newObject)).toBeTruthy();
+    expect(populatedMap.has(newObject)).toBeTruthy();
+    expect(emptyMap.get(newObject)).toBe(objectValue);
+    expect(populatedMap.get(newObject)).toBe(objectValue);
   });
 
   it('does allow setting of value for undefined key', function () {
     emptyMap.set(undefined, undefinedValue);
-    assert(emptyMap.has(undefined));
-    assert(emptyMap.get(undefined) === undefinedValue);
+    expect(emptyMap.has(undefined)).toBeTruthy();
+    expect(emptyMap.get(undefined)).toBe(undefinedValue);
   });
 
   it('does contain value for object key if previously added', function () {
-    assert(populatedMap.has(object));
-    assert(populatedMap.get(object) === objectValue);
+    expect(populatedMap.has(object)).toBeTruthy();
+    expect(populatedMap.get(object)).toBe(objectValue);
   });
 
   it('does allow deleting of value for previously defined object key', function () {
     populatedMap.delete(object);
-    assert(!populatedMap.has(object));
-    assert(populatedMap.get(object) === undefined);
+    expect(populatedMap.has(object)).toBeFalsy();
+    expect(populatedMap.get(object)).toBe(undefined);
   });
 
   it('does contain value for undefined key if previously added', function () {
-    assert(populatedMap.has(undefined));
-    assert(populatedMap.get(undefined) === undefinedValue);
+    expect(populatedMap.has(undefined)).toBeTruthy();
+    expect(populatedMap.get(undefined)).toBe(undefinedValue);
   });
 
   it('does allow deleting of value for previously defined object key', function () {
     populatedMap.delete(undefined);
-    assert(!populatedMap.has(undefined));
-    assert(populatedMap.get(undefined) === undefined);
+    expect(populatedMap.has(undefined)).toBeFalsy();
+    expect(populatedMap.get(undefined)).toBe(undefined);
   });
 
   it('does not contain value for undefined key if not previously added', function () {
-    assert(!emptyMap.has(undefined));
-    assert(emptyMap.get(undefined) === undefined);
+    expect(emptyMap.has(undefined)).toBeFalsy();
+    expect(emptyMap.get(undefined)).toBe(undefined);
   });
 });

--- a/apps/test/unit/util/getScriptDataTest.js
+++ b/apps/test/unit/util/getScriptDataTest.js
@@ -1,7 +1,5 @@
 import getScriptData from '@cdo/apps/util/getScriptData';
 
-import {expect} from '../../util/reconfiguredChai'; // eslint-disable-line no-restricted-imports
-
 describe('the getScriptData function', () => {
   beforeEach(() => {
     const someDiv = document.createElement('div');
@@ -13,19 +11,19 @@ describe('the getScriptData function', () => {
     `;
   });
   it('extracts data from a script tag', () => {
-    expect(getScriptData('foo')).to.equal(1);
-    expect(getScriptData('bar')).to.deep.equal({userId: 'neato'});
+    expect(getScriptData('foo')).toBe(1);
+    expect(getScriptData('bar')).toEqual({userId: 'neato'});
   });
 
   it('is case-insensitive', () => {
-    expect(getScriptData('FOO')).to.equal(1);
+    expect(getScriptData('FOO')).toBe(1);
   });
 
   it('throws an error if the script tag does not exist', () => {
-    expect(() => getScriptData('does-not-exist')).to.throw;
+    expect(() => getScriptData('does-not-exist')).toThrow();
   });
 
   it('throws an error if the json is malformed', () => {
-    expect(() => getScriptData('malformed')).to.throw;
+    expect(() => getScriptData('malformed')).toThrow();
   });
 });


### PR DESCRIPTION
This PR refactors restricted imports (sinon & chai) over to Jest.

I noticed some [previous work](https://github.com/code-dot-org/code-dot-org/pull/59565) was done a while back using a different codemod, and thought I'd continue the effort with this PR. With that in mind, I used the `jscodeshift` library last month to write a simple codemod at https://github.com/jamsch/code-org-test-refactor-codemod (as I figured it may have been more useful to add new refactors).

My method of doing this was:

1. Run `./transform-dir.sh "/Users/james/Projects/code-dot-org/apps/test/unit"`
2. After each file changed, the codemod runs the test suite with a filter for the specific file changed
3. If tests fail, revert the changes (& optionally update the codemod itself to cover the broken case)

Note that this PR only includes a small subset of the file changes. I intentionally didn't want to include more because it does become impossible to review especially for an external contributor.

## Links

N/A

## Testing story

All tests pass

## Deployment strategy

N/A

## Follow-up work

There's still  quite a number of files to codemod. I've kept this PR intentionally small because there's a lot of changes.

## Privacy
N/A


## Security
N/A


## Caching
N/A

## PR Creation Checklist:

- [x] Tests provide adequate coverage
- [x] Privacy impacts have been documented
- [x] Security impacts have been documented
- [x] Code is well-commented
- [x] New features are translatable or updates will not break translations
- [x] Relevant documentation has been added or updated
- [x] User impact is well-understood and desirable
- [x] Follow-up work items (including potential tech debt) are tracked and linked
