### PR TITLE
More Refinements to Daemon & FrontEnd S3 Policies

### DIFF
--- a/aws/cloudformation/cloud_formation_stack.yml.erb
+++ b/aws/cloudformation/cloud_formation_stack.yml.erb
@@ -227,7 +227,7 @@ Resources:
 
               # Management S3 APIs that Daemon and FrontEnds don't need.
               - 's3:PutBucketVersioning'
-              - 's3:PutBucketReplication'
+              - 's3:PutReplicationConfiguration'
               - 's3:PutBucketCORS'
               - 's3:PutBucketLogging'
               - 's3:PutEncryptionConfiguration'
@@ -244,6 +244,8 @@ Resources:
               - 'arn:aws:s3:::cucumber-logs/*'
               - 'arn:aws:s3:::cdo-build-package/*'
               - 'arn:aws:s3:::cdo-dist/*'
+              - 'arn:aws:s3:::images.code.org/*'
+              - 'arn:aws:s3:::videos.code.org/*'
           # TODO: Move to dedicated policy for GenAI
           # GenAI Sagemaker access
           - Effect: Allow


### PR DESCRIPTION
Another fix to #69202 

The Curriculum Authoring environment (levelbuilder) needs to be able to upload images/videos with public access to two buckets.

Also fix a typo in the Put Replication Config action.

## Testing story
`bundle exec rake adhoc:validate RAILS_ENV=adhoc STACK_NAME=adhoc-levelbuilder-s3`



## Deployment strategy
<!--  Any special steps required to deploy this, besides merging?
      - Are there database migrations or manual steps?
      - Does this require coordination with other teams or systems? -->



## Follow-up work
<!--  List any clean-up or technical debt that will be addressed in future work.
      - Include Jira links where applicable.
      - Are there any known limitations or improvements planned? -->



## Privacy
<!--  How does this change impact Student & Teacher privacy?
      - Does this collect, use, share, or modify PII, either new or existing? -->



## Security
<!--  How does this change impact our security surface-area?
      - Do API's touched have the right auth?
      - Do infra changes impact our attack surface or encryption?
-->



## Caching
<!--  How does this change impact caching behavior?
      - Are cache keys or invalidation strategies affected?
      - Will this require cache warming or invalidation after deployment? -->



## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
