### PR TITLE
Web Lab 2 preview: include google fonts in style src

### DIFF
--- a/dashboard/app/controllers/codeprojects_preview_controller.rb
+++ b/dashboard/app/controllers/codeprojects_preview_controller.rb
@@ -9,6 +9,7 @@ class CodeprojectsPreviewController < ApplicationController
     # We allow connections to the domain and all subdomains of each allowed hostname.
     allowed_connect_src = ALLOWED_HOSTNAME_SUFFIXES.map {|hostname| "#{prefix}#{hostname} #{prefix}*.#{hostname}"}.join(" ")
     allowed_image_src = ALLOWED_IMAGE_HOSTNAME_SUFFIXES.map {|hostname| "#{prefix}#{hostname} #{prefix}*.#{hostname}"}.join(" ")
+    allowed_font_src = ALLOWED_FONT_HOSTNAMES.map {|hostname| "#{prefix}#{hostname} #{prefix}*.#{hostname}"}.join(" ")
 
     if rack_env?(:development)
       # dashboard_site_host is set to use port 3000 in development, but we want to also allow port 9000.
@@ -47,8 +48,9 @@ class CodeprojectsPreviewController < ApplicationController
     script_src_inline = " 'unsafe-inline'"
 
     # Security Control: Restrict CSS loading sources (overrides default-src for stylesheets)
+    # Allow loading allowed font hostnames in styles.
     # Goal: Allow student styling while preventing external CSS injection
-    style_src_base = "'self' blob:"
+    style_src_base = "'self' blob: #{allowed_font_src}"
 
     # Security Control: Allow inline styles for student HTML projects
     # Goal: Enable students to write inline CSS in their HTML files
@@ -67,8 +69,8 @@ class CodeprojectsPreviewController < ApplicationController
     script_src = script_src_base + script_src_eval + script_src_inline
     style_src = style_src_base + style_src_inline
 
-    # Allow loading google fonts and any self-hosted fonts.
-    font_src = "'self' fonts.googleapis.com fonts.gstatic.com"
+    # Allow loading allowed fonts and any self-hosted fonts.
+    font_src = "'self' #{allowed_font_src}"
 
     policies = [
       "default-src #{default_src}",

--- a/dashboard/app/helpers/allowed_hostname_helper.rb
+++ b/dashboard/app/helpers/allowed_hostname_helper.rb
@@ -142,6 +142,7 @@ module AllowedHostnameHelper
   ].freeze
 
   ALLOWED_FONT_HOSTNAMES = [
+    # These hostnames are used to load google fonts. Public API.
     'fonts.googleapis.com',
     'fonts.gstatic.com'
   ]

--- a/dashboard/app/helpers/allowed_hostname_helper.rb
+++ b/dashboard/app/helpers/allowed_hostname_helper.rb
@@ -140,4 +140,9 @@ module AllowedHostnameHelper
   ALLOWED_IMAGE_HOSTNAME_SUFFIXES = [
     'picsum.photos' # Placeholder images - Public API
   ].freeze
+
+  ALLOWED_FONT_HOSTNAMES = [
+    'fonts.googleapis.com',
+    'fonts.gstatic.com'
+  ]
 end


### PR DESCRIPTION
#69169 locked down the style source in the content security policy for the Web Lab 2 preview. I realized I needed to update it to now include the google font urls so those can be utilized in student's stylesheets.

## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
