### PR TITLE
fix(storybook): ensure component lib dep

### DIFF
--- a/frontend/apps/design-system-storybook/decorators/MuiDecorator.tsx
+++ b/frontend/apps/design-system-storybook/decorators/MuiDecorator.tsx
@@ -1,9 +1,10 @@
 import {CssBaseline, ThemeProvider} from '@mui/material';
 import {withThemeFromJSXProvider} from '@storybook/addon-themes';
+import {Decorator, StoryContext} from '@storybook/react-webpack5';
 
 import {CdoTheme} from '@code-dot-org/component-library/themes';
 
-export default withThemeFromJSXProvider({
+const BaseMuiDecorator = withThemeFromJSXProvider({
   themes: {
     'code.org': CdoTheme,
   },
@@ -11,3 +12,24 @@ export default withThemeFromJSXProvider({
   Provider: ThemeProvider,
   GlobalStyles: CssBaseline,
 });
+
+/**
+ * Conditionally applies the MUI ThemeProvider decorator based on the
+ * `useMui` parameter in the story's context. By default, MUI is not applied.
+ *
+ * As more components are migrated to MUI, we can flip the default to true and
+ * only disable MUI for non-MUI stories.
+ */
+const MuiDecorator: Decorator = (Story, context: StoryContext) => {
+  const enabled = context.parameters?.useMui ?? false;
+
+  if (!enabled) {
+    // Just render the story without the theme wrapper
+    return <Story />;
+  }
+
+  // Delegate to the actual MUI theme decorator
+  return BaseMuiDecorator(Story, context);
+};
+
+export default MuiDecorator;

--- a/frontend/apps/design-system-storybook/package.json
+++ b/frontend/apps/design-system-storybook/package.json
@@ -37,6 +37,7 @@
   },
   "devDependencies": {
     "@applitools/eyes-storybook": "^3.56.0",
+    "@code-dot-org/component-library": "workspace:*",
     "@code-dot-org/component-library-styles": "workspace:*",
     "@code-dot-org/fonts": "workspace:*",
     "@code-dot-org/lint-config": "workspace:*",

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -1144,6 +1144,7 @@ __metadata:
   resolution: "@code-dot-org/design-system-storybook@workspace:apps/design-system-storybook"
   dependencies:
     "@applitools/eyes-storybook": "npm:^3.56.0"
+    "@code-dot-org/component-library": "workspace:*"
     "@code-dot-org/component-library-styles": "workspace:*"
     "@code-dot-org/fonts": "workspace:*"
     "@code-dot-org/lint-config": "workspace:*"


### PR DESCRIPTION
When the marketing app was removed, the indirect build of the component
library was also removed. This causes the design system storybook to
fail to build if the component library was not cached. Explicitly call
out this dependency instead.