### PR TITLE
AI Chat: prevent super long strings in chat message bubbles

### DIFF
--- a/apps/src/aiComponentLibrary/chatMessage/chat-message.module.scss
+++ b/apps/src/aiComponentLibrary/chatMessage/chat-message.module.scss
@@ -63,7 +63,6 @@ $icon-overlay-padding-right: 8px;
   background-color: var(--background-neutral-secondary);
   border-end-start-radius: $message-border-radius;
   border-end-end-radius: 0;
-  overflow-wrap: break-word;
   word-break: break-word;
 }
 
@@ -73,7 +72,6 @@ $icon-overlay-padding-right: 8px;
   border-end-start-radius: 0;
   border-end-end-radius: $message-border-radius;
   overflow-x: auto;
-  overflow-wrap: break-word;
   word-break: break-word;
 }
 

--- a/apps/src/aiComponentLibrary/chatMessage/chat-message.module.scss
+++ b/apps/src/aiComponentLibrary/chatMessage/chat-message.module.scss
@@ -63,7 +63,6 @@ $icon-overlay-padding-right: 8px;
   background-color: var(--background-neutral-secondary);
   border-end-start-radius: $message-border-radius;
   border-end-end-radius: 0;
-  word-wrap: break-word;
   overflow-wrap: break-word;
   word-break: break-word;
 }
@@ -74,7 +73,6 @@ $icon-overlay-padding-right: 8px;
   border-end-start-radius: 0;
   border-end-end-radius: $message-border-radius;
   overflow-x: auto;
-  word-wrap: break-word;
   overflow-wrap: break-word;
   word-break: break-word;
 }

--- a/apps/src/aiComponentLibrary/chatMessage/chat-message.module.scss
+++ b/apps/src/aiComponentLibrary/chatMessage/chat-message.module.scss
@@ -63,6 +63,9 @@ $icon-overlay-padding-right: 8px;
   background-color: var(--background-neutral-secondary);
   border-end-start-radius: $message-border-radius;
   border-end-end-radius: 0;
+  word-wrap: break-word;
+  overflow-wrap: break-word;
+  word-break: break-word;
 }
 
 .message-assistant {
@@ -71,6 +74,9 @@ $icon-overlay-padding-right: 8px;
   border-end-start-radius: 0;
   border-end-end-radius: $message-border-radius;
   overflow-x: auto;
+  word-wrap: break-word;
+  overflow-wrap: break-word;
+  word-break: break-word;
 }
 
 %message-container {

--- a/apps/src/aiComponentLibrary/chatMessage/chat-message.module.scss
+++ b/apps/src/aiComponentLibrary/chatMessage/chat-message.module.scss
@@ -18,10 +18,8 @@ $icon-overlay-padding-right: 8px;
   gap: 0.5rem;
   border-start-start-radius: $message-border-radius;
   border-start-end-radius: $message-border-radius;
-}
+  word-break: break-word;
 
-// Prevent code blocks from overflowing their container
-@mixin wrap-code {
   code {
     word-break: break-word;
     white-space: unset;
@@ -71,9 +69,6 @@ $icon-overlay-padding-right: 8px;
   background-color: var(--background-neutral-secondary);
   border-end-start-radius: $message-border-radius;
   border-end-end-radius: 0;
-  word-break: break-word;
-
-  @include wrap-code;
 }
 
 .message-assistant {
@@ -82,9 +77,6 @@ $icon-overlay-padding-right: 8px;
   border-end-start-radius: 0;
   border-end-end-radius: $message-border-radius;
   overflow-x: auto;
-  word-break: break-word;
-
-  @include wrap-code;
 }
 
 %message-container {

--- a/apps/src/aiComponentLibrary/chatMessage/chat-message.module.scss
+++ b/apps/src/aiComponentLibrary/chatMessage/chat-message.module.scss
@@ -20,6 +20,14 @@ $icon-overlay-padding-right: 8px;
   border-start-end-radius: $message-border-radius;
 }
 
+// Prevent code blocks from overflowing their container
+@mixin wrap-code {
+  code {
+    word-break: break-word;
+    white-space: unset;
+  }
+}
+
 %markdown-styles {
   h1 {
     @include heading-xxl;
@@ -64,6 +72,8 @@ $icon-overlay-padding-right: 8px;
   border-end-start-radius: $message-border-radius;
   border-end-end-radius: 0;
   word-break: break-word;
+
+  @include wrap-code;
 }
 
 .message-assistant {
@@ -73,6 +83,8 @@ $icon-overlay-padding-right: 8px;
   border-end-end-radius: $message-border-radius;
   overflow-x: auto;
   word-break: break-word;
+
+  @include wrap-code;
 }
 
 %message-container {


### PR DESCRIPTION
Adds the [word-break](https://developer.mozilla.org/en-US/docs/Web/CSS/word-break) css property to prevent super long strings in chat message bubbles.

## Links 
Jira ticket: [AFL-208](https://codedotorg.atlassian.net/browse/AFL-208)

## Testing story
Tested locally

----

## Regular string

| Before | After |
| ---- | ---- |
| <img width="415" height="781" alt="Screenshot 2025-10-22 at 10 34 05 AM" src="https://github.com/user-attachments/assets/ed01185c-3abe-4568-9a11-5baad75ffd41" /> | <img width="415" height="781" alt="After" src="https://github.com/user-attachments/assets/e3b07976-2483-4b31-803c-9c2b7b1afcb8" /> | 

## Inline code

| Before | After |
| ---- | ---- |
|  <img width="415" height="781" alt="Screenshot 2025-10-22 at 11 04 49 AM" src="https://github.com/user-attachments/assets/bc34fe9f-7b98-427e-b722-d659d052ee30" /> | <img width="415" height="781" alt="After" src="https://github.com/user-attachments/assets/7616ffd4-9a0f-4f54-bc4f-9bac5c1abcc0" /> | 
