### PR TITLE
Fix Ruby bindings for OpenSSL 3.6

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -397,4 +397,6 @@ end
 
 # OpenSSL 3.6 broke Ruby's OpenSSL bindings, see: https://github.com/ruby/openssl/issues/949
 # By using the openssl gem, we can pick up the fixes without needing to upgrade Ruby.
+# This gem line can be removed once we upgrade to Ruby 3.4 >= 3.4.8, or Ruby 3.3 >= 3.3.10 or Ruby 3.2 >= 3.2.10
+# which will include the openssl fix by default, see: https://github.com/ruby/openssl/issues/949#issuecomment-3388132260
 gem 'openssl', '>= 3.3.1'

--- a/Gemfile
+++ b/Gemfile
@@ -394,3 +394,7 @@ gem 'rubyzip'
 Dir[Bundler.root.join('**/engines/*/*.gemspec')].sort.each do |gemspec_path|
   gem File.basename(gemspec_path, '.gemspec'), path: '.', glob: '**/engines/*/*.gemspec'
 end
+
+# OpenSSL 3.6 broke Ruby's OpenSSL bindings, see: https://github.com/ruby/openssl/issues/949
+# By using the openssl gem, we can pick up the fixes without needing to upgrade Ruby.
+gem 'openssl', '>= 3.3.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -663,6 +663,7 @@ GEM
       time
       uri
     open_uri_redirections (0.2.1)
+    openssl (3.3.1)
     orm_adapter (0.5.0)
     os (1.1.4)
     ostruct (0.6.0)
@@ -1096,6 +1097,7 @@ DEPENDENCIES
   omniauth-microsoft_v2_auth!
   omniauth-rails_csrf_protection (~> 1.0.2)
   open_uri_redirections
+  openssl (>= 3.3.1)
   os
   parallel
   parallel_tests


### PR DESCRIPTION
OpenSSL 3.6 broke Ruby's openssl bindings.

See:
1. https://github.com/openssl/openssl/issues/28758
2. https://github.com/ruby/openssl/issues/949

This PR explicitly requests the 3.3.1 release of the ruby `openssl` gem which contains fixes for the OpenSSL 3.6 brekaage.

This gem is also available in newer ruby releases, see: https://github.com/ruby/openssl/issues/949#issuecomment-3388132260

Easiest symptom is to try running `bin/aws_access`:
```
➜  code-dot-org git:(staging) bin/aws_access 
/Users/seth/.rbenv/versions/3.1.0/lib/ruby/gems/3.1.0/gems/net-protocol-0.2.1/lib/net/protocol.rb:46:in `connect_nonblock': SSL_connect returned=1 errno=0 peeraddr=52.119.199.56:443 state=error: certificate verify failed (unable to get certificate CRL) (Seahorse::Client::NetworkingError)
```