### PR TITLE
Refactor channel ID resolution to service object

### DIFF
--- a/bin/grep-applab-source
+++ b/bin/grep-applab-source
@@ -74,7 +74,7 @@ applab_channels.each_slice(MAX_THREADS) do |chunk|
       if source
         commands.each do |regex, filename|
           source.scan(regex).each do |match|
-            channel = storage_encrypt_channel_id(owner_storage_id, project_id)
+            channel = Services::ChannelId.channel_id_for(storage_id: owner_storage_id, project_id: project_id)
             project_url = "https://#{CDO.dashboard_hostname}/projects/applab/#{channel}/view"
 
             File.open(filename, 'a') do |file|

--- a/bin/oneoff/backfill_data/channel_tokens_storage_app_id
+++ b/bin/oneoff/backfill_data/channel_tokens_storage_app_id
@@ -11,7 +11,7 @@ ChannelToken.find_in_batches(batch_size: 500) do |channel_tokens_batch|
   puts "PROCESSING: slice #{slice}..."
   ActiveRecord::Base.transaction do
     channel_tokens_batch.each do |channel_token|
-      _owner_id, storage_app_id = storage_decrypt_channel_id(channel_token.channel)
+      _owner_id, storage_app_id = Services::ChannelId.storage_and_project_id_from_token(channel_token.channel)
       channel_token.storage_app_id = storage_app_id
       save_result = channel_token.save(touch: false)
       raise "ERROR: ID #{channel_token.id}. STORAGE_APP_ID: #{storage_app_id}." unless save_result

--- a/bin/oneoff/backfill_data/channel_tokens_storage_id
+++ b/bin/oneoff/backfill_data/channel_tokens_storage_id
@@ -13,7 +13,7 @@ ChannelToken.find_in_batches(batch_size: 500) do |channel_tokens_batch|
   ActiveRecord::Base.transaction do
     channel_tokens_batch.each do |channel_token|
       next unless channel_token.storage_id.nil?
-      storage_id, _storage_app_id = storage_decrypt_channel_id(channel_token.channel)
+      storage_id, _storage_app_id = Services::ChannelId.storage_and_project_id_from_token(channel_token.channel)
       channel_token.storage_id = storage_id
       save_result = channel_token.save(touch: false)
       raise "ERROR: ID #{channel_token.id}. STORAGE_ID: #{storage_id}." unless save_result

--- a/dashboard/app/controllers/aichat_events_controller.rb
+++ b/dashboard/app/controllers/aichat_events_controller.rb
@@ -28,7 +28,7 @@ class AichatEventsController < ApplicationController
 
     project_id = nil
     if context[:channelId]
-      _, project_id = storage_decrypt_channel_id(context[:channelId])
+      _, project_id = Services::ChannelId.storage_and_project_id_from_token(context[:channelId])
     end
 
     begin
@@ -77,7 +77,7 @@ class AichatEventsController < ApplicationController
     if script_id.present? && level_id.present?
       aichat_events = AichatEvent.where(user_id: user_id, script_id: script_id, level_id: level_id)
     elsif channel_id.present?
-      _, project_id = storage_decrypt_channel_id(channel_id)
+      _, project_id = Services::ChannelId.storage_and_project_id_from_token(channel_id)
       aichat_events = AichatEvent.where(user_id: user_id, project_id: project_id)
     end
     aichat_events = aichat_events.order(:created_at).map do |event|

--- a/dashboard/app/controllers/aichat_requests_controller.rb
+++ b/dashboard/app/controllers/aichat_requests_controller.rb
@@ -157,7 +157,7 @@ class AichatRequestsController < ApplicationController
 
   private def get_project_id(context)
     if context[:channelId]
-      _, project_id = storage_decrypt_channel_id(context[:channelId])
+      _, project_id = Services::ChannelId.storage_and_project_id_from_token(context[:channelId])
       project_id
     end
   end

--- a/dashboard/app/controllers/featured_projects_controller.rb
+++ b/dashboard/app/controllers/featured_projects_controller.rb
@@ -5,7 +5,7 @@ class FeaturedProjectsController < ApplicationController
   # in the list of featured projects at 'projects/featured', but will not be displayed in the
   # public gallery until its status is 'active'.
   def bookmark
-    _, project_id = storage_decrypt_channel_id(params[:channel_id])
+    _, project_id = Services::ChannelId.storage_and_project_id_from_token(params[:channel_id])
     return render_404 unless project_id
     @featured_project = FeaturedProject.find_or_create_by!(project_id: project_id)
     @featured_project.update! unfeatured_at: nil, featured_at: nil
@@ -14,7 +14,7 @@ class FeaturedProjectsController < ApplicationController
 
   # Set the featured project to 'active', i.e., project will be displayed in public gallery.
   def feature
-    _, project_id = storage_decrypt_channel_id(params[:channel_id])
+    _, project_id = Services::ChannelId.storage_and_project_id_from_token(params[:channel_id])
     return render_404 unless project_id
     @featured_project = FeaturedProject.find_or_create_by!(project_id: project_id)
     @featured_project.update! unfeatured_at: nil, featured_at: DateTime.now
@@ -25,7 +25,7 @@ class FeaturedProjectsController < ApplicationController
 
   # Set the featured project to 'archived', i.e., project will not be displayed in public gallery.
   def unfeature
-    _, project_id = storage_decrypt_channel_id(params[:channel_id])
+    _, project_id = Services::ChannelId.storage_and_project_id_from_token(params[:channel_id])
     return render_404 unless project_id
     @featured_project = FeaturedProject.find_by! project_id: project_id
     @featured_project.update! unfeatured_at: DateTime.now
@@ -33,7 +33,7 @@ class FeaturedProjectsController < ApplicationController
   end
 
   def destroy
-    _, project_id = storage_decrypt_channel_id(params[:channel_id])
+    _, project_id = Services::ChannelId.storage_and_project_id_from_token(params[:channel_id])
     return render_404 unless project_id
     @featured_project = FeaturedProject.find_by! project_id: project_id
     @featured_project.destroy!

--- a/dashboard/app/controllers/musiclab_controller.rb
+++ b/dashboard/app/controllers/musiclab_controller.rb
@@ -76,7 +76,7 @@ class MusiclabController < ApplicationController
 
   private def get_project_details(project_channel_ids)
     project_ids = project_channel_ids.map do |channel_id|
-      _, project_id = storage_decrypt_channel_id(channel_id)
+      _, project_id = Services::ChannelId.storage_and_project_id_from_token(channel_id)
       project_id
     end
     Project.

--- a/dashboard/app/controllers/project_commits_controller.rb
+++ b/dashboard/app/controllers/project_commits_controller.rb
@@ -3,7 +3,7 @@ class ProjectCommitsController < ApplicationController
 
   # POST /project_commits
   def create
-    _, project_id = storage_decrypt_channel_id(params[:storage_id])
+    _, project_id = Services::ChannelId.storage_and_project_id_from_token(params[:storage_id])
     # Use find_or_initialize_by to detect if this is a duplicate submission.
     project_commit = ProjectCommit.find_or_initialize_by(
       project_id: project_id,
@@ -42,7 +42,7 @@ class ProjectCommitsController < ApplicationController
 
   # GET /project_commits/:channel_id
   def project_commits
-    user_storage_id, project_id = storage_decrypt_channel_id(params[:channel_id])
+    user_storage_id, project_id = Services::ChannelId.storage_and_project_id_from_token(params[:channel_id])
     project_owner = User.find_by(id: user_id_for_storage_id(user_storage_id))
     return render :not_acceptable unless project_owner
     return render :forbidden unless can?(:view_project_commits, project_owner)

--- a/dashboard/app/controllers/projects_controller.rb
+++ b/dashboard/app/controllers/projects_controller.rb
@@ -252,7 +252,7 @@ class ProjectsController < ApplicationController
     @featured_project_table_rows = []
     project_featured_project_combo_data.each do |project_details|
       project_details_value = JSON.parse(project_details[:value])
-      channel = storage_encrypt_channel_id(project_details[:storage_id], project_details[:id])
+      channel = Services::ChannelId.channel_id_for(storage_id: project_details[:storage_id], project_id: project_details[:id])
       status = get_featured_project_status(project_details[:featured_at], project_details[:unfeatured_at])
       featured_project_row = {
         projectName: project_details_value['name'],
@@ -496,7 +496,7 @@ class ProjectsController < ApplicationController
     end
 
     begin
-      _, project_id = storage_decrypt_channel_id(params[:channel_id]) if params[:channel_id]
+      _, project_id = Services::ChannelId.storage_and_project_id_from_token(params[:channel_id]) if params[:channel_id]
     rescue ArgumentError, OpenSSL::Cipher::CipherError
       # continue as normal, as we only use this value for stats.
     end
@@ -560,7 +560,7 @@ class ProjectsController < ApplicationController
 
   # GET /projects/:project_type/:channel_id/submission_status
   def submission_status
-    _, project_id = storage_decrypt_channel_id(params[:channel_id])
+    _, project_id = Services::ChannelId.storage_and_project_id_from_token(params[:channel_id])
     project = Project.find_by(id: project_id)
     begin
       authorize! :submission_status, project
@@ -577,7 +577,7 @@ class ProjectsController < ApplicationController
     channel_id = params[:channel_id]
     project_type = params[:project_type]
     return render status: :bad_request, json: {error: "Project description is required for submission."} if submission_description.empty?
-    _, project_id = storage_decrypt_channel_id(channel_id)
+    _, project_id = Services::ChannelId.storage_and_project_id_from_token(channel_id)
     project = Project.find_by(id: project_id)
     begin
       authorize! :submit, project
@@ -592,7 +592,7 @@ class ProjectsController < ApplicationController
     end
     # Publish the project, i.e., make it public.
     begin
-      storage_id, _ = storage_decrypt_channel_id(channel_id)
+      storage_id, _ = Services::ChannelId.storage_and_project_id_from_token(channel_id)
       Projects.new(storage_id).publish(channel_id, project_type, current_user)
     end
     # Send ZenDesk ticket with user/project info and submission description.
@@ -618,7 +618,7 @@ class ProjectsController < ApplicationController
     return if redirect_under_13_without_tos_teacher(@level)
     src_channel_id = params[:channel_id]
     begin
-      _, remix_parent_id = storage_decrypt_channel_id(src_channel_id)
+      _, remix_parent_id = Services::ChannelId.storage_and_project_id_from_token(src_channel_id)
     rescue ArgumentError, OpenSSL::Cipher::CipherError
       return head :bad_request
     end
@@ -667,7 +667,7 @@ class ProjectsController < ApplicationController
     end
     project_info = {}
     owner_info = {}
-    owner_info['storage_id'], project_info['id'] = storage_decrypt_channel_id(src_channel_id)
+    owner_info['storage_id'], project_info['id'] = Services::ChannelId.storage_and_project_id_from_token(src_channel_id)
     project_info['sources_link'] = "https://s3.console.aws.amazon.com/s3/buckets/#{CDO.sources_s3_bucket}/#{CDO.sources_s3_directory}/#{owner_info['storage_id']}/#{project_info['id']}/"
     # For legacy labs, other links are displayed.
     # App Lab includes assets, Gamelab includes animations, and Weblab includes files.
@@ -823,7 +823,7 @@ class ProjectsController < ApplicationController
 
   # Creates a remix of the given project. Creates a new channel and copies over all project data.
   private def remix_project(src_channel_id, project_type, is_subproject: false)
-    _, remix_parent_id = storage_decrypt_channel_id(src_channel_id)
+    _, remix_parent_id = Services::ChannelId.storage_and_project_id_from_token(src_channel_id)
     project = Projects.new(get_storage_id)
     new_channel_id = ChannelToken.create_channel(
       request.ip,

--- a/dashboard/app/controllers/report_abuse_controller.rb
+++ b/dashboard/app/controllers/report_abuse_controller.rb
@@ -26,7 +26,7 @@ class ReportAbuseController < ApplicationController
   # they are safe. This reduces spamming of the report abuse feature.
   def protected_project?
     return false if params[:channel_id].blank?
-    owner_storage_id, _ = storage_decrypt_channel_id(params[:channel_id])
+    owner_storage_id, _ = Services::ChannelId.storage_and_project_id_from_token(params[:channel_id])
     owner_user_id = user_id_for_storage_id(owner_storage_id)
     return false unless owner_user_id
     project_owner = User.find(owner_user_id)

--- a/dashboard/app/controllers/rubrics_controller.rb
+++ b/dashboard/app/controllers/rubrics_controller.rb
@@ -67,7 +67,7 @@ class RubricsController < ApplicationController
     project_id = nil
     version_id = nil
     if channel_token
-      _owner_id, project_id = storage_decrypt_channel_id(channel_token.channel)
+      _owner_id, project_id = Services::ChannelId.storage_and_project_id_from_token(channel_token.channel)
       source_data = SourceBucket.new.get(channel_token.channel, "main.json")
       if source_data[:status] == 'FOUND'
         version_id = source_data[:version_id]

--- a/dashboard/app/controllers/xhr_proxy_controller.rb
+++ b/dashboard/app/controllers/xhr_proxy_controller.rb
@@ -37,7 +37,7 @@ class XhrProxyController < ApplicationController
     url = params[:u]
 
     begin
-      owner_storage_id, _ = storage_decrypt_channel_id(channel_id)
+      owner_storage_id, _ = Services::ChannelId.storage_and_project_id_from_token(channel_id)
     rescue ArgumentError, OpenSSL::Cipher::CipherError => exception
       render_error_response 403, "Invalid token: '#{channel_id}' for url: '#{url}' exception: #{exception.message}"
       return

--- a/dashboard/app/helpers/aichat_ai_helper.rb
+++ b/dashboard/app/helpers/aichat_ai_helper.rb
@@ -170,7 +170,7 @@ module AichatAiHelper
   end
 
   def self.get_openai_assistant_response(aichat_model_customizations, stored_messages, new_message, level_id, project_id, user_id)
-    encrypted_channel_id = storage_encrypt_channel_id(storage_id_for_user_id(user_id), project_id) if project_id
+    encrypted_channel_id = Services::ChannelId.channel_id_for(storage_id: storage_id_for_user_id(user_id), project_id: project_id) if project_id
 
     model_id = aichat_model_customizations["selectedModelId"]
 

--- a/dashboard/app/helpers/levels_helper.rb
+++ b/dashboard/app/helpers/levels_helper.rb
@@ -128,7 +128,7 @@ module LevelsHelper
     channel_token = ChannelToken.find_channel_token(level, user_storage_id, script_id)
     return result unless channel_token
 
-    _owner_id, result[:project_id] = storage_decrypt_channel_id(channel_token.channel)
+    _owner_id, result[:project_id] = Services::ChannelId.storage_and_project_id_from_token(channel_token.channel)
     source_data = SourceBucket.new.get(channel_token.channel, "main.json")
 
     if source_data[:status] == 'FOUND'
@@ -1087,7 +1087,7 @@ module LevelsHelper
     channel_token = ChannelToken.where(storage_id: storage_id, level_id: level_id_for_channel_token, script_id: unit_id).last
     if channel_token
       storage_app_id = channel_token.storage_app_id
-      channel_id = storage_encrypt_channel_id(storage_id, storage_app_id)
+      channel_id = Services::ChannelId.channel_id_for(storage_id: storage_id, project_id: storage_app_id)
       s3_filename = "#{base_dir}/#{storage_id}/#{storage_app_id}/main.json"
       s3_args = {bucket: bucket, key: s3_filename}
       s3_args[:version_id] = code_version if code_version

--- a/dashboard/app/jobs/evaluate_rubric_job.rb
+++ b/dashboard/app/jobs/evaluate_rubric_job.rb
@@ -270,7 +270,7 @@ class EvaluateRubricJob < ApplicationJob
 
     user = User.find(options[:user_id])
     channel_id = get_channel_id(user, script_level)
-    _owner_id, project_id = storage_decrypt_channel_id(channel_id)
+    _owner_id, project_id = Services::ChannelId.storage_and_project_id_from_token(channel_id)
 
     # Create a queued record of this work request (if none were given)
     rubric_ai_evaluation_id = options[:rubric_ai_evaluation_id]

--- a/dashboard/app/models/backpack.rb
+++ b/dashboard/app/models/backpack.rb
@@ -28,13 +28,13 @@ class Backpack < ApplicationRecord
       # Create a project for this user's backpack in the app determined by game_id
       project = Projects.new(storage_id_for_user_id(user_id))
       encrypted_id = project.create({hidden: true}, ip: ip, type: 'backpack')
-      _, project_id = storage_decrypt_channel_id(encrypted_id)
+      _, project_id = Services::ChannelId.storage_and_project_id_from_token(encrypted_id)
       backpack = create!(user_id: user_id, game_id: game_id, project_id: project_id)
     end
     backpack
   end
 
   def channel
-    storage_encrypt_channel_id(storage_id_for_user_id(user_id), project_id)
+    Services::ChannelId.channel_id_for(storage_id: storage_id_for_user_id(user_id), project_id: project_id)
   end
 end

--- a/dashboard/app/models/channel_token.rb
+++ b/dashboard/app/models/channel_token.rb
@@ -30,7 +30,7 @@ class ChannelToken < ApplicationRecord
   alias_attribute :project_id, :storage_app_id
 
   def channel
-    storage_encrypt_channel_id(storage_id, project_id)
+    Services::ChannelId.channel_id_for(storage_id: storage_id, project_id: project_id)
   end
 
   # @param [Level] level The level associated with the channel token request.
@@ -57,7 +57,7 @@ class ChannelToken < ApplicationRecord
         create!(level: level.host_level, storage_id: user_storage_id, script_id: script_id) do |ct|
           # Get a new channel_id.
           channel = create_channel ip, project, data: data, standalone: false, level: level
-          _, ct.project_id = storage_decrypt_channel_id(channel)
+          _, ct.project_id = Services::ChannelId.storage_and_project_id_from_token(channel)
         end
       end
     end

--- a/dashboard/app/models/code_review.rb
+++ b/dashboard/app/models/code_review.rb
@@ -44,7 +44,7 @@ class CodeReview < ApplicationRecord
   def self.open_for_project?(channel:)
     return false unless channel
 
-    _, project_id = storage_decrypt_channel_id(channel)
+    _, project_id = Services::ChannelId.storage_and_project_id_from_token(channel)
     CodeReview.exists?(project_id: project_id, closed_at: nil)
   end
 

--- a/dashboard/app/models/featured_project.rb
+++ b/dashboard/app/models/featured_project.rb
@@ -39,7 +39,7 @@ class FeaturedProject < ApplicationRecord
   # @return [Boolean] whether the project associated with the given
   # encrypted_channel_id is currently featured
   def self.featured_channel_id?(encrypted_channel_id)
-    _, project_id = storage_decrypt_channel_id encrypted_channel_id
+    _, project_id = Services::ChannelId.storage_and_project_id_from_token encrypted_channel_id
     find_by(project_id: project_id)&.active?
   rescue ArgumentError
     false

--- a/dashboard/app/models/project.rb
+++ b/dashboard/app/models/project.rb
@@ -43,17 +43,11 @@ class Project < ApplicationRecord
   # ActiveRecord::RecordNotFound error if the corresponding project cannot
   # be found.
   def self.find_by_channel_id(channel_id)
-    begin
-      _, project_id = storage_decrypt_channel_id(channel_id)
-    rescue
-      raise ActiveRecord::RecordNotFound.new("Invalid channel_id: #{channel_id}")
-    end
-
-    Project.find(project_id)
+    Services::ChannelId.project_from_channel_id!(channel_id)
   end
 
   def channel_id
-    storage_encrypt_channel_id(storage_id, id)
+    Services::ChannelId.channel_id_for(storage_id: storage_id, project_id: id)
   end
 
   # Returns the user_id of the owner of this project. Returns nil if the project

--- a/dashboard/app/models/user.rb
+++ b/dashboard/app/models/user.rb
@@ -1918,7 +1918,7 @@ class User < ApplicationRecord
   end
 
   def self.find_channel_owner(encrypted_channel_id)
-    owner_storage_id, _ = storage_decrypt_channel_id(encrypted_channel_id)
+    owner_storage_id, _ = Services::ChannelId.storage_and_project_id_from_token(encrypted_channel_id)
     user_id = user_id_for_storage_id(owner_storage_id)
     User.find(user_id)
   rescue ArgumentError, OpenSSL::Cipher::CipherError, ActiveRecord::RecordNotFound

--- a/dashboard/app/views/levels/_admin.html.haml
+++ b/dashboard/app/views/levels/_admin.html.haml
@@ -117,7 +117,7 @@
       Project info:
       %ul
         - owner_storage_id, project_id = begin
-          - storage_decrypt_channel_id(params[:channel_id])
+          - Services::ChannelId.storage_and_project_id_from_token(params[:channel_id])
         - rescue
           - [nil, nil]
         - sources_link = "https://s3.console.aws.amazon.com/s3/buckets/#{CDO.sources_s3_bucket}/#{CDO.sources_s3_directory}/#{owner_storage_id}/#{project_id}/"

--- a/dashboard/db/migrate/20170923000355_populate_storage_id.rb
+++ b/dashboard/db/migrate/20170923000355_populate_storage_id.rb
@@ -11,7 +11,7 @@ class PopulateStorageId < ActiveRecord::Migration[5.0]
       ActiveRecord::Base.transaction do
         channel_tokens_batch.each do |channel_token|
           next unless channel_token.storage_id.nil?
-          storage_id, _storage_app_id = storage_decrypt_channel_id(channel_token.channel)
+          storage_id, _storage_app_id = Services::ChannelId.storage_and_project_id_from_token(channel_token.channel)
           channel_token.storage_id = storage_id
           save_result = channel_token.save(touch: false)
           raise "ERROR: ID #{channel_token.id}. STORAGE_ID: #{storage_id}." unless save_result

--- a/dashboard/legacy/middleware/channels_api.rb
+++ b/dashboard/legacy/middleware/channels_api.rb
@@ -74,7 +74,7 @@ class ChannelsApi < Sinatra::Base
     project = Projects.new(get_storage_id)
 
     begin
-      _, remix_parent_id = storage_decrypt_channel_id(request.GET['parent']) if request.GET['parent']
+      _, remix_parent_id = Services::ChannelId.storage_and_project_id_from_token(request.GET['parent']) if request.GET['parent']
     rescue ArgumentError, OpenSSL::Cipher::CipherError, Projects::ValidationError
       bad_request
     end

--- a/dashboard/legacy/middleware/files_api.rb
+++ b/dashboard/legacy/middleware/files_api.rb
@@ -42,14 +42,14 @@ class FilesApi < Sinatra::Base
     return true if owns_channel?(encrypted_channel_id) || admin? || has_permission?('project_validator')
 
     # teachers can see abusive assets of their students
-    owner_storage_id, _ = storage_decrypt_channel_id(encrypted_channel_id)
+    owner_storage_id, _ = Services::ChannelId.storage_and_project_id_from_token(encrypted_channel_id)
     owner_user_id = user_id_for_storage_id(owner_storage_id)
 
     teaches_student?(owner_user_id)
   end
 
   def codeprojects_can_view?(encrypted_channel_id)
-    owner_storage_id, _ = storage_decrypt_channel_id(encrypted_channel_id)
+    owner_storage_id, _ = Services::ChannelId.storage_and_project_id_from_token(encrypted_channel_id)
 
     # Attempt to find active project in database. This will raise Projects::NotFound if
     # no active project exists, which is handled below.
@@ -95,7 +95,7 @@ class FilesApi < Sinatra::Base
   def record_event(quota_event_type, quota_type, encrypted_channel_id)
     return unless CDO.newrelic_logging
 
-    owner_storage_id, _ = storage_decrypt_channel_id(encrypted_channel_id)
+    owner_storage_id, _ = Services::ChannelId.storage_and_project_id_from_token(encrypted_channel_id)
     owner_user_id = user_id_for_storage_id(owner_storage_id)
     event_details = {
       quota_type: quota_type,
@@ -289,7 +289,7 @@ class FilesApi < Sinatra::Base
   def should_sanitize_for_under_13?(encrypted_channel_id)
     return false if owns_channel?(encrypted_channel_id)
 
-    owner_storage_id, _ = storage_decrypt_channel_id(encrypted_channel_id)
+    owner_storage_id, _ = Services::ChannelId.storage_and_project_id_from_token(encrypted_channel_id)
     owner_id = user_id_for_storage_id(owner_storage_id)
     under_13?(owner_id)
   end
@@ -691,7 +691,7 @@ class FilesApi < Sinatra::Base
       versions = get_bucket_impl(endpoint).new.list_versions(encrypted_channel_id, filename, with_comments: request.GET['with_comments'])
       return versions.to_json if owns_channel?(encrypted_channel_id)
 
-      owner_storage_id, _ = storage_decrypt_channel_id(encrypted_channel_id)
+      owner_storage_id, _ = Services::ChannelId.storage_and_project_id_from_token(encrypted_channel_id)
       owner_user_id = user_id_for_storage_id(owner_storage_id)
       return versions.to_json if teaches_student?(owner_user_id)
 

--- a/dashboard/legacy/middleware/helpers/asset_bucket.rb
+++ b/dashboard/legacy/middleware/helpers/asset_bucket.rb
@@ -39,7 +39,7 @@ class AssetBucket < BucketHelper
   end
 
   def copy_level_starter_assets(src_channel, dest_channel)
-    src_owner_id, src_storage_app_id = storage_decrypt_channel_id(src_channel)
+    src_owner_id, src_storage_app_id = Services::ChannelId.storage_and_project_id_from_token(src_channel)
 
     channel = ChannelToken.find_by(storage_id: src_owner_id, storage_app_id: src_storage_app_id)
     return unless channel
@@ -49,7 +49,7 @@ class AssetBucket < BucketHelper
     level = Level.cache_find(channel.level_id)
     return unless level&.starter_assets
 
-    dest_owner_id, dest_storage_app_id = storage_decrypt_channel_id(dest_channel)
+    dest_owner_id, dest_storage_app_id = Services::ChannelId.storage_and_project_id_from_token(dest_channel)
 
     # As noted above, when copying from a template-backed level,
     # the level associated with the channel is the template level (rather than the "derived" level).

--- a/dashboard/legacy/middleware/helpers/bucket_helper.rb
+++ b/dashboard/legacy/middleware/helpers/bucket_helper.rb
@@ -55,7 +55,7 @@ class BucketHelper
   end
 
   def app_size(encrypted_channel_id)
-    owner_id, storage_app_id = storage_decrypt_channel_id(encrypted_channel_id)
+    owner_id, storage_app_id = Services::ChannelId.storage_and_project_id_from_token(encrypted_channel_id)
     prefix = s3_path owner_id, storage_app_id
     track_list_operation 'BucketHelper.app_size'
     s3.list_objects(bucket: @bucket, prefix: prefix).contents.sum(&:size).to_i
@@ -70,7 +70,7 @@ class BucketHelper
   #                 object whose size we should return.
   # @return [[Int, Int]] size of target_object and size of entire app
   def object_and_app_size(encrypted_channel_id, target_object)
-    owner_id, storage_app_id = storage_decrypt_channel_id(encrypted_channel_id)
+    owner_id, storage_app_id = Services::ChannelId.storage_and_project_id_from_token(encrypted_channel_id)
 
     app_prefix = s3_path owner_id, storage_app_id
     target_object_prefix = s3_path owner_id, storage_app_id, target_object
@@ -86,7 +86,7 @@ class BucketHelper
   end
 
   def list(encrypted_channel_id)
-    owner_id, storage_app_id = storage_decrypt_channel_id(encrypted_channel_id)
+    owner_id, storage_app_id = Services::ChannelId.storage_and_project_id_from_token(encrypted_channel_id)
     prefix = s3_path owner_id, storage_app_id
     track_list_operation 'BucketHelper.list'
     s3.list_objects(bucket: @bucket, prefix: prefix).contents.map do |fileinfo|
@@ -100,7 +100,7 @@ class BucketHelper
   def get(encrypted_channel_id, filename, if_modified_since = nil, version = nil)
     if_modified_since = nil if if_modified_since == ''
     begin
-      owner_id, storage_app_id = storage_decrypt_channel_id(encrypted_channel_id)
+      owner_id, storage_app_id = Services::ChannelId.storage_and_project_id_from_token(encrypted_channel_id)
     rescue ArgumentError, OpenSSL::Cipher::CipherError
       return {status: 'NOT_FOUND'}
     end
@@ -131,8 +131,8 @@ class BucketHelper
   end
 
   def copy_files(src_channel, dest_channel, options = {})
-    src_owner_id, src_storage_app_id = storage_decrypt_channel_id(src_channel)
-    dest_owner_id, dest_storage_app_id = storage_decrypt_channel_id(dest_channel)
+    src_owner_id, src_storage_app_id = Services::ChannelId.storage_and_project_id_from_token(src_channel)
+    dest_owner_id, dest_storage_app_id = Services::ChannelId.storage_and_project_id_from_token(dest_channel)
 
     src_prefix = s3_path src_owner_id, src_storage_app_id
     track_list_operation 'BucketHelper.copy_files'
@@ -164,7 +164,7 @@ class BucketHelper
   end
 
   def restore_file_version(encrypted_channel_id, filename, version)
-    owner_id, storage_app_id = storage_decrypt_channel_id(encrypted_channel_id)
+    owner_id, storage_app_id = Services::ChannelId.storage_and_project_id_from_token(encrypted_channel_id)
     key = s3_path owner_id, storage_app_id, filename
 
     encoded_location = ERB::Util.url_encode("#{@bucket}/#{key}")
@@ -173,14 +173,14 @@ class BucketHelper
   end
 
   def replace_abuse_score(encrypted_channel_id, filename, abuse_score)
-    owner_id, storage_app_id = storage_decrypt_channel_id(encrypted_channel_id)
+    owner_id, storage_app_id = Services::ChannelId.storage_and_project_id_from_token(encrypted_channel_id)
     key = s3_path owner_id, storage_app_id, filename
 
     s3.copy_object(bucket: @bucket, copy_source: ERB::Util.url_encode("#{@bucket}/#{key}"), key: key, metadata: {abuse_score: abuse_score.to_s}, metadata_directive: 'REPLACE')
   end
 
   def create_or_replace(encrypted_channel_id, filename, body, version = nil, abuse_score = 0)
-    owner_id, storage_app_id = storage_decrypt_channel_id(encrypted_channel_id)
+    owner_id, storage_app_id = Services::ChannelId.storage_and_project_id_from_token(encrypted_channel_id)
 
     key = s3_path owner_id, storage_app_id, filename
     response = s3.put_object(bucket: @bucket, key: key, body: body, metadata: {abuse_score: abuse_score.to_s})
@@ -211,7 +211,7 @@ class BucketHelper
   def check_current_version(encrypted_channel_id, filename, current_version, should_replace, timestamp, tab_id, user_id)
     return true unless filename == 'main.json' && @bucket == CDO.sources_s3_bucket && current_version
 
-    owner_id, storage_app_id = storage_decrypt_channel_id(encrypted_channel_id)
+    owner_id, storage_app_id = Services::ChannelId.storage_and_project_id_from_token(encrypted_channel_id)
     key = s3_path owner_id, storage_app_id, filename
 
     begin
@@ -285,7 +285,7 @@ class BucketHelper
   # @param [String] version - Version of destination object to replace
   # @return [Hash] S3 response from copy operation
   def copy(encrypted_channel_id, filename, source_filename, version = nil)
-    owner_id, storage_app_id = storage_decrypt_channel_id(encrypted_channel_id)
+    owner_id, storage_app_id = Services::ChannelId.storage_and_project_id_from_token(encrypted_channel_id)
 
     key = s3_path owner_id, storage_app_id, filename
     copy_source = @bucket + '/' + s3_path(owner_id, storage_app_id, source_filename)
@@ -298,14 +298,14 @@ class BucketHelper
   end
 
   def delete(encrypted_channel_id, filename)
-    owner_id, storage_app_id = storage_decrypt_channel_id(encrypted_channel_id)
+    owner_id, storage_app_id = Services::ChannelId.storage_and_project_id_from_token(encrypted_channel_id)
     key = s3_path owner_id, storage_app_id, filename
 
     s3.delete_object(bucket: @bucket, key: key)
   end
 
   def delete_multiple(encrypted_channel_id, filenames)
-    owner_id, storage_app_id = storage_decrypt_channel_id(encrypted_channel_id)
+    owner_id, storage_app_id = Services::ChannelId.storage_and_project_id_from_token(encrypted_channel_id)
     objects = filenames.map {|filename| {key: s3_path(owner_id, storage_app_id, filename)}}
 
     s3.delete_objects(bucket: @bucket, delete: {objects: objects, quiet: true})
@@ -320,7 +320,7 @@ class BucketHelper
   # @return [Integer] the number of objects deleted
   def hard_delete_channel_content(encrypted_channel_id)
     # TODO: Handle pagination in the S3 APIs
-    owner_id, storage_app_id = storage_decrypt_channel_id(encrypted_channel_id)
+    owner_id, storage_app_id = Services::ChannelId.storage_and_project_id_from_token(encrypted_channel_id)
     # Find all versions of all objects
     channel_prefix = s3_path owner_id, storage_app_id
     track_list_operation 'BucketHelper.hard_delete_channel_content'
@@ -345,7 +345,7 @@ class BucketHelper
   end
 
   def list_versions(encrypted_channel_id, filename, with_comments: false)
-    owner_id, storage_app_id = storage_decrypt_channel_id(encrypted_channel_id)
+    owner_id, storage_app_id = Services::ChannelId.storage_and_project_id_from_token(encrypted_channel_id)
     key = s3_path owner_id, storage_app_id, filename
 
     track_list_operation 'BucketHelper.list_versions'
@@ -370,7 +370,7 @@ class BucketHelper
 
   # Used for testing
   def list_delete_markers(encrypted_channel_id, filename)
-    owner_id, storage_app_id = storage_decrypt_channel_id(encrypted_channel_id)
+    owner_id, storage_app_id = Services::ChannelId.storage_and_project_id_from_token(encrypted_channel_id)
     key = s3_path owner_id, storage_app_id, filename
 
     track_list_operation 'BucketHelper.list_delete_markers'
@@ -388,7 +388,7 @@ class BucketHelper
   # Copies the given version of the file to make it the current revision.
   # (All intermediate versions are preserved.)
   def restore_previous_version(encrypted_channel_id, filename, version_id, user_id)
-    owner_id, storage_app_id = storage_decrypt_channel_id(encrypted_channel_id)
+    owner_id, storage_app_id = Services::ChannelId.storage_and_project_id_from_token(encrypted_channel_id)
     key = s3_path owner_id, storage_app_id, filename
 
     version_restored = false
@@ -491,7 +491,7 @@ class BucketHelper
   end
 
   protected def log_restored_file(project_id:, user_id:, filename:, source_version_id:, new_version_id:)
-    owner_id, storage_app_id = storage_decrypt_channel_id(project_id)
+    owner_id, storage_app_id = Services::ChannelId.storage_and_project_id_from_token(project_id)
     key = s3_path owner_id, storage_app_id, filename
     FirehoseClient.instance.put_record(
       :analysis,

--- a/dashboard/legacy/middleware/helpers/file_bucket.rb
+++ b/dashboard/legacy/middleware/helpers/file_bucket.rb
@@ -73,7 +73,7 @@ class FileBucket < BucketHelper
   # expiration.
   #
   def make_temporary_public_url(encrypted_channel_id, filename, expires_in = 5.minutes)
-    owner_id, storage_app_id = storage_decrypt_channel_id(encrypted_channel_id)
+    owner_id, storage_app_id = Services::ChannelId.storage_and_project_id_from_token(encrypted_channel_id)
     key = s3_path owner_id, storage_app_id, filename
     Aws::S3::Presigner.new(client: s3).presigned_url(
       :get_object,

--- a/dashboard/legacy/middleware/helpers/projects.rb
+++ b/dashboard/legacy/middleware/helpers/projects.rb
@@ -47,7 +47,7 @@ class Projects
   end
 
   def delete(channel_id)
-    owner, project_id = storage_decrypt_channel_id(channel_id)
+    owner, project_id = Services::ChannelId.storage_and_project_id_from_token(channel_id)
     raise NotFound, "channel `#{channel_id}` not found in your storage" unless owner == @storage_id
 
     delete_count = @table.where(id: project_id).update(state: 'deleted', updated_at: DateTime.now)
@@ -59,7 +59,7 @@ class Projects
   end
 
   def restore(channel_id)
-    owner, project_id = storage_decrypt_channel_id(channel_id)
+    owner, project_id = Services::ChannelId.storage_and_project_id_from_token(channel_id)
     raise NotFound, "channel `#{channel_id}` not found in your storage" unless owner == @storage_id
 
     update_count = @table.where(id: project_id).update(state: 'active', updated_at: DateTime.now)
@@ -69,7 +69,7 @@ class Projects
   end
 
   def get(channel_id)
-    owner, project_id = storage_decrypt_channel_id(channel_id)
+    owner, project_id = Services::ChannelId.storage_and_project_id_from_token(channel_id)
     row = @table.where(id: project_id).exclude(state: 'deleted').first
     raise NotFound, "channel `#{channel_id}` not found" unless row
 
@@ -91,7 +91,7 @@ class Projects
   end
 
   def update(channel_id, value, ip_address, project_type: nil, locale: 'en')
-    owner, project_id = storage_decrypt_channel_id(channel_id)
+    owner, project_id = Services::ChannelId.storage_and_project_id_from_token(channel_id)
     raise NotFound, "channel `#{channel_id}` not found in your storage" unless owner == @storage_id
 
     new_name = value['name']
@@ -123,7 +123,7 @@ class Projects
   end
 
   def publish(channel_id, type, user)
-    owner, project_id = storage_decrypt_channel_id(channel_id)
+    owner, project_id = Services::ChannelId.storage_and_project_id_from_token(channel_id)
     raise NotFound, "channel `#{channel_id}` not found in your storage" unless owner == @storage_id
     row = {
       project_type: type,
@@ -179,7 +179,7 @@ class Projects
   end
 
   def unpublish(channel_id)
-    owner, project_id = storage_decrypt_channel_id(channel_id)
+    owner, project_id = Services::ChannelId.storage_and_project_id_from_token(channel_id)
     raise NotFound, "channel `#{channel_id}` not found in your storage" unless owner == @storage_id
     row = {
       published_at: nil,
@@ -190,7 +190,7 @@ class Projects
 
   # Determine if the current user can view the project
   def get_sharing_disabled(channel_id, current_user_id)
-    owner_storage_id, project_id = storage_decrypt_channel_id(channel_id)
+    owner_storage_id, project_id = Services::ChannelId.storage_and_project_id_from_token(channel_id)
     owner_user_id = user_id_for_storage_id(owner_storage_id)
 
     # Sharing of a project is not disabled for the project owner
@@ -212,7 +212,7 @@ class Projects
 
   # Determine if the current user is teacher of project owner.
   def get_is_teacher_of_project_owner(channel_id, current_user_id)
-    owner_storage_id, __ = storage_decrypt_channel_id(channel_id)
+    owner_storage_id, __ = Services::ChannelId.storage_and_project_id_from_token(channel_id)
     owner_user_id = user_id_for_storage_id(owner_storage_id)
     teaches_student?(owner_user_id, current_user_id)
   end
@@ -235,7 +235,7 @@ class Projects
   end
 
   def increment_abuse(channel_id, amount, override_frozen = false)
-    _owner, project_id = storage_decrypt_channel_id(channel_id)
+    _owner, project_id = Services::ChannelId.storage_and_project_id_from_token(channel_id)
 
     row = @table.where(id: project_id).exclude(state: 'deleted').first
     raise NotFound, "channel `#{channel_id}` not found" unless row
@@ -259,7 +259,7 @@ class Projects
   end
 
   def reset_abuse(channel_id)
-    _owner, project_id = storage_decrypt_channel_id(channel_id)
+    _owner, project_id = Services::ChannelId.storage_and_project_id_from_token(channel_id)
 
     row = @table.where(id: project_id).exclude(state: 'deleted').first
     raise NotFound, "channel `#{channel_id}` not found" unless row
@@ -272,7 +272,7 @@ class Projects
 
   def to_a
     @table.where(storage_id: @storage_id).exclude(state: 'deleted').filter_map do |row|
-      channel_id = storage_encrypt_channel_id(row[:storage_id], row[:id])
+      channel_id = Services::ChannelId.channel_id_for(storage_id: row[:storage_id], project_id: row[:id])
       begin
         Projects.merged_row_value(
           row,
@@ -294,7 +294,7 @@ class Projects
       # Malformed channel, or missing level.
     end
 
-    storage_encrypt_channel_id(row[:storage_id], row[:id]) if row
+    Services::ChannelId.channel_id_for(storage_id: row[:storage_id], project_id: row[:id]) if row
   end
 
   # Find the encrypted channel token for most recent project of the given project_type.
@@ -356,11 +356,11 @@ class Projects
   #
   def self.remix_ancestry(channel_id, depth: 1)
     [].tap do |ancestors|
-      _, project_id = storage_decrypt_channel_id(channel_id)
+      _, project_id = Services::ChannelId.storage_and_project_id_from_token(channel_id)
       next_row = Projects.table.where(id: project_id).first
       while next_row&.[](:remix_parent_id)
         next_row = Projects.table.where(id: next_row[:remix_parent_id]).first
-        ancestors.push storage_encrypt_channel_id(next_row[:storage_id], next_row[:id]) if next_row
+        ancestors.push Services::ChannelId.channel_id_for(storage_id: next_row[:storage_id], project_id: next_row[:id]) if next_row
         break if ancestors.size >= depth
       end
     end
@@ -369,7 +369,7 @@ class Projects
   end
 
   def self.get_abuse(channel_id)
-    _, project_id = storage_decrypt_channel_id(channel_id)
+    _, project_id = Services::ChannelId.storage_and_project_id_from_token(channel_id)
     project_info = Projects.table.where(id: project_id).first
     project_info[:abuse_score]
   end

--- a/dashboard/legacy/middleware/helpers/source_bucket.rb
+++ b/dashboard/legacy/middleware/helpers/source_bucket.rb
@@ -35,7 +35,7 @@ class SourceBucket < BucketHelper
     # In most cases fall back on the generic restore behavior.
     return super(encrypted_channel_id, filename, version_id, user_id) unless filename == MAIN_JSON_FILENAME
 
-    owner_id, storage_app_id = storage_decrypt_channel_id(encrypted_channel_id)
+    owner_id, storage_app_id = Services::ChannelId.storage_and_project_id_from_token(encrypted_channel_id)
     key = s3_path owner_id, storage_app_id, filename
 
     source_object = s3.get_object(bucket: @bucket, key: key, version_id: version_id)
@@ -86,8 +86,8 @@ class SourceBucket < BucketHelper
   # in dest_channel
   # Note: this function assumes that the animations have already been copied
   def remix_source(src_channel, dest_channel, animation_list)
-    src_owner_id, src_storage_app_id = storage_decrypt_channel_id(src_channel)
-    dest_owner_id, dest_storage_app_id = storage_decrypt_channel_id(dest_channel)
+    src_owner_id, src_storage_app_id = Services::ChannelId.storage_and_project_id_from_token(src_channel)
+    dest_owner_id, dest_storage_app_id = Services::ChannelId.storage_and_project_id_from_token(dest_channel)
 
     src = s3_path src_owner_id, src_storage_app_id, MAIN_JSON_FILENAME
     dest = s3_path dest_owner_id, dest_storage_app_id, MAIN_JSON_FILENAME
@@ -124,7 +124,7 @@ class SourceBucket < BucketHelper
   # bucket will be called main.json.
   # This avoids a potentially expensive LIST request to S3.
   def app_size(encrypted_channel_id)
-    owner_id, storage_app_id = storage_decrypt_channel_id(encrypted_channel_id)
+    owner_id, storage_app_id = Services::ChannelId.storage_and_project_id_from_token(encrypted_channel_id)
     key = s3_path owner_id, storage_app_id, MAIN_JSON_FILENAME
     s3.head_object(bucket: @bucket, key: key).content_length.to_i
   rescue Aws::S3::Errors::NotFound

--- a/dashboard/legacy/test/middleware/helpers/test_bucket_helper.rb
+++ b/dashboard/legacy/test/middleware/helpers/test_bucket_helper.rb
@@ -32,7 +32,7 @@ class BucketHelperTest < Minitest::Test
     mock_table = mock
     mock_table.expects(:select).returns(mock_select).once
     DASHBOARD_DB.expects(:[]).with(:project_commits).returns(mock_table).once
-    bucket_helper.expects(:storage_decrypt_channel_id).returns([1, 2])
+    bucket_helper.expects(:Services::ChannelId.storage_and_project_id_from_token).returns([1, 2])
 
     version_list = bucket_helper.list_versions('base64', 'main.json', with_comments: true)
     assert_equal [{versionId: '1234', lastModified: '0', comment: 'Comment', isLatest: false}], version_list
@@ -59,7 +59,7 @@ class BucketHelperTest < Minitest::Test
     mock_table = mock
     mock_table.expects(:select).returns(mock_select).once
     DASHBOARD_DB.expects(:[]).with(:project_commits).returns(mock_table).once
-    bucket_helper.expects(:storage_decrypt_channel_id).returns([1, 2])
+    bucket_helper.expects(:Services::ChannelId.storage_and_project_id_from_token).returns([1, 2])
 
     version_list = bucket_helper.list_versions('base64', 'main.json', with_comments: true)
     assert_equal [{versionId: '1234', lastModified: '0', isLatest: false}], version_list

--- a/dashboard/legacy/test/middleware/helpers/test_projects.rb
+++ b/dashboard/legacy/test/middleware/helpers/test_projects.rb
@@ -223,8 +223,8 @@ class ProjectsTest < Minitest::Test
     project = Projects.new(student_storage_id)
     channel_id = project.create({projectType: 'spritelab'}, ip: 123)
 
-    # Stub storage_decrypt_channel_id to return the correct owner storage ID.
-    project.expects(:storage_decrypt_channel_id).with(channel_id).returns([student_storage_id, 123])
+    # Stub Services::ChannelId.storage_and_project_id_from_token to return the correct owner storage ID.
+    project.expects(:Services::ChannelId.storage_and_project_id_from_token).with(channel_id).returns([student_storage_id, 123])
     project.expects(:user_id_for_storage_id).with(student_storage_id).returns(student_user_id)
     project.expects(:teaches_student?).with(student_user_id, teacher_user_id).returns(true)
 
@@ -239,7 +239,7 @@ class ProjectsTest < Minitest::Test
     project = Projects.new(student_storage_id)
     channel_id = project.create({projectType: 'spritelab'}, ip: 123)
 
-    project.expects(:storage_decrypt_channel_id).with(channel_id).returns([student_storage_id, 123])
+    project.expects(:Services::ChannelId.storage_and_project_id_from_token).with(channel_id).returns([student_storage_id, 123])
     project.expects(:user_id_for_storage_id).with(student_storage_id).returns(student_user_id)
     project.expects(:teaches_student?).with(student_user_id, non_teacher_user_id).returns(false)
 

--- a/dashboard/legacy/test/middleware/test_channels.rb
+++ b/dashboard/legacy/test/middleware/test_channels.rb
@@ -204,15 +204,15 @@ class ChannelsTest < Minitest::Test
     assert last_request.url.end_with? "/#{response['id']}"
     assert_equal 456, response['def']
 
-    _, storage_app_id = storage_decrypt_channel_id(response['id'])
-    _, parent_storage_app_id = storage_decrypt_channel_id(encrypted_parent_channel_id)
+    _, storage_app_id = Services::ChannelId.storage_and_project_id_from_token(response['id'])
+    _, parent_storage_app_id = Services::ChannelId.storage_and_project_id_from_token(encrypted_parent_channel_id)
     assert_equal parent_storage_app_id, Projects.table.where(id: storage_app_id).first[:remix_parent_id]
   end
 
   def test_update_project_type
     post '/v3/channels', {abc: 123}.to_json, 'CONTENT_TYPE' => 'application/json;charset=utf-8'
     encrypted_channel_id = last_response.location.split('/').last
-    _, storage_app_id = storage_decrypt_channel_id(encrypted_channel_id)
+    _, storage_app_id = Services::ChannelId.storage_and_project_id_from_token(encrypted_channel_id)
     assert_nil Projects.table.where(id: storage_app_id).first[:project_type]
 
     post "/v3/channels/#{encrypted_channel_id}", {projectType: 'gamelab'}.to_json, 'CONTENT_TYPE' => 'application/json;charset=utf-8'

--- a/dashboard/lib/projects_list.rb
+++ b/dashboard/lib/projects_list.rb
@@ -45,7 +45,7 @@ module ProjectsList
       personal_projects_list = []
       storage_id = storage_id_for_user_id(user_id)
       Projects.new(storage_id).get_active_projects.each do |project|
-        channel_id = storage_encrypt_channel_id(storage_id, project[:id])
+        channel_id = Services::ChannelId.channel_id_for(storage_id: storage_id, project_id: project[:id])
         project_data = get_project_row_data(project, channel_id, with_library: true)
         personal_projects_list << project_data if project_data
       end
@@ -64,7 +64,7 @@ module ProjectsList
       projects_query = Projects.new(storage_id).get_projects_with_state(state: state, order: Sequel.desc(:updated_at))
 
       projects_query.each do |project|
-        channel_id = storage_encrypt_channel_id(storage_id, project[:id])
+        channel_id = Services::ChannelId.channel_id_for(storage_id: storage_id, project_id: project[:id])
         project_data = get_project_row_data(project, channel_id, with_library: true)
         personal_projects_list << project_data if project_data
       end
@@ -85,7 +85,7 @@ module ProjectsList
           Projects.new(student_storage_id).get_active_projects.each do |project|
             # The channel id stored in the project's value field may not be reliable
             # when apps are remixed, so recompute the channel id.
-            channel_id = storage_encrypt_channel_id(student_storage_id, project[:id])
+            channel_id = Services::ChannelId.channel_id_for(storage_id: student_storage_id, project_id: project[:id])
             project_data = get_project_row_data(project, channel_id, student)
             projects_list_data << project_data if project_data
           end
@@ -164,7 +164,7 @@ module ProjectsList
           each do |project|
             # The channel id stored in the project's value field may not be reliable
             # when apps are remixed, so recompute the channel id.
-            channel_id = storage_encrypt_channel_id(project[:storage_id], project[:id])
+            channel_id = Services::ChannelId.channel_id_for(storage_id: project[:storage_id], project_id: project[:id])
             project_owner = section_users.find {|user| user.id == user_storage_ids[project[:storage_id]]}
             project_data = get_library_row_data(project, channel_id, section.name, project_owner)
             if project_data && (project_owner.id != section.user_id || project_data[:sharedWith].include?(section.id))
@@ -183,7 +183,7 @@ module ProjectsList
     # @return [Array<String>] The channel_ids of libraries that have been updated since the given version.
     def fetch_updated_library_channels(libraries)
       project_ids = libraries.filter_map do |library|
-        _, id = storage_decrypt_channel_id(library['channel_id'])
+        _, id = Services::ChannelId.storage_and_project_id_from_token(library['channel_id'])
         library['project_id'] = id
         id
       rescue
@@ -240,7 +240,7 @@ module ProjectsList
       data_for_featured_project_cards = []
       project_featured_project_user_combo_data.each do |project_details|
         project_details_value = JSON.parse(project_details[:value])
-        channel = storage_encrypt_channel_id(project_details[:storage_id], project_details[:id])
+        channel = Services::ChannelId.channel_id_for(storage_id: project_details[:storage_id], project_id: project_details[:id])
         data_for_featured_project_card = {
           "channel" => channel,
           "name" => project_details_value['name'],

--- a/dashboard/lib/services/channel_id.rb
+++ b/dashboard/lib/services/channel_id.rb
@@ -1,0 +1,39 @@
+module Services
+  class ChannelId
+    UUID_REGEX = /\A[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\z/i
+
+    class NotFoundError < StandardError; end
+
+    class << self
+      def storage_and_project_id_from_token(channel_id)
+        if uuid?(channel_id)
+          project = Projects.table.where(uuid: channel_id).first || Project.find_by(uuid: channel_id)
+          raise NotFoundError, "No project found with uuid #{channel_id}" unless project
+
+          [project[:storage_id] || project.storage_id, project[:id] || project.id]
+        else
+          storage_decrypt_channel_id(channel_id)
+        end
+      end
+
+      def channel_id_for(storage_id:, project_id:)
+        project = Projects.table.where(id: project_id).first || Project.find_by(id: project_id)
+        uuid = project&.[](:uuid) || project&.uuid
+        return uuid if uuid
+
+        storage_encrypt_channel_id(storage_id, project_id)
+      end
+
+      def project_from_channel_id!(channel_id)
+        _, project_id = storage_and_project_id_from_token(channel_id)
+        Project.find(project_id)
+      rescue ArgumentError, OpenSSL::Cipher::CipherError, ActiveRecord::RecordNotFound, NotFoundError
+        raise ActiveRecord::RecordNotFound.new("Invalid channel_id: #{channel_id}")
+      end
+
+      def uuid?(channel_id)
+        UUID_REGEX.match?(channel_id.to_s)
+      end
+    end
+  end
+end

--- a/dashboard/test/controllers/aichat_events_controller_test.rb
+++ b/dashboard/test/controllers/aichat_events_controller_test.rb
@@ -39,7 +39,7 @@ class AichatEventsControllerTest < ActionController::TestCase
   end
 
   setup do
-    @controller.stubs(:storage_decrypt_channel_id).returns([123, 456])
+    Services::ChannelId.stubs(:storage_and_project_id_from_token).returns([123, 456])
   end
 
   # *****
@@ -203,7 +203,7 @@ class AichatEventsControllerTest < ActionController::TestCase
       :aichat_event,
       user_id: @authorized_student1.id,
       level_id: @level.id,
-      project_id: 456, # matches stubbed storage_decrypt_channel_id
+      project_id: 456, # matches stubbed Services::ChannelId.storage_and_project_id_from_token
       aichat_event: {role: 'user', chatMessageText: 'project match', status: 'ok', timestamp: Time.now.to_i}
     )
     _non_matching_event = create(

--- a/dashboard/test/controllers/aichat_requests_controller_test.rb
+++ b/dashboard/test/controllers/aichat_requests_controller_test.rb
@@ -35,7 +35,7 @@ class AichatRequestsControllerTest < ActionController::TestCase
   end
 
   setup do
-    @controller.stubs(:storage_decrypt_channel_id).returns([123, @project_id])
+    Services::ChannelId.stubs(:storage_and_project_id_from_token).returns([123, @project_id])
     DCDO.stubs(:get).with('block_ai_tutor_chat_completion', anything).returns(false)
     DCDO.stubs(:get).with('block_aichat_chat_completion', anything).returns(false)
     DCDO.stubs(:get).with('aichat_request_limit_per_min', anything).returns(AichatRequestsController::DEFAULT_REQUEST_LIMIT_PER_MIN)

--- a/dashboard/test/controllers/api/v1/projects/section_projects_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/projects/section_projects_controller_test.rb
@@ -79,7 +79,7 @@ class Api::V1::Projects::SectionProjectsControllerTest < ActionController::TestC
     # This verifies that the hidden project was not shown.
     assert_equal 2, projects_list.size
     project_row = projects_list.first
-    storage_id, _ = storage_decrypt_channel_id(project_row['channel'])
+    storage_id, _ = Services::ChannelId.storage_and_project_id_from_token(project_row['channel'])
     assert_equal STUDENT_STORAGE_ID, storage_id
     assert_equal 'Bobs App', project_row['name']
     assert_equal @student.name, project_row['studentName']
@@ -87,7 +87,7 @@ class Api::V1::Projects::SectionProjectsControllerTest < ActionController::TestC
     assert_equal '2017-01-25T17:48:12.358-08:00', project_row['updatedAt']
 
     project_row = projects_list.last
-    storage_id, _ = storage_decrypt_channel_id(project_row['channel'])
+    storage_id, _ = Services::ChannelId.storage_and_project_id_from_token(project_row['channel'])
     assert_equal STUDENT_STORAGE_ID, storage_id
     assert_equal 'Bobs Other App', project_row['name']
     assert_equal @student.name, project_row['studentName']

--- a/dashboard/test/controllers/backpacks_controller_test.rb
+++ b/dashboard/test/controllers/backpacks_controller_test.rb
@@ -20,7 +20,7 @@ class BackpacksControllerTest < ActionController::TestCase
     refute_nil Backpack.find_by(user_id: @user.id, game_id: @game_id)
     body = JSON.parse(response.body)
     channel = body['channel']
-    storage_id, project_id = storage_decrypt_channel_id(channel)
+    storage_id, project_id = Services::ChannelId.storage_and_project_id_from_token(channel)
     assert storage_id > 0 && project_id > 0
   end
 

--- a/dashboard/test/controllers/project_commits_controller_test.rb
+++ b/dashboard/test/controllers/project_commits_controller_test.rb
@@ -5,7 +5,7 @@ class ProjectCommitsControllerTest < ActionController::TestCase
     student = create(:student)
     sign_in student
 
-    @controller.expects(:storage_decrypt_channel_id).with("abcdef").returns([123, 654])
+    Services::ChannelId.expects(:storage_and_project_id_from_token).with("abcdef").returns([123, 654])
     assert_creates(ProjectCommit) do
       post :create, params: {storage_id: 'abcdef', version_id: 'fghj', comment: 'This is a comment'}
     end
@@ -19,7 +19,7 @@ class ProjectCommitsControllerTest < ActionController::TestCase
     sign_in student
 
     # Create the first commit.
-    @controller.expects(:storage_decrypt_channel_id).with("abcdef").returns([123, 654]).twice
+    Services::ChannelId.expects(:storage_and_project_id_from_token).with("abcdef").returns([123, 654]).twice
     post :create, params: {storage_id: 'abcdef', version_id: 'version123', comment: 'Original comment'}
 
     # Verify it was created.
@@ -44,7 +44,7 @@ class ProjectCommitsControllerTest < ActionController::TestCase
     sign_in student
 
     # Create the first commit.
-    @controller.expects(:storage_decrypt_channel_id).with("abcdef").returns([123, 654]).twice
+    Services::ChannelId.expects(:storage_and_project_id_from_token).with("abcdef").returns([123, 654]).twice
     post :create, params: {storage_id: 'abcdef', version_id: 'version456', comment: 'First comment'}
 
     # Attempt to create a duplicate - expect Honeybadger notification
@@ -73,7 +73,7 @@ class ProjectCommitsControllerTest < ActionController::TestCase
     fake_project_id = 654
     fake_channel_id = 'abcdef'
     @controller.expects(:user_id_for_storage_id).with(fake_storage_id).returns(student.id)
-    @controller.expects(:storage_decrypt_channel_id).with(fake_channel_id).returns([fake_storage_id, fake_project_id])
+    Services::ChannelId.expects(:storage_and_project_id_from_token).with(fake_channel_id).returns([fake_storage_id, fake_project_id])
 
     create(:project_commit, project_id: fake_project_id, comment: "First comment", created_at: 2.days.ago)
     create(:project_commit, project_id: fake_project_id, comment: "Second comment", created_at: 1.day.ago)
@@ -95,7 +95,7 @@ class ProjectCommitsControllerTest < ActionController::TestCase
     fake_project_id = 654
     fake_channel_id = 'abcdef'
     @controller.expects(:user_id_for_storage_id).with(fake_storage_id).returns(student.id)
-    @controller.expects(:storage_decrypt_channel_id).with(fake_channel_id).returns([fake_storage_id, fake_project_id])
+    Services::ChannelId.expects(:storage_and_project_id_from_token).with(fake_channel_id).returns([fake_storage_id, fake_project_id])
 
     create(:project_commit, project_id: fake_project_id, comment: "First comment", created_at: 2.days.ago)
     create(:project_commit, project_id: fake_project_id, comment: "", created_at: 1.day.ago)
@@ -119,7 +119,7 @@ class ProjectCommitsControllerTest < ActionController::TestCase
     fake_project_id = 654
     fake_channel_id = 'abcdef'
     @controller.expects(:user_id_for_storage_id).with(fake_storage_id).returns(student.id)
-    @controller.expects(:storage_decrypt_channel_id).with(fake_channel_id).returns([fake_storage_id, fake_project_id])
+    Services::ChannelId.expects(:storage_and_project_id_from_token).with(fake_channel_id).returns([fake_storage_id, fake_project_id])
 
     create(:project_commit, project_id: fake_project_id, comment: "Third comment")
 
@@ -144,7 +144,7 @@ class ProjectCommitsControllerTest < ActionController::TestCase
     fake_project_id = 654
     fake_channel_id = 'abcdef'
     @controller.expects(:user_id_for_storage_id).with(fake_storage_id).returns(project_owner_student.id)
-    @controller.expects(:storage_decrypt_channel_id).with(fake_channel_id).returns([fake_storage_id, fake_project_id])
+    Services::ChannelId.expects(:storage_and_project_id_from_token).with(fake_channel_id).returns([fake_storage_id, fake_project_id])
     create(:code_review, user_id: project_owner_student.id, project_id: fake_project_id)
 
     create(:project_commit, project_id: fake_project_id, comment: "Third comment")
@@ -170,7 +170,7 @@ class ProjectCommitsControllerTest < ActionController::TestCase
     fake_project_id = 654
     fake_channel_id = 'abcdef'
     @controller.expects(:user_id_for_storage_id).with(fake_storage_id).returns(project_owner_student.id)
-    @controller.expects(:storage_decrypt_channel_id).with(fake_channel_id).returns([fake_storage_id, fake_project_id])
+    Services::ChannelId.expects(:storage_and_project_id_from_token).with(fake_channel_id).returns([fake_storage_id, fake_project_id])
     create(:code_review, user_id: project_owner_student.id, project_id: fake_project_id)
 
     create(:project_commit, project_id: fake_project_id, comment: "Third comment")

--- a/dashboard/test/controllers/projects_controller_test.rb
+++ b/dashboard/test/controllers/projects_controller_test.rb
@@ -553,7 +553,7 @@ class ProjectsControllerTest < ActionController::TestCase
     sign_in_with_request @project_owner
     Project.stubs(:find_by).returns(@test_project)
     channel_id = '123456'
-    @controller.stubs(:storage_decrypt_channel_id).returns([123, 456])
+    Services::ChannelId.stubs(:storage_and_project_id_from_token).returns([123, 456])
     SharedConstants::PROJECT_SUBMISSION_STATUS.each_value do |status|
       @test_project.stubs(:submission_status).returns(status)
       get :submission_status, params: {project_type: 'music', channel_id: channel_id}

--- a/dashboard/test/controllers/rubrics_controller_test.rb
+++ b/dashboard/test/controllers/rubrics_controller_test.rb
@@ -47,7 +47,7 @@ class RubricsControllerTest < ActionController::TestCase
     # Don't actually talk to S3 when running SourceBucket.new
     AWS::S3.stubs :create_client
     stub_project_source_data(@channel_id)
-    _, @project_id = storage_decrypt_channel_id(@channel_id)
+    _, @project_id = Services::ChannelId.storage_and_project_id_from_token(@channel_id)
     @version_id = "fake-version-id"
   end
 

--- a/dashboard/test/controllers/user_level_interactions_controller_test.rb
+++ b/dashboard/test/controllers/user_level_interactions_controller_test.rb
@@ -29,7 +29,7 @@ class UserLevelInteractionsControllerTest < ActionController::TestCase
     # Don't actually talk to S3 when running SourceBucket.new
     AWS::S3.stubs :create_client
     stub_project_source_data(@channel_id)
-    _, @project_id = storage_decrypt_channel_id(@channel_id)
+    _, @project_id = Services::ChannelId.storage_and_project_id_from_token(@channel_id)
     fake_version_id = "fake-version-id"
 
     uli, metadata = check_created_uli(@csp_2024_script, @csp_2024_level)

--- a/dashboard/test/helpers/levels_helper_test.rb
+++ b/dashboard/test/helpers/levels_helper_test.rb
@@ -26,7 +26,7 @@ class LevelsHelperTest < ActionView::TestCase
 
     stubs(:current_user).returns nil
     stub_get_storage_id(nil)
-    stubs(:storage_decrypt_channel_id).returns([123, 456])
+    Services::ChannelId.stubs(:storage_and_project_id_from_token).returns([123, 456])
   end
 
   test "blockly_options refuses to generate options for non-blockly levels" do
@@ -463,7 +463,7 @@ class LevelsHelperTest < ActionView::TestCase
     @channel_id = get_channel_for(@level, script.id, @user)
     refute_nil @channel_id
 
-    _,  @project_id = storage_decrypt_channel_id(@channel_id)
+    _,  @project_id = Services::ChannelId.storage_and_project_id_from_token(@channel_id)
     create(:code_review, user_id: @user.id, project_id: @project_id)
 
     # calling app_options should set readonly_workspace, since a code review is open

--- a/dashboard/test/jobs/evaluate_rubric_job_test.rb
+++ b/dashboard/test/jobs/evaluate_rubric_job_test.rb
@@ -679,7 +679,7 @@ class EvaluateRubricJobTest < ActiveJob::TestCase
     version_id: 'fake-version-id',
     include_exact_confidence: true
   )
-    _owner_id, project_id = storage_decrypt_channel_id(channel_id)
+    _owner_id, project_id = Services::ChannelId.storage_and_project_id_from_token(channel_id)
     rubric_ai_eval = RubricAiEvaluation.where(user_id: user.id).order(updated_at: :desc).first
     assert_equal project_id, rubric_ai_eval.project_id
     assert_equal version_id, rubric_ai_eval.project_version

--- a/dashboard/test/lib/services/channel_id_test.rb
+++ b/dashboard/test/lib/services/channel_id_test.rb
@@ -1,0 +1,45 @@
+require 'test_helper'
+
+class Services::ChannelIdTest < ActiveSupport::TestCase
+  test 'storage_and_project_id_from_token supports uuid' do
+    project = create(:project)
+
+    storage_id, project_id = Services::ChannelId.storage_and_project_id_from_token(project.uuid)
+
+    assert_equal project.storage_id, storage_id
+    assert_equal project.id, project_id
+  end
+
+  test 'storage_and_project_id_from_token supports legacy channel tokens' do
+    project = create(:project)
+    legacy_channel = storage_encrypt_channel_id(project.storage_id, project.id)
+
+    storage_id, project_id = Services::ChannelId.storage_and_project_id_from_token(legacy_channel)
+
+    assert_equal project.storage_id, storage_id
+    assert_equal project.id, project_id
+  end
+
+  test 'channel_id_for returns uuid when present' do
+    project = create(:project)
+
+    assert_equal project.uuid, Services::ChannelId.channel_id_for(storage_id: project.storage_id, project_id: project.id)
+  end
+
+  test 'channel_id_for encrypts when uuid is missing' do
+    project = create(:project)
+    project.update_column(:uuid, nil)
+
+    channel = Services::ChannelId.channel_id_for(storage_id: project.storage_id, project_id: project.id)
+    storage_id, project_id = storage_decrypt_channel_id(channel)
+
+    assert_equal project.storage_id, storage_id
+    assert_equal project.id, project_id
+  end
+
+  test 'project_from_channel_id! raises on invalid channel id' do
+    assert_raises(ActiveRecord::RecordNotFound) do
+      Services::ChannelId.project_from_channel_id!('invalid-channel')
+    end
+  end
+end

--- a/dashboard/test/models/channel_token_test.rb
+++ b/dashboard/test/models/channel_token_test.rb
@@ -21,7 +21,7 @@ class ChannelTokenTest < ActiveSupport::TestCase
       @script.id
     )
 
-    storage_id, storage_app_id = storage_decrypt_channel_id(channel_token.channel)
+    storage_id, storage_app_id = Services::ChannelId.storage_and_project_id_from_token(channel_token.channel)
     assert_equal storage_id, channel_token.storage_id
     assert_equal storage_app_id, channel_token.storage_app_id
   end

--- a/dashboard/test/testing/projects_test_utils.rb
+++ b/dashboard/test/testing/projects_test_utils.rb
@@ -8,7 +8,7 @@ module ProjectsTestUtils
   def with_channel_for(owner)
     with_storage_id_for owner do |storage_id|
       encrypted_channel_id = Projects.new(storage_id).create({projectType: 'applab'}, ip: 123)
-      _, project_id = storage_decrypt_channel_id encrypted_channel_id
+      _, project_id = Services::ChannelId.storage_and_project_id_from_token encrypted_channel_id
       yield project_id, storage_id
     ensure
       projects_table.where(id: project_id).delete if project_id

--- a/lib/cdo/delete_accounts_helper.rb
+++ b/lib/cdo/delete_accounts_helper.rb
@@ -70,7 +70,7 @@ class DeleteAccountsHelper
     project_ids = get_project_ids(user)
     channel_count = project_ids.count
     encrypted_channel_ids = project_ids.map do |project_id|
-      storage_encrypt_channel_id user.user_storage_id, project_id
+      Services::ChannelId.channel_id_for(storage_id: user.user_storage_id, project_id: project_id)
     end
     @log.puts "Deleting S3 contents for #{channel_count} channels"
     buckets = [SourceBucket, AssetBucket, AnimationBucket, FileBucket].map(&:new)

--- a/shared/middleware/helpers/storage_id.rb
+++ b/shared/middleware/helpers/storage_id.rb
@@ -1,4 +1,5 @@
 require 'base64'
+require 'services/channel_id'
 
 # Create a storage id without an associated user id and track it using a cookie.
 def create_storage_id_cookie
@@ -52,21 +53,16 @@ end
 # encrypted or was encrypted using a different key (e.g. on localhost vs prod).
 def storage_decrypt_channel_id(encrypted)
   raise ArgumentError, "`encrypted` must be a string" unless encrypted.is_a? String
-  if uuid?(encrypted)
-    project = Projects.table.where(uuid: encrypted).first || Project.find_by(uuid: encrypted)
-    raise ArgumentError, "No project found with uuid #{encrypted}" unless project
-    [project[:storage_id], project[:id]]
-  else
-    # pad to a multiple of 4 characters to make a valid base64 string.
-    encrypted += '=' * ((4 - (encrypted.length % 4)) % 4)
-    storage_id, project_id = storage_decrypt(Base64.urlsafe_decode64(encrypted)).split(':').map(&:to_i)
-    raise ArgumentError, "`storage_id` must be an integer > 0" unless storage_id > 0
-    raise ArgumentError, "`project_id` must be an integer > 0" unless project_id > 0
-    [storage_id, project_id]
-  end
+  # pad to a multiple of 4 characters to make a valid base64 string.
+  encrypted += '=' * ((4 - (encrypted.length % 4)) % 4)
+  storage_id, project_id = storage_decrypt(Base64.urlsafe_decode64(encrypted)).split(':').map(&:to_i)
+  raise ArgumentError, "`storage_id` must be an integer > 0" unless storage_id > 0
+  raise ArgumentError, "`project_id` must be an integer > 0" unless project_id > 0
+  [storage_id, project_id]
 end
 
 def valid_encrypted_channel_id(encrypted)
+  return true if uuid?(encrypted)
   begin
     storage_decrypt_channel_id(encrypted)
   rescue ArgumentError, OpenSSL::Cipher::CipherError
@@ -98,12 +94,6 @@ def storage_encrypt_channel_id(storage_id, project_id)
   raise ArgumentError, "`storage_id` must be an integer > 0" unless storage_id > 0
   project_id = project_id.to_i
   raise ArgumentError, "`project_id` must be an integer > 0" unless project_id > 0
-  project = Projects.table.where(id: project_id).first || Project.find_by(id: project_id)
-
-  # return uuid if it exists
-  return project[:uuid] if project && project[:uuid]
-
-  # otherwise, continue to use the old encryption method
   Base64.urlsafe_encode64(storage_encrypt("#{storage_id}:#{project_id}")).tr('=', '')
 end
 
@@ -171,9 +161,9 @@ def storage_id_from_cookie
 end
 
 def owns_channel?(encrypted_channel_id)
-  owner_storage_id, _ = storage_decrypt_channel_id(encrypted_channel_id)
+  owner_storage_id, _ = Services::ChannelId.storage_and_project_id_from_token(encrypted_channel_id)
   owner_storage_id == get_storage_id
-rescue ArgumentError, OpenSSL::Cipher::CipherError
+rescue ArgumentError, OpenSSL::Cipher::CipherError, Services::ChannelId::NotFound, ActiveRecord::RecordNotFound
   false
 end
 
@@ -220,6 +210,5 @@ def delete_storage_id_for_user(user_id)
 end
 
 private def uuid?(string)
-  uuid_format = /\A[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\z/i
-  uuid_format.match?(string)
+  Services::ChannelId.uuid?(string)
 end

--- a/shared/test/middleware/helpers/test_storage_id.rb
+++ b/shared/test/middleware/helpers/test_storage_id.rb
@@ -134,11 +134,8 @@ class StorageIdTest < Minitest::Test
   end
 
   def test_storage_encrypt_channel_id
-    # Test with project without UUID - should encrypt
     storage_id = 123
     project_id = 456
-    mock_project = OpenStruct.new(id: project_id, storage_id: storage_id, uuid: nil)
-    Project.stubs(:find_by).with(id: project_id).returns(mock_project)
 
     encrypted = storage_encrypt_channel_id(storage_id, project_id)
     assert encrypted.is_a?(String)
@@ -148,28 +145,11 @@ class StorageIdTest < Minitest::Test
     decrypted_storage_id, decrypted_project_id = storage_decrypt(Base64.urlsafe_decode64(encrypted)).split(':').map(&:to_i)
     assert_equal storage_id, decrypted_storage_id
     assert_equal project_id, decrypted_project_id
-
-    # Test with project with UUID - should return UUID directly
-    uuid = SecureRandom.uuid
-    mock_project = OpenStruct.new(id: project_id, storage_id: storage_id, uuid: uuid)
-    Project.stubs(:find_by).with(id: project_id).returns(mock_project)
-
-    result = storage_encrypt_channel_id(storage_id, project_id)
-    assert_equal uuid, result
   end
 
   def test_storage_decrypt_channel_id
     project_id = 789
     storage_id = 456
-    uuid = SecureRandom.uuid
-
-    # uuid-based decryption
-    mock_project = OpenStruct.new(id: project_id, storage_id: storage_id, uuid: uuid)
-    Project.stubs(:find_by).with(uuid: uuid).returns(mock_project)
-
-    storage_id_out, project_id_out = storage_decrypt_channel_id(uuid)
-    assert_equal storage_id, storage_id_out
-    assert_equal project_id, project_id_out
 
     # legacy token decryption
     channel_token = Base64.urlsafe_encode64(storage_encrypt("#{storage_id}:#{project_id}")).tr('=', '')


### PR DESCRIPTION
## Summary
- restore legacy-only encryption/decryption in the shared storage helpers
- introduce a Services::ChannelId resolver for UUID and legacy channel IDs and update callers to use it
- add unit coverage for the new resolver

## Testing
- bundle exec ruby -Itest dashboard/test/lib/services/channel_id_test.rb *(fails: sprockets dependency not checked out; run `bundle install` first)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6924749044008320bfc8ae80da8f2fc8)