### PR TITLE
Split out redux from Music Lab timeline

### DIFF
--- a/apps/src/music/views/MusicLabView.tsx
+++ b/apps/src/music/views/MusicLabView.tsx
@@ -278,7 +278,7 @@ const MusicLabView: React.FunctionComponent<MusicLabViewProps> = ({
     () => progressManager?.resetValidation(),
     [progressManager]
   );
-  usePlaybackUpdate(doPlaybackUpdate, resetValidation);
+  usePlaybackUpdate(isPlaying, doPlaybackUpdate, resetValidation);
 
   const onInstructionsTextClick = useCallback(
     (id: string) => {

--- a/apps/src/music/views/Timeline/TimelineContext.ts
+++ b/apps/src/music/views/Timeline/TimelineContext.ts
@@ -1,0 +1,10 @@
+import {createContext} from 'react';
+
+import useRequiredContext from '@cdo/apps/util/hooks/useRequiredContext';
+
+import {TimelineProps} from './TimelineUI';
+
+export const TimelineContext = createContext<TimelineProps | null>(null);
+
+export const useTimelineContext = () =>
+  useRequiredContext(TimelineContext, 'TimelineContext');

--- a/apps/src/music/views/Timeline/TimelineElement.tsx
+++ b/apps/src/music/views/Timeline/TimelineElement.tsx
@@ -1,14 +1,13 @@
 import classNames from 'classnames';
 import React from 'react';
-import {useDispatch} from 'react-redux';
 
 import {isChordEvent} from '@cdo/apps/music/player/interfaces/ChordEvent';
 import {isInstrumentEvent} from '@cdo/apps/music/player/interfaces/InstrumentEvent';
 import {PlaybackEvent} from '@cdo/apps/music/player/interfaces/PlaybackEvent';
 import {isSoundEvent} from '@cdo/apps/music/player/interfaces/SoundEvent';
-import {selectBlockId} from '@cdo/apps/music/redux/musicRedux';
 import SoundStyle from '@cdo/apps/music/utils/SoundStyle';
-import {useAppSelector} from '@cdo/apps/util/reduxHooks';
+
+import {useTimelineContext} from './TimelineContext';
 
 import moduleStyles from './timeline.module.scss';
 
@@ -34,23 +33,18 @@ const TimelineElement: React.FunctionComponent<TimelineElementProps> = ({
   top,
   left,
 }) => {
-  const isPlaying = useAppSelector(state => state.music.isPlaying);
-  const selectedBlockId = useAppSelector(state => state.music.selectedBlockId);
-  const dispatch = useDispatch();
+  const {isPlaying, selectedBlockId, currentPlayheadPosition, selectBlockId} =
+    useTimelineContext();
   const isInsideRandom = eventData.skipContext?.insideRandom;
   const isSkipSound = isPlaying && eventData.skipContext?.skipSound;
   const isThinBorder = height <= 4;
 
-  const isCurrentlyPlaying = useAppSelector(state => {
-    const currentPlayheadPosition = state.music.currentPlayheadPosition;
-    return (
-      isPlaying &&
-      !isSkipSound &&
-      currentPlayheadPosition !== 0 &&
-      currentPlayheadPosition >= eventData.when &&
-      currentPlayheadPosition < eventData.when + eventData.length
-    );
-  });
+  const isCurrentlyPlaying =
+    isPlaying &&
+    !isSkipSound &&
+    currentPlayheadPosition !== 0 &&
+    currentPlayheadPosition >= eventData.when &&
+    currentPlayheadPosition < eventData.when + eventData.length;
 
   const isBlockSelected = eventData.blockId === selectedBlockId;
 
@@ -90,7 +84,7 @@ const TimelineElement: React.FunctionComponent<TimelineElementProps> = ({
         left,
       }}
       onClick={event => {
-        dispatch(selectBlockId(eventData.blockId));
+        selectBlockId?.(eventData.blockId);
         event.stopPropagation();
       }}
     >

--- a/apps/src/music/views/Timeline/TimelineSampleEvents.jsx
+++ b/apps/src/music/views/Timeline/TimelineSampleEvents.jsx
@@ -1,9 +1,9 @@
 import PropTypes from 'prop-types';
 import React, {useRef} from 'react';
-import {useSelector} from 'react-redux';
 
 import UniqueSounds from '@cdo/apps/music/utils/UniqueSounds';
 
+import {useTimelineContext} from './TimelineContext';
 import TimelineElement from './TimelineElement';
 
 /**
@@ -16,7 +16,7 @@ const TimelineSampleEvents = ({
   getEventHeight,
   getEventVerticalSpace,
 }) => {
-  const soundEvents = useSelector(state => state.music.playbackEvents);
+  const {playbackEvents: soundEvents} = useTimelineContext();
 
   const uniqueSoundsRef = useRef(new UniqueSounds());
   // Let's cache the value of getUniqueSounds() so that the various helpers

--- a/apps/src/music/views/Timeline/TimelineSimple2Events.tsx
+++ b/apps/src/music/views/Timeline/TimelineSimple2Events.tsx
@@ -6,8 +6,8 @@ import {collectBlockIdsRecursively} from '@cdo/apps/music/blockly/blockUtils';
 import {MAX_FUNCTION_BOUNDS_RENDER_DEPTH} from '@cdo/apps/music/constants';
 import {FunctionEvents} from '@cdo/apps/music/player/interfaces/FunctionEvents';
 import {PlaybackEvent} from '@cdo/apps/music/player/interfaces/PlaybackEvent';
-import {useAppSelector} from '@cdo/apps/util/reduxHooks';
 
+import {useTimelineContext} from './TimelineContext';
 import TimelineElement from './TimelineElement';
 
 const timelineLayoutParam = AppConfig.getValue('timeline-layout');
@@ -199,9 +199,8 @@ const TimelineSimple2Events: React.FunctionComponent<
   getEventHeight,
   getEventVerticalSpace,
 }) => {
-  const soundEventsOriginal = useAppSelector(
-    state => state.music.playbackEvents
-  );
+  const {playbackEvents: soundEventsOriginal, orderedFunctions} =
+    useTimelineContext();
 
   // soundEventsOriginal has sounds sorted primarily by the immediate function
   // that generates them, and next by when they are played.
@@ -215,10 +214,6 @@ const TimelineSimple2Events: React.FunctionComponent<
   } else if (timelineLayoutParam !== 'old') {
     soundEvents = getOrderedByWhenSoundEvents(soundEventsOriginal);
   }
-
-  const orderedFunctions = useAppSelector(
-    state => state.music.orderedFunctions
-  );
 
   // Generate a list of unique sounds, with uniqueness being a combination of
   // the function name and the sound ID.

--- a/apps/src/music/views/Timeline/TimelineUI.tsx
+++ b/apps/src/music/views/Timeline/TimelineUI.tsx
@@ -1,0 +1,374 @@
+import classNames from 'classnames';
+import React, {
+  memo,
+  MouseEvent,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from 'react';
+
+import appConfig from '@cdo/apps/music/appConfig';
+import {BlockMode, MIN_NUM_MEASURES} from '@cdo/apps/music/constants';
+import musicI18n from '@cdo/apps/music/locale';
+import {FunctionEvents} from '@cdo/apps/music/player/interfaces/FunctionEvents';
+import {PlaybackEvent} from '@cdo/apps/music/player/interfaces/PlaybackEvent';
+import {ValueOf} from '@cdo/apps/types/utils';
+
+import usePlaybackUpdate from '../hooks/usePlaybackUpdate';
+
+import {TimelineContext} from './TimelineContext';
+import {TimelineElementClass} from './TimelineElement';
+import TimelineSampleEvents from './TimelineSampleEvents';
+import TimelineSimple2Events from './TimelineSimple2Events';
+
+import moduleStyles from './timeline.module.scss';
+
+// The width of one measure.
+const barWidth = 60;
+// A little room on the left.
+const paddingOffset = 10;
+// Start scrolling the playhead when it's more than this percentage of the way across the timeline area.
+const playheadScrollThreshold = 0.75;
+// How many extra measures to show at the end.
+const extraMeasures = 8;
+
+export interface TimelineProps {
+  playbackEvents: PlaybackEvent[];
+  orderedFunctions: FunctionEvents[];
+  isPlaying: boolean;
+  blockMode: ValueOf<typeof BlockMode>;
+  currentPlayheadPosition: number;
+  startingPlayheadPosition?: number;
+  hideTimelineEvents?: boolean;
+  allowChangeStartingPlayheadPosition?: boolean;
+  lastMeasure?: number;
+  loopEnabled?: boolean;
+  loopStart?: number;
+  loopEnd?: number;
+  setStartingPlayheadPosition?: (position: number) => void;
+  clearSelectedBlockId?: () => void;
+  selectedBlockId?: string;
+  selectBlockId?: (blockId: string) => void;
+}
+
+/**
+ * Renders the music playback timeline.
+ */
+const Timeline: React.FunctionComponent<TimelineProps> = props => {
+  const {
+    allowChangeStartingPlayheadPosition,
+    hideTimelineEvents = false,
+    isPlaying,
+    blockMode,
+    currentPlayheadPosition,
+    startingPlayheadPosition = 1,
+    lastMeasure = 0,
+    loopEnabled = false,
+    loopStart = 1,
+    loopEnd = 1,
+    setStartingPlayheadPosition,
+    clearSelectedBlockId,
+  } = props;
+
+  const canChangeStartingPlayheadPosition =
+    (allowChangeStartingPlayheadPosition ||
+      appConfig.getValue('allow-change-starting-playhead-position') ===
+        'true') &&
+    !isPlaying;
+  const measuresToDisplay =
+    Math.max(MIN_NUM_MEASURES, lastMeasure) + extraMeasures;
+  const playheadRef = useRef<HTMLDivElement>(null);
+  const timelineRef = useRef<HTMLDivElement>(null);
+
+  const positionToUse = isPlaying
+    ? currentPlayheadPosition
+    : startingPlayheadPosition;
+  const playHeadOffsetInPixels = (positionToUse - 1) * barWidth;
+
+  // The height of the primary timeline area for drawing events.  This is the height of each measure's
+  // vertical bar.
+  const [availableHeight, setAvailableHeight] = useState(0);
+
+  // Get the height that each event should occupy.  This is inclusive of empty vertical space at the bottom.
+  const getEventHeight = useCallback(
+    (numUniqueRows: number) => {
+      // While we might not actually have this many rows to show,
+      // we will limit each row's height to the size that would allow
+      // this many to be shown at once.
+      const minVisible = 5;
+
+      const maxVisible = 45;
+
+      // We might not actually have this many rows to show, but
+      // we will size the bars so that this many rows would show.
+      const numSoundsToShow = Math.max(
+        Math.min(numUniqueRows, maxVisible),
+        minVisible
+      );
+
+      return Math.floor(availableHeight / numSoundsToShow);
+    },
+    [availableHeight]
+  );
+
+  // How how much of the event height should be left as empty vertical space at the bottom.
+  const getEventVerticalSpace = useCallback((eventHeight: number) => {
+    return eventHeight > 8 ? 3 : eventHeight > 6 ? 2 : 1;
+  }, []);
+
+  const timelineElements = Array.from(
+    document.querySelectorAll<HTMLElement>(`.${TimelineElementClass}`)
+  );
+
+  const onKeyDown = useCallback(
+    (event: React.KeyboardEvent<HTMLButtonElement>) => {
+      const currentIndex = timelineElements.indexOf(event.currentTarget);
+      // For arrow keys, prevent scroll action and move focus accordingly, looping at start and end
+      if (event.key === 'ArrowRight' || event.key === 'ArrowDown') {
+        event.preventDefault();
+        const nextIndex = (currentIndex + 1) % timelineElements.length;
+        timelineElements[nextIndex].focus();
+      } else if (event.key === 'ArrowLeft' || event.key === 'ArrowUp') {
+        event.preventDefault();
+        const previousIndex =
+          (currentIndex - 1 + timelineElements.length) %
+          timelineElements.length;
+        timelineElements[previousIndex].focus();
+      } else if (event.key === 'Escape') {
+        // Move focus back to the timeline container
+        const timelineContainer = document.getElementById('timeline');
+        if (timelineContainer) {
+          timelineContainer.focus();
+        }
+      } else if (event.key === 'Tab') {
+        // Prevent default tab behavior to avoid moving focus out of the timeline
+        event.preventDefault();
+      }
+    },
+    [timelineElements]
+  );
+
+  const enterExitTimeline = (event: React.KeyboardEvent) => {
+    if (event.key === 'Enter') {
+      // Focus the first element if it exists
+      if (timelineElements.length > 0) {
+        timelineElements[0].focus();
+      }
+    }
+    if (event.key === 'Tab') {
+      if (event.shiftKey) {
+        // Allows browser to handle Shift + Tab as expected
+        return;
+      } else {
+        // If (only) Tab is pressed, they are moving to the next focusable item
+        (event.currentTarget as HTMLElement).blur();
+      }
+    }
+  };
+
+  const timelineElementProps = {
+    paddingOffset,
+    barWidth,
+    onKeyDown,
+    getEventHeight,
+    getEventVerticalSpace,
+  };
+
+  // Generate an array containing measure numbers from 1..measuresToDisplay.
+  const arrayOfMeasures = Array.from(
+    {length: measuresToDisplay},
+    (_, i) => i + 1
+  );
+
+  const onMeasuresBackgroundClick = useCallback(
+    (event: MouseEvent) => {
+      if (!setStartingPlayheadPosition || !canChangeStartingPlayheadPosition) {
+        return;
+      }
+      const offset =
+        event.clientX -
+        (event.target as Element).getBoundingClientRect().x -
+        paddingOffset;
+      const exactMeasure = offset / barWidth + 1;
+      // Round measure to the nearest beat (1/4 note).
+      const roundedMeasure = Math.round(exactMeasure * 4) / 4;
+      setStartingPlayheadPosition(roundedMeasure);
+    },
+    [canChangeStartingPlayheadPosition, setStartingPlayheadPosition]
+  );
+
+  const onMeasureNumberClick = useCallback(
+    (measureNumber: number) => {
+      if (!setStartingPlayheadPosition || !canChangeStartingPlayheadPosition) {
+        return;
+      }
+      setStartingPlayheadPosition(measureNumber);
+    },
+    [canChangeStartingPlayheadPosition, setStartingPlayheadPosition]
+  );
+
+  const scrollPlayheadForward = useCallback(() => {
+    if (!timelineRef.current || !playheadRef.current) {
+      return;
+    }
+    const playheadOffset =
+      playheadRef.current.getBoundingClientRect().left -
+      timelineRef.current.getBoundingClientRect().left;
+    const scrollThreshold =
+      timelineRef.current.clientWidth * playheadScrollThreshold;
+    if (playheadOffset > scrollThreshold) {
+      timelineRef.current.scrollBy(playheadOffset - scrollThreshold, 0);
+    }
+  }, [playheadRef]);
+
+  const scrollToPlayhead = useCallback(() => {
+    playheadRef.current?.scrollIntoView();
+  }, [playheadRef]);
+
+  usePlaybackUpdate(
+    isPlaying,
+    scrollPlayheadForward,
+    scrollToPlayhead,
+    scrollToPlayhead
+  );
+
+  const firstBarLineRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!firstBarLineRef.current) {
+      return;
+    }
+    const resizeObserver = new ResizeObserver(() => {
+      setAvailableHeight(firstBarLineRef.current?.offsetHeight || 0);
+    });
+    resizeObserver.observe(firstBarLineRef?.current);
+    return () => {
+      resizeObserver.disconnect();
+    };
+  }, []);
+
+  return (
+    <TimelineContext.Provider value={props}>
+      <div
+        id="timeline"
+        aria-label={musicI18n.timelineContainer()}
+        className={classNames(
+          moduleStyles.timeline,
+          isPlaying && moduleStyles.timelinePlaying
+        )}
+        onClick={clearSelectedBlockId}
+        onKeyDown={enterExitTimeline}
+        ref={timelineRef}
+        tabIndex={0} // eslint-disable-line jsx-a11y/no-noninteractive-tabindex
+      >
+        <div
+          id="timeline-measures-background"
+          className={classNames(
+            moduleStyles.measuresBackground,
+            moduleStyles.fullWidthOverlay,
+            canChangeStartingPlayheadPosition &&
+              moduleStyles.measuresBackgroundClickable
+          )}
+          style={{width: paddingOffset + measuresToDisplay * barWidth}}
+          onClick={onMeasuresBackgroundClick}
+        >
+          &nbsp;
+        </div>
+        <div id="timeline-measures" className={moduleStyles.fullWidthOverlay}>
+          {arrayOfMeasures.map((measure, index) => {
+            return (
+              <div
+                key={index}
+                className={moduleStyles.barLineContainer}
+                style={{left: paddingOffset + index * barWidth}}
+              >
+                <div
+                  className={classNames(
+                    moduleStyles.barNumber,
+                    measure === Math.floor(currentPlayheadPosition) &&
+                      moduleStyles.barNumberCurrent,
+                    canChangeStartingPlayheadPosition &&
+                      moduleStyles.barNumberClickable
+                  )}
+                  onClick={() => onMeasureNumberClick(measure)}
+                >
+                  {measure}
+                </div>
+                <div
+                  id={index === 0 ? 'timeline-first-barline' : undefined}
+                  ref={index === 0 ? firstBarLineRef : undefined}
+                  className={classNames(
+                    moduleStyles.barLine,
+                    measure === Math.floor(currentPlayheadPosition) &&
+                      moduleStyles.barLineCurrent
+                  )}
+                />
+              </div>
+            );
+          })}
+        </div>
+
+        <div id="timeline-soundsarea" className={moduleStyles.soundsArea}>
+          {!hideTimelineEvents &&
+            (blockMode === BlockMode.SIMPLE2 ? (
+              <TimelineSimple2Events {...timelineElementProps} />
+            ) : (
+              <TimelineSampleEvents {...timelineElementProps} />
+            ))}
+        </div>
+
+        <div id="timeline-playhead" className={moduleStyles.fullWidthOverlay}>
+          <div
+            className={classNames(
+              moduleStyles.playhead,
+              isPlaying && moduleStyles.playheadPlaying
+            )}
+            style={{left: paddingOffset + playHeadOffsetInPixels}}
+            ref={playheadRef}
+          >
+            &nbsp;
+          </div>
+        </div>
+        {loopEnabled && <LoopMarkers loopStart={loopStart} loopEnd={loopEnd} />}
+      </div>
+    </TimelineContext.Provider>
+  );
+};
+
+const LoopMarkers: React.FunctionComponent<{
+  loopStart: number;
+  loopEnd: number;
+}> = ({loopStart, loopEnd}) => {
+  const startOffset = (loopStart - 1) * barWidth;
+  const endOffset = (loopEnd - 1) * barWidth;
+
+  return (
+    <>
+      <div id="timeline-playhead" className={moduleStyles.fullWidthOverlay}>
+        <div
+          className={classNames(
+            moduleStyles.playhead,
+            moduleStyles.playheadLoop
+          )}
+          style={{left: paddingOffset + startOffset}}
+        >
+          &nbsp;
+        </div>
+      </div>
+      <div id="timeline-playhead" className={moduleStyles.fullWidthOverlay}>
+        <div
+          className={classNames(
+            moduleStyles.playhead,
+            moduleStyles.playheadLoop
+          )}
+          style={{left: paddingOffset + endOffset}}
+        >
+          &nbsp;
+        </div>
+      </div>
+    </>
+  );
+};
+
+export default memo(Timeline);

--- a/apps/src/music/views/Timeline/index.tsx
+++ b/apps/src/music/views/Timeline/index.tsx
@@ -1,41 +1,16 @@
-import classNames from 'classnames';
-import React, {
-  memo,
-  MouseEvent,
-  useCallback,
-  useEffect,
-  useRef,
-  useState,
-} from 'react';
+import React, {memo, useCallback} from 'react';
 import {useDispatch, useSelector} from 'react-redux';
 
 import {isPredictResponseSubmitted} from '@cdo/apps/lab2/redux/predictLevelRedux';
-import appConfig from '@cdo/apps/music/appConfig';
-import {BlockMode, MIN_NUM_MEASURES} from '@cdo/apps/music/constants';
-import musicI18n from '@cdo/apps/music/locale';
 import {
   clearSelectedBlockId,
   getBlockMode,
+  selectBlockId,
   setStartingPlayheadPosition,
 } from '@cdo/apps/music/redux/musicRedux';
 import {useAppSelector} from '@cdo/apps/util/reduxHooks';
 
-import usePlaybackUpdate from '../hooks/usePlaybackUpdate';
-
-import {TimelineElementClass} from './TimelineElement';
-import TimelineSampleEvents from './TimelineSampleEvents';
-import TimelineSimple2Events from './TimelineSimple2Events';
-
-import moduleStyles from './timeline.module.scss';
-
-// The width of one measure.
-const barWidth = 60;
-// A little room on the left.
-const paddingOffset = 10;
-// Start scrolling the playhead when it's more than this percentage of the way across the timeline area.
-const playheadScrollThreshold = 0.75;
-// How many extra measures to show at the end.
-const extraMeasures = 8;
+import TimelineUI from './TimelineUI';
 
 interface TimelineProps {
   allowChangeStartingPlayheadPosition?: boolean;
@@ -43,326 +18,68 @@ interface TimelineProps {
 }
 
 /**
- * Renders the music playback timeline.
+ * Renders the Music Lab timeline, connected to the redux store.
+ * To use the UI-only, unconnected Timeline, see {@link TimelineUI}.
  */
-const Timeline: React.FunctionComponent<TimelineProps> = ({
+const TimelineContainer: React.FC<TimelineProps> = ({
   allowChangeStartingPlayheadPosition,
   isPredictLevel,
 }) => {
-  const isPlaying = useAppSelector(state => state.music.isPlaying);
-
-  const blockMode = useSelector(getBlockMode);
   const dispatch = useDispatch();
+  const playbackEvents = useAppSelector(state => state.music.playbackEvents);
+  const orderedFunctions = useAppSelector(
+    state => state.music.orderedFunctions
+  );
+  const predictResponseSubmitted = useAppSelector(isPredictResponseSubmitted);
+  const isPlaying = useAppSelector(state => state.music.isPlaying);
+  const blockMode = useSelector(getBlockMode);
   const currentPlayheadPosition = useAppSelector(
     state => state.music.currentPlayheadPosition
   );
   const startingPlayheadPosition = useAppSelector(
     state => state.music.startingPlayheadPosition
   );
-
-  const canChangeStartingPlayheadPosition =
-    (allowChangeStartingPlayheadPosition ||
-      appConfig.getValue('allow-change-starting-playhead-position') ===
-        'true') &&
-    !isPlaying;
-  const measuresToDisplay =
-    Math.max(
-      MIN_NUM_MEASURES,
-      useAppSelector(state => state.music.lastMeasure)
-    ) + extraMeasures;
+  const lastMeasure = useAppSelector(state => state.music.lastMeasure);
   const loopEnabled = useAppSelector(state => state.music.loopEnabled);
   const loopStart = useAppSelector(state => state.music.loopStart);
   const loopEnd = useAppSelector(state => state.music.loopEnd);
-  const playheadRef = useRef<HTMLDivElement>(null);
-  const timelineRef = useRef<HTMLDivElement>(null);
-
-  const positionToUse = isPlaying
-    ? currentPlayheadPosition
-    : startingPlayheadPosition;
-  const playHeadOffsetInPixels = (positionToUse - 1) * barWidth;
-
-  // The height of the primary timeline area for drawing events.  This is the height of each measure's
-  // vertical bar.
-  const [availableHeight, setAvailableHeight] = useState(0);
-
-  // Get the height that each event should occupy.  This is inclusive of empty vertical space at the bottom.
-  const getEventHeight = useCallback(
-    (numUniqueRows: number) => {
-      // While we might not actually have this many rows to show,
-      // we will limit each row's height to the size that would allow
-      // this many to be shown at once.
-      const minVisible = 5;
-
-      const maxVisible = 45;
-
-      // We might not actually have this many rows to show, but
-      // we will size the bars so that this many rows would show.
-      const numSoundsToShow = Math.max(
-        Math.min(numUniqueRows, maxVisible),
-        minVisible
-      );
-
-      return Math.floor(availableHeight / numSoundsToShow);
+  const selectedBlockId = useAppSelector(state => state.music.selectedBlockId);
+  const setStartingPlayheadPositionCallback = useCallback(
+    (position: number) => {
+      dispatch(setStartingPlayheadPosition(position));
     },
-    [availableHeight]
+    [dispatch]
   );
-
-  // How how much of the event height should be left as empty vertical space at the bottom.
-  const getEventVerticalSpace = useCallback((eventHeight: number) => {
-    return eventHeight > 8 ? 3 : eventHeight > 6 ? 2 : 1;
-  }, []);
-
-  const timelineElements = Array.from(
-    document.querySelectorAll<HTMLElement>(`.${TimelineElementClass}`)
-  );
-
-  const onKeyDown = useCallback(
-    (event: React.KeyboardEvent<HTMLButtonElement>) => {
-      const currentIndex = timelineElements.indexOf(event.currentTarget);
-      // For arrow keys, prevent scroll action and move focus accordingly, looping at start and end
-      if (event.key === 'ArrowRight' || event.key === 'ArrowDown') {
-        event.preventDefault();
-        const nextIndex = (currentIndex + 1) % timelineElements.length;
-        timelineElements[nextIndex].focus();
-      } else if (event.key === 'ArrowLeft' || event.key === 'ArrowUp') {
-        event.preventDefault();
-        const previousIndex =
-          (currentIndex - 1 + timelineElements.length) %
-          timelineElements.length;
-        timelineElements[previousIndex].focus();
-      } else if (event.key === 'Escape') {
-        // Move focus back to the timeline container
-        const timelineContainer = document.getElementById('timeline');
-        if (timelineContainer) {
-          timelineContainer.focus();
-        }
-      } else if (event.key === 'Tab') {
-        // Prevent default tab behavior to avoid moving focus out of the timeline
-        event.preventDefault();
-      }
-    },
-    [timelineElements]
-  );
-
-  const enterExitTimeline = (event: React.KeyboardEvent) => {
-    if (event.key === 'Enter') {
-      // Focus the first element if it exists
-      if (timelineElements.length > 0) {
-        timelineElements[0].focus();
-      }
-    }
-    if (event.key === 'Tab') {
-      if (event.shiftKey) {
-        // Allows browser to handle Shift + Tab as expected
-        return;
-      } else {
-        // If (only) Tab is pressed, they are moving to the next focusable item
-        (event.currentTarget as HTMLElement).blur();
-      }
-    }
-  };
-
-  const timelineElementProps = {
-    paddingOffset,
-    barWidth,
-    onKeyDown,
-    getEventHeight,
-    getEventVerticalSpace,
-  };
-
-  // Generate an array containing measure numbers from 1..measuresToDisplay.
-  const arrayOfMeasures = Array.from(
-    {length: measuresToDisplay},
-    (_, i) => i + 1
-  );
-
-  const onMeasuresBackgroundClick = useCallback(
-    (event: MouseEvent) => {
-      if (!canChangeStartingPlayheadPosition) {
-        return;
-      }
-      const offset =
-        event.clientX -
-        (event.target as Element).getBoundingClientRect().x -
-        paddingOffset;
-      const exactMeasure = offset / barWidth + 1;
-      // Round measure to the nearest beat (1/4 note).
-      const roundedMeasure = Math.round(exactMeasure * 4) / 4;
-      dispatch(setStartingPlayheadPosition(roundedMeasure));
-    },
-    [dispatch, canChangeStartingPlayheadPosition]
-  );
-
-  const onMeasureNumberClick = useCallback(
-    (measureNumber: number) => {
-      if (!canChangeStartingPlayheadPosition) {
-        return;
-      }
-      dispatch(setStartingPlayheadPosition(measureNumber));
-    },
-    [dispatch, canChangeStartingPlayheadPosition]
-  );
-
-  const onTimelineClick = useCallback(() => {
+  const clearSelectedBlockIdCallback = useCallback(() => {
     dispatch(clearSelectedBlockId());
   }, [dispatch]);
-
-  const scrollPlayheadForward = useCallback(() => {
-    if (!timelineRef.current || !playheadRef.current) {
-      return;
-    }
-    const playheadOffset =
-      playheadRef.current.getBoundingClientRect().left -
-      timelineRef.current.getBoundingClientRect().left;
-    const scrollThreshold =
-      timelineRef.current.clientWidth * playheadScrollThreshold;
-    if (playheadOffset > scrollThreshold) {
-      timelineRef.current.scrollBy(playheadOffset - scrollThreshold, 0);
-    }
-  }, [playheadRef]);
-
-  const scrollToPlayhead = useCallback(() => {
-    playheadRef.current?.scrollIntoView();
-  }, [playheadRef]);
-
-  usePlaybackUpdate(scrollPlayheadForward, scrollToPlayhead, scrollToPlayhead);
-  const predictResponseSubmitted = useAppSelector(isPredictResponseSubmitted);
-  const canPopulateTimeline = !isPredictLevel || predictResponseSubmitted;
-
-  const firstBarLineRef = useRef<HTMLDivElement>(null);
-
-  useEffect(() => {
-    if (!firstBarLineRef.current) {
-      return;
-    }
-    const resizeObserver = new ResizeObserver(() => {
-      setAvailableHeight(firstBarLineRef.current?.offsetHeight || 0);
-    });
-    resizeObserver.observe(firstBarLineRef?.current);
-    return () => {
-      resizeObserver.disconnect();
-    };
-  }, []);
+  const selectBlockIdCallback = useCallback(
+    (blockId: string) => {
+      dispatch(selectBlockId(blockId));
+    },
+    [dispatch]
+  );
 
   return (
-    <div
-      id="timeline"
-      aria-label={musicI18n.timelineContainer()}
-      className={classNames(
-        moduleStyles.timeline,
-        isPlaying && moduleStyles.timelinePlaying
-      )}
-      onClick={onTimelineClick}
-      onKeyDown={enterExitTimeline}
-      ref={timelineRef}
-      tabIndex={0} // eslint-disable-line jsx-a11y/no-noninteractive-tabindex
-    >
-      <div
-        id="timeline-measures-background"
-        className={classNames(
-          moduleStyles.measuresBackground,
-          moduleStyles.fullWidthOverlay,
-          canChangeStartingPlayheadPosition &&
-            moduleStyles.measuresBackgroundClickable
-        )}
-        style={{width: paddingOffset + measuresToDisplay * barWidth}}
-        onClick={onMeasuresBackgroundClick}
-      >
-        &nbsp;
-      </div>
-      <div id="timeline-measures" className={moduleStyles.fullWidthOverlay}>
-        {arrayOfMeasures.map((measure, index) => {
-          return (
-            <div
-              key={index}
-              className={moduleStyles.barLineContainer}
-              style={{left: paddingOffset + index * barWidth}}
-            >
-              <div
-                className={classNames(
-                  moduleStyles.barNumber,
-                  measure === Math.floor(currentPlayheadPosition) &&
-                    moduleStyles.barNumberCurrent,
-                  canChangeStartingPlayheadPosition &&
-                    moduleStyles.barNumberClickable
-                )}
-                onClick={() => onMeasureNumberClick(measure)}
-              >
-                {measure}
-              </div>
-              <div
-                id={index === 0 ? 'timeline-first-barline' : undefined}
-                ref={index === 0 ? firstBarLineRef : undefined}
-                className={classNames(
-                  moduleStyles.barLine,
-                  measure === Math.floor(currentPlayheadPosition) &&
-                    moduleStyles.barLineCurrent
-                )}
-              />
-            </div>
-          );
-        })}
-      </div>
-
-      <div id="timeline-soundsarea" className={moduleStyles.soundsArea}>
-        {canPopulateTimeline &&
-          (blockMode === BlockMode.SIMPLE2 ? (
-            <TimelineSimple2Events {...timelineElementProps} />
-          ) : (
-            <TimelineSampleEvents {...timelineElementProps} />
-          ))}
-      </div>
-
-      <div id="timeline-playhead" className={moduleStyles.fullWidthOverlay}>
-        <div
-          className={classNames(
-            moduleStyles.playhead,
-            isPlaying && moduleStyles.playheadPlaying
-          )}
-          style={{left: paddingOffset + playHeadOffsetInPixels}}
-          ref={playheadRef}
-        >
-          &nbsp;
-        </div>
-      </div>
-      {loopEnabled && <LoopMarkers loopStart={loopStart} loopEnd={loopEnd} />}
-    </div>
+    <TimelineUI
+      playbackEvents={playbackEvents}
+      orderedFunctions={orderedFunctions}
+      allowChangeStartingPlayheadPosition={allowChangeStartingPlayheadPosition}
+      hideTimelineEvents={isPredictLevel && !predictResponseSubmitted}
+      isPlaying={isPlaying}
+      blockMode={blockMode}
+      currentPlayheadPosition={currentPlayheadPosition}
+      startingPlayheadPosition={startingPlayheadPosition}
+      lastMeasure={lastMeasure}
+      loopEnabled={loopEnabled}
+      loopStart={loopStart}
+      loopEnd={loopEnd}
+      setStartingPlayheadPosition={setStartingPlayheadPositionCallback}
+      clearSelectedBlockId={clearSelectedBlockIdCallback}
+      selectBlockId={selectBlockIdCallback}
+      selectedBlockId={selectedBlockId}
+    />
   );
 };
 
-const LoopMarkers: React.FunctionComponent<{
-  loopStart: number;
-  loopEnd: number;
-}> = ({loopStart, loopEnd}) => {
-  const startOffset = (loopStart - 1) * barWidth;
-  const endOffset = (loopEnd - 1) * barWidth;
-
-  return (
-    <>
-      <div id="timeline-playhead" className={moduleStyles.fullWidthOverlay}>
-        <div
-          className={classNames(
-            moduleStyles.playhead,
-            moduleStyles.playheadLoop
-          )}
-          style={{left: paddingOffset + startOffset}}
-        >
-          &nbsp;
-        </div>
-      </div>
-      <div id="timeline-playhead" className={moduleStyles.fullWidthOverlay}>
-        <div
-          className={classNames(
-            moduleStyles.playhead,
-            moduleStyles.playheadLoop
-          )}
-          style={{left: paddingOffset + endOffset}}
-        >
-          &nbsp;
-        </div>
-      </div>
-    </>
-  );
-};
-
-export default memo(Timeline);
+export default memo(TimelineContainer);

--- a/apps/src/music/views/hooks/usePlaybackUpdate.ts
+++ b/apps/src/music/views/hooks/usePlaybackUpdate.ts
@@ -1,21 +1,20 @@
 import {useEffect, useRef} from 'react';
 
-import {useAppSelector} from '@cdo/apps/util/reduxHooks';
-
 const UPDATE_RATE = 1000 / 30; // 30 times per second
 
 /**
  * A hook for performing updates during playback.
+ * @param isPlaying whether playback is in progress.
  * @param doUpdate function to run every UPDATE_RATE milliseconds while playback is in progress.
  * @param onPlay optional function to run when playback starts.
  * @param onStop optional function to run when playback stops.
  */
 export default function usePlaybackUpdate(
+  isPlaying: boolean,
   doUpdate: () => void,
   onPlay?: () => void,
   onStop?: () => void
 ) {
-  const isPlaying = useAppSelector(state => state.music.isPlaying);
   const intervalId = useRef<number | undefined>();
 
   useEffect(() => {

--- a/apps/src/util/hooks/useRequiredContext.ts
+++ b/apps/src/util/hooks/useRequiredContext.ts
@@ -1,0 +1,16 @@
+import {Context, useContext} from 'react';
+
+/**
+ * A custom hook that ensures a context value is present.
+ * If the context value is null or undefined, an error is thrown.
+ */
+export default function useRequiredContext<T>(
+  context: Context<T | null>,
+  contextName: string
+): T {
+  const ctx = useContext(context);
+  if (!ctx) {
+    throw new Error(`${contextName} must be used within a Provider`);
+  }
+  return ctx;
+}

--- a/apps/test/unit/music/views/Timeline/TimelineUITest.tsx
+++ b/apps/test/unit/music/views/Timeline/TimelineUITest.tsx
@@ -1,0 +1,53 @@
+import {render} from '@testing-library/react';
+import React from 'react';
+
+import {BlockMode} from '@cdo/apps/music/constants';
+import TimelineUI from '@cdo/apps/music/views/Timeline/TimelineUI';
+import {RootState} from '@cdo/apps/types/redux';
+
+const mockUseSelector = jest.fn();
+const mockUseDispatch = jest.fn();
+
+jest.mock('react-redux', () => ({
+  Provider: ({children}: {children: React.ReactNode}) => <>{children}</>,
+  useSelector: (selector: (state: RootState) => unknown) =>
+    mockUseSelector(selector),
+  useDispatch: () => mockUseDispatch,
+}));
+
+describe('TimelineUI', () => {
+  beforeAll(() => {
+    // Need to mock scrollIntoView since it's not implemented in JSDOM
+    window.HTMLElement.prototype.scrollIntoView = jest.fn();
+  });
+
+  beforeEach(() => {
+    mockUseSelector.mockClear();
+    mockUseDispatch.mockClear();
+  });
+
+  it('should not directly access redux', () => {
+    const mockProps = {
+      playbackEvents: [
+        {
+          id: '1',
+          type: 'sound',
+          when: 1,
+          triggered: false,
+          length: 2,
+          blockId: 'block1',
+          soundType: 'lead',
+        } as const,
+      ],
+      orderedFunctions: [],
+      isPlaying: false,
+      blockMode: BlockMode.SIMPLE2,
+      currentPlayheadPosition: 1,
+    };
+
+    render(<TimelineUI {...mockProps} />);
+
+    expect(mockUseSelector).not.toHaveBeenCalled();
+    expect(mockUseDispatch).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
This separates the Music Lab timeline into a top level container that accesses the music lab redux state, and a UI-only presentation component (and subcomponents) that don't depend on any redux. This allows us to reuse the UI-only version in other contexts like on the Dance Party AI choreography levels, or in a Dance music mashup share view, etc. No functional changes.

## Testing story
Tested locally to verify no functional changes. I also added a quick unit test to make sure we don't accidentally add back any redux to the UI components. We should ideally extend that unit test to actually test the timeline view and functionality, but I'll leave that for a later time.