### PR TITLE
Revert "add levelbuilder modal"

### DIFF
--- a/dashboard/app/views/teacher_dashboard/show.html.haml
+++ b/dashboard/app/views/teacher_dashboard/show.html.haml
@@ -28,21 +28,5 @@
     = render partial: 'layouts/implicit_new_user_terms_interstitial'
   - if Policies::Ai.ai_differentiation_enabled?(current_user)
     %div#ai-differentiation-fab-mount-point
-  - if current_user.levelbuilder?
-    = render layout: 'shared/extra_links' do
-      %li= link_to 'Videos', videos_path
-      %li= link_to 'Images', '/images/new'
-      %li
-        = link_to 'Scripts', scripts_path
-        = link_to '(Update all)', scripts_path(rake: '1'), data: { confirm: 'Are you sure want to re-seed script data?'}
-      %li= link_to 'Courses', all_courses_path
-      %li= link_to t('builder.manage'), levels_path
-      %li= link_to 'Block Pools', pools_path
-      %li= link_to 'Shared Functions', shared_blockly_functions_path
-      %li= link_to 'Helper Libraries', libraries_path
-      %li= link_to 'Gallery', 'projects/public'
-      %li= link_to 'Foorm Surveys (preview)', 'foorm/forms/editor'
-      %li= link_to '(BETA) Sprite Lab Sprite Management', 'sprites'
-      %li= link_to 'Helpful Links', helpful_links_path
 
 #teacher-dashboard


### PR DESCRIPTION
Reverts code-dot-org/code-dot-org#68848

This change is causing eyes diffs in test because certain tests are apparently being run with Levelbuilder permission, triggering this modal. It's unclear at this late hour whether that's desired or not, so we're reverting.