### PR TITLE
Redis migration: re-add dummy placeholders defined in globals.yml

### DIFF
--- a/config.yml.erb
+++ b/config.yml.erb
@@ -530,6 +530,15 @@ discourse_sso_url:
 discourse_url:
 pledge_map_table_id:
 
+# SESSION_STORE_MIGRATION_DELETE_ME
+#
+# TODO: we no longer use these, but they are still being injected into globals.yml by chef.
+# To remove them, we need to figure out where chef is getting the values from.
+geocoder_read_replica_1:
+geocoder_read_replica_2:
+geocoder_redis_url:
+level_sources_redis_url:
+
 #### Parameters related to CloudFormation-stack deployment
 stack_name: <%=env%>
 cdn_enabled: <%=chef_managed%>


### PR DESCRIPTION
We ran into errors trying to apply the redis migration because chef is still trying to add these to globals.yml: geocoder_read_replica_1, geocoder_read_replica_2, geocoder_redis_url, level_sources_redis_url

Therefore they need to be present in config.yml.erb.

This PR restores these config variables with dummy/empty-string values.