### PR TITLE
(feat) Adds forward ref to Button, GenericButton, Fixes Panel Levels keyboard Nav

### DIFF
--- a/apps/src/panels/PanelsView.tsx
+++ b/apps/src/panels/PanelsView.tsx
@@ -72,7 +72,7 @@ const PanelsView: React.FunctionComponent<PanelsProps> = ({
   const {cancel} = useBrowserTextToSpeech();
 
   const lastPanelStartTime = useRef<number>(Date.now());
-  const nextButtonRef = useRef<HTMLElement>(null);
+  const nextButtonRef = useRef<HTMLButtonElement>(null);
 
   targetWidth -= horizontalMargin * 2;
   targetHeight -= verticalMargin * 2 + childrenAreaHeight;

--- a/apps/src/panels/PanelsView.tsx
+++ b/apps/src/panels/PanelsView.tsx
@@ -72,6 +72,7 @@ const PanelsView: React.FunctionComponent<PanelsProps> = ({
   const {cancel} = useBrowserTextToSpeech();
 
   const lastPanelStartTime = useRef<number>(Date.now());
+  const nextButtonRef = useRef<HTMLElement>(null);
 
   targetWidth -= horizontalMargin * 2;
   targetHeight -= verticalMargin * 2 + childrenAreaHeight;
@@ -159,6 +160,18 @@ const PanelsView: React.FunctionComponent<PanelsProps> = ({
   }, [currentPanelIndex, setTypingDone]);
 
   const panel = panels[currentPanelIndex];
+  const showTyping =
+    panel.typing || queryParams('panels-show-typing') === 'true';
+
+  // When typing, only show the button when the typing is done.
+  const showButton = !showTyping || typingDone;
+
+  useEffect(() => {
+    if (showButton) {
+      nextButtonRef.current?.focus();
+    }
+  }, [showButton, currentPanelIndex]);
+
   if (!panel) {
     return null;
   }
@@ -190,12 +203,6 @@ const PanelsView: React.FunctionComponent<PanelsProps> = ({
       : commonI18n.continue();
 
   const plainText = markdownToTxt(panel.text);
-
-  const showTyping =
-    panel.typing || queryParams('panels-show-typing') === 'true';
-
-  // When typing, only show the button when the typing is done.
-  const showButton = !showTyping || typingDone;
 
   return (
     <div
@@ -268,6 +275,7 @@ const PanelsView: React.FunctionComponent<PanelsProps> = ({
       >
         {showButton && (
           <Button
+            ref={nextButtonRef}
             key={`button-${currentPanelIndex}`}
             id="panels-button"
             onClick={handleButtonClick}

--- a/frontend/packages/component-library/src/button/Button.tsx
+++ b/frontend/packages/component-library/src/button/Button.tsx
@@ -1,4 +1,4 @@
-import {memo} from 'react';
+import {forwardRef, memo} from 'react';
 
 import GenericButton, {
   CoreButtonProps,
@@ -16,9 +16,12 @@ export const buttonColors: {[key in ButtonColor]: ButtonColor} = {
 
 export interface ButtonProps extends CoreButtonProps, ButtonSpecificProps {}
 
-const Button: React.FunctionComponent<ButtonProps> = props => (
-  <GenericButton {...props} />
-);
+const Button = forwardRef<HTMLElement, ButtonProps>((props, ref) => (
+  <GenericButton
+    ref={ref as React.Ref<HTMLButtonElement & HTMLAnchorElement>}
+    {...props}
+  />
+));
 
 /**
  * ###  Status: ```Ready for dev```

--- a/frontend/packages/component-library/src/button/Button.tsx
+++ b/frontend/packages/component-library/src/button/Button.tsx
@@ -16,12 +16,9 @@ export const buttonColors: {[key in ButtonColor]: ButtonColor} = {
 
 export interface ButtonProps extends CoreButtonProps, ButtonSpecificProps {}
 
-const Button = forwardRef<HTMLElement, ButtonProps>((props, ref) => (
-  <GenericButton
-    ref={ref as React.Ref<HTMLButtonElement & HTMLAnchorElement>}
-    {...props}
-  />
-));
+const Button = forwardRef<HTMLButtonElement | HTMLAnchorElement, ButtonProps>(
+  (props, ref) => <GenericButton ref={ref} {...props} />,
+);
 
 /**
  * ###  Status: ```Ready for dev```

--- a/frontend/packages/component-library/src/button/GenericButton.tsx
+++ b/frontend/packages/component-library/src/button/GenericButton.tsx
@@ -1,5 +1,5 @@
 import classNames from 'classnames';
-import {memo, useMemo, HTMLAttributes} from 'react';
+import React, {forwardRef, memo, useMemo, HTMLAttributes} from 'react';
 
 import {ComponentSizeXSToL} from '@/common/types';
 import FontAwesomeV6Icon, {FontAwesomeV6IconProps} from '@/fontAwesomeV6Icon';
@@ -191,121 +191,130 @@ const spinnerIcon: FontAwesomeV6IconProps = {
   animationType: 'spin',
 };
 
-const GenericButton: React.FunctionComponent<GenericButtonProps> = ({
-  className,
-  id,
-  disabled = false,
-  isPending = false,
-  ariaLabel,
-  size = 'm',
-  type = 'primary',
-  color = 'purple',
-  buttonTagTypeAttribute = 'button',
-  /** Text button specific props */
-  iconLeft,
-  iconRight,
-  text,
-  /** IconOnly button specific props*/
-  isIconOnly = false,
-  icon,
-  /** <a> specific props */
-  useAsLink = false,
-  href,
-  target,
-  download,
-  title,
-  analyticsCallback,
-  /** <button> specific props */
-  onClick,
-  value,
-  name,
-  forceHover = false,
-  ...rest
-}) => {
-  const ButtonTag = useAsLink ? 'a' : 'button';
+const GenericButton = forwardRef<
+  HTMLButtonElement | HTMLAnchorElement,
+  GenericButtonProps
+>(
+  (
+    {
+      className,
+      id,
+      disabled = false,
+      isPending = false,
+      ariaLabel,
+      size = 'm',
+      type = 'primary',
+      color = 'purple',
+      buttonTagTypeAttribute = 'button',
+      /** Text button specific props */
+      iconLeft,
+      iconRight,
+      text,
+      /** IconOnly button specific props*/
+      isIconOnly = false,
+      icon,
+      /** <a> specific props */
+      useAsLink = false,
+      href,
+      target,
+      download,
+      title,
+      analyticsCallback,
+      /** <button> specific props */
+      onClick,
+      value,
+      name,
+      forceHover = false,
+      ...rest
+    },
+    ref,
+  ) => {
+    const ButtonTag = useAsLink ? 'a' : 'button';
 
-  const tagSpecificProps =
-    ButtonTag === 'a'
-      ? {
-          href: disabled ? undefined : href,
-          target,
-          /** Copied from old button component. Only need it for the older browsers,
-           *  since modern browsers (~2020+ release year secures these vulnerabilities by default) */
-          // Opening links in new tabs with 'target=_blank' is inherently insecure. Unfortunately, we depend
-          // on this functionality in a couple of place. Fortunately, it is possible to partially mitigate some of
-          // the insecurity of this functionality by using the `rel` tag to block some of the potential exploits.
-          // Therefore, we do so here.
-          rel: target === '_blank' ? 'noopener noreferrer' : undefined,
+    const tagSpecificProps =
+      ButtonTag === 'a'
+        ? {
+            href: disabled ? undefined : href,
+            target,
+            /** Copied from old button component. Only need it for the older browsers,
+             *  since modern browsers (~2020+ release year secures these vulnerabilities by default) */
+            // Opening links in new tabs with 'target=_blank' is inherently insecure. Unfortunately, we depend
+            // on this functionality in a couple of place. Fortunately, it is possible to partially mitigate some of
+            // the insecurity of this functionality by using the `rel` tag to block some of the potential exploits.
+            // Therefore, we do so here.
+            rel: target === '_blank' ? 'noopener noreferrer' : undefined,
+            download,
+            title,
+            onClick: analyticsCallback,
+          }
+        : {type: buttonTagTypeAttribute, onClick, value, name};
+
+    // Check if correct props combination is passed
+    useMemo(
+      () =>
+        checkButtonPropsForErrors({
+          type,
+          icon,
+          useAsLink,
+          onClick,
+          href,
           download,
-          title,
-          onClick: analyticsCallback,
-        }
-      : {type: buttonTagTypeAttribute, onClick, value, name};
+          text,
+          isIconOnly,
+          color,
+        }),
+      [type, icon, useAsLink, onClick, href, download, text, isIconOnly, color],
+    );
 
-  // Check if correct props combination is passed
-  useMemo(
-    () =>
-      checkButtonPropsForErrors({
-        type,
-        icon,
-        useAsLink,
-        onClick,
-        href,
-        download,
-        text,
-        isIconOnly,
-        color,
-      }),
-    [type, icon, useAsLink, onClick, href, download, text, isIconOnly, color],
-  );
-
-  /** Handling isPending state content & spinner show logic here.
+    /** Handling isPending state content & spinner show logic here.
      - If there's only text - we show only spinner.
      - If there's only icon - we show only spinner.
      - If there's text and iconLeft or both iconLeft and iconRight -> we show spinner on the left + text + iconRight (if it's present).
      - If there's text and iconRight - we show text + spinner on the right.
      */
-  const showIcon = icon && !isPending;
-  const showIconLeft = iconLeft && !isPending;
-  const showIconRight =
-    (iconRight && !isPending) || (isPending && iconRight && iconLeft);
-  const addPendingButtonWithHiddenTextClass =
-    isPending && !icon && !iconLeft && !iconRight;
-  const spinnerPosition = iconRight && !iconLeft ? 'right' : 'left';
+    const showIcon = icon && !isPending;
+    const showIconLeft = iconLeft && !isPending;
+    const showIconRight =
+      (iconRight && !isPending) || (isPending && iconRight && iconLeft);
+    const addPendingButtonWithHiddenTextClass =
+      isPending && !icon && !iconLeft && !iconRight;
+    const spinnerPosition = iconRight && !iconLeft ? 'right' : 'left';
 
-  return (
-    <ButtonTag
-      className={classNames(
-        moduleStyles.button,
-        moduleStyles[`button-${type}`],
-        moduleStyles[`button-${color}`],
-        moduleStyles[`button-${size}`],
-        forceHover && moduleStyles['button-withForcedHover'],
-        isIconOnly && moduleStyles['button-iconOnly'],
-        addPendingButtonWithHiddenTextClass &&
-          moduleStyles.buttonPendingWithHiddenText,
-        className,
-      )}
-      id={id}
-      disabled={disabled}
-      {...rest}
-      aria-disabled={disabled || rest['aria-disabled']}
-      aria-label={ariaLabel || rest['aria-label']}
-      {...tagSpecificProps}
-    >
-      {isPending && spinnerPosition === 'left' && (
-        <FontAwesomeV6Icon {...spinnerIcon} />
-      )}
-      {showIconLeft && <FontAwesomeV6Icon {...iconLeft} />}
-      {showIcon && <FontAwesomeV6Icon {...icon} />}
-      {text && <span>{text}</span>}
-      {showIconRight && <FontAwesomeV6Icon {...iconRight} />}
-      {isPending && spinnerPosition === 'right' && (
-        <FontAwesomeV6Icon {...spinnerIcon} />
-      )}
-    </ButtonTag>
-  );
-};
+    return (
+      <ButtonTag
+        ref={ref as React.Ref<HTMLButtonElement & HTMLAnchorElement>}
+        className={classNames(
+          moduleStyles.button,
+          moduleStyles[`button-${type}`],
+          moduleStyles[`button-${color}`],
+          moduleStyles[`button-${size}`],
+          forceHover && moduleStyles['button-withForcedHover'],
+          isIconOnly && moduleStyles['button-iconOnly'],
+          addPendingButtonWithHiddenTextClass &&
+            moduleStyles.buttonPendingWithHiddenText,
+          className,
+        )}
+        id={id}
+        disabled={disabled}
+        {...rest}
+        aria-disabled={disabled || rest['aria-disabled']}
+        aria-label={ariaLabel || rest['aria-label']}
+        {...tagSpecificProps}
+      >
+        {isPending && spinnerPosition === 'left' && (
+          <FontAwesomeV6Icon {...spinnerIcon} />
+        )}
+        {showIconLeft && <FontAwesomeV6Icon {...iconLeft} />}
+        {showIcon && <FontAwesomeV6Icon {...icon} />}
+        {text && <span>{text}</span>}
+        {showIconRight && <FontAwesomeV6Icon {...iconRight} />}
+        {isPending && spinnerPosition === 'right' && (
+          <FontAwesomeV6Icon {...spinnerIcon} />
+        )}
+      </ButtonTag>
+    );
+  },
+);
 
 /**
  * ### Production-ready Checklist:

--- a/frontend/packages/component-library/src/button/GenericButton.tsx
+++ b/frontend/packages/component-library/src/button/GenericButton.tsx
@@ -282,7 +282,8 @@ const GenericButton = forwardRef<
 
     return (
       <ButtonTag
-        ref={ref as React.Ref<HTMLButtonElement & HTMLAnchorElement>}
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        ref={ref as React.Ref<any>} // Cannot be more specific without refactoring entire file
         className={classNames(
           moduleStyles.button,
           moduleStyles[`button-${type}`],


### PR DESCRIPTION
This makes it so that focus moves immediately to the next button when each panel level opens so that it is much easier for a keyboard user to navigate. Before, the behavior was unpredictible- focus sometimes landed on the body element (one item before 'next') and sometimes on a link beyond the panel, requiring the user to tab nav backwards to find 'next'. 

Most of these changes are indent or copy/paste related: hide whitespace helps show something closer to the real diff.

There is a tradeoff here: we gain the ability to use a ref for both buttons and anchor tags, but I needed to use a generic 'any' ref to do this without refactoring the entire file away from its anchor/button design.


https://github.com/user-attachments/assets/165836df-0742-40b8-990a-b56ede0290ce



## Links

- Jira: https://codedotorg.atlassian.net/browse/SL-1464

## Testing story
<!--  Does your change include appropriate tests?
      - If so, please describe how the tests included in this PR are sufficient.
      - If not, please explain why this change does not need to be tested. -->



## Deployment strategy
<!--  Any special steps required to deploy this, besides merging?
      - Are there database migrations or manual steps?
      - Does this require coordination with other teams or systems? -->



## Follow-up work
<!--  List any clean-up or technical debt that will be addressed in future work.
      - Include Jira links where applicable.
      - Are there any known limitations or improvements planned? -->



## Privacy
<!--  How does this change impact Student & Teacher privacy?
      - Does this collect, use, share, or modify PII, either new or existing? -->



## Security
<!--  How does this change impact our security surface-area?
      - Do API's touched have the right auth?
      - Do infra changes impact our attack surface or encryption?
-->



## Caching
<!--  How does this change impact caching behavior?
      - Are cache keys or invalidation strategies affected?
      - Will this require cache warming or invalidation after deployment? -->



## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
