### PR TITLE
Lab2: fixes spacing between version history rows

### DIFF
--- a/apps/src/lab2/views/components/Instructions/ResourcePanel/VersionHistory/version-history-panel.module.scss
+++ b/apps/src/lab2/views/components/Instructions/ResourcePanel/VersionHistory/version-history-panel.module.scss
@@ -38,6 +38,12 @@
   min-height: 0;
   position: relative;
   padding-bottom: 0.625rem;
+
+  /* Add extra space after the second to last row
+  to add more space above the initial version row */
+  & > div:nth-last-child(2) {
+    margin-bottom: 1rem;
+  }
 }
 
 .listFooter {

--- a/apps/src/lab2/views/components/Instructions/ResourcePanel/VersionHistory/version-history-row.module.scss
+++ b/apps/src/lab2/views/components/Instructions/ResourcePanel/VersionHistory/version-history-row.module.scss
@@ -8,9 +8,14 @@
   border-radius: var(--border-radius-br-s, 4px);
   border: 1px solid var(--borders-neutral-primary);
   background: var(--background-neutral-secondary);
+  margin-block: 0 0.5rem;
   margin-inline: 0.625rem;
   position: relative;
   z-index: 1;
+
+  &:has(.commitDescription) {
+    margin-block: 0.625rem;
+  }
 }
 
 .row {
@@ -18,7 +23,7 @@
 }
 
 .initialVersionRow {
-  margin-block: 1rem 0;
+  margin-block: 0.625rem 0;
 }
 
 .currentVersionRow {


### PR DESCRIPTION
Fixes the spacing between rows in the Version History panel.

## Links 
Jira ticket: [AFL-381](https://codedotorg.atlassian.net/browse/AFL-381)

----

## Before


https://github.com/user-attachments/assets/f52c33c9-32fd-4f4e-b68f-893647989983



## After


https://github.com/user-attachments/assets/0af4c0cd-5ef2-45e7-bdc3-8d6483a1f2b1


