### PR TITLE
chore(http_cache): include static-asset paths to marketing router lambda

### DIFF
--- a/lib/cdo/http_cache.rb
+++ b/lib/cdo/http_cache.rb
@@ -308,7 +308,8 @@ class HttpCache
             # For static-asset paths, don't forward any cookies or additional headers.
             path: STATIC_ASSET_EXTENSION_PATHS + %w(/blockly/media/* /media),
             headers: [],
-            cookies: 'none'
+            cookies: 'none',
+            include_marketing_router_lambda: true,
           },
           {
             path: '/v2/*',

--- a/lib/cdo/http_cache.rb
+++ b/lib/cdo/http_cache.rb
@@ -179,7 +179,8 @@ class HttpCache
           {
             path: STATIC_ASSET_EXTENSION_PATHS + %w(/files/* /images/* /fonts/*),
             headers: [],
-            cookies: 'none'
+            cookies: 'none',
+            include_marketing_router_lambda: true,
           },
           # Dashboard-based API paths in Pegasus are session-specific, allowlist all cookies.
           {
@@ -308,8 +309,7 @@ class HttpCache
             # For static-asset paths, don't forward any cookies or additional headers.
             path: STATIC_ASSET_EXTENSION_PATHS + %w(/blockly/media/* /media),
             headers: [],
-            cookies: 'none',
-            include_marketing_router_lambda: true,
+            cookies: 'none'
           },
           {
             path: '/v2/*',

--- a/lib/cdo/http_cache.rb
+++ b/lib/cdo/http_cache.rb
@@ -184,7 +184,7 @@ class HttpCache
           },
           # For static-asset paths, don't forward any cookies or additional headers.
           {
-            path: STATIC_ASSET_EXTENSION_PATHS + %w(/files/* /images/* /fonts/*),
+            path: STATIC_ASSET_EXTENSION_PATHS - %w(/*.png) + %w(/files/* /images/* /fonts/*),
             headers: [],
             cookies: 'none'
           },

--- a/lib/cdo/http_cache.rb
+++ b/lib/cdo/http_cache.rb
@@ -175,12 +175,18 @@ class HttpCache
             headers: ALLOWLISTED_HEADERS,
             cookies: allowlisted_cookies,
           },
+          # For .png images, don't forward any cookies or additional headers.
+          {
+            path: '/*.png',
+            headers: [],
+            cookies: 'none',
+            include_marketing_router_lambda: true,
+          },
           # For static-asset paths, don't forward any cookies or additional headers.
           {
             path: STATIC_ASSET_EXTENSION_PATHS + %w(/files/* /images/* /fonts/*),
             headers: [],
-            cookies: 'none',
-            include_marketing_router_lambda: true,
+            cookies: 'none'
           },
           # Dashboard-based API paths in Pegasus are session-specific, allowlist all cookies.
           {


### PR DESCRIPTION
## Links
- Related PR: https://github.com/code-dot-org/code-dot-org/pull/69470