### PR TITLE
fix(cdn): update PriceClass configuration for environments

### DIFF
--- a/frontend/apps/marketing/cicd/3-app/template.yml.erb
+++ b/frontend/apps/marketing/cicd/3-app/template.yml.erb
@@ -234,7 +234,12 @@ Resources:
         Enabled: true
         Comment: Marketing Sites Application CloudFront Distribution
         HttpVersion: http2
-        PriceClass: PriceClass_100
+        # Use PriceClass_All for production to maximize global performance and availability.
+        # Use PriceClass_100 for non-production to reduce costs, as it limits edge locations.
+        PriceClass: !If
+          - IsProductionEnvironment
+          - PriceClass_All
+          - PriceClass_100
         Aliases:
           - !Sub "${SubdomainName}.${BaseDomainName}"
           - !Sub "preview-${SubdomainName}.${BaseDomainName}"


### PR DESCRIPTION
Adjust PriceClass setting to use PriceClass_All for production environments and PriceClass_100 for non-production to optimize performance and cost.