### PR TITLE
AI Chat Lab: add teacher viewing student project alert

### DIFF
--- a/apps/src/aichat/views/AichatView.tsx
+++ b/apps/src/aichat/views/AichatView.tsx
@@ -13,9 +13,13 @@ import {PERMISSIONS} from '@cdo/apps/lab2/constants';
 import {useLevelActivityMetrics} from '@cdo/apps/lab2/hooks/useLevelActivityMetrics';
 import useLifecycleNotifier from '@cdo/apps/lab2/hooks/useLifecycleNotifier';
 import Lab2Registry from '@cdo/apps/lab2/Lab2Registry';
-import {isProjectTemplateLevel} from '@cdo/apps/lab2/redux/lab2ReduxSelectors';
+import {
+  isProjectTemplateLevel,
+  isTeacherViewingStudent,
+} from '@cdo/apps/lab2/redux/lab2ReduxSelectors';
 import {LabProps} from '@cdo/apps/lab2/types';
 import {LifecycleEvent} from '@cdo/apps/lab2/utils';
+import TeacherViewingStudentProjectAlert from '@cdo/apps/lab2/views/alerts/teacherViewingStudentProject';
 import IconButtonWithTooltip from '@cdo/apps/lab2/views/components/IconButtonWithTooltip';
 import ResourcePanel from '@cdo/apps/lab2/views/components/Instructions/ResourcePanel';
 import PanelContainer from '@cdo/apps/lab2/views/components/PanelContainer';
@@ -67,6 +71,7 @@ const AichatView: React.FunctionComponent<LabProps<AichatLevelProperties>> = ({
 
   const viewAsUserId = useAppSelector(state => state.progress.viewAsUserId);
   const isUserTeacher = useAppSelector(state => state.currentUser.isTeacher);
+  const teacherViewingStudent = useAppSelector(isTeacherViewingStudent);
 
   const {
     name: levelName,
@@ -317,6 +322,7 @@ const AichatView: React.FunctionComponent<LabProps<AichatLevelProperties>> = ({
             <SegmentedButtons {...viewModeButtonsProps} />
           </div>
         )}
+        {teacherViewingStudent && <TeacherViewingStudentProjectAlert />}
         <div className={moduleStyles.labCoreContainer}>
           {viewMode === ViewMode.EDIT && (
             <>

--- a/apps/src/aichat/views/AichatView.tsx
+++ b/apps/src/aichat/views/AichatView.tsx
@@ -13,10 +13,7 @@ import {PERMISSIONS} from '@cdo/apps/lab2/constants';
 import {useLevelActivityMetrics} from '@cdo/apps/lab2/hooks/useLevelActivityMetrics';
 import useLifecycleNotifier from '@cdo/apps/lab2/hooks/useLifecycleNotifier';
 import Lab2Registry from '@cdo/apps/lab2/Lab2Registry';
-import {
-  isProjectTemplateLevel,
-  isTeacherViewingStudent,
-} from '@cdo/apps/lab2/redux/lab2ReduxSelectors';
+import {isProjectTemplateLevel} from '@cdo/apps/lab2/redux/lab2ReduxSelectors';
 import {LabProps} from '@cdo/apps/lab2/types';
 import {LifecycleEvent} from '@cdo/apps/lab2/utils';
 import TeacherViewingStudentProjectAlert from '@cdo/apps/lab2/views/alerts/teacherViewingStudentProject';
@@ -71,7 +68,7 @@ const AichatView: React.FunctionComponent<LabProps<AichatLevelProperties>> = ({
 
   const viewAsUserId = useAppSelector(state => state.progress.viewAsUserId);
   const isUserTeacher = useAppSelector(state => state.currentUser.isTeacher);
-  const teacherViewingStudent = useAppSelector(isTeacherViewingStudent);
+  const teacherViewingStudent = Boolean(viewAsUserId);
 
   const {
     name: levelName,

--- a/apps/src/codebridge/Workspace/Workspace.tsx
+++ b/apps/src/codebridge/Workspace/Workspace.tsx
@@ -12,10 +12,7 @@ import React, {useMemo, useRef} from 'react';
 import codebridgeI18n from '@cdo/apps/codebridge/locale';
 import {START_SOURCES, WARNING_BANNER_MESSAGES} from '@cdo/apps/lab2/constants';
 import {getAppOptionsEditBlocks} from '@cdo/apps/lab2/projects/utils';
-import {
-  isProjectTemplateLevel,
-  isTeacherViewingStudent,
-} from '@cdo/apps/lab2/redux/lab2ReduxSelectors';
+import {isProjectTemplateLevel} from '@cdo/apps/lab2/redux/lab2ReduxSelectors';
 import TeacherViewingStudentProjectAlert from '@cdo/apps/lab2/views/alerts/teacherViewingStudentProject';
 import PanelContainer from '@cdo/apps/lab2/views/components/PanelContainer';
 import WorkspaceHeader from '@cdo/apps/lab2/views/components/WorkspaceHeader';
@@ -43,7 +40,9 @@ const Workspace: React.FunctionComponent<WorkspaceProps> = ({
   const isStartMode = getAppOptionsEditBlocks() === START_SOURCES;
   const containerRef = useRef<HTMLDivElement>(null);
   const projectTemplateLevel = useAppSelector(isProjectTemplateLevel);
-  const teacherViewingStudent = useAppSelector(isTeacherViewingStudent);
+  const teacherViewingStudent = Boolean(
+    useAppSelector(state => state.progress.viewAsUserId)
+  );
 
   const showLockedFilesBanner = useAppSelector(
     state => state.codebridgeWorkspace.showLockedFilesBanner

--- a/apps/src/codebridge/Workspace/Workspace.tsx
+++ b/apps/src/codebridge/Workspace/Workspace.tsx
@@ -97,7 +97,9 @@ const Workspace: React.FunctionComponent<WorkspaceProps> = ({
         className={moduleStyles.workspace}
         headerClassName={moduleStyles.workspaceHeader}
       >
-        {teacherViewingStudent && <TeacherViewingStudentProjectAlert />}
+        {teacherViewingStudent && (
+          <TeacherViewingStudentProjectAlert inWorkspaceContainer />
+        )}
         {viewingOldVersion && (
           <Alert
             className={moduleStyles.previousVersionBanner}

--- a/apps/src/lab2/redux/lab2ReduxSelectors.ts
+++ b/apps/src/lab2/redux/lab2ReduxSelectors.ts
@@ -78,13 +78,6 @@ export const isReadOnlyWorkspace = (state: RootState) => {
   );
 };
 
-// Determine if a teacher is viewing a student's project in read-only mode.
-export const isTeacherViewingStudent = (state: RootState): boolean => {
-  const viewAsUserId = state.progress.viewAsUserId;
-  const isReadOnly = isReadOnlyWorkspace(state);
-  return Boolean(viewAsUserId && isReadOnly);
-};
-
 // Helper functions
 
 // Returns if the current state represents a predict level that should be read only.

--- a/apps/src/lab2/views/alerts/teacherViewingStudentProject/TeacherViewingStudentProjectAlert.tsx
+++ b/apps/src/lab2/views/alerts/teacherViewingStudentProject/TeacherViewingStudentProjectAlert.tsx
@@ -1,4 +1,5 @@
 import Alert from '@code-dot-org/component-library/alert';
+import classNames from 'classnames';
 import React, {useMemo} from 'react';
 
 import {getCurrentLevel} from '@cdo/apps/code-studio/progressReduxSelectors';
@@ -7,7 +8,16 @@ import {LevelStatus} from '@cdo/generated-scripts/sharedConstants';
 
 import moduleStyles from './teacherViewingStudentProjectAlert.module.scss';
 
-const TeacherViewingStudentProjectAlert: React.FC = () => {
+type TeacherViewingStudentProjectAlertProps = {
+  /** Is alert displayed within the workspace area */
+  inWorkspaceContainer?: boolean;
+  /** Optional custom className */
+  className?: string;
+};
+
+const TeacherViewingStudentProjectAlert: React.FC<
+  TeacherViewingStudentProjectAlertProps
+> = ({inWorkspaceContainer, className}) => {
   // Get the user ID of the student whose project is being viewed.
   const viewAsUserId = useAppSelector(state => state.progress.viewAsUserId);
 
@@ -45,7 +55,10 @@ const TeacherViewingStudentProjectAlert: React.FC = () => {
 
   return (
     <Alert
-      className={moduleStyles.alertBanner}
+      className={classNames(
+        inWorkspaceContainer && moduleStyles.inWorkspaceContainer,
+        className
+      )}
       text={alertText}
       type="info"
       size="xs"

--- a/apps/src/lab2/views/alerts/teacherViewingStudentProject/TeacherViewingStudentProjectAlert.tsx
+++ b/apps/src/lab2/views/alerts/teacherViewingStudentProject/TeacherViewingStudentProjectAlert.tsx
@@ -37,32 +37,22 @@ const TeacherViewingStudentProjectAlert: React.FC<
   // Track loading state when switching between students.
   // Progress data (levelNotStarted) may lag behind viewAsUserId updates.
   const previousViewAsUserIdRef = useRef<number | null | undefined>(undefined);
-  const previousUnitProgressRef = useRef<typeof unitProgress | undefined>(
-    undefined
-  );
   const [isLoadingLevelProgress, setIsLoadingLevelProgress] = useState(true);
 
+  // When viewAsUserId changes, mark as loading until progress catches up.
   useEffect(() => {
     if (previousViewAsUserIdRef.current !== viewAsUserId) {
       setIsLoadingLevelProgress(true);
       previousViewAsUserIdRef.current = viewAsUserId;
-      // Reset the unitProgress ref to detect when new progress arrives
-      previousUnitProgressRef.current = unitProgress;
     }
-  }, [viewAsUserId]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [viewAsUserId]);
 
-  // When unitProgress updates after a viewAsUserId change,
-  // progress has loaded for the new student.
+  // When unitProgress updates, progress has loaded for the new student.
   useEffect(() => {
-    if (
-      isLoadingLevelProgress &&
-      previousUnitProgressRef.current !== undefined &&
-      previousUnitProgressRef.current !== unitProgress
-    ) {
+    if (isLoadingLevelProgress) {
       setIsLoadingLevelProgress(false);
-      previousUnitProgressRef.current = unitProgress;
     }
-  }, [unitProgress, isLoadingLevelProgress]);
+  }, [unitProgress]); // eslint-disable-line react-hooks/exhaustive-deps
 
   // Get the name of the student being viewed to use in the alert text.
   const selectedStudentName = useMemo(() => {

--- a/apps/src/lab2/views/alerts/teacherViewingStudentProject/TeacherViewingStudentProjectAlert.tsx
+++ b/apps/src/lab2/views/alerts/teacherViewingStudentProject/TeacherViewingStudentProjectAlert.tsx
@@ -37,22 +37,32 @@ const TeacherViewingStudentProjectAlert: React.FC<
   // Track loading state when switching between students.
   // Progress data (levelNotStarted) may lag behind viewAsUserId updates.
   const previousViewAsUserIdRef = useRef<number | null | undefined>(undefined);
+  const previousUnitProgressRef = useRef<typeof unitProgress | undefined>(
+    undefined
+  );
   const [isLoadingLevelProgress, setIsLoadingLevelProgress] = useState(true);
 
-  // When viewAsUserId changes, mark as loading until progress catches up.
   useEffect(() => {
     if (previousViewAsUserIdRef.current !== viewAsUserId) {
       setIsLoadingLevelProgress(true);
       previousViewAsUserIdRef.current = viewAsUserId;
+      // Reset the unitProgress ref to detect when new progress arrives
+      previousUnitProgressRef.current = unitProgress;
     }
-  }, [viewAsUserId]);
+  }, [viewAsUserId]); // eslint-disable-line react-hooks/exhaustive-deps
 
-  // When unitProgress updates, progress has loaded for the new student.
+  // When unitProgress updates after a viewAsUserId change,
+  // progress has loaded for the new student.
   useEffect(() => {
-    if (isLoadingLevelProgress) {
+    if (
+      isLoadingLevelProgress &&
+      previousUnitProgressRef.current !== undefined &&
+      previousUnitProgressRef.current !== unitProgress
+    ) {
       setIsLoadingLevelProgress(false);
+      previousUnitProgressRef.current = unitProgress;
     }
-  }, [unitProgress]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [unitProgress, isLoadingLevelProgress]);
 
   // Get the name of the student being viewed to use in the alert text.
   const selectedStudentName = useMemo(() => {

--- a/apps/src/lab2/views/alerts/teacherViewingStudentProject/TeacherViewingStudentProjectAlert.tsx
+++ b/apps/src/lab2/views/alerts/teacherViewingStudentProject/TeacherViewingStudentProjectAlert.tsx
@@ -1,6 +1,6 @@
 import Alert from '@code-dot-org/component-library/alert';
 import classNames from 'classnames';
-import React, {useMemo} from 'react';
+import React, {useEffect, useMemo, useRef, useState} from 'react';
 
 import {getCurrentLevel} from '@cdo/apps/code-studio/progressReduxSelectors';
 import {useAppSelector} from '@cdo/apps/util/reduxHooks';
@@ -31,6 +31,29 @@ const TeacherViewingStudentProjectAlert: React.FC<
     state => getCurrentLevel(state)?.status === LevelStatus.not_tried
   );
 
+  // Get unitProgress to detect when progress data has been updated.
+  const unitProgress = useAppSelector(state => state.progress.unitProgress);
+
+  // Track loading state when switching between students.
+  // Progress data (levelNotStarted) may lag behind viewAsUserId updates.
+  const prevViewAsUserIdRef = useRef(viewAsUserId);
+  const [isLoadingLevelProgress, setIsLoadingLevelProgress] = useState(false);
+
+  // When viewAsUserId changes, mark as loading until progress catches up.
+  useEffect(() => {
+    if (prevViewAsUserIdRef.current !== viewAsUserId) {
+      setIsLoadingLevelProgress(true);
+      prevViewAsUserIdRef.current = viewAsUserId;
+    }
+  }, [viewAsUserId]);
+
+  // When unitProgress updates, progress has loaded for the new student.
+  useEffect(() => {
+    if (isLoadingLevelProgress) {
+      setIsLoadingLevelProgress(false);
+    }
+  }, [unitProgress]); // eslint-disable-line react-hooks/exhaustive-deps
+
   // Get the name of the student being viewed to use in the alert text.
   const selectedStudentName = useMemo(() => {
     if (viewAsUserId === null) {
@@ -41,7 +64,12 @@ const TeacherViewingStudentProjectAlert: React.FC<
     return student?.name;
   }, [viewAsUserId, studentsInSection]);
 
-  const alertText = levelNotStarted ? (
+  // Show a generic message while loading to avoid toggling stale status.
+  const alertText = isLoadingLevelProgress ? (
+    <>
+      Loading <strong>{selectedStudentName ?? 'student'}'s</strong> project...
+    </>
+  ) : levelNotStarted ? (
     <>
       <strong>{selectedStudentName ?? 'This student'}</strong> has not started
       the level.

--- a/apps/src/lab2/views/alerts/teacherViewingStudentProject/TeacherViewingStudentProjectAlert.tsx
+++ b/apps/src/lab2/views/alerts/teacherViewingStudentProject/TeacherViewingStudentProjectAlert.tsx
@@ -36,14 +36,14 @@ const TeacherViewingStudentProjectAlert: React.FC<
 
   // Track loading state when switching between students.
   // Progress data (levelNotStarted) may lag behind viewAsUserId updates.
-  const prevViewAsUserIdRef = useRef(viewAsUserId);
-  const [isLoadingLevelProgress, setIsLoadingLevelProgress] = useState(false);
+  const previousViewAsUserIdRef = useRef<number | null | undefined>(undefined);
+  const [isLoadingLevelProgress, setIsLoadingLevelProgress] = useState(true);
 
   // When viewAsUserId changes, mark as loading until progress catches up.
   useEffect(() => {
-    if (prevViewAsUserIdRef.current !== viewAsUserId) {
+    if (previousViewAsUserIdRef.current !== viewAsUserId) {
       setIsLoadingLevelProgress(true);
-      prevViewAsUserIdRef.current = viewAsUserId;
+      previousViewAsUserIdRef.current = viewAsUserId;
     }
   }, [viewAsUserId]);
 

--- a/apps/src/lab2/views/alerts/teacherViewingStudentProject/teacherViewingStudentProjectAlert.module.scss
+++ b/apps/src/lab2/views/alerts/teacherViewingStudentProject/teacherViewingStudentProjectAlert.module.scss
@@ -2,7 +2,7 @@
 
 // Overrides styles for the Alert component to
 // make it fit better in the workspace area
-.alertBanner {
+.inWorkspaceContainer {
   border-bottom: variables.$default-border;
   border-radius: 0;
   padding-block: 0;

--- a/apps/src/sketchlab/SketchlabView.tsx
+++ b/apps/src/sketchlab/SketchlabView.tsx
@@ -246,7 +246,9 @@ const SketchlabView: React.FC<LabProps<LevelProperties>> = ({
             )
           }
         >
-          {teacherViewingStudent && <TeacherViewingStudentProjectAlert />}
+          {teacherViewingStudent && (
+            <TeacherViewingStudentProjectAlert inWorkspaceContainer />
+          )}
           <Excalidraw
             initialData={
               experiments.isEnabledAllowingQueryString(S3_IMAGE_EXPERIMENT)

--- a/apps/src/sketchlab/SketchlabView.tsx
+++ b/apps/src/sketchlab/SketchlabView.tsx
@@ -17,10 +17,7 @@ import React, {useEffect, useCallback, useRef, useState} from 'react';
 import useLevelEditMode from '@cdo/apps/lab2/hooks/useLevelEditMode';
 import useThemeSetting from '@cdo/apps/lab2/hooks/useThemeSetting';
 import {useVerticalLayout} from '@cdo/apps/lab2/hooks/useVerticalLayout';
-import {
-  isReadOnlyWorkspace,
-  isTeacherViewingStudent,
-} from '@cdo/apps/lab2/redux/lab2ReduxSelectors';
+import {isReadOnlyWorkspace} from '@cdo/apps/lab2/redux/lab2ReduxSelectors';
 import {setHasRun} from '@cdo/apps/lab2/redux/systemRedux';
 import {LabProps, LevelProperties} from '@cdo/apps/lab2/types';
 import TeacherViewingStudentProjectAlert from '@cdo/apps/lab2/views/alerts/teacherViewingStudentProject';
@@ -208,7 +205,9 @@ const SketchlabView: React.FC<LabProps<LevelProperties>> = ({
     };
   }, [dispatch]);
 
-  const teacherViewingStudent = useAppSelector(isTeacherViewingStudent);
+  const teacherViewingStudent = Boolean(
+    useAppSelector(state => state.progress.viewAsUserId)
+  );
 
   return (
     <div className={moduleStyles.sketchlabContainer}>


### PR DESCRIPTION
Adds the teacher viewing student project alert to AI Chat Lab. Also adds `inWorkspaceContainer` and custom `className` props to the `TeacherViewingStudentProjectAlert` component so custom styles are only applied when the alert is in a lab's workspace container. I added this prop to the Web Lab 2/Python Lab Workspace and Sketch Lab components.

_Note:_ I removed the `isTeacherViewingStudent` redux selector that was added in https://github.com/code-dot-org/code-dot-org/pull/69927 since we can use `viewAsUserId` to check the same thing and keep this consistent across the codebase.

## Links
Jira ticket: [AFL-393](https://codedotorg.atlassian.net/browse/AFL-393)
Figma mock: [here](https://www.figma.com/file/tDzVjyvhfkF8lyGROENOAD?type=design&node-id=8754%3A62685&mode=dev)

## Testing story
Tested locally

----


https://github.com/user-attachments/assets/7264c807-cd5f-4ea5-b45a-7065eb535e4d

