### PR TITLE
Enable webpack filesystem cache

### DIFF
--- a/apps/package.json
+++ b/apps/package.json
@@ -128,7 +128,7 @@
     "grunt-newer": "^1.3.0",
     "grunt-notify": "0.4.5",
     "grunt-sass": "3.1.0",
-    "grunt-webpack": "^6.0.0",
+    "grunt-webpack": "^7.0.0",
     "history": "^2.0.1",
     "identity-obj-proxy": "^3.0.0",
     "jest": "^29.7.0",

--- a/apps/webpack.config.js
+++ b/apps/webpack.config.js
@@ -765,6 +765,16 @@ function createWebpackConfig({
           },
         }
       : undefined,
+    // FIXME: before this will actually do anything, upstream grunt-webpack needs
+    // to merge my PR: https://github.com/webpack/grunt-webpack/pull/250
+    //
+    // There's a bug that keeps grunt-webpack from working correctly with webpack 5's filesystem cache.
+    //
+    // Fork available at: https://github.com/code-dot-org/grunt-webpack/tree/call-webpack-compiler-close
+    cache: {
+      type: 'filesystem',
+      cacheDirectory: p('build/webpack-cache'),
+    },
   };
 
   //////////////////////////////////////////////

--- a/apps/yarn.lock
+++ b/apps/yarn.lock
@@ -11198,7 +11198,7 @@ __metadata:
     grunt-newer: "npm:^1.3.0"
     grunt-notify: "npm:0.4.5"
     grunt-sass: "npm:3.1.0"
-    grunt-webpack: "npm:^6.0.0"
+    grunt-webpack: "npm:^7.0.0"
     hammerjs: "npm:^2.0.8"
     history: "npm:^2.0.1"
     html2canvas: "npm:^0.5.0-beta4"
@@ -17640,15 +17640,15 @@ canvg@gabelerner/canvg:
   languageName: node
   linkType: hard
 
-"grunt-webpack@npm:^6.0.0":
-  version: 6.0.0
-  resolution: "grunt-webpack@npm:6.0.0"
+"grunt-webpack@npm:^7.0.0":
+  version: 7.0.0
+  resolution: "grunt-webpack@npm:7.0.0"
   dependencies:
     deep-for-each: "npm:^3.0.0"
-    lodash: "npm:^4.17.21"
+    webpack-merge: "npm:^6.0.1"
   peerDependencies:
     webpack: ^5.0.0
-  checksum: 10/9e075769bd1e49990b8e54d45ddd8ba0fadbf4ba9ee4f2aa92a8af42155c3324e810e2231471fad2f1d033d565fc44431709274cdf846c736b27fb8e11fa5f82
+  checksum: 10/049551ac476fbdc993550bd0a00ea40fce673bfeb647535317b41b0c34f0c9a694ceca2bb9fa5e6e13d1f76cae9f7dcbec076a4b2ee62169c234110d110dc111
   languageName: node
   linkType: hard
 
@@ -31300,6 +31300,17 @@ canvg@gabelerner/canvg:
   languageName: node
   linkType: hard
 
+"webpack-merge@npm:^6.0.1":
+  version: 6.0.1
+  resolution: "webpack-merge@npm:6.0.1"
+  dependencies:
+    clone-deep: "npm:^4.0.1"
+    flat: "npm:^5.0.2"
+    wildcard: "npm:^2.0.1"
+  checksum: 10/39ab911c26237922295d9b3d0617c8ea0c438c35a3b21b05506616a10423f5ece1962bccbedec932c5db61af57999b6d055d56d1f1755c63e2701bd4a55c3887
+  languageName: node
+  linkType: hard
+
 "webpack-notifier@npm:^1.15.0":
   version: 1.15.0
   resolution: "webpack-notifier@npm:1.15.0"
@@ -31696,7 +31707,7 @@ canvg@gabelerner/canvg:
   languageName: node
   linkType: hard
 
-"wildcard@npm:^2.0.0":
+"wildcard@npm:^2.0.0, wildcard@npm:^2.0.1":
   version: 2.0.1
   resolution: "wildcard@npm:2.0.1"
   checksum: 10/e0c60a12a219e4b12065d1199802d81c27b841ed6ad6d9d28240980c73ceec6f856771d575af367cbec2982d9ae7838759168b551776577f155044f5a5ba843c


### PR DESCRIPTION
Before this will do anything, upstream grunt-webpack will need to merge this PR: https://github.com/webpack/grunt-webpack/pull/250, and we'll need to bump the version to whatever grunt-webpack release includes our fix.

Turns on in webpack.config.js:
```
{ cache: { type: 'filesystem' } }
```
