### PR TITLE
Add a cloudwatch metric for number of open websockets

### DIFF
--- a/bin/cron/report_actioncable_metrics
+++ b/bin/cron/report_actioncable_metrics
@@ -1,0 +1,28 @@
+#!/usr/bin/env ruby
+require_relative 'only_one'
+abort 'Script already running' unless only_one_running?(__FILE__)
+
+require_relative '../../dashboard/config/environment'
+require 'cdo/aws/metrics'
+
+def main
+  report_actioncable_websocket_count
+end
+
+def report_actioncable_websocket_count
+  websocket_count = ActionCable.server.connections.count
+
+  Cdo::Metrics.put(
+    'code-dot-org/ActionCable',
+    'ActiveWebsocketConnections',
+    websocket_count,
+    {
+      Environment: CDO.rack_env
+    },
+    unit: 'Count'
+  )
+rescue => exception
+  Honeybadger.notify(exception, error_message: 'Error reporting ActionCable metrics')
+end
+
+main

--- a/cookbooks/cdo-apps/templates/default/crontab.erb
+++ b/cookbooks/cdo-apps/templates/default/crontab.erb
@@ -127,6 +127,7 @@
     # 'daemons' in all environments.
     cronjob at:'*/1 * * * *', do:deploy_dir('aws', 'ci_build'), notify: 'dev+build@code.org'
     cronjob at:'*/5 * * * *', do:deploy_dir('bin', 'cron', 'report_activejob_metrics')
+    cronjob at:'*/1 * * * *', do:deploy_dir('bin', 'cron', 'report_actioncable_metrics')
 
     # Refresh the Tutorials cache every hour (runs at the start of each hour, UTC)
     cronjob at:'0 * * * *', do:"#{deploy_dir('bin', 'cron', 'perform_job')} HocLegacy::RefreshTutorialsJob"


### PR DESCRIPTION
Reports how many open websocket connections there are every minute to cloudwatch.

Uses `ActionCable.server.connections.count`.

Based on the `active_job_metrics` reporters [here](https://github.com/code-dot-org/code-dot-org/blob/staging/bin/cron/report_activejob_metrics) and [here](https://github.com/code-dot-org/code-dot-org/blob/staging/dashboard/app/jobs/concerns/active_job_metrics.rb).
