### PR TITLE
Lab2: Reset version history error state correctly and add custom messages

### DIFF
--- a/apps/src/lab2/views/components/Instructions/ResourcePanel/VersionHistory/VersionHistoryPanel.tsx
+++ b/apps/src/lab2/views/components/Instructions/ResourcePanel/VersionHistory/VersionHistoryPanel.tsx
@@ -126,7 +126,7 @@ const VersionHistoryPanel: React.FunctionComponent<
           setCustomLoadError('This student has not started yet.');
         } else {
           setCustomLoadError(
-            'No version history found. Have you starting your project?'
+            'No version history found. Have you started your project?'
           );
         }
         return;

--- a/apps/src/lab2/views/components/Instructions/ResourcePanel/VersionHistory/VersionHistoryPanel.tsx
+++ b/apps/src/lab2/views/components/Instructions/ResourcePanel/VersionHistory/VersionHistoryPanel.tsx
@@ -70,6 +70,7 @@ const VersionHistoryPanel: React.FunctionComponent<
   const [listLoaded, setListLoaded] = useState(false);
   const [listLoading, setListLoading] = useState(false);
   const [listLoadError, setListLoadError] = useState(false);
+  const [customLoadError, setCustomLoadError] = useState<string | null>(null);
   const [versionSaved, setVersionSaved] = useState(false);
   const [versionLoadError, setVersionLoadError] = useState(false);
   const [versionLoading, setVersionLoading] = useState(false);
@@ -120,6 +121,14 @@ const VersionHistoryPanel: React.FunctionComponent<
       const projectManager = Lab2Registry.getInstance().getProjectManager();
       if (!projectManager) {
         setListLoadError(true);
+        if (viewAsUserId) {
+          // If a teacher is viewing a student who has not started, we will have no project manager.
+          setCustomLoadError('This student has not started yet.');
+        } else {
+          setCustomLoadError(
+            'No version history found. Have you starting your project?'
+          );
+        }
         return;
       }
       setListLoading(true);
@@ -133,13 +142,16 @@ const VersionHistoryPanel: React.FunctionComponent<
             setSelectedVersion('');
             setFocusSelectedVersion(true);
           }
+          setListLoadError(false);
+          setCustomLoadError(null);
         })
         .catch(() => {
           setListLoadError(true);
+          setCustomLoadError(null);
           setListLoading(false);
         });
     },
-    [setSelectedVersion]
+    [setSelectedVersion, viewAsUserId]
   );
 
   useLifecycleNotifier(LifecycleEvent.LevelLoadCompleted, () => {
@@ -486,7 +498,7 @@ const VersionHistoryPanel: React.FunctionComponent<
         <Alert
           className={moduleStyles.message}
           type="danger"
-          text={lab2I18n.versionHistoryLoadFailure()}
+          text={customLoadError || lab2I18n.versionHistoryLoadFailure()}
           size="xs"
         />
       )}


### PR DESCRIPTION
If a teacher viewed a student's level and they hadn't started the level yet, we showed a generic "Failed to load" message. In addition, if they switched to another student, even if that student had started they would also see the failed to load message. The reason for this was we weren't ever resetting the load error back to false on a successful load. You could refresh the page to load the version history correctly.

This PR fixes the load state issue, and also gives a clearer message to teachers if they are viewing a project that hasn't been started yet.

## Screenshot of new message
<img width="400" height="222" alt="Screenshot 2025-12-03 at 1 29 26 PM" src="https://github.com/user-attachments/assets/537a3a85-ac6a-4f8d-819a-413db3ca61ef" />

## Before screen recording

https://github.com/user-attachments/assets/a259910a-9cc0-43a5-8293-aa5c1aacb727


## After screen recording

https://github.com/user-attachments/assets/8d96e2e7-7309-4984-ac74-7c5656e06bf7


## Links

- Jira: [AFL-367](https://codedotorg.atlassian.net/browse/AFL-367)

## Testing story
Tested locally.



## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
