### PR TITLE
CMS-906: Add `/congrats` and `/congrats/*` routes to Marketing router lambda

### DIFF
--- a/aws/cloudformation/lambdas/marketing-router/index.js
+++ b/aws/cloudformation/lambdas/marketing-router/index.js
@@ -425,6 +425,7 @@ const marketingPaths = {
   "/codebytes": true,
   "/hour-of-code/": true,
   "/community": true,
+  "/congrats": true,
   "/contact": true,
   "/cookies": true,
   "/cps": true,
@@ -794,6 +795,7 @@ const pathPatterns = [
   /^\/_next\/static\//, // Next.js static assets
   /^\/_next\/image/,  // Next.js dynamic images, /_next/image*
   /^\/api\/hour\//,     // /api/hour/*
+  /^\/congrats\//,      // /congrats/*
   /^\/forms\//,         // /forms/*
   /^\/schools\//,       // /schools/*
   /^\/applab\/docs\//,  // /applab/docs/*

--- a/lib/cdo/http_cache.rb
+++ b/lib/cdo/http_cache.rb
@@ -169,12 +169,6 @@ class HttpCache
             headers: S3_FORWARD_HEADERS,
             cookies: 'none'
           },
-          {
-            path: %w[/congrats /congrats/*],
-            proxy: 'dashboard',
-            headers: ALLOWLISTED_HEADERS,
-            cookies: allowlisted_cookies,
-          },
           # For .png images, don't forward any cookies or additional headers.
           {
             path: '/*.png',
@@ -182,7 +176,7 @@ class HttpCache
             cookies: 'none',
             include_marketing_router_lambda: true,
           },
-          # For static-asset paths, don't forward any cookies or additional headers.
+          # For static-asset paths, don't forward any cookies or addinal headers.
           {
             path: STATIC_ASSET_EXTENSION_PATHS - %w(/*.png) + %w(/files/* /images/* /fonts/*),
             headers: [],

--- a/lib/cdo/http_cache.rb
+++ b/lib/cdo/http_cache.rb
@@ -169,12 +169,6 @@ class HttpCache
             headers: S3_FORWARD_HEADERS,
             cookies: 'none'
           },
-          {
-            path: %w[/congrats /congrats/*],
-            proxy: 'dashboard',
-            headers: ALLOWLISTED_HEADERS,
-            cookies: allowlisted_cookies,
-          },
           # For .png images, don't forward any cookies or additional headers.
           {
             path: '/*.png',

--- a/lib/cdo/http_cache.rb
+++ b/lib/cdo/http_cache.rb
@@ -176,7 +176,7 @@ class HttpCache
             cookies: 'none',
             include_marketing_router_lambda: true,
           },
-          # For static-asset paths, don't forward any cookies or addinal headers.
+          # For static-asset paths, don't forward any cookies or additional headers.
           {
             path: STATIC_ASSET_EXTENSION_PATHS - %w(/*.png) + %w(/files/* /images/* /fonts/*),
             headers: [],

--- a/lib/cdo/http_cache.rb
+++ b/lib/cdo/http_cache.rb
@@ -169,6 +169,12 @@ class HttpCache
             headers: S3_FORWARD_HEADERS,
             cookies: 'none'
           },
+          {
+            path: %w[/congrats /congrats/*],
+            proxy: 'dashboard',
+            headers: ALLOWLISTED_HEADERS,
+            cookies: allowlisted_cookies,
+          },
           # For .png images, don't forward any cookies or additional headers.
           {
             path: '/*.png',


### PR DESCRIPTION
Adds `/congrats` and `/congrats/*` routes to the Marketing router lambda to be handled by the Marketing redirects middleware instead of proxying them from Pegasus to Dashboard

## Links
- JIRA task: [CMS-906](https://codedotorg.atlassian.net/browse/CMS-906)
- Related PRs:
  1. https://github.com/code-dot-org/code-dot-org/pull/69299
  2. https://github.com/code-dot-org/marketing-sites/pull/16