### PR TITLE
AI Tutor: separate chat submission and request completion logging, rename client type 

### DIFF
--- a/apps/src/aichat/redux/thunks/submitChatContents.ts
+++ b/apps/src/aichat/redux/thunks/submitChatContents.ts
@@ -166,19 +166,18 @@ export const submitChatContents = createAsyncThunk(
           responseTime,
         })
       );
+      Lab2Registry.getInstance()
+        .getMetricsReporter()
+        .reportLoadTime('AichatModelResponseTime', responseTime, [
+          {
+            name: 'ModelId',
+            value: modelParameters.selectedModelId,
+          },
+        ]);
     } catch (error) {
       await handleChatCompletionError(error as Error, newUserMessage, dispatch);
       return;
     }
-
-    Lab2Registry.getInstance()
-      .getMetricsReporter()
-      .reportLoadTime('AichatModelResponseTime', Date.now() - startTime, [
-        {
-          name: 'ModelId',
-          value: modelParameters.selectedModelId,
-        },
-      ]);
 
     thunkAPI.dispatch(clearChatMessagePending());
     // Send a report that the user has started the aichat level after successfully sending

--- a/apps/src/aichat/redux/thunks/submitChatContents.ts
+++ b/apps/src/aichat/redux/thunks/submitChatContents.ts
@@ -111,46 +111,59 @@ export const submitChatContents = createAsyncThunk(
     const startTime = Date.now();
 
     let messages: CompletedChatMessage[] = [];
+    const projectFileCount =
+      newUserMessage.userAddedSelectionContext?.length || 0;
+    const projectFileCountHtml =
+      newUserMessage.userAddedSelectionContext?.filter(file =>
+        file.filename.endsWith('.html')
+      ).length || 0;
+    const projectFileCountJs =
+      newUserMessage.userAddedSelectionContext?.filter(file =>
+        file.filename.endsWith('.js')
+      ).length || 0;
+    const projectFileCountCss =
+      newUserMessage.userAddedSelectionContext?.filter(file =>
+        file.filename.endsWith('.css')
+      ).length || 0;
+    const fileCount = newUserMessage.assets?.length || 0;
+    const fileCountPdf =
+      newUserMessage.assets?.filter(asset => asset.filename.endsWith('.pdf'))
+        .length || 0;
+    const fileCountImage = fileCount - fileCountPdf;
+
+    const eventData = {
+      fileCount,
+      fileCountImage,
+      fileCountPdf,
+      projectFileCount,
+      projectFileCountHtml,
+      projectFileCountJs,
+      projectFileCountCss,
+      clientType,
+      ...analyticsProperties,
+    };
+
     try {
       Lab2Registry.getInstance()
         .getMetricsReporter()
         .incrementCounter('Aichat.ChatCompletionRequestInitiated');
+
+      dispatch(
+        sendAnalytics(EVENTS.SUBMIT_AICHAT_REQUEST_INITIATED, eventData)
+      );
+
       messages = await postAichatCompletionMessage(
         newUserMessage,
         chatEventsCurrent.filter(isCompletedChatMessage),
         modelParameters,
         aichatContext
       );
-      const projectFileCount =
-        newUserMessage.userAddedSelectionContext?.length || 0;
-      const projectFileCountHtml =
-        newUserMessage.userAddedSelectionContext?.filter(file =>
-          file.filename.endsWith('.html')
-        ).length || 0;
-      const projectFileCountJs =
-        newUserMessage.userAddedSelectionContext?.filter(file =>
-          file.filename.endsWith('.js')
-        ).length || 0;
-      const projectFileCountCss =
-        newUserMessage.userAddedSelectionContext?.filter(file =>
-          file.filename.endsWith('.css')
-        ).length || 0;
-      const fileCount = newUserMessage.assets?.length || 0;
-      const fileCountPdf =
-        newUserMessage.assets?.filter(asset => asset.filename.endsWith('.pdf'))
-          .length || 0;
-      const fileCountImage = fileCount - fileCountPdf;
+      // In milliseconds
+      const responseTime = Date.now() - startTime;
       dispatch(
         sendAnalytics(EVENTS.SUBMIT_AICHAT_REQUEST_SUCCESS, {
-          fileCount,
-          fileCountImage,
-          fileCountPdf,
-          projectFileCount,
-          projectFileCountHtml,
-          projectFileCountJs,
-          projectFileCountCss,
-          clientType,
-          ...analyticsProperties,
+          ...eventData,
+          responseTime,
         })
       );
     } catch (error) {
@@ -158,9 +171,10 @@ export const submitChatContents = createAsyncThunk(
       return;
     }
 
+    const responseTime = Date.now() - startTime;
     Lab2Registry.getInstance()
       .getMetricsReporter()
-      .reportLoadTime('AichatModelResponseTime', Date.now() - startTime, [
+      .reportLoadTime('AichatModelResponseTime', responseTime, [
         {
           name: 'ModelId',
           value: modelParameters.selectedModelId,

--- a/apps/src/aichat/redux/thunks/submitChatContents.ts
+++ b/apps/src/aichat/redux/thunks/submitChatContents.ts
@@ -171,10 +171,9 @@ export const submitChatContents = createAsyncThunk(
       return;
     }
 
-    const responseTime = Date.now() - startTime;
     Lab2Registry.getInstance()
       .getMetricsReporter()
-      .reportLoadTime('AichatModelResponseTime', responseTime, [
+      .reportLoadTime('AichatModelResponseTime', Date.now() - startTime, [
         {
           name: 'ModelId',
           value: modelParameters.selectedModelId,

--- a/apps/src/metrics/AnalyticsConstants.js
+++ b/apps/src/metrics/AnalyticsConstants.js
@@ -505,7 +505,8 @@ const EVENTS = {
   SAVE_MODEL_CARD_INFO: 'Student saves their model card info',
   PUBLISH_MODEL_CARD_INFO: 'Student publishes their model card info',
   AICHAT_START_OVER: 'Student starts over and resets to default model settings',
-  SUBMIT_AICHAT_REQUEST_SUCCESS: 'User submits aichat request successfully',
+  SUBMIT_AICHAT_REQUEST_INITIATED: 'User submits aichat request',
+  SUBMIT_AICHAT_REQUEST_SUCCESS: 'User aichat request succeeds',
   SUBMIT_AICHAT_REQUEST_UNAUTHORIZED:
     'Unauthorized user attempts to submit aichat request or model customizations and fails',
   SUBMIT_AICHAT_TEACHER_FEEDBACK: 'Teacher submits feedback on aichat message',

--- a/dashboard/test/controllers/aichat_requests_controller_test.rb
+++ b/dashboard/test/controllers/aichat_requests_controller_test.rb
@@ -14,7 +14,7 @@ class AichatRequestsControllerTest < ActionController::TestCase
     @level = create(:level)
     @script = create(:script, :in_single_unit_course)
 
-    @default_model_customizations = {clientType: 0, temperature: 0.5, retrievalContexts: ['test'], systemPrompt: 'test', selectedModelId: 'gpt-4o-mini'}.stringify_keys
+    @default_model_customizations = {clientType: SharedConstants::AI_CHAT_CLIENT_TYPES[:AI_CHAT_LAB], temperature: 0.5, retrievalContexts: ['test'], systemPrompt: 'test', selectedModelId: 'gpt-4o-mini'}.stringify_keys
     @default_aichat_context = {
       currentLevelId: @level.id,
       scriptId: @script.id,

--- a/lib/cdo/shared_constants.rb
+++ b/lib/cdo/shared_constants.rb
@@ -833,9 +833,9 @@ module SharedConstants
   }
 
   AI_CHAT_CLIENT_TYPES = {
-    AI_CHAT_LAB: 0,
-    AI_TUTOR: 1,
-    FLOW_LAB: 2,
+    AI_CHAT_LAB: "ai-chat-lab",
+    AI_TUTOR: "ai-tutor",
+    FLOW_LAB: "flow-lab",
   }
 
   AI_CHAT_READ_TIMEOUTS = {


### PR DESCRIPTION
https://docs.google.com/document/d/13kJMVYbmKVW83Ovuz_PrAJX1KgXhKV1_fA8Anc_-koo/edit?tab=t.0
https://codedotorg.atlassian.net/browse/AFL-170

We now send one event to Statsig when the user submits a chat message and another when we get the response back from AI so that we can include the response time. I also updated the clientType for aichat to be more human readable per Product request. 
 
<img width="393" height="266" alt="Screenshot 2025-10-31 at 9 32 58 AM" src="https://github.com/user-attachments/assets/8b20d523-604d-4e57-8881-4b719141be2a" />
