### PR TITLE
Backpack v2: split up useEffect for loading

### DIFF
--- a/apps/src/lab2/views/components/Instructions/ResourcePanel/Backpack/BackpackPanel.tsx
+++ b/apps/src/lab2/views/components/Instructions/ResourcePanel/Backpack/BackpackPanel.tsx
@@ -64,6 +64,9 @@ const BackpackPanel: React.FC<BackpackPanelProps> = ({
   useEffect(() => {
     // Show the load screen on initial load.
     loadBackpackFiles(true);
+  }, [loadBackpackFiles, backpackApi]);
+
+  useEffect(() => {
     // Subscribe to backpack changes. Always reload when notified, as we get notified for file
     // adds or deletes.
     const listenerId = backpackApi?.addEventListener((event, filename) => {


### PR DESCRIPTION
Fix-forward of an unexpected side effect of #70334. I noticed when we switch tabs we were reloading the backpack list every time, which we don't need to do. This seems to be because `openPanelCallback` is triggering the `useEffect` we use to load the list. The easy fix for this is to split up the useEffect into the initial load and the backpack listener registration; it's ok if we have to re-register the listener since we delete the old listener when we return.

## Testing story
Tested locally.



## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
