### PR TITLE
Add ability to chat about progress data on the progress page

### DIFF
--- a/apps/src/aiDifferentiation/AiDiffChat.tsx
+++ b/apps/src/aiDifferentiation/AiDiffChat.tsx
@@ -217,7 +217,7 @@ const AiDiffChat: React.FC<AiDiffChatProps> = ({
         inputText: prompt,
         isPreset,
         presetChipText,
-        ...(localThreadId === 0 ? {context} : {}),
+        context,
         ...(context.type === AiDiffContext.LEVEL ? {viewAsUserId} : {}),
       });
 

--- a/apps/src/templates/teacherNavigation/TeacherNavigationBar.tsx
+++ b/apps/src/templates/teacherNavigation/TeacherNavigationBar.tsx
@@ -237,21 +237,27 @@ const TeacherNavigationBar: React.FC<{
   );
 
   const aiContext = () => {
+    const onProgressPage =
+      currentPathObject?.absoluteUrl &&
+      currentPathObject.url === TEACHER_NAVIGATION_PATHS.progress;
     if (selectedSection?.courseId && selectedSection?.unitId)
       return {
-        type: AiDiffContext.COURSE,
+        type: onProgressPage ? AiDiffContext.PROGRESS : AiDiffContext.UNIT,
         courseId: selectedSection.courseId,
         unitId: selectedSection.unitId,
+        sectionId: selectedSection.id,
       };
     if (selectedSection?.courseId)
       return {
-        type: AiDiffContext.COURSE,
+        type: onProgressPage ? AiDiffContext.PROGRESS : AiDiffContext.COURSE,
         courseId: selectedSection.courseId,
+        sectionId: selectedSection.id,
       };
     if (selectedSection?.unitId)
       return {
-        type: AiDiffContext.UNIT,
+        type: onProgressPage ? AiDiffContext.PROGRESS : AiDiffContext.UNIT,
         unitId: selectedSection.unitId,
+        sectionId: selectedSection.id,
       };
     return {
       type: AiDiffContext.GENERAL,

--- a/apps/test/unit/aiDifferentiation/AiDiffChatTest.jsx
+++ b/apps/test/unit/aiDifferentiation/AiDiffChatTest.jsx
@@ -578,6 +578,10 @@ describe('AiDiffChat', () => {
           inputText: responseEventData.text,
           isPreset: false,
           presetChipText: null,
+          context: {
+            type: AiDiffContext.LESSON,
+            lessonId: 2,
+          },
         }),
         true,
         {

--- a/apps/test/unit/aiDifferentiation/AiDiffWorkspaceTest.jsx
+++ b/apps/test/unit/aiDifferentiation/AiDiffWorkspaceTest.jsx
@@ -298,6 +298,10 @@ describe('AiDiffWorkspace', () => {
           inputText: 'new message on old thread',
           isPreset: false,
           presetChipText: null,
+          context: {
+            type: AiDiffContext.LESSON,
+            lessonId: 2,
+          }
         }),
         true,
         {

--- a/apps/test/unit/aiDifferentiation/AiDiffWorkspaceTest.jsx
+++ b/apps/test/unit/aiDifferentiation/AiDiffWorkspaceTest.jsx
@@ -301,7 +301,7 @@ describe('AiDiffWorkspace', () => {
           context: {
             type: AiDiffContext.LESSON,
             lessonId: 2,
-          }
+          },
         }),
         true,
         {

--- a/dashboard/app/controllers/aidiff_threads_controller.rb
+++ b/dashboard/app/controllers/aidiff_threads_controller.rb
@@ -24,7 +24,7 @@ class AidiffThreadsController < ApplicationController
 
     context = params[:context]
 
-    get_curriculum_contexts(context[:levelId], context[:lessonId], context[:unitId], context[:courseId], context[:type])
+    get_curriculum_contexts(context[:levelId], context[:lessonId], context[:unitId], context[:courseId], context[:sectionId], context[:type])
 
     response_body = get_response_body(nil, context[:type], params[:inputText])
 
@@ -80,7 +80,7 @@ class AidiffThreadsController < ApplicationController
         courses.push(*c[:course_names])
       end
     else
-      get_curriculum_contexts(context[:levelId], context[:lessonId], context[:unitId], context[:courseId], context[:type])
+      get_curriculum_contexts(context[:levelId], context[:lessonId], context[:unitId], context[:courseId], context[:sectionId], context[:type])
 
       courses.push(*(@unit_group.present? ? [@unit_group.name, @unit_group.family_name] : ([@unit&.name, @unit&.family_name] if @unit.present?)))
     end
@@ -98,15 +98,17 @@ class AidiffThreadsController < ApplicationController
       return render status: :bad_request, json: {}
     end
 
+    context = params[:context]
+
     if @aidiff_thread.session_created.nil? || @aidiff_thread.session_created < 1.day.ago
       session_id = nil
-      input = AiDiffBedrockHelper.populate_new_session_messages(@aidiff_thread.aidiff_messages, params[:inputText])
+      input = populate_new_session_messages(@aidiff_thread.aidiff_messages, params[:inputText])
     else
       session_id = @aidiff_thread.external_id
       input = params[:inputText]
     end
 
-    get_curriculum_contexts(@aidiff_thread.level_id, @aidiff_thread.lesson_id, @aidiff_thread.unit_id, @aidiff_thread.course_id, @aidiff_thread.context_type)
+    get_curriculum_contexts(@aidiff_thread.level_id, @aidiff_thread.lesson_id, @aidiff_thread.unit_id, @aidiff_thread.course_id, context[:sectionId], @aidiff_thread.context_type)
     response_body = get_response_body(session_id, @aidiff_thread.context_type, input)
 
     # Log messages if the response was successful and not flagged for PII.
@@ -186,7 +188,7 @@ class AidiffThreadsController < ApplicationController
     unit_display_name = @unit&.title_for_display(unit_group_unit: @unit&.unit_group_units&.first)
     student_code = get_student_code(params[:viewAsUserId] || current_user.id, @level, @unit.id) if context_type == SharedConstants::AI_DIFF_CONTEXT[:LEVEL]
 
-    prompt = AiDiffBedrockHelper.get_prompt_for_context(
+    prompt = get_prompt_for_context(
       context_type,
       course_display_name,
       unit_display_name,
@@ -197,7 +199,7 @@ class AidiffThreadsController < ApplicationController
       student_code
     )
 
-    response = AiDiffBedrockHelper.request_bedrock_rag_chat(input, prompt, lesson_num, unit_num, course_names, session_id, @section_contexts, get_labs(context_type))
+    response = request_bedrock_rag_chat(input, prompt, lesson_num, unit_num, course_names, session_id, @section_contexts, get_labs(context_type))
     #TODO: check for profanity/PII in model response
 
     {
@@ -210,9 +212,9 @@ class AidiffThreadsController < ApplicationController
     }
   end
 
-  private def get_active_sections
+  private def get_section_contexts(sections)
     # all sections updated in the last year that have curriculum assigned
-    contexts = @current_user&.sections&.where(hidden: false, updated_at: 1.year.ago..Time.now)&.select {|s| s.script_id || s.course_id}&.map do |section|
+    contexts = sections&.map do |section|
       context_scope = SharedConstants::AI_DIFF_CONTEXT[:COURSE]
       course_display_name = CourseOffering.find_by(id: section.course_offering_id)&.display_name
       course_names = [section.unit_group&.name]
@@ -227,7 +229,7 @@ class AidiffThreadsController < ApplicationController
     contexts
   end
 
-  private def get_curriculum_contexts(level_id, lesson_id, unit_id, course_id, context_type)
+  private def get_curriculum_contexts(level_id, lesson_id, unit_id, course_id, section_id, context_type)
     if level_id
       @level = Level.find(level_id)
     end
@@ -240,9 +242,9 @@ class AidiffThreadsController < ApplicationController
     end
 
     if unit_id
-      @unit = Unit.find(unit_id)
+      @unit = Unit.get_from_cache(unit_id)
     elsif @lesson
-      @unit = Unit.find(@lesson.script_id)
+      @unit = Unit.get_from_cache(@lesson.script_id)
     end
 
     if course_id
@@ -252,7 +254,11 @@ class AidiffThreadsController < ApplicationController
     end
 
     if context_type == SharedConstants::AI_DIFF_CONTEXT[:GENERAL]
-      @section_contexts = get_active_sections
+      sections = current_user.sections_instructed.where(hidden: false, updated_at: 1.year.ago..Time.now)&.select {|s| s.script_id || s.course_id}
+      @section_contexts = get_section_contexts(sections)
+    elsif section_id
+      sections = current_user.sections_instructed.filter {|section| section.id == section_id}
+      @section_contexts = get_section_contexts(sections)
     end
   end
 

--- a/dashboard/app/controllers/aidiff_threads_controller.rb
+++ b/dashboard/app/controllers/aidiff_threads_controller.rb
@@ -98,7 +98,7 @@ class AidiffThreadsController < ApplicationController
       return render status: :bad_request, json: {}
     end
 
-    context = params[:context]
+    context = params[:context] || {}
 
     if @aidiff_thread.session_created.nil? || @aidiff_thread.session_created < 1.day.ago
       session_id = nil

--- a/dashboard/app/helpers/ai_diff_bedrock_helper.rb
+++ b/dashboard/app/helpers/ai_diff_bedrock_helper.rb
@@ -312,7 +312,7 @@ module AiDiffBedrockHelper
   ALPHABET = ('a'..'z').to_a
 
   def progress_csv_for_all_sections(section_contexts)
-    return [] unless section_contexts.respond_to?('map')
+    return [] unless section_contexts.respond_to?(:map)
 
     section_contexts.map do |section_context|
       section = section_context[:section]

--- a/dashboard/app/helpers/ai_diff_bedrock_helper.rb
+++ b/dashboard/app/helpers/ai_diff_bedrock_helper.rb
@@ -387,6 +387,4 @@ module AiDiffBedrockHelper
       data_row[level_text] = parsed_status
     end
   end
-
-
 end

--- a/dashboard/app/helpers/ai_diff_bedrock_helper.rb
+++ b/dashboard/app/helpers/ai_diff_bedrock_helper.rb
@@ -1,4 +1,6 @@
 module AiDiffBedrockHelper
+  include UsersHelper
+
   MAX_TOKENS = 1500
   TEMP = 0.5
   MODEL_ID = 'anthropic.claude-3-sonnet-20240229-v1:0'
@@ -7,7 +9,7 @@ module AiDiffBedrockHelper
   KB_ID = 'ODWSNBOEZG'
   RETRIEVAL_LIMIT = 10
 
-  def self.create_bedrock_client
+  def create_bedrock_client
     if (Rails.application.config.respond_to?(:stub_aichat_external_services) && Rails.application.config.stub_aichat_external_services) || [:development, :test].include?(rack_env)
       client = Aws::BedrockAgentRuntime::Client.new(stub_responses: true)
       client.stub_responses(
@@ -50,7 +52,7 @@ module AiDiffBedrockHelper
     end
   end
 
-  def self.get_prompt_supplement(section_contexts)
+  def get_prompt_supplement(section_contexts)
     return "" unless section_contexts
     prompt = "\nThe courses that this teacher may ask you about are:"
     section_contexts.each do |context|
@@ -59,7 +61,7 @@ module AiDiffBedrockHelper
     prompt
   end
 
-  def self.populate_new_session_messages(messages, input)
+  def populate_new_session_messages(messages, input)
     new_input_text = "This is a continuation of a previous conversation. The previous messages are:"
     messages.each do |msg|
       new_input_text << "\n\n#{msg.user? ? "User" : "Assistant"}: #{msg.raw_content}"
@@ -67,7 +69,7 @@ module AiDiffBedrockHelper
     new_input_text << "\n\n\n**The current message that you should respond to is:**\nUser: #{input}"
   end
 
-  def self.get_prompt_for_context(context, course_name, unit_name, lesson_name, is_preset, section_contexts, level_instructions, student_code)
+  def get_prompt_for_context(context, course_name, unit_name, lesson_name, is_preset, section_contexts, level_instructions, student_code)
     case context
     when SharedConstants::AI_DIFF_CONTEXT[:LEVEL]
       prompt =
@@ -126,6 +128,17 @@ module AiDiffBedrockHelper
       Here are the search results in numbered order:
       $search_results$", course_name: course_name
       )
+    when SharedConstants::AI_DIFF_CONTEXT[:PROGRESS]
+      prompt = format("You are a teaching assistant named Aida. It's your job to help K-12 computer science teachers using the code.org platform plan their lessons and adjust lesson plans to fit class time requirements, help students that are ahead or behind, provide alternate explanations of the material, and other relevant teaching tasks. Your focus is on helping teachers with the %{course_name} course. The teacher will either ask you questions about the current course plan and resources or ask you to make changes to or create new material for this course. When creating new material for the course, you must provide all the information a teacher needs. For example, if asked to create a quiz you should also provide the answer key. Your job is to use the information from the search results to help the teacher to the best of your ability, asking clarifying questions if needed. Your responses should be warm and helpful because you're the best lesson planner there could be, and you know all about computer science education.
+      The current course this teacher is working on is %{course_name}. The teacher is currently viewing a page showing how much progress their students have made in this course.
+
+      If asked about a student, here is some data in CSV format about the student progress the teacher is viewing. The column headers refer to level numbers. In the data rows, 'A' means the student attempted the work but did not finish; 'S' means the student submitted their work; 'V' means the student submitted their work and the submission has been validated for completeness or correctness; 'N' means the student has not started the work. Please do not repeat these abbreviations to the teacher as the page they are viewing uses a different, graphical method of displaying this information.
+
+      %{progress_csvs}
+
+      Here are the search results in numbered order:
+      $search_results$", course_name: course_name, progress_csvs: progress_csv_for_all_sections(section_contexts).join("\n\n")
+      )
     when SharedConstants::AI_DIFF_CONTEXT[:GENERAL]
       prompt = format("You are a teaching assistant named Aida. It's your job to help K-12 computer science teachers using the code.org platform plan their lessons and adjust lesson plans to fit class time requirements, help students that are ahead or behind, provide alternate explanations of the material, and other relevant teaching tasks. You also provide support with using the code.org platform. Your responses should be warm and helpful because you're the best lesson planner there could be, and you know all about computer science education.%{section_contexts}
 
@@ -144,7 +157,7 @@ module AiDiffBedrockHelper
     prompt
   end
 
-  def self.format_inputs_for_bedrock_request(input, prompt)
+  def format_inputs_for_bedrock_request(input, prompt)
     # Add system prompt and retrieval contexts if available to inputs as part of instructions that will be sent to model.
     {
       input: {
@@ -177,7 +190,7 @@ module AiDiffBedrockHelper
     }
   end
 
-  def self.filter_for_context(lesson_number, unit_num, course_names, section_contexts, labs = [])
+  def filter_for_context(lesson_number, unit_num, course_names, section_contexts, labs = [])
     filter_config = {}
     and_all_filters = []
     or_all_filters = []
@@ -247,7 +260,16 @@ module AiDiffBedrockHelper
     filter_config
   end
 
-  def self.request_bedrock_rag_chat(input, prompt, lesson_number, unit_num, course_name, session_id, section_contexts, labs = [])
+  def request_bedrock_rag_chat(
+    input,
+    prompt,
+    lesson_number,
+    unit_num,
+    course_name,
+    session_id,
+    section_contexts,
+    labs = []
+  )
     config = format_inputs_for_bedrock_request(input, prompt)
     config[:session_id] = session_id unless session_id.nil?
     filter_config = filter_for_context(lesson_number, unit_num, course_name, section_contexts, labs)
@@ -260,7 +282,7 @@ module AiDiffBedrockHelper
     format_rag_response(response)
   end
 
-  def self.format_rag_response(response)
+  def format_rag_response(response)
     text = response.output.text.dup
 
     # Remove useless references such as '(Sources 1 and 7)' from the response
@@ -286,4 +308,85 @@ module AiDiffBedrockHelper
       session_id: response.session_id,
     }
   end
+
+  ALPHABET = ('a'..'z').to_a
+
+  def progress_csv_for_all_sections(section_contexts)
+    return [] unless section_contexts.respond_to?('map')
+
+    section_contexts.map do |section_context|
+      section = section_context[:section]
+      progress_csv_for_students(section.students.distinct, section.default_script)
+    end
+  end
+
+  def progress_csv_for_students(students, unit)
+    student_progress = script_progress_for_users(students, unit)[0]
+    level_names, progress_table = get_csv_level_data(unit, students, student_progress)
+    headers = ['Student Name'].concat(level_names)
+
+    CSV.generate do |csv|
+      csv << headers
+      progress_table.each do |data_row|
+        csv << [data_row[:student_name]].concat(level_names.map {|column_name| data_row[column_name]})
+      end
+    end
+  end
+
+  def get_csv_level_data(unit, students, student_progress)
+    progress_table = students.map do |student|
+      {student_name: student.name, student_id: student.id}
+    end
+
+    level_names = []
+
+    unit.lessons.each do |lesson|
+      lesson.script_levels.each do |script_level|
+        next if script_level.assessment?
+
+        level_id = script_level.oldest_active_level.id || script_level.id
+        level_text = "#{lesson.relative_position}.#{script_level.level_display_text}"
+
+        if script_level.bubble_choice?
+          sublevels = script_level.level.sublevels
+          sublevels.each_with_index do |sublevel, index|
+            sublevel_name = "#{level_text}#{ALPHABET[index]}"
+            level_names << sublevel_name
+
+            add_level_data_for_all_students(progress_table, student_progress, sublevel.id, sublevel_name, sublevel.validated?)
+          end
+        else
+          add_level_data_for_all_students(progress_table, student_progress, level_id, level_text, script_level.level.validated?)
+          level_names << level_text
+        end
+      end
+    end
+
+    [level_names, progress_table]
+  end
+
+  def add_level_data_for_all_students(progress_table, student_progress, level_id, level_text, is_validated_level)
+    progress_table.each do |data_row|
+      level_progress_for_student = student_progress[data_row[:student_id]][level_id]
+
+      status = level_progress_for_student ? level_progress_for_student[:status] : 'not_tried'
+
+      parsed_status = case status
+                      when 'not_tried'
+                        'N'
+                      when 'passed', 'perfect', 'submitted', 'completed_assessment', 'free_play_complete'
+                        if is_validated_level
+                          'V'
+                        else
+                          'S'
+                        end
+                      when 'attempted'
+                        'A'
+                      end
+
+      data_row[level_text] = parsed_status
+    end
+  end
+
+
 end

--- a/dashboard/app/helpers/ai_diff_bedrock_helper.rb
+++ b/dashboard/app/helpers/ai_diff_bedrock_helper.rb
@@ -35,6 +35,9 @@ module AiDiffBedrockHelper
                       uri: "s3://dummy_file"
                     },
                     type: "S3"
+                  },
+                  metadata: {
+                    'url' => 'https://zombo.com'
                   }
                 }
               ]

--- a/dashboard/test/controllers/aidiff_threads_controller_test.rb
+++ b/dashboard/test/controllers/aidiff_threads_controller_test.rb
@@ -18,7 +18,7 @@ class AidiffThreadsControllerTest < ActionController::TestCase
 
     create(:single_user_experiment, min_user_id: @teacher.id, name: 'ai-differentiation')
 
-    @session_id = "1234"
+    @session_id = 'fake_session_id'
     @bedrock_client = Aws::BedrockAgentRuntime::Client.new(stub_responses: true)
     @bedrock_client.stub_responses(
       :retrieve_and_generate, {

--- a/dashboard/test/helpers/ai_diff_bedrock_helper_test.rb
+++ b/dashboard/test/helpers/ai_diff_bedrock_helper_test.rb
@@ -128,15 +128,12 @@ User: oh no"
     create(:script_level, script: script, levels: [level], lesson: lesson)
 
     # for user_1
-    sublevel1_user_level = create(:user_level, user: user_1, level: sublevel1_contained_level, script: script, best_result: ActivityConstants::BEST_PASS_RESULT, time_spent: 180)
-    sublevel2_user_level = create(:user_level, user: user_1, level: sublevel2, script: script, best_result: 20, time_spent: 300)
-
-    sublevel1_last_progress = UserLevel.find(sublevel1_user_level.id).updated_at.to_i
-    sublevel2_last_progress = UserLevel.find(sublevel2_user_level.id).updated_at.to_i
+    create(:user_level, user: user_1, level: sublevel1_contained_level, script: script, best_result: ActivityConstants::BEST_PASS_RESULT, time_spent: 180)
+    create(:user_level, user: user_1, level: sublevel2, script: script, best_result: 20, time_spent: 300)
 
     # for user_2
-    sublevel1_user_level_2 = create(:user_level, user: user_2, level: sublevel1_contained_level, script: script, best_result: ActivityConstants::BEST_PASS_RESULT, time_spent: 180)
-    sublevel2_user_level_2 = create(:user_level, user: user_2, level: sublevel2, script: script, best_result: 20, time_spent: 300)
+    create(:user_level, user: user_2, level: sublevel1_contained_level, script: script, best_result: ActivityConstants::BEST_PASS_RESULT, time_spent: 180)
+    create(:user_level, user: user_2, level: sublevel2, script: script, best_result: 20, time_spent: 300)
 
     context = SharedConstants::AI_DIFF_CONTEXT[:PROGRESS]
     course_display_name = "Computer Science Discoveries"

--- a/dashboard/test/helpers/ai_diff_bedrock_helper_test.rb
+++ b/dashboard/test/helpers/ai_diff_bedrock_helper_test.rb
@@ -40,7 +40,7 @@ class AiDiffBedrockHelperTest < ActionView::TestCase
         session_id: @session_id
       }
     )
-    AiDiffBedrockHelper.stubs(:create_bedrock_client).returns(@bedrock_client)
+    stubs(:create_bedrock_client).returns(@bedrock_client)
   end
 
   test 'Test previous message concatenation' do
@@ -49,7 +49,7 @@ class AiDiffBedrockHelperTest < ActionView::TestCase
     create(:aidiff_message, aidiff_thread: thread, content: "beep boop", raw_content: "beep boop")
     create(:aidiff_message, aidiff_thread: thread, role: :user, content: "open the pod bay doors", raw_content: "open the pod bay doors")
     create(:aidiff_message, aidiff_thread: thread, content: "I'm afraid I can't do that Dave", raw_content: "I'm afraid I can't do that Dave")
-    input = AiDiffBedrockHelper.populate_new_session_messages(thread.aidiff_messages, "oh no")
+    input = populate_new_session_messages(thread.aidiff_messages, "oh no")
     expected_input = "This is a continuation of a previous conversation. The previous messages are:
 
 User: hello
@@ -75,7 +75,7 @@ User: oh no"
     section_contexts = nil
     level_instructions = 'sudo make me a sandwich'
     student_code = nil
-    prompt = AiDiffBedrockHelper.get_prompt_for_context(
+    prompt = get_prompt_for_context(
       context,
       course_display_name,
       unit_name,
@@ -96,7 +96,90 @@ User: oh no"
             $search_results$
 
       $output_format_instructions$"
-    assert_equal prompt, expected_prompt
+    assert_equal expected_prompt, prompt
+  end
+
+  test 'Testing prompt formatting for progress' do
+    user_1 = create(:user, name: 'abc')
+    user_2 = create(:user, name: 'def')
+    user_3 = create(:user, name: 'ghi')
+
+    teacher = create(:teacher)
+    section = create(:section, teacher: teacher)
+    section.students << user_1 # we query for feedback where student is currently in section
+    section.students << user_2
+    section.students << user_3
+
+    # set up progress
+    script = create(:script, :in_single_unit_course)
+    section.script = script
+
+    lesson_group = create(:lesson_group, script: script)
+    lesson = create(:lesson, script: script, lesson_group: lesson_group)
+
+    # Create BubbleChoice level with sublevels, script_level, and user_levels.
+    sublevel1 = create(:level, name: 'choice_1')
+    sublevel1_contained_level = create(:free_response, name: "choice_1 contained")
+    sublevel1.contained_level_names = [sublevel1_contained_level.name]
+    sublevel1.save!
+
+    sublevel2 = create(:level, name: 'choice_2')
+    level = create(:bubble_choice_level, sublevels: [sublevel1, sublevel2])
+    create(:script_level, script: script, levels: [level], lesson: lesson)
+
+    # for user_1
+    sublevel1_user_level = create(:user_level, user: user_1, level: sublevel1_contained_level, script: script, best_result: ActivityConstants::BEST_PASS_RESULT, time_spent: 180)
+    sublevel2_user_level = create(:user_level, user: user_1, level: sublevel2, script: script, best_result: 20, time_spent: 300)
+
+    sublevel1_last_progress = UserLevel.find(sublevel1_user_level.id).updated_at.to_i
+    sublevel2_last_progress = UserLevel.find(sublevel2_user_level.id).updated_at.to_i
+
+    # for user_2
+    sublevel1_user_level_2 = create(:user_level, user: user_2, level: sublevel1_contained_level, script: script, best_result: ActivityConstants::BEST_PASS_RESULT, time_spent: 180)
+    sublevel2_user_level_2 = create(:user_level, user: user_2, level: sublevel2, script: script, best_result: 20, time_spent: 300)
+
+    context = SharedConstants::AI_DIFF_CONTEXT[:PROGRESS]
+    course_display_name = "Computer Science Discoveries"
+    unit_name = "CSD Unit 3"
+    lesson_name = "Test Lesson Name"
+    is_preset = false
+    section_contexts = [
+      {
+        section: section,
+        context: SharedConstants::AI_DIFF_CONTEXT[:PROGRESS],
+        course_display_name: "Fake Course A",
+        course_names: ["fake_a"]
+      }
+    ]
+    level_instructions = 'sudo make me a sandwich'
+    student_code = {student_code: 'print "Hello, world!";'}
+    prompt = get_prompt_for_context(
+      context,
+      course_display_name,
+      unit_name,
+      lesson_name,
+      is_preset,
+      section_contexts,
+      level_instructions,
+      student_code
+    )
+
+    expected_prompt = "You are a teaching assistant named Aida. It's your job to help K-12 computer science teachers using the code.org platform plan their lessons and adjust lesson plans to fit class time requirements, help students that are ahead or behind, provide alternate explanations of the material, and other relevant teaching tasks. Your focus is on helping teachers with the Computer Science Discoveries course. The teacher will either ask you questions about the current course plan and resources or ask you to make changes to or create new material for this course. When creating new material for the course, you must provide all the information a teacher needs. For example, if asked to create a quiz you should also provide the answer key. Your job is to use the information from the search results to help the teacher to the best of your ability, asking clarifying questions if needed. Your responses should be warm and helpful because you're the best lesson planner there could be, and you know all about computer science education.
+      The current course this teacher is working on is Computer Science Discoveries. The teacher is currently viewing a page showing how much progress their students have made in this course.
+
+      If asked about a student, here is some data in CSV format about the student progress the teacher is viewing. The column headers refer to level numbers. In the data rows, 'A' means the student attempted the work but did not finish; 'S' means the student submitted their work; 'V' means the student submitted their work and the submission has been validated for completeness or correctness; 'N' means the student has not started the work. Please do not repeat these abbreviations to the teacher as the page they are viewing uses a different, graphical method of displaying this information.
+
+      Student Name,1.1a,1.1b
+abc,S,S
+def,S,S
+ghi,N,N
+
+
+      Here are the search results in numbered order:
+      $search_results$
+
+      $output_format_instructions$"
+    assert_equal expected_prompt, prompt
   end
 
   test 'Testing prompt formatting for level, not preset, with student code' do
@@ -108,7 +191,7 @@ User: oh no"
     section_contexts = nil
     level_instructions = 'sudo make me a sandwich'
     student_code = {student_code: 'print "Hello, world!";'}
-    prompt = AiDiffBedrockHelper.get_prompt_for_context(
+    prompt = get_prompt_for_context(
       context,
       course_display_name,
       unit_name,
@@ -131,7 +214,7 @@ User: oh no"
             $search_results$
 
       $output_format_instructions$"
-    assert_equal prompt, expected_prompt
+    assert_equal expected_prompt, prompt
   end
 
   test 'Testing prompt formatting for level, not preset, with very long student code' do
@@ -143,7 +226,7 @@ User: oh no"
     section_contexts = nil
     level_instructions = 'sudo make me a sandwich'
     student_code = {student_code: 'a' * 100000}
-    prompt = AiDiffBedrockHelper.get_prompt_for_context(
+    prompt = get_prompt_for_context(
       context,
       course_display_name,
       unit_name,
@@ -166,7 +249,7 @@ User: oh no"
             $search_results$
 
       $output_format_instructions$"
-    assert_equal prompt, expected_prompt
+    assert_equal expected_prompt, prompt
   end
 
   test 'Testing prompt formatting for lesson, not preset' do
@@ -178,7 +261,7 @@ User: oh no"
     section_contexts = nil
     level_instructions = nil
     student_code = nil
-    prompt = AiDiffBedrockHelper.get_prompt_for_context(
+    prompt = get_prompt_for_context(
       context,
       course_display_name,
       unit_name,
@@ -197,7 +280,7 @@ User: oh no"
       $search_results$
 
       $output_format_instructions$"
-    assert_equal prompt, expected_prompt
+    assert_equal expected_prompt, prompt
   end
 
   test 'Testing prompt formatting for unit, not preset' do
@@ -209,7 +292,7 @@ User: oh no"
     section_contexts = nil
     level_instructions = nil
     student_code = nil
-    prompt = AiDiffBedrockHelper.get_prompt_for_context(
+    prompt = get_prompt_for_context(
       context,
       course_display_name,
       unit_name,
@@ -228,7 +311,7 @@ User: oh no"
       $search_results$
 
       $output_format_instructions$"
-    assert_equal prompt, expected_prompt
+    assert_equal expected_prompt, prompt
   end
 
   test 'Testing prompt formatting for course, not preset' do
@@ -240,7 +323,7 @@ User: oh no"
     section_contexts = nil
     level_instructions = nil
     student_code = nil
-    prompt = AiDiffBedrockHelper.get_prompt_for_context(
+    prompt = get_prompt_for_context(
       context,
       course_display_name,
       unit_name,
@@ -259,7 +342,7 @@ User: oh no"
       $search_results$
 
       $output_format_instructions$"
-    assert_equal prompt, expected_prompt
+    assert_equal expected_prompt, prompt
   end
 
   test 'Testing prompt formatting for general, not preset' do
@@ -271,7 +354,7 @@ User: oh no"
     section_contexts = nil
     level_instructions = nil
     student_code = nil
-    prompt = AiDiffBedrockHelper.get_prompt_for_context(
+    prompt = get_prompt_for_context(
       context,
       course_display_name,
       unit_name,
@@ -289,7 +372,7 @@ User: oh no"
       $search_results$
 
       $output_format_instructions$"
-    assert_equal prompt, expected_prompt
+    assert_equal expected_prompt, prompt
   end
 
   test 'Testing prompt formatting for general with sections, not preset' do
@@ -312,7 +395,7 @@ User: oh no"
     ]
     level_instructions = nil
     student_code = nil
-    prompt = AiDiffBedrockHelper.get_prompt_for_context(
+    prompt = get_prompt_for_context(
       context,
       course_display_name,
       unit_name,
@@ -333,7 +416,7 @@ The courses that this teacher may ask you about are:
       $search_results$
 
       $output_format_instructions$"
-    assert_equal prompt, expected_prompt
+    assert_equal expected_prompt, prompt
   end
 
   test 'Testing prompt formatting for lesson, is preset' do
@@ -345,7 +428,7 @@ The courses that this teacher may ask you about are:
     section_contexts = nil
     level_instructions = nil
     student_code = nil
-    prompt = AiDiffBedrockHelper.get_prompt_for_context(
+    prompt = get_prompt_for_context(
       context,
       course_display_name,
       unit_name,
@@ -362,7 +445,7 @@ The courses that this teacher may ask you about are:
 
       Here are the search results in numbered order:
       $search_results$"
-    assert_equal prompt, expected_prompt
+    assert_equal expected_prompt, prompt
   end
 
   test 'Testing prompt formatting for unit, is preset' do
@@ -374,7 +457,7 @@ The courses that this teacher may ask you about are:
     section_contexts = nil
     level_instructions = nil
     student_code = nil
-    prompt = AiDiffBedrockHelper.get_prompt_for_context(
+    prompt = get_prompt_for_context(
       context,
       course_display_name,
       unit_name,
@@ -391,7 +474,7 @@ The courses that this teacher may ask you about are:
 
       Here are the search results in numbered order:
       $search_results$"
-    assert_equal prompt, expected_prompt
+    assert_equal expected_prompt, prompt
   end
 
   test 'Testing prompt formatting for course, is preset' do
@@ -403,7 +486,7 @@ The courses that this teacher may ask you about are:
     section_contexts = nil
     level_instructions = nil
     student_code = nil
-    prompt = AiDiffBedrockHelper.get_prompt_for_context(
+    prompt = get_prompt_for_context(
       context,
       course_display_name,
       unit_name,
@@ -420,7 +503,7 @@ The courses that this teacher may ask you about are:
 
       Here are the search results in numbered order:
       $search_results$"
-    assert_equal prompt, expected_prompt
+    assert_equal expected_prompt, prompt
   end
 
   test 'Testing prompt formatting for general, is preset' do
@@ -432,7 +515,7 @@ The courses that this teacher may ask you about are:
     section_contexts = nil
     level_instructions = nil
     student_code = nil
-    prompt = AiDiffBedrockHelper.get_prompt_for_context(
+    prompt = get_prompt_for_context(
       context,
       course_display_name,
       unit_name,
@@ -448,7 +531,7 @@ The courses that this teacher may ask you about are:
 
       Here are the search results in numbered order:
       $search_results$"
-    assert_equal prompt, expected_prompt
+    assert_equal expected_prompt, prompt
   end
 
   test 'Testing prompt formatting for general with sections, is preset' do
@@ -471,7 +554,7 @@ The courses that this teacher may ask you about are:
     ]
     level_instructions = nil
     student_code = nil
-    prompt = AiDiffBedrockHelper.get_prompt_for_context(
+    prompt = get_prompt_for_context(
       context,
       course_display_name,
       unit_name,
@@ -490,13 +573,13 @@ The courses that this teacher may ask you about are:
 
       Here are the search results in numbered order:
       $search_results$"
-    assert_equal prompt, expected_prompt
+    assert_equal expected_prompt, prompt
   end
 
   test 'Testing input formatting for retrieve and generate request' do
     input = "Hello there!"
     prompt = "prompt text"
-    formatted_input = AiDiffBedrockHelper.format_inputs_for_bedrock_request(input, prompt)
+    formatted_input = format_inputs_for_bedrock_request(input, prompt)
     expected_input = {
       input: {
         text: "Hello there!"
@@ -536,7 +619,7 @@ The courses that this teacher may ask you about are:
     unit_num = 2
     lesson_number = 3
     section_contexts = nil
-    formatted_input = AiDiffBedrockHelper.format_inputs_for_bedrock_request(input, prompt)
+    formatted_input = format_inputs_for_bedrock_request(input, prompt)
     expected_input = {
       input: {
         text: "Hello there!"
@@ -580,7 +663,7 @@ The courses that this teacher may ask you about are:
       ]
     }
     assert_equal formatted_input, expected_input
-    filter = AiDiffBedrockHelper.filter_for_context(lesson_number, unit_num, course_names, section_contexts)
+    filter = filter_for_context(lesson_number, unit_num, course_names, section_contexts)
     assert_equal filter, expected_filter
   end
 
@@ -591,7 +674,7 @@ The courses that this teacher may ask you about are:
     unit_num = 2
     lesson_number = 3
     section_contexts = nil
-    formatted_input = AiDiffBedrockHelper.format_inputs_for_bedrock_request(input, prompt)
+    formatted_input = format_inputs_for_bedrock_request(input, prompt)
     expected_input = {
       input: {
         text: "Hello there!"
@@ -640,7 +723,7 @@ The courses that this teacher may ask you about are:
       ]
     }
     assert_equal formatted_input, expected_input
-    filter = AiDiffBedrockHelper.filter_for_context(lesson_number, unit_num, course_names, section_contexts, ['weblab', 'gamelab'])
+    filter = filter_for_context(lesson_number, unit_num, course_names, section_contexts, ['weblab', 'gamelab'])
     assert_equal filter, expected_filter
   end
 
@@ -651,7 +734,7 @@ The courses that this teacher may ask you about are:
     unit_num = 2
     lesson_number = nil
     section_contexts = nil
-    formatted_input = AiDiffBedrockHelper.format_inputs_for_bedrock_request(input, prompt)
+    formatted_input = format_inputs_for_bedrock_request(input, prompt)
     expected_input = {
       input: {
         text: "Hello there!"
@@ -691,7 +774,7 @@ The courses that this teacher may ask you about are:
       ]
     }
     assert_equal formatted_input, expected_input
-    filter = AiDiffBedrockHelper.filter_for_context(lesson_number, unit_num, course_names, section_contexts)
+    filter = filter_for_context(lesson_number, unit_num, course_names, section_contexts)
     assert_equal filter, expected_filter
   end
 
@@ -702,7 +785,7 @@ The courses that this teacher may ask you about are:
     unit_num = nil
     lesson_number = nil
     section_contexts = nil
-    formatted_input = AiDiffBedrockHelper.format_inputs_for_bedrock_request(input, prompt)
+    formatted_input = format_inputs_for_bedrock_request(input, prompt)
     expected_input = {
       input: {
         text: "Hello there!"
@@ -736,7 +819,7 @@ The courses that this teacher may ask you about are:
       in: {key: "course", value: ["test_course"]}
     }
     assert_equal formatted_input, expected_input
-    filter = AiDiffBedrockHelper.filter_for_context(lesson_number, unit_num, course_names, section_contexts)
+    filter = filter_for_context(lesson_number, unit_num, course_names, section_contexts)
     assert_equal filter, expected_filter
   end
 
@@ -747,7 +830,7 @@ The courses that this teacher may ask you about are:
     unit_num = nil
     lesson_number = nil
     section_contexts = nil
-    formatted_input = AiDiffBedrockHelper.format_inputs_for_bedrock_request(input, prompt)
+    formatted_input = format_inputs_for_bedrock_request(input, prompt)
     expected_input = {
       input: {
         text: "Hello there!"
@@ -781,7 +864,7 @@ The courses that this teacher may ask you about are:
       equals: {key: "scope", value: "general"}
     }
     assert_equal formatted_input, expected_input
-    filter = AiDiffBedrockHelper.filter_for_context(lesson_number, unit_num, course_names, section_contexts)
+    filter = filter_for_context(lesson_number, unit_num, course_names, section_contexts)
     assert_equal filter, expected_filter
   end
 
@@ -804,7 +887,7 @@ The courses that this teacher may ask you about are:
       }
     ]
     labs = ['javalab', 'pythonlab']
-    formatted_input = AiDiffBedrockHelper.format_inputs_for_bedrock_request(input, prompt)
+    formatted_input = format_inputs_for_bedrock_request(input, prompt)
     expected_input = {
       input: {
         text: "Hello there!"
@@ -843,7 +926,7 @@ The courses that this teacher may ask you about are:
       ]
     }
     assert_equal formatted_input, expected_input
-    filter = AiDiffBedrockHelper.filter_for_context(lesson_number, unit_num, course_names, section_contexts, labs)
+    filter = filter_for_context(lesson_number, unit_num, course_names, section_contexts, labs)
     assert_equal filter, expected_filter
   end
 
@@ -855,7 +938,7 @@ The courses that this teacher may ask you about are:
     lesson_number = 5
     section_contexts = nil
 
-    response = AiDiffBedrockHelper.request_bedrock_rag_chat(input, prompt, lesson_number, unit_num, course_names, @session_id, section_contexts)
+    response = request_bedrock_rag_chat(input, prompt, lesson_number, unit_num, course_names, @session_id, section_contexts)
     assert_equal response[:content], "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua."
     assert_equal response[:raw_content], "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua."
     assert_equal response[:session_id], "1234"

--- a/lib/cdo/shared_constants.rb
+++ b/lib/cdo/shared_constants.rb
@@ -890,7 +890,8 @@ module SharedConstants
     UNIT: "unit",
     COURSE: "course",
     GENERAL: "general",
-    LEVEL: "level"
+    LEVEL: "level",
+    PROGRESS: "progress"
   }.freeze
 
   DISALLOWED_ROUTES = [


### PR DESCRIPTION
This PR adds a CSV of student progress data to the AI TA prompt when the teacher is on the progress page. 

This involves adding a new `PROGRESS` context type for the TA chat requests, and passing in the currently-viewed section ID from the frontend to the chat controller. 


## Links
<!--  Links to relevant external resources.
      - spec docs, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- Jira: https://codedotorg.atlassian.net/browse/AITT-1147

## Testing story
New test of prompt generation with CSV included, other existing tests pass.


## Deployment strategy
Not using a special experiment here, it will just become available to teachers immediately upon the next DTP after merging.



## Follow-up work
<!--  List any clean-up or technical debt that will be addressed in future work.
      - Include Jira links where applicable.
      - Are there any known limitations or improvements planned? -->



## Privacy
<!--  How does this change impact Student & Teacher privacy?
      - Does this collect, use, share, or modify PII, either new or existing? -->



## Security
<!--  How does this change impact our security surface-area?
      - Do API's touched have the right auth?
      - Do infra changes impact our attack surface or encryption?
-->



## Caching
<!--  How does this change impact caching behavior?
      - Are cache keys or invalidation strategies affected?
      - Will this require cache warming or invalidation after deployment? -->



## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
