### PR TITLE
hoai2025: guide appear

### DIFF
--- a/apps/src/lab2/views/components/guide/Guide.module.scss
+++ b/apps/src/lab2/views/components/guide/Guide.module.scss
@@ -4,6 +4,28 @@ $top-position: 62px;
 $bottom-position: 20px;
 $gap-height: 43px;
 
+@keyframes slide-up {
+  from {
+    opacity: 0;
+    margin-top: 40px;
+  }
+  to {
+    opacity: 1;
+    margin-top: 0;
+  }
+}
+
+@keyframes slide-down {
+  from {
+    opacity: 0;
+    margin-bottom: 40px;
+  }
+  to {
+    opacity: 1;
+    margin-top: 0;
+  }
+}
+
 .guideContainerModal {
   background-color: rgba(0 0 0 / .3);
   position: absolute;
@@ -45,10 +67,12 @@ $gap-height: 43px;
 
   &NormalPosition {
     top: $top-position;
+    animation: 0.75s ease 1.5s backwards slide-up;
   }
 
   &BottomPosition {
     bottom: $bottom-position;
+    animation: 0.75s ease 1.5s backwards slide-down;
   }
 
   &Gap {

--- a/apps/src/lab2/views/components/guide/GuideInstructions.tsx
+++ b/apps/src/lab2/views/components/guide/GuideInstructions.tsx
@@ -24,8 +24,15 @@ const GuideInstructions: React.FunctionComponent<GuideInstructionsProps> = ({
 }) => {
   const {longInstructions} = levelProperties;
 
+  const levelSpecificId = `guide-instructions-${levelProperties.id}`;
+
   return (
-    <Guide id="guide-instructions" modal={undefined} width={width}>
+    <Guide
+      key={levelSpecificId}
+      id={levelSpecificId}
+      modal={undefined}
+      width={width}
+    >
       {longInstructions && (
         <MainInstructionsContent
           instructionsText={longInstructions}

--- a/apps/src/music/views/GenerateCode.tsx
+++ b/apps/src/music/views/GenerateCode.tsx
@@ -239,12 +239,13 @@ const GenerateCode: React.FunctionComponent<GenerateCodeProps> = ({
   const isStandalone =
     levelProperties.isProjectLevel || parentProperties?.isProjectLevel;
 
+  const levelSpecificId = `generate-panel-${levelProperties.id}`;
   if (!packId) {
     return null;
   }
 
   return (
-    <Guide id="generate-panel" modal={modal}>
+    <Guide key={levelSpecificId} id={levelSpecificId} modal={modal}>
       {aiGenerateState === 'none' &&
         useAdlib &&
         levelProperties.longInstructions && (


### PR DESCRIPTION
With this change, the Guide appears for the first time in each level after a small delay, and does a slide-in and fade. 

A unique key is used for music levels since the Guide is rendered continuously as we switch between them, an otherwise neat feature of Lab2. 

https://github.com/user-attachments/assets/33a744b3-db4a-4bc0-8f26-95c1ddbbc0ce

