### PR TITLE
feat(redirect): redirect Pegasus HoC API routes to Dashboard through Marketing

### DIFF
--- a/aws/cloudformation/lambdas/marketing-router/index.js
+++ b/aws/cloudformation/lambdas/marketing-router/index.js
@@ -793,6 +793,7 @@ const marketingPaths = {
 const pathPatterns = [
   /^\/_next\/static\//, // Next.js static assets
   /^\/_next\/image/,  // Next.js dynamic images, /_next/image*
+  /^\/api\/hour\//,     // /api/hour/*
   /^\/forms\//,         // /forms/*
   /^\/schools\//,       // /schools/*
   /^\/applab\/docs\//,  // /applab/docs/*

--- a/lib/cdo/http_cache.rb
+++ b/lib/cdo/http_cache.rb
@@ -361,16 +361,6 @@ class HttpCache
             },
           ],
         },
-        pegasus: {
-          behaviors: [
-            {
-              path: "#{HocLegacy::API_ROOT_PATH}/*",
-              proxy: 'dashboard',
-              headers: ALLOWLISTED_HEADERS,
-              cookies: allowlisted_cookies,
-            },
-          ],
-        }
       )
     end
 

--- a/lib/cdo/http_cache.rb
+++ b/lib/cdo/http_cache.rb
@@ -361,6 +361,16 @@ class HttpCache
             },
           ],
         },
+        pegasus: {
+          behaviors: [
+            {
+              path: "#{HocLegacy::API_ROOT_PATH}/*",
+              proxy: 'dashboard',
+              headers: ALLOWLISTED_HEADERS,
+              cookies: allowlisted_cookies,
+            },
+          ],
+        }
       )
     end
 


### PR DESCRIPTION
## Links
- Related PR: https://github.com/code-dot-org/marketing-sites/pull/13