### PR TITLE
Levelbuilder: allow resetting version history from edit page for script levels

### DIFF
--- a/dashboard/app/controllers/levels_controller.rb
+++ b/dashboard/app/controllers/levels_controller.rb
@@ -307,7 +307,7 @@ class LevelsController < ApplicationController
                    edit_blocks_level_path(@level, :start_sources)
                  else
                    if reset
-                     params["redirect"] || level_url(@level, show_callouts: 1, reset: reset)
+                     params["redirect"] ? params["redirect"] + "?reset=true" : level_url(@level, show_callouts: 1, reset: reset)
                    else
                      params["redirect"] || level_url(@level, show_callouts: 1)
                    end


### PR DESCRIPTION
On levelbuilder there is a checkbox at the bottom "Reset version history when saving and loading level". This only worked when going to the level url (ex. `/levels/12345`), not the script level url (/`courses/etc...`). This changes updates the checkbox to apply to both types of urls. All it does is add `?reset=true` to the end of the url. It works for all lab2 levels now, legacy is a bit hit or miss. I don't think Java Lab ever worked with this checkbox, for example, because it is not affected by Studio App' [handleClearPuzzle](https://github.com/code-dot-org/code-dot-org/blob/c43f3e096f0ad599f5573a74474be0518f127f83/apps/src/StudioApp.js#L894). It seems to work for App Lab. I couldn't get it to work for Maze, but I don't think there's any downside of adding the parameter, even if it doesn't work. 


## Links

- Jira: [AFL-292](https://codedotorg.atlassian.net/browse/AFL-292)

## Testing story
Tested locally on a variety of levels.


## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
