### PR TITLE
hoai2025: generate dancer visuals fix fix

### DIFF
--- a/apps/src/dance/lab2/views/GenerateDancer.tsx
+++ b/apps/src/dance/lab2/views/GenerateDancer.tsx
@@ -481,18 +481,20 @@ const GenerateDancer: React.FunctionComponent<DancerGenerateProps> = ({
             </div>
           )}
 
-          <div
-            className={classNames(
-              moduleStyles.dancer,
-              aiGenerateState === 'generating' && moduleStyles.dancerHidden
-            )}
-          >
-            <DancerCanvas
-              key={canvasKey}
-              size={containerHeight * 1.1}
-              move={getConfigValue('danceMove') || 'rest'}
-            />
-          </div>
+          {canvasKey && (
+            <div
+              className={classNames(
+                moduleStyles.dancer,
+                aiGenerateState === 'generating' && moduleStyles.dancerHidden
+              )}
+            >
+              <DancerCanvas
+                key={canvasKey}
+                size={containerHeight * 1.1}
+                move={getConfigValue('danceMove') || 'rest'}
+              />
+            </div>
+          )}
         </div>
       </div>
     </div>


### PR DESCRIPTION
This follow-up to https://github.com/code-dot-org/code-dot-org/pull/69441 avoids creating a new dancer renderer twice in rapid succession when beginning a Generate Dancer level.