### PR TITLE
[HOAI] Use new default generated dancer

### DIFF
--- a/apps/src/dance/lottie/LottieDancerUtils.ts
+++ b/apps/src/dance/lottie/LottieDancerUtils.ts
@@ -30,11 +30,11 @@ const BASE_HOST = 'https://curriculum.code.org/media/musiclab/generate';
 const DEFAULT_HEAD_W = 1024;
 const DEFAULT_HEAD_H = 1024;
 
-const ASSETS_FOLDER = 'basic2';
-const TEST_GENERATED_DANCER = 'basic-frog-baseball-cap-00';
+const DEFAULT_PATH = 'default';
+const DEFAULT_DANCER = 'default';
 
-const DEFAULT_HEAD_URL = `${BASE_HOST}/dancer/${ASSETS_FOLDER}/${TEST_GENERATED_DANCER}.png`;
-const DEFAULT_METADATA_URL = `${BASE_HOST}/dancer/${ASSETS_FOLDER}/${TEST_GENERATED_DANCER}-metadata.json`;
+const DEFAULT_HEAD_URL = `${BASE_HOST}/dancer/${DEFAULT_PATH}/${DEFAULT_DANCER}.png`;
+const DEFAULT_METADATA_URL = `${BASE_HOST}/dancer/${DEFAULT_PATH}/${DEFAULT_DANCER}-metadata.json`;
 
 export const getConfigValue = (name: string) =>
   queryParams(name) as string | undefined;


### PR DESCRIPTION
Request from @dju90:

> One of the things we're testing out this week is having a couple dance party levels before each "stage." Having it as [the very first level](https://levelbuilder-studio.code.org/courses/hoai-pilot-6/units/1/lessons/1/levels/2) will give students context on what a dance party is before they start making it their own...and also shows how boring it can be without their efforts. To this end, if we provide a plain gray head and torso png, I'm assuming it would be possible to recolor the arms and legs plain gray as well...?
> Is it also possible to set this as the only available dancer in level 2, before the student has created any custom dancer (that comes after)

A new default dancer head with metadata has been uploaded to S3. This simply updates the Lottie renderer utils to point to it for a default dancer, ie. when they haven't generated one yet themselves. The metadata includes a single gray body color which is used for all re-coloring. Note that the custom Lottie renderer doesn't yet touch dancer torsos, so the blue zip-up on the torso is expected.

To see the new dancer in a dance level, the level must use the blocks from the new `GeneratedDancers` block pool. The user should also _not_ have any generated dancer options saved in local storage, as those will always override the default.

This dancer can already be used in any Dance or Music level by appending `?dancer=default&path=default`. Now, no URL parameters are needed.

Resting default dancer on blank Dance Party canvas:

<img width="800" height="800" alt="image" src="https://github.com/user-attachments/assets/48f6fb32-8630-44b5-9d6a-30b5b8821286" />

Blocks with updated head image:
<img width="326" height="181" alt="image" src="https://github.com/user-attachments/assets/e2ab7281-67b1-40d2-bae4-2d18278a2085" />


## Links
<!--  Links to relevant external resources.
      - spec docs, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- Jira: 

## Testing story
<!--  Does your change include appropriate tests?
      - If so, please describe how the tests included in this PR are sufficient.
      - If not, please explain why this change does not need to be tested. -->



## Deployment strategy
<!--  Any special steps required to deploy this, besides merging?
      - Are there database migrations or manual steps?
      - Does this require coordination with other teams or systems? -->



## Follow-up work
<!--  List any clean-up or technical debt that will be addressed in future work.
      - Include Jira links where applicable.
      - Are there any known limitations or improvements planned? -->



## Privacy
<!--  How does this change impact Student & Teacher privacy?
      - Does this collect, use, share, or modify PII, either new or existing? -->



## Security
<!--  How does this change impact our security surface-area?
      - Do API's touched have the right auth?
      - Do infra changes impact our attack surface or encryption?
-->



## Caching
<!--  How does this change impact caching behavior?
      - Are cache keys or invalidation strategies affected?
      - Will this require cache warming or invalidation after deployment? -->



## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
