### PR TITLE
Restore pathname-to-string Casting Logic

### DIFF
--- a/dashboard/config/application.rb
+++ b/dashboard/config/application.rb
@@ -190,7 +190,7 @@ module Dashboard
     #
     # These directories will also be treated as top-level directories by
     # Zeitwerk, rather than as subdirectories which require namspacing.
-    config.eager_load_paths += runtime_load_paths.map(&:to_s)
+    config.eager_load_paths += runtime_load_paths
 
     # Ignore certain directories for autoloading and eager loading
     Rails.autoloaders.main.ignore(
@@ -203,7 +203,13 @@ module Dashboard
     # still be autoloaded as needed without being explicitly required.
     config.autoload_paths << Rails.root.join('lib', 'devtools')
     Rails.autoloaders.main.do_not_eager_load(Rails.root.join('lib', 'devtools'))
+
+    # Explicitly cast all paths to strings; otherwise, the bootsnap gem might
+    # fail in some local development environments with a `no implicit
+    # conversion of Pathname into String` error when trying to run `db:migrate`
+    # See https://github.com/rails/bootsnap/blob/v1.16.0/lib/bootsnap/load_path_cache/loaded_features_index.rb#L39
     config.autoload_paths.map!(&:to_s)
+    config.eager_load_paths.map!(&:to_s)
 
     # use https://(*-)studio.code.org urls in mails
     config.action_mailer.default_url_options = {host: CDO.canonical_hostname('studio.code.org'), protocol: 'https'}

--- a/dashboard/config/application.rb
+++ b/dashboard/config/application.rb
@@ -126,7 +126,7 @@ module Dashboard
     config.active_record.default_timezone = :utc
 
     # By default, config/locales/*.rb,yml are auto loaded.
-    config.i18n.load_path += Dir[Rails.root.join('config', 'locales', '*', '*.{json,yml}')]
+    config.i18n.load_path += Dir[Rails.root.join('config', 'locales', '*', '*.{json,yml}').to_s]
     config.i18n.backend = CDO.i18n_backend
     config.i18n.enforce_available_locales = false
     config.i18n.available_locales = [Cdo::I18n::DEFAULT_LOCALE]
@@ -190,7 +190,7 @@ module Dashboard
     #
     # These directories will also be treated as top-level directories by
     # Zeitwerk, rather than as subdirectories which require namspacing.
-    config.eager_load_paths += runtime_load_paths
+    config.eager_load_paths += runtime_load_paths.map(&:to_s)
 
     # Ignore certain directories for autoloading and eager loading
     Rails.autoloaders.main.ignore(
@@ -203,6 +203,7 @@ module Dashboard
     # still be autoloaded as needed without being explicitly required.
     config.autoload_paths << Rails.root.join('lib', 'devtools')
     Rails.autoloaders.main.do_not_eager_load(Rails.root.join('lib', 'devtools'))
+    config.autoload_paths.map!(&:to_s)
 
     # use https://(*-)studio.code.org urls in mails
     config.action_mailer.default_url_options = {host: CDO.canonical_hostname('studio.code.org'), protocol: 'https'}

--- a/dashboard/config/application.rb
+++ b/dashboard/config/application.rb
@@ -126,7 +126,7 @@ module Dashboard
     config.active_record.default_timezone = :utc
 
     # By default, config/locales/*.rb,yml are auto loaded.
-    config.i18n.load_path += Dir[Rails.root.join('config', 'locales', '*', '*.{json,yml}').to_s]
+    config.i18n.load_path += Dir[Rails.root.join('config', 'locales', '*', '*.{json,yml}')]
     config.i18n.backend = CDO.i18n_backend
     config.i18n.enforce_available_locales = false
     config.i18n.available_locales = [Cdo::I18n::DEFAULT_LOCALE]


### PR DESCRIPTION
I removed some `.to_s` calls while replacing the `annotate` gem, since our comments indicated that gem was the only reason we needed them. That might have been true at some point, but it turns out that the `bootsnap` gem also depends on this logic!

Specifically, some (but not all) local development environment when trying to run `dashboard-console` or `db:migrate` started throwing an error like:

```
.rbenv/versions/3.1.0/lib/ruby/gems/3.1.0/gems/bootsnap-1.16.0/lib/bootsnap/load_path_cache/loaded_features_index.rb:39:in `start_with?': no implicit conversion of Pathname into String (TypeError) 
```

## Links

Follow-up to:
- https://github.com/code-dot-org/code-dot-org/pull/69000

Slack Threads:
- https://codedotorg.slack.com/archives/C046G4TRLEN/p1760463441711179
- https://codedotorg.slack.com/archives/C0T0PNTM3/p1761613339304869

## Testing story

Because we only load the bootsnap gem in the development environment, I think an automated test that'd be able to catch this would be more work than it's worth. My plan at this point is to continue to rely on developers to identify local-development-environment-specific regressions; please let me know if you have a better idea!

I'm also unfortunately not able to reproduce the underlying problem on my local machine, so I'm relying on the devs for whom this manifests to verify correctness. Thank you for your help!