### PR TITLE
[DESIGN2-338] [Button] Update white text button color variables in MUI theme

### DIFF
--- a/frontend/packages/component-library/src/themes/code.org/styleOverrides/button.tsx
+++ b/frontend/packages/component-library/src/themes/code.org/styleOverrides/button.tsx
@@ -380,10 +380,10 @@ export const BUTTON_OVERRIDES: Components<Theme>['MuiButton'] = {
     {
       props: {variant: 'text', color: 'white'},
       style: {
-        color: 'var(--text-neutral-inverse)',
+        color: 'var(--neutral-base-white)',
         '&:hover, &.force-hover, &[data-force-hover="true"]': {
           backgroundColor: 'var(--neutral-white-alpha-30)',
-          color: 'var(--text-neutral-inverse)',
+          color: 'var(--neutral-base-white)',
         },
         '&:active': {
           backgroundColor: 'var(--neutral-white-alpha-30)',

--- a/frontend/packages/component-library/src/themes/code.org/styleOverrides/iconButton.tsx
+++ b/frontend/packages/component-library/src/themes/code.org/styleOverrides/iconButton.tsx
@@ -327,10 +327,10 @@ const iconButtonVariants = [
     props: {variant: 'text', color: 'white'},
     style: {
       backgroundColor: 'transparent',
-      color: 'var(--text-neutral-inverse)',
+      color: 'var(--neutral-base-white)',
       '&:hover, &.force-hover, &[data-force-hover="true"]': {
         backgroundColor: 'var(--neutral-white-alpha-30)',
-        color: 'var(--text-neutral-inverse)',
+        color: 'var(--neutral-base-white)',
       },
       '&:active': {
         backgroundColor: 'var(--neutral-white-alpha-30)',


### PR DESCRIPTION
Updates the color variables for the MUI Button and IconButton so this will work with dark themes.

## Links
Jira ticket: [DESIGN2-338](https://codedotorg.atlassian.net/browse/DESIGN2-338)
Related [comment](https://github.com/code-dot-org/code-dot-org/pull/70256/changes#r2687693839) 