### PR TITLE
Web Lab 2: remove url change debounce

### DIFF
--- a/apps/src/codebridge/FilePreview/HTMLPreview.tsx
+++ b/apps/src/codebridge/FilePreview/HTMLPreview.tsx
@@ -19,7 +19,6 @@ import {HTMLPreviewHeader} from './HTMLPreviewHeader';
 
 import moduleStyles from './styles/html-preview.module.scss';
 
-const URL_CHANGE_DELAY_MS = 300;
 const SOURCE_CHANGE_DELAY_MS = 500;
 
 export const HTMLPreview: React.FC = () => {
@@ -192,14 +191,10 @@ export const HTMLPreview: React.FC = () => {
   }, [previewUrl, currentFile, navigationHistory, navigationHistoryIndex]);
 
   useEffect(() => {
-    const debouncedUpdate = setTimeout(() => {
-      iframeRef.current?.contentWindow?.postMessage(
-        {type: IframeMessageType.CHANGE_FILE_URL_BAR, fileName: currentFile},
-        previewUrl
-      );
-    }, URL_CHANGE_DELAY_MS);
-
-    return () => clearTimeout(debouncedUpdate);
+    iframeRef.current?.contentWindow?.postMessage(
+      {type: IframeMessageType.CHANGE_FILE_URL_BAR, fileName: currentFile},
+      previewUrl
+    );
   }, [currentFile, previewUrl]);
 
   useEffect(() => {


### PR DESCRIPTION
We were previously debouncing the url change messages to the inner preview iframe because we were automatically sending updates as the user typed. However, in #68052 we updated the url bar to only send the request on enter, so we no longer need to debounce. 

I am making this change because the debounce was causing some issues in the upcoming work to move web lab 2 to a service worker, and it has no downside for the current implementation.

## Links

- Jira: prefactor for [AFL-243](https://codedotorg.atlassian.net/browse/AFL-243)

## Testing story
Confirmed changing urls still works as expected.


## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
