### PR TITLE
hoai2025: tinted background color

### DIFF
--- a/apps/src/dance/lab2/views/dance-view.module.scss
+++ b/apps/src/dance/lab2/views/dance-view.module.scss
@@ -1,3 +1,9 @@
+$tinted-background-color: color-mix(
+  in srgb,
+  var(--background-neutral-tertiary),
+  transparent 30%
+);
+
 .danceLab {
   height: 100%;
   width: 100%;
@@ -26,7 +32,7 @@
         width: calc(100% - 8px);
         padding: 0 10px;
         box-sizing: border-box;
-        background-color: rgba(255 255 255 / 0.1);
+        background-color: $tinted-background-color;
         border-radius: 4px;
         margin: 4px;
 
@@ -171,7 +177,7 @@ screen and (min-height: 720px) and (min-width: 970px) {
   right: 4px;
   left: 4px;
   border-radius: 4px;
-  background-color: rgba(255 255 255 / 0.1);
+  background-color: $tinted-background-color;
   border: none;
 }
 


### PR DESCRIPTION
This follow-up to https://github.com/code-dot-org/code-dot-org/pull/69649 adjusts the background color of the dance visualization overlays to. be closer to what was there before, with opacity adjusted to hopefully provide adequate contrast for both light and dark visualization backgrounds.

### dark background

<img width="423" height="423" alt="Screenshot 2025-11-24 at 12 54 39 PM" src="https://github.com/user-attachments/assets/7959d118-f8f2-4b25-993a-12e8dd90d8d0" />

### light background

<img width="423" height="423" alt="Screenshot 2025-11-24 at 12 55 22 PM" src="https://github.com/user-attachments/assets/74e9e873-bae1-4ded-ba3f-a7b7d5c7cb45" />
