### PR TITLE
fix(dahsboard/tests): enable use_transactional_tests

### DIFF
--- a/dashboard/test/controllers/api_controller_test.rb
+++ b/dashboard/test/controllers/api_controller_test.rb
@@ -1141,9 +1141,7 @@ class ApiControllerTest < ActionController::TestCase
   test "should get progress for section with section script" do
     Unit.stubs(:should_cache?).returns true
 
-    # 8 queries from the request + 1 extra query triggered by the lazy transaction.
-    # @see ActiveSupport::Testing::TransactionalTestCase
-    assert_queries 9 do
+    assert_queries 8 do
       get :section_progress, params: {section_id: @flappy_section.id}
     end
     assert_response :success

--- a/dashboard/test/testing/transactional_test_case.rb
+++ b/dashboard/test/testing/transactional_test_case.rb
@@ -9,11 +9,16 @@ module ActiveSupport
       include ActiveSupport::Testing::SetupAllAndTeardownAll
 
       included do
-        class_attribute :db_connection, default: ActiveRecord::Base.connection
+        class_attribute :db_connection
 
-        # Disables transactional tests, which wrap each test in a transaction and reload fixtures per test.
+        # Runs each test inside a database transaction that is rolled back after the test.
+        # @note Enabled by default, but set explicitly to make this behavior clear and ensure it stays enabled.
         # @see https://github.com/rails/rails/blob/v6.1.7.7/activerecord/lib/active_record/test_fixtures.rb
-        self.use_transactional_tests = false
+        self.use_transactional_tests = true
+
+        # Skips per-test fixture loading to reduce database setup overhead.
+        # @note Fixtures are already loaded during test database seeding.
+        self.pre_loaded_fixtures = true
       end
 
       class_methods do
@@ -21,6 +26,8 @@ module ActiveSupport
         # @warning This keeps a transaction open for the whole test class.
         #          Writes from other connections, for example Sequel, can wait on locks or hit a MySQL deadlock.
         private def setup_all(*args, &block)
+          self.db_connection = ActiveRecord::Base.connection
+
           super(*args) do
             db_connection.begin_transaction(joinable: false)
             instance_exec(&block) if block
@@ -30,16 +37,6 @@ module ActiveSupport
             db_connection.rollback_transaction
           end
         end
-      end
-
-      def before_setup
-        db_connection.begin_transaction(joinable: false)
-        super
-      end
-
-      def after_teardown
-        super
-        db_connection.rollback_transaction
       end
     end
   end


### PR DESCRIPTION
Reverting changes at the class level using `setup_all` seems to work fine, but some changes are not being reverted within a single test case. Re-enabling `use_transactional_tests`, which was enabled by default before, restores the previous behavior and should resolve the issue.

## Links
- https://github.com/code-dot-org/code-dot-org/pull/70011
- https://github.com/code-dot-org/code-dot-org/pull/70169
- https://github.com/code-dot-org/code-dot-org/pull/70189