### PR TITLE
Fix CensusSubmission errors in PII scrubber

### DIFF
--- a/dashboard/lib/services/user/pii_scrubber.rb
+++ b/dashboard/lib/services/user/pii_scrubber.rb
@@ -19,6 +19,7 @@ module Services
       attr_reader :user, :email
 
       REDACTED_STRING = 'redacted'
+      REDACTED_EMAIL_STRING = 'redacted@code.org'
       EMAIL_REGEX = /\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b/i
 
       def initialize(user:)
@@ -64,7 +65,7 @@ module Services
         if email.present? && ::User.find_by_email(email).blank?
           EmailPreference.where(email: email).destroy_all
           Census::CensusSubmission.where(submitter_email_address: email).find_each do |cs|
-            cs.update!(submitter_email_address: nil, submitter_name: nil)
+            cs.update!(submitter_email_address: REDACTED_EMAIL_STRING, submitter_name: REDACTED_STRING)
           end
         end
 
@@ -127,7 +128,7 @@ module Services
         user.simple_survey_submissions.each do |sss|
           foorm_submission = sss.foorm_submission
           if foorm_submission.present?
-            foorm_submission.update!(answers: foorm_submission.answers.gsub(EMAIL_REGEX, REDACTED_STRING))
+            foorm_submission.update!(answers: foorm_submission.answers.gsub(EMAIL_REGEX, REDACTED_EMAIL_STRING))
           end
         end
       end


### PR DESCRIPTION
Turns out some CensusSubmission fields that aren't required in the db do have ActiveRecord validations that effectively make them required. The PII scrubber was causing validation errors trying to save CensusSubmissions with nil emails and submitter_names. This changed the logic to set these to redacted strings instead of nil. The email has a validation for format, so I added back in the REDACTED_EMAIL_STRING constant, and set it to "redacted@code.org". Confirmed with RED that this value works for them.


## Links
[JIRA](https://codedotorg.atlassian.net/browse/P20-1679)

## Testing story
<!--  Does your change include appropriate tests?
      - If so, please describe how the tests included in this PR are sufficient.
      - If not, please explain why this change does not need to be tested. -->



## Deployment strategy
<!--  Any special steps required to deploy this, besides merging?
      - Are there database migrations or manual steps?
      - Does this require coordination with other teams or systems? -->



## Follow-up work
<!--  List any clean-up or technical debt that will be addressed in future work.
      - Include Jira links where applicable.
      - Are there any known limitations or improvements planned? -->



## Privacy
<!--  How does this change impact Student & Teacher privacy?
      - Does this collect, use, share, or modify PII, either new or existing? -->



## Security
<!--  How does this change impact our security surface-area?
      - Do API's touched have the right auth?
      - Do infra changes impact our attack surface or encryption?
-->



## Caching
<!--  How does this change impact caching behavior?
      - Are cache keys or invalidation strategies affected?
      - Will this require cache warming or invalidation after deployment? -->



## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
