### PR TITLE
Prevents race between the DOM load and the localization entrypoint.

### DIFF
--- a/apps/src/localization/entrypoint.js
+++ b/apps/src/localization/entrypoint.js
@@ -161,7 +161,7 @@ function loadLocalize() {
     };
 
     // When the site loads, ensure the language selector has the correct value
-    document.addEventListener('DOMContentLoaded', () => {
+    const onDOMLoad = () => {
       const localeSelect =
         document.querySelector('#locale') ||
         document.querySelector("select[name='locale']");
@@ -180,7 +180,14 @@ function loadLocalize() {
         localeSelect.addEventListener('change', handleChange);
       }
       ensureSelector(cdoLanguage);
-    });
+    };
+
+    if (document.readyState === 'loading') {
+      document.addEventListener('DOMContentLoaded', onDOMLoad);
+    } else {
+      // 'interactive' or 'complete' — DOMContentLoaded has already fired
+      onDOMLoad();
+    }
 
     // Translate everything in the Blockly message pool
     ensureSelector(cdoLanguage);


### PR DESCRIPTION
Fixes a rare but pernicious race condition that breaks the locale dropdown for LocalizeJS-enabled pages, such as the Hour of AI.

## Warning!!

We have entered Pixel Lock for Hour of AI! All merges to the `staging` branch from Dec 2 through Dec 12 must go through live change review and be deemed critical for supporting the Hour of AI. External contributions will not be accepted at this time.

For non-critical changes, please change your base to `staging-next` and delete this warning. We will merge `staging-next` into `staging` on Dec 15, 2025.

<!-- end warning -->


<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Testing story
<!--  Does your change include appropriate tests?
      - If so, please describe how the tests included in this PR are sufficient.
      - If not, please explain why this change does not need to be tested. -->



## Deployment strategy
<!--  Any special steps required to deploy this, besides merging?
      - Are there database migrations or manual steps?
      - Does this require coordination with other teams or systems? -->



## Follow-up work
<!--  List any clean-up or technical debt that will be addressed in future work.
      - Include Jira links where applicable.
      - Are there any known limitations or improvements planned? -->



## Privacy
<!--  How does this change impact Student & Teacher privacy?
      - Does this collect, use, share, or modify PII, either new or existing? -->



## Security
<!--  How does this change impact our security surface-area?
      - Do API's touched have the right auth?
      - Do infra changes impact our attack surface or encryption?
-->



## Caching
<!--  How does this change impact caching behavior?
      - Are cache keys or invalidation strategies affected?
      - Will this require cache warming or invalidation after deployment? -->



## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
