### PR TITLE
Drone: Upgrade drone/autoscaler to upgrade docker client

### DIFF
--- a/aws/cloudformation/drone-stack.yml
+++ b/aws/cloudformation/drone-stack.yml
@@ -304,7 +304,7 @@ Resources:
         -
           Name: drone-autoscaler
           Essential: true
-          Image: drone/autoscaler:1.13.0
+          Image: drone/autoscaler:1.14.0
           MemoryReservation: 1024
           LogConfiguration:
             LogDriver: awslogs

--- a/aws/cloudformation/drone-stack.yml
+++ b/aws/cloudformation/drone-stack.yml
@@ -408,6 +408,9 @@ Resources:
 
             # BEGIN: Settings for the Drone Runner ("worker"/"agent") executing on the EC2 Instances provisioned by Autoscaler.
             -
+              Name: DRONE_AGENT_IMAGE
+              Value: drone/drone-runner-docker:1.8
+            -
               Name: DRONE_AGENT_CONCURRENCY
               Value: 1
             # END: Settings for the Drone Runner.

--- a/aws/cloudformation/drone-stack.yml
+++ b/aws/cloudformation/drone-stack.yml
@@ -40,6 +40,10 @@ Parameters:
   WorkerSubnetId:
     Type: AWS::EC2::Subnet::Id
     Description: Existing VPC Subnet Id where ECS EC2 Instances hosting Drone Runner ("worker") containers will be provisioned.
+  WorkerImage:
+    Type: String
+    Description: Docker Image that Drone Autoscaler tells Drone Runner ("worker") EC2 Instances to Pull and launch.
+    Default: 'drone/drone-runner-docker:1.8'
   DroneServerECSAMI:
     Description: AMI ID for EC2 Instance running Drone Server ECS Service.
     Type: AWS::SSM::Parameter::Value<AWS::EC2::Image::Id>
@@ -408,8 +412,8 @@ Resources:
 
             # BEGIN: Settings for the Drone Runner ("worker"/"agent") executing on the EC2 Instances provisioned by Autoscaler.
             -
-              Name: DRONE_AGENT_IMAGE
-              Value: drone/drone-runner-docker:1.8
+              Name: DRONE_AGENT_IMAGE # https://autoscale.drone.io/reference/drone-agent-image/
+              Value: !Ref WorkerImage
             -
               Name: DRONE_AGENT_CONCURRENCY
               Value: 1


### PR DESCRIPTION
The drone/autoscaler image has been updated with the new Docker client. This resolves an issue where the previous version had too-old of a client for the latest Docker Engine release.

## Links

- Jira: https://codedotorg.atlassian.net/browse/INF-1946
- https://github.com/drone/autoscaler/issues/147
- https://github.com/drone/autoscaler/pull/149

## Testing story
<!--  Does your change include appropriate tests?
      - If so, please describe how the tests included in this PR are sufficient.
      - If not, please explain why this change does not need to be tested. -->



## Deployment strategy
<!--  Any special steps required to deploy this, besides merging?
      - Are there database migrations or manual steps?
      - Does this require coordination with other teams or systems? -->



## Follow-up work
<!--  List any clean-up or technical debt that will be addressed in future work.
      - Include Jira links where applicable.
      - Are there any known limitations or improvements planned? -->



## Privacy
<!--  How does this change impact Student & Teacher privacy?
      - Does this collect, use, share, or modify PII, either new or existing? -->



## Security
<!--  How does this change impact our security surface-area?
      - Do API's touched have the right auth?
      - Do infra changes impact our attack surface or encryption?
-->



## Caching
<!--  How does this change impact caching behavior?
      - Are cache keys or invalidation strategies affected?
      - Will this require cache warming or invalidation after deployment? -->



## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
