### PR TITLE
never skip pegasus content when preparing cached build

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -314,20 +314,20 @@ steps:
       - "find . -type f -not -path './.git/*' | wc -l > .cached-staging-build-file-count"
       - 'printf "Baseline file count: %s\n" "$(cat .cached-staging-build-file-count)"'
 
-  # - name: cache-staging-ci-build
-  #   image: plugins/s3-cache
-  #   volumes:
-  #     - name: mysql
-  #       path: /var/lib/mysql
-  #   settings:
-  #     filename: cache-staging-ci-build.tar.gz
-  #     endpoint: s3://cdo-drone
-  #     rebuild: true
-  #     debug: true
-  #     pull: true
-  #     mount:
-  #       - .
-  #       - /var/lib/mysql
+  - name: cache-staging-ci-build
+    image: plugins/s3-cache
+    volumes:
+      - name: mysql
+        path: /var/lib/mysql
+    settings:
+      filename: cache-staging-ci-build.tar.gz
+      endpoint: s3://cdo-drone
+      rebuild: true
+      debug: true
+      pull: true
+      mount:
+        - .
+        - /var/lib/mysql
 
 volumes:
   - name: mysql
@@ -339,7 +339,6 @@ trigger:
     - "staging-next"
   event:
     - push
-    - pull_request
 
 ---
 kind: signature

--- a/.drone.yml
+++ b/.drone.yml
@@ -314,20 +314,20 @@ steps:
       - "find . -type f -not -path './.git/*' | wc -l > .cached-staging-build-file-count"
       - 'printf "Baseline file count: %s\n" "$(cat .cached-staging-build-file-count)"'
 
-  - name: cache-staging-ci-build
-    image: plugins/s3-cache
-    volumes:
-      - name: mysql
-        path: /var/lib/mysql
-    settings:
-      filename: cache-staging-ci-build.tar.gz
-      endpoint: s3://cdo-drone
-      rebuild: true
-      debug: true
-      pull: true
-      mount:
-        - .
-        - /var/lib/mysql
+  # - name: cache-staging-ci-build
+  #   image: plugins/s3-cache
+  #   volumes:
+  #     - name: mysql
+  #       path: /var/lib/mysql
+  #   settings:
+  #     filename: cache-staging-ci-build.tar.gz
+  #     endpoint: s3://cdo-drone
+  #     rebuild: true
+  #     debug: true
+  #     pull: true
+  #     mount:
+  #       - .
+  #       - /var/lib/mysql
 
 volumes:
   - name: mysql
@@ -339,6 +339,7 @@ trigger:
     - "staging-next"
   event:
     - push
+    - pull_request
 
 ---
 kind: signature

--- a/lib/rake/ci.rake
+++ b/lib/rake/ci.rake
@@ -193,7 +193,9 @@ namespace :ci do
   end
 
   timed_task_with_logging :sparse_checkout do
-    if CI::Utils.tagged?(SKIP_PEGASUS_CONTENT)
+    # never do sparse checkout in prepare_cacheable_build CI job, or it will
+    # cause later unit and ui jobs to fail.
+    if CI::Utils.tagged?(SKIP_PEGASUS_CONTENT) && ['unit_tests', 'ui_tests'].include?(ENV.fetch('CI_JOB', nil))
       cmd = 'bin/sparse-checkout no-pegasus-content'
       ChatClient.log "Commit message: '#{CI::Utils.git_commit_message}' contains [#{SKIP_PEGASUS_CONTENT}], running `#{cmd}`."
       RakeUtils.system_stream_output "git status --porcelain"


### PR DESCRIPTION
quick fix for the issue where squash-merging a commit containing the `[skip pegasus content]` commit tag will corrupt the drone build cache, causing subsequent builds to fail. For more background, see https://github.com/code-dot-org/code-dot-org/pull/69989

## Testing story
- [x] confirm that unit and ui pipelines correctly detect the `[skip pegasus content]` commit tag
- [x] confirm that cached-staging-build pipeline correctly ignores the `[skip pegasus content]` commit tag
