### PR TITLE
Fix production honeybadger error logging ActionCable metrics

### DIFF
--- a/lib/cdo/app_server_metrics.rb
+++ b/lib/cdo/app_server_metrics.rb
@@ -81,7 +81,7 @@ module Cdo
     def self.start_background_metrics_thread(host:)
       Thread.new do
         dimensions = {
-          PID: Process.pid,
+          PID: Process.pid.to_s,
           Host: host,
         }
 


### PR DESCRIPTION
Fixes [honeybadger issue](
https://app.honeybadger.io/projects/3240/faults/125069280/01KAA53KXK10PFQ2K2Y59VG80E):
```
ArgumentError: expected params[:metric_data][0][:dimensions][0][:value] to be a String, got class Integer instead.
```
