### PR TITLE
Redis rollout: revert to `GeocoderSubnetGroup` for memcached

### DIFF
--- a/aws/cloudformation/components/memcached.yml.erb
+++ b/aws/cloudformation/components/memcached.yml.erb
@@ -1,8 +1,8 @@
 <% cache_node_type = rack_env?(:production) ? 'cache.r5.large' : 'cache.t2.micro' -%>
-  MemcachedSubnetGroup:
+  GeocoderSubnetGroup:
     Type: AWS::ElastiCache::SubnetGroup
     Properties:
-      Description: Memcached Subnet Group
+      Description: Geocoder Cache Subnet Group
       SubnetIds: <%= subnets.to_json %>
 
   MemcachedParameterGroup:
@@ -17,7 +17,7 @@
     Properties:
       CacheNodeType: <%= cache_node_type %>
       CacheParameterGroupName: !Ref MemcachedParameterGroup
-      CacheSubnetGroupName: !Ref MemcachedSubnetGroup
+      CacheSubnetGroupName: !Ref GeocoderSubnetGroup
       ClusterName: <%=stack_name[0..19]%> # Max 20 chars
       Engine: memcached
       EngineVersion: 1.4


### PR DESCRIPTION
When we tried to rollout https://github.com/code-dot-org/code-dot-org/pull/68629, we got cloudformation errors like:
```
The resource Memcached is in a UPDATE_FAILED state
This AWS::ElastiCache::CacheCluster resource is in a UPDATE_FAILED state.

CloudFormation cannot update a stack when a custom-named resource requires replacing. Rename autoscale-prod and update the stack again.
```

The only aspects of memcached changed were renaming the subnetgroup, previously it referred to `GeocoderSubnetGroup`, and since Geocoder was going away as a separate instance, we renamed the group for clarity.