### PR TITLE
Hide Codebridge file browser header popup button when read-only workspace

### DIFF
--- a/apps/src/codebridge/Workspace/Workspace.tsx
+++ b/apps/src/codebridge/Workspace/Workspace.tsx
@@ -12,7 +12,10 @@ import React, {useMemo, useRef} from 'react';
 import codebridgeI18n from '@cdo/apps/codebridge/locale';
 import {START_SOURCES, WARNING_BANNER_MESSAGES} from '@cdo/apps/lab2/constants';
 import {getAppOptionsEditBlocks} from '@cdo/apps/lab2/projects/utils';
-import {isProjectTemplateLevel} from '@cdo/apps/lab2/redux/lab2ReduxSelectors';
+import {
+  isProjectTemplateLevel,
+  isReadOnlyWorkspace,
+} from '@cdo/apps/lab2/redux/lab2ReduxSelectors';
 import TeacherViewingStudentProjectAlert from '@cdo/apps/lab2/views/alerts/teacherViewingStudentProject';
 import PanelContainer from '@cdo/apps/lab2/views/components/PanelContainer';
 import WorkspaceHeader from '@cdo/apps/lab2/views/components/WorkspaceHeader';
@@ -43,6 +46,7 @@ const Workspace: React.FunctionComponent<WorkspaceProps> = ({
   const teacherViewingStudent = Boolean(
     useAppSelector(state => state.progress.viewAsUserId)
   );
+  const isReadOnly = useAppSelector(isReadOnlyWorkspace);
 
   const showLockedFilesBanner = useAppSelector(
     state => state.codebridgeWorkspace.showLockedFilesBanner
@@ -126,7 +130,7 @@ const Workspace: React.FunctionComponent<WorkspaceProps> = ({
               </BodyFourText>
             )}
             <div className={moduleStyles.fileBrowserHeaderButtons}>
-              {showFileBrowser && !teacherViewingStudent && (
+              {showFileBrowser && !isReadOnly && (
                 <FileBrowserHeaderPopUpButton />
               )}
               <ToggleFileBrowserButton />


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
This PR updates the file browser header popup button so that it is hidden when the Codebridge workspace is read-only.

Currently, the pop-up button is displayed when read-only on a standalone project viewed by a non-owner and for a user on a Web Lab 2 level when a user being prompted to either accept/reject an AI Tutor proposed update (read-only workspace).

## Before update

On a Web Lab 2 level, when in AI Tutor version, a user can still create a new file even though the workspace is read-only and the new file is saved as part of the project.


https://github.com/user-attachments/assets/d0ebf823-a4af-4b0f-a7fc-50f8633da79a

On a standalone Web Lab 2 project, a non-owner can create a new file, but the file is not saved on reload (confusing experience):


https://github.com/user-attachments/assets/28ce6dae-1be6-4f57-9552-c2fed6eea42e

## After update

On a Web Lab 2 level, when in AI Tutor version the file browser header popup button is hidden:
<img width="1342" height="695" alt="after-aitutor-version" src="https://github.com/user-attachments/assets/9dce2ae6-6a6b-4b63-a2aa-51fb441ac264" />

On a standalone Web Lab 2 project for a non-owner the file browser header popup button is hidden:
<img width="1377" height="796" alt="after-readonly-standalone-project" src="https://github.com/user-attachments/assets/0f9773d1-ba4c-4317-94b0-21b67eba2003" />


## Links
<!--  Links to relevant external resources.
      - spec docs, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- Jira: https://codedotorg.atlassian.net/browse/AFL-415

## Testing story
<!--  Does your change include appropriate tests?
      - If so, please describe how the tests included in this PR are sufficient.
      - If not, please explain why this change does not need to be tested. -->

Tested locally on `weblab2` levels when in AI Tutor version, and in a `weblab2` standalone project for a non-owner (read-only).

## Deployment strategy
<!--  Any special steps required to deploy this, besides merging?
      - Are there database migrations or manual steps?
      - Does this require coordination with other teams or systems? -->



## Follow-up work
<!--  List any clean-up or technical debt that will be addressed in future work.
      - Include Jira links where applicable.
      - Are there any known limitations or improvements planned? -->



## Privacy
<!--  How does this change impact Student & Teacher privacy?
      - Does this collect, use, share, or modify PII, either new or existing? -->



## Security
<!--  How does this change impact our security surface-area?
      - Do API's touched have the right auth?
      - Do infra changes impact our attack surface or encryption?
-->



## Caching
<!--  How does this change impact caching behavior?
      - Are cache keys or invalidation strategies affected?
      - Will this require cache warming or invalidation after deployment? -->



## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
