### PR TITLE
Lab2: set min width for resource panel to 250px

### DIFF
--- a/apps/src/pythonlab/layout/HorizontalLayout.tsx
+++ b/apps/src/pythonlab/layout/HorizontalLayout.tsx
@@ -12,7 +12,7 @@ import {useAppSelector} from '@cdo/apps/util/reduxHooks';
 import moduleStyles from '@cdo/apps/lab2/views/components/layout/layout.module.scss';
 
 const MIN_RIGHT_PANEL_WIDTH = 300;
-const MIN_LEFT_PANEL_WIDTH = 150;
+const MIN_LEFT_PANEL_WIDTH = 250;
 const MIN_LEFT_PANEL_WIDTH_COLLAPSED = 55;
 const MIN_OUTPUT_HEIGHT = 120;
 const MIN_EDITOR_HEIGHT = 200;

--- a/apps/src/pythonlab/layout/VerticalLayout.tsx
+++ b/apps/src/pythonlab/layout/VerticalLayout.tsx
@@ -11,7 +11,7 @@ import {useAppSelector} from '@cdo/apps/util/reduxHooks';
 
 import moduleStyles from '@cdo/apps/lab2/views/components/layout/layout.module.scss';
 
-const MIN_INFO_PANEL_WIDTH = 150;
+const MIN_INFO_PANEL_WIDTH = 250;
 const MIN_OUTPUT_WIDTH = 200;
 const MIN_EDITOR_WIDTH = 300;
 const INITIAL_INFO_PANEL_WIDTH = 300;

--- a/apps/src/sketchlab/SketchlabView.tsx
+++ b/apps/src/sketchlab/SketchlabView.tsx
@@ -33,7 +33,7 @@ import SketchlabTourSteps from './sketchlabTourSteps';
 
 import moduleStyles from './styles/sketchlab-view.module.scss';
 
-const MIN_INFO_PANEL_WIDTH = 150;
+const MIN_INFO_PANEL_WIDTH = 250;
 // This initial width is derived from the following:
 // The narrowest screen we see in GA with 1% usage is 1024px.
 // The version of Excalidraw we're using switches into a mobile mode at 730px.

--- a/apps/src/weblab2/layout/VerticalLayout.tsx
+++ b/apps/src/weblab2/layout/VerticalLayout.tsx
@@ -22,7 +22,7 @@ import {ViewMode} from '../types';
 import lab2Styles from '@cdo/apps/lab2/views/components/layout/layout.module.scss';
 import weblab2Styles from '@cdo/apps/weblab2/layout/vertical-layout.module.scss';
 
-const MIN_INFO_PANEL_WIDTH = 150;
+const MIN_INFO_PANEL_WIDTH = 250;
 const INITIAL_INFO_PANEL_WIDTH = 400;
 const INITIAL_INFO_PANEL_WIDTH_WIDGET = 500;
 const MIN_EDITOR_WIDTH = 300;


### PR DESCRIPTION
Sets the min width on Web Lab 2, Python Lab, and Sketch Lab to 250px to improve usability and prevent it from being too narrow to be useful.

## Links
Jira ticket: [AFL-310](https://codedotorg.atlassian.net/browse/AFL-310)

## Testing story
Tested locally

----

## Before

### Web Lab 2



https://github.com/user-attachments/assets/a4cb2a44-1f10-403d-a3c3-c76d58f55627


### Python Lab


https://github.com/user-attachments/assets/e2d47541-d047-4a18-b6a2-d7f8aeb17e32



### Sketch Lab


https://github.com/user-attachments/assets/9f7a35b5-982a-4b9f-94f4-33761515aec6



## After

### Web Lab 2

https://github.com/user-attachments/assets/08bde3d1-e3e9-4cd3-81f1-83c1e9d17a57



### Python Lab


https://github.com/user-attachments/assets/15d66129-38cd-406d-8278-48a2486567de


https://github.com/user-attachments/assets/93082102-9199-49b0-9257-7a9a2a772964


### Sketch Lab

https://github.com/user-attachments/assets/4cc89166-ca7f-43b4-8be6-fae1b753c3d6

