### PR TITLE
Optionally Configure a Marketing Site to use Web Application Firewall

### DIFF
--- a/frontend/apps/marketing/cicd/1-setup/account-resources.yml.erb
+++ b/frontend/apps/marketing/cicd/1-setup/account-resources.yml.erb
@@ -240,10 +240,11 @@ Resources:
                               TextTransformations:
                                 - Priority: 0
                                   Type: NONE
+          # This Label helps downstream Rules conditionally apply the CHALLENGE action, so don't Sample or publish Metrics.
           VisibilityConfig:
-            CloudWatchMetricsEnabled: true
+            CloudWatchMetricsEnabled: false
             MetricName: LabelHTMLRequests
-            SampledRequestsEnabled: true
+            SampledRequestsEnabled: false
           RuleLabels:
             - Name: HTMLContent
         - Name: AWS-AWSManagedRulesAmazonIpReputationList

--- a/frontend/apps/marketing/cicd/1-setup/account-resources.yml.erb
+++ b/frontend/apps/marketing/cicd/1-setup/account-resources.yml.erb
@@ -691,8 +691,8 @@ Resources:
   CloudFrontManagementPolicy:
     Type: AWS::IAM::ManagedPolicy
     Properties:
-      ManagedPolicyName: marketing-sites-cloudfront-management-policy
-      Description: CloudFront permissions for marketing sites
+      ManagedPolicyName: marketing-sites-cloudfront-waf-shield-policy
+      Description: CloudFront distribution management with WAF and Shield Advanced protection capabilities
       PolicyDocument:
         Version: '2012-10-17'
         Statement:
@@ -735,12 +735,84 @@ Resources:
             Action:
               - cloudfront:Get*
               - cloudfront:Describe*
+              - cloudfront:List*
             Resource: '*'
+          
+          # WAF Permissions for CloudFront Protection
+          - Sid: WAFReadPermissions
+            Effect: Allow
+            Action:
+              - wafv2:GetWebACL
+              - wafv2:ListWebACLs
+              - wafv2:GetWebACLForResource
+              - wafv2:ListResourcesForWebACL
+              - wafv2:ListTagsForResource
+            Resource:
+              - !Sub 'arn:aws:wafv2:*:${AWS::AccountId}:global/webacl/*/*'
+              - !Sub 'arn:aws:wafv2:*:${AWS::AccountId}:global/ipset/*/*'
+          
+          - Sid: WAFAssociationPermissions
+            Effect: Allow
+            Action:
+              - wafv2:AssociateWebACL
+              - wafv2:DisassociateWebACL
+            Resource:
+              - !Sub 'arn:aws:wafv2:*:${AWS::AccountId}:global/webacl/*/*'
+              - !Sub 'arn:aws:cloudfront::${AWS::AccountId}:distribution/*'
+          
+          - Sid: WAFTagPermissions
+            Effect: Allow
+            Action:
+              - wafv2:TagResource
+              - wafv2:UntagResource
+            Resource: !Sub 'arn:aws:wafv2:*:${AWS::AccountId}:global/webacl/*/*'
+          
+          # Shield Advanced Permissions for CloudFront Protection
+          - Sid: ShieldReadPermissions
+            Effect: Allow
+            Action:
+              - shield:DescribeProtection
+              - shield:ListProtections
+              - shield:DescribeSubscription
+              - shield:GetSubscriptionState
+              - shield:DescribeDRTAccess
+              - shield:DescribeEmergencyContactSettings
+              - shield:ListTagsForResource
+            Resource: '*'
+          
+          - Sid: ShieldProtectionManagement
+            Effect: Allow
+            Action:
+              - shield:CreateProtection
+              - shield:DeleteProtection
+              - shield:UpdateProtection
+              - shield:UpdateApplicationLayerAutomaticResponse
+              - shield:EnableApplicationLayerAutomaticResponse
+              - shield:DisableApplicationLayerAutomaticResponse
+            Resource:
+              - !Sub 'arn:aws:shield::${AWS::AccountId}:protection/*'
+              - !Sub 'arn:aws:cloudfront::${AWS::AccountId}:distribution/*'
+          
+          - Sid: ShieldTagManagement
+            Effect: Allow
+            Action:
+              - shield:TagResource
+              - shield:UntagResource
+            Resource: !Sub 'arn:aws:shield::${AWS::AccountId}:protection/*'
+          
+          - Sid: ShieldHealthCheckAssociation
+            Effect: Allow
+            Action:
+              - shield:AssociateHealthCheck
+              - shield:DisassociateHealthCheck
+            Resource:
+              - !Sub 'arn:aws:shield::${AWS::AccountId}:protection/*'
+              - !Sub 'arn:aws:route53:::healthcheck/*'
   DNSCertificateManagementPolicy:
     Type: AWS::IAM::ManagedPolicy
     Properties:
-      ManagedPolicyName: marketing-sites-dns-certificate-management-policy
-      Description: Route53 and ACM permissions for marketing sites
+      ManagedPolicyName: marketing-sites-dns-certificate-health-policy
+      Description: Route53 DNS, ACM certificates, and health check management for Shield Advanced integration
       PolicyDocument:
         Version: '2012-10-17'
         Statement:
@@ -754,6 +826,34 @@ Resources:
               - acm:Add*
               - acm:Describe*
             Resource: '*'
+          
+          # Route 53 Health Check Permissions (for Shield Advanced)
+          - Sid: Route53HealthCheckManagement
+            Effect: Allow
+            Action:
+              - route53:CreateHealthCheck
+              - route53:DeleteHealthCheck
+              - route53:UpdateHealthCheck
+              - route53:GetHealthCheck
+              - route53:GetHealthCheckStatus
+              - route53:ListHealthChecks
+              - route53:ChangeTagsForResource
+            Resource:
+              - !Sub 'arn:aws:route53:::healthcheck/*'
+              - 'arn:aws:route53:::hostedzone/*'
+              - 'arn:aws:route53:::change/*'
+          
+          # CloudWatch Alarms for Shield Health Checks
+          - Sid: CloudWatchAlarmManagement
+            Effect: Allow
+            Action:
+              - cloudwatch:PutMetricAlarm
+              - cloudwatch:DeleteAlarms
+              - cloudwatch:DescribeAlarms
+              - cloudwatch:GetMetricStatistics
+              - cloudwatch:PutMetricData
+            Resource:
+              - !Sub 'arn:aws:cloudwatch:*:${AWS::AccountId}:alarm:*'
   EFSManagementPolicy:
     Type: AWS::IAM::ManagedPolicy
     Properties:
@@ -1132,6 +1232,33 @@ Resources:
                   - secretsmanager:Get*
                   - secretsmanager:Describe*
                 Resource: "arn:aws:secretsmanager:*:*:secret:marketing-sites/<%=environment_type%>/*"
+              
+              # WAF Web ACL Association for CloudFront
+              - Sid: AllowMarketingSitesWebACLAssociation
+                Effect: Allow
+                Action:
+                  - wafv2:AssociateWebACL
+                  - wafv2:DisassociateWebACL
+                  - wafv2:GetWebACLForResource
+                Resource:
+                  - !GetAtt MarketingSitesWebACL.Arn
+                  - !Sub "arn:aws:cloudfront::${AWS::AccountId}:distribution/*"
+              
+              # Shield Advanced Protection for CloudFront (primarily for production)
+              - Sid: AllowShieldProtectionForCloudFront
+                Effect: Allow
+                Action:
+                  - shield:CreateProtection
+                  - shield:DeleteProtection
+                  - shield:UpdateProtection
+                  - shield:DescribeProtection
+                  - shield:AssociateHealthCheck
+                  - shield:DisassociateHealthCheck
+                  - shield:TagResource
+                  - shield:UntagResource
+                Resource:
+                  - !Sub "arn:aws:shield::${AWS::AccountId}:protection/*"
+                  - !Sub "arn:aws:cloudfront::${AWS::AccountId}:distribution/*"
 <% end %>
 
 Outputs:
@@ -1141,6 +1268,9 @@ Outputs:
   MarketingSitesWebACLId:
     Description: ID of the Marketing Sites WAF Web ACL
     Value: !GetAtt MarketingSitesWebACL.Id
+  MarketingSitesWebACLName:
+    Description: Name of the Marketing Sites WAF Web ACL for easy reference
+    Value: !Ref MarketingSitesWebACL
 <%
   marketing_sites_environment_configuration.each do |environment_type, _|
     environment_type = environment_type.to_s

--- a/frontend/apps/marketing/cicd/3-app/deploy.rb
+++ b/frontend/apps/marketing/cicd/3-app/deploy.rb
@@ -24,7 +24,8 @@ options = {
   # TODO: populate Account ID dynamically.
   # role_arn: "arn:aws:iam::${account_id}:role/admin/CloudFormationMarketingSitesDevelopmentRole"
   role_arn: nil,
-  cloudformation_role_boundary: nil
+  cloudformation_role_boundary: nil,
+  web_application_firewall: nil
 }
 
 opt_parser = OptionParser.new do |opts|
@@ -152,6 +153,15 @@ opt_parser = OptionParser.new do |opts|
     "Format: arn:aws:iam::<account-id>:policy/<policy-name>"
   ) do |arn|
     options[:cloudformation_role_boundary] = arn
+  end
+
+  opts.on(
+    '--web-application-firewall ARN',
+    String,
+    "ARN of the Web Application Firewall Web Access Control List (WAF Web ACL / WAF Protection Pack) to protect this site.",
+    "Format: arn:aws:wafv2:<region-id>:<account-id>:global/webacl/<Web ACL Name>/<Web ACL Id>"
+  ) do |arn|
+    options[:web_application_firewall] = arn
   end
 
   opts.on('-h', '--help', 'Show this help message') do

--- a/frontend/apps/marketing/cicd/3-app/template.yml.erb
+++ b/frontend/apps/marketing/cicd/3-app/template.yml.erb
@@ -320,6 +320,9 @@ Resources:
             ViewerProtocolPolicy: redirect-to-https
             ResponseHeadersPolicyId: !Ref DefaultResponseHeadersPolicy
             OriginRequestPolicyId: 216adef6-5c7f-47e4-b989-5492eafa07d3 # AllViewer
+<% if options[:web_application_firewall] %>
+        WebACLId: <%= options[:web_application_firewall] %>
+<% end %>
 
   ####################################
   # Load Balancer Resources          #


### PR DESCRIPTION
https://codedotorg.atlassian.net/browse/INF-1701

## Test

Successfully applied this change to the Stack `csforall-marketing-sites-dev-code-org` in our AWS Dev Account.


## Deployment strategy

1. Merge this change
2. Deploy the Global / Region Resources in the production AWS Account and each Region in that Account
3. Update the GitHub Actions Environment for test and production CSforALL Marketing Sites to specify that the Account's WAF Protection Pack (Web ACL) should be used to protect the site.



## Follow-up work

Enable Shield Advanced protection for a Marketing Site, if the Account has a Shield Advanced Subscription.



## Privacy
<!--  How does this change impact Student & Teacher privacy?
      - Does this collect, use, share, or modify PII, either new or existing? -->



## Security
<!--  How does this change impact our security surface-area?
      - Do API's touched have the right auth?
      - Do infra changes impact our attack surface or encryption?
-->



## Caching
<!--  How does this change impact caching behavior?
      - Are cache keys or invalidation strategies affected?
      - Will this require cache warming or invalidation after deployment? -->



## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
