### PR TITLE
hoai2025: level fixes

### DIFF
--- a/dashboard/config/levels/custom/music/mix-move-ai-music-prompt-3-input-choice.level
+++ b/dashboard/config/levels/custom/music/mix-move-ai-music-prompt-3-input-choice.level
@@ -8,6 +8,7 @@
   "properties": {
     "level_data": {
       "library": "launch2024",
+      "allowChangeStartingPlayheadPosition": true,
       "guideMode": "aiCodeGenerate",
       "aiCodeGenerateAdlib": {
         "id": "sounds",
@@ -76,7 +77,7 @@
             }
           ]
         },
-        "variantCount": 3
+        "variantCount": 10
       },
       "aiCodeGenerateExtraPrompt": "You can also use any of the following additional drum sounds: \"{drumSounds}\"."
     },

--- a/dashboard/config/levels/custom/music/mix-move-ai-music-prompt-3-input.level
+++ b/dashboard/config/levels/custom/music/mix-move-ai-music-prompt-3-input.level
@@ -8,6 +8,7 @@
   "properties": {
     "level_data": {
       "library": "launch2024",
+      "allowChangeStartingPlayheadPosition": true,
       "guideMode": "aiCodeGenerate",
       "aiCodeGenerateAdlib": {
         "id": "sounds",


### PR DESCRIPTION
Two small level-fixes:

- https://github.com/code-dot-org/code-dot-org/pull/69433 added the ability to change starting playhead position  to the template level, but should have added it to the two instances of the final music level (one in a regular level, the other in the final freeplay bubble choice) instead.
- https://github.com/code-dot-org/code-dot-org/pull/69393 increased the generated music variant count to 10 in the two regular music generation levels, but should have also added it to the one in the final freeplay bubble choice as well.
