### PR TITLE
hoai2025: disable dancer review state when readonly

### DIFF
--- a/apps/src/dance/lab2/views/GenerateDancer.tsx
+++ b/apps/src/dance/lab2/views/GenerateDancer.tsx
@@ -1,5 +1,9 @@
 import {Button} from '@code-dot-org/component-library/button';
 import {useTheme} from '@code-dot-org/component-library/common/contexts';
+import {
+  BodyThreeText,
+  EmText,
+} from '@code-dot-org/component-library/typography';
 import classNames from 'classnames';
 import {sample} from 'lodash';
 import React, {useCallback, useEffect, useRef, useState} from 'react';
@@ -19,8 +23,8 @@ import continueOrFinishLesson from '@cdo/apps/lab2/progress/continueOrFinishLess
 import {isReadOnlyWorkspace} from '@cdo/apps/lab2/redux/lab2ReduxSelectors';
 import {LifecycleEvent} from '@cdo/apps/lab2/utils/LifecycleNotifier';
 import Adlib, {
-  AdlibsType,
   AdlibChoices,
+  AdlibsType,
 } from '@cdo/apps/lab2/views/components/guide/Adlib';
 import Guide from '@cdo/apps/lab2/views/components/guide/Guide';
 import MainInstructionsContent from '@cdo/apps/lab2/views/components/Instructions/MainInstructionsContent';
@@ -442,6 +446,11 @@ const GenerateDancer: React.FunctionComponent<DancerGenerateProps> = ({
                 />
               </>
             )}
+          {isReadOnly && (
+            <BodyThreeText className={moduleStyles.readOnlyText}>
+              <EmText>{`AI generated a dancer based on this prompt:`}</EmText>
+            </BodyThreeText>
+          )}
 
           {/* Ensure that the Adlib is rendered, but hidden, when 'reviewing', so that
               onAdlibTextChange is called to set the prompt text, specifically for

--- a/apps/src/dance/lab2/views/GenerateDancer.tsx
+++ b/apps/src/dance/lab2/views/GenerateDancer.tsx
@@ -99,6 +99,8 @@ const GenerateDancer: React.FunctionComponent<DancerGenerateProps> = ({
 
   const blockList = useRef<AdlibsBlockList | undefined>(undefined);
 
+  const isReadOnly = useAppSelector(isReadOnlyWorkspace);
+
   const getInitialChoices = useCallback(
     (adlibsValue: AdlibsType) => {
       const initial: AdlibChoices = {};
@@ -188,13 +190,13 @@ const GenerateDancer: React.FunctionComponent<DancerGenerateProps> = ({
     if (adlibs && currentSources) {
       const {initial, existing} = getInitialChoices(adlibs);
       setAdlibChoices(initial);
-      if (existing) {
+      if (!isReadOnly && existing) {
         setAiGenerateState('reviewing');
       } else {
         setAiGenerateState('none');
       }
     }
-  }, [adlibs, currentSources, getInitialChoices]);
+  }, [adlibs, currentSources, getInitialChoices, isReadOnly]);
 
   useLifecycleNotifier(LifecycleEvent.LevelLoadCompleted, () => {
     setAiGenerateState('loading');
@@ -378,8 +380,6 @@ const GenerateDancer: React.FunctionComponent<DancerGenerateProps> = ({
       )
     );
   }, [dispatch, levelProperties.appName, levelProperties.id]);
-
-  const isReadOnly = useAppSelector(isReadOnlyWorkspace);
 
   const showTts =
     levelProperties.offerBrowserTts || queryParams('show-tts') === 'true';

--- a/apps/src/dance/lab2/views/GenerateDancer.tsx
+++ b/apps/src/dance/lab2/views/GenerateDancer.tsx
@@ -1,9 +1,5 @@
 import {Button} from '@code-dot-org/component-library/button';
 import {useTheme} from '@code-dot-org/component-library/common/contexts';
-import {
-  BodyThreeText,
-  EmText,
-} from '@code-dot-org/component-library/typography';
 import classNames from 'classnames';
 import {sample} from 'lodash';
 import React, {useCallback, useEffect, useRef, useState} from 'react';
@@ -447,9 +443,10 @@ const GenerateDancer: React.FunctionComponent<DancerGenerateProps> = ({
               </>
             )}
           {isReadOnly && (
-            <BodyThreeText className={moduleStyles.readOnlyText}>
-              <EmText>{`AI generated a dancer based on this prompt:`}</EmText>
-            </BodyThreeText>
+            <MainInstructionsContent
+              instructionsText="AI generated a dancer based on this prompt:"
+              markdownClassName={moduleStyles.markdown}
+            />
           )}
 
           {/* Ensure that the Adlib is rendered, but hidden, when 'reviewing', so that


### PR DESCRIPTION
## Warning!!

We have entered Pixel Lock for Hour of AI! All merges to the `staging` branch from Dec 2 through Dec 12 must go through live change review and be deemed critical for supporting the Hour of AI. External contributions will not be accepted at this time.

For non-critical changes, please change your base to `staging-next` and delete this warning. We will merge `staging-next` into `staging` on Dec 15, 2025.

<!-- end warning -->

Fixes a small side effect of https://github.com/code-dot-org/code-dot-org/pull/69777 where the "Back to Prompt" screen would show up even on readonly Music Dance AI projects. This meant that non-project owners could click "Regenerate" on a readonly project; thankfully this didn't actually overwrite the project owner's dancer but still leads to confusing behavior.

## Testing story
- Tested locally