### PR TITLE
Add Workshop Detail Change (for Regional Partners) email to MailJet

### DIFF
--- a/dashboard/app/controllers/api/v1/pd/workshops_controller.rb
+++ b/dashboard/app/controllers/api/v1/pd/workshops_controller.rb
@@ -300,6 +300,7 @@ class Api::V1::Pd::WorkshopsController < ApplicationController
       Pd::WorkshopMailer.facilitator_detail_change_notification(facilitator, @workshop).deliver_now
     end
     Pd::WorkshopMailer.organizer_detail_change_notification(@workshop).deliver_now
+    Pd::WorkshopMailjetMailer.send_rp_workshop_detail_change_notification(@workshop, general_detail_changes, sessions_have_changed, pre_update_session_info, post_update_session_info)
   end
 
   private def adjust_facilitators

--- a/dashboard/app/mailers/pd/workshop_mailjet_mailer.rb
+++ b/dashboard/app/mailers/pd/workshop_mailjet_mailer.rb
@@ -22,7 +22,7 @@ class Pd::WorkshopMailjetMailer
   def self.send_teacher_workshop_detail_change_notification(enrollment, user, use_alternate_email, general_detail_changes, sessions_have_changed, pre_update_session_info, post_update_session_info)
     email = use_alternate_email ? user.alternate_email : user.email
     name = user.given_name || user.name
-    email_vars = build_workshop_detail_change_email_vars(workshop, name, email, general_detail_changes, sessions_have_changed, pre_update_session_info, post_update_session_info, enrollment)
+    email_vars = build_workshop_detail_change_email_vars(enrollment.workshop, name, email, general_detail_changes, sessions_have_changed, pre_update_session_info, post_update_session_info, enrollment)
 
     retryable_send_email('teacher_workshop_detail_change_notification', email, user.friendly_name, email_vars)
   end

--- a/dashboard/app/mailers/pd/workshop_mailjet_mailer.rb
+++ b/dashboard/app/mailers/pd/workshop_mailjet_mailer.rb
@@ -20,27 +20,20 @@ class Pd::WorkshopMailjetMailer
   end
 
   def self.send_teacher_workshop_detail_change_notification(enrollment, user, use_alternate_email, general_detail_changes, sessions_have_changed, pre_update_session_info, post_update_session_info)
-    workshop = enrollment.workshop
-    organizer = workshop.organizer
-    regional_partner = workshop.regional_partner
     email = use_alternate_email ? user.alternate_email : user.email
-    email_vars = {
-      email_to: email,
-      name: user.given_name || user.name,
-      workshop_name: workshop_name_with_fallback(workshop),
-      cancel_registration_link: CDO.studio_url("pd/workshop_enrollment/#{enrollment.code}/cancel", CDO.default_scheme),
-      facilitator_name: workshop_facilitator_names(workshop),
-      rp_email: contact_email_with_fallback(regional_partner&.contact_email_with_backup),
-      rp_name: contact_name_with_fallback(regional_partner&.name),
-      organizer_email: contact_email_with_fallback(organizer&.email),
-      organizer_name: contact_name_with_fallback(organizer&.name),
-      detail_changes: general_detail_changes,
-      sessions_have_changed: sessions_have_changed,
-      pre_update_session_info: pre_update_session_info,
-      post_update_session_info: post_update_session_info
-    }
+    name = user.given_name || user.name
+    email_vars = build_workshop_detail_change_email_vars(workshop, name, email, general_detail_changes, sessions_have_changed, pre_update_session_info, post_update_session_info, enrollment)
 
     retryable_send_email('teacher_workshop_detail_change_notification', email, user.friendly_name, email_vars)
+  end
+
+  def self.send_rp_workshop_detail_change_notification(workshop, general_detail_changes, sessions_have_changed, pre_update_session_info, post_update_session_info)
+    rp = workshop.regional_partner
+    rp_email = contact_email_with_fallback(rp&.contact_email_with_backup)
+    rp_name = contact_name_with_fallback(rp&.name)
+    email_vars = build_workshop_detail_change_email_vars(workshop, rp_name, rp_email, general_detail_changes, sessions_have_changed, pre_update_session_info, post_update_session_info)
+
+    retryable_send_email('regional_partner_workshop_detail_change_notification', rp_email, rp_name, email_vars)
   end
 
   def self.send_teacher_post_workshop_survey(enrollment, user, use_alternate_email)
@@ -126,6 +119,27 @@ class Pd::WorkshopMailjetMailer
       workshop_subjects: workshop.course_offerings.present? ? workshop.course_offerings.map(&:display_name)&.join(', ') : workshop.subject,
       workshop_name: workshop_name_with_fallback(workshop),
       num_days: days
+    }
+  end
+
+  private_class_method def self.build_workshop_detail_change_email_vars(workshop, name, email, general_detail_changes, sessions_have_changed, pre_update_session_info, post_update_session_info, enrollment = nil)
+    organizer = workshop.organizer
+    regional_partner = workshop.regional_partner
+
+    {
+      email_to: email,
+      name: name,
+      workshop_name: workshop_name_with_fallback(workshop),
+      cancel_registration_link: enrollment&.code ? CDO.studio_url("pd/workshop_enrollment/#{enrollment.code}/cancel", CDO.default_scheme) : '',
+      facilitator_name: workshop_facilitator_names(workshop),
+      rp_email: contact_email_with_fallback(regional_partner&.contact_email_with_backup),
+      rp_name: contact_name_with_fallback(regional_partner&.name),
+      organizer_email: contact_email_with_fallback(organizer&.email),
+      organizer_name: contact_name_with_fallback(organizer&.name),
+      detail_changes: general_detail_changes,
+      sessions_have_changed: sessions_have_changed,
+      pre_update_session_info: pre_update_session_info,
+      post_update_session_info: post_update_session_info
     }
   end
 end

--- a/dashboard/test/controllers/api/v1/pd/workshops_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/pd/workshops_controller_test.rb
@@ -633,6 +633,13 @@ class Api::V1::Pd::WorkshopsControllerTest < ActionController::TestCase
       workshop.sessions.map(&:session_info_for_emails),
       expected_post_update_session_info
     ).times(5)
+    Pd::WorkshopMailjetMailer.expects(:send_rp_workshop_detail_change_notification).with(
+      workshop,
+      [{name: 'Description', old: 'A really cool workshop', new: workshop_params[:description]}],
+      true,
+      workshop.sessions.map(&:session_info_for_emails),
+      expected_post_update_session_info
+    )
 
     put :update, params: {
       id: workshop.id,
@@ -652,6 +659,7 @@ class Api::V1::Pd::WorkshopsControllerTest < ActionController::TestCase
     create(:pd_enrollment, application_id: application.id, user: teacher, workshop: workshop)
 
     Pd::WorkshopMailjetMailer.expects(:send_teacher_workshop_detail_change_notification).times(2)
+    Pd::WorkshopMailjetMailer.expects(:send_rp_workshop_detail_change_notification).times(1)
 
     params = workshop_params.merge(course: Pd::Workshop::COURSE_CSA, subject: Pd::Workshop::SUBJECT_SUMMER_WORKSHOP, virtual: true, funding_type: nil)
 
@@ -670,6 +678,7 @@ class Api::V1::Pd::WorkshopsControllerTest < ActionController::TestCase
       create(:pd_enrollment, workshop: @workshop)
     end
     Pd::WorkshopMailjetMailer.expects(:send_teacher_workshop_detail_change_notification).never
+    Pd::WorkshopMailjetMailer.expects(:send_rp_workshop_detail_change_notification).never
 
     put :update, params: {
       id: @workshop.id,

--- a/lib/cdo/shared_constants/mailjet_constants.rb
+++ b/lib/cdo/shared_constants/mailjet_constants.rb
@@ -65,6 +65,15 @@ module MailjetConstants
       from_address: 'noreply@code.org',
       from_name: 'Code.org',
     },
+    regional_partner_workshop_detail_change_notification: {
+      template_id: {
+        production: {
+          default: 7_249_336,
+        }
+      },
+      from_address: 'noreply@code.org',
+      from_name: 'Code.org',
+    },
     teacher_post_workshop_survey: {
       template_id: {
         production: {


### PR DESCRIPTION
Sends Regional Partners a similar workshop detail-change email to the one sent to enrollees. Note: since regional partners don't have their own enrollment, the "Cancel registration" button is disabled with a note stating that participants will be able to use that button.

<img width="719" height="465" alt="1" src="https://github.com/user-attachments/assets/e00be80f-c391-411a-b4c2-d7a14e55b6ad" />

<img width="724" height="564" alt="2" src="https://github.com/user-attachments/assets/a401c78a-6780-4b65-9bcd-df4765c9331a" />

## Links
Jira: [here](https://codedotorg.atlassian.net/jira/software/projects/AITT/boards/70?jql=assignee%20%3D%2060d62161f65054006980bd71&selectedIssue=AITT-1256)
MailJet: [here](https://app.mailjet.com/template/13239979/build)

## Testing story
Local testing and adding unit tests.
