### PR TITLE
String for fake class name in AI Chat type errors

### DIFF
--- a/dashboard/app/helpers/aichat_ruby_types.rb
+++ b/dashboard/app/helpers/aichat_ruby_types.rb
@@ -12,7 +12,7 @@ module AichatRubyTypes
   def self.raise_or_notify_type_error(message)
     if rack_env?(:production)
       Honeybadger.notify(
-        error_class: AichatRubyTypesWarning,
+        error_class: 'AichatRubyTypesWarning',
         error_message: message
       )
     else


### PR DESCRIPTION
Use a string for the fake class name we report to Honeybadger.

https://codedotorg.slack.com/archives/C03DBDN67B7/p1762474601683999

We decided to log to Honeybadger instead of erroring if a type error was observed in production (which can happen when production daemon and frontend servers are out of sync during a DTP): https://github.com/code-dot-org/code-dot-org/pull/68232

There was a suggestion in that PR to model the error reporting after another place where we warn to Honeybadger and use a fake class name -- we just missed the bit where you just use a string instead of a proper class.

https://github.com/code-dot-org/code-dot-org/blob/f6f64c12fafce614a15d4d6914ce1f14f431e968/dashboard/app/controllers/pd/regional_partner_contact_controller.rb#L13-L15