### PR TITLE
Convert BackpackClientApi to TypeScript

### DIFF
--- a/apps/src/code-studio/initApp/clientApi.js
+++ b/apps/src/code-studio/initApp/clientApi.js
@@ -241,15 +241,15 @@ function errorString(request, status, error, details = null) {
   );
 }
 
-module.exports = {
-  /**
-   * Create a ClientApi instance with the given base URL.
-   * @param {!string} url - Custom API base url (e.g. '/v3/netsim')
-   * @returns {ClientApi}
-   */
-  create: function (url) {
-    return _.assign({}, base, {
-      api_base_url: url,
-    });
-  },
-};
+/**
+ * Create a ClientApi instance with the given base URL.
+ * @param {!string} url - Custom API base url (e.g. '/v3/netsim')
+ * @returns {ClientApi}
+ */
+function create(url) {
+  return _.assign({}, base, {
+    api_base_url: url,
+  });
+}
+
+export default {create};

--- a/apps/src/code-studio/initApp/clientApiType.ts
+++ b/apps/src/code-studio/initApp/clientApiType.ts
@@ -1,40 +1,40 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 export interface ClientApi {
   all: (callback: any) => void;
-  create: (value: any, callback: (error: string, data: any) => void) => void;
+  create: (value: any, callback: (error: Error, data: any) => void) => void;
   delete: (
     childPath: string,
-    callback: (error: string, result: boolean) => void
+    callback: (error: Error, result: boolean) => void
   ) => void;
   deleteObject: (
     childPath: string,
-    callback: (error: string, result: boolean) => void
+    callback: (error: Error, result: boolean) => void
   ) => void;
   fetch: (
-    childPath: string,
-    callback: (error: string, data: any, jqXHR: JQuery.jqXHR) => void,
+    childPath: string | null,
+    callback: (error: Error, data: any, jqXHR: JQuery.jqXHR) => void,
     dataType?: string
   ) => void;
   update: (
-    childPath: string,
+    childPath: string | null,
     value: any,
-    callback: (error: string, data: any | boolean) => void
+    callback: (error: Error, data: any | boolean) => void
   ) => void;
   copyAll: (
     src: string,
     dest: string,
-    callback: (error: string, data: any) => void
+    callback: (error: Error, data: any) => void
   ) => void;
   put: (
-    id: number | string,
+    id: number | string | null,
     value: string,
     filename: string,
-    callback: (error: string, data: any | boolean) => void
+    callback: (error: Error, data: any | boolean) => void
   ) => void;
   patchAll: (
     id: number,
     queryParams: string,
     value: string,
-    callback: (error: string, data: any) => void
+    callback: (error: Error, data: any) => void
   ) => void;
 }

--- a/apps/src/code-studio/initApp/clientApiType.ts
+++ b/apps/src/code-studio/initApp/clientApiType.ts
@@ -1,0 +1,40 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+export interface ClientApi {
+  all: (callback: any) => void;
+  create: (value: any, callback: (error: string, data: any) => void) => void;
+  delete: (
+    childPath: string,
+    callback: (error: string, result: boolean) => void
+  ) => void;
+  deleteObject: (
+    childPath: string,
+    callback: (error: string, result: boolean) => void
+  ) => void;
+  fetch: (
+    childPath: string,
+    callback: (error: string, data: any, jqXHR: JQuery.jqXHR) => void,
+    dataType?: string
+  ) => void;
+  update: (
+    childPath: string,
+    value: any,
+    callback: (error: string, data: any | boolean) => void
+  ) => void;
+  copyAll: (
+    src: string,
+    dest: string,
+    callback: (error: string, data: any) => void
+  ) => void;
+  put: (
+    id: number | string,
+    value: string,
+    filename: string,
+    callback: (error: string, data: any | boolean) => void
+  ) => void;
+  patchAll: (
+    id: number,
+    queryParams: string,
+    value: string,
+    callback: (error: string, data: any) => void
+  ) => void;
+}

--- a/apps/src/code-studio/initApp/clientApiType.ts
+++ b/apps/src/code-studio/initApp/clientApiType.ts
@@ -1,3 +1,5 @@
+// We are allowing any in this interface to make this usable in TypeScript, as the clientApi
+// could return many different object types.
 /* eslint-disable @typescript-eslint/no-explicit-any */
 export interface ClientApi {
   all: (callback: any) => void;

--- a/apps/src/sharedComponents/backpack/BackpackClientApi.ts
+++ b/apps/src/sharedComponents/backpack/BackpackClientApi.ts
@@ -1,9 +1,27 @@
 import clientApi from '@cdo/apps/code-studio/initApp/clientApi';
+import {ClientApi} from '@cdo/apps/code-studio/initApp/clientApiType';
 
 const REQUEST_RETRY_COUNT = 1;
 
+interface FilesObject {
+  [filename: string]: {
+    text: string;
+  };
+}
+
+type ErrorCallback = (error?: string, failedFiles?: string[]) => void;
+
 export default class BackpackClientApi {
-  constructor(appType, channelId) {
+  backpackApi: ClientApi;
+  appType: string;
+  channelId: string;
+  uploadingFiles: boolean;
+  fileUploadsInProgress: string[];
+  fileUploadsFailed: string[];
+  fileDeletesInProgress: string[];
+  fileDeletesFailed: string[];
+
+  constructor(appType: string, channelId: string) {
     this.backpackApi = clientApi.create('/v3/libraries');
     this.appType = appType;
     this.channelId = channelId;
@@ -18,7 +36,7 @@ export default class BackpackClientApi {
     return !!this.channelId;
   }
 
-  fetchChannelId(callback) {
+  fetchChannelId(callback: () => void) {
     $.ajax({
       url: `/backpacks/channel/${this.appType}`,
       type: 'get',
@@ -28,7 +46,11 @@ export default class BackpackClientApi {
     });
   }
 
-  fetchFile(filename, onError, onSuccess) {
+  fetchFile(
+    filename: string,
+    onError: ErrorCallback,
+    onSuccess: (data: object) => void
+  ) {
     if (!this.hasBackpack()) {
       onError();
     }
@@ -36,7 +58,7 @@ export default class BackpackClientApi {
     const cacheBustSuffix = `?t=${Date.now()}`;
     this.backpackApi.fetch(
       this.channelId + '/' + filename + cacheBustSuffix,
-      (error, data) => {
+      (error: string, data) => {
         if (error) {
           onError(error);
         } else {
@@ -47,7 +69,10 @@ export default class BackpackClientApi {
     );
   }
 
-  getFileList(onError, onSuccess) {
+  getFileList(
+    onError: ErrorCallback,
+    onSuccess: (filenames: string[]) => void
+  ) {
     if (!this.hasBackpack() && this.appType === 'javalab') {
       onError();
     }
@@ -57,7 +82,9 @@ export default class BackpackClientApi {
           onError(error);
           return;
         }
-        const filenames = data.map(fileData => fileData.filename);
+        const filenames = (data as {filename: string}[]).map(
+          fileData => fileData.filename
+        );
         onSuccess(filenames);
       });
     };
@@ -82,7 +109,12 @@ export default class BackpackClientApi {
    * @param {Function} onError Function to call if any file fails to save
    * @param {Function} onSuccess Function to call if all files save.
    */
-  saveFiles(files, filenames, onError, onSuccess) {
+  saveFiles(
+    files: FilesObject,
+    filenames: string[],
+    onError: ErrorCallback,
+    onSuccess: () => void
+  ) {
     this.updateFilesHelper(
       this.fileUploadsInProgress,
       filenames,
@@ -100,7 +132,12 @@ export default class BackpackClientApi {
    * @param {Function} onError Function to call if file fails to save.
    * @param {Function} onSuccess Function to call if file saves.
    */
-  saveCodebridgeFile(filename, fileContents, onError, onSuccess) {
+  saveCodebridgeFile(
+    filename: string,
+    fileContents: string,
+    onError: ErrorCallback,
+    onSuccess: () => void
+  ) {
     const fileObject = {[filename]: {text: fileContents}};
     this.updateFilesHelper(
       this.fileUploadsInProgress,
@@ -118,7 +155,11 @@ export default class BackpackClientApi {
    * @param {Function} onSuccess Function to call if all files are deleted.
    */
 
-  deleteFiles(filenames, onError, onSuccess) {
+  deleteFiles(
+    filenames: string[],
+    onError: ErrorCallback,
+    onSuccess: () => void
+  ) {
     this.updateFilesHelper(
       this.fileDeletesInProgress,
       filenames,
@@ -138,7 +179,13 @@ export default class BackpackClientApi {
    * @param {Function} onSuccess success callback, only called if there is nothing to update
    * @param {Function} callback callback function to continue updating files
    */
-  updateFilesHelper(filesInProgress, filenames, onError, onSuccess, callback) {
+  updateFilesHelper(
+    filesInProgress: string[],
+    filenames: string[],
+    onError: ErrorCallback,
+    onSuccess: () => void,
+    callback: () => void
+  ) {
     if (filesInProgress.length > 0) {
       // If an update is currently in progress (a previous update has not gone through its
       // entire list of files to resolve), return an error. Frontend should prevent multiple
@@ -159,7 +206,12 @@ export default class BackpackClientApi {
     }
   }
 
-  saveFilesHelper(files, filenames, onError, onSuccess) {
+  saveFilesHelper(
+    files: FilesObject,
+    filenames: string[],
+    onError: ErrorCallback,
+    onSuccess: () => void
+  ) {
     this.fileUploadsInProgress = [...filenames];
     this.fileUploadsFailed = [];
     filenames.forEach(filename => {
@@ -176,11 +228,11 @@ export default class BackpackClientApi {
   }
 
   writeSingleFileToBackpack(
-    filename,
-    fileContents,
-    onError,
-    onSuccess,
-    retryCount
+    filename: string,
+    fileContents: string,
+    onError: ErrorCallback,
+    onSuccess: () => void,
+    retryCount: number
   ) {
     this.backpackApi.put(this.channelId, fileContents, filename, (error, _) => {
       if (error) {
@@ -216,7 +268,11 @@ export default class BackpackClientApi {
     });
   }
 
-  deleteFilesHelper(filenames, onError, onSuccess) {
+  deleteFilesHelper(
+    filenames: string[],
+    onError: ErrorCallback,
+    onSuccess: () => void
+  ) {
     this.fileDeletesInProgress = [...filenames];
     this.fileDeletesFailed = [];
     filenames.forEach(filename => {
@@ -230,7 +286,12 @@ export default class BackpackClientApi {
     });
   }
 
-  deleteSingleFileFromBackpack(filename, onError, onSuccess, retryCount) {
+  deleteSingleFileFromBackpack(
+    filename: string,
+    onError: ErrorCallback,
+    onSuccess: () => void,
+    retryCount: number
+  ) {
     this.backpackApi.deleteObject(
       this.channelId + '/' + filename,
       (error, _) => {
@@ -271,12 +332,12 @@ export default class BackpackClientApi {
   // Check if all files are done updating. If they are, call either onSuccess
   // or onError depending on if we saw any errors.
   onRequestComplete(
-    filename,
-    filesInRequest,
-    failedFileList,
-    onError,
-    onSuccess,
-    error
+    filename: string,
+    filesInRequest: string[],
+    failedFileList: string[],
+    onError: ErrorCallback,
+    onSuccess: () => void,
+    error?: string
   ) {
     const filenameIndex = filesInRequest.indexOf(filename);
     if (filenameIndex >= 0) {

--- a/apps/src/sharedComponents/backpack/BackpackClientApi.ts
+++ b/apps/src/sharedComponents/backpack/BackpackClientApi.ts
@@ -9,19 +9,19 @@ interface FilesObject {
   };
 }
 
-type ErrorCallback = (error?: string, failedFiles?: string[]) => void;
+type ErrorCallback = (error?: Error, failedFiles?: string[]) => void;
 
 export default class BackpackClientApi {
   backpackApi: ClientApi;
   appType: string;
-  channelId: string;
+  channelId: string | null;
   uploadingFiles: boolean;
   fileUploadsInProgress: string[];
   fileUploadsFailed: string[];
   fileDeletesInProgress: string[];
   fileDeletesFailed: string[];
 
-  constructor(appType: string, channelId: string) {
+  constructor(appType: string, channelId: string | null) {
     this.backpackApi = clientApi.create('/v3/libraries');
     this.appType = appType;
     this.channelId = channelId;
@@ -49,7 +49,7 @@ export default class BackpackClientApi {
   fetchFile(
     filename: string,
     onError: ErrorCallback,
-    onSuccess: (data: object) => void
+    onSuccess: (data: string) => void
   ) {
     if (!this.hasBackpack()) {
       onError();
@@ -58,7 +58,7 @@ export default class BackpackClientApi {
     const cacheBustSuffix = `?t=${Date.now()}`;
     this.backpackApi.fetch(
       this.channelId + '/' + filename + cacheBustSuffix,
-      (error: string, data) => {
+      (error, data) => {
         if (error) {
           onError(error);
         } else {
@@ -337,7 +337,7 @@ export default class BackpackClientApi {
     failedFileList: string[],
     onError: ErrorCallback,
     onSuccess: () => void,
-    error?: string
+    error?: Error
   ) {
     const filenameIndex = filesInRequest.indexOf(filename);
     if (filenameIndex >= 0) {


### PR DESCRIPTION
This converts `BackpackClientApi` to TypeScript to make it easier to work with going forward. To get this working I had to convert `clientApi` to use a standard export rather than `module.exports`. The only place that file was used was for Backpack and App Lab libraries, and I confirmed both features still work with the change.

I opted to type `clientApi` as a separate type but still keep `any` for now since I believe it really could be any object (I am not 100% confident on that, lmk if there's something more specific I can do!).

## Links
- Jira: pre-work for [AFL-182](https://codedotorg.atlassian.net/browse/AFL-182)

## Testing story
Tested locally that backpack still works in Codebridge and Java Lab. I also confirmed App Lab libraries are unaffected.


## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
