### PR TITLE
Do not send emails to internal accounts

### DIFF
--- a/dashboard/lib/inactive_teacher_deletion_warning_mailer.rb
+++ b/dashboard/lib/inactive_teacher_deletion_warning_mailer.rb
@@ -32,6 +32,7 @@ class InactiveTeacherDeletionWarningMailer
         break if accounts_batch.empty? || num_teachers_warned >= @limit
         accounts_batch.each do |teacher|
           next if teacher.email.blank?
+          next if teacher.email.end_with?('@code.org') # skip internal accounts
           send_warning_email(teacher)
           # Set email sent at field
           mark_warning_email_sent(teacher.id) unless @dry_run

--- a/dashboard/test/lib/services/user/inactive_teacher_deletion_warning_mailer_test.rb
+++ b/dashboard/test/lib/services/user/inactive_teacher_deletion_warning_mailer_test.rb
@@ -101,6 +101,20 @@ class User::InactiveTeacherDeletionWarningMailerTest < ActiveJob::TestCase
       end
     end
 
+    context 'when teacher email is internal' do
+      let(:teacher) {create(:teacher, email: 'teacher@code.org', name: teacher_name)}
+
+      it 'does not warn teacher' do
+        expect_teacher_warning_to_be_sent.never
+        send_warning_emails
+      end
+
+      it 'does not increment num_teachers_warned' do
+        send_warning_emails
+        _(described_instance.send(:num_teachers_warned)).must_equal 0
+      end
+    end
+
     context 'when dry run' do
       let(:dry_run) {true}
       it 'does not send emails in dry run mode' do


### PR DESCRIPTION
We want to skip internal code.org accounts when sending Inactive deletion warning emails. We will save some email credits for old accounts that employees used to test in prod.



## Links


- Jira: [here](https://codedotorg.atlassian.net/browse/P20-1749)
