### PR TITLE
Wrap choice level SublevelCard component in link for better accessibility 

### DIFF
--- a/apps/src/code-studio/components/SublevelCard.jsx
+++ b/apps/src/code-studio/components/SublevelCard.jsx
@@ -1,3 +1,4 @@
+import {Heading3} from '@code-dot-org/component-library/typography';
 import _ from 'lodash';
 import PropTypes from 'prop-types';
 import queryString from 'query-string';
@@ -92,11 +93,7 @@ export default class SublevelCard extends React.Component {
     const {isLessonExtra, sublevel} = this.props;
 
     if (isLessonExtra) {
-      return (
-        <a href={this.getSublevelUrl()}>
-          <LessonExtrasFlagIcon isPerfect={sublevel.perfect} size={30} />
-        </a>
-      );
+      return <LessonExtrasFlagIcon isPerfect={sublevel.perfect} size={30} />;
     }
 
     let mappedSublevel = sublevel;
@@ -109,7 +106,7 @@ export default class SublevelCard extends React.Component {
     return (
       <ProgressBubble
         level={mappedSublevel}
-        disabled={false}
+        disabled={true}
         hideToolTips={true}
       />
     );
@@ -119,43 +116,45 @@ export default class SublevelCard extends React.Component {
     const {sublevel} = this.props;
 
     return (
-      <div
-        key={sublevel.id}
-        style={styles.row}
-        className="uitest-bubble-choice"
-      >
-        <a href={this.getSublevelUrl()}>{this.renderThumbnail()}</a>
+      <a href={this.getSublevelUrl()}>
         <div
-          style={{
-            ...styles.column,
-            ...{width: WIDTH - (MARGIN * 2 + THUMBNAIL_IMAGE_SIZE)},
-          }}
+          key={sublevel.id}
+          style={styles.row}
+          className="uitest-bubble-choice"
         >
-          <div style={styles.bubbleAndTitle}>
-            {this.renderBubble()}
-            <a
-              href={this.getSublevelUrl()}
-              style={styles.title}
-              className="sublevel-card-title-uitest"
-            >
-              {sublevel.display_name}
-            </a>
-          </div>
-          {sublevel.description && (
-            <div
-              style={styles.description}
-              className="sublevel-card-description-uitest"
-            >
-              <SafeMarkdown markdown={sublevel.description} />
+          {this.renderThumbnail()}
+          <div
+            style={{
+              ...styles.column,
+              ...{width: WIDTH - (MARGIN * 2 + THUMBNAIL_IMAGE_SIZE)},
+            }}
+          >
+            <div style={styles.bubbleAndTitle}>
+              {this.renderBubble()}
+              <Heading3
+                className="sublevel-card-title-uitest"
+                visualAppearance="heading-xs"
+                noMargin
+              >
+                {sublevel.display_name}
+              </Heading3>
             </div>
-          )}
+            {sublevel.description && (
+              <div
+                style={styles.description}
+                className="sublevel-card-description-uitest"
+              >
+                <SafeMarkdown markdown={sublevel.description} />
+              </div>
+            )}
+          </div>
         </div>
-      </div>
+      </a>
     );
   }
 }
 
-const THUMBNAIL_IMAGE_SIZE = 200;
+const THUMBNAIL_IMAGE_SIZE = 150;
 const MARGIN = 10;
 const WIDTH = 435;
 
@@ -168,13 +167,14 @@ const styles = {
     backgroundColor: color.white,
     border: '1px solid rgb(187, 187, 187)',
     borderRadius: 2,
+    cursor: 'pointer',
   },
   thumbnail: {
     minWidth: THUMBNAIL_IMAGE_SIZE,
     width: THUMBNAIL_IMAGE_SIZE,
     height: THUMBNAIL_IMAGE_SIZE,
-    border: '1px solid rgb(187, 187, 187)',
-    borderRadius: 2,
+    padding: MARGIN,
+    borderInlineEnd: '1px solid rgb(187, 187, 187)',
   },
   placeholderThumbnail: {
     minWidth: THUMBNAIL_IMAGE_SIZE,
@@ -202,7 +202,8 @@ const styles = {
   bubbleAndTitle: {
     display: 'flex',
     flexDirection: 'row',
-    alignItems: 'flex-start',
+    alignItems: 'center',
+    gap: 10,
   },
   title: {
     minHeight: 30,
@@ -219,6 +220,8 @@ const styles = {
     alignItems: 'center',
   },
   description: {
-    marginTop: 5,
+    marginTop: 6,
+    marginInlineStart: 4,
+    color: color.black,
   },
 };

--- a/apps/test/unit/code-studio/components/SublevelCardTest.js
+++ b/apps/test/unit/code-studio/components/SublevelCardTest.js
@@ -30,7 +30,8 @@ describe('SublevelCard', () => {
   it('renders level information', () => {
     const wrapper = setUp();
     expect(DEFAULT_SUBLEVEL.display_name).toEqual(
-      wrapper.find('.sublevel-card-title-uitest').text()
+      // Filter out React wrappers to get only DOM nodes
+      wrapper.find('.sublevel-card-title-uitest').hostNodes().text()
     );
     expect(DEFAULT_SUBLEVEL.description).toEqual(
       wrapper.find('.sublevel-card-description-uitest').text()
@@ -63,7 +64,8 @@ describe('SublevelCard', () => {
     const wrapper = setUp(true);
     expect(1).toEqual(wrapper.find('LessonExtrasFlagIcon').length);
     expect(DEFAULT_SUBLEVEL.display_name).toEqual(
-      wrapper.find('.sublevel-card-title-uitest').text()
+      // Filter out React wrappers to get only DOM nodes
+      wrapper.find('.sublevel-card-title-uitest').hostNodes().text()
     );
     expect(DEFAULT_SUBLEVEL.description).toEqual(
       wrapper.find('.sublevel-card-description-uitest').text()


### PR DESCRIPTION
Wraps the SublevelCard component in a link to prevent empty tab stops. Also makes minor UI updates. 

_Note:_ adding more complicated styles like hover and focus would require a significant refactor which is out of scope.

## Links
Jira ticket: [SL-1479](https://codedotorg.atlassian.net/browse/SL-1479)

## Testing story
Tested locally across browsers and updated `SublevelCardTest.js` to account for the DSCO Heading3 component being used for the title.

----

## Before


https://github.com/user-attachments/assets/77bf20c7-86d9-4273-91f5-9f7b50e4c1d2



<img width="1782" height="806" alt="Screenshot 2025-12-16 at 1 26 49 PM" src="https://github.com/user-attachments/assets/b256b5dc-aee5-4183-910c-52d33580b440" />

## After


https://github.com/user-attachments/assets/a2565040-97ce-4766-b1d6-4bee7878f68d

<img width="1782" height="806" alt="Screenshot 2025-12-16 at 1 19 38 PM" src="https://github.com/user-attachments/assets/7402b571-c168-4368-b89f-203f44a17c85" />
