### PR TITLE
First pass at fixes to AI TA Redux

### DIFF
--- a/apps/src/aiDifferentiation/AiDiffChat.tsx
+++ b/apps/src/aiDifferentiation/AiDiffChat.tsx
@@ -23,7 +23,7 @@ import AiDiffBotMessageFooter from './AiDiffBotMessageFooter';
 import AiDiffChatFooter from './AiDiffChatFooter';
 import AiDiffChatHeader from './AiDiffChatHeader';
 import AiDiffSuggestedPrompts from './AiDiffSuggestedPrompts';
-import {defaultThreadTitle} from './constants';
+import {DEFAULT_THREAD_TITLE} from './constants';
 import {
   contextPrompts,
   APCSP_DUMMY_CREATE,
@@ -96,7 +96,7 @@ interface AiDiffChatProps {
 const AiDiffChat: React.FC<AiDiffChatProps> = ({
   context,
   threadMessages = [],
-  threadTitle = defaultThreadTitle,
+  threadTitle = DEFAULT_THREAD_TITLE,
   setThreadTitle,
   scriptName,
   chatResponseCallback = () => {},
@@ -274,7 +274,7 @@ const AiDiffChat: React.FC<AiDiffChatProps> = ({
 
       if (
         setThreadTitle &&
-        (!threadTitle || threadTitle === defaultThreadTitle)
+        (!threadTitle || threadTitle === DEFAULT_THREAD_TITLE)
       ) {
         setThreadTitle(message.slice(0, 100));
       }
@@ -290,7 +290,7 @@ const AiDiffChat: React.FC<AiDiffChatProps> = ({
     (prompt: ChatPrompt) => {
       if (
         setThreadTitle &&
-        (!threadTitle || threadTitle === defaultThreadTitle)
+        (!threadTitle || threadTitle === DEFAULT_THREAD_TITLE)
       ) {
         setThreadTitle(prompt.label);
       }

--- a/apps/src/aiDifferentiation/AiDiffWorkspace.tsx
+++ b/apps/src/aiDifferentiation/AiDiffWorkspace.tsx
@@ -7,7 +7,7 @@ import HttpClient from '../util/HttpClient';
 
 import AiDiffChat from './AiDiffChat';
 import AiDiffSidebar from './AiDiffSidebar';
-import {defaultThreadTitle} from './constants';
+import {DEFAULT_THREAD_TITLE} from './constants';
 import AiDiffNotificationList from './notifications/AiDiffNotificationList';
 import {
   ChatItem,
@@ -38,7 +38,7 @@ const AiDiffWorkSpace: React.FC<AiDiffWorkSpaceProps> = ({
   const [threads, setThreads] = useState<ChatThread[]>();
   const [threadMessages, setThreadMessages] = useState<ChatItem[]>();
   const [threadId, setThreadId] = useState<number>(0);
-  const [threadTitle, setThreadTitle] = useState<string>(defaultThreadTitle);
+  const [threadTitle, setThreadTitle] = useState<string>(DEFAULT_THREAD_TITLE);
   const [keyId, setKeyId] = useState<number>(0);
   const [initialThreadPrompt, setInitialThreadPrompt] =
     useState<ChatPrompt | null>(null);
@@ -81,7 +81,7 @@ const AiDiffWorkSpace: React.FC<AiDiffWorkSpaceProps> = ({
       if (thread === 0) {
         setThreadMessages([]);
         setThreadId(thread);
-        setThreadTitle(defaultThreadTitle);
+        setThreadTitle(DEFAULT_THREAD_TITLE);
         // changing the keyId resets the component state.
         // if key is already 0 (i.e. starting a new thread from a new thread)
         // then we need to alternate to a different key value to reset state

--- a/apps/src/aiDifferentiation/constants.ts
+++ b/apps/src/aiDifferentiation/constants.ts
@@ -1,1 +1,22 @@
-export const defaultThreadTitle = 'Unnamed chat';
+import {SUGGESTED_PROMPTS_FOR_SELECTION} from './predefinedPrompts';
+
+export const DEFAULT_THREAD_TITLE = 'Unnamed chat';
+
+// Optional way to delineate the type/usage of a thread to tailor what we want, such as:
+// - Do or don't show suggested prompts
+// - Start with a more specific initial message
+export type ThreadTypeFields = {
+  initialMessage: string;
+  showSuggestedPrompts: boolean;
+};
+export const THREAD_TYPES: {[threadType: string]: ThreadTypeFields} = {
+  default: {
+    initialMessage: SUGGESTED_PROMPTS_FOR_SELECTION['default'].initialMessage,
+    showSuggestedPrompts: true,
+  },
+  lessonSummaryHelp: {
+    initialMessage:
+      "Let's work together to prep for this lesson! What would you like help with?",
+    showSuggestedPrompts: false,
+  },
+};

--- a/apps/src/aichat/redux/slice.ts
+++ b/apps/src/aichat/redux/slice.ts
@@ -1,5 +1,12 @@
 import {createSlice, PayloadAction} from '@reduxjs/toolkit';
 
+import {
+  DEFAULT_THREAD_TITLE,
+  ThreadTypeFields,
+  THREAD_TYPES,
+} from '@cdo/apps/aiDifferentiation/constants';
+import {SUGGESTED_PROMPTS_FOR_SELECTION} from '@cdo/apps/aiDifferentiation/predefinedPrompts';
+import {ChatItem, ChatPrompt} from '@cdo/apps/aiDifferentiation/types';
 import {registerReducers} from '@cdo/apps/redux';
 
 import {
@@ -37,7 +44,16 @@ import {validateModelId} from '../views/modelCustomization/utils';
 import {AichatState} from './state';
 
 const initialState: AichatState = {
+  chatIsOpen: false,
   clientType: undefined,
+  threadId: 0,
+  threadTitle: DEFAULT_THREAD_TITLE,
+  threadType: THREAD_TYPES.default,
+  initialThreadPrompt: null,
+  selectedPrompt: null,
+  threadMessages: [],
+  threadKeyId: 0,
+  initialChatMessage: SUGGESTED_PROMPTS_FOR_SELECTION['default'].initialMessage,
   chatEventsPast: [],
   chatEventsCurrent: [],
   studentChatHistory: [],
@@ -65,6 +81,9 @@ const aichatSlice = createSlice({
   name: 'aichat',
   initialState,
   reducers: {
+    setChatIsOpen: (state, action: PayloadAction<boolean>) => {
+      state.chatIsOpen = action.payload;
+    },
     addEventToChatEventsCurrent: (state, action: PayloadAction<ChatEvent>) => {
       state.chatEventsCurrent.push(action.payload);
     },
@@ -112,6 +131,30 @@ const aichatSlice = createSlice({
     setClientType(state, action: PayloadAction<AiChatClientType>) {
       state.clientType = action.payload;
     },
+    setThreadId(state, action: PayloadAction<number>) {
+      state.threadId = action.payload;
+    },
+    setThreadTitle(state, action: PayloadAction<string>) {
+      state.threadTitle = action.payload;
+    },
+    setThreadType(state, action: PayloadAction<ThreadTypeFields>) {
+      state.threadType = action.payload;
+    },
+    setInitialThreadPrompt(state, action: PayloadAction<ChatPrompt | null>) {
+      state.initialThreadPrompt = action.payload;
+    },
+    setSelectedPrompt(state, action: PayloadAction<ChatPrompt | null>) {
+      state.selectedPrompt = action.payload;
+    },
+    setThreadMessages(state, action: PayloadAction<ChatItem[]>) {
+      state.threadMessages = action.payload;
+    },
+    addThreadMessage: (state, action: PayloadAction<ChatItem>) => {
+      state.threadMessages.push(action.payload);
+    },
+    setThreadKeyId(state, action: PayloadAction<number>) {
+      state.threadKeyId = action.payload;
+    },
     removeUpdateMessage: (state, action: PayloadAction<number>) => {
       const modelUpdateMessageInfo = getUpdateMessageLocation(
         action.payload,
@@ -158,6 +201,9 @@ const aichatSlice = createSlice({
     setNewChatSession: state => {
       state.chatEventsPast.push(...state.chatEventsCurrent);
       state.chatEventsCurrent = [];
+    },
+    setInitialChatMessage(state, action: PayloadAction<string>) {
+      state.initialChatMessage = action.payload;
     },
     setShowModalType: (
       state,
@@ -390,7 +436,10 @@ const getUpdateMessageLocation = (removeId: number, state: AichatState) => {
 
 registerReducers({aichat: aichatSlice.reducer});
 
+export const aichatReducer = aichatSlice.reducer;
+
 export const {
+  setChatIsOpen,
   addEventToChatEventsCurrent,
   startSave,
   updateChatMessageStatus,
@@ -404,12 +453,21 @@ export const {
   setAiCustomizationProperty,
   setModelCardProperty,
   setNewChatSession,
+  setInitialChatMessage,
   setShowModalType,
   setStartingAiCustomizations,
   setStudentChatHistory,
   setOwnChatHistory,
   setUserHasAichatAccess,
   setClientType,
+  setThreadId,
+  setThreadTitle,
+  setThreadType,
+  setInitialThreadPrompt,
+  setSelectedPrompt,
+  setThreadMessages,
+  addThreadMessage,
+  setThreadKeyId,
   setViewMode,
   addStagedFile,
   stagedFileUploadFinished,

--- a/apps/src/aichat/redux/state.ts
+++ b/apps/src/aichat/redux/state.ts
@@ -1,3 +1,6 @@
+import {ThreadTypeFields} from '@cdo/apps/aiDifferentiation/constants';
+import {ChatItem, ChatPrompt} from '@cdo/apps/aiDifferentiation/types';
+
 import {ModalTypes} from '../constants';
 import {
   AiCustomizations,
@@ -14,7 +17,29 @@ import {
 } from '../types';
 
 export interface AichatState {
+  chatIsOpen: boolean;
   clientType?: AiChatClientType;
+  // Id of the current thread open
+  threadId: number;
+  // Title of the current thread open
+  threadTitle: string;
+  // Type of thread which can be used to delineate initial messages, whether to show
+  // suggested prompts, etc.
+  threadType: ThreadTypeFields;
+  // Specify prompt for a new thread
+  initialThreadPrompt: ChatPrompt | null;
+  // Selected prompt in the current thread
+  selectedPrompt: ChatPrompt | null;
+  // Chat history of the current thread
+  threadMessages: ChatItem[];
+  // This is similar to the threadId but is used slightly differently: changing the
+  // threadKeyId resets the component state. If threadKeyId is already 0 (i.e.
+  // starting a new thread from a new thread) then we need to alternate to a different
+  // key value to reset state (-1 is safe because it won't accidentally match a
+  // threadId value).
+  threadKeyId: number;
+  // AI TA's opening message for a thread
+  initialChatMessage: string;
   // Content from previous chat sessions that we track purely for visibility to the user
   // and do not send to the model as history.
   chatEventsPast: ChatEvent[];

--- a/apps/src/aichat/redux/thunks/fetchThreadMessages.ts
+++ b/apps/src/aichat/redux/thunks/fetchThreadMessages.ts
@@ -1,0 +1,110 @@
+import {createAsyncThunk} from '@reduxjs/toolkit';
+
+import {Role} from '@cdo/apps/aiComponentLibrary/chatMessage/types';
+import {
+  THREAD_TYPES,
+  ThreadTypeFields,
+  DEFAULT_THREAD_TITLE,
+} from '@cdo/apps/aiDifferentiation/constants';
+import {
+  ChatPrompt,
+  ChatThread,
+  chatThreadMessagesValidator,
+} from '@cdo/apps/aiDifferentiation/types';
+import {RootState} from '@cdo/apps/types/redux';
+import HttpClient from '@cdo/apps/util/HttpClient';
+import {AiInteractionStatus as Status} from '@cdo/generated-scripts/sharedConstants';
+
+import {
+  setThreadId,
+  setThreadTitle,
+  setThreadType,
+  setThreadMessages,
+  setThreadKeyId,
+  setInitialChatMessage,
+  setInitialThreadPrompt,
+  setSelectedPrompt,
+} from '../slice';
+
+interface FetchThreadMessagesParams {
+  thread: number;
+  threadType?: ThreadTypeFields;
+  initialThreadPrompt?: ChatPrompt;
+  suggestedPrompts?: ChatPrompt[];
+}
+
+async function asyncFetchThreadMessages(thread: number): Promise<ChatThread> {
+  const response = await HttpClient.fetchJson<ChatThread>(
+    `/aidiff_threads/${thread}`,
+    {},
+    chatThreadMessagesValidator
+  );
+  return response.value;
+}
+
+export const fetchThreadMessages = createAsyncThunk(
+  'aichat/fetchThreadMessages',
+  async (
+    {
+      thread,
+      threadType = THREAD_TYPES.default,
+      initialThreadPrompt,
+      suggestedPrompts,
+    }: FetchThreadMessagesParams,
+    thunkAPI
+  ) => {
+    const state = thunkAPI.getState() as RootState;
+    thunkAPI.dispatch(setThreadType(threadType));
+
+    if (thread === 0) {
+      thunkAPI.dispatch(setThreadId(0));
+      thunkAPI.dispatch(setThreadTitle(DEFAULT_THREAD_TITLE));
+      thunkAPI.dispatch(setInitialChatMessage(threadType.initialMessage));
+      thunkAPI.dispatch(setSelectedPrompt(null));
+
+      if (initialThreadPrompt) {
+        thunkAPI.dispatch(setInitialThreadPrompt(initialThreadPrompt));
+        thunkAPI.dispatch(
+          setThreadMessages([
+            {
+              role: Role.USER,
+              chatMessageText: initialThreadPrompt.prompt,
+              status: Status.OK,
+            },
+          ])
+        );
+      } else {
+        const initialAIMessage = {
+          role: Role.ASSISTANT,
+          chatMessageText: threadType.initialMessage,
+          status: Status.OK,
+        };
+        thunkAPI.dispatch(setInitialThreadPrompt(null));
+        thunkAPI.dispatch(
+          setThreadMessages(
+            suggestedPrompts && threadType.showSuggestedPrompts
+              ? [initialAIMessage, suggestedPrompts]
+              : [initialAIMessage]
+          )
+        );
+      }
+
+      // changing the keyId resets the component state.
+      // if key is already 0 (i.e. starting a new thread from a new thread)
+      // then we need to alternate to a different key value to reset state
+      // -1 is safe because it won't accidentally match a threadID value
+      if (state.aichat.threadKeyId === 0) {
+        thunkAPI.dispatch(setThreadKeyId(-1));
+      } else {
+        thunkAPI.dispatch(setThreadKeyId(thread));
+      }
+    } else {
+      asyncFetchThreadMessages(thread).then(response => {
+        thunkAPI.dispatch(setThreadMessages(response.messages || []));
+        thunkAPI.dispatch(setThreadId(thread));
+        thunkAPI.dispatch(setThreadTitle(response.title));
+        thunkAPI.dispatch(setThreadKeyId(thread));
+      });
+    }
+  }
+);

--- a/apps/src/aichat/redux/thunks/index.ts
+++ b/apps/src/aichat/redux/thunks/index.ts
@@ -9,3 +9,4 @@ export {sendAnalytics} from './sendAnalytics';
 export {submitChatContents} from './submitChatContents';
 export {submitTeacherFeedback} from './submitTeacherFeedback';
 export {updateAiCustomization} from './updateAiCustomization';
+export {fetchThreadMessages} from './fetchThreadMessages';


### PR DESCRIPTION
After AI TA redux updates had to be [reverted](https://github.com/code-dot-org/code-dot-org/pull/70038) when `staging-next` was merged into `staging` (with [this followup](https://github.com/code-dot-org/code-dot-org/pull/70040)), I decided to reintroduce the content in batches so it wasn't one big PR just in case another revert was necessary. This PR just adds the variables to state, constants, and adds the `fetchThreadMessages` thunk without implementing any of them. Since I didn't add any implementation (other than some updated imports), this feels like a super safe change to start with.

## Links
Revert PR this is based on: [here](https://github.com/code-dot-org/code-dot-org/pull/70038)
Fix-forward followup PR that fixed failing unit + UI tests: [here](https://github.com/code-dot-org/code-dot-org/pull/70040)
