### PR TITLE
Sketch Lab: upload starter assets and exemplar assets to S3

### DIFF
--- a/apps/src/codebridge/FileBrowser/hooks/useFileUploader.tsx
+++ b/apps/src/codebridge/FileBrowser/hooks/useFileUploader.tsx
@@ -51,7 +51,8 @@ export const useFileUploader = (
         const bodyData = new FormData();
         bodyData.append('files[]', file);
 
-        const url = `/level_starter_assets/${name}/uuid/${uuid}.${fileType}`;
+        const encodedLevelName = encodeURIComponent(name);
+        const url = `/level_starter_assets/${encodedLevelName}/uuid/${uuid}.${fileType}`;
         await HttpClient.post(url, bodyData, true);
         return url;
       } else {

--- a/apps/src/sketchlab/SketchlabView.tsx
+++ b/apps/src/sketchlab/SketchlabView.tsx
@@ -17,10 +17,6 @@ import React, {useEffect, useCallback, useRef, useState} from 'react';
 import useLevelEditMode from '@cdo/apps/lab2/hooks/useLevelEditMode';
 import useThemeSetting from '@cdo/apps/lab2/hooks/useThemeSetting';
 import {useVerticalLayout} from '@cdo/apps/lab2/hooks/useVerticalLayout';
-import {
-  getIsStartMode,
-  getAppOptionsEditingExemplar,
-} from '@cdo/apps/lab2/projects/utils';
 import {isReadOnlyWorkspace} from '@cdo/apps/lab2/redux/lab2ReduxSelectors';
 import {setHasRun} from '@cdo/apps/lab2/redux/systemRedux';
 import {LabProps, LevelProperties} from '@cdo/apps/lab2/types';
@@ -157,18 +153,13 @@ const SketchlabView: React.FC<LabProps<LevelProperties>> = ({
           serializedData.appState.zoom = appState.zoom;
         }
 
-        // TO DO: figure out how to update to support starter assets.
-        // Work tracked here: https://codedotorg.atlassian.net/browse/AFL-354
-        // In starter code and exemplar editing modes, we manage saving explicitly via the button in the header.
-        let uploadedFiles;
-        if (!(getIsStartMode() || getAppOptionsEditingExemplar())) {
-          uploadedFiles = await uploadExternalFiles(
-            currentSources.source.externalFiles || {},
-            serializedData.files,
-            filesBeingUploadedRef,
-            channelId
-          );
-        }
+        const uploadedFiles = await uploadExternalFiles(
+          currentSources.source.externalFiles || {},
+          serializedData.files,
+          filesBeingUploadedRef,
+          channelId,
+          levelProperties.name
+        );
 
         updateSources({
           source: {
@@ -181,7 +172,7 @@ const SketchlabView: React.FC<LabProps<LevelProperties>> = ({
         });
       }, DEBOUNCED_WORKSPACE_SERIALIZATION_MS);
     },
-    [updateSources, channelId, currentSources.source]
+    [updateSources, channelId, currentSources.source, levelProperties.name]
   );
 
   useEffect(() => {

--- a/apps/src/sketchlab/utils/uploadBase64ToUrl.ts
+++ b/apps/src/sketchlab/utils/uploadBase64ToUrl.ts
@@ -18,7 +18,9 @@ async function canvasToBlob(
 export async function uploadBase64ToUrl(
   dataUrl: string,
   uploadUrl: string,
-  mimeType: string
+  mimeType: string,
+  starterAsset: boolean,
+  filenameWithExtension: string
 ): Promise<Response> {
   const img = new Image();
   img.src = dataUrl;
@@ -33,9 +35,16 @@ export async function uploadBase64ToUrl(
 
   const blob = await canvasToBlob(canvas, mimeType);
 
-  const file = new File([blob], 'file', {
+  const file = new File([blob], filenameWithExtension, {
     type: mimeType,
   });
 
-  return await HttpClient.put(uploadUrl, file);
+  if (starterAsset) {
+    const bodyData = new FormData();
+    bodyData.append('files[]', file);
+
+    return await HttpClient.post(uploadUrl, bodyData, true);
+  } else {
+    return await HttpClient.put(uploadUrl, file);
+  }
 }

--- a/apps/src/sketchlab/utils/uploadExternalFiles.ts
+++ b/apps/src/sketchlab/utils/uploadExternalFiles.ts
@@ -45,8 +45,6 @@ export const uploadExternalFiles = async (
     const fileUploadPromises = newFileIds.map(async fileId => {
       filesBeingUploadedRef.current.add(fileId);
 
-      // TO DO: update to support starter assets.
-      // Work tracked here: https://codedotorg.atlassian.net/browse/AFL-354
       const newFile = excalidrawFiles[fileId];
       const extension = MIME_TO_EXT[newFile.mimeType];
       const filenameWithExtension = `${fileId}.${extension}`;

--- a/apps/src/sketchlab/utils/uploadExternalFiles.ts
+++ b/apps/src/sketchlab/utils/uploadExternalFiles.ts
@@ -55,7 +55,7 @@ export const uploadExternalFiles = async (
         ? `/level_starter_assets/${encodeURIComponent(
             levelName
           )}/uuid/${filenameWithExtension}`
-        : `/v3/assets/${channelId}/${fileId}.${extension}`;
+        : `/v3/assets/${channelId}/${filenameWithExtension}`;
       const newExternalFile: SketchlabProjectFile = {
         id: fileId,
       };

--- a/apps/src/sketchlab/utils/uploadExternalFiles.ts
+++ b/apps/src/sketchlab/utils/uploadExternalFiles.ts
@@ -1,4 +1,8 @@
 import {
+  getIsStartMode,
+  getAppOptionsEditingExemplar,
+} from '@cdo/apps/lab2/projects/utils';
+import {
   SketchlabProjectFile,
   SketchlabExternalFiles,
   ExcalidrawFilesWithOptionalData,
@@ -27,7 +31,8 @@ export const uploadExternalFiles = async (
   savedFiles: SketchlabExternalFiles,
   excalidrawFiles: ExcalidrawFilesWithOptionalData,
   filesBeingUploadedRef: React.MutableRefObject<Set<string>>,
-  channelId: string
+  channelId: string,
+  levelName: string
 ) => {
   const savedFileIds = Object.keys(savedFiles || {});
   const excalidrawFileIds = Object.keys(excalidrawFiles || {});
@@ -44,7 +49,15 @@ export const uploadExternalFiles = async (
       // Work tracked here: https://codedotorg.atlassian.net/browse/AFL-354
       const newFile = excalidrawFiles[fileId];
       const extension = MIME_TO_EXT[newFile.mimeType];
-      const externalUrl = `/v3/assets/${channelId}/${fileId}.${extension}`;
+      const filenameWithExtension = `${fileId}.${extension}`;
+      const isStarterAssetOrExemplar = !!(
+        getIsStartMode() || getAppOptionsEditingExemplar()
+      );
+      const externalUrl = isStarterAssetOrExemplar
+        ? `/level_starter_assets/${encodeURIComponent(
+            levelName
+          )}/uuid/${filenameWithExtension}`
+        : `/v3/assets/${channelId}/${fileId}.${extension}`;
       const newExternalFile: SketchlabProjectFile = {
         id: fileId,
       };
@@ -53,7 +66,9 @@ export const uploadExternalFiles = async (
         await uploadBase64ToUrl(
           newFile.dataURL as string,
           externalUrl,
-          newFile.mimeType
+          newFile.mimeType,
+          isStarterAssetOrExemplar,
+          filenameWithExtension
         );
         newExternalFile.url = externalUrl;
       } catch {

--- a/dashboard/app/controllers/level_starter_assets_controller.rb
+++ b/dashboard/app/controllers/level_starter_assets_controller.rb
@@ -54,6 +54,7 @@ class LevelStarterAssetsController < ApplicationController
 
   # POST /level_starter_assets/:level_name/uuid/:uuid
   def upload_by_uuid
+    puts 'in controller'
     # upload_data sets an appropriate header and returns nil in error cases.
     upload_data = validate_upload
     return unless upload_data

--- a/dashboard/app/controllers/level_starter_assets_controller.rb
+++ b/dashboard/app/controllers/level_starter_assets_controller.rb
@@ -54,7 +54,6 @@ class LevelStarterAssetsController < ApplicationController
 
   # POST /level_starter_assets/:level_name/uuid/:uuid
   def upload_by_uuid
-    puts 'in controller'
     # upload_data sets an appropriate header and returns nil in error cases.
     upload_data = validate_upload
     return unless upload_data

--- a/dashboard/app/models/levels/sketchlab.rb
+++ b/dashboard/app/models/levels/sketchlab.rb
@@ -43,4 +43,8 @@ class Sketchlab < Level
   def uses_lab2?
     true
   end
+
+  def add_starter_asset!(_, _)
+    true
+  end
 end


### PR DESCRIPTION
Updates Sketch Lab to upload images to S3 when in start mode or when editing an exemplar.

This change is supplemental to the existing image encoding (ie, we are still uploading encoded images to the project sources), so should not have an effect on users until we stop doing that.

## Links

- Jira: https://codedotorg.atlassian.net/jira/software/c/projects/AFL/boards/381

## Testing story

I tested manually that I could add images to the canvas, see images being uploaded successfully to s3 via the network tab, and, when hitting the "save" button in the header, that the new image URLs were stored as part of the `externalFiles` property. I could also load these assets on the level itself with the `?s3-images=true` URL param added, which actually loads the images into Excalidraw.