### PR TITLE
Disable Eyes Logging by Default

### DIFF
--- a/dashboard/test/ui/features/step_definitions/eyes_steps.rb
+++ b/dashboard/test/ui/features/step_definitions/eyes_steps.rb
@@ -83,7 +83,10 @@ def ensure_eyes_available
   return if @eyes
   @eyes = Applitools::Selenium::Eyes.new
   @eyes.api_key = CDO.applitools_eyes_api_key
-  @eyes.log_handler = Logger.new('../../log/eyes.log')
+  # Disables Eyes SDK logging by default.
+  @eyes.log_handler = Logger.new('../../log/eyes.log') if DCDO.get('eyes_logging', false)
+  # Disable Eyes Universal Core logging by default, which logs to `/tmp/applitools-log/`.
+  eyes.configuration.show_logs = DCDO.get('eyes_logging', false)
 end
 
 # There are several fonts we sometimes load associated with Font Awesome, but Font Awesome 6 at the "solid" weight (900) is our default,


### PR DESCRIPTION
Our managed test server storage utilization breached 90% today because `/tmp/applitools-logs/` was consuming 131GB (Volume is 256GB). Also `/dashboard/log/eyes*.log*` is consuming ~2GB.

## Testing story

Not sure 🤔. Our managed test server is the only place where the Eyes logic is fully enabled.


## Deployment strategy
<!--  Any special steps required to deploy this, besides merging?
      - Are there database migrations or manual steps?
      - Does this require coordination with other teams or systems? -->



## Follow-up work
<!--  List any clean-up or technical debt that will be addressed in future work.
      - Include Jira links where applicable.
      - Are there any known limitations or improvements planned? -->



## Privacy
<!--  How does this change impact Student & Teacher privacy?
      - Does this collect, use, share, or modify PII, either new or existing? -->



## Security
<!--  How does this change impact our security surface-area?
      - Do API's touched have the right auth?
      - Do infra changes impact our attack surface or encryption?
-->



## Caching
<!--  How does this change impact caching behavior?
      - Are cache keys or invalidation strategies affected?
      - Will this require cache warming or invalidation after deployment? -->



## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
