### PR TITLE
hoai2025: standalone & copy updates

### DIFF
--- a/apps/src/bubbleChoice/customModes/MusicDanceAi/MusicDanceAi.tsx
+++ b/apps/src/bubbleChoice/customModes/MusicDanceAi/MusicDanceAi.tsx
@@ -1,3 +1,4 @@
+import {useTheme} from '@code-dot-org/component-library/common/contexts';
 import FontAwesomeV6Icon from '@code-dot-org/component-library/fontAwesomeV6Icon';
 import {BodyThreeText} from '@code-dot-org/component-library/typography';
 import classNames from 'classnames';
@@ -176,6 +177,12 @@ const MusicDanceAi: React.FC<MusicDanceAiProps> = ({
     getLevelPropertiesPath,
     dispatch,
   ]);
+
+  // Default to dark mode for this experience.
+  const {setTheme} = useTheme();
+  useEffect(() => {
+    setTheme('Dark');
+  }, [setTheme]);
 
   useEffect(() => {
     loadData();

--- a/apps/src/dance/lab2/views/DanceView.tsx
+++ b/apps/src/dance/lab2/views/DanceView.tsx
@@ -154,15 +154,15 @@ const DanceView: React.FunctionComponent<{
 
     return {
       analysis: [],
-      artist: 'A.I.', // TODO: user's name?
+      artist: '', // Unused
       bpm: musicProjectPlayer.current.getBpm().toString(),
       delay: '0',
       duration: 0, // Unused
       file: '', // Unused
-      title: 'My AI Remix', // TODO: what should this be?
+      title: guideMode === 'instructions' ? 'Starter Beat' : 'My Music Mix',
       peaks: {},
     };
-  }, [currentSongMetadata, loadedMusicProject]);
+  }, [currentSongMetadata, loadedMusicProject, guideMode]);
 
   const WorkspaceAlert = useLevelEditMode<DanceLevelProperties>(
     levelProperties.id,
@@ -521,7 +521,9 @@ const DanceView: React.FunctionComponent<{
   return (
     <div id="dance-lab" className={moduleStyles.danceLab}>
       <div className={moduleStyles.mainContent}>
-        {!getIsShareView() && <AgeDialog turnOffFilter={turnOffFilter} />}
+        {!getIsShareView() && !usingMusicProject && (
+          <AgeDialog turnOffFilter={turnOffFilter} />
+        )}
         <ResourcePanel
           isRunning={isRunning}
           hasRun={hasRun}
@@ -536,7 +538,7 @@ const DanceView: React.FunctionComponent<{
         {!isToolboxMode && (
           <PanelContainer
             id="visualization"
-            headerContent="Dance Party!"
+            headerContent="Dance"
             headerClassName={moduleStyles.panelHeader}
             className={classNames(
               moduleStyles.visualizationArea,

--- a/apps/src/dance/lab2/views/GenerateDance.tsx
+++ b/apps/src/dance/lab2/views/GenerateDance.tsx
@@ -197,8 +197,8 @@ const GenerateDance: React.FunctionComponent<GenerateCodeProps> = ({
   ].includes(aiGenerateState);
 
   const parentProperties = useParentLevelProperties();
-  const showNavigation =
-    !levelProperties.isProjectLevel && !parentProperties?.isProjectLevel;
+  const isStandalone =
+    levelProperties.isProjectLevel || parentProperties?.isProjectLevel;
 
   return (
     <Guide id="generate-panel" modal={modal} position="bottom">
@@ -274,7 +274,8 @@ const GenerateDance: React.FunctionComponent<GenerateCodeProps> = ({
             color="black"
             size="s"
             onClick={() => {
-              setAiGenerateState('editing');
+              // Skip the 'editing' validation state for standalone projects.
+              setAiGenerateState(isStandalone ? 'edited' : 'editing');
               resetProgram();
             }}
             className={styles.buttonWide}
@@ -300,8 +301,9 @@ const GenerateDance: React.FunctionComponent<GenerateCodeProps> = ({
         <>
           <div>
             <Heading4>Modify the code</Heading4>
-            Amazing moves! Keep editing, or update your dancer design or music
-            mix above. Click Finish when you're done.
+            {isStandalone
+              ? 'Amazing moves! Keep editing, or update your dancer design or music mix above.'
+              : "Amazing moves! Keep editing, or update your dancer design or music mix above. Click Finish when you're done."}
           </div>
           <div className={styles.buttonRow}>
             <Button
@@ -317,7 +319,7 @@ const GenerateDance: React.FunctionComponent<GenerateCodeProps> = ({
               }}
               className={styles.buttonWide}
             />
-            {showNavigation && (
+            {!isStandalone && (
               <NavigationArea
                 levelProperties={levelProperties}
                 // The following props don't really matter as we don't have a Submit button or validation here.

--- a/apps/src/music/views/GenerateCode.tsx
+++ b/apps/src/music/views/GenerateCode.tsx
@@ -198,8 +198,8 @@ const GenerateCode: React.FunctionComponent<GenerateCodeProps> = ({
   ].includes(aiGenerateState);
 
   const parentProperties = useParentLevelProperties();
-  const showNavigation =
-    !levelProperties.isProjectLevel && !parentProperties?.isProjectLevel;
+  const isStandalone =
+    levelProperties.isProjectLevel || parentProperties?.isProjectLevel;
 
   if (!packId) {
     return null;
@@ -309,7 +309,8 @@ const GenerateCode: React.FunctionComponent<GenerateCodeProps> = ({
             color="black"
             size="s"
             onClick={() => {
-              dispatch(setAiGenerateState('editing'));
+              // Skip the 'editing' validation state for standalone projects.
+              dispatch(setAiGenerateState(isStandalone ? 'edited' : 'editing'));
               setPlaying(false);
             }}
             className={styles.buttonWide}
@@ -351,7 +352,7 @@ const GenerateCode: React.FunctionComponent<GenerateCodeProps> = ({
               }}
               className={styles.buttonWide}
             />
-            {showNavigation && (
+            {!isStandalone && (
               <NavigationArea
                 levelProperties={levelProperties}
                 // The following props don't really matter as we don't have a Submit button or validation here.


### PR DESCRIPTION
Assorted fixes for standalone project mode and Dance levels:
- In standalone project mode, we now skip the 'editing' validation phase of code generation in both Music and Dance, and instead go straight to 'edited' which displays the final pane with the "Back to Prompt" button.
- Adjusted the text for the Dance sublevel in the standalone project to remove mention of a finish button.
- Default to dark theme for the standalone project bubble choice level.
- Update Dance metadata and panel header strings.
- Hide the age verification dialog if using a music project in Dance Party

## Testing story
- Tested locally with hoai script