### PR TITLE
hoai2025: share link behind DCDO flag

### DIFF
--- a/apps/src/lab2/views/dialogs/CopyToClipboardButton.tsx
+++ b/apps/src/lab2/views/dialogs/CopyToClipboardButton.tsx
@@ -1,0 +1,49 @@
+import {Button} from '@code-dot-org/component-library/button';
+import React, {useCallback, useState} from 'react';
+
+import {ProjectType} from '@cdo/apps/lab2/types';
+import {EVENTS, PLATFORMS} from '@cdo/apps/metrics/AnalyticsConstants';
+import analyticsReporter from '@cdo/apps/metrics/AnalyticsReporter';
+import {commonI18n as i18n} from '@cdo/apps/types/locale';
+import copyToClipboard from '@cdo/apps/util/copyToClipboard';
+import trackEvent from '@cdo/apps/util/trackEvent';
+
+import moduleStyles from './share-dialog.module.scss';
+
+export const CopyToClipboardButton: React.FunctionComponent<{
+  shareUrl: string;
+  projectType: ProjectType;
+  channelId: string | undefined;
+}> = ({shareUrl, projectType, channelId}) => {
+  const [copiedToClipboard, setCopiedToClipboard] = useState(false);
+
+  const handleCopyToClipboard = useCallback(() => {
+    copyToClipboard(shareUrl, () => {
+      setCopiedToClipboard(true);
+    });
+    trackEvent('share', 'share_copy_url', {value: projectType});
+    analyticsReporter.sendEvent(
+      EVENTS.SHARING_LINK_COPY,
+      {
+        lab_type: projectType,
+        channel_id: channelId,
+      },
+      PLATFORMS.STATSIG
+    );
+  }, [shareUrl, projectType, channelId]);
+
+  return (
+    <Button
+      iconLeft={{
+        iconName: copiedToClipboard ? 'clipboard-check' : 'clipboard',
+      }}
+      ariaLabel={i18n.copyLinkToProject()}
+      text={i18n.copyLinkToProject()}
+      type="secondary"
+      color="black"
+      size="m"
+      onClick={handleCopyToClipboard}
+      className={moduleStyles.shareDialogButton}
+    />
+  );
+};

--- a/apps/src/lab2/views/dialogs/ShareDialog.tsx
+++ b/apps/src/lab2/views/dialogs/ShareDialog.tsx
@@ -5,7 +5,7 @@ import Modal from '@code-dot-org/component-library/modal';
 import Typography from '@code-dot-org/component-library/typography';
 import classNames from 'classnames';
 import QRCode from 'qrcode.react';
-import React, {useCallback, useState} from 'react';
+import React, {useCallback} from 'react';
 import FocusLock from 'react-focus-lock';
 
 import {hideShareDialog} from '@cdo/apps/code-studio/components/shareDialogRedux';
@@ -17,11 +17,10 @@ import analyticsReporter from '@cdo/apps/metrics/AnalyticsReporter';
 import {SignInState} from '@cdo/apps/templates/currentUserRedux';
 import {SubmissionStatusType} from '@cdo/apps/templates/projects/submitProjectDialog/submitProjectApi';
 import {commonI18n as i18n} from '@cdo/apps/types/locale';
-import copyToClipboard from '@cdo/apps/util/copyToClipboard';
 import {useAppDispatch, useAppSelector} from '@cdo/apps/util/reduxHooks';
-import trackEvent from '@cdo/apps/util/trackEvent';
 import {ProjectSubmissionStatus} from '@cdo/generated-scripts/sharedConstants';
 
+import {CopyToClipboardButton} from './CopyToClipboardButton';
 import HoaiCongrats from './finishDialogs/HoaiCongrats';
 
 import moduleStyles from './share-dialog.module.scss';
@@ -30,44 +29,6 @@ const TEACHER_FEEDBACK_LINK =
   'https://docs.google.com/forms/d/e/1FAIpQLSflGeMmY_ff1QllJfpTsWGZdn_xv6dKpPba_evTMwfbvG3FTA/viewform';
 const STUDENT_FEEDBACK_LINK =
   'https://docs.google.com/forms/d/e/1FAIpQLSeZGNgX4wDvA29stId_Q2toofJN-r12zSP8yBMZ-E9KW5XPWg/viewform';
-
-const CopyToClipboardButton: React.FunctionComponent<{
-  shareUrl: string;
-  projectType: ProjectType;
-  channelId: string | undefined;
-}> = ({shareUrl, projectType, channelId}) => {
-  const [copiedToClipboard, setCopiedToClipboard] = useState(false);
-
-  const handleCopyToClipboard = useCallback(() => {
-    copyToClipboard(shareUrl, () => {
-      setCopiedToClipboard(true);
-    });
-    trackEvent('share', 'share_copy_url', {value: projectType});
-    analyticsReporter.sendEvent(
-      EVENTS.SHARING_LINK_COPY,
-      {
-        lab_type: projectType,
-        channel_id: channelId,
-      },
-      PLATFORMS.STATSIG
-    );
-  }, [shareUrl, projectType, channelId]);
-
-  return (
-    <Button
-      iconLeft={{
-        iconName: copiedToClipboard ? 'clipboard-check' : 'clipboard',
-      }}
-      ariaLabel={i18n.copyLinkToProject()}
-      text={i18n.copyLinkToProject()}
-      type="secondary"
-      color="black"
-      size="m"
-      onClick={handleCopyToClipboard}
-      className={moduleStyles.shareDialogButton}
-    />
-  );
-};
 
 const AfeCareerTourBlock: React.FunctionComponent = () => {
   const careersUrl =
@@ -196,6 +157,9 @@ const ShareDialog: React.FunctionComponent<{
       <HoaiCongrats
         handleClose={handleClose}
         finishUrl={finishUrl}
+        shareUrl={shareUrl}
+        projectType={projectType}
+        channelId={channelId}
         theme={theme}
       />
     );

--- a/apps/src/lab2/views/dialogs/finishDialogs/HoaiCongrats.tsx
+++ b/apps/src/lab2/views/dialogs/finishDialogs/HoaiCongrats.tsx
@@ -1,17 +1,40 @@
 import {Theme} from '@code-dot-org/component-library/common/contexts';
 import Modal from '@code-dot-org/component-library/modal';
+import Typography from '@code-dot-org/component-library/typography';
+import QRCode from 'qrcode.react';
 import React from 'react';
+
+import {queryParams} from '@cdo/apps/code-studio/utils';
+import DCDO from '@cdo/apps/dcdo';
+import {ProjectType} from '@cdo/apps/lab2/types';
+
+import {CopyToClipboardButton} from '../CopyToClipboardButton';
+
+import styles from './hoai-congrats.module.scss';
+
+const key = 'hoai2025-share-enabled';
+const shareEnabled = DCDO.get(key, false) || queryParams(key) === 'true';
 
 interface Props {
   handleClose: () => void;
   finishUrl: string;
+  shareUrl: string;
+  projectType: ProjectType;
+  channelId: string | undefined;
   theme?: Theme;
 }
 
 /**
  * Congrats dialog shown for Hour of AI activities.
  */
-const HoaiCongrats: React.FC<Props> = ({handleClose, finishUrl, theme}) => {
+const HoaiCongrats: React.FC<Props> = ({
+  handleClose,
+  finishUrl,
+  shareUrl,
+  theme,
+  projectType,
+  channelId,
+}) => {
   return (
     <Modal
       data-theme={theme}
@@ -19,6 +42,28 @@ const HoaiCongrats: React.FC<Props> = ({handleClose, finishUrl, theme}) => {
       description="You finished this Hour of AI activity. What's next?"
       primaryButtonProps={{text: 'Finish', href: finishUrl, useAsLink: true}}
       secondaryButtonProps={{text: 'Keep Playing', onClick: handleClose}}
+      customContent={
+        shareEnabled && (
+          <div className={styles.shareContainer}>
+            <div className={styles.block}>
+              <Typography semanticTag="h2" visualAppearance="heading-md">
+                Share your project
+              </Typography>
+              <div className={styles.qrCode} id="share-qrcode-container">
+                <QRCode
+                  value={shareUrl + '?qr=true'}
+                  size={parseInt(styles.qrCodeSize)}
+                />
+              </div>
+              <CopyToClipboardButton
+                shareUrl={shareUrl}
+                projectType={projectType}
+                channelId={channelId}
+              />
+            </div>
+          </div>
+        )
+      }
     />
   );
 };

--- a/apps/src/lab2/views/dialogs/finishDialogs/hoai-congrats.module.scss
+++ b/apps/src/lab2/views/dialogs/finishDialogs/hoai-congrats.module.scss
@@ -1,0 +1,35 @@
+$qr-code-size: 117;
+
+.shareContainer {
+  display: flex;
+  width: 100%;
+  justify-content: center;
+}
+
+.block {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  padding: 20px;
+  background-color: var(--background-neutral-tertiary);
+  align-items: center;
+  border-radius: 10px;
+  width: 280px;
+  box-sizing: border-box;
+  
+  > h2 {
+    margin: 0;
+  }
+}
+
+.qrCode {
+  padding: 4px;
+  border-radius: 4px;
+  background-color: white;
+  height: #{$qr-code-size}px;
+  width: #{$qr-code-size}px;
+}
+
+:export {
+  qrCodeSize: $qr-code-size;
+}

--- a/lib/dynamic_config/dcdo.rb
+++ b/lib/dynamic_config/dcdo.rb
@@ -71,7 +71,8 @@ class DCDOBase < DynamicConfigBase
       'actioncable-disconnect-timeout': DCDO.get('actioncable-disconnect-timeout', 30 * 1000),
       'disable-progress-v1': DCDO.get('disable-progress-v1', false),
       'detect-remote-network-config': DCDO.get('detect-remote-network-config', {}),
-      'show-aita-lesson-summaries': DCDO.get('show-aita-lesson-summaries', false)
+      'show-aita-lesson-summaries': DCDO.get('show-aita-lesson-summaries', false),
+      'hoai2025-share-enabled': DCDO.get('hoai2025-share-enabled', false)
     }
   end
 end


### PR DESCRIPTION
Adds the sharing QR code and button to the Hour of AI congrats/finish dialog hidden behind a DCDO flag `'hoai2025-share-enabled'`. It can also be enabled via query param (`?hoai2025-share-dialog=true`). This allows us to prepare sharing/standalone features but keep them inaccessible until we're ready to turn them on.

The share UI is modeled after the existing HOC 2024 share dialog, but split out into its own style/component in case we'd like to deviate from the existing styling in the future.

<img width="1512" height="826" alt="Screenshot 2025-11-09 at 2 31 07 PM" src="https://github.com/user-attachments/assets/441867bc-405c-479f-b695-fc260d520cfc" />