### PR TITLE
AI Chat: update logic to show chatButtons div

### DIFF
--- a/apps/src/aichat/views/UserChatMessageEditor.tsx
+++ b/apps/src/aichat/views/UserChatMessageEditor.tsx
@@ -137,7 +137,7 @@ const UserChatMessageEditor: React.FunctionComponent<
 
   return (
     <>
-      {chatButtons && !chatDisabled && (
+      {chatButtons && chatButtons.length > 0 && !chatDisabled && (
         <div className={moduleStyles.chatButtonsContainer}>
           {chatButtons.map(({ChatButton, key}) => (
             <ChatButton key={key} onClick={handleSubmit} />


### PR DESCRIPTION
Updates the logic in the `UserChatMessageEditor` component to only show the `chatButtons` div when the array length is > 0. This was causing an empty div to render in the DOM, causing extra padding at the top of the footer in Web Lab 2 where there are no chat buttons. 

## Links
Jira ticket: [AFL-402](https://codedotorg.atlassian.net/browse/AFL-402)

## Testing story
Tested locally in Web Lab 2 and Python Lab to make sure the chat buttons were showing when expected.

----

| Before | After |
| ---- | ---- |
| <img width="402" height="183" alt="Screenshot 2025-12-17 at 12 48 59 PM" src="https://github.com/user-attachments/assets/877d3850-d12c-40e9-84d2-1bb7c30969f0" /> | <img width="402" height="183" alt="Screenshot 2025-12-17 at 12 48 55 PM" src="https://github.com/user-attachments/assets/c9e2b72b-ee63-49bb-b4a8-147f7815f8e3" /> |

