### PR TITLE
fix(SegmentedButtons): use value instead of label for key

### DIFF
--- a/frontend/packages/component-library/src/segmentedButtons/SegmentedButtons.tsx
+++ b/frontend/packages/component-library/src/segmentedButtons/SegmentedButtons.tsx
@@ -73,7 +73,7 @@ const SegmentedButtons: React.FunctionComponent<SegmentedButtonsProps> = ({
           id,
         }) => (
           <SegmentedButton
-            key={label}
+            key={value}
             selected={selectedButtonValue === value}
             label={label}
             ariaLabel={ariaLabel}

--- a/frontend/packages/component-library/src/segmentedButtons/stories/SegmentedButtons.story.tsx
+++ b/frontend/packages/component-library/src/segmentedButtons/stories/SegmentedButtons.story.tsx
@@ -61,8 +61,11 @@ const MultipleTemplate: StoryFn<{
   ) => (
     <div data-theme={theme} style={style}>
       <h3 style={titleStyle}>{theme} Theme</h3>
-      {args.components?.map(componentArg => (
-        <div key={`${theme}-${componentArg.size}`} style={{marginTop: 15}}>
+      {args.components?.map((componentArg, index) => (
+        <div
+          key={`${theme}-${componentArg.size}-${index}`}
+          style={{marginTop: 15}}
+        >
           <SegmentedButtons
             {...componentArg}
             selectedButtonValue={


### PR DESCRIPTION
Updates the SegmentedButtons component to use the `value` prop ([ref](https://github.com/code-dot-org/code-dot-org/blob/beacd209c02774c97988552f081d016fa2096b5e/frontend/packages/component-library/src/segmentedButtons/_SegmentedButton.tsx#L19-L20)) instead of the `label` prop to avoid unique key errors when the type is `iconOnly`. I also updated the Storybook stories keys to fix unique key errors there too.

## Links
Jira ticket: [DESIGN2-327](https://codedotorg.atlassian.net/browse/DESIGN2-327) 
Slack convo: [here](https://codedotorg.slack.com/archives/C0532LCK125/p1764112356441069)

----

## Before

### Storybook
<img width="1797" height="1074" alt="Before" src="https://github.com/user-attachments/assets/7aa7d3f5-8da1-41dd-9ccb-a254db97fcb7" />

## Web Lab 2
<img width="1797" height="1074" alt="Before_WL2" src="https://github.com/user-attachments/assets/4d28148d-2fc7-4a9a-8aa2-6fb2b8731697" />

## After

### Storybook
<img width="1797" height="1074" alt="After" src="https://github.com/user-attachments/assets/a40eb9db-077d-455a-a4d7-b5bf38abf27d" />

### Web Lab 2

<img width="1797" height="1074" alt="Screenshot 2025-11-26 at 10 02 11 AM" src="https://github.com/user-attachments/assets/9ab3e009-8aa4-42b0-bbef-a83a52ad71d7" />

