### PR TITLE
fix(redis_session_store): prevent skipped sessions from being stored as deleted

### DIFF
--- a/dashboard/lib/middlewares/redis_session_store.rb
+++ b/dashboard/lib/middlewares/redis_session_store.rb
@@ -58,19 +58,21 @@ module Middlewares
     # allowing concurrent requests to identify that the session is being deleted and prevent its restoration.
     #
     # @see https://github.com/redis-store/redis-rack/blob/v3.0.0/lib/rack/session/redis.rb#L54
-    def delete_session(req, sid, ...)
+    def delete_session(req, sid, options)
       super
     ensure
-      write_session(req, sid, {deleted: true}, ex: 60) # marks the session as deleted for 60 seconds
-      req.session.delete('deleted') # prevents commiting the "deleted" flag to the renewed session
-      # By default, a deleted session should be renewed, which involves generating a new session ID and cookie for it.
-      # However, since the deleted session is being overwritten with the "deleted" flag, it will bypass the renewal step.
-      # Therefore, we need to manually set the :renew option to force the session to be renewed.
-      # See:
-      # - https://github.com/rack/rack/blob/v2.2.9/lib/rack/session/abstract/id.rb#L217-L218
-      # - https://github.com/rack/rack/blob/v2.2.9/lib/rack/session/abstract/id.rb#L377-L380
-      # - https://github.com/redis-store/redis-rack/blob/v3.0.0/lib/rack/session/redis.rb#L60
-      req.session.options[:renew] = true
+      unless options[:skip]
+        write_session(req, sid, {deleted: true}, ex: 60) # marks the session as deleted for 60 seconds
+        req.session.delete('deleted') # prevents commiting the "deleted" flag to the renewed session
+        # By default, a deleted session should be renewed, which involves generating a new session ID and cookie for it.
+        # However, since the deleted session is being overwritten with the "deleted" flag, it will bypass the renewal step.
+        # Therefore, we need to manually set the :renew option to force the session to be renewed.
+        # See:
+        # - https://github.com/rack/rack/blob/v2.2.9/lib/rack/session/abstract/id.rb#L217-L218
+        # - https://github.com/rack/rack/blob/v2.2.9/lib/rack/session/abstract/id.rb#L377-L380
+        # - https://github.com/redis-store/redis-rack/blob/v3.0.0/lib/rack/session/redis.rb#L60
+        options[:renew] = true
+      end
     end
 
     # Overrides +Rack::Session::Abstract::Persisted#commit_session?+ to skip

--- a/dashboard/test/lib/middlewares/redis_session_store_test.rb
+++ b/dashboard/test/lib/middlewares/redis_session_store_test.rb
@@ -20,7 +20,7 @@ class Middlewares::RedisSessionStoreTest < ActiveSupport::TestCase
   end
 
   describe '#delete_session' do
-    subject(:delete_session) {redis_session_store.delete_session(request, session_id, {})}
+    subject(:delete_session) {redis_session_store.delete_session(request, session_id, session.options)}
 
     let(:session_data) {{deleted: false}}
     let(:session_options) {{renew: false}}
@@ -37,6 +37,24 @@ class Middlewares::RedisSessionStoreTest < ActiveSupport::TestCase
 
     it 'sets session :renew option' do
       _ {delete_session}.must_change -> {request.session.options[:renew]}, from: false, to: true
+    end
+
+    context 'when session is skipped' do
+      let(:session_options) {{skip: true}}
+
+      it 'does not store session as deleted' do
+        _ {delete_session}.must_change -> {redis_session_store.send(:get_session_with_fallback, session_id)},
+                                       from: {deleted: false},
+                                       to: nil
+      end
+
+      it 'does not delete request session :deleted flag' do
+        _ {delete_session}.wont_change -> {request.session['deleted']}
+      end
+
+      it 'does not set session :renew option' do
+        _ {delete_session}.wont_change -> {request.session.options[:renew]}
+      end
     end
   end
 


### PR DESCRIPTION
During a refactoring, while running the UI test **"Certificate page features – Pegasus share page preserves certificate when redirecting"**, I ran into an edge case involving session management.

In the step [**Given I am on ‘http://studio.code.org/courses/mc/units/1/reset’**](https://github.com/code-dot-org/code-dot-org/blob/deleted-session-preservation-middleware-fix/dashboard/test/ui/features/teacher_tools/certificates/certificates.feature#L6), when no user is logged in, the application executes `reset_session` while `request.session_options[:skip] = true`. Under normal circumstances, this configuration should result in no action, since `reset_session` is effectively a no-operation when the session is marked as skipped.

https://github.com/code-dot-org/code-dot-org/blob/e0a57a67452c2a7bc93fd4424da119ba98c02c38/dashboard/app/controllers/script_levels_controller.rb#L11

https://github.com/code-dot-org/code-dot-org/blob/8d795a9df6f151224e10c5af7feb8ab6c7916129/dashboard/app/helpers/cached_unit_helper.rb#L11-L15

https://github.com/code-dot-org/code-dot-org/blob/e0a57a67452c2a7bc93fd4424da119ba98c02c38/dashboard/app/controllers/script_levels_controller.rb#L41

However, [DeletedSessionPreservation#delete_session](https://github.com/code-dot-org/code-dot-org/blob/staging/dashboard/lib/middlewares/redis_session_store.rb#L64) writes a `{deleted: true}` entry to the session store, disregarding the `:skip` flag. This results in the current session being marked as deleted for 60 seconds, while a new session is not initialized as expected, even though `req.session.options[:renew] = true` is set.
https://github.com/code-dot-org/code-dot-org/blob/f9c7689ea69672b7e29389a6a6264083ebc3e14b/dashboard/lib/middlewares/redis_session_store.rb#L61-L74

As a result, the current session is marked as deleted for approximately 60 seconds. During this period, all attempts to write data to the session are ignored, including the generation of a new CSRF token. Consequently, subsequent requests fail with a **422 InvalidAuthenticityToken** error, as no valid CSRF token is stored in the session.

## Links
- JIRA task: [P20-906](https://codedotorg.atlassian.net/browse/P20-906)
- Related PR: https://github.com/code-dot-org/code-dot-org/pull/62153