### PR TITLE
[DO NOT MERGE] POC: unified source management in Lab2

### DIFF
--- a/apps/src/lab2/lab2Redux.ts
+++ b/apps/src/lab2/lab2Redux.ts
@@ -169,7 +169,11 @@ export const setUpWithLevel = createAsyncThunk<
       }
     }
 
-    if (!levelProperties.usesProjects) {
+    // Skipping for sketchlab for demo purposes
+    if (
+      !levelProperties.usesProjects ||
+      levelProperties.appName === 'sketchlab'
+    ) {
       // If projects are disabled on this level, we can skip loading projects data.
       setProjectAndLevelData(
         {levelProperties},

--- a/apps/src/lab2/projects/ProjectManager.ts
+++ b/apps/src/lab2/projects/ProjectManager.ts
@@ -229,16 +229,13 @@ export default class ProjectManager {
    * @returns a promise that resolves to a Response. If the save is successful, the response
    * will be empty, otherwise it will contain failure information.
    */
-  async flushSave() {
+  async flushSave(forceNewVersion = false) {
     if (this.destroyed) {
       // If we have already been destroyed, don't attempt to save.
       this.resetSaveState();
       return this.getNoopResponseAndSendSaveNoopEvent();
     }
-    return await this.enqueueSaveOrSave(
-      /* forceSave */ true,
-      /* forceNewVersion */ false
-    );
+    return await this.enqueueSaveOrSave(/* forceSave */ true, forceNewVersion);
   }
 
   /**

--- a/apps/src/lab2/projects/unified-poc/configureHeader.ts
+++ b/apps/src/lab2/projects/unified-poc/configureHeader.ts
@@ -1,0 +1,28 @@
+import header from '@cdo/apps/code-studio/header';
+
+import {LevelProperties} from '../../types';
+
+export default function configureHeader(
+  isOwner: boolean,
+  levelProperties: LevelProperties
+) {
+  const hideShareAndRemix = levelProperties.hideShareAndRemix !== false;
+  const isProjectLevel = levelProperties.isProjectLevel;
+  if (isOwner) {
+    if (isProjectLevel) {
+      // Standalone projects see project header (includes rename option).
+      // Standalone projects always show share and remix.
+      header.showProjectHeader();
+    } else {
+      // Project backed levels see project backed header, which can
+      // conditionally show share and remix.
+      header.showHeaderForProjectBacked({
+        showShareAndRemix: !hideShareAndRemix,
+      });
+    }
+  } else if (isProjectLevel) {
+    // If we are viewing another user's project, and this is a standalone
+    // project, show the minimal project header (project name and remix button).
+    header.showMinimalProjectHeader();
+  }
+}

--- a/apps/src/lab2/projects/unified-poc/demoVersionHistory/DemoVersionHistory.tsx
+++ b/apps/src/lab2/projects/unified-poc/demoVersionHistory/DemoVersionHistory.tsx
@@ -1,0 +1,101 @@
+import {Button} from '@code-dot-org/component-library/button';
+import React, {useState} from 'react';
+
+import {ProjectVersion} from '../../../types';
+
+import styles from './styles.module.scss';
+
+interface Props {
+  isLoading: boolean;
+  isEditable: boolean;
+  versionList: ProjectVersion[];
+  currentVersion: string | undefined;
+  previewVersion: (version: string) => void;
+  restoreVersion: (version: string) => void;
+  createCommit: (description: string) => void;
+}
+
+/** Low-fidelity version history to demonstrate usage of useSources hook. NOT meant to replace VersionHistoryPanel.tsx */
+const DemoVersionHistory: React.FC<Props> = ({
+  isLoading,
+  isEditable,
+  versionList,
+  currentVersion,
+  previewVersion,
+  restoreVersion,
+  createCommit,
+}) => {
+  const [commitMessage, setCommitMessage] = useState('');
+  return (
+    <div className={styles.container}>
+      <h3>Demo Version History</h3>
+      <p>
+        using <code>useSources</code> hook
+      </p>
+      <div className={styles.row}>
+        Loading:{' '}
+        <p className={isLoading ? styles.green : styles.red}>
+          {isLoading ? 'true' : 'false'}
+        </p>
+      </div>
+      <div className={styles.row}>
+        Editable:{' '}
+        <p className={isEditable ? styles.green : styles.red}>
+          {isEditable ? 'true' : 'false'}
+        </p>
+      </div>
+      {versionList.map(({versionId, isLatest, comment, lastModified}) => {
+        const isCurrent = currentVersion === versionId;
+        return (
+          <div className={styles.version} key={versionId}>
+            {lastModified && <p>{new Date(lastModified).toLocaleString()}</p>}
+            {isLatest && <p className={styles.green}>Latest</p>}
+            {isCurrent && <p className={styles.green}>Current</p>}
+            {comment && <p>{comment}</p>}
+            <div className={styles.row}>
+              <Button
+                size="xs"
+                onClick={() => previewVersion(versionId)}
+                text={isCurrent ? 'Viewing' : 'View'}
+                iconLeft={{iconName: isCurrent ? 'check' : 'eye'}}
+                type="secondary"
+                disabled={isLoading || isCurrent}
+              />
+              {isCurrent && !isLatest && (
+                <Button
+                  size="xs"
+                  onClick={() => restoreVersion(versionId)}
+                  text={'Restore'}
+                  iconLeft={{iconName: 'arrow-rotate-left'}}
+                  disabled={isLoading}
+                />
+              )}
+            </div>
+            {isLatest && isCurrent && !comment && (
+              <>
+                <textarea
+                  placeholder="Enter commit message"
+                  value={commitMessage}
+                  onChange={e => setCommitMessage(e.target.value)}
+                  disabled={isLoading}
+                />
+                <Button
+                  size="xs"
+                  onClick={() => {
+                    createCommit(commitMessage);
+                    setCommitMessage('');
+                  }}
+                  text={'Commit'}
+                  iconLeft={{iconName: 'file'}}
+                  disabled={isLoading || !commitMessage}
+                />
+              </>
+            )}
+          </div>
+        );
+      })}
+    </div>
+  );
+};
+
+export default DemoVersionHistory;

--- a/apps/src/lab2/projects/unified-poc/demoVersionHistory/DemoVersionHistory.tsx
+++ b/apps/src/lab2/projects/unified-poc/demoVersionHistory/DemoVersionHistory.tsx
@@ -8,6 +8,7 @@ import styles from './styles.module.scss';
 interface Props {
   isLoading: boolean;
   isEditable: boolean;
+  hasEdited: boolean;
   versionList: ProjectVersion[];
   currentVersion: string | undefined;
   previewVersion: (version: string) => void;
@@ -24,6 +25,7 @@ const DemoVersionHistory: React.FC<Props> = ({
   previewVersion,
   restoreVersion,
   createCommit,
+  hasEdited,
 }) => {
   const [commitMessage, setCommitMessage] = useState('');
   return (
@@ -32,18 +34,9 @@ const DemoVersionHistory: React.FC<Props> = ({
       <p>
         using <code>useSources</code> hook
       </p>
-      <div className={styles.row}>
-        Loading:{' '}
-        <p className={isLoading ? styles.green : styles.red}>
-          {isLoading ? 'true' : 'false'}
-        </p>
-      </div>
-      <div className={styles.row}>
-        Editable:{' '}
-        <p className={isEditable ? styles.green : styles.red}>
-          {isEditable ? 'true' : 'false'}
-        </p>
-      </div>
+      <BooleanDisplay label="Loading" value={isLoading} />
+      <BooleanDisplay label="Editable" value={isEditable} />
+      <BooleanDisplay label="Has Edited" value={hasEdited} />
       {versionList.map(({versionId, isLatest, comment, lastModified}) => {
         const isCurrent = currentVersion === versionId;
         return (
@@ -71,7 +64,7 @@ const DemoVersionHistory: React.FC<Props> = ({
                 />
               )}
             </div>
-            {isLatest && isCurrent && !comment && (
+            {isLatest && isCurrent && hasEdited && (
               <>
                 <textarea
                   placeholder="Enter commit message"
@@ -97,5 +90,17 @@ const DemoVersionHistory: React.FC<Props> = ({
     </div>
   );
 };
+
+const BooleanDisplay: React.FC<{label: string; value: boolean}> = ({
+  label,
+  value,
+}) => (
+  <div className={styles.row}>
+    {label}:
+    <p className={value ? styles.green : styles.red}>
+      {value ? 'true' : 'false'}
+    </p>
+  </div>
+);
 
 export default DemoVersionHistory;

--- a/apps/src/lab2/projects/unified-poc/demoVersionHistory/styles.module.scss
+++ b/apps/src/lab2/projects/unified-poc/demoVersionHistory/styles.module.scss
@@ -1,0 +1,52 @@
+.container {
+  display: flex;
+  flex-direction: column;
+  padding: 12px;
+  gap: 8px;
+  border: 1px solid var(--borders-neutral-primary);
+  overflow-y: auto;
+  width: 290px;
+}
+
+h3 {
+  white-space: nowrap;
+}
+
+.row {
+  display: flex;
+  flex-direction: row;
+  gap: 8px;
+  button {
+    flex: 1;
+  }
+}
+
+.green {
+  color: var(--text-success-primary);
+}
+.red {
+  color: var(--text-error-primary);
+}
+
+h3,
+p {
+  margin: 0;
+}
+
+.version {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  border: 1px solid var(--borders-neutral-primary);
+  padding: 8px;
+
+  .id {
+    font-size: 10px;
+  }
+
+  textarea {
+    width: auto;
+    resize: none;
+    margin: 0;
+  }
+}

--- a/apps/src/lab2/projects/unified-poc/multiFile/multiFileUtils.ts
+++ b/apps/src/lab2/projects/unified-poc/multiFile/multiFileUtils.ts
@@ -1,0 +1,83 @@
+/**
+ * Example of a few utility function to handle more complex multi-file scenarios (adapted from lab2ProjectRedux)
+ *
+ * Sample Usage:
+ *
+ * const {currentSource, updateSources} = useSource<MultiFileProjectSources>({levelProperties: ..., ...});
+ *
+ * const onRenameClick = (fileId: string, newName: string) => {
+ *   renameFile(fileId, newName, currentSource, updateSources);
+ * }
+ *
+ * const onMoveFolderClick = (folderId: FolderId, parentId: FolderId) => {
+ *   moveFolder(folderId, parentId, currentSource, updateSources);
+ * }
+ */
+
+import {FolderId, MultiFileSource, ProjectSources} from '@cdo/apps/lab2/types';
+
+interface MultiFileProjectSources extends ProjectSources {
+  source: MultiFileSource;
+}
+
+export function renameFile(
+  fileId: string,
+  newName: string,
+  currentSources: MultiFileProjectSources,
+  updateSources: (
+    newSources: MultiFileProjectSources,
+    forceSave?: boolean
+  ) => void
+) {
+  const source = currentSources.source;
+  if (!source.files[fileId] || source.files[fileId]?.name === newName) {
+    // No-op if the name is the same or the file does not exist.
+    return;
+  }
+  updateSources({
+    ...currentSources,
+    source: {
+      ...source,
+      files: {
+        ...source.files,
+        [fileId]: {
+          ...source.files[fileId],
+          name: newName,
+          language: newName.split('.').pop()?.toLowerCase() || '',
+        },
+      },
+    },
+  });
+}
+
+export function moveFolder(
+  folderId: FolderId,
+  parentId: FolderId,
+  currentSources: MultiFileProjectSources,
+  updateSources: (
+    newSources: MultiFileProjectSources,
+    forceSave?: boolean
+  ) => void
+) {
+  const source = currentSources.source;
+  if (
+    !source.folders[folderId] ||
+    source.folders[folderId].parentId === parentId
+  ) {
+    // No-op if the folder does not exist or is already in the target parent.
+    return;
+  }
+  updateSources({
+    ...currentSources,
+    source: {
+      ...source,
+      folders: {
+        ...source.folders,
+        [folderId]: {
+          ...source.folders[folderId],
+          parentId: parentId,
+        },
+      },
+    },
+  });
+}

--- a/apps/src/lab2/projects/unified-poc/setProjectCallbacks.ts
+++ b/apps/src/lab2/projects/unified-poc/setProjectCallbacks.ts
@@ -1,0 +1,41 @@
+import {
+  setProjectUpdatedAt,
+  setProjectUpdatedError,
+  setProjectUpdatedSaved,
+  setProjectUpdatedSaving,
+} from '@cdo/apps/code-studio/projectRedux';
+import {AppDispatch} from '@cdo/apps/util/reduxHooks';
+
+import {setChannel} from '../../lab2Redux';
+import {setProjectTooLarge} from '../../redux/lab2ProjectRedux';
+import ProjectManager from '../ProjectManager';
+
+export default function setProjectCallbacks(
+  projectManager: ProjectManager,
+  dispatch: AppDispatch
+) {
+  projectManager.addSaveStartListener(() =>
+    dispatch(setProjectUpdatedSaving())
+  );
+  projectManager.addSaveSuccessListener(channel => {
+    dispatch(setProjectUpdatedAt(channel.updatedAt));
+    dispatch(setChannel(channel));
+    // If we had a successful save, we know the project is not too large.
+    dispatch(setProjectTooLarge(false));
+  });
+  projectManager.addSaveNoopListener(channel => {
+    if (channel) {
+      dispatch(setProjectUpdatedAt(channel.updatedAt));
+      dispatch(setChannel(channel));
+    } else {
+      dispatch(setProjectUpdatedSaved());
+    }
+  });
+  projectManager.addSaveFailListener(error => {
+    dispatch(setProjectUpdatedError());
+    if (error.message?.includes('413')) {
+      // The user's project is too large to save. Mark it as too large.
+      dispatch(setProjectTooLarge(true));
+    }
+  });
+}

--- a/apps/src/lab2/projects/unified-poc/useSources.ts
+++ b/apps/src/lab2/projects/unified-poc/useSources.ts
@@ -1,0 +1,290 @@
+import {isEqual} from 'lodash';
+import {useCallback, useEffect, useRef, useState} from 'react';
+
+import {toolboxToWorkspaceBlocks} from '@cdo/apps/blockly/utils/toolbox';
+import {clearHeader} from '@cdo/apps/code-studio/headerRedux';
+import HttpClient from '@cdo/apps/util/HttpClient';
+import {useAppDispatch, useAppSelector} from '@cdo/apps/util/reduxHooks';
+
+import {
+  INITIAL_VERSION_ID,
+  START_SOURCES,
+  TOOLBOX_BLOCKS,
+} from '../../constants';
+import {
+  BlocklyLevelProperties,
+  LevelProperties,
+  ProjectSources,
+  ProjectVersion,
+} from '../../types';
+import getInitialSources from '../../utils/getInitialSources';
+import ProjectManager from '../ProjectManager';
+import ProjectManagerFactory from '../ProjectManagerFactory';
+import {getAppOptionsEditBlocks} from '../utils';
+
+import configureHeader from './configureHeader';
+import setProjectCallbacks from './setProjectCallbacks';
+
+const isStartMode = getAppOptionsEditBlocks() === START_SOURCES;
+const isToolboxMode = getAppOptionsEditBlocks() === TOOLBOX_BLOCKS;
+
+interface UseSourcesInput<T extends ProjectSources> {
+  /** Level properties for the current level */
+  levelProperties: LevelProperties;
+  /** Default project sources, used if there are no start sources on the level (or when editing start sources). */
+  defaultSources: T;
+  /** Standalone project channel (project) ID, if this is a standalone project */
+  standaloneChannelId?: string;
+  /** Optional callback called when sources are reinitialized (i.e. start over, restoring a version), as opposed to edited directly. */
+  onReinitialize?: () => void;
+  /** Whether to include version history functionality (previewing, restoring, committing versions) */
+  includeVersionHistory?: boolean;
+}
+
+interface UseSourcesOutput<T extends ProjectSources> {
+  /** If a load is in progress. */
+  isLoading: boolean;
+  /** If the current sources are editable. */
+  isEditable: boolean;
+  /** The current project sources. */
+  currentSources: T | undefined;
+  /** Update the current project sources. */
+  updateSources: (newSources: T, forceSave?: boolean) => void;
+  /** Reset the project sources to the start sources. */
+  startOver: () => void;
+
+  /** Version History fields (empty/no-ops if includeVersionHistory is false) **/
+
+  /** List of all versions for the current project. */
+  versionList: ProjectVersion[];
+  /** The ID of the current version. */
+  currentVersion: string | undefined;
+  /** Preview (read-only) a specific version of the project. */
+  previewVersion: (version: string) => void;
+  /** Restore a specific version of the project, to make it the current version. */
+  restoreVersion: (version: string) => void;
+  /** Create a new commit with the given description. Creates and saves a new project version. */
+  createCommit: (description: string) => void;
+}
+
+/**
+ * A custom hook that manages source loading, the state of the current project sources,
+ * and provides source management functionality to labs, including version history
+ * functionality (previewing, restoring, committing versions).
+ */
+export default function useSources<T extends ProjectSources>({
+  levelProperties,
+  defaultSources,
+  standaloneChannelId,
+  onReinitialize,
+  includeVersionHistory = false,
+}: UseSourcesInput<T>): UseSourcesOutput<T> {
+  const dispatch = useAppDispatch();
+  const userId = useAppSelector(state => state.progress.viewAsUserId);
+  const scriptId = useAppSelector(state => state.progress.scriptId);
+  const projectManagerRef = useRef<ProjectManager | null>(null);
+
+  const [isLoading, setIsLoading] = useState(false);
+  const [currentSources, setCurrentSources] = useState<T>();
+  const [versionList, setVersionList] = useState<ProjectVersion[]>([]);
+  const [currentVersion, setCurrentVersion] = useState<string>();
+
+  const isOwner = projectManagerRef.current?.getLastChannel()?.isOwner;
+
+  // Editable if the current user is the project owner and we are not viewing and old version.
+  const isEditable =
+    (!isLoading &&
+      isOwner &&
+      (!includeVersionHistory ||
+        versionList.find(v => v.versionId === currentVersion)?.isLatest)) ||
+    false;
+
+  /**
+   * Loads project data and version list (if needed) for current level/user.
+   * This is meant to be called whenever the level or view as user changes.
+   */
+  const loadProject = useCallback(async () => {
+    const {usesProjects, id, isProjectLevel} = levelProperties;
+    if (!usesProjects) {
+      return;
+    }
+    // Clear out existing data.
+    setCurrentSources(undefined);
+    setVersionList([]);
+    await projectManagerRef.current?.cleanUp();
+
+    // Set up new Project Manager.
+    projectManagerRef.current = standaloneChannelId
+      ? ProjectManagerFactory.getProjectManager(
+          standaloneChannelId,
+          isProjectLevel || false
+        )
+      : await ProjectManagerFactory.getProjectManagerForLevel(
+          id,
+          isProjectLevel || false,
+          userId || undefined,
+          scriptId || undefined
+        );
+
+    // Load and set initial project sources (even if we don't have a project).
+    const projectAndSources = await projectManagerRef.current?.load();
+    setCurrentSources(
+      (getInitialSources(levelProperties, projectAndSources?.sources) as T) ||
+        defaultSources
+    );
+
+    // No project; return early.
+    if (!projectManagerRef.current) return;
+
+    // Load project versions, if needed.
+    if (includeVersionHistory) {
+      await refreshVersionList(projectManagerRef.current);
+    }
+    setProjectCallbacks(projectManagerRef.current, dispatch);
+  }, [
+    levelProperties,
+    defaultSources,
+    standaloneChannelId,
+    userId,
+    scriptId,
+    includeVersionHistory,
+    dispatch,
+  ]);
+
+  const refreshVersionList = async (projectManager: ProjectManager) => {
+    const versionList = await projectManager.getVersionList(true);
+    setVersionList(versionList);
+    const latestVersion =
+      versionList.find(v => v.isLatest)?.versionId || INITIAL_VERSION_ID;
+    setCurrentVersion(latestVersion);
+  };
+
+  const reinitializeSources = useCallback(
+    (sources: T | undefined) => {
+      setCurrentSources(sources);
+      onReinitialize?.();
+    },
+    [onReinitialize]
+  );
+
+  const updateSources = useCallback(
+    (newSources: T, forceSave = false) => {
+      if (!projectManagerRef.current || !isEditable) return;
+      setCurrentSources(prev => {
+        // Perform a deep equality check to prevent unnecessary re-renders
+        if (isEqual(prev, newSources)) {
+          return prev;
+        }
+        return newSources;
+      });
+
+      projectManagerRef.current?.save(newSources, forceSave);
+    },
+    [setCurrentSources, isEditable]
+  );
+
+  const startOver = useCallback(() => {
+    if (!projectManagerRef.current) return;
+    const {templateSources, startSources} = levelProperties;
+    if (isToolboxMode) {
+      return {
+        source: toolboxToWorkspaceBlocks(
+          (levelProperties as BlocklyLevelProperties).toolboxDefinition
+        ),
+      };
+    }
+    const startOverSources = isStartMode
+      ? defaultSources
+      : ((templateSources || startSources || defaultSources) as ProjectSources);
+    projectManagerRef.current.save(startOverSources as T, true);
+    reinitializeSources(startOverSources as T | undefined);
+  }, [defaultSources, levelProperties, reinitializeSources]);
+
+  const previewVersion = useCallback(
+    async (version: string) => {
+      if (!includeVersionHistory || !projectManagerRef.current) return;
+
+      setIsLoading(true);
+      await projectManagerRef.current.flushSave();
+      const sources = await projectManagerRef.current.loadSources(version);
+      reinitializeSources(sources as T | undefined);
+      setCurrentVersion(version);
+      setIsLoading(false);
+    },
+    [includeVersionHistory, reinitializeSources]
+  );
+
+  const restoreVersion = useCallback(
+    async (version: string) => {
+      if (!includeVersionHistory || !projectManagerRef.current) return;
+
+      setIsLoading(true);
+      await projectManagerRef.current.flushSave();
+      const sources = await projectManagerRef.current.restoreSources(version);
+      reinitializeSources(sources as T | undefined);
+      await refreshVersionList(projectManagerRef.current);
+      setIsLoading(false);
+    },
+    [includeVersionHistory, reinitializeSources]
+  );
+
+  const createCommit = useCallback(
+    async (description: string) => {
+      if (!includeVersionHistory || !projectManagerRef.current || !isEditable)
+        return;
+
+      setIsLoading(true);
+      await projectManagerRef.current.flushSave(/* forceNewVersion */ true);
+      const comment = description.trim();
+      const newVersionId = projectManagerRef.current.getCurrentVersionId();
+
+      if (!comment || !newVersionId) return; // TODO: Handle no version ID.
+
+      const payload = {
+        storage_id: projectManagerRef.current.getChannelId(),
+        version_id: newVersionId,
+        comment,
+      };
+
+      // TODO: Should this be inside ProjectManager?
+      await HttpClient.post('/project_commits', JSON.stringify(payload), true, {
+        'Content-Type': 'application/json; charset=UTF-8',
+      });
+      // Set this boolean to true so if any updates occur, a new version is created and this version remains intact and is not overwritten.
+      projectManagerRef.current.setForceNewVersion(true);
+      await refreshVersionList(projectManagerRef.current);
+      setIsLoading(false);
+    },
+    [includeVersionHistory, isEditable]
+  );
+
+  useEffect(() => {
+    setIsLoading(true);
+    loadProject()
+      .catch(error => {
+        // TODO: Error handling/UI
+        console.error('Error loading project', error);
+      })
+      .finally(() => setIsLoading(false));
+  }, [loadProject]);
+
+  useEffect(() => {
+    dispatch(clearHeader());
+    if (projectManagerRef.current && !isLoading) {
+      configureHeader(isOwner || false, levelProperties);
+    }
+  }, [isOwner, levelProperties, dispatch, isLoading]);
+
+  return {
+    isLoading,
+    isEditable,
+    currentSources,
+    updateSources,
+    startOver,
+    versionList,
+    currentVersion,
+    previewVersion,
+    restoreVersion,
+    createCommit,
+  };
+}

--- a/apps/src/lab2/projects/unified-poc/useSources.ts
+++ b/apps/src/lab2/projects/unified-poc/useSources.ts
@@ -46,6 +46,8 @@ interface UseSourcesOutput<T extends ProjectSources> {
   isLoading: boolean;
   /** If the current sources are editable. */
   isEditable: boolean;
+  /** If the user has updated the most recently loaded sources. Reset when reloading sources or restoring a version. */
+  hasEdited: boolean;
   /** The current project sources. */
   currentSources: T | undefined;
   /** Update the current project sources. */
@@ -88,6 +90,7 @@ export default function useSources<T extends ProjectSources>({
   const [currentSources, setCurrentSources] = useState<T>();
   const [versionList, setVersionList] = useState<ProjectVersion[]>([]);
   const [currentVersion, setCurrentVersion] = useState<string>();
+  const [hasEdited, setHasEdited] = useState(false);
 
   const isOwner = projectManagerRef.current?.getLastChannel()?.isOwner;
 
@@ -111,6 +114,8 @@ export default function useSources<T extends ProjectSources>({
     // Clear out existing data.
     setCurrentSources(undefined);
     setVersionList([]);
+    setCurrentVersion(undefined);
+    setHasEdited(false);
     await projectManagerRef.current?.cleanUp();
 
     // Set up new Project Manager.
@@ -175,6 +180,7 @@ export default function useSources<T extends ProjectSources>({
         if (isEqual(prev, newSources)) {
           return prev;
         }
+        setHasEdited(true);
         return newSources;
       });
 
@@ -198,6 +204,7 @@ export default function useSources<T extends ProjectSources>({
       : ((templateSources || startSources || defaultSources) as ProjectSources);
     projectManagerRef.current.save(startOverSources as T, true);
     reinitializeSources(startOverSources as T | undefined);
+    setHasEdited(false);
   }, [defaultSources, levelProperties, reinitializeSources]);
 
   const previewVersion = useCallback(
@@ -223,6 +230,7 @@ export default function useSources<T extends ProjectSources>({
       const sources = await projectManagerRef.current.restoreSources(version);
       reinitializeSources(sources as T | undefined);
       await refreshVersionList(projectManagerRef.current);
+      setHasEdited(false);
       setIsLoading(false);
     },
     [includeVersionHistory, reinitializeSources]
@@ -253,6 +261,7 @@ export default function useSources<T extends ProjectSources>({
       // Set this boolean to true so if any updates occur, a new version is created and this version remains intact and is not overwritten.
       projectManagerRef.current.setForceNewVersion(true);
       await refreshVersionList(projectManagerRef.current);
+      setHasEdited(false);
       setIsLoading(false);
     },
     [includeVersionHistory, isEditable]
@@ -278,6 +287,7 @@ export default function useSources<T extends ProjectSources>({
   return {
     isLoading,
     isEditable,
+    hasEdited,
     currentSources,
     updateSources,
     startOver,

--- a/apps/src/sketchlab/SketchlabView.tsx
+++ b/apps/src/sketchlab/SketchlabView.tsx
@@ -19,18 +19,19 @@ import useThemeSetting from '@cdo/apps/lab2/hooks/useThemeSetting';
 import {useVerticalLayout} from '@cdo/apps/lab2/hooks/useVerticalLayout';
 import {isReadOnlyWorkspace} from '@cdo/apps/lab2/redux/lab2ReduxSelectors';
 import {setHasRun} from '@cdo/apps/lab2/redux/systemRedux';
-import {LabProps, LevelProperties, ProjectSources} from '@cdo/apps/lab2/types';
+import {LabProps, LevelProperties} from '@cdo/apps/lab2/types';
 import TeacherViewingStudentProjectAlert from '@cdo/apps/lab2/views/alerts/teacherViewingStudentProject';
 import ResourcePanel from '@cdo/apps/lab2/views/components/Instructions/ResourcePanel';
 import ResizeBar from '@cdo/apps/lab2/views/components/layout/ResizeBar';
 import PanelContainer from '@cdo/apps/lab2/views/components/PanelContainer';
 import WorkspaceHeader from '@cdo/apps/lab2/views/components/WorkspaceHeader';
-import SourcesContainer, {
-  useSources,
-} from '@cdo/apps/lab2/views/SourcesContainer';
 import {commonI18n} from '@cdo/apps/types/locale';
 import experiments from '@cdo/apps/util/experiments';
 import {useAppDispatch, useAppSelector} from '@cdo/apps/util/reduxHooks';
+
+import DemoVersionHistory from '../lab2/projects/unified-poc/demoVersionHistory/DemoVersionHistory';
+import useSources from '../lab2/projects/unified-poc/useSources';
+import {DialogType, useDialogControl} from '../lab2/views/dialogs';
 
 import SketchlabTourSteps from './sketchlabTourSteps';
 import {SketchlabSources, SerializedExcalidrawState} from './types';
@@ -58,12 +59,23 @@ const SketchlabView: React.FC<LabProps<LevelProperties>> = ({
   levelProperties,
 }) => {
   const excalidrawApiRef = useRef<ExcalidrawImperativeAPI | null>();
+  const reinitializationHandler = useCallback(() => {
+    setExcalidrawMountKey(key => key + 1);
+  }, []);
+
   const {
+    isLoading: isLoadingSources,
+    isEditable,
     currentSources,
     updateSources,
-    setReinitializationHandler,
-    showStartOverDialog,
-  } = useSources<SketchlabSources>();
+    startOver,
+    ...versionHistoryProps
+  } = useSources<SketchlabSources>({
+    levelProperties,
+    defaultSources: DEFAULT_SOURCES,
+    onReinitialize: reinitializationHandler,
+    includeVersionHistory: true,
+  });
 
   const saveSourcesTimeoutRef = useRef<NodeJS.Timeout | null>(null);
 
@@ -78,10 +90,14 @@ const SketchlabView: React.FC<LabProps<LevelProperties>> = ({
 
   const readonlyWorkspace = useAppSelector(isReadOnlyWorkspace);
 
-  const onClickStartOver = useCallback(() => {
-    showStartOverDialog('custom', commonI18n.startOverGeneric());
-  }, [showStartOverDialog]);
+  const dialogControl = useDialogControl();
 
+  const onClickStartOver = useCallback(() => {
+    dialogControl.showDialog({
+      type: DialogType.StartOver,
+      handleConfirm: startOver,
+    });
+  }, [dialogControl, startOver]);
   const {theme} = useTheme();
 
   const hasRun = useAppSelector(state => state.lab2System.hasRun);
@@ -134,6 +150,7 @@ const SketchlabView: React.FC<LabProps<LevelProperties>> = ({
       state: AppState,
       files: BinaryFiles
     ) => {
+      if (isLoadingSources || !currentSources) return;
       if (saveSourcesTimeoutRef.current) {
         clearTimeout(saveSourcesTimeoutRef.current);
         saveSourcesTimeoutRef.current = null;
@@ -179,7 +196,8 @@ const SketchlabView: React.FC<LabProps<LevelProperties>> = ({
     [
       updateSources,
       channelId,
-      currentSources.source,
+      currentSources,
+      isLoadingSources,
       levelProperties.name,
       readonlyWorkspace,
     ]
@@ -192,24 +210,6 @@ const SketchlabView: React.FC<LabProps<LevelProperties>> = ({
       }
     };
   }, []);
-
-  const reinitializationHandler = useCallback(() => {
-    setExcalidrawMountKey(key => key + 1);
-  }, []);
-
-  const onLoadVersion = useCallback(
-    (sources: ProjectSources) => {
-      if (sources) {
-        updateSources(sources as SketchlabSources);
-      }
-      reinitializationHandler();
-    },
-    [updateSources, reinitializationHandler]
-  );
-
-  useEffect(() => {
-    setReinitializationHandler(reinitializationHandler);
-  }, [setReinitializationHandler, reinitializationHandler]);
 
   // Since there's no run button in Sketch Lab, set it to true by default
   // to enable the Submit button on edit on submittable levels.
@@ -237,18 +237,17 @@ const SketchlabView: React.FC<LabProps<LevelProperties>> = ({
           hasRun={hasRun}
           hasEdited={false}
           settings={[useThemeSetting('sketchlab')]}
-          versionHistoryProps={{
-            startSources:
-              (levelProperties?.startSources as ProjectSources) ||
-              DEFAULT_SOURCES,
-            onLoadVersion: onLoadVersion,
-          }}
         />
       </div>
       <ResizeBar
         isVertical={true}
         separatorProps={panelSeparatorProps}
         isDragging={isDragging}
+      />
+      <DemoVersionHistory
+        {...versionHistoryProps}
+        isEditable={isEditable}
+        isLoading={isLoadingSources}
       />
       <div style={{width: rightPanelWidth}}>
         <PanelContainer
@@ -272,21 +271,25 @@ const SketchlabView: React.FC<LabProps<LevelProperties>> = ({
           {teacherViewingStudent && (
             <TeacherViewingStudentProjectAlert inWorkspaceContainer />
           )}
-          <Excalidraw
-            initialData={
-              experiments.isEnabledAllowingQueryString(S3_IMAGE_EXPERIMENT)
-                ? populateInitialExcalidrawState(
-                    currentSources.source,
-                    downloadedFilesDataRef.current
-                  )
-                : (currentSources.source as ExcalidrawInitialDataState)
-            }
-            onChange={debouncedSerializeAndSaveWorkspace}
-            excalidrawAPI={api => (excalidrawApiRef.current = api)}
-            key={excalidrawMountKey}
-            theme={theme.toLowerCase() as ExcalidrawTheme}
-            viewModeEnabled={readonlyWorkspace}
-          />
+          {isLoadingSources || !currentSources ? (
+            <div>Loading...</div>
+          ) : (
+            <Excalidraw
+              initialData={
+                experiments.isEnabledAllowingQueryString(S3_IMAGE_EXPERIMENT)
+                  ? populateInitialExcalidrawState(
+                      currentSources.source,
+                      downloadedFilesDataRef.current
+                    )
+                  : (currentSources.source as ExcalidrawInitialDataState)
+              }
+              onChange={debouncedSerializeAndSaveWorkspace}
+              excalidrawAPI={api => (excalidrawApiRef.current = api)}
+              key={excalidrawMountKey}
+              theme={theme.toLowerCase() as ExcalidrawTheme}
+              viewModeEnabled={!isEditable}
+            />
+          )}
           {WorkspaceAlert}
         </PanelContainer>
       </div>
@@ -294,12 +297,4 @@ const SketchlabView: React.FC<LabProps<LevelProperties>> = ({
   );
 };
 
-export default (props: LabProps<LevelProperties>) => (
-  <SourcesContainer
-    {...props}
-    defaultSources={DEFAULT_SOURCES}
-    key={props.levelProperties.id}
-  >
-    <SketchlabView levelProperties={props.levelProperties} />
-  </SourcesContainer>
-);
+export default SketchlabView;


### PR DESCRIPTION
Here's a proof-of-concept of a unified source management system in Lab2, that aims to effectively replace ProjectContainer, SourcesContainer, and lab2ProjectRedux. Initially I was thinking of creating a new wrapper component in the vein of the existing SourcesContainer+context, but as I wrote this out, a single hook felt like a better fit. The goal isn't to merge this PR as-is, but just to lay out my thoughts on a direction that we can discuss.

At a high level, this hook provides labs with all the data, state, and APIs they need to read and update sources, including version history. By design, there's no UI, so labs can use these values and callbacks as they need, and/or plug them into other framework components like Version History. And this really does function like a proper hook, in that labs can optionally choose to "hook" into the sources system that lab2 provides, but don't need to if they don't support projects. Project/sources management moves from a global/wrapper-based system into more of a plug-in, available when needed. This also means that, along with https://github.com/code-dot-org/code-dot-org/pull/70246, loads between labs are now pretty much instantaneous since there's no mandatory network requests between level transitions; project loading is confined to the hook, so labs can choose how to handle that loading state themselves, and choose to keep certain UI elements on the page if desired.

Most of this code is either adapted or copied from the existing components mentioned above, but the idea is that we get a single source of truth for sources management and a unified with API with less guesswork and (hopefully) less complexity. In this example, labs don't need to interface with the ProjectManager directly at all; everything this managed through the hook. Furthermore, since since project data is managed in the hook's local state and not redux, we can in theory support multiple usages of this hook on a page at once (for example in the Hour of AI multi-lab freeplay experience).

For this example, I integrated the hook with Sketch Lab, and wrote up a quick low-fi version of version history, just to test out all the APIs and demonstrate how they'd be used. I didn't want to bloat the diff with updating all of the real version history component, but you can kind of see how it would be pretty straightforward to transition over since it's mostly a matter of substituting props and callbacks.

**Key Files**
- `useSources.ts`: this is the big one - it does all the work of loading sources, and providing the various callbacks and data for labs to read and write project data.
  - split out a few utility functions like configureHeader and setProjectCallbacks, copied from ProjectContainer
  - If it helps, I'd take a look at type typescript interfaces `UseSourcesInput` and `UseSourcesOutput` + their comments which may help lay out the philosophy behind what the hook is aiming to do.
- `DemoVersionHistory.tsx`: the UI isn't important (it's way less slick than the actual Version History panel 🙂), but check this out to see how the APIs get integrated into a view
- `SketchlabView.tsx`: check this out to see how this would get used in a lab; it's actually not a whole lot different than the current SourcesContainer implementation, but hopefully a tad simpler
- `multiFileUtils.ts`: I included some examples to demonstrate how we might port the more complex redux thunk actions that pertain to multi-file operations in Codebridge; the code is pretty much the same, just adapted to use the outputs of the useSources hook.

More than happy to discuss this over a call for anyone interested - give it a spin and let me know what you think! (it should look something like this):
- bonus: try adding `?lab2-no-fade=true` to see level transitions without a fade in between, where instructions update instantly, and we show a loading state over the excalidraw workspace (just for demonstration, not a high quality loading animation).

<img width="1512" height="831" alt="Screenshot 2026-01-12 at 5 48 40 PM" src="https://github.com/user-attachments/assets/de1eb091-2779-4e5d-8060-2c4fc1d7d086" />