### PR TITLE
AI Tutor - Only render assistant messages as markdown

### DIFF
--- a/apps/src/aiComponentLibrary/chatMessage/ChatMessage.tsx
+++ b/apps/src/aiComponentLibrary/chatMessage/ChatMessage.tsx
@@ -89,7 +89,7 @@ const ChatMessage: React.FunctionComponent<ChatMessageProps> = ({
                 openExternalLinksInNewTab
               />
             ) : (
-              text
+              <p>{text}</p>
             )}
           </div>
         </div>

--- a/apps/src/aiComponentLibrary/chatMessage/ChatMessage.tsx
+++ b/apps/src/aiComponentLibrary/chatMessage/ChatMessage.tsx
@@ -82,11 +82,15 @@ const ChatMessage: React.FunctionComponent<ChatMessageProps> = ({
                 : commonI18n.aiChatMessageUser()
             }
           >
-            <SafeMarkdown
-              markdown={text}
-              rehypeMap={rehypeMap}
-              openExternalLinksInNewTab
-            />
+            {role === Role.ASSISTANT ? (
+              <SafeMarkdown
+                markdown={text}
+                rehypeMap={rehypeMap}
+                openExternalLinksInNewTab
+              />
+            ) : (
+              text
+            )}
           </div>
         </div>
         <div


### PR DESCRIPTION
This PR changes the previous AI Chat / Tutor `ChatMessage` functionality where all chat messages were rendered as markdown.  The new behavior limits this to tutor (assistant) messages.

This fixes a bug reported by @dmcavoy where HTML tags like `<script>` that are added to a user message, are removed before being displayed in the chat history:

https://github.com/user-attachments/assets/c0b0c055-89d8-41bc-9c92-5f6556551514


## Links
This was reported and discussed in this[ slack thread](https://codedotorg.slack.com/archives/C08S29NDZ5E/p1760624499010939).

The Jira ticket is [here](https://codedotorg.atlassian.net/browse/LABS-1646?atlOrigin=eyJpIjoiM2RmMDk0MDZmMTA1NGFhYTk3OWQ3YjgwOTNlNTFkODMiLCJwIjoiamlyYS1zbGFjay1pbnQifQ).

## PR Creation Checklist:
- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
