### PR TITLE
Migration to add script column to AI lesson summaries table

### DIFF
--- a/dashboard/app/models/ai_lesson_summary.rb
+++ b/dashboard/app/models/ai_lesson_summary.rb
@@ -8,6 +8,7 @@
 #  lesson_summary :text(65535)
 #  created_at     :datetime         not null
 #  updated_at     :datetime         not null
+#  script         :text(65535)
 #
 class AiLessonSummary < ApplicationRecord
   belongs_to :user

--- a/dashboard/db/migrate/20251119161129_add_script_to_ai_lesson_summary_table.rb
+++ b/dashboard/db/migrate/20251119161129_add_script_to_ai_lesson_summary_table.rb
@@ -1,0 +1,5 @@
+class AddScriptToAiLessonSummaryTable < ActiveRecord::Migration[6.1]
+  def change
+    add_column :ai_lesson_summaries, :script, :text
+  end
+end

--- a/dashboard/db/schema.rb
+++ b/dashboard/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2025_11_14_201207) do
+ActiveRecord::Schema.define(version: 2025_11_19_161129) do
 
   create_table "activities", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "user_id"
@@ -59,6 +59,7 @@ ActiveRecord::Schema.define(version: 2025_11_14_201207) do
     t.text "lesson_summary"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.text "script"
   end
 
   create_table "ai_tutor_interaction_feedbacks", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|


### PR DESCRIPTION
This update adds a text column for storing AI generated podcast scripts to the ai_lesson_summaries table.

## Links
<!--  Links to relevant external resources.
      - spec docs, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- Jira: [AITT-1304](https://codedotorg.atlassian.net/browse/AITT-1304)

## Testing story
<!--  Does your change include appropriate tests?
      - If so, please describe how the tests included in this PR are sufficient.
      - If not, please explain why this change does not need to be tested. -->



## Deployment strategy
<!--  Any special steps required to deploy this, besides merging?
      - Are there database migrations or manual steps?
      - Does this require coordination with other teams or systems? -->



## Follow-up work
<!--  List any clean-up or technical debt that will be addressed in future work.
      - Include Jira links where applicable.
      - Are there any known limitations or improvements planned? -->



## Privacy
<!--  How does this change impact Student & Teacher privacy?
      - Does this collect, use, share, or modify PII, either new or existing? -->



## Security
<!--  How does this change impact our security surface-area?
      - Do API's touched have the right auth?
      - Do infra changes impact our attack surface or encryption?
-->



## Caching
<!--  How does this change impact caching behavior?
      - Are cache keys or invalidation strategies affected?
      - Will this require cache warming or invalidation after deployment? -->



## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
