### PR TITLE
fix reference to chef_managed in `CDO.test_system?`

### DIFF
--- a/lib/cdo.rb
+++ b/lib/cdo.rb
@@ -320,7 +320,7 @@ module Cdo
     # to ensure that other systems (such as Continuous Integration builds) that are operating
     # with RACK_ENV=test do not carry out actions on behalf of the managed test system.
     def test_system?
-      rack_env?(:test) && pegasus_hostname == 'test.code.org' && CDO.chef_managed
+      rack_env?(:test) && pegasus_hostname == 'test.code.org' && chef_managed
     end
 
     # Identify whether we are executing within a web application server as most of our Ruby classes and modules


### PR DESCRIPTION
* See bug report in [slack](https://codedotorg.slack.com/archives/C0T0PNTM3/p1763086635350079). https://github.com/code-dot-org/code-dot-org/pull/69362 broke the test build with the following stack trace:
```
Nov 14 02:12:33 test bundle[666240]: /home/ubuntu/test/lib/cdo.rb:323:in `test_system?': uninitialized constant Cdo::Impl::CDO (NameError)
Nov 14 02:12:33 test bundle[666240]:       rack_env?(:test) && pegasus_hostname == 'test.code.org' && CDO.chef_managed
Nov 14 02:12:33 test bundle[666240]:                                                                  ^^^
Nov 14 02:12:33 test bundle[666240]:         from /home/ubuntu/test/config/test.yml.erb:85:in `block in render'
```
the problem is that `CDO` is sometimes not accessible within lib/cdo.rb. The solution is to change the reference from `CDO.chef_managed` to `chef_managed`, which there is another example of elsewhere in the same file.

## Testing story

- [x] `CDO.test_system?` evaluates to `false` when running `RAILS_ENV=test bin/dashboard-console` locally
- [x] passing drone run

after applying the fix to the test machine:
  - [x] `CDO.test_system?` returns `true` in dashboard-console
  - [x]  the test build passes (except for some unrelated eyes diffs)

in theory, there isn't much risk to other chef-managed environments (production, staging, levelbuilder) because the `rack_env?(:test) && pegasus_hostname == 'test.code.org'` logic should short-circuit in other chef managed environments before evaluating the new `chef_managed` term, so I feel reasonably confident in shipping this (and not rolling back the original PR) without validating those environments.

## Deployment strategy

To be merged once the test build and drone pass