### PR TITLE
Pass Args Directly to `ActiveRecord#includes`

### DIFF
--- a/dashboard/app/models/programming_class.rb
+++ b/dashboard/app/models/programming_class.rb
@@ -169,7 +169,7 @@ class ProgrammingClass < ApplicationRecord
     cache_key = "programming_class/#{programming_environment_name}/#{key}"
     Rails.cache.fetch(cache_key, force: !Unit.should_cache?) do
       env = ProgrammingEnvironment.find_by_name(programming_environment_name)
-      ProgrammingClass.includes([:programming_environment, :programming_environment_category, :programming_methods]).find_by(programming_environment_id: env.id, key: key)
+      ProgrammingClass.includes(:programming_environment, :programming_environment_category, :programming_methods).find_by(programming_environment_id: env.id, key: key)
     end
   end
 

--- a/dashboard/app/models/programming_expression.rb
+++ b/dashboard/app/models/programming_expression.rb
@@ -412,7 +412,7 @@ class ProgrammingExpression < ApplicationRecord
   def self.get_from_cache(programming_environment_name, key)
     Rails.cache.fetch("programming_expression/#{programming_environment_name}/#{key}", force: !Unit.should_cache?) do
       env = ProgrammingEnvironment.find_by_name(programming_environment_name)
-      ProgrammingExpression.includes([:programming_environment, :programming_environment_category]).find_by(programming_environment_id: env.id, key: key)
+      ProgrammingExpression.includes(:programming_environment, :programming_environment_category).find_by(programming_environment_id: env.id, key: key)
     end
   end
 end

--- a/dashboard/app/models/unit.rb
+++ b/dashboard/app/models/unit.rb
@@ -71,34 +71,26 @@ class Unit < ApplicationRecord
   scope(
     :with_associated_models, lambda do
       includes(
-        [
+        :lesson_groups,
+        :resources,
+        :student_resources,
+        script_levels: [
           {
-            script_levels: [
-              {
-                levels: [
-                  :concepts,
-                  :game,
-                  :level_concept_difficulty,
-                  :levels_child_levels
-                ]
-              },
-              :lesson,
-              :callouts
+            levels: [
+              :concepts,
+              :game,
+              :level_concept_difficulty,
+              :levels_child_levels
             ]
           },
-          :lesson_groups,
-          :resources,
-          :student_resources,
-          {
-            lessons: [
-              :lesson_activities,
-              {script_levels: [:levels]}
-            ]
-          },
-          {
-            unit_group_units: :unit_group
-          }
-        ]
+          :lesson,
+          :callouts
+        ],
+        lessons: [
+          :lesson_activities,
+          {script_levels: [:levels]}
+        ],
+        unit_group_units: :unit_group
       )
     end
   )
@@ -107,29 +99,23 @@ class Unit < ApplicationRecord
   scope(
     :with_seed_models, lambda do
       includes(
-        [
-          {
-            unit_group_units: {
-              unit_group: :course_version
-            }
-          },
-          :lesson_groups,
-          {
-            lessons: [
-              {lesson_activities: :activity_sections},
-              :resources,
-              :vocabularies,
-              :programming_expressions,
-              :objectives,
-              {rubric: {learning_goals: :learning_goal_evidence_levels}},
-              :standards,
-              :opportunity_standards
-            ]
-          },
-          :script_levels,
-          :levels,
+        :lesson_groups,
+        :script_levels,
+        :levels,
+        :resources,
+        :student_resources,
+        unit_group_units: {
+          unit_group: :course_version
+        },
+        lessons: [
+          {lesson_activities: :activity_sections},
           :resources,
-          :student_resources
+          :vocabularies,
+          :programming_expressions,
+          :objectives,
+          {rubric: {learning_goals: :learning_goal_evidence_levels}},
+          :standards,
+          :opportunity_standards
         ]
       )
     end

--- a/dashboard/app/models/unit.rb
+++ b/dashboard/app/models/unit.rb
@@ -88,7 +88,7 @@ class Unit < ApplicationRecord
         ],
         lessons: [
           :lesson_activities,
-          {script_levels: [:levels]}
+          {script_levels: :levels}
         ],
         unit_group_units: :unit_group
       )
@@ -100,13 +100,9 @@ class Unit < ApplicationRecord
     :with_seed_models, lambda do
       includes(
         :lesson_groups,
-        :script_levels,
-        :levels,
         :resources,
         :student_resources,
-        unit_group_units: {
-          unit_group: :course_version
-        },
+        script_levels: :levels,
         lessons: [
           {lesson_activities: :activity_sections},
           :resources,
@@ -116,7 +112,10 @@ class Unit < ApplicationRecord
           {rubric: {learning_goals: :learning_goal_evidence_levels}},
           :standards,
           :opportunity_standards
-        ]
+        ],
+        unit_group_units: {
+          unit_group: :course_version
+        }
       )
     end
   )

--- a/dashboard/app/models/unit_group.rb
+++ b/dashboard/app/models/unit_group.rb
@@ -47,15 +47,11 @@ class UnitGroup < ApplicationRecord
   scope(
     :with_associated_models, lambda do
       includes(
-        [
-          :plc_course,
-          :default_unit_group_units,
-          {
-            course_version: {
-              course_offering: :course_versions
-            }
-          }
-        ]
+        :plc_course,
+        :default_unit_group_units,
+        course_version: {
+          course_offering: :course_versions
+        }
       )
     end
   )


### PR DESCRIPTION
Currently, we get the following error in Rails 7:

    ERROR["test_lesson_hierarchy_uses_cache", "UnitTest", 143.19057093799984]
     test_lesson_hierarchy_uses_cache#UnitTest (143.19s)
    Minitest::UnexpectedError:         RuntimeError: Database disconnected
                test/models/unit_test.rb:226:in `block in <class:UnitTest>'
                test/testing/setup_all_and_teardown_all.rb:36:in `run'

I am unfortunately still not sure what exactly changed between 6.1 and 7.0 to cause this, but I did note that the pattern of wrapping the args in an array and the kwargs in individual hashes does not match [the example in the documentation](https://api.rubyonrails.org/v7.0.8.7/classes/ActiveRecord/QueryMethods.html#method-i-includes). It turns out that updating our calls to match that example is sufficient to get this functionality working on both 6.1 and 7.0, so this PR recommends we do just that.

My guess is that we were just using an antiquated pattern which 7.0 no longer supports; I wasn't able to find anything in [the changelog](https://github.com/rails/rails/blob/7-0-stable/activerecord/CHANGELOG.md) to confirm, but this seems innocuous enough that I'm comfortable just rolling with that assumption. Please let me know if you have any concerns, though, and I'd be happy to spend a bit more time digging.