### PR TITLE
Remove docs entry for non-existent getFrame Sprite method

### DIFF
--- a/apps/src/p5lab/gamelab/dropletConfig.js
+++ b/apps/src/p5lab/gamelab/dropletConfig.js
@@ -698,14 +698,6 @@ module.exports.blocks = [
     type: 'value',
   },
   {
-    func: 'getFrame',
-    blockPrefix: spriteBlockPrefix,
-    category: 'Sprites',
-    tipPrefix: spriteMethodPrefix,
-    modeOptionName: '*.getFrame',
-    type: 'value',
-  },
-  {
     func: 'getSpeed',
     blockPrefix: spriteBlockPrefix,
     category: 'Sprites',


### PR DESCRIPTION
Calling getFrame on a Sprite (even one with an assigned Animation) seems to return an error, so removing its docs entry.

**Previous behavior (this tooltip/autocomplete no longer shows up after this change, and the "Examples" link is a 404)**

<img width="587" height="841" alt="image" src="https://github.com/user-attachments/assets/18e3767b-6a16-4913-b04d-8c0ca492b389" />

## Links

- Zendesk report: https://codeorg.zendesk.com/agent/tickets/570566

## Testing story

Tested manually locally.