### PR TITLE
Tutor: Limit the number of console lines added to the hidden context

### DIFF
--- a/apps/src/aiTutor/helpers/aiTutorContextHelper.ts
+++ b/apps/src/aiTutor/helpers/aiTutorContextHelper.ts
@@ -1,36 +1,25 @@
 import {AiTutorContext, MaybePromise} from '../types';
 
+export const MAX_CONSOLE_LINES = 50;
+
 const SOURCE_CODE_INTRO = "Here is the student's current code:";
-
 const HAS_NOT_RUN = 'The student has not run the source code.';
-
 const HAS_NOT_EDITED = 'The student has not edited the source code.';
-
 const HIDDEN_SOURCE_CODE_INTRO =
   'Here is the hidden source code used to run this lesson. The student cannot view or modify this code so do not reference it in your response:';
-
 const READ_ONLY_SOURCE_CODE_INTRO =
   'Here is the source code used to run this lesson. The student can view the code but cannot modify it:';
-
 const VALIDATION_CONTENTS_INTRO = 'Here is the validation code:';
-
 const VALIDATION_RESULTS_INTRO =
   'Here are the validation test names along with their results, in JSON:';
-
 const VALIDATION_NOT_RUN = 'The student has not run test validation yet.';
-
 const INSTRUCTIONS_INTRO = 'Here are the instructions:';
-
 const DOCUMENTATION_INTRO = 'Here is the documentation:';
-
 const DOCUMENTATION_LOCATION_INTRO =
   'Here is where the student can find the documentation:';
-
 const EXAMPLES_LOCATION_INTRO =
   'Here is where the student can find example projects:';
-
-const CONSOLE_OUTPUT_INTRO =
-  "Here is the output currently shown in the student's debug console:";
+const CONSOLE_OUTPUT_INTRO = `Here is the output currently shown in the student's debug console, limited to the last ${MAX_CONSOLE_LINES} lines:`;
 
 /*
  * Abstract base class used to provide lab specific context to AI Tutor.  Each lab will inherit from and

--- a/apps/src/pythonlab/helpers/aiTutorContextHelper.ts
+++ b/apps/src/pythonlab/helpers/aiTutorContextHelper.ts
@@ -1,7 +1,10 @@
 import CodebridgeRegistry from '@codebridge/CodebridgeRegistry';
 
 import {tryFetchDocsForClass} from '@cdo/apps/aiTutor/docContextApi';
-import {AiTutorContextHelper} from '@cdo/apps/aiTutor/helpers/aiTutorContextHelper';
+import {
+  AiTutorContextHelper,
+  MAX_CONSOLE_LINES,
+} from '@cdo/apps/aiTutor/helpers/aiTutorContextHelper';
 import {AiTutorContext} from '@cdo/apps/aiTutor/types';
 import {stripAnsiSequences} from '@cdo/apps/codebridge/Console/MessageHelpers';
 import {ProjectFile} from '@cdo/apps/codebridge/types';
@@ -74,6 +77,7 @@ export class AiTutorPythonLabContextHelper extends AiTutorContextHelper<AiTutorP
     const consoleLines = CodebridgeRegistry.getInstance()
       .getConsoleManager()
       ?.getTerminalLines()
+      ?.slice(-MAX_CONSOLE_LINES)
       ?.map(line => stripAnsiSequences(line));
     const consoleOutput =
       consoleLines && consoleLines.length > 0


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

This limits the number of console output lines added to the hidden context in AI Tutor to 50. 

We saw some [quota exceeded issues](https://codedotorg.slack.com/archives/C0T0PNTM3/p1767808961409559) for input token count due to messages being sent with enormous hiddenContext due to console output.  This was partly mitigated by increasing the rate limits for the tutor project, but very large hiddenContext was also [causing problems with the db](https://codedotorg.slack.com/archives/C0T0PNTM3/p1767816097087429?thread_ts=1767810823.540909&cid=C0T0PNTM3) so we are implementing this fix in addition.

## Links
<!--  Links to relevant external resources.
      - spec docs, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- [slack thread](https://codedotorg.slack.com/archives/C08S29NDZ5E/p1767818392867949?thread_ts=1767810119.611459&cid=C08S29NDZ5E)

## Testing story
<!--  Does your change include appropriate tests?
      - If so, please describe how the tests included in this PR are sufficient.
      - If not, please explain why this change does not need to be tested. -->

Tested locally that the console output is truncated.
