### PR TITLE
Backpack v2: clean up logic for automatically opening panel

### DIFF
--- a/apps/src/lab2/views/components/Instructions/ResourcePanel/Backpack/BackpackPanel.tsx
+++ b/apps/src/lab2/views/components/Instructions/ResourcePanel/Backpack/BackpackPanel.tsx
@@ -15,20 +15,25 @@ import moduleStyles from './backpack-panel.module.scss';
 
 const SHOW_RECENTLY_ADDED_DURATION_MS = 3000;
 
-const BackpackPanel: React.FC<BackpackProps> = ({
+interface BackpackPanelProps extends BackpackProps {
+  openPanelCallback: () => void;
+}
+
+type AlertConfig = {type: 'success' | 'danger'; message: string};
+
+const BackpackPanel: React.FC<BackpackPanelProps> = ({
   validateFileName,
   saveFile,
   createNewFile,
   findIdForFileName,
+  openPanelCallback,
 }) => {
   const backpackApi = useBackpackAPIContext();
   const [fileList, setFileList] = useState<string[] | undefined>(undefined);
   const [loadError, setLoadError] = useState<boolean>(false);
   const [isLoading, setIsLoading] = useState<boolean>(false);
   const currentUserId = useAppSelector(state => state.currentUser.userId);
-  const [alertList, setAlertList] = useState<
-    {type: 'success' | 'danger'; message: string}[]
-  >([]);
+  const [alertList, setAlertList] = useState<AlertConfig[]>([]);
   const [recentlyAddedFiles, setRecentlyAddedFiles] = useState<string[]>([]);
 
   const loadBackpackFiles = useCallback(
@@ -72,6 +77,7 @@ const BackpackPanel: React.FC<BackpackProps> = ({
             message: `${filename} successfully saved to your Backpack!`,
           },
         ]);
+        openPanelCallback();
         // Show that the file was recently added for SHOW_RECENTLY_ADDED_DURATION_MS milliseconds.
         setRecentlyAddedFiles(prevFiles => [...prevFiles, filename]);
         setTimeout(() => {
@@ -86,7 +92,7 @@ const BackpackPanel: React.FC<BackpackProps> = ({
         backpackApi?.removeEventListener(listenerId);
       }
     };
-  }, [loadBackpackFiles, backpackApi]);
+  }, [loadBackpackFiles, backpackApi, openPanelCallback]);
 
   if (!backpackApi) {
     let titleMessage = 'Your Backpack is unavailable';
@@ -169,9 +175,10 @@ const BackpackPanel: React.FC<BackpackProps> = ({
           key={fileName}
           fileName={fileName}
           backpackApi={backpackApi}
-          addAlert={(type, message) =>
-            setAlertList(prevAlerts => [...prevAlerts, {type, message}])
-          }
+          addAlert={(type, message) => {
+            setAlertList(prevAlerts => [...prevAlerts, {type, message}]);
+            openPanelCallback();
+          }}
           validateFileName={validateFileName}
           saveFile={saveFile}
           createNewFile={createNewFile}

--- a/apps/src/lab2/views/components/Instructions/ResourcePanel/index.tsx
+++ b/apps/src/lab2/views/components/Instructions/ResourcePanel/index.tsx
@@ -25,8 +25,6 @@ import PanelContainer from '@cdo/apps/lab2/views/components/PanelContainer';
 import StudentRubricView from '@cdo/apps/lab2/views/components/rubrics/StudentRubricView';
 import {useExtraLinksButtonContext} from '@cdo/apps/lab2/views/LabViewsRenderer';
 import {EVENTS} from '@cdo/apps/metrics/AnalyticsConstants';
-import {useBackpackAPIContext} from '@cdo/apps/sharedComponents/backpack/BackpackAPIContext';
-import {BackpackEvent} from '@cdo/apps/sharedComponents/backpack/BackpackClientApi';
 import {commonI18n} from '@cdo/apps/types/locale';
 import {getTypedKeys} from '@cdo/apps/types/utils';
 import {findFirstFocusableElement} from '@cdo/apps/util/findFirstFocusableElement';
@@ -189,8 +187,6 @@ const ResourcePanel: React.FC<ResourcePanelProps> = ({
   const isWidgetView = instructionsProps.levelProperties.widgetView;
   const dispatch = useAppDispatch();
 
-  const backpackApi = useBackpackAPIContext();
-
   // Tooltip should disappear quickly.
   const hideTooltipDelayMs = 10;
 
@@ -276,7 +272,12 @@ const ResourcePanel: React.FC<ResourcePanelProps> = ({
     }
 
     if (showBackpack) {
-      tabMap[Tabs.Backpack] = <BackpackPanel {...backpackProps} />;
+      tabMap[Tabs.Backpack] = (
+        <BackpackPanel
+          {...backpackProps}
+          openPanelCallback={() => setCurrentTab(Tabs.Backpack)}
+        />
+      );
     }
 
     if (
@@ -355,23 +356,6 @@ const ResourcePanel: React.FC<ResourcePanelProps> = ({
     // Reset current tab to instructions when switching levels or viewAsUserId.
     setCurrentTab(Tabs.Instructions);
   }, [levelId, viewAsUserId]);
-
-  useEffect(() => {
-    // Subscribe to backpack changes if we have a backpack and the tab exists.
-    // We set the current tab to backpack if the user just added a file to the backpack.
-    if (backpackApi && availableTabs[Tabs.Backpack]) {
-      const listenerId = backpackApi.addEventListener((event, _) => {
-        if (event === BackpackEvent.FileAdded) {
-          setCurrentTab(Tabs.Backpack);
-        }
-      });
-      return () => {
-        if (listenerId) {
-          backpackApi?.removeEventListener(listenerId);
-        }
-      };
-    }
-  }, [availableTabs, backpackApi]);
 
   // Move focus to panel content when AI Tutor or Version History tab is selected via keyboard.
   useEffect(() => {


### PR DESCRIPTION
Follow up to #70319
This updates the logic for how we automatically open the backpack panel if we have a new alert to show the user. Most of the time the panel should already be open (when saving to the user's project), but it's possible the user will switch panels while the file is uploading if they have a slow network. We also still want to automatically open the panel when they save successfully from their project to the backpack. If a save to the backpack fails in Codebridge, we show an error in a modal (existing behavior). It's important for accessibility that when there is a new alert it is accessible on the screen.

To clean this up, rather than having the resource panel subscribe to backpack changes, instead pass in a function to the panel to set is as the current tab. This way we can use this function on both successes and errors.


## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
