### PR TITLE
disable purge cronjob

### DIFF
--- a/bin/cron/purge_expired_deleted_accounts
+++ b/bin/cron/purge_expired_deleted_accounts
@@ -3,7 +3,6 @@ require_relative 'only_one'
 abort 'Script already running' unless only_one_running?(__FILE__)
 
 require_relative '../../dashboard/config/environment'
-exit if DCDO.get('pii-scrub-enabled', false)
 
 #
 # purge_expired_deleted_accounts

--- a/cookbooks/cdo-apps/templates/default/crontab.erb
+++ b/cookbooks/cdo-apps/templates/default/crontab.erb
@@ -139,11 +139,9 @@
       cronjob at:'*/1 * * * *', do:deploy_dir('bin', 'cron', 'form_geos')
       cronjob at:'*/1 * * * *', do:deploy_dir('bin', 'cron', 'user_geos')
       cronjob at:'0 9 * * 5', do:deploy_dir('bin', 'cron', 'create_rollup_tables')
-      cronjob at:"0 8 * * *", do:deploy_dir('bin', 'cron', 'purge_expired_deleted_accounts')
       cronjob at:'0 4 * * 0', do:deploy_dir('bin', 'cron', 'update_project_count')
 
-      # Scrub PII from expired deleted accounts nightly at 8:00 AM UTC. Currently relies on the
-      # DCDO flag pii-scrub-enabled in order to run.
+      # Scrub PII from expired deleted accounts nightly at 8:00 AM UTC.
       cronjob at:"0 8 * * *", do:"#{deploy_dir('bin', 'cron', 'perform_job')} User::PiiScrubberJob"
     end
   end

--- a/dashboard/app/jobs/user/pii_scrubber_job.rb
+++ b/dashboard/app/jobs/user/pii_scrubber_job.rb
@@ -3,7 +3,6 @@
 # This renders the accounts unrecoverable but retains as much useful non-PII data as possible.
 class User::PiiScrubberJob < ApplicationJob
   def perform(dry_run: false, deleted_since: nil, limit: nil)
-    return unless DCDO.get('pii-scrub-enabled', false)
     ExpiredDeletedAccountPiiScrubber.new(dry_run:, deleted_since:, limit:).call
   end
 end


### PR DESCRIPTION
The PII scrubber has been performing fine for a month now. Logs are confirmed to be working. This PR removes the crontab entry for the expired_deleted_account_purger, and the DCDO flag we were using to toggle between it and the PII scrubber.

## Links
[JIRA](https://codedotorg.atlassian.net/browse/P20-1496)

## Testing story
<!--  Does your change include appropriate tests?
      - If so, please describe how the tests included in this PR are sufficient.
      - If not, please explain why this change does not need to be tested. -->



## Deployment strategy
<!--  Any special steps required to deploy this, besides merging?
      - Are there database migrations or manual steps?
      - Does this require coordination with other teams or systems? -->



## Follow-up work
<!--  List any clean-up or technical debt that will be addressed in future work.
      - Include Jira links where applicable.
      - Are there any known limitations or improvements planned? -->



## Privacy
<!--  How does this change impact Student & Teacher privacy?
      - Does this collect, use, share, or modify PII, either new or existing? -->



## Security
<!--  How does this change impact our security surface-area?
      - Do API's touched have the right auth?
      - Do infra changes impact our attack surface or encryption?
-->



## Caching
<!--  How does this change impact caching behavior?
      - Are cache keys or invalidation strategies affected?
      - Will this require cache warming or invalidation after deployment? -->



## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
