### PR TITLE
[AITT-1281] Don't automatically open TA in levels

### DIFF
--- a/apps/src/sites/studio/pages/levels/show.js
+++ b/apps/src/sites/studio/pages/levels/show.js
@@ -23,6 +23,10 @@ $(document).ready(initPage);
 
 function initPage() {
   const script = document.querySelector('script[data-level]');
+  if (!script || !script.dataset.level) {
+    console.error('Level script element not found');
+    return;
+  }
   const config = JSON.parse(script.dataset.level);
 
   registerReducers({instructions});
@@ -50,6 +54,50 @@ function initPage() {
     );
   }
 
+  // Helper function to determine if the current level is a lab
+  const isLabLevel = () => {
+    try {
+      // Check config.app first
+      let appType = config.app;
+      // Fallback to Redux store pageConstants if config.app is not available
+      if (!appType) {
+        try {
+          const pageConstants = getStore().getState().pageConstants;
+          appType = pageConstants?.appType;
+        } catch (e) {
+          // If store isn't ready yet, just return false
+          return false;
+        }
+      }
+      // If still no app type, we can't determine if it's a lab
+      if (!appType) {
+        return false;
+      }
+      appType = appType.toLowerCase();
+      // Lab2 apps
+      const lab2Apps = [
+        'aichat',
+        'bubble_choice',
+        'dance',
+        'music',
+        'panels',
+        'pythonlab',
+        'standalone_video',
+        'weblab2',
+        'sketchlab',
+      ];
+      // Legacy lab apps (end with "lab")
+      const isLegacyLab = appType.endsWith('lab');
+      // Check if it's a lab2 app
+      const isLab2App = lab2Apps.includes(appType);
+      return isLegacyLab || isLab2App;
+    } catch (e) {
+      // If anything goes wrong, default to allowing auto-open (safer)
+      console.warn('Error detecting lab level:', e);
+      return false;
+    }
+  };
+
   // AI Differentiation FAB to be shown only if rubric FAB is not.
   const renderAiDiffButton = () => {
     const reportingData = {
@@ -69,12 +117,16 @@ function initPage() {
       'ai-differentiation-fab-mount-point'
     );
     if (aiDiffFabMountPoint && experiments.isEnabled('ai-diff-levels')) {
+      // Don't automatically open TA in lab contexts
+      const isLab = isLabLevel();
       ReactDOM.render(
         <Provider store={getStore()}>
           <AiDiffFloatingActionButton
             context={differentiationContext}
             scriptId={reportingData.unitName}
             scriptName={reportingData.unitName}
+            canStartOpen={!isLab}
+            canDefaultOpen={!isLab}
           />
         </Provider>,
         aiDiffFabMountPoint

--- a/apps/src/sites/studio/pages/levels/show.js
+++ b/apps/src/sites/studio/pages/levels/show.js
@@ -23,10 +23,6 @@ $(document).ready(initPage);
 
 function initPage() {
   const script = document.querySelector('script[data-level]');
-  if (!script || !script.dataset.level) {
-    console.error('Level script element not found');
-    return;
-  }
   const config = JSON.parse(script.dataset.level);
 
   registerReducers({instructions});
@@ -54,50 +50,6 @@ function initPage() {
     );
   }
 
-  // Helper function to determine if the current level is a lab
-  const isLabLevel = () => {
-    try {
-      // Check config.app first
-      let appType = config.app;
-      // Fallback to Redux store pageConstants if config.app is not available
-      if (!appType) {
-        try {
-          const pageConstants = getStore().getState().pageConstants;
-          appType = pageConstants?.appType;
-        } catch (e) {
-          // If store isn't ready yet, just return false
-          return false;
-        }
-      }
-      // If still no app type, we can't determine if it's a lab
-      if (!appType) {
-        return false;
-      }
-      appType = appType.toLowerCase();
-      // Lab2 apps
-      const lab2Apps = [
-        'aichat',
-        'bubble_choice',
-        'dance',
-        'music',
-        'panels',
-        'pythonlab',
-        'standalone_video',
-        'weblab2',
-        'sketchlab',
-      ];
-      // Legacy lab apps (end with "lab")
-      const isLegacyLab = appType.endsWith('lab');
-      // Check if it's a lab2 app
-      const isLab2App = lab2Apps.includes(appType);
-      return isLegacyLab || isLab2App;
-    } catch (e) {
-      // If anything goes wrong, default to allowing auto-open (safer)
-      console.warn('Error detecting lab level:', e);
-      return false;
-    }
-  };
-
   // AI Differentiation FAB to be shown only if rubric FAB is not.
   const renderAiDiffButton = () => {
     const reportingData = {
@@ -117,16 +69,14 @@ function initPage() {
       'ai-differentiation-fab-mount-point'
     );
     if (aiDiffFabMountPoint && experiments.isEnabled('ai-diff-levels')) {
-      // Don't automatically open TA in lab contexts
-      const isLab = isLabLevel();
       ReactDOM.render(
         <Provider store={getStore()}>
           <AiDiffFloatingActionButton
             context={differentiationContext}
             scriptId={reportingData.unitName}
             scriptName={reportingData.unitName}
-            canStartOpen={!isLab}
-            canDefaultOpen={!isLab}
+            canStartOpen={false}
+            canDefaultOpen={false}
           />
         </Provider>,
         aiDiffFabMountPoint


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
## [AITT-1281] Don't automatically open TA in levels

Upon investigation - fix turned out to be as easy as this.


https://github.com/user-attachments/assets/f9f48b95-515f-4bdb-bd49-2be30322e488


## Links
<!--  Links to relevant external resources.
      - spec docs, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- Jira: [AITT-1281](https://codedotorg.atlassian.net/browse/AITT-1281)

## Testing story
<!--  Does your change include appropriate tests?
      - If so, please describe how the tests included in this PR are sufficient.
      - If not, please explain why this change does not need to be tested. -->



## Deployment strategy
<!--  Any special steps required to deploy this, besides merging?
      - Are there database migrations or manual steps?
      - Does this require coordination with other teams or systems? -->



## Follow-up work
<!--  List any clean-up or technical debt that will be addressed in future work.
      - Include Jira links where applicable.
      - Are there any known limitations or improvements planned? -->



## Privacy
<!--  How does this change impact Student & Teacher privacy?
      - Does this collect, use, share, or modify PII, either new or existing? -->



## Security
<!--  How does this change impact our security surface-area?
      - Do API's touched have the right auth?
      - Do infra changes impact our attack surface or encryption?
-->



## Caching
<!--  How does this change impact caching behavior?
      - Are cache keys or invalidation strategies affected?
      - Will this require cache warming or invalidation after deployment? -->



## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
