### PR TITLE
Revert "[AIChat] Adds aria-live screenreader support"

### DIFF
--- a/apps/src/aichat/views/ChatWorkspace.tsx
+++ b/apps/src/aichat/views/ChatWorkspace.tsx
@@ -1,7 +1,6 @@
 import {FontAwesomeV6IconProps} from '@code-dot-org/component-library/fontAwesomeV6Icon';
 import Tabs, {TabsProps} from '@code-dot-org/component-library/tabs';
-import markdownToTxt from 'markdown-to-txt';
-import React, {useCallback, useEffect, useState, useMemo} from 'react';
+import React, {useCallback, useEffect, useMemo} from 'react';
 
 import {useAiChatDisabled} from '@cdo/apps/aichat/context/aiChatDisabledContext';
 import {isModelUpdate, WorkspaceTeacherViewTab} from '@cdo/apps/aichat/types';
@@ -225,17 +224,6 @@ const ChatWorkspace: React.FunctionComponent<ChatWorkspaceProps> = ({
     });
   }, [dispatch, previousParameters, modelParameters]);
 
-  const [liveAnnouncement, setLiveAnnouncement] = useState('');
-  const chatEvents = selectedStudent ? studentChatHistory : visibleItems;
-  useEffect(() => {
-    if (chatEvents.length > 0) {
-      const last = chatEvents[chatEvents.length - 1];
-      if ('chatMessageText' in last && last.chatMessageText) {
-        setLiveAnnouncement(markdownToTxt(last.chatMessageText));
-      }
-    }
-  }, [chatEvents]);
-
   const iconValue: FontAwesomeV6IconProps = {
     iconName: 'lock',
     iconStyle: 'solid',
@@ -296,18 +284,15 @@ const ChatWorkspace: React.FunctionComponent<ChatWorkspaceProps> = ({
 
   const uploadDisabled = !canChatWithModel || !!selectedStudent || chatDisabled;
 
+  const chatEvents = selectedStudent ? studentChatHistory : visibleItems;
+
   const isTeacherView = !!selectedStudent;
 
   const showTabs =
     selectedStudent && clientType === AiChatClientTypes.AI_CHAT_LAB;
 
   return (
-    <div
-      id="chat-workspace-area"
-      className={moduleStyles.chatWorkspace}
-      aria-live="polite"
-    >
-      <div className={moduleStyles.accessibilityHidden}>{liveAnnouncement}</div>
+    <div id="chat-workspace-area" className={moduleStyles.chatWorkspace}>
       {showTabs ? (
         <Tabs {...tabArgs} />
       ) : (
@@ -317,6 +302,7 @@ const ChatWorkspace: React.FunctionComponent<ChatWorkspaceProps> = ({
           buildAssetUrl={buildAssetUrlValue}
         />
       )}
+
       <div className={moduleStyles.footer}>
         {multimodalAvailable && (
           <StagedFilesPreview buildAssetUrl={buildAssetUrl} />

--- a/apps/src/aichat/views/chatWorkspace.module.scss
+++ b/apps/src/aichat/views/chatWorkspace.module.scss
@@ -25,16 +25,6 @@ $tabs-default-spacing: 4px;
   border-radius: 0.375rem;
 }
 
-// We should avoid using this unless necessary for accessibility,
-// as it renders its component out of frame at a size of 1 pixel.
-.accessibilityHidden {
-  position: 'absolute';
-  left: '-9999px';
-  height: 1;
-  width: 1;
-  overflow: 'hidden';
-}
-
 %conversation-area,
 .conversationArea {
   flex-grow: 1;


### PR DESCRIPTION
Reverts code-dot-org/code-dot-org#69548

Now the web is flagging these values as 'invalid property values' so I'll need to find another solution
<img width="349" height="185" alt="Screenshot 2025-11-20 at 12 05 00 PM" src="https://github.com/user-attachments/assets/ac0dff43-aeea-486c-b857-32216d6a291e" />
