### PR TITLE
Set MySQL Transaction Isolation level to READ-COMMITTED on Development and Continuous Integration

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -80,7 +80,7 @@ steps:
   - name: unit-tests
     # see: docker/ci/Dockerfile
     # TODO: switch to codedotorg/cdo-ci
-    image: codedotorg/code-dot-org:1.16
+    image: codedotorg/code-dot-org:1.17
     pull: always
     environment:
       CI_JOB: 'unit_tests'
@@ -190,7 +190,7 @@ steps:
   - name: ui-tests
     # see: docker/ci/Dockerfile
     # TODO: switch to codedotorg/cdo-ci
-    image: codedotorg/code-dot-org:1.16
+    image: codedotorg/code-dot-org:1.17
     pull: always
     volumes:
       - name: mysql
@@ -271,7 +271,7 @@ steps:
   # snapshot of the fully-built project and resulting database, but don't
   # actually run the tests.
   - name: prepare-ci-tests
-    image: codedotorg/code-dot-org:1.16
+    image: codedotorg/code-dot-org:1.17
     pull: always
     environment:
       CI_JOB: 'ui_tests'

--- a/.drone.yml
+++ b/.drone.yml
@@ -312,6 +312,6 @@ trigger:
 
 ---
 kind: signature
-hmac: 017c2f750c43c36090a68e67662a4f86d4aee137f83b7be90da61181e79d8c35
+hmac: 68d7fb57c1e92a0d229f9cd1ffca4580ef65fdfc9f255fc0df14517f522ad0f7
 
 ...

--- a/SETUP.md
+++ b/SETUP.md
@@ -77,11 +77,23 @@ You can do Code.org development using macOS, Ubuntu, or Windows (running Ubuntu 
         <code>bundle exec rake install</code> must always be called from the local project's root directory, or it won't work.
     </details>
 
-1. fix your database timezone to match our servers
+1. Configure your database timezone and transaction isolation level to match our servers
     - `bin/mysql-client-admin`
-    - `SET GLOBAL time_zone = '+00:00';` Set time zone for all new database connections
-    - `SET PERSIST time_zone = '+00:00';` Save the setting to the mysqld-auto.cnf file which is read on restart
-    - `SELECT @@global.time_zone;` Verify the setting
+    - Copy and paste the following SQL commands:
+```sql
+    -- Set time zone for all new database connections
+    SET GLOBAL time_zone = '+00:00';
+    -- Save the time zone setting to mysqld-auto.cnf (read on restart)
+    SET PERSIST time_zone = '+00:00';
+    
+    -- Set transaction isolation level for all new database connections
+    SET GLOBAL transaction_isolation = 'READ-COMMITTED';
+    -- Save the transaction isolation setting to mysqld-auto.cnf (read on restart)
+    SET PERSIST transaction_isolation = 'READ-COMMITTED';
+    
+    -- Verify both settings
+    SELECT @@global.time_zone, @@global.transaction_isolation;
+```
 
 1. `bundle exec rake build`
     - This may fail for external contributors who don't have permissions to access Code.org AWS Secrets. Assign placeholder values to any configuration settings that are [ordinarily populated in Development environments from AWS Secrets](https://github.com/code-dot-org/code-dot-org/blob/staging/config/development.yml.erb) as indicated in this example: https://github.com/code-dot-org/code-dot-org/blob/5b3baed4a9c2e7226441ca4492a3bca23a4d7226/locals.yml.default#L136-L139

--- a/dashboard/app/models/application_record.rb
+++ b/dashboard/app/models/application_record.rb
@@ -6,4 +6,51 @@ class ApplicationRecord < ActiveRecord::Base
     reading: Policies::ActiveRecordRoles.get_reading_role_name,
     reporting: Policies::ActiveRecordRoles.get_reporting_role_name,
   }
+
+  # Our infrastructure code falls back to setting `CDO.db_endpoint_proxy_reporting` to the writer database (typically
+  # MySQL Community Edition runnong on LOCALHOST)on environments that do not have an Aurora cluster with a reader
+  # database instance and a reporting RDS Proxy so that usage of the reporting role does not raise an error on local
+  # development environments or continuous integration environments. Optionally use this method to verify that the
+  # current environment actually has a reporting database.
+  def self.reporting_database_configured?
+    connected_to(role: :reporting) do
+      conn = connection
+
+      # Detect if this is Aurora by querying an Aurora-specific variable
+      is_aurora = begin
+        conn.select_value('SELECT @@aurora_version')
+        true
+      rescue ActiveRecord::StatementInvalid
+        false
+      end
+
+      checks = {
+        transaction_isolation: conn.select_value('SELECT @@transaction_isolation'),
+        max_execution_time: conn.select_value('SELECT @@max_execution_time')
+      }.tap do |h|
+        if is_aurora
+          h[:innodb_read_only] = conn.select_value('SELECT @@innodb_read_only')
+          h[:aurora_read_replica_read_committed] = conn.select_value('SELECT @@aurora_read_replica_read_committed')
+          h[:aurora_server_id] = conn.select_value('SELECT @@aurora_server_id')
+        end
+      end
+
+      errors = []
+      errors << "Not on InnoDB read-only instance (expected 1, got #{checks[:innodb_read_only]})" if is_aurora && checks[:innodb_read_only] != 1
+      errors << "aurora_read_replica_read_committed not ON (expected 1, got #{checks[:aurora_read_replica_read_committed]})" if is_aurora && checks[:aurora_read_replica_read_committed] != 1
+      errors << "Wrong isolation level (expected 'READ-COMMITTED', got '#{checks[:transaction_isolation]}')" unless checks[:transaction_isolation] == 'READ-COMMITTED'
+      errors << "max_execution_time not 0 (expected 0, got #{checks[:max_execution_time]})" unless checks[:max_execution_time] == 0
+
+      db_type = is_aurora ? "Aurora" : "MySQL Community Edition"
+
+      if errors.any?
+        CDO.log.error "Reporting database validation failed on #{db_type}: #{errors.join(', ')}"
+        CDO.log.error "Connection details: #{checks.inspect}"
+        false
+      else
+        CDO.log.info "Reporting database validation succeeded on #{db_type}: #{checks.inspect}"
+        true
+      end
+    end
+  end
 end

--- a/dashboard/test/models/application_record_reporting_test.rb
+++ b/dashboard/test/models/application_record_reporting_test.rb
@@ -1,0 +1,74 @@
+require 'test_helper'
+
+class ApplicationRecordReportingTest < ActiveSupport::TestCase
+  setup do
+    @mock_connection = mock('connection')
+    ApplicationRecord.stubs(:connection).returns(@mock_connection)
+  end
+
+  # Scenario 1: Production Aurora with RDS Proxy pointing to reader
+  test 'reporting_database_configured? returns true for properly configured Aurora reporting database' do
+    # Aurora detection succeeds
+    @mock_connection.stubs(:select_value).with('SELECT @@aurora_version').returns('3.04.0')
+
+    # All Aurora checks pass
+    @mock_connection.stubs(:select_value).with('SELECT @@innodb_read_only').returns(1)
+    @mock_connection.stubs(:select_value).with('SELECT @@aurora_read_replica_read_committed').returns(1)
+    @mock_connection.stubs(:select_value).with('SELECT @@transaction_isolation').returns('READ-COMMITTED')
+    @mock_connection.stubs(:select_value).with('SELECT @@max_execution_time').returns(0)
+    @mock_connection.stubs(:select_value).with('SELECT @@aurora_server_id').returns('autoscale-prod-1')
+
+    CDO.log.expects(:info).with(regexp_matches(/Reporting database validation succeeded on Aurora/))
+
+    assert ApplicationRecord.reporting_database_configured?
+  end
+
+  test 'reporting_database_configured? returns false for misconfigured Aurora reporting database' do
+    # Aurora detection succeeds
+    @mock_connection.stubs(:select_value).with('SELECT @@aurora_version').returns('3.04.0')
+
+    # Some checks fail
+    @mock_connection.stubs(:select_value).with('SELECT @@innodb_read_only').returns(0)
+    @mock_connection.stubs(:select_value).with('SELECT @@aurora_read_replica_read_committed').returns(0)
+    @mock_connection.stubs(:select_value).with('SELECT @@transaction_isolation').returns('REPEATABLE-READ')
+    @mock_connection.stubs(:select_value).with('SELECT @@max_execution_time').returns(30000)
+    @mock_connection.stubs(:select_value).with('SELECT @@aurora_server_id').returns('autoscale-prod-0')
+
+    CDO.log.expects(:error).with(regexp_matches(/Reporting database validation failed on Aurora/))
+    CDO.log.expects(:error).with(regexp_matches(/Connection details:/))
+
+    refute ApplicationRecord.reporting_database_configured?
+  end
+
+  # Scenario 2: MySQL Community Edition (local dev, CI, or localhost on EC2)
+  test 'reporting_database_configured? returns true for properly configured MySQL Community Edition' do
+    # Aurora detection fails (not Aurora)
+    @mock_connection.stubs(:select_value).with('SELECT @@aurora_version').raises(
+      ActiveRecord::StatementInvalid.new("Unknown system variable 'aurora_version'")
+    )
+
+    # Non-Aurora checks pass
+    @mock_connection.stubs(:select_value).with('SELECT @@transaction_isolation').returns('READ-COMMITTED')
+    @mock_connection.stubs(:select_value).with('SELECT @@max_execution_time').returns(0)
+
+    CDO.log.expects(:info).with(regexp_matches(/Reporting database validation succeeded on MySQL Community Edition/))
+
+    assert ApplicationRecord.reporting_database_configured?
+  end
+
+  test 'reporting_database_configured? returns false for misconfigured MySQL Community Edition' do
+    # Aurora detection fails (not Aurora)
+    @mock_connection.stubs(:select_value).with('SELECT @@aurora_version').raises(
+      ActiveRecord::StatementInvalid.new("Unknown system variable 'aurora_version'")
+    )
+
+    # Non-Aurora checks fail
+    @mock_connection.stubs(:select_value).with('SELECT @@transaction_isolation').returns('REPEATABLE-READ')
+    @mock_connection.stubs(:select_value).with('SELECT @@max_execution_time').returns(5000)
+
+    CDO.log.expects(:error).with(regexp_matches(/Reporting database validation failed on MySQL Community Edition/))
+    CDO.log.expects(:error).with(regexp_matches(/Connection details:/))
+
+    refute ApplicationRecord.reporting_database_configured?
+  end
+end

--- a/docker/README.md
+++ b/docker/README.md
@@ -73,16 +73,16 @@ Make sure everything works locally using the instructions above.
 cd docker/ci
 ```
 
-Sign in to Docker Hub through the command line; when prompted, enter the password found under "access token for docker cli authentication" in the lastpass docker hub notes field
+Sign in to Docker Hub through the command line; when prompted, enter the value found in the field "Admin API Token" in the 1Password Docker credential for the user `codedotorg`
 
 ```
 docker login -u codedotorg
 ```
 
-Build a full image to your local machine
+Build a full image that will execute on Intel/X86 systems to your local machine
 
 ```
-docker build .
+docker build --platform linux/amd64 .
 ```
 
 **Note:** We are moving to a new naming convention in order to use different docker images for different purposes. What was the `code-dot-org` image will become the `cdo-ci` image. For now, these docs advise publishing both names.

--- a/docker/ci/Dockerfile
+++ b/docker/ci/Dockerfile
@@ -112,6 +112,10 @@ RUN locale-gen en_US.UTF-8
 RUN apt-get update && \
     apt-get install --yes libmysqlclient-dev mysql-client mysql-server
 
+# Configure MySQL with READ-COMMITTED transaction isolation
+RUN mkdir -p /etc/mysql/mysql.conf.d && \
+    echo '[mysqld]\ntransaction-isolation = READ-COMMITTED' > /etc/mysql/mysql.conf.d/ci-config.cnf
+
 # disable auth for local dashboard mysql db
 RUN service mysql start && \
     echo "ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password BY '';" | mysql && \


### PR DESCRIPTION
Set the MySQL Transaction Isolation level to the same custom setting (`READ-COMMITTED`) on continuous integration builds and on development environments that we already set on [Aurora clusters](https://github.com/code-dot-org/code-dot-org/blob/10a59a129e4758a743ba3bd6da9b4206d8a0781a/aws/cloudformation/components/database.yml.erb#L173) and adhoc environments that use [Community Edition MySQL](https://github.com/code-dot-org/code-dot-org/blob/10a59a129e4758a743ba3bd6da9b4206d8a0781a/cookbooks/cdo-mysql/templates/default/cdo.cnf.erb#L4).

Also add a method to the base `ApplicationRecord` class to verify that the current system has a real reporting database (this test checks the transaction isolation level, which is how I ended down this rabbit hole).

This is part of work to enable ActiveRecord to query the "Reporting" database.
https://codedotorg.atlassian.net/browse/INF-1752

## Testing story
<!--  Does your change include appropriate tests?
      - If so, please describe how the tests included in this PR are sufficient.
      - If not, please explain why this change does not need to be tested. -->



## Deployment strategy

1. Push the docker image tag for the next incremental release number (`1.17`)
2. Update and Sign `.drone.yml` to reference the docker image release number
3. Merge!
4. Notify Engineers to run the SQL statements that set and persist the transaction isolation level on their existing environments.



## Follow-up work
<!--  List any clean-up or technical debt that will be addressed in future work.
      - Include Jira links where applicable.
      - Are there any known limitations or improvements planned? -->



## Privacy
<!--  How does this change impact Student & Teacher privacy?
      - Does this collect, use, share, or modify PII, either new or existing? -->



## Security
<!--  How does this change impact our security surface-area?
      - Do API's touched have the right auth?
      - Do infra changes impact our attack surface or encryption?
-->



## Caching
<!--  How does this change impact caching behavior?
      - Are cache keys or invalidation strategies affected?
      - Will this require cache warming or invalidation after deployment? -->



## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
