### PR TITLE
Double-check student CAP compliance before sending warning email

### DIFF
--- a/dashboard/app/jobs/cap/teacher_sections_warning_job.rb
+++ b/dashboard/app/jobs/cap/teacher_sections_warning_job.rb
@@ -15,12 +15,22 @@ module CAP
         email_cap_sections = []
 
         cap_affected_sections.where(user: teacher).find_each do |section|
+          section_students = Queries::ChildAccount.cap_affected(scope: section.students)
+          # Although the student might normally be affected by CAP, we have exceptions
+          # such as being in a school managed sections. So we must double-check each student's
+          # compliance.
+          non_compliant_students = section_students.reject {|s| Policies::ChildAccount.compliant?(s)}
+
+          next if non_compliant_students.empty?
+
           cap_section_ids << section.id
           email_cap_sections << {
             Name: section.name,
             Link: section.manage_students_url,
           }
         end
+
+        next if email_cap_sections.empty?
 
         send_warning_email(teacher.email, teacher.name, email_cap_sections)
 

--- a/dashboard/test/jobs/cap/teacher_sections_warning_job_test.rb
+++ b/dashboard/test/jobs/cap/teacher_sections_warning_job_test.rb
@@ -126,5 +126,15 @@ class CAP::TeacherSectionsWarningJobTest < ActiveJob::TestCase
         perform_enqueued_jobs {perform_later}
       end
     end
+
+    context 'when student is locked but in a Google Classroom section' do
+      let(:section) {create(:section, user: teacher, name: section_name, hidden: section_hidden, login_type: Section::LOGIN_TYPE_GOOGLE_CLASSROOM)}
+
+      it 'does not warn teacher because student is compliant via section membership' do
+        expect_teacher_warning_to_be_sent.never
+        expect_event_logging.never
+        perform_enqueued_jobs {perform_later}
+      end
+    end
   end
 end


### PR DESCRIPTION
Currently, we don’t enforce CAP on students in Google Classroom sections, even for states that enforce CAP. We use [Policies::ChildAccount.compliant?](https://github.com/code-dot-org/code-dot-org/blob/staging/dashboard/lib/policies/child_account.rb#L46) to determine if a student should be locked out or not, regardless of the cap_status(user.cap_status). However, there is a [teacher sections warning job](https://github.com/code-dot-org/code-dot-org/blob/staging/dashboard/app/jobs/cap/teacher_sections_warning_job.rb) that sends teachers emails about students who are locked out of their sections. [The query](https://github.com/code-dot-org/code-dot-org/blob/staging/dashboard/lib/queries/child_account.rb#L22) that assembles the list of cap affected students goes off of the user.cap_status value. So even if a student is compliant by being rostered in a Google Classroom section (where Policies::ChildAccount.compliant? would return true), they will be included in this warning the teachers receive.

This PR double-checks each student's CAP compliance before sending a warning email to a teacher.

Ideally `cap_affected` would have been updated, but I couldn't think of an efficient way to do that. In this solution, we use cap_affected as a very efficient way to filter the millions of student accounts we have, then we apply the expensive `.compliant?` filtering on a much smaller subset of students.


## Links
* [Jira](https://codedotorg.atlassian.net/browse/P20-1714)
## Testing story
* Unit tests


## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
