### PR TITLE
Revert - Revert "AI Chat / Tutor - Scroll to beginning of incoming tutor message if no space"

### DIFF
--- a/apps/src/aichat/views/ChatEventsList.tsx
+++ b/apps/src/aichat/views/ChatEventsList.tsx
@@ -1,11 +1,12 @@
 import Button from '@code-dot-org/component-library/button';
 import classNames from 'classnames';
-import React, {useEffect, useRef, useState} from 'react';
+import React, {useEffect, useRef, useState, useCallback} from 'react';
 
 import {useAiChatDisabled} from '@cdo/apps/aichat/context/aiChatDisabledContext';
+import {Role} from '@cdo/apps/aiComponentLibrary/chatMessage/types';
 import {useAppSelector} from '@cdo/apps/util/reduxHooks';
 
-import {ChatAsset, ChatEvent} from '../types';
+import {ChatAsset, ChatEvent, isChatMessage} from '../types';
 
 import {ChatDisabled} from './ChatDisabled';
 import ChatEventView from './ChatEventView';
@@ -36,22 +37,29 @@ const ChatEventsList: React.FunctionComponent<ChatEventsListProps> = ({
   );
 
   const conversationContainerRef = useRef<HTMLDivElement>(null);
+  const previousLastMessageRole = useRef<Role | null>(null);
+  const previousEventsLength = useRef<number | null>(null);
   const parentRef = useRef<HTMLDivElement>(null);
   const finalEventRef = useRef<HTMLDivElement>(null);
 
-  const scrollToBottom = () => {
+  const scrollToLastMessage = useCallback((keepTopOfMessageVisible = false) => {
     if (conversationContainerRef.current) {
       setShowScrollToBottom(false);
       setInProgrammaticScroll(true);
 
-      if (!isAtBottom()) {
+      if (keepTopOfMessageVisible) {
+        finalEventRef.current?.scrollIntoView({
+          behavior: 'smooth',
+          block: 'start',
+        });
+      } else if (!isAtBottom()) {
         conversationContainerRef.current.scrollTo({
           top: conversationContainerRef.current.scrollHeight,
           behavior: 'smooth',
         });
       }
     }
-  };
+  }, []);
 
   const isAtBottom = () => {
     const container = conversationContainerRef.current;
@@ -120,7 +128,36 @@ const ChatEventsList: React.FunctionComponent<ChatEventsListProps> = ({
     };
   }, [inProgrammaticScroll]);
 
-  useEffect(scrollToBottom, [events.length, isWaitingForChatResponse]);
+  useEffect(() => {
+    if (previousEventsLength.current !== events.length) {
+      previousEventsLength.current = events.length;
+
+      const lastMessage = events.at(-1);
+      let lastMessageRole: Role | null = null;
+      if (lastMessage && isChatMessage(lastMessage)) {
+        lastMessageRole = lastMessage.role;
+      }
+
+      // Heuristic to determine if we have an incoming assistant message and need to scroll only
+      // to the top of the incoming message, For all other messages we scroll to the bottom.
+      // Checking previousLastMessageRole.current is truthy avoids triggering this behavior when
+      // the history is first loaded.
+      const isIncomingAssistantMessage =
+        lastMessageRole === 'assistant' &&
+        previousLastMessageRole.current &&
+        previousLastMessageRole.current !== 'assistant';
+
+      if (isIncomingAssistantMessage) {
+        // Scroll to top of last message.
+        scrollToLastMessage(true);
+      } else {
+        // Scroll to bottom of last message.
+        scrollToLastMessage();
+      }
+
+      previousLastMessageRole.current = lastMessageRole;
+    }
+  }, [events, events.length, scrollToLastMessage]);
 
   return (
     <div
@@ -144,13 +181,13 @@ const ChatEventsList: React.FunctionComponent<ChatEventsListProps> = ({
           <ChatDisabled message={chatDisabledMessage} />
         ) : (
           <>
-            {events.map((event, id) => (
+            {events.map((event, index) => (
               <ChatEventView
                 event={event}
                 key={event.timestamp}
                 isTeacherView={isTeacherView}
                 buildAssetUrl={buildAssetUrl}
-                ref={id === events.length - 1 ? finalEventRef : undefined}
+                ref={index === events.length - 1 ? finalEventRef : undefined}
                 tabIndex={isInChatNavigationMode ? 0 : -1}
                 onKeyDown={e => {
                   if (e.key === 'Escape' && e.target === e.currentTarget) {
@@ -172,7 +209,7 @@ const ChatEventsList: React.FunctionComponent<ChatEventsListProps> = ({
             size="xs"
             color="black"
             type="secondary"
-            onClick={scrollToBottom}
+            onClick={() => scrollToLastMessage()}
             className={moduleStyles.scrollToBottomButton}
           />
         </div>

--- a/apps/src/aichat/views/ChatEventsList.tsx
+++ b/apps/src/aichat/views/ChatEventsList.tsx
@@ -132,7 +132,7 @@ const ChatEventsList: React.FunctionComponent<ChatEventsListProps> = ({
     if (previousEventsLength.current !== events.length) {
       previousEventsLength.current = events.length;
 
-      const lastMessage = events.at(-1);
+      const lastMessage = events[events.length - 1];
       let lastMessageRole: Role | null = null;
       if (lastMessage && isChatMessage(lastMessage)) {
         lastMessageRole = lastMessage.role;

--- a/apps/src/aichat/views/chatWorkspace.module.scss
+++ b/apps/src/aichat/views/chatWorkspace.module.scss
@@ -15,6 +15,10 @@ $tabs-default-spacing: 4px;
   overflow: hidden;
 }
 
+.chatMessageOutline {
+  scroll-margin-top: .6rem;
+}
+
 .chatMessageOutline:focus-visible {
   outline: 2px solid var(--borders-brand-teal-primary);
   outline-offset: 2px;


### PR DESCRIPTION
Reverts revert PR: https://github.com/code-dot-org/code-dot-org/pull/69525 and re-introduces PR: https://github.com/code-dot-org/code-dot-org/pull/69300.

The latter was causing test failures because of the use of `Array.prototype.at()` due to SauceLab being set up to run an older version of safari than we currently support. This was reported and discussed on slack [here](https://codedotorg.slack.com/archives/C0T0PNTM3/p1762978983355149).

The use of `events.at(-1)` was converted to `events[events.length-1]`.

