### PR TITLE
feat(fonts): add font support

### DIFF
--- a/frontend/apps/studio/package.json
+++ b/frontend/apps/studio/package.json
@@ -19,6 +19,7 @@
   "dependencies": {
     "@code-dot-org/component-library": "workspace:*",
     "@code-dot-org/component-library-styles": "workspace:*",
+    "@code-dot-org/fonts": "workspace:*",
     "@emotion/react": "^11.14.0",
     "@emotion/styled": "^11.14.1",
     "@mui/material": "^7.3.4",

--- a/frontend/apps/studio/src/App.tsx
+++ b/frontend/apps/studio/src/App.tsx
@@ -1,10 +1,13 @@
+// Ensure critical fonts are loaded very early.
+import '@code-dot-org/fonts/brands/code.org/index.css';
 import '@code-dot-org/component-library-styles/colors.scss';
-import {CssBaseline, ThemeProvider, Typography} from '@mui/material';
+import {ThemeProvider, Typography} from '@mui/material';
 import CdoLogo from '@/config/brand/assets/cdo-logo-inverse.webp';
 
 import {LinkButton} from '@code-dot-org/component-library/button';
 import Header from '@code-dot-org/component-library/header';
 import {CdoTheme} from '@code-dot-org/component-library/themes';
+import Bootstrap from './modules/bootstrap';
 
 const SIGNED_OUT_MENU_ITEMS = [
   {label: 'Learn', href: '/students'},
@@ -19,8 +22,7 @@ const SIGNED_OUT_MENU_ITEMS = [
 function App() {
   return (
     <ThemeProvider theme={CdoTheme}>
-      {/* Resets browser CSS defaults (e.g. body margin) using MUI defaults */}
-      <CssBaseline />
+      <Bootstrap locale="en-US" />
       <Header
         logoImageUrl={CdoLogo}
         brandName="Code.org"

--- a/frontend/apps/studio/src/modules/bootstrap/index.tsx
+++ b/frontend/apps/studio/src/modules/bootstrap/index.tsx
@@ -1,0 +1,21 @@
+import FontLoader from '@code-dot-org/fonts/FontLoader';
+import {CssBaseline} from '@mui/material';
+
+interface BootstrapProps {
+  locale: string;
+}
+
+/**
+ * Early bootstrap component for loading necessary fonts and styles.
+ */
+const Bootstrap = ({locale}: BootstrapProps) => {
+  return (
+    <>
+      <FontLoader locale={locale} />
+      {/* Resets browser CSS defaults (e.g. body margin) using MUI defaults */}
+      <CssBaseline />
+    </>
+  );
+};
+
+export default Bootstrap;

--- a/frontend/apps/studio/vite.config.ts
+++ b/frontend/apps/studio/vite.config.ts
@@ -1,5 +1,5 @@
 import react from '@vitejs/plugin-react';
-import {defineConfig} from 'vite';
+import {defineConfig, searchForWorkspaceRoot} from 'vite';
 import ViteRails from 'vite-plugin-rails';
 import path from 'node:path';
 
@@ -10,6 +10,10 @@ export default defineConfig(({mode}) => {
   return {
     server: {
       allowedHosts: isDev ? ['localhost-studio.code.org'] : undefined,
+      fs: {
+        // Allow serving files from the workspace root for monorepo setups
+        allow: [searchForWorkspaceRoot(process.cwd())],
+      },
     },
     resolve: {
       alias: {

--- a/frontend/packages/component-library/src/header/Header.tsx
+++ b/frontend/packages/component-library/src/header/Header.tsx
@@ -58,7 +58,7 @@ const styles = {
     '&:hover': {
       backgroundColor: 'var(--background-brand-teal-strong)',
     },
-    fontSize: 'var(--font-size-body-sm)',
+    fontWeight: 'normal',
   },
 };
 
@@ -97,8 +97,8 @@ const Header: React.FC<HeaderProps> = ({
                   <Link
                     href={item.href}
                     color="inherit"
+                    variant="body3"
                     sx={styles.menuListItemLink}
-                    variant="body1"
                   >
                     {item.label}
                   </Link>

--- a/frontend/packages/component-library/src/header/Header.tsx
+++ b/frontend/packages/component-library/src/header/Header.tsx
@@ -98,6 +98,7 @@ const Header: React.FC<HeaderProps> = ({
                     href={item.href}
                     color="inherit"
                     sx={styles.menuListItemLink}
+                    variant="body1"
                   >
                     {item.label}
                   </Link>

--- a/frontend/packages/component-library/src/themes/code.org/styleOverrides/index.ts
+++ b/frontend/packages/component-library/src/themes/code.org/styleOverrides/index.ts
@@ -1,7 +1,9 @@
 import {Components, Theme} from '@mui/material/styles';
 
+import {LINK_OVERRIDES} from './link';
 import {TYPOGRAPHY_OVERRIDES} from './typography';
 
 export const STYLE_OVERRIDES: Components<Theme> = {
   MuiTypography: TYPOGRAPHY_OVERRIDES,
+  MuiLink: LINK_OVERRIDES,
 };

--- a/frontend/packages/component-library/src/themes/code.org/styleOverrides/link.ts
+++ b/frontend/packages/component-library/src/themes/code.org/styleOverrides/link.ts
@@ -1,0 +1,12 @@
+import {Components, Theme} from '@mui/material/styles';
+
+export const LINK_OVERRIDES: Components<Theme>['MuiLink'] = {
+  defaultProps: {
+    variant: 'body2',
+  },
+  styleOverrides: {
+    root: ({theme}) => ({
+      fontWeight: theme.typography.fontWeightBold,
+    }),
+  },
+};

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -1260,6 +1260,7 @@ __metadata:
   dependencies:
     "@code-dot-org/component-library": "workspace:*"
     "@code-dot-org/component-library-styles": "workspace:*"
+    "@code-dot-org/fonts": "workspace:*"
     "@code-dot-org/lint-config": "workspace:*"
     "@emotion/react": "npm:^11.14.0"
     "@emotion/styled": "npm:^11.14.1"


### PR DESCRIPTION
This PR adds Code.org branding font support to the vite application.

- Introduced a new Bootstrap component to load necessary fonts and styles.
- Updated vite.config.ts to allow serving files from the workspace root.
- Added @code-dot-org/fonts dependency to yarn.lock.

--

## Before

<img width="609" height="179" alt="Screenshot From 2025-11-06 16-33-26" src="https://github.com/user-attachments/assets/3b2e6b8b-c413-4544-9eb0-89c03cc8fe4f" />


## After

<img width="609" height="179" alt="Screenshot From 2025-11-06 16-33-02" src="https://github.com/user-attachments/assets/96afcf8d-dbf5-4fb6-b013-db877d9eaa84" />


