### PR TITLE
AI Tutor: level details in analytics logging 

### DIFF
--- a/apps/src/aichat/redux/thunks/helpers/notifyErrorUnauthorized.ts
+++ b/apps/src/aichat/redux/thunks/helpers/notifyErrorUnauthorized.ts
@@ -41,7 +41,6 @@ export async function notifyErrorUnauthorized(
     sendAnalytics(
       EVENTS.SUBMIT_AICHAT_REQUEST_UNAUTHORIZED,
       {
-        levelPath: window.location.pathname,
         userType,
         userAction,
       },

--- a/apps/src/aichat/redux/thunks/onSaveComplete.ts
+++ b/apps/src/aichat/redux/thunks/onSaveComplete.ts
@@ -36,7 +36,6 @@ export const onSaveComplete =
           sendAnalytics(saveTypeToAnalyticsEvent[currentSaveType], {
             propertyUpdated: property,
             propertyChangedTo,
-            levelPath: window.location.pathname,
           })
         );
       }

--- a/apps/src/aichat/redux/thunks/sendAnalytics.ts
+++ b/apps/src/aichat/redux/thunks/sendAnalytics.ts
@@ -12,7 +12,6 @@ export const sendAnalytics =
   (dispatch: AppDispatch, getState: () => RootState) => {
     const state = getState();
     const aichatState = state.aichat;
-
     const labState = state.lab;
     const clientType = aichatState.clientType;
     const userHasAichatAccess = aichatState.userHasAichatAccess;

--- a/apps/src/aichat/redux/thunks/sendAnalytics.ts
+++ b/apps/src/aichat/redux/thunks/sendAnalytics.ts
@@ -10,8 +10,6 @@ import {AiChatClientTypes} from '@cdo/generated-scripts/sharedConstants';
 export const sendAnalytics =
   (event: string, properties: object, skipAccessCheck = false) =>
   (dispatch: AppDispatch, getState: () => RootState) => {
-    const state = getState();
-    console.log('state in sendAnalytics thunk:', state);
     const curriculumDetails = getState().lab;
     const clientType = getState().aichat.clientType;
     const userHasAichatAccess = getState().aichat.userHasAichatAccess;

--- a/apps/src/aichat/redux/thunks/sendAnalytics.ts
+++ b/apps/src/aichat/redux/thunks/sendAnalytics.ts
@@ -10,9 +10,21 @@ import {AiChatClientTypes} from '@cdo/generated-scripts/sharedConstants';
 export const sendAnalytics =
   (event: string, properties: object, skipAccessCheck = false) =>
   (dispatch: AppDispatch, getState: () => RootState) => {
-    const curriculumDetails = getState().lab;
-    const clientType = getState().aichat.clientType;
-    const userHasAichatAccess = getState().aichat.userHasAichatAccess;
+    const state = getState();
+    const aichatState = state.aichat;
+
+    const labState = state.lab;
+    const clientType = aichatState.clientType;
+    const userHasAichatAccess = aichatState.userHasAichatAccess;
+
+    const analyticsProperties = {
+      aiTutorMode: labState.levelProperties?.aiTutorMode,
+      appType: labState.levelProperties?.appName,
+      levelId: labState.levelProperties?.id,
+      scriptId: labState.scriptId,
+      channel: labState.channel?.id,
+      levelPath: window.location.pathname,
+    };
 
     // Only check `userHasAichatAccess` for AI Chat.
     if (
@@ -20,22 +32,15 @@ export const sendAnalytics =
       userHasAichatAccess ||
       skipAccessCheck
     ) {
-      const propertiesWithClientType = {
+      const allProperties = {
         ...properties,
+        ...analyticsProperties,
         clientType,
       };
-      const propertiesWithCurriculumDetails = {
-        ...propertiesWithClientType,
-        aiTutorMode: curriculumDetails.levelProperties?.aiTutorMode,
-        appType: curriculumDetails.levelProperties?.appName,
-        levelId: curriculumDetails.levelProperties?.id,
-        scriptId: curriculumDetails.scriptId,
-        channel: curriculumDetails.channel?.id,
-        levelPath: window.location.pathname,
-      };
+
       analyticsReporter.sendEvent(
         event,
-        propertiesWithCurriculumDetails,
+        allProperties,
 
         // Only log to Amplitude for AI Chat otherwise just log to Statsig.
         clientType === AiChatClientTypes.AI_CHAT_LAB

--- a/apps/src/aichat/redux/thunks/sendAnalytics.ts
+++ b/apps/src/aichat/redux/thunks/sendAnalytics.ts
@@ -10,6 +10,9 @@ import {AiChatClientTypes} from '@cdo/generated-scripts/sharedConstants';
 export const sendAnalytics =
   (event: string, properties: object, skipAccessCheck = false) =>
   (dispatch: AppDispatch, getState: () => RootState) => {
+    const state = getState();
+    console.log('state in sendAnalytics thunk:', state);
+    const curriculumDetails = getState().lab;
     const clientType = getState().aichat.clientType;
     const userHasAichatAccess = getState().aichat.userHasAichatAccess;
 
@@ -23,9 +26,18 @@ export const sendAnalytics =
         ...properties,
         clientType,
       };
+      const propertiesWithCurriculumDetails = {
+        ...propertiesWithClientType,
+        aiTutorMode: curriculumDetails.levelProperties?.aiTutorMode,
+        appType: curriculumDetails.levelProperties?.appName,
+        levelId: curriculumDetails.levelProperties?.id,
+        scriptId: curriculumDetails.scriptId,
+        channel: curriculumDetails.channel?.id,
+        levelPath: window.location.pathname,
+      };
       analyticsReporter.sendEvent(
         event,
-        propertiesWithClientType,
+        propertiesWithCurriculumDetails,
 
         // Only log to Amplitude for AI Chat otherwise just log to Statsig.
         clientType === AiChatClientTypes.AI_CHAT_LAB

--- a/apps/src/aichat/redux/thunks/sendAnalytics.ts
+++ b/apps/src/aichat/redux/thunks/sendAnalytics.ts
@@ -16,15 +16,6 @@ export const sendAnalytics =
     const clientType = aichatState.clientType;
     const userHasAichatAccess = aichatState.userHasAichatAccess;
 
-    const analyticsProperties = {
-      aiTutorMode: labState.levelProperties?.aiTutorMode,
-      appType: labState.levelProperties?.appName,
-      levelId: labState.levelProperties?.id,
-      scriptId: labState.scriptId,
-      channel: labState.channel?.id,
-      levelPath: window.location.pathname,
-    };
-
     // Only check `userHasAichatAccess` for AI Chat.
     if (
       clientType !== AiChatClientTypes.AI_CHAT_LAB ||
@@ -33,8 +24,13 @@ export const sendAnalytics =
     ) {
       const allProperties = {
         ...properties,
-        ...analyticsProperties,
         clientType,
+        aiTutorMode: labState.levelProperties?.aiTutorMode,
+        appType: labState.levelProperties?.appName,
+        levelId: labState.levelProperties?.id,
+        scriptId: labState.scriptId,
+        channel: labState.channel?.id,
+        levelPath: window.location.pathname,
       };
 
       analyticsReporter.sendEvent(

--- a/apps/src/aichat/redux/thunks/submitChatContents.ts
+++ b/apps/src/aichat/redux/thunks/submitChatContents.ts
@@ -129,7 +129,6 @@ export const submitChatContents = createAsyncThunk(
       const fileCountImage = fileCount - fileCountPdf;
       dispatch(
         sendAnalytics(EVENTS.SUBMIT_AICHAT_REQUEST_SUCCESS, {
-          levelPath: window.location.pathname,
           fileCount,
           fileCountImage,
           fileCountPdf,

--- a/apps/src/aichat/redux/thunks/submitTeacherFeedback.ts
+++ b/apps/src/aichat/redux/thunks/submitTeacherFeedback.ts
@@ -21,7 +21,6 @@ export const submitTeacherFeedback = createAsyncThunk<
     await postSubmitTeacherFeedback(id, feedback);
     dispatch(
       sendAnalytics(EVENTS.SUBMIT_AICHAT_TEACHER_FEEDBACK, {
-        levelPath: window.location.pathname,
         feedback: feedback,
       })
     );

--- a/apps/src/aichat/views/AichatView.tsx
+++ b/apps/src/aichat/views/AichatView.tsx
@@ -346,11 +346,7 @@ const AichatView: React.FunctionComponent<LabProps<AichatLevelProperties>> = ({
                       !viewAsUserId &&
                       renderModelCustomizationHeaderRight(() => {
                         onClickStartOver();
-                        dispatch(
-                          sendAnalytics(EVENTS.AICHAT_START_OVER, {
-                            levelPath: window.location.pathname,
-                          })
-                        );
+                        dispatch(sendAnalytics(EVENTS.AICHAT_START_OVER, {}));
                       })
                     }
                   >

--- a/apps/src/lab2/types.ts
+++ b/apps/src/lab2/types.ts
@@ -203,6 +203,7 @@ export interface LevelProperties {
   startDirection?: number;
   widgetView?: boolean;
   widgetViewAllowShowCode?: boolean;
+  aiTutorMode?: string;
   // Properties added for parity with non-lab2 AI Tutor levels
   aiTutorAvailable?: boolean;
   isAssessment?: boolean;


### PR DESCRIPTION
https://codedotorg.atlassian.net/browse/AFL-170
[AIF Launch checklist](https://docs.google.com/document/d/13kJMVYbmKVW83Ovuz_PrAJX1KgXhKV1_fA8Anc_-koo/edit?tab=t.0#heading=h.8ergzi9ck93o)
[AI Tutor analytics inventory](https://docs.google.com/document/d/1FjDTaVkKslT6p_oarOQVFt-CYWNaazAB2l9SjD7d8ds/edit?tab=t.0#heading=h.8ergzi9ck93o)

As we prepare to pilot AIF 🎉 we want to ensure that we are tracking all of the metrics we'd like to understand AI Tutor usage. This PR adds additional information to what is sent to Statsig with each aichat event we're already logging: `aiTutorMode`, `appType`, `leveIId`, `scriptId`, `channelId` and `levelPath`. 

Because we now always send `levelPath` I removed it from the chat event logs that explicitly included it. 

**+Add File button clicked and file uploaded**
<img width="577" height="208" alt="Screenshot 2025-10-29 at 2 20 18 PM" src="https://github.com/user-attachments/assets/9c527a19-15c9-49f4-9ee2-d6b766e2acda" />

**AI Tutor prompt submitted** 
<img width="598" height="88" alt="Screenshot 2025-10-29 at 2 21 41 PM" src="https://github.com/user-attachments/assets/9d7379f0-e765-4229-a800-00b6632d1190" />

**AI Tutor  chat cleared** 
<img width="588" height="81" alt="Screenshot 2025-10-29 at 2 22 08 PM" src="https://github.com/user-attachments/assets/5e94fa3d-b0ae-4e16-bcf5-36d3f42877c2" />


**AI Tutor chat history copied** 
<img width="580" height="86" alt="Screenshot 2025-10-29 at 2 22 34 PM" src="https://github.com/user-attachments/assets/72f72579-66a1-4368-b51e-530cbe7533f8" />
