### PR TITLE
Add temporary link to generate podcasts for testing

### DIFF
--- a/apps/src/templates/teacherNavigation/lessonMaterials/LessonMaterialsContainer.tsx
+++ b/apps/src/templates/teacherNavigation/lessonMaterials/LessonMaterialsContainer.tsx
@@ -216,6 +216,8 @@ const LessonMaterialsContainer: React.FC<LessonMaterialsContainerProps> = ({
 
   const [selectedLesson, setSelectedLesson] = useState<Lesson | null>(null);
 
+  const generatePodcastUrl = `/ai_lesson_summary_podcasts/generate_podcast?lesson_id=${selectedLesson?.id}`;
+
   React.useEffect(() => {
     if (selectedLesson) {
       HttpClient.fetchJson<LessonSummaryInfoResponse>(
@@ -336,6 +338,10 @@ const LessonMaterialsContainer: React.FC<LessonMaterialsContainerProps> = ({
         <div className={styles.lessonSummaryContainer}>
           {experiments.isEnabled('ai-lesson-podcasts') && (
             <div className={styles.lessonSummarySection}>
+              {/* The following link is temporary for testing and will be removed before official release */}
+              <a href={generatePodcastUrl}>
+                Generate Podcast (this may take a minute...)
+              </a>
               <div className={styles.lessonSummarySectionHeader}>
                 <div className={styles.lessonSummarySectionTitle}>
                   <FontAwesomeV6Icon iconName="headphones" iconStyle="solid" />

--- a/dashboard/app/controllers/ai_lesson_summary_podcasts_controller.rb
+++ b/dashboard/app/controllers/ai_lesson_summary_podcasts_controller.rb
@@ -3,7 +3,7 @@ class AiLessonSummaryPodcastsController < ApplicationController
 
   def generate_podcast
     if current_user && (SingleUserExperiment.enabled?(user: current_user, experiment_name: 'ai_lesson_summaries') || DCDO.get('show-aita-lesson-summaries', false))
-      # Placeholder to be replaced with generated script
+
       script = AiLessonSummariesHelper.generate_lesson_summary(params[:lesson_id], current_user.id, AiSystemPrompts::LessonSummariesSystemPromptHelper::RESPONSE_FORMATS[:PODCAST_SCRIPT])[:json]
       script = JSON.parse(script)['podcast_script']
       podcast = AiLessonSummaryPodcastsHelper.get_podcast_from_script(script)


### PR DESCRIPTION
This update adds a temporary link (hidden behind an experiment) that hits the `generate_podcast` endpoint on our backend. This is purely for internal testing and will be removed before official release.

<img width="431" height="181" alt="image" src="https://github.com/user-attachments/assets/fa33b574-a4e0-4176-bcec-105f2382dc15" />


## Links
<!--  Links to relevant external resources.
      - spec docs, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- Jira: 

## Testing story
<!--  Does your change include appropriate tests?
      - If so, please describe how the tests included in this PR are sufficient.
      - If not, please explain why this change does not need to be tested. -->



## Deployment strategy
<!--  Any special steps required to deploy this, besides merging?
      - Are there database migrations or manual steps?
      - Does this require coordination with other teams or systems? -->



## Follow-up work
<!--  List any clean-up or technical debt that will be addressed in future work.
      - Include Jira links where applicable.
      - Are there any known limitations or improvements planned? -->



## Privacy
<!--  How does this change impact Student & Teacher privacy?
      - Does this collect, use, share, or modify PII, either new or existing? -->



## Security
<!--  How does this change impact our security surface-area?
      - Do API's touched have the right auth?
      - Do infra changes impact our attack surface or encryption?
-->



## Caching
<!--  How does this change impact caching behavior?
      - Are cache keys or invalidation strategies affected?
      - Will this require cache warming or invalidation after deployment? -->



## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
