### PR TITLE
chore: migration that drops aichat_event indexes that do not include id

### DIFF
--- a/dashboard/app/models/aichat_event.rb
+++ b/dashboard/app/models/aichat_event.rb
@@ -14,9 +14,7 @@
 #
 # Indexes
 #
-#  index_ace_user_level_script        (user_id,level_id,script_id)
 #  index_ace_user_level_script_id     (user_id,level_id,script_id,id)
-#  index_ace_user_project             (user_id,project_id)
 #  index_ace_user_project_id          (user_id,project_id,id)
 #  index_aichat_events_on_request_id  (request_id)
 #

--- a/dashboard/db/migrate/20260109152639_remove_indexes_on_aichat_events.rb
+++ b/dashboard/db/migrate/20260109152639_remove_indexes_on_aichat_events.rb
@@ -1,0 +1,6 @@
+class RemoveIndexesOnAichatEvents < ActiveRecord::Migration[6.1]
+  def change
+    remove_index :aichat_events, name: "index_ace_user_project", if_exists: true
+    remove_index :aichat_events, name: "index_ace_user_level_script", if_exists: true
+  end
+end

--- a/dashboard/db/schema.rb
+++ b/dashboard/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2026_01_07_212238) do
+ActiveRecord::Schema.define(version: 2026_01_09_152639) do
 
   create_table "activities", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "user_id"
@@ -104,9 +104,7 @@ ActiveRecord::Schema.define(version: 2026_01_07_212238) do
     t.bigint "request_id"
     t.index ["request_id"], name: "index_aichat_events_on_request_id"
     t.index ["user_id", "level_id", "script_id", "id"], name: "index_ace_user_level_script_id"
-    t.index ["user_id", "level_id", "script_id"], name: "index_ace_user_level_script"
     t.index ["user_id", "project_id", "id"], name: "index_ace_user_project_id"
-    t.index ["user_id", "project_id"], name: "index_ace_user_project"
   end
 
   create_table "aichat_requests", charset: "utf8mb4", collation: "utf8mb4_bin", force: :cascade do |t|


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->



## Links
<!--  Links to relevant external resources.
      - spec docs, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- Jira: 

## Testing story
<!--  Does your change include appropriate tests?
      - If so, please describe how the tests included in this PR are sufficient.
      - If not, please explain why this change does not need to be tested. -->



## Deployment strategy
<!--  Any special steps required to deploy this, besides merging?
      - Are there database migrations or manual steps?
      - Does this require coordination with other teams or systems? -->



## Follow-up work
<!--  List any clean-up or technical debt that will be addressed in future work.
      - Include Jira links where applicable.
      - Are there any known limitations or improvements planned? -->



## Privacy
<!--  How does this change impact Student & Teacher privacy?
      - Does this collect, use, share, or modify PII, either new or existing? -->



## Security
<!--  How does this change impact our security surface-area?
      - Do API's touched have the right auth?
      - Do infra changes impact our attack surface or encryption?
-->



## Caching
<!--  How does this change impact caching behavior?
      - Are cache keys or invalidation strategies affected?
      - Will this require cache warming or invalidation after deployment? -->



## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
