### PR TITLE
Fix "with exception" calls to Honeybadger.notify_cronjob_error

### DIFF
--- a/bin/cron/applab_datasets/daily_weather
+++ b/bin/cron/applab_datasets/daily_weather
@@ -154,7 +154,7 @@ def get_weather_data
     response = Net::HTTP.get_response(URI(url))
     if response.code != '200'
       puts "Failed to retrieve data from Open Weather API for WeatherForecastOffice with zip code #{office.zip_code}. This office will not be updated in App Labs datasets."
-      Honeybadger.notify(
+      Honeybadger.notify_cronjob_error(
         error: response.message,
         error_message: "Failed to retrieve data from Open Weather API for WeatherForecastOffice with zip code #{office.zip_code}. This office will not be updated in App Labs datasets.",
       )
@@ -204,7 +204,7 @@ def main
   records = get_weather_data
   if records.empty?
     puts "No data returned from OpenWeather API. No records will be written to datablock storage."
-    Honeybadger.notify(
+    Honeybadger.notify_cronjob_error(
       error_message: "No data returned from OpenWeather API. No records will be written to datablock storage."
       )
     return

--- a/lib/cdo/honeybadger.rb
+++ b/lib/cdo/honeybadger.rb
@@ -57,7 +57,7 @@ module Honeybadger
 
   # notify_cronjob_error - logs a Honeybadger error in the Cronjobs project
   # See https://docs.honeybadger.io/ruby/gem-reference/api.html#honeybadger-notify-error-opts
-  def self.notify_cronjob_error(opts)
+  def self.notify_cronjob_error(...)
     # Configure and start Honeybadger
     Honeybadger.configure do |config|
       config.env = ENV.fetch('RACK_ENV', nil)
@@ -68,7 +68,7 @@ module Honeybadger
       config.report_data = true
     end
 
-    result = Honeybadger.notify(opts)
+    result = Honeybadger.notify(...)
     Honeybadger.flush # these events are sometimes getting swallowed without this
     result
   end


### PR DESCRIPTION
Currently Honeybadger calls from `spotify` generate an error themselves, see: https://app.honeybadger.io/projects/45435/faults/114807671/01KBJ1G4BYK5EJ4GMCJF354WY0?q=spotify

When the `spotify` bin was updated to use `Honeybadger.notify_cronjob_error()`, it was not noticed that it passes an exception AND opts. This is valid to `Honeybadger.notify()`, so this PR changes notify_cronjob_error() to use Ruby argument forwarding to forward ALL arguments.

Otherwise you get errors about your errors like:
```
/home/ubuntu/production/lib/cdo/honeybadger.rb:60:in `notify_cronjob_error': wrong number of arguments (given 2, expected 1) (ArgumentError)
```

Additionally, switch daily_weather to use `notify_cronjob_error`, which is more likely to get reported and not silently get flushed when the process closes.