### PR TITLE
Lab2: show text cursor in Codebridge editor

### DIFF
--- a/apps/src/codebridge/Editor/styles/editor.module.scss
+++ b/apps/src/codebridge/Editor/styles/editor.module.scss
@@ -3,6 +3,7 @@
   height: 100%;
   background-color: var(--background-neutral-primary);
   overflow: hidden;
+  cursor: text;
 
   .aiTutorTooltip {
     border-radius: 6px;
@@ -21,7 +22,7 @@
 
 .noOpenFilesContainer {
   width: 100%;
-  height: 100%;    
+  height: 100%;
   display: flex;
   justify-content: center;
   align-items: center;


### PR DESCRIPTION
Shows a text cursor instead of the default pointer in Codebridge text editor in Web Lab 2 and Python Lab.

## Links
Jira ticket: [AFL-307](https://codedotorg.atlassian.net/browse/AFL-307)

## Testing story
Tested locally. Tried recording the change but the screen recorder is buggy with cursors and doesn't show it, but I confirmed it's working. 