### PR TITLE
Set statsig_stable_id cookie at .code.org

### DIFF
--- a/frontend/apps/marketing/src/providers/statsig/__tests__/client.test.tsx
+++ b/frontend/apps/marketing/src/providers/statsig/__tests__/client.test.tsx
@@ -109,7 +109,12 @@ describe('getClient', () => {
     expect(setCookie).toHaveBeenCalledWith(
       'statsig_stable_id',
       'new-stable-id',
-      {path: '/'},
+      {
+        path: '/',
+        domain: '.code.org',
+        sameSite: 'lax',
+        secure: true,
+      },
     );
   });
 

--- a/frontend/apps/marketing/src/providers/statsig/client.ts
+++ b/frontend/apps/marketing/src/providers/statsig/client.ts
@@ -27,6 +27,9 @@ function getStatsigStableId() {
     stableId = uuidv4();
     setCookie('statsig_stable_id', stableId, {
       path: '/',
+      domain: '.code.org',
+      sameSite: 'lax',
+      secure: true,
     });
   }
 


### PR DESCRIPTION
Currently the marketing site sets the `statsig_stable_id` under the more restrictive `code.org` domain. This PR expands that to set it under the broader `.code.org` domain, so it's useable from the marketing site and dashboard.

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->



## Links
<!--  Links to relevant external resources.
      - spec docs, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- Jira: 

## Testing story
<!--  Does your change include appropriate tests?
      - If so, please describe how the tests included in this PR are sufficient.
      - If not, please explain why this change does not need to be tested. -->



## Deployment strategy
<!--  Any special steps required to deploy this, besides merging?
      - Are there database migrations or manual steps?
      - Does this require coordination with other teams or systems? -->



## Follow-up work
<!--  List any clean-up or technical debt that will be addressed in future work.
      - Include Jira links where applicable.
      - Are there any known limitations or improvements planned? -->



## Privacy
<!--  How does this change impact Student & Teacher privacy?
      - Does this collect, use, share, or modify PII, either new or existing? -->



## Security
<!--  How does this change impact our security surface-area?
      - Do API's touched have the right auth?
      - Do infra changes impact our attack surface or encryption?
-->



## Caching
<!--  How does this change impact caching behavior?
      - Are cache keys or invalidation strategies affected?
      - Will this require cache warming or invalidation after deployment? -->



## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
