### PR TITLE
Lab2: adjust instructions heading sizes 

### DIFF
--- a/apps/src/lab2/views/components/Instructions/instructions.module.scss
+++ b/apps/src/lab2/views/components/Instructions/instructions.module.scss
@@ -190,6 +190,7 @@
     font-size: 0.75rem;
     line-height: 1.48;
     font-weight: 600;
+    text-transform: uppercase;
   }
 
   ol,

--- a/apps/src/lab2/views/components/Instructions/instructions.module.scss
+++ b/apps/src/lab2/views/components/Instructions/instructions.module.scss
@@ -161,33 +161,35 @@
   }
 
   h1 {
-    font-size: 3rem;
-    line-height: 1.16;
-  }
-
-  h2 {
-    font-size: 2.125rem;
-    line-height: 1.24;
-  }
-
-  h3 {
     font-size: 1.75rem;
     line-height: 1.28;
   }
 
-  h4 {
+  h2 {
     font-size: 1.5rem;
     line-height: 1.32;
   }
 
-  h5 {
+  h3 {
     font-size: 1.25rem;
     line-height: 1.4;
   }
 
-  h6 {
+  h4 {
     font-size: 1rem;
     line-height: 1.48;
+  }
+
+  h5 {
+    font-size: 0.875rem;
+    line-height: 1.48;
+    font-weight: 600;
+  }
+
+  h6 {
+    font-size: 0.75rem;
+    line-height: 1.48;
+    font-weight: 600;
   }
 
   ol,


### PR DESCRIPTION
Makes all of the headings updated in this PR: https://github.com/code-dot-org/code-dot-org/pull/68997 smaller so h1 and h2s aren't screaming.

## Links
Jira ticket: [AFL-312](https://codedotorg.atlassian.net/browse/AFL-312)

## Testing story
Tested locally

----

<img width="757" height="494" alt="Screenshot 2025-10-23 at 10 52 48 AM" src="https://github.com/user-attachments/assets/264818e8-8a1f-4a8e-bdba-9e399ac8befd" />

<img width="342" height="777" alt="Screenshot 2025-10-23 at 10 52 26 AM" src="https://github.com/user-attachments/assets/3899de5f-f7b5-464d-8fcb-eb35a6f06d78" />
