### PR TITLE
Fix how students are deduplicated

### DIFF
--- a/dashboard/app/controllers/api_controller.rb
+++ b/dashboard/app/controllers/api_controller.rb
@@ -324,7 +324,7 @@ class ApiController < ApplicationController
     # occur when we get the progress for the student twice.  We saw two issues that were caused by
     # having duplicate students in a section AND the number of students being a multiple of the page amount
     # Deduplicating students ensures all data for all students is pulled.
-    deduplicated_students = section.students.distinct
+    deduplicated_students = section.students.distinct.order(:id)
     paged_students = deduplicated_students.page(page).per(per)
     # As designed, if there are 50 students, the client will ask for both
     # page 1 and page 2, even though page 2 is out of range. However, it should


### PR DESCRIPTION
This work was done in collaboration with Liam!

This addresses a problem Teacher Tools has run into occasionally on our progress page, both in the "legacy" and V2 views.  

In legacy view, this would show up in some sections when toggling over to level view.  While scrolling down the page would suddenly break and show the below error. 
<img width="875" height="487" alt="image" src="https://github.com/user-attachments/assets/1c946295-bf8d-42df-80e2-175394abed0d" />


In V2, the progress view would just constantly show "loading" skeleton as the data would constantly load and re-load. 

<img width="583" height="629" alt="image" src="https://github.com/user-attachments/assets/f215734f-9f70-46b9-932a-779c1552b22d" />



The "fix" was always to add or remove one student from the section.  This would fix the errors, but was not the ideal user experience

We were able to re-create this issue locally.  It seems like the issue is able to be re-created if you put 60 students all with the same name in the section AND give progress to one of the students.  We suspect that this issue was revealing itself in production when a section:

1. Has more than 20 students - probably more than 40 (20 students is considered a "page" in our system)
2. Two students have the same "name" and those two students straddled a "page" - say that they were students 20 and 21. 


The fix here is to modify how we "deduplicate" students so we rely solely on ID. 


## Links
[Jira ticket](https://codeorg.zendesk.com/agent/tickets/566998)
[Thread](https://codedotorg.slack.com/archives/C0462BZKHL6/p1765217659030839)

- Jira: 

## Testing story
<!--  Does your change include appropriate tests?
      - If so, please describe how the tests included in this PR are sufficient.
      - If not, please explain why this change does not need to be tested. -->



## Deployment strategy

- Deploy and revisit the above zen desk ticket to see if the section works now.