### PR TITLE
Web Lab 2: allow loading google fonts

### DIFF
--- a/dashboard/app/controllers/codeprojects_preview_controller.rb
+++ b/dashboard/app/controllers/codeprojects_preview_controller.rb
@@ -66,6 +66,9 @@ class CodeprojectsPreviewController < ApplicationController
     script_src = script_src_base + script_src_eval + script_src_inline
     style_src = style_src_base + style_src_inline
 
+    # Allow loading google fonts and any self-hosted fonts.
+    font_src = "'self' fonts.googleapis.com fonts.gstatic.com"
+
     policies = [
       "default-src #{default_src}",
       "connect-src #{connect_src}",
@@ -73,6 +76,7 @@ class CodeprojectsPreviewController < ApplicationController
       "script-src #{script_src}",
       "style-src #{style_src}",
       "img-src #{img_src}",
+      "font-src #{font_src}"
     ]
 
     unless rack_env?(:development) || rack_env?(:test)


### PR DESCRIPTION
This PR allows users in Web Lab 2 to load in [google fonts](https://developers.google.com/fonts/docs/getting_started) as a font src. If their school firewall blocks the google fonts api, they still will not be able to load fonts, so we may eventually want to self-host a subset of desired fonts.

## Screenshot
This is using the font "Inconsolata"
<img width="1705" height="906" alt="Screenshot 2025-10-23 at 3 27 27 PM" src="https://github.com/user-attachments/assets/754b7672-d1cf-40d1-b651-48b18020d8e4" />


## Security
I believe the google fonts api is a safe one to allow users to load from.


## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
