### PR TITLE
hoai2025: remove dancers fix

### DIFF
--- a/dashboard/config/levels/custom/dance/hoai2025-freeplay-dancer.level
+++ b/dashboard/config/levels/custom/dance/hoai2025-freeplay-dancer.level
@@ -34,7 +34,7 @@
     "default_song": "introtoshamstep_47SOUL",
     "uses_lab2": "true",
     "guide_mode": "aiDancerGenerate",
-    "ai_dancer_generate_adlib": "creature-attire-mood-style-04",
+    "ai_dancer_generate_adlib": "creature-attire-mood-style-05",
     "long_instructions": "#### Create Your Dancer\r\nModify the prompt to generate a new dancer with AI.",
     "preload_asset_list": null,
     "encrypted_examples": [


### PR DESCRIPTION
A quick follow-up to https://github.com/code-dot-org/code-dot-org/pull/69287 to update the dancer adlib for the final level of `/s/hoai2025-dev`.  