### PR TITLE
Revert "Lab2: use DSCO Modal component in GenericDialog "

### DIFF
--- a/apps/src/lab2/views/dialogs/DialogManager.tsx
+++ b/apps/src/lab2/views/dialogs/DialogManager.tsx
@@ -22,6 +22,8 @@ import {
   DialogClosePromiseReturnType,
 } from './types';
 
+import moduleStyles from './dialog-manager.module.scss';
+
 /**
  * Manages displaying common dialogs for Lab2.
  */
@@ -103,10 +105,12 @@ const DialogManager: React.FunctionComponent<DialogManagerProps> = ({
         setPromiseArgs,
       }}
     >
-      {DialogView && <DialogView {...activeDialog?.dialogArgs} />}
-      {/* Adding inert attribute to disable interaction with underlying content
-          when a dialog is open so keyboard navigation works as expected */}
-      <div {...(DialogView ? {inert: ''} : {})}>{children}</div>
+      {DialogView && (
+        <div className={moduleStyles.dialogContainer}>
+          <DialogView {...activeDialog?.dialogArgs} />
+        </div>
+      )}
+      {children}
     </DialogControlContext.Provider>
   );
 };

--- a/apps/src/lab2/views/dialogs/GenericDialog.tsx
+++ b/apps/src/lab2/views/dialogs/GenericDialog.tsx
@@ -1,9 +1,16 @@
 import Button from '@code-dot-org/component-library/button';
 import {useTheme} from '@code-dot-org/component-library/common/contexts';
-import Modal from '@code-dot-org/component-library/modal';
+import {
+  BodyTwoText,
+  Heading3,
+} from '@code-dot-org/component-library/typography';
+import FocusTrap from 'focus-trap-react';
 import React, {useMemo} from 'react';
 
-import {useEnterKeyboardTrap} from '@cdo/apps/lab2/hooks';
+import {
+  useEnterKeyboardTrap,
+  useEscapeKeyboardTrap,
+} from '@cdo/apps/lab2/hooks';
 import commonI18n from '@cdo/locale';
 
 import {useDialogControl} from './DialogControlContext';
@@ -13,9 +20,15 @@ export type ButtonType = 'confirm' | 'cancel' | 'neutral';
 
 export type dialogCallback = (args?: unknown) => void;
 
-type GenericDialogTitleProps = {
-  title?: string;
-};
+type GenericDialogTitleProps =
+  | {
+      title?: never;
+      titleComponent?: React.ReactNode;
+    }
+  | {
+      title?: string;
+      titleComponent?: never;
+    };
 
 export type GenericDialogBodyProps =
   | {
@@ -43,19 +56,17 @@ export type GenericDialogProps = GenericDialogTitleProps &
 import moduleStyles from './generic-dialog.module.scss';
 
 /**
- * Generic dialog component for Lab2 labs, built on the DSCO Modal component.
- *
- * Supports:
- * - A title string
- * - A message string or custom body component
- * - Up to three buttons: confirm, cancel, and neutral
- *
- * Each button accepts: text, callback, disabled, and destructive flags.
- * The confirm button defaults to "OK" and can be styled as destructive (red).
- * The cancel button defaults to "Cancel" and appears as a secondary button.
- * When all three buttons are present, cancel moves to the bottom content area.
- *
- * Dialogs use DialogControlContext to manage closing behavior.
+ * Generic root dialog used in Lab2 labs.
+ * Allows a title component or title message
+ * a body component or message
+ * a list of up to three buttons - confirm, cancel, neutral
+ * each button takes up to four args - a callback (if not a default will be provided), a label,
+ * a disabled flag, and a destructive flag. The confirm button is the only one that can be destructive,
+ * and it will be styled as such (red) to provide extra visual warning when attempting to delete something.
+ * An accept button is always added, with the default "OK" text if not provided.
+ * dialogs maintain a context, which can provide data to any of the callbacks.
+ * The title, message, and confirm button text can be customized.
+ * If no confirm button text is provided, the default text is "OK" (translatable).
  */
 
 export type GetButtonCallbackArgs = {
@@ -91,6 +102,7 @@ const useButtonCallback = ({
 const GenericDialog: React.FunctionComponent<GenericDialogProps> = ({
   buttons,
   title,
+  titleComponent,
   message,
   bodyComponent,
   getButtonCallback = defaultGetButtonCallback,
@@ -123,50 +135,71 @@ const GenericDialog: React.FunctionComponent<GenericDialogProps> = ({
     getButtonCallback,
   });
 
+  useEscapeKeyboardTrap(cancelCallback);
   useEnterKeyboardTrap(confirmCallback);
 
+  const hasBodyComponent = !!bodyComponent;
+
   return (
-    <Modal
-      title={title}
-      customContent={bodyComponent || message}
-      customBottomContent={
-        buttons?.neutral && buttons?.cancel ? (
-          <Button
-            onClick={cancelCallback}
-            type="secondary"
-            disabled={buttons.cancel.disabled}
-            color={theme === 'Dark' ? 'white' : 'gray'}
-            text={buttons.cancel.text || commonI18n.cancel()}
-          />
-        ) : undefined
-      }
-      onClose={buttons?.cancel ? cancelCallback : undefined}
-      className={moduleStyles.genericDialog}
-      primaryButtonProps={{
-        onClick: confirmCallback,
-        disabled: buttons?.confirm?.disabled,
-        color: buttons?.confirm?.destructive ? 'destructive' : 'purple',
-        text: buttons?.confirm?.text || commonI18n.dialogOK(),
-        id: 'uitest-generic-dialog-ok',
-      }}
-      secondaryButtonProps={
-        buttons?.neutral
-          ? {
-              onClick: neutralCallback,
-              disabled: buttons.neutral.disabled,
-              color: buttons.neutral.destructive ? 'destructive' : 'white',
-              text: buttons.neutral.text,
-            }
-          : buttons?.cancel
-          ? {
-              onClick: cancelCallback,
-              disabled: buttons.cancel.disabled,
-              color: theme === 'Dark' ? 'white' : 'gray',
-              text: buttons.cancel.text || commonI18n.cancel(),
-            }
-          : undefined
-      }
-    />
+    <FocusTrap>
+      <div className={moduleStyles['genericDialog-' + theme]}>
+        {titleComponent ? (
+          titleComponent
+        ) : title ? (
+          <Heading3 className={moduleStyles.title}>{title}</Heading3>
+        ) : null}
+        <div
+          className={
+            hasBodyComponent
+              ? moduleStyles.bodyComponent
+              : moduleStyles.bodyText
+          }
+        >
+          {hasBodyComponent ? (
+            bodyComponent
+          ) : (
+            <BodyTwoText>{message}</BodyTwoText>
+          )}
+        </div>
+        <div className={moduleStyles.buttonContainer}>
+          <div className={moduleStyles.outerButtonContainer}>
+            {buttons?.cancel ? (
+              <Button
+                onClick={cancelCallback}
+                className={moduleStyles.cancel}
+                type="secondary"
+                disabled={buttons.cancel.disabled}
+                color={theme === 'Dark' ? 'white' : 'gray'}
+                text={buttons.cancel.text || commonI18n.cancel()}
+              />
+            ) : (
+              <div />
+            )}
+            <div className={moduleStyles.innerButtonContainer}>
+              {buttons?.neutral && (
+                <Button
+                  onClick={neutralCallback}
+                  type="secondary"
+                  disabled={buttons.neutral.disabled}
+                  color={
+                    buttons?.neutral?.destructive ? 'destructive' : 'white'
+                  }
+                  text={buttons.neutral.text}
+                />
+              )}
+              <Button
+                onClick={confirmCallback}
+                disabled={buttons?.confirm?.disabled}
+                type="primary"
+                color={buttons?.confirm?.destructive ? 'destructive' : 'purple'}
+                text={buttons?.confirm?.text || commonI18n.dialogOK()}
+                id="uitest-generic-dialog-ok"
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+    </FocusTrap>
   );
 };
 

--- a/apps/src/lab2/views/dialogs/PendingDialog.tsx
+++ b/apps/src/lab2/views/dialogs/PendingDialog.tsx
@@ -1,13 +1,22 @@
+import {useTheme} from '@code-dot-org/component-library/common/contexts';
 import FontAwesomeV6Icon from '@code-dot-org/component-library/fontAwesomeV6Icon';
-import Modal from '@code-dot-org/component-library/modal';
-import {BodyTwoText} from '@code-dot-org/component-library/typography';
+import {
+  BodyTwoText,
+  Heading3,
+} from '@code-dot-org/component-library/typography';
 import React from 'react';
 
 export type dialogCallback = (args?: unknown) => void;
 
-type PendingDialogTitleProps = {
-  title?: string;
-};
+type PendingDialogTitleProps =
+  | {
+      title?: never;
+      titleComponent?: React.ReactNode;
+    }
+  | {
+      title?: string;
+      titleComponent?: never;
+    };
 
 type PendingDialogBodyProps =
   | {
@@ -29,12 +38,20 @@ import moduleStyles from './generic-dialog.module.scss';
 
 const PendingDialog: React.FunctionComponent<PendingDialogProps> = ({
   title,
+  titleComponent,
   message,
   bodyComponent,
 }) => {
-  const customContent = (
-    <>
-      {bodyComponent || (message && <BodyTwoText>{message}</BodyTwoText>)}
+  const {theme} = useTheme();
+  const hasBodyComponent = !!bodyComponent;
+  return (
+    <div className={moduleStyles['genericDialog-' + theme]}>
+      {titleComponent ? (
+        titleComponent
+      ) : title ? (
+        <Heading3 className={moduleStyles.title}>{title}</Heading3>
+      ) : null}
+      {hasBodyComponent ? bodyComponent : <BodyTwoText>{message}</BodyTwoText>}
       <div className={moduleStyles.spinnerContainer}>
         <FontAwesomeV6Icon
           iconName="spinner"
@@ -42,16 +59,7 @@ const PendingDialog: React.FunctionComponent<PendingDialogProps> = ({
           className={moduleStyles.spinnerIcon}
         />
       </div>
-    </>
-  );
-
-  return (
-    <Modal
-      title={title}
-      customContent={customContent}
-      className={moduleStyles.genericDialog}
-      primaryButtonProps={{isPending: true, text: 'Loading', onClick: () => {}}}
-    />
+    </div>
   );
 };
 

--- a/apps/src/lab2/views/dialogs/dialog-manager.module.scss
+++ b/apps/src/lab2/views/dialogs/dialog-manager.module.scss
@@ -1,0 +1,13 @@
+@import 'color.scss';
+@import '../common.scss';
+
+.dialogContainer {
+  @extend %full-container-overlay;
+}
+
+%dialog {
+  background-color: $neutral_light;
+  border-radius: 5px;
+  padding: 36px 56px 40px;
+  width: 600px;
+}

--- a/apps/src/lab2/views/dialogs/generic-dialog.module.scss
+++ b/apps/src/lab2/views/dialogs/generic-dialog.module.scss
@@ -1,10 +1,62 @@
-.genericDialog {
-  font-size: 1rem;
+@import './dialog-manager.module.scss';
 
-  // Add padding around labels inside the dialog so the focus
-  // state styles are not cut off when elements are focused.
-  label {
-    padding: 0.25rem;
+%generic-dialog {
+  @extend %dialog;
+  display: flex;
+  flex-direction: column;
+}
+
+.genericDialog-Dark {
+  @extend %generic-dialog;
+  background-color: $light_gray_950;
+
+  // override any foreground text in the dialog that might be
+  // passed in for the title or body of the dialog
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6,
+  strong {
+    color: var(--text-neutral-primary);
+  }
+  p {
+    color: var(--text-neutral-secondary);
+  }
+}
+
+.genericDialog-Light {
+  @extend %generic-dialog;
+}
+
+.title {
+  padding: 0;
+  margin-bottom: 8px;
+}
+
+.bodyText {
+  padding-top: 12px;
+  padding-bottom: 8px;
+}
+
+.bodyComponent {
+  padding-bottom: 12px;
+}
+
+.buttonContainer {
+  .outerButtonContainer {
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+    margin-top: 16px;
+
+    .innerButtonContainer {
+      display: flex;
+      flex-direction: row;
+      justify-content: space-between;
+      gap: 10px;
+    }
   }
 }
 
@@ -17,5 +69,5 @@
 
 .spinnerIcon {
   font-size: 36px;
-  color: var(--text-neutral-primary);
+  color: var(--neutral-base-white);
 }


### PR DESCRIPTION
Reverts code-dot-org/code-dot-org#70233

There's an issue with the keyboard navigation firing the confirmation action on Cancel, see this Slack [thread](https://codedotorg.slack.com/archives/C03DBDN67B7/p1768258137319649).