### PR TITLE
Update url override for New Music Project button

### DIFF
--- a/apps/src/templates/projects/NewProjectButtons.jsx
+++ b/apps/src/templates/projects/NewProjectButtons.jsx
@@ -121,7 +121,7 @@ const PROJECT_INFO = {
   music: {
     label: i18n.projectTypeMusic(),
     thumbnail: studio('/shared/images/courses/logo_music.png'),
-    urlOverride: '/s/music-intro-2024/reset',
+    urlOverride: 'https://code.org/music',
   },
   pythonlab: {
     label: i18n.projectTypePythonlab(),

--- a/apps/src/templates/projects/NewProjectButtons.jsx
+++ b/apps/src/templates/projects/NewProjectButtons.jsx
@@ -5,7 +5,7 @@ import React from 'react';
 import {connect} from 'react-redux';
 
 import fontConstants from '@cdo/apps/fontConstants';
-import {studio} from '@cdo/apps/lib/util/urlHelpers';
+import {studio, pegasus} from '@cdo/apps/lib/util/urlHelpers';
 import i18n from '@cdo/locale';
 
 import styleConstants from '../../styleConstants';
@@ -121,7 +121,7 @@ const PROJECT_INFO = {
   music: {
     label: i18n.projectTypeMusic(),
     thumbnail: studio('/shared/images/courses/logo_music.png'),
-    urlOverride: 'https://code.org/music',
+    urlOverride: pegasus('/music'),
   },
   pythonlab: {
     label: i18n.projectTypePythonlab(),


### PR DESCRIPTION
We received a [ticket](https://codeorg.zendesk.com/agent/tickets/565728) where a user expressed confusion about where the New Project menu button for Music Lab takes you:
> FYI, when we use the “new project” button and navigate to Music Lab, the link leads us to the curriculum offerings rather than a new project.

<img width="280" height="504" alt="image" src="https://github.com/user-attachments/assets/10f1b981-bfff-42d4-a82d-012ac2ace701" />

This is in fact intentional. However, our response to the user revealed an inconsistency:
> Is this intentional? https://studio.code.org/courses/music-intro-2024/units/1/lessons/1/levels/1 is what this links to. 

Andrew evidently found the new project button at https://studio.code.org/projects/ shown here:
<img width="1018" height="435" alt="image" src="https://github.com/user-attachments/assets/415b4c50-fcfd-4cbb-8ef0-94c071ac15ab" />

This links to our oldest Music Lab tutorial via https://studio.code.org/s/music-intro-2024/reset

I believe this out of date. We should make these two buttons consistent. @breville has recently advised that pointing to the lab landing page is intentional, so that's how I'm standardizing here. Note that this PR only touches the button on the projects page, and not the site header menu buttons.

To make things even more confusing, @tshaffercodeorg pointed out that the site header on the signed-out Code.org website in fact takes you to: https://studio.code.org/projects/music/new
<img width="425" height="496" alt="image" src="https://github.com/user-attachments/assets/eea4f1e1-8e72-455d-a884-9d7c6dfc419f" />
Thanks to @kelbyhawn for addressing that issue here: 
- https://github.com/code-dot-org/marketing-sites/pull/46




## Links
<!--  Links to relevant external resources.
      - spec docs, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- Jira: 

## Testing story
<!--  Does your change include appropriate tests?
      - If so, please describe how the tests included in this PR are sufficient.
      - If not, please explain why this change does not need to be tested. -->



## Deployment strategy
<!--  Any special steps required to deploy this, besides merging?
      - Are there database migrations or manual steps?
      - Does this require coordination with other teams or systems? -->



## Follow-up work
<!--  List any clean-up or technical debt that will be addressed in future work.
      - Include Jira links where applicable.
      - Are there any known limitations or improvements planned? -->



## Privacy
<!--  How does this change impact Student & Teacher privacy?
      - Does this collect, use, share, or modify PII, either new or existing? -->



## Security
<!--  How does this change impact our security surface-area?
      - Do API's touched have the right auth?
      - Do infra changes impact our attack surface or encryption?
-->



## Caching
<!--  How does this change impact caching behavior?
      - Are cache keys or invalidation strategies affected?
      - Will this require cache warming or invalidation after deployment? -->



## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
