### PR TITLE
feat(broad tutor): add index on user and project for aichat_events

### DIFF
--- a/dashboard/app/models/aichat_event.rb
+++ b/dashboard/app/models/aichat_event.rb
@@ -15,6 +15,7 @@
 # Indexes
 #
 #  index_ace_user_level_script        (user_id,level_id,script_id)
+#  index_ace_user_project             (user_id,project_id)
 #  index_aichat_events_on_request_id  (request_id)
 #
 class AichatEvent < ApplicationRecord

--- a/dashboard/db/migrate/20251013190700_add_index_to_aichat_events_user_project.rb
+++ b/dashboard/db/migrate/20251013190700_add_index_to_aichat_events_user_project.rb
@@ -1,0 +1,5 @@
+class AddIndexToAichatEventsUserProject < ActiveRecord::Migration[6.1]
+  def change
+    add_index :aichat_events, [:user_id, :project_id], unique: false, name: 'index_ace_user_project'
+  end
+end

--- a/dashboard/db/schema.rb
+++ b/dashboard/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2025_10_06_144448) do
+ActiveRecord::Schema.define(version: 2025_10_13_190700) do
 
   create_table "activities", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "user_id"
@@ -103,6 +103,7 @@ ActiveRecord::Schema.define(version: 2025_10_06_144448) do
     t.bigint "request_id"
     t.index ["request_id"], name: "index_aichat_events_on_request_id"
     t.index ["user_id", "level_id", "script_id"], name: "index_ace_user_level_script"
+    t.index ["user_id", "project_id"], name: "index_ace_user_project"
   end
 
   create_table "aichat_requests", charset: "utf8mb4", collation: "utf8mb4_bin", force: :cascade do |t|


### PR DESCRIPTION
This pr adds a non-unique index to the `aichat_events` table on `user_id` and `project_id` to clear the way for fetching ai chat history for standalone projects in game lab, web lab, and app lab. Standalone projects do not have a `script_id` or `level_id`, which is how we are fetching chat history currently (existing index is on `user_id`, `script_id`, and `level_id`).

## Links
<!--  Links to relevant external resources.
      - spec docs, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- Jira: https://codedotorg.atlassian.net/browse/LABS-1597

## Testing story
<!--  Does your change include appropriate tests?
      - If so, please describe how the tests included in this PR are sufficient.
      - If not, please explain why this change does not need to be tested. -->
`aichat_events` production table has ~6 million records. I created an adhoc off of a feature branch matching staging (without the migration file) and connected a production db clone. I then cherry picked the commit containing the migration file.
```
ubuntu@adhoc-ryan-aichat-events-index-adhoc-test:~/adhoc$ git show 606806c952ce86252f6f37f1d0f0386571dc08ed
commit 606806c952ce86252f6f37f1d0f0386571dc08ed
Author: Ryan Driscoll <driscollrp@gmail.com>
Date:   Tue Oct 14 09:25:28 2025 -0600

    feat: migration that adds an index on aichat_events table to optimize chat_history queries for standalone projects that have only a user_id and project_id

diff --git a/dashboard/db/migrate/20251013190700_add_index_to_aichat_events_user_project.rb b/dashboard/db/migrate/20251013190700_add_index_to_aichat_events_user_project.rb
new file mode 100644
index 00000000000..0d95ebdb4ae
--- /dev/null
+++ b/dashboard/db/migrate/20251013190700_add_index_to_aichat_events_user_project.rb
@@ -0,0 +1,5 @@
+class AddIndexToAichatEventsUserProject < ActiveRecord::Migration[6.1]
+  def change
+    add_index :aichat_events, [:user_id, :project_id], unique: false, name: 'index_ace_user_project'
+  end
+end
ubuntu@adhoc-ryan-aichat-events-index-adhoc-test:~/adhoc$ git cherry-pick 606806c952ce86252f6f37f1d0f0386571dc08ed
[ryan-aichat-events-index-adhoc-test c8b24dc7485] feat: migration that adds an index on aichat_events table to optimize chat_history queries for standalone projects that have only a user_id and project_id
 Author: Ryan Driscoll <driscollrp@gmail.com>
 Date: Tue Oct 14 09:25:28 2025 -0600
 1 file changed, 5 insertions(+)
 create mode 100644 dashboard/db/migrate/20251013190700_add_index_to_aichat_events_user_project.rb
```

Then I ran the migration `bundle exec rails db:migrate`

```
== 20251013190700 AddIndexToAichatEventsUserProject: migrating ================
-- add_index(:aichat_events, [:user_id, :project_id], {:unique=>false, :name=>"index_ace_user_project"})
   -> 28.3688s
== 20251013190700 AddIndexToAichatEventsUserProject: migrated (28.3689s) ======
```

The migration duration was 28 seconds.


## Deployment strategy
<!--  Any special steps required to deploy this, besides merging?
      - Are there database migrations or manual steps?
      - Does this require coordination with other teams or systems? -->



## Follow-up work
<!--  List any clean-up or technical debt that will be addressed in future work.
      - Include Jira links where applicable.
      - Are there any known limitations or improvements planned? -->
controller method update that constructs the query based on the provided params is here: https://github.com/code-dot-org/code-dot-org/pull/68710



## Privacy
<!--  How does this change impact Student & Teacher privacy?
      - Does this collect, use, share, or modify PII, either new or existing? -->



## Security
<!--  How does this change impact our security surface-area?
      - Do API's touched have the right auth?
      - Do infra changes impact our attack surface or encryption?
-->



## Caching
<!--  How does this change impact caching behavior?
      - Are cache keys or invalidation strategies affected?
      - Will this require cache warming or invalidation after deployment? -->



## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
