### PR TITLE
use new user_script.unit_group field to determine which My Courses cards to show

### DIFF
--- a/dashboard/app/controllers/home_controller.rb
+++ b/dashboard/app/controllers/home_controller.rb
@@ -148,11 +148,11 @@ class HomeController < ApplicationController
 
     @homepage_data[:hasFeedback] = TeacherFeedback.has_feedback?(current_user.id)
 
-    script = Queries::ScriptActivity.primary_student_unit(current_user)
-    if script
+    unit_context = Queries::ScriptActivity.primary_student_unit_context(current_user)
+    if unit_context
+      script = unit_context[:unit]
       script_level = current_user.next_unpassed_progression_level(script)
-      unit_group = script.get_original_unit_group
-      unit_group_unit = script.unit_group_units.find {|ugu| ugu.unit_group == unit_group} if unit_group
+      unit_group_unit = unit_context[:unit_group_unit]
     end
     @homepage_data[:topCourse] = nil
     if script && script_level

--- a/dashboard/app/controllers/home_controller.rb
+++ b/dashboard/app/controllers/home_controller.rb
@@ -140,7 +140,7 @@ class HomeController < ApplicationController
     @show_school_info_interstitial = params[:showSchoolInfoInterstitial]
     @show_section_creation_celebration_dialog = params[:showSectionCreationDialog]
 
-    @homepage_data[:courses] = current_user.recent_student_courses_and_units
+    @homepage_data[:courses] = current_user.recent_student_courses
 
     @homepage_data[:hasFeedback] = TeacherFeedback.has_feedback?(current_user.id)
 

--- a/dashboard/app/controllers/home_controller.rb
+++ b/dashboard/app/controllers/home_controller.rb
@@ -140,11 +140,7 @@ class HomeController < ApplicationController
     @show_school_info_interstitial = params[:showSchoolInfoInterstitial]
     @show_section_creation_celebration_dialog = params[:showSectionCreationDialog]
 
-    # Students and teachers will receive a @top_course for their primary
-    # script, so we don't want to include that script (if it exists) in the
-    # regular lists of recent scripts.
-    exclude_primary_script = true
-    @homepage_data[:courses] = current_user.recent_student_courses_and_units(exclude_primary_script)
+    @homepage_data[:courses] = current_user.recent_student_courses_and_units
 
     @homepage_data[:hasFeedback] = TeacherFeedback.has_feedback?(current_user.id)
 

--- a/dashboard/app/models/concerns/user/assigned_courses_and_scripts.rb
+++ b/dashboard/app/models/concerns/user/assigned_courses_and_scripts.rb
@@ -171,7 +171,7 @@ module User::AssignedCoursesAndScripts
 
   # Return a collection of courses for the user.
   # @return [Array{CourseData}] an array of hashes of course data
-  def recent_student_courses_and_units
+  def recent_student_courses
     courses_as_participant.select {|c| !c.pl_course?}.map(&:summarize_short)
   end
 

--- a/dashboard/app/models/concerns/user/assigned_courses_and_scripts.rb
+++ b/dashboard/app/models/concerns/user/assigned_courses_and_scripts.rb
@@ -21,10 +21,6 @@ module User::AssignedCoursesAndScripts
     unit_groups.concat(section_courses).uniq
   end
 
-  def visible_scripts
-    scripts.map(&:cached).select {|s| [Curriculum::SharedCourseConstants::PUBLISHED_STATE.stable, Curriculum::SharedCourseConstants::PUBLISHED_STATE.preview].include?(s.get_published_state)}
-  end
-
   def assigned_script?(script)
     section_scripts.include?(script) || section_courses.include?(script&.get_original_unit_group)
   end

--- a/dashboard/app/models/concerns/user/assigned_courses_and_scripts.rb
+++ b/dashboard/app/models/concerns/user/assigned_courses_and_scripts.rb
@@ -169,46 +169,10 @@ module User::AssignedCoursesAndScripts
     user_course_data + user_script_data
   end
 
-  # Return a collection of courses and scripts for the user.
-  # First in the list will be courses enrolled in by the user's sections.
-  # Following that will be all scripts in which the user has made progress that # are not in any of the enrolled courses.
-  # @param exclude_primary_script [boolean]
-  # Example: true when the primary_script is being used for a TopCourse on /home
-  # @return [Array{CourseData, ScriptData}] an array of hashes of script and
-  # course data
-  # TODO: TEACH-1528 Update this to use a new UserCourses table. For now, this returns a /s/ url for each unit, displayed
-  # on the student home page course tiles
-  def recent_student_courses_and_units(exclude_primary_script)
-    primary_script_id = Queries::ScriptActivity.primary_student_unit(self).try(:id)
-
-    # Filter out user_scripts that are already covered by a course
-    unit_group_units_script_ids = courses_as_participant.map(&:default_unit_group_units).flatten.pluck(:script_id).uniq
-
-    user_scripts = Queries::ScriptActivity.in_progress_and_completed_scripts(self).
-      select {|user_script| unit_group_units_script_ids.exclude?(user_script.script_id)}
-
-    user_student_scripts = user_scripts.select {|us| !us.script.pl_course?}
-
-    user_script_data = user_student_scripts.filter_map do |user_script|
-      # Skip this script if we are excluding the primary script and this is the
-      # primary script.
-      if exclude_primary_script && user_script[:script_id] == primary_script_id
-        nil
-      else
-        script_id = user_script[:script_id]
-        script = Unit.get_from_cache(script_id)
-        {
-          name: script[:name],
-          title: data_t_suffix('script.name', script[:name], 'title'),
-          description: data_t_suffix('script.name', script[:name], 'description_short', default: ''),
-          link: script_path(script),
-        }
-      end
-    end
-
-    user_course_data = courses_as_participant.select {|c| !c.pl_course?}.map(&:summarize_short)
-
-    user_course_data + user_script_data
+  # Return a collection of courses for the user.
+  # @return [Array{CourseData}] an array of hashes of course data
+  def recent_student_courses_and_units
+    courses_as_participant.select {|c| !c.pl_course?}.map(&:summarize_short)
   end
 
   def pl_units_started

--- a/dashboard/app/models/concerns/user/assigned_courses_and_scripts.rb
+++ b/dashboard/app/models/concerns/user/assigned_courses_and_scripts.rb
@@ -14,7 +14,11 @@ module User::AssignedCoursesAndScripts
 
   # Returns the set of courses the user has been assigned to or has progress in.
   def courses_as_participant
-    visible_scripts.filter_map(&:get_original_unit_group).concat(section_courses).uniq
+    unit_groups = user_scripts.map do |us|
+      us.unit_group || us.script.original_unit_group
+    end.compact.uniq
+    unit_groups.filter!(&:launched?)
+    unit_groups.concat(section_courses).uniq
   end
 
   def visible_scripts

--- a/dashboard/lib/queries/script_activity.rb
+++ b/dashboard/lib/queries/script_activity.rb
@@ -36,11 +36,6 @@ class Queries::ScriptActivity
     user.user_scripts.where.not(user_scripts: {completed_at: nil})
   end
 
-  # return the primary unit with progress for all student units
-  def self.primary_student_unit(user)
-    working_on_student_units(user).first.try(:cached)
-  end
-
   # return the primary unit and unit group with progress for all student units
   def self.primary_student_unit_context(user)
     user_script = working_on_user_scripts(user).first

--- a/dashboard/lib/queries/script_activity.rb
+++ b/dashboard/lib/queries/script_activity.rb
@@ -41,6 +41,15 @@ class Queries::ScriptActivity
     working_on_student_units(user).first.try(:cached)
   end
 
+  # return the primary unit and unit group with progress for all student units
+  def self.primary_student_unit_context(user)
+    user_script = working_on_user_scripts(user).first
+    return nil unless user_script
+    unit = user_script.script
+    unit_group_unit = Queries::Courses.unit_group_unit(unit, user_script.unit_group)
+    {unit: unit, unit_group_unit: unit_group_unit}
+  end
+
   # return the primary unit with progress for all pl units
   def self.primary_pl_unit(user)
     working_on_pl_units(user).first.try(:cached)

--- a/dashboard/test/controllers/followers_controller_test.rb
+++ b/dashboard/test/controllers/followers_controller_test.rb
@@ -319,7 +319,8 @@ class FollowersControllerTest < ActionController::TestCase
     user_script = UserScript.where(user: assigns(:user), script: @laurel_section_script.script).first
     assert user_script
     assert user_script.assigned_at
-    assert_equal @laurel_section_script.script, Queries::ScriptActivity.primary_student_unit(assigns(:user))
+    context = Queries::ScriptActivity.primary_student_unit_context(assigns(:user))
+    assert_equal @laurel_section_script.script, context[:unit]
   end
 
   test "student_register with a picture/word section redirects to section login" do

--- a/dashboard/test/controllers/home_controller_test.rb
+++ b/dashboard/test/controllers/home_controller_test.rb
@@ -457,4 +457,83 @@ class HomeControllerTest < ActionController::TestCase
       get :debug
     end
   end
+
+  test "home page topCourse uses correct unit_group when UserScript has different unit_group than script original_unit_group" do
+    student = create(:student)
+
+    # Create two unit groups for the same script
+    original_unit_group = create(:unit_group, name: 'original-course', published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.stable)
+    different_unit_group = create(:unit_group, name: 'different-course', published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.stable)
+
+    script = create(:script, :with_levels, original_unit_group: original_unit_group)
+
+    # Add the script to both unit groups
+    create(:unit_group_unit, unit_group: original_unit_group, script: script, position: 1)
+    create(:unit_group_unit, unit_group: different_unit_group, script: script, position: 2)
+    script.reload
+
+    # Create a user_script with the different unit_group (not the original)
+    # Use the UserScript.find_and_migrate_or_create_by! method to ensure unit_group is set properly
+    user_script = UserScript.find_and_migrate_or_create_by!(user_id: student.id, unit: script, unit_group: different_unit_group)
+    user_script.update!(started_at: Time.now)
+
+    sign_in student
+    get :home
+
+    # Verify topCourse is set
+    refute_nil assigns(:homepage_data)[:topCourse]
+    top_course = assigns(:homepage_data)[:topCourse]
+
+    # Verify the links use the different_unit_group, not the original_unit_group
+    assert_equal "/courses/different-course/units/2", top_course[:linkToOverview]
+    assert_equal "/courses/different-course/units/2/next", top_course[:linkToLesson]
+  end
+
+  test "home page courses data comes from courses_as_participant" do
+    student = create(:student)
+
+    # Create a section course
+    section_course = create(:unit_group, name: 'section-course', published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.stable)
+    section = create(:section, unit_group: section_course)
+    section.students << student
+
+    # Create a user_script course
+    user_script_course = create(:unit_group, name: 'user-script-course', published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.stable)
+    script = create(:script, original_unit_group: user_script_course)
+    create(:unit_group_unit, unit_group: user_script_course, script: script, position: 1)
+    script.reload
+    create(:user_script, user: student, script: script, unit_group: user_script_course)
+
+    sign_in student
+    get :home
+
+    # Verify courses data is set
+    refute_nil assigns(:homepage_data)[:courses]
+    courses = assigns(:homepage_data)[:courses]
+
+    # Should have both courses
+    assert_equal 2, courses.length
+    course_names = courses.pluck(:name)
+    assert_includes course_names, 'section-course'
+    assert_includes course_names, 'user-script-course'
+  end
+
+  test "home page topCourse with nil unit_group_unit" do
+    student = create(:student)
+
+    # Create a standalone script (not in any unit_group)
+    script = create(:script, :with_levels)
+    create(:user_script, user: student, script: script, started_at: Time.now)
+
+    sign_in student
+    get :home
+
+    # Verify topCourse is set
+    refute_nil assigns(:homepage_data)[:topCourse]
+    top_course = assigns(:homepage_data)[:topCourse]
+
+    # Verify the links use the script path (not course path) when there's no unit_group_unit
+    assert_equal "/s/#{script.name}", top_course[:linkToOverview]
+    assert_equal "/s/#{script.name}/next", top_course[:linkToLesson]
+  end
 end

--- a/dashboard/test/controllers/home_controller_test.rb
+++ b/dashboard/test/controllers/home_controller_test.rb
@@ -461,20 +461,15 @@ class HomeControllerTest < ActionController::TestCase
   test "home page topCourse uses correct unit_group when UserScript has different unit_group than script original_unit_group" do
     student = create(:student)
 
-    # Create two unit groups for the same script
-    original_unit_group = create(:unit_group, name: 'original-course', published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.stable)
-    different_unit_group = create(:unit_group, name: 'different-course', published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.stable)
-
-    script = create(:script, :with_levels, original_unit_group: original_unit_group)
-
-    # Add the script to both unit groups
-    create(:unit_group_unit, unit_group: original_unit_group, script: script, position: 1)
-    create(:unit_group_unit, unit_group: different_unit_group, script: script, position: 2)
-    script.reload
+    # Create two unit groups for the same unit
+    unit = create(:script, :with_levels)
+    create(:single_unit_course, :stable, unit: unit)
+    other_unit_group = create(:single_unit_course, :stable)
+    create(:unit_group_unit, unit_group: other_unit_group, script: unit, position: 2)
 
     # Create a user_script with the different unit_group (not the original)
     # Use the UserScript.find_and_migrate_or_create_by! method to ensure unit_group is set properly
-    user_script = UserScript.find_and_migrate_or_create_by!(user_id: student.id, unit: script, unit_group: different_unit_group)
+    user_script = UserScript.find_and_migrate_or_create_by!(user_id: student.id, unit: unit, unit_group: other_unit_group)
     user_script.update!(started_at: Time.now)
 
     sign_in student
@@ -484,9 +479,9 @@ class HomeControllerTest < ActionController::TestCase
     refute_nil assigns(:homepage_data)[:topCourse]
     top_course = assigns(:homepage_data)[:topCourse]
 
-    # Verify the links use the different_unit_group, not the original_unit_group
-    assert_equal "/courses/different-course/units/2", top_course[:linkToOverview]
-    assert_equal "/courses/different-course/units/2/next", top_course[:linkToLesson]
+    # Verify the links use the other_unit_group, not the original_unit_group
+    assert_equal "/courses/#{other_unit_group.name}/units/2", top_course[:linkToOverview]
+    assert_equal "/courses/#{other_unit_group.name}/units/2/next", top_course[:linkToLesson]
   end
 
   test "home page courses data comes from courses_as_participant" do

--- a/dashboard/test/integration/home_test.rb
+++ b/dashboard/test/integration/home_test.rb
@@ -33,4 +33,176 @@ class HomeTest < ActionDispatch::IntegrationTest
       assert_nil data['section']['secret_words']
     end
   end
+
+  test 'student home shows no topCourse or courses initially' do
+    student = create(:student)
+    sign_in student
+
+    get '/home'
+    assert_response :success
+
+    assert_select 'script[data-homepage]' do |elements|
+      data = JSON.parse(elements.first['data-homepage'])
+      assert_nil data['topCourse'], 'topCourse should be nil initially'
+      assert_empty data['courses'], 'courses should be empty initially'
+    end
+  end
+
+  test 'student home shows topCourse and courses after milestone in original course' do
+    # Create a unit with levels
+    unit = create(:unit, :with_levels)
+
+    # Create two single_unit_courses for the same unit with stable published state
+    original_course = create(:single_unit_course, :stable, unit: unit)
+    create(:single_unit_course, :stable, unit: unit)
+
+    # Create and sign in as student
+    student = create(:student)
+    sign_in student
+
+    # Get a script_level from the unit for milestone posts
+    script_level = unit.script_levels.first
+    level = script_level.oldest_active_level
+
+    # Post milestone for the level in the context of original course
+    post "/milestone/0/#{script_level.id}", params: {
+      course_id: original_course.id,
+      level_id: level.id,
+      result: 'true',
+      testResult: 100,
+      program: '<xml/>'
+    }
+    assert_response :success
+
+    # Hit home controller and verify topCourse and courses are set
+    get '/home'
+    assert_response :success
+
+    assert_select 'script[data-homepage]' do |elements|
+      data = JSON.parse(elements.first['data-homepage'])
+
+      # Verify topCourse is set and references the unit/course
+      refute_nil data['topCourse'], 'topCourse should be set after milestone'
+      assert_includes data['topCourse']['linkToOverview'], original_course.name
+
+      # Verify courses array contains the course
+      refute_empty data['courses'], 'courses should not be empty after milestone'
+      course_names = data['courses'].map {|c| c['link']}.compact
+      assert course_names.any? {|link| link.include?(original_course.name)},
+        'courses should include the original course'
+    end
+  end
+
+  test 'student home shows topCourse and courses after milestone in other course' do
+    # Create a unit with levels
+    unit = create(:unit, :with_levels)
+
+    # Create two single_unit_courses for the same unit with stable published state
+    create(:single_unit_course, :stable, unit: unit)
+    other_course = create(:single_unit_course, :stable, unit: unit)
+
+    # Create and sign in as student
+    student = create(:student)
+    sign_in student
+
+    # Get a script_level from the unit for milestone posts
+    script_level = unit.script_levels.first
+    level = script_level.oldest_active_level
+
+    # Post milestone for the level in the context of other course
+    post "/milestone/0/#{script_level.id}", params: {
+      course_id: other_course.id,
+      level_id: level.id,
+      result: 'true',
+      testResult: 100,
+      program: '<xml/>'
+    }
+    assert_response :success
+
+    # Hit home controller and verify topCourse and courses are set
+    get '/home'
+    assert_response :success
+
+    assert_select 'script[data-homepage]' do |elements|
+      data = JSON.parse(elements.first['data-homepage'])
+
+      # Verify topCourse is set and references the unit/other course
+      refute_nil data['topCourse'], 'topCourse should be set after milestone'
+      assert_includes data['topCourse']['linkToOverview'], other_course.name
+
+      # Verify courses array contains the course
+      refute_empty data['courses'], 'courses should not be empty after milestone'
+      course_names = data['courses'].map {|c| c['link']}.compact
+      assert course_names.any? {|link| link.include?(other_course.name)},
+        'courses should include the other course'
+    end
+  end
+
+  test 'student home shows all courses after milestones in multiple courses' do
+    Timecop.freeze do
+      # Create two units with levels
+      unit1 = create(:unit, :with_levels)
+      unit2 = create(:unit, :with_levels)
+
+      # Create single_unit_courses with stable published state
+      course1 = create(:single_unit_course, :stable, unit: unit1)
+      course2 = create(:single_unit_course, :stable, unit: unit2)
+
+      # Create and sign in as student
+      student = create(:student)
+      sign_in student
+
+      # Post milestone for first course
+      script_level1 = unit1.script_levels.first
+      level1 = script_level1.oldest_active_level
+      post "/milestone/0/#{script_level1.id}", params: {
+        course_id: course1.id,
+        level_id: level1.id,
+        result: 'true',
+        testResult: 100,
+        program: '<xml/>'
+      }
+      assert_response :success
+
+      # Move time forward to make the second milestone more recent
+      Timecop.travel 1.hour
+
+      # Post milestone for second course
+      script_level2 = unit2.script_levels.first
+      level2 = script_level2.oldest_active_level
+      post "/milestone/0/#{script_level2.id}", params: {
+        course_id: course2.id,
+        level_id: level2.id,
+        result: 'true',
+        testResult: 100,
+        program: '<xml/>'
+      }
+      assert_response :success
+
+      # Hit home controller and verify both courses are shown
+      get '/home'
+      assert_response :success
+
+      assert_select 'script[data-homepage]' do |elements|
+        data = JSON.parse(elements.first['data-homepage'])
+
+        # Verify topCourse is set to the most recent course (course2)
+        refute_nil data['topCourse'], 'topCourse should be set after milestones'
+        assert_includes data['topCourse']['linkToOverview'], course2.name,
+          'topCourse should be the most recently accessed course (course2)'
+
+        # Verify courses array contains both courses
+        assert_equal 2, data['courses'].length, 'courses should contain exactly 2 courses'
+        course_links = data['courses'].map {|c| c['link']}.compact
+        puts "course_links: #{course_links.inspect}"
+
+        assert course_links.any? {|link| link.include?(course1.name)},
+          'courses should include a link to the first course'
+        assert course_links.any? {|link| link.include?(course2.name)},
+          'courses should include a link to the second course'
+      end
+    end
+  ensure
+    Timecop.return
+  end
 end

--- a/dashboard/test/lib/queries/script_activity_test.rb
+++ b/dashboard/test/lib/queries/script_activity_test.rb
@@ -16,13 +16,10 @@ class Queries::ScriptActivityTest < ActiveSupport::TestCase
 
     # working on scripts
     assert_equal [s2.script, s1.script], Queries::ScriptActivity.working_on_student_units(@user)
-    # primary script -- most recently progressed in
-    assert_equal s2.script, Queries::ScriptActivity.primary_student_unit(@user)
 
     # add an assigned script that's more recent
     a = create(:user_script, user: @user, started_at: (Time.now - 1.day))
     assert_equal [a.script, s2.script, s1.script], Queries::ScriptActivity.working_on_student_units(@user)
-    assert_equal a.script, Queries::ScriptActivity.primary_student_unit(@user)
 
     unit_group = create(:unit_group, published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.stable)
     course_script = create(:script)
@@ -30,12 +27,90 @@ class Queries::ScriptActivityTest < ActiveSupport::TestCase
     course_script.reload
     create(:user_script, user: @user, started_at: Time.now - 12.hours, script: course_script)
     assert_equal [course_script, a.script, s2.script, s1.script], Queries::ScriptActivity.working_on_student_units(@user)
-    assert_equal course_script, Queries::ScriptActivity.primary_student_unit(@user)
 
     # make progress on an older script
     s1.update_attribute(:last_progress_at, Time.now - 3.hours)
     assert_equal [s1.script, course_script, a.script, s2.script], Queries::ScriptActivity.working_on_student_units(@user)
-    assert_equal s1.script, Queries::ScriptActivity.primary_student_unit(@user)
+  end
+
+  test 'primary_student_unit_context returns correct unit and unit_group_unit' do
+    # Create scripts without original_unit_group so unit_group_unit will be nil
+    s1 = create(:user_script, user: @user, script: create(:script), started_at: (Time.now - 10.days), last_progress_at: (Time.now - 4.days))
+    s2 = create(:user_script, user: @user, script: create(:script), started_at: (Time.now - 50.days), last_progress_at: (Time.now - 3.days))
+
+    # primary unit context -- most recently progressed in
+    context = Queries::ScriptActivity.primary_student_unit_context(@user)
+    assert_equal s2.script, context[:unit]
+    assert_nil context[:unit_group_unit]
+
+    # add a script with a unit_group
+    unit_group = create(:unit_group, published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.stable)
+    course_script = create(:script)
+    unit_group_unit = create(:unit_group_unit, unit_group: unit_group, script: course_script, position: 1)
+    course_script.reload
+    create(:user_script, user: @user, started_at: Time.now - 12.hours, script: course_script, unit_group: unit_group)
+
+    context = Queries::ScriptActivity.primary_student_unit_context(@user)
+    assert_equal course_script, context[:unit]
+    assert_equal unit_group_unit, context[:unit_group_unit]
+
+    # make progress on an older script
+    s1.update_attribute(:last_progress_at, Time.now - 3.hours)
+    context = Queries::ScriptActivity.primary_student_unit_context(@user)
+    assert_equal s1.script, context[:unit]
+    assert_nil context[:unit_group_unit]
+  end
+
+  test 'primary_student_unit_context with UserScript unit_group different from script original_unit_group' do
+    original_unit_group = create(:unit_group, name: 'original-course', published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.stable)
+    different_unit_group = create(:unit_group, name: 'different-course', published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.stable)
+    script = create(:script, original_unit_group: original_unit_group)
+
+    create(:unit_group_unit, unit_group: original_unit_group, script: script, position: 1)
+    different_ugu = create(:unit_group_unit, unit_group: different_unit_group, script: script, position: 1)
+    script.reload
+
+    # Create a user_script with the different unit_group (not the original)
+    user_script = UserScript.find_and_migrate_or_create_by!(user_id: @user.id, unit: script, unit_group: different_unit_group)
+    user_script.update!(started_at: Time.now)
+
+    context = Queries::ScriptActivity.primary_student_unit_context(@user)
+    assert_equal script, context[:unit]
+    # Should return the unit_group_unit for the different_unit_group, not the original
+    assert_equal different_ugu, context[:unit_group_unit]
+    assert_equal different_unit_group, context[:unit_group_unit].unit_group
+  end
+
+  test 'primary_student_unit_context returns nil when user has no activity' do
+    context = Queries::ScriptActivity.primary_student_unit_context(@user)
+    assert_nil context
+  end
+
+  test 'primary_student_unit_context handles multiple user_scripts with different progress' do
+    unit_group_1 = create(:unit_group, name: 'course-1', published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.stable)
+    unit_group_2 = create(:unit_group, name: 'course-2', published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.stable)
+
+    script_1 = create(:script)
+    script_2 = create(:script)
+
+    create(:unit_group_unit, unit_group: unit_group_1, script: script_1, position: 1)
+    ugu_2 = create(:unit_group_unit, unit_group: unit_group_2, script: script_2, position: 1)
+
+    script_1.reload
+    script_2.reload
+
+    # Create user_scripts with different progress times
+    us1 = UserScript.find_and_migrate_or_create_by!(user_id: @user.id, unit: script_1, unit_group: unit_group_1)
+    us1.update!(started_at: Time.now - 2.days, last_progress_at: Time.now - 2.days)
+
+    us2 = UserScript.find_and_migrate_or_create_by!(user_id: @user.id, unit: script_2, unit_group: unit_group_2)
+    us2.update!(started_at: Time.now - 1.day, last_progress_at: Time.now - 1.day)
+
+    # Should return the most recently progressed script's context
+    context = Queries::ScriptActivity.primary_student_unit_context(@user)
+    assert_equal script_2, context[:unit]
+    assert_equal ugu_2, context[:unit_group_unit]
+    assert_equal unit_group_2, context[:unit_group_unit].unit_group
   end
 
   test 'user is working on pl scripts' do

--- a/dashboard/test/models/concerns/user/assigned_courses_and_scripts_test.rb
+++ b/dashboard/test/models/concerns/user/assigned_courses_and_scripts_test.rb
@@ -55,7 +55,7 @@ class AssignedCoursesAndScripts < ActiveSupport::TestCase
       end
     end
 
-    context 'when the user has progress in a standalone unit' do
+    context 'when the user has progress in a single-unit course' do
       let(:user) {create(:student)}
       let(:course) {create(:single_unit_course, :stable)}
       let(:unit) {course.first_unit}

--- a/dashboard/test/models/concerns/user/assigned_courses_and_scripts_test.rb
+++ b/dashboard/test/models/concerns/user/assigned_courses_and_scripts_test.rb
@@ -3,17 +3,17 @@ require 'test_helper'
 class AssignedCoursesAndScripts < ActiveSupport::TestCase
   include Minitest::RSpecMocks
 
-  let(:student) {create(:student)}
+  let(:assigned_student) {create(:student)}
   let(:teacher) {create(:teacher)}
   let(:section) {create(:section, user_id: teacher.id, unit_group: unit_group)}
   let(:unit_group) {create(:unit_group, name: 'course')}
 
   before do
-    Follower.create!(section_id: section.id, student_user_id: student.id, user: teacher)
+    Follower.create!(section_id: section.id, student_user_id: assigned_student.id, user: teacher)
   end
 
   describe '#assigned_courses' do
-    subject(:assigned_courses) {student.assigned_courses}
+    subject(:assigned_courses) {assigned_student.assigned_courses}
     context 'when the student is assigned to a course' do
       it 'returns the course data for the assigned course' do
         _(assigned_courses.length).must_equal 1
@@ -25,22 +25,21 @@ class AssignedCoursesAndScripts < ActiveSupport::TestCase
   describe '#assigned_course?' do
     context 'when the student is assigned to the course' do
       it 'returns true' do
-        _(student.assigned_course?(unit_group)).must_equal true
+        _(assigned_student.assigned_course?(unit_group)).must_equal true
       end
     end
 
     context 'when the student is not assigned to the course' do
       let(:another_course) {create(:unit_group, name: 'another-course')}
       it 'returns false' do
-        _(student.assigned_course?(another_course)).must_equal false
+        _(assigned_student.assigned_course?(another_course)).must_equal false
       end
     end
   end
 
   describe '#courses_as_participant' do
-    subject(:courses_as_participant) {student.courses_as_participant}
-
     context 'when the student is assigned a course' do
+      subject(:courses_as_participant) {assigned_student.courses_as_participant}
       it 'returns the course as a participant' do
         _(courses_as_participant.length).must_equal 1
         _(courses_as_participant.first.name).must_equal 'course'
@@ -49,7 +48,7 @@ class AssignedCoursesAndScripts < ActiveSupport::TestCase
   end
 
   describe '#any_visible_assigned_scripts?' do
-    subject(:any_visible_assigned_scripts?) {student.any_visible_assigned_scripts?}
+    subject(:any_visible_assigned_scripts?) {assigned_student.any_visible_assigned_scripts?}
     let(:visible_script) {create(:script, :in_single_unit_course, published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.stable)}
     let(:hidden_script) {create(:script, :in_single_unit_course, published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.beta)}
 
@@ -61,8 +60,8 @@ class AssignedCoursesAndScripts < ActiveSupport::TestCase
 
     context 'when the student has assigned scripts' do
       before do
-        student.assign_script(visible_script)
-        student.assign_script(hidden_script)
+        assigned_student.assign_script(visible_script)
+        assigned_student.assign_script(hidden_script)
       end
 
       it 'returns true if there are visible scripts' do
@@ -71,7 +70,7 @@ class AssignedCoursesAndScripts < ActiveSupport::TestCase
     end
 
     context 'when the student has only hidden scripts' do
-      before {student.assign_script(hidden_script)}
+      before {assigned_student.assign_script(hidden_script)}
       it 'returns false' do
         _(any_visible_assigned_scripts?).must_equal false
       end

--- a/dashboard/test/models/concerns/user/assigned_courses_and_scripts_test.rb
+++ b/dashboard/test/models/concerns/user/assigned_courses_and_scripts_test.rb
@@ -45,6 +45,124 @@ class AssignedCoursesAndScripts < ActiveSupport::TestCase
         _(courses_as_participant.first.name).must_equal assigned_course.name
       end
     end
+
+    context 'when the user has no progress or section courses' do
+      let(:user) {create(:student)}
+      subject(:courses_as_participant) {user.courses_as_participant}
+
+      it 'returns an empty array' do
+        _(courses_as_participant).must_equal []
+      end
+    end
+
+    context 'when the user has progress in a standalone unit' do
+      let(:user) {create(:student)}
+      let(:course) {create(:single_unit_course, :stable)}
+      let(:unit) {course.first_unit}
+      subject(:courses_as_participant) {user.courses_as_participant}
+
+      before do
+        user.assign_script(unit)
+      end
+
+      it 'returns the course via original_unit_group' do
+        _(courses_as_participant.length).must_equal 1
+        _(courses_as_participant.first.name).must_equal course.name
+      end
+    end
+
+    context 'when a unit belongs to multiple courses' do
+      let(:user) {create(:student)}
+      let(:original_course) {create(:single_unit_course, :stable)}
+      let(:unit) {original_course.first_unit}
+      let(:progress_course) {create(:single_unit_course, :stable, unit: unit)}
+      subject(:courses_as_participant) {user.courses_as_participant}
+
+      before do
+        user.assign_script(unit, progress_course)
+      end
+
+      it 'returns the progress course when user_script has explicit unit_group' do
+        _(courses_as_participant.length).must_equal 1
+        _(courses_as_participant.first.name).must_equal progress_course.name
+      end
+    end
+
+    context 'when user has both section courses and progress courses' do
+      let(:user) {create(:student)}
+      let(:teacher) {create(:teacher)}
+      let(:section_course) {create(:single_unit_course, :stable)}
+      let(:progress_course) {create(:single_unit_course, :stable)}
+      let(:section) {create(:section, user_id: teacher.id, unit_group: section_course)}
+      subject(:courses_as_participant) {user.courses_as_participant}
+
+      before do
+        # User is in a section for section_course
+        Follower.create!(section_id: section.id, student_user_id: user.id, user: teacher)
+        # User also has independent progress in progress_course
+        user.assign_script(progress_course.first_unit)
+      end
+
+      it 'returns both courses' do
+        _(courses_as_participant.length).must_equal 2
+        course_names = courses_as_participant.map(&:name)
+        _(course_names).must_include section_course.name
+        _(course_names).must_include progress_course.name
+      end
+
+      context 'when the section course and progress course are the same' do
+        before do
+          # Also add progress in the section course
+          user.assign_script(section_course.first_unit)
+        end
+
+        it 'deduplicates and returns unique courses' do
+          _(courses_as_participant.length).must_equal 2
+          course_names = courses_as_participant.map(&:name)
+          _(course_names).must_include section_course.name
+          _(course_names).must_include progress_course.name
+        end
+      end
+    end
+
+    context 'when user has progress in non-launched courses' do
+      let(:user) {create(:student)}
+      let(:launched_course) {create(:single_unit_course, :stable)}
+      let(:non_launched_course) {create(:single_unit_course)}
+      subject(:courses_as_participant) {user.courses_as_participant}
+
+      before do
+        user.assign_script(launched_course.first_unit)
+        user.assign_script(non_launched_course.first_unit)
+      end
+
+      it 'filters out non-launched courses' do
+        _(courses_as_participant.length).must_equal 1
+        _(courses_as_participant.first.name).must_equal launched_course.name
+      end
+    end
+
+    context 'when user has multiple user_scripts with different courses' do
+      let(:user) {create(:student)}
+      let(:course_1) {create(:single_unit_course, :stable)}
+      let(:course_2) {create(:single_unit_course, :stable)}
+      let(:course_3) {create(:single_unit_course, :stable)}
+      subject(:courses_as_participant) {user.courses_as_participant}
+
+      before do
+        user.assign_script(course_1.first_unit)
+        user.assign_script(course_2.first_unit)
+        user.assign_script(course_3.first_unit)
+      end
+
+      it 'returns all unique launched courses' do
+        _(courses_as_participant.length).must_equal 3
+        course_names = courses_as_participant.map(&:name)
+        _(course_names).must_include course_1.name
+        _(course_names).must_include course_2.name
+        _(course_names).must_include course_3.name
+      end
+    end
   end
 
   describe '#any_visible_assigned_scripts?' do

--- a/dashboard/test/models/concerns/user/assigned_courses_and_scripts_test.rb
+++ b/dashboard/test/models/concerns/user/assigned_courses_and_scripts_test.rb
@@ -48,24 +48,6 @@ class AssignedCoursesAndScripts < ActiveSupport::TestCase
     end
   end
 
-  describe '#visible_scripts' do
-    subject(:visible_scripts) {student.visible_scripts}
-    let(:visible_script) {create(:script, :in_single_unit_course, published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.stable)}
-    let(:hidden_script) {create(:script, :in_single_unit_course, published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.beta)}
-
-    context 'when the student is assigned scripts' do
-      before do
-        student.assign_script(visible_script)
-        student.assign_script(hidden_script)
-      end
-
-      it 'only returns the script visible script' do
-        _(visible_scripts.length).must_equal 1
-        _(visible_scripts.first).must_equal visible_script
-      end
-    end
-  end
-
   describe '#any_visible_assigned_scripts?' do
     subject(:any_visible_assigned_scripts?) {student.any_visible_assigned_scripts?}
     let(:visible_script) {create(:script, :in_single_unit_course, published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.stable)}
@@ -498,34 +480,16 @@ class AssignedCoursesAndScripts < ActiveSupport::TestCase
     end
 
     describe '#recent_student_courses_and_units' do
-      subject(:recent_student_courses_and_units) {student.recent_student_courses_and_units(false)}
+      subject(:recent_student_courses_and_units) {student.recent_student_courses_and_units}
 
       it 'returns both courses and scripts' do
-        _(recent_student_courses_and_units.length).must_equal 2
+        _(recent_student_courses_and_units.length).must_equal 1
         course_data = recent_student_courses_and_units.first
-        script_data = recent_student_courses_and_units.last
 
         _(course_data[:name]).must_equal 'csd'
         _(course_data[:title]).must_equal 'Computer Science Discoveries'
         _(course_data[:description]).must_equal 'CSD short description'
         _(course_data[:link]).must_equal '/courses/csd'
-
-        _(script_data[:name]).must_equal 'other'
-        _(script_data[:title]).must_equal 'Unit Other'
-        _(script_data[:description]).must_equal 'other-description'
-        _(script_data[:link]).must_equal '/s/other'
-      end
-
-      it 'does not return student scripts that are in returned student courses' do
-        script = Unit.find_by_name('csd1')
-        student.assign_script(script)
-
-        _(recent_student_courses_and_units.length).must_equal 2
-        _(recent_student_courses_and_units.pluck(:title)).must_equal [
-          'Computer Science Discoveries',
-          'Unit Other'
-        ]
-        _(recent_student_courses_and_units.pluck(:name)).wont_include 'csd1'
       end
     end
   end

--- a/dashboard/test/models/concerns/user/assigned_courses_and_scripts_test.rb
+++ b/dashboard/test/models/concerns/user/assigned_courses_and_scripts_test.rb
@@ -592,12 +592,12 @@ class AssignedCoursesAndScripts < ActiveSupport::TestCase
       end
     end
 
-    describe '#recent_student_courses_and_units' do
-      subject(:recent_student_courses_and_units) {student.recent_student_courses_and_units}
+    describe '#recent_student_courses' do
+      subject(:recent_student_courses) {student.recent_student_courses}
 
       it 'returns both courses and scripts' do
-        _(recent_student_courses_and_units.length).must_equal 1
-        course_data = recent_student_courses_and_units.first
+        _(recent_student_courses.length).must_equal 1
+        course_data = recent_student_courses.first
 
         _(course_data[:name]).must_equal 'csd'
         _(course_data[:title]).must_equal 'Computer Science Discoveries'

--- a/dashboard/test/models/concerns/user/assigned_courses_and_scripts_test.rb
+++ b/dashboard/test/models/concerns/user/assigned_courses_and_scripts_test.rb
@@ -5,8 +5,8 @@ class AssignedCoursesAndScripts < ActiveSupport::TestCase
 
   let(:assigned_student) {create(:student)}
   let(:teacher) {create(:teacher)}
-  let(:section) {create(:section, user_id: teacher.id, unit_group: unit_group)}
-  let(:unit_group) {create(:unit_group, name: 'course')}
+  let(:assigned_course) {create(:single_unit_course)}
+  let(:section) {create(:section, user_id: teacher.id, unit_group: assigned_course)}
 
   before do
     Follower.create!(section_id: section.id, student_user_id: assigned_student.id, user: teacher)
@@ -17,7 +17,7 @@ class AssignedCoursesAndScripts < ActiveSupport::TestCase
     context 'when the student is assigned to a course' do
       it 'returns the course data for the assigned course' do
         _(assigned_courses.length).must_equal 1
-        _(assigned_courses.first[:name]).must_equal 'course'
+        _(assigned_courses.first[:name]).must_equal assigned_course.name
       end
     end
   end
@@ -25,14 +25,14 @@ class AssignedCoursesAndScripts < ActiveSupport::TestCase
   describe '#assigned_course?' do
     context 'when the student is assigned to the course' do
       it 'returns true' do
-        _(assigned_student.assigned_course?(unit_group)).must_equal true
+        _(assigned_student.assigned_course?(assigned_course)).must_equal true
       end
     end
 
     context 'when the student is not assigned to the course' do
-      let(:another_course) {create(:unit_group, name: 'another-course')}
+      let(:another_unit_group) {create(:single_unit_course)}
       it 'returns false' do
-        _(assigned_student.assigned_course?(another_course)).must_equal false
+        _(assigned_student.assigned_course?(another_unit_group)).must_equal false
       end
     end
   end
@@ -42,7 +42,7 @@ class AssignedCoursesAndScripts < ActiveSupport::TestCase
       subject(:courses_as_participant) {assigned_student.courses_as_participant}
       it 'returns the course as a participant' do
         _(courses_as_participant.length).must_equal 1
-        _(courses_as_participant.first.name).must_equal 'course'
+        _(courses_as_participant.first.name).must_equal assigned_course.name
       end
     end
   end
@@ -82,17 +82,15 @@ class AssignedCoursesAndScripts < ActiveSupport::TestCase
     let(:single_unit_course) {create(:single_unit_course)}
     let(:single_script) {single_unit_course.first_unit}
     let(:section_1) {create(:section, script: single_script, unit_group: single_unit_course)}
-    let(:section_2) {create(:section, unit_group: unit_group)}
-    let(:unit_group_unit) {create(:script)}
+    let(:section_2) {create(:section, unit_group: assigned_course)}
     before do
-      create(:unit_group_unit, unit_group: unit_group, script: unit_group_unit, position: 1)
       section_1.students << user
       section_2.students << user
     end
     describe '#assigned_script?' do
       context 'when the user is assigned a script' do
         subject(:assigned_script?) {user.assigned_script?(single_script)}
-        subject(:assigned_script_course?) {user.assigned_script?(unit_group.first_unit)}
+        subject(:assigned_script_course?) {user.assigned_script?(assigned_course.first_unit)}
 
         it 'returns true' do
           _(assigned_script?).must_equal true
@@ -117,7 +115,7 @@ class AssignedCoursesAndScripts < ActiveSupport::TestCase
         it 'returns all assigned and default scripts' do
           _(section_scripts.length).must_equal 2
           _(section_scripts).must_include single_script
-          _(section_scripts).must_include unit_group_unit
+          _(section_scripts).must_include assigned_course.first_unit
         end
       end
     end
@@ -126,17 +124,15 @@ class AssignedCoursesAndScripts < ActiveSupport::TestCase
   describe '#most_recently_assigned_unit_group_unit' do
     let(:user) {create(:student)}
     let(:section_1) {create(:section, unit_group: unit_group)}
-    let(:unit_group_unit) {create(:script)}
     subject(:most_recently_assigned_unit_group_unit) {user.most_recently_assigned_unit_group_unit}
 
     before do
-      create(:unit_group_unit, unit_group: unit_group, script: unit_group_unit, position: 1)
-      user.assign_script(unit_group_unit)
+      user.assign_script(assigned_course.first_unit)
     end
 
     context 'when the user has assigned scripts' do
       it 'returns the most recently assigned unit group unit' do
-        _(user.most_recently_assigned_unit_group_unit).must_equal unit_group.default_unit_group_units.first
+        _(user.most_recently_assigned_unit_group_unit).must_equal assigned_course.default_unit_group_units.first
       end
     end
 


### PR DESCRIPTION
* Finishes https://codedotorg.atlassian.net/browse/TEACH-1556. 
* Follows https://github.com/code-dot-org/code-dot-org/pull/67766 
* terminology and background cheat sheet ([slack](https://codedotorg.slack.com/archives/C045UAX4WKH/p1760463260455889))

In a nutshell, this PR starts passing accurate unit group info to the RecentCourses section of the student homepage, ensuring that progress made in modular courses recently (since #67766) causes the modular course rather than the original course to appear.

## Screenshots

previously, a student who made progress in a modular course would see the original course on their homepage:
<img width="1254" height="840" alt="my-courses-before" src="https://github.com/user-attachments/assets/a260bed4-0f0a-4db1-8042-84cdc5ff219d" />

with this PR, the student will now see the modular course:
<img width="1256" height="845" alt="Screenshot 2025-10-14 at 11 38 30 AM" src="https://github.com/user-attachments/assets/a4114133-3de7-4ccf-8ef4-3d670a765639" />

## Caveats

Note that even with this PR, we could still show the wrong My Courses tile for progress that was made after the launch of Modular courses on 2025-05-01 and before the launch of #67766 on 2025-10-04. This is because:
* when we launched modular courses on 05-01, we kept writing `nil` values for `user_scripts.unit_group_id`
* #67766 started writing the `user_scripts.unit_group_id` field only for new creates/updates to the `user_scripts` table, but we did not do a comprehensive backfill at that time. discussion [here](https://codedotorg.slack.com/archives/C068ZAMH7TL/p1759772275383449)
* this PR still assumes that any `nil` values for `user_script.unit_group` should refer to the original unit group
* therefore, a student who last had assignment to / progress in a modular course between May and September will still see the original course card rather than the modular course card. 

There are currently ~600K UserScript objects for units which are in more than one course for which we cannot definitively determine the correct unit group. Of these, it seems resaonable to assume that a relatively small fraction (<10%?) were actually made in a modular course and are now misattributed to the original course. See analysis below.
 
Fortunately, the following workarounds exist to make the correct course cards appear: 
- teacher unassigns then reassigns the section to the course
- student makes progress in the modular course

## Testing story
- manual testing shown in screenshots
- extensive new unit tests
- in place of UI tests, this PR adds a rails integration test which covers the scenario where a student makes progress (via milestone posts) and then views the homepage

## Analysis

for the curious, here is a breakdown by unit name of the number of user_script objects for which we cannot accurately determine whether the user_script should belong to the original course or a modular course. because the original versions of CSD and AIF are so much more popular than their modular counterparts (citation needed), it seems reasonable to assume in the code that more often than not these represent progress created in the original course.

```
mysql> SELECT   COUNT(us.id) AS num FROM   user_scripts us   JOIN scripts s ON us.script_id = s.id WHERE   us.script_id IN (     142704,589888,803203,803215,803230,803243,803257,803278,803281,     803286,803529,803531,847148,847149,847150,847151,847152,847153,917885   )   AND us.updated_at > '2025-05-01' AND us.updated_at < '2025-10-04' ;
+--------+
| num    |
+--------+
| 588569 |
+--------+
1 row in set (1.96 sec)

mysql> SELECT   s.name,   COUNT(us.id) AS num FROM   user_scripts us   JOIN scripts s ON us.script_id = s.id WHERE   us.script_id IN (...)   AND us.updated_at > '2025-05-01' AND us.updated_at < '2025-10-04' GROUP BY   s.name ORDER BY   num DESC;
+---------------------------------+--------+
| name                            | num    |
+---------------------------------+--------+
| csd1-2025                       | 177433 |
| csd2-2025                       |  87470 |
| csd7-2025                       |  74854 |
| csd3-2025                       |  48185 |
| aif1-2025                       |  45444 |
| programming-with-music-lab-2025 |  21415 |
| aif3-2025                       |  21072 |
| csd4-2025                       |  20470 |
| aif2-2025                       |  16325 |
| csd6b-2025                      |  16046 |
| csd5-2025                       |  14846 |
| csd6a-2025                      |  14047 |
| exploring-gen-ai1-2025          |   8587 |
| aif5-2025                       |   7226 |
| aif4-2025                       |   5981 |
| aif6-2025                       |   3573 |
| exploring-gen-ai2-2025          |   2950 |
| csd5-2023                       |   2503 |
| k5gettingstarted                |    140 |
+---------------------------------+--------+
19 rows in set (2.09 sec)
```
where `us.script_id IN (...)` is a list of the ids of the ~20 units in modular courses.