### PR TITLE
chore(email): remove POSTE open tracking pixel

### DIFF
--- a/pegasus/emails/dashboard.html
+++ b/pegasus/emails/dashboard.html
@@ -16,5 +16,3 @@ cc: <%= local_assigns.fetch(:cc, nil)&.inspect&.html_safe%>
 bcc: <%= local_assigns.fetch(:bcc, nil)&.inspect&.html_safe %>
 ---
 <%= local_assigns.fetch(:body, "").html_safe %>
-
-<img src="<%= local_assigns.fetch(:tracking_pixel, "") %>"/>

--- a/pegasus/test/fixtures/deliverer/expected/dashboard/body.html
+++ b/pegasus/test/fixtures/deliverer/expected/dashboard/body.html
@@ -3,5 +3,4 @@
 <h1>Testing</h1>
 
 <p>This email should be able to render HTML</p>
-
 </body></html>

--- a/pegasus/test/fixtures/deliverer/expected/dashboard/body.html
+++ b/pegasus/test/fixtures/deliverer/expected/dashboard/body.html
@@ -4,5 +4,4 @@
 
 <p>This email should be able to render HTML</p>
 
-<img src="">
 </body></html>


### PR DESCRIPTION
This PR removes the POSTE open tracking pixel which is no longer used or tracked.

[Context](https://docs.google.com/document/d/1oXznG4xONij5mctpf49oodvoPZzU_Xbbn8t-0f6BHEM/edit?tab=t.0)


Tested on https://adhoc-stephen-remove-poste-email-open-tracking-studio.cdn-code.org/

<img width="1457" height="265" alt="image" src="https://github.com/user-attachments/assets/a999afc6-0c4a-4cc8-92df-ebffd94a874d" />
