### PR TITLE
chore(autoscale): double desired instances on deploy

### DIFF
--- a/frontend/apps/marketing/cicd/3-app/template.yml.erb
+++ b/frontend/apps/marketing/cicd/3-app/template.yml.erb
@@ -637,8 +637,8 @@ Resources:
         TargetValue: 70.0
         PredefinedMetricSpecification:
           PredefinedMetricType: ECSServiceAverageCPUUtilization
-        ScaleInCooldown: 60 # Wait 60 seconds before scaling up
-        ScaleOutCooldown: 900 # Scale out incrementally over 15 minutes
+        ScaleInCooldown: 300 # Wait 5 minutes before removing more instances
+        ScaleOutCooldown: 60 # Wait 1 minute before adding more instances
   ECSAutoScalingRole:
     Type: AWS::IAM::Role
     Properties:

--- a/frontend/apps/marketing/cicd/3-app/template.yml.erb
+++ b/frontend/apps/marketing/cicd/3-app/template.yml.erb
@@ -635,7 +635,7 @@ Resources:
         PredefinedMetricSpecification:
           PredefinedMetricType: ECSServiceAverageCPUUtilization
         ScaleInCooldown: 60 # Wait 60 seconds before scaling up
-        ScaleOutCooldown: 300 # Wait 5 minutes before scaling down
+        ScaleOutCooldown: 600 # Wait 10 minutes before scaling down
   ECSAutoScalingRole:
     Type: AWS::IAM::Role
     Properties:

--- a/frontend/apps/marketing/cicd/3-app/template.yml.erb
+++ b/frontend/apps/marketing/cicd/3-app/template.yml.erb
@@ -616,7 +616,10 @@ Resources:
     Type: AWS::ApplicationAutoScaling::ScalableTarget
     Properties:
       MaxCapacity: 20 # Upper limit for scaling, can be increased as needed
-      MinCapacity: 3 # High availability minimum
+      MinCapacity:  !If
+        - IsProductionEnvironment
+        - 3 # High Availability for production
+        - 1
       ResourceId: !Sub "service/${EcsCluster}/${FargateService.Name}"
       RoleARN: !GetAtt ECSAutoScalingRole.Arn
       ScalableDimension: ecs:service:DesiredCount

--- a/frontend/apps/marketing/cicd/3-app/template.yml.erb
+++ b/frontend/apps/marketing/cicd/3-app/template.yml.erb
@@ -570,7 +570,7 @@ Resources:
       EnableECSManagedTags: false
       HealthCheckGracePeriodSeconds: 60
       LaunchType: FARGATE
-      DesiredCount: 3
+      DesiredCount: 6
       AvailabilityZoneRebalancing: ENABLED
       LoadBalancers:
         - ContainerName: web

--- a/frontend/apps/marketing/cicd/3-app/template.yml.erb
+++ b/frontend/apps/marketing/cicd/3-app/template.yml.erb
@@ -638,7 +638,7 @@ Resources:
         PredefinedMetricSpecification:
           PredefinedMetricType: ECSServiceAverageCPUUtilization
         ScaleInCooldown: 60 # Wait 60 seconds before scaling up
-        ScaleOutCooldown: 600 # Wait 10 minutes before scaling down
+        ScaleOutCooldown: 900 # Scale out incrementally over 15 minutes
   ECSAutoScalingRole:
     Type: AWS::IAM::Role
     Properties:

--- a/frontend/apps/marketing/tests/e2e/activity-catalog.spec.ts
+++ b/frontend/apps/marketing/tests/e2e/activity-catalog.spec.ts
@@ -9,7 +9,11 @@ async function waitForImages(page: Page) {
 
   for (const lazyImage of lazyImages) {
     await lazyImage.scrollIntoViewIfNeeded();
-    await expect(lazyImage).toHaveJSProperty('complete', true);
+
+    // wait up to 10 seconds for each image to load
+    await expect(lazyImage).toHaveJSProperty('complete', true, {
+      timeout: 10000,
+    });
   }
 }
 
@@ -40,9 +44,6 @@ test.describe('Activity Catalog', () => {
       page.getByRole('heading', {name: 'Explore Hour of Code Activities'}),
     ).toBeVisible();
     await expect(page.getByPlaceholder('Search...')).toBeVisible();
-
-    // Wait for lazy loaded images to load
-    await waitForImages(page);
 
     // Click the "13-18" label element
     await page.locator('label').filter({hasText: '13-18'}).click();

--- a/frontend/apps/marketing/tests/e2e/activity-catalog.spec.ts
+++ b/frontend/apps/marketing/tests/e2e/activity-catalog.spec.ts
@@ -88,6 +88,8 @@ test.describe('Activity Catalog', () => {
   });
 
   test('eyes', {tag: '@csforall'}, async ({page, eyes, browserName}) => {
+    // This test waits for images to load, so it is slow
+    test.slow();
     test.skip(browserName === 'webkit', 'AVIF does not work on Webkit');
     test.skip(getSiteType() !== 'csforall', 'Only runs on csforall site');
 


### PR DESCRIPTION
During a deployment, the cloudfront cache is invalidated which causes a significant spike in traffic for dynamic images consuming all available CPU. Additionally, the CSForAll UI tests "warms up" the activity catalog by ensuring all images are populated in the Cloudfront cache which drives a spike in temporary load.

To mitigate this one-time spike in traffic, the desired instances are doubled to handle this traffic. Eventually, the autoscaling tracking target of >70% will downscale to 3 minimum instances thus allowing for a temporary surge in avaialbility but downscaling for cost reasons. This downscale operation occurs over the course of 15 minutes to ensure we gracefully step down from the expected surge of traffic from the cache invalidation event and let the caches be repopulated going forward. (See screenshot below)

This PR adds an additional 3 instances for 15 minutes after which will be terminated unless the CPU tracking needs require them still.

Additionally, this PR updates the minimum instances for pre-production to be 1 instance for cost reasons.

Finally, this PR updates the UI tests to be less flaky by allowing images to take longer to load for image heavy pages like the CSForAll Activity Catalog.

<img width="1105" height="566" alt="image" src="https://github.com/user-attachments/assets/a125fe1d-d004-4cd5-95d1-9388ec8f1fca" />
