### PR TITLE
Refactor GenericPrompt validation function

### DIFF
--- a/apps/i18n/codebridge/en_us.json
+++ b/apps/i18n/codebridge/en_us.json
@@ -33,7 +33,7 @@
   "dragAndDropInstructionsFolders": "To pick up a file or folder, press m. While dragging, use the arrow keys or tab to move the item. Press m, space or enter to drop the item in its new position, or press escape to cancel.",
   "dragAndDropInstructionsTabs": "To pick up a file, press m. While dragging, use the arrow keys or tab to move the file. Press m, space or enter to drop the file in its new position, or press escape to cancel.",
   "duplicateFileError": "Filename {fileName} is already in use in this folder. Please choose a different name.",
-  "duplicateFolderError": "Foldername {folderName} is already in use in this folder. Please choose a different name.",
+  "duplicateFolderError": "Folder name {folderName} is already in use in this folder. Please choose a different name.",
   "duplicateSupportFileError": "Filename {fileName} is already in use in this folder in the level's support code. Please choose a different name.",
   "error": "Error",
   "expectedFailure": "Expected failure",

--- a/apps/src/codebridge/FileBrowser/prompts/openNewFilePrompt.tsx
+++ b/apps/src/codebridge/FileBrowser/prompts/openNewFilePrompt.tsx
@@ -1,7 +1,7 @@
 import {NewFileFunction} from '@codebridge/codebridgeContext/types';
 import {DEFAULT_FOLDER_ID} from '@codebridge/constants';
 import {FolderId, ProjectFile} from '@codebridge/types';
-import {validateFileName} from '@codebridge/utils';
+import {validateFileNameForModal} from '@codebridge/utils';
 
 import codebridgeI18n from '@cdo/apps/codebridge/locale';
 import {MultiFileSource} from '@cdo/apps/lab2/types';
@@ -40,7 +40,7 @@ export const openNewFilePrompt = async ({
     type: DialogType.GenericPrompt,
     title: codebridgeI18n.newFilePrompt(),
     validateInput: (fileName: string) =>
-      validateFileName({
+      validateFileNameForModal({
         fileName,
         folderId,
         projectFiles,

--- a/apps/src/codebridge/FileBrowser/prompts/openNewFolderPrompt.tsx
+++ b/apps/src/codebridge/FileBrowser/prompts/openNewFolderPrompt.tsx
@@ -1,7 +1,7 @@
 import {NewFolderFunction} from '@codebridge/codebridgeContext/types';
 import {DEFAULT_FOLDER_ID} from '@codebridge/constants';
 import {FolderId} from '@codebridge/types';
-import {validateFolderName} from '@codebridge/utils';
+import {validateFolderNameForModal} from '@codebridge/utils';
 
 import codebridgeI18n from '@cdo/apps/codebridge/locale';
 import {MultiFileSource} from '@cdo/apps/lab2/types';
@@ -30,8 +30,13 @@ export const openNewFolderPrompt = async ({
   const results = await dialogControl.showDialog({
     type: DialogType.GenericPrompt,
     title: codebridgeI18n.newFolderPrompt(),
-    validateInput: (folderName: string) =>
-      validateFolderName({folderName, parentId, projectFolders}),
+    validateInput: (folderName: string) => {
+      return validateFolderNameForModal({
+        folderName,
+        parentId,
+        projectFolders,
+      });
+    },
     useModal: true,
   });
   if (results.type !== 'confirm') {

--- a/apps/src/codebridge/FileBrowser/prompts/openRenameFilePrompt.tsx
+++ b/apps/src/codebridge/FileBrowser/prompts/openRenameFilePrompt.tsx
@@ -1,6 +1,6 @@
 import {RenameFileFunction} from '@codebridge/codebridgeContext/types';
 import {ProjectFile, FileId} from '@codebridge/types';
-import {validateFileName} from '@codebridge/utils';
+import {validateFileNameForModal} from '@codebridge/utils';
 
 import codebridgeI18n from '@cdo/apps/codebridge/locale';
 import {MultiFileSource} from '@cdo/apps/lab2/types';
@@ -46,7 +46,7 @@ export const openRenameFilePrompt = async ({
         return;
       }
 
-      return validateFileName({
+      return validateFileNameForModal({
         fileName: newName,
         folderId: file.folderId,
         projectFiles,

--- a/apps/src/codebridge/FileBrowser/prompts/openRenameFolderPrompt.tsx
+++ b/apps/src/codebridge/FileBrowser/prompts/openRenameFolderPrompt.tsx
@@ -1,6 +1,6 @@
 import {RenameFolderFunction} from '@codebridge/codebridgeContext/types';
 import {FolderId} from '@codebridge/types';
-import {validateFolderName} from '@codebridge/utils';
+import {validateFolderNameForModal} from '@codebridge/utils';
 
 import codebridgeI18n from '@cdo/apps/codebridge/locale';
 import {MultiFileSource} from '@cdo/apps/lab2/types';
@@ -36,7 +36,7 @@ export const openRenameFolderPrompt = async ({
         return;
       }
 
-      return validateFolderName({
+      return validateFolderNameForModal({
         folderName: newName,
         parentId: folder.parentId,
         projectFolders,

--- a/apps/src/codebridge/utils/validateFileName.ts
+++ b/apps/src/codebridge/utils/validateFileName.ts
@@ -75,3 +75,15 @@ export const validateFileName = ({
     }
   }
 };
+
+export const validateFileNameForModal = (
+  args: ValidateFileNameArgs
+): {text: string; type: 'error' | 'warning'} | undefined => {
+  const errorMessage = validateFileName(args);
+  if (errorMessage) {
+    return {
+      text: errorMessage,
+      type: 'error',
+    };
+  }
+};

--- a/apps/src/codebridge/utils/validateFolderName.ts
+++ b/apps/src/codebridge/utils/validateFolderName.ts
@@ -45,3 +45,15 @@ export const validateFolderName = ({
     return codebridgeI18n.duplicateFolderError({folderName});
   }
 };
+
+export const validateFolderNameForModal = (
+  args: ValidateFolderNameArgs
+): {text: string; type: 'error' | 'warning'} | undefined => {
+  const errorMessage = validateFolderName(args);
+  if (errorMessage) {
+    return {
+      text: errorMessage,
+      type: 'error',
+    };
+  }
+};

--- a/apps/src/lab2/views/dialogs/GenericPrompt.tsx
+++ b/apps/src/lab2/views/dialogs/GenericPrompt.tsx
@@ -25,8 +25,6 @@ export type GenericPromptProps = Pick<
   ) => {text: string; type: 'error' | 'warning'} | undefined;
   requiresPrompt?: boolean;
   message?: string;
-  confirmButtonTextWithWarning?: string;
-  confirmButtonText?: string;
 };
 
 /**
@@ -75,8 +73,6 @@ const GenericPrompt: React.FunctionComponent<GenericPromptProps> = ({
   validateInput = () => undefined,
   requiresPrompt = true,
   useModal = false,
-  confirmButtonText,
-  confirmButtonTextWithWarning,
 }) => {
   const {promiseArgs, setPromiseArgs} = useDialogControl();
   const prompt = (promiseArgs ?? (value || '')) as string;
@@ -144,7 +140,6 @@ const GenericPrompt: React.FunctionComponent<GenericPromptProps> = ({
     };
 
   const hasError = validationMessage?.type === 'error';
-  const hasWarning = validationMessage?.type === 'warning';
 
   return (
     <GenericDialog
@@ -163,10 +158,6 @@ const GenericPrompt: React.FunctionComponent<GenericPromptProps> = ({
         confirm: {
           callback: () => handleConfirm?.(prompt),
           disabled: hasError || (requiresPrompt && !prompt.length),
-          text:
-            hasWarning && confirmButtonTextWithWarning
-              ? confirmButtonTextWithWarning
-              : confirmButtonText,
         },
         cancel: {callback: () => handleCancel?.()},
       }}

--- a/apps/src/lab2/views/dialogs/GenericPrompt.tsx
+++ b/apps/src/lab2/views/dialogs/GenericPrompt.tsx
@@ -124,7 +124,7 @@ const GenericPrompt: React.FunctionComponent<GenericPromptProps> = ({
     () => {
       if (closeType === 'confirm') {
         const validationError = validateInput(prompt);
-        if (validationError && validationError.type === 'error') {
+        if (validationError) {
           setValidationMessage(validationError);
           return;
         }

--- a/apps/src/lab2/views/dialogs/GenericPrompt.tsx
+++ b/apps/src/lab2/views/dialogs/GenericPrompt.tsx
@@ -20,9 +20,13 @@ export type GenericPromptProps = Pick<
   handleCancel?: () => void;
   placeholder?: string;
   value?: string;
-  validateInput?: (prompt: string) => string | undefined;
+  validateInput?: (
+    prompt: string
+  ) => {text: string; type: 'error' | 'warning'} | undefined;
   requiresPrompt?: boolean;
   message?: string;
+  confirmButtonTextWithWarning?: string;
+  confirmButtonText?: string;
 };
 
 /**
@@ -71,18 +75,20 @@ const GenericPrompt: React.FunctionComponent<GenericPromptProps> = ({
   validateInput = () => undefined,
   requiresPrompt = true,
   useModal = false,
+  confirmButtonText,
+  confirmButtonTextWithWarning,
 }) => {
   const {promiseArgs, setPromiseArgs} = useDialogControl();
   const prompt = (promiseArgs ?? (value || '')) as string;
-  const [errorMessage, setErrorMessage] = useState<string | undefined>(
-    undefined
-  );
+  const [validationMessage, setValidationMessage] = useState<
+    {text: string; type: 'error' | 'warning'} | undefined
+  >(undefined);
 
   const debouncedErrorHandler = useMemo(() => {
     return debounce((newInput: string) => {
-      setErrorMessage(validateInput(newInput));
+      setValidationMessage(validateInput(newInput));
     }, DEBOUNCE_TIME_OUT);
-  }, [setErrorMessage, validateInput]);
+  }, [setValidationMessage, validateInput]);
 
   const handleInputChange = useCallback(
     (newInput: string) => {
@@ -93,18 +99,17 @@ const GenericPrompt: React.FunctionComponent<GenericPromptProps> = ({
       //That'll prevent the error from popping up immediately and giving a chance to type.
       // Otherwise, if there is no input or the user already has an error, then we want to
       // validate immediately (in an attempt to clear the error), so use the non-debounced version.
-      if (newInput.length && !errorMessage?.length) {
+      if (newInput.length && !validationMessage?.text?.length) {
         debouncedErrorHandler(newInput);
       } else {
-        setErrorMessage(validateInput(newInput));
+        setValidationMessage(validateInput(newInput));
       }
     },
     [
-      errorMessage,
-      validateInput,
       setPromiseArgs,
-      setErrorMessage,
+      validationMessage?.text?.length,
       debouncedErrorHandler,
+      validateInput,
     ]
   );
 
@@ -123,8 +128,8 @@ const GenericPrompt: React.FunctionComponent<GenericPromptProps> = ({
     () => {
       if (closeType === 'confirm') {
         const validationError = validateInput(prompt);
-        if (validationError) {
-          setErrorMessage(validationError);
+        if (validationError && validationError.type === 'error') {
+          setValidationMessage(validationError);
           return;
         }
       }
@@ -138,6 +143,9 @@ const GenericPrompt: React.FunctionComponent<GenericPromptProps> = ({
       return defaultCallback();
     };
 
+  const hasError = validationMessage?.type === 'error';
+  const hasWarning = validationMessage?.type === 'warning';
+
   return (
     <GenericDialog
       title={title}
@@ -148,13 +156,17 @@ const GenericPrompt: React.FunctionComponent<GenericPromptProps> = ({
           placeholder={placeholder}
           prompt={prompt}
           handleInputChange={handleInputChange}
-          errorMessage={errorMessage}
+          errorMessage={validationMessage?.text}
         />
       }
       buttons={{
         confirm: {
           callback: () => handleConfirm?.(prompt),
-          disabled: Boolean(errorMessage) || (requiresPrompt && !prompt.length),
+          disabled: hasError || (requiresPrompt && !prompt.length),
+          text:
+            hasWarning && confirmButtonTextWithWarning
+              ? confirmButtonTextWithWarning
+              : confirmButtonText,
         },
         cancel: {callback: () => handleCancel?.()},
       }}


### PR DESCRIPTION
This is pre-work for enabling backpack in Sketch Lab. For Sketch Lab we want to be able to give users a warning that a file name is duplicated in their backpack, but still allow them to go forward with replacing it if they want to. We will still also need to have errors in validating file names, if the name they provide is invalid (contains spaces, for example). Since the Sketch Lab backpack pr will be fairly involved, I wanted to split this into its own PR.

This updates the validation function to return an object with the type of the validation error. We will only disable the continue button if the validation was an error, not a warning.


## Links

- Jira: [AFL-221](https://codedotorg.atlassian.net/browse/AFL-221)

## Testing story
The only place this prompt was used was in adding/renaming files and folders in Codebridge. I confirmed those modals still work as expected.


## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
