### PR TITLE
Remove Hour Constraints for Workshop Certificates

### DIFF
--- a/dashboard/app/models/pd/workshop.rb
+++ b/dashboard/app/models/pd/workshop.rb
@@ -668,11 +668,9 @@ class Pd::Workshop < ApplicationRecord
     end
   end
 
-  # Apply max # of hours for certificates, if applicable, to the number of scheduled session-hours.
-  # @return [Integer] number of pd hours, after applying constraints
-  def effective_num_hours
-    actual_hours = sessions.sum(&:hours)
-    [actual_hours, time_constraint(:max_hours)].compact.min
+  # @return [Integer] number of scheduled pd session hours
+  def num_scheduled_session_hours
+    sessions.sum(&:hours)
   end
 
   # @return [Boolean] true if a Code Studio account is required for attendance, otherwise false.
@@ -810,7 +808,7 @@ class Pd::Workshop < ApplicationRecord
   end
 
   # Lookup a time constraint by type
-  # @param constraint_type [Symbol] e.g. :min_days, :max_days, or :max_hours
+  # @param constraint_type [Symbol] e.g. :min_days or :max_days
   # @returns [Number, nil] constraint for the specified subject and type, or nil if none exists
   def time_constraint(constraint_type)
     TIME_CONSTRAINTS[course].try(:[], subject).try(:[], constraint_type)

--- a/dashboard/app/models/pd/workshop.rb
+++ b/dashboard/app/models/pd/workshop.rb
@@ -670,7 +670,7 @@ class Pd::Workshop < ApplicationRecord
 
   # @return [Integer] number of scheduled pd session hours
   def num_scheduled_session_hours
-    sessions.sum(&:hours)
+    sessions&.sum(&:hours)&.presence || 0
   end
 
   # @return [Boolean] true if a Code Studio account is required for attendance, otherwise false.

--- a/dashboard/app/models/pd/workshop_constants.rb
+++ b/dashboard/app/models/pd/workshop_constants.rb
@@ -38,58 +38,57 @@ module Pd
     # Each subject has the following constraints:
     # min_days: the minimum # of days a teacher must attend in order to be counted at all.
     # max_days: the maximum # of days the workshop can be recognized for.
-    # max_hours: the maximum # of hours the workshop can be recognized for.
     TIME_CONSTRAINTS = {
       COURSE_ECS => {
-        SUBJECT_ECS_PHASE_2 => {min_days: 3, max_days: 5, max_hours: 30},
-        SUBJECT_ECS_UNIT_3 => {min_days: 1, max_days: 1, max_hours: 6},
-        SUBJECT_ECS_UNIT_4 => {min_days: 1, max_days: 1, max_hours: 6},
-        SUBJECT_ECS_UNIT_5 => {min_days: 1, max_days: 1, max_hours: 6},
-        SUBJECT_ECS_UNIT_6 => {min_days: 1, max_days: 1, max_hours: 6},
-        SUBJECT_ECS_PHASE_4 => {min_days: 2, max_days: 3, max_hours: 18}
+        SUBJECT_ECS_PHASE_2 => {min_days: 3, max_days: 5},
+        SUBJECT_ECS_UNIT_3 => {min_days: 1, max_days: 1},
+        SUBJECT_ECS_UNIT_4 => {min_days: 1, max_days: 1},
+        SUBJECT_ECS_UNIT_5 => {min_days: 1, max_days: 1},
+        SUBJECT_ECS_UNIT_6 => {min_days: 1, max_days: 1},
+        SUBJECT_ECS_PHASE_4 => {min_days: 2, max_days: 3}
       },
       COURSE_CS_IN_A => {
-        SUBJECT_CS_IN_A_PHASE_2 => {min_days: 2, max_days: 3, max_hours: 18},
-        SUBJECT_CS_IN_A_PHASE_3 => {min_days: 1, max_days: 1, max_hours: 7}
+        SUBJECT_CS_IN_A_PHASE_2 => {min_days: 2, max_days: 3},
+        SUBJECT_CS_IN_A_PHASE_3 => {min_days: 1, max_days: 1}
       },
       COURSE_CS_IN_S => {
-        SUBJECT_CS_IN_S_PHASE_2 => {min_days: 2, max_days: 3, max_hours: 18},
-        SUBJECT_CS_IN_S_PHASE_3_SEMESTER_1 => {min_days: 1, max_days: 1, max_hours: 7},
-        SUBJECT_CS_IN_S_PHASE_3_SEMESTER_2 => {min_days: 1, max_days: 1, max_hours: 7}
+        SUBJECT_CS_IN_S_PHASE_2 => {min_days: 2, max_days: 3},
+        SUBJECT_CS_IN_S_PHASE_3_SEMESTER_1 => {min_days: 1, max_days: 1},
+        SUBJECT_CS_IN_S_PHASE_3_SEMESTER_2 => {min_days: 1, max_days: 1}
       },
       COURSE_CSP => {
-        SUBJECT_CSP_SUMMER_WORKSHOP => {max_hours: 33.5},
-        SUBJECT_CSP_WORKSHOP_1 => {min_days: 1, max_days: 1, max_hours: 6},
-        SUBJECT_CSP_WORKSHOP_2 => {min_days: 1, max_days: 1, max_hours: 6},
-        SUBJECT_CSP_WORKSHOP_3 => {min_days: 1, max_days: 1, max_hours: 6},
-        SUBJECT_CSP_WORKSHOP_4 => {min_days: 1, max_days: 1, max_hours: 6},
-        SUBJECT_CSP_WORKSHOP_1_2 => {min_days: 2, max_days: 2, max_hours: 12},
-        SUBJECT_CSP_WORKSHOP_3_4 => {min_days: 2, max_days: 2, max_hours: 12},
-        SUBJECT_CSP_TEACHER_CON => {max_hours: 33.5},
-        SUBJECT_CSP_FOR_RETURNING_TEACHERS => {max_hours: 7}
+        SUBJECT_CSP_SUMMER_WORKSHOP => {},
+        SUBJECT_CSP_WORKSHOP_1 => {min_days: 1, max_days: 1},
+        SUBJECT_CSP_WORKSHOP_2 => {min_days: 1, max_days: 1},
+        SUBJECT_CSP_WORKSHOP_3 => {min_days: 1, max_days: 1},
+        SUBJECT_CSP_WORKSHOP_4 => {min_days: 1, max_days: 1},
+        SUBJECT_CSP_WORKSHOP_1_2 => {min_days: 2, max_days: 2},
+        SUBJECT_CSP_WORKSHOP_3_4 => {min_days: 2, max_days: 2},
+        SUBJECT_CSP_TEACHER_CON => {},
+        SUBJECT_CSP_FOR_RETURNING_TEACHERS => {}
       },
       COURSE_CSA => {
-        SUBJECT_CSA_SUMMER_WORKSHOP => {max_hours: 33.5},
-        SUBJECT_CSA_WORKSHOP_1 => {min_days: 1, max_days: 1, max_hours: 6},
-        SUBJECT_CSA_WORKSHOP_2 => {min_days: 1, max_days: 1, max_hours: 6},
-        SUBJECT_CSA_WORKSHOP_3 => {min_days: 1, max_days: 1, max_hours: 6},
-        SUBJECT_CSA_WORKSHOP_4 => {min_days: 1, max_days: 1, max_hours: 6},
-        SUBJECT_CSA_WORKSHOP_1_2 => {min_days: 2, max_days: 2, max_hours: 12},
-        SUBJECT_CSA_WORKSHOP_3_4 => {min_days: 2, max_days: 2, max_hours: 12}
+        SUBJECT_CSA_SUMMER_WORKSHOP => {},
+        SUBJECT_CSA_WORKSHOP_1 => {min_days: 1, max_days: 1},
+        SUBJECT_CSA_WORKSHOP_2 => {min_days: 1, max_days: 1},
+        SUBJECT_CSA_WORKSHOP_3 => {min_days: 1, max_days: 1},
+        SUBJECT_CSA_WORKSHOP_4 => {min_days: 1, max_days: 1},
+        SUBJECT_CSA_WORKSHOP_1_2 => {min_days: 2, max_days: 2},
+        SUBJECT_CSA_WORKSHOP_3_4 => {min_days: 2, max_days: 2}
       },
       COURSE_CSD => {
-        SUBJECT_CSD_SUMMER_WORKSHOP => {max_hours: 33.5},
-        SUBJECT_CSD_WORKSHOP_1 => {min_days: 1, max_days: 1, max_hours: 6},
-        SUBJECT_CSD_WORKSHOP_2 => {min_days: 1, max_days: 1, max_hours: 6},
-        SUBJECT_CSD_WORKSHOP_3 => {min_days: 1, max_days: 1, max_hours: 6},
-        SUBJECT_CSD_WORKSHOP_4 => {min_days: 1, max_days: 1, max_hours: 6},
-        SUBJECT_CSD_WORKSHOP_1_2 => {min_days: 2, max_days: 2, max_hours: 12},
-        SUBJECT_CSD_WORKSHOP_3_4 => {min_days: 2, max_days: 2, max_hours: 12},
-        SUBJECT_CSD_TEACHER_CON => {max_hours: 33.5}
+        SUBJECT_CSD_SUMMER_WORKSHOP => {},
+        SUBJECT_CSD_WORKSHOP_1 => {min_days: 1, max_days: 1},
+        SUBJECT_CSD_WORKSHOP_2 => {min_days: 1, max_days: 1},
+        SUBJECT_CSD_WORKSHOP_3 => {min_days: 1, max_days: 1},
+        SUBJECT_CSD_WORKSHOP_4 => {min_days: 1, max_days: 1},
+        SUBJECT_CSD_WORKSHOP_1_2 => {min_days: 2, max_days: 2},
+        SUBJECT_CSD_WORKSHOP_3_4 => {min_days: 2, max_days: 2},
+        SUBJECT_CSD_TEACHER_CON => {}
       },
       COURSE_CSF => {
-        SUBJECT_CSF_101 => {min_days: 1, max_days: 1, max_hours: 7},
-        SUBJECT_CSF_201 => {min_days: 1, max_days: 1, max_hours: 6}
+        SUBJECT_CSF_101 => {min_days: 1, max_days: 1},
+        SUBJECT_CSF_201 => {min_days: 1, max_days: 1}
       }
     }.freeze
 

--- a/dashboard/lib/pd/certificate_renderer.rb
+++ b/dashboard/lib/pd/certificate_renderer.rb
@@ -79,7 +79,7 @@ module Pd
     private_class_method def self.pd_hours(workshop)
       [
         {
-          string: ActiveSupport::NumberHelper.number_to_rounded(workshop.effective_num_hours, precision: 1, strip_insignificant_zeros: true),
+          string: ActiveSupport::NumberHelper.number_to_rounded(workshop.num_scheduled_session_hours, precision: 1, strip_insignificant_zeros: true),
           y: 143,
           x: -265,
           pointsize: 30,

--- a/dashboard/test/controllers/pd/workshop_certificate_controller_test.rb
+++ b/dashboard/test/controllers/pd/workshop_certificate_controller_test.rb
@@ -52,7 +52,7 @@ class Pd::WorkshopCertificateControllerTest < ActionController::TestCase
     expect_renders_text(mock_image, 'CS Fundamentals')
     expect_renders_text(mock_image, 'Intro Workshop')
     workshop.facilitators.each {|f| expect_renders_text(mock_image, f.name)}
-    workshop_hours = Integer(workshop.effective_num_hours)
+    workshop_hours = Integer(workshop.num_scheduled_session_hours)
     expect_renders_text(mock_image, workshop_hours.to_s)
     expect_renders_text(mock_image, workshop.workshop_date_range_string)
 
@@ -71,7 +71,7 @@ class Pd::WorkshopCertificateControllerTest < ActionController::TestCase
     expect_renders_text(mock_image, 'CS Discoveries')
     expect_renders_text(mock_image, '5-day Summer Workshop')
     @workshop.facilitators.each {|f| expect_renders_text(mock_image, f.name)}
-    workshop_hours = Integer(@workshop.effective_num_hours)
+    workshop_hours = Integer(@workshop.num_scheduled_session_hours)
     expect_renders_text(mock_image, workshop_hours.to_s)
     expect_renders_text(mock_image, @workshop.workshop_date_range_string)
 
@@ -97,7 +97,7 @@ class Pd::WorkshopCertificateControllerTest < ActionController::TestCase
     expect_renders_text(mock_image, 'CS Discoveries')
     expect_renders_text(mock_image, 'Code.org TeacherCon')
     expect_renders_text(mock_image, Pd::CertificateRenderer::HARDCODED_CSD_FACILITATOR)
-    workshop_hours = Integer(workshop.effective_num_hours)
+    workshop_hours = Integer(workshop.num_scheduled_session_hours)
     expect_renders_text(mock_image, workshop_hours.to_s)
     expect_renders_text(mock_image, workshop.workshop_date_range_string)
 
@@ -123,7 +123,7 @@ class Pd::WorkshopCertificateControllerTest < ActionController::TestCase
     expect_renders_text(mock_image, 'CS Principles')
     expect_renders_text(mock_image, 'Code.org TeacherCon')
     expect_renders_text(mock_image, Pd::CertificateRenderer::HARDCODED_CSP_FACILITATOR)
-    workshop_hours = Integer(workshop.effective_num_hours)
+    workshop_hours = Integer(workshop.num_scheduled_session_hours)
     expect_renders_text(mock_image, workshop_hours.to_s)
     expect_renders_text(mock_image, workshop.workshop_date_range_string)
 

--- a/dashboard/test/models/pd/workshop_test.rb
+++ b/dashboard/test/models/pd/workshop_test.rb
@@ -603,22 +603,9 @@ class Pd::WorkshopTest < ActiveSupport::TestCase
     assert_equal ids.reverse, Pd::Workshop.where(id: ids).order_by_state(desc: true).pluck(:id)
   end
 
-  test 'effective_num_hours with no max_hours constraint returns the total session hours' do
+  test 'num_scheduled_session_hours returns the total session hours' do
     @workshop.sessions.expects(:map).returns([5, 5, 5, 5]) # 20 hours over 4 sessions
-    @workshop.expects(:time_constraint).with(:max_hours).returns(nil)
-    assert_equal 20, @workshop.effective_num_hours
-  end
-
-  test 'effective_num_hours with max_hours constraint lower than the session hours returns the constraint' do
-    @workshop.sessions.expects(:map).returns([5, 5, 5, 5]) # 20 hours over 4 sessions
-    @workshop.expects(:time_constraint).with(:max_hours).returns(15)
-    assert_equal 15, @workshop.effective_num_hours
-  end
-
-  test 'effective_num_hours with max_hours constraint greater than the session hours returns the session hours' do
-    @workshop.sessions.expects(:map).returns([5, 5, 5, 5]) # 20 hours over 4 sessions
-    @workshop.expects(:time_constraint).with(:max_hours).returns(50)
-    assert_equal 20, @workshop.effective_num_hours
+    assert_equal 20, @workshop.num_scheduled_session_hours
   end
 
   test 'time constraint lookup' do
@@ -633,44 +620,6 @@ class Pd::WorkshopTest < ActiveSupport::TestCase
     assert_nil workshop_bad_subject.time_constraint(:max_days)
     assert_equal 5, workshop_ambiguous_subject_ecs.time_constraint(:max_days)
     assert_equal 3, workshop_ambiguous_subject_cs_in_a.time_constraint(:max_days)
-  end
-
-  test 'teacherCon workshops are capped at 33.5 hours' do
-    workshop_csd_teachercon = build(:workshop,
-      course: Pd::Workshop::COURSE_CSD,
-      subject: Pd::Workshop::SUBJECT_CSD_TEACHER_CON,
-      num_sessions: 5,
-      each_session_hours: 8
-)
-    # workshop subject is deprecated so validation must be skipped
-    workshop_csd_teachercon.save(validate: false)
-
-    workshop_csp_teachercon = build(:workshop,
-      course: Pd::Workshop::COURSE_CSD,
-      subject: Pd::Workshop::SUBJECT_CSP_TEACHER_CON,
-      num_sessions: 5,
-      each_session_hours: 8
-)
-    # workshop subject is deprecated so validation must be skipped
-    workshop_csp_teachercon.save(validate: false)
-
-    assert_equal 33.5, workshop_csd_teachercon.effective_num_hours
-    assert_equal 33.5, workshop_csp_teachercon.effective_num_hours
-  end
-
-  test 'csp summer workshops are capped at 33.5 hours' do
-    workshop = create(:csp_summer_workshop, num_sessions: 5, each_session_hours: 8)
-    assert_equal 33.5, workshop.effective_num_hours
-  end
-
-  test 'CSF 101 workshops are capped at 7 hours' do
-    workshop = build(:csf_intro_workshop, each_session_hours: 8)
-    assert_equal 7, workshop.effective_num_hours
-  end
-
-  test 'CSF 201 workshops are capped at 6 hours' do
-    workshop_csf_201 = build(:csf_deep_dive_workshop, each_session_hours: 7)
-    assert_equal 6, workshop_csf_201.effective_num_hours
   end
 
   test 'does not send teacher_enrollment_reminder if suppress_reminders? is true' do

--- a/dashboard/test/models/pd/workshop_test.rb
+++ b/dashboard/test/models/pd/workshop_test.rb
@@ -608,6 +608,11 @@ class Pd::WorkshopTest < ActiveSupport::TestCase
     assert_equal 20, @workshop.num_scheduled_session_hours
   end
 
+  test 'num_scheduled_session_hours returns 0 if no sessions present' do
+    workshop = create(:workshop, num_sessions: 0)
+    assert_equal 0, workshop.num_scheduled_session_hours
+  end
+
   test 'time constraint lookup' do
     workshop_bad_course = build(:workshop, course: 'nonexistent')
     workshop_bad_subject = build(:workshop, course: Pd::Workshop::COURSE_CSP, subject: 'nonexistent')


### PR DESCRIPTION
Removes the hour constraints for workshop certificates and instead just shows the sum of the scheduled pd session durations.

### Example certificate with 72 hours worth of session hours (which is much higher than the original CSD AYW1 cap)
![no cap](https://github.com/user-attachments/assets/b082e53d-579a-4baa-8f8d-4ffb1f753b96)

## Links
Jira ticket: [here](https://codedotorg.atlassian.net/jira/software/c/projects/TEACHING/boards/678?assignee=60d62161f65054006980bd71&selectedIssue=TEACHING-23)
Slack discussion: [here](https://codedotorg.slack.com/archives/C04540KNGDQ/p1765897094472059)

## Testing story
Local testing and updating unit tests.
