### PR TITLE
use transactional test case whenever we use setup_all

### DIFF
--- a/dashboard/test/controllers/api/v1/section_libraries_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/section_libraries_controller_test.rb
@@ -2,6 +2,7 @@ require 'test_helper'
 
 class Api::V1::SectionLibrariesControllerTest < ActionController::TestCase
   setup_all do
+    create(:level, name: 'collision')
     @teacher = create(:teacher)
     @section = create(:section, user: @teacher, login_type: 'word')
     @student = create(:follower, section: @section).student_user

--- a/dashboard/test/controllers/api/v1/section_libraries_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/section_libraries_controller_test.rb
@@ -4,7 +4,6 @@ class Api::V1::SectionLibrariesControllerTest < ActionController::TestCase
   self.use_transactional_test_case = true
 
   setup_all do
-    create(:level, name: 'collision')
     @teacher = create(:teacher)
     @section = create(:section, user: @teacher, login_type: 'word')
     @student = create(:follower, section: @section).student_user

--- a/dashboard/test/controllers/api/v1/section_libraries_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/section_libraries_controller_test.rb
@@ -1,6 +1,8 @@
 require 'test_helper'
 
 class Api::V1::SectionLibrariesControllerTest < ActionController::TestCase
+  self.use_transactional_test_case = true
+
   setup_all do
     create(:level, name: 'collision')
     @teacher = create(:teacher)

--- a/dashboard/test/controllers/backpacks_controller_test.rb
+++ b/dashboard/test/controllers/backpacks_controller_test.rb
@@ -1,6 +1,8 @@
 require 'test_helper'
 
 class BackpacksControllerTest < ActionController::TestCase
+  self.use_transactional_test_case = true
+
   setup_all do
     create(:level, name: 'collision')
     @user = create(:user)

--- a/dashboard/test/controllers/backpacks_controller_test.rb
+++ b/dashboard/test/controllers/backpacks_controller_test.rb
@@ -2,7 +2,6 @@ require 'test_helper'
 
 class BackpacksControllerTest < ActionController::TestCase
   setup do
-    create(:level, name: 'collision')
     @user = create(:user)
     @storage_id = fake_storage_id_for_user_id(@user.id)
     @game_id = 68

--- a/dashboard/test/controllers/backpacks_controller_test.rb
+++ b/dashboard/test/controllers/backpacks_controller_test.rb
@@ -2,6 +2,7 @@ require 'test_helper'
 
 class BackpacksControllerTest < ActionController::TestCase
   setup_all do
+    create(:level, name: 'collision')
     @user = create(:user)
     @storage_id = fake_storage_id_for_user_id(@user.id)
     @game_id = 68

--- a/dashboard/test/controllers/backpacks_controller_test.rb
+++ b/dashboard/test/controllers/backpacks_controller_test.rb
@@ -1,9 +1,7 @@
 require 'test_helper'
 
 class BackpacksControllerTest < ActionController::TestCase
-  self.use_transactional_test_case = true
-
-  setup_all do
+  setup do
     create(:level, name: 'collision')
     @user = create(:user)
     @storage_id = fake_storage_id_for_user_id(@user.id)

--- a/dashboard/test/controllers/certificates_controller_test.rb
+++ b/dashboard/test/controllers/certificates_controller_test.rb
@@ -3,6 +3,7 @@ require 'base64'
 
 class CertificatesControllerTest < ActionController::TestCase
   setup_all do
+    create(:level, name: 'collision')
     @teacher = create(:teacher)
     @teacher.freeze
   end

--- a/dashboard/test/controllers/certificates_controller_test.rb
+++ b/dashboard/test/controllers/certificates_controller_test.rb
@@ -2,6 +2,8 @@ require 'test_helper'
 require 'base64'
 
 class CertificatesControllerTest < ActionController::TestCase
+  self.use_transactional_test_case = true
+
   setup_all do
     create(:level, name: 'collision')
     @teacher = create(:teacher)

--- a/dashboard/test/controllers/certificates_controller_test.rb
+++ b/dashboard/test/controllers/certificates_controller_test.rb
@@ -5,7 +5,6 @@ class CertificatesControllerTest < ActionController::TestCase
   self.use_transactional_test_case = true
 
   setup_all do
-    create(:level, name: 'collision')
     @teacher = create(:teacher)
     @teacher.freeze
   end

--- a/dashboard/test/controllers/data_docs_controller_test.rb
+++ b/dashboard/test/controllers/data_docs_controller_test.rb
@@ -3,6 +3,8 @@ require 'test_helper'
 class DataDocsControllerTest < ActionController::TestCase
   include Devise::Test::ControllerHelpers
 
+  self.use_transactional_test_case = true
+
   setup_all do
     create(:level, name: 'collision')
     @levelbuilder = create(:levelbuilder)

--- a/dashboard/test/controllers/data_docs_controller_test.rb
+++ b/dashboard/test/controllers/data_docs_controller_test.rb
@@ -4,6 +4,7 @@ class DataDocsControllerTest < ActionController::TestCase
   include Devise::Test::ControllerHelpers
 
   setup_all do
+    create(:level, name: 'collision')
     @levelbuilder = create(:levelbuilder)
 
     @test_params = {

--- a/dashboard/test/controllers/data_docs_controller_test.rb
+++ b/dashboard/test/controllers/data_docs_controller_test.rb
@@ -6,7 +6,6 @@ class DataDocsControllerTest < ActionController::TestCase
   self.use_transactional_test_case = true
 
   setup_all do
-    create(:level, name: 'collision')
     @levelbuilder = create(:levelbuilder)
 
     @test_params = {

--- a/dashboard/test/controllers/datablock_storage_controller_test.rb
+++ b/dashboard/test/controllers/datablock_storage_controller_test.rb
@@ -2,6 +2,7 @@ require "test_helper"
 
 class DatablockStorageControllerTest < ActionDispatch::IntegrationTest
   setup_all do
+    create(:level, name: 'collision')
     @student = create(:student)
 
     project = create(:project, owner: @student)

--- a/dashboard/test/controllers/datablock_storage_controller_test.rb
+++ b/dashboard/test/controllers/datablock_storage_controller_test.rb
@@ -4,7 +4,6 @@ class DatablockStorageControllerTest < ActionDispatch::IntegrationTest
   self.use_transactional_test_case = true
 
   setup_all do
-    create(:level, name: 'collision')
     @student = create(:student)
 
     project = create(:project, owner: @student)

--- a/dashboard/test/controllers/datablock_storage_controller_test.rb
+++ b/dashboard/test/controllers/datablock_storage_controller_test.rb
@@ -1,6 +1,8 @@
 require "test_helper"
 
 class DatablockStorageControllerTest < ActionDispatch::IntegrationTest
+  self.use_transactional_test_case = true
+
   setup_all do
     create(:level, name: 'collision')
     @student = create(:student)

--- a/dashboard/test/controllers/experiments_controller_test.rb
+++ b/dashboard/test/controllers/experiments_controller_test.rb
@@ -4,7 +4,6 @@ class ExperimentsControllerTest < ActionController::TestCase
   self.use_transactional_test_case = true
 
   setup_all do
-    create(:level, name: 'collision')
     @pilot = create(:pilot, allow_joining_via_url: true)
     @pilot_name = @pilot.name
   end

--- a/dashboard/test/controllers/experiments_controller_test.rb
+++ b/dashboard/test/controllers/experiments_controller_test.rb
@@ -2,6 +2,7 @@ require 'test_helper'
 
 class ExperimentsControllerTest < ActionController::TestCase
   setup_all do
+    create(:level, name: 'collision')
     @pilot = create(:pilot, allow_joining_via_url: true)
     @pilot_name = @pilot.name
   end

--- a/dashboard/test/controllers/experiments_controller_test.rb
+++ b/dashboard/test/controllers/experiments_controller_test.rb
@@ -1,6 +1,8 @@
 require 'test_helper'
 
 class ExperimentsControllerTest < ActionController::TestCase
+  self.use_transactional_test_case = true
+
   setup_all do
     create(:level, name: 'collision')
     @pilot = create(:pilot, allow_joining_via_url: true)

--- a/dashboard/test/controllers/featured_projects_controller_test.rb
+++ b/dashboard/test/controllers/featured_projects_controller_test.rb
@@ -4,7 +4,6 @@ class FeaturedProjectsControllerTest < ActionController::TestCase
   self.use_transactional_test_case = true
 
   setup_all do
-    create(:level, name: 'collision')
     @project_validator = create(:project_validator)
     @teacher = create(:teacher)
 

--- a/dashboard/test/controllers/featured_projects_controller_test.rb
+++ b/dashboard/test/controllers/featured_projects_controller_test.rb
@@ -1,6 +1,8 @@
 require 'test_helper'
 
 class FeaturedProjectsControllerTest < ActionController::TestCase
+  self.use_transactional_test_case = true
+
   setup_all do
     create(:level, name: 'collision')
     @project_validator = create(:project_validator)

--- a/dashboard/test/controllers/featured_projects_controller_test.rb
+++ b/dashboard/test/controllers/featured_projects_controller_test.rb
@@ -2,6 +2,7 @@ require 'test_helper'
 
 class FeaturedProjectsControllerTest < ActionController::TestCase
   setup_all do
+    create(:level, name: 'collision')
     @project_validator = create(:project_validator)
     @teacher = create(:teacher)
 

--- a/dashboard/test/controllers/foorm/libraries_controller_test.rb
+++ b/dashboard/test/controllers/foorm/libraries_controller_test.rb
@@ -5,7 +5,6 @@ module Foorm
     self.use_transactional_test_case = true
 
     setup_all do
-      create(:level, name: 'collision')
       @levelbuilder = create(:levelbuilder)
     end
 

--- a/dashboard/test/controllers/foorm/libraries_controller_test.rb
+++ b/dashboard/test/controllers/foorm/libraries_controller_test.rb
@@ -2,6 +2,8 @@ require 'test_helper'
 
 module Foorm
   class LibrariesControllerTest < ActionController::TestCase
+    self.use_transactional_test_case = true
+
     setup_all do
       create(:level, name: 'collision')
       @levelbuilder = create(:levelbuilder)

--- a/dashboard/test/controllers/foorm/libraries_controller_test.rb
+++ b/dashboard/test/controllers/foorm/libraries_controller_test.rb
@@ -3,6 +3,7 @@ require 'test_helper'
 module Foorm
   class LibrariesControllerTest < ActionController::TestCase
     setup_all do
+      create(:level, name: 'collision')
       @levelbuilder = create(:levelbuilder)
     end
 

--- a/dashboard/test/controllers/lti_v1_controller_test.rb
+++ b/dashboard/test/controllers/lti_v1_controller_test.rb
@@ -9,6 +9,8 @@ require 'clients/lti_dynamic_registration_client'
 class LtiV1ControllerTest < ActionDispatch::IntegrationTest
   include Devise::Test::IntegrationHelpers
 
+  self.use_transactional_test_case = true
+
   setup_all do
     create(:level, name: 'collision')
     @integration = create(:lti_integration)

--- a/dashboard/test/controllers/lti_v1_controller_test.rb
+++ b/dashboard/test/controllers/lti_v1_controller_test.rb
@@ -12,7 +12,6 @@ class LtiV1ControllerTest < ActionDispatch::IntegrationTest
   self.use_transactional_test_case = true
 
   setup_all do
-    create(:level, name: 'collision')
     @integration = create(:lti_integration)
     @deployment_id = SecureRandom.uuid
     @key = SecureRandom.alphanumeric 10

--- a/dashboard/test/controllers/lti_v1_controller_test.rb
+++ b/dashboard/test/controllers/lti_v1_controller_test.rb
@@ -10,6 +10,7 @@ class LtiV1ControllerTest < ActionDispatch::IntegrationTest
   include Devise::Test::IntegrationHelpers
 
   setup_all do
+    create(:level, name: 'collision')
     @integration = create(:lti_integration)
     @deployment_id = SecureRandom.uuid
     @key = SecureRandom.alphanumeric 10

--- a/dashboard/test/helpers/teacher_application_helper_test.rb
+++ b/dashboard/test/helpers/teacher_application_helper_test.rb
@@ -8,6 +8,8 @@ class TeacherApplicationHelperTest < ActionView::TestCase
     stubs(:current_user).returns user
   end
 
+  self.use_transactional_test_case = true
+
   setup_all do
     create(:level, name: 'collision')
     @user_with_two_incomplete_apps = create(:teacher)

--- a/dashboard/test/helpers/teacher_application_helper_test.rb
+++ b/dashboard/test/helpers/teacher_application_helper_test.rb
@@ -11,7 +11,6 @@ class TeacherApplicationHelperTest < ActionView::TestCase
   self.use_transactional_test_case = true
 
   setup_all do
-    create(:level, name: 'collision')
     @user_with_two_incomplete_apps = create(:teacher)
     @incomplete_application = create TEACHER_APPLICATION_FACTORY, user: @user_with_two_incomplete_apps, status: 'incomplete'
     create TEACHER_APPLICATION_FACTORY, user: @user_with_two_incomplete_apps, status: 'incomplete', application_year: '2018-2019'

--- a/dashboard/test/helpers/teacher_application_helper_test.rb
+++ b/dashboard/test/helpers/teacher_application_helper_test.rb
@@ -9,6 +9,7 @@ class TeacherApplicationHelperTest < ActionView::TestCase
   end
 
   setup_all do
+    create(:level, name: 'collision')
     @user_with_two_incomplete_apps = create(:teacher)
     @incomplete_application = create TEACHER_APPLICATION_FACTORY, user: @user_with_two_incomplete_apps, status: 'incomplete'
     create TEACHER_APPLICATION_FACTORY, user: @user_with_two_incomplete_apps, status: 'incomplete', application_year: '2018-2019'

--- a/dashboard/test/lib/lti_access_token_test.rb
+++ b/dashboard/test/lib/lti_access_token_test.rb
@@ -5,6 +5,8 @@ require 'jwt'
 class LtiAccessTokenTest < ActiveSupport::TestCase
   include LtiAccessToken
 
+  self.use_transactional_test_case = true
+
   setup_all do
     create(:level, name: 'collision')
     @lti_integration = create(:lti_integration)

--- a/dashboard/test/lib/lti_access_token_test.rb
+++ b/dashboard/test/lib/lti_access_token_test.rb
@@ -8,7 +8,6 @@ class LtiAccessTokenTest < ActiveSupport::TestCase
   self.use_transactional_test_case = true
 
   setup_all do
-    create(:level, name: 'collision')
     @lti_integration = create(:lti_integration)
     fake_response_hash = {
       access_token: 'fake_access_token',

--- a/dashboard/test/lib/lti_access_token_test.rb
+++ b/dashboard/test/lib/lti_access_token_test.rb
@@ -6,6 +6,7 @@ class LtiAccessTokenTest < ActiveSupport::TestCase
   include LtiAccessToken
 
   setup_all do
+    create(:level, name: 'collision')
     @lti_integration = create(:lti_integration)
     fake_response_hash = {
       access_token: 'fake_access_token',

--- a/dashboard/test/lib/pd/foorm/form_analytics_parser_test.rb
+++ b/dashboard/test/lib/pd/foorm/form_analytics_parser_test.rb
@@ -3,6 +3,7 @@ require 'test_helper'
 module Pd::Foorm
   class FormAnalyticsParserTest < ActiveSupport::TestCase
     setup_all do
+      create(:level, name: 'collision')
       @form = create(:foorm_form_csf_intro_post_survey)
       @reshaped_form = FormAnalyticsParser.reshape_form(@form)
     end

--- a/dashboard/test/lib/pd/foorm/form_analytics_parser_test.rb
+++ b/dashboard/test/lib/pd/foorm/form_analytics_parser_test.rb
@@ -2,6 +2,8 @@ require 'test_helper'
 
 module Pd::Foorm
   class FormAnalyticsParserTest < ActiveSupport::TestCase
+    self.use_transactional_test_case = true
+
     setup_all do
       create(:level, name: 'collision')
       @form = create(:foorm_form_csf_intro_post_survey)

--- a/dashboard/test/lib/pd/foorm/form_analytics_parser_test.rb
+++ b/dashboard/test/lib/pd/foorm/form_analytics_parser_test.rb
@@ -5,7 +5,6 @@ module Pd::Foorm
     self.use_transactional_test_case = true
 
     setup_all do
-      create(:level, name: 'collision')
       @form = create(:foorm_form_csf_intro_post_survey)
       @reshaped_form = FormAnalyticsParser.reshape_form(@form)
     end

--- a/dashboard/test/lib/pd/foorm/rollup_helper_test.rb
+++ b/dashboard/test/lib/pd/foorm/rollup_helper_test.rb
@@ -3,6 +3,7 @@ require 'test_helper'
 module Pd::Foorm
   class RollupHelperTest < ActiveSupport::TestCase
     setup_all do
+      create(:level, name: 'collision')
       @rollup_configuration = JSON.parse(File.read('test/fixtures/rollup_config.json'), symbolize_names: true)
       @daily_survey_day_0 = create(:foorm_form_summer_pre_survey)
       @daily_survey_day_5 = create(:foorm_form_summer_post_survey)

--- a/dashboard/test/lib/pd/foorm/rollup_helper_test.rb
+++ b/dashboard/test/lib/pd/foorm/rollup_helper_test.rb
@@ -5,7 +5,6 @@ module Pd::Foorm
     self.use_transactional_test_case = true
 
     setup_all do
-      create(:level, name: 'collision')
       @rollup_configuration = JSON.parse(File.read('test/fixtures/rollup_config.json'), symbolize_names: true)
       @daily_survey_day_0 = create(:foorm_form_summer_pre_survey)
       @daily_survey_day_5 = create(:foorm_form_summer_post_survey)

--- a/dashboard/test/lib/pd/foorm/rollup_helper_test.rb
+++ b/dashboard/test/lib/pd/foorm/rollup_helper_test.rb
@@ -2,6 +2,8 @@ require 'test_helper'
 
 module Pd::Foorm
   class RollupHelperTest < ActiveSupport::TestCase
+    self.use_transactional_test_case = true
+
     setup_all do
       create(:level, name: 'collision')
       @rollup_configuration = JSON.parse(File.read('test/fixtures/rollup_config.json'), symbolize_names: true)

--- a/dashboard/test/lib/pd/foorm/submission_analytics_parser_test.rb
+++ b/dashboard/test/lib/pd/foorm/submission_analytics_parser_test.rb
@@ -5,7 +5,6 @@ module Pd::Foorm
     self.use_transactional_test_case = true
 
     setup_all do
-      create(:level, name: 'collision')
       @form = create(:foorm_form_csf_intro_post_survey)
     end
     teardown_all {@form.delete}

--- a/dashboard/test/lib/pd/foorm/submission_analytics_parser_test.rb
+++ b/dashboard/test/lib/pd/foorm/submission_analytics_parser_test.rb
@@ -2,7 +2,10 @@ require 'test_helper'
 
 module Pd::Foorm
   class SubmissionAnalyticsParserTest < ActiveSupport::TestCase
-    setup_all {@form = create(:foorm_form_csf_intro_post_survey)}
+    setup_all do
+      create(:level, name: 'collision')
+      @form = create(:foorm_form_csf_intro_post_survey)
+    end
     teardown_all {@form.delete}
 
     test 'reshape_submission formats matrix question response as expected' do

--- a/dashboard/test/lib/pd/foorm/submission_analytics_parser_test.rb
+++ b/dashboard/test/lib/pd/foorm/submission_analytics_parser_test.rb
@@ -2,6 +2,8 @@ require 'test_helper'
 
 module Pd::Foorm
   class SubmissionAnalyticsParserTest < ActiveSupport::TestCase
+    self.use_transactional_test_case = true
+
     setup_all do
       create(:level, name: 'collision')
       @form = create(:foorm_form_csf_intro_post_survey)

--- a/dashboard/test/lib/pd/survey_pipeline/mapper_test.rb
+++ b/dashboard/test/lib/pd/survey_pipeline/mapper_test.rb
@@ -5,6 +5,7 @@ require 'pd/survey_pipeline/reducer'
 module Pd::SurveyPipeline
   class GenericMapperTest < ActiveSupport::TestCase
     setup_all do
+      create(:level, name: 'collision')
       # All combinations of (a, b, c) which each value could be 0 or 1.
       @data = [
         {a: 0, b: 0, c: 0},

--- a/dashboard/test/lib/pd/survey_pipeline/mapper_test.rb
+++ b/dashboard/test/lib/pd/survey_pipeline/mapper_test.rb
@@ -7,7 +7,6 @@ module Pd::SurveyPipeline
     self.use_transactional_test_case = true
 
     setup_all do
-      create(:level, name: 'collision')
       # All combinations of (a, b, c) which each value could be 0 or 1.
       @data = [
         {a: 0, b: 0, c: 0},

--- a/dashboard/test/lib/pd/survey_pipeline/mapper_test.rb
+++ b/dashboard/test/lib/pd/survey_pipeline/mapper_test.rb
@@ -4,6 +4,8 @@ require 'pd/survey_pipeline/reducer'
 
 module Pd::SurveyPipeline
   class GenericMapperTest < ActiveSupport::TestCase
+    self.use_transactional_test_case = true
+
     setup_all do
       create(:level, name: 'collision')
       # All combinations of (a, b, c) which each value could be 0 or 1.

--- a/dashboard/test/lib/policies/inline_answer_test.rb
+++ b/dashboard/test/lib/policies/inline_answer_test.rb
@@ -1,6 +1,8 @@
 require 'test_helper'
 
 class Policies::InlineAnswerTest < ActiveSupport::TestCase
+  self.use_transactional_test_case = true
+
   setup_all do
     create(:level, name: 'collision')
     @authorized_teacher = create(:authorized_teacher)

--- a/dashboard/test/lib/policies/inline_answer_test.rb
+++ b/dashboard/test/lib/policies/inline_answer_test.rb
@@ -4,7 +4,6 @@ class Policies::InlineAnswerTest < ActiveSupport::TestCase
   self.use_transactional_test_case = true
 
   setup_all do
-    create(:level, name: 'collision')
     @authorized_teacher = create(:authorized_teacher)
     @teacher = create(:teacher)
     @student = create(:student)

--- a/dashboard/test/lib/policies/inline_answer_test.rb
+++ b/dashboard/test/lib/policies/inline_answer_test.rb
@@ -2,6 +2,7 @@ require 'test_helper'
 
 class Policies::InlineAnswerTest < ActiveSupport::TestCase
   setup_all do
+    create(:level, name: 'collision')
     @authorized_teacher = create(:authorized_teacher)
     @teacher = create(:teacher)
     @student = create(:student)

--- a/dashboard/test/lib/policies/script_activity_test.rb
+++ b/dashboard/test/lib/policies/script_activity_test.rb
@@ -1,6 +1,8 @@
 require 'test_helper'
 
 class Policies::ScriptActivityTest < ActiveSupport::TestCase
+  self.use_transactional_test_case = true
+
   setup_all do
     create(:level, name: 'collision')
     @user = create(:user)

--- a/dashboard/test/lib/policies/script_activity_test.rb
+++ b/dashboard/test/lib/policies/script_activity_test.rb
@@ -2,6 +2,7 @@ require 'test_helper'
 
 class Policies::ScriptActivityTest < ActiveSupport::TestCase
   setup_all do
+    create(:level, name: 'collision')
     @user = create(:user)
     @script = create(:script, :in_single_unit_course)
     @lesson_group = create(:lesson_group, script: @script)

--- a/dashboard/test/lib/policies/script_activity_test.rb
+++ b/dashboard/test/lib/policies/script_activity_test.rb
@@ -4,7 +4,6 @@ class Policies::ScriptActivityTest < ActiveSupport::TestCase
   self.use_transactional_test_case = true
 
   setup_all do
-    create(:level, name: 'collision')
     @user = create(:user)
     @script = create(:script, :in_single_unit_course)
     @lesson_group = create(:lesson_group, script: @script)

--- a/dashboard/test/lib/services/complete_application_reminder_test.rb
+++ b/dashboard/test/lib/services/complete_application_reminder_test.rb
@@ -2,6 +2,7 @@ require 'test_helper'
 
 class Services::CompleteApplicationReminderTest < ActiveSupport::TestCase
   setup_all do
+    create(:level, name: 'collision')
     Pd::Application::TeacherApplication.any_instance.stubs(:deliver_email)
   end
 

--- a/dashboard/test/lib/services/complete_application_reminder_test.rb
+++ b/dashboard/test/lib/services/complete_application_reminder_test.rb
@@ -4,7 +4,6 @@ class Services::CompleteApplicationReminderTest < ActiveSupport::TestCase
   self.use_transactional_test_case = true
 
   setup_all do
-    create(:level, name: 'collision')
     Pd::Application::TeacherApplication.any_instance.stubs(:deliver_email)
   end
 

--- a/dashboard/test/lib/services/complete_application_reminder_test.rb
+++ b/dashboard/test/lib/services/complete_application_reminder_test.rb
@@ -1,6 +1,8 @@
 require 'test_helper'
 
 class Services::CompleteApplicationReminderTest < ActiveSupport::TestCase
+  self.use_transactional_test_case = true
+
   setup_all do
     create(:level, name: 'collision')
     Pd::Application::TeacherApplication.any_instance.stubs(:deliver_email)

--- a/dashboard/test/lib/services/i18n/curriculum_sync_utils/render_translations_test.rb
+++ b/dashboard/test/lib/services/i18n/curriculum_sync_utils/render_translations_test.rb
@@ -2,6 +2,7 @@ require 'test_helper'
 
 class Services::I18n::CurriculumSyncUtils::RenderTranslationsTest < ActiveSupport::TestCase
   setup_all do
+    create(:level, name: 'collision')
     @lesson = create(:lesson, overview: "This is the english overview")
     @activity_section = create(:activity_section, name: "English name", description: "English description")
     @test_locale = :'te-ST'

--- a/dashboard/test/lib/services/i18n/curriculum_sync_utils/render_translations_test.rb
+++ b/dashboard/test/lib/services/i18n/curriculum_sync_utils/render_translations_test.rb
@@ -1,6 +1,8 @@
 require 'test_helper'
 
 class Services::I18n::CurriculumSyncUtils::RenderTranslationsTest < ActiveSupport::TestCase
+  self.use_transactional_test_case = true
+
   setup_all do
     create(:level, name: 'collision')
     @lesson = create(:lesson, overview: "This is the english overview")

--- a/dashboard/test/lib/services/i18n/curriculum_sync_utils/render_translations_test.rb
+++ b/dashboard/test/lib/services/i18n/curriculum_sync_utils/render_translations_test.rb
@@ -4,7 +4,6 @@ class Services::I18n::CurriculumSyncUtils::RenderTranslationsTest < ActiveSuppor
   self.use_transactional_test_case = true
 
   setup_all do
-    create(:level, name: 'collision')
     @lesson = create(:lesson, overview: "This is the english overview")
     @activity_section = create(:activity_section, name: "English name", description: "English description")
     @test_locale = :'te-ST'

--- a/dashboard/test/models/aidiff_artifact_test.rb
+++ b/dashboard/test/models/aidiff_artifact_test.rb
@@ -1,6 +1,8 @@
 require "test_helper"
 
 class AidiffArtifactTest < ActiveSupport::TestCase
+  self.use_transactional_test_case = true
+
   setup_all do
     create(:level, name: 'collision')
     @user = create(:user)

--- a/dashboard/test/models/aidiff_artifact_test.rb
+++ b/dashboard/test/models/aidiff_artifact_test.rb
@@ -4,7 +4,6 @@ class AidiffArtifactTest < ActiveSupport::TestCase
   self.use_transactional_test_case = true
 
   setup_all do
-    create(:level, name: 'collision')
     @user = create(:user)
   end
 

--- a/dashboard/test/models/aidiff_artifact_test.rb
+++ b/dashboard/test/models/aidiff_artifact_test.rb
@@ -2,6 +2,7 @@ require "test_helper"
 
 class AidiffArtifactTest < ActiveSupport::TestCase
   setup_all do
+    create(:level, name: 'collision')
     @user = create(:user)
   end
 

--- a/dashboard/test/models/aidiff_exit_ticket_test.rb
+++ b/dashboard/test/models/aidiff_exit_ticket_test.rb
@@ -2,6 +2,7 @@ require "test_helper"
 
 class AidiffExitTicketTest < ActiveSupport::TestCase
   setup_all do
+    create(:level, name: 'collision')
     @user = create(:user)
   end
 

--- a/dashboard/test/models/aidiff_exit_ticket_test.rb
+++ b/dashboard/test/models/aidiff_exit_ticket_test.rb
@@ -1,6 +1,8 @@
 require "test_helper"
 
 class AidiffExitTicketTest < ActiveSupport::TestCase
+  self.use_transactional_test_case = true
+
   setup_all do
     create(:level, name: 'collision')
     @user = create(:user)

--- a/dashboard/test/models/aidiff_exit_ticket_test.rb
+++ b/dashboard/test/models/aidiff_exit_ticket_test.rb
@@ -4,7 +4,6 @@ class AidiffExitTicketTest < ActiveSupport::TestCase
   self.use_transactional_test_case = true
 
   setup_all do
-    create(:level, name: 'collision')
     @user = create(:user)
   end
 

--- a/dashboard/test/models/aidiff_lesson_hook_test.rb
+++ b/dashboard/test/models/aidiff_lesson_hook_test.rb
@@ -1,6 +1,8 @@
 require "test_helper"
 
 class AidiffLessonHookTest < ActiveSupport::TestCase
+  self.use_transactional_test_case = true
+
   setup_all do
     create(:level, name: 'collision')
     @user = create(:user)

--- a/dashboard/test/models/aidiff_lesson_hook_test.rb
+++ b/dashboard/test/models/aidiff_lesson_hook_test.rb
@@ -2,6 +2,7 @@ require "test_helper"
 
 class AidiffLessonHookTest < ActiveSupport::TestCase
   setup_all do
+    create(:level, name: 'collision')
     @user = create(:user)
   end
 

--- a/dashboard/test/models/aidiff_lesson_hook_test.rb
+++ b/dashboard/test/models/aidiff_lesson_hook_test.rb
@@ -4,7 +4,6 @@ class AidiffLessonHookTest < ActiveSupport::TestCase
   self.use_transactional_test_case = true
 
   setup_all do
-    create(:level, name: 'collision')
     @user = create(:user)
   end
 

--- a/dashboard/test/models/aidiff_message_feedback_test.rb
+++ b/dashboard/test/models/aidiff_message_feedback_test.rb
@@ -4,7 +4,6 @@ class AidiffMessageFeedbackTest < ActiveSupport::TestCase
   self.use_transactional_test_case = true
 
   setup_all do
-    create(:level, name: 'collision')
     @user = create(:user)
   end
 

--- a/dashboard/test/models/aidiff_message_feedback_test.rb
+++ b/dashboard/test/models/aidiff_message_feedback_test.rb
@@ -1,6 +1,8 @@
 require "test_helper"
 
 class AidiffMessageFeedbackTest < ActiveSupport::TestCase
+  self.use_transactional_test_case = true
+
   setup_all do
     create(:level, name: 'collision')
     @user = create(:user)

--- a/dashboard/test/models/aidiff_message_feedback_test.rb
+++ b/dashboard/test/models/aidiff_message_feedback_test.rb
@@ -2,6 +2,7 @@ require "test_helper"
 
 class AidiffMessageFeedbackTest < ActiveSupport::TestCase
   setup_all do
+    create(:level, name: 'collision')
     @user = create(:user)
   end
 

--- a/dashboard/test/models/aidiff_thread_test.rb
+++ b/dashboard/test/models/aidiff_thread_test.rb
@@ -4,7 +4,6 @@ class AidiffThreadTest < ActiveSupport::TestCase
   self.use_transactional_test_case = true
 
   setup_all do
-    create(:level, name: 'collision')
     @user = create(:user)
   end
 

--- a/dashboard/test/models/aidiff_thread_test.rb
+++ b/dashboard/test/models/aidiff_thread_test.rb
@@ -2,6 +2,7 @@ require 'test_helper'
 
 class AidiffThreadTest < ActiveSupport::TestCase
   setup_all do
+    create(:level, name: 'collision')
     @user = create(:user)
   end
 

--- a/dashboard/test/models/aidiff_thread_test.rb
+++ b/dashboard/test/models/aidiff_thread_test.rb
@@ -1,6 +1,8 @@
 require 'test_helper'
 
 class AidiffThreadTest < ActiveSupport::TestCase
+  self.use_transactional_test_case = true
+
   setup_all do
     create(:level, name: 'collision')
     @user = create(:user)

--- a/dashboard/test/models/code_review_test.rb
+++ b/dashboard/test/models/code_review_test.rb
@@ -1,6 +1,8 @@
 require 'test_helper'
 
 class CodeReviewTest < ActiveSupport::TestCase
+  self.use_transactional_test_case = true
+
   setup_all do
     create(:level, name: 'collision')
     @project_owner = create(:student)

--- a/dashboard/test/models/code_review_test.rb
+++ b/dashboard/test/models/code_review_test.rb
@@ -4,7 +4,6 @@ class CodeReviewTest < ActiveSupport::TestCase
   self.use_transactional_test_case = true
 
   setup_all do
-    create(:level, name: 'collision')
     @project_owner = create(:student)
     @project = create(:project, owner: @project_owner)
     @channel_id = @project.channel_id

--- a/dashboard/test/models/code_review_test.rb
+++ b/dashboard/test/models/code_review_test.rb
@@ -2,6 +2,7 @@ require 'test_helper'
 
 class CodeReviewTest < ActiveSupport::TestCase
   setup_all do
+    create(:level, name: 'collision')
     @project_owner = create(:student)
     @project = create(:project, owner: @project_owner)
     @channel_id = @project.channel_id

--- a/dashboard/test/models/concerns/curriculum/assignable_course_test.rb
+++ b/dashboard/test/models/concerns/curriculum/assignable_course_test.rb
@@ -1,6 +1,8 @@
 require 'test_helper'
 
 class AssignableCourseTests < ActiveSupport::TestCase
+  self.use_transactional_test_case = true
+
   setup_all do
     create(:level, name: 'collision')
     @teacher = create(:teacher)

--- a/dashboard/test/models/concerns/curriculum/assignable_course_test.rb
+++ b/dashboard/test/models/concerns/curriculum/assignable_course_test.rb
@@ -2,6 +2,7 @@ require 'test_helper'
 
 class AssignableCourseTests < ActiveSupport::TestCase
   setup_all do
+    create(:level, name: 'collision')
     @teacher = create(:teacher)
     @levelbuilder = create(:levelbuilder)
   end

--- a/dashboard/test/models/concerns/curriculum/assignable_course_test.rb
+++ b/dashboard/test/models/concerns/curriculum/assignable_course_test.rb
@@ -4,7 +4,6 @@ class AssignableCourseTests < ActiveSupport::TestCase
   self.use_transactional_test_case = true
 
   setup_all do
-    create(:level, name: 'collision')
     @teacher = create(:teacher)
     @levelbuilder = create(:levelbuilder)
   end

--- a/dashboard/test/models/concerns/curriculum/course_types_test.rb
+++ b/dashboard/test/models/concerns/curriculum/course_types_test.rb
@@ -4,7 +4,6 @@ class CourseTypesTests < ActiveSupport::TestCase
   self.use_transactional_test_case = true
 
   setup_all do
-    create(:level, name: 'collision')
     @student = create(:student)
     @teacher = create(:teacher)
     @facilitator = create(:facilitator)

--- a/dashboard/test/models/concerns/curriculum/course_types_test.rb
+++ b/dashboard/test/models/concerns/curriculum/course_types_test.rb
@@ -1,6 +1,8 @@
 require 'test_helper'
 
 class CourseTypesTests < ActiveSupport::TestCase
+  self.use_transactional_test_case = true
+
   setup_all do
     create(:level, name: 'collision')
     @student = create(:student)

--- a/dashboard/test/models/concerns/curriculum/course_types_test.rb
+++ b/dashboard/test/models/concerns/curriculum/course_types_test.rb
@@ -2,6 +2,7 @@ require 'test_helper'
 
 class CourseTypesTests < ActiveSupport::TestCase
   setup_all do
+    create(:level, name: 'collision')
     @student = create(:student)
     @teacher = create(:teacher)
     @facilitator = create(:facilitator)

--- a/dashboard/test/models/course_offering_test.rb
+++ b/dashboard/test/models/course_offering_test.rb
@@ -1,6 +1,8 @@
 require 'test_helper'
 
 class CourseOfferingTest < ActiveSupport::TestCase
+  self.use_transactional_test_case = true
+
   setup_all do
     create(:level, name: 'collision')
     @student = create(:student)

--- a/dashboard/test/models/course_offering_test.rb
+++ b/dashboard/test/models/course_offering_test.rb
@@ -4,7 +4,6 @@ class CourseOfferingTest < ActiveSupport::TestCase
   self.use_transactional_test_case = true
 
   setup_all do
-    create(:level, name: 'collision')
     @student = create(:student)
     @teacher = create(:teacher)
     @facilitator = create(:facilitator)

--- a/dashboard/test/models/course_offering_test.rb
+++ b/dashboard/test/models/course_offering_test.rb
@@ -2,6 +2,7 @@ require 'test_helper'
 
 class CourseOfferingTest < ActiveSupport::TestCase
   setup_all do
+    create(:level, name: 'collision')
     @student = create(:student)
     @teacher = create(:teacher)
     @facilitator = create(:facilitator)

--- a/dashboard/test/models/course_version_test.rb
+++ b/dashboard/test/models/course_version_test.rb
@@ -4,7 +4,6 @@ class CourseVersionTest < ActiveSupport::TestCase
   self.use_transactional_test_case = true
 
   setup_all do
-    create(:level, name: 'collision')
     @student = create(:student)
     @teacher = create(:teacher)
     @facilitator = create(:facilitator)

--- a/dashboard/test/models/course_version_test.rb
+++ b/dashboard/test/models/course_version_test.rb
@@ -2,6 +2,7 @@ require 'test_helper'
 
 class CourseVersionTest < ActiveSupport::TestCase
   setup_all do
+    create(:level, name: 'collision')
     @student = create(:student)
     @teacher = create(:teacher)
     @facilitator = create(:facilitator)

--- a/dashboard/test/models/course_version_test.rb
+++ b/dashboard/test/models/course_version_test.rb
@@ -1,6 +1,8 @@
 require 'test_helper'
 
 class CourseVersionTest < ActiveSupport::TestCase
+  self.use_transactional_test_case = true
+
   setup_all do
     create(:level, name: 'collision')
     @student = create(:student)

--- a/dashboard/test/models/levels/widget_test.rb
+++ b/dashboard/test/models/levels/widget_test.rb
@@ -4,7 +4,6 @@ class WidgetTest < ActiveSupport::TestCase
   self.use_transactional_test_case = true
 
   setup_all do
-    create(:level, name: 'collision')
     @level = Widget.create!(
       name: 'Test Widget',
       long_instructions: 'These are the **markdown** instructions for the test widget.',

--- a/dashboard/test/models/levels/widget_test.rb
+++ b/dashboard/test/models/levels/widget_test.rb
@@ -1,6 +1,8 @@
 require 'test_helper'
 
 class WidgetTest < ActiveSupport::TestCase
+  self.use_transactional_test_case = true
+
   setup_all do
     create(:level, name: 'collision')
     @level = Widget.create!(

--- a/dashboard/test/models/levels/widget_test.rb
+++ b/dashboard/test/models/levels/widget_test.rb
@@ -2,6 +2,7 @@ require 'test_helper'
 
 class WidgetTest < ActiveSupport::TestCase
   setup_all do
+    create(:level, name: 'collision')
     @level = Widget.create!(
       name: 'Test Widget',
       long_instructions: 'These are the **markdown** instructions for the test widget.',

--- a/dashboard/test/models/pd/application/principal_approval_application_test.rb
+++ b/dashboard/test/models/pd/application/principal_approval_application_test.rb
@@ -2,6 +2,8 @@ require 'test_helper'
 
 module Pd::Application
   class PrincipalApprovalApplicationTest < ActiveSupport::TestCase
+    self.use_transactional_test_case = true
+
     setup_all do
       create(:level, name: 'collision')
       Pd::Application::ApplicationBase.any_instance.stubs(:deliver_email)

--- a/dashboard/test/models/pd/application/principal_approval_application_test.rb
+++ b/dashboard/test/models/pd/application/principal_approval_application_test.rb
@@ -5,7 +5,6 @@ module Pd::Application
     self.use_transactional_test_case = true
 
     setup_all do
-      create(:level, name: 'collision')
       Pd::Application::ApplicationBase.any_instance.stubs(:deliver_email)
     end
 

--- a/dashboard/test/models/pd/application/principal_approval_application_test.rb
+++ b/dashboard/test/models/pd/application/principal_approval_application_test.rb
@@ -3,6 +3,7 @@ require 'test_helper'
 module Pd::Application
   class PrincipalApprovalApplicationTest < ActiveSupport::TestCase
     setup_all do
+      create(:level, name: 'collision')
       Pd::Application::ApplicationBase.any_instance.stubs(:deliver_email)
     end
 


### PR DESCRIPTION
An [unexplained dashboard unit test failure](https://codedotorg.slack.com/archives/C0T0PNTM3/p1765490102514529?thread_ts=1765488164.529189&cid=C0T0PNTM3) prompted me to investigate a hunch about using `setup_all` without `use_transactional_test_case`. as you can see from the first drone run, we are not properly cleaning up objects inside `setup_all` if `use_transactional_test_case` is not also specified. in that commit, I added some intentionally colliding `create` commands, and we get errors like this:
```
==ERROR["setup_all", Services::CompleteApplicationReminderTest, 188.73090645000002]
 setup_all#Services::CompleteApplicationReminderTest (188.73s)
Minitest::UnexpectedError:         ActiveRecord::RecordInvalid: Validation failed: Name has already been taken
```
plus many more errors and failures which cascade from these.

The short-term fix is to add `use_transactional_test_case` wherever we use `setup_all`, which fixes the above failures.

I generated the list of files to update with this command:
```
[14:15:22] Mac:~/src/cdo/dashboard/test (always-use-transactional-test-case-with-setup-all)$ grep -l -w setup_all **/*_test.rb | xargs grep -L use_transactional_test_case
```

## Testing story
- see drone results on individual commits for evidence that the problem exists and that this solution fixes it

## Follow-up work
- it would be nice to have a lint rule to enforce that we `use_transactional_test_case` whenever we use `setup_all`

