### PR TITLE
move dcdo require in purger script

### DIFF
--- a/bin/cron/purge_expired_deleted_accounts
+++ b/bin/cron/purge_expired_deleted_accounts
@@ -1,6 +1,8 @@
 #!/usr/bin/env ruby
 require_relative 'only_one'
 abort 'Script already running' unless only_one_running?(__FILE__)
+
+require_relative '../../dashboard/config/environment'
 exit if DCDO.get('pii-scrub-enabled', false)
 
 #
@@ -44,6 +46,5 @@ OptionParser.new do |opts|
   end
 end.parse!
 
-require_relative '../../dashboard/config/environment'
 require_relative '../../dashboard/lib/expired_deleted_account_purger'
 ExpiredDeletedAccountPurger.new(options).purge_expired_deleted_accounts!


### PR DESCRIPTION
Fixes an error when the expired_deleted_account_purger script tries to check the DCDO flag added in [PR 68730](https://github.com/code-dot-org/code-dot-org/pull/68730).



## Links
[JIRA](https://app.honeybadger.io/projects/45435/faults/124074477)

## Testing story
Run `bin/cron/purge_expired_deleted_accounts` locally. Should not get an error.

Previous error:
```
bin/cron/purge_expired_deleted_accounts:4:in `<main>': uninitialized constant DCDO (NameError)
```

## Deployment strategy
<!--  Any special steps required to deploy this, besides merging?
      - Are there database migrations or manual steps?
      - Does this require coordination with other teams or systems? -->



## Follow-up work
<!--  List any clean-up or technical debt that will be addressed in future work.
      - Include Jira links where applicable.
      - Are there any known limitations or improvements planned? -->



## Privacy
<!--  How does this change impact Student & Teacher privacy?
      - Does this collect, use, share, or modify PII, either new or existing? -->



## Security
<!--  How does this change impact our security surface-area?
      - Do API's touched have the right auth?
      - Do infra changes impact our attack surface or encryption?
-->



## Caching
<!--  How does this change impact caching behavior?
      - Are cache keys or invalidation strategies affected?
      - Will this require cache warming or invalidation after deployment? -->



## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
