### PR TITLE
CMS-745: Remove Pegasus Hoc API proxy to Dashboard

### DIFF
--- a/lib/cdo/http_cache.rb
+++ b/lib/cdo/http_cache.rb
@@ -127,7 +127,7 @@ class HttpCache
 
     # These cookies are allowlisted on all session-specific (not cached) pages.
     allowlisted_cookies = [
-      'hour_of_code',
+      HocLegacy::HOC_COOKIE_KEY,
       'progress',
       'lines',
       'scripts',
@@ -142,7 +142,7 @@ class HttpCache
       'sign_up_user_type',
     ].concat(default_cookies)
 
-    http_config = {
+    {
       pegasus: {
         behaviors: [
           # NextJS assets path for the marketing app
@@ -356,32 +356,6 @@ class HttpCache
         }
       }
     }
-
-    if defined?(HocLegacy::Engine)
-      http_config.deep_merge!(
-        dashboard: {
-          behaviors: [
-            {
-              path: "#{HocLegacy::API_ROOT_PATH}/*",
-              headers: ALLOWLISTED_HEADERS,
-              cookies: allowlisted_cookies,
-            },
-          ],
-        },
-        pegasus: {
-          behaviors: [
-            {
-              path: "#{HocLegacy::API_ROOT_PATH}/*",
-              proxy: 'dashboard',
-              headers: ALLOWLISTED_HEADERS,
-              cookies: allowlisted_cookies,
-            },
-          ],
-        }
-      )
-    end
-
-    http_config
   end
 
   def self.uncached_script_level_path?(script_level_path)

--- a/lib/cdo/http_cache.rb
+++ b/lib/cdo/http_cache.rb
@@ -127,6 +127,7 @@ class HttpCache
 
     # These cookies are allowlisted on all session-specific (not cached) pages.
     allowlisted_cookies = [
+      'hour_of_code',
       'progress',
       'lines',
       'scripts',
@@ -140,10 +141,6 @@ class HttpCache
       storage_id,
       'sign_up_user_type',
     ].concat(default_cookies)
-
-    # Allows the HoC session tracking cookie
-    require 'hoc_legacy'
-    allowlisted_cookies << HocLegacy::HOC_COOKIE_KEY
 
     {
       pegasus: {

--- a/lib/cdo/http_cache.rb
+++ b/lib/cdo/http_cache.rb
@@ -127,7 +127,6 @@ class HttpCache
 
     # These cookies are allowlisted on all session-specific (not cached) pages.
     allowlisted_cookies = [
-      HocLegacy::HOC_COOKIE_KEY,
       'progress',
       'lines',
       'scripts',
@@ -141,6 +140,10 @@ class HttpCache
       storage_id,
       'sign_up_user_type',
     ].concat(default_cookies)
+
+    # Allows the HoC session tracking cookie
+    require 'hoc_legacy'
+    allowlisted_cookies << HocLegacy::HOC_COOKIE_KEY
 
     {
       pegasus: {


### PR DESCRIPTION
Removes the Pegasus HoC API proxy to Dashboard, since these routes are now managed through Marketing router lambda redirects:
https://github.com/code-dot-org/code-dot-org/blob/53f51c9de5280ed38cb626e7b94517bbb571556c/aws/cloudformation/lambdas/marketing-router/index.js#L796

## Test
<img alt="finish_pixel" src="https://github.com/user-attachments/assets/24bf2502-3c95-4092-8d13-051cbab5c9da" />

## Links
- JIRA task: [CMS-745](https://codedotorg.atlassian.net/browse/CMS-745)
- Related PRs:
  1. https://github.com/code-dot-org/code-dot-org/pull/69097
  2. https://github.com/code-dot-org/marketing-sites/pull/13
  3. https://github.com/code-dot-org/code-dot-org/pull/69470