### PR TITLE
Add browser TTS option to Dance levels

### DIFF
--- a/dashboard/app/views/levels/editors/_dance.html.haml
+++ b/dashboard/app/views/levels/editors/_dance.html.haml
@@ -15,6 +15,7 @@
 = render partial: 'levels/editors/fields/encrypted_examples', locals: {f: f, level_type: 'dance'}
 = render partial: 'levels/editors/fields/lab2', locals: {f: f, level_type: 'dance'}
 = render partial: 'levels/editors/fields/dance_ai_fields', locals: {f: f}
+= render partial: 'levels/editors/fields/browser_tts', locals: {f: f}
 
 = render partial: 'levels/editors/fields/preload_assets', locals: {f: f}
 = render partial: 'levels/editors/fields/sharing', locals: {f: f}


### PR DESCRIPTION
Adds the Browser TTS option to Dance Party levels. Note that this is only applicable for Lab2 Dance levels that use the new browser-based TTS system.

## Testing story
- Tested locally with HoAI script