### PR TITLE
Disable Aurora Enhanced MySQL Binary Logging during Hour of AI

### DIFF
--- a/aws/cloudformation/components/database.yml.erb
+++ b/aws/cloudformation/components/database.yml.erb
@@ -157,7 +157,7 @@
         gtid-mode: 'ON'
         enforce_gtid_consistency: 'ON'
 
-        # Disable Enhanced Binary Logging during Hour of Code
+        # Disable Enhanced Binary Logging during Hour of AI
         aurora_enhanced_binlog: 0
         binlog_backup: 1
         binlog_replication_globaldb: 1

--- a/aws/cloudformation/components/database.yml.erb
+++ b/aws/cloudformation/components/database.yml.erb
@@ -153,7 +153,7 @@
         # BEGIN: Static configuration settings.
         # WARNING - Changing these settings triggers restart of each database instance in the cluster during Stack Update.
 
-        binlog_format: 'OFF' # Disable binary logging during Hour of Code
+        binlog_format: 'OFF' # Disable binary logging during Hour of AI
         gtid-mode: 'ON'
         enforce_gtid_consistency: 'ON'
 

--- a/aws/cloudformation/components/database.yml.erb
+++ b/aws/cloudformation/components/database.yml.erb
@@ -153,14 +153,14 @@
         # BEGIN: Static configuration settings.
         # WARNING - Changing these settings triggers restart of each database instance in the cluster during Stack Update.
 
-        binlog_format: 'ROW'
+        binlog_format: 'OFF' # Disable binary logging during Hour of Code
         gtid-mode: 'ON'
         enforce_gtid_consistency: 'ON'
 
-        # Enable Enhanced Binary Logging to support Zero-ETL Integration with Redshift
-        aurora_enhanced_binlog: 1
-        binlog_backup: 0
-        binlog_replication_globaldb: 0
+        # Disable Enhanced Binary Logging during Hour of Code
+        aurora_enhanced_binlog: 0
+        binlog_backup: 1
+        binlog_replication_globaldb: 1
         binlog_row_image: full # This is actually a dynamic setting, but let's keep all these settings together.
         binlog_row_metadata: full # Also dynamic.
 


### PR DESCRIPTION
Reverts code-dot-org/code-dot-org#62961

We don't yet use binary logging on our production database. Disable it to improve write latency during Hour of AI.

## TEST

`bundle exec rake adhoc:start RAILS_ENV=adhoc DATABASE=true STACK_NAME=adhoc-disable-binary-logging`

## DEPLOYMENT

- [ ] Merge this change to deploy to non-production Stacks (`staging`, `test`, `levelbuilder`, `adhoc-*`). It will trigger restart of all instances in the database cluster on each non-production environment.
- [ ] Manually restart production database instances to apply this change to production cluster after the change has been deployed to production and updated the production Parameter Group. To minimize downtime, we'll do this at the same time we scale up the database instance types from 8xlarge to 16xlarge