### PR TITLE
Project saving metrics: use unknown for metrics logging if no app name

### DIFF
--- a/apps/src/code-studio/initApp/project.js
+++ b/apps/src/code-studio/initApp/project.js
@@ -906,6 +906,12 @@ var projects = (module.exports = {
     }
   },
 
+  // Metrics logging requires a non-null value, so we return 'unknown' if
+  // there is no known standalone app for this project.
+  getStandaloneAppForMetrics() {
+    return this.getStandaloneApp() || 'unknown';
+  },
+
   isWebLab() {
     return this.getStandaloneApp() === 'weblab';
   },
@@ -1145,7 +1151,7 @@ var projects = (module.exports = {
                 err.message
               );
               MetricsReporter.incrementCounter('LegacyLab.ProjectSaveFailure', [
-                {name: 'AppName', value: this.getStandaloneApp()},
+                {name: 'AppName', value: this.getStandaloneAppForMetrics()},
                 {name: 'SaveType', value: 'sources'},
               ]);
               if (saveSourcesErrorCount >= NUM_ERRORS_BEFORE_WARNING) {
@@ -1326,7 +1332,7 @@ var projects = (module.exports = {
           MetricsReporter.logError({
             event: 'Error in getUpdatedSourceAndHtml_',
             error: repackageError(error),
-            appType: this.getStandaloneApp(),
+            appType: this.getStandaloneAppForMetrics(),
             channelId: this.getCurrentId(),
           });
           callback({error});
@@ -1411,7 +1417,7 @@ var projects = (module.exports = {
       event: errorType,
       errorMessage: errorText,
       errorCount: errorCount,
-      appType: this.getStandaloneApp(),
+      appType: this.getStandaloneAppForMetrics(),
       channelId: this.getCurrentId(),
     });
 
@@ -1448,7 +1454,7 @@ var projects = (module.exports = {
         header.showTryAgainDialog();
       }
       MetricsReporter.incrementCounter('LegacyLab.ProjectSaveFailure', [
-        {name: 'AppName', value: this.getStandaloneApp()},
+        {name: 'AppName', value: this.getStandaloneAppForMetrics()},
         {name: 'SaveType', value: 'channel'},
       ]);
       return;
@@ -1480,7 +1486,7 @@ var projects = (module.exports = {
     current = current || {};
     Object.assign(current, data);
     MetricsReporter.incrementCounter('LegacyLab.ProjectSaveSuccess', [
-      {name: 'AppName', value: this.getStandaloneApp()},
+      {name: 'AppName', value: this.getStandaloneAppForMetrics()},
     ]);
 
     if (shouldNavigate) {


### PR DESCRIPTION
See [this slack thread](https://codedotorg.slack.com/archives/C03CK49G9/p1766086900575419?thread_ts=1765995877.297459&cid=C03CK49G9).
I updated both the logs and the metrics to use 'unknown' instead of `null` for the app name. I don't think the logs have the same issue as the metrics, but I figured it was good to be consistent.



## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
