### PR TITLE
Codebridge: add icon for markdown file type

### DIFF
--- a/apps/src/codebridge/utils/fileUtils.ts
+++ b/apps/src/codebridge/utils/fileUtils.ts
@@ -8,6 +8,7 @@ const FILE_TYPE_ICON_MAP = {
   py: {iconName: 'python', iconStyle: 'regular' as const, isBrand: true},
   csv: {iconName: 'file-csv', iconStyle: 'solid' as const, isBrand: false},
   txt: {iconName: 'file-lines', iconStyle: 'solid' as const, isBrand: false},
+  md: {iconName: 'markdown', iconStyle: 'regular' as const, isBrand: true},
   html: {iconName: 'file-code', iconStyle: 'solid' as const, isBrand: false},
   js: {iconName: 'js', iconStyle: 'regular' as const, isBrand: true},
   css: {iconName: 'css', iconStyle: 'regular' as const, isBrand: true},

--- a/apps/test/unit/codebridge/utils/fileUtilsTest.ts
+++ b/apps/test/unit/codebridge/utils/fileUtilsTest.ts
@@ -81,6 +81,13 @@ describe('fileUtils', () => {
     expect(
       getFileIconNameAndStyle({
         ...defaultFile,
+        name: 'test.md',
+        type: ProjectFileType.STARTER,
+      })
+    ).toEqual({iconName: 'markdown', iconStyle: 'regular', isBrand: true});
+    expect(
+      getFileIconNameAndStyle({
+        ...defaultFile,
         name: 'test.html',
         type: ProjectFileType.STARTER,
       })


### PR DESCRIPTION
Adds a Markdown icon for `.md` files.

## Links
Jira ticket: [AFL-211](https://codedotorg.atlassian.net/browse/AFL-211)

## Testing story
Tested locally and added unit test

----

| Before | After | 
| ---- | ---- |
| <img width="577" height="217" alt="Screenshot 2025-10-28 at 12 26 51 PM" src="https://github.com/user-attachments/assets/3e1f4ffd-ce8f-4fc8-a1cd-b888eca44b3a" /> | <img width="577" height="217" alt="After" src="https://github.com/user-attachments/assets/d377096a-ab37-4e3e-8f94-990def70798b" /> |

## Dark mode

<img width="577" height="217" alt="Screenshot 2025-10-28 at 12 29 07 PM" src="https://github.com/user-attachments/assets/7f266f3b-c32a-4b03-8132-b3caa97724d1" />
