### PR TITLE
feat(tsconfig): add shared config for vite

### DIFF
--- a/frontend/apps/studio/tsconfig.app.json
+++ b/frontend/apps/studio/tsconfig.app.json
@@ -1,29 +1,7 @@
 {
-  "extends": "@code-dot-org/lint-config/typescript/tsconfig.react.json",
+  "extends": "@code-dot-org/lint-config/typescript/tsconfig.vite.app.json",
   "compilerOptions": {
-    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.app.tsbuildinfo",
-    "target": "ES2022",
-    "useDefineForClassFields": true,
-    "lib": ["ES2022", "DOM", "DOM.Iterable"],
-    "module": "ESNext",
-    "types": ["vite/client"],
-    "skipLibCheck": true,
-
-    /* Bundler mode */
-    "moduleResolution": "bundler",
-    "allowImportingTsExtensions": true,
-    "verbatimModuleSyntax": true,
-    "moduleDetection": "force",
-    "noEmit": true,
-    "jsx": "react-jsx",
-
-    /* Linting */
-    "strict": true,
-    "noUnusedLocals": true,
-    "noUnusedParameters": true,
-    "erasableSyntaxOnly": true,
-    "noFallthroughCasesInSwitch": true,
-    "noUncheckedSideEffectImports": true
+    "baseUrl": "."
   },
-  "include": ["src"]
+  "include": ["src", "entrypoints"]
 }

--- a/frontend/apps/studio/tsconfig.node.json
+++ b/frontend/apps/studio/tsconfig.node.json
@@ -1,27 +1,7 @@
 {
-  "extends": "@code-dot-org/lint-config/typescript/tsconfig.node22.json",
+  "extends": "@code-dot-org/lint-config/typescript/tsconfig.vite.node.json",
   "compilerOptions": {
-    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.node.tsbuildinfo",
-    "target": "ES2023",
-    "lib": ["ES2023"],
-    "module": "ESNext",
-    "types": ["node"],
-    "skipLibCheck": true,
-
-    /* Bundler mode */
-    "moduleResolution": "bundler",
-    "allowImportingTsExtensions": true,
-    "verbatimModuleSyntax": true,
-    "moduleDetection": "force",
-    "noEmit": true,
-
-    /* Linting */
-    "strict": true,
-    "noUnusedLocals": true,
-    "noUnusedParameters": true,
-    "erasableSyntaxOnly": true,
-    "noFallthroughCasesInSwitch": true,
-    "noUncheckedSideEffectImports": true
+    "baseUrl": "."
   },
   "include": ["vite.config.ts"]
 }

--- a/frontend/packages/lint-config/package.json
+++ b/frontend/packages/lint-config/package.json
@@ -29,6 +29,7 @@
   "devDependencies": {
     "@eslint/js": "^9.15.0",
     "@tsconfig/node22": "^22.0.4",
+    "@tsconfig/vite-react": "^7.0.2",
     "eslint": "^9.15.0",
     "eslint-import-resolver-typescript": "^3.6.3",
     "eslint-plugin-import-x": "^4.4.3",

--- a/frontend/packages/lint-config/typescript/tsconfig.vite.app.json
+++ b/frontend/packages/lint-config/typescript/tsconfig.vite.app.json
@@ -1,0 +1,15 @@
+{
+  // Use Typescript recommended defaults with Code.org customizations
+  // See: https://www.npmjs.com/package/@tsconfig/vite-react
+  // Only add global typescript configuration changes that will apply to all packages
+  // Specific typescript changes should be made in the consuming package
+  "extends": "@tsconfig/vite-react/tsconfig.json",
+  "compilerOptions": {
+    "baseUrl": ".",
+    "types": ["vite/client"],
+    // For Code.org applications, the `@/*` path alias refers to the `src` directory
+    "paths": {
+      "@/*": ["src/*"]
+    }
+  }
+}

--- a/frontend/packages/lint-config/typescript/tsconfig.vite.node.json
+++ b/frontend/packages/lint-config/typescript/tsconfig.vite.node.json
@@ -1,0 +1,31 @@
+{
+  // A shareable version of the following base config
+  // https://github.com/vitejs/vite/blob/main/packages/create-vite/template-react-ts/tsconfig.node.json
+  "compilerOptions": {
+    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.node.tsbuildinfo",
+    "target": "ES2023",
+    "lib": ["ES2023"],
+    "module": "ESNext",
+    "types": ["node"],
+    "skipLibCheck": true,
+
+    /* Bundler mode */
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "verbatimModuleSyntax": true,
+    "moduleDetection": "force",
+    "noEmit": true,
+
+    /* Linting */
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "erasableSyntaxOnly": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUncheckedSideEffectImports": true,
+    // For Code.org applications, the `@/*` path alias refers to the `src` directory
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  }
+}

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -1242,6 +1242,7 @@ __metadata:
   dependencies:
     "@eslint/js": "npm:^9.15.0"
     "@tsconfig/node22": "npm:^22.0.4"
+    "@tsconfig/vite-react": "npm:^7.0.2"
     eslint: "npm:^9.15.0"
     eslint-import-resolver-typescript: "npm:^3.6.3"
     eslint-plugin-import-x: "npm:^4.4.3"
@@ -5491,6 +5492,13 @@ __metadata:
   version: 22.0.4
   resolution: "@tsconfig/node22@npm:22.0.4"
   checksum: 10c0/3c55efaa4a097740f5280bbe0e94baef673cd71925c07e8a6251d878809ef1ed065d8a44085ebe39b496612f40fe4c7cff7ab67c199534b60dc2236407e752b7
+  languageName: node
+  linkType: hard
+
+"@tsconfig/vite-react@npm:^7.0.2":
+  version: 7.0.2
+  resolution: "@tsconfig/vite-react@npm:7.0.2"
+  checksum: 10c0/cc63685e4f7b70a2ca34becb81939dad3f852f5640b6072aeeb2671b41f8bd1d80746ac7438c166090d6f22ca41db89282238e09a8877b8ac495c9fb0fa58257
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This PR refactors the tsconfig structure for vite to use a shared
configuration to prepare for the initialization of vite-based
sub-packages and labs. This allows newly created packages to extend the
shared tsconfig and not have to manage many different configuration
flavors.

- Change base configurations to extend from Vite-specific TypeScript settings.
- Add new TypeScript configuration files for Vite applications and Node.
- Add package dependencies to include @tsconfig/vite-react.