### PR TITLE
hoai2025: standalone project updates

### DIFF
--- a/apps/src/templates/projects/projectConstants.ts
+++ b/apps/src/templates/projects/projectConstants.ts
@@ -84,6 +84,5 @@ export const PROJECT_DEFAULT_THUMBNAIL_IMAGE_OVERRIDE: {
 } = {
   music: studio('/shared/images/courses/logo_music.png'),
   pythonlab: studio('/shared/images/courses/logo_pythonlab.png'),
-  // Temporary placeholder
-  music_dance_ai: '/blockly/media/dance/placeholder.png',
+  music_dance_ai: studio('/blockly/media/dance/mix-move-ai-banner-square.png'),
 };

--- a/apps/src/templates/projects/projectTypeMap.js
+++ b/apps/src/templates/projects/projectTypeMap.js
@@ -45,7 +45,7 @@ export const PROJECT_TYPE_MAP = {
   story: i18n.projectTypeStory(),
   time_capsule: i18n.projectTypeTimeCapsule(),
   transformers: i18n.projectTypeTransformers(),
-  music_dance_ai: 'Music Dance AI Mashup',
+  music_dance_ai: 'Mix & Move with AI',
 };
 
 export const FEATURED_PROJECT_TYPE_MAP = {

--- a/apps/static/dance/mix-move-ai-banner-square.png
+++ b/apps/static/dance/mix-move-ai-banner-square.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5bc4925f1d7d5af218686ab3722c296b4aff3a2447dc48532f2f4e9b24f11e65
+size 364816

--- a/dashboard/config/levels/custom/music/Music AI Subproject.level
+++ b/dashboard/config/levels/custom/music/Music AI Subproject.level
@@ -14,8 +14,78 @@
     "disable_edit_run_for_submission": "false",
     "level_data": {
       "library": "launch2024",
-      "aiCodeGenerateAdlib": "length",
-      "guideMode": "aiCodeGenerate"
+      "allowChangeStartingPlayheadPosition": true,
+      "guideMode": "aiCodeGenerate",
+      "aiCodeGenerateAdlib": {
+        "id": "sounds",
+        "template": "Code a {mood} music mix with a {length} length, using {drums} drums.",
+        "options": {
+          "mood": [
+            {
+              "id": "simple",
+              "text": "simple"
+            },
+            {
+              "id": "creative",
+              "text": "creative"
+            },
+            {
+              "id": "wild",
+              "text": "wild"
+            }
+          ],
+          "length": [
+            {
+              "id": "short",
+              "text": "short"
+            },
+            {
+              "id": "medium",
+              "text": "medium"
+            },
+            {
+              "id": "long",
+              "text": "long"
+            }
+          ],
+          "drums": [
+            {
+              "id": "original",
+              "text": "original"
+            },
+            {
+              "id": "electro",
+              "text": "electro"
+            },
+            {
+              "id": "groove",
+              "text": "groove"
+            },
+            {
+              "id": "indie",
+              "text": "indie"
+            },
+            {
+              "id": "pop",
+              "text": "pop"
+            },
+            {
+              "id": "hiphop",
+              "text": "hip hop"
+            },
+            {
+              "id": "rock",
+              "text": "heavy rock"
+            },
+            {
+              "id": "acoustic",
+              "text": "acoustic"
+            }
+          ]
+        },
+        "variantCount": 10
+      },
+      "aiCodeGenerateExtraPrompt": "You can also use any of the following additional drum sounds: \"{drumSounds}\"."
     },
     "predict_settings": {
       "isPredictLevel": false
@@ -29,7 +99,7 @@
     "display_name": "Create a song!",
     "preload_asset_list": null
   },
-  "audit_log": "[{\"changed_at\":\"2025-09-18T17:51:22.247+00:00\",\"changed\":[\"cloned from \\\"New Music AI Project\\\"\"],\"cloned_from\":\"New Music AI Project\"},{\"changed_at\":\"2025-09-18 17:52:09 +0000\",\"changed\":[\"predict_settings\"],\"changed_by_id\":1,\"changed_by_email\":\"sanchit+localhost@code.org\"},{\"changed_at\":\"2025-10-23 18:42:31 +0000\",\"changed\":[\"level_data\",\"predict_settings\"],\"changed_by_id\":1,\"changed_by_email\":\"sanchit+localhost@code.org\"}]"
+  "audit_log": "[{\"changed_at\":\"2025-09-18T17:51:22.247+00:00\",\"changed\":[\"cloned from \\\"New Music AI Project\\\"\"],\"cloned_from\":\"New Music AI Project\"},{\"changed_at\":\"2025-09-18 17:52:09 +0000\",\"changed\":[\"predict_settings\"],\"changed_by_id\":1,\"changed_by_email\":\"sanchit+localhost@code.org\"},{\"changed_at\":\"2025-10-23 18:42:31 +0000\",\"changed\":[\"level_data\",\"predict_settings\"],\"changed_by_id\":1,\"changed_by_email\":\"sanchit+localhost@code.org\"},{\"changed_at\":\"2025-11-19 21:42:55 +0000\",\"changed\":[\"predict_settings\"],\"changed_by_id\":1,\"changed_by_email\":\"sanchit+localhost@code.org\"},{\"changed_at\":\"2025-11-19 21:47:28 +0000\",\"changed\":[\"level_data\",\"predict_settings\"],\"changed_by_id\":1,\"changed_by_email\":\"sanchit+localhost@code.org\"}]"
 }]]></config>
   <blocks/>
 </Music>

--- a/dashboard/config/scripts/new_music_dance_ai_project.bubble_choice
+++ b/dashboard/config/scripts/new_music_dance_ai_project.bubble_choice
@@ -1,12 +1,12 @@
 name 'New Music Dance AI Project'
-display_name 'Music Dance AI Test'
-description 'Generate a song, dance, or dancer using AI!'
+display_name 'Mix & Move with AI Project'
+description 'Generate a song, dance, and dancer using AI!'
 
 sublevels
-level 'Music AI Subproject'
 level 'Dancer AI Subproject'
+level 'Music AI Subproject'
 level 'Dance AI Subproject'
+
 uses_lab2
 standalone
-
 custom_mode 'music_dance_ai'


### PR DESCRIPTION
Updates to the Music Dance AI standalone project level:
- Update the music sublevel level data to match the freeplay level (updated prompt, adlib)
- Change user-facing project type name to "Mix & Move with AI"
- Update gallery image
- Update bubble choice level to show dancer level first.

<img width="987" height="140" alt="Screenshot 2025-11-19 at 2 35 22 PM" src="https://github.com/user-attachments/assets/cb8db443-0677-489e-8e8d-8220a4ba002b" />

## Links
- Jira: https://codedotorg.atlassian.net/browse/LABS-1753

## Testing story
Tested locally with freeplay & standalone