### PR TITLE
hoai2025: share and remix buttons in freeplay header

### DIFF
--- a/dashboard/app/dsl/bubble_choice_dsl.rb
+++ b/dashboard/app/dsl/bubble_choice_dsl.rb
@@ -58,6 +58,8 @@ class BubbleChoiceDSL < ContentDSL
 
   def finish_dialog(text) @hash[:finish_dialog] = text end
 
+  def hide_share_and_remix(value) @hash[:hide_share_and_remix] = value end
+
   def self.serialize(level)
     new_dsl = "name '#{escape(level.name)}'"
     new_dsl += "\neditor_experiment '#{level.editor_experiment}'" if level.editor_experiment.present?

--- a/dashboard/app/models/levels/bubble_choice.rb
+++ b/dashboard/app/models/levels/bubble_choice.rb
@@ -39,6 +39,7 @@ class BubbleChoice < DSLDefined
     custom_mode
     navigation_type
     finish_dialog
+    hide_share_and_remix
   )
 
   ALPHABET = ('a'..'z').to_a

--- a/dashboard/config/scripts/mix_move_ai_dance_freeplay.bubble_choice
+++ b/dashboard/config/scripts/mix_move_ai_dance_freeplay.bubble_choice
@@ -12,3 +12,4 @@ custom_mode 'music_dance_ai'
 uses_lab2
 navigation_type 'next_level'
 finish_dialog 'hoai2025'
+hide_share_and_remix 'false'


### PR DESCRIPTION
Enable the Share and Remix buttons on the freeplay level header. This involves adding a new `hide_share_and_remix` field to bubble choice DSL levels, which is only applicable for bubble choice projects like this.

<img width="757" height="452" alt="Screenshot 2025-11-20 at 3 14 54 PM" src="https://github.com/user-attachments/assets/e09a2dd6-bda2-482e-94ce-8df223b7a66f" />

## Links
https://codedotorg.atlassian.net/browse/LABS-1693

## Testing story
Tested locally with freeplay level.