### PR TITLE
hoai2025: no dancer in legacy dance

### DIFF
--- a/apps/src/dance/Dance.js
+++ b/apps/src/dance/Dance.js
@@ -6,7 +6,6 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import {Provider} from 'react-redux';
 
-import LottieDancerRenderer from '@cdo/apps/dance/lottie/LottieDancerRenderer';
 import ErrorBoundary from '@cdo/apps/lab2/ErrorBoundary';
 import {ErrorFallbackPage} from '@cdo/apps/lab2/views/ErrorFallbackPage';
 import firehoseClient from '@cdo/apps/metrics/firehose';
@@ -458,7 +457,7 @@ Dance.prototype.afterInject_ = function () {
     i18n: danceMsg,
     resourceLoader: new ResourceLoader(ASSET_BASE),
     logger: danceMetricsReporter,
-    externalRendererFactory: () => new LottieDancerRenderer(),
+    externalRendererFactory: undefined,
   });
 
   // Add command names from the Dance Party API to the Blockly generator's


### PR DESCRIPTION
With this change, a Lottie dancer renderer is no longer passed into legacy dance levels.

Without this change, our automated UI testing on an iPad simulator running iOS 14.5 was hitting Lottie-related errors:
<img width="250" alt="lottie-error" src="https://github.com/user-attachments/assets/22f70cd4-aa5a-414c-869b-2562d4009317" />

Just a theory, but the errors were occurring when changing effects, so it might be that Lottie was putting pressure on canvas resources on this older device.

With this change, legacy dance levels seem to work alright on the simulated iPad, and Dance in Lab2 in the new progression continues to show the new custom dancers.