### PR TITLE
hoai2025: dancer fix clicks

### DIFF
--- a/apps/src/dance/lab2/views/generate-dancer.module.scss
+++ b/apps/src/dance/lab2/views/generate-dancer.module.scss
@@ -98,6 +98,7 @@
   top: -10%;
   transition: opacity 0.2s ease;
   opacity: 1;
+  pointer-events: none;
 
   &Hidden {
     opacity: 0;


### PR DESCRIPTION
This fixes the Generate Dancer UI so that tabs in the resource panel, such as the copyright tab, can again be clicked.
