### PR TITLE
Clean up references to Courses 1-4 and 20-hour/Accelerated

### DIFF
--- a/apps/src/templates/certificates/congratsNextLevelActivityCards.js
+++ b/apps/src/templates/certificates/congratsNextLevelActivityCards.js
@@ -1,26 +1,5 @@
 import i18n from '@cdo/locale';
 
-const Course2 = {
-  scriptName: 'course2',
-  link: '/s/course2',
-  image: 'course2',
-  buttonText: i18n.viewCourse(),
-};
-
-const Course3 = {
-  scriptName: 'course3',
-  link: '/s/course3',
-  image: 'course3',
-  buttonText: i18n.viewCourse(),
-};
-
-const Course4 = {
-  scriptName: 'course4',
-  link: '/s/course4',
-  image: 'course4',
-  buttonText: i18n.viewCourse(),
-};
-
 const Applab = {
   scriptName: 'applab-intro',
   link: '/s/applab-intro/reset',
@@ -64,9 +43,6 @@ const CourseF = {
 };
 
 export const nextLevelCourseCards = [
-  Course2,
-  Course3,
-  Course4,
   Applab,
   CourseB,
   CourseC,

--- a/apps/src/templates/studioHomepages/CourseBlocks.jsx
+++ b/apps/src/templates/studioHomepages/CourseBlocks.jsx
@@ -4,7 +4,6 @@ import React, {Component} from 'react';
 import ReactDOM from 'react-dom';
 
 import {pegasus} from '@cdo/apps/lib/util/urlHelpers';
-import {NotificationResponsive} from '@cdo/apps/sharedComponents/Notification';
 import {
   InternationalGradeBandCards,
   ToolsCards,
@@ -71,66 +70,6 @@ class CoursesAToF extends Component {
             tiles={['#coursec', '#coursed', '#coursee', '#coursef']}
           />
         </ContentContainer>
-      </div>
-    );
-  }
-}
-
-const LegacyCSFNotification = () => (
-  <NotificationResponsive
-    type="bullhorn_yellow"
-    notice={i18n.courseBlocksLegacyNotificationSupportEndedHeading()}
-    details={i18n.courseBlocksLegacyNotificationSupportEndedBody()}
-    detailsLinkText={i18n.courseBlocksLegacyNotificationDetailsLinkText()}
-    detailsLink={pegasus('/educate/curriculum/csf-transition-guide')}
-    detailsLinkNewWindow={true}
-    dismissible={false}
-    buttons={[
-      {
-        text: i18n.courseBlocksLegacyNotificationButtonCourses14(),
-        link: pegasus('/educate/curriculum/elementary-school'),
-        newWindow: true,
-      },
-      {
-        text: i18n.courseBlocksLegacyNotificationButtonCoursesAccelerated(),
-        link: '/s/20-hour',
-        newWindow: true,
-      },
-    ]}
-  />
-);
-
-class Courses1To4 extends Component {
-  render() {
-    return (
-      <ContentContainer
-        heading={i18n.csf()}
-        description={i18n.csfDescription()}
-        link={'/home/#recent-courses'}
-        linkText={i18n.viewMyRecentCourses()}
-      >
-        <CourseBlocks
-          tiles={['#course1', '#course2', '#course3', '#course4']}
-        />
-      </ContentContainer>
-    );
-  }
-}
-
-class AcceleratedAndUnplugged extends Component {
-  componentDidMount() {
-    $('#20-hour').appendTo(ReactDOM.findDOMNode(this.refs.twenty_hour)).show();
-    $('#unplugged').appendTo(ReactDOM.findDOMNode(this.refs.unplugged)).show();
-  }
-
-  render() {
-    return (
-      <div className="tutorial-row">
-        <ProtectedStatefulDiv
-          className="tutorial-block-wide"
-          ref="twenty_hour"
-        />
-        <ProtectedStatefulDiv className="tutorial-block-wide" ref="unplugged" />
       </div>
     );
   }
@@ -213,7 +152,6 @@ export class CourseBlocksHoc extends Component {
 export class CourseBlocksIntl extends Component {
   static propTypes = {
     isTeacher: PropTypes.bool,
-    showModernElementaryCourses: PropTypes.bool.isRequired,
     specialAnnouncement: shapes.specialAnnouncement,
   };
 
@@ -224,16 +162,10 @@ export class CourseBlocksIntl extends Component {
   }
 
   render() {
-    const {showModernElementaryCourses: modernCsf, specialAnnouncement} =
-      this.props;
-    const AcceleratedCourses = () => (
-      <ContentContainer>
-        <AcceleratedAndUnplugged />
-      </ContentContainer>
-    );
+    const {specialAnnouncement} = this.props;
     return (
       <div>
-        {modernCsf ? <ModernCsfCourses /> : <AcceleratedCourses />}
+        <ModernCsfCourses />
 
         <CourseBlocksHoc isInternational />
 
@@ -244,9 +176,7 @@ export class CourseBlocksIntl extends Component {
           />
         )}
 
-        {modernCsf ? <CoursesAToF /> : <Courses1To4 />}
-
-        {modernCsf && <LegacyCSFNotification />}
+        <CoursesAToF />
 
         <CourseBlocksWrapper
           heading={i18n.courseBlocksInternationalGradeBandsContainerHeading()}

--- a/apps/test/unit/templates/certificates/GraduateToNextLevelTest.js
+++ b/apps/test/unit/templates/certificates/GraduateToNextLevelTest.js
@@ -26,9 +26,6 @@ describe('GraduateToNextLevel', () => {
     });
   });
   [
-    'course2',
-    'course3',
-    'course4',
     'courseb-2017',
     'coursec-2050',
     'coursed-2011',

--- a/dashboard/app/controllers/api_controller.rb
+++ b/dashboard/app/controllers/api_controller.rb
@@ -764,7 +764,7 @@ class ApiController < ApplicationController
     script_id = params[:script_id] if params[:script_id].present?
     script_id ||= section.default_script.try(:id)
     script = Unit.get_from_cache(script_id) if script_id
-    script ||= Unit.twenty_hour_unit
+    script ||= Unit.hoc_2014_unit
     script
   end
 end

--- a/dashboard/app/helpers/course_block_helper.rb
+++ b/dashboard/app/helpers/course_block_helper.rb
@@ -58,26 +58,6 @@ module CourseBlockHelper
         body: data_t_suffix('script.name', id, 'description_short'),
         teacher_guide: CDO.code_org_url("/hourofcode/artist")
       },
-      Unit::COURSE1_NAME => {
-        title: data_t_suffix('script.name', id, 'title'),
-        body: data_t_suffix('script.name', id, 'description_short'),
-        audience: data_t_suffix('script.name', id, 'description_audience')
-      },
-      Unit::COURSE2_NAME => {
-        title: data_t_suffix('script.name', id, 'title'),
-        body: data_t_suffix('script.name', id, 'description_short'),
-        audience: data_t_suffix('script.name', id, 'description_audience')
-      },
-      Unit::COURSE3_NAME => {
-        title: data_t_suffix('script.name', id, 'title'),
-        body: data_t_suffix('script.name', id, 'description_short'),
-        audience: data_t_suffix('script.name', id, 'description_audience')
-      },
-      Unit::COURSE4_NAME => {
-        title: data_t_suffix('script.name', id, 'title'),
-        body: data_t_suffix('script.name', id, 'description_short'),
-        audience: data_t_suffix('script.name', id, 'description_audience')
-      },
       Unit::COURSEA_NAME => {
         title: data_t_suffix('script.name', id, 'title'),
         body: data_t_suffix('script.name', id, 'description_short'),
@@ -172,10 +152,6 @@ module CourseBlockHelper
       Unit::TEXT_COMPRESSION_NAME => {
         url: script_reset_url(id),
         teacher_guide: "https://curriculum.code.org/hoc/2016/1/"
-      },
-      Unit::TWENTY_HOUR_NAME => {
-        title: I18n.t('upsell.20hour.title'),
-        body: I18n.t('upsell.20hour.body')
       },
       Unit::OCEANS_NAME => {
         url: CDO.code_org_url('/oceans'),

--- a/dashboard/app/models/unit.rb
+++ b/dashboard/app/models/unit.rb
@@ -634,10 +634,6 @@ class Unit < ApplicationRecord
     name == 'flappy'
   end
 
-  def csf_international?
-    ScriptConstants::CATEGORIES[:csf_international].include?(name)
-  end
-
   def self.unit_names_by_curriculum_umbrella(curriculum_umbrella)
     Unit.where("properties -> '$.curriculum_umbrella' = ?", curriculum_umbrella).pluck(:name)
   end
@@ -784,7 +780,6 @@ class Unit < ApplicationRecord
 
   def has_banner?
     # Temporarily remove Course A-F banner (wrong size) - Josh L.
-    return true if csf_international?
     return false if csf?
 
     [

--- a/dashboard/app/models/unit.rb
+++ b/dashboard/app/models/unit.rb
@@ -289,20 +289,12 @@ class Unit < ApplicationRecord
     enable_blockly_keyboard_navigation
   )
 
-  def self.twenty_hour_unit
-    Unit.get_from_cache(Unit::TWENTY_HOUR_NAME)
-  end
-
   def self.hoc_2014_unit
     Unit.get_from_cache(Unit::HOC_NAME)
   end
 
   def self.starwars_unit
     Unit.get_from_cache(Unit::STARWARS_NAME)
-  end
-
-  def self.course1_unit
-    Unit.get_from_cache(Unit::COURSE1_NAME)
   end
 
   def self.flappy_unit
@@ -618,17 +610,12 @@ class Unit < ApplicationRecord
   # Legacy levels have different video and title logic in LevelsHelper.
   def legacy_curriculum?
     [
-      Unit::TWENTY_HOUR_NAME,
       Unit::HOC_2013_NAME,
       Unit::EDIT_CODE_NAME,
       Unit::TWENTY_FOURTEEN_NAME,
       Unit::FLAPPY_NAME,
       Unit::JIGSAW_NAME
     ].include? name
-  end
-
-  def twenty_hour?
-    name == '20-hour'
   end
 
   def hoc?
@@ -681,8 +668,6 @@ class Unit < ApplicationRecord
   end
 
   def k5_course?
-    return false if twenty_hour?
-
     # TODO(dmcavoy): When we update course type to differentiate between k5 and 6-12 update this method
     k5_csc_course = [
       Unit::POETRY_2021_NAME,
@@ -1211,12 +1196,7 @@ class Unit < ApplicationRecord
   end
 
   def csf_finish_url
-    if name == Unit::TWENTY_HOUR_NAME
-      # Rename from 20-hour to public facing Accelerated
-      ApplicationController.helpers.course_completion_certificate_url(course_name: Unit::ACCELERATED_NAME)
-    else
-      ApplicationController.helpers.course_completion_certificate_url(course_name: name)
-    end
+    ApplicationController.helpers.course_completion_certificate_url(course_name: name)
   end
 
   def finish_url(unit_group_unit: nil)

--- a/dashboard/app/models/user.rb
+++ b/dashboard/app/models/user.rb
@@ -1702,7 +1702,7 @@ class User < ApplicationRecord
       end
 
       script = Unit.get_from_cache(script_id)
-      script_valid = script.csf? && script.name != Unit::COURSE1_NAME
+      script_valid = script.csf?
       if (!user_level.perfect? || user_level.best_result == ActivityConstants::MANUAL_PASS_RESULT) &&
           new_result >= ActivityConstants::BEST_PASS_RESULT &&
           script_valid &&

--- a/dashboard/app/views/layouts/_header.html.haml
+++ b/dashboard/app/views/layouts/_header.html.haml
@@ -1,7 +1,7 @@
 :ruby
   require 'cdo/language_dir'
 
-  script = local_assigns[:script] || Unit.twenty_hour_unit
+  script = local_assigns[:script] || Unit.hoc_2014_unit
   script_level = local_assigns[:script_level]
   level = local_assigns[:level]
   lesson = local_assigns[:lesson]

--- a/dashboard/app/views/scripts/show.html.haml
+++ b/dashboard/app/views/scripts/show.html.haml
@@ -37,11 +37,6 @@
     %br/
     %br/
     - if @current_user.try(:teacher?)
-      - if @script.csf_international?
-        %a{href: CDO.code_org_url('/curriculum/docs/k-5/overview')}
-          = t('home.all_courses')
-        %br/
-        %br/
 
   - if current_user.try(:levelbuilder?)
     -# Show all the levels, their names, and instructions in the extra links box.

--- a/dashboard/app/views/scripts/show.html.haml
+++ b/dashboard/app/views/scripts/show.html.haml
@@ -36,7 +36,6 @@
     %div{style: 'clear: both;'}
     %br/
     %br/
-    - if @current_user.try(:teacher?)
 
   - if current_user.try(:levelbuilder?)
     -# Show all the levels, their names, and instructions in the extra links box.

--- a/dashboard/lib/certificate_image.rb
+++ b/dashboard/lib/certificate_image.rb
@@ -286,18 +286,12 @@ class CertificateImage
     image
   end
 
-  def self.accelerated_course?(course)
-    [ScriptConstants::ACCELERATED_NAME, ScriptConstants::TWENTY_HOUR_NAME].include?(course)
-  end
-
   # assume any unrecognized course name is a hoc course
   def self.hoc_course?(course_name)
     course_type(course_name) == CERTIFICATE_COURSE_TYPES[:HOC]
   end
 
   def self.course_type(course_name)
-    return CERTIFICATE_COURSE_TYPES[:ACCELERATED] if accelerated_course?(course_name)
-
     unit_or_unit_group = CurriculumHelper.find_matching_unit_or_unit_group(course_name)
     course_version = unit_or_unit_group&.get_course_version
     return CERTIFICATE_COURSE_TYPES[:HOC] if course_version&.hoc_or_hoai?
@@ -342,10 +336,6 @@ class CertificateImage
       'music_hoc_certificate.png'
     elsif course == ScriptConstants::OCEANS_NAME
       'oceans_hoc_certificate.png'
-    elsif accelerated_course?(course)
-      # The 20-hour course is referred to as "accelerated" throughout the
-      # congrats and certificate pages (see csf_finish_url).
-      '20hours_certificate.jpg'
     elsif course_type == 'hoc'
       'hour_of_ai_certificate.png'
     elsif course_type == 'pl'

--- a/dashboard/lib/script_constants.rb
+++ b/dashboard/lib/script_constants.rb
@@ -157,12 +157,6 @@ module ScriptConstants
       HOW_AI_WORKS_2023_NAME = 'how-ai-works-2023'.freeze,
       AI_ETHICS_2023_NAME = 'ai-ethics-2023'.freeze,
     ],
-    csf_international: [
-      COURSE1_NAME = 'course1'.freeze,
-      COURSE2_NAME = 'course2'.freeze,
-      COURSE3_NAME = 'course3'.freeze,
-      COURSE4_NAME = 'course4'.freeze,
-    ],
     csd_2023: [
       CSD1_2023_NAME = 'csd1-2023'.freeze,
       CSD2_2023_NAME = 'csd2-2023'.freeze,
@@ -223,9 +217,6 @@ module ScriptConstants
       CSD4_NAME = 'csd4-2017'.freeze,
       CSD5_NAME = 'csd5-2017'.freeze,
       CSD6_NAME = 'csd6-2017'.freeze,
-    ],
-    twenty_hour: [
-      TWENTY_HOUR_NAME = '20-hour'.freeze,
     ],
     flappy: [FLAPPY_NAME],
     minecraft: [
@@ -356,10 +347,8 @@ module ScriptConstants
     *CATEGORIES[:csf_2021],
     *CATEGORIES[:csf_2022],
     *CATEGORIES[:csf_2023],
-    *CATEGORIES[:csf_international],
 
     *CATEGORIES[:hoc],
-    *CATEGORIES[:twenty_hour],
     *ADDITIONAL_I18N_UNITS,
     *TRANSLATEABLE_CSC_UNITS,
     *TRANSLATABLE_PD_PL_UNITS,
@@ -367,17 +356,6 @@ module ScriptConstants
   ].freeze
 
   def self.csf_next_course_recommendation(course_name)
-    # These course names without years in them should be mapped statically to their recommendation.
-    static_mapping = {
-      "course1" => "course2",
-      "course2" => "course3",
-      "course3" => "course4",
-      "accelerated" => "course4",
-      "course4" => "applab-intro"
-    }
-
-    return static_mapping[course_name] if static_mapping.include?(course_name)
-
     # For CSF courses with years in their name, separate into prefix and year. Determine the recommended
     # next prefix based on constant mapping, then add the year to the recommended prefix.
     # Example: coursea-2019 becomes prefix: coursea, year: 2019.

--- a/dashboard/lib/script_constants.rb
+++ b/dashboard/lib/script_constants.rb
@@ -10,6 +10,13 @@ module ScriptConstants
   ALGEBRA_NAME = 'algebra'.freeze
   AIML_2021_NAME = 'aiml-2021'.freeze
 
+  # Deprecated course constants (kept for deprecated course page rendering)
+  COURSE1_NAME = 'course1'.freeze
+  COURSE2_NAME = 'course2'.freeze
+  COURSE3_NAME = 'course3'.freeze
+  COURSE4_NAME = 'course4'.freeze
+  TWENTY_HOUR_NAME = '20-hour'.freeze
+
   CSP_UNIT1_NAME = 'cspunit1'.freeze
   CSP_UNIT2_NAME = 'cspunit2'.freeze
   CSP_UNIT3_NAME = 'cspunit3'.freeze

--- a/dashboard/test/controllers/api_controller_test.rb
+++ b/dashboard/test/controllers/api_controller_test.rb
@@ -104,7 +104,7 @@ class ApiControllerTest < ActionController::TestCase
     get :section_text_responses, params: {section_id: @section.id}
     assert_response :success
 
-    # we fall back to twenty_hour_unit, which has no text_response levels
+    # we fall back to hoc_2014_unit, which has no text_response levels
     assert_equal '[]', @response.body
   end
 

--- a/dashboard/test/controllers/certificate_images_controller_test.rb
+++ b/dashboard/test/controllers/certificate_images_controller_test.rb
@@ -61,8 +61,8 @@ class CertificateImagesControllerTest < ActionController::TestCase
     assert_response :success
   end
 
-  test 'can show accelerated course' do
-    data = {name: 'student', course: 'accelerated'}
+  test 'can show CSF course' do
+    data = {name: 'student', course: 'coursea-2025'}
     filename = Base64.urlsafe_encode64(data.to_json)
     get :show, format: 'jpg', params: {filename: filename}
     assert_response :success

--- a/dashboard/test/controllers/certificate_images_controller_test.rb
+++ b/dashboard/test/controllers/certificate_images_controller_test.rb
@@ -23,13 +23,6 @@ class CertificateImagesControllerTest < ActionController::TestCase
     assert_response :success
   end
 
-  test 'can show course1 course name' do
-    data = {name: 'student', course: 'course1'}
-    filename = Base64.urlsafe_encode64(data.to_json)
-    get :show, format: 'jpg', params: {filename: filename}
-    assert_response :success
-  end
-
   test 'can show coursea course name' do
     coursea = create(:script, name: "coursea-2021")
     coursea_course = create(:single_unit_course, name: "coursea-2021", family_name: 'coursea', version_year: '2021', unit: coursea)
@@ -57,13 +50,6 @@ class CertificateImagesControllerTest < ActionController::TestCase
     data = {name: 'student', course: 'csp-2021'}
     filename = Base64.urlsafe_encode64(data.to_json)
     CertificateImage.expects(:create_course_certificate_image).with('student', 'csp-2021', "Computer Science Principles ('21-'22)").returns(stub_image).once
-    get :show, format: 'jpg', params: {filename: filename}
-    assert_response :success
-  end
-
-  test 'can show CSF course' do
-    data = {name: 'student', course: 'coursea-2025'}
-    filename = Base64.urlsafe_encode64(data.to_json)
     get :show, format: 'jpg', params: {filename: filename}
     assert_response :success
   end

--- a/dashboard/test/controllers/script_levels_controller_test.rb
+++ b/dashboard/test/controllers/script_levels_controller_test.rb
@@ -867,15 +867,6 @@ class ScriptLevelsControllerTest < ActionController::TestCase
   end
 
   #TODO: TEACH-1788 This will need to be updated when we change the test fixtures
-  test "updated routing for 20 hour script" do
-    sl = ScriptLevel.find_by script: Unit.twenty_hour_unit, chapter: 3
-    assert_equal '/s/20-hour/lessons/2/levels/2', build_script_level_path(sl)
-    assert_routing(
-      {method: "get", path: "http://#{CDO.dashboard_hostname}#{build_script_level_path(sl)}"},
-      {controller: "script_levels", action: "show", script_id: Unit::TWENTY_HOUR_NAME, lesson_position: sl.lesson.to_param, id: sl.to_param}
-    )
-  end
-
   test "chapter based routing" do
     assert_routing(
       {method: "get", path: "http://#{CDO.dashboard_hostname}/hoc/reset"},

--- a/dashboard/test/controllers/script_levels_controller_test.rb
+++ b/dashboard/test/controllers/script_levels_controller_test.rb
@@ -717,7 +717,7 @@ class ScriptLevelsControllerTest < ActionController::TestCase
   test "ridiculous chapter number throws NotFound instead of RangeError" do
     assert_raises ActiveRecord::RecordNotFound do
       get :show, params: {
-        course_course_name: Unit.twenty_hour_unit.original_unit_group.name,
+        course_course_name: Unit.hoc_2014_unit.original_unit_group.name,
         unit_position: '1',
         lesson_position: '99999999999999999999999999',
         id: '1'
@@ -726,7 +726,7 @@ class ScriptLevelsControllerTest < ActionController::TestCase
 
     assert_raises ActiveRecord::RecordNotFound do
       get :show, params: {
-        course_course_name: Unit.twenty_hour_unit.original_unit_group.name,
+        course_course_name: Unit.hoc_2014_unit.original_unit_group.name,
         unit_position: '1',
         lesson_position: '1',
         id: '99999999999999999999999999'

--- a/dashboard/test/controllers/scripts_controller_test.rb
+++ b/dashboard/test/controllers/scripts_controller_test.rb
@@ -60,6 +60,16 @@ class ScriptsControllerTest < ActionController::TestCase
     assert_redirected_to "/s/#{new_unit.name}"
   end
 
+  test "should render deprecated course page for deprecated courses" do
+    deprecated_unit = create(:script, :in_single_unit_course)
+    deprecated_unit.update(is_deprecated: true)
+
+    get :show, params: {course_course_name: deprecated_unit.original_unit_group.name, position: 1}
+    assert_response :success
+    assert_template 'errors/deprecated_course'
+    assert_equal deprecated_unit.name, assigns(:deprecated_curriculum_name)
+  end
+
   test "should not get index if not signed in" do
     get :index
 

--- a/dashboard/test/helpers/script_levels_helper_test.rb
+++ b/dashboard/test/helpers/script_levels_helper_test.rb
@@ -12,7 +12,6 @@ class ScriptLevelsHelperTest < ActionView::TestCase
     create(:section, user: @teacher, script: script)
     @section = create(:section, user: @teacher, script: script)
     create(:follower, section: @section, student_user: @student)
-    create(:unit, name: Unit::COURSE4_NAME)
   end
 
   test 'tracking_pixel_url' do
@@ -20,7 +19,6 @@ class ScriptLevelsHelperTest < ActionView::TestCase
     assert_equal '//test-studio.code.org/api/hour/begin_codeorg.png', tracking_pixel_url(Unit.get_from_cache(Unit::HOC_2013_NAME))
 
     assert_equal '//test-studio.code.org/api/hour/begin_frozen.png', tracking_pixel_url(Unit.get_from_cache(Unit::FROZEN_NAME))
-    assert_equal '//test-studio.code.org/api/hour/begin_course4.png', tracking_pixel_url(Unit.get_from_cache(Unit::COURSE4_NAME))
     assert_equal '//test-studio.code.org/api/hour/begin_artist.png', tracking_pixel_url(Unit.get_from_cache(Unit::ARTIST_NAME))
   end
 
@@ -29,7 +27,6 @@ class ScriptLevelsHelperTest < ActionView::TestCase
     assert_equal '//test-studio.code.org/api/hour/finish', Unit.get_from_cache(Unit::HOC_2013_NAME).hoc_finish_url
 
     assert_equal '//test-studio.code.org/api/hour/finish/frozen', Unit.get_from_cache(Unit::FROZEN_NAME).hoc_finish_url
-    assert_equal '//test-studio.code.org/api/hour/finish/course4', Unit.get_from_cache(Unit::COURSE4_NAME).hoc_finish_url
     assert_equal '//test-studio.code.org/api/hour/finish/starwars', Unit.get_from_cache(Unit::STARWARS_NAME).hoc_finish_url
     assert_equal '//test-studio.code.org/api/hour/finish/artist', Unit.get_from_cache(Unit::ARTIST_NAME).hoc_finish_url
   end

--- a/dashboard/test/lib/certificate_image_test.rb
+++ b/dashboard/test/lib/certificate_image_test.rb
@@ -4,10 +4,7 @@ class CertificateImageTest < ActiveSupport::TestCase
   self.use_transactional_test_case = true
 
   setup_all do
-    create_csf_unit 'course1'
-    create_csf_unit 'course2'
-    create_csf_unit 'course3'
-    create_csf_unit 'course4'
+    create_csf_unit 'coursea-2025'
   end
 
   def test_special_template_courses
@@ -16,30 +13,19 @@ class CertificateImageTest < ActiveSupport::TestCase
     assert CertificateImage.prefilled_title_course?('frozen')
     assert CertificateImage.prefilled_title_course?('starwars')
     assert CertificateImage.prefilled_title_course?('mc')
-    assert CertificateImage.prefilled_title_course?('20-hour')
-    assert CertificateImage.prefilled_title_course?('accelerated')
     assert CertificateImage.prefilled_title_course?('mee')
     assert CertificateImage.prefilled_title_course?('mee_empathy')
     assert CertificateImage.prefilled_title_course?('mee_timecraft')
     assert CertificateImage.prefilled_title_course?('mee_estate')
-    refute CertificateImage.prefilled_title_course?('course1')
-    refute CertificateImage.prefilled_title_course?('course2')
-    refute CertificateImage.prefilled_title_course?('course3')
-    refute CertificateImage.prefilled_title_course?('course4')
   end
 
   def test_course_templates
     assert_equal 'MC_Hour_Of_Code_Certificate.png', CertificateImage.certificate_template_for('mc')
-    assert_equal '20hours_certificate.jpg', CertificateImage.certificate_template_for('20-hour')
-    assert_equal '20hours_certificate.jpg', CertificateImage.certificate_template_for('accelerated')
     assert_equal 'hour_of_ai_certificate.png', CertificateImage.certificate_template_for('frozen')
     assert_equal 'hour_of_ai_certificate.png', CertificateImage.certificate_template_for('starwars')
     assert_equal 'hour_of_ai_certificate.png', CertificateImage.certificate_template_for('flappy')
     assert_equal 'hour_of_ai_certificate.png', CertificateImage.certificate_template_for('playlab')
-    assert_equal 'blank_certificate.png', CertificateImage.certificate_template_for('course1')
-    assert_equal 'blank_certificate.png', CertificateImage.certificate_template_for('course2')
-    assert_equal 'blank_certificate.png', CertificateImage.certificate_template_for('course3')
-    assert_equal 'blank_certificate.png', CertificateImage.certificate_template_for('course4')
+    assert_equal 'blank_certificate.png', CertificateImage.certificate_template_for('coursea-2025')
   end
 
   def test_pl_course_template
@@ -67,32 +53,29 @@ class CertificateImageTest < ActiveSupport::TestCase
     assert_image hoc_certificate_image_with_too_long_name, 1754, 1235, 'PNG'
     unspecified_course_image = CertificateImage.create_course_certificate_image('Robot Tester', nil)
     assert_image unspecified_course_image, 1754, 1235, 'PNG'
-    blank_named_certificate_image = CertificateImage.create_course_certificate_image('Robot Tester', 'course1', 'Course 1')
+    blank_named_certificate_image = CertificateImage.create_course_certificate_image('Robot Tester', 'coursea-2025', 'Course A')
     assert_image blank_named_certificate_image, 1754, 1240, 'PNG'
-    twenty_hour_certificate_image = CertificateImage.create_course_certificate_image('Robot Tester', '20-hour')
-    assert_image twenty_hour_certificate_image, 1754, 1240, 'JPEG'
-    accelerated_certificate_image = CertificateImage.create_course_certificate_image('Robot Tester', 'accelerated')
-    assert_image accelerated_certificate_image, 1754, 1240, 'JPEG'
 
     # Create course certificates with nil and empty values
-    nil_sponsor_course_certificate_image = CertificateImage.create_course_certificate_image('Robot Tester', 'course1', 'Course 1')
+    nil_sponsor_course_certificate_image = CertificateImage.create_course_certificate_image('Robot Tester', 'coursea-2025', 'Course A')
     assert_image nil_sponsor_course_certificate_image, 1754, 1240, 'PNG'
-    empty_name_course_certificate_image = CertificateImage.create_course_certificate_image('', 'course1', 'Course 1')
+    empty_name_course_certificate_image = CertificateImage.create_course_certificate_image('', 'coursea-2025', 'Course A')
     assert_image empty_name_course_certificate_image, 1754, 1240, 'PNG'
-    empty_title_course_certificate_image = CertificateImage.create_course_certificate_image('Robot Tester', 'course1', '')
+    empty_title_course_certificate_image = CertificateImage.create_course_certificate_image('Robot Tester', 'coursea-2025', '')
     assert_image empty_title_course_certificate_image, 1754, 1240, 'PNG'
 
-    # Entered name "à Test Namé" on /congrats/course1
+    # Test ISO-8859-1 encoded names are handled correctly
+    # Entered name "à Test Namé" on /congrats
     # JS btoa(JSON.stringified(config)) becomes:
-    #   "eyJuYW1lIjoi4CBUZXN0IE5hbekiLCJjb3Vyc2UiOiJDb3Vyc2UgMSJ9"
+    #   "eyJuYW1lIjoi4CBUZXN0IE5hbekiLCJjb3Vyc2UiOiJDb3Vyc2UgQSJ9"
     # Ruby JSON.parse(Base64.urlsafe_decode64(encoded_config) becomes:
-    #   { name: "à Test Namé", course: "Course 1"}
+    #   { name: "à Test Namé", course: "Course A"}
     #   ^ but the name is encoded in ISO-8859-1. This used to throw when gsub
     #     would get called on the string with a regex. Now we call
     #     force_8859_to_utf8 on the string, and the chars now render OK.
     iso_8859_name = 'An ISO-8859 Tester \xE0' # Includes an à in ISO-8859-1
-    twenty_hour_certificate_image = CertificateImage.create_course_certificate_image(iso_8859_name, '20-hour')
-    assert_image twenty_hour_certificate_image, 1754, 1240, 'JPEG'
+    coursea_certificate_image = CertificateImage.create_course_certificate_image(iso_8859_name, 'coursea-2025')
+    assert_image coursea_certificate_image, 1754, 1240, 'PNG'
   end
 
   def test_pl_certificate_image_generation
@@ -145,7 +128,6 @@ class CertificateImageTest < ActiveSupport::TestCase
     assert CertificateImage.hoc_course?('kodable')
     assert CertificateImage.hoc_course?('hello')
 
-    refute CertificateImage.hoc_course?('course1')
     refute CertificateImage.hoc_course?('coursea-2021')
     refute CertificateImage.hoc_course?('csp-2021')
     refute CertificateImage.hoc_course?('other')

--- a/dashboard/test/lib/queries/script_activity_test.rb
+++ b/dashboard/test/lib/queries/script_activity_test.rb
@@ -151,22 +151,6 @@ class Queries::ScriptActivityTest < ActiveSupport::TestCase
     assert_equal s1.script, Queries::ScriptActivity.primary_pl_unit(teacher)
   end
 
-  test 'user should prefer working on 20hour instead of hoc' do
-    # TODO figure out if we still need this test
-    skip
-
-    create_hourofcode_unit_and_levels
-    twenty_hour = Unit.twenty_hour_unit
-    hoc = Unit.find_by(name: 'hourofcode')
-
-    # do a level that is both in script 1 and hoc
-    [twenty_hour, hoc].each do |script|
-      UserScript.create! user: @user, script: script
-    end
-
-    assert_equal [twenty_hour, hoc], Queries::ScriptActivity.working_on_units(@user)
-  end
-
   test 'in_progress_and_completed_scripts does not include deleted scripts' do
     real_script = Unit.starwars_unit
     fake_script = create(:script)

--- a/dashboard/test/lib/queries/script_activity_test.rb
+++ b/dashboard/test/lib/queries/script_activity_test.rb
@@ -152,6 +152,9 @@ class Queries::ScriptActivityTest < ActiveSupport::TestCase
   end
 
   test 'user should prefer working on 20hour instead of hoc' do
+    # TODO figure out if we still need this test
+    skip
+
     create_hourofcode_unit_and_levels
     twenty_hour = Unit.twenty_hour_unit
     hoc = Unit.find_by(name: 'hourofcode')

--- a/dashboard/test/lib/script_constants_test.rb
+++ b/dashboard/test/lib/script_constants_test.rb
@@ -3,12 +3,6 @@ require 'test_helper'
 class ScriptConstantsTest < ActiveSupport::TestCase
   def test_csf_next_course_recommendation
     {
-      "course1" => "course2",
-      "course2" => "course3",
-      "course3" => "course4",
-      "accelerated" => "course4",
-      "course4" => "applab-intro",
-
       "coursea-2019" => "courseb-2019",
       "courseb-2019" => "coursec-2019",
       "coursec-2019" => "coursed-2019",

--- a/dashboard/test/models/script_level_test.rb
+++ b/dashboard/test/models/script_level_test.rb
@@ -37,9 +37,10 @@ class ScriptLevelTest < ActiveSupport::TestCase
   end
 
   test 'counts puzzle position and total in lesson' do
-    # default script
-    sl = Unit.hoc_2014_unit.script_levels[1]
-    assert_equal 1, sl.position
+    # Create a test script with known structure
+    test_unit = create(:unit, :with_levels, lessons_count: 1, levels_count: 20)
+    sl = test_unit.script_levels[1]
+    assert_equal 2, sl.position
     assert_equal 20, sl.lesson_total
 
     # new script

--- a/dashboard/test/models/script_level_test.rb
+++ b/dashboard/test/models/script_level_test.rb
@@ -38,7 +38,7 @@ class ScriptLevelTest < ActiveSupport::TestCase
 
   test 'counts puzzle position and total in lesson' do
     # default script
-    sl = Unit.twenty_hour_unit.script_levels[1]
+    sl = Unit.hoc_2014_unit.script_levels[1]
     assert_equal 1, sl.position
     assert_equal 20, sl.lesson_total
 
@@ -822,8 +822,8 @@ class ScriptLevelTest < ActiveSupport::TestCase
   end
 
   test 'cached_find' do
-    script_level = ScriptLevel.cache_find(Unit.twenty_hour_unit.script_levels[0].id)
-    assert_equal(Unit.twenty_hour_unit.script_levels[0], script_level)
+    script_level = ScriptLevel.cache_find(Unit.hoc_2014_unit.script_levels[0].id)
+    assert_equal(Unit.hoc_2014_unit.script_levels[0], script_level)
 
     multi_lesson_unit = create(:unit, :with_levels, lessons_count: 3, levels_count: 3)
     script_level2 = ScriptLevel.cache_find(multi_lesson_unit.script_levels.last.id)

--- a/dashboard/test/models/unit_test.rb
+++ b/dashboard/test/models/unit_test.rb
@@ -467,10 +467,6 @@ class UnitTest < ActiveSupport::TestCase
 
   test 'banner image' do
     assert_nil Unit.find_by_name('flappy').banner_image
-    course1_unit = create(:script, name: 'course1')
-    course2_unit = create(:script, name: 'course2')
-    assert_equal 'banner_course1.jpg', course1_unit.banner_image
-    assert_equal 'banner_course2.jpg', course2_unit.banner_image
     assert_nil Unit.find_by_name('csf1').banner_image
   end
 


### PR DESCRIPTION
Now that Courses 1-4 and 20-hour (also known as accelerated) have been deprecated for a couple months, this PR removes some of the extra business logic we had for those courses.

This PR was generated largely by Claude Code, with a human (me) in the loop, to more quickly find and remove references to these courses. I'm mostly relying on test coverage to ensure no unintended breakages.