### PR TITLE
Adjust S3 Client Timeouts and Fix Connection Pool Timeout

### DIFF
--- a/dashboard/legacy/test/middleware/test_files.rb
+++ b/dashboard/legacy/test/middleware/test_files.rb
@@ -174,6 +174,7 @@ class FilesTest < FilesApiTestBase
     # for DCDO.get('disallowed_html_tags', []), which is the only call we care about in this test.
     DCDO.stubs(:get).with('disallowed_html_tags', []).returns(['script', 'meta[http-equiv]'])
     DCDO.stubs(:get).with('s3_timeout', 15).returns(15)
+    DCDO.stubs(:get).with('s3_connection_pool_timeout', 5).returns(5)
     DCDO.stubs(:get).with('s3_slow_request', 15).returns(15)
 
     filename = 'index.html'

--- a/lib/cdo/aws/s3.rb
+++ b/lib/cdo/aws/s3.rb
@@ -41,7 +41,7 @@ module AWS
       end
     end
 
-    # Creates an S3 client using the the official AWS SDK for Ruby v2 and
+    # Creates an S3 client using the AWS SDK and
     # the credentials specified in the CDO config.
     # @return [Aws::S3::Client]
     def self.connect_v2!
@@ -57,15 +57,17 @@ module AWS
                     Aws::S3::Client.new
                   end
 
-      # Adjust s3_timeout using a dynamic variable,
-      # updating the S3 client if the variable changes.
+      # Adjust the timeouts for opening an HTTP connection and waiting for a response to short values to ensure we fail
+      # fast when S3 is slow instead tying up the fixed number of HTTP worker threads we provision per vCPU.
       timeout = DCDO.get('s3_timeout', 15)
-      if timeout != s3.config.http_open_timeout
+      connection_pool_timeout = DCDO.get('s3_connection_pool_timeout', 5)
+      if CDO.running_web_application? && timeout != s3.config.http_open_timeout
         s3.config.http_open_timeout = timeout
         s3.config.http_read_timeout = timeout
-        s3.config.http_idle_timeout = timeout / 2
+        s3.config.http_idle_timeout = connection_pool_timeout # Keep unused connections in the client HTTP pool for re-use.
       end
 
+      # Custom setting that controls threshold for tracking AWS API calls that take a long time to complete.
       notify_timeout = DCDO.get('s3_slow_request', timeout)
       s3.config.notify_timeout = notify_timeout if s3.config.notify_timeout != notify_timeout
 

--- a/lib/cdo/aws/s3.rb
+++ b/lib/cdo/aws/s3.rb
@@ -41,8 +41,9 @@ module AWS
       end
     end
 
-    # Creates an S3 client using the AWS SDK and
-    # the credentials specified in the CDO config.
+    # Creates an S3 client using the AWS SDK and the credentials specified in the CDO config. When invoked after the `s3`
+    # attribute has already been initialized, the existing client's configuration will be updated with the current
+    # DCDO configuration settings.
     # @return [Aws::S3::Client]
     def self.connect_v2!
       self.s3 ||= if CDO.aws_s3_emulated
@@ -57,19 +58,20 @@ module AWS
                     Aws::S3::Client.new
                   end
 
-      # Adjust the timeouts for opening an HTTP connection and waiting for a response to short values to ensure we fail
-      # fast when S3 is slow instead tying up the fixed number of HTTP worker threads we provision per vCPU.
+      # When executing within a web application server, adjust the timeouts for opening an HTTP connection and waiting
+      # for a response to short values to ensure we fail fast when S3 is slow instead tying up the fixed number of HTTP
+      # worker threads we provision per vCPU. Code executing in cron jobs, ActiveJobs, irb (dashboard-console),
+      # and Ruby shell scripts do not need these short timeouts.
       timeout = DCDO.get('s3_timeout', 15)
       connection_pool_timeout = DCDO.get('s3_connection_pool_timeout', 5)
+      notify_timeout = DCDO.get('s3_slow_request', timeout)  # Threshold for tracking slow S3 responses.
       if CDO.running_web_application? && timeout != s3.config.http_open_timeout
         s3.config.http_open_timeout = timeout
         s3.config.http_read_timeout = timeout
         s3.config.http_idle_timeout = connection_pool_timeout # Keep unused connections in the client HTTP pool for re-use.
+        # Custom client setting for our `SlowAwsResponseNotifier` Class.
+        s3.config.notify_timeout = notify_timeout if notify_timeout != s3.config.notify_timeout
       end
-
-      # Custom setting that controls threshold for tracking AWS API calls that take a long time to complete.
-      notify_timeout = DCDO.get('s3_slow_request', timeout)
-      s3.config.notify_timeout = notify_timeout if s3.config.notify_timeout != notify_timeout
 
       s3
     end

--- a/shared/test/test_aws_s3_integration.rb
+++ b/shared/test/test_aws_s3_integration.rb
@@ -137,28 +137,44 @@ class AwsS3IntegrationTest < Minitest::Test
   end
 
   def test_s3_timeout
-    client = AWS::S3.connect_v2!
-    # Use default timeout settings by default.
-    assert_equal 60, client.config.http_read_timeout
+    client = AWS::S3.connect_v2! # Each subsequent call to `AWS::S3.connect_v2!`in this test updates `client`.
+    # AWS SDK defaults.
+    assert_equal 15, client.config.http_open_timeout, 'Default S3 client http open timeout should be 15.'
+    assert_equal 60, client.config.http_read_timeout, 'Default S3 client http read timeout should be 60.'
+    assert_equal 5, client.config.http_idle_timeout, 'Default S3 client http connection pool timeout should be 5.'
+    assert_nil client.config.notify_timeout, 'When client is initialized, custom setting notify_timeout should be nil.'
 
+    # Code not executing inside a webserver still uses AWS defaults even when settings are modified.
     DCDO.set('s3_timeout', 1)
-    # Slight limitation: change isn't applied until #connect_v2! is called.
-    assert_equal 60, client.config.http_read_timeout
-    assert_equal 1, AWS::S3.connect_v2!.config.http_read_timeout
-    # Existing client references are updated.
-    assert_equal 1, client.config.http_read_timeout
+    DCDO.set('s3_slow_request', 30)
+    DCDO.set('s3_connection_pool_timeout', 10)
+    AWS::S3.connect_v2!
+    assert_equal 15, client.config.http_open_timeout, 'Outside the web application server, S3 client http open timeout should be 15.'
+    assert_equal 60, client.config.http_read_timeout, 'Outside the web application server, S3 client http read timeout should be 60.'
+    assert_equal 5, client.config.http_idle_timeout, 'Outside the web application server, S3 client http connection pool timeout should be 5.'
+    assert_nil client.config.notify_timeout, 'Outside the web application server, custom S3 client setting notify_timeout should be nil.'
+
+    # We only apply custom S3 client timeout settings within the web server.
+    CDO.stubs(:running_web_application?).returns(true)
+    DCDO.set('s3_timeout', 1)
+    DCDO.set('s3_slow_request', 30)
+    DCDO.set('s3_connection_pool_timeout', 10)
+    AWS::S3.connect_v2!
+    assert_equal 1, client.config.http_open_timeout, 'Inside the web application server, S3 client http open timeout should be 1.'
+    assert_equal 1, client.config.http_read_timeout, 'Inside the web application server, S3 client http read timeout should be 1.'
+    assert_equal 10, client.config.http_idle_timeout, 'Inside the web application server, S3 client http connection pool timeout should be 10.'
+    assert_equal 30, client.config.notify_timeout, 'Custom slow response threshold should be 30.'
 
     DCDO.set('s3_timeout', nil)
     AWS::S3.connect_v2!
-    # Slight limitation: doesn't revert to default setting (60) if variable is set to nil.
-    assert_equal 15, client.config.http_read_timeout
+    assert_equal 15, client.config.http_read_timeout, 'Setting DCDO s3_timeout to nil does not revert read timeout to default.'
 
-    assert_equal 15, client.config.notify_timeout
-    DCDO.set('s3_slow_request', 30)
-    AWS::S3.connect_v2!
-    assert_equal 30, client.config.notify_timeout
-    assert_equal 15, client.config.http_read_timeout
+    # Reset.
+    DCDO.set('s3_timeout', nil)
     DCDO.set('s3_slow_request', nil)
+    DCDO.set('s3_connection_pool_timeout', nil)
+    AWS::S3.connect_v2!
+    CDO.stubs(:running_web_application?).returns(false)
   end
 
   # Ensure find objects with ext correctly finds and filters responses


### PR DESCRIPTION
Since the Ruby 3.1.0 --> 3.1.7 upgrade, we've seen an increase in HTTP client connectivity issues when our web application servers invoke external web services. [Discussion](https://codedotorg.slack.com/archives/C0T0PNTM3/p1762467346339169).

We fast fail S3 API calls to avoid tying up the fixed pool of HTTP worker threads that we provision per vCPU. Improve this logic by only applying it when our S3 client is executing within a web application server. There's no need for short timeouts for cronjobs or ActiveJobs.

Also - it appears that we're not correctly configuring how long to keep a connection in the client HTTP pool for re-use. This likely should be configured separately from our fast fail logic, so configure a separate dynamic configuration setting (DCDO) for it, and for now use the [AWS S3 SDK](https://docs.aws.amazon.com/sdk-for-ruby/v3/api/Aws/S3/Client.html) default. I'm speculating that the very short connection pool timeout may be exacerbating our HTTP client issues.

```
:http_idle_timeout (Float) — default: 5 — The number of seconds a connection is allowed to sit idle before it is considered stale. Stale connections are closed and removed from the pool before making a request.
```

In production, the S3 client open and read timeout in production is 2 seconds which means our client pool timeout is only 1 second:
```
[production] dashboard > DCDO.get('s3_timeout', 15)
=> 2
```

## Testing story
<!--  Does your change include appropriate tests?
      - If so, please describe how the tests included in this PR are sufficient.
      - If not, please explain why this change does not need to be tested. -->



## Deployment strategy
<!--  Any special steps required to deploy this, besides merging?
      - Are there database migrations or manual steps?
      - Does this require coordination with other teams or systems? -->



## Follow-up work
We should probably be configuring AWS SDK client timeout universally within our web application server to use short open/read timeouts. One exception might be our `Cdo::Buffer` module could use longer/default timeouts since we flush in a background thread within the web application server.


## Privacy
<!--  How does this change impact Student & Teacher privacy?
      - Does this collect, use, share, or modify PII, either new or existing? -->



## Security
<!--  How does this change impact our security surface-area?
      - Do API's touched have the right auth?
      - Do infra changes impact our attack surface or encryption?
-->



## Caching
<!--  How does this change impact caching behavior?
      - Are cache keys or invalidation strategies affected?
      - Will this require cache warming or invalidation after deployment? -->



## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
