### PR TITLE
hoai2025: dance guide

### DIFF
--- a/apps/src/dance/lab2/views/GenerateDance.tsx
+++ b/apps/src/dance/lab2/views/GenerateDance.tsx
@@ -161,7 +161,7 @@ const GenerateDance: React.FunctionComponent<GenerateCodeProps> = ({
   const showNavigation = !levelProperties.isProjectLevel && !multiProject;
 
   return (
-    <Guide id="generate-panel" modal={modal} width="narrow">
+    <Guide id="generate-panel" modal={modal} position="bottom">
       {['none', 'generating'].includes(aiGenerateState) &&
         levelProperties.longInstructions && (
           <MainInstructionsContent
@@ -207,7 +207,7 @@ const GenerateDance: React.FunctionComponent<GenerateCodeProps> = ({
         <>
           <div>Do you want to keep what AI generated?</div>
 
-          <div className={styles.buttonRows}>
+          <div className={styles.buttonRow}>
             <Button
               ariaLabel={'Try prompting again'}
               text={'Try prompting again'}

--- a/apps/src/dance/lab2/views/generate-dance.module.scss
+++ b/apps/src/dance/lab2/views/generate-dance.module.scss
@@ -2,9 +2,9 @@
   flex: 1;
 }
 
-.buttonRows {
+.buttonRow {
   display: flex;
-  justify-content: flex-end;
+  justify-content: space-between;
+  margin-top: 10px;
   gap: 10px;
-  flex-direction: column;
 }

--- a/apps/src/lab2/views/components/guide/Guide.module.scss
+++ b/apps/src/lab2/views/components/guide/Guide.module.scss
@@ -14,7 +14,6 @@
   display: flex;
   flex-direction: column;
   position: absolute;
-  top: 62px;
   right: 32px;
   border-radius: 14px;
   padding: 24px;
@@ -32,5 +31,13 @@
 
   &NarrowWidth {
     width: 20%;
+  }
+
+  &NormalPosition {
+    top: 62px;
+  }
+
+  &BottomPosition {
+    bottom: 20px;
   }
 }

--- a/apps/src/lab2/views/components/guide/Guide.tsx
+++ b/apps/src/lab2/views/components/guide/Guide.tsx
@@ -7,6 +7,7 @@ interface GuideProps {
   id?: string;
   children: React.ReactNode;
   width?: 'normal' | 'narrow';
+  position?: 'normal' | 'bottom';
   modal?: boolean;
 }
 
@@ -17,6 +18,7 @@ const Guide: React.FunctionComponent<GuideProps> = ({
   id,
   children,
   width,
+  position,
   modal,
 }) => {
   return (
@@ -28,7 +30,12 @@ const Guide: React.FunctionComponent<GuideProps> = ({
         id={id}
         className={classNames(
           styles.guide,
-          width === 'narrow' ? styles.guideNarrowWidth : styles.guideNormalWidth
+          width === 'narrow'
+            ? styles.guideNarrowWidth
+            : styles.guideNormalWidth,
+          position === 'bottom'
+            ? styles.guideBottomPosition
+            : styles.NormalPosition
         )}
       >
         {children}

--- a/apps/src/lab2/views/components/guide/Guide.tsx
+++ b/apps/src/lab2/views/components/guide/Guide.tsx
@@ -35,7 +35,7 @@ const Guide: React.FunctionComponent<GuideProps> = ({
             : styles.guideNormalWidth,
           position === 'bottom'
             ? styles.guideBottomPosition
-            : styles.NormalPosition
+            : styles.guideNormalPosition
         )}
       >
         {children}


### PR DESCRIPTION
This proposes making the Guide in the final dance generation level its usual full width, and placed in the bottom-right corner.
