### PR TITLE
EXPERIMENT: Revert "use transactional test case whenever we use setup_all"

### DIFF
--- a/dashboard/test/controllers/api/v1/section_libraries_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/section_libraries_controller_test.rb
@@ -1,8 +1,6 @@
 require 'test_helper'
 
 class Api::V1::SectionLibrariesControllerTest < ActionController::TestCase
-  self.use_transactional_test_case = true
-
   setup_all do
     @teacher = create(:teacher)
     @section = create(:section, user: @teacher, login_type: 'word')

--- a/dashboard/test/controllers/backpacks_controller_test.rb
+++ b/dashboard/test/controllers/backpacks_controller_test.rb
@@ -1,7 +1,7 @@
 require 'test_helper'
 
 class BackpacksControllerTest < ActionController::TestCase
-  setup do
+  setup_all do
     @user = create(:user)
     @storage_id = fake_storage_id_for_user_id(@user.id)
     @game_id = 68

--- a/dashboard/test/controllers/certificates_controller_test.rb
+++ b/dashboard/test/controllers/certificates_controller_test.rb
@@ -2,8 +2,6 @@ require 'test_helper'
 require 'base64'
 
 class CertificatesControllerTest < ActionController::TestCase
-  self.use_transactional_test_case = true
-
   setup_all do
     @teacher = create(:teacher)
     @teacher.freeze

--- a/dashboard/test/controllers/data_docs_controller_test.rb
+++ b/dashboard/test/controllers/data_docs_controller_test.rb
@@ -3,8 +3,6 @@ require 'test_helper'
 class DataDocsControllerTest < ActionController::TestCase
   include Devise::Test::ControllerHelpers
 
-  self.use_transactional_test_case = true
-
   setup_all do
     @levelbuilder = create(:levelbuilder)
 

--- a/dashboard/test/controllers/datablock_storage_controller_test.rb
+++ b/dashboard/test/controllers/datablock_storage_controller_test.rb
@@ -1,8 +1,6 @@
 require "test_helper"
 
 class DatablockStorageControllerTest < ActionDispatch::IntegrationTest
-  self.use_transactional_test_case = true
-
   setup_all do
     @student = create(:student)
 

--- a/dashboard/test/controllers/experiments_controller_test.rb
+++ b/dashboard/test/controllers/experiments_controller_test.rb
@@ -1,8 +1,6 @@
 require 'test_helper'
 
 class ExperimentsControllerTest < ActionController::TestCase
-  self.use_transactional_test_case = true
-
   setup_all do
     @pilot = create(:pilot, allow_joining_via_url: true)
     @pilot_name = @pilot.name

--- a/dashboard/test/controllers/featured_projects_controller_test.rb
+++ b/dashboard/test/controllers/featured_projects_controller_test.rb
@@ -1,8 +1,6 @@
 require 'test_helper'
 
 class FeaturedProjectsControllerTest < ActionController::TestCase
-  self.use_transactional_test_case = true
-
   setup_all do
     @project_validator = create(:project_validator)
     @teacher = create(:teacher)

--- a/dashboard/test/controllers/foorm/libraries_controller_test.rb
+++ b/dashboard/test/controllers/foorm/libraries_controller_test.rb
@@ -2,8 +2,6 @@ require 'test_helper'
 
 module Foorm
   class LibrariesControllerTest < ActionController::TestCase
-    self.use_transactional_test_case = true
-
     setup_all do
       @levelbuilder = create(:levelbuilder)
     end

--- a/dashboard/test/controllers/lti_v1_controller_test.rb
+++ b/dashboard/test/controllers/lti_v1_controller_test.rb
@@ -9,8 +9,6 @@ require 'clients/lti_dynamic_registration_client'
 class LtiV1ControllerTest < ActionDispatch::IntegrationTest
   include Devise::Test::IntegrationHelpers
 
-  self.use_transactional_test_case = true
-
   setup_all do
     @integration = create(:lti_integration)
     @deployment_id = SecureRandom.uuid

--- a/dashboard/test/helpers/teacher_application_helper_test.rb
+++ b/dashboard/test/helpers/teacher_application_helper_test.rb
@@ -8,8 +8,6 @@ class TeacherApplicationHelperTest < ActionView::TestCase
     stubs(:current_user).returns user
   end
 
-  self.use_transactional_test_case = true
-
   setup_all do
     @user_with_two_incomplete_apps = create(:teacher)
     @incomplete_application = create TEACHER_APPLICATION_FACTORY, user: @user_with_two_incomplete_apps, status: 'incomplete'

--- a/dashboard/test/lib/lti_access_token_test.rb
+++ b/dashboard/test/lib/lti_access_token_test.rb
@@ -5,8 +5,6 @@ require 'jwt'
 class LtiAccessTokenTest < ActiveSupport::TestCase
   include LtiAccessToken
 
-  self.use_transactional_test_case = true
-
   setup_all do
     @lti_integration = create(:lti_integration)
     fake_response_hash = {

--- a/dashboard/test/lib/pd/foorm/form_analytics_parser_test.rb
+++ b/dashboard/test/lib/pd/foorm/form_analytics_parser_test.rb
@@ -2,8 +2,6 @@ require 'test_helper'
 
 module Pd::Foorm
   class FormAnalyticsParserTest < ActiveSupport::TestCase
-    self.use_transactional_test_case = true
-
     setup_all do
       @form = create(:foorm_form_csf_intro_post_survey)
       @reshaped_form = FormAnalyticsParser.reshape_form(@form)

--- a/dashboard/test/lib/pd/foorm/rollup_helper_test.rb
+++ b/dashboard/test/lib/pd/foorm/rollup_helper_test.rb
@@ -2,8 +2,6 @@ require 'test_helper'
 
 module Pd::Foorm
   class RollupHelperTest < ActiveSupport::TestCase
-    self.use_transactional_test_case = true
-
     setup_all do
       @rollup_configuration = JSON.parse(File.read('test/fixtures/rollup_config.json'), symbolize_names: true)
       @daily_survey_day_0 = create(:foorm_form_summer_pre_survey)

--- a/dashboard/test/lib/pd/foorm/submission_analytics_parser_test.rb
+++ b/dashboard/test/lib/pd/foorm/submission_analytics_parser_test.rb
@@ -2,11 +2,7 @@ require 'test_helper'
 
 module Pd::Foorm
   class SubmissionAnalyticsParserTest < ActiveSupport::TestCase
-    self.use_transactional_test_case = true
-
-    setup_all do
-      @form = create(:foorm_form_csf_intro_post_survey)
-    end
+    setup_all {@form = create(:foorm_form_csf_intro_post_survey)}
     teardown_all {@form.delete}
 
     test 'reshape_submission formats matrix question response as expected' do

--- a/dashboard/test/lib/pd/survey_pipeline/mapper_test.rb
+++ b/dashboard/test/lib/pd/survey_pipeline/mapper_test.rb
@@ -4,8 +4,6 @@ require 'pd/survey_pipeline/reducer'
 
 module Pd::SurveyPipeline
   class GenericMapperTest < ActiveSupport::TestCase
-    self.use_transactional_test_case = true
-
     setup_all do
       # All combinations of (a, b, c) which each value could be 0 or 1.
       @data = [

--- a/dashboard/test/lib/policies/inline_answer_test.rb
+++ b/dashboard/test/lib/policies/inline_answer_test.rb
@@ -1,8 +1,6 @@
 require 'test_helper'
 
 class Policies::InlineAnswerTest < ActiveSupport::TestCase
-  self.use_transactional_test_case = true
-
   setup_all do
     @authorized_teacher = create(:authorized_teacher)
     @teacher = create(:teacher)

--- a/dashboard/test/lib/policies/script_activity_test.rb
+++ b/dashboard/test/lib/policies/script_activity_test.rb
@@ -1,8 +1,6 @@
 require 'test_helper'
 
 class Policies::ScriptActivityTest < ActiveSupport::TestCase
-  self.use_transactional_test_case = true
-
   setup_all do
     @user = create(:user)
     @script = create(:script, :in_single_unit_course)

--- a/dashboard/test/lib/services/complete_application_reminder_test.rb
+++ b/dashboard/test/lib/services/complete_application_reminder_test.rb
@@ -1,8 +1,6 @@
 require 'test_helper'
 
 class Services::CompleteApplicationReminderTest < ActiveSupport::TestCase
-  self.use_transactional_test_case = true
-
   setup_all do
     Pd::Application::TeacherApplication.any_instance.stubs(:deliver_email)
   end

--- a/dashboard/test/lib/services/i18n/curriculum_sync_utils/render_translations_test.rb
+++ b/dashboard/test/lib/services/i18n/curriculum_sync_utils/render_translations_test.rb
@@ -1,8 +1,6 @@
 require 'test_helper'
 
 class Services::I18n::CurriculumSyncUtils::RenderTranslationsTest < ActiveSupport::TestCase
-  self.use_transactional_test_case = true
-
   setup_all do
     @lesson = create(:lesson, overview: "This is the english overview")
     @activity_section = create(:activity_section, name: "English name", description: "English description")

--- a/dashboard/test/models/aidiff_artifact_test.rb
+++ b/dashboard/test/models/aidiff_artifact_test.rb
@@ -1,8 +1,6 @@
 require "test_helper"
 
 class AidiffArtifactTest < ActiveSupport::TestCase
-  self.use_transactional_test_case = true
-
   setup_all do
     @user = create(:user)
   end

--- a/dashboard/test/models/aidiff_exit_ticket_test.rb
+++ b/dashboard/test/models/aidiff_exit_ticket_test.rb
@@ -1,8 +1,6 @@
 require "test_helper"
 
 class AidiffExitTicketTest < ActiveSupport::TestCase
-  self.use_transactional_test_case = true
-
   setup_all do
     @user = create(:user)
   end

--- a/dashboard/test/models/aidiff_lesson_hook_test.rb
+++ b/dashboard/test/models/aidiff_lesson_hook_test.rb
@@ -1,8 +1,6 @@
 require "test_helper"
 
 class AidiffLessonHookTest < ActiveSupport::TestCase
-  self.use_transactional_test_case = true
-
   setup_all do
     @user = create(:user)
   end

--- a/dashboard/test/models/aidiff_message_feedback_test.rb
+++ b/dashboard/test/models/aidiff_message_feedback_test.rb
@@ -1,8 +1,6 @@
 require "test_helper"
 
 class AidiffMessageFeedbackTest < ActiveSupport::TestCase
-  self.use_transactional_test_case = true
-
   setup_all do
     @user = create(:user)
   end

--- a/dashboard/test/models/aidiff_thread_test.rb
+++ b/dashboard/test/models/aidiff_thread_test.rb
@@ -1,8 +1,6 @@
 require 'test_helper'
 
 class AidiffThreadTest < ActiveSupport::TestCase
-  self.use_transactional_test_case = true
-
   setup_all do
     @user = create(:user)
   end

--- a/dashboard/test/models/code_review_test.rb
+++ b/dashboard/test/models/code_review_test.rb
@@ -1,8 +1,6 @@
 require 'test_helper'
 
 class CodeReviewTest < ActiveSupport::TestCase
-  self.use_transactional_test_case = true
-
   setup_all do
     @project_owner = create(:student)
     @project = create(:project, owner: @project_owner)

--- a/dashboard/test/models/concerns/curriculum/assignable_course_test.rb
+++ b/dashboard/test/models/concerns/curriculum/assignable_course_test.rb
@@ -1,8 +1,6 @@
 require 'test_helper'
 
 class AssignableCourseTests < ActiveSupport::TestCase
-  self.use_transactional_test_case = true
-
   setup_all do
     @teacher = create(:teacher)
     @levelbuilder = create(:levelbuilder)

--- a/dashboard/test/models/concerns/curriculum/course_types_test.rb
+++ b/dashboard/test/models/concerns/curriculum/course_types_test.rb
@@ -1,8 +1,6 @@
 require 'test_helper'
 
 class CourseTypesTests < ActiveSupport::TestCase
-  self.use_transactional_test_case = true
-
   setup_all do
     @student = create(:student)
     @teacher = create(:teacher)

--- a/dashboard/test/models/course_offering_test.rb
+++ b/dashboard/test/models/course_offering_test.rb
@@ -1,8 +1,6 @@
 require 'test_helper'
 
 class CourseOfferingTest < ActiveSupport::TestCase
-  self.use_transactional_test_case = true
-
   setup_all do
     @student = create(:student)
     @teacher = create(:teacher)

--- a/dashboard/test/models/course_version_test.rb
+++ b/dashboard/test/models/course_version_test.rb
@@ -1,8 +1,6 @@
 require 'test_helper'
 
 class CourseVersionTest < ActiveSupport::TestCase
-  self.use_transactional_test_case = true
-
   setup_all do
     @student = create(:student)
     @teacher = create(:teacher)

--- a/dashboard/test/models/levels/widget_test.rb
+++ b/dashboard/test/models/levels/widget_test.rb
@@ -1,8 +1,6 @@
 require 'test_helper'
 
 class WidgetTest < ActiveSupport::TestCase
-  self.use_transactional_test_case = true
-
   setup_all do
     @level = Widget.create!(
       name: 'Test Widget',

--- a/dashboard/test/models/pd/application/principal_approval_application_test.rb
+++ b/dashboard/test/models/pd/application/principal_approval_application_test.rb
@@ -2,8 +2,6 @@ require 'test_helper'
 
 module Pd::Application
   class PrincipalApprovalApplicationTest < ActiveSupport::TestCase
-    self.use_transactional_test_case = true
-
     setup_all do
       Pd::Application::ApplicationBase.any_instance.stubs(:deliver_email)
     end


### PR DESCRIPTION
Reverts code-dot-org/code-dot-org#70001. Experimental PR to see if this fixes flaky unit tests in drone.