### PR TITLE
Fix MySQL password exposure in mysql_console_helper.rb (Part 1 of 4)

### DIFF
--- a/lib/cdo/mysql_console_helper.rb
+++ b/lib/cdo/mysql_console_helper.rb
@@ -8,11 +8,7 @@ module MysqlConsoleHelper
     opts << "--database=#{database}" if database
     opts << "--port=#{db.port}" if db.port
     # SECURITY: Password is NOT included here to avoid exposure in logs and process lists.
-    # Previously, we added --password=#{db.password} which exposed credentials in:
-    # - Build logs (when system() logs the full command)
-    # - Process lists (ps aux shows command-line arguments)
-    # - Shell history (if commands are logged)
-    # MySQL itself warns: "Using a password on the command line interface can be insecure."
+    # Previously, we added --password=#{db.password} which exposed credentials.
     # Now, below, we use a temporary option file with restricted permissions instead (see run method).
     opts.join(' ')
   end

--- a/lib/cdo/mysql_console_helper.rb
+++ b/lib/cdo/mysql_console_helper.rb
@@ -20,8 +20,10 @@ module MysqlConsoleHelper
   # Executes MySQL command via CLI. Uses shell instead of Ruby MySQL client because:
   # - Interactive CLI features (pager, formatting, history) are required for developer/admin use
   # - Used by bin/mysql-client-* scripts which are interactive tools
-  # Execution environment: Developer workstations, admin servers (single user, manual execution)
-  # Temp file risk: Low - single user environment, not susceptible to temp directory sniffing
+  # Execution environment: Developer workstations, console servers
+  # Temp file risk:
+  # - Low - when used on a non-web-serving server
+  # - Medium if used on a public web-serving server as an exploit could observe ps, /tmp
   def self.run(db, args, warn: true)
     db = URI.parse(db) unless db.is_a?(URI)
 

--- a/lib/cdo/mysql_console_helper.rb
+++ b/lib/cdo/mysql_console_helper.rb
@@ -13,7 +13,7 @@ module MysqlConsoleHelper
     # - Process lists (ps aux shows command-line arguments)
     # - Shell history (if commands are logged)
     # MySQL itself warns: "Using a password on the command line interface can be insecure."
-    # Use a temporary option file with restricted permissions instead (see run method).
+    # Now, below, we use a temporary option file with restricted permissions instead (see run method).
     opts.join(' ')
   end
 

--- a/lib/cdo/mysql_console_helper.rb
+++ b/lib/cdo/mysql_console_helper.rb
@@ -7,10 +7,21 @@ module MysqlConsoleHelper
     database = db.path[1..]
     opts << "--database=#{database}" if database
     opts << "--port=#{db.port}" if db.port
-    opts << "--password=#{db.password}" if db.password
+    # SECURITY: Password is NOT included here to avoid exposure in logs and process lists.
+    # Previously, we added --password=#{db.password} which exposed credentials in:
+    # - Build logs (when system() logs the full command)
+    # - Process lists (ps aux shows command-line arguments)
+    # - Shell history (if commands are logged)
+    # MySQL itself warns: "Using a password on the command line interface can be insecure."
+    # Use a temporary option file with restricted permissions instead (see run method).
     opts.join(' ')
   end
 
+  # Executes MySQL command via CLI. Uses shell instead of Ruby MySQL client because:
+  # - Interactive CLI features (pager, formatting, history) are required for developer/admin use
+  # - Used by bin/mysql-client-* scripts which are interactive tools
+  # Execution environment: Developer workstations, admin servers (single user, manual execution)
+  # Temp file risk: Low - single user environment, not susceptible to temp directory sniffing
   def self.run(db, args, warn: true)
     db = URI.parse(db) unless db.is_a?(URI)
 
@@ -32,6 +43,35 @@ module MysqlConsoleHelper
 
     mysql_command = "mysql #{options(db)}"
     mysql_command += " --execute=\"#{args}\"" unless args.empty?
-    system(mysql_command)
+
+    # SECURITY: Use a temporary option file instead of --password= to prevent
+    # password from appearing in process lists, logs, or environment variables.
+    # Previously, we passed --password=#{db.password} on the command line, which:
+    # - Exposed passwords in build logs (system() logs the full command string)
+    # - Made passwords visible via `ps aux` (any user can see process arguments)
+    # - Triggered MySQL's warning: "Using a password on the command line interface can be insecure."
+    # Using --defaults-extra-file with a temporary file (mode 600) is the secure approach
+    # per MySQL documentation.
+    if db.password
+      require 'tempfile'
+      require 'fileutils'
+      # Create temporary option file with restricted permissions
+      option_file = Tempfile.new(['mysql', '.cnf'])
+      # Set restrictive permissions BEFORE writing password (owner read/write only)
+      FileUtils.chmod(0o600, option_file.path)
+      option_file.write("[client]\n")
+      option_file.write("password=#{db.password}\n")
+      option_file.close
+      mysql_command = "mysql --defaults-extra-file=#{option_file.path} #{options(db)}"
+      mysql_command += " --execute=\"#{args}\"" unless args.empty?
+      begin
+        system(mysql_command)
+      ensure
+        # Always clean up the temporary file
+        option_file.unlink
+      end
+    else
+      system(mysql_command)
+    end
   end
 end

--- a/lib/cdo/mysql_console_helper.rb
+++ b/lib/cdo/mysql_console_helper.rb
@@ -49,7 +49,7 @@ module MysqlConsoleHelper
     # - Made passwords visible via `ps aux` (any user can see process arguments)
     # - Triggered MySQL's warning: "Using a password on the command line interface can be insecure."
     # Using --defaults-extra-file with a temporary file (mode 600) is the secure approach
-    # per MySQL documentation.
+    # per MySQL documentation.  See INF-1962
     if db.password
       require 'tempfile'
       require 'fileutils'


### PR DESCRIPTION
<!--
  PR Title (for GitHub):
  Fix MySQL password exposure in mysql_console_helper.rb (Part 1 of 4)
-->

Use temporary option files (mode 600) instead of --password= to prevent password from appearing in process lists.

**Part 1 of 4** - This PR is part of a multi-step effort to eliminate MySQL password exposure across the codebase. See the [Overview Document](https://docs.google.com/document/d/1cQeSpAFNReODvVtfwsgxGlrVN2-E3ngH7l-tYldETC8/edit?tab=t.0) for the complete context and all related PRs.

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

Fixes MySQL password exposure in `lib/cdo/mysql_console_helper.rb` where credentials were passed as command-line arguments (`--password=`), making them visible in process lists (`ps aux`).

This is **Part 1 of 4** in a multi-step cleanup to eliminate MySQL password exposure across the codebase. Each PR addresses a specific file or set of files to keep changes focused and testable.

**Before:** Passwords visible in process lists.  
**After:** Passwords in temporary option files (mode 600), cleaned up immediately after use. No passwords in command-line arguments.

The fix creates a temporary option file with restrictive permissions (mode 600) **before** writing the password, uses it for the MySQL command, then cleans up the file immediately via `ensure` blocks.

## Context

**What this module does:** `MysqlConsoleHelper` is a Ruby helper module that constructs MySQL command-line options and executes MySQL commands. It's used in two contexts:

1. **Interactive database tools:** Called by various `bin/mysql-client-*` scripts (e.g., `bin/mysql-client-dashboard-writer`, `bin/mysql-client-dashboard-reporting`, `bin/mysql-client-pegasus-reader`, etc.). These are command-line tools for engineers to interactively connect to MySQL databases for administration and debugging.

2. **Test infrastructure:** Also used by `test_run_utils.rb` (see PR #69751) during CI/CD test runs for database setup.

**Where it's executed:** Commonly run from console servers (production console, staging console, test console), engineer workstations, or test/staging servers (which are also web servers serving public traffic). Executed manually by engineers when they need to query databases - not part of automated CI/CD pipelines.

## Links
<!--  Links to relevant external resources.
      - spec docs, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- **Overview Document:** [Google Doc](https://docs.google.com/document/d/1cQeSpAFNReODvVtfwsgxGlrVN2-E3ngH7l-tYldETC8/edit?tab=t.0) - Complete context for all 4 PRs in this multi-step cleanup
- Jira: [INF-1962](https://codedotorg.atlassian.net/browse/INF-1962)
- Related: [RISK-29](https://codedotorg.atlassian.net/browse/RISK-29) - Running processes as same user as web server

## Testing story
<!--  Does your change include appropriate tests?
      - If so, please describe how the tests included in this PR are sufficient.
      - If not, please explain why this change does not need to be tested. -->

Manual testing required:
- Verify `bin/mysql-client-*` scripts work correctly
- Confirm passwords don't appear in process lists (`ps aux`)
- Test interactive MySQL console usage

This is a security fix that changes how passwords are passed to MySQL CLI. The functionality remains the same - only the method of passing credentials changes from command-line arguments to temporary option files.

### My manual testing

In my manual testing, this is what I saw when I ran `ps aux` after running the `bin/mysql-client-dashboard-writer` script:
```
dave             12166   0.0  0.0 435320816   5552 s002  S+   11:03AM   0:00.01 mysql --defaults-extra-file=/var/folders/nh/f8c6g33n5lq27w9x22fcr9d80000gn/T/mysql20251124-12150-5vzra8.cnf --user=root --host=localhost --database=dashboard_development --port=3306
```

## Deployment strategy
<!--  Any special steps required to deploy this, besides merging?
      - Are there database migrations or manual steps?
      - Does this require coordination with other teams or systems? -->

No special deployment steps required. This is a code-only change that affects how MySQL commands are executed.

## Follow-up work
<!--  List any clean-up or technical debt that will be addressed in future work.
      - Include Jira links where applicable.
      - Are there any known limitations or improvements planned? -->

- [RISK-29](https://codedotorg.atlassian.net/browse/RISK-29): Run cron jobs and web server as different users to eliminate same-user enumeration risk entirely.

## Privacy
<!--  How does this change impact Student & Teacher privacy?
      - Does this collect, use, share, or modify PII, either new or existing? -->

No privacy impact. This change improves security of database credential handling but does not change data collection, use, or sharing.

## Security
<!--  How does this change impact our security surface-area?
      - Do API's touched have the right auth?
      - Do infra changes impact our attack surface or encryption?
-->

**Security improvement:** Eliminates MySQL password exposure in process lists.

**Execution context:**
- Environment: Developer workstations, console servers, or other internal servers
- User context: Manual execution by individual developers/admins
- Risk level:
   - **Low** - When run from console, or other internal server
   - **Medium** - If run from a public web-serving server, as long as we have the same-user risk

## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage - Manual testing required (see Testing story)
- [X] Privacy impacts have been documented
- [X] Security impacts have been documented
- [X] Code is well-commented
- [N/A] New features are translatable or updates will not break translations
- [X] Relevant documentation has been added or updated
- [X] User impact is well-understood and desirable
- [X] Follow-up work items (including potential tech debt) are tracked and linked
