### PR TITLE
Music: fix header buttons

### DIFF
--- a/apps/src/music/views/HeaderButtons.module.scss
+++ b/apps/src/music/views/HeaderButtons.module.scss
@@ -30,7 +30,7 @@
   }
 }
 
-.buttonWithPack {
+.startOverButton {
   background-color: var(--background-neutral-primary);
   color: var(--text-neutral-primary);
   display: flex;
@@ -39,11 +39,15 @@
   gap: 0.125rem;
   height: 26.25px;
   padding-block: 0.1875rem;
-  padding-inline: 0.125rem 0.5rem;
+  padding-inline:  0.5rem;
   border: variables.$default-border;
   border-color: var(--borders-neutral-strong);
   border-radius: 0.25rem;
   transition: all 0.2s ease;
+
+  &WithPack {
+    padding-inline: 0.125rem 0.5rem;
+  }
 
   &:hover {
     background-color: var(--background-neutral-tertiary);

--- a/apps/src/music/views/HeaderButtons.tsx
+++ b/apps/src/music/views/HeaderButtons.tsx
@@ -1,6 +1,7 @@
 import {Button} from '@code-dot-org/component-library/button';
 import FontAwesomeV6Icon from '@code-dot-org/component-library/fontAwesomeV6Icon';
 import Typography from '@code-dot-org/component-library/typography';
+import classNames from 'classnames';
 import React, {memo, useCallback, useContext} from 'react';
 import {useSelector} from 'react-redux';
 
@@ -137,11 +138,11 @@ const HeaderButtons: React.FunctionComponent<HeaderButtonsProps> = ({
 
   return (
     <div className={moduleStyles.container} ref={containerRef} tabIndex={-1}>
-      {/* Show static pack info; clickable Start Over button */}
+      {/* Show static pack info & clickable Start Over button. */}
       {!allowPackSelection && packFolder && (
         <>
           <CurrentPack packFolder={packFolder} />
-          {/* Start Over Button */}
+          {/* Start Over button. */}
           <IconButtonWithTooltip
             id="start-over"
             label={musicI18n.startOver()}
@@ -157,23 +158,30 @@ const HeaderButtons: React.FunctionComponent<HeaderButtonsProps> = ({
           />
         </>
       )}
-      {/* Show clickable pack info with Start Over icon */}
-      {!readOnlyWorkspace && allowPackSelection && (
+      {/* Show Start Over button, possibly with pack information inside it. */}
+      {!readOnlyWorkspace && (
         <>
           <button
             onClick={onClickStartOver}
             type="button"
             id="start-over-button"
-            className={moduleStyles.buttonWithPack}
+            className={classNames(
+              moduleStyles.startOverButton,
+              allowPackSelection &&
+                packFolder &&
+                moduleStyles.startOverButtonWithPack
+            )}
           >
-            {packFolder && <CurrentPack packFolder={packFolder} />}
+            {allowPackSelection && packFolder && (
+              <CurrentPack packFolder={packFolder} />
+            )}
             <FontAwesomeV6Icon iconName="refresh" iconStyle="solid" />
           </button>
         </>
       )}
       {!readOnlyWorkspace && (
         <>
-          {/* Undo Button */}
+          {/* Undo button. */}
           <IconButtonWithTooltip
             id="undo"
             label={musicI18n.undo()}
@@ -188,7 +196,7 @@ const HeaderButtons: React.FunctionComponent<HeaderButtonsProps> = ({
             onClick={() => onClickUndoRedo('undo')}
             containerRef={containerRef}
           />
-          {/* Redo Button */}
+          {/* Redo button. */}
           <IconButtonWithTooltip
             id="redo"
             label={musicI18n.redo()}
@@ -205,7 +213,7 @@ const HeaderButtons: React.FunctionComponent<HeaderButtonsProps> = ({
           />
         </>
       )}
-      {/* Skip to Project Button */}
+      {/* Skip to Project button. */}
       {skipUrl && (
         <Button
           text={commonI18n.skipToProject()}

--- a/apps/src/music/views/HeaderButtons.tsx
+++ b/apps/src/music/views/HeaderButtons.tsx
@@ -138,25 +138,9 @@ const HeaderButtons: React.FunctionComponent<HeaderButtonsProps> = ({
 
   return (
     <div className={moduleStyles.container} ref={containerRef} tabIndex={-1}>
-      {/* Show static pack info & clickable Start Over button. */}
+      {/* Show static pack information. */}
       {!allowPackSelection && packFolder && (
-        <>
-          <CurrentPack packFolder={packFolder} />
-          {/* Start Over button. */}
-          <IconButtonWithTooltip
-            id="start-over"
-            label={musicI18n.startOver()}
-            icon={{iconName: 'refresh', iconStyle: 'solid'}}
-            type="tertiary"
-            color="black"
-            buttonSize="xs"
-            tooltipSize="xs"
-            tooltipDirection="onBottom"
-            hideTooltipTail={true}
-            onClick={onClickStartOver}
-            containerRef={containerRef}
-          />
-        </>
+        <CurrentPack packFolder={packFolder} />
       )}
       {/* Show Start Over button, possibly with pack information inside it. */}
       {!readOnlyWorkspace && (


### PR DESCRIPTION
This fixes a couple issues with the Music Lab header buttons:

- Restores the logic to show a Start Over button in a level that does allow starting over even though the pack can't be changed (e.g. `/courses/music-jam-2024/units/1/lessons/1/levels/3`).  In this case the button has only a Start Over icon in it.
- Restores the behavior to not show a Start Over button even when showing the pack, for a read-only music project (e.g. `/view` appended to somebody else's shared music project).

### Show Start Over without pack

#### before
<img width="178" height="62" alt="Screenshot 2025-10-24 at 3 01 07 PM" src="https://github.com/user-attachments/assets/1c606db8-881d-479e-abe5-f142dbe4f38e" />

#### after
<img width="178" height="62" alt="Screenshot 2025-10-24 at 3 00 24 PM" src="https://github.com/user-attachments/assets/8f3e9e68-5ca1-4966-96db-0e82d67c2c79" />

### Don't show Start Over for a read-only project

#### before
<img width="260" height="62" alt="Screenshot 2025-10-24 at 3 02 24 PM" src="https://github.com/user-attachments/assets/7346d01d-5b75-4325-808c-1fbfd51bebf1" />

#### after
<img width="260" height="62" alt="Screenshot 2025-10-24 at 3 02 45 PM" src="https://github.com/user-attachments/assets/e5b0575c-78f6-4b4d-a924-c63e640eab9d" />

## 
Follow-up to https://github.com/code-dot-org/code-dot-org/pull/68335.