### PR TITLE
AI Tutor: change clientType from number to string

### DIFF
--- a/apps/src/aichat/redux/thunks/submitChatContents.ts
+++ b/apps/src/aichat/redux/thunks/submitChatContents.ts
@@ -111,61 +111,73 @@ export const submitChatContents = createAsyncThunk(
     const startTime = Date.now();
 
     let messages: CompletedChatMessage[] = [];
+    const projectFileCount =
+      newUserMessage.userAddedSelectionContext?.length || 0;
+    const projectFileCountHtml =
+      newUserMessage.userAddedSelectionContext?.filter(file =>
+        file.filename.endsWith('.html')
+      ).length || 0;
+    const projectFileCountJs =
+      newUserMessage.userAddedSelectionContext?.filter(file =>
+        file.filename.endsWith('.js')
+      ).length || 0;
+    const projectFileCountCss =
+      newUserMessage.userAddedSelectionContext?.filter(file =>
+        file.filename.endsWith('.css')
+      ).length || 0;
+    const fileCount = newUserMessage.assets?.length || 0;
+    const fileCountPdf =
+      newUserMessage.assets?.filter(asset => asset.filename.endsWith('.pdf'))
+        .length || 0;
+    const fileCountImage = fileCount - fileCountPdf;
+
+    const eventData = {
+      fileCount,
+      fileCountImage,
+      fileCountPdf,
+      projectFileCount,
+      projectFileCountHtml,
+      projectFileCountJs,
+      projectFileCountCss,
+      clientType,
+      ...analyticsProperties,
+    };
+
     try {
       Lab2Registry.getInstance()
         .getMetricsReporter()
         .incrementCounter('Aichat.ChatCompletionRequestInitiated');
+
+      dispatch(
+        sendAnalytics(EVENTS.SUBMIT_AICHAT_REQUEST_INITIATED, eventData)
+      );
+
       messages = await postAichatCompletionMessage(
         newUserMessage,
         chatEventsCurrent.filter(isCompletedChatMessage),
         modelParameters,
         aichatContext
       );
-      const projectFileCount =
-        newUserMessage.userAddedSelectionContext?.length || 0;
-      const projectFileCountHtml =
-        newUserMessage.userAddedSelectionContext?.filter(file =>
-          file.filename.endsWith('.html')
-        ).length || 0;
-      const projectFileCountJs =
-        newUserMessage.userAddedSelectionContext?.filter(file =>
-          file.filename.endsWith('.js')
-        ).length || 0;
-      const projectFileCountCss =
-        newUserMessage.userAddedSelectionContext?.filter(file =>
-          file.filename.endsWith('.css')
-        ).length || 0;
-      const fileCount = newUserMessage.assets?.length || 0;
-      const fileCountPdf =
-        newUserMessage.assets?.filter(asset => asset.filename.endsWith('.pdf'))
-          .length || 0;
-      const fileCountImage = fileCount - fileCountPdf;
+      // In milliseconds
+      const responseTime = Date.now() - startTime;
       dispatch(
         sendAnalytics(EVENTS.SUBMIT_AICHAT_REQUEST_SUCCESS, {
-          fileCount,
-          fileCountImage,
-          fileCountPdf,
-          projectFileCount,
-          projectFileCountHtml,
-          projectFileCountJs,
-          projectFileCountCss,
-          clientType,
-          ...analyticsProperties,
+          ...eventData,
+          responseTime,
         })
       );
+      Lab2Registry.getInstance()
+        .getMetricsReporter()
+        .reportLoadTime('AichatModelResponseTime', responseTime, [
+          {
+            name: 'ModelId',
+            value: modelParameters.selectedModelId,
+          },
+        ]);
     } catch (error) {
       await handleChatCompletionError(error as Error, newUserMessage, dispatch);
       return;
     }
-
-    Lab2Registry.getInstance()
-      .getMetricsReporter()
-      .reportLoadTime('AichatModelResponseTime', Date.now() - startTime, [
-        {
-          name: 'ModelId',
-          value: modelParameters.selectedModelId,
-        },
-      ]);
 
     thunkAPI.dispatch(clearChatMessagePending());
     // Send a report that the user has started the aichat level after successfully sending

--- a/apps/src/metrics/AnalyticsConstants.js
+++ b/apps/src/metrics/AnalyticsConstants.js
@@ -505,7 +505,8 @@ const EVENTS = {
   SAVE_MODEL_CARD_INFO: 'Student saves their model card info',
   PUBLISH_MODEL_CARD_INFO: 'Student publishes their model card info',
   AICHAT_START_OVER: 'Student starts over and resets to default model settings',
-  SUBMIT_AICHAT_REQUEST_SUCCESS: 'User submits aichat request successfully',
+  SUBMIT_AICHAT_REQUEST_INITIATED: 'User submits aichat request',
+  SUBMIT_AICHAT_REQUEST_SUCCESS: 'User aichat request succeeds',
   SUBMIT_AICHAT_REQUEST_UNAUTHORIZED:
     'Unauthorized user attempts to submit aichat request or model customizations and fails',
   SUBMIT_AICHAT_TEACHER_FEEDBACK: 'Teacher submits feedback on aichat message',

--- a/dashboard/app/helpers/aichat_ai_client_types.rb
+++ b/dashboard/app/helpers/aichat_ai_client_types.rb
@@ -239,7 +239,7 @@ module AichatAiClientTypes
   #   temperature: number;
 
   #   // Client type.
-  #   clientType: number
+  #   clientType: string
 
   #   // Configure the response. Optional, defaults to TextResponse.
   #   response?: TextResponseConfig | JsonResponseConfig
@@ -250,7 +250,7 @@ module AichatAiClientTypes
     :model, string,
     :systemInstructions, Optional(MessagePart[]),
     :temperature, number,
-    :clientType, number,
+    :clientType, string,
     :response,  Optional(TextResponseConfig | JsonResponseConfig)
   )
 

--- a/dashboard/test/controllers/aichat_requests_controller_test.rb
+++ b/dashboard/test/controllers/aichat_requests_controller_test.rb
@@ -14,7 +14,7 @@ class AichatRequestsControllerTest < ActionController::TestCase
     @level = create(:level)
     @script = create(:script, :in_single_unit_course)
 
-    @default_model_customizations = {clientType: 0, temperature: 0.5, retrievalContexts: ['test'], systemPrompt: 'test', selectedModelId: 'gpt-4o-mini'}.stringify_keys
+    @default_model_customizations = {clientType: SharedConstants::AI_CHAT_CLIENT_TYPES[:AI_CHAT_LAB], temperature: 0.5, retrievalContexts: ['test'], systemPrompt: 'test', selectedModelId: 'gpt-4o-mini'}.stringify_keys
     @default_aichat_context = {
       currentLevelId: @level.id,
       scriptId: @script.id,

--- a/dashboard/test/helpers/aichat_ai_client_test.rb
+++ b/dashboard/test/helpers/aichat_ai_client_test.rb
@@ -28,7 +28,7 @@ class AichatAiClientTest < ActionView::TestCase
     @encrypted_channel_id = 12345
     @user_id = 'test-user'
     @project_id = 'Aichat project'
-    @client_type = 0
+    @client_type = SharedConstants::AI_CHAT_CLIENT_TYPES[:AI_CHAT_LAB]
     @response_text = "some response text"
     @specific_error_message = 'some specific error message'
     @ruby_types_error = 'does not match type'

--- a/lib/cdo/shared_constants.rb
+++ b/lib/cdo/shared_constants.rb
@@ -833,9 +833,9 @@ module SharedConstants
   }
 
   AI_CHAT_CLIENT_TYPES = {
-    AI_CHAT_LAB: 0,
-    AI_TUTOR: 1,
-    FLOW_LAB: 2,
+    AI_CHAT_LAB: "ai-chat-lab",
+    AI_TUTOR: "ai-tutor",
+    FLOW_LAB: "flow-lab",
   }
 
   AI_CHAT_READ_TIMEOUTS = {


### PR DESCRIPTION
Reverts https://github.com/code-dot-org/code-dot-org/pull/69242, including a fix for the failure. 

Locally, I went to the same [level that the UI test failed on](https://github.com/code-dot-org/code-dot-org/blob/0651766d315f79163e83efc38b312c217ddcb7fb/dashboard/test/ui/features/star_labs/aichat/chat_multimodal.feature#L9), and was able to successfully get an AI response back in AI Chat Lab. 
<img width="1561" height="1011" alt="Screenshot 2025-11-03 at 11 10 23 AM" src="https://github.com/user-attachments/assets/b7a9bd55-d555-43eb-aa2a-e0dcb3b90c9f" />

