### PR TITLE
feat(Checkbox): Tweaks to styling + a11y and functionality improvements + stories

### DIFF
--- a/frontend/packages/component-library/src/checkbox/Checkbox.tsx
+++ b/frontend/packages/component-library/src/checkbox/Checkbox.tsx
@@ -1,5 +1,12 @@
 import classnames from 'classnames';
-import {memo, useRef, useEffect, ReactNode, ChangeEvent, InputHTMLAttributes} from 'react';
+import {
+  memo,
+  useRef,
+  useEffect,
+  ReactNode,
+  ChangeEvent,
+  InputHTMLAttributes,
+} from 'react';
 
 import {componentSizeToBodyTextSizeMap} from '@/common/constants';
 import {ComponentSizeXSToL} from '@/common/types';

--- a/frontend/packages/component-library/src/checkbox/Checkbox.tsx
+++ b/frontend/packages/component-library/src/checkbox/Checkbox.tsx
@@ -1,6 +1,5 @@
 import classnames from 'classnames';
 import {
-  memo,
   useRef,
   useEffect,
   ReactNode,
@@ -125,4 +124,4 @@ const Checkbox: React.FunctionComponent<CheckboxProps> = ({
   );
 };
 
-export default memo(Checkbox);
+export default Checkbox;

--- a/frontend/packages/component-library/src/checkbox/Checkbox.tsx
+++ b/frontend/packages/component-library/src/checkbox/Checkbox.tsx
@@ -103,7 +103,7 @@ const Checkbox: React.FunctionComponent<CheckboxProps> = ({
         onChange={onChange}
         {...HTMLAttributes}
         className={className}
-        aria-label={ariaLabel ?? HTMLAttributes['aria-label']}
+        aria-label={ariaLabel || HTMLAttributes['aria-label']}
         aria-checked={indeterminate ? 'mixed' : undefined}
       />
       <i className="fa-solid" />

--- a/frontend/packages/component-library/src/checkbox/Checkbox.tsx
+++ b/frontend/packages/component-library/src/checkbox/Checkbox.tsx
@@ -1,11 +1,5 @@
 import classnames from 'classnames';
-import {
-  useRef,
-  useEffect,
-  ReactNode,
-  ChangeEvent,
-  InputHTMLAttributes,
-} from 'react';
+import {memo, useRef, useEffect, ReactNode, ChangeEvent, InputHTMLAttributes} from 'react';
 
 import {componentSizeToBodyTextSizeMap} from '@/common/constants';
 import {ComponentSizeXSToL} from '@/common/types';
@@ -14,7 +8,10 @@ import Typography from '@/typography';
 import moduleStyles from './checkbox.module.scss';
 
 export interface CheckboxProps
-  extends Omit<InputHTMLAttributes<HTMLInputElement>, 'size'> {
+  extends Omit<
+    InputHTMLAttributes<HTMLInputElement>,
+    'size' | 'type' | 'onChange' | 'checked' | 'name' | 'value'
+  > {
   /** Checkbox checked state */
   checked: boolean;
   /** Checkbox onChange handler*/
@@ -34,6 +31,14 @@ export interface CheckboxProps
   indeterminate?: boolean;
   /** Size of checkbox */
   size?: ComponentSizeXSToL;
+  /** Text thickness styling */
+  textThickness?: 'thick' | 'thin';
+  /** Optional aria-label for the checkbox input (consistency with Button/Radio) */
+  ariaLabel?: string;
+  /** Custom className for the outer label */
+  className?: string;
+  /** Children (Checkbox custom content) */
+  children?: React.ReactNode;
 }
 
 /**
@@ -58,6 +63,10 @@ const Checkbox: React.FunctionComponent<CheckboxProps> = ({
   disabled = false,
   indeterminate = false,
   size = 'm',
+  textThickness = 'thin',
+  ariaLabel,
+  className,
+  children,
   ...HTMLAttributes
 }) => {
   const checkboxRef = useRef<HTMLInputElement>(null);
@@ -71,7 +80,11 @@ const Checkbox: React.FunctionComponent<CheckboxProps> = ({
 
   return (
     <label
-      className={classnames(moduleStyles.label, moduleStyles[`label-${size}`])}
+      className={classnames(
+        moduleStyles.label,
+        moduleStyles[`label-${size}`],
+        className || (HTMLAttributes as any).className,
+      )}
     >
       <input
         type="checkbox"
@@ -82,15 +95,27 @@ const Checkbox: React.FunctionComponent<CheckboxProps> = ({
         disabled={disabled}
         onChange={onChange}
         {...HTMLAttributes}
+        className={classnames((HTMLAttributes as any).className, className)}
+        aria-label={ariaLabel || (HTMLAttributes as any)['aria-label']}
+        aria-checked={indeterminate ? 'mixed' : undefined}
       />
       <i className="fa-solid" />
       {label && (
-        <Typography semanticTag="span" visualAppearance={bodyTextSize}>
+        <Typography
+          semanticTag="span"
+          className={classnames(
+            moduleStyles.checkboxLabel,
+            moduleStyles[`checkboxLabel-${textThickness}`],
+          )}
+          visualAppearance={bodyTextSize}
+          noMargin
+        >
           {label}
         </Typography>
       )}
+      {children}
     </label>
   );
 };
 
-export default Checkbox;
+export default memo(Checkbox);

--- a/frontend/packages/component-library/src/checkbox/Checkbox.tsx
+++ b/frontend/packages/component-library/src/checkbox/Checkbox.tsx
@@ -91,7 +91,6 @@ const Checkbox: React.FunctionComponent<CheckboxProps> = ({
         moduleStyles.label,
         moduleStyles[`label-${size}`],
         className,
-        HTMLAttributes.className,
       )}
     >
       <input
@@ -103,7 +102,7 @@ const Checkbox: React.FunctionComponent<CheckboxProps> = ({
         disabled={disabled}
         onChange={onChange}
         {...HTMLAttributes}
-        className={classnames(HTMLAttributes.className, className)}
+        className={className}
         aria-label={ariaLabel ?? HTMLAttributes['aria-label']}
         aria-checked={indeterminate ? 'mixed' : undefined}
       />

--- a/frontend/packages/component-library/src/checkbox/Checkbox.tsx
+++ b/frontend/packages/component-library/src/checkbox/Checkbox.tsx
@@ -90,7 +90,8 @@ const Checkbox: React.FunctionComponent<CheckboxProps> = ({
       className={classnames(
         moduleStyles.label,
         moduleStyles[`label-${size}`],
-        className || (HTMLAttributes as any).className,
+        className,
+        HTMLAttributes.className,
       )}
     >
       <input
@@ -102,8 +103,8 @@ const Checkbox: React.FunctionComponent<CheckboxProps> = ({
         disabled={disabled}
         onChange={onChange}
         {...HTMLAttributes}
-        className={classnames((HTMLAttributes as any).className, className)}
-        aria-label={ariaLabel || (HTMLAttributes as any)['aria-label']}
+        className={classnames(HTMLAttributes.className, className)}
+        aria-label={ariaLabel ?? HTMLAttributes['aria-label']}
         aria-checked={indeterminate ? 'mixed' : undefined}
       />
       <i className="fa-solid" />

--- a/frontend/packages/component-library/src/checkbox/checkbox.module.scss
+++ b/frontend/packages/component-library/src/checkbox/checkbox.module.scss
@@ -1,5 +1,6 @@
 @use '@code-dot-org/component-library-styles/mixins.scss' as mixins;
-@use '@code-dot-org/component-library-styles/typography.module.scss' as typography;
+@use '@code-dot-org/component-library-styles/typography.module.scss' as
+  typography;
 
 // Checkbox common styles
 .label {

--- a/frontend/packages/component-library/src/checkbox/checkbox.module.scss
+++ b/frontend/packages/component-library/src/checkbox/checkbox.module.scss
@@ -1,8 +1,18 @@
+@use '@code-dot-org/component-library-styles/mixins.scss' as mixins;
+@use '@code-dot-org/component-library-styles/typography.module.scss' as typography;
+
 // Checkbox common styles
 .label {
   display: flex;
-  gap: 8px;
-  align-items: center;
+  align-items: flex-start;
+  position: relative;
+  margin: 0;
+
+  .checkboxLabel {
+    margin: 0;
+    user-select: none;
+    -webkit-user-select: none;
+  }
 
   span {
     margin-bottom: 0;
@@ -136,66 +146,105 @@
 }
 
 // Sizes
-.label-xs {
+.label-l {
+  gap: 8px;
   input[type='checkbox'] {
     & + i {
-      width: 16px;
-      height: 16px;
+      width: 24px;
+      height: 24px;
+      margin-top: 2px;
 
       &::before {
-        font-size: 8px;
-        width: 12px;
-        height: 12px;
-        line-height: 12px;
+        font-size: 14px;
+        width: 20px;
+        height: 20px;
+        line-height: 20px;
       }
     }
   }
-}
-
-.label-s {
-  input[type='checkbox'] {
-    & + i {
-      width: 18px;
-      height: 18px;
-
-      &::before {
-        font-size: 9.5px;
-        width: 14px;
-        height: 14px;
-        line-height: 14px;
-      }
-    }
+  .checkboxLabel-thick {
+    @include mixins.button-one-text;
+    margin-bottom: 0;
+  }
+  .checkboxLabel-thin {
+    @include typography.body-one;
+    margin-bottom: 0;
   }
 }
 
 .label-m {
+  gap: 8px;
   input[type='checkbox'] {
     & + i {
       width: 20px;
       height: 20px;
-
+      margin-top: 1px;
       &::before {
-        font-size: 11px;
+        font-size: 12px;
         width: 16px;
         height: 16px;
         line-height: 16px;
       }
     }
   }
+  .checkboxLabel-thick {
+    @include mixins.button-two-text;
+    margin-bottom: 0;
+  }
+  .checkboxLabel-thin {
+    @include typography.body-two;
+    margin-bottom: 0;
+  }
 }
 
-.label-l {
+.label-s {
+  gap: 6px;
   input[type='checkbox'] {
     & + i {
-      width: 24px;
-      height: 24px;
+      width: 18px;
+      height: 18px;
+      margin-top: 1px;
 
       &::before {
-        font-size: 13px;
-        width: 20px;
-        height: 20px;
-        line-height: 20px;
+        font-size: 10px;
+        width: 14px;
+        height: 14px;
+        line-height: 14px;
       }
     }
+  }
+  .checkboxLabel-thick {
+    @include mixins.button-three-text;
+    margin-bottom: 0;
+  }
+  .checkboxLabel-thin {
+    @include typography.body-three;
+    margin-bottom: 0;
+  }
+}
+
+.label-xs {
+  gap: 6px;
+  input[type='checkbox'] {
+    & + i {
+      width: 16px;
+      height: 16px;
+      margin-top: 2px;
+
+      &::before {
+        font-size: 10px;
+        width: 12px;
+        height: 12px;
+        line-height: 12px;
+      }
+    }
+  }
+  .checkboxLabel-thick {
+    @include mixins.button-four-text;
+    margin-bottom: 0;
+  }
+  .checkboxLabel-thin {
+    @include typography.body-four;
+    margin-bottom: 0;
   }
 }

--- a/frontend/packages/component-library/src/checkbox/stories/Checkbox.story.tsx
+++ b/frontend/packages/component-library/src/checkbox/stories/Checkbox.story.tsx
@@ -128,6 +128,8 @@ CheckboxesWithCustomContent.args = {
       name: 'test-custom-content-0',
       label: '',
       size: 'm' as ComponentSizeXSToL,
+      checked: false,
+      onChange: () => null,
       children: (
         <>
           <span>With Custom Content</span>
@@ -139,6 +141,8 @@ CheckboxesWithCustomContent.args = {
       name: 'test-custom-content-1',
       label: 'With Custom Content and Label',
       size: 'm' as ComponentSizeXSToL,
+      checked: false,
+      onChange: () => null,
       children: (
         <Tags
           tagsList={[
@@ -151,6 +155,8 @@ CheckboxesWithCustomContent.args = {
       name: 'test-custom-content-2',
       label: 'Without Custom Content',
       size: 'm' as ComponentSizeXSToL,
+      checked: false,
+      onChange: () => null,
     },
   ],
 };

--- a/frontend/packages/component-library/src/checkbox/stories/Checkbox.story.tsx
+++ b/frontend/packages/component-library/src/checkbox/stories/Checkbox.story.tsx
@@ -1,7 +1,6 @@
 import {Meta, StoryFn} from '@storybook/react-webpack5';
 import {useState, Dispatch, SetStateAction} from 'react';
 
-import {ComponentSizeXSToL} from '@/common/types';
 import Tags from '@/tags';
 
 import Checkbox, {CheckboxProps} from '../index';
@@ -127,7 +126,7 @@ CheckboxesWithCustomContent.args = {
     {
       name: 'test-custom-content-0',
       label: '',
-      size: 'm' as ComponentSizeXSToL,
+      size: 'm',
       checked: false,
       onChange: () => null,
       children: (
@@ -140,7 +139,7 @@ CheckboxesWithCustomContent.args = {
     {
       name: 'test-custom-content-1',
       label: 'With Custom Content and Label',
-      size: 'm' as ComponentSizeXSToL,
+      size: 'm',
       checked: false,
       onChange: () => null,
       children: (
@@ -154,7 +153,7 @@ CheckboxesWithCustomContent.args = {
     {
       name: 'test-custom-content-2',
       label: 'Without Custom Content',
-      size: 'm' as ComponentSizeXSToL,
+      size: 'm',
       checked: false,
       onChange: () => null,
     },
@@ -195,28 +194,28 @@ GroupOfSizesOfCheckboxes.args = {
     {
       name: 'test-xs',
       label: 'Label XS',
-      size: 'xs' as ComponentSizeXSToL,
+      size: 'xs',
       checked: false,
       onChange: () => null,
     },
     {
       name: 'test-s',
       label: 'Label S',
-      size: 's' as ComponentSizeXSToL,
+      size: 's',
       checked: false,
       onChange: () => null,
     },
     {
       name: 'test-m',
       label: 'Label M',
-      size: 'm' as ComponentSizeXSToL,
+      size: 'm',
       checked: false,
       onChange: () => null,
     },
     {
       name: 'test-l',
       label: 'Label L',
-      size: 'l' as ComponentSizeXSToL,
+      size: 'l',
       checked: false,
       onChange: () => null,
     },
@@ -230,7 +229,7 @@ LabelWeights.args = {
       name: 'lw-thin',
       label: 'Thin label',
       textThickness: 'thin',
-      size: 'm' as ComponentSizeXSToL,
+      size: 'm',
       checked: false,
       onChange: () => null,
     },
@@ -238,7 +237,7 @@ LabelWeights.args = {
       name: 'lw-thick',
       label: 'Thick label',
       textThickness: 'thick',
-      size: 'm' as ComponentSizeXSToL,
+      size: 'm',
       checked: false,
       onChange: () => null,
     },
@@ -292,7 +291,7 @@ MultiLineLabels.args = {
   components: [
     {
       name: 'wrap-xs',
-      size: 'xs' as ComponentSizeXSToL,
+      size: 'xs',
       label:
         'This is a quite long label intended to wrap onto multiple lines to demonstrate alignment.',
       checked: false,
@@ -300,7 +299,7 @@ MultiLineLabels.args = {
     },
     {
       name: 'wrap-s',
-      size: 's' as ComponentSizeXSToL,
+      size: 's',
       label:
         'This is a quite long label intended to wrap onto multiple lines to demonstrate alignment.',
       checked: false,
@@ -308,7 +307,7 @@ MultiLineLabels.args = {
     },
     {
       name: 'wrap-m',
-      size: 'm' as ComponentSizeXSToL,
+      size: 'm',
       label:
         'This is a quite long label intended to wrap onto multiple lines to demonstrate alignment.',
       checked: false,
@@ -316,7 +315,7 @@ MultiLineLabels.args = {
     },
     {
       name: 'wrap-l',
-      size: 'l' as ComponentSizeXSToL,
+      size: 'l',
       label:
         'This is a quite long label intended to wrap onto multiple lines to demonstrate alignment.',
       checked: false,

--- a/frontend/packages/component-library/src/checkbox/stories/Checkbox.story.tsx
+++ b/frontend/packages/component-library/src/checkbox/stories/Checkbox.story.tsx
@@ -2,6 +2,7 @@ import {Meta, StoryFn} from '@storybook/react-webpack5';
 import {useState, Dispatch, SetStateAction} from 'react';
 
 import {ComponentSizeXSToL} from '@/common/types';
+import Tags from '@/tags';
 
 import Checkbox, {CheckboxProps} from '../index';
 
@@ -112,6 +113,46 @@ GroupOfDefaultCheckboxes.args = {
   ],
 };
 
+const CustomContentTemplate: StoryFn<{components: CheckboxProps[]}> = args => (
+  <div style={{padding: 20}}>
+    {args.components.map(c => (
+      <Checkbox key={c.name} {...c} />
+    ))}
+  </div>
+);
+
+export const CheckboxesWithCustomContent = CustomContentTemplate.bind({});
+CheckboxesWithCustomContent.args = {
+  components: [
+    {
+      name: 'test-custom-content-0',
+      label: '',
+      size: 'm' as ComponentSizeXSToL,
+      children: (
+        <>
+          <span>With Custom Content</span>
+          <button type="button">Custom content</button>
+        </>
+      ),
+    },
+    {
+      name: 'test-custom-content-1',
+      label: 'With Custom Content and Label',
+      size: 'm' as ComponentSizeXSToL,
+      children: (
+        <Tags
+          tagsList={[{label: 'Tag1', tooltipContent: 'Tag tooltip', tooltipId: ''}]}
+        />
+      ),
+    },
+    {
+      name: 'test-custom-content-2',
+      label: 'Without Custom Content',
+      size: 'm' as ComponentSizeXSToL,
+    },
+  ],
+};
+
 export const GroupOfDisabledCheckboxes = MultipleTemplate.bind({});
 GroupOfDisabledCheckboxes.args = {
   components: [
@@ -174,109 +215,104 @@ GroupOfSizesOfCheckboxes.args = {
   ],
 };
 
-//
-// ———————————————————————————————————————————————————
-// Supernova documentation (Light theme only)
-// ———————————————————————————————————————————————————
-// These examples are purely for Supernova docs and will not include a Dark theme.
+export const LabelWeights = MultipleTemplate.bind({});
+LabelWeights.args = {
+  components: [
+    {
+      name: 'lw-thin',
+      label: 'Thin label',
+      textThickness: 'thin',
+      size: 'm' as ComponentSizeXSToL,
+      checked: false,
+      onChange: () => null,
+    },
+    {
+      name: 'lw-thick',
+      label: 'Thick label',
+      textThickness: 'thick',
+      size: 'm' as ComponentSizeXSToL,
+      checked: false,
+      onChange: () => null,
+    },
+  ],
+};
 
-const SupernovaDefaultTemplate: StoryFn<CheckboxProps> = () => (
-  <>
-    <div style={{display: 'flex', justifyContent: 'space-around', padding: 20}}>
-      {[
-        {
-          name: 'sn-test',
-          label: 'Checkbox',
-          checked: false,
-          onChange: () => null,
-        },
-        {
-          name: 'sn-test-checked',
-          label: 'Checkbox',
-          checked: true,
-          onChange: () => null,
-        },
-        {
-          name: 'sn-test-indet',
-          label: 'Checkbox Indeterminate',
-          indeterminate: true,
-          checked: false,
-          onChange: () => null,
-        },
-      ].map(props => (
-        <Checkbox key={props.name} {...props} />
+const MultiLineTemplate: StoryFn<{components: CheckboxProps[]}> = args => {
+  const initial = Object.fromEntries(
+    args.components.map(c => [c.name, !!c.checked]),
+  );
+  const [lightState, setLightState] =
+    useState<Record<string, boolean>>(initial);
+  const [darkState, setDarkState] = useState<Record<string, boolean>>(initial);
+
+  const renderGroup = (
+    state: Record<string, boolean>,
+    setState: Dispatch<SetStateAction<Record<string, boolean>>>,
+  ) => (
+    <div style={{maxWidth: 220}}>
+      {args.components.map(c => (
+        <Checkbox
+          key={c.name}
+          {...c}
+          checked={state[c.name]}
+          onChange={e => {
+            const next = {...state, [c.name]: e.target.checked};
+            setState(next);
+            c.onChange?.(e);
+          }}
+        />
       ))}
     </div>
-    <div style={{display: 'flex', justifyContent: 'space-around', padding: 20}}>
-      {[
-        {
-          name: 'sn-test',
-          label: 'Checkbox',
-          disabled: true,
-          checked: false,
-          onChange: () => null,
-        },
-        {
-          name: 'sn-test-checked',
-          label: 'Checkbox',
-          disabled: true,
-          checked: true,
-          onChange: () => null,
-        },
-        {
-          name: 'sn-test-indet',
-          label: 'Checkbox Indeterminate',
-          disabled: true,
-          indeterminate: true,
-          checked: false,
-          onChange: () => null,
-        },
-      ].map(props => (
-        <Checkbox key={props.name + '-disabled'} {...props} />
-      ))}
-    </div>
-  </>
-);
+  );
 
-export const SupernovaGroupOfDefaultCheckboxes = SupernovaDefaultTemplate.bind(
-  {},
-);
+  return (
+    <>
+      <div data-theme="Light" style={{padding: 20}}>
+        <h3>Light Theme</h3>
+        {renderGroup(lightState, setLightState)}
+      </div>
+      <div data-theme="Dark" style={{background: '#292F36', padding: 20}}>
+        <h3 style={{color: '#FFF'}}>Dark Theme</h3>
+        {renderGroup(darkState, setDarkState)}
+      </div>
+    </>
+  );
+};
 
-const SupernovaSizesTemplate: StoryFn<CheckboxProps> = () => (
-  <div style={{display: 'flex', justifyContent: 'space-around', padding: 20}}>
-    {[
-      {
-        name: 'sn-xs',
-        label: 'Checkbox XS',
-        checked: false,
-        size: 'xs' as ComponentSizeXSToL,
-        onChange: () => null,
-      },
-      {
-        name: 'sn-s',
-        label: 'Checkbox S',
-        checked: false,
-        size: 's' as ComponentSizeXSToL,
-        onChange: () => null,
-      },
-      {
-        name: 'sn-m',
-        label: 'Checkbox M',
-        checked: false,
-        size: 'm' as ComponentSizeXSToL,
-        onChange: () => null,
-      },
-      {
-        name: 'sn-l',
-        label: 'Checkbox L',
-        checked: false,
-        size: 'l' as ComponentSizeXSToL,
-        onChange: () => null,
-      },
-    ].map(props => (
-      <Checkbox key={props.name} {...props} />
-    ))}
-  </div>
-);
-
-export const SupernovaGroupOfCheckboxesSizes = SupernovaSizesTemplate.bind({});
+export const MultiLineLabels = MultiLineTemplate.bind({});
+MultiLineLabels.args = {
+  components: [
+    {
+      name: 'wrap-xs',
+      size: 'xs' as ComponentSizeXSToL,
+      label:
+        'This is a quite long label intended to wrap onto multiple lines to demonstrate alignment.',
+      checked: false,
+      onChange: () => null,
+    },
+    {
+      name: 'wrap-s',
+      size: 's' as ComponentSizeXSToL,
+      label:
+        'This is a quite long label intended to wrap onto multiple lines to demonstrate alignment.',
+      checked: false,
+      onChange: () => null,
+    },
+    {
+      name: 'wrap-m',
+      size: 'm' as ComponentSizeXSToL,
+      label:
+        'This is a quite long label intended to wrap onto multiple lines to demonstrate alignment.',
+      checked: false,
+      onChange: () => null,
+    },
+    {
+      name: 'wrap-l',
+      size: 'l' as ComponentSizeXSToL,
+      label:
+        'This is a quite long label intended to wrap onto multiple lines to demonstrate alignment.',
+      checked: false,
+      onChange: () => null,
+    },
+  ],
+};

--- a/frontend/packages/component-library/src/checkbox/stories/Checkbox.story.tsx
+++ b/frontend/packages/component-library/src/checkbox/stories/Checkbox.story.tsx
@@ -141,7 +141,9 @@ CheckboxesWithCustomContent.args = {
       size: 'm' as ComponentSizeXSToL,
       children: (
         <Tags
-          tagsList={[{label: 'Tag1', tooltipContent: 'Tag tooltip', tooltipId: ''}]}
+          tagsList={[
+            {label: 'Tag1', tooltipContent: 'Tag tooltip', tooltipId: ''},
+          ]}
         />
       ),
     },


### PR DESCRIPTION
### Overview
Aligns Checkbox styles with Figma as well as props + stories with recently-updated RadioButton for UI and API parity.

### What's Changed:

- **Styles:**
  - Added size-specific gaps matching radio: 8px (L/M), 6px (S/XS)
  - Reordered size blocks L → M → S → XS to match our library pattern
  - Slightly bigger "check" icon to align with Figma and improve visibility
  - Top-aligned checkbox input + a small margin tweak to keep it vert-centered when the label is multi-line.

- **Component:**
  - New prop for `textThickness ('thin' default | 'thick')`
  - Now accepts className and children! Mirrors className onto label and input per Claude suggestion: _className applied to both wrapper and input to preserve any prior selectors_.
  - memoized component to improve performance (Claude suggested this)

- **Accessibility:**
  - Set's `aria-checked="mixed"` when `indeterminate=true`
  - Added prop for `ariaLabel`

- **Stories:**
  - Removed legacy SuperNova stories
  - Added stories for multi-line, custom content, and label thickness. 
---

**Multi-line Alignment**
| Before | After |
|--------|--------|
| <img width="250" height="414" alt="Screenshot 2025-11-26 at 12 09 48 PM" src="https://github.com/user-attachments/assets/b3ce0755-f773-48d9-884b-b01d544ddf94" /> | <img width="250" height="414" alt="Screenshot 2025-11-26 at 12 08 31 PM" src="https://github.com/user-attachments/assets/221b59ad-cdba-42da-adc4-c8df7c9a40e3" /> |

**Thick/Thin Labels**

<img width="153" height="59" alt="Screenshot 2025-11-26 at 12 13 22 PM" src="https://github.com/user-attachments/assets/73e3b245-118b-4126-ab73-ef46ecba634a" />

&nbsp;
**Stories**
| Before | After |
|--------|--------|
| <img width="279" height="272" alt="Screenshot 2025-11-26 at 12 14 11 PM" src="https://github.com/user-attachments/assets/8395905f-3094-499a-ad30-bb7b98bea840" /> | <img width="277" height="262" alt="Screenshot 2025-11-26 at 12 14 39 PM" src="https://github.com/user-attachments/assets/f85ad835-44c7-4b8b-85cb-226630ba2c6d" /> |

## Links
<!--  Links to relevant external resources.
      - spec docs, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- Jira: 

## Testing story
<!--  Does your change include appropriate tests?
      - If so, please describe how the tests included in this PR are sufficient.
      - If not, please explain why this change does not need to be tested. -->



## Deployment strategy
<!--  Any special steps required to deploy this, besides merging?
      - Are there database migrations or manual steps?
      - Does this require coordination with other teams or systems? -->



## Follow-up work
<!--  List any clean-up or technical debt that will be addressed in future work.
      - Include Jira links where applicable.
      - Are there any known limitations or improvements planned? -->



## Privacy
<!--  How does this change impact Student & Teacher privacy?
      - Does this collect, use, share, or modify PII, either new or existing? -->



## Security
<!--  How does this change impact our security surface-area?
      - Do API's touched have the right auth?
      - Do infra changes impact our attack surface or encryption?
-->



## Caching
<!--  How does this change impact caching behavior?
      - Are cache keys or invalidation strategies affected?
      - Will this require cache warming or invalidation after deployment? -->



## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
