### PR TITLE
Add /promote/stats to router

### DIFF
--- a/aws/cloudformation/lambdas/marketing-router/index.js
+++ b/aws/cloudformation/lambdas/marketing-router/index.js
@@ -788,6 +788,7 @@ const marketingPaths = {
   "/about/impact-report": true,
   "/news/fetc": true,
   "/mix-move-ai": true,
+  "/promote/stats": true,
 }
 
 const pathPatterns = [


### PR DESCRIPTION
Redirect to `/promote` as per [slack](https://codedotorg.slack.com/archives/C08S81DAPD2/p1761066060142699?thread_ts=1761063043.432029&cid=C08S81DAPD2)