### PR TITLE
hoai2025: dance start over fixes

### DIFF
--- a/apps/src/dance/lab2/views/DanceView.tsx
+++ b/apps/src/dance/lab2/views/DanceView.tsx
@@ -133,6 +133,11 @@ const DanceView: React.FunctionComponent<{
     startOver,
   } = useSources<DanceProjectSources>();
 
+  const sourcesRef = useRef(currentSources);
+  useEffect(() => {
+    sourcesRef.current = currentSources;
+  }, [currentSources]);
+
   const mergeSources = useCallback(
     (patch: Partial<DanceProjectSources>, forceSave = false) => {
       const next = {...sourcesRef.current, ...patch};
@@ -468,13 +473,19 @@ const DanceView: React.FunctionComponent<{
       return;
     }
     // In case there is no song set in the current sources, set it to the default.
-    if (!currentSources.selectedSong) {
+    if (!currentSources.selectedSong && !usingMusicProject) {
       const defaultSong = levelProperties.defaultSong;
       const songToUse =
         defaultSong && songData[defaultSong] ? defaultSong : songKeys[0];
       mergeSources({selectedSong: songToUse});
     }
-  }, [songData, currentSources, mergeSources, levelProperties.defaultSong]);
+  }, [
+    songData,
+    currentSources,
+    mergeSources,
+    levelProperties.defaultSong,
+    usingMusicProject,
+  ]);
 
   // Load the selected song whenever it changes in project sources.
   useEffect(() => {
@@ -578,11 +589,6 @@ const DanceView: React.FunctionComponent<{
   }, [progressManager, levelProperties.appName, guideMode]);
 
   const settings = useBlocklySettings();
-
-  const sourcesRef = useRef(currentSources);
-  useEffect(() => {
-    sourcesRef.current = currentSources;
-  }, [currentSources]);
 
   if (isShareView) {
     const musicMetadata = loadedMusicProject

--- a/apps/src/dance/lab2/views/GenerateDance.tsx
+++ b/apps/src/dance/lab2/views/GenerateDance.tsx
@@ -129,7 +129,7 @@ const GenerateDance: React.FunctionComponent<GenerateCodeProps> = ({
     if (aiGenerateState === 'none' && blockCount > 1) {
       setAiGenerateState('edited');
     } else if (
-      ['editing', 'edited'].includes(aiGenerateState) &&
+      ['listened', 'editing', 'edited'].includes(aiGenerateState) &&
       blockCount <= 1
     ) {
       resetProgram();
@@ -341,8 +341,6 @@ const GenerateDance: React.FunctionComponent<GenerateCodeProps> = ({
             size="s"
             onClick={() => {
               startOver();
-              setAiGenerateState('none');
-              resetProgram();
               analyticsReporter.sendEvent(
                 EVENTS.DANCE_PARTY_GENERATE_CODE_BACK_TO_PROMPT_CLICKED,
                 {levelPath: window.location.pathname}
@@ -419,8 +417,6 @@ const GenerateDance: React.FunctionComponent<GenerateCodeProps> = ({
               size="s"
               onClick={() => {
                 startOver();
-                setAiGenerateState('none');
-                resetProgram();
                 analyticsReporter.sendEvent(
                   EVENTS.DANCE_PARTY_GENERATE_CODE_BACK_TO_PROMPT_CLICKED,
                   {levelPath: window.location.pathname}


### PR DESCRIPTION
We noticed that as an unintended side effect of https://github.com/code-dot-org/code-dot-org/pull/69653, Start Over and Back to Prompt wouldn't appear to reset the code workspace, until you refreshed the page.

The root cause here seemed to be that the value of `sourcesRef` was out of sync with `currentSources` when updates were occurring. When a user clicked Start Over, we would correctly compute the start over sources and set them in the SourcesContainer's state, which updated the value of `currentSources` in DanceView. However, this also triggered a useEffect further down which is meant to update the selected to song to the default song if there is not one selected, which is always the case in this tutorial. When this useEffect ran, it called `mergeSources` which merged the new selected song with current value of `sourcesRef.current`, which had not yet updated to the most recent value of `currentSources`. This meant that we then overwrote the value of `currentSources` with the previous value, and replaced the blank workspace with the previous iteration's blocks.

Fortunately the immediate fix here is straightforward: we move up the assignment of `sourcesRef.current` before all other `useEffect` hooks so the value is up to date before any `mergeSources` operations occur. Additionally, I added a check to make sure the song selection effect doesn't run for level where we have a music lab project as it's not relevant.

Mike and I discussed offline that there may be potential to further improve this solution and reduce some of the dependencies, but that would require reworking other logic that we'd rather not disrupt until after Hour of AI.