### PR TITLE
AI Chat: remove catchall Honeybadger notification

### DIFF
--- a/dashboard/app/jobs/aichat_request_chat_completion_job.rb
+++ b/dashboard/app/jobs/aichat_request_chat_completion_job.rb
@@ -30,12 +30,6 @@ class AichatRequestChatCompletionJob < ApplicationJob
 
     request = arguments.first[:request]
     request.update!(response: exception.message, execution_status: SharedConstants::AI_REQUEST_EXECUTION_STATUS[:FAILURE])
-    Honeybadger.notify(
-      "AichatRequestChatCompletionJob failed with unexpected error: #{exception.message}",
-      context: {
-        request: request.to_json
-      }
-    )
 
     # Report metrics for the failed job (after_perform doesn't run on failure).
     report_job_finish(request)


### PR DESCRIPTION
Follow-up to https://github.com/code-dot-org/code-dot-org/pull/65200

Removes a duplicate Honeybadger notification that is produced any time an error occurs when trying to complete an AI Chat job.

Each of these errors is still reported once the error is formally raised.

The downside is that we wouldn't have the full request details in Honeybadger, and that knowing where to look to get the details is pretty buried in the more detailed error reports (ie, looking at the record in `aichat_requests` table):

<img width="1011" height="400" alt="image" src="https://github.com/user-attachments/assets/dd28a350-b5f4-4fca-a478-8f61c871940f" />

## Testing story

I didn't test this -- made change via GitHub UI :).