### PR TITLE
[Hour of AI] Prevent repeat field values in complex generated Dance code

### DIFF
--- a/apps/src/dance/blockly/buildDanceBlockly.ts
+++ b/apps/src/dance/blockly/buildDanceBlockly.ts
@@ -218,13 +218,14 @@ function makeSetBackgroundBlock(
   type: string,
   effects: string[],
   palettes: string[],
-  simpleCode: boolean
+  simpleCode: boolean,
+  excludedEffect?: string | null
 ): BlockState {
   return {
     type,
     fields: {
       PALETTE: randomField('PALETTE', palettes),
-      EFFECT: randomField('EFFECT', effects, simpleCode),
+      EFFECT: randomField('EFFECT', effects, simpleCode, excludedEffect),
     },
     kind: 'block',
   };
@@ -233,12 +234,13 @@ function makeSetBackgroundBlock(
 function makeSetForegroundBlock(
   type: string,
   effects: string[],
-  simpleCode: boolean
+  simpleCode: boolean,
+  excludedEffect?: string | null
 ): BlockState {
   return {
     type,
     fields: {
-      EFFECT: randomField('EFFECT', effects, simpleCode),
+      EFFECT: randomField('EFFECT', effects, simpleCode, excludedEffect),
     },
     kind: 'block',
   };
@@ -489,10 +491,16 @@ export default function buildDanceBlockly(
     leadGroupValue
   );
 
-  // We force the backup dancers to not repeat the lead dancer's move.
-  const leadDancerMove = Blockly.Xml.textToDom(
-    leadChangeMoveBlock.fields?.MOVE || ''
-  ).textContent;
+  // We capture initial values to prevent repeats in subsequent blocks of the same type.
+  const initialMoveValue =
+    Blockly.Xml.textToDom(initialChangeMove.fields?.MOVE)?.textContent || null;
+  const initialBackgroundEffect =
+    Blockly.Xml.textToDom(initialBg.fields?.EFFECT)?.textContent || null;
+  const initialForegroundEffect =
+    Blockly.Xml.textToDom(initialFg.fields?.EFFECT)?.textContent || null;
+  const leadDancerMove =
+    Blockly.Xml.textToDom(leadChangeMoveBlock.fields?.MOVE)?.textContent ||
+    null;
 
   const backupGroupValue = `&quot;${backgroundDancers.toUpperCase()}&quot;`;
   const backupChangeMoveBlock = makeChangeMoveEachLRBlock(
@@ -534,43 +542,70 @@ export default function buildDanceBlockly(
   };
 
   // Event blocks for each measure
-  const eventBlocks: BlockState[] = measures
-    // First measure is redundant with "when run"
-    .filter(measure => measure !== 1)
-    .map((measure): BlockState => {
-      const backgroundBlock = makeSetBackgroundBlock(
-        setBackgroundBlockType,
-        validBackgrounds,
-        validPalettes,
-        simpleCode
-      );
-      const foregroundBlock = makeSetForegroundBlock(
-        setForegroundBlockType,
-        validForegrounds,
-        simpleCode
-      );
-      const changeMoveBlock = makeChangeMoveEachLRBlock(
-        changeMoveBlockType,
-        validMoves,
-        backgroundDancers,
-        simpleCode
-      );
-      const chain = chainBlocks(
-        backgroundBlock,
-        foregroundBlock,
-        changeMoveBlock
-      );
+  const eventBlocks: BlockState[] = [];
+  let lastEventBackground: string | null = initialBackgroundEffect;
+  let lastEventForeground: string | null = initialForegroundEffect;
+  let lastEventMove: string | null = initialMoveValue;
 
-      return {
-        ...eventBlock,
-        fields: {
-          TIMESTAMP: measure,
-          UNIT: unitMeasuresField(),
-        },
-        next: {block: chain},
-        kind: 'block',
-      };
+  for (const measure of measures.filter(m => m !== 1)) {
+    const backgroundBlock = makeSetBackgroundBlock(
+      setBackgroundBlockType,
+      validBackgrounds,
+      validPalettes,
+      simpleCode,
+      lastEventBackground
+    );
+
+    // Exclude the previously used foreground effect
+    const foregroundBlock = makeSetForegroundBlock(
+      setForegroundBlockType,
+      validForegrounds,
+      simpleCode,
+      lastEventForeground
+    );
+
+    // Exclude the previously used move
+    const changeMoveBlock = makeChangeMoveEachLRBlock(
+      changeMoveBlockType,
+      validMoves,
+      backgroundDancers,
+      simpleCode,
+      undefined, // defaultGroupFieldValue, only used for simple code
+      lastEventMove
+    );
+
+    const chain = chainBlocks(
+      backgroundBlock,
+      foregroundBlock,
+      changeMoveBlock
+    );
+
+    // Capture the actual chosen values from the generated field XML,
+    // so they are not repeated in the next stack.
+    const chosenBg =
+      Blockly.Xml.textToDom((backgroundBlock.fields?.EFFECT as string) || '')
+        .textContent || null;
+    const chosenFg =
+      Blockly.Xml.textToDom((foregroundBlock.fields?.EFFECT as string) || '')
+        .textContent || null;
+    const chosenMove =
+      Blockly.Xml.textToDom((changeMoveBlock.fields?.MOVE as string) || '')
+        .textContent || null;
+
+    lastEventBackground = chosenBg;
+    lastEventForeground = chosenFg;
+    lastEventMove = chosenMove;
+
+    eventBlocks.push({
+      type: atTimestampNotAfterBlockType,
+      fields: {
+        TIMESTAMP: measure,
+        UNIT: unitMeasuresField(),
+      },
+      next: {block: chain},
+      kind: 'block',
     });
+  }
 
   flyoutDefinition.contents.push({...eventBlock});
 

--- a/apps/src/dance/blockly/buildDanceBlockly.ts
+++ b/apps/src/dance/blockly/buildDanceBlockly.ts
@@ -548,6 +548,7 @@ export default function buildDanceBlockly(
   let lastEventMove: string | null = initialMoveValue;
 
   for (const measure of measures.filter(m => m !== 1)) {
+    // Exclude the previously used background effect
     const backgroundBlock = makeSetBackgroundBlock(
       setBackgroundBlockType,
       validBackgrounds,

--- a/apps/src/dance/blockly/buildDanceBlockly.ts
+++ b/apps/src/dance/blockly/buildDanceBlockly.ts
@@ -133,6 +133,16 @@ function getPreferredBlockType(
     : DANCELAB_PREFIX + blockType;
 }
 
+function getBlockFieldValue(
+  block: BlockState,
+  fieldName: string
+): string | null {
+  return (
+    Blockly.Xml.textToDom((block.fields?.[fieldName] as string) || '')
+      .textContent || null
+  );
+}
+
 const MAKE_SPRITE = 'makeAnonymousDanceSprite';
 const CHANGE_MOVE = 'changeMoveEachLR';
 const SET_BACKGROUND = 'setBackgroundEffectWithPalette';
@@ -492,15 +502,10 @@ export default function buildDanceBlockly(
   );
 
   // We capture initial values to prevent repeats in subsequent blocks of the same type.
-  const initialMoveValue =
-    Blockly.Xml.textToDom(initialChangeMove.fields?.MOVE)?.textContent || null;
-  const initialBackgroundEffect =
-    Blockly.Xml.textToDom(initialBg.fields?.EFFECT)?.textContent || null;
-  const initialForegroundEffect =
-    Blockly.Xml.textToDom(initialFg.fields?.EFFECT)?.textContent || null;
-  const leadDancerMove =
-    Blockly.Xml.textToDom(leadChangeMoveBlock.fields?.MOVE)?.textContent ||
-    null;
+  const initialMoveValue = getBlockFieldValue(initialChangeMove, 'MOVE');
+  const initialBackgroundEffect = getBlockFieldValue(initialBg, 'EFFECT');
+  const initialForegroundEffect = getBlockFieldValue(initialFg, 'EFFECT');
+  const leadDancerMove = getBlockFieldValue(leadChangeMoveBlock, 'MOVE');
 
   const backupGroupValue = `&quot;${backgroundDancers.toUpperCase()}&quot;`;
   const backupChangeMoveBlock = makeChangeMoveEachLRBlock(
@@ -583,15 +588,9 @@ export default function buildDanceBlockly(
 
     // Capture the actual chosen values from the generated field XML,
     // so they are not repeated in the next stack.
-    const chosenBg =
-      Blockly.Xml.textToDom((backgroundBlock.fields?.EFFECT as string) || '')
-        .textContent || null;
-    const chosenFg =
-      Blockly.Xml.textToDom((foregroundBlock.fields?.EFFECT as string) || '')
-        .textContent || null;
-    const chosenMove =
-      Blockly.Xml.textToDom((changeMoveBlock.fields?.MOVE as string) || '')
-        .textContent || null;
+    const chosenBg = getBlockFieldValue(backgroundBlock, 'EFFECT');
+    const chosenFg = getBlockFieldValue(foregroundBlock, 'EFFECT');
+    const chosenMove = getBlockFieldValue(changeMoveBlock, 'MOVE');
 
     lastEventBackground = chosenBg;
     lastEventForeground = chosenFg;


### PR DESCRIPTION
Due to randomness, the dancer’s initial move could repeat at the first timed event (e.g., “drop” at setup and again at measure 3).

<img width="399" height="577" alt="image" src="https://github.com/user-attachments/assets/96e2b20d-588f-4f51-abdf-7ebc87f62012" />

This wasn't an issue for simple code, despite the `do forever` block showing up twice. For the second, block we'd exclude the first block's field value from the list of available options, ensuring both are always unique:
<img width="314" height="409" alt="image" src="https://github.com/user-attachments/assets/04b4dc8d-f0c4-4f93-a787-fb726743598c" />

This branch extends that logic to other `MOVE` and `EFFECT` fields. The result is that moves and effects will not be repeated in adjacent stacks in complex code. Note that I didn't bother to implement this for the `set background effect` block's `PALETTE` field, since using a new effect should be sufficient to make it feel like the newest block is doing something new.

Maybe worth noting is that it's possible for the same move or effect to show up more than once, just not in adjacent stacks. This example shows the background effects `Sparkles` and `Stars` each being used multiple time, but not right after themselves.

<img width="261" height="826" alt="image" src="https://github.com/user-attachments/assets/7458e464-e530-4202-92e1-c35f674fcf3e" />



## Links
<!--  Links to relevant external resources.
      - spec docs, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- Jira: 

## Testing story
<!--  Does your change include appropriate tests?
      - If so, please describe how the tests included in this PR are sufficient.
      - If not, please explain why this change does not need to be tested. -->



## Deployment strategy
<!--  Any special steps required to deploy this, besides merging?
      - Are there database migrations or manual steps?
      - Does this require coordination with other teams or systems? -->



## Follow-up work
<!--  List any clean-up or technical debt that will be addressed in future work.
      - Include Jira links where applicable.
      - Are there any known limitations or improvements planned? -->



## Privacy
<!--  How does this change impact Student & Teacher privacy?
      - Does this collect, use, share, or modify PII, either new or existing? -->



## Security
<!--  How does this change impact our security surface-area?
      - Do API's touched have the right auth?
      - Do infra changes impact our attack surface or encryption?
-->



## Caching
<!--  How does this change impact caching behavior?
      - Are cache keys or invalidation strategies affected?
      - Will this require cache warming or invalidation after deployment? -->



## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
