### PR TITLE
AI Tutor: add icon colors for standalone suggested prompts

### DIFF
--- a/apps/src/aiTutor/views/legacyLabs/AiTutorSidebar.module.scss
+++ b/apps/src/aiTutor/views/legacyLabs/AiTutorSidebar.module.scss
@@ -48,14 +48,14 @@
   }
 
   .icon-brain {
-    color: purple;
+    color: var(--text-brand-purple-primary-fixed);
   }
 
   .icon-bug {
-    color: red;
+    color: var(--text-error-primary-fixed);
   }
 
   .icon-star {
-    color: goldenrod;
+    color: var(--text-warning-primary-fixed);
   }
 }

--- a/apps/src/lab2/views/components/AiTutorChat.module.scss
+++ b/apps/src/lab2/views/components/AiTutorChat.module.scss
@@ -69,6 +69,18 @@
     color: var(--text-info-primary-fixed);
   }
 
+  .icon-brain {
+    color: purple;
+  }
+
+  .icon-bug {
+    color: red;
+  }
+
+  .icon-star {
+    color: goldenrod;
+  }
+
   // Hover and active states
   @include generate-chat-button-hover-states(
     (

--- a/apps/src/lab2/views/components/AiTutorChat.module.scss
+++ b/apps/src/lab2/views/components/AiTutorChat.module.scss
@@ -70,15 +70,15 @@
   }
 
   .icon-brain {
-    color: purple;
+    color: var(--text-brand-purple-primary-fixed);
   }
 
   .icon-bug {
-    color: red;
+    color: var(--text-error-primary-fixed);
   }
 
   .icon-star {
-    color: goldenrod;
+    color: var(--text-warning-primary-fixed);
   }
 
   // Hover and active states
@@ -87,6 +87,9 @@
       'code': 'success',
       'lightbulb': 'warning',
       'book': 'info',
+      'brain': 'brand-purple',
+      'bug': 'error',
+      'star': 'warning',
     )
   );
 


### PR DESCRIPTION
Tiny 🎨 update. The icon colors for suggested prompts in the open AI Tutor window now match the icon colors in the closed AI Tutor sidebar. 

AI Tutor sidebar for legacy labs
<img width="115" height="297" alt="Screenshot 2025-10-28 at 11 46 29 AM" src="https://github.com/user-attachments/assets/f590462f-6b99-4ea4-b2cf-a8886ad63ac1" />

AI Tutor chat window suggested prompt icons BEFORE 
<img width="375" height="187" alt="Screenshot 2025-10-28 at 11 49 48 AM" src="https://github.com/user-attachments/assets/f289f89c-f559-4404-aa64-33c4592603e3" />

AI Tutor chat window suggested prompt icons AFTER
<img width="375" height="283" alt="Screenshot 2025-10-28 at 11 46 22 AM" src="https://github.com/user-attachments/assets/b624594a-8977-41ab-9bcf-71352259fb3f" />
