### PR TITLE
feat(test): allow stubbing of HTTP requests for UI testing

### DIFF
--- a/config.yml.erb
+++ b/config.yml.erb
@@ -327,6 +327,9 @@ gatekeeper_table_name: gatekeeper_<%=env%>
 # Allows DCDO settings via cookies. See: `Rack::CookieDCDO`
 use_cookie_dcdo: false
 
+# Enables stubbing HTTP requests using VCR and WebMock based on cookie data. See: `Rack::HttpStub`
+http_stub_enabled: false
+
 # Allows Geolocation to be altered via cookies.
 # See: 'lib/cdo/rack/geolocation_override.rb'
 # and: 'dashboard/test/ui/features/xteam/gdpr_dialog.feature'

--- a/config/development.yml.erb
+++ b/config/development.yml.erb
@@ -79,6 +79,9 @@ google_gemini_ai_tutor_api_key: !Secret
 # Enables DCDO settings via cookies
 use_cookie_dcdo: true
 
+# Enables HTTP requests stubbing
+http_stub_enabled: true
+
 # Allows Geolocation to be altered via cookies.
 use_geolocation_override: true
 

--- a/config/test.yml.erb
+++ b/config/test.yml.erb
@@ -94,5 +94,8 @@ statsig_api_client_key: 'client-fake-key'
 # Enables DCDO settings via cookies
 use_cookie_dcdo: true
 
+# Enables HTTP request stubbing
+http_stub_enabled: true
+
 # Allows Geolocation to be altered via cookies.
 use_geolocation_override: true

--- a/dashboard/app/controllers/test_controller.rb
+++ b/dashboard/app/controllers/test_controller.rb
@@ -497,4 +497,26 @@ class TestController < ApplicationController
         get('dcdo_mocking_test'),
     }
   end
+
+  # Endpoint for testing HTTP stubbing.
+  # @see /dashboard/test/ui/features/http_stubbing.feature
+  def get_http_stubs
+    response1 = begin
+      JSON.parse Net::HTTP.get(URI('https://request1?param=test'))
+    rescue SocketError
+      'real'
+    end
+    response2 = begin
+      JSON.parse Net::HTTP.post(URI('https://request2?param=test'), 'fake_params').body
+    rescue SocketError
+      'real'
+    end
+    response3 = begin
+      JSON.parse Net::HTTP.get(URI('https://request3?param=test'))
+    rescue SocketError
+      'real'
+    end
+
+    render json: {response1:, response2:, response3:}
+  end
 end

--- a/dashboard/config/application.rb
+++ b/dashboard/config/application.rb
@@ -56,6 +56,12 @@ module Dashboard
     require 'cdo/rack/global_edition'
     config.middleware.insert_before Rack::Cors, Rack::GlobalEdition
 
+    if CDO.http_stub_enabled
+      # Enables HTTP request stubbing with VCR and WebMock, using cookie data for configuration.
+      require 'cdo/rack/http_stub'
+      config.middleware.insert_before Rack::Cors, Rack::HttpStub, fixtures_dir: root.join('test/ui/http_stubs').to_s
+    end
+
     unless CDO.chef_managed
       # Only Chef-managed environments run an HTTP-cache service alongside the Rack app.
       # For other environments (development / CI), run the HTTP cache from Rack middleware.

--- a/dashboard/test/ui/features/http_stubbing.feature
+++ b/dashboard/test/ui/features/http_stubbing.feature
@@ -1,0 +1,33 @@
+Feature: HTTP stubbing
+  Scenario: Stub external HTTP requests within Studio
+    Given I am on "http://studio.code.org/reset_session"
+
+    When I use a cookie to stub matching HTTP requests from the "http_stubbing_test" fixture:
+      | get  | https\:\/\/request1\/\?param\=test |           |
+      | post | https\:\/\/request2\/\?param\=test | "WebMock" |
+    And I am on "http://studio.code.org/api/test/get_http_stubs"
+    Then response json key "response1" has value ""VCR""
+    And response json key "response2" has value ""WebMock""
+    And response json key "response3" has value ""real""
+
+    When I use a cookie to stub matching HTTP requests from the "http_stubbing_test" fixture:
+      | post | https\:\/\/request2\/\?param\=test |           |
+      | get  | https\:\/\/request3\/\?param\=test | "WebMock" |
+    And I am on "http://studio.code.org/api/test/get_http_stubs"
+    Then response json key "response1" has value ""real""
+    And response json key "response2" has value ""VCR""
+    And response json key "response3" has value ""WebMock""
+
+    When I use a cookie to stub matching HTTP requests from the "http_stubbing_test" fixture:
+      | get | https\:\/\/request1\/\?param\=test | "WebMock" |
+      | get | https\:\/\/request3\/\?param\=test |           |
+    And I am on "http://studio.code.org/api/test/get_http_stubs"
+    Then response json key "response1" has value ""WebMock""
+    And response json key "response2" has value ""real""
+    And response json key "response3" has value ""VCR""
+
+    When I delete the cookie named "http_stub"
+    And I am on "http://studio.code.org/api/test/get_http_stubs"
+    Then response json key "response1" has value ""real""
+    And response json key "response2" has value ""real""
+    And response json key "response3" has value ""real""

--- a/dashboard/test/ui/features/step_definitions/http_stub_steps.rb
+++ b/dashboard/test/ui/features/step_definitions/http_stub_steps.rb
@@ -1,0 +1,21 @@
+require 'cgi'
+require 'json'
+
+require 'cdo/rack/http_stub'
+
+Given(/^I use a cookie to stub matching HTTP requests from the "(.*)" fixture:$/) do |name, stubs|
+  name = CGI.escape(name)
+
+  stubs = stubs.raw.map do |(method, pattern, value)|
+    {}.tap do |stub|
+      stub[:method]  = method
+      stub[:pattern] = CGI.escape(Regexp.escape(pattern))
+      stub[:value]   = JSON.parse(value) if value.present?
+    end
+  end
+
+  add_cookie Rack::HttpStub::COOKIE_KEY, JSON.dump(name:, stubs:)
+rescue Selenium::WebDriver::Error::InvalidCookieDomainError
+  warn red("WARNING: First, navigate the page for which domain you want to stub the HTTP requests `#{name}`")
+  raise
+end

--- a/dashboard/test/ui/features/support/cookie_helpers.rb
+++ b/dashboard/test/ui/features/support/cookie_helpers.rb
@@ -31,6 +31,16 @@ module CookieHelpers
     encryptor.decrypt_and_verify(message)
   end
 
+  def add_cookie(key, value)
+    current_host = URI(@browser.current_url.to_s).host
+    current_domain = current_host && PublicSuffix.parse(current_host).domain
+
+    cookie = {name: key, value: value, path: '/'}
+    cookie[:domain] = ".#{current_domain}" if current_domain # sets the cookie for the top-level domain
+
+    @browser.manage.add_cookie(cookie)
+  end
+
   # It's safer to retrieve a cookie from the list of all cookies
   # because `#cookie_named` may raise `Selenium::WebDriver::Error::UnknownMethodError` during mobile testing.
   def get_cookie(key)

--- a/dashboard/test/ui/features/support/dashboard_helpers.rb
+++ b/dashboard/test/ui/features/support/dashboard_helpers.rb
@@ -25,13 +25,7 @@ module DashboardHelpers
     dcdo_cookie_value = JSON.parse(get_cookie(Rack::CookieDCDO::KEY).try(:[], :value).presence || '{}')
     dcdo_cookie_value[key] = value
 
-    current_host = URI(@browser.current_url.to_s).host
-    current_domain = current_host && PublicSuffix.parse(current_host).domain
-
-    dcdo_cookie = {name: Rack::CookieDCDO::KEY, value: dcdo_cookie_value.to_json, path: '/'}
-    dcdo_cookie[:domain] = ".#{current_domain}" if current_domain # sets the cookie for the top-level domain
-
-    @browser.manage.add_cookie(dcdo_cookie)
+    add_cookie(Rack::CookieDCDO::KEY, dcdo_cookie_value.to_json)
   rescue Selenium::WebDriver::Error::InvalidCookieDomainError
     warn red("WARNING: First, navigate the page for which domain you want to mock the DCDO `#{key}`")
     raise

--- a/dashboard/test/ui/http_stubs/http_stubbing_test.yml
+++ b/dashboard/test/ui/http_stubs/http_stubbing_test.yml
@@ -1,0 +1,52 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://request1/?param=test
+    body:
+      encoding: US-ASCII
+      string: ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type: application/json
+    body:
+      encoding: UTF-8
+      string: '"VCR"'
+  recorded_at: Wed, 21 Oct 2025 00:00:00 GMT
+- request:
+    method: post
+    uri: https://request2/?param=test
+    body:
+      encoding: UTF-8
+      string: fake_params
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type: application/json
+    body:
+      encoding: UTF-8
+      string: '"VCR"'
+  recorded_at: Wed, 21 Oct 2025 00:00:01 GMT
+- request:
+    method: get
+    uri: https://request3/?param=test
+    body:
+      encoding: US-ASCII
+      string: ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type: application/json
+    body:
+      encoding: UTF-8
+      string: '"VCR"'
+  recorded_at: Wed, 21 Oct 2025 00:00:02 GMT
+recorded_with: VCR 6.2.0
+...

--- a/lib/cdo/http_cache.rb
+++ b/lib/cdo/http_cache.rb
@@ -124,6 +124,12 @@ class HttpCache
     require 'cdo/rack/global_edition'
     default_cookies << Rack::GlobalEdition::REGION_KEY
 
+    # Enables HTTP request stubbing with VCR and WebMock, using cookie data for configuration. See: Rack::HttpStub
+    if CDO.http_stub_enabled
+      require 'cdo/rack/http_stub'
+      default_cookies << Rack::HttpStub::COOKIE_KEY
+    end
+
     # These cookies are allowlisted on all session-specific (not cached) pages.
     allowlisted_cookies = [
       'hour_of_code',

--- a/lib/cdo/rack/http_stub.rb
+++ b/lib/cdo/rack/http_stub.rb
@@ -1,0 +1,117 @@
+# frozen_string_literal: true
+
+require 'active_support'
+require 'json'
+
+module Rack
+  # Middleware for stubbing HTTP requests using VCR and WebMock based on cookie data.
+  #
+  # It uses VCR to record and replay HTTP interactions,
+  # and WebMock to stub requests and return expected value.
+  #
+  # Cookie-driven behavior:
+  # The middleware looks for a cookie keyed by COOKIE_KEY (default: "http_stub").
+  # If present, it must contain a JSON object with the following structure:
+  #
+  # {
+  #   "name": "cassette_identifier",    # String. Name of the VCR cassette to use.
+  #   "stubs": [                        # Array of per-request stub definitions.
+  #     {
+  #       "method": "get",              # String. HTTP method (case-insensitive).
+  #       "pattern": "escaped_regex",   # String. CGI-escaped, Regexp-escaped pattern matched against full request URI.
+  #       "value": { ... }              # Optional JSON value returned as the stubbed response body.
+  #     },
+  #     {
+  #       "method": "get",
+  #       "pattern": "escaped_regex"    # If no "value" key, the real request response will be stored in VCR cassette.
+  #     }
+  #   ]
+  # }
+  #
+  # Notes on fields:
+  # - pattern: Produced by Regexp.escape and then CGI.escape when set (see test step definitions).
+  #            At match time we wrap it in a Regexp (`%r[#{stub['pattern']}]`) so it should represent
+  #            the raw (unescaped) content once decoded. The cookie stores the escaped form.
+  # - value: When present, the request is fully stubbed via WebMock and never reaches VCR.
+  #          The response content-type is application/json and body is JSON.dump(value).
+  # - Missing or empty cookie / missing "name" / empty "stubs" => middleware is a no-op.
+  #
+  # Example cookie value (URL-decoding applied for readability):
+  # {
+  #   "name": "users_index",
+  #   "stubs": [
+  #     {
+  #       "method": "get",
+  #       "pattern": "^https:\/\/api\.example\.com\/users$",
+  #       "value": {"users": [{"id":1,"name":"Artem"}]}
+  #     }
+  #   ]
+  # }
+  #
+  # @note This middleware is intended for testing purposes only.
+  # @see `dashboard/test/ui/features/http_stubbing.feature`
+  class HttpStub
+    COOKIE_KEY = 'http_stub'
+
+    def initialize(app, fixtures_dir:)
+      @app = app
+      @fixtures_dir = fixtures_dir
+    end
+
+    def call(env)
+      stub_requests(env) do
+        @app.call(env)
+      end
+    end
+
+    private def stub_requests(env, &)
+      request = Request.new(env)
+
+      cassette_name, request_stubs = JSON.parse(request.cookies[COOKIE_KEY].presence || '{}')&.values_at('name', 'stubs')
+      return yield if cassette_name.blank? || request_stubs.blank?
+
+      require 'vcr'
+      require 'webmock'
+
+      # Sets up WebMock stubs for requests that include a predefined 'value'.
+      # These requests are intercepted and return the specified response
+      # instead of being executed and recorded by VCR.
+      request_stubs.each do |stub|
+        next unless stub.key?('value')
+
+        WebMock.stub_request(stub['method'].downcase.to_sym, %r[#{stub['pattern']}]).to_return(
+          headers: {'Content-Type' => 'application/json'},
+          body: JSON.dump(stub['value']),
+        )
+      end
+
+      # Reset VCR configs and hooks to ensure a clean state.
+      VCR.send(:initialize_ivars)
+
+      # Records and replays all requests that match the cookie data,
+      # except those intercepted by the WebMock stubs defined above.
+      VCR.use_cassette(cassette_name, record: :new_episodes) do
+        VCR.configure do |config|
+          config.cassette_library_dir = @fixtures_dir
+          config.hook_into :webmock
+          config.allow_http_connections_when_no_cassette = true
+          config.debug_logger = $stdout if rack_env?(:development)
+
+          config.before_record do |interaction|
+            interaction.request.headers = {}
+          end
+
+          config.ignore_request do |stubbed_request|
+            request_stubs.none? do |stub|
+              stubbed_request.method.to_s.casecmp?(stub['method']) && stubbed_request.uri.match?(%r[#{stub['pattern']}])
+            end
+          end
+        end
+
+        yield
+      end
+    ensure
+      WebMock.reset!
+    end
+  end
+end


### PR DESCRIPTION
### Summary

This PR introduces a Rack middleware `Rack::HttpStub` that integrates **VCR** and **WebMock** to enable **cookie-driven** HTTP stubbing/recording within Studio for testing purposes only.

### How it works

* Middleware: `lib/cdo/rack/http_stub.rb`

  * **WebMock** intercepts requests that have a predefined `value` and returns it without hitting the network.
  * **VCR** records/replays other matching requests into a named cassette (`record: :new_episodes`).
  * Request headers are stripped before recording to avoid leaking secrets.
  * No cookie / empty config ⇒ middleware is a no-op.
* Cookie format (`http_stub`), URL-decoded for clarity:

  ```json
  {
    "name": "cassette_identifier",
    "stubs": [
      {
        "method": "get",
        "pattern": "^https://api\\.example\\.com/users$",
        "value": {"users": [{"id":1,"name":"Artem"}]}
      },
      {
        "method": "post",
        "pattern": "^https://api\\.example\\.com/login$"
      }
    ]
  }
  ```

  * `value` present ⇒ fully stubbed by WebMock (JSON response, no VCR entry).
  * `value` absent ⇒ real response is recorded/replayed by VCR.
  * `pattern` is a regexp (escaped when stored in the cookie) matched against the **full URI**.
