### PR TITLE
[Mix&Move] Remove dance move support from Music Lab levels

### DIFF
--- a/apps/src/lab2/levelEditors/levelData/EditMusicLevelData.tsx
+++ b/apps/src/lab2/levelEditors/levelData/EditMusicLevelData.tsx
@@ -37,23 +37,6 @@ const RECOMMENDED_LIBRARY = 'launch2024';
 
 const JSON_FIELDS = [['startSources', 'Start Sources']] as const;
 
-const NO_DANCER_MOVE = 'none';
-const SUPPORTED_DANCE_MOVES = [
-  {value: NO_DANCER_MOVE, text: '(no dancer)'},
-  {value: 'rest', text: 'None (Rest)'},
-  {value: 'roll', text: 'Body Roll'},
-  {value: 'clap_high', text: 'Clap High'},
-  {value: 'dab', text: 'Dab'},
-  {value: 'double_jam', text: 'Double Down'},
-  {value: 'drop', text: 'Drop'},
-  {value: 'floss', text: 'Floss'},
-  {value: 'fresh', text: 'Fresh'},
-  {value: 'clown', text: 'Gangnam'},
-  {value: 'kick', text: 'Star'},
-  {value: 'this_or_that', text: 'This or That'},
-  {value: 'thriller', text: 'Zombie'},
-];
-
 interface EditMusicLevelDataProps {
   initialLevelData: MusicLevelData;
 }
@@ -334,29 +317,6 @@ const EditMusicLevelData: React.FunctionComponent<EditMusicLevelDataProps> = ({
                 });
               }}
               className={moduleStyles.input}
-            />
-          </div>
-          <div className={moduleStyles.inputRow}>
-            <label htmlFor="danceMove" className={moduleStyles.label}>
-              Hour of AI Settings:
-            </label>
-            <BodyFourText className={moduleStyles.helperText}>
-              If a dance move is set, the selected dance move will be used to
-              animate an AI generated Lottie Dancer over the timeline.
-            </BodyFourText>
-            <SimpleDropdown
-              labelText="Dance Move"
-              name="danceMove"
-              size="s"
-              items={SUPPORTED_DANCE_MOVES}
-              selectedValue={levelData.danceMove}
-              onChange={(event: React.ChangeEvent<HTMLSelectElement>) => {
-                let danceMove: string | undefined = event.target.value;
-                if (danceMove === NO_DANCER_MOVE) {
-                  danceMove = undefined;
-                }
-                setLevelData({...levelData, danceMove});
-              }}
             />
           </div>
         </div>

--- a/apps/src/lab2/views/DancerCanvas.tsx
+++ b/apps/src/lab2/views/DancerCanvas.tsx
@@ -1,19 +1,8 @@
 /**
  * A lightweight React component that renders a single Lottie dancer animation
  * directly into a <canvas> element using LottieDancerRenderer.
- *
- * It supports two mutually exclusive modes:
- *   • Timeline mode – when `measurePosition` is provided.
- *       The parent (e.g. MusicLab Timeline) drives animation timing by
- *       supplying a fractional measure position, and this component renders
- *       the corresponding frame on each update.
- *
- *   • GenerateDancer mode – when `measurePosition` is not provided.
- *       The component runs its own requestAnimationFrame loop, advancing
- *       by real elapsed time for a continuous preview.
- *
- * The component automatically initializes the renderer, handles resize
- * events, and notifies the parent via `onLoadingChange` while assets load.
+ * The component runs its own requestAnimationFrame loop, advancing
+ * by real elapsed time for a continuous preview.
  */
 
 import React, {useCallback, useEffect, useRef, useState} from 'react';
@@ -24,52 +13,16 @@ import {DanceMoves} from '@cdo/apps/dance/lottie/LottieDancerTypes';
 type Props = {
   /** Square pixel size for the canvas (width === height). */
   size: number;
-  /** When provided (e.g. Timeline), render based on the fractional measure. */
-  measurePosition?: number;
   /** Explicit dance move to load. */
   move?: string;
-  onLoadingChange?: (loading: boolean) => void;
 };
 
-const DancerCanvas: React.FC<Props> = ({
-  size,
-  measurePosition,
-  move,
-  onLoadingChange,
-}) => {
-  const isTimelineMode = typeof measurePosition === 'number';
-
+const DancerCanvas: React.FC<Props> = ({size, move}) => {
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
   const lastInitNodeRef = useRef<HTMLCanvasElement | null>(null);
   const rendererRef = useRef<LottieDancerRenderer | null>(null);
-
-  // Measure position is provided by the Timeline only.
-  const measureRef = useRef<number | undefined>(measurePosition);
-
-  // Current frame is used only in GenerateDancer mode.
   const frameRef = useRef(0);
-
   const [ready, setReady] = useState(false);
-
-  // Render at the specified fractional measure position (Timeline mode).
-  const renderAtMeasure = useCallback((measure: number) => {
-    const renderer = rendererRef.current;
-    if (!renderer) {
-      return;
-    }
-    const totalFrames = renderer.getDurationFrames() || 0;
-    if (!totalFrames) {
-      return;
-    }
-
-    // A single loop plays out over half a measure. Every other half-measure
-    // is mirrored.
-    const mirror = Math.floor(measure * 2) % 2 === 1;
-
-    const animationStep = measure % 1;
-    const frameIndex = Math.floor(animationStep * totalFrames * 2);
-    renderer.renderFrame(frameIndex, mirror);
-  }, []);
 
   // Render the current frame (GenerateDancer mode).
   const renderCurrentFrame = useCallback(() => {
@@ -105,35 +58,20 @@ const DancerCanvas: React.FC<Props> = ({
 
       (async () => {
         try {
-          // Communicate with GeneratedDancer that the preview is still loading.
-          onLoadingChange?.(true);
-
           if (rendererRef.current) {
             await rendererRef.current.setSource(move as DanceMoves);
           }
           setReady(true);
 
-          // Draw the first frame.
-          if (isTimelineMode) {
-            renderAtMeasure(measureRef.current!);
-          } else {
-            frameRef.current = 0;
-            renderCurrentFrame();
-          }
+          frameRef.current = 0;
+          renderCurrentFrame();
         } catch {
           setReady(false);
-        } finally {
-          // Communicate with GeneratedDancer that the preview is done loading.
-          onLoadingChange?.(false);
         }
       })();
     },
-    [isTimelineMode, move, onLoadingChange, renderAtMeasure, renderCurrentFrame]
+    [move, renderCurrentFrame]
   );
-
-  useEffect(() => {
-    measureRef.current = measurePosition;
-  }, [measurePosition]);
 
   // Resize the canvas and inform Lottie of the size change.
   useEffect(() => {
@@ -147,26 +85,13 @@ const DancerCanvas: React.FC<Props> = ({
     node.height = Math.max(1, Math.floor(size * window.devicePixelRatio));
     if (rendererRef.current && ready) {
       rendererRef.current.resize();
-      if (isTimelineMode) {
-        renderAtMeasure(measureRef.current!);
-      } else {
-        renderCurrentFrame();
-      }
+      renderCurrentFrame();
     }
-  }, [isTimelineMode, size, ready, renderAtMeasure, renderCurrentFrame]);
+  }, [size, ready, renderCurrentFrame]);
 
-  // Render using the provided measure position (e.g. Timeline mode).
+  // Render using RAF. Drives animation by real elapsed time.
   useEffect(() => {
-    if (!ready || typeof measurePosition !== 'number') {
-      return;
-    }
-    renderAtMeasure(measurePosition);
-  }, [isTimelineMode, measurePosition, ready, renderAtMeasure]);
-
-  // Render using RAF when no measure position is provided (e.g. GenerateDancer mode).
-  // Drives animation by real elapsed time.
-  useEffect(() => {
-    if (!ready || isTimelineMode) {
+    if (!ready) {
       return;
     }
 
@@ -198,7 +123,7 @@ const DancerCanvas: React.FC<Props> = ({
         cancelAnimationFrame(rafId);
       }
     };
-  }, [isTimelineMode, ready]);
+  }, [ready]);
 
   if (!move) {
     return null;

--- a/dashboard/config/levels/custom/music/HoAI-Mix-Move-Educators-11.level
+++ b/dashboard/config/levels/custom/music/HoAI-Mix-Move-Educators-11.level
@@ -183,7 +183,6 @@
     "level_data": {
       "validationTimeout": 6,
       "library": "launch2024",
-      "danceMove": "rest",
       "packId": "default",
       "guideMode": "instructions",
       "startSources": {

--- a/dashboard/config/levels/custom/music/HoAI-Mix-Move-Educators-12.level
+++ b/dashboard/config/levels/custom/music/HoAI-Mix-Move-Educators-12.level
@@ -56,7 +56,6 @@
       }
     ],
     "level_data": {
-      "danceMove": "roll",
       "guideMode": "instructions",
       "startSources": {
         "blocks": {

--- a/dashboard/config/levels/custom/music/HoAI-Mix-Move-Educators-13.level
+++ b/dashboard/config/levels/custom/music/HoAI-Mix-Move-Educators-13.level
@@ -7,7 +7,6 @@
   "properties": {
     "level_data": {
       "library": "launch2024",
-      "danceMove": "floss",
       "guideMode": "aiCodeGenerate",
       "aiCodeGenerateExtraPrompt": "Always nest play blocks inside play together. Use only two to three play togethers and do not use repeat.",
       "aiCodeGenerateAdlib": {

--- a/dashboard/config/levels/custom/music/HoAI_pilot_6_music_code_sound.level
+++ b/dashboard/config/levels/custom/music/HoAI_pilot_6_music_code_sound.level
@@ -184,7 +184,6 @@
     "level_data": {
       "validationTimeout": 6,
       "library": "launch2024",
-      "danceMove": "rest",
       "packId": "default",
       "guideMode": "instructions",
       "startSources": {

--- a/dashboard/config/levels/custom/music/HoAI_pilot_6_music_code_sound_7.level
+++ b/dashboard/config/levels/custom/music/HoAI_pilot_6_music_code_sound_7.level
@@ -183,7 +183,6 @@
     "level_data": {
       "validationTimeout": 6,
       "library": "launch2024",
-      "danceMove": "rest",
       "packId": "default",
       "startSources": {
         "blocks": {

--- a/dashboard/config/levels/custom/music/HoAI_pilot_6_music_gen_song.level
+++ b/dashboard/config/levels/custom/music/HoAI_pilot_6_music_gen_song.level
@@ -8,7 +8,6 @@
   "properties": {
     "level_data": {
       "library": "launch2024",
-      "danceMove": "dab",
       "guideMode": "aiCodeGenerate",
       "aiCodeGenerateAdlib": {
         "id": "length",

--- a/dashboard/config/levels/custom/music/HoAI_pilot_6_music_gen_song_7.level
+++ b/dashboard/config/levels/custom/music/HoAI_pilot_6_music_gen_song_7.level
@@ -7,7 +7,6 @@
   "properties": {
     "level_data": {
       "library": "launch2024",
-      "danceMove": "dab",
       "aiCodeGenerate": "true",
       "aiCodeGenerateAdlib": {
         "id": "length",

--- a/dashboard/config/levels/custom/music/HoAI_pilot_6_music_gen_song_free_text.level
+++ b/dashboard/config/levels/custom/music/HoAI_pilot_6_music_gen_song_free_text.level
@@ -10,7 +10,6 @@
       "library": "launch2024",
       "guideMode": "aiCodeGenerate",
       "aiCodeGenerateText": "true",
-      "danceMove": "dab",
       "toolbox": {
         "blocks": {
           "Play": [

--- a/dashboard/config/levels/custom/music/HoAI_pilot_6_music_gen_song_free_text_7.level
+++ b/dashboard/config/levels/custom/music/HoAI_pilot_6_music_gen_song_free_text_7.level
@@ -9,7 +9,6 @@
       "library": "launch2024",
       "aiCodeGenerate": "true",
       "aiCodeGenerateText": "true",
-      "danceMove": "dab",
       "toolbox": {
         "blocks": {
           "Play": [

--- a/dashboard/config/levels/custom/music/HoAI_pilot_6_music_gen_tog.level
+++ b/dashboard/config/levels/custom/music/HoAI_pilot_6_music_gen_tog.level
@@ -8,7 +8,6 @@
   "properties": {
     "level_data": {
       "library": "launch2024",
-      "danceMove": "floss",
       "guideMode": "aiCodeGenerate",
       "aiCodeGenerateExtraPrompt": "Always nest play blocks inside play together. Use only two to three play togethers and do not use repeat.",
       "aiCodeGenerateAdlib": {

--- a/dashboard/config/levels/custom/music/HoAI_pilot_6_music_gen_tog_7.level
+++ b/dashboard/config/levels/custom/music/HoAI_pilot_6_music_gen_tog_7.level
@@ -7,7 +7,6 @@
   "properties": {
     "level_data": {
       "library": "launch2024",
-      "danceMove": "floss",
       "aiCodeGenerate": "true",
       "aiCodeGenerateExtraPrompt": "Always nest play blocks inside play together. Use only two to three play togethers and do not use repeat.",
       "aiCodeGenerateAdlib": {

--- a/dashboard/config/levels/custom/music/HoAI_pilot_7_music_code_sound.level
+++ b/dashboard/config/levels/custom/music/HoAI_pilot_7_music_code_sound.level
@@ -184,7 +184,6 @@
     "level_data": {
       "validationTimeout": 6,
       "library": "launch2024",
-      "danceMove": "rest",
       "packId": "default",
       "guideMode": "instructions",
       "startSources": {

--- a/dashboard/config/levels/custom/music/HoAI_pilot_7_music_gen_song.level
+++ b/dashboard/config/levels/custom/music/HoAI_pilot_7_music_gen_song.level
@@ -8,7 +8,6 @@
   "properties": {
     "level_data": {
       "library": "launch2024",
-      "danceMove": "dab",
       "guideMode": "aiCodeGenerate",
       "aiCodeGenerateAdlib": {
         "id": "length",

--- a/dashboard/config/levels/custom/music/HoAI_pilot_7_music_gen_tog.level
+++ b/dashboard/config/levels/custom/music/HoAI_pilot_7_music_gen_tog.level
@@ -7,7 +7,6 @@
   "properties": {
     "level_data": {
       "library": "launch2024",
-      "danceMove": "floss",
       "guideMode": "aiCodeGenerate",
       "aiCodeGenerateExtraPrompt": "Always nest play blocks inside play together. Use only two to three play togethers and do not use repeat.",
       "aiCodeGenerateAdlib": {

--- a/dashboard/config/levels/custom/music/hoai-pilot-6-play-together.level
+++ b/dashboard/config/levels/custom/music/hoai-pilot-6-play-together.level
@@ -57,7 +57,6 @@
       }
     ],
     "level_data": {
-      "danceMove": "roll",
       "guideMode": "instructions",
       "startSources": {
         "blocks": {

--- a/dashboard/config/levels/custom/music/hoai-pilot-6-play-together_7.level
+++ b/dashboard/config/levels/custom/music/hoai-pilot-6-play-together_7.level
@@ -56,7 +56,6 @@
       }
     ],
     "level_data": {
-      "danceMove": "roll",
       "startSources": {
         "blocks": {
           "languageVersion": 0,

--- a/dashboard/config/levels/custom/music/hoai-pilot-7-play-together.level
+++ b/dashboard/config/levels/custom/music/hoai-pilot-7-play-together.level
@@ -57,7 +57,6 @@
       }
     ],
     "level_data": {
-      "danceMove": "roll",
       "guideMode": "instructions",
       "startSources": {
         "blocks": {

--- a/dashboard/config/levels/custom/music/hoai2025-music-instructions.level
+++ b/dashboard/config/levels/custom/music/hoai2025-music-instructions.level
@@ -182,7 +182,6 @@
     "level_data": {
       "validationTimeout": 6,
       "library": "launch2024",
-      "danceMove": "rest",
       "packId": "default",
       "guideMode": "instructions",
       "startSources": {

--- a/dashboard/config/levels/custom/music/mix-move-ai-music-prompt-2-input-PL.level
+++ b/dashboard/config/levels/custom/music/mix-move-ai-music-prompt-2-input-PL.level
@@ -7,7 +7,6 @@
   "properties": {
     "level_data": {
       "library": "launch2024",
-      "danceMove": "floss",
       "guideMode": "aiCodeGenerate",
       "aiCodeGenerateExtraPrompt": "Always nest play blocks inside play together. Use only two to three play togethers and do not use repeat.",
       "aiCodeGenerateAdlib": {

--- a/dashboard/config/levels/custom/music/mix-move-ai-music-prompt-2-input.level
+++ b/dashboard/config/levels/custom/music/mix-move-ai-music-prompt-2-input.level
@@ -8,7 +8,6 @@
   "properties": {
     "level_data": {
       "library": "launch2024",
-      "danceMove": "floss",
       "guideMode": "aiCodeGenerate",
       "aiCodeGenerateExtraPrompt": "Always nest play blocks inside play together. Use only two to three play togethers and do not use repeat.",
       "aiCodeGenerateAdlib": {

--- a/dashboard/config/levels/custom/music/mix-move-ai-play-together-PL.level
+++ b/dashboard/config/levels/custom/music/mix-move-ai-play-together-PL.level
@@ -56,7 +56,6 @@
       }
     ],
     "level_data": {
-      "danceMove": "roll",
       "guideMode": "instructions",
       "startSources": {
         "blocks": {

--- a/dashboard/config/levels/custom/music/mix-move-ai-play-together.level
+++ b/dashboard/config/levels/custom/music/mix-move-ai-play-together.level
@@ -57,7 +57,6 @@
       }
     ],
     "level_data": {
-      "danceMove": "roll",
       "guideMode": "instructions",
       "startSources": {
         "blocks": {

--- a/dashboard/config/levels/custom/music/mix-move-ai-sequence-PL.level
+++ b/dashboard/config/levels/custom/music/mix-move-ai-sequence-PL.level
@@ -183,7 +183,6 @@
     "level_data": {
       "validationTimeout": 6,
       "library": "launch2024",
-      "danceMove": "rest",
       "packId": "default",
       "guideMode": "instructions",
       "startSources": {

--- a/dashboard/config/levels/custom/music/mix-move-ai-sequence.level
+++ b/dashboard/config/levels/custom/music/mix-move-ai-sequence.level
@@ -184,7 +184,6 @@
     "level_data": {
       "validationTimeout": 6,
       "library": "launch2024",
-      "danceMove": "rest",
       "packId": "default",
       "guideMode": "instructions",
       "startSources": {


### PR DESCRIPTION
This removes support for an unused feature that made it possible to render a Lottie dancer animation over the Music Lab timeline. This clean-up task involves three main parts:

- Removing the unsupported `danceMove` value from all Music levels that had one
- Removing the level edit field so it cannot be added to new levels
- Cleaning up `DancerCanvas` so it works by RAF only. This doesn't change the behavior of the canvas in `GenerateDancer` as we were not supplying a current measure from there.

Originally added with https://github.com/code-dot-org/code-dot-org/pull/68792

Levelbuilder field to be deleted:
<img width="992" height="451" alt="image" src="https://github.com/user-attachments/assets/a52830bb-1632-4a05-9c06-52ad7559119d" />

