### PR TITLE
chore(vcr-cassettes): prevent storing request headers

### DIFF
--- a/dashboard/engines/cdo_contentful/test/fixtures/vcr_cassettes/cs_for_all/entries/tutorials/poem_art.yml
+++ b/dashboard/engines/cdo_contentful/test/fixtures/vcr_cassettes/cs_for_all/entries/tutorials/poem_art.yml
@@ -6,21 +6,6 @@ http_interactions:
     body:
       encoding: UTF-8
       string: ''
-    headers:
-      X-Contentful-User-Agent:
-      - sdk contentful.rb/2.18.0; platform ruby/3.1.0; os macOS/24;
-      Authorization:
-      - Bearer dnVyQ99x_U7o8ZTUK-4tM-__EENnjBB_nJ7uWCCSL-Q
-      Content-Type:
-      - application/vnd.contentful.delivery.v1+json
-      Accept-Encoding:
-      - gzip
-      Connection:
-      - close
-      Host:
-      - preview.contentful.com
-      User-Agent:
-      - http.rb/5.2.0
   response:
     status:
       code: 200

--- a/dashboard/engines/cdo_contentful/test/fixtures/vcr_cassettes/marketing/entries/dashboard_notifications.yml
+++ b/dashboard/engines/cdo_contentful/test/fixtures/vcr_cassettes/marketing/entries/dashboard_notifications.yml
@@ -6,21 +6,6 @@ http_interactions:
     body:
       encoding: UTF-8
       string: ''
-    headers:
-      X-Contentful-User-Agent:
-      - sdk contentful.rb/2.18.0; platform ruby/3.1.0; os macOS/24;
-      Authorization:
-      - Bearer YaMMQinGe3DlLoegQDfpdIvcDUXOA8ATwwqC7ugje0o
-      Content-Type:
-      - application/vnd.contentful.delivery.v1+json
-      Accept-Encoding:
-      - gzip
-      Connection:
-      - close
-      Host:
-      - cdn.contentful.com
-      User-Agent:
-      - http.rb/5.2.0
   response:
     status:
       code: 200

--- a/dashboard/engines/cdo_contentful/test/fixtures/vcr_cassettes/marketing/entries/teacher_homepage_sidebars/55R4y1NlZ0qJG9O0qgyq0Q.yml
+++ b/dashboard/engines/cdo_contentful/test/fixtures/vcr_cassettes/marketing/entries/teacher_homepage_sidebars/55R4y1NlZ0qJG9O0qgyq0Q.yml
@@ -6,21 +6,6 @@ http_interactions:
     body:
       encoding: UTF-8
       string: ''
-    headers:
-      X-Contentful-User-Agent:
-      - sdk contentful.rb/2.18.0; platform ruby/3.1.0; os macOS/24;
-      Authorization:
-      - Bearer YaMMQinGe3DlLoegQDfpdIvcDUXOA8ATwwqC7ugje0o
-      Content-Type:
-      - application/vnd.contentful.delivery.v1+json
-      Accept-Encoding:
-      - gzip
-      Connection:
-      - close
-      Host:
-      - cdn.contentful.com
-      User-Agent:
-      - http.rb/5.2.0
   response:
     status:
       code: 200

--- a/dashboard/engines/cdo_contentful/test/test_helper.rb
+++ b/dashboard/engines/cdo_contentful/test/test_helper.rb
@@ -20,5 +20,12 @@ require 'vcr'
 VCR.configure do |config|
   config.cassette_library_dir = File.join(__dir__, 'fixtures', 'vcr_cassettes')
   config.hook_into :webmock
-  config.default_cassette_options = {record: :once}
+
+  config.default_cassette_options = {
+    record: :once,
+  }
+
+  config.before_record do |interaction|
+    interaction.request.headers = {}
+  end
 end

--- a/dashboard/engines/hoc_legacy/test/fixtures/vcr_cassettes/hoc_legacy/tutorial_api/basic_flow.yml
+++ b/dashboard/engines/hoc_legacy/test/fixtures/vcr_cassettes/hoc_legacy/tutorial_api/basic_flow.yml
@@ -6,21 +6,6 @@ http_interactions:
     body:
       encoding: UTF-8
       string: ''
-    headers:
-      X-Contentful-User-Agent:
-      - sdk contentful.rb/2.18.0; platform ruby/3.1.0; os macOS/24;
-      Authorization:
-      - Bearer dnVyQ99x_U7o8ZTUK-4tM-__EENnjBB_nJ7uWCCSL-Q
-      Content-Type:
-      - application/vnd.contentful.delivery.v1+json
-      Accept-Encoding:
-      - gzip
-      Connection:
-      - close
-      Host:
-      - preview.contentful.com
-      User-Agent:
-      - http.rb/5.2.0
   response:
     status:
       code: 200

--- a/dashboard/engines/hoc_legacy/test/fixtures/vcr_cassettes/hoc_legacy/tutorial_api/basic_flow_with_finish_current.yml
+++ b/dashboard/engines/hoc_legacy/test/fixtures/vcr_cassettes/hoc_legacy/tutorial_api/basic_flow_with_finish_current.yml
@@ -6,21 +6,6 @@ http_interactions:
     body:
       encoding: UTF-8
       string: ''
-    headers:
-      X-Contentful-User-Agent:
-      - sdk contentful.rb/2.18.0; platform ruby/3.1.0; os macOS/24;
-      Authorization:
-      - Bearer dnVyQ99x_U7o8ZTUK-4tM-__EENnjBB_nJ7uWCCSL-Q
-      Content-Type:
-      - application/vnd.contentful.delivery.v1+json
-      Accept-Encoding:
-      - gzip
-      Connection:
-      - close
-      Host:
-      - preview.contentful.com
-      User-Agent:
-      - http.rb/5.2.0
   response:
     status:
       code: 200

--- a/dashboard/engines/hoc_legacy/test/fixtures/vcr_cassettes/hoc_legacy/tutorial_api/basic_flow_without_activity_tracking.yml
+++ b/dashboard/engines/hoc_legacy/test/fixtures/vcr_cassettes/hoc_legacy/tutorial_api/basic_flow_without_activity_tracking.yml
@@ -6,21 +6,6 @@ http_interactions:
     body:
       encoding: UTF-8
       string: ''
-    headers:
-      X-Contentful-User-Agent:
-      - sdk contentful.rb/2.18.0; platform ruby/3.1.0; os macOS/24;
-      Authorization:
-      - Bearer dnVyQ99x_U7o8ZTUK-4tM-__EENnjBB_nJ7uWCCSL-Q
-      Content-Type:
-      - application/vnd.contentful.delivery.v1+json
-      Accept-Encoding:
-      - gzip
-      Connection:
-      - close
-      Host:
-      - preview.contentful.com
-      User-Agent:
-      - http.rb/5.2.0
   response:
     status:
       code: 200

--- a/dashboard/test/testing/vcr_cassettes.rb
+++ b/dashboard/test/testing/vcr_cassettes.rb
@@ -1,8 +1,16 @@
 require 'vcr'
 
 VCR.configure do |config|
-  config.cassette_library_dir = File.expand_path('../fixtures/vcr_cassettes', __dir__)
+  config.cassette_library_dir = Rails.root.join('test/fixtures/vcr_cassettes').to_s
   config.hook_into :webmock
-  config.default_cassette_options = {record: :once}
+  config.ignore_localhost = true
   config.allow_http_connections_when_no_cassette = true
+
+  config.default_cassette_options = {
+    record: :once,
+  }
+
+  config.before_record do |interaction|
+    interaction.request.headers = {}
+  end
 end


### PR DESCRIPTION
Usually, request headers contain sensitive information or secrets, so it's best to avoid storing them in VCR cassettes by default, as they rarely provide significant value for testing