### PR TITLE
fix new_account route for non-lti users

### DIFF
--- a/dashboard/app/controllers/lti/v1/account_linking_controller.rb
+++ b/dashboard/app/controllers/lti/v1/account_linking_controller.rb
@@ -64,7 +64,7 @@ module Lti
 
       # POST /lti/v1/account_linking/new_account
       def new_account
-        if current_user
+        if current_user && Policies::Lti.lti?(current_user)
           current_user.lms_landing_opted_out = true
           current_user.verify_teacher! if Policies::Lti.unverified_teacher?(current_user)
           current_user.save!

--- a/dashboard/test/controllers/lti/v1/account_linking_controller_test.rb
+++ b/dashboard/test/controllers/lti/v1/account_linking_controller_test.rb
@@ -149,7 +149,6 @@ class Lti::V1::AccountLinkingControllerTest < ActionController::TestCase
         sign_in user
         new_account_request
 
-        user.reload
         _(user.verified_teacher?).must_equal false
       end
     end
@@ -164,14 +163,12 @@ class Lti::V1::AccountLinkingControllerTest < ActionController::TestCase
       it 'does not opt the user out of lms landing' do
         new_account_request
 
-        user.reload
         _(user.lms_landing_opted_out).must_be_nil
       end
 
       it 'does not verify the teacher' do
         new_account_request
 
-        user.reload
         _(user.verified_teacher?).must_equal false
       end
     end

--- a/dashboard/test/controllers/lti/v1/account_linking_controller_test.rb
+++ b/dashboard/test/controllers/lti/v1/account_linking_controller_test.rb
@@ -101,54 +101,80 @@ class Lti::V1::AccountLinkingControllerTest < ActionController::TestCase
     post :link_email, params: {email: @user.email, password: 'password'}
   end
 
-  test 'returns bad request if not logged in' do
-    post :new_account
+  describe '#new_account' do
+    subject(:new_account_request) {post :new_account}
+    let(:user) {create(:teacher, :with_lti_authentication_option)}
 
-    assert_response :bad_request
-  end
+    context 'when user is not logged and not in-progress with registration' do
+      it 'returns bad request' do
+        new_account_request
+        assert_response :bad_request
+      end
+    end
 
-  test 'opts out of lms landing for a signed in user' do
-    lti_user = create(:student)
-    sign_in lti_user
+    context 'when signed in' do
+      before do
+        sign_in user
+      end
 
-    post :new_account
+      it 'opts the user out of lms landing' do
+        new_account_request
 
-    lti_user.reload
+        user.reload
+        _(user.lms_landing_opted_out).must_equal true
+      end
 
-    assert_equal true, lti_user.lms_landing_opted_out
-  end
+      it 'verifies the teacher' do
+        new_account_request
 
-  test 'opts out of lms landing for a partial registration user' do
-    lti_user = create(:student)
-    PartialRegistration.persist_attributes(session, lti_user)
+        user.reload
+        _(user.verified_teacher?).must_equal true
+      end
+    end
 
-    post :new_account
+    context 'when partial registration' do
+      it 'opts the user out of lms landing' do
+        PartialRegistration.persist_attributes(session, user)
+        new_account_request
 
-    partial_user = User.new_with_session(ActionController::Parameters.new, session)
+        partial_user = User.new_with_session(ActionController::Parameters.new, session)
+        _(partial_user.lms_landing_opted_out).must_equal true
+      end
+    end
 
-    assert_equal true, partial_user.lms_landing_opted_out
-  end
+    context 'when student' do
+      let(:user) {create(:student, :with_lti_authentication_option)}
 
-  test 'verifies roster-synced teacher if they are not already verified' do
-    lti_user = create(:teacher)
-    sign_in lti_user
+      it 'does not verify the student' do
+        sign_in user
+        new_account_request
 
-    post :new_account
+        user.reload
+        _(user.verified_teacher?).must_equal false
+      end
+    end
 
-    lti_user.reload
+    context 'when non-LTI user' do
+      let(:user) {create(:teacher)}
 
-    assert lti_user.verified_teacher?
-  end
+      before do
+        sign_in user
+      end
 
-  test 'do not verify roster-synced student' do
-    lti_user = create(:student)
-    sign_in lti_user
+      it 'does not opt the user out of lms landing' do
+        new_account_request
 
-    post :new_account
+        user.reload
+        _(user.lms_landing_opted_out).must_be_nil
+      end
 
-    lti_user.reload
+      it 'does not verify the teacher' do
+        new_account_request
 
-    refute lti_user.verified_teacher?
+        user.reload
+        _(user.verified_teacher?).must_equal false
+      end
+    end
   end
 
   describe '#unlink' do


### PR DESCRIPTION
Fixes the LTI new_account route for non-LTI users. Also refactors the tests for this route to use the spec syntax, and adds a test for this particular case.

## Links
[JIRA](https://codedotorg.atlassian.net/browse/P20-1695)

## Testing story
```
bundle exec spring testunit test/controllers/lti/v1/account_linking_controller_test.rb
Running via Spring preloader in process 78173
Started with run options --seed 27643

68% Time: 00:00:01,  ETA: 00:00:01
  16/16: [======================================================================] 100% Time: 00:00:01, Time: 00:00:01

Finished in 1.97365s
16 tests, 30 assertions, 0 failures, 0 errors, 0 skips
```

## Deployment strategy
<!--  Any special steps required to deploy this, besides merging?
      - Are there database migrations or manual steps?
      - Does this require coordination with other teams or systems? -->



## Follow-up work
<!--  List any clean-up or technical debt that will be addressed in future work.
      - Include Jira links where applicable.
      - Are there any known limitations or improvements planned? -->



## Privacy
<!--  How does this change impact Student & Teacher privacy?
      - Does this collect, use, share, or modify PII, either new or existing? -->



## Security
<!--  How does this change impact our security surface-area?
      - Do API's touched have the right auth?
      - Do infra changes impact our attack surface or encryption?
-->



## Caching
<!--  How does this change impact caching behavior?
      - Are cache keys or invalidation strategies affected?
      - Will this require cache warming or invalidation after deployment? -->



## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
