### PR TITLE
hoai2025: music skip stop

### DIFF
--- a/apps/src/music/views/GenerateCode.tsx
+++ b/apps/src/music/views/GenerateCode.tsx
@@ -353,7 +353,10 @@ const GenerateCode: React.FunctionComponent<GenerateCodeProps> = ({
             onClick={() => {
               // Skip the 'editing' validation state for standalone projects.
               dispatch(setAiGenerateState(isStandalone ? 'edited' : 'editing'));
-              setPlaying(false);
+
+              if (appConfig.getValue('ai-music-skip-stop') !== 'true') {
+                setPlaying(false);
+              }
             }}
             className={styles.buttonWide}
           />


### PR DESCRIPTION
An optional, internal `?ai-music-skip-stop=true` URL parameter will no longer stop music from playing when "Use code" is selected.
 