### PR TITLE
Fix MySQL password exposure in load testing scripts (Part 4 of 4)

### DIFF
--- a/dashboard/test/load/database/runload-production-clone.sh
+++ b/dashboard/test/load/database/runload-production-clone.sh
@@ -36,7 +36,20 @@ rate=5
 let num_sysbench_clients=max_db_connections/threads
 
 # Drop / create the sysbench schema
-mysql -h$1 -udb -p$PASSWORD -e "drop schema if exists sysbench;create schema sysbench;"
+# Uses mysql CLI instead of Ruby MySQL client because this is a bash script.
+# Execution environment: Load testing EC2 instances (multiple concurrent processes as same user)
+# Temp file risk: High - multiple concurrent load tests as same user can enumerate `/tmp` and read each other's temp files
+# SECURITY: Using -p$PASSWORD on command line exposes password in process lists (ps aux) and shell history.
+# MySQL warns: "Using a password on the command line interface can be insecure."
+# Use a temporary option file with restricted permissions (600) instead.
+TMP_CNF=$(mktemp /tmp/mysql.XXXXXX.cnf)
+chmod 600 "$TMP_CNF"
+cat > "$TMP_CNF" <<EOF
+[client]
+password=$PASSWORD
+EOF
+mysql --defaults-extra-file="$TMP_CNF" -h$1 -udb -e "drop schema if exists sysbench;create schema sysbench;"
+rm -f "$TMP_CNF"
 
 # Execute tests
 # Launch multiple sysbench clients

--- a/dashboard/test/load/database/runload.sh
+++ b/dashboard/test/load/database/runload.sh
@@ -31,7 +31,20 @@ cd src
 cd lua
 
 # Drop / create the sysbench schema
-mysql -h$1 -udb -p$PASSWORD -e "drop schema if exists sysbench;create schema sysbench;"
+# Uses mysql CLI instead of Ruby MySQL client because this is a bash script.
+# Execution environment: Load testing EC2 instances (multiple concurrent processes as same user)
+# Temp file risk: High - multiple concurrent load tests as same user can enumerate `/tmp` and read each other's temp files
+# SECURITY: Using -p$PASSWORD on command line exposes password in process lists (ps aux) and shell history.
+# MySQL warns: "Using a password on the command line interface can be insecure."
+# Use a temporary option file with restricted permissions (600) instead.
+TMP_CNF=$(mktemp /tmp/mysql.XXXXXX.cnf)
+chmod 600 "$TMP_CNF"
+cat > "$TMP_CNF" <<EOF
+[client]
+password=$PASSWORD
+EOF
+mysql --defaults-extra-file="$TMP_CNF" -h$1 -udb -e "drop schema if exists sysbench;create schema sysbench;"
+rm -f "$TMP_CNF"
 
 # Execute tests
 if [ "$2" == "oltp_read_only.lua" ]


### PR DESCRIPTION
<!--
  PR Title (for GitHub):
  Fix MySQL password exposure in load testing scripts (Part 4 of 4)
-->

Use temporary option files (mode 600) instead of -p$PASSWORD to prevent password from appearing in process lists.

**Part 4 of 4** - This PR is part of a multi-step effort to eliminate MySQL password exposure across the codebase. See the [Overview Document](https://docs.google.com/document/d/1cQeSpAFNReODvVtfwsgxGlrVN2-E3ngH7l-tYldETC8/edit?tab=t.0) for the complete context and all related PRs.

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

Fixes MySQL password exposure in load testing scripts where credentials were passed as command-line arguments (`-p$PASSWORD`), making them visible in process lists.

This is **Part 4 of 4** (final part) in a multi-step cleanup to eliminate MySQL password exposure across the codebase. This PR addresses both load testing scripts (`runload.sh` and `runload-production-clone.sh`).

**Before:** Passwords visible in process lists.  
**After:** Passwords in temporary option files (mode 600), cleaned up after use. No passwords in command-line arguments.

Both scripts now:
1. Create temp file with `mktemp`
2. Set permissions to 600 **before** writing password
3. Write MySQL option file content
4. Use `--defaults-extra-file` instead of `-p$PASSWORD`
5. Clean up temp file after use

**Files changed:**
- `dashboard/test/load/database/runload.sh`
- `dashboard/test/load/database/runload-production-clone.sh`

## Context

**What these scripts do:** These are bash scripts for running database load tests using sysbench on EC2 instances. They're used for performance testing and capacity planning:
- `runload.sh`: Tests against a specified database cluster
- `runload-production-clone.sh`: Tests against a production database clone cluster (created July 2020 to enable load testing against production-like data without impacting production)

The scripts set up sysbench, create test schemas, and launch hundreds of concurrent database connections to stress test the database.

**Where they're executed:**
- Run on dedicated EC2 instances
- Executed as `ec2-user` (?!) user on the load testing instances
- Not part of regular CI/CD pipelines
- Used for ad-hoc performance testing and capacity planning

## Links
<!--  Links to relevant external resources.
      - spec docs, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- **Overview Document:** [Google Doc](https://docs.google.com/document/d/1cQeSpAFNReODvVtfwsgxGlrVN2-E3ngH7l-tYldETC8/edit?tab=t.0) - Complete context for all 4 PRs in this multi-step cleanup
- Jira: [INF-1962](https://codedotorg.atlassian.net/browse/INF-1962)
- Related: [RISK-29](https://codedotorg.atlassian.net/browse/RISK-29) - Running processes as same user as web server

## Testing story
<!--  Does your change include appropriate tests?
      - If so, please describe how the tests included in this PR are sufficient.
      - If not, please explain why this change does not need to be tested. -->

Manual testing required:
- Verify load testing scripts work correctly
- Confirm passwords don't appear in process lists
- Test concurrent sysbench execution

This is a security fix that changes how passwords are passed to MySQL CLI. The functionality remains the same - only the method of passing credentials changes from command-line arguments to temporary option files.

## Deployment strategy
<!--  Any special steps required to deploy this, besides merging?
      - Are there database migrations or manual steps?
      - Does this require coordination with other teams or systems? -->

No special deployment steps required. This is a code-only change that affects how MySQL commands are executed during load testing.

## Follow-up work
<!--  List any clean-up or technical debt that will be addressed in future work.
      - Include Jira links where applicable.
      - Are there any known limitations or improvements planned? -->

- [RISK-29](https://codedotorg.atlassian.net/browse/RISK-29): Run cron jobs and web server as different users to eliminate same-user enumeration risk entirely.

## Privacy
<!--  How does this change impact Student & Teacher privacy?
      - Does this collect, use, share, or modify PII, either new or existing? -->

No privacy impact. This change improves security of database credential handling but does not change data collection, use, or sharing.

## Security
<!--  How does this change impact our security surface-area?
      - Do API's touched have the right auth?
      - Do infra changes impact our attack surface or encryption?
-->

**Security improvement:** Eliminates MySQL password exposure in process lists.

**Execution context:**
- Environment: Load testing EC2 instances (dedicated instances, not web servers)
- User context: Runs as `ec2-user` (?!) user on EC2 instances
- Risk level: **High** - Multiple concurrent load tests as same user can enumerate `/tmp` and read each other's temp files

**Remaining risk:** Same-user enumeration in concurrent load test scenarios. These scripts run multiple concurrent sysbench processes, all as the same user. While mode 600 protects against other users, same-user processes can enumerate `/tmp` and potentially read each other's temp files (race condition). This will be addressed by RISK-29.

## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage - Manual testing required (see Testing story)
- [X] Privacy impacts have been documented
- [X] Security impacts have been documented
- [X] Code is well-commented
- [N/A] New features are translatable or updates will not break translations
- [X] Relevant documentation has been added or updated
- [X] User impact is well-understood and desirable
- [X] Follow-up work items (including potential tech debt) are tracked and linked
