### PR TITLE
hoai2025: share OG image

### DIFF
--- a/dashboard/app/assets/images/music_dance_ai_sharing_drawing.png
+++ b/dashboard/app/assets/images/music_dance_ai_sharing_drawing.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ecd4ad060c90fca54ad2eb783a225cdf4e3f039c32465c86b2eea440308fa9a2
+size 3021913

--- a/dashboard/app/helpers/application_helper.rb
+++ b/dashboard/app/helpers/application_helper.rb
@@ -174,6 +174,9 @@ module ApplicationHelper
       else
         asset_url "bounce_sharing_drawing.png"
       end
+    elsif opts[:level].is_a?(BubbleChoice)
+      project_type = opts[:level].try(:project_type)
+      asset_url "#{project_type}_sharing_drawing.png"
     else
       asset_url 'sharing_drawing.png'
     end

--- a/dashboard/app/views/shared/_sharing_meta_tags.html.haml
+++ b/dashboard/app/views/shared/_sharing_meta_tags.html.haml
@@ -1,5 +1,5 @@
 -# only works for pages that have a @level
-- if @level && @level.game.supports_sharing?
+- if @level && (@level.game.supports_sharing? || @level.try(:supports_sharing?))
   - content_for :og do
     = tag 'meta', name: 'viewport', content: 'initial-scale=1'
 


### PR DESCRIPTION
Enables the meta 'og' tags to show a custom image for this project type.

<img width="384" height="279" alt="Screenshot 2025-11-09 at 6 01 35 PM" src="https://github.com/user-attachments/assets/fe33e4df-4515-4ef0-932c-a9a9a40f83c2" />

## Links

- Jira: https://codedotorg.atlassian.net/browse/LABS-1648