### PR TITLE
hoai2025: share

### DIFF
--- a/apps/src/dance/lab2/views/DanceShare.tsx
+++ b/apps/src/dance/lab2/views/DanceShare.tsx
@@ -69,13 +69,13 @@ const DanceShare: React.FC<DanceShareProps> = props => {
           moduleStyles.share
         )}
       >
-        <div className={moduleStyles.header}>
-          <Heading3 className={moduleStyles.projectTitle}>
-            {projectTitle}
-          </Heading3>
-          <img src={mixMoveAiBanner} alt="Mix & Move with AI" />
-        </div>
         <div id={props.visualizationId} className={moduleStyles.visualization}>
+          <div className={moduleStyles.header}>
+            <Heading3 className={moduleStyles.projectTitle}>
+              {projectTitle}
+            </Heading3>
+            <img src={mixMoveAiBanner} alt="Mix & Move with AI" />
+          </div>
           {usingMusicProject && (
             <MusicProjectBar
               isLoading={!loadedMusicProject}

--- a/apps/src/dance/lab2/views/dance-view.module.scss
+++ b/apps/src/dance/lab2/views/dance-view.module.scss
@@ -22,14 +22,22 @@
         display: flex;
         justify-content: space-between;
         align-items: center;
+        position: absolute;
+        width: calc(100% - 8px);
+        padding: 0 10px;
+        box-sizing: border-box;
+        background-color: rgba(255 255 255 / 0.1);
+        border-radius: 4px;
+        margin: 4px;
 
-        > h3 {
+        >h3 {
           margin: 0;
           text-overflow: ellipsis;
           overflow: hidden;
           white-space: nowrap;
         }
-        > img {
+
+        >img {
           height: 70px;
         }
       }
@@ -142,19 +150,29 @@
 
 .timelineContainer {
   height: 150px;
+  display: none;
+}
+
+/* With the logo pinned in the upper-left, and the language selector in the
+ * lower-left, there is room for the timeline on taller screens when those items
+ * are above and below the share UI, and on slightly shorter screens with extra
+ * width so they can sit beside the share UI.
+ */
+@media screen and (min-height: 800px),
+screen and (min-height: 720px) and (min-width: 970px) {
+  .timelineContainer {
+    display: initial;
+  }
 }
 
 .musicProjectOverlay {
   position: absolute;
-  bottom: 4px;
+  bottom: 0;
   right: 4px;
   left: 4px;
   border-radius: 4px;
-  background-color: color-mix(
-    in srgb,
-    var(--background-neutral-tertiary),
-    transparent 50%
-  );
+  background-color: rgba(255 255 255 / 0.1);
+  border: none;
 }
 
 .actionBar {


### PR DESCRIPTION
This makes a few tweaks suggested by @sanchitmalhotra126 to the nice share UI built in https://github.com/code-dot-org/code-dot-org/pull/69425.  

Notably, the timeline is hidden on smaller displays, and the header text & logo are moved into the dance visualization.

### With timeline

<img width="753" height="842" alt="Screenshot 2025-11-18 at 8 01 59 PM" src="https://github.com/user-attachments/assets/1232504d-3623-43ad-a8df-fcf80532cc18" />

### Without timeline

<img width="753" height="785" alt="Screenshot 2025-11-18 at 8 12 06 PM" src="https://github.com/user-attachments/assets/255f7ef9-dd65-488a-b3bb-76d6dbd9a42b" />

