### PR TITLE
Upgrade TypeScript to 5.9.3

### DIFF
--- a/apps/package.json
+++ b/apps/package.json
@@ -175,7 +175,7 @@
     "ts-jest": "^29.1.2",
     "ts-loader": "^9.5.1",
     "ts-sinon": "^2.0.2",
-    "typescript": "^5.5.3",
+    "typescript": "^5.9.3",
     "unminified-webpack-plugin": "^3.0.0",
     "unplugin": "^1.7.1",
     "webpack": "^5.94.0",

--- a/apps/yarn.lock
+++ b/apps/yarn.lock
@@ -11460,7 +11460,7 @@ __metadata:
     ts-jest: "npm:^29.1.2"
     ts-loader: "npm:^9.5.1"
     ts-sinon: "npm:^2.0.2"
-    typescript: "npm:^5.5.3"
+    typescript: "npm:^5.9.3"
     uglify-js: "npm:^3.18.0"
     unified: "npm:~9.2.0"
     unminified-webpack-plugin: "npm:^3.0.0"
@@ -30422,23 +30422,23 @@ canvg@gabelerner/canvg:
   languageName: node
   linkType: hard
 
-"typescript@npm:^5.5.3":
-  version: 5.5.3
-  resolution: "typescript@npm:5.5.3"
+"typescript@npm:^5.9.3":
+  version: 5.9.3
+  resolution: "typescript@npm:5.9.3"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 10/11a867312419ed497929aafd2f1d28b2cd41810a5eb6c6e9e169559112e9ea073d681c121a29102e67cd4478d0a4ae37a306a5800f3717f59c4337e6a9bd5e8d
+  checksum: 10/c089d9d3da2729fd4ac517f9b0e0485914c4b3c26f80dc0cffcb5de1719a17951e92425d55db59515c1a7ddab65808466debb864d0d56dcf43f27007d0709594
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@npm%3A^5.5.3#optional!builtin<compat/typescript>":
-  version: 5.5.3
-  resolution: "typescript@patch:typescript@npm%3A5.5.3#optional!builtin<compat/typescript>::version=5.5.3&hash=379a07"
+"typescript@patch:typescript@npm%3A^5.9.3#optional!builtin<compat/typescript>":
+  version: 5.9.3
+  resolution: "typescript@patch:typescript@npm%3A5.9.3#optional!builtin<compat/typescript>::version=5.9.3&hash=5786d5"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 10/7cf7acb78a80f749b82842f2ffe01e90e7b3e709a6f4268588e0b7599c41dca1059be217f47778fe1a380bfaf60933021ef20d002c426d4d7745e1b36c11467b
+  checksum: 10/696e1b017bc2635f4e0c94eb4435357701008e2f272f553d06e35b494b8ddc60aa221145e286c28ace0c89ee32827a28c2040e3a69bdc108b1a5dc8fb40b72e3
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Upgrades our `apps` TypeScript dependency to 5.9.3. This version gives support for `node20` as a `module` option, which is potentially of use to unblock some dependency upgrades.

- [Slack thread](https://codedotorg.slack.com/archives/C0T0PNR0D/p1764977473457439?thread_ts=1707783384.341769&cid=C0T0PNR0D) with more discussion
- TypeScript 5.9 [release notes](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-5-9.html) 

## Testing story

Relying on tests passing to validate this change. I also ran `yarn start` locally with this change without issue.