### PR TITLE
Ensure tag is copied from a database cluster to its Snapshots

### DIFF
--- a/aws/cloudformation/components/database.yml.erb
+++ b/aws/cloudformation/components/database.yml.erb
@@ -331,6 +331,7 @@
       EnableIAMDatabaseAuthentication: true
       VpcSecurityGroupIds: [!ImportValue VPC-DBSecurityGroup]
       DBSubnetGroupName: !ImportValue VPC-DBSubnetGroup
+      CopyTagsToSnapshot: true
       EnableCloudwatchLogsExports:
         - general
         - audit


### PR DESCRIPTION
Support #69364 by ensuring a Database Cluster's Tags are copied to its Snapshots.

## Testing story
`bundle exec rake adhoc:start RAILS_ENV=adhoc DATABASE=true STACK_NAME=adhoc-database-tag-to-snapshot`

confirmed that Tags were copied to the adhoc's cluster's Snapshot
<img width="744" height="634" alt="image" src="https://github.com/user-attachments/assets/c06bdfc2-be22-4476-ab5a-dbe7dd6e6822" />


## Deployment strategy

Production database cluster was provisioned manually. Manually configure this change on production.



## Follow-up work
<!--  List any clean-up or technical debt that will be addressed in future work.
      - Include Jira links where applicable.
      - Are there any known limitations or improvements planned? -->



## Privacy
<!--  How does this change impact Student & Teacher privacy?
      - Does this collect, use, share, or modify PII, either new or existing? -->



## Security
<!--  How does this change impact our security surface-area?
      - Do API's touched have the right auth?
      - Do infra changes impact our attack surface or encryption?
-->



## Caching
<!--  How does this change impact caching behavior?
      - Are cache keys or invalidation strategies affected?
      - Will this require cache warming or invalidation after deployment? -->



## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
