### PR TITLE
AI TA: fix version history overlap

### DIFF
--- a/apps/src/aiDifferentiation/ai-differentiation.module.scss
+++ b/apps/src/aiDifferentiation/ai-differentiation.module.scss
@@ -70,8 +70,8 @@ $sidebar-tooltip-z-index: 2010;
     align-items: center;
     gap: 0.75rem;
     align-self: stretch;
-    border-bottom: 1px solid var(--borders-neutral-primary, #D4DAE1);
-    background: var(--background-neutral-primary, #FFF);
+    border-bottom: 1px solid var(--borders-neutral-primary, #d4dae1);
+    background: var(--background-neutral-primary, #fff);
 
     .chatHeaderTitle {
       flex: 1 0 0;
@@ -292,15 +292,14 @@ $sidebar-tooltip-z-index: 2010;
   position: fixed;
   left: $fab-left * 1px;
   bottom: $fab-bottom * 1px;
-
   height: $fab-height * 1px;
   width: 48px;
   background-size: 60px;
   padding: 0;
   background-color: transparent;
-
   border-width: 0;
   border-radius: 50%;
+  z-index: 1000;
 
   img {
     opacity: 1;


### PR DESCRIPTION
Adds a z-index value to the AI TA floating action button to prevent other page elements from overlapping. 

## Links
Jira ticket: [AFL-387](https://codedotorg.atlassian.net/browse/AFL-387)

## Testing story
Tested locally; also tested to make sure other dialogs and the full screen preview in Web Lab 2 displays above it

----

| Before | After |
| ---- | ---- |
| <img width="437" height="231" alt="Before" src="https://github.com/user-attachments/assets/1a0c6410-e2d9-4617-a34c-962df21a6cc5" /> | <img width="437" height="231" alt="After" src="https://github.com/user-attachments/assets/0a54c113-1217-4f2e-ad13-22d11f7c2a88" /> |

