### PR TITLE
Extra Links: fix react unmounting warning

### DIFF
--- a/apps/src/lab2/hooks/useExtraLinks.ts
+++ b/apps/src/lab2/hooks/useExtraLinks.ts
@@ -16,7 +16,8 @@ async function fetchExtraLinksData(
   permissions: string[],
   levelId: number,
   scriptLevelId?: string,
-  channelId?: string
+  channelId?: string,
+  abortSignal?: AbortSignal
 ): Promise<ExtraLinksData> {
   // Fetch level link data.
   let levelLinkData: ExtraLinksLevelData | undefined;
@@ -39,7 +40,8 @@ async function fetchExtraLinksData(
   if (permissions.includes(PERMISSIONS.PROJECT_VALIDATOR)) {
     const levelProjectDataResponse =
       await HttpClient.fetchJson<ExtraLinksProjectData>(
-        `/projects/${channelId}/extra_links`
+        `/projects/${channelId}/extra_links`,
+        {signal: abortSignal}
       );
     projectLinkData = levelProjectDataResponse.value;
   }
@@ -67,12 +69,21 @@ export const useExtraLinks = (levelId: number) => {
 
   useEffect(() => {
     setIsLoading(true);
-    fetchExtraLinksData(permissions, levelId, scriptLevelId, channelId).then(
-      data => {
+    const abortController = new AbortController();
+    fetchExtraLinksData(
+      permissions,
+      levelId,
+      scriptLevelId,
+      channelId,
+      abortController.signal
+    ).then(data => {
+      if (!abortController.signal.aborted) {
         setExtraLinksData(data);
         setIsLoading(false);
       }
-    );
+    });
+
+    return () => abortController.abort();
   }, [permissions, levelId, scriptLevelId, channelId]);
   const {levelLinkData, projectLinkData} = extraLinksData || {};
 


### PR DESCRIPTION
We would occasionally see the warning `Warning: Can't perform a React state update on an unmounted component.` when switching between levels relating to `useExtraLinks`. This adds an [AbortController](https://developer.mozilla.org/en-US/docs/Web/API/AbortController) to the useExtraLinks fetch request so we can cancel the request if the useEffect returns before the fetch request is done.

## Testing story
Tested locally that the error goes away and the extra links data still populates correctly,


## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
