### PR TITLE
Fix curriculum_courses endpoint in the general context

### DIFF
--- a/dashboard/app/controllers/aidiff_threads_controller.rb
+++ b/dashboard/app/controllers/aidiff_threads_controller.rb
@@ -76,7 +76,7 @@ class AidiffThreadsController < ApplicationController
     courses = []
 
     if context[:type] == SharedConstants::AI_DIFF_CONTEXT[:GENERAL]
-      get_active_sections.each do |c|
+      get_section_contexts(get_active_sections).each do |c|
         courses.push(*c[:course_names])
       end
     else
@@ -212,6 +212,10 @@ class AidiffThreadsController < ApplicationController
     }
   end
 
+  private def get_active_sections
+    current_user.sections_instructed.where(hidden: false, updated_at: 1.year.ago..Time.now)&.select {|s| s.script_id || s.course_id}
+  end
+
   private def get_section_contexts(sections)
     # all sections updated in the last year that have curriculum assigned
     contexts = sections&.map do |section|
@@ -254,8 +258,7 @@ class AidiffThreadsController < ApplicationController
     end
 
     if context_type == SharedConstants::AI_DIFF_CONTEXT[:GENERAL]
-      sections = current_user.sections_instructed.where(hidden: false, updated_at: 1.year.ago..Time.now)&.select {|s| s.script_id || s.course_id}
-      @section_contexts = get_section_contexts(sections)
+      @section_contexts = get_section_contexts(get_active_sections)
     elsif section_id
       sections = current_user.sections_instructed.filter {|section| section.id == section_id}
       @section_contexts = get_section_contexts(sections)

--- a/dashboard/test/controllers/aidiff_threads_controller_test.rb
+++ b/dashboard/test/controllers/aidiff_threads_controller_test.rb
@@ -5,6 +5,7 @@ class AidiffThreadsControllerTest < ActionController::TestCase
 
   setup do
     @unit_group = create(:unit_group, family_name: 'beepboop')
+    @unit_group2 = create(:unit_group, family_name: 'dootdoot')
     @course_offering = create(:course_offering, display_name: 'Course Name')
     @course_version = create(:course_version, content_root: @unit_group, course_offering: @course_offering)
     @unit_in_course = create(:script, name: 'unit-in-teacher-instructed-course2')
@@ -15,6 +16,9 @@ class AidiffThreadsControllerTest < ActionController::TestCase
 
     @teacher_sans_experiment = create(:teacher)
     @teacher = create(:teacher)
+
+    @section = create(:section, user: @teacher, unit_group: @unit_group)
+    @section2 = create(:section, user: @teacher, unit_group: @unit_group2)
 
     create(:single_user_experiment, min_user_id: @teacher.id, name: 'ai-differentiation')
 
@@ -504,6 +508,22 @@ class AidiffThreadsControllerTest < ActionController::TestCase
       assert_response :success
       assert_equal 2, json_response["courses"].count
       assert_includes(json_response["courses"], "beepboop")
+    end
+
+    test "returns success for curriculum_courses in general context" do
+      sign_in @teacher
+
+      post :curriculum_courses, params: {
+        context: {
+          type: "general"
+        },
+      }
+
+      json_response = JSON.parse(response.body)
+      assert_response :success
+      assert_equal 4, json_response["courses"].count
+      assert_includes(json_response["courses"], "beepboop")
+      assert_includes(json_response["courses"], "dootdoot")
     end
   end
 


### PR DESCRIPTION
#69674 shipped a regression to the `aidiff_threads/curriculum_courses` endpoint when called in the `GENERAL` context. This was not caught by any automated tests because none of the existing tests exercised that code path.

This PR fixes the bug and also adds a test that would have caught it.

## Links
[Slack thread](https://codedotorg.slack.com/archives/C0T0PNTM3/p1764119518936749)

## Testing story
<!--  Does your change include appropriate tests?
      - If so, please describe how the tests included in this PR are sufficient.
      - If not, please explain why this change does not need to be tested. -->



## Deployment strategy
<!--  Any special steps required to deploy this, besides merging?
      - Are there database migrations or manual steps?
      - Does this require coordination with other teams or systems? -->



## Follow-up work
<!--  List any clean-up or technical debt that will be addressed in future work.
      - Include Jira links where applicable.
      - Are there any known limitations or improvements planned? -->



## Privacy
<!--  How does this change impact Student & Teacher privacy?
      - Does this collect, use, share, or modify PII, either new or existing? -->



## Security
<!--  How does this change impact our security surface-area?
      - Do API's touched have the right auth?
      - Do infra changes impact our attack surface or encryption?
-->



## Caching
<!--  How does this change impact caching behavior?
      - Are cache keys or invalidation strategies affected?
      - Will this require cache warming or invalidation after deployment? -->



## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
