### PR TITLE
Disable HTTP connection pooling with WebPurify

### DIFF
--- a/lib/cdo/web_purify.rb
+++ b/lib/cdo/web_purify.rb
@@ -11,7 +11,8 @@ module WebPurify
   REQUEST_LIMIT = 4
   CONNECTION_OPTIONS = {
     read_timeout: DCDO.get('webpurify_http_read_timeout', 10),
-    open_timeout: DCDO.get('webpurify_tcp_connect_timeout', 5)
+    open_timeout: DCDO.get('webpurify_tcp_connect_timeout', 5),
+    keep_alive_timeout: DCDO.get('webpurify_http_keep_alive_timeout', 0) # Disable HTTP connection pooling.
   }
   ISO_639_1_TO_WEBPURIFY = {
     'es' => 'sp',


### PR DESCRIPTION
Since upgrading from Ruby 3.1.0 to 3.1.7 (which upgraded the bundled `net-http` from 0.2.0 to 0.3.0.1) we've seen intermittent HTTP connectivity errors (about 200 user HTTP requests per day fail) when our web application servers attempt to issue web service calls to WebPurify.

[Net::OpenTimeout Errors since Octoboer 1, 2025](https://app.honeybadger.io/projects/3240/faults?sort=times_desc&q=occurred.after%3A%2224+hours+ago%22%E2%80%83environment%3A%22production%22%E2%80%83Net%3A%3AOpen%E2%80%83): 
<img width="1034" height="406" alt="image" src="https://github.com/user-attachments/assets/475ae8ab-af98-4d51-8ef6-15fbe93e9235" />


This issue is possibly because Ruby 3.1 defaults http connection pool (keep alive) to 2 seconds, but, net-http v0.3.0/v0.3.0.1 has [known issues](https://bugs.ruby-lang.org/issues/19017) where it can "hang" or block incorrectly when trying to reuse a connection that the server has arguably closed. 

We don't carry out a high enough volume of external web service calls to Web Purify for connection pooling to improve performance. Disable connection pooling by setting http keep-alive to zero.



## Testing story
<!--  Does your change include appropriate tests?
      - If so, please describe how the tests included in this PR are sufficient.
      - If not, please explain why this change does not need to be tested. -->



## Deployment strategy
<!--  Any special steps required to deploy this, besides merging?
      - Are there database migrations or manual steps?
      - Does this require coordination with other teams or systems? -->



## Follow-up work
<!--  List any clean-up or technical debt that will be addressed in future work.
      - Include Jira links where applicable.
      - Are there any known limitations or improvements planned? -->



## Privacy
<!--  How does this change impact Student & Teacher privacy?
      - Does this collect, use, share, or modify PII, either new or existing? -->



## Security
<!--  How does this change impact our security surface-area?
      - Do API's touched have the right auth?
      - Do infra changes impact our attack surface or encryption?
-->



## Caching
<!--  How does this change impact caching behavior?
      - Are cache keys or invalidation strategies affected?
      - Will this require cache warming or invalidation after deployment? -->



## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
