### PR TITLE
Codebridge: fix dropdown persistence issue in the File Manager

### DIFF
--- a/apps/src/codebridge/PopUpButton/PopUpButton.tsx
+++ b/apps/src/codebridge/PopUpButton/PopUpButton.tsx
@@ -46,6 +46,7 @@ export const PopUpButton = ({
   // rendered in a portal, outside of the main lab container.
   const {theme} = useTheme();
 
+  // Handler to close the dropdown.
   const setIsOpenFalse = useCallback(() => {
     setIsOpen(false);
     document.removeEventListener('click', setIsOpenFalse);
@@ -64,6 +65,7 @@ export const PopUpButton = ({
     }, 0);
   }, [setIsOpen, className]);
 
+  // Handler to show the dropdown.
   const clickHandler = useCallback(
     (
       e:
@@ -76,8 +78,8 @@ export const PopUpButton = ({
       setIsOpen(oldIsOpen => {
         const newIsOpen = !oldIsOpen;
         if (newIsOpen) {
-          // Close any other open dropdowns before opening this one
-          // Use setTimeout to avoid updating another component during render
+          // Close any other open dropdowns before opening this one.
+          // Use setTimeout to avoid updating another component during render.
           if (currentOpenDropdown && currentOpenDropdown !== setIsOpenFalse) {
             const closeOtherDropdown = currentOpenDropdown;
             setTimeout(() => closeOtherDropdown(), 0);
@@ -94,6 +96,7 @@ export const PopUpButton = ({
           );
         } else {
           document.removeEventListener('click', setIsOpenFalse);
+
           // Clear the currentOpenDropdown variable when closing
           if (currentOpenDropdown === setIsOpenFalse) {
             currentOpenDropdown = null;

--- a/apps/src/codebridge/PopUpButton/PopUpButton.tsx
+++ b/apps/src/codebridge/PopUpButton/PopUpButton.tsx
@@ -45,6 +45,8 @@ export const PopUpButton = ({
   const dropdownRef = useRef<HTMLDivElement | null>(null);
   // Unique identifier for current dropdown instance
   const instanceId = useRef(createUuid());
+  // Track pending timeouts for cleanup
+  const timeoutsRef = useRef<Set<NodeJS.Timeout>>(new Set());
 
   // We need to set the theme here because the dropdown is
   // rendered in a portal, outside of the main lab container.
@@ -56,9 +58,11 @@ export const PopUpButton = ({
       const customEvent = e as CustomEvent<{sourceId: string}>;
       if (customEvent.detail.sourceId !== instanceId.current) {
         // Defer state update to avoid updating during render
-        setTimeout(() => {
+        const timeoutId = setTimeout(() => {
           setIsOpen(false);
+          timeoutsRef.current.delete(timeoutId);
         }, 0);
+        timeoutsRef.current.add(timeoutId);
       }
     };
     document.addEventListener(CLOSE_OTHER_DROPDOWNS_EVENT, handleCloseOthers);
@@ -78,9 +82,11 @@ export const PopUpButton = ({
     buttonElementRef.current?.blur();
 
     // Because this operates on a delay, update the styles on a delay too
-    setTimeout(() => {
+    const timeoutId = setTimeout(() => {
       setComputedButtonStyles(className);
+      timeoutsRef.current.delete(timeoutId);
     }, 0);
+    timeoutsRef.current.add(timeoutId);
   }, [setIsOpen, className]);
 
   // Handler to show the dropdown.
@@ -105,10 +111,11 @@ export const PopUpButton = ({
 
           // Defer adding the close handler until the next tick of the event
           // loop, otherwise it'll fire immediately and re-close the pop up.
-          setTimeout(
-            () => document.addEventListener('click', setIsOpenFalse),
-            0
-          );
+          const timeoutId = setTimeout(() => {
+            document.addEventListener('click', setIsOpenFalse);
+            timeoutsRef.current.delete(timeoutId);
+          }, 0);
+          timeoutsRef.current.add(timeoutId);
         } else {
           document.removeEventListener('click', setIsOpenFalse);
         }
@@ -132,14 +139,16 @@ export const PopUpButton = ({
               ? buttonRect.right - dropdownRect.width + window.scrollX
               : buttonRect.left + window.scrollX;
           // Defer all state updates to avoid updating during render
-          setTimeout(() => {
+          const timeoutId = setTimeout(() => {
             setDropdownStyles({
               top,
               left,
             });
             setUpdatedStyles(true);
             setComputedButtonStyles(classNames(className, moduleStyles.active));
+            timeoutsRef.current.delete(timeoutId);
           }, 0);
+          timeoutsRef.current.add(timeoutId);
         }
       }
     };
@@ -151,6 +160,20 @@ export const PopUpButton = ({
       window.removeEventListener('resize', updateDropdownPositionIfShown);
     };
   }, [alignment, buttonRef, isOpen, className]);
+
+  // Clear all pending timeouts and event listeners on unmount
+  // to prevent memory leaks and state updates after unmount.
+  useEffect(() => {
+    const timeouts = timeoutsRef.current;
+    return () => {
+      // Clear all pending timeouts to prevent state updates after unmount
+      timeouts.forEach(timeoutId => clearTimeout(timeoutId));
+      timeouts.clear();
+
+      // Remove click event listener if it exists
+      document.removeEventListener('click', setIsOpenFalse);
+    };
+  }, [setIsOpenFalse]);
 
   // We wait to make the dropdown visible until we've calculated the position
   // it should be in based on its own width and the size of the button.

--- a/apps/src/codebridge/PopUpButton/PopUpButton.tsx
+++ b/apps/src/codebridge/PopUpButton/PopUpButton.tsx
@@ -36,10 +36,12 @@ export const PopUpButton = ({
   const [isOpen, setIsOpen] = useState(false);
   const [buttonRef, setButtonRef] = useState<HTMLElement | null>(null);
   const [dropdownStyles, setDropdownStyles] = useState<React.CSSProperties>({});
-  const dropdownRef = useRef<HTMLDivElement | null>(null);
-  const buttonElementRef = useRef<HTMLButtonElement | null>(null);
   const [updatedStyles, setUpdatedStyles] = useState(false);
   const [computedButtonStyles, setComputedButtonStyles] = useState(className);
+  // Get the button element ref to remove focus when closing the dropdown
+  const buttonElementRef = useRef<HTMLButtonElement | null>(null);
+  const dropdownRef = useRef<HTMLDivElement | null>(null);
+
   // We need to set the theme here because the dropdown is
   // rendered in a portal, outside of the main lab container.
   const {theme} = useTheme();
@@ -47,12 +49,15 @@ export const PopUpButton = ({
   const setIsOpenFalse = useCallback(() => {
     setIsOpen(false);
     document.removeEventListener('click', setIsOpenFalse);
+
     // Clear the currentOpenDropdown variable when closing
     if (currentOpenDropdown === setIsOpenFalse) {
       currentOpenDropdown = null;
     }
+
     // Remove focus from the button when closing the dropdown
     buttonElementRef.current?.blur();
+
     // Because this operates on a delay, update the styles on a delay too
     setTimeout(() => {
       setComputedButtonStyles(className);
@@ -74,14 +79,15 @@ export const PopUpButton = ({
           // Close any other open dropdowns before opening this one
           // Use setTimeout to avoid updating another component during render
           if (currentOpenDropdown && currentOpenDropdown !== setIsOpenFalse) {
-            const closeOpenDropdown = currentOpenDropdown;
-            setTimeout(() => closeOpenDropdown(), 0);
+            const closeOtherDropdown = currentOpenDropdown;
+            setTimeout(() => closeOtherDropdown(), 0);
           }
+
           // Track this dropdown as the currently open one
           currentOpenDropdown = setIsOpenFalse;
-          // React 17 changed the location where click handlers are added, so we want
-          // to defer adding the close handler until the next tick of the event loop,
-          // otherwise it'll fire immediately and re-close the pop up.'
+
+          // Defer adding the close handler until the next tick of the event
+          // loop, otherwise it'll fire immediately and re-close the pop up.
           setTimeout(
             () => document.addEventListener('click', setIsOpenFalse),
             0

--- a/apps/src/codebridge/PopUpButton/PopUpButton.tsx
+++ b/apps/src/codebridge/PopUpButton/PopUpButton.tsx
@@ -37,6 +37,7 @@ export const PopUpButton = ({
   const [buttonRef, setButtonRef] = useState<HTMLElement | null>(null);
   const [dropdownStyles, setDropdownStyles] = useState<React.CSSProperties>({});
   const dropdownRef = useRef<HTMLDivElement | null>(null);
+  const buttonElementRef = useRef<HTMLButtonElement | null>(null);
   const [updatedStyles, setUpdatedStyles] = useState(false);
   const [computedButtonStyles, setComputedButtonStyles] = useState(className);
   // We need to set the theme here because the dropdown is
@@ -50,10 +51,12 @@ export const PopUpButton = ({
     if (currentOpenDropdown === setIsOpenFalse) {
       currentOpenDropdown = null;
     }
-    // Because this operates on a delay, we also have to update the styles on a delay
+    // Remove focus from the button when closing the dropdown
+    buttonElementRef.current?.blur();
+    // Because this operates on a delay, update the styles on a delay too
     setTimeout(() => {
       setComputedButtonStyles(className);
-    }, 300);
+    }, 0);
   }, [setIsOpen, className]);
 
   const clickHandler = useCallback(
@@ -138,6 +141,7 @@ export const PopUpButton = ({
   return (
     <>
       <Button
+        ref={buttonElementRef}
         className={computedButtonStyles}
         size="xs"
         icon={{iconStyle: 'solid', iconName}}

--- a/apps/src/codebridge/PopUpButton/PopUpButton.tsx
+++ b/apps/src/codebridge/PopUpButton/PopUpButton.tsx
@@ -39,14 +39,14 @@ export const PopUpButton = ({
   const dropdownRef = useRef<HTMLDivElement | null>(null);
   const [updatedStyles, setUpdatedStyles] = useState(false);
   const [computedButtonStyles, setComputedButtonStyles] = useState(className);
-  // We need to set the theme here because the dropdown is rendered in a portal, outside of the
-  // main lab container.
+  // We need to set the theme here because the dropdown is
+  // rendered in a portal, outside of the main lab container.
   const {theme} = useTheme();
 
   const setIsOpenFalse = useCallback(() => {
     setIsOpen(false);
     document.removeEventListener('click', setIsOpenFalse);
-    // Clear the global dropdown reference when closing
+    // Clear the currentOpenDropdown variable when closing
     if (currentOpenDropdown === setIsOpenFalse) {
       currentOpenDropdown = null;
     }
@@ -71,8 +71,8 @@ export const PopUpButton = ({
           // Close any other open dropdowns before opening this one
           // Use setTimeout to avoid updating another component during render
           if (currentOpenDropdown && currentOpenDropdown !== setIsOpenFalse) {
-            const closeOther = currentOpenDropdown;
-            setTimeout(() => closeOther(), 0);
+            const closeOpenDropdown = currentOpenDropdown;
+            setTimeout(() => closeOpenDropdown(), 0);
           }
           // Track this dropdown as the currently open one
           currentOpenDropdown = setIsOpenFalse;
@@ -85,7 +85,7 @@ export const PopUpButton = ({
           );
         } else {
           document.removeEventListener('click', setIsOpenFalse);
-          // Clear the global dropdown reference when closing
+          // Clear the currentOpenDropdown variable when closing
           if (currentOpenDropdown === setIsOpenFalse) {
             currentOpenDropdown = null;
           }

--- a/apps/src/codebridge/PopUpButton/PopUpButton.tsx
+++ b/apps/src/codebridge/PopUpButton/PopUpButton.tsx
@@ -20,6 +20,9 @@ type PopUpButtonProps = {
 
 const TOP_PADDING = 5;
 
+// Track which dropdown is currently open
+let currentOpenDropdown: (() => void) | null = null;
+
 export const PopUpButton = ({
   children,
   iconName,
@@ -43,6 +46,10 @@ export const PopUpButton = ({
   const setIsOpenFalse = useCallback(() => {
     setIsOpen(false);
     document.removeEventListener('click', setIsOpenFalse);
+    // Clear the global dropdown reference when closing
+    if (currentOpenDropdown === setIsOpenFalse) {
+      currentOpenDropdown = null;
+    }
     // Because this operates on a delay, we also have to update the styles on a delay
     setTimeout(() => {
       setComputedButtonStyles(className);
@@ -61,6 +68,14 @@ export const PopUpButton = ({
       setIsOpen(oldIsOpen => {
         const newIsOpen = !oldIsOpen;
         if (newIsOpen) {
+          // Close any other open dropdowns before opening this one
+          // Use setTimeout to avoid updating another component during render
+          if (currentOpenDropdown && currentOpenDropdown !== setIsOpenFalse) {
+            const closeOther = currentOpenDropdown;
+            setTimeout(() => closeOther(), 0);
+          }
+          // Track this dropdown as the currently open one
+          currentOpenDropdown = setIsOpenFalse;
           // React 17 changed the location where clickhandlers are added, so we want to defer adding the close
           // handler until the next tick of the event loop, otherwise it'll fire immediately and re-close the pop up.'
           setTimeout(
@@ -69,6 +84,10 @@ export const PopUpButton = ({
           );
         } else {
           document.removeEventListener('click', setIsOpenFalse);
+          // Clear the global dropdown reference when closing
+          if (currentOpenDropdown === setIsOpenFalse) {
+            currentOpenDropdown = null;
+          }
         }
         return newIsOpen;
       });

--- a/apps/src/codebridge/PopUpButton/PopUpButton.tsx
+++ b/apps/src/codebridge/PopUpButton/PopUpButton.tsx
@@ -39,7 +39,7 @@ export const PopUpButton = ({
   const dropdownRef = useRef<HTMLDivElement | null>(null);
   const [updatedStyles, setUpdatedStyles] = useState(false);
   const [computedButtonStyles, setComputedButtonStyles] = useState(className);
-  // We need to set the theme here becausse the dropdown is rendered in a portal, outside of the
+  // We need to set the theme here because the dropdown is rendered in a portal, outside of the
   // main lab container.
   const {theme} = useTheme();
 
@@ -76,8 +76,9 @@ export const PopUpButton = ({
           }
           // Track this dropdown as the currently open one
           currentOpenDropdown = setIsOpenFalse;
-          // React 17 changed the location where clickhandlers are added, so we want to defer adding the close
-          // handler until the next tick of the event loop, otherwise it'll fire immediately and re-close the pop up.'
+          // React 17 changed the location where click handlers are added, so we want
+          // to defer adding the close handler until the next tick of the event loop,
+          // otherwise it'll fire immediately and re-close the pop up.'
           setTimeout(
             () => document.addEventListener('click', setIsOpenFalse),
             0

--- a/apps/src/codebridge/PopUpButton/PopUpButton.tsx
+++ b/apps/src/codebridge/PopUpButton/PopUpButton.tsx
@@ -20,7 +20,7 @@ type PopUpButtonProps = {
 
 const TOP_PADDING = 5;
 
-// Track which dropdown is currently open
+// Global state to track which dropdown is currently open
 let currentOpenDropdown: (() => void) | null = null;
 
 export const PopUpButton = ({
@@ -51,7 +51,7 @@ export const PopUpButton = ({
     setIsOpen(false);
     document.removeEventListener('click', setIsOpenFalse);
 
-    // Clear the currentOpenDropdown variable when closing
+    // Clear the global currentOpenDropdown reference when closing
     if (currentOpenDropdown === setIsOpenFalse) {
       currentOpenDropdown = null;
     }
@@ -97,7 +97,7 @@ export const PopUpButton = ({
         } else {
           document.removeEventListener('click', setIsOpenFalse);
 
-          // Clear the currentOpenDropdown variable when closing
+          // Clear the global currentOpenDropdown reference when closing
           if (currentOpenDropdown === setIsOpenFalse) {
             currentOpenDropdown = null;
           }

--- a/apps/src/codebridge/PopUpButton/PopUpButton.tsx
+++ b/apps/src/codebridge/PopUpButton/PopUpButton.tsx
@@ -5,6 +5,8 @@ import FocusTrap from 'focus-trap-react';
 import React, {useState, useCallback, useRef, useEffect} from 'react';
 import {createPortal} from 'react-dom';
 
+import {createUuid} from '@cdo/apps/utils';
+
 import moduleStyles from './pop-up-button.module.scss';
 
 type PopUpButtonProps = {
@@ -20,8 +22,8 @@ type PopUpButtonProps = {
 
 const TOP_PADDING = 5;
 
-// Global state to track which dropdown is currently open
-let currentOpenDropdown: (() => void) | null = null;
+// Custom event used to coordinate closing other dropdowns when one opens
+const CLOSE_OTHER_DROPDOWNS_EVENT = 'popupbutton:close';
 
 export const PopUpButton = ({
   children,
@@ -41,22 +43,38 @@ export const PopUpButton = ({
   // Get the button element ref to remove focus when closing the dropdown
   const buttonElementRef = useRef<HTMLButtonElement | null>(null);
   const dropdownRef = useRef<HTMLDivElement | null>(null);
+  // Unique identifier for current dropdown instance
+  const instanceId = useRef(createUuid());
 
   // We need to set the theme here because the dropdown is
   // rendered in a portal, outside of the main lab container.
   const {theme} = useTheme();
+
+  // Listen for close events from other dropdowns
+  useEffect(() => {
+    const handleCloseOthers = (e: Event) => {
+      const customEvent = e as CustomEvent<{sourceId: string}>;
+      if (customEvent.detail.sourceId !== instanceId.current) {
+        // Defer state update to avoid updating during render
+        setTimeout(() => {
+          setIsOpen(false);
+        }, 0);
+      }
+    };
+    document.addEventListener(CLOSE_OTHER_DROPDOWNS_EVENT, handleCloseOthers);
+    return () =>
+      document.removeEventListener(
+        CLOSE_OTHER_DROPDOWNS_EVENT,
+        handleCloseOthers
+      );
+  }, []);
 
   // Handler to close the dropdown.
   const setIsOpenFalse = useCallback(() => {
     setIsOpen(false);
     document.removeEventListener('click', setIsOpenFalse);
 
-    // Clear the global currentOpenDropdown reference when closing
-    if (currentOpenDropdown === setIsOpenFalse) {
-      currentOpenDropdown = null;
-    }
-
-    // Remove focus from the button when closing the dropdown
+    // Remove focus from the menu button when closing the dropdown
     buttonElementRef.current?.blur();
 
     // Because this operates on a delay, update the styles on a delay too
@@ -78,15 +96,12 @@ export const PopUpButton = ({
       setIsOpen(oldIsOpen => {
         const newIsOpen = !oldIsOpen;
         if (newIsOpen) {
-          // Close any other open dropdowns before opening this one.
-          // Use setTimeout to avoid updating another component during render.
-          if (currentOpenDropdown && currentOpenDropdown !== setIsOpenFalse) {
-            const closeOtherDropdown = currentOpenDropdown;
-            setTimeout(() => closeOtherDropdown(), 0);
-          }
-
-          // Track this dropdown as the currently open one
-          currentOpenDropdown = setIsOpenFalse;
+          // Tell other dropdowns to close
+          document.dispatchEvent(
+            new CustomEvent(CLOSE_OTHER_DROPDOWNS_EVENT, {
+              detail: {sourceId: instanceId.current},
+            })
+          );
 
           // Defer adding the close handler until the next tick of the event
           // loop, otherwise it'll fire immediately and re-close the pop up.
@@ -96,11 +111,6 @@ export const PopUpButton = ({
           );
         } else {
           document.removeEventListener('click', setIsOpenFalse);
-
-          // Clear the global currentOpenDropdown reference when closing
-          if (currentOpenDropdown === setIsOpenFalse) {
-            currentOpenDropdown = null;
-          }
         }
         return newIsOpen;
       });
@@ -121,12 +131,15 @@ export const PopUpButton = ({
             alignment === 'right'
               ? buttonRect.right - dropdownRect.width + window.scrollX
               : buttonRect.left + window.scrollX;
-          setDropdownStyles({
-            top,
-            left,
-          });
-          setUpdatedStyles(true);
-          setComputedButtonStyles(classNames(className, moduleStyles.active));
+          // Defer all state updates to avoid updating during render
+          setTimeout(() => {
+            setDropdownStyles({
+              top,
+              left,
+            });
+            setUpdatedStyles(true);
+            setComputedButtonStyles(classNames(className, moduleStyles.active));
+          }, 0);
         }
       }
     };


### PR DESCRIPTION
Fixes an issue where more than one dropdown can be opened at the same time in the Codebridge File Manager. Also hides the focus state on the menu button when clicking away from a dropdown.

_Note:_ I cleaned up the structure of this file a bit and updated some comments.

## Links
Jira ticket: [AFL-364](https://codedotorg.atlassian.net/browse/AFL-364)

## Testing story
Tested locally across browsers

----

## Before


https://github.com/user-attachments/assets/eef71b87-af10-4851-96a8-44bba41f5b58



## After


https://github.com/user-attachments/assets/69365f5f-6062-4f5a-9e0f-6867900fa09b

