### PR TITLE
hoai2025: hide dance toolbox if empty

### DIFF
--- a/apps/src/dance/lab2/views/DanceView.tsx
+++ b/apps/src/dance/lab2/views/DanceView.tsx
@@ -171,12 +171,10 @@ const DanceView: React.FunctionComponent<{
       mode => {
         if (mode === 'toolbox') {
           if (workspace.current) {
-            const toolboxDef = workspaceToToolboxDefinition(workspace.current);
-            // TODO: We should probably handle this within workspaceToToolboxDefinition,
-            // but we want to avoid affecting other levels right now.
             return {
-              toolbox_definition:
-                toolboxDef.contents.length === 0 ? undefined : toolboxDef,
+              toolbox_definition: workspaceToToolboxDefinition(
+                workspace.current
+              ),
             };
           }
         }

--- a/apps/src/dance/lab2/views/DanceView.tsx
+++ b/apps/src/dance/lab2/views/DanceView.tsx
@@ -171,10 +171,12 @@ const DanceView: React.FunctionComponent<{
       mode => {
         if (mode === 'toolbox') {
           if (workspace.current) {
+            const toolboxDef = workspaceToToolboxDefinition(workspace.current);
+            // TODO: We should probably handle this within workspaceToToolboxDefinition,
+            // but we want to avoid affecting other levels right now.
             return {
-              toolbox_definition: workspaceToToolboxDefinition(
-                workspace.current
-              ),
+              toolbox_definition:
+                toolboxDef.contents.length === 0 ? undefined : toolboxDef,
             };
           }
         }
@@ -375,9 +377,14 @@ const DanceView: React.FunctionComponent<{
       Categories: [BLOCK_TYPES.category, BLOCK_TYPES.categoryDynamic],
       ...blocksByCategory,
     };
-    const toolbox = isToolboxMode
+    let toolbox = isToolboxMode
       ? getToolboxDefinition(toolboxModeBlocks, 'categoryToolbox')
       : levelProperties.toolboxDefinition;
+
+    // Don't show the toolbox if it's empty
+    if (toolbox?.contents?.length === 0) {
+      toolbox = undefined;
+    }
 
     workspace.current = Blockly.inject(blocklyDiv, {
       toolbox,


### PR DESCRIPTION
Fix to hide the toolbox if the contents are empty on Dance Lab2 levels.

Note that this issue still exists on Music Lab (the other Blockly lab2 lab), but we're opting to keep this change scoped to Dance for now to avoid regressing existing Music Lab levels.