### PR TITLE
fix: move ui test id to ordered list element rather than parent wrapper

### DIFF
--- a/apps/src/templates/studioHomepages/teacherHomepageV2/SectionList.tsx
+++ b/apps/src/templates/studioHomepages/teacherHomepageV2/SectionList.tsx
@@ -161,7 +161,7 @@ export const SectionList: React.FC<SectionListProps> = ({
     : sortableSectionIds;
 
   return (
-    <div id="ui-test-section-list">
+    <div>
       {sectionsAreLoaded ? (
         <DndContext
           sensors={sensors}
@@ -173,7 +173,7 @@ export const SectionList: React.FC<SectionListProps> = ({
             items={sortableSectionIds}
             strategy={verticalListSortingStrategy}
           >
-            <ol className={styles.sectionList}>
+            <ol id="ui-test-section-list" className={styles.sectionList}>
               {sectionIdsToShow.map(id =>
                 sections[id] ? (
                   <SectionCard

--- a/dashboard/test/ui/features/step_definitions/section_management_steps.rb
+++ b/dashboard/test/ui/features/step_definitions/section_management_steps.rb
@@ -291,7 +291,7 @@ Then /^I save the section id from row (\d+) of the section table$/ do |section_i
   href = nil
   wait_until do
     href = @browser.execute_script(
-      "return $('#ui-test-section-list ol li:eq(#{section_index}) #ui-test-Section-settings').attr('href')"
+      "return $('#ui-test-section-list li:eq(#{section_index}) #ui-test-Section-settings').attr('href')"
     )
     !href.nil?
   end


### PR DESCRIPTION
The parent wrapper with the ui-test id also renders a spinner while the sections are loading. moving the id to the list itself means the ui tests that "wait until" the element is visible will wait for the async fetch to complete.

this happened several times when trying to run the teacher homepage [eyes tests](https://eyes.applitools.com/app/test-results/00000251640705066433/00000251640705066314/steps/1?accountId=mG4DoRfv0ntEgI3XIYBulrKxlZqrHtGwbP3V103ojvLFU110&mode=step-editor) locally:
<img width="1922" height="1008" alt="Screenshot 2025-10-30 at 11 37 47 AM" src="https://github.com/user-attachments/assets/2367af33-5c2f-45f8-b082-240a69cb090d" />

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->



## Links
<!--  Links to relevant external resources.
      - spec docs, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- Jira: 

## Testing story
<!--  Does your change include appropriate tests?
      - If so, please describe how the tests included in this PR are sufficient.
      - If not, please explain why this change does not need to be tested. -->



## Deployment strategy
<!--  Any special steps required to deploy this, besides merging?
      - Are there database migrations or manual steps?
      - Does this require coordination with other teams or systems? -->



## Follow-up work
<!--  List any clean-up or technical debt that will be addressed in future work.
      - Include Jira links where applicable.
      - Are there any known limitations or improvements planned? -->



## Privacy
<!--  How does this change impact Student & Teacher privacy?
      - Does this collect, use, share, or modify PII, either new or existing? -->



## Security
<!--  How does this change impact our security surface-area?
      - Do API's touched have the right auth?
      - Do infra changes impact our attack surface or encryption?
-->



## Caching
<!--  How does this change impact caching behavior?
      - Are cache keys or invalidation strategies affected?
      - Will this require cache warming or invalidation after deployment? -->



## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
