### PR TITLE
AI Chat / Tutor: Fix copyable code overlay bug when content overflows (scrolling)

### DIFF
--- a/apps/src/aiComponentLibrary/copyableCodeBlock/CopyableCodeBlock.tsx
+++ b/apps/src/aiComponentLibrary/copyableCodeBlock/CopyableCodeBlock.tsx
@@ -73,7 +73,9 @@ const CopyableCodeBlock: React.FunctionComponent = (
         />
       </header>
       <div className={moduleStyles.codeContentBody}>
-        <pre ref={preRef} className={moduleStyles.codeContent} {...props} />
+        <div className={moduleStyles.codeContent}>
+          <pre ref={preRef} {...props} />
+        </div>
         <div
           className={`${moduleStyles.codeContentOverlay}${
             visible ? ' ' + moduleStyles.showOverlay : ''

--- a/apps/src/aiComponentLibrary/copyableCodeBlock/copyable-code-block.module.scss
+++ b/apps/src/aiComponentLibrary/copyableCodeBlock/copyable-code-block.module.scss
@@ -21,17 +21,24 @@
   .codeContentBody {
     position: relative;
     width: 100%;
+    height: auto;
     padding-bottom: 0.5rem;
-    max-height: 400px;
-    overflow: auto;
+
 
     > .codeContent {
+      max-height: 400px;
+      width: 100%;
+      overflow: auto;
+
+      > pre {
       margin: 0;
       padding-bottom: 0;
       border-radius: 0;
       border: none;
       background-color: var(--background-neutral-primary);
       color: var(--text-neutral-primary);
+      }
+
     }
 
     > .codeContentOverlay {

--- a/apps/src/aiComponentLibrary/copyableCodeBlock/copyable-code-block.module.scss
+++ b/apps/src/aiComponentLibrary/copyableCodeBlock/copyable-code-block.module.scss
@@ -31,14 +31,13 @@
       overflow: auto;
 
       > pre {
-      margin: 0;
-      padding-bottom: 0;
-      border-radius: 0;
-      border: none;
-      background-color: var(--background-neutral-primary);
-      color: var(--text-neutral-primary);
+        margin: 0;
+        padding-bottom: 0;
+        border-radius: 0;
+        border: none;
+        background-color: var(--background-neutral-primary);
+        color: var(--text-neutral-primary);
       }
-
     }
 
     > .codeContentOverlay {


### PR DESCRIPTION
This PR fixes a bug that occured when copyable code overflows its container.  In this case, the overlay, that indicates the code was successfully copied, was scrolling with the content and no longer covering the content.  The fix makes the overlay stay in place so that the text "Copied" is always centered and the overlay fully covers the copied code as intended. 

Before (AI Tutor):

https://github.com/user-attachments/assets/a295c6e2-6d49-4393-a29a-7d33a75c6815

After (AI Tutor):

https://github.com/user-attachments/assets/5f4579e3-5da5-4084-91a8-cf661ec89b5a

After (AI Chat):

https://github.com/user-attachments/assets/0826bd1b-8f5e-4cee-8f42-43c7260641b6

## Links
This was mentioned in slack [here](https://codedotorg.slack.com/archives/C08S29NDZ5E/p1762279406915999) and the Jira ticket is [here](https://codedotorg.atlassian.net/browse/LABS-1708).


## Testing story
The fix was manually tested in both AI tutor and AI Chat.

## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
