### PR TITLE
Deprecate cdo-form-uploads bucket

### DIFF
--- a/lib/forms/pegasus_form_validation.rb
+++ b/lib/forms/pegasus_form_validation.rb
@@ -69,12 +69,6 @@ module PegasusFormValidation
     end
   end
 
-  private def uploaded_file(value)
-    return value if value.instance_of?(FieldError)
-    return nil if value.blank?
-    AWS::S3.upload_to_bucket('cdo-form-uploads', value[:filename], File.open(value[:tempfile]))
-  end
-
   private def email_address(value)
     return value if value.instance_of?(FieldError)
     email = downcased stripped value

--- a/lib/test/forms/test_pegasus_form_validation.rb
+++ b/lib/test/forms/test_pegasus_form_validation.rb
@@ -77,16 +77,6 @@ class PegasusFormValidationTest < Minitest::Test
     assert_equal FIELD_ERROR, FormValidationMethods.stripped(FIELD_ERROR)
   end
 
-  def test_uploaded_file
-    mock_file = mock
-    File.expects(:open).with('temp-filename').returns(mock_file).once
-    AWS::S3.expects(:upload_to_bucket).with('cdo-form-uploads', 's3-filename', mock_file).once
-    FormValidationMethods.uploaded_file({filename: 's3-filename', tempfile: 'temp-filename'})
-
-    assert_nil FormValidationMethods.uploaded_file('')
-    assert_equal FIELD_ERROR, FormValidationMethods.uploaded_file(FIELD_ERROR)
-  end
-
   def test_email_address
     assert_equal 'person@example.net', FormValidationMethods.email_address('person@example.net')
     assert_equal 'downcased@andstripped.net', FormValidationMethods.email_address('  DownCased@AndStripped.net  ')

--- a/pegasus/forms/company_profile.rb
+++ b/pegasus/forms/company_profile.rb
@@ -17,10 +17,6 @@ class CompanyProfile < Form
       result[:gplus_b] = nil_if_empty data[:gplus_b]
       result[:final_hoc_count_i] = nil_if_empty stripped data[:final_hoc_count_i]
       result[:hide_counter_b] = nil_if_empty data[:hide_counter_b]
-
-      if FormError.detect_errors(result).empty?
-        result[:logo_path_s] = default_if_empty uploaded_file(data[:logo_file]), result[:logo_path_s]
-      end
     end
   end
 end

--- a/pegasus/routes/form_routes.rb
+++ b/pegasus/routes/form_routes.rb
@@ -1,15 +1,3 @@
-get '/forms/uploads/*' do |uri|
-  cache_file = cache_dir('fetch', request.site, request.path_info)
-  unless File.file?(cache_file) && File.mtime(cache_file) > settings.launched_at
-    FileUtils.mkdir_p File.dirname(cache_file)
-    File.write(cache_file, AWS::S3.download_from_bucket('cdo-form-uploads', uri))
-  end
-  pass unless File.file?(cache_file)
-
-  cache_control :public, :must_revalidate, max_age: settings.static_max_age
-  send_file(cache_file)
-end
-
 post '/forms/:kind' do |kind|
   halt 403 if settings.read_only
   begin


### PR DESCRIPTION
@sureshc did an investigation and concluded this bucket is no longer used, so let's remove references to it out of our codebase!

There were 59 visits to URLs of the pattern `/form/uploads/*` since the beginning of June so I don't think that endpoint will be missed. 🚮 



## Links
<!--  Links to relevant external resources.
      - spec docs, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- Jira: 

## Testing story
<!--  Does your change include appropriate tests?
      - If so, please describe how the tests included in this PR are sufficient.
      - If not, please explain why this change does not need to be tested. -->



## Deployment strategy
<!--  Any special steps required to deploy this, besides merging?
      - Are there database migrations or manual steps?
      - Does this require coordination with other teams or systems? -->



## Follow-up work
<!--  List any clean-up or technical debt that will be addressed in future work.
      - Include Jira links where applicable.
      - Are there any known limitations or improvements planned? -->



## Privacy
<!--  How does this change impact Student & Teacher privacy?
      - Does this collect, use, share, or modify PII, either new or existing? -->



## Security
<!--  How does this change impact our security surface-area?
      - Do API's touched have the right auth?
      - Do infra changes impact our attack surface or encryption?
-->



## Caching
<!--  How does this change impact caching behavior?
      - Are cache keys or invalidation strategies affected?
      - Will this require cache warming or invalidation after deployment? -->



## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
