### PR TITLE
Fix warning mailer

### DIFF
--- a/dashboard/lib/inactive_teacher_deletion_warning_mailer.rb
+++ b/dashboard/lib/inactive_teacher_deletion_warning_mailer.rb
@@ -29,8 +29,9 @@ class InactiveTeacherDeletionWarningMailer
     ActiveRecord::Base.connected_to(role: :reporting) do
       loop do
         accounts_batch = inactive_teachers
-        break if accounts_batch.empty? || num_teachers_warned >= @limit
+        break if accounts_batch.empty?
         accounts_batch.each do |teacher|
+          break if num_teachers_warned >= @limit
           next if teacher.email.blank?
           next if teacher.email.end_with?('@code.org') # skip internal accounts
           send_warning_email(teacher)

--- a/dashboard/lib/inactive_teacher_deletion_warning_mailer.rb
+++ b/dashboard/lib/inactive_teacher_deletion_warning_mailer.rb
@@ -41,7 +41,7 @@ class InactiveTeacherDeletionWarningMailer
           upload_metrics(teacher.id) unless @dry_run
         rescue StandardError => exception
           self.num_errors += 1
-          log_message("Error deleting user_id #{teacher.id}: #{exception.message}")
+          log_message("Error emailing user_id #{teacher.id}: #{exception.message}")
         ensure
           processed_teacher_ids << teacher.id
         end

--- a/dashboard/lib/inactive_teacher_deletion_warning_mailer.rb
+++ b/dashboard/lib/inactive_teacher_deletion_warning_mailer.rb
@@ -33,7 +33,10 @@ class InactiveTeacherDeletionWarningMailer
         accounts_batch.each do |teacher|
           break if num_teachers_warned >= @limit
           next if teacher.email.blank?
-          next if teacher.email.end_with?('@code.org') # skip internal accounts
+          if teacher.email.end_with?('@code.org') # skip internal accounts
+            mark_warning_email_sent(teacher.id) unless @dry_run # Mark as sent to avoid re-processing
+            next
+          end
           send_warning_email(teacher)
           # Set email sent at field
           mark_warning_email_sent(teacher.id) unless @dry_run

--- a/dashboard/test/lib/services/user/inactive_teacher_deletion_warning_mailer_test.rb
+++ b/dashboard/test/lib/services/user/inactive_teacher_deletion_warning_mailer_test.rb
@@ -122,6 +122,27 @@ class User::InactiveTeacherDeletionWarningMailerTest < ActiveJob::TestCase
         send_warning_emails
       end
     end
+
+    describe 'when limit is provided' do
+      context 'when limit is zero' do
+        let(:limit) {0}
+        it 'limits the inactive teachers query to the specified limit' do
+          expect_teacher_warning_to_be_sent.never
+          send_warning_emails
+          _(described_instance.send(:num_teachers_warned)).must_equal 0
+        end
+      end
+
+      context 'when limit is greater than zero' do
+        let(:limit) {1}
+        let(:teacher2) {create(:teacher, email: "test" + teacher_email, name: teacher_name, current_sign_in_at: 48.months.ago, user_data_retention_status: create(:user_data_retention_status))}
+        it 'sends emails up to the specified limit' do
+          expect_teacher_warning_to_be_sent.times(1)
+          send_warning_emails
+          _(described_instance.send(:num_teachers_warned)).must_equal 1
+        end
+      end
+    end
   end
 
   describe '#inactive_teachers' do

--- a/dashboard/test/lib/services/user/inactive_teacher_deletion_warning_mailer_test.rb
+++ b/dashboard/test/lib/services/user/inactive_teacher_deletion_warning_mailer_test.rb
@@ -135,9 +135,21 @@ class User::InactiveTeacherDeletionWarningMailerTest < ActiveJob::TestCase
 
       context 'when limit is greater than zero' do
         let(:limit) {1}
-        let(:teacher2) {create(:teacher, email: "test" + teacher_email, name: teacher_name, current_sign_in_at: 48.months.ago, user_data_retention_status: create(:user_data_retention_status))}
+
+        let(:other_teacher) {create(:teacher, email: other_email, name: other_name, current_sign_in_at: 48.months.ago, user_data_retention_status: create(:user_data_retention_status))}
+        let(:other_email) {Faker::Internet.email}
+        let(:other_name) {Faker::Name.name}
+        let(:expect_other_teacher_warning_to_be_sent) do
+          MailJet.expects(:send_email).with(
+            :inactive_teacher_deletion_warning,
+            other_teacher.email,
+            other_teacher.name,
+            vars: {first_name: other_teacher.given_name || other_teacher.name}
+          )
+        end
         it 'sends emails up to the specified limit' do
           expect_teacher_warning_to_be_sent.times(1)
+          expect_other_teacher_warning_to_be_sent.never
           send_warning_emails
           _(described_instance.send(:num_teachers_warned)).must_equal 1
         end

--- a/dashboard/test/lib/services/user/inactive_teacher_deletion_warning_mailer_test.rb
+++ b/dashboard/test/lib/services/user/inactive_teacher_deletion_warning_mailer_test.rb
@@ -102,7 +102,7 @@ class User::InactiveTeacherDeletionWarningMailerTest < ActiveJob::TestCase
     end
 
     context 'when teacher email is internal' do
-      let(:teacher) {create(:teacher, email: 'teacher@code.org', name: teacher_name)}
+      let(:teacher) {create(:teacher, email: 'teacher@code.org', name: teacher_name, current_sign_in_at: 48.months.ago)}
 
       it 'does not warn teacher' do
         expect_teacher_warning_to_be_sent.never
@@ -112,6 +112,12 @@ class User::InactiveTeacherDeletionWarningMailerTest < ActiveJob::TestCase
       it 'does not increment num_teachers_warned' do
         send_warning_emails
         _(described_instance.send(:num_teachers_warned)).must_equal 0
+      end
+
+      it 'sets deletion_warning_email_sent_at' do
+        send_warning_emails
+        teacher.reload
+        _(teacher.user_data_retention_status&.deletion_warning_email_sent_at).wont_be_nil
       end
     end
 


### PR DESCRIPTION
Fix warning mailer job to correctly enforce the limit parameter.

Moves the limit check within the batch loop in order to enforce the limit parameter and accurately limit the amount of teachers warned.

Also marks internal accounts as emailed in order to prevent them from being included in query response on new job runs.

## Links

- Jira: [here](https://codedotorg.atlassian.net/browse/P20-1771)

## Testing story
<!--  Does your change include appropriate tests?
      - If so, please describe how the tests included in this PR are sufficient.
      - If not, please explain why this change does not need to be tested. -->



## Deployment strategy
<!--  Any special steps required to deploy this, besides merging?
      - Are there database migrations or manual steps?
      - Does this require coordination with other teams or systems? -->



## Follow-up work
<!--  List any clean-up or technical debt that will be addressed in future work.
      - Include Jira links where applicable.
      - Are there any known limitations or improvements planned? -->



## Privacy
<!--  How does this change impact Student & Teacher privacy?
      - Does this collect, use, share, or modify PII, either new or existing? -->



## Security
<!--  How does this change impact our security surface-area?
      - Do API's touched have the right auth?
      - Do infra changes impact our attack surface or encryption?
-->



## Caching
<!--  How does this change impact caching behavior?
      - Are cache keys or invalidation strategies affected?
      - Will this require cache warming or invalidation after deployment? -->



## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
