### PR TITLE
[Lab2] Resolves WCAG violation for Extra Links Button

### DIFF
--- a/apps/i18n/lab2/en_us.json
+++ b/apps/i18n/lab2/en_us.json
@@ -10,6 +10,7 @@
   "error": "Error",
   "expand": "Expand",
   "expectedFailure": "Expected failure",
+  "extraLinks": "Extra links",
   "fail": "Fail",
   "forTeachersOnly": "For Teachers Only",
   "informationPanelDropdown": "Information panel dropdown",

--- a/apps/i18n/lab2/en_us.json
+++ b/apps/i18n/lab2/en_us.json
@@ -10,7 +10,7 @@
   "error": "Error",
   "expand": "Expand",
   "expectedFailure": "Expected failure",
-  "extraLinks": "Extra links",
+  "extraLinks": "Extra Links",
   "fail": "Fail",
   "forTeachersOnly": "For Teachers Only",
   "informationPanelDropdown": "Information panel dropdown",

--- a/apps/src/lab2/views/components/Instructions/ResourcePanel/ResourcePanelExtraLinks.tsx
+++ b/apps/src/lab2/views/components/Instructions/ResourcePanel/ResourcePanelExtraLinks.tsx
@@ -2,6 +2,7 @@ import {Theme} from '@code-dot-org/component-library/common/contexts';
 import React, {useState} from 'react';
 
 import {useExtraLinks} from '@cdo/apps/lab2/hooks/useExtraLinks';
+import lab2I18n from '@cdo/apps/lab2/locale';
 import ExtraLinksModal from '@cdo/apps/lab2/views/ExtraLinksModal';
 
 import ButtonWithDialog from './ButtonWithDialog';
@@ -35,6 +36,7 @@ const ResourcePanelExtraLinks: React.FunctionComponent<
   return (
     <ButtonWithDialog
       text={'Extra Links'}
+      ariaLabel={lab2I18n.extraLinks()}
       id={'extra-links'}
       theme={theme}
       Dialog={innerDialog}


### PR DESCRIPTION
This adds an aria label to the extra links button to resolve a WCAG violation.

For future work, we should figure out a way to resolve the errors of icon only buttons that utilize tooltips, as they either read on a screenreader only once but violate wcag, or we fix the wcag violations and the screenreader reads both the tooltip text and the aria label. 

## Links

- Jira: https://codedotorg.atlassian.net/browse/SL-1460

## Testing story
<!--  Does your change include appropriate tests?
      - If so, please describe how the tests included in this PR are sufficient.
      - If not, please explain why this change does not need to be tested. -->



## Deployment strategy
<!--  Any special steps required to deploy this, besides merging?
      - Are there database migrations or manual steps?
      - Does this require coordination with other teams or systems? -->



## Follow-up work
<!--  List any clean-up or technical debt that will be addressed in future work.
      - Include Jira links where applicable.
      - Are there any known limitations or improvements planned? -->



## Privacy
<!--  How does this change impact Student & Teacher privacy?
      - Does this collect, use, share, or modify PII, either new or existing? -->



## Security
<!--  How does this change impact our security surface-area?
      - Do API's touched have the right auth?
      - Do infra changes impact our attack surface or encryption?
-->



## Caching
<!--  How does this change impact caching behavior?
      - Are cache keys or invalidation strategies affected?
      - Will this require cache warming or invalidation after deployment? -->



## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
