### PR TITLE
Revert "Revert "Use Consistent Volume Size Across All Prod Instances""

### DIFF
--- a/aws/cloudformation/cloud_formation_stack.yml.erb
+++ b/aws/cloudformation/cloud_formation_stack.yml.erb
@@ -261,7 +261,7 @@ Resources:
   subnets: subnets(azs(AVAILABILITY_ZONES - ['us-east-1e'])), # us-east-1e doesn't support m5 instance types.
   frontend_policies: [{Ref: 'CDOPolicy'}, {'Fn::ImportValue': 'IAM-SessionPermissions'}],
   frontend_properties: {TargetGroupARNs: [Ref: 'ALBTargetGroup']},
-  frontend_volume_size: 64,
+  frontend_volume_size: 128,
   ami_timeout: 'PT120M',
   build_ami: erb_file(BOOTSTRAP_CHEF,
     resource_id: "AMICreate#{commit_hash}",

--- a/aws/cloudformation/components/ami.yml.erb
+++ b/aws/cloudformation/components/ami.yml.erb
@@ -177,7 +177,7 @@ frontend_device_name ||= '/dev/sda1'
         BlockDeviceMappings:
           - DeviceName: <%=frontend_device_name%>
             Ebs:
-              VolumeSize: <%=frontend_volume_size * 2%> # Double volume size to leave room for logs written to disk
+              VolumeSize: <%=frontend_volume_size%>
               VolumeType: gp2
         TagSpecifications:
           - ResourceType: instance


### PR DESCRIPTION
Reverts code-dot-org/code-dot-org#68490, restoring https://github.com/code-dot-org/code-dot-org/pull/68176

Second attempt at applying this change cleanly!

We think we have a good understanding of why the last one failed, and what we need to do this time. The detail that makes this complicated is that we are still targeting an Ubuntu 20 AMI in CloudFormation, but we've manually updated the persistent servers managed by the template to Ubuntu 22. Because this change will replace the AMI builder resource, we need to manually reapply that Ubuntu 22 update as part of this process.

Last time, we allowed the new server's initial bootstrap script to run to completion before applying the upgrade. This meant that we created a snapshot of the server in its pre-upgrade state, which got associated with the relevant git commit. Our expectation was that after we finished the upgrade and re-ran the bootstrap script, we'd create a new snapshot and override the old one; turns out, that's not how it works.

This time, we need to prevent the machine from sending a success signal until after the Ubuntu 22 upgrade has been applied. Our plan is to:

- manually kill the initial bootstrap script once the new server has started up for the first time
- apply the Ubuntu 22 upgrade
- reboot the server
- run the bootstrap script, which will let a snapshot be created and allow the DTP to continue