### PR TITLE
fix(dashboard/tests): setup fixtures for each transactional test case

### DIFF
--- a/dashboard/test/testing/transactional_test_case.rb
+++ b/dashboard/test/testing/transactional_test_case.rb
@@ -16,7 +16,10 @@ module ActiveSupport
         class_attribute :use_transactional_test_case, instance_writer: false, default: false
 
         setup_all do
-          begin_transaction if use_transactional_test_case?
+          if use_transactional_test_case?
+            setup_fixtures
+            begin_transaction
+          end
         end
 
         teardown_all do


### PR DESCRIPTION
## Issue
Running `dashboard/test/models/user_test.rb` locally, I noticed that some tests start failing on the second run with `ActiveRecord::RecordInvalid: Validation failed: Name has already been taken`. Cleaning the database resolves the issue. This suggests that `setup_fixtures` performs the required preparation that some tests rely on:
https://github.com/code-dot-org/code-dot-org/pull/70011/changes#diff-eb47820cae5ae9559352d9989d041d563a4586c952b0a9251f52e1cc7d48e6f9L27

## Links
- Related PR: https://github.com/code-dot-org/code-dot-org/pull/70011