### PR TITLE
hoai2025: v0 congrats dialog

### DIFF
--- a/apps/src/lab2/constants.ts
+++ b/apps/src/lab2/constants.ts
@@ -1,4 +1,4 @@
-import {AppName} from './types';
+import {AppName, ProjectType} from './types';
 
 export const SOURCE_FILE = 'main.json';
 
@@ -18,7 +18,12 @@ export const START_SOURCES = 'start_sources';
 export const TOOLBOX_BLOCKS = 'toolbox_blocks';
 export const EDIT_EXEMPLAR = 'edit_exemplar';
 
-export const LABS_USING_NEW_SHARE_DIALOG = ['music', 'pythonlab', 'weblab2'];
+export const PROJECT_TYPES_USING_NEW_SHARE_DIALOG: ProjectType[] = [
+  'music',
+  'pythonlab',
+  'weblab2',
+  'music_dance_ai',
+];
 
 // Text-based labs that are currently supported by lab2.
 export const TEXT_BASED_LABS: AppName[] = ['aichat', 'pythonlab', 'weblab2'];

--- a/apps/src/lab2/types.ts
+++ b/apps/src/lab2/types.ts
@@ -314,7 +314,8 @@ export type ProjectType =
   | 'playlab'
   | 'playlab_k1'
   | 'sports'
-  | 'basketball';
+  | 'basketball'
+  | 'music_dance_ai';
 
 export type AppName = keyof typeof lab2EntryPoints;
 
@@ -406,3 +407,5 @@ export interface LabProps<
   initialSources?: U;
   channel?: Channel;
 }
+
+export type ShareDialogId = 'hoc2024' | 'hoai2025';

--- a/apps/src/lab2/types.ts
+++ b/apps/src/lab2/types.ts
@@ -192,7 +192,7 @@ export interface LevelProperties {
   submittable?: boolean;
   disableEditRunForSubmission?: boolean;
   finishUrl?: string;
-  finishDialog?: string;
+  finishDialog?: ShareDialogId;
   offerBrowserTts?: boolean;
   useSecondaryFinishButton?: boolean;
   // Python Lab/Codebridge specific properties

--- a/apps/src/lab2/views/Lab2ShareDialogWrapper.tsx
+++ b/apps/src/lab2/views/Lab2ShareDialogWrapper.tsx
@@ -4,7 +4,7 @@ import {useSelector} from 'react-redux';
 import ShareDialogLegacy from '@cdo/apps/code-studio/components/ShareDialog';
 import {hideShareDialog} from '@cdo/apps/code-studio/components/shareDialogRedux';
 import popupWindow from '@cdo/apps/code-studio/popup-window';
-import {LABS_USING_NEW_SHARE_DIALOG} from '@cdo/apps/lab2/constants';
+import {PROJECT_TYPES_USING_NEW_SHARE_DIALOG} from '@cdo/apps/lab2/constants';
 import {EVENTS, PLATFORMS} from '@cdo/apps/metrics/AnalyticsConstants';
 import analyticsReporter from '@cdo/apps/metrics/AnalyticsReporter';
 import {MetricEvent} from '@cdo/apps/metrics/events';
@@ -17,6 +17,8 @@ import {
 import SubmitProjectDialog from '@cdo/apps/templates/projects/submitProjectDialog/SubmitProjectDialog';
 import {NetworkError} from '@cdo/apps/util/HttpClient';
 import {useAppDispatch, useAppSelector} from '@cdo/apps/util/reduxHooks';
+
+import {ShareDialogId} from '../types';
 
 import ShareDialog from './dialogs/ShareDialog';
 
@@ -109,7 +111,7 @@ const Lab2ShareDialogWrapper: React.FunctionComponent<
     return null;
   }
 
-  if (LABS_USING_NEW_SHARE_DIALOG.includes(projectType)) {
+  if (PROJECT_TYPES_USING_NEW_SHARE_DIALOG.includes(projectType)) {
     return dialogPanel === 'share' ? (
       <ShareDialog
         dialogId={shareDialogId}
@@ -150,7 +152,7 @@ const Lab2ShareDialogWrapper: React.FunctionComponent<
 };
 
 interface Lab2ShareDialogWrapperProps {
-  shareDialogId?: string;
+  shareDialogId?: ShareDialogId;
   shareUrl: string;
   finishUrl?: string;
 }

--- a/apps/src/lab2/views/dialogs/ShareDialog.tsx
+++ b/apps/src/lab2/views/dialogs/ShareDialog.tsx
@@ -11,16 +11,18 @@ import FocusLock from 'react-focus-lock';
 import {hideShareDialog} from '@cdo/apps/code-studio/components/shareDialogRedux';
 import DCDO from '@cdo/apps/dcdo';
 import Lab2Registry from '@cdo/apps/lab2/Lab2Registry';
-import {ProjectType} from '@cdo/apps/lab2/types';
+import {ProjectType, ShareDialogId} from '@cdo/apps/lab2/types';
 import {EVENTS, PLATFORMS} from '@cdo/apps/metrics/AnalyticsConstants';
 import analyticsReporter from '@cdo/apps/metrics/AnalyticsReporter';
 import {SignInState} from '@cdo/apps/templates/currentUserRedux';
 import {SubmissionStatusType} from '@cdo/apps/templates/projects/submitProjectDialog/submitProjectApi';
+import {commonI18n as i18n} from '@cdo/apps/types/locale';
 import copyToClipboard from '@cdo/apps/util/copyToClipboard';
 import {useAppDispatch, useAppSelector} from '@cdo/apps/util/reduxHooks';
 import trackEvent from '@cdo/apps/util/trackEvent';
 import {ProjectSubmissionStatus} from '@cdo/generated-scripts/sharedConstants';
-import i18n from '@cdo/locale';
+
+import HoaiCongrats from './finishDialogs/HoaiCongrats';
 
 import moduleStyles from './share-dialog.module.scss';
 
@@ -142,7 +144,7 @@ const SubmitButtonInfo: React.FunctionComponent<{
  */
 
 const ShareDialog: React.FunctionComponent<{
-  dialogId?: string;
+  dialogId?: ShareDialogId;
   shareUrl: string;
   finishUrl?: string;
   projectType: ProjectType;
@@ -188,6 +190,16 @@ const ShareDialog: React.FunctionComponent<{
   // ThemeProvider (the header is in its own tree). We copy the lab theme to the registry
   // in Lab2Wrapper.
   const theme = Lab2Registry.getInstance().getTheme();
+
+  if (finishUrl && dialogId === 'hoai2025') {
+    return (
+      <HoaiCongrats
+        handleClose={handleClose}
+        finishUrl={finishUrl}
+        theme={theme}
+      />
+    );
+  }
 
   return sharingDisabled() ? (
     <div data-theme={theme}>

--- a/apps/src/lab2/views/dialogs/finishDialogs/HoaiCongrats.tsx
+++ b/apps/src/lab2/views/dialogs/finishDialogs/HoaiCongrats.tsx
@@ -1,0 +1,26 @@
+import {Theme} from '@code-dot-org/component-library/common/contexts';
+import Modal from '@code-dot-org/component-library/modal';
+import React from 'react';
+
+interface Props {
+  handleClose: () => void;
+  finishUrl: string;
+  theme?: Theme;
+}
+
+/**
+ * Congrats dialog shown for Hour of AI activities.
+ */
+const HoaiCongrats: React.FC<Props> = ({handleClose, finishUrl, theme}) => {
+  return (
+    <Modal
+      data-theme={theme}
+      title="Congratulations!"
+      description="You finished this Hour of AI activity. What's next?"
+      primaryButtonProps={{text: 'Finish', href: finishUrl, useAsLink: true}}
+      secondaryButtonProps={{text: 'Keep Playing', onClick: handleClose}}
+    />
+  );
+};
+
+export default HoaiCongrats;

--- a/dashboard/app/dsl/bubble_choice_dsl.rb
+++ b/dashboard/app/dsl/bubble_choice_dsl.rb
@@ -56,6 +56,8 @@ class BubbleChoiceDSL < ContentDSL
     @hash[:navigation_type] = type
   end
 
+  def finish_dialog(text) @hash[:finish_dialog] = text end
+
   def self.serialize(level)
     new_dsl = "name '#{escape(level.name)}'"
     new_dsl += "\neditor_experiment '#{level.editor_experiment}'" if level.editor_experiment.present?

--- a/dashboard/app/models/levels/bubble_choice.rb
+++ b/dashboard/app/models/levels/bubble_choice.rb
@@ -38,6 +38,7 @@ class BubbleChoice < DSLDefined
     hide_letters_lab2
     custom_mode
     navigation_type
+    finish_dialog
   )
 
   ALPHABET = ('a'..'z').to_a
@@ -271,6 +272,10 @@ class BubbleChoice < DSLDefined
 
   def channel_backed?
     return false if try(:is_project_level)
+    custom_mode == SharedConstants::BUBBLE_CHOICE_CUSTOM_MODES[:MUSIC_DANCE_AI]
+  end
+
+  def supports_sharing?
     custom_mode == SharedConstants::BUBBLE_CHOICE_CUSTOM_MODES[:MUSIC_DANCE_AI]
   end
 

--- a/dashboard/config/scripts/hoai2025_freeplay.bubble_choice
+++ b/dashboard/config/scripts/hoai2025_freeplay.bubble_choice
@@ -10,3 +10,4 @@ level 'hoai2025-freeplay-dance'
 custom_mode 'music_dance_ai'
 uses_lab2
 navigation_type 'next_level'
+finish_dialog 'hoai2025'

--- a/dashboard/config/scripts/mix_move_ai_dance_freeplay.bubble_choice
+++ b/dashboard/config/scripts/mix_move_ai_dance_freeplay.bubble_choice
@@ -11,3 +11,4 @@ level 'mix-move-ai-music-prompt-3-input-choice'
 custom_mode 'music_dance_ai'
 uses_lab2
 navigation_type 'next_level'
+finish_dialog 'hoai2025'


### PR DESCRIPTION
Adds a super bare-bones Congrats dialog of the Hour of AI 2025 tutorial. For now this just uses the DCDO Modal component with a Finish or Keep Playing action. We will plan to progressively add share/remix/view functionality but keep the entry point here hidden behind a DCDO flag. All this will be added in subsequent PRs.

<img width="1512" height="904" alt="Screenshot 2025-11-06 at 3 50 38 PM" src="https://github.com/user-attachments/assets/f9ddb06e-4ed8-4464-a260-38cf768e8e99" />

## Links
- Jira: https://codedotorg.atlassian.net/browse/LABS-1617

## Testing story
- Tested locally with prod and dev script