### PR TITLE
Fix web lab 2 preview for exemplars and start mode

### DIFF
--- a/apps/src/codebridge/FilePreview/HTMLPreview.tsx
+++ b/apps/src/codebridge/FilePreview/HTMLPreview.tsx
@@ -7,6 +7,11 @@ import React, {useEffect, useMemo, useRef, useState} from 'react';
 import codebridgeI18n from '@cdo/apps/codebridge/locale';
 import useLifecycleNotifier from '@cdo/apps/lab2/hooks/useLifecycleNotifier';
 import {setIsFullScreenView} from '@cdo/apps/lab2/lab2Redux';
+import {
+  getAppOptionsViewingExemplar,
+  getAppOptionsEditingExemplar,
+  getIsStartMode,
+} from '@cdo/apps/lab2/projects/utils';
 import {isPredictResponseSubmitted} from '@cdo/apps/lab2/redux/predictLevelRedux';
 import {MultiFileSource} from '@cdo/apps/lab2/types';
 import {LifecycleEvent, sendLab2AnalyticsEvent} from '@cdo/apps/lab2/utils';
@@ -36,8 +41,13 @@ export const HTMLPreview: React.FC = () => {
     // and domain names are case-insensitive.
     state => state.lab.channel?.id?.toLowerCase().replace('_', '') || ''
   );
+
+  const isViewingExemplar = getAppOptionsViewingExemplar();
+  const isEditingExemplar = getAppOptionsEditingExemplar();
+  const isStartMode = getIsStartMode();
   const isFullScreenView = useAppSelector(state => state.lab.isFullScreenView);
   const {levelProperties} = useCodebridgeContext();
+  const levelId = levelProperties.id;
   const iframeRef = useRef<HTMLIFrameElement | null>(null);
   const previewContainerRef = useRef<HTMLDivElement | null>(null);
   const previewUrl = useMemo(() => {
@@ -48,17 +58,36 @@ export const HTMLPreview: React.FC = () => {
       experiments.LOCAL_WEBLAB2_PREVIEW
     );
     const isLocalhost = 'localhost' === environmentKey;
+
     // When testing on localhost, it can be convenient to have a fixed subdomain
     // to avoid having to give permissions to every channel id version of the preview url.
     // Use the flag ?local-weblab2-preview=true or ?enableExperiments=local-weblab2-preview
     // to enable the fixed prefix locally.
-    const prefix =
+    let prefix =
       useLocalPrefixOverride && isLocalhost
         ? 'localtesting'
         : normalizedChannelId;
+    // In some cases we have no channel id, so we fall back to other prefixes.
+    if (!prefix) {
+      if (isViewingExemplar || isEditingExemplar) {
+        prefix = `exemplar-${levelId}`;
+      } else if (isStartMode) {
+        prefix = `start-mode-${levelId}`;
+      } else {
+        // Unknown channel, not in exemplar or start mode, use generic preview prefix.
+        prefix = 'weblab2-project';
+      }
+    }
+
     const port = isLocalhost && location.port ? `:${location.port}` : '';
     return `${location.protocol}//${prefix}.preview.${subdomain}codeprojects.org${port}`;
-  }, [normalizedChannelId]);
+  }, [
+    isEditingExemplar,
+    isStartMode,
+    isViewingExemplar,
+    levelId,
+    normalizedChannelId,
+  ]);
 
   const isAiTutorVersion = useAppSelector(
     state => state.lab2Project.viewingAiTutorVersion

--- a/apps/src/codebridge/FilePreview/HTMLPreview.tsx
+++ b/apps/src/codebridge/FilePreview/HTMLPreview.tsx
@@ -75,7 +75,7 @@ export const HTMLPreview: React.FC = () => {
         prefix = `start-mode-${levelId}`;
       } else {
         // Unknown channel, not in exemplar or start mode, use generic preview prefix.
-        prefix = 'weblab2-project';
+        prefix = `weblab2-${levelId}`;
       }
     }
 


### PR DESCRIPTION
We now prefix all preview urls with a subdomain to support the upcoming preview. The prefix is normally defined by the channel id. However, for exemplars and start mode, there is no channel id, so the preview was failing to load because we didn't have an alternative prefix. This adds fallback prefixes for the case of no channel id, in exemplar mode, start mode, or any other case.

Before we would see this when viewing exemplar/start code:

<img width="398" height="959" alt="Screenshot 2025-12-18 at 1 28 46 PM" src="https://github.com/user-attachments/assets/7fb52eb5-e43f-46bd-93ec-7fc7f4e1ffa2" />

After we see the preview as expected.


## Links
- [slack](https://codedotorg.slack.com/archives/C06JELCAPT9/p1766090930026639?thread_ts=1766079618.242379&cid=C06JELCAPT9)

## Testing story
Tested locally.


## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
