### PR TITLE
Use Pregenerated Namespace for User UUIDs

### DIFF
--- a/dashboard/app/models/user.rb
+++ b/dashboard/app/models/user.rb
@@ -1420,7 +1420,7 @@ class User < ApplicationRecord
 
   # Can be used to identify users in cases where integer IDs may be vulnerable to abuse
   def uuid
-    id && Digest::UUID.uuid_v5(Dashboard::Application.config.secret_key_base, id.to_s)
+    id && Digest::UUID.uuid_v5(Digest::UUID::OID_NAMESPACE, id.to_s)
   end
 
   # @return [String, nil] the user's US state code in the ISO 3166-2:US standard


### PR DESCRIPTION
Starting in Rails 7.0, Active Support enforces the RFC4122 specification which requires valid UUIDs as namespace identifiers when generating v5 UUIDs.

We are in one place in our codebase currently using Rails' `secret_key_base` as the namespace:

https://github.com/code-dot-org/code-dot-org/blob/169cb3d575803069ad585e272d6a4814d3f6982c/dashboard/app/models/user.rb#L1421-L1424

This value is not guaranteed to be a UUID in production, and in other environments like test it is in fact [guaranteed **not** to be a UUID](https://github.com/code-dot-org/code-dot-org/blob/169cb3d575803069ad585e272d6a4814d3f6982c/config/test.yml.erb#L29), resulting in errors like:

    ERROR["test_a_get_request_to_get_current_returns_signed_in_user_info", "Api::V1::UsersControllerTest", 572.6412735459999]
     test_a_get_request_to_get_current_returns_signed_in_user_info#Api::V1::UsersControllerTest (572.64s)
    Minitest::UnexpectedError:         ArgumentError: Only UUIDs are valid namespace identifiers
                app/models/user.rb:1420:in `uuid'
                app/controllers/api/v1/users_controller.rb:49:in `current'
                app/controllers/application_controller.rb:433:in `with_global_current_user'
                app/controllers/application_controller.rb:206:in `with_locale'
                test/controllers/api/v1/users_controller_test.rb:270:in `block in <class:UsersControllerTest>'
                test/testing/setup_all_and_teardown_all.rb:36:in `run'

In preparation for an upcoming upgrade to Rails 7, this PR proposes we use the existing "Object ID" namespace instead.

# !!!NOTE!!!

I'm not certain how these UUIDs are being used in our application, and so I don't know whether we expect them to be consistent between deploys or not. This change will result in us generating different UUIDs for our users than they had before, so we should confirm what effect that will have.

## Links

- We added this UUID functionality in https://github.com/code-dot-org/code-dot-org/pull/57517
- Rails updated their implementation in https://github.com/rails/rails/pull/37682
- [RFC 4122 of the UUID spec](https://www.ietf.org/rfc/rfc4122.txt)
- [relevant Rails changelog entry](https://github.com/rails/rails/blob/7-0-stable/activesupport/CHANGELOG.md#rails-700rc1-december-06-2021)


## Testing story
<!--  Does your change include appropriate tests?
      - If so, please describe how the tests included in this PR are sufficient.
      - If not, please explain why this change does not need to be tested. -->



## Deployment strategy
<!--  Any special steps required to deploy this, besides merging?
      - Are there database migrations or manual steps?
      - Does this require coordination with other teams or systems? -->



## Follow-up work
<!--  List any clean-up or technical debt that will be addressed in future work.
      - Include Jira links where applicable.
      - Are there any known limitations or improvements planned? -->



## Privacy
<!--  How does this change impact Student & Teacher privacy?
      - Does this collect, use, share, or modify PII, either new or existing? -->



## Security
<!--  How does this change impact our security surface-area?
      - Do API's touched have the right auth?
      - Do infra changes impact our attack surface or encryption?
-->



## Caching
<!--  How does this change impact caching behavior?
      - Are cache keys or invalidation strategies affected?
      - Will this require cache warming or invalidation after deployment? -->



## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
