### PR TITLE
hoai2025: background effect block

### DIFF
--- a/dashboard/config/levels/custom/dance/mix-move-ai-dance-background.level
+++ b/dashboard/config/levels/custom/dance/mix-move-ai-dance-background.level
@@ -122,7 +122,7 @@
                   },
                   "next": {
                     "block": {
-                      "type": "Dancelab_setBackgroundEffectWithPaletteAI",
+                      "type": "GeneratedDancers_setBackgroundEffectWithPalette",
                       "id": "Xe8Sdv]u~#w`bh4dz`X~",
                       "deletable": false,
                       "movable": false,

--- a/dashboard/config/levels/custom/dance/mix-move-ai-dance-move.level
+++ b/dashboard/config/levels/custom/dance/mix-move-ai-dance-move.level
@@ -126,7 +126,7 @@
                   },
                   "next": {
                     "block": {
-                      "type": "Dancelab_setBackgroundEffectWithPaletteAI",
+                      "type": "GeneratedDancers_setBackgroundEffectWithPalette",
                       "id": "}3E#h@z]BaYkI%8d)b[v",
                       "deletable": false,
                       "movable": false,


### PR DESCRIPTION
This updates the "set background effect" block in a couple levels to use the subset of effects set up in https://github.com/code-dot-org/code-dot-org/pull/69343.  

Thanks to @mikeharv for noticing this.