### PR TITLE
fix: use AR sql to filter and order course offerings

### DIFF
--- a/dashboard/app/controllers/congrats_controller.rb
+++ b/dashboard/app/controllers/congrats_controller.rb
@@ -88,8 +88,9 @@ class CongratsController < ApplicationController
         @sections = current_user.sections.all.reject(&:hidden).map(&:summarize)
       end
       @assignable_course_suggestions =
-        CourseOffering.assignable_published_for_students_course_offerings.
-          select {|co| co.self_paced_pl_course_offering_id == curriculum.get_course_version&.course_offering_id}.
+        CourseOffering.
+          assignable_published_for_students_course_offerings.
+          where(self_paced_pl_course_offering_id: curriculum.get_course_version&.course_offering_id).
           map(&:summarize_for_catalog)
     end
     @next_course_script_name = ScriptConstants.csf_next_course_recommendation(@course_name)

--- a/dashboard/app/controllers/curriculum_catalog_controller.rb
+++ b/dashboard/app/controllers/curriculum_catalog_controller.rb
@@ -20,7 +20,7 @@ class CurriculumCatalogController < ApplicationController
     end
 
     @catalog_data = {
-      curriculaData: CourseOffering.assignable_published_for_students_course_offerings.sort_by(&:display_name).map {|co| co&.summarize_for_catalog(locale, current_user)},
+      curriculaData: CourseOffering.assignable_published_for_students_course_offerings.order(:display_name).map {|co| co&.summarize_for_catalog(locale, current_user)},
       isEnglish: language == "en",
       languageEnglishName: @language_english_name,
       languageNativeName: @language_native_name,

--- a/dashboard/app/models/course_offering.rb
+++ b/dashboard/app/models/course_offering.rb
@@ -204,7 +204,16 @@ class CourseOffering < ApplicationRecord
   # - Published (associated unit group or unit 'published_state' setting is 'preview' or 'stable')
   # - For students (associated unit group or unit 'participant_audience' setting is student)
   def self.assignable_published_for_students_course_offerings
-    all_course_offerings.select {|co| co.assignable? && co.any_version_is_in_published_state? && co.get_participant_audience == 'student'}
+    CourseOffering.includes(course_versions: {content_root: {default_unit_group_units: {}}}).
+      joins(course_versions: :content_root).
+      where(assignable: true).
+      where(course_versions: {published_state: [
+              Curriculum::SharedCourseConstants::PUBLISHED_STATE.preview,
+              Curriculum::SharedCourseConstants::PUBLISHED_STATE.stable
+            ]}
+      ).
+      where(unit_groups: {participant_audience: 'student'}).
+      distinct
   end
 
   def self.assignable_course_offerings(user)


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->



## Links
<!--  Links to relevant external resources.
      - spec docs, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- Jira: 

## Testing story
<!--  Does your change include appropriate tests?
      - If so, please describe how the tests included in this PR are sufficient.
      - If not, please explain why this change does not need to be tested. -->



## Deployment strategy
<!--  Any special steps required to deploy this, besides merging?
      - Are there database migrations or manual steps?
      - Does this require coordination with other teams or systems? -->



## Follow-up work
<!--  List any clean-up or technical debt that will be addressed in future work.
      - Include Jira links where applicable.
      - Are there any known limitations or improvements planned? -->



## Privacy
<!--  How does this change impact Student & Teacher privacy?
      - Does this collect, use, share, or modify PII, either new or existing? -->



## Security
<!--  How does this change impact our security surface-area?
      - Do API's touched have the right auth?
      - Do infra changes impact our attack surface or encryption?
-->



## Caching
<!--  How does this change impact caching behavior?
      - Are cache keys or invalidation strategies affected?
      - Will this require cache warming or invalidation after deployment? -->



## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
