### PR TITLE
hoai2025: music start over

### DIFF
--- a/apps/src/dance/lab2/views/GenerateDance.tsx
+++ b/apps/src/dance/lab2/views/GenerateDance.tsx
@@ -227,7 +227,9 @@ const GenerateDance: React.FunctionComponent<GenerateCodeProps> = ({
     'generated',
     'listening',
     'listened',
-  ].includes(aiGenerateState);
+  ].includes(aiGenerateState)
+    ? 'full'
+    : undefined;
 
   const parentProperties = useParentLevelProperties();
   const isStandalone =

--- a/apps/src/lab2/views/components/guide/Guide.module.scss
+++ b/apps/src/lab2/views/components/guide/Guide.module.scss
@@ -8,6 +8,10 @@
   right: 0;
   bottom: 0;
   z-index: 71;
+
+  &Gap {
+    top: 43px;
+  }
 }
 
 .guide {
@@ -41,6 +45,10 @@
 
   &BottomPosition {
     bottom: 20px;
+  }
+
+  &Gap {
+    top: 62px - 43px;
   }
 }
 

--- a/apps/src/lab2/views/components/guide/Guide.module.scss
+++ b/apps/src/lab2/views/components/guide/Guide.module.scss
@@ -1,5 +1,9 @@
 @use '../layout/variables.scss' as variables;
 
+$top-position: 62px;
+$bottom-position: 20px;
+$gap-height: 43px;
+
 .guideContainerModal {
   background-color: rgba(0 0 0 / .3);
   position: absolute;
@@ -10,7 +14,7 @@
   z-index: 71;
 
   &Gap {
-    top: 43px;
+    top: $gap-height;
   }
 }
 
@@ -40,15 +44,15 @@
   }
 
   &NormalPosition {
-    top: 62px;
+    top: $top-position;
   }
 
   &BottomPosition {
-    bottom: 20px;
+    bottom: $bottom-position;
   }
 
   &Gap {
-    top: 62px - 43px;
+    top: $top-position - $gap-height;
   }
 }
 

--- a/apps/src/lab2/views/components/guide/Guide.tsx
+++ b/apps/src/lab2/views/components/guide/Guide.tsx
@@ -8,7 +8,7 @@ interface GuideProps {
   children: React.ReactNode;
   width?: 'normal' | 'narrow';
   position?: 'normal' | 'bottom';
-  modal?: boolean;
+  modal?: 'full' | 'gap';
 }
 
 // The Guide is a floating container for instructional content.  It is larger
@@ -24,7 +24,16 @@ const Guide: React.FunctionComponent<GuideProps> = ({
   return (
     <div
       id={id ? `${id}-container` : undefined}
-      className={modal ? styles.guideContainerModal : undefined}
+      className={
+        modal === 'gap'
+          ? classNames(
+              styles.guideContainerModal,
+              styles.guideContainerModalGap
+            )
+          : modal === 'full'
+          ? styles.guideContainerModal
+          : undefined
+      }
     >
       <div
         id={id}
@@ -35,7 +44,8 @@ const Guide: React.FunctionComponent<GuideProps> = ({
             : styles.guideNormalWidth,
           position === 'bottom'
             ? styles.guideBottomPosition
-            : styles.guideNormalPosition
+            : styles.guideNormalPosition,
+          modal === 'gap' && styles.guideGap
         )}
       >
         {children}

--- a/apps/src/lab2/views/components/guide/Guide.tsx
+++ b/apps/src/lab2/views/components/guide/Guide.tsx
@@ -24,16 +24,10 @@ const Guide: React.FunctionComponent<GuideProps> = ({
   return (
     <div
       id={id ? `${id}-container` : undefined}
-      className={
-        modal === 'gap'
-          ? classNames(
-              styles.guideContainerModal,
-              styles.guideContainerModalGap
-            )
-          : modal === 'full'
-          ? styles.guideContainerModal
-          : undefined
-      }
+      className={classNames(
+        modal && styles.guideContainerModal,
+        modal === 'gap' && styles.guideContainerModalGap
+      )}
     >
       <div
         id={id}

--- a/apps/src/lab2/views/components/guide/GuideInstructions.tsx
+++ b/apps/src/lab2/views/components/guide/GuideInstructions.tsx
@@ -25,7 +25,7 @@ const GuideInstructions: React.FunctionComponent<GuideInstructionsProps> = ({
   const {longInstructions} = levelProperties;
 
   return (
-    <Guide id="guide-instructions" modal={false} width={width}>
+    <Guide id="guide-instructions" modal={undefined} width={width}>
       {longInstructions && (
         <MainInstructionsContent
           instructionsText={longInstructions}

--- a/apps/src/music/views/GenerateCode.tsx
+++ b/apps/src/music/views/GenerateCode.tsx
@@ -223,15 +223,17 @@ const GenerateCode: React.FunctionComponent<GenerateCodeProps> = ({
 
   const glowSpeed = aiGenerateState === 'generating' ? 'fast' : 'normal';
 
-  const modal = [
-    'none',
-    'generating',
-    'generated',
-    'listening',
-    'listened',
-    'clearing-before-none',
-    'clearing-before-generating',
-  ].includes(aiGenerateState);
+  const modal = ['none', 'listened'].includes(aiGenerateState)
+    ? 'gap'
+    : [
+        'generating',
+        'generated',
+        'listening',
+        'clearing-before-none',
+        'clearing-before-generating',
+      ].includes(aiGenerateState)
+    ? 'full'
+    : undefined;
 
   const parentProperties = useParentLevelProperties();
   const isStandalone =


### PR DESCRIPTION
This change allows the user to "start over" in music, choosing a new song if the pack dialog is available, in both the initial Guide state of choosing an adlib, and in the state in which they've listened to four measures of the song but are yet to choose whether to prompt again, regenerate, or use code.  This is done by moving the top of the Guide modal down enough to make the top bar clickable.
