### PR TITLE
fix: fallback to false to ensure the i18nDropdownInBase prop is never null

### DIFF
--- a/dashboard/app/views/layouts/_small_footer.html.haml
+++ b/dashboard/app/views/layouts/_small_footer.html.haml
@@ -2,7 +2,7 @@
   full_width = local_assigns[:full_width]
   channel = local_assigns[:channel]
   reactProps = {
-    i18nDropdownInBase: view_options[:has_i18n],
+    i18nDropdownInBase: view_options[:has_i18n] || false,
     localeUrl: locale_url,
     currentLocale: locale,
     localeOptions: locale_options.map {|(text, value)| {text: text, value: value}},


### PR DESCRIPTION
fixes a react proptype console warning for small footer, ensuring it is always defined since it is a required prop

BEFORE:
<img width="1051" height="448" alt="Screenshot 2025-11-03 at 2 05 15 PM" src="https://github.com/user-attachments/assets/431b925c-abdf-4a27-b9f7-fc9370f623f0" />

AFTER:
<img width="1358" height="388" alt="Screenshot 2025-11-03 at 2 05 36 PM" src="https://github.com/user-attachments/assets/2bf05e14-6573-4091-993f-adc9acf077ec" />

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->



## Links
<!--  Links to relevant external resources.
      - spec docs, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- Jira: 

## Testing story
<!--  Does your change include appropriate tests?
      - If so, please describe how the tests included in this PR are sufficient.
      - If not, please explain why this change does not need to be tested. -->



## Deployment strategy
<!--  Any special steps required to deploy this, besides merging?
      - Are there database migrations or manual steps?
      - Does this require coordination with other teams or systems? -->



## Follow-up work
<!--  List any clean-up or technical debt that will be addressed in future work.
      - Include Jira links where applicable.
      - Are there any known limitations or improvements planned? -->



## Privacy
<!--  How does this change impact Student & Teacher privacy?
      - Does this collect, use, share, or modify PII, either new or existing? -->



## Security
<!--  How does this change impact our security surface-area?
      - Do API's touched have the right auth?
      - Do infra changes impact our attack surface or encryption?
-->



## Caching
<!--  How does this change impact caching behavior?
      - Are cache keys or invalidation strategies affected?
      - Will this require cache warming or invalidation after deployment? -->



## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
