### PR TITLE
Revert "Revert "Revert "Revert "Second pass at fixes to AI TA Redux""""

### DIFF
--- a/apps/src/aiDifferentiation/AiDiffChat.tsx
+++ b/apps/src/aiDifferentiation/AiDiffChat.tsx
@@ -1,15 +1,14 @@
-import React, {
-  Dispatch,
-  SetStateAction,
-  useEffect,
-  useRef,
-  useState,
-} from 'react';
+import React, {useEffect, useRef, useState} from 'react';
 
+import {
+  setThreadId,
+  addThreadMessage,
+  setThreadTitle,
+} from '@cdo/apps/aichat/redux/slice';
 import ChatMessage from '@cdo/apps/aiComponentLibrary/chatMessage/ChatMessage';
 import {Role} from '@cdo/apps/aiComponentLibrary/chatMessage/types';
 import {PersonalizationData} from '@cdo/apps/aiDifferentiation/hooks/useTeachingProfileData';
-import {useAppSelector} from '@cdo/apps/util/reduxHooks';
+import {useAppDispatch, useAppSelector} from '@cdo/apps/util/reduxHooks';
 import {
   AiInteractionStatus as Status,
   AiDiffContext,
@@ -24,95 +23,38 @@ import AiDiffChatFooter from './AiDiffChatFooter';
 import AiDiffChatHeader from './AiDiffChatHeader';
 import AiDiffSuggestedPrompts from './AiDiffSuggestedPrompts';
 import {DEFAULT_THREAD_TITLE} from './constants';
-import {
-  contextPrompts,
-  APCSP_DUMMY_CREATE,
-  APCSP_DUMMY_EXAM,
-  SUGGESTED_PROMPTS_FOR_SELECTION,
-  SUGGEST_CURRICULUM_PROMPT,
-  GET_STARTED_PROMPT,
-  CREATE_SECTION_PROMPT,
-} from './predefinedPrompts';
+import {SUGGESTED_PROMPTS_FOR_SELECTION} from './predefinedPrompts';
 import {ChatItem, ChatPrompt, Context, SuggestPromptsType} from './types';
 
 import style from './ai-differentiation.module.scss';
 
-const APCSP_PROMPTS = [APCSP_DUMMY_CREATE, APCSP_DUMMY_EXAM];
-
 const AIDIFF_THREADS_ENDPOINT = '/aidiff_threads';
 const AIDIFF_CHAT_COMPLETION = 'chat_completion';
 
-const getDefaultSuggestedPrompts = (
-  context: Context,
-  teacherHasSections: boolean,
-  teacherHasSectionWithCurriculum: boolean,
-  teacherHasSectionWithStudents: boolean
-) =>
-  context.type === AiDiffContext.GENERAL
-    ? SUGGESTED_PROMPTS_FOR_SELECTION['support'].suggestedPrompts.filter(
-        ({label}) => {
-          // Hide some new thread default prompts based on teacher's sections
-          if (
-            (label === GET_STARTED_PROMPT.label ||
-              label === CREATE_SECTION_PROMPT.label) &&
-            teacherHasSections &&
-            teacherHasSectionWithCurriculum &&
-            teacherHasSectionWithStudents
-          ) {
-            return false;
-          }
-
-          if (
-            label === SUGGEST_CURRICULUM_PROMPT.label &&
-            teacherHasSectionWithCurriculum
-          ) {
-            return false;
-          }
-
-          return true;
-        }
-      )
-    : SUGGESTED_PROMPTS_FOR_SELECTION['default'].suggestedPrompts;
-
 interface AiDiffChatProps {
   context: Context;
-  threadMessages?: ChatItem[];
-  threadTitle?: string;
-  setThreadTitle?: Dispatch<SetStateAction<string>>;
   scriptName?: string;
   chatResponseCallback?: () => void;
-  initialChatMessage?: string;
-  suggestedPrompts?: ChatPrompt[];
   hideChatHeader?: boolean;
-  curriculumCourses?: string[];
   threadFetchCallback?: () => void;
-  threadId?: number;
-  setThreadId?: Dispatch<SetStateAction<number>>;
-  initialThreadPrompt?: ChatPrompt | null;
-  setInitialThreadPrompt?: Dispatch<SetStateAction<ChatPrompt | null>>;
   personalizationData?: PersonalizationData;
 }
 
 const AiDiffChat: React.FC<AiDiffChatProps> = ({
   context,
-  threadMessages = [],
-  threadTitle = DEFAULT_THREAD_TITLE,
-  setThreadTitle,
   scriptName,
   chatResponseCallback = () => {},
-  initialChatMessage = SUGGESTED_PROMPTS_FOR_SELECTION['default']
-    .initialMessage,
-  suggestedPrompts,
   hideChatHeader = false,
-  curriculumCourses = [],
   threadFetchCallback = () => {},
-  threadId = 0,
-  setThreadId = () => {},
-  initialThreadPrompt = null,
-  setInitialThreadPrompt = () => {},
   personalizationData,
 }) => {
   const [userMessage, setUserMessage] = useState<string>('');
+  const [hasSentInitialPrompt, setHasSentInitialPrompt] =
+    useState<boolean>(false);
+  const [isWaitingForResponse, setIsWaitingForResponse] = useState(false);
+
+  const userMessageEditorRef = useRef<HTMLTextAreaElement>(null);
+
   const reportingData = React.useMemo(() => {
     return {
       chatContext: context,
@@ -120,57 +62,17 @@ const AiDiffChat: React.FC<AiDiffChatProps> = ({
     };
   }, [context, scriptName]);
 
-  const [isWaitingForResponse, setIsWaitingForResponse] = useState(false);
-  const [localThreadId, setLocalThreadId] = useState(threadId);
-
-  const userMessageEditorRef = useRef<HTMLTextAreaElement>(null);
-
   const viewAsUserId = useAppSelector(
     state => state.progress?.viewAsUserId || undefined
   );
+  const threadId = useAppSelector(state => state.aichat.threadId);
+  const threadTitle = useAppSelector(state => state.aichat.threadTitle);
+  const initialThreadPrompt = useAppSelector(
+    state => state.aichat.initialThreadPrompt
+  );
+  const threadMessages = useAppSelector(state => state.aichat.threadMessages);
 
-  const teacherSections = Object.values(
-    useAppSelector(state => state.teacherSections.sections)
-  );
-  const teacherHasSections = teacherSections.length > 0;
-  const teacherHasSectionWithCurriculum = !!teacherSections.find(
-    section => section.courseId !== null
-  );
-  const teacherHasSectionWithStudents = !!teacherSections.find(
-    section => section.studentCount > 0
-  );
-
-  const additionalPrompts: ChatPrompt[] = [];
-  if (curriculumCourses.includes('csp')) {
-    additionalPrompts.push(...APCSP_PROMPTS);
-  }
-  if (context.type === AiDiffContext.LEVEL) {
-    additionalPrompts.push(
-      contextPrompts.code.DEBUG_THIS_CODE,
-      contextPrompts.code.IMPROVE_THIS_CODE
-    );
-  }
-
-  const [messageHistory, setMessageHistory] = useState<ChatItem[]>(
-    threadMessages.length > 0
-      ? threadMessages
-      : [
-          {
-            role: Role.ASSISTANT,
-            chatMessageText: initialChatMessage,
-            status: Status.OK,
-          },
-          (
-            suggestedPrompts ||
-            getDefaultSuggestedPrompts(
-              context,
-              teacherHasSections,
-              teacherHasSectionWithCurriculum,
-              teacherHasSectionWithStudents
-            )
-          ).concat(additionalPrompts),
-        ]
-  );
+  const dispatch = useAppDispatch();
 
   const sendChatEvent = React.useCallback(
     (role: string, prompt: string, preset: boolean, thread: number) => {
@@ -195,20 +97,20 @@ const AiDiffChat: React.FC<AiDiffChatProps> = ({
     (prompt: string, isPreset: boolean, presetChipText: string | null) => {
       setIsWaitingForResponse(true);
 
-      if (localThreadId !== 0) {
-        sendChatEvent(Role.USER, prompt, isPreset, localThreadId);
+      if (threadId !== 0) {
+        sendChatEvent(Role.USER, prompt, isPreset, threadId);
       }
 
       const endpoint =
-        localThreadId === 0
+        threadId === 0
           ? `${AIDIFF_THREADS_ENDPOINT}`
-          : `${AIDIFF_THREADS_ENDPOINT}/${localThreadId}/${AIDIFF_CHAT_COMPLETION}`;
+          : `${AIDIFF_THREADS_ENDPOINT}/${threadId}/${AIDIFF_CHAT_COMPLETION}`;
 
       const body = JSON.stringify({
         inputText: prompt,
         isPreset,
         presetChipText,
-        context,
+        ...(threadId === 0 ? {context} : {}),
         ...(context.type === AiDiffContext.LEVEL ? {viewAsUserId} : {}),
       });
 
@@ -226,7 +128,7 @@ const AiDiffChat: React.FC<AiDiffChatProps> = ({
 
           // logging here because on the first user message the threadID is 0
           // we only get a threadID initialized in the response
-          if (localThreadId === 0) {
+          if (threadId === 0) {
             threadFetchCallback();
             sendChatEvent(Role.USER, prompt, isPreset, json.thread_id);
           }
@@ -238,10 +140,9 @@ const AiDiffChat: React.FC<AiDiffChatProps> = ({
             json.thread_id
           );
           if (json.thread_id) {
-            setLocalThreadId(json.thread_id);
-            setThreadId(json.thread_id);
+            dispatch(setThreadId(json.thread_id));
           }
-          setMessageHistory(prevMessages => [...prevMessages, newAiMessage]);
+          dispatch(addThreadMessage(newAiMessage));
         })
         .catch(error => console.log(error))
         .finally(() => {
@@ -253,14 +154,13 @@ const AiDiffChat: React.FC<AiDiffChatProps> = ({
         });
     },
     [
-      localThreadId,
+      threadId,
       context,
       viewAsUserId,
       sendChatEvent,
+      dispatch,
       threadFetchCallback,
-      setLocalThreadId,
       chatResponseCallback,
-      setThreadId,
     ]
   );
 
@@ -276,14 +176,14 @@ const AiDiffChat: React.FC<AiDiffChatProps> = ({
         setThreadTitle &&
         (!threadTitle || threadTitle === DEFAULT_THREAD_TITLE)
       ) {
-        setThreadTitle(message.slice(0, 100));
+        dispatch(setThreadTitle(message.slice(0, 100)));
       }
 
-      setMessageHistory(prevMessages => [...prevMessages, newUserMessage]);
+      dispatch(addThreadMessage(newUserMessage));
       getAIResponse(message, false, null);
       setUserMessage('');
     },
-    [threadTitle, getAIResponse, setThreadTitle]
+    [threadTitle, dispatch, getAIResponse]
   );
 
   const onPromptSelect = React.useCallback(
@@ -292,51 +192,33 @@ const AiDiffChat: React.FC<AiDiffChatProps> = ({
         setThreadTitle &&
         (!threadTitle || threadTitle === DEFAULT_THREAD_TITLE)
       ) {
-        setThreadTitle(prompt.label);
+        dispatch(setThreadTitle(prompt.label));
       }
-
       if (prompt.response !== undefined) {
-        setMessageHistory(prevMessages => [
-          ...prevMessages,
-          {
+        dispatch(
+          addThreadMessage({
             role: Role.ASSISTANT,
             chatMessageText: prompt.response ?? '',
             status: Status.OK,
-          },
-        ]);
+          })
+        );
       }
       if (prompt.followUpPrompts !== undefined) {
-        setMessageHistory(prevMessages => [
-          ...prevMessages,
-          prompt.followUpPrompts ?? [],
-        ]);
+        dispatch(addThreadMessage(prompt.followUpPrompts));
       }
       if (!prompt.followUpPrompts && !prompt.response) {
         getAIResponse(prompt.prompt, true, prompt.label);
       }
     },
-    [getAIResponse, setThreadTitle, threadTitle]
+    [dispatch, getAIResponse, threadTitle]
   );
 
   React.useEffect(() => {
-    if (initialThreadPrompt && threadMessages.length === 0 && threadId === 0) {
-      const newUserMessage = {
-        role: Role.USER,
-        chatMessageText: initialThreadPrompt.prompt,
-        status: Status.OK,
-      };
-
-      setMessageHistory(prevMessages => [...prevMessages, newUserMessage]);
+    if (initialThreadPrompt && threadId === 0 && !hasSentInitialPrompt) {
+      setHasSentInitialPrompt(true);
       onPromptSelect(initialThreadPrompt);
-      setInitialThreadPrompt(null);
     }
-  }, [
-    initialThreadPrompt,
-    threadMessages,
-    threadId,
-    onPromptSelect,
-    setInitialThreadPrompt,
-  ]);
+  }, [initialThreadPrompt, threadId, hasSentInitialPrompt, onPromptSelect]);
 
   const onSuggestPrompts = (promptType: SuggestPromptsType) => {
     const aiInitialSuggestionsMessage = {
@@ -348,11 +230,8 @@ const AiDiffChat: React.FC<AiDiffChatProps> = ({
     const newSuggestions =
       SUGGESTED_PROMPTS_FOR_SELECTION[promptType].suggestedPrompts;
 
-    setMessageHistory(prevMessages => [
-      ...prevMessages,
-      aiInitialSuggestionsMessage,
-      newSuggestions,
-    ]);
+    dispatch(addThreadMessage(aiInitialSuggestionsMessage));
+    dispatch(addThreadMessage(newSuggestions));
   };
 
   // Scroll to bottom of content when a new message comes in
@@ -361,24 +240,24 @@ const AiDiffChat: React.FC<AiDiffChatProps> = ({
     if (chatWindowRef.current) {
       chatWindowRef.current?.scrollIntoView();
     }
-  }, [messageHistory]);
+  }, [threadMessages]);
 
   return (
     <div className={style.chatContainer}>
       {!hideChatHeader && (
         <AiDiffChatHeader
           onSuggestPrompts={onSuggestPrompts}
-          messages={messageHistory}
+          messages={threadMessages}
           threadTitle={threadTitle}
           personalizationData={personalizationData}
         />
       )}
       <div className={style.chatContent}>
-        {messageHistory.map((item: ChatItem, id: number) =>
+        {threadMessages.map((item: ChatItem, id: number) =>
           Array.isArray(item) ? (
             <AiDiffSuggestedPrompts
               suggestedPrompts={item}
-              isLatest={id === messageHistory.length - 1}
+              isLatest={id === threadMessages.length - 1}
               onSubmit={onPromptSelect}
               key={id}
             />

--- a/apps/src/aiDifferentiation/AiDiffContainer.tsx
+++ b/apps/src/aiDifferentiation/AiDiffContainer.tsx
@@ -19,9 +19,8 @@ const AI_DIFF_POSITION_Y = 'aiDiffPositionY';
 interface AiDiffContainerProps {
   closeTutor?: () => void;
   context: Context;
-  open: boolean;
+  curriculumCourses: string[];
   scriptName?: string;
-  curriculumCourses?: string[];
   unreadNotificationCount: number;
 }
 
@@ -49,9 +48,8 @@ const AI_DIFF_CLOSE_BUTTON_CLASSNAME = 'ai_diff_close_button';
 const AiDiffContainer: React.FC<AiDiffContainerProps> = ({
   closeTutor,
   context,
-  open,
-  scriptName,
   curriculumCourses,
+  scriptName,
   unreadNotificationCount,
 }) => {
   const [showWelcomeExperience, setShowWelcomeExperience] = useState(true);
@@ -67,6 +65,7 @@ const AiDiffContainer: React.FC<AiDiffContainerProps> = ({
   const hasCompletedAiDifferentiationWelcome = useAppSelector(
     state => state.currentUser.hasCompletedAiDifferentiationWelcome
   );
+  const chatIsOpen = useAppSelector(state => state.aichat.chatIsOpen);
 
   useEffect(() => {
     const ensureDraggableIsVisible = () => {
@@ -121,32 +120,30 @@ const AiDiffContainer: React.FC<AiDiffContainerProps> = ({
             ? style.aiDiffContainer
             : style.aiDiffContainerWide
         }
-        style={open ? undefined : {display: 'none'}}
+        style={chatIsOpen ? undefined : {display: 'none'}}
       >
-        <FocusLock disabled={!open}>
+        <FocusLock disabled={!chatIsOpen}>
           <AiDiffHeader
             closeTutor={closeTutor}
             closeButtonClassName={AI_DIFF_CLOSE_BUTTON_CLASSNAME}
           />
           <div className={style.fabBackground}>
-            {!hasCompletedAiDifferentiationWelcome && showWelcomeExperience
-              ? curriculumCourses && (
-                  <AiDiffWelcome
-                    setShowWelcomeExperience={setShowWelcomeExperience}
-                    context={context}
-                    scriptName={scriptName}
-                    curriculumCourses={curriculumCourses}
-                  />
-                )
-              : curriculumCourses && (
-                  <AiDiffWorkSpace
-                    context={context}
-                    personalizationData={personalizationData}
-                    scriptName={scriptName}
-                    curriculumCourses={curriculumCourses}
-                    unreadNotificationCount={unreadNotificationCount}
-                  />
-                )}
+            {!hasCompletedAiDifferentiationWelcome && showWelcomeExperience ? (
+              <AiDiffWelcome
+                setShowWelcomeExperience={setShowWelcomeExperience}
+                context={context}
+                curriculumCourses={curriculumCourses}
+                scriptName={scriptName}
+              />
+            ) : (
+              <AiDiffWorkSpace
+                context={context}
+                personalizationData={personalizationData}
+                curriculumCourses={curriculumCourses}
+                scriptName={scriptName}
+                unreadNotificationCount={unreadNotificationCount}
+              />
+            )}
           </div>
         </FocusLock>
       </div>

--- a/apps/src/aiDifferentiation/AiDiffFloatingActionButton.tsx
+++ b/apps/src/aiDifferentiation/AiDiffFloatingActionButton.tsx
@@ -2,8 +2,11 @@ import {Badge} from '@mui/material';
 import classNames from 'classnames';
 import React, {useEffect, useState} from 'react';
 
+import {fetchThreadMessages} from '@cdo/apps/aichat/redux';
+import {setChatIsOpen} from '@cdo/apps/aichat/redux/slice';
 import DCDO from '@cdo/apps/dcdo';
 import experiments from '@cdo/apps/util/experiments';
+import {useAppDispatch, useAppSelector} from '@cdo/apps/util/reduxHooks';
 import {
   tryGetSessionStorage,
   trySetSessionStorage,
@@ -37,7 +40,6 @@ interface AiDiffFloatingActionButtonProps {
   canDefaultOpen?: boolean;
 }
 
-export const EXT_COMPONENT_OPEN_FAB_EVENT = 'ExternalComponentOpensFabEvent';
 const SESSION_STORAGE_KEY = 'AiDiffFabOpenStateKey';
 const LOCAL_STORAGE_OPENED_KEY = 'AiDiffHasOpenedKey';
 const LOCAL_STORAGE_CLOSED_KEY = 'AiDiffHasClosedKey';
@@ -71,7 +73,10 @@ const AiDiffFloatingActionButton: React.FC<AiDiffFloatingActionButtonProps> = ({
     number | 'loading'
   >('loading');
 
-  const [isOpen, setIsOpen] = useState<boolean>(false);
+  const chatIsOpen = useAppSelector(state => state.aichat.chatIsOpen);
+  const threadMessages = useAppSelector(state => state.aichat.threadMessages);
+
+  const dispatch = useAppDispatch();
 
   React.useEffect(() => {
     // If the user has manually opened or closed the FAB, we should not open it automatically.
@@ -85,13 +90,15 @@ const AiDiffFloatingActionButton: React.FC<AiDiffFloatingActionButtonProps> = ({
       // Keeps FAB open/closed on new pages in the same tab or window
       // New tab or window is default closed if they have previously opened/closed the FAB
       // Default open if they have never opened/closed the fab before (i.e. first time on the site)
-      setIsOpen(
-        canStartOpen &&
-          ((isFirstSession && canDefaultOpen) ||
-            JSON.parse(tryGetSessionStorage(SESSION_STORAGE_KEY, false)))
+      dispatch(
+        setChatIsOpen(
+          canStartOpen &&
+            ((isFirstSession && canDefaultOpen) ||
+              JSON.parse(tryGetSessionStorage(SESSION_STORAGE_KEY, false)))
+        )
       );
     }
-  }, [canStartOpen, hasOpened, hasClosed, canDefaultOpen]);
+  }, [canStartOpen, hasOpened, hasClosed, canDefaultOpen, dispatch]);
 
   const updateUnreadNotificationCount = React.useCallback(() => {
     HttpClient.fetchJson<AiDiffNotification[]>('/notifications')
@@ -129,6 +136,19 @@ const AiDiffFloatingActionButton: React.FC<AiDiffFloatingActionButtonProps> = ({
 
   const [curriculumCourses, setCurriculumCourses] = useState<string[]>();
 
+  React.useEffect(() => {
+    if (!threadMessages || threadMessages.length === 0) {
+      dispatch(
+        fetchThreadMessages({
+          contextType: context.type,
+          thread: 0,
+          curriculumCourses: curriculumCourses,
+        })
+      );
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
   useEffect(() => {
     const body = JSON.stringify({
       context: context,
@@ -144,7 +164,7 @@ const AiDiffFloatingActionButton: React.FC<AiDiffFloatingActionButtonProps> = ({
         console.log(error);
         setCurriculumCourses([]);
       });
-  }, [context]);
+  }, [context, dispatch]);
 
   const [isFabImageLoaded, setIsFabImageLoaded] = useState(false);
 
@@ -158,7 +178,7 @@ const AiDiffFloatingActionButton: React.FC<AiDiffFloatingActionButtonProps> = ({
       aiDiffChatContext: context,
       scriptName,
     };
-    const eventName = isOpen
+    const eventName = chatIsOpen
       ? EVENTS.AI_DIFF_CHAT_CLOSED
       : EVENTS.AI_DIFF_CHAT_OPENED;
     analyticsReporter.sendEvent(eventName, eventData, PLATFORMS.STATSIG);
@@ -167,13 +187,17 @@ const AiDiffFloatingActionButton: React.FC<AiDiffFloatingActionButtonProps> = ({
     } else {
       trySetLocalStorage(LOCAL_STORAGE_CLOSED_KEY, true.toString());
     }
-    setIsOpen(!isOpen);
-    trySetSessionStorage(SESSION_STORAGE_KEY, (!isOpen).toString());
+    dispatch(setChatIsOpen(!chatIsOpen));
+    dispatch(
+      fetchThreadMessages({
+        contextType: context.type,
+        thread: 0,
+        curriculumCourses: curriculumCourses,
+      })
+    );
+    trySetSessionStorage(SESSION_STORAGE_KEY, (!chatIsOpen).toString());
     updateUnreadNotificationCount();
   };
-
-  // Add listener to open the FAB if an external component sends event to open it
-  document.addEventListener(EXT_COMPONENT_OPEN_FAB_EVENT, handleClick);
 
   return (
     <div id="fab-contained">
@@ -230,10 +254,9 @@ const AiDiffFloatingActionButton: React.FC<AiDiffFloatingActionButtonProps> = ({
       </button>
       <AiDiffContainer
         context={context}
-        open={isOpen}
         closeTutor={handleClick}
+        curriculumCourses={curriculumCourses || ([] as string[])}
         scriptName={scriptName}
-        curriculumCourses={curriculumCourses}
         unreadNotificationCount={
           unreadNotificationCount === 'loading' ? 0 : unreadNotificationCount
         }

--- a/apps/src/aiDifferentiation/AiDiffSidebar.tsx
+++ b/apps/src/aiDifferentiation/AiDiffSidebar.tsx
@@ -6,23 +6,25 @@ import {Box, List, ListItem, ListItemButton, ListItemText} from '@mui/material';
 import classNames from 'classnames';
 import React, {useCallback, useState} from 'react';
 
+import {fetchThreadMessages} from '@cdo/apps/aichat/redux/thunks';
 import {EVENTS} from '@cdo/apps/metrics/AnalyticsConstants';
 import analyticsReporter from '@cdo/apps/metrics/AnalyticsReporter';
 import {commonI18n} from '@cdo/apps/types/locale';
 import experiments from '@cdo/apps/util/experiments';
+import {useAppDispatch, useAppSelector} from '@cdo/apps/util/reduxHooks';
 import i18n from '@cdo/locale';
 
-import {ChatThread} from './types';
+import {ChatThread, Context} from './types';
 
 import styles from './ai-differentiation.module.scss';
 
 interface AiDiffSidebarProps {
+  context: Context;
   threads?: ChatThread[];
-  selectedThreadId?: number;
-  threadSelectCallback?: (thread: number) => void;
   setShowNotifications: (show: boolean) => void;
   showNotifications: boolean;
   unreadNotificationCount: number;
+  curriculumCourses: string[] | undefined;
 }
 
 const now = new Date();
@@ -64,24 +66,25 @@ const ThreadItem: React.FC<{
 );
 
 const AiDiffSidebar: React.FC<AiDiffSidebarProps> = ({
+  context,
   threads = [],
-  selectedThreadId,
-  threadSelectCallback = () => {},
   setShowNotifications,
   showNotifications,
   unreadNotificationCount,
+  curriculumCourses,
 }) => {
+  const selectedThreadId = useAppSelector(state => state.aichat.threadId);
   const [isCollapsed, setIsCollapsed] = useState(false);
   const [showDailyBytes, setShowDailyBytes] = useState(false);
+
+  const dispatch = useAppDispatch();
+
   const toggleSidebar = () => {
     setIsCollapsed(!isCollapsed);
   };
 
-  const onNewChatButtonClick = useCallback(() => {
-    setShowNotifications(false);
-    setShowDailyBytes(false);
-    threadSelectCallback(0);
-  }, [setShowNotifications, threadSelectCallback, setShowDailyBytes]);
+  const checkIfThreadIsSelected = (thread: ChatThread) =>
+    !showNotifications && !showDailyBytes && thread.id === selectedThreadId;
 
   const onNotificationsButtonClick = useCallback(() => {
     setShowNotifications(true);
@@ -101,7 +104,13 @@ const AiDiffSidebar: React.FC<AiDiffSidebarProps> = ({
   const handleListItemClick = (chatId: number) => {
     setShowNotifications(false);
     setShowDailyBytes(false);
-    threadSelectCallback(chatId);
+    dispatch(
+      fetchThreadMessages({
+        contextType: context.type,
+        thread: chatId,
+        curriculumCourses: curriculumCourses,
+      })
+    );
   };
 
   const todayChats = threads.filter(thread => {
@@ -119,8 +128,23 @@ const AiDiffSidebar: React.FC<AiDiffSidebarProps> = ({
     return thread.updatedAt < thirtyDaysAgo;
   });
 
-  const checkIfThreadIsSelected = (thread: ChatThread) =>
-    !showNotifications && !showDailyBytes && thread.id === selectedThreadId;
+  const onNewChatButtonClick = useCallback(() => {
+    setShowNotifications(false);
+    setShowDailyBytes(false);
+    dispatch(
+      fetchThreadMessages({
+        contextType: context.type,
+        thread: 0,
+        curriculumCourses: curriculumCourses,
+      })
+    );
+  }, [
+    setShowNotifications,
+    setShowDailyBytes,
+    curriculumCourses,
+    context,
+    dispatch,
+  ]);
 
   return (
     <aside

--- a/apps/src/aiDifferentiation/AiDiffSuggestedPrompts.tsx
+++ b/apps/src/aiDifferentiation/AiDiffSuggestedPrompts.tsx
@@ -1,6 +1,8 @@
-import React, {useState} from 'react';
+import React from 'react';
 
+import {setSelectedPrompt} from '@cdo/apps/aichat/redux/slice';
 import SuggestedPrompts from '@cdo/apps/aiComponentLibrary/suggestedPrompt/SuggestedPrompts';
+import {useAppDispatch, useAppSelector} from '@cdo/apps/util/reduxHooks';
 
 import {ChatPrompt} from './types';
 
@@ -15,27 +17,34 @@ const AiDiffSuggestedPrompts: React.FC<ComponentProps> = ({
   isLatest,
   onSubmit,
 }) => {
-  const [selectedPrompt, setSelectedPrompt] = useState<ChatPrompt>();
+  const selectedPrompt = useAppSelector(state => state.aichat.selectedPrompt);
+
+  const dispatch = useAppDispatch();
 
   const onClick = (prompt: ChatPrompt) => () => {
     // The first prompt selected is final.
     // Can't select a prompt after something else has happened.
-    if (selectedPrompt || !isLatest) {
+    if (
+      (selectedPrompt && suggestedPrompts.includes(selectedPrompt)) ||
+      !isLatest
+    ) {
       return;
     }
 
     onSubmit(prompt);
-    setSelectedPrompt(prompt);
+    dispatch(setSelectedPrompt(prompt));
   };
 
-  const structuredPrompts = suggestedPrompts.map(prompt => {
-    return {
-      label: prompt.label,
-      selected: prompt === selectedPrompt,
-      onClick: onClick(prompt),
-      show: true,
-    };
-  });
+  const structuredPrompts = suggestedPrompts
+    .filter(prompt => prompt !== undefined)
+    .map(prompt => {
+      return {
+        label: prompt.label,
+        selected: prompt === selectedPrompt,
+        onClick: onClick(prompt),
+        show: true,
+      };
+    });
 
   return <SuggestedPrompts suggestedPrompts={structuredPrompts} />;
 };

--- a/apps/src/aiDifferentiation/AiDiffWorkspace.tsx
+++ b/apps/src/aiDifferentiation/AiDiffWorkspace.tsx
@@ -1,28 +1,22 @@
 import React, {useCallback, useEffect, useState} from 'react';
 
+import {fetchThreadMessages} from '@cdo/apps/aichat/redux/thunks';
 import {PersonalizationData} from '@cdo/apps/aiDifferentiation/hooks/useTeachingProfileData';
+import {useAppDispatch} from '@cdo/apps/util/reduxHooks';
 
 import HttpClient from '../util/HttpClient';
 
 import AiDiffChat from './AiDiffChat';
 import AiDiffSidebar from './AiDiffSidebar';
-import {DEFAULT_THREAD_TITLE} from './constants';
 import AiDiffNotificationList from './notifications/AiDiffNotificationList';
-import {
-  ChatItem,
-  ChatThread,
-  chatThreadValidator,
-  chatThreadMessagesValidator,
-  Context,
-  ChatPrompt,
-} from './types';
+import {ChatThread, chatThreadValidator, Context} from './types';
 
 import style from './ai-differentiation.module.scss';
 
 interface AiDiffWorkSpaceProps {
   context: Context;
   scriptName?: string;
-  curriculumCourses?: string[];
+  curriculumCourses: string[];
   unreadNotificationCount: number;
   personalizationData?: PersonalizationData;
 }
@@ -35,13 +29,9 @@ const AiDiffWorkSpace: React.FC<AiDiffWorkSpaceProps> = ({
   personalizationData,
 }) => {
   const [threads, setThreads] = useState<ChatThread[]>();
-  const [threadMessages, setThreadMessages] = useState<ChatItem[]>();
-  const [threadId, setThreadId] = useState<number>(0);
-  const [threadTitle, setThreadTitle] = useState<string>(DEFAULT_THREAD_TITLE);
-  const [keyId, setKeyId] = useState<number>(0);
-  const [initialThreadPrompt, setInitialThreadPrompt] =
-    useState<ChatPrompt | null>(null);
   const [showNotifications, setShowNotifications] = useState<boolean>(false);
+
+  const dispatch = useAppDispatch();
 
   async function asyncFetchThreads(): Promise<ChatThread[]> {
     const response = await HttpClient.fetchJson<ChatThread[]>(
@@ -55,7 +45,7 @@ const AiDiffWorkSpace: React.FC<AiDiffWorkSpaceProps> = ({
   const fetchThreads = useCallback(() => {
     asyncFetchThreads().then(response => {
       setThreads(
-        response.sort((a, b) => {
+        response?.sort((a, b) => {
           return a.updatedAt > b.updatedAt ? -1 : 1;
         })
       );
@@ -66,63 +56,33 @@ const AiDiffWorkSpace: React.FC<AiDiffWorkSpaceProps> = ({
     fetchThreads();
   }, [fetchThreads]);
 
-  async function asyncFetchThreadMessages(thread: number): Promise<ChatThread> {
-    const response = await HttpClient.fetchJson<ChatThread>(
-      `/aidiff_threads/${thread}`,
-      {},
-      chatThreadMessagesValidator
-    );
-    return response.value;
-  }
-
-  const fetchThreadMessages = useCallback(
-    (thread: number) => {
-      if (thread === 0) {
-        setThreadMessages([]);
-        setThreadId(thread);
-        setThreadTitle(DEFAULT_THREAD_TITLE);
-        // changing the keyId resets the component state.
-        // if key is already 0 (i.e. starting a new thread from a new thread)
-        // then we need to alternate to a different key value to reset state
-        // -1 is safe because it won't accidentally match a threadID value
-        if (keyId === 0) {
-          setKeyId(-1);
-        } else {
-          setKeyId(thread);
-        }
-      } else {
-        asyncFetchThreadMessages(thread).then(response => {
-          setThreadMessages(response.messages);
-          setThreadId(thread);
-          setThreadTitle(response.title);
-          setKeyId(thread);
-        });
-      }
-    },
-    [setThreadMessages, keyId]
-  );
-
   const aiPromptOutsideChatClicked = useCallback(
     (label: string, prompt: string) => {
       setShowNotifications(false);
-      setInitialThreadPrompt({
-        label: label,
-        prompt: prompt,
-      });
-      fetchThreadMessages(0);
+      dispatch(
+        fetchThreadMessages({
+          contextType: context.type,
+          thread: 0,
+          initialThreadPrompt: {
+            label: label,
+            prompt: prompt,
+          },
+          curriculumCourses: curriculumCourses,
+        })
+      );
     },
-    [fetchThreadMessages]
+    [dispatch, context, curriculumCourses]
   );
 
   return (
     <div className={style.aiDiffWorkspace}>
       <AiDiffSidebar
+        context={context}
         threads={threads}
-        selectedThreadId={threadId}
-        threadSelectCallback={fetchThreadMessages}
         setShowNotifications={setShowNotifications}
         showNotifications={showNotifications}
         unreadNotificationCount={unreadNotificationCount}
+        curriculumCourses={curriculumCourses}
       />
       {showNotifications ? (
         <AiDiffNotificationList aiPromptClick={aiPromptOutsideChatClicked} />
@@ -130,17 +90,8 @@ const AiDiffWorkSpace: React.FC<AiDiffWorkSpaceProps> = ({
         <AiDiffChat
           context={context}
           scriptName={scriptName}
-          curriculumCourses={curriculumCourses}
           threadFetchCallback={fetchThreads}
-          threadMessages={threadMessages}
-          threadTitle={threadTitle}
-          setThreadTitle={setThreadTitle}
-          key={keyId}
-          threadId={threadId}
-          setThreadId={setThreadId}
           personalizationData={personalizationData}
-          initialThreadPrompt={initialThreadPrompt}
-          setInitialThreadPrompt={setInitialThreadPrompt}
         />
       )}
     </div>

--- a/apps/src/aiDifferentiation/welcome/AiDiffWelcome.tsx
+++ b/apps/src/aiDifferentiation/welcome/AiDiffWelcome.tsx
@@ -14,8 +14,17 @@ import classNames from 'classnames';
 import React from 'react';
 import Confetti from 'react-dom-confetti';
 
+import {
+  setInitialChatMessage,
+  setThreadMessages,
+} from '@cdo/apps/aichat/redux/slice';
+import {Role} from '@cdo/apps/aiComponentLibrary/chatMessage/types';
 import HttpClient from '@cdo/apps/util/HttpClient';
-import {AiDiffContext} from '@cdo/generated-scripts/sharedConstants';
+import {useAppDispatch} from '@cdo/apps/util/reduxHooks';
+import {
+  AiInteractionStatus as Status,
+  AiDiffContext,
+} from '@cdo/generated-scripts/sharedConstants';
 import ai101Thumnail from '@cdo/static/ai-101-pl-course-thumbnail.png';
 import aiBotHappy from '@cdo/static/ai-bot-happy.png';
 import aiBotScanning from '@cdo/static/ai-bot-scanning.png';
@@ -43,9 +52,9 @@ const WelcomeStates: {[key in WelcomeState]: WelcomeState} = {
 interface AiDiffWelcomeProps {
   setShowWelcomeExperience: (show: boolean) => void;
   context: Context;
+  curriculumCourses: string[];
   scriptName?: string;
   firstState?: WelcomeState;
-  curriculumCourses?: string[];
 }
 
 const optionButton = (
@@ -132,20 +141,19 @@ const AiDiffWelcome: React.FC<AiDiffWelcomeProps> = ({
   setShowWelcomeExperience,
   context,
   scriptName,
+  curriculumCourses,
   // This should only be used for testing purposes
   firstState = 'get_started',
-  curriculumCourses,
 }) => {
   const [currentWelcomeState, setCurrentWelcomeState] =
     React.useState<WelcomeState>(firstState);
-
   const [chatContinueButtonDisabled, setChatContinueButtonDisabled] =
     React.useState(true);
-
   const [selectedOption, setSelectedOption] =
     React.useState<SuggestPromptsType | null>(null);
-
   const [confettiActive, setConfettiActive] = React.useState<boolean>(false);
+
+  const dispatch = useAppDispatch();
 
   const reportingContext = React.useMemo(() => {
     return {
@@ -155,6 +163,24 @@ const AiDiffWelcome: React.FC<AiDiffWelcomeProps> = ({
       url: window.location.href,
     };
   }, [context, scriptName, selectedOption]);
+
+  React.useEffect(() => {
+    if (selectedOption) {
+      const {initialMessage, suggestedPrompts} =
+        SUGGESTED_PROMPTS_FOR_SELECTION[selectedOption];
+      dispatch(setInitialChatMessage(initialMessage));
+      dispatch(
+        setThreadMessages([
+          {
+            role: Role.ASSISTANT,
+            chatMessageText: initialMessage,
+            status: Status.OK,
+          },
+          suggestedPrompts,
+        ])
+      );
+    }
+  }, [selectedOption, dispatch]);
 
   const updateShowWelcomeExperience = React.useCallback(
     (statsigKey: string) => {
@@ -253,8 +279,7 @@ const AiDiffWelcome: React.FC<AiDiffWelcomeProps> = ({
               'Create',
               'Differentiate assessment materials, generate lesson-aligned activities and practice problems'
             )}
-            {curriculumCourses &&
-              curriculumCourses.includes('csp') &&
+            {curriculumCourses.includes('csp') &&
               optionButton(
                 selectedOption === 'apcsp',
                 () => setSelectedOption('apcsp'),
@@ -350,9 +375,6 @@ const AiDiffWelcome: React.FC<AiDiffWelcomeProps> = ({
       return null;
     }
 
-    const {initialMessage, suggestedPrompts} =
-      SUGGESTED_PROMPTS_FOR_SELECTION[selectedOption];
-
     return (
       <div className={style.practicePage}>
         {progressBarHeader(60, () => setCurrentWelcomeState('select_option'))}
@@ -361,8 +383,6 @@ const AiDiffWelcome: React.FC<AiDiffWelcomeProps> = ({
             context={context}
             scriptName={scriptName}
             chatResponseCallback={() => setChatContinueButtonDisabled(false)}
-            initialChatMessage={initialMessage}
-            suggestedPrompts={suggestedPrompts}
             hideChatHeader
           />
         </div>

--- a/apps/src/aichat/redux/thunks/fetchThreadMessages.ts
+++ b/apps/src/aichat/redux/thunks/fetchThreadMessages.ts
@@ -7,13 +7,31 @@ import {
   DEFAULT_THREAD_TITLE,
 } from '@cdo/apps/aiDifferentiation/constants';
 import {
+  EXAMPLE_PROMPT,
+  EXPLAIN_CONCEPT_PROMPT,
+  DEBUG_MISTAKES_PROMPT,
+  EXIT_TICKET_PROMPT,
+  MINI_LESSON_PROMPT,
+  APCSP_DUMMY_CREATE,
+  APCSP_DUMMY_EXAM,
+  DEBUG_THIS_CODE,
+  IMPROVE_THIS_CODE,
+  SUGGESTED_PROMPTS_FOR_SELECTION,
+  SUGGEST_CURRICULUM_PROMPT,
+  GET_STARTED_PROMPT,
+  CREATE_SECTION_PROMPT,
+} from '@cdo/apps/aiDifferentiation/predefinedPrompts';
+import {
   ChatPrompt,
   ChatThread,
   chatThreadMessagesValidator,
 } from '@cdo/apps/aiDifferentiation/types';
 import {RootState} from '@cdo/apps/types/redux';
 import HttpClient from '@cdo/apps/util/HttpClient';
-import {AiInteractionStatus as Status} from '@cdo/generated-scripts/sharedConstants';
+import {
+  AiDiffContext,
+  AiInteractionStatus as Status,
+} from '@cdo/generated-scripts/sharedConstants';
 
 import {
   setThreadId,
@@ -27,11 +45,54 @@ import {
 } from '../slice';
 
 interface FetchThreadMessagesParams {
+  contextType: string;
   thread: number;
   threadType?: ThreadTypeFields;
   initialThreadPrompt?: ChatPrompt;
-  suggestedPrompts?: ChatPrompt[];
+  curriculumCourses: string[] | undefined;
 }
+
+const APCSP_PROMPTS = [APCSP_DUMMY_CREATE, APCSP_DUMMY_EXAM];
+
+const SUGGESTED_PROMPTS = [
+  EXAMPLE_PROMPT,
+  EXPLAIN_CONCEPT_PROMPT,
+  DEBUG_MISTAKES_PROMPT,
+  MINI_LESSON_PROMPT,
+  EXIT_TICKET_PROMPT,
+];
+
+const getDefaultSuggestedPrompts = (
+  contextType: string,
+  teacherHasSections: boolean,
+  teacherHasSectionWithCurriculum: boolean,
+  teacherHasSectionWithStudents: boolean
+) =>
+  contextType === AiDiffContext.GENERAL
+    ? SUGGESTED_PROMPTS_FOR_SELECTION['support'].suggestedPrompts.filter(
+        ({label}) => {
+          // Hide some new thread default prompts based on teacher's sections
+          if (
+            (label === GET_STARTED_PROMPT.label ||
+              label === CREATE_SECTION_PROMPT.label) &&
+            teacherHasSections &&
+            teacherHasSectionWithCurriculum &&
+            teacherHasSectionWithStudents
+          ) {
+            return false;
+          }
+
+          if (
+            label === SUGGEST_CURRICULUM_PROMPT.label &&
+            teacherHasSectionWithCurriculum
+          ) {
+            return false;
+          }
+
+          return true;
+        }
+      )
+    : SUGGESTED_PROMPTS;
 
 async function asyncFetchThreadMessages(thread: number): Promise<ChatThread> {
   const response = await HttpClient.fetchJson<ChatThread>(
@@ -46,14 +107,41 @@ export const fetchThreadMessages = createAsyncThunk(
   'aichat/fetchThreadMessages',
   async (
     {
+      contextType,
       thread,
       threadType = THREAD_TYPES.default,
       initialThreadPrompt,
-      suggestedPrompts,
+      curriculumCourses = [] as string[],
     }: FetchThreadMessagesParams,
     thunkAPI
   ) => {
     const state = thunkAPI.getState() as RootState;
+    const teacherSectionData = state.teacherSections?.sections;
+    const teacherSections = teacherSectionData
+      ? Object.values(teacherSectionData)
+      : [];
+    const teacherHasSections = teacherSections.length > 0;
+    const teacherHasSectionWithCurriculum = !!teacherSections.find(
+      section => section.courseId !== null
+    );
+    const teacherHasSectionWithStudents = !!teacherSections.find(
+      section => section.studentCount > 0
+    );
+    const defaultSuggestedPrompts = getDefaultSuggestedPrompts(
+      contextType,
+      teacherHasSections,
+      teacherHasSectionWithCurriculum,
+      teacherHasSectionWithStudents
+    );
+    const additionalPrompts: ChatPrompt[] = [];
+    if (curriculumCourses?.includes('csp')) {
+      additionalPrompts.push(...APCSP_PROMPTS);
+    }
+    if (contextType === AiDiffContext.LEVEL) {
+      additionalPrompts.push(DEBUG_THIS_CODE, IMPROVE_THIS_CODE);
+    }
+    const suggestedPrompts = defaultSuggestedPrompts.concat(additionalPrompts);
+
     thunkAPI.dispatch(setThreadType(threadType));
 
     if (thread === 0) {
@@ -84,7 +172,7 @@ export const fetchThreadMessages = createAsyncThunk(
           setThreadMessages(
             suggestedPrompts && threadType.showSuggestedPrompts
               ? [initialAIMessage, suggestedPrompts]
-              : [initialAIMessage]
+              : [initialAIMessage, SUGGESTED_PROMPTS]
           )
         );
       }

--- a/apps/src/templates/teacherNavigation/lessonMaterials/LessonMaterialsContainer.tsx
+++ b/apps/src/templates/teacherNavigation/lessonMaterials/LessonMaterialsContainer.tsx
@@ -10,7 +10,9 @@ import _ from 'lodash';
 import React, {useState, useMemo} from 'react';
 import {useSelector} from 'react-redux';
 
-import {EXT_COMPONENT_OPEN_FAB_EVENT} from '@cdo/apps/aiDifferentiation/AiDiffFloatingActionButton';
+import {setChatIsOpen} from '@cdo/apps/aichat/redux/slice';
+import {fetchThreadMessages} from '@cdo/apps/aichat/redux/thunks';
+import {THREAD_TYPES} from '@cdo/apps/aiDifferentiation/constants';
 import {EVENTS} from '@cdo/apps/metrics/AnalyticsConstants';
 import analyticsReporter from '@cdo/apps/metrics/AnalyticsReporter';
 import {
@@ -22,6 +24,7 @@ import {selectedSectionSelector} from '@cdo/apps/templates/teacherDashboard/teac
 import experiments from '@cdo/apps/util/experiments';
 import HttpClient from '@cdo/apps/util/HttpClient';
 import {useAppDispatch, useAppSelector} from '@cdo/apps/util/reduxHooks';
+import {AiDiffContext} from '@cdo/generated-scripts/sharedConstants';
 import i18n from '@cdo/locale';
 import AIBotTAIcon from '@cdo/static/ai-bot-ta-tag-icon.png';
 
@@ -67,13 +70,6 @@ const lessonMaterialsApiCall = (unitId: number) =>
   HttpClient.fetchJson<LessonMaterialsData>(
     `/dashboardapi/lesson_materials/${unitId}`
   ).then(response => response?.value);
-
-const handleLessonSummaryAskAITAClick = () => {
-  const openAITAEvent = new Event(EXT_COMPONENT_OPEN_FAB_EVENT, {
-    bubbles: true,
-  });
-  document.dispatchEvent(openAITAEvent);
-};
 
 interface LessonMaterialsContainerProps {
   showNoCurriculumAssigned: boolean;
@@ -237,6 +233,18 @@ const LessonMaterialsContainer: React.FC<LessonMaterialsContainerProps> = ({
         });
     }
   }, [userId, selectedLesson]);
+
+  const handleLessonSummaryAskAITAClick = () => {
+    dispatch(
+      fetchThreadMessages({
+        contextType: AiDiffContext.LESSON,
+        thread: 0,
+        threadType: THREAD_TYPES.lessonSummaryHelp,
+        curriculumCourses: [],
+      })
+    );
+    dispatch(setChatIsOpen(true));
+  };
 
   const renderHeader = () => {
     return (

--- a/apps/test/unit/aiDifferentiation/AiDiffChatTest.jsx
+++ b/apps/test/unit/aiDifferentiation/AiDiffChatTest.jsx
@@ -8,11 +8,35 @@ import {
 import React from 'react';
 import {Provider} from 'react-redux';
 
+import {
+  aichatReducer,
+  setThreadId,
+  setThreadTitle,
+  setThreadType,
+  setThreadMessages,
+  setInitialChatMessage,
+} from '@cdo/apps/aichat/redux/slice';
 import {Role} from '@cdo/apps/aiComponentLibrary/chatMessage/types';
 import AiDiffChat from '@cdo/apps/aiDifferentiation/AiDiffChat';
+import {THREAD_TYPES} from '@cdo/apps/aiDifferentiation/constants';
+import {
+  EXAMPLE_PROMPT,
+  EXPLAIN_CONCEPT_PROMPT,
+  DEBUG_MISTAKES_PROMPT,
+  EXIT_TICKET_PROMPT,
+  MINI_LESSON_PROMPT,
+  APCSP_DUMMY_CREATE,
+  APCSP_DUMMY_EXAM,
+  SUGGESTED_PROMPTS_FOR_SELECTION,
+} from '@cdo/apps/aiDifferentiation/predefinedPrompts';
 import {EVENTS, PLATFORMS} from '@cdo/apps/metrics/AnalyticsConstants';
 import analyticsReporter from '@cdo/apps/metrics/AnalyticsReporter';
-import {getStore, registerReducers} from '@cdo/apps/redux';
+import {
+  getStore,
+  registerReducers,
+  restoreRedux,
+  stubRedux,
+} from '@cdo/apps/redux';
 import currentUser, {
   setInitialData,
 } from '@cdo/apps/templates/currentUserRedux';
@@ -35,6 +59,14 @@ jest.mock('@react-pdf/renderer', () => {
   };
 });
 
+const DEFAULT_SUGGESTED_PROMPTS = [
+  EXAMPLE_PROMPT,
+  EXPLAIN_CONCEPT_PROMPT,
+  DEBUG_MISTAKES_PROMPT,
+  MINI_LESSON_PROMPT,
+  EXIT_TICKET_PROMPT,
+];
+
 const defaultProps = {
   closeTutor: () => {},
   open: true,
@@ -53,18 +85,40 @@ const defaultChatResponse = {
   message_id: 42,
 };
 
+const defaultFeedbackResponse = {
+  chatContext: {
+    type: AiDiffContext.LESSON,
+    lessonId: 2,
+  },
+  scriptName: 'test_lesson',
+  thumbsUp: true,
+  thumbsDown: false,
+  flagged: false,
+  text: "Beep boop I'm a bot",
+  messageId: 42,
+};
+
 describe('AiDiffChat', () => {
-  let fetchStub;
+  let postStub;
   let sendEventSpy;
 
   beforeEach(() => {
+    stubRedux();
     window.HTMLElement.prototype.scrollIntoView = () => {};
     sessionStorage.clear();
-    fetchStub = jest
-      .spyOn(HttpClient, 'post')
-      .mockResolvedValue(
-        Promise.resolve(new Response(JSON.stringify(defaultChatResponse)))
-      );
+    postStub = jest.spyOn(HttpClient, 'post').mockImplementation(url => {
+      if (url.includes('aidiff_threads')) {
+        return Promise.resolve(
+          new Response(JSON.stringify(defaultChatResponse))
+        );
+      }
+      if (url.includes('submit_feedback')) {
+        return Promise.resolve(
+          new Response(JSON.stringify(defaultFeedbackResponse))
+        );
+      }
+      return Promise.resolve(new Response(JSON.stringify(defaultChatResponse)));
+    });
 
     sendEventSpy = jest.spyOn(analyticsReporter, 'sendEvent');
   });
@@ -72,14 +126,16 @@ describe('AiDiffChat', () => {
   afterEach(() => {
     sessionStorage.clear();
     jest.restoreAllMocks();
+    restoreRedux();
   });
 
-  function renderDefault(propOverrides = {}) {
+  function renderDefault(overrideThreadId = 0, overrideThreadMessages = []) {
     const store = getStore();
 
     registerReducers({
       currentUser,
       teacherSections,
+      aichat: aichatReducer,
     });
     store.dispatch(
       setInitialData({
@@ -88,10 +144,33 @@ describe('AiDiffChat', () => {
       })
     );
     store.dispatch(setSections([]));
+    store.dispatch(setThreadId(overrideThreadId));
+    store.dispatch(setThreadTitle('Sample title'));
+    store.dispatch(setThreadType(THREAD_TYPES.default));
+    store.dispatch(
+      setInitialChatMessage(
+        SUGGESTED_PROMPTS_FOR_SELECTION['default'].initialMessage
+      )
+    );
+    store.dispatch(
+      setThreadMessages(
+        overrideThreadMessages.length > 0
+          ? overrideThreadMessages
+          : [
+              {
+                role: Role.ASSISTANT,
+                chatMessageText:
+                  SUGGESTED_PROMPTS_FOR_SELECTION['default'].initialMessage,
+                status: Status.OK,
+              },
+              DEFAULT_SUGGESTED_PROMPTS,
+            ]
+      )
+    );
 
     render(
       <Provider store={store}>
-        <AiDiffChat {...defaultProps} {...propOverrides} />
+        <AiDiffChat {...defaultProps} />
       </Provider>
     );
   }
@@ -100,7 +179,7 @@ describe('AiDiffChat', () => {
     renderDefault();
     const message = screen.getByLabelText(i18n.aiChatMessageBot());
     expect(message).toHaveTextContent(
-      "Hi! I'm your AI Teaching Assistant. What can I help you with? Here are some things you can ask me."
+      SUGGESTED_PROMPTS_FOR_SELECTION['default'].initialMessage
     );
     // Suggested prompts
     const suggestedPromptsGroup = screen.getByRole('group', {
@@ -114,44 +193,6 @@ describe('AiDiffChat', () => {
     screen.getByRole('button', {name: 'Debug common mistakes'});
     screen.getByRole('button', {name: 'Generate a mini lesson'});
     screen.getByRole('button', {name: 'Write an exit ticket'});
-  });
-
-  it('initial message and suggested prompts are rendered, APCSP prompts included if csp in context', () => {
-    const overrideProps = {
-      ...defaultProps,
-      curriculumCourses: ['csp-year', 'csp'],
-    };
-    renderDefault(overrideProps);
-    const message = screen.getByLabelText(i18n.aiChatMessageBot());
-    expect(message).toHaveTextContent(
-      "Hi! I'm your AI Teaching Assistant. What can I help you with? Here are some things you can ask me."
-    );
-    //suggested prompts
-    screen.getByRole('button', {name: 'Give me an example'});
-    screen.getByRole('button', {name: 'Explain a concept'});
-    screen.getByRole('button', {name: 'Debug common mistakes'});
-    screen.getByRole('button', {name: 'Generate a mini lesson'});
-    screen.getByRole('button', {name: 'Write an exit ticket'});
-    screen.getByRole('button', {name: 'Create task support'});
-    screen.getByRole('button', {name: 'AP exam support'});
-  });
-
-  it('initial message and suggested prompts are rendered for general context', () => {
-    const overrideProps = {
-      ...defaultProps,
-      context: {type: AiDiffContext.GENERAL},
-    };
-    renderDefault(overrideProps);
-    const message = screen.getByLabelText(i18n.aiChatMessageBot());
-    expect(message).toHaveTextContent(
-      "Hi! I'm your AI Teaching Assistant. What can I help you with? Here are some things you can ask me."
-    );
-    //suggested prompts
-    screen.getByRole('button', {name: 'Suggest a curriculum'});
-    screen.getByRole('button', {name: 'Get started with Code.org'});
-    screen.getByRole('button', {name: 'Learn about Professional Learning'});
-    screen.getByRole('button', {name: 'How to create a section?'});
-    screen.getByRole('button', {name: 'Get help using Code.org'});
   });
 
   it('Selecting a suggested prompt gives response', async () => {
@@ -170,7 +211,7 @@ describe('AiDiffChat', () => {
       role: Role.USER,
       isPreset: true,
       text: 'I need an explanation of a concept. You can ask me a follow-up question to find out what concept needs to be explained.',
-      threadId: 3,
+      threadId: defaultChatResponse.thread_id,
       url: window.location.href,
     };
     const responseEventData2 = {
@@ -182,13 +223,13 @@ describe('AiDiffChat', () => {
       role: Role.ASSISTANT,
       isPreset: true,
       text: "Beep boop I'm a bot",
-      threadId: 3,
+      threadId: defaultChatResponse.thread_id,
       url: window.location.href,
     };
 
     // Sends the api call then logs the suggested prompt and the bot message
     await waitFor(() => {
-      expect(fetchStub).toHaveBeenCalledWith(
+      expect(postStub).toHaveBeenCalledWith(
         '/aidiff_threads',
         JSON.stringify({
           inputText: responseEventData.text,
@@ -221,12 +262,17 @@ describe('AiDiffChat', () => {
     expect(message).toHaveTextContent("Beep boop I'm a bot");
   });
 
-  it('Selecting a 2-stage APCSP suggested prompt gives response and second set of prompts', async () => {
-    const overrideProps = {
-      ...defaultProps,
-      curriculumCourses: ['csp-year', 'csp'],
-    };
-    renderDefault(overrideProps);
+  it('Selecting a 2-stage APCSP suggested prompt gives response and adds second set of prompts to thread messages', async () => {
+    const overrideThreadMessages = [
+      {
+        role: Role.ASSISTANT,
+        chatMessageText:
+          SUGGESTED_PROMPTS_FOR_SELECTION['default'].initialMessage,
+        status: Status.OK,
+      },
+      [...DEFAULT_SUGGESTED_PROMPTS, APCSP_DUMMY_CREATE, APCSP_DUMMY_EXAM],
+    ];
+    renderDefault(0, overrideThreadMessages);
 
     // Click a suggested prompt
     const suggestedPromptsGroup = screen.getByRole('group', {
@@ -281,7 +327,7 @@ describe('AiDiffChat', () => {
       role: Role.USER,
       isPreset: true,
       text: 'Can I give students a grade on their Create PT?',
-      threadId: 3,
+      threadId: defaultChatResponse.thread_id,
       url: window.location.href,
     };
     const responseEventData2 = {
@@ -293,13 +339,13 @@ describe('AiDiffChat', () => {
       role: Role.ASSISTANT,
       isPreset: true,
       text: "Beep boop I'm a bot",
-      threadId: 3,
+      threadId: defaultChatResponse.thread_id,
       url: window.location.href,
     };
 
     // Sends the api call then logs the suggested prompt and the bot message
     await waitFor(() => {
-      expect(fetchStub).toHaveBeenCalledWith(
+      expect(postStub).toHaveBeenCalledWith(
         '/aidiff_threads',
         JSON.stringify({
           inputText: responseEventData.text,
@@ -336,7 +382,7 @@ describe('AiDiffChat', () => {
       name: i18n.aiDifferentiationThumbsUp(),
     });
     fireEvent.click(thumbsUpBtn);
-    expect(fetchStub).not.toHaveBeenCalled();
+    expect(postStub).not.toHaveBeenCalled();
 
     // Click a suggested prompt
     const prompt = screen.getByRole('button', {name: 'Explain a concept'});
@@ -351,7 +397,7 @@ describe('AiDiffChat', () => {
       role: Role.USER,
       isPreset: true,
       text: 'I need an explanation of a concept. You can ask me a follow-up question to find out what concept needs to be explained.',
-      threadId: 3,
+      threadId: defaultChatResponse.thread_id,
       url: window.location.href,
     };
     const responseEventData2 = {
@@ -363,7 +409,7 @@ describe('AiDiffChat', () => {
       role: Role.ASSISTANT,
       isPreset: true,
       text: "Beep boop I'm a bot",
-      threadId: 3,
+      threadId: defaultChatResponse.thread_id,
       url: window.location.href,
     };
     const feedbackEventData = {
@@ -381,7 +427,7 @@ describe('AiDiffChat', () => {
 
     // Sends the api call then logs the suggested prompt and the bot message
     await waitFor(() => {
-      expect(fetchStub).toHaveBeenCalledWith(
+      expect(postStub).toHaveBeenCalledWith(
         '/aidiff_threads',
         JSON.stringify({
           inputText: responseEventData.text,
@@ -422,7 +468,7 @@ describe('AiDiffChat', () => {
     fireEvent.click(thumbsUpBtn2);
 
     await waitFor(() => {
-      expect(fetchStub).toHaveBeenCalledWith(
+      expect(postStub).toHaveBeenCalledWith(
         '/aidiff_messages/42/submit_feedback',
         JSON.stringify({
           approval: true,
@@ -466,7 +512,7 @@ describe('AiDiffChat', () => {
       role: Role.USER,
       isPreset: false,
       text: userMessage,
-      threadId: 3,
+      threadId: defaultChatResponse.thread_id,
       url: window.location.href,
     };
     const responseEventData2 = {
@@ -478,13 +524,13 @@ describe('AiDiffChat', () => {
       role: Role.ASSISTANT,
       isPreset: false,
       text: "Beep boop I'm a bot",
-      threadId: 3,
+      threadId: defaultChatResponse.thread_id,
       url: window.location.href,
     };
 
     // Sends the api call then logs the user message and the bot message
     await waitFor(() => {
-      expect(fetchStub).toHaveBeenCalledWith(
+      expect(postStub).toHaveBeenCalledWith(
         '/aidiff_threads',
         JSON.stringify({
           inputText: responseEventData.text,
@@ -525,25 +571,21 @@ describe('AiDiffChat', () => {
   });
 
   it('Provided message history is displayed, typing message calls chat_completion with thread id', async () => {
-    const overrideProps = {
-      ...defaultProps,
-      threadId: 3,
-      threadMessages: [
-        {
-          role: 'user',
-          chatMessageText: 'hello help please',
-          status: Status.OK,
-          id: 5,
-        },
-        {
-          role: 'assistant',
-          chatMessageText: 'beep boop',
-          status: Status.OK,
-          id: 6,
-        },
-      ],
-    };
-    renderDefault(overrideProps);
+    const overrideThreadMessages = [
+      {
+        role: 'user',
+        chatMessageText: 'hello help please',
+        status: Status.OK,
+        id: 0,
+      },
+      {
+        role: 'assistant',
+        chatMessageText: 'beep boop',
+        status: Status.OK,
+        id: 1,
+      },
+    ];
+    renderDefault(defaultChatResponse.thread_id, overrideThreadMessages);
     const userMessage = 'Hello this is a user message';
     const textbox = screen.getByRole('textbox');
     const submit_btn = screen.getByRole('button', {name: i18n.submit()});
@@ -576,7 +618,7 @@ describe('AiDiffChat', () => {
       role: Role.USER,
       isPreset: false,
       text: userMessage,
-      threadId: 3,
+      threadId: defaultChatResponse.thread_id,
       url: window.location.href,
     };
     const responseEventData2 = {
@@ -588,22 +630,18 @@ describe('AiDiffChat', () => {
       role: Role.ASSISTANT,
       isPreset: false,
       text: "Beep boop I'm a bot",
-      threadId: 3,
+      threadId: defaultChatResponse.thread_id,
       url: window.location.href,
     };
 
     // Sends the api call then logs the user message and the bot message
     await waitFor(() => {
-      expect(fetchStub).toHaveBeenCalledWith(
-        '/aidiff_threads/3/chat_completion',
+      expect(postStub).toHaveBeenCalledWith(
+        `/aidiff_threads/${defaultChatResponse.thread_id}/chat_completion`,
         JSON.stringify({
           inputText: responseEventData.text,
           isPreset: false,
           presetChipText: null,
-          context: {
-            type: AiDiffContext.LESSON,
-            lessonId: 2,
-          },
         }),
         true,
         {
@@ -654,7 +692,7 @@ describe('AiDiffChat', () => {
       role: Role.USER,
       isPreset: false,
       text: userMessage,
-      threadId: 3,
+      threadId: defaultChatResponse.thread_id,
       url: window.location.href,
     };
     const responseEventData2 = {
@@ -666,11 +704,11 @@ describe('AiDiffChat', () => {
       role: Role.ASSISTANT,
       isPreset: false,
       text: "Beep boop I'm a bot",
-      threadId: 3,
+      threadId: defaultChatResponse.thread_id,
       url: window.location.href,
     };
     await waitFor(() => {
-      expect(fetchStub).toHaveBeenCalledWith(
+      expect(postStub).toHaveBeenCalledWith(
         '/aidiff_threads',
         JSON.stringify({
           inputText: responseEventData.text,
@@ -711,7 +749,7 @@ describe('AiDiffChat', () => {
     // Reset spies so we can check it hasn't been called again
     jest.clearAllMocks();
     fireEvent.click(prompt);
-    expect(fetchStub).not.toHaveBeenCalled();
+    expect(postStub).not.toHaveBeenCalled();
     expect(sendEventSpy).not.toHaveBeenCalled();
   });
 

--- a/apps/test/unit/aiDifferentiation/AiDiffContainerTest.jsx
+++ b/apps/test/unit/aiDifferentiation/AiDiffContainerTest.jsx
@@ -3,6 +3,7 @@ import userEvent from '@testing-library/user-event';
 import React from 'react';
 import {Provider} from 'react-redux';
 
+import {aichatReducer} from '@cdo/apps/aichat/redux/slice';
 import AiDiffContainer from '@cdo/apps/aiDifferentiation/AiDiffContainer';
 import {getStore, registerReducers} from '@cdo/apps/redux';
 import currentUser, {
@@ -25,13 +26,12 @@ jest.mock('@react-pdf/renderer', () => {
 
 const DEFAULT_PROPS = {
   closeTutor: () => {},
-  open: true,
   context: {
     type: AiDiffContext.LESSON,
     lessonId: 2,
   },
-  scriptName: 'test_lesson',
   curriculumCourses: [],
+  scriptName: 'test_lesson',
 };
 
 const defaultThreadListResponse = [
@@ -68,6 +68,7 @@ describe('AiDiffContainer', () => {
     registerReducers({
       currentUser,
       teacherSections,
+      aichat: aichatReducer,
     });
     store.dispatch(
       setInitialData({
@@ -88,7 +89,7 @@ describe('AiDiffContainer', () => {
   it('visible when open', async () => {
     renderDefault();
     await waitFor(() => {
-      expect(screen.getByText('AI Teaching Assistant')).toBeVisible();
+      screen.getByText('AI Teaching Assistant');
       screen.getByText('Experiment');
     });
   });

--- a/apps/test/unit/aiDifferentiation/AiDiffFloatingActionButtonTest.jsx
+++ b/apps/test/unit/aiDifferentiation/AiDiffFloatingActionButtonTest.jsx
@@ -2,8 +2,14 @@ import {render, screen, fireEvent, waitFor} from '@testing-library/react';
 import React from 'react';
 import {Provider} from 'react-redux';
 
+import {aichatReducer, setChatIsOpen} from '@cdo/apps/aichat/redux/slice';
 import AiDiffFloatingActionButton from '@cdo/apps/aiDifferentiation/AiDiffFloatingActionButton';
-import {getStore, registerReducers} from '@cdo/apps/redux';
+import {
+  getStore,
+  registerReducers,
+  stubRedux,
+  restoreRedux,
+} from '@cdo/apps/redux';
 import currentUser, {
   setInitialData,
 } from '@cdo/apps/templates/currentUserRedux';
@@ -47,6 +53,7 @@ describe('AIDiffFloatingActionButton', () => {
   let fetchJsonStub;
 
   beforeEach(() => {
+    stubRedux();
     window.HTMLElement.prototype.scrollIntoView = () => {};
     sessionStorage.clear();
     localStorage.clear();
@@ -67,6 +74,7 @@ describe('AIDiffFloatingActionButton', () => {
     sessionStorage.clear();
     localStorage.clear();
     jest.restoreAllMocks();
+    restoreRedux();
   });
 
   function renderDefault(propOverrides = {}) {
@@ -75,6 +83,7 @@ describe('AIDiffFloatingActionButton', () => {
     registerReducers({
       currentUser,
       teacherSections,
+      aichat: aichatReducer,
     });
     store.dispatch(
       setInitialData({
@@ -84,6 +93,7 @@ describe('AIDiffFloatingActionButton', () => {
       })
     );
     store.dispatch(setSections([]));
+    store.dispatch(setChatIsOpen(false));
 
     render(
       <Provider store={store}>

--- a/apps/test/unit/aiDifferentiation/AiDiffWorkspaceTest.jsx
+++ b/apps/test/unit/aiDifferentiation/AiDiffWorkspaceTest.jsx
@@ -8,8 +8,17 @@ import {
 import React from 'react';
 import {Provider} from 'react-redux';
 
-import {aichatReducer} from '@cdo/apps/aichat/redux/slice';
+import {aichatReducer, setThreadMessages} from '@cdo/apps/aichat/redux/slice';
+import {Role} from '@cdo/apps/aiComponentLibrary/chatMessage/types';
 import AiDiffWorkspace from '@cdo/apps/aiDifferentiation/AiDiffWorkspace';
+import {
+  EXAMPLE_PROMPT,
+  EXPLAIN_CONCEPT_PROMPT,
+  DEBUG_MISTAKES_PROMPT,
+  EXIT_TICKET_PROMPT,
+  MINI_LESSON_PROMPT,
+  SUGGESTED_PROMPTS_FOR_SELECTION,
+} from '@cdo/apps/aiDifferentiation/predefinedPrompts';
 import {
   chatThreadMessagesValidator,
   chatThreadValidator,
@@ -52,6 +61,14 @@ const defaultProps = {
   curriculumCourses: [],
   personalizationData: {},
 };
+
+const DEFAULT_SUGGESTED_PROMPTS = [
+  EXAMPLE_PROMPT,
+  EXPLAIN_CONCEPT_PROMPT,
+  DEBUG_MISTAKES_PROMPT,
+  MINI_LESSON_PROMPT,
+  EXIT_TICKET_PROMPT,
+];
 
 const now = new Date();
 const sixDaysAgo = new Date(now);
@@ -122,7 +139,7 @@ const defaultChatResponse = {
 
 describe('AiDiffWorkspace', () => {
   let fetchJsonStub;
-  let fetchStub;
+  let postStub;
 
   beforeEach(() => {
     stubRedux();
@@ -131,7 +148,7 @@ describe('AiDiffWorkspace', () => {
 
     fetchJsonStub = jest.fn();
     HttpClient.fetchJson = fetchJsonStub;
-    fetchStub = jest.spyOn(HttpClient, 'post').mockResolvedValue({
+    postStub = jest.spyOn(HttpClient, 'post').mockResolvedValue({
       json: jest.fn(() => defaultChatResponse),
     });
   });
@@ -157,6 +174,17 @@ describe('AiDiffWorkspace', () => {
       })
     );
     store.dispatch(setSections([]));
+    store.dispatch(
+      setThreadMessages([
+        {
+          role: Role.ASSISTANT,
+          chatMessageText:
+            SUGGESTED_PROMPTS_FOR_SELECTION['default'].initialMessage,
+          status: Status.OK,
+        },
+        DEFAULT_SUGGESTED_PROMPTS,
+      ])
+    );
 
     render(
       <Provider store={store}>
@@ -318,16 +346,12 @@ describe('AiDiffWorkspace', () => {
     fireEvent.click(submit_btn);
 
     await waitFor(() => {
-      expect(fetchStub).toHaveBeenCalledWith(
+      expect(postStub).toHaveBeenCalledWith(
         '/aidiff_threads/2/chat_completion',
         JSON.stringify({
           inputText: 'new message on old thread',
           isPreset: false,
           presetChipText: null,
-          context: {
-            type: AiDiffContext.LESSON,
-            lessonId: 2,
-          },
         }),
         true,
         {
@@ -430,7 +454,7 @@ describe('AiDiffWorkspace', () => {
     fireEvent.click(submit_btn);
 
     await waitFor(() => {
-      expect(fetchStub).toHaveBeenCalledWith(
+      expect(postStub).toHaveBeenCalledWith(
         '/aidiff_threads',
         JSON.stringify({
           inputText: 'starting new thread',
@@ -506,7 +530,7 @@ describe('AiDiffWorkspace', () => {
     fireEvent.click(submit_btn);
 
     await waitFor(() => {
-      expect(fetchStub).toHaveBeenCalledWith(
+      expect(postStub).toHaveBeenCalledWith(
         '/aidiff_threads',
         JSON.stringify({
           inputText: 'starting new thread',
@@ -561,7 +585,7 @@ describe('AiDiffWorkspace', () => {
     expect(screen.queryByLabelText(i18n.aiChatMessageUser())).toBeNull();
 
     fetchJsonStub.mockClear();
-    fetchStub.mockClear();
+    postStub.mockClear();
 
     const submit_btn2 = screen.getByRole('button', {name: i18n.submit()});
     const textbox2 = screen.getByRole('textbox');
@@ -569,7 +593,7 @@ describe('AiDiffWorkspace', () => {
     fireEvent.click(submit_btn2);
 
     await waitFor(() => {
-      expect(fetchStub).toHaveBeenCalledWith(
+      expect(postStub).toHaveBeenCalledWith(
         '/aidiff_threads',
         JSON.stringify({
           inputText: 'starting 2nd thread',

--- a/apps/test/unit/aiDifferentiation/welcome/AiDiffWelcomeTest.jsx
+++ b/apps/test/unit/aiDifferentiation/welcome/AiDiffWelcomeTest.jsx
@@ -1,7 +1,10 @@
 import {render, screen, fireEvent, waitFor} from '@testing-library/react';
 import React from 'react';
+import {Provider} from 'react-redux';
 
+import {aichatReducer} from '@cdo/apps/aichat/redux/slice';
 import AiDiffWelcome from '@cdo/apps/aiDifferentiation/welcome/AiDiffWelcome';
+import {getStore, registerReducers} from '@cdo/apps/redux';
 
 jest.mock('@cdo/apps/util/HttpClient', () => ({
   post: jest.fn().mockResolvedValue({
@@ -34,6 +37,7 @@ jest.mock('react-dom-confetti', () => () => <div>confetti</div>);
 const DEFAULT_PROPS = {
   setShowWelcomeExperience: () => {},
   context: 'some-context',
+  curriculumCourses: [],
   scriptId: 1,
   scriptName: 'Test Script',
 };
@@ -43,8 +47,20 @@ describe('AiDiffWelcome', () => {
     window.HTMLElement.prototype.scrollIntoView = () => {};
   });
 
+  function renderDefault(propOverrides = {}) {
+    const store = getStore();
+
+    registerReducers({aichat: aichatReducer});
+
+    render(
+      <Provider store={store}>
+        <AiDiffWelcome {...DEFAULT_PROPS} {...propOverrides} />
+      </Provider>
+    );
+  }
+
   test('renders get started page initially', () => {
-    render(<AiDiffWelcome {...DEFAULT_PROPS} />);
+    renderDefault();
     screen.getByText('AI Teaching Assistant');
 
     screen.getByText('Empowering teachers. Enhancing learning.');
@@ -52,7 +68,7 @@ describe('AiDiffWelcome', () => {
   });
 
   test('clicking "Get Started" transitions to select option page', () => {
-    render(<AiDiffWelcome {...DEFAULT_PROPS} />);
+    renderDefault();
 
     fireEvent.click(screen.getByText('Get Started'));
 
@@ -62,7 +78,7 @@ describe('AiDiffWelcome', () => {
   });
 
   test('selecting an option and clicking "Continue" transitions to practice page', () => {
-    render(<AiDiffWelcome {...DEFAULT_PROPS} firstState={'select_option'} />);
+    renderDefault({firstState: 'select_option'});
 
     fireEvent.click(screen.getByRole('button', {name: 'Ideate'}));
 
@@ -72,7 +88,7 @@ describe('AiDiffWelcome', () => {
   });
 
   test('practice page buttons work correctly', async () => {
-    render(<AiDiffWelcome {...DEFAULT_PROPS} firstState={'practice'} />);
+    renderDefault({firstState: 'practice'});
 
     expect(screen.getByRole('button', {name: 'Continue'})).toBeDisabled();
 
@@ -87,13 +103,10 @@ describe('AiDiffWelcome', () => {
 
   test('clicking "Finish" on the end page triggers setShowWelcomeExperience', async () => {
     const setShowWelcomeExperienceStub = jest.fn();
-    render(
-      <AiDiffWelcome
-        {...DEFAULT_PROPS}
-        setShowWelcomeExperience={setShowWelcomeExperienceStub}
-        firstState={'end_page'}
-      />
-    );
+    renderDefault({
+      setShowWelcomeExperience: setShowWelcomeExperienceStub,
+      firstState: 'end_page',
+    });
     screen.getByText('You’re on your way to becoming an AI all-star!');
 
     screen.getByText('Continue your learning journey');
@@ -109,7 +122,7 @@ describe('AiDiffWelcome', () => {
   }, 15000);
 
   test('End page buttons work correctly', async () => {
-    render(<AiDiffWelcome {...DEFAULT_PROPS} firstState={'end_page'} />);
+    renderDefault({firstState: 'end_page'});
 
     screen.getByText('confetti');
 
@@ -126,7 +139,7 @@ describe('AiDiffWelcome', () => {
   });
 
   test('Back button works correctly', () => {
-    render(<AiDiffWelcome {...DEFAULT_PROPS} firstState={'select_option'} />);
+    renderDefault({firstState: 'select_option'});
 
     fireEvent.click(screen.getByRole('button', {name: 'Back'}));
     screen.getByText('AI Teaching Assistant');
@@ -136,13 +149,10 @@ describe('AiDiffWelcome', () => {
 
   test('Skip tutorial works correctly', async () => {
     const setShowWelcomeExperienceStub = jest.fn();
-    render(
-      <AiDiffWelcome
-        {...DEFAULT_PROPS}
-        setShowWelcomeExperience={setShowWelcomeExperienceStub}
-        firstState={'select_option'}
-      />
-    );
+    renderDefault({
+      setShowWelcomeExperience: setShowWelcomeExperienceStub,
+      firstState: 'select_option',
+    });
 
     fireEvent.click(screen.getByRole('link', {name: 'Skip the tutorial'}));
 


### PR DESCRIPTION
Reverts code-dot-org/code-dot-org#70216

This PR is identical to [this one](https://github.com/code-dot-org/code-dot-org/pull/70137) (which was reverted). I originally thought the [eyes test here](https://eyes.applitools.com/app/test-results/00000251634496291790/00000251634496232754/steps/7?accountId=mG4DoRfv0ntEgI3XIYBulrKxlZqrHtGwbP3V103ojvLFU110&mode=step-editor) was a failure so I put out a revert to not block the DTP. After investigation, I realize I misunderstood what I was seeing and the test actually was behaving as expected and just needed the new baselines accepted. I originally thought it wasn't showing the starting message and was greying out the prompts when it shouldn't, but after going step by step through the eyes test manually I realize that what's actually happening is:
- When the eyes test user goes through the Welcome flow, they select the "Create" suggestion which starts a thread
- Before, this would basically have them get their bearings before being sent to a fresh thread (as shown in the original eyes baseline)
- Now, the prompts and messages they clicked/sent in the Welcome flow are saved as a thread in redux which is then shown once they're done with the Welcome flow (so they can pick up where they left off)
- So it's not that the first message isn't there, the chat is just scrolled down to the latest message so the first message isn't currently visible. And, the prompt that was selected earlier in the Welcome flow is still selected here (with the others greyed out since the user already picked one)

The original PR was totally fine to merge and the new eyes diffs were okay to accept as the new baselines, but I misunderstood them and I reverted in a panic since I didn't want to disrupt the DTP (as this has already been a difficult PR to merge in previously).

### Testing
After manually going through the steps of the failing eyes test, I see the expected full thread (split into two screenshots of top of the scroll bar and bottom):
![scroll 1](https://github.com/user-attachments/assets/12f2555f-373d-4a22-a35a-bc41a4f62430)
![scroll 2](https://github.com/user-attachments/assets/3874fff7-f972-4dc4-a8cb-e11fdedb4c5a)

Scrolling to the middle (before typing in the "Which lessons have a project" message), I see the view that was screenshot in the eyes test that I thought was wrong but actually is expected:
![before message](https://github.com/user-attachments/assets/13c79e3f-66f8-467a-9445-19ca083ae9d7)
![eyes](https://github.com/user-attachments/assets/574e0bed-9f40-4515-b9f3-a3947620e197)
