### PR TITLE
Sketch Lab / Web Lab 2: fix images in exemplars

### DIFF
--- a/apps/src/codebridge/FileBrowser/hooks/useFileUploader.tsx
+++ b/apps/src/codebridge/FileBrowser/hooks/useFileUploader.tsx
@@ -2,13 +2,15 @@ import {useCodebridgeContext} from '@codebridge/codebridgeContext';
 import {validateFileName as validateCodebridgeFileName} from '@codebridge/utils';
 import {useCallback} from 'react';
 
-import {START_SOURCES} from '@cdo/apps/lab2/constants';
 import {
   useFileUploader as useLab2FileUploader,
   analyticsEvents,
   FileUploaderProps,
 } from '@cdo/apps/lab2/hooks';
-import {getAppOptionsEditBlocks} from '@cdo/apps/lab2/projects/utils';
+import {
+  getIsStartMode,
+  getAppOptionsEditingExemplar,
+} from '@cdo/apps/lab2/projects/utils';
 import {MultiFileSource} from '@cdo/apps/lab2/types';
 import {sendLab2AnalyticsEvent} from '@cdo/apps/lab2/utils/analyticsReporterHelper';
 import {EVENTS} from '@cdo/apps/metrics/AnalyticsConstants';
@@ -29,7 +31,8 @@ export const useFileUploader = (
 ) => {
   const {levelProperties, onImageFlagged} = useCodebridgeContext();
   const {validationFile, name} = levelProperties;
-  const isStartMode = getAppOptionsEditBlocks() === START_SOURCES;
+  const isStartMode = getIsStartMode();
+  const isEditingExemplar = getAppOptionsEditingExemplar();
   const files = useAppSelector(
     state => (state.lab2Project.projectSources?.source as MultiFileSource).files
   );
@@ -44,7 +47,7 @@ export const useFileUploader = (
       const uuid = createUuid();
       const fileType = file.name.split('.').pop();
 
-      if (isStartMode) {
+      if (isStartMode || isEditingExemplar) {
         const bodyData = new FormData();
         bodyData.append('files[]', file);
 
@@ -57,7 +60,7 @@ export const useFileUploader = (
         return url;
       }
     },
-    [channelId, isStartMode, name]
+    [channelId, isStartMode, isEditingExemplar, name]
   );
 
   const sendAnalyticsEvent = useCallback(

--- a/apps/src/sketchlab/SketchlabView.tsx
+++ b/apps/src/sketchlab/SketchlabView.tsx
@@ -17,7 +17,10 @@ import React, {useEffect, useCallback, useRef, useState} from 'react';
 import useLevelEditMode from '@cdo/apps/lab2/hooks/useLevelEditMode';
 import useThemeSetting from '@cdo/apps/lab2/hooks/useThemeSetting';
 import {useVerticalLayout} from '@cdo/apps/lab2/hooks/useVerticalLayout';
-import {getIsStartMode} from '@cdo/apps/lab2/projects/utils';
+import {
+  getIsStartMode,
+  getAppOptionsEditingExemplar,
+} from '@cdo/apps/lab2/projects/utils';
 import {isReadOnlyWorkspace} from '@cdo/apps/lab2/redux/lab2ReduxSelectors';
 import {setHasRun} from '@cdo/apps/lab2/redux/systemRedux';
 import {LabProps, LevelProperties} from '@cdo/apps/lab2/types';
@@ -156,9 +159,9 @@ const SketchlabView: React.FC<LabProps<LevelProperties>> = ({
 
         // TO DO: figure out how to update to support starter assets.
         // Work tracked here: https://codedotorg.atlassian.net/browse/AFL-354
-        // In start mode, we manage saving explicitly via the button in the header.
+        // In starter code and exemplar editing modes, we manage saving explicitly via the button in the header.
         let uploadedFiles;
-        if (!getIsStartMode()) {
+        if (!(getIsStartMode() || getAppOptionsEditingExemplar())) {
           uploadedFiles = await uploadExternalFiles(
             currentSources.source.externalFiles || {},
             serializedData.files,


### PR DESCRIPTION
Two issues related to images I just thought of/encountered [as I look into adding S3 storage support for images in Sketch Lab start code / exemplars](https://codedotorg.atlassian.net/browse/AFL-354):

1. In Web Lab 2, images in exemplars fully didn't work. The change here is a bit of a hack in that images in exemplars are now stored via the same code path / in the same S3 location as level starter assets (with URLs like `level_starter_assets/`). Despite the name not being quite right, it does somewhat make sense for the storage of assets to be the same between starter code and exemplars, as they function very similarly (ie, both store sources to different keys in the level config file).
2. In Sketch Lab, we were attempting (and failing) to upload images added in exemplar mode to S3. This doesn't have a functional impact at the moment, but produces a failed network request.