### PR TITLE
quick fix for config vars in managed test env

### DIFF
--- a/config/test.yml.erb
+++ b/config/test.yml.erb
@@ -15,9 +15,9 @@ imm_reader_client_id:     '92ef2120-f523-41fe-a995-f9720bf70b81'
 # This saves 30 seconds each time the rails environment is loaded.
 lazy_load_i18n: <%= !(running_web_application? || unit_test) %>
 
-# Disable Secrets unless we are running the web application on the chef-managed
-# test system.
-<% unless managed_test_server? -%>
+# Disable Secrets unless we are running on the chef-managed test system,
+# outside of unit tests (such as in rake tasks, web server or rails console).
+<% unless test_system? && !unit_test -%>
 <%= clear_secrets %>
 
 dashboard_honeybadger_api_key: '00000000'


### PR DESCRIPTION
fix forward for an [issue](https://codedotorg.slack.com/archives/C0T0PNTM3/p1765818661421439?thread_ts=1765816288.628749&cid=C0T0PNTM3) caused by https://github.com/code-dot-org/code-dot-org/pull/69900

## Testing story

this fix has been patched into the test machine for several days and we've had many successful DTTs while it has been in place.