### PR TITLE
INF-2006: Lower Mistral min_num_instances from 3 to 2

### DIFF
--- a/aws/cloudformation/standalone/gen_ai_curriculum/deployment/config.rb
+++ b/aws/cloudformation/standalone/gen_ai_curriculum/deployment/config.rb
@@ -22,7 +22,7 @@ module Config
         production: "ml.g5.4xlarge",
         test: "ml.g5.xlarge"
       },
-      min_num_instances: 3,
+      min_num_instances: 2,
       max_num_instances: 4,
       autoscaling_target_value: 150
     },

--- a/aws/cloudformation/standalone/gen_ai_curriculum/deployment/deploy_gen_ai_curriculum_stack
+++ b/aws/cloudformation/standalone/gen_ai_curriculum/deployment/deploy_gen_ai_curriculum_stack
@@ -106,6 +106,7 @@ def main
     "--stack-name gen-ai-curriculum-#{options[:environment]} " \
     "--template-file gen_ai_curriculum.yml " \
     "--role-arn arn:aws:iam::#{account_id}:role/admin/CloudFormationService " \
+    "--tags environment-type=#{options[:environment]} " \
     "--parameter-overrides " \
     "Environment=#{options[:environment]} " \
     "HuggingFaceImageUri=#{image_uri} " \


### PR DESCRIPTION
This PR lowers the 'min_num_instances' for the Mistral model in the Gen AI production CloudFormation stack from 3 to 2. This change aims to reduce the baseline resource consumption for the Mistral endpoint while maintaining autoscaling capabilities.

This must be deployed manually via `aws/cloudformation/standalone/gen_ai_curriculum/deployment/deploy_gen_ai_curriculum_stack`