### PR TITLE
Don't Load Spring on Chef-managed Deployment Servers

### DIFF
--- a/cookbooks/cdo-home-ubuntu/templates/default/bashrc.erb
+++ b/cookbooks/cdo-home-ubuntu/templates/default/bashrc.erb
@@ -117,5 +117,3 @@ export LC_ALL=en_US.UTF-8
 export LANG=en_US.UTF-8
 export LANGUAGE=en_US.UTF-8
 
-# TODO: explain this
-export DISABLE_SPRING=1

--- a/cookbooks/cdo-home-ubuntu/templates/default/bashrc.erb
+++ b/cookbooks/cdo-home-ubuntu/templates/default/bashrc.erb
@@ -117,3 +117,5 @@ export LC_ALL=en_US.UTF-8
 export LANG=en_US.UTF-8
 export LANGUAGE=en_US.UTF-8
 
+# TODO: explain this
+export DISABLE_SPRING=1

--- a/dashboard/bin/spring
+++ b/dashboard/bin/spring
@@ -1,15 +1,17 @@
 #!/usr/bin/env ruby
 
-# This file loads spring without using Bundler, in order to be fast.
+# This file loads Spring without using Bundler, in order to be fast.
 # It gets overwritten when you run the `spring binstub` command.
 
 unless defined?(Spring)
   require 'rubygems'
   require 'bundler'
 
-  if (match = Bundler.default_lockfile.read.match(/^GEM$.*?^    (?:  )*spring \((.*?)\)$.*?^$/m))
-    Gem.paths = {'GEM_PATH' => [Bundler.bundle_path.to_s, *Gem.path].uniq.join(Gem.path_separator)}
-    gem 'spring', match[1]
+  lockfile = Bundler::LockfileParser.new(Bundler.default_lockfile.read)
+  spring = lockfile.specs.detect {|spec| spec.name == 'spring'}
+  if spring
+    Gem.use_paths Gem.dir, Bundler.bundle_path.to_s, *Gem.path
+    gem 'spring', spring.version
     require 'spring/binstub'
   end
 end

--- a/dashboard/bin/spring
+++ b/dashboard/bin/spring
@@ -7,11 +7,16 @@ unless defined?(Spring)
   require 'rubygems'
   require 'bundler'
 
-  lockfile = Bundler::LockfileParser.new(Bundler.default_lockfile.read)
-  spring = lockfile.specs.detect {|spec| spec.name == 'spring'}
-  if spring
-    Gem.use_paths Gem.dir, Bundler.bundle_path.to_s, *Gem.path
-    gem 'spring', spring.version
-    require 'spring/binstub'
+  # Spring breaks when Bundler is running in deployment mode (ie, on the
+  # managed test server), but fortunately it also doesn't offer any benefits to
+  # us on our deployed servers so we can safely skip it in that situation.
+  unless Bundler.settings[:deployment]
+    lockfile = Bundler::LockfileParser.new(Bundler.default_lockfile.read)
+    spring = lockfile.specs.detect {|spec| spec.name == 'spring'}
+    if spring
+      Gem.use_paths Gem.dir, Bundler.bundle_path.to_s, *Gem.path
+      gem 'spring', spring.version
+      require 'spring/binstub'
+    end
   end
 end


### PR DESCRIPTION
As a tool intended to speed up developer's iteration cycles, Spring is only needed in local development environments. But because we want to support developers running tests locally and lack a good way to distinguish between local developer tests and our managed test environment, we also end up installing it on our persistent managed test server.

For a long time, having Spring on the test server has been unnecessary but not actively problematic. Unfortunately, [our recent change to start installing gems in `deployment` mode on our deployment servers](https://github.com/code-dot-org/code-dot-org/pull/67642) broke this state, since Spring can't find the installed gems anymore:

```
ubuntu@test:~/test$ bin/dashboard-console
/usr/local/lib/ruby/gems/3.1.0/gems/bundler-2.5.17/lib/bundler/runtime.rb:299:in `check_for_activated_spec!': You have already activated set 1.0.2, but your Gemfile requires set 1.1.0. Since set is a default gem, you can either remove your dependency on it or try updating to a newer version of bundler that supports set as a default gem. (Gem::LoadError)
```

This PR proposes that we resolve this by updating the autogenerated spring executable to only load Spring into non-`deployment` environments. We could alternatively add `DISABLE_SPRING=1` to [the `.bashrc` that we generate for all of our managed servers](https://github.com/code-dot-org/code-dot-org/blob/staging/cookbooks/cdo-home-ubuntu/templates/default/bashrc.erb); I think arguably that would be cleaner than making a manual update to a file that we don't typically update manually, but it would also be less discoverable. Open to suggestions if you'd prefer that direction, or another one entirely!

## Misc

**Note that this PR includes both an automated code change and a manual one**, and the automated one is responsible for the majority of the diff. Specifically, I first ran `spring binstub` to [update the autogenerated spring executable](https://github.com/code-dot-org/code-dot-org/pull/69484/commits/07d4bb5c10b71eece495aaf117dd8021f4c6f27c), and then [applied our desired customization to that updated executable](https://github.com/code-dot-org/code-dot-org/pull/69484/commits/392cba47374b3aa8fa473a32a80d118a3f7034b8?w=1). I'd be happy to split these up (or to forgo the autogenerated update entirely) if anyone would prefer.

## Links

- [slack thread](https://codedotorg.slack.com/archives/C046G4TRLEN/p1759443635923989)

## Testing story

Verified manually on the test server that with this change in place, we can again run `dashboard-console` on that server without needing to manually specify `DISABLE_SPRING=1`