### PR TITLE
run yarn lint concurrently

### DIFF
--- a/apps/package.json
+++ b/apps/package.json
@@ -264,6 +264,7 @@
     "classnames": "^2.3.2",
     "codemirror": "5.5",
     "codemirror-spell-checker": "^1.1.2",
+    "concurrently": "^9.2.1",
     "dapjs": "^2.3.0",
     "details-element-polyfill": "https://github.com/javan/details-element-polyfill",
     "ejs": "^3.1.10",

--- a/apps/package.json
+++ b/apps/package.json
@@ -10,7 +10,9 @@
   "scripts": {
     "lint": "yarn lint:scss && yarn lint:js",
     "lint:fix": "yarn lint:scss --fix && yarn lint:js --fix",
-    "lint:js": "eslint --format ./.eslintCustomMessagesFormatter.js --ext=.js,.jsx,.ts,.tsx --report-unused-disable-directives-severity=error .",
+    "lint:js": "concurrently \"yarn lint:js:ts\" \"yarn lint:jsx:tsx\"",
+    "lint:js:ts": "eslint --format ./.eslintCustomMessagesFormatter.js --ext=.js,.ts --report-unused-disable-directives-severity=error .",
+    "lint:jsx:tsx": "eslint --format ./.eslintCustomMessagesFormatter.js --ext=.jsx,.tsx --report-unused-disable-directives-severity=error .",
     "lint:scss": "npx stylelint '**/*.scss'",
     "test": "./run-tests-in-parallel.sh",
     "test:unit": "jest",

--- a/apps/run-tests-in-parallel.sh
+++ b/apps/run-tests-in-parallel.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# This is the implementation of `yarn test`. It runs all the tests 
+# This is the implementation of `yarn test`. It runs all the tests
 # (just like `npx karma start`) would, but it splits them into parallel jobs.
 #
 # If you want to add a new levelType or testType to `yarn test`, add an
@@ -32,7 +32,7 @@ function linuxNumProcs() {
   if ((procs == 0)); then
     local free_kb=$(awk "/MemFree/ {printf \"%d\", \$2/1024}" /proc/meminfo)
     procs=1
-  fi 
+  fi
 
   echo $procs
 }
@@ -96,7 +96,14 @@ echo && echo && echo "Starting ${PROCS}x-parallel test jobs:"
 PARALLEL="parallel --will-cite --halt 2 -j ${PROCS} --joblog - :::"
 
 # Each line in this SCRIPT block will be run as a parallel test job
-# If any line fails, the whole block will fail and exit early
+# If any line fails, the whole block will fail and exit early.
+#
+# yarn lint has been configured to run with 2-way parallelism specifically to
+# optimize for drone m7i.4xlarge machines with 16 CPUs and 64GB RAM. We use
+# `concurrently` to do this because eslint 8.56 does not have built-in support
+# for concurrency. Once we upgrade to eslint 9.34, we can replace the use of
+# `concurrently` with `eslint --concurrency 2 ...` instead. See:
+# https://eslint.org/blog/2025/08/eslint-v9.34.0-released/
 ${PARALLEL} <<SCRIPT || (echo && echo && echo "One of the parallel test jobs FAILED, exiting early." && echo && exit 1)
   yarn lint
   npx karma start --testType=unit --port=9876

--- a/apps/run-tests-in-parallel.sh
+++ b/apps/run-tests-in-parallel.sh
@@ -107,7 +107,6 @@ PARALLEL="parallel --will-cite --halt 2 -j ${PROCS} --joblog - :::"
 ${PARALLEL} <<SCRIPT || (echo && echo && echo "One of the parallel test jobs FAILED, exiting early." && echo && exit 1)
   yarn lint
   npx karma start --testType=unit --port=9876
-  npx karma start --testType=storybook --port=9877
   npx karma start --testType=integration --levelType='turtle' --port=9879
   npx karma start --testType=integration --levelType='maze' --port=9880
   npx karma start --testType=integration --levelType='gamelab' --port=9881

--- a/apps/yarn.lock
+++ b/apps/yarn.lock
@@ -11143,6 +11143,7 @@ __metadata:
     classnames: "npm:^2.3.2"
     codemirror: "npm:5.5"
     codemirror-spell-checker: "npm:^1.1.2"
+    concurrently: "npm:^9.2.1"
     copy-webpack-plugin: "npm:^9.0.1"
     css-loader: "npm:^6.2.0"
     dapjs: "npm:^2.3.0"
@@ -11942,6 +11943,16 @@ canvg@gabelerner/canvg:
   languageName: node
   linkType: hard
 
+"chalk@npm:4.1.2, chalk@npm:^4.0.0, chalk@npm:^4.0.2, chalk@npm:^4.1.0, chalk@npm:^4.1.2, chalk@npm:~4.1.0":
+  version: 4.1.2
+  resolution: "chalk@npm:4.1.2"
+  dependencies:
+    ansi-styles: "npm:^4.1.0"
+    supports-color: "npm:^7.1.0"
+  checksum: 10/cb3f3e594913d63b1814d7ca7c9bafbf895f75fbf93b92991980610dfd7b48500af4e3a5d4e3a8f337990a96b168d7eb84ee55efdce965e2ee8efc20f8c8f139
+  languageName: node
+  linkType: hard
+
 "chalk@npm:^1.0.0, chalk@npm:^1.1.1, chalk@npm:^1.1.3":
   version: 1.1.3
   resolution: "chalk@npm:1.1.3"
@@ -11973,16 +11984,6 @@ canvg@gabelerner/canvg:
     ansi-styles: "npm:^4.1.0"
     supports-color: "npm:^7.1.0"
   checksum: 10/37f90b31fd655fb49c2bd8e2a68aebefddd64522655d001ef417e6f955def0ed9110a867ffc878a533f2dafea5f2032433a37c8a7614969baa7f8a1cd424ddfc
-  languageName: node
-  linkType: hard
-
-"chalk@npm:^4.0.0, chalk@npm:^4.0.2, chalk@npm:^4.1.0, chalk@npm:^4.1.2, chalk@npm:~4.1.0":
-  version: 4.1.2
-  resolution: "chalk@npm:4.1.2"
-  dependencies:
-    ansi-styles: "npm:^4.1.0"
-    supports-color: "npm:^7.1.0"
-  checksum: 10/cb3f3e594913d63b1814d7ca7c9bafbf895f75fbf93b92991980610dfd7b48500af4e3a5d4e3a8f337990a96b168d7eb84ee55efdce965e2ee8efc20f8c8f139
   languageName: node
   linkType: hard
 
@@ -12639,6 +12640,23 @@ canvg@gabelerner/canvg:
     readable-stream: "npm:^2.2.2"
     typedarray: "npm:^0.0.6"
   checksum: 10/71db903c84fc073ca35a274074e8d26c4330713d299f8623e993c448c1f6bf8b967806dd1d1a7b0f8add6f15ab1af7435df21fe79b4fe7efd78420c89e054e28
+  languageName: node
+  linkType: hard
+
+"concurrently@npm:^9.2.1":
+  version: 9.2.1
+  resolution: "concurrently@npm:9.2.1"
+  dependencies:
+    chalk: "npm:4.1.2"
+    rxjs: "npm:7.8.2"
+    shell-quote: "npm:1.8.3"
+    supports-color: "npm:8.1.1"
+    tree-kill: "npm:1.2.2"
+    yargs: "npm:17.7.2"
+  bin:
+    conc: dist/bin/concurrently.js
+    concurrently: dist/bin/concurrently.js
+  checksum: 10/2a6b1acbcdbeb478926b80fd81d0b7e075fa16d78a76ceb43f0478b8aeea1c70781379be2f7d6a2528e51fac48ce4ebb686ae2328e4b35e0b1d17234f121c700
   languageName: node
   linkType: hard
 
@@ -27098,6 +27116,15 @@ canvg@gabelerner/canvg:
   languageName: node
   linkType: hard
 
+"rxjs@npm:7.8.2":
+  version: 7.8.2
+  resolution: "rxjs@npm:7.8.2"
+  dependencies:
+    tslib: "npm:^2.1.0"
+  checksum: 10/03dff09191356b2b87d94fbc1e97c4e9eb3c09d4452399dddd451b09c2f1ba8d56925a40af114282d7bc0c6fe7514a2236ca09f903cf70e4bbf156650dddb49d
+  languageName: node
+  linkType: hard
+
 "safe-array-concat@npm:^1.0.1":
   version: 1.0.1
   resolution: "safe-array-concat@npm:1.0.1"
@@ -27658,6 +27685,13 @@ canvg@gabelerner/canvg:
   version: 3.0.0
   resolution: "shebang-regex@npm:3.0.0"
   checksum: 10/1a2bcae50de99034fcd92ad4212d8e01eedf52c7ec7830eedcf886622804fe36884278f2be8be0ea5fde3fd1c23911643a4e0f726c8685b61871c8908af01222
+  languageName: node
+  linkType: hard
+
+"shell-quote@npm:1.8.3":
+  version: 1.8.3
+  resolution: "shell-quote@npm:1.8.3"
+  checksum: 10/5473e354637c2bd698911224129c9a8961697486cff1fb221f234d71c153fc377674029b0223d1d3c953a68d451d79366abfe53d1a0b46ee1f28eb9ade928f4c
   languageName: node
   linkType: hard
 
@@ -28876,6 +28910,15 @@ canvg@gabelerner/canvg:
   languageName: node
   linkType: hard
 
+"supports-color@npm:8.1.1, supports-color@npm:^8.0.0, supports-color@npm:^8.1.1":
+  version: 8.1.1
+  resolution: "supports-color@npm:8.1.1"
+  dependencies:
+    has-flag: "npm:^4.0.0"
+  checksum: 10/157b534df88e39c5518c5e78c35580c1eca848d7dbaf31bbe06cdfc048e22c7ff1a9d046ae17b25691128f631a51d9ec373c1b740c12ae4f0de6e292037e4282
+  languageName: node
+  linkType: hard
+
 "supports-color@npm:^2.0.0":
   version: 2.0.0
   resolution: "supports-color@npm:2.0.0"
@@ -28907,15 +28950,6 @@ canvg@gabelerner/canvg:
   dependencies:
     has-flag: "npm:^4.0.0"
   checksum: 10/c8bb7afd564e3b26b50ca6ee47572c217526a1389fe018d00345856d4a9b08ffbd61fadaf283a87368d94c3dcdb8f5ffe2650a5a65863e21ad2730ca0f05210a
-  languageName: node
-  linkType: hard
-
-"supports-color@npm:^8.0.0, supports-color@npm:^8.1.1":
-  version: 8.1.1
-  resolution: "supports-color@npm:8.1.1"
-  dependencies:
-    has-flag: "npm:^4.0.0"
-  checksum: 10/157b534df88e39c5518c5e78c35580c1eca848d7dbaf31bbe06cdfc048e22c7ff1a9d046ae17b25691128f631a51d9ec373c1b740c12ae4f0de6e292037e4282
   languageName: node
   linkType: hard
 
@@ -29543,6 +29577,15 @@ canvg@gabelerner/canvg:
   version: 0.0.3
   resolution: "tr46@npm:0.0.3"
   checksum: 10/8f1f5aa6cb232f9e1bdc86f485f916b7aa38caee8a778b378ffec0b70d9307873f253f5cbadbe2955ece2ac5c83d0dc14a77513166ccd0a0c7fe197e21396695
+  languageName: node
+  linkType: hard
+
+"tree-kill@npm:1.2.2":
+  version: 1.2.2
+  resolution: "tree-kill@npm:1.2.2"
+  bin:
+    tree-kill: cli.js
+  checksum: 10/49117f5f410d19c84b0464d29afb9642c863bc5ba40fcb9a245d474c6d5cc64d1b177a6e6713129eb346b40aebb9d4631d967517f9fbe8251c35b21b13cd96c7
   languageName: node
   linkType: hard
 
@@ -31926,6 +31969,21 @@ canvg@gabelerner/canvg:
   languageName: node
   linkType: hard
 
+"yargs@npm:17.7.2, yargs@npm:^17.3.1":
+  version: 17.7.2
+  resolution: "yargs@npm:17.7.2"
+  dependencies:
+    cliui: "npm:^8.0.1"
+    escalade: "npm:^3.1.1"
+    get-caller-file: "npm:^2.0.5"
+    require-directory: "npm:^2.1.1"
+    string-width: "npm:^4.2.3"
+    y18n: "npm:^5.0.5"
+    yargs-parser: "npm:^21.1.1"
+  checksum: 10/abb3e37678d6e38ea85485ed86ebe0d1e3464c640d7d9069805ea0da12f69d5a32df8e5625e370f9c96dd1c2dc088ab2d0a4dd32af18222ef3c4224a19471576
+  languageName: node
+  linkType: hard
+
 "yargs@npm:^16.0.3, yargs@npm:^16.1.1, yargs@npm:^16.2.0":
   version: 16.2.0
   resolution: "yargs@npm:16.2.0"
@@ -31938,21 +31996,6 @@ canvg@gabelerner/canvg:
     y18n: "npm:^5.0.5"
     yargs-parser: "npm:^20.2.2"
   checksum: 10/807fa21211d2117135d557f95fcd3c3d390530cda2eca0c840f1d95f0f40209dcfeb5ec18c785a1f3425896e623e3b2681e8bb7b6600060eda1c3f4804e7957e
-  languageName: node
-  linkType: hard
-
-"yargs@npm:^17.3.1":
-  version: 17.7.2
-  resolution: "yargs@npm:17.7.2"
-  dependencies:
-    cliui: "npm:^8.0.1"
-    escalade: "npm:^3.1.1"
-    get-caller-file: "npm:^2.0.5"
-    require-directory: "npm:^2.1.1"
-    string-width: "npm:^4.2.3"
-    y18n: "npm:^5.0.5"
-    yargs-parser: "npm:^21.1.1"
-  checksum: 10/abb3e37678d6e38ea85485ed86ebe0d1e3464c640d7d9069805ea0da12f69d5a32df8e5625e370f9c96dd1c2dc088ab2d0a4dd32af18222ef3c4224a19471576
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Shaves about 45 seconds off of `yarn lint` time on drone `unit` pipeline by splitting the linting into 2 tasks and then running them via `concurrently`. For past discussion that led to this solution, see comments on https://github.com/code-dot-org/code-dot-org/pull/69060

