### PR TITLE
Music: settings fix

### DIFF
--- a/apps/src/music/views/HeaderButtons.tsx
+++ b/apps/src/music/views/HeaderButtons.tsx
@@ -10,7 +10,6 @@ import IconButtonWithTooltip from '@cdo/apps/lab2/views/components/IconButtonWit
 import SettingsButton from '@cdo/apps/lab2/views/components/Settings/SettingsButton';
 import {useDialogControl, DialogType} from '@cdo/apps/lab2/views/dialogs';
 import {commonI18n} from '@cdo/apps/types/locale';
-import experiments from '@cdo/apps/util/experiments';
 import {useAppSelector} from '@cdo/apps/util/reduxHooks';
 
 import {getBaseAssetUrl} from '../appConfig';
@@ -62,6 +61,7 @@ interface HeaderButtonsProps {
   clearCode: () => void;
   allowPackSelection: boolean;
   skipUrl: string | undefined;
+  showSettings: boolean;
   hideChaff: () => void;
 }
 
@@ -74,6 +74,7 @@ const HeaderButtons: React.FunctionComponent<HeaderButtonsProps> = ({
   clearCode,
   allowPackSelection,
   skipUrl,
+  showSettings,
   hideChaff,
 }) => {
   const readOnlyWorkspace: boolean = useSelector(isReadOnlyWorkspace);
@@ -181,11 +182,7 @@ const HeaderButtons: React.FunctionComponent<HeaderButtonsProps> = ({
         </>
       )}
       {/* Settings Button */}
-      {!experiments.isEnabledAllowingQueryString(
-        experiments.LAB2_RESOURCE_PANEL
-      ) ? (
-        <SettingsButton settings={settings} />
-      ) : null}
+      {showSettings && <SettingsButton settings={settings} />}
       {!readOnlyWorkspace && (
         <>
           {/* Undo Button */}

--- a/apps/src/music/views/MusicLabView.tsx
+++ b/apps/src/music/views/MusicLabView.tsx
@@ -387,6 +387,7 @@ const MusicLabView: React.FunctionComponent<MusicLabViewProps> = ({
                 clearCode={clearCode}
                 allowPackSelection={allowPackSelection}
                 skipUrl={skipUrl}
+                showSettings={!showInstructions}
                 hideChaff={hideChaff}
               />
             }


### PR DESCRIPTION
This small follow-up to https://github.com/code-dot-org/code-dot-org/pull/68721 fixes the header buttons so that they no longer show the settings button if it's already being shown next to instructions as part of the Resource Panel.
