### PR TITLE
Show warning when in AI Tutor version and attempting to reload browser

### DIFF
--- a/apps/src/aiComponentLibrary/chatMessage/ChatMessage.tsx
+++ b/apps/src/aiComponentLibrary/chatMessage/ChatMessage.tsx
@@ -1,5 +1,5 @@
 import classNames from 'classnames';
-import React from 'react';
+import React, {useEffect} from 'react';
 
 import {sendAnalytics} from '@cdo/apps/aichat/redux';
 import {EVENTS} from '@cdo/apps/metrics/AnalyticsConstants';
@@ -59,6 +59,26 @@ const ChatMessage: React.FunctionComponent<ChatMessageProps> = ({
     state => state.weblab2?.aiTutorVersionFiles || []
   );
 
+  // Show browser warning when there are pending AI Tutor version changes
+  const showAiTutorVersionActions =
+    isAiTutorVersion && isLastMessage && aiTutorVersionFiles.length > 0;
+
+  useEffect(() => {
+    if (showAiTutorVersionActions) {
+      const handleBeforeUnload = (event: BeforeUnloadEvent) => {
+        event.preventDefault();
+        // Chrome requires returnValue to be set.
+        event.returnValue = '';
+      };
+
+      window.addEventListener('beforeunload', handleBeforeUnload);
+
+      return () => {
+        window.removeEventListener('beforeunload', handleBeforeUnload);
+      };
+    }
+  }, [showAiTutorVersionActions]);
+
   return (
     <div
       className={classNames(
@@ -110,11 +130,9 @@ const ChatMessage: React.FunctionComponent<ChatMessageProps> = ({
                   rehypeMap={rehypeMap}
                   openExternalLinksInNewTab
                 />
-                {isAiTutorVersion &&
-                  isLastMessage &&
-                  aiTutorVersionFiles.length > 0 && (
-                    <AiTutorVersionActions files={aiTutorVersionFiles} />
-                  )}
+                {showAiTutorVersionActions && (
+                  <AiTutorVersionActions files={aiTutorVersionFiles} />
+                )}
               </div>
             ) : (
               <p>{text}</p>

--- a/apps/src/aiComponentLibrary/chatMessage/ChatMessage.tsx
+++ b/apps/src/aiComponentLibrary/chatMessage/ChatMessage.tsx
@@ -59,10 +59,10 @@ const ChatMessage: React.FunctionComponent<ChatMessageProps> = ({
     state => state.weblab2?.aiTutorVersionFiles || []
   );
 
-  // Show browser warning when there are pending AI Tutor version changes
   const showAiTutorVersionActions =
     isAiTutorVersion && isLastMessage && aiTutorVersionFiles.length > 0;
 
+  // Show browser warning when user attempts to reload the page before accepting or rejecting AI Tutor's proposed updates.
   useEffect(() => {
     if (showAiTutorVersionActions) {
       const handleBeforeUnload = (event: BeforeUnloadEvent) => {


### PR DESCRIPTION
This PR shows the browser warning 'Reload site? Changes you made may not be saved' when a user attempts to reload browser when in AI Tutor version view, i.e. when the accept-reject flow is triggered, and the user is prompted to either accept or reject the model's updates.

## After update

https://github.com/user-attachments/assets/69bcf74a-5cd3-467c-b9c4-d29cf95b5116






## Warning!!

We have entered Pixel Lock for Hour of AI! All merges to the `staging` branch from Dec 2 through Dec 12 must go through live change review and be deemed critical for supporting the Hour of AI. External contributions will not be accepted at this time.

For non-critical changes, please change your base to `staging-next` and delete this warning. We will merge `staging-next` into `staging` on Dec 15, 2025.

<!-- end warning -->


<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->


## Links
<!--  Links to relevant external resources.
      - spec docs, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- Jira: https://codedotorg.atlassian.net/browse/AFL-403

## Testing story

Tested locally in weblab2 levels with weblab2-accept-reject flag on.


<!--  Does your change include appropriate tests?
      - If so, please describe how the tests included in this PR are sufficient.
      - If not, please explain why this change does not need to be tested. -->



## Deployment strategy
<!--  Any special steps required to deploy this, besides merging?
      - Are there database migrations or manual steps?
      - Does this require coordination with other teams or systems? -->



## Follow-up work
<!--  List any clean-up or technical debt that will be addressed in future work.
      - Include Jira links where applicable.
      - Are there any known limitations or improvements planned? -->

I noticed that the 'Continue' button is still enabled when the AI tutor's response is pending. I think we should probably disabled the 'Continue' button when waiting for the model response.

It is disabled when in AI tutor version view.


## Privacy
<!--  How does this change impact Student & Teacher privacy?
      - Does this collect, use, share, or modify PII, either new or existing? -->



## Security
<!--  How does this change impact our security surface-area?
      - Do API's touched have the right auth?
      - Do infra changes impact our attack surface or encryption?
-->



## Caching
<!--  How does this change impact caching behavior?
      - Are cache keys or invalidation strategies affected?
      - Will this require cache warming or invalidation after deployment? -->



## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
