### PR TITLE
Fix ADD row appearing on roster page for email sections (TEACHING-20)

### DIFF
--- a/apps/src/templates/teacherNavigation/selectedSectionLoader.ts
+++ b/apps/src/templates/teacherNavigation/selectedSectionLoader.ts
@@ -35,6 +35,16 @@ export const asyncLoadSelectedSection = async (
 
   getStore().dispatch(startLoadingSectionData());
   getStore().dispatch(selectSection(sectionId));
+
+  // Set loginType before loading students to ensure correct behavior when
+  // navigating via NavLink. This prevents the empty "Add Student" row from
+  // appearing for email sections when the previous section was word/picture.
+  const section = state.sections[parseInt(sectionId)];
+  if (section?.loginType) {
+    getStore().dispatch(setLoginType(section.loginType));
+    getStore().dispatch(setRosterProvider(section.loginType));
+  }
+
   getStore().dispatch(loadSectionStudentData(sectionId));
 
   const response = fetch(`/dashboardapi/section/${sectionId}`, {

--- a/apps/test/unit/templates/manageStudents/manageStudentsReduxTest.js
+++ b/apps/test/unit/templates/manageStudents/manageStudentsReduxTest.js
@@ -761,6 +761,14 @@ describe('manageStudentsRedux', () => {
       });
     });
 
+    it('setLoginType does NOT create an add row for email login types', () => {
+      const action = setLoginType('email');
+      const nextState = manageStudents(initialState, action);
+      assert.notExists(nextState.studentData[0]);
+      assert.deepEqual(nextState.editingData, {});
+      assert.deepEqual(nextState.loginType, 'email');
+    });
+
     it('addStudentsSuccess updates studentData, removes editingData, and adds new blank row', () => {
       // Initial state with blank row
       const initialState = {

--- a/apps/test/unit/templates/manageStudents/manageStudentsReduxTest.js
+++ b/apps/test/unit/templates/manageStudents/manageStudentsReduxTest.js
@@ -764,7 +764,7 @@ describe('manageStudentsRedux', () => {
     it('setLoginType does NOT create an add row for email login types', () => {
       const action = setLoginType('email');
       const nextState = manageStudents(initialState, action);
-      assert.notExists(nextState.studentData[0]);
+      assert.equal(nextState.studentData[0], undefined);
       assert.deepEqual(nextState.editingData, {});
       assert.deepEqual(nextState.loginType, 'email');
     });


### PR DESCRIPTION
This fixes a bug where navigating from a word/picture section to an email section would incorrectly show an empty "add student" row. The issue occurred because loadSectionStudentData was called before the new section's loginType was set, causing it to use the previous section's loginType.

Changes:
- Set loginType from cached section data BEFORE calling loadSectionStudentData in asyncLoadSelectedSection
- Added test to verify email login types don't create ADD row

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->



## Links
<!--  Links to relevant external resources.
      - spec docs, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- Jira: 

## Testing story
<!--  Does your change include appropriate tests?
      - If so, please describe how the tests included in this PR are sufficient.
      - If not, please explain why this change does not need to be tested. -->



## Deployment strategy
<!--  Any special steps required to deploy this, besides merging?
      - Are there database migrations or manual steps?
      - Does this require coordination with other teams or systems? -->



## Follow-up work
<!--  List any clean-up or technical debt that will be addressed in future work.
      - Include Jira links where applicable.
      - Are there any known limitations or improvements planned? -->



## Privacy
<!--  How does this change impact Student & Teacher privacy?
      - Does this collect, use, share, or modify PII, either new or existing? -->



## Security
<!--  How does this change impact our security surface-area?
      - Do API's touched have the right auth?
      - Do infra changes impact our attack surface or encryption?
-->



## Caching
<!--  How does this change impact caching behavior?
      - Are cache keys or invalidation strategies affected?
      - Will this require cache warming or invalidation after deployment? -->



## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
