### PR TITLE
Sketch Lab: upload images to S3 via canvas element

### DIFF
--- a/apps/src/sketchlab/utils/uploadBase64ToUrl.ts
+++ b/apps/src/sketchlab/utils/uploadBase64ToUrl.ts
@@ -1,12 +1,5 @@
 import HttpClient from '@cdo/apps/util/HttpClient';
 
-async function loadImage(dataUrl: string): Promise<HTMLImageElement> {
-  const img = new Image();
-  img.src = dataUrl;
-  await img.decode();
-  return img;
-}
-
 async function canvasToBlob(
   canvas: HTMLCanvasElement,
   mimeType: string
@@ -27,14 +20,16 @@ export async function uploadBase64ToUrl(
   uploadUrl: string,
   mimeType: string
 ): Promise<Response> {
-  const img = await loadImage(dataUrl);
+  const img = new Image();
+  img.src = dataUrl;
+  await img.decode();
 
   // Create a canvas and draw the image onto it
   const canvas = document.createElement('canvas');
   canvas.width = img.width;
   canvas.height = img.height;
-  const ctx = canvas.getContext('2d');
-  ctx?.drawImage(img, 0, 0);
+  const context = canvas.getContext('2d');
+  context?.drawImage(img, 0, 0);
 
   const blob = await canvasToBlob(canvas, mimeType);
 

--- a/apps/src/sketchlab/utils/uploadBase64ToUrl.ts
+++ b/apps/src/sketchlab/utils/uploadBase64ToUrl.ts
@@ -1,12 +1,43 @@
 import HttpClient from '@cdo/apps/util/HttpClient';
 
+async function loadImage(dataUrl: string): Promise<HTMLImageElement> {
+  const img = new Image();
+  img.src = dataUrl;
+  await img.decode();
+  return img;
+}
+
+async function canvasToBlob(
+  canvas: HTMLCanvasElement,
+  mimeType: string
+): Promise<Blob> {
+  return new Promise<Blob>((resolve, reject) => {
+    canvas.toBlob(blob => {
+      if (blob) {
+        resolve(blob);
+      } else {
+        reject(new Error('Failed to convert canvas to blob'));
+      }
+    }, mimeType);
+  });
+}
+
 export async function uploadBase64ToUrl(
   dataUrl: string,
   uploadUrl: string,
   mimeType: string
 ): Promise<Response> {
-  const localResponse = await fetch(dataUrl);
-  const blob = await localResponse.blob();
+  const img = await loadImage(dataUrl);
+
+  // Create a canvas and draw the image onto it
+  const canvas = document.createElement('canvas');
+  canvas.width = img.width;
+  canvas.height = img.height;
+  const ctx = canvas.getContext('2d');
+  ctx?.drawImage(img, 0, 0);
+
+  const blob = await canvasToBlob(canvas, mimeType);
+
   const file = new File([blob], 'file', {
     type: mimeType,
   });


### PR DESCRIPTION
We ran into Content Security Policy issues in converting image data URLs -> blobs via the fetch API.

This PR offers an alternative: converting the image to a blob by putting it on a canvas element first.

## Links

- Slack: https://codedotorg.slack.com/archives/C06JELCAPT9/p1763154643990659
- Jira: https://codedotorg.atlassian.net/browse/AFL-374

## Testing story

I tested that I could upload an image successfully with the production CSP in place locally.