### PR TITLE
chore(pegasus): change announcement image to studio

### DIFF
--- a/apps/src/templates/studioHomepages/MarketingAnnouncementBanner.jsx
+++ b/apps/src/templates/studioHomepages/MarketingAnnouncementBanner.jsx
@@ -2,7 +2,7 @@ import PropTypes from 'prop-types';
 import React, {useState, useEffect, useRef, useCallback} from 'react';
 
 import Button from '@cdo/apps/legacySharedComponents/Button';
-import {pegasus} from '@cdo/apps/lib/util/urlHelpers';
+import {studio} from '@cdo/apps/lib/util/urlHelpers';
 import {tryGetLocalStorage, trySetLocalStorage} from '@cdo/apps/utils';
 
 import color from '../../util/color';
@@ -93,7 +93,7 @@ const MarketingAnnouncementBanner = ({announcement, marginBottom}) => {
       {/* ID is used for easier targeting in Google Optimize */}
       <div id="special-announcement-action-block" ref={bannerRef}>
         <TwoColumnActionBlock
-          imageUrl={pegasus(announcement.image)}
+          imageUrl={studio(announcement.image)}
           subHeading={announcement.title}
           description={announcement.body}
           buttons={[button]}


### PR DESCRIPTION
All marketing announcements are either located on `/blockly` or `/shared` which are accessible on `studio.code.org`. This change ensures that dashboard images are isolated to dashboard.