### PR TITLE
hoai2025: final mix

### DIFF
--- a/apps/src/music/ai/generate/GenerateCode.ts
+++ b/apps/src/music/ai/generate/GenerateCode.ts
@@ -99,12 +99,18 @@ export const generateSongAi = async (
 
   console.log('Starting AI ask...');
 
+  // It's possible that the extra prompt text references the drums.
+  const promptTextExtraWithDrums = promptTextExtra?.replace(
+    '{drumSounds}',
+    drumSounds
+  );
+
   const result = await askAi(
     'Here is the context: \n\n' +
       GenerateContext(contextText, sounds, drumSounds) +
       '\n\n And here is the request: \n\n' +
       promptText +
-      (promptTextExtra ? '\n\n' + promptTextExtra : '')
+      (promptTextExtraWithDrums ? '\n\n' + promptTextExtraWithDrums : '')
   );
 
   if (result.length > 1 && result[1].status === AiInteractionStatus.OK) {

--- a/apps/src/music/ai/generate/GenerateCodeContent.ts
+++ b/apps/src/music/ai/generate/GenerateCodeContent.ts
@@ -1,26 +1,22 @@
-export const DefaultContext = `Your job will be to generate pseudocode for a system that plays a song.  You'll be given a description of what to play, and then you should output code that generates the song to be played. The pseudocode looks something like this:
+export const DefaultContext = `
+Your job will be to generate pseudocode for a system that plays a song.  You'll be given a description of what to play, and then you should output code that generates the song to be played. The pseudocode looks something like this:
 
 when_run
-  play "hiphop/drum_beat_808"
-  play "electro/drum_beat_hyper"
+  play "song_or_genre_name/sound_name_1"
+  play "song_or_genre_name/sound_name_2"
   play_together
-    play "hiphop/drum_beat_808"
-    play "electro/drum_beat_hyper"
-  repeat 3
-    play "hiphop/drum_beat_808"
-    play "electro/drum_beat_hyper"
+    play "song_or_genre_name/sound_name_3"
+    play "song_or_genre_name/sound_name_4"
+  repeat 2
+    play "song_or_genre_name/sound_name_5"
 
-Indenting is important.  In this example, when the code is run, it plays "hiphop/drum_beat_808" and then "electro/drum_beat_hyper".  Then it plays "electro_beat_808" and "electro/drum_beat_hyper" at the same time.  Then it plays the same thing three times: "hiphop/drum_beat_808" followed by "electro/drum_beat_hyper".
+Indenting is important.  In this example, when the code is run, it plays "song_or_genre_name/sound_name_1" and then "song_or_genre_name/sound_name_2".  Then it plays "song_or_genre_name/sound_name_3" and "song_or_genre_name/sound_name_4" at the same time.  Then it plays the same thing twice: "song_or_genre_name/sound_name_5"
+
 Don't include any comments in the generated pseudocode.
 
-The valid sounds to use are: {sounds}.  (The length of each sound is in parentheses.)  You can use any of these sounds in your pseudocode. DO NOT include the sound length in the pseudocode.
-You should only use repeat in two specific scenarios:
+The valid sounds to use are: {sounds}.  You can also use any of the following additional drum sounds: "{drumSounds}". (The length of each sound is in parentheses.)  You can use any of these sounds in your pseudocode. DO NOT include the sound length in the pseudocode.
 
-1) if explicitly asked to make the song loop
-
-OR
-
-2) within a play together, to multiply a shorter sound to equal a longer sound. For example:
+You should only use repeat in one specific scenario: within a play together, to multiply a shorter sound to equal a longer, non-repeated sound. For example:
 
 play_together
   sample_with_length_4
@@ -35,6 +31,8 @@ play_together
   repeat 2
     sample_with_length_2
   sample_with_length_4
+
+If asked to use genre drums, use more of those instead of the original artist's drums.
 `;
 
 export const DefaultPrompt =

--- a/apps/src/music/ai/generate/GenerateCodeContent.ts
+++ b/apps/src/music/ai/generate/GenerateCodeContent.ts
@@ -11,10 +11,30 @@ when_run
     play "electro/drum_beat_hyper"
 
 Indenting is important.  In this example, when the code is run, it plays "hiphop/drum_beat_808" and then "electro/drum_beat_hyper".  Then it plays "electro_beat_808" and "electro/drum_beat_hyper" at the same time.  Then it plays the same thing three times: "hiphop/drum_beat_808" followed by "electro/drum_beat_hyper".
-
 Don't include any comments in the generated pseudocode.
 
 The valid sounds to use are: {sounds}.  (The length of each sound is in parentheses.)  You can use any of these sounds in your pseudocode. DO NOT include the sound length in the pseudocode.
+You should only use repeat in two specific scenarios:
+
+1) if explicitly asked to make the song loop
+
+OR
+
+2) within a play together, to multiply a shorter sound to equal a longer sound. For example:
+
+play_together
+  sample_with_length_4
+  repeat 2
+    sample_with_length_2
+  repeat 2
+    another_sample_with_length_2
+
+Another example:
+
+play_together
+  repeat 2
+    sample_with_length_2
+  sample_with_length_4
 `;
 
 export const DefaultPrompt =

--- a/dashboard/config/levels/custom/music/hoai2025-music-adlib-3.level
+++ b/dashboard/config/levels/custom/music/hoai2025-music-adlib-3.level
@@ -10,7 +10,7 @@
       "guideMode": "aiCodeGenerate",
       "aiCodeGenerateAdlib": {
         "id": "sounds",
-        "template": "Code a {mood} music mix. It should be {length} length. Use {drums}.",
+        "template": "Code a {mood} music mix. It should be a {length} length. Use {drums}.",
         "options": {
           "mood": [
             {

--- a/dashboard/config/levels/custom/music/hoai2025-music-adlib-3.level
+++ b/dashboard/config/levels/custom/music/hoai2025-music-adlib-3.level
@@ -1,0 +1,98 @@
+<Music>
+  <config><![CDATA[{
+  "game_id": 70,
+  "created_at": "2025-10-28T21:43:54.000Z",
+  "level_num": "custom",
+  "user_id": 1,
+  "properties": {
+    "level_data": {
+      "library": "launch2024",
+      "guideMode": "aiCodeGenerate",
+      "aiCodeGenerateAdlib": {
+        "id": "sounds",
+        "template": "Code a {mood} music mix. It should be {length} length. Use {drums}.",
+        "options": {
+          "mood": [
+            {
+              "id": "simple",
+              "text": "simple"
+            },
+            {
+              "id": "creative",
+              "text": "creative"
+            },
+            {
+              "id": "wild",
+              "text": "wild"
+            }
+          ],
+          "length": [
+            {
+              "id": "short",
+              "text": "short"
+            },
+            {
+              "id": "medium",
+              "text": "medium"
+            },
+            {
+              "id": "long",
+              "text": "long"
+            }
+          ],
+          "drums": [
+            {
+              "id": "original",
+              "text": "original drums"
+            },
+            {
+              "id": "electro",
+              "text": "electro drums"
+            },
+            {
+              "id": "groove",
+              "text": "groove drums"
+            },
+            {
+              "id": "indie",
+              "text": "indie drums"
+            },
+            {
+              "id": "pop",
+              "text": "pop drums"
+            },
+            {
+              "id": "hiphop",
+              "text": "hip hop drums"
+            },
+            {
+              "id": "rock",
+              "text": "heavy rock drums"
+            }
+          ]
+        },
+        "variantCount": 3
+      },
+      "aiCodeGenerateExtraPrompt": "You can also use any of the following additional drum sounds: \"{drumSounds}\"."
+    },
+    "encrypted": "false",
+    "offer_browser_tts": "false",
+    "use_secondary_finish_button": "false",
+    "hide_share_and_remix": "true",
+    "submittable": "false",
+    "disable_edit_run_for_submission": "false",
+    "predict_settings": {
+      "isPredictLevel": false
+    },
+    "exemplar_settings": {
+      "playerEnabled": false,
+      "validationEnabled": false
+    },
+    "long_instructions": "### Create a Mix\r\nTell AI what to create.",
+    "preload_asset_list": null
+  },
+  "published": true,
+  "audit_log": "[{\"changed_at\":\"2025-10-28T21:43:54.444+00:00\",\"changed\":[\"cloned from \\\"hoai2025-music-adlib-2\\\"\"],\"cloned_from\":\"hoai2025-music-adlib-2\"}]"
+}]]></config>
+  <blocks/>
+</Music>

--- a/dashboard/config/scripts_json/hoai2025-dev.script_json
+++ b/dashboard/config/scripts_json/hoai2025-dev.script_json
@@ -8,7 +8,7 @@
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2025-10-19 04:46:00 UTC",
+    "serialized_at": "2025-10-28 22:15:45 UTC",
     "hide_within_course": false,
     "published_state": null,
     "instruction_type": null,
@@ -81,6 +81,9 @@
       "activity_section_position": 1,
       "assessment": false,
       "properties": {
+        "level_keys": [
+          "hoai2025-dance-instructions"
+        ]
       },
       "bonus": false,
       "seeding_key": {
@@ -198,6 +201,9 @@
       "activity_section_position": 6,
       "assessment": false,
       "properties": {
+        "level_keys": [
+          "hoai2025-music-instructions"
+        ]
       },
       "bonus": false,
       "seeding_key": {
@@ -267,6 +273,27 @@
       "activity_section_position": 9,
       "assessment": false,
       "properties": {
+      },
+      "bonus": false,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "hoai2025-music-adlib-3"
+        ],
+        "lesson.key": "lesson-1",
+        "lesson_group.key": "",
+        "script.name": "hoai2025-dev",
+        "activity_section.key": "433ca43c-27a9-4011-b6dd-b4d2e5616c95"
+      },
+      "level_keys": [
+        "hoai2025-music-adlib-3"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 10,
+      "activity_section_position": 10,
+      "assessment": false,
+      "properties": {
         "level_keys": [
           "hoai2025-music-text"
         ]
@@ -286,9 +313,9 @@
       ]
     },
     {
-      "chapter": 10,
-      "position": 10,
-      "activity_section_position": 10,
+      "chapter": 11,
+      "position": 11,
+      "activity_section_position": 11,
       "assessment": false,
       "properties": {
         "level_keys": [
@@ -400,6 +427,18 @@
         "level.key": "hoai2025-music-adlib-2",
         "script_level.level_keys": [
           "hoai2025-music-adlib-2"
+        ],
+        "lesson.key": "lesson-1",
+        "lesson_group.key": "",
+        "script.name": "hoai2025-dev",
+        "activity_section.key": "433ca43c-27a9-4011-b6dd-b4d2e5616c95"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "hoai2025-music-adlib-3",
+        "script_level.level_keys": [
+          "hoai2025-music-adlib-3"
         ],
         "lesson.key": "lesson-1",
         "lesson_group.key": "",


### PR DESCRIPTION
This adds a new level to `/s/hoai2025` which demonstrates a new adlib being proposed for the final music generation level (and shared via template-backed level with the final freeplay level's music generation sublevel).  

It also updates the music generation prompt used for all music generation.  

<img width="699" height="325" alt="Screenshot 2025-10-28 at 3 34 50 PM" src="https://github.com/user-attachments/assets/aba9e4d0-002b-4c84-b2b4-31bab2c0a7a1" />

