### PR TITLE
Codebridge: update styles on file manager dropdowns

### DIFF
--- a/apps/src/codebridge/PopUpButton/pop-up-button.module.scss
+++ b/apps/src/codebridge/PopUpButton/pop-up-button.module.scss
@@ -1,9 +1,18 @@
+@mixin focus-styles($outline-offset, $border-radius) {
+  outline: var(--borders-brand-teal-primary) solid 2px;
+  outline-offset: $outline-offset;
+  border-radius: $border-radius;
+}
+
 .popup-button-menu {
   position: absolute;
   cursor: pointer;
   border: 1px solid var(--borders-neutral-primary);
   border-radius: 4px;
-  background-color: var(--background-neutral-secondary);
+  padding: 0.25rem 0;
+  background-color: var(--background-neutral-primary);
+  box-shadow: rgba(0 0 0 / 0.1) 0 10px 15px -3px,
+    rgba(0 0 0 / 0.05) 0 4px 6px -2px;
   color: var(--text-neutral-primary);
   min-width: 100px;
   text-align: left;
@@ -11,15 +20,11 @@
   z-index: 1000;
 
   &:focus-visible {
-    outline: var(--borders-brand-teal-primary) solid 2px;
-    outline-offset: 2px;
-    border-radius: 0.375rem;
+    @include focus-styles(2px, 0.25rem);
   }
   // Apply focus-visible styles to all child elements
   *:focus-visible {
-    outline: var(--borders-brand-teal-primary) solid 2px;
-    outline-offset: 2px;
-    border-radius: 0.375rem;
+    @include focus-styles(-1px, 0);
   }
 }
 

--- a/apps/src/codebridge/styles/dropdown.module.scss
+++ b/apps/src/codebridge/styles/dropdown.module.scss
@@ -1,15 +1,19 @@
 .dropdownItem {
   display: flex;
-  padding: 8px 16px 8px 12px;
+  padding-block: 0.25rem;
+  padding-inline: 0.5rem 0.625rem;
   align-items: center;
-  gap: 12px;
+  gap: 0.375rem;
   align-self: stretch;
+  transition: background-color 0.2s ease-in-out;
 
   &:hover {
-    background-color: var(--background-neutral-quaternary);
+    background-color: var(--background-neutral-tertiary);
   }
 
   i {
-    color: var(--text-neutral-tertiary);
+    color: var(--text-neutral-primary);
+    text-align: center;
+    width: 1rem;
   }
 }


### PR DESCRIPTION
Updates the dropdown UI in the Codebridge file manager used in Lab 2 labs. Doing this in lieu of replacing these with the DSCO ActionDropdown component since it gets hidden by the Python Lab console panel (see: https://github.com/code-dot-org/code-dot-org/pull/69338).

## Links
Jira ticket: https://codedotorg.atlassian.net/browse/[AFL-350](https://codedotorg.atlassian.net/browse/AFL-350)

## Testing story
Tested locally

----

## Before

https://github.com/user-attachments/assets/a3b5a788-001a-404d-b8e8-97b016189f49




## After


https://github.com/user-attachments/assets/006d02db-1896-4b91-907b-d700170a8ef1





