### PR TITLE
Fix MySQL password exposure in test_run_utils.rb (Part 2 of 4)

### DIFF
--- a/lib/cdo/test_run_utils.rb
+++ b/lib/cdo/test_run_utils.rb
@@ -3,6 +3,75 @@ require_relative '../../deployment'
 require 'cdo/chat_client'
 
 module TestRunUtils
+  # Creates a temporary MySQL option file with restricted permissions if a password is provided.
+  # Returns the --defaults-extra-file argument and the option file object.
+  # The caller is responsible for cleaning up the temp file (use ensure block).
+  def self.create_mysql_option_file(db)
+    db = URI.parse(db) unless db.is_a?(URI)
+
+    if db.password
+      require 'tempfile'
+      require 'fileutils'
+      option_file = Tempfile.new(['mysql', '.cnf'])
+      # Set restrictive permissions BEFORE writing password (owner read/write only)
+      FileUtils.chmod(0o600, option_file.path)
+      option_file.write("[client]\n")
+      option_file.write("password=#{db.password}\n")
+      option_file.close
+      ["--defaults-extra-file=#{option_file.path} ", option_file]
+    else
+      ['', nil]
+    end
+  end
+
+  # Executes mysqldump via CLI. Uses shell instead of Ruby MySQL client because:
+  # - No Ruby equivalent - mysqldump is CLI-only tool
+  # Execution environment: CI containers (Drone), test servers
+  # Temp file risk: High - same user runs multiple CI processes, can enumerate `/tmp` and read each other's temp files
+  # Not susceptible to temp directory sniffing from other users (mode 600 protects), but same-user processes can access
+  def self.mysqldump_secure(db, database, additional_opts = '')
+    db = URI.parse(db) unless db.is_a?(URI)
+    opts = MysqlConsoleHelper.options(db)
+    mysql_opt_arg, option_file = create_mysql_option_file(db)
+
+    begin
+      command = "#{mysql_opt_arg}mysqldump #{opts} --skip-comments --set-gtid-purged=OFF #{additional_opts} #{database}".strip
+      yield command
+    ensure
+      # Always clean up the temporary file, even if the command fails
+      option_file&.unlink
+    end
+  end
+
+  # Executes mysql via CLI. Uses shell instead of Ruby MySQL client because:
+  # - Used in shell pipes (e.g., `tee <file >(cmd1) >(cmd2)`) which require shell syntax
+  # - Simpler to reuse same pattern as mysqldump_secure
+  # Execution environment: CI containers (Drone), test servers
+  # Temp file risk: High - same user runs multiple CI processes, can enumerate `/tmp` and read each other's temp files
+  # Not susceptible to temp directory sniffing from other users (mode 600 protects), but same-user processes can access
+  def self.mysql_secure(db, command_template)
+    db = URI.parse(db) unless db.is_a?(URI)
+    mysql_opt_arg, option_file = create_mysql_option_file(db)
+
+    begin
+      # Insert --defaults-extra-file right after 'mysql' in the command
+      command = command_template.sub(/mysql /, "#{mysql_opt_arg}mysql ")
+      yield command
+    ensure
+      # Always clean up the temporary file, even if the command fails
+      option_file&.unlink
+    end
+  end
+
+  # Returns the mysql command prefix (with --defaults-extra-file if password exists) for use in shell command construction.
+  # The returned option_file must be kept in scope and cleaned up by the caller.
+  # Use mysqldump_secure or mysql_secure instead if possible, as they handle cleanup automatically.
+  def self.mysql_opt_file_arg(db)
+    db = URI.parse(db) unless db.is_a?(URI)
+    mysql_opt_arg, option_file = create_mysql_option_file(db)
+    [mysql_opt_arg, option_file]
+  end
+
   def self.run_apps_tests
     Dir.chdir(apps_dir) do
       ChatClient.wrap('apps tests') do
@@ -75,8 +144,6 @@ module TestRunUtils
     writer = URI.parse(CDO.dashboard_db_writer || 'mysql://root@localhost/dashboard_test')
     database = writer.path[1..]
     writer.path = ''
-    opts = MysqlConsoleHelper.options(writer)
-    mysqldump_opts = "mysqldump #{opts} --skip-comments --set-gtid-purged=OFF"
 
     if seed_data
       File.write(seed_file, seed_data)
@@ -86,7 +153,10 @@ module TestRunUtils
       RakeUtils.rake_stream_output 'db:create db:test:prepare'
       ENV.delete 'TEST_ENV_NUMBER'
       # Store new DB contents
-      `#{mysqldump_opts} #{database}1 | sed '#{auto_inc}' > #{seed_file.path}`
+      # SECURITY: mysqldump_secure handles temp file creation/cleanup to avoid password exposure
+      mysqldump_secure(writer, "#{database}1") do |mysqldump_cmd|
+        `#{mysqldump_cmd} | sed '#{auto_inc}' > #{seed_file.path}`
+      end
 
       if upload_seed_data
         gzip_data = Zlib::GzipWriter.wrap(StringIO.new) {|gz| IO.copy_stream(seed_file.path, gz); gz.finish}.tap(&:rewind)
@@ -103,7 +173,11 @@ module TestRunUtils
       end
     end
 
-    cloned_data = `#{mysqldump_opts} #{database}2 | sed '#{auto_inc}'`
+    # SECURITY: mysqldump_secure handles temp file creation/cleanup to avoid password exposure
+    cloned_data = mysqldump_secure(writer, "#{database}2") do |mysqldump_cmd|
+      `#{mysqldump_cmd} | sed '#{auto_inc}'`
+    end
+
     if seed_data.equal?(cloned_data)
       CDO.log.info 'Test data not modified'
     else
@@ -115,12 +189,28 @@ module TestRunUtils
       procs = ParallelTests.determine_number_of_processes(nil)
       CDO.log.info "Test data modified, cloning across #{procs} databases..."
       databases = (2..procs).map {|i| "#{database}#{i}"}
-      databases.each do |db|
-        recreate_db = "DROP DATABASE IF EXISTS #{db}; CREATE DATABASE IF NOT EXISTS #{db};"
-        RakeUtils.system_stream_output "echo '#{recreate_db}' | mysql #{opts}"
+      # For the pipes command, we need to keep the option file alive for the entire command.
+      # Uses shell instead of Ruby MySQL client because shell pipe syntax `>(cmd1) >(cmd2)` requires CLI.
+      # Execution environment: CI containers (Drone), test servers
+      # Temp file risk: High - same user runs multiple CI processes, can enumerate `/tmp` and read each other's temp files
+      # SECURITY: Create option file once and reuse for all mysql commands in the pipes
+      mysql_opt_arg, option_file = mysql_opt_file_arg(writer)
+      opts = MysqlConsoleHelper.options(writer)
+      begin
+        # Uses shell instead of Ruby MySQL client (Sequel) because:
+        # - Same execution context as pipes command below (which requires shell syntax)
+        # - Simpler to reuse same temp file pattern
+        # - Could use Sequel, but would require separate connection handling
+        databases.each do |db|
+          recreate_db = "DROP DATABASE IF EXISTS #{db}; CREATE DATABASE IF NOT EXISTS #{db};"
+          RakeUtils.system_stream_output "echo '#{recreate_db}' | #{mysql_opt_arg}mysql #{opts}"
+        end
+        pipes = databases.map {|db| ">(#{mysql_opt_arg}mysql #{opts} #{db})"}.join(' ')
+        RakeUtils.system_stream_output "/bin/bash -c 'tee <#{seed_file.path} #{pipes} >/dev/null'"
+      ensure
+        # Always clean up the temporary file, even if commands fail
+        option_file&.unlink
       end
-      pipes = databases.map {|db| ">(mysql #{opts} #{db})"}.join(' ')
-      RakeUtils.system_stream_output "/bin/bash -c 'tee <#{seed_file.path} #{pipes} >/dev/null'"
     end
   end
 


### PR DESCRIPTION
<!--
  PR Title (for GitHub):
  Fix MySQL password exposure in test_run_utils.rb (Part 2 of 4)
-->

Use temporary option files (mode 600) for mysqldump and mysql commands to prevent password from appearing in build logs or process lists.

**Part 2 of 4** - This PR is part of a multi-step effort to eliminate MySQL password exposure across the codebase. See the [Overview Document](https://docs.google.com/document/d/1cQeSpAFNReODvVtfwsgxGlrVN2-E3ngH7l-tYldETC8/edit?tab=t.0) for the complete context and all related PRs.

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

Fixes MySQL password exposure in `lib/cdo/test_run_utils.rb` where credentials were passed as command-line arguments for `mysqldump` and `mysql` commands, making them visible in build logs and process lists.

This is **Part 2 of 4** in a multi-step cleanup to eliminate MySQL password exposure across the codebase. This PR addresses all three MySQL usage locations in `test_run_utils.rb` (mysqldump, mysql pipes, and single mysql commands).

**Before:** Passwords visible in build logs, process lists.  
**After:** Passwords in temporary option files (mode 600), cleaned up immediately via `ensure` blocks. No passwords in command-line arguments.

This change adds helper functions (`mysqldump_secure`, `mysql_secure`, `mysql_opt_file_arg`, `create_mysql_option_file`) that create temporary option files with restrictive permissions (mode 600) **before** writing passwords, use them for MySQL commands, then clean up immediately.

All three MySQL usage locations in this file now use secure temp files:
- `mysqldump` for database seeding
- `mysql` in shell pipes (`tee <file >(cmd1) >(cmd2)`)
- `mysql` for single database operations

## Context

**What this module does:** `test_run_utils.rb` is a utility module for running various test suites, including database setup and cloning for parallel test execution. The `setup_dashboard_tests_parallel()` method (which contains the MySQL commands fixed here) is specifically used to:
- Clone test databases for parallel test execution (creates `dashboard_test1`, `dashboard_test2`, etc.)
- Upload seed data to test databases
- Prepare the database schema for parallel test runners

**Where it's executed:**
- **Drone CI:** Runs during regular CI builds when dashboard tests are executed
- **Chef-managed test system:** Runs during the full QA test pass (`rake test:qa`)
- Executed as part of the `test:dashboard_qa` rake task
- Runs in the `ci` user context in Drone, or `node[:user]` context on test servers

**Why this was the primary vulnerability:** This was the **only location** where passwords were actually exposed in build logs stored in S3 (the issue discovered by Seth Nickell). The other PRs in this series only exposed passwords in process lists, which requires more extreme attack scenarios.

## Links
<!--  Links to relevant external resources.
      - spec docs, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- **Overview Document:** [Google Doc](https://docs.google.com/document/d/1cQeSpAFNReODvVtfwsgxGlrVN2-E3ngH7l-tYldETC8/edit?tab=t.0) - Complete context for all 4 PRs in this multi-step cleanup
- Jira: [INF-1962](https://codedotorg.atlassian.net/browse/INF-1962)
- Related: [RISK-29](https://codedotorg.atlassian.net/browse/RISK-29) - Running processes as same user as web server

## Testing story
<!--  Does your change include appropriate tests?
      - If so, please describe how the tests included in this PR are sufficient.
      - If not, please explain why this change does not need to be tested. -->

Manual testing required:
- Verify `rake test:qa` works correctly
- Verify `rake test:dashboard` works correctly
- Confirm passwords don't appear in build logs
- Test parallel test database setup

This is a security fix that changes how passwords are passed to MySQL CLI tools. The functionality remains the same - only the method of passing credentials changes from command-line arguments to temporary option files.

## Deployment strategy
<!--  Any special steps required to deploy this, besides merging?
      - Are there database migrations or manual steps?
      - Does this require coordination with other teams or systems? -->

No special deployment steps required. This is a code-only change that affects how MySQL commands are executed during test setup.

## Follow-up work
<!--  List any clean-up or technical debt that will be addressed in future work.
      - Include Jira links where applicable.
      - Are there any known limitations or improvements planned? -->

- [RISK-29](https://codedotorg.atlassian.net/browse/RISK-29): Run cron jobs and web server as different users to eliminate same-user enumeration risk entirely.

## Privacy
<!--  How does this change impact Student & Teacher privacy?
      - Does this collect, use, share, or modify PII, either new or existing? -->

No privacy impact. This change improves security of database credential handling but does not change data collection, use, or sharing.

## Security
<!--  How does this change impact our security surface-area?
      - Do API's touched have the right auth?
      - Do infra changes impact our attack surface or encryption?
-->

**Security improvement:** Eliminates MySQL password exposure in build logs and process lists.

**Execution context:**
- Environment: 
  - **Drone CI:** Containers running as `ci` user (uid 3434)
  - **Test server:** Runs as `node[:user]` during `infra:ci` → `test:qa` (test server is also a web server serving public traffic)
- User context: 
  - **Drone:** Isolated containers, `ci` user
  - **Test server:** Same user as web server (per RISK-29)
- Risk level: **Medium** - Runs during deployment/CI only (not web requests). Same-user enumeration risk on test server where web server and test processes run as the same user.

**Remaining risk:** Same-user enumeration in shared environments (addressed by RISK-29). When cron jobs and web server run as the same user, processes can enumerate `/tmp` and potentially read each other's temp files (race condition). This is particularly relevant on the test server, which serves public web traffic and runs test processes as the same user.

## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage - Manual testing required (see Testing story)
- [X] Privacy impacts have been documented
- [X] Security impacts have been documented
- [X] Code is well-commented
- [N/A] New features are translatable or updates will not break translations
- [X] Relevant documentation has been added or updated
- [X] User impact is well-understood and desirable
- [X] Follow-up work items (including potential tech debt) are tracked and linked
