### PR TITLE
Revert "Revert "Revert "Revert "Revert "Use Consistent Volume Size Across All Prod Instances"""""

### DIFF
--- a/aws/cloudformation/cloud_formation_stack.yml.erb
+++ b/aws/cloudformation/cloud_formation_stack.yml.erb
@@ -295,7 +295,7 @@ Resources:
   subnets: subnets(azs(AVAILABILITY_ZONES - ['us-east-1e'])), # us-east-1e doesn't support m5 instance types.
   frontend_policies: [{Ref: 'CDOPolicy'}, {'Fn::ImportValue': 'IAM-SessionPermissions'}],
   frontend_properties: {TargetGroupARNs: [Ref: 'ALBTargetGroup']},
-  frontend_volume_size: 128,
+  frontend_volume_size: 64,
   ami_timeout: 'PT120M',
   build_ami: erb_file(BOOTSTRAP_CHEF,
     resource_id: "AMICreate#{commit_hash}",

--- a/aws/cloudformation/components/ami.yml.erb
+++ b/aws/cloudformation/components/ami.yml.erb
@@ -177,7 +177,7 @@ frontend_device_name ||= '/dev/sda1'
         BlockDeviceMappings:
           - DeviceName: <%=frontend_device_name%>
             Ebs:
-              VolumeSize: <%=frontend_volume_size%>
+              VolumeSize: <%=frontend_volume_size * 2%> # Double volume size to leave room for logs written to disk
               VolumeType: gp2
         TagSpecifications:
           - ResourceType: instance


### PR DESCRIPTION
Reverts code-dot-org/code-dot-org#69308

This time, the upsize itself was successful! We updated Ubuntu and kicked off a build on the new volume as planned.

Unfortunately, this process revealed an existing issue in our stack right now; we have a circular dependency in the build between the creation of the web service and the creation of a `newrelic.yml` config file. This will only manifest when creating a new production server from scratch, which unfortunately means it manifests here.

See thread [here](https://codedotorg.slack.com/archives/C03CK49G9/p1762308002834399?thread_ts=1762293673.594869&cid=C03CK49G9)

Reverting this change so we can deploy a fix to that underlying problem.