### PR TITLE
hoai2025: adlib style

### DIFF
--- a/apps/src/lab2/views/components/guide/Adlib.module.scss
+++ b/apps/src/lab2/views/components/guide/Adlib.module.scss
@@ -39,6 +39,10 @@
     font-size: 16px;
     line-height: 2.4;
     padding: 16px;
+
+    &ReadOnly {
+      line-height: 1.5;
+    }
   }
 }
 

--- a/apps/src/lab2/views/components/guide/Adlib.tsx
+++ b/apps/src/lab2/views/components/guide/Adlib.tsx
@@ -143,7 +143,12 @@ const Adlib: React.FunctionComponent<AdlibProps> = ({
           : undefined
       )}
     >
-      <div className={styles.adlibInner}>
+      <div
+        className={classNames(
+          styles.adlibInner,
+          readOnly && styles.adlibInnerReadOnly
+        )}
+      >
         <div>{readOnly ? localizedFilledAdlibText : adlibHtml}</div>
         {children}
       </div>


### PR DESCRIPTION
This improves the adlib text styling by reducing the `line-height` of the read only text.  It doesn't need such a big line height when read only, because there aren't `select` boxes to keep vertically separated. 
