### PR TITLE
Remove "allow multiple attempts" as an option from lab2 predict levels

### DIFF
--- a/apps/src/lab2/levelEditors/predictSettings/EditPredictSettings.tsx
+++ b/apps/src/lab2/levelEditors/predictSettings/EditPredictSettings.tsx
@@ -23,7 +23,6 @@ const EditPredictSettings: React.FunctionComponent<
     isPredictLevel: false,
     solution: '',
     questionType: PredictQuestionType.FreeResponse,
-    allowMultipleAttempts: false,
     placeholderText: '',
     multipleChoiceOptions: [''],
     freeResponseHeight: PREDICT_FREE_RESPONSE_DEFAULT_HEIGHT,
@@ -109,17 +108,6 @@ const EditPredictSettings: React.FunctionComponent<
           ) : (
             renderMultipleChoiceOptions()
           )}
-          <Checkbox
-            label="Allow multiple tries"
-            checked={predictSettings.allowMultipleAttempts || false}
-            onChange={e =>
-              setPredictSettings({
-                ...predictSettings,
-                allowMultipleAttempts: e.target.checked,
-              })
-            }
-            name="allow_multiple_tries"
-          />
           <Checkbox
             label="Allow user to edit code after submitting a response"
             checked={predictSettings.codeEditableAfterSubmit || false}

--- a/apps/src/lab2/levelEditors/types.ts
+++ b/apps/src/lab2/levelEditors/types.ts
@@ -2,7 +2,6 @@ export interface LevelPredictSettings {
   isPredictLevel: boolean;
   solution?: string;
   questionType?: PredictQuestionType;
-  allowMultipleAttempts?: boolean;
   codeEditableAfterSubmit?: boolean;
   // Free Response settings
   freeResponseHeight?: number;

--- a/apps/src/lab2/redux/predictLevelRedux.ts
+++ b/apps/src/lab2/redux/predictLevelRedux.ts
@@ -1,9 +1,4 @@
-import {
-  PayloadAction,
-  createAsyncThunk,
-  createSelector,
-  createSlice,
-} from '@reduxjs/toolkit';
+import {PayloadAction, createAsyncThunk, createSlice} from '@reduxjs/toolkit';
 
 import {
   queryUserProgress,
@@ -73,18 +68,10 @@ export const submitPredictResponse =
 export const isPredictResponseSubmitted = (state: RootState) =>
   state.predictLevel.hasSubmittedResponse;
 
-// The predict answer is locked if the level does not allow multiple predict attempts
-// and the user has already submitted a response.
-export const isPredictAnswerLocked = createSelector(
-  [
-    (state: RootState) =>
-      state.lab.levelProperties?.predictSettings?.allowMultipleAttempts,
-    isPredictResponseSubmitted,
-  ],
-  (allowMultipleAttempts, hasSubmittedResponse) => {
-    return !allowMultipleAttempts && hasSubmittedResponse;
-  }
-);
+// The predict answer is locked if the user has already submitted a response.
+export const isPredictAnswerLocked = (state: RootState) => {
+  return state.predictLevel.hasSubmittedResponse;
+};
 
 // REDUCER
 const predictSlice = createSlice({

--- a/dashboard/app/helpers/allowed_hostname_helper.rb
+++ b/dashboard/app/helpers/allowed_hostname_helper.rb
@@ -134,14 +134,10 @@ module AllowedHostnameHelper
     'open.mapquestapi.com',     # MapQuest mapping services
     'swapi.dev',                # Star Wars data. We may want to remove this in favor of swapi.info
     # REMOVED: 'theunitedstates.io' - HIGH RISK: DNS resolves but no HTTP/HTTPS service available
-    'collectionapi.metmuseum.org',
-    'images.metmuseum.org',
   ].freeze
 
   ALLOWED_IMAGE_HOSTNAME_SUFFIXES = [
-    'picsum.photos', # Placeholder images - Public API
-    'collectionapi.metmuseum.org',
-    'images.metmuseum.org',
+    'picsum.photos' # Placeholder images - Public API
   ].freeze
 
   ALLOWED_FONT_HOSTNAMES = [

--- a/dashboard/app/helpers/allowed_hostname_helper.rb
+++ b/dashboard/app/helpers/allowed_hostname_helper.rb
@@ -134,10 +134,14 @@ module AllowedHostnameHelper
     'open.mapquestapi.com',     # MapQuest mapping services
     'swapi.dev',                # Star Wars data. We may want to remove this in favor of swapi.info
     # REMOVED: 'theunitedstates.io' - HIGH RISK: DNS resolves but no HTTP/HTTPS service available
+    'collectionapi.metmuseum.org',
+    'images.metmuseum.org',
   ].freeze
 
   ALLOWED_IMAGE_HOSTNAME_SUFFIXES = [
-    'picsum.photos' # Placeholder images - Public API
+    'picsum.photos', # Placeholder images - Public API
+    'collectionapi.metmuseum.org',
+    'images.metmuseum.org',
   ].freeze
 
   ALLOWED_FONT_HOSTNAMES = [


### PR DESCRIPTION
This removes the option to allow multiple attempts on predict levels for lab2. This was discussed and approved by product/curriculum on [slack](https://codedotorg.slack.com/archives/CFGAVL2CA/p1759341555507599). There were only a few levels using this setting and none needed to be. 

With this change, if any level had the old setting, it will just be ignored, and in the future the setting won't be added to new levels.

## Links

- Jira: [AFL-261](https://codedotorg.atlassian.net/browse/AFL-261)

## Testing story
Tested locally that predict levels work as expected and levels with the old setting still work as expected.

## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
