### PR TITLE
fix callout warnings during rake seed

### DIFF
--- a/dashboard/app/models/callout.rb
+++ b/dashboard/app/models/callout.rb
@@ -54,7 +54,8 @@ class Callout < ApplicationRecord
     script_level = ScriptLevel.joins(levels: :game).joins(:script).where(script_level_search_conditions)
 
     unless script_level && script_level.count > 0
-      raise "Error finding script level with search conditions: #{script_level_search_conditions}"
+      puts "Error finding script level with search conditions: #{script_level_search_conditions}"
+      return nil
     end
 
     begin

--- a/dashboard/app/models/callout.rb
+++ b/dashboard/app/models/callout.rb
@@ -54,8 +54,7 @@ class Callout < ApplicationRecord
     script_level = ScriptLevel.joins(levels: :game).joins(:script).where(script_level_search_conditions)
 
     unless script_level && script_level.count > 0
-      puts "Error finding script level with search conditions: #{script_level_search_conditions}"
-      return nil
+      raise "Error finding script level with search conditions: #{script_level_search_conditions}"
     end
 
     begin

--- a/dashboard/config/callouts.tsv
+++ b/dashboard/config/callouts.tsv
@@ -53,16 +53,3 @@ Gumball_add_score	gumball	gumball_sound_and_points	Studio	playlab_add_score	[blo
 Gumball_add_score	gumball	gumball_sound_and_points	Studio	playlab_add_score	[data-id='whenActorTouches']	{"position": {"my": "top left", "at": "bottom left", "adjust": {"x": 22, "y":4}} }
 Gumball_add_blocks	gumball	gumball_warn_food_fight	Studio	playlab_add_blocks	[block-id='7']	{"position": {"my": "top left", "at": "bottom left", "adjust": {"x": 22, "y":4}} }
 Gumball_add_blocks	gumball	gumball_warn_food_fight	Studio	playlab_add_blocks	[data-id='whenRun']	{"position": {"my": "top left", "at": "bottom left", "adjust": {"x": 22, "y":4}} }
-Iceage_drag_say	iceage	iceage_hello1	Studio	playlab_drag_say	[block-id='2']	{"position": {"my": "top left", "at": "bottom left", "adjust": {"x": 22, "y":4}} }
-Iceage_drag_say	iceage	iceage_hello1	Studio	playlab_drag_say	[data-id='whenRun']	{"position": {"my": "top left", "at": "bottom left", "adjust": {"x": 22, "y":4}} }
-Icage_use_twice	iceage	iceage_hello2	Studio	playlab_use_twice	[block-id='1']	{"position": {"my": "top left", "at": "bottom left", "adjust": {"x": 62, "y":0}} }
-Icage_use_twice	iceage	iceage_hello2	Studio	playlab_use_twice	[data-id='actorSay']	{"position": {"my": "top left", "at": "bottom left", "adjust": {"x": 62, "y":0}} }
-Iceage_play_sound	iceage	iceage_move_to_actor	Studio	playlab_play_sound	[block-id='7']	{"position": {"my": "top left", "at": "bottom left", "adjust": {"x": 22, "y":4}} }
-Iceage_play_sound	iceage	iceage_move_to_actor	Studio	playlab_play_sound	[data-id='whenActorTouches']	{"position": {"my": "top left", "at": "bottom left", "adjust": {"x": 22, "y":4}} }
-Iceage_arrow_keys	iceage	iceage_move_events	Studio	arrows_move_actor	#rightButton	{"position": {"my": "bottom left", "at": "top middle", "adjust": {"x": 0, "y":4}} }
-Iceage_add_move	iceage	iceage_repeat	Studio	playlab_add_move	[block-id='5']	{"position": {"my": "top left", "at": "top left", "adjust": {"x": 60, "y":40}} }
-Iceage_add_move	iceage	iceage_repeat	Studio	playlab_add_move	[data-id='repeatForever']	{"position": {"my": "top left", "at": "top left", "adjust": {"x": 60, "y":40}} }
-Iceage_add_score	iceage	iceage_sound_and_points	Studio	playlab_add_score	[block-id='3']	{"position": {"my": "top left", "at": "bottom left", "adjust": {"x": 22, "y":4}} }
-Iceage_add_score	iceage	iceage_sound_and_points	Studio	playlab_add_score	[data-id='whenActorTouches']	{"position": {"my": "top left", "at": "bottom left", "adjust": {"x": 22, "y":4}} }
-Iceage_add_blocks	iceage	iceage_warn_ice_age	Studio	playlab_add_blocks	[block-id='7']	{"position": {"my": "top left", "at": "bottom left", "adjust": {"x": 22, "y":4}} }
-Iceage_add_blocks	iceage	iceage_warn_ice_age	Studio	playlab_add_blocks	[data-id='whenRun']	{"position": {"my": "top left", "at": "bottom left", "adjust": {"x": 22, "y":4}} }


### PR DESCRIPTION
In the course of some other work, I noticed these errors showing up every time we seed in any environment:
```
Error finding script level with search conditions: {"scripts.name"=>"iceage", "levels.level_num"=>"iceage_hello1", "games.name"=>"Studio"}
Error finding script level with search conditions: {"scripts.name"=>"iceage", "levels.level_num"=>"iceage_hello1", "games.name"=>"Studio"}
Error finding script level with search conditions: {"scripts.name"=>"iceage", "levels.level_num"=>"iceage_hello2", "games.name"=>"Studio"}
Error finding script level with search conditions: {"scripts.name"=>"iceage", "levels.level_num"=>"iceage_hello2", "games.name"=>"Studio"}
Error finding script level with search conditions: {"scripts.name"=>"iceage", "levels.level_num"=>"iceage_move_to_actor", "games.name"=>"Studio"}
Error finding script level with search conditions: {"scripts.name"=>"iceage", "levels.level_num"=>"iceage_move_to_actor", "games.name"=>"Studio"}
Error finding script level with search conditions: {"scripts.name"=>"iceage", "levels.level_num"=>"iceage_move_events", "games.name"=>"Studio"}
Error finding script level with search conditions: {"scripts.name"=>"iceage", "levels.level_num"=>"iceage_repeat", "games.name"=>"Studio"}
Error finding script level with search conditions: {"scripts.name"=>"iceage", "levels.level_num"=>"iceage_repeat", "games.name"=>"Studio"}
Error finding script level with search conditions: {"scripts.name"=>"iceage", "levels.level_num"=>"iceage_sound_and_points", "games.name"=>"Studio"}
Error finding script level with search conditions: {"scripts.name"=>"iceage", "levels.level_num"=>"iceage_sound_and_points", "games.name"=>"Studio"}
Error finding script level with search conditions: {"scripts.name"=>"iceage", "levels.level_num"=>"iceage_warn_ice_age", "games.name"=>"Studio"}
Error finding script level with search conditions: {"scripts.name"=>"iceage", "levels.level_num"=>"iceage_warn_ice_age", "games.name"=>"Studio"}
Finished seed:callouts (less than 1 second)
```

We have two ways of generating callouts in our system: 
* for newer levels we use `level.callout_json`: https://github.com/code-dot-org/code-dot-org/blob/16bb2cd9b8edabc88a310c1c9bb727b43a4f438e/dashboard/app/models/levels/level.rb#L206-L208
* for older levels we assocate a `Callout` object with the `ScriptLevel`: https://github.com/code-dot-org/code-dot-org/blob/16bb2cd9b8edabc88a310c1c9bb727b43a4f438e/dashboard/app/models/levels/level.rb#L221-L223

The problem in this case appears to be that we have some levels that we moved to the newer format but never cleaned up the config that would create callouts for them in the older format.

This PR does the following:
* removes outdated callouts that are generating the warnings

I stopped short of turning the warning into an error, because the test environment also has errors on `Hour of Code` and `gumball` units, presumably because those are not in `UI_TEST_SCRIPTS` and therefore not seeded in the test environment.

## Testing story

I verified the following in each of development, levelbuilder and production:
* spot-checked `iceage_hello1` at `/courses/iceage/units/1/lessons/1/levels/1` in an incognito window and verified the callout is actually appearing there (presumably due to that level's `callout_json`)
* when I search for the level names, I don't see any corresponding callout objects in the system, and each level already has `callouts_json`:
```
[development] dashboard > level_names
=> ["iceage_hello1", "iceage_hello2", "iceage_move_to_actor", "iceage_move_events", "iceage_repeat", "iceage_sound_and_points", "iceage_warn_ice_age"]
[development] dashboard * level_names.each do |name|
[development] dashboard *   level = Level.find_by_name(name)
[development] dashboard *   puts level.game.name
[development] dashboard *   puts level.script_levels.any?{|sl| sl.callouts.any?}
[development] dashboard *   puts level.callout_json
[development] dashboard > end
CustomStudio
false
[{"localization_key":"playlab_drag_say","callout_text":null,"element_id":"[block-id='2']","qtip_config":{"position":{"my":"top left","at":"bottom left","adjust":{"x":22,"y":4}}},"on":null},{"element_id":"[data-id='2']","localization_key":"playlab_drag_say","callout_text":null,"qtip_config":{"position":{"my":"top left","at":"bottom left","adjust":{"x":22,"y":4}}},"on":null}]
...
```
