### PR TITLE
Add Auto Scaling Group Predictive Policy in Forecast-Only Mode

### DIFF
--- a/aws/cloudformation/components/ami.yml.erb
+++ b/aws/cloudformation/components/ami.yml.erb
@@ -261,6 +261,21 @@ frontend_device_name ||= '/dev/sda1'
                 Action: 'sns:Publish'
                 Resource: !Ref WebServerHookTopicNew
       PermissionsBoundary: !ImportValue IAM-DevPermissions
+  PredictiveScalingPolicy:
+    Type: AWS::AutoScaling::ScalingPolicy
+    Properties:
+      AutoScalingGroupName: !Ref Frontends
+      PolicyType: PredictiveScaling
+      PredictiveScalingConfiguration:
+        Mode: ForecastOnly # Generate forecasts, but don't actually scale the Auto Scaling Group.
+        MetricSpecifications:
+          - TargetValue: 50
+            PredefinedMetricPairSpecification:
+              PredefinedMetricType: ASGCPUUtilization
+        # Warm up new instance 5 minutes before Predictive Scaling forecasts that it will be needed.
+        SchedulingBufferTime: 300
+        MaxCapacityBreachBehavior: IncreaseMaxCapacity
+        MaxCapacityBuffer: 4  # Usage increases 2-3X  from 5AM to 6:30AM PT
 
   FrontendHighMemoryAlarm:
     Type: AWS::CloudWatch::Alarm


### PR DESCRIPTION
Our Auto Scaling Group "Scheduled actions" are cumbersome to maintain, and timezone errors are easy to make. They were implemented before Predictive Auto Scaling. Enable Predictive Scaling in "forecast-only" mode in advance of switching to Predicting Scaling and removing "Scheduled actions".

See discussion:
https://codedotorg.slack.com/archives/C03CK49G9/p1760996015288949

Scaling Policies have two goals that are inherently in tension with each other:

- proactively scale up in advance of increase in usage to improve performance and reliability
- save on costs by explicitly downscaling to a safe minimum during low-usage time periods

In parallel to this change, we're implementing a quick fix to the Scheduled actions in #68959


## Testing story

`bundle exec rake adhoc:full_stack:start RAILS_ENV=adhoc STACK_NAME=adhoc-predictive-scaling`

Correctly provisions a Predictive Policy in forecast-only mode while leaving the existing Dynamic Scaling (CPU) Policy in place:
<img width="1653" height="815" alt="image" src="https://github.com/user-attachments/assets/e4cd5af2-9b95-4354-b3f8-c2aa87ffbe77" />



## Deployment strategy
<!--  Any special steps required to deploy this, besides merging?
      - Are there database migrations or manual steps?
      - Does this require coordination with other teams or systems? -->



## Follow-up work
<!--  List any clean-up or technical debt that will be addressed in future work.
      - Include Jira links where applicable.
      - Are there any known limitations or improvements planned? -->



## Privacy
<!--  How does this change impact Student & Teacher privacy?
      - Does this collect, use, share, or modify PII, either new or existing? -->



## Security
<!--  How does this change impact our security surface-area?
      - Do API's touched have the right auth?
      - Do infra changes impact our attack surface or encryption?
-->



## Caching
<!--  How does this change impact caching behavior?
      - Are cache keys or invalidation strategies affected?
      - Will this require cache warming or invalidation after deployment? -->



## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
