### PR TITLE
Add support for non-standard Classlink role

### DIFF
--- a/dashboard/app/controllers/lti/v1/integrations_controller.rb
+++ b/dashboard/app/controllers/lti/v1/integrations_controller.rb
@@ -63,7 +63,9 @@ module Lti
       # Displays the onboarding portal for creating a new LTI Integration
       def new
         @form_data = {}
-        @form_data[:lms_platforms] = Policies::Lti::LMS_PLATFORMS.map do |key, value|
+        @form_data[:lms_platforms] = Policies::Lti::LMS_PLATFORMS.filter_map do |key, value|
+          # TODO: Remove this special case when ClassLink support is ready
+          next if key == :classlink && !DCDO.get('classlink_lms_enabled', false)
           {platform: key, name: value[:name]}
         end
 

--- a/dashboard/app/controllers/lti_v1_controller.rb
+++ b/dashboard/app/controllers/lti_v1_controller.rb
@@ -158,7 +158,9 @@ class LtiV1Controller < ApplicationController
       deployment_id = decoded_jwt[Policies::Lti::LTI_DEPLOYMENT_ID_CLAIM]
       deployment_name = decoded_jwt[Policies::Lti::LTI_DEPLOYMENT_PLATFORM_CLAIM]&.[](:name)
       deployment = Queries::Lti.get_deployment(integration[:id], deployment_id)
-      lti_account_type = Policies::Lti.get_account_type(decoded_jwt[Policies::Lti::LTI_ROLES_KEY])
+      # ClassLink uses a non-standard role claim key
+      role_key = decoded_jwt[Policies::Lti::CLASSLINK_ROLE_KEY].present? ? Policies::Lti::CLASSLINK_ROLE_KEY : Policies::Lti::LTI_ROLES_KEY
+      lti_account_type = Policies::Lti.get_account_type(decoded_jwt[role_key])
 
       # If deployment name is nil, update it with the name from the JWT. This
       # could likely be removed after a period of time, as we also write the name

--- a/dashboard/lib/policies/lti.rb
+++ b/dashboard/lib/policies/lti.rb
@@ -31,7 +31,8 @@ class Policies::Lti
 
   MEMBERSHIP_CONTAINER_CONTENT_TYPE = 'application/vnd.ims.lti-nrps.v2.membershipcontainer+json'.freeze
   TEACHER_ROLES = Set.new(['http://purl.imsglobal.org/vocab/lis/v1/institution/person#Instructor',
-                           'http://purl.imsglobal.org/vocab/lis/v2/membership#Instructor']
+                           'http://purl.imsglobal.org/vocab/lis/v2/membership#Instructor',
+                           'Teacher']
 ).freeze
   STAFF_ROLES = Set.new(
     [
@@ -52,6 +53,7 @@ class Policies::Lti
   LTI_NRPS_CLAIM = "https://purl.imsglobal.org/spec/lti-nrps/claim/namesroleservice".freeze
   LTI_PLATFORM_CONFIGURATION = "https://purl.imsglobal.org/spec/lti-platform-configuration".freeze
   CANVAS_ACCOUNT_NAME = "https://canvas.instructure.com/lti/account_name".freeze
+  CLASSLINK_ROLE_KEY = 'classLink_role'.freeze
 
   # Prioritized lists for looking up a user's name from custom LTI variable claims.
   TEACHER_NAME_KEYS = [:name, :display_name, :full_name, :family_name, :given_name].freeze
@@ -85,6 +87,14 @@ class Policies::Lti
       auth_redirect_url: 'https://lti-service.svc.schoology.com/lti-service/authorize-redirect'.freeze,
       jwks_url: 'https://lti-service.svc.schoology.com/lti-service/.well-known/jwks'.freeze,
       access_token_url: 'https://lti-service.svc.schoology.com/lti-service/access-token'.freeze,
+    },
+    # https://launchpad.classlink.com/.well-known/openid-configuration
+    classlink: {
+      name: 'ClassLink'.freeze,
+      issuer: "https://launchpad.classlink.com".freeze,
+      auth_redirect_url: "https://launchpad.classlink.com/oauth2/v2/auth".freeze,
+      jwks_url: "https://launchpad.classlink.com/oauth2/v2/jwks".freeze,
+      access_token_url: "https://launchpad.classlink.com/oauth2/v2/token".freeze,
     },
   }
 
@@ -133,6 +143,10 @@ class Policies::Lti
   MAX_COURSE_MEMBERSHIP = 650
 
   def self.get_account_type(roles)
+    # ClassLink includes a non-standard role as a string instead of an array of strings
+    if roles.is_a?(String)
+      return STAFF_ROLES.include?(roles) ? User::TYPE_TEACHER : User::TYPE_STUDENT
+    end
     roles.each do |role|
       return User::TYPE_TEACHER if STAFF_ROLES.include? role
     end

--- a/dashboard/lib/services/lti.rb
+++ b/dashboard/lib/services/lti.rb
@@ -9,7 +9,9 @@ require 'metrics/events'
 module Services
   module Lti
     def self.initialize_lti_user(id_token)
-      user_type = Policies::Lti.get_account_type(id_token[Policies::Lti::LTI_ROLES_KEY])
+      # ClassLink uses a non-standard role claim key
+      role_key = id_token[Policies::Lti::CLASSLINK_ROLE_KEY].present? ? Policies::Lti::CLASSLINK_ROLE_KEY : Policies::Lti::LTI_ROLES_KEY
+      user_type = Policies::Lti.get_account_type(id_token[role_key])
       user = ::User.new
       user.provider = ::User::PROVIDER_MIGRATED
       user.user_type = user_type

--- a/dashboard/test/lib/policies/lti_test.rb
+++ b/dashboard/test/lib/policies/lti_test.rb
@@ -8,6 +8,7 @@ class Policies::LtiTest < ActiveSupport::TestCase
   setup do
     @ids = ['http://some-iss.com', ['some-aud'], 'some-sub'].freeze
     @roles_key = Policies::Lti::LTI_ROLES_KEY
+    @classlink_role_key = Policies::Lti::CLASSLINK_ROLE_KEY
     @teacher_roles = [
       'http://purl.imsglobal.org/vocab/lis/v2/institution/person#Administrator',
       'http://purl.imsglobal.org/vocab/lis/v2/institution/person#Instructor',
@@ -40,6 +41,16 @@ class Policies::LtiTest < ActiveSupport::TestCase
   test 'get_account_type should return a student if id_token does not have TEACHER_ROLES' do
     @id_token[@roles_key] = ['not-a-teacher-role']
     assert_equal Policies::Lti.get_account_type(@id_token[Policies::Lti::LTI_ROLES_KEY]), User::TYPE_STUDENT
+  end
+
+  test 'get_account_type should return a teacher if id_token has Classlink formated Teacher role' do
+    @id_token[@classlink_role_key] = 'Teacher'
+    assert_equal Policies::Lti.get_account_type(@id_token[@classlink_role_key]), User::TYPE_TEACHER
+  end
+
+  test 'get_account_type should return a student if id_token has Classlink formated Student role' do
+    @id_token[@classlink_role_key] = 'Student'
+    assert_equal Policies::Lti.get_account_type(@id_token[@classlink_role_key]), User::TYPE_STUDENT
   end
 
   test 'issuer should return the issuer of the LTI Platform from a users LTI authentication_options' do


### PR DESCRIPTION
This PR adds support for ClassLink LTI launches. It adds the required LTI URLs, as well as handles a specialized role format. Classlink sends roles in a non-standard format in the id_token.

**Standard Format Example (LTI 1.3)**
```
...
"https://purl.imsglobal.org/spec/lti/claim/roles": [
    "http://purl.imsglobal.org/vocab/lis/v2/institution/person#teacher"
],
...
```

**Classlink Format Example**
```
...
"classLink_role": "Teacher",
...
```


<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->



## Links
<!--  Links to relevant external resources.
      - spec docs, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- Jira: 

## Testing story
<!--  Does your change include appropriate tests?
      - If so, please describe how the tests included in this PR are sufficient.
      - If not, please explain why this change does not need to be tested. -->



## Deployment strategy
<!--  Any special steps required to deploy this, besides merging?
      - Are there database migrations or manual steps?
      - Does this require coordination with other teams or systems? -->



## Follow-up work
<!--  List any clean-up or technical debt that will be addressed in future work.
      - Include Jira links where applicable.
      - Are there any known limitations or improvements planned? -->



## Privacy
<!--  How does this change impact Student & Teacher privacy?
      - Does this collect, use, share, or modify PII, either new or existing? -->



## Security
<!--  How does this change impact our security surface-area?
      - Do API's touched have the right auth?
      - Do infra changes impact our attack surface or encryption?
-->



## Caching
<!--  How does this change impact caching behavior?
      - Are cache keys or invalidation strategies affected?
      - Will this require cache warming or invalidation after deployment? -->



## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
