### PR TITLE
hoai2025: generate dancer visuals fix

### DIFF
--- a/apps/src/dance/lab2/views/generate-dancer.module.scss
+++ b/apps/src/dance/lab2/views/generate-dancer.module.scss
@@ -75,7 +75,6 @@
 }
 
 .background {
-  position: absolute;
   height: 107%;
 
   .backgroundImage {
@@ -87,6 +86,7 @@
   position: absolute;
   display: flex;
   justify-content: center;
+  width: 100%;
   height: 99.5%;
   opacity: 1;
   animation: fadein 5s;


### PR DESCRIPTION
The Generate Dancer DOM was giving Safari trouble.  Having a `position: relative` `div` with only `position: absolute` children was causing the background to actually move around, and also froze the DOM developer tools.

This follow-up to https://github.com/code-dot-org/code-dot-org/pull/69396 fixes the issue, and also improves the sizing of the silhouette.