### PR TITLE
Add Statsig analytics and log errors via Metrics Reporter for accept-reject flow

### DIFF
--- a/apps/src/aiComponentLibrary/aiTutorVersionFileChip/AiTutorVersionFileChip.tsx
+++ b/apps/src/aiComponentLibrary/aiTutorVersionFileChip/AiTutorVersionFileChip.tsx
@@ -6,6 +6,8 @@ import classNames from 'classnames';
 import React from 'react';
 
 import {MultiFileSource, ProjectFile} from '@cdo/apps/lab2/types';
+import {sendLab2AnalyticsEvent} from '@cdo/apps/lab2/utils';
+import {EVENTS} from '@cdo/apps/metrics/AnalyticsConstants';
 import {useAppDispatch, useAppSelector} from '@cdo/apps/util/reduxHooks';
 import {setAiFilePathToPreview} from '@cdo/apps/weblab2/weblab2Redux';
 
@@ -47,6 +49,15 @@ const AiTutorVersionFileChip: React.FC<AiTutorVersionFileChipProps> = ({
     const filePath =
       folderPath === '' ? file.name : folderPath + '/' + file.name;
     dispatch(setAiFilePathToPreview({path: filePath, timestamp: Date.now()}));
+    sendLab2AnalyticsEvent(
+      EVENTS.AI_TUTOR_VERSION_FILE_PREVIEW_BUTTON_CLICKED,
+      {
+        fileName: file.name,
+        fileType: file.language,
+        aiTutorVersionFileUpdated: isUpdatedFile ? 'true' : 'false',
+        aiTutorVersionFileCreated: isNewFile ? 'true' : 'false',
+      }
+    );
   };
 
   return (

--- a/apps/src/codebridge/FileBrowser/FileBrowserRow/FileRow.tsx
+++ b/apps/src/codebridge/FileBrowser/FileBrowserRow/FileRow.tsx
@@ -3,6 +3,8 @@ import classNames from 'classnames';
 import React, {useMemo} from 'react';
 
 import {setActiveFileThunk} from '@cdo/apps/lab2/redux/lab2ProjectReduxThunks';
+import {sendLab2AnalyticsEvent} from '@cdo/apps/lab2/utils';
+import {EVENTS} from '@cdo/apps/metrics/AnalyticsConstants';
 import {useAppDispatch} from '@cdo/apps/util/reduxHooks';
 
 import {FileRowIcon} from './FileRowIcon';
@@ -52,6 +54,25 @@ export const FileRow: React.FunctionComponent<FileRowProps> = ({
     return classNames(...classes);
   }, [isActive, isDragging, isAiTutorVersion]);
 
+  const onOpenFunction = (id: string) => {
+    dispatch(setActiveFileThunk(id));
+    if (isAiTutorVersion) {
+      sendLab2AnalyticsEvent(
+        EVENTS.AI_TUTOR_VERSION_FILE_BROWSER_TAB_CLICKED_IN_FILE_BROWSER,
+        {
+          fileName: item.name,
+          fileType: item.language,
+          aiTutorVersionFileUpdated: item.isAiTutorVersionUpdated
+            ? 'true'
+            : 'false',
+          aiTutorVersionFileCreated: item.isAiTutorVersionCreated
+            ? 'true'
+            : 'false',
+        }
+      );
+    }
+  };
+
   return (
     <ItemRow
       item={item}
@@ -59,7 +80,7 @@ export const FileRow: React.FunctionComponent<FileRowProps> = ({
       dropdownOptions={dropdownOptions}
       IconComponent={FileRowIcon}
       NameComponent={FileRowName}
-      openFunction={id => dispatch(setActiveFileThunk(id))}
+      openFunction={() => onOpenFunction(item.id)}
       className={className}
     />
   );

--- a/apps/src/codebridge/FileBrowser/FileBrowserRow/FileRow.tsx
+++ b/apps/src/codebridge/FileBrowser/FileBrowserRow/FileRow.tsx
@@ -60,19 +60,16 @@ export const FileRow: React.FunctionComponent<FileRowProps> = ({
   const onOpenFunction = (id: string) => {
     dispatch(setActiveFileThunk(id));
     if (isAiTutorVersion) {
-      sendLab2AnalyticsEvent(
-        EVENTS.AI_TUTOR_VERSION_FILE_BROWSER_TAB_CLICKED_IN_FILE_BROWSER,
-        {
-          fileName: item.name,
-          fileType: item.language,
-          aiTutorVersionFileUpdated: item.isAiTutorVersionUpdated
-            ? 'true'
-            : 'false',
-          aiTutorVersionFileCreated: item.isAiTutorVersionCreated
-            ? 'true'
-            : 'false',
-        }
-      );
+      sendLab2AnalyticsEvent(EVENTS.AI_TUTOR_VERSION_VIEW_FILE_CLICKED, {
+        fileName: item.name,
+        fileType: item.language,
+        aiTutorVersionFileUpdated: item.isAiTutorVersionUpdated
+          ? 'true'
+          : 'false',
+        aiTutorVersionFileCreated: item.isAiTutorVersionCreated
+          ? 'true'
+          : 'false',
+      });
     }
   };
 

--- a/apps/src/codebridge/FileBrowser/FileBrowserRow/FileRow.tsx
+++ b/apps/src/codebridge/FileBrowser/FileBrowserRow/FileRow.tsx
@@ -5,7 +5,7 @@ import React, {useMemo} from 'react';
 import {setActiveFileThunk} from '@cdo/apps/lab2/redux/lab2ProjectReduxThunks';
 import {sendLab2AnalyticsEvent} from '@cdo/apps/lab2/utils';
 import {EVENTS} from '@cdo/apps/metrics/AnalyticsConstants';
-import {useAppDispatch} from '@cdo/apps/util/reduxHooks';
+import {useAppDispatch, useAppSelector} from '@cdo/apps/util/reduxHooks';
 
 import {FileRowIcon} from './FileRowIcon';
 import {FileRowName} from './FileRowName';
@@ -38,11 +38,14 @@ export const FileRow: React.FunctionComponent<FileRowProps> = ({
   const dispatch = useAppDispatch();
   const dropdownOptions = useFileRowOptions(item, hasValidationFile);
   const isActive = item.active || false;
-  const isAiTutorVersion =
+  const isAiTutorVersion = useAppSelector(
+    state => state.lab2Project.viewingAiTutorVersion
+  );
+  const isAiTutorVersionFile =
     item.isAiTutorVersionUpdated || item.isAiTutorVersionCreated || false;
   const className = useMemo(() => {
     const classes = [];
-    if (isAiTutorVersion) {
+    if (isAiTutorVersionFile) {
       classes.push(moduleStyles.aiTutorVersion);
     }
     if (isActive) {
@@ -52,7 +55,7 @@ export const FileRow: React.FunctionComponent<FileRowProps> = ({
       classes.push(moduleStyles.dragging);
     }
     return classNames(...classes);
-  }, [isActive, isDragging, isAiTutorVersion]);
+  }, [isActive, isDragging, isAiTutorVersionFile]);
 
   const onOpenFunction = (id: string) => {
     dispatch(setActiveFileThunk(id));

--- a/apps/src/codebridge/FileBrowser/FileBrowserRow/FolderRow.tsx
+++ b/apps/src/codebridge/FileBrowser/FileBrowserRow/FolderRow.tsx
@@ -9,8 +9,6 @@ import React from 'react';
 
 import {toggleOpenFolderThunk} from '@cdo/apps/lab2/redux/lab2ProjectReduxThunks';
 import {MultiFileSource} from '@cdo/apps/lab2/types';
-import {sendLab2AnalyticsEvent} from '@cdo/apps/lab2/utils';
-import {EVENTS} from '@cdo/apps/metrics/AnalyticsConstants';
 import {useAppDispatch, useAppSelector} from '@cdo/apps/util/reduxHooks';
 
 import {FolderRowIcon} from './FolderRowIcon';
@@ -57,22 +55,6 @@ export const FolderRow: React.FunctionComponent<FolderRowProps> = ({
   );
   const dropdownOptions = useFolderRowOptions(item, startFileUpload);
   const dispatch = useAppDispatch();
-  const isAiTutorVersion = useAppSelector(
-    state => state.lab2Project.viewingAiTutorVersion
-  );
-  const onOpenFunction = (id: string) => {
-    dispatch(toggleOpenFolderThunk(id));
-    if (isAiTutorVersion) {
-      console.log('isAiTutorVersion', isAiTutorVersion);
-      sendLab2AnalyticsEvent(
-        EVENTS.AI_TUTOR_VERSION_FILE_BROWSER_TAB_CLICKED_IN_FILE_BROWSER,
-        {
-          folderId: item.id,
-          folderName: item.name,
-        }
-      );
-    }
-  };
 
   return (
     <>
@@ -83,7 +65,7 @@ export const FolderRow: React.FunctionComponent<FolderRowProps> = ({
         dropdownOptions={dropdownOptions}
         IconComponent={FolderRowIcon}
         NameComponent={FolderRowName}
-        openFunction={id => onOpenFunction(id)}
+        openFunction={id => dispatch(toggleOpenFolderThunk(id))}
       />
     </>
   );

--- a/apps/src/codebridge/FileBrowser/FileBrowserRow/FolderRow.tsx
+++ b/apps/src/codebridge/FileBrowser/FileBrowserRow/FolderRow.tsx
@@ -63,6 +63,7 @@ export const FolderRow: React.FunctionComponent<FolderRowProps> = ({
   const onOpenFunction = (id: string) => {
     dispatch(toggleOpenFolderThunk(id));
     if (isAiTutorVersion) {
+      console.log('isAiTutorVersion', isAiTutorVersion);
       sendLab2AnalyticsEvent(
         EVENTS.AI_TUTOR_VERSION_FILE_BROWSER_TAB_CLICKED_IN_FILE_BROWSER,
         {

--- a/apps/src/codebridge/FileBrowser/FileBrowserRow/FolderRow.tsx
+++ b/apps/src/codebridge/FileBrowser/FileBrowserRow/FolderRow.tsx
@@ -9,6 +9,8 @@ import React from 'react';
 
 import {toggleOpenFolderThunk} from '@cdo/apps/lab2/redux/lab2ProjectReduxThunks';
 import {MultiFileSource} from '@cdo/apps/lab2/types';
+import {sendLab2AnalyticsEvent} from '@cdo/apps/lab2/utils';
+import {EVENTS} from '@cdo/apps/metrics/AnalyticsConstants';
 import {useAppDispatch, useAppSelector} from '@cdo/apps/util/reduxHooks';
 
 import {FolderRowIcon} from './FolderRowIcon';
@@ -55,6 +57,21 @@ export const FolderRow: React.FunctionComponent<FolderRowProps> = ({
   );
   const dropdownOptions = useFolderRowOptions(item, startFileUpload);
   const dispatch = useAppDispatch();
+  const isAiTutorVersion = useAppSelector(
+    state => state.lab2Project.viewingAiTutorVersion
+  );
+  const onOpenFunction = (id: string) => {
+    dispatch(toggleOpenFolderThunk(id));
+    if (isAiTutorVersion) {
+      sendLab2AnalyticsEvent(
+        EVENTS.AI_TUTOR_VERSION_FILE_BROWSER_TAB_CLICKED_IN_FILE_BROWSER,
+        {
+          folderId: item.id,
+          folderName: item.name,
+        }
+      );
+    }
+  };
 
   return (
     <>
@@ -65,7 +82,7 @@ export const FolderRow: React.FunctionComponent<FolderRowProps> = ({
         dropdownOptions={dropdownOptions}
         IconComponent={FolderRowIcon}
         NameComponent={FolderRowName}
-        openFunction={id => dispatch(toggleOpenFolderThunk(id))}
+        openFunction={id => onOpenFunction(id)}
       />
     </>
   );

--- a/apps/src/codebridge/FilePreview/HTMLPreview.tsx
+++ b/apps/src/codebridge/FilePreview/HTMLPreview.tsx
@@ -8,8 +8,9 @@ import useLifecycleNotifier from '@cdo/apps/lab2/hooks/useLifecycleNotifier';
 import {setIsFullScreenView} from '@cdo/apps/lab2/lab2Redux';
 import {isPredictResponseSubmitted} from '@cdo/apps/lab2/redux/predictLevelRedux';
 import {MultiFileSource} from '@cdo/apps/lab2/types';
-import {LifecycleEvent} from '@cdo/apps/lab2/utils';
+import {LifecycleEvent, sendLab2AnalyticsEvent} from '@cdo/apps/lab2/utils';
 import PanelContainer from '@cdo/apps/lab2/views/components/PanelContainer';
+import {EVENTS} from '@cdo/apps/metrics/AnalyticsConstants';
 import experiments from '@cdo/apps/util/experiments';
 import {useAppSelector, useAppDispatch} from '@cdo/apps/util/reduxHooks';
 
@@ -39,6 +40,10 @@ export const HTMLPreview: React.FC = () => {
     const port = 'localhost' === environmentKey ? `:${location.port}` : '';
     return `${location.protocol}//preview.${subdomain}codeprojects.org${port}`;
   }, []);
+
+  const isAiTutorVersion = useAppSelector(
+    state => state.lab2Project.viewingAiTutorVersion
+  );
 
   // The new preview is currently behind an experiment flag. We pass this flag
   // through to the inner iframe via a query string so it knows whether or not to use the new preview.
@@ -112,6 +117,15 @@ export const HTMLPreview: React.FC = () => {
       navigationHistoryIndex,
       navigationHistory
     );
+    if (isAiTutorVersion) {
+      sendLab2AnalyticsEvent(
+        EVENTS.AI_TUTOR_VERSION_FILE_PREVIEWED_IN_URL_BAR,
+        {
+          fileName: newInputValue,
+          fileType: newInputValue.split('.').pop() || '',
+        }
+      );
+    }
   };
 
   const onNavigateBack = () => {

--- a/apps/src/codebridge/FileTabs/FileTab.tsx
+++ b/apps/src/codebridge/FileTabs/FileTab.tsx
@@ -33,12 +33,15 @@ const FileTab = ({file}: FileTabProps) => {
   const {iconName, iconStyle, isBrand} = getFileIconNameAndStyle(file);
   const iconClassName = isBrand ? 'fa-brands' : undefined;
   const isActive = file.active || file === activeFile;
-  const isAiTutorVersion =
+  const isAiTutorVersionFile =
     file.isAiTutorVersionUpdated || file.isAiTutorVersionCreated || false;
+  const isAiTutorVersion = useAppSelector(
+    state => state.lab2Project.viewingAiTutorVersion
+  );
   const className = classNames(moduleStyles.fileTab, {
-    [moduleStyles.aiTutorVersionActive]: isActive && isAiTutorVersion,
-    [moduleStyles.aiTutorVersionInactive]: !isActive && isAiTutorVersion,
-    [moduleStyles.active]: isActive && !isAiTutorVersion,
+    [moduleStyles.aiTutorVersionActive]: isActive && isAiTutorVersionFile,
+    [moduleStyles.aiTutorVersionInactive]: !isActive && isAiTutorVersionFile,
+    [moduleStyles.active]: isActive && !isAiTutorVersionFile,
   });
   const tabRef = useRef<HTMLDivElement>(null);
 

--- a/apps/src/codebridge/FileTabs/FileTab.tsx
+++ b/apps/src/codebridge/FileTabs/FileTab.tsx
@@ -14,6 +14,8 @@ import {
   setActiveFileThunk,
 } from '@cdo/apps/lab2/redux/lab2ProjectReduxThunks';
 import {MultiFileSource} from '@cdo/apps/lab2/types';
+import {sendLab2AnalyticsEvent} from '@cdo/apps/lab2/utils';
+import {EVENTS} from '@cdo/apps/metrics/AnalyticsConstants';
 import {useAppDispatch, useAppSelector} from '@cdo/apps/util/reduxHooks';
 
 import moduleStyles from './styles/fileTabs.module.scss';
@@ -59,11 +61,29 @@ const FileTab = ({file}: FileTabProps) => {
       window.removeEventListener('resize', throttledScrollTabIntoView);
   }, [isActive, throttledScrollTabIntoView]);
 
+  const handleOnClick = (id: string) => {
+    dispatch(setActiveFileThunk(file.id));
+    if (isAiTutorVersion) {
+      sendLab2AnalyticsEvent(
+        EVENTS.AI_TUTOR_VERSION_FILE_TAB_CLICKED_IN_TABS_BAR,
+        {
+          fileName: file.name,
+          fileType: file.language,
+          aiTutorVersionFileUpdated: file.isAiTutorVersionUpdated
+            ? 'true'
+            : 'false',
+          aiTutorVersionFileCreated: file.isAiTutorVersionCreated
+            ? 'true'
+            : 'false',
+        }
+      );
+    }
+  };
   return (
     <div className={className} key={file.id}>
       <div
         className={moduleStyles.label}
-        onClick={() => dispatch(setActiveFileThunk(file.id))}
+        onClick={() => handleOnClick(file.id)}
         ref={tabRef}
       >
         <FontAwesomeV6Icon

--- a/apps/src/codebridge/FileTabs/FileTab.tsx
+++ b/apps/src/codebridge/FileTabs/FileTab.tsx
@@ -67,19 +67,16 @@ const FileTab = ({file}: FileTabProps) => {
   const handleOnClick = (id: string) => {
     dispatch(setActiveFileThunk(file.id));
     if (isAiTutorVersion) {
-      sendLab2AnalyticsEvent(
-        EVENTS.AI_TUTOR_VERSION_FILE_TAB_CLICKED_IN_TABS_BAR,
-        {
-          fileName: file.name,
-          fileType: file.language,
-          aiTutorVersionFileUpdated: file.isAiTutorVersionUpdated
-            ? 'true'
-            : 'false',
-          aiTutorVersionFileCreated: file.isAiTutorVersionCreated
-            ? 'true'
-            : 'false',
-        }
-      );
+      sendLab2AnalyticsEvent(EVENTS.AI_TUTOR_VERSION_VIEW_FILE_CLICKED, {
+        fileName: file.name,
+        fileType: file.language,
+        aiTutorVersionFileUpdated: file.isAiTutorVersionUpdated
+          ? 'true'
+          : 'false',
+        aiTutorVersionFileCreated: file.isAiTutorVersionCreated
+          ? 'true'
+          : 'false',
+      });
     }
   };
   return (

--- a/apps/src/metrics/AnalyticsConstants.js
+++ b/apps/src/metrics/AnalyticsConstants.js
@@ -669,6 +669,10 @@ const EVENTS = {
     'Music Lab Generate Code Back To Prompt Clicked',
   MUSIC_LAB_GENERATE_CODE_USE_CODE_CLICKED:
     'Music Lab Generate Code Use Code Clicked',
+
+  // AI Tutor accept-reject flow
+  AI_TUTOR_VERSION_ACCEPTED: 'AI Tutor Version Accepted',
+  AI_TUTOR_VERSION_REJECTED: 'AI Tutor Version Rejected',
 };
 
 const EVENT_GROUP_NAMES = {

--- a/apps/src/metrics/AnalyticsConstants.js
+++ b/apps/src/metrics/AnalyticsConstants.js
@@ -674,10 +674,8 @@ const EVENTS = {
   AI_TUTOR_VERSION_ACCEPTED: 'AI Tutor Version Accepted',
   AI_TUTOR_VERSION_REJECTED: 'AI Tutor Version Rejected',
   AI_TUTOR_GENERATED_CODE: 'AI Tutor Generated Code',
-  AI_TUTOR_VERSION_FILE_TAB_CLICKED_IN_TABS_BAR:
-    'File Tab Clicked in File Tabs Bar in AI Tutor Version View',
-  AI_TUTOR_VERSION_FILE_BROWSER_TAB_CLICKED_IN_FILE_BROWSER:
-    'File Browser Tab Clicked in File Browser in AI Tutor Version View',
+  AI_TUTOR_VERSION_VIEW_FILE_CLICKED:
+    'File Tab Clicked in AI Tutor Version View',
   AI_TUTOR_VERSION_FILE_PREVIEW_BUTTON_CLICKED:
     'AI Tutor Version File Preview Button Clicked',
   AI_TUTOR_VERSION_FILE_PREVIEWED_IN_URL_BAR:

--- a/apps/src/metrics/AnalyticsConstants.js
+++ b/apps/src/metrics/AnalyticsConstants.js
@@ -673,6 +673,15 @@ const EVENTS = {
   // AI Tutor accept-reject flow
   AI_TUTOR_VERSION_ACCEPTED: 'AI Tutor Version Accepted',
   AI_TUTOR_VERSION_REJECTED: 'AI Tutor Version Rejected',
+  AI_TUTOR_GENERATED_CODE: 'AI Tutor Generated Code',
+  AI_TUTOR_VERSION_FILE_TAB_CLICKED_IN_TABS_BAR:
+    'File Tab Clicked in File Tabs Bar in AI Tutor Version View',
+  AI_TUTOR_VERSION_FILE_BROWSER_TAB_CLICKED_IN_FILE_BROWSER:
+    'File Browser Tab Clicked in File Browser in AI Tutor Version View',
+  AI_TUTOR_VERSION_FILE_PREVIEW_BUTTON_CLICKED:
+    'AI Tutor Version File Preview Button Clicked',
+  AI_TUTOR_VERSION_FILE_PREVIEWED_IN_URL_BAR:
+    'File Previewed in AI Tutor Version View via URL bar',
 };
 
 const EVENT_GROUP_NAMES = {

--- a/apps/src/weblab2/hooks/useAiTutorResponseSchemaSettings.ts
+++ b/apps/src/weblab2/hooks/useAiTutorResponseSchemaSettings.ts
@@ -8,6 +8,8 @@ import {
   setViewingAiTutorVersion,
 } from '@cdo/apps/lab2/redux/lab2ProjectRedux';
 import {MultiFileSource, ProjectFile} from '@cdo/apps/lab2/types';
+import {sendLab2AnalyticsEvent} from '@cdo/apps/lab2/utils';
+import {EVENTS} from '@cdo/apps/metrics/AnalyticsConstants';
 import experiments from '@cdo/apps/util/experiments';
 import {useAppDispatch} from '@cdo/apps/util/reduxHooks';
 
@@ -54,6 +56,9 @@ export const useAiTutorResponseSchemaSettings = (
           ) {
             return formatCopyPasteResponse(jsonResponse.answer);
           }
+          sendLab2AnalyticsEvent(EVENTS.AI_TUTOR_GENERATED_CODE, {
+            answerType,
+          });
           dispatch(setViewingAiTutorVersion(true));
           // When viewing AI Tutor version, store current sources as projectSourceBeforeAiTutorVersion.
           // Workspace will be read-only until user clicks "accept" or "reject".

--- a/apps/src/weblab2/weblab2ReduxThunks.ts
+++ b/apps/src/weblab2/weblab2ReduxThunks.ts
@@ -15,6 +15,8 @@ import {
   ProjectFile,
   ProjectSources,
 } from '@cdo/apps/lab2/types';
+import {sendLab2AnalyticsEvent} from '@cdo/apps/lab2/utils';
+import {EVENTS} from '@cdo/apps/metrics/AnalyticsConstants';
 import {RootState} from '@cdo/apps/types/redux';
 import HttpClient from '@cdo/apps/util/HttpClient';
 import {AppDispatch} from '@cdo/apps/util/reduxHooks';
@@ -45,8 +47,11 @@ export const acceptAiTutorVersion = createAsyncThunk<
   const sources = state.lab2Project.projectSources;
   const channelId = state.lab.channel?.id;
   if (!channelId || !sources) {
-    console.error('Channel ID or project sources not available');
-    // TODO: add error handling.
+    Lab2Registry.getInstance()
+      .getMetricsReporter()
+      .logError(
+        'Channel ID or project sources not available when accepting AI Tutor version'
+      );
     return;
   }
   const sourcesBeforeAiTutorVersion = {
@@ -63,6 +68,10 @@ export const acceptAiTutorVersion = createAsyncThunk<
     files: files,
   };
   thunkAPI.dispatch(addChatEvent(notification));
+  sendLab2AnalyticsEvent(EVENTS.AI_TUTOR_VERSION_ACCEPTED, {
+    numFiles: files.length.toString(),
+    fileTypes: files[0].language || '',
+  });
   resetAiTutorVersionState(thunkAPI.dispatch);
 
   // Update current source so that isAiTutorVersionUpdated and isAiTutorVersionCreated are set to false.
@@ -101,7 +110,11 @@ export const acceptAiTutorVersion = createAsyncThunk<
   );
   const projectManager = Lab2Registry.getInstance().getProjectManager();
   if (!projectManager) {
-    console.error('Project manager not available');
+    Lab2Registry.getInstance()
+      .getMetricsReporter()
+      .logError(
+        'Project manager not available when accepting AI Tutor version'
+      );
     return;
   }
   const newVersionId = projectManager.getCurrentVersionId();
@@ -121,7 +134,9 @@ export const acceptAiTutorVersion = createAsyncThunk<
       // Set this boolean to true so if any updates occur, a new version is created and this version remains intact and is not overwritten.
       projectManager.setForceNewVersion(true);
     } catch (error) {
-      console.error('Failed to save commit comment:', error);
+      Lab2Registry.getInstance()
+        .getMetricsReporter()
+        .logError('Failure to save commit comment', error as Error);
     }
   }
 });
@@ -149,6 +164,10 @@ export const rejectAiTutorVersion = createAsyncThunk<
     files: files,
   };
   thunkAPI.dispatch(addChatEvent(notification));
+  sendLab2AnalyticsEvent(EVENTS.AI_TUTOR_VERSION_REJECTED, {
+    numFiles: files.length.toString(),
+    fileTypes: files[0].language || '',
+  });
 
   // Revert to previous source.
   thunkAPI.dispatch(setSource(prevSource || source));


### PR DESCRIPTION
This PR adds Statsig event logging for when a user accepts or rejects AI tutor version file updates in Web Lab 2 accept-reject flow. It also logs errors via Metrics Reporter during the flow.

Note that in the JSON schema description included in the request, the model is asked to limit the code files to one language (html, css or js) across the entire files list (`html`, `css`, or `js` fences). The Statsig event's payload includes `numFiles`, `filesType` (limited to one), `levelPath`, and `appName`. Locally testing, the model has consistently followed this rule in contrast to when we previously asked the model to returning the file `id` and `folderId` of updated files.

## After update

User accepts AI Tutor version files:
<img width="1366" height="202" alt="Screenshot 2025-12-10 at 9 29 17 AM" src="https://github.com/user-attachments/assets/212bedcc-0dfc-4c91-a19f-8f4cd5a4273e" />

User rejects AI Tutor version files
<img width="1356" height="262" alt="Screenshot 2025-12-10 at 9 27 15 AM" src="https://github.com/user-attachments/assets/a1a19ea9-bcb1-47a6-827c-c4d69ed5a9de" />

Statsig events sent for:
- when code is generated (html, css, or js),
- user clicks on preview button,
- user enters file path in url bar in AI Tutor version view,
- user clicks on file tab in file browser or tabs bar (note that the event name has since been updated so these two event are now the same)

https://github.com/user-attachments/assets/131cad61-5431-429f-bcf9-d8941fbddb61


## Warning!!

We have entered Pixel Lock for Hour of AI! All merges to the `staging` branch from Dec 2 through Dec 12 must go through live change review and be deemed critical for supporting the Hour of AI. External contributions will not be accepted at this time.

For non-critical changes, please change your base to `staging-next` and delete this warning. We will merge `staging-next` into `staging` on Dec 15, 2025.

<!-- end warning -->


<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->


## Links
<!--  Links to relevant external resources.
      - spec docs, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- Jira: https://codedotorg.atlassian.net/browse/AFL-290

## Testing story
<!--  Does your change include appropriate tests?
      - If so, please describe how the tests included in this PR are sufficient.
      - If not, please explain why this change does not need to be tested. -->

Tested locally and confirmed the statsig event logs in dev console.

## Deployment strategy
<!--  Any special steps required to deploy this, besides merging?
      - Are there database migrations or manual steps?
      - Does this require coordination with other teams or systems? -->



## Follow-up work
<!--  List any clean-up or technical debt that will be addressed in future work.
      - Include Jira links where applicable.
      - Are there any known limitations or improvements planned? -->



## Privacy
<!--  How does this change impact Student & Teacher privacy?
      - Does this collect, use, share, or modify PII, either new or existing? -->



## Security
<!--  How does this change impact our security surface-area?
      - Do API's touched have the right auth?
      - Do infra changes impact our attack surface or encryption?
-->



## Caching
<!--  How does this change impact caching behavior?
      - Are cache keys or invalidation strategies affected?
      - Will this require cache warming or invalidation after deployment? -->



## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
