### PR TITLE
Dance: storage ID cookie

### DIFF
--- a/dashboard/app/controllers/script_levels_controller.rb
+++ b/dashboard/app/controllers/script_levels_controller.rb
@@ -618,11 +618,6 @@ class ScriptLevelsController < ApplicationController
 
     readonly_view_options if @level.channel_backed? && params[:version].present?
 
-    # Add video generation URL for only the last level of Dance
-    # If we eventually want to add video generation for other levels or level
-    # types, this is the condition that should be extended.
-    replay_video_view_options(get_channel_for(@level, @script_level.script_id, current_user)) if @level.channel_backed? && @level.is_a?(Dancelab)
-
     @@fallback_responses ||= {}
     @fallback_response = @@fallback_responses[@script_level.id] ||= {
       success: milestone_response(script_level: @script_level, level: @level, solved?: true, unit_group: @unit_group),


### PR DESCRIPTION
**Credit:** This was solved in an intensive debugging session with @sanchitmalhotra126.  Credit to @mikeharv for raising the issue and @sureshc for advice along the way.

The team noticed that dancer characters in the new `/s/mix-move-ai-2025` script were not always blank when using a new private browser.  And we were even seeing the same dancer on different computers!

The culprit was a single line of old code which wrote the storage ID cookie in the initial page load under very specific circumstances: when first rendering a dance level that was project-backed, for a visitor who has never before visited a different project-backed page.  

This line called an innocuous `get_channel_for` which called an even more innocuous `get_storage_id` which actually creates a storage ID and sets the storage ID cookie for the page response if there isn't one already.

The issue was that the page is aggressively cached (because the script is marked as cached) and so the same storage ID cookie was being returned for more than one of us.

Fortunately, visitors to `/s/mix-move-2025` will almost always load the first video level and then progress through the dance levels without full page loads.

Going forward, we no longer set the storage ID cookie when rendering a project-backed dance page.