### PR TITLE
Add Metrics Reporter logs for saving errors in legacy projects

### DIFF
--- a/apps/src/code-studio/initApp/project.js
+++ b/apps/src/code-studio/initApp/project.js
@@ -5,6 +5,7 @@ import {
   OPEN_ENDED_PROJECTS_YOUNG_AGE,
 } from '@cdo/apps/constants';
 import firehoseClient from '@cdo/apps/metrics/firehose';
+import MetricsReporter from '@cdo/apps/metrics/MetricsReporter';
 import {getGlobalEditionRegion} from '@cdo/apps/util/globalEdition';
 import HttpClient from '@cdo/apps/util/HttpClient';
 import {AbuseConstants} from '@cdo/generated-scripts/sharedConstants';
@@ -966,6 +967,17 @@ var projects = (module.exports = {
 
     return new Promise(resolve => {
       this.getUpdatedSourceAndHtml_(newSources => {
+        if (newSources.error) {
+          MetricsReporter.logError({
+            event:
+              'Error from getUpdatedSourceAndHtml_ in saveIfSourcesChanged',
+            error: newSources.error,
+            appType: this.getStandaloneApp(),
+            channelId: this.getCurrentId(),
+          });
+          resolve();
+          return;
+        }
         const sourcesChanged =
           JSON.stringify(currentSources) !== JSON.stringify(newSources);
         if (sourcesChanged || thumbnailChanged) {
@@ -1392,6 +1404,14 @@ var projects = (module.exports = {
     // Share URLs only make sense for standalone app types.
     // This includes most app types, but excludes pixelation.
     const shareUrl = this.getStandaloneApp() ? this.getShareUrl() : '';
+
+    MetricsReporter.logError({
+      event: errorType,
+      errorMessage: errorText,
+      errorCount: errorCount,
+      channelId: this.getCurrentId(),
+      appType: this.getStandaloneApp(),
+    });
 
     return firehoseClient.putRecord(
       {

--- a/apps/src/code-studio/initApp/project.js
+++ b/apps/src/code-studio/initApp/project.js
@@ -5,6 +5,7 @@ import {
   OPEN_ENDED_PROJECTS_YOUNG_AGE,
 } from '@cdo/apps/constants';
 import firehoseClient from '@cdo/apps/metrics/firehose';
+import MetricsReporter from '@cdo/apps/metrics/MetricsReporter';
 import {getGlobalEditionRegion} from '@cdo/apps/util/globalEdition';
 import HttpClient from '@cdo/apps/util/HttpClient';
 import {AbuseConstants} from '@cdo/generated-scripts/sharedConstants';
@@ -716,10 +717,25 @@ var projects = (module.exports = {
         }
 
         if (!appOptions.level.skipRunSave) {
-          $(window).on(
-            events.appModeChanged,
-            this.saveIfSourcesChanged.bind(this)
-          );
+          $(window).on(events.appModeChanged, () => {
+            try {
+              this.saveIfSourcesChanged().catch(error => {
+                MetricsReporter.logError({
+                  message:
+                    'error in saveIfSourcesChanged when app mode changed',
+                  error,
+                  channelId: this.getCurrentId(),
+                });
+              });
+            } catch (error) {
+              MetricsReporter.logError({
+                message:
+                  'error in saveIfSourcesChanged when app mode changed - synchronously',
+                error,
+                channelId: this.getCurrentId(),
+              });
+            }
+          });
         }
 
         $(window).on(
@@ -1295,7 +1311,17 @@ var projects = (module.exports = {
       this.sourceHandler
         .getLevelSource()
         .then(source => {
-          const html = this.sourceHandler.getLevelHtml();
+          let html;
+          try {
+            html = this.sourceHandler.getLevelHtml();
+          } catch (error) {
+            MetricsReporter.logError({
+              message: 'error in getLevelHtml',
+              error,
+              channelId: this.getCurrentId(),
+            });
+            return callback({error});
+          }
           const makerAPIsEnabled = this.sourceHandler.getMakerAPIsEnabled();
           const selectedSong = this.sourceHandler.getSelectedSong();
           const selectedPoem = this.sourceHandler.getSelectedPoem();

--- a/apps/src/code-studio/initApp/project.js
+++ b/apps/src/code-studio/initApp/project.js
@@ -722,7 +722,7 @@ var projects = (module.exports = {
               this.saveIfSourcesChanged().catch(error => {
                 MetricsReporter.logError({
                   message:
-                    'error in saveIfSourcesChanged when app mode changed',
+                    'Error in saveIfSourcesChanged when app mode changed',
                   error,
                   channelId: this.getCurrentId(),
                 });
@@ -730,7 +730,7 @@ var projects = (module.exports = {
             } catch (error) {
               MetricsReporter.logError({
                 message:
-                  'error in saveIfSourcesChanged when app mode changed - synchronously',
+                  'Error in saveIfSourcesChanged when app mode changed - synchronously',
                 error,
                 channelId: this.getCurrentId(),
               });
@@ -980,8 +980,12 @@ var projects = (module.exports = {
       return Promise.resolve();
     }
 
-    return new Promise(resolve => {
+    return new Promise((resolve, reject) => {
       this.getUpdatedSourceAndHtml_(newSources => {
+        if (newSources.error) {
+          return reject(newSources.error);
+        }
+
         const sourcesChanged =
           JSON.stringify(currentSources) !== JSON.stringify(newSources);
         if (sourcesChanged || thumbnailChanged) {
@@ -1046,6 +1050,9 @@ var projects = (module.exports = {
     const completeAsyncSave = () =>
       new Promise((resolve, reject) =>
         this.getUpdatedSourceAndHtml_(sourceAndHtml => {
+          if (sourceAndHtml.error) {
+            return reject(sourceAndHtml.error);
+          }
           try {
             this.saveSourceAndHtml_(
               sourceAndHtml,
@@ -1316,7 +1323,7 @@ var projects = (module.exports = {
             html = this.sourceHandler.getLevelHtml();
           } catch (error) {
             MetricsReporter.logError({
-              message: 'error in getLevelHtml',
+              message: 'Error in getLevelHtml',
               error,
               channelId: this.getCurrentId(),
             });
@@ -1342,7 +1349,14 @@ var projects = (module.exports = {
             teacherHasConfirmedUploadWarning,
           });
         })
-        .catch(error => callback({error}))
+        .catch(error => {
+          MetricsReporter.logError({
+            message: 'Error in getUpdatedSourceAndHtml promise chain',
+            error,
+            channelId: this.getCurrentId(),
+          });
+          callback({error});
+        })
     );
   },
 
@@ -1356,8 +1370,11 @@ var projects = (module.exports = {
    * @returns {Promise} (mostly useful for tests)
    */
   setMakerEnabled(apisEnabled) {
-    return new Promise(resolve => {
+    return new Promise((resolve, reject) => {
       this.getUpdatedSourceAndHtml_(sourceAndHtml => {
+        if (sourceAndHtml.error) {
+          return reject(sourceAndHtml.error);
+        }
         this.saveSourceAndHtml_(
           {
             ...sourceAndHtml,
@@ -1381,8 +1398,11 @@ var projects = (module.exports = {
         library.fromLevelbuilder = true;
       });
     }
-    return new Promise(resolve => {
+    return new Promise((resolve, reject) => {
       this.getUpdatedSourceAndHtml_(sourceAndHtml => {
+        if (sourceAndHtml.error) {
+          return reject(sourceAndHtml.error);
+        }
         this.saveSourceAndHtml_(
           {
             ...sourceAndHtml,
@@ -1535,6 +1555,11 @@ var projects = (module.exports = {
     this.getUpdatedSourceAndHtml_(newSources => {
       if (newSources.error) {
         header.showProjectSaveError();
+        MetricsReporter.logError({
+          message: 'Error in autosave getUpdatedSourceAndHtml',
+          error: newSources.error,
+          channelId: this.getCurrentId(),
+        });
         callCallback();
         return;
       }

--- a/apps/src/code-studio/initApp/project.js
+++ b/apps/src/code-studio/initApp/project.js
@@ -967,6 +967,7 @@ var projects = (module.exports = {
 
     return new Promise(resolve => {
       this.getUpdatedSourceAndHtml_(newSources => {
+        // Adding error logging for retrieval of current sources for debugging/monitoring purposes.
         if (newSources.error) {
           MetricsReporter.logError({
             event:
@@ -975,8 +976,6 @@ var projects = (module.exports = {
             appType: this.getStandaloneApp(),
             channelId: this.getCurrentId(),
           });
-          resolve();
-          return;
         }
         const sourcesChanged =
           JSON.stringify(currentSources) !== JSON.stringify(newSources);
@@ -1409,8 +1408,8 @@ var projects = (module.exports = {
       event: errorType,
       errorMessage: errorText,
       errorCount: errorCount,
-      channelId: this.getCurrentId(),
       appType: this.getStandaloneApp(),
+      channelId: this.getCurrentId(),
     });
 
     return firehoseClient.putRecord(

--- a/apps/src/code-studio/initApp/project.js
+++ b/apps/src/code-studio/initApp/project.js
@@ -5,7 +5,6 @@ import {
   OPEN_ENDED_PROJECTS_YOUNG_AGE,
 } from '@cdo/apps/constants';
 import firehoseClient from '@cdo/apps/metrics/firehose';
-import MetricsReporter from '@cdo/apps/metrics/MetricsReporter';
 import {getGlobalEditionRegion} from '@cdo/apps/util/globalEdition';
 import HttpClient from '@cdo/apps/util/HttpClient';
 import {AbuseConstants} from '@cdo/generated-scripts/sharedConstants';
@@ -717,25 +716,10 @@ var projects = (module.exports = {
         }
 
         if (!appOptions.level.skipRunSave) {
-          $(window).on(events.appModeChanged, () => {
-            try {
-              this.saveIfSourcesChanged().catch(error => {
-                MetricsReporter.logError({
-                  message:
-                    'Error in saveIfSourcesChanged when app mode changed',
-                  error,
-                  channelId: this.getCurrentId(),
-                });
-              });
-            } catch (error) {
-              MetricsReporter.logError({
-                message:
-                  'Error in saveIfSourcesChanged when app mode changed - synchronously',
-                error,
-                channelId: this.getCurrentId(),
-              });
-            }
-          });
+          $(window).on(
+            events.appModeChanged,
+            this.saveIfSourcesChanged.bind(this)
+          );
         }
 
         $(window).on(
@@ -980,12 +964,8 @@ var projects = (module.exports = {
       return Promise.resolve();
     }
 
-    return new Promise((resolve, reject) => {
+    return new Promise(resolve => {
       this.getUpdatedSourceAndHtml_(newSources => {
-        if (newSources.error) {
-          return reject(newSources.error);
-        }
-
         const sourcesChanged =
           JSON.stringify(currentSources) !== JSON.stringify(newSources);
         if (sourcesChanged || thumbnailChanged) {
@@ -1050,9 +1030,6 @@ var projects = (module.exports = {
     const completeAsyncSave = () =>
       new Promise((resolve, reject) =>
         this.getUpdatedSourceAndHtml_(sourceAndHtml => {
-          if (sourceAndHtml.error) {
-            return reject(sourceAndHtml.error);
-          }
           try {
             this.saveSourceAndHtml_(
               sourceAndHtml,
@@ -1318,17 +1295,7 @@ var projects = (module.exports = {
       this.sourceHandler
         .getLevelSource()
         .then(source => {
-          let html;
-          try {
-            html = this.sourceHandler.getLevelHtml();
-          } catch (error) {
-            MetricsReporter.logError({
-              message: 'Error in getLevelHtml',
-              error,
-              channelId: this.getCurrentId(),
-            });
-            return callback({error});
-          }
+          const html = this.sourceHandler.getLevelHtml();
           const makerAPIsEnabled = this.sourceHandler.getMakerAPIsEnabled();
           const selectedSong = this.sourceHandler.getSelectedSong();
           const selectedPoem = this.sourceHandler.getSelectedPoem();
@@ -1349,14 +1316,7 @@ var projects = (module.exports = {
             teacherHasConfirmedUploadWarning,
           });
         })
-        .catch(error => {
-          MetricsReporter.logError({
-            message: 'Error in getUpdatedSourceAndHtml promise chain',
-            error,
-            channelId: this.getCurrentId(),
-          });
-          callback({error});
-        })
+        .catch(error => callback({error}))
     );
   },
 
@@ -1370,11 +1330,8 @@ var projects = (module.exports = {
    * @returns {Promise} (mostly useful for tests)
    */
   setMakerEnabled(apisEnabled) {
-    return new Promise((resolve, reject) => {
+    return new Promise(resolve => {
       this.getUpdatedSourceAndHtml_(sourceAndHtml => {
-        if (sourceAndHtml.error) {
-          return reject(sourceAndHtml.error);
-        }
         this.saveSourceAndHtml_(
           {
             ...sourceAndHtml,
@@ -1398,11 +1355,8 @@ var projects = (module.exports = {
         library.fromLevelbuilder = true;
       });
     }
-    return new Promise((resolve, reject) => {
+    return new Promise(resolve => {
       this.getUpdatedSourceAndHtml_(sourceAndHtml => {
-        if (sourceAndHtml.error) {
-          return reject(sourceAndHtml.error);
-        }
         this.saveSourceAndHtml_(
           {
             ...sourceAndHtml,
@@ -1555,11 +1509,6 @@ var projects = (module.exports = {
     this.getUpdatedSourceAndHtml_(newSources => {
       if (newSources.error) {
         header.showProjectSaveError();
-        MetricsReporter.logError({
-          message: 'Error in autosave getUpdatedSourceAndHtml',
-          error: newSources.error,
-          channelId: this.getCurrentId(),
-        });
         callCallback();
         return;
       }


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
We've received recent Zendesk reports of App Lab, Sprite Lab, and Web Lab projects not saving - see [spreadsheet of Zendesk tickets](https://docs.google.com/spreadsheets/d/1Ju5DEoFKCug2OWFALHglozMuDUcXxwHggURs0avvoZE/edit?gid=0#gid=0) report lost progress by app type.

There have been a couple tickets in particular about lost progress in App Lab Design Mode ([Example](https://codeorg.zendesk.com/agent/tickets/559448)). I looked into how sources are saved in Design Mode - within `project.js`'s `autosave`, we call on `getUpdatedSourceAndHtml_`, which includes a retrieval of html from applab.js's [getHtml](https://github.com/code-dot-org/code-dot-org/blob/2759329da9508b97224c46564f2928dcd06ab8a5/apps/src/applab/applab.js#L322). Within this function, `serializeToLevelHtml` is called from `designMode.js` if `#designModeViz` is visible. Thus, if a user is in Design Mode and stays in Design mode, the project auto-saves every 30 seconds if there's been a change in the Design Mode workspace.

When the user toggles from Design to Code mode, this change triggers the `appModeChanged` event listener which [calls on `saveIfSourcesChanged`](https://github.com/code-dot-org/code-dot-org/blob/91e2057327e35384551df23a1df6745ecece5e6d/apps/src/code-studio/initApp/project.js#L719-L721).

Locally, I added debugging logs and was not able to repro a failure to save html either in Design Mode or when switching from Design to Code mode.

However, I did ask Claude about whether this jQuery window event listener could be fragile, and the response was:
```
The listener uses $(window).on() which stores events in jQuery's internal data structure. This can fail if:
- jQuery is reinitialized or reloaded
- There are multiple jQuery instances on the page
- Certain browser extensions interfere with jQuery event handling
- Memory pressure causes jQuery's event cache to be garbage collected
```
They recommended using native event listeners or redux/state management to trigger saves. However, this is a busy time of year and many users are actively using App Lab projects, so I decided to just add metric reports of retrieval and saving errors of projects.

I added logging via `MetricsReporter` when an error is returned from retrieving the current sources and html, and also included `MetricsReporter` logging within the existing `project`'s `logError_`.  `logError` already includes logging through `firehoseClient`, but `firehose` has not been [reliable](https://codedotorg.slack.com/archives/C0T0TPL9W/p1651865664948019) and product has since been other platforms (e.g., Statsig).

UPDATE:
@cnbrenci searched within New Relic for JS errors, specifically for  'Attempting to blow away existing levelHtml'.
from:
https://github.com/code-dot-org/code-dot-org/blob/7736205270a9615cfa347903c01639c75fdc91c9/apps/src/code-studio/initApp/project.js#L1090-L1092

Interestingly, she found that this [New Relic error](https://one.newrelic.com/nr1-core/errors-inbox/entity-inbox/NTAxNDYzfEJST1dTRVJ8QVBQTElDQVRJT058Mzc5MjIzNA?duration=1800000&filters=selectedInstance%20IN%20%28%29&state=88afbfb1-577a-096a-44a1-3b07e04879ea) occurred often impacting 2.30k users during the past month (Sept 28 - Oct 28). 

Hopefully, additional logging will help us gather more detailed error data and figure out what the source of the failure is.

## Links
<!--  Links to relevant external resources.
      - spec docs, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- Jira: https://codedotorg.atlassian.net/browse/AFL-315

## Testing story
<!--  Does your change include appropriate tests?
      - If so, please describe how the tests included in this PR are sufficient.
      - If not, please explain why this change does not need to be tested. -->




## Deployment strategy
<!--  Any special steps required to deploy this, besides merging?
      - Are there database migrations or manual steps?
      - Does this require coordination with other teams or systems? -->



## Follow-up work
<!--  List any clean-up or technical debt that will be addressed in future work.
      - Include Jira links where applicable.
      - Are there any known limitations or improvements planned? -->

Follow-up can include a Cloud Watch alarm/dashboard for project saving.

## Privacy
<!--  How does this change impact Student & Teacher privacy?
      - Does this collect, use, share, or modify PII, either new or existing? -->



## Security
<!--  How does this change impact our security surface-area?
      - Do API's touched have the right auth?
      - Do infra changes impact our attack surface or encryption?
-->



## Caching
<!--  How does this change impact caching behavior?
      - Are cache keys or invalidation strategies affected?
      - Will this require cache warming or invalidation after deployment? -->



## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
