### PR TITLE
Simplify a11y testing

### DIFF
--- a/frontend/apps/design-system-storybook/.storybook/preview.js
+++ b/frontend/apps/design-system-storybook/.storybook/preview.js
@@ -26,7 +26,9 @@ const preview = {
         date: /Date$/i,
       },
     },
-
+    a11y: {
+      test: 'error',
+    },
     docs: {
       codePanel: true,
     },

--- a/frontend/apps/design-system-storybook/.storybook/test-runner.ts
+++ b/frontend/apps/design-system-storybook/.storybook/test-runner.ts
@@ -10,14 +10,27 @@ const DEFAULT_VIEWPORT_SIZE = {width: 1280, height: 720};
  * to learn more about the test-runner hooks API.
  */
 const config: TestRunnerConfig = {
-  async preVisit(page, story) {
+  async preVisit(page, context) {
     await injectAxe(page);
 
-    const context = await getStoryContext(page, story);
-    const viewportName = context.parameters?.viewport?.defaultViewport;
-    const viewportParameter =
-      INITIAL_VIEWPORTS[viewportName] || MINIMAL_VIEWPORTS[viewportName];
+    // Match the last bit of the Story class to the viewport type
+    // Get the viewport name that matches the built-in viewports, if
+    // that last bit is well-known
+    const storyName = context.id;
+    const viewportName = storyName.endsWith('-mobile')
+      ? 'mobile2'
+      : storyName.endsWith('-small-desktop')
+        ? 'ipad12p'
+        : storyName.endsWith('-tablet')
+          ? 'tablet'
+          : undefined;
 
+    // Get that viewport configuration
+    const viewportParameter = viewportName
+      ? INITIAL_VIEWPORTS[viewportName] || MINIMAL_VIEWPORTS[viewportName]
+      : undefined;
+
+    // If we found one, apply the viewport dimensions
     if (viewportParameter) {
       const viewportSize = Object.entries(
         viewportParameter.styles || {},
@@ -31,9 +44,10 @@ const config: TestRunnerConfig = {
         {width: 0, height: 0},
       );
 
-      page.setViewportSize(viewportSize);
+      return page.setViewportSize(viewportSize);
     } else {
-      page.setViewportSize(DEFAULT_VIEWPORT_SIZE);
+      // Otherwise, just set the viewport to the provided default
+      return page.setViewportSize(DEFAULT_VIEWPORT_SIZE);
     }
   },
   async postVisit(page, context) {

--- a/frontend/apps/design-system-storybook/.storybook/test-runner.ts
+++ b/frontend/apps/design-system-storybook/.storybook/test-runner.ts
@@ -1,6 +1,4 @@
 import type {TestRunnerConfig} from '@storybook/test-runner';
-import {getStoryContext} from '@storybook/test-runner';
-import {injectAxe, checkA11y} from 'axe-playwright';
 import {INITIAL_VIEWPORTS, MINIMAL_VIEWPORTS} from 'storybook/viewport';
 
 const DEFAULT_VIEWPORT_SIZE = {width: 1280, height: 720};
@@ -11,8 +9,6 @@ const DEFAULT_VIEWPORT_SIZE = {width: 1280, height: 720};
  */
 const config: TestRunnerConfig = {
   async preVisit(page, context) {
-    await injectAxe(page);
-
     // Match the last bit of the Story class to the viewport type
     // Get the viewport name that matches the built-in viewports, if
     // that last bit is well-known
@@ -49,40 +45,6 @@ const config: TestRunnerConfig = {
       // Otherwise, just set the viewport to the provided default
       return page.setViewportSize(DEFAULT_VIEWPORT_SIZE);
     }
-  },
-  async postVisit(page, context) {
-    // Get the entire context of a story, including parameters, args, argTypes, etc.
-    const storyContext = await getStoryContext(page, context);
-
-    const storyA11yConfigRules = storyContext.parameters?.a11y?.config
-      ?.rules as {id: string; enabled: boolean}[];
-    const customAxeRules = {} as {
-      [key: string]: {
-        enabled: boolean;
-      };
-    };
-
-    // If some custom a11y rules config is passed to the story - it will be automatically fetched by test runner
-    // so that CI and QA will also follow that config.
-    if (storyA11yConfigRules) {
-      storyA11yConfigRules.forEach(
-        rule => (customAxeRules[rule.id] = {enabled: rule.enabled}),
-      );
-    }
-
-    // Do not run a11y tests on disabled stories.
-    if (storyContext.parameters?.a11y?.disable) {
-      return;
-    }
-
-    await checkA11y(page, '#storybook-root', {
-      detailedReport: true,
-      verbose: false,
-      detailedReportOptions: {
-        html: true,
-      },
-      axeOptions: {rules: customAxeRules},
-    });
   },
 };
 


### PR DESCRIPTION
It is unnecessary to inject axe and call the checkA11y in Storybook 9 with the main a11y addon. So, let's remove it!

Can confirm all the a11y checks and existing parameters seem to work and it will still fail the CI if a11y checks fail.

## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
