### PR TITLE
Fix lesson numbers on compact unit view showing up when disabled

### DIFF
--- a/apps/src/templates/progress/SummaryProgressRow.jsx
+++ b/apps/src/templates/progress/SummaryProgressRow.jsx
@@ -26,6 +26,7 @@ function SummaryProgressRow({
   lessonIsHiddenForStudents,
   lessonIsLockedForUser,
   lessonIsLockedForAllStudents,
+  unitHasUnnumberedLessons,
   viewAs,
 }) {
   // The parent component filters out hidden SummaryProgressRows from the student view,
@@ -39,7 +40,7 @@ function SummaryProgressRow({
   const showAsLocked = isLockedForUser || isLockedForSection;
 
   let lessonTitle = lesson.name;
-  if (lesson.lessonNumber) {
+  if (lesson.lessonNumber && !unitHasUnnumberedLessons) {
     lessonTitle = lesson.lessonNumber + '. ' + lessonTitle;
   }
 
@@ -137,6 +138,7 @@ SummaryProgressRow.propTypes = {
   lessonIsHiddenForStudents: PropTypes.bool.isRequired,
   lessonIsLockedForUser: PropTypes.func.isRequired,
   lessonIsLockedForAllStudents: PropTypes.func.isRequired,
+  unitHasUnnumberedLessons: PropTypes.bool.isRequired,
 };
 
 export const styles = {
@@ -209,6 +211,7 @@ export default connect((state, ownProps) => ({
     state,
     ViewType.Participant
   ),
+  unitHasUnnumberedLessons: state.progress.unitHasUnnumberedLessons,
   lessonIsLockedForUser: (lesson, levels, viewAs) =>
     lessonIsLockedForUser(lesson, levels, state, viewAs),
   lessonIsLockedForAllStudents: lessonId =>

--- a/apps/test/unit/templates/progress/SummaryProgressRowTest.js
+++ b/apps/test/unit/templates/progress/SummaryProgressRowTest.js
@@ -16,6 +16,7 @@ const baseProps = {
   lessonIsLockedForUser: () => false,
   lessonIsLockedForAllStudents: () => false,
   viewAs: ViewType.Instructor,
+  unitHasUnnumberedLessons: false,
 };
 
 const setUp = (overrideProps = {}) => {
@@ -49,6 +50,23 @@ describe('SummaryProgressRow', () => {
       expect(wrapper.props().style.borderStyle).toEqual('dashed');
       expect(wrapper.find('td').at(0).props().style.opacity).toEqual(0.6);
       expect(wrapper.find('td').at(1).props().style.opacity).toEqual(0.6);
+    });
+
+    it('renders lesson numbers with unitHasUnnumberedLessons false', () => {
+      const wrapper = setUp({
+        unitHasUnnumberedLessons: false,
+      });
+
+      expect(wrapper.find('td').at(0).text()).toContain('3. Maze');
+    });
+
+    it('renders lesson names without numbers with unitHasUnnumberedLessons true', () => {
+      const wrapper = setUp({
+        unitHasUnnumberedLessons: true,
+      });
+
+      expect(wrapper.find('td').at(0).text()).toContain('Maze');
+      expect(wrapper.find('td').at(0).text()).not.toContain('3.');
     });
 
     it('disables bubbles when locked', () => {


### PR DESCRIPTION
Lesson numbers were still showing up in the compact lesson view even when `unitHasUnnumberedLessons` was true. This is a bug fix for a bug introduced in https://github.com/code-dot-org/code-dot-org/pull/65008


Before (notice how it shows `0: Lesson 1`): 
<img width="1017" height="584" alt="image" src="https://github.com/user-attachments/assets/677cfbf2-ac73-4170-825d-4736dc2fe846" />

After:
<img width="844" height="690" alt="image" src="https://github.com/user-attachments/assets/1674a9c1-e08d-4c2c-9fc2-f5d2b113a203" />

And still works when `unitHasUnnumberedLessons` is false
<img width="1170" height="662" alt="image" src="https://github.com/user-attachments/assets/96a55e38-8291-4e5e-85e2-171165c0e7f1" />

## Links
zendesk: https://codeorg.zendesk.com/agent/tickets/561578