### PR TITLE
chore(ProjectsTestUtils): perform `with_channel_for` within rolled back transaction

### DIFF
--- a/dashboard/test/testing/projects_test_utils.rb
+++ b/dashboard/test/testing/projects_test_utils.rb
@@ -7,11 +7,11 @@ module ProjectsTestUtils
   # @param [User] owner - may be nil for anonymous channel
   def with_channel_for(owner)
     with_storage_id_for owner do |storage_id|
-      encrypted_channel_id = Projects.new(storage_id).create({projectType: 'applab'}, ip: 123)
-      _, project_id = storage_decrypt_channel_id encrypted_channel_id
-      yield project_id, storage_id
-    ensure
-      projects_table.where(id: project_id).delete if project_id
+      projects_table.db.transaction(joinable: false, rollback: :always) do
+        encrypted_channel_id = Projects.new(storage_id).create({projectType: 'applab'}, ip: 123)
+        _, project_id = storage_decrypt_channel_id encrypted_channel_id
+        yield project_id, storage_id
+      end
     end
   end
 


### PR DESCRIPTION
## Issue
```bash
===========ERROR["test_find_channel_owner_returns_nil_for_channel_with_no_owner", "UserTest", 545.5476686069999]
 test_find_channel_owner_returns_nil_for_channel_with_no_owner#UserTest (545.55s)
Minitest::UnexpectedError:         Sequel::DatabaseError: Mysql2::Error::TimeoutError: Timeout waiting for a response from the last query. (waited 30 seconds)
            test/testing/projects_test_utils.rb:31:in `with_storage_id_for'
```

## Links
- Related PR: https://github.com/code-dot-org/code-dot-org/pull/70170