### PR TITLE
increase drone instance size to m7i.4xlarge

### DIFF
--- a/aws/cloudformation/drone-stack.yml
+++ b/aws/cloudformation/drone-stack.yml
@@ -36,7 +36,7 @@ Parameters:
   WorkerInstanceType:
     Type: String
     Description: EC2 Instance Type that Autoscaler provisions to run Builds.
-    Default: m5.4xlarge
+    Default: m7i.4xlarge
   WorkerSubnetId:
     Type: AWS::EC2::Subnet::Id
     Description: Existing VPC Subnet Id where ECS EC2 Instances hosting Drone Runner ("worker") containers will be provisioned.

--- a/aws/cloudformation/drone-stack.yml
+++ b/aws/cloudformation/drone-stack.yml
@@ -388,7 +388,7 @@ Resources:
               Value: 50
             -
               Name: DRONE_AMAZON_TAGS
-              Value: cost-center:ci
+              Value: environment:ci
             # END: Settings for the EC2 Instances that Drone Autoscaler provisions.
 
             # BEGIN: Settings for the Drone Runner ("worker"/"agent") executing on the EC2 Instances provisioned by Autoscaler.

--- a/aws/cloudformation/drone-stack.yml
+++ b/aws/cloudformation/drone-stack.yml
@@ -36,7 +36,7 @@ Parameters:
   WorkerInstanceType:
     Type: String
     Description: EC2 Instance Type that Autoscaler provisions to run Builds.
-    Default: m5.xlarge
+    Default: m5.4xlarge
   WorkerSubnetId:
     Type: AWS::EC2::Subnet::Id
     Description: Existing VPC Subnet Id where ECS EC2 Instances hosting Drone Runner ("worker") containers will be provisioned.

--- a/aws/cloudformation/drone-stack.yml
+++ b/aws/cloudformation/drone-stack.yml
@@ -156,22 +156,22 @@ Resources:
     Type: AWS::EC2::LaunchTemplate
     Properties:
       LaunchTemplateName: !Sub "DroneMasterLaunchTemplate-${AWS::StackName}"
-      LaunchTemplateData: 
-        IamInstanceProfile: 
+      LaunchTemplateData:
+        IamInstanceProfile:
           Name: ecsInstanceRole
         KeyName: !Sub "winter-dev-${AWS::Region}"
-        SecurityGroupIds: 
+        SecurityGroupIds:
           - !Ref DroneMasterEcsSecurityGroup
         ImageId: !Ref DroneServerECSAMI
         InstanceType: t3.medium
         Monitoring:
           Enabled: true
-        UserData: 
+        UserData:
           Fn::Base64:
-            !Sub 
+            !Sub
               - "#!/bin/bash\necho ECS_CLUSTER=${EcsClusterName} >> /etc/ecs/ecs.config;echo ECS_BACKEND_HOST= >> /etc/ecs/ecs.config;"
               - {EcsClusterName: !Ref DroneMasterECSCluster}
- 
+
   DroneMasterEcsInstanceAsg:
     Type: AWS::AutoScaling::AutoScalingGroup
     Properties:
@@ -203,7 +203,7 @@ Resources:
           Host:
             SourcePath: /var/lib/drone
       ContainerDefinitions:
-        - 
+        -
           Name: drone-master
           Essential: true
           Image: drone/drone:1.9.0
@@ -215,7 +215,7 @@ Resources:
               awslogs-region: !Ref AWS::Region
               awslogs-stream-prefix: ecs
           PortMappings:
-            - 
+            -
               ContainerPort: 80
             -
               ContainerPort: 443
@@ -235,10 +235,10 @@ Resources:
               ValueFrom: !Sub "arn:aws:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:drone/shared/rpc-secret-etPSzp"
           Environment:
             -
-              Name: DRONE_GITHUB_SERVER 
+              Name: DRONE_GITHUB_SERVER
               Value: https://github.com
             -
-              Name: DRONE_SERVER_HOST 
+              Name: DRONE_SERVER_HOST
               Value: drone.cdn-code.org
             -
               Name: DRONE_SERVER_PROTO
@@ -386,6 +386,9 @@ Resources:
             -
               Name: DRONE_AMAZON_VOLUME_SIZE
               Value: 50
+            -
+              Name: DRONE_AMAZON_TAGS
+              Value: cost-center:ci
             # END: Settings for the EC2 Instances that Drone Autoscaler provisions.
 
             # BEGIN: Settings for the Drone Runner ("worker"/"agent") executing on the EC2 Instances provisioned by Autoscaler.


### PR DESCRIPTION
Per discussion in infra standup, lets increase drone instance size from m5.2xlarge (not currently captured in github) to m7i.4xlarge, before making further optimizations.

## Deployment strategy
 
* pair with Suresh to deploy to drone infrastructure
* create changeset of cloudformation stack
