### PR TITLE
Web Lab 2: Do not re-render on open/close of files or folders

### DIFF
--- a/apps/src/codebridge/FilePreview/HTMLPreview.tsx
+++ b/apps/src/codebridge/FilePreview/HTMLPreview.tsx
@@ -1,15 +1,19 @@
 import {useCodebridgeContext} from '@codebridge/codebridgeContext';
 import classNames from 'classnames';
+import {isEqual} from 'lodash';
 import React, {useEffect, useMemo, useRef, useState} from 'react';
 
 import codebridgeI18n from '@cdo/apps/codebridge/locale';
 import useLifecycleNotifier from '@cdo/apps/lab2/hooks/useLifecycleNotifier';
 import {setIsFullScreenView} from '@cdo/apps/lab2/lab2Redux';
 import {isPredictResponseSubmitted} from '@cdo/apps/lab2/redux/predictLevelRedux';
+import {MultiFileSource} from '@cdo/apps/lab2/types';
 import {LifecycleEvent} from '@cdo/apps/lab2/utils';
 import PanelContainer from '@cdo/apps/lab2/views/components/PanelContainer';
 import experiments from '@cdo/apps/util/experiments';
 import {useAppSelector, useAppDispatch} from '@cdo/apps/util/reduxHooks';
+
+import {filterSourceForPreview} from '../utils/filterSourceForPreview';
 
 import {
   IframeMessageType,
@@ -49,13 +53,17 @@ export const HTMLPreview: React.FC = () => {
   const [navigationHistoryIndex, setNavigationHistoryIndex] = useState(-1);
 
   const source = useAppSelector(
-    state => state.lab2Project.projectSources?.source
+    state =>
+      state.lab2Project.projectSources?.source as MultiFileSource | undefined
   );
+
   const aiFilePathToPreview = useAppSelector(
     state => state.weblab2.aiFilePathToPreview
   );
   const [isIframeLoaded, setIsIframeLoaded] = useState(false);
-  const [debouncedSource, setDebouncedSource] = useState(source);
+  const [debouncedSource, setDebouncedSource] = useState(
+    filterSourceForPreview(source)
+  );
   const sourceLevelId = useRef<number | undefined>(undefined);
   const [isLevelLoading, setIsLevelLoading] = useState(false);
   const [inputValue, setInputValue] = useState<string>(DEFAULT_START_HTML_FILE);
@@ -236,7 +244,7 @@ export const HTMLPreview: React.FC = () => {
     }
     if (sourceLevelId.current !== levelProperties.id) {
       // If we have a new level id, update the source immediately.
-      setDebouncedSource(source);
+      setDebouncedSource(filterSourceForPreview(source));
       sourceLevelId.current = levelProperties.id;
       setCurrentFile(DEFAULT_START_HTML_FILE);
       setInputValue(DEFAULT_START_HTML_FILE);
@@ -245,7 +253,14 @@ export const HTMLPreview: React.FC = () => {
     } else {
       // Set a timeout to send the debounced value after 500ms
       const debouncedSourceSetter = setTimeout(() => {
-        setDebouncedSource(source);
+        // Only update the source if the filtered source has changed.
+        setDebouncedSource(previousSource => {
+          const newFilteredSource = filterSourceForPreview(source);
+          if (!isEqual(previousSource, newFilteredSource)) {
+            return newFilteredSource;
+          }
+          return previousSource;
+        });
       }, SOURCE_CHANGE_DELAY_MS);
 
       // Cleanup the timeout if source or level changes before 500ms has elapsed.

--- a/apps/src/codebridge/utils/filterSourceForPreview.ts
+++ b/apps/src/codebridge/utils/filterSourceForPreview.ts
@@ -1,0 +1,33 @@
+import {MultiFileSource, ProjectFile, FileId} from '@cdo/apps/lab2/types';
+
+// Given a MultiFileSource, return a new MultiFileSource that removes the openFiles
+// and active file/folder information, as this is not needed for preview. This allows us to avoid
+// re-rendering the preview iframe when only open/active files change.
+export const filterSourceForPreview = (
+  source: MultiFileSource | undefined
+): MultiFileSource | undefined => {
+  if (!source) {
+    return source;
+  }
+  const files: Record<FileId, ProjectFile> = Object.fromEntries(
+    Object.entries(source.files).map(([fileId, file]) => {
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      const {active, ...props} = file;
+      return [fileId, props];
+    })
+  );
+
+  const folders = Object.fromEntries(
+    Object.entries(source.folders).map(([folderId, folder]) => {
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      const {open, ...props} = folder;
+      return [folderId, props];
+    })
+  );
+
+  return {
+    files,
+    folders,
+    // Skip including openFiles
+  };
+};


### PR DESCRIPTION
Currently the web lab 2 preview will re-render on any source change, which can include opening/closing a file or folder or changing the active file. This will get annoying when API requests come into projects, as the API request will re-fetch on each of those changes.

This update uses a filtered version of the source that excludes the changes that are irrelevant to the preview. When we are going to send an updated source, we first check if the filtered version has changed, and only send if it has.

In the before/after videos, the line at the bottom of the preview is triggered from an API request, so you can see it change on many more changes in before vs after.

## Before
https://github.com/user-attachments/assets/90011871-ca9d-4062-a39e-64dec11fe928



## After
https://github.com/user-attachments/assets/4234dc7c-9463-4beb-aed9-473eeb630b4e



## Links
- Jira: [AFL-391](https://codedotorg.atlassian.net/browse/AFL-391)

## Testing story
Tested locally.





## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
