### PR TITLE
feat(aichat): scroll to last user message

### DIFF
--- a/apps/src/aichat/hooks/useChatEventsScrollHandler.tsx
+++ b/apps/src/aichat/hooks/useChatEventsScrollHandler.tsx
@@ -7,6 +7,13 @@ import {ChatEvent, isChatMessage} from '../types';
 const BOTTOM_BUFFER = 16;
 const MESSAGE_AREA_VERTICAL_PADDING = 20;
 
+type StateRefType = {
+  spacerHeight: number;
+  prevEventsCount: number;
+  containerResizeInitialized: boolean;
+  messageResizeInitialized: boolean;
+};
+
 export const useChatEventsScrollHandler = (events: ChatEvent[]) => {
   const [showScrollToBottom, setShowScrollToBottom] = useState(false);
 
@@ -15,9 +22,11 @@ export const useChatEventsScrollHandler = (events: ChatEvent[]) => {
   const lastUserMessageRef = useRef<HTMLDivElement | null>(null);
   const activeMessageRef = useRef<HTMLDivElement | null>(null);
 
-  const stateRef = useRef({
+  const stateRef = useRef<StateRefType>({
     spacerHeight: 0,
     prevEventsCount: events.length,
+    containerResizeInitialized: false,
+    messageResizeInitialized: false,
   });
 
   const scrollToBottom = useCallback((behavior: ScrollBehavior = 'smooth') => {
@@ -67,19 +76,29 @@ export const useChatEventsScrollHandler = (events: ChatEvent[]) => {
     }
   }, []);
 
-  const handleResize = useCallback(() => {
-    // on resize, only update the spacer if it already has height
-    if (stateRef.current.spacerHeight) {
-      updateSpacer();
-    }
+  const handleResize = useCallback(
+    (
+      stateRefKey: 'containerResizeInitialized' | 'messageResizeInitialized'
+    ) => {
+      // on resize, only update the spacer if both resize observers
+      // have been initialized
+      if (stateRef.current[stateRefKey]) {
+        updateSpacer();
+      } else {
+        stateRef.current[stateRefKey] = true;
+      }
 
-    setShowScrollToBottom(!isAtBottom());
-  }, [isAtBottom, updateSpacer]);
+      setShowScrollToBottom(!isAtBottom());
+    },
+    [isAtBottom, updateSpacer]
+  );
 
   // window/container resizing
   useEffect(() => {
     if (!containerRef.current) return;
-    const observer = new ResizeObserver(handleResize);
+    const observer = new ResizeObserver(() =>
+      handleResize('containerResizeInitialized')
+    );
     observer.observe(containerRef.current);
     return () => observer.disconnect();
   }, [handleResize]);
@@ -89,7 +108,9 @@ export const useChatEventsScrollHandler = (events: ChatEvent[]) => {
     const currentMessage = activeMessageRef.current;
     if (!currentMessage) return;
 
-    const observer = new ResizeObserver(handleResize);
+    const observer = new ResizeObserver(() =>
+      handleResize('messageResizeInitialized')
+    );
 
     observer.observe(currentMessage);
     return () => observer.disconnect();

--- a/apps/src/aichat/hooks/useChatEventsScrollHandler.tsx
+++ b/apps/src/aichat/hooks/useChatEventsScrollHandler.tsx
@@ -5,41 +5,31 @@ import {Role} from '@cdo/apps/aiComponentLibrary/chatMessage/types';
 import {ChatEvent, isChatMessage} from '../types';
 
 const BOTTOM_BUFFER = 16;
-
-const toPixels = (value: string) => {
-  const parsed = parseFloat(value);
-  return Number.isNaN(parsed) ? 0 : parsed;
-};
+const MESSAGE_AREA_VERTICAL_PADDING = 20;
 
 export const useChatEventsScrollHandler = (events: ChatEvent[]) => {
   const [showScrollToBottom, setShowScrollToBottom] = useState(false);
-
   const containerRef = useRef<HTMLDivElement>(null);
   const spacerRef = useRef<HTMLDivElement>(null);
-  const spacerHeightRef = useRef(0);
   const lastUserMessageRef = useRef<HTMLDivElement | null>(null);
-  const prevEventsCount = useRef(events.length);
-  const prevAssistantMessageLength = useRef(0);
+
+  // Ref tracking to avoid re-renders
+  const stateRef = useRef({
+    spacerHeight: 0,
+    prevEventsCount: events.length,
+    prevAssistantLength: 0,
+  });
 
   const scrollToBottom = useCallback((behavior: ScrollBehavior = 'smooth') => {
-    const container = containerRef.current;
-    if (!container) {
-      return;
-    }
-
-    container.scrollTo({
-      top: container.scrollHeight,
+    containerRef.current?.scrollTo({
+      top: containerRef.current.scrollHeight,
       behavior,
     });
   }, []);
 
   const isAtBottom = useCallback(() => {
     const container = containerRef.current;
-
-    if (!container) {
-      return false;
-    }
-
+    if (!container) return false;
     return (
       container.scrollTop + container.clientHeight + BOTTOM_BUFFER >=
       container.scrollHeight
@@ -49,108 +39,90 @@ export const useChatEventsScrollHandler = (events: ChatEvent[]) => {
   const updateSpacer = useCallback(() => {
     const container = containerRef.current;
     const spacer = spacerRef.current;
-    const anchorElement = lastUserMessageRef.current;
+    const anchor = lastUserMessageRef.current;
 
-    if (!container || !spacer) {
-      return;
-    }
-
-    if (!anchorElement || !container.contains(anchorElement)) {
-      if (spacerHeightRef.current !== 0) {
-        spacerHeightRef.current = 0;
+    if (!container || !spacer || !anchor) {
+      if (spacer && stateRef.current.spacerHeight !== 0) {
         spacer.style.height = '0px';
+        stateRef.current.spacerHeight = 0;
       }
-      lastUserMessageRef.current = null;
       return;
     }
 
     const containerHeight = container.clientHeight;
-    const containerStyle = getComputedStyle(container);
-    const paddingTop = toPixels(containerStyle.paddingTop);
-    const paddingBottom = toPixels(containerStyle.paddingBottom);
 
-    // the height of the space between the top of the user message
-    // to the bottom of the pending assistant message
-    const contentHeightBelowAnchor = spacer.offsetTop - anchorElement.offsetTop;
-
-    // we want enough space so that 'contentHeightBelowAnchor' + spacer fills the container
-    // minus the vertical container padding
-    const desiredSpacerHeight = Math.max(
+    const contentHeightBelowAnchor = spacer.offsetTop - anchor.offsetTop;
+    const desiredHeight = Math.max(
       0,
-      containerHeight - contentHeightBelowAnchor - paddingTop - paddingBottom
+      containerHeight - contentHeightBelowAnchor - MESSAGE_AREA_VERTICAL_PADDING
     );
 
-    if (Math.abs(desiredSpacerHeight - spacerHeightRef.current) > 1) {
-      spacerHeightRef.current = desiredSpacerHeight;
-      spacer.style.height = `${desiredSpacerHeight}px`;
+    if (Math.abs(desiredHeight - stateRef.current.spacerHeight) > 1) {
+      stateRef.current.spacerHeight = desiredHeight;
+      spacer.style.height = `${desiredHeight}px`;
     }
   }, []);
 
+  // Handle Window/Container Resizing
+  useEffect(() => {
+    if (!containerRef.current) return;
+    const observer = new ResizeObserver(() => updateSpacer());
+    observer.observe(containerRef.current);
+    return () => observer.disconnect();
+  }, [updateSpacer]);
+
   useLayoutEffect(() => {
-    // initial load of chat events
-    if (events.length && !prevEventsCount.current) {
-      prevEventsCount.current = events.length;
+    const {prevEventsCount, prevAssistantLength} = stateRef.current;
+    const currentEvent = events[events.length - 1];
+    if (!currentEvent) return;
+
+    const isNewEvent = events.length !== prevEventsCount;
+
+    // 1. Initial Load
+    if (events.length && !prevEventsCount) {
+      stateRef.current.prevEventsCount = events.length;
       scrollToBottom('auto');
       return;
     }
 
-    const currentEvent = events[events.length - 1];
-
-    // updating the current assistant chat event
+    // 2. Streaming Assistant Message
     if (
-      currentEvent &&
+      !isNewEvent &&
       isChatMessage(currentEvent) &&
-      events.length === prevEventsCount.current
+      currentEvent.role === Role.ASSISTANT
     ) {
-      if (
-        currentEvent.role === Role.ASSISTANT &&
-        currentEvent.chatMessageText.length > prevAssistantMessageLength.current
-      ) {
-        prevAssistantMessageLength.current =
+      if (currentEvent.chatMessageText.length > prevAssistantLength) {
+        stateRef.current.prevAssistantLength =
           currentEvent.chatMessageText.length;
         updateSpacer();
         setShowScrollToBottom(!isAtBottom());
       }
     }
 
-    // new chat event or chats cleared
-    if (events.length !== prevEventsCount.current) {
-      prevEventsCount.current = events.length;
-
+    // 3. New Message Added (User or Assistant)
+    if (isNewEvent) {
+      stateRef.current.prevEventsCount = events.length;
       updateSpacer();
 
-      // do not scroll unless last message is from the user
-      const lastMessageIsUser =
-        currentEvent &&
-        isChatMessage(currentEvent) &&
-        currentEvent.role === Role.USER;
-
-      if (lastMessageIsUser) {
-        prevAssistantMessageLength.current = 0;
+      const currentEventFromUser =
+        isChatMessage(currentEvent) && currentEvent.role === Role.USER;
+      if (currentEventFromUser) {
+        stateRef.current.prevAssistantLength = 0;
         scrollToBottom();
       } else {
         setShowScrollToBottom(!isAtBottom());
       }
     }
-  }, [events, scrollToBottom, updateSpacer, isAtBottom]);
+  }, [events, updateSpacer, isAtBottom, scrollToBottom]);
 
+  // Scroll Listener for the Button
   useEffect(() => {
     const container = containerRef.current;
+    if (!container) return;
 
-    if (!container) {
-      return;
-    }
-
-    const handleUserScroll = () => {
-      setShowScrollToBottom(!isAtBottom());
-    };
-
-    container.addEventListener('scroll', handleUserScroll);
-    handleUserScroll();
-
-    return () => {
-      container?.removeEventListener('scroll', handleUserScroll);
-    };
+    const handleScroll = () => setShowScrollToBottom(!isAtBottom());
+    container.addEventListener('scroll', handleScroll, {passive: true});
+    return () => container.removeEventListener('scroll', handleScroll);
   }, [isAtBottom]);
 
   return {

--- a/apps/src/aichat/hooks/useChatEventsScrollHandler.tsx
+++ b/apps/src/aichat/hooks/useChatEventsScrollHandler.tsx
@@ -9,15 +9,15 @@ const MESSAGE_AREA_VERTICAL_PADDING = 20;
 
 export const useChatEventsScrollHandler = (events: ChatEvent[]) => {
   const [showScrollToBottom, setShowScrollToBottom] = useState(false);
+
   const containerRef = useRef<HTMLDivElement>(null);
   const spacerRef = useRef<HTMLDivElement>(null);
   const lastUserMessageRef = useRef<HTMLDivElement | null>(null);
+  const activeMessageRef = useRef<HTMLDivElement | null>(null);
 
-  // Ref tracking to avoid re-renders
   const stateRef = useRef({
     spacerHeight: 0,
     prevEventsCount: events.length,
-    prevAssistantLength: 0,
   });
 
   const scrollToBottom = useCallback((behavior: ScrollBehavior = 'smooth') => {
@@ -51,7 +51,10 @@ export const useChatEventsScrollHandler = (events: ChatEvent[]) => {
 
     const containerHeight = container.clientHeight;
 
+    // as the active message grows, spacer.offsetTop increases,
+    // contentHeightBelowAnchor increases, and desiredHeight decreases.
     const contentHeightBelowAnchor = spacer.offsetTop - anchor.offsetTop;
+
     const desiredHeight = Math.max(
       0,
       containerHeight - contentHeightBelowAnchor - MESSAGE_AREA_VERTICAL_PADDING
@@ -59,55 +62,61 @@ export const useChatEventsScrollHandler = (events: ChatEvent[]) => {
 
     if (Math.abs(desiredHeight - stateRef.current.spacerHeight) > 1) {
       stateRef.current.spacerHeight = desiredHeight;
+      // direct DOM manipulation prevents render loops
       spacer.style.height = `${desiredHeight}px`;
     }
   }, []);
 
-  // Handle Window/Container Resizing
+  const handleResize = useCallback(() => {
+    // on resize, only update the spacer if it already has height
+    if (stateRef.current.spacerHeight) {
+      updateSpacer();
+    }
+
+    setShowScrollToBottom(!isAtBottom());
+  }, [isAtBottom, updateSpacer]);
+
+  // window/container resizing
   useEffect(() => {
     if (!containerRef.current) return;
-    const observer = new ResizeObserver(() => updateSpacer());
+    const observer = new ResizeObserver(handleResize);
     observer.observe(containerRef.current);
     return () => observer.disconnect();
-  }, [updateSpacer]);
+  }, [handleResize]);
+
+  // message resizing (streaming)
+  useEffect(() => {
+    const currentMessage = activeMessageRef.current;
+    if (!currentMessage) return;
+
+    const observer = new ResizeObserver(handleResize);
+
+    observer.observe(currentMessage);
+    return () => observer.disconnect();
+  }, [events.length, handleResize]);
 
   useLayoutEffect(() => {
-    const {prevEventsCount, prevAssistantLength} = stateRef.current;
+    const {prevEventsCount} = stateRef.current;
     const currentEvent = events[events.length - 1];
-    if (!currentEvent) return;
 
-    const isNewEvent = events.length !== prevEventsCount;
+    const initialLoadOfEvents = !prevEventsCount && events.length;
+    const newEventOrChatCleared =
+      prevEventsCount && events.length !== prevEventsCount;
 
-    // 1. Initial Load
-    if (events.length && !prevEventsCount) {
-      stateRef.current.prevEventsCount = events.length;
+    stateRef.current.prevEventsCount = events.length;
+
+    if (initialLoadOfEvents) {
+      //  jump to bottom of messages
       scrollToBottom('auto');
-      return;
-    }
-
-    // 2. Streaming Assistant Message
-    if (
-      !isNewEvent &&
-      isChatMessage(currentEvent) &&
-      currentEvent.role === Role.ASSISTANT
-    ) {
-      if (currentEvent.chatMessageText.length > prevAssistantLength) {
-        stateRef.current.prevAssistantLength =
-          currentEvent.chatMessageText.length;
-        updateSpacer();
-        setShowScrollToBottom(!isAtBottom());
-      }
-    }
-
-    // 3. New Message Added (User or Assistant)
-    if (isNewEvent) {
-      stateRef.current.prevEventsCount = events.length;
+    } else if (newEventOrChatCleared) {
       updateSpacer();
 
       const currentEventFromUser =
-        isChatMessage(currentEvent) && currentEvent.role === Role.USER;
+        currentEvent &&
+        isChatMessage(currentEvent) &&
+        currentEvent.role === Role.USER;
+
       if (currentEventFromUser) {
-        stateRef.current.prevAssistantLength = 0;
         scrollToBottom();
       } else {
         setShowScrollToBottom(!isAtBottom());
@@ -115,11 +124,10 @@ export const useChatEventsScrollHandler = (events: ChatEvent[]) => {
     }
   }, [events, updateSpacer, isAtBottom, scrollToBottom]);
 
-  // Scroll Listener for the Button
+  // scroll listener for scroll to bottom button
   useEffect(() => {
     const container = containerRef.current;
     if (!container) return;
-
     const handleScroll = () => setShowScrollToBottom(!isAtBottom());
     container.addEventListener('scroll', handleScroll, {passive: true});
     return () => container.removeEventListener('scroll', handleScroll);
@@ -128,6 +136,7 @@ export const useChatEventsScrollHandler = (events: ChatEvent[]) => {
   return {
     containerRef,
     lastUserMessageRef,
+    activeMessageRef,
     spacerRef,
     showScrollToBottom,
     scrollToBottom,

--- a/apps/src/aichat/hooks/useChatEventsScrollHandler.tsx
+++ b/apps/src/aichat/hooks/useChatEventsScrollHandler.tsx
@@ -19,6 +19,7 @@ export const useChatEventsScrollHandler = (events: ChatEvent[]) => {
   const spacerHeightRef = useRef(0);
   const lastUserMessageRef = useRef<HTMLDivElement | null>(null);
   const prevEventsCount = useRef(events.length);
+  const prevAssistantMessageLength = useRef(0);
 
   const scrollToBottom = useCallback((behavior: ScrollBehavior = 'smooth') => {
     const container = containerRef.current;
@@ -45,96 +46,93 @@ export const useChatEventsScrollHandler = (events: ChatEvent[]) => {
     );
   }, []);
 
-  const updateSpacerAndScroll = useCallback(
-    (preventScroll: boolean) => {
-      let container = containerRef.current;
-      const spacer = spacerRef.current;
-      const anchorElement = lastUserMessageRef.current;
+  const updateSpacer = useCallback(() => {
+    const container = containerRef.current;
+    const spacer = spacerRef.current;
+    const anchorElement = lastUserMessageRef.current;
 
-      if (!container || !spacer) {
-        return;
+    if (!container || !spacer) {
+      return;
+    }
+
+    if (!anchorElement || !container.contains(anchorElement)) {
+      if (spacerHeightRef.current !== 0) {
+        spacerHeightRef.current = 0;
+        spacer.style.height = '0px';
       }
+      lastUserMessageRef.current = null;
+      return;
+    }
 
-      if (!anchorElement || !container.contains(anchorElement)) {
-        if (spacerHeightRef.current !== 0) {
-          spacerHeightRef.current = 0;
-          spacer.style.height = '0px';
-        }
-        lastUserMessageRef.current = null;
-        return;
-      }
+    const containerHeight = container.clientHeight;
+    const containerStyle = getComputedStyle(container);
+    const paddingTop = toPixels(containerStyle.paddingTop);
+    const paddingBottom = toPixels(containerStyle.paddingBottom);
 
-      const containerHeight = container.clientHeight;
-      const containerStyle = getComputedStyle(container);
-      const paddingTop = toPixels(containerStyle.paddingTop);
-      const paddingBottom = toPixels(containerStyle.paddingBottom);
+    // the height of the space between the top of the user message
+    // to the bottom of the pending assistant message
+    const contentHeightBelowAnchor = spacer.offsetTop - anchorElement.offsetTop;
 
-      // the height of the space between the top of the user message
-      // to the bottom of the pending assistant message
-      const contentHeightBelowAnchor =
-        spacer.offsetTop - anchorElement.offsetTop;
+    // we want enough space so that 'contentHeightBelowAnchor' + spacer fills the container
+    // minus the vertical container padding
+    const desiredSpacerHeight = Math.max(
+      0,
+      containerHeight - contentHeightBelowAnchor - paddingTop - paddingBottom
+    );
 
-      // we want enough space so that 'contentHeightBelowAnchor' + spacer fills the container
-      // minus the vertical container padding
-      const desiredSpacerHeight = Math.max(
-        0,
-        containerHeight - contentHeightBelowAnchor - paddingTop - paddingBottom
-      );
-
-      if (Math.abs(desiredSpacerHeight - spacerHeightRef.current) > 1) {
-        spacerHeightRef.current = desiredSpacerHeight;
-        spacer.style.height = `${desiredSpacerHeight}px`;
-      }
-
-      // scroll is prevented when last message is from the assistant
-      // check if assistant message overflows container and needs scroll
-      // to bottom button
-      if (preventScroll) {
-        setShowScrollToBottom(!isAtBottom());
-        return;
-      }
-
-      requestAnimationFrame(() => {
-        // re-measure after DOM update
-        container = containerRef.current;
-
-        if (!container) {
-          return;
-        }
-
-        container.scrollTo({
-          top: container.scrollHeight,
-          behavior: 'smooth',
-        });
-        setShowScrollToBottom(!isAtBottom());
-      });
-    },
-    [isAtBottom]
-  );
+    if (Math.abs(desiredSpacerHeight - spacerHeightRef.current) > 1) {
+      spacerHeightRef.current = desiredSpacerHeight;
+      spacer.style.height = `${desiredSpacerHeight}px`;
+    }
+  }, []);
 
   useLayoutEffect(() => {
-    // initial load of chat history
+    // initial load of chat events
     if (events.length && !prevEventsCount.current) {
       prevEventsCount.current = events.length;
       scrollToBottom('auto');
       return;
     }
 
-    // new chat message
+    const currentEvent = events[events.length - 1];
+
+    // updating the current assistant chat event
+    if (
+      currentEvent &&
+      isChatMessage(currentEvent) &&
+      events.length === prevEventsCount.current
+    ) {
+      if (
+        currentEvent.role === Role.ASSISTANT &&
+        currentEvent.chatMessageText.length > prevAssistantMessageLength.current
+      ) {
+        prevAssistantMessageLength.current =
+          currentEvent.chatMessageText.length;
+        updateSpacer();
+        setShowScrollToBottom(!isAtBottom());
+      }
+    }
+
+    // new chat event or chats cleared
     if (events.length !== prevEventsCount.current) {
       prevEventsCount.current = events.length;
 
-      // do not scroll unless last message is from the user
-      const lastEvent = events[events.length - 1];
-      const preventScroll = !(
-        lastEvent &&
-        isChatMessage(lastEvent) &&
-        lastEvent.role === Role.USER
-      );
+      updateSpacer();
 
-      updateSpacerAndScroll(preventScroll);
+      // do not scroll unless last message is from the user
+      const lastMessageIsUser =
+        currentEvent &&
+        isChatMessage(currentEvent) &&
+        currentEvent.role === Role.USER;
+
+      if (lastMessageIsUser) {
+        prevAssistantMessageLength.current = 0;
+        scrollToBottom();
+      } else {
+        setShowScrollToBottom(!isAtBottom());
+      }
     }
-  }, [events, scrollToBottom, updateSpacerAndScroll]);
+  }, [events, scrollToBottom, updateSpacer, isAtBottom]);
 
   useEffect(() => {
     const container = containerRef.current;

--- a/apps/src/aichat/hooks/useChatEventsScrollHandler.tsx
+++ b/apps/src/aichat/hooks/useChatEventsScrollHandler.tsx
@@ -1,0 +1,165 @@
+import {useCallback, useEffect, useLayoutEffect, useRef, useState} from 'react';
+
+import {Role} from '@cdo/apps/aiComponentLibrary/chatMessage/types';
+
+import {ChatEvent, isChatMessage} from '../types';
+
+const BOTTOM_BUFFER = 16;
+
+const toPixels = (value: string) => {
+  const parsed = parseFloat(value);
+  return Number.isNaN(parsed) ? 0 : parsed;
+};
+
+export const useChatEventsScrollHandler = (events: ChatEvent[]) => {
+  const [showScrollToBottom, setShowScrollToBottom] = useState(false);
+
+  const containerRef = useRef<HTMLDivElement>(null);
+  const spacerRef = useRef<HTMLDivElement>(null);
+  const spacerHeightRef = useRef(0);
+  const lastUserMessageRef = useRef<HTMLDivElement | null>(null);
+  const prevEventsCount = useRef(events.length);
+
+  const scrollToBottom = useCallback((behavior: ScrollBehavior = 'smooth') => {
+    const container = containerRef.current;
+    if (!container) {
+      return;
+    }
+
+    container.scrollTo({
+      top: container.scrollHeight,
+      behavior,
+    });
+  }, []);
+
+  const isAtBottom = useCallback(() => {
+    const container = containerRef.current;
+
+    if (!container) {
+      return false;
+    }
+
+    return (
+      container.scrollTop + container.clientHeight + BOTTOM_BUFFER >=
+      container.scrollHeight
+    );
+  }, []);
+
+  const updateSpacerAndScroll = useCallback(
+    (preventScroll: boolean) => {
+      let container = containerRef.current;
+      const spacer = spacerRef.current;
+      const anchorElement = lastUserMessageRef.current;
+
+      if (!container || !spacer) {
+        return;
+      }
+
+      if (!anchorElement || !container.contains(anchorElement)) {
+        if (spacerHeightRef.current !== 0) {
+          spacerHeightRef.current = 0;
+          spacer.style.height = '0px';
+        }
+        lastUserMessageRef.current = null;
+        return;
+      }
+
+      const containerHeight = container.clientHeight;
+      const containerStyle = getComputedStyle(container);
+      const paddingTop = toPixels(containerStyle.paddingTop);
+      const paddingBottom = toPixels(containerStyle.paddingBottom);
+
+      // the height of the space between the top of the user message
+      // to the bottom of the pending assistant message
+      const contentHeightBelowAnchor =
+        spacer.offsetTop - anchorElement.offsetTop;
+
+      // we want enough space so that 'contentHeightBelowAnchor' + spacer fills the container
+      // minus the vertical container padding
+      const desiredSpacerHeight = Math.max(
+        0,
+        containerHeight - contentHeightBelowAnchor - paddingTop - paddingBottom
+      );
+
+      if (Math.abs(desiredSpacerHeight - spacerHeightRef.current) > 1) {
+        spacerHeightRef.current = desiredSpacerHeight;
+        spacer.style.height = `${desiredSpacerHeight}px`;
+      }
+
+      // scroll is prevented when last message is from the assistant
+      // check if assistant message overflows container and needs scroll
+      // to bottom button
+      if (preventScroll) {
+        setShowScrollToBottom(!isAtBottom());
+        return;
+      }
+
+      requestAnimationFrame(() => {
+        // re-measure after DOM update
+        container = containerRef.current;
+
+        if (!container) {
+          return;
+        }
+
+        container.scrollTo({
+          top: container.scrollHeight,
+          behavior: 'smooth',
+        });
+        setShowScrollToBottom(!isAtBottom());
+      });
+    },
+    [isAtBottom]
+  );
+
+  useLayoutEffect(() => {
+    // initial load of chat history
+    if (events.length && !prevEventsCount.current) {
+      prevEventsCount.current = events.length;
+      scrollToBottom('auto');
+      return;
+    }
+
+    // new chat message
+    if (events.length !== prevEventsCount.current) {
+      prevEventsCount.current = events.length;
+
+      // do not scroll unless last message is from the user
+      const lastEvent = events[events.length - 1];
+      const preventScroll = !(
+        lastEvent &&
+        isChatMessage(lastEvent) &&
+        lastEvent.role === Role.USER
+      );
+
+      updateSpacerAndScroll(preventScroll);
+    }
+  }, [events, scrollToBottom, updateSpacerAndScroll]);
+
+  useEffect(() => {
+    const container = containerRef.current;
+
+    if (!container) {
+      return;
+    }
+
+    const handleUserScroll = () => {
+      setShowScrollToBottom(!isAtBottom());
+    };
+
+    container.addEventListener('scroll', handleUserScroll);
+    handleUserScroll();
+
+    return () => {
+      container?.removeEventListener('scroll', handleUserScroll);
+    };
+  }, [isAtBottom]);
+
+  return {
+    containerRef,
+    lastUserMessageRef,
+    spacerRef,
+    showScrollToBottom,
+    scrollToBottom,
+  };
+};

--- a/apps/src/aichat/views/ChatEventsList.tsx
+++ b/apps/src/aichat/views/ChatEventsList.tsx
@@ -1,11 +1,19 @@
 import Button from '@code-dot-org/component-library/button';
 import classNames from 'classnames';
-import React, {useEffect, useRef, useState, useCallback} from 'react';
+import React, {
+  FC,
+  forwardRef,
+  useCallback,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 
 import {useAiChatDisabled} from '@cdo/apps/aichat/context/aiChatDisabledContext';
 import {Role} from '@cdo/apps/aiComponentLibrary/chatMessage/types';
 import {useAppSelector} from '@cdo/apps/util/reduxHooks';
 
+import {useChatEventsScrollHandler} from '../hooks/useChatEventsScrollHandler';
 import {selectIsWaitingForChatResponse} from '../redux';
 import {ChatAsset, ChatEvent, isChatMessage} from '../types';
 
@@ -33,134 +41,50 @@ const ChatEventsList: React.FunctionComponent<ChatEventsListProps> = ({
 }) => {
   const {chatDisabled, chatDisabledMessage} = useAiChatDisabled();
   const [isInChatNavigationMode, setIsInChatNavigationMode] = useState(false);
-  const [inProgrammaticScroll, setInProgrammaticScroll] = useState(false);
-  const [showScrollToBottom, setShowScrollToBottom] = useState(true);
+  const {
+    containerRef,
+    lastUserMessageRef,
+    spacerRef,
+    showScrollToBottom,
+    scrollToBottom,
+  } = useChatEventsScrollHandler(events);
+
   const isWaitingForChatResponse = useAppSelector(
     selectIsWaitingForChatResponse
   );
 
-  const conversationContainerRef = useRef<HTMLDivElement>(null);
-  const previousLastMessageRole = useRef<Role | null>(null);
-  const previousEventsLength = useRef<number | null>(null);
   const parentRef = useRef<HTMLDivElement>(null);
-  const finalEventRef = useRef<HTMLDivElement>(null);
+  const finalEventRef = useRef<HTMLDivElement | null>(null);
 
-  const scrollToLastMessage = useCallback((keepTopOfMessageVisible = false) => {
-    if (conversationContainerRef.current) {
-      setShowScrollToBottom(false);
-      setInProgrammaticScroll(true);
-
-      if (keepTopOfMessageVisible) {
-        finalEventRef.current?.scrollIntoView({
-          behavior: 'smooth',
-          block: 'start',
-        });
-      } else if (!isAtBottom()) {
-        conversationContainerRef.current.scrollTo({
-          top: conversationContainerRef.current.scrollHeight,
-          behavior: 'smooth',
-        });
+  const lastUserMessageIndex = useMemo(() => {
+    for (let index = events.length - 1; index >= 0; index--) {
+      const event = events[index];
+      if (isChatMessage(event) && event.role === Role.USER) {
+        return index;
       }
     }
-  }, []);
+    return -1;
+  }, [events]);
 
-  const isAtBottom = () => {
-    const container = conversationContainerRef.current;
-
-    if (!container) {
-      return false;
-    }
-
-    // Add a pixel of buffer to account for rounding errors.
-    return (
-      container.scrollTop + container.clientHeight + 1 >= container.scrollHeight
-    );
-  };
-
-  const handleParentKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
-    if (e.target === e.currentTarget && e.key === 'Enter') {
-      setIsInChatNavigationMode(true);
-      finalEventRef.current?.focus();
-    }
-  };
-
-  useEffect(() => {
-    const container = conversationContainerRef.current;
-
-    if (!container) {
-      return;
-    }
-
-    const handleUserScroll = () => {
-      setShowScrollToBottom(!isAtBottom());
-    };
-
-    let previousScrollTop: number | null = null;
-    let scrollEndIntervalId: number;
-    let resizeObserver: ResizeObserver | undefined;
-
-    // If we're in a programmatic scroll, set up an interval to detect when programmatic scroll has
-    // ended. We do not show the scroll to bottom button until the programmatic scroll finishes.
-    if (inProgrammaticScroll) {
-      scrollEndIntervalId = window.setInterval(() => {
-        if (conversationContainerRef.current) {
-          if (
-            previousScrollTop === conversationContainerRef.current.scrollTop
-          ) {
-            window.clearInterval(scrollEndIntervalId);
-            setInProgrammaticScroll(false);
-            setShowScrollToBottom(!isAtBottom());
-            previousScrollTop = null;
-          } else {
-            previousScrollTop = conversationContainerRef.current.scrollTop;
-          }
-        }
-      }, 250);
-    }
-    // Otherwise, set up the user scroll handler to display the scroll button when not at scroll end.
-    else {
-      container.addEventListener('scroll', handleUserScroll);
-      resizeObserver = new ResizeObserver(handleUserScroll);
-      resizeObserver.observe(container);
-    }
-
-    return () => {
-      container?.removeEventListener('scroll', handleUserScroll);
-      resizeObserver?.disconnect();
-      window.clearInterval(scrollEndIntervalId);
-    };
-  }, [inProgrammaticScroll]);
-
-  useEffect(() => {
-    if (previousEventsLength.current !== events.length) {
-      previousEventsLength.current = events.length;
-
-      const lastMessage = events[events.length - 1];
-      let lastMessageRole: Role | null = null;
-      if (lastMessage && isChatMessage(lastMessage)) {
-        lastMessageRole = lastMessage.role;
+  const handleItemKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLDivElement>) => {
+      if (e.key === 'Escape' && e.target === e.currentTarget) {
+        setIsInChatNavigationMode(false);
+        parentRef.current?.focus();
       }
+    },
+    []
+  );
 
-      // Heuristic to determine if we have an incoming assistant message and need to scroll only
-      // to the top of the incoming message, For all other messages we scroll to the bottom.
-      // Checking previousLastMessageRole.current is truthy avoids triggering this behavior when
-      // the history is first loaded.
-      const isIncomingAssistantMessage =
-        lastMessageRole === 'assistant' &&
-        previousLastMessageRole.current &&
-        previousLastMessageRole.current !== 'assistant';
-
-      if (isIncomingAssistantMessage) {
-        // Scroll to top of last message.
-        scrollToLastMessage(true);
-      } else {
-        // Scroll to bottom of last message.
-        scrollToLastMessage();
+  const handleParentKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLDivElement>) => {
+      if (e.target === e.currentTarget && e.key === 'Enter') {
+        setIsInChatNavigationMode(true);
+        finalEventRef.current?.focus();
       }
-
-      previousLastMessageRole.current = lastMessageRole;
-    }
-  }, [events, events.length, scrollToLastMessage]);
+    },
+    []
+  );
 
   return (
     <div
@@ -179,28 +103,17 @@ const ChatEventsList: React.FunctionComponent<ChatEventsListProps> = ({
         moduleStyles.scrollToBottomContainer
       )}
     >
-      {showScrollToBottom && (
-        <div className={moduleStyles.floatingScrollToBottomButtonContainer}>
-          <Button
-            isIconOnly
-            icon={{iconName: 'arrow-down'}}
-            size="xs"
-            color="black"
-            type="secondary"
-            onClick={() => scrollToLastMessage()}
-            className={moduleStyles.scrollToBottomButton}
-            ariaLabel="Scroll to bottom of messages"
-            aria-controls="chat-workspace-conversation"
-          />
-        </div>
+      {showScrollToBottom && !isWaitingForChatResponse && (
+        <ScrollToBottomButton scrollToBottom={scrollToBottom} />
       )}
-      <div className={moduleStyles.messageArea} ref={conversationContainerRef}>
+      <div className={moduleStyles.messageArea} ref={containerRef}>
         {chatDisabled ? (
           <ChatDisabled message={chatDisabledMessage} />
         ) : (
           <>
             {events.map((event, index) => {
               const isLastMessage = index === events.length - 1;
+              const isLastUserMessage = index === lastUserMessageIndex;
               return (
                 <ChatEventView
                   event={event}
@@ -209,18 +122,21 @@ const ChatEventsList: React.FunctionComponent<ChatEventsListProps> = ({
                   buildAssetUrl={buildAssetUrl}
                   isAiTutorVersion={isAiTutorVersion}
                   isLastMessage={isLastMessage}
-                  ref={isLastMessage ? finalEventRef : undefined}
-                  tabIndex={isInChatNavigationMode ? 0 : -1}
-                  onKeyDown={e => {
-                    if (e.key === 'Escape' && e.target === e.currentTarget) {
-                      setIsInChatNavigationMode(false);
-                      parentRef.current?.focus();
+                  ref={element => {
+                    if (isLastUserMessage) {
+                      lastUserMessageRef.current = element;
+                    }
+                    if (isLastMessage) {
+                      finalEventRef.current = element;
                     }
                   }}
+                  tabIndex={isInChatNavigationMode ? 0 : -1}
+                  onKeyDown={handleItemKeyDown}
                 />
               );
             })}
             <WaitingAnimation shouldDisplay={isWaitingForChatResponse} />
+            <Spacer ref={spacerRef} />
           </>
         )}
       </div>
@@ -229,3 +145,25 @@ const ChatEventsList: React.FunctionComponent<ChatEventsListProps> = ({
 };
 
 export default ChatEventsList;
+
+const Spacer = forwardRef<HTMLDivElement>((_, ref) => (
+  <div ref={ref} className={moduleStyles.scrollSpacer} />
+));
+
+const ScrollToBottomButton: FC<{scrollToBottom: () => void}> = ({
+  scrollToBottom,
+}) => (
+  <div className={moduleStyles.floatingScrollToBottomButtonContainer}>
+    <Button
+      isIconOnly
+      icon={{iconName: 'arrow-down'}}
+      size="xs"
+      color="black"
+      type="secondary"
+      onClick={() => scrollToBottom()}
+      className={moduleStyles.scrollToBottomButton}
+      ariaLabel="Scroll to bottom of messages"
+      aria-controls="chat-workspace-conversation"
+    />
+  </div>
+);

--- a/apps/src/aichat/views/ChatEventsList.tsx
+++ b/apps/src/aichat/views/ChatEventsList.tsx
@@ -44,6 +44,7 @@ const ChatEventsList: React.FunctionComponent<ChatEventsListProps> = ({
   const {
     containerRef,
     lastUserMessageRef,
+    activeMessageRef,
     spacerRef,
     showScrollToBottom,
     scrollToBottom,
@@ -54,7 +55,6 @@ const ChatEventsList: React.FunctionComponent<ChatEventsListProps> = ({
   );
 
   const parentRef = useRef<HTMLDivElement>(null);
-  const finalEventRef = useRef<HTMLDivElement | null>(null);
 
   const lastUserMessageIndex = useMemo(() => {
     for (let index = events.length - 1; index >= 0; index--) {
@@ -73,17 +73,17 @@ const ChatEventsList: React.FunctionComponent<ChatEventsListProps> = ({
         parentRef.current?.focus();
       }
     },
-    []
+    [parentRef]
   );
 
   const handleParentKeyDown = useCallback(
     (e: React.KeyboardEvent<HTMLDivElement>) => {
       if (e.target === e.currentTarget && e.key === 'Enter') {
         setIsInChatNavigationMode(true);
-        finalEventRef.current?.focus();
+        activeMessageRef.current?.focus();
       }
     },
-    []
+    [activeMessageRef]
   );
 
   return (
@@ -127,7 +127,7 @@ const ChatEventsList: React.FunctionComponent<ChatEventsListProps> = ({
                       lastUserMessageRef.current = element;
                     }
                     if (isLastMessage) {
-                      finalEventRef.current = element;
+                      activeMessageRef.current = element;
                     }
                   }}
                   tabIndex={isInChatNavigationMode ? 0 : -1}

--- a/apps/src/aichat/views/chatWorkspace.module.scss
+++ b/apps/src/aichat/views/chatWorkspace.module.scss
@@ -79,6 +79,11 @@ $tabs-default-spacing: 4px;
   pointer-events: none;
 }
 
+.scrollSpacer {
+  flex-shrink: 0;
+  width: 100%;
+}
+
 .chatDisabledContainer {
   margin: auto;
   display: flex;

--- a/apps/test/unit/aichat/hooks/useChatEventsScrollHandlerTest.tsx
+++ b/apps/test/unit/aichat/hooks/useChatEventsScrollHandlerTest.tsx
@@ -1,0 +1,188 @@
+import {fireEvent, render, waitFor} from '@testing-library/react';
+import React from 'react';
+
+import {useChatEventsScrollHandler} from '@cdo/apps/aichat/hooks/useChatEventsScrollHandler';
+import {ChatEvent, CompletedChatMessage} from '@cdo/apps/aichat/types';
+import {Role} from '@cdo/apps/aiComponentLibrary/chatMessage/types';
+import {AiInteractionStatus} from '@cdo/generated-scripts/sharedConstants';
+
+type HookState = ReturnType<typeof useChatEventsScrollHandler>;
+
+let hookState: HookState;
+
+const HookHarness: React.FC<{events: ChatEvent[]}> = ({events}) => {
+  hookState = useChatEventsScrollHandler(events);
+
+  return (
+    <div ref={hookState.containerRef}>
+      <div ref={hookState.lastUserMessageRef} />
+      <div ref={hookState.activeMessageRef} />
+      <div ref={hookState.spacerRef} />
+    </div>
+  );
+};
+
+const getHookElements = () => {
+  const container = hookState.containerRef.current as HTMLDivElement;
+  const anchor = hookState.lastUserMessageRef.current as HTMLDivElement;
+  const active = hookState.activeMessageRef.current as HTMLDivElement;
+  const spacer = hookState.spacerRef.current as HTMLDivElement;
+  if (!container || !anchor || !active || !spacer) {
+    throw new Error('Hook refs not set yet');
+  }
+  return {container, anchor, active, spacer};
+};
+
+const createMessage = (
+  overrides: Partial<CompletedChatMessage> = {}
+): CompletedChatMessage => ({
+  timestamp: 1,
+  chatMessageText: 'Hello',
+  role: Role.USER,
+  status: AiInteractionStatus.OK,
+  requestId: 1,
+  ...overrides,
+});
+
+const setContainerHeights = (
+  element: HTMLElement,
+  {clientHeight, scrollHeight}: {clientHeight: number; scrollHeight: number}
+) => {
+  Object.defineProperty(element, 'clientHeight', {
+    value: clientHeight,
+    configurable: true,
+  });
+  Object.defineProperty(element, 'scrollHeight', {
+    value: scrollHeight,
+    configurable: true,
+  });
+};
+
+const setOffsetTop = (element: HTMLElement, offsetTop: number) => {
+  Object.defineProperty(element, 'offsetTop', {
+    value: offsetTop,
+    configurable: true,
+  });
+};
+
+const attachScrollToMock = (element: HTMLDivElement) => {
+  const scrollToMock = jest.fn(({top}: ScrollToOptions) => {
+    if (typeof top === 'number') {
+      element.scrollTop = top;
+    }
+  });
+  element.scrollTo = scrollToMock as unknown as typeof element.scrollTo;
+  return scrollToMock;
+};
+
+describe('useChatEventsScrollHandler', () => {
+  beforeEach(() => {
+    hookState = undefined as unknown as HookState;
+  });
+
+  it('scrolls to bottom on initial load when events appear', () => {
+    const {rerender} = render(<HookHarness events={[]} />);
+
+    const {container} = getHookElements();
+    setContainerHeights(container, {clientHeight: 200, scrollHeight: 1000});
+    const scrollToMock = attachScrollToMock(container);
+
+    const events = [createMessage({requestId: 1})];
+    rerender(<HookHarness events={events} />);
+
+    expect(scrollToMock).toHaveBeenCalledWith({
+      top: 1000,
+      behavior: 'auto',
+    });
+  });
+
+  it('scrolls to bottom when a new user message is added', () => {
+    const {rerender} = render(
+      <HookHarness
+        events={[createMessage({role: Role.ASSISTANT, requestId: 1})]}
+      />
+    );
+
+    const {container} = getHookElements();
+    setContainerHeights(container, {clientHeight: 200, scrollHeight: 800});
+    const scrollToMock = attachScrollToMock(container);
+
+    rerender(
+      <HookHarness
+        events={[
+          createMessage({role: Role.ASSISTANT, requestId: 1}),
+          createMessage({role: Role.USER, requestId: 2}),
+        ]}
+      />
+    );
+
+    expect(scrollToMock).toHaveBeenCalledWith({
+      top: 800,
+      behavior: 'smooth',
+    });
+  });
+
+  it('shows the scroll-to-bottom button when a non-user message arrives off screen', async () => {
+    const {rerender} = render(
+      <HookHarness events={[createMessage({role: Role.USER, requestId: 1})]} />
+    );
+
+    const {container} = getHookElements();
+    setContainerHeights(container, {clientHeight: 200, scrollHeight: 1000});
+    container.scrollTop = 0;
+
+    rerender(
+      <HookHarness
+        events={[
+          createMessage({role: Role.USER, requestId: 1}),
+          createMessage({role: Role.ASSISTANT, requestId: 2}),
+        ]}
+      />
+    );
+
+    await waitFor(() => {
+      expect(hookState.showScrollToBottom).toBe(true);
+    });
+  });
+
+  it('updates the spacer height based on the last user message position', () => {
+    const {rerender} = render(
+      <HookHarness events={[createMessage({role: Role.USER, requestId: 1})]} />
+    );
+
+    const {container, anchor, spacer} = getHookElements();
+
+    setContainerHeights(container, {clientHeight: 300, scrollHeight: 600});
+    setOffsetTop(anchor, 100);
+    setOffsetTop(spacer, 250);
+
+    rerender(
+      <HookHarness
+        events={[
+          createMessage({role: Role.USER, requestId: 1}),
+          createMessage({role: Role.ASSISTANT, requestId: 2}),
+        ]}
+      />
+    );
+
+    // container height = container.clientHeight = 300
+    // space below content = spacer.offsetTop - anchor.offsetTop = 250 - 100 = 150
+    // padding = 20
+    // spacerHeight = 300 - 150 - 20 = 130
+    expect(spacer.style.height).toBe('130px');
+  });
+
+  it('updates showScrollToBottom on scroll events', async () => {
+    render(<HookHarness events={[createMessage({requestId: 1})]} />);
+
+    const {container} = getHookElements();
+    setContainerHeights(container, {clientHeight: 200, scrollHeight: 1000});
+    container.scrollTop = 0;
+
+    fireEvent.scroll(container);
+
+    await waitFor(() => {
+      expect(hookState.showScrollToBottom).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
This pr updates the scroll behavior in the `ChatEventsList` component by adding a custom hook to encapsulate the logic for showing and hiding the "scroll to bottom" button, and scrolling user and assistant messages into view. It also moves the user message to the top using an empty div spacer that dynamically resizes based on the remaining space in the message container, shrinking to 0px when the message overflows the container. This is done using a resize observer on the last chat message. While the scroll behavior is fine currently, when streaming is implemented the old logic does not account for an assistant message that starts small and grows over time (see video of existing behavior with streaming on the large response).

## Existing scroll behavior
new user message appears at bottom of container, small assistant message is shown at bottom, large assistant message smooth scrolls to start of message.

https://github.com/user-attachments/assets/7b26bef4-6972-457b-8e00-35965d1cc780

## New scroll behavior
new user message appears at the top of the container, small assistant message shown right below, large assistant message appears below user message and fills space below.

https://github.com/user-attachments/assets/66dcd0f6-d2be-4fed-974b-b76e38ca5556

## Existing behavior with streaming
new user message appears at bottom of container, small assistant message is shown at bottom, large assistant message's first few lines appear below user message and grows below the container, out of view

https://github.com/user-attachments/assets/4d9fb74e-5bfc-4028-bfd1-e52014c517eb

## New behavior with streaming
new user message appears at the top of the container, small assistant message shown right below, large assistant message appears below user message and updates to fill the space below and beyond the container

https://github.com/user-attachments/assets/9dd08f71-219f-45e3-8d1a-0278efcee715



## Links
<!--  Links to relevant external resources.
      - spec docs, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- Jira: https://codedotorg.atlassian.net/browse/LABS-1769

## Testing story
<!--  Does your change include appropriate tests?
      - If so, please describe how the tests included in this PR are sufficient.
      - If not, please explain why this change does not need to be tested. -->



## Deployment strategy
<!--  Any special steps required to deploy this, besides merging?
      - Are there database migrations or manual steps?
      - Does this require coordination with other teams or systems? -->



## Follow-up work
<!--  List any clean-up or technical debt that will be addressed in future work.
      - Include Jira links where applicable.
      - Are there any known limitations or improvements planned? -->



## Privacy
<!--  How does this change impact Student & Teacher privacy?
      - Does this collect, use, share, or modify PII, either new or existing? -->



## Security
<!--  How does this change impact our security surface-area?
      - Do API's touched have the right auth?
      - Do infra changes impact our attack surface or encryption?
-->



## Caching
<!--  How does this change impact caching behavior?
      - Are cache keys or invalidation strategies affected?
      - Will this require cache warming or invalidation after deployment? -->



## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
