### PR TITLE
Backpack: more generic naming for Codebridge

### DIFF
--- a/apps/src/codebridge/FileBrowser/prompts/openSaveToBackpackPrompt.tsx
+++ b/apps/src/codebridge/FileBrowser/prompts/openSaveToBackpackPrompt.tsx
@@ -96,10 +96,10 @@ export const openSaveToBackpackPrompt = async ({
         name: selectedFileName,
         contents: file.contents,
         folderId: DEFAULT_FOLDER_ID,
-        language: 'py',
+        language: file.language,
         active: false,
       } as ProjectFile;
-      backpackApi.savePythonlabFile(
+      backpackApi.saveCodebridgeFile(
         selectedFileName,
         fileContents,
         handleError(

--- a/apps/src/codebridge/FileBrowser/prompts/openSaveToBackpackPrompt.tsx
+++ b/apps/src/codebridge/FileBrowser/prompts/openSaveToBackpackPrompt.tsx
@@ -1,4 +1,3 @@
-import {DEFAULT_FOLDER_ID} from '@codebridge/constants';
 import {getFileNameWithNumberSuffix} from '@codebridge/utils';
 import React from 'react';
 
@@ -92,16 +91,9 @@ export const openSaveToBackpackPrompt = async ({
       }
       const successCallback = () => sendLab2AnalyticsEvent(successMetric);
 
-      const fileContents = {
-        name: selectedFileName,
-        contents: file.contents,
-        folderId: DEFAULT_FOLDER_ID,
-        language: file.language,
-        active: false,
-      } as ProjectFile;
       backpackApi.saveCodebridgeFile(
         selectedFileName,
-        fileContents,
+        file.contents,
         handleError(
           codebridgeI18n.saveToBackpackTitle(),
           codebridgeI18n.saveToBackpackError({selectedFileName}) +

--- a/apps/src/sharedComponents/backpack/BackpackClientApi.js
+++ b/apps/src/sharedComponents/backpack/BackpackClientApi.js
@@ -75,20 +75,20 @@ export default class BackpackClientApi {
 
   /**
    * Save files to the backpack
-   * @param {Object} filesJson json-formatted string of all file sources in the project
+   * @param {Object} files all file sources in the project
    * Expected format is {"filename1.java": {"text": "{...}"},...}.
    * @param {Array} filenames Array of filenames to save to the backpack. Filenames must
-   * exist in filesJson.
+   * exist in files.
    * @param {Function} onError Function to call if any file fails to save
    * @param {Function} onSuccess Function to call if all files save.
    */
-  saveFiles(filesJson, filenames, onError, onSuccess) {
+  saveFiles(files, filenames, onError, onSuccess) {
     this.updateFilesHelper(
       this.fileUploadsInProgress,
       filenames,
       onError,
       onSuccess,
-      () => this.saveFilesHelper(filesJson, filenames, onError, onSuccess)
+      () => this.saveFilesHelper(files, filenames, onError, onSuccess)
     );
   }
 
@@ -159,11 +159,11 @@ export default class BackpackClientApi {
     }
   }
 
-  saveFilesHelper(filesJson, filenames, onError, onSuccess) {
+  saveFilesHelper(files, filenames, onError, onSuccess) {
     this.fileUploadsInProgress = [...filenames];
     this.fileUploadsFailed = [];
     filenames.forEach(filename => {
-      const fileContents = filesJson[filename].text;
+      const fileContents = files[filename].text;
       // write file with REQUEST_RETRY_COUNT failure retries
       this.writeSingleFileToBackpack(
         filename,

--- a/apps/src/sharedComponents/backpack/BackpackClientApi.js
+++ b/apps/src/sharedComponents/backpack/BackpackClientApi.js
@@ -75,7 +75,7 @@ export default class BackpackClientApi {
 
   /**
    * Save files to the backpack
-   * @param {String} filesJson json-formatted string of all file sources in the project
+   * @param {Object} filesJson json-formatted string of all file sources in the project
    * Expected format is {"filename1.java": {"text": "{...}"},...}.
    * @param {Array} filenames Array of filenames to save to the backpack. Filenames must
    * exist in filesJson.
@@ -100,14 +100,13 @@ export default class BackpackClientApi {
    * @param {Function} onSuccess Function to call if file saves.
    */
   saveCodebridgeFile(filename, fileContents, onError, onSuccess) {
-    const fileObject = {[filename]: fileContents};
+    const fileObject = {[filename]: {text: fileContents}};
     this.updateFilesHelper(
       this.fileUploadsInProgress,
       [filename],
       onError,
       onSuccess,
-      () =>
-        this.saveFilesHelper(fileObject, [filename], onError, onSuccess, true)
+      () => this.saveFilesHelper(fileObject, [filename], onError, onSuccess)
     );
   }
 
@@ -159,13 +158,11 @@ export default class BackpackClientApi {
     }
   }
 
-  saveFilesHelper(filesJson, filenames, onError, onSuccess, multiFile) {
+  saveFilesHelper(filesJson, filenames, onError, onSuccess) {
     this.fileUploadsInProgress = [...filenames];
     this.fileUploadsFailed = [];
     filenames.forEach(filename => {
-      const fileContents = multiFile
-        ? filesJson[filename].contents
-        : filesJson[filename].text;
+      const fileContents = filesJson[filename].text;
       // write file with REQUEST_RETRY_COUNT failure retries
       this.writeSingleFileToBackpack(
         filename,

--- a/apps/src/sharedComponents/backpack/BackpackClientApi.js
+++ b/apps/src/sharedComponents/backpack/BackpackClientApi.js
@@ -93,13 +93,13 @@ export default class BackpackClientApi {
   }
 
   /**
-   * Save a pythonlab file to the backpack
+   * Save a Codebridge (ie, MultiFile project) file to the backpack
    * @param {String} filename
    * @param {ProjectFile} fileContents ProjectFile
    * @param {Function} onError Function to call if file fails to save
    * @param {Function} onSuccess Function to call if file saves.
    */
-  savePythonlabFile(filename, fileContents, onError, onSuccess) {
+  saveCodebridgeFile(filename, fileContents, onError, onSuccess) {
     const fileObject = {[filename]: fileContents};
     this.updateFilesHelper(
       this.fileUploadsInProgress,
@@ -107,13 +107,7 @@ export default class BackpackClientApi {
       onError,
       onSuccess,
       () =>
-        this.saveFilesHelper(
-          fileObject,
-          [filename],
-          onError,
-          onSuccess,
-          'pythonlab'
-        )
+        this.saveFilesHelper(fileObject, [filename], onError, onSuccess, true)
     );
   }
 
@@ -165,14 +159,13 @@ export default class BackpackClientApi {
     }
   }
 
-  saveFilesHelper(filesJson, filenames, onError, onSuccess, appType) {
+  saveFilesHelper(filesJson, filenames, onError, onSuccess, multiFile) {
     this.fileUploadsInProgress = [...filenames];
     this.fileUploadsFailed = [];
     filenames.forEach(filename => {
-      const fileContents =
-        appType === 'pythonlab'
-          ? filesJson[filename].contents
-          : filesJson[filename].text;
+      const fileContents = multiFile
+        ? filesJson[filename].contents
+        : filesJson[filename].text;
       // write file with REQUEST_RETRY_COUNT failure retries
       this.writeSingleFileToBackpack(
         filename,

--- a/apps/src/sharedComponents/backpack/BackpackClientApi.js
+++ b/apps/src/sharedComponents/backpack/BackpackClientApi.js
@@ -93,10 +93,11 @@ export default class BackpackClientApi {
   }
 
   /**
-   * Save a Codebridge (ie, MultiFile project) file to the backpack
+   * Takes a file name and contents and saves to the backpack.
+   * Used in Codebridge labs to save a file.
    * @param {String} filename
-   * @param {ProjectFile} fileContents ProjectFile
-   * @param {Function} onError Function to call if file fails to save
+   * @param {String} fileContents Contents of file to be saved to the backpack.
+   * @param {Function} onError Function to call if file fails to save.
    * @param {Function} onSuccess Function to call if file saves.
    */
   saveCodebridgeFile(filename, fileContents, onError, onSuccess) {

--- a/apps/test/unit/codebridge/FileBrowser/prompts/openSaveToBackpackPromptTest.ts
+++ b/apps/test/unit/codebridge/FileBrowser/prompts/openSaveToBackpackPromptTest.ts
@@ -31,7 +31,7 @@ describe('openSaveToBackpackPrompt', () => {
     await runSaveToBackpackPrompt();
 
     expect(mockBackpackApi.getFileList).toHaveBeenCalled();
-    expect(mockBackpackApi.savePythonlabFile).toHaveBeenCalledWith(
+    expect(mockBackpackApi.saveCodebridgeFile).toHaveBeenCalledWith(
       'project_file.py',
       expect.objectContaining({name: 'project_file.py'}),
       expect.any(Function),
@@ -45,7 +45,7 @@ describe('openSaveToBackpackPrompt', () => {
     await runSaveToBackpackPrompt();
 
     expect(mockBackpackApi.getFileList).toHaveBeenCalled();
-    expect(mockBackpackApi.savePythonlabFile).not.toHaveBeenCalled();
+    expect(mockBackpackApi.saveCodebridgeFile).not.toHaveBeenCalled();
   });
 
   it('should rename file when duplicate exists and rename (neutral) is selected', async () => {
@@ -55,7 +55,7 @@ describe('openSaveToBackpackPrompt', () => {
     await runSaveToBackpackPrompt();
 
     expect(mockBackpackApi.getFileList).toHaveBeenCalled();
-    expect(mockBackpackApi.savePythonlabFile).toHaveBeenCalledWith(
+    expect(mockBackpackApi.saveCodebridgeFile).toHaveBeenCalledWith(
       'project_file_1.py',
       expect.objectContaining({
         name: 'project_file_1.py',
@@ -72,7 +72,7 @@ describe('openSaveToBackpackPrompt', () => {
     await runSaveToBackpackPrompt();
 
     expect(mockBackpackApi.getFileList).toHaveBeenCalled();
-    expect(mockBackpackApi.savePythonlabFile).toHaveBeenCalledWith(
+    expect(mockBackpackApi.saveCodebridgeFile).toHaveBeenCalledWith(
       'project_file.py',
       expect.objectContaining({
         name: 'project_file.py',

--- a/apps/test/unit/codebridge/FileBrowser/prompts/openSaveToBackpackPromptTest.ts
+++ b/apps/test/unit/codebridge/FileBrowser/prompts/openSaveToBackpackPromptTest.ts
@@ -33,7 +33,7 @@ describe('openSaveToBackpackPrompt', () => {
     expect(mockBackpackApi.getFileList).toHaveBeenCalled();
     expect(mockBackpackApi.saveCodebridgeFile).toHaveBeenCalledWith(
       'project_file.py',
-      expect.objectContaining({name: 'project_file.py'}),
+      'This is project_file.py.',
       expect.any(Function),
       expect.any(Function)
     );
@@ -57,10 +57,7 @@ describe('openSaveToBackpackPrompt', () => {
     expect(mockBackpackApi.getFileList).toHaveBeenCalled();
     expect(mockBackpackApi.saveCodebridgeFile).toHaveBeenCalledWith(
       'project_file_1.py',
-      expect.objectContaining({
-        name: 'project_file_1.py',
-        contents: 'This is project_file.py.',
-      }),
+      'This is project_file.py.',
       expect.any(Function),
       expect.any(Function)
     );
@@ -74,10 +71,7 @@ describe('openSaveToBackpackPrompt', () => {
     expect(mockBackpackApi.getFileList).toHaveBeenCalled();
     expect(mockBackpackApi.saveCodebridgeFile).toHaveBeenCalledWith(
       'project_file.py',
-      expect.objectContaining({
-        name: 'project_file.py',
-        contents: 'This is project_file.py.',
-      }),
+      'This is project_file.py.',
       expect.any(Function),
       expect.any(Function)
     );

--- a/apps/test/unit/codebridge/test_utils.ts
+++ b/apps/test/unit/codebridge/test_utils.ts
@@ -106,7 +106,7 @@ export const getBackpackAPIMock = (
       onSuccess(fileList);
     }),
     saveFiles: jest.fn(),
-    savePythonlabFile: jest.fn(),
+    saveCodebridgeFile: jest.fn(),
     deleteFiles: jest.fn(),
     updateFilesHelper: jest.fn(),
     saveFilesHelper: jest.fn(),


### PR DESCRIPTION
Straight refactor to remove unnecessary references to Python Lab in Backpack code. I replaced with "Codebridge", but not sure if that's the right word either. "MultiFile" maybe, but that would make the function name saveMultiFileFile, which doesn't quite roll off the tongue?

Also renames a `filesJson` param that is an object, not a JSON string.

## Links

- Jira: https://codedotorg.atlassian.net/browse/AFL-183

## Testing story

I tested manually adding/importing files from the backpack in Web Lab 2/Python Lab/Java Lab.