### PR TITLE
Save podcast script to AiLessonSummary table

### DIFF
--- a/apps/src/templates/teacherNavigation/lessonMaterials/LessonMaterialsContainer.tsx
+++ b/apps/src/templates/teacherNavigation/lessonMaterials/LessonMaterialsContainer.tsx
@@ -241,7 +241,7 @@ const LessonMaterialsContainer: React.FC<LessonMaterialsContainerProps> = ({
   React.useEffect(() => {
     if (selectedLesson) {
       HttpClient.fetchJson<LessonSummaryInfoResponse>(
-        `/ai_lesson_summaries/show?user_id=${userId}&lesson_id=${selectedLesson?.id}`
+        `/ai_lesson_summaries/show?lesson_id=${selectedLesson?.id}`
       )
         .then(response => {
           const preParsedResponse = response.value?.lesson_summary;

--- a/dashboard/app/controllers/ai_lesson_summaries_controller.rb
+++ b/dashboard/app/controllers/ai_lesson_summaries_controller.rb
@@ -3,32 +3,35 @@ class AiLessonSummariesController < ApplicationController
 
   # GET /ai_lesson_summaries/show?lesson_id=2
   def show
-    @ai_lesson_summary = AiLessonSummary.find_by(
+    @ai_lesson_summary = AiLessonSummary.where(
       user_id: current_user.id,
       lesson_id: params[:lesson_id]
-    )
+    ).where.not(lesson_summary: nil)&.first
 
     if @ai_lesson_summary
       render json: @ai_lesson_summary.as_json(include: :lesson)
     else
-      render json: {error: 'AI lesson summary not found'}, status: :not_found
+      render json: {error: 'AI brief text lesson summary not found'}, status: :not_found
     end
   end
 
   # GET /ai_lesson_summaries/ai_lesson_summary_podcast_script?lesson_id=2
   def ai_lesson_summary_podcast_script
-    podcast_script_json = AiLessonSummariesHelper.get_ai_lesson_summary(params[:lesson_id], current_user.id, AiSystemPrompts::LessonSummariesSystemPromptHelper::RESPONSE_FORMATS[:PODCAST_SCRIPT])
+    podcast_script_json = AiLessonSummary.where(
+      user_id: current_user.id,
+      lesson_id: params[:lesson_id]
+    ).where.not(script: nil)&.first
 
     if podcast_script_json
       begin
-        pre_processed_script = JSON.parse(podcast_script_json[:json])['podcast_script']
-        processed_podcast_script = clean_up_podcast_script_response(pre_processed_script)
+        # Replace quotes and apostrophes with single tick quotes, and replace all newlines and double spaces with a single space
+        processed_podcast_script = podcast_script_json.script&.gsub(/\"|\’/, "'")&.squish
         render json: {podcast_script: processed_podcast_script}
       rescue => exception
         render json: {error: "Error parsing podcast script response: #{exception}"}, status: :internal_server_error
       end
     else
-      render json: {error: 'Failure to generate transcript'}, status: :internal_server_error
+      render json: {error: 'AI lesson summary podcast script not found'}, status: :not_found
     end
   end
 
@@ -60,10 +63,5 @@ class AiLessonSummariesController < ApplicationController
 
   private def ai_lesson_summary_params
     params.transform_keys(&:underscore).permit(:lesson_id, :unit_id, :lesson_summary)
-  end
-
-  private def clean_up_podcast_script_response(podcast_script_response)
-    replaced_newlines = podcast_script_response.gsub("\n\n", " ")
-    replaced_newlines.gsub(/\"|\’/, "'").squish
   end
 end

--- a/dashboard/app/helpers/ai_lesson_summaries_helper.rb
+++ b/dashboard/app/helpers/ai_lesson_summaries_helper.rb
@@ -4,7 +4,7 @@ module AiLessonSummariesHelper
   API_KEY = CDO.openai_lesson_summaries_api_key
   MODEL = SharedConstants::EVALUATE_STUDENT_LEARNING_MODEL_VERSION
 
-  def self.get_ai_lesson_summary(lesson_id, user_id = nil, response_format = AiSystemPrompts::LessonSummariesSystemPromptHelper::RESPONSE_FORMATS[:BRIEF_SUMMARY])
+  def self.generate_lesson_summary(lesson_id, user_id = nil, response_format = AiSystemPrompts::LessonSummariesSystemPromptHelper::RESPONSE_FORMATS[:BRIEF_SUMMARY])
     system_prompt = AiSystemPrompts::LessonSummariesSystemPromptHelper.get_system_prompt(lesson_id, user_id, response_format)
     client = Client.new(API_KEY, MODEL)
 
@@ -25,10 +25,29 @@ module AiLessonSummariesHelper
     end
   end
 
+  # Retrieves existing AiLessonSummary with the desired response_format if it exists, otherwise generates and saves it it.
   def self.retrieve_and_save_ai_lesson_summary(lesson_id, user_id, response_format)
-    ai_lesson_summary = get_ai_lesson_summary(lesson_id, user_id, response_format)
-    if ai_lesson_summary[:status] == 200 && response_format == AiSystemPrompts::LessonSummariesSystemPromptHelper::RESPONSE_FORMATS[:BRIEF_SUMMARY]
-      AiLessonSummary.create!({user_id: user_id, lesson_id: lesson_id, lesson_summary: ai_lesson_summary[:json]})
+    # Check for existing AiLessonSummary with the desired response_format
+    existing_summary_with_given_response_format = get_existing_summary(lesson_id, user_id, response_format)
+    return existing_summary_with_given_response_format if existing_summary_with_given_response_format.present?
+
+    # Obtain AiLessonSummary for this lesson + user pairing if it exists with a format other than the desired response_format
+    existing_summary = get_existing_summary(lesson_id, user_id, nil)
+    # Generate lesson summary in the desired response_format
+    new_ai_lesson_summary = generate_lesson_summary(lesson_id, user_id, response_format)
+
+    if new_ai_lesson_summary[:status] == 200
+      if existing_summary.present?
+        response_format == AiSystemPrompts::LessonSummariesSystemPromptHelper::RESPONSE_FORMATS[:BRIEF_SUMMARY] ?
+          existing_summary.update!(lesson_summary: new_ai_lesson_summary[:json]) :
+          existing_summary.update!(script: JSON.parse(new_ai_lesson_summary[:json])['podcast_script'])
+        existing_summary
+      else
+        new_ai_lesson_summary_params = response_format == AiSystemPrompts::LessonSummariesSystemPromptHelper::RESPONSE_FORMATS[:BRIEF_SUMMARY] ?
+          {user_id: user_id, lesson_id: lesson_id, lesson_summary: new_ai_lesson_summary[:json]} :
+          {user_id: user_id, lesson_id: lesson_id, script: JSON.parse(new_ai_lesson_summary[:json])['podcast_script']}
+        AiLessonSummary.create!(new_ai_lesson_summary_params)
+      end
     end
   end
 
@@ -83,6 +102,25 @@ module AiLessonSummariesHelper
         open_timeout: DCDO.get('openai_http_open_timeout', 5),
         read_timeout: DCDO.get('openai_http_read_timeout', 30)
       )
+    end
+  end
+
+  private_class_method def self.get_existing_summary(lesson_id, user_id, response_format)
+    if response_format.present?
+      response_format == AiSystemPrompts::LessonSummariesSystemPromptHelper::RESPONSE_FORMATS[:BRIEF_SUMMARY] ?
+        AiLessonSummary.where(
+          user_id: user_id,
+          lesson_id: lesson_id
+        ).where.not(lesson_summary: nil)&.first :
+        AiLessonSummary.where(
+          user_id: user_id,
+          lesson_id: lesson_id
+        ).where.not(script: nil)&.first
+    else
+      AiLessonSummary.where(
+        user_id: user_id,
+        lesson_id: lesson_id
+      )&.first
     end
   end
 end

--- a/dashboard/test/controllers/ai_lesson_summaries_controller_test.rb
+++ b/dashboard/test/controllers/ai_lesson_summaries_controller_test.rb
@@ -13,7 +13,7 @@ class AiLessonSummariesControllerTest < ActionController::TestCase
     @lesson_without_plan = create(:lesson, lesson_group: lesson_group)
     @lesson_with_plan_2 = create(:lesson, has_lesson_plan: true, lesson_group: lesson_group)
     @lesson_without_plan_2 = create(:lesson, lesson_group: lesson_group)
-    @ai_lesson_summary = AiLessonSummary.create(user_id: @teacher.id, lesson_id: @lesson_with_plan.id, lesson_summary: 'Test summary')
+    @ai_lesson_summary = AiLessonSummary.create(user_id: @teacher.id, lesson_id: @lesson_with_plan.id, lesson_summary: 'Test summary', script: "Test script with\n\nnewlines and \"quotes\"")
   end
 
   # *****
@@ -39,7 +39,7 @@ class AiLessonSummariesControllerTest < ActionController::TestCase
   # show action tests
   # *****
 
-  test 'show returns AI lesson summary when found for current user' do
+  test 'show returns AI lesson summary with brief text summary when found for current user' do
     sign_in @teacher
     get :show, params: {lesson_id: @lesson_with_plan.id}, format: :json
 
@@ -52,16 +52,16 @@ class AiLessonSummariesControllerTest < ActionController::TestCase
     assert response_data['lesson'].present?, 'Should include lesson data'
   end
 
-  test 'show returns not found when AI lesson summary does not exist' do
+  test 'show returns not found when AI lesson summary with brief text summary does not exist' do
     sign_in @teacher
     non_existent_lesson = create(:lesson)
     get :show, params: {lesson_id: non_existent_lesson.id}, format: :json
 
     assert_response :not_found
-    assert_equal 'AI lesson summary not found', json_response['error']
+    assert_equal 'AI brief text lesson summary not found', json_response['error']
   end
 
-  test 'show returns not found when AI lesson summary belongs to different user' do
+  test 'show returns not found when AI lesson summary with brief text summary belongs to different user' do
     other_teacher = create(:teacher)
     other_lesson = create(:lesson, has_lesson_plan: true)
     AiLessonSummary.create(user_id: other_teacher.id, lesson_id: other_lesson.id, lesson_summary: "Should not display")
@@ -70,7 +70,7 @@ class AiLessonSummariesControllerTest < ActionController::TestCase
     get :show, params: {lesson_id: other_lesson.id}, format: :json
 
     assert_response :not_found
-    assert_equal 'AI lesson summary not found', json_response['error']
+    assert_equal 'AI brief text lesson summary not found', json_response['error']
   end
 
   test 'show uses current_user.id instead of params user_id for security' do
@@ -83,6 +83,40 @@ class AiLessonSummariesControllerTest < ActionController::TestCase
     response_data = json_response
     # Should return the teacher's summary, not look for student's
     assert_equal @teacher.id, response_data['user_id']
+  end
+
+  # *****
+  # ai_lesson_summary_podcast_script action tests
+  # *****
+
+  test 'ai_lesson_summary_podcast_script returns parsed AI lesson summary with podcast script when found for current user' do
+    sign_in @teacher
+    get :ai_lesson_summary_podcast_script, params: {lesson_id: @lesson_with_plan.id}, format: :json
+
+    assert_response :success
+    response_data = json_response
+    assert_equal response_data['podcast_script'], "Test script with newlines and 'quotes'"
+  end
+
+  test 'ai_lesson_summary_podcast_script returns not found when AI lesson summary with podcast script does not exist' do
+    sign_in @teacher
+    non_existent_lesson = create(:lesson)
+    get :ai_lesson_summary_podcast_script, params: {lesson_id: non_existent_lesson.id}, format: :json
+
+    assert_response :not_found
+    assert_equal json_response['error'], 'AI lesson summary podcast script not found'
+  end
+
+  test 'ai_lesson_summary_podcast_script returns not found when AI lesson summary with podcast script belongs to different user' do
+    other_teacher = create(:teacher)
+    other_lesson = create(:lesson, has_lesson_plan: true)
+    AiLessonSummary.create(user_id: other_teacher.id, lesson_id: other_lesson.id, lesson_summary: "Should not display")
+
+    sign_in @teacher
+    get :ai_lesson_summary_podcast_script, params: {lesson_id: other_lesson.id}, format: :json
+
+    assert_response :not_found
+    assert_equal json_response['error'], 'AI lesson summary podcast script not found'
   end
 
   # *****

--- a/dashboard/test/helpers/ai_lesson_summaries_helper_test.rb
+++ b/dashboard/test/helpers/ai_lesson_summaries_helper_test.rb
@@ -18,44 +18,63 @@ class AiLessonSummariesHelperTest < ActionView::TestCase
     DCDO.stubs(:get).with('openai_http_open_timeout', 5).returns(5)
     DCDO.stubs(:get).with('openai_http_read_timeout', 30).returns(30)
 
-    @successful_openai_response = {
+    @system_prompt = "Test system prompt for lesson #{@lesson.id}"
+    @lesson_summary = {
+      learning_objective: "Students will learn variables",
+      lesson_beats: ["Introduction, practice, assessment"],
+      misconceptions: ["Variables are boxes"],
+      tips: ["Use concrete examples"]
+    }.to_json
+    @podcast_script = "Test podcast script."
+
+    @brief_text_successful_openai_response = {
+      choices: [{
+        message: {
+          content: @lesson_summary
+        }
+      }]
+    }.to_json
+    @podcast_script_successful_openai_response = {
       choices: [{
         message: {
           content: {
-            learning_objective: "Students will learn variables",
-            lesson_beats: ["Introduction, practice, assessment"],
-            misconceptions: ["Variables are boxes"],
-            tips: ["Use concrete examples"]
+            podcast_script: @podcast_script
           }.to_json
         }
       }]
     }.to_json
-
-    @system_prompt = "Test system prompt for lesson #{@lesson.id}"
 
     # Mock the system prompt helper
     AiSystemPrompts::LessonSummariesSystemPromptHelper.stubs(:get_system_prompt).
       with(@lesson.id, nil, AiSystemPrompts::LessonSummariesSystemPromptHelper::RESPONSE_FORMATS[:BRIEF_SUMMARY]).returns(@system_prompt)
     AiSystemPrompts::LessonSummariesSystemPromptHelper.stubs(:get_system_prompt).
       with(@lesson.id, @user.id, AiSystemPrompts::LessonSummariesSystemPromptHelper::RESPONSE_FORMATS[:BRIEF_SUMMARY]).returns(@system_prompt)
+    AiSystemPrompts::LessonSummariesSystemPromptHelper.stubs(:get_system_prompt).
+      with(@lesson.id, nil, AiSystemPrompts::LessonSummariesSystemPromptHelper::RESPONSE_FORMATS[:PODCAST_SCRIPT]).returns(@system_prompt)
+    AiSystemPrompts::LessonSummariesSystemPromptHelper.stubs(:get_system_prompt).
+      with(@lesson.id, @user.id, AiSystemPrompts::LessonSummariesSystemPromptHelper::RESPONSE_FORMATS[:PODCAST_SCRIPT]).returns(@system_prompt)
+  end
+
+  teardown do
+    AiLessonSummary.where(user_id: @user.id).destroy_all
   end
 
   # *****
-  # get_ai_lesson_summary tests
+  # generate_lesson_summary tests
   # *****
 
-  test "get_ai_lesson_summary returns successful response when API call succeeds" do
+  test "generate_lesson_summary returns successful response when API call succeeds" do
     # Mock successful HTTP response
     mock_response = mock('response')
     mock_response.stubs(:code).returns(200)
-    mock_response.stubs(:body).returns(@successful_openai_response)
+    mock_response.stubs(:body).returns(@brief_text_successful_openai_response)
 
     # Mock the Client class
     mock_client = mock('client')
     mock_client.expects(:request_lesson_summary).with(@system_prompt, AiSystemPrompts::LessonSummariesSystemPromptHelper::RESPONSE_FORMATS[:BRIEF_SUMMARY]).returns(mock_response)
     AiLessonSummariesHelper::Client.expects(:new).returns(mock_client)
 
-    result = AiLessonSummariesHelper.get_ai_lesson_summary(@lesson.id, nil, AiSystemPrompts::LessonSummariesSystemPromptHelper::RESPONSE_FORMATS[:BRIEF_SUMMARY])
+    result = AiLessonSummariesHelper.generate_lesson_summary(@lesson.id, nil, AiSystemPrompts::LessonSummariesSystemPromptHelper::RESPONSE_FORMATS[:BRIEF_SUMMARY])
 
     expected_content = {
       learning_objective: "Students will learn variables",
@@ -68,7 +87,7 @@ class AiLessonSummariesHelperTest < ActionView::TestCase
     assert_equal expected_content, result[:json]
   end
 
-  test "get_ai_lesson_summary returns error status when API call fails" do
+  test "generate_lesson_summary returns error status when API call fails" do
     # Mock failed HTTP response
     error_response = {error: "API limit exceeded"}.to_json
     mock_response = mock('response')
@@ -81,15 +100,15 @@ class AiLessonSummariesHelperTest < ActionView::TestCase
     AiLessonSummariesHelper::Client.expects(:new).returns(mock_client)
 
     assert_raises(StandardError) do
-      AiLessonSummariesHelper.get_ai_lesson_summary(@lesson.id, nil, AiSystemPrompts::LessonSummariesSystemPromptHelper::RESPONSE_FORMATS[:BRIEF_SUMMARY])
+      AiLessonSummariesHelper.generate_lesson_summary(@lesson.id, nil, AiSystemPrompts::LessonSummariesSystemPromptHelper::RESPONSE_FORMATS[:BRIEF_SUMMARY])
     end
   end
 
-  test "get_ai_lesson_summary gets system prompt from helper" do
+  test "generate_lesson_summary gets system prompt from helper" do
     # Mock HTTP response
     mock_response = mock('response')
     mock_response.stubs(:code).returns(200)
-    mock_response.stubs(:body).returns(@successful_openai_response)
+    mock_response.stubs(:body).returns(@brief_text_successful_openai_response)
 
     # Mock the Client class
     mock_client = mock('client')
@@ -99,16 +118,16 @@ class AiLessonSummariesHelperTest < ActionView::TestCase
     AiSystemPrompts::LessonSummariesSystemPromptHelper.expects(:get_system_prompt).
       with(@lesson.id, nil, AiSystemPrompts::LessonSummariesSystemPromptHelper::RESPONSE_FORMATS[:BRIEF_SUMMARY]).returns(@system_prompt)
 
-    AiLessonSummariesHelper.get_ai_lesson_summary(@lesson.id, nil, AiSystemPrompts::LessonSummariesSystemPromptHelper::RESPONSE_FORMATS[:BRIEF_SUMMARY])
+    AiLessonSummariesHelper.generate_lesson_summary(@lesson.id, nil, AiSystemPrompts::LessonSummariesSystemPromptHelper::RESPONSE_FORMATS[:BRIEF_SUMMARY])
   end
 
   # *****
   # retrieve_and_save_ai_lesson_summary tests
   # *****
 
-  test "retrieve_and_save_ai_lesson_summary creates AiLessonSummary when API call succeeds" do
+  test "retrieve_and_save_ai_lesson_summary creates AiLessonSummary when API call succeeds for brief text summary response" do
     # Mock successful API response
-    AiLessonSummariesHelper.expects(:get_ai_lesson_summary).with(@lesson.id, @user.id, AiSystemPrompts::LessonSummariesSystemPromptHelper::RESPONSE_FORMATS[:BRIEF_SUMMARY]).
+    AiLessonSummariesHelper.expects(:generate_lesson_summary).with(@lesson.id, @user.id, AiSystemPrompts::LessonSummariesSystemPromptHelper::RESPONSE_FORMATS[:BRIEF_SUMMARY]).
       returns({status: 200, json: "Generated lesson summary"})
 
     assert_difference 'AiLessonSummary.count', 1 do
@@ -121,9 +140,9 @@ class AiLessonSummariesHelperTest < ActionView::TestCase
     assert_equal "Generated lesson summary", created_summary.lesson_summary
   end
 
-  test "retrieve_and_save_ai_lesson_summary does not create AiLessonSummary when API call fails" do
+  test "retrieve_and_save_ai_lesson_summary does not create AiLessonSummary when API call fails for brief text summary response" do
     # Mock failed API response
-    AiLessonSummariesHelper.expects(:get_ai_lesson_summary).with(@lesson.id, @user.id, AiSystemPrompts::LessonSummariesSystemPromptHelper::RESPONSE_FORMATS[:BRIEF_SUMMARY]).
+    AiLessonSummariesHelper.expects(:generate_lesson_summary).with(@lesson.id, @user.id, AiSystemPrompts::LessonSummariesSystemPromptHelper::RESPONSE_FORMATS[:BRIEF_SUMMARY]).
       returns({status: 500, json: "Internal server error"})
 
     assert_no_difference 'AiLessonSummary.count' do
@@ -131,11 +150,11 @@ class AiLessonSummariesHelperTest < ActionView::TestCase
     end
   end
 
-  test "Retrieve_and_save creates record with actual API response structure" do
+  test "retrieve_and_save_ai_lesson_summary creates record with actual API response structure for brief text summary response" do
     # Mock the full chain
     mock_response = mock('response')
     mock_response.stubs(:code).returns(200)
-    mock_response.stubs(:body).returns(@successful_openai_response)
+    mock_response.stubs(:body).returns(@brief_text_successful_openai_response)
 
     HTTParty.stubs(:post).returns(mock_response)
 
@@ -150,6 +169,123 @@ class AiLessonSummariesHelperTest < ActionView::TestCase
     assert_equal ["Introduction, practice, assessment"], summary_data['lesson_beats']
     assert_equal ["Variables are boxes"], summary_data['misconceptions']
     assert_equal ["Use concrete examples"], summary_data['tips']
+  end
+
+  test "retrieve_and_save_ai_lesson_summary creates AiLessonSummary when API call succeeds for podcast script response" do
+    # Mock the full chain
+    mock_response = mock('response')
+    mock_response.stubs(:code).returns(200)
+    mock_response.stubs(:body).returns(@podcast_script_successful_openai_response)
+
+    HTTParty.stubs(:post).returns(mock_response)
+
+    assert_difference 'AiLessonSummary.count', 1 do
+      AiLessonSummariesHelper.retrieve_and_save_ai_lesson_summary(@lesson.id, @user.id, AiSystemPrompts::LessonSummariesSystemPromptHelper::RESPONSE_FORMATS[:PODCAST_SCRIPT])
+    end
+
+    created_summary = AiLessonSummary.last
+    assert_equal @user.id, created_summary.user_id
+    assert_equal @lesson.id, created_summary.lesson_id
+    assert_equal @podcast_script, created_summary.script
+  end
+
+  test "retrieve_and_save_ai_lesson_summary does not create AiLessonSummary when API call fails for podcast script response" do
+    # Mock failed API response
+    AiLessonSummariesHelper.expects(:generate_lesson_summary).with(@lesson.id, @user.id, AiSystemPrompts::LessonSummariesSystemPromptHelper::RESPONSE_FORMATS[:PODCAST_SCRIPT]).
+      returns({status: 500, json: "Internal server error"})
+
+    assert_no_difference 'AiLessonSummary.count' do
+      AiLessonSummariesHelper.retrieve_and_save_ai_lesson_summary(@lesson.id, @user.id, AiSystemPrompts::LessonSummariesSystemPromptHelper::RESPONSE_FORMATS[:PODCAST_SCRIPT])
+    end
+  end
+
+  test "retrieve_and_save_ai_lesson_summary returns existing AiLessonSummary with brief text summary for request of brief text summary response" do
+    AiLessonSummary.create!(user_id: @user.id, lesson_id: @lesson.id, lesson_summary: @lesson_summary)
+    AiLessonSummariesHelper.expects(:generate_lesson_summary).never
+
+    brief_text_lesson_summary = nil
+    assert_no_difference 'AiLessonSummary.count' do
+      brief_text_lesson_summary = AiLessonSummariesHelper.retrieve_and_save_ai_lesson_summary(@lesson.id, @user.id, AiSystemPrompts::LessonSummariesSystemPromptHelper::RESPONSE_FORMATS[:BRIEF_SUMMARY])
+    end
+
+    assert_equal @user.id, brief_text_lesson_summary.user_id
+    assert_equal @lesson.id, brief_text_lesson_summary.lesson_id
+    assert_equal @lesson_summary, brief_text_lesson_summary.lesson_summary
+  end
+
+  test "retrieve_and_save_ai_lesson_summary returns existing AiLessonSummary with podcast script for request of podcast script response" do
+    AiLessonSummary.create!(user_id: @user.id, lesson_id: @lesson.id, script: @podcast_script)
+    AiLessonSummariesHelper.expects(:generate_lesson_summary).never
+
+    podcast_script_lesson_summary = nil
+    assert_no_difference 'AiLessonSummary.count' do
+      podcast_script_lesson_summary = AiLessonSummariesHelper.retrieve_and_save_ai_lesson_summary(@lesson.id, @user.id, AiSystemPrompts::LessonSummariesSystemPromptHelper::RESPONSE_FORMATS[:PODCAST_SCRIPT])
+    end
+
+    assert_equal @user.id, podcast_script_lesson_summary.user_id
+    assert_equal @lesson.id, podcast_script_lesson_summary.lesson_id
+    assert_equal @podcast_script, podcast_script_lesson_summary.script
+  end
+
+  test "retrieve_and_save_ai_lesson_summary returns existing AiLessonSummary with both brief text summary and podcast script for request of either" do
+    AiLessonSummary.create!(user_id: @user.id, lesson_id: @lesson.id, lesson_summary: @lesson_summary, script: @podcast_script)
+    AiLessonSummariesHelper.expects(:generate_lesson_summary).never
+
+    brief_text_lesson_summary = nil
+    podcast_script_lesson_summary = nil
+    assert_no_difference 'AiLessonSummary.count' do
+      brief_text_lesson_summary = AiLessonSummariesHelper.retrieve_and_save_ai_lesson_summary(@lesson.id, @user.id, AiSystemPrompts::LessonSummariesSystemPromptHelper::RESPONSE_FORMATS[:BRIEF_SUMMARY])
+      podcast_script_lesson_summary = AiLessonSummariesHelper.retrieve_and_save_ai_lesson_summary(@lesson.id, @user.id, AiSystemPrompts::LessonSummariesSystemPromptHelper::RESPONSE_FORMATS[:PODCAST_SCRIPT])
+    end
+
+    assert_equal @user.id, brief_text_lesson_summary.user_id
+    assert_equal @lesson.id, brief_text_lesson_summary.lesson_id
+    assert_equal @lesson_summary, brief_text_lesson_summary.lesson_summary
+    assert_equal @user.id, podcast_script_lesson_summary.user_id
+    assert_equal @lesson.id, podcast_script_lesson_summary.lesson_id
+    assert_equal @podcast_script, podcast_script_lesson_summary.script
+  end
+
+  test "retrieve_and_save_ai_lesson_summary updates existing AiLessonSummary with brief text summary for request of podcast script response" do
+    # Mock the full chain
+    mock_response = mock('response')
+    mock_response.stubs(:code).returns(200)
+    mock_response.stubs(:body).returns(@podcast_script_successful_openai_response)
+
+    HTTParty.stubs(:post).returns(mock_response)
+
+    AiLessonSummary.create!(user_id: @user.id, lesson_id: @lesson.id, lesson_summary: @lesson_summary)
+
+    lesson_summary = nil
+    assert_no_difference 'AiLessonSummary.count' do
+      lesson_summary = AiLessonSummariesHelper.retrieve_and_save_ai_lesson_summary(@lesson.id, @user.id, AiSystemPrompts::LessonSummariesSystemPromptHelper::RESPONSE_FORMATS[:PODCAST_SCRIPT])
+    end
+
+    assert_equal @user.id, lesson_summary.user_id
+    assert_equal @lesson.id, lesson_summary.lesson_id
+    assert_equal @lesson_summary, lesson_summary.lesson_summary
+    assert_equal @podcast_script, lesson_summary.script
+  end
+
+  test "retrieve_and_save_ai_lesson_summary updates existing AiLessonSummary with podcast script for request of brief text summary response" do
+    # Mock the full chain
+    mock_response = mock('response')
+    mock_response.stubs(:code).returns(200)
+    mock_response.stubs(:body).returns(@brief_text_successful_openai_response)
+
+    HTTParty.stubs(:post).returns(mock_response)
+
+    AiLessonSummary.create!(user_id: @user.id, lesson_id: @lesson.id, script: @podcast_script)
+
+    lesson_summary = nil
+    assert_no_difference 'AiLessonSummary.count' do
+      lesson_summary = AiLessonSummariesHelper.retrieve_and_save_ai_lesson_summary(@lesson.id, @user.id, AiSystemPrompts::LessonSummariesSystemPromptHelper::RESPONSE_FORMATS[:BRIEF_SUMMARY])
+    end
+
+    assert_equal @user.id, lesson_summary.user_id
+    assert_equal @lesson.id, lesson_summary.lesson_id
+    assert_equal @lesson_summary, lesson_summary.lesson_summary
+    assert_equal @podcast_script, lesson_summary.script
   end
 
   # *****


### PR DESCRIPTION
Adds ability to save the podcast script to the `AiLessonSummary` table, and updates the `retrieve_and_save_ai_lesson_summary` method to return an existing `AiLessonSummary` if one already exists for that user + lesson combination, and updates existing `AiLessonSummary` if a different response type is requested (e.g. requesting a podcast script for an `AiLessonSummary` that already has a brief text summary for that user + lesson combination).

### `retrieve_and_save_ai_lesson_summary` creates new `AiLessonSummary` entries
New brief text summary:
![new lesson input](https://github.com/user-attachments/assets/37921fd6-9ebe-493c-97c7-b6bd7c60811c)
![new lesson output](https://github.com/user-attachments/assets/bd75e745-ecb8-4e07-9642-14f592fa43cc)

New podcast script:
![new script input](https://github.com/user-attachments/assets/2c684e27-f50a-4e04-9041-5064ff5a3f4e)
![new script output](https://github.com/user-attachments/assets/ffefc7aa-ad77-4cd4-8dae-343ab6485604)

### `retrieve_and_save_ai_lesson_summary` returns existing `AiLessonSummary` entry if one exists with the given response type
Brief text summary:
![request existing lesson brief text](https://github.com/user-attachments/assets/5be42273-66e0-4767-a975-afbee42100a0)

Podcast script:
![request existing podcast script](https://github.com/user-attachments/assets/a8c38a5f-500e-4aa7-b0a4-c857f1efa5b9)

### `retrieve_and_save_ai_lesson_summary` updates existing `AiLessonSummary` entry if new response type is requested that it doesn't have
Requesting brief text summary on entry with just a podcast script:
![request brief text for existing podcast input](https://github.com/user-attachments/assets/e5ab633b-65da-4acf-97ca-e5ba913db648)
![request brief text for existing podcast output](https://github.com/user-attachments/assets/7d823699-86bb-46f6-8ddc-5ff97b533c14)

Requesting podcast script on entry with just a brief text summary:
![request podcast on existing brief text](https://github.com/user-attachments/assets/ae29a21f-b0ba-4217-a1cd-1917600019b0)
![request podcast on existing brief text output](https://github.com/user-attachments/assets/2c4bda00-2462-451b-bfbb-44414a873b23)

### Logging output for both the `show` and `ai_lesson_summary_podcast_script` endpoints for an `AiLessonSummary` with both response types
![printing logging both endpoints](https://github.com/user-attachments/assets/e0a28ca8-0a75-4e6e-910e-4c75f7ecf0a0)

## Links
Jira ticket: [here](https://codedotorg.atlassian.net/jira/software/c/projects/TEACHING/boards/678?assignee=60d62161f65054006980bd71&selectedIssue=AITT-1311)

## Testing story
Local testing and adding unit tests.
