### PR TITLE
Sketch Lab: support version history

### DIFF
--- a/apps/src/lab2/redux/lab2ProjectReduxThunks.ts
+++ b/apps/src/lab2/redux/lab2ProjectReduxThunks.ts
@@ -95,7 +95,7 @@ export const loadVersion = createAsyncThunk(
     payload: {
       startSources: ProjectSources;
       version?: ProjectVersion;
-      onRestore?: (sources: ProjectSources) => void;
+      onLoadVersion?: (sources: ProjectSources) => void;
     },
     thunkAPI
   ) => {
@@ -113,7 +113,7 @@ export const loadVersion = createAsyncThunk(
           version: payload.version,
         })
       );
-      if (payload.onRestore) payload.onRestore(sources);
+      if (payload.onLoadVersion) payload.onLoadVersion(sources);
     }
   }
 );
@@ -124,7 +124,7 @@ export const previewStartSources = createAsyncThunk(
   async (
     payload: {
       startSources: ProjectSources;
-      onRestore?: (sources: ProjectSources) => void;
+      onLoadVersion?: (sources: ProjectSources) => void;
     },
     thunkAPI
   ) => {
@@ -135,7 +135,7 @@ export const previewStartSources = createAsyncThunk(
       thunkAPI.dispatch(
         setPreviousVersionSource({sources: payload.startSources})
       );
-      if (payload.onRestore) payload.onRestore(payload.startSources);
+      if (payload.onLoadVersion) payload.onLoadVersion(payload.startSources);
     }
   }
 );
@@ -144,7 +144,7 @@ export const previewStartSources = createAsyncThunk(
 export const resetToCurrentVersion = createAsyncThunk(
   'lab2Project/resetToActiveVersion',
   async (
-    payload: {onRestore?: (sources: ProjectSources) => void},
+    payload: {onLoadVersion?: (sources: ProjectSources) => void},
     thunkAPI
   ) => {
     const projectManager = Lab2Registry.getInstance().getProjectManager();
@@ -152,7 +152,7 @@ export const resetToCurrentVersion = createAsyncThunk(
       const sources = await projectManager.loadSources();
       thunkAPI.dispatch(setProjectSource(sources));
       thunkAPI.dispatch(setViewingOldVersion(false));
-      if (sources && payload.onRestore) payload.onRestore(sources);
+      if (sources && payload.onLoadVersion) payload.onLoadVersion(sources);
     }
   }
 );

--- a/apps/src/lab2/redux/lab2ProjectReduxThunks.ts
+++ b/apps/src/lab2/redux/lab2ProjectReduxThunks.ts
@@ -95,6 +95,7 @@ export const loadVersion = createAsyncThunk(
     payload: {
       startSources: ProjectSources;
       version?: ProjectVersion;
+      onRestore?: (sources: ProjectSources) => void;
     },
     thunkAPI
   ) => {
@@ -112,6 +113,7 @@ export const loadVersion = createAsyncThunk(
           version: payload.version,
         })
       );
+      if (payload.onRestore) payload.onRestore(sources);
     }
   }
 );
@@ -134,12 +136,13 @@ export const previewStartSources = createAsyncThunk(
 // Reset the project to the current version, loading the sources from the project manager.
 export const resetToCurrentVersion = createAsyncThunk(
   'lab2Project/resetToActiveVersion',
-  async (_, thunkAPI) => {
+  async (payload: {onRestore: (sources: ProjectSources) => void}, thunkAPI) => {
     const projectManager = Lab2Registry.getInstance().getProjectManager();
     if (projectManager) {
       const sources = await projectManager.loadSources();
       thunkAPI.dispatch(setProjectSource(sources));
       thunkAPI.dispatch(setViewingOldVersion(false));
+      if (sources) payload.onRestore(sources);
     }
   }
 );

--- a/apps/src/lab2/redux/lab2ProjectReduxThunks.ts
+++ b/apps/src/lab2/redux/lab2ProjectReduxThunks.ts
@@ -121,7 +121,13 @@ export const loadVersion = createAsyncThunk(
 // Load the start sources for the project and set them as the previous version source.
 export const previewStartSources = createAsyncThunk(
   'lab2Project/previewStartSources',
-  async (payload: {startSources: ProjectSources}, thunkAPI) => {
+  async (
+    payload: {
+      startSources: ProjectSources;
+      onRestore?: (sources: ProjectSources) => void;
+    },
+    thunkAPI
+  ) => {
     const projectManager = Lab2Registry.getInstance().getProjectManager();
     if (projectManager) {
       // We need to ensure we save the existing project before loading the start source.
@@ -129,6 +135,7 @@ export const previewStartSources = createAsyncThunk(
       thunkAPI.dispatch(
         setPreviousVersionSource({sources: payload.startSources})
       );
+      if (payload.onRestore) payload.onRestore(payload.startSources);
     }
   }
 );
@@ -136,13 +143,16 @@ export const previewStartSources = createAsyncThunk(
 // Reset the project to the current version, loading the sources from the project manager.
 export const resetToCurrentVersion = createAsyncThunk(
   'lab2Project/resetToActiveVersion',
-  async (payload: {onRestore: (sources: ProjectSources) => void}, thunkAPI) => {
+  async (
+    payload: {onRestore?: (sources: ProjectSources) => void},
+    thunkAPI
+  ) => {
     const projectManager = Lab2Registry.getInstance().getProjectManager();
     if (projectManager) {
       const sources = await projectManager.loadSources();
       thunkAPI.dispatch(setProjectSource(sources));
       thunkAPI.dispatch(setViewingOldVersion(false));
-      if (sources) payload.onRestore(sources);
+      if (sources && payload.onRestore) payload.onRestore(sources);
     }
   }
 );

--- a/apps/src/lab2/views/SourcesContainer.tsx
+++ b/apps/src/lab2/views/SourcesContainer.tsx
@@ -14,6 +14,7 @@ import {toolboxToWorkspaceBlocks} from '@cdo/apps/blockly/utils/toolbox';
 import {START_SOURCES, TOOLBOX_BLOCKS} from '@cdo/apps/lab2/constants';
 import Lab2Registry from '@cdo/apps/lab2/Lab2Registry';
 import {getAppOptionsEditBlocks} from '@cdo/apps/lab2/projects/utils';
+import {isReadOnlyWorkspace} from '@cdo/apps/lab2/redux/lab2ReduxSelectors';
 import {
   BlocklyLevelProperties,
   LabProps,
@@ -22,6 +23,7 @@ import {
 import StartOverDialog, {
   MessageType,
 } from '@cdo/apps/lab2/views/dialogs/dsco/StartOverDialog';
+import {useAppSelector} from '@cdo/apps/util/reduxHooks';
 
 import ProjectManager from '../projects/ProjectManager';
 import getInitialSources from '../utils/getInitialSources';
@@ -74,6 +76,10 @@ const SourcesContainer: React.FC<SourcesContainerProps> = ({
     () => getInitialSources(levelProperties, initialSources) || defaultSources
   );
 
+  const readonlyWorkspace = useAppSelector(isReadOnlyWorkspace);
+  const readonlyWorkspaceRef = useRef(readonlyWorkspace);
+  readonlyWorkspaceRef.current = readonlyWorkspace;
+
   const [startOverProps, setStartOverProps] = useState<{
     type: MessageType;
     message?: string;
@@ -87,7 +93,7 @@ const SourcesContainer: React.FC<SourcesContainerProps> = ({
   const reinitializeSources = useCallback(
     (sources: ProjectSources, save: boolean = false) => {
       setCurrentSources(sources);
-      if (save) {
+      if (save && !readonlyWorkspaceRef.current) {
         (
           projectManager || Lab2Registry.getInstance().getProjectManager()
         )?.save(sources, true);
@@ -130,10 +136,12 @@ const SourcesContainer: React.FC<SourcesContainerProps> = ({
         }
         return newSources;
       });
-      (projectManager || Lab2Registry.getInstance().getProjectManager())?.save(
-        newSources,
-        forceSave
-      );
+
+      if (!readonlyWorkspaceRef.current) {
+        (
+          projectManager || Lab2Registry.getInstance().getProjectManager()
+        )?.save(newSources, forceSave);
+      }
     },
     [setCurrentSources, projectManager]
   );

--- a/apps/src/lab2/views/SourcesContainer.tsx
+++ b/apps/src/lab2/views/SourcesContainer.tsx
@@ -76,6 +76,9 @@ const SourcesContainer: React.FC<SourcesContainerProps> = ({
     () => getInitialSources(levelProperties, initialSources) || defaultSources
   );
 
+  // When we use this value to decide whether to save sources or not,
+  // we want to make sure that we have the most up-to-date version of the readonly state of the workspace.
+  // In order to achieve this, we re-fetch the current value and save it to a ref on each render.
   const readonlyWorkspace = useAppSelector(isReadOnlyWorkspace);
   const readonlyWorkspaceRef = useRef(readonlyWorkspace);
   readonlyWorkspaceRef.current = readonlyWorkspace;

--- a/apps/src/lab2/views/components/Instructions/ResourcePanel/VersionHistory/VersionHistoryPanel.tsx
+++ b/apps/src/lab2/views/components/Instructions/ResourcePanel/VersionHistory/VersionHistoryPanel.tsx
@@ -270,9 +270,9 @@ const VersionHistoryPanel: React.FunctionComponent<
         /* forceNewVersion */ true
       )
     );
-    // fix here
+    if (onRestore) onRestore(startSources);
     successfulProjectResetCleanUp();
-  }, [dispatch, startSources, successfulProjectResetCleanUp]);
+  }, [dispatch, startSources, successfulProjectResetCleanUp, onRestore]);
 
   const confirmStartOver = useCallback(() => {
     dialogControl?.showDialog({
@@ -360,14 +360,23 @@ const VersionHistoryPanel: React.FunctionComponent<
         });
       }
       if (viewingInitialVersion) {
+        // Should onRestore be passed as an arg?
         dispatch(previewStartSources({startSources}));
+        if (onRestore) onRestore(startSources);
       } else if (isLatest) {
-        dispatch(resetToCurrentVersion());
+        if (onRestore) dispatch(resetToCurrentVersion({onRestore}));
       } else {
-        dispatch(loadVersion({startSources, version}));
+        dispatch(loadVersion({startSources, version, onRestore}));
       }
     },
-    [dispatch, isLatestVersion, setSelectedVersion, startSources, versionList]
+    [
+      dispatch,
+      isLatestVersion,
+      setSelectedVersion,
+      startSources,
+      versionList,
+      onRestore,
+    ]
   );
 
   const handleSaveVersionSuccess = useCallback(() => {

--- a/apps/src/lab2/views/components/Instructions/ResourcePanel/VersionHistory/VersionHistoryPanel.tsx
+++ b/apps/src/lab2/views/components/Instructions/ResourcePanel/VersionHistory/VersionHistoryPanel.tsx
@@ -383,7 +383,6 @@ const VersionHistoryPanel: React.FunctionComponent<
     });
     dispatch(setHasEdited(false));
     successfulProjectResetCleanUp(true);
-    // Needs to go in here?
     setVersionSaved(true);
   }, [dispatch, selectedVersion, successfulProjectResetCleanUp]);
 

--- a/apps/src/lab2/views/components/Instructions/ResourcePanel/VersionHistory/VersionHistoryPanel.tsx
+++ b/apps/src/lab2/views/components/Instructions/ResourcePanel/VersionHistory/VersionHistoryPanel.tsx
@@ -42,7 +42,7 @@ interface VersionHistoryPanelProps {
   disabled?: boolean;
   isOpen?: boolean;
   alwaysShowAutoSaves?: boolean;
-  onRestore?: (sources: ProjectSources) => void;
+  onLoadVersion?: (sources: ProjectSources) => void;
 }
 
 // Define version segments to support collapsing auto-save groups
@@ -70,7 +70,7 @@ const VersionHistoryPanel: React.FunctionComponent<
   disabled = false,
   isOpen = false,
   alwaysShowAutoSaves = false,
-  onRestore,
+  onLoadVersion,
 }) => {
   const [versionList, setVersionList] = useState<ProjectVersion[]>([]);
   // Track collapsed state for each group of auto-saves by group index
@@ -270,9 +270,9 @@ const VersionHistoryPanel: React.FunctionComponent<
         /* forceNewVersion */ true
       )
     );
-    if (onRestore) onRestore(startSources);
+    if (onLoadVersion) onLoadVersion(startSources);
     successfulProjectResetCleanUp();
-  }, [dispatch, startSources, successfulProjectResetCleanUp, onRestore]);
+  }, [dispatch, startSources, successfulProjectResetCleanUp, onLoadVersion]);
 
   const confirmStartOver = useCallback(() => {
     dialogControl?.showDialog({
@@ -299,7 +299,7 @@ const VersionHistoryPanel: React.FunctionComponent<
         .then(sources => {
           if (sources) {
             dispatch(setProjectSource(sources));
-            if (onRestore) onRestore(sources);
+            if (onLoadVersion) onLoadVersion(sources);
             successfulProjectResetCleanUp();
           } else {
             setVersionLoadError(true);
@@ -316,7 +316,7 @@ const VersionHistoryPanel: React.FunctionComponent<
     confirmStartOver,
     dispatch,
     successfulProjectResetCleanUp,
-    onRestore,
+    onLoadVersion,
   ]);
 
   const isLatestVersion = useCallback(
@@ -360,11 +360,11 @@ const VersionHistoryPanel: React.FunctionComponent<
         });
       }
       if (viewingInitialVersion) {
-        dispatch(previewStartSources({startSources, onRestore}));
+        dispatch(previewStartSources({startSources, onLoadVersion}));
       } else if (isLatest) {
-        dispatch(resetToCurrentVersion({onRestore}));
+        dispatch(resetToCurrentVersion({onLoadVersion}));
       } else {
-        dispatch(loadVersion({startSources, version, onRestore}));
+        dispatch(loadVersion({startSources, version, onLoadVersion}));
       }
     },
     [
@@ -373,7 +373,7 @@ const VersionHistoryPanel: React.FunctionComponent<
       setSelectedVersion,
       startSources,
       versionList,
-      onRestore,
+      onLoadVersion,
     ]
   );
 

--- a/apps/src/lab2/views/components/Instructions/ResourcePanel/VersionHistory/VersionHistoryPanel.tsx
+++ b/apps/src/lab2/views/components/Instructions/ResourcePanel/VersionHistory/VersionHistoryPanel.tsx
@@ -42,6 +42,7 @@ interface VersionHistoryPanelProps {
   disabled?: boolean;
   isOpen?: boolean;
   alwaysShowAutoSaves?: boolean;
+  onRestore?: (sources: ProjectSources) => void;
 }
 
 // Define version segments to support collapsing auto-save groups
@@ -69,6 +70,7 @@ const VersionHistoryPanel: React.FunctionComponent<
   disabled = false,
   isOpen = false,
   alwaysShowAutoSaves = false,
+  onRestore,
 }) => {
   const [versionList, setVersionList] = useState<ProjectVersion[]>([]);
   // Track collapsed state for each group of auto-saves by group index
@@ -268,6 +270,7 @@ const VersionHistoryPanel: React.FunctionComponent<
         /* forceNewVersion */ true
       )
     );
+    // fix here
     successfulProjectResetCleanUp();
   }, [dispatch, startSources, successfulProjectResetCleanUp]);
 
@@ -296,6 +299,7 @@ const VersionHistoryPanel: React.FunctionComponent<
         .then(sources => {
           if (sources) {
             dispatch(setProjectSource(sources));
+            if (onRestore) onRestore(sources);
             successfulProjectResetCleanUp();
           } else {
             setVersionLoadError(true);
@@ -312,6 +316,7 @@ const VersionHistoryPanel: React.FunctionComponent<
     confirmStartOver,
     dispatch,
     successfulProjectResetCleanUp,
+    onRestore,
   ]);
 
   const isLatestVersion = useCallback(
@@ -371,6 +376,7 @@ const VersionHistoryPanel: React.FunctionComponent<
     });
     dispatch(setHasEdited(false));
     successfulProjectResetCleanUp(true);
+    // Needs to go in here?
     setVersionSaved(true);
   }, [dispatch, selectedVersion, successfulProjectResetCleanUp]);
 

--- a/apps/src/lab2/views/components/Instructions/ResourcePanel/VersionHistory/VersionHistoryPanel.tsx
+++ b/apps/src/lab2/views/components/Instructions/ResourcePanel/VersionHistory/VersionHistoryPanel.tsx
@@ -360,11 +360,9 @@ const VersionHistoryPanel: React.FunctionComponent<
         });
       }
       if (viewingInitialVersion) {
-        // Should onRestore be passed as an arg?
-        dispatch(previewStartSources({startSources}));
-        if (onRestore) onRestore(startSources);
+        dispatch(previewStartSources({startSources, onRestore}));
       } else if (isLatest) {
-        if (onRestore) dispatch(resetToCurrentVersion({onRestore}));
+        dispatch(resetToCurrentVersion({onRestore}));
       } else {
         dispatch(loadVersion({startSources, version, onRestore}));
       }

--- a/apps/src/lab2/views/components/Instructions/ResourcePanel/index.tsx
+++ b/apps/src/lab2/views/components/Instructions/ResourcePanel/index.tsx
@@ -63,6 +63,7 @@ export interface Setting {
 interface VersionHistoryProps {
   startSources: ProjectSources;
   alwaysShowAutoSaves?: boolean;
+  onRestore?: (sources: ProjectSources) => void;
 }
 
 const tabInfo: {[key in Tabs]: {title: string; icon: string}} = {
@@ -229,6 +230,7 @@ const ResourcePanel: React.FC<ResourcePanelProps> = ({
           disabled={isTemporarilyReadOnly && !isViewingOldVersion}
           isOpen={currentTab === Tabs.VersionHistory}
           alwaysShowAutoSaves={versionHistoryProps.alwaysShowAutoSaves}
+          onRestore={versionHistoryProps.onRestore}
         />
       );
     }

--- a/apps/src/lab2/views/components/Instructions/ResourcePanel/index.tsx
+++ b/apps/src/lab2/views/components/Instructions/ResourcePanel/index.tsx
@@ -63,7 +63,7 @@ export interface Setting {
 interface VersionHistoryProps {
   startSources: ProjectSources;
   alwaysShowAutoSaves?: boolean;
-  onRestore?: (sources: ProjectSources) => void;
+  onLoadVersion?: (sources: ProjectSources) => void;
 }
 
 const tabInfo: {[key in Tabs]: {title: string; icon: string}} = {
@@ -230,7 +230,7 @@ const ResourcePanel: React.FC<ResourcePanelProps> = ({
           disabled={isTemporarilyReadOnly && !isViewingOldVersion}
           isOpen={currentTab === Tabs.VersionHistory}
           alwaysShowAutoSaves={versionHistoryProps.alwaysShowAutoSaves}
-          onRestore={versionHistoryProps.onRestore}
+          onLoadVersion={versionHistoryProps.onLoadVersion}
         />
       );
     }

--- a/apps/src/sketchlab/SketchlabView.tsx
+++ b/apps/src/sketchlab/SketchlabView.tsx
@@ -19,7 +19,7 @@ import useThemeSetting from '@cdo/apps/lab2/hooks/useThemeSetting';
 import {useVerticalLayout} from '@cdo/apps/lab2/hooks/useVerticalLayout';
 import {isReadOnlyWorkspace} from '@cdo/apps/lab2/redux/lab2ReduxSelectors';
 import {setHasRun} from '@cdo/apps/lab2/redux/systemRedux';
-import {LabProps, LevelProperties} from '@cdo/apps/lab2/types';
+import {LabProps, LevelProperties, ProjectSources} from '@cdo/apps/lab2/types';
 import ResourcePanel from '@cdo/apps/lab2/views/components/Instructions/ResourcePanel';
 import ResizeBar from '@cdo/apps/lab2/views/components/layout/ResizeBar';
 import PanelContainer from '@cdo/apps/lab2/views/components/PanelContainer';
@@ -183,14 +183,25 @@ const SketchlabView: React.FC<LabProps<LevelProperties>> = ({
     };
   }, []);
 
-  useEffect(() => {
-    setReinitializationHandler(() => {
+  // Does this need dependency array?
+  const reinitializationHandler = useCallback(
+    (sources?: ProjectSources) => {
+      console.log('Reinitializing Excalidraw workspace');
+
+      if (sources) {
+        updateSources(sources as SketchlabSources); // remove forced type? move this so other uses of handler don't need arg?
+      }
       setExcalidrawMountKey(key => key + 1);
 
       // Reset loaded images on remount so we don't end up with a large number of images stored across pages.
       downloadedFilesDataRef.current = {};
-    });
-  }, [setReinitializationHandler]);
+    },
+    [updateSources]
+  );
+
+  useEffect(() => {
+    setReinitializationHandler(reinitializationHandler);
+  }, [setReinitializationHandler, reinitializationHandler]);
 
   // Since there's no run button in Sketch Lab, set it to true by default
   // to enable the Submit button on edit on submittable levels.
@@ -204,6 +215,7 @@ const SketchlabView: React.FC<LabProps<LevelProperties>> = ({
     };
   }, [dispatch]);
 
+  console.log(currentSources.source);
   return (
     <div className={moduleStyles.sketchlabContainer}>
       <SketchlabTourSteps />
@@ -214,6 +226,10 @@ const SketchlabView: React.FC<LabProps<LevelProperties>> = ({
           hasRun={hasRun}
           hasEdited={false}
           settings={[useThemeSetting('sketchlab')]}
+          versionHistoryProps={{
+            startSources: levelProperties?.startSources as ProjectSources, // Fix this
+            onRestore: reinitializationHandler,
+          }}
         />
       </div>
       <ResizeBar

--- a/apps/src/sketchlab/SketchlabView.tsx
+++ b/apps/src/sketchlab/SketchlabView.tsx
@@ -197,7 +197,7 @@ const SketchlabView: React.FC<LabProps<LevelProperties>> = ({
     setExcalidrawMountKey(key => key + 1);
   }, []);
 
-  const onRestoreVersion = useCallback(
+  const onLoadVersion = useCallback(
     (sources: ProjectSources) => {
       if (sources) {
         updateSources(sources as SketchlabSources);
@@ -239,7 +239,7 @@ const SketchlabView: React.FC<LabProps<LevelProperties>> = ({
           settings={[useThemeSetting('sketchlab')]}
           versionHistoryProps={{
             startSources: levelProperties?.startSources as ProjectSources,
-            onRestore: onRestoreVersion,
+            onLoadVersion: onLoadVersion,
           }}
         />
       </div>

--- a/apps/src/sketchlab/SketchlabView.tsx
+++ b/apps/src/sketchlab/SketchlabView.tsx
@@ -192,20 +192,21 @@ const SketchlabView: React.FC<LabProps<LevelProperties>> = ({
     };
   }, []);
 
-  // Does this need dependency array?
-  const reinitializationHandler = useCallback(
-    (sources?: ProjectSources) => {
-      console.log('Reinitializing Excalidraw workspace');
+  const reinitializationHandler = useCallback(() => {
+    setExcalidrawMountKey(key => key + 1);
 
+    // Reset loaded images on remount so we don't end up with a large number of images stored across pages.
+    downloadedFilesDataRef.current = {};
+  }, []);
+
+  const onRestoreVersion = useCallback(
+    (sources: ProjectSources) => {
       if (sources) {
         updateSources(sources as SketchlabSources); // remove forced type? move this so other uses of handler don't need arg?
       }
-      setExcalidrawMountKey(key => key + 1);
-
-      // Reset loaded images on remount so we don't end up with a large number of images stored across pages.
-      downloadedFilesDataRef.current = {};
+      reinitializationHandler();
     },
-    [updateSources]
+    [updateSources, reinitializationHandler]
   );
 
   useEffect(() => {
@@ -224,7 +225,6 @@ const SketchlabView: React.FC<LabProps<LevelProperties>> = ({
     };
   }, [dispatch]);
 
-  console.log(currentSources.source);
   return (
     <div className={moduleStyles.sketchlabContainer}>
       <SketchlabTourSteps />
@@ -236,8 +236,8 @@ const SketchlabView: React.FC<LabProps<LevelProperties>> = ({
           hasEdited={false}
           settings={[useThemeSetting('sketchlab')]}
           versionHistoryProps={{
-            startSources: levelProperties?.startSources as ProjectSources, // Fix this
-            onRestore: reinitializationHandler,
+            startSources: levelProperties?.startSources as ProjectSources,
+            onRestore: onRestoreVersion,
           }}
         />
       </div>

--- a/apps/src/sketchlab/SketchlabView.tsx
+++ b/apps/src/sketchlab/SketchlabView.tsx
@@ -203,7 +203,7 @@ const SketchlabView: React.FC<LabProps<LevelProperties>> = ({
   const onRestoreVersion = useCallback(
     (sources: ProjectSources) => {
       if (sources) {
-        updateSources(sources as SketchlabSources); // remove forced type? move this so other uses of handler don't need arg?
+        updateSources(sources as SketchlabSources);
       }
       reinitializationHandler();
     },

--- a/apps/src/sketchlab/SketchlabView.tsx
+++ b/apps/src/sketchlab/SketchlabView.tsx
@@ -195,9 +195,6 @@ const SketchlabView: React.FC<LabProps<LevelProperties>> = ({
 
   const reinitializationHandler = useCallback(() => {
     setExcalidrawMountKey(key => key + 1);
-
-    // Reset loaded images on remount so we don't end up with a large number of images stored across pages.
-    downloadedFilesDataRef.current = {};
   }, []);
 
   const onRestoreVersion = useCallback(

--- a/apps/src/sketchlab/SketchlabView.tsx
+++ b/apps/src/sketchlab/SketchlabView.tsx
@@ -153,26 +153,35 @@ const SketchlabView: React.FC<LabProps<LevelProperties>> = ({
           serializedData.appState.zoom = appState.zoom;
         }
 
-        const uploadedFiles = await uploadExternalFiles(
-          currentSources.source.externalFiles || {},
-          serializedData.files,
-          filesBeingUploadedRef,
-          channelId,
-          levelProperties.name
-        );
+        let uploadedFiles = {};
+        if (!readonlyWorkspace) {
+          uploadedFiles = await uploadExternalFiles(
+            currentSources.source.externalFiles || {},
+            serializedData.files,
+            filesBeingUploadedRef,
+            channelId,
+            levelProperties.name
+          );
+        }
 
         updateSources({
           source: {
             ...serializedData,
             externalFiles: {
               ...currentSources.source.externalFiles,
-              ...(uploadedFiles || {}),
+              ...uploadedFiles,
             },
           },
         });
       }, DEBOUNCED_WORKSPACE_SERIALIZATION_MS);
     },
-    [updateSources, channelId, currentSources.source, levelProperties.name]
+    [
+      updateSources,
+      channelId,
+      currentSources.source,
+      levelProperties.name,
+      readonlyWorkspace,
+    ]
   );
 
   useEffect(() => {


### PR DESCRIPTION
Adds version history to Sketch Lab. The approach here was to pass our handler that updates sources in `SourcesContainer` to the version history component as a prop. Ideally, we'd like to unify these approaches to managing sources at some point in the future. More discussion in [this Slack thread](https://codedotorg.slack.com/archives/C06JELCAPT9/p1765409667333159).

<img width="1072" height="904" alt="image" src="https://github.com/user-attachments/assets/a8dafeba-d099-4c1e-bfd8-892a2d998d86" />

## Links

- Jira: https://codedotorg.atlassian.net/browse/AFL-231

## Testing story

Tested manually that I could view/restore intermediate versions, the initial version (with "start over" warning modal), and go back to the current version. Also tested that viewing a version made the canvas readonly and that changes were not saved if the page was reloaded after viewing (but not restoring) an old version.

## Follow-up work

There's a UI to created named versions with a description, which relies on setting a bit of Redux state (`hasEdited`) that Sketch Lab doesn't support yet. To simplify things, I'll do that as a follow-up.