### PR TITLE
hoai2025: freeplay updates

### DIFF
--- a/apps/src/bubbleChoice/customModes/MusicDanceAi/MusicDanceAi.tsx
+++ b/apps/src/bubbleChoice/customModes/MusicDanceAi/MusicDanceAi.tsx
@@ -2,23 +2,22 @@ import {useTheme} from '@code-dot-org/component-library/common/contexts';
 import FontAwesomeV6Icon from '@code-dot-org/component-library/fontAwesomeV6Icon';
 import {BodyThreeText} from '@code-dot-org/component-library/typography';
 import classNames from 'classnames';
-import React, {Suspense, useCallback, useEffect, useState} from 'react';
+import React, {memo, Suspense, useCallback, useEffect, useState} from 'react';
 
 import {
   getCurrentLesson,
-  getCurrentScriptLevelId,
   levelById,
 } from '@cdo/apps/code-studio/progressReduxSelectors';
-import {DanceLevelProperties} from '@cdo/apps/dance/types';
-import {setIsLoading} from '@cdo/apps/lab2/lab2Redux';
+import {setIsLoading, setPageError} from '@cdo/apps/lab2/lab2Redux';
+import Lab2Registry from '@cdo/apps/lab2/Lab2Registry';
 import ProjectManager from '@cdo/apps/lab2/projects/ProjectManager';
 import ProjectManagerFactory from '@cdo/apps/lab2/projects/ProjectManagerFactory';
+import {getIsShareView} from '@cdo/apps/lab2/projects/utils';
 import {LevelPropertiesValidator} from '@cdo/apps/lab2/responseValidators';
 import {
   BubbleChoiceLevelData,
   BubbleChoiceSublevel,
   Channel,
-  LabProps,
   LevelProperties,
 } from '@cdo/apps/lab2/types';
 import LevelPropertiesCache from '@cdo/apps/lab2/utils/LevelPropertiesCache';
@@ -65,9 +64,10 @@ async function loadLevelProperties(path: string): Promise<LevelProperties> {
   return value;
 }
 
-interface LabData extends LabProps {
-  // In addition to LabProps, we'll also pass down a dedicated ProjectManager for each sublevel,
-  // so each lab is writing and reading the correct project (instead accessing the singleton from Lab2Registry).
+interface LabData {
+  levelProperties: LevelProperties;
+  // We pass down a dedicated ProjectManager for each sublevel, so each lab is writing
+  // and reading the correct project (instead accessing the singleton from Lab2Registry).
   // Note that this requires the LabView to accept a ProjectManager prop, which is currently only supported by Music and Dance.
   projectManager?: ProjectManager;
 }
@@ -83,10 +83,9 @@ const MusicDanceAi: React.FC<MusicDanceAiProps> = ({
   channel,
 }) => {
   const [currentTab, setCurrentTab] = useState<Tab>();
-  const [propsMap, setPropsMap] = useState<{[tab in Tab]?: LabData}>({});
+  const [tabDataMap, setTabDataMap] = useState<{[tab in Tab]?: LabData}>();
   const userId = useAppSelector(state => state.progress.viewAsUserId);
   const scriptId = useAppSelector(state => state.progress.scriptId);
-  const scriptLevelId = useAppSelector(getCurrentScriptLevelId);
   const dispatch = useAppDispatch();
 
   const levelPropertiesPathPrefix = useAppSelector(state => {
@@ -115,6 +114,10 @@ const MusicDanceAi: React.FC<MusicDanceAiProps> = ({
 
   // Load level properties and project data for each sublevel.
   const loadData = useCallback(async () => {
+    if (tabDataMap) {
+      // Already loaded; return.
+      return;
+    }
     const sublevels = (
       levelProperties.levelData as BubbleChoiceLevelData | undefined
     )?.sublevels;
@@ -128,55 +131,118 @@ const MusicDanceAi: React.FC<MusicDanceAiProps> = ({
       const sublevelProperties = await loadLevelProperties(
         getLevelPropertiesPath(sublevel)
       );
+      const appName = sublevelProperties.appName;
+      let tab: Tab | undefined;
+      if (appName === 'music') {
+        tab = Tab.Music;
+      } else if (appName === 'dance' && 'guideMode' in sublevelProperties) {
+        const guideMode = sublevelProperties.guideMode;
+        tab = guideMode === 'aiCodeGenerate' ? Tab.Dance : Tab.Dancer;
+      }
+
+      if (!tab) {
+        Lab2Registry.getInstance()
+          .getMetricsReporter()
+          .logWarning('Invalid level type ' + sublevelProperties.appName);
+        continue;
+      }
+
       const data: LabData = {levelProperties: sublevelProperties};
 
       let projectManager: ProjectManager | null = null;
 
-      if (levelProperties.isProjectLevel && channel.subprojects) {
-        const channelId = channel.subprojects.find(
-          ({level_id}) => level_id.toString() === sublevel.level_id
-        )?.project_id;
-        if (channelId) {
-          projectManager = ProjectManagerFactory.getProjectManager(channelId);
+      if (levelProperties.isProjectLevel) {
+        let channelId: string | undefined;
+        // Check subprojects first.
+        if (channel.subprojects) {
+          channelId = channel.subprojects.find(
+            ({level_id}) => level_id.toString() === sublevel.level_id
+          )?.project_id;
+        } else if (channel.labConfig) {
+          // Otherwise, check labConfig for cases where we've transitioned from a script level.
+          channelId = channel.labConfig[tab]?.channelId;
         }
+
+        if (!channelId) {
+          Lab2Registry.getInstance()
+            .getMetricsReporter()
+            .logWarning(
+              'Expected to find subproject channel ID for standalone project.'
+            );
+          continue;
+        }
+
+        projectManager = ProjectManagerFactory.getProjectManager(channelId);
       } else {
         projectManager = await ProjectManagerFactory.getProjectManagerForLevel(
           parseInt(sublevel.level_id),
           userId || undefined,
-          scriptId || undefined,
-          scriptLevelId
+          scriptId || undefined
         );
       }
 
       if (projectManager) {
-        const {sources, channel} = await projectManager.load();
-        data.initialSources = sources;
-        data.channel = channel;
+        await projectManager.load();
         data.projectManager = projectManager;
       }
-      if (sublevelProperties.appName === 'music') {
-        map[Tab.Music] = data;
-      } else if (sublevelProperties.appName === 'dance') {
-        map[
-          (sublevelProperties as DanceLevelProperties).guideMode ===
-          'aiCodeGenerate'
-            ? Tab.Dance
-            : Tab.Dancer
-        ] = data;
-      }
+      map[tab] = data;
     }
-    setPropsMap(map);
+
+    setTabDataMap(map);
     setCurrentTab(getTypedKeys(map)[0]);
     dispatch(setIsLoading(false));
   }, [
     levelProperties,
+    channel.labConfig,
     channel.subprojects,
     userId,
     scriptId,
-    scriptLevelId,
     getLevelPropertiesPath,
     dispatch,
+    tabDataMap,
   ]);
+
+  // Clear out tab data when switching levels.
+  useEffect(() => {
+    setTabDataMap(undefined);
+  }, [levelProperties.id]);
+
+  useEffect(() => {
+    if (!tabDataMap) {
+      return;
+    }
+    // Update the parent channel with sublevel channel IDs once we've loaded everything.
+    const updatedLabConfig: {[key: string]: {channelId: string}} = {};
+    const updatedSubprojects: {level_id: number; project_id: string}[] = [];
+
+    for (const tab of getTypedKeys(tabDataMap)) {
+      const data = tabDataMap[tab];
+      if (!data?.projectManager) {
+        continue;
+      }
+      updatedLabConfig[tab] = {channelId: data.projectManager.getChannelId()};
+      updatedSubprojects.push({
+        level_id: data.levelProperties.id,
+        project_id: data.projectManager.getChannelId(),
+      });
+      data.projectManager?.addSaveSuccessListener(() => {
+        Lab2Registry.getInstance()
+          .getProjectManager()
+          ?.updateChannel({updatedAt: new Date().toISOString()}, true);
+      });
+    }
+    const channelUpdate: Partial<Channel> = {
+      labConfig: updatedLabConfig,
+    };
+    if (levelProperties.isProjectLevel && !channel.subprojects) {
+      // Also update the subprojects in the specific case where we're
+      // viewing a project created from a script level in a standalone context.
+      channelUpdate.subprojects = updatedSubprojects;
+    }
+    Lab2Registry.getInstance()
+      .getProjectManager()
+      ?.updateChannel(channelUpdate, true);
+  }, [tabDataMap, channel.subprojects, levelProperties.isProjectLevel]);
 
   // Default to dark mode for this experience.
   const {setTheme} = useTheme();
@@ -188,16 +254,47 @@ const MusicDanceAi: React.FC<MusicDanceAiProps> = ({
     loadData();
   }, [loadData]);
 
-  // Delay rendering each tab until we see it for the first time to avoid UI issues (ex: Music Lab pack dialog locking focus while hidden).
-  const [seenTabs, setSeenTabs] = useState<Set<Tab>>(new Set());
-  useEffect(() => {
-    if (currentTab) {
-      setSeenTabs(prevSeenTabs => new Set(prevSeenTabs).add(currentTab));
-    }
-  }, [currentTab]);
-
-  if (!currentTab) {
+  if (!tabDataMap || !currentTab) {
     return null;
+  }
+
+  const tabData = tabDataMap[currentTab];
+  const LabView =
+    tabData && lab2EntryPoints[tabData?.levelProperties.appName]?.view;
+
+  if (!LabView) {
+    console.error('Invalid state: selected tab without data');
+    return null;
+  }
+
+  const labProps = {
+    ...tabData,
+    initialSources: tabData.projectManager?.getLastSource(),
+    channel: tabData.projectManager?.getLastChannel(),
+  };
+
+  if (getIsShareView()) {
+    // Present the Dance share UI in share view.
+    const danceProps = tabDataMap[Tab.Dance];
+    if (!danceProps) {
+      dispatch(
+        setPageError({
+          errorMessage:
+            'Missing required dance level in Music Dance AI project',
+        })
+      );
+      return null;
+    }
+    const DanceView = lab2EntryPoints.dance.view;
+    return (
+      <ParentLevelPropertiesContext.Provider value={levelProperties}>
+        <div className={styles.container}>
+          <Suspense fallback={<Loading isLoading={true} />}>
+            <DanceView {...danceProps} />
+          </Suspense>
+        </div>
+      </ParentLevelPropertiesContext.Provider>
+    );
   }
 
   return (
@@ -205,7 +302,7 @@ const MusicDanceAi: React.FC<MusicDanceAiProps> = ({
       <div className={styles.container}>
         <div className={styles.tabSwitcher}>
           {Object.values(Tab).map(tab => {
-            const disabled = !propsMap[tab];
+            const disabled = !tabDataMap[tab];
             return (
               <button
                 type="button"
@@ -227,37 +324,15 @@ const MusicDanceAi: React.FC<MusicDanceAiProps> = ({
           })}
         </div>
         <div className={styles.labsContainer}>
-          {Array.from(seenTabs).map(tab => {
-            const sublevelProps = propsMap[tab];
-            const LabView =
-              sublevelProps &&
-              lab2EntryPoints[sublevelProps?.levelProperties.appName]?.view;
-            const hidden = tab !== currentTab;
-            return (
-              LabView && (
-                <div
-                  className={classNames(
-                    styles.labContainer,
-                    hidden && styles.hidden
-                  )}
-                  key={tab}
-                  ref={el => {
-                    if (el) {
-                      el.inert = hidden;
-                    }
-                  }}
-                >
-                  <Suspense fallback={<Loading isLoading={true} />}>
-                    <LabView {...sublevelProps} />
-                  </Suspense>
-                </div>
-              )
-            );
-          })}
+          <div className={classNames(styles.labContainer)}>
+            <Suspense fallback={<Loading isLoading={true} />}>
+              <LabView {...labProps} />
+            </Suspense>
+          </div>
         </div>
       </div>
     </ParentLevelPropertiesContext.Provider>
   );
 };
 
-export default MusicDanceAi;
+export default memo(MusicDanceAi);

--- a/apps/src/bubbleChoice/customModes/MusicDanceAi/MusicDanceAi.tsx
+++ b/apps/src/bubbleChoice/customModes/MusicDanceAi/MusicDanceAi.tsx
@@ -326,7 +326,7 @@ const MusicDanceAi: React.FC<MusicDanceAiProps> = ({
         <div className={styles.labsContainer}>
           <div className={classNames(styles.labContainer)}>
             <Suspense fallback={<Loading isLoading={true} />}>
-              <LabView {...labProps} />
+              <LabView {...labProps} key={currentTab} />
             </Suspense>
           </div>
         </div>

--- a/apps/src/lab2/projects/ProjectManager.ts
+++ b/apps/src/lab2/projects/ProjectManager.ts
@@ -254,6 +254,24 @@ export default class ProjectManager {
     return await this.enqueueSaveOrSave(forceSave, /* forceNewVersion */ false);
   }
 
+  async updateChannel(channelUpdates: Partial<Channel>, forceSave = false) {
+    if (this.destroyed || !this.lastChannel) {
+      // If we have already been destroyed or the channel does not exist,
+      // don't attempt to update.
+      return this.getNoopResponseAndSendSaveNoopEvent();
+    }
+    if (!this.channelToSave) {
+      this.channelToSave = JSON.parse(
+        JSON.stringify(this.lastChannel)
+      ) as Channel;
+    }
+    this.channelToSave = {
+      ...this.channelToSave,
+      ...channelUpdates,
+    };
+    return await this.enqueueSaveOrSave(forceSave, /* forceNewVersion */ false);
+  }
+
   /**
    * Returns a share URL for the current project.
    *
@@ -395,6 +413,16 @@ export default class ProjectManager {
 
   setLastSource(lastSource: ProjectSources) {
     this.lastSource = JSON.stringify(lastSource);
+  }
+
+  getLastSource() {
+    return this.lastSource
+      ? (JSON.parse(this.lastSource) as ProjectSources)
+      : undefined;
+  }
+
+  getLastChannel() {
+    return this.lastChannel;
   }
 
   getShouldCaptureThumbnail() {

--- a/apps/src/music/redux/musicRedux.ts
+++ b/apps/src/music/redux/musicRedux.ts
@@ -315,10 +315,15 @@ export const getCurrentlyPlayingBlockIds = (state: {
   return playingBlockIds;
 };
 
+/**
+ * @deprecated TODO: derive block mode from props.
+ */
 export const getBlockMode = (state: RootState): ValueOf<typeof BlockMode> => {
   const {initialSources, levelProperties} = state.lab;
   return (
-    (initialSources?.labConfig?.music.blockMode as ValueOf<typeof BlockMode>) ||
+    (initialSources?.labConfig?.music?.blockMode as ValueOf<
+      typeof BlockMode
+    >) ||
     (levelProperties?.levelData as MusicLevelData | undefined)?.blockMode ||
     BlockMode.SIMPLE2
   );


### PR DESCRIPTION
A few fixes and logic updates for the freeplay Music Dance AI level to prepare for share/view/remix functionality.

- Fixes an issue where updates on one tab wouldn't be reflected on another tab. This is because the assets that are shared between tabs (generated dancer and music code) are loaded in by the level when it first mounts and not expected to change. Previously, we were keeping each tab rendered in the background which means that they would only ever use the first value they were loaded with. To fix this, we go back to rendering each tab individually, so the generated dancer and music code are refreshed when switching tabs. This does mean that the transition isn't quite as seamless, but since we're still not rendering the sublevels through the lab2 system, we don't see a full page fade.
- We now save a mapping of tab type -> sublevel channel ID to the parent project's `labConfig`. This is to support share and remix functionality which is a little tricky due to the multi-project set up. More details and background below.
- We also save/update the channel's `subprojects` entry specifically on standalone projects that are derived from script levels, again to support remix functionality. More on this below as well.

### Handling Share, View & Remix

Managing four channel IDs instead of one makes sharing, viewing, and remixing a little tricky 🙂 on standard project types, when viewing or sharing a freeplay project, we just take the channel ID for the freeplay project and present it on the standalone project level (projects/\<project type\>/\<channel ID\>). In this multi-project case, the freeplay level has a channel ID for the parent level, as well as channel IDs that correspond to each sublevel. When we share/view by navigating to projects/music_dance_ai/\<channel ID\>, we only have access to the parent channel ID and not the child IDs. To solve this, I decided to save a mapping of tab name ('Dance'/'Music'/'Dancer') to sublevel channel ID in the project's `labConfig` entry. This kind of data is highly specific to this project type, but I figured that labConfig is the place to put specific data like this. When we load the project on the standalone project level, we use the `labConfig` entry to look up the child project IDs.

<img width="351" height="197" alt="Screenshot 2025-11-05 at 10 13 45 PM" src="https://github.com/user-attachments/assets/aa0ba3fe-c69f-4274-8f6a-4cb015d03325" />

Remixing is a little more challenging. Coming from the standalone project level is relatively straightforward; we already create a `subprojects` mapping for new standalone projects of this type that maps sublevel ID -> channel ID. When we remix then, we just need to remix each subproject channel ID along with the parent channel ID.

However, in the scenario where we've come from a script level project above, we don't have this subproject mapping because the level IDs on the freeplay are different than the project level. What I opted to do here is just create the subprojects mapping on the client and save it to the channel, specifically for this case where we're viewing a project created on a script level, but in a standalone level context. There is an implication here that the channel associated with the script level will have data saved to it that has to do with the standalone project level and doesn't apply to the script level. It doesn't affect any behavior because on the script level, we will always retrieve the channel IDs based on the level and user instead of the `subprojects` mapping. It felt like an acceptable tradeoff at this stage even though it's a mismatched.

<img width="349" height="249" alt="Screenshot 2025-11-05 at 10 13 54 PM" src="https://github.com/user-attachments/assets/409fadb0-3b21-4451-a4ed-154f9765c3ea" />

All this is quite complex and probably easier to talk through in person with some concrete examples, so I'm happy to dive into this further!

## Testing story
- Tested this on the final freeplay level and viewing/sharing the channel ID.
