### PR TITLE
skip flaky tests due to frequent sequel timeouts

### DIFF
--- a/dashboard/test/controllers/user_level_interactions_controller_test.rb
+++ b/dashboard/test/controllers/user_level_interactions_controller_test.rb
@@ -19,6 +19,7 @@ class UserLevelInteractionsControllerTest < ActionController::TestCase
   end
 
   test "create User Level Interaction for project level" do
+    # TODO: re-enable after addressing Sequel timeouts. See PR #70106
     skip 'flaky due to frequent Sequel timeouts'
     @lesson = create(:lesson, :with_lesson_group, script: @csp_2024_script)
     @script_level = create(:script_level, script: @csp_2024_script, lesson: @lesson, levels: [@csp_2024_level])

--- a/dashboard/test/controllers/user_level_interactions_controller_test.rb
+++ b/dashboard/test/controllers/user_level_interactions_controller_test.rb
@@ -19,6 +19,7 @@ class UserLevelInteractionsControllerTest < ActionController::TestCase
   end
 
   test "create User Level Interaction for project level" do
+    skip 'flaky due to frequent Sequel timeouts'
     @lesson = create(:lesson, :with_lesson_group, script: @csp_2024_script)
     @script_level = create(:script_level, script: @csp_2024_script, lesson: @lesson, levels: [@csp_2024_level])
     @fake_ip = '127.0.0.1'

--- a/dashboard/test/lib/account_purger_test.rb
+++ b/dashboard/test/lib/account_purger_test.rb
@@ -82,6 +82,8 @@ class AccountPurgerTest < ActiveSupport::TestCase
   end
 
   test 'uses dashboard and pegasus transactions' do
+    # TODO: re-enable after addressing Sequel timeouts. See PR #70106
+    skip 'flaky due to frequent Sequel timeouts'
     test_name = 'Boaty McBoatface'
 
     refute_equal test_name, @student.name

--- a/dashboard/test/models/user_test.rb
+++ b/dashboard/test/models/user_test.rb
@@ -2799,6 +2799,7 @@ class UserTest < ActiveSupport::TestCase
   end
 
   test 'undestroy restores recently soft-deleted projects' do
+    skip 'flaky due to frequent Sequel timeouts'
     Timecop.freeze do
       student = create(:student)
       with_channel_for student do |channel_id_a|
@@ -3991,6 +3992,7 @@ class UserTest < ActiveSupport::TestCase
   end
 
   test 'find_channel_owner finds channel owner' do
+    skip 'flaky due to frequent Sequel timeouts'
     student = create(:student)
     with_channel_for student do |project_id, storage_id|
       encrypted_channel_id = storage_encrypt_channel_id storage_id, project_id

--- a/dashboard/test/models/user_test.rb
+++ b/dashboard/test/models/user_test.rb
@@ -2799,6 +2799,7 @@ class UserTest < ActiveSupport::TestCase
   end
 
   test 'undestroy restores recently soft-deleted projects' do
+    # TODO: re-enable after addressing Sequel timeouts. See PR #70106
     skip 'flaky due to frequent Sequel timeouts'
     Timecop.freeze do
       student = create(:student)
@@ -3992,6 +3993,7 @@ class UserTest < ActiveSupport::TestCase
   end
 
   test 'find_channel_owner finds channel owner' do
+    # TODO: re-enable after addressing Sequel timeouts. See PR #70106
     skip 'flaky due to frequent Sequel timeouts'
     student = create(:student)
     with_channel_for student do |project_id, storage_id|


### PR DESCRIPTION
Multiple dashboard unit tests recently started failing in drone with the following error:
```
Minitest::UnexpectedError:         Sequel::DatabaseError: Mysql2::Error::TimeoutError: Timeout waiting for a response from the last query. (waited 30 seconds)
```

This PR disables the 3 worst offenders. Here is the error output for those 3 tests:
```
ERROR["test_create_User_Level_Interaction_for_project_level", "UserLevelInteractionsControllerTest", 385.328863338]
 test_create_User_Level_Interaction_for_project_level#UserLevelInteractionsControllerTest (385.33s)
Minitest::UnexpectedError:         Sequel::DatabaseError: Mysql2::Error::TimeoutError: Timeout waiting for a response from the last query. (waited 30 seconds)
            test/controllers/user_level_interactions_controller_test.rb:25:in `block in <class:UserLevelInteractionsControllerTest>'
            test/testing/setup_all_and_teardown_all.rb:36:in `run'

ERROR["test_find_channel_owner_finds_channel_owner", "UserTest", 340.3733022749984]
 test_find_channel_owner_finds_channel_owner#UserTest (340.37s)
Minitest::UnexpectedError:         Sequel::DatabaseError: Mysql2::Error::TimeoutError: Timeout waiting for a response from the last query. (waited 30 seconds)
            test/testing/projects_test_utils.rb:25:in `with_storage_id_for'
            test/testing/projects_test_utils.rb:9:in `with_channel_for'
            test/models/user_test.rb:3995:in `block in <class:UserTest>'
            test/testing/setup_all_and_teardown_all.rb:36:in `run'

ERROR["test_undestroy_restores_recently_soft-deleted_projects", "UserTest", 381.173459738]
 test_undestroy_restores_recently_soft-deleted_projects#UserTest (381.17s)
Minitest::UnexpectedError:         Sequel::DatabaseError: Mysql2::Error::TimeoutError: Timeout waiting for a response from the last query. (waited 30 seconds)
            test/testing/projects_test_utils.rb:25:in `with_storage_id_for'
            test/testing/projects_test_utils.rb:9:in `with_channel_for'
            test/models/user_test.rb:2804:in `block (2 levels) in <class:UserTest>'
            test/models/user_test.rb:2802:in `block in <class:UserTest>'
            test/testing/setup_all_and_teardown_all.rb:36:in `run'
```

## root cause

We do not have any great leads for why the tests started failing. From my perspective, I first noticed them failing while running drone on https://github.com/code-dot-org/code-dot-org/pull/70001 which adds `use_transactional_test_case` to more tests which touch the database in `setup_all`. However, it's not clear why this PR would be the culprit, because none of the offending tests are ones I touched in that PR, and its also possible that the timing was a coincidence.

I thought maybe that the amount of parallelism we are using for dashboard test runs was simply too high, but I believe I have ruled that out by lowering the parallelism from 7 down to 2 without successfully eliminating the errors: https://github.com/code-dot-org/code-dot-org/pull/70096

UPDATE: The following PR is confirmed to fix the flakiness:
* https://github.com/code-dot-org/code-dot-org/pull/70011

## Testing story
<!--  Does your change include appropriate tests?
      - If so, please describe how the tests included in this PR are sufficient.
      - If not, please explain why this change does not need to be tested. -->



## Deployment strategy
<!--  Any special steps required to deploy this, besides merging?
      - Are there database migrations or manual steps?
      - Does this require coordination with other teams or systems? -->



## Follow-up work
<!--  List any clean-up or technical debt that will be addressed in future work.
      - Include Jira links where applicable.
      - Are there any known limitations or improvements planned? -->


