### PR TITLE
NPS survey on admin - add documentation

### DIFF
--- a/dashboard/app/views/admin_nps/nps_form.html.haml
+++ b/dashboard/app/views/admin_nps/nps_form.html.haml
@@ -2,7 +2,11 @@
 
 %p User the dropdown menu below to determine the audience of the most recent NPS survey.
 %p This will save as a DCDO flag, which will automatically update the audience.
-%p NOTE: Any audience other than "none" will launch the survey immediately.
+
+%strong Notes:
+%ul
+  %li Any audience other than "none" will launch the survey immediately.
+  %li This is the very last step in starting the NPS survey.  For the full process, check out the #{link_to('NPS Survey Runbook', 'https://docs.google.com/document/d/1KhQqlOs4NX-HGHW5ro0LTu76lz2LNsZhu9xsXBPcgWg/edit')}.
 
 %h2 Survey Audience
 


### PR DESCRIPTION
Adds this link to the NPS documentation on the NPS page admin can access.

<img width="770" height="500" alt="image" src="https://github.com/user-attachments/assets/9ac6ba59-9295-4b8f-804d-ca1797224001" />

My hope is that this means we need less institutional knowledge (and google drive hunting) to run the NPS survey successfully. 