### PR TITLE
chore(lintstaged): add missing config

### DIFF
--- a/frontend/apps/studio/.lintstagedrc.mjs
+++ b/frontend/apps/studio/.lintstagedrc.mjs
@@ -1,0 +1,6 @@
+import baseConfig from '@code-dot-org/lint-config/lint-staged/lintstagedrc.mjs';
+
+/**
+ * @type {import('lint-staged').Configuration}
+ */
+export default baseConfig;


### PR DESCRIPTION
lintstaged was not working for commit hooks because the config was missing. Added a default config.