### PR TITLE
Music: timeline fix

### DIFF
--- a/apps/src/music/views/Timeline/TimelineUI.tsx
+++ b/apps/src/music/views/Timeline/TimelineUI.tsx
@@ -243,8 +243,15 @@ const Timeline: React.FunctionComponent<TimelineProps> = props => {
       return;
     }
     const resizeObserver = new ResizeObserver(() => {
+      // Don't use the entire height of the bar line in event height calculations.
+      // Currently, assuming it's 4 pixels shorter is sufficient in subsequent
+      // calculations to avoid events from being cut off.
+      const barlineHeightCompensation = 4;
+
       const firstBarLineHeight = firstBarLineRef.current?.offsetHeight;
-      setAvailableHeight(firstBarLineHeight ? firstBarLineHeight - 2 : 0);
+      setAvailableHeight(
+        firstBarLineHeight ? firstBarLineHeight - barlineHeightCompensation : 0
+      );
     });
     resizeObserver.observe(firstBarLineRef?.current);
     return () => {

--- a/apps/src/music/views/Timeline/TimelineUI.tsx
+++ b/apps/src/music/views/Timeline/TimelineUI.tsx
@@ -243,7 +243,8 @@ const Timeline: React.FunctionComponent<TimelineProps> = props => {
       return;
     }
     const resizeObserver = new ResizeObserver(() => {
-      setAvailableHeight(firstBarLineRef.current?.offsetHeight || 0);
+      const firstBarLineHeight = firstBarLineRef.current?.offsetHeight;
+      setAvailableHeight(firstBarLineHeight ? firstBarLineHeight - 2 : 0);
     });
     resizeObserver.observe(firstBarLineRef?.current);
     return () => {


### PR DESCRIPTION
This makes a small adjustment to avoid the vertical overflow of timeline elements.

### before

<img width="414" height="201" alt="Screenshot 2025-12-02 at 9 57 50 PM" src="https://github.com/user-attachments/assets/b62db056-6f4c-43dc-973b-a59089839fe9" />

### after

<img width="414" height="201" alt="Screenshot 2025-12-02 at 9 56 44 PM" src="https://github.com/user-attachments/assets/21b88108-c94b-4b5e-bc28-a7a31f50c9fd" />
