### PR TITLE
fix(tutor): clear textarea when changing levels

### DIFF
--- a/apps/src/aiComponentLibrary/userMessageEditor/UserMessageEditor.tsx
+++ b/apps/src/aiComponentLibrary/userMessageEditor/UserMessageEditor.tsx
@@ -1,6 +1,14 @@
 import Button from '@code-dot-org/component-library/button';
 import classnames from 'classnames';
-import React, {useState, useCallback, useMemo, useEffect, useRef} from 'react';
+import React, {
+  useState,
+  useMemo,
+  useEffect,
+  useRef,
+  Dispatch,
+  SetStateAction,
+  useCallback,
+} from 'react';
 
 import {commonI18n} from '@cdo/apps/types/locale';
 
@@ -13,6 +21,8 @@ const MAX_MESSAGE_LENGTH = 10000;
  */
 
 export interface UserMessageEditorProps {
+  userMessage: string;
+  setUserMessage: Dispatch<SetStateAction<string>>;
   onSubmit: (userMessage: string) => void;
   disabled: boolean;
   showSubmitLabel?: boolean;
@@ -28,6 +38,8 @@ const UserMessageEditor = React.forwardRef<
 >(
   (
     {
+      userMessage,
+      setUserMessage,
       onSubmit,
       disabled,
       editorContainerClassName,
@@ -38,7 +50,6 @@ const UserMessageEditor = React.forwardRef<
     externalInputRef
   ) => {
     const internalInputRef = useRef<HTMLTextAreaElement | null>(null);
-    const [userMessage, setUserMessage] = useState<string>('');
     // Track focus state on textarea to apply focus styles to container since
     // :focus-visible doesn't work on divs and :has() is not supported in Firefox.
     const [focused, setFocused] = useState(false);
@@ -59,7 +70,7 @@ const UserMessageEditor = React.forwardRef<
         onSubmit(userMessage);
         setUserMessage('');
       },
-      [onSubmit]
+      [onSubmit, setUserMessage]
     );
 
     useEffect(() => {

--- a/apps/src/aiComponentLibrary/userMessageEditor/UserMessageEditor.tsx
+++ b/apps/src/aiComponentLibrary/userMessageEditor/UserMessageEditor.tsx
@@ -1,14 +1,6 @@
 import Button from '@code-dot-org/component-library/button';
 import classnames from 'classnames';
-import React, {
-  useState,
-  useMemo,
-  useEffect,
-  useRef,
-  Dispatch,
-  SetStateAction,
-  useCallback,
-} from 'react';
+import React, {useState, useMemo, useEffect, useRef} from 'react';
 
 import {commonI18n} from '@cdo/apps/types/locale';
 
@@ -22,7 +14,7 @@ const MAX_MESSAGE_LENGTH = 10000;
 
 export interface UserMessageEditorProps {
   userMessage: string;
-  setUserMessage: Dispatch<SetStateAction<string>>;
+  onChange: (userMessage: string) => void;
   onSubmit: (userMessage: string) => void;
   disabled: boolean;
   showSubmitLabel?: boolean;
@@ -39,7 +31,7 @@ const UserMessageEditor = React.forwardRef<
   (
     {
       userMessage,
-      setUserMessage,
+      onChange,
       onSubmit,
       disabled,
       editorContainerClassName,
@@ -61,17 +53,9 @@ const UserMessageEditor = React.forwardRef<
     const handleKeyPress = (e: React.KeyboardEvent, userMessage: string) => {
       if (e.key === 'Enter' && !e.shiftKey && userMessage.trim() !== '') {
         e.preventDefault(); // Prevent the text box from having just a blank line.
-        handleSubmit(userMessage);
+        onSubmit(userMessage);
       }
     };
-
-    const handleSubmit = useCallback(
-      (userMessage: string) => {
-        onSubmit(userMessage);
-        setUserMessage('');
-      },
-      [onSubmit, setUserMessage]
-    );
 
     useEffect(() => {
       if (!internalInputRef.current) {
@@ -109,7 +93,7 @@ const UserMessageEditor = React.forwardRef<
           placeholder={
             customPlaceholder || commonI18n.aiUserMessagePlaceholder()
           }
-          onChange={e => setUserMessage(e.target.value)}
+          onChange={e => onChange(e.target.value)}
           value={userMessage}
           disabled={disabled}
           onKeyDown={e => handleKeyPress(e, userMessage)}
@@ -126,7 +110,7 @@ const UserMessageEditor = React.forwardRef<
             id="uitest-chat-submit"
             isIconOnly={!showSubmitLabel}
             size="xs"
-            onClick={() => handleSubmit(userMessage)}
+            onClick={() => onSubmit(userMessage)}
             disabled={disabled || !userMessage || userMessageIsEmpty}
             text={showSubmitLabel ? commonI18n.submit() : undefined}
             {...{[showSubmitLabel ? 'iconLeft' : 'icon']: icon}}

--- a/apps/src/aiComponentLibrary/userMessageEditor/UserMessageEditor.tsx
+++ b/apps/src/aiComponentLibrary/userMessageEditor/UserMessageEditor.tsx
@@ -76,6 +76,7 @@ const UserMessageEditor = React.forwardRef<
           focused && moduleStyles.focused,
           editorContainerClassName
         )}
+        onClick={() => internalInputRef.current?.focus()}
       >
         <textarea
           ref={node => {
@@ -110,7 +111,10 @@ const UserMessageEditor = React.forwardRef<
             id="uitest-chat-submit"
             isIconOnly={!showSubmitLabel}
             size="xs"
-            onClick={() => onSubmit(userMessage)}
+            onClick={e => {
+              e.stopPropagation();
+              onSubmit(userMessage);
+            }}
             disabled={disabled || !userMessage || userMessageIsEmpty}
             text={showSubmitLabel ? commonI18n.submit() : undefined}
             {...{[showSubmitLabel ? 'iconLeft' : 'icon']: icon}}

--- a/apps/src/aiComponentLibrary/userMessageEditor/user-message-editor.module.scss
+++ b/apps/src/aiComponentLibrary/userMessageEditor/user-message-editor.module.scss
@@ -9,6 +9,7 @@
   flex-direction: column;
   gap: 0.5rem;
   transition: outline 0.2s ease-in;
+  cursor: text;
 
   @include mixins.border-styles($border-color: var(--borders-neutral-strong));
 

--- a/apps/src/aiDifferentiation/AiDiffChat.tsx
+++ b/apps/src/aiDifferentiation/AiDiffChat.tsx
@@ -290,6 +290,7 @@ const AiDiffChat: React.FC<AiDiffChatProps> = ({
 
       setMessageHistory(prevMessages => [...prevMessages, newUserMessage]);
       getAIResponse(message, false, null);
+      setUserMessage('');
     },
     [threadTitle, getAIResponse, setThreadTitle]
   );
@@ -421,7 +422,7 @@ const AiDiffChat: React.FC<AiDiffChatProps> = ({
       </div>
       <AiDiffChatFooter
         userMessage={userMessage}
-        setUserMessage={setUserMessage}
+        onChange={setUserMessage}
         onSubmit={onMessageSend}
         waiting={isWaitingForResponse}
         userMessageEditorRef={userMessageEditorRef}

--- a/apps/src/aiDifferentiation/AiDiffChat.tsx
+++ b/apps/src/aiDifferentiation/AiDiffChat.tsx
@@ -124,6 +124,7 @@ const AiDiffChat: React.FC<AiDiffChatProps> = ({
   initialThreadPrompt = null,
   setInitialThreadPrompt = () => {},
 }) => {
+  const [userMessage, setUserMessage] = useState<string>('');
   const reportingData = React.useMemo(() => {
     return {
       chatContext: context,
@@ -419,6 +420,8 @@ const AiDiffChat: React.FC<AiDiffChatProps> = ({
         </div>
       </div>
       <AiDiffChatFooter
+        userMessage={userMessage}
+        setUserMessage={setUserMessage}
         onSubmit={onMessageSend}
         waiting={isWaitingForResponse}
         userMessageEditorRef={userMessageEditorRef}

--- a/apps/src/aiDifferentiation/AiDiffChatFooter.tsx
+++ b/apps/src/aiDifferentiation/AiDiffChatFooter.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, {Dispatch, SetStateAction} from 'react';
 
 import UserMessageEditor from '@cdo/apps/aiComponentLibrary/userMessageEditor/UserMessageEditor';
 import {commonI18n} from '@cdo/apps/types/locale';
@@ -6,12 +6,16 @@ import {commonI18n} from '@cdo/apps/types/locale';
 import style from './ai-differentiation.module.scss';
 
 interface AiDiffChatFooterProps {
+  userMessage: string;
+  setUserMessage: Dispatch<SetStateAction<string>>;
   onSubmit: (msg: string) => void;
   waiting: boolean;
   userMessageEditorRef?: React.RefObject<HTMLTextAreaElement>;
 }
 
 const AiDiffChatFooter: React.FC<AiDiffChatFooterProps> = ({
+  userMessage,
+  setUserMessage,
   onSubmit,
   waiting,
   userMessageEditorRef,
@@ -19,6 +23,8 @@ const AiDiffChatFooter: React.FC<AiDiffChatFooterProps> = ({
   return (
     <div className={style.chatFooter}>
       <UserMessageEditor
+        userMessage={userMessage}
+        setUserMessage={setUserMessage}
         ref={userMessageEditorRef}
         onSubmit={onSubmit}
         disabled={waiting}

--- a/apps/src/aiDifferentiation/AiDiffChatFooter.tsx
+++ b/apps/src/aiDifferentiation/AiDiffChatFooter.tsx
@@ -1,4 +1,4 @@
-import React, {Dispatch, SetStateAction} from 'react';
+import React from 'react';
 
 import UserMessageEditor from '@cdo/apps/aiComponentLibrary/userMessageEditor/UserMessageEditor';
 import {commonI18n} from '@cdo/apps/types/locale';
@@ -7,7 +7,7 @@ import style from './ai-differentiation.module.scss';
 
 interface AiDiffChatFooterProps {
   userMessage: string;
-  setUserMessage: Dispatch<SetStateAction<string>>;
+  onChange: (msg: string) => void;
   onSubmit: (msg: string) => void;
   waiting: boolean;
   userMessageEditorRef?: React.RefObject<HTMLTextAreaElement>;
@@ -15,7 +15,7 @@ interface AiDiffChatFooterProps {
 
 const AiDiffChatFooter: React.FC<AiDiffChatFooterProps> = ({
   userMessage,
-  setUserMessage,
+  onChange,
   onSubmit,
   waiting,
   userMessageEditorRef,
@@ -24,7 +24,7 @@ const AiDiffChatFooter: React.FC<AiDiffChatFooterProps> = ({
     <div className={style.chatFooter}>
       <UserMessageEditor
         userMessage={userMessage}
-        setUserMessage={setUserMessage}
+        onChange={onChange}
         ref={userMessageEditorRef}
         onSubmit={onSubmit}
         disabled={waiting}

--- a/apps/src/aichat/views/ChatWorkspace.tsx
+++ b/apps/src/aichat/views/ChatWorkspace.tsx
@@ -306,6 +306,7 @@ const ChatWorkspace: React.FunctionComponent<ChatWorkspaceProps> = ({
             hasStarterAssets={hasStarterAssets}
             buildAssetUrl={buildAssetUrl}
             uploadDisabled={uploadDisabled}
+            currentLevelId={currentLevelId}
           />
         )}
       </div>

--- a/apps/src/aichat/views/UserChatMessageEditor.tsx
+++ b/apps/src/aichat/views/UserChatMessageEditor.tsx
@@ -78,6 +78,8 @@ const UserChatMessageEditor: React.FunctionComponent<
     uploadsPending ||
     chatDisabled;
 
+  const clearUserMessage = () => setUserMessage('');
+
   const handleSubmit = useCallback(
     async (message: string, analyticsProperties?: AnalyticsProperties) => {
       if (!disabled) {
@@ -100,6 +102,7 @@ const UserChatMessageEditor: React.FunctionComponent<
             responseCallback,
           })
         );
+        clearUserMessage();
       }
     },
     [
@@ -116,7 +119,7 @@ const UserChatMessageEditor: React.FunctionComponent<
   );
 
   useEffect(() => {
-    setUserMessage('');
+    clearUserMessage();
   }, [currentLevelId]);
 
   useEffect(() => {
@@ -138,7 +141,7 @@ const UserChatMessageEditor: React.FunctionComponent<
       )}
       <UserMessageEditor
         userMessage={userMessage}
-        setUserMessage={setUserMessage}
+        onChange={setUserMessage}
         onSubmit={handleSubmit}
         disabled={disabled}
         editorContainerClassName={editorContainerClassName}

--- a/apps/src/aichat/views/UserChatMessageEditor.tsx
+++ b/apps/src/aichat/views/UserChatMessageEditor.tsx
@@ -1,4 +1,4 @@
-import React, {useCallback, useEffect, useRef} from 'react';
+import React, {useCallback, useEffect, useRef, useState} from 'react';
 
 import {useAiChatDisabled} from '@cdo/apps/aichat/context/aiChatDisabledContext';
 import UserMessageEditor from '@cdo/apps/aiComponentLibrary/userMessageEditor/UserMessageEditor';
@@ -66,6 +66,8 @@ const UserChatMessageEditor: React.FunctionComponent<
   const userAddedSelectionContext = useAppSelector(
     state => state.aichat.userAddedSelectionContext
   );
+  const currentLevelId = useAppSelector(state => state.progress.currentLevelId);
+
   const dispatch = useAppDispatch();
 
   const inputRef = useRef<HTMLTextAreaElement>(null);
@@ -112,6 +114,10 @@ const UserChatMessageEditor: React.FunctionComponent<
       responseCallback,
     ]
   );
+
+  useEffect(() => {
+    setUserMessage('');
+  }, [currentLevelId]);
 
   useEffect(() => {
     if (!disabled) {

--- a/apps/src/aichat/views/UserChatMessageEditor.tsx
+++ b/apps/src/aichat/views/UserChatMessageEditor.tsx
@@ -50,6 +50,7 @@ const UserChatMessageEditor: React.FunctionComponent<
   buildAssetUrl,
   uploadDisabled,
 }) => {
+  const [userMessage, setUserMessage] = useState<string>('');
   const {chatDisabled} = useAiChatDisabled();
   const isWaitingForChatResponse = useAppSelector(
     state => !!state.aichat.chatMessagePending
@@ -76,12 +77,12 @@ const UserChatMessageEditor: React.FunctionComponent<
     chatDisabled;
 
   const handleSubmit = useCallback(
-    async (userMessage: string, analyticsProperties?: AnalyticsProperties) => {
+    async (message: string, analyticsProperties?: AnalyticsProperties) => {
       if (!disabled) {
         const hiddenContext = await hiddenContextCallback?.();
         dispatch(
           submitChatContents({
-            text: userMessage,
+            text: message,
             modelParameters,
             clientType,
             hiddenContext,
@@ -130,6 +131,8 @@ const UserChatMessageEditor: React.FunctionComponent<
         </div>
       )}
       <UserMessageEditor
+        userMessage={userMessage}
+        setUserMessage={setUserMessage}
         onSubmit={handleSubmit}
         disabled={disabled}
         editorContainerClassName={editorContainerClassName}

--- a/apps/src/aichat/views/UserChatMessageEditor.tsx
+++ b/apps/src/aichat/views/UserChatMessageEditor.tsx
@@ -24,6 +24,7 @@ interface UserChatMessageEditorProps {
   hiddenContextCallback?: () => Promise<string>;
   multimodalAvailable?: boolean;
   responseCallback?: (response: string) => string;
+  currentLevelId?: string | null;
 
   /** UploadButton props */
   uploadDisabled?: UploadButtonProps['isDisabled'];
@@ -45,6 +46,7 @@ const UserChatMessageEditor: React.FunctionComponent<
   hiddenContextCallback,
   multimodalAvailable,
   responseCallback,
+  currentLevelId,
   levelName,
   hasStarterAssets,
   buildAssetUrl,
@@ -66,7 +68,6 @@ const UserChatMessageEditor: React.FunctionComponent<
   const userAddedSelectionContext = useAppSelector(
     state => state.aichat.userAddedSelectionContext
   );
-  const currentLevelId = useAppSelector(state => state.progress.currentLevelId);
 
   const dispatch = useAppDispatch();
 

--- a/apps/test/unit/aichat/UserChatMessageEditorTest.tsx
+++ b/apps/test/unit/aichat/UserChatMessageEditorTest.tsx
@@ -11,7 +11,6 @@ import {
   PendingChatMessage,
 } from '@cdo/apps/aichat/types';
 import UserChatMessageEditor from '@cdo/apps/aichat/views/UserChatMessageEditor';
-import {ProgressState} from '@cdo/apps/code-studio/progressRedux';
 import {commonI18n} from '@cdo/apps/types/locale';
 import {
   AiChatClientTypes,
@@ -22,16 +21,12 @@ const mockDispatch = jest.fn();
 const mockSubmitChatContents = jest.fn();
 let mockState: {
   aichat: Partial<AichatState>;
-  progress: Partial<ProgressState>;
 } = {
   aichat: {
     chatMessagePending: undefined,
     saveInProgress: false,
     stagedFiles: [],
     userAddedSelectionContext: {},
-  },
-  progress: {
-    currentLevelId: 'level1',
   },
 };
 
@@ -55,6 +50,7 @@ describe('UserChatMessageEditor', () => {
       retrievalContexts: [],
     },
     clientType: AiChatClientTypes.AI_TUTOR,
+    currentLevelId: 'level1',
   };
 
   beforeEach(() => {
@@ -66,9 +62,6 @@ describe('UserChatMessageEditor', () => {
         saveInProgress: false,
         stagedFiles: [],
         userAddedSelectionContext: {},
-      },
-      progress: {
-        currentLevelId: 'level1',
       },
     };
   });
@@ -195,9 +188,7 @@ describe('UserChatMessageEditor', () => {
 
     expect(textarea).toHaveValue('Here is a message that should clear');
 
-    mockState.progress.currentLevelId = 'level2';
-
-    rerender(<UserChatMessageEditor {...baseProps} />);
+    rerender(<UserChatMessageEditor {...baseProps} currentLevelId="level2" />);
 
     expect(textarea).toHaveValue('');
   });

--- a/apps/test/unit/aichat/UserChatMessageEditorTest.tsx
+++ b/apps/test/unit/aichat/UserChatMessageEditorTest.tsx
@@ -1,4 +1,4 @@
-import {render, screen} from '@testing-library/react';
+import {act, render, screen} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
 import '@testing-library/jest-dom';
@@ -112,7 +112,9 @@ describe('UserChatMessageEditor', () => {
 
     await user.click(textarea);
     await user.type(textarea, 'Hello bot');
-    await user.keyboard('{Enter}');
+    await act(async () => {
+      await user.keyboard('{Enter}');
+    });
 
     expect(mockSubmitChatContents).toHaveBeenCalledTimes(1);
     // First arg is the payload object
@@ -170,7 +172,9 @@ describe('UserChatMessageEditor', () => {
       commonI18n.aiUserMessagePlaceholder()
     );
     await user.type(textarea, 'Use my image');
-    await user.keyboard('{Enter}');
+    await act(async () => {
+      await user.keyboard('{Enter}');
+    });
 
     expect(mockSubmitChatContents).toHaveBeenCalledTimes(1);
     expect(mockSubmitChatContents.mock.calls[0][0]).toMatchObject({

--- a/apps/test/unit/aichat/UserChatMessageEditorTest.tsx
+++ b/apps/test/unit/aichat/UserChatMessageEditorTest.tsx
@@ -11,6 +11,7 @@ import {
   PendingChatMessage,
 } from '@cdo/apps/aichat/types';
 import UserChatMessageEditor from '@cdo/apps/aichat/views/UserChatMessageEditor';
+import {ProgressState} from '@cdo/apps/code-studio/progressRedux';
 import {commonI18n} from '@cdo/apps/types/locale';
 import {
   AiChatClientTypes,
@@ -19,12 +20,18 @@ import {
 
 const mockDispatch = jest.fn();
 const mockSubmitChatContents = jest.fn();
-let mockState: {aichat: Partial<AichatState>} = {
+let mockState: {
+  aichat: Partial<AichatState>;
+  progress: Partial<ProgressState>;
+} = {
   aichat: {
     chatMessagePending: undefined,
     saveInProgress: false,
     stagedFiles: [],
     userAddedSelectionContext: {},
+  },
+  progress: {
+    currentLevelId: 'level1',
   },
 };
 
@@ -59,6 +66,9 @@ describe('UserChatMessageEditor', () => {
         saveInProgress: false,
         stagedFiles: [],
         userAddedSelectionContext: {},
+      },
+      progress: {
+        currentLevelId: 'level1',
       },
     };
   });
@@ -167,5 +177,24 @@ describe('UserChatMessageEditor', () => {
       text: 'Use my image',
       assets: [file],
     });
+  });
+
+  it('clears the un-submitted user message when the level changes', async () => {
+    const user = userEvent.setup();
+
+    const {rerender} = render(<UserChatMessageEditor {...baseProps} />);
+
+    const textarea = screen.getByPlaceholderText(
+      commonI18n.aiUserMessagePlaceholder()
+    );
+    await user.type(textarea, 'Here is a message that should clear');
+
+    expect(textarea).toHaveValue('Here is a message that should clear');
+
+    mockState.progress.currentLevelId = 'level2';
+
+    rerender(<UserChatMessageEditor {...baseProps} />);
+
+    expect(textarea).toHaveValue('');
   });
 });


### PR DESCRIPTION
This pull request lifts the `userMessage` state from the `UserMessageEditor` to the parent components in order for `UserMessageEditor` to be a true controlled component. Moving the state means it's accessible in the parents as well, making it possible to clear the state when the `currentLevelId` changes, which was the primary goal.

This also includes some super minor ux improvements, so the container div wrapping the textarea input will trigger the input focus when clicked, and the cursor style is updated to `text`.

BEFORE:

https://github.com/user-attachments/assets/71661960-ba70-4c85-9709-a5c76f302b2d


AFTER:

https://github.com/user-attachments/assets/31dd6ca8-33f2-4d17-815d-bfc1968d66e6


## Links
<!--  Links to relevant external resources.
      - spec docs, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- Jira: https://codedotorg.atlassian.net/browse/LABS-1668

## Testing story
<!--  Does your change include appropriate tests?
      - If so, please describe how the tests included in this PR are sufficient.
      - If not, please explain why this change does not need to be tested. -->



## Deployment strategy
<!--  Any special steps required to deploy this, besides merging?
      - Are there database migrations or manual steps?
      - Does this require coordination with other teams or systems? -->



## Follow-up work
<!--  List any clean-up or technical debt that will be addressed in future work.
      - Include Jira links where applicable.
      - Are there any known limitations or improvements planned? -->



## Privacy
<!--  How does this change impact Student & Teacher privacy?
      - Does this collect, use, share, or modify PII, either new or existing? -->



## Security
<!--  How does this change impact our security surface-area?
      - Do API's touched have the right auth?
      - Do infra changes impact our attack surface or encryption?
-->



## Caching
<!--  How does this change impact caching behavior?
      - Are cache keys or invalidation strategies affected?
      - Will this require cache warming or invalidation after deployment? -->



## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
