### PR TITLE
[AIChat] Replaces ellipsis button and dropdown for disclaimer dialog with tooltip icon button

### DIFF
--- a/apps/src/aichat/views/AichatView.tsx
+++ b/apps/src/aichat/views/AichatView.tsx
@@ -1,6 +1,5 @@
 /** @file Top-level view for AI Chat Lab */
 
-import ActionDropdown from '@code-dot-org/component-library/dropdown/actionDropdown';
 import SegmentedButtons, {
   SegmentedButtonsProps,
 } from '@code-dot-org/component-library/segmentedButtons';
@@ -405,20 +404,18 @@ const AichatView: React.FunctionComponent<LabProps<AichatLevelProperties>> = ({
 
 const renderModelCustomizationHeaderRight = (onStartOver: () => void) => {
   return (
-    <div>
-      <IconButtonWithTooltip
-        id="start-over"
-        label={aichatI18n.aria_startOver()}
-        icon={{iconName: 'refresh', iconStyle: 'solid'}}
-        type="tertiary"
-        color="gray"
-        buttonSize="xs"
-        tooltipSize="xs"
-        tooltipDirection="onBottom"
-        hideTooltipTail={true}
-        onClick={onStartOver}
-      />
-    </div>
+    <IconButtonWithTooltip
+      id="start-over"
+      label={aichatI18n.aria_startOver()}
+      icon={{iconName: 'refresh', iconStyle: 'solid'}}
+      type="tertiary"
+      color="gray"
+      buttonSize="xs"
+      tooltipSize="xs"
+      tooltipDirection="onBottom"
+      hideTooltipTail={true}
+      onClick={onStartOver}
+    />
   );
 };
 
@@ -427,24 +424,17 @@ const renderInstructionsHeaderRight = (
   onInfoClick: () => void
 ) => {
   return isUserTeacher ? (
-    <ActionDropdown
-      name="instructionsInfoDropdown"
-      labelText={aichatI18n.instructionsHeaderRight()}
-      size="xs"
-      triggerButtonProps={{
-        type: 'tertiary',
-        isIconOnly: true,
-        color: 'black',
-        icon: {iconName: 'ellipsis-vertical', iconStyle: 'solid'},
-      }}
-      options={[
-        {
-          value: 'teacherOnboardingModal',
-          label: aichatI18n.aboutAichatLab(),
-          icon: {iconName: 'circle-info', iconStyle: 'solid'},
-          onClick: onInfoClick,
-        },
-      ]}
+    <IconButtonWithTooltip
+      id="about-aichat-lab"
+      label={aichatI18n.aboutAichatLab()}
+      icon={{iconName: 'message-question', iconStyle: 'solid'}}
+      type="tertiary"
+      color="black"
+      buttonSize="xs"
+      tooltipSize="xs"
+      tooltipDirection="onBottom"
+      hideTooltipTail={true}
+      onClick={onInfoClick}
     />
   ) : null;
 };


### PR DESCRIPTION
## Warning!!

We have entered Pixel Lock for Hour of AI! All merges to the `staging` branch from Dec 2 through Dec 12 must go through live change review and be deemed critical for supporting the Hour of AI. External contributions will not be accepted at this time.

For non-critical changes, please change your base to `staging-next` and delete this warning. We will merge `staging-next` into `staging` on Dec 15, 2025.

<!-- end warning -->


The existing experience is not great for anyone, a11y users included. The button opens a dropdown with a single item, which opens up the disclaimer dialog. This PR replaces that with a single icon button with tooltip that does the same. This way, we don't have an unnecessary tab stop or single-item dropdown. 

I also removed the extra div and confirmed that the start over button looks the same (there wasn't a style reason to do this- it looks like an artifact from a [PR update here](https://github.com/code-dot-org/code-dot-org/pull/61558/files#diff-258a76195564458e17b8ba9722e21c1f405eb46e9a88550ef84618348b71f78aL310). 

<img width="262" height="160" alt="Screenshot 2025-12-02 at 2 43 20 PM" src="https://github.com/user-attachments/assets/a519086b-f2fa-4971-9e66-f27e9ae3ee2d" />
<img width="1383" height="406" alt="Screenshot 2025-12-02 at 2 00 09 PM" src="https://github.com/user-attachments/assets/49ea01df-81ac-4bbb-8cb0-848899ae94ed" />


Before:
<img width="1710" height="895" alt="Screenshot 2025-12-02 at 1 27 47 PM" src="https://github.com/user-attachments/assets/3c7d145d-0c87-4ccf-8714-91dc8a959d84" />
<img width="765" height="230" alt="Screenshot 2025-12-02 at 2 52 05 PM" src="https://github.com/user-attachments/assets/a4cf3ed6-27cc-44a1-bf80-a7587b8f1da7" />

<img width="512" height="300" alt="Screenshot 2025-12-02 at 1 23 48 PM" src="https://github.com/user-attachments/assets/7562e178-6251-4e72-8c94-4e79b95f500a" />


After:

<img width="411" height="188" alt="Screenshot 2025-12-02 at 2 51 51 PM" src="https://github.com/user-attachments/assets/db977fad-bade-4d86-9ff5-b183487d2a22" />

https://github.com/user-attachments/assets/33e9e855-9a53-44de-affe-dd24ee742f9b


## Links
<!--  Links to relevant external resources.
      - spec docs, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- Jira: 

## Testing story
<!--  Does your change include appropriate tests?
      - If so, please describe how the tests included in this PR are sufficient.
      - If not, please explain why this change does not need to be tested. -->



## Deployment strategy
<!--  Any special steps required to deploy this, besides merging?
      - Are there database migrations or manual steps?
      - Does this require coordination with other teams or systems? -->



## Follow-up work
<!--  List any clean-up or technical debt that will be addressed in future work.
      - Include Jira links where applicable.
      - Are there any known limitations or improvements planned? -->



## Privacy
<!--  How does this change impact Student & Teacher privacy?
      - Does this collect, use, share, or modify PII, either new or existing? -->



## Security
<!--  How does this change impact our security surface-area?
      - Do API's touched have the right auth?
      - Do infra changes impact our attack surface or encryption?
-->



## Caching
<!--  How does this change impact caching behavior?
      - Are cache keys or invalidation strategies affected?
      - Will this require cache warming or invalidation after deployment? -->



## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
