### PR TITLE
fix(poste): add body param

### DIFF
--- a/lib/test/test_deliverer.rb
+++ b/lib/test/test_deliverer.rb
@@ -45,7 +45,9 @@ class DelivererTest < Minitest::Test
       id: 1,
       contact_id: contact[:id],
       message_id: message_id,
-      params: {}.to_json
+      params: {
+        body: 'This is a test email'
+      }.to_json
     }
     @deliverer.send(delivery)
     assert_match "To: #{email}", @fake_smtp.message


### PR DESCRIPTION
Updated the delivery params in the DelivererTest to include a body for the test email, ensuring the message is properly formatted for assertions.