### PR TITLE
Add certificate for Mix & Move with AI

### DIFF
--- a/apps/static/certificates/mix_move_hour_of_ai_certificate.png
+++ b/apps/static/certificates/mix_move_hour_of_ai_certificate.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:4b4f5329395ef1ba4f8ebbf2ff5e4058b6eace4a6a6f69806d64c89498c90aa8
-size 1630398
+oid sha256:514f500d78f0b95e7d8ee7b9761b52126a59f7de8bac24ad0a7bd23aa4a47dcc
+size 516679

--- a/apps/static/certificates/mix_move_hour_of_ai_certificate.png
+++ b/apps/static/certificates/mix_move_hour_of_ai_certificate.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4b4f5329395ef1ba4f8ebbf2ff5e4058b6eace4a6a6f69806d64c89498c90aa8
+size 1630398

--- a/dashboard/lib/certificate_image.rb
+++ b/dashboard/lib/certificate_image.rb
@@ -336,6 +336,8 @@ class CertificateImage
       'MC_Hour_Of_Code_Certificate_mee_timecraft.png'
     elsif course == 'mee_estate'
       'MC_Hour_Of_Code_Certificate_mee_estate.png'
+    elseif course == ScriptConstants::MIX_MOVE_AI_2025
+      'mix_move_hour_of_ai_certificate.png'
     elsif course == ScriptConstants::MUSIC_JAM_2024
       'music_hoc_certificate.png'
     elsif course == ScriptConstants::OCEANS_NAME

--- a/dashboard/lib/certificate_image.rb
+++ b/dashboard/lib/certificate_image.rb
@@ -336,7 +336,7 @@ class CertificateImage
       'MC_Hour_Of_Code_Certificate_mee_timecraft.png'
     elsif course == 'mee_estate'
       'MC_Hour_Of_Code_Certificate_mee_estate.png'
-    elseif course == ScriptConstants::MIX_MOVE_AI_2025
+    elsif course == ScriptConstants::MIX_MOVE_AI_2025
       'mix_move_hour_of_ai_certificate.png'
     elsif course == ScriptConstants::MUSIC_JAM_2024
       'music_hoc_certificate.png'

--- a/dashboard/lib/script_constants.rb
+++ b/dashboard/lib/script_constants.rb
@@ -116,6 +116,7 @@ module ScriptConstants
       # with code_s matching the script name (in quotes) in this list.
 
       nil,
+      MIX_MOVE_AI_2025 = 'mix-move-ai-2025'.freeze, # 2025 hour of ai
       MUSIC_JAM_2024 = 'music-jam-2024'.freeze, # 2024 hour of code
       DANCE_AI_2023 = 'dance-ai-2023'.freeze, # 2023 hour of code
       POEM_ART_2021_NAME = 'poem-art-2021'.freeze, # 2021 hour of code


### PR DESCRIPTION
This change adds a sufficient placeholder certificate image for the new Hour of AI tutorial, "Mix & Move with AI". The name of that script in levelbuilder is mix-move-ai-2025.

Design will follow up with a new image before 11/19.

Based on #69025 and #61706



## Links

- Jira: https://codedotorg.atlassian.net/browse/LABS-1707

## Testing story
Need an engineer to pull this branch and test the change locally please.

## Follow-up work
Contentful needs a tutorial added to it with tutorial id = mix-move-ai-2025
