### PR TITLE
[Lab2] Adding aria-valuemax to ResizeBar so that wcag stops complaining about infinity

### DIFF
--- a/apps/src/lab2/views/components/layout/ResizeBar.tsx
+++ b/apps/src/lab2/views/components/layout/ResizeBar.tsx
@@ -68,11 +68,10 @@ const ResizeBar: React.FunctionComponent<ResizeBarProps> = ({
       <div
         className={classNames(moduleStyles.absoluteBar, resizingBarClass)}
         {...mainSeparatorProps}
-        // TODO: the separator props are applying role "separator" as well as min/max/now aria values.
-        // Is it ok to ignore this warning?
-        // https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/separator_role
+        // The separator props are applying role "separator" as well as min/now aria values.
         // eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex
         tabIndex={0}
+        aria-valuemax={20000} // Infinity fails accessibility checks, so use a large number instead.
         onFocus={() => setIsActive(true)}
         onBlur={() => setIsActive(false)}
       >


### PR DESCRIPTION
Addresses a comment from https://github.com/code-dot-org/code-dot-org/pull/63803/files and fixes WCAG violations in Lab2 (additionally, will fix wcag violations wherever the ResizeBar is used). 

Confirmed I am still able to resize to absurdity, as seen on a 25% zoomed 15 inch mac (which the actual value is still in the 6,000s, well below the new 20,000 limit). 

<img width="1710" height="884" alt="Screenshot 2025-10-14 at 4 12 21 PM" src="https://github.com/user-attachments/assets/4228fb39-c635-46c8-ac02-e9e653b650d6" />


## Links

- Jira: https://codedotorg.atlassian.net/browse/SL-1449

## Testing story
<!--  Does your change include appropriate tests?
      - If so, please describe how the tests included in this PR are sufficient.
      - If not, please explain why this change does not need to be tested. -->



## Deployment strategy
<!--  Any special steps required to deploy this, besides merging?
      - Are there database migrations or manual steps?
      - Does this require coordination with other teams or systems? -->



## Follow-up work
<!--  List any clean-up or technical debt that will be addressed in future work.
      - Include Jira links where applicable.
      - Are there any known limitations or improvements planned? -->



## Privacy
<!--  How does this change impact Student & Teacher privacy?
      - Does this collect, use, share, or modify PII, either new or existing? -->



## Security
<!--  How does this change impact our security surface-area?
      - Do API's touched have the right auth?
      - Do infra changes impact our attack surface or encryption?
-->



## Caching
<!--  How does this change impact caching behavior?
      - Are cache keys or invalidation strategies affected?
      - Will this require cache warming or invalidation after deployment? -->



## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
