### PR TITLE
hoai2025: focus

### DIFF
--- a/apps/src/dance/lab2/views/GenerateDance.tsx
+++ b/apps/src/dance/lab2/views/GenerateDance.tsx
@@ -369,6 +369,10 @@ const GenerateDance: React.FunctionComponent<GenerateCodeProps> = ({
           </div>
         </>
       )}
+      {/* Retain focus with a hidden button. */}
+      {['generating', 'generated', 'listening', 'editing'].includes(
+        aiGenerateState
+      ) && <div tabIndex={0} role="button" className={styles.hiddenButton} />}
     </Guide>
   );
 };

--- a/apps/src/dance/lab2/views/GenerateDancer.tsx
+++ b/apps/src/dance/lab2/views/GenerateDancer.tsx
@@ -465,6 +465,14 @@ const GenerateDancer: React.FunctionComponent<DancerGenerateProps> = ({
               </div>
             </>
           )}
+          {/* Retain focus with a hidden button. */}
+          {['generating'].includes(aiGenerateState) && (
+            <div
+              tabIndex={0}
+              role="button"
+              className={moduleStyles.hiddenButton}
+            />
+          )}
         </Guide>
         <div className={moduleStyles.dancerContainer} ref={containerRef}>
           <div className={moduleStyles.background}>

--- a/apps/src/dance/lab2/views/generate-dance.module.scss
+++ b/apps/src/dance/lab2/views/generate-dance.module.scss
@@ -22,3 +22,12 @@
     font-size: 16px;
   }
 }
+
+.hiddenButton {
+  opacity: 0;
+  position: fixed;
+  left: -100%;
+  bottom: -100%;
+  width: 0;
+  height: 0;
+}

--- a/apps/src/dance/lab2/views/generate-dancer.module.scss
+++ b/apps/src/dance/lab2/views/generate-dancer.module.scss
@@ -123,3 +123,12 @@
     font-size: 16px;
   }
 }
+
+.hiddenButton {
+  opacity: 0;
+  position: fixed;
+  left: -100%;
+  bottom: -100%;
+  width: 0;
+  height: 0;
+}

--- a/apps/src/music/views/GenerateCode.module.scss
+++ b/apps/src/music/views/GenerateCode.module.scss
@@ -50,3 +50,12 @@
     font-size: 16px;
   }
 }
+
+.hiddenButton {
+  opacity: 0;
+  position: fixed;
+  left: -100%;
+  bottom: -100%;
+  width: 0;
+  height: 0;
+}

--- a/apps/src/music/views/GenerateCode.tsx
+++ b/apps/src/music/views/GenerateCode.tsx
@@ -410,6 +410,10 @@ const GenerateCode: React.FunctionComponent<GenerateCodeProps> = ({
           </div>
         </>
       )}
+      {/* Retain focus with a hidden button. */}
+      {['generating', 'generated', 'listening', 'editing'].includes(
+        aiGenerateState
+      ) && <div tabIndex={0} role="button" className={styles.hiddenButton} />}
     </Guide>
   );
 };


### PR DESCRIPTION
We've been seeing, particularly on Chrome, that when a Guide button has focus and then becomes disabled or just disappears, that the browser puts focus on another button.  In our case, that can be one of three buttons (home logo, template-backed level icon, or first tab in resource panel) that have a tooltip which then shows up unexpectedly. 

After some experimentation, it appears that an off-screen button at the bottom of the Guide's DOM will capture this focus.  By making it only appear in states in which we've witnessed focus go too far away (because the Guide has no buttons in such states), it seems to leave focus in a good state once it's gone again.

A longer term fix might involve always leaving a disabled button showing in the Guide, and disabling it using `aria-disabled` so that focus can remain on it.

Thanks to @hannahbergam for helping to think through this.
