### PR TITLE
Fix URL in lesson summary notifications

### DIFF
--- a/dashboard/app/jobs/ai_lesson_summaries_job.rb
+++ b/dashboard/app/jobs/ai_lesson_summaries_job.rb
@@ -29,7 +29,7 @@ class AiLessonSummariesJob < ApplicationJob
         icon_name: 'solid-flask-sparkle',
         icon_color: 'Aqua',
         href_links: [{text: 'View lesson materials',
-                     url: "/teacher_dashboard/sections/#{section.id}/lesson_materials"}],
+                     url: "/teacher_dashboard/sections/#{section.id}/materials"}],
       )
     end
   end

--- a/dashboard/test/jobs/ai_lesson_summaries_job_test.rb
+++ b/dashboard/test/jobs/ai_lesson_summaries_job_test.rb
@@ -278,7 +278,7 @@ class AiLessonSummariesJobTest < ActiveJob::TestCase
     assert_equal 'Aqua', notification.icon_color
     assert_equal 1, notification.href_links.size
     assert_equal 'View lesson materials', notification.href_links.first['text']
-    assert_equal "/teacher_dashboard/sections/#{@section.id}/lesson_materials", notification.href_links.first['url']
+    assert_equal "/teacher_dashboard/sections/#{@section.id}/materials", notification.href_links.first['url']
   end
 
   test 'after_perform creates notification with correct lesson count for single lesson' do
@@ -311,7 +311,7 @@ class AiLessonSummariesJobTest < ActiveJob::TestCase
     end
 
     notification = TeacherNotification.last
-    assert_equal "/teacher_dashboard/sections/#{@section.id}/lesson_materials", notification.href_links.first['url']
+    assert_equal "/teacher_dashboard/sections/#{@section.id}/materials", notification.href_links.first['url']
   end
 
   test 'after_perform uses first section when unit_id provided but no matching section exists' do
@@ -329,7 +329,7 @@ class AiLessonSummariesJobTest < ActiveJob::TestCase
     end
 
     notification = TeacherNotification.last
-    assert_equal "/teacher_dashboard/sections/#{@section.id}/lesson_materials", notification.href_links.first['url']
+    assert_equal "/teacher_dashboard/sections/#{@section.id}/materials", notification.href_links.first['url']
   end
 
   test 'after_perform does not create notification when user has no sections' do


### PR DESCRIPTION
This update changes the URL in the lesson summary notification to end in `/materials` instead of `/lesson_materials`

## Links
<!--  Links to relevant external resources.
      - spec docs, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- Jira: 

## Testing story
<!--  Does your change include appropriate tests?
      - If so, please describe how the tests included in this PR are sufficient.
      - If not, please explain why this change does not need to be tested. -->



## Deployment strategy
<!--  Any special steps required to deploy this, besides merging?
      - Are there database migrations or manual steps?
      - Does this require coordination with other teams or systems? -->



## Follow-up work
<!--  List any clean-up or technical debt that will be addressed in future work.
      - Include Jira links where applicable.
      - Are there any known limitations or improvements planned? -->



## Privacy
<!--  How does this change impact Student & Teacher privacy?
      - Does this collect, use, share, or modify PII, either new or existing? -->



## Security
<!--  How does this change impact our security surface-area?
      - Do API's touched have the right auth?
      - Do infra changes impact our attack surface or encryption?
-->



## Caching
<!--  How does this change impact caching behavior?
      - Are cache keys or invalidation strategies affected?
      - Will this require cache warming or invalidation after deployment? -->



## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
