### PR TITLE
hoai: generate analytics

### DIFF
--- a/apps/src/dance/lab2/views/GenerateDance.tsx
+++ b/apps/src/dance/lab2/views/GenerateDance.tsx
@@ -16,6 +16,8 @@ import Adlib, {
 import Guide from '@cdo/apps/lab2/views/components/guide/Guide';
 import MainInstructionsContent from '@cdo/apps/lab2/views/components/Instructions/MainInstructionsContent';
 import NavigationArea from '@cdo/apps/lab2/views/components/Instructions/NavigationArea';
+import {EVENTS} from '@cdo/apps/metrics/AnalyticsConstants';
+import analyticsReporter from '@cdo/apps/metrics/AnalyticsReporter';
 
 import buildDanceBlockly from '../../blockly/buildDanceBlockly';
 
@@ -134,43 +136,58 @@ const GenerateDance: React.FunctionComponent<GenerateCodeProps> = ({
     setPromptText('');
   });
 
-  const generateDance = useCallback(async () => {
-    setAiGenerateState('generating');
+  const generateDance = useCallback(
+    async (regenerate = false) => {
+      setAiGenerateState('generating');
 
-    const startTime = Date.now();
-    const {workspaceSerialization, flyoutDefinition} = buildDanceBlockly(
-      measures,
+      analyticsReporter.sendEvent(
+        EVENTS[
+          `DANCE_PARTY_${regenerate ? 'REGENERATE' : 'GENERATE'}_CODE_CLICKED`
+        ],
+        {
+          adlibChoices,
+          levelPath: window.location.pathname,
+        }
+      );
+      const startTime = Date.now();
+      const {workspaceSerialization, flyoutDefinition} = buildDanceBlockly(
+        measures,
+        blockDefinitions,
+        adlibChoices && adlibChoices['complexity'] === 'complex'
+          ? 'complex'
+          : 'simple',
+        adlibChoices && adlibChoices['energy'] === 'high' ? 'high' : 'chill',
+        (adlibChoices && adlibChoices['dancers']) || 'nobody'
+      );
+
+      const elapsedTime = Date.now() - startTime;
+      const remainingDelayDuration = Math.max(
+        GENERATE_DELAY_DURATION - elapsedTime,
+        0
+      );
+      await new Promise(res => setTimeout(res, remainingDelayDuration));
+
+      updateSources(workspaceSerialization);
+      updateBlocklyFlyout(flyoutDefinition);
+      const levelId = levelProperties.id;
+      localStorage.setItem(
+        `flyout-${levelId}`,
+        JSON.stringify(flyoutDefinition)
+      );
+      runProgram();
+
+      setAiGenerateState('generated');
+    },
+    [
+      adlibChoices,
       blockDefinitions,
-      adlibChoices && adlibChoices['complexity'] === 'complex'
-        ? 'complex'
-        : 'simple',
-      adlibChoices && adlibChoices['energy'] === 'high' ? 'high' : 'chill',
-      (adlibChoices && adlibChoices['dancers']) || 'nobody'
-    );
-
-    const elapsedTime = Date.now() - startTime;
-    const remainingDelayDuration = Math.max(
-      GENERATE_DELAY_DURATION - elapsedTime,
-      0
-    );
-    await new Promise(res => setTimeout(res, remainingDelayDuration));
-
-    updateSources(workspaceSerialization);
-    updateBlocklyFlyout(flyoutDefinition);
-    const levelId = levelProperties.id;
-    localStorage.setItem(`flyout-${levelId}`, JSON.stringify(flyoutDefinition));
-    runProgram();
-
-    setAiGenerateState('generated');
-  }, [
-    adlibChoices,
-    blockDefinitions,
-    levelProperties.id,
-    measures,
-    runProgram,
-    updateBlocklyFlyout,
-    updateSources,
-  ]);
+      levelProperties.id,
+      measures,
+      runProgram,
+      updateBlocklyFlyout,
+      updateSources,
+    ]
+  );
 
   useEffect(() => {
     // There can be a delay before we're playing, so wait for it explicitly.
@@ -285,6 +302,10 @@ const GenerateDance: React.FunctionComponent<GenerateCodeProps> = ({
               startOver();
               setAiGenerateState('none');
               resetProgram();
+              analyticsReporter.sendEvent(
+                EVENTS.DANCE_PARTY_GENERATE_CODE_BACK_TO_PROMPT_CLICKED,
+                {levelPath: window.location.pathname}
+              );
             }}
             className={styles.buttonWide}
           />
@@ -299,7 +320,7 @@ const GenerateDance: React.FunctionComponent<GenerateCodeProps> = ({
             onClick={() => {
               startOver();
               resetProgram();
-              generateDance();
+              generateDance(true);
             }}
             className={styles.buttonWide}
           />
@@ -313,6 +334,13 @@ const GenerateDance: React.FunctionComponent<GenerateCodeProps> = ({
             onClick={() => {
               // Skip the 'editing' validation state for standalone projects.
               setAiGenerateState(isStandalone ? 'edited' : 'editing');
+              analyticsReporter.sendEvent(
+                EVENTS.DANCE_PARTY_GENERATE_CODE_USE_CODE_CLICKED,
+                {
+                  adlibChoices,
+                  levelPath: window.location.pathname,
+                }
+              );
             }}
             className={styles.buttonWide}
           />
@@ -352,6 +380,10 @@ const GenerateDance: React.FunctionComponent<GenerateCodeProps> = ({
                 startOver();
                 setAiGenerateState('none');
                 resetProgram();
+                analyticsReporter.sendEvent(
+                  EVENTS.DANCE_PARTY_GENERATE_CODE_BACK_TO_PROMPT_CLICKED,
+                  {levelPath: window.location.pathname}
+                );
               }}
               className={styles.buttonWide}
             />

--- a/apps/src/dance/lab2/views/GenerateDancer.tsx
+++ b/apps/src/dance/lab2/views/GenerateDancer.tsx
@@ -177,100 +177,110 @@ const GenerateDancer: React.FunctionComponent<DancerGenerateProps> = ({
     setHasGenerated(false);
   });
 
-  const generateDancerCache = useCallback(async () => {
-    const startTime = Date.now();
+  const generateDancerCache = useCallback(
+    async (regenerate = false) => {
+      const startTime = Date.now();
 
-    if (!adlibs || !adlibChoices) {
-      return;
-    }
-
-    // Special case: for the creature-attire-mood-style-05 adlib only,
-    // move mood from choices to choicesExtra, and use a unique path.
-    // This is because the style option is not used in retrieving the
-    // head image, and is instead used to retrieve the body.
-    let choicesToSave;
-    let choicesExtraToSave;
-    let pathToSave;
-    if (
-      [
-        'creature-attire-mood-style-04',
-        'creature-attire-mood-style-05',
-      ].includes(adlibOption)
-    ) {
-      pathToSave =
-        adlibOption === 'creature-attire-mood-style-04'
-          ? 'creature-attire-mood-04'
-          : 'creature-attire-mood-05';
-      choicesToSave = Object.keys(adlibChoices)
-        .slice(0, -1)
-        .map(key => adlibChoices[key]);
-      choicesExtraToSave = Object.keys(adlibChoices)
-        .slice(-1)
-        .map(key => adlibChoices[key]);
-    } else {
-      pathToSave = adlibOption;
-      choicesToSave = Object.keys(adlibChoices).map(key => adlibChoices[key]);
-      choicesExtraToSave = undefined;
-    }
-
-    // Build a list of available variants, excluding blocked ones.
-    const variants = [];
-    for (
-      let variant = 0;
-      variant <= adlibs[adlibOption].variantCount - 1;
-      variant++
-    ) {
-      // Generate a filename that will match an entry in the block list.
-      const assetFilename = `${choicesToSave?.join('-')}-${variant
-        .toString()
-        .padStart(2, '0')}`;
-
-      if (!blockList.current?.[adlibOption].includes(assetFilename)) {
-        variants.push(variant);
+      if (!adlibs || !adlibChoices) {
+        return;
       }
-    }
 
-    // Build a smaller set of available variants, by excluding recently-shown
-    // ones.
-    const newVariants = variants.filter(
-      variant => !variantHistory.current.includes(variant)
-    );
+      // Special case: for the creature-attire-mood-style-05 adlib only,
+      // move mood from choices to choicesExtra, and use a unique path.
+      // This is because the style option is not used in retrieving the
+      // head image, and is instead used to retrieve the body.
+      let choicesToSave;
+      let choicesExtraToSave;
+      let pathToSave;
+      if (
+        [
+          'creature-attire-mood-style-04',
+          'creature-attire-mood-style-05',
+        ].includes(adlibOption)
+      ) {
+        pathToSave =
+          adlibOption === 'creature-attire-mood-style-04'
+            ? 'creature-attire-mood-04'
+            : 'creature-attire-mood-05';
+        choicesToSave = Object.keys(adlibChoices)
+          .slice(0, -1)
+          .map(key => adlibChoices[key]);
+        choicesExtraToSave = Object.keys(adlibChoices)
+          .slice(-1)
+          .map(key => adlibChoices[key]);
+      } else {
+        pathToSave = adlibOption;
+        choicesToSave = Object.keys(adlibChoices).map(key => adlibChoices[key]);
+        choicesExtraToSave = undefined;
+      }
 
-    const variant = sample(newVariants) as number;
-    const bodyVariant = getRandomInt(0, BODY_VARIANT_COUNT - 1);
+      // Build a list of available variants, excluding blocked ones.
+      const variants = [];
+      for (
+        let variant = 0;
+        variant <= adlibs[adlibOption].variantCount - 1;
+        variant++
+      ) {
+        // Generate a filename that will match an entry in the block list.
+        const assetFilename = `${choicesToSave?.join('-')}-${variant
+          .toString()
+          .padStart(2, '0')}`;
 
-    // Keep the recently-shown array length at a maximum that ensures
-    // there are still two choices to be made each time.
-    const availableVariantCount = variants.length;
-    const lengthOfVariantsHistory = Math.max(availableVariantCount - 2, 2);
-    const newVariantsHistory: number[] = [...variantHistory.current, variant];
-    if (newVariantsHistory.length > lengthOfVariantsHistory) {
-      newVariantsHistory.shift(); // Remove the oldest entry.
-    }
-    variantHistory.current = newVariantsHistory;
+        if (!blockList.current?.[adlibOption].includes(assetFilename)) {
+          variants.push(variant);
+        }
+      }
 
-    const newDancerMetadata: GeneratedDancerMetadata = {
-      adlibOption,
-      path: (queryParams('ai-dancer-path') as string) || pathToSave,
-      choices: choicesToSave,
-      choicesExtra: choicesExtraToSave,
-      variant,
-      extraVariant: bodyVariant,
-    };
-    updateSources(
-      {...currentSources, generatedDancer: newDancerMetadata},
-      true
-    );
+      // Build a smaller set of available variants, by excluding recently-shown
+      // ones.
+      const newVariants = variants.filter(
+        variant => !variantHistory.current.includes(variant)
+      );
 
-    const elapsedTime = Date.now() - startTime;
-    const remainingDelayDuration = Math.max(
-      GENERATE_TOTAL_DELAY_DURATION -
-        GENERATE_INITIAL_DELAY_DURATION -
-        elapsedTime,
-      0
-    );
-    await new Promise(res => setTimeout(res, remainingDelayDuration));
-  }, [adlibChoices, adlibOption, adlibs, updateSources, currentSources]);
+      const variant = sample(newVariants) as number;
+      const bodyVariant = getRandomInt(0, BODY_VARIANT_COUNT - 1);
+
+      // Keep the recently-shown array length at a maximum that ensures
+      // there are still two choices to be made each time.
+      const availableVariantCount = variants.length;
+      const lengthOfVariantsHistory = Math.max(availableVariantCount - 2, 2);
+      const newVariantsHistory: number[] = [...variantHistory.current, variant];
+      if (newVariantsHistory.length > lengthOfVariantsHistory) {
+        newVariantsHistory.shift(); // Remove the oldest entry.
+      }
+      variantHistory.current = newVariantsHistory;
+
+      const newDancerMetadata: GeneratedDancerMetadata = {
+        adlibOption,
+        path: (queryParams('ai-dancer-path') as string) || pathToSave,
+        choices: choicesToSave,
+        choicesExtra: choicesExtraToSave,
+        variant,
+        extraVariant: bodyVariant,
+      };
+      analyticsReporter.sendEvent(
+        EVENTS[`${regenerate ? 'REGENERATE' : 'GENERATE'}_DANCER_CLICKED`],
+        {
+          ...newDancerMetadata,
+          levelPath: window.location.pathname,
+        }
+      );
+      updateSources(
+        {...currentSources, generatedDancer: newDancerMetadata},
+        true
+      );
+
+      const elapsedTime = Date.now() - startTime;
+      const remainingDelayDuration = Math.max(
+        GENERATE_TOTAL_DELAY_DURATION -
+          GENERATE_INITIAL_DELAY_DURATION -
+          elapsedTime,
+        0
+      );
+      await new Promise(res => setTimeout(res, remainingDelayDuration));
+    },
+    [adlibChoices, adlibOption, adlibs, updateSources, currentSources]
+  );
 
   // Update local storage whenever the generated dancer metadata changes and update the canvas key so the canvas refreshes.
   const [canvasKey, setCanvasKey] = useState<string>();
@@ -301,16 +311,21 @@ const GenerateDancer: React.FunctionComponent<DancerGenerateProps> = ({
     });
   }, [levelProperties, signedIn, scriptName]);
 
-  const generateDancer = useCallback(async () => {
-    if (!hasGenerated) {
-      logLevelActivity();
-    }
-    setAiGenerateState('generating');
-    await new Promise(res => setTimeout(res, GENERATE_INITIAL_DELAY_DURATION));
-    await generateDancerCache();
-    setAiGenerateState('reviewing');
-    setHasGenerated(true);
-  }, [generateDancerCache, hasGenerated, logLevelActivity]);
+  const generateDancer = useCallback(
+    async (regenerate = false) => {
+      if (!hasGenerated) {
+        logLevelActivity();
+      }
+      setAiGenerateState('generating');
+      await new Promise(res =>
+        setTimeout(res, GENERATE_INITIAL_DELAY_DURATION)
+      );
+      await generateDancerCache(regenerate);
+      setAiGenerateState('reviewing');
+      setHasGenerated(true);
+    },
+    [generateDancerCache, hasGenerated, logLevelActivity]
+  );
 
   const glowSpeed = aiGenerateState === 'generating' ? 'fast' : 'normal';
 
@@ -429,7 +444,7 @@ const GenerateDancer: React.FunctionComponent<DancerGenerateProps> = ({
                     iconLeft={{iconName: 'sparkles'}}
                     isPending={aiGenerateState === 'generating'}
                     disabled={aiGenerateState === 'generating'}
-                    onClick={generateDancer}
+                    onClick={() => generateDancer()}
                     className={moduleStyles.buttonWide}
                   />
                 </div>
@@ -452,7 +467,15 @@ const GenerateDancer: React.FunctionComponent<DancerGenerateProps> = ({
                   type="secondary"
                   color="black"
                   size="s"
-                  onClick={() => setAiGenerateState('none')}
+                  onClick={() => {
+                    analyticsReporter.sendEvent(
+                      EVENTS.GENERATE_DANCER_BACK_TO_PROMPT_CLICKED,
+                      {
+                        levelPath: window.location.pathname,
+                      }
+                    );
+                    setAiGenerateState('none');
+                  }}
                   className={moduleStyles.buttonWide}
                 />
 
@@ -463,7 +486,7 @@ const GenerateDancer: React.FunctionComponent<DancerGenerateProps> = ({
                   color="black"
                   size="s"
                   iconLeft={{iconName: 'sparkles'}}
-                  onClick={generateDancer}
+                  onClick={() => generateDancer(true)}
                   className={moduleStyles.buttonWide}
                 />
 

--- a/apps/src/metrics/AnalyticsConstants.js
+++ b/apps/src/metrics/AnalyticsConstants.js
@@ -631,6 +631,26 @@ const EVENTS = {
 
   // Dance Party (Lab2)
   DANCE_PARTY_SESSION_END: 'Dance Party Session End',
+  GENERATE_DANCER_CLICKED: 'Generate Dancer Clicked',
+  REGENERATE_DANCER_CLICKED: 'Regenerate Dancer Clicked',
+  GENERATE_DANCER_BACK_TO_PROMPT_CLICKED:
+    'Generate Dancer Back To Prompt Clicked',
+  DANCE_PARTY_GENERATE_CODE_CLICKED: 'Dance Party Generate Code Clicked',
+  DANCE_PARTY_REGENERATE_CODE_CLICKED: 'Dance Party Regenerate Code Clicked',
+  DANCE_PARTY_GENERATE_CODE_BACK_TO_PROMPT_CLICKED:
+    'Dance Party Generate Code Back To Prompt Clicked',
+  DANCE_PARTY_GENERATE_CODE_USE_CODE_CLICKED:
+    'Dance Party Generate Code Use Code Clicked',
+
+  // Music Lab
+  // Note that some Music Lab events are already sent through the Music Lab-specific {@link AnalyticsReporter.ts}.
+  // Reporting will be consolidated once Amplitude support has been removed.
+  MUSIC_LAB_GENERATE_CODE_CLICKED: 'Music Lab Generate Code Clicked',
+  MUSIC_LAB_REGENERATE_CODE_CLICKED: 'Music Lab Regenerate Code Clicked',
+  MUSIC_LAB_GENERATE_CODE_BACK_TO_PROMPT_CLICKED:
+    'Music Lab Generate Code Back To Prompt Clicked',
+  MUSIC_LAB_GENERATE_CODE_USE_CODE_CLICKED:
+    'Music Lab Generate Code Use Code Clicked',
 };
 
 const EVENT_GROUP_NAMES = {

--- a/apps/src/music/views/GenerateCode.tsx
+++ b/apps/src/music/views/GenerateCode.tsx
@@ -15,6 +15,7 @@ import Adlib, {
 import Guide from '@cdo/apps/lab2/views/components/guide/Guide';
 import MainInstructionsContent from '@cdo/apps/lab2/views/components/Instructions/MainInstructionsContent';
 import NavigationArea from '@cdo/apps/lab2/views/components/Instructions/NavigationArea';
+import {EVENTS} from '@cdo/apps/metrics/AnalyticsConstants';
 import analyticsReporter from '@cdo/apps/metrics/AnalyticsReporter';
 import {useAppDispatch, useAppSelector} from '@cdo/apps/util/reduxHooks';
 
@@ -105,47 +106,60 @@ const GenerateCode: React.FunctionComponent<GenerateCodeProps> = ({
     adlibOption ? '' : DefaultPrompt
   );
 
-  const generateSong = useCallback(async () => {
-    const startTime = Date.now();
+  const generateSong = useCallback(
+    async (regenerate = false) => {
+      const startTime = Date.now();
 
-    dispatch(setAiGenerateState('generating'));
+      dispatch(setAiGenerateState('generating'));
 
-    const pseudocode = await (useCache && useAdlib
-      ? generateSongCache(adlibOption || '', useAdlib, packId, adlibChoices)
-      : generateSongAi(
-          contextText,
+      analyticsReporter.sendEvent(
+        EVENTS[
+          `MUSIC_LAB_${regenerate ? 'REGENERATE' : 'GENERATE'}_CODE_CLICKED`
+        ],
+        {
+          adlibChoices,
           packId,
-          promptText || '',
-          (levelProperties.levelData as MusicLevelData)
-            .aiCodeGenerateExtraPrompt
-        ));
+          levelPath: window.location.pathname,
+        }
+      );
+      const pseudocode = await (useCache && useAdlib
+        ? generateSongCache(adlibOption || '', useAdlib, packId, adlibChoices)
+        : generateSongAi(
+            contextText,
+            packId,
+            promptText || '',
+            (levelProperties.levelData as MusicLevelData)
+              .aiCodeGenerateExtraPrompt
+          ));
 
-    const elapsedTime = Date.now() - startTime;
-    const remainingDelayDuration = Math.max(
-      GENERATE_DELAY_DURATION - elapsedTime,
-      0
-    );
-    await new Promise(res => setTimeout(res, remainingDelayDuration));
+      const elapsedTime = Date.now() - startTime;
+      const remainingDelayDuration = Math.max(
+        GENERATE_DELAY_DURATION - elapsedTime,
+        0
+      );
+      await new Promise(res => setTimeout(res, remainingDelayDuration));
 
-    if (pseudocode) {
-      const resultBlockly = generateBlocklyJson(pseudocode);
-      dispatch(setCodeToLoad(resultBlockly));
-    }
+      if (pseudocode) {
+        const resultBlockly = generateBlocklyJson(pseudocode);
+        dispatch(setCodeToLoad(resultBlockly));
+      }
 
-    setPlaying(true);
-    dispatch(setAiGenerateState('generated'));
-  }, [
-    adlibChoices,
-    adlibOption,
-    contextText,
-    dispatch,
-    levelProperties.levelData,
-    packId,
-    promptText,
-    setPlaying,
-    useAdlib,
-    useCache,
-  ]);
+      setPlaying(true);
+      dispatch(setAiGenerateState('generated'));
+    },
+    [
+      adlibChoices,
+      adlibOption,
+      contextText,
+      dispatch,
+      levelProperties.levelData,
+      packId,
+      promptText,
+      setPlaying,
+      useAdlib,
+      useCache,
+    ]
+  );
 
   useEffect(() => {
     // If we are clearing, make sure we are called with the new
@@ -156,7 +170,7 @@ const GenerateCode: React.FunctionComponent<GenerateCodeProps> = ({
       aiGenerateState === 'clearing-before-generating' &&
       blockCount <= 1
     ) {
-      generateSong();
+      generateSong(true);
     }
   }, [aiGenerateState, blockCount, dispatch, generateSong]);
 
@@ -329,6 +343,10 @@ const GenerateCode: React.FunctionComponent<GenerateCodeProps> = ({
               setPlaying(false);
               clearCode(true);
               dispatch(setAiGenerateState('clearing-before-none'));
+              analyticsReporter.sendEvent(
+                EVENTS.MUSIC_LAB_GENERATE_CODE_BACK_TO_PROMPT_CLICKED,
+                {levelPath: window.location.pathname, packId}
+              );
             }}
             className={styles.buttonWide}
           />
@@ -360,6 +378,10 @@ const GenerateCode: React.FunctionComponent<GenerateCodeProps> = ({
             onClick={() => {
               // Skip the 'editing' validation state for standalone projects.
               dispatch(setAiGenerateState(isStandalone ? 'edited' : 'editing'));
+              analyticsReporter.sendEvent(
+                EVENTS.MUSIC_LAB_GENERATE_CODE_USE_CODE_CLICKED,
+                {levelPath: window.location.pathname, packId, adlibChoices}
+              );
             }}
             className={styles.buttonWide}
           />
@@ -397,6 +419,10 @@ const GenerateCode: React.FunctionComponent<GenerateCodeProps> = ({
                 setPlaying(false);
                 clearCode(true);
                 dispatch(setAiGenerateState('clearing-before-none'));
+                analyticsReporter.sendEvent(
+                  EVENTS.MUSIC_LAB_GENERATE_CODE_BACK_TO_PROMPT_CLICKED,
+                  {levelPath: window.location.pathname, packId}
+                );
               }}
               className={styles.buttonWide}
             />


### PR DESCRIPTION
Adds analytics for all the generate-related actions in the Hour of AI tutorial. These include:

- Generate dancer/code
- Regenerate dancer/code
- Back to Prompt
- Use code (for Music/Dance)

The generate, regenerate, and use code analytics all include the selected adlib options as their payload. The Music Lab events also include the selected pack ID.

| Generate Dancer      | Generate Music Code | Generate Dance Code |
| ----------- | ----------- | -----------  |
|<img width="1557" height="826" alt="Screenshot 2025-11-10 at 2 19 39 PM" src="https://github.com/user-attachments/assets/a125d2fb-cfa2-4ee4-a473-84b88329a978" /> | <img width="1512" height="821" alt="Screenshot 2025-11-10 at 5 28 47 PM" src="https://github.com/user-attachments/assets/349c2dee-a2e8-40cb-b2b3-2dd20b89f5f8" /> | <img width="1512" height="822" alt="Screenshot 2025-11-10 at 9 20 35 PM" src="https://github.com/user-attachments/assets/a580bdca-70d2-4e47-98c6-5bbd44b00d0f" /> |
| <img width="1508" height="785" alt="Screenshot 2025-11-10 at 2 20 55 PM" src="https://github.com/user-attachments/assets/fdf06567-b756-4763-b639-ad7499e60b2f" /> | <img width="1460" height="797" alt="Screenshot 2025-11-10 at 5 29 47 PM" src="https://github.com/user-attachments/assets/0233c05a-ab33-4860-857f-f2e0a2983963" /> | <img width="1512" height="825" alt="Screenshot 2025-11-10 at 9 21 54 PM" src="https://github.com/user-attachments/assets/5aabf3c8-9bf3-49be-bd94-e861dac41ff9" /> |

## Links
- Jira: https://codedotorg.atlassian.net/browse/LABS-1705

## Testing story
Tested locally with Statsig