### PR TITLE
increase drone ui test parallelization to take advantage of bigger instance size

### DIFF
--- a/lib/rake/ci.rake
+++ b/lib/rake/ci.rake
@@ -64,6 +64,9 @@ SKIP_PEGASUS_CONTENT = 'skip pegasus content'.freeze
 # that fail. This flag ensures all tests will use SauceLabs for all runs.
 SKIP_LOCAL_WEBDRIVER = 'skip local webdriver'.freeze
 
+# Maximum parallel browsers to use for UI and eyes tests
+PARALLEL_COUNT = 24
+
 namespace :ci do
   desc 'Runs tests for changed sub-folders, or all tests if the tag specified is present in the most recent commit message.'
   timed_task_with_logging :run_tests do
@@ -129,7 +132,7 @@ namespace :ci do
           "--local " \
           "--ci " \
           "#{use_saucelabs ? "--config #{ui_test_browsers.join(',')} " : ''}" \
-          "--parallel #{use_saucelabs ? 16 : 8} " \
+          "--parallel #{PARALLEL_COUNT} " \
           "--abort_when_failures_exceed 10 " \
           "--retry_count 2 " \
           "#{CI::Utils.tagged?(SKIP_LOCAL_WEBDRIVER) ? '' : '--first_run_local '}" \
@@ -143,7 +146,7 @@ namespace :ci do
             "--config Chrome,iPhone " \
             "--local " \
             "--ci " \
-            "--parallel 10 " \
+            "--parallel #{PARALLEL_COUNT} " \
             "--retry_count 1 " \
             "#{CI::Utils.tagged?(SKIP_LOCAL_WEBDRIVER) ? '' : '--first_run_local '}" \
             "--with-status-page " \


### PR DESCRIPTION
After much experimentation with the new `m7i.4xlarge` drone worker instance size, it appears that the following parameters yield the optimal ui test run times:
* dashboard_workers: 5 (no change, configured [here](https://github.com/code-dot-org/code-dot-org/blob/03f12fa625fc4e9618c2641914476ede2d484186/.github/workflows/run_ui_tests.yml#L54)). this controls the number of puma processes
* max parallel ui test runners: 24 (see PR diff)

process to arrive at this result (see [gsheet](https://docs.google.com/spreadsheets/d/19z3ukXr-HxSnrwHpLILmoBwkWWXecGk40Fdfctf5a54/edit?gid=0#gid=0)):
* experimented with 3 to 8 workers, expanding search up and down until I saw diminishing returns
* found the approximate best number of test runners for each number of workers
* ran additional reruns on best results as necessary to increase confidence

This shaves about 3 minutes off of drone `ui` pipeline run time.

### before

```
UI TEST REPORT: *✅ PASSED*
190 passed. 0 failed. Test count: 190. Duration: 12:44 minutes. Total successful reruns of flaky tests: 10.

EYES TEST REPORT: *✅ PASSED*
77 passed. 0 failed. Test count: 77. Duration: 4:56 minutes. Total successful reruns of flaky tests: 4. 

Finished ci:run_ui_tests (20 minutes)
```

### after

```
UI TEST REPORT: *✅ PASSED*
 190 passed. 0 failed. Test count: 190. Duration: 11:10 minutes. Total successful reruns of flaky tests: 10.

EYES TEST REPORT: *✅ PASSED*
77 passed. 0 failed. Test count: 77. Duration: 3:17 minutes. Total successful reruns of flaky tests: 4.

Finished ci:run_ui_tests (17 minutes)
```

## Testing story

the gsheet clearly demonstrates the performance improvement, and suggests we couldn't be leaving more than a few seconds on the table by further tweaking these two parameters. 

In terms of reliability, I saw two good indicators that this change won't introduce substantial flakiness:
* I didn't see any drone failures during UI test execution except when the number of workers and/or runners were well above their optimal values (see rows marked with `x` in the gsheet)
* I didn't see significantly higher retry counts in the runs that gave optimal or near-optimal results (as illustrated above)

