### PR TITLE
Add repeat and dcdo flags

### DIFF
--- a/apps/src/experimentActionCableLoad/experiment-actioncable-load.js
+++ b/apps/src/experimentActionCableLoad/experiment-actioncable-load.js
@@ -1,6 +1,7 @@
 import {createConsumer} from '@rails/actioncable';
 import _ from 'lodash';
 
+import DCDO from '@cdo/apps/dcdo';
 import experiments from '@cdo/apps/util/experiments';
 
 export const experimentActionCableLoad = function () {
@@ -16,6 +17,13 @@ const testLoad = function () {
 
   const connectionId = _.random(10000);
 
+  const repeatInterval = DCDO.get('actioncable-repeat-interval', 1000);
+  const isRepeat = DCDO.get('actioncable-repeat', true);
+  const disconnectTimeout = DCDO.get(
+    'actioncable-disconnect-timeout',
+    30 * 1000
+  );
+
   logEvent('ActionCableLoadTestingConnecting', connectionId);
 
   const channel = consumer.subscriptions.create(
@@ -25,12 +33,20 @@ const testLoad = function () {
         logEvent('ActionCableLoadTestingConnected', connectionId);
 
         setTimeout(() => {
-          channel.echo(connectionId);
+          if (channel) {
+            channel.echo(connectionId);
+          }
         }, 1000);
       },
       received(data) {
         if (data?.connectionId === connectionId) {
           logEvent('ActionCableLoadTestingReceived', connectionId);
+        }
+
+        if (!!channel && isRepeat) {
+          setTimeout(() => {
+            channel.echo(connectionId);
+          }, repeatInterval);
         }
       },
       echo(connectionId) {
@@ -45,7 +61,7 @@ const testLoad = function () {
     consumer.disconnect();
 
     logEvent('ActionCableLoadTestingUnsubscribed', connectionId);
-  }, 30 * 1000);
+  }, disconnectTimeout);
 };
 
 const logEvent = (eventName, connectionId) => {

--- a/lib/dynamic_config/dcdo.rb
+++ b/lib/dynamic_config/dcdo.rb
@@ -65,6 +65,9 @@ class DCDOBase < DynamicConfigBase
       'skills-dashboard': DCDO.get('skills-dashboard', false),
       'teacher-homepage-welcome': DCDO.get('teacher-homepage-welcome', false),
       'blockly-keyboard-navigation': DCDO.get('blockly-keyboard-navigation', false),
+      'actioncable-repeat-interval': DCDO.get('actioncable-repeat-interval', 1000),
+      'actioncable-repeat': DCDO.get('actioncable-repeat', true),
+      'actioncable-disconnect-timeout': DCDO.get('actioncable-disconnect-timeout', 30 * 1000),
     }
   end
 end


### PR DESCRIPTION
Adds repeat websocket echos for testing.

Also adds the repeat on/off, repeat timeout and connection duration as DCDO flags to modify on the fly.
