### PR TITLE
AI Chat: remove extra space at bottom of code snippet in chat message

### DIFF
--- a/apps/src/aiComponentLibrary/copyableCodeBlock/copyable-code-block.module.scss
+++ b/apps/src/aiComponentLibrary/copyableCodeBlock/copyable-code-block.module.scss
@@ -1,10 +1,11 @@
 .codeBlock {
-  margin: .6rem 0;
+  margin: 0.6rem 0;
   border-radius: 4px;
   border: 2px solid var(--borders-neutral-primary);
   overflow: hidden;
+  background-color: var(--background-neutral-primary);
 
-  >.header {
+  > .header {
     display: flex;
     flex-direction: row;
     justify-content: end;
@@ -12,28 +13,28 @@
     padding: 4px 4px 5px 4px;
 
     // Add multiple class names to override Component Library specificity.
-    >.copyButton.copyButton {
+    > .copyButton.copyButton {
       border: var(--borders-neutral-primary) solid 1px;
     }
   }
 
-
   .codeContentBody {
     position: relative;
     width: 100%;
-    display: inline-block;
+    padding-bottom: 0.5rem;
     max-height: 400px;
     overflow: auto;
 
-    >.codeContent {
+    > .codeContent {
       margin: 0;
+      padding-bottom: 0;
       border-radius: 0;
       border: none;
       background-color: var(--background-neutral-primary);
       color: var(--text-neutral-primary);
     }
 
-    >.codeContentOverlay {
+    > .codeContentOverlay {
       position: absolute;
       transition: opacity 1s ease;
       top: 0;
@@ -53,26 +54,26 @@
         pointer-events: unset;
       }
 
-      >.codeContentOverlayBackground {
+      > .codeContentOverlayBackground {
         width: 100%;
         height: 100%;
         background-color: var(--neutral-base-black);
         opacity: 0.9;
       }
 
-      >.codeContentAriaMessage {
+      > .codeContentAriaMessage {
         opacity: 0;
       }
 
-      >.codeContentOverlayMessage {
+      > .codeContentOverlayMessage {
         position: absolute;
         top: 50%;
         left: 50%;
         transform: translate(-50%, -50%);
 
-        >.checkMarkIcon {
+        > .checkMarkIcon {
           color: var(--sentiment-success-50);
-          margin-right: .2rem;
+          margin-right: 0.2rem;
         }
       }
     }


### PR DESCRIPTION
Removes empty extra space at the bottom of a code snippet in AI Chat. _Reviewer note:_ there are lots of whitespace changes bc of the linter, feel free to hide!

## Links
Jira ticket: [AFL-321](https://codedotorg.atlassian.net/browse/AFL-321)

## Testing story
Tested locally

----

## Before
| Light | Dark |
| ---- | ---- |
| <img width="410" height="776" alt="Screenshot 2025-10-24 at 11 36 14 AM" src="https://github.com/user-attachments/assets/766cb8c2-f86e-4ff1-a3ff-1de09e16fe74" /> | <img width="410" height="776" alt="Screenshot 2025-10-24 at 11 36 21 AM" src="https://github.com/user-attachments/assets/67060085-a5c4-4c77-a2c7-c46cb5f7cf13" /> |

## After
| Light | Dark |
| ---- | ---- |
| <img width="410" height="776" alt="After_Light" src="https://github.com/user-attachments/assets/6e0a35b8-c01b-4b4c-ab56-c58311da87a1" /> | <img width="410" height="776" alt="After_Dark" src="https://github.com/user-attachments/assets/c93c2dbe-fbb4-4a02-9da9-22d68d2945ac" /> |

