### PR TITLE
chore(cache): downsize `marketing-sites` elasticache

### DIFF
--- a/frontend/apps/marketing/cicd/3-app/template.yml.erb
+++ b/frontend/apps/marketing/cicd/3-app/template.yml.erb
@@ -723,8 +723,8 @@ Resources:
       EngineVersion: 7.1
       CacheNodeType: !If
         - IsProductionEnvironment
-        - cache.r7g.xlarge
-        - cache.t3.medium
+        - cache.r7g.large
+        - cache.t4g.micro
       NumNodeGroups: 1
       ReplicasPerNodeGroup: 1
       SecurityGroupIds:


### PR DESCRIPTION
After running the marketing sites for 3 months, we've seen we are consistently below 5% CPU usage and 2% memory. As such, downsize the production capacity to the smallest r7i to maintain memory optimizations (`r7i.large` is the smallest).

Similiarly, in pre-production the CPU usage is consistently below 1%, as such downsize to the absolute smallest `t4g.micro`. We will be able to reference load patterns between the absolute smallest versus the current sizing to right-size pre-production.