### PR TITLE
Improve screenreader a11y for AI tutor files 

### DIFF
--- a/apps/src/aiComponentLibrary/aiTutorVersionFileChip/AiTutorVersionFileChip.tsx
+++ b/apps/src/aiComponentLibrary/aiTutorVersionFileChip/AiTutorVersionFileChip.tsx
@@ -49,6 +49,18 @@ const AiTutorVersionFileChip: React.FC<AiTutorVersionFileChipProps> = ({
     dispatch(setAiFilePathToPreview({path: filePath, timestamp: Date.now()}));
   };
 
+  const statusText = isNewFile
+    ? 'New file created by AI Tutor'
+    : 'File updated by AI Tutor';
+  const acceptanceText = !isInReview
+    ? isAccepted
+      ? ', accepted'
+      : ', rejected'
+    : '';
+  const accessibleLabel = `${statusText}: ${file.name}${acceptanceText}`;
+
+  const hasPreviewButton = isHtmlFile && isInReview;
+
   return (
     <div
       className={classNames(moduleStyles.chip, {
@@ -56,14 +68,36 @@ const AiTutorVersionFileChip: React.FC<AiTutorVersionFileChipProps> = ({
         [moduleStyles.updatedFile]: isUpdatedFile,
       })}
     >
-      <div className={moduleStyles.statusIndicator}>
-        <FontAwesomeV6Icon
-          iconName={isNewFile ? 'plus-circle' : 'pen-circle'}
-          iconStyle="solid"
-        />
+      {/* File info - accessible as a single image element */}
+      <div
+        className={moduleStyles.fileInfo}
+        role="img"
+        aria-label={accessibleLabel}
+      >
+        <div className={moduleStyles.statusIndicator}>
+          <FontAwesomeV6Icon
+            iconName={isNewFile ? 'plus-circle' : 'pen-circle'}
+            iconStyle="solid"
+          />
+        </div>
+        <span className={moduleStyles.fileName}>{file.name}</span>
+        {!isInReview && isAccepted && (
+          <FontAwesomeV6Icon
+            iconName="check"
+            iconStyle="solid"
+            className={moduleStyles.acceptedIcon}
+          />
+        )}
+        {!isInReview && !isAccepted && (
+          <FontAwesomeV6Icon
+            iconName="xmark"
+            iconStyle="solid"
+            className={moduleStyles.rejectedIcon}
+          />
+        )}
       </div>
-      <span className={moduleStyles.fileName}>{file.name}</span>
-      {isHtmlFile && isInReview && (
+      {/* Preview button - outside role="img" so it remains accessible */}
+      {hasPreviewButton && (
         <span className={moduleStyles.previewButtonWrapper}>
           <WithTooltip
             tooltipProps={{
@@ -84,20 +118,6 @@ const AiTutorVersionFileChip: React.FC<AiTutorVersionFileChipProps> = ({
             />
           </WithTooltip>
         </span>
-      )}
-      {!isInReview && isAccepted && (
-        <FontAwesomeV6Icon
-          iconName="check"
-          iconStyle="solid"
-          className={moduleStyles.acceptedIcon}
-        />
-      )}
-      {!isInReview && !isAccepted && (
-        <FontAwesomeV6Icon
-          iconName="xmark"
-          iconStyle="solid"
-          className={moduleStyles.rejectedIcon}
-        />
       )}
     </div>
   );

--- a/apps/src/aiComponentLibrary/aiTutorVersionFileChip/AiTutorVersionFileChip.tsx
+++ b/apps/src/aiComponentLibrary/aiTutorVersionFileChip/AiTutorVersionFileChip.tsx
@@ -68,10 +68,9 @@ const AiTutorVersionFileChip: React.FC<AiTutorVersionFileChipProps> = ({
         [moduleStyles.updatedFile]: isUpdatedFile,
       })}
     >
-      {/* File info - accessible as a single image element */}
       <div
         className={moduleStyles.fileInfo}
-        role="img"
+        role="status"
         aria-label={accessibleLabel}
       >
         <div className={moduleStyles.statusIndicator}>

--- a/apps/src/aiComponentLibrary/aiTutorVersionFileChip/ai-tutor-version-file-chip.module.scss
+++ b/apps/src/aiComponentLibrary/aiTutorVersionFileChip/ai-tutor-version-file-chip.module.scss
@@ -12,6 +12,14 @@
   position: relative;
   box-sizing: border-box;
 
+  .fileInfo {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    flex: 1;
+    min-width: 0; // Allow text truncation
+  }
+
   .statusIndicator {
     position: absolute;
     top: -1px;


### PR DESCRIPTION
This PR improves screenreader accessibility for the `AiTutorVersionFileChip` component by adding more detailed status info for files that are updated/created by AI tutor during the review process. Instead of just the file name being read out loud (e.g. '`index.html` you are currently on a selectable text'), the label is now more descriptive (e.g. 'File updated by AI Tutor `index.html` image'). And if the notification is selected, 'accept' or 'reject' is included in the VoiceOver announcement.

I added `role="status"` with `aria-label`, wrapped the visual elements in a `.fileInfo` container with an accessible label but had to move the preview button outside of `role="status"` container so it remains focusable and interactive.


## After update

Screencast of user navigating in chat history that includes the following chat events:
- a notification that contains an AI tutor version file chip (accepted),
- a model response that contains an AI tutor version file chip in review - when the user using VoiceOver navigation (Ctrl+option+right arrow) and navigates to file chip, detailed status is announced.


https://github.com/user-attachments/assets/401016f7-d55f-46f2-8df1-9d9454b727fc






## Warning!!

We have entered Pixel Lock for Hour of AI! All merges to the `staging` branch from Dec 2 through Dec 12 must go through live change review and be deemed critical for supporting the Hour of AI. External contributions will not be accepted at this time.

For non-critical changes, please change your base to `staging-next` and delete this warning. We will merge `staging-next` into `staging` on Dec 15, 2025.

<!-- end warning -->


<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->


## Links
<!--  Links to relevant external resources.
      - spec docs, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- Jira: https://codedotorg.atlassian.net/browse/AFL-198

## Testing story
<!--  Does your change include appropriate tests?
      - If so, please describe how the tests included in this PR are sufficient.
      - If not, please explain why this change does not need to be tested. -->

I tested with VoiceOver on macOS (Cmd+F5). The screenreader now announced:
- File info: "New file created by AI Tutor: script.js, accepted, image"
- Preview button (when present): "Preview script.js, button"


## Deployment strategy
<!--  Any special steps required to deploy this, besides merging?
      - Are there database migrations or manual steps?
      - Does this require coordination with other teams or systems? -->



## Follow-up work
<!--  List any clean-up or technical debt that will be addressed in future work.
      - Include Jira links where applicable.
      - Are there any known limitations or improvements planned? -->



## Privacy
<!--  How does this change impact Student & Teacher privacy?
      - Does this collect, use, share, or modify PII, either new or existing? -->



## Security
<!--  How does this change impact our security surface-area?
      - Do API's touched have the right auth?
      - Do infra changes impact our attack surface or encryption?
-->



## Caching
<!--  How does this change impact caching behavior?
      - Are cache keys or invalidation strategies affected?
      - Will this require cache warming or invalidation after deployment? -->



## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
