### PR TITLE
FIX - GitHub Actions Configure Marketing Sites Web Application Firewall

### DIFF
--- a/frontend/apps/marketing/cicd/3-app/deploy.rb
+++ b/frontend/apps/marketing/cicd/3-app/deploy.rb
@@ -28,6 +28,11 @@ options = {
   web_application_firewall: nil
 }
 
+# To simplify the bash logic, GitHub Actions attempts to populate every optional command line argument:
+# https://github.com/code-dot-org/code-dot-org/blob/61057a9080e9cfb67672e027bd0ab91634e84830/.github/workflows/marketing-app-deploy-to-environment.yml#L104-L116
+#
+# OptionsParser interprets an empty value as an invalid argument when the declared type is `String`, so we omit the String
+# type constraint on optional arguments and set the option to `nil` when the supplied argument was an empty string.
 opt_parser = OptionParser.new do |opts|
   opts.banner = "Usage: ./deploy.rb [options]"
 
@@ -86,28 +91,22 @@ opt_parser = OptionParser.new do |opts|
     options[:subdomain_name] = subdomain
   end
 
+  # optional
   opts.on(
     '--production_domain_name DOMAIN',
     "Fully qualified production domain name for this site",
     "(e.g. 'hourofcode.org' for production deployments)",
     "Only used when environment_type is 'production'"
   ) do |domain|
-    # To simplify the bash logic, GitHub Actions always attempts to send this argument, even when the GitHub Environment
-    # `PRODUCTION_DOMAIN_NAME` does not exist or is empty. OptionsParser with String type interprets an empty string
-    # value as an invalid argument, so we remove the String type constraint and set this to `nil` when the supplied
-    # argument was an empty string.
     options[:production_domain_name] = (domain.nil? || domain.empty?) ? nil : domain
   end
 
+  # optional
   opts.on(
     '--production_hosted_zone_id ID',
     "AWS Route 53 Hosted Zone ID for the production domain",
     "Required when production_domain_name is specified"
   ) do |id|
-    # To simplify the bash logic, GitHub Actions always attempts to send this argument, even when the GitHub Environment
-    # Secret `PRODUCTION_HOSTED_ZONE_ID` does not exist or is empty. OptionsParser with String type interprets an empty
-    # string value as an invalid argument, so we remove the String type constraint and set this to `nil` when the
-    # supplied argument was an empty string.
     options[:production_hosted_zone_id] = (id.nil? || id.empty?) ? nil : id
   end
 
@@ -155,13 +154,13 @@ opt_parser = OptionParser.new do |opts|
     options[:cloudformation_role_boundary] = arn
   end
 
+  # optional
   opts.on(
     '--web-application-firewall ARN',
-    String,
     "ARN of the Web Application Firewall Web Access Control List (WAF Web ACL / WAF Protection Pack) to protect this site.",
     "Format: arn:aws:wafv2:<region-id>:<account-id>:global/webacl/<Web ACL Name>/<Web ACL Id>"
-  ) do |arn|
-    options[:web_application_firewall] = arn
+  ) do |waf_web_acl_arn|
+    options[:web_application_firewall] = (waf_web_acl_arn.nil? || waf_web_acl_arn.empty?) ? nil : waf_web_acl_arn
   end
 
   opts.on('-h', '--help', 'Show this help message') do


### PR DESCRIPTION
The GitHub Actions invocation of the `deploy` script was failing for GitHub Environments that don't have the `WEB_APPLICATION_FIREWALL_ARN` Secret configured. 
#69120 

## Testing story
<!--  Does your change include appropriate tests?
      - If so, please describe how the tests included in this PR are sufficient.
      - If not, please explain why this change does not need to be tested. -->



## Deployment strategy
<!--  Any special steps required to deploy this, besides merging?
      - Are there database migrations or manual steps?
      - Does this require coordination with other teams or systems? -->



## Follow-up work
<!--  List any clean-up or technical debt that will be addressed in future work.
      - Include Jira links where applicable.
      - Are there any known limitations or improvements planned? -->



## Privacy
<!--  How does this change impact Student & Teacher privacy?
      - Does this collect, use, share, or modify PII, either new or existing? -->



## Security
<!--  How does this change impact our security surface-area?
      - Do API's touched have the right auth?
      - Do infra changes impact our attack surface or encryption?
-->



## Caching
<!--  How does this change impact caching behavior?
      - Are cache keys or invalidation strategies affected?
      - Will this require cache warming or invalidation after deployment? -->



## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
