### PR TITLE
Fix bugcrowd adhoc stability issues and improve default configuration

### DIFF
--- a/aws/cloudformation/cloud_formation_stack.yml.erb
+++ b/aws/cloudformation/cloud_formation_stack.yml.erb
@@ -59,7 +59,7 @@ Parameters:
     Description: Route 53 Hosted Zone ID for Codeprojects base domain name.
   InstanceType:
     Type: String
-    Default: <%=rack_env?(:production) ? 'm7i.12xlarge' : (stack_name == 'adhoc-bugcrowd' ? 'm7i.4xlarge' : 't3.2xlarge')%>
+    Default: <%=rack_env?(:production) ? 'm7i.12xlarge' : 't3.2xlarge'%>
   Branch:
     Type: String
     Default: <%=branch%>

--- a/aws/cloudformation/cloud_formation_stack.yml.erb
+++ b/aws/cloudformation/cloud_formation_stack.yml.erb
@@ -59,7 +59,7 @@ Parameters:
     Description: Route 53 Hosted Zone ID for Codeprojects base domain name.
   InstanceType:
     Type: String
-    Default: <%=rack_env?(:production) ? 'm7i.12xlarge' : (stack_name.include?('bugcrowd') ? 'm7i.4xlarge' : 't3.2xlarge')%>
+    Default: <%=rack_env?(:production) ? 'm7i.12xlarge' : (stack_name == 'adhoc-bugcrowd' ? 'm7i.4xlarge' : 't3.2xlarge')%>
   Branch:
     Type: String
     Default: <%=branch%>

--- a/aws/cloudformation/cloud_formation_stack.yml.erb
+++ b/aws/cloudformation/cloud_formation_stack.yml.erb
@@ -59,7 +59,7 @@ Parameters:
     Description: Route 53 Hosted Zone ID for Codeprojects base domain name.
   InstanceType:
     Type: String
-    Default: <%=rack_env?(:production) ? 'm7i.12xlarge' : 't3.2xlarge'%>
+    Default: <%=rack_env?(:production) ? 'm7i.12xlarge' : (stack_name.include?('bugcrowd') ? 'm7i.4xlarge' : 't3.2xlarge')%>
   Branch:
     Type: String
     Default: <%=branch%>

--- a/dashboard/config/environments/adhoc.rb
+++ b/dashboard/config/environments/adhoc.rb
@@ -15,7 +15,7 @@ Dashboard::Application.configure do
 
   # Consider disabling full error reports for profiling/load-testing by setting
   # this flag to false, due to memory leak: https://github.com/rails/rails/issues/27273
-  config.consider_all_requests_local = ENV['STACK_NAME'].to_s.exclude?('bugcrowd')
+  config.consider_all_requests_local = ENV['STACK_NAME'] != 'adhoc-bugcrowd'
 
   config.action_controller.perform_caching = true
   config.public_file_server.enabled = true

--- a/dashboard/config/environments/adhoc.rb
+++ b/dashboard/config/environments/adhoc.rb
@@ -15,7 +15,7 @@ Dashboard::Application.configure do
 
   # Consider disabling full error reports for profiling/load-testing by setting
   # this flag to false, due to memory leak: https://github.com/rails/rails/issues/27273
-  config.consider_all_requests_local = ENV['STACK_NAME'] != 'bugcrowd'
+  config.consider_all_requests_local = ENV['STACK_NAME'].to_s.exclude?('bugcrowd')
 
   config.action_controller.perform_caching = true
   config.public_file_server.enabled = true

--- a/lib/cdo/app_server_hooks.rb
+++ b/lib/cdo/app_server_hooks.rb
@@ -22,7 +22,9 @@ module Cdo
       require 'dynamic_config/gatekeeper'
       require 'dynamic_config/dcdo'
 
-      if Gatekeeper.allows('enableWebServiceProcessRollingRestart')
+      # Default to enabled (true) since this is needed in production and all environments to work around memory leaks.
+      # Can still be disabled via Gatekeeper if needed.
+      if Gatekeeper.allows('enableWebServiceProcessRollingRestart', default: true)
         require 'puma_worker_killer'
 
         restart_period = DCDO.get('web_service_process_restart_period', 12 * 3600) # default to 12 hours


### PR DESCRIPTION
# Fix bugcrowd adhoc stability issues and improve default configuration

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

This PR addresses three stability and configuration issues for adhoc environments:

1. **[CANCELLED]** ~~**Bugcrowd instance size upgrade (INF-1945)**: The bugcrowd adhoc environment was experiencing periodic hangs and 499 errors due to CPU saturation on the `t3.2xlarge` burstable instance. Upgraded to `m7i.4xlarge` for sustained CPU performance.~~
   - Instead, we will use the `INSTANCE_TYPE=` command line argument.

3. **Debug pages fix (INF-1770)**: Fixed the logic that disables debug pages on bugcrowd adhoc. The check was using exact equality (`!= 'bugcrowd'`) but the stack name is `'adhoc-bugcrowd'`, so debug pages were incorrectly enabled.

4. **Rolling restart default**: Changed the default for `enableWebServiceProcessRollingRestart` from `false` to `true`. This workaround for memory leaks has been enabled manually in production for years, and all environments that run for extended periods need this. Making it the default ensures new environments automatically get this protection without manual configuration.

## Links
<!--  Links to relevant external resources.
      - spec docs, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- Jira: [INF-1945](https://codedotorg.atlassian.net/browse/INF-1945) - Bugcrowd adhoc environment instability
- Jira: [INF-1770](https://codedotorg.atlassian.net/browse/INF-1770) - Debug pages showing on bugcrowd adhoc

## Testing story
<!--  Does your change include appropriate tests?
      - If so, please describe how the tests included in this PR are sufficient.
      - If not, please explain why this change does not need to be tested. -->

- **Instance size change**: Will be tested when the bugcrowd stack is recreated (done). CloudFormation template validation passes.
- **Debug pages fix**: Logic change is straightforward - checks if stack name includes 'bugcrowd' instead of exact equality. Can be verified after deployment by triggering an error and confirming debug pages don't show.
   - Cannot test this until after this deploys to production, in which case this new code change will also update in production. And then we may have to restart the dashboard database. But at that point, debug pages should be disabled on the ad hoc environment, closing issue INF-1770.
- **Rolling restart default**: This is a configuration default change. Existing environments with the flag manually set will continue to use their configured value. New environments will default to enabled, matching production behavior.

## Follow-up work
<!--  List any clean-up or technical debt that will be addressed in future work.
      - Include Jira links where applicable.
      - Are there any known limitations or improvements planned? -->

- Monitor bugcrowd adhoc environment after instance upgrade to confirm CPU utilization improves and 499 errors decrease.
- This change of rolling restart = `true` is essentially accepting our memory leak as not going to be fixed. It unfortunately is at a very low priority for us to fix right now and not really in sight for the sake of technical debt prioritization. This unfortunately means that we are accepting the memory leak, but nevertheless, this eventually should be fixed, at which point this default could be set back to `false`.

## Security
<!--  How does this change impact our security surface-area?
      - Do API's touched have the right auth?
      - Do infra changes impact our attack surface or encryption?
-->

- **Debug pages fix**: Security improvement - prevents sensitive error information from being exposed on bugcrowd adhoc environment.

## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [X] Security impacts have been documented
- [X] Code is well-commented
- [ ] Relevant documentation has been added or updated
- [X] User impact is well-understood and desirable
- [X] Follow-up work items (including potential tech debt) are tracked and linked

