### PR TITLE
shallow clone in cache-staging-build

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -76,7 +76,7 @@ steps:
       # Update the remote URL to use authentication
       - git remote set-url origin $AUTHENTICATED_GITHUB_URL
       # Checkout our source branch (=the PR)
-      - git fetch origin $DRONE_SOURCE_BRANCH:$DRONE_SOURCE_BRANCH
+      - git fetch --depth 100 origin $DRONE_SOURCE_BRANCH:$DRONE_SOURCE_BRANCH
       - git checkout $DRONE_SOURCE_BRANCH
       - git pull
       - git reset --hard $DRONE_COMMIT
@@ -197,7 +197,7 @@ steps:
       # Update the remote URL to use authentication
       - git remote set-url origin $AUTHENTICATED_GITHUB_URL
       # Checkout our source branch (the PR's branch).
-      - git fetch origin $DRONE_SOURCE_BRANCH:$DRONE_SOURCE_BRANCH
+      - git fetch --depth 100 origin $DRONE_SOURCE_BRANCH:$DRONE_SOURCE_BRANCH
       - git checkout $DRONE_SOURCE_BRANCH
       - git pull
       - git reset --hard $DRONE_COMMIT

--- a/.drone.yml
+++ b/.drone.yml
@@ -342,6 +342,6 @@ trigger:
 
 ---
 kind: signature
-hmac: 5738601f8d2ebca065b2904493e5bca64b6cda1423d7052b058f6e1c9aefd5aa
+hmac: ecaad47595e0ac8c9dcbf2fb5f565dc2fb37caf1d104acedb927fa8a7232afa6
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -320,7 +320,7 @@ steps:
       - name: mysql
         path: /var/lib/mysql
     settings:
-      filename: cache-staging-ci-build.tar.gz
+      filename: cache-staging-ci-build-PR-70052.tar.gz
       endpoint: s3://cdo-drone
       rebuild: true
       debug: true
@@ -339,6 +339,7 @@ trigger:
     - "staging-next"
   event:
     - push
+    - pull_request
 
 ---
 kind: signature

--- a/.drone.yml
+++ b/.drone.yml
@@ -43,7 +43,7 @@ steps:
   - name: get-cached-staging-build
     image: plugins/s3-cache
     settings:
-      filename: cache-staging-ci-build.tar.gz
+      filename: cache-staging-ci-build-PR-70052.tar.gz
       endpoint: s3://cdo-drone
       restore: true
       debug: true
@@ -164,7 +164,7 @@ steps:
       - name: mysql
         path: /drone/src/var/lib/mysql
     settings:
-      filename: cache-staging-ci-build.tar.gz
+      filename: cache-staging-ci-build-PR-70052.tar.gz
       endpoint: s3://cdo-drone
       restore: true
       debug: true

--- a/.drone.yml
+++ b/.drone.yml
@@ -287,7 +287,7 @@ steps:
       # DRONE_REPO_OWNER = organization name (e.g., "code-dot-org")
       # DRONE_REPO_NAME = repository name (e.g., "code-dot-org")
       - AUTHENTICATED_GITHUB_URL="https://$GITHUB_TOKEN@github.com/$DRONE_REPO_OWNER/$DRONE_REPO_NAME.git"
-      - git clone --depth 1 --single-branch --branch $DRONE_BRANCH $AUTHENTICATED_GITHUB_URL .
+      - git clone --depth 100 --branch $DRONE_BRANCH $AUTHENTICATED_GITHUB_URL .
 
   # Do all the work necessary to run UI tests so we can capture a complete
   # snapshot of the fully-built project and resulting database, but don't

--- a/.drone.yml
+++ b/.drone.yml
@@ -318,7 +318,7 @@ steps:
       - name: mysql
         path: /var/lib/mysql
     settings:
-      filename: cache-staging-ci-build.tar.gz
+      filename: cache-staging-ci-build-PR-70052.tar.gz
       endpoint: s3://cdo-drone
       rebuild: true
       debug: true
@@ -337,6 +337,7 @@ trigger:
     - "staging-next"
   event:
     - push
+    - pull_request
 
 ---
 kind: signature

--- a/.drone.yml
+++ b/.drone.yml
@@ -78,7 +78,6 @@ steps:
       # Checkout our source branch (=the PR)
       - git fetch --depth 100 origin $DRONE_SOURCE_BRANCH:$DRONE_SOURCE_BRANCH
       - git checkout $DRONE_SOURCE_BRANCH
-      - git pull
       - git reset --hard $DRONE_COMMIT
       # Fetch the target branch (which is staging for pull requests.) We need this for determining which tests to run based on changed files.
       - git remote set-branches --add origin $DRONE_TARGET_BRANCH
@@ -199,7 +198,6 @@ steps:
       # Checkout our source branch (the PR's branch).
       - git fetch --depth 100 origin $DRONE_SOURCE_BRANCH:$DRONE_SOURCE_BRANCH
       - git checkout $DRONE_SOURCE_BRANCH
-      - git pull
       - git reset --hard $DRONE_COMMIT
       # Also fetch the target branch (usually staging for pull requests). We
       # need this for determining which tests to run based on changed files.

--- a/.drone.yml
+++ b/.drone.yml
@@ -76,7 +76,7 @@ steps:
       # Update the remote URL to use authentication
       - git remote set-url origin $AUTHENTICATED_GITHUB_URL
       # Checkout our source branch (=the PR)
-      - git fetch origin $DRONE_SOURCE_BRANCH
+      - git fetch origin $DRONE_SOURCE_BRANCH:$DRONE_SOURCE_BRANCH
       - git checkout $DRONE_SOURCE_BRANCH
       - git pull
       - git reset --hard $DRONE_COMMIT
@@ -197,7 +197,7 @@ steps:
       # Update the remote URL to use authentication
       - git remote set-url origin $AUTHENTICATED_GITHUB_URL
       # Checkout our source branch (the PR's branch).
-      - git fetch origin $DRONE_SOURCE_BRANCH
+      - git fetch origin $DRONE_SOURCE_BRANCH:$DRONE_SOURCE_BRANCH
       - git checkout $DRONE_SOURCE_BRANCH
       - git pull
       - git reset --hard $DRONE_COMMIT

--- a/.drone.yml
+++ b/.drone.yml
@@ -318,7 +318,7 @@ steps:
       - name: mysql
         path: /var/lib/mysql
     settings:
-      filename: cache-staging-ci-build-PR-70052.tar.gz
+      filename: cache-staging-ci-build.tar.gz
       endpoint: s3://cdo-drone
       rebuild: true
       debug: true
@@ -337,7 +337,6 @@ trigger:
     - "staging-next"
   event:
     - push
-    - pull_request
 
 ---
 kind: signature

--- a/.drone.yml
+++ b/.drone.yml
@@ -343,6 +343,6 @@ trigger:
 
 ---
 kind: signature
-hmac: 8380ec279dc40128beca1b341a9fff3212255c2a343d9fed59c9c839ab095669
+hmac: 5738601f8d2ebca065b2904493e5bca64b6cda1423d7052b058f6e1c9aefd5aa
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -340,6 +340,6 @@ trigger:
 
 ---
 kind: signature
-hmac: ecaad47595e0ac8c9dcbf2fb5f565dc2fb37caf1d104acedb927fa8a7232afa6
+hmac: 1896ba1c9208b25359eebcd0ad472ed37b2efeb3b96a9801923723e5d0b7b568
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -320,7 +320,7 @@ steps:
       - name: mysql
         path: /var/lib/mysql
     settings:
-      filename: cache-staging-ci-build-PR-70052.tar.gz
+      filename: cache-staging-ci-build.tar.gz
       endpoint: s3://cdo-drone
       rebuild: true
       debug: true
@@ -339,7 +339,6 @@ trigger:
     - "staging-next"
   event:
     - push
-    - pull_request
 
 ---
 kind: signature

--- a/.drone.yml
+++ b/.drone.yml
@@ -289,7 +289,7 @@ steps:
       # DRONE_REPO_OWNER = organization name (e.g., "code-dot-org")
       # DRONE_REPO_NAME = repository name (e.g., "code-dot-org")
       - AUTHENTICATED_GITHUB_URL="https://$GITHUB_TOKEN@github.com/$DRONE_REPO_OWNER/$DRONE_REPO_NAME.git"
-      - git clone --branch $DRONE_BRANCH $AUTHENTICATED_GITHUB_URL .
+      - git clone --depth 1 --single-branch --branch $DRONE_BRANCH $AUTHENTICATED_GITHUB_URL .
 
   # Do all the work necessary to run UI tests so we can capture a complete
   # snapshot of the fully-built project and resulting database, but don't


### PR DESCRIPTION
- cache-staging-build pipeline
  - clone step runs 2 min faster
  - cache-staging-ci-build upload runs 1 min faster
- s3
  - tgz file is 2.3GB smaller
- unit / ui pipeline
  - get-cached-staging-build download is 20 sec faster, but
  - clone step is 20 sec slower 🤷 
  - .git dir is 2GB smaller

## Testing story
<!--  Does your change include appropriate tests?
      - If so, please describe how the tests included in this PR are sufficient.
      - If not, please explain why this change does not need to be tested. -->



## Deployment strategy
<!--  Any special steps required to deploy this, besides merging?
      - Are there database migrations or manual steps?
      - Does this require coordination with other teams or systems? -->



## Follow-up work
<!--  List any clean-up or technical debt that will be addressed in future work.
      - Include Jira links where applicable.
      - Are there any known limitations or improvements planned? -->

