### PR TITLE
chore(newrelic): enable agent via `CDO.newrelic_logging`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -190,7 +190,7 @@ gem 'highline', '~> 3.1.0'
 
 gem 'honeybadger', '>= 4.5.6' # error monitoring
 
-gem 'newrelic_rpm', '~> 8.3', group: [:staging, :development, :production] # perf/error/etc monitoring
+gem 'newrelic_rpm', '~> 8.3', require: false # perf/error/etc monitoring
 
 gem 'redcarpet', '~> 3.6.0'
 

--- a/Gemfile
+++ b/Gemfile
@@ -190,7 +190,7 @@ gem 'highline', '~> 3.1.0'
 
 gem 'honeybadger', '>= 4.5.6' # error monitoring
 
-gem 'newrelic_rpm', '~> 8.3', require: false # perf/error/etc monitoring
+gem 'newrelic_rpm', '~> 8.3', group: [:staging, :development, :production], require: false # perf/error/etc monitoring
 
 gem 'redcarpet', '~> 3.6.0'
 

--- a/cookbooks/cdo-apps/libraries/cdo_apps.rb
+++ b/cookbooks/cdo-apps/libraries/cdo_apps.rb
@@ -105,7 +105,7 @@ module CdoApps
         log_dir: log_dir
     end
 
-    if node['cdo-newrelic'] && CDO.newrelic_logging
+    if node['cdo-newrelic']
       template "#{app_root}/config/newrelic.yml" do
         source 'newrelic.yml.erb'
         user user

--- a/cookbooks/cdo-apps/libraries/cdo_apps.rb
+++ b/cookbooks/cdo-apps/libraries/cdo_apps.rb
@@ -105,7 +105,7 @@ module CdoApps
         log_dir: log_dir
     end
 
-    if node['cdo-newrelic']
+    if node['cdo-newrelic'] && CDO.newrelic_logging
       template "#{app_root}/config/newrelic.yml" do
         source 'newrelic.yml.erb'
         user user


### PR DESCRIPTION
This change restricts loading of the `newrelic_rpm` agent to environments where it is actually used. We do not consume APM data in `staging` or `development`, so loading the agent there provides no value. Removing it eliminates unnecessary instrumentation, configuration, and background activity, and reduces application startup time and runtime overhead.

https://github.com/code-dot-org/code-dot-org/blob/0967ea4e6018ce6d6af59405686974d30b2854a0/config/production.yml.erb#L20

https://github.com/code-dot-org/code-dot-org/blob/0967ea4e6018ce6d6af59405686974d30b2854a0/dashboard/config/application.rb#L236-L238

All NewRelic calls are conditional, like this one:
https://github.com/code-dot-org/code-dot-org/blob/0967ea4e6018ce6d6af59405686974d30b2854a0/dashboard/app/controllers/xhr_proxy_controller.rb#L51

## Links
- Related PR: https://github.com/code-dot-org/code-dot-org/pull/10476

## Testing Story

**tl; dr:** `bundle exec rake test:ui feature=dashboard/test/ui/features/platform/login_redirect.feature`

Specifically, I ran that test with Spring explicitly disabled for both my local web application server and the test execution. When running against staging latest, that test takes 80-90 seconds to pass on my local machine; adding `require: false` cuts that down to just ~50 seconds!