### PR TITLE
hoai2025: improve dancer palette

### DIFF
--- a/apps/src/dance/lottie/LottieDancerRenderer.ts
+++ b/apps/src/dance/lottie/LottieDancerRenderer.ts
@@ -54,6 +54,7 @@ import {
   mirrorPngDataUrl,
   getHeadScale,
   cropDataUrl,
+  improvePalette,
 } from './LottieDancerUtils';
 
 const DEFAULT_SKELETON = 'unicorn';
@@ -312,6 +313,10 @@ export default class LottieDancerRenderer {
             );
           }
         }
+      }
+
+      if (palette) {
+        palette = improvePalette(palette);
       }
 
       // Recolor assets based on hard-coded accessory-name rules.

--- a/apps/src/dance/lottie/LottieDancerRenderer.ts
+++ b/apps/src/dance/lottie/LottieDancerRenderer.ts
@@ -316,6 +316,8 @@ export default class LottieDancerRenderer {
       }
 
       if (palette) {
+        // Improve palette to avoid secondary and tertiary colors being too close to
+        // primary color.
         palette = improvePalette(palette);
       }
 

--- a/apps/src/dance/lottie/LottieDancerUtils.ts
+++ b/apps/src/dance/lottie/LottieDancerUtils.ts
@@ -44,6 +44,10 @@ const PALETTES_PATH = `${SKELETONS_PATH}/palettes`;
 
 const DEFAULT_HEAD_SCALE = 0.5;
 
+// When we improve the palette, we want both secondary and tertiary to be at least
+// this far from the primary, when measured using simple Euclidean color distance.
+const COLOR_DISTANCE_REQUIRED = 0.32;
+
 // Expected colors to replace in body SVGs.
 const BODY_SVG_PRIMARY = '#33FF21';
 const BODY_SVG_SECONDARY = '#808080';
@@ -678,6 +682,7 @@ function getInlineFillFromStyle(style: string | null): string | null {
   return m ? m[1] : null;
 }
 
+/** Simple Euclidean color distance between two colors. */
 function colorDistance(color1: RGBA, color2: RGBA) {
   return Math.sqrt(
     (color1[0] - color2[0]) * (color1[0] - color2[0]) +
@@ -686,19 +691,25 @@ function colorDistance(color1: RGBA, color2: RGBA) {
   );
 }
 
+/** Simple inversion of a color. */
 function colorInverse(color: RGBA): RGBA {
   return [1 - color[0], 1 - color[1], 1 - color[2], color[3]];
 }
 
+/** Returns a new, improved palette, in which secondary and tertiary are
+ * at least COLOR_DISTANCE_REQUIRED away from primary.  If either is initially
+ * closer, then it is inverted in the returned palette.
+ */
 export function improvePalette(palette: Palette): Palette {
   if (palette.primary && palette.secondary && palette.tertiary) {
     const primary = palette.primary;
     const secondary =
-      colorDistance(palette.primary, palette.secondary) < 0.3
+      colorDistance(palette.primary, palette.secondary) <
+      COLOR_DISTANCE_REQUIRED
         ? colorInverse(palette.secondary)
         : palette.secondary;
     const tertiary =
-      colorDistance(palette.primary, palette.tertiary) < 0.3
+      colorDistance(palette.primary, palette.tertiary) < COLOR_DISTANCE_REQUIRED
         ? colorInverse(palette.tertiary)
         : palette.tertiary;
 

--- a/apps/src/dance/lottie/LottieDancerUtils.ts
+++ b/apps/src/dance/lottie/LottieDancerUtils.ts
@@ -678,6 +678,36 @@ function getInlineFillFromStyle(style: string | null): string | null {
   return m ? m[1] : null;
 }
 
+function colorDistance(color1: RGBA, color2: RGBA) {
+  return Math.sqrt(
+    (color1[0] - color2[0]) * (color1[0] - color2[0]) +
+      (color1[1] - color2[1]) * (color1[1] - color2[1]) +
+      (color1[2] - color2[2]) * (color1[2] - color2[2])
+  );
+}
+
+function colorInverse(color: RGBA): RGBA {
+  return [1 - color[0], 1 - color[1], 1 - color[2], color[3]];
+}
+
+export function improvePalette(palette: Palette): Palette {
+  if (palette.primary && palette.secondary && palette.tertiary) {
+    const primary = palette.primary;
+    const secondary =
+      colorDistance(palette.primary, palette.secondary) < 0.3
+        ? colorInverse(palette.secondary)
+        : palette.secondary;
+    const tertiary =
+      colorDistance(palette.primary, palette.secondary) < 0.3
+        ? colorInverse(palette.tertiary)
+        : palette.tertiary;
+
+    return {primary, secondary, tertiary};
+  }
+
+  return palette;
+}
+
 /**
  * Performs in-place recoloring of an SVG markup string.
  * Only shapes whose fill or inline-style fill exactly matches one of the

--- a/apps/src/dance/lottie/LottieDancerUtils.ts
+++ b/apps/src/dance/lottie/LottieDancerUtils.ts
@@ -698,7 +698,7 @@ export function improvePalette(palette: Palette): Palette {
         ? colorInverse(palette.secondary)
         : palette.secondary;
     const tertiary =
-      colorDistance(palette.primary, palette.secondary) < 0.3
+      colorDistance(palette.primary, palette.tertiary) < 0.3
         ? colorInverse(palette.tertiary)
         : palette.tertiary;
 


### PR DESCRIPTION
This adds a small client-side function to improve the dancer palette.  It ensures that the secondary and tertiary colors are far enough away from the primary color, by measuring the simple Euclidean distance of each, and inverting it if it is too close.