### PR TITLE
Lab2: update SettingsPanel to use PanelContainer

### DIFF
--- a/apps/src/lab2/views/components/Instructions/ResourcePanel/SettingsPanel.tsx
+++ b/apps/src/lab2/views/components/Instructions/ResourcePanel/SettingsPanel.tsx
@@ -1,11 +1,11 @@
 import CloseButton from '@code-dot-org/component-library/closeButton';
 import {useTheme} from '@code-dot-org/component-library/common/contexts';
 import {SimpleDropdown} from '@code-dot-org/component-library/dropdown';
-import Typography from '@code-dot-org/component-library/typography';
 import React, {useEffect, useState} from 'react';
 
 import {sendLab2AnalyticsEvent} from '@cdo/apps/lab2/utils';
 import {Setting} from '@cdo/apps/lab2/views/components/Instructions/ResourcePanel';
+import PanelContainer from '@cdo/apps/lab2/views/components/PanelContainer';
 import localization, {useLocalization} from '@cdo/apps/localization';
 import {LanguageInfo} from '@cdo/apps/localization/Localization';
 import {EVENTS} from '@cdo/apps/metrics/AnalyticsConstants';
@@ -25,7 +25,7 @@ const SettingsPanel: React.FunctionComponent<SettingsPanelProps> = ({
 }) => {
   const {theme} = useTheme();
   // SimpleDropdown isn't themed properly, so we have to manually set the color.
-  const dropdownColor = theme === 'Dark' ? 'white' : 'black';
+  const dropdownColor = theme === 'Dark' ? 'white' : 'gray';
   const locale = useLocalization();
   const [localeOptions, setLocaleOptions] = useState<LanguageInfo[]>(
     localization.locales
@@ -72,20 +72,18 @@ const SettingsPanel: React.FunctionComponent<SettingsPanelProps> = ({
   };
 
   return (
-    <div className={styles.settingsPanel}>
-      <div className={styles.header}>
-        <Typography
-          semanticTag="h2"
-          visualAppearance="overline-two"
-          className={styles.headerText}
-        >
-          {commonI18n.settings()}
-        </Typography>
+    <PanelContainer
+      id="settings-panel"
+      headerContent="Settings"
+      className={styles.settingsPanel}
+      headerClassName={styles.settingsHeader}
+      rightHeaderContent={
         <CloseButton
           onClick={closePanel}
           aria-label={commonI18n.closeSettings()}
         />
-      </div>
+      }
+    >
       <div className={styles.settingsList}>
         <form
           action={'/locale'}
@@ -129,7 +127,7 @@ const SettingsPanel: React.FunctionComponent<SettingsPanelProps> = ({
           />
         ))}
       </div>
-    </div>
+    </PanelContainer>
   );
 };
 

--- a/apps/src/lab2/views/components/Instructions/ResourcePanel/settings-panel.module.scss
+++ b/apps/src/lab2/views/components/Instructions/ResourcePanel/settings-panel.module.scss
@@ -4,10 +4,10 @@
   border-top: variables.$default-border;
   background: var(--background-neutral-secondary);
   flex: 1;
-}
 
-.settingsHeader.settingsHeader {
-  background-color: var(--background-neutral-secondary);
+  .settingsHeader {
+    background-color: var(--background-neutral-secondary);
+  }
 }
 
 .settingsList {

--- a/apps/src/lab2/views/components/Instructions/ResourcePanel/settings-panel.module.scss
+++ b/apps/src/lab2/views/components/Instructions/ResourcePanel/settings-panel.module.scss
@@ -1,30 +1,21 @@
+@use '@cdo/apps/lab2/views/components/layout/variables.scss' as variables;
+
 .settingsPanel {
-  border-top: 1px solid var(--borders-neutral-primary);
-  border-left: 1px solid var(--borders-neutral-primary);
+  border-top: variables.$default-border;
   background: var(--background-neutral-secondary);
-}
-
-.header {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  padding: 8px;
-  background: var(--background-neutral-secondary);
-  border-bottom: 1px solid var(--borders-neutral-primary);
-}
-
-.headerText {
   flex: 1;
-  text-align: center;
-  margin: 0;
+}
+
+.settingsHeader.settingsHeader {
+  background-color: var(--background-neutral-secondary);
 }
 
 .settingsList {
   display: flex;
-  padding: 8px;
+  padding: 0.625rem 0.625rem 1rem 0.625rem;
   flex-direction: column;
   align-items: flex-start;
-  gap: 12px;
+  gap: 0.75rem;
   align-self: stretch;
   width: 100%;
   box-sizing: border-box;


### PR DESCRIPTION
Updates the SettingsPanel component to use PanelContainer to match the updated mocks and the rest of the updated Resource Panel.

## Links
Jira ticket: [AFL-239](https://codedotorg.atlassian.net/browse/AFL-239)
Figma mock: [here](https://www.figma.com/design/tDzVjyvhfkF8lyGROENOAD/Web-Lab-2?node-id=3301-2486&m=dev)

## Testing story
Tested locally across browsers in all the Lab2 labs.

----

## Before


https://github.com/user-attachments/assets/5df1c410-e893-4372-879c-b81f14d741f6



## After


https://github.com/user-attachments/assets/db843659-4660-4c85-a1ce-634e9d75eb0b

