### PR TITLE
Un-Revert "Create rails teacher notifications"

### DIFF
--- a/apps/src/aiDifferentiation/notifications/AiDiffNotificationList.tsx
+++ b/apps/src/aiDifferentiation/notifications/AiDiffNotificationList.tsx
@@ -24,11 +24,16 @@ const AiDiffNotificationList: React.FC<AiDiffNotificationListProps> = ({
     HttpClient.fetchJson<AiDiffNotification[]>('/notifications', {}, undefined)
       .then(response => {
         setLoading(false);
-        const loadedNotifications = response?.value?.map(n => ({
-          ...n,
-          publishedAt: new Date(n.publishedAt),
-          readAt: n.readAt ? new Date(n.readAt) : null,
-        }));
+        const loadedNotifications =
+          response?.value
+            ?.map(n => ({
+              ...n,
+              publishedAt: new Date(n.publishedAt),
+              readAt: n.readAt ? new Date(n.readAt) : null,
+            }))
+            .sort(
+              (a, b) => b.publishedAt.getTime() - a.publishedAt.getTime()
+            ) || [];
         setNotifications(loadedNotifications);
       })
       .catch(error => {
@@ -41,8 +46,17 @@ const AiDiffNotificationList: React.FC<AiDiffNotificationListProps> = ({
   React.useEffect(() => {
     const unreadNotifications = notifications.filter(n => n.readAt === null);
     if (unreadNotifications.length > 0) {
-      const unreadIds = unreadNotifications.map(n => n.externalId);
-      const payload = {external_notification_ids: unreadIds};
+      const unreadExternalIds = unreadNotifications
+        .filter(n => !!n.externalId)
+        .map(n => n.externalId);
+
+      const unreadTeacherNotificationIds = unreadNotifications
+        .filter(n => !n.externalId)
+        .map(n => n.id);
+      const payload = {
+        external_notification_ids: unreadExternalIds,
+        teacher_notification_ids: unreadTeacherNotificationIds,
+      };
 
       // We don't mark the notifications locally as read so that we still get the `unread`
       // UI state until the user refreshes.
@@ -65,7 +79,7 @@ const AiDiffNotificationList: React.FC<AiDiffNotificationListProps> = ({
 
   return (
     <div className={styles.listContainer}>
-      <div className={styles.list}>
+      <ol className={styles.list}>
         {loading ? (
           <>
             <Notification notification={null} key={'1'} />
@@ -76,12 +90,12 @@ const AiDiffNotificationList: React.FC<AiDiffNotificationListProps> = ({
           notifications.map(notification => (
             <Notification
               notification={notification}
-              key={notification.externalId}
+              key={notification.externalId || notification.id}
               aiPromptClick={aiPromptClick}
             />
           ))
         )}
-      </div>
+      </ol>
     </div>
   );
 };

--- a/apps/src/aiDifferentiation/notifications/Notification.tsx
+++ b/apps/src/aiDifferentiation/notifications/Notification.tsx
@@ -60,7 +60,7 @@ const Notification: React.FC<NotificationProps> = ({
   };
 
   return (
-    <div className={styles.notification}>
+    <li className={styles.notification}>
       <FontAwesomeV6Icon
         iconName={notificationOrPlaceholder.iconName}
         iconStyle="solid"
@@ -156,7 +156,7 @@ const Notification: React.FC<NotificationProps> = ({
       ) : (
         <div className={styles.readAt} />
       )}
-    </div>
+    </li>
   );
 };
 

--- a/apps/test/unit/aiDifferentiation/notifications/AiDiffNotificationListTest.jsx
+++ b/apps/test/unit/aiDifferentiation/notifications/AiDiffNotificationListTest.jsx
@@ -6,25 +6,38 @@ import HttpClient from '@cdo/apps/util/HttpClient';
 
 jest.mock('@cdo/apps/util/HttpClient');
 
-const NOTIFICATION_1 = {
+const EXTERNAL_NOTIFICATION_1 = {
   id: 'notification-1',
   externalId: 'ext-notif-1',
-  title: 'First Notification',
-  description: 'This is the first notification',
+  title: 'First External Notification',
+  description: 'This is the first external notification',
   readAt: null,
   iconName: 'bell',
   publishedAt: '2023-01-01T12:00:00Z',
 };
-const NOTIFICATION_2 = {
+const EXTERNAL_NOTIFICATION_2 = {
   id: 'notification-2',
   externalId: 'ext-notif-2',
-  title: 'Second Notification',
-  description: 'This is the second notification',
-  readAt: '2023-01-02T10:00:00Z',
+  title: 'Second External Notification',
+  description: 'This is the second external notification',
+  readAt: '2023-01-04T10:00:00Z',
   iconName: 'info',
-  publishedAt: '2023-01-01T10:00:00Z',
+  publishedAt: '2023-01-03T10:00:00Z',
 };
-const mockNotifications = [NOTIFICATION_1, NOTIFICATION_2];
+const NOTIFICATION_1 = {
+  id: 'notification-1',
+  externalId: null,
+  title: 'First Notification',
+  description: 'This is the first notification',
+  readAt: null,
+  iconName: 'info',
+  publishedAt: '2023-01-02T10:00:00Z',
+};
+const mockNotifications = [
+  EXTERNAL_NOTIFICATION_1,
+  EXTERNAL_NOTIFICATION_2,
+  NOTIFICATION_1,
+];
 
 describe('AiDiffNotificationList', () => {
   beforeEach(() => {
@@ -54,19 +67,27 @@ describe('AiDiffNotificationList', () => {
     });
 
     it('handles notifications with null readAt dates', async () => {
-      HttpClient.fetchJson.mockResolvedValue({value: [NOTIFICATION_1]});
+      HttpClient.fetchJson.mockResolvedValue({
+        value: [
+          EXTERNAL_NOTIFICATION_1,
+          EXTERNAL_NOTIFICATION_2,
+          NOTIFICATION_1,
+        ],
+      });
 
       render(<AiDiffNotificationList />);
 
       await waitFor(() => {
+        screen.getByText('First External Notification:');
         screen.getByText('First Notification:');
       });
 
-      screen.getByLabelText('Unread');
+      // Ignores already read notification
+      expect(screen.getAllByLabelText('Unread')).toHaveLength(2);
 
       expect(markAsReadMock).toHaveBeenCalledWith(
         '/notifications/mark_as_read',
-        '{"external_notification_ids":["ext-notif-1"]}',
+        '{"external_notification_ids":["ext-notif-1"],"teacher_notification_ids":["notification-1"]}',
         true,
         {
           'Content-Type': 'application/json; charset=UTF-8',
@@ -75,15 +96,17 @@ describe('AiDiffNotificationList', () => {
     });
 
     it('handles notifications with readAt dates', async () => {
-      HttpClient.fetchJson.mockResolvedValue({value: [NOTIFICATION_2]});
+      HttpClient.fetchJson.mockResolvedValue({
+        value: [EXTERNAL_NOTIFICATION_2],
+      });
 
       render(<AiDiffNotificationList />);
 
       await waitFor(() => {
-        screen.getByText('Second Notification:');
+        screen.getByText('Second External Notification:');
       });
 
-      screen.getByText('This is the second notification');
+      screen.getByText('This is the second external notification');
       expect(screen.queryByLabelText('Unread')).toBeNull();
       expect(markAsReadMock).toHaveBeenCalledTimes(0);
     });
@@ -127,14 +150,22 @@ describe('AiDiffNotificationList', () => {
     });
   });
 
-  it('renders correct number of notifications', async () => {
+  it('sorts notifications by most recent publishedAt date', async () => {
     HttpClient.fetchJson.mockResolvedValue({value: mockNotifications});
 
     render(<AiDiffNotificationList />);
 
     await waitFor(() => {
       screen.getByText('First Notification:');
-      screen.getByText('Second Notification:');
+      screen.getByText('First External Notification:');
+      screen.getByText('Second External Notification:');
     });
+
+    const notifications = screen.getAllByText(/:$/).map(el => el.textContent);
+    expect(notifications).toEqual([
+      'Second External Notification: ',
+      'First Notification: ',
+      'First External Notification: ',
+    ]);
   });
 });

--- a/dashboard/app/controllers/notifications_controller.rb
+++ b/dashboard/app/controllers/notifications_controller.rb
@@ -16,26 +16,41 @@ class NotificationsController < ApplicationController
 
   def mark_as_read
     external_notification_ids = (params[:external_notification_ids] || []).compact_blank
+    teacher_notification_ids = (params[:teacher_notification_ids] || []).compact_blank
 
-    if external_notification_ids.empty?
+    if external_notification_ids.empty? && teacher_notification_ids.empty?
       render json: {status: 'error', message: 'No notification IDs provided'}, status: :bad_request
       return
     end
 
-    valid_external_ids = filter_to_existing_ids(external_notification_ids, LOCALE)
-    found_external_notifications = current_user.external_notifications.where(external_id: valid_external_ids)
+    total_marked = 0
 
-    found_external_notifications.where(read_at: nil).update_all(read_at: Time.current)
-    found_ids = found_external_notifications.pluck(:external_id)
-    notifications_to_create = valid_external_ids - found_ids
-    notifications_to_create.each do |external_id|
-      ExternalNotification.create!(user_id: current_user.id, external_id: external_id, read_at: Time.current)
+    # Handle external notifications (existing logic)
+    if external_notification_ids.any?
+      valid_external_ids = filter_to_existing_ids(external_notification_ids, LOCALE)
+      found_external_notifications = current_user.external_notifications.where(external_id: valid_external_ids)
+
+      found_external_notifications.where(read_at: nil).update_all(read_at: Time.current)
+      found_ids = found_external_notifications.pluck(:external_id)
+      notifications_to_create = valid_external_ids - found_ids
+      notifications_to_create.each do |external_id|
+        ExternalNotification.create!(user_id: current_user.id, external_id: external_id, read_at: Time.current)
+      end
+
+      total_marked += found_ids.count + notifications_to_create.count
+    end
+
+    # Handle teacher notifications (new logic)
+    if teacher_notification_ids.any?
+      teacher_notifications = current_user.teacher_notifications.where(id: teacher_notification_ids, read_at: nil)
+      marked_teacher_count = teacher_notifications.update_all(read_at: Time.current)
+      total_marked += marked_teacher_count
     end
 
     response_data = {
       status: 'success',
-      message: "#{found_ids.count + notifications_to_create.count} notification(s) marked as read",
-      marked_count: found_ids.count + notifications_to_create.count,
+      message: "#{total_marked} notification(s) marked as read",
+      marked_count: total_marked,
     }
 
     render json: response_data, status: :ok

--- a/dashboard/app/models/teacher_notification.rb
+++ b/dashboard/app/models/teacher_notification.rb
@@ -1,0 +1,51 @@
+# == Schema Information
+#
+# Table name: teacher_notifications
+#
+#  id           :bigint           not null, primary key
+#  user_id      :integer          not null
+#  title        :string(255)      not null
+#  description  :text(65535)      not null
+#  icon_name    :string(255)
+#  icon_color   :string(255)
+#  href_links   :json
+#  ai_prompts   :json
+#  priority     :integer          default(0)
+#  expires_at   :datetime
+#  read_at      :datetime
+#  is_dismissed :boolean          default(FALSE), not null
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#
+# Indexes
+#
+#  index_teacher_notifications_on_user_id_and_created_at    (user_id,created_at)
+#  index_teacher_notifications_on_user_id_and_is_dismissed  (user_id,is_dismissed)
+#  index_teacher_notifications_on_user_id_and_read_at       (user_id,read_at)
+#
+class TeacherNotification < ApplicationRecord
+  belongs_to :user
+
+  scope :not_dismissed, -> {where(is_dismissed: false)}
+  scope :not_expired, -> {where('expires_at IS NULL OR expires_at > ?', Time.current)}
+  scope :active, -> {not_dismissed.not_expired}
+
+  validates :title, presence: true
+  validates :description, presence: true
+
+  def read?
+    read_at.present?
+  end
+
+  def expired?
+    expires_at.present? && expires_at < Time.current
+  end
+
+  def active?
+    !is_dismissed && !expired?
+  end
+
+  def mark_as_read!
+    update!(read_at: Time.current) unless read?
+  end
+end

--- a/dashboard/app/models/user.rb
+++ b/dashboard/app/models/user.rb
@@ -314,6 +314,7 @@ class User < ApplicationRecord
   has_many :lti_user_identities, dependent: :destroy
 
   has_many :external_notifications, dependent: :destroy
+  has_many :teacher_notifications, dependent: :destroy
 
   has_one :latest_parental_permission_request, -> {order(updated_at: :desc)}, class_name: 'ParentalPermissionRequest'
 

--- a/dashboard/config/application.rb
+++ b/dashboard/config/application.rb
@@ -260,6 +260,9 @@ module Dashboard
                             CdoContentful::Marketing::Entry::DashboardNotification
                           end
       ::Notifications.register(Marketing::DashboardNotifications::ContentfulNotificationSource.new(contentful_client))
+
+      # Register the TeacherNotificationSource for database-backed notifications
+      ::Notifications.register(TeacherNotificationSource.new)
     end
   end
 end

--- a/dashboard/lib/teacher_notification_source.rb
+++ b/dashboard/lib/teacher_notification_source.rb
@@ -1,0 +1,23 @@
+class TeacherNotificationSource < Notifications::Source
+  SOURCE_NAME = 'teacher_notification'
+
+  def get(user_id:, locale:)
+    TeacherNotification.active.where(user_id: user_id).map do |notification|
+      {
+        id: notification.id,
+        source: SOURCE_NAME,
+        external_id: nil, # external ID is only used for contentful notifications
+        title: notification.title,
+        description: notification.description,
+        icon_name: notification.icon_name,
+        icon_color: notification.icon_color,
+        href_links: notification.href_links,
+        ai_prompts: notification.ai_prompts,
+        priority: notification.priority,
+        published_at: notification.created_at.iso8601,
+        expires_at: notification.expires_at&.iso8601,
+        read_at: notification.read_at&.iso8601
+      }
+    end
+  end
+end

--- a/dashboard/test/controllers/notifications_controller_test.rb
+++ b/dashboard/test/controllers/notifications_controller_test.rb
@@ -3,7 +3,7 @@ require 'contentful'
 
 class NotificationsControllerTest < ActionDispatch::IntegrationTest
   include Minitest::RSpecMocks
-  TestEntry = Struct.new(:external_id, :title, :description, :icon_name, :href_links, :ai_prompts, :priority, :published_at, :expires_at, :read_at, keyword_init: true)
+  TestEntry = Struct.new(:external_id, :title, :description, :icon_name, :href_links, :ai_prompts, :priority, :published_at, :expires_at, :read_at, :source, keyword_init: true)
 
   let(:entry_id_1) {SecureRandom.hex(10).to_s}
   let(:entry_id_2) {SecureRandom.hex(10).to_s}
@@ -13,6 +13,36 @@ class NotificationsControllerTest < ActionDispatch::IntegrationTest
   let(:later) {2.days.from_now.iso8601}
   let(:user) {create(:user)}
   let(:other_user) {create(:user)}
+
+  let(:teacher_notification_1) do
+    create(:teacher_notification,
+      user: user,
+      title: 'Teacher Notification 1',
+      description: 'Teacher Description 1',
+      icon_name: 'teacher_icon1',
+      icon_color: 'blue',
+      href_links: [{'url' => 'https://teacher.example.com/1', 'text' => 'Teacher Link 1'}],
+      ai_prompts: [{'text' => 'Teacher Prompt 1', 'prompt' => 'Teacher Prompt 1 text'}],
+      priority: 1,
+      expires_at: 1.day.from_now,
+      read_at: nil
+    )
+  end
+
+  let(:teacher_notification_2) do
+    create(:teacher_notification,
+      user: user,
+      title: 'Teacher Notification 2',
+      description: 'Teacher Description 2',
+      icon_name: 'teacher_icon2',
+      icon_color: 'red',
+      href_links: [{'url' => 'https://teacher.example.com/2', 'text' => 'Teacher Link 2'}],
+      ai_prompts: [{'text' => 'Teacher Prompt 2', 'prompt' => 'Teacher Prompt 2 text'}],
+      priority: 2,
+      expires_at: 2.days.from_now,
+      read_at: Time.current
+    )
+  end
 
   let(:entry_1) do
     TestEntry.new(
@@ -25,7 +55,8 @@ class NotificationsControllerTest < ActionDispatch::IntegrationTest
       priority: 0,
       published_at: yesterday,
       expires_at: tomorrow,
-      read_at: today
+      read_at: today,
+      source: 'contentful'
       )
   end
 
@@ -40,7 +71,8 @@ class NotificationsControllerTest < ActionDispatch::IntegrationTest
       priority: 0,
       published_at: yesterday,
       expires_at: later,
-      read_at: nil
+      read_at: nil,
+      source: 'contentful'
       )
   end
 
@@ -80,6 +112,104 @@ class NotificationsControllerTest < ActionDispatch::IntegrationTest
         _(response_data[0]["readAt"]).must_equal today
 
         _(response_data[1]["externalId"]).must_equal entry_id_2
+      end
+
+      it 'returns user teacher notifications only' do
+        teacher_notification_data_1 = {
+          id: teacher_notification_1.id,
+          source: 'teacher_notification',
+          external_id: nil,
+          title: 'Teacher Notification 1',
+          description: 'Teacher Description 1',
+          icon_name: 'teacher_icon1',
+          icon_color: 'blue',
+          href_links: [{'url' => 'https://teacher.example.com/1', 'text' => 'Teacher Link 1'}],
+          ai_prompts: [{'text' => 'Teacher Prompt 1', 'prompt' => 'Teacher Prompt 1 text'}],
+          priority: 1,
+          published_at: teacher_notification_1.created_at.iso8601,
+          expires_at: teacher_notification_1.expires_at&.iso8601,
+          read_at: nil
+        }
+
+        teacher_notification_data_2 = {
+          id: teacher_notification_2.id,
+          source: 'teacher_notification',
+          external_id: nil,
+          title: 'Teacher Notification 2',
+          description: 'Teacher Description 2',
+          icon_name: 'teacher_icon2',
+          icon_color: 'red',
+          href_links: [{'url' => 'https://teacher.example.com/2', 'text' => 'Teacher Link 2'}],
+          ai_prompts: [{'text' => 'Teacher Prompt 2', 'prompt' => 'Teacher Prompt 2 text'}],
+          priority: 2,
+          published_at: teacher_notification_2.created_at.iso8601,
+          expires_at: teacher_notification_2.expires_at&.iso8601,
+          read_at: teacher_notification_2.read_at&.iso8601
+        }
+
+        Notifications.stubs(:get_all).returns([teacher_notification_data_1, teacher_notification_data_2])
+        get '/notifications'
+
+        assert_response :success
+
+        response_data = JSON.parse(@response.body)
+        _(response_data.length).must_equal 2
+
+        _(response_data[0]).wont_be_nil
+        _(response_data[0]["id"]).must_equal teacher_notification_1.id
+        _(response_data[0]["source"]).must_equal 'teacher_notification'
+        _(response_data[0]["title"]).must_equal 'Teacher Notification 1'
+        _(response_data[0]["description"]).must_equal 'Teacher Description 1'
+        _(response_data[0]["iconName"]).must_equal 'teacher_icon1'
+        _(response_data[0]["iconColor"]).must_equal 'blue'
+        _(response_data[0]["hrefLinks"]).must_equal [{'url' => 'https://teacher.example.com/1', 'text' => 'Teacher Link 1'}]
+        _(response_data[0]["aiPrompts"]).must_equal [{'text' => 'Teacher Prompt 1', 'prompt' => 'Teacher Prompt 1 text'}]
+        _(response_data[0]["priority"]).must_equal 1
+        _(response_data[0]["readAt"]).must_be_nil
+
+        _(response_data[1]).wont_be_nil
+        _(response_data[1]["id"]).must_equal teacher_notification_2.id
+        _(response_data[1]["readAt"]).wont_be_nil
+      end
+
+      it 'returns both external and teacher notifications combined' do
+        # Stub to return both external and teacher notifications
+        teacher_notification_data_1 = {
+          id: teacher_notification_1.id,
+          source: 'teacher_notification',
+          external_id: nil,
+          title: 'Teacher Notification 1',
+          description: 'Teacher Description 1',
+          icon_name: 'teacher_icon1',
+          icon_color: 'blue',
+          href_links: [{'url' => 'https://teacher.example.com/1', 'text' => 'Teacher Link 1'}],
+          ai_prompts: [{'text' => 'Teacher Prompt 1', 'prompt' => 'Teacher Prompt 1 text'}],
+          priority: 1,
+          published_at: teacher_notification_1.created_at.iso8601,
+          expires_at: teacher_notification_1.expires_at&.iso8601,
+          read_at: nil
+        }
+
+        Notifications.stubs(:get_all).returns([entry_1, teacher_notification_data_1])
+        get '/notifications'
+
+        assert_response :success
+
+        response_data = JSON.parse(@response.body)
+        _(response_data.length).must_equal 2
+
+        external_notification = response_data.find {|n| n["externalId"] == entry_id_1}
+        teacher_notification = response_data.find {|n| n["title"] == 'Teacher Notification 1'}
+
+        _(external_notification).wont_be_nil
+        _(external_notification["externalId"]).must_equal entry_id_1
+        _(external_notification["title"]).must_equal 'Notification 1'
+        _(external_notification["source"]).must_equal 'contentful'
+
+        _(teacher_notification).wont_be_nil
+        _(teacher_notification["id"]).must_equal teacher_notification_1.id
+        _(teacher_notification["title"]).must_equal 'Teacher Notification 1'
+        _(teacher_notification["source"]).must_equal 'teacher_notification'
       end
     end
   end
@@ -163,6 +293,94 @@ class NotificationsControllerTest < ActionDispatch::IntegrationTest
         _(external_notification1.read_at.to_i).must_equal yesterday.to_i
         _(ExternalNotification.find_by(external_id: entry_2.external_id, user: user)&.read_at).wont_be_nil
       end
+
+      it 'successfully marks teacher notifications as read' do
+        teacher_notification_1
+        teacher_notification_2
+
+        post '/notifications/mark_as_read', params: {teacher_notification_ids: [teacher_notification_1.id]}
+        assert_response :ok
+
+        response_data = JSON.parse(@response.body)
+        _(response_data["status"]).must_equal "success"
+        _(response_data["message"]).must_equal "1 notification(s) marked as read"
+        _(response_data["marked_count"]).must_equal 1
+
+        teacher_notification_1.reload
+        _(teacher_notification_1.read_at).wont_be_nil
+      end
+
+      it 'successfully marks multiple teacher notifications as read' do
+        teacher_notification_1
+        teacher_notification_2.update!(read_at: nil)
+
+        post '/notifications/mark_as_read', params: {teacher_notification_ids: [teacher_notification_1.id, teacher_notification_2.id]}
+        assert_response :ok
+
+        response_data = JSON.parse(@response.body)
+        _(response_data["status"]).must_equal "success"
+        _(response_data["message"]).must_equal "2 notification(s) marked as read"
+        _(response_data["marked_count"]).must_equal 2
+
+        teacher_notification_1.reload
+        teacher_notification_2.reload
+        _(teacher_notification_1.read_at).wont_be_nil
+        _(teacher_notification_2.read_at).wont_be_nil
+      end
+
+      it 'does not update already read teacher notifications' do
+        teacher_notification_1
+        teacher_notification_2
+
+        notification_2_read_at = teacher_notification_2['read_at']
+
+        post '/notifications/mark_as_read', params: {teacher_notification_ids: [teacher_notification_1.id, teacher_notification_2.id]}
+        assert_response :ok
+
+        response_data = JSON.parse(@response.body)
+        _(response_data["status"]).must_equal "success"
+        _(response_data["message"]).must_equal "1 notification(s) marked as read"
+        _(response_data["marked_count"]).must_equal 1
+
+        teacher_notification_1.reload
+        teacher_notification_2.reload
+        _(teacher_notification_1.read_at).wont_be_nil
+        _(teacher_notification_2.read_at.to_i).must_equal notification_2_read_at.to_i
+      end
+
+      it 'successfully marks both external and teacher notifications as read' do
+        Notifications.stubs(:get_all).returns([entry_1])
+        teacher_notification_1
+
+        post '/notifications/mark_as_read', params: {
+          external_notification_ids: [entry_1.external_id],
+          teacher_notification_ids: [teacher_notification_1.id]
+        }
+        assert_response :ok
+
+        response_data = JSON.parse(@response.body)
+        _(response_data["status"]).must_equal "success"
+        _(response_data["message"]).must_equal "2 notification(s) marked as read"
+        _(response_data["marked_count"]).must_equal 2
+
+        _(ExternalNotification.find_by(external_id: entry_1.external_id, user: user)&.read_at).wont_be_nil
+        teacher_notification_1.reload
+        _(teacher_notification_1.read_at).wont_be_nil
+      end
+
+      it 'does not update teacher notifications for other users' do
+        other_teacher_notification = create(:teacher_notification, user: other_user, read_at: nil)
+
+        post '/notifications/mark_as_read', params: {teacher_notification_ids: [other_teacher_notification.id]}
+        assert_response :ok
+
+        response_data = JSON.parse(@response.body)
+        _(response_data["status"]).must_equal "success"
+        _(response_data["marked_count"]).must_equal 0
+
+        other_teacher_notification.reload
+        _(other_teacher_notification.read_at).must_be_nil
+      end
     end
 
     context 'with invalid parameters' do
@@ -193,6 +411,24 @@ class NotificationsControllerTest < ActionDispatch::IntegrationTest
         response_data = JSON.parse(@response.body)
         _(response_data["status"]).must_equal "success"
         _(response_data["marked_count"]).must_equal 0
+      end
+
+      it 'returns error for empty teacher notification_ids' do
+        post '/notifications/mark_as_read', params: {teacher_notification_ids: []}
+        assert_response :bad_request
+
+        response_data = JSON.parse(@response.body)
+        _(response_data["status"]).must_equal "error"
+        _(response_data["message"]).must_equal "No notification IDs provided"
+      end
+
+      it 'returns error for empty both external and teacher notification_ids' do
+        post '/notifications/mark_as_read', params: {external_notification_ids: [], teacher_notification_ids: []}
+        assert_response :bad_request
+
+        response_data = JSON.parse(@response.body)
+        _(response_data["status"]).must_equal "error"
+        _(response_data["message"]).must_equal "No notification IDs provided"
       end
     end
   end

--- a/dashboard/test/factories/factories.rb
+++ b/dashboard/test/factories/factories.rb
@@ -2374,4 +2374,18 @@ FactoryBot.define do
     association :user
     form_id {1}
   end
+
+  factory :teacher_notification do
+    association :user
+    title {"Test Teacher Notification"}
+    description {"Test teacher notification description"}
+    icon_name {"notification_icon"}
+    icon_color {"blue"}
+    href_links {[{'url' => 'https://example.com', 'text' => 'Test Link'}]}
+    ai_prompts {[{'text' => 'Test Prompt', 'prompt' => 'Test prompt text'}]}
+    priority {0}
+    expires_at {1.day.from_now}
+    read_at {nil}
+    is_dismissed {false}
+  end
 end


### PR DESCRIPTION
Un-revert the use of a migration.

Original PR: https://github.com/code-dot-org/code-dot-org/pull/69792

Partial revert (reverts using the new table, but not the creation migration):  https://github.com/code-dot-org/code-dot-org/pull/69851