### PR TITLE
Add Statsig analytics for lab introJS flows

### DIFF
--- a/apps/src/lab2/views/components/Instructions/ResourcePanel/OnboardingTourSteps.tsx
+++ b/apps/src/lab2/views/components/Instructions/ResourcePanel/OnboardingTourSteps.tsx
@@ -1,7 +1,11 @@
 import {Steps} from 'intro.js-react';
 import React from 'react';
 
+import {getCurrentLevel} from '@cdo/apps/code-studio/progressReduxSelectors';
+import {sendLab2AnalyticsEvent} from '@cdo/apps/lab2/utils';
+import {EVENTS} from '@cdo/apps/metrics/AnalyticsConstants';
 import {commonI18n} from '@cdo/apps/types/locale';
+import {useAppSelector} from '@cdo/apps/util/reduxHooks';
 import {tryGetLocalStorage, trySetLocalStorage} from '@cdo/apps/utils';
 
 import {RESOURCE_PANEL_PINNED_BUTTON_ONBOARDING_TOUR_SEEN} from './constants';
@@ -17,26 +21,40 @@ if (urlParams.get('noIntrojs') === 'true') {
 // Note that this introjs flow includes a step that highlights the navigation button which is always visible
 // at the bottom of the resource panel (whether it's enabled or not).
 // Some labs do not always show the navigation button so this tour is not appropriate for all labs.
-const OnboardingTourSteps: React.FC = () => {
+const OnboardingTourSteps: React.FC<{appName: string}> = ({appName}) => {
   const resourcePanelPinnedButtonOnboardingTourSeen = tryGetLocalStorage(
     RESOURCE_PANEL_PINNED_BUTTON_ONBOARDING_TOUR_SEEN,
     'no'
   );
+  const levelPath =
+    useAppSelector(state => getCurrentLevel(state)?.path) || 'standalone';
 
   return (
     <Steps
       enabled={resourcePanelPinnedButtonOnboardingTourSeen !== 'yes'}
+      onStart={() => {
+        sendLab2AnalyticsEvent(EVENTS.INTROJS_FLOW_STARTED, appName, {
+          flowName: 'Resource Panel Onboarding',
+          levelPath,
+        });
+      }}
       initialStep={INITIAL_STEP}
       steps={STEPS}
       onExit={() => {
-        console.log('onExit');
+        sendLab2AnalyticsEvent(EVENTS.INTROJS_FLOW_EXIT, appName, {
+          flowName: 'Resource Panel Onboarding',
+          levelPath,
+        });
         trySetLocalStorage(
           RESOURCE_PANEL_PINNED_BUTTON_ONBOARDING_TOUR_SEEN,
           'yes'
         );
       }}
       onComplete={() => {
-        console.log('onComplete');
+        sendLab2AnalyticsEvent(EVENTS.INTROJS_FLOW_COMPLETED, appName, {
+          flowName: 'Resource Panel Onboarding',
+          levelPath,
+        });
       }}
       options={{
         scrollToElement: false,

--- a/apps/src/lab2/views/components/Instructions/ResourcePanel/OnboardingTourSteps.tsx
+++ b/apps/src/lab2/views/components/Instructions/ResourcePanel/OnboardingTourSteps.tsx
@@ -26,8 +26,7 @@ const OnboardingTourSteps: React.FC<{appName: string}> = ({appName}) => {
     RESOURCE_PANEL_PINNED_BUTTON_ONBOARDING_TOUR_SEEN,
     'no'
   );
-  const levelPath =
-    useAppSelector(state => getCurrentLevel(state)?.path) || 'standalone';
+  const levelPath = useAppSelector(state => getCurrentLevel(state)?.path) || '';
 
   return (
     <Steps

--- a/apps/src/lab2/views/components/Instructions/ResourcePanel/OnboardingTourSteps.tsx
+++ b/apps/src/lab2/views/components/Instructions/ResourcePanel/OnboardingTourSteps.tsx
@@ -18,6 +18,8 @@ if (urlParams.get('noIntrojs') === 'true') {
   trySetLocalStorage(RESOURCE_PANEL_PINNED_BUTTON_ONBOARDING_TOUR_SEEN, 'yes');
 }
 
+const RESOURCE_PANEL_ONBOARDING_FLOW_NAME = 'Resource Panel Onboarding';
+
 // Note that this introjs flow includes a step that highlights the navigation button which is always visible
 // at the bottom of the resource panel (whether it's enabled or not).
 // Some labs do not always show the navigation button so this tour is not appropriate for all labs.
@@ -33,7 +35,7 @@ const OnboardingTourSteps: React.FC<{appName: string}> = ({appName}) => {
       enabled={resourcePanelPinnedButtonOnboardingTourSeen !== 'yes'}
       onStart={() => {
         sendLab2AnalyticsEvent(EVENTS.INTROJS_FLOW_STARTED, appName, {
-          flowName: 'Resource Panel Onboarding',
+          flowName: RESOURCE_PANEL_ONBOARDING_FLOW_NAME,
           levelPath,
         });
       }}
@@ -41,7 +43,7 @@ const OnboardingTourSteps: React.FC<{appName: string}> = ({appName}) => {
       steps={STEPS}
       onExit={() => {
         sendLab2AnalyticsEvent(EVENTS.INTROJS_FLOW_EXIT, appName, {
-          flowName: 'Resource Panel Onboarding',
+          flowName: RESOURCE_PANEL_ONBOARDING_FLOW_NAME,
           levelPath,
         });
         trySetLocalStorage(
@@ -51,7 +53,7 @@ const OnboardingTourSteps: React.FC<{appName: string}> = ({appName}) => {
       }}
       onComplete={() => {
         sendLab2AnalyticsEvent(EVENTS.INTROJS_FLOW_COMPLETED, appName, {
-          flowName: 'Resource Panel Onboarding',
+          flowName: RESOURCE_PANEL_ONBOARDING_FLOW_NAME,
           levelPath,
         });
       }}

--- a/apps/src/lab2/views/components/Instructions/ResourcePanel/OnboardingTourSteps.tsx
+++ b/apps/src/lab2/views/components/Instructions/ResourcePanel/OnboardingTourSteps.tsx
@@ -29,10 +29,14 @@ const OnboardingTourSteps: React.FC = () => {
       initialStep={INITIAL_STEP}
       steps={STEPS}
       onExit={() => {
+        console.log('onExit');
         trySetLocalStorage(
           RESOURCE_PANEL_PINNED_BUTTON_ONBOARDING_TOUR_SEEN,
           'yes'
         );
+      }}
+      onComplete={() => {
+        console.log('onComplete');
       }}
       options={{
         scrollToElement: false,

--- a/apps/src/lab2/views/components/Instructions/ResourcePanel/ValidationTourSteps.tsx
+++ b/apps/src/lab2/views/components/Instructions/ResourcePanel/ValidationTourSteps.tsx
@@ -50,8 +50,7 @@ const ValidationTourSteps: React.FC<ValidationTourStepsProps> = ({
     RESOURCE_PANEL_PINNED_BUTTON_ONBOARDING_TOUR_SEEN,
     'no'
   );
-  const levelPath =
-    useAppSelector(state => getCurrentLevel(state)?.path) || 'standalone';
+  const levelPath = useAppSelector(state => getCurrentLevel(state)?.path) || '';
 
   const returnFocusToTourPanel = () => {
     setTimeout(() => {

--- a/apps/src/lab2/views/components/Instructions/ResourcePanel/ValidationTourSteps.tsx
+++ b/apps/src/lab2/views/components/Instructions/ResourcePanel/ValidationTourSteps.tsx
@@ -1,8 +1,12 @@
 import {Steps} from 'intro.js-react';
 import React, {useState, useEffect} from 'react';
 
+import {getCurrentLevel} from '@cdo/apps/code-studio/progressReduxSelectors';
+import {sendLab2AnalyticsEvent} from '@cdo/apps/lab2/utils';
 import {ValidationSettings} from '@cdo/apps/lab2/views/components/Instructions/InstructionsV2';
+import {EVENTS} from '@cdo/apps/metrics/AnalyticsConstants';
 import {commonI18n} from '@cdo/apps/types/locale';
+import {useAppSelector} from '@cdo/apps/util/reduxHooks';
 import {tryGetLocalStorage, trySetLocalStorage} from '@cdo/apps/utils';
 
 import {
@@ -26,6 +30,7 @@ interface ValidationTourStepsProps {
   validationSettings: ValidationSettings | undefined;
   setCurrentTab: (tab: Tabs) => void;
   onValidate: (() => void) | undefined;
+  appName: string;
 }
 
 // This introjs flow is currently only used for Python Lab, but other labs can opt in to use it if they also
@@ -35,6 +40,7 @@ const ValidationTourSteps: React.FC<ValidationTourStepsProps> = ({
   validationSettings,
   setCurrentTab,
   onValidate,
+  appName,
 }) => {
   const [validationTourEnabled, setValidationTourEnabled] = useState(false);
   const [validationTourStep, setValidationTourStep] = useState(0);
@@ -44,6 +50,8 @@ const ValidationTourSteps: React.FC<ValidationTourStepsProps> = ({
     RESOURCE_PANEL_PINNED_BUTTON_ONBOARDING_TOUR_SEEN,
     'no'
   );
+  const levelPath =
+    useAppSelector(state => getCurrentLevel(state)?.path) || 'standalone';
 
   const returnFocusToTourPanel = () => {
     setTimeout(() => {
@@ -252,15 +260,27 @@ const ValidationTourSteps: React.FC<ValidationTourStepsProps> = ({
   return (
     <Steps
       enabled={validationTourEnabled}
+      onStart={() => {
+        sendLab2AnalyticsEvent(EVENTS.INTROJS_FLOW_STARTED, appName, {
+          flowName: 'Resource Panel Validation Tour',
+          levelPath,
+        });
+      }}
       initialStep={validationTourStep}
       steps={VALIDATION_TOUR_STEPS}
       onExit={() => {
-        console.log('onExit');
         setValidationTourEnabled(false);
         trySetLocalStorage(VALIDATION_TOUR_SEEN, 'yes');
+        sendLab2AnalyticsEvent(EVENTS.INTROJS_FLOW_EXIT, appName, {
+          flowName: 'Resource Panel Validation Tour',
+          levelPath,
+        });
       }}
       onComplete={() => {
-        console.log('onComplete');
+        sendLab2AnalyticsEvent(EVENTS.INTROJS_FLOW_COMPLETED, appName, {
+          flowName: 'Resource Panel Validation Tour',
+          levelPath,
+        });
       }}
       onChange={nextStepIndex => {
         setValidationTourStep(nextStepIndex);

--- a/apps/src/lab2/views/components/Instructions/ResourcePanel/ValidationTourSteps.tsx
+++ b/apps/src/lab2/views/components/Instructions/ResourcePanel/ValidationTourSteps.tsx
@@ -255,8 +255,12 @@ const ValidationTourSteps: React.FC<ValidationTourStepsProps> = ({
       initialStep={validationTourStep}
       steps={VALIDATION_TOUR_STEPS}
       onExit={() => {
+        console.log('onExit');
         setValidationTourEnabled(false);
         trySetLocalStorage(VALIDATION_TOUR_SEEN, 'yes');
+      }}
+      onComplete={() => {
+        console.log('onComplete');
       }}
       onChange={nextStepIndex => {
         setValidationTourStep(nextStepIndex);

--- a/apps/src/lab2/views/components/Instructions/ResourcePanel/ValidationTourSteps.tsx
+++ b/apps/src/lab2/views/components/Instructions/ResourcePanel/ValidationTourSteps.tsx
@@ -25,6 +25,8 @@ if (urlParams.get('noIntrojs') === 'true') {
   trySetLocalStorage(VALIDATION_TOUR_SEEN, 'yes');
 }
 
+const VALIDATION_FLOW_NAME = 'Resource Panel Validation';
+
 interface ValidationTourStepsProps {
   hasValidationConditions: boolean;
   validationSettings: ValidationSettings | undefined;
@@ -261,7 +263,7 @@ const ValidationTourSteps: React.FC<ValidationTourStepsProps> = ({
       enabled={validationTourEnabled}
       onStart={() => {
         sendLab2AnalyticsEvent(EVENTS.INTROJS_FLOW_STARTED, appName, {
-          flowName: 'Resource Panel Validation Tour',
+          flowName: VALIDATION_FLOW_NAME,
           levelPath,
         });
       }}
@@ -271,13 +273,13 @@ const ValidationTourSteps: React.FC<ValidationTourStepsProps> = ({
         setValidationTourEnabled(false);
         trySetLocalStorage(VALIDATION_TOUR_SEEN, 'yes');
         sendLab2AnalyticsEvent(EVENTS.INTROJS_FLOW_EXIT, appName, {
-          flowName: 'Resource Panel Validation Tour',
+          flowName: VALIDATION_FLOW_NAME,
           levelPath,
         });
       }}
       onComplete={() => {
         sendLab2AnalyticsEvent(EVENTS.INTROJS_FLOW_COMPLETED, appName, {
-          flowName: 'Resource Panel Validation Tour',
+          flowName: VALIDATION_FLOW_NAME,
           levelPath,
         });
       }}

--- a/apps/src/lab2/views/components/Instructions/ResourcePanel/index.tsx
+++ b/apps/src/lab2/views/components/Instructions/ResourcePanel/index.tsx
@@ -390,13 +390,14 @@ const ResourcePanel: React.FC<ResourcePanelProps> = ({
         id={resourcePanelInstructionsElementId}
         className={classNames(styles.resourcePanel, className)}
       >
-        {isOnboardingTourEnabled && <OnboardingTourSteps />}
+        {isOnboardingTourEnabled && <OnboardingTourSteps appName={appName} />}
         {isValidationTourEnabled && (
           <ValidationTourSteps
             hasValidationConditions={hasValidationConditions}
             validationSettings={instructionsProps.validationSettings}
             setCurrentTab={setCurrentTab}
             onValidate={instructionsProps.validationSettings?.onValidate}
+            appName={appName}
           />
         )}
         <div

--- a/apps/src/metrics/AnalyticsConstants.js
+++ b/apps/src/metrics/AnalyticsConstants.js
@@ -627,6 +627,10 @@ const EVENTS = {
   RESOURCE_PANEL_LANGUAGE_CHANGE: 'Resource Panel Language Change',
   RESOURCE_PANEL_SETTINGS_CHANGE: 'Resource Panel Settings Change',
 
+  // IntroJS flows
+  INTROJS_FLOW_STARTED: 'IntroJS Flow Started',
+  INTROJS_FLOW_COMPLETED: 'IntroJS Flow Completed',
+
   // AI Teaching Assistant - Differentiation
 };
 

--- a/apps/src/metrics/AnalyticsConstants.js
+++ b/apps/src/metrics/AnalyticsConstants.js
@@ -629,6 +629,7 @@ const EVENTS = {
 
   // IntroJS flows
   INTROJS_FLOW_STARTED: 'IntroJS Flow Started',
+  INTROJS_FLOW_EXIT: 'IntroJS Flow Exited',
   INTROJS_FLOW_COMPLETED: 'IntroJS Flow Completed',
 
   // AI Teaching Assistant - Differentiation

--- a/apps/src/sketchlab/SketchlabView.tsx
+++ b/apps/src/sketchlab/SketchlabView.tsx
@@ -174,7 +174,7 @@ const SketchlabView: React.FC<LabProps<LevelProperties>> = ({
 
   return (
     <div className={moduleStyles.sketchlabContainer}>
-      <SketchlabTourSteps />
+      <SketchlabTourSteps appName={'sketchlab'} />
       <div style={{width: leftPanelWidth}} className={panelClassName}>
         <ResourcePanel
           levelProperties={levelProperties}

--- a/apps/src/sketchlab/sketchlabTourSteps.tsx
+++ b/apps/src/sketchlab/sketchlabTourSteps.tsx
@@ -19,6 +19,8 @@ if (urlParams.get('noIntrojs') === 'true') {
   trySetLocalStorage(SKETCHLAB_ONBOARDING_TOUR_SEEN, 'yes');
 }
 
+const SKETCHLAB_ONBOARDING_FLOW_NAME = 'Sketch Lab Onboarding';
+
 const OnboardingTourSteps: React.FC<{appName: string}> = ({appName}) => {
   const sketchlabOnboardingTourSeen = tryGetLocalStorage(
     SKETCHLAB_ONBOARDING_TOUR_SEEN,
@@ -199,7 +201,7 @@ const OnboardingTourSteps: React.FC<{appName: string}> = ({appName}) => {
       enabled={isToolbarReady && sketchlabOnboardingTourSeen !== 'yes'}
       onStart={() => {
         sendLab2AnalyticsEvent(EVENTS.INTROJS_FLOW_STARTED, appName, {
-          flowName: 'SketchLab Onboarding',
+          flowName: SKETCHLAB_ONBOARDING_FLOW_NAME,
           levelPath,
         });
       }}
@@ -207,14 +209,14 @@ const OnboardingTourSteps: React.FC<{appName: string}> = ({appName}) => {
       steps={STEPS}
       onExit={() => {
         sendLab2AnalyticsEvent(EVENTS.INTROJS_FLOW_EXIT, appName, {
-          flowName: 'SketchLab Onboarding',
+          flowName: SKETCHLAB_ONBOARDING_FLOW_NAME,
           levelPath,
         });
         trySetLocalStorage(SKETCHLAB_ONBOARDING_TOUR_SEEN, 'yes');
       }}
       onComplete={() => {
         sendLab2AnalyticsEvent(EVENTS.INTROJS_FLOW_COMPLETED, appName, {
-          flowName: 'SketchLab Onboarding',
+          flowName: SKETCHLAB_ONBOARDING_FLOW_NAME,
           levelPath,
         });
       }}

--- a/apps/src/sketchlab/sketchlabTourSteps.tsx
+++ b/apps/src/sketchlab/sketchlabTourSteps.tsx
@@ -1,8 +1,13 @@
 import {Steps} from 'intro.js-react';
 import React, {useEffect, useState} from 'react';
 
+import {getCurrentLevel} from '@cdo/apps/code-studio/progressReduxSelectors';
 import {commonI18n} from '@cdo/apps/types/locale';
+import {useAppSelector} from '@cdo/apps/util/reduxHooks';
 import {tryGetLocalStorage, trySetLocalStorage} from '@cdo/apps/utils';
+
+import {sendLab2AnalyticsEvent} from '../lab2/utils';
+import {EVENTS} from '../metrics/AnalyticsConstants';
 
 import {SKETCHLAB_ONBOARDING_TOUR_SEEN} from './constants';
 import {STEPS, INITIAL_STEP} from './sketchlabTourHelpers';
@@ -14,7 +19,7 @@ if (urlParams.get('noIntrojs') === 'true') {
   trySetLocalStorage(SKETCHLAB_ONBOARDING_TOUR_SEEN, 'yes');
 }
 
-const OnboardingTourSteps: React.FC = () => {
+const OnboardingTourSteps: React.FC<{appName: string}> = ({appName}) => {
   const sketchlabOnboardingTourSeen = tryGetLocalStorage(
     SKETCHLAB_ONBOARDING_TOUR_SEEN,
     'no'
@@ -25,6 +30,8 @@ const OnboardingTourSteps: React.FC = () => {
 
   // The Next button on the Open Menu step (6th step) is disabled until the user completes an action.
   const [openMenuNextStepEnabled, setOpenMenuNextStepEnabled] = useState(false);
+
+  const levelPath = useAppSelector(state => getCurrentLevel(state)?.path) || '';
 
   useEffect(() => {
     if (sketchlabOnboardingTourSeen !== 'yes') {
@@ -190,14 +197,26 @@ const OnboardingTourSteps: React.FC = () => {
   return (
     <Steps
       enabled={isToolbarReady && sketchlabOnboardingTourSeen !== 'yes'}
+      onStart={() => {
+        sendLab2AnalyticsEvent(EVENTS.INTROJS_FLOW_STARTED, appName, {
+          flowName: 'SketchLab Onboarding',
+          levelPath,
+        });
+      }}
       initialStep={INITIAL_STEP}
       steps={STEPS}
       onExit={() => {
-        console.log('onExit');
+        sendLab2AnalyticsEvent(EVENTS.INTROJS_FLOW_EXIT, appName, {
+          flowName: 'SketchLab Onboarding',
+          levelPath,
+        });
         trySetLocalStorage(SKETCHLAB_ONBOARDING_TOUR_SEEN, 'yes');
       }}
       onComplete={() => {
-        console.log('onComplete');
+        sendLab2AnalyticsEvent(EVENTS.INTROJS_FLOW_COMPLETED, appName, {
+          flowName: 'SketchLab Onboarding',
+          levelPath,
+        });
       }}
       onChange={nextStepIndex => {
         setTourStep(nextStepIndex);

--- a/apps/src/sketchlab/sketchlabTourSteps.tsx
+++ b/apps/src/sketchlab/sketchlabTourSteps.tsx
@@ -193,7 +193,11 @@ const OnboardingTourSteps: React.FC = () => {
       initialStep={INITIAL_STEP}
       steps={STEPS}
       onExit={() => {
+        console.log('onExit');
         trySetLocalStorage(SKETCHLAB_ONBOARDING_TOUR_SEEN, 'yes');
+      }}
+      onComplete={() => {
+        console.log('onComplete');
       }}
       onChange={nextStepIndex => {
         setTourStep(nextStepIndex);


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
This PR adds Statsig analytics reporting for introJS flows in labs. Specifically, we add logging for:
- when a user begins an introJS flow,
- when a user exits the flow (logs when the user exits the flow at any point including the last panel),
- when a user completes the flow (user reaches the last panel and clicks on either the 'x' close button or the 'Done' button.

`flowName`, `labType`, `levelPath` are included in the Statsig reporting.

Note that if a user completes the flow, i.e., reaches the last panel/step, both the 'IntroJS Flow Exited' and 'IntroJS Flow Completed' will be logged.
Currently, there are 3 introJS flows: resource panel onboarding in Codebridge (`pythonlab`, `weblab2`), validation tour (`pythonlab`), and Sketch Lab onboarding.

## After update

Screenshot of Statsig event logs when a user completes the Sketch Lab onboarding tour:
<img width="1426" height="690" alt="sketchlab-on-completed" src="https://github.com/user-attachments/assets/ef2b78fd-81e2-4cf0-9e69-be4e249a380b" />



Screenshot of Statsig event logs when a user starts the Sketch Lab onboarding tour but does not complete it:
<img width="1423" height="576" alt="sketchlab-on-exit" src="https://github.com/user-attachments/assets/360ec118-a304-4837-acef-91f7e1a7fb46" />


Screenshot of Statsig event logs when a user completes the resource panel onboarding tour:
<img width="686" height="249" alt="resource-panel-onboarding-completed" src="https://github.com/user-attachments/assets/4c549395-5316-40b5-9f92-3ff8ac888bcd" />

Screenshot of Statsig event logs when a user completes the validation tour:
<img width="804" height="198" alt="validation-on-completed" src="https://github.com/user-attachments/assets/62008900-82ca-4db1-a142-57701acfc5a8" />


## Links
<!--  Links to relevant external resources.
      - spec docs, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- Jira: https://codedotorg.atlassian.net/browse/AFL-337

## Testing story
<!--  Does your change include appropriate tests?
      - If so, please describe how the tests included in this PR are sufficient.
      - If not, please explain why this change does not need to be tested. -->

Tested locally across lab2 labs.

## Deployment strategy
<!--  Any special steps required to deploy this, besides merging?
      - Are there database migrations or manual steps?
      - Does this require coordination with other teams or systems? -->



## Follow-up work
<!--  List any clean-up or technical debt that will be addressed in future work.
      - Include Jira links where applicable.
      - Are there any known limitations or improvements planned? -->



## Privacy
<!--  How does this change impact Student & Teacher privacy?
      - Does this collect, use, share, or modify PII, either new or existing? -->



## Security
<!--  How does this change impact our security surface-area?
      - Do API's touched have the right auth?
      - Do infra changes impact our attack surface or encryption?
-->



## Caching
<!--  How does this change impact caching behavior?
      - Are cache keys or invalidation strategies affected?
      - Will this require cache warming or invalidation after deployment? -->



## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
