### PR TITLE
remove deprecated api/v1/user_scripts route

### DIFF
--- a/dashboard/app/controllers/api/v1/user_scripts_controller.rb
+++ b/dashboard/app/controllers/api/v1/user_scripts_controller.rb
@@ -5,7 +5,6 @@ class Api::V1::UserScriptsController < ApplicationController
   # Use `course` and `unit` (singular) to differentiate from other routes which typically use
   # plurals to refer to course_name and unit_position.
   # PATCH /api/v1/user_scripts/course/:course_id/unit/:script_id
-  # PATCH /user_scripts/:script_id (deprecated)
   def update
     if @user_script.update(params.permit(:version_warning_dismissed))
       head :no_content
@@ -17,11 +16,10 @@ class Api::V1::UserScriptsController < ApplicationController
   private def set_user_script
     script_id = params.require(:script_id)
     unit = Unit.get_from_cache(script_id)
-    # TODO: remove script-only route. Once '/api/v1/user_scripts/:script_id' is removed from
-    # routes.rb, require :course_id here and remove the presence check.
-    unit_group = UnitGroup.get_from_cache(params[:course_id]) if params[:course_id].present?
+    course_id = params.require(:course_id)
+    unit_group = UnitGroup.get_from_cache(course_id)
 
-    unless unit
+    unless unit && unit_group
       head :not_found
       return
     end

--- a/dashboard/config/routes.rb
+++ b/dashboard/config/routes.rb
@@ -87,7 +87,6 @@ Dashboard::Application.routes.draw do
       end
     end
 
-    patch '/api/v1/user_scripts/:script_id', to: 'api/v1/user_scripts#update'
     patch '/api/v1/user_scripts/course/:course_id/unit/:script_id', to: 'api/v1/user_scripts#update'
 
     get '/download/:product', to: 'hoc_download#index'

--- a/dashboard/test/controllers/api/v1/user_scripts_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/user_scripts_controller_test.rb
@@ -1,45 +1,6 @@
 require 'test_helper'
 
 class Api::V1::UserScriptsControllerTest < ActionDispatch::IntegrationTest
-  test "student with deprecated user script can dismiss version warning" do
-    user_script = create(:user_script)
-    user_script.update!(unit_group: nil)
-    sign_in user_script.user
-    patch "/api/v1//user_scripts/#{user_script.script.id}", params: {
-      version_warning_dismissed: true
-    }
-    assert_response :success
-    user_script.reload
-    assert_equal "true", user_script.version_warning_dismissed
-  end
-
-  test "student without user_script can dismiss version warning" do
-    user = create(:user)
-    script = create(:unit, :in_single_unit_course)
-    unit_group = script.get_original_unit_group
-    sign_in user
-    patch "/api/v1//user_scripts/#{script.id}", params: {
-      version_warning_dismissed: true
-    }
-    assert_response :success
-    user_script = UserScript.find_by(user: user, script: script)
-    refute_nil user_script
-    assert_equal unit_group.id, user_script.unit_group_id
-    assert_equal "true", user_script.version_warning_dismissed
-  end
-
-  test "raises for nonexistent script" do
-    user = create(:user)
-    sign_in user
-    bogus_script_id = 10_000_000
-    patch "/api/v1//user_scripts/#{bogus_script_id}", params: {
-      version_warning_dismissed: true
-    }
-    assert_response :not_found
-    user_script = UserScript.find_by(user: user, script: bogus_script_id)
-    assert_nil user_script
-  end
-
   test "student can dismiss version warning via course_id and script_id" do
     unit_group = create(:single_unit_course, :stable)
     unit = unit_group.first_unit
@@ -68,12 +29,38 @@ class Api::V1::UserScriptsControllerTest < ActionDispatch::IntegrationTest
     assert_equal "true", user_script.version_warning_dismissed
   end
 
-  test "raises for nonexistent course or unit" do
+  test "not found for nonexistent course or unit" do
     user = create(:user)
     sign_in user
     patch "/api/v1//user_scripts/course/999999/unit/999999", params: {
       version_warning_dismissed: true
     }
     assert_response :not_found
+  end
+
+  test "not found for nonexistent unit with valid course" do
+    user = create(:user)
+    unit_group = create(:single_unit_course, :stable)
+    sign_in user
+    bogus_script_id = 10_000_000
+    patch "/api/v1//user_scripts/course/#{unit_group.id}/unit/#{bogus_script_id}", params: {
+      version_warning_dismissed: true
+    }
+    assert_response :not_found
+    user_script = UserScript.find_by(user: user, script: bogus_script_id)
+    assert_nil user_script
+  end
+
+  test "not found for nonexistent course with valid unit" do
+    user = create(:user)
+    unit = create(:unit, :in_single_unit_course)
+    sign_in user
+    bogus_course_id = 10_000_000
+    patch "/api/v1//user_scripts/course/#{bogus_course_id}/unit/#{unit.id}", params: {
+      version_warning_dismissed: true
+    }
+    assert_response :not_found
+    user_script = UserScript.find_by(user: user, script: unit)
+    assert_nil user_script
   end
 end


### PR DESCRIPTION
Finishes https://codedotorg.atlassian.net/browse/TEACH-2166 . Removes the old `api/v1/user_scripts/:script_id` route in favor of the new `/api/v1/user_scripts/course/:course_id/script/:script_id`. JS requests to the old route were turned off in https://github.com/code-dot-org/code-dot-org/pull/67766/files#diff-10b20371e10ee516a9a0305c31182863afee127836875e6b8e38379f04140720 . 

## Testing story
* updated existing unit tests
* verified via AWS athena on 10/13 that the old route is no longer being accessed in production:
```
#	day			num_requests
1	2025-09-20	30
2	2025-09-21	31
3	2025-09-22	343
4	2025-09-23	314
5	2025-09-24	347
6	2025-09-25	316
7	2025-09-26	289
8	2025-09-27	39
9	2025-09-28	23
10	2025-09-29	324
11	2025-09-30	330
12	2025-10-01	289
13	2025-10-02	197
14	2025-10-03	2
15	2025-10-06	3
16	2025-10-08	1
```
