### PR TITLE
Web Lab 2: make Desktop and Mobile segmented buttons icon only 

### DIFF
--- a/apps/src/codebridge/FilePreview/HTMLPreviewHeader.tsx
+++ b/apps/src/codebridge/FilePreview/HTMLPreviewHeader.tsx
@@ -50,24 +50,25 @@ export const HTMLPreviewHeader: React.FC<HTMLPreviewHeaderProps> = ({
     color: 'strong',
     buttons: [
       {
-        label: weblab2I18n.desktop(),
-        value: PreviewViewMode.DESKTOP,
-        iconLeft: {
+        icon: {
           iconName: 'desktop',
           iconStyle: 'solid',
+          title: weblab2I18n.desktop(),
         },
+        value: PreviewViewMode.DESKTOP,
       },
       {
-        label: weblab2I18n.mobile(),
-        value: PreviewViewMode.MOBILE,
-        iconLeft: {
+        icon: {
           iconName: 'mobile',
           iconStyle: 'solid',
+          title: weblab2I18n.mobile(),
         },
+        value: PreviewViewMode.MOBILE,
       },
     ],
     size: 'xs',
     selectedButtonValue: previewViewMode,
+    type: 'iconOnly',
     onChange: previewViewMode =>
       setPreviewViewMode(previewViewMode as PreviewViewMode),
   };


### PR DESCRIPTION
Removes the labels on the Desktop and Mobile preview mode segmented buttons in Web Lab 2 since some languages have long translations.

## Links
Jira ticket: [AFL-215](https://codedotorg.atlassian.net/browse/AFL-215)

----

| Before | After |
| ---- | ---- |
| <img width="467" height="217" alt="Screenshot 2025-10-14 at 11 10 02 AM" src="https://github.com/user-attachments/assets/59657a02-7c26-462a-abd7-b4439a89f0cd" /> | <img width="467" height="217" alt="Screenshot 2025-10-14 at 11 10 10 AM" src="https://github.com/user-attachments/assets/5b9acad6-84ad-425d-a462-ee9dfff27157" /> |



https://github.com/user-attachments/assets/ff7f5509-6312-46f8-a343-558e8292753b

