### PR TITLE
compute drone total-build-time stats

### DIFF
--- a/bin/drone/stats
+++ b/bin/drone/stats
@@ -43,14 +43,6 @@ end.parse!
 OLDEST_BUILD_OF_INTEREST = options[:ago].ago
 MAX_DRONE_PAGE_NUM = 200
 
-# Check for incompatible options
-if options[:total_build_time] && options[:only_stages]
-  puts "Error: --only-stages cannot be used with --total-build-time"
-  puts "The --total-build-time option calculates total build duration, not individual stage durations."
-  puts "Remove either --only-stages or --total-build-time and try again."
-  exit 1
-end
-
 # ============================================================================
 # MAIN
 # ============================================================================
@@ -165,6 +157,11 @@ def collect_total_build_time_data(options)
       select {|build| options[:only_successful] ? build[:status] == "success" : true}.
       select {|build| options[:event] ? build[:event] == options[:event] : true}
 
+    # If --only-stages is specified, we need to fetch build details to filter by stages
+    if options[:only_stages]
+      builds = filter_builds_by_stages(builds, options)
+    end
+
     new_builds = builds.map do |build|
       next if build[:finished].zero? || build[:started].zero? || build[:created].zero?
       {
@@ -194,6 +191,28 @@ def collect_total_build_time_data(options)
 
   raise "No builds found matching the specified criteria" if builds_data.empty?
   builds_data
+end
+
+def filter_builds_by_stages(builds, options)
+  build_nums = builds.map {|build| build[:number]}
+
+  filtered_build_nums = Parallel.map(build_nums, in_threads: 32) do |build_num|
+    build_info = drone_api_get("builds/#{build_num}")
+    stage_names = build_info[:stages].map {|stage| stage[:name]}
+
+    # Check if all stages in this build are in the allowed list
+    all_stages_allowed = stage_names.all? {|name| options[:only_stages].include?(name)}
+
+    if options[:verbose] && !all_stages_allowed
+      unexpected_stages = stage_names - options[:only_stages]
+      puts "Skipping build ##{build_num} with unexpected stages: #{unexpected_stages.join(', ')}"
+    end
+
+    all_stages_allowed ? build_num : nil
+  end.compact
+
+  # Filter original builds list to only include those that passed the stage check
+  builds.select {|build| filtered_build_nums.include?(build[:number])}
 end
 
 def write_total_build_time_stats_table(builds_data, options)

--- a/bin/drone/stats
+++ b/bin/drone/stats
@@ -196,22 +196,35 @@ end
 def filter_builds_by_stages(builds, options)
   build_nums = builds.map {|build| build[:number]}
 
-  filtered_build_nums = Parallel.map(build_nums, in_threads: 32) do |build_num|
+  results = Parallel.map(build_nums, in_threads: 32) do |build_num|
     build_info = drone_api_get("builds/#{build_num}")
     stage_names = build_info[:stages].map {|stage| stage[:name]}
 
     # Check if all stages in this build are in the allowed list
     all_stages_allowed = stage_names.all? {|name| options[:only_stages].include?(name)}
 
-    if options[:verbose] && !all_stages_allowed
+    if all_stages_allowed
+      {allowed: true, build_num: build_num}
+    else
       unexpected_stages = stage_names - options[:only_stages]
-      puts "Skipping build ##{build_num} with unexpected stages: #{unexpected_stages.join(', ')}"
+      {allowed: false, build_num: build_num, unexpected_stages: unexpected_stages}
     end
+  end
 
-    all_stages_allowed ? build_num : nil
-  end.compact
+  # Print skipped builds after parallel processing completes to avoid interfering with progress output
+  if options[:verbose]
+    skipped = results.select {|r| !r[:allowed]}
+    unless skipped.empty?
+      print(TERMINAL_CLEAR_LINE) if $stdout.tty?
+      messages = skipped.map do |skip_info|
+        "Skipping build ##{skip_info[:build_num]} with unexpected stages: #{skip_info[:unexpected_stages].join(', ')}"
+      end
+      puts messages.join("\n")
+    end
+  end
 
   # Filter original builds list to only include those that passed the stage check
+  filtered_build_nums = results.select {|r| r[:allowed]}.map {|r| r[:build_num]}
   builds.select {|build| filtered_build_nums.include?(build[:number])}
 end
 

--- a/bin/drone/stats
+++ b/bin/drone/stats
@@ -8,7 +8,7 @@ require "parallel"
 require "csv"
 require 'httparty'
 
-options = {ago: 1.week, json: false, only_successful: true, only_stages: nil, verbose: nil}
+options = {ago: 1.week, json: false, only_successful: true, only_stages: nil, verbose: nil, event: nil, total_build_time: false}
 OptionParser.new do |opts|
   opts.on("--verbose", 'Output more information') {options[:verbose] = true}
   opts.on("--json", 'Output successful builds in JSON format') do
@@ -19,11 +19,19 @@ OptionParser.new do |opts|
     num, unit = ago_str.split
     options[:ago] = num.to_i.public_send(unit.downcase)
   end
-  opts.on("--only-successful=true", 'Filter to only successful drone builds (default: true)') do |only_successful|
-    options[:only_successful] = [nil, "1", "true"].include? only_successful
+  opts.on("--only-successful[=OPTIONAL]", 'Filter to only successful drone builds (default: true)') do |only_successful|
+    # If flag is passed without a value (nil), or with "true"/"1", set to true
+    # If passed with "false"/"0", set to false
+    options[:only_successful] = only_successful.nil? || ["true", "1"].include?(only_successful)
   end
   opts.on("--only-stages=STAGES", 'Only process some drone stages, e.g. `--only-stages="unit,ui"`') do |stages|
     options[:only_stages] = stages.split(",").map(&:strip)
+  end
+  opts.on("--event=EVENT_TYPE", 'Filter to specific event type, e.g. `--event=pull_request`') do |event|
+    options[:event] = event
+  end
+  opts.on("--total-build-time", 'Calculate total build time instead of stage durations') do
+    options[:total_build_time] = true
   end
 end.parse!
 
@@ -54,36 +62,75 @@ OLDEST_BUILD_OF_INTEREST = options[:ago].ago
 oldest_build_seen = Time.now
 MAX_DRONE_PAGE_NUM = 200
 drone_page_num = 1
-build_stages = []
+
+if options[:total_build_time]
+  builds_data = []
+else
+  build_stages = []
+end
+
+# Check for incompatible options
+if options[:total_build_time] && options[:only_stages]
+  puts "Error: --only-stages cannot be used with --total-build-time"
+  puts "The --total-build-time option calculates total build duration, not individual stage durations."
+  puts "Remove either --only-stages or --total-build-time and try again."
+  exit 1
+end
 
 while oldest_build_seen >= OLDEST_BUILD_OF_INTEREST
   raise "Exceeded hardcoded max drone API page limit (#{MAX_DRONE_PAGE_NUM})" if drone_page_num > MAX_DRONE_PAGE_NUM
 
   builds = drone_api_get("builds?page=#{drone_page_num}").
-    select {|build| options[:only_successful] ? build[:status] == "success" : true}
-  build_nums = builds.map {|build| build[:number]}
+    select {|build| options[:only_successful] ? build[:status] == "success" : true}.
+    select {|build| options[:event] ? build[:event] == options[:event] : true}
 
-  new_build_stages = Parallel.flat_map(build_nums, in_threads: 32) do |build_num|
-    build_info = drone_api_get("builds/#{build_num}")
-
-    build_info[:stages].map do |stage|
-      next if options[:only_stages] && !options[:only_stages].include?(stage[:name])
+  if options[:total_build_time]
+    # For total build time, we work with build-level data
+    new_builds = builds.map do |build|
+      next if build[:finished].zero? || build[:started].zero? || build[:created].zero?
       {
-        **stage, # see: https://docs.drone.io/api/builds/build_info/
-        build_num: build_info[:number],
-        build: build_info,
-        date: Time.at(stage[:stopped]),
+        number: build[:number],
+        event: build[:event],
+        status: build[:status],
+        created: build[:created],
+        started: build[:started],
+        finished: build[:finished],
+        date: Time.at(build[:finished]),
+        queue_time_minutes: ((build[:started] - build[:created]) / 60.0).round(2),
+        run_time_minutes: ((build[:finished] - build[:started]) / 60.0).round(2),
+        total_time_minutes: ((build[:finished] - build[:created]) / 60.0).round(2)
       }
-    end
-  end.compact
+    end.compact
 
-  raise "No new build stages found, is --only-stages set correctly?" if new_build_stages.empty?
+    raise "No new builds found" if new_builds.empty?
+    oldest_build_seen = new_builds.map {|b| b[:date]}.min
+    new_builds.select! {|b| b[:date] >= OLDEST_BUILD_OF_INTEREST}
+    builds_data += new_builds
+  else
+    # For stage-level analysis, use existing logic
+    build_nums = builds.map {|build| build[:number]}
 
-  oldest_build_seen = new_build_stages.map {|s| s[:date]}.min
-  new_build_stages.select! {|s| s[:date] >= OLDEST_BUILD_OF_INTEREST}
+    new_build_stages = Parallel.flat_map(build_nums, in_threads: 32) do |build_num|
+      build_info = drone_api_get("builds/#{build_num}")
+
+      build_info[:stages].map do |stage|
+        next if options[:only_stages] && !options[:only_stages].include?(stage[:name])
+        {
+          **stage, # see: https://docs.drone.io/api/builds/build_info/
+          build_num: build_info[:number],
+          build: build_info,
+          date: Time.at(stage[:stopped]),
+        }
+      end
+    end.compact
+
+    raise "No new build stages found, is --only-stages set correctly?" if new_build_stages.empty?
+    oldest_build_seen = new_build_stages.map {|s| s[:date]}.min
+    new_build_stages.select! {|s| s[:date] >= OLDEST_BUILD_OF_INTEREST}
+    build_stages += new_build_stages
+  end
+
   print("#{TERMINAL_CLEAR_LINE}Processed builds back to #{oldest_build_seen}") if $stdout.tty?
-
-  build_stages += new_build_stages
   drone_page_num += 1
 end
 puts(TERMINAL_CLEAR_LINE) if $stdout.tty?
@@ -95,9 +142,7 @@ def descriptive_statistics(data, units: nil, round: nil)
   format = round ? ->(v) {v.round(round)} : ->(v) {v}
   {
     count: data.size,
-    **(units.nil? ? {} : {units: units}),
     mean: format.call(data.sum / data.size.to_f),
-    sum: format.call(data.sum),
     p_0: format.call(data.min),
     p_25: format.call(quartile.call(1)),
     p_50: format.call(quartile.call(2)),
@@ -136,12 +181,35 @@ def compute_stats_for(all_build_stages, options, units: nil, round: nil, &data_s
     }
   end
 
-  duration_stats = all_build_stages.group_by {|stage| stage[:name]}.map do |stage_name, subset_of_stages|
+  all_build_stages.group_by {|stage| stage[:name]}.map do |stage_name, subset_of_stages|
     stats_for.call(stage_name, subset_of_stages)
   end
+end
 
-  all_stage_name_label = options[:only_stages] ? options[:only_stages].join("+") : "ALL"
-  duration_stats << stats_for.call(all_stage_name_label, all_build_stages)
+def compute_build_stats_for(all_builds, options, units: nil, round: nil, &data_selector)
+  options_filtered = options.reject {|key, value| OPTIONS_NOT_TO_OUTPUT_TO_TABLE.include?(key) || value.nil?}.inspect.tr('"', "'")
+
+  stats_for = lambda do |event_type, builds|
+    data = builds.map(&data_selector).compact
+    {
+      event_type: event_type,
+      **descriptive_statistics(data, units: units, round: round),
+      options: options_filtered,
+    }
+  end
+
+  build_stats = all_builds.group_by {|build| build[:event]}.map do |event_type, subset_of_builds|
+    stats_for.call(event_type, subset_of_builds)
+  end
+
+  # Only add an "ALL" row if there are multiple event types or no specific event filter
+  unique_event_types = all_builds.map {|build| build[:event]}.uniq
+  if unique_event_types.length > 1 || options[:event].nil?
+    all_event_label = options[:event] || "ALL"
+    build_stats << stats_for.call(all_event_label, all_builds)
+  end
+
+  build_stats
 end
 
 def write_duration_stats_table(build_stages, options)
@@ -156,8 +224,37 @@ def write_duration_stats_table(build_stages, options)
   write_stats_table("drone-duration-stats.tsv", duration_mins_stats)
 end
 
+def write_total_build_time_stats_table(builds_data, options)
+  options_filtered = options.reject {|key, value| OPTIONS_NOT_TO_OUTPUT_TO_TABLE.include?(key) || value.nil?}.inspect.tr('"', "'")
+
+  stats_for = lambda do |metric_name, data_selector|
+    data = builds_data.map(&data_selector).compact
+    {
+      metric_type: metric_name,
+      **descriptive_statistics(data, units: "minutes", round: 2),
+      options: options_filtered,
+    }
+  end
+
+  build_time_stats = [
+    stats_for.call("queue_time", ->(build) {build[:queue_time_minutes]}),
+    stats_for.call("run_time", ->(build) {build[:run_time_minutes]}),
+    stats_for.call("total_time", ->(build) {build[:total_time_minutes]}),
+  ]
+
+  write_stats_table("drone-total-build-time-stats.tsv", build_time_stats)
+end
+
 if options[:json]
-  puts JSON.pretty_generate(build_stages)
+  if options[:total_build_time]
+    puts JSON.pretty_generate(builds_data)
+  else
+    puts JSON.pretty_generate(build_stages)
+  end
 else
-  write_duration_stats_table(build_stages, options)
+  if options[:total_build_time]
+    write_total_build_time_stats_table(builds_data, options)
+  else
+    write_duration_stats_table(build_stages, options)
+  end
 end

--- a/bin/drone/stats
+++ b/bin/drone/stats
@@ -8,6 +8,11 @@ require "parallel"
 require "csv"
 require 'httparty'
 
+# Terminal control code to clear the current line
+TERMINAL_CLEAR_LINE="\r\e[K"
+OPTIONS_NOT_TO_OUTPUT_TO_TABLE = [:json]
+
+# Parse command line options
 options = {ago: 1.week, json: false, only_successful: true, only_stages: nil, verbose: nil, event: nil, total_build_time: false}
 OptionParser.new do |opts|
   opts.on("--verbose", 'Output more information') {options[:verbose] = true}
@@ -35,39 +40,8 @@ OptionParser.new do |opts|
   end
 end.parse!
 
-def drone_api_get(path)
-  drone_url = "https://drone.cdn-code.org"
-  url = "#{drone_url}/api/repos/code-dot-org/code-dot-org/#{path}"
-  drone_token = ENV.fetch('DRONE_TOKEN', nil)
-  raise "Env var DRONE_TOKEN must be set to 'Your Personal Token' from #{drone_url}/account" if drone_token.nil?
-
-  res = HTTParty.get(
-    url,
-    headers: {
-      "Authorization" => "Bearer #{ENV.fetch('DRONE_TOKEN', nil)}",
-      "Content-Type" => "application/json",
-    },
-    format: :plain,
-  )
-  raise "#{res.code} #{res.message} - GET request to #{url} failed" unless res.success?
-  JSON.parse res.body, symbolize_names: true
-end
-
-# Terminal control code to clear the current line
-TERMINAL_CLEAR_LINE="\r\e[K"
-
-OPTIONS_NOT_TO_OUTPUT_TO_TABLE = [:json]
-
 OLDEST_BUILD_OF_INTEREST = options[:ago].ago
-oldest_build_seen = Time.now
 MAX_DRONE_PAGE_NUM = 200
-drone_page_num = 1
-
-if options[:total_build_time]
-  builds_data = []
-else
-  build_stages = []
-end
 
 # Check for incompatible options
 if options[:total_build_time] && options[:only_stages]
@@ -77,15 +51,44 @@ if options[:total_build_time] && options[:only_stages]
   exit 1
 end
 
-while oldest_build_seen >= OLDEST_BUILD_OF_INTEREST
-  raise "Exceeded hardcoded max drone API page limit (#{MAX_DRONE_PAGE_NUM})" if drone_page_num > MAX_DRONE_PAGE_NUM
+# ============================================================================
+# MAIN
+# ============================================================================
 
-  builds = drone_api_get("builds?page=#{drone_page_num}").
-    select {|build| options[:only_successful] ? build[:status] == "success" : true}.
-    select {|build| options[:event] ? build[:event] == options[:event] : true}
-
+def main(options)
   if options[:total_build_time]
-    # For total build time, we work with build-level data
+    builds_data = collect_total_build_time_data(options)
+    if options[:json]
+      puts JSON.pretty_generate(builds_data)
+    else
+      write_total_build_time_stats_table(builds_data, options)
+    end
+  else
+    build_stages = collect_stage_data(options)
+    if options[:json]
+      puts JSON.pretty_generate(build_stages)
+    else
+      write_stage_stats_table(build_stages, options)
+    end
+  end
+end
+
+# ============================================================================
+# TOTAL BUILD TIME METHODS
+# ============================================================================
+
+def collect_total_build_time_data(options)
+  builds_data = []
+  oldest_build_seen = Time.now
+  drone_page_num = 1
+
+  while oldest_build_seen >= OLDEST_BUILD_OF_INTEREST
+    raise "Exceeded hardcoded max drone API page limit (#{MAX_DRONE_PAGE_NUM})" if drone_page_num > MAX_DRONE_PAGE_NUM
+
+    builds = drone_api_get("builds?page=#{drone_page_num}").
+      select {|build| options[:only_successful] ? build[:status] == "success" : true}.
+      select {|build| options[:event] ? build[:event] == options[:event] : true}
+
     new_builds = builds.map do |build|
       next if build[:finished].zero? || build[:started].zero? || build[:created].zero?
       {
@@ -107,130 +110,14 @@ while oldest_build_seen >= OLDEST_BUILD_OF_INTEREST
       new_builds.select! {|b| b[:date] >= OLDEST_BUILD_OF_INTEREST}
       builds_data += new_builds
     end
-  else
-    # For stage-level analysis, use existing logic
-    build_nums = builds.map {|build| build[:number]}
 
-    new_build_stages = Parallel.flat_map(build_nums, in_threads: 32) do |build_num|
-      build_info = drone_api_get("builds/#{build_num}")
-
-      build_info[:stages].map do |stage|
-        next if options[:only_stages] && !options[:only_stages].include?(stage[:name])
-        {
-          **stage, # see: https://docs.drone.io/api/builds/build_info/
-          build_num: build_info[:number],
-          build: build_info,
-          date: Time.at(stage[:stopped]),
-        }
-      end
-    end.compact
-
-    unless new_build_stages.empty?
-      oldest_build_seen = new_build_stages.map {|s| s[:date]}.min
-      new_build_stages.select! {|s| s[:date] >= OLDEST_BUILD_OF_INTEREST}
-      build_stages += new_build_stages
-    end
+    print("#{TERMINAL_CLEAR_LINE}Processed builds back to #{oldest_build_seen}") if $stdout.tty?
+    drone_page_num += 1
   end
+  puts(TERMINAL_CLEAR_LINE) if $stdout.tty?
 
-  print("#{TERMINAL_CLEAR_LINE}Processed builds back to #{oldest_build_seen}") if $stdout.tty?
-  drone_page_num += 1
-end
-puts(TERMINAL_CLEAR_LINE) if $stdout.tty?
-
-# Check if we found any data
-if options[:total_build_time]
   raise "No builds found matching the specified criteria" if builds_data.empty?
-else
-  raise "No build stages found matching the specified criteria" if build_stages.empty?
-end
-
-def descriptive_statistics(data, units: nil, round: nil)
-  raise "All values must be numeric" unless data.all?(Numeric)
-  data = data.sort
-  quartile = ->(quartile_num) {data[(data.length * quartile_num / 4.0).floor]}
-  format = round ? ->(v) {v.round(round)} : ->(v) {v}
-  {
-    count: data.size,
-    mean: format.call(data.sum / data.size.to_f),
-    p_0: format.call(data.min),
-    p_25: format.call(quartile.call(1)),
-    p_50: format.call(quartile.call(2)),
-    p_75: format.call(quartile.call(3)),
-    p_100: format.call(data.max),
-  }
-end
-
-def to_justified_tsv_str(hash)
-  col_names = hash.first.keys
-  col_widths = col_names.map {|col| [col.to_s.length, *hash.map {|row| row[col].to_s.length}].max}
-
-  CSV.generate(col_sep: "\t", force_quotes: false) do |csv|
-    csv << col_names.map.with_index {|col, i| col.to_s.ljust(col_widths[i])}
-    hash.each {|row| csv << row.values.map.with_index {|val, i| val.to_s.ljust(col_widths[i])}}
-  end
-end
-
-def write_stats_table(filename, data)
-  tsv = to_justified_tsv_str(data)
-  puts "## #{filename} ##"
-  puts tsv
-  puts
-  File.write(filename, tsv)
-end
-
-def compute_stats_for(all_build_stages, options, units: nil, round: nil, &data_selector)
-  options_filtered = options.reject {|key, value| OPTIONS_NOT_TO_OUTPUT_TO_TABLE.include?(key) || value.nil?}.inspect.tr('"', "'")
-
-  stats_for = lambda do |stage_name, build_stages|
-    data = build_stages.map(&data_selector).compact
-    {
-      stage_name: stage_name,
-      **descriptive_statistics(data, units: units, round: round),
-      options: options_filtered,
-    }
-  end
-
-  all_build_stages.group_by {|stage| stage[:name]}.map do |stage_name, subset_of_stages|
-    stats_for.call(stage_name, subset_of_stages)
-  end
-end
-
-def compute_build_stats_for(all_builds, options, units: nil, round: nil, &data_selector)
-  options_filtered = options.reject {|key, value| OPTIONS_NOT_TO_OUTPUT_TO_TABLE.include?(key) || value.nil?}.inspect.tr('"', "'")
-
-  stats_for = lambda do |event_type, builds|
-    data = builds.map(&data_selector).compact
-    {
-      event_type: event_type,
-      **descriptive_statistics(data, units: units, round: round),
-      options: options_filtered,
-    }
-  end
-
-  build_stats = all_builds.group_by {|build| build[:event]}.map do |event_type, subset_of_builds|
-    stats_for.call(event_type, subset_of_builds)
-  end
-
-  # Only add an "ALL" row if there are multiple event types or no specific event filter
-  unique_event_types = all_builds.map {|build| build[:event]}.uniq
-  if unique_event_types.length > 1 || options[:event].nil?
-    all_event_label = options[:event] || "ALL"
-    build_stats << stats_for.call(all_event_label, all_builds)
-  end
-
-  build_stats
-end
-
-def write_duration_stats_table(build_stages, options)
-  duration_mins_stats = compute_stats_for(build_stages, options, units: "minutes", round: 2) do |stage|
-    # We don't want to generate durations for stages that are still ongoing
-    next if stage[:stopped].zero? || stage[:started].zero?
-
-    # Compute duration in minutes from unix timestamps
-    # for valid fields of stage, see: https://docs.drone.io/api/builds/build_info/
-    ((stage[:stopped] - stage[:started]) / 60.0).round(2)
-  end
-  write_stats_table("drone-duration-stats.tsv", duration_mins_stats)
+  builds_data
 end
 
 def write_total_build_time_stats_table(builds_data, options)
@@ -254,16 +141,140 @@ def write_total_build_time_stats_table(builds_data, options)
   write_stats_table("drone-total-build-time-stats.tsv", build_time_stats)
 end
 
-if options[:json]
-  if options[:total_build_time]
-    puts JSON.pretty_generate(builds_data)
-  else
-    puts JSON.pretty_generate(build_stages)
+# ============================================================================
+# STAGE-SPECIFIC METHODS
+# ============================================================================
+
+def collect_stage_data(options)
+  build_stages = []
+  oldest_build_seen = Time.now
+  drone_page_num = 1
+
+  while oldest_build_seen >= OLDEST_BUILD_OF_INTEREST
+    raise "Exceeded hardcoded max drone API page limit (#{MAX_DRONE_PAGE_NUM})" if drone_page_num > MAX_DRONE_PAGE_NUM
+
+    builds = drone_api_get("builds?page=#{drone_page_num}").
+      select {|build| options[:only_successful] ? build[:status] == "success" : true}.
+      select {|build| options[:event] ? build[:event] == options[:event] : true}
+
+    build_nums = builds.map {|build| build[:number]}
+
+    new_build_stages = Parallel.flat_map(build_nums, in_threads: 32) do |build_num|
+      build_info = drone_api_get("builds/#{build_num}")
+
+      build_info[:stages].map do |stage|
+        next if options[:only_stages] && !options[:only_stages].include?(stage[:name])
+        {
+          **stage, # see: https://docs.drone.io/api/builds/build_info/
+          build_num: build_info[:number],
+          build: build_info,
+          date: Time.at(stage[:stopped]),
+        }
+      end
+    end.compact
+
+    unless new_build_stages.empty?
+      oldest_build_seen = new_build_stages.map {|s| s[:date]}.min
+      new_build_stages.select! {|s| s[:date] >= OLDEST_BUILD_OF_INTEREST}
+      build_stages += new_build_stages
+    end
+
+    print("#{TERMINAL_CLEAR_LINE}Processed builds back to #{oldest_build_seen}") if $stdout.tty?
+    drone_page_num += 1
   end
-else
-  if options[:total_build_time]
-    write_total_build_time_stats_table(builds_data, options)
-  else
-    write_duration_stats_table(build_stages, options)
+  puts(TERMINAL_CLEAR_LINE) if $stdout.tty?
+
+  raise "No build stages found matching the specified criteria" if build_stages.empty?
+  build_stages
+end
+
+def write_stage_stats_table(build_stages, options)
+  duration_mins_stats = compute_stage_stats_for(build_stages, options, units: "minutes", round: 2) do |stage|
+    # We don't want to generate durations for stages that are still ongoing
+    next if stage[:stopped].zero? || stage[:started].zero?
+
+    # Compute duration in minutes from unix timestamps
+    # for valid fields of stage, see: https://docs.drone.io/api/builds/build_info/
+    ((stage[:stopped] - stage[:started]) / 60.0).round(2)
+  end
+  write_stats_table("drone-duration-stats.tsv", duration_mins_stats)
+end
+
+def compute_stage_stats_for(all_build_stages, options, units: nil, round: nil, &data_selector)
+  options_filtered = options.reject {|key, value| OPTIONS_NOT_TO_OUTPUT_TO_TABLE.include?(key) || value.nil?}.inspect.tr('"', "'")
+
+  stats_for = lambda do |stage_name, build_stages|
+    data = build_stages.map(&data_selector).compact
+    {
+      stage_name: stage_name,
+      **descriptive_statistics(data, units: units, round: round),
+      options: options_filtered,
+    }
+  end
+
+  all_build_stages.group_by {|stage| stage[:name]}.map do |stage_name, subset_of_stages|
+    stats_for.call(stage_name, subset_of_stages)
   end
 end
+
+# ============================================================================
+# SHARED UTILITY METHODS
+# ============================================================================
+
+def write_stats_table(filename, data)
+  tsv = to_justified_tsv_str(data)
+  puts "## #{filename} ##"
+  puts tsv
+  puts
+  File.write(filename, tsv)
+end
+
+def to_justified_tsv_str(hash)
+  col_names = hash.first.keys
+  col_widths = col_names.map {|col| [col.to_s.length, *hash.map {|row| row[col].to_s.length}].max}
+
+  CSV.generate(col_sep: "\t", force_quotes: false) do |csv|
+    csv << col_names.map.with_index {|col, i| col.to_s.ljust(col_widths[i])}
+    hash.each {|row| csv << row.values.map.with_index {|val, i| val.to_s.ljust(col_widths[i])}}
+  end
+end
+
+def descriptive_statistics(data, units: nil, round: nil)
+  raise "All values must be numeric" unless data.all?(Numeric)
+  data = data.sort
+  quartile = ->(quartile_num) {data[(data.length * quartile_num / 4.0).floor]}
+  format = round ? ->(v) {v.round(round)} : ->(v) {v}
+  {
+    count: data.size,
+    mean: format.call(data.sum / data.size.to_f),
+    p_0: format.call(data.min),
+    p_25: format.call(quartile.call(1)),
+    p_50: format.call(quartile.call(2)),
+    p_75: format.call(quartile.call(3)),
+    p_100: format.call(data.max),
+  }
+end
+
+def drone_api_get(path)
+  drone_url = "https://drone.cdn-code.org"
+  url = "#{drone_url}/api/repos/code-dot-org/code-dot-org/#{path}"
+  drone_token = ENV.fetch('DRONE_TOKEN', nil)
+  raise "Env var DRONE_TOKEN must be set to 'Your Personal Token' from #{drone_url}/account" if drone_token.nil?
+
+  res = HTTParty.get(
+    url,
+    headers: {
+      "Authorization" => "Bearer #{ENV.fetch('DRONE_TOKEN', nil)}",
+      "Content-Type" => "application/json",
+    },
+    format: :plain,
+  )
+  raise "#{res.code} #{res.message} - GET request to #{url} failed" unless res.success?
+  JSON.parse res.body, symbolize_names: true
+end
+
+# ============================================================================
+# EXECUTE MAIN
+# ============================================================================
+
+main(options)

--- a/bin/drone/stats
+++ b/bin/drone/stats
@@ -74,74 +74,6 @@ def main(options)
 end
 
 # ============================================================================
-# TOTAL BUILD TIME METHODS
-# ============================================================================
-
-def collect_total_build_time_data(options)
-  builds_data = []
-  oldest_build_seen = Time.now
-  drone_page_num = 1
-
-  while oldest_build_seen >= OLDEST_BUILD_OF_INTEREST
-    raise "Exceeded hardcoded max drone API page limit (#{MAX_DRONE_PAGE_NUM})" if drone_page_num > MAX_DRONE_PAGE_NUM
-
-    builds = drone_api_get("builds?page=#{drone_page_num}").
-      select {|build| options[:only_successful] ? build[:status] == "success" : true}.
-      select {|build| options[:event] ? build[:event] == options[:event] : true}
-
-    new_builds = builds.map do |build|
-      next if build[:finished].zero? || build[:started].zero? || build[:created].zero?
-      {
-        number: build[:number],
-        event: build[:event],
-        status: build[:status],
-        created: build[:created],
-        started: build[:started],
-        finished: build[:finished],
-        date: Time.at(build[:finished]),
-        queue_time_minutes: ((build[:started] - build[:created]) / 60.0).round(2),
-        run_time_minutes: ((build[:finished] - build[:started]) / 60.0).round(2),
-        total_time_minutes: ((build[:finished] - build[:created]) / 60.0).round(2)
-      }
-    end.compact
-
-    unless new_builds.empty?
-      oldest_build_seen = new_builds.map {|b| b[:date]}.min
-      new_builds.select! {|b| b[:date] >= OLDEST_BUILD_OF_INTEREST}
-      builds_data += new_builds
-    end
-
-    print("#{TERMINAL_CLEAR_LINE}Processed builds back to #{oldest_build_seen}") if $stdout.tty?
-    drone_page_num += 1
-  end
-  puts(TERMINAL_CLEAR_LINE) if $stdout.tty?
-
-  raise "No builds found matching the specified criteria" if builds_data.empty?
-  builds_data
-end
-
-def write_total_build_time_stats_table(builds_data, options)
-  options_filtered = options.reject {|key, value| OPTIONS_NOT_TO_OUTPUT_TO_TABLE.include?(key) || value.nil?}.inspect.tr('"', "'")
-
-  stats_for = lambda do |metric_name, data_selector|
-    data = builds_data.map(&data_selector).compact
-    {
-      metric_type: metric_name,
-      **descriptive_statistics(data, units: "minutes", round: 2),
-      options: options_filtered,
-    }
-  end
-
-  build_time_stats = [
-    stats_for.call("queue_time", ->(build) {build[:queue_time_minutes]}),
-    stats_for.call("run_time", ->(build) {build[:run_time_minutes]}),
-    stats_for.call("total_time", ->(build) {build[:total_time_minutes]}),
-  ]
-
-  write_stats_table("drone-total-build-time-stats.tsv", build_time_stats)
-end
-
-# ============================================================================
 # STAGE-SPECIFIC METHODS
 # ============================================================================
 
@@ -215,6 +147,74 @@ def compute_stage_stats_for(all_build_stages, options, units: nil, round: nil, &
   all_build_stages.group_by {|stage| stage[:name]}.map do |stage_name, subset_of_stages|
     stats_for.call(stage_name, subset_of_stages)
   end
+end
+
+# ============================================================================
+# TOTAL BUILD TIME METHODS
+# ============================================================================
+
+def collect_total_build_time_data(options)
+  builds_data = []
+  oldest_build_seen = Time.now
+  drone_page_num = 1
+
+  while oldest_build_seen >= OLDEST_BUILD_OF_INTEREST
+    raise "Exceeded hardcoded max drone API page limit (#{MAX_DRONE_PAGE_NUM})" if drone_page_num > MAX_DRONE_PAGE_NUM
+
+    builds = drone_api_get("builds?page=#{drone_page_num}").
+      select {|build| options[:only_successful] ? build[:status] == "success" : true}.
+      select {|build| options[:event] ? build[:event] == options[:event] : true}
+
+    new_builds = builds.map do |build|
+      next if build[:finished].zero? || build[:started].zero? || build[:created].zero?
+      {
+        number: build[:number],
+        event: build[:event],
+        status: build[:status],
+        created: build[:created],
+        started: build[:started],
+        finished: build[:finished],
+        date: Time.at(build[:finished]),
+        queue_time_minutes: ((build[:started] - build[:created]) / 60.0).round(2),
+        run_time_minutes: ((build[:finished] - build[:started]) / 60.0).round(2),
+        total_time_minutes: ((build[:finished] - build[:created]) / 60.0).round(2)
+      }
+    end.compact
+
+    unless new_builds.empty?
+      oldest_build_seen = new_builds.map {|b| b[:date]}.min
+      new_builds.select! {|b| b[:date] >= OLDEST_BUILD_OF_INTEREST}
+      builds_data += new_builds
+    end
+
+    print("#{TERMINAL_CLEAR_LINE}Processed builds back to #{oldest_build_seen}") if $stdout.tty?
+    drone_page_num += 1
+  end
+  puts(TERMINAL_CLEAR_LINE) if $stdout.tty?
+
+  raise "No builds found matching the specified criteria" if builds_data.empty?
+  builds_data
+end
+
+def write_total_build_time_stats_table(builds_data, options)
+  options_filtered = options.reject {|key, value| OPTIONS_NOT_TO_OUTPUT_TO_TABLE.include?(key) || value.nil?}.inspect.tr('"', "'")
+
+  stats_for = lambda do |metric_name, data_selector|
+    data = builds_data.map(&data_selector).compact
+    {
+      metric_type: metric_name,
+      **descriptive_statistics(data, units: "minutes", round: 2),
+      options: options_filtered,
+    }
+  end
+
+  build_time_stats = [
+    stats_for.call("queue_time", ->(build) {build[:queue_time_minutes]}),
+    stats_for.call("run_time", ->(build) {build[:run_time_minutes]}),
+    stats_for.call("total_time", ->(build) {build[:total_time_minutes]}),
+  ]
+
+  write_stats_table("drone-total-build-time-stats.tsv", build_time_stats)
 end
 
 # ============================================================================

--- a/bin/drone/stats
+++ b/bin/drone/stats
@@ -102,10 +102,11 @@ while oldest_build_seen >= OLDEST_BUILD_OF_INTEREST
       }
     end.compact
 
-    raise "No new builds found" if new_builds.empty?
-    oldest_build_seen = new_builds.map {|b| b[:date]}.min
-    new_builds.select! {|b| b[:date] >= OLDEST_BUILD_OF_INTEREST}
-    builds_data += new_builds
+    unless new_builds.empty?
+      oldest_build_seen = new_builds.map {|b| b[:date]}.min
+      new_builds.select! {|b| b[:date] >= OLDEST_BUILD_OF_INTEREST}
+      builds_data += new_builds
+    end
   else
     # For stage-level analysis, use existing logic
     build_nums = builds.map {|build| build[:number]}
@@ -124,16 +125,24 @@ while oldest_build_seen >= OLDEST_BUILD_OF_INTEREST
       end
     end.compact
 
-    raise "No new build stages found, is --only-stages set correctly?" if new_build_stages.empty?
-    oldest_build_seen = new_build_stages.map {|s| s[:date]}.min
-    new_build_stages.select! {|s| s[:date] >= OLDEST_BUILD_OF_INTEREST}
-    build_stages += new_build_stages
+    unless new_build_stages.empty?
+      oldest_build_seen = new_build_stages.map {|s| s[:date]}.min
+      new_build_stages.select! {|s| s[:date] >= OLDEST_BUILD_OF_INTEREST}
+      build_stages += new_build_stages
+    end
   end
 
   print("#{TERMINAL_CLEAR_LINE}Processed builds back to #{oldest_build_seen}") if $stdout.tty?
   drone_page_num += 1
 end
 puts(TERMINAL_CLEAR_LINE) if $stdout.tty?
+
+# Check if we found any data
+if options[:total_build_time]
+  raise "No builds found matching the specified criteria" if builds_data.empty?
+else
+  raise "No build stages found matching the specified criteria" if build_stages.empty?
+end
 
 def descriptive_statistics(data, units: nil, round: nil)
   raise "All values must be numeric" unless data.all?(Numeric)


### PR DESCRIPTION
today `bin/drone/stats` computes per-pipeline metrics for ui / unit test run times in drone. This PR adds the ability to print the total time for drone builds, including a breakdown by wait time and build time. This is to help produce a clearer top-level measure for any potential drone improvements (or regressions). Here is how the new stats look:
```
[10:14:22] Dave-M4:~/src/cdo (drone-total-time-stats %)$ bin/drone/stats --event=pull_request --total-build-time --ago="4 weeks"

## drone-total-build-time-stats.tsv ##
metric_type	count	mean 	p_0  	p_25 	p_50 	p_75  	p_100  	options
queue_time 	629  	2.96 	0.0  	0.02 	0.02 	0.17  	83.35  	{:ago=>4 weeks, :only_successful=>true, :event=>'pull_request', :total_build_time=>true}
run_time   	629  	93.61	61.47	80.3 	84.92	102.82	1134.1 	{:ago=>4 weeks, :only_successful=>true, :event=>'pull_request', :total_build_time=>true}
total_time 	629  	96.57	61.48	80.58	87.03	106.63	1134.25	{:ago=>4 weeks, :only_successful=>true, :event=>'pull_request', :total_build_time=>true}
```

While I was in here, I also took the liberty of removing the "sum" column as well as the "ALL" row from the output of the existing per-stage (pipeline) stats. I didn't see a use for these, but lmk if you prefer to keep them and I'll add them back:
```
[11:02:12] Dave-M4:~/src/cdo (drone-total-time-stats %)$ bin/drone/stats --event=pull_request --ago="4 weeks"

## drone-duration-stats.tsv ##
stage_name                   	count	mean 	p_0  	p_25 	p_50 	p_75  	p_100 	options
unit                         	628  	70.16	26.5 	42.8 	45.45	102.75	144.22	{:ago=>4 weeks, :only_successful=>true, :event=>'pull_request', :total_build_time=>false}
ui                           	629  	79.29	60.92	77.38	79.92	82.1  	140.23	{:ago=>4 weeks, :only_successful=>true, :event=>'pull_request', :total_build_time=>false}
cache-staging-build-artifacts	3    	93.54	77.0 	77.0 	96.43	107.18	107.18	{:ago=>4 weeks, :only_successful=>true, :event=>'pull_request', :total_build_time=>false}
```

side note: the `cache-staging-build-artifacts` pipeline is showing up in the output despite the `--event=pull_request` filter due to [a draft PR which temporarily hacks the trigger logic](https://github.com/code-dot-org/code-dot-org/pull/68860/files#diff-b54b39f1afced2465e1f3641db9d5bbf4f3a7fcf890996dfedd3c197bcb7f8c7R323-R335). those results can be filtered out when running in either mode via `--only-stages`:
```
[11:34:51] Dave-M4:~/src/cdo (drone-total-time-stats %)$ bin/drone/stats --event=pull_request --ago="4 weeks ago" --only_stages=unit,ui

## drone-duration-stats.tsv ##
stage_name	count	mean 	p_0  	p_25 	p_50 	p_75  	p_100 	options
unit      	628  	70.24	26.5 	42.8 	45.48	102.75	144.22	{:ago=>4 weeks, :only_successful=>true, :only_stages=>['unit', 'ui'], :event=>'pull_request', :total_build_time=>false}
ui        	631  	79.31	60.92	77.38	79.92	82.17 	140.23	{:ago=>4 weeks, :only_successful=>true, :only_stages=>['unit', 'ui'], :event=>'pull_request', :total_build_time=>false}

[11:44:49] Dave-M4:~/src/cdo (drone-total-time-stats *%)$ bin/drone/stats --event=pull_request --ago="4 weeks" --only_stages=unit,ui --total-build-time --verbose
Skipping build #41729 with unexpected stages: cache-staging-build-artifacts
Skipping build #41695 with unexpected stages: cache-staging-build-artifacts
Skipping build #41307 with unexpected stages: cache-staging-build-artifacts

## drone-total-build-time-stats.tsv ##
metric_type	count	mean 	p_0  	p_25 	p_50 	p_75  	p_100 	options
queue_time 	629  	2.98 	0.0  	0.02 	0.02 	0.17  	83.35 	{:ago=>4 weeks, :only_successful=>true, :only_stages=>['unit', 'ui'], :verbose=>true, :event=>'pull_request', :total_build_time=>true}
run_time   	629  	91.57	61.47	80.3 	84.97	102.75	144.22	{:ago=>4 weeks, :only_successful=>true, :only_stages=>['unit', 'ui'], :verbose=>true, :event=>'pull_request', :total_build_time=>true}
total_time 	629  	94.55	61.48	80.58	87.03	106.55	177.63	{:ago=>4 weeks, :only_successful=>true, :only_stages=>['unit', 'ui'], :verbose=>true, :event=>'pull_request', :total_build_time=>true}
```