### PR TITLE
hoai2025: freeplay tabbed experience

### DIFF
--- a/apps/script/generateSharedConstants.rb
+++ b/apps/script/generateSharedConstants.rb
@@ -123,6 +123,7 @@ def main
       RESOURCE_EMBEDDABILITY_OPTIONS
       AI_DIFF_CONTEXT
       DISALLOWED_ROUTES
+      BUBBLE_CHOICE_CUSTOM_MODES
     ),
     file_type: 'ts'
   )

--- a/apps/src/bubbleChoice/BubbleChoice.tsx
+++ b/apps/src/bubbleChoice/BubbleChoice.tsx
@@ -9,28 +9,27 @@ import classNames from 'classnames';
 import _ from 'lodash';
 import React, {useEffect, useMemo, useRef} from 'react';
 
-import {
-  navigateToLevelId,
-  setCurrentLevelId,
-} from '@cdo/apps/code-studio/progressRedux';
 import {levelById} from '@cdo/apps/code-studio/progressReduxSelectors';
 import continueOrFinishLesson from '@cdo/apps/lab2/progress/continueOrFinishLesson';
-import {
-  LabProps,
-  BubbleChoiceLevelData,
-  BubbleChoiceSublevel,
-} from '@cdo/apps/lab2/types';
+import {BubbleChoiceLevelData, LabProps} from '@cdo/apps/lab2/types';
 import EnhancedSafeMarkdown from '@cdo/apps/templates/EnhancedSafeMarkdown';
 import ProgressBubble from '@cdo/apps/templates/progress/ProgressBubble';
 import {useAppDispatch, useAppSelector} from '@cdo/apps/util/reduxHooks';
-import {LevelStatus} from '@cdo/generated-scripts/sharedConstants';
+import {
+  BubbleChoiceCustomModes,
+  LevelStatus,
+} from '@cdo/generated-scripts/sharedConstants';
 
-import notifyLevelChange from '../lab2/utils/notifyLevelChange';
 import {commonI18n} from '../types/locale';
+
+import {BubbleChoiceLevelProperties} from './types';
+import useNavigateToSublevel from './useNavigateToSublevel';
 
 import styles from './BubbleChoice.module.scss';
 
-const BubbleChoice: React.FC<LabProps> = ({levelProperties}) => {
+const BubbleChoice: React.FC<LabProps<BubbleChoiceLevelProperties>> = ({
+  levelProperties,
+}) => {
   // The image has a 4:3 aspect ratio.
   const imageAspectRatio = 4 / 3;
 
@@ -52,9 +51,6 @@ const BubbleChoice: React.FC<LabProps> = ({levelProperties}) => {
           sublevel.level_id
         )?.status || LevelStatus.not_tried
     )
-  );
-  const currentLessonId = useAppSelector(
-    state => state.progress.currentLessonId
   );
 
   const [containerWidth, setContainerWidth] = React.useState(0);
@@ -127,21 +123,36 @@ const BubbleChoice: React.FC<LabProps> = ({levelProperties}) => {
     return level;
   };
 
-  const navigateToSublevel = (sublevel: BubbleChoiceSublevel) => {
-    if (currentLessonId) {
-      dispatch(navigateToLevelId(sublevel.level_id));
-    } else if (levelProperties.isProjectLevel) {
-      // For BubbleChoice project levels, set the level ID in redux, and let the
-      // MultiProjectContainer handle switching projects. The standard progress redux
-      // system does not work for project levels since there is no progress, lesson, etc.
-      dispatch(setCurrentLevelId(sublevel.level_id));
-      // TODO: This is a dupe of code in navigateToLevelId(). Can we consolidate?
-      notifyLevelChange(String(levelProperties.id), sublevel.level_id);
-      // TODO: Handle browser navigation.
-    } else {
-      window.location.href = sublevel.url;
+  const navigateToSublevel = useNavigateToSublevel();
+
+  const onSingleLevel = useAppSelector(
+    ({progress}) =>
+      progress.currentLevelId &&
+      !progress.currentLessonId &&
+      !levelProperties.isProjectLevel
+  );
+  useEffect(() => {
+    if (
+      !onSingleLevel &&
+      levelProperties.customMode === BubbleChoiceCustomModes.MUSIC_DANCE_AI
+    ) {
+      // Navigate directly to the first available sublevel in the custom Music Dance AI mode.
+      navigateToSublevel(levelProperties, levelBubbleChoice.sublevels[0]);
     }
-  };
+  }, [
+    onSingleLevel,
+    levelProperties,
+    levelBubbleChoice.sublevels,
+    navigateToSublevel,
+  ]);
+
+  if (
+    !onSingleLevel &&
+    levelProperties.customMode === BubbleChoiceCustomModes.MUSIC_DANCE_AI
+  ) {
+    // In Music Dance AI custom mode, we immediately navigate to the first sublevel so there's nothing to render.
+    return null;
+  }
 
   return (
     <div id="bubble-choice" className={styles.bubbleChoiceContainer}>
@@ -178,7 +189,7 @@ const BubbleChoice: React.FC<LabProps> = ({levelProperties}) => {
                 width: imageWidth,
                 height: imageWidth / aspectRatio,
               }}
-              onClick={() => navigateToSublevel(sublevel)}
+              onClick={() => navigateToSublevel(levelProperties, sublevel)}
             >
               <div
                 className={styles.sublevelImageContainer}

--- a/apps/src/bubbleChoice/customModes/MusicDanceAi/ModeSwitchBar.tsx
+++ b/apps/src/bubbleChoice/customModes/MusicDanceAi/ModeSwitchBar.tsx
@@ -1,0 +1,200 @@
+import FontAwesomeV6Icon from '@code-dot-org/component-library/fontAwesomeV6Icon';
+import {BodyThreeText} from '@code-dot-org/component-library/typography';
+import classNames from 'classnames';
+import React, {useCallback, useEffect, useState} from 'react';
+
+import {
+  getCurrentLesson,
+  getCurrentLevel,
+  levelById,
+} from '@cdo/apps/code-studio/progressReduxSelectors';
+import {DanceLevelProperties} from '@cdo/apps/dance/types';
+import {setIsLoading} from '@cdo/apps/lab2/lab2Redux';
+import {useMultiProject} from '@cdo/apps/lab2/projects/MultiProjectContainer';
+import {
+  BubbleChoiceLevelData,
+  BubbleChoiceSublevel,
+  LevelProperties,
+} from '@cdo/apps/lab2/types';
+import LevelPropertiesCache from '@cdo/apps/lab2/utils/LevelPropertiesCache';
+import HttpClient from '@cdo/apps/util/HttpClient';
+import {useAppDispatch, useAppSelector} from '@cdo/apps/util/reduxHooks';
+import {BubbleChoiceCustomModes} from '@cdo/generated-scripts/sharedConstants';
+
+import {BubbleChoiceLevelProperties} from '../../types';
+import useNavigateToSublevel from '../../useNavigateToSublevel';
+
+import styles from './styles.module.scss';
+
+// This is somewhat redundant with how Lab2 already loads level properties,
+// but we need a way to verify the parent's level properties and pre-load
+// all child level properties so we know which level is which.
+// Ideally, Lab2 should just pre-load level properties for all levels in a
+// lesson progression since it's all static.
+async function loadLevelProperties(
+  levelId: string,
+  pathPrefix?: string,
+  sublevelPosition?: number
+) {
+  const cached = LevelPropertiesCache.getById(parseInt(levelId));
+  if (cached) {
+    return cached;
+  }
+  const path = pathPrefix
+    ? `${pathPrefix}${
+        sublevelPosition ? `/sublevel/${sublevelPosition}` : ''
+      }/level_properties`
+    : `/levels/${levelId}/level_properties`;
+  const {value} = await HttpClient.fetchJson<LevelProperties>(path);
+  LevelPropertiesCache.set(path, value);
+  return value;
+}
+
+enum Tab {
+  Dancer = 'Dancer',
+  Music = 'Music',
+  Dance = 'Dance',
+}
+
+const labels: {[tab in Tab]: string} = {
+  [Tab.Dancer]: 'Create Dancer',
+  [Tab.Music]: 'Create Music',
+  [Tab.Dance]: 'Dance Party',
+};
+
+/**
+ * A custom component used for the custom Music Dance AI mode in BubbleChoice levels.
+ * It pre-loads level properties for all sublevels, and displays a mode switcher bar
+ * that allows users to switch between different sublevels without navigating back
+ * to the parent bubble choice project.
+ * Note that this could be genericized if we'd like to reuse it for other custom bubble choice modes.
+ */
+const ModeSwitchBar: React.FC<{levelId: number}> = ({levelId}) => {
+  const dispatch = useAppDispatch();
+  const multiProject = useMultiProject();
+  const progressParentLevelId: string | undefined = useAppSelector(
+    state => getCurrentLevel(state)?.parentLevelId
+  );
+
+  const parentLevelId =
+    (progressParentLevelId && progressParentLevelId) ||
+    multiProject?.parentLevelId?.toString();
+
+  const [sublevelMap, setSublevelMap] =
+    useState<{[tab in Tab]?: BubbleChoiceSublevel}>();
+
+  const levelPropertiesPathPrefix = useAppSelector(state => {
+    if (parentLevelId && state.progress.lessons) {
+      const scriptName = state.progress.scriptName;
+      const lessonPosition = getCurrentLesson(state)?.relative_position;
+      const currentLevel = levelById(
+        state.progress,
+        state.progress.currentLessonId,
+        parentLevelId
+      );
+      return `/s/${scriptName}/lessons/${lessonPosition}/levels/${currentLevel.levelNumber}`;
+    }
+  });
+
+  const setupLevels = useCallback(async () => {
+    if (parentLevelId === undefined) {
+      setSublevelMap(undefined);
+      return;
+    }
+
+    dispatch(setIsLoading(true));
+
+    // Fetch parent level properties first
+    const parentProperties = await loadLevelProperties(
+      parentLevelId,
+      levelPropertiesPathPrefix
+    );
+
+    if (
+      parentProperties.appName === 'bubble_choice' &&
+      (parentProperties as BubbleChoiceLevelProperties).customMode ===
+        BubbleChoiceCustomModes.MUSIC_DANCE_AI
+    ) {
+      const sublevels = (parentProperties.levelData as BubbleChoiceLevelData)
+        ?.sublevels;
+
+      if (!sublevels) {
+        dispatch(setIsLoading(false));
+        return;
+      }
+
+      const sublevelMap: {[tab in Tab]?: BubbleChoiceSublevel} = {};
+      // Go ahead and fetch all child level properties so we know which level is which.
+      // In subsequent navigations, these should be cached.
+      for (const sublevel of sublevels) {
+        const properties = await loadLevelProperties(
+          sublevel.level_id,
+          levelPropertiesPathPrefix,
+          sublevel.position
+        );
+        if (properties.appName === 'music') {
+          sublevelMap[Tab.Music] = sublevel;
+        }
+        if (properties.appName === 'dance') {
+          sublevelMap[
+            (properties as DanceLevelProperties).guideMode === 'aiCodeGenerate'
+              ? Tab.Dance
+              : Tab.Dancer
+          ] = sublevel;
+        }
+      }
+      setSublevelMap(sublevelMap);
+    }
+    dispatch(setIsLoading(false));
+  }, [dispatch, parentLevelId, levelPropertiesPathPrefix]);
+
+  useEffect(() => {
+    setupLevels();
+  }, [setupLevels]);
+
+  const navigateToSublevel = useNavigateToSublevel();
+
+  if (!parentLevelId || !sublevelMap) {
+    return null;
+  }
+
+  const parentLevelProperties = LevelPropertiesCache.getById(
+    parseInt(parentLevelId)
+  );
+  if (!parentLevelProperties) {
+    console.error('Invalid state: missing parent level properties');
+    return null;
+  }
+
+  return (
+    <div className={styles.container}>
+      {Object.values(Tab).map(tab => {
+        const sublevel = sublevelMap[tab];
+        return (
+          <button
+            type="button"
+            className={classNames(
+              styles.button,
+              !sublevel && styles.locked,
+              levelId.toString() === sublevel?.level_id && styles.selected
+            )}
+            key={tab}
+            onClick={() =>
+              !sublevel
+                ? undefined
+                : navigateToSublevel(parentLevelProperties, sublevel)
+            }
+            disabled={!sublevel}
+          >
+            <BodyThreeText>
+              {!sublevel && <FontAwesomeV6Icon iconName={'lock'} />}
+              {labels[tab]}
+            </BodyThreeText>
+          </button>
+        );
+      })}
+    </div>
+  );
+};
+
+export default ModeSwitchBar;

--- a/apps/src/bubbleChoice/customModes/MusicDanceAi/styles.module.scss
+++ b/apps/src/bubbleChoice/customModes/MusicDanceAi/styles.module.scss
@@ -1,0 +1,40 @@
+@import '../../../mixins.scss';
+@import 'color.scss';
+
+.container {
+  display: flex;
+  background-color: var(--background-neutral-secondary);
+  padding: 4px;
+  border-bottom: 1px solid var(--borders-neutral-primary);
+}
+
+.button {
+  @include remove-button-styles;
+  padding: 4px;
+  flex: 1;
+
+  > p {
+    margin: 0;
+  }
+
+  &.selected {
+    background-color: var(--background-neutral-primary-inverse);
+    font-weight: bold;
+    border-radius: 20px;
+    padding: 4px;
+
+    > p {
+      color: var(--text-neutral-primary-inverse);
+    }
+  }
+
+  &.locked {
+    cursor: not-allowed;
+    > p {
+      color: var(--text-neutral-disabled);
+      > i {
+        margin-right: 8px;
+      }
+    }
+  }
+}

--- a/apps/src/bubbleChoice/types.ts
+++ b/apps/src/bubbleChoice/types.ts
@@ -1,0 +1,8 @@
+import {BubbleChoiceCustomModes} from '@cdo/generated-scripts/sharedConstants';
+
+import {LevelProperties} from '../lab2/types';
+import {ValueOf} from '../types/utils';
+
+export interface BubbleChoiceLevelProperties extends LevelProperties {
+  customMode?: ValueOf<typeof BubbleChoiceCustomModes>;
+}

--- a/apps/src/bubbleChoice/useNavigateToSublevel.ts
+++ b/apps/src/bubbleChoice/useNavigateToSublevel.ts
@@ -1,0 +1,39 @@
+import {useCallback} from 'react';
+
+import {
+  navigateToLevelId,
+  setCurrentLevelId,
+} from '../code-studio/progressRedux';
+import {BubbleChoiceSublevel, LevelProperties} from '../lab2/types';
+import notifyLevelChange from '../lab2/utils/notifyLevelChange';
+import {useAppDispatch, useAppSelector} from '../util/reduxHooks';
+
+export default function useNavigateToSublevel() {
+  const dispatch = useAppDispatch();
+  const currentLessonId = useAppSelector(
+    state => state.progress.currentLessonId
+  );
+  const currentLevelId = useAppSelector(state => state.progress.currentLevelId);
+
+  return useCallback(
+    (
+      parentLevelProperties: LevelProperties,
+      sublevel: BubbleChoiceSublevel
+    ) => {
+      if (currentLessonId) {
+        dispatch(navigateToLevelId(sublevel.level_id));
+      } else if (parentLevelProperties.isProjectLevel) {
+        // For BubbleChoice project levels, set the level ID in redux, and let the
+        // MultiProjectContainer handle switching projects. The standard progress redux
+        // system does not work for project levels since there is no progress, lesson, etc.
+        dispatch(setCurrentLevelId(sublevel.level_id));
+        // TODO: This is a dupe of code in navigateToLevelId(). Can we consolidate?
+        notifyLevelChange(currentLevelId, sublevel.level_id);
+        // TODO: Handle browser navigation.
+      } else {
+        window.location.href = sublevel.url;
+      }
+    },
+    [currentLessonId, currentLevelId, dispatch]
+  );
+}

--- a/apps/src/dance/lab2/views/DanceView.tsx
+++ b/apps/src/dance/lab2/views/DanceView.tsx
@@ -25,7 +25,7 @@ import {
   getToolboxDefinition,
   workspaceToToolboxDefinition,
 } from '@cdo/apps/blockly/utils/toolbox';
-import BackToParentProject from '@cdo/apps/bubbleChoice/BackToParentProject';
+import ModeSwitchBar from '@cdo/apps/bubbleChoice/customModes/MusicDanceAi/ModeSwitchBar';
 import {saveReplayLog} from '@cdo/apps/code-studio/components/shareDialogRedux';
 import {queryParams} from '@cdo/apps/code-studio/utils';
 import defaultSources from '@cdo/apps/dance/blockly/defaultSources.json';
@@ -523,134 +523,129 @@ const DanceView: React.FunctionComponent<{
 
   return (
     <div id="dance-lab" className={moduleStyles.danceLab}>
-      {!getIsShareView() && <AgeDialog turnOffFilter={turnOffFilter} />}
-      {!guideMode && (
-        <ResourcePanel
-          isRunning={isRunning}
-          hasRun={hasRun}
-          hasEdited={hasEdited}
-          levelProperties={levelProperties}
-          headerClassName={moduleStyles.panelHeader}
-          className={moduleStyles.instructionsArea}
-          settings={settings}
-        />
-      )}
-      <div className={moduleStyles.divider} />
-      {!isToolboxMode && (
+      <ModeSwitchBar levelId={levelProperties.id} />
+      <div className={moduleStyles.mainContent}>
+        {!getIsShareView() && <AgeDialog turnOffFilter={turnOffFilter} />}
+        {!guideMode && (
+          <ResourcePanel
+            isRunning={isRunning}
+            hasRun={hasRun}
+            hasEdited={hasEdited}
+            levelProperties={levelProperties}
+            headerClassName={moduleStyles.panelHeader}
+            className={moduleStyles.instructionsArea}
+            settings={settings}
+          />
+        )}
+        <div className={moduleStyles.divider} />
+        {!isToolboxMode && (
+          <PanelContainer
+            id="visualization"
+            headerContent="Dance Party!"
+            headerClassName={moduleStyles.panelHeader}
+            className={classNames(
+              moduleStyles.visualizationArea,
+              guideMode && moduleStyles.jumbo
+            )}
+          >
+            <div className={moduleStyles.visualizationColumn}>
+              {!usingMusicProject && currentSources.selectedSong && (
+                <SongSelector
+                  enableSongSelection={!isRunning}
+                  setSong={onSetSong}
+                  selectedSong={currentSources.selectedSong}
+                  songData={songData}
+                  filterOn={filterOn}
+                  levelIsRunning={isRunning}
+                />
+              )}
+              {usingMusicProject &&
+                (loadedMusicProject && metadataToUse ? (
+                  <MusicProjectBar title={metadataToUse.title} />
+                ) : (
+                  // Temp UI
+                  'Loading your Music Lab project...'
+                ))}
+              <div
+                id={DANCE_VISUALIZATION_ID}
+                className={moduleStyles.visualization}
+              >
+                <div
+                  className={classNames(
+                    moduleStyles.loading,
+                    isLoading && moduleStyles.loadingShow
+                  )}
+                >
+                  <img
+                    src={loadingGif}
+                    className={moduleStyles.loadingGif}
+                    alt={danceI18n.dancePartyLoading()}
+                  />
+                </div>
+              </div>
+              <DanceControls
+                onRun={runProgram}
+                onReset={resetProgram}
+                disabled={(usingMusicProject && !loadedMusicProject) || false}
+              />
+            </div>
+          </PanelContainer>
+        )}
+        <div className={moduleStyles.divider} />
         <PanelContainer
-          id="visualization"
-          headerContent="Dance Party!"
+          id="dance-workspace-panel"
+          headerContent={commonI18n.workspaceHeaderShort()}
+          className={moduleStyles.workspaceArea}
           headerClassName={moduleStyles.panelHeader}
-          className={classNames(
-            moduleStyles.visualizationArea,
-            guideMode && moduleStyles.jumbo
-          )}
-          leftHeaderContent={
-            <BackToParentProject
-              text="Go to Hub"
-              iconLeft={{iconName: 'home'}}
-              type="secondary"
-              size="s"
-            />
+          rightHeaderContent={
+            !readonlyWorkspace && (
+              <Button
+                text={commonI18n.startOver()}
+                iconRight={{iconStyle: 'solid', iconName: 'refresh'}}
+                color={'black'}
+                onClick={onClickStartOver}
+                ariaLabel={commonI18n.startOver()}
+                size={'xs'}
+                type="secondary"
+              />
+            )
           }
         >
-          <div className={moduleStyles.visualizationColumn}>
-            {!usingMusicProject && currentSources.selectedSong && (
-              <SongSelector
-                enableSongSelection={!isRunning}
-                setSong={onSetSong}
-                selectedSong={currentSources.selectedSong}
-                songData={songData}
-                filterOn={filterOn}
-                levelIsRunning={isRunning}
-              />
-            )}
-            {usingMusicProject &&
-              (loadedMusicProject && metadataToUse ? (
-                <MusicProjectBar title={metadataToUse.title} />
-              ) : (
-                // Temp UI
-                'Loading your Music Lab project...'
-              ))}
-            <div
-              id={DANCE_VISUALIZATION_ID}
-              className={moduleStyles.visualization}
-            >
-              <div
-                className={classNames(
-                  moduleStyles.loading,
-                  isLoading && moduleStyles.loadingShow
-                )}
-              >
-                <img
-                  src={loadingGif}
-                  className={moduleStyles.loadingGif}
-                  alt={danceI18n.dancePartyLoading()}
-                />
-              </div>
-            </div>
-            <DanceControls
-              onRun={runProgram}
-              onReset={resetProgram}
-              disabled={(usingMusicProject && !loadedMusicProject) || false}
-            />
-          </div>
+          {WorkspaceAlert}
+          <div id={BLOCKLY_DIV_ID} />
         </PanelContainer>
-      )}
-      <div className={moduleStyles.divider} />
-      <PanelContainer
-        id="dance-workspace-panel"
-        headerContent={commonI18n.workspaceHeaderShort()}
-        className={moduleStyles.workspaceArea}
-        headerClassName={moduleStyles.panelHeader}
-        rightHeaderContent={
-          !readonlyWorkspace && (
-            <Button
-              text={commonI18n.startOver()}
-              iconRight={{iconStyle: 'solid', iconName: 'refresh'}}
-              color={'black'}
-              onClick={onClickStartOver}
-              ariaLabel={commonI18n.startOver()}
-              size={'xs'}
-              type="secondary"
-            />
-          )
-        }
-      >
-        {WorkspaceAlert}
-        <div id={BLOCKLY_DIV_ID} />
-      </PanelContainer>
-      {guideMode === 'instructions' && (
-        <GuideInstructions
-          isRunning={isRunning}
-          hasRun={hasRun}
-          hasEdited={hasEdited}
-          levelProperties={levelProperties}
-          width="narrow"
-        />
-      )}
-      {guideMode === 'aiCodeGenerate' && (
-        <Guide id="generate-panel" width="narrow">
-          {
-            <>
-              <div>
-                {generatedAiDance
-                  ? "Let's dance!"
-                  : "Now, let's generate a dance sequence to go with your song!"}
-              </div>
-              <Button
-                ariaLabel={'Generate dance'}
-                text={generatedAiDance ? 'Generate again!' : 'Generate dance'}
-                type="primary"
-                color="black"
-                size="s"
-                iconLeft={{iconName: 'sparkles'}}
-                onClick={generateAiDance}
-              />
-            </>
-          }
-        </Guide>
-      )}
+        {guideMode === 'instructions' && (
+          <GuideInstructions
+            isRunning={isRunning}
+            hasRun={hasRun}
+            hasEdited={hasEdited}
+            levelProperties={levelProperties}
+            width="narrow"
+          />
+        )}
+        {guideMode === 'aiCodeGenerate' && (
+          <Guide id="generate-panel" width="narrow">
+            {
+              <>
+                <div>
+                  {generatedAiDance
+                    ? "Let's dance!"
+                    : "Now, let's generate a dance sequence to go with your song!"}
+                </div>
+                <Button
+                  ariaLabel={'Generate dance'}
+                  text={generatedAiDance ? 'Generate again!' : 'Generate dance'}
+                  type="primary"
+                  color="black"
+                  size="s"
+                  iconLeft={{iconName: 'sparkles'}}
+                  onClick={generateAiDance}
+                />
+              </>
+            }
+          </Guide>
+        )}
+      </div>
     </div>
   );
 };

--- a/apps/src/dance/lab2/views/GenerateDancer.tsx
+++ b/apps/src/dance/lab2/views/GenerateDancer.tsx
@@ -2,7 +2,7 @@ import {Button} from '@code-dot-org/component-library/button';
 import {useTheme} from '@code-dot-org/component-library/common/contexts';
 import React, {useCallback, useEffect, useRef, useState} from 'react';
 
-import BackToParentProject from '@cdo/apps/bubbleChoice/BackToParentProject';
+import ModeSwitchBar from '@cdo/apps/bubbleChoice/customModes/MusicDanceAi/ModeSwitchBar';
 import {DanceLevelProperties} from '@cdo/apps/dance/types';
 import useLifecycleNotifier from '@cdo/apps/lab2/hooks/useLifecycleNotifier';
 import continueOrFinishLesson from '@cdo/apps/lab2/progress/continueOrFinishLesson';
@@ -173,126 +173,122 @@ const GenerateDancer: React.FunctionComponent<DancerGenerateProps> = ({
 
   return (
     <div id="dance-lab" className={moduleStyles.dancerGenerate}>
-      <Guide id="generate-panel" glowSpeed={glowSpeed}>
-        {(aiGenerateState === 'generating' ||
-          aiGenerateState === 'reviewing') && (
-          <div className={moduleStyles.textArea}>{promptText}</div>
-        )}
-        {aiGenerateState === 'none' && (
-          <>
-            {levelProperties.aiDancerGenerateText && (
-              <>
-                <div>Describe the dancer you'd like AI to create.</div>
-                <textarea
-                  id="generate-description"
-                  onChange={evt => {
-                    setPromptText(evt.target.value);
-                  }}
-                  value={promptText}
-                  rows={4}
-                  className={moduleStyles.textArea}
-                />
+      <ModeSwitchBar levelId={levelProperties.id} />
+      <div className={moduleStyles.mainContent}>
+        <Guide id="generate-panel" glowSpeed={glowSpeed}>
+          {(aiGenerateState === 'generating' ||
+            aiGenerateState === 'reviewing') && (
+            <div className={moduleStyles.textArea}>{promptText}</div>
+          )}
+          {aiGenerateState === 'none' && (
+            <>
+              {levelProperties.aiDancerGenerateText && (
+                <>
+                  <div>Describe the dancer you'd like AI to create.</div>
+                  <textarea
+                    id="generate-description"
+                    onChange={evt => {
+                      setPromptText(evt.target.value);
+                    }}
+                    value={promptText}
+                    rows={4}
+                    className={moduleStyles.textArea}
+                  />
+                  <Button
+                    ariaLabel={'Continue'}
+                    text={'Continue'}
+                    type="primary"
+                    color="black"
+                    size="s"
+                    iconRight={{iconName: 'arrow-right', iconStyle: 'solid'}}
+                    onClick={() => {
+                      dispatch(continueOrFinishLesson());
+                      analyticsReporter.sendEvent('hoai2025-dancer-prompt', {
+                        promptText,
+                      });
+                    }}
+                  />
+                </>
+              )}
+              {!levelProperties.aiDancerGenerateText && (
+                <>
+                  <Adlib
+                    adlib={adlibs[adlibOption]}
+                    onChange={(promptText, choices) => {
+                      setPromptText(promptText);
+                      setChoices(choices);
+                      variantHistory.current = [];
+                    }}
+                    className={moduleStyles.textArea}
+                  />
+                  <Button
+                    ariaLabel={'Generate dancer'}
+                    text={'Generate dancer'}
+                    type="primary"
+                    color="black"
+                    size="s"
+                    iconLeft={{iconName: 'sparkles'}}
+                    onClick={generateDancer}
+                  />
+                </>
+              )}
+            </>
+          )}
+
+          {aiGenerateState === 'generating' ? 'Generating a dancer...' : ''}
+
+          {aiGenerateState === 'reviewing' && (
+            <>
+              <div>Here is the dancer that was generated. Do you like it?</div>
+
+              <div className={moduleStyles.buttonRow}>
                 <Button
-                  ariaLabel={'Continue'}
-                  text={'Continue'}
+                  ariaLabel={"No. Let's try again."}
+                  text={"No. Let's try again."}
                   type="primary"
                   color="black"
                   size="s"
-                  iconRight={{iconName: 'arrow-right', iconStyle: 'solid'}}
-                  onClick={() => {
-                    dispatch(continueOrFinishLesson());
-                    analyticsReporter.sendEvent('hoai2025-dancer-prompt', {
-                      promptText,
-                    });
-                  }}
+                  onClick={() => setAiGenerateState('none')}
                 />
-              </>
-            )}
-            {!levelProperties.aiDancerGenerateText && (
-              <>
-                <Adlib
-                  adlib={adlibs[adlibOption]}
-                  onChange={(promptText, choices) => {
-                    setPromptText(promptText);
-                    setChoices(choices);
-                    variantHistory.current = [];
-                  }}
-                  className={moduleStyles.textArea}
-                />
+
                 <Button
-                  ariaLabel={'Generate dancer'}
-                  text={'Generate dancer'}
+                  ariaLabel={"Yes. Let's continue."}
+                  text={"Yes. Let's continue."}
                   type="primary"
                   color="black"
                   size="s"
-                  iconLeft={{iconName: 'sparkles'}}
-                  onClick={generateDancer}
+                  onClick={() => setAiGenerateState('done')}
                 />
-              </>
-            )}
-          </>
-        )}
+              </div>
+            </>
+          )}
 
-        {aiGenerateState === 'generating' ? 'Generating a dancer...' : ''}
+          {aiGenerateState === 'done' && (
+            <>
+              <div>Great! Let's continue.</div>
 
-        {aiGenerateState === 'reviewing' && (
-          <>
-            <div>Here is the dancer that was generated. Do you like it?</div>
-
-            <div className={moduleStyles.buttonRow}>
               <Button
-                ariaLabel={"No. Let's try again."}
-                text={"No. Let's try again."}
+                ariaLabel={'Continue'}
+                text={'Continue'}
                 type="primary"
                 color="black"
                 size="s"
-                onClick={() => setAiGenerateState('none')}
+                iconRight={{iconName: 'arrow-right', iconStyle: 'solid'}}
+                onClick={() => dispatch(continueOrFinishLesson())}
               />
-
-              <Button
-                ariaLabel={"Yes. Let's continue."}
-                text={"Yes. Let's continue."}
-                type="primary"
-                color="black"
-                size="s"
-                onClick={() => setAiGenerateState('done')}
-              />
-            </div>
-          </>
-        )}
-
-        {aiGenerateState === 'done' && (
-          <>
-            <div>Great! Let's continue.</div>
-
-            <Button
-              ariaLabel={'Continue'}
-              text={'Continue'}
-              type="primary"
-              color="black"
-              size="s"
-              iconRight={{iconName: 'arrow-right', iconStyle: 'solid'}}
-              onClick={() => dispatch(continueOrFinishLesson())}
+            </>
+          )}
+        </Guide>
+        <div className={moduleStyles.dancerContainer} ref={containerRef}>
+          <div>
+            {showPlaceholder && <img alt="" src={dancerEmptyHeadShoulders} />}
+            <DancerCanvas
+              key={dancerMetadata || 'none'}
+              size={containerHeight}
+              move="rest"
+              onLoadingChange={setIsPreviewLoading}
             />
-          </>
-        )}
-
-        <BackToParentProject
-          text="Go to Hub"
-          iconLeft={{iconName: 'home'}}
-          type="secondary"
-          size="s"
-        />
-      </Guide>
-      <div className={moduleStyles.dancerContainer} ref={containerRef}>
-        <div>
-          {showPlaceholder && <img alt="" src={dancerEmptyHeadShoulders} />}
-          <DancerCanvas
-            key={dancerMetadata || 'none'}
-            size={containerHeight}
-            move="rest"
-            onLoadingChange={setIsPreviewLoading}
-          />
+          </div>
         </div>
       </div>
     </div>

--- a/apps/src/dance/lab2/views/dance-view.module.scss
+++ b/apps/src/dance/lab2/views/dance-view.module.scss
@@ -40,7 +40,7 @@
 
   &.jumbo {
     flex: initial;
-    width: min(50vw, calc(100vh - 240px));
+    width: min(50vw, calc(100vh - 250px));
 
     canvas {
       width: 100% !important;

--- a/apps/src/dance/lab2/views/dance-view.module.scss
+++ b/apps/src/dance/lab2/views/dance-view.module.scss
@@ -2,7 +2,14 @@
   height: 100%;
   width: 100%;
   display: flex;
+  flex-direction: column;
+}
+
+.mainContent {
+  display: flex;
+  flex: 1;
   flex-direction: row;
+  position: relative;
 }
 
 .visualizationColumn {
@@ -30,11 +37,11 @@
 .visualizationArea {
   flex: 0;
   background-color: var(--background-neutral-primary);
-  
+
   &.jumbo {
     flex: initial;
     width: min(50vw, calc(100vh - 240px));
-    
+
     canvas {
       width: 100% !important;
       height: 100% !important;

--- a/apps/src/dance/lab2/views/generate-dancer.module.scss
+++ b/apps/src/dance/lab2/views/generate-dancer.module.scss
@@ -6,7 +6,15 @@
   height: 100%;
   width: 100%;
   display: flex;
+  flex-direction: column;
+}
+
+.mainContent {
+  display: flex;
   flex-direction: row;
+  position: relative;
+  overflow: hidden;
+  flex: 1;
 }
 
 .textArea {

--- a/apps/src/lab2/lab2Redux.ts
+++ b/apps/src/lab2/lab2Redux.ts
@@ -53,6 +53,7 @@ import {
   PartialUserAppOptions,
   Validation,
 } from './types';
+import LevelPropertiesCache from './utils/LevelPropertiesCache';
 import {LifecycleEvent} from './utils/LifecycleNotifier';
 
 interface PageError {
@@ -509,11 +510,16 @@ function setProjectAndLevelData(
 async function loadLevelProperties(
   levelPropertiesPath: string
 ): Promise<LevelProperties> {
+  const cached = LevelPropertiesCache.get(levelPropertiesPath);
+  if (cached) {
+    return cached;
+  }
   const response = await HttpClient.fetchJson<LevelProperties>(
     levelPropertiesPath,
     {},
     LevelPropertiesValidator
   );
+  LevelPropertiesCache.set(levelPropertiesPath, response.value);
   return response.value;
 }
 

--- a/apps/src/lab2/projects/MultiProjectContainer.tsx
+++ b/apps/src/lab2/projects/MultiProjectContainer.tsx
@@ -15,6 +15,7 @@ import ProjectContainer from './ProjectContainer';
 import {getStandaloneProjectId} from './utils';
 
 const MultiProjectContext = createContext<{
+  parentLevelId: number;
   backToParent: () => void;
 } | null>(null);
 
@@ -86,7 +87,7 @@ const MultiProjectContainer: React.FC<{children: React.ReactNode}> = ({
   }
 
   return (
-    <MultiProjectContext.Provider value={{backToParent}}>
+    <MultiProjectContext.Provider value={{backToParent, parentLevelId}}>
       <ProjectContainer channelId={currentProjectId}>
         {children}
       </ProjectContainer>

--- a/apps/src/lab2/types.ts
+++ b/apps/src/lab2/types.ts
@@ -248,6 +248,7 @@ export interface BubbleChoiceSublevel {
   level_id: string;
   thumbnail_url: string;
   url: string;
+  position: number;
 }
 
 // Addtional fields for videos that are linked as references in the

--- a/apps/src/lab2/utils/LevelPropertiesCache.ts
+++ b/apps/src/lab2/utils/LevelPropertiesCache.ts
@@ -1,0 +1,27 @@
+import {LevelProperties} from '../types';
+
+/**
+ * In memory cache for level properties in Lab2 level progressions.
+ * Longer term, we should just pre-load level properties for all levels in a lesson.
+ */
+class LevelPropertiesCache {
+  constructor(private cache: {[path: string]: LevelProperties} = {}) {}
+
+  public get(path: string): LevelProperties | null {
+    return this.cache[path] || null;
+  }
+
+  public set(path: string, levelProperties: LevelProperties): void {
+    this.cache[path] = levelProperties;
+  }
+
+  public getById(id: number): LevelProperties | null {
+    return (
+      Object.values(this.cache).find(
+        levelProperties => levelProperties.id === id
+      ) || null
+    );
+  }
+}
+
+export default new LevelPropertiesCache();

--- a/apps/src/lab2/views/components/guide/Guide.module.scss
+++ b/apps/src/lab2/views/components/guide/Guide.module.scss
@@ -23,8 +23,8 @@
 }
 
 .guide {
-  position: fixed;
-  top: 110px;
+  position: absolute;
+  top: 62px;
   right: 80px;
   border-radius: 20px;
   padding: 4px;

--- a/apps/src/music/views/MusicLabView.tsx
+++ b/apps/src/music/views/MusicLabView.tsx
@@ -5,7 +5,7 @@ import {useSelector} from 'react-redux';
 
 import {WorkspaceSerialization} from '@cdo/apps/blockly/types';
 import {applyBlockIdOverrides} from '@cdo/apps/blockly/utils';
-import BackToParentProject from '@cdo/apps/bubbleChoice/BackToParentProject';
+import ModeSwitchBar from '@cdo/apps/bubbleChoice/customModes/MusicDanceAi/ModeSwitchBar';
 import header from '@cdo/apps/code-studio/header';
 import {
   START_SOURCES,
@@ -311,208 +311,206 @@ const MusicLabView: React.FunctionComponent<MusicLabViewProps> = ({
   }
 
   return (
-    <div
-      id="music-lab"
-      className={classNames(
-        moduleStyles.musicLab,
-        timelineAtTop && moduleStyles.reverse
-      )}
-    >
-      {allowPackSelection && <PackDialog player={player} />}
-      {guideMode === 'instructions' && (
-        <GuideInstructions
-          levelProperties={levelProperties}
-          isRunning={isPlaying}
-          hasRun={hasRun}
-          hasEdited={hasEdited}
-        />
-      )}
-      {guideMode === 'aiCodeGenerate' && (
-        <GenerateCode
-          adlibOption={aiCodeGenerateAdlibOption}
-          adlib={aiCodeGenerateAdlib}
-          levelProperties={levelProperties}
-          setPlaying={setPlaying}
-          hasEdited={hasEdited}
-          setToolboxVisibility={visible =>
-            blocklyWorkspace.setToolboxVisibility(visible)
-          }
-        />
-      )}
+    <div id="music-lab" className={classNames(moduleStyles.musicLab)}>
+      <ModeSwitchBar levelId={levelProperties.id} />
       <div
-        id="work-area"
-        className={classNames(moduleStyles.workArea, {
-          // Allow full height when the play area is hidden.
-          [moduleStyles.toolboxMode]: isToolboxMode,
-          [moduleStyles.reverse]:
-            instructionsPosition === InstructionsPosition.RIGHT,
-        })}
+        className={classNames(
+          moduleStyles.mainContent,
+          timelineAtTop && moduleStyles.reverse
+        )}
       >
-        {!guideMode && (
-          <div
-            id="instructions-area"
-            className={classNames(
-              moduleStyles.instructionsArea,
-              moduleStyles.instructionsSide,
-              isStandaloneCollapsed && moduleStyles.instructionsCollapsed
-            )}
-          >
-            <ResourcePanel
-              isRunning={isPlaying}
-              handleInstructionsTextClick={onInstructionsTextClick}
-              bottomComponent={
-                exemplarPlayerInsideInstructions &&
-                showExemplarPlayer && (
-                  <ExemplarPlayerView
-                    playbackEvents={exemplarPlaybackEvents}
-                    title={exemplarSettings.playerTitle!}
-                    player={player}
-                    insideInstructions={exemplarPlayerInsideInstructions}
-                  />
-                )
+        {allowPackSelection && <PackDialog player={player} />}
+        {guideMode === 'instructions' && (
+          <GuideInstructions
+            levelProperties={levelProperties}
+            isRunning={isPlaying}
+            hasRun={hasRun}
+            hasEdited={hasEdited}
+          />
+        )}
+        {guideMode === 'aiCodeGenerate' && (
+          <GenerateCode
+            adlibOption={aiCodeGenerateAdlibOption}
+            adlib={aiCodeGenerateAdlib}
+            levelProperties={levelProperties}
+            setPlaying={setPlaying}
+            hasEdited={hasEdited}
+            setToolboxVisibility={visible =>
+              blocklyWorkspace.setToolboxVisibility(visible)
+            }
+          />
+        )}
+        <div
+          id="work-area"
+          className={classNames(moduleStyles.workArea, {
+            // Allow full height when the play area is hidden.
+            [moduleStyles.toolboxMode]: isToolboxMode,
+            [moduleStyles.reverse]:
+              instructionsPosition === InstructionsPosition.RIGHT,
+          })}
+        >
+          {!guideMode && (
+            <div
+              id="instructions-area"
+              className={classNames(
+                moduleStyles.instructionsArea,
+                moduleStyles.instructionsSide,
+                isStandaloneCollapsed && moduleStyles.instructionsCollapsed
+              )}
+            >
+              <ResourcePanel
+                isRunning={isPlaying}
+                handleInstructionsTextClick={onInstructionsTextClick}
+                bottomComponent={
+                  exemplarPlayerInsideInstructions &&
+                  showExemplarPlayer && (
+                    <ExemplarPlayerView
+                      playbackEvents={exemplarPlaybackEvents}
+                      title={exemplarSettings.playerTitle!}
+                      player={player}
+                      insideInstructions={exemplarPlayerInsideInstructions}
+                    />
+                  )
+                }
+                hasRun={hasRun}
+                hasEdited={hasEdited}
+                fixedDarkBackground={true}
+                overrideTheme={'Light'}
+                includeFooterSpacing={false}
+                levelProperties={levelProperties}
+                headerClassName={moduleStyles.headerWithBorder}
+                settings={settings}
+                hideContinueIfDisabled={true}
+                hideNavigation={false}
+                styleNavigationAsBubble={true}
+                documentationUrl={'/docs/ide/music'}
+              />
+            </div>
+          )}
+
+          <div id="blockly-area" className={moduleStyles.blocklyArea}>
+            <PanelContainer
+              id="workspace-panel"
+              headerContent={<WorkspaceHeader />}
+              hideHeaders={hideHeaders}
+              rightHeaderContent={
+                <HeaderButtons
+                  onClickUndo={undo}
+                  onClickRedo={redo}
+                  clearCode={clearCode}
+                  allowPackSelection={allowPackSelection}
+                  skipUrl={skipUrl}
+                  hideChaff={hideChaff}
+                />
               }
-              hasRun={hasRun}
-              hasEdited={hasEdited}
-              fixedDarkBackground={true}
-              overrideTheme={'Light'}
-              includeFooterSpacing={false}
-              levelProperties={levelProperties}
               headerClassName={moduleStyles.headerWithBorder}
-              settings={settings}
-              hideContinueIfDisabled={true}
-              hideNavigation={false}
-              styleNavigationAsBubble={true}
-              documentationUrl={'/docs/ide/music'}
-            />
+            >
+              {isStartMode && (
+                <div
+                  id="startSourcesWarningBanner"
+                  className={moduleStyles.warningBanner}
+                >
+                  {projectTemplateLevel
+                    ? WARNING_BANNER_MESSAGES.TEMPLATE
+                    : WARNING_BANNER_MESSAGES.STANDARD}
+                </div>
+              )}
+              {isEditingExemplar && (
+                <div
+                  id="toolboxModeWarningBanner"
+                  className={moduleStyles.warningBanner}
+                >
+                  {WARNING_BANNER_MESSAGES.EXEMPLAR_MODE}
+                </div>
+              )}
+              {isViewingExemplar && (
+                <div
+                  id="toolboxModeWarningBanner"
+                  className={moduleStyles.warningBanner}
+                >
+                  {WARNING_BANNER_MESSAGES.VIEWING_EXEMPLAR}
+                </div>
+              )}
+              {isToolboxMode && (
+                <div
+                  id="toolboxModeWarningBanner"
+                  className={moduleStyles.warningBanner}
+                >
+                  {WARNING_BANNER_MESSAGES.TOOLBOX_MODE}
+                </div>
+              )}
+              {AppConfig.getValue('js-editor') === 'true' && (
+                <CodeEditor
+                  onCodeChange={executeCode}
+                  startCode={''}
+                  editorConfigExtensions={[javascript()]}
+                  appName="music"
+                />
+              )}
+              <div role="application" id={blocklyDivId} />
+              {showAdvancedControls && (
+                <div className={moduleStyles.advancedControlsContainer}>
+                  <AdvancedControls />
+                </div>
+              )}
+            </PanelContainer>
+          </div>
+        </div>
+
+        {!isToolboxMode && (
+          <div id="play-area" className={classNames(moduleStyles.playArea)}>
+            <div id="controls-area" className={moduleStyles.controlsArea}>
+              <PanelContainer
+                id="controls-panel"
+                headerContent={musicI18n.panelHeaderControls()}
+                hideHeaders={hideHeaders}
+              >
+                <Controls
+                  setPlaying={setPlaying}
+                  playTrigger={playTrigger}
+                  triggers={triggers}
+                  isPredictLevel={
+                    levelProperties.predictSettings?.isPredictLevel
+                  }
+                  enableSkipControls={
+                    AppConfig.getValue('skip-controls-enabled') === 'true'
+                  }
+                />
+              </PanelContainer>
+            </div>
+
+            <div
+              dir="ltr"
+              id="timeline-area"
+              className={moduleStyles.timelineArea}
+              ref={timelineAreaRef}
+            >
+              <PanelContainer
+                id="timeline-panel"
+                headerContent={musicI18n.panelHeaderTimeline()}
+                hideHeaders={hideHeaders}
+              >
+                <div className={moduleStyles.dancerCanvasContainer}>
+                  <DancerCanvas
+                    size={dancerSize}
+                    measurePosition={dancerMeasurePosition}
+                    move={danceMove}
+                  />
+                </div>
+                <Timeline
+                  allowChangeStartingPlayheadPosition={
+                    (levelProperties.levelData as MusicLevelData | undefined)
+                      ?.allowChangeStartingPlayheadPosition
+                  }
+                  isPredictLevel={
+                    levelProperties.predictSettings?.isPredictLevel
+                  }
+                />
+              </PanelContainer>
+            </div>
           </div>
         )}
-
-        <div id="blockly-area" className={moduleStyles.blocklyArea}>
-          <PanelContainer
-            id="workspace-panel"
-            headerContent={<WorkspaceHeader />}
-            hideHeaders={hideHeaders}
-            rightHeaderContent={
-              <HeaderButtons
-                onClickUndo={undo}
-                onClickRedo={redo}
-                clearCode={clearCode}
-                allowPackSelection={allowPackSelection}
-                skipUrl={skipUrl}
-                hideChaff={hideChaff}
-              />
-            }
-            headerClassName={moduleStyles.headerWithBorder}
-            leftHeaderContent={
-              <BackToParentProject
-                text="Go to Hub"
-                iconLeft={{iconName: 'home'}}
-                type="secondary"
-                size="s"
-              />
-            }
-          >
-            {isStartMode && (
-              <div
-                id="startSourcesWarningBanner"
-                className={moduleStyles.warningBanner}
-              >
-                {projectTemplateLevel
-                  ? WARNING_BANNER_MESSAGES.TEMPLATE
-                  : WARNING_BANNER_MESSAGES.STANDARD}
-              </div>
-            )}
-            {isEditingExemplar && (
-              <div
-                id="toolboxModeWarningBanner"
-                className={moduleStyles.warningBanner}
-              >
-                {WARNING_BANNER_MESSAGES.EXEMPLAR_MODE}
-              </div>
-            )}
-            {isViewingExemplar && (
-              <div
-                id="toolboxModeWarningBanner"
-                className={moduleStyles.warningBanner}
-              >
-                {WARNING_BANNER_MESSAGES.VIEWING_EXEMPLAR}
-              </div>
-            )}
-            {isToolboxMode && (
-              <div
-                id="toolboxModeWarningBanner"
-                className={moduleStyles.warningBanner}
-              >
-                {WARNING_BANNER_MESSAGES.TOOLBOX_MODE}
-              </div>
-            )}
-            {AppConfig.getValue('js-editor') === 'true' && (
-              <CodeEditor
-                onCodeChange={executeCode}
-                startCode={''}
-                editorConfigExtensions={[javascript()]}
-                appName="music"
-              />
-            )}
-            <div role="application" id={blocklyDivId} />
-            {showAdvancedControls && (
-              <div className={moduleStyles.advancedControlsContainer}>
-                <AdvancedControls />
-              </div>
-            )}
-          </PanelContainer>
-        </div>
       </div>
-
-      {!isToolboxMode && (
-        <div id="play-area" className={classNames(moduleStyles.playArea)}>
-          <div id="controls-area" className={moduleStyles.controlsArea}>
-            <PanelContainer
-              id="controls-panel"
-              headerContent={musicI18n.panelHeaderControls()}
-              hideHeaders={hideHeaders}
-            >
-              <Controls
-                setPlaying={setPlaying}
-                playTrigger={playTrigger}
-                triggers={triggers}
-                isPredictLevel={levelProperties.predictSettings?.isPredictLevel}
-                enableSkipControls={
-                  AppConfig.getValue('skip-controls-enabled') === 'true'
-                }
-              />
-            </PanelContainer>
-          </div>
-
-          <div
-            dir="ltr"
-            id="timeline-area"
-            className={moduleStyles.timelineArea}
-            ref={timelineAreaRef}
-          >
-            <PanelContainer
-              id="timeline-panel"
-              headerContent={musicI18n.panelHeaderTimeline()}
-              hideHeaders={hideHeaders}
-            >
-              <div className={moduleStyles.dancerCanvasContainer}>
-                <DancerCanvas
-                  size={dancerSize}
-                  measurePosition={dancerMeasurePosition}
-                  move={danceMove}
-                />
-              </div>
-              <Timeline
-                allowChangeStartingPlayheadPosition={
-                  (levelProperties.levelData as MusicLevelData | undefined)
-                    ?.allowChangeStartingPlayheadPosition
-                }
-                isPredictLevel={levelProperties.predictSettings?.isPredictLevel}
-              />
-            </PanelContainer>
-          </div>
-        </div>
-      )}
     </div>
   );
 };

--- a/apps/src/music/views/music-view.module.scss
+++ b/apps/src/music/views/music-view.module.scss
@@ -19,6 +19,14 @@ $default-spacing: 2px;
   user-select: none;
   display: flex;
   flex-direction: column;
+}
+
+.mainContent {
+  position: relative;
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
 
   &.reverse {
     flex-direction: column-reverse;

--- a/dashboard/app/dsl/bubble_choice_dsl.rb
+++ b/dashboard/app/dsl/bubble_choice_dsl.rb
@@ -40,6 +40,14 @@ class BubbleChoiceDSL < ContentDSL
     @hash[:sublevels] << name
   end
 
+  def custom_mode(text)
+    valid_modes = SharedConstants::BUBBLE_CHOICE_CUSTOM_MODES.values
+    unless valid_modes.include?(text)
+      raise "custom_mode must be one of [#{valid_modes.join(', ')}]"
+    end
+    @hash[:custom_mode] = text
+  end
+
   def self.serialize(level)
     new_dsl = "name '#{escape(level.name)}'"
     new_dsl += "\neditor_experiment '#{level.editor_experiment}'" if level.editor_experiment.present?

--- a/dashboard/app/views/levels/editors/fields/_dsl_fields.html.haml
+++ b/dashboard/app/views/levels/editors/fields/_dsl_fields.html.haml
@@ -55,6 +55,18 @@
       you can add/remove the <code>hide_letters_lab2</code> property above
       to control whether letters appear in the bubbles for each sublevel.
       The <code>hide_letters_lab2</code> has no effect on a legacy bubble choice level.
+    %h4 Tip: Custom Modes
+    %p
+      With the Lab2 version of bubble choice levels (described above), certain custom modes
+      are available which present alternate versions of the bubble choice level. Use
+      <code>custom_mode 'mode_name'</code> to enable. Currently this includes:
+    %ul
+      %li
+        <code>music_dance_ai</code>: A mode for Hour of AI 2025 which shows a custom
+        tabbed experience where students can switch between a Dancer Creation, Music Creation,
+        and Dance Creation level. At least one of these level types must be included as a sublevel
+        for this mode to be enabled. If some sublevels are missing, the corresponding tabs will display
+        as disabled and locked.
 
   - if @level.is_a?(Multi)
     %h4 Tip: Allow Multiple Attempts

--- a/dashboard/config/scripts/hoai_pilot_6_choice.bubble_choice
+++ b/dashboard/config/scripts/hoai_pilot_6_choice.bubble_choice
@@ -7,4 +7,5 @@ level 'pilot_generate_dancer_choice_2_3_4'
 level 'length_prompt_choice_2_3_4'
 level 'dance_moves_choice_2_3_4'
 
+custom_mode 'music_dance_ai'
 uses_lab2

--- a/lib/cdo/shared_constants.rb
+++ b/lib/cdo/shared_constants.rb
@@ -907,4 +907,8 @@ module SharedConstants
     "/oauth_sign_out/",
     "/certificates/"
   ].freeze
+
+  BUBBLE_CHOICE_CUSTOM_MODES = {
+    MUSIC_DANCE_AI: 'music_dance_ai',
+  }.freeze
 end


### PR DESCRIPTION
This adds a brand new "tabbed" level experience for Hour of AI 2025, where users can tab between the three sublevels (Create Dancer, Create Music, Dance Party) of a Music Dance AI bubble choice level. Though this is fairly niche to the HoAI 2025 experience which mashes up Dance Party and Music Lab, there's potential to genericize this for future use cases tabbing between sublevels of a bubble choice level. Here's how it works:

- We first add a new `custom_mode` field to bubble choice DSL levels, which right now only has one option (`'music_dance_ai'`). This custom mode gets saved on to the bubble choice level's properties, and allows the BubbleChoice Lab2 component to render an alternate view for the level. In this case, the BubbleChoice component simply auto-redirects to the first available sublevel, since there's nothing to show at the "top" parent level.
  - The idea here is to decouple the data of the bubble choice level from its view; this allows us to think of the bubble choice level data as a more generic data structure to associate parent levels to child levels, that can have any number of corresponding layouts and views.
- Each of the constituent levels (Dance and Music) renders a `ModeSwitchBar` which contains the bulk of the logic and functionality relating to this change. If we are not in a bubble choice level context or not using this specific custom mode, the Mode Switch Bar will render nothing so existing Music and Dance levels will be unaffected.
  - This is rendered by the labs themselves and not at the Lab2 parent level because a) I didn't want to introduce custom code into the Lab2 core layer and b) by each lab rendering the tabs at the same place, it gives the appearance of them being fixed. Note that currently however, there is a full-page fade that covers the lab content and the tabs (see follow-up work). 
- The `ModeSwitchBar` does the following:
  - Loads the level properties for the parent level to determine if we're in a Music Dance AI mode. To reduce redundancy, I've introduced a `LevelPropertiesCache` to the Lab2 core which saves off a mapping of level properties path -> level properties in memory. Longer term, I believe we should just pre-fetch the level properties for all levels in a progression since it's all static data that we know of up front, but that's beyond the scope of this change.
  - Loads the level properties for each child level. We need to do this up front to know which level is which (Dancer/Music/Dance) and which are available.
  - Renders the bar UI. Clicking on any of the buttons calls `navigateToSublevel` which handles changing the level in the lab2 system and rendering the correct lab.

To add this to a level, add `custom_mode 'music_dance_ai'` to an existing bubble choice level with at least one of: a Music Lab level, dance level with `guideMode: 'aiCodeGenerate'`, and dance level with `guideMode: 'aiDancerGenerate'`.

<img width="1721" height="925" alt="Screenshot 2025-10-24 at 12 47 34 PM" src="https://github.com/user-attachments/assets/033a4cb5-8153-43a0-9ed9-cfccbd7febe9" />
<img width="1724" height="924" alt="Screenshot 2025-10-24 at 12 47 18 PM" src="https://github.com/user-attachments/assets/af08531a-771d-495c-a748-3bf33cf57b7e" />
<img width="1720" height="924" alt="Screenshot 2025-10-24 at 12 47 08 PM" src="https://github.com/user-attachments/assets/a7e1ce95-1361-4983-87cb-5223484e8806" />

### Locked Levels
P0 for this work is just to enable this mode for freeplay. However, I've set this up so that if we don't have a level specified for one of the modes in the DSL, then the other tabs will appear disabled and locked:

<img width="1411" height="827" alt="Screenshot 2025-10-24 at 1 27 47 PM" src="https://github.com/user-attachments/assets/4b5ffd55-6872-486b-b3e4-7311d1e7d38a" />

### Follow-up work
- Better fade transition; right now there is a full page fade which hides the bar, but we might able to only fade over the lab content and keep the bar visible by using the `lab2-no-fade` flag.

