### PR TITLE
hoai2025: guide minimize

### DIFF
--- a/apps/src/dance/lab2/views/GenerateDance.tsx
+++ b/apps/src/dance/lab2/views/GenerateDance.tsx
@@ -97,6 +97,7 @@ const GenerateDance: React.FunctionComponent<GenerateCodeProps> = ({
     | 'listened'
     | 'editing'
     | 'edited'
+    | 'playing'
   >('none');
 
   const getInitialChoices = () => {
@@ -233,6 +234,23 @@ const GenerateDance: React.FunctionComponent<GenerateCodeProps> = ({
     ? 'full'
     : undefined;
 
+  const guideWidth = aiGenerateState === 'playing' ? 'very-narrow' : 'normal';
+
+  const cornerIcon =
+    aiGenerateState === 'edited'
+      ? 'minimize'
+      : aiGenerateState === 'playing'
+      ? 'maximize'
+      : undefined;
+
+  const onCornerIcon = useCallback(() => {
+    if (aiGenerateState === 'edited') {
+      setAiGenerateState('playing');
+    } else if (aiGenerateState === 'playing') {
+      setAiGenerateState('edited');
+    }
+  }, [aiGenerateState]);
+
   const parentProperties = useParentLevelProperties();
   const isStandalone =
     levelProperties.isProjectLevel || parentProperties?.isProjectLevel;
@@ -247,7 +265,14 @@ const GenerateDance: React.FunctionComponent<GenerateCodeProps> = ({
   }, [dispatch, levelProperties.appName, levelProperties.id]);
 
   return (
-    <Guide id="generate-panel" modal={modal} position="bottom">
+    <Guide
+      id="generate-panel"
+      modal={modal}
+      width={guideWidth}
+      position="bottom"
+      cornerIcon={cornerIcon}
+      onCornerIcon={onCornerIcon}
+    >
       {aiGenerateState === 'none' && levelProperties.longInstructions && (
         <MainInstructionsContent
           instructionsText={levelProperties.longInstructions}
@@ -415,6 +440,9 @@ const GenerateDance: React.FunctionComponent<GenerateCodeProps> = ({
           </div>
         </>
       )}
+
+      {aiGenerateState === 'playing' && <div>Keep playing!</div>}
+
       {/* Retain focus with a hidden button. */}
       {['generating', 'generated', 'listening', 'editing'].includes(
         aiGenerateState

--- a/apps/src/dance/lab2/views/GenerateDance.tsx
+++ b/apps/src/dance/lab2/views/GenerateDance.tsx
@@ -243,7 +243,7 @@ const GenerateDance: React.FunctionComponent<GenerateCodeProps> = ({
       ? 'maximize'
       : undefined;
 
-  const onCornerIcon = useCallback(() => {
+  const onCornerIconClick = useCallback(() => {
     if (aiGenerateState === 'edited') {
       setAiGenerateState('playing');
     } else if (aiGenerateState === 'playing') {
@@ -271,7 +271,7 @@ const GenerateDance: React.FunctionComponent<GenerateCodeProps> = ({
       width={guideWidth}
       position="bottom"
       cornerIcon={cornerIcon}
-      onCornerIcon={onCornerIcon}
+      onCornerIconClick={onCornerIconClick}
     >
       {aiGenerateState === 'none' && levelProperties.longInstructions && (
         <MainInstructionsContent

--- a/apps/src/lab2/views/components/guide/Guide.module.scss
+++ b/apps/src/lab2/views/components/guide/Guide.module.scss
@@ -1,4 +1,5 @@
 @use '../layout/variables.scss' as variables;
+@import '../../../../mixins.scss';
 
 $top-position: 62px;
 $bottom-position: 20px;
@@ -61,6 +62,11 @@ $gap-height: 43px;
     width: 40%;
   }
 
+  &VeryNarrowWidth {
+    width: 10%;
+    min-width: 160px;
+  }
+
   &NarrowWidth {
     width: 20%;
   }
@@ -78,6 +84,15 @@ $gap-height: 43px;
   &Gap {
     top: $top-position - $gap-height;
   }
+}
+
+.cornerIconButton {
+  @include remove-button-styles;
+  position: absolute;
+  top: 10px;
+  right: 20px;
+  font-size: 24px;
+  color: var(--neutral-base-white);
 }
 
 .markdown {

--- a/apps/src/lab2/views/components/guide/Guide.tsx
+++ b/apps/src/lab2/views/components/guide/Guide.tsx
@@ -1,3 +1,4 @@
+import FontAwesomeV6Icon from '@code-dot-org/component-library/fontAwesomeV6Icon';
 import classNames from 'classnames';
 import React from 'react';
 
@@ -6,9 +7,11 @@ import styles from './Guide.module.scss';
 interface GuideProps {
   id?: string;
   children: React.ReactNode;
-  width?: 'normal' | 'narrow';
+  width?: 'normal' | 'narrow' | 'very-narrow';
   position?: 'normal' | 'bottom';
   modal?: 'full' | 'gap';
+  cornerIcon?: 'minimize' | 'maximize';
+  onCornerIcon?: () => void;
 }
 
 // The Guide is a floating container for instructional content.  It is larger
@@ -20,6 +23,8 @@ const Guide: React.FunctionComponent<GuideProps> = ({
   width,
   position,
   modal,
+  cornerIcon,
+  onCornerIcon,
 }) => {
   return (
     <div
@@ -33,7 +38,9 @@ const Guide: React.FunctionComponent<GuideProps> = ({
         id={id}
         className={classNames(
           styles.guide,
-          width === 'narrow'
+          width === 'very-narrow'
+            ? styles.guideVeryNarrowWidth
+            : width === 'narrow'
             ? styles.guideNarrowWidth
             : styles.guideNormalWidth,
           position === 'bottom'
@@ -43,6 +50,18 @@ const Guide: React.FunctionComponent<GuideProps> = ({
         )}
       >
         {children}
+        {cornerIcon && onCornerIcon && (
+          <button
+            type="button"
+            className={styles.cornerIconButton}
+            onClick={onCornerIcon}
+          >
+            <FontAwesomeV6Icon
+              iconName={cornerIcon === 'minimize' ? 'caret-down' : 'caret-up'}
+              iconStyle="solid"
+            />
+          </button>
+        )}
       </div>
     </div>
   );

--- a/apps/src/lab2/views/components/guide/Guide.tsx
+++ b/apps/src/lab2/views/components/guide/Guide.tsx
@@ -11,7 +11,7 @@ interface GuideProps {
   position?: 'normal' | 'bottom';
   modal?: 'full' | 'gap';
   cornerIcon?: 'minimize' | 'maximize';
-  onCornerIcon?: () => void;
+  onCornerIconClick?: () => void;
 }
 
 // The Guide is a floating container for instructional content.  It is larger
@@ -24,7 +24,7 @@ const Guide: React.FunctionComponent<GuideProps> = ({
   position,
   modal,
   cornerIcon,
-  onCornerIcon,
+  onCornerIconClick,
 }) => {
   return (
     <div
@@ -50,11 +50,14 @@ const Guide: React.FunctionComponent<GuideProps> = ({
         )}
       >
         {children}
-        {cornerIcon && onCornerIcon && (
+        {cornerIcon && onCornerIconClick && (
           <button
             type="button"
             className={styles.cornerIconButton}
-            onClick={onCornerIcon}
+            onClick={onCornerIconClick}
+            aria-label={
+              cornerIcon === 'minimize' ? 'Minimize guide' : 'Restore guide'
+            }
           >
             <FontAwesomeV6Icon
               iconName={cornerIcon === 'minimize' ? 'caret-down' : 'caret-up'}


### PR DESCRIPTION
This proposes the ability to minimize the Guide at the very end of the tutorial progression, encouraging further free-play.

#### Minimize becomes available

<img width="1362" height="719" alt="Screenshot 2025-11-17 at 2 19 24 PM" src="https://github.com/user-attachments/assets/e19bdc52-7211-4266-8f0c-8dd3d2b0bd83" />

#### Minimized

<img width="1362" height="719" alt="Screenshot 2025-11-17 at 2 19 36 PM" src="https://github.com/user-attachments/assets/992f2979-6529-4c18-979f-0e479514a3a6" />
