### PR TITLE
hoai2025: initial dancer choices

### DIFF
--- a/apps/src/dance/lab2/views/GenerateDancer.tsx
+++ b/apps/src/dance/lab2/views/GenerateDancer.tsx
@@ -100,10 +100,7 @@ const GenerateDancer: React.FunctionComponent<DancerGenerateProps> = ({
     (adlibsValue: AdlibsType) => {
       const initial: AdlibChoices = {};
       if (adlibsValue) {
-        const raw = localStorage.getItem(GENERATED_DANCER_STORAGE_KEY);
-        const lastDancer = raw
-          ? (JSON.parse(raw) as GeneratedDancerMetadata)
-          : null;
+        const lastChoices = currentSources.generatedDancer?.choices;
 
         Object.keys(adlibsValue[adlibOption]?.options || []).forEach(
           (key, index) => {
@@ -112,10 +109,10 @@ const GenerateDancer: React.FunctionComponent<DancerGenerateProps> = ({
             if (
               options
                 .map(option => option.id)
-                .includes(lastDancer?.choices[index] || '')
+                .includes(lastChoices?.[index] || '')
             ) {
               // Use a value from the last saved dancer.
-              initial[key] = lastDancer?.choices[index] || '';
+              initial[key] = lastChoices?.[index] || '';
             } else {
               // Select a random value.
               initial[key] = sample(options)?.id || '';
@@ -125,7 +122,7 @@ const GenerateDancer: React.FunctionComponent<DancerGenerateProps> = ({
       }
       return initial;
     },
-    [adlibOption]
+    [adlibOption, currentSources.generatedDancer?.choices]
   );
 
   useEffect(() => {
@@ -159,13 +156,18 @@ const GenerateDancer: React.FunctionComponent<DancerGenerateProps> = ({
 
       setAiGenerateState('none');
       setAdlibs(adlibsValue);
-      setAdlibChoices(getInitialChoices(adlibsValue));
       setPromptText('');
       variantHistory.current = [];
     };
 
     fetchAdlib();
   }, [adlibs, aiGenerateState, getInitialChoices]);
+
+  useEffect(() => {
+    if (adlibs && currentSources) {
+      setAdlibChoices(getInitialChoices(adlibs));
+    }
+  }, [adlibs, currentSources, getInitialChoices]);
 
   useLifecycleNotifier(LifecycleEvent.LevelLoadCompleted, () => {
     setAiGenerateState('loading');

--- a/apps/src/dance/lab2/views/GenerateDancer.tsx
+++ b/apps/src/dance/lab2/views/GenerateDancer.tsx
@@ -100,10 +100,28 @@ const GenerateDancer: React.FunctionComponent<DancerGenerateProps> = ({
     (adlibsValue: AdlibsType) => {
       const initial: AdlibChoices = {};
       if (adlibsValue) {
-        Object.keys(adlibsValue[adlibOption]?.options || []).forEach(key => {
-          const options = adlibsValue[adlibOption].options[key];
-          initial[key] = sample(options)?.id || '';
-        });
+        const raw = localStorage.getItem(GENERATED_DANCER_STORAGE_KEY);
+        const lastDancer = raw
+          ? (JSON.parse(raw) as GeneratedDancerMetadata)
+          : null;
+
+        Object.keys(adlibsValue[adlibOption]?.options || []).forEach(
+          (key, index) => {
+            const options = adlibsValue[adlibOption].options[key];
+
+            if (
+              options
+                .map(option => option.id)
+                .includes(lastDancer?.choices[index] || '')
+            ) {
+              // Use a value from the last saved dancer.
+              initial[key] = lastDancer?.choices[index] || '';
+            } else {
+              // Select a random value.
+              initial[key] = sample(options)?.id || '';
+            }
+          }
+        );
       }
       return initial;
     },

--- a/apps/src/dance/lab2/views/GenerateDancer.tsx
+++ b/apps/src/dance/lab2/views/GenerateDancer.tsx
@@ -100,7 +100,10 @@ const GenerateDancer: React.FunctionComponent<DancerGenerateProps> = ({
     (adlibsValue: AdlibsType) => {
       const initial: AdlibChoices = {};
       if (adlibsValue) {
-        const lastChoices = currentSources.generatedDancer?.choices;
+        const lastChoices = [
+          ...(currentSources.generatedDancer?.choices || []),
+          ...(currentSources.generatedDancer?.choicesExtra || []),
+        ];
 
         Object.keys(adlibsValue[adlibOption]?.options || []).forEach(
           (key, index) => {
@@ -122,7 +125,7 @@ const GenerateDancer: React.FunctionComponent<DancerGenerateProps> = ({
       }
       return initial;
     },
-    [adlibOption, currentSources.generatedDancer?.choices]
+    [adlibOption, currentSources.generatedDancer]
   );
 
   useEffect(() => {


### PR DESCRIPTION
If a dancer has been previously generated, then a subsequent Generate Dancer adlib will prepopulate itself with the choices that it can use from that previous set.  It works whether the new adlib has fewer, more, or the same number of choices as the previous one.
