### PR TITLE
Move lesson materials retrieval to a shared utils file

### DIFF
--- a/dashboard/app/helpers/ai_system_prompts/lesson_summaries_system_prompt_helper.rb
+++ b/dashboard/app/helpers/ai_system_prompts/lesson_summaries_system_prompt_helper.rb
@@ -87,10 +87,10 @@ module AiSystemPrompts::LessonSummariesSystemPromptHelper
     lesson_plan_text = AiSystemPrompts::LessonUtils.generate_lesson_materials_text(lesson_id)
 
     prompt = intro +
-             personalization +
-             "Use the following lesson plan to generate your summary:\n\n" +
-             lesson_plan_text +
-             "\n\nYour summary should be returned in JSON format and should be composed as follows:
+      personalization +
+      "Use the following lesson plan to generate your summary:\n\n" +
+      lesson_plan_text +
+      "\n\nYour summary should be returned in JSON format and should be composed as follows:
 {learning_objective: this should be a brief, one paragraph summary of the lesson, focusing on each of the Learning Objectives and how they will be achieved,
 lesson_beats: an ordered list of the main parts of the lesson, including activities and new vocabulary terms,
 misconceptions: an unordered list including 2 - 3 misconceptions students might have about the material being covered,

--- a/dashboard/app/helpers/ai_system_prompts/lesson_summaries_system_prompt_helper.rb
+++ b/dashboard/app/helpers/ai_system_prompts/lesson_summaries_system_prompt_helper.rb
@@ -75,7 +75,6 @@ Ways AI Can Help:
 
 module AiSystemPrompts::LessonSummariesSystemPromptHelper
   def self.get_system_prompt(lesson_id, user_id = nil)
-    lesson_plan = get_lesson_materials(lesson_id)
     intro = "You are an expert teaching assistant in a computer science classroom who has been asked to summarize the upcoming lesson to help the teacher prepare for class."
     personalization = if user_id
                         get_personalization(user_id)
@@ -85,20 +84,13 @@ module AiSystemPrompts::LessonSummariesSystemPromptHelper
                         ""
                       end
 
-    prompt = intro + personalization + "Use the following lesson plan to generate your summary:
+    lesson_plan_text = AiSystemPrompts::LessonUtils.generate_lesson_materials_text(lesson_id)
 
-Lesson Name: #{lesson_plan[:name]}
-Lesson Overview: #{lesson_plan[:overview]}
-Learning Objectives: #{lesson_plan[:objectives].to_json}
-#{'Lesson Purpose: '+lesson_plan[:purpose] if lesson_plan[:purpose]}
-#{'Assessment Opportunities: '+lesson_plan[:assessment_opportunities] if lesson_plan[:assessment_opportunities]}
-Standards: #{lesson_plan[:standards].to_json}
-#{'Opportunity Standards: '+lesson_plan[:opportunity_standards].to_json.to_s if lesson_plan[:opportunity_standards]}
-Activities: #{lesson_plan[:activities].to_json}
-Preparation: #{lesson_plan[:preparation]}
-Vocabulary: #{lesson_plan[:vocabularies].to_json}
-
-Your summary should be returned in JSON format and should be composed as follows:
+    prompt = intro +
+             personalization +
+             "Use the following lesson plan to generate your summary:\n\n" +
+             lesson_plan_text +
+             "\n\nYour summary should be returned in JSON format and should be composed as follows:
 {learning_objective: this should be a brief, one paragraph summary of the lesson, focusing on each of the Learning Objectives and how they will be achieved,
 lesson_beats: an ordered list of the main parts of the lesson, including activities and new vocabulary terms,
 misconceptions: an unordered list including 2 - 3 misconceptions students might have about the material being covered,
@@ -148,52 +140,5 @@ tips: additional strategies or ideas to help with teaching the lesson}"
       personalization_string << "\nThey were matched with the following teaching persona as part of a personalization quiz:\n#{persona}\n\n"
     end
     personalization_string
-  end
-
-  def self.get_lesson_materials(lesson_id)
-    lesson = Lesson.find(lesson_id)
-    lesson_materials = lesson.summarize_for_lesson_show(current_user, true)
-    @lesson_plan = {}
-    @lesson_plan[:name] = lesson.name
-    @lesson_plan[:overview] = lesson_materials[:overview]
-    @lesson_plan[:objectives] = []
-    lesson.objectives.each do |o|
-      @lesson_plan[:objectives] << o.description
-    end
-    @lesson_plan[:purpose] = lesson.purpose
-    @lesson_plan[:assessment_opportunities] = lesson.assessment_opportunities
-    @lesson_plan[:standards] = []
-    lesson.standards.each do |s|
-      @lesson_plan[:standards] << s.description
-    end
-    @lesson_plan[:opportunity_standards] = []
-    lesson.opportunity_standards.each do |s|
-      @lesson_plan[:opportunity_standards] << s.description
-    end
-    @lesson_plan[:activities] = []
-    lesson_materials[:activities].each do |a|
-      activity = {name: a[:name]}
-      activity[:sections] = []
-      a[:activitySections].each do |section|
-        sect = {description: "", levels: []}
-        sect[:description] = section[:description]
-        section[:scriptLevels].each do |sl|
-          sl[:levels].each do |l|
-            sect[:levels] << l[:longInstructions]
-            l[:containedLevels].each do |cl|
-              sect[:levels] << cl[:longInstructions]
-            end
-          end
-        end
-        activity[:sections] << sect
-      end
-      @lesson_plan[:activities] << activity
-    end
-    @lesson_plan[:preparation] = lesson.preparation
-    @lesson_plan[:vocabularies] = []
-    lesson_materials[:vocabularies].each do |v|
-      @lesson_plan[:vocabularies] << {word: v[:word], definition: v[:definition]}
-    end
-    @lesson_plan
   end
 end

--- a/dashboard/app/helpers/ai_system_prompts/lesson_utils.rb
+++ b/dashboard/app/helpers/ai_system_prompts/lesson_utils.rb
@@ -1,0 +1,64 @@
+module AiSystemPrompts::LessonUtils
+  def self.generate_lesson_materials_text(lesson_id)
+    pp 'lfm2', lesson_id
+    lesson_plan = get_lesson_materials(lesson_id)
+    pp 'lfm3', lesson_plan
+    "Lesson Name: #{lesson_plan[:name]}
+Lesson Overview: #{lesson_plan[:overview]}
+Learning Objectives: #{lesson_plan[:objectives].to_json}
+#{'Lesson Purpose: '+lesson_plan[:purpose] if lesson_plan[:purpose]}
+#{'Assessment Opportunities: '+lesson_plan[:assessment_opportunities] if lesson_plan[:assessment_opportunities]}
+Standards: #{lesson_plan[:standards].to_json}
+#{'Opportunity Standards: '+lesson_plan[:opportunity_standards].to_json.to_s if lesson_plan[:opportunity_standards]}
+Activities: #{lesson_plan[:activities].to_json}
+Preparation: #{lesson_plan[:preparation]}
+Vocabulary: #{lesson_plan[:vocabularies].to_json}"
+  end
+
+  def self.get_lesson_materials(lesson_id)
+    lesson = Lesson.find(lesson_id)
+    lesson_materials = lesson.summarize_for_lesson_show(current_user, true)
+    @lesson_plan = {}
+    @lesson_plan[:name] = lesson.name
+    @lesson_plan[:overview] = lesson_materials[:overview]
+    @lesson_plan[:objectives] = []
+    lesson.objectives.each do |o|
+      @lesson_plan[:objectives] << o.description
+    end
+    @lesson_plan[:purpose] = lesson.purpose
+    @lesson_plan[:assessment_opportunities] = lesson.assessment_opportunities
+    @lesson_plan[:standards] = []
+    lesson.standards.each do |s|
+      @lesson_plan[:standards] << s.description
+    end
+    @lesson_plan[:opportunity_standards] = []
+    lesson.opportunity_standards.each do |s|
+      @lesson_plan[:opportunity_standards] << s.description
+    end
+    @lesson_plan[:activities] = []
+    lesson_materials[:activities].each do |a|
+      activity = {name: a[:name]}
+      activity[:sections] = []
+      a[:activitySections].each do |section|
+        sect = {description: "", levels: []}
+        sect[:description] = section[:description]
+        section[:scriptLevels].each do |sl|
+          sl[:levels].each do |l|
+            sect[:levels] << l[:longInstructions]
+            l[:containedLevels].each do |cl|
+              sect[:levels] << cl[:longInstructions]
+            end
+          end
+        end
+        activity[:sections] << sect
+      end
+      @lesson_plan[:activities] << activity
+    end
+    @lesson_plan[:preparation] = lesson.preparation
+    @lesson_plan[:vocabularies] = []
+    lesson_materials[:vocabularies].each do |v|
+      @lesson_plan[:vocabularies] << {word: v[:word], definition: v[:definition]}
+    end
+    @lesson_plan
+  end
+end

--- a/dashboard/app/helpers/ai_system_prompts/lesson_utils.rb
+++ b/dashboard/app/helpers/ai_system_prompts/lesson_utils.rb
@@ -1,8 +1,6 @@
 module AiSystemPrompts::LessonUtils
   def self.generate_lesson_materials_text(lesson_id)
-    pp 'lfm2', lesson_id
     lesson_plan = get_lesson_materials(lesson_id)
-    pp 'lfm3', lesson_plan
     "Lesson Name: #{lesson_plan[:name]}
 Lesson Overview: #{lesson_plan[:overview]}
 Learning Objectives: #{lesson_plan[:objectives].to_json}


### PR DESCRIPTION
## Warning!!

We have entered Pixel Lock for Hour of AI! All merges to the `staging` branch from Dec 2 through Dec 12 must go through live change review and be deemed critical for supporting the Hour of AI. External contributions will not be accepted at this time.

For non-critical changes, please change your base to `staging-next` and delete this warning. We will merge `staging-next` into `staging` on Dec 15, 2025.

<!-- end warning -->

Moving the `get_lesson_materials` to a new utils file so that I can re-use it for lesson insights on the student snapshot page. 

This PR just moves `get_lesson_materials` and the string generation based on the output of that function into a utils file.


## Links
<!--  Links to relevant external resources.
      - spec docs, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- Jira: https://codedotorg.atlassian.net/browse/AITT-1322
