### PR TITLE
feat(tutor): add hasRun and hasEdited context for tutor

### DIFF
--- a/apps/src/aiTutor/helpers/aiTutorContextHelper.ts
+++ b/apps/src/aiTutor/helpers/aiTutorContextHelper.ts
@@ -2,6 +2,10 @@ import {AiTutorContext, MaybePromise} from '../types';
 
 const SOURCE_CODE_INTRO = "Here is the student's current code:";
 
+const HAS_NOT_RUN = 'The student has not run the source code.';
+
+const HAS_NOT_EDITED = 'The student has not edited the source code.';
+
 const HIDDEN_SOURCE_CODE_INTRO =
   'Here is the hidden source code used to run this lesson. The student cannot view or modify this code so do not reference it in your response:';
 
@@ -51,12 +55,16 @@ export abstract class AiTutorContextHelper<AiTutorParams extends object> {
       longInstructions,
       documentation,
       consoleOutput,
+      hasRun,
+      hasEdited,
     } = await this.getAiTutorContext();
 
     const validationNotRun = validationContents && !validationResults;
 
     const hiddenContextString = [
       sourceCode ? `${SOURCE_CODE_INTRO} ${sourceCode}` : '',
+      hasRun === false ? HAS_NOT_RUN : '',
+      hasEdited === false ? HAS_NOT_EDITED : '',
       hiddenSourceCode ? `${HIDDEN_SOURCE_CODE_INTRO} ${hiddenSourceCode}` : '',
       readOnlySourceCode
         ? `${READ_ONLY_SOURCE_CODE_INTRO} ${readOnlySourceCode}`

--- a/apps/src/aiTutor/types.ts
+++ b/apps/src/aiTutor/types.ts
@@ -20,6 +20,8 @@ export interface AiTutorContext {
   documentation?: string;
   documentationLocation?: string;
   consoleOutput?: string;
+  hasRun?: boolean;
+  hasEdited?: boolean;
 }
 
 export interface AnalyticsData {

--- a/apps/src/pythonlab/PythonlabView.tsx
+++ b/apps/src/pythonlab/PythonlabView.tsx
@@ -104,6 +104,8 @@ const PythonlabView: React.FunctionComponent<
   const miniAppName = useAppSelector(
     state => state.lab2Project.projectSources?.labConfig?.miniApp?.name
   );
+  const hasRun = useAppSelector(state => state.lab2System.hasRun);
+  const hasEdited = useAppSelector(state => state.lab2Project.hasEdited);
 
   const hasSource = !!source;
   const isAiTutorEnabled = useMemo(() => {
@@ -195,6 +197,8 @@ const PythonlabView: React.FunctionComponent<
         miniAppName,
         validationFile,
         longInstructions: levelProperties.longInstructions,
+        hasRun,
+        hasEdited,
       });
     }
   }, [
@@ -203,6 +207,8 @@ const PythonlabView: React.FunctionComponent<
     validationFile,
     miniAppName,
     isAiTutorEnabled,
+    hasRun,
+    hasEdited,
   ]);
 
   const onRun = async (

--- a/apps/src/pythonlab/helpers/aiTutorContextHelper.ts
+++ b/apps/src/pythonlab/helpers/aiTutorContextHelper.ts
@@ -15,6 +15,8 @@ interface AiTutorPythonLabParams {
   validationFile: ProjectFile | undefined;
   longInstructions: string | undefined;
   miniAppName: string | undefined;
+  hasRun: boolean | undefined;
+  hasEdited: boolean | undefined;
 }
 export class AiTutorPythonLabContextHelper extends AiTutorContextHelper<AiTutorPythonLabParams> {
   private documentationPromise?: Promise<string | undefined>;
@@ -37,7 +39,8 @@ export class AiTutorPythonLabContextHelper extends AiTutorContextHelper<AiTutorP
   protected override async getAiTutorContext(): Promise<AiTutorContext> {
     if (!this.params) return {};
 
-    const {source, validationFile, longInstructions} = this.params;
+    const {source, validationFile, longInstructions, hasRun, hasEdited} =
+      this.params;
     const sourceCode = source
       ? Object.values(source.files)
           .filter(
@@ -84,6 +87,8 @@ export class AiTutorPythonLabContextHelper extends AiTutorContextHelper<AiTutorP
       longInstructions,
       documentation,
       consoleOutput,
+      hasRun,
+      hasEdited,
     };
   }
 }

--- a/apps/src/weblab2/Weblab2View.tsx
+++ b/apps/src/weblab2/Weblab2View.tsx
@@ -94,6 +94,10 @@ const Weblab2View: React.FC<
     state => !!state.lab2Project.projectSources?.source
   );
 
+  const hasEdited = useAppSelector(state => state.lab2Project.hasEdited);
+
+  const hasRun = useAppSelector(state => state.lab2System.hasRun);
+
   // Note: this causes Web Lab 2 to re-render when sources change.
   // Unfortunately, the way AI tutor is set up right now requires passing in a context
   // rather than a callback for the context. In the future, we should consider refactoring AI
@@ -102,8 +106,10 @@ const Weblab2View: React.FC<
     aiTutorHelper.setAiTutorContext({
       source,
       longInstructions: levelProperties.longInstructions,
+      hasEdited,
+      hasRun,
     });
-  }, [source, levelProperties.longInstructions]);
+  }, [source, levelProperties.longInstructions, hasEdited, hasRun]);
 
   // Since there's no run button in Weblab2, set it to true by default
   // to enable the Submit button on edit on submittable levels.

--- a/apps/src/weblab2/helpers/aiTutorContextHelper.ts
+++ b/apps/src/weblab2/helpers/aiTutorContextHelper.ts
@@ -5,6 +5,8 @@ import {MultiFileSource, ProjectFileType} from '@cdo/apps/lab2/types';
 interface AiTutorWebLab2Params {
   source: MultiFileSource | undefined;
   longInstructions: string | undefined;
+  hasEdited: boolean | undefined;
+  hasRun: boolean | undefined;
 }
 
 const LANGUAGES_TO_EXCLUDE_FROM_CONTEXT = ['txt', 'csv', 'md'];
@@ -19,7 +21,7 @@ export class AiTutorWebLab2ContextHelper extends AiTutorContextHelper<AiTutorWeb
   protected override getAiTutorContext(): AiTutorContext {
     if (!this.params) return {};
 
-    const {source, longInstructions} = this.params;
+    const {source, longInstructions, hasEdited, hasRun} = this.params;
     const sourceCode = source
       ? Object.values(source.files)
           .filter(
@@ -37,6 +39,8 @@ export class AiTutorWebLab2ContextHelper extends AiTutorContextHelper<AiTutorWeb
     return {
       sourceCode,
       longInstructions,
+      hasEdited,
+      hasRun,
     };
   }
 }


### PR DESCRIPTION
This pull request enhances the AI Tutor context by tracking and including whether the student has run or edited their source code. These new context flags are now passed through both Python Lab and Web Lab 2, and are surfaced in the AI Tutor's context strings to inform AI responses. This allows the AI Tutor to better understand and respond to the student's progress and actions.

* Added `hasRun` and `hasEdited` boolean flags to the `AiTutorContext` interface, enabling tracking of whether the student has run or edited their code.
* Updated context helper classes (`AiTutorPythonLabContextHelper` and `AiTutorWebLab2ContextHelper`) to extract and pass `hasRun` and `hasEdited` from their parameters into the AI Tutor context.
* Updated `PythonlabView` and `Weblab2View` components to pull `hasRun` and `hasEdited` from Redux state and pass them into the AI Tutor context.
* Added new context strings (`HAS_NOT_RUN`, `HAS_NOT_EDITED`) to inform the AI Tutor when the student has not yet run or edited their code, and included these in the context string construction.



## Links
<!--  Links to relevant external resources.
      - spec docs, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- Jira: https://codedotorg.atlassian.net/browse/LABS-1589

## Testing story
<!--  Does your change include appropriate tests?
      - If so, please describe how the tests included in this PR are sufficient.
      - If not, please explain why this change does not need to be tested. -->



## Deployment strategy
<!--  Any special steps required to deploy this, besides merging?
      - Are there database migrations or manual steps?
      - Does this require coordination with other teams or systems? -->



## Follow-up work
<!--  List any clean-up or technical debt that will be addressed in future work.
      - Include Jira links where applicable.
      - Are there any known limitations or improvements planned? -->



## Privacy
<!--  How does this change impact Student & Teacher privacy?
      - Does this collect, use, share, or modify PII, either new or existing? -->



## Security
<!--  How does this change impact our security surface-area?
      - Do API's touched have the right auth?
      - Do infra changes impact our attack surface or encryption?
-->



## Caching
<!--  How does this change impact caching behavior?
      - Are cache keys or invalidation strategies affected?
      - Will this require cache warming or invalidation after deployment? -->



## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
