### PR TITLE
Web Lab 2: update outline on AI Tutor files in accept/reject flow

### DIFF
--- a/apps/src/codebridge/FileBrowser/styles/filebrowser.module.scss
+++ b/apps/src/codebridge/FileBrowser/styles/filebrowser.module.scss
@@ -27,13 +27,19 @@
   font-size: 14px;
   min-height: 24px;
   margin-inline: 0.375rem;
+  margin-bottom: 2px;
   padding-block: 0.125rem;
   transition: all 0.2s ease-in-out;
 
   &.aiTutorVersion {
-    border-radius: var(--border-radius-br-s, 4px);
-    border: 1px solid var(--borders-brand-aqua-primary);
+    border-radius: 0.25rem;
+    outline: 1px solid var(--borders-brand-aqua-primary);
+    outline-offset: -1px;
     background: var(--background-brand-aqua-extra-light);
+
+    i {
+      color: var(--text-neutral-primary);
+    }
 
     &:hover:not(.dragging) {
       background-color: var(--background-brand-aqua-light);

--- a/apps/src/codebridge/FileTabs/styles/fileTabs.module.scss
+++ b/apps/src/codebridge/FileTabs/styles/fileTabs.module.scss
@@ -18,6 +18,7 @@
     outline: var(--borders-brand-teal-primary) solid 2px;
     outline-offset: 2px;
     border-radius: variables.$default-border-radius;
+    z-index: 10; // Ensure outline is visible above outline in aiTutorVersionActive
   }
 }
 
@@ -66,6 +67,7 @@
 
 .aiTutorVersionActive {
   background-color: var(--background-brand-aqua-primary);
+  outline: 1px solid transparent;
 
   p,
   i {
@@ -75,7 +77,8 @@
 
 .aiTutorVersionInactive {
   background-color: var(--background-brand-aqua-extra-light);
-  border: 1px solid var(--borders-brand-aqua-primary);
+  outline: 1px solid var(--borders-brand-aqua-primary);
+  outline-offset: -1px;
 
   p,
   i {


### PR DESCRIPTION
Updates the AI Tutor generated file outlines in the accept/reject flow. This prevents shifting when selecting an existing file in the files panel. Also adds some margin in the file manager sidebar between files and changes the icon color to black.

## Links
Jira ticket: [AFL-400](https://codedotorg.atlassian.net/browse/AFL-400)

## Testing story
Tested locally across browsers

----

## Before


https://github.com/user-attachments/assets/4bec08e4-bd20-4608-b040-7818e638de16



## After


https://github.com/user-attachments/assets/1f8902f2-a9ac-4736-a578-1989288c4bc1

