### PR TITLE
Deprecate the pwc unit

### DIFF
--- a/dashboard/config/scripts_json/pwc.script_json
+++ b/dashboard/config/scripts_json/pwc.script_json
@@ -18,7 +18,8 @@
       ],
       "content_area": "hoc",
       "curriculum_umbrella": "HOC",
-      "is_migrated": true
+      "is_migrated": true,
+      "is_deprecated": true
     },
     "new_name": null,
     "family_name": null,


### PR DESCRIPTION
This is an old course with limited usage that PwC (the organization we collaborated with) has asked us to take down. Bryan added a banner before break warning users.

Longer discussion here: https://codedotorg.slack.com/archives/CFGAVL2CA/p1765401187366319



