### PR TITLE
Backpack: add default mime type for markdown

### DIFF
--- a/dashboard/legacy/middleware/files_api.rb
+++ b/dashboard/legacy/middleware/files_api.rb
@@ -237,7 +237,13 @@ class FilesApi < Sinatra::Base
     type = File.extname(filename)
     not_found if type.empty?
     unsupported_media_type unless buckets.allowed_file_type?(type)
-    content_type type
+    type_params = {}
+    # Sinatra does not have a content type for markdown files, so we
+    # add it here.
+    if type == '.md'
+      type_params = {default: 'text/markdown'}
+    end
+    content_type(type, type_params)
 
     # Unless this is hosted by codeprojects.org or is a safely viewable file type,
     # serve all files with Content-Disposition set to attachment so browsers


### PR DESCRIPTION
It turned out that Sinatra does not know the mime type for a `.md` file, which was causing us to be unable to import markdown files from the backpack into projects. Here is the [honeybadger error](https://app.honeybadger.io/projects/3240/faults/124727059).

The easiest solution to this is to provide a `default` parameter to the `content_type` method if we see a `md` type. Then the correct content type will be applied rather than the request failing.


## Links

- Jira: [AFL-331](https://codedotorg.atlassian.net/browse/AFL-331)
- Documentation for [content_type](https://www.rubydoc.info/gems/sinatra/Sinatra%2FHelpers:content_type). These are the docs for a version that's higher than what we are using, but both versions use the `default` parameter value in the same way.

## Testing story
Confirmed you can now import a markdown file from the backpack in web lab 2.


## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
