### PR TITLE
Codebridge: fix scroll-padding on file tabs

### DIFF
--- a/apps/src/codebridge/FileTabs/styles/fileTabs.module.scss
+++ b/apps/src/codebridge/FileTabs/styles/fileTabs.module.scss
@@ -9,6 +9,7 @@
   overflow-x: auto;
   max-width: 100%;
   background-color: var(--background-neutral-primary);
+  scroll-padding-inline-start: 1rem;
   scrollbar-width: thin;
   box-sizing: border-box;
   color: var(--text-neutral-secondary);


### PR DESCRIPTION
Fixes an issue where the selected tab is getting cut off to the left. The `scroll-padding-inline-start` css property fixes this by adding some buffer. 

## Links
Jira ticket: [AFL-349](https://codedotorg.atlassian.net/browse/AFL-349)

## Testing story
Tested locally and for LTR and RTL languages

----

## Before


https://github.com/user-attachments/assets/968b599c-4296-4366-abae-f627a8f1aa9a

## After


https://github.com/user-attachments/assets/211b04c5-9dc2-400c-b0a1-bb517a3c6676

