### PR TITLE
Sketch Lab: make desktop view more likely to be default

### DIFF
--- a/apps/src/sketchlab/SketchlabView.tsx
+++ b/apps/src/sketchlab/SketchlabView.tsx
@@ -29,7 +29,12 @@ import {useAppDispatch, useAppSelector} from '@cdo/apps/util/reduxHooks';
 import moduleStyles from './styles/sketchlab-view.module.scss';
 
 const MIN_INFO_PANEL_WIDTH = 150;
-const INITIAL_INFO_PANEL_WIDTH = 400;
+// This initial width is derived from the following:
+// The narrowest screen we see in GA with 1% usage is 1024px.
+// The version of Excalidraw we're using switches into a mobile mode at 730px.
+// So, we want to make sure the initial workspace is over 730px.
+// 1024 - 290 - 1px for resize bar = 734px.
+const INITIAL_INFO_PANEL_WIDTH = 290;
 const MIN_WORKSPACE_WIDTH = 400;
 const INITIAL_WORKSPACE_WIDTH = 800;
 


### PR DESCRIPTION
Excalidraw switches into a "mobile" view, which is not a super great experience, when it is less than 730px. An example of this is when you are looking at the color palette in the mobile view, it takes up the whole screen:

<img height="500" alt="image" src="https://github.com/user-attachments/assets/63cb1ca3-3ec8-4b48-b5bc-2eb3caca6e0e" />

This PR changes the default instructions panel width to 290px so that students with small screens (say, 1024px width) are more likely to see the desktop view:

<img height="500" alt="image" src="https://github.com/user-attachments/assets/885d249a-f011-4d01-af74-9a30c080bbae" />

Also worth noting a couple of other things:
- Excalidraw seems to have moved to a much smaller width for cutting over to the mobile view in newer versions ([I think 599px](https://github.com/excalidraw/excalidraw/blob/master/packages/common/src/constants.ts#L356)).
- The UI at excalidraw.com for smaller screens seems much improved to what we're using currently. We're on 0.17.6, but blocked on moving to 0.18.0 where I think some of these changes would be available. [More detail in this Slack thread](https://codedotorg.slack.com/archives/C0T0PNR0D/p1758065850365879?thread_ts=1707783384.341769&cid=C0T0PNR0D).

## Links

- Jira: https://codedotorg.atlassian.net/browse/AFL-262

## Testing story

Tested manually with a 1024px viewport that I now see the desktop view when I open a Sketch Lab page.