### PR TITLE
Disable FocusLock when not opened in AiDiffContainer

### DIFF
--- a/apps/src/aiDifferentiation/AiDiffContainer.tsx
+++ b/apps/src/aiDifferentiation/AiDiffContainer.tsx
@@ -120,7 +120,7 @@ const AiDiffContainer: React.FC<AiDiffContainerProps> = ({
         }
         style={open ? undefined : {display: 'none'}}
       >
-        <FocusLock>
+        <FocusLock disabled={!open}>
           <AiDiffHeader
             closeTutor={closeTutor}
             closeButtonClassName={AI_DIFF_CLOSE_BUTTON_CLASSNAME}


### PR DESCRIPTION
## Summary

Fixed a bug in the AI Teaching Assistant where clicking a button would cause focus to unexpectedly jump to another button. When users were prompted to press the space bar after clicking, the space key would inadvertently trigger the newly-focused button instead of having the intended behaviour.

**Root Cause:** The `<FocusLock>` component in `AiDiffContainer` was actively managing focus even when the container wasn't being interacted with. When the component state changed, FocusLock would re-evaluate focusable elements and automatically redirect focus, causing it to jump from the clicked element to other focusable elements.

**Solution:** Added `disabled={!open}` prop to the `FocusLock` component so it only manages focus when the AI Diff container is actually open and being actively used.

### New behavior (Development)
In the first video, you can see:
- Initial focus remains on `<body>` after clicking "Run"
- No unexpected focus jumps occur
- User interactions behave as expected

### Old behavior (Production)
In the first video, you can see:
- Initial focus is on `<body>`
- After clicking the "Run" button, the focus unexpectedly jumps to the "Run" button itself
- Space bar would trigger the focused button instead of the expected behavior


https://github.com/user-attachments/assets/bcad0a0c-093e-4ebd-8f9d-150a61f54d4c

The second video demonstrates that `FocusLock` still functions correctly when the AiDiffContainer is opened, maintaining focus within the container as intended for accessibility.

https://github.com/user-attachments/assets/15309e1c-a5cf-49e2-b75a-172ae96afa94


## Links

- Jira: [AITT-1250](https://codedotorg.atlassian.net/browse/AITT-1250)

## Testing story

**Manual Testing:**
- Tested that clicking buttons no longer causes unexpected focus jumps
- Verified that FocusLock still functions correctly when the AI Diff container is open
- Confirmed space bar behavior works as expected after button clicks
- Tested that focus management works correctly during AI response loading/completion

## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
