### PR TITLE
hoai2025: music start over fix fix

### DIFF
--- a/apps/src/music/views/MusicView.jsx
+++ b/apps/src/music/views/MusicView.jsx
@@ -543,7 +543,7 @@ class UnconnectedMusicView extends React.Component {
     }
 
     // In case we are showing the music generation Guide, reset its state.
-    this.props.setAiGenerateState('clearing');
+    this.props.setAiGenerateState('clearing-before-none');
 
     // In Start mode, load sources from the default JSON.
     if (isStartMode) {


### PR DESCRIPTION
This makes a small follow-up fix to the fix in #69356.  It had been working, but the relevant state was renamed in #69326 which was merged in the interim.  Now, using the Start Over button always resets the Guide to its initial prompt UI.