### PR TITLE
Add WAF Log nonterminatingmatchingrules field to Glue table.

### DIFF
--- a/aws/cloudformation/data.yml.erb
+++ b/aws/cloudformation/data.yml.erb
@@ -733,6 +733,8 @@ Resources:
               Type: string
             - Name: httprequest
               Type: struct<clientip:string,country:string,headers:array<struct<name:string,value:string>>,uri:string,args:string,httpmethod:string,requestid:string>
+            - Name: nonterminatingmatchingrules
+              Type: array<struct<ruleid:string,action:string,rulematchdetails:array<struct<conditiontype:string,sensitivitylevel:string,location:string,matchedelements:array<string>>>,captcharesponse:struct<responsecode:int,solvetimestamp:bigint>,challengeresponse:struct<responsecode:int,solvetimestamp:bigint>>>
             - Name: ja3fingerprint
               Type: string
           OutputFormat: org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat


### PR DESCRIPTION
Add the Web Application Firewall (WAF) Web Access Control List (ACL) log field `nonterminatingmatchingrules` to the Glue table so we can search for HTTP requests that were `COUNT`ed and determine whether those Rules are identifying legitimate malicious requests and that the rate of false positives is low.

## Testing story
```bash
code-dot-org % export AWS_PROFILE=codeorg-admin
code-dot-org % bundle exec rake stack:data:validate RAILS_ENV=production ADMIN=true
Finished stack:data:environment (less than a minute)
Pending update for stack `DATA-production`:
Modify GlobalWebACLLogsTable [AWS::Glue::Table] Properties Replacement: Conditional (TableInput)
Finished stack:data:validate (less than a minute)
```


## Deployment strategy
```bash
code-dot-org % export AWS_PROFILE=codeorg-admin
code-dot-org % bundle exec rake stack:data:start RAILS_ENV=production ADMIN=true
```



## Follow-up work
<!--  List any clean-up or technical debt that will be addressed in future work.
      - Include Jira links where applicable.
      - Are there any known limitations or improvements planned? -->



## Privacy
<!--  How does this change impact Student & Teacher privacy?
      - Does this collect, use, share, or modify PII, either new or existing? -->



## Security
<!--  How does this change impact our security surface-area?
      - Do API's touched have the right auth?
      - Do infra changes impact our attack surface or encryption?
-->



## Caching
<!--  How does this change impact caching behavior?
      - Are cache keys or invalidation strategies affected?
      - Will this require cache warming or invalidation after deployment? -->



## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
