### PR TITLE
hoai2025: freeplay level progress

### DIFF
--- a/apps/src/code-studio/progressRedux.ts
+++ b/apps/src/code-studio/progressRedux.ts
@@ -44,7 +44,6 @@ import {
 import {authorizeLockable} from './lessonLockRedux';
 import {
   getCurrentLevel,
-  getCurrentScriptLevelId,
   levelById,
   nextLevelId,
 } from './progressReduxSelectors';
@@ -437,6 +436,21 @@ export const sendSubmitReport = createAsyncThunk<
   );
 });
 
+export function sendSuccessReportForLevel(
+  levelId: string,
+  appType: string
+): AsyncProgressThunkAction {
+  return (dispatch, getState) => {
+    return sendReportForLevel(
+      levelId,
+      appType,
+      TestResults.ALL_PASS,
+      dispatch,
+      getState
+    );
+  };
+}
+
 // Helpers
 
 function sendReportHelper(
@@ -451,7 +465,30 @@ function sendReportHelper(
   if (!state.currentLessonId || !levelId) {
     return Promise.resolve();
   }
-  const scriptLevelId = getCurrentScriptLevelId(getState());
+  return sendReportForLevel(
+    levelId,
+    appType,
+    result,
+    dispatch,
+    getState,
+    extraData
+  );
+}
+
+function sendReportForLevel(
+  levelId: string,
+  appType: string,
+  result: number,
+  dispatch: ThunkDispatch<RootState, undefined, AnyAction>,
+  getState: () => RootState,
+  extraData?: OptionalMilestoneData
+) {
+  const state = getState().progress;
+  const currentLevel = levelById(state, state.currentLessonId, levelId);
+  const scriptLevelId = currentLevel.parentLevelId
+    ? levelById(state, state.currentLessonId, currentLevel.parentLevelId)
+        ?.scriptLevelId
+    : currentLevel.scriptLevelId;
   if (!scriptLevelId) {
     return Promise.resolve();
   }
@@ -488,7 +525,6 @@ function sendReportHelper(
       dispatch(mergeResults({[levelId]: result}));
       // If the level is the sublevel of a bubble level,
       // also update the status of the parent level.
-      const currentLevel = getCurrentLevel(getState());
       if (currentLevel.parentLevelId) {
         dispatch(mergeResults({[currentLevel.parentLevelId]: result}));
       }

--- a/apps/src/dance/lab2/views/GenerateDance.tsx
+++ b/apps/src/dance/lab2/views/GenerateDance.tsx
@@ -6,18 +6,20 @@ import React, {useCallback, useEffect, useState} from 'react';
 
 import {BlockDefinition, WorkspaceSerialization} from '@cdo/apps/blockly/types';
 import {useParentLevelProperties} from '@cdo/apps/bubbleChoice/customModes/MusicDanceAi/ParentLevelPropertiesContext';
+import {sendSuccessReportForLevel} from '@cdo/apps/code-studio/progressRedux';
 import {DanceLevelProperties} from '@cdo/apps/dance/types';
 import useLifecycleNotifier from '@cdo/apps/lab2/hooks/useLifecycleNotifier';
 import {LifecycleEvent} from '@cdo/apps/lab2/utils/LifecycleNotifier';
 import Adlib, {
-  AdlibType,
   AdlibChoices,
+  AdlibType,
 } from '@cdo/apps/lab2/views/components/guide/Adlib';
 import Guide from '@cdo/apps/lab2/views/components/guide/Guide';
 import MainInstructionsContent from '@cdo/apps/lab2/views/components/Instructions/MainInstructionsContent';
 import NavigationArea from '@cdo/apps/lab2/views/components/Instructions/NavigationArea';
 import {EVENTS} from '@cdo/apps/metrics/AnalyticsConstants';
 import analyticsReporter from '@cdo/apps/metrics/AnalyticsReporter';
+import {useAppDispatch} from '@cdo/apps/util/reduxHooks';
 
 import buildDanceBlockly from '../../blockly/buildDanceBlockly';
 
@@ -234,6 +236,15 @@ const GenerateDance: React.FunctionComponent<GenerateCodeProps> = ({
   const parentProperties = useParentLevelProperties();
   const isStandalone =
     levelProperties.isProjectLevel || parentProperties?.isProjectLevel;
+  const dispatch = useAppDispatch();
+  const sublevelOnContinue = useCallback(() => {
+    dispatch(
+      sendSuccessReportForLevel(
+        levelProperties.id.toString(),
+        levelProperties.appName
+      )
+    );
+  }, [dispatch, levelProperties.appName, levelProperties.id]);
 
   return (
     <Guide id="generate-panel" modal={modal} position="bottom">
@@ -397,6 +408,8 @@ const GenerateDance: React.FunctionComponent<GenerateCodeProps> = ({
                 hasEdited={true}
                 isRunning={false}
                 className={styles.buttonWide}
+                // If on a Music Dance AI sublevel, make sure we report success for this specific sublevel so that progress is correctly updated.
+                onContinue={parentProperties ? sublevelOnContinue : undefined}
               />
             )}
           </div>

--- a/apps/src/dance/lab2/views/GenerateDancer.tsx
+++ b/apps/src/dance/lab2/views/GenerateDancer.tsx
@@ -6,6 +6,7 @@ import {sample} from 'lodash';
 import React, {useCallback, useEffect, useRef, useState} from 'react';
 
 import {useParentLevelProperties} from '@cdo/apps/bubbleChoice/customModes/MusicDanceAi/ParentLevelPropertiesContext';
+import {sendSuccessReportForLevel} from '@cdo/apps/code-studio/progressRedux';
 import {queryParams} from '@cdo/apps/code-studio/utils';
 import {
   DanceLevelProperties,
@@ -355,6 +356,14 @@ const GenerateDancer: React.FunctionComponent<DancerGenerateProps> = ({
   const parentProperties = useParentLevelProperties();
   const showNavigation =
     !levelProperties.isProjectLevel && !parentProperties?.isProjectLevel;
+  const sublevelOnContinue = useCallback(() => {
+    dispatch(
+      sendSuccessReportForLevel(
+        levelProperties.id.toString(),
+        levelProperties.appName
+      )
+    );
+  }, [dispatch, levelProperties.appName, levelProperties.id]);
 
   return (
     <div id="dance-lab" className={moduleStyles.dancerGenerate}>
@@ -498,6 +507,10 @@ const GenerateDancer: React.FunctionComponent<DancerGenerateProps> = ({
                     hasEdited={true}
                     isRunning={false}
                     className={moduleStyles.buttonWide}
+                    // If on a Music Dance AI sublevel, make sure we report success for this specific sublevel so that progress is correctly updated.
+                    onContinue={
+                      parentProperties ? sublevelOnContinue : undefined
+                    }
                   />
                 )}
               </div>

--- a/apps/src/lab2/views/components/Instructions/ContinueButton.tsx
+++ b/apps/src/lab2/views/components/Instructions/ContinueButton.tsx
@@ -10,6 +10,7 @@ import moduleStyles from '@cdo/apps/lab2/views/components/Instructions/instructi
 interface ContinueButtonProps extends ButtonProps {
   tooltipMessage?: string;
   hideIfDisabled?: boolean;
+  onContinue?: () => void;
 }
 
 /**
@@ -20,6 +21,7 @@ const ContinueButton: React.FC<ContinueButtonProps> = ({
   tooltipMessage,
   hideIfDisabled,
   disabled,
+  onContinue,
   ...buttonProps
 }) => {
   const dispatch = useAppDispatch();
@@ -44,7 +46,10 @@ const ContinueButton: React.FC<ContinueButtonProps> = ({
       >
         <Button
           id="instructions-continue-button"
-          onClick={() => dispatch(continueOrFinishLesson())}
+          onClick={() => {
+            onContinue?.();
+            dispatch(continueOrFinishLesson());
+          }}
           disabled={disabled}
           size={'s'}
           {...buttonProps}

--- a/apps/src/lab2/views/components/Instructions/NavigationArea.tsx
+++ b/apps/src/lab2/views/components/Instructions/NavigationArea.tsx
@@ -35,6 +35,8 @@ interface NavigationAreaProps {
   markdownClassName?: string;
   overrideTheme?: Theme;
   styleAsBubble?: boolean;
+  /** Optional on continue/finish callback. */
+  onContinue?: () => void;
 }
 
 /**
@@ -52,6 +54,7 @@ const NavigationArea: React.FC<NavigationAreaProps> = ({
   markdownClassName,
   overrideTheme,
   styleAsBubble = false,
+  onContinue,
 }) => {
   const {
     id,
@@ -237,6 +240,7 @@ const NavigationArea: React.FC<NavigationAreaProps> = ({
               text={hasNextLevel ? commonI18n.continue() : commonI18n.finish()}
               tooltipMessage={continueTooltip}
               hideIfDisabled={hideContinueIfDisabled}
+              onContinue={onContinue}
             />
           )}
         </div>

--- a/apps/src/music/views/GenerateCode.tsx
+++ b/apps/src/music/views/GenerateCode.tsx
@@ -4,6 +4,7 @@ import {sample} from 'lodash';
 import React, {useCallback, useEffect, useState} from 'react';
 
 import {useParentLevelProperties} from '@cdo/apps/bubbleChoice/customModes/MusicDanceAi/ParentLevelPropertiesContext';
+import {sendSuccessReportForLevel} from '@cdo/apps/code-studio/progressRedux';
 import useLifecycleNotifier from '@cdo/apps/lab2/hooks/useLifecycleNotifier';
 import {LevelProperties} from '@cdo/apps/lab2/types';
 import {LifecycleEvent} from '@cdo/apps/lab2/utils/LifecycleNotifier';
@@ -238,6 +239,14 @@ const GenerateCode: React.FunctionComponent<GenerateCodeProps> = ({
   const parentProperties = useParentLevelProperties();
   const isStandalone =
     levelProperties.isProjectLevel || parentProperties?.isProjectLevel;
+  const sublevelOnContinue = useCallback(() => {
+    dispatch(
+      sendSuccessReportForLevel(
+        levelProperties.id.toString(),
+        levelProperties.appName
+      )
+    );
+  }, [dispatch, levelProperties.appName, levelProperties.id]);
 
   const levelSpecificId = `generate-panel-${levelProperties.id}`;
   if (!packId) {
@@ -437,6 +446,8 @@ const GenerateCode: React.FunctionComponent<GenerateCodeProps> = ({
                 hasEdited={true}
                 isRunning={false}
                 className={styles.buttonWide}
+                // If on a Music Dance AI sublevel, make sure we report success for this specific sublevel so that progress is correctly updated.
+                onContinue={parentProperties ? sublevelOnContinue : undefined}
               />
             )}
           </div>

--- a/apps/src/types/progressTypes.ts
+++ b/apps/src/types/progressTypes.ts
@@ -67,6 +67,7 @@ export interface Level {
   status?: string;
   sublevels?: Level[];
   usesLab2: boolean;
+  parentLevelId?: string;
 }
 
 export interface LevelWithProgress extends Level {


### PR DESCRIPTION
Fixes an issue where the final freeplay level bubble wouldn't stay green (completed) after finishing the progression. The issue here was that when we click continue or finish on a Lab2 level, we automatically emit a success milestone event for the current level if it does not have any validation. However for bubble choice levels, our progress system uses the progress from the sublevel with the most work (as it doesn't really make sense to "complete" the parent bubble choice level itself). In our freeplay implementation, we never actually switch into the sublevel, so the current level ID at the time of finishing is the bubble choice level, and we therefore never emit a success event for sublevel that corresponds to the tab the user is on.

Fix here is to introduce an alternate code path to track a success event for a specified level ID. Ideally I'd like to refactor this a bit more to always pass through the level ID from Continue button instead of relying on `state.progress.currentLevelId`, to support modular cases like this. However, I'll leave that for a future change post Hour of AI.

## Testing story
- Tested locally, confirmed freeplay level stays green after leaving and coming back to the progression.