### PR TITLE
Add widget template dropdown settings

### DIFF
--- a/apps/src/templates/studentSnapshot/widgetTemplate/WidgetTemplate.story.tsx
+++ b/apps/src/templates/studentSnapshot/widgetTemplate/WidgetTemplate.story.tsx
@@ -112,6 +112,10 @@ Example grid setup (used in storybook):
         defaultValue: {summary: 'false'},
       },
     },
+    settingsOptions: {
+      control: false,
+      description: 'Options for the settings dropdown in the widget header',
+    },
   },
 };
 
@@ -124,6 +128,20 @@ export const Default: Story = {
     gridWidth: 1,
     gridHeight: 1,
     children: <div>This is the widget content</div>,
+    settingsOptions: [
+      {
+        value: 'setting1',
+        onClick: () => alert('Setting 1 clicked!'),
+        label: 'Setting 1',
+        icon: {iconName: 'cog'},
+      },
+      {
+        value: 'setting2',
+        onClick: () => alert('Setting 2 clicked!'),
+        label: 'Setting 2',
+        icon: {iconName: 'smile'},
+      },
+    ],
   },
 };
 

--- a/apps/src/templates/studentSnapshot/widgetTemplate/index.tsx
+++ b/apps/src/templates/studentSnapshot/widgetTemplate/index.tsx
@@ -1,4 +1,5 @@
-import {Button} from '@code-dot-org/component-library/button';
+import {ActionDropdown} from '@code-dot-org/component-library/dropdown';
+import {ActionDropdownOption} from '@code-dot-org/component-library/dropdown/actionDropdown';
 import {Typography} from '@mui/material';
 import React from 'react';
 
@@ -7,6 +8,8 @@ import i18n from '@cdo/locale';
 
 import styles from './widgetTemplate.module.scss';
 
+interface DropdownOption extends ActionDropdownOption {}
+
 interface WidgetTemplateProps {
   widgetName: string;
   gridWidth: number;
@@ -14,6 +17,7 @@ interface WidgetTemplateProps {
   children: React.ReactNode;
   scrollable?: boolean;
   loading?: boolean;
+  settingsOptions?: DropdownOption[];
 }
 
 const WidgetTemplate: React.FC<WidgetTemplateProps> = ({
@@ -23,6 +27,7 @@ const WidgetTemplate: React.FC<WidgetTemplateProps> = ({
   children,
   scrollable = false,
   loading = false,
+  settingsOptions = [],
 }) => {
   return (
     <div
@@ -33,18 +38,24 @@ const WidgetTemplate: React.FC<WidgetTemplateProps> = ({
         <Typography component="h4" variant="h5">
           {widgetName}
         </Typography>
-        <div>
-          <Button
-            color="gray"
-            size="xs"
-            type="secondary"
-            onClick={() => alert('Settings - does nothing yet')}
-            isIconOnly
-            icon={{iconName: 'gear'}}
-            aria-label={i18n.settings()}
-            disabled={loading}
-          />
-        </div>
+        {settingsOptions.length > 0 && (
+          <div>
+            <ActionDropdown
+              triggerButtonProps={{
+                color: 'gray',
+                type: 'secondary',
+                icon: {iconName: 'gear'},
+                isIconOnly: true,
+              }}
+              name={`${widgetName}-settings-dropdown`}
+              labelText={i18n.settings()}
+              size="xs"
+              disabled={loading}
+              options={settingsOptions}
+              menuPlacement="right"
+            />
+          </div>
+        )}
       </div>
       <div
         className={`${styles.content} ${

--- a/apps/test/unit/templates/studentSnapshot/WidgetTemplateTest.tsx
+++ b/apps/test/unit/templates/studentSnapshot/WidgetTemplateTest.tsx
@@ -16,7 +16,6 @@ describe('WidgetTemplate', () => {
 
     screen.getByText('Test Widget');
     screen.getByText('Test content');
-    screen.getByRole('button', {name: 'Settings'});
   });
 
   it('renders loading', () => {
@@ -24,7 +23,6 @@ describe('WidgetTemplate', () => {
 
     screen.getByText('Test Widget');
     expect(screen.queryByText('Test content')).toBeNull();
-    screen.getByRole('button', {name: 'Settings'});
     screen.getByTitle('Loading...');
   });
 
@@ -48,7 +46,7 @@ describe('WidgetTemplate', () => {
     fireEvent.click(settingsButton);
 
     // Click the dropdown option
-    const optionButton = screen.getByRole('menuitem', {name: 'Test Option'});
+    const optionButton = screen.getByRole('button', {name: 'Test Option'});
     fireEvent.click(optionButton);
 
     // Verify the onClick handler was called

--- a/apps/test/unit/templates/studentSnapshot/WidgetTemplateTest.tsx
+++ b/apps/test/unit/templates/studentSnapshot/WidgetTemplateTest.tsx
@@ -1,4 +1,4 @@
-import {render, screen} from '@testing-library/react';
+import {fireEvent, render, screen} from '@testing-library/react';
 import React from 'react';
 
 import WidgetTemplate from '@cdo/apps/templates/studentSnapshot/widgetTemplate';
@@ -26,5 +26,32 @@ describe('WidgetTemplate', () => {
     expect(screen.queryByText('Test content')).toBeNull();
     screen.getByRole('button', {name: 'Settings'});
     screen.getByTitle('Loading...');
+  });
+
+  it('allows clicking settings dropdown options', () => {
+    const mockOnClick = jest.fn();
+    const settingsOptions = [
+      {
+        value: 'option1',
+        label: 'Test Option',
+        onClick: mockOnClick,
+        icon: {iconName: 'cog'},
+      },
+    ];
+
+    render(
+      <WidgetTemplate {...defaultProps} settingsOptions={settingsOptions} />
+    );
+
+    // Click the settings button to open dropdown
+    const settingsButton = screen.getByRole('button', {name: 'Settings'});
+    fireEvent.click(settingsButton);
+
+    // Click the dropdown option
+    const optionButton = screen.getByRole('menuitem', {name: 'Test Option'});
+    fireEvent.click(optionButton);
+
+    // Verify the onClick handler was called
+    expect(mockOnClick).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
Changes the settings button to a dropdown menu. The widgetTemplate allows for a parameter to set the dropdown options. If no settings are present, the settings button does not show up.


https://github.com/user-attachments/assets/0bf521d5-712a-4353-835c-729ae1369365



## Links
<!--  Links to relevant external resources.
      - spec docs, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- Jira: https://codedotorg.atlassian.net/browse/AITT-1358
