### PR TITLE
P20-1753: Bump rack from 2.2.9 to 2.2.21

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -719,7 +719,7 @@ GEM
     rack-session (1.0.2)
       rack (< 3)
     rack-ssl-enforcer (0.2.9)
-    rack-test (2.0.2)
+    rack-test (2.2.0)
       rack (>= 1.3)
     rack_csrf (2.7.0)
       rack (>= 1.1.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -705,7 +705,7 @@ GEM
     pusher-signature (0.1.8)
     pycall (1.5.2)
     racc (1.8.1)
-    rack (2.2.9)
+    rack (2.2.21)
     rack-cache (1.13.0)
       rack (>= 0.4)
     rack-cors (2.0.1)


### PR DESCRIPTION
## Fixes:
- https://github.com/code-dot-org/code-dot-org/security/dependabot/886
- https://github.com/code-dot-org/code-dot-org/security/dependabot/981
- https://github.com/code-dot-org/code-dot-org/security/dependabot/979
- https://github.com/code-dot-org/code-dot-org/security/dependabot/912
- https://github.com/code-dot-org/code-dot-org/security/dependabot/983
- https://github.com/code-dot-org/code-dot-org/security/dependabot/971
- https://github.com/code-dot-org/code-dot-org/security/dependabot/977

# Links
- JIRA task: [P20-1753](https://codedotorg.atlassian.net/browse/P20-1753)