### PR TITLE
Report Detailed Metrics Data When Failing to Publish

### DIFF
--- a/lib/cdo/aws/metrics.rb
+++ b/lib/cdo/aws/metrics.rb
@@ -48,7 +48,7 @@ module Cdo
           metric_data: events
         )
       rescue => exception
-        Honeybadger.notify(exception)
+        Honeybadger.notify(exception, context: events)
       end
 
       def size(events)

--- a/lib/cdo/aws/metrics.rb
+++ b/lib/cdo/aws/metrics.rb
@@ -48,7 +48,13 @@ module Cdo
           metric_data: events
         )
       rescue => exception
-        Honeybadger.notify(exception, context: events)
+        Honeybadger.notify(
+          exception,
+          context: {
+            namespace: @namespace,
+            metric_data: events
+          }
+        )
       end
 
       def size(events)


### PR DESCRIPTION
We've been getting some `ArgumentError`s from `aws-sdk-core/param_validator.rb` lately; our [speculative revert](https://github.com/code-dot-org/code-dot-org/pull/70061) did not work, so we're now looking for some more data to facilitate further debugging

See threads [here](https://codedotorg.slack.com/archives/C0T0PNTM3/p1765908856850409) and [here](https://codedotorg.slack.com/archives/C03CK49G9/p1765995877297459) for more context