### PR TITLE
Remove unit name collision

### DIFF
--- a/dashboard/test/controllers/aidiff_exit_tickets_controller_test.rb
+++ b/dashboard/test/controllers/aidiff_exit_tickets_controller_test.rb
@@ -7,7 +7,7 @@ class AidiffExitTicketsControllerTest < ActionController::TestCase
     @unit_group = create(:unit_group, family_name: 'beepboop')
     @course_offering = create(:course_offering, display_name: 'Course Name')
     @course_version = create(:course_version, content_root: @unit_group, course_offering: @course_offering)
-    @unit_in_course = create(:script, name: 'unit-in-teacher-instructed-course')
+    @unit_in_course = create(:script)
     create(:unit_group_unit, script: @unit_in_course, unit_group: @unit_group, position: 1)
     @lesson_group = create(:lesson_group, script: @unit_in_course)
     @lesson = create(:lesson, script: @unit_in_course, lesson_group: @lesson_group)

--- a/dashboard/test/controllers/aidiff_lesson_hooks_controller_test.rb
+++ b/dashboard/test/controllers/aidiff_lesson_hooks_controller_test.rb
@@ -7,7 +7,7 @@ class AidiffLessonHooksControllerTest < ActionController::TestCase
     @unit_group = create(:unit_group, family_name: 'beepboop')
     @course_offering = create(:course_offering, display_name: 'Course Name')
     @course_version = create(:course_version, content_root: @unit_group, course_offering: @course_offering)
-    @unit_in_course = create(:script, name: 'unit-in-teacher-instructed-course')
+    @unit_in_course = create(:script)
     create(:unit_group_unit, script: @unit_in_course, unit_group: @unit_group, position: 1)
     @lesson_group = create(:lesson_group, script: @unit_in_course)
     @lesson = create(:lesson, script: @unit_in_course, lesson_group: @lesson_group)

--- a/dashboard/test/controllers/aidiff_threads_controller_test.rb
+++ b/dashboard/test/controllers/aidiff_threads_controller_test.rb
@@ -8,7 +8,7 @@ class AidiffThreadsControllerTest < ActionController::TestCase
     @unit_group2 = create(:unit_group, family_name: 'dootdoot')
     @course_offering = create(:course_offering, display_name: 'Course Name')
     @course_version = create(:course_version, content_root: @unit_group, course_offering: @course_offering)
-    @unit_in_course = create(:script, name: 'unit-in-teacher-instructed-course2')
+    @unit_in_course = create(:script)
     create(:unit_group_unit, script: @unit_in_course, unit_group: @unit_group, position: 1)
     @lesson_group = create(:lesson_group, script: @unit_in_course)
     @lesson = create(:lesson, script: @unit_in_course, lesson_group: @lesson_group)


### PR DESCRIPTION
## Warning!!

We have entered Pixel Lock for Hour of AI! All merges to the `staging` branch from Dec 2 through Dec 12 must go through live change review and be deemed critical for supporting the Hour of AI. External contributions will not be accepted at this time.

For non-critical changes, please change your base to `staging-next` and delete this warning. We will merge `staging-next` into `staging` on Dec 15, 2025.

<!-- end warning -->

Removes the name from the unit factory create in the aidiff unit tests to fix a `name already taken` error

## Links
Slack thread: https://codedotorg.slack.com/archives/C0T0PNTM3/p1765307217436709

## Testing story
<!--  Does your change include appropriate tests?
      - If so, please describe how the tests included in this PR are sufficient.
      - If not, please explain why this change does not need to be tested. -->



## Deployment strategy
<!--  Any special steps required to deploy this, besides merging?
      - Are there database migrations or manual steps?
      - Does this require coordination with other teams or systems? -->



## Follow-up work
<!--  List any clean-up or technical debt that will be addressed in future work.
      - Include Jira links where applicable.
      - Are there any known limitations or improvements planned? -->



## Privacy
<!--  How does this change impact Student & Teacher privacy?
      - Does this collect, use, share, or modify PII, either new or existing? -->



## Security
<!--  How does this change impact our security surface-area?
      - Do API's touched have the right auth?
      - Do infra changes impact our attack surface or encryption?
-->



## Caching
<!--  How does this change impact caching behavior?
      - Are cache keys or invalidation strategies affected?
      - Will this require cache warming or invalidation after deployment? -->



## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
