### PR TITLE
🧹 Remove Radium from libraries components 

### DIFF
--- a/apps/src/code-studio/components/libraries/LibraryListItem.jsx
+++ b/apps/src/code-studio/components/libraries/LibraryListItem.jsx
@@ -1,13 +1,13 @@
+import classNames from 'classnames';
 import PropTypes from 'prop-types';
-import Radium from 'radium'; // eslint-disable-line no-restricted-imports
 import React from 'react';
 
-import fontConstants from '@cdo/apps/fontConstants';
 import FontAwesome from '@cdo/apps/legacySharedComponents/FontAwesome';
 import InlineMarkdown from '@cdo/apps/templates/InlineMarkdown';
 import Tooltip from '@cdo/apps/templates/Tooltip';
-import color from '@cdo/apps/util/color';
 import i18n from '@cdo/locale';
+
+import styles from './library-list-item.module.scss';
 
 export class LibraryListItem extends React.Component {
   static propTypes = {
@@ -27,34 +27,38 @@ export class LibraryListItem extends React.Component {
     let library = this.props.library;
 
     return (
-      <div style={styles.listItem}>
-        <div style={[{marginRight: 25}, styles.overflowEllipsis]}>
+      <div className={styles.listItem}>
+        <div
+          className={classNames(styles.titleSection, styles.overflowEllipsis)}
+        >
           <Tooltip text={i18n.viewCode()} place="bottom">
-            <a onClick={this.viewCode} style={styles.libraryTitle}>
+            <a onClick={this.viewCode} className={styles.libraryTitle}>
               {library.name}
             </a>
           </Tooltip>
           {library.userName && (
-            <div style={[styles.author, styles.overflowEllipsis]}>
+            <div className={classNames(styles.author, styles.overflowEllipsis)}>
               <InlineMarkdown
                 markdown={i18n.authorName({name: library.userName})}
               />
             </div>
           )}
         </div>
-        <div style={[styles.description, styles.overflowEllipsis]}>
+        <div
+          className={classNames(styles.description, styles.overflowEllipsis)}
+        >
           {library.description}
         </div>
-        <div style={styles.actions}>
+        <div className={styles.actions}>
           {this.props.onAdd && (
             <Tooltip text={i18n.add()} place="bottom">
               <button
                 type="button"
                 key={'add-' + library.id}
                 onClick={() => this.props.onAdd(library.id)}
-                style={[styles.actionBtn, styles.addBtn]}
+                className={classNames(styles.actionBtn, styles.addBtn)}
               >
-                <FontAwesome icon="plus" style={styles.iconPadding} />
+                <FontAwesome icon="plus" className={styles.iconPadding} />
               </button>
             </Tooltip>
           )}
@@ -63,10 +67,10 @@ export class LibraryListItem extends React.Component {
               type="button"
               key={'update-' + library.id}
               onClick={() => this.props.onUpdate(library.channelId)}
-              style={[styles.actionBtn, styles.updateBtn]}
+              className={classNames(styles.actionBtn, styles.updateBtn)}
             >
-              <FontAwesome icon="refresh" style={{padding: '0 1px'}} />
-              <span style={styles.updateText}>{i18n.update()}</span>
+              <FontAwesome icon="refresh" className={styles.updateIcon} />
+              <span className={styles.updateText}>{i18n.update()}</span>
             </button>
           )}
           {this.props.onRemove && (
@@ -80,13 +84,16 @@ export class LibraryListItem extends React.Component {
             >
               <button
                 type="button"
-                className="ui-test-remove-library"
                 key={'remove-' + library.id}
                 onClick={() => this.props.onRemove(library.channelId)}
-                style={[styles.actionBtn, styles.removeBtn]}
+                className={classNames(
+                  'ui-test-remove-library',
+                  styles.actionBtn,
+                  styles.removeBtn
+                )}
                 disabled={!!library.fromLevelbuilder}
               >
-                <FontAwesome icon="trash-o" style={styles.iconPadding} />
+                <FontAwesome icon="trash-o" className={styles.iconPadding} />
               </button>
             </Tooltip>
           )}
@@ -96,84 +103,4 @@ export class LibraryListItem extends React.Component {
   }
 }
 
-const styles = {
-  overflowEllipsis: {
-    textOverflow: 'ellipsis',
-    overflow: 'hidden',
-  },
-  listItem: {
-    padding: 8,
-    margin: 2,
-    color: color.dark_charcoal,
-    textAlign: 'left',
-    display: 'flex',
-    borderBottom: `1px solid ${color.lightest_gray}`,
-    lineHeight: 1.5,
-  },
-  libraryTitle: {
-    ...fontConstants['main-font-semi-bold'],
-    fontSize: 16,
-    cursor: 'pointer',
-    color: color.link_color,
-    ':hover': {
-      color: color.link_color,
-    },
-  },
-  description: {
-    marginRight: 25,
-    flexShrink: 2,
-  },
-  actions: {
-    display: 'flex',
-    flexGrow: 1,
-    justifyContent: 'flex-end',
-  },
-  actionBtn: {
-    padding: 8,
-    fontSize: 18,
-    backgroundColor: color.white,
-    ':hover': {
-      boxShadow: 'none',
-    },
-  },
-  iconPadding: {
-    padding: '0 2px',
-  },
-  addBtn: {
-    color: color.link_color,
-    borderColor: color.link_color,
-    ':hover': {
-      color: color.white,
-      backgroundColor: color.link_color,
-    },
-  },
-  updateBtn: {
-    color: color.orange,
-    borderColor: color.orange,
-    ':hover': {
-      color: color.white,
-      backgroundColor: color.orange,
-    },
-  },
-  updateText: {
-    ...fontConstants['main-font-semi-bold'],
-    paddingLeft: 5,
-    fontSize: 16,
-  },
-  removeBtn: {
-    color: color.dark_red,
-    borderColor: color.dark_red,
-    ':hover': {
-      color: color.white,
-      backgroundColor: color.dark_red,
-    },
-    ':disabled': {
-      color: color.light_gray,
-      borderColor: color.light_gray,
-      backgroundColor: color.lightest_gray,
-      cursor: 'default',
-    },
-  },
-};
-
-export default Radium(LibraryListItem);
+export default LibraryListItem;

--- a/apps/src/code-studio/components/libraries/LibraryManagerDialog.jsx
+++ b/apps/src/code-studio/components/libraries/LibraryManagerDialog.jsx
@@ -1,5 +1,5 @@
-import $ from 'jquery';
 import classNames from 'classnames';
+import $ from 'jquery';
 import PropTypes from 'prop-types';
 import React from 'react';
 
@@ -12,6 +12,7 @@ import BaseDialog from '@cdo/apps/templates/BaseDialog';
 import i18n from '@cdo/locale';
 
 import libraryParser from './libraryParser';
+
 import styles from './library-manager-dialog.module.scss';
 
 // Map userName from class libraries to project libraries so the author is displayed in the UI.
@@ -203,7 +204,9 @@ export class LibraryManagerDialog extends React.Component {
   displayProjectLibraries = () => {
     const {projectLibraries, updatedLibraryChannels} = this.state;
     if (!Array.isArray(projectLibraries) || !projectLibraries.length) {
-      return <div className={styles.message}>{i18n.noLibrariesInProject()}</div>;
+      return (
+        <div className={styles.message}>{i18n.noLibrariesInProject()}</div>
+      );
     }
 
     const onUpdate = channelId => {
@@ -234,7 +237,9 @@ export class LibraryManagerDialog extends React.Component {
   displayClassLibraries = () => {
     const {classLibraries, errorMessages, sectionFilter} = this.state;
     if (errorMessages.loadClassLibraries) {
-      return <div className={styles.error}>{errorMessages.loadClassLibraries}</div>;
+      return (
+        <div className={styles.error}>{errorMessages.loadClassLibraries}</div>
+      );
     }
     if (!Array.isArray(classLibraries) || !classLibraries.length) {
       return <div className={styles.message}>{i18n.noLibrariesInClass()}</div>;
@@ -363,57 +368,61 @@ export class LibraryManagerDialog extends React.Component {
           })}
           useUpdatedStyles
         >
-          <h1 className={styles.header}>{i18n.libraryManage()}</h1>
-          <div className={styles.libraryList}>
-            {this.displayProjectLibraries()}
+          <div className={styles.marginSides}>
+            <h1 className={styles.header}>{i18n.libraryManage()}</h1>
+            <div className={styles.libraryList}>
+              {this.displayProjectLibraries()}
+            </div>
+            <h2 className={styles.subHeader}>{i18n.libraryClassImport()}</h2>
+            <div style={{textAlign: 'left'}}>
+              <label className={styles.messageInline}>
+                {i18n.showingLibrariesFromSection()}
+              </label>
+              <select
+                onChange={event =>
+                  this.setState({sectionFilter: event.target.value})
+                }
+              >
+                <option value="">{i18n.all()}</option>
+                {sections.map(section => (
+                  <option key={section} value={section}>
+                    {section}
+                  </option>
+                ))}
+              </select>
+            </div>
+            <div className={styles.libraryList}>
+              {this.displayClassLibraries()}
+            </div>
+            <h2 className={styles.subHeader}>{i18n.libraryIdImport()}</h2>
+            <div className={styles.inputParent} id="ui-test-import-library">
+              <input
+                className={styles.linkBox}
+                type="text"
+                value={importLibraryId}
+                onChange={this.setLibraryToImport}
+              />
+              <button
+                className={styles.addButton}
+                onClick={() => {
+                  this.setState({isLoading: true});
+                  this.fetchLatestLibrary(
+                    importLibraryId,
+                    this.addLibraryById,
+                    'import' /* event */
+                  );
+                }}
+                type="button"
+                disabled={!importLibraryId}
+              >
+                {isLoading && (
+                  <FontAwesome icon="spinner" className="fa-spin" />
+                )}
+                {!isLoading && i18n.add()}
+              </button>
+            </div>
+            <div className={styles.error}>{errorMessages.importFromId}</div>
           </div>
-          <h2 className={styles.subHeader}>{i18n.libraryClassImport()}</h2>
-          <div style={{textAlign: 'left'}}>
-            <label className={styles.messageInline}>
-              {i18n.showingLibrariesFromSection()}
-            </label>
-            <select
-              onChange={event =>
-                this.setState({sectionFilter: event.target.value})
-              }
-            >
-              <option value="">{i18n.all()}</option>
-              {sections.map(section => (
-                <option key={section} value={section}>
-                  {section}
-                </option>
-              ))}
-            </select>
-          </div>
-          <div className={styles.libraryList}>
-            {this.displayClassLibraries()}
-          </div>
-          <h2 className={styles.subHeader}>{i18n.libraryIdImport()}</h2>
-          <div className={styles.inputParent} id="ui-test-import-library">
-            <input
-              className={styles.linkBox}
-              type="text"
-              value={importLibraryId}
-              onChange={this.setLibraryToImport}
-            />
-            <button
-              className={styles.addButton}
-              onClick={() => {
-                this.setState({isLoading: true});
-                this.fetchLatestLibrary(
-                  importLibraryId,
-                  this.addLibraryById,
-                  'import' /* event */
-                );
-              }}
-              type="button"
-              disabled={!importLibraryId}
-            >
-              {isLoading && <FontAwesome icon="spinner" className="fa-spin" />}
-              {!isLoading && i18n.add()}
-            </button>
-          </div>
-          <div className={styles.error}>{errorMessages.importFromId}</div>
         </BaseDialog>
         {displayLibrary && this.renderDisplayLibrary()}
       </div>

--- a/apps/src/code-studio/components/libraries/LibraryManagerDialog.jsx
+++ b/apps/src/code-studio/components/libraries/LibraryManagerDialog.jsx
@@ -1,6 +1,6 @@
 import $ from 'jquery';
+import classNames from 'classnames';
 import PropTypes from 'prop-types';
-import Radium from 'radium'; // eslint-disable-line no-restricted-imports
 import React from 'react';
 
 import LibraryClientApi from '@cdo/apps/code-studio/components/libraries/LibraryClientApi';
@@ -9,12 +9,10 @@ import LibraryViewCode from '@cdo/apps/code-studio/components/libraries/LibraryV
 import Button from '@cdo/apps/legacySharedComponents/Button';
 import FontAwesome from '@cdo/apps/legacySharedComponents/FontAwesome';
 import BaseDialog from '@cdo/apps/templates/BaseDialog';
-import color from '@cdo/apps/util/color';
 import i18n from '@cdo/locale';
 
 import libraryParser from './libraryParser';
-
-const DEFAULT_MARGIN = 7;
+import styles from './library-manager-dialog.module.scss';
 
 // Map userName from class libraries to project libraries so the author is displayed in the UI.
 // We only want users to see the author name for libraries from their classmates.
@@ -205,7 +203,7 @@ export class LibraryManagerDialog extends React.Component {
   displayProjectLibraries = () => {
     const {projectLibraries, updatedLibraryChannels} = this.state;
     if (!Array.isArray(projectLibraries) || !projectLibraries.length) {
-      return <div style={styles.message}>{i18n.noLibrariesInProject()}</div>;
+      return <div className={styles.message}>{i18n.noLibrariesInProject()}</div>;
     }
 
     const onUpdate = channelId => {
@@ -236,10 +234,10 @@ export class LibraryManagerDialog extends React.Component {
   displayClassLibraries = () => {
     const {classLibraries, errorMessages, sectionFilter} = this.state;
     if (errorMessages.loadClassLibraries) {
-      return <div style={styles.error}>{errorMessages.loadClassLibraries}</div>;
+      return <div className={styles.error}>{errorMessages.loadClassLibraries}</div>;
     }
     if (!Array.isArray(classLibraries) || !classLibraries.length) {
-      return <div style={styles.message}>{i18n.noLibrariesInClass()}</div>;
+      return <div className={styles.message}>{i18n.noLibrariesInClass()}</div>;
     }
 
     const filteredLibraries = sectionFilter
@@ -318,7 +316,7 @@ export class LibraryManagerDialog extends React.Component {
             onClose={onClose}
             sourceCode={displayLibrary.source}
             buttons={
-              <div style={styles.updateButtons}>
+              <div className={styles.updateButtons}>
                 <Button
                   text={i18n.cancel()}
                   color={Button.ButtonColor.gray}
@@ -360,14 +358,18 @@ export class LibraryManagerDialog extends React.Component {
         <BaseDialog
           isOpen
           handleClose={this.closeLibraryManager}
-          style={{...styles.dialog, ...(displayLibrary ? styles.hidden : {})}}
+          className={classNames(styles.dialog, {
+            [styles.hidden]: displayLibrary,
+          })}
           useUpdatedStyles
         >
-          <h1 style={styles.header}>{i18n.libraryManage()}</h1>
-          <div style={styles.libraryList}>{this.displayProjectLibraries()}</div>
-          <h2 style={styles.subHeader}>{i18n.libraryClassImport()}</h2>
+          <h1 className={styles.header}>{i18n.libraryManage()}</h1>
+          <div className={styles.libraryList}>
+            {this.displayProjectLibraries()}
+          </div>
+          <h2 className={styles.subHeader}>{i18n.libraryClassImport()}</h2>
           <div style={{textAlign: 'left'}}>
-            <label style={{...styles.message, display: 'inline'}}>
+            <label className={styles.messageInline}>
               {i18n.showingLibrariesFromSection()}
             </label>
             <select
@@ -383,17 +385,19 @@ export class LibraryManagerDialog extends React.Component {
               ))}
             </select>
           </div>
-          <div style={styles.libraryList}>{this.displayClassLibraries()}</div>
-          <h2 style={styles.subHeader}>{i18n.libraryIdImport()}</h2>
-          <div style={styles.inputParent} id="ui-test-import-library">
+          <div className={styles.libraryList}>
+            {this.displayClassLibraries()}
+          </div>
+          <h2 className={styles.subHeader}>{i18n.libraryIdImport()}</h2>
+          <div className={styles.inputParent} id="ui-test-import-library">
             <input
-              style={styles.linkBox}
+              className={styles.linkBox}
               type="text"
               value={importLibraryId}
               onChange={this.setLibraryToImport}
             />
             <button
-              style={styles.add}
+              className={styles.addButton}
               onClick={() => {
                 this.setState({isLoading: true});
                 this.fetchLatestLibrary(
@@ -409,80 +413,11 @@ export class LibraryManagerDialog extends React.Component {
               {!isLoading && i18n.add()}
             </button>
           </div>
-          <div style={styles.error}>{errorMessages.importFromId}</div>
+          <div className={styles.error}>{errorMessages.importFromId}</div>
         </BaseDialog>
         {displayLibrary && this.renderDisplayLibrary()}
       </div>
     );
   }
 }
-
-const styles = {
-  dialog: {
-    padding: '0 15px',
-    cursor: 'default',
-  },
-  linkBox: {
-    cursor: 'auto',
-    height: '22px',
-    marginBottom: 0,
-    flex: 1,
-    maxWidth: 400,
-  },
-  header: {
-    textAlign: 'left',
-    fontSize: 24,
-    marginTop: 20,
-  },
-  subHeader: {
-    textAlign: 'left',
-    fontSize: 18,
-    margin: DEFAULT_MARGIN,
-  },
-  libraryList: {
-    maxHeight: '200px',
-    overflowY: 'auto',
-    borderBottom: `2px solid ${color.purple}`,
-  },
-  message: {
-    color: color.dark_charcoal,
-    textAlign: 'left',
-    margin: DEFAULT_MARGIN,
-    overflow: 'hidden',
-    lineHeight: '15px',
-    whiteSpace: 'pre-wrap',
-  },
-  inputParent: {
-    display: 'flex',
-    alignItems: 'baseline',
-  },
-  add: {
-    margin: DEFAULT_MARGIN,
-    fontSize: 16,
-    padding: DEFAULT_MARGIN,
-    color: color.dark_charcoal,
-    borderColor: color.dark_charcoal,
-    ':disabled': {
-      color: color.light_gray,
-      borderColor: color.light_gray,
-      backgroundColor: color.lightest_gray,
-    },
-  },
-  hidden: {
-    visibility: 'hidden',
-  },
-  error: {
-    color: color.red,
-    textAlign: 'left',
-    margin: DEFAULT_MARGIN,
-    minHeight: 18,
-    whiteSpace: 'pre-wrap',
-    lineHeight: 1,
-  },
-  updateButtons: {
-    display: 'flex',
-    justifyContent: 'space-between',
-  },
-};
-
-export default Radium(LibraryManagerDialog);
+export default LibraryManagerDialog;

--- a/apps/src/code-studio/components/libraries/library-list-item.module.scss
+++ b/apps/src/code-studio/components/libraries/library-list-item.module.scss
@@ -1,0 +1,111 @@
+@import 'color';
+@import '@code-dot-org/component-library-styles/font';
+
+.listItem {
+  padding: 8px;
+  margin: 2px;
+  color: $dark_charcoal;
+  text-align: left;
+  display: flex;
+  border-bottom: 1px solid $lightest_gray;
+  line-height: 1.5;
+}
+
+.overflowEllipsis {
+  text-overflow: ellipsis;
+  overflow: hidden;
+}
+
+.titleSection {
+  margin-right: 25px;
+}
+
+.libraryTitle {
+  @include main-font-semi-bold;
+  font-size: 16px;
+  cursor: pointer;
+  color: $link_color;
+  text-decoration: underline;
+
+  &:hover {
+    color: $link_color;
+  }
+}
+
+.author {
+  @include main-font-regular;
+}
+
+.description {
+  margin-right: 25px;
+  flex-shrink: 2;
+}
+
+.actions {
+  display: flex;
+  flex-grow: 1;
+  justify-content: flex-end;
+}
+
+.actionBtn {
+  padding: 8px;
+  font-size: 18px;
+  background-color: $white;
+  border: 1px solid transparent;
+  cursor: pointer;
+
+  &:hover {
+    box-shadow: none;
+  }
+}
+
+.iconPadding {
+  padding: 0 2px;
+}
+
+.updateIcon {
+  padding: 0 1px;
+}
+
+.addBtn {
+  color: $link_color;
+  border-color: $link_color;
+
+  &:hover {
+    color: $white;
+    background-color: $link_color;
+  }
+}
+
+.updateBtn {
+  color: $orange;
+  border-color: $orange;
+
+  &:hover {
+    color: $white;
+    background-color: $orange;
+  }
+}
+
+.updateText {
+  @include main-font-semi-bold;
+  padding-left: 5px;
+  font-size: 16px;
+}
+
+.removeBtn {
+  color: $dark_red;
+  border-color: $dark_red;
+
+  &:hover {
+    color: $white;
+    background-color: $dark_red;
+  }
+
+  &:disabled {
+    color: $light_gray;
+    border-color: $light_gray;
+    background-color: $lightest_gray;
+    cursor: default;
+  }
+}

--- a/apps/src/code-studio/components/libraries/library-list-item.module.scss
+++ b/apps/src/code-studio/components/libraries/library-list-item.module.scss
@@ -22,7 +22,7 @@
 
 .libraryTitle {
   @include main-font-semi-bold;
-  font-size: 20px;
+  font-size: 16px;
   cursor: pointer;
   color: $link_color;
 

--- a/apps/src/code-studio/components/libraries/library-list-item.module.scss
+++ b/apps/src/code-studio/components/libraries/library-list-item.module.scss
@@ -22,13 +22,13 @@
 
 .libraryTitle {
   @include main-font-semi-bold;
-  font-size: 16px;
+  font-size: 20px;
   cursor: pointer;
   color: $link_color;
-  text-decoration: underline;
 
   &:hover {
     color: $link_color;
+    text-decoration: underline;
   }
 }
 

--- a/apps/src/code-studio/components/libraries/library-manager-dialog.module.scss
+++ b/apps/src/code-studio/components/libraries/library-manager-dialog.module.scss
@@ -9,6 +9,11 @@
   visibility: hidden;
 }
 
+.marginSides {
+  margin-left: 15px;
+  margin-right: 15px;
+}
+
 .header {
   text-align: left;
   font-size: 24px;
@@ -37,7 +42,6 @@
 }
 
 .messageInline {
-  composes: message;
   display: inline;
 }
 

--- a/apps/src/code-studio/components/libraries/library-manager-dialog.module.scss
+++ b/apps/src/code-studio/components/libraries/library-manager-dialog.module.scss
@@ -1,0 +1,85 @@
+@import 'color';
+
+.dialog {
+  padding: 0 15px;
+  cursor: default;
+}
+
+.hidden {
+  visibility: hidden;
+}
+
+.header {
+  text-align: left;
+  font-size: 24px;
+  margin-top: 20px;
+}
+
+.subHeader {
+  text-align: left;
+  font-size: 18px;
+  margin: 7px;
+}
+
+.libraryList {
+  max-height: 200px;
+  overflow-y: auto;
+  border-bottom: 2px solid $purple;
+}
+
+.message {
+  color: $dark_charcoal;
+  text-align: left;
+  margin: 7px;
+  overflow: hidden;
+  line-height: 15px;
+  white-space: pre-wrap;
+}
+
+.messageInline {
+  composes: message;
+  display: inline;
+}
+
+.inputParent {
+  display: flex;
+  align-items: baseline;
+}
+
+.linkBox {
+  cursor: auto;
+  height: 22px;
+  margin-bottom: 0;
+  flex: 1;
+  max-width: 400px;
+}
+
+.addButton {
+  margin: 7px;
+  font-size: 16px;
+  padding: 7px;
+  color: $dark_charcoal;
+  border: 1px solid $dark_charcoal;
+  cursor: pointer;
+
+  &:disabled {
+    color: $light_gray;
+    border-color: $light_gray;
+    background-color: $lightest_gray;
+    cursor: default;
+  }
+}
+
+.error {
+  color: $red;
+  text-align: left;
+  margin: 7px;
+  min-height: 18px;
+  white-space: pre-wrap;
+  line-height: 1;
+}
+
+.updateButtons {
+  display: flex;
+  justify-content: space-between;
+}


### PR DESCRIPTION
Refactors `LibraryManagerDialog` and `LibraryListItem` to no longer use Radium and extracts styles into their own files. 

No major changes to the styles:

**before** 
<img width="754" height="390" alt="libary_dialog_before" src="https://github.com/user-attachments/assets/b1784d76-923e-4fb7-a162-3e1592e64cd2" />

**after** 
<img width="723" height="404" alt="library_dialog_after" src="https://github.com/user-attachments/assets/001734e6-3836-4c28-b04f-d15b13197f5b" />



