### PR TITLE
Lab2: don't require lesson plan when fetching level properties

### DIFF
--- a/dashboard/app/controllers/lessons_controller.rb
+++ b/dashboard/app/controllers/lessons_controller.rb
@@ -198,7 +198,7 @@ class LessonsController < ApplicationController
     unit_group_unit = unit_context[:unit_group_unit]
 
     @lesson = script.lessons.find do |l|
-      l.has_lesson_plan && l.relative_position == params[:lesson_position].to_i
+      l.relative_position == params[:lesson_position].to_i
     end
     raise ActiveRecord::RecordNotFound unless @lesson
 

--- a/dashboard/test/controllers/lessons_controller_test.rb
+++ b/dashboard/test/controllers/lessons_controller_test.rb
@@ -240,6 +240,13 @@ class LessonsControllerTest < ActionController::TestCase
   test_user_gets_response_for :student_lesson_plan, response: :success, user: :levelbuilder,
                               params: -> {{course_course_name: @in_development_course.name, unit_position: 1, lesson_position: @in_development_unit.lessons[0].relative_position}}, name: 'levelbuilder can view in-development student lesson plan'
 
+  # anyone can fetch lesson level properties
+  test_user_gets_response_for :level_properties, params: -> {{course_course_name: @course.name, unit_position: 1, lesson_position: @lesson.relative_position}}, user: nil, response: :success
+
+  test_user_gets_response_for :level_properties, user: nil, response: :success,
+                              params: -> {{course_course_name: @course.name, unit_position: 1, lesson_position: @lesson2.relative_position}},
+                              name: 'anyone can fetch lesson level properties on a lesson without a lesson plan'
+
   test 'show includes correct SEO data' do
     get :show, params: {
       course_course_name: @course.name,


### PR DESCRIPTION
Fixes a bug where the lesson level_properties API didn't work on lessons without a lesson plan, such as lessons in PL scripts. The `has_lesson_plan` check was inadvertently copied from similar code elsewhere when originally adding this function in https://github.com/code-dot-org/code-dot-org/pull/70246

## Links
https://codedotorg.slack.com/archives/C03DBDN67B7/p1768408540866199

## Testing story
Tested locally with PL scripts + added a test case.