### PR TITLE
Use Rails-7-compatible `to_formatted_s` for string formatting

### DIFF
--- a/dashboard/lib/services/curriculum_pdfs/lesson_plans.rb
+++ b/dashboard/lib/services/curriculum_pdfs/lesson_plans.rb
@@ -19,7 +19,7 @@ module Services
         # <Pathname:csp1-2021/20210216001309/student-lesson-plans/Welcome to CSP.pdf>
         def get_lesson_plan_pathname(lesson, student_facing: false, versioned: true)
           return nil unless lesson&.script&.seeded_from
-          version_number = versioned ? Time.parse(lesson.script.seeded_from).to_s(:number) : 'fallback'
+          version_number = versioned ? Time.parse(lesson.script.seeded_from).to_formatted_s(:number) : 'fallback'
           suffix = student_facing ? '-Student' : ''
           filename = ActiveStorage::Filename.new(lesson.localized_name.parameterize(preserve_case: true) + suffix + ".pdf").to_s
           subdir = student_facing ? "student-lesson-plans" : "teacher-lesson-plans"

--- a/dashboard/lib/services/curriculum_pdfs/script_overview.rb
+++ b/dashboard/lib/services/curriculum_pdfs/script_overview.rb
@@ -17,7 +17,7 @@ module Services
         # For example: <Pathname:csp1-2021/20210909014219/Digital+Information+%28%2721-%2722%29.pdf>
         def get_script_overview_pathname(script, versioned: true)
           return nil unless script&.seeded_from
-          version_number = versioned ? Time.parse(script.seeded_from).to_s(:number) : 'fallback'
+          version_number = versioned ? Time.parse(script.seeded_from).to_formatted_s(:number) : 'fallback'
           filename = ActiveStorage::Filename.new(script.localized_title.parameterize(preserve_case: true) + ".pdf").to_s
           return Pathname.new(File.join(script.name, version_number, filename))
         end

--- a/dashboard/test/helpers/delete_accounts_helper_test.rb
+++ b/dashboard/test/helpers/delete_accounts_helper_test.rb
@@ -953,7 +953,7 @@ class DeleteAccountsHelperTest < ActionView::TestCase
     ActiveRecord::Base.connection.exec_query(
       <<-SQL.squish
         INSERT INTO `pd_facilitator_program_registrations` (user_id, form_data, created_at, updated_at)
-        VALUES (#{teacher.id}, '{"country": "USA"}', '#{Time.now.to_s(:db)}', '#{Time.now.to_s(:db)}')
+        VALUES (#{teacher.id}, '{"country": "USA"}', '#{Time.now.to_formatted_s(:db)}', '#{Time.now.to_formatted_s(:db)}')
     SQL
     )
 
@@ -976,7 +976,7 @@ class DeleteAccountsHelperTest < ActionView::TestCase
     ActiveRecord::Base.connection.exec_query(
       <<-SQL.squish
         INSERT INTO `pd_fit_weekend1819_registrations` (pd_application_id, form_data, created_at, updated_at)
-        VALUES (#{application.id}, '{"country": "USA"}', '#{Time.now.to_s(:db)}', '#{Time.now.to_s(:db)}')
+        VALUES (#{application.id}, '{"country": "USA"}', '#{Time.now.to_formatted_s(:db)}', '#{Time.now.to_formatted_s(:db)}')
     SQL
     )
 
@@ -999,7 +999,7 @@ class DeleteAccountsHelperTest < ActionView::TestCase
     ActiveRecord::Base.connection.exec_query(
       <<-SQL.squish
         INSERT INTO `pd_fit_weekend_registrations` (pd_application_id, registration_year, form_data, created_at, updated_at)
-        VALUES (#{application.id}, '2019-2020', '{"country": "USA"}', '#{Time.now.to_s(:db)}', '#{Time.now.to_s(:db)}')
+        VALUES (#{application.id}, '2019-2020', '{"country": "USA"}', '#{Time.now.to_formatted_s(:db)}', '#{Time.now.to_formatted_s(:db)}')
     SQL
     )
 
@@ -1076,7 +1076,7 @@ class DeleteAccountsHelperTest < ActionView::TestCase
     ActiveRecord::Base.connection.exec_query(
       <<-SQL.squish
         INSERT INTO `pd_regional_partner_program_registrations` (user_id, form_data, teachercon, created_at, updated_at)
-        VALUES (#{teacher.id}, '{"country": "USA"}', 1, '#{Time.now.to_s(:db)}', '#{Time.now.to_s(:db)}')
+        VALUES (#{teacher.id}, '{"country": "USA"}', 1, '#{Time.now.to_formatted_s(:db)}', '#{Time.now.to_formatted_s(:db)}')
     SQL
     )
 
@@ -1094,7 +1094,7 @@ class DeleteAccountsHelperTest < ActionView::TestCase
     ActiveRecord::Base.connection.exec_query(
       <<-SQL.squish
         INSERT INTO `pd_regional_partner_program_registrations` (user_id, form_data, teachercon, created_at, updated_at)
-        VALUES (#{teacher.id}, '{"country": "USA"}', 1, '#{Time.now.to_s(:db)}', '#{Time.now.to_s(:db)}')
+        VALUES (#{teacher.id}, '{"country": "USA"}', 1, '#{Time.now.to_formatted_s(:db)}', '#{Time.now.to_formatted_s(:db)}')
     SQL
     )
 
@@ -1116,7 +1116,7 @@ class DeleteAccountsHelperTest < ActionView::TestCase
     ActiveRecord::Base.connection.exec_query(
       <<-SQL.squish
         INSERT INTO `pd_teachercon1819_registrations` (user_id, form_data, created_at, updated_at)
-        VALUES (#{teacher.id}, '{"country": "USA"}', '#{Time.now.to_s(:db)}', '#{Time.now.to_s(:db)}')
+        VALUES (#{teacher.id}, '{"country": "USA"}', '#{Time.now.to_formatted_s(:db)}', '#{Time.now.to_formatted_s(:db)}')
     SQL
     )
 
@@ -1157,7 +1157,7 @@ class DeleteAccountsHelperTest < ActionView::TestCase
     ActiveRecord::Base.connection.exec_query(
       <<-SQL.squish
         INSERT INTO `pd_teacher_applications` (user_id, primary_email, secondary_email, created_at, updated_at, application)
-        VALUES (#{user.id}, '#{user.email}', '#{secondary_email}', '#{Time.now.to_s(:db)}', '#{Time.now.to_s(:db)}', '{}')
+        VALUES (#{user.id}, '#{user.email}', '#{secondary_email}', '#{Time.now.to_formatted_s(:db)}', '#{Time.now.to_formatted_s(:db)}', '{}')
       SQL
     )
 
@@ -1177,7 +1177,7 @@ class DeleteAccountsHelperTest < ActionView::TestCase
     ActiveRecord::Base.connection.exec_query(
       <<-SQL.squish
         INSERT INTO `pd_teacher_applications` (user_id, primary_email, secondary_email, created_at, updated_at, application)
-        VALUES (#{user.id}, '#{user.email}', '#{secondary_email}', '#{Time.now.to_s(:db)}', '#{Time.now.to_s(:db)}', '{}')
+        VALUES (#{user.id}, '#{user.email}', '#{secondary_email}', '#{Time.now.to_formatted_s(:db)}', '#{Time.now.to_formatted_s(:db)}', '{}')
       SQL
     )
 
@@ -1197,7 +1197,7 @@ class DeleteAccountsHelperTest < ActionView::TestCase
     ActiveRecord::Base.connection.exec_query(
       <<-SQL.squish
         INSERT INTO `pd_teacher_applications` (user_id, primary_email, secondary_email, created_at, updated_at, application)
-        VALUES (#{user.id}, '#{user.email}', '#{secondary_email}', '#{Time.now.to_s(:db)}', '#{Time.now.to_s(:db)}', '{"primaryEmail": "#{user.email}"}')
+        VALUES (#{user.id}, '#{user.email}', '#{secondary_email}', '#{Time.now.to_formatted_s(:db)}', '#{Time.now.to_formatted_s(:db)}', '{"primaryEmail": "#{user.email}"}')
       SQL
     )
 

--- a/dashboard/test/models/lesson_test.rb
+++ b/dashboard/test/models/lesson_test.rb
@@ -724,7 +724,7 @@ class LessonTest < ActiveSupport::TestCase
 
     script.seeded_from = Time.now.to_s
     assert_equal(
-      "https://lesson-plans.code.org/#{script.name}/#{Time.parse(script.seeded_from).to_s(:number)}/teacher-lesson-plans/Some-Verbose-Lesson-Name.pdf",
+      "https://lesson-plans.code.org/#{script.name}/#{Time.parse(script.seeded_from).to_formatted_s(:number)}/teacher-lesson-plans/Some-Verbose-Lesson-Name.pdf",
       new_lesson.lesson_plan_pdf_url
     )
   end
@@ -736,7 +736,7 @@ class LessonTest < ActiveSupport::TestCase
 
     script.seeded_from = Time.now.to_s
     assert_equal(
-      "https://lesson-plans.code.org/#{script.name}/#{Time.parse(script.seeded_from).to_s(:number)}/student-lesson-plans/Some-Verbose-Lesson-Name-Student.pdf",
+      "https://lesson-plans.code.org/#{script.name}/#{Time.parse(script.seeded_from).to_formatted_s(:number)}/student-lesson-plans/Some-Verbose-Lesson-Name-Student.pdf",
       new_lesson.student_lesson_plan_pdf_url
     )
   end


### PR DESCRIPTION
In Rails 6.1, the native `to_s` method [is extended to support an optional `format` argument](https://www.rubydoc.info/gems/activesupport/6.1.0/DateTime:to_s), and this method is also [aliased as `to_formatted_s`](https://www.rubydoc.info/gems/activesupport/6.1.0/DateTime:to_formatted_s). In Rails 7.0, the `to_s` method is restored to default, and its formatting functionality has been moved to [a new `to_fs` method](https://www.rubydoc.info/gems/activesupport/7.0.8/DateTime:to_fs), which fortunately is also [aliased as `to_formatted_s`](https://www.rubydoc.info/gems/activesupport/7.0.8/DateTime:to_formatted_s)

To facilitate the upgrade from 6.1 to 7.0, this PR updates all existing uses of `to_s` formatting to use `to_formatted_s` instead. Once the upgrade has concluded, we could update all uses to `to_fs`. Or just leave em as is :shrug: 

## Links

https://guides.rubyonrails.org/7_0_release_notes.html#active-support-deprecations

## Testing story

Every usage I changed is one that failed in a Rails 7.0 unit test; I feel confident we can rely on unit tests in this PR to validate that this change doesn't break any existing functionality, and on unit tests in my Rails 7 branch to validate that this change gets things working for that version.

I also grepped the codebase looking for other examples, but found none.