### PR TITLE
[ACQ-3528-2] [Follow up] Update workshops on PL catalog to be more relevant to user

### DIFF
--- a/apps/src/templates/courseOfferings/courseCard/courseExpandedCard/CourseOfferingExpandedCard.tsx
+++ b/apps/src/templates/courseOfferings/courseCard/courseExpandedCard/CourseOfferingExpandedCard.tsx
@@ -90,7 +90,7 @@ const CourseOfferingExpandedCard: React.FunctionComponent<
             )}
             {courseOffering.image && <Image src={courseOffering.image} />}
           </div>
-          {relatedCurriculums?.length && (
+          {!!relatedCurriculums?.length && (
             <div className={moduleStyles.additionalDetails}>
               <div>
                 <FontAwesomeV6Icon

--- a/dashboard/app/models/course_offering.rb
+++ b/dashboard/app/models/course_offering.rb
@@ -230,14 +230,14 @@ class CourseOffering < ApplicationRecord
   end
 
   def self.self_paced_course_offerings_for_catalog(user = nil, locale = 'en-us')
-    offerings = all_course_offerings.select do |co|
-      co.get_participant_audience == 'teacher' &&
-        co.instruction_type == 'self_paced' &&
-        co.assignable? &&
-        co.any_version_is_in_published_state?
+    all_course_offerings.filter_map do |co|
+      if co.get_participant_audience == 'teacher' &&
+          co.instruction_type == 'self_paced' &&
+          co.assignable? &&
+          co.any_version_is_in_published_state?
+        co.summarize_for_catalog(locale, user)
+      end
     end
-
-    offerings.map {|co| co.summarize_for_catalog(locale, user)}
   end
 
   def self.self_paced_pl_course_offerings_for_workshops

--- a/dashboard/app/models/pd/workshop.rb
+++ b/dashboard/app/models/pd/workshop.rb
@@ -983,14 +983,12 @@ class Pd::Workshop < ApplicationRecord
     when "National"
       true
     when "Regional"
-      zip = user&.school_info&.school&.zip || user&.school_info&.zip
+      school = Queries::SchoolInfo.current_school(user)
+      zip = school&.dig(:school_zip)
       return false if zip.blank?
 
-      normalized_zip = zip.to_s.rjust(5, '0')
-
       zip_codes = regional_partner&.mappings&.pluck(:zip_code)
-
-      zip_codes&.include?(normalized_zip)
+      zip_codes&.include?(zip)
     else
       false
     end


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## [ACQ-3528-2] [Follow up] Update workshops on PL catalog to be more relevant to user

Follow up to https://github.com/code-dot-org/code-dot-org/pull/68737

## Links
<!--  Links to relevant external resources.
      - spec docs, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- Jira: [ACQ-3528](https://codedotorg.atlassian.net/browse/ACQ-3528)

## Testing story
<!--  Does your change include appropriate tests?
      - If so, please describe how the tests included in this PR are sufficient.
      - If not, please explain why this change does not need to be tested. -->



## Deployment strategy
<!--  Any special steps required to deploy this, besides merging?
      - Are there database migrations or manual steps?
      - Does this require coordination with other teams or systems? -->



## Follow-up work
<!--  List any clean-up or technical debt that will be addressed in future work.
      - Include Jira links where applicable.
      - Are there any known limitations or improvements planned? -->



## Privacy
<!--  How does this change impact Student & Teacher privacy?
      - Does this collect, use, share, or modify PII, either new or existing? -->



## Security
<!--  How does this change impact our security surface-area?
      - Do API's touched have the right auth?
      - Do infra changes impact our attack surface or encryption?
-->



## Caching
<!--  How does this change impact caching behavior?
      - Are cache keys or invalidation strategies affected?
      - Will this require cache warming or invalidation after deployment? -->



## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
