### PR TITLE
Codebridge: update Files header dropdown to use DSCO ActionDropdown

### DIFF
--- a/apps/src/codebridge/FileBrowser/FileBrowserHeaderPopUpButton.tsx
+++ b/apps/src/codebridge/FileBrowser/FileBrowserHeaderPopUpButton.tsx
@@ -1,7 +1,6 @@
+import {ActionDropdown} from '@code-dot-org/component-library/dropdown';
 import {useCodebridgeContext} from '@codebridge/codebridgeContext';
 import {DEFAULT_FOLDER_ID} from '@codebridge/constants';
-import {PopUpButton} from '@codebridge/PopUpButton/PopUpButton';
-import {PopUpButtonOption} from '@codebridge/PopUpButton/PopUpButtonOption';
 import React from 'react';
 
 import codebridgeI18n from '@cdo/apps/codebridge/locale';
@@ -68,42 +67,50 @@ export const FileBrowserHeaderPopUpButton = () => {
   return (
     <>
       <FileUploaderComponent />
-      <PopUpButton
-        iconName="plus"
-        alignment="left"
-        id="uitest-files-plus"
-        ariaLabel={codebridgeI18n.manageFiles()}
-      >
-        <PopUpButtonOption
-          iconName="plus"
-          labelText={codebridgeI18n.newFolder()}
-          clickHandler={() =>
-            openNewFolderPrompt({parentId: DEFAULT_FOLDER_ID})
-          }
-        />
-        <PopUpButtonOption
-          iconName="plus"
-          labelText={codebridgeI18n.newFile()}
-          clickHandler={() => openNewFilePrompt(openNewFilePromptArgs)}
-          id="uitest-new-file"
-        />
-        <PopUpButtonOption
-          iconName="upload"
-          labelText={codebridgeI18n.uploadFile()}
-          clickHandler={() => startFileUpload()}
-        />
-        <PopUpButtonOption
-          iconName="backpack"
-          labelText={codebridgeI18n.importFromBackpackTitle()}
-          clickHandler={() =>
-            openImportFromBackpackPrompt({
-              backpackApi: backpackApi,
-              projectFiles: files,
-              validationFile: validationFile,
-            })
-          }
-        />
-      </PopUpButton>
+      <ActionDropdown
+        name="manageFilesDropdown"
+        labelText={codebridgeI18n.manageFiles()}
+        triggerButtonProps={{
+          isIconOnly: true,
+          icon: {iconName: 'plus', iconStyle: 'solid'},
+        }}
+        size="xs"
+        menuVerticalPlacement="bottom"
+        options={[
+          {
+            value: 'newFolder',
+            label: codebridgeI18n.newFolder(),
+            icon: {iconName: 'plus'},
+            onClick: () => {
+              openNewFolderPrompt({parentId: DEFAULT_FOLDER_ID});
+            },
+          },
+          {
+            value: 'newFile',
+            label: codebridgeI18n.newFile(),
+            icon: {iconName: 'plus', iconStyle: 'solid'},
+            onClick: () => openNewFilePrompt(openNewFilePromptArgs),
+            optionId: 'uitest-new-file',
+          },
+          {
+            value: 'uploadFile',
+            label: codebridgeI18n.uploadFile(),
+            icon: {iconName: 'upload', iconStyle: 'solid'},
+            onClick: () => startFileUpload(),
+          },
+          {
+            value: 'importFromBackpack',
+            label: codebridgeI18n.importFromBackpackTitle(),
+            icon: {iconName: 'backpack', iconStyle: 'solid'},
+            onClick: () =>
+              openImportFromBackpackPrompt({
+                backpackApi: backpackApi,
+                projectFiles: files,
+                validationFile: validationFile,
+              }),
+          },
+        ]}
+      />
     </>
   );
 };

--- a/apps/src/codebridge/FileBrowser/FileBrowserHeaderPopUpButton.tsx
+++ b/apps/src/codebridge/FileBrowser/FileBrowserHeaderPopUpButton.tsx
@@ -68,13 +68,13 @@ export const FileBrowserHeaderPopUpButton = () => {
     <>
       <FileUploaderComponent />
       <ActionDropdown
-        name="manageFilesDropdown"
+        name="uitest-files-plus"
         labelText={codebridgeI18n.manageFiles()}
         triggerButtonProps={{
-          type: 'tertiary',
-          color: 'gray',
           isIconOnly: true,
           icon: {iconName: 'plus', iconStyle: 'solid'},
+          color: 'gray',
+          type: 'tertiary',
         }}
         size="xs"
         menuVerticalPlacement="bottom"

--- a/apps/src/codebridge/FileBrowser/FileBrowserHeaderPopUpButton.tsx
+++ b/apps/src/codebridge/FileBrowser/FileBrowserHeaderPopUpButton.tsx
@@ -71,6 +71,8 @@ export const FileBrowserHeaderPopUpButton = () => {
         name="manageFilesDropdown"
         labelText={codebridgeI18n.manageFiles()}
         triggerButtonProps={{
+          type: 'tertiary',
+          color: 'gray',
           isIconOnly: true,
           icon: {iconName: 'plus', iconStyle: 'solid'},
         }}

--- a/apps/src/lab2/views/dialogs/dialog-manager.module.scss
+++ b/apps/src/lab2/views/dialogs/dialog-manager.module.scss
@@ -4,7 +4,8 @@
 
 .dialogContainer {
   @extend %full-container-overlay;
-  // Adding these styles to override the common.scss styles.
+  // Adding these styles to override the common.scss styles
+  // just in case this affects dialogs we don't want to change.
   // TODO - Ideally dialogs that are using this stylesheet
   // should be replaced with a DSCO component.
   top: -$top-spacing;

--- a/apps/src/lab2/views/dialogs/dialog-manager.module.scss
+++ b/apps/src/lab2/views/dialogs/dialog-manager.module.scss
@@ -1,8 +1,16 @@
+@use '@cdo/apps/lab2/views/components/layout/variables.scss' as variables;
 @import 'color.scss';
 @import '../common.scss';
 
 .dialogContainer {
   @extend %full-container-overlay;
+  // Adding these styles to override the common.scss styles.
+  // TODO - Ideally dialogs that are using this stylesheet
+  // should be replaced with a DSCO component.
+  top: -$top-spacing;
+  height: calc(100% + $top-spacing);
+  background-color: var(--neutral-black-alpha-90);
+  z-index: variables.$z-index-fullscreen;
 }
 
 %dialog {

--- a/dashboard/test/ui/features/code_tools/pythonlab/pythonlab_files.feature
+++ b/dashboard/test/ui/features/code_tools/pythonlab/pythonlab_files.feature
@@ -8,7 +8,7 @@ Background:
   And I wait to see "#uitest-codebridge-run"
 
 Scenario: Can add a new, unlocked file
-  And I press "uitest-files-plus"
+  And I press "uitest-files-plus-dropdown"
   And I wait to see "#uitest-new-file"
   And I press "uitest-new-file"
   And I wait to see "#uitest-prompt-field"

--- a/frontend/packages/component-library/src/dropdown/actionDropdown/ActionDropdown.tsx
+++ b/frontend/packages/component-library/src/dropdown/actionDropdown/ActionDropdown.tsx
@@ -18,6 +18,7 @@ export interface ActionDropdownOption extends CustomDropdownOption {
   onClick: () => void;
   isOptionDestructive?: boolean;
   icon: FontAwesomeV6IconProps;
+  optionId?: string;
 }
 
 export interface ActionDropdownProps extends AriaAttributes {
@@ -100,6 +101,7 @@ const ActionDropdown: React.FunctionComponent<ActionDropdownProps> = ({
             onClick,
             isOptionDisabled,
             isOptionDestructive,
+            optionId,
             icon: {
               iconName,
               iconStyle,
@@ -110,6 +112,7 @@ const ActionDropdown: React.FunctionComponent<ActionDropdownProps> = ({
           return (
             <li key={value}>
               <button
+                id={optionId}
                 className={classNames(
                   moduleStyles.dropdownMenuItem,
                   isOptionDisabled && moduleStyles.disabledDropdownMenuItem,


### PR DESCRIPTION
Updates the file manager header dropdown menu to use the [DSCO ActionDropdown](https://code-dot-org.github.io/code-dot-org/component-library-storybook/?path=/docs/designsystem-dropdown-action-dropdown--docs) component. Also adds some custom styles to the `dialogContainer` class to make the dialogs that pop up when you select an option from this dropdown look more like the DSCO Dialog components. 

## Links
Jira ticket: [AFL-340](https://codedotorg.atlassian.net/browse/AFL-340)

## Testing story
Tested locally

----

## Before

### Web Lab 2


https://github.com/user-attachments/assets/e9667e9d-d69c-4167-8998-c2904b564fcd



### Python Lab


https://github.com/user-attachments/assets/a16a7eff-1182-4a72-a487-de50124797e0



## After

### Web Lab 2


https://github.com/user-attachments/assets/3c204747-1eb1-4c38-990b-3b0cf668b971



### Python Lab


https://github.com/user-attachments/assets/f43f1b26-38d7-4a9e-8c31-f872467ef739

