### PR TITLE
Levelbuilder tidy: update vocabulary delete dialogs

### DIFF
--- a/apps/src/levelbuilder/AllVocabulariesEditor.jsx
+++ b/apps/src/levelbuilder/AllVocabulariesEditor.jsx
@@ -3,7 +3,11 @@ import React, {Component} from 'react';
 import {connect} from 'react-redux';
 import * as Table from 'reactabular-table';
 
-import Dialog from '@cdo/apps/legacySharedComponents/Dialog';
+// import Dialog from '@cdo/apps/legacySharedComponents/Dialog';
+
+import Dialog from '@code-dot-org/component-library/dialog';
+import {buttonColors} from '@code-dot-org/component-library/button';
+
 import {
   addVocabulary,
   updateVocabulary,
@@ -118,6 +122,10 @@ class AllVocabulariesEditor extends Component {
   };
 
   handleDeleteVocabularyConfirm = () => {
+    console.log(
+      'handleDeleteVocabularyConfirm called',
+      this.state.vocabularyForDeletion
+    );
     this.props.removeVocabulary(this.state.vocabularyForDeletion.key);
     this.handleDeleteVocabularyDialogClose();
   };
@@ -158,14 +166,26 @@ class AllVocabulariesEditor extends Component {
         )}
         {this.state.vocabularyForDeletion && (
           <Dialog
-            body={`Are you sure you want to permanently delete vocabulary "${this.state.vocabularyForDeletion.word}"?`}
-            cancelText="Cancel"
-            confirmText="Delete"
-            confirmType="danger"
-            isOpen={true}
-            handleClose={this.handleDeleteVocabularyDialogClose}
-            onCancel={this.handleDeleteVocabularyDialogClose}
-            onConfirm={this.handleDeleteVocabularyConfirm}
+            title="Delete Vocabulary"
+            description={`Are you sure you want to permanently delete vocabulary "${this.state.vocabularyForDeletion.word}"?`}
+            onClose={() => this.handleDeleteVocabularyDialogClose()}
+            primaryButtonProps={{
+              text: `Delete`,
+              size: 's',
+              onClick: () => {
+                this.handleDeleteVocabularyConfirm();
+              },
+              color: buttonColors.destructive,
+            }}
+            secondaryButtonProps={{
+              size: 's',
+              text: 'Cancel',
+              type: 'secondary',
+              color: buttonColors.gray,
+              onClick: () => {
+                this.handleDeleteVocabularyDialogClose();
+              },
+            }}
           />
         )}
 

--- a/apps/src/levelbuilder/AllVocabulariesEditor.jsx
+++ b/apps/src/levelbuilder/AllVocabulariesEditor.jsx
@@ -137,6 +137,7 @@ class AllVocabulariesEditor extends Component {
             onClick={this.handleAddVocabularyClick}
             style={styles.addButton}
             type="button"
+            className="unit-test-add-vocabulary"
           >
             <i className="fa fa-plus" style={{marginRight: 7}} />
             Create New Vocabulary

--- a/apps/src/levelbuilder/AllVocabulariesEditor.jsx
+++ b/apps/src/levelbuilder/AllVocabulariesEditor.jsx
@@ -117,7 +117,7 @@ class AllVocabulariesEditor extends Component {
     });
   };
 
-  handleDeleteVocabularyConfirm = async () => {
+  handleDeleteVocabularyConfirm = () => {
     this.props.removeVocabulary(this.state.vocabularyForDeletion.key);
     this.handleDeleteVocabularyDialogClose();
   };

--- a/apps/src/levelbuilder/AllVocabulariesEditor.jsx
+++ b/apps/src/levelbuilder/AllVocabulariesEditor.jsx
@@ -3,11 +3,6 @@ import React, {Component} from 'react';
 import {connect} from 'react-redux';
 import * as Table from 'reactabular-table';
 
-// import Dialog from '@cdo/apps/legacySharedComponents/Dialog';
-
-import Dialog from '@code-dot-org/component-library/dialog';
-import {buttonColors} from '@code-dot-org/component-library/button';
-
 import {
   addVocabulary,
   updateVocabulary,
@@ -16,6 +11,7 @@ import {
 import {vocabularyShape} from '@cdo/apps/levelbuilder/shapes';
 
 import AddVocabularyDialog from './lesson-editor/AddVocabularyDialog';
+import DeleteVocabularyDialog from './lesson-editor/DeleteVocabularyDialog';
 import {lessonEditorTableStyles} from './lesson-editor/TableConstants';
 
 class AllVocabulariesEditor extends Component {
@@ -121,11 +117,7 @@ class AllVocabulariesEditor extends Component {
     });
   };
 
-  handleDeleteVocabularyConfirm = () => {
-    console.log(
-      'handleDeleteVocabularyConfirm called',
-      this.state.vocabularyForDeletion
-    );
+  handleDeleteVocabularyConfirm = async () => {
     this.props.removeVocabulary(this.state.vocabularyForDeletion.key);
     this.handleDeleteVocabularyDialogClose();
   };
@@ -165,30 +157,14 @@ class AllVocabulariesEditor extends Component {
           />
         )}
         {this.state.vocabularyForDeletion && (
-          <Dialog
-            title="Delete Vocabulary"
-            description={`Are you sure you want to permanently delete vocabulary "${this.state.vocabularyForDeletion.word}"?`}
-            onClose={() => this.handleDeleteVocabularyDialogClose()}
-            primaryButtonProps={{
-              text: `Delete`,
-              size: 's',
-              onClick: () => {
-                this.handleDeleteVocabularyConfirm();
-              },
-              color: buttonColors.destructive,
-            }}
-            secondaryButtonProps={{
-              size: 's',
-              text: 'Cancel',
-              type: 'secondary',
-              color: buttonColors.gray,
-              onClick: () => {
-                this.handleDeleteVocabularyDialogClose();
-              },
-            }}
+          <DeleteVocabularyDialog
+            vocabularyForDeletion={this.state.vocabularyForDeletion}
+            handleDeleteVocabularyConfirm={this.handleDeleteVocabularyConfirm}
+            handleDeleteVocabularyDialogClose={
+              this.handleDeleteVocabularyDialogClose
+            }
           />
         )}
-
         <Table.Provider columns={columns} style={{width: '100%'}}>
           <Table.Header />
           <Table.Body rows={this.props.vocabularies} rowKey="key" />

--- a/apps/src/levelbuilder/lesson-editor/DeleteVocabularyDialog.jsx
+++ b/apps/src/levelbuilder/lesson-editor/DeleteVocabularyDialog.jsx
@@ -32,6 +32,7 @@ class DeleteVocabularyDialog extends Component {
     } catch (err) {
       alert('Failed to delete vocabulary.');
     }
+  };
 
   render() {
     const {handleDeleteVocabularyDialogClose, vocabularyForDeletion} =

--- a/apps/src/levelbuilder/lesson-editor/DeleteVocabularyDialog.jsx
+++ b/apps/src/levelbuilder/lesson-editor/DeleteVocabularyDialog.jsx
@@ -23,15 +23,15 @@ class DeleteVocabularyDialog extends Component {
           },
         }
       );
-      if (!response.ok) {
+      if (response.ok) {
+        this.props.handleDeleteVocabularyConfirm();
+      } else {
         const data = await response.json();
         alert(data.message || 'Failed to delete vocabulary.');
       }
     } catch (err) {
       alert('Failed to delete vocabulary.');
     }
-    this.props.handleDeleteVocabularyConfirm();
-  };
 
   render() {
     const {handleDeleteVocabularyDialogClose, vocabularyForDeletion} =

--- a/apps/src/levelbuilder/lesson-editor/DeleteVocabularyDialog.jsx
+++ b/apps/src/levelbuilder/lesson-editor/DeleteVocabularyDialog.jsx
@@ -1,0 +1,66 @@
+import {buttonColors} from '@code-dot-org/component-library/button';
+import Dialog from '@code-dot-org/component-library/dialog';
+import PropTypes from 'prop-types';
+import React, {Component} from 'react';
+
+class DeleteVocabularyDialog extends Component {
+  static propTypes = {
+    handleDeleteVocabularyConfirm: PropTypes.func.isRequired,
+    handleDeleteVocabularyDialogClose: PropTypes.func.isRequired,
+    vocabularyForDeletion: PropTypes.object.isRequired,
+  };
+
+  deleteVocabulary = async () => {
+    try {
+      const response = await fetch(
+        `/vocabularies/${this.props.vocabularyForDeletion.id}`,
+        {
+          method: 'DELETE',
+          headers: {
+            'Content-Type': 'application/json',
+            'X-CSRF-Token':
+              document.querySelector('meta[name="csrf-token"]')?.content || '',
+          },
+        }
+      );
+      if (!response.ok) {
+        const data = await response.json();
+        alert(data.message || 'Failed to delete vocabulary.');
+      }
+    } catch (err) {
+      alert('Failed to delete vocabulary.');
+    }
+    this.props.handleDeleteVocabularyConfirm();
+  };
+
+  render() {
+    const {handleDeleteVocabularyDialogClose, vocabularyForDeletion} =
+      this.props;
+    return (
+      <Dialog
+        title="Delete Vocabulary"
+        description={`Are you sure you want to permanently delete vocabulary "${vocabularyForDeletion.word}"?`}
+        onClose={() => handleDeleteVocabularyDialogClose()}
+        primaryButtonProps={{
+          text: `Delete`,
+          size: 's',
+          onClick: () => {
+            this.deleteVocabulary();
+          },
+          color: buttonColors.destructive,
+        }}
+        secondaryButtonProps={{
+          size: 's',
+          text: 'Cancel',
+          type: 'secondary',
+          color: buttonColors.gray,
+          onClick: () => {
+            handleDeleteVocabularyDialogClose();
+          },
+        }}
+      />
+    );
+  }
+}
+
+export default DeleteVocabularyDialog;

--- a/apps/src/levelbuilder/lesson-editor/DeleteVocabularyDialog.jsx
+++ b/apps/src/levelbuilder/lesson-editor/DeleteVocabularyDialog.jsx
@@ -43,6 +43,7 @@ class DeleteVocabularyDialog extends Component {
         description={`Are you sure you want to permanently delete vocabulary "${vocabularyForDeletion.word}"?`}
         onClose={() => handleDeleteVocabularyDialogClose()}
         primaryButtonProps={{
+          id: 'delete-vocabulary',
           text: `Delete`,
           size: 's',
           onClick: () => {
@@ -51,6 +52,7 @@ class DeleteVocabularyDialog extends Component {
           color: buttonColors.destructive,
         }}
         secondaryButtonProps={{
+          id: 'cancel-delete-vocabulary',
           size: 's',
           text: 'Cancel',
           type: 'secondary',

--- a/apps/src/levelbuilder/lesson-editor/VocabulariesEditor.jsx
+++ b/apps/src/levelbuilder/lesson-editor/VocabulariesEditor.jsx
@@ -3,7 +3,6 @@ import React, {Component} from 'react';
 import {connect} from 'react-redux';
 import * as Table from 'reactabular-table';
 
-import Dialog from '@cdo/apps/legacySharedComponents/Dialog';
 import {
   addVocabulary,
   updateVocabulary,
@@ -13,6 +12,7 @@ import {vocabularyShape} from '@cdo/apps/levelbuilder/shapes';
 import color from '@cdo/apps/util/color';
 
 import AddVocabularyDialog from './AddVocabularyDialog';
+import DeleteVocabularyDialog from './DeleteVocabularyDialog';
 import SearchBox from './SearchBox';
 import {lessonEditorTableStyles} from './TableConstants';
 
@@ -177,15 +177,12 @@ class VocabulariesEditor extends Component {
           />
         )}
         {this.state.confirmRemovalDialogOpen && (
-          <Dialog
-            body={`Are you sure you want to remove the vocabulary "${this.state.vocabularyForRemoval.word}" from this lesson?`}
-            cancelText="Cancel"
-            confirmText="Delete"
-            confirmType="danger"
-            isOpen={this.state.confirmRemovalDialogOpen}
-            handleClose={this.handleRemoveVocabularyDialogClose}
-            onCancel={this.handleRemoveVocabularyDialogClose}
-            onConfirm={this.handleRemoveVocabularyConfirm}
+          <DeleteVocabularyDialog
+            vocabularyForDeletion={this.state.vocabularyForDeletion}
+            handleDeleteVocabularyConfirm={this.handleDeleteVocabularyConfirm}
+            handleDeleteVocabularyDialogClose={
+              this.handleDeleteVocabularyDialogClose
+            }
           />
         )}
         <div style={styles.search}>

--- a/apps/src/levelbuilder/lesson-editor/VocabulariesEditor.jsx
+++ b/apps/src/levelbuilder/lesson-editor/VocabulariesEditor.jsx
@@ -178,7 +178,7 @@ class VocabulariesEditor extends Component {
         )}
         {this.state.confirmRemovalDialogOpen && (
           <DeleteVocabularyDialog
-            vocabularyForDeletion={this.state.vocabularyForDeletion}
+            vocabularyForDeletion={this.state.vocabularyForRemoval}
             handleDeleteVocabularyConfirm={this.handleDeleteVocabularyConfirm}
             handleDeleteVocabularyDialogClose={
               this.handleDeleteVocabularyDialogClose
@@ -206,6 +206,7 @@ class VocabulariesEditor extends Component {
           onClick={this.handleAddVocabularyClick}
           style={styles.addButton}
           type="button"
+          className="unit-test-add-vocabulary"
         >
           <i className="fa fa-plus" style={{marginRight: 7}} /> Create New
           Vocabulary

--- a/apps/test/unit/levelbuilder/AllVocabulariesEditorTest.js
+++ b/apps/test/unit/levelbuilder/AllVocabulariesEditorTest.js
@@ -39,8 +39,9 @@ describe('AllVocabulariesEditor', () => {
     expect(wrapper.find('tr').length).toBe(3);
   });
 
-  it('can remove a vocabulary', () => {
+  it('opens the delete vocabulary dialog', () => {
     const wrapper = mount(<AllVocabulariesEditor {...defaultProps} />);
+    expect(wrapper.find('Dialog').exists()).toBe(false);
     const numVocabularies = wrapper.find('tr').length;
     expect(numVocabularies).toBeGreaterThanOrEqual(2);
     // Find one of the "remove" buttons and click it
@@ -49,16 +50,21 @@ describe('AllVocabulariesEditor', () => {
       .first();
     removeVocabularyButton.simulate('mouseDown');
     const removeDialog = wrapper.find('Dialog');
-    const deleteButton = removeDialog.find('button').at(2);
-    deleteButton.simulate('click');
-    expect(removeVocabulary).toHaveBeenCalledTimes(1);
+    expect(removeDialog.exists()).toBe(true);
+    expect(removeDialog.text()).toEqual(
+      expect.stringContaining('Delete Vocabulary')
+    );
   });
 
-  it('can add a vocabulary', () => {
+  it('opens the add vocabulary dialog', () => {
     const wrapper = mount(<AllVocabulariesEditor {...defaultProps} />);
-    const addVocabularyButton = wrapper.find('a');
-    expect(addVocabularyButton.contains('Create New Vocabulary')).toBe(true);
+    expect(wrapper.find('BaseDialog').exists()).toBe(false);
+    const addVocabularyButton = wrapper
+      .find('.unit-test-add-vocabulary')
+      .first();
     addVocabularyButton.simulate('click');
-    expect(wrapper.find('AddVocabularyDialog').length).toBe(1);
+    const addDialog = wrapper.find('BaseDialog');
+    expect(addDialog.exists()).toBe(true);
+    expect(addDialog.text()).toEqual(expect.stringContaining('Add Vocabulary'));
   });
 });

--- a/apps/test/unit/levelbuilder/lesson-editor/DeleteVocabularyDialogTest.js
+++ b/apps/test/unit/levelbuilder/lesson-editor/DeleteVocabularyDialogTest.js
@@ -1,0 +1,74 @@
+import {mount} from 'enzyme'; // eslint-disable-line no-restricted-imports
+import React from 'react';
+
+import DeleteVocabularyDialog from '@cdo/apps/levelbuilder/lesson-editor/DeleteVocabularyDialog';
+
+const flushPromises = () => new Promise(resolve => setTimeout(resolve, 0));
+
+describe('DeleteVocabularyDialog', () => {
+  let handleDeleteVocabularyConfirm,
+    handleDeleteVocabularyDialogClose,
+    fetchSpy,
+    alertSpy,
+    defaultProps;
+
+  beforeEach(() => {
+    handleDeleteVocabularyConfirm = jest.fn();
+    handleDeleteVocabularyDialogClose = jest.fn();
+    fetchSpy = jest.spyOn(window, 'fetch');
+    alertSpy = jest.spyOn(window, 'alert').mockImplementation(() => {});
+    defaultProps = {
+      vocabularyForDeletion: {
+        id: 10,
+        word: 'algorithm',
+      },
+      handleDeleteVocabularyConfirm,
+      handleDeleteVocabularyDialogClose,
+    };
+  });
+
+  afterEach(() => {
+    fetchSpy.mockRestore();
+    alertSpy.mockRestore();
+  });
+
+  it('shows the vocabulary word in the dialog copy', () => {
+    const wrapper = mount(<DeleteVocabularyDialog {...defaultProps} />);
+    expect(wrapper.text()).toContain('algorithm');
+  });
+
+  it('deletes vocabulary and calls confirm handler on success', async () => {
+    fetchSpy.mockResolvedValue({ok: true});
+    const wrapper = mount(<DeleteVocabularyDialog {...defaultProps} />);
+    wrapper.find('#delete-vocabulary').first().simulate('click');
+    await flushPromises();
+
+    expect(fetchSpy).toHaveBeenCalledWith('/vocabularies/10', {
+      method: 'DELETE',
+      headers: expect.objectContaining({'Content-Type': 'application/json'}),
+    });
+    expect(handleDeleteVocabularyConfirm).toHaveBeenCalledTimes(1);
+    expect(alertSpy).not.toHaveBeenCalled();
+  });
+
+  it('shows an alert when delete fails', async () => {
+    fetchSpy.mockResolvedValue({
+      ok: false,
+      json: () => Promise.resolve({message: 'boom'}),
+    });
+    const wrapper = mount(<DeleteVocabularyDialog {...defaultProps} />);
+
+    wrapper.find('#delete-vocabulary').first().simulate('click');
+    await flushPromises();
+
+    expect(handleDeleteVocabularyConfirm).not.toHaveBeenCalled();
+    expect(alertSpy).toHaveBeenCalled();
+  });
+
+  it('closes dialog without deleting when cancel is clicked', () => {
+    const wrapper = mount(<DeleteVocabularyDialog {...defaultProps} />);
+    wrapper.find('#cancel-delete-vocabulary').first().simulate('click');
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(handleDeleteVocabularyDialogClose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/test/unit/levelbuilder/lesson-editor/VocabulariesEditorTest.js
+++ b/apps/test/unit/levelbuilder/lesson-editor/VocabulariesEditorTest.js
@@ -37,8 +37,9 @@ describe('VocabulariesEditor', () => {
     expect(wrapper.find('tr').length).toBe(3);
   });
 
-  it('can remove a vocabulary', () => {
+  it('opens the delete vocabulary dialog', () => {
     const wrapper = mount(<VocabulariesEditor {...defaultProps} />);
+    expect(wrapper.find('Dialog').exists()).toBe(false);
     const numVocabularies = wrapper.find('tr').length;
     expect(numVocabularies).toBeGreaterThanOrEqual(2);
     // Find one of the "remove" buttons and click it
@@ -47,23 +48,21 @@ describe('VocabulariesEditor', () => {
       .first();
     removeVocabularyButton.simulate('mouseDown');
     const removeDialog = wrapper.find('Dialog');
-    const deleteButton = removeDialog.find('button').at(2);
-    deleteButton.simulate('click');
-    expect(removeVocabulary).toHaveBeenCalledTimes(1);
+    expect(removeDialog.exists()).toBe(true);
+    expect(removeDialog.text()).toEqual(
+      expect.stringContaining('Delete Vocabulary')
+    );
   });
 
-  it('can cancel removing a vocabulary', () => {
+  it('opens the add vocabulary dialog', () => {
     const wrapper = mount(<VocabulariesEditor {...defaultProps} />);
-    const numVocabularies = wrapper.find('tr').length;
-    expect(numVocabularies).toBeGreaterThanOrEqual(2);
-    // Find one of the "remove" buttons and click it
-    const removeVocabularyButton = wrapper
-      .find('.unit-test-remove-vocabulary')
+    expect(wrapper.find('BaseDialog').exists()).toBe(false);
+    const addVocabularyButton = wrapper
+      .find('.unit-test-add-vocabulary')
       .first();
-    removeVocabularyButton.simulate('mouseDown');
-    const removeDialog = wrapper.find('Dialog');
-    const cancelButton = removeDialog.find('button').at(1);
-    cancelButton.simulate('click');
-    expect(removeVocabulary).not.toHaveBeenCalled();
+    addVocabularyButton.simulate('click');
+    const addDialog = wrapper.find('BaseDialog');
+    expect(addDialog.exists()).toBe(true);
+    expect(addDialog.text()).toEqual(expect.stringContaining('Add Vocabulary'));
   });
 });

--- a/dashboard/app/controllers/vocabularies_controller.rb
+++ b/dashboard/app/controllers/vocabularies_controller.rb
@@ -50,8 +50,10 @@ class VocabulariesController < ApplicationController
 
   def destroy
     vocabulary = Vocabulary.find_by_id(vocabulary_params[:id])
-    # Guard against nil vocabulary
-    # Remove any references to this vocabulary in lessons
+    unless vocabulary
+      render status: :bad_request, json: {error: "vocabulary not found"}
+      return
+    end
     if vocabulary.destroy
       render json: {status: 'success', message: 'Vocabulary word deleted successfully'}, status: :ok
     else

--- a/dashboard/app/controllers/vocabularies_controller.rb
+++ b/dashboard/app/controllers/vocabularies_controller.rb
@@ -48,6 +48,17 @@ class VocabulariesController < ApplicationController
     end
   end
 
+  def destroy
+    vocabulary = Vocabulary.find_by_id(vocabulary_params[:id])
+    # Guard against nil vocabulary
+    # Remove any references to this vocabulary in lessons
+    if vocabulary.destroy
+      render json: {status: 'success', message: 'Vocabulary word deleted successfully'}, status: :ok
+    else
+      render json: {status: 'error', message: vocabulary.errors.full_messages.to_sentence}, status: :bad_request
+    end
+  end
+
   # GET /courses/:course_name/vocab/edit
   def edit
     @course_version = CurriculumHelper.find_matching_course_version(params[:course_name])

--- a/dashboard/app/models/vocabulary.rb
+++ b/dashboard/app/models/vocabulary.rb
@@ -19,7 +19,7 @@
 class Vocabulary < ApplicationRecord
   include SerializedProperties
 
-  has_and_belongs_to_many :lessons, join_table: :lessons_vocabularies
+  has_and_belongs_to_many :lessons, join_table: :lessons_vocabularies, dependent: :delete_all
   belongs_to :course_version, optional: true
 
   KEY_CHAR_RE = /[a-z_]/

--- a/dashboard/config/routes.rb
+++ b/dashboard/config/routes.rb
@@ -569,7 +569,7 @@ Dashboard::Application.routes.draw do
       end
     end
 
-    resources :vocabularies, only: [:create, :update] do
+    resources :vocabularies, only: [:create, :update, :destroy] do
       collection do
         get :search
       end


### PR DESCRIPTION
I want to finally remove all the references to Radium in our codebase. One of those references is in an [old Dialog component](https://github.com/code-dot-org/code-dot-org/blob/staging-next/apps/src/legacySharedComponents/Dialog.jsx). We have a newer [DSCO Dialog](https://github.com/code-dot-org/code-dot-org/blob/c19879add24a709ae71eb9fcc73da52713b40615/frontend/packages/component-library/src/dialog/Dialog.tsx#L58) component. So I went on a side quest off my original side quest to swap out the old Dialog for the new Dialog. In the process I discovered that we have UI for levelbuilders to delete Vocabulary, but [no corresponding functionality](https://codedotorg.slack.com/archives/CFGAVL2CA/p1764785002525069) 🙃. 

In this PR, I refactored to make a `DeleteVocabularyDialog` component that uses the new DSCO Dialog and is shared between `AllVocabulariesEditor` and `VocabulariesEditor`. Clicking "Delete" in the `DeleteVocabularyDialog` now also actually deletes the Vocabulary and removes it from any associated Lessons in the process. 

**Before** 

https://github.com/user-attachments/assets/77ba74bb-1068-441b-bbec-747fa5f3303e

**After** 

https://github.com/user-attachments/assets/4612ee3a-b31b-4711-9c38-685d98503a6a

