### PR TITLE
P20-1752: Bump httparty from 0.21.0 to 0.24.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -292,7 +292,7 @@ gem 'pusher', '~> 1.3.1', require: false
 gem 'youtube-dl.rb', group: [:development, :staging, :levelbuilder]
 
 gem 'daemons', '1.1.9' # Pinned to old version, see PR 57938
-gem 'httparty'
+gem 'httparty', '~> 0.24'
 gem 'oj', '~> 3.10'
 
 gem 'rest-client', '~> 2.0.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -510,7 +510,8 @@ GEM
     http-cookie (1.0.6)
       domain_name (~> 0.5)
     http-form_data (2.3.0)
-    httparty (0.21.0)
+    httparty (0.24.0)
+      csv
       mini_mime (>= 1.0.0)
       multi_xml (>= 0.5.2)
     httpclient (2.8.3)
@@ -1072,7 +1073,7 @@ DEPENDENCIES
   hoc_legacy!
   honeybadger (>= 4.5.6)
   http (~> 5.3.1)
-  httparty
+  httparty (~> 0.24)
   image_optim!
   image_optim_pack (~> 0.5.0)!
   image_optim_rails (~> 0.4.0)


### PR DESCRIPTION
Fixes https://github.com/code-dot-org/code-dot-org/security/dependabot/1026

## Links
- JIRA task: [P20-1752](https://codedotorg.atlassian.net/browse/P20-1752)