### PR TITLE
ChooseCurriculum - UI set

### DIFF
--- a/apps/i18n/common/en_us.json
+++ b/apps/i18n/common/en_us.json
@@ -1519,6 +1519,7 @@
   "grade": "Grade",
   "gradeLevel": "Grade {number}",
   "gradeRange": "{numGrades, plural, one {Grade: {youngestGrade}} other {Grades: {youngestGrade}-{oldestGrade}}}",
+  "gradesTaught": "What grade(s) do you teach?",
   "greaterThan": "Greater than",
   "greaterThanOrEqualTo": "Greater than or equal to",
   "groups": "Groups",

--- a/apps/i18n/common/en_us.json
+++ b/apps/i18n/common/en_us.json
@@ -1519,7 +1519,6 @@
   "grade": "Grade",
   "gradeLevel": "Grade {number}",
   "gradeRange": "{numGrades, plural, one {Grade: {youngestGrade}} other {Grades: {youngestGrade}-{oldestGrade}}}",
-  "gradesTaught": "What grade(s) do you teach?",
   "greaterThan": "Greater than",
   "greaterThanOrEqualTo": "Greater than or equal to",
   "groups": "Groups",

--- a/apps/i18n/signup/en_us.json
+++ b/apps/i18n/signup/en_us.json
@@ -75,6 +75,7 @@
   "get_informational_emails": "Get informational emails about Code.org updates and opportunities (1-2/month)",
   "after_creating_your_account": "After creating your account, you will receive a set of onboarding emails to help you get started.",
   "go_to_my_account": "Go to my account",
+  "grades_taught": "What grade(s) do you teach?*",
   "finish_creating_student_account": "Finish creating your student account",
   "i_am_a_parent_or_guardian": "I am a parent or guardian signing up on behalf of my child.",
   "display_name": "Display name",

--- a/apps/src/signUpFlow/AccountType.tsx
+++ b/apps/src/signUpFlow/AccountType.tsx
@@ -6,6 +6,7 @@ import React, {useState, useEffect} from 'react';
 import {studio} from '@cdo/apps/lib/util/urlHelpers';
 import {EVENTS, PLATFORMS} from '@cdo/apps/metrics/AnalyticsConstants';
 import analyticsReporter from '@cdo/apps/metrics/AnalyticsReporter';
+import statsigReporter from '@cdo/apps/metrics/StatsigReporter';
 import locale from '@cdo/apps/signUpFlow/locale';
 import AccountBanner from '@cdo/apps/templates/account/AccountBanner';
 
@@ -17,6 +18,7 @@ import {
   ACCOUNT_TYPE_SESSION_KEY,
   OAUTH_LOGIN_TYPE_SESSION_KEY,
   setUserReturnToUrl,
+  TEACHER_IN_GRADE_SELECTION_EXPERIMENT_KEY,
 } from './signUpFlowConstants';
 
 import style from './signUpFlowStyles.module.scss';
@@ -72,7 +74,16 @@ const AccountType: React.FunctionComponent<{
       },
       PLATFORMS.BOTH
     );
+    const isInGradeSelectionExperiment = statsigReporter.getIsInExperiment(
+      'select_grades_taught_on_account_creation',
+      'enable_selecting_grades',
+      false
+    );
     sessionStorage.setItem(ACCOUNT_TYPE_SESSION_KEY, accountType);
+    sessionStorage.setItem(
+      TEACHER_IN_GRADE_SELECTION_EXPERIMENT_KEY,
+      isInGradeSelectionExperiment
+    );
 
     // By default, navigate the user to the login type page after selecting their user
     // type. However, if a user is sent to this page after trying to login through OAuth

--- a/apps/src/signUpFlow/FinishTeacherAccount.tsx
+++ b/apps/src/signUpFlow/FinishTeacherAccount.tsx
@@ -26,7 +26,6 @@ import GradeLevelChips from '@cdo/apps/templates/sectionsRefresh/GradeLevelChips
 import {getAuthenticityToken} from '@cdo/apps/util/AuthenticityTokenStore';
 import trackEvent from '@cdo/apps/util/trackEvent';
 import {UserTypes, EducatorRoles} from '@cdo/generated-scripts/sharedConstants';
-import i18n from '@cdo/locale';
 
 import {useSchoolInfo} from '../schoolInfo/hooks/useSchoolInfo';
 import {buildSchoolData} from '../schoolInfo/utils/buildSchoolData';
@@ -194,7 +193,8 @@ const FinishTeacherAccount: React.FunctionComponent<{
       !gdprValid ||
       schoolInfoInvalid(schoolInfo) ||
       !educatorRole ||
-      signupSources.length < 1,
+      signupSources.length < 1 ||
+      (selectedGrades.length < 1 && isInGradeSelectionExperiment),
     [
       gdprValid,
       givenName,
@@ -203,6 +203,8 @@ const FinishTeacherAccount: React.FunctionComponent<{
       schoolInfo,
       educatorRole,
       signupSources,
+      selectedGrades,
+      isInGradeSelectionExperiment,
     ]
   );
 
@@ -460,7 +462,7 @@ const FinishTeacherAccount: React.FunctionComponent<{
           />
           {isInGradeSelectionExperiment && (
             <GradeLevelChips
-              inputLabel={i18n.gradesTaught()}
+              inputLabel={locale.grades_taught()}
               values={selectedGrades}
               setValues={vals => setSelectedGrades(vals)}
               className={style.gradeSelectChips}

--- a/apps/src/signUpFlow/FinishTeacherAccount.tsx
+++ b/apps/src/signUpFlow/FinishTeacherAccount.tsx
@@ -22,9 +22,11 @@ import analyticsReporter from '@cdo/apps/metrics/AnalyticsReporter';
 import {schoolInfoInvalid} from '@cdo/apps/schoolInfo/utils/schoolInfoInvalid';
 import SafeMarkdown from '@cdo/apps/templates/SafeMarkdown';
 import SchoolDataInputs from '@cdo/apps/templates/SchoolDataInputs';
+import GradeLevelChips from '@cdo/apps/templates/sectionsRefresh/GradeLevelChips';
 import {getAuthenticityToken} from '@cdo/apps/util/AuthenticityTokenStore';
 import trackEvent from '@cdo/apps/util/trackEvent';
 import {UserTypes, EducatorRoles} from '@cdo/generated-scripts/sharedConstants';
+import i18n from '@cdo/locale';
 
 import {useSchoolInfo} from '../schoolInfo/hooks/useSchoolInfo';
 import {buildSchoolData} from '../schoolInfo/utils/buildSchoolData';
@@ -106,6 +108,7 @@ const FinishTeacherAccount: React.FunctionComponent<{
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [errorCreatingAccountMessage, setErrorCreatingAccountMessage] =
     useState('');
+  const [selectedGrades, setSelectedGrades] = useState<string[]>([]);
 
   // Remove oauth user_type cookie if it exists
   cookies.remove(SIGN_UP_USER_TYPE);
@@ -449,6 +452,12 @@ const FinishTeacherAccount: React.FunctionComponent<{
             }}
             itemGroups={roleItemGroups}
             dropdownTextThickness="thin"
+          />
+          <GradeLevelChips
+            inputLabel={i18n.gradesTaught()}
+            values={selectedGrades}
+            setValues={vals => setSelectedGrades(vals)}
+            className={style.gradeSelectChips}
           />
           <SchoolDataInputs {...schoolInfo} includeHeaders={false} />
           {showGDPR && (

--- a/apps/src/signUpFlow/FinishTeacherAccount.tsx
+++ b/apps/src/signUpFlow/FinishTeacherAccount.tsx
@@ -43,6 +43,7 @@ import {
   clearSignUpSessionStorage,
   SIGN_UP_USER_TYPE,
   MAX_DISPLAY_NAME_LENGTH,
+  TEACHER_IN_GRADE_SELECTION_EXPERIMENT_KEY,
 } from './signUpFlowConstants';
 
 import style from './signUpFlowStyles.module.scss';
@@ -112,6 +113,10 @@ const FinishTeacherAccount: React.FunctionComponent<{
 
   // Remove oauth user_type cookie if it exists
   cookies.remove(SIGN_UP_USER_TYPE);
+
+  const isInGradeSelectionExperiment =
+    sessionStorage.getItem(TEACHER_IN_GRADE_SELECTION_EXPERIMENT_KEY) ===
+    'true';
 
   useEffect(() => {
     // If the user hasn't selected a user type or login type, redirect them back to the incomplete step of signup.
@@ -453,12 +458,14 @@ const FinishTeacherAccount: React.FunctionComponent<{
             itemGroups={roleItemGroups}
             dropdownTextThickness="thin"
           />
-          <GradeLevelChips
-            inputLabel={i18n.gradesTaught()}
-            values={selectedGrades}
-            setValues={vals => setSelectedGrades(vals)}
-            className={style.gradeSelectChips}
-          />
+          {isInGradeSelectionExperiment && (
+            <GradeLevelChips
+              inputLabel={i18n.gradesTaught()}
+              values={selectedGrades}
+              setValues={vals => setSelectedGrades(vals)}
+              className={style.gradeSelectChips}
+            />
+          )}
           <SchoolDataInputs {...schoolInfo} includeHeaders={false} />
           {showGDPR && (
             <div>

--- a/apps/src/signUpFlow/signUpFlowConstants.tsx
+++ b/apps/src/signUpFlow/signUpFlowConstants.tsx
@@ -11,6 +11,8 @@ export const GIVEN_NAME_SESSION_KEY = 'givenName';
 export const FAMILY_NAME_SESSION_KEY = 'familyName';
 export const OAUTH_LOGIN_TYPE_SESSION_KEY = 'oauthType';
 export const USER_RETURN_TO_SESSION_KEY = 'userReturnTo';
+export const TEACHER_IN_GRADE_SELECTION_EXPERIMENT_KEY =
+  'isInSelectGradesExperiment';
 
 export const setUserReturnToUrl = () => {
   const userReturnTo = queryParams('user_return_to');

--- a/apps/src/signUpFlow/signUpFlowStyles.module.scss
+++ b/apps/src/signUpFlow/signUpFlowStyles.module.scss
@@ -30,11 +30,21 @@ select {
   font-weight: 400 !important;
 }
 
-p, label {
+p,
+label {
   margin-bottom: 0 !important;
   padding-top: 0 !important;
 }
 
+.gradeSelectChips {
+  label {
+    width: auto !important; // Override the global width: 100% for chip labels
+    padding-top: 0.25rem !important;
+    padding-bottom: 0.25rem !important;
+  }
+}
+
+// This is the part causing issues
 label {
   width: 100%;
   align-items: start !important;
@@ -57,7 +67,6 @@ span {
   margin-top: 0.4375rem;
   color: $light_negative_500;
 }
-
 
 // Login Type Selection page
 
@@ -167,7 +176,7 @@ span {
     }
 
     img {
-      margin-right: .5rem;
+      margin-right: 0.5rem;
       width: 2rem;
     }
 
@@ -177,11 +186,11 @@ span {
 
       button {
         width: 100%;
-        margin: 0 0 .5rem 0;
+        margin: 0 0 0.5rem 0;
       }
 
       i {
-        margin-bottom: .25rem;
+        margin-bottom: 0.25rem;
       }
     }
 
@@ -193,10 +202,10 @@ span {
     .validationMessage {
       display: flex;
       align-items: center;
-      margin-top: .125rem;
+      margin-top: 0.125rem;
 
       i {
-        margin-right: .5rem;
+        margin-right: 0.5rem;
       }
 
       .teal {
@@ -283,7 +292,7 @@ span {
       .iconContainer {
         margin-bottom: 0.75rem;
 
-        img{
+        img {
           padding: 0.5rem;
           background: $light_white;
           border: 1px solid $light_gray_200;
@@ -292,7 +301,7 @@ span {
       }
 
       p {
-        margin-bottom: .25rem;
+        margin-bottom: 0.25rem;
       }
 
       .subheader {
@@ -306,14 +315,14 @@ span {
 
       i {
         float: right;
-        margin: .625rem 0 .5rem .5rem;
+        margin: 0.625rem 0 0.5rem 0.5rem;
         font-size: 1rem;
         color: $light_gray_400;
       }
 
       span {
         font-weight: 600;
-        font-size: .875rem;
+        font-size: 0.875rem;
         color: $black;
       }
 
@@ -335,7 +344,7 @@ span {
   }
 
   .signUpWithTitle {
-    margin-bottom: .25rem;
+    margin-bottom: 0.25rem;
   }
 
   .inputContainer {
@@ -345,7 +354,6 @@ span {
     gap: 1.125rem;
   }
 }
-
 
 // Account Type Selection page
 
@@ -442,7 +450,6 @@ span {
     align-self: end;
   }
 }
-
 
 // Finish Teacher/Student Account pages
 
@@ -550,7 +557,6 @@ span {
         }
       }
     }
-    
   }
 
   .requiredLabel {
@@ -660,7 +666,7 @@ span {
       color: $light_negative_500;
       font-size: 0.875rem;
     }
-  
+
     .errorMessageText {
       margin-top: 2px;
 

--- a/apps/src/signUpFlow/signUpFlowStyles.module.scss
+++ b/apps/src/signUpFlow/signUpFlowStyles.module.scss
@@ -38,13 +38,12 @@ label {
 
 .gradeSelectChips {
   label {
-    width: auto !important; // Override the global width: 100% for chip labels
+    width: auto !important;
     padding-top: 0.25rem !important;
     padding-bottom: 0.25rem !important;
   }
 }
 
-// This is the part causing issues
 label {
   width: 100%;
   align-items: start !important;

--- a/apps/src/templates/sectionsRefresh/GradeLevelChips.jsx
+++ b/apps/src/templates/sectionsRefresh/GradeLevelChips.jsx
@@ -1,0 +1,42 @@
+import Chips from '@code-dot-org/component-library/chips';
+import PropTypes from 'prop-types';
+import React from 'react';
+
+import {StudentGradeLevels} from '@cdo/generated-scripts/sharedConstants';
+import i18n from '@cdo/locale';
+
+import moduleStyles from './sections-refresh.module.scss';
+
+export default function GradeLevelChips({
+  values,
+  setValues,
+  disabled = false,
+  inputLabel = i18n.chooseGrades(),
+  className,
+}) {
+  const gradeOptions = StudentGradeLevels.map(g => ({label: g, value: g}));
+
+  return (
+    <div className={moduleStyles.containerWithMarginTop}>
+      <Chips
+        label={inputLabel}
+        name="grades"
+        required={true}
+        requiredMessageText={i18n.chooseAtLeastOne()}
+        options={gradeOptions}
+        values={values || []}
+        setValues={setValues}
+        disabled={disabled}
+        className={className}
+      />
+    </div>
+  );
+}
+
+GradeLevelChips.propTypes = {
+  values: PropTypes.array,
+  setValues: PropTypes.func.isRequired,
+  disabled: PropTypes.bool,
+  inputLabel: PropTypes.string,
+  className: PropTypes.string,
+};


### PR DESCRIPTION
Does two things:

- Adds a A/B assignment to teachers, based on this document.
- If the teacher is added to the experiment, teachers see grade selection in signup flow.


<img width="429" height="700" alt="image" src="https://github.com/user-attachments/assets/5a802928-4ae5-4ce6-85ca-9a9b188ce03f" />

What this does not do:
- Save grade selection anywhere.  My understanding is that we want to see if selecting grades impacts retention at all.  At this moment, we would only use the grades to help new teachers find a course to teach.  Since that work is still being developed, I don't see the need to save this information yet.  When we do save the information, we will want to save it to a `section` (NOT the `user`) which will take a bit more back end work than this task requires. 



## Testing story
<!--  Does your change include appropriate tests?
      - If so, please describe how the tests included in this PR are sufficient.
      - If not, please explain why this change does not need to be tested. -->



## Deployment strategy
Using an A/B test with statsig

