### PR TITLE
Lab2 Listeners: Fix bug with list changing during event

### DIFF
--- a/apps/src/lab2/utils/LifecycleNotifier.tsx
+++ b/apps/src/lab2/utils/LifecycleNotifier.tsx
@@ -56,7 +56,9 @@ class LifecycleNotifier {
   }
 
   notify<T extends LifecycleEvent>(event: T, ...args: CallbackArgs[T]) {
-    this.listeners[event]?.forEach(callback => callback(...args));
+    // Copy the listener list to avoid skipping listeners if the list is modified during iteration.
+    const staticListenerList = [...(this.listeners[event] || [])];
+    staticListenerList.forEach(callback => callback(...args));
   }
 }
 


### PR DESCRIPTION
I found a funky bug where we weren't triggering [this level completed listener](https://github.com/code-dot-org/code-dot-org/blob/1cd863c49838a9197d3084e2ee7fdbfc9eec0e20/apps/src/codebridge/FilePreview/HTMLPreview.tsx#L187-L189) for Web Lab 2 when switching between levels backed by the same project template. The effect of this was when you changed to the next level, your code changes would no longer be updated in the preview because we thought the level was still loading.

I found out that the reason this was happening is for some reason only when switching between template levels, the [version history callback](https://github.com/code-dot-org/code-dot-org/blob/1cd863c49838a9197d3084e2ee7fdbfc9eec0e20/apps/src/lab2/views/components/Instructions/ResourcePanel/VersionHistory/VersionHistoryPanel.tsx#L145-L147) was being added a removed during the execution of the [listener callbacks](https://github.com/code-dot-org/code-dot-org/blob/1cd863c49838a9197d3084e2ee7fdbfc9eec0e20/apps/src/lab2/utils/LifecycleNotifier.tsx#L58-L60). This had the effect of calling the version history callback twice, and the HTMLPreview callback never. This was because the list was ordered [VersionHistory, HTMLPreview], VersionHistory was called, then it was added and removed. Now the list order is [HTMLPreview, VersionHistory], we call the next callback in the list, which is version history again. 

The fix for this is to copy the list of listeners before the foreach loop, so we are working off a static list that won't change underneath us.

## Before

https://github.com/user-attachments/assets/9df54e93-3e07-429d-8350-19e950586117


## After

https://github.com/user-attachments/assets/3f51ace2-9da4-4c32-9b3b-625eca832446



## Links

- Jira: [AFL-392](https://codedotorg.atlassian.net/browse/AFL-392)

## Testing story
Tested locally.



## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
