### PR TITLE
Add an admin-only mass delete student progress UI

### DIFF
--- a/apps/src/sites/studio/pages/admin_users/mass_delete_student_progress.js
+++ b/apps/src/sites/studio/pages/admin_users/mass_delete_student_progress.js
@@ -1,0 +1,11 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+
+import MassDeleteContainer from '@cdo/apps/templates/admin/MassDeleteContainer';
+
+document.addEventListener('DOMContentLoaded', function () {
+  const mountPoint = document.getElementById('mass-delete-container');
+  if (mountPoint) {
+    ReactDOM.render(<MassDeleteContainer />, mountPoint);
+  }
+});

--- a/apps/src/templates/admin/MassDeleteContainer.tsx
+++ b/apps/src/templates/admin/MassDeleteContainer.tsx
@@ -1,5 +1,6 @@
 import {Button} from '@code-dot-org/component-library/button';
 import React, {useState} from 'react';
+import * as Table from 'reactabular-table';
 
 import styles from './mass_delete.module.scss';
 
@@ -283,23 +284,49 @@ const MassDeleteContainer: React.FC = () => {
     }
   };
 
+  const openingDirections = (
+    <div>
+      <h1>Mass Delete Student Progress</h1>
+      <p className={styles.strongWarning}>
+        Warning:Using this tool will permanently delete student progress. Use
+        with caution.
+      </p>
+      To delete student progress in bulk, please enter the{' '}
+      <strong>teacher ID</strong> of the teacher associated with the student
+      data and upload a <strong>CSV file</strong> using one of the following
+      supported formats.
+      <div className={styles.formatInfo}>
+        <strong>Supported formats:</strong>
+        <ul>
+          <li>
+            <strong>With student IDs:</strong> CSV with columns "student_id" and
+            "unit_name"
+          </li>
+          <li>
+            <strong>With usernames:</strong> CSV with columns "student_username"
+            and "unit_name" (will be converted automatically)
+          </li>
+        </ul>
+      </div>
+      <hr />
+    </div>
+  );
+
   return (
     <div className={styles.massDeleteContainer}>
-      <h1>Mass Delete Student Progress</h1>
-
+      {openingDirections}
       <div className={styles.teacherSection}>
-        <label htmlFor="teacher-id">Teacher ID or Email:</label>
-        <input
-          id="teacher-id"
-          type="text"
-          value={teacherId}
-          onChange={e => setTeacherId(e.target.value)}
-          placeholder="Enter teacher ID"
-          className={styles.teacherInput}
-        />
-        <p className={styles.helperText}>
-          Required: The teacher whose students' progress will be deleted
-        </p>
+        <div className={styles.inputRow}>
+          <label htmlFor="teacher-id">Teacher ID:</label>
+          <input
+            id="teacher-id"
+            type="text"
+            value={teacherId}
+            onChange={e => setTeacherId(e.target.value)}
+            placeholder="Enter teacher ID"
+            className={styles.teacherInput}
+          />
+        </div>
       </div>
 
       <div className={styles.uploadSection}>
@@ -348,34 +375,18 @@ const MassDeleteContainer: React.FC = () => {
             )}
           </div>
         )}
-        <div className={styles.formatInfo}>
-          <p>
-            <strong>Supported formats:</strong>
-          </p>
-          <ul>
-            <li>
-              <strong>With student IDs:</strong> CSV with columns "student_id"
-              and "unit_name"
-            </li>
-            <li>
-              <strong>With usernames:</strong> CSV with columns
-              "student_username" and "unit_name" (will be converted
-              automatically)
-            </li>
-          </ul>
-        </div>
       </div>
 
       <div className={styles.buttonSection}>
         <Button
           text="Test delete"
           onClick={() => deleteProgress(true)}
-          disabled={!csvData || !teacherId.trim()}
+          disabled={!csvData || !teacherId.trim() || hasUsernames}
         />
         <Button
           text="Delete for real"
           onClick={() => deleteProgress(false)}
-          disabled={!csvData || !teacherId.trim()}
+          disabled={!csvData || !teacherId.trim() || hasUsernames}
         />
         {(!csvData || !teacherId.trim()) && (
           <p className={styles.disabledInfo}>
@@ -388,7 +399,6 @@ const MassDeleteContainer: React.FC = () => {
         )}
       </div>
 
-      {/* Data Preview Table */}
       {csvData && csvData.length > 0 && (
         <div className={styles.dataPreview}>
           <h3>Uploaded Data Preview</h3>
@@ -397,38 +407,40 @@ const MassDeleteContainer: React.FC = () => {
           </p>
 
           <div className={styles.tableContainer}>
-            <table className={styles.dataTable}>
-              <thead>
-                <tr className={styles.tableHeader}>
-                  <th className={styles.tableHeaderCell}>#</th>
-                  {hasUsernames ? (
-                    <th className={styles.tableHeaderCell}>Student Username</th>
-                  ) : (
-                    <th className={styles.tableHeaderCell}>Student ID</th>
-                  )}
-                  <th className={styles.tableHeaderCell}>Unit Name</th>
-                </tr>
-              </thead>
-              <tbody>
-                {csvData.map((row, index) => (
-                  <tr key={index} className={styles.tableRow}>
-                    <td className={styles.indexCell}>{index + 1}</td>
-                    <td className={styles.tableCell}>
-                      {hasUsernames ? row.student_username : row.student_id}
-                    </td>
-                    <td className={styles.lastCell}>{row.unit_name}</td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
+            <Table.Provider
+              className="table table-striped"
+              columns={[
+                {
+                  property: 'index',
+                  header: {
+                    label: '#',
+                  },
+                },
+                {
+                  property: hasUsernames ? 'student_username' : 'student_id',
+                  header: {
+                    label: hasUsernames ? 'Student Username' : 'Student ID',
+                  },
+                },
+                {
+                  property: 'unit_name',
+                  header: {
+                    label: 'Unit Name',
+                  },
+                },
+              ]}
+            >
+              <Table.Header />
+              <Table.Body
+                rows={csvData.map((row, index) => ({
+                  ...row,
+                  index: index + 1,
+                  id: index,
+                }))}
+                rowKey="id"
+              />
+            </Table.Provider>
           </div>
-
-          {csvData.length > 10 && (
-            <p className={styles.tableNote}>
-              Note: All {csvData.length} records will be processed during
-              deletion.
-            </p>
-          )}
         </div>
       )}
     </div>

--- a/apps/src/templates/admin/MassDeleteContainer.tsx
+++ b/apps/src/templates/admin/MassDeleteContainer.tsx
@@ -38,10 +38,8 @@ const parseCsv = (file: File): Promise<OriginalData[]> => {
             throw new Error('CSV must have at least one data row');
           }
 
-          // Get the headers from the first row keys
           const headers = Object.keys(results.data[0]);
 
-          // Check for student identifier column (either student_id or student_username)
           const hasStudentId = headers.includes('student_id');
           const hasStudentUsername = headers.includes('student_username');
 

--- a/apps/src/templates/admin/MassDeleteContainer.tsx
+++ b/apps/src/templates/admin/MassDeleteContainer.tsx
@@ -266,7 +266,7 @@ const MassDeleteContainer: React.FC = () => {
 
   const openingDirections = (
     <div>
-      <h1>Mass Delete Student Progress</h1>
+      <h1>Mass Delete Student Progress - NOT READY FOR USE YET</h1>
       <p className={styles.strongWarning}>
         Warning:Using this tool will permanently delete student progress. Use
         with caution.

--- a/apps/src/templates/admin/MassDeleteContainer.tsx
+++ b/apps/src/templates/admin/MassDeleteContainer.tsx
@@ -1,0 +1,438 @@
+import {Button} from '@code-dot-org/component-library/button';
+import React, {useState} from 'react';
+
+import styles from './mass_delete.module.scss';
+
+// Type definitions
+interface OriginalData {
+  student_id?: string;
+  student_username?: string;
+  unit_name: string;
+}
+
+interface ProcessedData {
+  student_id: string;
+  unit_name: string;
+}
+
+// Utility functions
+const parseCsv = (file: File): Promise<OriginalData[]> => {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = e => {
+      try {
+        const text = e.target?.result as string;
+        const lines = text.split('\n').filter(line => line.trim());
+
+        if (lines.length < 2) {
+          throw new Error(
+            'CSV must have at least a header row and one data row'
+          );
+        }
+
+        // Parse header row
+        const headers = lines[0]
+          .split(',')
+          .map(header => header.trim().toLowerCase());
+
+        // Check for student identifier column (either student_id or student_username)
+        const hasStudentId = headers.includes('student_id');
+        const hasStudentUsername = headers.includes('student_username');
+
+        if (!hasStudentId && !hasStudentUsername) {
+          throw new Error(
+            'CSV must have a column named "student_id" or "student_username"'
+          );
+        }
+
+        if (!headers.includes('unit_name')) {
+          throw new Error('CSV must have a column named "unit_name"');
+        }
+
+        // Find column indices
+        const studentIdIndex = hasStudentId
+          ? headers.indexOf('student_id')
+          : -1;
+        const studentUsernameIndex = hasStudentUsername
+          ? headers.indexOf('student_username')
+          : -1;
+        const unitNameIndex = headers.indexOf('unit_name');
+
+        // Parse data rows
+        const parsedData: OriginalData[] = [];
+
+        for (let i = 1; i < lines.length; i++) {
+          const cells = lines[i].split(',').map(cell => cell.trim());
+
+          const maxIndex = Math.max(
+            studentIdIndex,
+            studentUsernameIndex,
+            unitNameIndex
+          );
+
+          if (cells.length < maxIndex + 1) {
+            throw new Error(`Row ${i + 1} has insufficient columns`);
+          }
+
+          const studentId =
+            studentIdIndex >= 0 ? cells[studentIdIndex] : undefined;
+          const studentUsername =
+            studentUsernameIndex >= 0 ? cells[studentUsernameIndex] : undefined;
+          const unitName = cells[unitNameIndex];
+
+          if ((!studentId && !studentUsername) || !unitName) {
+            throw new Error(
+              `Row ${i + 1} has missing student identifier or unit_name`
+            );
+          }
+
+          const rowData: OriginalData = {
+            unit_name: unitName,
+          };
+
+          if (studentId) {
+            rowData.student_id = studentId;
+          }
+
+          if (studentUsername) {
+            rowData.student_username = studentUsername;
+          }
+
+          parsedData.push(rowData);
+        }
+
+        resolve(parsedData);
+      } catch (error) {
+        reject(error);
+      }
+    };
+    reader.onerror = () => reject(new Error('Failed to read file'));
+    reader.readAsText(file);
+  });
+};
+
+const hasUsernameColumn = (data: OriginalData[]): boolean => {
+  return data.length > 0 && data[0].student_username !== undefined;
+};
+
+const getCSRFToken = (): string => {
+  const token = document
+    .querySelector('meta[name="csrf-token"]')
+    ?.getAttribute('content');
+  return token || '';
+};
+
+// Main container component
+const MassDeleteContainer: React.FC = () => {
+  const [csvFile, setCsvFile] = useState<File | null>(null);
+  const [csvData, setCsvData] = useState<Array<{
+    student_id?: string;
+    student_username?: string;
+    unit_name: string;
+  }> | null>(null);
+  const [csvError, setCsvError] = useState<string | null>(null);
+  const [hasUsernames, setHasUsernames] = useState<boolean>(false);
+  const [teacherId, setTeacherId] = useState<string>('');
+  const [isConverting, setIsConverting] = useState<boolean>(false);
+  const [conversionError, setConversionError] = useState<string | null>(null);
+
+  // Keep original uploaded data in state
+  const [originalCsvData, setOriginalCsvData] = useState<OriginalData[]>();
+  // Keep processed data ready for deletion
+  const [processedCsvData, setProcessedCsvData] = useState<ProcessedData[]>();
+
+  const handleFileUpload = async (
+    event: React.ChangeEvent<HTMLInputElement>
+  ) => {
+    const file = event.target.files?.[0];
+    setCsvError(null);
+
+    if (file && file.type === 'text/csv') {
+      setCsvFile(file);
+
+      try {
+        // Parse and validate CSV
+        const parsedData = await parseCsv(file);
+        setOriginalCsvData(parsedData);
+        setCsvData(parsedData);
+
+        // Determine if conversion is needed
+        if (hasUsernameColumn(parsedData)) {
+          setHasUsernames(true);
+        } else {
+          // Convert to ProcessedData format for data that already has student_id
+          const processedData = parsedData.map(item => ({
+            student_id: item.student_id!,
+            unit_name: item.unit_name,
+          }));
+          setProcessedCsvData(processedData);
+          setHasUsernames(false);
+        }
+      } catch (error) {
+        setCsvError(
+          error instanceof Error ? error.message : 'Failed to parse CSV'
+        );
+        setCsvData(null);
+        setOriginalCsvData(undefined);
+        setProcessedCsvData(undefined);
+      }
+    } else {
+      setCsvError('Please upload a valid CSV file');
+    }
+  };
+
+  const convertUsernamesToIds = async () => {
+    if (!originalCsvData || !hasUsernames) {
+      console.log('No username data to convert');
+      return;
+    }
+
+    setIsConverting(true);
+    setConversionError(null);
+    console.log('Starting username to ID conversion...');
+
+    try {
+      const response = await fetch('/admin/convert_usernames_to_ids', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Accept: 'application/json',
+          'X-CSRF-Token': getCSRFToken(),
+        },
+        body: JSON.stringify({
+          csv_data: originalCsvData,
+          teacher_id: teacherId,
+        }),
+      });
+
+      if (!response.ok) {
+        console.info(
+          `HTTP error for convert_usernames_to_ids. status: ${response.status}`
+        );
+      }
+
+      const result = await response.json();
+
+      if (result.success) {
+        setProcessedCsvData(result.converted_data);
+        setCsvData(result.converted_data);
+        setHasUsernames(false);
+      }
+    } catch (error) {
+      console.error('Error during conversion:', error);
+      setConversionError(
+        error instanceof Error
+          ? error.message
+          : 'Failed to convert usernames to student IDs. Please try again.'
+      );
+    } finally {
+      setIsConverting(false);
+    }
+  };
+
+  const deleteProgress = async (isDryRun = true) => {
+    try {
+      const response = await fetch('/admin/delete_user_progress', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Accept: 'application/json',
+          'X-CSRF-Token': getCSRFToken(),
+        },
+        body: JSON.stringify({
+          csv_data: processedCsvData,
+          teacher_id: teacherId,
+          dry_run: isDryRun,
+        }),
+      });
+
+      if (!response.ok) {
+        const errorData = await response.json().catch(() => ({}));
+        throw new Error(
+          errorData.error || `HTTP error! status: ${response.status}`
+        );
+      }
+
+      const result = await response.json();
+
+      if (result.success) {
+        console.log('Delete operation completed successfully');
+        console.log('Result:', result);
+
+        // Show user-friendly feedback
+        alert(
+          `${
+            result.dry_run ? 'Test delete' : 'Actual delete'
+          } completed successfully. Check console for details.`
+        );
+      } else {
+        console.error('Delete operation failed:', result);
+        throw new Error(
+          result.error +
+            (result.details ? `\n\nDetails: ${result.details}` : '')
+        );
+      }
+    } catch (error) {
+      console.error('Error during deletion:', error);
+      alert(
+        error instanceof Error
+          ? `Delete operation failed: ${error.message}`
+          : 'Delete operation failed. Please try again.'
+      );
+      throw error;
+    }
+  };
+
+  return (
+    <div className={styles.massDeleteContainer}>
+      <h1>Mass Delete Student Progress</h1>
+
+      <div className={styles.teacherSection}>
+        <label htmlFor="teacher-id">Teacher ID or Email:</label>
+        <input
+          id="teacher-id"
+          type="text"
+          value={teacherId}
+          onChange={e => setTeacherId(e.target.value)}
+          placeholder="Enter teacher ID"
+          className={styles.teacherInput}
+        />
+        <p className={styles.helperText}>
+          Required: The teacher whose students' progress will be deleted
+        </p>
+      </div>
+
+      <div className={styles.uploadSection}>
+        <label htmlFor="csv-upload">Upload CSV file:</label>
+        <input
+          id="csv-upload"
+          type="file"
+          accept=".csv"
+          onChange={handleFileUpload}
+          className={styles.fileInput}
+        />
+        {csvError && (
+          <div className={styles.errorMessage}>Error: {csvError}</div>
+        )}
+        {csvFile && !csvError && (
+          <div>
+            <p>
+              File uploaded: {csvFile.name} ({csvData?.length || 0} rows)
+            </p>
+            {hasUsernames ? (
+              <div>
+                <p className={styles.warningMessage}>
+                  ⚠️ CSV contains usernames - will need conversion to IDs before
+                  deletion
+                </p>
+                <Button
+                  text={
+                    isConverting
+                      ? 'Converting...'
+                      : 'Convert usernames to student IDs'
+                  }
+                  onClick={convertUsernamesToIds}
+                  disabled={isConverting}
+                  className={
+                    isConverting ? styles.converting : styles.convertButton
+                  }
+                />
+                {conversionError && (
+                  <p className={styles.conversionError}>{conversionError}</p>
+                )}
+              </div>
+            ) : (
+              <p className={styles.successMessage}>
+                ✅ CSV contains student IDs - ready for deletion
+              </p>
+            )}
+          </div>
+        )}
+        <div className={styles.formatInfo}>
+          <p>
+            <strong>Supported formats:</strong>
+          </p>
+          <ul>
+            <li>
+              <strong>With student IDs:</strong> CSV with columns "student_id"
+              and "unit_name"
+            </li>
+            <li>
+              <strong>With usernames:</strong> CSV with columns
+              "student_username" and "unit_name" (will be converted
+              automatically)
+            </li>
+          </ul>
+        </div>
+      </div>
+
+      <div className={styles.buttonSection}>
+        <Button
+          text="Test delete"
+          onClick={() => deleteProgress(true)}
+          disabled={!csvData || !teacherId.trim()}
+        />
+        <Button
+          text="Delete for real"
+          onClick={() => deleteProgress(false)}
+          disabled={!csvData || !teacherId.trim()}
+        />
+        {(!csvData || !teacherId.trim()) && (
+          <p className={styles.disabledInfo}>
+            {!teacherId.trim() && !csvData
+              ? 'Please enter a Teacher ID and upload a CSV file'
+              : !teacherId.trim()
+              ? 'Please enter a Teacher ID'
+              : 'Please upload a CSV file'}
+          </p>
+        )}
+      </div>
+
+      {/* Data Preview Table */}
+      {csvData && csvData.length > 0 && (
+        <div className={styles.dataPreview}>
+          <h3>Uploaded Data Preview</h3>
+          <p className={styles.previewInfo}>
+            Showing {csvData.length} record{csvData.length !== 1 ? 's' : ''}
+          </p>
+
+          <div className={styles.tableContainer}>
+            <table className={styles.dataTable}>
+              <thead>
+                <tr className={styles.tableHeader}>
+                  <th className={styles.tableHeaderCell}>#</th>
+                  {hasUsernames ? (
+                    <th className={styles.tableHeaderCell}>Student Username</th>
+                  ) : (
+                    <th className={styles.tableHeaderCell}>Student ID</th>
+                  )}
+                  <th className={styles.tableHeaderCell}>Unit Name</th>
+                </tr>
+              </thead>
+              <tbody>
+                {csvData.map((row, index) => (
+                  <tr key={index} className={styles.tableRow}>
+                    <td className={styles.indexCell}>{index + 1}</td>
+                    <td className={styles.tableCell}>
+                      {hasUsernames ? row.student_username : row.student_id}
+                    </td>
+                    <td className={styles.lastCell}>{row.unit_name}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+
+          {csvData.length > 10 && (
+            <p className={styles.tableNote}>
+              Note: All {csvData.length} records will be processed during
+              deletion.
+            </p>
+          )}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default MassDeleteContainer;

--- a/apps/src/templates/admin/MassDeleteContainer.tsx
+++ b/apps/src/templates/admin/MassDeleteContainer.tsx
@@ -1,4 +1,5 @@
 import {Button} from '@code-dot-org/component-library/button';
+import Papa from 'papaparse';
 import React, {useState} from 'react';
 import * as Table from 'reactabular-table';
 
@@ -19,96 +20,77 @@ interface ProcessedData {
 // Utility functions
 const parseCsv = (file: File): Promise<OriginalData[]> => {
   return new Promise((resolve, reject) => {
-    const reader = new FileReader();
-    reader.onload = e => {
-      try {
-        const text = e.target?.result as string;
-        const lines = text.split('\n').filter(line => line.trim());
-
-        if (lines.length < 2) {
-          throw new Error(
-            'CSV must have at least a header row and one data row'
-          );
-        }
-
-        // Parse header row
-        const headers = lines[0]
-          .split(',')
-          .map(header => header.trim().toLowerCase());
-
-        // Check for student identifier column (either student_id or student_username)
-        const hasStudentId = headers.includes('student_id');
-        const hasStudentUsername = headers.includes('student_username');
-
-        if (!hasStudentId && !hasStudentUsername) {
-          throw new Error(
-            'CSV must have a column named "student_id" or "student_username"'
-          );
-        }
-
-        if (!headers.includes('unit_name')) {
-          throw new Error('CSV must have a column named "unit_name"');
-        }
-
-        // Find column indices
-        const studentIdIndex = hasStudentId
-          ? headers.indexOf('student_id')
-          : -1;
-        const studentUsernameIndex = hasStudentUsername
-          ? headers.indexOf('student_username')
-          : -1;
-        const unitNameIndex = headers.indexOf('unit_name');
-
-        // Parse data rows
-        const parsedData: OriginalData[] = [];
-
-        for (let i = 1; i < lines.length; i++) {
-          const cells = lines[i].split(',').map(cell => cell.trim());
-
-          const maxIndex = Math.max(
-            studentIdIndex,
-            studentUsernameIndex,
-            unitNameIndex
-          );
-
-          if (cells.length < maxIndex + 1) {
-            throw new Error(`Row ${i + 1} has insufficient columns`);
-          }
-
-          const studentId =
-            studentIdIndex >= 0 ? cells[studentIdIndex] : undefined;
-          const studentUsername =
-            studentUsernameIndex >= 0 ? cells[studentUsernameIndex] : undefined;
-          const unitName = cells[unitNameIndex];
-
-          if ((!studentId && !studentUsername) || !unitName) {
+    Papa.parse<Record<string, string>>(file, {
+      header: true,
+      skipEmptyLines: true,
+      transformHeader: (header: string) => header.trim().toLowerCase(),
+      complete: results => {
+        try {
+          if (results.errors.length > 0) {
             throw new Error(
-              `Row ${i + 1} has missing student identifier or unit_name`
+              `CSV parsing errors: ${results.errors
+                .map(e => e.message)
+                .join(', ')}`
             );
           }
 
-          const rowData: OriginalData = {
-            unit_name: unitName,
-          };
-
-          if (studentId) {
-            rowData.student_id = studentId;
+          if (!results.data || results.data.length === 0) {
+            throw new Error('CSV must have at least one data row');
           }
 
-          if (studentUsername) {
-            rowData.student_username = studentUsername;
+          // Get the headers from the first row keys
+          const headers = Object.keys(results.data[0]);
+
+          // Check for student identifier column (either student_id or student_username)
+          const hasStudentId = headers.includes('student_id');
+          const hasStudentUsername = headers.includes('student_username');
+
+          if (!hasStudentId && !hasStudentUsername) {
+            throw new Error(
+              'CSV must have a column named "student_id" or "student_username"'
+            );
           }
 
-          parsedData.push(rowData);
+          if (!headers.includes('unit_name')) {
+            throw new Error('CSV must have a column named "unit_name"');
+          }
+
+          // Process the data
+          const parsedData: OriginalData[] = results.data.map((row, index) => {
+            const studentId = row.student_id?.trim();
+            const studentUsername = row.student_username?.trim();
+            const unitName = row.unit_name?.trim();
+
+            if ((!studentId && !studentUsername) || !unitName) {
+              throw new Error(
+                `Row ${index + 2} has missing student identifier or unit_name`
+              );
+            }
+
+            const rowData: OriginalData = {
+              unit_name: unitName,
+            };
+
+            if (studentId) {
+              rowData.student_id = studentId;
+            }
+
+            if (studentUsername) {
+              rowData.student_username = studentUsername;
+            }
+
+            return rowData;
+          });
+
+          resolve(parsedData);
+        } catch (error) {
+          reject(error);
         }
-
-        resolve(parsedData);
-      } catch (error) {
-        reject(error);
-      }
-    };
-    reader.onerror = () => reject(new Error('Failed to read file'));
-    reader.readAsText(file);
+      },
+      error: error => {
+        reject(new Error(`Failed to parse CSV: ${error.message}`));
+      },
+    });
   });
 };
 
@@ -291,7 +273,15 @@ const MassDeleteContainer: React.FC = () => {
         Warning:Using this tool will permanently delete student progress. Use
         with caution.
       </p>
-      To delete student progress in bulk, please enter the{' '}
+      <p>
+        This tool is intended to only be used when deleting student progress by
+        unit. For teacher requests needing all data to be deleted for students,
+        please follow the process oulined in{' '}
+        <a href="https://docs.google.com/document/d/1mBY56DeAzrwTM3CVIOFho3azTi9mudE37ZQrVZXxaMA/edit?tab=t.0#heading=h.k909psfgxiwj">
+          our Process Doc.
+        </a>
+      </p>
+      To delete student progress for multiple students by unit, please enter the{' '}
       <strong>teacher ID</strong> of the teacher associated with the student
       data and upload a <strong>CSV file</strong> using one of the following
       supported formats.

--- a/apps/src/templates/admin/mass_delete.module.scss
+++ b/apps/src/templates/admin/mass_delete.module.scss
@@ -1,0 +1,133 @@
+.teacherSection {
+  margin-bottom: 20px;
+}
+
+.teacherInput {
+  margin: 10px 0;
+  padding: 8px;
+  width: 300px;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+}
+
+.helperText {
+  font-size: 14px;
+  color: #666;
+  margin: 5px 0;
+}
+
+.fileInput {
+  margin: 10px 0;
+}
+
+.errorMessage {
+  color: red;
+  margin: 10px 0;
+}
+
+.warningMessage {
+  color: orange;
+  font-weight: bold;
+}
+
+.successMessage {
+  color: green;
+}
+
+.convertButton {
+  margin-top: 10px;
+  background-color: #007bff;
+
+  &.converting {
+    background-color: #ccc;
+  }
+}
+
+.conversionError {
+  color: red;
+  margin-top: 10px;
+  font-size: 14px;
+}
+
+.formatInfo {
+  margin-top: 10px;
+  font-size: 14px;
+  color: #666;
+}
+
+.buttonSection {
+  margin-top: 20px;
+  display: flex;
+  gap: 10px;
+}
+
+.disabledInfo {
+  color: #666;
+  font-size: 14px;
+  margin-top: 10px;
+}
+
+.dataPreview {
+  margin-top: 30px;
+}
+
+.previewInfo {
+  color: #666;
+  margin-bottom: 15px;
+}
+
+.tableContainer {
+  overflow-x: auto;
+}
+
+.dataTable {
+  width: 100%;
+  border-collapse: collapse;
+  border: 1px solid #ddd;
+  background-color: #fff;
+}
+
+.tableHeader {
+  background-color: #f5f5f5;
+}
+
+.tableHeaderCell {
+  padding: 12px;
+  text-align: left;
+  border-bottom: 2px solid #ddd;
+  font-weight: bold;
+}
+
+.tableRow {
+  border-bottom: 1px solid #eee;
+
+  &:nth-child(even) {
+    background-color: #f9f9f9;
+  }
+
+  &:nth-child(odd) {
+    background-color: #fff;
+  }
+}
+
+.tableCell {
+  padding: 10px 12px;
+  border-right: 1px solid #eee;
+}
+
+.indexCell {
+  padding: 10px 12px;
+  border-right: 1px solid #eee;
+  color: #666;
+}
+
+.lastCell {
+  padding: 10px 12px;
+}
+
+.tableNote {
+  color: #666;
+  font-size: 14px;
+  margin-top: 10px;
+  font-style: italic;
+}

--- a/apps/src/templates/admin/mass_delete.module.scss
+++ b/apps/src/templates/admin/mass_delete.module.scss
@@ -1,19 +1,20 @@
 .teacherSection {
   margin-bottom: 20px;
+  display: flex;
+  flex-direction: column;
+}
+
+.inputRow {
+  display: flex;
+  align-items: center;
+  gap: 10px;
 }
 
 .teacherInput {
-  margin: 10px 0;
   padding: 8px;
   width: 300px;
   border: 1px solid #ccc;
   border-radius: 4px;
-}
-
-.helperText {
-  font-size: 14px;
-  color: #666;
-  margin: 5px 0;
 }
 
 .fileInput {
@@ -23,6 +24,11 @@
 .errorMessage {
   color: red;
   margin: 10px 0;
+}
+
+.strongWarning {
+  font-weight: bold;
+  color: red;
 }
 
 .warningMessage {
@@ -78,56 +84,4 @@
 
 .tableContainer {
   overflow-x: auto;
-}
-
-.dataTable {
-  width: 100%;
-  border-collapse: collapse;
-  border: 1px solid #ddd;
-  background-color: #fff;
-}
-
-.tableHeader {
-  background-color: #f5f5f5;
-}
-
-.tableHeaderCell {
-  padding: 12px;
-  text-align: left;
-  border-bottom: 2px solid #ddd;
-  font-weight: bold;
-}
-
-.tableRow {
-  border-bottom: 1px solid #eee;
-
-  &:nth-child(even) {
-    background-color: #f9f9f9;
-  }
-
-  &:nth-child(odd) {
-    background-color: #fff;
-  }
-}
-
-.tableCell {
-  padding: 10px 12px;
-  border-right: 1px solid #eee;
-}
-
-.indexCell {
-  padding: 10px 12px;
-  border-right: 1px solid #eee;
-  color: #666;
-}
-
-.lastCell {
-  padding: 10px 12px;
-}
-
-.tableNote {
-  color: #666;
-  font-size: 14px;
-  margin-top: 10px;
-  font-style: italic;
 }

--- a/apps/webpackEntryPoints.js
+++ b/apps/webpackEntryPoints.js
@@ -25,6 +25,7 @@ const ALL_APPS = [
 
 // prettier-ignore
 const CODE_STUDIO_ENTRIES = {
+  'admin_users/mass_delete_student_progress': './src/sites/studio/pages/admin_users/mass_delete_student_progress.js',
   'certificates/batch': './src/sites/studio/pages/certificates/batch.js',
   'certificates/show': './src/sites/studio/pages/certificates/show.js',
   'code-studio': './src/sites/studio/pages/code-studio.js',

--- a/dashboard/app/controllers/admin_users_controller.rb
+++ b/dashboard/app/controllers/admin_users_controller.rb
@@ -1,4 +1,6 @@
 require 'cdo/activity_constants'
+require 'csv'
+require 'tempfile'
 
 class AdminUsersController < ApplicationController
   include Pd::PageHelper
@@ -354,6 +356,139 @@ class AdminUsersController < ApplicationController
   rescue ArgumentError => exception
     flash[:alert] = "ADD EMAIL FAILED: #{exception.message}"
     redirect_to studio_person_form_path
+  end
+
+  # GET /admin/mass_delete_student_progress
+  def mass_delete_student_progress
+  end
+
+  # POST /admin/convert_usernames_to_ids
+  def convert_usernames_to_ids
+    # Validate input parameters
+    csv_data = params[:csv_data]
+    if csv_data.blank?
+      render json: {success: false, error: 'CSV data is required'}, status: :bad_request
+      return
+    end
+
+    # Create temporary input file
+    temp_input = Tempfile.new(['usernames', '.csv'])
+    # Create output filename that script expects
+    temp_output = temp_input.path.sub(/\.csv\z/, '-user-ids.csv')
+
+    # Write frontend data to temp file
+    CSV.open(temp_input.path, 'w', headers: true) do |csv|
+      csv << ['student_username', 'unit_name']  # Headers
+      csv_data.each {|row| csv << [row['student_username'], row['unit_name']]}
+    end
+
+    Rails.logger.info "Created temp input file: #{temp_input.path}"
+    Rails.logger.info "Expected output file: #{temp_output}"
+
+    # Instead of running the external script, implement the conversion logic directly
+    # This avoids issues with environment loading and paths
+    converted_data = []
+    error_message = nil
+
+    CSV.foreach(temp_input.path, headers: true) do |row|
+      username = row['student_username']
+      unit_name = row['unit_name']
+
+      unless username
+        Rails.logger.error 'CSV must have a column named "student_username".'
+        error_message = 'CSV must have a column named "student_username"'
+        break
+      end
+
+      user = User.find_by_username(username)
+      unless user
+        Rails.logger.error "Student with username #{username} not found"
+        error_message = "Student with username #{username} not found"
+        break
+      end
+
+      converted_data << {
+        student_id: user.id.to_s,
+        unit_name: unit_name
+      }.compact
+    end
+
+    if error_message
+      temp_input.unlink
+      render json: {success: false, error: error_message}, status: :bad_request
+      return
+    end
+
+    Rails.logger.info "Successfully converted #{converted_data.length} records"
+
+    # Cleanup temp files
+    temp_input.unlink
+
+    render json: {success: true, converted_data: converted_data}
+  rescue => exception
+    Rails.logger.error "Error in convert_usernames_to_ids: #{exception.message}"
+    Rails.logger.error exception.backtrace.join("\n")
+    render json: {success: false, error: 'Internal server error', details: exception.message}, status: :internal_server_error
+  end
+
+  # POST /admin/delete_user_progress
+  def delete_user_progress
+    # Endpoint for deleting user progress using the Ruby script
+    unless request.post?
+      render json: {error: 'Only POST requests are allowed'}, status: :method_not_allowed
+      return
+    end
+
+    begin
+      csv_data = params[:csv_data]
+      teacher_id = params[:teacher_id]
+      dry_run = params[:dry_run]
+
+      if csv_data.blank? || teacher_id.blank?
+        render json: {error: 'CSV data and teacher ID are required'}, status: :bad_request
+        return
+      end
+
+      # Create a temporary file for the CSV content with student_id,unit_name format
+      temp_file = Tempfile.new(['delete_progress', '.csv'])
+      CSV.open(temp_file.path, 'w', headers: true) do |csv|
+        csv << ['student_id', 'unit_name']
+        csv_data.each do |row|
+          csv << [row['student_id'], row['unit_name']]
+        end
+      end
+
+      # Path to the delete script
+      repo_root = File.expand_path('..', Rails.root)
+      script_path = File.join(repo_root, 'bin', 'oneoff', 'reset_student_progress_in_bulk', 'delete_user_progress_by_unit.rb')
+
+      # Determine commit flag
+      commit_flag = dry_run == true ? '' : 'for-real'
+
+      # Run the Ruby script with the temporary file
+      output = `cd #{repo_root} && ruby #{script_path} #{teacher_id} #{temp_file.path} #{commit_flag} 2>&1`
+      exit_status = $?.exitstatus
+
+      # Clean up the temporary file
+      temp_file.unlink
+
+      if exit_status != 0
+        Rails.logger.error "Delete progress script failed with exit status #{exit_status}: #{output}"
+        render json: {error: 'Delete progress script failed', details: output}, status: :internal_server_error
+        return
+      end
+
+      render json: {
+        success: true,
+        output: output,
+        dry_run: dry_run,
+        message: dry_run ? "Dry run completed successfully" : "Progress deletion completed successfully"
+      }
+    rescue => exception
+      Rails.logger.error "Error in delete_user_progress: #{exception.message}"
+      Rails.logger.error exception.backtrace.join("\n")
+      render json: {error: 'Internal server error', details: exception.message}, status: :internal_server_error
+    end
   end
 
   private def restricted_users

--- a/dashboard/app/controllers/admin_users_controller.rb
+++ b/dashboard/app/controllers/admin_users_controller.rb
@@ -364,7 +364,6 @@ class AdminUsersController < ApplicationController
 
   # POST /admin/convert_usernames_to_ids
   def convert_usernames_to_ids
-    # Validate input parameters
     csv_data = params[:csv_data]
     if csv_data.blank?
       render json: {success: false, error: 'CSV data is required'}, status: :bad_request
@@ -385,8 +384,6 @@ class AdminUsersController < ApplicationController
     Rails.logger.info "Created temp input file: #{temp_input.path}"
     Rails.logger.info "Expected output file: #{temp_output}"
 
-    # Instead of running the external script, implement the conversion logic directly
-    # This avoids issues with environment loading and paths
     converted_data = []
     error_message = nil
 
@@ -421,7 +418,6 @@ class AdminUsersController < ApplicationController
 
     Rails.logger.info "Successfully converted #{converted_data.length} records"
 
-    # Cleanup temp files
     temp_input.unlink
 
     render json: {success: true, converted_data: converted_data}
@@ -433,7 +429,6 @@ class AdminUsersController < ApplicationController
 
   # POST /admin/delete_user_progress
   def delete_user_progress
-    # Endpoint for deleting user progress using the Ruby script
     unless request.post?
       render json: {error: 'Only POST requests are allowed'}, status: :method_not_allowed
       return
@@ -462,14 +457,11 @@ class AdminUsersController < ApplicationController
       repo_root = File.expand_path('..', Rails.root)
       script_path = File.join(repo_root, 'bin', 'oneoff', 'reset_student_progress_in_bulk', 'delete_user_progress_by_unit.rb')
 
-      # Determine commit flag
       commit_flag = dry_run == true ? '' : 'for-real'
 
-      # Run the Ruby script with the temporary file
       output = `cd #{repo_root} && ruby #{script_path} #{teacher_id} #{temp_file.path} #{commit_flag} 2>&1`
       exit_status = $?.exitstatus
 
-      # Clean up the temporary file
       temp_file.unlink
 
       if exit_status != 0

--- a/dashboard/app/views/admin_users/mass_delete_student_progress.html.haml
+++ b/dashboard/app/views/admin_users/mass_delete_student_progress.html.haml
@@ -1,0 +1,7 @@
+%meta{name: "csrf-token", content: form_authenticity_token}
+
+#mass-delete-container
+
+%script{src: webpack_asset_path('js/admin_users/mass_delete_student_progress.js')}
+
+= render partial: 'home/admin'

--- a/dashboard/config/routes.rb
+++ b/dashboard/config/routes.rb
@@ -736,6 +736,9 @@ Dashboard::Application.routes.draw do
         put :user_project, action: 'user_project_restore_form', as: 'user_project_restore_form'
         get :delete_progress, action: 'delete_progress_form', as: 'delete_progress_form'
         post :delete_progress
+        get 'mass-delete-student-progress', action: 'mass_delete_student_progress'
+        post :convert_usernames_to_ids
+        post :delete_user_progress
       end
 
       get :styleguide, to: redirect('/styleguide/'), as: 'admin_styleguide'


### PR DESCRIPTION
Initial start to an admin page for deleting user progress.

https://github.com/user-attachments/assets/9e4a74da-977f-478a-913d-bb674237b787

## Links
<!--  Links to relevant external resources.
      - spec docs, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- Jira: 

## Testing story
<!--  Does your change include appropriate tests?
      - If so, please describe how the tests included in this PR are sufficient.
      - If not, please explain why this change does not need to be tested. -->




## Follow ups

- Disable "Delete" buttons when a delete is in progress
- Include link to a template with the correct header cell names
- Possibly, add to preview table when the student data has been deleted
- Overall improve how errors are surfaced to the user
- Add context for what "test delete" does vs "delete for real"
- Add better notifications for when the deletions are finished
- Add tests for new controller endpoints
- Test for speed of large files and/or determine max size of file