### PR TITLE
Sketch Lab: remount SourcesContainer when level ID changes

### DIFF
--- a/apps/src/sketchlab/SketchlabView.tsx
+++ b/apps/src/sketchlab/SketchlabView.tsx
@@ -246,7 +246,11 @@ const SketchlabView: React.FC<LabProps<LevelProperties>> = ({
 };
 
 export default (props: LabProps<LevelProperties>) => (
-  <SourcesContainer {...props} defaultSources={DEFAULT_SOURCES}>
+  <SourcesContainer
+    {...props}
+    defaultSources={DEFAULT_SOURCES}
+    key={props.levelProperties.id}
+  >
     <SketchlabView levelProperties={props.levelProperties} />
   </SourcesContainer>
 );


### PR DESCRIPTION
Sanchit and I were playing with project saving in Sketch Lab as you switch between levels this morning. We noticed that it is possible for sources to be accidentally overwritten by the previous level's sources if you switch quickly between levels.

This can be avoided by remounting the SourcesContainer when the level changes in order to avoid possible  tbh, I don't know that I have the right words to explain exactly why works (maybe @sanchitmalhotra126 does? 😬 )

This is a pattern that lab2 Dance (ie, the only other use of SourcesContainer) follows as well. Longer term, we may want to make this behavior a default for uses of the SourcesContainer.

## Links

- Jira: https://codedotorg.atlassian.net/browse/AFL-375

## Testing story

The easiest way to repro the issue this fixes is to remove the setTimeout wrapper from our Sketch Lab change handler, then switch back and forth between levels. You should see that the progress from the level you're changing _from_ ends up being displayed on the level you're changing _to_ (ie, it seems like a load of the new level's sources isn't happening).

Looking at the network tab, on level change, we saw a PUT happening to the "from" level's sources, then a GET of the "to" level's sources, then a subsequent PUT of the "from" level's sources to the "to" level (not what we want!).

With this change in place, we no longer see that second overriding PUT happening.

## Follow-up work

We also chatted about the complexity introduced by the file upload handing we now have to do, where we need to upload an image to S3 every time a user uploads one to their project. The most straightforward way to handle this we think is to block switching levels while an upload is in flight, such that we don't run into similar issues if you switch levels while an upload is happening. I added a follow-up ticket for that here: https://codedotorg.atlassian.net/browse/AFL-383