### PR TITLE
hoai2025: no dancer in legacy dance fix

### DIFF
--- a/apps/src/dance/lab2/ProgramExecutor.ts
+++ b/apps/src/dance/lab2/ProgramExecutor.ts
@@ -40,6 +40,7 @@ interface ProgramExecutorOptions {
   ) => void;
   stopSound?: () => void;
   onSoundEnded?: () => void;
+  externalRendererFactory?: () => LottieDancerRenderer;
 }
 
 /**
@@ -88,7 +89,7 @@ export default class ProgramExecutor {
         i18n: danceMsg,
         resourceLoader: new ResourceLoader(ASSET_BASE),
         logger: options.metricsReporter,
-        externalRendererFactory: () => new LottieDancerRenderer(),
+        externalRendererFactory: options.externalRendererFactory,
       });
     this.nativeAPI.reset();
     this.metricsReporter = options.metricsReporter;

--- a/apps/src/dance/lab2/views/DanceView.tsx
+++ b/apps/src/dance/lab2/views/DanceView.tsx
@@ -41,6 +41,7 @@ import {
   setRunIsStarting,
   setSong,
 } from '@cdo/apps/dance/danceRedux';
+import LottieDancerRenderer from '@cdo/apps/dance/lottie/LottieDancerRenderer';
 import {getFilterStatus} from '@cdo/apps/dance/songs';
 import SongSelector from '@cdo/apps/dance/SongSelector';
 import {
@@ -536,6 +537,7 @@ const DanceView: React.FunctionComponent<{
         ? () => musicProjectPlayer.current?.stop()
         : undefined,
       onSoundEnded: resetProgram,
+      externalRendererFactory: () => new LottieDancerRenderer(),
     });
 
     if (recordReplayLog) {


### PR DESCRIPTION
The attempted fix in https://github.com/code-dot-org/code-dot-org/pull/69440 wasn't quite right.  It turns out that legacy Dance Party uses `dance/lab2/ProgramExecutor.ts` for the AI modal previews, which meant it was still creating Lottie dancer renderers.  

In fact, in the Dance AI modal, it was creating a new dancer renderer every time it previewed a new set of effects, which probably helps explain the pressure on the canvas resources.  The failing UI test was hitting the Lottie canvas error while doing that sequence of  previews.

With this change, only the new Lab2 Dance view should be providing the factory to generate a dancer renderer to Dance Party.
