### PR TITLE
Upgrade ffi gem in Chef cookbooks

### DIFF
--- a/cookbooks/Gemfile
+++ b/cookbooks/Gemfile
@@ -7,6 +7,7 @@ ruby '>= 3.0', '< 3.5'
 gem 'berkshelf'
 gem 'chef', '17.6.18'
 gem 'chefspec'
+gem 'ffi', '~> 1.17'
 gem 'kitchen-inspec'
 
 gem 'test-kitchen'

--- a/cookbooks/Gemfile.lock
+++ b/cookbooks/Gemfile.lock
@@ -375,7 +375,7 @@ GEM
       faraday (~> 1.0)
     fauxhai-ng (9.3.0)
       net-ssh
-    ffi (1.16.3)
+    ffi (1.17.2)
     ffi-libarchive (1.1.14)
       ffi (~> 1.0)
     ffi-yajl (2.6.0)
@@ -449,7 +449,7 @@ GEM
     jwt (2.5.0)
     kitchen-docker (2.13.0)
       test-kitchen (>= 1.0.0)
-    kitchen-dokken (2.17.3)
+    kitchen-dokken (2.20.7)
       docker-api (>= 1.33, < 3)
       lockfile (~> 2.1)
       test-kitchen (>= 1.15, < 4)
@@ -490,8 +490,7 @@ GEM
       mixlib-shellout
       mixlib-versioning
       thor
-    mixlib-log (3.1.1)
-      ffi (< 1.17.0)
+    mixlib-log (3.0.9)
     mixlib-shellout (3.2.8)
       chef-utils
     mixlib-versioning (1.2.12)
@@ -612,7 +611,7 @@ GEM
     strings-ansi (0.2.0)
     strscan (3.1.0)
     syslog-logger (1.6.8)
-    test-kitchen (3.4.0)
+    test-kitchen (3.5.1)
       bcrypt_pbkdf (~> 1.0)
       chef-utils (>= 16.4.35)
       ed25519 (~> 1.2)
@@ -790,6 +789,7 @@ DEPENDENCIES
   berkshelf
   chef (= 17.6.18)
   chefspec
+  ffi (~> 1.17)
   json (>= 2.3.0)
   kitchen-docker
   kitchen-dokken


### PR DESCRIPTION
Upgrade the native Ruby gem `ffi` in the `/cookbooks` subproject, because versions before 1.17 often have compilation issues on macOS development environments.

## Testing story

`bundle exec rake adhoc:start RAILS_ENV=adhoc STACK_NAME=adhoc-upgrade-ffi-gem`



## Deployment strategy
<!--  Any special steps required to deploy this, besides merging?
      - Are there database migrations or manual steps?
      - Does this require coordination with other teams or systems? -->



## Follow-up work
<!--  List any clean-up or technical debt that will be addressed in future work.
      - Include Jira links where applicable.
      - Are there any known limitations or improvements planned? -->



## Privacy
<!--  How does this change impact Student & Teacher privacy?
      - Does this collect, use, share, or modify PII, either new or existing? -->



## Security
<!--  How does this change impact our security surface-area?
      - Do API's touched have the right auth?
      - Do infra changes impact our attack surface or encryption?
-->



## Caching
<!--  How does this change impact caching behavior?
      - Are cache keys or invalidation strategies affected?
      - Will this require cache warming or invalidation after deployment? -->



## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
