### PR TITLE
AI Tutor: add human readable level, script and course names

### DIFF
--- a/apps/src/aichat/redux/thunks/sendAnalytics.ts
+++ b/apps/src/aichat/redux/thunks/sendAnalytics.ts
@@ -13,6 +13,7 @@ export const sendAnalytics =
     const state = getState();
     const aichatState = state.aichat;
     const labState = state.lab;
+    const progressState = state.progress;
     const clientType = aichatState.clientType;
     const userHasAichatAccess = aichatState.userHasAichatAccess;
 
@@ -28,7 +29,10 @@ export const sendAnalytics =
         aiTutorMode: labState.levelProperties?.aiTutorMode,
         appType: labState.levelProperties?.appName,
         levelId: labState.levelProperties?.id,
+        levelName: labState.levelProperties?.name,
         scriptId: labState.scriptId,
+        scriptName: progressState.scriptName,
+        courseName: progressState.courseName,
         channel: labState.channel?.id,
         levelPath: window.location.pathname,
       };


### PR DESCRIPTION
https://codedotorg.atlassian.net/browse/AFL-170

Per Product request, adding human readable level, script and course names to our AI Tutor analytics logging since they are easier to reason about and group by in Statsig. 

<img width="588" height="128" alt="Screenshot 2025-11-03 at 11 36 59 AM" src="https://github.com/user-attachments/assets/27264773-f56c-440b-a738-9f4f6b9cc21f" />
