### PR TITLE
Backpack v2: improvements

### DIFF
--- a/apps/src/lab2/views/components/Instructions/ResourcePanel/Backpack/BackpackFileChip.tsx
+++ b/apps/src/lab2/views/components/Instructions/ResourcePanel/Backpack/BackpackFileChip.tsx
@@ -1,6 +1,7 @@
 import {Button} from '@code-dot-org/component-library/button';
 import {ActionDropdown} from '@code-dot-org/component-library/dropdown';
 import FontAwesomeV6Icon from '@code-dot-org/component-library/fontAwesomeV6Icon';
+import Tags from '@code-dot-org/component-library/tags';
 import {
   BodyFourText,
   BodyThreeText,
@@ -28,6 +29,7 @@ interface BackpackFileChipProps extends BackpackProps {
   fileName: string;
   backpackApi: BackpackClientApi;
   addAlert: (type: 'success' | 'danger', message: string) => void;
+  isRecentlyAdded?: boolean;
 }
 
 // TODO: add statsig logging
@@ -39,6 +41,7 @@ const BackpackFileChip: React.FC<BackpackFileChipProps> = ({
   saveFile,
   createNewFile,
   findIdForFileName,
+  isRecentlyAdded,
 }) => {
   const fileExtension = fileName.split('.').pop()?.toUpperCase();
   const fileIcon = useMemo(
@@ -149,15 +152,29 @@ const BackpackFileChip: React.FC<BackpackFileChipProps> = ({
         </BodyFourText>
       </div>
       <div className={moduleStyles.fileActions}>
-        <Button
-          size="xs"
-          isIconOnly
-          icon={{iconName: 'plus'}}
-          color="gray"
-          type="secondary"
-          onClick={handleAdd}
-          disabled={addButtonDisabled}
-        />
+        {isRecentlyAdded ? (
+          <Tags
+            tagsList={[
+              {
+                tooltipId: `${fileName}-recently-added`,
+                label: 'Added',
+                tooltipContent: 'Added',
+                icon: {iconName: 'check', placement: 'left'},
+              },
+            ]}
+            size="s"
+          />
+        ) : (
+          <Button
+            size="xs"
+            isIconOnly
+            icon={{iconName: 'plus'}}
+            color="gray"
+            type="secondary"
+            onClick={handleAdd}
+            disabled={addButtonDisabled}
+          />
+        )}
         <ActionDropdown
           name={`backpack-options-${fileName}`}
           options={[

--- a/apps/src/lab2/views/components/Instructions/ResourcePanel/Backpack/BackpackFileChip.tsx
+++ b/apps/src/lab2/views/components/Instructions/ResourcePanel/Backpack/BackpackFileChip.tsx
@@ -2,6 +2,7 @@ import {Button} from '@code-dot-org/component-library/button';
 import {ActionDropdown} from '@code-dot-org/component-library/dropdown';
 import FontAwesomeV6Icon from '@code-dot-org/component-library/fontAwesomeV6Icon';
 import Tags from '@code-dot-org/component-library/tags';
+import {WithTooltip} from '@code-dot-org/component-library/tooltip';
 import {
   BodyFourText,
   BodyThreeText,
@@ -60,6 +61,9 @@ const BackpackFileChip: React.FC<BackpackFileChipProps> = ({
   const dialogControl = useDialogControl();
   // If we are in read-only mode, disable the add button.
   const addButtonDisabled = useAppSelector(isReadOnlyWorkspace);
+  const addButtonTooltipText = addButtonDisabled
+    ? 'Cannot add files in read-only mode'
+    : 'Add to project';
 
   const handleAdd = async () => {
     const {isSupportFileName, newFileName} = validateFileName(fileName);
@@ -165,15 +169,26 @@ const BackpackFileChip: React.FC<BackpackFileChipProps> = ({
             size="s"
           />
         ) : (
-          <Button
-            size="xs"
-            isIconOnly
-            icon={{iconName: 'plus'}}
-            color="gray"
-            type="secondary"
-            onClick={handleAdd}
-            disabled={addButtonDisabled}
-          />
+          <WithTooltip
+            tooltipProps={{
+              text: addButtonTooltipText,
+              tooltipId: `${fileName}-add-button-tooltip`,
+              direction: 'onTop',
+              size: 'xs',
+            }}
+          >
+            <div>
+              <Button
+                size="xs"
+                isIconOnly
+                icon={{iconName: 'plus'}}
+                color="gray"
+                type="secondary"
+                onClick={handleAdd}
+                disabled={addButtonDisabled}
+              />
+            </div>
+          </WithTooltip>
         )}
         <ActionDropdown
           name={`backpack-options-${fileName}`}

--- a/apps/src/lab2/views/components/Instructions/ResourcePanel/Backpack/BackpackPanel.tsx
+++ b/apps/src/lab2/views/components/Instructions/ResourcePanel/Backpack/BackpackPanel.tsx
@@ -57,10 +57,15 @@ const BackpackPanel: React.FC<BackpackProps> = ({
     loadBackpackFiles(true);
     // Subscribe to backpack changes. Always reload when notified, as we get notified for file
     // adds or deletes.
-    backpackApi?.addEventListener(() => {
+    const listenerId = backpackApi?.addEventListener(() => {
       // We don't show the load view here to avoid the screen flickering when the backpack updates.
       loadBackpackFiles(false);
     });
+    return () => {
+      if (listenerId) {
+        backpackApi?.removeEventListener(listenerId);
+      }
+    };
   }, [loadBackpackFiles, backpackApi]);
 
   if (!backpackApi) {

--- a/apps/src/lab2/views/components/Instructions/ResourcePanel/Backpack/BackpackPanel.tsx
+++ b/apps/src/lab2/views/components/Instructions/ResourcePanel/Backpack/BackpackPanel.tsx
@@ -5,6 +5,7 @@ import React, {useCallback, useEffect, useState} from 'react';
 import Lab2Registry from '@cdo/apps/lab2/Lab2Registry';
 import {BackpackProps} from '@cdo/apps/lab2/views/components/Instructions/ResourcePanel';
 import {useBackpackAPIContext} from '@cdo/apps/sharedComponents/backpack/BackpackAPIContext';
+import {BackpackEvent} from '@cdo/apps/sharedComponents/backpack/BackpackClientApi';
 import {useAppSelector} from '@cdo/apps/util/reduxHooks';
 
 import BackpackFileChip from './BackpackFileChip';
@@ -57,9 +58,15 @@ const BackpackPanel: React.FC<BackpackProps> = ({
     loadBackpackFiles(true);
     // Subscribe to backpack changes. Always reload when notified, as we get notified for file
     // adds or deletes.
-    const listenerId = backpackApi?.addEventListener(() => {
+    const listenerId = backpackApi?.addEventListener(event => {
       // We don't show the load view here to avoid the screen flickering when the backpack updates.
       loadBackpackFiles(false);
+      if (event === BackpackEvent.FileAdded) {
+        setAlertList(prevAlerts => [
+          ...prevAlerts,
+          {type: 'success', message: 'File successfully saved to Backpack!'},
+        ]);
+      }
     });
     return () => {
       if (listenerId) {

--- a/apps/src/lab2/views/components/Instructions/ResourcePanel/Backpack/BackpackPanel.tsx
+++ b/apps/src/lab2/views/components/Instructions/ResourcePanel/Backpack/BackpackPanel.tsx
@@ -13,6 +13,8 @@ import BackpackMessage from './BackpackMessage';
 
 import moduleStyles from './backpack-panel.module.scss';
 
+const SHOW_RECENTLY_ADDED_DURATION_MS = 3000;
+
 const BackpackPanel: React.FC<BackpackProps> = ({
   validateFileName,
   saveFile,
@@ -27,6 +29,7 @@ const BackpackPanel: React.FC<BackpackProps> = ({
   const [alertList, setAlertList] = useState<
     {type: 'success' | 'danger'; message: string}[]
   >([]);
+  const [recentlyAddedFiles, setRecentlyAddedFiles] = useState<string[]>([]);
 
   const loadBackpackFiles = useCallback(
     (showLoading: boolean) => {
@@ -58,14 +61,23 @@ const BackpackPanel: React.FC<BackpackProps> = ({
     loadBackpackFiles(true);
     // Subscribe to backpack changes. Always reload when notified, as we get notified for file
     // adds or deletes.
-    const listenerId = backpackApi?.addEventListener(event => {
+    const listenerId = backpackApi?.addEventListener((event, filename) => {
       // We don't show the load view here to avoid the screen flickering when the backpack updates.
       loadBackpackFiles(false);
       if (event === BackpackEvent.FileAdded) {
         setAlertList(prevAlerts => [
           ...prevAlerts,
-          {type: 'success', message: 'File successfully saved to Backpack!'},
+          {
+            type: 'success',
+            message: `${filename} successfully saved to Backpack!`,
+          },
         ]);
+        setRecentlyAddedFiles(prevFiles => [...prevFiles, filename]);
+        setTimeout(() => {
+          setRecentlyAddedFiles(prevFiles =>
+            prevFiles.filter(file => file !== filename)
+          );
+        }, SHOW_RECENTLY_ADDED_DURATION_MS);
       }
     });
     return () => {
@@ -163,6 +175,7 @@ const BackpackPanel: React.FC<BackpackProps> = ({
           saveFile={saveFile}
           createNewFile={createNewFile}
           findIdForFileName={findIdForFileName}
+          isRecentlyAdded={recentlyAddedFiles.includes(fileName)}
         />
       ))}
     </div>

--- a/apps/src/lab2/views/components/Instructions/ResourcePanel/Backpack/BackpackPanel.tsx
+++ b/apps/src/lab2/views/components/Instructions/ResourcePanel/Backpack/BackpackPanel.tsx
@@ -69,9 +69,10 @@ const BackpackPanel: React.FC<BackpackProps> = ({
           ...prevAlerts,
           {
             type: 'success',
-            message: `${filename} successfully saved to Backpack!`,
+            message: `${filename} successfully saved to your Backpack!`,
           },
         ]);
+        // Show that the file was recently added for SHOW_RECENTLY_ADDED_DURATION_MS milliseconds.
         setRecentlyAddedFiles(prevFiles => [...prevFiles, filename]);
         setTimeout(() => {
           setRecentlyAddedFiles(prevFiles =>

--- a/apps/src/sharedComponents/backpack/BackpackClientApi.ts
+++ b/apps/src/sharedComponents/backpack/BackpackClientApi.ts
@@ -21,7 +21,7 @@ const rootUrl = (channelId: string) => `/v3/libraries/${channelId}`;
 const getCacheBustSuffix = () => `?t=${Date.now()}`;
 
 // Events that can a listener can subscribe to.
-enum BackpackEvent {
+export enum BackpackEvent {
   FileAdded = 'fileAdded',
   FileDeleted = 'fileDeleted',
 }

--- a/apps/src/sharedComponents/backpack/BackpackClientApi.ts
+++ b/apps/src/sharedComponents/backpack/BackpackClientApi.ts
@@ -25,7 +25,7 @@ export enum BackpackEvent {
   FileAdded = 'fileAdded',
   FileDeleted = 'fileDeleted',
 }
-type BackpackEventListener = (event: BackpackEvent) => void;
+type BackpackEventListener = (event: BackpackEvent, filename: string) => void;
 
 export default class BackpackClientApi {
   appType: string;
@@ -205,7 +205,7 @@ export default class BackpackClientApi {
       return;
     }
     Object.values(this.eventListeners).forEach(listener =>
-      listener(BackpackEvent.FileAdded)
+      listener(BackpackEvent.FileAdded, filename)
     );
     onSuccess();
   }
@@ -412,10 +412,12 @@ export default class BackpackClientApi {
     if (filenameIndex >= 0) {
       filesInRequest.splice(filenameIndex, 1);
     }
-    if (filesInRequest.length === 0 && failedFileList.length === 0) {
+    if (!failedFileList.includes(filename)) {
       Object.values(this.eventListeners).forEach(listener =>
-        listener(requestType)
+        listener(requestType, filename)
       );
+    }
+    if (filesInRequest.length === 0 && failedFileList.length === 0) {
       onSuccess();
     } else if (filesInRequest.length === 0) {
       onError(error, failedFileList);

--- a/apps/src/sharedComponents/backpack/BackpackClientApi.ts
+++ b/apps/src/sharedComponents/backpack/BackpackClientApi.ts
@@ -1,4 +1,5 @@
 import HttpClient from '@cdo/apps/util/HttpClient';
+import {createUuid} from '@cdo/apps/utils';
 
 const REQUEST_RETRY_COUNT = 1;
 
@@ -34,7 +35,7 @@ export default class BackpackClientApi {
   fileUploadsFailed: string[];
   fileDeletesInProgress: string[];
   fileDeletesFailed: string[];
-  eventListeners: BackpackEventListener[];
+  eventListeners: {[key: string]: BackpackEventListener};
 
   constructor(appType: string, channelId: string | null) {
     this.appType = appType;
@@ -44,7 +45,7 @@ export default class BackpackClientApi {
     this.fileUploadsFailed = [];
     this.fileDeletesInProgress = [];
     this.fileDeletesFailed = [];
-    this.eventListeners = [];
+    this.eventListeners = {};
   }
 
   hasBackpack() {
@@ -203,7 +204,9 @@ export default class BackpackClientApi {
       onError(error as Error);
       return;
     }
-    this.eventListeners.forEach(listener => listener(BackpackEvent.FileAdded));
+    Object.values(this.eventListeners).forEach(listener =>
+      listener(BackpackEvent.FileAdded)
+    );
     onSuccess();
   }
 
@@ -410,7 +413,9 @@ export default class BackpackClientApi {
       filesInRequest.splice(filenameIndex, 1);
     }
     if (filesInRequest.length === 0 && failedFileList.length === 0) {
-      this.eventListeners.forEach(listener => listener(requestType));
+      Object.values(this.eventListeners).forEach(listener =>
+        listener(requestType)
+      );
       onSuccess();
     } else if (filesInRequest.length === 0) {
       onError(error, failedFileList);
@@ -418,6 +423,14 @@ export default class BackpackClientApi {
   }
 
   addEventListener(listener: BackpackEventListener) {
-    this.eventListeners.push(listener);
+    const id = createUuid();
+    this.eventListeners[id] = listener;
+    return id;
+  }
+
+  removeEventListener(id: string) {
+    if (this.eventListeners[id]) {
+      delete this.eventListeners[id];
+    }
   }
 }


### PR DESCRIPTION
More follow-ups to #70272:
- When a file is added to the backpack, show a success message at the top of the panel.
- When a file is added to the backpack, show an "Added" tag for 3 seconds before converting it to the "add to project" button.
- Add a tooltip to the add to project button
- Update the backpack event listener to support the added tag by including the filename that was added/deleted. In addition, update the event listener api to support removing an event listener on unmount.

## Screenshots/Screen recordings

### Adding a file to the backpack (new alert + tag)

https://github.com/user-attachments/assets/894604a5-2fbb-4454-ae1d-fdbee153da87

### Add to project tooltip
<img width="267" height="124" alt="Screenshot 2026-01-12 at 3 44 41 PM" src="https://github.com/user-attachments/assets/6cc302c9-e567-44fb-bcc9-19fe09e67456" />

### Add to project disabled tooltip
For now, this is only disabled in read-only. When we expand the backpack to support sketch lab there will also be a disabled case where the file type is not supported. The tooltip will be updated at that point to have an additional case for the text.
<img width="381" height="124" alt="Screenshot 2026-01-12 at 3 45 05 PM" src="https://github.com/user-attachments/assets/1dffdac1-8e02-4390-8cf3-5cd503851332" />


## Links

- Jira: [AFL-416](https://codedotorg.atlassian.net/browse/AFL-416)

## Testing story
Tested locally.



## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
