### PR TITLE
hoai2025: fallback to default music if not found

### DIFF
--- a/apps/src/music/ProjectPlayer.ts
+++ b/apps/src/music/ProjectPlayer.ts
@@ -1,4 +1,5 @@
 import {SourcesStore} from '../lab2/projects/SourcesStore';
+import {NetworkError} from '../util/HttpClient';
 
 import {
   cacheKey,
@@ -119,24 +120,39 @@ class ProjectPlayer {
     }
 
     // Otherwise, load from server.
-    const sources = await this.sourcesStore.load(channelId);
-    const labConfig = sources.labConfig as MusicLabConfig;
-    // Prepare library so sounds are available during code execution.
-    await this.prepareLibrary(labConfig.music.library, labConfig.music.packId);
+    try {
+      const sources = await this.sourcesStore.load(channelId);
+      const labConfig = sources.labConfig as MusicLabConfig;
+      // Prepare library so sounds are available during code execution.
+      await this.prepareLibrary(
+        labConfig.music.library,
+        labConfig.music.packId
+      );
 
-    this.workspace.loadCode(JSON.parse(sources.source as string));
-    this.workspace.compileSong(labConfig.music.blockMode);
-    const {playbackEvents, orderedFunctions, lastMeasure} =
-      this.workspace.executeCompiledSong();
+      this.workspace.loadCode(JSON.parse(sources.source as string));
+      this.workspace.compileSong(labConfig.music.blockMode);
+      const {playbackEvents, orderedFunctions, lastMeasure} =
+        this.workspace.executeCompiledSong();
 
-    return {
-      channelId,
-      playbackEvents,
-      orderedFunctions,
-      lastMeasure,
-      packId: labConfig.music.packId,
-      libraryName: labConfig.music.library,
-    };
+      return {
+        channelId,
+        playbackEvents,
+        orderedFunctions,
+        lastMeasure,
+        packId: labConfig.music.packId,
+        libraryName: labConfig.music.library,
+      };
+    } catch (e) {
+      if (
+        e instanceof NetworkError &&
+        (e as NetworkError).response.status === 404
+      ) {
+        // Use default metadata if a music project has not yet been created.
+        return this.prepareLibraryFromMetadata(defaultMetadata);
+      } else {
+        throw e;
+      }
+    }
   }
 
   private async prepareLibrary(libraryName?: string, packId?: string) {


### PR DESCRIPTION
Fix for a case where you load the final freeplay level without ever having created a music project. In that case, instead of erroring out, we'll just fall back to the default "Starter Beat" music.

## Testing story
- Tested locally by starting the progression as a signed out user and going directly to level 14 (final freeplay).