### PR TITLE
Revert "Revert "refactor(broad tutor): move AiTutorContainer from CodeWorkspaceContainer to InstructionsWithWorkspace""

### DIFF
--- a/apps/src/aiTutor/types.ts
+++ b/apps/src/aiTutor/types.ts
@@ -20,11 +20,11 @@ export interface AiTutorContext {
 }
 
 export interface AnalyticsData {
-  labType: string;
+  labType?: string;
   channelId?: string;
   location: string;
-  levelId?: string;
-  unitId?: string;
+  levelId?: number;
+  unitId?: number;
 }
 
 export type MaybePromise<T> = T | Promise<T>;

--- a/apps/src/aiTutor/views/legacyLabs/AiTutorContainer.tsx
+++ b/apps/src/aiTutor/views/legacyLabs/AiTutorContainer.tsx
@@ -2,11 +2,11 @@ import Button from '@code-dot-org/component-library/button';
 import {BodyThreeText} from '@code-dot-org/component-library/typography';
 import classNames from 'classnames';
 import React, {FC} from 'react';
-import {useSelector} from 'react-redux';
 
 import AiTutorChat from '@cdo/apps/lab2/views/components/AiTutorChat';
 import {LegacyLabsState} from '@cdo/apps/redux/legacyLabs';
 import {singleton as studioApp} from '@cdo/apps/StudioApp';
+import {useAppSelector} from '@cdo/apps/util/reduxHooks';
 import aiBotOutlineIcon from '@cdo/static/ai-bot-outline.png';
 
 import {
@@ -36,7 +36,7 @@ export const AiTutorContainer: FC<{
   toggleAiChat: () => void;
   aiChatOpen: boolean;
 }> = ({toggleAiChat, aiChatOpen}) => {
-  const labState = useSelector(
+  const labState = useAppSelector(
     (state: {pageConstants: LegacyLabsState}) => state.pageConstants
   );
 

--- a/apps/src/aiTutor/views/legacyLabs/AiTutorSidebar.module.scss
+++ b/apps/src/aiTutor/views/legacyLabs/AiTutorSidebar.module.scss
@@ -2,6 +2,7 @@
   width: 45px;
   position: absolute;
   right: 0;
+  top: 0;
 
   &-header {
     display: flex;

--- a/apps/src/aiTutor/views/legacyLabs/constants.ts
+++ b/apps/src/aiTutor/views/legacyLabs/constants.ts
@@ -1,0 +1,1 @@
+export const AI_TUTOR_LABS = ['applab', 'gamelab', 'weblab'];

--- a/apps/src/redux/legacyLabs.ts
+++ b/apps/src/redux/legacyLabs.ts
@@ -2,8 +2,8 @@
 // to see a full list of pageConstants state, reference
 // https://github.com/code-dot-org/code-dot-org/blob/9b394de6615920058336e2b4ddfea6b2e1591d28/apps/src/redux/pageConstants.js#L5
 export interface LegacyLabsState {
-  channelId: string;
-  serverLevelId: string;
-  serverScriptId: string;
-  appType: string;
+  channelId?: string;
+  serverLevelId?: number;
+  serverScriptId?: number;
+  appType?: string;
 }

--- a/apps/src/templates/CodeWorkspaceContainer.jsx
+++ b/apps/src/templates/CodeWorkspaceContainer.jsx
@@ -9,9 +9,7 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import {connect} from 'react-redux';
 
-import {AiTutorContainer} from '../aiTutor/views/legacyLabs/AiTutorContainer';
 import commonStyles from '../commonStyles';
-import experiments from '../util/experiments';
 import * as utils from '../utils';
 
 class CodeWorkspaceContainer extends React.Component {
@@ -23,11 +21,6 @@ class CodeWorkspaceContainer extends React.Component {
     hidden: PropTypes.bool.isRequired,
     isRtl: PropTypes.bool.isRequired,
     noVisualization: PropTypes.bool.isRequired,
-    labType: PropTypes.string,
-  };
-
-  state = {
-    aiChatOpen: false,
   };
 
   /**
@@ -44,18 +37,8 @@ class CodeWorkspaceContainer extends React.Component {
     }
   }
 
-  toggleAiChat = () => {
-    this.setState(prevState => ({aiChatOpen: !prevState.aiChatOpen}));
-  };
-
   render() {
-    const {hidden, isRtl, noVisualization, children, style, labType} =
-      this.props;
-
-    const AiTutorLabs = ['applab', 'gamelab', 'weblab'];
-    const showAiTutor =
-      AiTutorLabs.includes(labType) &&
-      experiments.isEnabled(experiments.LEGACY_LAB_AI_TUTOR);
+    const {hidden, isRtl, noVisualization, children, style} = this.props;
 
     const mainStyle = {
       ...styles.main,
@@ -68,22 +51,9 @@ class CodeWorkspaceContainer extends React.Component {
 
     return (
       <div style={mainStyle} className="editor-column">
-        <div
-          id="codeWorkspace"
-          style={{
-            ...styles.codeWorkspace,
-            // 45px sidebar + 6px border = 51px
-            right: showAiTutor ? (this.state.aiChatOpen ? 350 : 51) : 0,
-          }}
-        >
+        <div id="codeWorkspace" style={styles.codeWorkspace}>
           {children}
         </div>
-        {showAiTutor && (
-          <AiTutorContainer
-            toggleAiChat={this.toggleAiChat}
-            aiChatOpen={this.state.aiChatOpen}
-          />
-        )}
       </div>
     );
   }
@@ -97,7 +67,6 @@ export default connect(
       !state.pageConstants.visualizationInWorkspace,
     isRtl: state.isRtl,
     noVisualization: state.pageConstants.noVisualization,
-    labType: state.pageConstants.appType,
   }),
   undefined,
   null,

--- a/apps/src/templates/instructions/InstructionsWithWorkspace.jsx
+++ b/apps/src/templates/instructions/InstructionsWithWorkspace.jsx
@@ -119,26 +119,23 @@ export class UnwrappedInstructionsWithWorkspace extends React.Component {
 
     const chatContainerSpace = 335; // 325px chat container + 10px margin = 335px
     const sidebarSpace = 55; // 45px sidebar + 10px margin = 55px
-    const right = showAiTutor
-      ? this.state.aiChatOpen
-        ? chatContainerSpace
-        : sidebarSpace
-      : 0;
+    const tutorSpace = this.state.aiChatOpen
+      ? chatContainerSpace
+      : sidebarSpace;
+
+    if (showAiTutor) {
+      instructionsStyle.right = tutorSpace;
+      workspaceStyle.right = tutorSpace;
+    }
 
     return (
       <span>
-        <TopInstructions
-          mainStyle={{
-            ...instructionsStyle,
-            right,
-          }}
-        />
+        <TopInstructions mainStyle={instructionsStyle} />
         <CodeWorkspaceContainer
           ref={this.setCodeWorkspaceContainerRef}
           style={{
             ...workspaceStyle,
             top: instructionsHeight,
-            right,
           }}
         >
           {children}

--- a/apps/src/templates/instructions/InstructionsWithWorkspace.jsx
+++ b/apps/src/templates/instructions/InstructionsWithWorkspace.jsx
@@ -3,7 +3,11 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import {connect} from 'react-redux';
 
+import {AI_TUTOR_LABS} from '@cdo/apps/aiTutor/views/legacyLabs/constants';
+
+import {AiTutorContainer} from '../../aiTutor/views/legacyLabs/AiTutorContainer';
 import {setInstructionsMaxHeightAvailable} from '../../redux/instructions';
+import experiments from '../../util/experiments';
 import CodeWorkspaceContainer from '../CodeWorkspaceContainer';
 
 import TopInstructions from './TopInstructions';
@@ -24,12 +28,14 @@ export class UnwrappedInstructionsWithWorkspace extends React.Component {
     // Provided by redux
     instructionsHeight: PropTypes.number.isRequired,
     setInstructionsMaxHeightAvailable: PropTypes.func.isRequired,
+    labType: PropTypes.string,
   };
 
   // only used so that we can rerender when resized
   state = {
     windowWidth: undefined,
     windowHeight: undefined,
+    aiChatOpen: true,
   };
 
   setCodeWorkspaceContainerRef = element => {
@@ -86,6 +92,10 @@ export class UnwrappedInstructionsWithWorkspace extends React.Component {
     setInstructionsMaxHeightAvailable(maxInstructionsHeight);
   };
 
+  toggleAiChat = () => {
+    this.setState(prevState => ({aiChatOpen: !prevState.aiChatOpen}));
+  };
+
   componentDidMount() {
     window.addEventListener('resize', this.onResize);
   }
@@ -95,18 +105,50 @@ export class UnwrappedInstructionsWithWorkspace extends React.Component {
   }
 
   render() {
-    const {instructionsStyle, workspaceStyle, instructionsHeight, children} =
-      this.props;
+    const {
+      instructionsStyle,
+      workspaceStyle,
+      instructionsHeight,
+      labType,
+      children,
+    } = this.props;
+
+    const showAiTutor =
+      AI_TUTOR_LABS.includes(labType) &&
+      experiments.isEnabled(experiments.LEGACY_LAB_AI_TUTOR);
+
+    const chatContainerSpace = 335; // 325px chat container + 10px margin = 335px
+    const sidebarSpace = 55; // 45px sidebar + 10px margin = 55px
+    const right = showAiTutor
+      ? this.state.aiChatOpen
+        ? chatContainerSpace
+        : sidebarSpace
+      : 0;
 
     return (
       <span>
-        <TopInstructions mainStyle={instructionsStyle} />
+        <TopInstructions
+          mainStyle={{
+            ...instructionsStyle,
+            right,
+          }}
+        />
         <CodeWorkspaceContainer
           ref={this.setCodeWorkspaceContainerRef}
-          style={{...workspaceStyle, top: instructionsHeight}}
+          style={{
+            ...workspaceStyle,
+            top: instructionsHeight,
+            right,
+          }}
         >
           {children}
         </CodeWorkspaceContainer>
+        {showAiTutor && (
+          <AiTutorContainer
+            toggleAiChat={this.toggleAiChat}
+            aiChatOpen={this.state.aiChatOpen}
+          />
+        )}
       </span>
     );
   }
@@ -115,6 +157,7 @@ export class UnwrappedInstructionsWithWorkspace extends React.Component {
 export default connect(
   state => ({
     instructionsHeight: state.instructions.renderedHeight,
+    labType: state.pageConstants.appType,
   }),
   dispatch => ({
     setInstructionsMaxHeightAvailable(maxHeight) {

--- a/apps/test/unit/templates/instructions/InstructionsWithWorkspaceTest.jsx
+++ b/apps/test/unit/templates/instructions/InstructionsWithWorkspaceTest.jsx
@@ -27,6 +27,7 @@ describe('InstructionsWithWorkspace', () => {
     expect(wrapper.state()).toEqual({
       windowWidth: undefined,
       windowHeight: undefined,
+      aiChatOpen: true,
     });
   });
 


### PR DESCRIPTION
this re-applies https://github.com/code-dot-org/code-dot-org/pull/68887 after having to revert due to ui eyes tests failing that cover rtl languages. at issue was defaulting the `right` positioning to `0` when not in the legacy labs ai tutor experiment. instead, I'm leaving it as `undefined` so the style object passed as props is not overridden

BEFORE:
<img width="1355" height="949" alt="Screenshot 2025-10-21 at 4 22 00 PM" src="https://github.com/user-attachments/assets/0aed2183-a398-4569-8cf8-573506d216aa" />

AFTER:
<img width="1351" height="950" alt="Screenshot 2025-10-21 at 4 21 02 PM" src="https://github.com/user-attachments/assets/3e4b62bd-a83a-44c9-8d51-f97ffc958847" />


Reverts code-dot-org/code-dot-org#68996