### PR TITLE
remove milestone logging

### DIFF
--- a/dashboard/app/controllers/activities_controller.rb
+++ b/dashboard/app/controllers/activities_controller.rb
@@ -157,13 +157,6 @@ class ActivitiesController < ApplicationController
       share_failure: share_failure,
       user_level: @user_level
     )
-
-    # log this at the end so that server errors (which might be caused by invalid input) prevent logging
-    log_milestone(@level_source, params)
-  end
-
-  private def milestone_logger
-    @@milestone_logger ||= Logger.new("#{Rails.root}/log/milestone.log")
   end
 
   private def track_progress_for_user
@@ -237,21 +230,5 @@ class ActivitiesController < ApplicationController
 
       client_state.add_script(@script_level.script_id)
     end
-  end
-
-  private def log_milestone(level_source, params)
-    log_string = 'Milestone Report:'
-    log_string +=
-      if current_user || session.id
-        "\t#{current_user ? current_user.id.to_s : ('s:' + session.id.to_s)}"
-      else
-        "\tanon"
-      end
-    log_string += "\t#{request.remote_ip}\t#{params[:app]}\t#{params[:level]}\t#{params[:result]}" \
-                  "\t#{params[:testResult]}\t#{params[:time]}\t#{params[:attempt]}\t#{params[:lines]}"
-    log_string += level_source.try(:id) ? "\t#{level_source.id}" : "\t"
-    log_string += "\t#{request.user_agent}"
-
-    milestone_logger.info log_string
   end
 end

--- a/dashboard/test/controllers/activities_controller_test.rb
+++ b/dashboard/test/controllers/activities_controller_test.rb
@@ -128,9 +128,6 @@ class ActivitiesControllerTest < ActionController::TestCase
   end
 
   test "logged in milestone" do
-    # do all the logging
-    @controller.expects :log_milestone
-
     assert_creates(LevelSource, UserLevel, UserScript) do
       assert_does_not_create(Activity) do
         post :milestone, params: @milestone_params
@@ -155,9 +152,6 @@ class ActivitiesControllerTest < ActionController::TestCase
   end
 
   test "logged in milestone sets unit_group_id from course_id parameter" do
-    # do all the logging
-    @controller.expects :log_milestone
-
     assert_creates(LevelSource, UserLevel, UserScript) do
       assert_does_not_create(Activity) do
         post :milestone, params: @milestone_params
@@ -279,9 +273,6 @@ class ActivitiesControllerTest < ActionController::TestCase
   end
 
   test "logged in milestone with existing userlevel with script" do
-    # do all the logging
-    @controller.expects :log_milestone
-
     UserScript.create(user: @user, script: @script, unit_group: @script.get_original_unit_group)
     UserLevel.create(level: @script_level.level, user: @user, script: @script_level.script)
 
@@ -296,9 +287,6 @@ class ActivitiesControllerTest < ActionController::TestCase
 
   test "logged in milestone with too large program does not crash" do
     # the column that we store the program is 20000 bytes, don't crash if we fail to save because the field is too large
-
-    # do all the logging
-    @controller.expects :log_milestone
 
     assert_creates(UserLevel, UserScript) do
       assert_does_not_create(LevelSource, Activity) do
@@ -323,9 +311,6 @@ class ActivitiesControllerTest < ActionController::TestCase
   end
 
   test "logged in milestone with panda does not crash" do
-    # do all the logging
-    @controller.expects :log_milestone
-
     assert_creates(UserLevel, UserScript, LevelSource) do
       assert_does_not_create(Activity) do
         post :milestone, params: @milestone_params.merge(program: "<hey>#{panda_panda}</hey>")
@@ -334,14 +319,6 @@ class ActivitiesControllerTest < ActionController::TestCase
 
     assert_response :success
     assert_equal_expected_keys build_expected_response, JSON.parse(@response.body)
-  end
-
-  # Expect the controller to invoke "milestone_logger.info()" with a
-  # string that matches given regular expression.
-  def expect_controller_logs_milestone_regexp(regexp)
-    @controller.send(:milestone_logger).expects(:info).with do |log_string|
-      log_string !~ regexp
-    end
   end
 
   test "logged in milestone with messed up email" do
@@ -353,9 +330,6 @@ class ActivitiesControllerTest < ActionController::TestCase
   end
 
   test "logged in milestone not passing" do
-    # do all the logging
-    @controller.expects :log_milestone
-
     assert_creates(LevelSource, UserLevel) do
       assert_does_not_create(Activity) do
         post :milestone,
@@ -368,9 +342,6 @@ class ActivitiesControllerTest < ActionController::TestCase
   end
 
   test "logged in milestone with image not passing" do
-    # do all the logging
-    @controller.expects :log_milestone
-
     assert_creates(LevelSource, UserLevel) do
       assert_does_not_create(Activity) do
         post :milestone,
@@ -389,9 +360,6 @@ class ActivitiesControllerTest < ActionController::TestCase
   end
 
   test "logged in milestone with image" do
-    # do all the logging
-    @controller.expects :log_milestone
-
     expect_s3_upload
 
     original_user_level_count = UserLevel.count
@@ -421,9 +389,6 @@ class ActivitiesControllerTest < ActionController::TestCase
   end
 
   test "logged in milestone with existing level source and level source image" do
-    # do all the logging
-    @controller.expects :log_milestone
-
     program = "<whatever>"
 
     level_source = LevelSource.find_identical_or_create(@script_level.level, program)
@@ -557,9 +522,6 @@ class ActivitiesControllerTest < ActionController::TestCase
     # catch that exception and just run it again (the second time we
     # will get the 'existing' object)
 
-    # do all the logging
-    @controller.expects :log_milestone
-
     # some Mocha shenanigans to simulate throwing a duplicate entry
     # error and then succeeding by returning the existing userlevel
     # (assumes that the only call to first_or_initialize when handling
@@ -637,9 +599,6 @@ class ActivitiesControllerTest < ActionController::TestCase
   test "anonymous milestone starting with empty session saves progress in section" do
     sign_out @user
 
-    # do all the logging
-    @controller.expects :log_milestone
-
     assert_creates(LevelSource) do
       assert_does_not_create(Activity, UserLevel) do
         post :milestone, params: @milestone_params.merge(user_id: 0)
@@ -660,9 +619,6 @@ class ActivitiesControllerTest < ActionController::TestCase
     # set up existing session
     client_state.set_level_progress(@script_level_prev, 50)
 
-    # do all the logging
-    @controller.expects :log_milestone
-
     assert_creates(LevelSource) do
       assert_does_not_create(Activity, UserLevel) do
         post :milestone, params: @milestone_params.merge(user_id: 0)
@@ -679,9 +635,6 @@ class ActivitiesControllerTest < ActionController::TestCase
 
   test "anonymous milestone not passing" do
     sign_out @user
-
-    # do all the logging
-    @controller.expects :log_milestone
 
     assert_creates(LevelSource) do
       assert_does_not_create(Activity, UserLevel) do
@@ -705,9 +658,6 @@ class ActivitiesControllerTest < ActionController::TestCase
 
     # set up existing session
     client_state.set_level_progress(@script_level_prev, 50)
-
-    # do all the logging
-    @controller.expects :log_milestone
 
     expect_s3_upload
 
@@ -734,9 +684,6 @@ class ActivitiesControllerTest < ActionController::TestCase
 
     # set up existing session
     client_state.set_level_progress(@script_level_prev, 50)
-
-    # do all the logging
-    @controller.expects :log_milestone
 
     expect_s3_upload_failure
 


### PR DESCRIPTION
We are writing milestone logs to the local filesystem, `dashboard/logs/milestone.log`. We only have a oneoff script that references the local milestone logs saved to every server, but we don’t use it. This PR removes the milestone logging functionality to save filesystem iops.

## Links

- Jira: [INF-1975](https://codedotorg.atlassian.net/browse/INF-1975)

## Testing story
Verified that logs are no longer output to  `milestone.log` locally when a "milestone" is saved

## Follow-up
- [INF-1977](https://codedotorg.atlassian.net/browse/INF-1977): Turn off or fix S3 log uploader, which is overwriting most log files

