### PR TITLE
Publish Puma Listener Metrics by EC2 Instance ID

### DIFF
--- a/lib/cdo/app_server_metrics.rb
+++ b/lib/cdo/app_server_metrics.rb
@@ -35,6 +35,11 @@ module Cdo
       @namespace = opts[:namespace] || 'App Server'
       @dimensions = opts[:dimensions] || {}
       @interval = opts[:interval] || 1
+      @instance_id = begin
+        AWS::EC2.instance_id
+      rescue
+        nil
+      end
       self.instance = self
     end
 
@@ -56,6 +61,15 @@ module Cdo
           name,
           value,
           @dimensions,
+          storage_resolution: 1,
+          unit: 'Count'
+        )
+        # Also publish active/queued/calling listener metrics with an EC2 Instance ID Dimension.
+        Cdo::Metrics.put(
+          @namespace,
+          name,
+          value,
+          @dimensions.merge(InstanceId: @instance_id),
           storage_resolution: 1,
           unit: 'Count'
         )
@@ -85,10 +99,7 @@ module Cdo
           Host: host,
         }
 
-        begin
-          dimensions[:InstanceId] = AWS::EC2.instance_id
-        rescue
-        end
+        dimensions[:InstanceId] = @instance_id
 
         loop do
           Cdo::Metrics.put(

--- a/lib/test/cdo/test_app_server_metrics.rb
+++ b/lib/test/cdo/test_app_server_metrics.rb
@@ -27,14 +27,30 @@ class AppServerMetricsTest < Minitest::Test
 
   def expect_metrics(*metrics)
     @sequence ||= sequence('metrics')
+    # Define the ID we expect to see.
+    # Must match the value stubbed in the test method below.
+    expected_instance_id = 'i-12345678'
+
     metrics.each do |name, value|
+      # Expect app server metrics published with Dimensions for the current environment/site.
       Cdo::Metrics.expects(:put).with(
         "App Server", name, value, {}, {storage_resolution: 1, unit: 'Count'}
+      ).in_sequence(@sequence)
+
+      # Expect app server metrics published with Dimensions for the current environment/site AND current EC2 Instance ID.
+      Cdo::Metrics.expects(:put).with(
+        "App Server",
+        name,
+        value,
+        {InstanceId: expected_instance_id},
+        {storage_resolution: 1, unit: 'Count'}
       ).in_sequence(@sequence)
     end
   end
 
   def test_app_server_metrics
+    AWS::EC2.stubs(:instance_id).returns('i-12345678')
+
     Raindrops::Linux.expects(:tcp_listener_stats).
       with([TCP_LISTENER]).times(2).
       returns(


### PR DESCRIPTION
https://codedotorg.atlassian.net/browse/INF-1793

Help identify whether a subset of EC2 Instances is experiencing request processing latency within `puma` by publishing puma active/calling/queued HTTP request metrics by Instance ID in addition to per system.

## Testing story
`bundle exec rake adhoc:start RAILS_ENV=adhoc STACK_NAME=adhoc-puma-metrics-instance-id`

<img width="1690" height="715" alt="image" src="https://github.com/user-attachments/assets/d1d26579-ef30-4ac3-9fee-a05991d7eb34" />



## Deployment strategy
<!--  Any special steps required to deploy this, besides merging?
      - Are there database migrations or manual steps?
      - Does this require coordination with other teams or systems? -->



## Follow-up work
<!--  List any clean-up or technical debt that will be addressed in future work.
      - Include Jira links where applicable.
      - Are there any known limitations or improvements planned? -->



## Privacy
<!--  How does this change impact Student & Teacher privacy?
      - Does this collect, use, share, or modify PII, either new or existing? -->



## Security
<!--  How does this change impact our security surface-area?
      - Do API's touched have the right auth?
      - Do infra changes impact our attack surface or encryption?
-->



## Caching
<!--  How does this change impact caching behavior?
      - Are cache keys or invalidation strategies affected?
      - Will this require cache warming or invalidation after deployment? -->



## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
