### PR TITLE
Add check for warning email before Inactive user deletion

### DIFF
--- a/dashboard/lib/inactive_user_deleter.rb
+++ b/dashboard/lib/inactive_user_deleter.rb
@@ -59,8 +59,8 @@ class InactiveUserDeleter
       account_batch = inactive_users
       account_batch.each do |user|
         break if num_accounts_deleted >= limit
-        delete_user(user)
-        self.num_accounts_deleted += 1
+        # Only delete student accounts or teacher accounts where a deletion warning email has been sent over 30 days ago
+        delete_user(user) if user.student? || user.user_data_retention_status.deletion_warning_email_sent_at < 30.days.ago
       rescue StandardError => exception
         self.num_errors += 1
         Honeybadger.notify(exception, context: {user_id: user.id})
@@ -84,13 +84,10 @@ class InactiveUserDeleter
 
   def inactive_users
     ActiveRecord::Base.connected_to(role: :reporting) do
-      result = Queries::User::Inactive.
-        call(inactive_since: inactive_since).
-        where.not(id: processed_user_ids).
-        left_outer_joins(:user_data_retention_status)
-      users = result.where(user_type: User::TYPE_STUDENT).
-      or(result.where(user_type: User::TYPE_TEACHER).where.not(user_data_retention_status: {deletion_warning_email_sent_at: nil}))
-      users.limit(BATCH_SIZE)
+      Queries::User::Inactive.
+      call(inactive_since: inactive_since).
+      where.not(id: processed_user_ids).
+      limit(BATCH_SIZE)
     end
   end
 
@@ -111,6 +108,7 @@ class InactiveUserDeleter
       log_message("Deleting inactive user (id=#{user.id})")
       user.destroy!
     end
+    self.num_accounts_deleted += 1
   end
 
   private def upload_metrics

--- a/dashboard/lib/inactive_user_deleter.rb
+++ b/dashboard/lib/inactive_user_deleter.rb
@@ -24,6 +24,7 @@ class InactiveUserDeleter
   ACCOUNT_DELETION_LIMIT = 8_000
   BATCH_SIZE = 1_000
   INACTIVE_USER_TTL = 42.months
+  DELETION_WARNING_GRACE_PERIOD = 30.days
 
   # @param dry_run [Boolean] If true, no accounts will actually be deleted.
   # @param inactive_since [Time] The time before which accounts are considered inactive
@@ -62,7 +63,7 @@ class InactiveUserDeleter
         # Only delete student accounts or teacher accounts where a deletion warning email has been sent over 30 days ago
         user_data_retention_status = user.user_data_retention_status
         deletion_warning_email_sent_at = user_data_retention_status&.deletion_warning_email_sent_at
-        if user.student? || (deletion_warning_email_sent_at && deletion_warning_email_sent_at < 30.days.ago)
+        if user.student? || (deletion_warning_email_sent_at && deletion_warning_email_sent_at < DELETION_WARNING_GRACE_PERIOD.ago)
           delete_user(user)
           self.num_accounts_deleted += 1
         end

--- a/dashboard/lib/inactive_user_deleter.rb
+++ b/dashboard/lib/inactive_user_deleter.rb
@@ -60,7 +60,11 @@ class InactiveUserDeleter
       account_batch.each do |user|
         break if num_accounts_deleted >= limit
         # Only delete student accounts or teacher accounts where a deletion warning email has been sent over 30 days ago
-        delete_user(user) if user.student? || user.user_data_retention_status.deletion_warning_email_sent_at < 30.days.ago
+        user_data_retention_status = user.user_data_retention_status
+        deletion_warning_email_sent_at = user_data_retention_status&.deletion_warning_email_sent_at
+        if user.student? || (deletion_warning_email_sent_at && deletion_warning_email_sent_at < 30.days.ago)
+          delete_user(user)
+        end
       rescue StandardError => exception
         self.num_errors += 1
         Honeybadger.notify(exception, context: {user_id: user.id})

--- a/dashboard/lib/inactive_user_deleter.rb
+++ b/dashboard/lib/inactive_user_deleter.rb
@@ -58,7 +58,7 @@ class InactiveUserDeleter
     # for this operation, so we can use a simple limit approach.
     loop do
       account_batch = inactive_users
-      account_batch.each do |user|
+      account_batch.includes(:user_data_retention_status).each do |user|
         break if num_accounts_deleted >= limit
         # Only delete student accounts or teacher accounts where a deletion warning email has been sent over 30 days ago
         user_data_retention_status = user.user_data_retention_status

--- a/dashboard/lib/inactive_user_deleter.rb
+++ b/dashboard/lib/inactive_user_deleter.rb
@@ -84,10 +84,13 @@ class InactiveUserDeleter
 
   def inactive_users
     ActiveRecord::Base.connected_to(role: :reporting) do
-      Queries::User::Inactive.
-      call(inactive_since: inactive_since).
-      where.not(id: processed_user_ids).
-      limit(BATCH_SIZE)
+      result = Queries::User::Inactive.
+        call(inactive_since: inactive_since).
+        where.not(id: processed_user_ids).
+        left_outer_joins(:user_data_retention_status)
+      users = result.where(user_type: User::TYPE_STUDENT).
+      or(result.where(user_type: User::TYPE_TEACHER).where.not(user_data_retention_status: {deletion_warning_email_sent_at: nil}))
+      users.limit(BATCH_SIZE)
     end
   end
 

--- a/dashboard/lib/inactive_user_deleter.rb
+++ b/dashboard/lib/inactive_user_deleter.rb
@@ -64,6 +64,7 @@ class InactiveUserDeleter
         deletion_warning_email_sent_at = user_data_retention_status&.deletion_warning_email_sent_at
         if user.student? || (deletion_warning_email_sent_at && deletion_warning_email_sent_at < 30.days.ago)
           delete_user(user)
+          self.num_accounts_deleted += 1
         end
       rescue StandardError => exception
         self.num_errors += 1
@@ -112,7 +113,6 @@ class InactiveUserDeleter
       log_message("Deleting inactive user (id=#{user.id})")
       user.destroy!
     end
-    self.num_accounts_deleted += 1
   end
 
   private def upload_metrics

--- a/dashboard/test/lib/inactive_user_deleter_test.rb
+++ b/dashboard/test/lib/inactive_user_deleter_test.rb
@@ -95,6 +95,12 @@ class User::InactiveUserDeleterTest < ActiveJob::TestCase
       _(described_instance.send(:num_accounts_deleted)).must_equal 2
     end
 
+    it 'correctly increments num_accounts_deleted when deleting inactive teachers with mixed retention statuses' do
+      create(:teacher, current_sign_in_at: inactive_since - 1.day, user_data_retention_status: create(:user_data_retention_status, deletion_warning_email_sent_at: described_class::DELETION_WARNING_GRACE_PERIOD.ago + 1.day))
+      delete_inactive_users
+      _(described_instance.send(:num_accounts_deleted)).must_equal 2
+    end
+
     it 'uploads metrics' do
       expect_event_logging.once
       delete_inactive_users

--- a/dashboard/test/lib/inactive_user_deleter_test.rb
+++ b/dashboard/test/lib/inactive_user_deleter_test.rb
@@ -14,7 +14,7 @@ class User::InactiveUserDeleterTest < ActiveJob::TestCase
   let!(:student) {create(:student, current_sign_in_at: inactive_since - 1.day)}
   let!(:teacher) {create(:teacher, current_sign_in_at: inactive_since - 1.day, user_data_retention_status: user_data_retention_status)}
   let!(:user_data_retention_status) {create(:user_data_retention_status, deletion_warning_email_sent_at: deletion_warning_email_sent_at)}
-  let(:deletion_warning_email_sent_at) {42.days.ago}
+  let(:deletion_warning_email_sent_at) {described_class::DELETION_WARNING_GRACE_PERIOD.ago - 1.day}
 
   let(:expect_event_logging) do
     Metrics::Events.expects(:log_event).with(
@@ -84,7 +84,7 @@ class User::InactiveUserDeleterTest < ActiveJob::TestCase
     end
 
     it 'does not delete inactive teachers who have been sent deletion warning email less than 30 days ago' do
-      teacher_recent_warning = create(:teacher, current_sign_in_at: inactive_since - 1.day, user_data_retention_status: create(:user_data_retention_status, deletion_warning_email_sent_at: 29.days.ago))
+      teacher_recent_warning = create(:teacher, current_sign_in_at: inactive_since - 1.day, user_data_retention_status: create(:user_data_retention_status, deletion_warning_email_sent_at: described_class::DELETION_WARNING_GRACE_PERIOD.ago + 1.day))
       delete_inactive_users
       teacher_recent_warning.reload
       _(teacher_recent_warning.deleted?).must_equal false

--- a/dashboard/test/lib/inactive_user_deleter_test.rb
+++ b/dashboard/test/lib/inactive_user_deleter_test.rb
@@ -12,7 +12,9 @@ class User::InactiveUserDeleterTest < ActiveJob::TestCase
 
   let(:email) {Faker::Internet.unique.email}
   let!(:student) {create(:student, current_sign_in_at: inactive_since - 1.day)}
-  let!(:teacher) {create(:teacher, current_sign_in_at: inactive_since - 1.day, user_data_retention_status: create(:user_data_retention_status, deletion_warning_email_sent_at: 42.months.ago))}
+  let!(:teacher) {create(:teacher, current_sign_in_at: inactive_since - 1.day, user_data_retention_status: user_data_retention_status)}
+  let!(:user_data_retention_status) {create(:user_data_retention_status, deletion_warning_email_sent_at: deletion_warning_email_sent_at)}
+  let(:deletion_warning_email_sent_at) {42.days.ago}
 
   let(:expect_event_logging) do
     Metrics::Events.expects(:log_event).with(
@@ -81,6 +83,13 @@ class User::InactiveUserDeleterTest < ActiveJob::TestCase
       _(teacher_no_warning.deleted?).must_equal false
     end
 
+    it 'does not delete inactive teachers who have been sent deletion warning email less than 30 days ago' do
+      teacher_recent_warning = create(:teacher, current_sign_in_at: inactive_since - 1.day, user_data_retention_status: create(:user_data_retention_status, deletion_warning_email_sent_at: 29.days.ago))
+      delete_inactive_users
+      teacher_recent_warning.reload
+      _(teacher_recent_warning.deleted?).must_equal false
+    end
+
     it 'increments num_accounts_deleted' do
       delete_inactive_users
       _(described_instance.send(:num_accounts_deleted)).must_equal 2
@@ -146,15 +155,6 @@ class User::InactiveUserDeleterTest < ActiveJob::TestCase
       it 'does not include accounts from processed_user_ids' do
         described_instance.processed_user_ids << student.id
         _(inactive_users).wont_include student
-      end
-
-      it 'includes inactive teachers who have been sent deletion warning email more than 40 months ago' do
-        _(inactive_users).must_include teacher
-      end
-
-      it 'does not include inactive teachers who have not been sent deletion warning email' do
-        teacher_no_warning = create(:teacher, current_sign_in_at: inactive_since - 1.day, user_data_retention_status: create(:user_data_retention_status, deletion_warning_email_sent_at: nil))
-        _(inactive_users).wont_include teacher_no_warning
       end
     end
   end

--- a/dashboard/test/lib/inactive_user_deleter_test.rb
+++ b/dashboard/test/lib/inactive_user_deleter_test.rb
@@ -12,7 +12,7 @@ class User::InactiveUserDeleterTest < ActiveJob::TestCase
 
   let(:email) {Faker::Internet.unique.email}
   let!(:student) {create(:student, current_sign_in_at: inactive_since - 1.day)}
-  let!(:teacher) {create(:teacher, current_sign_in_at: inactive_since - 1.day)}
+  let!(:teacher) {create(:teacher, current_sign_in_at: inactive_since - 1.day, user_data_retention_status: create(:user_data_retention_status, deletion_warning_email_sent_at: 42.months.ago))}
 
   let(:expect_event_logging) do
     Metrics::Events.expects(:log_event).with(
@@ -72,6 +72,13 @@ class User::InactiveUserDeleterTest < ActiveJob::TestCase
       active_user.reload
 
       _(active_user.deleted?).must_equal false
+    end
+
+    it 'does not delete inactive teachers who have not been sent deletion warning email' do
+      teacher_no_warning = create(:teacher, current_sign_in_at: inactive_since - 1.day, user_data_retention_status: create(:user_data_retention_status, deletion_warning_email_sent_at: nil))
+      delete_inactive_users
+      teacher_no_warning.reload
+      _(teacher_no_warning.deleted?).must_equal false
     end
 
     it 'increments num_accounts_deleted' do
@@ -139,6 +146,15 @@ class User::InactiveUserDeleterTest < ActiveJob::TestCase
       it 'does not include accounts from processed_user_ids' do
         described_instance.processed_user_ids << student.id
         _(inactive_users).wont_include student
+      end
+
+      it 'includes inactive teachers who have been sent deletion warning email more than 40 months ago' do
+        _(inactive_users).must_include teacher
+      end
+
+      it 'does not include inactive teachers who have not been sent deletion warning email' do
+        teacher_no_warning = create(:teacher, current_sign_in_at: inactive_since - 1.day, user_data_retention_status: create(:user_data_retention_status, deletion_warning_email_sent_at: nil))
+        _(inactive_users).wont_include teacher_no_warning
       end
     end
   end


### PR DESCRIPTION
This PR updates the Inactive User deleter to include an additional check for teachers, ensuring that only those who have already received a deletion warning email are deleted.

## Links


- Jira: 

