### PR TITLE
run drone on DTT pull requests for stats purposes

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -31,7 +31,7 @@ steps:
         cat <<EOF
 
         Running on hostname: $hostname
-        
+
         To "ssh" into this drone instance, wait until the 'unit-tests' step starts and run:
         bin/drone/shell $hostname
 
@@ -142,7 +142,6 @@ trigger:
   branch:
     exclude:
       - "production"
-      - "test"
       - "levelbuilder"
   event:
     - pull_request
@@ -173,7 +172,7 @@ steps:
         cat <<EOF
 
         Running on hostname: $hostname
-        
+
         To "ssh" into this drone instance, wait until the 'ui-tests' step starts and run:
         bin/drone/shell $hostname
 
@@ -287,7 +286,6 @@ trigger:
   branch:
     exclude:
       - "production"
-      - "test"
       - "levelbuilder"
   event:
     - pull_request
@@ -378,6 +376,6 @@ trigger:
     - push
 ---
 kind: signature
-hmac: f91f1b63a5d39a1dc5e56c1e86b7a8c1b06535d3e7b234f942462d344dd04d09
+hmac: 738b8a924f22e0e86e4de6465941c2923ce58e37ca8be1eeff294c5657f33285
 
 ...


### PR DESCRIPTION
The purpose of this PR is to add some high-confidence drone runs that can be used to measure overall drone flakiness. drone runs against developer PRs are not useful for this because there's no easy way to determine whether a build failed due to flakiness or due to an error in the PR. 

I also considered these other trigger conditions:
- on push to staging
- on push to test

however, because drone triggers do not support complex AND / OR logic, those conditions were not practical to implement.

## Testing story

signing the drone file succeeds (it will give an error if it can't parse the yaml). otherwise, i'm just relying on inspection to convince myself that this change looks correct.

note that there's no guarantee the drone runs will actually pass when they run on DTT PRs. If those fail, I will plan to fix forward since we don't have anything depending on these drone runs yet. 

## Deployment strategy

once deployed to test:
- verify that drone builds are running on DTT PRs, and are running the `unit` and `ui` pipelines

