### PR TITLE
Remove AiTutorContext unused properties

### DIFF
--- a/apps/src/aiTutor/types.ts
+++ b/apps/src/aiTutor/types.ts
@@ -19,7 +19,6 @@ export interface AiTutorContext {
   longInstructions?: string;
   documentation?: string;
   documentationLocation?: string;
-  userSelection?: string;
 }
 
 export interface AnalyticsData {

--- a/apps/src/weblab2/Weblab2View.tsx
+++ b/apps/src/weblab2/Weblab2View.tsx
@@ -85,9 +85,6 @@ const Weblab2View: React.FC<
     state =>
       state.lab2Project.projectSources?.source as MultiFileSource | undefined
   );
-  const userAddedSelectionContext = useAppSelector(
-    state => state.aichat.userAddedSelectionContext
-  );
 
   const {startSources} = useSource(
     defaultProject,
@@ -107,9 +104,8 @@ const Weblab2View: React.FC<
     aiTutorHelper.setAiTutorContext({
       source,
       longInstructions: levelProperties.longInstructions,
-      selection: userAddedSelectionContext,
     });
-  }, [source, levelProperties.longInstructions, userAddedSelectionContext]);
+  }, [source, levelProperties.longInstructions]);
 
   // Since there's no run button in Weblab2, set it to true by default
   // to enable the Submit button on edit on submittable levels.

--- a/apps/src/weblab2/helpers/aiTutorContextHelper.ts
+++ b/apps/src/weblab2/helpers/aiTutorContextHelper.ts
@@ -21,7 +21,7 @@ export class AiTutorWebLab2ContextHelper extends AiTutorContextHelper<AiTutorWeb
   protected override getAiTutorContext(): AiTutorContext {
     if (!this.params) return {};
 
-    const {source, longInstructions, selection} = this.params;
+    const {source, longInstructions} = this.params;
     const sourceCode = source
       ? Object.values(source.files)
           .filter(
@@ -36,33 +36,9 @@ export class AiTutorWebLab2ContextHelper extends AiTutorContextHelper<AiTutorWeb
           .join('\n\n')
       : undefined;
 
-    const userSelection =
-      selection && Object.values(selection).length > 0
-        ? Object.values(selection)
-            .map(context => {
-              if (context.lineReference) {
-                const lineString =
-                  context.lineReference.start === context.lineReference.end
-                    ? `line ${context.lineReference.start}`
-                    : `lines ${context.lineReference.start} - ${context.lineReference.end}`;
-                return `snippet of file ${
-                  context.filename
-                }, ${lineString}\nContents of snippet:\n${this.codeBlock(
-                  context.sourceCode
-                )}`;
-              } else {
-                return `entirety of file ${
-                  context.filename
-                }\nContents of file:\n${this.codeBlock(context.sourceCode)}`;
-              }
-            })
-            .join('\n\n')
-        : undefined;
-
     return {
       sourceCode,
       longInstructions,
-      userSelection,
     };
   }
 }

--- a/apps/src/weblab2/helpers/aiTutorContextHelper.ts
+++ b/apps/src/weblab2/helpers/aiTutorContextHelper.ts
@@ -1,4 +1,3 @@
-import {UserAddedSelectionContext} from '@cdo/apps/aichat/types';
 import {AiTutorContextHelper} from '@cdo/apps/aiTutor/helpers/aiTutorContextHelper';
 import {AiTutorContext} from '@cdo/apps/aiTutor/types';
 import {MultiFileSource, ProjectFileType} from '@cdo/apps/lab2/types';
@@ -6,7 +5,6 @@ import {MultiFileSource, ProjectFileType} from '@cdo/apps/lab2/types';
 interface AiTutorWebLab2Params {
   source: MultiFileSource | undefined;
   longInstructions: string | undefined;
-  selection: UserAddedSelectionContext;
 }
 
 const LANGUAGES_TO_EXCLUDE_FROM_CONTEXT = ['txt', 'csv', 'md'];


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
Quick clean-up! Remove now unused `AiTutorContext` prop `userSelection` and unused `AiTutorWebLab2Param`, `selection`. Follow-up to https://github.com/code-dot-org/code-dot-org/pull/69002#discussion_r2465717076.



## Links
<!--  Links to relevant external resources.
      - spec docs, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- Jira: https://codedotorg.atlassian.net/browse/AFL-326

## Testing story
<!--  Does your change include appropriate tests?
      - If so, please describe how the tests included in this PR are sufficient.
      - If not, please explain why this change does not need to be tested. -->

Checked locally on `weblab2` level that AI Tutor worked as expected including when lines were selected.

## Deployment strategy
<!--  Any special steps required to deploy this, besides merging?
      - Are there database migrations or manual steps?
      - Does this require coordination with other teams or systems? -->



## Follow-up work
<!--  List any clean-up or technical debt that will be addressed in future work.
      - Include Jira links where applicable.
      - Are there any known limitations or improvements planned? -->



## Privacy
<!--  How does this change impact Student & Teacher privacy?
      - Does this collect, use, share, or modify PII, either new or existing? -->



## Security
<!--  How does this change impact our security surface-area?
      - Do API's touched have the right auth?
      - Do infra changes impact our attack surface or encryption?
-->



## Caching
<!--  How does this change impact caching behavior?
      - Are cache keys or invalidation strategies affected?
      - Will this require cache warming or invalidation after deployment? -->



## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
