### PR TITLE
Switch SlowAWSResponse from HoneyBadger to CloudWatch Metrics

### DIFF
--- a/lib/cdo/aws/s3.rb
+++ b/lib/cdo/aws/s3.rb
@@ -9,8 +9,8 @@ module AWS
   module S3
     mattr_accessor :s3
 
-    # AWS SDK client plugin to log 'slow' (as defined by :notify_timeout) S3 responses to Honeybadger,
-    # recording the request headers in the error context for further investigation.
+    # AWS SDK client plugin to log 'slow' (as defined by :notify_timeout) S3 responses to CloudWatch Metrics. Track S3
+    # API calls that take an unusually long time because that ties up our fixed pool of HTTP worker threads per vCPU.
     class SlowAwsResponseNotifier < Seahorse::Client::Plugin
       option(:notify_timeout, 5) # seconds
 
@@ -19,15 +19,13 @@ module AWS
           start_time = Time.now
           response = @handler.call(context)
           duration = Time.now - start_time
-          if duration > context.config.notify_timeout
-            Honeybadger.notify(
-              error_class: "SlowAWSResponse",
-              error_message: "Slow AWS response",
-              context: response.context.
-                http_response.headers.to_h.
-                slice('x-amz-request-id', 'x-amz-id-2').
-                merge(duration: duration)
-            )
+          # Only track long S3 API calls issued by web application server code on our production or managed test systems.
+          if CDO.running_web_application? &&
+              (CDO.rack_env?(:production) || CDO.test_system?) &&
+              duration > context.config.notify_timeout
+
+            Cdo::Metrics.put('S3Client', 'SlowResponse', 1, {Host: CDO.dashboard_hostname})
+            Cdo::Metrics.put('S3Client', 'SlowResponseDuration', duration, {Host: CDO.dashboard_hostname})
           end
           response
         end

--- a/shared/test/test_aws_s3_integration.rb
+++ b/shared/test/test_aws_s3_integration.rb
@@ -1,5 +1,6 @@
 require_relative 'test_helper'
 require 'cdo/aws/s3'
+require 'cdo/aws/metrics'
 require 'timecop'
 
 class AwsS3IntegrationTest < Minitest::Test
@@ -185,17 +186,26 @@ class AwsS3IntegrationTest < Minitest::Test
     handler(Handler)
   end
 
-  # Ensures a slow s3 request triggers a Honeybadger notification.
+  # Ensures a slow S3 response publishes CloudWatch Metrics.
   def test_s3_timeout_notify
     Aws::S3::Client.add_plugin(SlowResponder)
     Aws::S3::Client.unstub(:new)
     AWS::S3.s3 = nil
-    Honeybadger.expects(:notify).once
+    original_dashboard_hostname = CDO.dashboard_hostname
+    # Simulate conditions where tracking of slow S3 responses are enabled.
+    CDO.stubs(:running_web_application?).returns(true)
+    CDO.stubs(:test_system?).returns(true)
+    Cdo::Metrics.expects(:put).at_least(2)
     client = AWS::S3.connect_v2!
+    # Ensure Metric is published with a Host dimension that can we can ignore in CloudWatch.
+    CDO.stubs(:dashboard_hostname).returns('integration-test.example.net')
     client.head_bucket(bucket: TEST_BUCKET)
   ensure
     Aws::S3::Client.remove_plugin(SlowResponder)
     AWS::S3.s3 = nil
     Timecop.return
+    CDO.stubs(:running_web_application?).returns(false)
+    CDO.stubs(:test_system?).returns(false)
+    CDO.stubs(:dashboard_hostname).returns(original_dashboard_hostname)
   end
 end


### PR DESCRIPTION
Our primary usage of HoneyBadger is to track user HTTP requests that our web application servers raised an uncaught Error and returned a negative (HTTP 5XX) response to. We have been logging slow AWS S3 API responses in HoneyBadger which can cause the On Call engineer to mistakenly assume that these HTTP requests failed. Switch to publishing these events as CloudWatch Metrics. More discussion and context. [here](https://codedotorg.slack.com/archives/C0T0PNTM3/p1762467346339169).

## Testing story
These metrics are only published on our production and managed test server. Not sure the best way to test this change.

The calls to `Cdo::Metrics.put` are working from a development environment:

```ruby
[development] dashboard > Cdo::Metrics.put('S3Client', 'SlowResponse', 1, {Host: CDO.dashboard_hostname})
[development] dashboard >             Cdo::Metrics.put('S3Client', 'SlowResponseDuration', 25, {Host: CDO.dashboard_hostname})
=> true
[development] dashboard > exit
Flushing Cdo::Metrics::Buffer, waiting 9.99999700000626 seconds
```

<img width="1446" height="672" alt="image" src="https://github.com/user-attachments/assets/9f1be612-4104-4975-8525-41e2257a28da" />




## Deployment strategy

Add a Widget to our CloudWatch Overview Dashboard in the S3 section to track these Metrics.



## Follow-up work
<!--  List any clean-up or technical debt that will be addressed in future work.
      - Include Jira links where applicable.
      - Are there any known limitations or improvements planned? -->



## Privacy
<!--  How does this change impact Student & Teacher privacy?
      - Does this collect, use, share, or modify PII, either new or existing? -->



## Security
<!--  How does this change impact our security surface-area?
      - Do API's touched have the right auth?
      - Do infra changes impact our attack surface or encryption?
-->



## Caching
<!--  How does this change impact caching behavior?
      - Are cache keys or invalidation strategies affected?
      - Will this require cache warming or invalidation after deployment? -->



## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
