### PR TITLE
Revert "AI Chat / Tutor - Scroll to beginning of incoming tutor message if no space"

### DIFF
--- a/apps/src/aichat/views/ChatEventsList.tsx
+++ b/apps/src/aichat/views/ChatEventsList.tsx
@@ -1,12 +1,11 @@
 import Button from '@code-dot-org/component-library/button';
 import classNames from 'classnames';
-import React, {useEffect, useRef, useState, useCallback} from 'react';
+import React, {useEffect, useRef, useState} from 'react';
 
 import {useAiChatDisabled} from '@cdo/apps/aichat/context/aiChatDisabledContext';
-import {Role} from '@cdo/apps/aiComponentLibrary/chatMessage/types';
 import {useAppSelector} from '@cdo/apps/util/reduxHooks';
 
-import {ChatAsset, ChatEvent, isChatMessage} from '../types';
+import {ChatAsset, ChatEvent} from '../types';
 
 import {ChatDisabled} from './ChatDisabled';
 import ChatEventView from './ChatEventView';
@@ -37,29 +36,22 @@ const ChatEventsList: React.FunctionComponent<ChatEventsListProps> = ({
   );
 
   const conversationContainerRef = useRef<HTMLDivElement>(null);
-  const previousLastMessageRole = useRef<Role | null>(null);
-  const previousEventsLength = useRef<number | null>(null);
   const parentRef = useRef<HTMLDivElement>(null);
   const finalEventRef = useRef<HTMLDivElement>(null);
 
-  const scrollToLastMessage = useCallback((keepTopOfMessageVisible = false) => {
+  const scrollToBottom = () => {
     if (conversationContainerRef.current) {
       setShowScrollToBottom(false);
       setInProgrammaticScroll(true);
 
-      if (keepTopOfMessageVisible) {
-        finalEventRef.current?.scrollIntoView({
-          behavior: 'smooth',
-          block: 'start',
-        });
-      } else if (!isAtBottom()) {
+      if (!isAtBottom()) {
         conversationContainerRef.current.scrollTo({
           top: conversationContainerRef.current.scrollHeight,
           behavior: 'smooth',
         });
       }
     }
-  }, []);
+  };
 
   const isAtBottom = () => {
     const container = conversationContainerRef.current;
@@ -128,36 +120,7 @@ const ChatEventsList: React.FunctionComponent<ChatEventsListProps> = ({
     };
   }, [inProgrammaticScroll]);
 
-  useEffect(() => {
-    if (previousEventsLength.current !== events.length) {
-      previousEventsLength.current = events.length;
-
-      const lastMessage = events.at(-1);
-      let lastMessageRole: Role | null = null;
-      if (lastMessage && isChatMessage(lastMessage)) {
-        lastMessageRole = lastMessage.role;
-      }
-
-      // Heuristic to determine if we have an incoming assistant message and need to scroll only
-      // to the top of the incoming message, For all other messages we scroll to the bottom.
-      // Checking previousLastMessageRole.current is truthy avoids triggering this behavior when
-      // the history is first loaded.
-      const isIncomingAssistantMessage =
-        lastMessageRole === 'assistant' &&
-        previousLastMessageRole.current &&
-        previousLastMessageRole.current !== 'assistant';
-
-      if (isIncomingAssistantMessage) {
-        // Scroll to top of last message.
-        scrollToLastMessage(true);
-      } else {
-        // Scroll to bottom of last message.
-        scrollToLastMessage();
-      }
-
-      previousLastMessageRole.current = lastMessageRole;
-    }
-  }, [events, events.length, scrollToLastMessage]);
+  useEffect(scrollToBottom, [events.length, isWaitingForChatResponse]);
 
   return (
     <div
@@ -181,13 +144,13 @@ const ChatEventsList: React.FunctionComponent<ChatEventsListProps> = ({
           <ChatDisabled message={chatDisabledMessage} />
         ) : (
           <>
-            {events.map((event, index) => (
+            {events.map((event, id) => (
               <ChatEventView
                 event={event}
                 key={event.timestamp}
                 isTeacherView={isTeacherView}
                 buildAssetUrl={buildAssetUrl}
-                ref={index === events.length - 1 ? finalEventRef : undefined}
+                ref={id === events.length - 1 ? finalEventRef : undefined}
                 tabIndex={isInChatNavigationMode ? 0 : -1}
                 onKeyDown={e => {
                   if (e.key === 'Escape' && e.target === e.currentTarget) {
@@ -209,7 +172,7 @@ const ChatEventsList: React.FunctionComponent<ChatEventsListProps> = ({
             size="xs"
             color="black"
             type="secondary"
-            onClick={() => scrollToLastMessage()}
+            onClick={scrollToBottom}
             className={moduleStyles.scrollToBottomButton}
           />
         </div>

--- a/apps/src/aichat/views/chatWorkspace.module.scss
+++ b/apps/src/aichat/views/chatWorkspace.module.scss
@@ -15,10 +15,6 @@ $tabs-default-spacing: 4px;
   overflow: hidden;
 }
 
-.chatMessageOutline {
-  scroll-margin-top: .6rem;
-}
-
 .chatMessageOutline:focus-visible {
   outline: 2px solid var(--borders-brand-teal-primary);
   outline-offset: 2px;


### PR DESCRIPTION
Reverts code-dot-org/code-dot-org#69300
This is causing UI test failures on old Safari. [Slack thread](https://codedotorg.slack.com/archives/C0T0PNTM3/p1762978983355149)