### PR TITLE
Deprecate firehose logging

### DIFF
--- a/apps/src/metrics/firehose.js
+++ b/apps/src/metrics/firehose.js
@@ -1,4 +1,8 @@
 /** @file Provides clients to AWS Firehose, whose data is imported into AWS Redshift. */
+/**
+ * @deprecated We will be deprecating Firehose in favor of a different analytics solution.
+ * Please do not add new uses of this module.
+ */
 
 import logToCloud from '@cdo/apps/logToCloud';
 import {getStore} from '@cdo/apps/redux';
@@ -297,6 +301,10 @@ class FirehoseClient {
 }
 
 // Verifies that given data will not fail firehose batch
+/**
+ * @deprecated We will be deprecating Firehose in favor of a different analytics solution.
+ * Please do not add new uses of this module.
+ */
 function validateFirehoseDataSize(data) {
   const json_size = new Blob([data?.data_json]).size;
   const string_size = new Blob([data?.data_string]).size;
@@ -378,12 +386,20 @@ function getSingleton() {
   return promise;
 }
 
+/**
+ * @deprecated We will be deprecating Firehose in favor of a different analytics solution.
+ * Please do not add new uses of this module.
+ */
 function putRecord(data, options) {
   return getSingleton().then(firehoseClient =>
     firehoseClient.putRecord(data, options)
   );
 }
 
+/**
+ * @deprecated We will be deprecating Firehose in favor of a different analytics solution.
+ * Please do not add new uses of this module.
+ */
 function putRecordBatch(data, options) {
   return getSingleton().then(firehoseClient =>
     firehoseClient.putRecordBatch(data, options)

--- a/lib/cdo/firehose.rb
+++ b/lib/cdo/firehose.rb
@@ -4,6 +4,7 @@ require 'aws-sdk-firehose'
 require 'active_support/core_ext/module/attribute_accessors'
 
 # A wrapper client to the AWS Firehose service.
+# @deprecated We will be deprecating Firehose in favor of a different analytics solution. Please do not add new uses of this module.
 class FirehoseClient
   include Singleton
 
@@ -124,6 +125,7 @@ class FirehoseClient
   # Posts a record to the analytics stream.
   # @param stream [Symbol] The Firehose Stream to send the data to. A Symbol in the STREAMS hash.
   # @param data [Hash] The data to insert into the stream.
+  # @deprecated We will be deprecating Firehose in favor of a different analytics solution. Please do not add new uses of this module.
   def put_record(stream, data)
     return unless Gatekeeper.allows('firehose', default: true)
     raise ArgumentError.new("stream must be defined") if stream.nil? || stream.blank?


### PR DESCRIPTION
To consolidate logging efforts and increase security, we want to remove Firehose logging entirely. The first step in this process is to deprecate current Firehose usages. This PR deprecates the logging methods in `firehose.js` and `firehose.rb`, discouraging new use of Firehose. This PR does **not** change current Firehose implementations. 

<img width="973" height="436" alt="Screenshot 2025-12-03 at 3 33 30 PM" src="https://github.com/user-attachments/assets/26d2e844-f793-46be-aa1c-679872a70630" />

<img width="505" height="367" alt="Screenshot 2025-12-03 at 3 32 12 PM" src="https://github.com/user-attachments/assets/9130e533-01d3-4de2-bb4b-c764c7895fa2" />

## Links

- Jira: [INF-1783](https://codedotorg.atlassian.net/browse/INF-1783)


## Follow-up work
- [INF-1357](https://codedotorg.atlassian.net/browse/INF-1357): Continue removing Firehose logging and replacing the current events with other implementations or deleting them entirely.

## Deployment Strategy
- Make an announcement at eng weekly regarding the deprecation of Firehose.

## Security
This is the first step in securing our event analytics pipeline
