### PR TITLE
[Drone] use drone-runner-docker fork for Drone workers

### DIFF
--- a/aws/cloudformation/drone-stack.yml
+++ b/aws/cloudformation/drone-stack.yml
@@ -304,7 +304,7 @@ Resources:
         -
           Name: drone-autoscaler
           Essential: true
-          Image: drone/autoscaler:1.13.0
+          Image: drone/autoscaler:1.14.0
           MemoryReservation: 1024
           LogConfiguration:
             LogDriver: awslogs

--- a/aws/cloudformation/drone-stack.yml
+++ b/aws/cloudformation/drone-stack.yml
@@ -32,7 +32,7 @@ Parameters:
   WorkerInstanceAMI:
     Type: String
     Description: Amazon Machine Image that Autoscaler uses to launch Worker EC2 Instances.
-    Default: ami-09b347c7ebb552ae2
+    Default: ami-041891f7c52014278
   WorkerInstanceType:
     Type: String
     Description: EC2 Instance Type that Autoscaler provisions to run Builds.

--- a/aws/cloudformation/drone-stack.yml
+++ b/aws/cloudformation/drone-stack.yml
@@ -409,7 +409,7 @@ Resources:
             # BEGIN: Settings for the Drone Runner ("worker"/"agent") executing on the EC2 Instances provisioned by Autoscaler.
             -
               Name: DRONE_AGENT_IMAGE
-              Value: syncloud/drone-runner-docker:1.9.0-amd64
+              Value: codedotorg/drone-runner-docker
             -
               Name: DRONE_AGENT_CONCURRENCY
               Value: 1

--- a/aws/cloudformation/drone-stack.yml
+++ b/aws/cloudformation/drone-stack.yml
@@ -409,6 +409,7 @@ Resources:
             # BEGIN: Settings for the Drone Runner ("worker"/"agent") executing on the EC2 Instances provisioned by Autoscaler.
             -
               Name: DRONE_AGENT_IMAGE
+              # TODO move back to mainline after drone-runners/drone-runner-docker#79 or similar is merged to update Docker Go client
               Value: codedotorg/drone-runner-docker
             -
               Name: DRONE_AGENT_CONCURRENCY

--- a/aws/cloudformation/drone-stack.yml
+++ b/aws/cloudformation/drone-stack.yml
@@ -408,6 +408,9 @@ Resources:
 
             # BEGIN: Settings for the Drone Runner ("worker"/"agent") executing on the EC2 Instances provisioned by Autoscaler.
             -
+              Name: DRONE_AGENT_IMAGE
+              Value: syncloud/drone-runner-docker:1.9.0-amd64
+            -
               Name: DRONE_AGENT_CONCURRENCY
               Value: 1
             # END: Settings for the Drone Runner.


### PR DESCRIPTION
This configures Autoscaler to use an updated `drone-runner-docker` image, built with an updated docker image.

Alternatively, we could build and push our own image. I'm hoping we see a mainline image update soon and can just revert this PR.

## Links

- https://github.com/drone-runners/drone-runner-docker/pull/79#issuecomment-3577677183
- Jira: 

## Testing story
<!--  Does your change include appropriate tests?
      - If so, please describe how the tests included in this PR are sufficient.
      - If not, please explain why this change does not need to be tested. -->



## Deployment strategy
<!--  Any special steps required to deploy this, besides merging?
      - Are there database migrations or manual steps?
      - Does this require coordination with other teams or systems? -->



## Follow-up work
<!--  List any clean-up or technical debt that will be addressed in future work.
      - Include Jira links where applicable.
      - Are there any known limitations or improvements planned? -->



## Privacy
<!--  How does this change impact Student & Teacher privacy?
      - Does this collect, use, share, or modify PII, either new or existing? -->



## Security
<!--  How does this change impact our security surface-area?
      - Do API's touched have the right auth?
      - Do infra changes impact our attack surface or encryption?
-->



## Caching
<!--  How does this change impact caching behavior?
      - Are cache keys or invalidation strategies affected?
      - Will this require cache warming or invalidation after deployment? -->



## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
