### PR TITLE
feat(accessibility): add alt text to expandable images

### DIFF
--- a/apps/package.json
+++ b/apps/package.json
@@ -212,7 +212,7 @@
     "@code-dot-org/p5.play": "1.3.21-cdo",
     "@code-dot-org/piskel": "0.13.0-cdo.13",
     "@code-dot-org/redactable-markdown": "^0.10.0",
-    "@code-dot-org/remark-plugins": "^2.0.0",
+    "@code-dot-org/remark-plugins": "^2.0.1",
     "@codemirror/autocomplete": "^6.18.6",
     "@codemirror/commands": "^6.8.0",
     "@codemirror/lang-css": "^6.3.1",

--- a/apps/src/redux/instructionsDialog.js
+++ b/apps/src/redux/instructionsDialog.js
@@ -15,6 +15,7 @@ export default function reducer(state = initialState, action) {
       open: true,
       imgOnly: action.imgOnly,
       imgUrl: action.imgUrl,
+      imgAlt: action.imgAlt,
     };
   }
 
@@ -29,10 +30,11 @@ export default function reducer(state = initialState, action) {
   return state;
 }
 
-export const openDialog = ({imgOnly, imgUrl}) => ({
+export const openDialog = ({imgOnly, imgUrl, imgAlt}) => ({
   type: OPEN_DIALOG,
   imgOnly,
   imgUrl,
+  imgAlt,
 });
 
 export const closeDialog = () => ({type: CLOSE_DIALOG});

--- a/apps/src/templates/EnhancedSafeMarkdown.jsx
+++ b/apps/src/templates/EnhancedSafeMarkdown.jsx
@@ -39,11 +39,12 @@ export class UnconnectedExpandableImagesWrapper extends React.Component {
 }
 
 export const ExpandableImagesWrapper = connect(null, dispatch => ({
-  showImageDialog(imgUrl) {
+  showImageDialog(imgUrl, imgAlt) {
     dispatch(
       openDialog({
         imgOnly: true,
         imgUrl,
+        imgAlt,
       })
     );
   },

--- a/apps/src/templates/instructions/AniGifPreview.jsx
+++ b/apps/src/templates/instructions/AniGifPreview.jsx
@@ -13,23 +13,33 @@ class ImagePreviewUnwrapped extends React.Component {
     noVisualization: PropTypes.bool.isRequired,
   };
 
+  static defaultProps = {
+    alt: '',
+  };
+
   handleKeyDown = e => {
     if (e.key === 'Enter' || e.key === ' ') {
-      e.preventDefault();
+      if (e.key === ' ') {
+        e.preventDefault();
+      }
       this.props.showInstructionsDialog();
     }
   };
 
   render() {
     const {url, alt, showInstructionsDialog, noVisualization} = this.props;
+    let ariaLabel = 'Click or press Enter to view larger image';
+    if (alt) {
+      ariaLabel = `${ariaLabel}. ${alt}`;
+    }
+
     return (
       <div id="ani-gif-preview-wrapper" style={styles.wrapper}>
         <div
           id="ani-gif-preview"
           role="button"
           tabIndex={0}
-          aria-label={alt || undefined}
-          aria-hidden={alt ? undefined : 'true'}
+          aria-label={ariaLabel}
           style={[
             styles.aniGifPreview(url),
             noVisualization && styles.bigPreview,

--- a/apps/src/templates/instructions/AniGifPreview.jsx
+++ b/apps/src/templates/instructions/AniGifPreview.jsx
@@ -8,20 +8,34 @@ import {openDialog} from '../../redux/instructionsDialog';
 class ImagePreviewUnwrapped extends React.Component {
   static propTypes = {
     url: PropTypes.string.isRequired,
+    alt: PropTypes.string,
     showInstructionsDialog: PropTypes.func.isRequired,
     noVisualization: PropTypes.bool.isRequired,
   };
 
+  handleKeyDown = e => {
+    if (e.key === 'Enter' || e.key === ' ' || e.key === 'Space') {
+      e.preventDefault();
+      this.props.showInstructionsDialog();
+    }
+  };
+
   render() {
+    const {url, alt, showInstructionsDialog, noVisualization} = this.props;
     return (
       <div id="ani-gif-preview-wrapper" style={styles.wrapper}>
         <div
           id="ani-gif-preview"
+          role="button"
+          tabIndex={0}
+          aria-label={alt || undefined}
+          aria-hidden={alt ? undefined : 'true'}
           style={[
-            styles.aniGifPreview(this.props.url),
-            this.props.noVisualization && styles.bigPreview,
+            styles.aniGifPreview(url),
+            noVisualization && styles.bigPreview,
           ]}
-          onClick={this.props.showInstructionsDialog}
+          onClick={showInstructionsDialog}
+          onKeyDown={this.handleKeyDown}
         />
       </div>
     );

--- a/apps/src/templates/instructions/AniGifPreview.jsx
+++ b/apps/src/templates/instructions/AniGifPreview.jsx
@@ -14,7 +14,7 @@ class ImagePreviewUnwrapped extends React.Component {
   };
 
   handleKeyDown = e => {
-    if (e.key === 'Enter' || e.key === ' ' || e.key === 'Space') {
+    if (e.key === 'Enter' || e.key === ' ') {
       e.preventDefault();
       this.props.showInstructionsDialog();
     }

--- a/apps/src/templates/instructions/ExampleImage.jsx
+++ b/apps/src/templates/instructions/ExampleImage.jsx
@@ -3,14 +3,15 @@ import React from 'react';
 
 import color from '@cdo/apps/util/color';
 
-export default function ExampleImage({src}) {
+export default function ExampleImage({src, alt}) {
   // TODO: A11y279 (https://codedotorg.atlassian.net/browse/A11Y-279)
   // Verify or update this alt-text as necessary
-  return <img style={styles.img} src={src} alt="" />;
+  return <img style={styles.img} src={src} alt={alt ?? ''} />;
 }
 
 ExampleImage.propTypes = {
   src: PropTypes.string.isRequired,
+  alt: PropTypes.string,
 };
 
 const styles = {

--- a/apps/src/templates/instructions/Instructions.jsx
+++ b/apps/src/templates/instructions/Instructions.jsx
@@ -19,6 +19,7 @@ export default class Instructions extends React.Component {
   static propTypes = {
     instructions: PropTypes.string,
     imgURL: PropTypes.string,
+    imgAlt: PropTypes.string,
     authoredHints: PropTypes.element,
     inputOutputTable: PropTypes.arrayOf(PropTypes.arrayOf(PropTypes.number)),
     inTopPane: PropTypes.bool,
@@ -43,6 +44,7 @@ export default class Instructions extends React.Component {
       noInstructionsWhenCollapsed,
       inputOutputTable,
       imgURL,
+      imgAlt,
       authoredHints,
     } = this.props;
 
@@ -66,7 +68,7 @@ export default class Instructions extends React.Component {
           </>
         )}
         {inputOutputTable && <InputOutputTable data={inputOutputTable} />}
-        {imgURL && !inTopPane && <ExampleImage src={imgURL} />}
+        {imgURL && !inTopPane && <ExampleImage src={imgURL} alt={imgAlt} />}
         {imgURL && inTopPane && <AniGifPreview />}
         {authoredHints}
       </div>

--- a/apps/src/templates/instructions/Instructions.jsx
+++ b/apps/src/templates/instructions/Instructions.jsx
@@ -69,7 +69,7 @@ export default class Instructions extends React.Component {
         )}
         {inputOutputTable && <InputOutputTable data={inputOutputTable} />}
         {imgURL && !inTopPane && <ExampleImage src={imgURL} alt={imgAlt} />}
-        {imgURL && inTopPane && <AniGifPreview />}
+        {imgURL && inTopPane && <AniGifPreview alt={imgAlt} />}
         {authoredHints}
       </div>
     );

--- a/apps/src/templates/instructions/InstructionsDialog.jsx
+++ b/apps/src/templates/instructions/InstructionsDialog.jsx
@@ -15,7 +15,7 @@ export function InstructionsDialog(props) {
     if (props.imgOnly && props.imgUrl) {
       return (
         <div style={styles.imgContainer}>
-          <ExampleImage src={props.imgUrl} />
+          <ExampleImage src={props.imgUrl} alt={props.imgAlt} />
         </div>
       );
     }
@@ -24,6 +24,7 @@ export function InstructionsDialog(props) {
       <Instructions
         instructions={props.instructions}
         imgURL={props.imgUrl}
+        imgAlt={props.imgAlt}
         isBlockly={props.isBlockly}
         inTopPane={false}
       />
@@ -55,6 +56,7 @@ InstructionsDialog.propTypes = {
   isOpen: PropTypes.bool,
   imgOnly: PropTypes.bool,
   imgUrl: PropTypes.string,
+  imgAlt: PropTypes.string,
   instructions: PropTypes.string,
   isBlockly: PropTypes.bool,
   handleClose: PropTypes.func.isRequired,
@@ -65,6 +67,7 @@ export default connect(
     isOpen: state.instructionsDialog.open,
     imgOnly: state.instructionsDialog.imgOnly,
     imgUrl: state.instructionsDialog.imgUrl || state.pageConstants.aniGifURL,
+    imgAlt: state.instructionsDialog.imgAlt,
     instructions:
       state.instructions.longInstructions ||
       state.instructions.shortInstructions,

--- a/apps/src/templates/utils/expandableImages.js
+++ b/apps/src/templates/utils/expandableImages.js
@@ -36,9 +36,10 @@ export function renderExpandableImages(node, showImageDialog) {
     ReactDOM.render(
       <ImagePreview
         url={expandableImg.dataset.url}
+        alt={expandableImg.dataset.alt}
         noVisualization={false}
         showInstructionsDialog={() =>
-          showImageDialog(expandableImg.dataset.url)
+          showImageDialog(expandableImg.dataset.url, expandableImg.dataset.alt)
         }
       />,
       expandableImg

--- a/apps/src/templates/utils/expandableImages.js
+++ b/apps/src/templates/utils/expandableImages.js
@@ -36,10 +36,10 @@ export function renderExpandableImages(node, showImageDialog) {
     ReactDOM.render(
       <ImagePreview
         url={expandableImg.dataset.url}
-        alt={expandableImg.dataset.alt}
+        alt={expandableImg.textContent}
         noVisualization={false}
         showInstructionsDialog={() =>
-          showImageDialog(expandableImg.dataset.url, expandableImg.dataset.alt)
+          showImageDialog(expandableImg.dataset.url, expandableImg.textContent)
         }
       />,
       expandableImg

--- a/apps/test/unit/templates/instructions/AniGifPreviewTest.jsx
+++ b/apps/test/unit/templates/instructions/AniGifPreviewTest.jsx
@@ -6,6 +6,71 @@ import {ImagePreview} from '@cdo/apps/templates/instructions/AniGifPreview';
 import {expect} from '../../../util/deprecatedChai'; // eslint-disable-line no-restricted-imports
 
 describe('ImagePreview', () => {
+  it('contains aria-label when alt prop is present', () => {
+    const onClickCallback = () => {};
+    const wrapper = shallow(
+      <ImagePreview
+        url="example.gif"
+        alt="this is alt text"
+        showInstructionsDialog={onClickCallback}
+        noVisualization={false}
+      />
+    );
+    expect(wrapper).to.containMatchingElement(
+      <div
+        id="ani-gif-preview-wrapper"
+        style={{
+          display: 'inline-block',
+          position: 'relative',
+        }}
+      >
+        <div
+          id="ani-gif-preview"
+          onClick={onClickCallback}
+          style={{
+            cursor: 'pointer',
+            backgroundImage: "url('example.gif')",
+          }}
+          role="button"
+          tabIndex={0}
+          aria-label="this is alt text"
+        />
+      </div>
+    );
+  });
+
+  it('contains aria-hidden when alt prop is not present', () => {
+    const onClickCallback = () => {};
+    const wrapper = shallow(
+      <ImagePreview
+        url="example.gif"
+        showInstructionsDialog={onClickCallback}
+        noVisualization={false}
+      />
+    );
+    expect(wrapper).to.containMatchingElement(
+      <div
+        id="ani-gif-preview-wrapper"
+        style={{
+          display: 'inline-block',
+          position: 'relative',
+        }}
+      >
+        <div
+          id="ani-gif-preview"
+          onClick={onClickCallback}
+          style={{
+            cursor: 'pointer',
+            backgroundImage: "url('example.gif')",
+          }}
+          role="button"
+          tabIndex={0}
+          aria-hidden="true"
+        />
+      </div>
+    );
+  });
+
   it('renders normal size if noVisualization is false', () => {
     const onClickCallback = () => {};
     const wrapper = shallow(

--- a/apps/test/unit/templates/instructions/AniGifPreviewTest.jsx
+++ b/apps/test/unit/templates/instructions/AniGifPreviewTest.jsx
@@ -6,12 +6,12 @@ import {ImagePreview} from '@cdo/apps/templates/instructions/AniGifPreview';
 import {expect} from '../../../util/deprecatedChai'; // eslint-disable-line no-restricted-imports
 
 describe('ImagePreview', () => {
-  it('contains aria-label when alt prop is present', () => {
+  it('contains aria-label with click instructions when alt prop is present', () => {
     const onClickCallback = () => {};
     const wrapper = shallow(
       <ImagePreview
         url="example.gif"
-        alt="this is alt text"
+        alt="This is alt text"
         showInstructionsDialog={onClickCallback}
         noVisualization={false}
       />
@@ -33,13 +33,13 @@ describe('ImagePreview', () => {
           }}
           role="button"
           tabIndex={0}
-          aria-label="this is alt text"
+          aria-label="Click or press Enter to view larger image. This is alt text"
         />
       </div>
     );
   });
 
-  it('contains aria-hidden when alt prop is not present', () => {
+  it('contains aria-label with click instructions only when alt prop is not present', () => {
     const onClickCallback = () => {};
     const wrapper = shallow(
       <ImagePreview
@@ -65,7 +65,7 @@ describe('ImagePreview', () => {
           }}
           role="button"
           tabIndex={0}
-          aria-hidden="true"
+          aria-label="Click or press Enter to view larger image"
         />
       </div>
     );

--- a/apps/test/unit/templates/utils/expandableImagesTest.js
+++ b/apps/test/unit/templates/utils/expandableImagesTest.js
@@ -18,7 +18,7 @@ describe('expandableImages', () => {
       const result = document.createElement('span');
       result.classList.add('expandable-image');
       result.dataset['url'] = url;
-      result.dataset['alt'] = alt;
+      result.textContent = alt;
       return result;
     };
 

--- a/apps/test/unit/templates/utils/expandableImagesTest.js
+++ b/apps/test/unit/templates/utils/expandableImagesTest.js
@@ -14,16 +14,20 @@ describe('expandableImages', () => {
       renderSpy.mockRestore();
     });
 
-    const createExpandableImage = url => {
+    const createExpandableImage = (url, alt) => {
       const result = document.createElement('span');
       result.classList.add('expandable-image');
       result.dataset['url'] = url;
+      result.dataset['alt'] = alt;
       return result;
     };
 
     it('creates an ImagePreview when it finds an expandable image', () => {
       const containerNode = document.createElement('div');
-      const image = createExpandableImage('https://example.com/img.jpg');
+      const image = createExpandableImage(
+        'https://example.com/img.jpg',
+        'This is alt text'
+      );
       containerNode.appendChild(image);
 
       renderExpandableImages(containerNode);
@@ -32,6 +36,7 @@ describe('expandableImages', () => {
 
       const renderElement = renderSpy.mock.calls[0][0];
       expect(renderElement.props.url).toBe('https://example.com/img.jpg');
+      expect(renderElement.props.alt).toBe('This is alt text');
 
       const renderContainer = renderSpy.mock.calls[0][1];
       expect(renderContainer).toBe(image);

--- a/apps/yarn.lock
+++ b/apps/yarn.lock
@@ -4059,10 +4059,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@code-dot-org/remark-plugins@npm:2.0.0, @code-dot-org/remark-plugins@npm:^2.0.0":
+"@code-dot-org/remark-plugins@npm:2.0.0":
   version: 2.0.0
   resolution: "@code-dot-org/remark-plugins@npm:2.0.0"
   checksum: 10/551b440b6567cd653ae5994d31dcaf2f3cd5f7ba59044758006b4a12c215dd06c2f768ce9517cf522093eebb19accad1839d468ad89fc303dbb6cb33678e6c6c
+  languageName: node
+  linkType: hard
+
+"@code-dot-org/remark-plugins@npm:^2.0.1":
+  version: 2.0.1
+  resolution: "@code-dot-org/remark-plugins@npm:2.0.1"
+  checksum: 10/9d80760ede352c83f50e2a7f74bbbff855dc2d29cc4e4dfd822d661721095983636308314042fcf1f9c0aebae1b536ff8bf0e81c0aa2fa91ebd6fd12a66e8e09
   languageName: node
   linkType: hard
 
@@ -11052,7 +11059,7 @@ __metadata:
     "@code-dot-org/p5.play": "npm:1.3.21-cdo"
     "@code-dot-org/piskel": "npm:0.13.0-cdo.13"
     "@code-dot-org/redactable-markdown": "npm:^0.10.0"
-    "@code-dot-org/remark-plugins": "npm:^2.0.0"
+    "@code-dot-org/remark-plugins": "npm:^2.0.1"
     "@codemirror/autocomplete": "npm:^6.18.6"
     "@codemirror/commands": "npm:^6.8.0"
     "@codemirror/lang-css": "npm:^6.3.1"


### PR DESCRIPTION
This pull request adds support for passing and displaying `alt` text for instructional images throughout the instructions dialog and related components, improving accessibility. The changes ensure that alternative text is properly handled in Redux state, React props, and rendered elements, and that accessibility attributes are set appropriately. Unit tests are also updated and added to verify these behaviors.

**Accessibility and alt text support:**

* Added `imgAlt` (alt text) support to Redux state, actions, and reducers for the instructions dialog (`instructionsDialog.js`). 
* Updated `Instructions`, `ExampleImage`, `AniGifPreview`, and `InstructionsDialog` components to accept and propagate `alt` text for images, ensuring it is rendered in the correct places (`Instructions.jsx`, `ExampleImage.jsx`, `AniGifPreview.jsx`, `InstructionsDialog.jsx`).
* Updated logic for expandable images to pass `alt` text through the rendering pipeline (`expandableImages.js`, `EnhancedSafeMarkdown.jsx`).

**Accessibility attributes and keyboard interaction:**

* Modified `AniGifPreview` to set `aria-label` default instructions to get a larger image along with `alt` text if provided, and to support keyboard activation for improved accessibility (`AniGifPreview.jsx`).

**Testing and verification:**

* Added and updated unit tests to verify correct handling of `alt` text and `aria-label`, as well as the passing of `alt` text through expandable images (`AniGifPreviewTest.jsx`, `expandableImagesTest.js`).

<img width="1177" height="814" alt="Screenshot 2025-10-17 at 1 30 32 PM" src="https://github.com/user-attachments/assets/10655f30-379a-40ce-86f0-4e045efe4574" />

<img width="1359" height="886" alt="Screenshot 2025-10-17 at 1 30 58 PM" src="https://github.com/user-attachments/assets/d379b976-f056-4294-b6f1-6794c39dd312" />

https://github.com/user-attachments/assets/b1de768b-e352-41fb-ab2c-50d9fa8a881b


## Links
<!--  Links to relevant external resources.
      - spec docs, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- Jira: https://codedotorg.atlassian.net/browse/LP-2838
- companion pr: remark repo https://github.com/code-dot-org/remark-plugins/pull/52

## Testing story
<!--  Does your change include appropriate tests?
      - If so, please describe how the tests included in this PR are sufficient.
      - If not, please explain why this change does not need to be tested. -->



## Deployment strategy
<!--  Any special steps required to deploy this, besides merging?
      - Are there database migrations or manual steps?
      - Does this require coordination with other teams or systems? -->



## Follow-up work
<!--  List any clean-up or technical debt that will be addressed in future work.
      - Include Jira links where applicable.
      - Are there any known limitations or improvements planned? -->



## Privacy
<!--  How does this change impact Student & Teacher privacy?
      - Does this collect, use, share, or modify PII, either new or existing? -->



## Security
<!--  How does this change impact our security surface-area?
      - Do API's touched have the right auth?
      - Do infra changes impact our attack surface or encryption?
-->



## Caching
<!--  How does this change impact caching behavior?
      - Are cache keys or invalidation strategies affected?
      - Will this require cache warming or invalidation after deployment? -->



## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
