### PR TITLE
DSCO swap: student dropdown on projects page 

### DIFF
--- a/apps/src/templates/projects/SectionProjectsList.jsx
+++ b/apps/src/templates/projects/SectionProjectsList.jsx
@@ -65,7 +65,6 @@ class SectionProjectsList extends Component {
 
     return (
       <div>
-        <h1>Hi!</h1>
         <div style={styles.filterRow}>
           <StudentFilterDropdown
             onChangeStudent={this.onChangeStudent.bind(this)}

--- a/apps/src/templates/projects/SectionProjectsList.jsx
+++ b/apps/src/templates/projects/SectionProjectsList.jsx
@@ -65,6 +65,7 @@ class SectionProjectsList extends Component {
 
     return (
       <div>
+        <h1>Hi!</h1>
         <div style={styles.filterRow}>
           <StudentFilterDropdown
             onChangeStudent={this.onChangeStudent.bind(this)}

--- a/apps/src/templates/projects/StudentFilterDropdown.jsx
+++ b/apps/src/templates/projects/StudentFilterDropdown.jsx
@@ -5,7 +5,6 @@ import React, {Component} from 'react';
 import commonMsg from '@cdo/locale';
 
 import styles from './StudentFilterDropdown.module.scss';
-import classNames from 'classnames';
 
 export const ALL_STUDENTS = '_all_students';
 

--- a/apps/src/templates/projects/StudentFilterDropdown.jsx
+++ b/apps/src/templates/projects/StudentFilterDropdown.jsx
@@ -31,7 +31,6 @@ class StudentFilterDropdown extends Component {
           </p>
         </span>
         <SimpleDropdown
-          labelText={commonMsg.filterByStudent()}
           isLabelVisible={false}
           aria-label={commonMsg.filterByStudent()}
           dropdownTextThickness="thin"

--- a/apps/src/templates/projects/StudentFilterDropdown.jsx
+++ b/apps/src/templates/projects/StudentFilterDropdown.jsx
@@ -5,6 +5,7 @@ import React, {Component} from 'react';
 import commonMsg from '@cdo/locale';
 
 import styles from './StudentFilterDropdown.module.scss';
+import classNames from 'classnames';
 
 export const ALL_STUDENTS = '_all_students';
 
@@ -24,9 +25,16 @@ class StudentFilterDropdown extends Component {
   render() {
     return (
       <span className={styles.filterWrapper} style={this.props.style}>
+        <span className={styles.filterLabel}>
+          <p className={classNames(styles.filterLabelText)}>
+            {commonMsg.filterByStudent()}
+          </p>
+        </span>
         <SimpleDropdown
           labelText={commonMsg.filterByStudent()}
+          isLabelVisible={false}
           aria-label={commonMsg.filterByStudent()}
+          dropdownTextThickness="thin"
           selectedValue={this.props.selectedStudent}
           onChange={this.onChange.bind(this)}
           size="s"

--- a/apps/src/templates/projects/StudentFilterDropdown.jsx
+++ b/apps/src/templates/projects/StudentFilterDropdown.jsx
@@ -1,11 +1,10 @@
+import {SimpleDropdown} from '@code-dot-org/component-library/dropdown';
 import PropTypes from 'prop-types';
-import Radium from 'radium'; // eslint-disable-line no-restricted-imports
 import React, {Component} from 'react';
 
-import fontConstants from '@cdo/apps/fontConstants';
 import commonMsg from '@cdo/locale';
 
-import color from '../../util/color';
+import styles from './StudentFilterDropdown.module.scss';
 
 export const ALL_STUDENTS = '_all_students';
 
@@ -24,42 +23,28 @@ class StudentFilterDropdown extends Component {
 
   render() {
     return (
-      <span style={[styles.filterWrapper, this.props.style]}>
-        <span style={styles.filterText}>{commonMsg.filterByStudent()}</span>
-        &nbsp;
-        <select
-          value={this.props.selectedStudent}
+      <span className={styles.filterWrapper} style={this.props.style}>
+        <SimpleDropdown
+          labelText={commonMsg.filterByStudent()}
+          aria-label={commonMsg.filterByStudent()}
+          selectedValue={this.props.selectedStudent}
           onChange={this.onChange.bind(this)}
-          style={styles.filterSelect}
-        >
-          <option value={ALL_STUDENTS} key={ALL_STUDENTS}>
-            {commonMsg.allStudents()}
-          </option>
-          {this.props.studentNames.map(studentName => (
-            <option value={studentName} key={studentName}>
-              {studentName}
-            </option>
-          ))}
-        </select>
+          size="s"
+          name="students"
+          items={[
+            {
+              value: ALL_STUDENTS,
+              text: commonMsg.allStudents(),
+            },
+            ...this.props.studentNames.map(studentName => ({
+              value: studentName,
+              text: studentName,
+            })),
+          ]}
+        />
       </span>
     );
   }
 }
 
-const styles = {
-  filterWrapper: {
-    display: 'inline-flex',
-    alignItems: 'center',
-    fontSize: 14,
-  },
-  filterSelect: {
-    margin: 0,
-    color: 'dimgray',
-  },
-  filterText: {
-    color: color.charcoal,
-    ...fontConstants['main-font-semi-bold'],
-  },
-};
-
-export default Radium(StudentFilterDropdown);
+export default StudentFilterDropdown;

--- a/apps/src/templates/projects/StudentFilterDropdown.jsx
+++ b/apps/src/templates/projects/StudentFilterDropdown.jsx
@@ -26,7 +26,7 @@ class StudentFilterDropdown extends Component {
     return (
       <span className={styles.filterWrapper} style={this.props.style}>
         <span className={styles.filterLabel}>
-          <p className={classNames(styles.filterLabelText)}>
+          <p className={styles.filterLabelText}>
             {commonMsg.filterByStudent()}
           </p>
         </span>

--- a/apps/src/templates/projects/StudentFilterDropdown.jsx
+++ b/apps/src/templates/projects/StudentFilterDropdown.jsx
@@ -37,6 +37,7 @@ class StudentFilterDropdown extends Component {
           selectedValue={this.props.selectedStudent}
           onChange={this.onChange.bind(this)}
           size="s"
+          color="gray"
           name="students"
           items={[
             {

--- a/apps/src/templates/projects/StudentFilterDropdown.module.scss
+++ b/apps/src/templates/projects/StudentFilterDropdown.module.scss
@@ -2,4 +2,19 @@
   display: inline-flex;
   align-items: center;
   font-size: 14px;
+  height: 24px;
+  float: right;
+}
+
+.filterLabel {
+  display: inline-flex;
+  align-items: center;
+  font-size: 14px;
+  float: right;
+}
+
+.filterLabelText {
+  margin: 0 8px 0 0;
+  color: rgb(91, 103, 112);
+  font-weight: 600;
 }

--- a/apps/src/templates/projects/StudentFilterDropdown.module.scss
+++ b/apps/src/templates/projects/StudentFilterDropdown.module.scss
@@ -8,7 +8,6 @@
 .filterLabel {
   display: inline-flex;
   align-items: center;
-  float: right;
 }
 
 .filterLabelText {

--- a/apps/src/templates/projects/StudentFilterDropdown.module.scss
+++ b/apps/src/templates/projects/StudentFilterDropdown.module.scss
@@ -9,7 +9,6 @@
 .filterLabel {
   display: inline-flex;
   align-items: center;
-  font-size: 14px;
   float: right;
 }
 
@@ -17,4 +16,5 @@
   margin: 0 8px 0 0;
   color: rgb(91, 103, 112);
   font-weight: 600;
+  font-size: 16px;
 }

--- a/apps/src/templates/projects/StudentFilterDropdown.module.scss
+++ b/apps/src/templates/projects/StudentFilterDropdown.module.scss
@@ -1,0 +1,5 @@
+.filterWrapper {
+  display: inline-flex;
+  align-items: center;
+  font-size: 14px;
+}

--- a/apps/src/templates/projects/StudentFilterDropdown.module.scss
+++ b/apps/src/templates/projects/StudentFilterDropdown.module.scss
@@ -12,7 +12,7 @@
 
 .filterLabelText {
   margin: 0 8px 0 0;
-  color: rgb(91, 103, 112);
+  color: var(--text-neutral-primary);
   font-weight: 600;
   font-size: 16px;
 }

--- a/apps/src/templates/projects/StudentFilterDropdown.module.scss
+++ b/apps/src/templates/projects/StudentFilterDropdown.module.scss
@@ -3,7 +3,6 @@
   align-items: center;
   font-size: 14px;
   height: 24px;
-  float: right;
 }
 
 .filterLabel {


### PR DESCRIPTION
Refactors the `StudentFilterDropdown` shown on the projects area of the teacher dashboard to use the DSCO `SimpleDropdown` component as a means to re-use the component library components more broadly and decrease our dependence on Radium. 

before 
<img width="874" height="315" alt="Screenshot 2025-12-11 at 1 25 52 PM" src="https://github.com/user-attachments/assets/2ed6060a-09cb-4349-aa4d-c0bccd988626" />

after 
<img width="1047" height="356" alt="Screenshot 2025-12-11 at 1 25 38 PM" src="https://github.com/user-attachments/assets/05d1744d-5771-454a-b805-a4795b03ad53" />

