### PR TITLE
set memcached and redis maintenance window

### DIFF
--- a/aws/cloudformation/components/memcached.yml.erb
+++ b/aws/cloudformation/components/memcached.yml.erb
@@ -24,4 +24,5 @@
       NumCacheNodes: 2
       AZMode: cross-az
       PreferredAvailabilityZones: <%= AVAILABILITY_ZONES.first(2).to_json %>
+      PreferredMaintenanceWindow: sat:03:00-sat:04:00
       VpcSecurityGroupIds: [!ImportValue VPC-MemcachedSecurityGroup]

--- a/aws/cloudformation/components/redis.yml.erb
+++ b/aws/cloudformation/components/redis.yml.erb
@@ -28,6 +28,7 @@
 
       SecurityGroupIds: [!ImportValue VPC-RedisSecurityGroup]
       CacheSubnetGroupName: !Ref RedisSubnetGroup
+      PreferredMaintenanceWindow: sat:05:00-sat:06:00
   # CloudWatch Alarms for Redis
   #
   # Based on:


### PR DESCRIPTION
These were previously manually provisioned.

Memcached SharedCache was set to: Friday 03:00 - Friday 04:00 UTC
Redis was Thursday 05:00 - Thursday 06:00 UTC

sliding both to Saturday


## Links
<!--  Links to relevant external resources.
      - spec docs, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- Jira: 

## Testing story
<!--  Does your change include appropriate tests?
      - If so, please describe how the tests included in this PR are sufficient.
      - If not, please explain why this change does not need to be tested. -->



## Deployment strategy
<!--  Any special steps required to deploy this, besides merging?
      - Are there database migrations or manual steps?
      - Does this require coordination with other teams or systems? -->



## Follow-up work
<!--  List any clean-up or technical debt that will be addressed in future work.
      - Include Jira links where applicable.
      - Are there any known limitations or improvements planned? -->



## Privacy
<!--  How does this change impact Student & Teacher privacy?
      - Does this collect, use, share, or modify PII, either new or existing? -->



## Security
<!--  How does this change impact our security surface-area?
      - Do API's touched have the right auth?
      - Do infra changes impact our attack surface or encryption?
-->



## Caching
<!--  How does this change impact caching behavior?
      - Are cache keys or invalidation strategies affected?
      - Will this require cache warming or invalidation after deployment? -->



## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
