### PR TITLE
seeding tools: dependent-destroy course version when destroying unit group

### DIFF
--- a/dashboard/app/models/course_version.rb
+++ b/dashboard/app/models/course_version.rb
@@ -67,14 +67,6 @@ class CourseVersion < ApplicationRecord
   delegate :link, to: :content_root, allow_nil: false
   delegate :localized_assignment_family_title, to: :content_root, allow_nil: false
 
-  before_destroy :ensure_no_resources
-
-  def ensure_no_resources
-    if resources.any? || vocabularies.any? || reference_guides.any?
-      raise ActiveRecord::RecordNotDestroyed, "Cannot delete CourseVersion with resources, vocabularies, or reference guides"
-    end
-  end
-
   # Seeding method for creating / updating / deleting the CourseVersion for the given
   # potential content root, i.e. a UnitGroup.
   #

--- a/dashboard/app/models/course_version.rb
+++ b/dashboard/app/models/course_version.rb
@@ -23,9 +23,9 @@ class CourseVersion < ApplicationRecord
   include Rails.application.routes.url_helpers
 
   belongs_to :course_offering, optional: true
-  has_many :resources
-  has_many :vocabularies
-  has_many :reference_guides
+  has_many :resources, dependent: :destroy
+  has_many :vocabularies, dependent: :destroy
+  has_many :reference_guides, dependent: :destroy
 
   attr_readonly :content_root_id
 

--- a/dashboard/test/models/course_version_test.rb
+++ b/dashboard/test/models/course_version_test.rb
@@ -223,12 +223,21 @@ class CourseVersionTest < ActiveSupport::TestCase
     assert_nil CourseVersion.find_by(course_offering: offering, key: '2050') # old CourseVersion should be deleted
   end
 
-  test "cannot destroy course version if it has resources" do
+  test "destroying course version destroys associated resources" do
     course_version = create(:course_version)
-    create(:resource, course_version: course_version)
-    assert_raises ActiveRecord::RecordNotDestroyed do
-      course_version.destroy_and_destroy_parent_if_empty
-    end
+    resource = create(:resource, course_version: course_version)
+    vocabulary = create(:vocabulary, course_version: course_version)
+    reference_guide = create(:reference_guide, course_version: course_version)
+
+    resource_id = resource.id
+    vocabulary_id = vocabulary.id
+    reference_guide_id = reference_guide.id
+
+    course_version.destroy_and_destroy_parent_if_empty
+
+    assert_nil Resource.find_by(id: resource_id)
+    assert_nil Vocabulary.find_by(id: vocabulary_id)
+    assert_nil ReferenceGuide.find_by(id: reference_guide_id)
   end
 
   test "destroy_and_destroy_parent_if_empty destroys version and offering for offering with one version" do

--- a/dashboard/test/models/unit_group_test.rb
+++ b/dashboard/test/models/unit_group_test.rb
@@ -169,6 +169,7 @@ class UnitGroupTest < ActiveSupport::TestCase
     unit_group.student_resources = [create(:resource, course_version: course_version)]
 
     serialization = unit_group.serialize
+    unit_group.original_units.each {|u| u.update!(original_unit_group: nil)}
     unit_group.destroy
     course_version.destroy
 
@@ -213,6 +214,7 @@ class UnitGroupTest < ActiveSupport::TestCase
     unit_group.resources = [create(:resource, course_version: course_version), create(:resource, course_version: course_version)]
 
     serialization = unit_group.serialize
+    unit_group.original_units.each {|u| u.update!(original_unit_group: nil)}
     unit_group.destroy
     course_version.destroy
 


### PR DESCRIPTION
Sometimes, when modifying ui test courses / units locally, I get into a bad state and want to delete local curriculum objects and reseed. Today this can be quite onerous due to the `ensure_no_resources` check on course version. Currently I do something like this:

```
[development] dashboard >
CourseOffering.find_by_key('ui-test-artist').destroy
Unit.find_by_name('ui-test-artist').destroy
ug = UnitGroup.find_by_name('ui-test-artist')
cv = ug.course_version
cv.resources.destroy_all
cv.vocabularies.destroy_all
cv.destroy
ug.reload
ug.destroy

[13:57:56] Dave-M4:~/src/cdo/dashboard (staging)$ rm config/scripts/.seeded
[13:58:00] Dave-M4:~/src/cdo/dashboard (staging)$ bundle exec rake seed:ui_test
```

If I forget a step, the unit group and course version will sometimes fail to delete with hard-to-decode console output:
```
[development] dashboard > UnitGroup.find_by_name('ui-test-artist').destroy
WARNING: MYSQL_OPT_RECONNECT is deprecated and will be removed in a future version.
  UnitGroup Load (1.4ms)  SELECT `unit_groups`.* FROM `unit_groups` WHERE `unit_groups`.`name` = 'ui-test-artist' LIMIT 1
  TRANSACTION (0.4ms)  BEGIN
  UnitGroupUnit Load (0.5ms)  SELECT `course_scripts`.* FROM `course_scripts` WHERE `course_scripts`.`course_id` = 858 ORDER BY `course_scripts`.`position` ASC
  UnitGroupUnit Destroy (0.3ms)  DELETE FROM `course_scripts` WHERE `course_scripts`.`id` = 1475
  UnitGroupsStudentResource Load (0.9ms)  SELECT `unit_groups_student_resources`.* FROM `unit_groups_student_resources` WHERE `unit_groups_student_resources`.`unit_group_id` = 858
  CourseVersion Load (0.5ms)  SELECT `course_versions`.* FROM `course_versions` WHERE `course_versions`.`content_root_id` = 858 LIMIT 1
  Resource Exists? (1.8ms)  SELECT 1 AS one FROM `resources` WHERE `resources`.`course_version_id` = 881 LIMIT 1
  TRANSACTION (0.4ms)  ROLLBACK
=> false
```

It's not clear why the ensure_no_resources check exists or needs to exist, because we already prevent destructive changes on levelbuilder codepaths via the various checks for `prevent_course_version_change?`.

This PR makes some small but important changes:
- remove `ensure_no_resources` check when destroying course version
- dependent-destroy resources, vocab, and ref guides when destroying course version
- updates existing unit tests to match new behavior

The following dependent-destroy relationship already exists:
- https://github.com/code-dot-org/code-dot-org/blob/3375f084c10c2ac5c51330c6363ab998778d6781/dashboard/app/models/unit_group.rb#L45

## Testing story
- updated existing unit tests to reflect new behavior
- inspected code to verify that all occurrences of deleting course version / unit group are either already protected by `prevent_course_version_change?` check, or are test / migration cleanup pathways where cascading deletes are the desired behavior
- manually verified I can destroy and reseed ui-test-artist course and units (levelbuilder_mode must be disabled):
```
[development] dashboard > 
CourseOffering.find_by_key('ui-test-artist').destroy
Unit.find_by_name('ui-test-artist').destroy
UnitGroup.find_by_name('ui-test-artist').destroy

[13:57:56] Dave-M4:~/src/cdo/dashboard (staging)$ rm config/scripts/.seeded
[13:58:00] Dave-M4:~/src/cdo/dashboard (staging)$ bundle exec rake seed:ui_test
```



## Follow-up work

- Note that the `Unit.find_by_name('ui-test-artist').destroy` step is still necessary because otherwise the unit will have an invalid `original_unit_group_id`. Possible follow-up work would be to experiment with `dependent: :nullify` or another strategy to make sure all unit_group.original_units have their `original_unit_group_id`s nullified.
- eliminate the need to explicitly remove `config/scripts/.seeded`, by looking at `unit.updated_at` instead
