### PR TITLE
add ClassLink logo for account linking page

### DIFF
--- a/apps/src/simpleSignUp/lti/assets/classlink.png
+++ b/apps/src/simpleSignUp/lti/assets/classlink.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d4fd577440c28512713be6f57206fac9a4e7bb548ce765d65d9a5f6748d5e25a
+size 2964

--- a/apps/src/simpleSignUp/lti/link/LtiLinkAccountPage/LtiWelcomeBanner/index.tsx
+++ b/apps/src/simpleSignUp/lti/link/LtiLinkAccountPage/LtiWelcomeBanner/index.tsx
@@ -6,8 +6,8 @@ import codeLogo from '@cdo/apps/templates/images/codeLogo.png';
 import i18n from '@cdo/locale';
 
 import canvas from '../../../assets/canvas.svg';
-import schoology from '../../../assets/schoology.svg';
 import classlink from '../../../assets/classlink.png';
+import schoology from '../../../assets/schoology.svg';
 import {LtiProviderContext} from '../context';
 
 import styles from '../../../../link-account.module.scss';

--- a/apps/src/simpleSignUp/lti/link/LtiLinkAccountPage/LtiWelcomeBanner/index.tsx
+++ b/apps/src/simpleSignUp/lti/link/LtiLinkAccountPage/LtiWelcomeBanner/index.tsx
@@ -7,6 +7,7 @@ import i18n from '@cdo/locale';
 
 import canvas from '../../../assets/canvas.svg';
 import schoology from '../../../assets/schoology.svg';
+import classlink from '../../../assets/classlink.png';
 import {LtiProviderContext} from '../context';
 
 import styles from '../../../../link-account.module.scss';
@@ -22,6 +23,8 @@ const LtiWelcomeBanner = () => {
         return canvas;
       case 'schoology':
         return schoology;
+      case 'classlink':
+        return classlink;
       default:
         return undefined;
     }

--- a/apps/src/simpleSignUp/lti/link/LtiLinkAccountPage/types.ts
+++ b/apps/src/simpleSignUp/lti/link/LtiLinkAccountPage/types.ts
@@ -2,4 +2,5 @@ export type LtiProvider =
   | 'canvas_cloud'
   | 'canvas_beta_cloud'
   | 'canvas_test_cloud'
-  | 'schoology';
+  | 'schoology'
+  | 'classlink';


### PR DESCRIPTION
Adds the ClassLink logo on the LTI account linking page. It will now show up along with the Code.org logo when a user launches from ClassLink, although this LMS is not yet supported in prod:

<img width="1138" height="715" alt="Screenshot 2025-10-23 at 4 03 47 PM" src="https://github.com/user-attachments/assets/787a8f10-92f5-41b6-b4af-075cb2474948" />



## Links
[JIRA](https://codedotorg.atlassian.net/browse/P20-1674)

- Jira: 

## Testing story

- `yarn start` in apps directory
- launch from ClassLink dev



## Deployment strategy
<!--  Any special steps required to deploy this, besides merging?
      - Are there database migrations or manual steps?
      - Does this require coordination with other teams or systems? -->



## Follow-up work
<!--  List any clean-up or technical debt that will be addressed in future work.
      - Include Jira links where applicable.
      - Are there any known limitations or improvements planned? -->



## Privacy
<!--  How does this change impact Student & Teacher privacy?
      - Does this collect, use, share, or modify PII, either new or existing? -->



## Security
<!--  How does this change impact our security surface-area?
      - Do API's touched have the right auth?
      - Do infra changes impact our attack surface or encryption?
-->



## Caching
<!--  How does this change impact caching behavior?
      - Are cache keys or invalidation strategies affected?
      - Will this require cache warming or invalidation after deployment? -->



## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
