### PR TITLE
CMS-1027: Skip and report invalid Tutorial entries

### DIFF
--- a/dashboard/engines/hoc_legacy/lib/hoc_legacy/tutorials.rb
+++ b/dashboard/engines/hoc_legacy/lib/hoc_legacy/tutorials.rb
@@ -31,7 +31,7 @@ module HocLegacy
 
       private def fetch_all
         CdoContentful::CsForAll::Entry::Tutorial.
-          find_each(order: FETCH_ORDER, limit: FETCH_LIMIT).
+          find_each(order: FETCH_ORDER, limit: FETCH_LIMIT, 'tutorialID[exists]': true).
           with_object({}) do |tutorial, data|
             data[tutorial.tutorial_id] = tutorial
           rescue StandardError => exception

--- a/dashboard/engines/hoc_legacy/lib/hoc_legacy/tutorials.rb
+++ b/dashboard/engines/hoc_legacy/lib/hoc_legacy/tutorials.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'cdo/honeybadger'
+
 module HocLegacy
   module Tutorials
     CACHE_KEY = 'hoc_legacy:tutorials'
@@ -30,7 +32,17 @@ module HocLegacy
       private def fetch_all
         CdoContentful::CsForAll::Entry::Tutorial.
           find_each(order: FETCH_ORDER, limit: FETCH_LIMIT).
-          with_object({}) {|tutorial, data| data[tutorial.tutorial_id] = tutorial}
+          with_object({}) do |tutorial, data|
+            data[tutorial.tutorial_id] = tutorial
+          rescue StandardError => exception
+            Honeybadger.notify(
+              exception,
+              error_message: '[Contentful] Invalid Tutorial entry',
+              context: {
+                tutorial: tutorial.sys,
+              },
+            )
+          end
       end
     end
   end

--- a/dashboard/engines/hoc_legacy/test/fixtures/vcr_cassettes/hoc_legacy/tutorial_api/basic_flow.yml
+++ b/dashboard/engines/hoc_legacy/test/fixtures/vcr_cassettes/hoc_legacy/tutorial_api/basic_flow.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://preview.contentful.com/spaces/27jkibac934d/environments/master/entries?content_type=curriculum&limit=200&locale=en-US&order=fields.tutorialID,sys.createdAt&skip=0
+    uri: https://preview.contentful.com/spaces/27jkibac934d/environments/master/entries?content_type=curriculum&fields.tutorialID%5Bexists%5D=true&limit=200&locale=en-US&order=fields.tutorialID,sys.createdAt&skip=0
     body:
       encoding: UTF-8
       string: ''

--- a/dashboard/engines/hoc_legacy/test/fixtures/vcr_cassettes/hoc_legacy/tutorial_api/basic_flow_with_finish_current.yml
+++ b/dashboard/engines/hoc_legacy/test/fixtures/vcr_cassettes/hoc_legacy/tutorial_api/basic_flow_with_finish_current.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://preview.contentful.com/spaces/27jkibac934d/environments/master/entries?content_type=curriculum&limit=200&locale=en-US&order=fields.tutorialID,sys.createdAt&skip=0
+    uri: https://preview.contentful.com/spaces/27jkibac934d/environments/master/entries?content_type=curriculum&fields.tutorialID%5Bexists%5D=true&limit=200&locale=en-US&order=fields.tutorialID,sys.createdAt&skip=0
     body:
       encoding: UTF-8
       string: ''

--- a/dashboard/engines/hoc_legacy/test/fixtures/vcr_cassettes/hoc_legacy/tutorial_api/basic_flow_without_activity_tracking.yml
+++ b/dashboard/engines/hoc_legacy/test/fixtures/vcr_cassettes/hoc_legacy/tutorial_api/basic_flow_without_activity_tracking.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://preview.contentful.com/spaces/27jkibac934d/environments/master/entries?content_type=curriculum&limit=200&locale=en-US&order=fields.tutorialID,sys.createdAt&skip=0
+    uri: https://preview.contentful.com/spaces/27jkibac934d/environments/master/entries?content_type=curriculum&fields.tutorialID%5Bexists%5D=true&limit=200&locale=en-US&order=fields.tutorialID,sys.createdAt&skip=0
     body:
       encoding: UTF-8
       string: ''

--- a/dashboard/engines/hoc_legacy/test/fixtures/vcr_cassettes/hoc_legacy/tutorials.yml
+++ b/dashboard/engines/hoc_legacy/test/fixtures/vcr_cassettes/hoc_legacy/tutorials.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://preview.contentful.com/spaces/27jkibac934d/environments/master/entries?content_type=curriculum&limit=200&locale=en-US&order=fields.tutorialID,sys.createdAt&skip=0
+    uri: https://preview.contentful.com/spaces/27jkibac934d/environments/master/entries?content_type=curriculum&fields.tutorialID%5Bexists%5D=true&limit=200&locale=en-US&order=fields.tutorialID,sys.createdAt&skip=0
     body:
       encoding: UTF-8
       string: ''

--- a/dashboard/engines/hoc_legacy/test/lib/hoc_legacy/tutorials_test.rb
+++ b/dashboard/engines/hoc_legacy/test/lib/hoc_legacy/tutorials_test.rb
@@ -61,7 +61,7 @@ class HocLegacy::TutorialsTest < ActiveSupport::TestCase
           error,
           error_message: '[Contentful] Invalid Tutorial entry',
           context: kind_of(Hash)
-        )
+        ).once
         get_tutorial
       end
     end

--- a/dashboard/engines/hoc_legacy/test/lib/hoc_legacy/tutorials_test.rb
+++ b/dashboard/engines/hoc_legacy/test/lib/hoc_legacy/tutorials_test.rb
@@ -44,6 +44,27 @@ class HocLegacy::TutorialsTest < ActiveSupport::TestCase
         _get_tutorial.must_be_nil
       end
     end
+
+    context 'when Tutorial entry is invalid' do
+      let(:error) {StandardError.new('Invalid Tutorial entry')}
+
+      before do
+        allow_any_instance_of(Contentful::Entry).to receive(:tutorial_id).and_raise(error)
+      end
+
+      it 'returns nil' do
+        _get_tutorial.must_be_nil
+      end
+
+      it 'notifies Honeybadger' do
+        expect(Honeybadger).to receive(:notify).with(
+          error,
+          error_message: '[Contentful] Invalid Tutorial entry',
+          context: kind_of(Hash)
+        )
+        get_tutorial
+      end
+    end
   end
 
   describe '.refresh' do

--- a/dashboard/engines/hoc_legacy/test/lib/hoc_legacy/tutorials_test.rb
+++ b/dashboard/engines/hoc_legacy/test/lib/hoc_legacy/tutorials_test.rb
@@ -80,7 +80,7 @@ class HocLegacy::TutorialsTest < ActiveSupport::TestCase
 
       expect(CdoContentful::CsForAll::Entry::Tutorial).
         to receive(:find_each).
-        with(limit: 200, order: 'fields.tutorialID').
+        with(limit: 200, order: 'fields.tutorialID', 'tutorialID[exists]': true).
         exactly(2).times.
         and_return(
           [OpenStruct.new(tutorial_id: original_tutorial_id)].to_enum,


### PR DESCRIPTION
## Issue
When fetching draft data from Contentful, some Tutorial entries may not have the required Tutorial ID. This causes a NoMethodError during processing, which breaks the entire store update.

## Solution
Ignore invalid Tutorial entries that are missing the required `Tutorial ID` field and report them to Honeybadger for visibility

## Links
- JIRA task: [CMS-1027](https://codedotorg.atlassian.net/browse/CMS-1027)
- Related PR: https://github.com/code-dot-org/code-dot-org/pull/69188