### PR TITLE
Lab2: reorder and style teachers only tab in Resource Panel

### DIFF
--- a/apps/src/lab2/views/components/Instructions/ResourcePanel/index.tsx
+++ b/apps/src/lab2/views/components/Instructions/ResourcePanel/index.tsx
@@ -63,10 +63,6 @@ interface VersionHistoryProps {
 const tabInfo: {[key in Tabs]: {title: string; icon: string}} = {
   [Tabs.Instructions]: {title: commonI18n.instructions(), icon: 'info-circle'},
   [Tabs.AiTutor]: {title: commonI18n.aiTutor(), icon: 'ai-head-solid'},
-  [Tabs.TeachersOnly]: {
-    title: commonI18n.teachingTips(),
-    icon: 'chalkboard-teacher',
-  },
   [Tabs.StudentRubric]: {
     title: commonI18n.rubric(),
     icon: 'clipboard-list',
@@ -78,6 +74,10 @@ const tabInfo: {[key in Tabs]: {title: string; icon: string}} = {
   [Tabs.Validation]: {
     title: commonI18n.validation(),
     icon: 'clipboard-check',
+  },
+  [Tabs.TeachersOnly]: {
+    title: commonI18n.teachingTips(),
+    icon: 'chalkboard-teacher',
   },
 };
 
@@ -203,19 +203,6 @@ const ResourcePanel: React.FC<ResourcePanelProps> = ({
       );
     }
 
-    if (
-      isUserTeacher &&
-      (levelProperties.teacherMarkdown ||
-        levelProperties.predictSettings?.solution)
-    ) {
-      tabMap[Tabs.TeachersOnly] = (
-        <ForTeachersOnly
-          levelProperties={levelProperties}
-          className={styles.panelContent}
-        />
-      );
-    }
-
     if (hiddenContextCallback && aiTutorVisible) {
       tabMap[Tabs.AiTutor] = (
         <AiTutorChat
@@ -256,6 +243,19 @@ const ResourcePanel: React.FC<ResourcePanelProps> = ({
 
     if (showRubric) {
       tabMap[Tabs.StudentRubric] = <StudentRubricView />;
+    }
+
+    if (
+      isUserTeacher &&
+      (levelProperties.teacherMarkdown ||
+        levelProperties.predictSettings?.solution)
+    ) {
+      tabMap[Tabs.TeachersOnly] = (
+        <ForTeachersOnly
+          levelProperties={levelProperties}
+          className={classNames(styles.panelContent, styles.teachersOnlyTab)}
+        />
+      );
     }
 
     return tabMap;
@@ -466,7 +466,8 @@ const ResourcePanel: React.FC<ResourcePanelProps> = ({
                     <Button
                       className={classNames(
                         styles.tabButton,
-                        tab === currentTab && styles.selected
+                        tab === currentTab && styles.selected,
+                        tab === Tabs.TeachersOnly && styles.teachersOnlyTab
                       )}
                       onClick={() => onClickTab(tab)}
                       key={tab}

--- a/apps/src/lab2/views/components/Instructions/ResourcePanel/styles.module.scss
+++ b/apps/src/lab2/views/components/Instructions/ResourcePanel/styles.module.scss
@@ -49,6 +49,14 @@
     border-radius: 0;
     background-color: var(--background-neutral-secondary);
 
+    &.teachersOnlyTab {
+      background-color: var(--background-info-extra-light);
+
+      i {
+        color: var(--text-info-primary-fixed);
+      }
+    }
+
     &.selected {
       background-color: var(--background-neutral-primary);
       position: relative;
@@ -79,11 +87,22 @@
         width: 3px;
         background-color: var(--borders-brand-teal-primary);
       }
+
+      &.teachersOnlyTab {
+        i {
+          color: var(--text-info-primary-fixed);
+        }
+
+        &::before {
+          background-color: var(--text-info-primary-fixed);
+        }
+      }
     }
 
     i {
       color: var(--text-neutral-quaternary);
       font-size: 1.25rem;
+      width: auto;
     }
 
     &:hover:not(.selected) {
@@ -91,6 +110,10 @@
 
       i {
         color: var(--text-neutral-tertiary);
+      }
+
+      &.teachersOnlyTab i {
+        color: var(--text-info-primary-fixed);
       }
     }
 
@@ -127,6 +150,7 @@
       }
     }
   }
+
   .bottomTabs {
     display: flex;
     flex-direction: column;


### PR DESCRIPTION
Moves the teachers only tab to the bottom of the list in the Resources Panel used in Lab 2 labs. Also applies specific styling so it stands out from the student tabs.

## Links
Jira ticket: [AFL-334](https://codedotorg.atlassian.net/browse/AFL-334)

## Testing story
Tested locally

----

## Before


https://github.com/user-attachments/assets/0e37daf3-4c78-44ca-859c-7b8b09747859



## After

### Light


https://github.com/user-attachments/assets/2acdaac1-11b4-428a-98cd-c127848fa6b3



### Dark


https://github.com/user-attachments/assets/bff8ac90-00c3-4aac-84bc-b59a460b515e

