### PR TITLE
feat(tutor): show flash message when teacher joins pilot

### DIFF
--- a/apps/src/flashes/FlashHandler.tsx
+++ b/apps/src/flashes/FlashHandler.tsx
@@ -1,0 +1,54 @@
+import Alert, {AlertProps} from '@code-dot-org/component-library/alert';
+import {Snackbar} from '@mui/material';
+import React, {FC, useState} from 'react';
+
+type FlashType = 'notice' | 'alert';
+
+type FlashMessage = string | string[];
+
+type Flash = [FlashType, FlashMessage][];
+
+export const FlashHandler: FC<{flash?: Flash; autoHideDuration?: number}> = ({
+  flash,
+  autoHideDuration,
+}) => {
+  const [showFlash, setShowFlash] = useState(!!flash?.length);
+
+  const getAlertType = (flashType: FlashType): AlertProps['type'] => {
+    switch (flashType) {
+      case 'alert':
+        return 'danger';
+      case 'notice':
+        return 'success';
+      default:
+        return 'primary';
+    }
+  };
+
+  const handleClose = () => {
+    setShowFlash(false);
+  };
+
+  if (!flash?.length) {
+    return null;
+  }
+
+  // rails flash could contain multiple flash types and multiple messages per type
+  // presently only supporting the first type and message
+  const [type, message] = flash[0];
+  const text = Array.isArray(message) ? message[0] : message;
+
+  return (
+    <Snackbar
+      anchorOrigin={{vertical: 'top', horizontal: 'center'}}
+      open={showFlash}
+      autoHideDuration={autoHideDuration}
+      onClose={(_, reason) => {
+        if (reason === 'clickaway') return;
+        handleClose();
+      }}
+    >
+      <Alert type={getAlertType(type)} text={text} onClose={handleClose} />
+    </Snackbar>
+  );
+};

--- a/apps/src/sites/studio/pages/teacher_dashboard/show.js
+++ b/apps/src/sites/studio/pages/teacher_dashboard/show.js
@@ -8,6 +8,7 @@ import isRtl from '@cdo/apps/code-studio/isRtlRedux';
 import progressRedux from '@cdo/apps/code-studio/progressRedux';
 import verifiedInstructor from '@cdo/apps/code-studio/verifiedInstructorRedux';
 import viewAs from '@cdo/apps/code-studio/viewAsRedux';
+import {FlashHandler} from '@cdo/apps/flashes/FlashHandler';
 import {getStore, registerReducers} from '@cdo/apps/redux';
 import locales, {setLocaleCode} from '@cdo/apps/redux/localesRedux';
 import unitSelection from '@cdo/apps/redux/unitSelectionRedux';
@@ -34,6 +35,9 @@ import TeacherNavigationRouter from '@cdo/apps/templates/teacherNavigation/Teach
 import {createReactRoot} from '@cdo/apps/util/createReactRoot';
 import experiments from '@cdo/apps/util/experiments';
 
+// 6 seconds
+const FLASH_DURATION = 6 * 1000;
+
 const script = document.querySelector('script[data-dashboard]');
 const scriptData = JSON.parse(script.dataset.dashboard);
 const {
@@ -46,6 +50,7 @@ const {
   hasCompletedPersonalizationQuiz,
   sectionOrder,
   providers,
+  flash,
 } = scriptData;
 
 $(document).ready(function () {
@@ -108,6 +113,7 @@ $(document).ready(function () {
           canEnableAITutor={canEnableAITutor}
         />
       )}
+      <FlashHandler flash={flash} autoHideDuration={FLASH_DURATION} />
     </Provider>,
     document.getElementById('teacher-dashboard')
   );

--- a/apps/test/unit/flash/FlashHandlerTest.tsx
+++ b/apps/test/unit/flash/FlashHandlerTest.tsx
@@ -1,0 +1,71 @@
+import {render, screen, waitFor} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import '@testing-library/jest-dom';
+import React from 'react';
+
+import {FlashHandler} from '@cdo/apps/flashes/FlashHandler';
+
+describe('FlashHandler', () => {
+  it('does not render when flash is undefined', () => {
+    const {container} = render(<FlashHandler />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('does not render when flash is empty', () => {
+    const {container} = render(<FlashHandler flash={[]} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders the first flash message with mapped alert type for notice', () => {
+    render(<FlashHandler flash={[['notice', 'All good']]} />);
+
+    const alert = screen.getByRole('alert');
+    expect(alert).toBeInTheDocument();
+    expect(alert).toHaveAttribute(
+      'class',
+      expect.stringContaining('alert-success')
+    );
+    expect(screen.getByText('All good')).toBeInTheDocument();
+  });
+
+  it('renders the first flash message with mapped alert type for alert', () => {
+    render(<FlashHandler flash={[['alert', 'Something went wrong']]} />);
+
+    const alert = screen.getByRole('alert');
+    expect(alert).toBeInTheDocument();
+    expect(alert).toHaveAttribute(
+      'class',
+      expect.stringContaining('alert-danger')
+    );
+    expect(screen.getByText('Something went wrong')).toBeInTheDocument();
+  });
+
+  it('uses the first message when multiple messages are provided', () => {
+    render(
+      <FlashHandler
+        flash={[
+          ['alert', ['Alert message 1', 'Alert message 2']],
+          ['notice', ['Notice message 1', 'Notice message 2']],
+        ]}
+      />
+    );
+
+    expect(screen.getByText('Alert message 1')).toBeInTheDocument();
+    expect(screen.queryByText('Alert message 2')).not.toBeInTheDocument();
+    expect(screen.queryByText('Notice message 1')).not.toBeInTheDocument();
+    expect(screen.queryByText('Notice message 2')).not.toBeInTheDocument();
+  });
+
+  it('closes the snackbar when the close button is clicked', async () => {
+    const user = userEvent.setup();
+    render(<FlashHandler flash={[['alert', 'Dismiss me']]} />);
+
+    expect(screen.getByRole('alert')).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', {name: 'Close alert'}));
+
+    await waitFor(() => {
+      expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+    });
+  });
+});

--- a/dashboard/app/controllers/teacher_dashboard_controller.rb
+++ b/dashboard/app/controllers/teacher_dashboard_controller.rb
@@ -29,6 +29,7 @@ class TeacherDashboardController < ApplicationController
     end
     @section_order = UserPreference.find_by(user_id: current_user.id)&.section_order
     @locale_code = request.locale
+    @flash = flash
     view_options(full_width: true, no_padding_container: true)
   end
 

--- a/dashboard/app/views/teacher_dashboard/show.html.haml
+++ b/dashboard/app/views/teacher_dashboard/show.html.haml
@@ -17,6 +17,7 @@
   teacher_dashboard_data[:showAITALessonSummary] = DCDO.get('show-aita-lesson-summaries', false)
   teacher_dashboard_data[:hasCompletedPersonalizationQuiz] = @current_user.present? && TeachingProfileData.find_by(user: @current_user).present?
   teacher_dashboard_data[:providers] = @current_user.providers
+  teacher_dashboard_data[:flash] = @flash if @flash.present?
 
 = render partial: 'shared/emulate_print_media'
 


### PR DESCRIPTION
This pull request introduces a new `FlashHandler` React component to display Rails flash messages as dismissible snackbars in the teacher dashboard, and integrates it into the dashboard's frontend and backend data flow. It also adds unit tests for this new component.

**Limitation**
The rails `flash` object can contain more than `notice` and `alert` types and multiple messages per type. This implementation only handles the first type and first message. Searching the codebase for rails flash usage in controllers shows fairly minimal usage and only one type/message added at a time. That plus the fact the MUI `Snackbar` component is fixed position (not stackable without a larger lift and accessibility considerations), it was decided to only handle one flash type and one message.

**Frontend Feature: Flash Message Display**

* Added a new `FlashHandler` React component in `apps/src/flashes/FlashHandler.tsx` to render the first flash message from the Rails backend as a Material UI `Snackbar` with appropriate alert styling and dismiss functionality.
* Integrated `FlashHandler` into the teacher dashboard React page (`apps/src/sites/studio/pages/teacher_dashboard/show.js`), including passing the flash data from backend props and setting a 6-second auto-hide duration.

**Backend Data Flow**

* Modified the Rails controller (`dashboard/app/controllers/teacher_dashboard_controller.rb`) to include the `flash` object in the data sent to the frontend.
* Updated the HAML view (`dashboard/app/views/teacher_dashboard/show.html.haml`) to pass the flash data into the `teacher_dashboard_data` prop for frontend consumption.

**Testing**

* Added tests for `FlashHandler` in `apps/test/unit/flash/FlashHandlerTest.tsx`, covering rendering logic, alert type mapping, handling of multiple messages, and dismiss functionality.

LOGGED IN:

https://github.com/user-attachments/assets/178adbe3-c14f-4fe9-ba30-1b110a68f1d5


LOGGED OUT:

https://github.com/user-attachments/assets/8f5fd39c-8e8a-43df-81ca-aad1595cd620



## Links
<!--  Links to relevant external resources.
      - spec docs, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- Jira: https://codedotorg.atlassian.net/browse/LABS-1713

## Testing story
<!--  Does your change include appropriate tests?
      - If so, please describe how the tests included in this PR are sufficient.
      - If not, please explain why this change does not need to be tested. -->



## Deployment strategy
<!--  Any special steps required to deploy this, besides merging?
      - Are there database migrations or manual steps?
      - Does this require coordination with other teams or systems? -->



## Follow-up work
<!--  List any clean-up or technical debt that will be addressed in future work.
      - Include Jira links where applicable.
      - Are there any known limitations or improvements planned? -->



## Privacy
<!--  How does this change impact Student & Teacher privacy?
      - Does this collect, use, share, or modify PII, either new or existing? -->



## Security
<!--  How does this change impact our security surface-area?
      - Do API's touched have the right auth?
      - Do infra changes impact our attack surface or encryption?
-->



## Caching
<!--  How does this change impact caching behavior?
      - Are cache keys or invalidation strategies affected?
      - Will this require cache warming or invalidation after deployment? -->



## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
