### PR TITLE
Image Generation for HoAI

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -394,6 +394,9 @@ gem "webrick", "~> 1.9"
 
 gem 'rubyzip'
 
+gem 'chunky_png', '~> 1.4'
+gem 'ruby-openai', '~> 6.5'
+
 # Automatically include all rails engines
 Dir[Bundler.root.join('**/engines/*/*.gemspec')].sort.each do |gemspec_path|
   gem File.basename(gemspec_path, '.gemspec'), path: '.', glob: '**/engines/*/*.gemspec'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -298,6 +298,7 @@ GEM
     childprocess (5.1.0)
       logger (~> 1.5)
     chronic (0.10.2)
+    chunky_png (1.4.0)
     cld (0.13.0)
       ffi
     cldr-plurals-runtime-rb (1.1.0)
@@ -377,6 +378,7 @@ GEM
     dry-cli (1.3.0)
     e2mmap (0.1.0)
     erubi (1.12.0)
+    event_stream_parser (1.0.0)
     eventmachine (1.2.7)
     execjs (2.7.0)
     exifr (1.2.5)
@@ -833,6 +835,10 @@ GEM
       rubocop (>= 1.7.0, < 2.0)
     rubocop-rails-accessibility (0.2.0)
       rubocop (>= 1.0.0)
+    ruby-openai (6.5.0)
+      event_stream_parser (>= 0.3.0, < 2.0.0)
+      faraday (>= 1)
+      faraday-multipart (>= 1)
     ruby-prof (1.7.0)
     ruby-progressbar (1.13.0)
     ruby-rc4 (0.1.5)
@@ -1030,6 +1036,7 @@ DEPENDENCIES
   cdo_contentful!
   cgi (~> 0.3.6)
   chronic (~> 0.10.2)
+  chunky_png (~> 1.4)
   cld
   colorize
   composite_primary_keys (~> 13.0)
@@ -1150,6 +1157,7 @@ DEPENDENCIES
   rubocop-performance
   rubocop-rails
   rubocop-rails-accessibility
+  ruby-openai (~> 6.5)
   ruby-prof (>= 1.7.0)
   ruby-progressbar
   rubyzip

--- a/dashboard/app/jobs/doctor_dance_party_images_batch_job.rb
+++ b/dashboard/app/jobs/doctor_dance_party_images_batch_job.rb
@@ -1,0 +1,43 @@
+class DoctorDancePartyImagesBatchJob < ApplicationJob
+  queue_as :images
+
+  # options: {
+  #   bucket:, namespace:, folders:, transparency_threshold:, regenerate:, regen_namespace:,
+  #   force_recompute_colors:, normalize_grays:
+  # }
+  def perform(options = {})
+    bucket     = options[:bucket]     || DancePartyImageGenerator::Settings.bucket
+    namespace  = options[:namespace]  || DancePartyImageGenerator::Settings.namespace
+    folders    = Array(options[:folders]).presence || %w[animal animal-attire adjective-animal-attire]
+    regen      = !!options[:regenerate]
+    regen_ns   = options[:regen_namespace] # write regens into a different S3 prefix (optional)
+    threshold  = (options[:transparency_threshold] || 0.90).to_f
+    force_cols = !!options[:force_recompute_colors]
+    normalize  = options.key?(:normalize_grays) ? !!options[:normalize_grays] : true
+
+    storage = DancePartyImageGenerator::Storage::S3Storage.new(bucket: bucket, namespace: namespace)
+
+    total = 0
+    folders.each do |folder|
+      storage.list_json(folder).each do |meta_key|
+        DoctorOneDancePartyImageJob.perform_later(
+          meta_key,
+          {
+            bucket: bucket,
+            namespace: namespace,
+            transparency_threshold: threshold,
+            regenerate: regen,
+            regen_namespace: regen_ns,
+            force_recompute_colors: force_cols,
+            normalize_grays: normalize
+          }
+        )
+        total += 1
+      end
+    end
+
+    Rails.logger.info("[DPIG][DoctorBatch] Enqueued #{total} doctor jobs " \
+                      "(bucket=#{bucket}, ns=#{namespace || '(none)'})."
+)
+  end
+end

--- a/dashboard/app/jobs/doctor_one_dance_party_image_job.rb
+++ b/dashboard/app/jobs/doctor_one_dance_party_image_job.rb
@@ -1,0 +1,83 @@
+class DoctorOneDancePartyImageJob < ApplicationJob
+  queue_as :images
+  retry_on StandardError, attempts: 5, wait: :exponentially_longer
+
+  # meta_key: relative key to *-metadata.json under namespace
+  def perform(meta_key, opts = {})
+    bucket     = opts[:bucket]
+    namespace  = opts[:namespace]
+    regen_ns   = opts[:regen_namespace]
+    threshold  = opts[:transparency_threshold] || 0.90
+    regenerate = !!opts[:regenerate]
+    force_cols = !!opts[:force_recompute_colors]
+    normalize  = opts.key?(:normalize_grays) ? !!opts[:normalize_grays] : true
+
+    storage    = DancePartyImageGenerator::Storage::S3Storage.new(bucket: bucket, namespace: namespace)
+    meta       = storage.read_json(meta_key)
+    png_key    = DancePartyImageGenerator::Storage::S3Storage::Storage.png_for(meta_key, meta)
+
+    # Make sure the image exists
+    full_png   = storage.full_key(png_key)
+    unless AWS::S3.exists_in_bucket(bucket, full_png)
+      Rails.logger.warn("[DPIG][Doctor] Missing image for #{meta_key} -> #{png_key}")
+      return
+    end
+
+    # Load bytes for analysis
+    png_bytes = AWS::S3.download_from_bucket(bucket, full_png)
+
+    # Transparency check
+    if DancePartyImageGenerator::PaletteExtractor.too_transparent?(png_bytes, threshold: threshold)
+      Rails.logger.warn("[DPIG][Doctor] Too transparent #{png_key} (>= #{(threshold*100).round}% alpha=0)")
+      if regenerate
+        # Decide where to write regenerated assets
+        dest_ns   = regen_ns.presence || namespace
+        dest_store = DancePartyImageGenerator::Storage::S3Storage.new(bucket: bucket, namespace: dest_ns)
+
+        prompt = meta["prompt_used"] ||
+          DancePartyImageGenerator::PromptBuilder.new.build(
+            adj: meta["adjective"], animal: meta["animal"], attire: meta["attire"]
+          )
+
+        client = OpenAI::Client.new(access_token: ENV.fetch("OPENAI_API_KEY", nil))
+        b64 = client.images.generate(
+          parameters: {model: "gpt-image-1", prompt: prompt, size: "1024x1024", n: 1, background: "transparent"}
+        ).dig("data", 0, "b64_json")
+
+        # Save regenerated
+        dest_store.write_png_base64(png_key, b64, width: 1024, height: 1024)
+        png_bytes = AWS::S3.download_from_bucket(bucket, dest_store.full_key(png_key))
+        body, sec, ter = DancePartyImageGenerator::PaletteExtractor.extract_png_bytes(png_bytes, normalize_grays: normalize)
+
+        new_meta = meta.merge(
+          "file_name"          => File.basename(png_key),
+          "body_color"         => body,
+          "secondary_color"    => sec,
+          "tertiary_color"     => ter,
+          "regenerated"        => true,
+          "regen_reason"       => "too_transparent",
+          "regen_output_ns"    => dest_ns
+        )
+        dest_store.write_json(meta_key, DancePartyImageGenerator::Metadata::Record.dump(new_meta))
+      end
+      return
+    end
+
+    # Palette refresh: recompute or fill missing
+    need_cols = force_cols ||
+      meta["body_color"].to_s.blank? ||
+      meta["secondary_color"].to_s.blank? ||
+      meta["tertiary_color"].to_s.blank?
+
+    if need_cols
+      body, sec, ter = DancePartyImageGenerator::PaletteExtractor.extract_png_bytes(png_bytes, normalize_grays: normalize)
+      changed = (meta["body_color"] != body) || (meta["secondary_color"] != sec) || (meta["tertiary_color"] != ter)
+      if changed
+        meta["body_color"] = body
+        meta["secondary_color"] = sec
+        meta["tertiary_color"] = ter
+        storage.write_json(meta_key, DancePartyImageGenerator::Metadata::Record.dump(meta))
+      end
+    end
+  end
+end

--- a/dashboard/app/jobs/generate_dance_party_images_batch_job.rb
+++ b/dashboard/app/jobs/generate_dance_party_images_batch_job.rb
@@ -1,0 +1,58 @@
+class GenerateDancePartyImagesBatchJob < ApplicationJob
+  queue_as :images
+
+  # options: { repeats_per_combo:, bucket:, namespace:, sets: %i[animal animal_attire adj_animal_attire] }
+  def perform(options = {})
+    animals    = DancePartyImageGenerator::Settings.animals
+    attire     = DancePartyImageGenerator::Settings.attire
+    adjectives = DancePartyImageGenerator::Settings.adjectives
+    repeats    = (options[:repeats_per_combo] || DancePartyImageGenerator::Settings.repeats).to_i
+    bucket     = options[:bucket]    || DancePartyImageGenerator::Settings.bucket
+    namespace  = options[:namespace] || DancePartyImageGenerator::Settings.namespace
+    sets       = Array(options[:sets]).presence || %i[animal animal_attire adj_animal_attire]
+
+    # Build deduped plan in required order per animal:
+    # 1) animal
+    # 2) animal + attire
+    # 3) adjective + animal + attire
+    combos = []
+    animals.each do |animal|
+      combos << {animal:, adj: nil, attire: nil} if sets.include?(:animal)
+      if sets.include?(:animal_attire)
+        attire.each {|att| combos << {animal:, adj: nil, attire: att}}
+      end
+      if sets.include?(:adj_animal_attire)
+        attire.each do |att|
+          adjectives.each do |adj|
+            combos << {animal:, adj:, attire: att}
+          end
+        end
+      end
+    end
+
+    # Enqueue each variant as its own job for maximum parallelism
+    count = 0
+    combos.each do |combo|
+      repeats.times do |v|
+        item = combo.merge(variant: v)
+        dest =
+          if combo[:adj].nil? && combo[:attire].nil?
+            :animal
+          elsif combo[:adj].nil? && combo[:attire].present?
+            :animal_attire
+          else
+            :adj_animal_attire
+          end
+
+        GenerateOneDancePartyImageJob.perform_later(
+          item,
+          dest,
+          {bucket:, namespace: namespace}
+        )
+        count += 1
+      end
+    end
+
+    Rails.logger.info("[DPIG] Enqueued #{count} image jobs (bucket=#{bucket}, ns=#{namespace || '(none)'}).")
+  end
+end

--- a/dashboard/app/jobs/generate_one_dance_party_image_job.rb
+++ b/dashboard/app/jobs/generate_one_dance_party_image_job.rb
@@ -1,0 +1,39 @@
+class GenerateOneDancePartyImageJob < ApplicationJob
+  queue_as :images
+  retry_on StandardError, attempts: 5, wait: :exponentially_longer
+
+  # item: { adj:, animal:, attire:, variant: }
+  # dest: :animal | :animal_attire | :adj_animal_attire
+  # opts: { bucket:, namespace: }
+  def perform(item, dest, opts = {})
+    bucket    = opts.symbolize_keys[:bucket]    || DancePartyImageGenerator::Settings.bucket
+    namespace = opts.symbolize_keys[:namespace] || DancePartyImageGenerator::Settings.namespace
+
+    storage = DancePartyImageGenerator::Storage::S3Storage.new(bucket: bucket, namespace: namespace)
+    prompt  = DancePartyImageGenerator::PromptBuilder.new(width: 1024, height: 1024)
+
+    # Plan → base name and keys
+    base     = DancePartyImageGenerator::Naming.base_name(item.symbolize_keys) # e.g., "emo-frog-headband-00"
+    png_rel  = DancePartyImageGenerator::Storage::S3Storage::Storage.path_for(dest: dest.to_sym, base: base, ext: ".png")
+    json_rel = DancePartyImageGenerator::Storage::S3Storage::Storage.path_for(dest: dest.to_sym, base: base, ext: "-metadata.json")
+
+    # Idempotency: skip if both already exist
+    if AWS::S3.exists_in_bucket(bucket, storage.full_key(png_rel)) &&
+        AWS::S3.exists_in_bucket(bucket, storage.full_key(json_rel))
+      Rails.logger.info("[DPIG] Skip existing #{base}")
+      return
+    end
+
+    # Generate one via the service (reusing your adapter + robust palette)
+    gen = DancePartyImageGenerator::ImageGenerator.new(
+      openai: OpenAI::Client.new(access_token: ENV.fetch("OPENAI_API_KEY", nil)),
+      storage: storage,
+      prompt_builder: prompt,
+      palette_extractor: DancePartyImageGenerator::PaletteExtractor.new,
+      logger: Rails.logger,
+      width: 1024, height: 1024, model: "gpt-image-1", background: "transparent"
+    )
+
+    gen.call(plan: [item.symbolize_keys], dest: dest.to_sym)
+  end
+end

--- a/dashboard/app/jobs/generate_one_dance_party_image_job.rb
+++ b/dashboard/app/jobs/generate_one_dance_party_image_job.rb
@@ -1,21 +1,32 @@
+# app/jobs/generate_one_dance_party_image_job.rb
+require "openai"
+
 class GenerateOneDancePartyImageJob < ApplicationJob
   queue_as :images
   retry_on StandardError, attempts: 5, wait: :exponentially_longer
+
+  IMG_W = 1024
+  IMG_H = 1024
+  MODEL = "gpt-image-1"
 
   # item: { adj:, animal:, attire:, variant: }
   # dest: :animal | :animal_attire | :adj_animal_attire
   # opts: { bucket:, namespace: }
   def perform(item, dest, opts = {})
+    item      = item.symbolize_keys
+    dest      = dest.to_sym
     bucket    = opts.symbolize_keys[:bucket]    || DancePartyImageGenerator::Settings.bucket
     namespace = opts.symbolize_keys[:namespace] || DancePartyImageGenerator::Settings.namespace
 
-    storage = DancePartyImageGenerator::Storage::S3Storage.new(bucket: bucket, namespace: namespace)
-    prompt  = DancePartyImageGenerator::PromptBuilder.new(width: 1024, height: 1024)
+    key = CDO.openai_student_learning_api_key.presence || ENV.fetch("OPENAI_API_KEY", nil)
+    raise "Missing OpenAI API key (set openai_student_learning_api_key or OPENAI_API_KEY)" if key.blank?
 
-    # Plan → base name and keys
-    base     = DancePartyImageGenerator::Naming.base_name(item.symbolize_keys) # e.g., "emo-frog-headband-00"
-    png_rel  = DancePartyImageGenerator::Storage::S3Storage::Storage.path_for(dest: dest.to_sym, base: base, ext: ".png")
-    json_rel = DancePartyImageGenerator::Storage::S3Storage::Storage.path_for(dest: dest.to_sym, base: base, ext: "-metadata.json")
+    storage = DancePartyImageGenerator::Storage::S3Storage.new(bucket: bucket, namespace: namespace)
+    prompt  = DancePartyImageGenerator::PromptBuilder.new(width: IMG_W, height: IMG_H)
+
+    base     = DancePartyImageGenerator::Naming.base_name(item) # e.g., "emo-frog-headband-00"
+    png_rel  = DancePartyImageGenerator::Storage::S3Storage::Storage.path_for(dest: dest, base: base, ext: ".png")
+    json_rel = DancePartyImageGenerator::Storage::S3Storage::Storage.path_for(dest: dest, base: base, ext: "-metadata.json")
 
     # Idempotency: skip if both already exist
     if AWS::S3.exists_in_bucket(bucket, storage.full_key(png_rel)) &&
@@ -24,16 +35,18 @@ class GenerateOneDancePartyImageJob < ApplicationJob
       return
     end
 
-    # Generate one via the service (reusing your adapter + robust palette)
     gen = DancePartyImageGenerator::ImageGenerator.new(
-      openai: OpenAI::Client.new(access_token: ENV.fetch("OPENAI_API_KEY", nil)),
+      openai: OpenAI::Client.new(access_token: key),                 # ← keyword arg
       storage: storage,
       prompt_builder: prompt,
       palette_extractor: DancePartyImageGenerator::PaletteExtractor.new,
       logger: Rails.logger,
-      width: 1024, height: 1024, model: "gpt-image-1", background: "transparent"
+      width: IMG_W, height: IMG_H, model: MODEL, background: "transparent"
     )
 
-    gen.call(plan: [item.symbolize_keys], dest: dest.to_sym)
+    gen.call(plan: [item], dest: dest)
+  rescue => exception
+    Rails.logger.error("[DPIG] GenerateOneDancePartyImageJob failed for #{base || item.inspect}: #{exception.class}: #{exception.message}")
+    raise
   end
 end

--- a/dashboard/app/jobs/refresh_palette_batch_job.rb
+++ b/dashboard/app/jobs/refresh_palette_batch_job.rb
@@ -1,0 +1,26 @@
+class RefreshPaletteBatchJob < ApplicationJob
+  queue_as :images
+
+  # opts: { bucket:, namespace:, folders:, force:, normalize_grays: }
+  def perform(opts = {})
+    bucket     = opts[:bucket]    || DancePartyImageGenerator::Settings.bucket
+    namespace  = opts[:namespace] || DancePartyImageGenerator::Settings.namespace
+    folders    = Array(opts[:folders]).presence || %w[animal animal-attire adjective-animal-attire]
+    force      = !!opts[:force]
+    normalize  = opts.key?(:normalize_grays) ? !!opts[:normalize_grays] : true
+
+    storage = DancePartyImageGenerator::Storage::S3Storage.new(bucket: bucket, namespace: namespace)
+
+    total = 0
+    folders.each do |folder|
+      storage.list_json(folder).each do |meta_key|
+        RefreshPaletteOneJob.perform_later(meta_key, {
+                                             bucket: bucket, namespace: namespace, force: force, normalize_grays: normalize
+                                           }
+)
+        total += 1
+      end
+    end
+    Rails.logger.info("[DPIG][PaletteBatch] Enqueued #{total} palette jobs.")
+  end
+end

--- a/dashboard/app/jobs/refresh_palette_one_job.rb
+++ b/dashboard/app/jobs/refresh_palette_one_job.rb
@@ -19,7 +19,8 @@ class RefreshPaletteOneJob < ApplicationJob
     return unless need
 
     bytes = AWS::S3.download_from_bucket(bucket, full_png)
-    body, sec, ter = DancePartyImageGenerator::PaletteExtractor.extract_png_bytes(bytes, normalize_grays: normalize)
+    pe = DancePartyImageGenerator::PaletteExtractor.new(normalize_grays: normalize)
+    body, sec, ter = pe.extract(bytes)
     meta["body_color"] = body
     meta["secondary_color"] = sec
     meta["tertiary_color"] = ter

--- a/dashboard/app/jobs/refresh_palette_one_job.rb
+++ b/dashboard/app/jobs/refresh_palette_one_job.rb
@@ -1,0 +1,28 @@
+class RefreshPaletteOneJob < ApplicationJob
+  queue_as :images
+  retry_on StandardError, attempts: 5, wait: :exponentially_longer
+
+  def perform(meta_key, opts = {})
+    bucket    = opts[:bucket]
+    namespace = opts[:namespace]
+    force     = !!opts[:force]
+    normalize = opts.key?(:normalize_grays) ? !!opts[:normalize_grays] : true
+
+    storage = DancePartyImageGenerator::Storage::S3Storage.new(bucket: bucket, namespace: namespace)
+    meta    = storage.read_json(meta_key)
+    png_key = DancePartyImageGenerator::Storage::S3Storage::Storage.png_for(meta_key, meta)
+
+    full_png = storage.full_key(png_key)
+    return unless AWS::S3.exists_in_bucket(bucket, full_png)
+
+    need = force || meta["body_color"].to_s.blank? || meta["secondary_color"].to_s.blank? || meta["tertiary_color"].to_s.blank?
+    return unless need
+
+    bytes = AWS::S3.download_from_bucket(bucket, full_png)
+    body, sec, ter = DancePartyImageGenerator::PaletteExtractor.extract_png_bytes(bytes, normalize_grays: normalize)
+    meta["body_color"] = body
+    meta["secondary_color"] = sec
+    meta["tertiary_color"] = ter
+    storage.write_json(meta_key, DancePartyImageGenerator::Metadata::Record.dump(meta))
+  end
+end

--- a/dashboard/app/services/DancePartyImageGenerator/image_doctor.rb
+++ b/dashboard/app/services/DancePartyImageGenerator/image_doctor.rb
@@ -1,0 +1,76 @@
+module DancePartyImageGenerator
+  class ImageDoctor
+    def initialize(storage:, palette_extractor:, openai: nil, logger: Rails.logger, regenerate: false, regen_mode: :inplace, regen_root: nil)
+      @storage = storage
+      @palette = palette_extractor
+      @openai = openai
+      @logger = logger
+      @regenerate = regenerate
+      @regen_mode = regen_mode
+      @regen_root = regen_root
+    end
+
+    # folders: %w[animal animal-attire adjective-animal-attire]
+    def call(folders:, transparency_threshold: 0.90)
+      folders.each do |folder|
+        @storage.list_json(folder).each do |meta_key|
+          meta = @storage.read_json(meta_key)
+          png_key = Storage.png_for(meta_key, meta)
+          next unless AWS::S3.exists_in_bucket(@storage.bucket, @storage.full_key(png_key))
+
+          img = @storage.read_png(png_key)
+          if too_transparent?(img, threshold: transparency_threshold)
+            regenerate(meta_key, meta, png_key) if @regenerate && @openai
+            next
+          end
+
+          body, sec, ter = @palette.extract(img)
+          if needs_patch?(meta, body, sec, ter)
+            meta["body_color"] = body
+            meta["secondary_color"] = sec
+            meta["tertiary_color"] = ter
+            @storage.write_json(meta_key, Metadata::Record.dump(meta))
+          end
+        end
+      end
+    end
+
+    private def needs_patch?(meta, body, sec, ter)
+      meta["body_color"] != body || meta["secondary_color"] != sec || meta["tertiary_color"] != ter
+    end
+
+    private def too_transparent?(img, threshold:)
+      alpha = img.alpha_channel
+      (alpha.count {|a| a == 0}.to_f / alpha.size) >= threshold
+    end
+
+    private def regenerate(meta_key, meta, png_key)
+      dest_png_key, dest_meta_key =
+        if @regen_mode == :separate
+          Storage.mirror_keys(@regen_root, meta_key, png_key)
+        else
+          [png_key, meta_key]
+        end
+
+      prompt = meta["prompt_used"] || PromptBuilder.new.build(meta.symbolize_keys.slice(:adj, :animal, :attire))
+      b64 = @openai.images.generate(
+        parameters: {model: "gpt-image-1", prompt:, size: "1024x1024", n: 1, background: "transparent"}
+      ).dig("data", 0, "b64_json")
+
+      @storage.write_png_base64(dest_png_key, b64)
+      img2 = @storage.read_png(dest_png_key)
+      body, sec, ter = @palette.extract(img2)
+
+      new_meta = meta.merge(
+        "file_name"          => File.basename(dest_png_key),
+        "body_color"         => body,
+        "secondary_color"    => sec,
+        "tertiary_color"     => ter,
+        "regenerated"        => true,
+        "regen_reason"       => "too_transparent",
+        "regen_output_mode"  => @regen_mode.to_s
+      )
+      @storage.write_json(dest_meta_key, Metadata::Record.dump(new_meta))
+    end
+  end
+end

--- a/dashboard/app/services/DancePartyImageGenerator/image_generator.rb
+++ b/dashboard/app/services/DancePartyImageGenerator/image_generator.rb
@@ -1,0 +1,57 @@
+module DancePartyImageGenerator
+  class ImageGenerator
+    DEFAULTS = {width: 1024, height: 1024, model: "gpt-image-1", background: "transparent", retries: 5}.freeze
+
+    def initialize(openai:, storage:, prompt_builder:, palette_extractor:, logger: Rails.logger, **opts)
+      @openai = openai
+      @storage = storage
+      @prompt = prompt_builder
+      @palette = palette_extractor
+      @logger = logger
+      @cfg = DEFAULTS.merge(opts)
+    end
+
+    def call(plan:, dest:)
+      plan.each {|item| generate_one(item, dest)}
+    end
+
+    private def generate_one(item, dest)
+      base     = Naming.base_name(item)
+      png_key  = Storage.path_for(dest: dest, base: base, ext: ".png")
+      json_key = Storage.path_for(dest: dest, base: base, ext: "-metadata.json")
+
+      if AWS::S3.exists_in_bucket(@storage.bucket, @storage.full_key(png_key)) &&
+          AWS::S3.exists_in_bucket(@storage.bucket, @storage.full_key(json_key))
+        return
+      end
+
+      prompt = @prompt.build(item)
+      b64    = request_image(prompt)
+
+      @storage.write_png_base64(png_key, b64, width: @cfg[:width], height: @cfg[:height])
+      img = @storage.read_png(png_key)
+
+      body, sec, ter = @palette.extract(img)
+      record = Metadata::Record.from(
+        item,
+        file_name: File.basename(png_key),
+        prompt_used: prompt,
+        body_color: body, secondary_color: sec, tertiary_color: ter
+      )
+      @storage.write_json(json_key, Metadata::Record.dump(record))
+    rescue => exception
+      @logger.error("[DPIG][ImageGenerator] generate_one failed for #{base}: #{exception.class}: #{exception.message}")
+      # optionally: raise
+    end
+
+    private def request_image(prompt)
+      resp = @openai.images.generate(
+        parameters: {
+          model: @cfg[:model], prompt: prompt,
+          size: "#{@cfg[:width]}x#{@cfg[:height]}", n: 1, background: @cfg[:background]
+        }
+      )
+      resp.dig("data", 0, "b64_json") || raise("no image data")
+    end
+  end
+end

--- a/dashboard/app/services/DancePartyImageGenerator/image_generator.rb
+++ b/dashboard/app/services/DancePartyImageGenerator/image_generator.rb
@@ -1,6 +1,7 @@
 module DancePartyImageGenerator
   class ImageGenerator
     DEFAULTS = {width: 1024, height: 1024, model: "gpt-image-1", background: "transparent", retries: 5}.freeze
+    PATHS = Storage::S3Storage::Storage
 
     def initialize(openai:, storage:, prompt_builder:, palette_extractor:, logger: Rails.logger, **opts)
       @openai = openai
@@ -17,8 +18,8 @@ module DancePartyImageGenerator
 
     private def generate_one(item, dest)
       base     = Naming.base_name(item)
-      png_key  = Storage.path_for(dest: dest, base: base, ext: ".png")
-      json_key = Storage.path_for(dest: dest, base: base, ext: "-metadata.json")
+      png_key  = PATHS.path_for(dest: dest, base: base, ext: ".png")
+      json_key = PATHS.path_for(dest: dest, base: base, ext: "-metadata.json")
 
       if AWS::S3.exists_in_bucket(@storage.bucket, @storage.full_key(png_key)) &&
           AWS::S3.exists_in_bucket(@storage.bucket, @storage.full_key(json_key))

--- a/dashboard/app/services/DancePartyImageGenerator/metadata/record.rb
+++ b/dashboard/app/services/DancePartyImageGenerator/metadata/record.rb
@@ -1,0 +1,62 @@
+module DancePartyImageGenerator
+  module Metadata
+    class Record
+      DEFAULT_WIDTH  = 1024
+      DEFAULT_HEIGHT = 1024
+
+      def self.from(item, file_name:, prompt_used:, body_color:, secondary_color:, tertiary_color:, width: DEFAULT_WIDTH, height: DEFAULT_HEIGHT)
+        {
+          "id"              => SecureRandom.uuid,
+          "file_name"       => file_name,
+          "title"           => title_for(item),
+          "description"     => desc_for(item),
+          "tags"            => tags_for(item),
+          "width"           => width,
+          "height"          => height,
+          "orientation"     => "portrait",
+          "color_palette"   => [],
+          "people_count"    => 0,
+          "copy_space"      => false,
+          "background"      => "transparent",
+          "adjective"       => item[:adj],
+          "animal"          => item[:animal],
+          "attire"          => item[:attire],
+          "variant"         => item[:variant],
+          "prompt_used"     => prompt_used,
+          "body_color"      => body_color,
+          "secondary_color" => secondary_color,
+          "tertiary_color"  => tertiary_color
+        }
+      end
+
+      # Serialization helpers
+      def self.dump(record_hash) = JSON.pretty_generate(record_hash)
+      def self.load(json_str)    = JSON.parse(json_str)
+
+      # Formatting helpers
+      def self.title_for(i)
+        if i[:adj] && i[:attire]
+          "#{i[:adj].to_s.titleize} #{i[:animal].to_s.titleize} In #{i[:attire].to_s.titleize}"
+        elsif i[:attire]
+          "#{i[:animal].to_s.titleize} In #{i[:attire].to_s.titleize}"
+        else
+          i[:animal].to_s.titleize
+        end
+      end
+
+      def self.desc_for(i)
+        if i[:adj] && i[:attire]
+          "#{i[:adj]} #{i[:animal]} in #{i[:attire]}"
+        elsif i[:attire]
+          "#{i[:animal]} in #{i[:attire]}"
+        else
+          i[:animal].to_s
+        end
+      end
+
+      def self.tags_for(i)
+        [i[:animal], i[:adj], i[:attire]].compact
+      end
+    end
+  end
+end

--- a/dashboard/app/services/DancePartyImageGenerator/metadata/record.rb
+++ b/dashboard/app/services/DancePartyImageGenerator/metadata/record.rb
@@ -18,7 +18,7 @@ module DancePartyImageGenerator
           "people_count"    => 0,
           "copy_space"      => false,
           "background"      => "transparent",
-          "adjective"       => item[:adj],
+          "mood"       => item[:adj],
           "animal"          => item[:animal],
           "attire"          => item[:attire],
           "variant"         => item[:variant],

--- a/dashboard/app/services/DancePartyImageGenerator/naming.rb
+++ b/dashboard/app/services/DancePartyImageGenerator/naming.rb
@@ -1,0 +1,16 @@
+module DancePartyImageGenerator
+  module Naming
+    module_function def slug(text) = text.to_s.downcase.strip.gsub(/[^\w\- ]+/, "").gsub(/[ _]+/, "-")
+
+    # item: {animal:, adj: (optional), attire: (optional), variant: Integer}
+    module_function def base_name(item)
+      i = item.symbolize_keys
+      parts = []
+      parts << slug(i[:adj])   if i[:adj].present?
+      parts << slug(i[:animal])
+      parts << slug(i[:attire]) if i[:attire].present?
+      parts << format("%02d", Integer(i[:variant]))
+      parts.join("-")
+    end
+  end
+end

--- a/dashboard/app/services/DancePartyImageGenerator/naming.rb
+++ b/dashboard/app/services/DancePartyImageGenerator/naming.rb
@@ -1,6 +1,6 @@
 module DancePartyImageGenerator
   module Naming
-    module_function def slug(text) = text.to_s.downcase.strip.gsub(/[^\w\- ]+/, "").gsub(/[ _]+/, "-")
+    module_function def slug(text) = text.to_s.downcase.strip.gsub(/[^\w\- ]+/, "").gsub(/[ ]+/, "-")
 
     # item: {animal:, adj: (optional), attire: (optional), variant: Integer}
     module_function def base_name(item)

--- a/dashboard/app/services/DancePartyImageGenerator/naming.rb
+++ b/dashboard/app/services/DancePartyImageGenerator/naming.rb
@@ -6,9 +6,9 @@ module DancePartyImageGenerator
     module_function def base_name(item)
       i = item.symbolize_keys
       parts = []
-      parts << slug(i[:adj])   if i[:adj].present?
       parts << slug(i[:animal])
       parts << slug(i[:attire]) if i[:attire].present?
+      parts << slug(i[:adj])   if i[:adj].present?
       parts << format("%02d", Integer(i[:variant]))
       parts.join("-")
     end

--- a/dashboard/app/services/DancePartyImageGenerator/palette_extractor.rb
+++ b/dashboard/app/services/DancePartyImageGenerator/palette_extractor.rb
@@ -1,0 +1,184 @@
+# frozen_string_literal: true
+
+require "chunky_png"
+
+module DancePartyImageGenerator
+  class PaletteExtractor
+    # Tunables (mirror your Python config)
+    SECONDARY_MIN_DELTAE      = 18.0
+    MIN_PERCENT_FOR_SECONDARY = 0.5   # %
+    MIN_PERCENT_FOR_TERTIARY  = 0.2   # %
+
+    # Fallbacks when no visible pixels
+    OFF_WHITE = "#F2F2F2"
+    OFF_BLACK = "#0A0A0A"
+
+    # Public: quick helpers --------------------------------------------------
+
+    def self.extract_png_bytes(png_bytes, normalize_grays: true)
+      new(normalize_grays: normalize_grays).extract_png_bytes(png_bytes)
+    end
+
+    def self.too_transparent?(png_bytes, threshold: 0.90)
+      img = ChunkyPNG::Image.from_blob(png_bytes)
+      total = img.width * img.height
+      zeros = 0
+      img.pixels.each {|p| zeros += 1 if ((p >> 24) & 0xFF) == 0}
+      (zeros.to_f / total) >= threshold
+    end
+
+    # Instance API ----------------------------------------------------------
+
+    def initialize(alpha_weight: true, normalize_grays: true)
+      @alpha_weight   = alpha_weight
+      @normalize_grays = normalize_grays
+    end
+
+    def extract_png_bytes(png_bytes)
+      img = ChunkyPNG::Image.from_blob(png_bytes)
+      counts, total = count_visible_colors(img, @alpha_weight)
+
+      return [OFF_WHITE, OFF_WHITE, OFF_WHITE] if total <= 0.0
+
+      uniq_colors = counts.keys
+      weights     = uniq_colors.map {|k| counts[k]}
+      percents    = weights.map {|w| (w / total) * 100.0}
+
+      # Dominant
+      dom_idx = weights.each_with_index.max[1]
+      dom_rgb = unpack_rgb(uniq_colors[dom_idx])
+      dom_hex = hex(dom_rgb)
+
+      # CIELab + ΔE against dominant
+      labs = uniq_colors.map {|k| rgb_to_lab(unpack_rgb(k))}
+      dom_lab = labs[dom_idx]
+      deltas  = labs.map {|lab| delta_e76(dom_lab, lab)}
+
+      # Secondary: sufficiently different & frequent
+      sec_idx = best_secondary_index(weights, percents, deltas, dom_idx)
+      sec_hex = hex(unpack_rgb(uniq_colors[sec_idx]))
+
+      # Tertiary: furthest ΔE with some presence
+      ter_idx = best_tertiary_index(weights, percents, deltas, dom_idx)
+      ter_hex = hex(unpack_rgb(uniq_colors[ter_idx]))
+
+      # Optional normalization of exact black/white to off-tones
+      if @normalize_grays
+        dom_hex = normalize_gray(dom_hex)
+        sec_hex = normalize_gray(sec_hex)
+        ter_hex = normalize_gray(ter_hex)
+      end
+
+      [dom_hex, sec_hex, ter_hex]
+    end
+
+    # Count visible colors with optional alpha weighting
+    private def count_visible_colors(img, alpha_weight)
+      counts = Hash.new(0.0)
+      total  = 0.0
+
+      img.pixels.each do |p|
+        a = (p >> 24) & 0xFF
+        next if a == 0
+
+        r = (p >> 16) & 0xFF
+        g = (p >>  8) & 0xFF
+        b = (p) & 0xFF
+
+        key = (r << 16) | (g << 8) | b
+        w   = alpha_weight ? (a / 255.0) : 1.0
+        counts[key] += w
+        total       += w
+      end
+
+      [counts, total]
+    end
+
+    private def unpack_rgb(key)
+      r = (key >> 16) & 0xFF
+      g = (key >>  8) & 0xFF
+      b = (key) & 0xFF
+      [r, g, b]
+    end
+
+    private def hex(rgb)
+      format("#%02X%02X%02X", *rgb)
+    end
+
+    private def normalize_gray(h)
+      case h.upcase
+      when "#000000", "#010101", "#0D0D0D", "#111111"
+        OFF_BLACK
+      when "#FFFFFF", "#FEFEFE", "#FDFDFD"
+        OFF_WHITE
+      else
+        h
+      end
+    end
+
+    # ---- Color science (sRGB -> XYZ -> Lab, ΔE76) ------------------------
+
+    private def srgb_to_linear(c) # c in 0..1
+      if c <= 0.04045
+        c / 12.92
+      else
+        ((c + 0.055) / 1.055) ** 2.4
+      end
+    end
+
+    private def rgb_to_xyz(r255, g255, b255)
+      r = srgb_to_linear(r255 / 255.0)
+      g = srgb_to_linear(g255 / 255.0)
+      b = srgb_to_linear(b255 / 255.0)
+      x = (0.4124564*r) + (0.3575761*g) + (0.1804375*b)
+      y = (0.2126729*r) + (0.7151522*g) + (0.0721750*b)
+      z = (0.0193339*r) + (0.1191920*g) + (0.9503041*b)
+      [x, y, z]
+    end
+
+    private def f_xyz(t)
+      eps = (6.0/29.0)**3
+      k   = ((29.0/6.0)**2) / 3.0
+      t > eps ? t ** (1.0/3.0) : ((k * t) + (4.0/29.0))
+    end
+
+    private def rgb_to_lab(rgb)
+      x, y, z = rgb_to_xyz(*rgb)
+      xn = 0.95047
+      yn = 1.00000
+      zn = 1.08883 # D65
+      fx = f_xyz(x/xn)
+      fy = f_xyz(y/yn)
+      fz = f_xyz(z/zn)
+      l = (116.0 * fy) - 16.0
+      a = 500.0 * (fx - fy)
+      b = 200.0 * (fy - fz)
+      [l, a, b]
+    end
+
+    private def delta_e76(lab1, lab2)
+      dl = lab2[0] - lab1[0]
+      da = lab2[1] - lab1[1]
+      db = lab2[2] - lab1[2]
+      Math.sqrt((dl*dl) + (da*da) + (db*db))
+    end
+
+    # ---- Candidate picking ------------------------------------------------
+
+    private def best_secondary_index(weights, perc, deltas, dom_idx)
+      idxs = (0...weights.length).to_a - [dom_idx]
+      # Apply thresholds
+      cands = idxs.select {|i| deltas[i] >= SECONDARY_MIN_DELTAE && perc[i] >= MIN_PERCENT_FOR_SECONDARY}
+      cands = idxs if cands.empty?
+      # Prefer larger ΔE, then higher weight
+      cands.max_by {|i| [deltas[i], weights[i]]} || dom_idx
+    end
+
+    private def best_tertiary_index(weights, perc, deltas, dom_idx)
+      idxs = (0...weights.length).to_a - [dom_idx]
+      cands = idxs.select {|i| perc[i] >= MIN_PERCENT_FOR_TERTIARY}
+      cands = idxs if cands.empty?
+      cands.max_by {|i| deltas[i]} || dom_idx
+    end
+  end
+end

--- a/dashboard/app/services/DancePartyImageGenerator/palette_extractor.rb
+++ b/dashboard/app/services/DancePartyImageGenerator/palette_extractor.rb
@@ -4,65 +4,75 @@ require "chunky_png"
 
 module DancePartyImageGenerator
   class PaletteExtractor
-    # Tunables (mirror your Python config)
     SECONDARY_MIN_DELTAE      = 18.0
-    MIN_PERCENT_FOR_SECONDARY = 0.5   # %
-    MIN_PERCENT_FOR_TERTIARY  = 0.2   # %
-
-    # Fallbacks when no visible pixels
+    MIN_PERCENT_FOR_SECONDARY = 0.5  # %
+    MIN_PERCENT_FOR_TERTIARY  = 0.2  # %
     OFF_WHITE = "#F2F2F2"
     OFF_BLACK = "#0A0A0A"
 
-    # Public: quick helpers --------------------------------------------------
-
-    def self.extract_png_bytes(png_bytes, normalize_grays: true)
-      new(normalize_grays: normalize_grays).extract_png_bytes(png_bytes)
-    end
-
-    def self.too_transparent?(png_bytes, threshold: 0.90)
-      img = ChunkyPNG::Image.from_blob(png_bytes)
-      total = img.width * img.height
-      zeros = 0
-      img.pixels.each {|p| zeros += 1 if ((p >> 24) & 0xFF) == 0}
-      (zeros.to_f / total) >= threshold
-    end
-
-    # Instance API ----------------------------------------------------------
-
     def initialize(alpha_weight: true, normalize_grays: true)
-      @alpha_weight   = alpha_weight
+      @alpha_weight    = alpha_weight
       @normalize_grays = normalize_grays
     end
 
-    def extract_png_bytes(png_bytes)
-      img = ChunkyPNG::Image.from_blob(png_bytes)
-      counts, total = count_visible_colors(img, @alpha_weight)
+    # Public API used by ImageGenerator:
+    # accepts MiniMagick::Image, ChunkyPNG::Image, or raw PNG bytes
+    def extract(image)
+      bytes =
+        case image
+        when String then image
+        when MiniMagick::Image, ChunkyPNG::Image then image.to_blob
+        else
+          image.respond_to?(:to_blob) ? image.to_blob :
+            raise(ArgumentError, "Unsupported image type: #{image.class}")
+        end
+      extract_from_bytes(bytes)
+    end
+
+    # Convenience (also usable directly)
+    def extract_from_bytes(bytes)
+      img = ChunkyPNG::Image.from_blob(bytes)
+
+      counts = Hash.new(0.0)
+      total  = 0.0
+      img.pixels.each do |p|
+        a = (p >> 24) & 0xFF
+        next if a == 0
+        r = (p >> 16) & 0xFF; g = (p >>  8) & 0xFF; b = p & 0xFF
+        key = (r << 16) | (g << 8) | b
+        w   = @alpha_weight ? (a / 255.0) : 1.0
+        counts[key] += w
+        total       += w
+      end
 
       return [OFF_WHITE, OFF_WHITE, OFF_WHITE] if total <= 0.0
 
-      uniq_colors = counts.keys
-      weights     = uniq_colors.map {|k| counts[k]}
-      percents    = weights.map {|w| (w / total) * 100.0}
+      uniq    = counts.keys
+      weights = uniq.map {|k| counts[k]}
+      perc    = weights.map {|w| (w / total) * 100.0}
 
-      # Dominant
       dom_idx = weights.each_with_index.max[1]
-      dom_rgb = unpack_rgb(uniq_colors[dom_idx])
+      dom_rgb = unpack_rgb(uniq[dom_idx])
       dom_hex = hex(dom_rgb)
 
-      # CIELab + ΔE against dominant
-      labs = uniq_colors.map {|k| rgb_to_lab(unpack_rgb(k))}
+      labs    = uniq.map {|k| rgb_to_lab(*unpack_rgb(k))}
       dom_lab = labs[dom_idx]
       deltas  = labs.map {|lab| delta_e76(dom_lab, lab)}
 
-      # Secondary: sufficiently different & frequent
-      sec_idx = best_secondary_index(weights, percents, deltas, dom_idx)
-      sec_hex = hex(unpack_rgb(uniq_colors[sec_idx]))
+      others = (0...uniq.length).to_a - [dom_idx]
+
+      # Secondary: sufficiently different & frequent; prefer larger ΔE, then weight
+      sec_candidates = others.select {|i| deltas[i] >= SECONDARY_MIN_DELTAE && perc[i] >= MIN_PERCENT_FOR_SECONDARY}
+      sec_candidates = others if sec_candidates.empty?
+      sec_idx = sec_candidates.max_by {|i| [deltas[i], weights[i]]} || dom_idx
+      sec_hex = hex(unpack_rgb(uniq[sec_idx]))
 
       # Tertiary: furthest ΔE with some presence
-      ter_idx = best_tertiary_index(weights, percents, deltas, dom_idx)
-      ter_hex = hex(unpack_rgb(uniq_colors[ter_idx]))
+      ter_candidates = others.select {|i| perc[i] >= MIN_PERCENT_FOR_TERTIARY}
+      ter_candidates = others if ter_candidates.empty?
+      ter_idx = ter_candidates.max_by {|i| deltas[i]} || dom_idx
+      ter_hex = hex(unpack_rgb(uniq[ter_idx]))
 
-      # Optional normalization of exact black/white to off-tones
       if @normalize_grays
         dom_hex = normalize_gray(dom_hex)
         sec_hex = normalize_gray(sec_hex)
@@ -72,64 +82,32 @@ module DancePartyImageGenerator
       [dom_hex, sec_hex, ter_hex]
     end
 
-    # Count visible colors with optional alpha weighting
-    private def count_visible_colors(img, alpha_weight)
-      counts = Hash.new(0.0)
-      total  = 0.0
-
-      img.pixels.each do |p|
-        a = (p >> 24) & 0xFF
-        next if a == 0
-
-        r = (p >> 16) & 0xFF
-        g = (p >>  8) & 0xFF
-        b = (p) & 0xFF
-
-        key = (r << 16) | (g << 8) | b
-        w   = alpha_weight ? (a / 255.0) : 1.0
-        counts[key] += w
-        total       += w
-      end
-
-      [counts, total]
+    # Class conveniences (used by doctor jobs, etc.)
+    def self.extract_png_bytes(bytes, normalize_grays: true)
+      new(normalize_grays: normalize_grays).extract_from_bytes(bytes)
     end
 
-    private def unpack_rgb(key)
-      r = (key >> 16) & 0xFF
-      g = (key >>  8) & 0xFF
-      b = (key) & 0xFF
-      [r, g, b]
+    def self.too_transparent?(bytes, threshold: 0.90)
+      img = ChunkyPNG::Image.from_blob(bytes)
+      zeros = img.pixels.count {|p| ((p >> 24) & 0xFF).zero?}
+      zeros.to_f / (img.width * img.height) >= threshold
     end
 
-    private def hex(rgb)
-      format("#%02X%02X%02X", *rgb)
-    end
+    private def unpack_rgb(key) = [(key >> 16) & 0xFF, (key >> 8) & 0xFF, key & 0xFF]
+    private def hex(rgb)        = format("#%02X%02X%02X", *rgb)
 
     private def normalize_gray(h)
-      case h.upcase
-      when "#000000", "#010101", "#0D0D0D", "#111111"
-        OFF_BLACK
-      when "#FFFFFF", "#FEFEFE", "#FDFDFD"
-        OFF_WHITE
-      else
-        h
-      end
+      up = h.upcase
+      return OFF_BLACK if %w[#000000 #010101 #0D0D0D #111111].include?(up)
+      return OFF_WHITE if %w[#FFFFFF #FEFEFE #FDFDFD].include?(up)
+      h
     end
 
-    # ---- Color science (sRGB -> XYZ -> Lab, ΔE76) ------------------------
-
-    private def srgb_to_linear(c) # c in 0..1
-      if c <= 0.04045
-        c / 12.92
-      else
-        ((c + 0.055) / 1.055) ** 2.4
-      end
-    end
+    # --- sRGB -> Lab and ΔE76 ---
+    private def srgb_to_linear(c) = c <= 0.04045 ? c/12.92 : ((c+0.055)/1.055)**2.4
 
     private def rgb_to_xyz(r255, g255, b255)
-      r = srgb_to_linear(r255 / 255.0)
-      g = srgb_to_linear(g255 / 255.0)
-      b = srgb_to_linear(b255 / 255.0)
+      r = srgb_to_linear(r255/255.0); g = srgb_to_linear(g255/255.0); b = srgb_to_linear(b255/255.0)
       x = (0.4124564*r) + (0.3575761*g) + (0.1804375*b)
       y = (0.2126729*r) + (0.7151522*g) + (0.0721750*b)
       z = (0.0193339*r) + (0.1191920*g) + (0.9503041*b)
@@ -137,48 +115,24 @@ module DancePartyImageGenerator
     end
 
     private def f_xyz(t)
-      eps = (6.0/29.0)**3
-      k   = ((29.0/6.0)**2) / 3.0
+      eps = (6.0/29.0)**3; k = ((29.0/6.0)**2) / 3.0
       t > eps ? t ** (1.0/3.0) : ((k * t) + (4.0/29.0))
     end
 
-    private def rgb_to_lab(rgb)
-      x, y, z = rgb_to_xyz(*rgb)
+    private def rgb_to_lab(r, g, b)
+      x, y, z = rgb_to_xyz(r, g, b)
       xn = 0.95047
       yn = 1.00000
-      zn = 1.08883 # D65
+      zn = 1.08883
       fx = f_xyz(x/xn)
       fy = f_xyz(y/yn)
       fz = f_xyz(z/zn)
-      l = (116.0 * fy) - 16.0
-      a = 500.0 * (fx - fy)
-      b = 200.0 * (fy - fz)
-      [l, a, b]
+      [(116.0*fy) - 16.0, 500.0*(fx - fy), 200.0*(fy - fz)]
     end
 
-    private def delta_e76(lab1, lab2)
-      dl = lab2[0] - lab1[0]
-      da = lab2[1] - lab1[1]
-      db = lab2[2] - lab1[2]
+    private def delta_e76(l1, l2)
+      dl = l2[0]-l1[0]; da = l2[1]-l1[1]; db = l2[2]-l1[2]
       Math.sqrt((dl*dl) + (da*da) + (db*db))
-    end
-
-    # ---- Candidate picking ------------------------------------------------
-
-    private def best_secondary_index(weights, perc, deltas, dom_idx)
-      idxs = (0...weights.length).to_a - [dom_idx]
-      # Apply thresholds
-      cands = idxs.select {|i| deltas[i] >= SECONDARY_MIN_DELTAE && perc[i] >= MIN_PERCENT_FOR_SECONDARY}
-      cands = idxs if cands.empty?
-      # Prefer larger ΔE, then higher weight
-      cands.max_by {|i| [deltas[i], weights[i]]} || dom_idx
-    end
-
-    private def best_tertiary_index(weights, perc, deltas, dom_idx)
-      idxs = (0...weights.length).to_a - [dom_idx]
-      cands = idxs.select {|i| perc[i] >= MIN_PERCENT_FOR_TERTIARY}
-      cands = idxs if cands.empty?
-      cands.max_by {|i| deltas[i]} || dom_idx
     end
   end
 end

--- a/dashboard/app/services/DancePartyImageGenerator/palette_extractor.rb
+++ b/dashboard/app/services/DancePartyImageGenerator/palette_extractor.rb
@@ -10,9 +10,14 @@ module DancePartyImageGenerator
     OFF_WHITE = "#F2F2F2"
     OFF_BLACK = "#0A0A0A"
 
-    def initialize(alpha_weight: true, normalize_grays: true)
+    PY_MUTEX = Mutex.new
+
+    def initialize(alpha_weight: true, normalize_grays: true, logger: Rails.logger)
       @alpha_weight    = alpha_weight
       @normalize_grays = normalize_grays
+      @logger          = logger
+      @py_ready        = false
+      @py_func         = nil
     end
 
     # Public API used by ImageGenerator:
@@ -20,17 +25,172 @@ module DancePartyImageGenerator
     def extract(image)
       bytes =
         case image
-        when String then image
+        when String then image # already bytes
         when MiniMagick::Image, ChunkyPNG::Image then image.to_blob
         else
           image.respond_to?(:to_blob) ? image.to_blob :
             raise(ArgumentError, "Unsupported image type: #{image.class}")
         end
-      extract_from_bytes(bytes)
+
+      # Try Python fast path first
+      begin
+        dom, sec, ter = python_extract(bytes)
+        return [dom, sec, ter]
+      rescue => exception
+        @logger.warn("[DPIG][PaletteExtractor] PyCall path failed (#{exception.class}: #{exception.message}) — falling back to Ruby")
+      end
+
+      # Fallback to Ruby path
+      extract_from_bytes_ruby(bytes)
     end
 
-    # Convenience (also usable directly)
-    def extract_from_bytes(bytes)
+    # ---------- Python path via PyCall ----------
+    def python_extract(bytes)
+      ensure_python!
+      result = nil
+      PY_MUTEX.synchronize do
+        # danc_extract_palette_bytes(b, alpha_weight, normalize_grays, sec_deltaE, min_pct_sec, min_pct_ter)
+        result = @py_func.call(bytes, @alpha_weight, @normalize_grays, SECONDARY_MIN_DELTAE, MIN_PERCENT_FOR_SECONDARY, MIN_PERCENT_FOR_TERTIARY)
+      end
+      [*result].map(&:to_s)
+    end
+
+    def ensure_python!
+      return if @py_ready
+      begin
+        require 'pycall/import'
+        extend PyCall::Import
+        pyimport 'builtins'
+        pyimport 'io'
+        pyimport 'numpy', as: :np
+        pyimport 'PIL.Image', as: :PILImage
+      rescue LoadError => exception
+        raise "PyCall not available: #{exception.message}"
+      rescue PyCall::PyError => exception
+        raise "Python import failed: #{exception}"
+      end
+
+      PyCall.exec(<<~PYCODE)
+        import numpy as np
+        from PIL import Image
+        import io
+
+        def danc_extract_palette_bytes(b,
+                                       alpha_weight=True,
+                                       normalize_grays=True,
+                                       secondary_min_deltae=18.0,
+                                       min_pct_secondary=0.5,
+                                       min_pct_tertiary=0.2):
+            img = Image.open(io.BytesIO(b)).convert("RGBA")
+            arr = np.asarray(img)
+            rgb = arr[..., :3].reshape(-1, 3).astype(np.uint8)
+            alpha = arr[..., 3].reshape(-1)
+
+            vis = alpha > 0
+            if not np.any(vis):
+                return ("#F2F2F2", "#F2F2F2", "#F2F2F2")
+
+            rgb   = rgb[vis]
+            a     = alpha[vis].astype(np.float32) / 255.0
+            w     = a if alpha_weight else np.ones(rgb.shape[0], dtype=np.float32)
+
+            packed = (rgb[:,0].astype(np.uint32) << 16) | (rgb[:,1].astype(np.uint32) << 8) | rgb[:,2].astype(np.uint32)
+            uniq, inv = np.unique(packed, return_inverse=True)
+            counts = np.bincount(inv, weights=w, minlength=uniq.shape[0]).astype(np.float64)
+            total  = counts.sum() if counts.sum() > 0 else 1.0
+            perc   = (counts / total) * 100.0
+
+            rs = ((uniq >> 16) & 0xFF).astype(np.uint8)
+            gs = ((uniq >> 8)  & 0xFF).astype(np.uint8)
+            bs = ( uniq        & 0xFF).astype(np.uint8)
+            colors = np.stack([rs, gs, bs], axis=1)
+
+            def srgb_to_linear(c):
+                c = c.astype(np.float32)
+                a = c <= 0.04045
+                out = np.empty_like(c, dtype=np.float32)
+                out[a]  = c[a] / 12.92
+                out[~a] = ((c[~a] + 0.055) / 1.055) ** 2.4
+                return out
+
+            def rgb_to_xyz(rgb):
+                rgb = rgb.astype(np.float32) / 255.0
+                r, g, b = rgb[:,0], rgb[:,1], rgb[:,2]
+                r_lin, g_lin, b_lin = srgb_to_linear(r), srgb_to_linear(g), srgb_to_linear(b)
+                X = 0.4124564*r_lin + 0.3575761*g_lin + 0.1804375*b_lin
+                Y = 0.2126729*r_lin + 0.7151522*g_lin + 0.0721750*b_lin
+                Z = 0.0193339*r_lin + 0.1191920*g_lin + 0.9503041*b_lin
+                return np.stack([X, Y, Z], axis=1)
+
+            def xyz_to_lab(xyz):
+                Xn, Yn, Zn = 0.95047, 1.0, 1.08883
+                x = xyz[:,0] / Xn; y = xyz[:,1] / Yn; z = xyz[:,2] / Zn
+                eps = (6/29)**3; k = (29/6)**2 / 3
+                def f(t):
+                    out = np.empty_like(t, dtype=np.float32)
+                    mask = t > eps
+                    out[mask]  = np.cbrt(t[mask])
+                    out[~mask] = k*t[~mask] + 4/29
+                    return out
+                fx, fy, fz = f(x), f(y), f(z)
+                L = 116*fy - 16; a = 500*(fx - fy); b = 200*(fy - fz)
+                return np.stack([L, a, b], axis=1)
+
+            labs    = xyz_to_lab(rgb_to_xyz(colors))
+            dom_idx = int(np.argmax(counts))
+            dom_lab = labs[dom_idx]
+            deltas  = np.linalg.norm(labs - dom_lab, axis=1)
+
+            idx = np.arange(colors.shape[0])
+            def to_hex(c): return "#%02X%02X%02X" % (int(c[0]), int(c[1]), int(c[2]))
+
+            dom_hex = to_hex(colors[dom_idx])
+
+            # Secondary: sufficiently different & frequent; prefer larger ΔE, then weight
+            mask_sec = (idx != dom_idx) & (deltas >= secondary_min_deltae) & (perc >= min_pct_secondary)
+            cand = idx[mask_sec]
+            if cand.size == 0:
+                cand = idx[idx != dom_idx]
+            if cand.size:
+                order = np.lexsort((-counts[cand], -deltas[cand]))
+                sec_idx = cand[order[0]]
+            else:
+                sec_idx = dom_idx
+            sec_hex = to_hex(colors[sec_idx])
+
+            # Tertiary: furthest ΔE with some presence
+            mask_ter = (idx != dom_idx) & (perc >= min_pct_tertiary)
+            cand2 = idx[mask_ter]
+            if cand2.size == 0:
+                cand2 = idx[idx != dom_idx]
+            if cand2.size:
+                ter_idx = cand2[np.argmax(deltas[cand2])]
+            else:
+                ter_idx = dom_idx
+            ter_hex = to_hex(colors[ter_idx])
+
+            def norm_gray(h):
+                up = h.upper()
+                if up in ("#000000","#010101","#0D0D0D","#111111"):
+                    return "#0A0A0A"
+                if up in ("#FFFFFF","#FEFEFE","#FDFDFD"):
+                    return "#F2F2F2"
+                return h
+
+            if normalize_grays:
+                dom_hex = norm_gray(dom_hex)
+                sec_hex = norm_gray(sec_hex)
+                ter_hex = norm_gray(ter_hex)
+
+            return (dom_hex, sec_hex, ter_hex)
+      PYCODE
+
+      @py_func  = PyCall.eval('danc_extract_palette_bytes')
+      @py_ready = true
+    end
+
+    # ---------- Ruby fallback (your original logic) ----------
+    def extract_from_bytes_ruby(bytes)
       img = ChunkyPNG::Image.from_blob(bytes)
 
       counts = Hash.new(0.0)
@@ -61,13 +221,11 @@ module DancePartyImageGenerator
 
       others = (0...uniq.length).to_a - [dom_idx]
 
-      # Secondary: sufficiently different & frequent; prefer larger ΔE, then weight
       sec_candidates = others.select {|i| deltas[i] >= SECONDARY_MIN_DELTAE && perc[i] >= MIN_PERCENT_FOR_SECONDARY}
       sec_candidates = others if sec_candidates.empty?
       sec_idx = sec_candidates.max_by {|i| [deltas[i], weights[i]]} || dom_idx
       sec_hex = hex(unpack_rgb(uniq[sec_idx]))
 
-      # Tertiary: furthest ΔE with some presence
       ter_candidates = others.select {|i| perc[i] >= MIN_PERCENT_FOR_TERTIARY}
       ter_candidates = others if ter_candidates.empty?
       ter_idx = ter_candidates.max_by {|i| deltas[i]} || dom_idx
@@ -82,17 +240,7 @@ module DancePartyImageGenerator
       [dom_hex, sec_hex, ter_hex]
     end
 
-    # Class conveniences (used by doctor jobs, etc.)
-    def self.extract_png_bytes(bytes, normalize_grays: true)
-      new(normalize_grays: normalize_grays).extract_from_bytes(bytes)
-    end
-
-    def self.too_transparent?(bytes, threshold: 0.90)
-      img = ChunkyPNG::Image.from_blob(bytes)
-      zeros = img.pixels.count {|p| ((p >> 24) & 0xFF).zero?}
-      zeros.to_f / (img.width * img.height) >= threshold
-    end
-
+    # ---- helpers (Ruby) ----
     private def unpack_rgb(key) = [(key >> 16) & 0xFF, (key >> 8) & 0xFF, key & 0xFF]
     private def hex(rgb)        = format("#%02X%02X%02X", *rgb)
 
@@ -103,9 +251,8 @@ module DancePartyImageGenerator
       h
     end
 
-    # --- sRGB -> Lab and ΔE76 ---
+    # --- sRGB -> Lab and ΔE76 (Ruby fallback) ---
     private def srgb_to_linear(c) = c <= 0.04045 ? c/12.92 : ((c+0.055)/1.055)**2.4
-
     private def rgb_to_xyz(r255, g255, b255)
       r = srgb_to_linear(r255/255.0); g = srgb_to_linear(g255/255.0); b = srgb_to_linear(b255/255.0)
       x = (0.4124564*r) + (0.3575761*g) + (0.1804375*b)
@@ -113,23 +260,16 @@ module DancePartyImageGenerator
       z = (0.0193339*r) + (0.1191920*g) + (0.9503041*b)
       [x, y, z]
     end
-
     private def f_xyz(t)
       eps = (6.0/29.0)**3; k = ((29.0/6.0)**2) / 3.0
       t > eps ? t ** (1.0/3.0) : ((k * t) + (4.0/29.0))
     end
-
     private def rgb_to_lab(r, g, b)
       x, y, z = rgb_to_xyz(r, g, b)
-      xn = 0.95047
-      yn = 1.00000
-      zn = 1.08883
-      fx = f_xyz(x/xn)
-      fy = f_xyz(y/yn)
-      fz = f_xyz(z/zn)
+      xn = 0.95047; yn = 1.00000; zn = 1.08883
+      fx = f_xyz(x/xn); fy = f_xyz(y/yn); fz = f_xyz(z/zn)
       [(116.0*fy) - 16.0, 500.0*(fx - fy), 200.0*(fy - fz)]
     end
-
     private def delta_e76(l1, l2)
       dl = l2[0]-l1[0]; da = l2[1]-l1[1]; db = l2[2]-l1[2]
       Math.sqrt((dl*dl) + (da*da) + (db*db))

--- a/dashboard/app/services/DancePartyImageGenerator/prompt_builder.rb
+++ b/dashboard/app/services/DancePartyImageGenerator/prompt_builder.rb
@@ -1,0 +1,27 @@
+module DancePartyImageGenerator
+  class PromptBuilder
+    def initialize(width: 1024, height: 1024)
+      (@w = width
+       @h = height)
+    end
+
+    # {adj:, animal:, attire:}
+    def build(item)
+      theme =
+        if item[:adj] && item[:attire] then "#{item[:adj]} #{item[:animal]} in #{item[:attire]}"
+        elsif item[:attire] then "#{item[:animal]} in #{item[:attire]}"
+        else
+          item[:animal]
+        end
+      <<~PROMPT
+        Create one non-human character head for Code.org’s Dance Party.
+        Canvas & Size: exactly #{@w} px wide × #{@h} px tall.
+        Focus: Show only the head and face, no body, no neck, no shoulders...
+        Background: transparent PNG only. Entire head visible and centered, nothing cropped.
+        Theme: #{theme}.
+        Art style: Flat vector color fills, no outlines, no shading/gradients...
+        Framing: small uniform margin; head fills most of the canvas.
+      PROMPT
+    end
+  end
+end

--- a/dashboard/app/services/DancePartyImageGenerator/prompt_builder.rb
+++ b/dashboard/app/services/DancePartyImageGenerator/prompt_builder.rb
@@ -8,7 +8,7 @@ module DancePartyImageGenerator
     # {adj:, animal:, attire:}
     def build(item)
       theme =
-        if item[:adj] && item[:attire] then "#{item[:adj]} #{item[:animal]} in #{item[:attire]}"
+        if item[:adj] && item[:attire] then "#{item[:animal]} wearing #{item[:attire]}, with #{item[:adj]} mood."
         elsif item[:attire] then "#{item[:animal]} in #{item[:attire]}"
         else
           item[:animal]

--- a/dashboard/app/services/DancePartyImageGenerator/settings.rb
+++ b/dashboard/app/services/DancePartyImageGenerator/settings.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "yaml"
+
 module DancePartyImageGenerator
   module Settings
     DEFAULT_ANIMALS    = %w[frog moose wolf panda tiger].freeze
@@ -7,26 +9,23 @@ module DancePartyImageGenerator
     DEFAULT_ADJECTIVES = %w[basic emo sporty streetwear fancy preppy].freeze
     DEFAULT_REPEATS    = 3
 
-    module_function def config
-      # locals.yml is not auto-parsed by Rails by default; load it like this:
-      @config ||= begin
-        path = Rails.root.join("config", "locals.yml")
-        all  = path.exist? ? YAML.load_file(path) : {}
-        env  = Rails.env
-        (all[env] || {})["dance_party_image_generator"] || {}
-      end
+    module_function def raw
+      path = Rails.root.join("config", "dance_party_image_generator.yml")
+      return {} unless path.exist?
+      all = YAML.safe_load_file(path, aliases: true) || {}
+      all[Rails.env] || all["default"] || {}
     end
 
     module_function def list(key, fallback)
-      arr = Array(config[key.to_s]).map(&:to_s).map(&:strip).compact_blank
+      arr = Array(raw[key.to_s]).map(&:to_s).map(&:strip).compact_blank
       arr.presence || fallback
     end
 
-    module_function def animals      = list(:animals,    DEFAULT_ANIMALS)
-    module_function def attire       = list(:attire,     DEFAULT_ATTIRES)
-    module_function def adjectives   = list(:adjectives, DEFAULT_ADJECTIVES)
-    module_function def repeats      = Integer(config["repeats_per_combo"] || DEFAULT_REPEATS)
-    module_function def namespace    = config["namespace"].to_s.presence
-    module_function def bucket       = (config["bucket"].presence || ENV.fetch("S3_BUCKET", nil))
+    module_function def animals    = list(:animals,    DEFAULT_ANIMALS)
+    module_function def attire     = list(:attire,     DEFAULT_ATTIRES)
+    module_function def adjectives = list(:adjectives, DEFAULT_ADJECTIVES)
+    module_function def repeats    = Integer(raw["repeats_per_combo"] || DEFAULT_REPEATS)
+    module_function def namespace  = raw["namespace"].to_s.presence
+    module_function def bucket     = raw["bucket"].presence || ENV.fetch("S3_BUCKET", nil)
   end
 end

--- a/dashboard/app/services/DancePartyImageGenerator/settings.rb
+++ b/dashboard/app/services/DancePartyImageGenerator/settings.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module DancePartyImageGenerator
+  module Settings
+    DEFAULT_ANIMALS    = %w[frog moose wolf panda tiger].freeze
+    DEFAULT_ATTIRES    = %w[headphones sunglasses crown headscarf baseball-cap beanie headband].freeze
+    DEFAULT_ADJECTIVES = %w[basic emo sporty streetwear fancy preppy].freeze
+    DEFAULT_REPEATS    = 3
+
+    module_function def config
+      # locals.yml is not auto-parsed by Rails by default; load it like this:
+      @config ||= begin
+        path = Rails.root.join("config", "locals.yml")
+        all  = path.exist? ? YAML.load_file(path) : {}
+        env  = Rails.env
+        (all[env] || {})["dance_party_image_generator"] || {}
+      end
+    end
+
+    module_function def list(key, fallback)
+      arr = Array(config[key.to_s]).map(&:to_s).map(&:strip).compact_blank
+      arr.presence || fallback
+    end
+
+    module_function def animals      = list(:animals,    DEFAULT_ANIMALS)
+    module_function def attire       = list(:attire,     DEFAULT_ATTIRES)
+    module_function def adjectives   = list(:adjectives, DEFAULT_ADJECTIVES)
+    module_function def repeats      = Integer(config["repeats_per_combo"] || DEFAULT_REPEATS)
+    module_function def namespace    = config["namespace"].to_s.presence
+    module_function def bucket       = (config["bucket"].presence || ENV.fetch("S3_BUCKET", nil))
+  end
+end

--- a/dashboard/app/services/DancePartyImageGenerator/storage/s3_storage.rb
+++ b/dashboard/app/services/DancePartyImageGenerator/storage/s3_storage.rb
@@ -75,9 +75,9 @@ module DancePartyImageGenerator
         module_function def path_for(dest:, base:, ext:)
           folder =
             case dest
-            when :animal          then "animal"
-            when :animal_attire   then "animal-attire"
-            else                        "adjective-animal-attire"
+            when :animal          then "creature-04"
+            when :animal_attire   then "creature-attire-04"
+            else                        "creature-attire-mood-style-04"
             end
           File.join(folder, "#{base}#{ext}")
         end

--- a/dashboard/app/services/DancePartyImageGenerator/storage/s3_storage.rb
+++ b/dashboard/app/services/DancePartyImageGenerator/storage/s3_storage.rb
@@ -1,0 +1,111 @@
+# frozen_string_literal: true
+
+require "json"
+require "base64"
+require "mini_magick"
+require "fileutils"
+
+module DancePartyImageGenerator
+  module Storage
+    class S3Storage
+      attr_reader :bucket
+
+      def initialize(bucket:, namespace: nil, upload_opts: {})
+        @bucket     = bucket
+        @namespace  = normalize_namespace(namespace)
+        @upload_opts = {no_random: true}.merge(upload_opts)
+      end
+
+      def full_key(key)
+        return key if @namespace.blank?
+        File.join(@namespace, key)
+      end
+
+      # basic ops
+
+      def write_json(key, json)
+        data = json.is_a?(String) ? json : JSON.pretty_generate(json)
+        AWS::S3.upload_to_bucket(
+          @bucket,
+          full_key(key),
+          data,
+          **@upload_opts.merge(content_type: "application/json")
+        )
+        true
+      end
+
+      def read_json(key)
+        body = AWS::S3.download_from_bucket(@bucket, full_key(key))
+        JSON.parse(body)
+      end
+
+      def list_json(prefix)
+        absolute = AWS::S3.find_objects_with_ext(@bucket, ".json", full_key(prefix)) || []
+        absolute.
+          select {|k| k.end_with?("-metadata.json")}.
+          map {|k| relativize(k)}
+      end
+
+      def write_png_base64(key, b64, width: nil, height: nil)
+        bytes = Base64.decode64(b64)
+        if width && height
+          image = MiniMagick::Image.read(bytes)
+          if image.width != width || image.height != height
+            image.resize("#{width}x#{height}!")
+            bytes = image.to_blob
+          end
+        end
+        AWS::S3.upload_to_bucket(
+          @bucket,
+          full_key(key),
+          bytes,
+          **@upload_opts.merge(content_type: "image/png")
+        )
+        true
+      end
+
+      def read_png(key)
+        data = AWS::S3.download_from_bucket(@bucket, full_key(key))
+        MiniMagick::Image.read(data)
+      end
+
+      # path helpers
+
+      module Storage
+        module_function def path_for(dest:, base:, ext:)
+          folder =
+            case dest
+            when :animal          then "animal"
+            when :animal_attire   then "animal-attire"
+            else                        "adjective-animal-attire"
+            end
+          File.join(folder, "#{base}#{ext}")
+        end
+
+        module_function def png_for(meta_key, meta)
+          dir  = File.dirname(meta_key)
+          file = meta["file_name"] || File.basename(meta_key).sub(/-metadata\.json\z/, ".png")
+          File.join(dir, file)
+        end
+
+        module_function def mirror_keys(root, meta_key, png_key)
+          dir     = File.dirname(meta_key)
+          out_dir = File.join(root.to_s, dir)
+          FileUtils.mkdir_p(out_dir)
+          base = File.basename(png_key, ".png")
+          [File.join(out_dir, "#{base}.png"), File.join(out_dir, "#{base}-metadata.json")]
+        end
+      end
+
+      private def normalize_namespace(ns)
+        return nil if ns.nil? || ns.to_s.strip.empty?
+        ns.to_s.delete_prefix('/').delete_suffix('/')
+      end
+
+      private def relativize(key)
+        return key if @namespace.blank?
+        key.start_with?(@namespace + "/") ? key[@namespace.size + 1..] : key
+      end
+    end
+  end
+end

--- a/dashboard/config/dance_party_image_generator.yml
+++ b/dashboard/config/dance_party_image_generator.yml
@@ -1,9 +1,40 @@
 default: &default
-  animals: ["frog"]
-  attire: ["headphones"]
-  adjectives: ["basic"]
-  repeats_per_combo: 1
-  namespace: "media/musiclab/generate/dancer/ruby_test"
+  animals:
+    [
+      wolf,
+      moose,
+      frog,
+      tiger,
+      frilled_lizard,
+      axolotl,
+      fox,
+      giraffe,
+      turtle,
+      jellyfish,
+      koala,
+      bunny_rabbit,
+      cat,
+      dog,
+      squirrel,
+      planet,
+      mushroom,
+      flame,
+      volcano,
+      zombie,
+    ]
+  attire:
+    [
+      headscarf,
+      sunglasses,
+      headphones,
+      crown,
+      beanie,
+      colorful_hair,
+      no_accessories,
+    ]
+  adjectives: [happy, silly, sleepy, surprised, confused, fierce]
+  repeats_per_combo: 2
+  namespace: "media/musiclab/generate/dancer"
   bucket: "cdo-curriculum"
 
 development:

--- a/dashboard/config/dance_party_image_generator.yml
+++ b/dashboard/config/dance_party_image_generator.yml
@@ -12,7 +12,7 @@ default: &default
       turtle,
       jellyfish,
       koala,
-      bunny_rabbit,
+      rabbit,
       cat,
       dog,
       squirrel,

--- a/dashboard/config/dance_party_image_generator.yml
+++ b/dashboard/config/dance_party_image_generator.yml
@@ -1,0 +1,16 @@
+default: &default
+  animals: ["frog"]
+  attire: ["headphones"]
+  adjectives: ["basic"]
+  repeats_per_combo: 1
+  namespace: "media/musiclab/generate/dancer/ruby_test"
+  bucket: "cdo-curriculum"
+
+development:
+  <<: *default
+
+test:
+  <<: *default
+
+production:
+  <<: *default


### PR DESCRIPTION
This is a ruby adaptation of the original image generation script written in Python found here: https://colab.research.google.com/drive/1Ao-XqE1Q_2ZvNAiVFHsdflzvhriTreNC?usp=sharing

## Contents Summary
- Assorted services for both generating and subsequently "doctoring" (quality checking) animal heads and associated metadata jsons for HoAI
- Jobs for parallelized batch and individual image creation and doctoring using these services

## Script Test Run Results
<img width="644" height="723" alt="image" src="https://github.com/user-attachments/assets/2c58bf6c-a745-48a5-aa15-f5c473066d3a" />

<img width="1041" height="960" alt="image" src="https://github.com/user-attachments/assets/c9c07738-114f-48d1-b527-1cfc7c26cc09" />


## To-Do
- Lower Transparency threshold to try and catch heads with transparent eyes instead of white eyes
- Add additional doctor check for artifacting around edges of the picture