### PR TITLE
[Lab2] Makes Scrollbar navigable

### DIFF
--- a/apps/i18n/pythonlab/en_us.json
+++ b/apps/i18n/pythonlab/en_us.json
@@ -1,7 +1,7 @@
 {
   "changeConsoleVisibility": "Change Console Visibility",
   "codeEditorEditing": "Code Editor: editing",
-  "codeEditorDescription": "Code Editor: Press Enter to edit, Escape to exit.",
+  "codeEditorDescription": "Code Editor: Press Enter to edit, Escape to exit, Arrows to scroll.",
   "console": "Console",
   "consoleOnly": "Console only",
   "consoleOnlyDescription": "A project that outputs to the console.",

--- a/apps/src/code-studio/initializeCodeMirror.js
+++ b/apps/src/code-studio/initializeCodeMirror.js
@@ -127,6 +127,7 @@ function initializeCodeMirror(target, mode, options = {}) {
 
   var editor = CodeMirror.fromTextArea(node, {
     mode: mode,
+    autofocus: false,
     backdrop: backdrop,
     htmlMode: htmlMode,
     viewportMargin: Infinity,

--- a/apps/src/codebridge/Workspace/Workspace.tsx
+++ b/apps/src/codebridge/Workspace/Workspace.tsx
@@ -5,7 +5,7 @@ import {Editor} from '@codebridge/Editor/Editor';
 import {FileBrowser} from '@codebridge/FileBrowser/FileBrowser';
 import {FileTabs} from '@codebridge/FileTabs/FileTabs';
 import classnames from 'classnames';
-import React, {useEffect, useRef} from 'react';
+import React, {useRef} from 'react';
 
 import codebridgeI18n from '@cdo/apps/codebridge/locale';
 import {START_SOURCES, WARNING_BANNER_MESSAGES} from '@cdo/apps/lab2/constants';
@@ -14,7 +14,6 @@ import {setRestoredOldVersion} from '@cdo/apps/lab2/redux/lab2ProjectRedux';
 import {isProjectTemplateLevel} from '@cdo/apps/lab2/redux/lab2ReduxSelectors';
 import PanelContainer from '@cdo/apps/lab2/views/components/PanelContainer';
 import WorkspaceHeader from '@cdo/apps/lab2/views/components/WorkspaceHeader';
-import i18n from '@cdo/apps/pythonlab/locale';
 import {useAppDispatch, useAppSelector} from '@cdo/apps/util/reduxHooks';
 
 import HeaderButtons from './HeaderButtons';
@@ -59,41 +58,6 @@ const Workspace: React.FunctionComponent<WorkspaceProps> = ({
     dispatch(setRestoredOldVersion(false));
   };
 
-  // Sets keydown event listener on the editor container to handle Escape key
-  useEffect(() => {
-    const handleKeyDown = (event: KeyboardEvent) => {
-      if (event.key === 'Escape') {
-        // Move focus back to codemirror-container
-        containerRef.current?.focus();
-      }
-    };
-    const observer = new MutationObserver(() => {
-      const cmContentDiv = document.querySelector('.cm-content') as HTMLElement;
-      if (cmContentDiv) {
-        cmContentDiv.addEventListener('keydown', handleKeyDown);
-        observer.disconnect(); // Stop observing once the element is found
-      }
-    });
-
-    observer.observe(document.body, {childList: true, subtree: true});
-
-    return () => observer.disconnect(); // Cleanup observer on unmount
-  }, []);
-
-  const onKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
-    const cmContentDiv = document.querySelector('.cm-content');
-
-    if (cmContentDiv) {
-      cmContentDiv.setAttribute('aria-label', i18n.codeEditorEditing());
-      cmContentDiv.setAttribute('tabIndex', '-1'); // Ensure focusability
-
-      if (event.key === 'Enter') {
-        // Open the .cm-content (focus it)
-        (cmContentDiv as HTMLElement).focus();
-      }
-    }
-  };
-
   return (
     <div style={style} className={className}>
       <PanelContainer
@@ -118,19 +82,12 @@ const Workspace: React.FunctionComponent<WorkspaceProps> = ({
           </div>
           <FileTabs />
           {showFileBrowser && <FileBrowser />}
-          {/* eslint-disable jsx-a11y/no-noninteractive-tabindex */}
           <div
             className={classnames(moduleStyles.workplaceEditorWrapper, {
               [moduleStyles.withFileBrowser]: showFileBrowser,
             })}
-            tabIndex={0}
-            onKeyDown={onKeyDown}
-            aria-label={i18n.codeEditorDescription()}
             ref={containerRef}
-            role="application"
-            id="uitest-codebridge-editor"
           >
-            {/* eslint-enable jsx-a11y/no-noninteractive-tabindex */}
             <Editor
               langMapping={config.languageMapping}
               editableFileTypes={config.editableFileTypes}

--- a/apps/src/lab2/views/components/editor/CodeEditor.tsx
+++ b/apps/src/lab2/views/components/editor/CodeEditor.tsx
@@ -12,6 +12,7 @@ import {
   setEditorFontSizeLoaded,
 } from '@cdo/apps/lab2/redux/lab2ViewRedux';
 import {AppName} from '@cdo/apps/lab2/types';
+import i18n from '@cdo/apps/pythonlab/locale';
 import {SignInState} from '@cdo/apps/templates/currentUserRedux';
 import {useAppSelector, useAppDispatch} from '@cdo/apps/util/reduxHooks';
 
@@ -79,6 +80,71 @@ const CodeEditor: React.FunctionComponent<CodeEditorProps> = ({
       },
     });
   };
+
+  useEffect(() => {
+    let observer: MutationObserver | null = null;
+    let cleanup: (() => void) | null = null;
+
+    function setup() {
+      // This is not 'reacty' but we have to query them because CodeMirror
+      // manages these elements within the extension.
+      const cmScroller = document.querySelector(
+        '.cm-scroller'
+      ) as HTMLElement | null;
+      const cmContentDiv = document.querySelector(
+        '.cm-content'
+      ) as HTMLElement | null;
+      if (!cmScroller || !cmContentDiv) return false;
+
+      // Make scroller part of tab order, make editor hidden from tab order, and
+      // set labels on both elements
+      cmContentDiv.setAttribute('tabIndex', '-1');
+      cmScroller.setAttribute('tabIndex', '0');
+      cmContentDiv.setAttribute('aria-label', i18n.codeEditorEditing());
+      cmScroller.setAttribute('id', 'uitest-codebridge-editor');
+      cmScroller.setAttribute('aria-label', i18n.codeEditorDescription());
+
+      // Keydown handler for cmScroller
+      const onScrollerKeyDown = (event: KeyboardEvent) => {
+        if (event.key === 'Enter') {
+          cmContentDiv.setAttribute('tabIndex', '-1');
+          cmContentDiv.focus();
+        }
+      };
+      cmScroller.addEventListener('keydown', onScrollerKeyDown);
+
+      // Keydown handler for cmContentDiv (Escape to return focus)
+      const onContentKeyDown = (event: KeyboardEvent) => {
+        if (event.key === 'Escape') {
+          cmScroller.focus();
+        }
+      };
+      cmContentDiv.addEventListener('keydown', onContentKeyDown);
+
+      // Cleanup function
+      cleanup = () => {
+        cmScroller.removeEventListener('keydown', onScrollerKeyDown);
+        cmContentDiv.removeEventListener('keydown', onContentKeyDown);
+      };
+
+      return true;
+    }
+
+    if (!setup()) {
+      observer = new MutationObserver(() => {
+        if (setup()) {
+          observer?.disconnect();
+        }
+      });
+      observer.observe(document.body, {childList: true, subtree: true});
+    }
+
+    return () => {
+      observer?.disconnect();
+      cleanup?.();
+    };
+  }, []);
+
   useEffect(() => {
     if (!editorFontSizeLoaded || editorRef.current === null || didInit) {
       return;

--- a/apps/src/lab2/views/components/editor/CodeEditor.tsx
+++ b/apps/src/lab2/views/components/editor/CodeEditor.tsx
@@ -107,7 +107,6 @@ const CodeEditor: React.FunctionComponent<CodeEditorProps> = ({
       // Keydown handler for cmScroller
       const onScrollerKeyDown = (event: KeyboardEvent) => {
         if (event.key === 'Enter') {
-          cmContentDiv.setAttribute('tabIndex', '-1');
           cmContentDiv.focus();
         }
       };

--- a/dashboard/app/assets/stylesheets/application.scss
+++ b/dashboard/app/assets/stylesheets/application.scss
@@ -4336,6 +4336,12 @@ a {
 
 .cm-scroller {
   overflow: auto;
+
+  &:focus-visible {
+    outline: var(--borders-brand-teal-primary) solid 2px;
+    outline-offset: -2px;
+    border-radius: 0.375rem;
+  }
 }
 
 .cm-wrap {


### PR DESCRIPTION
This PR shifts the tab stop from the editor container to the CodeMirror Scroller. This fixes a WCAG violation that the scroller was not reachable, while also improving tab navigation and not adding another tab stop.

Now, when you land on the container, you are actually on the scroller and can scroll using the arrow keys. You can still then enter and exit the editor as usual. 

This required some code that is unfortunately a bit 'hacky', as we do not and cannot set up the inner workings of codemirror ourselves. Thus, I was required to override the CodeMirror default of autofocus (so I can manage focus myself), and had to query the document for access to both the scroller and the codemirror content container. Additionally, I couldn't use typical UseEffect because of the order of loading/rendering of the scroller, so had to use a mutationObserver.

The before experience won't look all that much different because there is the same number of tab stops, just with fewer keyboard options (couldn't scroll with arrows) and thus, a shorter aria-label. 


Additionally, a quirk of screenreaders is that if you are manually setting focus, sometimes the screenreader won't automatically catch up when focus shifts. Thus, we have the same problem before and after, where once you escape back out of the editor, you don't automatically get read aloud the label. 


Before:

https://github.com/user-attachments/assets/6defaff2-7411-4949-b7fa-ec6a8f36aecf




After:

https://github.com/user-attachments/assets/e705c1c1-7af7-4288-9019-d25ec39c16bc




## Links

- Jira: https://codedotorg.atlassian.net/browse/SL-1461

## Testing story
<!--  Does your change include appropriate tests?
      - If so, please describe how the tests included in this PR are sufficient.
      - If not, please explain why this change does not need to be tested. -->



## Deployment strategy
<!--  Any special steps required to deploy this, besides merging?
      - Are there database migrations or manual steps?
      - Does this require coordination with other teams or systems? -->



## Follow-up work
<!--  List any clean-up or technical debt that will be addressed in future work.
      - Include Jira links where applicable.
      - Are there any known limitations or improvements planned? -->



## Privacy
<!--  How does this change impact Student & Teacher privacy?
      - Does this collect, use, share, or modify PII, either new or existing? -->



## Security
<!--  How does this change impact our security surface-area?
      - Do API's touched have the right auth?
      - Do infra changes impact our attack surface or encryption?
-->



## Caching
<!--  How does this change impact caching behavior?
      - Are cache keys or invalidation strategies affected?
      - Will this require cache warming or invalidation after deployment? -->



## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
