### PR TITLE
Change google link to slack link for increased security

### DIFF
--- a/aws/ci_build
+++ b/aws/ci_build
@@ -172,7 +172,7 @@ def main
       if CDO.test_system?
         DevelopersTopic.set_dtt 'no (robo-DTT failed)'
         msg = "***<@#{DevelopersTopic.dotd}> See instructions in " \
-          "<https://docs.google.com/document/d/1T4gZD6A5jOflEQH0i9_y2VA4trlJTsmdZXWTdGRzGWA/edit?usp=sharing|this document> " \
+          "<https://codedotorg.slack.com/archives/C03CM903Y/p1760475342261049|this document> " \
           "for current guidance on tracking flaky tests.***"
         ChatClient.log msg, color: 'yellow'
       end


### PR DESCRIPTION
See slack thread for discussion: https://codedotorg.slack.com/archives/C03CK49G9/p1760474408710789

Changes a google drive link to a slack link that helps prevent unintentional auth request accepts.
