### PR TITLE
Fix Daemon & FrontEnd S3 Policy (cdo-dist)

### DIFF
--- a/aws/cloudformation/cloud_formation_stack.yml.erb
+++ b/aws/cloudformation/cloud_formation_stack.yml.erb
@@ -236,13 +236,14 @@ Resources:
               - 's3:PutObjectLegalHold'
               - 's3:PutObjectRetention'
             Resource: '*'
-          # Deny PutObjectAcl except for cucumber-logs and cdo-build-package buckets
+          # Deny PutObjectAcl except for some test log / build / deployment buckets.
           - Effect: Deny
             Action:
               - 's3:PutObjectAcl'
             NotResource:
               - 'arn:aws:s3:::cucumber-logs/*'
               - 'arn:aws:s3:::cdo-build-package/*'
+              - 'arn:aws:s3:::cdo-dist/*'
           # TODO: Move to dedicated policy for GenAI
           # GenAI Sagemaker access
           - Effect: Allow


### PR DESCRIPTION
Another fix for #69202 
Our build systems need to be able to PutObjectACL to the `cdo-dist` bucket.

## Testing story

`bundle exec rake adhoc:validate RAILS_ENV=adhoc STACK_NAME=adhoc-fix-s3-policy`



## Deployment strategy
Stephen manually applied this policy to the staging and test Policies.



## Follow-up work
<!--  List any clean-up or technical debt that will be addressed in future work.
      - Include Jira links where applicable.
      - Are there any known limitations or improvements planned? -->



## Privacy
<!--  How does this change impact Student & Teacher privacy?
      - Does this collect, use, share, or modify PII, either new or existing? -->



## Security
<!--  How does this change impact our security surface-area?
      - Do API's touched have the right auth?
      - Do infra changes impact our attack surface or encryption?
-->



## Caching
<!--  How does this change impact caching behavior?
      - Are cache keys or invalidation strategies affected?
      - Will this require cache warming or invalidation after deployment? -->



## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
