### PR TITLE
set primary_contact_info_id to nil in PII scrubber

### DIFF
--- a/dashboard/lib/services/user/pii_scrubber.rb
+++ b/dashboard/lib/services/user/pii_scrubber.rb
@@ -45,6 +45,7 @@ module Services
           ao.assign_attributes(email: '', hashed_email: '', authentication_id: nil, data: nil)
           ao.save(validate: false) # Records may be invalid due to duplicate empty string emails
         end
+        user.primary_contact_info_id = nil # in rare cases, this might point to a different account's live auth option
         user.lti_user_identities.with_deleted.order(deleted_at: :desc).each(&:really_destroy!)
         user.email = ''
         user.hashed_email = nil


### PR DESCRIPTION
We hit a few email uniqueness validation errors in the PII scrubber. The two users affected had no authentication options associated with them, but their `primary_contact_info_id` was still set, pointing to a live authentication option that was in use by another account tied to their email. This was causing validation errors since the `email` method in the User model pulls from the `primary_contact_info`. This PR aims to solve this validation issue by explicitly setting `primary_contact_info_id` to nil.



## Links
[JIRA](https://codedotorg.atlassian.net/browse/P20-1681)

- Jira: 

## Testing story
<!--  Does your change include appropriate tests?
      - If so, please describe how the tests included in this PR are sufficient.
      - If not, please explain why this change does not need to be tested. -->



## Deployment strategy
<!--  Any special steps required to deploy this, besides merging?
      - Are there database migrations or manual steps?
      - Does this require coordination with other teams or systems? -->



## Follow-up work
<!--  List any clean-up or technical debt that will be addressed in future work.
      - Include Jira links where applicable.
      - Are there any known limitations or improvements planned? -->



## Privacy
<!--  How does this change impact Student & Teacher privacy?
      - Does this collect, use, share, or modify PII, either new or existing? -->



## Security
<!--  How does this change impact our security surface-area?
      - Do API's touched have the right auth?
      - Do infra changes impact our attack surface or encryption?
-->



## Caching
<!--  How does this change impact caching behavior?
      - Are cache keys or invalidation strategies affected?
      - Will this require cache warming or invalidation after deployment? -->



## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
