### PR TITLE
feat(carousel): show 10% of next slide on mobile

### DIFF
--- a/frontend/packages/component-library/src/carousel/Carousel.tsx
+++ b/frontend/packages/component-library/src/carousel/Carousel.tsx
@@ -85,6 +85,11 @@ const Carousel: React.FC<CarouselProps> = ({
             el: `#${carouselId}-pagination`,
           }}
           breakpoints={{
+            // when window width is mobile, show 10% of the following slide
+            [0]: {
+              slidesPerView: 1.1,
+              slidesPerGroup: 1,
+            },
             // when window width is tablet
             [breakpointTablet]: {
               slidesPerView: 2,


### PR DESCRIPTION
This PR updates the logic for mobile carousels to show 10% of the next slide to indicate to the user that there are more slides to see by swiping.

# Before

<img width="633" height="780" alt="Screenshot From 2025-10-22 07-00-30" src="https://github.com/user-attachments/assets/b2743956-0d81-4baa-897d-b267254ccb27" />


# After

<img width="633" height="780" alt="Screenshot From 2025-10-22 07-00-39" src="https://github.com/user-attachments/assets/8a513fa1-6d45-407f-bc13-f5821a31032a" />
