### PR TITLE
hoai2025: generate dancer visuals fix

### DIFF
--- a/apps/src/dance/lab2/views/GenerateDancer.tsx
+++ b/apps/src/dance/lab2/views/GenerateDancer.tsx
@@ -293,7 +293,6 @@ const GenerateDancer: React.FunctionComponent<DancerGenerateProps> = ({
 
   const containerRef = useRef<HTMLDivElement | null>(null);
   const [containerHeight, setContainerHeight] = useState(0);
-  const [isPreviewLoading, setIsPreviewLoading] = useState(false);
   useEffect(() => {
     if (!containerRef.current) {
       return;
@@ -314,13 +313,6 @@ const GenerateDancer: React.FunctionComponent<DancerGenerateProps> = ({
   const onAdlibTextChange = useCallback((text: string) => {
     setPromptText(text);
   }, []);
-
-  // We artificially increase the 'generating' time so that the image doesn't appear
-  // too soon.
-  const showGenerating =
-    canvasKey === undefined ||
-    aiGenerateState === 'generating' ||
-    isPreviewLoading;
 
   const parentProperties = useParentLevelProperties();
   const showNavigation =
@@ -475,7 +467,7 @@ const GenerateDancer: React.FunctionComponent<DancerGenerateProps> = ({
             />
           </div>
 
-          {showGenerating && (
+          {aiGenerateState === 'generating' && (
             <div className={moduleStyles.dancerSilhouetteBright}>
               <img alt="" src={dancerSilhouetteBrightImage} />
             </div>
@@ -484,14 +476,13 @@ const GenerateDancer: React.FunctionComponent<DancerGenerateProps> = ({
           <div
             className={classNames(
               moduleStyles.dancer,
-              showGenerating && moduleStyles.dancerHidden
+              aiGenerateState === 'generating' && moduleStyles.dancerHidden
             )}
           >
             <DancerCanvas
               key={canvasKey}
               size={containerHeight * 1.1}
               move={getConfigValue('danceMove') || 'rest'}
-              onLoadingChange={setIsPreviewLoading}
             />
           </div>
         </div>


### PR DESCRIPTION
This follow-up to https://github.com/code-dot-org/code-dot-org/pull/69396 fixes a small flash of the dancer silhouette when first entering a Generate Dancer level.  The code is now simplified to only show this silhouette when we are explicitly generating a new dancer.  Thanks to @dju90 for catching this.
