### PR TITLE
feat(tutor): oneoff scripts to update levels ai_tutor_available property

### DIFF
--- a/bin/oneoff/cleanup_ai_tutor_available_booleans.rb
+++ b/bin/oneoff/cleanup_ai_tutor_available_booleans.rb
@@ -1,0 +1,38 @@
+#!/usr/bin/env ruby
+
+# This script cleans all levels where ai_tutor_available was set to a boolean value
+#
+# The ai_tutor_available property is stored as the string "true"/"false" in
+# Level#properties, matching Level#ai_tutor_available?.
+#
+# This script updates each Level via save! so that after_save callbacks run
+# (specifically LevelFiles.write_custom_level_file)
+
+require_relative '../../dashboard/config/environment'
+require src_dir 'database'
+
+dry_run = ARGV.include?('--dry-run')
+
+counts = {
+  is_true: 0,
+  is_false: 0
+}
+
+time_taken = Benchmark.realtime do
+  ActiveRecord::Base.transaction do
+    # Clean up existing ai_tutor_available json booleans to strings
+    Level.where("properties->'$.ai_tutor_available' = true").find_each(batch_size: 100) do |level|
+      level.properties['ai_tutor_available'] = 'true' unless dry_run
+      level.save! unless dry_run
+      counts[:is_true] += 1
+    end
+    Level.where("properties->'$.ai_tutor_available' = false").find_each(batch_size: 100) do |level|
+      level.properties['ai_tutor_available'] = 'false' unless dry_run
+      level.save! unless dry_run
+      counts[:is_false] += 1
+    end
+  end
+end
+
+puts "It took #{time_taken} seconds to update ai_tutor_available:"
+puts "Level cleaning -> true: #{counts[:is_true]}, false: #{counts[:is_false]} levels containing boolean value rather than string value."

--- a/bin/oneoff/set_ai_tutor_available_for_csa_levels.rb
+++ b/bin/oneoff/set_ai_tutor_available_for_csa_levels.rb
@@ -12,12 +12,12 @@ count_sublevels_updated = 0
 time_taken = Benchmark.realtime do
   ActiveRecord::Base.transaction do
     Level.includes(:script_levels).all.select {|level| level.script_levels.any? {|sl| sl.script.csa?}}.each do |csa_level|
-      csa_level.properties["ai_tutor_available"] = true
+      csa_level.properties["ai_tutor_available"] = 'true'
       csa_level.save!
       sublevel_ids = ParentLevelsChildLevel.where(parent_level: csa_level).pluck(:child_level_id)
       sublevels = Level.where(id: sublevel_ids)
       sublevels.each do |sublevel|
-        sublevel.properties["ai_tutor_available"] = true
+        sublevel.properties["ai_tutor_available"] = 'true'
         sublevel.save!
         count_sublevels_updated += 1
       end

--- a/bin/oneoff/set_ai_tutor_available_for_pilot_levels.rb
+++ b/bin/oneoff/set_ai_tutor_available_for_pilot_levels.rb
@@ -1,0 +1,97 @@
+#!/usr/bin/env ruby
+
+# This script updates the ai_tutor_available property for levels:
+#   * Sets ai_tutor_available to "false" for all CSA levels and their sublevels
+#   * Sets ai_tutor_available to "true" for CSD 2025 levels and their sublevels
+#   * Sets ai_tutor_available to "true" for AIF 2025 Unit 2 levels and their sublevels
+#   * Sets ai_tutor_available to "true" for some specific standalone projects
+#
+# The ai_tutor_available property is stored as the string "true"/"false" in
+# Level#properties, matching Level#ai_tutor_available?.
+#
+# This script updates each Level via save! so that after_save callbacks run
+# (specifically LevelFiles.write_custom_level_file)
+
+require_relative '../../dashboard/config/environment'
+require src_dir 'database'
+
+dry_run = ARGV.include?('--dry-run')
+
+CSA_UMBRELLA = Curriculum::SharedCourseConstants::CURRICULUM_UMBRELLA.CSA
+
+def update_levels_and_sublevels(level_scope, ai_value, counts, key, dry_run)
+  level_ids = level_scope.distinct.pluck(:id)
+  sublevel_ids = ParentLevelsChildLevel.where(parent_level_id: level_ids).pluck(:child_level_id).uniq
+
+  Level.where(id: level_ids).find_each(batch_size: 100) do |level|
+    next if level.properties['ai_tutor_available'] == ai_value
+
+    level.properties['ai_tutor_available'] = ai_value unless dry_run
+    level.save! unless dry_run
+    counts[key][:levels] += 1
+  end
+
+  Level.where(id: sublevel_ids).find_each(batch_size: 100) do |sublevel|
+    next if sublevel.properties['ai_tutor_available'] == ai_value
+
+    sublevel.properties['ai_tutor_available'] = ai_value unless dry_run
+    sublevel.save! unless dry_run
+    counts[key][:sublevels] += 1
+  end
+end
+
+counts = {
+  csa: {levels: 0, sublevels: 0},
+  csd: {levels: 0, sublevels: 0},
+  aif_unit2: {levels: 0, sublevels: 0},
+  standalone: {levels: 0, sublevels: 0},
+}
+
+time_taken = Benchmark.realtime do
+  ActiveRecord::Base.transaction do
+    # CSA: set ai_tutor_available to "false" on levels and sublevels
+    csa_unit_ids = Unit.where("properties -> '$.curriculum_umbrella' = ?", CSA_UMBRELLA).pluck(:id)
+    csa_levels = Level.joins(:script_levels).where(script_levels: {script_id: csa_unit_ids})
+    update_levels_and_sublevels(csa_levels, 'false', counts, :csa, dry_run)
+
+    # CSD: set ai_tutor_available to "true" on levels and sublevels
+    csd_unit_ids = Unit.where(name: %w(
+                                csd1-2025
+                                csd2-2025
+                                csd3-2025
+                                csd4-2025
+                                csd5-2025
+                                csd6a-2025
+                                csd6b-2025
+                                csd7-2025
+                                programming-with-music-lab-2025
+                              )
+).pluck(:id)
+    csd_levels = Level.joins(:script_levels).where(script_levels: {script_id: csd_unit_ids})
+    update_levels_and_sublevels(csd_levels, 'true', counts, :csd, dry_run)
+
+    # AIF Unit 2: set ai_tutor_available to "true" on levels and sublevels
+    aif_unit2_ids = Unit.
+      where(name: 'aif2-2025').
+      pluck(:id)
+    aif_unit2_levels = Level.joins(:script_levels).where(script_levels: {script_id: aif_unit2_ids})
+    update_levels_and_sublevels(aif_unit2_levels, 'true', counts, :aif_unit2, dry_run)
+
+    # Standalone projects: set ai_tutor_available to "true" on levels and sublevels
+    standalone_project_levels = Level.where(name: [
+                                              'New App Lab Project',
+                                              'New Game Lab Project',
+                                              'New Web Lab Project',
+                                              'New Python Lab Project',
+                                              'New Web Lab 2 Project',
+                                            ]
+)
+    update_levels_and_sublevels(standalone_project_levels, 'true', counts, :standalone, dry_run)
+  end
+end
+
+puts "It took #{time_taken} seconds to update ai_tutor_available:"
+puts "CSA -> \"false\" for #{counts[:csa][:levels]} levels and #{counts[:csa][:sublevels]} sublevels."
+puts "CSD -> \"true\" for #{counts[:csd][:levels]} levels and #{counts[:csd][:sublevels]} sublevels."
+puts "AIF U2 -> \"true\" for #{counts[:aif_unit2][:levels]} levels and #{counts[:aif_unit2][:sublevels]} sublevels."
+puts "Standalone -> \"true\" for #{counts[:standalone][:levels]} levels and #{counts[:standalone][:sublevels]} sublevels."

--- a/dashboard/app/models/levels/level.rb
+++ b/dashboard/app/models/levels/level.rb
@@ -520,7 +520,7 @@ class Level < ApplicationRecord
   end
 
   def ai_tutor_available?
-    properties["ai_tutor_available"] == "true"
+    properties["ai_tutor_available"] == "true" || properties["ai_tutor_available"] == true
   end
 
   def summarize


### PR DESCRIPTION
This pr includes two one off scripts that will be called on the levelbuilder server to update levels in the database and in the level files. 

- `cleanup_ai_tutor_available_booleans` should be run first
  - cleans some mis-typed json values in `levels.properties`
  - `ai_tutor_available` property should be a string literal ("true" or "false") to match updates made through the level edit form. There are 6771 boolean values for this property that need to be updated
  - companion changes related to this:
    -  in the level model to check for string "true" or boolean true, just to avoid a future issue since it's not intuitive that we're storing booleans as string literals
    - the one off script that I suspect set the boolean values has been updated to set string values in case it's used or referenced in the future

- `set_ai_tutor_available_for_pilot_levels` should be run second
  - turns off `ai_tutor_available` for CSA levels by setting them to "false"
  - turns on `ai_tutor_available` for CSD 2025 levels by setting them to "true"
  - turns on `ai_tutor_available` for AIF unit 2 levels by setting them to "true"
  - turns on `ai_tutor_available` for specific standalone project levels whose lab supports ai tutor by setting them to "true"


## Links
<!--  Links to relevant external resources.
      - spec docs, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- Jira: https://codedotorg.atlassian.net/browse/LABS-1713
- Slack: https://codedotorg.slack.com/archives/C08S29NDZ5E/p1763151455244129

## Testing story
<!--  Does your change include appropriate tests?
      - If so, please describe how the tests included in this PR are sufficient.
      - If not, please explain why this change does not need to be tested. -->
ran both scripts locally after seeding levels

cleaning levels with boolean values took 28 minutes
```
It took 1710.203978000005 seconds to update ai_tutor_available:
Level cleaning -> true: 6771, false: 0 levels containing boolean value rather than string value.
```

setting ai_tutor_available took 20 minutes
```
It took 1230.3379669999995 seconds to update ai_tutor_available:
CSA -> "false" for 2433 levels and 3872 sublevels.
CSD -> "true" for 696 levels and 744 sublevels.
AIF U2 -> "true" for 73 levels and 140 sublevels.
Standalone -> "true" for 5 levels and 0 sublevels.
```

running both resulted in 9189 level files with changes needing to be committed

## Deployment strategy
<!--  Any special steps required to deploy this, besides merging?
      - Are there database migrations or manual steps?
      - Does this require coordination with other teams or systems? -->

- ssh into levelbuilder server
- run cleanup script
- run level update script
- commit level file changes to levelbuilder branch
- let the changes get to staging in the overnight scoop


## Follow-up work
<!--  List any clean-up or technical debt that will be addressed in future work.
      - Include Jira links where applicable.
      - Are there any known limitations or improvements planned? -->



## Privacy
<!--  How does this change impact Student & Teacher privacy?
      - Does this collect, use, share, or modify PII, either new or existing? -->



## Security
<!--  How does this change impact our security surface-area?
      - Do API's touched have the right auth?
      - Do infra changes impact our attack surface or encryption?
-->



## Caching
<!--  How does this change impact caching behavior?
      - Are cache keys or invalidation strategies affected?
      - Will this require cache warming or invalidation after deployment? -->



## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
