### PR TITLE
force seed step to run in drone cache-staging-build pipeline

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -289,7 +289,7 @@ steps:
       # DRONE_REPO_OWNER = organization name (e.g., "code-dot-org")
       # DRONE_REPO_NAME = repository name (e.g., "code-dot-org")
       - AUTHENTICATED_GITHUB_URL="https://$GITHUB_TOKEN@github.com/$DRONE_REPO_OWNER/$DRONE_REPO_NAME.git"
-      - git clone --branch $DRONE_BRANCH $AUTHENTICATED_GITHUB_URL .
+      - git clone --branch $DRONE_SOURCE_BRANCH $AUTHENTICATED_GITHUB_URL .
 
   # Do all the work necessary to run UI tests so we can capture a complete
   # snapshot of the fully-built project and resulting database, but don't
@@ -320,7 +320,7 @@ steps:
       - name: mysql
         path: /var/lib/mysql
     settings:
-      filename: cache-staging-ci-build.tar.gz
+      filename: cache-staging-ci-build-PR-69989.tar.gz
       endpoint: s3://cdo-drone
       rebuild: true
       debug: true
@@ -339,9 +339,10 @@ trigger:
     - "staging-next"
   event:
     - push
+    - pull_request
 
 ---
 kind: signature
-hmac: 8380ec279dc40128beca1b341a9fff3212255c2a343d9fed59c9c839ab095669
+hmac: d0bb42c2fbfbbc430f2fb56fc45aa999ad35d253a4878396254e036380096069
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -289,7 +289,7 @@ steps:
       # DRONE_REPO_OWNER = organization name (e.g., "code-dot-org")
       # DRONE_REPO_NAME = repository name (e.g., "code-dot-org")
       - AUTHENTICATED_GITHUB_URL="https://$GITHUB_TOKEN@github.com/$DRONE_REPO_OWNER/$DRONE_REPO_NAME.git"
-      - git clone --branch $DRONE_SOURCE_BRANCH $AUTHENTICATED_GITHUB_URL .
+      - git clone --branch $DRONE_BRANCH $AUTHENTICATED_GITHUB_URL .
 
   # Do all the work necessary to run UI tests so we can capture a complete
   # snapshot of the fully-built project and resulting database, but don't
@@ -320,7 +320,7 @@ steps:
       - name: mysql
         path: /var/lib/mysql
     settings:
-      filename: cache-staging-ci-build-PR-69989.tar.gz
+      filename: cache-staging-ci-build.tar.gz
       endpoint: s3://cdo-drone
       rebuild: true
       debug: true
@@ -339,10 +339,9 @@ trigger:
     - "staging-next"
   event:
     - push
-    - pull_request
 
 ---
 kind: signature
-hmac: d0bb42c2fbfbbc430f2fb56fc45aa999ad35d253a4878396254e036380096069
+hmac: 8380ec279dc40128beca1b341a9fff3212255c2a343d9fed59c9c839ab095669
 
 ...

--- a/docker/ci/scripts/prepare_cacheable_build.sh
+++ b/docker/ci/scripts/prepare_cacheable_build.sh
@@ -4,5 +4,5 @@ source docker/ci/scripts/prepare_ci_env.sh
 
 bundle exec rake install
 bundle exec rake build
-bundle exec rake ci:seed_ui_test
+bundle exec rake ci:force_seed_ui_test
 

--- a/lib/rake/ci.rake
+++ b/lib/rake/ci.rake
@@ -186,6 +186,12 @@ namespace :ci do
     end
   end
 
+  timed_task_with_logging :force_seed_ui_test do
+    Dir.chdir('dashboard') do
+      RakeUtils.rake_stream_output 'seed:ui_test'
+    end
+  end
+
   timed_task_with_logging :sparse_checkout do
     if CI::Utils.tagged?(SKIP_PEGASUS_CONTENT)
       cmd = 'bin/sparse-checkout no-pegasus-content'


### PR DESCRIPTION
We currently have an optimization in drone where, after each push to staging, we run the `cache-staging-build` pipeline which does a full build and seed, then we store the result to s3. then, on drone runs against PRs, we start by pulling down that cached build, avoiding ~30 minutes of seeding and other build steps.

I recently discovered a bug in the `cache-staging-build` logic makes it so that a PR containing `[skip ui]` in any commit message can cause the cache step to skip seeding. This causes all subsequent drone builds against PRs to take an extra 25 minutes, until another push to staging happens in a PR without a `[skip ui]` tag in the commit message. 

For example: 
* https://github.com/code-dot-org/code-dot-org/pull/69900 included a commit message containing `[skip ui]`
* when the PR was squash-merged, the commit message for the merge commit also contained `[skip ui]`
* this caused the `prepare-cacheable-build` step in the `cache-staging-build` pipeline to skip seeding ui tests: https://drone.cdn-code.org/code-dot-org/code-dot-org/45962/1/2
* the build cache was then updated with db contents did not contain seeded data
* subsequent drone runs then took approximately 55 minutes (rather than 30 minutes) to complete: https://drone.cdn-code.org/code-dot-org/code-dot-org/45969/2/5
  * `Finished ci:seed_ui_test (26 minutes)`

The solution is to make sure that `prepare_cacheable_build.sh` seeds ui test scripts regardless of commit message contents.

## Testing story

- verified that cache-staging-build step now seeds ui test scripts even when `[skip ui]` tag is present in the commit message. see `cache-staging-build` --> `prepare-cacheable-build` output in intermediate drone runs for details.
