### PR TITLE
Revert "Revert "feat(mui): run mui typography codemod on teacher dashboard""

### DIFF
--- a/apps/src/templates/studioHomepages/teacherHomepageV2/CourseContentDropdown.tsx
+++ b/apps/src/templates/studioHomepages/teacherHomepageV2/CourseContentDropdown.tsx
@@ -1,5 +1,5 @@
 import {CustomDropdown} from '@code-dot-org/component-library/dropdown';
-import {BodyThreeText} from '@code-dot-org/component-library/typography';
+import {Typography} from '@mui/material';
 import React, {useEffect, useState, useMemo} from 'react';
 
 import {EVENTS} from '@cdo/apps/metrics/AnalyticsConstants.js';
@@ -68,13 +68,15 @@ export const CourseContentDropdown: React.FC<CourseContentDropdownProps> = ({
 
   return (
     <div className={styles.courseContentDropdownContainer}>
-      <BodyThreeText
+      <Typography
         className={styles.courseTitleText}
         id={`course-content-dropdown-${section.name.replaceAll(' ', '-')}`}
+        variant="body3"
+        gutterBottom
       >
         <b>{`${i18n.course()}: `}</b>
         {section.courseDisplayName}
-      </BodyThreeText>
+      </Typography>
       {section.unitId ? (
         <CustomDropdown
           className={styles.courseContentDropdown}

--- a/apps/src/templates/studioHomepages/teacherHomepageV2/EmptyStateButton.tsx
+++ b/apps/src/templates/studioHomepages/teacherHomepageV2/EmptyStateButton.tsx
@@ -1,5 +1,5 @@
 import FontAwesomeV6Icon from '@code-dot-org/component-library/fontAwesomeV6Icon';
-import {BodyThreeText} from '@code-dot-org/component-library/typography';
+import {Typography} from '@mui/material';
 import React from 'react';
 import {NavLink} from 'react-router-dom';
 
@@ -46,7 +46,9 @@ export const EmptyStateButton: React.FC<EmptyStateButtonProps> = ({
           iconName={icon}
           iconStyle={'solid'}
         />
-        <BodyThreeText>{buttonText}</BodyThreeText>
+        <Typography variant="body3" gutterBottom>
+          {buttonText}
+        </Typography>
       </div>
       <FontAwesomeV6Icon
         className={styles.emptyStateButtonIcon}
@@ -66,7 +68,9 @@ export const EmptyStateButton: React.FC<EmptyStateButtonProps> = ({
           iconName={icon}
           iconStyle={'solid'}
         />
-        <BodyThreeText>{buttonText}</BodyThreeText>
+        <Typography variant="body3" gutterBottom>
+          {buttonText}
+        </Typography>
       </div>
       <FontAwesomeV6Icon
         className={styles.emptyStateButtonIcon}

--- a/apps/src/templates/studioHomepages/teacherHomepageV2/Header.tsx
+++ b/apps/src/templates/studioHomepages/teacherHomepageV2/Header.tsx
@@ -1,7 +1,7 @@
 import {Button} from '@code-dot-org/component-library/button';
 import {ActionDropdown} from '@code-dot-org/component-library/dropdown';
 import SegmentedButtons from '@code-dot-org/component-library/segmentedButtons';
-import {Heading4} from '@code-dot-org/component-library/typography';
+import {Typography} from '@mui/material';
 import React from 'react';
 
 import {EVENTS, PLATFORMS} from '@cdo/apps/metrics/AnalyticsConstants.js';
@@ -50,7 +50,9 @@ export const Header: React.FC<HeaderProps> = ({
 
   return (
     <div id="teacher-home-header">
-      <Heading4>{i18n.classSections()}</Heading4>
+      <Typography variant="h4" gutterBottom>
+        {i18n.classSections()}
+      </Typography>
       <div className={styles.headerButtonRow}>
         <SegmentedButtons
           onChange={value =>

--- a/apps/src/templates/studioHomepages/teacherHomepageV2/JoinLink/JoinLinkCopyButton.tsx
+++ b/apps/src/templates/studioHomepages/teacherHomepageV2/JoinLink/JoinLinkCopyButton.tsx
@@ -4,7 +4,7 @@ import {
   TooltipOverlay,
   WithTooltip,
 } from '@code-dot-org/component-library/tooltip';
-import {OverlineOneText} from '@code-dot-org/component-library/typography';
+import {Typography} from '@mui/material';
 import classNames from 'classnames';
 import React from 'react';
 
@@ -86,18 +86,18 @@ const JoinLinkCopyButton: React.FC<JoinLinkCopyButtonProps> = ({
   return loginType &&
     (LOGIN_TYPES_WITH_PASSWORD_COLUMN as string[]).includes(loginType) ? (
     hidden ? (
-      <OverlineOneText>
+      <Typography variant="overline1" gutterBottom>
         <span>{i18n.sectionCodeWithColon()}</span>{' '}
         <span className={styles.sectionCodeTextHidden}>{sectionCode}</span>
-      </OverlineOneText>
+      </Typography>
     ) : (
       <div className={styles.sectionCodeBox} data-for="section-code" data-tip>
         {!showCopiedMsg && (
           <TooltipOverlay>
             <span className={styles.sectionCodeText}>
-              <OverlineOneText>
+              <Typography variant="overline1" gutterBottom>
                 <span>{i18n.sectionCodeWithColon()}</span>
-              </OverlineOneText>
+              </Typography>
               <WithTooltip
                 tooltipProps={{
                   tooltipId: 'section-code',
@@ -108,7 +108,7 @@ const JoinLinkCopyButton: React.FC<JoinLinkCopyButtonProps> = ({
                   iconLeft: {iconName: 'copy'},
                 }}
               >
-                <OverlineOneText>
+                <Typography variant="overline1" gutterBottom>
                   <button
                     id={'ui-test-section-code-button'}
                     className={styles.sectionCode}
@@ -117,7 +117,7 @@ const JoinLinkCopyButton: React.FC<JoinLinkCopyButtonProps> = ({
                   >
                     {sectionCode}
                   </button>
-                </OverlineOneText>
+                </Typography>
               </WithTooltip>
             </span>
           </TooltipOverlay>
@@ -131,7 +131,7 @@ const JoinLinkCopyButton: React.FC<JoinLinkCopyButtonProps> = ({
         className={classNames(styles.sectionCodeBox, styles.sectionCodeText)}
         id="uitest-no-section-code"
       >
-        <OverlineOneText>
+        <Typography variant="overline1" gutterBottom>
           {`${i18n.sectionCodeWithColon()} ${i18n.notApplicable()}`}
           <button
             onClick={() => showSectionCodeDialog()}
@@ -142,7 +142,7 @@ const JoinLinkCopyButton: React.FC<JoinLinkCopyButtonProps> = ({
           >
             <FontAwesomeV6Icon iconName="question-circle" iconStyle="regular" />
           </button>
-        </OverlineOneText>
+        </Typography>
       </div>
       {shouldShowDialog && (
         <Dialog

--- a/apps/src/templates/studioHomepages/teacherHomepageV2/PermanentPromotions.tsx
+++ b/apps/src/templates/studioHomepages/teacherHomepageV2/PermanentPromotions.tsx
@@ -1,10 +1,6 @@
 import FontAwesomeV6Icon from '@code-dot-org/component-library/fontAwesomeV6Icon';
 import Link from '@code-dot-org/component-library/link';
-import {
-  BodyFourText,
-  BodyTwoText,
-  StrongText,
-} from '@code-dot-org/component-library/typography';
+import {Typography} from '@mui/material';
 import React from 'react';
 
 import bookWithBulb from './images/book_with_bulb.png';
@@ -51,10 +47,14 @@ const PermanentPromotions: React.FC = () => {
       {promotions.map(promotion => (
         <li key={promotion.id} className={styles.staticPromotion}>
           <div className={styles.staticPromotionText}>
-            <BodyTwoText>
-              <StrongText>{promotion.title}</StrongText>
-            </BodyTwoText>
-            <BodyFourText>{promotion.description}</BodyFourText>
+            <Typography variant="body2" gutterBottom>
+              <Typography variant="strong" gutterBottom>
+                {promotion.title}
+              </Typography>
+            </Typography>
+            <Typography variant="body4" gutterBottom>
+              {promotion.description}
+            </Typography>
             <Link href={promotion.buttonTarget} size="xs" openInNewTab={true}>
               {promotion.buttonLabel}
               <FontAwesomeV6Icon iconName="up-right-from-square" />

--- a/apps/src/templates/studioHomepages/teacherHomepageV2/SectionCard.tsx
+++ b/apps/src/templates/studioHomepages/teacherHomepageV2/SectionCard.tsx
@@ -1,7 +1,7 @@
 import {Button} from '@code-dot-org/component-library/button';
-import {Heading5} from '@code-dot-org/component-library/typography';
 import {useSortable} from '@dnd-kit/sortable';
 import {CSS} from '@dnd-kit/utilities';
+import {Typography} from '@mui/material';
 import React from 'react';
 
 import {Section} from '@cdo/apps/templates/teacherDashboard/types/teacherSectionTypes';
@@ -64,9 +64,13 @@ export const SectionCard: React.FC<SectionCardProps> = ({
             size={'s'}
           />
           <div className={styles.sectionCardHeaderText}>
-            <Heading5 id={`section-card-title-${section.id}`}>
+            <Typography
+              id={`section-card-title-${section.id}`}
+              variant="h5"
+              gutterBottom
+            >
               {section.name}
-            </Heading5>
+            </Typography>
             <JoinLinkCopyButton
               loginType={section.loginType}
               sectionCode={section.code}

--- a/apps/src/templates/studioHomepages/teacherHomepageV2/SectionCardBody.tsx
+++ b/apps/src/templates/studioHomepages/teacherHomepageV2/SectionCardBody.tsx
@@ -1,5 +1,5 @@
 import FontAwesomeV6Icon from '@code-dot-org/component-library/fontAwesomeV6Icon';
-import {BodyThreeText} from '@code-dot-org/component-library/typography';
+import {Typography} from '@mui/material';
 import React from 'react';
 
 import {Section} from '@cdo/apps/templates/teacherDashboard/types/teacherSectionTypes';
@@ -49,9 +49,9 @@ const SectionCardBody: React.FC<SectionCardBodyProps> = ({section}) => {
                 iconName={'check-circle'}
                 iconStyle={'solid'}
               />
-              <BodyThreeText>
+              <Typography variant="body3" gutterBottom>
                 {i18n.studentsAdded({numStudents: section.studentCount})}
-              </BodyThreeText>
+              </Typography>
             </div>
           </div>
         ) : (

--- a/apps/src/templates/studioHomepages/teacherHomepageV2/SkeletonTeacherPromo.tsx
+++ b/apps/src/templates/studioHomepages/teacherHomepageV2/SkeletonTeacherPromo.tsx
@@ -1,8 +1,4 @@
-import {
-  BodyThreeText,
-  Heading5,
-  OverlineTwoText,
-} from '@code-dot-org/component-library/typography';
+import {Typography} from '@mui/material';
 import classNames from 'classnames';
 import React from 'react';
 
@@ -18,18 +14,22 @@ export const SkeletonTeacherPromo: React.FC = () => {
       aria-label={i18n.loading()}
       key="skeleton"
     >
-      <OverlineTwoText className={styles.promotionType}>
+      <Typography
+        className={styles.promotionType}
+        variant="overline2"
+        gutterBottom
+      >
         <Skeleton />
-      </OverlineTwoText>
-      <Heading5 className={styles.promotionTitle}>
+      </Typography>
+      <Typography className={styles.promotionTitle} variant="h5" gutterBottom>
         <Skeleton />
-      </Heading5>
+      </Typography>
       <div className={classNames(styles.promotionImage, styles.imageSkeleton)}>
         <Skeleton />
       </div>
-      <BodyThreeText>
+      <Typography variant="body3" gutterBottom>
         <Skeleton count={4} />
-      </BodyThreeText>
+      </Typography>
     </li>
   );
 };

--- a/apps/src/templates/studioHomepages/teacherHomepageV2/TaskButton.tsx
+++ b/apps/src/templates/studioHomepages/teacherHomepageV2/TaskButton.tsx
@@ -1,5 +1,5 @@
 import FontAwesomeV6Icon from '@code-dot-org/component-library/fontAwesomeV6Icon';
-import {BodyThreeText} from '@code-dot-org/component-library/typography';
+import {Typography} from '@mui/material';
 import React from 'react';
 import {NavLink} from 'react-router-dom';
 
@@ -58,7 +58,9 @@ export const TaskButton: React.FC<TaskButtonProps> = ({
           iconName={icon}
           iconStyle={'solid'}
         />
-        <BodyThreeText>{buttonText}</BodyThreeText>
+        <Typography variant="body3" gutterBottom>
+          {buttonText}
+        </Typography>
       </div>
       <FontAwesomeV6Icon
         className={styles.taskButtonArrow}

--- a/apps/src/templates/studioHomepages/teacherHomepageV2/TeacherHomepage.tsx
+++ b/apps/src/templates/studioHomepages/teacherHomepageV2/TeacherHomepage.tsx
@@ -1,4 +1,4 @@
-import {Heading2} from '@code-dot-org/component-library/typography';
+import {Typography} from '@mui/material';
 import React from 'react';
 
 import {EVENTS, PLATFORMS} from '@cdo/apps/metrics/AnalyticsConstants.js';
@@ -105,11 +105,11 @@ const TeacherHomepage: React.FC<TeacherHomepageProps> = ({studioUrlPrefix}) => {
   return (
     <div className={styles.teacherHomepage}>
       <div className={styles.teacherHomepageBody}>
-        <Heading2>
+        <Typography variant="h2" gutterBottom>
           {teacherName
             ? i18n.welcome({teacherName: teacherName})
             : i18n.welcomeWithoutName()}
-        </Heading2>
+        </Typography>
         <div className={styles.teacherHomepageContent}>
           <div className={styles.teacherHomepageLeftContent}>
             <Header

--- a/apps/src/templates/studioHomepages/teacherHomepageV2/TeacherHomepageDrawer.tsx
+++ b/apps/src/templates/studioHomepages/teacherHomepageV2/TeacherHomepageDrawer.tsx
@@ -1,10 +1,7 @@
 import Alert from '@code-dot-org/component-library/alert';
 import {Button} from '@code-dot-org/component-library/button';
 import CloseButton from '@code-dot-org/component-library/closeButton';
-import {
-  BodyThreeText,
-  Heading3,
-} from '@code-dot-org/component-library/typography';
+import {Typography} from '@mui/material';
 import Drawer from '@mui/material/Drawer';
 import React from 'react';
 
@@ -383,8 +380,12 @@ export const TeacherHomepageDrawer: React.FC<TeacherHomepageDrawerProps> = ({
             }
           />
         )}
-        <Heading3>{headerText()}</Heading3>
-        <BodyThreeText>{bodyText()}</BodyThreeText>
+        <Typography variant="h3" gutterBottom>
+          {headerText()}
+        </Typography>
+        <Typography variant="body3" gutterBottom>
+          {bodyText()}
+        </Typography>
       </div>
       {interactiveContent()}
       <div className={styles.drawerFooter}>

--- a/apps/src/templates/studioHomepages/teacherHomepageV2/TeacherPromo.tsx
+++ b/apps/src/templates/studioHomepages/teacherHomepageV2/TeacherPromo.tsx
@@ -1,12 +1,7 @@
 import {LinkButton} from '@code-dot-org/component-library/button';
 import CloseButton from '@code-dot-org/component-library/closeButton';
 import FontAwesomeV6Icon from '@code-dot-org/component-library/fontAwesomeV6Icon';
-import {
-  BodyThreeText,
-  Heading5,
-  OverlineTwoText,
-  StrongText,
-} from '@code-dot-org/component-library/typography';
+import {Typography} from '@mui/material';
 import classNames from 'classnames';
 import _ from 'lodash';
 import React from 'react';
@@ -78,24 +73,38 @@ const TeacherPromo: React.FC<TeacherPromoProps> = ({
           onClick={() => onClose(id)}
         />
       )}
-      <OverlineTwoText className={styles.promotionType}>
+      <Typography
+        className={styles.promotionType}
+        variant="overline2"
+        gutterBottom
+      >
         <FontAwesomeV6Icon iconName={getIconType(announcementType)} />{' '}
         {announcementType}
-      </OverlineTwoText>
-      <Heading5 className={styles.promotionTitle}>{title}</Heading5>
+      </Typography>
+      <Typography className={styles.promotionTitle} variant="h5" gutterBottom>
+        {title}
+      </Typography>
       {image && (
         <img src={image} alt={title} className={styles.promotionImage} />
       )}
-      <BodyThreeText>{description}</BodyThreeText>
+      <Typography variant="body3" gutterBottom>
+        {description}
+      </Typography>
       {partnerLogo && (
-        <BodyThreeText className={styles.promotionPartnerLogo}>
-          <StrongText>{i18n.partnershipWith()}</StrongText>
+        <Typography
+          className={styles.promotionPartnerLogo}
+          variant="body3"
+          gutterBottom
+        >
+          <Typography variant="strong" gutterBottom>
+            {i18n.partnershipWith()}
+          </Typography>
           <img
             src={partnerLogo}
             alt="Partner Logo"
             className={styles.partnerLogo}
           />
-        </BodyThreeText>
+        </Typography>
       )}
       <LinkButton
         href={buttonTarget}

--- a/apps/src/templates/studioHomepages/teacherHomepageV2/sectionAvatars/SectionAvatarEditDialog.tsx
+++ b/apps/src/templates/studioHomepages/teacherHomepageV2/sectionAvatars/SectionAvatarEditDialog.tsx
@@ -1,9 +1,6 @@
 import Button from '@code-dot-org/component-library/button';
 import {CustomDialog} from '@code-dot-org/component-library/dialog';
-import {
-  Heading3,
-  BodyTwoText,
-} from '@code-dot-org/component-library/typography';
+import {Typography} from '@mui/material';
 import React from 'react';
 
 import i18n from '@cdo/locale';
@@ -53,12 +50,16 @@ const SectionAvatarEditDialog: React.FC<SectionAvatarEditDialogProps> = ({
         {i18n.avatarEditDialogDescription()}
       </div>
       <div className={styles.avatarDialogHeader}>
-        <Heading3>{i18n.editAvatar()}</Heading3>
+        <Typography variant="h3" gutterBottom>
+          {i18n.editAvatar()}
+        </Typography>
         <hr />
       </div>
       <div className={styles.avatarDialogBody}>
         <label className={styles.avatarDialogLabels}>
-          <BodyTwoText>{i18n.avatar()}</BodyTwoText>
+          <Typography variant="body2" gutterBottom>
+            {i18n.avatar()}
+          </Typography>
           <SectionAvatar
             color={selectedColor}
             emoji={selectedEmoji}
@@ -67,7 +68,9 @@ const SectionAvatarEditDialog: React.FC<SectionAvatarEditDialogProps> = ({
         </label>
         <div className={styles.avatarDialogBodyRight}>
           <label className={styles.avatarDialogLabels}>
-            <BodyTwoText>{i18n.chooseEmoji()}</BodyTwoText>
+            <Typography variant="body2" gutterBottom>
+              {i18n.chooseEmoji()}
+            </Typography>
             <PickerGrid
               type={'emoji'}
               selectCallback={setSelectedEmoji}
@@ -75,7 +78,9 @@ const SectionAvatarEditDialog: React.FC<SectionAvatarEditDialogProps> = ({
             />
           </label>
           <label className={styles.avatarDialogLabels}>
-            <BodyTwoText>{i18n.chooseColor()}</BodyTwoText>
+            <Typography variant="body2" gutterBottom>
+              {i18n.chooseColor()}
+            </Typography>
             <PickerGrid
               type={'color'}
               selectCallback={setSelectedColor}

--- a/apps/src/templates/studioHomepages/teacherHomepageV2/welcome/WelcomePopup.tsx
+++ b/apps/src/templates/studioHomepages/teacherHomepageV2/welcome/WelcomePopup.tsx
@@ -1,5 +1,5 @@
 import Modal from '@code-dot-org/component-library/modal';
-import {BodyTwoText} from '@code-dot-org/component-library/typography';
+import {Typography} from '@mui/material';
 import React from 'react';
 
 import UserPreferences from '@cdo/apps/lib/util/UserPreferences';
@@ -94,7 +94,9 @@ const WelcomePopup: React.FC<WelcomePopupProps> = ({onCloseCallback}) => {
       customContent={
         <div>
           <img src={currentSlide.image} alt="" className={styles.image} />
-          <BodyTwoText>{currentSlide.body}</BodyTwoText>
+          <Typography variant="body2" gutterBottom>
+            {currentSlide.body}
+          </Typography>
         </div>
       }
     />

--- a/apps/src/themes/code.org/styleOverrides/typography.ts
+++ b/apps/src/themes/code.org/styleOverrides/typography.ts
@@ -29,46 +29,46 @@ export const TYPOGRAPHY_OVERRIDES: Components<Theme>['MuiTypography'] = {
       },
     }),
     gutterBottom: ({theme}) => ({
-      '&.MuiTypography-h1': {
+      '&:where(.MuiTypography-h1)': {
         marginBottom: theme.spacing(3), // 24px
       },
-      '&.MuiTypography-h2': {
+      '&:where(.MuiTypography-h2)': {
         marginBottom: theme.spacing(2.125), // 17px
       },
-      '&.MuiTypography-h3': {
+      '&:where(.MuiTypography-h3)': {
         marginBottom: theme.spacing(1.75), // 14px
       },
-      '&.MuiTypography-h4': {
+      '&:where(.MuiTypography-h4)': {
         marginBottom: theme.spacing(1.5), // 12px
       },
-      '&.MuiTypography-h5': {
+      '&:where(.MuiTypography-h5)': {
         marginBottom: theme.spacing(1.25), // 10px
       },
-      '&.MuiTypography-h6': {
+      '&:where(.MuiTypography-h6)': {
         marginBottom: theme.spacing(1), // 8px
       },
-      '&.MuiTypography-body1': {
+      '&:where(.MuiTypography-body1)': {
         marginBottom: theme.spacing(2.5), // 20px
       },
-      '&.MuiTypography-body2': {
+      '&:where(.MuiTypography-body2)': {
         marginBottom: theme.spacing(2), // 16px
       },
-      '&.MuiTypography-body3': {
+      '&:where(.MuiTypography-body3)': {
         marginBottom: theme.spacing(1.75), // 14px
       },
-      '&.MuiTypography-body4': {
+      '&:where(.MuiTypography-body4)': {
         marginBottom: theme.spacing(1.625), // 13px
       },
-      '&.MuiTypography-overline1': {
+      '&:where(.MuiTypography-overline1)': {
         marginBottom: theme.spacing(1.75), // 14px
       },
-      '&.MuiTypography-overline2': {
+      '&:where(.MuiTypography-overline2)': {
         marginBottom: theme.spacing(1.625), // 13px
       },
-      '&.MuiTypography-overline3': {
+      '&:where(.MuiTypography-overline3)': {
         marginBottom: theme.spacing(1.375), // 11px
       },
-      '&.MuiTypography-figcaption': {
+      '&:where(.MuiTypography-figcaption)': {
         marginBottom: theme.spacing(1.75), // 14px
       },
     }),

--- a/apps/tools/codemod/typography-to-mui.js
+++ b/apps/tools/codemod/typography-to-mui.js
@@ -7,7 +7,7 @@
 // - Rewrites imports: removes DSCO Typography / wrapper imports; adds MUI Typography import
 
 // Run:
-//   npx jscodeshift -t ./apps/tools/codemod/typography-to-mui.js "src/**/*.{ts,tsx,js,jsx}" --parser=tsx --extensions=tsx,ts,jsx,js
+//   npx jscodeshift -t ./apps/tools/codemod/typography-to-mui.js "src/directory-or-file-to-modify" --parser=tsx --extensions=tsx,ts,jsx,js
 
 // Tips:
 //   - Add --dry --print to preview changes


### PR DESCRIPTION
Reverts code-dot-org/code-dot-org#69106

This re-applies the changes in https://github.com/code-dot-org/code-dot-org/pull/69106 after it failed eyes tests for the teacher dashboard. The eyes test showed that mui Typography elements with the gutterBottom prop had the wrong `margin-bottom` styles if the margin had been overridden in a module scss stylesheet. This was because the `gutterBottom` style override was applied with two classes and resulted in `MuiTypography-root.MuiTypography-body2` which has a specificity of (0,2,0), and the desired scss stylesheet styles had a class + an element, giving specificity of (0,1,1). replacing the style override with `MuiTypography-root:where(.MuiTypography-body2)` reduced the specificity to (0,1,0) since the "where" pseudo class selector gives a specificity of zero, resulting in (0,1,0), allowing our scss styles to take priority.