### PR TITLE
Set statsig_stable_id cookie only for codeorg brand

### DIFF
--- a/frontend/apps/marketing/src/app/[brand]/[locale]/layout.tsx
+++ b/frontend/apps/marketing/src/app/[brand]/[locale]/layout.tsx
@@ -61,6 +61,7 @@ export default async function Layout({
                 stage={getStage()}
                 clientKey={statsigClientKey}
                 values={statsigBootstrapValues}
+                brand={brand}
               >
                 {getHeader(brand)}
                 {children}

--- a/frontend/apps/marketing/src/providers/statsig/StatsigProvider.tsx
+++ b/frontend/apps/marketing/src/providers/statsig/StatsigProvider.tsx
@@ -11,6 +11,7 @@ interface StatsigProviderProps {
   clientKey?: string;
   children: ReactNode;
   values: string;
+  brand: string;
 }
 
 export default function StatsigProvider({
@@ -18,6 +19,7 @@ export default function StatsigProvider({
   clientKey,
   values,
   children,
+  brand,
 }: StatsigProviderProps) {
   if (!clientKey) {
     console.debug(
@@ -26,7 +28,7 @@ export default function StatsigProvider({
     return children;
   }
 
-  const client = getClient(clientKey, stage, values);
+  const client = getClient(clientKey, stage, values, brand);
 
   return <BaseStatsigProvider client={client}>{children}</BaseStatsigProvider>;
 }

--- a/frontend/apps/marketing/src/providers/statsig/__tests__/client.test.tsx
+++ b/frontend/apps/marketing/src/providers/statsig/__tests__/client.test.tsx
@@ -30,12 +30,14 @@ const MockStatsigComponent = ({
   clientKey,
   stage,
   values,
+  brand,
 }: {
   clientKey: string;
   stage: Stage;
   values: string;
+  brand: string;
 }) => {
-  getClient(clientKey, stage, values);
+  getClient(clientKey, stage, values, brand);
 
   return <></>;
 };
@@ -50,6 +52,7 @@ describe('getClient', () => {
     const clientKey = 'test-client-key';
     const stage = 'production';
     const values = 'test-values';
+    const brand = 'codeorg';
 
     render(
       <OneTrustContext.Provider
@@ -59,6 +62,7 @@ describe('getClient', () => {
           clientKey={clientKey}
           stage={stage}
           values={values}
+          brand={brand}
         />
         <div>Test Child</div>
       </OneTrustContext.Provider>,
@@ -82,6 +86,7 @@ describe('getClient', () => {
     const clientKey = 'test-client-key';
     const stage = 'production';
     const values = 'test-values';
+    const brand = 'codeorg';
 
     render(
       <OneTrustContext.Provider
@@ -91,6 +96,7 @@ describe('getClient', () => {
           clientKey={clientKey}
           stage={stage}
           values={values}
+          brand={brand}
         />
         <div>Test Child</div>
       </OneTrustContext.Provider>,
@@ -123,6 +129,7 @@ describe('getClient', () => {
     const clientKey = 'test-client-key';
     const stage = 'production';
     const values = 'test-values';
+    const brand = 'codeorg';
 
     render(
       <OneTrustContext.Provider
@@ -132,6 +139,7 @@ describe('getClient', () => {
           clientKey={clientKey}
           stage={stage}
           values={values}
+          brand={brand}
         />
         <div>Test Child</div>
       </OneTrustContext.Provider>,
@@ -154,6 +162,7 @@ describe('getClient', () => {
     const clientKey = 'test-client-key';
     const stage = 'production';
     const values = 'test-values';
+    const brand = 'codeorg';
 
     render(
       <OneTrustContext.Provider
@@ -165,6 +174,7 @@ describe('getClient', () => {
           clientKey={clientKey}
           stage={stage}
           values={values}
+          brand={brand}
         />
         <div>Test Child</div>
       </OneTrustContext.Provider>,
@@ -172,7 +182,7 @@ describe('getClient', () => {
 
     expect(useClientBootstrapInit).toHaveBeenCalledWith(
       clientKey,
-      {userID: 'marketing-user', customIDs: {stableID: undefined}},
+      {userID: 'marketing-user'},
       values,
       {
         environment: {tier: stage},
@@ -186,6 +196,7 @@ describe('getClient', () => {
     (getCookie as jest.Mock).mockReturnValue('existing-stable-id');
     const clientKey = 'test-client-key';
     const values = 'test-values';
+    const brand = 'codeorg';
 
     // Production: plugins should be set
     render(
@@ -196,6 +207,7 @@ describe('getClient', () => {
           clientKey={clientKey}
           stage={'production'}
           values={values}
+          brand={brand}
         />
       </OneTrustContext.Provider>,
     );
@@ -218,6 +230,7 @@ describe('getClient', () => {
           clientKey={clientKey}
           stage={'development'}
           values={values}
+          brand={brand}
         />
       </OneTrustContext.Provider>,
     );

--- a/frontend/apps/marketing/src/providers/statsig/__tests__/client.test.tsx
+++ b/frontend/apps/marketing/src/providers/statsig/__tests__/client.test.tsx
@@ -192,6 +192,38 @@ describe('getClient', () => {
     expect(setCookie).not.toHaveBeenCalled();
   });
 
+  it('should not set stableId for non-code.org brands', () => {
+    const clientKey = 'test-client-key';
+    const stage = 'production';
+    const values = 'test-values';
+    const brand = 'otherbrand';
+
+    render(
+      <OneTrustContext.Provider
+        value={{allowedCookies: new Set([OneTrustCookieGroup.Performance])}}
+      >
+        <MockStatsigComponent
+          clientKey={clientKey}
+          stage={stage}
+          values={values}
+          brand={brand}
+        />
+        <div>Test Child</div>
+      </OneTrustContext.Provider>,
+    );
+
+    expect(useClientBootstrapInit).toHaveBeenCalledWith(
+      clientKey,
+      {userID: 'marketing-user'},
+      values,
+      {
+        environment: {tier: stage},
+        plugins: plugins,
+      },
+    );
+    expect(setCookie).not.toHaveBeenCalled();
+  });
+
   it('should only set plugins in production', () => {
     (getCookie as jest.Mock).mockReturnValue('existing-stable-id');
     const clientKey = 'test-client-key';

--- a/frontend/apps/marketing/src/providers/statsig/client.ts
+++ b/frontend/apps/marketing/src/providers/statsig/client.ts
@@ -1,6 +1,7 @@
 import {
   useStatsigClient,
   useClientBootstrapInit,
+  StatsigUser,
 } from '@statsig/react-bindings';
 import {setCookie} from 'cookies-next';
 import {getCookie} from 'cookies-next/client';
@@ -12,6 +13,8 @@ import OneTrustContext, {
   OneTrustCookieGroup,
 } from '@/providers/onetrust/context/OneTrustContext';
 import plugins from '@/providers/statsig/plugins';
+
+const CODEORG_BRAND = 'codeorg';
 
 function getStatsigStableId() {
   const onetrustContext = useContext(OneTrustContext);
@@ -36,16 +39,23 @@ function getStatsigStableId() {
   return stableId;
 }
 
-export function getClient(clientKey: string, stage: Stage, values: string) {
-  return useClientBootstrapInit(
-    clientKey,
-    {userID: 'marketing-user', customIDs: {stableID: getStatsigStableId()}},
-    values,
-    {
-      environment: {tier: stage},
-      plugins: stage === 'production' ? plugins : undefined,
-    },
-  );
+export function getClient(
+  clientKey: string,
+  stage: Stage,
+  values: string,
+  brand: string,
+) {
+  // Add stableID only for code.org brand so we can track users across
+  // studio.code.org and code.org, otherwise fallback to Statsig SDK's default behavior
+  const stableId = brand === CODEORG_BRAND ? getStatsigStableId() : undefined;
+  const payload: StatsigUser = stableId
+    ? {userID: 'marketing-user', customIDs: {stableID: stableId}}
+    : {userID: 'marketing-user'};
+
+  return useClientBootstrapInit(clientKey, payload, values, {
+    environment: {tier: stage},
+    plugins: stage === 'production' ? plugins : undefined,
+  });
 }
 
 // Log events in Statsig

--- a/frontend/apps/marketing/src/providers/statsig/client.ts
+++ b/frontend/apps/marketing/src/providers/statsig/client.ts
@@ -48,11 +48,11 @@ export function getClient(
   // Add stableID only for code.org brand so we can track users across
   // studio.code.org and code.org, otherwise fallback to Statsig SDK's default behavior
   const stableId = brand === CODEORG_BRAND ? getStatsigStableId() : undefined;
-  const payload: StatsigUser = stableId
+  const user: StatsigUser = stableId
     ? {userID: 'marketing-user', customIDs: {stableID: stableId}}
     : {userID: 'marketing-user'};
 
-  return useClientBootstrapInit(clientKey, payload, values, {
+  return useClientBootstrapInit(clientKey, user, values, {
     environment: {tier: stage},
     plugins: stage === 'production' ? plugins : undefined,
   });


### PR DESCRIPTION
This PR adds functionality to only set a statsig_stable_id as a cookie on the marketing site for the codeorg brand. Other brands will use the Statsig SDK's [default behavior](https://docs.statsig.com/client/javascript-sdk#how-stable-id-works).

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->



## Links
<!--  Links to relevant external resources.
      - spec docs, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- Jira: 

## Testing story
<!--  Does your change include appropriate tests?
      - If so, please describe how the tests included in this PR are sufficient.
      - If not, please explain why this change does not need to be tested. -->



## Deployment strategy
<!--  Any special steps required to deploy this, besides merging?
      - Are there database migrations or manual steps?
      - Does this require coordination with other teams or systems? -->



## Follow-up work
<!--  List any clean-up or technical debt that will be addressed in future work.
      - Include Jira links where applicable.
      - Are there any known limitations or improvements planned? -->



## Privacy
<!--  How does this change impact Student & Teacher privacy?
      - Does this collect, use, share, or modify PII, either new or existing? -->



## Security
<!--  How does this change impact our security surface-area?
      - Do API's touched have the right auth?
      - Do infra changes impact our attack surface or encryption?
-->



## Caching
<!--  How does this change impact caching behavior?
      - Are cache keys or invalidation strategies affected?
      - Will this require cache warming or invalidation after deployment? -->



## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
