### PR TITLE
[P5Lab] Preload animations before initializing interpreter

### DIFF
--- a/apps/src/p5lab/P5Lab.js
+++ b/apps/src/p5lab/P5Lab.js
@@ -1037,11 +1037,7 @@ export default class P5Lab {
     this.p5Wrapper.startExecution();
     this.p5Wrapper.setLoop(true);
 
-    if (
-      !this.JSInterpreter ||
-      !this.JSInterpreter.initialized() ||
-      this.executionError
-    ) {
+    if (this.executionError) {
       return;
     }
 
@@ -1219,7 +1215,7 @@ export default class P5Lab {
    */
   onP5Preload() {
     this.preloadLabAssets()
-      .then(this.runPreloadEventHandler_())
+      .then(() => this.runPreloadEventHandler_())
       .then(() => this.p5Wrapper.notifyPreloadPhaseComplete());
     return false;
   }


### PR DESCRIPTION
A user [reported](https://codeorg.zendesk.com/agent/tickets/564928) an issue where Game Lab was indicating it was `Unable to find an animation`, yet the animation definitely existed.
<img width="2360" height="1640" alt="image" src="https://github.com/user-attachments/assets/bb51a2ad-1c54-42e4-b49b-c025a2f66491" />
<img width="2360" height="1640" alt="image" src="https://github.com/user-attachments/assets/84b8214b-b98d-47b3-9e71-e7a4d2db0600" />

I easily repro'd the behavior by visiting the same [project](https://studio.code.org/projects/gamelab/kK04u8dmvPqLqxCufiDM08CGKz5gX_87jXr63xhFFIY/edit) on production.
<img width="1512" height="754" alt="image" src="https://github.com/user-attachments/assets/c741882e-f6e5-4159-86a7-fbdb4ea39335" />

The problem seems to be that the interpreter is running before Game Lab has finished preloading animations. This is happening because `runPreloadEventHandler_()` (which calls `this.JSInterpreter.executeInterpreter()`) is being invoked immediately instead of after `preloadLabAssets()` resolves. 
To fix this, we can pass `runPreloadEventHandler_()` as an arrow function to `.then()` so it only runs after animations are actually ready. This correctly chains the promise so student code runs only after animations are ready:
<img width="1512" height="755" alt="image" src="https://github.com/user-attachments/assets/604c9d49-a8c2-4973-af86-8989b125dd64" />

(Note: I confirmed this fixes the student's issue by manually copying all sources and animations into a new project on `localhost`, sort of cross-environment remix.)

This one-line change fixes animation loading, but unfortunately breaks other functionality such as project thumbnail generation.

In `P5Lab.execute()` there is an early return to prevent execution from starting before the interpreter is ready. The current promise chain causes the interpreter to be initialized very early, before `execute()`, so this hasn't been fine. However, after fixing the promise chain, `execute()` is now being called before initializing the interpreter. This means we'd always return early and never go on to do things like start the tick loop, stopping thumbnail capture from working. 

Relaxing the early return is necessary because interpreter initialization now happens later. This is safe because `onTick()` already checks for an initialized interpreter. 

With both changes, we avoid regressions. For example, we still generate and save a thumbnail correctly:
<img width="980" height="78" alt="image" src="https://github.com/user-attachments/assets/9e1cc710-76a2-4d68-b3f2-4525a3e1453f" />

In my first attempt at this work, I went down a rabbit hole trying to handle timeouts in tests caused by this early return. That branch and commit history are here:
- https://github.com/code-dot-org/code-dot-org/pull/69693


## Links
<!--  Links to relevant external resources.
      - spec docs, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- Jira: 

## Testing story
<!--  Does your change include appropriate tests?
      - If so, please describe how the tests included in this PR are sufficient.
      - If not, please explain why this change does not need to be tested. -->


## Deployment strategy
<!--  Any special steps required to deploy this, besides merging?
      - Are there database migrations or manual steps?
      - Does this require coordination with other teams or systems? -->



## Follow-up work
<!--  List any clean-up or technical debt that will be addressed in future work.
      - Include Jira links where applicable.
      - Are there any known limitations or improvements planned? -->



## Privacy
<!--  How does this change impact Student & Teacher privacy?
      - Does this collect, use, share, or modify PII, either new or existing? -->



## Security
<!--  How does this change impact our security surface-area?
      - Do API's touched have the right auth?
      - Do infra changes impact our attack surface or encryption?
-->



## Caching
<!--  How does this change impact caching behavior?
      - Are cache keys or invalidation strategies affected?
      - Will this require cache warming or invalidation after deployment? -->



## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
