### PR TITLE
Lab 2 Version History: only allow committing version when viewing newest

### DIFF
--- a/apps/src/lab2/views/components/Instructions/ResourcePanel/VersionHistory/VersionHistoryPanel.tsx
+++ b/apps/src/lab2/views/components/Instructions/ResourcePanel/VersionHistory/VersionHistoryPanel.tsx
@@ -474,7 +474,7 @@ const VersionHistoryPanel: React.FunctionComponent<
           restoreDisabled={disabled || versionLoading}
           alwaysShowAutoSaves={alwaysShowAutoSaves}
         >
-          {isLatest && hasEdited && !viewAsUserId && (
+          {isLatest && hasEdited && !viewingOldVersion && !viewAsUserId && (
             <SaveVersionPanel
               projectSources={projectSources}
               onSuccess={handleSaveVersionSuccess}
@@ -490,6 +490,7 @@ const VersionHistoryPanel: React.FunctionComponent<
       onVersionChange,
       disabled,
       viewAsUserId,
+      viewingOldVersion,
       restoreSelectedVersion,
       versionLoading,
       hasEdited,


### PR DESCRIPTION
Hides the version history commit message UI unless you're viewing the current version of a project.

Prior to this change, you could commit a version when viewing an old version, which felt confusing:
<img width="1199" height="459" alt="image" src="https://github.com/user-attachments/assets/0b917531-43b7-420b-b946-f4753d539b25" />

Now, the comment editing UI is hidden:
<img width="1212" height="384" alt="image" src="https://github.com/user-attachments/assets/9cf63c00-77ce-42f3-b860-8b4ed6299480" />


## Links
- [Slack discussion](https://codedotorg.slack.com/archives/C06JELCAPT9/p1766000945361069?thread_ts=1765409667.333159&cid=C06JELCAPT9)