### PR TITLE
Lab2: remove script level ID from find project API

### DIFF
--- a/apps/src/bubbleChoice/customModes/MusicDanceAi/MusicDanceAi.tsx
+++ b/apps/src/bubbleChoice/customModes/MusicDanceAi/MusicDanceAi.tsx
@@ -5,7 +5,6 @@ import React, {memo, Suspense, useCallback, useEffect, useState} from 'react';
 
 import {
   getCurrentLesson,
-  getCurrentScriptLevelId,
   levelById,
 } from '@cdo/apps/code-studio/progressReduxSelectors';
 import {GENERATED_DANCER_STORAGE_KEY} from '@cdo/apps/dance/ai/constants';
@@ -99,7 +98,6 @@ const MusicDanceAi: React.FC<MusicDanceAiProps> = ({
   const [tabDataMap, setTabDataMap] = useState<{[tab in Tab]?: LabData}>();
   const userId = useAppSelector(state => state.progress.viewAsUserId);
   const scriptId = useAppSelector(state => state.progress.scriptId);
-  const scriptLevelId = useAppSelector(getCurrentScriptLevelId);
   const dispatch = useAppDispatch();
 
   const levelPropertiesPathPrefix = useAppSelector(state => {
@@ -191,8 +189,7 @@ const MusicDanceAi: React.FC<MusicDanceAiProps> = ({
         projectManager = await ProjectManagerFactory.getProjectManagerForLevel(
           parseInt(sublevel.level_id),
           userId || undefined,
-          scriptId || undefined,
-          scriptLevelId || undefined
+          scriptId || undefined
         );
       }
 
@@ -221,7 +218,6 @@ const MusicDanceAi: React.FC<MusicDanceAiProps> = ({
     channel.subprojects,
     userId,
     scriptId,
-    scriptLevelId,
     getLevelPropertiesPath,
     dispatch,
     tabDataMap,

--- a/apps/src/lab2/lab2Redux.ts
+++ b/apps/src/lab2/lab2Redux.ts
@@ -133,7 +133,6 @@ export const setUpWithLevel = createAsyncThunk<
     userAppOptionsPath?: string;
     channelId?: string;
     userId?: number;
-    scriptLevelId?: string;
   },
   {dispatch: AppDispatch; state: RootState}
 >('lab/setUpWithLevel', async (payload, thunkAPI) => {
@@ -226,8 +225,7 @@ export const setUpWithLevel = createAsyncThunk<
       : await ProjectManagerFactory.getProjectManagerForLevel(
           payload.levelId,
           payload.userId,
-          payload.scriptId,
-          payload.scriptLevelId
+          payload.scriptId
         );
 
     // Only set the project manager and initiate load

--- a/apps/src/lab2/projects/ChannelsStore.ts
+++ b/apps/src/lab2/projects/ChannelsStore.ts
@@ -11,18 +11,8 @@ import * as projectsApi from './projectsApi';
 export class ChannelsStore {
   defaultChannel: DefaultChannel = {name: 'New Project'};
 
-  loadForLevel(
-    levelId: number,
-    scriptId?: number,
-    scriptLevelId?: string,
-    userId?: number
-  ) {
-    return projectsApi.getChannelForLevel(
-      levelId,
-      scriptId,
-      scriptLevelId,
-      userId
-    );
+  loadForLevel(levelId: number, scriptId?: number, userId?: number) {
+    return projectsApi.getChannelForLevel(levelId, scriptId, userId);
   }
 
   load(channelId: string) {

--- a/apps/src/lab2/projects/ProjectContainer.tsx
+++ b/apps/src/lab2/projects/ProjectContainer.tsx
@@ -10,7 +10,6 @@ import {useSelector} from 'react-redux';
 import header from '@cdo/apps/code-studio/header';
 import {clearHeader} from '@cdo/apps/code-studio/headerRedux';
 import {
-  getCurrentScriptLevelId,
   getLevelPropertiesPath,
   getUserAppOptionsPath,
 } from '@cdo/apps/code-studio/progressReduxSelectors';
@@ -38,7 +37,6 @@ const ProjectContainer: React.FunctionComponent<ProjectContainerProps> = ({
   const scriptId = useAppSelector(
     state => state.progress.scriptId || undefined
   );
-  const scriptLevelId = useSelector(getCurrentScriptLevelId);
 
   const isStandaloneProjectLevel = useAppSelector(
     state => state.lab.levelProperties?.isProjectLevel
@@ -79,7 +77,6 @@ const ProjectContainer: React.FunctionComponent<ProjectContainerProps> = ({
           levelId: parseInt(currentLevelId),
           userId,
           scriptId,
-          scriptLevelId,
           levelPropertiesPath,
           userAppOptionsPath,
           channelId,
@@ -96,7 +93,6 @@ const ProjectContainer: React.FunctionComponent<ProjectContainerProps> = ({
     appName,
     currentLevelId,
     scriptId,
-    scriptLevelId,
     levelPropertiesPath,
     userAppOptionsPath,
     dispatch,

--- a/apps/src/lab2/projects/ProjectManagerFactory.ts
+++ b/apps/src/lab2/projects/ProjectManagerFactory.ts
@@ -35,14 +35,12 @@ export default class ProjectManagerFactory {
    * @param levelId The identifier for the level.
    * @param userId The user ID of the creator.  Can be undefined if the user is looking at their own work.
    * @param scriptId The id of the script. Can be undefined if the level is not in the context of a script.
-   * @param scriptLevelId the ID of the script level (if different from the level ID). Can be undefined if the level is not in the context of a script.
    * @returns A project manager
    */
   static async getProjectManagerForLevel(
     levelId: number,
     userId?: number,
-    scriptId?: number,
-    scriptLevelId?: string
+    scriptId?: number
   ): Promise<ProjectManager | null> {
     const channelsStore = new ChannelsStore();
     let channelId: string | undefined = undefined;
@@ -50,7 +48,6 @@ export default class ProjectManagerFactory {
     const response = await channelsStore.loadForLevel(
       levelId,
       scriptId,
-      scriptLevelId,
       userId
     );
     if (response.ok) {

--- a/apps/src/lab2/projects/projectsApi.ts
+++ b/apps/src/lab2/projects/projectsApi.ts
@@ -9,15 +9,11 @@ const rootUrl = '/projects/';
 export async function getChannelForLevel(
   levelId: number,
   scriptId?: number,
-  scriptLevelId?: string,
   userId?: number
 ): Promise<Response> {
   let requestString = rootUrl;
   if (scriptId !== undefined) {
     requestString += `script/${scriptId}/`;
-  }
-  if (scriptLevelId !== undefined) {
-    requestString += `script_level/${scriptLevelId}/`;
   }
   requestString += `level/${levelId}`;
   if (userId !== undefined) {

--- a/dashboard/app/controllers/projects_controller.rb
+++ b/dashboard/app/controllers/projects_controller.rb
@@ -361,7 +361,6 @@ class ProjectsController < ApplicationController
   # Returns json: {channel: <encrypted-channel-token>}
   def get_or_create_for_level
     script_id = params[:script_id]
-    script_level_id = params[:script_level_id]
     level = Level.find(params[:level_id])
     user_id = params[:user_id]
 
@@ -370,17 +369,8 @@ class ProjectsController < ApplicationController
 
     # If viewing another user's work, ensure that we have permission.
     if user_id
-      # If a script level ID was provided, ensure it matches the level ID.
-      if script_level_id
-        script_level = ScriptLevel.cache_find(script_level_id.to_i)
-        same_level = script_level.oldest_active_level.id == level.id
-        is_sublevel = ParentLevelsChildLevel.exists?(child_level_id: level.id, parent_level_id: script_level.oldest_active_level.id)
-        return render(status: :forbidden, json: {error: "Access denied."}) unless same_level || is_sublevel
-      else
-        script_level = level.script_levels.find_by_script_id(script_id)
-      end
       user = User.find(user_id)
-      unless can?(:view_as_user, script_level, user)
+      unless user&.student_of?(current_user)
         return render(status: :forbidden, json: {error: "Access denied."})
       end
 

--- a/dashboard/config/routes.rb
+++ b/dashboard/config/routes.rb
@@ -369,8 +369,7 @@ Dashboard::Application.routes.draw do
     # can include script_id to get or create a project for the level and script.
     # Optionally, the request can include user_id to get a project for another user,
     # like a teacher viewing a student's work.
-    # The request can also include a script_level_id if the level_id refers to a different level (for example, a sublevel).
-    get "projects(/script/:script_id)(/script_level/:script_level_id)/level/:level_id(/user/:user_id)", to: 'projects#get_or_create_for_level'
+    get "projects(/script/:script_id)/level/:level_id(/user/:user_id)", to: 'projects#get_or_create_for_level'
 
     post '/locale', to: 'home#set_locale', as: 'locale'
 

--- a/dashboard/test/controllers/projects_controller_test.rb
+++ b/dashboard/test/controllers/projects_controller_test.rb
@@ -479,49 +479,6 @@ class ProjectsControllerTest < ActionController::TestCase
     refute_nil @response.body['channel']
   end
 
-  test 'get_or_create_for_level with user uses script level ID if provided' do
-    teacher = create(:teacher)
-    section = create(:section, user: teacher, login_type: 'word')
-    student = create(:user)
-    other_student = create(:user)
-    create(:follower, section: section, student_user: student)
-    sign_in teacher
-
-    script = create(:script, :in_single_unit_course)
-    sublevel = create(:level, :blockly)
-    parent_level = create(:bubble_choice_level, sublevels: [sublevel])
-    script_level = create(:script_level, script: script, levels: [parent_level])
-
-    # Teacher should be able to get the channel for the given sublevel for the student.
-    get :get_or_create_for_level, params: {script_id: script.id, level_id: sublevel.id, script_level_id: script_level.id, user_id: student.id}
-    assert_response :success
-
-    # Teacher should be able to get the channel for the parent level for the student since it matches the script level ID.
-    get :get_or_create_for_level, params: {script_id: script.id, level_id: parent_level.id, script_level_id: script_level.id, user_id: student.id}
-    assert_response :success
-
-    # Teacher should not be able to get the channel for the given sublevel for a student not in their section.
-    get :get_or_create_for_level, params: {script_id: script.id, level_id: sublevel.id, script_level_id: script_level.id, user_id: other_student.id}
-    assert_response :forbidden
-  end
-
-  test 'get_or_create_for_level with user returns forbidden if script level ID does not match level ID' do
-    teacher = create(:teacher)
-    section = create(:section, user: teacher, login_type: 'word')
-    student = create(:user)
-    create(:follower, section: section, student_user: student)
-    sign_in teacher
-
-    script = create(:script, :in_single_unit_course)
-    sublevel = create(:level, :blockly)
-    other_level = create(:level, :blockly)
-    script_level = create(:script_level, script: script, levels: [other_level])
-
-    # Teacher should not be able to get the channel for the given sublevel since the provided level ID does not match the script level ID.
-    get :get_or_create_for_level, params: {script_id: script.id, level_id: sublevel.id, script_level_id: script_level.id, user_id: student.id}
-    assert_response :forbidden
-  end
-
   test 'on lab2 levels navigating to /view redirects to /edit if user is project owner' do
     channel_id = '12345'
     Projects.any_instance.stubs(:get).returns({isOwner: true})


### PR DESCRIPTION
Minor cleanup to the get_or_create_for_level projects API that I noticed during HoAI work: previously we were passing in the `scriptLevelId` to this API because we used it in conjunction with a provided user ID to verify if the current user had permission to view the given user's project on this level. However, the `can?(:view_as_user)` function that receives the script level ID only actually uses it for code review-specific scenarios, and otherwise just checks if the given user is a student of the current user. Since the latter conditions is all we care about, we can skip checking the script level ID which simplifies logic in this controller action and simplifies downstream API and function calls.

## Testing story
Tested locally that teacher view student work still works as expected, and otherwise users cannot access projects of other users that are not their students.