### PR TITLE
Allow Boston transit API

### DIFF
--- a/lib/cdo/shared_constants.rb
+++ b/lib/cdo/shared_constants.rb
@@ -975,9 +975,9 @@ module SharedConstants
     'api.census.gov',             # US Census data - Public API
     'api.energidataservice.dk',   # Danish energy data - Public API
     'api.fda.gov',                # FDA data - Public API
-    'api-v3.mbta.com',            # Boston transit data
     'api.nal.usda.gov',           # USDA data
     'api.si.edu',                 # Smithsonian data - API key required 🔑
+    'api-v3.mbta.com',            # Boston transit data
     'data.austintexas.gov',       # Austin city data
     'data.cityofchicago.org',     # Chicago city data
     'data.gv.at',                 # Austrian government data

--- a/lib/cdo/shared_constants.rb
+++ b/lib/cdo/shared_constants.rb
@@ -975,6 +975,7 @@ module SharedConstants
     'api.census.gov',             # US Census data - Public API
     'api.energidataservice.dk',   # Danish energy data - Public API
     'api.fda.gov',                # FDA data - Public API
+    'api-v3.mbta.com',            # Boston transit data
     'api.nal.usda.gov',           # USDA data
     'api.si.edu',                 # Smithsonian data - API key required 🔑
     'data.austintexas.gov',       # Austin city data


### PR DESCRIPTION
Allows access to Boston's transit API per Zendesk request: https://codeorg.zendesk.com/agent/tickets/570551

Here's a example API call without a API key: https://api-v3.mbta.com/routes