### PR TITLE
hoai2025: ship music skip stop

### DIFF
--- a/apps/src/dance/lab2/views/GenerateDance.tsx
+++ b/apps/src/dance/lab2/views/GenerateDance.tsx
@@ -313,7 +313,6 @@ const GenerateDance: React.FunctionComponent<GenerateCodeProps> = ({
             onClick={() => {
               // Skip the 'editing' validation state for standalone projects.
               setAiGenerateState(isStandalone ? 'edited' : 'editing');
-              resetProgram();
             }}
             className={styles.buttonWide}
           />

--- a/apps/src/music/views/GenerateCode.tsx
+++ b/apps/src/music/views/GenerateCode.tsx
@@ -353,10 +353,6 @@ const GenerateCode: React.FunctionComponent<GenerateCodeProps> = ({
             onClick={() => {
               // Skip the 'editing' validation state for standalone projects.
               dispatch(setAiGenerateState(isStandalone ? 'edited' : 'editing'));
-
-              if (appConfig.getValue('ai-music-skip-stop') !== 'true') {
-                setPlaying(false);
-              }
             }}
             className={styles.buttonWide}
           />

--- a/dashboard/config/levels/custom/dance/mix-move-ai-dance-prompt-3-input-choice.level
+++ b/dashboard/config/levels/custom/dance/mix-move-ai-dance-prompt-3-input-choice.level
@@ -97,6 +97,7 @@
       "kind": "flyoutToolbox"
     },
     "long_instructions": "### Use AI to code your dance\r\nModify the prompt, then press Generate code.",
+    "use_secondary_finish_button": "true",
     "preload_asset_list": null
   },
   "published": true,


### PR DESCRIPTION
Ship the change tested with https://github.com/code-dot-org/code-dot-org/pull/69397: we will no longer stop music playing when "Use code" is selected.

This makes the same change when generating a dance.  And changes the final Finish button to be secondary.