### PR TITLE
Fix DTT: Mysql2::Error: Column 'data_updated_at' cannot be null

### DIFF
--- a/shared/test/test_poste.rb
+++ b/shared/test/test_poste.rb
@@ -21,7 +21,8 @@ class PosteTest < SequelTestCase
         hashed_email: STUDENT_EMAIL_HASH,
         username: 'code studio student',
         user_type: 'student',
-        birthday: '2000-01-02'
+        birthday: '2000-01-02',
+        updated_at: Time.now,
       }
     )
     DASHBOARD_DB[:users].insert(
@@ -30,7 +31,8 @@ class PosteTest < SequelTestCase
         hashed_email: TEACHER_EMAIL_HASH,
         username: 'code studio teacher',
         user_type: 'teacher',
-        birthday: '2000-01-02'
+        birthday: '2000-01-02',
+        updated_at: Time.now,
       }
     )
   end
@@ -291,7 +293,8 @@ class Poste2Test < SequelTestCase
       hashed_email: hashed_email,
       username: 'code studio student',
       user_type: 'student',
-      birthday: '2000-01-02'
+      birthday: '2000-01-02',
+      updated_at: Time.now,
     )
     # rubocop:enable CustomCops/DashboardDbUsage
 
@@ -309,7 +312,8 @@ class Poste2Test < SequelTestCase
       hashed_email: hashed_email,
       username: 'code studio teacher',
       user_type: 'teacher',
-      birthday: '2000-01-02'
+      birthday: '2000-01-02',
+      updated_at: Time.now,
     )
     # rubocop:enable CustomCops/DashboardDbUsage
 


### PR DESCRIPTION
DTT is currently blocked by failing ruby unit tests:
```
[0m[1000D[KERROR["test_dry_run_makes_no_Pardot_API_calls", "ContactRollupsV2Test", 71.56187427602708]
 test_dry_run_makes_no_Pardot_API_calls#ContactRollupsV2Test (71.56s)
Minitest::UnexpectedError:         ActiveRecord::NotNullViolation: Mysql2::Error: Column 'data_updated_at' cannot be null
```

The theory is that the ContactRollupsV2Test are running at the same time as this test, which is creating users without updated_at set (due to Sequelize being used in test_poste.rb), which then fails the ContactRollupsV2Test.

See slack thread: https://codedotorg.slack.com/archives/C0T0PNTM3/p1763621980250769