### PR TITLE
Update language when renaming file in Codebridge

### DIFF
--- a/apps/src/lab2/redux/lab2ProjectRedux.ts
+++ b/apps/src/lab2/redux/lab2ProjectRedux.ts
@@ -170,6 +170,8 @@ const projectSlice = createSlice({
               [action.payload.fileId]: {
                 ...source.files[action.payload.fileId],
                 name: action.payload.newName,
+                language:
+                  action.payload.newName.split('.').pop()?.toLowerCase() || '',
               },
             },
           },

--- a/apps/test/unit/lab2/redux/lab2ProjectReduxTest.ts
+++ b/apps/test/unit/lab2/redux/lab2ProjectReduxTest.ts
@@ -239,6 +239,30 @@ describe('lab2ProjectRedux', () => {
       expect(state.hasEdited).toBe(true);
     });
 
+    it('should update file language when renaming with new extension', () => {
+      const initialProjectSources = createMockProjectSources();
+      const initialStateWithSources = {
+        ...initialState,
+        projectSources: initialProjectSources,
+      };
+
+      // Verify initial language
+      const initialFile = (
+        initialStateWithSources.projectSources!.source as MultiFileSource
+      ).files['1'];
+      expect(initialFile.language).toBe('html');
+
+      const state = reducer(
+        initialStateWithSources,
+        renameFile({fileId: '1', newName: 'renamed.css'})
+      );
+
+      const file = (state.projectSources!.source as MultiFileSource).files['1'];
+      expect(file.name).toBe('renamed.css');
+      expect(file.language).toBe('css');
+      expect(state.hasEdited).toBe(true);
+    });
+
     it('should not rename if file does not exist', () => {
       const initialProjectSources = createMockProjectSources();
       const initialStateWithSources = {


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
This PR updates the `renameFile` thunk - when a file is renamed, the `language` property is also updated.
We saw a case when a level's initial sources included only one `.css` file with the wrong `language` and posited that the initial file was originally an `html` file and was renamed by the levelbuilder.

I considered removing the `language` property from the `ProjectFile` type since it is derived from the file name. But it is used a lot throughout the code base so I kept the update small in this PR. But someone feels like it would be the right thing to do, open to a bigger change as a follow-up!


## Links
<!--  Links to relevant external resources.
      - spec docs, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- Jira: https://codedotorg.atlassian.net/browse/AFL-414

## Testing story
<!--  Does your change include appropriate tests?
      - If so, please describe how the tests included in this PR are sufficient.
      - If not, please explain why this change does not need to be tested. -->

Added a unit test to confirm that the language is updated when a file is renamed and the file extension has changed.

## Deployment strategy
<!--  Any special steps required to deploy this, besides merging?
      - Are there database migrations or manual steps?
      - Does this require coordination with other teams or systems? -->



## Follow-up work
<!--  List any clean-up or technical debt that will be addressed in future work.
      - Include Jira links where applicable.
      - Are there any known limitations or improvements planned? -->



## Privacy
<!--  How does this change impact Student & Teacher privacy?
      - Does this collect, use, share, or modify PII, either new or existing? -->



## Security
<!--  How does this change impact our security surface-area?
      - Do API's touched have the right auth?
      - Do infra changes impact our attack surface or encryption?
-->



## Caching
<!--  How does this change impact caching behavior?
      - Are cache keys or invalidation strategies affected?
      - Will this require cache warming or invalidation after deployment? -->



## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
