### PR TITLE
hoai2025: pilot 6 fixes

### DIFF
--- a/apps/src/music/views/GenerateCode.tsx
+++ b/apps/src/music/views/GenerateCode.tsx
@@ -71,26 +71,19 @@ const GenerateCode: React.FunctionComponent<GenerateCodeProps> = ({
 
   // Use legacy adlib ID, adlib object, or new adlib ID.
   const useAdlib =
-    !useText && adlib && typeof adlib === 'string'
+    !useText &&
+    (adlib && typeof adlib === 'string'
       ? adlibs[adlib]
       : adlib
       ? adlib
       : adlibOption
       ? adlibs[adlibOption]
-      : undefined;
+      : undefined);
 
   useLifecycleNotifier(LifecycleEvent.LevelLoadCompleted, () => {
     dispatch(setAiGenerateState('none'));
     setPromptText(adlibOption ? '' : useText ? '' : DefaultPrompt);
   });
-
-  useEffect(() => {
-    setToolboxVisibility(
-      ['none', 'editing', 'edited', 'listeningAfterEdit'].includes(
-        aiGenerateState
-      )
-    );
-  }, [aiGenerateState, setToolboxVisibility]);
 
   const generateSong = useCallback(async () => {
     dispatch(setAiGenerateState('generating'));

--- a/dashboard/config/levels/custom/music/HoAI_pilot_6_music_code_sound.level
+++ b/dashboard/config/levels/custom/music/HoAI_pilot_6_music_code_sound.level
@@ -184,7 +184,7 @@
     "level_data": {
       "validationTimeout": 6,
       "library": "launch2024",
-      "dancerMove": "rest",
+      "danceMove": "rest",
       "packId": "default",
       "startSources": {
         "blocks": {

--- a/dashboard/config/levels/custom/music/HoAI_pilot_6_music_gen_song.level
+++ b/dashboard/config/levels/custom/music/HoAI_pilot_6_music_gen_song.level
@@ -8,7 +8,7 @@
   "properties": {
     "level_data": {
       "library": "launch2024",
-      "dancerMove": "dab",
+      "danceMove": "dab",
       "aiCodeGenerate": "true",
       "aiCodeGenerateAdlib": {
         "id": "length",

--- a/dashboard/config/levels/custom/music/HoAI_pilot_6_music_gen_song_free_text.level
+++ b/dashboard/config/levels/custom/music/HoAI_pilot_6_music_gen_song_free_text.level
@@ -2,7 +2,7 @@
   <config><![CDATA[{
   "published": true,
   "game_id": 70,
-  "created_at": "2025-10-14T23:09:53.000Z",
+  "created_at": "2025-10-15T18:05:34.000Z",
   "level_num": "custom",
   "user_id": 1,
   "properties": {
@@ -10,36 +10,6 @@
       "library": "launch2024",
       "aiCodeGenerate": "true",
       "aiCodeGenerateText": "true",
-      "aiCodeGenerateAdlib": {
-        "id": "length",
-        "template": "Please code a music remix that layers {type1}, {type2}, and {type3} together, around {length} measures long.",
-        "options": {
-          "type1": [
-            "bass",
-            "leads",
-            "beats",
-            "vocals"
-          ],
-          "type2": [
-            "bass",
-            "leads",
-            "beats",
-            "vocals"
-          ],
-          "type3": [
-            "bass",
-            "leads",
-            "beats",
-            "vocals"
-          ],
-          "length": [
-            "10",
-            "15",
-            "20"
-          ]
-        },
-        "variantCount": 3
-      },
       "toolbox": {
         "blocks": {
           "Play": [
@@ -71,10 +41,9 @@
     "display_name": "Regenerate the music",
     "thumbnail_url": "https://images.code.org/18f4fa0ac2cc0deb0e478e38dd2a85e4-botmusic.jpg",
     "name_suffix": "_4",
-    "long_instructions": "####Remix a song for the party!\r\nUse AI to help get started with the code.",
     "preload_asset_list": null
   },
-  "audit_log": "[{\"changed_at\":\"2025-10-14T23:09:53.896+00:00\",\"changed\":[\"cloned from \\\"HoAI_pilot_6_music_gen_song\\\"\"],\"cloned_from\":\"HoAI_pilot_6_music_gen_song\"},{\"changed_at\":\"2025-10-14 23:11:43 +0000\",\"changed\":[\"level_data\",\"predict_settings\"],\"changed_by_id\":887,\"changed_by_email\":\"bryan@code.org\"}]"
+  "audit_log": "[{\"changed_at\":\"2025-10-14T23:09:53.896+00:00\",\"changed\":[\"cloned from \\\"HoAI_pilot_6_music_gen_song\\\"\"],\"cloned_from\":\"HoAI_pilot_6_music_gen_song\"},{\"changed_at\":\"2025-10-14 23:11:43 +0000\",\"changed\":[\"level_data\",\"predict_settings\"],\"changed_by_id\":887,\"changed_by_email\":\"bryan@code.org\"},{\"changed_at\":\"2025-10-15 21:14:04 +0000\",\"changed\":[\"predict_settings\",\"long_instructions\"],\"changed_by_id\":1,\"changed_by_email\":\"brendan+levelbuilder@code.org\"}]"
 }]]></config>
   <blocks/>
 </Music>

--- a/dashboard/config/levels/custom/music/HoAI_pilot_6_music_gen_tog.level
+++ b/dashboard/config/levels/custom/music/HoAI_pilot_6_music_gen_tog.level
@@ -8,7 +8,7 @@
   "properties": {
     "level_data": {
       "library": "launch2024",
-      "dancerMove": "floss",
+      "danceMove": "floss",
       "aiCodeGenerate": "true",
       "aiCodeGenerateExtraPrompt": "Always nest play blocks inside play together. Use only two to three play togethers and do not use repeat.",
       "aiCodeGenerateAdlib": {

--- a/dashboard/config/levels/custom/music/hoai-pilot-6-play-together.level
+++ b/dashboard/config/levels/custom/music/hoai-pilot-6-play-together.level
@@ -57,7 +57,7 @@
       }
     ],
     "level_data": {
-      "dancerMove": "roll",
+      "danceMove": "roll",
       "startSources": {
         "blocks": {
           "languageVersion": 0,


### PR DESCRIPTION
Some quick fixes for the pilot 6 (`/courses/hoai-pilot-6`) round of playtesting:
- The free-text entry entry Music level now shows the text entry box rather than an adlib.
  - Two fixes included, either of which is suficient: adlib removed from level; logic updated.
- The toolbox hiding has been removed for now
  - Didn't work for flyout (i.e. non-category) toolbox.
  - Reports that sometimes the flyout toolbox wasn't visible.
- Dancers in Music levels now show.

Follow-up to https://github.com/code-dot-org/code-dot-org/pull/68834.