### PR TITLE
Codebridge: fix dragging folder into itself bug

### DIFF
--- a/apps/src/codebridge/utils/dragAndDropUtils.ts
+++ b/apps/src/codebridge/utils/dragAndDropUtils.ts
@@ -143,13 +143,15 @@ export const getHighestPriorityCollision = (
   const dragType = active.data.current?.type;
   const activeId = active.data.current?.id;
   if (dragType === DragType.FOLDER) {
-    // Filter out any attempts to move into a folder that is a child of this folder.
+    // Filter out any attempts to move into a folder that is a child of this folder or into itself.
     const allChildren = getFolderChildren(
       activeId as string,
       Object.values(folders)
     );
     rectangleCollisions = rectangleCollisions.filter(
-      collision => !allChildren.includes(collision.id as string)
+      collision =>
+        !allChildren.includes(collision.id as string) &&
+        collision.id !== activeId
     );
   }
 


### PR DESCRIPTION
@hannahbergam found a bug where if you drag a folder into the spot it previously was, the folder disappears. What was happening was we were assigning the folder to have a parent of itself, which causes it to disappear from view. The quick fix for this is to not allow dragging a folder into itself in our collision detection algorithm. 

## Before

https://github.com/user-attachments/assets/32aaabb7-f2f4-402c-96fd-7efd409ca0f5


## After

https://github.com/user-attachments/assets/7aecb677-5195-472a-848b-8746647379ca


## Links

- Jira: [AFL-421](https://codedotorg.atlassian.net/browse/AFL-421)

## Testing story
Tested locally.



## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
