### PR TITLE
Adds TextToSpeech to Guide (and updates to use content for Instructions and PanelsView)

### DIFF
--- a/apps/src/dance/lab2/views/GenerateDance.tsx
+++ b/apps/src/dance/lab2/views/GenerateDance.tsx
@@ -1,5 +1,4 @@
 import {Button} from '@code-dot-org/component-library/button';
-import {Heading3} from '@code-dot-org/component-library/typography';
 import * as GoogleBlockly from 'blockly/core';
 import {sample} from 'lodash';
 import React, {useCallback, useEffect, useState} from 'react';
@@ -7,6 +6,7 @@ import React, {useCallback, useEffect, useState} from 'react';
 import {BlockDefinition, WorkspaceSerialization} from '@cdo/apps/blockly/types';
 import {useParentLevelProperties} from '@cdo/apps/bubbleChoice/customModes/MusicDanceAi/ParentLevelPropertiesContext';
 import {sendSuccessReportForLevel} from '@cdo/apps/code-studio/progressRedux';
+import {queryParams} from '@cdo/apps/code-studio/utils';
 import {DanceLevelProperties} from '@cdo/apps/dance/types';
 import useLifecycleNotifier from '@cdo/apps/lab2/hooks/useLifecycleNotifier';
 import {isReadOnlyWorkspace} from '@cdo/apps/lab2/redux/lab2ReduxSelectors';
@@ -117,7 +117,7 @@ const GenerateDance: React.FunctionComponent<GenerateCodeProps> = ({
     getInitialChoices()
   );
 
-  const [promptText, setPromptText] = useState('');
+  const [localizedPromptText, setLocalizedPromptText] = useState('');
 
   useEffect(() => {
     // If there is already a generated dance when we begin, presumably
@@ -140,7 +140,7 @@ const GenerateDance: React.FunctionComponent<GenerateCodeProps> = ({
   useLifecycleNotifier(LifecycleEvent.LevelLoadCompleted, () => {
     setAiGenerateState('none');
     setAdlibChoices(getInitialChoices());
-    setPromptText('');
+    setLocalizedPromptText('');
   });
 
   const generateDance = useCallback(
@@ -216,8 +216,8 @@ const GenerateDance: React.FunctionComponent<GenerateCodeProps> = ({
     setAdlibChoices({...choices});
   }, []);
 
-  const onAdlibTextChange = useCallback((text: string) => {
-    setPromptText(text);
+  const onAdlibTextChange = useCallback((_text: string, localized: string) => {
+    setLocalizedPromptText(localized);
   }, []);
 
   const glowSpeed = aiGenerateState === 'generating' ? 'fast' : 'normal';
@@ -262,6 +262,9 @@ const GenerateDance: React.FunctionComponent<GenerateCodeProps> = ({
     );
   }, [dispatch, levelProperties.appName, levelProperties.id]);
 
+  const showTts =
+    levelProperties.offerBrowserTts || queryParams('show-tts') === 'true';
+
   const isReadOnly = useAppSelector(isReadOnlyWorkspace);
   if (isReadOnly) {
     return null;
@@ -280,14 +283,17 @@ const GenerateDance: React.FunctionComponent<GenerateCodeProps> = ({
         <MainInstructionsContent
           instructionsText={levelProperties.longInstructions}
           markdownClassName={styles.markdown}
+          showTts={showTts}
         />
       )}
 
       {aiGenerateState === 'generating' && (
-        <div>
-          <Heading3>Generating...</Heading3>
-          AI is generating code based on your prompt.
-        </div>
+        <MainInstructionsContent
+          heading="Generating..."
+          content="AI is generating code based on your prompt."
+          markdownClassName={styles.markdown}
+          showTts={showTts}
+        />
       )}
 
       {['none', 'generating', 'generated'].includes(aiGenerateState) && (
@@ -322,13 +328,18 @@ const GenerateDance: React.FunctionComponent<GenerateCodeProps> = ({
       )}
 
       {['listening', 'listened'].includes(aiGenerateState) && (
-        <div>
-          <Heading3>
-            {aiGenerateState === 'listening' && 'Take a look...'}
-            {aiGenerateState === 'listened' && 'Decide what to do next'}
-          </Heading3>
-          <div>AI generated code based on your prompt, "{promptText}"</div>
-        </div>
+        <MainInstructionsContent
+          heading={
+            aiGenerateState === 'listening'
+              ? 'Take a look...'
+              : aiGenerateState === 'listened'
+              ? 'Decide what to do next'
+              : ''
+          }
+          content={`AI generated code based on your prompt, "${localizedPromptText}"`}
+          markdownClassName={styles.markdown}
+          showTts={showTts}
+        />
       )}
 
       {aiGenerateState === 'listened' && (
@@ -389,27 +400,35 @@ const GenerateDance: React.FunctionComponent<GenerateCodeProps> = ({
       )}
 
       {aiGenerateState === 'editing' && !isRunning && (
-        <div>
-          <Heading3>Modify the code</Heading3>
-          AI helped you get started. Now, edit the code to make it your own.
-        </div>
+        <MainInstructionsContent
+          heading="Modify the code"
+          content="AI helped you get started. Now, edit the code to make it your own."
+          markdownClassName={styles.markdown}
+          showTts={showTts}
+        />
       )}
 
       {aiGenerateState === 'editing' && isRunning && (
-        <div>
-          <Heading3>Modify the code</Heading3>
-          Try changing the code.
-        </div>
+        <MainInstructionsContent
+          heading="Modify the code"
+          content="Try changing the code."
+          markdownClassName={styles.markdown}
+          showTts={showTts}
+        />
       )}
 
       {aiGenerateState === 'edited' && (
         <>
-          <div>
-            <Heading3>Modify the code</Heading3>
-            {isStandalone
-              ? 'Amazing moves! Keep editing, or use the tabs at the top to update your dancer design or music mix.'
-              : "Amazing moves! Keep editing, or use the tabs at the top to update your dancer design or music mix. Click Finish when you're done."}
-          </div>
+          <MainInstructionsContent
+            heading="Modify the code"
+            content={
+              isStandalone
+                ? 'Amazing moves! Keep editing, or use the tabs at the top to update your dancer design or music mix.'
+                : "Amazing moves! Keep editing, or use the tabs at the top to update your dancer design or music mix. Click Finish when you're done."
+            }
+            markdownClassName={styles.markdown}
+            showTts={showTts}
+          />
           <div className={styles.buttonRow}>
             <Button
               ariaLabel={'Back to prompt'}

--- a/apps/src/dance/lab2/views/GenerateDancer.tsx
+++ b/apps/src/dance/lab2/views/GenerateDancer.tsx
@@ -1,6 +1,5 @@
 import {Button} from '@code-dot-org/component-library/button';
 import {useTheme} from '@code-dot-org/component-library/common/contexts';
-import {Heading3} from '@code-dot-org/component-library/typography';
 import classNames from 'classnames';
 import {sample} from 'lodash';
 import React, {useCallback, useEffect, useRef, useState} from 'react';
@@ -91,6 +90,8 @@ const GenerateDancer: React.FunctionComponent<DancerGenerateProps> = ({
   );
 
   const [promptText, setPromptText] = useState<string>('');
+
+  const [localizedPromptText, setLocalizedPromptText] = useState<string>('');
 
   const variantHistory = useRef<number[]>([]);
 
@@ -341,8 +342,9 @@ const GenerateDancer: React.FunctionComponent<DancerGenerateProps> = ({
     variantHistory.current = [];
   }, []);
 
-  const onAdlibTextChange = useCallback((text: string) => {
+  const onAdlibTextChange = useCallback((text: string, localized: string) => {
     setPromptText(text);
+    setLocalizedPromptText(localized);
   }, []);
 
   const parentProperties = useParentLevelProperties();
@@ -358,6 +360,9 @@ const GenerateDancer: React.FunctionComponent<DancerGenerateProps> = ({
   }, [dispatch, levelProperties.appName, levelProperties.id]);
 
   const isReadOnly = useAppSelector(isReadOnlyWorkspace);
+
+  const showTts =
+    levelProperties.offerBrowserTts || queryParams('show-tts') === 'true';
 
   return (
     <div id="dance-lab" className={moduleStyles.dancerGenerate}>
@@ -375,14 +380,17 @@ const GenerateDancer: React.FunctionComponent<DancerGenerateProps> = ({
             <MainInstructionsContent
               instructionsText={levelProperties.longInstructions}
               markdownClassName={moduleStyles.markdown}
+              showTts={showTts}
             />
           )}
 
           {aiGenerateState === 'generating' && (
-            <div>
-              <Heading3>Generating...</Heading3>
-              AI is generating a dancer based on your prompt.
-            </div>
+            <MainInstructionsContent
+              heading="Generating"
+              content="AI is generating a dancer based on your prompt."
+              markdownClassName={moduleStyles.markdown}
+              showTts={showTts}
+            />
           )}
 
           {aiGenerateState === 'none' &&
@@ -457,12 +465,12 @@ const GenerateDancer: React.FunctionComponent<DancerGenerateProps> = ({
               </>
             )}
           {aiGenerateState === 'reviewing' && (
-            <div>
-              <Heading3>Decide what to do next</Heading3>
-              <div>
-                AI generated a dancer based on your prompt, "{promptText}"
-              </div>
-            </div>
+            <MainInstructionsContent
+              heading="Decide what to do next"
+              content={`AI generated a dancer based on your prompt, "${localizedPromptText}"`}
+              markdownClassName={moduleStyles.markdown}
+              showTts={showTts}
+            />
           )}
           {aiGenerateState === 'reviewing' && (
             <>

--- a/apps/src/lab2/views/components/Instructions/InstructionsV2.tsx
+++ b/apps/src/lab2/views/components/Instructions/InstructionsV2.tsx
@@ -6,7 +6,6 @@ import InstructorsOnly from '@cdo/apps/code-studio/components/InstructorsOnly';
 import {queryParams} from '@cdo/apps/code-studio/utils';
 import {LevelProperties} from '@cdo/apps/lab2/types';
 import MainInstructionsContent from '@cdo/apps/lab2/views/components/Instructions/MainInstructionsContent';
-import TextToSpeech from '@cdo/apps/lab2/views/components/TextToSpeech';
 
 import NavigationArea from './NavigationArea';
 import PredictQuestion from './PredictQuestion';
@@ -121,14 +120,10 @@ const Instructions: React.FunctionComponent<InstructionsProps> = ({
             <MainInstructionsContent
               instructionsText={longInstructions}
               handleInstructionsTextClick={handleInstructionsTextClick}
+              showTts={showTts}
             />
             <PredictQuestion className={moduleStyles.predictQuestion} />
           </div>
-          {showTts && (
-            <div className={moduleStyles.ttsContainer}>
-              <TextToSpeech text={longInstructions} />
-            </div>
-          )}
           {bottomComponent && (
             <div className={moduleStyles.bottomComponent}>
               {bottomComponent}

--- a/apps/src/lab2/views/components/Instructions/InstructionsV2.tsx
+++ b/apps/src/lab2/views/components/Instructions/InstructionsV2.tsx
@@ -1,11 +1,12 @@
 import {Theme, useTheme} from '@code-dot-org/component-library/common/contexts';
 import classNames from 'classnames';
-import React from 'react';
+import React, {useRef, MutableRefObject} from 'react';
 
 import InstructorsOnly from '@cdo/apps/code-studio/components/InstructorsOnly';
 import {queryParams} from '@cdo/apps/code-studio/utils';
 import {LevelProperties} from '@cdo/apps/lab2/types';
 import MainInstructionsContent from '@cdo/apps/lab2/views/components/Instructions/MainInstructionsContent';
+import TextToSpeech from '@cdo/apps/lab2/views/components/TextToSpeech';
 
 import NavigationArea from './NavigationArea';
 import PredictQuestion from './PredictQuestion';
@@ -81,6 +82,7 @@ const Instructions: React.FunctionComponent<InstructionsProps> = ({
   const isPredictLevel = predictSettings?.isPredictLevel;
   const showTts = offerBrowserTts || queryParams('show-tts') === 'true';
   const {theme: defaultTheme} = useTheme();
+  const ref: MutableRefObject<HTMLDivElement | null> = useRef(null);
 
   // Don't render anything if we don't have any instructions.
   if (longInstructions === undefined) {
@@ -120,10 +122,15 @@ const Instructions: React.FunctionComponent<InstructionsProps> = ({
             <MainInstructionsContent
               instructionsText={longInstructions}
               handleInstructionsTextClick={handleInstructionsTextClick}
-              showTts={showTts}
+              ref={ref}
             />
             <PredictQuestion className={moduleStyles.predictQuestion} />
           </div>
+          {showTts && (
+            <div className={moduleStyles.ttsContainer}>
+              <TextToSpeech contentRef={ref} />
+            </div>
+          )}
           {bottomComponent && (
             <div className={moduleStyles.bottomComponent}>
               {bottomComponent}

--- a/apps/src/lab2/views/components/Instructions/MainInstructionsContent.tsx
+++ b/apps/src/lab2/views/components/Instructions/MainInstructionsContent.tsx
@@ -1,5 +1,5 @@
 import classNames from 'classnames';
-import React from 'react';
+import React, {forwardRef, useRef, MutableRefObject} from 'react';
 
 import TextToSpeech from '@cdo/apps/lab2/views/components/TextToSpeech';
 import EnhancedSafeMarkdown from '@cdo/apps/templates/EnhancedSafeMarkdown';
@@ -17,33 +17,46 @@ interface MainInstructionsContentProps {
  * Component to display the main instructions content for a level.
  * This is extracted out to a component so it can be used both in Instructions
  * and in MainInstructionsBubblePreview.
+ *
+ * You can also get a reference to the rendered div, which can be useful when
+ * passed to a TextToSpeech component to render the contents as audio.
  */
-const MainInstructionsContent: React.FunctionComponent<
+const MainInstructionsContent = forwardRef<
+  HTMLElement,
   MainInstructionsContentProps
-> = ({
-  instructionsText,
-  markdownClassName,
-  handleInstructionsTextClick,
-  showTts,
-}) => {
-  return (
-    <div className={moduleStyles.mainInstructions}>
-      <EnhancedSafeMarkdown
-        markdown={instructionsText}
-        className={classNames(
-          moduleStyles.markdownText,
-          showTts ? moduleStyles.markdownTts : undefined,
-          markdownClassName
+>(
+  (
+    {instructionsText, markdownClassName, handleInstructionsTextClick, showTts},
+    ref
+  ) => {
+    const contentRef: MutableRefObject<HTMLElement | null> = useRef(null);
+
+    return (
+      <div
+        ref={(ref || contentRef) as MutableRefObject<HTMLDivElement | null>}
+        className={moduleStyles.mainInstructions}
+      >
+        <EnhancedSafeMarkdown
+          markdown={instructionsText}
+          className={classNames(
+            moduleStyles.markdownText,
+            showTts ? moduleStyles.markdownTts : undefined,
+            markdownClassName
+          )}
+          handleInstructionsTextClick={handleInstructionsTextClick}
+        />
+        {showTts && (
+          <div className={moduleStyles.markdownTtsContainer}>
+            <TextToSpeech
+              contentRef={
+                (ref || contentRef) as MutableRefObject<HTMLDivElement | null>
+              }
+            />
+          </div>
         )}
-        handleInstructionsTextClick={handleInstructionsTextClick}
-      />
-      {showTts && (
-        <div className={moduleStyles.markdownTtsContainer}>
-          <TextToSpeech text={instructionsText} />
-        </div>
-      )}
-    </div>
-  );
-};
+      </div>
+    );
+  }
+);
 
 export default MainInstructionsContent;

--- a/apps/src/lab2/views/components/Instructions/MainInstructionsContent.tsx
+++ b/apps/src/lab2/views/components/Instructions/MainInstructionsContent.tsx
@@ -1,6 +1,7 @@
 import classNames from 'classnames';
 import React from 'react';
 
+import TextToSpeech from '@cdo/apps/lab2/views/components/TextToSpeech';
 import EnhancedSafeMarkdown from '@cdo/apps/templates/EnhancedSafeMarkdown';
 
 import moduleStyles from './instructions.module.scss';
@@ -9,6 +10,7 @@ interface MainInstructionsContentProps {
   instructionsText: string;
   markdownClassName?: string;
   handleInstructionsTextClick?: (id: string) => void;
+  showTts?: boolean;
 }
 
 /**
@@ -18,14 +20,28 @@ interface MainInstructionsContentProps {
  */
 const MainInstructionsContent: React.FunctionComponent<
   MainInstructionsContentProps
-> = ({instructionsText, markdownClassName, handleInstructionsTextClick}) => {
+> = ({
+  instructionsText,
+  markdownClassName,
+  handleInstructionsTextClick,
+  showTts,
+}) => {
   return (
     <div className={moduleStyles.mainInstructions}>
       <EnhancedSafeMarkdown
         markdown={instructionsText}
-        className={classNames(moduleStyles.markdownText, markdownClassName)}
+        className={classNames(
+          moduleStyles.markdownText,
+          showTts ? moduleStyles.markdownTts : undefined,
+          markdownClassName
+        )}
         handleInstructionsTextClick={handleInstructionsTextClick}
       />
+      {showTts && (
+        <div className={moduleStyles.markdownTtsContainer}>
+          <TextToSpeech text={instructionsText} />
+        </div>
+      )}
     </div>
   );
 };

--- a/apps/src/lab2/views/components/Instructions/MainInstructionsContent.tsx
+++ b/apps/src/lab2/views/components/Instructions/MainInstructionsContent.tsx
@@ -6,19 +6,44 @@ import EnhancedSafeMarkdown from '@cdo/apps/templates/EnhancedSafeMarkdown';
 
 import moduleStyles from './instructions.module.scss';
 
-interface MainInstructionsContentProps {
-  instructionsText: string;
+interface BaseMainInstructionsContentProps {
+  /** Custom classname for the markdown container */
   markdownClassName?: string;
+  /** The callback for interactions with 'clickable text' */
   handleInstructionsTextClick?: (id: string) => void;
+  /** When true, renders a TextToSpeech play button to read the text */
   showTts?: boolean;
 }
+
+interface MainInstructionsContentWithMarkdown
+  extends BaseMainInstructionsContentProps {
+  /** Markdown to form the basis of the rendered instructions */
+  instructionsText: string;
+  heading?: never;
+  content?: never;
+}
+
+interface MainInstructionsContentSimple
+  extends BaseMainInstructionsContentProps {
+  instructionsText?: never;
+  /** The heading for the content, when not using instructionsText */
+  heading: string;
+  /** The simple paragraph content, when not using instructionsText */
+  content: string;
+}
+
+export type MainInstructionsContentProps =
+  | MainInstructionsContentWithMarkdown
+  | MainInstructionsContentSimple;
 
 /**
  * Component to display the main instructions content for a level.
  * This is extracted out to a component so it can be used both in Instructions
  * and in MainInstructionsBubblePreview.
  *
- * It assumes the `instructionsText` field is markdown.
+ * It assumes the `instructionsText` field is markdown. Otherwise, you can
+ * specify a `heading` and `content` which will render the equivalent markdown
+ * with a 3rd level heading and paragraph content.
  *
  * You can also get a reference to the rendered div, which can be useful when
  * passed to a TextToSpeech component to render the contents as audio. Just
@@ -39,10 +64,19 @@ const MainInstructionsContent = forwardRef<
   MainInstructionsContentProps
 >(
   (
-    {instructionsText, markdownClassName, handleInstructionsTextClick, showTts},
+    {
+      instructionsText,
+      heading,
+      content,
+      markdownClassName,
+      handleInstructionsTextClick,
+      showTts,
+    },
     ref
   ) => {
     const contentRef: MutableRefObject<HTMLElement | null> = useRef(null);
+
+    const markdown = instructionsText || `### ${heading}\n\n${content}`;
 
     return (
       <div
@@ -50,7 +84,7 @@ const MainInstructionsContent = forwardRef<
         className={moduleStyles.mainInstructions}
       >
         <EnhancedSafeMarkdown
-          markdown={instructionsText}
+          markdown={markdown}
           className={classNames(
             moduleStyles.markdownText,
             showTts ? moduleStyles.markdownTts : undefined,

--- a/apps/src/lab2/views/components/Instructions/MainInstructionsContent.tsx
+++ b/apps/src/lab2/views/components/Instructions/MainInstructionsContent.tsx
@@ -18,8 +18,21 @@ interface MainInstructionsContentProps {
  * This is extracted out to a component so it can be used both in Instructions
  * and in MainInstructionsBubblePreview.
  *
+ * It assumes the `instructionsText` field is markdown.
+ *
  * You can also get a reference to the rendered div, which can be useful when
- * passed to a TextToSpeech component to render the contents as audio.
+ * passed to a TextToSpeech component to render the contents as audio. Just
+ * pass in a `ref` to capture the element.
+ *
+ * If you pass showTts as `true`, then it will render its own TextToSpeech play
+ * button at the top-right of the container. It will ensure that the first item
+ * in the markdown content is rendered with enough of a margin to accommodate
+ * the button. It is therefore best if that is a header of some kind.
+ *
+ * If you want to use your own TextToSpeech button component, just pass the
+ * `ref` from this component along to the TextToSpeech's `contentRef`
+ * property and the TextToSpeech will read the text content of this component
+ * aloud when played.
  */
 const MainInstructionsContent = forwardRef<
   HTMLElement,

--- a/apps/src/lab2/views/components/Instructions/instructions.module.scss
+++ b/apps/src/lab2/views/components/Instructions/instructions.module.scss
@@ -49,6 +49,7 @@
 }
 
 .mainInstructions {
+  position: relative;
   white-space: normal;
 }
 
@@ -234,6 +235,27 @@
       }
     }
   }
+}
+
+.markdownTts {
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6 {
+    &:first-child {
+      margin-inline-end: 1.5rem;
+    }
+  }
+}
+
+.markdownTtsContainer {
+  display: flex;
+  justify-content: flex-end;
+  position: absolute;
+  top: 0;
+  inset-inline-end: 0;
 }
 
 .validationIcon {

--- a/apps/src/lab2/views/components/Instructions/instructions.module.scss
+++ b/apps/src/lab2/views/components/Instructions/instructions.module.scss
@@ -238,15 +238,8 @@
 }
 
 .markdownTts {
-  h1,
-  h2,
-  h3,
-  h4,
-  h5,
-  h6 {
-    &:first-child {
-      margin-inline-end: 1.5rem;
-    }
+  > *:first-child {
+    margin-inline-end: 1.5rem;
   }
 }
 

--- a/apps/src/lab2/views/components/Instructions/instructions.module.scss
+++ b/apps/src/lab2/views/components/Instructions/instructions.module.scss
@@ -237,12 +237,16 @@
   }
 }
 
+// For markdown content that contains the tts button inside its contents
 .markdownTts {
   > *:first-child {
+    // Make room within the first element to fit the tts button
     margin-inline-end: 1.5rem;
   }
 }
 
+// The text-to-speech button is contained and 'floated' to the top of the
+// current markdown container when tts is contained in the markdown content
 .markdownTtsContainer {
   display: flex;
   justify-content: flex-end;

--- a/apps/src/lab2/views/components/TextToSpeech.tsx
+++ b/apps/src/lab2/views/components/TextToSpeech.tsx
@@ -78,6 +78,8 @@ const TextToSpeech: React.FunctionComponent<TextToSpeechProps> = ({text}) => {
     }
   };
 
+  console.log('hello??', text, ttsButtonEnabled, isTtsAvailable);
+
   if (!ttsButtonEnabled || !isTtsAvailable) {
     return null;
   }

--- a/apps/src/lab2/views/components/TextToSpeech.tsx
+++ b/apps/src/lab2/views/components/TextToSpeech.tsx
@@ -1,17 +1,20 @@
 import FontAwesomeV6Icon from '@code-dot-org/component-library/fontAwesomeV6Icon';
 import classNames from 'classnames';
-import React, {useState} from 'react';
+import React, {useEffect, useState, MutableRefObject} from 'react';
 
 import {queryParams} from '@cdo/apps/code-studio/utils';
 import DCDO from '@cdo/apps/dcdo';
+import {useLocalization} from '@cdo/apps/localization';
 import {useBrowserTextToSpeech} from '@cdo/apps/sharedComponents/BrowserTextToSpeechWrapper';
-import currentLocale from '@cdo/apps/util/currentLocale';
 import i18n from '@cdo/locale';
 
 import moduleStyles from './TextToSpeech.module.scss';
 
 interface TextToSpeechProps {
-  text: string;
+  /** The exact text to read aloud. */
+  text?: string;
+  /** A Ref capturing the live content to read aloud. */
+  contentRef?: MutableRefObject<HTMLElement | null>;
 }
 
 const usePause = queryParams('tts-play-pause') === 'true';
@@ -21,18 +24,38 @@ const stopIcon = (queryParams('tts-stop-icon') as string) || 'circle-stop';
 const enabledLocales = DCDO.get('browser-tts-button-enabled-locales', []) as
   | string[]
   | boolean;
-const ttsButtonEnabled =
-  enabledLocales === true ||
-  (Array.isArray(enabledLocales) && enabledLocales.includes(currentLocale()));
 
 /**
  * TextToSpeech play button.
+ *
+ * This takes either some specific `text` content or a reference to a given
+ * element to derive that text from using the `textContent` property.
+ *
+ * The button is not rendered if the text-to-speech engine is not available
+ * or the current locale is not enabled via the array provided by the
+ * `browser-tts-button-enabled-locales` DCDO flag.
  */
-const TextToSpeech: React.FunctionComponent<TextToSpeechProps> = ({text}) => {
+const TextToSpeech: React.FunctionComponent<TextToSpeechProps> = ({
+  text,
+  contentRef,
+}) => {
   const {isTtsAvailable, speak, cancel, pause, resume} =
     useBrowserTextToSpeech();
   const [isPlaying, setIsPlaying] = useState(false);
   const [isPaused, setIsPaused] = useState(false);
+
+  const [ttsButtonEnabled, setTtsButtonEnabled] = useState(false);
+
+  const locale = useLocalization();
+
+  // Determine, whenever the locale is set on the first time or updated, if the
+  // text-to-speech engine is available for that locale.
+  useEffect(() => {
+    setTtsButtonEnabled(
+      enabledLocales === true ||
+        (Array.isArray(enabledLocales) && enabledLocales.includes(locale))
+    );
+  }, [locale]);
 
   const playText = () => {
     if (!isTtsAvailable) {
@@ -56,7 +79,11 @@ const TextToSpeech: React.FunctionComponent<TextToSpeechProps> = ({text}) => {
       return;
     }
 
-    const utterance = speak(text);
+    // Determine the text to speak by either using the 'text' override or the
+    // text content for the provided content element.
+    const spokenText: string = text || contentRef?.current?.textContent || '';
+
+    const utterance = speak(spokenText);
     if (utterance) {
       utterance.addEventListener('start', () => setIsPlaying(true));
       utterance.addEventListener('end', () => {
@@ -77,8 +104,6 @@ const TextToSpeech: React.FunctionComponent<TextToSpeechProps> = ({text}) => {
       playText();
     }
   };
-
-  console.log('hello??', text, ttsButtonEnabled, isTtsAvailable);
 
   if (!ttsButtonEnabled || !isTtsAvailable) {
     return null;

--- a/apps/src/lab2/views/components/guide/Guide.module.scss
+++ b/apps/src/lab2/views/components/guide/Guide.module.scss
@@ -89,8 +89,8 @@ $gap-height: 43px;
 .cornerIconButton {
   @include remove-button-styles;
   position: absolute;
-  top: 10px;
-  right: 20px;
+  top: 2px;
+  right: 12px;
   font-size: 24px;
   color: var(--neutral-base-white);
 }

--- a/apps/src/lab2/views/components/guide/GuideInstructions.tsx
+++ b/apps/src/lab2/views/components/guide/GuideInstructions.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 
+import {queryParams} from '@cdo/apps/code-studio/utils';
 import {LevelProperties} from '@cdo/apps/lab2/types';
 import Guide from '@cdo/apps/lab2/views/components/guide/Guide';
 import MainInstructionsContent from '@cdo/apps/lab2/views/components/Instructions/MainInstructionsContent';
@@ -22,7 +23,8 @@ const GuideInstructions: React.FunctionComponent<GuideInstructionsProps> = ({
   hasRun,
   hasEdited,
 }) => {
-  const {longInstructions} = levelProperties;
+  const {longInstructions, offerBrowserTts} = levelProperties;
+  const showTts = offerBrowserTts || queryParams('show-tts') === 'true';
 
   const levelSpecificId = `guide-instructions-${levelProperties.id}`;
 
@@ -37,6 +39,7 @@ const GuideInstructions: React.FunctionComponent<GuideInstructionsProps> = ({
         <MainInstructionsContent
           instructionsText={longInstructions}
           markdownClassName={styles.markdown}
+          showTts={showTts}
         />
       )}
 

--- a/apps/src/music/views/GenerateCode.tsx
+++ b/apps/src/music/views/GenerateCode.tsx
@@ -1,5 +1,4 @@
 import {Button} from '@code-dot-org/component-library/button';
-import {Heading3} from '@code-dot-org/component-library/typography';
 import {sample} from 'lodash';
 import React, {useCallback, useEffect, useState} from 'react';
 
@@ -286,10 +285,13 @@ const GenerateCode: React.FunctionComponent<GenerateCodeProps> = ({
       )}
 
       {aiGenerateState === 'generating' && (
-        <div>
-          <Heading3>Generating...</Heading3>
-          AI is generating code based on your prompt.
-        </div>
+        <MainInstructionsContent
+          instructionsText={
+            '### Generating...\n\nAI is generating code based on your prompt.'
+          }
+          markdownClassName={styles.markdown}
+          showTts={showTts}
+        />
       )}
 
       {['none', 'generating', 'generated'].includes(aiGenerateState) &&
@@ -343,15 +345,17 @@ const GenerateCode: React.FunctionComponent<GenerateCodeProps> = ({
       )}
 
       {['listening', 'listened'].includes(aiGenerateState) && (
-        <div>
-          <Heading3>
-            {aiGenerateState === 'listening' && 'Take a listen...'}
-            {aiGenerateState === 'listened' && 'Decide what to do next'}
-          </Heading3>
-          <div>
-            AI generated code based on your prompt, "{localizedPromptText}"
-          </div>
-        </div>
+        <MainInstructionsContent
+          instructionsText={`### ${
+            aiGenerateState === 'listening'
+              ? 'Take a listen...'
+              : aiGenerateState === 'listened'
+              ? 'Decide what to do next'
+              : ''
+          }\n\nAI generated code based on your prompt, "${localizedPromptText}"`}
+          markdownClassName={styles.markdown}
+          showTts={showTts}
+        />
       )}
 
       {aiGenerateState === 'listened' && (
@@ -412,25 +416,30 @@ const GenerateCode: React.FunctionComponent<GenerateCodeProps> = ({
       )}
 
       {aiGenerateState === 'editing' && !isPlaying && (
-        <div>
-          <Heading3>Modify the code</Heading3>
-          AI helped you get started. Make your own changes, then press Run.
-        </div>
+        <MainInstructionsContent
+          instructionsText={
+            '### Modify the code\n\nAI helped you get started. Make your own changes, then press Run.'
+          }
+          markdownClassName={styles.markdown}
+          showTts={showTts}
+        />
       )}
 
       {aiGenerateState === 'editing' && isPlaying && (
-        <div>
-          <Heading3>Modify the code</Heading3>
-          <div>Try changing the code. </div>
-        </div>
+        <MainInstructionsContent
+          instructionsText={'### Modify the code\n\nTry changing the code.'}
+          markdownClassName={styles.markdown}
+          showTts={showTts}
+        />
       )}
 
       {aiGenerateState === 'edited' && (
         <>
-          <div>
-            <Heading3>Modify the code</Heading3>
-            <div>That's a great mix!</div>
-          </div>
+          <MainInstructionsContent
+            instructionsText={"### Modify the code\n\nThat's a great mix!"}
+            markdownClassName={styles.markdown}
+            showTts={showTts}
+          />
           <div className={styles.buttonRow}>
             <Button
               ariaLabel={'Back to prompt'}

--- a/apps/src/music/views/GenerateCode.tsx
+++ b/apps/src/music/views/GenerateCode.tsx
@@ -5,6 +5,7 @@ import React, {useCallback, useEffect, useState} from 'react';
 
 import {useParentLevelProperties} from '@cdo/apps/bubbleChoice/customModes/MusicDanceAi/ParentLevelPropertiesContext';
 import {sendSuccessReportForLevel} from '@cdo/apps/code-studio/progressRedux';
+import {queryParams} from '@cdo/apps/code-studio/utils';
 import useLifecycleNotifier from '@cdo/apps/lab2/hooks/useLifecycleNotifier';
 import {isReadOnlyWorkspace} from '@cdo/apps/lab2/redux/lab2ReduxSelectors';
 import {LevelProperties} from '@cdo/apps/lab2/types';
@@ -259,6 +260,9 @@ const GenerateCode: React.FunctionComponent<GenerateCodeProps> = ({
     return null;
   }
 
+  const showTts =
+    levelProperties.offerBrowserTts || queryParams('show-tts') === 'true';
+
   return (
     <Guide key={levelSpecificId} id={levelSpecificId} modal={modal}>
       {aiGenerateState === 'none' &&
@@ -267,6 +271,7 @@ const GenerateCode: React.FunctionComponent<GenerateCodeProps> = ({
           <MainInstructionsContent
             instructionsText={levelProperties.longInstructions}
             markdownClassName={styles.markdown}
+            showTts={showTts}
           />
         )}
 

--- a/apps/src/music/views/GenerateCode.tsx
+++ b/apps/src/music/views/GenerateCode.tsx
@@ -286,9 +286,8 @@ const GenerateCode: React.FunctionComponent<GenerateCodeProps> = ({
 
       {aiGenerateState === 'generating' && (
         <MainInstructionsContent
-          instructionsText={
-            '### Generating...\n\nAI is generating code based on your prompt.'
-          }
+          heading="Generating..."
+          content="AI is generating code based on your prompt."
           markdownClassName={styles.markdown}
           showTts={showTts}
         />
@@ -346,13 +345,14 @@ const GenerateCode: React.FunctionComponent<GenerateCodeProps> = ({
 
       {['listening', 'listened'].includes(aiGenerateState) && (
         <MainInstructionsContent
-          instructionsText={`### ${
+          heading={
             aiGenerateState === 'listening'
               ? 'Take a listen...'
               : aiGenerateState === 'listened'
               ? 'Decide what to do next'
               : ''
-          }\n\nAI generated code based on your prompt, "${localizedPromptText}"`}
+          }
+          content={`AI generated code based on your prompt, "${localizedPromptText}"`}
           markdownClassName={styles.markdown}
           showTts={showTts}
         />
@@ -417,9 +417,8 @@ const GenerateCode: React.FunctionComponent<GenerateCodeProps> = ({
 
       {aiGenerateState === 'editing' && !isPlaying && (
         <MainInstructionsContent
-          instructionsText={
-            '### Modify the code\n\nAI helped you get started. Make your own changes, then press Run.'
-          }
+          heading="Modify the code"
+          content="AI helped you get started. Make your own changes, then press Run."
           markdownClassName={styles.markdown}
           showTts={showTts}
         />
@@ -427,7 +426,8 @@ const GenerateCode: React.FunctionComponent<GenerateCodeProps> = ({
 
       {aiGenerateState === 'editing' && isPlaying && (
         <MainInstructionsContent
-          instructionsText={'### Modify the code\n\nTry changing the code.'}
+          heading="Modify the code"
+          content="Try changing the code."
           markdownClassName={styles.markdown}
           showTts={showTts}
         />
@@ -436,7 +436,8 @@ const GenerateCode: React.FunctionComponent<GenerateCodeProps> = ({
       {aiGenerateState === 'edited' && (
         <>
           <MainInstructionsContent
-            instructionsText={"### Modify the code\n\nThat's a great mix!"}
+            heading="Modify the code"
+            content="That's a great mix!"
             markdownClassName={styles.markdown}
             showTts={showTts}
           />

--- a/apps/src/panels/PanelsView.tsx
+++ b/apps/src/panels/PanelsView.tsx
@@ -78,7 +78,7 @@ const PanelsView: React.FunctionComponent<PanelsProps> = ({
   const [typingDone, setTypingDone] = useState(false);
   const {cancel} = useBrowserTextToSpeech();
 
-  const contentRef: MutableRefObject<HTMLElement | null> = useRef(null);
+  const contentRef: MutableRefObject<HTMLDivElement | null> = useRef(null);
 
   const lastPanelStartTime = useRef<number>(Date.now());
   const nextButtonRef = useRef<HTMLButtonElement>(null);

--- a/apps/src/panels/PanelsView.tsx
+++ b/apps/src/panels/PanelsView.tsx
@@ -1,7 +1,14 @@
 import {Button} from '@code-dot-org/component-library/button';
 import classNames from 'classnames';
 import markdownToTxt from 'markdown-to-txt';
-import React, {useCallback, useEffect, useMemo, useRef, useState} from 'react';
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  MutableRefObject,
+} from 'react';
 import Typist from 'react-typist';
 
 import TextToSpeech from '@cdo/apps/lab2/views/components/TextToSpeech';
@@ -70,6 +77,8 @@ const PanelsView: React.FunctionComponent<PanelsProps> = ({
   >(undefined);
   const [typingDone, setTypingDone] = useState(false);
   const {cancel} = useBrowserTextToSpeech();
+
+  const contentRef: MutableRefObject<HTMLElement | null> = useRef(null);
 
   const lastPanelStartTime = useRef<number>(Date.now());
   const nextButtonRef = useRef<HTMLButtonElement>(null);
@@ -235,6 +244,7 @@ const PanelsView: React.FunctionComponent<PanelsProps> = ({
         )}
         {panel.text && (
           <div
+            ref={contentRef}
             className={classNames(
               styles.text,
               panel.dark && styles.textDark,
@@ -244,7 +254,7 @@ const PanelsView: React.FunctionComponent<PanelsProps> = ({
             {offerBrowserTts && (
               // Override the theme since the text container is always white.
               <div className={styles.ttsContainer} data-theme="Light">
-                <TextToSpeech text={panel.text} />
+                <TextToSpeech contentRef={contentRef} />
               </div>
             )}
             {showTyping ? (

--- a/apps/src/sharedComponents/BrowserTextToSpeechWrapper.tsx
+++ b/apps/src/sharedComponents/BrowserTextToSpeechWrapper.tsx
@@ -6,6 +6,8 @@ import React, {
   useState,
 } from 'react';
 
+import {useLocalization} from '@cdo/apps/localization';
+
 import {
   isTtsAvailable,
   onTtsAvailable,
@@ -21,9 +23,11 @@ const BrowserTextToSpeechWrapper: React.FC<{children: ReactNode}> = ({
 }) => {
   const [ttsReady, setTtsReady] = useState(isTtsAvailable());
 
+  const locale = useLocalization();
+
   useEffect(() => {
     onTtsAvailable(setTtsReady);
-  }, []);
+  }, [locale]);
 
   return (
     <BrowserTtsContext.Provider value={{isTtsAvailable: ttsReady, ...ttsApi}}>

--- a/lib/dynamic_config/dcdo.rb
+++ b/lib/dynamic_config/dcdo.rb
@@ -53,7 +53,7 @@ class DCDOBase < DynamicConfigBase
       'teacher-homepage-v2-announcement': DCDO.get('teacher-homepage-v2-announcement', false),
       'best-of-stem-2024': DCDO.get('best-of-stem-2024', false),
       # Enabled locales for browser text to speech. Set to an empty array to disable all languages, or true to enable all.
-      'browser-tts-button-enabled-locales': DCDO.get('browser-tts-button-enabled-locales', ['en-US']),
+      'browser-tts-button-enabled-locales': DCDO.get('browser-tts-button-enabled-locales', ['en-US', 'en']),
       'lab2-submit-project-enabled': DCDO.get('lab2-submit-project-enabled', true),
       'cdo-blockly-usage': DCDO.get('cdo-blockly-usage', false),
       'ai-dancer-head-crop': DCDO.get('ai-dancer-head-crop', false),


### PR DESCRIPTION
Updates the `TextToSpeech`, `MainInstructionsContent`, and `Guide` components (and styles) to accommodate the use of a `TextToSpeech` play button in `Guide` components.

In the localization system, the content changes without a page load. So, components that need to reflect a change in language need to make use of the `useLocalization` hook. This adds such logic to the text-to-speech support code to ensure that when it renders, it might re-render as null if text-to-speech is not enabled in the locale that is switched to and vice versa.

Also, the content is what is rendered inside the container. The existing `TextToSpeech` assumes it is given the text beforehand. This is problematic even in the old system as the 'localized' string is often markdown content for instructions. Therefore, the TTS engine _might_ read the `#` symbols aloud, especially if the markdown does not have a space between the hashes and the first word of the header.

To faciliate this, the `TextToSpeech` component was updated to use the existing `text` property as an "override" for when you want to provide an exact phrase but also to use a `contentRef` when you want to pass it a `ref` of a rendered component. It will then get the current live text content of that element to read aloud when the button is pressed. This solves both the markdown problem in the old system and supports on-demand localization of the new localization system.

The existing instructions component was wired up to use the `contentRef` property.

The `PanelsView` component powering the panels levels was also updated to pass the content into the `TextToSpeech` component to also avoid markdown issues and support the new TMS.

## Examples

| Image | Description |
|--------|--------------|
| <img width="337" height="226" alt="image" src="https://github.com/user-attachments/assets/0adb02a0-514b-4ed3-920f-9ef2b6898e7c" /> | English `Guide` component with a TTS button |
| <img width="341" height="228" alt="image" src="https://github.com/user-attachments/assets/dd50c001-4920-4a84-a3e0-bb3c80fbd84c" />| Spanish selected for a `Guide` component |
| <img width="278" height="525" alt="image" src="https://github.com/user-attachments/assets/fa440e58-bbe9-44c1-8750-6021dfa10d83" /> | Squished Spanish `Guide` |
| <img width="341" height="228" alt="image" src="https://github.com/user-attachments/assets/71908b8d-89f7-475f-93ef-2e523cdb1944" /> | Korean without a tts button |
| <img width="270" height="510" alt="image" src="https://github.com/user-attachments/assets/0b73b57e-a071-40d2-96aa-7cbd4dedb22a" /> | English Instructions panel (new TMS) with tts button |
| <img width="272" height="602" alt="image" src="https://github.com/user-attachments/assets/fc4297d2-a33d-4c32-b98f-c52c987c3247" /> | Spanish Instructions panel (new TMS) with tts button |
| <img width="210" height="275" alt="image" src="https://github.com/user-attachments/assets/ef1fc972-483a-4f6f-9328-af4812639665" /> | Existing Instructions panel with tts button |
| <img width="567" height="316" alt="image" src="https://github.com/user-attachments/assets/54e6c519-b6e9-432b-b6e7-925d6d047322" /> | Spanish `PanelsView` with a tts button |

## Video

https://github.com/user-attachments/assets/166434d9-2ca9-4e36-b616-6ea88cb0568d

https://github.com/user-attachments/assets/c6561c5e-423a-4c11-bdc8-3e3123c57d74

## Links

- Jira: [LABS-1674](https://codedotorg.atlassian.net/browse/LABS-1674)

## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
