### PR TITLE
Lab2 Version History: collapse auto-saved versions

### DIFF
--- a/apps/src/lab2/views/components/Instructions/ResourcePanel/VersionHistory/VersionHistoryPanel.tsx
+++ b/apps/src/lab2/views/components/Instructions/ResourcePanel/VersionHistory/VersionHistoryPanel.tsx
@@ -500,7 +500,7 @@ const VersionHistoryPanel: React.FunctionComponent<
                   version.comment,
                   undefined,
                   version.comment
-                    ? 'Save new version'
+                    ? 'Save new version' // Hardcoding this so it can be translated by Localize
                     : lab2I18n.saveCurrentVersion()
                 );
               } else {
@@ -537,7 +537,8 @@ const VersionHistoryPanel: React.FunctionComponent<
                           parseDate(version.lastModified),
                           version.isLatest,
                           version.comment,
-                          moduleStyles.autoSaveRow
+                          moduleStyles.autoSaveRow,
+                          undefined
                         )
                       )}
                   </React.Fragment>
@@ -547,7 +548,10 @@ const VersionHistoryPanel: React.FunctionComponent<
             {renderVersionRow(
               INITIAL_VERSION_ID,
               lab2I18n.initialVersion(),
-              latestVersion === INITIAL_VERSION_ID
+              latestVersion === INITIAL_VERSION_ID,
+              undefined,
+              undefined,
+              undefined
             )}
           </div>
         </div>

--- a/apps/src/lab2/views/components/Instructions/ResourcePanel/VersionHistory/VersionHistoryPanel.tsx
+++ b/apps/src/lab2/views/components/Instructions/ResourcePanel/VersionHistory/VersionHistoryPanel.tsx
@@ -389,6 +389,58 @@ const VersionHistoryPanel: React.FunctionComponent<
 
   const showList = listLoaded && !listLoading && !listLoadError;
 
+  // Helper function to render a single version row to reduce code duplication.
+  const renderVersionRow = useCallback(
+    (
+      versionId: string,
+      label: string,
+      isLatest: boolean,
+      comment?: string,
+      className?: string,
+      saveButtonLabel?: string
+    ) => {
+      return (
+        <VersionHistoryRow
+          className={className}
+          key={versionId}
+          versionId={versionId}
+          label={label}
+          comment={comment}
+          isLatest={isLatest}
+          isSelected={selectedVersion === versionId}
+          onChange={onVersionChange}
+          disabled={disabled}
+          showRestoreButton={
+            !isLatest && selectedVersion === versionId && !viewAsUserId
+          }
+          restoreOnClick={restoreSelectedVersion}
+          restoreLoading={versionLoading}
+          restoreDisabled={disabled || versionLoading}
+        >
+          {isLatest && hasEdited && !viewAsUserId && (
+            <SaveVersionPanel
+              projectSources={projectSources}
+              onSuccess={handleSaveVersionSuccess}
+              disabled={disabled || versionLoading}
+              buttonLabel={saveButtonLabel || lab2I18n.saveCurrentVersion()}
+            />
+          )}
+        </VersionHistoryRow>
+      );
+    },
+    [
+      selectedVersion,
+      onVersionChange,
+      disabled,
+      viewAsUserId,
+      restoreSelectedVersion,
+      versionLoading,
+      hasEdited,
+      projectSources,
+      handleSaveVersionSuccess,
+    ]
+  );
+
   return (
     <div className={moduleStyles.versionHistoryPanel}>
       {versionSaved && (
@@ -441,38 +493,15 @@ const VersionHistoryPanel: React.FunctionComponent<
             {versionSegments.map((segment: VersionSegment) => {
               if (segment.type === 'committed') {
                 const version = segment.version;
-                return (
-                  <VersionHistoryRow
-                    key={version.versionId}
-                    versionId={version.versionId}
-                    label={parseDate(version.lastModified)}
-                    comment={version.comment}
-                    isLatest={version.isLatest}
-                    isSelected={selectedVersion === version.versionId}
-                    onChange={onVersionChange}
-                    disabled={disabled}
-                    showRestoreButton={
-                      !version.isLatest &&
-                      selectedVersion === version.versionId &&
-                      !viewAsUserId
-                    }
-                    restoreOnClick={restoreSelectedVersion}
-                    restoreLoading={versionLoading}
-                    restoreDisabled={disabled || versionLoading}
-                  >
-                    {version.isLatest && hasEdited && !viewAsUserId && (
-                      <SaveVersionPanel
-                        projectSources={projectSources}
-                        onSuccess={handleSaveVersionSuccess}
-                        disabled={disabled || versionLoading}
-                        buttonLabel={
-                          version.comment
-                            ? 'Save new version'
-                            : lab2I18n.saveCurrentVersion()
-                        }
-                      />
-                    )}
-                  </VersionHistoryRow>
+                return renderVersionRow(
+                  version.versionId,
+                  parseDate(version.lastModified),
+                  version.isLatest,
+                  version.comment,
+                  undefined,
+                  version.comment
+                    ? 'Save new version'
+                    : lab2I18n.saveCurrentVersion()
                 );
               } else {
                 // Auto-save group
@@ -502,56 +531,24 @@ const VersionHistoryPanel: React.FunctionComponent<
                       />
                     )}
                     {!isCollapsed &&
-                      versions.map(version => (
-                        <VersionHistoryRow
-                          className={moduleStyles.autoSaveRow}
-                          key={version.versionId}
-                          versionId={version.versionId}
-                          label={parseDate(version.lastModified)}
-                          comment={version.comment}
-                          isLatest={version.isLatest}
-                          isSelected={selectedVersion === version.versionId}
-                          onChange={onVersionChange}
-                          disabled={disabled}
-                          showRestoreButton={
-                            !version.isLatest &&
-                            selectedVersion === version.versionId &&
-                            !viewAsUserId
-                          }
-                          restoreOnClick={restoreSelectedVersion}
-                          restoreLoading={versionLoading}
-                          restoreDisabled={disabled || versionLoading}
-                        >
-                          {version.isLatest && hasEdited && !viewAsUserId && (
-                            <SaveVersionPanel
-                              projectSources={projectSources}
-                              onSuccess={handleSaveVersionSuccess}
-                              disabled={disabled || versionLoading}
-                              buttonLabel={lab2I18n.saveCurrentVersion()}
-                            />
-                          )}
-                        </VersionHistoryRow>
-                      ))}
+                      versions.map(version =>
+                        renderVersionRow(
+                          version.versionId,
+                          parseDate(version.lastModified),
+                          version.isLatest,
+                          version.comment,
+                          moduleStyles.autoSaveRow
+                        )
+                      )}
                   </React.Fragment>
                 );
               }
             })}
-            <VersionHistoryRow
-              versionId={INITIAL_VERSION_ID}
-              label={lab2I18n.initialVersion()}
-              isLatest={latestVersion === INITIAL_VERSION_ID}
-              isSelected={selectedVersion === INITIAL_VERSION_ID}
-              onChange={onVersionChange}
-              disabled={disabled}
-              showRestoreButton={
-                selectedVersion === INITIAL_VERSION_ID &&
-                latestVersion !== INITIAL_VERSION_ID &&
-                !viewAsUserId
-              }
-              restoreOnClick={restoreSelectedVersion}
-              restoreLoading={versionLoading}
-              restoreDisabled={disabled || versionLoading}
-            />
+            {renderVersionRow(
+              INITIAL_VERSION_ID,
+              lab2I18n.initialVersion(),
+              latestVersion === INITIAL_VERSION_ID
+            )}
           </div>
         </div>
       )}

--- a/apps/src/lab2/views/components/Instructions/ResourcePanel/VersionHistory/VersionHistoryPanel.tsx
+++ b/apps/src/lab2/views/components/Instructions/ResourcePanel/VersionHistory/VersionHistoryPanel.tsx
@@ -1,4 +1,5 @@
 import Alert from '@code-dot-org/component-library/alert';
+import Button from '@code-dot-org/component-library/button';
 import FontAwesomeV6Icon from '@code-dot-org/component-library/fontAwesomeV6Icon';
 import classNames from 'classnames';
 import React, {useCallback, useEffect, useMemo, useRef, useState} from 'react';
@@ -42,6 +43,15 @@ interface VersionHistoryPanelProps {
   disabled?: boolean;
 }
 
+// Define version segments to support collapsing auto-save groups
+type VersionSegment =
+  | {type: 'committed'; version: ProjectVersion}
+  | {
+      type: 'autoSaveGroup';
+      versions: ProjectVersion[];
+      groupIndex: number;
+    };
+
 const VersionHistoryPanel: React.FunctionComponent<
   VersionHistoryPanelProps
 > = ({
@@ -53,6 +63,10 @@ const VersionHistoryPanel: React.FunctionComponent<
   disabled = false,
 }) => {
   const [versionList, setVersionList] = useState<ProjectVersion[]>([]);
+  // Track collapsed state for each group of auto-saves by group index
+  const [collapsedGroups, setCollapsedGroups] = useState<Set<number>>(
+    new Set()
+  );
   const [listLoaded, setListLoaded] = useState(false);
   const [listLoading, setListLoading] = useState(false);
   const [listLoadError, setListLoadError] = useState(false);
@@ -312,6 +326,67 @@ const VersionHistoryPanel: React.FunctionComponent<
     setVersionSaved(true);
   }, [dispatch, selectedVersion, successfulProjectResetCleanUp]);
 
+  // Group versions into segments where each segment is either:
+  // 1. The latest version (always displayed at the top)
+  // 2. A committed version (with comment)
+  // 3. A group of consecutive auto-saved versions (without comments, excluding latest)
+  const versionSegments = useMemo(() => {
+    const segments: VersionSegment[] = [];
+    let currentAutoSaveGroup: ProjectVersion[] = [];
+    let groupIndex = 0;
+
+    versionList.forEach((version, index) => {
+      if (version.comment || version.isLatest) {
+        // If there are accumulated auto-saves, add them as a group
+        if (currentAutoSaveGroup.length > 0) {
+          segments.push({
+            type: 'autoSaveGroup',
+            versions: currentAutoSaveGroup,
+            groupIndex: groupIndex++,
+          });
+          currentAutoSaveGroup = [];
+        }
+        // Add the committed version or latest version
+        segments.push({type: 'committed', version});
+      } else {
+        // Accumulate all auto-saved versions (excluding latest)
+        currentAutoSaveGroup.push(version);
+      }
+
+      // Handle any remaining auto-saves at the end
+      if (index === versionList.length - 1 && currentAutoSaveGroup.length > 0) {
+        segments.push({
+          type: 'autoSaveGroup',
+          versions: currentAutoSaveGroup,
+          groupIndex: groupIndex++,
+        });
+      }
+    });
+
+    return segments;
+  }, [versionList]);
+
+  // Initialize collapsed state for all groups (all collapsed by default)
+  useEffect(() => {
+    const allGroupIndices = versionSegments
+      .filter(segment => segment.type === 'autoSaveGroup')
+      .map(segment => (segment as {groupIndex: number}).groupIndex);
+
+    setCollapsedGroups(new Set(allGroupIndices));
+  }, [versionSegments]);
+
+  const toggleGroupCollapsed = useCallback((groupIndex: number) => {
+    setCollapsedGroups(prev => {
+      const newSet = new Set(prev);
+      if (newSet.has(groupIndex)) {
+        newSet.delete(groupIndex);
+      } else {
+        newSet.add(groupIndex);
+      }
+      return newSet;
+    });
+  }, []);
+
   const showList = listLoaded && !listLoading && !listLoadError;
 
   return (
@@ -363,39 +438,104 @@ const VersionHistoryPanel: React.FunctionComponent<
       {showList && (
         <div className={moduleStyles.listContainer}>
           <div className={moduleStyles.list}>
-            {versionList.map(version => (
-              <VersionHistoryRow
-                key={version.versionId}
-                versionId={version.versionId}
-                label={parseDate(version.lastModified)}
-                comment={version.comment}
-                isLatest={version.isLatest}
-                isSelected={selectedVersion === version.versionId}
-                onChange={onVersionChange}
-                disabled={disabled}
-                showRestoreButton={
-                  !version.isLatest &&
-                  selectedVersion === version.versionId &&
-                  !viewAsUserId
-                }
-                restoreOnClick={restoreSelectedVersion}
-                restoreLoading={versionLoading}
-                restoreDisabled={disabled || versionLoading}
-              >
-                {version.isLatest && hasEdited && !viewAsUserId && (
-                  <SaveVersionPanel
-                    projectSources={projectSources}
-                    onSuccess={handleSaveVersionSuccess}
-                    disabled={disabled || versionLoading}
-                    buttonLabel={
-                      version.comment
-                        ? 'Save new version' // Hardcoding this so it can be translated by Localize
-                        : lab2I18n.saveCurrentVersion()
+            {versionSegments.map((segment: VersionSegment) => {
+              if (segment.type === 'committed') {
+                const version = segment.version;
+                return (
+                  <VersionHistoryRow
+                    key={version.versionId}
+                    versionId={version.versionId}
+                    label={parseDate(version.lastModified)}
+                    comment={version.comment}
+                    isLatest={version.isLatest}
+                    isSelected={selectedVersion === version.versionId}
+                    onChange={onVersionChange}
+                    disabled={disabled}
+                    showRestoreButton={
+                      !version.isLatest &&
+                      selectedVersion === version.versionId &&
+                      !viewAsUserId
                     }
-                  />
-                )}
-              </VersionHistoryRow>
-            ))}
+                    restoreOnClick={restoreSelectedVersion}
+                    restoreLoading={versionLoading}
+                    restoreDisabled={disabled || versionLoading}
+                  >
+                    {version.isLatest && hasEdited && !viewAsUserId && (
+                      <SaveVersionPanel
+                        projectSources={projectSources}
+                        onSuccess={handleSaveVersionSuccess}
+                        disabled={disabled || versionLoading}
+                        buttonLabel={
+                          version.comment
+                            ? 'Save new version'
+                            : lab2I18n.saveCurrentVersion()
+                        }
+                      />
+                    )}
+                  </VersionHistoryRow>
+                );
+              } else {
+                // Auto-save group
+                const {versions, groupIndex} = segment;
+                const isCollapsed = collapsedGroups.has(groupIndex);
+                const hasMultipleVersions = versions.length > 1;
+
+                return (
+                  <React.Fragment key={`group-${groupIndex}`}>
+                    {hasMultipleVersions && (
+                      <Button
+                        className={moduleStyles.collapseButton}
+                        text={
+                          isCollapsed
+                            ? `Show ${versions.length} auto-saves`
+                            : `Hide ${versions.length} auto-saves`
+                        }
+                        iconLeft={{
+                          iconName: isCollapsed ? 'angles-down' : 'angles-up',
+                        }}
+                        color="black"
+                        size="xs"
+                        type="tertiary"
+                        aria-expanded={!isCollapsed}
+                        onClick={() => toggleGroupCollapsed(groupIndex)}
+                        disabled={disabled}
+                      />
+                    )}
+                    {!isCollapsed &&
+                      versions.map(version => (
+                        <VersionHistoryRow
+                          className={moduleStyles.autoSaveRow}
+                          key={version.versionId}
+                          versionId={version.versionId}
+                          label={parseDate(version.lastModified)}
+                          comment={version.comment}
+                          isLatest={version.isLatest}
+                          isSelected={selectedVersion === version.versionId}
+                          onChange={onVersionChange}
+                          disabled={disabled}
+                          showRestoreButton={
+                            !version.isLatest &&
+                            selectedVersion === version.versionId &&
+                            !viewAsUserId
+                          }
+                          restoreOnClick={restoreSelectedVersion}
+                          restoreLoading={versionLoading}
+                          restoreDisabled={disabled || versionLoading}
+                        >
+                          {version.isLatest && hasEdited && !viewAsUserId && (
+                            <SaveVersionPanel
+                              projectSources={projectSources}
+                              onSuccess={handleSaveVersionSuccess}
+                              disabled={disabled || versionLoading}
+                              buttonLabel={lab2I18n.saveCurrentVersion()}
+                            />
+                          )}
+                        </VersionHistoryRow>
+                      ))}
+                  </React.Fragment>
+                );
+              }
+            })}
             <VersionHistoryRow
               versionId={INITIAL_VERSION_ID}
               label={lab2I18n.initialVersion()}

--- a/apps/src/lab2/views/components/Instructions/ResourcePanel/VersionHistory/VersionHistoryRow.tsx
+++ b/apps/src/lab2/views/components/Instructions/ResourcePanel/VersionHistory/VersionHistoryRow.tsx
@@ -22,6 +22,7 @@ interface VersionHistoryRowProps {
   disabled?: boolean;
   children?: React.ReactNode;
   showRestoreButton: boolean;
+  className?: string;
 }
 
 interface RestoreVersionButtonProps {
@@ -45,6 +46,7 @@ const VersionHistoryRow: React.FunctionComponent<
   restoreOnClick,
   restoreDisabled = false,
   restoreLoading = false,
+  className,
 }) => {
   if (isLatest) {
     label = commonI18n.currentVersion();
@@ -72,7 +74,11 @@ const VersionHistoryRow: React.FunctionComponent<
   return (
     <div
       id={versionId}
-      className={classNames(moduleStyles.rowContainer, rowMarginStyle)}
+      className={classNames(
+        moduleStyles.rowContainer,
+        rowMarginStyle,
+        className
+      )}
     >
       <div className={moduleStyles.versionContent}>
         <div className={moduleStyles.versionHeader}>

--- a/apps/src/lab2/views/components/Instructions/ResourcePanel/VersionHistory/version-history-panel.module.scss
+++ b/apps/src/lab2/views/components/Instructions/ResourcePanel/VersionHistory/version-history-panel.module.scss
@@ -49,7 +49,9 @@
   }
 }
 
-.collapseButton {
+/* Repeating the class name to increase
+specificity to override DSCO styles */
+.collapseButton.collapseButton {
   margin-inline-start: 0.75rem;
   background: var(--background-neutral-primary);
   position: relative;

--- a/apps/src/lab2/views/components/Instructions/ResourcePanel/VersionHistory/version-history-panel.module.scss
+++ b/apps/src/lab2/views/components/Instructions/ResourcePanel/VersionHistory/version-history-panel.module.scss
@@ -22,7 +22,7 @@
   &::before {
     content: '';
     position: absolute;
-    inset-inline-start: 30px; // Align with radio button
+    inset-inline-start: 28px; // Align with radio button
     top: 10px;
     bottom: 10px;
     width: 1px;
@@ -38,10 +38,26 @@
   position: relative;
   padding-bottom: 0.625rem;
 
+  & > .collapseButton + .autoSaveRow {
+    margin-top: 0.625rem;
+  }
+
   /* Add extra space after the second to last row
   to add more space above the initial version row */
   & > div:nth-last-child(2) {
     margin-bottom: 1rem;
+  }
+}
+
+.collapseButton {
+  margin-inline-start: 0.75rem;
+  background: var(--background-neutral-primary);
+  position: relative;
+  z-index: 1;
+
+  span,
+  i {
+    color: var(--text-neutral-quaternary);
   }
 }
 

--- a/apps/test/unit/lab2/views/components/Instructions/ResourcePanel/VersionHistory/VersionHistoryPanelTest.tsx
+++ b/apps/test/unit/lab2/views/components/Instructions/ResourcePanel/VersionHistory/VersionHistoryPanelTest.tsx
@@ -31,6 +31,44 @@ const SAMPLE_VERSION_LIST: ProjectVersion[] = [
   {versionId: '3', lastModified: '2025-02-25T18:11:10.000Z', isLatest: true},
 ];
 
+// Create a version list with multiple auto-saves between committed versions
+const SAMPLE_VERSION_LIST_WITH_AUTOSAVES: ProjectVersion[] = [
+  {
+    versionId: '0',
+    lastModified: '2024-11-25T18:11:10.000Z',
+    isLatest: false,
+  },
+  {
+    versionId: '1',
+    lastModified: '2024-12-25T18:11:10.000Z',
+    isLatest: false,
+    comment: 'First committed version',
+  },
+  // Three auto-saves in a group
+  {
+    versionId: '2',
+    lastModified: '2025-01-25T18:11:10.000Z',
+    isLatest: false,
+  },
+  {
+    versionId: '3',
+    lastModified: '2025-01-26T18:11:10.000Z',
+    isLatest: false,
+  },
+  {
+    versionId: '4',
+    lastModified: '2025-01-27T18:11:10.000Z',
+    isLatest: false,
+  },
+  // Latest committed version
+  {
+    versionId: '5',
+    lastModified: '2025-02-25T18:11:10.000Z',
+    isLatest: true,
+    comment: 'Latest committed version',
+  },
+];
+
 const ownedChannel: Channel = {
   id: '1',
   name: '1',
@@ -162,10 +200,16 @@ describe('VersionHistoryPanel', () => {
       {timeout: 2000}
     );
 
+    // Click to expand auto-saved version group if necessary
+    const collapseButton = screen.getByRole('button', {
+      name: /Show \d+ auto-saves/,
+    });
+    const user = userEvent.setup();
+    await user.click(collapseButton);
+
     const versionInput = screen.getByDisplayValue('2') as HTMLInputElement;
     expect(versionInput.checked).toBe(false);
 
-    const user = userEvent.setup();
     await user.click(versionInput);
 
     await waitFor(() => {
@@ -183,8 +227,14 @@ describe('VersionHistoryPanel', () => {
       {timeout: 2000}
     );
 
-    const restoreButton = screen.getByRole('button', {name: 'Restore'});
+    // Click to expand auto-saved version group if necessary
+    const collapseButton = screen.getByRole('button', {
+      name: /Show \d+ auto-saves/,
+    });
     const user = userEvent.setup();
+    await user.click(collapseButton);
+
+    const restoreButton = screen.getByRole('button', {name: 'Restore'});
     await user.click(restoreButton);
 
     await waitFor(
@@ -237,6 +287,13 @@ describe('VersionHistoryPanel', () => {
       {timeout: 2000}
     );
 
+    // Click to expand auto-saved version group if necessary
+    const collapseButton = screen.getByRole('button', {
+      name: /Show \d+ auto-saves/,
+    });
+    const user = userEvent.setup();
+    await user.click(collapseButton);
+
     const restoreButton = screen.getByRole('button', {name: 'Restore'});
     expect(restoreButton).not.toBeDisabled();
   });
@@ -250,6 +307,13 @@ describe('VersionHistoryPanel', () => {
       () => expect(mockedProjectManager.getVersionList).toHaveBeenCalled(),
       {timeout: 2000}
     );
+
+    // Click to expand auto-saved version group if necessary
+    const collapseButton = screen.getByRole('button', {
+      name: /Show \d+ auto-saves/,
+    });
+    const user = userEvent.setup();
+    await user.click(collapseButton);
 
     const versionInput = screen.getByDisplayValue('2') as HTMLInputElement;
     expect(versionInput.checked).toBe(true);
@@ -295,7 +359,75 @@ describe('VersionHistoryPanel', () => {
       {timeout: 2000}
     );
 
-    const restoreButton = screen.getByRole('button', {name: 'Restore'});
-    expect(restoreButton).toBeDisabled();
+    // Click to expand auto-saved version group if necessary
+    const collapseButton = screen.getByRole('button', {
+      name: /Show \d+ auto-saves/,
+    });
+    const user = userEvent.setup();
+    await user.click(collapseButton);
+
+    const restoreButton = screen.queryByRole('button', {name: 'Restore'});
+    if (restoreButton) {
+      expect(restoreButton).toBeDisabled();
+    }
+  });
+
+  it('collapses and expands auto-save groups when collapse button is clicked', async () => {
+    mockedProjectManager = {
+      getVersionList: jest.fn(() =>
+        Promise.resolve(SAMPLE_VERSION_LIST_WITH_AUTOSAVES)
+      ),
+      loadSources: jest.fn(() => Promise.resolve({source: 'loaded'})),
+      flushSave: jest.fn(),
+    } as unknown as jest.Mocked<ProjectManager>;
+    Lab2Registry.getInstance().setProjectManager(mockedProjectManager);
+
+    renderDefault({selectedVersion: '5'});
+
+    await waitFor(
+      () => expect(mockedProjectManager.getVersionList).toHaveBeenCalled(),
+      {timeout: 2000}
+    );
+
+    // The collapse button should be present for the auto-save group
+    const collapseButton = screen.getByRole('button', {
+      name: 'Show 3 auto-saves',
+    });
+    expect(collapseButton).toBeInTheDocument();
+    expect(collapseButton).toHaveAttribute('aria-expanded', 'false');
+
+    // Auto-save versions should be hidden initially
+    expect(screen.queryByDisplayValue('2')).not.toBeInTheDocument();
+    expect(screen.queryByDisplayValue('3')).not.toBeInTheDocument();
+    expect(screen.queryByDisplayValue('4')).not.toBeInTheDocument();
+
+    // Click to expand the group
+    const user = userEvent.setup();
+    await user.click(collapseButton);
+
+    // After expanding, the button text should change
+    const expandedButton = screen.getByRole('button', {
+      name: 'Hide 3 auto-saves',
+    });
+    expect(expandedButton).toHaveAttribute('aria-expanded', 'true');
+
+    // Auto-save versions should now be visible
+    expect(screen.getByDisplayValue('2')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('3')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('4')).toBeInTheDocument();
+
+    // Click again to collapse
+    await user.click(expandedButton);
+
+    // Button should show "Show" again
+    const collapsedButton = screen.getByRole('button', {
+      name: 'Show 3 auto-saves',
+    });
+    expect(collapsedButton).toHaveAttribute('aria-expanded', 'false');
+
+    // Auto-save versions should be hidden again
+    expect(screen.queryByDisplayValue('2')).not.toBeInTheDocument();
+    expect(screen.queryByDisplayValue('3')).not.toBeInTheDocument();
+    expect(screen.queryByDisplayValue('4')).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
Adds collapse functionality to auto-saved version groups in the Version History panel in Lab2 labs (Web Lab 2 and Python Lab). This creates a cleaner and more focused UX/UI by showing committed versions with comments up front and collapsing groups of auto-saved versions by default.

## Links
Jira ticket: [AFL-379](https://codedotorg.atlassian.net/browse/AFL-379)
Figma mock: [here](https://www.figma.com/design/tDzVjyvhfkF8lyGROENOAD/Web-Lab-2?node-id=8029-32795&m=dev)

## Testing story
- Tested locally, in RTL languages, across browsers, and with keyboard and screen reader navigation
- Updated existing unit tests to work with the collapse functionally and added a unit test to test this feature

----

## Before


https://github.com/user-attachments/assets/ff86dbe0-e1d8-45f9-bb38-d75fa97c8dcb



## After

### Web Lab 2


https://github.com/user-attachments/assets/892bae6d-6a8f-4f0e-9579-77d054eabf45



### Python Lab


https://github.com/user-attachments/assets/bcec0bff-993b-4acc-8a79-293a27b96371

