### PR TITLE
chore(vite): use CssBaseline for CSS reset

### DIFF
--- a/frontend/apps/studio/src/App.tsx
+++ b/frontend/apps/studio/src/App.tsx
@@ -1,6 +1,5 @@
-import './global.css';
 import '@code-dot-org/component-library-styles/colors.scss';
-import {ThemeProvider, Typography} from '@mui/material';
+import {CssBaseline, ThemeProvider, Typography} from '@mui/material';
 import CdoLogo from '@/config/brand/assets/cdo-logo-inverse.webp';
 
 import {LinkButton} from '@code-dot-org/component-library/button';
@@ -20,6 +19,8 @@ const SIGNED_OUT_MENU_ITEMS = [
 function App() {
   return (
     <ThemeProvider theme={CdoTheme}>
+      {/* Resets browser CSS defaults (e.g. body margin) using MUI defaults */}
+      <CssBaseline />
       <Header
         logoImageUrl={CdoLogo}
         brandName="Code.org"

--- a/frontend/apps/studio/src/global.css
+++ b/frontend/apps/studio/src/global.css
@@ -1,3 +1,0 @@
-body {
-    margin: 0;
-}


### PR DESCRIPTION
Deleted global CSS file and integrated CssBaseline from MUI to reset browser CSS defaults.

Documentation: https://mui.com/material-ui/react-css-baseline/

-- 

## Testing

Verified that margins are removed on body by default.

<img width="609" height="179" alt="image" src="https://github.com/user-attachments/assets/300ce61b-e0b6-4062-b81c-b3e7159674af" />
