### PR TITLE
hoai2025: freeplay music project loading

### DIFF
--- a/apps/src/bubbleChoice/customModes/MusicDanceAi/MusicDanceAi.tsx
+++ b/apps/src/bubbleChoice/customModes/MusicDanceAi/MusicDanceAi.tsx
@@ -8,6 +8,8 @@ import {
   getCurrentLesson,
   levelById,
 } from '@cdo/apps/code-studio/progressReduxSelectors';
+import {GENERATED_DANCER_STORAGE_KEY} from '@cdo/apps/dance/ai/constants';
+import {DanceProjectSources} from '@cdo/apps/dance/types';
 import {setIsLoading} from '@cdo/apps/lab2/lab2Redux';
 import Lab2Registry from '@cdo/apps/lab2/Lab2Registry';
 import ProjectManager from '@cdo/apps/lab2/projects/ProjectManager';
@@ -25,10 +27,12 @@ import Loading from '@cdo/apps/lab2/views/Loading';
 import {getTypedKeys} from '@cdo/apps/types/utils';
 import HttpClient from '@cdo/apps/util/HttpClient';
 import {useAppDispatch, useAppSelector} from '@cdo/apps/util/reduxHooks';
+import {trySetLocalStorage} from '@cdo/apps/utils';
 
 import {lab2EntryPoints} from '../../../../lab2EntryPoints';
 import {BubbleChoiceLevelProperties} from '../../types';
 
+import {MusicProjectContext} from './MusicProjectContext';
 import {ParentLevelPropertiesContext} from './ParentLevelPropertiesContext';
 
 import styles from './styles.module.scss';
@@ -182,8 +186,18 @@ const MusicDanceAi: React.FC<MusicDanceAiProps> = ({
       }
 
       if (projectManager) {
-        await projectManager.load();
+        const {sources} = await projectManager.load();
         data.projectManager = projectManager;
+        // If present, load the generated dancer metadata into local storage so it's available for the Dance tab.
+        if (
+          tab === Tab.Dancer &&
+          (sources as DanceProjectSources)?.generatedDancer
+        ) {
+          trySetLocalStorage(
+            GENERATED_DANCER_STORAGE_KEY,
+            JSON.stringify((sources as DanceProjectSources).generatedDancer)
+          );
+        }
       }
       map[tab] = data;
     }
@@ -267,6 +281,8 @@ const MusicDanceAi: React.FC<MusicDanceAiProps> = ({
     return null;
   }
 
+  const musicData = tabDataMap[Tab.Music];
+
   const labProps = {
     ...tabData,
     initialSources: tabData.projectManager?.getLastSource(),
@@ -275,40 +291,44 @@ const MusicDanceAi: React.FC<MusicDanceAiProps> = ({
 
   return (
     <ParentLevelPropertiesContext.Provider value={levelProperties}>
-      <div className={styles.container}>
-        {!getIsShareView() && (
-          <div className={styles.tabSwitcher}>
-            {Object.values(Tab).map(tab => {
-              const disabled = !tabDataMap[tab];
-              return (
-                <button
-                  type="button"
-                  className={classNames(
-                    styles.button,
-                    disabled && styles.locked,
-                    tab === currentTab && styles.selected
-                  )}
-                  key={tab}
-                  onClick={() => (disabled ? undefined : setCurrentTab(tab))}
-                  disabled={disabled}
-                >
-                  <BodyThreeText>
-                    {disabled && <FontAwesomeV6Icon iconName={'lock'} />}
-                    {labels[tab]}
-                  </BodyThreeText>
-                </button>
-              );
-            })}
-          </div>
-        )}
-        <div className={styles.labsContainer}>
-          <div className={classNames(styles.labContainer)}>
-            <Suspense fallback={<Loading isLoading={true} />}>
-              <LabView {...labProps} key={currentTab} />
-            </Suspense>
+      <MusicProjectContext.Provider
+        value={musicData?.projectManager?.getChannelId()}
+      >
+        <div className={styles.container}>
+          {!getIsShareView() && (
+            <div className={styles.tabSwitcher}>
+              {Object.values(Tab).map(tab => {
+                const disabled = !tabDataMap[tab];
+                return (
+                  <button
+                    type="button"
+                    className={classNames(
+                      styles.button,
+                      disabled && styles.locked,
+                      tab === currentTab && styles.selected
+                    )}
+                    key={tab}
+                    onClick={() => (disabled ? undefined : setCurrentTab(tab))}
+                    disabled={disabled}
+                  >
+                    <BodyThreeText>
+                      {disabled && <FontAwesomeV6Icon iconName={'lock'} />}
+                      {labels[tab]}
+                    </BodyThreeText>
+                  </button>
+                );
+              })}
+            </div>
+          )}
+          <div className={styles.labsContainer}>
+            <div className={classNames(styles.labContainer)}>
+              <Suspense fallback={<Loading isLoading={true} />}>
+                <LabView {...labProps} key={currentTab} />
+              </Suspense>
+            </div>
           </div>
         </div>
-      </div>
+      </MusicProjectContext.Provider>
     </ParentLevelPropertiesContext.Provider>
   );
 };

--- a/apps/src/bubbleChoice/customModes/MusicDanceAi/MusicProjectContext.ts
+++ b/apps/src/bubbleChoice/customModes/MusicDanceAi/MusicProjectContext.ts
@@ -1,0 +1,6 @@
+import {createContext, useContext} from 'react';
+
+// Provides the music project channel ID to sublevels in the Music Dance AI experience.
+export const MusicProjectContext = createContext<string | undefined>(undefined);
+
+export const useMusicProject = () => useContext(MusicProjectContext);

--- a/apps/src/dance/lab2/views/DanceView.tsx
+++ b/apps/src/dance/lab2/views/DanceView.tsx
@@ -25,8 +25,8 @@ import {
   getToolboxDefinition,
   workspaceToToolboxDefinition,
 } from '@cdo/apps/blockly/utils/toolbox';
+import {useMusicProject} from '@cdo/apps/bubbleChoice/customModes/MusicDanceAi/MusicProjectContext';
 import {saveReplayLog} from '@cdo/apps/code-studio/components/shareDialogRedux';
-import {queryParams} from '@cdo/apps/code-studio/utils';
 import defaultSources from '@cdo/apps/dance/blockly/defaultSources.json';
 import {
   installSharedBlocks,
@@ -69,6 +69,7 @@ import SourcesContainer, {
 } from '@cdo/apps/lab2/views/SourcesContainer';
 import {EVENTS} from '@cdo/apps/metrics/AnalyticsConstants';
 import analyticsReporter from '@cdo/apps/metrics/AnalyticsReporter';
+import {defaultMetadata} from '@cdo/apps/music/DefaultMusic';
 import ProjectPlayer from '@cdo/apps/music/ProjectPlayer';
 import usePlaybackUpdate from '@cdo/apps/music/views/hooks/usePlaybackUpdate';
 import MusicProjectBar from '@cdo/apps/music/views/MusicProjectBar';
@@ -144,8 +145,10 @@ const DanceView: React.FunctionComponent<{
   const [loadedMusicProject, setLoadedMusicProject] = useState(false);
 
   const guideMode = levelProperties.guideMode;
+  const musicChannelId = useMusicProject();
   const usingMusicProject =
-    !!guideMode && ['aiCodeGenerate', 'instructions'].includes(guideMode);
+    guideMode === 'instructions' ||
+    (guideMode === 'aiCodeGenerate' && !!musicChannelId);
 
   const {theme} = useTheme();
 
@@ -495,18 +498,24 @@ const DanceView: React.FunctionComponent<{
 
       // Use the default music if the level specifies.
       // Otherwise use the specific channel if provided.
-      // Otherwise just pass a dummy string as we expect to find a music
-      // project in local storage.
-      const channelId =
-        guideMode === 'instructions'
-          ? 'default-music'
-          : (queryParams('music-channel') as string) || 'local-storage';
-
       musicProjectPlayer.current
-        .loadProject(channelId, guideMode === 'aiCodeGenerate')
-        .then(() => setLoadedMusicProject(true));
+        .loadProject(
+          guideMode === 'instructions'
+            ? defaultMetadata.channelId
+            : musicChannelId!
+        )
+        .then(() => setLoadedMusicProject(true))
+        .catch(error => {
+          dispatch(
+            setPageError({
+              errorMessage: 'Error loading music project',
+              error,
+              details: {channelId: musicChannelId},
+            })
+          );
+        });
     }
-  }, [usingMusicProject, guideMode]);
+  }, [usingMusicProject, musicChannelId, guideMode, dispatch]);
 
   // Set up the ProgramExecutor
   useEffect(() => {

--- a/apps/src/music/DefaultMusic.ts
+++ b/apps/src/music/DefaultMusic.ts
@@ -1,32 +1,36 @@
 import {MusicMetadata} from './ai/generate/GenerateCode';
+import {SoundEvent} from './player/interfaces/SoundEvent';
+
+const soundEvents: SoundEvent[] = [
+  {
+    id: 'pop/drum_kit_pop',
+    type: 'sound',
+    length: 2,
+    soundType: 'beat',
+    blockId: 'block-1',
+    triggered: false,
+    when: 1,
+    skipContext: {insideRandom: false, skipSound: false},
+    validationInfo: {parentControlTypes: []},
+    functionContext: {name: 'when_run', uniqueInvocationId: 18},
+  },
+  {
+    id: 'pop/drum_kit_pop',
+    type: 'sound',
+    length: 2,
+    soundType: 'beat',
+    blockId: 'block-2',
+    triggered: false,
+    when: 3,
+    skipContext: {insideRandom: false, skipSound: false},
+    validationInfo: {parentControlTypes: []},
+    functionContext: {name: 'when_run', uniqueInvocationId: 18},
+  },
+];
 
 export const defaultMetadata: MusicMetadata = {
-  playbackEvents: [
-    {
-      id: 'pop/drum_kit_pop',
-      type: 'sound',
-      length: 2,
-      //soundType: 'beat',
-      blockId: 'block-1',
-      triggered: false,
-      when: 1,
-      skipContext: {insideRandom: false, skipSound: false},
-      validationInfo: {parentControlTypes: []},
-      functionContext: {name: 'when_run', uniqueInvocationId: 18},
-    },
-    {
-      id: 'pop/drum_kit_pop',
-      type: 'sound',
-      length: 2,
-      //soundType: 'beat',
-      blockId: 'block-2',
-      triggered: false,
-      when: 3,
-      skipContext: {insideRandom: false, skipSound: false},
-      validationInfo: {parentControlTypes: []},
-      functionContext: {name: 'when_run', uniqueInvocationId: 18},
-    },
-  ],
+  channelId: 'default-music',
+  playbackEvents: soundEvents,
   lastMeasure: 5,
   packId: 'default',
   libraryName: 'launch2024',

--- a/apps/src/music/ProjectPlayer.ts
+++ b/apps/src/music/ProjectPlayer.ts
@@ -1,5 +1,3 @@
-// TODO: Better name?
-
 import {SourcesStore} from '../lab2/projects/SourcesStore';
 
 import {
@@ -30,32 +28,13 @@ class ProjectPlayer {
     setUpBlocklyForMusicLab();
   }
 
-  // TODO: Support fetching by level + user ID?
-  async loadProject(channelId: string, useLocalStorage = false) {
+  async loadProject(channelId: string) {
     this.currentMetadata = null;
     this.eventMeasures = null;
     this.workspace.initHeadless();
 
-    if (channelId === 'default-music') {
-      this.currentMetadata = defaultMetadata;
-    } else {
-      this.currentMetadata = await this.loadMetadata(
-        channelId,
-        useLocalStorage
-      );
-    }
-    const {libraryName, packId, playbackEvents} = this.currentMetadata;
-
-    let library = MusicLibrary.getInstance();
-    if (!library) {
-      library = await MusicLibrary.loadLibrary(libraryName || 'launch2024');
-    }
-
-    if (packId) {
-      library.setCurrentPackId(packId);
-    }
-
-    this.player.updateConfiguration(library.getBPM(), library.getKey());
+    this.currentMetadata = await this.loadMetadata(channelId);
+    const playbackEvents = this.currentMetadata.playbackEvents;
     this.eventMeasures = computeEventMeasures(playbackEvents);
 
     await this.player.preloadSounds(playbackEvents);
@@ -74,7 +53,7 @@ class ProjectPlayer {
           this.player.getCurrentPlayheadPosition();
 
         // Stop the song after the last measure.
-        if (currentPlayheadPosition >= lastMeasure) {
+        if (currentPlayheadPosition >= lastMeasure + 1) {
           onEnded?.();
           this.stop();
         }
@@ -118,33 +97,64 @@ class ProjectPlayer {
     return this.currentMetadata;
   }
 
-  private async loadMetadata(
-    channelId: string,
-    useLocalStorage = false
-  ): Promise<MusicMetadata> {
-    // Try to load from local storage if it exists
-    if (useLocalStorage) {
-      const metadataString = localStorage.getItem(cacheKey());
-      if (metadataString) {
-        return JSON.parse(metadataString) as MusicMetadata;
+  private async loadMetadata(channelId: string): Promise<MusicMetadata> {
+    // Return default if specified.
+    if (channelId === defaultMetadata.channelId) {
+      return this.prepareLibraryFromMetadata(defaultMetadata);
+    }
+
+    // Try to load from local storage if it exists.
+    const metadataString = localStorage.getItem(cacheKey());
+    if (metadataString) {
+      try {
+        const localStorageMetadata = JSON.parse(
+          metadataString
+        ) as MusicMetadata;
+        if (localStorageMetadata.channelId === channelId) {
+          return this.prepareLibraryFromMetadata(localStorageMetadata);
+        }
+      } catch (e) {
+        // Ignore JSON parse errors and fall through to loading from server.
       }
     }
 
     // Otherwise, load from server.
     const sources = await this.sourcesStore.load(channelId);
     const labConfig = sources.labConfig as MusicLabConfig;
+    // Prepare library so sounds are available during code execution.
+    await this.prepareLibrary(labConfig.music.library, labConfig.music.packId);
+
     this.workspace.loadCode(JSON.parse(sources.source as string));
     this.workspace.compileSong(labConfig.music.blockMode);
     const {playbackEvents, orderedFunctions, lastMeasure} =
       this.workspace.executeCompiledSong();
 
     return {
+      channelId,
       playbackEvents,
       orderedFunctions,
       lastMeasure,
       packId: labConfig.music.packId,
       libraryName: labConfig.music.library,
     };
+  }
+
+  private async prepareLibrary(libraryName?: string, packId?: string) {
+    let library = MusicLibrary.getInstance();
+    if (!library) {
+      library = await MusicLibrary.loadLibrary(libraryName || 'launch2024');
+    }
+
+    if (packId) {
+      library.setCurrentPackId(packId);
+    }
+
+    this.player.updateConfiguration(library.getBPM(), library.getKey());
+  }
+
+  private async prepareLibraryFromMetadata(metadata: MusicMetadata) {
+    await this.prepareLibrary(metadata.libraryName, metadata.packId);
+    return metadata;
   }
 }
 

--- a/apps/src/music/ai/generate/GenerateCode.ts
+++ b/apps/src/music/ai/generate/GenerateCode.ts
@@ -20,6 +20,7 @@ import {GenerateContext} from './GenerateCodeContent';
 export const cacheKey = () => `music-ai-generate`;
 
 export interface MusicMetadata {
+  channelId: string;
   playbackEvents: PlaybackEvent[];
   orderedFunctions: FunctionEvents[];
   lastMeasure: number;
@@ -38,6 +39,7 @@ export const saveGeneratedSongMetadata = (
   trySetLocalStorage(
     cacheKey(),
     JSON.stringify({
+      channelId,
       playbackEvents: events,
       orderedFunctions,
       lastMeasure,


### PR DESCRIPTION
This PR adds logic to load the correct music project from the associated channel ID on music dance AI freeplay and standalone levels, so we're not dependent on the music code already being loaded into local storage. We will still check local storage, but only use the code if the metadata matches the channel ID we want. If not present, we will load the project from the server, compile and execute the events, and use those in our Dance project.

Fortunately, since the only level type where we need to support this is the custom freeplay combo experience, we already know which music channel ID we need to use (the channel ID associated with the music sublevel). We expose the channel ID to DanceView using a `MusicProjectContext`. Additionally, we also pre-load the generated dancer metadata into local storage when loading the freeplay/standalone level so it's available for the dance tab, without first having to navigate to the dancer tab.

This change formally removes our hard dependency on local storage for these level types, and allows a project to be viewed by other users and other browsers with all the right data present. It also means that data persists even if local storage is cleared for any reason (see video below). With this, the only local storage dependent levels are the non-freeplay Dance party levels which will always use the _last generated dancer_ regardless of level. Ideally, we'd solve this as well by explicitly "linking" Dance party levels to dancer levels, but we're deferring this fix for later as it only affects specific levels in the tutorial in very specific scenarios.

Video flow showing freeplay data persisting after clearing local storage, sharing, and viewing in a different browser:

https://github.com/user-attachments/assets/41a271e4-75a4-4fca-9fb9-be1a453a5ec3

## Links

## Testing story
- Tested locally with freeplay level and converting to a standalone project.