### PR TITLE
Sketch Lab: fix remount caused by unstable default sources

### DIFF
--- a/apps/src/sketchlab/SketchlabView.tsx
+++ b/apps/src/sketchlab/SketchlabView.tsx
@@ -157,10 +157,7 @@ const SketchlabView: React.FC<LabProps<LevelProperties>> = ({
   }, []);
 
   useEffect(() => {
-    setReinitializationHandler(() => {
-      console.log('reinit!');
-      setExcalidrawMountKey(key => key + 1);
-    });
+    setReinitializationHandler(() => setExcalidrawMountKey(key => key + 1));
   }, [setReinitializationHandler]);
 
   // Since there's no run button in Sketch Lab, set it to true by default

--- a/apps/src/sketchlab/SketchlabView.tsx
+++ b/apps/src/sketchlab/SketchlabView.tsx
@@ -45,6 +45,8 @@ const INITIAL_WORKSPACE_WIDTH = 800;
 
 const DEBOUNCED_WORKSPACE_SERIALIZATION_MS = 500;
 
+const DEFAULT_SOURCES = {source: {}};
+
 interface SketchlabSources extends ProjectSources {
   source: ExcalidrawInitialDataState;
 }
@@ -155,7 +157,10 @@ const SketchlabView: React.FC<LabProps<LevelProperties>> = ({
   }, []);
 
   useEffect(() => {
-    setReinitializationHandler(() => setExcalidrawMountKey(key => key + 1));
+    setReinitializationHandler(() => {
+      console.log('reinit!');
+      setExcalidrawMountKey(key => key + 1);
+    });
   }, [setReinitializationHandler]);
 
   // Since there's no run button in Sketch Lab, set it to true by default
@@ -222,7 +227,7 @@ const SketchlabView: React.FC<LabProps<LevelProperties>> = ({
 };
 
 export default (props: LabProps<LevelProperties>) => (
-  <SourcesContainer {...props} defaultSources={{source: {}}}>
+  <SourcesContainer {...props} defaultSources={DEFAULT_SOURCES}>
     <SketchlabView levelProperties={props.levelProperties} />
   </SourcesContainer>
 );


### PR DESCRIPTION
We observed weird progress resets happening in Sketch Lab.

It seems like we end up re-rendering the whole lab2 container on project save, and since the default sources were regenerated each re-render, we were triggering this effect, which resets sources and remounts Excalidraw with a not-up-to-date set of sources:

https://github.com/code-dot-org/code-dot-org/blob/31d69c118df782e4cd042868b72db73d154b890b/apps/src/lab2/views/SourcesContainer.tsx#L103-L107

I'll think more on / curious for thoughts on how to make this less of a "footgun" as they say in the biz, but I think this sorts the immediate problem.

## Links

- Slack discussion: https://codedotorg.slack.com/archives/C06JELCAPT9/p1762209786867179

## Testing story

I was able to repro the issue where if I added an element to the canvas then let the page sit for 30 seconds (ie, our project save interval), my changes to the canvas would disappear.

With this change, I no longer repro the issue.