### PR TITLE
App Lab: Allow JSON API content type

### DIFF
--- a/dashboard/app/controllers/xhr_proxy_controller.rb
+++ b/dashboard/app/controllers/xhr_proxy_controller.rb
@@ -20,6 +20,7 @@ class XhrProxyController < ApplicationController
     %w(
       application/json
       application/geo+json
+      application/vnd.api+json
       text/javascript
       text/json
       text/plain


### PR DESCRIPTION
Follow up to allowing a new API in App Lab: https://github.com/code-dot-org/code-dot-org/pull/70220

The content type returned by the API is slightly different than our typical `application/json` (specific to the "JSON API"), so we allow that as well in order to enable the API.
https://jsonapi.org/
https://www.iana.org/assignments/media-types/application/vnd.api+json