### PR TITLE
Prevent CustomDropdown menus from being clipped

### DIFF
--- a/apps/src/codebridge/Workspace/workspace.module.scss
+++ b/apps/src/codebridge/Workspace/workspace.module.scss
@@ -62,7 +62,9 @@
   display: grid;
   grid-template-columns: 34px auto;
   grid-auto-rows: 40px 1fr auto;
-  overflow: hidden;
+  // Allow overlay elements like dropdown menus to extend outside of the
+  // header row without being clipped.
+  overflow: visible;
   flex: 1;
 }
 

--- a/frontend/packages/component-library/src/dropdown/CustomDropdown.tsx
+++ b/frontend/packages/component-library/src/dropdown/CustomDropdown.tsx
@@ -4,6 +4,9 @@ import {
   useMemo,
   useRef,
   useEffect,
+  useLayoutEffect,
+  useState,
+  type CSSProperties,
   AriaAttributes,
   KeyboardEvent,
   memo,
@@ -122,6 +125,9 @@ const CustomDropdown: React.FunctionComponent<CustomDropdownProps> = ({
 }) => {
   const {activeDropdownName, setActiveDropdownName} = useDropdownContext();
   const dropdownRef = useRef<HTMLDivElement>(null);
+  const dropdownMenuRef = useRef<HTMLDivElement>(null);
+  const [dropdownMenuStyles, setDropdownMenuStyles] = useState<CSSProperties>({});
+  const [isDropdownMenuPositioned, setIsDropdownMenuPositioned] = useState(false);
   const handleClickOutside = useCallback(
     (event: Event) => {
       if (
@@ -175,6 +181,66 @@ const CustomDropdown: React.FunctionComponent<CustomDropdownProps> = ({
     () => activeDropdownName === name,
     [activeDropdownName, name],
   );
+
+  const updateDropdownMenuPosition = useCallback(() => {
+    if (
+      !isOpen ||
+      !dropdownRef.current ||
+      !dropdownMenuRef.current ||
+      typeof window === 'undefined'
+    ) {
+      return;
+    }
+
+    const dropdownRect = dropdownRef.current.getBoundingClientRect();
+    const menuRect = dropdownMenuRef.current.getBoundingClientRect();
+    const VERTICAL_OFFSET = 4;
+
+    const top =
+      menuVerticalPlacement === 'top'
+        ? dropdownRect.top - menuRect.height - VERTICAL_OFFSET
+        : dropdownRect.bottom + VERTICAL_OFFSET;
+    const left =
+      menuPlacement === 'right'
+        ? dropdownRect.right - menuRect.width
+        : dropdownRect.left;
+
+    setDropdownMenuStyles({
+      top,
+      left,
+    });
+    setIsDropdownMenuPositioned(true);
+  }, [isOpen, menuPlacement, menuVerticalPlacement]);
+
+  useEffect(() => {
+    if (!isOpen) {
+      setIsDropdownMenuPositioned(false);
+      setDropdownMenuStyles({});
+      return;
+    }
+
+    if (typeof window === 'undefined' || typeof document === 'undefined') {
+      return;
+    }
+
+    const handleWindowChange = () => {
+      updateDropdownMenuPosition();
+    };
+
+    window.addEventListener('resize', handleWindowChange);
+    document.addEventListener('scroll', handleWindowChange, true);
+
+    return () => {
+      window.removeEventListener('resize', handleWindowChange);
+      document.removeEventListener('scroll', handleWindowChange, true);
+    };
+  }, [isOpen, updateDropdownMenuPosition]);
+
+  useLayoutEffect(() => {
+    if (isOpen) {
+      updateDropdownMenuPosition();
+    }
+  }, [isOpen, updateDropdownMenuPosition, children]);
 
   // Collapse dropdown if 'Escape' is pressed
   const onKeyDown: (e: KeyboardEvent) => void = e => {
@@ -268,7 +334,16 @@ const CustomDropdown: React.FunctionComponent<CustomDropdownProps> = ({
           <FontAwesomeV6Icon iconStyle="solid" iconName="chevron-down" />
         </button>
       )}
-      <div className={moduleStyles.dropdownMenuContainer}>
+      <div
+        className={moduleStyles.dropdownMenuContainer}
+        ref={dropdownMenuRef}
+        style={{
+          ...dropdownMenuStyles,
+          position: isOpen ? 'fixed' : 'absolute',
+          visibility:
+            isOpen && isDropdownMenuPositioned ? 'visible' : 'hidden',
+        }}
+      >
         {/** Dropdown menu content is rendered here as children props*/}
         {children}
       </div>


### PR DESCRIPTION
## Summary
- position CustomDropdown menus using fixed coordinates so they are not clipped by ancestor overflow containers
- recalculate menu placement when the dropdown opens and on resize/scroll to keep it aligned with the trigger
- hide the menu until its coordinates have been measured to avoid flicker while positioning

## Testing
- yarn test --runTestsByPath src/dropdown/actionDropdown/__tests__/ActionDropdown.test.tsx

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_690dd77367448328a17ab1b10d1c9b0d)