### PR TITLE
[Lab2] Fixes screenreader instructions for files and tabs

### DIFF
--- a/apps/src/codebridge/FileBrowser/FileBrowser.tsx
+++ b/apps/src/codebridge/FileBrowser/FileBrowser.tsx
@@ -6,12 +6,14 @@ import {
   dragAndDropKeyboardCodes,
   fileBrowserCollisionDetector,
   fileBrowserKeyboardCoordinateGetter,
+  getFileNameById,
 } from '@codebridge/utils/dragAndDropUtils';
 import {
   DndContext,
   DragStartEvent,
   DragOverEvent,
   DragEndEvent,
+  DragCancelEvent,
   PointerSensor,
   useSensor,
   useSensors,
@@ -29,7 +31,7 @@ import {DndDataContextProvider} from './DnDDataContextProvider';
 import {Droppable} from './Droppable';
 import {useHandleDragEnd} from './hooks';
 import InnerFileBrowser from './InnerFileBrowser';
-import {DragDataType, DropDataType} from './types';
+import {DragDataType, DragType, DropDataType} from './types';
 
 import moduleStyles from './styles/filebrowser.module.scss';
 
@@ -87,6 +89,97 @@ export const FileBrowser = React.memo(() => {
     [projectFolders]
   );
 
+  const announcements = useMemo(() => {
+    const getItemName = (itemId: string, itemType: DragType) =>
+      itemType === DragType.FILE
+        ? getFileNameById(itemId, source.files)
+        : source.folders[itemId]?.name || itemId;
+
+    const getItemPosition = (itemId: string, parentId: string) => {
+      const foldersInParent = Object.values(source.folders)
+        .filter(f => f.parentId === parentId)
+        .sort((a, b) => a.name.localeCompare(b.name));
+      const filesInParent = Object.values(source.files)
+        .filter(f => f.folderId === parentId)
+        .sort((a, b) => a.name.localeCompare(b.name));
+
+      const folderIndex = foldersInParent.findIndex(f => f.id === itemId);
+      if (folderIndex !== -1)
+        return {
+          position: folderIndex + 1,
+          total: foldersInParent.length + filesInParent.length,
+        };
+
+      const fileIndex = filesInParent.findIndex(f => f.id === itemId);
+      if (fileIndex !== -1)
+        return {
+          position: foldersInParent.length + fileIndex + 1,
+          total: foldersInParent.length + filesInParent.length,
+        };
+
+      return {position: 0, total: 0};
+    };
+
+    const getFolderName = (folderId: string) =>
+      folderId === DEFAULT_FOLDER_ID
+        ? 'root folder'
+        : projectFolders[folderId]?.name || 'folder';
+
+    const getTypeLabel = (type: DragType) =>
+      type === DragType.FILE ? 'file' : 'folder';
+
+    return {
+      onDragStart({active}: DragStartEvent) {
+        const data = active.data.current as DragDataType;
+        const {position, total} = getItemPosition(data.id, data.parentId);
+        return `Picked up ${getTypeLabel(data.type)} ${getItemName(
+          data.id,
+          data.type
+        )}. Item is in position ${position} of ${total}`;
+      },
+      onDragOver({active, over}: DragOverEvent) {
+        const data = active.data.current as DragDataType;
+        const itemName = getItemName(data.id, data.type);
+        const typeLabel = getTypeLabel(data.type);
+        return over
+          ? `${
+              typeLabel.charAt(0).toUpperCase() + typeLabel.slice(1)
+            } ${itemName} is over ${getFolderName(
+              (over.data.current as DropDataType).id
+            )}`
+          : `${
+              typeLabel.charAt(0).toUpperCase() + typeLabel.slice(1)
+            } ${itemName} is not over a drop zone`;
+      },
+      onDragEnd({active, over}: DragEndEvent) {
+        const data = active.data.current as DragDataType;
+        const itemName = getItemName(data.id, data.type);
+        const typeLabel = getTypeLabel(data.type);
+        if (over) {
+          const {position, total} = getItemPosition(
+            data.id,
+            (over.data.current as DropDataType).id
+          );
+          return `${
+            typeLabel.charAt(0).toUpperCase() + typeLabel.slice(1)
+          } ${itemName} was moved to ${getFolderName(
+            (over.data.current as DropDataType).id
+          )}. New position is ${position} of ${total}`;
+        }
+        return `${
+          typeLabel.charAt(0).toUpperCase() + typeLabel.slice(1)
+        } ${itemName} was dropped`;
+      },
+      onDragCancel({active}: DragCancelEvent) {
+        const data = active.data.current as DragDataType;
+        return `Dragging was cancelled. ${getItemName(
+          data.id,
+          data.type
+        )} was dropped`;
+      },
+    };
+  }, [source.folders, source.files, projectFolders]);
+
   return (
     <div id="file-browser" className={moduleStyles.fileBrowser}>
       <div className={moduleStyles.fileBrowserContents}>
@@ -102,6 +195,7 @@ export const FileBrowser = React.memo(() => {
             modifiers={[restrictToVerticalAxis]}
             collisionDetection={collisionDetector}
             accessibility={{
+              announcements,
               screenReaderInstructions: {
                 draggable: codebridgeI18n.dragAndDropInstructionsFolders(),
               },

--- a/apps/src/codebridge/FileTabs/FileTabs.tsx
+++ b/apps/src/codebridge/FileTabs/FileTabs.tsx
@@ -1,11 +1,14 @@
 import {getOpenFiles} from '@codebridge/utils';
 import {
   dragAndDropKeyboardCodes,
+  getFileNameById,
   sortableKeyboardCoordinatesWithTab,
 } from '@codebridge/utils/dragAndDropUtils';
 import {
   DndContext,
+  DragCancelEvent,
   DragEndEvent,
+  DragOverEvent,
   DragOverlay,
   DragStartEvent,
   KeyboardSensor,
@@ -23,7 +26,7 @@ import {
   horizontalListSortingStrategy,
   SortableContext,
 } from '@dnd-kit/sortable';
-import React, {useState} from 'react';
+import React, {useMemo, useState} from 'react';
 
 import i18n from '@cdo/apps/codebridge/locale';
 import {
@@ -99,6 +102,46 @@ export const FileTabs = React.memo(() => {
     }
   }
 
+  const announcements = useMemo(() => {
+    const getName = (id: string) => getFileNameById(id, source.files);
+    const getPosition = (id: string) => files.findIndex(f => f.id === id) + 1;
+
+    return {
+      onDragStart({active}: DragStartEvent) {
+        const position = getPosition(active.id as string);
+        return `Picked up file ${getName(
+          active.id as string
+        )}. Item is in position ${position} of ${files.length}`;
+      },
+      onDragOver({active, over}: DragOverEvent) {
+        const fileName = getName(active.id as string);
+        return over
+          ? `File ${fileName} is over ${getName(
+              over.id as string
+            )} at position ${getPosition(over.id as string)}`
+          : `File ${fileName} is not over a valid position`;
+      },
+      onDragEnd({active, over}: DragEndEvent) {
+        const fileName = getName(active.id as string);
+        if (over && active.id !== over.id) {
+          const movedFiles = arrayMove(
+            files,
+            getPosition(active.id as string) - 1,
+            getPosition(over.id as string) - 1
+          );
+          const newPosition = movedFiles.findIndex(f => f.id === active.id) + 1;
+          return `File ${fileName} was moved. New position is ${newPosition} of ${files.length}`;
+        }
+        return `File ${fileName} was dropped at its original position`;
+      },
+      onDragCancel({active}: DragCancelEvent) {
+        return `Dragging was cancelled. ${getName(
+          active.id as string
+        )} was dropped`;
+      },
+    };
+  }, [files, source.files]);
+
   return (
     <div className={moduleStyles.fileTabs}>
       <DndContext
@@ -109,6 +152,7 @@ export const FileTabs = React.memo(() => {
         collisionDetection={closestCenter}
         modifiers={[restrictToParentElement, restrictToHorizontalAxis]}
         accessibility={{
+          announcements,
           screenReaderInstructions: {
             draggable: i18n.dragAndDropInstructionsTabs(),
           },

--- a/apps/src/codebridge/utils/dragAndDropUtils.ts
+++ b/apps/src/codebridge/utils/dragAndDropUtils.ts
@@ -230,3 +230,11 @@ export const dragAndDropKeyboardCodes = {
   cancel: ['Escape'],
   end: ['KeyM', 'Enter', 'Space'],
 };
+
+// Helper function to get the name of a file by its ID
+export const getFileNameById = (
+  fileId: string,
+  files: Record<string, {name: string}>
+): string => {
+  return files[fileId]?.name || fileId;
+};


### PR DESCRIPTION
I heavily leaned on the [documentation example here](https://docs.dndkit.com/guides/accessibility#screen-reader-instructions). Claude was very helpful in this task, both during the initial draft and when I asked for a concision clean up/refactor. 


Before:

(Tabs: Static indices used instead of positions, no helpful names):

https://github.com/user-attachments/assets/f192e782-b2be-46b0-a6b9-0974f71cdb0a


(Files and folders: Out of order indices used, no helpful names):

https://github.com/user-attachments/assets/0e5667b1-4445-4f38-ab8f-86a0be9d2b7f


After:

Positions and names used for both files/folders and tabs:

https://github.com/user-attachments/assets/6875e37f-cf58-41c5-96d5-d7f22f95bf88


Followup Work:

Ensure that when a user uses the keyboard to drop a file into a folder in the file browser area, move focus to the folder parent (you can see at the very end of the video that focus is lost and defaults to the body element). [ticket created here](https://codedotorg.atlassian.net/browse/SL-1516)

## Links

- Jira: https://codedotorg.atlassian.net/browse/CT-1111

## Testing story
<!--  Does your change include appropriate tests?
      - If so, please describe how the tests included in this PR are sufficient.
      - If not, please explain why this change does not need to be tested. -->



## Deployment strategy
<!--  Any special steps required to deploy this, besides merging?
      - Are there database migrations or manual steps?
      - Does this require coordination with other teams or systems? -->



## Follow-up work
<!--  List any clean-up or technical debt that will be addressed in future work.
      - Include Jira links where applicable.
      - Are there any known limitations or improvements planned? -->



## Privacy
<!--  How does this change impact Student & Teacher privacy?
      - Does this collect, use, share, or modify PII, either new or existing? -->



## Security
<!--  How does this change impact our security surface-area?
      - Do API's touched have the right auth?
      - Do infra changes impact our attack surface or encryption?
-->



## Caching
<!--  How does this change impact caching behavior?
      - Are cache keys or invalidation strategies affected?
      - Will this require cache warming or invalidation after deployment? -->



## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
