### PR TITLE
Lab2: set page title for standalone projects

### DIFF
--- a/apps/src/bubbleChoice/customModes/MusicDanceAi/MusicDanceAi.tsx
+++ b/apps/src/bubbleChoice/customModes/MusicDanceAi/MusicDanceAi.tsx
@@ -186,10 +186,14 @@ const MusicDanceAi: React.FC<MusicDanceAiProps> = ({
           continue;
         }
 
-        projectManager = ProjectManagerFactory.getProjectManager(channelId);
+        projectManager = ProjectManagerFactory.getProjectManager(
+          channelId,
+          levelProperties.isProjectLevel || false
+        );
       } else {
         projectManager = await ProjectManagerFactory.getProjectManagerForLevel(
           parseInt(sublevel.level_id),
+          levelProperties.isProjectLevel || false,
           userId || undefined,
           scriptId || undefined,
           scriptLevelId || undefined

--- a/apps/src/bubbleChoice/customModes/MusicDanceAi/MusicDanceAi.tsx
+++ b/apps/src/bubbleChoice/customModes/MusicDanceAi/MusicDanceAi.tsx
@@ -188,7 +188,8 @@ const MusicDanceAi: React.FC<MusicDanceAiProps> = ({
 
         projectManager = ProjectManagerFactory.getProjectManager(
           channelId,
-          levelProperties.isProjectLevel || false
+          // isStandaloneProjectLevel can always be false for subprojects, as it is only relevant for setting the page title.
+          false
         );
       } else {
         projectManager = await ProjectManagerFactory.getProjectManagerForLevel(

--- a/apps/src/bubbleChoice/customModes/MusicDanceAi/MusicDanceAi.tsx
+++ b/apps/src/bubbleChoice/customModes/MusicDanceAi/MusicDanceAi.tsx
@@ -194,7 +194,7 @@ const MusicDanceAi: React.FC<MusicDanceAiProps> = ({
       } else {
         projectManager = await ProjectManagerFactory.getProjectManagerForLevel(
           parseInt(sublevel.level_id),
-          levelProperties.isProjectLevel || false,
+          false, // isStandaloneProjectLevel is always false here.
           userId || undefined,
           scriptId || undefined,
           scriptLevelId || undefined

--- a/apps/src/lab2/lab2Redux.ts
+++ b/apps/src/lab2/lab2Redux.ts
@@ -221,10 +221,12 @@ export const setUpWithLevel = createAsyncThunk<
     const projectManager = payload.channelId
       ? ProjectManagerFactory.getProjectManager(
           payload.channelId,
+          levelProperties.isProjectLevel || false,
           thunkAPI.getState().lab.isShareView
         )
       : await ProjectManagerFactory.getProjectManagerForLevel(
           payload.levelId,
+          levelProperties.isProjectLevel || false,
           payload.userId,
           payload.scriptId,
           payload.scriptLevelId

--- a/apps/src/lab2/projects/ProjectManager.ts
+++ b/apps/src/lab2/projects/ProjectManager.ts
@@ -10,6 +10,7 @@
  *
  * If a project manager is destroyed, the enqueued save will be cancelled, if it exists.
  */
+import {convertProjectTypeToDisplayName} from '@cdo/apps/lab2/utils';
 import {NetworkError} from '@cdo/apps/util/HttpClient';
 import {
   currentLocation,
@@ -21,7 +22,6 @@ import LabMetricsReporter from '../Lab2MetricsReporter';
 import Lab2Registry from '../Lab2Registry';
 import {ValidationError} from '../responseValidators';
 import {Channel, ProjectAndSources, ProjectSources} from '../types';
-import {convertProjectTypeToDisplayName} from '../utils/convertProjectTypeToDisplayName';
 
 import {ChannelsStore} from './ChannelsStore';
 import {getProjectThumbnailUrl, updateProjectThumbnail} from './filesApi';
@@ -744,6 +744,13 @@ export default class ProjectManager {
     return sources;
   }
 
+  /**
+   * Set the title of the page based on the channel name. We only do this for standalone project levels.
+   * The title format is:
+   * {channel.name} - {project type display name} - Code.org [{environment}]. If we are on production,
+   * we omit the environment suffix, and if we don't have a project type display name, we omit that as well.
+   * @param channel
+   */
   private setTitleFromChannel(channel: Channel) {
     if (channel.name && this.isStandaloneProjectLevel) {
       const currentEnvironment = getEnvironment();
@@ -755,8 +762,7 @@ export default class ProjectManager {
       const projectString = projectName ? `${projectName} - ` : '';
       document.title = `${channel.name} - ${projectString}Code.org${environmentSuffix}`;
     }
-    // no-op if the channel does not have a name or this is not a standalone level.
-    // We will use the default document title from the server.
+    // Otherwise, we will use the default document title from the server.
   }
 
   // LISTENERS

--- a/apps/src/lab2/projects/ProjectManager.ts
+++ b/apps/src/lab2/projects/ProjectManager.ts
@@ -261,6 +261,7 @@ export default class ProjectManager {
       ) as Channel;
     }
     this.channelToSave.name = name;
+    this.setTitleFromChannel(this.channelToSave);
     return await this.enqueueSaveOrSave(forceSave, /* forceNewVersion */ false);
   }
 

--- a/apps/src/lab2/projects/ProjectManager.ts
+++ b/apps/src/lab2/projects/ProjectManager.ts
@@ -11,12 +11,17 @@
  * If a project manager is destroyed, the enqueued save will be cancelled, if it exists.
  */
 import {NetworkError} from '@cdo/apps/util/HttpClient';
-import {currentLocation} from '@cdo/apps/utils';
+import {
+  currentLocation,
+  getEnvironment,
+  isProductionEnvironment,
+} from '@cdo/apps/utils';
 
 import LabMetricsReporter from '../Lab2MetricsReporter';
 import Lab2Registry from '../Lab2Registry';
 import {ValidationError} from '../responseValidators';
 import {Channel, ProjectAndSources, ProjectSources} from '../types';
+import {convertProjectTypeToDisplayName} from '../utils/convertProjectTypeToDisplayName';
 
 import {ChannelsStore} from './ChannelsStore';
 import {getProjectThumbnailUrl, updateProjectThumbnail} from './filesApi';
@@ -58,12 +63,14 @@ export default class ProjectManager {
   private thumbnailUrl: string | undefined;
   private thumbnailPngBlob: Blob | undefined;
   private forceNewVersion: boolean = false;
+  private isStandaloneProjectLevel: boolean = false;
 
   constructor({
     sourcesStore,
     channelsStore,
     channelId,
     reduceChannelUpdates,
+    isStandaloneProjectLevel,
     isShareView = false,
     metricsReporter = Lab2Registry.getInstance().getMetricsReporter(),
   }: {
@@ -71,6 +78,7 @@ export default class ProjectManager {
     channelsStore: ChannelsStore;
     channelId: string;
     reduceChannelUpdates: boolean;
+    isStandaloneProjectLevel: boolean;
     isShareView?: boolean;
     metricsReporter?: LabMetricsReporter;
   }) {
@@ -82,6 +90,7 @@ export default class ProjectManager {
     this.forceReloading = false;
     this.metricsReporter = metricsReporter;
     this.isShareView = isShareView;
+    this.isStandaloneProjectLevel = isStandaloneProjectLevel;
   }
 
   getChannelId(): string {
@@ -112,6 +121,7 @@ export default class ProjectManager {
     );
     const isTeacherOfProjectOwner =
       await this.channelsStore.getIsTeacherOfProjectOwner(channel);
+    this.setTitleFromChannel(channel);
     return {
       sources,
       channel,
@@ -731,6 +741,21 @@ export default class ProjectManager {
     const sources = await this.loadSources(versionId);
     this.lastSource = JSON.stringify(sources);
     return sources;
+  }
+
+  private setTitleFromChannel(channel: Channel) {
+    if (channel.name && this.isStandaloneProjectLevel) {
+      const currentEnvironment = getEnvironment();
+      const environmentSuffix =
+        isProductionEnvironment() || !currentEnvironment
+          ? ''
+          : ` [${currentEnvironment}]`;
+      const projectName = convertProjectTypeToDisplayName(channel.projectType);
+      const projectString = projectName ? `${projectName} - ` : '';
+      document.title = `${channel.name} - ${projectString}Code.org${environmentSuffix}`;
+    }
+    // no-op if the channel does not have a name or this is not a standalone level.
+    // We will use the default document title from the server.
   }
 
   // LISTENERS

--- a/apps/src/lab2/projects/ProjectManagerFactory.ts
+++ b/apps/src/lab2/projects/ProjectManagerFactory.ts
@@ -17,6 +17,7 @@ export default class ProjectManagerFactory {
    */
   static getProjectManager(
     projectId: string,
+    isStandaloneProjectLevel: boolean,
     isShareView: boolean = false
   ): ProjectManager {
     return new ProjectManager({
@@ -25,6 +26,7 @@ export default class ProjectManagerFactory {
       channelId: projectId,
       reduceChannelUpdates: false,
       isShareView,
+      isStandaloneProjectLevel,
     });
   }
 
@@ -40,6 +42,7 @@ export default class ProjectManagerFactory {
    */
   static async getProjectManagerForLevel(
     levelId: number,
+    isStandaloneProjectLevel: boolean,
     userId?: number,
     scriptId?: number,
     scriptLevelId?: string
@@ -71,6 +74,7 @@ export default class ProjectManagerFactory {
       channelsStore,
       channelId,
       reduceChannelUpdates,
+      isStandaloneProjectLevel,
     });
   }
 }

--- a/apps/src/lab2/utils/convertProjectTypeToDisplayName.ts
+++ b/apps/src/lab2/utils/convertProjectTypeToDisplayName.ts
@@ -1,0 +1,10 @@
+import {PROJECT_TYPE_MAP} from '@cdo/apps/templates/projects/projectTypeMap';
+
+import {ProjectType} from '../types';
+
+export function convertProjectTypeToDisplayName(
+  projectType: ProjectType
+): string {
+  const name = PROJECT_TYPE_MAP[projectType as keyof typeof PROJECT_TYPE_MAP];
+  return name || '';
+}

--- a/apps/src/lab2/utils/index.ts
+++ b/apps/src/lab2/utils/index.ts
@@ -6,3 +6,4 @@ export * from './partialApply';
 export * from './fetchPermissions';
 export * from './getLabViewPageAction';
 export * from './getIsLabViewBlocked';
+export * from './convertProjectTypeToDisplayName';

--- a/apps/src/templates/projects/projectTypeMap.js
+++ b/apps/src/templates/projects/projectTypeMap.js
@@ -2,7 +2,6 @@ import i18n from '@cdo/locale';
 
 /**
  * Map from project type to friendly name.
- * @type {Object}
  */
 
 export const PROJECT_TYPE_MAP = {
@@ -46,6 +45,7 @@ export const PROJECT_TYPE_MAP = {
   time_capsule: i18n.projectTypeTimeCapsule(),
   transformers: i18n.projectTypeTransformers(),
   music_dance_ai: 'Mix & Move with AI',
+  weblab2: 'Web Lab 2',
 };
 
 export const FEATURED_PROJECT_TYPE_MAP = {

--- a/apps/test/unit/lab2/projects/ProjectManagerTest.ts
+++ b/apps/test/unit/lab2/projects/ProjectManagerTest.ts
@@ -62,6 +62,7 @@ describe('ProjectManager', () => {
       channelsStore,
       channelId: FAKE_CHANNEL_ID,
       reduceChannelUpdates: false,
+      isStandaloneProjectLevel: false,
     });
     const {sources, channel} = await projectManager.load();
     expect(sources).to.deep.equal(FAKE_SOURCE);
@@ -75,6 +76,7 @@ describe('ProjectManager', () => {
       channelsStore,
       channelId: FAKE_CHANNEL_ID,
       reduceChannelUpdates: false,
+      isStandaloneProjectLevel: false,
     });
     await projectManager.load();
     await projectManager.save(UPDATED_SOURCE);
@@ -89,6 +91,7 @@ describe('ProjectManager', () => {
       channelsStore,
       channelId: FAKE_CHANNEL_ID,
       reduceChannelUpdates: false,
+      isStandaloneProjectLevel: false,
     });
     await projectManager.load();
     await projectManager.save(FAKE_SOURCE);
@@ -103,6 +106,7 @@ describe('ProjectManager', () => {
       channelsStore,
       channelId: FAKE_CHANNEL_ID,
       reduceChannelUpdates: false,
+      isStandaloneProjectLevel: false,
     });
     await projectManager.load();
     await projectManager.save(UPDATED_SOURCE);
@@ -120,6 +124,7 @@ describe('ProjectManager', () => {
       channelsStore,
       channelId: FAKE_CHANNEL_ID,
       reduceChannelUpdates: false,
+      isStandaloneProjectLevel: false,
     });
     await projectManager.load();
     await projectManager.save(UPDATED_SOURCE);
@@ -137,6 +142,7 @@ describe('ProjectManager', () => {
       channelsStore,
       channelId: FAKE_CHANNEL_ID,
       reduceChannelUpdates: false,
+      isStandaloneProjectLevel: false,
     });
     await projectManager.load();
     projectManager.destroy();
@@ -153,6 +159,7 @@ describe('ProjectManager', () => {
       channelsStore,
       channelId: FAKE_CHANNEL_ID,
       reduceChannelUpdates: true /* turn emergency mode on */,
+      isStandaloneProjectLevel: false,
     });
     await projectManager.load();
     await projectManager.save(UPDATED_SOURCE);
@@ -172,6 +179,7 @@ describe('ProjectManager', () => {
       channelsStore,
       channelId: FAKE_CHANNEL_ID,
       reduceChannelUpdates: false,
+      isStandaloneProjectLevel: false,
     });
 
     const noopListener = sinon.stub();
@@ -187,6 +195,7 @@ describe('ProjectManager', () => {
       channelsStore,
       channelId: FAKE_CHANNEL_ID,
       reduceChannelUpdates: false,
+      isStandaloneProjectLevel: false,
     });
     await projectManager.load();
     await projectManager.rename('new name');
@@ -205,6 +214,7 @@ describe('ProjectManager', () => {
       channelsStore,
       channelId: FAKE_CHANNEL_ID,
       reduceChannelUpdates: false,
+      isStandaloneProjectLevel: false,
     });
     await projectManager.load();
     await projectManager.save(UPDATED_SOURCE);
@@ -220,6 +230,7 @@ describe('ProjectManager', () => {
       channelsStore,
       channelId: FAKE_CHANNEL_ID,
       reduceChannelUpdates: false,
+      isStandaloneProjectLevel: false,
     });
 
     const {channel, sources} = await projectManager.load();
@@ -239,6 +250,7 @@ describe('ProjectManager', () => {
       channelsStore,
       channelId: FAKE_CHANNEL_ID,
       reduceChannelUpdates: false,
+      isStandaloneProjectLevel: false,
     });
 
     try {
@@ -257,6 +269,7 @@ describe('ProjectManager', () => {
       channelsStore,
       channelId: FAKE_CHANNEL_ID,
       reduceChannelUpdates: false,
+      isStandaloneProjectLevel: false,
     });
     await projectManager.load();
     await projectManager.save(UPDATED_SOURCE);
@@ -273,6 +286,7 @@ describe('ProjectManager', () => {
       channelsStore,
       channelId: FAKE_CHANNEL_ID,
       reduceChannelUpdates: false,
+      isStandaloneProjectLevel: false,
     });
 
     // Load the initial sources
@@ -305,6 +319,7 @@ describe('ProjectManager', () => {
       channelsStore,
       channelId: FAKE_CHANNEL_ID,
       reduceChannelUpdates: false,
+      isStandaloneProjectLevel: false,
     });
 
     // Load the initial sources
@@ -326,6 +341,7 @@ describe('ProjectManager', () => {
       channelsStore,
       channelId: FAKE_CHANNEL_ID,
       reduceChannelUpdates: false,
+      isStandaloneProjectLevel: false,
     });
     await projectManager.load();
     await projectManager.save(UPDATED_SOURCE, false, true);
@@ -347,6 +363,7 @@ describe('ProjectManager', () => {
       channelsStore,
       channelId: FAKE_CHANNEL_ID,
       reduceChannelUpdates: false,
+      isStandaloneProjectLevel: false,
     });
     await projectManager.load();
     await projectManager.save(UPDATED_SOURCE);
@@ -382,6 +399,7 @@ describe('ProjectManager', () => {
       channelsStore,
       channelId: FAKE_CHANNEL_ID,
       reduceChannelUpdates: false,
+      isStandaloneProjectLevel: false,
     });
     await projectManager.load();
     await projectManager.save(UPDATED_SOURCE);
@@ -417,6 +435,7 @@ describe('ProjectManager', () => {
       channelsStore,
       channelId: FAKE_CHANNEL_ID,
       reduceChannelUpdates: false,
+      isStandaloneProjectLevel: false,
     });
     await projectManager.load();
     await projectManager.save(UPDATED_SOURCE);
@@ -453,6 +472,7 @@ describe('ProjectManager', () => {
       channelsStore,
       channelId: FAKE_CHANNEL_ID,
       reduceChannelUpdates: false,
+      isStandaloneProjectLevel: false,
     });
     await projectManager.load();
 


### PR DESCRIPTION
Legacy projects put the project title in the page title for standalone projects. We never made this update for lab2 projects, so they currently will say `<Title of Standalone Level> - Code.org`, for example Python lab says `New Python Lab Project - Code.org`. This updates lab2 levels to instead say `<Project Title> - <Friendly Lab Name> - Code.org`, which a suffix on code.org if we are in a non-prod environment (as our other page titles do).

## Before
<img width="321" height="223" alt="Screenshot 2026-01-05 at 12 49 04 PM" src="https://github.com/user-attachments/assets/a7ae12fa-ee10-4fd3-a8f1-54baf62eb810" />

## After
<img width="293" height="102" alt="Screenshot 2026-01-05 at 12 49 31 PM" src="https://github.com/user-attachments/assets/e3aed7c5-f735-4d42-ac9c-3efe0c3ebe4a" />

## Links
- [Slack thread](https://codedotorg.slack.com/archives/C03DBDN67B7/p1767642403607719)



## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
