### PR TITLE
[Blockly] Send analytics when changing theme in legacy labs

### DIFF
--- a/apps/src/blockly/utils.ts
+++ b/apps/src/blockly/utils.ts
@@ -425,24 +425,22 @@ export function setThemeAndRenderBlocks(
   }
 }
 
-export function setWorkspaceTheme(
-  workspace: GoogleBlockly.WorkspaceSvg,
-  name: string
-) {
+export function setWorkspaceTheme(name: string) {
   // Save the theme to user preferences, falling back to localStorage for signed-out users.
   new UserPreferences().setBlocklyTheme(name, () =>
     localStorage.setItem(BLOCKLY_THEME, name)
   );
 
-  const currentTheme = workspace.getTheme();
-  const themeName = name + (isDarkTheme(currentTheme) ? DARK_THEME_SUFFIX : '');
-  setAllWorkspacesTheme(Blockly.themes[themeName as Themes], currentTheme);
   const analyticsData = Blockly.analyticsData;
   analyticsReporter.sendEvent(EVENTS.BLOCKLY_LAB_SETTING_CHANGED, {
     setting: EVENTS.BLOCKLY_SETTING_THEME,
     value: name,
     ...analyticsData,
   });
+
+  const currentTheme = Blockly.getMainWorkspace().getTheme();
+  const themeName = name + (isDarkTheme(currentTheme) ? DARK_THEME_SUFFIX : '');
+  setAllWorkspacesTheme(Blockly.themes[themeName as Themes], currentTheme);
 }
 
 export function setAllWorkspacesTheme(

--- a/apps/src/lab2/hooks/useBlocklySettings.ts
+++ b/apps/src/lab2/hooks/useBlocklySettings.ts
@@ -45,7 +45,7 @@ export function useBlocklySettings(): Setting[] {
   }, []);
 
   const handleBlocklyThemeChange = (name: string) => {
-    setWorkspaceTheme(Blockly.getMainWorkspace(), name);
+    setWorkspaceTheme(name);
     setSelectedTheme(name);
   };
 

--- a/apps/src/templates/Settings.jsx
+++ b/apps/src/templates/Settings.jsx
@@ -3,7 +3,7 @@ import React, {useState, useEffect} from 'react';
 import {BLOCKLY_THEME, Themes} from '@cdo/apps/blockly/constants';
 import commonI18n from '@cdo/locale';
 
-import {setAllWorkspacesTheme} from '../blockly/utils';
+import {setWorkspaceTheme} from '../blockly/utils';
 import UserPreferences from '../lib/util/UserPreferences';
 
 import styles from './settings.module.scss';
@@ -31,7 +31,7 @@ const SettingsModal = () => {
     const theme = Blockly.themes[value];
     if (theme) {
       setSelectedTheme(value);
-      setAllWorkspacesTheme(theme, Blockly.getMainWorkspace()?.getTheme());
+      setWorkspaceTheme(value);
       new UserPreferences().setBlocklyTheme(value, () =>
         localStorage.setItem(BLOCKLY_THEME, value)
       );


### PR DESCRIPTION
@dju90 noticed that our analytics suggest we are seeing less usage of our accessible color themes in Blockly labs compared to last year:

<img width="981" height="428" alt="image" src="https://github.com/user-attachments/assets/b26a1d33-a0a6-4bee-97a2-abb34d9bd4fd" />

This is likely due, at least in part, to the fact that we are only reporting theme changes in Lab2 (e.g. Music Lab) and no other labs. When we added the settings panel to all legacy labs, it did not add any analytics (https://github.com/code-dot-org/code-dot-org/pull/67470).
<img width="982" height="269" alt="image" src="https://github.com/user-attachments/assets/94aecf01-43cf-43ca-819a-86f4947be188" />

Analytics aren’t firing because our settings panel for legacy labs is bypassing the one place where the analytics event is actually sent. This fixes that by having the settings panel call `setWorkspaceTheme` which handles all work related to preference storage, multiple-workspace theme switching, and analytics. 

You can see in the original legacy labs settings panel PR that we actually used to use `setWorkspaceTheme` back when we provided these options in the context menu: https://github.com/code-dot-org/code-dot-org/pull/67470/files#diff-37ba27a24ee17da13643bc01237a7e56544ff219812da41af2495b56c9482a31L448
This perfectly explains why we're seeing such a dramatic drop in (logged) usage.

While doing this, I noticed that the function named above takes a `workspace`, but that workspace is only ever the main student workspace. The `workspace` argument is only used to get the current theme, which is used to determine if we need to re-render blocks. The inner `setAllWorkspacesTheme` call already finds _all_ workspaces and updates them together. To simplify things, I removed the parameter. I also moved the analytics reporting work above the the actual workspace rendering work. The workspace rendering work is potentially heavier, so I don't want it to needlessly delay reporting a preference change.


## Links
<!--  Links to relevant external resources.
      - spec docs, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- Jira: 

## Testing story
<!--  Does your change include appropriate tests?
      - If so, please describe how the tests included in this PR are sufficient.
      - If not, please explain why this change does not need to be tested. -->



## Deployment strategy
<!--  Any special steps required to deploy this, besides merging?
      - Are there database migrations or manual steps?
      - Does this require coordination with other teams or systems? -->



## Follow-up work
<!--  List any clean-up or technical debt that will be addressed in future work.
      - Include Jira links where applicable.
      - Are there any known limitations or improvements planned? -->



## Privacy
<!--  How does this change impact Student & Teacher privacy?
      - Does this collect, use, share, or modify PII, either new or existing? -->



## Security
<!--  How does this change impact our security surface-area?
      - Do API's touched have the right auth?
      - Do infra changes impact our attack surface or encryption?
-->



## Caching
<!--  How does this change impact caching behavior?
      - Are cache keys or invalidation strategies affected?
      - Will this require cache warming or invalidation after deployment? -->



## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
