### PR TITLE
Set stableID in local storage

### DIFF
--- a/apps/src/metrics/statsigHelpers.js
+++ b/apps/src/metrics/statsigHelpers.js
@@ -31,14 +31,8 @@ export function findOrCreateStableId() {
   const localStorageId = localStorage.getItem(LOCAL_STORAGE_KEY);
   let stableId;
 
-  if (cookieId && localStorageId) {
-    if (cookieId === localStorageId) {
-      stableId = cookieId;
-    } else {
-      // If both exist but differ, prefer localStorage (less likely to be cleared)
-      stableId = localStorageId;
-    }
-  } else if (cookieId) {
+  if (cookieId) {
+    // Prefer the cookie value if it exists
     stableId = cookieId;
   } else if (localStorageId) {
     stableId = localStorageId;
@@ -49,14 +43,15 @@ export function findOrCreateStableId() {
   if (consentAllowsStatsigCookie()) {
     cookies.set(STABLE_ID_KEY, stableId, COOKIE_OPTIONS);
     localStorage.setItem(LOCAL_STORAGE_KEY, stableId);
+    return stableId;
   } else {
     // Ensure any existing cookie is removed to satisfy OneTrust
     // (must pass same attributes used when setting the cookie)
     cookies.remove(STABLE_ID_KEY, {path: '/', domain: '.code.org'});
     localStorage.removeItem(LOCAL_STORAGE_KEY);
+    // Return undefined to let Statsig set it's own stableID
+    return undefined;
   }
-
-  return stableId;
 }
 
 function consentAllowsStatsigCookie() {

--- a/apps/src/metrics/statsigHelpers.js
+++ b/apps/src/metrics/statsigHelpers.js
@@ -27,10 +27,22 @@ export function getUserType() {
 }
 
 export function findOrCreateStableId() {
-  let stableId =
-    cookies.get(STABLE_ID_KEY) || localStorage.getItem(LOCAL_STORAGE_KEY);
+  const cookieId = cookies.get(STABLE_ID_KEY);
+  const localStorageId = localStorage.getItem(LOCAL_STORAGE_KEY);
+  let stableId;
 
-  if (!stableId) {
+  if (cookieId && localStorageId) {
+    if (cookieId === localStorageId) {
+      stableId = cookieId;
+    } else {
+      // If both exist but differ, prefer localStorage (less likely to be cleared)
+      stableId = localStorageId;
+    }
+  } else if (cookieId) {
+    stableId = cookieId;
+  } else if (localStorageId) {
+    stableId = localStorageId;
+  } else {
     stableId = createUuid();
   }
 

--- a/apps/src/metrics/statsigHelpers.js
+++ b/apps/src/metrics/statsigHelpers.js
@@ -3,6 +3,7 @@ import cookies from 'js-cookie';
 import {getEnvironment, isProductionEnvironment, createUuid} from '../utils';
 
 const STABLE_ID_KEY = 'statsig_stable_id';
+const LOCAL_STORAGE_KEY = STABLE_ID_KEY.toUpperCase();
 const COOKIE_OPTIONS = {
   path: '/',
   domain: '.code.org',
@@ -26,7 +27,8 @@ export function getUserType() {
 }
 
 export function findOrCreateStableId() {
-  let stableId = cookies.get(STABLE_ID_KEY);
+  let stableId =
+    cookies.get(STABLE_ID_KEY) || localStorage.getItem(LOCAL_STORAGE_KEY);
 
   if (!stableId) {
     stableId = createUuid();
@@ -34,10 +36,12 @@ export function findOrCreateStableId() {
 
   if (consentAllowsStatsigCookie()) {
     cookies.set(STABLE_ID_KEY, stableId, COOKIE_OPTIONS);
+    localStorage.setItem(LOCAL_STORAGE_KEY, stableId);
   } else {
     // Ensure any existing cookie is removed to satisfy OneTrust
     // (must pass same attributes used when setting the cookie)
     cookies.remove(STABLE_ID_KEY, {path: '/', domain: '.code.org'});
+    localStorage.removeItem(LOCAL_STORAGE_KEY);
   }
 
   return stableId;


### PR DESCRIPTION
This PR adds two changes:

- To align with Marketing site functionality, also set stableID in local storage if OneTrust consent allows
- Don't return stableID if OneTrust consent isn't given. This allows Statsig to fallback to default functionality and set it's own

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->



## Links
<!--  Links to relevant external resources.
      - spec docs, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- Jira: 

## Testing story
<!--  Does your change include appropriate tests?
      - If so, please describe how the tests included in this PR are sufficient.
      - If not, please explain why this change does not need to be tested. -->



## Deployment strategy
<!--  Any special steps required to deploy this, besides merging?
      - Are there database migrations or manual steps?
      - Does this require coordination with other teams or systems? -->



## Follow-up work
<!--  List any clean-up or technical debt that will be addressed in future work.
      - Include Jira links where applicable.
      - Are there any known limitations or improvements planned? -->



## Privacy
<!--  How does this change impact Student & Teacher privacy?
      - Does this collect, use, share, or modify PII, either new or existing? -->



## Security
<!--  How does this change impact our security surface-area?
      - Do API's touched have the right auth?
      - Do infra changes impact our attack surface or encryption?
-->



## Caching
<!--  How does this change impact caching behavior?
      - Are cache keys or invalidation strategies affected?
      - Will this require cache warming or invalidation after deployment? -->



## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
