### PR TITLE
Resource Panel tabs: move focus to panels when version history/AI Tutor selected

### DIFF
--- a/apps/src/lab2/views/components/Instructions/ResourcePanel/index.tsx
+++ b/apps/src/lab2/views/components/Instructions/ResourcePanel/index.tsx
@@ -139,6 +139,7 @@ const ResourcePanel: React.FC<ResourcePanelProps> = ({
   const hasAutoCollapsedNoTabs = useRef(false);
   const settingsButtonRef = useRef<HTMLDivElement | null>(null);
   const floatingPanelRef = useRef<HTMLDivElement | null>(null);
+  const tabContentRefs = useRef<{[key in Tabs]?: HTMLDivElement | null}>({});
   const isUserTeacher = useAppSelector(state => state.currentUser.isTeacher);
   const [selectedVersion, setSelectedVersion] = useState<string>('');
   const isViewingOldVersion = useAppSelector(
@@ -311,6 +312,30 @@ const ResourcePanel: React.FC<ResourcePanelProps> = ({
     // Reset current tab to instructions when switching levels or viewAsUserId.
     setCurrentTab(Tabs.Instructions);
   }, [levelId, viewAsUserId]);
+
+  // Move focus to panel content when AI Tutor or Version History tab is selected via keyboard
+  useEffect(() => {
+    if (currentTab === Tabs.AiTutor || currentTab === Tabs.VersionHistory) {
+      const panelContent = tabContentRefs.current[currentTab];
+      if (panelContent) {
+        // Use setTimeout to ensure the panel is rendered and visible before focusing
+        const timeoutId = setTimeout(() => {
+          // Find the first focusable element in the panel
+          const focusableElement = panelContent.querySelector<HTMLElement>(
+            'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+          );
+          if (focusableElement) {
+            focusableElement.focus();
+          } else {
+            // If no focusable element exists, make the panel content focusable and focus it
+            panelContent.setAttribute('tabindex', '-1');
+            panelContent.focus();
+          }
+        }, 0);
+        return () => clearTimeout(timeoutId);
+      }
+    }
+  }, [currentTab]);
 
   // Hide the page footer and extra links when the resource panel is shown, and show when unmounting.
   const {setShowExtraLinksButton} = useExtraLinksButtonContext();
@@ -534,6 +559,21 @@ const ResourcePanel: React.FC<ResourcePanelProps> = ({
                     ref={el => {
                       if (el) {
                         el.inert = tab !== currentTab;
+                        // Store ref for AI Tutor and Version History tabs
+                        if (
+                          tab === Tabs.AiTutor ||
+                          tab === Tabs.VersionHistory
+                        ) {
+                          tabContentRefs.current[tab] = el;
+                        }
+                      } else {
+                        // Clear ref when element is removed
+                        if (
+                          tab === Tabs.AiTutor ||
+                          tab === Tabs.VersionHistory
+                        ) {
+                          tabContentRefs.current[tab] = null;
+                        }
                       }
                     }}
                   >

--- a/apps/src/lab2/views/components/Instructions/ResourcePanel/index.tsx
+++ b/apps/src/lab2/views/components/Instructions/ResourcePanel/index.tsx
@@ -321,8 +321,12 @@ const ResourcePanel: React.FC<ResourcePanelProps> = ({
       if (panelContent) {
         // Use setTimeout to ensure the panel is rendered and visible before focusing.
         const timeoutId = setTimeout(() => {
-          // Find the first focusable element in the panel.
-          const focusableElement = findFirstFocusableElement(panelContent);
+          const focusableElement =
+            currentTab === Tabs.AiTutor
+              ? panelContent.querySelector<HTMLTextAreaElement>(
+                  '#uitest-chat-textarea'
+                )
+              : findFirstFocusableElement(panelContent);
           if (focusableElement) {
             focusableElement.focus();
           } else {

--- a/apps/src/lab2/views/components/Instructions/ResourcePanel/index.tsx
+++ b/apps/src/lab2/views/components/Instructions/ResourcePanel/index.tsx
@@ -26,6 +26,7 @@ import {useExtraLinksButtonContext} from '@cdo/apps/lab2/views/LabViewsRenderer'
 import {EVENTS} from '@cdo/apps/metrics/AnalyticsConstants';
 import {commonI18n} from '@cdo/apps/types/locale';
 import {getTypedKeys} from '@cdo/apps/types/utils';
+import {findFirstFocusableElement} from '@cdo/apps/util/findFirstFocusableElement';
 import {useAppSelector, useAppDispatch} from '@cdo/apps/util/reduxHooks';
 import '@cdo/apps/lab2/introjs.scss';
 
@@ -313,17 +314,15 @@ const ResourcePanel: React.FC<ResourcePanelProps> = ({
     setCurrentTab(Tabs.Instructions);
   }, [levelId, viewAsUserId]);
 
-  // Move focus to panel content when AI Tutor or Version History tab is selected via keyboard
+  // Move focus to panel content when AI Tutor or Version History tab is selected via keyboard.
   useEffect(() => {
     if (currentTab === Tabs.AiTutor || currentTab === Tabs.VersionHistory) {
       const panelContent = tabContentRefs.current[currentTab];
       if (panelContent) {
-        // Use setTimeout to ensure the panel is rendered and visible before focusing
+        // Use setTimeout to ensure the panel is rendered and visible before focusing.
         const timeoutId = setTimeout(() => {
-          // Find the first focusable element in the panel
-          const focusableElement = panelContent.querySelector<HTMLElement>(
-            'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
-          );
+          // Find the first focusable element in the panel.
+          const focusableElement = findFirstFocusableElement(panelContent);
           if (focusableElement) {
             focusableElement.focus();
           } else {
@@ -559,7 +558,7 @@ const ResourcePanel: React.FC<ResourcePanelProps> = ({
                     ref={el => {
                       if (el) {
                         el.inert = tab !== currentTab;
-                        // Store ref for AI Tutor and Version History tabs
+                        // Store ref for AI Tutor and Version History tabs.
                         if (
                           tab === Tabs.AiTutor ||
                           tab === Tabs.VersionHistory
@@ -567,7 +566,7 @@ const ResourcePanel: React.FC<ResourcePanelProps> = ({
                           tabContentRefs.current[tab] = el;
                         }
                       } else {
-                        // Clear ref when element is removed
+                        // Clear ref when element is removed.
                         if (
                           tab === Tabs.AiTutor ||
                           tab === Tabs.VersionHistory

--- a/apps/src/util/findFirstFocusableElement.ts
+++ b/apps/src/util/findFirstFocusableElement.ts
@@ -1,0 +1,12 @@
+/**
+ * Finds the first focusable element within a container.
+ * @param container - The element to search within
+ * @returns The first focusable element, or null if none found
+ */
+export const findFirstFocusableElement = (
+  container: HTMLElement
+): HTMLElement | null => {
+  return container.querySelector<HTMLElement>(
+    'a, button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+  );
+};


### PR DESCRIPTION
This PR improves keyboard navigation of resource panel tabs (Version History and AI Tutor) by moving the focus to a panel element after the tab is selected (instead of having focus stay on tab):
- AI Tutor -> focus moves to chat message editor
- Version History -> focus moves to first version in list

## Before update

https://github.com/user-attachments/assets/23337bf2-8978-4d88-9a8f-f54d91a88022



## After update

https://github.com/user-attachments/assets/a26e6942-c2d9-4085-bbcd-fff5b9107f8f





## Warning!!

We have entered Pixel Lock for Hour of AI! All merges to the `staging` branch from Dec 2 through Dec 12 must go through live change review and be deemed critical for supporting the Hour of AI. External contributions will not be accepted at this time.

For non-critical changes, please change your base to `staging-next` and delete this warning. We will merge `staging-next` into `staging` on Dec 15, 2025.

<!-- end warning -->


<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->


## Links
<!--  Links to relevant external resources.
      - spec docs, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- Jira: https://codedotorg.atlassian.net/browse/AFL-397

## Testing story
<!--  Does your change include appropriate tests?
      - If so, please describe how the tests included in this PR are sufficient.
      - If not, please explain why this change does not need to be tested. -->

Tested locally on Web Lab 2 levels.

## Deployment strategy
<!--  Any special steps required to deploy this, besides merging?
      - Are there database migrations or manual steps?
      - Does this require coordination with other teams or systems? -->



## Follow-up work
<!--  List any clean-up or technical debt that will be addressed in future work.
      - Include Jira links where applicable.
      - Are there any known limitations or improvements planned? -->



## Privacy
<!--  How does this change impact Student & Teacher privacy?
      - Does this collect, use, share, or modify PII, either new or existing? -->



## Security
<!--  How does this change impact our security surface-area?
      - Do API's touched have the right auth?
      - Do infra changes impact our attack surface or encryption?
-->



## Caching
<!--  How does this change impact caching behavior?
      - Are cache keys or invalidation strategies affected?
      - Will this require cache warming or invalidation after deployment? -->



## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
