### PR TITLE
Handle Schoology nrps bug

### DIFF
--- a/dashboard/lib/clients/lti_advantage_client.rb
+++ b/dashboard/lib/clients/lti_advantage_client.rb
@@ -1,35 +1,40 @@
 class Clients::LtiAdvantageClient
   include LtiAccessToken
 
+  PAGE_LIMIT = 100
+
   def initialize(client_id, issuer)
     raise ArgumentError unless client_id && issuer
     @client_id = client_id
     @issuer = issuer
+    @page_limit = PAGE_LIMIT
   end
 
   # Call the LTI Advantage API to get the membership (roster) for a given context (course/section).
   # The URL for the API will vary between LMS platforms, and is initially contained in the launch context.
   # See the LTI spec for details:
   # https://www.imsglobal.org/spec/lti-nrps/v2p0/
-  def get_context_membership(url, resource_link_id, page_limit = 100)
+  def get_context_membership(url, resource_link_id)
     options = {
       headers: {
         'Accept' => Policies::Lti::MEMBERSHIP_CONTAINER_CONTENT_TYPE,
         'Authorization' => "Bearer #{get_access_token(@client_id, @issuer)}",
       },
-      query: {
-        limit: page_limit,
-      },
     }
-    options[:query][:rlid] = resource_link_id if Policies::Lti.issuer_accepts_resource_link?(@issuer)
-    res = make_request(url, options)
+    initial_url = build_uri(url, resource_link_id)
+    res = make_request(initial_url, options)
     next_page = next_page_url(res[:headers])
     parsed_res = res[:body]
+    # For Schoology, we need to pass the next page number due to a bug in their API implementation.
+    # Since we've alredy fetched the first page, we start at page 2.
+    page = 2
     while next_page
+      next_page = @issuer == Policies::Lti::LMS_PLATFORMS[:schoology][:issuer] ?  build_uri_schoology(next_page, resource_link_id, page) : build_uri(next_page, resource_link_id)
       current_page = make_request(next_page, options)
       parsed_res[:members].concat(current_page[:body][:members])
       return parsed_res unless parsed_res[:members].length <= Policies::Lti::MAX_COURSE_MEMBERSHIP
       next_page = next_page_url(current_page[:headers])
+      page += 1
     end
     parsed_res
   end
@@ -39,6 +44,26 @@ def make_request(url, options)
   res = HTTParty.get(url, options)
   raise "Error getting context membership: #{res.code} #{res.body}" unless res.code == HTTP::Status::OK
   return {headers: res.headers, body: JSON.parse(res.body, symbolize_names: true)}
+end
+
+private def build_uri(url, resource_link_id)
+  uri = URI(url)
+  existing_params = uri.query ? Rack::Utils.parse_query(uri.query) : {}
+  # Rack::Utils.parse_query returns string keys, so we need to use string keys when merging
+  rlid_param = Policies::Lti.issuer_accepts_resource_link?(@issuer) ? {'rlid' => resource_link_id} : {}
+  page_limit_param = {'limit' => @page_limit}
+  query_params = existing_params.merge(page_limit_param, rlid_param)
+  uri.query = query_params.to_query
+  uri.to_s
+end
+
+private def build_uri_schoology(url, resource_link_id, page)
+  uri = URI(url)
+  uri.query = {
+    limit: @page_limit,
+    page: page,
+  }.to_query
+  uri.to_s
 end
 
 # Get the next page URL from the Link header in the response.

--- a/dashboard/lib/clients/lti_advantage_client.rb
+++ b/dashboard/lib/clients/lti_advantage_client.rb
@@ -26,10 +26,10 @@ class Clients::LtiAdvantageClient
     next_page = next_page_url(res[:headers])
     parsed_res = res[:body]
     # For Schoology, we need to pass the next page number due to a bug in their API implementation.
-    # Since we've alredy fetched the first page, we start at page 2.
+    # Since we've already fetched the first page, we start at page 2.
     page = 2
     while next_page
-      next_page = @issuer == Policies::Lti::LMS_PLATFORMS[:schoology][:issuer] ?  build_uri_schoology(next_page, resource_link_id, page) : build_uri(next_page, resource_link_id)
+      next_page = @issuer == Policies::Lti::LMS_PLATFORMS[:schoology][:issuer] ?  build_uri_schoology(next_page, page) : build_uri(next_page, resource_link_id)
       current_page = make_request(next_page, options)
       parsed_res[:members].concat(current_page[:body][:members])
       return parsed_res unless parsed_res[:members].length <= Policies::Lti::MAX_COURSE_MEMBERSHIP
@@ -57,7 +57,7 @@ private def build_uri(url, resource_link_id)
   uri.to_s
 end
 
-private def build_uri_schoology(url, resource_link_id, page)
+private def build_uri_schoology(url, page)
   uri = URI(url)
   uri.query = {
     limit: @page_limit,

--- a/dashboard/test/lib/clients/lti_advantage_client_test.rb
+++ b/dashboard/test/lib/clients/lti_advantage_client_test.rb
@@ -9,8 +9,8 @@ class Clients::LtiAdvantageClientTest < ActiveSupport::TestCase
 
     @lti_client = Clients::LtiAdvantageClient.new(@client_id, @issuer)
     @lti_client.stubs(:get_access_token).returns('fake_access_token')
-    @page_2_url = 'https://example.com/api/lti/courses/1234/memberships?rlid=1234&page=2'
-    @page_3_url = 'https://example.com/api/lti/courses/1234/memberships?rlid=1234&page=3'
+    @page_2_url = 'https://example.com/api/lti/courses/1234/memberships?limit=100&page=2&rlid=1234'
+    @page_3_url = 'https://example.com/api/lti/courses/1234/memberships?limit=100&page=3&rlid=1234'
     @response_page_1 = {
       headers: {
         link: "<#{@page_2_url}>; rel=\"next\""
@@ -39,19 +39,15 @@ class Clients::LtiAdvantageClientTest < ActiveSupport::TestCase
     response_body = 'expected_response_body'
 
     access_token = 'expected_access_token'
-    url = 'expected_url'
+    url = 'expected_url?limit=100&rlid=expected_rlid'
     expected_headers = {
       'Accept' => 'application/vnd.ims.lti-nrps.v2.membershipcontainer+json',
       'Authorization' => "Bearer #{access_token}"
     }
-    expected_query = {
-      rlid: @rlid,
-      limit: 100
-    }
 
     @lti_client.expects(:sign_jwt).never # should not be called since the get_access_token method is stubbed
     @lti_client.expects(:get_access_token).with(@client_id, @issuer).once.returns(access_token)
-    HTTParty.expects(:get).with(url, headers: expected_headers, query: expected_query).once.returns(stub(code: response_code, body: response_body))
+    HTTParty.expects(:get).with(url, headers: expected_headers).once.returns(stub(code: response_code, body: response_body))
     Policies::Lti.stubs(:issuer_accepts_resource_link?).returns(true)
     actual_error = assert_raises(RuntimeError) {@lti_client.get_context_membership(url, @rlid)}
     assert_equal "Error getting context membership: #{response_code} #{response_body}", actual_error.message
@@ -65,7 +61,8 @@ class Clients::LtiAdvantageClientTest < ActiveSupport::TestCase
 
   test 'fetches the next page if present' do
     original_url = "https://example.com/api/lti/courses/1234/memberships?rlid=1234"
-    @lti_client.expects(:make_request).with(original_url, anything).once.returns(@response_page_1)
+    expected_url_page_1 = "https://example.com/api/lti/courses/1234/memberships?limit=100&rlid=1234"
+    @lti_client.expects(:make_request).with(expected_url_page_1, anything).once.returns(@response_page_1)
     @lti_client.expects(:make_request).with(@page_2_url, anything).once.returns(@response_page_2)
     @lti_client.expects(:make_request).with(@page_3_url, anything).once.returns(@response_page_3)
     res = @lti_client.get_context_membership(original_url, @rlid)


### PR DESCRIPTION
This PR adds functionality to handle a bug in the Schoology NRPS API, where it doesn't increment the page query param. Additionally, this PR improves the query param handling for all NRPS responses, with special handling for Schoology specifically until they address the bug (we've opened a ticket on them).

This was extensively tested locally against our Schoology and Canvas sandbox accounts to make sure we are handling the new functionality correctly, and not breaking existing functionality.

This is a highly important PR, as it allows the El Paso school district to correctly roster for Hour of AI.

## Additional Context

When we call an NRPS API, we add a `limit=100` query parameter. Schoology mirrors back this URL in a response header (the link to the next URL to call), and we were inadvertently concatenating another `limit=100` query param. We hit this error for the first time this week, as we've never had a course larger than 100 being rostered via LTI. Here is an example of the concatenated URL we ended up calling

```
https://lti-service.svc.schoology.com/lti-service/tool/foo/services/names-roles/v2p0/membership/bar?limit=100&limit=100&page=1
``` 

Once we fixed this, we discovered Schoology actually isn't returning the correct link to the next URL in the header. Here's the header we get back from Schoology. You can see the `page=1` param in this URL. We would expect this page to be a link to the next page we should call, but it is actually the current "page" we are on. As a result, we have to manually increment this page count for Schoology only.

```
link: <https://lti-service.svc.schoology.com/lti-service/tool/foo/services/names-roles/v2p0/membership/bar?limit=100&page=1>; rel="next"
```


<!-- end warning -->


<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->


## Links
<!--  Links to relevant external resources.
      - spec docs, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- Jira: 

## Testing story
<!--  Does your change include appropriate tests?
      - If so, please describe how the tests included in this PR are sufficient.
      - If not, please explain why this change does not need to be tested. -->



## Deployment strategy
<!--  Any special steps required to deploy this, besides merging?
      - Are there database migrations or manual steps?
      - Does this require coordination with other teams or systems? -->



## Follow-up work
<!--  List any clean-up or technical debt that will be addressed in future work.
      - Include Jira links where applicable.
      - Are there any known limitations or improvements planned? -->



## Privacy
<!--  How does this change impact Student & Teacher privacy?
      - Does this collect, use, share, or modify PII, either new or existing? -->



## Security
<!--  How does this change impact our security surface-area?
      - Do API's touched have the right auth?
      - Do infra changes impact our attack surface or encryption?
-->



## Caching
<!--  How does this change impact caching behavior?
      - Are cache keys or invalidation strategies affected?
      - Will this require cache warming or invalidation after deployment? -->



## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
