### PR TITLE
Fix exception on extra links abort controller

### DIFF
--- a/apps/src/lab2/hooks/useExtraLinks.ts
+++ b/apps/src/lab2/hooks/useExtraLinks.ts
@@ -86,7 +86,6 @@ export const useExtraLinks = (levelId: number) => {
         }
       })
       .catch(e => {
-        setIsLoading(false);
         if (e.name === 'AbortError') {
           // Ignore abort errors
           return;
@@ -96,6 +95,7 @@ export const useExtraLinks = (levelId: number) => {
           .logError('Error fetching extra links data', e as Error, {
             message: e.message,
           });
+        setIsLoading(false);
       });
 
     return () => abortController.abort();

--- a/apps/src/lab2/hooks/useExtraLinks.ts
+++ b/apps/src/lab2/hooks/useExtraLinks.ts
@@ -5,7 +5,6 @@ import HttpClient from '@cdo/apps/util/HttpClient';
 import {useAppSelector} from '@cdo/apps/util/reduxHooks';
 
 import {PERMISSIONS} from '../constants';
-import Lab2MetricsReporter from '../Lab2MetricsReporter';
 import Lab2Registry from '../Lab2Registry';
 import {ExtraLinksLevelData, ExtraLinksProjectData} from '../types';
 

--- a/apps/src/lab2/hooks/useExtraLinks.ts
+++ b/apps/src/lab2/hooks/useExtraLinks.ts
@@ -5,6 +5,8 @@ import HttpClient from '@cdo/apps/util/HttpClient';
 import {useAppSelector} from '@cdo/apps/util/reduxHooks';
 
 import {PERMISSIONS} from '../constants';
+import Lab2MetricsReporter from '../Lab2MetricsReporter';
+import Lab2Registry from '../Lab2Registry';
 import {ExtraLinksLevelData, ExtraLinksProjectData} from '../types';
 
 interface ExtraLinksData {
@@ -76,12 +78,25 @@ export const useExtraLinks = (levelId: number) => {
       scriptLevelId,
       channelId,
       abortController.signal
-    ).then(data => {
-      if (!abortController.signal.aborted) {
-        setExtraLinksData(data);
+    )
+      .then(data => {
+        if (!abortController.signal.aborted) {
+          setExtraLinksData(data);
+          setIsLoading(false);
+        }
+      })
+      .catch(e => {
         setIsLoading(false);
-      }
-    });
+        if (e.name === 'AbortError') {
+          // Ignore abort errors
+          return;
+        }
+        Lab2Registry.getInstance()
+          .getMetricsReporter()
+          .logError('Error fetching extra links data', e as Error, {
+            message: e.message,
+          });
+      });
 
     return () => abortController.abort();
   }, [permissions, levelId, scriptLevelId, channelId]);


### PR DESCRIPTION
@fisher-alice discovered that for some reason project validator accounts end up triggering an abort controller abort in `useExtraLinks` in the process of page loading. On prod this triggers a console error, on local it triggers the full page error which can be hard to exit out of.

This catches the exception appropriately. If it's not an abort error, we'll log it but not throw anything, since extra links not loading shouldn't block the page from loading.


## Testing story
Tested locally that the error is no longer thrown for project validator accounts.



## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
