### PR TITLE
fix: package json script lint:fix

### DIFF
--- a/apps/package.json
+++ b/apps/package.json
@@ -9,8 +9,9 @@
   },
   "scripts": {
     "lint": "yarn lint:scss && yarn lint:js",
-    "lint:fix": "yarn lint:scss --fix && yarn lint:js --fix",
+    "lint:fix": "yarn lint:scss --fix && yarn lint:js:fix",
     "lint:js": "concurrently \"yarn lint:js:ts\" \"yarn lint:jsx:tsx\"",
+    "lint:js:fix": "concurrently \"yarn lint:js:ts --fix\" \"yarn lint:jsx:tsx --fix\"",
     "lint:js:ts": "eslint --format ./.eslintCustomMessagesFormatter.js --ext=.js,.ts --report-unused-disable-directives-severity=error .",
     "lint:jsx:tsx": "eslint --format ./.eslintCustomMessagesFormatter.js --ext=.jsx,.tsx --report-unused-disable-directives-severity=error .",
     "lint:scss": "npx stylelint '**/*.scss'",


### PR DESCRIPTION
A recent change to run linting concurrently caused `yarn lint:fix` to fail. I added a new `lint:js:fix` script so the `--fix` flag can be passed to both concurrent scripts



## Links
<!--  Links to relevant external resources.
      - spec docs, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- Jira: 

## Testing story
<!--  Does your change include appropriate tests?
      - If so, please describe how the tests included in this PR are sufficient.
      - If not, please explain why this change does not need to be tested. -->



## Deployment strategy
<!--  Any special steps required to deploy this, besides merging?
      - Are there database migrations or manual steps?
      - Does this require coordination with other teams or systems? -->



## Follow-up work
<!--  List any clean-up or technical debt that will be addressed in future work.
      - Include Jira links where applicable.
      - Are there any known limitations or improvements planned? -->



## Privacy
<!--  How does this change impact Student & Teacher privacy?
      - Does this collect, use, share, or modify PII, either new or existing? -->



## Security
<!--  How does this change impact our security surface-area?
      - Do API's touched have the right auth?
      - Do infra changes impact our attack surface or encryption?
-->



## Caching
<!--  How does this change impact caching behavior?
      - Are cache keys or invalidation strategies affected?
      - Will this require cache warming or invalidation after deployment? -->



## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
