### PR TITLE
hoai2025: disable guides in readonly mode

### DIFF
--- a/apps/src/bubbleChoice/customModes/MusicDanceAi/MusicDanceAi.tsx
+++ b/apps/src/bubbleChoice/customModes/MusicDanceAi/MusicDanceAi.tsx
@@ -227,6 +227,7 @@ const MusicDanceAi: React.FC<MusicDanceAiProps> = ({
     tabDataMap,
   ]);
 
+  // Set the initial tab once data is loaded if we haven't already.
   useEffect(() => {
     if (!currentTab && tabDataMap) {
       setCurrentTab(getIsShareView() ? Tab.Dance : getTypedKeys(tabDataMap)[0]);

--- a/apps/src/bubbleChoice/customModes/MusicDanceAi/MusicDanceAi.tsx
+++ b/apps/src/bubbleChoice/customModes/MusicDanceAi/MusicDanceAi.tsx
@@ -5,6 +5,7 @@ import React, {memo, Suspense, useCallback, useEffect, useState} from 'react';
 
 import {
   getCurrentLesson,
+  getCurrentScriptLevelId,
   levelById,
 } from '@cdo/apps/code-studio/progressReduxSelectors';
 import {GENERATED_DANCER_STORAGE_KEY} from '@cdo/apps/dance/ai/constants';
@@ -98,6 +99,7 @@ const MusicDanceAi: React.FC<MusicDanceAiProps> = ({
   const [tabDataMap, setTabDataMap] = useState<{[tab in Tab]?: LabData}>();
   const userId = useAppSelector(state => state.progress.viewAsUserId);
   const scriptId = useAppSelector(state => state.progress.scriptId);
+  const scriptLevelId = useAppSelector(getCurrentScriptLevelId);
   const dispatch = useAppDispatch();
 
   const levelPropertiesPathPrefix = useAppSelector(state => {
@@ -189,7 +191,8 @@ const MusicDanceAi: React.FC<MusicDanceAiProps> = ({
         projectManager = await ProjectManagerFactory.getProjectManagerForLevel(
           parseInt(sublevel.level_id),
           userId || undefined,
-          scriptId || undefined
+          scriptId || undefined,
+          scriptLevelId || undefined
         );
       }
 
@@ -211,7 +214,6 @@ const MusicDanceAi: React.FC<MusicDanceAiProps> = ({
     }
 
     setTabDataMap(map);
-    setCurrentTab(getIsShareView() ? Tab.Dance : getTypedKeys(map)[0]);
     dispatch(setIsLoading(false));
   }, [
     levelProperties,
@@ -219,15 +221,22 @@ const MusicDanceAi: React.FC<MusicDanceAiProps> = ({
     channel.subprojects,
     userId,
     scriptId,
+    scriptLevelId,
     getLevelPropertiesPath,
     dispatch,
     tabDataMap,
   ]);
 
-  // Clear out tab data when switching levels.
+  useEffect(() => {
+    if (!currentTab && tabDataMap) {
+      setCurrentTab(getIsShareView() ? Tab.Dance : getTypedKeys(tabDataMap)[0]);
+    }
+  }, [currentTab, tabDataMap]);
+
+  // Clear out tab data when switching levels or view as user.
   useEffect(() => {
     setTabDataMap(undefined);
-  }, [levelProperties.id]);
+  }, [levelProperties.id, userId]);
 
   useEffect(() => {
     if (!tabDataMap) {

--- a/apps/src/dance/lab2/views/GenerateDance.tsx
+++ b/apps/src/dance/lab2/views/GenerateDance.tsx
@@ -9,6 +9,7 @@ import {useParentLevelProperties} from '@cdo/apps/bubbleChoice/customModes/Music
 import {sendSuccessReportForLevel} from '@cdo/apps/code-studio/progressRedux';
 import {DanceLevelProperties} from '@cdo/apps/dance/types';
 import useLifecycleNotifier from '@cdo/apps/lab2/hooks/useLifecycleNotifier';
+import {isReadOnlyWorkspace} from '@cdo/apps/lab2/redux/lab2ReduxSelectors';
 import {LifecycleEvent} from '@cdo/apps/lab2/utils/LifecycleNotifier';
 import Adlib, {
   AdlibChoices,
@@ -19,7 +20,7 @@ import MainInstructionsContent from '@cdo/apps/lab2/views/components/Instruction
 import NavigationArea from '@cdo/apps/lab2/views/components/Instructions/NavigationArea';
 import {EVENTS} from '@cdo/apps/metrics/AnalyticsConstants';
 import analyticsReporter from '@cdo/apps/metrics/AnalyticsReporter';
-import {useAppDispatch} from '@cdo/apps/util/reduxHooks';
+import {useAppDispatch, useAppSelector} from '@cdo/apps/util/reduxHooks';
 
 import buildDanceBlockly from '../../blockly/buildDanceBlockly';
 
@@ -260,6 +261,11 @@ const GenerateDance: React.FunctionComponent<GenerateCodeProps> = ({
       )
     );
   }, [dispatch, levelProperties.appName, levelProperties.id]);
+
+  const isReadOnly = useAppSelector(isReadOnlyWorkspace);
+  if (isReadOnly) {
+    return null;
+  }
 
   return (
     <Guide

--- a/apps/src/dance/lab2/views/GenerateDancer.tsx
+++ b/apps/src/dance/lab2/views/GenerateDancer.tsx
@@ -17,6 +17,7 @@ import {useLevelActivityMetrics} from '@cdo/apps/lab2/hooks/useLevelActivityMetr
 import useLifecycleNotifier from '@cdo/apps/lab2/hooks/useLifecycleNotifier';
 import Lab2Registry from '@cdo/apps/lab2/Lab2Registry';
 import continueOrFinishLesson from '@cdo/apps/lab2/progress/continueOrFinishLesson';
+import {isReadOnlyWorkspace} from '@cdo/apps/lab2/redux/lab2ReduxSelectors';
 import {LifecycleEvent} from '@cdo/apps/lab2/utils/LifecycleNotifier';
 import Adlib, {
   AdlibsType,
@@ -32,7 +33,7 @@ import {EVENTS} from '@cdo/apps/metrics/AnalyticsConstants';
 import analyticsReporter from '@cdo/apps/metrics/AnalyticsReporter';
 import getRandomInt from '@cdo/apps/util/getRandomInt';
 import HttpClient from '@cdo/apps/util/HttpClient';
-import {useAppDispatch} from '@cdo/apps/util/reduxHooks';
+import {useAppDispatch, useAppSelector} from '@cdo/apps/util/reduxHooks';
 import {trySetSessionStorage} from '@cdo/apps/utils';
 import backgroundImage from '@cdo/static/dance/generateDancer/generate-dancer-background.png';
 import dancerSilhouetteBrightImage from '@cdo/static/dance/generateDancer/generate-dancer-silhouette-bright.svg';
@@ -356,6 +357,8 @@ const GenerateDancer: React.FunctionComponent<DancerGenerateProps> = ({
     );
   }, [dispatch, levelProperties.appName, levelProperties.id]);
 
+  const isReadOnly = useAppSelector(isReadOnlyWorkspace);
+
   return (
     <div id="dance-lab" className={moduleStyles.dancerGenerate}>
       <div className={moduleStyles.mainContent}>
@@ -418,36 +421,39 @@ const GenerateDancer: React.FunctionComponent<DancerGenerateProps> = ({
                   <Adlib
                     adlib={adlibs[adlibOption]}
                     adlibChoices={adlibChoices}
-                    readOnly={['generating', 'reviewing'].includes(
-                      aiGenerateState
-                    )}
+                    readOnly={
+                      isReadOnly ||
+                      ['generating', 'reviewing'].includes(aiGenerateState)
+                    }
                     glowSpeed={glowSpeed}
                     onChoicesChange={onAdlibChoicesChange}
                     onTextChange={onAdlibTextChange}
                   />
                 )}
-                <div className={moduleStyles.buttonRow}>
-                  <Button
-                    ariaLabel={
-                      aiGenerateState === 'none'
-                        ? 'Generate dancer'
-                        : 'Generating dancer'
-                    }
-                    text={
-                      aiGenerateState === 'none'
-                        ? 'Generate dancer'
-                        : 'Generating dancer'
-                    }
-                    type="primary"
-                    color="black"
-                    size="s"
-                    iconLeft={{iconName: 'sparkles'}}
-                    isPending={aiGenerateState === 'generating'}
-                    disabled={aiGenerateState === 'generating'}
-                    onClick={() => generateDancer()}
-                    className={moduleStyles.buttonWide}
-                  />
-                </div>
+                {!isReadOnly && (
+                  <div className={moduleStyles.buttonRow}>
+                    <Button
+                      ariaLabel={
+                        aiGenerateState === 'none'
+                          ? 'Generate dancer'
+                          : 'Generating dancer'
+                      }
+                      text={
+                        aiGenerateState === 'none'
+                          ? 'Generate dancer'
+                          : 'Generating dancer'
+                      }
+                      type="primary"
+                      color="black"
+                      size="s"
+                      iconLeft={{iconName: 'sparkles'}}
+                      isPending={aiGenerateState === 'generating'}
+                      disabled={aiGenerateState === 'generating'}
+                      onClick={() => generateDancer()}
+                      className={moduleStyles.buttonWide}
+                    />
+                  </div>
+                )}
               </>
             )}
           {aiGenerateState === 'reviewing' && (
@@ -516,6 +522,7 @@ const GenerateDancer: React.FunctionComponent<DancerGenerateProps> = ({
             />
           )}
         </Guide>
+        )
         <div className={moduleStyles.dancerContainer} ref={containerRef}>
           <div className={moduleStyles.background}>
             <img

--- a/apps/src/dance/lab2/views/GenerateDancer.tsx
+++ b/apps/src/dance/lab2/views/GenerateDancer.tsx
@@ -522,7 +522,6 @@ const GenerateDancer: React.FunctionComponent<DancerGenerateProps> = ({
             />
           )}
         </Guide>
-        )
         <div className={moduleStyles.dancerContainer} ref={containerRef}>
           <div className={moduleStyles.background}>
             <img

--- a/apps/src/music/views/GenerateCode.tsx
+++ b/apps/src/music/views/GenerateCode.tsx
@@ -6,6 +6,7 @@ import React, {useCallback, useEffect, useState} from 'react';
 import {useParentLevelProperties} from '@cdo/apps/bubbleChoice/customModes/MusicDanceAi/ParentLevelPropertiesContext';
 import {sendSuccessReportForLevel} from '@cdo/apps/code-studio/progressRedux';
 import useLifecycleNotifier from '@cdo/apps/lab2/hooks/useLifecycleNotifier';
+import {isReadOnlyWorkspace} from '@cdo/apps/lab2/redux/lab2ReduxSelectors';
 import {LevelProperties} from '@cdo/apps/lab2/types';
 import {LifecycleEvent} from '@cdo/apps/lab2/utils/LifecycleNotifier';
 import Adlib, {
@@ -247,6 +248,11 @@ const GenerateCode: React.FunctionComponent<GenerateCodeProps> = ({
       )
     );
   }, [dispatch, levelProperties.appName, levelProperties.id]);
+
+  const isReadOnly = useAppSelector(isReadOnlyWorkspace);
+  if (isReadOnly) {
+    return null;
+  }
 
   const levelSpecificId = `generate-panel-${levelProperties.id}`;
   if (!packId) {


### PR DESCRIPTION
Disable the Guide UI on when viewing levels/projects in readonly mode. This applies for teachers viewing student work, and users viewing a shared project they don't own.

In Generate Dance and Generate Music levels, the guide is entirely hidden. For Generate Dancer levels, I opted to keep the guide visible but readonly so the viewer can still see what the prompt was (especially in the case of teacher assessing student work).

Also includes some fixes to the standalone/freeplay level type for enabling teacher viewing student work.

<img width="1513" height="827" alt="Screenshot 2025-11-19 at 3 02 05 PM" src="https://github.com/user-attachments/assets/8bf96add-08ca-47fa-a931-fb342241d187" />

<img width="1517" height="823" alt="Screenshot 2025-11-19 at 3 02 13 PM" src="https://github.com/user-attachments/assets/a1ce1c9d-aaec-4fa4-987e-152b783575cb" />

<img width="1515" height="826" alt="Screenshot 2025-11-19 at 3 02 23 PM" src="https://github.com/user-attachments/assets/3ed22699-bb70-4fb1-b572-f29a913cc920" />


## Links
https://codedotorg.atlassian.net/browse/LABS-1752

## Testing story
Tested locally on HoAI script and standalone levels.