### PR TITLE
AI Tutor: Add console output to the hidden context

### DIFF
--- a/apps/src/aiTutor/helpers/aiTutorContextHelper.ts
+++ b/apps/src/aiTutor/helpers/aiTutorContextHelper.ts
@@ -23,6 +23,9 @@ const DOCUMENTATION_LOCATION_INTRO =
 const EXAMPLES_LOCATION_INTRO =
   'Here is where the student can find example projects:';
 
+const CONSOLE_OUTPUT_INTRO =
+  "Here is the output currently shown in the student's debug console:";
+
 /*
  * Abstract base class used to provide lab specific context to AI Tutor.  Each lab will inherit from and
  * extend this class, but conversion to a system prompt string should be kept here for coordination and
@@ -45,6 +48,7 @@ export abstract class AiTutorContextHelper<AiTutorParams extends object> {
       validationResults,
       longInstructions,
       documentation,
+      consoleOutput,
     } = await this.getAiTutorContext();
 
     const hiddenContextString = [
@@ -67,6 +71,7 @@ export abstract class AiTutorContextHelper<AiTutorParams extends object> {
       this.examplesLocation
         ? `${EXAMPLES_LOCATION_INTRO} ${this.examplesLocation}`
         : '',
+      consoleOutput ? `${CONSOLE_OUTPUT_INTRO} ${consoleOutput}` : '',
     ]
       .filter(Boolean)
       .join('\n\n');

--- a/apps/src/aiTutor/types.ts
+++ b/apps/src/aiTutor/types.ts
@@ -19,6 +19,7 @@ export interface AiTutorContext {
   longInstructions?: string;
   documentation?: string;
   documentationLocation?: string;
+  consoleOutput?: string;
 }
 
 export interface AnalyticsData {

--- a/apps/src/codebridge/Console/ConsoleManager.ts
+++ b/apps/src/codebridge/Console/ConsoleManager.ts
@@ -1,6 +1,16 @@
 import {FitAddon} from '@xterm/addon-fit';
 import {Terminal} from '@xterm/xterm';
 
+const ESC = '\\x1B';
+const ANSI_ESCAPE_SEQUENCE_REGEX = new RegExp(
+  `${ESC}\\[[0-9;?]*[ -/]*[@-~]`,
+  'g'
+);
+const OSC_ESCAPE_SEQUENCE_REGEX = new RegExp(
+  `${ESC}\\][0-9;?]*(?:[\\s\\S]*?)(?:\\u0007|${ESC}\\\\)`,
+  'g'
+);
+
 // Manager for xterm.js-based console in codebridge
 export default class ConsoleManager {
   private terminal: Terminal;
@@ -42,7 +52,10 @@ export default class ConsoleManager {
     this.executeTerminalLinesListeners();
   }
 
-  public getTerminalLines() {
+  public getTerminalLines(stripFormatting = false) {
+    if (stripFormatting) {
+      return this.terminalLines.map(ConsoleManager.stripAnsiSequences);
+    }
     return this.terminalLines;
   }
 
@@ -111,5 +124,11 @@ export default class ConsoleManager {
       this.terminalLines.push(message);
     }
     this.executeTerminalLinesListeners();
+  }
+
+  private static stripAnsiSequences(line: string) {
+    return line
+      .replace(OSC_ESCAPE_SEQUENCE_REGEX, '')
+      .replace(ANSI_ESCAPE_SEQUENCE_REGEX, '');
   }
 }

--- a/apps/src/codebridge/Console/ConsoleManager.ts
+++ b/apps/src/codebridge/Console/ConsoleManager.ts
@@ -1,17 +1,6 @@
 import {FitAddon} from '@xterm/addon-fit';
 import {Terminal} from '@xterm/xterm';
 
-const ESC = '\x1B';
-const BEL = '\x07';
-const ANSI_ESCAPE_SEQUENCE_REGEX = new RegExp(
-  `${ESC}\[[0-9;?]*[ -/]*[@-~]`,
-  'g'
-);
-const OSC_ESCAPE_SEQUENCE_REGEX = new RegExp(
-  `${ESC}\][0-9;?]*(?:[\s\S]*?)(?:${BEL}|${ESC}\\)`,
-  'g'
-);
-
 // Manager for xterm.js-based console in codebridge
 export default class ConsoleManager {
   private terminal: Terminal;
@@ -53,10 +42,7 @@ export default class ConsoleManager {
     this.executeTerminalLinesListeners();
   }
 
-  public getTerminalLines(stripFormatting = false) {
-    if (stripFormatting) {
-      return this.terminalLines.map(ConsoleManager.stripAnsiSequences);
-    }
+  public getTerminalLines() {
     return this.terminalLines;
   }
 
@@ -125,11 +111,5 @@ export default class ConsoleManager {
       this.terminalLines.push(message);
     }
     this.executeTerminalLinesListeners();
-  }
-
-  private static stripAnsiSequences(line: string) {
-    return line
-      .replace(OSC_ESCAPE_SEQUENCE_REGEX, '')
-      .replace(ANSI_ESCAPE_SEQUENCE_REGEX, '');
   }
 }

--- a/apps/src/codebridge/Console/ConsoleManager.ts
+++ b/apps/src/codebridge/Console/ConsoleManager.ts
@@ -1,13 +1,14 @@
 import {FitAddon} from '@xterm/addon-fit';
 import {Terminal} from '@xterm/xterm';
 
-const ESC = '\\x1B';
+const ESC = '\x1B';
+const BEL = '\x07';
 const ANSI_ESCAPE_SEQUENCE_REGEX = new RegExp(
-  `${ESC}\\[[0-9;?]*[ -/]*[@-~]`,
+  `${ESC}\[[0-9;?]*[ -/]*[@-~]`,
   'g'
 );
 const OSC_ESCAPE_SEQUENCE_REGEX = new RegExp(
-  `${ESC}\\][0-9;?]*(?:[\\s\\S]*?)(?:\\u0007|${ESC}\\\\)`,
+  `${ESC}\][0-9;?]*(?:[\s\S]*?)(?:${BEL}|${ESC}\\)`,
   'g'
 );
 

--- a/apps/src/codebridge/Console/MessageHelpers.ts
+++ b/apps/src/codebridge/Console/MessageHelpers.ts
@@ -5,6 +5,25 @@ import {RunType} from '../types';
 const IMAGE_WIDTH = 600;
 const IMAGE_HEIGHT = 600;
 
+const ESC = '\x1b';
+const BEL = '\x07';
+const ANSI_ESCAPE_SEQUENCE_REGEX = new RegExp(
+  `${ESC}\\[[0-9;?]*[ -/]*[@-~]`,
+  'g'
+);
+const OSC_ESCAPE_SEQUENCE_REGEX = new RegExp(
+  `${ESC}][0-9;?]*(?:[\\s\\S]*?)(?:${BEL}|${ESC}\\\\)`,
+  'g'
+);
+
+// Remove any control characters from the message, such as ANSI color codes or
+// image display sequences, and return just the plain text message.
+export function stripAnsiSequences(line: string) {
+  return line
+    .replace(OSC_ESCAPE_SEQUENCE_REGEX, '')
+    .replace(ANSI_ESCAPE_SEQUENCE_REGEX, '');
+}
+
 export function getSystemMessage(message: string, appName?: string) {
   const systemMessagePrefix = appName === 'pythonlab' ? '[PYTHON LAB] ' : '';
   return `${systemMessagePrefix}${message}`;

--- a/apps/src/pythonlab/helpers/aiTutorContextHelper.ts
+++ b/apps/src/pythonlab/helpers/aiTutorContextHelper.ts
@@ -3,6 +3,7 @@ import CodebridgeRegistry from '@codebridge/CodebridgeRegistry';
 import {tryFetchDocsForClass} from '@cdo/apps/aiTutor/docContextApi';
 import {AiTutorContextHelper} from '@cdo/apps/aiTutor/helpers/aiTutorContextHelper';
 import {AiTutorContext} from '@cdo/apps/aiTutor/types';
+import {stripAnsiSequences} from '@cdo/apps/codebridge/Console/MessageHelpers';
 import {ProjectFile} from '@cdo/apps/codebridge/types';
 import {MultiFileSource, ProjectFileType} from '@cdo/apps/lab2/types';
 import {studio} from '@cdo/apps/lib/util/urlHelpers';
@@ -69,7 +70,8 @@ export class AiTutorPythonLabContextHelper extends AiTutorContextHelper<AiTutorP
 
     const consoleLines = CodebridgeRegistry.getInstance()
       .getConsoleManager()
-      ?.getTerminalLines(true /* stripFormatting */);
+      ?.getTerminalLines()
+      ?.map(line => stripAnsiSequences(line));
     const consoleOutput =
       consoleLines && consoleLines.length > 0
         ? this.codeBlock(consoleLines.join('\n'))

--- a/apps/src/pythonlab/helpers/aiTutorContextHelper.ts
+++ b/apps/src/pythonlab/helpers/aiTutorContextHelper.ts
@@ -1,3 +1,5 @@
+import CodebridgeRegistry from '@codebridge/CodebridgeRegistry';
+
 import {tryFetchDocsForClass} from '@cdo/apps/aiTutor/docContextApi';
 import {AiTutorContextHelper} from '@cdo/apps/aiTutor/helpers/aiTutorContextHelper';
 import {AiTutorContext} from '@cdo/apps/aiTutor/types';
@@ -65,12 +67,21 @@ export class AiTutorPythonLabContextHelper extends AiTutorContextHelper<AiTutorP
 
     const documentation = await this.documentationPromise;
 
+    const consoleLines = CodebridgeRegistry.getInstance()
+      .getConsoleManager()
+      ?.getTerminalLines(true /* stripFormatting */);
+    const consoleOutput =
+      consoleLines && consoleLines.length > 0
+        ? this.codeBlock(consoleLines.join('\n'))
+        : undefined;
+
     return {
       sourceCode,
       validationContents,
       validationResults,
       longInstructions,
       documentation,
+      consoleOutput,
     };
   }
 }

--- a/apps/test/unit/codebridge/Console/MessageHelpersTest.ts
+++ b/apps/test/unit/codebridge/Console/MessageHelpersTest.ts
@@ -1,0 +1,41 @@
+import {
+  getImageMessage,
+  getErrorMessage,
+  stripAnsiSequences,
+} from '@cdo/apps/codebridge/Console/MessageHelpers';
+
+describe('stripAnsiSequences', () => {
+  it('returns original string when there are no control sequences', () => {
+    const message = 'plain text message';
+    expect(stripAnsiSequences(message)).toBe(message);
+  });
+
+  it('strips ANSI color codes while preserving text', () => {
+    const coloredMessage = '\x1b[31mError\x1b[0m: something went wrong';
+    expect(stripAnsiSequences(coloredMessage)).toBe(
+      'Error: something went wrong'
+    );
+  });
+
+  it('strips ANSI color codes from error message while preserving text', () => {
+    const text = 'Error: something went wrong';
+    const coloredMessage = getErrorMessage(text);
+    expect(stripAnsiSequences(coloredMessage)).toBe(text);
+  });
+
+  it('removes OSC image sequences and keeps surrounding text', () => {
+    const oscSequence =
+      '\x1b]1337;File=inline=1;size=4;width=10px;height=10px:SGVsbG8=\x07';
+    const messageWithImage = `start ${oscSequence} end`;
+    expect(stripAnsiSequences(messageWithImage)).toBe('start  end');
+  });
+
+  it('removes OSC image returned from getImageMessage and keeps surrounding text', () => {
+    const oscSequence = getImageMessage('SGVsbG8=');
+    const messageWithImage = `start ${oscSequence} end`;
+    expect(oscSequence).toBe(
+      '\x1b]1337;File=inline=1;size=5;width=600px;height=600px:SGVsbG8=\x1b\\'
+    );
+    expect(stripAnsiSequences(messageWithImage)).toBe('start  end');
+  });
+});


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
This PR adds console output to the AI Tutor's hidden context


## Links
<!--  Links to relevant external resources.
      - spec docs, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- Jira: https://codedotorg.atlassian.net/browse/LABS-1588

## Testing story
<!--  Does your change include appropriate tests?
      - If so, please describe how the tests included in this PR are sufficient.
      - If not, please explain why this change does not need to be tested. -->

 - UTs on the new helper to strip formatting escape sequences from the console lines before sending to tutor.
 - Manual testing verifying that the console contents is added to hidden context, clearing the console results in the next message not sending console output.
 - Manual testing chatting with the tutor to see how it responds to having this information


An example of tutor using the console output to inform response:
<img width="1320" height="1451" alt="image" src="https://github.com/user-attachments/assets/4e4355b7-2631-487f-8947-3aa8ab8f45e3" />

Helping with an error in the console:
<img width="1197" height="1459" alt="image" src="https://github.com/user-attachments/assets/1654e477-268b-4f26-a610-b11370b9a7c0" />

<img width="1215" height="1463" alt="image" src="https://github.com/user-attachments/assets/e94103a4-2282-413f-bd1e-00bbfd3a80c3" />

<img width="916" height="1052" alt="image" src="https://github.com/user-attachments/assets/d842adec-f262-4565-9113-dd3412f3e459" />
