### PR TITLE
Revert "Revert "feat(mui): run mui typography codemod on workshop dashboard""

### DIFF
--- a/apps/package.json
+++ b/apps/package.json
@@ -9,8 +9,9 @@
   },
   "scripts": {
     "lint": "yarn lint:scss && yarn lint:js",
-    "lint:fix": "yarn lint:scss --fix && yarn lint:js --fix",
+    "lint:fix": "yarn lint:scss --fix && yarn lint:js:fix",
     "lint:js": "concurrently \"yarn lint:js:ts\" \"yarn lint:jsx:tsx\"",
+    "lint:js:fix": "concurrently \"yarn lint:js:ts --fix\" \"yarn lint:jsx:tsx --fix\"",
     "lint:js:ts": "eslint --format ./.eslintCustomMessagesFormatter.js --ext=.js,.ts --report-unused-disable-directives-severity=error .",
     "lint:jsx:tsx": "eslint --format ./.eslintCustomMessagesFormatter.js --ext=.jsx,.tsx --report-unused-disable-directives-severity=error .",
     "lint:scss": "npx stylelint '**/*.scss'",

--- a/apps/src/code-studio/pd/workshop_dashboard/workshop_form/WorkshopForm.tsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/workshop_form/WorkshopForm.tsx
@@ -1,6 +1,6 @@
 import Alert from '@code-dot-org/component-library/alert';
 import {Dialog} from '@code-dot-org/component-library/dialog';
-import {Heading1} from '@code-dot-org/component-library/typography';
+import {Typography} from '@mui/material';
 import React, {
   FC,
   useCallback,
@@ -296,7 +296,9 @@ export const WorkshopForm: FC<WorkshopFormProps> = ({config}) => {
           closeLabel="Cancel"
         />
       )}
-      <Heading1 visualAppearance="heading-xl">{heading}</Heading1>
+      <Typography component="h1" variant="h2" gutterBottom>
+        {heading}
+      </Typography>
       <Basics
         capacity={workshopFormState.capacity}
         description={workshopFormState.description}

--- a/apps/src/code-studio/pd/workshop_dashboard/workshop_form/components/MultiSelectInput.tsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/workshop_form/components/MultiSelectInput.tsx
@@ -4,7 +4,7 @@ import FormFieldWrapper, {
   FormFieldWrapperProps,
 } from '@code-dot-org/component-library/formFieldWrapper';
 import Tags from '@code-dot-org/component-library/tags';
-import {BodyThreeText} from '@code-dot-org/component-library/typography';
+import {Typography} from '@mui/material';
 import classNames from 'classnames';
 import React, {useState, useRef, useEffect, useCallback, useMemo} from 'react';
 
@@ -340,12 +340,15 @@ export const MultiSelectInput: React.FC<{
                       }
                     >
                       <div className={styles.optionLabelText}>
-                        <BodyThreeText>{option.label}</BodyThreeText>
+                        <Typography variant="body3" gutterBottom>
+                          {option.label}
+                        </Typography>
                         {option.secondaryLabel && (
-                          <BodyThreeText>{option.secondaryLabel}</BodyThreeText>
+                          <Typography variant="body3" gutterBottom>
+                            {option.secondaryLabel}
+                          </Typography>
                         )}
                       </div>
-
                       {selected && (
                         <FontAwesomeV6Icon
                           iconName={
@@ -359,9 +362,13 @@ export const MultiSelectInput: React.FC<{
                 })
               ) : (
                 <li>
-                  <BodyThreeText className={styles.emptyState}>
+                  <Typography
+                    className={styles.emptyState}
+                    variant="body3"
+                    gutterBottom
+                  >
                     {emptyStateMessage}
-                  </BodyThreeText>
+                  </Typography>
                 </li>
               )}
             </ul>

--- a/apps/src/code-studio/pd/workshop_dashboard/workshop_form/components/TimeZoneEditor.tsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/workshop_form/components/TimeZoneEditor.tsx
@@ -1,7 +1,7 @@
 import {Button} from '@code-dot-org/component-library/button';
 import {SimpleDropdown} from '@code-dot-org/component-library/dropdown';
 import FontAwesomeV6Icon from '@code-dot-org/component-library/fontAwesomeV6Icon';
-import {BodyThreeText} from '@code-dot-org/component-library/typography';
+import {Typography} from '@mui/material';
 import moment from 'moment-timezone';
 import React, {FC, memo, useState} from 'react';
 
@@ -27,9 +27,9 @@ export const TimeZoneEditor: FC<{
 
   return (
     <div className={styles.container}>
-      <BodyThreeText id="tz-label">
+      <Typography id="tz-label" variant="body3" gutterBottom>
         {timeZone ? fields.time_zone.label : 'Workshop times are local'}
-      </BodyThreeText>
+      </Typography>
       {editMode ? (
         <SimpleDropdown
           name={fields.time_zone.stateKey}
@@ -49,9 +49,9 @@ export const TimeZoneEditor: FC<{
           }))}
         />
       ) : (
-        <BodyThreeText>
+        <Typography variant="body3" gutterBottom>
           <strong>{timeZone}</strong>
-        </BodyThreeText>
+        </Typography>
       )}
       {!editMode && (
         <Button

--- a/apps/src/code-studio/pd/workshop_dashboard/workshop_form/sections/AdditionalInfo.tsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/workshop_form/sections/AdditionalInfo.tsx
@@ -1,7 +1,7 @@
 import {SimpleDropdown} from '@code-dot-org/component-library/dropdown';
 import FormFieldWrapper from '@code-dot-org/component-library/formFieldWrapper';
 import TextField from '@code-dot-org/component-library/textField';
-import {Heading2} from '@code-dot-org/component-library/typography';
+import {Typography} from '@mui/material';
 import classNames from 'classnames';
 import React, {ChangeEvent, FC, memo, useMemo} from 'react';
 
@@ -58,7 +58,9 @@ export const AdditionalInfo: FC<AdditionalInfoProps> = ({
 
   return (
     <section>
-      <Heading2 visualAppearance="heading-sm">Additional Information</Heading2>
+      <Typography component="h2" variant="h5" gutterBottom>
+        Additional Information
+      </Typography>
       {(fields.fee || fields.participant_group_type) && (
         <div className={commonStyles.row}>
           {fields.fee && (

--- a/apps/src/code-studio/pd/workshop_dashboard/workshop_form/sections/Basics.tsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/workshop_form/sections/Basics.tsx
@@ -5,7 +5,7 @@ import {
 import FormFieldWrapper from '@code-dot-org/component-library/formFieldWrapper';
 import Tags from '@code-dot-org/component-library/tags';
 import TextField from '@code-dot-org/component-library/textField';
-import {Heading2} from '@code-dot-org/component-library/typography';
+import {Typography} from '@mui/material';
 import classNames from 'classnames';
 import React, {ChangeEvent, FC, memo, useCallback, useMemo} from 'react';
 
@@ -155,7 +155,9 @@ export const Basics: FC<BasicsProps> = ({
 
   return (
     <section>
-      <Heading2 visualAppearance="heading-sm">Workshop Basics</Heading2>
+      <Typography component="h2" variant="h5" gutterBottom>
+        Workshop Basics
+      </Typography>
       {(fields.name || fields.grades || fields.subject) && (
         <div className={commonStyles.row}>
           {fields.name && (

--- a/apps/src/code-studio/pd/workshop_dashboard/workshop_form/sections/EmailsReminders.tsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/workshop_form/sections/EmailsReminders.tsx
@@ -1,10 +1,6 @@
 import {LinkButton} from '@code-dot-org/component-library/button';
 import Toggle from '@code-dot-org/component-library/toggle';
-import {
-  BodyFourText,
-  Heading2,
-  OverlineThreeText,
-} from '@code-dot-org/component-library/typography';
+import {Typography} from '@mui/material';
 import React, {FC, memo, useCallback} from 'react';
 
 import {SectionProps, WorkshopFormState} from '../../workshops/types';
@@ -58,10 +54,14 @@ export const EmailsReminders: FC<EmailsRemindersProps> = ({
 
   return (
     <section>
-      <Heading2 visualAppearance="heading-sm">Emails & Reminders</Heading2>
+      <Typography component="h2" variant="h5" gutterBottom>
+        Emails & Reminders
+      </Typography>
       <div className={commonStyles.row}>
         <div className={commonStyles.col}>
-          <OverlineThreeText>pre-workshop emails</OverlineThreeText>
+          <Typography variant="overline3" gutterBottom>
+            pre-workshop emails
+          </Typography>
           {fields.suppress_email && (
             <div className={commonStyles.toggleWrapper}>
               <div className={commonStyles.row}>
@@ -79,7 +79,9 @@ export const EmailsReminders: FC<EmailsRemindersProps> = ({
           )}
         </div>
         <div className={commonStyles.col}>
-          <OverlineThreeText>post-workshop emails</OverlineThreeText>
+          <Typography variant="overline3" gutterBottom>
+            post-workshop emails
+          </Typography>
           <div className={commonStyles.toggleWrapper}>
             <div className={commonStyles.row}>
               <Toggle
@@ -93,9 +95,9 @@ export const EmailsReminders: FC<EmailsRemindersProps> = ({
               {/* TODO: blank href for now until we have mailjet email preview links */}
               <PreviewEmailLink href="" />
             </div>
-            <BodyFourText>
+            <Typography variant="body4" gutterBottom>
               *We require this email for every workshop.
-            </BodyFourText>
+            </Typography>
           </div>
         </div>
       </div>

--- a/apps/src/code-studio/pd/workshop_dashboard/workshop_form/sections/PartnerFacilitator.tsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/workshop_form/sections/PartnerFacilitator.tsx
@@ -1,5 +1,5 @@
 import {SimpleDropdown} from '@code-dot-org/component-library/dropdown';
-import {Heading2} from '@code-dot-org/component-library/typography';
+import {Typography} from '@mui/material';
 import classNames from 'classnames';
 import React, {
   FC,
@@ -158,9 +158,9 @@ export const PartnerFacilitator: FC<PartnerFacilitatorProps> = ({
 
   return (
     <section>
-      <Heading2 visualAppearance="heading-sm">
+      <Typography component="h2" variant="h5" gutterBottom>
         Partner and Facilitator Information
-      </Heading2>
+      </Typography>
       {(fields.regional_partner_id || fields.facilitators) && (
         <div className={commonStyles.row}>
           {fields.regional_partner_id && (

--- a/apps/src/code-studio/pd/workshop_dashboard/workshop_form/sections/PublishSettings.tsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/workshop_form/sections/PublishSettings.tsx
@@ -1,7 +1,7 @@
 import Checkbox from '@code-dot-org/component-library/checkbox';
 import FormFieldWrapper from '@code-dot-org/component-library/formFieldWrapper';
 import TextField from '@code-dot-org/component-library/textField';
-import {Heading2} from '@code-dot-org/component-library/typography';
+import {Typography} from '@mui/material';
 import classNames from 'classnames';
 import React, {ChangeEvent, FC, memo} from 'react';
 
@@ -42,7 +42,9 @@ export const PublishSettings: FC<PublishSettingsProps> = ({
 
   return (
     <section>
-      <Heading2 visualAppearance="heading-sm">Publish Settings</Heading2>
+      <Typography component="h2" variant="h5" gutterBottom>
+        Publish Settings
+      </Typography>
       {(fields.registration_link || fields.hidden) && (
         <div className={commonStyles.row}>
           {fields.registration_link && (

--- a/apps/src/code-studio/pd/workshop_dashboard/workshop_form/sections/Schedule.tsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/workshop_form/sections/Schedule.tsx
@@ -1,4 +1,4 @@
-import {Heading2} from '@code-dot-org/component-library/typography';
+import {Typography} from '@mui/material';
 import React, {Dispatch, FC, memo, useCallback} from 'react';
 
 import {
@@ -34,7 +34,9 @@ export const Schedule: FC<ScheduleProps> = ({
   );
   return (
     <section>
-      <Heading2 visualAppearance="heading-sm">Schedule</Heading2>
+      <Typography component="h2" variant="h5" gutterBottom>
+        Schedule
+      </Typography>
       <TimeZoneEditor
         timeZone={timeZone}
         handleChange={handleChange}

--- a/apps/src/code-studio/pd/workshop_dashboard/workshops/attendance/WorkshopAttendance.tsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/workshops/attendance/WorkshopAttendance.tsx
@@ -1,11 +1,6 @@
 import {LinkButton, buttonColors} from '@code-dot-org/component-library/button';
 import Link from '@code-dot-org/component-library/link';
 import {
-  Heading2,
-  BodyFourText,
-  StrongText,
-} from '@code-dot-org/component-library/typography';
-import {
   Card,
   CardContent,
   CardHeader,
@@ -15,6 +10,7 @@ import {
   TableBody,
   TableRow,
   TableCell,
+  Typography,
 } from '@mui/material';
 import React, {FC} from 'react';
 
@@ -39,22 +35,22 @@ export const WorkshopAttendance: FC = () => {
         className={commonStyles.cardHeader}
         title={
           <Box className={commonStyles.cardHeaderContainer}>
-            <Heading2 visualAppearance="body-two" noMargin>
-              <StrongText>Take Attendance</StrongText>
-            </Heading2>
+            <Typography component="h2" variant="body2">
+              <Typography variant="strong">Take Attendance</Typography>
+            </Typography>
           </Box>
         }
       />
       <CardContent className={commonStyles.cardContent}>
         <Box className={commonStyles.sectionContainer}>
           <Box className={commonStyles.column}>
-            <BodyFourText noMargin>
+            <Typography variant="body4">
               There is a unique attendance URL for each day of your workshop. On
               each day of your workshop, your participants must visit that day's
               attendance URL to receive professional development credit. The
               attendance URL(s) will be shown below, 2 days in advance, for your
               convenience.
-            </BodyFourText>
+            </Typography>
           </Box>
         </Box>
 
@@ -67,19 +63,19 @@ export const WorkshopAttendance: FC = () => {
             <TableHead>
               <TableRow>
                 <TableCell>
-                  <BodyFourText noMargin>
-                    <StrongText>Date</StrongText>
-                  </BodyFourText>
+                  <Typography variant="body4">
+                    <Typography variant="strong">Date</Typography>
+                  </Typography>
                 </TableCell>
                 <TableCell>
-                  <BodyFourText noMargin>
-                    <StrongText>Attendance URL</StrongText>
-                  </BodyFourText>
+                  <Typography variant="body4">
+                    <Typography variant="strong">Attendance URL</Typography>
+                  </Typography>
                 </TableCell>
                 <TableCell>
-                  <BodyFourText noMargin>
-                    <StrongText>View Daily Roster</StrongText>
-                  </BodyFourText>
+                  <Typography variant="body4">
+                    <Typography variant="strong">View Daily Roster</Typography>
+                  </Typography>
                 </TableCell>
               </TableRow>
             </TableHead>
@@ -103,9 +99,9 @@ export const WorkshopAttendance: FC = () => {
                 return (
                   <TableRow key={session.id}>
                     <TableCell>
-                      <BodyFourText noMargin>
+                      <Typography variant="body4">
                         {formattedDateMonthFirst}
-                      </BodyFourText>
+                      </Typography>
                     </TableCell>
                     <TableCell>
                       {session.showLink && (

--- a/apps/src/code-studio/pd/workshop_dashboard/workshops/components/Loading.tsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/workshops/components/Loading.tsx
@@ -1,5 +1,5 @@
 import FontAwesomeV6Icon from '@code-dot-org/component-library/fontAwesomeV6Icon';
-import {BodyTwoText} from '@code-dot-org/component-library/typography';
+import {Typography} from '@mui/material';
 import React, {FC} from 'react';
 
 import styles from './Loading.module.scss';
@@ -7,7 +7,7 @@ import styles from './Loading.module.scss';
 export const Loading: FC = () => {
   return (
     <div className={styles.loading}>
-      <BodyTwoText noMargin>Loading...</BodyTwoText>
+      <Typography variant="body2">Loading...</Typography>
       <FontAwesomeV6Icon iconName="spinner" animationType="spin" />
     </div>
   );

--- a/apps/src/code-studio/pd/workshop_dashboard/workshops/enrollments/WorkshopEnrollments.tsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/workshops/enrollments/WorkshopEnrollments.tsx
@@ -3,11 +3,6 @@ import {Button, buttonColors} from '@code-dot-org/component-library/button';
 import Checkbox from '@code-dot-org/component-library/checkbox';
 import Dialog from '@code-dot-org/component-library/dialog';
 import TextField from '@code-dot-org/component-library/textField';
-import Typography, {
-  BodyTwoText,
-  OverlineThreeText,
-  OverlineTwoText,
-} from '@code-dot-org/component-library/typography';
 import {
   Table,
   TableBody,
@@ -19,6 +14,7 @@ import {
   Card,
   Box,
   Divider,
+  Typography,
 } from '@mui/material';
 import classNames from 'classnames';
 import React, {
@@ -40,7 +36,6 @@ import {useWorkshopContext} from '../WorkshopLayout';
 
 import styles from './WorkshopEnrollments.module.scss';
 import commonStyles from '../WorkshopLayout.module.scss';
-
 const pluralize = (length: number): string => (length > 1 ? 's' : '');
 
 const columns: {key: keyof EnrollmentData; label: string}[] = [
@@ -284,9 +279,9 @@ export const WorkshopEnrollments: FC = () => {
               orientation="vertical"
               className={styles.actionDivider}
             />
-            <OverlineTwoText noMargin className={styles.numSelectedText}>
+            <Typography className={styles.numSelectedText} variant="overline2">
               {selected.length} selected
-            </OverlineTwoText>
+            </Typography>
             <Button
               ariaLabel={`Move selected enrollment${s}`}
               onClick={() => setActiveDialog('move')}
@@ -333,7 +328,7 @@ export const WorkshopEnrollments: FC = () => {
                 </TableCell>
                 {columns.map(({label, key}) => (
                   <TableCell key={key}>
-                    <OverlineThreeText noMargin>{label}</OverlineThreeText>
+                    <Typography variant="overline3">{label}</Typography>
                   </TableCell>
                 ))}
               </TableRow>
@@ -362,9 +357,9 @@ export const WorkshopEnrollments: FC = () => {
                       </TableCell>
                       {columns.map(({key}) => (
                         <TableCell key={key}>
-                          <BodyTwoText noMargin>
+                          <Typography variant="body2">
                             {renderCellValue(row, key)}
-                          </BodyTwoText>
+                          </Typography>
                         </TableCell>
                       ))}
                     </TableRow>
@@ -384,7 +379,6 @@ export const WorkshopEnrollments: FC = () => {
           onRowsPerPageChange={handleChangeRowsPerPage}
         />
       </Card>
-
       {activeDialog === 'remove' && (
         <Dialog
           id="remove-enrollments-dialog"
@@ -395,7 +389,7 @@ export const WorkshopEnrollments: FC = () => {
           title={`Remove Enrollment${s}?`}
           customContent={
             <Box id="dsco-dialog-description">
-              <Typography semanticTag="div" visualAppearance="body-two">
+              <Typography component="div" variant="body2" gutterBottom>
                 {`Are you sure you want to remove the enrollment${s} for:`}
                 <ul className={styles.enrollmentList}>
                   {selectedNotAttended.map(
@@ -414,11 +408,7 @@ export const WorkshopEnrollments: FC = () => {
                     type="warning"
                     text={`The following users have already attended a session and cannot be removed.`}
                   />
-                  <Typography
-                    noMargin
-                    semanticTag="div"
-                    visualAppearance="body-two"
-                  >
+                  <Typography component="div" variant="body2">
                     <ul className={styles.enrollmentList}>
                       {selectedAlreadyAttended.map(
                         ({id, givenName, familyName, email}) => (
@@ -459,7 +449,6 @@ export const WorkshopEnrollments: FC = () => {
           }}
         />
       )}
-
       {activeDialog === 'move' && (
         <Dialog
           id="move-enrollments-dialog"
@@ -470,7 +459,7 @@ export const WorkshopEnrollments: FC = () => {
           title={`Move Enrollment${s}?`}
           customContent={
             <Box id="dsco-dialog-description">
-              <Typography semanticTag="div" visualAppearance="body-two">
+              <Typography component="div" variant="body2" gutterBottom>
                 {`You are moving the following enrollment${s} for:`}
                 <ul className={styles.enrollmentList}>
                   {selected.map(({id, givenName, familyName, email}) => (

--- a/apps/src/code-studio/pd/workshop_dashboard/workshops/overview/sections/WorkshopInformationSection.tsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/workshops/overview/sections/WorkshopInformationSection.tsx
@@ -1,10 +1,12 @@
 import {Button, buttonColors} from '@code-dot-org/component-library/button';
 import {
-  Heading2,
-  BodyFourText,
-  StrongText,
-} from '@code-dot-org/component-library/typography';
-import {Card, CardContent, CardHeader, Box, Divider} from '@mui/material';
+  Card,
+  CardContent,
+  CardHeader,
+  Box,
+  Divider,
+  Typography,
+} from '@mui/material';
 import useMediaQuery from '@mui/material/useMediaQuery';
 import classNames from 'classnames';
 import moment from 'moment-timezone';
@@ -48,9 +50,9 @@ export const WorkshopInformationSection: React.FC<
         className={styles.cardHeader}
         title={
           <Box className={styles.cardHeaderContainer}>
-            <Heading2 visualAppearance="body-two" noMargin>
-              <StrongText>Workshop Information</StrongText>
-            </Heading2>
+            <Typography component="h2" variant="body2">
+              <Typography variant="strong">Workshop Information</Typography>
+            </Typography>
             {canEdit && canShowEditButton && (
               <Button
                 text={isWorkshopAdmin ? 'Edit (admin)' : 'Edit'}
@@ -69,21 +71,23 @@ export const WorkshopInformationSection: React.FC<
           <Box className={styles.column}>
             <Box>
               <Box className={styles.labelRow}>
-                <StrongText>Workshop Name</StrongText>
+                <Typography variant="strong">Workshop Name</Typography>
               </Box>
-              <BodyFourText noMargin>
+              <Typography variant="body4">
                 {workshop.name || workshop.course}
-              </BodyFourText>
+              </Typography>
             </Box>
 
             <Box>
               <Box className={styles.labelRow}>
-                <StrongText>Subject/Topics</StrongText>
+                <Typography variant="strong">Subject/Topics</Typography>
               </Box>
               <Box component="ul" className={styles.unstyledList}>
                 {workshop.subject && (
                   <Box component="li">
-                    <BodyFourText>{workshop.subject}</BodyFourText>
+                    <Typography variant="body4" gutterBottom>
+                      {workshop.subject}
+                    </Typography>
                   </Box>
                 )}
                 {workshop.courseOfferingNames &&
@@ -93,7 +97,7 @@ export const WorkshopInformationSection: React.FC<
                       key={course}
                       className={styles.subjectListItem}
                     >
-                      <BodyFourText noMargin>{course}</BodyFourText>
+                      <Typography variant="body4">{course}</Typography>
                     </Box>
                   ))}
               </Box>
@@ -110,25 +114,25 @@ export const WorkshopInformationSection: React.FC<
           <Box className={styles.column}>
             <Box>
               <Box className={classNames(styles.labelRow, styles.sessionRow)}>
-                <StrongText>Date</StrongText>
-                <StrongText>Time</StrongText>
-                <StrongText>Location Name</StrongText>
+                <Typography variant="strong">Date</Typography>
+                <Typography variant="strong">Time</Typography>
+                <Typography variant="strong">Location Name</Typography>
               </Box>
 
               {workshop.sessions.map(session => (
                 <Box key={session.id} className={styles.sessionRow}>
-                  <BodyFourText noMargin>
+                  <Typography variant="body4">
                     {moment.tz(session.start, timeZone).format('MM/DD/YYYY')}
-                  </BodyFourText>
-                  <BodyFourText noMargin>
+                  </Typography>
+                  <Typography variant="body4">
                     {moment.tz(session.start, timeZone).format(TIME_FORMAT)} -{' '}
                     {moment.tz(session.end, timeZone).format(TIME_FORMAT)}
-                  </BodyFourText>
-                  <BodyFourText noMargin>
+                  </Typography>
+                  <Typography variant="body4">
                     {session.sessionFormat === 'in_person'
                       ? session.locationName ?? 'N/A'
                       : 'Virtual'}
-                  </BodyFourText>
+                  </Typography>
                 </Box>
               ))}
             </Box>
@@ -144,26 +148,26 @@ export const WorkshopInformationSection: React.FC<
           <Box className={styles.column}>
             <Box>
               <Box className={styles.labelRow}>
-                <StrongText>Facilitators</StrongText>
+                <Typography variant="strong">Facilitators</Typography>
               </Box>
               {workshop.facilitators?.length ? (
                 workshop.facilitators.map(facilitator => (
-                  <BodyFourText noMargin key={facilitator.id}>
+                  <Typography key={facilitator.id} variant="body4">
                     {facilitator.name}, {facilitator.email}
-                  </BodyFourText>
+                  </Typography>
                 ))
               ) : (
-                <BodyFourText noMargin>N/A</BodyFourText>
+                <Typography variant="body4">N/A</Typography>
               )}
             </Box>
 
             <Box>
               <Box className={styles.labelRow}>
-                <StrongText>Regional Partner</StrongText>
+                <Typography variant="strong">Regional Partner</Typography>
               </Box>
-              <BodyFourText noMargin>
+              <Typography variant="body4">
                 {workshop.regionalPartnerName || 'N/A'}
-              </BodyFourText>
+              </Typography>
             </Box>
           </Box>
         </Box>

--- a/apps/src/code-studio/pd/workshop_dashboard/workshops/overview/sections/WorkshopLinksSection.tsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/workshops/overview/sections/WorkshopLinksSection.tsx
@@ -1,17 +1,13 @@
 import Link from '@code-dot-org/component-library/link';
 import Tags from '@code-dot-org/component-library/tags';
 import {
-  Heading2,
-  BodyFourText,
-  StrongText,
-} from '@code-dot-org/component-library/typography';
-import {
   Card,
   CardContent,
   CardHeader,
   Box,
   Divider,
   useMediaQuery,
+  Typography,
 } from '@mui/material';
 import classNames from 'classnames';
 import React from 'react';
@@ -41,9 +37,9 @@ export const WorkshopLinksSection: React.FC<WorkshopLinksSectionProps> = ({
         className={styles.cardHeader}
         title={
           <Box display="flex" alignItems="center">
-            <Heading2 visualAppearance="body-two" noMargin>
+            <Typography component="h2" variant="body2">
               <strong>Your Workshop Links</strong>
-            </Heading2>
+            </Typography>
           </Box>
         }
       />
@@ -52,7 +48,7 @@ export const WorkshopLinksSection: React.FC<WorkshopLinksSectionProps> = ({
           {/* Marketing Page Column */}
           <Box className={styles.column}>
             <Box className={styles.labelRow}>
-              <StrongText>Marketing Page</StrongText>
+              <Typography variant="strong">Marketing Page</Typography>
               <Tags
                 size="s"
                 className={classNames(styles.workshopTag, styles.visibility)}
@@ -75,11 +71,11 @@ export const WorkshopLinksSection: React.FC<WorkshopLinksSectionProps> = ({
               />
             </Box>
             <Box>
-              <BodyFourText noMargin>
+              <Typography variant="body4">
                 Share this page with teachers to promote your workshop. It
                 includes key details and will guide them to the correct
                 registration process.
-              </BodyFourText>
+              </Typography>
               <Link
                 className={styles.workshopLink}
                 size="xs"
@@ -110,15 +106,15 @@ export const WorkshopLinksSection: React.FC<WorkshopLinksSectionProps> = ({
 
               <Box className={styles.column}>
                 <Box className={styles.labelRow}>
-                  <StrongText>Join Workshop Page</StrongText>
+                  <Typography variant="strong">Join Workshop Page</Typography>
                 </Box>
                 <Box>
-                  <BodyFourText noMargin>
+                  <Typography variant="body4">
                     Participants must use this link to enroll in this workshop
                     on Code.org after registering through your system. This
                     ensures they're counted for attendance, surveys, and
                     certificates.
-                  </BodyFourText>
+                  </Typography>
                   <Link
                     className={styles.workshopLink}
                     size="xs"

--- a/apps/src/code-studio/pd/workshop_dashboard/workshops/overview/sections/WorkshopStatusSection.tsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/workshops/overview/sections/WorkshopStatusSection.tsx
@@ -3,13 +3,7 @@ import {Button, buttonColors} from '@code-dot-org/component-library/button';
 import {Dialog} from '@code-dot-org/component-library/dialog';
 import Link from '@code-dot-org/component-library/link';
 import Tags from '@code-dot-org/component-library/tags';
-import {
-  Heading2,
-  BodyFourText,
-  StrongText,
-  Heading3,
-} from '@code-dot-org/component-library/typography';
-import {Card, CardContent, CardHeader, Box} from '@mui/material';
+import {Card, CardContent, CardHeader, Box, Typography} from '@mui/material';
 import classNames from 'classnames';
 import React, {useCallback, useState} from 'react';
 
@@ -139,9 +133,9 @@ export const WorkshopStatusSection: React.FC<WorkshopStatusSectionProps> = ({
           title={
             <Box className={styles.cardHeaderContainer}>
               <Box className={styles.cardHeaderRow}>
-                <Heading2 visualAppearance="body-two" noMargin>
-                  <StrongText>Workshop Status</StrongText>
-                </Heading2>
+                <Typography component="h2" variant="body2">
+                  <Typography variant="strong">Workshop Status</Typography>
+                </Typography>
                 <Tags
                   className={classNames(styles.workshopTag, styles.status)}
                   tagsList={[
@@ -178,22 +172,24 @@ export const WorkshopStatusSection: React.FC<WorkshopStatusSectionProps> = ({
           <Box className={styles.sectionContainer}>
             <Box className={styles.column}>
               {notStarted && (
-                <BodyFourText noMargin>
+                <Typography variant="body4">
                   On the day of your workshop, click the "Start Workshop" button
                   below.
-                </BodyFourText>
+                </Typography>
               )}
 
               {inProgress && workshop.accountRequiredForAttendance && (
                 <>
-                  <BodyFourText noMargin>
+                  <Typography variant="body4">
                     On the day of the workshop, ask workshop attendees to follow
                     the steps:
-                  </BodyFourText>
-                  <Heading3 visualAppearance="body-two" noMargin>
-                    <StrongText>Step 1: Sign into Code Studio</StrongText>
-                  </Heading3>
-                  <BodyFourText noMargin>
+                  </Typography>
+                  <Typography component="h3" variant="body2">
+                    <Typography variant="strong">
+                      Step 1: Sign into Code Studio
+                    </Typography>
+                  </Typography>
+                  <Typography variant="body4">
                     Tell workshop attendees to sign into their Code Studio
                     accounts. If they do not already have an account tell them
                     to create one by going to{' '}
@@ -206,11 +202,13 @@ export const WorkshopStatusSection: React.FC<WorkshopStatusSectionProps> = ({
                     >
                       {window.origin}
                     </Link>
-                  </BodyFourText>
-                  <Heading3 visualAppearance="body-two" noMargin>
-                    <StrongText>Step 2: Take attendance</StrongText>
-                  </Heading3>
-                  <BodyFourText noMargin>
+                  </Typography>
+                  <Typography component="h3" variant="body2">
+                    <Typography variant="strong">
+                      Step 2: Take attendance
+                    </Typography>
+                  </Typography>
+                  <Typography variant="body4">
                     After workshop attendees have signed into their Code Studio
                     accounts, use the attendance links below to take attendance.
                     Note: Workshop attendees need to have enrolled in the
@@ -225,17 +223,17 @@ export const WorkshopStatusSection: React.FC<WorkshopStatusSectionProps> = ({
                     >
                       {`${window.origin}/professional-learning/workshops/${workshop.id}`}
                     </Link>
-                  </BodyFourText>
+                  </Typography>
                 </>
               )}
 
               {inProgress && !workshop.accountRequiredForAttendance && (
                 <>
-                  <BodyFourText noMargin>
+                  <Typography variant="body4">
                     On the day of the workshop, ask workshop attendees to
                     register if they haven't already:
-                  </BodyFourText>
-                  <BodyFourText noMargin>
+                  </Typography>
+                  <Typography variant="body4">
                     <Link
                       className={styles.workshopLink}
                       size="xs"
@@ -245,23 +243,23 @@ export const WorkshopStatusSection: React.FC<WorkshopStatusSectionProps> = ({
                     >
                       {`${window.origin}/professional-learning/workshops/${workshop.id}`}
                     </Link>
-                  </BodyFourText>
+                  </Typography>
                 </>
               )}
 
               {inProgress && cannotEndWorkshop && (
-                <BodyFourText noMargin>
+                <Typography variant="body4">
                   Workshop should not end until all sessions are complete and
                   attendance has been taken.
-                </BodyFourText>
+                </Typography>
               )}
 
               {ended && (
                 <>
-                  <BodyFourText noMargin>
+                  <Typography variant="body4">
                     We hope you had a great workshop!
-                  </BodyFourText>
-                  <BodyFourText noMargin>
+                  </Typography>
+                  <Typography variant="body4">
                     Workshop attendees will receive an email with survey link
                     from{' '}
                     <Link size="xs" href="mailto:survey@code.org">
@@ -277,14 +275,14 @@ export const WorkshopStatusSection: React.FC<WorkshopStatusSectionProps> = ({
                     'my account' page via the top right corner to confirm their
                     email address was typed correctly when they first created
                     the account.
-                  </BodyFourText>
-                  <BodyFourText noMargin>
+                  </Typography>
+                  <Typography variant="body4">
                     If they still can't find the email, have them email{' '}
                     <Link size="xs" href="mailto:support@code.org">
                       support@code.org
                     </Link>{' '}
                     and we will help them.
-                  </BodyFourText>
+                  </Typography>
                 </>
               )}
 
@@ -323,7 +321,6 @@ export const WorkshopStatusSection: React.FC<WorkshopStatusSectionProps> = ({
           </Box>
         </CardContent>
       </Card>
-
       {dialogs.map(({stateKey, label, description, primaryButtonProps}) =>
         activeDialog === stateKey ? (
           <Dialog

--- a/apps/src/code-studio/pd/workshop_dashboard/workshops/surveys/components/BarChartGroup.tsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/workshops/surveys/components/BarChartGroup.tsx
@@ -1,8 +1,4 @@
-import {
-  BodyTwoText,
-  StrongText,
-} from '@code-dot-org/component-library/typography';
-import {Box} from '@mui/material';
+import {Box, Typography} from '@mui/material';
 import React from 'react';
 import {
   BarChart,
@@ -201,9 +197,9 @@ const BarChartGroup: React.FC<BarChartGroupProps> = ({
 }) => (
   <Box className={moduleStyles.barChartGroupContainer}>
     <Box className={moduleStyles.barChartGroupHeaderContainer}>
-      <BodyTwoText noMargin>
-        <StrongText>{title}</StrongText>
-      </BodyTwoText>
+      <Typography variant="body2">
+        <Typography variant="strong">{title}</Typography>
+      </Typography>
     </Box>
     <Box className={moduleStyles.simpleBarChartContainer}>
       <SimpleBarChart
@@ -219,5 +215,4 @@ const BarChartGroup: React.FC<BarChartGroupProps> = ({
 );
 
 export {SimpleBarChart, BarChartGroup};
-
 export default BarChartGroup;

--- a/apps/src/code-studio/pd/workshop_dashboard/workshops/surveys/components/EmptyState.tsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/workshops/surveys/components/EmptyState.tsx
@@ -1,10 +1,5 @@
 import Image, {ImageProps} from '@code-dot-org/component-library/image';
-import {
-  BodyThreeText,
-  BodyTwoText,
-  StrongText,
-} from '@code-dot-org/component-library/typography';
-import {Box} from '@mui/material';
+import {Box, Typography} from '@mui/material';
 import classNames from 'classnames';
 import React, {FC} from 'react';
 
@@ -32,10 +27,10 @@ export const EmptyState: FC<EmptyStateProps> = ({
       {/* empty state images generally do not convey additional meaning. 
       using alt="" by default so screen readers will ignore the image */}
       <Image className={styles.emptyStateImage} alt="" {...imageProps} />
-      <BodyTwoText noMargin>
-        <StrongText>{title}</StrongText>
-      </BodyTwoText>
-      <BodyThreeText noMargin>{description}</BodyThreeText>
+      <Typography variant="body2">
+        <Typography variant="strong">{title}</Typography>
+      </Typography>
+      <Typography variant="body3">{description}</Typography>
     </Box>
   );
 };

--- a/apps/src/code-studio/pd/workshop_dashboard/workshops/surveys/components/ExportSurveysButton.tsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/workshops/surveys/components/ExportSurveysButton.tsx
@@ -1,10 +1,7 @@
 import Alert from '@code-dot-org/component-library/alert';
 import {Button} from '@code-dot-org/component-library/button';
 import {CustomDialog} from '@code-dot-org/component-library/dialog';
-import {
-  BodyOneText,
-  BodyTwoText,
-} from '@code-dot-org/component-library/typography';
+import {Typography} from '@mui/material';
 import React, {useState} from 'react';
 import {useParams} from 'react-router-dom';
 
@@ -77,13 +74,13 @@ export const ExportSurveysButton = () => {
             id="dsco-dialog-description"
             className={commonStyles.customDialogContent}
           >
-            <BodyOneText
+            <Typography
               id="export-survey-dialog-title"
-              visualAppearance="heading-md"
-              noMargin
+              component="p"
+              variant="h4"
             >
               Export Survey Results
-            </BodyOneText>
+            </Typography>
             <table>
               <tbody>
                 {(forms ?? []).map(form => {
@@ -92,12 +89,12 @@ export const ExportSurveysButton = () => {
                   return (
                     <tr key={`${form.name}_${form.version}`}>
                       <td>
-                        <BodyTwoText noMargin>{formName}</BodyTwoText>
+                        <Typography variant="body2">{formName}</Typography>
                       </td>
                       <td>
-                        <BodyTwoText noMargin>
+                        <Typography variant="body2">
                           {`Version: ${form.version}`}
-                        </BodyTwoText>
+                        </Typography>
                       </td>
                       <td>
                         <Button

--- a/apps/src/code-studio/pd/workshop_dashboard/workshops/surveys/components/FollowUpRequestedCard.tsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/workshops/surveys/components/FollowUpRequestedCard.tsx
@@ -1,9 +1,4 @@
-import {
-  BodyThreeText,
-  Heading2,
-  StrongText,
-} from '@code-dot-org/component-library/typography';
-import {Card, CardContent, Box, CardHeader} from '@mui/material';
+import {Card, CardContent, Box, CardHeader, Typography} from '@mui/material';
 import classNames from 'classnames';
 import React, {FC} from 'react';
 
@@ -34,12 +29,12 @@ export const FollowUpRequestedCard: FC<FollowUpRequestedCardProps> = ({
         className={commonStyles.cardHeader}
         title={
           <>
-            <Heading2 visualAppearance="body-one" noMargin>
-              <StrongText>{title}</StrongText>
-            </Heading2>
-            <BodyThreeText noMargin className={commonStyles.subHeader}>
+            <Typography component="h2" variant="body1">
+              <Typography variant="strong">{title}</Typography>
+            </Typography>
+            <Typography className={commonStyles.subHeader} variant="body3">
               {description}
-            </BodyThreeText>
+            </Typography>
           </>
         }
       />
@@ -50,10 +45,10 @@ export const FollowUpRequestedCard: FC<FollowUpRequestedCardProps> = ({
           >
             {items.map(item => (
               <Box key={item.email} className={styles.emailRow}>
-                <BodyThreeText noMargin>
-                  <StrongText>{item.name}</StrongText>
-                </BodyThreeText>
-                <BodyThreeText noMargin>{item.email}</BodyThreeText>
+                <Typography variant="body3">
+                  <Typography variant="strong">{item.name}</Typography>
+                </Typography>
+                <Typography variant="body3">{item.email}</Typography>
                 <CopyButton
                   buttonText="Copy email"
                   textToCopy={item.email}

--- a/apps/src/code-studio/pd/workshop_dashboard/workshops/surveys/components/FreeResponseCard.tsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/workshops/surveys/components/FreeResponseCard.tsx
@@ -1,10 +1,5 @@
 import Tags from '@code-dot-org/component-library/tags';
-import {
-  BodyThreeText,
-  Heading2,
-  StrongText,
-} from '@code-dot-org/component-library/typography';
-import {Card, CardContent, Box, CardHeader} from '@mui/material';
+import {Card, CardContent, Box, CardHeader, Typography} from '@mui/material';
 import classNames from 'classnames';
 import React, {FC} from 'react';
 
@@ -38,12 +33,12 @@ export const FreeResponseCard: FC<FreeResponseCardProps> = ({
         className={commonStyles.cardHeader}
         title={
           <Box className={styles.cardHeaderRow}>
-            <Heading2
-              visualAppearance={size === 's' ? 'body-two' : 'body-one'}
-              noMargin
+            <Typography
+              component="h2"
+              variant={size === 's' ? 'body2' : 'body1'}
             >
-              <StrongText>{title}</StrongText>
-            </Heading2>
+              <Typography variant="strong">{title}</Typography>
+            </Typography>
             {tagText && (
               <Tags
                 size="s"
@@ -73,7 +68,7 @@ export const FreeResponseCard: FC<FreeResponseCardProps> = ({
                   statusColor && styles[statusColor]
                 )}
               >
-                <BodyThreeText noMargin>{item}</BodyThreeText>
+                <Typography variant="body3">{item}</Typography>
               </Box>
             ))}
           </Box>

--- a/apps/src/code-studio/pd/workshop_dashboard/workshops/surveys/components/PercentageBarGroup.tsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/workshops/surveys/components/PercentageBarGroup.tsx
@@ -1,8 +1,4 @@
-import {
-  BodyThreeText,
-  StrongText,
-} from '@code-dot-org/component-library/typography';
-import {Box} from '@mui/material';
+import {Box, Typography} from '@mui/material';
 import classNames from 'classnames';
 import React, {FC, useEffect, useState} from 'react';
 
@@ -37,9 +33,9 @@ export const PercentageBarGroup: FC<PercentageBarGroupProps> = ({
     <Box className={classNames(commonStyles.column, className)}>
       {items.map(item => (
         <Box key={item.label}>
-          <BodyThreeText noMargin id={normalizeString(item.label)}>
-            <StrongText>{item.label}</StrongText>
-          </BodyThreeText>
+          <Typography id={normalizeString(item.label)} variant="body3">
+            <Typography variant="strong">{item.label}</Typography>
+          </Typography>
           <Box className={styles.barRow}>
             <PercentageBar
               percentage={item.percentage}
@@ -47,9 +43,9 @@ export const PercentageBarGroup: FC<PercentageBarGroupProps> = ({
               count={item.count}
               label={item.label}
             />
-            <BodyThreeText noMargin className={styles.barLabel}>{`${
+            <Typography className={styles.barLabel} variant="body3">{`${
               item.count
-            }${barLabel ? ` ${barLabel}` : ''}`}</BodyThreeText>
+            }${barLabel ? ` ${barLabel}` : ''}`}</Typography>
           </Box>
         </Box>
       ))}

--- a/apps/src/code-studio/pd/workshop_dashboard/workshops/surveys/components/ScoreCard.tsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/workshops/surveys/components/ScoreCard.tsx
@@ -1,14 +1,7 @@
 import {Button} from '@code-dot-org/component-library/button';
 import {CustomDialog} from '@code-dot-org/component-library/dialog';
 import FontAwesomeV6Icon from '@code-dot-org/component-library/fontAwesomeV6Icon';
-import {
-  BodyFourText,
-  BodyThreeText,
-  Heading2,
-  Heading3,
-  StrongText,
-} from '@code-dot-org/component-library/typography';
-import {Card, CardContent, Box} from '@mui/material';
+import {Card, CardContent, Box, Typography} from '@mui/material';
 import classNames from 'classnames';
 import React, {FC, useMemo, useState} from 'react';
 
@@ -75,12 +68,12 @@ export const ScoreCard: FC<ScoreCardProps> = ({
       >
         <CardContent className={commonStyles.cardContent}>
           <Box>
-            <Heading2 visualAppearance="overline-two" noMargin>
-              <StrongText>{title}</StrongText>
-            </Heading2>
-            <BodyFourText className={commonStyles.description} noMargin>
+            <Typography component="h2" variant="overline2">
+              <Typography variant="strong">{title}</Typography>
+            </Typography>
+            <Typography className={commonStyles.description} variant="body4">
               {responseBasedDescription}
-            </BodyFourText>
+            </Typography>
           </Box>
 
           <Box
@@ -90,16 +83,16 @@ export const ScoreCard: FC<ScoreCardProps> = ({
             {insufficientData ? (
               <FontAwesomeV6Icon iconName="question" />
             ) : (
-              <BodyThreeText noMargin visualAppearance="heading-lg">
+              <Typography component="p" variant="h3">
                 {score}
-              </BodyThreeText>
+              </Typography>
             )}
           </Box>
         </CardContent>
         <Box className={styles.scoreCardFooter}>
           <Box className={styles.scoreCardFooterText}>
             <FontAwesomeV6Icon iconName="info-circle" />
-            <BodyFourText noMargin>{footer}</BodyFourText>
+            <Typography variant="body4">{footer}</Typography>
           </Box>
           {breakdown && !insufficientData && (
             <Button
@@ -118,20 +111,18 @@ export const ScoreCard: FC<ScoreCardProps> = ({
           className={commonStyles.customDialog}
           onClose={() => setShowBreakdown(false)}
         >
-          <Heading3 id="response-breakdown" noMargin>
+          <Typography id="response-breakdown" variant="h3">
             Response breakdown
-          </Heading3>
+          </Typography>
           <Box className={styles.breakdownContentContainer}>
             <Box
               id="dsco-dialog-description"
               className={styles.longTitleContainer}
             >
-              <BodyThreeText noMargin>
-                <StrongText>{longTitle}</StrongText>
-              </BodyThreeText>
-              <BodyFourText
-                noMargin
-              >{`${responseCount} responses received`}</BodyFourText>
+              <Typography variant="body3">
+                <Typography variant="strong">{longTitle}</Typography>
+              </Typography>
+              <Typography variant="body4">{`${responseCount} responses received`}</Typography>
             </Box>
             {questionType === 'likert' && (
               <PercentageBarGroup

--- a/apps/src/code-studio/pd/workshop_dashboard/workshops/surveys/components/SelectCard.tsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/workshops/surveys/components/SelectCard.tsx
@@ -1,9 +1,4 @@
-import {
-  BodyThreeText,
-  Heading2,
-  StrongText,
-} from '@code-dot-org/component-library/typography';
-import {Card, CardContent, CardHeader} from '@mui/material';
+import {Card, CardContent, CardHeader, Typography} from '@mui/material';
 import classNames from 'classnames';
 import React, {FC} from 'react';
 
@@ -43,12 +38,12 @@ export const SelectCard: FC<SelectCardProps> = ({
         className={styles.cardHeader}
         title={
           <>
-            <Heading2 visualAppearance="body-one" noMargin>
-              <StrongText>{title}</StrongText>
-            </Heading2>
-            <BodyThreeText noMargin className={styles.subHeader}>
+            <Typography component="h2" variant="body1">
+              <Typography variant="strong">{title}</Typography>
+            </Typography>
+            <Typography className={styles.subHeader} variant="body3">
               {description}
-            </BodyThreeText>
+            </Typography>
           </>
         }
       />

--- a/apps/src/sites/studio/pages/pd/workshop_dashboard/index.js
+++ b/apps/src/sites/studio/pages/pd/workshop_dashboard/index.js
@@ -1,11 +1,11 @@
 import React from 'react';
-import ReactDOM from 'react-dom';
 
 import WorkshopDashboard from '@cdo/apps/code-studio/pd/workshop_dashboard/workshop_dashboard';
+import {createReactRoot} from '@cdo/apps/util/createReactRoot';
 import getScriptData from '@cdo/apps/util/getScriptData';
 
 document.addEventListener('DOMContentLoaded', function () {
-  ReactDOM.render(
+  createReactRoot(
     <WorkshopDashboard {...getScriptData('props')} />,
     document.getElementById('workshop-container')
   );

--- a/apps/src/templates/studioHomepages/teacherHomepageV2/PermanentPromotions.tsx
+++ b/apps/src/templates/studioHomepages/teacherHomepageV2/PermanentPromotions.tsx
@@ -48,9 +48,7 @@ const PermanentPromotions: React.FC = () => {
         <li key={promotion.id} className={styles.staticPromotion}>
           <div className={styles.staticPromotionText}>
             <Typography variant="body2" gutterBottom>
-              <Typography variant="strong" gutterBottom>
-                {promotion.title}
-              </Typography>
+              <Typography variant="strong">{promotion.title}</Typography>
             </Typography>
             <Typography variant="body4" gutterBottom>
               {promotion.description}

--- a/apps/src/templates/studioHomepages/teacherHomepageV2/TeacherPromo.tsx
+++ b/apps/src/templates/studioHomepages/teacherHomepageV2/TeacherPromo.tsx
@@ -96,9 +96,7 @@ const TeacherPromo: React.FC<TeacherPromoProps> = ({
           variant="body3"
           gutterBottom
         >
-          <Typography variant="strong" gutterBottom>
-            {i18n.partnershipWith()}
-          </Typography>
+          <Typography variant="strong">{i18n.partnershipWith()}</Typography>
           <img
             src={partnerLogo}
             alt="Partner Logo"

--- a/apps/tools/codemod/typography-to-mui.js
+++ b/apps/tools/codemod/typography-to-mui.js
@@ -318,7 +318,7 @@ function transformer(file, api) {
       }
 
       const noMargin = getJSXAttr(opening, 'noMargin');
-      if (!noMargin) {
+      if (!noMargin && semanticTag !== 'em' && semanticTag !== 'strong') {
         inferred.gutterBottom = true;
       }
 
@@ -363,7 +363,11 @@ function transformer(file, api) {
       }
 
       const noMargin = getJSXAttr(opening, 'noMargin');
-      if (!noMargin) {
+      if (
+        !noMargin &&
+        inferred.variant !== 'em' &&
+        inferred.variant !== 'strong'
+      ) {
         inferred.gutterBottom = true;
       }
 

--- a/apps/tools/codemod/typography-to-mui.js
+++ b/apps/tools/codemod/typography-to-mui.js
@@ -7,7 +7,9 @@
 // - Rewrites imports: removes DSCO Typography / wrapper imports; adds MUI Typography import
 
 // Run:
-//   npx jscodeshift -t ./apps/tools/codemod/typography-to-mui.js "src/directory-or-file-to-modify" --parser=tsx --extensions=tsx,ts,jsx,js
+//   cd apps
+//   npx jscodeshift -t ./tools/codemod/typography-to-mui.js "src/directory-or-file-to-modify" --parser=tsx --extensions=tsx,ts,jsx,js
+//   yarn lint:fix
 
 // Tips:
 //   - Add --dry --print to preview changes


### PR DESCRIPTION
Reverts code-dot-org/code-dot-org#69105

This pr reverts the revert of https://github.com/code-dot-org/code-dot-org/pull/69067

Eyes diffs in the workshop dashboard required another look. It turned out the codemod script was adding the `gutterBottom` prop to `strong` and `em` elements. Looking back at the dsco typography styles, it was clear those elements should not have margin-bottom. I've modified the codemod script to exclude `strong` and `em` elements from getting the `gutterBottom` prop. 

After running the eyes tests locally, the majority of the diffs resolved, however there is one nagging [diff](https://eyes.applitools.com/app/test-results/00000251640614500784/00000251640614500625/steps/2?accountId=mG4DoRfv0ntEgI3XIYBulrKxlZqrHtGwbP3V103ojvLFU110&mode=step-editor) in the `WorkshopAttendance` component I just can't figure out. It looks like somehow the "Attendance URL" column header takes up less horizontal space after running the script. But I compared the calculated widths in the devtools and they're the same 69.4219px. I've tried for way too long to figure out why this diff exists and it's killing me 🤯 
<img width="1921" height="963" alt="Screenshot 2025-10-28 at 3 35 40 PM" src="https://github.com/user-attachments/assets/7300d3a5-a7aa-44f7-84c0-ef058f9ed24f" />

It's also totally not important, so I'll just accept the new baselines when it merges... just makes me sad 😭 