### PR TITLE
Web Lab 2 experiment: use structured output for all responses

### DIFF
--- a/apps/src/aichat/types/structuredOutput.ts
+++ b/apps/src/aichat/types/structuredOutput.ts
@@ -10,6 +10,7 @@ export interface JsonObjectSchema {
   required: string[];
   description?: string;
   additionalProperties: boolean;
+  propertyOrdering?: string[];
 }
 
 interface JsonProperties {

--- a/apps/src/aichat/types/structuredOutput.ts
+++ b/apps/src/aichat/types/structuredOutput.ts
@@ -10,6 +10,7 @@ export interface JsonObjectSchema {
   required: string[];
   description?: string;
   additionalProperties: boolean;
+  // propertyOrdering is only used by Gemini.
   propertyOrdering?: string[];
 }
 

--- a/apps/src/util/experiments.js
+++ b/apps/src/util/experiments.js
@@ -68,6 +68,8 @@ experiments.LAB2_RESOURCE_PANEL = 'lab2-resource-panel';
 experiments.LEGACY_LAB_AI_TUTOR = 'legacy-lab-ai-tutor';
 // Use accept/reject code flow in Web Lab 2
 experiments.WEBLAB2_ACCEPT_REJECT = 'weblab2-accept-reject';
+// Use structured output in web lab 2 (still using copy code flow)
+experiments.WEBLAB2_STRUCTURED_OUTPUT = 'weblab2-structured-output';
 
 /**
  * This was a gamified version of the finish dialog, built in 2018,

--- a/apps/src/weblab2/Weblab2View.tsx
+++ b/apps/src/weblab2/Weblab2View.tsx
@@ -145,8 +145,11 @@ const Weblab2View: React.FC<
             return jsonResponse.explanation;
           },
         };
-      } else {
-        console.log({copyCodeJsonSchema});
+      } else if (
+        experiments.isEnabledAllowingQueryString(
+          experiments.WEBLAB2_STRUCTURED_OUTPUT
+        )
+      ) {
         return {
           jsonSchema: copyCodeJsonSchema,
           responseCallback: (response: string) => {

--- a/apps/src/weblab2/Weblab2View.tsx
+++ b/apps/src/weblab2/Weblab2View.tsx
@@ -12,13 +12,18 @@ import {setHasRun} from '@cdo/apps/lab2/redux/systemRedux';
 import {LabProps, MultiFileSource, ProjectSources} from '@cdo/apps/lab2/types';
 import experiments from '@cdo/apps/util/experiments';
 
-import {JsonObjectSchema, ResponseSchemaSettings} from '../aichat/types';
+import {ResponseSchemaSettings} from '../aichat/types';
 import {useSource} from '../codebridge/hooks/useSource';
 import {useAppDispatch, useAppSelector} from '../util/reduxHooks';
 
 import {WEBLAB2_EDITABLE_FILE_TYPES} from './constants';
 import {AiTutorWebLab2ContextHelper} from './helpers/aiTutorContextHelper';
 import {getPromptNameFromMode} from './helpers/aiTutorHelper';
+import {
+  acceptRejectJsonSchema,
+  copyCodeJsonSchema,
+  formatExplanationResponse,
+} from './helpers/aiTutorStructuredResponseHelper';
 import FullScreenView from './layout/FullScreenView';
 import ShareView from './layout/ShareView';
 import VerticalLayout from './layout/VerticalLayout';
@@ -46,28 +51,6 @@ const defaultConfig: ConfigType = {
     share: ShareView,
     fullScreen: FullScreenView,
   },
-};
-
-const aiTutorResponseJsonSchema: JsonObjectSchema = {
-  type: 'object',
-  properties: {
-    code: {
-      type: 'array',
-      items: {
-        type: 'object',
-        properties: {
-          language: {type: 'string'},
-          sourceCode: {type: 'string'},
-          filename: {type: 'string'},
-        },
-        required: ['language', 'sourceCode', 'filename'],
-        additionalProperties: false,
-      },
-    },
-    explanation: {type: 'string'},
-  },
-  required: ['code', 'explanation'],
-  additionalProperties: false,
 };
 
 const defaultSource: MultiFileSource = {
@@ -152,14 +135,25 @@ const Weblab2View: React.FC<
         )
       ) {
         return {
-          jsonSchema: aiTutorResponseJsonSchema,
+          jsonSchema: acceptRejectJsonSchema,
           responseCallback: (response: string) => {
+            const jsonResponse = JSON.parse(response);
             console.log('🤖: Tutor response (in jsonSchema callback):', {
-              response,
+              jsonResponse,
             });
             // TODO: send code to the appropriate place
-            const jsonResponse = JSON.parse(response);
             return jsonResponse.explanation;
+          },
+        };
+      } else {
+        return {
+          jsonSchema: copyCodeJsonSchema,
+          responseCallback: (response: string) => {
+            const jsonResponse = JSON.parse(response);
+            console.log('🤖: Tutor response (in jsonSchema callback):', {
+              jsonResponse,
+            });
+            return formatExplanationResponse(jsonResponse.explanation);
           },
         };
       }

--- a/apps/src/weblab2/Weblab2View.tsx
+++ b/apps/src/weblab2/Weblab2View.tsx
@@ -21,8 +21,8 @@ import {AiTutorWebLab2ContextHelper} from './helpers/aiTutorContextHelper';
 import {getPromptNameFromMode} from './helpers/aiTutorHelper';
 import {
   acceptRejectJsonSchema,
-  copyCodeJsonSchema,
   formatExplanationResponse,
+  copyCodeJsonSchema,
 } from './helpers/aiTutorStructuredResponseHelper';
 import FullScreenView from './layout/FullScreenView';
 import ShareView from './layout/ShareView';
@@ -154,7 +154,7 @@ const Weblab2View: React.FC<
             console.log('🤖: Tutor response (in jsonSchema callback):', {
               jsonResponse,
             });
-            return formatExplanationResponse(jsonResponse.explanation);
+            return formatExplanationResponse(jsonResponse.answer);
           },
         };
       }

--- a/apps/src/weblab2/Weblab2View.tsx
+++ b/apps/src/weblab2/Weblab2View.tsx
@@ -146,6 +146,7 @@ const Weblab2View: React.FC<
           },
         };
       } else {
+        console.log({copyCodeJsonSchema});
         return {
           jsonSchema: copyCodeJsonSchema,
           responseCallback: (response: string) => {

--- a/apps/src/weblab2/helpers/aiTutorHelper.ts
+++ b/apps/src/weblab2/helpers/aiTutorHelper.ts
@@ -1,5 +1,6 @@
 import {FontAwesomeV6IconProps} from '@code-dot-org/component-library/fontAwesomeV6Icon';
 
+import experiments from '@cdo/apps/util/experiments';
 import weblab2I18n from '@cdo/apps/weblab2/locale';
 
 export const DEFAULT_AI_TUTOR_MODE = 'suggest';
@@ -18,6 +19,14 @@ export const getPromptNameFromMode = (mode: string | undefined) => {
   let suffix = 'suggest';
   if (mode && Object.keys(MODE_MAP).includes(mode)) {
     suffix = mode;
+  }
+  if (
+    experiments.isEnabledAllowingQueryString(
+      experiments.WEBLAB2_STRUCTURED_OUTPUT
+    ) ||
+    experiments.isEnabledAllowingQueryString(experiments.WEBLAB2_ACCEPT_REJECT)
+  ) {
+    suffix += '-structured';
   }
   return `${prefix}${suffix}`;
 };

--- a/apps/src/weblab2/helpers/aiTutorStructuredResponseHelper.ts
+++ b/apps/src/weblab2/helpers/aiTutorStructuredResponseHelper.ts
@@ -1,12 +1,21 @@
 import {JsonObjectSchema} from '@cdo/apps/aichat/types';
 
-const getExplanationJsonSchema = (
-  isCopyCodeMode: boolean
-): JsonObjectSchema => {
+const getAnswerJsonSchema = (isCopyCodeMode: boolean): JsonObjectSchema => {
   return {
     type: 'object',
     properties: {
-      tutorMode: {type: 'string', enum: ['Build HTML', 'Build CSS']},
+      tutorMode: {
+        type: 'string',
+        enum: [
+          'Build HTML',
+          'Build CSS',
+          'Ask',
+          'Hint',
+          'Debug',
+          'Explain',
+          'Refuse',
+        ],
+      },
       goal: {
         type: 'string',
         description: 'What we are achieving this turn, limit to 1 line of text',
@@ -14,6 +23,28 @@ const getExplanationJsonSchema = (
       assumptions: {
         type: 'string',
         description: 'Explicit design choices you made from the wireframe',
+      },
+      code: {
+        type: 'array',
+        items: {
+          type: 'object',
+          properties: {
+            language: {type: 'string'},
+            sourceCode: {
+              type: 'string',
+            },
+            filename: {type: 'string'},
+          },
+          required: ['language', 'sourceCode', 'filename'],
+          additionalProperties: false,
+        },
+        description:
+          '`html` and/or `css` fences. When providing modifications to student code, provide the entire contents of the file. The list can be empty.',
+      },
+      explanation: {
+        type: 'string',
+        description:
+          "Explanation of the code or plain-text answer to the student's question",
       },
       nextSteps: {
         type: 'string',
@@ -28,37 +59,35 @@ const getExplanationJsonSchema = (
         type: 'string',
         description: 'short list to confirm ambiguous details',
       },
-      code: {
-        type: 'array',
-        items: {
-          type: 'object',
-          properties: {
-            language: {type: 'string'},
-            sourceCode: {
-              type: 'string',
-              description: isCopyCodeMode
-                ? 'Well formatted `html` and/or `css`. These can be full code files.'
-                : 'Well formatted html or css code snippets. These should not be full code files.',
-            },
-            filename: {type: 'string'},
-          },
-          required: ['language', 'sourceCode', 'filename'],
-          additionalProperties: false,
-        },
-      },
     },
-    required: ['tutorMode', 'goal', 'nextSteps', 'furtherSupport', 'code'],
+    required: [
+      'tutorMode',
+      'goal',
+      'nextSteps',
+      'furtherSupport',
+      'code',
+      'explanation',
+    ],
+    propertyOrdering: [
+      'tutorMode',
+      'goal',
+      'assumptions',
+      'code',
+      'explanation',
+      'nextSteps',
+      'furtherSupport',
+      'questions',
+    ],
     additionalProperties: false,
-    description: 'All string responses should be formatted in markdown.',
   };
 };
 
 export const copyCodeJsonSchema: JsonObjectSchema = {
   type: 'object',
   properties: {
-    explanation: getExplanationJsonSchema(true),
+    answer: getAnswerJsonSchema(true),
   },
-  required: ['explanation'],
+  required: ['answer'],
   additionalProperties: false,
 };
 
@@ -93,7 +122,7 @@ export const formatExplanationResponse = (response: any): string => {
   if (response.assumptions) {
     formattedResponse += `**Assumptions**\n\n${response.assumptions}\n\n`;
   }
-  if (response.code) {
+  if (response.code && response.code.length > 0) {
     formattedResponse += `**Code**\n\n`;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     response.code.forEach((code: any) => {
@@ -101,8 +130,11 @@ export const formatExplanationResponse = (response: any): string => {
       formattedResponse += `Filename: ${code.filename}\n\`\`\`\n${code.sourceCode}\n\`\`\`\n\n`;
     });
   }
+  if (response.explanation) {
+    formattedResponse += `**Explanation**\n\n${response.explanation}\n\n`;
+  }
   if (response.nextSteps) {
-    formattedResponse += `**Next Steps**\n${response.nextSteps}\n\n`;
+    formattedResponse += `**Next Steps**\n\n${response.nextSteps}\n\n`;
   }
   if (response.furtherSupport) {
     formattedResponse += `**Further Support**\n\n${response.furtherSupport}\n\n`;

--- a/apps/src/weblab2/helpers/aiTutorStructuredResponseHelper.ts
+++ b/apps/src/weblab2/helpers/aiTutorStructuredResponseHelper.ts
@@ -50,16 +50,17 @@ const getAnswerJsonSchema = (isCopyCodeMode: boolean): JsonObjectSchema => {
       nextSteps: {
         type: 'string',
         description:
-          '1-2 concrete action(s) for student to achieve goal. Format as bullets',
+          '1-2 concrete action(s) for student to achieve goal. Format as markdown bullets',
       },
       furtherSupport: {
         type: 'string',
-        description: '1–2 questions or 1–2 micro-hints. Format as bullets.',
+        description:
+          '1–2 questions or 1–2 micro-hints. Format as markdown bullets.',
       },
       questions: {
         type: 'string',
         description:
-          'short list to confirm ambiguous details. Format as bullets.',
+          'short list to confirm ambiguous details. Format as markdown bullets.',
       },
     },
     required: [

--- a/apps/src/weblab2/helpers/aiTutorStructuredResponseHelper.ts
+++ b/apps/src/weblab2/helpers/aiTutorStructuredResponseHelper.ts
@@ -129,7 +129,6 @@ export const formatExplanationResponse = (response: any): string => {
     formattedResponse += `**Code**\n\n`;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     response.code.forEach((code: any) => {
-      console.log({code});
       formattedResponse += `\`${code.filename}\`\n\`\`\`\n${code.sourceCode}\n\`\`\`\n\n`;
     });
   }
@@ -145,6 +144,5 @@ export const formatExplanationResponse = (response: any): string => {
   if (response.questions) {
     formattedResponse += `**Questions**\n\n${response.questions}\n\n`;
   }
-  console.log({formattedResponse});
   return formattedResponse;
 };

--- a/apps/src/weblab2/helpers/aiTutorStructuredResponseHelper.ts
+++ b/apps/src/weblab2/helpers/aiTutorStructuredResponseHelper.ts
@@ -1,0 +1,112 @@
+import {JsonObjectSchema} from '@cdo/apps/aichat/types';
+
+const getExplanationJsonSchema = (
+  isCopyCodeMode: boolean
+): JsonObjectSchema => {
+  return {
+    type: 'object',
+    properties: {
+      tutorMode: {type: 'string', enum: ['Build HTML', 'Build CSS']},
+      goal: {
+        type: 'string',
+        description: 'What we are achieving this turn, limit to 1 line of text',
+      },
+      assumptions: {
+        type: 'string',
+        description: 'Explicit design choices you made from the wireframe',
+      },
+      nextSteps: {
+        type: 'string',
+        description:
+          '1-2 bullets of concrete action(s) for student to achieve goal.',
+      },
+      furtherSupport: {
+        type: 'string',
+        description: '1–2 questions or 1–2 micro-hints',
+      },
+      questions: {
+        type: 'string',
+        description: 'short list to confirm ambiguous details',
+      },
+      code: {
+        type: 'array',
+        items: {
+          type: 'object',
+          properties: {
+            language: {type: 'string'},
+            sourceCode: {type: 'string'},
+            filename: {type: 'string'},
+          },
+          required: ['language', 'sourceCode', 'filename'],
+          additionalProperties: false,
+          description: isCopyCodeMode
+            ? 'Runnable `html` and/or `css` fences'
+            : 'Runnable html or css code snippets. These should not be full code files.',
+        },
+      },
+    },
+    required: ['tutorMode', 'goal', 'nextSteps', 'furtherSupport'],
+    additionalProperties: false,
+    description:
+      "Answer to the student's question. All string responses should be formatted in markdown.",
+  };
+};
+
+export const copyCodeJsonSchema: JsonObjectSchema = {
+  type: 'object',
+  properties: {
+    explanation: getExplanationJsonSchema(true),
+  },
+  required: ['explanation'],
+  additionalProperties: false,
+};
+
+export const acceptRejectJsonSchema: JsonObjectSchema = {
+  type: 'object',
+  properties: {
+    code: {
+      type: 'array',
+      items: {
+        type: 'object',
+        properties: {
+          language: {type: 'string'},
+          sourceCode: {type: 'string'},
+          filename: {type: 'string'},
+        },
+        required: ['language', 'sourceCode', 'filename'],
+        additionalProperties: false,
+      },
+    },
+    explanation: {type: 'string'},
+  },
+  required: ['code', 'explanation'],
+  additionalProperties: false,
+};
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export const formatExplanationResponse = (response: any): string => {
+  let formattedResponse = '';
+  if (response.goal) {
+    formattedResponse += `**Goal**\n\n${response.goal}\n\n`;
+  }
+  if (response.assumptions) {
+    formattedResponse += `**Assumptions**\n\n${response.assumptions}\n\n`;
+  }
+  if (response.code) {
+    formattedResponse += `**Code**\n\n`;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    response.code.forEach((code: any) => {
+      formattedResponse += `Filename: ${code.filename}\n\`\`\`${code.sourceCode}\n\`\`\`\n\n`;
+    });
+  }
+  if (response.nextSteps) {
+    formattedResponse += `**Next Steps**\n${response.nextSteps}\n\n`;
+  }
+  if (response.furtherSupport) {
+    formattedResponse += `**Further Support**\n\n${response.furtherSupport}\n\n`;
+  }
+  if (response.questions) {
+    formattedResponse += `**Questions**\n\n${response.questions}\n\n`;
+  }
+  return formattedResponse;
+};

--- a/apps/src/weblab2/helpers/aiTutorStructuredResponseHelper.ts
+++ b/apps/src/weblab2/helpers/aiTutorStructuredResponseHelper.ts
@@ -116,6 +116,7 @@ export const acceptRejectJsonSchema: JsonObjectSchema = {
   additionalProperties: false,
 };
 
+// Parsed json comes in as 'any'
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const formatExplanationResponse = (response: any): string => {
   let formattedResponse = '';
@@ -127,6 +128,7 @@ export const formatExplanationResponse = (response: any): string => {
   }
   if (response.code && response.code.length > 0) {
     formattedResponse += `**Code**\n\n`;
+    // Parsed json comes in as 'any'
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     response.code.forEach((code: any) => {
       formattedResponse += `\`${code.filename}\`\n\`\`\`\n${code.sourceCode}\n\`\`\`\n\n`;

--- a/apps/src/weblab2/helpers/aiTutorStructuredResponseHelper.ts
+++ b/apps/src/weblab2/helpers/aiTutorStructuredResponseHelper.ts
@@ -22,7 +22,8 @@ const getAnswerJsonSchema = (isCopyCodeMode: boolean): JsonObjectSchema => {
       },
       assumptions: {
         type: 'string',
-        description: 'Explicit design choices you made from the wireframe',
+        description:
+          'Explicit design choices you made from the wireframe. Format as bullets.',
       },
       code: {
         type: 'array',
@@ -44,20 +45,21 @@ const getAnswerJsonSchema = (isCopyCodeMode: boolean): JsonObjectSchema => {
       explanation: {
         type: 'string',
         description:
-          "Explanation of the code or plain-text answer to the student's question",
+          "1 paragraph or less explanation of the code or plain-text answer to the student's question. Use markdown.",
       },
       nextSteps: {
         type: 'string',
         description:
-          '1-2 bullets of concrete action(s) for student to achieve goal.',
+          '1-2 concrete action(s) for student to achieve goal. Format as bullets',
       },
       furtherSupport: {
         type: 'string',
-        description: '1–2 questions or 1–2 micro-hints',
+        description: '1–2 questions or 1–2 micro-hints. Format as bullets.',
       },
       questions: {
         type: 'string',
-        description: 'short list to confirm ambiguous details',
+        description:
+          'short list to confirm ambiguous details. Format as bullets.',
       },
     },
     required: [
@@ -127,7 +129,7 @@ export const formatExplanationResponse = (response: any): string => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     response.code.forEach((code: any) => {
       console.log({code});
-      formattedResponse += `Filename: ${code.filename}\n\`\`\`\n${code.sourceCode}\n\`\`\`\n\n`;
+      formattedResponse += `\`${code.filename}\`\n\`\`\`\n${code.sourceCode}\n\`\`\`\n\n`;
     });
   }
   if (response.explanation) {

--- a/apps/src/weblab2/helpers/aiTutorStructuredResponseHelper.ts
+++ b/apps/src/weblab2/helpers/aiTutorStructuredResponseHelper.ts
@@ -34,21 +34,22 @@ const getExplanationJsonSchema = (
           type: 'object',
           properties: {
             language: {type: 'string'},
-            sourceCode: {type: 'string'},
+            sourceCode: {
+              type: 'string',
+              description: isCopyCodeMode
+                ? 'Well formatted `html` and/or `css`. These can be full code files.'
+                : 'Well formatted html or css code snippets. These should not be full code files.',
+            },
             filename: {type: 'string'},
           },
           required: ['language', 'sourceCode', 'filename'],
           additionalProperties: false,
-          description: isCopyCodeMode
-            ? 'Runnable `html` and/or `css` fences'
-            : 'Runnable html or css code snippets. These should not be full code files.',
         },
       },
     },
-    required: ['tutorMode', 'goal', 'nextSteps', 'furtherSupport'],
+    required: ['tutorMode', 'goal', 'nextSteps', 'furtherSupport', 'code'],
     additionalProperties: false,
-    description:
-      "Answer to the student's question. All string responses should be formatted in markdown.",
+    description: 'All string responses should be formatted in markdown.',
   };
 };
 
@@ -96,7 +97,8 @@ export const formatExplanationResponse = (response: any): string => {
     formattedResponse += `**Code**\n\n`;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     response.code.forEach((code: any) => {
-      formattedResponse += `Filename: ${code.filename}\n\`\`\`${code.sourceCode}\n\`\`\`\n\n`;
+      console.log({code});
+      formattedResponse += `Filename: ${code.filename}\n\`\`\`\n${code.sourceCode}\n\`\`\`\n\n`;
     });
   }
   if (response.nextSteps) {
@@ -108,5 +110,6 @@ export const formatExplanationResponse = (response: any): string => {
   if (response.questions) {
     formattedResponse += `**Questions**\n\n${response.questions}\n\n`;
   }
+  console.log({formattedResponse});
   return formattedResponse;
 };

--- a/dashboard/app/helpers/aichat_ai_client_types.rb
+++ b/dashboard/app/helpers/aichat_ai_client_types.rb
@@ -127,6 +127,7 @@ module AichatAiClientTypes
   #   required: string[];
   #   description?: string;
   #   additionalProperties: boolean;
+  #   // propertyOrdering is only used by Gemini.
   #   propertyOrdering?: string[];
   # }
   JsonObjectSchema = Interface(

--- a/dashboard/app/helpers/aichat_ai_client_types.rb
+++ b/dashboard/app/helpers/aichat_ai_client_types.rb
@@ -127,6 +127,7 @@ module AichatAiClientTypes
   #   required: string[];
   #   description?: string;
   #   additionalProperties: boolean;
+  #   propertyOrdering?: string[];
   # }
   JsonObjectSchema = Interface(
     :type, string('object'),

--- a/dashboard/app/helpers/aichat_ai_client_types.rb
+++ b/dashboard/app/helpers/aichat_ai_client_types.rb
@@ -134,6 +134,7 @@ module AichatAiClientTypes
     :required, string[],
     :description, Optional(string),
     :additionalProperties, boolean(false),
+    :propertyOrdering, Optional(string[])
   )
 
   JsonArraySchema_ = ForwardRef()


### PR DESCRIPTION
This adds an additional experiment around structured output in Web Lab 2, related to #68820. I noticed when using the structured output from that PR that we were losing the desired format from the system prompt, which would have specific sections such as "Goal", "Next Steps", etc. 

This experiment, `weblab2-structured-output`, uses structured output for all Web Lab 2 requests to AI tutor. The format requested matches the desired format from the system prompt (see below for details). We still have the tutor return the mode, but now we hide it from users because we don't really want users to see it. I put this under a flag for now so product/curriculum can try out the new version side by side with the old version.

I also created new versions of the system prompts and saved them as `weblab2-<mode>-structured`. The only difference between the structured and non-structured prompts is I removed the desired output section and removed a couple references to putting filenames "above" code, since now they are in a clear json format.

<details>
  <summary>Original Markdown Format from System Prompt</summary>
```
```markdown
**Tutor Mode:** {Build-HTML|Build-CSS|Ask|Hint|Debug|Example|Refusal}
**Goal (1 line):** what we’re achieving this turn
**Assumptions (optional):** explicit design choices you made from the wireframe
**Code (when Build modes):** runnable `html` and/or `css` fences
**Next Steps (1–2 bullets):**
- concrete action(s) for student to achieve goal
**Further Support:**
- 1–2 questions *or*
- 1–2 micro-hints
**Questions (optional):**
- short list to confirm ambiguous details
```
</details>

## Before
<img width="574" height="910" alt="Screenshot 2025-10-15 at 3 23 14 PM" src="https://github.com/user-attachments/assets/48ea62fe-0bc9-480f-bc47-e681ca6944b0" />


## After
The response is a bit longer now, so I had to split it into two screenshots.
<img width="602" height="962" alt="Screenshot 2025-10-15 at 3 24 46 PM" src="https://github.com/user-attachments/assets/a1024163-b8e4-4d62-81be-26d97f254fea" />
<img width="602" height="379" alt="Screenshot 2025-10-15 at 3 24 53 PM" src="https://github.com/user-attachments/assets/4c362b54-ed2c-40ff-903c-458d0568a777" />


## Links
- Jira: [AFL-198](https://codedotorg.atlassian.net/browse/AFL-198)

## Testing story
Tested locally


## Follow-up work
If we generally like this, there's some work to do to clean up responses; for example it has seemed to have forgotten that users need to copy/paste their code.


## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
