### PR TITLE
Removing 'warden' keys and setting 'user_id' in Honeybadger errors

### DIFF
--- a/dashboard/config/honeybadger.yml
+++ b/dashboard/config/honeybadger.yml
@@ -6,8 +6,7 @@ exceptions:
 breadcrumbs:
   enabled: true
 request:
-  filter_keys:
-    - "warden.user.user.key"
+  filter_keys: []
 
 # report data to honeybadger on the test server. this will not happen in unit tests
 # or ci because we unset the api key in those situations (see test.yml.erb).

--- a/dashboard/config/initializers/honeybadger_user_context.rb
+++ b/dashboard/config/initializers/honeybadger_user_context.rb
@@ -1,24 +1,21 @@
 # Honeybadger configuration for user tracking and data filtering
-if defined?(Honeybadger)
-  # Remove all Warden session data from error reports before sending to Honeybadger
-  # This prevents any sensitive authentication data from being logged
-  Honeybadger.configure do |config|
-    config.before_notify do |notice|
-      if notice.request && notice.request[:session]
-        notice.request[:session].delete_if do |key, _value|
-          key.to_s.start_with?('warden.')
-        end
+
+# Remove all Warden session data from error reports before sending to Honeybadger
+# This prevents any sensitive authentication data from being logged
+Honeybadger.configure do |config|
+  config.before_notify do |notice|
+    if notice.request && notice.request[:session]
+      notice.request[:session].delete_if do |key, _value|
+        key.to_s.start_with?('warden.')
       end
     end
   end
+end
 
-  # Set user context for tracking unique affected users
-  # This allows Honeybadger to count affected users without exposing sensitive data
-  if defined?(Warden::Manager.after_set_user)
-    Warden::Manager.after_set_user do |user, _auth, _opts|
-      if user.respond_to?(:id)
-        Honeybadger.context(user_id: user.id)
-      end
-    end
+# Set user context for tracking unique affected users
+# This allows Honeybadger to count affected users without exposing sensitive data
+Warden::Manager.after_set_user do |user, _auth, _opts|
+  if user.respond_to?(:id)
+    Honeybadger.context(user_id: user.id)
   end
 end

--- a/dashboard/config/initializers/honeybadger_user_context.rb
+++ b/dashboard/config/initializers/honeybadger_user_context.rb
@@ -1,0 +1,24 @@
+# Honeybadger configuration for user tracking and data filtering
+if defined?(Honeybadger)
+  # Remove all Warden session data from error reports before sending to Honeybadger
+  # This prevents any sensitive authentication data from being logged
+  Honeybadger.configure do |config|
+    config.before_notify do |notice|
+      if notice.request && notice.request[:session]
+        notice.request[:session].delete_if do |key, _value|
+          key.to_s.start_with?('warden.')
+        end
+      end
+    end
+  end
+
+  # Set user context for tracking unique affected users
+  # This allows Honeybadger to count affected users without exposing sensitive data
+  if defined?(Warden::Manager.after_set_user)
+    Warden::Manager.after_set_user do |user, _auth, _opts|
+      if user.respond_to?(:id)
+        Honeybadger.context(user_id: user.id)
+      end
+    end
+  end
+end

--- a/dashboard/config/initializers/honeybadger_user_context.rb
+++ b/dashboard/config/initializers/honeybadger_user_context.rb
@@ -1,4 +1,4 @@
-# Honeybadger configuration for user tracking and data filtering
+# Honeybadger configuration for data filtering
 
 # Remove all Warden session data from error reports before sending to Honeybadger
 # This prevents any sensitive authentication data from being logged
@@ -9,13 +9,5 @@ Honeybadger.configure do |config|
         key.to_s.start_with?('warden.')
       end
     end
-  end
-end
-
-# Set user context for tracking unique affected users
-# This allows Honeybadger to count affected users without exposing sensitive data
-Warden::Manager.after_set_user do |user, _auth, _opts|
-  if user.respond_to?(:id)
-    Honeybadger.context(user_id: user.id)
   end
 end

--- a/dashboard/test/integration/honeybadger_test.rb
+++ b/dashboard/test/integration/honeybadger_test.rb
@@ -30,10 +30,7 @@ class HoneybadgerTest < ActionDispatch::IntegrationTest
     end
   end
 
-  # The value Honeybadger will set a filtered value to.
-  FILTERED = "[FILTERED]"
-
-  test "does NOT log encrypted data" do
+  test "does NOT log warden session data" do
     skip 'races the reconfiguration and errors if it contacts real honeybadger server'
     student = create(:student)
     sign_in student
@@ -46,6 +43,29 @@ class HoneybadgerTest < ActionDispatch::IntegrationTest
     # Other tests running in parallel might have logged notices too, but we're only interested in notices about our test controller
     notice = Honeybadger::Backend::Test.notifications[:notices].find {|n| n.controller == "honeybadger_error"}
     refute_nil notice
-    assert_equal FILTERED, notice.as_json[:request][:session]["warden.user.user.key"]
+
+    # Verify no warden keys exist in session data
+    session_data = notice.as_json[:request][:session]
+    warden_keys = session_data.keys.select {|key| key.to_s.start_with?('warden.')}
+    assert_empty warden_keys, "Warden keys should be completely removed, but found: #{warden_keys}"
+  end
+
+  test "sets user_id context for authenticated users" do
+    skip 'races the reconfiguration and errors if it contacts real honeybadger server'
+    student = create(:student)
+    sign_in student
+
+    get raise_error_path
+
+    # Ensure that the notifications hit the backend queue
+    Honeybadger.flush
+
+    # Find our test notice
+    notice = Honeybadger::Backend::Test.notifications[:notices].find {|n| n.controller == "honeybadger_error"}
+    refute_nil notice
+
+    # Verify user_id is set in context
+    context_data = notice.as_json[:request][:context]
+    assert_equal student.id, context_data[:user_id], "user_id should be set in Honeybadger context"
   end
 end


### PR DESCRIPTION
We had a security report where we discovered that we were logging a User’s encrypted password to Honeybadger. To solve that issue, we filtered the field from the data we report to Honeybadger in [this PR](https://github.com/code-dot-org/code-dot-org/pull/53545). However, it turns out that Honeybadger was using the value to identify unique Users and give the count for how many Users are affected by an error. Now all our errors only show 1 User being affected by an error.

We use Devise and Warden for handling authentication on our Rails server. Honeybadger detects that and tries to use those values for identifying users. This PR will simply remove the "Warden" section of the Honeybadger error since it isn't useful for us to debug issues. The hope is that Honeybadger will then default to using `context.user_id` to identify the "Affected Users".

[Example Honeybadger error where you can see this issue](https://app.honeybadger.io/projects/3240/faults/121285521/01KA9WTAX9Q5X4D9QV5D8QH9NJ?page=0#notice-summary).

Fixing the "Affected Users" count is helpful because it let's the DOTD quickly triage how many users the error is affecting.

#### Here you can see there are thousand of errors but "Affected Users" is 1 and the name is "[FILTERED]"
<img width="1273" height="441" alt="Screenshot 2025-11-17 at 5 46 54 PM" src="https://github.com/user-attachments/assets/38876de7-4115-4bd7-9f6f-c709c74b510e" />

#### Here you can see where Warden sets the "user.key" to "[FILTERED]"
<img width="394" height="155" alt="Screenshot 2025-11-17 at 5 15 39 PM" src="https://github.com/user-attachments/assets/417d36b3-dc74-459f-8d40-6817507ffa45" />

## Links
* [Jira](https://codedotorg.atlassian.net/browse/P20-1715)

## Testing story
* Unit tests

## Follow-up work
* Think about a solution which would also log a unique ID for unauthenticated visitors.

## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
