### PR TITLE
Redis migration: re-add MORE dummy placeholders defined in globals.yml

### DIFF
--- a/config.yml.erb
+++ b/config.yml.erb
@@ -538,6 +538,9 @@ geocoder_read_replica_1:
 geocoder_read_replica_2:
 geocoder_redis_url:
 level_sources_redis_url:
+redis_primary:
+redis_read_addresses:
+redis_read_ports:
 
 #### Parameters related to CloudFormation-stack deployment
 stack_name: <%=env%>


### PR DESCRIPTION
Follow-on to https://github.com/code-dot-org/code-dot-org/pull/68970, this time:
```
redis_primary:
redis_read_addresses:
redis_read_ports:
```