### PR TITLE
Fix On Call Script - Deploy Curriculum Content from staging to production

### DIFF
--- a/bin/dotd
+++ b/bin/dotd
@@ -305,7 +305,7 @@ def dotd_menu(dotd_name)
       end
       menu.choice(:DTP) {do_dtp(dotd_name)}
       menu.choice(:STP) do
-        if run_on 'production_daemon', 'production/bin/seed-curriculum-content-from-staging-branch'
+        if run_on 'production-daemon', 'production/bin/seed-curriculum-content-from-staging-branch'
           puts 'Content from staging branch successfully seeded to production database'
         else
           puts 'Content from staging branch was not successfully seeded to production database.'


### PR DESCRIPTION
Fix a typo in the servername preventing the new `STP` option that deployed curriculum content from the staging branch directly to the production environment.

## Testing story

Edited locally and successfully kicked off a curriculum release.



## Deployment strategy
<!--  Any special steps required to deploy this, besides merging?
      - Are there database migrations or manual steps?
      - Does this require coordination with other teams or systems? -->



## Follow-up work
<!--  List any clean-up or technical debt that will be addressed in future work.
      - Include Jira links where applicable.
      - Are there any known limitations or improvements planned? -->



## Privacy
<!--  How does this change impact Student & Teacher privacy?
      - Does this collect, use, share, or modify PII, either new or existing? -->



## Security
<!--  How does this change impact our security surface-area?
      - Do API's touched have the right auth?
      - Do infra changes impact our attack surface or encryption?
-->



## Caching
<!--  How does this change impact caching behavior?
      - Are cache keys or invalidation strategies affected?
      - Will this require cache warming or invalidation after deployment? -->



## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
