### PR TITLE
chore(turbo): use turbo watch mode for dev

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -69,20 +69,14 @@ yarn build
 
 ### Develop
 
-To develop **all** apps and packages, run the following command:
+To develop on the **studio** application, run in the `frontend` directory
 
 ```bash
 yarn dev
 ```
 
-To develop a specific set of apps and packages, use `yarn workspace [workspace name] [command]`.
-More information on this command [here](https://yarnpkg.com/cli/workspace).
-
-For example, to only run the design system storybook:
-
-```bash
-yarn workspace @code-dot-org/design-system-storybook dev
-```
+Changing any monorepo managed dependencies (such as labs) will automatically trigger a rebuild and be made
+available to the persistent dev server using Turborepo's watch feature.
 
 ### Formatting, Linting. (Prettier, ESLint, Stylelint)
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -18,7 +18,7 @@
   "scripts": {
     "build": "turbo build",
     "clean": "turbo clean",
-    "dev": "turbo dev",
+    "dev": "turbo watch dev --filter @code-dot-org/studio",
     "format": "prettier --check *",
     "format:fix": "prettier --write .",
     "lint": "turbo lint",
@@ -39,7 +39,7 @@
     "lint-staged": "^15.4.3",
     "prettier": "3.4.2",
     "rimraf": "^6.0.1",
-    "turbo": "^2.3.0",
+    "turbo": "^2.6.3",
     "typescript": "5.8.2",
     "typescript-eslint": "^8.49.0"
   },

--- a/frontend/turbo.json
+++ b/frontend/turbo.json
@@ -5,7 +5,7 @@
     "build": {
       "dependsOn": ["^build"],
       "inputs": ["$TURBO_DEFAULT$", ".env*"],
-      "outputs": [".next/**", "!.next/cache/**", "dist/**"]
+      "outputs": ["dist/**"]
     },
     "clean": {
       "dependsOn": ["^clean"]

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -1222,7 +1222,7 @@ __metadata:
     lint-staged: "npm:^15.4.3"
     prettier: "npm:3.4.2"
     rimraf: "npm:^6.0.1"
-    turbo: "npm:^2.3.0"
+    turbo: "npm:^2.6.3"
     typescript: "npm:5.8.2"
     typescript-eslint: "npm:^8.49.0"
   languageName: unknown
@@ -19082,58 +19082,58 @@ __metadata:
   languageName: node
   linkType: hard
 
-"turbo-darwin-64@npm:2.3.0":
-  version: 2.3.0
-  resolution: "turbo-darwin-64@npm:2.3.0"
+"turbo-darwin-64@npm:2.6.3":
+  version: 2.6.3
+  resolution: "turbo-darwin-64@npm:2.6.3"
   conditions: os=darwin & cpu=x64
   languageName: node
   linkType: hard
 
-"turbo-darwin-arm64@npm:2.3.0":
-  version: 2.3.0
-  resolution: "turbo-darwin-arm64@npm:2.3.0"
+"turbo-darwin-arm64@npm:2.6.3":
+  version: 2.6.3
+  resolution: "turbo-darwin-arm64@npm:2.6.3"
   conditions: os=darwin & cpu=arm64
   languageName: node
   linkType: hard
 
-"turbo-linux-64@npm:2.3.0":
-  version: 2.3.0
-  resolution: "turbo-linux-64@npm:2.3.0"
+"turbo-linux-64@npm:2.6.3":
+  version: 2.6.3
+  resolution: "turbo-linux-64@npm:2.6.3"
   conditions: os=linux & cpu=x64
   languageName: node
   linkType: hard
 
-"turbo-linux-arm64@npm:2.3.0":
-  version: 2.3.0
-  resolution: "turbo-linux-arm64@npm:2.3.0"
+"turbo-linux-arm64@npm:2.6.3":
+  version: 2.6.3
+  resolution: "turbo-linux-arm64@npm:2.6.3"
   conditions: os=linux & cpu=arm64
   languageName: node
   linkType: hard
 
-"turbo-windows-64@npm:2.3.0":
-  version: 2.3.0
-  resolution: "turbo-windows-64@npm:2.3.0"
+"turbo-windows-64@npm:2.6.3":
+  version: 2.6.3
+  resolution: "turbo-windows-64@npm:2.6.3"
   conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
 
-"turbo-windows-arm64@npm:2.3.0":
-  version: 2.3.0
-  resolution: "turbo-windows-arm64@npm:2.3.0"
+"turbo-windows-arm64@npm:2.6.3":
+  version: 2.6.3
+  resolution: "turbo-windows-arm64@npm:2.6.3"
   conditions: os=win32 & cpu=arm64
   languageName: node
   linkType: hard
 
-"turbo@npm:^2.3.0":
-  version: 2.3.0
-  resolution: "turbo@npm:2.3.0"
+"turbo@npm:^2.6.3":
+  version: 2.6.3
+  resolution: "turbo@npm:2.6.3"
   dependencies:
-    turbo-darwin-64: "npm:2.3.0"
-    turbo-darwin-arm64: "npm:2.3.0"
-    turbo-linux-64: "npm:2.3.0"
-    turbo-linux-arm64: "npm:2.3.0"
-    turbo-windows-64: "npm:2.3.0"
-    turbo-windows-arm64: "npm:2.3.0"
+    turbo-darwin-64: "npm:2.6.3"
+    turbo-darwin-arm64: "npm:2.6.3"
+    turbo-linux-64: "npm:2.6.3"
+    turbo-linux-arm64: "npm:2.6.3"
+    turbo-windows-64: "npm:2.6.3"
+    turbo-windows-arm64: "npm:2.6.3"
   dependenciesMeta:
     turbo-darwin-64:
       optional: true
@@ -19149,7 +19149,7 @@ __metadata:
       optional: true
   bin:
     turbo: bin/turbo
-  checksum: 10c0/cad6a7b16d2cdaa15fe75efe1938d335cb026c073dfe639aaf2dce4c4d10ecc6a63216689682c1d1f7238ceed56f6e4ba736aa1b738aec70afb66f770e7c3817
+  checksum: 10c0/3dab627a4e0f855c2ea2cc5e7d3d7abed01a7abace1197983c55e0563c413dfe45c80c121e5fa25d2cca013d895bde457d5cdf3a3d47000dc7d432a4cb68e78f
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Currently, when developing in `frontend`, it triggers a build and executes a persistent `dev` server which watches for changes. However, changing any files in dependencies (such as component library, labs, etc.) does not trigger a rebuild except if you ran `dev` with extra filter flags for the component you wished to run dev on. This results in a poor DevEx as the system should automatically determine what packages to rebuild using its dependency tracking system.

To address this, leverage the `turbo watch` feature which will automatically detect when a specific dependency has changed and trigger its build process. This improves DevEx as contributors will only need to run `yarn dev` on studio which will automatically take care of rebuilding as needed.

This PR also performs an upgrade of Turborepo to the latest version and removes Next.js outputs as we no longer use Next.js here.

- Clarified development instructions for the studio application in README.md.
- Updated package.json scripts for the studio app to use `turbo watch dev --filter @code-dot-org/studio`.
- Adjusted build and dev scripts in music package.json for consistency.
- Updated turbo.json outputs to streamline build process.
- Upgraded turbo dependency version in package.json and yarn.lock.