### PR TITLE
Lab2: update DisclaimerButton size to small in resource panel

### DIFF
--- a/apps/src/lab2/views/components/Instructions/ResourcePanel/DisclaimerButton.tsx
+++ b/apps/src/lab2/views/components/Instructions/ResourcePanel/DisclaimerButton.tsx
@@ -51,6 +51,7 @@ const DisclaimerButton: React.FunctionComponent<DisclaimerProps> = ({
       iconName={'shield-exclamation'}
       setIsDialogOpen={setIsDisclaimerOpen}
       ariaLabel={lab2I18n.aiTutorDisclaimerShort()}
+      buttonSize="s"
     />
   );
 };


### PR DESCRIPTION
Updates the DisclaimerButton size to match the other buttons in the resource panel. 

## Links
Jira ticket: [AFL-341](https://codedotorg.atlassian.net/browse/AFL-341)

----

## Before
https://github.com/user-attachments/assets/64c16a54-1348-4db8-b350-649b33d198cf

## After 
https://github.com/user-attachments/assets/1be08900-9c5a-4410-8909-a03ebe62455a


