### PR TITLE
AI Tutor - fix undefined method: raise_or_notify_type_error

### DIFF
--- a/dashboard/app/helpers/aichat_ruby_types.rb
+++ b/dashboard/app/helpers/aichat_ruby_types.rb
@@ -52,7 +52,7 @@ module AichatRubyTypes
       to_s
     end
 
-    # Helper to determint if a value is this type. Needs to be implemented in derived classes.
+    # Helper to determine if a value is this type. Needs to be implemented in derived classes.
     def value_is_type?(value)
       AichatRubyTypes.raise_or_notify_type_error("not implmemented")
     end

--- a/dashboard/app/helpers/aichat_ruby_types.rb
+++ b/dashboard/app/helpers/aichat_ruby_types.rb
@@ -54,12 +54,12 @@ module AichatRubyTypes
 
     # Helper to determint if a value is this type. Needs to be implemented in derived classes.
     def value_is_type?(value)
-      raise_or_notify_type_error("not implmemented")
+      AichatRubyTypes.raise_or_notify_type_error("not implmemented")
     end
 
     # Assert whether a value is this type.  Relies on `value_is_type?` helper.
     def assert_value_is_type(value, key = nil)
-      raise_or_notify_type_error("#{AichatRubyTypes.stringify_type(value)} does not match type: #{type_string}#{key.nil? ? "" : " for key=#{key}"}") unless value_is_type?(value)
+      AichatRubyTypes.raise_or_notify_type_error("#{AichatRubyTypes.stringify_type(value)} does not match type: #{type_string}#{key.nil? ? "" : " for key=#{key}"}") unless value_is_type?(value)
     end
   end
 


### PR DESCRIPTION
This is a bug fix for undefined method `raise_or_notify_type_error` due to `raise_or_notify_type_error` being created on the module, but used in a class defined within the module.  

This bug was introduced as part of #68232 which was to `update RubyTypes to not raise exceptions in production` and meant that certain exceptions were in fact still raising in production, while somewhat obscuring the details.

## Links
This issue was surfaced in this [slack thread](https://codedotorg.slack.com/archives/C08S29NDZ5E/p1761920541138939?thread_ts=1761754637.365489&cid=C08S29NDZ5E).
