### PR TITLE
Codeprojects csp: lock down image and style sources

### DIFF
--- a/dashboard/app/controllers/codeprojects_preview_controller.rb
+++ b/dashboard/app/controllers/codeprojects_preview_controller.rb
@@ -8,6 +8,7 @@ class CodeprojectsPreviewController < ApplicationController
     prefix = 'http://'
     # We allow connections to the domain and all subdomains of each allowed hostname.
     allowed_connect_src = ALLOWED_HOSTNAME_SUFFIXES.map {|hostname| "#{prefix}#{hostname} #{prefix}*.#{hostname}"}.join(" ")
+    allowed_image_src = ALLOWED_IMAGE_HOSTNAME_SUFFIXES.map {|hostname| "#{prefix}#{hostname} #{prefix}*.#{hostname}"}.join(" ")
 
     if rack_env?(:development)
       # dashboard_site_host is set to use port 3000 in development, but we want to also allow port 9000.
@@ -47,7 +48,7 @@ class CodeprojectsPreviewController < ApplicationController
 
     # Security Control: Restrict CSS loading sources (overrides default-src for stylesheets)
     # Goal: Allow student styling while preventing external CSS injection
-    style_src_base = "'self' https: blob:"
+    style_src_base = "'self' blob:"
 
     # Security Control: Allow inline styles for student HTML projects
     # Goal: Enable students to write inline CSS in their HTML files
@@ -57,7 +58,7 @@ class CodeprojectsPreviewController < ApplicationController
     # Security Control: Restrict image loading sources (overrides default-src for images)
     # Goal: Allow student images while preventing external image injection
     # Remaining Risk: Data URLs could contain malicious content (mitigated by iframe sandbox)
-    img_src = "'self' https: data: blob: #{code_studio_url}"
+    img_src = "'self' data: blob: #{code_studio_url} #{allowed_image_src}"
 
     # Security Control: Restrict which sites can embed this page in iframes
     # Goal: Prevent clickjacking attacks by controlling frame embedding

--- a/dashboard/app/helpers/allowed_hostname_helper.rb
+++ b/dashboard/app/helpers/allowed_hostname_helper.rb
@@ -136,4 +136,8 @@ module AllowedHostnameHelper
     'swapi.dev',                # Star Wars data. We may want to remove this in favor of swapi.info
     # REMOVED: 'theunitedstates.io' - HIGH RISK: DNS resolves but no HTTP/HTTPS service available
   ].freeze
+
+  ALLOWED_IMAGE_HOSTNAME_SUFFIXES = [
+    'picsum.photos' # Placeholder images - Public API
+  ].freeze
 end


### PR DESCRIPTION
The image-src and style-src content security policies had `https:` as a part of the policy. This was a mistake (probably on my part). This removes `https:` so we can have finer control over what sources users can access. For images the only additional source we are adding for now is `picsum.photos`, which is used in pilot curriculum and seems safe. I made a separate hostname list for images that we can add to as we see fit.

## Security
This will prevent potentially unsafe images from being loaded on web lab 2.


## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
