### PR TITLE
Backpack v2: show image previews and automatically open panel on save

### DIFF
--- a/apps/src/lab2/views/components/Instructions/ResourcePanel/Backpack/BackpackFileChip.tsx
+++ b/apps/src/lab2/views/components/Instructions/ResourcePanel/Backpack/BackpackFileChip.tsx
@@ -33,6 +33,8 @@ interface BackpackFileChipProps extends BackpackProps {
   isRecentlyAdded?: boolean;
 }
 
+const EXTENSIONS_WITH_PREVIEWS = ['PNG', 'JPG', 'JPEG'];
+
 // TODO: add statsig logging
 const BackpackFileChip: React.FC<BackpackFileChipProps> = ({
   fileName,
@@ -64,6 +66,13 @@ const BackpackFileChip: React.FC<BackpackFileChipProps> = ({
   const addButtonTooltipText = addButtonDisabled
     ? 'Cannot add files in read-only mode'
     : 'Add to project';
+
+  const filePreviewUrl = useMemo(() => {
+    if (fileExtension && EXTENSIONS_WITH_PREVIEWS.includes(fileExtension)) {
+      return backpackApi.getFileFetchUrl(fileName);
+    }
+    return undefined;
+  }, [backpackApi, fileExtension, fileName]);
 
   const handleAdd = async () => {
     const {isSupportFileName, newFileName} = validateFileName(fileName);
@@ -139,14 +148,22 @@ const BackpackFileChip: React.FC<BackpackFileChipProps> = ({
 
   return (
     <div className={moduleStyles.backpackFileChip}>
-      <div className={moduleStyles.fileIconContainer}>
-        <FontAwesomeV6Icon
-          iconName={fileIcon.iconName}
-          iconStyle={fileIcon.iconStyle}
-          className={moduleStyles.fileIcon}
-          iconFamily={fileIcon.isBrand ? 'brands' : undefined}
+      {filePreviewUrl ? (
+        <img
+          src={filePreviewUrl}
+          className={moduleStyles.filePreview}
+          alt={fileName}
         />
-      </div>
+      ) : (
+        <div className={moduleStyles.fileIconContainer}>
+          <FontAwesomeV6Icon
+            iconName={fileIcon.iconName}
+            iconStyle={fileIcon.iconStyle}
+            className={moduleStyles.fileIcon}
+            iconFamily={fileIcon.isBrand ? 'brands' : undefined}
+          />
+        </div>
+      )}
       <div className={moduleStyles.fileInfo} title={fileName}>
         <BodyThreeText className={moduleStyles.infoText}>
           <StrongText>{fileName}</StrongText>

--- a/apps/src/lab2/views/components/Instructions/ResourcePanel/Backpack/backpack-file-chip.module.scss
+++ b/apps/src/lab2/views/components/Instructions/ResourcePanel/Backpack/backpack-file-chip.module.scss
@@ -57,3 +57,9 @@
   gap: 4px;
   align-self: stretch;
 }
+
+.filePreview {
+  width: 52px;
+  height: 52px;
+  border-radius: var(--border-radius-br-s, 4px) 0 0 var(--border-radius-br-s, 4px);
+}

--- a/apps/src/lab2/views/components/Instructions/ResourcePanel/Backpack/backpack-file-chip.module.scss
+++ b/apps/src/lab2/views/components/Instructions/ResourcePanel/Backpack/backpack-file-chip.module.scss
@@ -40,7 +40,9 @@
   min-width: 0;
 }
 
-.infoText {
+// Duplicate class name to increase specificity, otherwise the typography component
+// may apply an unnecessary bottom margin.
+.infoText.infoText {
   margin: 0;
   overflow: hidden;
   text-overflow: ellipsis;

--- a/apps/src/lab2/views/components/Instructions/ResourcePanel/index.tsx
+++ b/apps/src/lab2/views/components/Instructions/ResourcePanel/index.tsx
@@ -25,6 +25,8 @@ import PanelContainer from '@cdo/apps/lab2/views/components/PanelContainer';
 import StudentRubricView from '@cdo/apps/lab2/views/components/rubrics/StudentRubricView';
 import {useExtraLinksButtonContext} from '@cdo/apps/lab2/views/LabViewsRenderer';
 import {EVENTS} from '@cdo/apps/metrics/AnalyticsConstants';
+import {useBackpackAPIContext} from '@cdo/apps/sharedComponents/backpack/BackpackAPIContext';
+import {BackpackEvent} from '@cdo/apps/sharedComponents/backpack/BackpackClientApi';
 import {commonI18n} from '@cdo/apps/types/locale';
 import {getTypedKeys} from '@cdo/apps/types/utils';
 import {findFirstFocusableElement} from '@cdo/apps/util/findFirstFocusableElement';
@@ -186,6 +188,8 @@ const ResourcePanel: React.FC<ResourcePanelProps> = ({
   const isProjectLevel = instructionsProps.levelProperties.isProjectLevel;
   const isWidgetView = instructionsProps.levelProperties.widgetView;
   const dispatch = useAppDispatch();
+
+  const backpackApi = useBackpackAPIContext();
 
   // Tooltip should disappear quickly.
   const hideTooltipDelayMs = 10;
@@ -351,6 +355,23 @@ const ResourcePanel: React.FC<ResourcePanelProps> = ({
     // Reset current tab to instructions when switching levels or viewAsUserId.
     setCurrentTab(Tabs.Instructions);
   }, [levelId, viewAsUserId]);
+
+  useEffect(() => {
+    if (backpackApi) {
+      // Subscribe to backpack changes if we have a backpack.
+      // We set the current tab to backpack if the user just added a file to the backpack.
+      const listenerId = backpackApi.addEventListener((event, _) => {
+        if (event === BackpackEvent.FileAdded) {
+          setCurrentTab(Tabs.Backpack);
+        }
+      });
+      return () => {
+        if (listenerId) {
+          backpackApi?.removeEventListener(listenerId);
+        }
+      };
+    }
+  }, [backpackApi]);
 
   // Move focus to panel content when AI Tutor or Version History tab is selected via keyboard.
   useEffect(() => {

--- a/apps/src/lab2/views/components/Instructions/ResourcePanel/index.tsx
+++ b/apps/src/lab2/views/components/Instructions/ResourcePanel/index.tsx
@@ -357,9 +357,9 @@ const ResourcePanel: React.FC<ResourcePanelProps> = ({
   }, [levelId, viewAsUserId]);
 
   useEffect(() => {
-    if (backpackApi) {
-      // Subscribe to backpack changes if we have a backpack.
-      // We set the current tab to backpack if the user just added a file to the backpack.
+    // Subscribe to backpack changes if we have a backpack and the tab exists.
+    // We set the current tab to backpack if the user just added a file to the backpack.
+    if (backpackApi && availableTabs[Tabs.Backpack]) {
       const listenerId = backpackApi.addEventListener((event, _) => {
         if (event === BackpackEvent.FileAdded) {
           setCurrentTab(Tabs.Backpack);
@@ -371,7 +371,7 @@ const ResourcePanel: React.FC<ResourcePanelProps> = ({
         }
       };
     }
-  }, [backpackApi]);
+  }, [availableTabs, backpackApi]);
 
   // Move focus to panel content when AI Tutor or Version History tab is selected via keyboard.
   useEffect(() => {

--- a/apps/src/sharedComponents/backpack/BackpackClientApi.ts
+++ b/apps/src/sharedComponents/backpack/BackpackClientApi.ts
@@ -100,7 +100,7 @@ export default class BackpackClientApi {
     if (!this.channelId) {
       return undefined;
     }
-    return `${rootUrl(this.channelId!)}/${filename}${getCacheBustSuffix()}`;
+    return `${rootUrl(this.channelId!)}/${filename}`;
   }
 
   async getFileList(

--- a/apps/src/sharedComponents/backpack/BackpackClientApi.ts
+++ b/apps/src/sharedComponents/backpack/BackpackClientApi.ts
@@ -96,6 +96,13 @@ export default class BackpackClientApi {
     }
   }
 
+  getFileFetchUrl(filename: string) {
+    if (!this.channelId) {
+      return undefined;
+    }
+    return `${rootUrl(this.channelId!)}/${filename}${getCacheBustSuffix()}`;
+  }
+
   async getFileList(
     onError: ErrorCallback,
     onSuccess: (filenames: string[]) => void


### PR DESCRIPTION
This makes two changes to the backpack panel:
- Show image previews in the panel
- If a user saves a file to their backpack, open the panel automatically on success. Note that we aren't opening the panel automatically on failure; that's not something we can currently track from the resource panel component. If we get confused users we can consider updating this, but it seems reasonable that users may need to click on the panel to see the alert in this case.

I also found an issue with the styling of the backpack panel when starting on a lab2 level without a backpack and then loading a level with the backpack without a reload. This was due to css import order, so I updated a style to make it more specific.

## Image Preview
<img width="406" height="673" alt="Screenshot 2026-01-13 at 12 46 56 PM" src="https://github.com/user-attachments/assets/b3c24e7b-8782-435d-8b12-c65849a124ff" />

## Open panel automatically

https://github.com/user-attachments/assets/a1df9cd4-a848-4bd1-ab8e-b6fda38972b3


## Links

- Jira: [AFL-416](https://codedotorg.atlassian.net/browse/AFL-416)

## Testing story
Tested locally.


## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
