### PR TITLE
AI Tutor/Chat: add file type icons on file chips

### DIFF
--- a/apps/src/aichat/views/assets/FilePreview.tsx
+++ b/apps/src/aichat/views/assets/FilePreview.tsx
@@ -80,6 +80,7 @@ const FilePreview: React.FC<{
       case 'pdf':
         return 'file-pdf';
       case 'txt':
+      case 'TEXT':
         return 'file-lines';
       default:
         return 'file';
@@ -89,16 +90,7 @@ const FilePreview: React.FC<{
   const getFileIconFamily = (
     extension: string
   ): FontAwesomeV6IconProps['iconFamily'] => {
-    switch (extension) {
-      case 'css':
-        return 'brands';
-      case 'js':
-        return 'brands';
-      case 'md':
-        return 'brands';
-      default:
-        return;
-    }
+    return ['css', 'js', 'md'].includes(extension) ? 'brands' : undefined;
   };
 
   return (

--- a/apps/src/aichat/views/assets/FilePreview.tsx
+++ b/apps/src/aichat/views/assets/FilePreview.tsx
@@ -1,4 +1,6 @@
-import FontAwesomeV6Icon from '@code-dot-org/component-library/fontAwesomeV6Icon';
+import FontAwesomeV6Icon, {
+  FontAwesomeV6IconProps,
+} from '@code-dot-org/component-library/fontAwesomeV6Icon';
 import {WithTooltip} from '@code-dot-org/component-library/tooltip';
 import {StrongText} from '@code-dot-org/component-library/typography';
 import classNames from 'classnames';
@@ -61,6 +63,43 @@ const FilePreview: React.FC<{
     const extension = filename.split('.').pop();
     return filename.includes('.') && extension ? extension : 'TEXT';
   };
+  const fileExtension = getFileExtension(filename);
+
+  const getFileIconName = (extension: string): string => {
+    switch (extension) {
+      case 'css':
+        return 'css';
+      case 'csv':
+        return 'file-csv';
+      case 'html':
+        return 'file-code';
+      case 'js':
+        return 'js';
+      case 'md':
+        return 'markdown';
+      case 'pdf':
+        return 'file-pdf';
+      case 'txt':
+        return 'file-lines';
+      default:
+        return 'file';
+    }
+  };
+
+  const getFileIconFamily = (
+    extension: string
+  ): FontAwesomeV6IconProps['iconFamily'] => {
+    switch (extension) {
+      case 'css':
+        return 'brands';
+      case 'js':
+        return 'brands';
+      case 'md':
+        return 'brands';
+      default:
+        return;
+    }
+  };
 
   return (
     <div className={styles[`preview-${previewType}`]} title={filename}>
@@ -112,12 +151,8 @@ const FilePreview: React.FC<{
         <>
           <div className={styles.fileIcon}>
             <FontAwesomeV6Icon
-              iconName={
-                {
-                  pdf: 'file-pdf',
-                  text: 'file-code',
-                }[type] || 'file'
-              }
+              iconName={getFileIconName(fileExtension)}
+              iconFamily={getFileIconFamily(fileExtension)}
             />
           </div>
           <div className={styles.filenameContainer}>
@@ -125,9 +160,7 @@ const FilePreview: React.FC<{
             <span className={styles.fileDetail}>
               {[
                 type === 'pdf' ? 'PDF' : null,
-                type === 'text'
-                  ? getFileExtension(filename).toUpperCase()
-                  : null,
+                type === 'text' ? fileExtension.toUpperCase() : null,
                 fileDetail ? fileDetail : null,
               ]
                 .filter(Boolean)


### PR DESCRIPTION
Adds file icons to file chips in AI Tutor/Chat and replaces the generic `file-code` icon. These match the icons in the file manager.

## Links
Jira ticket: 
Figma mock: [here](https://www.figma.com/design/tDzVjyvhfkF8lyGROENOAD?node-id=5272-34778&m=dev#1444341958)

## Testing story
Tested locally

----


https://github.com/user-attachments/assets/cc1f9417-59ce-4f50-9701-8ee5070fb37f

