### PR TITLE
Codebridge: separate page not found and preview empty views

### DIFF
--- a/apps/src/codebridge/FileBrowser/styles/filebrowser.module.scss
+++ b/apps/src/codebridge/FileBrowser/styles/filebrowser.module.scss
@@ -12,6 +12,11 @@
   height: 100%;
   background-color: var(--background-neutral-secondary);
   border-inline-end: variables.$default-border;
+
+  // Override the background color of any child divs
+  & > div {
+    background-color: var(--background-neutral-secondary);
+  }
 }
 
 .row {

--- a/apps/src/codebridge/FilePreview/HTMLPreview.tsx
+++ b/apps/src/codebridge/FilePreview/HTMLPreview.tsx
@@ -22,6 +22,7 @@ import {
   DEFAULT_START_HTML_FILE,
 } from './constants';
 import {HTMLPreviewHeader} from './HTMLPreviewHeader';
+import PreviewEmptyState from './PreviewEmptyState';
 import PreviewStopped from './PreviewStopped';
 
 import moduleStyles from './styles/html-preview.module.scss';
@@ -61,6 +62,11 @@ export const HTMLPreview: React.FC = () => {
     state =>
       state.lab2Project.projectSources?.source as MultiFileSource | undefined
   );
+
+  const emptyProject =
+    !source ||
+    (Object.keys(source.files).length === 0 &&
+      Object.keys(source.folders).length === 0);
 
   const aiFilePathToPreview = useAppSelector(
     state => state.weblab2.aiFilePathToPreview
@@ -222,6 +228,13 @@ export const HTMLPreview: React.FC = () => {
       }
       if (event.data.type === IframeMessageType.IFRAME_READY) {
         setIsIframeLoaded(true);
+        // Send the source immediately when iframe is ready
+        if (debouncedSource) {
+          iframeRef.current?.contentWindow?.postMessage(
+            {type: IframeMessageType.SET_SOURCE, source: debouncedSource},
+            previewUrl
+          );
+        }
         iframeRef.current?.contentWindow?.postMessage(
           {type: IframeMessageType.CHANGE_FILE_URL_BAR, fileName: currentFile},
           previewUrl
@@ -242,7 +255,13 @@ export const HTMLPreview: React.FC = () => {
 
     window.addEventListener('message', handleMessage);
     return () => window.removeEventListener('message', handleMessage);
-  }, [previewUrl, currentFile, navigationHistory, navigationHistoryIndex]);
+  }, [
+    previewUrl,
+    currentFile,
+    navigationHistory,
+    navigationHistoryIndex,
+    debouncedSource,
+  ]);
 
   useEffect(() => {
     iframeRef.current?.contentWindow?.postMessage(
@@ -347,7 +366,9 @@ export const HTMLPreview: React.FC = () => {
           onStopPreview={onStopPreview}
           isStopEnabled={!isStopped}
         />
-        {isStopped ? (
+        {emptyProject ? (
+          <PreviewEmptyState />
+        ) : isStopped ? (
           <PreviewStopped onReload={onReloadPreview} />
         ) : (
           /* This iframe points to the environment-specific version of preview.codeprojects.org. That url will eventually

--- a/apps/src/codebridge/FilePreview/HTMLPreview.tsx
+++ b/apps/src/codebridge/FilePreview/HTMLPreview.tsx
@@ -63,7 +63,7 @@ export const HTMLPreview: React.FC = () => {
       state.lab2Project.projectSources?.source as MultiFileSource | undefined
   );
 
-  const emptyProject =
+  const isEmptyProject =
     !source ||
     (Object.keys(source.files).length === 0 &&
       Object.keys(source.folders).length === 0);
@@ -366,7 +366,7 @@ export const HTMLPreview: React.FC = () => {
           onStopPreview={onStopPreview}
           isStopEnabled={!isStopped}
         />
-        {emptyProject ? (
+        {isEmptyProject ? (
           <PreviewEmptyState />
         ) : isStopped ? (
           <PreviewStopped onReload={onReloadPreview} />

--- a/apps/src/codebridge/FilePreview/InnerHTMLPreview.tsx
+++ b/apps/src/codebridge/FilePreview/InnerHTMLPreview.tsx
@@ -13,7 +13,6 @@ import {
   updateLinksToNonHtmlFiles,
 } from './htmlParsingHelpers';
 import PageNotFound from './PageNotFound';
-import PreviewEmptyState from './PreviewEmptyState';
 
 import moduleStyles from './styles/inner-html-preview.module.scss';
 const NOT_FOUND_FILE = 'NOT_FOUND';
@@ -173,11 +172,9 @@ const InnerHTMLPreview = () => {
     }
   }, [parentOrigin, source]);
 
-  const projectHasFiles = Object.keys(filesToBlobs).length > 0;
-
   const getPreview = useCallback(() => {
     if (blobUrl === NOT_FOUND_FILE) {
-      return projectHasFiles ? <PageNotFound /> : <PreviewEmptyState />;
+      return <PageNotFound />;
     } else if (blobUrl) {
       return (
         <iframe
@@ -198,7 +195,7 @@ const InnerHTMLPreview = () => {
         </div>
       );
     }
-  }, [blobUrl, allowScripts, projectHasFiles]);
+  }, [blobUrl, allowScripts]);
 
   return getPreview();
 };

--- a/apps/src/codebridge/FilePreview/InnerHTMLPreview.tsx
+++ b/apps/src/codebridge/FilePreview/InnerHTMLPreview.tsx
@@ -13,6 +13,7 @@ import {
   updateLinksToNonHtmlFiles,
 } from './htmlParsingHelpers';
 import PageNotFound from './PageNotFound';
+import PreviewEmptyState from './PreviewEmptyState';
 
 import moduleStyles from './styles/inner-html-preview.module.scss';
 const NOT_FOUND_FILE = 'NOT_FOUND';
@@ -172,9 +173,11 @@ const InnerHTMLPreview = () => {
     }
   }, [parentOrigin, source]);
 
+  const projectHasFiles = Object.keys(filesToBlobs).length > 0;
+
   const getPreview = useCallback(() => {
     if (blobUrl === NOT_FOUND_FILE) {
-      return <PageNotFound />;
+      return projectHasFiles ? <PageNotFound /> : <PreviewEmptyState />;
     } else if (blobUrl) {
       return (
         <iframe
@@ -195,7 +198,7 @@ const InnerHTMLPreview = () => {
         </div>
       );
     }
-  }, [blobUrl, allowScripts]);
+  }, [blobUrl, allowScripts, projectHasFiles]);
 
   return getPreview();
 };

--- a/apps/src/codebridge/FilePreview/PageNotFound.tsx
+++ b/apps/src/codebridge/FilePreview/PageNotFound.tsx
@@ -11,7 +11,7 @@ const PageNotFound = () => {
       <CodebridgeEmptyState
         imageProps={{src: pageNotFoundImage}}
         title="Page not found"
-        description="The file you're trying to preview doesn't exist. Check the file name or open a different page."
+        description="The page you're trying to preview doesn't exist."
       />
     </div>
   );

--- a/apps/src/codebridge/FilePreview/PageNotFound.tsx
+++ b/apps/src/codebridge/FilePreview/PageNotFound.tsx
@@ -1,17 +1,17 @@
 import {CodebridgeEmptyState} from '@codebridge/components/CodebridgeEmptyState';
 import React from 'react';
 
-import emptyPreviewPlaceholderImage from '@cdo/apps/codebridge/images/empty-preview-placeholder.svg';
+import pageNotFoundImage from '@cdo/apps/codebridge/images/page-not-found.png';
 
-import moduleStyles from './styles/page-not-found.module.scss';
+import moduleStyles from './styles/inner-html-preview.module.scss';
 
 const PageNotFound = () => {
   return (
     <div className={moduleStyles.placeholderContainer}>
       <CodebridgeEmptyState
-        imageProps={{src: emptyPreviewPlaceholderImage}}
-        title="Nothing to preview"
-        description="Your project preview will appear here once you've created or opened a page with content."
+        imageProps={{src: pageNotFoundImage}}
+        title="Page not found"
+        description="The file you're trying to preview doesn't exist. Check the file name or open a different page."
       />
     </div>
   );

--- a/apps/src/codebridge/FilePreview/PreviewEmptyState.tsx
+++ b/apps/src/codebridge/FilePreview/PreviewEmptyState.tsx
@@ -1,0 +1,20 @@
+import {CodebridgeEmptyState} from '@codebridge/components/CodebridgeEmptyState';
+import React from 'react';
+
+import emptyPreviewPlaceholderImage from '@cdo/apps/codebridge/images/empty-preview-placeholder.svg';
+
+import moduleStyles from './styles/inner-html-preview.module.scss';
+
+const PreviewEmptyState = () => {
+  return (
+    <div className={moduleStyles.placeholderContainer}>
+      <CodebridgeEmptyState
+        imageProps={{src: emptyPreviewPlaceholderImage}}
+        title="Nothing to preview"
+        description="Your project preview will appear here once you've created or opened a page with content."
+      />
+    </div>
+  );
+};
+
+export default PreviewEmptyState;

--- a/apps/src/codebridge/FilePreview/PreviewEmptyState.tsx
+++ b/apps/src/codebridge/FilePreview/PreviewEmptyState.tsx
@@ -3,17 +3,13 @@ import React from 'react';
 
 import emptyPreviewPlaceholderImage from '@cdo/apps/codebridge/images/empty-preview-placeholder.svg';
 
-import moduleStyles from './styles/inner-html-preview.module.scss';
-
 const PreviewEmptyState = () => {
   return (
-    <div className={moduleStyles.placeholderContainer}>
-      <CodebridgeEmptyState
-        imageProps={{src: emptyPreviewPlaceholderImage}}
-        title="Nothing to preview"
-        description="Your project preview will appear here once you've created or opened a page with content."
-      />
-    </div>
+    <CodebridgeEmptyState
+      imageProps={{src: emptyPreviewPlaceholderImage}}
+      title="Nothing to preview"
+      description="Your project preview will appear here once you've created or opened a page with content."
+    />
   );
 };
 

--- a/apps/src/codebridge/FilePreview/styles/inner-html-preview.module.scss
+++ b/apps/src/codebridge/FilePreview/styles/inner-html-preview.module.scss
@@ -8,3 +8,9 @@
   border: none;
   box-sizing: border-box;
 }
+
+// Set styles for the PageNotFound and PreviewEmptyState components
+.placeholderContainer {
+  height: 100vh;
+  background-color: white;
+}

--- a/apps/src/codebridge/FilePreview/styles/inner-html-preview.module.scss
+++ b/apps/src/codebridge/FilePreview/styles/inner-html-preview.module.scss
@@ -9,7 +9,7 @@
   box-sizing: border-box;
 }
 
-// Styles for the PageNotFound and PreviewEmptyState components
+// Styles for the PageNotFound component
 .placeholderContainer {
   height: 100vh;
   background-color: white;

--- a/apps/src/codebridge/FilePreview/styles/inner-html-preview.module.scss
+++ b/apps/src/codebridge/FilePreview/styles/inner-html-preview.module.scss
@@ -9,7 +9,7 @@
   box-sizing: border-box;
 }
 
-// Set styles for the PageNotFound and PreviewEmptyState components
+// Styles for the PageNotFound and PreviewEmptyState components
 .placeholderContainer {
   height: 100vh;
   background-color: white;

--- a/apps/src/codebridge/FilePreview/styles/page-not-found.module.scss
+++ b/apps/src/codebridge/FilePreview/styles/page-not-found.module.scss
@@ -1,4 +1,0 @@
-.placeholderContainer {
-  height: 100vh;
-  background-color: white;
-}

--- a/apps/src/codebridge/components/CodebridgeEmptyState.module.scss
+++ b/apps/src/codebridge/components/CodebridgeEmptyState.module.scss
@@ -16,6 +16,11 @@
     max-height: 8.5rem;
     height: auto;
     margin-bottom: 1rem;
+
+    // Prevent image from getting cut off in Safari
+    img {
+      object-fit: contain;
+    }
   }
 
   .textContainer {

--- a/apps/src/codebridge/images/page-not-found.png
+++ b/apps/src/codebridge/images/page-not-found.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4ef9830f22bb38a9cc6bd88ef32a1d5522c7d62888e16ac1612361e12e70218b
+size 51127


### PR DESCRIPTION
Separates the page not found 404 and preview empty states in the preview panel in Codebridge. 

## Links
Jira ticket: [AFL-351](https://codedotorg.atlassian.net/browse/AFL-351)
Related PR comment: https://github.com/code-dot-org/code-dot-org/pull/69348#issuecomment-3498744934

## Testing story
Tested locally across browsers

----

## Web Lab 2


https://github.com/user-attachments/assets/d95f8bfe-2eb2-4226-843e-8486fa07aae7



## Local 404

<img width="1378" height="921" alt="Screenshot 2025-12-12 at 1 17 15 PM" src="https://github.com/user-attachments/assets/5199d463-d349-4b2a-8e2b-8aedc107abb9" />



