### PR TITLE
Add metrics for project saves and failures

### DIFF
--- a/apps/src/code-studio/initApp/project.js
+++ b/apps/src/code-studio/initApp/project.js
@@ -1144,6 +1144,10 @@ var projects = (module.exports = {
                 saveSourcesErrorCount,
                 err.message
               );
+              MetricsReporter.incrementCounter('LegacyLab.ProjectSaveFailure', [
+                {name: 'AppName', value: this.getStandaloneApp()},
+                {name: 'SaveType', value: 'sources'},
+              ]);
               if (saveSourcesErrorCount >= NUM_ERRORS_BEFORE_WARNING) {
                 header.showTryAgainDialog();
               }
@@ -1175,6 +1179,9 @@ var projects = (module.exports = {
           currentSourceVersionId = response.versionId;
           replaceCurrentSourceVersion = !forceNewVersion;
           current.migratedToS3 = true;
+          MetricsReporter.incrementCounter('LegacyLab.ProjectSaveSuccess', [
+            {name: 'AppName', value: this.getStandaloneApp()},
+          ]);
 
           // Normally, reduceChannelUpdates is false and we update the channel
           // metadata every time source code is saved. When in emergency mode,

--- a/apps/src/code-studio/initApp/project.js
+++ b/apps/src/code-studio/initApp/project.js
@@ -1179,9 +1179,6 @@ var projects = (module.exports = {
           currentSourceVersionId = response.versionId;
           replaceCurrentSourceVersion = !forceNewVersion;
           current.migratedToS3 = true;
-          MetricsReporter.incrementCounter('LegacyLab.ProjectSaveSuccess', [
-            {name: 'AppName', value: this.getStandaloneApp()},
-          ]);
 
           // Normally, reduceChannelUpdates is false and we update the channel
           // metadata every time source code is saved. When in emergency mode,
@@ -1450,6 +1447,10 @@ var projects = (module.exports = {
       if (saveChannelErrorCount >= NUM_ERRORS_BEFORE_WARNING) {
         header.showTryAgainDialog();
       }
+      MetricsReporter.incrementCounter('LegacyLab.ProjectSaveFailure', [
+        {name: 'AppName', value: this.getStandaloneApp()},
+        {name: 'SaveType', value: 'channel'},
+      ]);
       return;
     } else if (saveChannelErrorCount) {
       // If the previous errors occurred due to network problems, we may not
@@ -1478,6 +1479,9 @@ var projects = (module.exports = {
 
     current = current || {};
     Object.assign(current, data);
+    MetricsReporter.incrementCounter('LegacyLab.ProjectSaveSuccess', [
+      {name: 'AppName', value: this.getStandaloneApp()},
+    ]);
 
     if (shouldNavigate) {
       // If we are at a /projects/<appname> link, we can display the project

--- a/apps/src/lab2/projects/ProjectManager.ts
+++ b/apps/src/lab2/projects/ProjectManager.ts
@@ -502,7 +502,7 @@ export default class ProjectManager {
         } else {
           errorToReport = new Error('Unknown error occurred');
         }
-        this.onSaveFail('Error saving sources', errorToReport);
+        this.onSaveFail('Error saving sources', errorToReport, 'sources');
         return;
       }
       this.lastSource = JSON.stringify(this.sourcesToSave);
@@ -549,7 +549,7 @@ export default class ProjectManager {
       try {
         channelResponse = await this.channelsStore.save(this.channelToSave);
       } catch (error) {
-        this.onSaveFail('Error saving channel', error as Error);
+        this.onSaveFail('Error saving channel', error as Error, 'channel');
         return;
       }
       const channelSaveResponse = await channelResponse.json();
@@ -561,9 +561,10 @@ export default class ProjectManager {
     this.sourcesToSave = undefined;
     this.executeSaveSuccessListeners(this.lastChannel);
     this.initialSaveComplete = true;
+    this.metricsReporter.publishMetric('Lab2.ProjectSaveSuccess', 1, 'Count');
   }
 
-  private onSaveFail(errorMessage: string, error: Error) {
+  private onSaveFail(errorMessage: string, error: Error, type: string) {
     this.saveInProgress = false;
     this.executeSaveFailListeners(error);
     if (error.message.includes('409') || error.message.includes('401')) {
@@ -583,6 +584,12 @@ export default class ProjectManager {
       this.metricsReporter.logError(errorMessage, error, {
         message: error.message,
       });
+      this.metricsReporter.publishMetric(
+        'Lab2.ProjectSaveFailure',
+        1,
+        'Count',
+        [{name: 'SaveType', value: type}]
+      );
     }
   }
 


### PR DESCRIPTION
This adds 4 new metrics:
- Lab2.ProjectSaveFailure
- Lab2.ProjectSaveSuccess
- LegacyLab.ProjectSaveFailure
- LegacyLab.ProjectSaveSuccess

I found myself wondering whether the number of save failures we were seeing in the lab2 logs was a lot of errors or just a drop in the bucket compared to successes. Since we only log errors, we don't have a clear way of finding that information now. These metrics could also potentially be used for alerting if we wanted to know if project save error rates suddenly increased. For both labs we mark whether the failure was in updating the sources or the channel as a 'SaveType' dimension. We only log success after both the sources and channel have saved, if we are trying to save both.

## Testing story
Tested that the metrics show up as expected in the console.


## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
