### PR TITLE
[MusicLab] Fixes play tune enter focus bug on some songs

### DIFF
--- a/apps/src/music/views/util/EaseIntoView.tsx
+++ b/apps/src/music/views/util/EaseIntoView.tsx
@@ -120,12 +120,10 @@ const EaseIntoView: React.FunctionComponent<EaseIntoViewProps> = ({
     }, 1000 / animationFramesPerSecond);
   }, [delayFrames, scrollStart, scrollEnd, doEase, frames]);
 
-  // This works only if the (appropriate) children have the 'showing' class.
-  // This is necessary because sometimes hidden elements are passed in as
-  // children, and we don't want to accidentally make those focusable. View
-  // instrumentGrid/index.tsx for the (only) example of this component in use.
+  // View instrumentGrid/index.tsx for an example of this component in use.
   const handleKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
     const container = containerRef.current;
+    const firstFocusable = focusableChildren.find(child => child);
     if (!container) return;
 
     switch (event.key) {
@@ -133,7 +131,7 @@ const EaseIntoView: React.FunctionComponent<EaseIntoViewProps> = ({
         event.preventDefault();
         // Make children that should be showing focusable and focus the first child.
         focusableChildren.forEach(ref => ref?.setAttribute('tabindex', '0'));
-        focusableChildren[0]?.focus();
+        firstFocusable?.focus();
         break;
 
       case 'Tab':

--- a/apps/src/music/views/util/EaseIntoView.tsx
+++ b/apps/src/music/views/util/EaseIntoView.tsx
@@ -123,8 +123,8 @@ const EaseIntoView: React.FunctionComponent<EaseIntoViewProps> = ({
   // View instrumentGrid/index.tsx for an example of this component in use.
   const handleKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
     const container = containerRef.current;
-    const firstFocusable = focusableChildren.find(child => child);
     if (!container) return;
+    const firstFocusable = focusableChildren.find(child => child);
 
     switch (event.key) {
       case 'Enter':


### PR DESCRIPTION
@breville caught that pressing enter to focus didn't work on songs where the first row of notes is hidden. This updates the code to focus on the first showing child instead of index zero. I also updated the comment as we are no longer querying 'showing' children (which is why the bug showed up [during my refactor](https://github.com/code-dot-org/code-dot-org/pull/68593)- we are no longer querying the dom here). 


https://github.com/user-attachments/assets/8d95343d-205c-4ae1-ac7f-41a5475ff04d



## Links

- Jira: https://codedotorg.atlassian.net/browse/SL-1452

## Testing story
<!--  Does your change include appropriate tests?
      - If so, please describe how the tests included in this PR are sufficient.
      - If not, please explain why this change does not need to be tested. -->



## Deployment strategy
<!--  Any special steps required to deploy this, besides merging?
      - Are there database migrations or manual steps?
      - Does this require coordination with other teams or systems? -->



## Follow-up work
<!--  List any clean-up or technical debt that will be addressed in future work.
      - Include Jira links where applicable.
      - Are there any known limitations or improvements planned? -->



## Privacy
<!--  How does this change impact Student & Teacher privacy?
      - Does this collect, use, share, or modify PII, either new or existing? -->



## Security
<!--  How does this change impact our security surface-area?
      - Do API's touched have the right auth?
      - Do infra changes impact our attack surface or encryption?
-->



## Caching
<!--  How does this change impact caching behavior?
      - Are cache keys or invalidation strategies affected?
      - Will this require cache warming or invalidation after deployment? -->



## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
