### PR TITLE
Re-Enable Aurora Enhanced MySQL Binary Logging after Hour of AI

### DIFF
--- a/aws/cloudformation/components/database.yml.erb
+++ b/aws/cloudformation/components/database.yml.erb
@@ -153,14 +153,14 @@
         # BEGIN: Static configuration settings.
         # WARNING - Changing these settings triggers restart of each database instance in the cluster during Stack Update.
 
-        binlog_format: 'OFF' # Disable binary logging during Hour of AI
+        binlog_format: 'ROW'
         gtid-mode: 'ON'
         enforce_gtid_consistency: 'ON'
 
-        # Disable Enhanced Binary Logging during Hour of AI
-        aurora_enhanced_binlog: 0
-        binlog_backup: 1
-        binlog_replication_globaldb: 1
+        # Enable Enhanced Binary Logging to support Zero-ETL Integration with Redshift
+        aurora_enhanced_binlog: 1
+        binlog_backup: 0
+        binlog_replication_globaldb: 0
         binlog_row_image: full # This is actually a dynamic setting, but let's keep all these settings together.
         binlog_row_metadata: full # Also dynamic.
 


### PR DESCRIPTION
Reverts code-dot-org/code-dot-org#69670

Merge this BEFORE we downscale database instances so it gets applied during the restarts for the downscale.

https://codedotorg.atlassian.net/browse/INF-1974