### PR TITLE
P20-1549: Fix `User.find_channel_owner` test

### DIFF
--- a/dashboard/test/models/user_test.rb
+++ b/dashboard/test/models/user_test.rb
@@ -4000,7 +4000,6 @@ class UserTest < ActiveSupport::TestCase
   end
 
   test 'find_channel_owner returns nil for channel with no owner' do
-    skip # flaky test. see https://github.com/code-dot-org/code-dot-org/pull/66713
     with_anonymous_channel do |project_id, storage_id|
       encrypted_channel_id = storage_encrypt_channel_id storage_id, project_id
       result = User.find_channel_owner encrypted_channel_id

--- a/dashboard/test/testing/projects_test_utils.rb
+++ b/dashboard/test/testing/projects_test_utils.rb
@@ -17,18 +17,11 @@ module ProjectsTestUtils
 
   # @param [User] user - may be nil for anonymous storage id
   def with_storage_id_for(user)
-    owns_storage_id = false
     user_id = user&.id
 
-    storage_id = storage_id_for_user_id(user_id)
-    unless storage_id
-      storage_id = create_storage_id_for_user(user_id)
-      owns_storage_id = true
+    user_storage_ids_table.db.transaction(joinable: false, rollback: :always) do
+      yield storage_id_for_user_id(user_id) || create_storage_id_for_user(user_id)
     end
-
-    yield storage_id
-  ensure
-    delete_storage_id_for_user(user_id) if owns_storage_id
   end
 
   def with_anonymous_channel(&block)


### PR DESCRIPTION
## Issue
```bash
=ERROR["test_find_channel_owner_returns_nil_for_channel_with_no_owner", "UserTest", 670.325951756]
740 | test_find_channel_owner_returns_nil_for_channel_with_no_owner#UserTest (670.33s)
741 | Minitest::UnexpectedError:         Sequel::DatabaseError: Mysql2::Error::TimeoutError: Timeout waiting for a response from the last query. (waited 30 seconds)
742 | test/testing/projects_test_utils.rb:31:in `with_storage_id_for'
743 | test/testing/projects_test_utils.rb:9:in `with_channel_for'
744 | test/testing/projects_test_utils.rb:35:in `with_anonymous_channel'
745 | test/models/user_test.rb:4246:in `block in <class:UserTest>'
746 | test/testing/setup_all_and_teardown_all.rb:36:in `run'
```

## Links
- JIRA task: [P20-1549](https://codedotorg.atlassian.net/browse/P20-1549)
- Related PR: https://github.com/code-dot-org/code-dot-org/pull/66713