### PR TITLE
hoai2025: music start over fix

### DIFF
--- a/apps/src/music/views/MusicView.jsx
+++ b/apps/src/music/views/MusicView.jsx
@@ -73,6 +73,7 @@ import {
   getBlockMode,
   addPlaybackEvents,
   setCodeToLoad,
+  setAiGenerateState,
 } from '../redux/musicRedux';
 import {Key} from '../utils/Notes';
 import SoundUploader from '../utils/SoundUploader';
@@ -137,6 +138,7 @@ class UnconnectedMusicView extends React.Component {
     scriptName: PropTypes.string,
     clearCodeToLoad: PropTypes.func,
     sendAttemptReport: PropTypes.func,
+    setAiGenerateState: PropTypes.func,
     isFirstAttempt: PropTypes.bool,
   };
 
@@ -539,6 +541,9 @@ class UnconnectedMusicView extends React.Component {
       this.props.setPackId(null);
       this.library.setCurrentPackId(null);
     }
+
+    // In case we are showing the music generation Guide, reset its state.
+    this.props.setAiGenerateState('clearing');
 
     // In Start mode, load sources from the default JSON.
     if (isStartMode) {
@@ -1074,6 +1079,7 @@ const MusicView = connect(
     clearCodeToLoad: () => dispatch(setCodeToLoad(undefined)),
     sendAttemptReport: () =>
       dispatch(sendProgressReport('music', TestResults.LEVEL_STARTED)),
+    setAiGenerateState: state => dispatch(setAiGenerateState(state)),
   })
 )(UnconnectedMusicView);
 

--- a/apps/src/music/views/PackDialog.tsx
+++ b/apps/src/music/views/PackDialog.tsx
@@ -19,7 +19,7 @@ import {AnalyticsContext} from '../context';
 import musicI18n from '../locale';
 import MusicLibrary, {SoundFolder} from '../player/MusicLibrary';
 import MusicPlayer from '../player/MusicPlayer';
-import {setPackId, setAiGenerateState} from '../redux/musicRedux';
+import {setPackId} from '../redux/musicRedux';
 
 import styles from './PackDialog.module.scss';
 
@@ -176,7 +176,6 @@ const PackDialog: React.FunctionComponent<PackDialogProps> = ({
 
       player.cancelPreviews();
       dispatch(setPackId(packId));
-      dispatch(setAiGenerateState('none'));
       library.setCurrentPackId(packId);
       setSelectedFolderId(null);
       analyticsReporter?.onPackSelected(packId);


### PR DESCRIPTION
Prior to this fix, using the Start Over button for AI generated music would reset the Guide to its initial prompt UI when the level allowed pack selection, but wouldn't reset properly if the level had a fixed pack.  Now, using the Start Over button always resets the Guide to its initial prompt UI.

This is slightly redundant in that the Guide also sometimes initiates a call to `ClearCode`, and already calls `setAiGenerateState('clearing')` in those situations, but this change doesn't appear to regress those flows.