### PR TITLE
hoai2025: remix multi-project

### DIFF
--- a/apps/src/bubbleChoice/customModes/MusicDanceAi/MusicDanceAi.tsx
+++ b/apps/src/bubbleChoice/customModes/MusicDanceAi/MusicDanceAi.tsx
@@ -26,7 +26,7 @@ import Loading from '@cdo/apps/lab2/views/Loading';
 import {getTypedKeys} from '@cdo/apps/types/utils';
 import HttpClient from '@cdo/apps/util/HttpClient';
 import {useAppDispatch, useAppSelector} from '@cdo/apps/util/reduxHooks';
-import {trySetLocalStorage} from '@cdo/apps/utils';
+import {trySetSessionStorage} from '@cdo/apps/utils';
 import DancerIcon from '@cdo/static/dance/mixMoveAi/design.svg';
 import MusicIcon from '@cdo/static/dance/mixMoveAi/mix.svg';
 import DanceIcon from '@cdo/static/dance/mixMoveAi/move.svg';
@@ -169,7 +169,7 @@ const MusicDanceAi: React.FC<MusicDanceAiProps> = ({
         if (channel.subprojects) {
           channelId = channel.subprojects.find(
             ({level_id}) => level_id.toString() === sublevel.level_id
-          )?.project_id;
+          )?.channel_id;
         } else if (channel.labConfig) {
           // Otherwise, check labConfig for cases where we've transitioned from a script level.
           channelId = channel.labConfig[tab]?.channelId;
@@ -201,7 +201,7 @@ const MusicDanceAi: React.FC<MusicDanceAiProps> = ({
           tab === Tab.Dancer &&
           (sources as DanceProjectSources)?.generatedDancer
         ) {
-          trySetLocalStorage(
+          trySetSessionStorage(
             GENERATED_DANCER_STORAGE_KEY,
             JSON.stringify((sources as DanceProjectSources).generatedDancer)
           );
@@ -235,7 +235,7 @@ const MusicDanceAi: React.FC<MusicDanceAiProps> = ({
     }
     // Update the parent channel with sublevel channel IDs once we've loaded everything.
     const updatedLabConfig: {[key: string]: {channelId: string}} = {};
-    const updatedSubprojects: {level_id: number; project_id: string}[] = [];
+    const updatedSubprojects: {level_id: number; channel_id: string}[] = [];
 
     for (const tab of getTypedKeys(tabDataMap)) {
       const data = tabDataMap[tab];
@@ -245,7 +245,7 @@ const MusicDanceAi: React.FC<MusicDanceAiProps> = ({
       updatedLabConfig[tab] = {channelId: data.projectManager.getChannelId()};
       updatedSubprojects.push({
         level_id: data.levelProperties.id,
-        project_id: data.projectManager.getChannelId(),
+        channel_id: data.projectManager.getChannelId(),
       });
       data.projectManager?.addSaveSuccessListener(() => {
         Lab2Registry.getInstance()

--- a/apps/src/lab2/types.ts
+++ b/apps/src/lab2/types.ts
@@ -47,7 +47,7 @@ export interface Channel {
   thumbnailUrl?: string;
   frozen?: boolean;
   // Certain project types (like bubble choice standalone projects) can have subprojects.
-  subprojects?: {level_id: number; project_id: string}[];
+  subprojects?: {level_id: number; channel_id: string}[];
   // Optional lab-specific configuration for this project.  If provided, this will be saved
   // to the Project model in the database along with the other entries in this interface,
   // inside the value field JSON.

--- a/dashboard/app/controllers/projects_controller.rb
+++ b/dashboard/app/controllers/projects_controller.rb
@@ -324,10 +324,10 @@ class ProjectsController < ApplicationController
     # Bubble Choice standalone project types allow multiple sub-projects to be associated with one parent project.
     # Create new projects for each sublevel
     if @level.is_a?(BubbleChoice)
-      project_data[:subprojects] =  @level.sublevels.map do |sublevel|
+      project_data[:subprojects] = @level.sublevels.map do |sublevel|
         {
           level_id: sublevel.id,
-          project_id: ChannelToken.create_channel(
+          channel_id: ChannelToken.create_channel(
             request.ip,
             Projects.new(get_storage_id),
             data: {hidden: true},
@@ -529,27 +529,31 @@ class ProjectsController < ApplicationController
   def remix
     return if redirect_under_13_without_tos_teacher(@level)
     src_channel_id = params[:channel_id]
-    begin
-      _, remix_parent_id = storage_decrypt_channel_id(src_channel_id)
-    rescue ArgumentError, OpenSSL::Cipher::CipherError
-      return head :bad_request
-    end
     project_type = params[:key]
     return head :forbidden if Projects.in_restricted_share_mode(src_channel_id, project_type)
 
-    new_channel_id = ChannelToken.create_channel(
-      request.ip,
-      Projects.new(get_storage_id),
-      src: src_channel_id,
-      type: project_type,
-      remix_parent_id: remix_parent_id,
-    )
-    AssetBucket.new.copy_files src_channel_id, new_channel_id if uses_asset_bucket?(project_type)
-    AssetBucket.new.copy_level_starter_assets src_channel_id, new_channel_id if uses_starter_assets?(project_type)
-    animation_list = uses_animation_bucket?(project_type) ? AnimationBucket.new.copy_files(src_channel_id, new_channel_id) : []
-    SourceBucket.new.remix_source src_channel_id, new_channel_id, animation_list
-    FileBucket.new.copy_files src_channel_id, new_channel_id if uses_file_bucket?(project_type)
+    new_channel_id = remix_project(src_channel_id, project_type)
+
+    project = Projects.new(get_storage_id)
+    src_project = project.get(src_channel_id)
+    # If this project has subprojects, remix each subproject and update the parent channel.
+    if src_project["subprojects"]
+      new_subprojects = src_project["subprojects"].map do |entry|
+        subproject_src_channel_id = entry['channel_id']
+        subproject = project.get(subproject_src_channel_id)
+        new_subproject_channel_id = remix_project(subproject_src_channel_id, subproject["projectType"], is_subproject: true)
+        {level_id: entry['level_id'], channel_id: new_subproject_channel_id}
+      end
+      value = project.get(new_channel_id)
+      project.update(
+        new_channel_id,
+        value.merge("subprojects" => new_subprojects),
+        request.ip
+      )
+    end
     redirect_to action: 'edit', channel_id: new_channel_id
+  rescue ArgumentError, OpenSSL::Cipher::CipherError
+    return head :bad_request
   end
 
   # GET /projects/:project_type/:channel_id/submission_status
@@ -813,6 +817,29 @@ class ProjectsController < ApplicationController
       )
       raise ZendeskError.new(response.code, response.body) unless response.success?
     end
+  end
+
+  # Creates a remix of the given project. Creates a new channel and copies over all project data.
+  private def remix_project(src_channel_id, project_type, is_subproject: false)
+    _, remix_parent_id = storage_decrypt_channel_id(src_channel_id)
+    project = Projects.new(get_storage_id)
+    new_channel_id = ChannelToken.create_channel(
+      request.ip,
+      project,
+      src: src_channel_id,
+      type: project_type,
+      remix_parent_id: remix_parent_id,
+      standalone: !is_subproject,
+      hidden: is_subproject
+    )
+
+    AssetBucket.new.copy_files src_channel_id, new_channel_id if uses_asset_bucket?(project_type)
+    AssetBucket.new.copy_level_starter_assets src_channel_id, new_channel_id if uses_starter_assets?(project_type)
+    animation_list = uses_animation_bucket?(project_type) ? AnimationBucket.new.copy_files(src_channel_id, new_channel_id) : []
+    SourceBucket.new.remix_source src_channel_id, new_channel_id, animation_list
+    FileBucket.new.copy_files src_channel_id, new_channel_id if uses_file_bucket?(project_type)
+
+    new_channel_id
   end
 end
 

--- a/dashboard/app/controllers/projects_controller.rb
+++ b/dashboard/app/controllers/projects_controller.rb
@@ -541,7 +541,9 @@ class ProjectsController < ApplicationController
       new_subprojects = src_project["subprojects"].map do |entry|
         subproject_src_channel_id = entry['channel_id']
         subproject = project.get(subproject_src_channel_id)
-        new_subproject_channel_id = remix_project(subproject_src_channel_id, subproject["projectType"], is_subproject: true)
+        subproject_type = subproject["projectType"]
+        return head :forbidden if Projects.in_restricted_share_mode(subproject_src_channel_id, subproject_type)
+        new_subproject_channel_id = remix_project(subproject_src_channel_id, subproject_type, is_subproject: true)
         {level_id: entry['level_id'], channel_id: new_subproject_channel_id}
       end
       value = project.get(new_channel_id)

--- a/dashboard/app/models/channel_token.rb
+++ b/dashboard/app/models/channel_token.rb
@@ -84,10 +84,10 @@ class ChannelToken < ApplicationRecord
   # @param [Hash] data Data to store in the channel.
   # @param [String] src Optional source channel to copy data from, instead of
   #   using the value from the `data` param.
-  def self.create_channel(ip, project, data: {}, src: nil, type: nil, remix_parent_id: nil, standalone: true, level: nil)
+  def self.create_channel(ip, project, data: {}, src: nil, type: nil, remix_parent_id: nil, standalone: true, level: nil, hidden: false)
     if src
       data = project.get(src)
-      data.merge!(name: "Remix: #{data['name']}", hidden: false, frozen: false)
+      data.merge!(name: "Remix: #{data['name']}", hidden: hidden, frozen: false)
     end
 
     timestamp = Time.now

--- a/dashboard/app/models/game.rb
+++ b/dashboard/app/models/game.rb
@@ -209,6 +209,10 @@ class Game < ApplicationRecord
     @@game_sketchlab ||= find_by_name("Sketchlab")
   end
 
+  def self.bubble_choice
+    @@game_bubble_choice ||= find_by_name("BubbleChoice")
+  end
+
   def unplugged?
     app == UNPLUG
   end

--- a/dashboard/test/factories/factories.rb
+++ b/dashboard/test/factories/factories.rb
@@ -1088,6 +1088,17 @@ FactoryBot.define do
     level_num {'custom'}
   end
 
+  factory :music_dance_ai, parent: :bubble_choice_level do
+    sequence(:name) {|n| "Music_Dance_AI_Level_#{n}"}
+    sublevels do
+      [
+        create(:dance, name: 'Generate Dancer'),
+        create(:music, name: 'Generate Music'),
+        create(:dance, name: 'Generate Dance')
+      ]
+    end
+  end
+
   factory :block do
     transient do
       sequence(:index)

--- a/dashboard/test/integration/remix_test.rb
+++ b/dashboard/test/integration/remix_test.rb
@@ -126,6 +126,30 @@ class RemixTest < ActionDispatch::IntegrationTest
     assert_only_remixes_sources_assets_starter_assets 'javalab'
   end
 
+  test 'music_dance_ai remixes subprojects' do
+    project_type = 'music_dance_ai'
+    stub_project_level project_type
+    original_channel_id = create_a_new_project project_type
+
+    project = Projects.new(get_storage_id)
+    src_subprojects = project.get(original_channel_id)["subprojects"]
+    assert_equal src_subprojects.length, 3
+
+    SourceBucket.any_instance.expects(:remix_source).times(4)
+
+    new_channel_id = remix_a_project project_type, original_channel_id
+    refute_equal original_channel_id, new_channel_id
+
+    assert_is_remix(new_channel_id, original_channel_id)
+
+    remix_subprojects = project.get(new_channel_id)["subprojects"]
+    assert_equal remix_subprojects.length, 3
+    remix_subprojects.each do |entry|
+      src_subproject_channel_id = src_subprojects.find {|sp| sp["level_id"] == entry["level_id"]}["channel_id"]
+      assert_is_remix(entry["channel_id"], src_subproject_channel_id)
+    end
+  end
+
   def assert_only_remixes_sources(project_type)
     stub_project_level project_type
     original_channel_id = create_a_new_project project_type
@@ -207,6 +231,10 @@ class RemixTest < ActionDispatch::IntegrationTest
 
     get "/projects/#{project_type}/#{original_channel_id}/remix"
     assert_response :forbidden
+  end
+
+  def assert_is_remix(new_channel_id, src_channel_id)
+    assert_equal Projects.remix_ancestry(new_channel_id).first, src_channel_id
   end
 
   private def stub_project_level(type)


### PR DESCRIPTION
Enables remixing standalone projects with subprojects (introduced in ), used in the Hour of AI freeplay and standalone levels.

The challenge here is that these special level types contain multiple levels and projects at once (here, a Generate Dancer, Music, and Generate Dance project/level). When remixing, we have to make sure to not only remix the parent, but remix each of the children channels, and maintain the correct relationship between the newly created parent channel and each of the newly created child channels. There is also some special consideration for how we read and overwrite the channel's `labConfig` value - when remixing, we want to treat the channel's `subproject`s as the source of truth, since the value of `labConfig` will be out of date. When loading the remixed project for the first time, we overwrite the project's `labConfig` with the new tab -> channel ID mapping.

Also fixes a minor regression with the conversion to session storage from local storage.

## Links

- Jira: https://codedotorg.atlassian.net/browse/LABS-1694

## Testing story
Tested locally with remixing freeplay and standalone projects + unit test.