### PR TITLE
Refine Engineer Permissions to Production AWS Data Resources

### DIFF
--- a/aws/cloudformation/iam.yml.erb
+++ b/aws/cloudformation/iam.yml.erb
@@ -310,6 +310,7 @@ roles = {
       'arn:aws:iam::aws:policy/PowerUserAccess',
       'arn:aws:iam::aws:policy/IAMReadOnlyAccess',
       '!Ref EngineerSecretsPolicy',
+      '!Ref EngineerDataPolicy',
       '!Ref CloudformationPassRolePolicy',
     ]
   },
@@ -661,6 +662,93 @@ roles.each do |name, config| %>
             Resource:
               - !Sub arn:aws:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:development/cdo/*
               - !Sub arn:aws:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:adhoc/cdo/*
+
+  EngineerDataPolicy:
+      Type: AWS::IAM::ManagedPolicy
+      Properties:
+        ManagedPolicyName: EngineersDataPolicy
+        Path: /engineering/
+        Description: Prevent accidental or malicious deletion of production data in S3, Aurora databases, etc.
+        PolicyDocument:
+          Version: 2012-10-17
+          Statement:
+            - Sid: DenyS3BucketDestructiveOperations
+              Effect: Deny
+              Action:
+                - s3:DeleteBucket
+                - s3:DeleteBucketPolicy
+                - s3:DeleteBucketWebsite
+                - s3:PutBucketAcl
+                - s3:PutBucketPolicy
+                - s3:PutBucketPublicAccessBlock
+                - s3:PutLifecycleConfiguration
+
+                # S3 Batch Operations - prevent mass operations
+                - s3:CreateJob
+                - s3:UpdateJobPriority
+                - s3:UpdateJobStatus
+
+                - s3:PutBucketVersioning
+                - s3:PutReplicationConfiguration
+                - s3:PutBucketCORS
+                - s3:PutBucketLogging
+                - s3:PutEncryptionConfiguration
+                - s3:BypassGovernanceRetention
+                - s3:DeleteObjectVersionTagging
+                - s3:PutObjectLegalHold
+                - s3:PutObjectRetention
+              Resource: '*'
+            - Sid: DenyDestructiveRDSOperationsOnProduction
+              Effect: Deny
+              Action:
+                - rds:DeleteDBInstance
+                - rds:DeleteDBCluster
+                - rds:DeleteDBSnapshot
+                - rds:DeleteDBClusterSnapshot
+                - rds:DeleteDBInstanceAutomatedBackup
+
+                - rds:StopDBInstance
+                - rds:StopDBCluster
+                - rds:RebootDBInstance
+                - rds:RebootDBCluster
+
+                - rds:ModifyDBInstance
+                - rds:ModifyDBCluster
+                - rds:ModifyDBParameterGroup
+                - rds:ModifyDBClusterParameterGroup
+                - rds:ResetDBParameterGroup
+                - rds:ResetDBClusterParameterGroup
+
+                - rds:RestoreDBInstanceFromDBSnapshot
+                - rds:RestoreDBClusterFromSnapshot
+                - rds:RestoreDBInstanceToPointInTime
+                - rds:RestoreDBClusterToPointInTime
+
+                - rds:FailoverDBCluster
+                - rds:BacktrackDBCluster
+                - rds:ModifyCurrentDBClusterCapacity
+
+              Resource:
+                - !Sub 'arn:aws:rds:*:${AWS::AccountId}:db:*'
+                - !Sub 'arn:aws:rds:*:${AWS::AccountId}:cluster:*'
+                - !Sub 'arn:aws:rds:*:${AWS::AccountId}:snapshot:*'
+                - !Sub 'arn:aws:rds:*:${AWS::AccountId}:cluster-snapshot:*'
+              Condition:
+                StringEquals:
+                  'aws:ResourceTag/environment': 'production'
+            - Sid: DenyTagModificationOnProductionRDS
+              Effect: Deny
+              Action:
+                - rds:RemoveTagsFromResource
+                - rds:AddTagsToResource
+              Resource:
+                - !Sub 'arn:aws:rds:*:${AWS::AccountId}:db:*'
+                - !Sub 'arn:aws:rds:*:${AWS::AccountId}:cluster:*'
+                - !Sub 'arn:aws:rds:*:${AWS::AccountId}:snapshot:*'
+                - !Sub 'arn:aws:rds:*:${AWS::AccountId}:cluster-snapshot:*'
+              Condition:
+                StringEquals:
+                  'aws:ResourceTag/environment': 'production'
 
   ContributorSecretsPolicy:
     Type: AWS::IAM::ManagedPolicy


### PR DESCRIPTION
https://codedotorg.atlassian.net/browse/INF-1889

Discuss these changes in Slack.

## Testing story
```bash
code-dot-org $ export AWS_PROFILE=codeorg-admin
code-dot-org $ bundle exec rake stack:iam:validate RAILS_ENV=production ADMIN=true

Finished stack:iam:environment (less than a minute)
Pending update for stack `IAM`:
Add EngineerDataPolicy [AWS::IAM::ManagedPolicy]
Modify EngineeringFullAccessRole [AWS::IAM::Role] Properties (ManagedPolicyArns, ManagedPolicyArns)
Finished stack:iam:validate (less than a minute)
```


## Deployment strategy

```bash
code-dot-org $ export AWS_PROFILE=codeorg-admin
code-dot-org $ bundle exec rake stack:iam:start RAILS_ENV=production ADMIN=true
```



## Follow-up work
<!--  List any clean-up or technical debt that will be addressed in future work.
      - Include Jira links where applicable.
      - Are there any known limitations or improvements planned? -->



## Privacy
<!--  How does this change impact Student & Teacher privacy?
      - Does this collect, use, share, or modify PII, either new or existing? -->



## Security
<!--  How does this change impact our security surface-area?
      - Do API's touched have the right auth?
      - Do infra changes impact our attack surface or encryption?
-->



## Caching
<!--  How does this change impact caching behavior?
      - Are cache keys or invalidation strategies affected?
      - Will this require cache warming or invalidation after deployment? -->



## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
