### PR TITLE
Revert "hoai2025: cache unit"

### DIFF
--- a/lib/cdo/http_cache.rb
+++ b/lib/cdo/http_cache.rb
@@ -77,7 +77,6 @@ class HttpCache
     dance-ai-2023
     mc
     music-jam-2024
-    mix-move-ai-2025
   ).map do |script_name|
     # Assume all cached units are in single unit courses.
     [script_name, "/courses/#{script_name}/units/1/lessons/*"]


### PR DESCRIPTION
Reverts code-dot-org/code-dot-org#69390.  It blocked internal users from being able to visit levels, because we [don't allow](https://github.com/code-dot-org/code-dot-org/blob/c042453ce02429d6c09eae803fcf27691056348b/dashboard/app/controllers/script_levels_controller.rb#L117-L128) them to visit a cached level if it's in a script that requires the user to be signed-in.  Once we flip the script to `"stable"` we can reapply this change.
