### PR TITLE
fix drone [test all] tag to run all unit tests

### DIFF
--- a/lib/rake/test.rake
+++ b/lib/rake/test.rake
@@ -222,6 +222,15 @@ namespace :test do
     ENV.delete 'USE_PEGASUS_UNITTEST_DB'
   end
 
+  timed_task_with_logging :dashboard_cdo_contentful_engine_ci do
+    # isolate unit tests from the pegasus_test DB
+    ENV['USE_PEGASUS_UNITTEST_DB'] = '1'
+    ENV['TEST_ENV_NUMBER'] = '1'
+    TestRunUtils.run_dashboard_cdo_contentful_engine_tests
+    ENV.delete 'TEST_ENV_NUMBER'
+    ENV.delete 'USE_PEGASUS_UNITTEST_DB'
+  end
+
   timed_task_with_logging :shared_ci do
     # isolate unit tests from the pegasus_test DB
     ENV['USE_PEGASUS_UNITTEST_DB'] = '1'
@@ -264,6 +273,7 @@ namespace :test do
     :dashboard_ci,
     :dashboard_legacy_ci,
     :dashboard_hoc_legacy_engine_ci,
+    :dashboard_cdo_contentful_engine_ci,
     :lib_ci,
     :bin_ci,
     :ui_live
@@ -277,6 +287,16 @@ namespace :test do
   desc 'Runs dashboard legacy tests.'
   timed_task_with_logging :dashboard_legacy do
     TestRunUtils.run_dashboard_legacy_tests
+  end
+
+  desc 'Runs dashboard cdo_contentful engine tests.'
+  timed_task_with_logging :dashboard_cdo_contentful_engine do
+    TestRunUtils.run_dashboard_cdo_contentful_engine_tests
+  end
+
+  desc 'Runs dashboard hoc_legacy engine tests.'
+  timed_task_with_logging :dashboard_hoc_legacy_engine do
+    TestRunUtils.run_dashboard_hoc_legacy_engine_tests
   end
 
   desc 'Runs pegasus tests.'


### PR DESCRIPTION
today, drone fails when you give the `[test all]` tag in the commit message because of the missing `dashboard_cdo_contentful_engine` rake target:
```
RAILS_ENV=test RACK_ENV=test bundle exec rake test:all
--
rake aborted!
Don't know how to build task 'dashboard_cdo_contentful_engine' (See the list of available tasks with `rake --tasks`)
/home/ci/.rbenv/versions/3.1.0/bin/bundle:25:in `load'
/home/ci/.rbenv/versions/3.1.0/bin/bundle:25:in `<main>'
Tasks: TOP => test:all
(See full trace by running task with --trace)
rake aborted!
'RAILS_ENV=test RACK_ENV=test bundle exec rake test:all' returned 1
/drone/src/lib/cdo/rake_utils.rb:89:in `system_stream_output'
/drone/src/lib/cdo/rake_utils.rb:68:in `rake_stream_output'
/drone/src/lib/rake/ci.rake:79:in `block (2 levels) in <top (required)>'
```

This is because the following are not defined as top-level tasks in test.rake: https://github.com/code-dot-org/code-dot-org/blob/60ce618b269cc5ab3934e70c4596490e0b9e782e/lib/rake/test.rake#L509-L510

The references to the undefined tasks were added in 
* https://github.com/code-dot-org/code-dot-org/pull/67655

This PR adds the missing rake tasks.

## Testing story

see drone results showing that the issue is fixed

