### PR TITLE
Web Lab 2 v2: Add cache bust suffix to starter image requests

### DIFF
--- a/apps/src/codebridge/FilePreview/weblab2_project_service_worker.js
+++ b/apps/src/codebridge/FilePreview/weblab2_project_service_worker.js
@@ -106,7 +106,9 @@ function main() {
         let fetchUrl = url;
         if (url.startsWith('/level_starter_assets/')) {
           // We fetch level starter assets from the code.org origin for this environment.
-          fetchUrl = codeDotOrgOrigin + url;
+          // Adding a temporary cache bust query parameter to avoid some caching issues with level starter assets.
+          const temporaryCacheBust = '?temp-cache-bust=1';
+          fetchUrl = codeDotOrgOrigin + url + temporaryCacheBust;
         }
         return await fetch(fetchUrl);
       }


### PR DESCRIPTION
This is a speculative fix to a mysterious error we've been seeing on the v2 preview. Sometimes the starter images fail to load with a non-specific error. I can get the same image to load in one browser and not load on another browser. One level that had failed images last night for me loaded fine this morning. My best guess is there is some caching issue going on since there was a fix to the starter images deployed yesterday afternoon. As a quick, hopeful, fix, I added a cache bust suffix to the level starter assets url to try to get around the issue.


## Links
- [slack thread](https://codedotorg.slack.com/archives/C06JELCAPT9/p1767659807867389?thread_ts=1767651176.340169&cid=C06JELCAPT9)

## Testing story
I haven't been able to repro this locally, but this change doesn't break anything locally. The v2 preview is still behind a flag, so this is very low risk.

## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
