### PR TITLE
P20-1722: Ensure clean session for assumed identity

### DIFF
--- a/dashboard/app/controllers/admin_users_controller.rb
+++ b/dashboard/app/controllers/admin_users_controller.rb
@@ -52,9 +52,16 @@ class AdminUsersController < ApplicationController
 
     if user
       log_admin_action("assume_identity", user.id)
+
+      admin = current_user
+
+      # Ensures a clean new session for the assumed identity
+      sign_out admin
+      reset_session
+
       # Set cookie to indicate assumed identity
       session[:assumed_identity] = true
-      session[:admin_id] = current_user.id
+      session[:admin_id] = admin.id
 
       bypass_sign_in user
       redirect_to '/'


### PR DESCRIPTION
An attempt to fix the identity assumption issue, where the Account Settings page frequently shows the admin account instead of the assumed identity

## Links
- JIRA task: [P20-1722](https://codedotorg.atlassian.net/browse/P20-1722)