### PR TITLE
Add error message for undefined Java filename error

### DIFF
--- a/apps/i18n/javalab/en_us.json
+++ b/apps/i18n/javalab/en_us.json
@@ -102,6 +102,7 @@
   "javaExtensionMissing": "Invalid file name. File names must end in '.java'.",
   "javabuilderInvalidClassError": "{causeMessage} is not supported by Java Lab.",
   "javabuilderJavaFilenameError": "Java file: {causeMessage} has an invalid file name. Java file names cannot contain spaces or special characters.",
+  "javabuilderJavaFilenameUndefinedError": "One of the Java file names is invalid. Please check the file names and try again.",
   "javabuilderMissingFilenameError": "One or more of your project files are missing file names.",
   "makeStarter": "Make starter file",
   "makeSupport": "Make support file",

--- a/apps/src/javalab/javabuilderExceptionHandler.js
+++ b/apps/src/javalab/javabuilderExceptionHandler.js
@@ -58,7 +58,10 @@ export function getExceptionMessage(exceptionDetails, type, miniAppType) {
       error = msg.fileNotFoundException({causeMessage});
       break;
     case JavabuilderExceptionType.INVALID_JAVA_FILE_NAME:
-      error = msg.javabuilderJavaFilenameError({causeMessage});
+      error =
+        causeMessage && causeMessage.length > 0
+          ? msg.javabuilderJavaFilenameError({causeMessage})
+          : msg.javabuilderJavaFilenameUndefinedError();
       break;
     case JavabuilderExceptionType.MISSING_PROJECT_FILE_NAME:
       error = msg.javabuilderMissingFilenameError();


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
In the case of an error caused by and invalid file name that is `undefined`, we return a more generic error message. Related to https://github.com/code-dot-org/javabuilder/pull/412. See jira ticket for details.


## Links
<!--  Links to relevant external resources.
      - spec docs, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- Jira: https://codedotorg.atlassian.net/browse/AFL-207

## Testing story
<!--  Does your change include appropriate tests?
      - If so, please describe how the tests included in this PR are sufficient.
      - If not, please explain why this change does not need to be tested. -->



## Deployment strategy
<!--  Any special steps required to deploy this, besides merging?
      - Are there database migrations or manual steps?
      - Does this require coordination with other teams or systems? -->



## Follow-up work
<!--  List any clean-up or technical debt that will be addressed in future work.
      - Include Jira links where applicable.
      - Are there any known limitations or improvements planned? -->



## Privacy
<!--  How does this change impact Student & Teacher privacy?
      - Does this collect, use, share, or modify PII, either new or existing? -->



## Security
<!--  How does this change impact our security surface-area?
      - Do API's touched have the right auth?
      - Do infra changes impact our attack surface or encryption?
-->



## Caching
<!--  How does this change impact caching behavior?
      - Are cache keys or invalidation strategies affected?
      - Will this require cache warming or invalidation after deployment? -->



## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
