### PR TITLE
Revert "skip rake install in drone ui pipeline (#69145)"

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -281,8 +281,6 @@ steps:
     commands:
       - sudo chown -R ci:ci .
       - /entrypoint.sh docker/ci/scripts/prepare_ci_tests.sh
-      - /entrypoint.sh docker/ci/scripts/install_ci_tests.sh
-      - /entrypoint.sh docker/ci/scripts/build_ci_tests.sh
 
   - name: cache-staging-ci-build
     image: plugins/s3-cache
@@ -312,6 +310,6 @@ trigger:
 
 ---
 kind: signature
-hmac: e6bf7a8aca5be4ce8eec1d97ab14781e7d7e25ed8a682b89a87dcf3c8f15ec44
+hmac: 12a10fb1535474843e0004d777e7fb5472679ab0d4f955faece04a24d1b05160
 
 ...

--- a/docker/ci/scripts/build_ci_tests.sh
+++ b/docker/ci/scripts/build_ci_tests.sh
@@ -1,5 +1,0 @@
-# catch any code loader errors before starting any rails environment
-bundle exec rake lint:zeitwerk
-bundle exec rake build
-
-bundle exec rake ci:seed_ui_test

--- a/docker/ci/scripts/install_ci_tests.sh
+++ b/docker/ci/scripts/install_ci_tests.sh
@@ -1,1 +1,0 @@
-bundle exec rake install

--- a/docker/ci/scripts/prepare_ci_tests.sh
+++ b/docker/ci/scripts/prepare_ci_tests.sh
@@ -80,3 +80,10 @@ aiproxy_api_key: 'fake_key'
 echo "Wrote settings and secrets from env vars into locals.yml."
 
 set -x
+
+bundle exec rake install
+# catch any code loader errors before starting any rails environment
+bundle exec rake lint:zeitwerk
+bundle exec rake build
+
+bundle exec rake ci:seed_ui_test

--- a/docker/ci/scripts/ui_tests.sh
+++ b/docker/ci/scripts/ui_tests.sh
@@ -6,6 +6,5 @@
 # `docker/ui-tests-compose.yml`. See instructions in that file.
 
 source docker/ci/scripts/prepare_ci_tests.sh
-source docker/ci/scripts/build_ci_tests.sh
 
 bundle exec rake ci:run_ui_tests

--- a/docker/ci/scripts/unit_tests.sh
+++ b/docker/ci/scripts/unit_tests.sh
@@ -7,13 +7,5 @@
 
 source docker/ci/scripts/prepare_ci_tests.sh
 
-# The install step is currently needed for unit (but not ui) because the database needed
-# by ui tests is prepopulated by the cache-staging-build step.
-# TODO: remove this line once cache-staging-build prepopulates dashboard unit test databases.
-source docker/ci/scripts/install_ci_tests.sh
-
-source docker/ci/scripts/build_ci_tests.sh
-
-
 bundle exec ruby tools/hooks/lint.rb origin/$CI_BASE_BRANCH $CI_HEAD_BRANCH
 bundle exec rake ci:run_tests


### PR DESCRIPTION
This reverts commit c72ca5537c1842c8452c9d101f98c396c35c8c26 because it broke the cache-staging-build pipeline in drone. See https://codedotorg.slack.com/archives/C03CK49G9/p1761781418416009

