### PR TITLE
Lab2: add theme support to IconButtonWithTooltip component

### DIFF
--- a/apps/src/lab2/views/components/IconButtonWithTooltip.tsx
+++ b/apps/src/lab2/views/components/IconButtonWithTooltip.tsx
@@ -1,4 +1,5 @@
 import Button, {ButtonProps} from '@code-dot-org/component-library/button';
+import {useTheme} from '@code-dot-org/component-library/common/contexts';
 import {
   TooltipProps,
   WithTooltip,
@@ -56,6 +57,11 @@ const IconButtonWithTooltip: React.FunctionComponent<IconButtonWithTooltipProps>
         },
         [onClick, containerRef]
       );
+
+      // Get the theme, if available. If not within a `ThemeProvider`,
+      // theme will be `undefined` which will then be ignored by `Tooltip`.
+      const {theme} = useTheme(true);
+
       return (
         <WithTooltip
           tooltipProps={{
@@ -65,6 +71,7 @@ const IconButtonWithTooltip: React.FunctionComponent<IconButtonWithTooltipProps>
             direction: tooltipDirection,
             hideTail: hideTooltipTail,
             className: className,
+            'data-theme': theme,
           }}
         >
           <Button


### PR DESCRIPTION
Adds default theme support to the IconButtonWithTooltip component so it works in both light and dark modes automatically everywhere this is used. 

Copied this over from the CopyButton component in preparation for replacing this with the IconButtonWithTooltip component in [AFL-268](https://codedotorg.atlassian.net/browse/AFL-268): https://github.com/code-dot-org/code-dot-org/blob/f1a7c744be22420ea4d035b0b0a30aa7dc32d462/apps/src/aiComponentLibrary/copyButton/CopyButton.tsx#L16-L20

## Links
Jira ticket: [AFL-286](https://codedotorg.atlassian.net/browse/AFL-286)

---- 

## Before


https://github.com/user-attachments/assets/7dba90aa-e614-41de-a07e-8cba13605439



## After

https://github.com/user-attachments/assets/dfff3b63-9d13-46b7-a053-734f660ce2f0

