### PR TITLE
Increase Database Migration Service MySQL to Redshift Export Timeout

### DIFF
--- a/bin/cron/export_mysql_database_to_redshift
+++ b/bin/cron/export_mysql_database_to_redshift
@@ -11,8 +11,8 @@ require 'cdo/redshift_import'
 
 # Delay between each check on task status.
 TASK_STATUS_DELAY = 10.minutes
-# As of early 2020, the Task that exports `user_levels` takes about 10 hours to complete and is the longest daily task.
-DAILY_TASK_MAX_EXECUTION_TIME = 16.hours
+# As of early 2025, the Task that exports `user_levels` takes about 18.5 hours to complete and is the longest daily task.
+DAILY_TASK_MAX_EXECUTION_TIME = 19.hours
 # As of early 2020, the Task that exports 'level_sources' takes about 30 hours to complete.
 WEEKLY_TASK_MAX_EXECUTION_TIME = 40.hours
 # We want to notify the RED team about the export status.


### PR DESCRIPTION
The `user_levels` table now takes about 18.5 hours to export from MySQL to Redshift. As a very short term workaround, increase the timeout that our export cronjob waits for the Database Migration Service (DMS) Replication Task to complete to 19 hours.

We were holding off on this until we resolved the issue with History Length increasing on the production Aurora cluster during exports, but that was resolved with #69998 

## Testing story




## Deployment strategy



## Follow-up work

- Switch to streaming data from MySQL to Redshift using Change Data Capture in the DMS once we re-enable binary logging in production
- Switch to Aurora Redshift Zero-ETL Integration


## Privacy
<!--  How does this change impact Student & Teacher privacy?
      - Does this collect, use, share, or modify PII, either new or existing? -->



## Security
<!--  How does this change impact our security surface-area?
      - Do API's touched have the right auth?
      - Do infra changes impact our attack surface or encryption?
-->



## Caching
<!--  How does this change impact caching behavior?
      - Are cache keys or invalidation strategies affected?
      - Will this require cache warming or invalidation after deployment? -->



## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
