### PR TITLE
Updates `preVisit` to avoid SB_PREVIEW_API_0011 errors in local runs.

### DIFF
--- a/frontend/apps/design-system-storybook/.storybook/test-runner.ts
+++ b/frontend/apps/design-system-storybook/.storybook/test-runner.ts
@@ -10,14 +10,27 @@ const DEFAULT_VIEWPORT_SIZE = {width: 1280, height: 720};
  * to learn more about the test-runner hooks API.
  */
 const config: TestRunnerConfig = {
-  async preVisit(page, story) {
+  async preVisit(page, context) {
     await injectAxe(page);
 
-    const context = await getStoryContext(page, story);
-    const viewportName = context.parameters?.viewport?.defaultViewport;
-    const viewportParameter =
-      INITIAL_VIEWPORTS[viewportName] || MINIMAL_VIEWPORTS[viewportName];
+    // Match the last bit of the Story class to the viewport type
+    // Get the viewport name that matches the built-in viewports, if
+    // that last bit is well-known
+    const storyName = context.id;
+    const viewportName = storyName.endsWith('-mobile')
+      ? 'mobile2'
+      : storyName.endsWith('-small-desktop')
+        ? 'ipad12p'
+        : storyName.endsWith('-tablet')
+          ? 'tablet'
+          : undefined;
 
+    // Get that viewport configuration
+    const viewportParameter = viewportName
+      ? INITIAL_VIEWPORTS[viewportName] || MINIMAL_VIEWPORTS[viewportName]
+      : undefined;
+
+    // If we found one, apply the viewport dimensions
     if (viewportParameter) {
       const viewportSize = Object.entries(
         viewportParameter.styles || {},
@@ -31,9 +44,10 @@ const config: TestRunnerConfig = {
         {width: 0, height: 0},
       );
 
-      page.setViewportSize(viewportSize);
+      return page.setViewportSize(viewportSize);
     } else {
-      page.setViewportSize(DEFAULT_VIEWPORT_SIZE);
+      // Otherwise, just set the viewport to the provided default
+      return page.setViewportSize(DEFAULT_VIEWPORT_SIZE);
     }
   },
   async postVisit(page, context) {


### PR DESCRIPTION
Currently, running `yarn test:ui:local` in the `design-system-storybook` package will result in a slew of errors:

```
  ● DesignSystem/Dropdown/Icon Dropdown › WithDisabledOptionIconDropdown › smoke-test

    page.evaluate: SB_PREVIEW_API_0011 (StoryStoreAccessedBeforeInitializationError): Cannot access the Story Store until the index is ready.

    It is not recommended to use methods directly on the Story Store anyway, in Storybook 9 we will
    remove access to the store entirely

      at Object.get (frontend/apps/design-system-storybook/http:/localhost:6006/sb-preview/runtime.js:41905:17)
      at __getContext (frontend/apps/design-system-storybook/<anonymous>:239:54)
      at eval (eval at evaluate (:234:30)frontend/apps/design-system-storybook/, <anonymous>:1:29)
      at UtilityScript.evaluate (frontend/apps/design-system-storybook/<anonymous>:236:17)
      at UtilityScript.<anonymous> (frontend/apps/design-system-storybook/<anonymous>:1:44)
      at getStoryContext (frontend/node_modules/@storybook/test-runner/dist/index.js:10160:15)
      at preVisit (frontend/apps/design-system-storybook/.storybook/test-runner.ts:16:42)
```

Essentially failing every test.

This is generally due to an upgrade to Storybook 9 and its wishy-washy handling of `preVisit` and `getStoryContext` where it allows a race for the ability for the latter to succeed and the page/story loading. If you try to wait for the page to load using the `waitForPageLoad` (or whatever it is), the test will just hang in the `preVisit` call apparently unable to satisfy this promise until the `preVisit` is done (you probably could wrap it such that `preVisit` completes before you are done, but I don't want to race the whole test run either... ugh)

We only needed `getStoryContext` to handle resizing the viewport for certain tests. There's no clear consensus about avoiding this issue. It is an [open bug](https://github.com/storybookjs/test-runner/issues/442) in the `storybookjs/testrunner` project.

Somewhere (now lost among dozens of tabs I had open) I found a recommendation to just use the story's name via the context id (which is a slug of the real story name, but suffices) where you look at, say, the end of the name for a well-known tag like 'Mobile', etc. That seemed reasonable as it also enforces a consistent naming for such tests that rely on screen size. So, that is the approach settled on here.

## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
