### PR TITLE
Sketch Lab: fix start over with no start sources

### DIFF
--- a/apps/src/sketchlab/SketchlabView.tsx
+++ b/apps/src/sketchlab/SketchlabView.tsx
@@ -238,7 +238,9 @@ const SketchlabView: React.FC<LabProps<LevelProperties>> = ({
           hasEdited={false}
           settings={[useThemeSetting('sketchlab')]}
           versionHistoryProps={{
-            startSources: levelProperties?.startSources as ProjectSources,
+            startSources:
+              (levelProperties?.startSources as ProjectSources) ||
+              DEFAULT_SOURCES,
             onLoadVersion: onLoadVersion,
           }}
         />


### PR DESCRIPTION
Kind of an edge case, but starting over on a level without start sources errored. I noticed this on http://localhost-studio.code.org:3000/courses/original-allthethings-course/units/1/lessons/54/levels/3. This fixes it!