### PR TITLE
Web Lab 2: fix start images in v2 preview

### DIFF
--- a/apps/src/codebridge/FilePreview/weblab2_project_service_worker.js
+++ b/apps/src/codebridge/FilePreview/weblab2_project_service_worker.js
@@ -24,7 +24,7 @@ function main() {
   const broadcastChannel = new BroadcastChannel(
     PROJECT_SERVICE_WORKER_BROADCAST_CHANNEL
   );
-  const originForUrls = getOriginForUrls();
+  const codeDotOrgOrigin = getCodeDotOrgOrigin();
 
   addEventListener('install', () => {
     // Ensure this service worker is activated immediately.
@@ -82,8 +82,8 @@ function main() {
     return requestedFile;
   }
 
-  // If a url starts with `/`, we want to fetch it from the code.org origin for this environment.
-  function getOriginForUrls() {
+  // Code.org origin for this environment.
+  function getCodeDotOrgOrigin() {
     const regex = /[^.]+\.preview\.([^.]+)\.codeprojects\.org/;
     const match = location.hostname.match(regex);
     const environment = match && match[1] ? `${match[1]}-` : '';
@@ -105,12 +105,9 @@ function main() {
       if (url) {
         let fetchUrl = url;
         if (url.startsWith('/level_starter_assets/')) {
-          // Prepend the origin for level starter assets requests.
-          fetchUrl = originForUrls + url;
+          // We fetch level starter assets from the code.org origin for this environment.
+          fetchUrl = codeDotOrgOrigin + url;
         }
-        console.log(
-          `Service worker fetching external URL for ${requestedFile}: ${fetchUrl}`
-        );
         return await fetch(fetchUrl);
       }
       return new Response(content, {

--- a/apps/src/codebridge/FilePreview/weblab2_project_service_worker.js
+++ b/apps/src/codebridge/FilePreview/weblab2_project_service_worker.js
@@ -24,6 +24,7 @@ function main() {
   const broadcastChannel = new BroadcastChannel(
     PROJECT_SERVICE_WORKER_BROADCAST_CHANNEL
   );
+  const originForUrls = getOriginForUrls();
 
   addEventListener('install', () => {
     // Ensure this service worker is activated immediately.
@@ -81,6 +82,17 @@ function main() {
     return requestedFile;
   }
 
+  // If a url starts with `/`, we want to fetch it from the code.org origin for this environment.
+  function getOriginForUrls() {
+    const regex = /[^.]+\.preview\.([^.]+)\.codeprojects\.org/;
+    const match = location.hostname.match(regex);
+    const environment = match && match[1] ? `${match[1]}-` : '';
+    const port =
+      'localhost-' === environment && location.port ? `:${location.port}` : '';
+    const cdn = environment.includes('adhoc') ? 'cdn-' : '';
+    return `${location.protocol}//${environment}studio.${cdn}code.org${port}`;
+  }
+
   async function handleProjectRequest(requestedFile, fileData) {
     try {
       const {content, mimeType, url} = fileData;
@@ -91,7 +103,15 @@ function main() {
         });
       }
       if (url) {
-        return await fetch(url);
+        let fetchUrl = url;
+        if (url.startsWith('/level_starter_assets/')) {
+          // Prepend the origin for level starter assets requests.
+          fetchUrl = originForUrls + url;
+        }
+        console.log(
+          `Service worker fetching external URL for ${requestedFile}: ${fetchUrl}`
+        );
+        return await fetch(fetchUrl);
       }
       return new Response(content, {
         status: 200,

--- a/dashboard/app/controllers/level_starter_assets_controller.rb
+++ b/dashboard/app/controllers/level_starter_assets_controller.rb
@@ -39,15 +39,15 @@ class LevelStarterAssetsController < ApplicationController
     uuid_name = "#{params[:uuid]}.#{params[:format]}"
 
     preview_host = CDO.preview_codeprojects_hostname
-    preview_regex = nil
     # Allow any subdomain of codeprojects preview (with optional port) to fetch level starter assets.
     if preview_host.present?
       preview_regex = %r{\Ahttps?://[^/]+\.#{Regexp.escape(preview_host)}(:\d+)?\z}
+      # If the request's origin matches the preview host, set CORS header to allow it.
+      if request.origin&.match?(preview_regex)
+        response.headers['Access-Control-Allow-Origin'] = request.origin
+      end
     end
-    # If the request's origin matches the preview host, set CORS header to allow it.
-    if preview_regex && (request.origin =~ preview_regex)
-      response.headers['Access-Control-Allow-Origin'] = request.origin
-    end
+
     get_file_and_send(uuid_name)
   end
 

--- a/dashboard/app/controllers/level_starter_assets_controller.rb
+++ b/dashboard/app/controllers/level_starter_assets_controller.rb
@@ -36,19 +36,17 @@ class LevelStarterAssetsController < ApplicationController
   # and the level's start_sources manages the mapping between friendly names
   # and UUIDs.
   def file_by_uuid
-    puts "hi from file_by_uuid"
     uuid_name = "#{params[:uuid]}.#{params[:format]}"
 
     preview_host = CDO.preview_codeprojects_hostname
     preview_regex = nil
-    # Allow any subdomain of the preview host (with optional port)
+    # Allow any subdomain of codeprojects preview (with optional port) to fetch level starter assets.
     if preview_host.present?
-      preview_regex = %r{\Ahttps?://[^/]*\.#{Regexp.escape(preview_host)}(:\d+)?\z}
+      preview_regex = %r{\Ahttps?://[^/]+\.#{Regexp.escape(preview_host)}(:\d+)?\z}
     end
-    puts "preview regex is " + preview_regex
-    if preview_regex && (request.referer =~ preview_regex)
-      puts "setting CORS header for #{request.referer}"
-      request.headers['Access-Control-Allow-Origin'] = request.referer
+    # If the request's origin matches the preview host, set CORS header to allow it.
+    if preview_regex && (request.origin =~ preview_regex)
+      response.headers['Access-Control-Allow-Origin'] = request.origin
     end
     get_file_and_send(uuid_name)
   end

--- a/dashboard/app/controllers/level_starter_assets_controller.rb
+++ b/dashboard/app/controllers/level_starter_assets_controller.rb
@@ -36,7 +36,20 @@ class LevelStarterAssetsController < ApplicationController
   # and the level's start_sources manages the mapping between friendly names
   # and UUIDs.
   def file_by_uuid
+    puts "hi from file_by_uuid"
     uuid_name = "#{params[:uuid]}.#{params[:format]}"
+
+    preview_host = CDO.preview_codeprojects_hostname
+    preview_regex = nil
+    # Allow any subdomain of the preview host (with optional port)
+    if preview_host.present?
+      preview_regex = %r{\Ahttps?://[^/]*\.#{Regexp.escape(preview_host)}(:\d+)?\z}
+    end
+    puts "preview regex is " + preview_regex
+    if preview_regex && (request.referer =~ preview_regex)
+      puts "setting CORS header for #{request.referer}"
+      request.headers['Access-Control-Allow-Origin'] = request.referer
+    end
     get_file_and_send(uuid_name)
   end
 

--- a/dashboard/config/routes.rb
+++ b/dashboard/config/routes.rb
@@ -39,6 +39,8 @@ Dashboard::Application.routes.draw do
     get '/', to: 'codeprojects_preview#show'
     # Must be served from / on preview.codeprojects.org to control the root scope:
     get '/weblab2_project_service_worker.js', to: 'codeprojects_preview#weblab2_project_service_worker'
+    # We proxy level starter assets requests so that we can serve starter assets from the preview page.
+    get '/level_starter_assets/uuid/:uuid', to: 'level_starter_assets#file_by_uuid', format: true
     # Custom 404 page for codeprojects preview
     get '*path', to: 'codeprojects_preview#not_found'
   end

--- a/dashboard/config/routes.rb
+++ b/dashboard/config/routes.rb
@@ -39,8 +39,6 @@ Dashboard::Application.routes.draw do
     get '/', to: 'codeprojects_preview#show'
     # Must be served from / on preview.codeprojects.org to control the root scope:
     get '/weblab2_project_service_worker.js', to: 'codeprojects_preview#weblab2_project_service_worker'
-    # We proxy level starter assets requests so that we can serve starter assets from the preview page.
-    get '/level_starter_assets/uuid/:uuid', to: 'level_starter_assets#file_by_uuid', format: true
     # Custom 404 page for codeprojects preview
     get '*path', to: 'codeprojects_preview#not_found'
   end

--- a/dashboard/test/controllers/level_starter_assets_controller_test.rb
+++ b/dashboard/test/controllers/level_starter_assets_controller_test.rb
@@ -141,6 +141,47 @@ class LevelStarterAssetsControllerTest < ActionController::TestCase
     assert_equal 'inline', response.headers['Content-Disposition']
   end
 
+  test 'file_by_uuid: returns file and CORS header for allowed origin' do
+    allowed_origin = "https://test.#{CDO.preview_codeprojects_hostname}"
+    @request.headers['Origin'] = allowed_origin
+
+    LevelStarterAssetsHelper.
+      expects(:get_object).
+      with(@uuid_name).
+      returns(@file_obj)
+    LevelStarterAssetsHelper.
+      expects(:read_file).
+      with(@file_obj).
+      returns('hello, world!')
+
+    level = create(:weblab2)
+    get :file_by_uuid, params: {level_name: level.name, uuid: @uuid, format: 'png'}
+
+    assert_response :success
+    assert_equal 'hello, world!', response.body
+    assert_equal 'image/png', response.headers['Content-Type']
+    assert_equal allowed_origin, response.headers['Access-Control-Allow-Origin']
+  end
+
+  test 'file_by_uuid: no CORS header provided for disallowed origin' do
+    @request.headers['Origin'] = 'https://evil.example'
+
+    LevelStarterAssetsHelper.
+      expects(:get_object).
+      with(@uuid_name).
+      returns(@file_obj)
+    LevelStarterAssetsHelper.
+      expects(:read_file).
+      with(@file_obj).
+      returns('hello, world!')
+
+    level = create(:weblab2)
+    get :file_by_uuid, params: {level_name: level.name, uuid: @uuid, format: 'png'}
+
+    # Expect to see a missing CORS header for the disallowed origin.
+    assert_nil response.headers['Access-Control-Allow-Origin']
+  end
+
   test 'upload: forbidden for non-levelbuilders' do
     sign_in create(:student)
     post :upload, params: {level_name: create(:applab).name, files: []}


### PR DESCRIPTION
In the v2 preview, starter images (those with a `level_starter_assets` url) were not loading. This was because we were trying to fetch them via the preview domain, which is not connected to the level starter assets controller. Interestingly it can proxy the `v3/assets` requests, presumably because those are not done via standard rails routes.

To fix this, when we fetch `level_starter_assets` from the service worker, we will update the url to instead fetch from the code.org domain instead. When I first tried this I ran into an issue with CORS, because of the cross-domain request. To fix that issue, I updated the CORS header of only the `uuid` route to allow requests from codeprojects preview. I considered proxying the level_starter_assets through codeprojects preview, but this path was easier to do down.

After this change, any image should show up in the new preview, whether it was added via a student or levelbuilder upload.

## Links
- [slack thread](https://codedotorg.slack.com/archives/C06JELCAPT9/p1766079618242379)

## Testing story
Tested locally and added unit tests.


## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
