### PR TITLE
Web Lab 2: skip txt, csv and md in AI tutor context

### DIFF
--- a/apps/src/weblab2/helpers/aiTutorContextHelper.ts
+++ b/apps/src/weblab2/helpers/aiTutorContextHelper.ts
@@ -9,6 +9,8 @@ interface AiTutorWebLab2Params {
   selection: UserAddedSelectionContext;
 }
 
+const LANGUAGES_TO_EXCLUDE_FROM_CONTEXT = ['txt', 'csv', 'md'];
+
 export class AiTutorWebLab2ContextHelper extends AiTutorContextHelper<AiTutorWebLab2Params> {
   private params?: AiTutorWebLab2Params;
 
@@ -25,7 +27,8 @@ export class AiTutorWebLab2ContextHelper extends AiTutorContextHelper<AiTutorWeb
           .filter(
             file =>
               file.type !== ProjectFileType.VALIDATION &&
-              file.type !== ProjectFileType.SYSTEM_SUPPORT
+              file.type !== ProjectFileType.SYSTEM_SUPPORT &&
+              !LANGUAGES_TO_EXCLUDE_FROM_CONTEXT.includes(file.language)
           )
           .map(file => `filename: ${file.name}\n\`\`\`${file.contents}\`\`\``)
           .join('\n\n')

--- a/apps/src/weblab2/helpers/aiTutorContextHelper.ts
+++ b/apps/src/weblab2/helpers/aiTutorContextHelper.ts
@@ -45,7 +45,7 @@ export class AiTutorWebLab2ContextHelper extends AiTutorContextHelper<AiTutorWeb
                     : `lines ${context.lineReference.start} - ${context.lineReference.end}`;
                 return `snippet of file ${context.filename}, ${lineString}\nContents of snippet:\n\`\`\`${context.sourceCode}\`\`\``;
               } else {
-                return `entirety of file ${context.filename}\nContents of file:\n\`\`\`${context.sourceCode}}\`\`\``;
+                return `entirety of file ${context.filename}\nContents of file:\n\`\`\`${context.sourceCode}\`\`\``;
               }
             })
             .join('\n\n')


### PR DESCRIPTION
To avoid sending potentially confusing information to the tutor, we are skipping adding txt, csv and md files as part of the source sent to the tutor. The student can still manually add these files as context.


## Links

- Jira: [AFL-273](https://codedotorg.atlassian.net/browse/AFL-273)

## Testing story
Confirmed in web lab 2 csv, md and txt files are no longer included by default in the source, but they can still be added as context. In testing context I noticed we had an errant `}` in the text for including a full file, so I removed that.


## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
