### PR TITLE
Fix MySQL password exposure in migrate_db script (Part 3 of 4)

### DIFF
--- a/bin/oneoff/migrate_db
+++ b/bin/oneoff/migrate_db
@@ -30,6 +30,39 @@ def run(cmd)
   IO.popen(cmd) {|output| output.each {|line| puts line.chomp}}
 end
 
+# Executes MySQL command via CLI. Uses shell instead of Ruby MySQL client because:
+# - Runs in Chef/knife context where full Code.org deployment environment may not be loaded
+# - Can't use MysqlConsoleHelper (requires CDO constants that aren't available)
+# - RDS-specific command (`CALL mysql.rds_reset_external_master()`) could use Sequel, but would require loading deployment environment
+# Execution environment: Admin workstations, jump servers (single user, manual execution)
+# Temp file risk: Low - single user environment, not susceptible to temp directory sniffing
+def run_mysql_secure(db_uri, mysql_command_template)
+  db = URI.parse(db_uri)
+  require 'tempfile'
+  require 'fileutils'
+
+  if db.password
+    # SECURITY: Using --password= on command line exposes passwords in process lists (ps aux)
+    # and logs. MySQL warns: "Using a password on the command line interface can be insecure."
+    # Using --defaults-extra-file with a temporary file (mode 600) is the secure approach.
+    option_file = Tempfile.new(['mysql', '.cnf'])
+    # Set restrictive permissions BEFORE writing password (owner read/write only)
+    FileUtils.chmod(0o600, option_file.path)
+    option_file.write("[client]\n")
+    option_file.write("password=#{db.password}\n")
+    option_file.close
+    # Insert --defaults-extra-file right after 'mysql' in the command
+    cmd = mysql_command_template.sub(/mysql /, "mysql --defaults-extra-file=#{option_file.path} ")
+    begin
+      run(cmd)
+    ensure
+      option_file.unlink
+    end
+  else
+    run(mysql_command_template)
+  end
+end
+
 # Use the `pdsh` utility and `ls_frontend_servers` script to 'fan out' a command via ssh to all front-ends.
 def fanout(cmd)
   puts "Running #{cmd}..."
@@ -58,7 +91,7 @@ def main
 
   # 3. Promote the new DB instance to master.
   puts "Promoting new DB instance to master..."
-  run "echo 'CALL mysql.rds_reset_external_master();' | mysql -u'#{writer.user}' -p'#{writer.password}' -h '#{writer.host}'"
+  run_mysql_secure(writer.to_s, "echo 'CALL mysql.rds_reset_external_master();' | mysql -u'#{writer.user}' -h '#{writer.host}'")
 
   # 4. Start applications on all frontends. [live-site downtime ends]
   fanout 'sudo chef-client'


### PR DESCRIPTION
<!--
  PR Title (for GitHub):
  Fix MySQL password exposure in migrate_db script (Part 3 of 4)
-->

Use temporary option files (mode 600) instead of --password= to prevent password from appearing in process lists or logs.

**Part 3 of 4** - This PR is part of a multi-step effort to eliminate MySQL password exposure across the codebase. See the [Overview Document](https://docs.google.com/document/d/1cQeSpAFNReODvVtfwsgxGlrVN2-E3ngH7l-tYldETC8/edit?tab=t.0) for the complete context and all related PRs.

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

Fixes MySQL password exposure in `bin/oneoff/migrate_db` where credentials were passed as command-line arguments (`-p'password'`), making them visible in process lists and logs.

This is **Part 3 of 4** in a multi-step cleanup to eliminate MySQL password exposure across the codebase. This PR addresses the RDS migration script used by infrastructure engineers.

**Before:** Passwords visible in process lists, logs.  
**After:** Passwords in temporary option files (mode 600), cleaned up immediately. No passwords in command-line arguments.

This change adds a `run_mysql_secure` helper function that creates a temporary option file with restrictive permissions (mode 600) **before** writing the password, uses it for the MySQL command, then cleans up the file immediately.

**Note:** This script runs in a Chef/knife context where the full Code.org deployment environment may not be loaded, so we shell out to mysql directly rather than using `MysqlConsoleHelper`.

## Links
<!--  Links to relevant external resources.
      - spec docs, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- **Overview Document:** [Google Doc](https://docs.google.com/document/d/1cQeSpAFNReODvVtfwsgxGlrVN2-E3ngH7l-tYldETC8/edit?tab=t.0) - Complete context for all 4 PRs in this multi-step cleanup
- Jira: [INF-1962](https://codedotorg.atlassian.net/browse/INF-1962)
- Related: [RISK-29](https://codedotorg.atlassian.net/browse/RISK-29) - Running processes as same user as web server

## Testing story
<!--  Does your change include appropriate tests?
      - If so, please describe how the tests included in this PR are sufficient.
      - If not, please explain why this change does not need to be tested. -->

Manual testing required:
- Verify `bin/oneoff/migrate_db` works correctly
- Confirm passwords don't appear in process lists
- Test RDS migration workflow

This is a security fix that changes how passwords are passed to MySQL CLI. The functionality remains the same - only the method of passing credentials changes from command-line arguments to temporary option files.

## Deployment strategy
<!--  Any special steps required to deploy this, besides merging?
      - Are there database migrations or manual steps?
      - Does this require coordination with other teams or systems? -->

No special deployment steps required. This is a code-only change that affects how MySQL commands are executed during RDS migrations.

## Follow-up work
<!--  List any clean-up or technical debt that will be addressed in future work.
      - Include Jira links where applicable.
      - Are there any known limitations or improvements planned? -->

- [RISK-29](https://codedotorg.atlassian.net/browse/RISK-29): Run cron jobs and web server as different users to eliminate same-user enumeration risk entirely.

## Privacy
<!--  How does this change impact Student & Teacher privacy?
      - Does this collect, use, share, or modify PII, either new or existing? -->

No privacy impact. This change improves security of database credential handling but does not change data collection, use, or sharing.

## Security
<!--  How does this change impact our security surface-area?
      - Do API's touched have the right auth?
      - Do infra changes impact our attack surface or encryption?
-->

**Security improvement:** Eliminates MySQL password exposure in process lists and logs.

**Execution context:**
- Environment: Admin workstations, jump servers
- User context: Manual execution by infrastructure engineers
- Risk level: **Low** - Single user, manual execution

**Remaining risk:** None for this specific change. Same-user enumeration risk does not apply here since this is single-user manual execution.

## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage - Manual testing required (see Testing story)
- [X] Privacy impacts have been documented
- [X] Security impacts have been documented
- [X] Code is well-commented
- [N/A] New features are translatable or updates will not break translations
- [X] Relevant documentation has been added or updated
- [X] User impact is well-understood and desirable
- [X] Follow-up work items (including potential tech debt) are tracked and linked
