### PR TITLE
include SetupTest in shared PosteTest

### DIFF
--- a/shared/test/test_poste.rb
+++ b/shared/test/test_poste.rb
@@ -8,6 +8,8 @@ require 'digest/md5'
 
 # rubocop:disable CustomCops/PegasusDbUsage
 class PosteTest < SequelTestCase
+  include SetupTest
+
   STUDENT_EMAIL = 'student@example.net'.freeze
   STUDENT_EMAIL_HASH = Digest::MD5.hexdigest(STUDENT_EMAIL).freeze
   TEACHER_EMAIL = 'teacher@example.net'.freeze

--- a/shared/test/test_poste.rb
+++ b/shared/test/test_poste.rb
@@ -138,6 +138,8 @@ class PosteTest < SequelTestCase
 end
 
 class Poste2Test < SequelTestCase
+  include SetupTest
+
   FROM_NAME = 'Code dot org'.freeze
   FROM_EMAIL = 'noreply@code.org'.freeze
   REPLY_TO_NAME = 'Reply-to Person'.freeze


### PR DESCRIPTION
speculative fix for issue where poste test is leaving bad user records in the dashboard test db. see [slack](https://codedotorg.slack.com/archives/C0T0PNTM3/p1763659046490939?thread_ts=1763621980.250769&cid=C0T0PNTM3) for details.

## Testing story

print debugging to confirm that `DASHBOARD_DB.transaction(rollback: :always)` is now getting called, and that it is happening outside of the setup block that creates the problematic users:
```
[09:15:59] Dave-M4:~/src/cdo/shared (staging *)$ bundle exec ruby -Itest ../shared/test/test_poste.rb
...
PosteTest
  test_decrypt_then_encrypt_noop                                  PASS (0.00s)
opening DASHBOARD_DB.transaction
starting PosteTest setup
finishing PosteTest setup
closing DASHBOARD_DB.transaction
```

@mgc1194 also verified manually on the test machine that there are no entries left in the users table after resetting dashboard_test1 and running this test.