### PR TITLE
Adding Strings instead of Pathnames to config.autoload_paths

### DIFF
--- a/dashboard/config/application.rb
+++ b/dashboard/config/application.rb
@@ -72,13 +72,13 @@ module Dashboard
 
       # Autoload mailer previews in development mode so changes are picked up without restarting the server.
       # autoload_paths is frozen by time it gets to development.rb, so it must be done here.
-      config.autoload_paths << Rails.root.join('test/mailers/previews')
+      config.autoload_paths << Rails.root.join('test/mailers/previews').to_s
 
       # Automatically load tools intended to make the local development
       # environment behave more like production.
       require 'cdo/local_development'
       if CDO.aws_s3_emulated
-        config.autoload_paths << Rails.root.join('../lib/cdo/local_development/s3_emulation')
+        config.autoload_paths << Rails.root.join('../lib/cdo/local_development/s3_emulation').to_s
       end
     end
 
@@ -181,7 +181,7 @@ module Dashboard
       Rails.root.join('app', 'models', 'levels'),
       Rails.root.join('app', 'models', 'sections'),
       Rails.root.join('../lib/cdo/shared_constants')
-    ]
+    ].map(&:to_s)
 
     config.autoload_paths += runtime_load_paths
 
@@ -201,7 +201,7 @@ module Dashboard
     # Tools which are designed for development / test environments should not be eager-loaded
     # because they may depend on gems which are not available in production. These tools can
     # still be autoloaded as needed without being explicitly required.
-    config.autoload_paths << Rails.root.join('lib', 'devtools')
+    config.autoload_paths << Rails.root.join('lib', 'devtools').to_s
     Rails.autoloaders.main.do_not_eager_load(Rails.root.join('lib', 'devtools'))
 
     # use https://(*-)studio.code.org urls in mails


### PR DESCRIPTION
When running 'bundle exec rails db:migrate` on Ubuntu, I get the following error
```
/home/daynewagner/.rbenv/versions/3.1.0/lib/ruby/gems/3.1.0/gems/bootsnap-1.16.0/lib/bootsnap/load_path_cache/loaded_features_index.rb:39:in `start_with?': no implicit conversion of Pathname into String (TypeError)
	from /home/daynewagner/.rbenv/versions/3.1.0/lib/ruby/gems/3.1.0/gems/bootsnap-1.16.0/lib/bootsnap/load_path_cache/loaded_features_index.rb:39:in `block (2 levels) in initialize'
	from /home/daynewagner/.rbenv/versions/3.1.0/lib/ruby/gems/3.1.0/gems/bootsnap-1.16.0/lib/bootsnap/load_path_cache/loaded_features_index.rb:38:in `each'
	from /home/daynewagner/.rbenv/versions/3.1.0/lib/ruby/gems/3.1.0/gems/bootsnap-1.16.0/lib/bootsnap/load_path_cache/loaded_features_index.rb:38:in `block in initialize'
	from /home/daynewagner/.rbenv/versions/3.1.0/lib/ruby/gems/3.1.0/gems/bootsnap-1.16.0/lib/bootsnap/load_path_cache/loaded_features_index.rb:36:in `each'
	from /home/daynewagner/.rbenv/versions/3.1.0/lib/ruby/gems/3.1.0/gems/bootsnap-1.16.0/lib/bootsnap/load_path_cache/loaded_features_index.rb:36:in `initialize'
	from /home/daynewagner/.rbenv/versions/3.1.0/lib/ruby/gems/3.1.0/gems/bootsnap-1.16.0/lib/bootsnap/load_path_cache.rb:39:in `new'
	from /home/daynewagner/.rbenv/versions/3.1.0/lib/ruby/gems/3.1.0/gems/bootsnap-1.16.0/lib/bootsnap/load_path_cache.rb:39:in `setup'
	from /home/daynewagner/.rbenv/versions/3.1.0/lib/ruby/gems/3.1.0/gems/bootsnap-1.16.0/lib/bootsnap.rb:49:in `setup'
	from /home/daynewagner/.rbenv/versions/3.1.0/lib/ruby/gems/3.1.0/gems/bootsnap-1.16.0/lib/bootsnap.rb:100:in `default_setup'
	from /home/daynewagner/.rbenv/versions/3.1.0/lib/ruby/gems/3.1.0/gems/bootsnap-1.16.0/lib/bootsnap/setup.rb:5:in `<top (required)>'
	from /home/daynewagner/.rbenv/versions/3.1.0/lib/ruby/gems/3.1.0/gems/zeitwerk-2.6.18/lib/zeitwerk/kernel.rb:34:in `require'
	from /home/daynewagner/.rbenv/versions/3.1.0/lib/ruby/gems/3.1.0/gems/zeitwerk-2.6.18/lib/zeitwerk/kernel.rb:34:in `require'
	from /home/daynewagner/projects/code-dot-org/dashboard/config/boot.rb:15:in `<top (required)>'
	from /home/daynewagner/projects/code-dot-org/dashboard/bin/rake:7:in `require_relative'
	from /home/daynewagner/projects/code-dot-org/dashboard/bin/rake:7:in `<top (required)>'
	from /home/daynewagner/.rbenv/versions/3.1.0/lib/ruby/gems/3.1.0/gems/spring-3.1.1/lib/spring/command_wrapper.rb:40:in `load'
	from /home/daynewagner/.rbenv/versions/3.1.0/lib/ruby/gems/3.1.0/gems/spring-3.1.1/lib/spring/command_wrapper.rb:40:in `call'
	from /home/daynewagner/.rbenv/versions/3.1.0/lib/ruby/gems/3.1.0/gems/spring-3.1.1/lib/spring/application.rb:217:in `block in serve'
	from /home/daynewagner/.rbenv/versions/3.1.0/lib/ruby/gems/3.1.0/gems/activesupport-6.1.7.7/lib/active_support/fork_tracker.rb:10:in `block in fork'
	from /home/daynewagner/.rbenv/versions/3.1.0/lib/ruby/gems/3.1.0/gems/activesupport-6.1.7.7/lib/active_support/fork_tracker.rb:10:in `block in fork'
	from /home/daynewagner/.rbenv/versions/3.1.0/lib/ruby/gems/3.1.0/gems/activesupport-6.1.7.7/lib/active_support/fork_tracker.rb:8:in `fork'
	from /home/daynewagner/.rbenv/versions/3.1.0/lib/ruby/gems/3.1.0/gems/activesupport-6.1.7.7/lib/active_support/fork_tracker.rb:8:in `fork'
	from /home/daynewagner/.rbenv/versions/3.1.0/lib/ruby/gems/3.1.0/gems/activesupport-6.1.7.7/lib/active_support/fork_tracker.rb:27:in `fork'
	from /home/daynewagner/.rbenv/versions/3.1.0/lib/ruby/gems/3.1.0/gems/nakayoshi_fork-0.0.4/lib/nakayoshi_fork.rb:23:in `fork'
	from /home/daynewagner/.rbenv/versions/3.1.0/lib/ruby/gems/3.1.0/gems/activesupport-6.1.7.7/lib/active_support/fork_tracker.rb:8:in `fork'
	from /home/daynewagner/.rbenv/versions/3.1.0/lib/ruby/gems/3.1.0/gems/activesupport-6.1.7.7/lib/active_support/fork_tracker.rb:27:in `fork'
	from /home/daynewagner/.rbenv/versions/3.1.0/lib/ruby/gems/3.1.0/gems/spring-3.1.1/lib/spring/application.rb:181:in `serve'
	from /home/daynewagner/.rbenv/versions/3.1.0/lib/ruby/gems/3.1.0/gems/spring-3.1.1/lib/spring/application.rb:144:in `block in run'
	from /home/daynewagner/.rbenv/versions/3.1.0/lib/ruby/gems/3.1.0/gems/spring-3.1.1/lib/spring/application.rb:138:in `loop'
	from /home/daynewagner/.rbenv/versions/3.1.0/lib/ruby/gems/3.1.0/gems/spring-3.1.1/lib/spring/application.rb:138:in `run'
	from /home/daynewagner/.rbenv/versions/3.1.0/lib/ruby/gems/3.1.0/gems/spring-3.1.1/lib/spring/application/boot.rb:19:in `<top (required)>'
	from <internal:/home/daynewagner/.rbenv/versions/3.1.0/lib/ruby/3.1.0/rubygems/core_ext/kernel_require.rb>:85:in `require'
	from <internal:/home/daynewagner/.rbenv/versions/3.1.0/lib/ruby/3.1.0/rubygems/core_ext/kernel_require.rb>:85:in `require'
	from -e:1:in `<main>'
```
This error points breaks in the `bootsnap` gem where it read the `$LOAD_PATH` and expects an Array of Strings. I briefly looked at the Rails Guide for `config.autoload_paths` and the Zeitwerk documentation and all the examples show explicitly adding Strings to `config.autoload_paths`. This PR updates our additions to `config.autoload_paths` and `config.eager_load_paths` to explicitly set Strings, not Pathnames.

## Testing story
* `bundle exec rails db:migrate` now works for me.

