### PR TITLE
[Hour of AI] Lottie Dancer improvements

### DIFF
--- a/apps/src/dance/lab2/ProgramExecutor.ts
+++ b/apps/src/dance/lab2/ProgramExecutor.ts
@@ -135,7 +135,15 @@ export default class ProgramExecutor {
       return;
     }
 
-    const previewDraw = () => {
+    const previewDraw = async () => {
+      if (this.nativeAPI.generatedDancer) {
+        await this.ensureAllMovesPrecached();
+        // Wait an extra animation frame to ensure any async Lottie work inside the generated dancer has
+        // finished before drawing.
+        await new Promise(resolve =>
+          requestAnimationFrame(() => requestAnimationFrame(resolve))
+        );
+      }
       this.nativeAPI.setEffectsInPreviewMode(true);
 
       // the user setup hook initializes effects,
@@ -326,5 +334,25 @@ export default class ProgramExecutor {
     this.metricsReporter.logWarning(
       `Missing required hooks in compiled code: ${hooks.join(', ')}`
     );
+  }
+
+  private async ensureAllMovesPrecached() {
+    if (!this.nativeAPI.generatedDancer) {
+      return;
+    }
+    await this.nativeAPI.generatedDancer.renderer.precacheMoves([
+      'rest',
+      'clap_high',
+      'clown',
+      'dab',
+      'double_jam',
+      'drop',
+      'floss',
+      'fresh',
+      'kick',
+      'roll',
+      'this_or_that',
+      'thriller',
+    ]);
   }
 }

--- a/apps/src/dance/lottie/LottieDancerRenderer.ts
+++ b/apps/src/dance/lottie/LottieDancerRenderer.ts
@@ -49,9 +49,10 @@ import {
   recolorBodySvgString,
   svgStringToDataUrl,
   getSkeletonMetadataUrl,
+  hideMagentaDress,
 } from './LottieDancerUtils';
 
-const TEST_SKELETON = 'duck';
+const DEFAULT_SKELETON = 'unicorn';
 
 export default class LottieDancerRenderer {
   // Injected by DanceParty's GeneratedDancer
@@ -78,6 +79,7 @@ export default class LottieDancerRenderer {
   private metadataUrl: string;
   private bodyUrl?: string;
   private bodyMetadataUrl?: string;
+  private currentMove: DanceMoves | null;
 
   constructor() {
     this.headScale = 0.5;
@@ -90,6 +92,7 @@ export default class LottieDancerRenderer {
     this.metadataUrl = urls.metadataUrl;
     this.bodyUrl = urls.bodyUrl;
     this.bodyMetadataUrl = urls.bodyMetadataUrl;
+    this.currentMove = null;
   }
   /**
    * The caller provides a CanvasRenderingContext2D to paint into.
@@ -120,6 +123,8 @@ export default class LottieDancerRenderer {
     // Lottie instance bound to our canvas 2D context
     await this.prepareLottie(animData);
 
+    this.currentMove = danceMove;
+
     this.totalFrames = Math.max(
       0,
       Math.round((animData.op || 0) - (animData.ip || 0))
@@ -139,16 +144,44 @@ export default class LottieDancerRenderer {
     return this.compW && this.compH ? {w: this.compW, h: this.compH} : null;
   }
 
-  renderFrame(frameIndex: number): void {
+  renderFrame(frameIndex: number, mirror?: number): void {
     if (!this.anim || !this.ctx || this.totalFrames === null) {
       return;
     }
+
+    if (this.moveRequiresMirroring()) {
+      // Flip the entire canvas for vectors.
+      (this.ctx.canvas as HTMLElement).style.transform = `scaleX(${mirror})`;
+    } else {
+      (this.ctx.canvas as HTMLElement).style.transform = '';
+    }
+
     const totalFrames = Math.max(1, this.totalFrames || 1);
     const frame = Math.floor(
       ((frameIndex % totalFrames) + totalFrames) % totalFrames
     );
-
     this.anim.goToAndStop(frame, true);
+  }
+
+  moveRequiresMirroring(): boolean {
+    if (this.currentMove === null) {
+      return false;
+    }
+    // List of moves that should be mirrored when rendering.
+    // Other moves (double_jam, this_or_that, zombie) already have symmetrical choreography.
+    const movesToMirror = new Set<DanceMoves>([
+      'rest',
+      'clap_high',
+      'dab',
+      'drop',
+      'floss',
+      'fresh',
+      'kick',
+      'roll',
+      'thriller',
+    ]);
+    const currentMove = this.currentMove;
+    return movesToMirror.has(currentMove);
   }
 
   resize(): void {
@@ -205,14 +238,17 @@ export default class LottieDancerRenderer {
           );
           const skeletonNameFromJson = bodyMetaData?.skeleton;
           if (typeof skeletonNameFromJson === 'string') {
-            console.log(
-              `Resolved skeleton name "${skeletonNameFromJson}" from body metadata JSON.`
-            );
             return skeletonNameFromJson.trim().toLowerCase();
           }
-        } catch {}
+        } catch (e) {
+          console.warn(
+            `Failed to fetch skeleton name from body metadata URL ${this.bodyMetadataUrl}`,
+            e,
+            `Falling back to ${skeletonParam || DEFAULT_SKELETON} skeleton.`
+          );
+        }
       }
-      return skeletonParam || TEST_SKELETON;
+      return skeletonParam || DEFAULT_SKELETON;
     })();
     return this.skeletonNamePromise;
   }
@@ -362,6 +398,12 @@ export default class LottieDancerRenderer {
           }
         }
       }
+
+      // The frog has an extra magenta dress layer that needs to be hidden.
+      if (skeletonName === 'frog') {
+        hideMagentaDress(animData);
+      }
+
       // Memoize transformed Lottie JSON per move (in-memory cache) so subsequent setSource calls skip recolor/head work.
       // This is useful if the same dance move is used later in a song, or if there are multiple generated dancers using the same move.
       this.cachedAnimationData[danceMoveLowerCase] = animData;

--- a/apps/src/dance/lottie/LottieDancerRenderer.ts
+++ b/apps/src/dance/lottie/LottieDancerRenderer.ts
@@ -144,14 +144,16 @@ export default class LottieDancerRenderer {
     return this.compW && this.compH ? {w: this.compW, h: this.compH} : null;
   }
 
-  renderFrame(frameIndex: number, mirror?: number): void {
+  renderFrame(frameIndex: number, mirror?: boolean): void {
     if (!this.anim || !this.ctx || this.totalFrames === null) {
       return;
     }
 
     if (this.moveRequiresMirroring()) {
       // Flip the entire canvas for vectors.
-      (this.ctx.canvas as HTMLElement).style.transform = `scaleX(${mirror})`;
+      (this.ctx.canvas as HTMLElement).style.transform = `scaleX(${
+        mirror ? -1 : 1
+      })`;
     } else {
       (this.ctx.canvas as HTMLElement).style.transform = '';
     }

--- a/apps/src/dance/lottie/LottieDancerUtils.ts
+++ b/apps/src/dance/lottie/LottieDancerUtils.ts
@@ -330,7 +330,7 @@ export async function fetchDataUrl(url?: string): Promise<string | null> {
       fileReader.readAsDataURL(blob);
     });
   } catch (e) {
-    console.log(`Failed to fetch data URL for image at ${url}:`, e);
+    console.warn(`Failed to fetch data URL for image at ${url}:`, e);
     return null;
   }
 }
@@ -385,6 +385,10 @@ export function getAssetById(
   ) as LottieAssetPrecomp | null;
 }
 
+/**
+ * Hides vector layers inside their respective comp. Also captures a copy of the
+ * first matching layer’s transform (ks), so we can reuse it for positioning.
+ */
 export function hideLayersByTypeAndCaptureKs(
   compAsset: LottieAssetPrecomp,
   typesToHide: number[] = [4, 1] // 4: shape, 1: solid
@@ -470,7 +474,7 @@ export function insertImageLayer(
   compDefaultH: number,
   scaleMul: number,
   extraLayerProps?: Partial<LottieImageLayer>
-): void {
+): LottieImageLayer {
   const compW = compAsset.w || compDefaultW;
   const compH = compAsset.h || compDefaultH;
   const imgW = DEFAULT_IMAGE_SIZE;
@@ -503,6 +507,7 @@ export function insertImageLayer(
   };
 
   (compAsset.layers = compAsset.layers || []).splice(insertIndex, 0, layer);
+  return layer;
 }
 
 export function loadCanvasAnimation(config: CanvasAnimConfig): AnimationItem {
@@ -531,7 +536,7 @@ export function resolveDancerAssets(opts: ResolveDancerAssetsOpts = {}): {
   const {sourceTag = 'default'} = opts;
   const srcSuffix = `?src=${encodeURIComponent(sourceTag)}`;
 
-  // 1) Initializae with defaults
+  // 1) Initialize with defaults
   const urls: ResolvedDancerAssets = {
     headUrl: `${DEFAULT_HEAD_URL}${srcSuffix}`,
     metadataUrl: DEFAULT_METADATA_URL,
@@ -706,4 +711,33 @@ export function recolorBodySvgString(
 
 export function getSkeletonMetadataUrl(skeletonName: string): string {
   return `${BASE_HOST}/dancers/input/palettes/${skeletonName}-metadata.json`;
+}
+
+// Hide the magenta "dress" solids in the comp tree (frog skeleton only).
+export function hideMagentaDress(animData: LottieJSON): void {
+  if (!animData) return;
+
+  // Build lookup for nested precomps.
+  const assetById: Record<string, LottieJSON> = {};
+  for (const asset of animData.assets || []) {
+    if (asset?.id) assetById[asset.id] = asset;
+  }
+
+  const visitComp = (comp: LottieJSON) => {
+    if (!comp?.layers) return;
+    for (const layer of comp.layers) {
+      if (layer.nm === 'Deep Magenta-Red Solid 4') {
+        layer.hd = true;
+      }
+
+      // Recurse into precomps.
+      if (layer.ty === 0 && typeof layer.refId === 'string') {
+        const child = assetById[layer.refId];
+        if (child) visitComp(child);
+      }
+    }
+  };
+
+  // Start from top-level comp.
+  visitComp(animData);
 }

--- a/apps/src/lab2/views/DancerCanvas.tsx
+++ b/apps/src/lab2/views/DancerCanvas.tsx
@@ -64,8 +64,7 @@ const DancerCanvas: React.FC<Props> = ({
 
     // A single loop plays out over half a measure. Every other half-measure
     // is mirrored.
-    const shouldMirror = Math.floor(measure * 2) % 2 === 1;
-    const mirror = shouldMirror ? -1 : 1;
+    const mirror = Math.floor(measure * 2) % 2 === 1;
 
     const animationStep = measure % 1;
     const frameIndex = Math.floor(animationStep * totalFrames * 2);
@@ -181,15 +180,12 @@ const DancerCanvas: React.FC<Props> = ({
     // The animation speed should be similar to with a 120 bpm song.
     const targetFps = 48;
 
-    let mirror = 1;
     const tick = (currentMs: number) => {
       const elapsedMs = currentMs - startMs;
-      const frameIndex =
-        Math.floor((elapsedMs * targetFps) / 1000) % totalFrames;
-      // Detect when the animation loops back to frame 0
-      if (frameRef.current === totalFrames - 1 && frameIndex === 0) {
-        mirror *= -1;
-      }
+      const elapsedFrames = Math.floor((elapsedMs * targetFps) / 1000);
+      const frameIndex = elapsedFrames % totalFrames;
+      // Every other loop is mirrored.
+      const mirror = Math.floor((elapsedFrames / totalFrames) % 2) === 1;
       frameRef.current = frameIndex;
       renderer?.renderFrame(frameIndex, mirror);
       rafId = requestAnimationFrame(tick);

--- a/apps/src/lab2/views/DancerCanvas.tsx
+++ b/apps/src/lab2/views/DancerCanvas.tsx
@@ -61,9 +61,15 @@ const DancerCanvas: React.FC<Props> = ({
     if (!totalFrames) {
       return;
     }
+
+    // A single loop plays out over half a measure. Every other half-measure
+    // is mirrored.
+    const shouldMirror = Math.floor(measure * 2) % 2 === 1;
+    const mirror = shouldMirror ? -1 : 1;
+
     const animationStep = measure % 1;
     const frameIndex = Math.floor(animationStep * totalFrames * 2);
-    renderer.renderFrame(frameIndex);
+    renderer.renderFrame(frameIndex, mirror);
   }, []);
 
   // Render the current frame (GenerateDancer mode).
@@ -90,6 +96,7 @@ const DancerCanvas: React.FC<Props> = ({
 
       if (!rendererRef.current) {
         rendererRef.current = new LottieDancerRenderer();
+        rendererRef.current.precacheMoves([move as DanceMoves]);
       }
       const context = node.getContext('2d');
       if (!context) {
@@ -169,15 +176,22 @@ const DancerCanvas: React.FC<Props> = ({
 
     const renderer = rendererRef.current;
     const totalFrames = renderer?.getDurationFrames?.() ?? 1;
-    const targetFps = 60;
 
+    // We aim to cycle through the entire animation each second.
+    // The animation speed should be similar to with a 120 bpm song.
+    const targetFps = 48;
+
+    let mirror = 1;
     const tick = (currentMs: number) => {
       const elapsedMs = currentMs - startMs;
       const frameIndex =
         Math.floor((elapsedMs * targetFps) / 1000) % totalFrames;
+      // Detect when the animation loops back to frame 0
+      if (frameRef.current === totalFrames - 1 && frameIndex === 0) {
+        mirror *= -1;
+      }
       frameRef.current = frameIndex;
-
-      renderer?.renderFrame(frameIndex);
+      renderer?.renderFrame(frameIndex, mirror);
       rafId = requestAnimationFrame(tick);
     };
 


### PR DESCRIPTION
This makes a number of improvements to our Lottie dancer animations, most notably:

- Dance Party preview now shows dancers as expected.
- Asymmetric dance moves are now mirrored correctly.
- Slightly slower animation speed during Generate a Dancer levels.
- A additional dress layer in some frog dance moves has been identified and hidden.
- Default skeleton changed to 'unicorn' to better align to newly designed bodies.
- Better console warnings when we fail to fetch expected assets.

This is a direct follow-up to:
- https://github.com/code-dot-org/code-dot-org/pull/69045

Sprite mirroring in Dance Party also requires:
- https://github.com/code-dot-org/dance-party/pull/678
- A new `dance-party` release and bump

### Preview draw

Until now, the preview frame in Dance Party, shown before pressing Run, was not consistently showing the generated dancer. We now wait one additional frame to ensure async work has time to complete before drawing.
Other sprites and backgrounds were working as expected.
|Before|After|
|-|-|
|<img width="400" height="400" alt="image" src="https://github.com/user-attachments/assets/080236bc-46ad-424d-b477-7a772731463b" />|<img width="400" height="400" alt="image" src="https://github.com/user-attachments/assets/169d170f-1a4d-4457-90b5-e48a3e8ce988" />|

### Dancer Mirroring
Most dance moves are performed only on one side. To give things a symmetrical effect, we mirror the moves, with a couple exceptions. To do this, after the full animation completes we will pass a new `mirror: -1 | 1` value to the renderer. For our `DancerCanvas` component, we just add a simple transform to the canvas context which flips horizontally.
The RAF fps was also decreased to better align to a typical song (ie. 120bpm). Animations have 48 frames and conveniently we can just use that as the FPS to align.

|Before|After|
|-|-|
|![before](https://github.com/user-attachments/assets/393ccebf-edac-4955-9d97-cca6971cbcc8) | ![after](https://github.com/user-attachments/assets/5626e8ad-f509-43f2-9681-714f5eaae7b5)|

### Hiding the Frog Dress
It was discovered that a few of the dance JSONs for the frog had an extra comp layer. It was likely intended to be used to define the frog's dress, but in practice it was just creating a bulbous shape. Worse, the current body replacement logic wasn't hiding it because it was in a different layer. I've added an extra processing step to handle this.

|Before|After|
|-|-|
|![before](https://github.com/user-attachments/assets/2da622fe-04b6-4798-a5a0-5a7a69211dfb)|![after](https://github.com/user-attachments/assets/2dda7ce8-05c8-4640-a027-631e690f8114)|


### Default Skeleton
Upon reviewing the latest body designs, I noticed that most of them are compatible with the "unicorn" skeleton. This is because they expect a dancer with both top and bottom clothing pieces (ie. shirt sleeves and pants). (The cat and duck only have tops. The bear and frog have leggings but no sleeves.)
<img width="551" height="825" alt="image" src="https://github.com/user-attachments/assets/267f9285-d066-43e8-a76d-8e7f4b2e661b" />
I believe that by using the "unicorn" as the default skeleton we could pivot to fetching body metadata only when needed as an override for this default. (If no body JSON is found, we use the default skeleton.)


## Dance Party Updates
Some additional light work is need in the dance party repo to get generated dancer sprites to mirror. That work is here: https://github.com/code-dot-org/dance-party/pull/678




## Links
<!--  Links to relevant external resources.
      - spec docs, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- Jira: 

## Testing story
<!--  Does your change include appropriate tests?
      - If so, please describe how the tests included in this PR are sufficient.
      - If not, please explain why this change does not need to be tested. -->



## Deployment strategy
<!--  Any special steps required to deploy this, besides merging?
      - Are there database migrations or manual steps?
      - Does this require coordination with other teams or systems? -->



## Follow-up work
<!--  List any clean-up or technical debt that will be addressed in future work.
      - Include Jira links where applicable.
      - Are there any known limitations or improvements planned? -->

Cut a new release of `dance-party`  with https://github.com/code-dot-org/dance-party/pull/678 and bump to it in this repo.


## Privacy
<!--  How does this change impact Student & Teacher privacy?
      - Does this collect, use, share, or modify PII, either new or existing? -->



## Security
<!--  How does this change impact our security surface-area?
      - Do API's touched have the right auth?
      - Do infra changes impact our attack surface or encryption?
-->



## Caching
<!--  How does this change impact caching behavior?
      - Are cache keys or invalidation strategies affected?
      - Will this require cache warming or invalidation after deployment? -->



## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
