### PR TITLE
Lab 2: update file tab UI in Codebridge code editor view

### DIFF
--- a/apps/src/codebridge/FilePreview/styles/html-preview-header.module.scss
+++ b/apps/src/codebridge/FilePreview/styles/html-preview-header.module.scss
@@ -1,5 +1,5 @@
 .previewHeaderContainer {
-  background-color: var(--background-neutral-tertiary);
+  background-color: var(--background-neutral-secondary);
   border-bottom: 1px solid var(--borders-neutral-primary);
   padding: 0.5rem;
   display: flex;

--- a/apps/src/codebridge/FileTabs/FileTab.tsx
+++ b/apps/src/codebridge/FileTabs/FileTab.tsx
@@ -1,5 +1,6 @@
 import CloseButton from '@code-dot-org/component-library/closeButton';
 import FontAwesomeV6Icon from '@code-dot-org/component-library/fontAwesomeV6Icon';
+import {BodyFourText} from '@code-dot-org/component-library/typography';
 import {ProjectFile} from '@codebridge/types';
 import {getFileIconNameAndStyle} from '@codebridge/utils';
 import classNames from 'classnames';
@@ -66,13 +67,14 @@ const FileTab = ({file}: FileTabProps) => {
           iconStyle={iconStyle}
           className={iconClassName}
         />
-        <span>{file.name}</span>
+        <BodyFourText noMargin>{file.name}</BodyFourText>
       </div>
       <CloseButton
         onClick={() => dispatch(closeFileThunk(file.id))}
         color={'light'}
         aria-label={codebridgeI18n.closeFile({filename: file.name})}
         className={moduleStyles.closeButton}
+        size="s"
       />
     </div>
   );

--- a/apps/src/codebridge/FileTabs/styles/fileTabs.module.scss
+++ b/apps/src/codebridge/FileTabs/styles/fileTabs.module.scss
@@ -22,14 +22,14 @@
 
 .fileTab {
   display: flex;
+  justify-content: space-between;
   align-items: center;
   gap: 0.375rem;
+  height: 24px;
   padding-block: 0;
   padding-inline: 0.5rem 0.25rem;
   cursor: pointer;
   white-space: nowrap;
-  justify-content: space-between;
-  height: 24px;
   background-color: var(--background-neutral-secondary);
   border-radius: variables.$default-border-radius;
   transition: all 0.2s ease-in-out;

--- a/apps/src/codebridge/FileTabs/styles/fileTabs.module.scss
+++ b/apps/src/codebridge/FileTabs/styles/fileTabs.module.scss
@@ -1,51 +1,64 @@
+@use '@cdo/apps/lab2/views/components/layout/variables.scss' as variables;
+
 .fileTabs {
   display: flex;
   justify-content: flex-start;
-  gap: 6px;
-  align-items: flex-end;
+  align-items: center;
+  gap: 0.5rem;
+  padding-inline: 0.5rem;
   overflow-x: auto;
   max-width: 100%;
-  background-color: var(--background-neutral-tertiary);
+  background-color: var(--background-neutral-primary);
   scrollbar-width: thin;
   box-sizing: border-box;
-  font-size: 14px;
-  font-weight: 600;
   color: var(--text-neutral-secondary);
 
   *:focus-visible {
     outline: var(--borders-brand-teal-primary) solid 2px;
     outline-offset: 2px;
-    border-radius: 0.375rem;
+    border-radius: variables.$default-border-radius;
   }
 }
 
 .fileTab {
   display: flex;
+  align-items: center;
+  gap: 0.375rem;
+  padding-block: 0;
+  padding-inline: 0.5rem 0.25rem;
   cursor: pointer;
   white-space: nowrap;
   justify-content: space-between;
-  height: 28px;
+  height: 24px;
   background-color: var(--background-neutral-secondary);
-  border-radius: 4px 4px 0 0;
+  border-radius: variables.$default-border-radius;
+  transition: all 0.2s ease-in-out;
 
   &:hover:not(.active) {
-    background-color: var(--background-neutral-quaternary);
+    background-color: var(--background-neutral-tertiary);
   }
 }
 
 .label {
   display: flex;
   align-items: center;
-  gap: 10px;
-  padding: 0 10px;
+  gap: 0.5rem;
+
+  p {
+    color: var(--text-neutral-tertiary);
+  }
 }
 
 .active {
-  background-color: var(--background-neutral-primary);
-  color: var(--text-neutral-primary);
-}
+  background-color: var(--background-brand-teal-primary);
+  color: var(--text-neutral-white-fixed);
 
-button.closeButton {
-  margin: 4px 0;
-  padding-right: 10px;
+  .closeButton:focus-visible {
+    outline-color: var(--borders-brand-teal-strong);
+  }
+
+  p,
+  i {
+    color: var(--text-neutral-white-fixed);
+  }
 }

--- a/apps/src/weblab2/layout/vertical-layout.module.scss
+++ b/apps/src/weblab2/layout/vertical-layout.module.scss
@@ -3,6 +3,7 @@
 
 .headerContainer {
   height: 2.5rem;
+  border-bottom: variables.$default-border;
 }
 
 .editorAndPreviewContainer {

--- a/dashboard/config/course_offerings/artificial-intelligence-foundations-semester2.json
+++ b/dashboard/config/course_offerings/artificial-intelligence-foundations-semester2.json
@@ -15,7 +15,7 @@
   "professional_learning_program": "https://code.org/apply",
   "video": null,
   "published_date": "2025-10-27 05:00:00 UTC",
-  "self_paced_pl_course_offering_key": null,
+  "self_paced_pl_course_offering_key": "teaching-ai-foundations-semester2",
   "ai_teaching_assistant_available": false,
   "facilitator_course_permissions": [
 

--- a/dashboard/config/course_offerings/artificial-intelligence-foundations-semester2.json
+++ b/dashboard/config/course_offerings/artificial-intelligence-foundations-semester2.json
@@ -15,7 +15,7 @@
   "professional_learning_program": "https://code.org/apply",
   "video": null,
   "published_date": "2025-10-27 05:00:00 UTC",
-  "self_paced_pl_course_offering_key": "teaching-ai-foundations-semester2",
+  "self_paced_pl_course_offering_key": null,
   "ai_teaching_assistant_available": false,
   "facilitator_course_permissions": [
 


### PR DESCRIPTION
Updates the file tab UI in Codebridge on Web Lab 2 and Python Lab to match mocks. This is part of ongoing work to update the File Manager UI.

## Links
Jira ticket: [AFL-333](https://codedotorg.atlassian.net/browse/AFL-333)
Figma mock: [here](https://www.figma.com/design/ahYTsb3I7rsJNW0n2vnXm6/DSCO-Components?node-id=11637-3062&m=dev)

## Testing story
Tested locally in light and dark mode, RTL languages, and across browsers

----

## Web Lab 2

### Before


https://github.com/user-attachments/assets/06a03514-0067-4c2f-9c38-3986c304baac



### After

Also updated the bg color of the Preview url header to match the other light grey bgs.

https://github.com/user-attachments/assets/9ad9aad4-1000-4c60-b08a-61871aa5cac7



## Python Lab

### Before


https://github.com/user-attachments/assets/ac4e8a52-e54d-4c3c-9200-546e76971a68



### After


https://github.com/user-attachments/assets/fd897995-b051-4f11-b8e1-284891d598f5

