### PR TITLE
hoai2025: session end event for Dance Lab2

### DIFF
--- a/apps/src/dance/lab2/hooks/useReportAnalytics.ts
+++ b/apps/src/dance/lab2/hooks/useReportAnalytics.ts
@@ -1,0 +1,77 @@
+import {useCallback, useEffect, useRef} from 'react';
+
+import Lab2Registry from '@cdo/apps/lab2/Lab2Registry';
+import {isReadOnlyWorkspace} from '@cdo/apps/lab2/redux/lab2ReduxSelectors';
+import {LevelProperties} from '@cdo/apps/lab2/types';
+import {EVENTS} from '@cdo/apps/metrics/AnalyticsConstants';
+import analyticsReporter from '@cdo/apps/metrics/AnalyticsReporter';
+import {useAppSelector} from '@cdo/apps/util/reduxHooks';
+
+interface AnalyticsPayload {
+  levelType?: string;
+  mode?: string;
+  channelId?: string;
+  levelPath?: string;
+  scriptName?: string;
+}
+
+/** Reports the "Dance Party Session End" analytics event. */
+export default function useReportAnalytics(
+  levelProperties: LevelProperties,
+  channelId?: string
+) {
+  const startTimeRef = useRef<number | null>(null);
+  const analyticsPayload = useRef<AnalyticsPayload>({});
+
+  const reportSessionEnd = useCallback(() => {
+    if (startTimeRef.current === null) {
+      Lab2Registry.getInstance()
+        .getMetricsReporter()
+        .logWarning('Analytics session end reported without a start time.');
+      return;
+    }
+
+    const duration = Date.now() - startTimeRef.current;
+    analyticsReporter.sendEvent(EVENTS.DANCE_PARTY_SESSION_END, {
+      ...analyticsPayload.current,
+      durationSeconds: duration / 1000,
+    });
+  }, []);
+
+  const viewMode = useAppSelector(state => {
+    const isReadOnly = isReadOnlyWorkspace(state);
+    const isPlayView = state.lab.isShareView;
+    return isPlayView ? 'Share' : isReadOnly ? 'View' : 'Edit';
+  });
+
+  const scriptName =
+    useAppSelector(state => state.progress.scriptName) || undefined;
+
+  useEffect(() => {
+    analyticsPayload.current.scriptName = scriptName;
+  }, [scriptName]);
+
+  useEffect(() => {
+    analyticsPayload.current.mode = viewMode;
+  }, [viewMode]);
+
+  useEffect(() => {
+    startTimeRef.current = Date.now();
+    analyticsPayload.current.channelId = channelId;
+    analyticsPayload.current.levelType = levelProperties.isProjectLevel
+      ? 'Standalone Project'
+      : 'Level';
+    analyticsPayload.current.levelPath = window.location.pathname;
+
+    window.addEventListener('beforeunload', reportSessionEnd);
+    return () => {
+      window.removeEventListener('beforeunload', reportSessionEnd);
+      reportSessionEnd();
+    };
+  }, [
+    reportSessionEnd,
+    levelProperties.id,
+    channelId,
+    levelProperties.isProjectLevel,
+  ]);
+}

--- a/apps/src/dance/lab2/views/DanceView.tsx
+++ b/apps/src/dance/lab2/views/DanceView.tsx
@@ -78,6 +78,7 @@ import AgeDialog from '@cdo/apps/templates/AgeDialog';
 import {commonI18n} from '@cdo/apps/types/locale';
 import {useAppDispatch, useAppSelector} from '@cdo/apps/util/reduxHooks';
 
+import useReportAnalytics from '../hooks/useReportAnalytics';
 import ProgramExecutor from '../ProgramExecutor';
 
 import DanceControls from './DanceControls';
@@ -725,22 +726,26 @@ const DanceView: React.FunctionComponent<{
   );
 };
 
-export default (props: LabProps<DanceLevelProperties, DanceProjectSources>) => (
-  <SourcesContainer
-    {...props}
-    defaultSources={defaultSources}
-    key={props.levelProperties.id}
-  >
-    {props.levelProperties.guideMode === 'aiDancerGenerate' ? (
-      <GenerateDancer
-        adlibOption={
-          props.levelProperties.aiDancerGenerateAdlib ||
-          'adjective-animal-attire'
-        }
-        levelProperties={props.levelProperties}
-      />
-    ) : (
-      <DanceView levelProperties={props.levelProperties} />
-    )}
-  </SourcesContainer>
-);
+export default (props: LabProps<DanceLevelProperties, DanceProjectSources>) => {
+  useReportAnalytics(props.levelProperties, props.channel?.id);
+
+  return (
+    <SourcesContainer
+      {...props}
+      defaultSources={defaultSources}
+      key={props.levelProperties.id}
+    >
+      {props.levelProperties.guideMode === 'aiDancerGenerate' ? (
+        <GenerateDancer
+          adlibOption={
+            props.levelProperties.aiDancerGenerateAdlib ||
+            'adjective-animal-attire'
+          }
+          levelProperties={props.levelProperties}
+        />
+      ) : (
+        <DanceView levelProperties={props.levelProperties} />
+      )}
+    </SourcesContainer>
+  );
+};

--- a/apps/src/metrics/AnalyticsConstants.js
+++ b/apps/src/metrics/AnalyticsConstants.js
@@ -628,6 +628,9 @@ const EVENTS = {
   RESOURCE_PANEL_SETTINGS_CHANGE: 'Resource Panel Settings Change',
 
   // AI Teaching Assistant - Differentiation
+
+  // Dance Party (Lab2)
+  DANCE_PARTY_SESSION_END: 'Dance Party Session End',
 };
 
 const EVENT_GROUP_NAMES = {


### PR DESCRIPTION
Reports a "session end" event to Statsig for Dance Party on Lab2 (including generate dancer mode) analogous to the Music Lab session end event. This includes time spent on the level as well as other metadata like level path, channel ID, script name, etc.

<img width="1515" height="829" alt="Screenshot 2025-11-10 at 12 35 51 PM" src="https://github.com/user-attachments/assets/e87a9d49-2c2b-405f-97c8-f804c3d3147e" />

<img width="1513" height="827" alt="Screenshot 2025-11-10 at 12 37 58 PM" src="https://github.com/user-attachments/assets/fad940d1-543c-455a-a69c-bb610ef01bd3" />

## Links

https://codedotorg.atlassian.net/browse/LABS-1705

## Testing story
- Tested by locally emitting analytics to Statsig and verifying in the dashboard.