### PR TITLE
Service for migrating Clever v2 -> v3.1 auth

### DIFF
--- a/dashboard/app/models/authentication_option.rb
+++ b/dashboard/app/models/authentication_option.rb
@@ -82,6 +82,12 @@ class AuthenticationOption < ApplicationRecord
     MICROSOFT
   ].freeze
 
+  module Clever
+    VERSION = {
+      v3_1: 'v3.1'
+    }.freeze
+  end
+
   scope :trusted_email, -> {where(credential_type: TRUSTED_EMAIL_CREDENTIAL_TYPES)}
 
   def google?

--- a/dashboard/lib/services/clever/v3_auth_option_builder.rb
+++ b/dashboard/lib/services/clever/v3_auth_option_builder.rb
@@ -1,5 +1,6 @@
 # Creates a new v3.1 Clever AuthenticationOption by duplicating an existing v2 Clever
 # AuthenticationOption.
+# Returns nil if the v2 auth option doesn't exist or if a v3 auth option already exists.
 # Returns the new AuthenticationOption without persisting it.
 module Services
   module Clever
@@ -18,6 +19,13 @@ module Services
         )
 
         return nil unless clever_auth_option
+
+        v3_already_exists = AuthenticationOption.exists?(
+          credential_type: AuthenticationOption::CLEVER,
+          authentication_id: clever_v3_id
+        )
+
+        return nil if v3_already_exists
 
         new_auth_option = clever_auth_option.dup
         new_auth_option.authentication_id = clever_v3_id

--- a/dashboard/lib/services/clever/v3_auth_option_builder.rb
+++ b/dashboard/lib/services/clever/v3_auth_option_builder.rb
@@ -1,0 +1,30 @@
+# Creates a new v3.1 Clever AuthenticationOption by duplicating an existing v2 Clever
+# AuthenticationOption.
+# Returns the new AuthenticationOption without persisting it.
+module Services
+  module Clever
+    class V3AuthOptionBuilder < Services::Base
+      attr_reader :clever_v2_id, :clever_v3_id
+
+      def initialize(clever_v2_id:, clever_v3_id:)
+        @clever_v2_id = clever_v2_id
+        @clever_v3_id = clever_v3_id
+      end
+
+      def call
+        clever_auth_option = ::AuthenticationOption.find_by(
+          credential_type: ::AuthenticationOption::CLEVER,
+          authentication_id: clever_v2_id
+        )
+
+        return nil unless clever_auth_option
+
+        new_auth_option = clever_auth_option.dup
+        new_auth_option.authentication_id = clever_v3_id
+        new_auth_option.version = ::AuthenticationOption::Clever::VERSION[:v3_1]
+
+        new_auth_option
+      end
+    end
+  end
+end

--- a/dashboard/lib/services/clever/v3_auth_option_builder.rb
+++ b/dashboard/lib/services/clever/v3_auth_option_builder.rb
@@ -12,8 +12,8 @@ module Services
       end
 
       def call
-        clever_auth_option = ::AuthenticationOption.find_by(
-          credential_type: ::AuthenticationOption::CLEVER,
+        clever_auth_option = AuthenticationOption.find_by(
+          credential_type: AuthenticationOption::CLEVER,
           authentication_id: clever_v2_id
         )
 
@@ -21,7 +21,7 @@ module Services
 
         new_auth_option = clever_auth_option.dup
         new_auth_option.authentication_id = clever_v3_id
-        new_auth_option.version = ::AuthenticationOption::Clever::VERSION[:v3_1]
+        new_auth_option.version = AuthenticationOption::Clever::VERSION[:v3_1]
 
         new_auth_option
       end

--- a/dashboard/test/lib/services/clever/v3_auth_option_builder_test.rb
+++ b/dashboard/test/lib/services/clever/v3_auth_option_builder_test.rb
@@ -58,5 +58,25 @@ class Services::Clever::V3AuthOptionBuilderTest < ActiveSupport::TestCase
         _(result).must_be_nil
       end
     end
+
+    context 'when v3 auth option already exists' do
+      let(:user) {create(:student, :with_clever_authentication_option)}
+      let(:original_auth) do
+        user.authentication_options.find_by(credential_type: AuthenticationOption::CLEVER)
+      end
+      let(:clever_v2_id) {original_auth.authentication_id}
+
+      before do
+        create(
+          :authentication_option,
+          credential_type: AuthenticationOption::CLEVER,
+          authentication_id: clever_v3_id
+        )
+      end
+
+      it 'returns nil' do
+        _(result).must_be_nil
+      end
+    end
   end
 end

--- a/dashboard/test/lib/services/clever/v3_auth_option_builder_test.rb
+++ b/dashboard/test/lib/services/clever/v3_auth_option_builder_test.rb
@@ -1,0 +1,62 @@
+require 'test_helper'
+
+class Services::Clever::V3AuthOptionBuilderTest < ActiveSupport::TestCase
+  describe '.call' do
+    let(:result) do
+      Services::Clever::V3AuthOptionBuilder.call(
+        clever_v2_id: clever_v2_id,
+        clever_v3_id: clever_v3_id
+      )
+    end
+
+    let(:clever_v3_id) {'new-v3-clever-id-123'}
+
+    context 'when clever auth option exists with given v2 id' do
+      let(:user) {create(:student, :with_clever_authentication_option)}
+      let(:original_auth) do
+        user.authentication_options.find_by(credential_type: AuthenticationOption::CLEVER)
+      end
+      let(:clever_v2_id) {original_auth.authentication_id}
+
+      it 'returns new auth option with v3 clever id' do
+        _(result.authentication_id).must_equal clever_v3_id
+      end
+
+      it 'sets version to v3.1' do
+        _(result.version).must_equal AuthenticationOption::Clever::VERSION[:v3_1]
+      end
+
+      it 'preserves credential type as clever' do
+        _(result.credential_type).must_equal AuthenticationOption::CLEVER
+      end
+
+      it 'does not persist the new auth option' do
+        _(result.id).must_be_nil
+      end
+
+      it 'preserves original email' do
+        _(result.email).must_equal original_auth.email
+      end
+
+      it 'preserves original hashed_email' do
+        _(result.hashed_email).must_equal original_auth.hashed_email
+      end
+
+      it 'preserves original user_id' do
+        _(result.user_id).must_equal original_auth.user_id
+      end
+
+      it 'preserves original data' do
+        _(result.data).must_equal original_auth.data
+      end
+    end
+
+    context 'when no clever auth option exists with given v2 id' do
+      let(:clever_v2_id) {'non-existent-v2-id'}
+
+      it 'returns nil' do
+        _(result).must_be_nil
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Context
Clever is a website schools use to organize their teachers and students. We allow users to log into code.org using the Clever accounts. We are in the process of upgrading our integration with Clever's v2 API to their v3.1 API. For using the v3.1 API, Clever has generated new Clever IDs for teachers and Clever provides a map from the v2 ID  to the new v3.1 ID.

## What this PR does
Creates a Service for creating a v3.1 Clever AuthenticationOption give the new v3.1 Clever ID and the old v2 Clever ID. This service will be used by our backfill script and login flow for generating the new authentication method for our Clever users.


## Links
* [Jira](https://codedotorg.atlassian.net/browse/P20-1647)


## Testing story
* Unit tests.

## Deployment strategy
This code isn't used yet.


## Follow-up work
Integrate it with the backfill scripts and the clever omniauth plugin.


## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
