### PR TITLE
🧹 Remove Radium from ChallengeDialog and PuzzleRatingButtons

### DIFF
--- a/apps/src/StudioApp.js
+++ b/apps/src/StudioApp.js
@@ -618,6 +618,8 @@ StudioApp.prototype.init = function (config) {
         primaryButtonLabel={msg.challengeLevelStart()}
         text={msg.challengeLevelIntro()}
         title={msg.challengeLevelTitle()}
+        levelId={config.serverLevelId}
+        unitId={config.serverScriptId}
       />,
       startDialogDiv
     );

--- a/apps/src/puzzleRatingUtils.js
+++ b/apps/src/puzzleRatingUtils.js
@@ -115,7 +115,6 @@ puzzleRatingUtils.cachePuzzleRating = function (container, options) {
 puzzleRatingUtils.submitCachedPuzzleRatings = function (url) {
   var ratings = puzzleRatingUtils.getPuzzleRatings_();
   ratings.forEach(function (rating) {
-    console.log('rating from og puzzle', rating);
     $.ajax({
       url: url,
       type: 'POST',

--- a/apps/src/puzzleRatingUtils.js
+++ b/apps/src/puzzleRatingUtils.js
@@ -115,6 +115,7 @@ puzzleRatingUtils.cachePuzzleRating = function (container, options) {
 puzzleRatingUtils.submitCachedPuzzleRatings = function (url) {
   var ratings = puzzleRatingUtils.getPuzzleRatings_();
   ratings.forEach(function (rating) {
+    console.log('rating from og puzzle', rating);
     $.ajax({
       url: url,
       type: 'POST',

--- a/apps/src/templates/ChallengeDialog.jsx
+++ b/apps/src/templates/ChallengeDialog.jsx
@@ -1,17 +1,16 @@
 import Button, {buttonColors} from '@code-dot-org/component-library/button';
 import PropTypes from 'prop-types';
-import Radium from 'radium'; // eslint-disable-line no-restricted-imports
 import React from 'react';
+import classNames from 'classnames';
 
 import assetUrl from '@cdo/apps/code-studio/assetUrl';
 import {getStore} from '@cdo/apps/redux';
 import i18n from '@cdo/locale';
 
-import color from '../util/color';
-
 import BackToFrontConfetti from './BackToFrontConfetti';
 import BaseDialog from './BaseDialog';
 import PuzzleRatingButtons from './PuzzleRatingButtons';
+import styles from './ChallengeDialog.module.scss';
 
 class ChallengeDialog extends React.Component {
   static propTypes = {
@@ -63,35 +62,43 @@ class ChallengeDialog extends React.Component {
 
   render() {
     const isRtl = getStore().getState().isRtl;
-    const bannerStyle = {
-      ...styles.banner,
-      ...(this.props.complete ? styles.bannerComplete : {}),
-    };
+    const bannerImage = this.props.complete
+      ? assetUrl('media/dialog/challenge_target_complete.svg')
+      : assetUrl('media/dialog/challenge_target.svg');
+    const bannerClassName = classNames(styles.banner, {
+      [styles.bannerComplete]: this.props.complete,
+    });
+    const dialogStyle = {top: '20%'};
+    const confettiStyle = {top: 150};
 
     return (
       <BaseDialog
         isOpen={this.state.isOpen}
-        style={styles.dialog}
+        style={dialogStyle}
         handleClose={this.handlePrimary}
         hideCloseButton={true}
         hideBackdrop={this.props.hideBackdrop}
+        bodyClassName={styles.dialogBody}
       >
         <img
           className="modal-image"
           src={this.props.avatar}
           alt={i18n.cheeringInstructorAltText()}
         />
-        <div style={bannerStyle}>
-          <h1 style={styles.title} id="uitest-challenge-title">
+        <div
+          className={bannerClassName}
+          style={{backgroundImage: `url(${bannerImage})`}}
+        >
+          <h1 className={styles.title} id="uitest-challenge-title">
             {this.props.title}
           </h1>
           <BackToFrontConfetti
             active={this.state.confettiActive}
-            style={styles.confetti}
+            style={confettiStyle}
           />
         </div>
-        <div style={styles.content}>
-          {this.props.text && <div style={styles.text}>{this.props.text}</div>}
+        <div className={styles.content}>
+          {this.props.text && <div className={styles.text}>{this.props.text}</div>}
           {this.props.children}
         </div>
         <Button
@@ -107,10 +114,10 @@ class ChallengeDialog extends React.Component {
           text={this.props.primaryButtonLabel}
           type="primary"
           color={buttonColors.purple}
-          style={isRtl ? styles.primaryButtonRtl : styles.primaryButton}
+          className={isRtl ? styles.primaryButtonRtl : styles.primaryButton}
         />
         {this.props.showPuzzleRatingButtons && (
-          <div style={styles.footer}>
+          <div className={styles.footer}>
             <PuzzleRatingButtons
               useLegacyStyles
               levelId={this.props.levelId}
@@ -123,65 +130,4 @@ class ChallengeDialog extends React.Component {
   }
 }
 
-const styles = {
-  dialog: {
-    top: '20%',
-    border: `5px solid ${color.purple}`,
-    borderRadius: 10,
-  },
-  banner: {
-    backgroundPosition: 'top center',
-    backgroundRepeat: 'no-repeat',
-    backgroundImage: `url(${assetUrl('media/dialog/challenge_target.svg')})`,
-    position: 'relative',
-    marginTop: -85,
-    height: 135,
-  },
-  bannerComplete: {
-    backgroundImage: `url(${assetUrl(
-      'media/dialog/challenge_target_complete.svg'
-    )})`,
-    marginTop: -99,
-    height: 149,
-  },
-  content: {
-    color: color.purple,
-    position: 'relative',
-    textAlign: 'center',
-    marginBottom: 30,
-  },
-  text: {
-    margin: '0px 40px 20px',
-    textAlign: 'center',
-    fontSize: 18,
-  },
-  title: {
-    textAlign: 'center',
-    position: 'absolute',
-    bottom: 0,
-    color: '#fff',
-    backgroundColor: color.purple,
-    border: '3px solid white',
-    minWidth: '50%',
-    left: '25%',
-    fontSize: '150%',
-    height: 30,
-    lineHeight: '30px',
-  },
-  confetti: {
-    top: 150,
-  },
-  primaryButton: {
-    float: 'right',
-  },
-  primaryButtonRtl: {
-    float: 'left',
-  },
-  footer: {
-    marginTop: 20,
-    paddingTop: 20,
-    borderTop: '2px solid #ccc',
-  },
-};
-
-export default Radium(ChallengeDialog);
+export default ChallengeDialog;

--- a/apps/src/templates/ChallengeDialog.jsx
+++ b/apps/src/templates/ChallengeDialog.jsx
@@ -31,6 +31,8 @@ class ChallengeDialog extends React.Component {
     showPuzzleRatingButtons: PropTypes.bool,
     text: PropTypes.string,
     title: PropTypes.string,
+    levelId: PropTypes.number,
+    unitId: PropTypes.number,
   };
 
   constructor(props) {
@@ -60,7 +62,7 @@ class ChallengeDialog extends React.Component {
   }
 
   render() {
-    // const isRtl = getStore().getState().isRtl;
+    const isRtl = getStore().getState().isRtl;
     const isRtl = false;
     const bannerStyle = {
       ...styles.banner,
@@ -110,7 +112,11 @@ class ChallengeDialog extends React.Component {
         />
         {this.props.showPuzzleRatingButtons && (
           <div style={styles.footer}>
-            <PuzzleRatingButtons useLegacyStyles />
+            <PuzzleRatingButtons
+              useLegacyStyles
+              levelId={this.props.levelId}
+              unitId={this.props.unitId}
+            />
           </div>
         )}
       </BaseDialog>

--- a/apps/src/templates/ChallengeDialog.jsx
+++ b/apps/src/templates/ChallengeDialog.jsx
@@ -1,7 +1,7 @@
 import Button, {buttonColors} from '@code-dot-org/component-library/button';
+import classNames from 'classnames';
 import PropTypes from 'prop-types';
 import React from 'react';
-import classNames from 'classnames';
 
 import assetUrl from '@cdo/apps/code-studio/assetUrl';
 import {getStore} from '@cdo/apps/redux';
@@ -10,6 +10,7 @@ import i18n from '@cdo/locale';
 import BackToFrontConfetti from './BackToFrontConfetti';
 import BaseDialog from './BaseDialog';
 import PuzzleRatingButtons from './PuzzleRatingButtons';
+
 import styles from './ChallengeDialog.module.scss';
 
 class ChallengeDialog extends React.Component {
@@ -98,7 +99,9 @@ class ChallengeDialog extends React.Component {
           />
         </div>
         <div className={styles.content}>
-          {this.props.text && <div className={styles.text}>{this.props.text}</div>}
+          {this.props.text && (
+            <div className={styles.text}>{this.props.text}</div>
+          )}
           {this.props.children}
         </div>
         <Button

--- a/apps/src/templates/ChallengeDialog.jsx
+++ b/apps/src/templates/ChallengeDialog.jsx
@@ -63,7 +63,6 @@ class ChallengeDialog extends React.Component {
 
   render() {
     const isRtl = getStore().getState().isRtl;
-    const isRtl = false;
     const bannerStyle = {
       ...styles.banner,
       ...(this.props.complete ? styles.bannerComplete : {}),

--- a/apps/src/templates/ChallengeDialog.jsx
+++ b/apps/src/templates/ChallengeDialog.jsx
@@ -60,7 +60,8 @@ class ChallengeDialog extends React.Component {
   }
 
   render() {
-    const isRtl = getStore().getState().isRtl;
+    // const isRtl = getStore().getState().isRtl;
+    const isRtl = false;
     const bannerStyle = {
       ...styles.banner,
       ...(this.props.complete ? styles.bannerComplete : {}),

--- a/apps/src/templates/ChallengeDialog.module.scss
+++ b/apps/src/templates/ChallengeDialog.module.scss
@@ -1,0 +1,57 @@
+.dialogBody {
+  border: 5px solid #8c52ba;
+}
+
+.banner {
+  background-position: top center;
+  background-repeat: no-repeat;
+  position: relative;
+  margin-top: -85px;
+  height: 135px;
+}
+
+.bannerComplete {
+  margin-top: -99px;
+  height: 149px;
+}
+
+.content {
+  color: #8c52ba;
+  position: relative;
+  text-align: center;
+  margin-bottom: 30px;
+}
+
+.text {
+  margin: 0 40px 20px;
+  text-align: center;
+  font-size: 18px;
+}
+
+.title {
+  text-align: center;
+  position: absolute;
+  bottom: 0;
+  color: #fff;
+  background-color: #8c52ba;
+  border: 3px solid #fff;
+  min-width: 50%;
+  left: 25%;
+  font-size: 150%;
+  height: 30px;
+  line-height: 30px;
+}
+
+.primaryButton {
+  float: right;
+}
+
+.primaryButtonRtl {
+  float: left;
+}
+
+.footer {
+  margin-top: 20px;
+  padding-top: 20px;
+  border-top: 2px solid #ccc;
+}

--- a/apps/src/templates/PuzzleRatingButtons.jsx
+++ b/apps/src/templates/PuzzleRatingButtons.jsx
@@ -2,6 +2,10 @@ import PropTypes from 'prop-types';
 import Radium from 'radium'; // eslint-disable-line no-restricted-imports
 import React, {Component} from 'react';
 
+const labState = useSelector(
+    (state: {pageConstants: LegacyLabsState}) => state.pageConstants
+  );
+
 import locale from '@cdo/locale';
 
 import color from '../util/color';
@@ -77,6 +81,20 @@ class PuzzleRatingButtons extends Component {
     label: PropTypes.string,
   };
 
+  logRating(rating) {
+    var url = '/puzzle_ratings';
+    console.log('rating from challenge puzzle', rating);
+    {script_id: 734, level_id: 73007, rating: '1'}
+    $.ajax({
+      url: url,
+      type: 'POST',
+      data: rating,
+      complete: function () {
+        console.log('Puzzle rating submitted');
+      },
+    });
+  }
+
   like() {
     this.setState({liked: !this.state.liked, disliked: false});
   }
@@ -91,7 +109,7 @@ class PuzzleRatingButtons extends Component {
     return (
       <div id="puzzleRatingButtons" style={{display: 'inline-block'}}>
         {this.props.useLegacyStyles && (
-          <span style={styles.question}>{label}</span>
+          <span style={styles.question}>Hi!!! {label}</span>
         )}
         <a
           className={

--- a/apps/src/templates/PuzzleRatingButtons.jsx
+++ b/apps/src/templates/PuzzleRatingButtons.jsx
@@ -1,6 +1,6 @@
+import classNames from 'classnames';
 import PropTypes from 'prop-types';
 import React, {Component} from 'react';
-import classNames from 'classnames';
 
 import locale from '@cdo/locale';
 

--- a/apps/src/templates/PuzzleRatingButtons.jsx
+++ b/apps/src/templates/PuzzleRatingButtons.jsx
@@ -2,10 +2,6 @@ import PropTypes from 'prop-types';
 import Radium from 'radium'; // eslint-disable-line no-restricted-imports
 import React, {Component} from 'react';
 
-const labState = useSelector(
-    (state: {pageConstants: LegacyLabsState}) => state.pageConstants
-  );
-
 import locale from '@cdo/locale';
 
 import color from '../util/color';
@@ -79,16 +75,21 @@ class PuzzleRatingButtons extends Component {
   static propTypes = {
     useLegacyStyles: PropTypes.bool,
     label: PropTypes.string,
+    levelId: PropTypes.number,
+    unitId: PropTypes.number,
   };
 
   logRating(rating) {
     var url = '/puzzle_ratings';
-    console.log('rating from challenge puzzle', rating);
-    {script_id: 734, level_id: 73007, rating: '1'}
+    ratingData = {
+      script_id: this.props.unitId,
+      level_id: this.props.levelId,
+      rating: rating,
+    };
     $.ajax({
       url: url,
       type: 'POST',
-      data: rating,
+      data: ratingData,
       complete: function () {
         console.log('Puzzle rating submitted');
       },
@@ -97,10 +98,12 @@ class PuzzleRatingButtons extends Component {
 
   like() {
     this.setState({liked: !this.state.liked, disliked: false});
+    this.logRating(1);
   }
 
   dislike() {
     this.setState({liked: false, disliked: !this.state.disliked});
+    this.logRating(0);
   }
 
   render() {

--- a/apps/src/templates/PuzzleRatingButtons.jsx
+++ b/apps/src/templates/PuzzleRatingButtons.jsx
@@ -112,7 +112,7 @@ class PuzzleRatingButtons extends Component {
     return (
       <div id="puzzleRatingButtons" style={{display: 'inline-block'}}>
         {this.props.useLegacyStyles && (
-          <span style={styles.question}>Hi!!! {label}</span>
+          <span style={styles.question}>{label}</span>
         )}
         <a
           className={

--- a/apps/src/templates/PuzzleRatingButtons.jsx
+++ b/apps/src/templates/PuzzleRatingButtons.jsx
@@ -1,76 +1,16 @@
 import PropTypes from 'prop-types';
-import Radium from 'radium'; // eslint-disable-line no-restricted-imports
 import React, {Component} from 'react';
+import classNames from 'classnames';
 
 import locale from '@cdo/locale';
 
-import color from '../util/color';
-
-const newStyles = {
-  puzzleRatingButton: {
-    fill: color.light_gray,
-    cursor: 'pointer',
-    display: 'inline-block',
-    backgroundColor: color.lightest_gray,
-    borderColor: color.light_gray,
-    borderWidth: 1,
-    borderStyle: 'solid',
-    padding: '5px 5px 0px',
-    ':active': {
-      backgroundColor: color.lighter_gray,
-    },
-  },
-  like: {
-    borderRadius: '2px 0px 0px 2px',
-  },
-  likeDisabled: {
-    ':hover': {
-      fill: '#333',
-    },
-  },
-  likeEnabled: {
-    fill: color.red,
-    backgroundColor: color.lighter_gray,
-    ':hover': {
-      fill: color.dark_red,
-    },
-  },
-  dislike: {
-    borderRadius: '0px 2px 2px 0px',
-  },
-  dislikeDisabled: {
-    ':hover': {
-      fill: color.dark_gray,
-    },
-  },
-  dislikeEnabled: {
-    fill: color.cyan,
-    backgroundColor: color.lighter_gray,
-    ':hover': {
-      fill: color.dark_blue,
-    },
-  },
-};
-
-const legacyStyles = {
-  puzzleRatingButton: {
-    verticalAlign: 'middle',
-  },
-  question: {
-    fontSize: 16,
-    color: color.light_gray,
-    marginRight: 10,
-  },
-};
+import styles from './PuzzleRatingButtons.module.scss';
 
 class PuzzleRatingButtons extends Component {
-  constructor() {
-    super();
-    this.state = {
-      liked: false,
-      disliked: false,
-    };
-  }
+  state = {
+    liked: false,
+    disliked: false,
+  };
 
   static propTypes = {
     useLegacyStyles: PropTypes.bool,
@@ -79,9 +19,9 @@ class PuzzleRatingButtons extends Component {
     unitId: PropTypes.number,
   };
 
-  logRating(rating) {
-    var url = '/puzzle_ratings';
-    ratingData = {
+  logRating = rating => {
+    const url = '/puzzle_ratings';
+    const ratingData = {
       script_id: this.props.unitId,
       level_id: this.props.levelId,
       rating: rating,
@@ -94,41 +34,54 @@ class PuzzleRatingButtons extends Component {
         console.log('Puzzle rating submitted');
       },
     });
-  }
+  };
 
-  like() {
-    this.setState({liked: !this.state.liked, disliked: false});
+  like = () => {
+    this.setState(state => ({liked: !state.liked, disliked: false}));
     this.logRating(1);
-  }
+  };
 
-  dislike() {
-    this.setState({liked: false, disliked: !this.state.disliked});
+  dislike = () => {
+    this.setState(state => ({liked: false, disliked: !state.disliked}));
     this.logRating(0);
-  }
+  };
 
   render() {
-    const styles = this.props.useLegacyStyles ? legacyStyles : newStyles;
+    const {useLegacyStyles} = this.props;
     const label = this.props.label || locale.puzzleRatingQuestion();
+    const likeClassName = classNames(
+      useLegacyStyles ? 'puzzle-rating-btn' : styles.button,
+      !useLegacyStyles && styles.like,
+      useLegacyStyles && styles.legacyButton,
+      {
+        [styles.likeEnabled]: !useLegacyStyles && this.state.liked,
+        [styles.likeDisabled]: !useLegacyStyles && !this.state.liked,
+        enabled: useLegacyStyles && this.state.liked,
+      }
+    );
+
+    const dislikeClassName = classNames(
+      useLegacyStyles ? 'puzzle-rating-btn' : styles.button,
+      !useLegacyStyles && styles.dislike,
+      useLegacyStyles && styles.legacyButton,
+      {
+        [styles.dislikeEnabled]: !useLegacyStyles && this.state.disliked,
+        [styles.dislikeDisabled]: !useLegacyStyles && !this.state.disliked,
+        enabled: useLegacyStyles && this.state.disliked,
+      }
+    );
+
     return (
-      <div id="puzzleRatingButtons" style={{display: 'inline-block'}}>
+      <div id="puzzleRatingButtons" className={styles.container}>
         {this.props.useLegacyStyles && (
-          <span style={styles.question}>{label}</span>
+          <span className={styles.question}>{label}</span>
         )}
         <a
-          className={
-            (this.state.liked ? 'enabled' : '') +
-            ' ' +
-            (this.props.useLegacyStyles ? 'puzzle-rating-btn' : '')
-          }
+          className={likeClassName}
           id="like"
           key="like"
           data-value="1"
-          onClick={this.like.bind(this)}
-          style={[
-            styles.puzzleRatingButton,
-            styles.like,
-            this.state.liked ? styles.likeEnabled : styles.likeDisabled,
-          ]}
+          onClick={this.like}
         >
           <svg
             version="1.1"
@@ -148,22 +101,11 @@ class PuzzleRatingButtons extends Component {
         </a>
 
         <a
-          className={
-            (this.state.disliked ? 'enabled' : '') +
-            ' ' +
-            (this.props.useLegacyStyles ? 'puzzle-rating-btn' : '')
-          }
+          className={dislikeClassName}
           id="dislike"
           key="dislike"
           data-value="0"
-          onClick={this.dislike.bind(this)}
-          style={[
-            styles.puzzleRatingButton,
-            styles.dislike,
-            this.state.disliked
-              ? styles.dislikeEnabled
-              : styles.dislikeDisabled,
-          ]}
+          onClick={this.dislike}
         >
           <svg
             version="1.1"
@@ -184,4 +126,4 @@ class PuzzleRatingButtons extends Component {
     );
   }
 }
-export default Radium(PuzzleRatingButtons);
+export default PuzzleRatingButtons;

--- a/apps/src/templates/PuzzleRatingButtons.module.scss
+++ b/apps/src/templates/PuzzleRatingButtons.module.scss
@@ -1,0 +1,65 @@
+.container {
+  display: inline-block;
+}
+
+.question {
+  font-size: 16px;
+  color: #949ca2;
+  margin-right: 10px;
+}
+
+.button {
+  fill: #949ca2;
+  cursor: pointer;
+  display: inline-block;
+  background-color: #e7e8ea;
+  border: 1px solid #949ca2;
+  padding: 5px 5px 0;
+  vertical-align: middle;
+}
+
+.button:active {
+  background-color: #c6cacd;
+}
+
+.button svg {
+  pointer-events: none;
+}
+
+.like {
+  border-radius: 2px 0 0 2px;
+}
+
+.dislike {
+  border-radius: 0 2px 2px 0;
+}
+
+.likeEnabled {
+  fill: #c00;
+  background-color: #c6cacd;
+}
+
+.likeEnabled:hover {
+  fill: #d62911;
+}
+
+.likeDisabled:hover {
+  fill: #333;
+}
+
+.dislikeEnabled {
+  fill: #0094ca;
+  background-color: #c6cacd;
+}
+
+.dislikeEnabled:hover {
+  fill: #00647f;
+}
+
+.dislikeDisabled:hover {
+  fill: #2d3139;
+}
+
+.legacyButton {
+  vertical-align: middle;
+}


### PR DESCRIPTION
Another tidying quest to remove Radium from our older components. 

There are "challenge" levels mostly in CSF that are denoted as `challenge` on the script level (query: 
`ScriptLevel.where("JSON_EXTRACT(properties, '$.challenge') = true")` An example challenge level: [studio.code.org/courses/express-2025/units/1/lessons/24/levels/10](https://studio.code.org/courses/express-2025/units/1/lessons/24/levels/10)

These levels use a different set of finish dialogs (purple bullseye), called the `ChallengeDialog`. 

<img width="761" height="390" alt="Screenshot 2026-01-13 at 12 20 17 PM" src="https://github.com/user-attachments/assets/87bd9b72-6209-4879-a97f-05d3a808e709" />

I refactored the `ChallengeDialog` to no longer use Radium and to extracted styles into a scss module. 

As is often the case when digging around in the old closets of our codebase, I discovered that while the `ChallengeDialog` renders `PuzzleRatingButtons` those buttons didn't actually log any puzzle ratings! 🤦🏼‍♀️ 

This was extra surprising because the PuzzleRatingButtons rendered in haml on the "traditional" level finish dialogs _do_ log to the PuzzleRatings table. 🕵🏼‍♀️ [Slack](https://codedotorg.slack.com/archives/CFGAVL2CA/p1767634469904419) 🧵 

In addition to refactoring `PuzzleRatingButtons` to no longer user Radium and extracted styles into a scss module, I also added a function to hit the existing /puzzle_ratings api from these buttons to log the user's feedback on challenge levels. 

https://github.com/user-attachments/assets/f57defa1-0a18-4f1e-a4cb-530479ff940a

Note, if you log feedback on a level once then the puzzle rating buttons aren't shown if the dialog is opened again - there's only one rating per user per level allowed. 

2 suggested followups, which I will not address in this PR given scope: 

1.) The PuzzleRatingButtons (neither the React set or the haml set) are accessible and should be refactored for higher contrast and keyboard navigability. 

2.) We're not actually doing anything with this data. It's stored in the PuzzleRatings table. It would be interesting to either look at the data as a input to guide curriculum revisions or delete to save space if we really have no intention of ever using it.