### PR TITLE
upgrade drone autoscaler and enable reaping of workers

### DIFF
--- a/aws/cloudformation/drone-stack.yml
+++ b/aws/cloudformation/drone-stack.yml
@@ -45,7 +45,7 @@ Parameters:
     Type: AWS::SSM::Parameter::Value<AWS::EC2::Image::Id>
     Default: /aws/service/ecs/optimized-ami/amazon-linux/recommended/image_id
   AutoscalerECSAMI:
-    Description: AMI ID
+    Description: AMI ID for ECS Optimized AMI
     Type: AWS::SSM::Parameter::Value<AWS::EC2::Image::Id>
     Default: /aws/service/ecs/optimized-ami/amazon-linux-2/recommended/image_id
 Resources:
@@ -459,6 +459,20 @@ Resources:
       MinSize: 1
       MaxSize: 1
       DesiredCapacity: 1
+    UpdatePolicy:
+      AutoScalingRollingUpdate:
+        MinInstancesInService: 0
+        MaxBatchSize: 1
+        PauseTime: PT5M
+        WaitOnResourceSignals: false
+        SuspendProcesses:
+          - HealthCheck
+          - ReplaceUnhealthy
+          - AZRebalance
+          - AlarmNotification
+          - ScheduledActions
+      AutoScalingReplacingUpdate:
+        WillReplace: true
 
   DroneAutoscalerEcsSecurityGroup:
     Type: AWS::EC2::SecurityGroup

--- a/aws/cloudformation/drone-stack.yml
+++ b/aws/cloudformation/drone-stack.yml
@@ -304,7 +304,7 @@ Resources:
         -
           Name: drone-autoscaler
           Essential: true
-          Image: drone/autoscaler:1.8.2
+          Image: drone/autoscaler:1.13.0
           MemoryReservation: 1024
           LogConfiguration:
             LogDriver: awslogs
@@ -396,6 +396,15 @@ Resources:
               Name: DRONE_AGENT_CONCURRENCY
               Value: 1
             # END: Settings for the Drone Runner.
+
+            # BEGIN: Reaper configuration - cleans up error-state workers
+            -
+              Name: DRONE_REAPER_ENABLED
+              Value: "true"
+            -
+              Name: DRONE_REAPER_INTERVAL
+              Value: "1h"
+            # END: Reaper configuration
 
   DroneAutoscalerEcsService:
     Type: AWS::ECS::Service

--- a/aws/cloudformation/drone-stack.yml
+++ b/aws/cloudformation/drone-stack.yml
@@ -339,6 +339,8 @@ Resources:
             -
               Name: DRONE_SERVER_PROTO
               Value: https
+
+            # BEGIN: Autoscaler Service Configuration
             -
               Name: DRONE_POOL_MIN
               Value: !Ref WorkerPoolMinimum
@@ -352,11 +354,24 @@ Resources:
               Name: DRONE_CAPACITY_BUFFER
               Value: !Ref WorkerCapacityBuffer
             -
+              Name: DRONE_REAPER_ENABLED
+              Value: "true"
+            -
+              Name: DRONE_REAPER_INTERVAL
+              Value: "5m"
+            -
+              Name: DRONE_PINGER_ENABLED
+              Value: "true"
+            -
+              Name: DRONE_PINGER_INTERVAL
+              Value: "5m"
+            -
               Name: DRONE_DEBUG
               Value: true
             -
               Name: DRONE_TRACE
               Value: true
+            # END: Autoscaler Service Configuration
 
             # BEGIN: Settings for the EC2 Instances that Drone Autoscaler provisions.
 
@@ -396,24 +411,6 @@ Resources:
               Name: DRONE_AGENT_CONCURRENCY
               Value: 1
             # END: Settings for the Drone Runner.
-
-            # BEGIN: Reaper configuration - cleans up error-state workers
-            -
-              Name: DRONE_REAPER_ENABLED
-              Value: "true"
-            -
-              Name: DRONE_REAPER_INTERVAL
-              Value: "5m"
-            # END: Reaper configuration
-
-            # BEGIN: Pinger configuration - detects unhealthy workers
-            -
-              Name: DRONE_PINGER_ENABLED
-              Value: "true"
-            -
-              Name: DRONE_PINGER_INTERVAL
-              Value: "5m"
-            # END: Pinger configuration
 
   DroneAutoscalerEcsService:
     Type: AWS::ECS::Service

--- a/aws/cloudformation/drone-stack.yml
+++ b/aws/cloudformation/drone-stack.yml
@@ -403,8 +403,17 @@ Resources:
               Value: "true"
             -
               Name: DRONE_REAPER_INTERVAL
-              Value: "1h"
+              Value: "5m"
             # END: Reaper configuration
+
+            # BEGIN: Pinger configuration - detects unhealthy workers
+            -
+              Name: DRONE_PINGER_ENABLED
+              Value: "true"
+            -
+              Name: DRONE_PINGER_INTERVAL
+              Value: "5m"
+            # END: Pinger configuration
 
   DroneAutoscalerEcsService:
     Type: AWS::ECS::Service


### PR DESCRIPTION
## Background

We've been getting a lot of errored drone builds lately with messages like this:
<img width="664" height="64" alt="image" src="https://github.com/user-attachments/assets/518fcec1-8223-424b-930c-e45d43d195b3" />

anecdotally, when even just one build is in an errored state, it appears to quickly start and fail many jobs in rapid succession, sometimes requiring developers to request multiple retries on the same PR before the job gets picked up by a different worker.

The errored workers can be manually viewed by drone admins via:
```
$ drone server ls -l
Name              Address           State      Created
agent-Eoj1xzQI    35.90.12.111      error      12 hours ago
agent-dKlNJTOr    44.243.197.246    running    12 hours ago
agent-AkVu0zBu    35.89.141.124     running    3 hours ago
agent-Yb8w16Cz    54.245.41.158     running    2 hours ago
```

workers in error states can be then terminated by drone admins via `bin/drone/destroy-errored-agents`, but this adds a manual step and can be frustrating for engineers who are blocked from starting a new drone run in the interim.

Our version of drone autoscaler already has config options available to enable reaping of workers that are in an error state. However, some bugs were found in this logic and later fixed in:
* https://github.com/drone/autoscaler/releases/tag/v1.9.0
* https://github.com/drone/autoscaler/pull/133

## Description

done in this PR:
* upgrade to latest drone autoscaler version 
* enable autoscaler to reap errored workers every 5 minutes
* enable autoscaler pinger every 5 minutes, which helps detect workers in a bad state sooner 

the 5 minute interval matches the existing polling interval for autoscaling capacity adjustments, which we've previously confirmed by looking at the ECS logs for autoscaler.

caveat:
* drone workers are often under high memory / CPU load specifically during highly-parallelized execution of ui tests. In theory, this could cause them to fail to respond to a ping and be terminated. one option is to enable the reaper but not the pinger, which will still catch workers in error states (we usually find at least one worker in this state in response to investigating the docker daemon warnings). however, I'm proposing we follow the best practice and enable the pinger, then be on the lookout for any ui test runs that seem to get killed unexpectedly, especially during ui test execution.

## Testing story

careful inspection of [docs](https://github.com/drone/autoscaler/blob/v1.13.0/config/config.go#L78-L86) and release notes

## Deployment strategy

pair with infra team member to deploy

## Follow-up work

- after a few days, check ECS logs for evidence of reaping
- be on the lookout for any new drone failures, especially during ui test execution