### PR TITLE
Use Consistent Volume Size Across All Prod Instances (again)

### DIFF
--- a/aws/cloudformation/cloud_formation_stack.yml.erb
+++ b/aws/cloudformation/cloud_formation_stack.yml.erb
@@ -302,7 +302,7 @@ Resources:
   frontend_availability_zones: frontend_availability_zones,
   frontend_policies: [{Ref: 'CDOPolicy'}, {'Fn::ImportValue': 'IAM-SessionPermissions'}],
   frontend_properties: {TargetGroupARNs: [Ref: 'ALBTargetGroup']},
-  frontend_volume_size: 64,
+  frontend_volume_size: 128,
   ami_timeout: 'PT120M',
   build_ami: erb_file(BOOTSTRAP_CHEF,
     resource_id: "AMICreate#{commit_hash}",

--- a/aws/cloudformation/components/ami.yml.erb
+++ b/aws/cloudformation/components/ami.yml.erb
@@ -182,7 +182,7 @@ frontend_device_name ||= '/dev/sda1'
         BlockDeviceMappings:
           - DeviceName: <%=frontend_device_name%>
             Ebs:
-              VolumeSize: <%=frontend_volume_size * 2%> # Double volume size to leave room for logs written to disk
+              VolumeSize: <%=frontend_volume_size%>
               VolumeType: gp3
         TagSpecifications:
           - ResourceType: instance


### PR DESCRIPTION
Yet another attempt at upsizing the AMI Builder! See https://github.com/code-dot-org/code-dot-org/pull/69320 for the previous one.

The last attempt was successful in the upsizing, but revealed an existing unrelated issue in the stack which forced us to revert the attempt. Now that that issue has been resolved, we're back to try the upsize again!

See https://github.com/code-dot-org/code-dot-org/pull/69138 for a summary of our deployment plan.