### PR TITLE
[AIChat] Adds screenreader aria-live support so messages read automatically as they appear

### DIFF
--- a/apps/src/aichat/views/ChatWorkspace.tsx
+++ b/apps/src/aichat/views/ChatWorkspace.tsx
@@ -292,11 +292,13 @@ const ChatWorkspace: React.FunctionComponent<ChatWorkspaceProps> = ({
       {showTabs ? (
         <Tabs {...tabArgs} />
       ) : (
-        <ChatEventsList
-          events={chatEvents}
-          isTeacherView={isTeacherView}
-          buildAssetUrl={buildAssetUrlValue}
-        />
+        <div role="log" aria-live="polite">
+          <ChatEventsList
+            events={chatEvents}
+            isTeacherView={isTeacherView}
+            buildAssetUrl={buildAssetUrlValue}
+          />
+        </div>
       )}
 
       <div className={moduleStyles.footer}>

--- a/apps/src/aichat/views/ChatWorkspace.tsx
+++ b/apps/src/aichat/views/ChatWorkspace.tsx
@@ -292,7 +292,12 @@ const ChatWorkspace: React.FunctionComponent<ChatWorkspaceProps> = ({
       {showTabs ? (
         <Tabs {...tabArgs} />
       ) : (
-        <div role="log" aria-live="polite">
+        <div
+          role="log"
+          aria-live="polite"
+          aria-relevant="additions"
+          aria-atomic="true"
+        >
           <ChatEventsList
             events={chatEvents}
             isTeacherView={isTeacherView}


### PR DESCRIPTION
After:

https://github.com/user-attachments/assets/c7194752-7187-4845-b43e-20e337a9ca78




## Links
<!--  Links to relevant external resources.
      - spec docs, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- Jira: 

## Testing story
<!--  Does your change include appropriate tests?
      - If so, please describe how the tests included in this PR are sufficient.
      - If not, please explain why this change does not need to be tested. -->



## Deployment strategy
<!--  Any special steps required to deploy this, besides merging?
      - Are there database migrations or manual steps?
      - Does this require coordination with other teams or systems? -->



## Follow-up work
<!--  List any clean-up or technical debt that will be addressed in future work.
      - Include Jira links where applicable.
      - Are there any known limitations or improvements planned? -->



## Privacy
<!--  How does this change impact Student & Teacher privacy?
      - Does this collect, use, share, or modify PII, either new or existing? -->



## Security
<!--  How does this change impact our security surface-area?
      - Do API's touched have the right auth?
      - Do infra changes impact our attack surface or encryption?
-->



## Caching
<!--  How does this change impact caching behavior?
      - Are cache keys or invalidation strategies affected?
      - Will this require cache warming or invalidation after deployment? -->



## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
