### PR TITLE
Report ActiveJob worker count on all metric pushes

### DIFF
--- a/dashboard/app/jobs/concerns/active_job_metrics.rb
+++ b/dashboard/app/jobs/concerns/active_job_metrics.rb
@@ -1,5 +1,6 @@
 require 'cdo/aws/metrics'
 require 'cdo/honeybadger'
+require 'cdo/active_job_backend'
 
 module ActiveJobMetrics
   extend ActiveSupport::Concern
@@ -142,6 +143,13 @@ module ActiveJobMetrics
         timestamp: Time.now,
         dimensions: dimensions,
       },
+      {
+        metric_name: 'WorkerCount',
+        value: worker_count,
+        unit: 'Count',
+        timestamp: Time.now,
+        dimensions: dimensions,
+      }
     ]
 
     Cdo::Metrics.push(METRICS_NAMESPACE, metrics)
@@ -149,6 +157,10 @@ module ActiveJobMetrics
 
   def self.report_overall_queue_metrics
     ActiveJobMetrics.report_metrics(ActiveJobMetrics, dimensions: [{name: 'Environment', value: CDO.rack_env}])
+  end
+
+  def self.worker_count
+    Cdo::ActiveJobBackend::ExistingWorkers.get_workers_from_ps.size
   end
 
   protected def report_job_count

--- a/dashboard/test/jobs/application_job_test.rb
+++ b/dashboard/test/jobs/application_job_test.rb
@@ -83,6 +83,20 @@ class ApplicationJobTest < ActiveJob::TestCase
     assert_equal @expected_my_waiting_to_start_count, ApplicationJob.new.waiting_to_start_jobs.count
   end
 
+  test 'overall queue metrics include worker count' do
+    ActiveJobMetrics.stubs(:worker_count).returns(3)
+
+    Cdo::Metrics.expects(:push).with(
+      ApplicationJob::METRICS_NAMESPACE,
+      all_of(
+        includes_metrics(WorkerCount: 3),
+        includes_dimensions(:WorkerCount, Environment: CDO.rack_env)
+      )
+    )
+
+    ActiveJobMetrics.report_overall_queue_metrics
+  end
+
   test 'enqueued jobs log several metrics' do
     # Splitting this into two assertions because 'includes_metrics' can't match multiple metrics with the same name.
     Cdo::Metrics.expects(:push).with(


### PR DESCRIPTION
Lets log worker count. We had a recent incident where workers failed after a planned database outage, but we didn't notice because the job throughput was already low and able to be handled by the remaining workers. This became a problem when traffic increased the next day. With this metric, we can check health and triage issues faster.


## Links
<!--  Links to relevant external resources.
      - spec docs, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- Jira: 

## Testing story
<!--  Does your change include appropriate tests?
      - If so, please describe how the tests included in this PR are sufficient.
      - If not, please explain why this change does not need to be tested. -->



## Deployment strategy
<!--  Any special steps required to deploy this, besides merging?
      - Are there database migrations or manual steps?
      - Does this require coordination with other teams or systems? -->



## Follow-up work
<!--  List any clean-up or technical debt that will be addressed in future work.
      - Include Jira links where applicable.
      - Are there any known limitations or improvements planned? -->



## Privacy
<!--  How does this change impact Student & Teacher privacy?
      - Does this collect, use, share, or modify PII, either new or existing? -->



## Security
<!--  How does this change impact our security surface-area?
      - Do API's touched have the right auth?
      - Do infra changes impact our attack surface or encryption?
-->



## Caching
<!--  How does this change impact caching behavior?
      - Are cache keys or invalidation strategies affected?
      - Will this require cache warming or invalidation after deployment? -->



## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
