### PR TITLE
Share workspace header between Codebridge, Sketch Lab, and Music Lab

### DIFF
--- a/apps/src/codebridge/Workspace/Workspace.tsx
+++ b/apps/src/codebridge/Workspace/Workspace.tsx
@@ -13,10 +13,9 @@ import {getAppOptionsEditBlocks} from '@cdo/apps/lab2/projects/utils';
 import {setRestoredOldVersion} from '@cdo/apps/lab2/redux/lab2ProjectRedux';
 import {isProjectTemplateLevel} from '@cdo/apps/lab2/redux/lab2ReduxSelectors';
 import PanelContainer from '@cdo/apps/lab2/views/components/PanelContainer';
+import WorkspaceHeader from '@cdo/apps/lab2/views/components/WorkspaceHeader';
 import i18n from '@cdo/apps/pythonlab/locale';
-import ProjectTemplateWorkspaceIconV2 from '@cdo/apps/templates/ProjectTemplateWorkspaceIconV2';
 import {useAppDispatch, useAppSelector} from '@cdo/apps/util/reduxHooks';
-import commonI18n from '@cdo/locale';
 
 import HeaderButtons from './HeaderButtons';
 
@@ -55,15 +54,6 @@ const Workspace: React.FunctionComponent<WorkspaceProps> = ({
     state => state.codebridgeWorkspace.showFileBrowser
   );
   const dispatch = useAppDispatch();
-
-  const headerContent = (
-    <div className={moduleStyles.centerHeaderContent}>
-      <div className={moduleStyles.centerHeaderContentText}>
-        {commonI18n.workspaceHeaderShort()}
-      </div>
-      {projectTemplateLevel && <ProjectTemplateWorkspaceIconV2 />}
-    </div>
-  );
 
   const closeRestoredVersionBanner = () => {
     dispatch(setRestoredOldVersion(false));
@@ -109,7 +99,7 @@ const Workspace: React.FunctionComponent<WorkspaceProps> = ({
       <PanelContainer
         id="editor-workspace"
         hideHeaders={hideHeaders}
-        headerContent={headerContent}
+        headerContent={<WorkspaceHeader />}
         rightHeaderContent={<HeaderButtons />}
         className={moduleStyles.workspace}
         headerClassName={moduleStyles.workspaceHeader}

--- a/apps/src/lab2/views/components/WorkspaceHeader.tsx
+++ b/apps/src/lab2/views/components/WorkspaceHeader.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+
+import {isProjectTemplateLevel} from '@cdo/apps/lab2/redux/lab2ReduxSelectors';
+import ProjectTemplateWorkspaceIconV2 from '@cdo/apps/templates/ProjectTemplateWorkspaceIconV2';
+import {useAppSelector} from '@cdo/apps/util/reduxHooks';
+import commonI18n from '@cdo/locale';
+
+import styles from './workspace-header.module.scss';
+
+const WorkspaceHeader = () => {
+  const projectTemplateLevel = useAppSelector(isProjectTemplateLevel);
+
+  return (
+    <div className={styles.centerHeaderContent}>
+      <div className={styles.centerHeaderContentText}>
+        {commonI18n.workspaceHeaderShort()}
+      </div>
+      {projectTemplateLevel && <ProjectTemplateWorkspaceIconV2 />}
+    </div>
+  );
+};
+
+export default WorkspaceHeader;

--- a/apps/src/lab2/views/components/workspace-header.module.scss
+++ b/apps/src/lab2/views/components/workspace-header.module.scss
@@ -1,5 +1,5 @@
-@import '../../../mixins.scss';
+@use '../../../mixins.scss' as mixins;
 
 .centerHeaderContent {
-  @include center-header-content(true);
+  @include mixins.center-header-content(true);
 }

--- a/apps/src/lab2/views/components/workspace-header.module.scss
+++ b/apps/src/lab2/views/components/workspace-header.module.scss
@@ -1,0 +1,5 @@
+@import '../../../mixins.scss';
+
+.centerHeaderContent {
+  @include center-header-content(true);
+}

--- a/apps/src/mixins.scss
+++ b/apps/src/mixins.scss
@@ -62,6 +62,7 @@
 @mixin center-header-content($include-text-styles) {
   display: flex;
   justify-content: center;
+  align-items: center;
   gap: 4px;
   overflow: hidden;
 

--- a/apps/src/music/views/MusicLabView.tsx
+++ b/apps/src/music/views/MusicLabView.tsx
@@ -24,8 +24,8 @@ import {LevelProperties} from '@cdo/apps/lab2/types';
 import CodeEditor from '@cdo/apps/lab2/views/components/editor/CodeEditor';
 import ResourcePanel from '@cdo/apps/lab2/views/components/Instructions/ResourcePanel';
 import PanelContainer from '@cdo/apps/lab2/views/components/PanelContainer';
+import WorkspaceHeader from '@cdo/apps/lab2/views/components/WorkspaceHeader';
 import {DialogType, useDialogControl} from '@cdo/apps/lab2/views/dialogs';
-import ProjectTemplateWorkspaceIconV2 from '@cdo/apps/templates/ProjectTemplateWorkspaceIconV2';
 import {useAppDispatch, useAppSelector} from '@cdo/apps/util/reduxHooks';
 
 import AnalyticsReporter from '../analytics/AnalyticsReporter';
@@ -307,15 +307,6 @@ const MusicLabView: React.FunctionComponent<MusicLabViewProps> = ({
     return <MusicPlayView setPlaying={setPlaying} />;
   }
 
-  const headerContent = (
-    <div className={moduleStyles.centerHeaderContent}>
-      <div className={moduleStyles.centerHeaderContentText}>
-        {musicI18n.panelHeaderWorkspace()}
-      </div>
-      {projectTemplateLevel && <ProjectTemplateWorkspaceIconV2 />}
-    </div>
-  );
-
   return (
     <div
       id="music-lab"
@@ -382,7 +373,7 @@ const MusicLabView: React.FunctionComponent<MusicLabViewProps> = ({
 
           <PanelContainer
             id="workspace-panel"
-            headerContent={headerContent}
+            headerContent={<WorkspaceHeader />}
             hideHeaders={hideHeaders}
             rightHeaderContent={
               <HeaderButtons

--- a/apps/src/sketchlab/SketchlabView.tsx
+++ b/apps/src/sketchlab/SketchlabView.tsx
@@ -15,6 +15,7 @@ import {LabProps, LevelProperties, ProjectSources} from '@cdo/apps/lab2/types';
 import ResourcePanel from '@cdo/apps/lab2/views/components/Instructions/ResourcePanel';
 import ResizeBar from '@cdo/apps/lab2/views/components/layout/ResizeBar';
 import PanelContainer from '@cdo/apps/lab2/views/components/PanelContainer';
+import WorkspaceHeader from '@cdo/apps/lab2/views/components/WorkspaceHeader';
 import SourcesContainer, {
   useSources,
 } from '@cdo/apps/lab2/views/SourcesContainer';
@@ -173,7 +174,7 @@ const SketchlabView: React.FC<LabProps<LevelProperties>> = ({
         <PanelContainer
           id="workspace"
           className={panelClassName}
-          headerContent="Workspace"
+          headerContent={<WorkspaceHeader />}
         >
           <Excalidraw
             initialData={currentSources.source}


### PR DESCRIPTION
Follow up to https://github.com/code-dot-org/code-dot-org/pull/68830.

Adds the project template icon to the Sketch Lab workspace header, and refactors to share code with Codebridge and Music Lab. It also makes a slight tweak to center the project template icon vertically (it has been bugging me that it is slightly below centered!)

I looked at adding this to Web Lab 2 as well, but I think we still need to change that Workspace into a normal PanelContainer for things to look right.

## Sketch Lab

<img width="1680" height="218" alt="image" src="https://github.com/user-attachments/assets/e68658d6-aa1f-4cf8-a459-c155b37e75a3" />

## Python Lab

<img width="1680" height="137" alt="image" src="https://github.com/user-attachments/assets/26af83a0-bfaa-4c04-9c6d-53bd78d82a61" />

## Music Lab

<img width="1680" height="271" alt="image" src="https://github.com/user-attachments/assets/d91983dd-a74d-40f2-94b3-664873cddaee" />

## Testing story

Tested manually (see screenshots).