### PR TITLE
CMS-553: Enable `/certificates/:session_id` in Marketing router

### DIFF
--- a/aws/cloudformation/lambdas/marketing-router/index.js
+++ b/aws/cloudformation/lambdas/marketing-router/index.js
@@ -795,6 +795,7 @@ const pathPatterns = [
   /^\/_next\/static\//, // Next.js static assets
   /^\/_next\/image/,  // Next.js dynamic images, /_next/image*
   /^\/api\/hour\//,     // /api/hour/*
+  /^\/certificates\//,  // /certificates/*
   /^\/congrats\//,      // /congrats/*
   /^\/forms\//,         // /forms/*
   /^\/schools\//,       // /schools/*


### PR DESCRIPTION
## Links
- JIRA task: [CMS-553](https://codedotorg.atlassian.net/browse/CMS-553)
- Related PRs: 
  1. https://github.com/code-dot-org/code-dot-org/pull/69408
  2. https://github.com/code-dot-org/marketing-sites/pull/8