### PR TITLE
tidy 🧹:  Remove radium from applab components

### DIFF
--- a/apps/src/applab/ImportProjectDialog.jsx
+++ b/apps/src/applab/ImportProjectDialog.jsx
@@ -3,6 +3,8 @@ import React from 'react';
 import {connect} from 'react-redux';
 
 import {studio} from '@cdo/apps/lib/util/urlHelpers';
+import {EVENTS} from '@cdo/apps/metrics/AnalyticsConstants';
+import analyticsReporter from '@cdo/apps/metrics/AnalyticsReporter';
 
 import Dialog, {Body, Buttons, Confirm} from '../legacySharedComponents/Dialog';
 import color from '../util/color';
@@ -22,6 +24,9 @@ export class ImportProjectDialog extends React.Component {
   state = {...initialState};
 
   onImport = () => {
+    analyticsReporter.sendEvent(EVENTS.APPLAB_IMPORT_PROJECT, {
+      url: this.state.url,
+    });
     this.props.onImport(this.state.url);
     this.setState(initialState);
   };

--- a/apps/src/applab/ImportScreensDialog.jsx
+++ b/apps/src/applab/ImportScreensDialog.jsx
@@ -1,6 +1,5 @@
 /* eslint-disable react/no-danger */
 import PropTypes from 'prop-types';
-import Radium from 'radium'; // eslint-disable-line no-restricted-imports
 import React from 'react';
 import {connect} from 'react-redux';
 
@@ -59,7 +58,7 @@ class AssetListItemUnwrapped extends React.Component {
           projectId={projectId}
           soundPlayer={soundPlayer}
         />
-        <div style={[styles.assetListItemText, styles.subtext]}>
+        <div style={combineStyles(styles.assetListItemText, styles.subtext)}>
           {asset.filename}
           {asset.willReplace && (
             <p style={styles.warning}>
@@ -72,7 +71,7 @@ class AssetListItemUnwrapped extends React.Component {
     );
   }
 }
-export const AssetListItem = Radium(AssetListItemUnwrapped);
+export const AssetListItem = AssetListItemUnwrapped;
 
 function quotedCommaJoin(strings) {
   return strings.map(s => `"${s}"`).join(', ');
@@ -87,10 +86,10 @@ class ScreenListItemUnwrapped extends React.Component {
     const {screen} = this.props;
     return (
       <div
-        style={[
+        style={combineStyles(
           styles.screenListItem,
-          !screen.canBeImported && styles.disabledScreenListItem,
-        ]}
+          !screen.canBeImported && styles.disabledScreenListItem
+        )}
       >
         <div style={styles.miniScreenWrapper}>
           <div
@@ -123,7 +122,7 @@ class ScreenListItemUnwrapped extends React.Component {
     );
   }
 }
-export const ScreenListItem = Radium(ScreenListItemUnwrapped);
+export const ScreenListItem = ScreenListItemUnwrapped;
 
 export class ImportScreensDialog extends React.Component {
   static propTypes = {
@@ -236,6 +235,9 @@ export class ImportScreensDialog extends React.Component {
     );
   }
 }
+
+const combineStyles = (...styles) =>
+  Object.assign({}, ...styles.filter(Boolean));
 
 // TODO: ditch color and fontSize in favor of more unified style components when they exist.
 const styles = {

--- a/apps/src/applab/Visualization.jsx
+++ b/apps/src/applab/Visualization.jsx
@@ -1,6 +1,5 @@
 import classNames from 'classnames';
 import PropTypes from 'prop-types';
-import Radium from 'radium'; // eslint-disable-line no-restricted-imports
 import React from 'react';
 import {connect} from 'react-redux';
 
@@ -52,6 +51,13 @@ class Visualization extends React.Component {
   };
 
   render() {
+    const {
+      isResponsive,
+      isShareView,
+      playspacePhoneFrame,
+      isRunning,
+      isPaused,
+    } = this.props;
     const appWidth = applabConstants.getAppWidth(this.props);
     const appHeight =
       applabConstants.APP_HEIGHT - applabConstants.FOOTER_HEIGHT;
@@ -60,17 +66,15 @@ class Visualization extends React.Component {
       <div
         id={VISUALIZATION_DIV_ID}
         className={this.getVisualizationClassNames()}
-        style={[
-          !this.props.isResponsive && {
+        style={combineStyles(
+          !isResponsive && {
             ...styles.nonResponsive,
             width: appWidth, // Required for the project share page.
           },
-          this.props.isShareView && styles.share,
-          this.props.playspacePhoneFrame && styles.phoneFrame,
-          this.props.playspacePhoneFrame &&
-            this.props.isRunning &&
-            styles.phoneFrameRunning,
-        ]}
+          isShareView && styles.share,
+          playspacePhoneFrame && styles.phoneFrame,
+          playspacePhoneFrame && isRunning && styles.phoneFrameRunning
+        )}
       >
         <div id="divApplab" className="appModern" />
         <div
@@ -89,16 +93,18 @@ class Visualization extends React.Component {
           handleTryAgain={this.handleTryAgain}
         />
         <div
-          style={[
-            {...styles.screenBlock, ...{width: appWidth}},
-            !(this.props.isPaused && this.props.playspacePhoneFrame) &&
-              commonStyles.hidden,
-          ]}
+          style={combineStyles(
+            {...styles.screenBlock, width: appWidth},
+            !(isPaused && playspacePhoneFrame) && commonStyles.hidden
+          )}
         />
       </div>
     );
   }
 }
+
+const combineStyles = (...styles) =>
+  Object.assign({}, ...styles.filter(Boolean));
 
 const styles = {
   nonResponsive: {
@@ -140,4 +146,4 @@ export default connect(state => ({
   playspacePhoneFrame: state.pageConstants.playspacePhoneFrame,
   isResponsive: isResponsiveFromState(state),
   widgetMode: state.pageConstants.widgetMode,
-}))(Radium(Visualization));
+}))(Visualization);

--- a/apps/src/metrics/AnalyticsConstants.js
+++ b/apps/src/metrics/AnalyticsConstants.js
@@ -460,7 +460,7 @@ const EVENTS = {
   // Import project
   APPLAB_IMPORT_PROJECT: 'User Imports Another App Lab Project',
 
-  // Curriculumm Recommender
+  // Curriculum Recommender
   RECOMMENDED_CATALOG_CURRICULUM_SHOWN: 'Recommended Catalog Curriculum Shown',
   RECOMMENDED_SIMILAR_CURRICULUM_CLICKED:
     'Recommended Similar Curriculum Clicked',

--- a/apps/src/metrics/AnalyticsConstants.js
+++ b/apps/src/metrics/AnalyticsConstants.js
@@ -457,6 +457,9 @@ const EVENTS = {
   // Export app
   EXPORT_APP: 'User Exports App From Share Advanced Options',
 
+  // Import project
+  APPLAB_IMPORT_PROJECT: 'User Imports Another App Lab Project',
+
   // Curriculumm Recommender
   RECOMMENDED_CATALOG_CURRICULUM_SHOWN: 'Recommended Catalog Curriculum Shown',
   RECOMMENDED_SIMILAR_CURRICULUM_CLICKED:


### PR DESCRIPTION
You can import screens from one project into another App Lab project! [support article](https://studio.code.org/docs/concepts/app-lab/design-mode/importing-screens/)

This PR does two things: 

1.) It logs a Statsig event when a user tries to import a project from one App Lab project into another. Confession: I had no idea we had this feature so I was curious about whether it actually gets used and with what frequency. 

<img width="388" height="75" alt="Screenshot 2025-12-03 at 11 18 18 AM" src="https://github.com/user-attachments/assets/0438c8db-9018-447a-9009-3c1ddbfdef9b" />

2.) Refactors `ImportScreensDialog` and `Visualization` components to no longer use Radium since Radium is deprecated and I'm on a side quest to get experiment with getting Codex to successfully do tedious tasks for me. 😁 Continuation from: https://github.com/code-dot-org/code-dot-org/pull/69264