### PR TITLE
Ensure CFU Widget is able to fetch question and response text regardless of level type

### DIFF
--- a/dashboard/app/controllers/student_snapshots_controller.rb
+++ b/dashboard/app/controllers/student_snapshots_controller.rb
@@ -188,7 +188,11 @@ class StudentSnapshotsController < ApplicationController
           result.empty? ? nil : result.to_i
         end
         level_result[:student_result] = student_result
-        level_result[:status] = student_user_level&.best_result && student_user_level.best_result >= 100 ? "correct" : "incorrect"
+
+        level_result[:status] = "unsubmitted"
+        unless student_result.empty?
+          level_result[:status] = student_user_level&.best_result && student_user_level.best_result >= 100 ? "correct" : "incorrect"
+        end
       end
     else
       level_result[:status] = "unsubmitted"

--- a/dashboard/app/controllers/student_snapshots_controller.rb
+++ b/dashboard/app/controllers/student_snapshots_controller.rb
@@ -100,9 +100,7 @@ class StudentSnapshotsController < ApplicationController
           cfu_responses_data << build_cfu_level_group_response(level, script_level, student, script)
         else
           user_level = user_levels_by_level_id[level.id]
-          student_answer = user_level&.level_source&.data
-
-          response_summary = summarize_cfu_level_result(level, student_answer)
+          response_summary = summarize_cfu_level_result(level, user_level)
 
           cfu_responses_data << {
             level_id: level.id,
@@ -144,7 +142,7 @@ class StudentSnapshotsController < ApplicationController
   # Summarizes a single CFU level result for a given student answer.
   # This mirrors summarize_level_result from Api::V1::AssessmentsController
   # but without aggregated stats.
-  private def summarize_cfu_level_result(level, student_answer)
+  private def summarize_cfu_level_result(level, student_user_level)
     level_result = {
       type: (
         case level
@@ -160,6 +158,8 @@ class StudentSnapshotsController < ApplicationController
         end
       )
     }
+
+    student_answer = student_user_level&.level_source&.data
 
     if student_answer
       case level
@@ -185,12 +185,7 @@ class StudentSnapshotsController < ApplicationController
           result.empty? ? nil : result.to_i
         end
         level_result[:student_result] = student_result
-
-        option_status = []
-        student_result.each_with_index do |answer, index|
-          option_status[index] = answer.nil? ? "unsubmitted" : "submitted"
-        end
-        level_result[:status] = option_status.presence || "unsubmitted"
+        level_result[:status] = student_user_level&.best_result && student_user_level.best_result >= 100 ? "correct" : "incorrect"
       end
     else
       level_result[:status] = "unsubmitted"
@@ -216,9 +211,7 @@ class StudentSnapshotsController < ApplicationController
     parent_ul = latest_by_level_id[level_group.id]
 
     sublevel_results = sublevels.map do |sublevel|
-      ul = latest_by_level_id[sublevel.id]
-      student_answer = ul&.level_source&.data
-      summarize_cfu_level_result(sublevel, student_answer).merge(level_id: sublevel.id)
+      summarize_cfu_level_result(sublevel, latest_by_level_id[sublevel.id]).merge(level_id: sublevel.id)
     end
 
     {

--- a/dashboard/app/controllers/student_snapshots_controller.rb
+++ b/dashboard/app/controllers/student_snapshots_controller.rb
@@ -108,7 +108,7 @@ class StudentSnapshotsController < ApplicationController
             level_id: level.id,
             script_level_id: script_level.id,
             response: response_summary,
-            submitted: user_level&.submitted,
+            submitted: user_level&.submitted || submitted?(response_summary[:status]),
             timestamp: user_level&.updated_at
           }
         end
@@ -228,7 +228,7 @@ class StudentSnapshotsController < ApplicationController
         type: "LevelGroup",
         level_results: sublevel_results
       },
-      submitted: parent_ul&.submitted,
+      submitted: parent_ul&.submitted || (sublevel_results.all? {|sublevel_result| submitted?(sublevel_result[:status])}),
       timestamp: parent_ul&.updated_at
     }
   end
@@ -250,5 +250,9 @@ class StudentSnapshotsController < ApplicationController
       question_text = question_summary&.dig(:question_text) || question_summary&.dig(:question)
       return question_text, (question_summary&.dig(:answers) || question_summary&.dig('answers'))
     end
+  end
+
+  private def submitted?(status)
+    status.is_a?(Array) ? status.exclude?("unsubmitted") : status != "unsubmitted"
   end
 end

--- a/dashboard/app/controllers/student_snapshots_controller.rb
+++ b/dashboard/app/controllers/student_snapshots_controller.rb
@@ -44,6 +44,13 @@ class StudentSnapshotsController < ApplicationController
         question_text = question_summary&.dig(:question_text) || question_summary&.dig(:question)
         answers = question_summary&.dig(:answers)
 
+        # Set question_text to array of sublevel question texts if level is a LevelGroup
+        if level.is_a?(LevelGroup)
+          question_text = level.levels.reduce([]) do |question_texts, sublevel|
+            question_texts << LevelGroup.get_sublevel_question_text(sublevel)
+          end
+        end
+
         cfu_levels_data << {
           id: level.id,
           name: level.name,

--- a/dashboard/app/controllers/student_snapshots_controller.rb
+++ b/dashboard/app/controllers/student_snapshots_controller.rb
@@ -36,10 +36,12 @@ class StudentSnapshotsController < ApplicationController
     lesson = Lesson.find_by(id: lesson_id)
     return render json: {error: "Can't find Lesson id=#{lesson_id}"}, status: :bad_request unless lesson
 
+    lesson_level_ids = lesson.levels&.map(&:id)&.presence || []
     cfu_levels_data = []
     cfu_script_levels_for(lesson).each do |script_level|
       script_level.levels.each do |level|
         question_text, answers = get_level_question_and_answers(level)
+        level_index_in_lesson = lesson_level_ids.index(level.id)
 
         cfu_levels_data << {
           id: level.id,
@@ -48,6 +50,7 @@ class StudentSnapshotsController < ApplicationController
           type: level.type,
           key: level.try(:key),
           script_level_id: script_level.id,
+          level_position: level_index_in_lesson ? level_index_in_lesson + 1 : -1,
           progression: script_level.progression,
           progression_display_name: script_level.progression ? I18n.t(script_level.progression, scope: %i[data progressions], default: script_level.progression) : nil,
           question_text: question_text,

--- a/dashboard/app/controllers/student_snapshots_controller.rb
+++ b/dashboard/app/controllers/student_snapshots_controller.rb
@@ -165,7 +165,7 @@ class StudentSnapshotsController < ApplicationController
       case level
       when TextMatch, FreeResponse
         level_result[:student_result] = student_answer
-        level_result[:status] = ""
+        level_result[:status] = student_answer.empty? ? "unsubmitted" : "submitted"
       when Multi
         answer_indexes = level.correct_answer_indexes_array
         student_result = student_answer.split(",").map(&:to_i).sort
@@ -190,7 +190,7 @@ class StudentSnapshotsController < ApplicationController
         student_result.each_with_index do |answer, index|
           option_status[index] = answer.nil? ? "unsubmitted" : "submitted"
         end
-        level_result[:status] = option_status
+        level_result[:status] = option_status.presence || "unsubmitted"
       end
     else
       level_result[:status] = "unsubmitted"

--- a/dashboard/app/controllers/student_snapshots_controller.rb
+++ b/dashboard/app/controllers/student_snapshots_controller.rb
@@ -39,17 +39,7 @@ class StudentSnapshotsController < ApplicationController
     cfu_levels_data = []
     cfu_script_levels_for(lesson).each do |script_level|
       script_level.levels.each do |level|
-        # Use existing Level helpers to get question text / answers when available.
-        question_summary = level.respond_to?(:question_summary) ? level.question_summary : nil
-        question_text = question_summary&.dig(:question_text) || question_summary&.dig(:question)
-        answers = question_summary&.dig(:answers)
-
-        # Set question_text to array of sublevel question texts if level is a LevelGroup
-        if level.is_a?(LevelGroup)
-          question_text = level.levels.reduce([]) do |question_texts, sublevel|
-            question_texts << LevelGroup.get_sublevel_question_text(sublevel)
-          end
-        end
+        question_text, answers = get_level_question_and_answers(level)
 
         cfu_levels_data << {
           id: level.id,
@@ -241,5 +231,24 @@ class StudentSnapshotsController < ApplicationController
       submitted: parent_ul&.submitted,
       timestamp: parent_ul&.updated_at
     }
+  end
+
+  # For Levels, return its question text and possible answers
+  # For LevelGroups, return an array of the sublevel question texts and their respective possible answers
+  private def get_level_question_and_answers(level)
+    if level.is_a?(LevelGroup)
+      level_group_question_texts = []
+      level_group_answers = []
+      level.levels.each do |sublevel|
+        sublevel_question_text, sublevel_answer_text = get_level_question_and_answers(sublevel)
+        level_group_question_texts << sublevel_question_text
+        level_group_answers << sublevel_answer_text
+      end
+      return level_group_question_texts, level_group_answers
+    else
+      question_summary = level.respond_to?(:question_summary) ? level.question_summary : nil
+      question_text = question_summary&.dig(:question_text) || question_summary&.dig(:question)
+      return question_text, (question_summary&.dig(:answers) || question_summary&.dig('answers'))
+    end
   end
 end

--- a/dashboard/app/models/levels/level_group.rb
+++ b/dashboard/app/models/levels/level_group.rb
@@ -204,6 +204,12 @@ class LevelGroup < DSLDefined
     child_levels.all
   end
 
+  def self.get_sublevel_question_text(sublevel)
+    sublevel.properties.try(:[], "questions").try(:[], 0).try(:[], "text") ||
+      sublevel.properties.try(:[], "question") ||
+      sublevel.properties.try(:[], "long_instructions")
+  end
+
   # Surveys: Given a sublevel, and the known response string to it, return a result hash.
   def self.get_sublevel_result(sublevel, sublevel_response)
     sublevel_result = {}
@@ -226,8 +232,7 @@ class LevelGroup < DSLDefined
   def self.get_levelgroup_survey_results(script_level, section)
     # Go through each sublevel
     script_level.level.levels.map do |sublevel|
-      question_text = sublevel.properties.try(:[], "questions").try(:[], 0).try(:[], "text") ||
-        sublevel.properties.try(:[], "long_instructions")
+      question_text = get_sublevel_question_text(sublevel)
 
       # Go through each student, and make sure to shuffle their results for additional
       # anonymity.

--- a/dashboard/app/models/levels/level_group.rb
+++ b/dashboard/app/models/levels/level_group.rb
@@ -204,12 +204,6 @@ class LevelGroup < DSLDefined
     child_levels.all
   end
 
-  def self.get_sublevel_question_text(sublevel)
-    sublevel.properties.try(:[], "questions").try(:[], 0).try(:[], "text") ||
-      sublevel.properties.try(:[], "question") ||
-      sublevel.properties.try(:[], "long_instructions")
-  end
-
   # Surveys: Given a sublevel, and the known response string to it, return a result hash.
   def self.get_sublevel_result(sublevel, sublevel_response)
     sublevel_result = {}
@@ -232,7 +226,8 @@ class LevelGroup < DSLDefined
   def self.get_levelgroup_survey_results(script_level, section)
     # Go through each sublevel
     script_level.level.levels.map do |sublevel|
-      question_text = get_sublevel_question_text(sublevel)
+      question_text = sublevel.properties.try(:[], "questions").try(:[], 0).try(:[], "text") ||
+        sublevel.properties.try(:[], "long_instructions")
 
       # Go through each student, and make sure to shuffle their results for additional
       # anonymity.

--- a/dashboard/app/models/levels/match.rb
+++ b/dashboard/app/models/levels/match.rb
@@ -57,6 +57,10 @@ class Match < DSLDefined
     properties['content1'] || properties['content2'] || properties['content3'] || properties['markdown'] || ''
   end
 
+  def get_question_text
+    question
+  end
+
   def question_content_class
     question_content_blank = properties['content1'].blank? &&
       properties['content2'].blank? &&

--- a/dashboard/test/controllers/student_snapshots_controller_test.rb
+++ b/dashboard/test/controllers/student_snapshots_controller_test.rb
@@ -161,10 +161,12 @@ class StudentSnapshotsControllerTest < ActionController::TestCase
       {"text" => "answer 2", "correct" => true},
       {"text" => "answer 2", "correct" => true},
     ]
-    cfu_level = create(:level, name: 'CFU Level', type: 'Multi',
+    cfu_level_1 = create(:level, name: 'CFU Level 1', type: 'Multi',
       properties: {display_name: 'CFU Display Name', questions: [{text: 'Question text'}], answers: level_answers}
     )
-    create(:script_level, script: @unit, lesson: @lesson1, progression: 'Check Your Understanding', levels: [cfu_level])
+    cfu_level_2 = create(:level, name: 'CFU Level 2', type: 'Match')
+    cfu_level_3 = create(:level, name: 'CFU Level 3', type: 'FreeResponse')
+    create(:script_level, script: @unit, lesson: @lesson1, progression: 'Check Your Understanding', levels: [cfu_level_1, cfu_level_2, cfu_level_3])
 
     get :cfu_levels, params: {lesson_id: @lesson1.id}
 
@@ -182,6 +184,11 @@ class StudentSnapshotsControllerTest < ActionController::TestCase
     assert_equal 'CFU Display Name', cfu_data['display_name']
     assert_equal cfu_data['question_text'], 'Question text'
     assert_equal cfu_data['answers'], level_answers
+
+    # Ensure level_position is tracked for CFU levels
+    assert_equal 1, cfu_data['level_position']
+    assert_equal 2, response_data['cfu_levels'][1]['level_position']
+    assert_equal 3, response_data['cfu_levels'][2]['level_position']
   end
 
   test "cfu_levels endpoint includes question and possible answers for level" do
@@ -400,19 +407,27 @@ class StudentSnapshotsControllerTest < ActionController::TestCase
     assert_response :ok
     response_data = JSON.parse(response.body)
     responses = response_data['cfu_responses']
-
+    # Correct response
     assert_equal true, responses[0]['submitted']
+    assert_equal 'correct', responses[0]['response']['status']
+    # Incorrect response
     assert_equal true, responses[1]['submitted']
+    assert_equal 'incorrect', responses[1]['response']['status']
+    # Submitted free response
     assert_equal true, responses[2]['submitted']
+    assert_equal 'submitted', responses[2]['response']['status']
 
     get :cfu_responses, params: {lesson_id: @lesson1.id, student_id: student_with_unsubmitted_levels.id}
     assert_response :ok
     response_data = JSON.parse(response.body)
     responses = response_data['cfu_responses']
-
+    # Unsubmitted responses
     assert_equal false, responses[0]['submitted']
+    assert_equal 'unsubmitted', responses[0]['response']['status']
     assert_equal false, responses[1]['submitted']
+    assert_equal 'unsubmitted', responses[0]['response']['status']
     assert_equal false, responses[2]['submitted']
+    assert_equal 'unsubmitted', responses[0]['response']['status']
   end
 
   test "cfu_responses endpoint tracks submitted status for LevelGroup CFUs" do

--- a/dashboard/test/controllers/student_snapshots_controller_test.rb
+++ b/dashboard/test/controllers/student_snapshots_controller_test.rb
@@ -156,7 +156,14 @@ class StudentSnapshotsControllerTest < ActionController::TestCase
   end
 
   test "cfu_levels endpoint includes all required fields" do
-    cfu_level = create(:level, name: 'CFU Level', type: 'Multi', display_name: 'CFU Display Name')
+    level_answers = [
+      {"text" => "answer 1", "correct" => false},
+      {"text" => "answer 2", "correct" => true},
+      {"text" => "answer 2", "correct" => true},
+    ]
+    cfu_level = create(:level, name: 'CFU Level', type: 'Multi',
+      properties: {display_name: 'CFU Display Name', questions: [{text: 'Question text'}], answers: level_answers}
+    )
     create(:script_level, script: @unit, lesson: @lesson1, progression: 'Check Your Understanding', levels: [cfu_level])
 
     get :cfu_levels, params: {lesson_id: @lesson1.id}
@@ -173,9 +180,89 @@ class StudentSnapshotsControllerTest < ActionController::TestCase
     refute_nil cfu_data['progression']
     refute_nil cfu_data['progression_display_name']
     assert_equal 'CFU Display Name', cfu_data['display_name']
-    # New optional fields for question content
-    assert_includes cfu_data.keys, 'question_text'
-    assert_includes cfu_data.keys, 'answers'
+    assert_equal cfu_data['question_text'], 'Question text'
+    assert_equal cfu_data['answers'], level_answers
+  end
+
+  test "cfu_levels endpoint includes question and possible answers for level" do
+    multi_level_answers = [
+      {"text" => "answer 1", "correct" => false},
+      {"text" => "answer 2", "correct" => true},
+    ]
+    match_level_answers = [
+      {"text" => "answer 1"},
+      {"text" => "answer 2"},
+      {"text" => "answer 3"}
+    ]
+
+    multi_cfu_level = create(:level, name: 'Multi CFU Level', type: 'Multi',
+      properties: {display_name: 'Multi CFU Display Name', questions: [{text: 'Multi question text'}], answers: multi_level_answers}
+    )
+    match_cfu_level = create(:level, name: 'Match CFU Level', type: 'Match',
+      properties: {display_name: 'Match CFU Display Name', content1: 'Match question text', answers: match_level_answers}
+    )
+    free_res_cfu_level = create(:level, name: 'Free Response CFU Level', type: 'FreeResponse',
+      properties: {display_name: 'Free Response CFU Display Name', long_instructions: 'Free Response question text', answers: nil}
+    )
+    create(:script_level, script: @unit, lesson: @lesson1, progression: 'Check Your Understanding', levels: [multi_cfu_level])
+    create(:script_level, script: @unit, lesson: @lesson1, progression: 'Check Your Understanding', levels: [match_cfu_level])
+    create(:script_level, script: @unit, lesson: @lesson1, progression: 'Check Your Understanding', levels: [free_res_cfu_level])
+
+    get :cfu_levels, params: {lesson_id: @lesson1.id}
+
+    assert_response :ok
+    response_data = JSON.parse(response.body)
+    cfu_data = response_data['cfu_levels']
+
+    assert_equal 'Multi question text', cfu_data[0]['question_text']
+    assert_equal multi_level_answers, cfu_data[0]['answers']
+    assert_equal 'Match question text', cfu_data[1]['question_text']
+    assert_equal match_level_answers, cfu_data[1]['answers']
+    assert_equal 'Free Response question text', cfu_data[2]['question_text']
+    assert_nil cfu_data[2]['answers']
+  end
+
+  test "cfu_levels endpoint includes question and possible answers for level_group" do
+    multi_sublevel_answers = [
+      {"text" => "answer 1", "correct" => false},
+      {"text" => "answer 2", "correct" => true},
+    ]
+    match_sublevel_answers = [
+      {"text" => "answer 1"},
+      {"text" => "answer 2"},
+      {"text" => "answer 3"}
+    ]
+
+    create(:level, name: 'Multi CFU Level', type: 'Multi',
+      properties: {display_name: 'Multi CFU Display Name', questions: [{text: 'Multi question text'}], answers: multi_sublevel_answers}
+    )
+    create(:level, name: 'Match CFU Level', type: 'Match',
+      properties: {display_name: 'Match CFU Display Name', content1: 'Match question text', answers: match_sublevel_answers}
+    )
+    create(:level, name: 'Free Response CFU Level', type: 'FreeResponse',
+      properties: {display_name: 'Free Response CFU Display Name', long_instructions: 'Free Response question text', answers: nil}
+    )
+    level_group_dsl = <<~DSL
+      name 'LevelGroupLevel1'
+      title 'Level Group'
+      anonymous 'true'
+
+      page
+      level 'Multi CFU Level'
+      level 'Match CFU Level'
+      level 'Free Response CFU Level'
+    DSL
+    level1 = LevelGroup.create_from_level_builder({}, {name: 'LevelGroupLevel1', dsl_text: level_group_dsl})
+    create(:script_level, script: @unit, lesson: @lesson1, progression: 'Check Your Understanding', levels: [level1], assessment: true)
+
+    get :cfu_levels, params: {lesson_id: @lesson1.id}
+
+    assert_response :ok
+    response_data = JSON.parse(response.body)
+    cfu_data = response_data['cfu_levels'].first
+
+    assert_equal ['Multi question text', 'Match question text', 'Free Response question text'], cfu_data['question_text']
+    assert_equal [multi_sublevel_answers, match_sublevel_answers, nil], cfu_data['answers']
   end
 
   test "cfu_levels endpoint uses level name as display_name when display_name is nil" do
@@ -273,5 +360,119 @@ class StudentSnapshotsControllerTest < ActionController::TestCase
     assert_equal sublevel.id, sublevel_result['level_id']
     assert_equal 'FreeResponse', sublevel_result['type']
     assert_equal 'hello world', sublevel_result['student_result']
+  end
+
+  test "cfu_responses endpoint tracks submitted status for CFU levels" do
+    multi_level_answers = [
+      {"text" => "answer 1", "correct" => false},
+      {"text" => "answer 2", "correct" => true},
+    ]
+    match_level_answers = [
+      {"text" => "answer 1"},
+      {"text" => "answer 2"},
+      {"text" => "answer 3"}
+    ]
+
+    multi_cfu_level = create(:level, name: 'Multi CFU Level', type: 'Multi',
+      properties: {display_name: 'Multi CFU Display Name', questions: [{text: 'Multi question text'}], answers: multi_level_answers}
+    )
+    match_cfu_level = create(:level, name: 'Match CFU Level', type: 'Match',
+      properties: {display_name: 'Match CFU Display Name', content1: 'Match question text', answers: match_level_answers}
+    )
+    free_res_cfu_level = create(:level, name: 'Free Response CFU Level', type: 'FreeResponse',
+      properties: {display_name: 'Free Response CFU Display Name', long_instructions: 'Free Response question text', answers: nil}
+    )
+    create(:script_level, script: @unit, lesson: @lesson1, progression: 'Check Your Understanding', levels: [multi_cfu_level])
+    create(:script_level, script: @unit, lesson: @lesson1, progression: 'Check Your Understanding', levels: [match_cfu_level])
+    create(:script_level, script: @unit, lesson: @lesson1, progression: 'Check Your Understanding', levels: [free_res_cfu_level])
+
+    student_with_submitted_levels = create(:student)
+    create(:user_level, user: student_with_submitted_levels, script: @unit, level: multi_cfu_level, level_source: create(:level_source, data: '1'))
+    create(:user_level, user: student_with_submitted_levels, script: @unit, level: match_cfu_level, level_source: create(:level_source, data: '0,2,1'))
+    create(:user_level, user: student_with_submitted_levels, script: @unit, level: free_res_cfu_level, level_source: create(:level_source, data: 'Sample free response text'))
+
+    student_with_unsubmitted_levels = create(:student)
+    create(:user_level, user: student_with_unsubmitted_levels, script: @unit, level: multi_cfu_level, level_source: create(:level_source, data: '-1'))
+    create(:user_level, user: student_with_unsubmitted_levels, script: @unit, level: match_cfu_level, level_source: create(:level_source, data: ''))
+    create(:user_level, user: student_with_unsubmitted_levels, script: @unit, level: free_res_cfu_level, level_source: create(:level_source, data: ''))
+
+    get :cfu_responses, params: {lesson_id: @lesson1.id, student_id: student_with_submitted_levels.id}
+    assert_response :ok
+    response_data = JSON.parse(response.body)
+    responses = response_data['cfu_responses']
+
+    assert_equal true, responses[0]['submitted']
+    assert_equal true, responses[1]['submitted']
+    assert_equal true, responses[2]['submitted']
+
+    get :cfu_responses, params: {lesson_id: @lesson1.id, student_id: student_with_unsubmitted_levels.id}
+    assert_response :ok
+    response_data = JSON.parse(response.body)
+    responses = response_data['cfu_responses']
+
+    assert_equal false, responses[0]['submitted']
+    assert_equal false, responses[1]['submitted']
+    assert_equal false, responses[2]['submitted']
+  end
+
+  test "cfu_responses endpoint tracks submitted status for LevelGroup CFUs" do
+    multi_level_answers = [
+      {"text" => "answer 1", "correct" => false},
+      {"text" => "answer 2", "correct" => true},
+    ]
+    match_level_answers = [
+      {"text" => "answer 1"},
+      {"text" => "answer 2"},
+      {"text" => "answer 3"}
+    ]
+
+    multi_cfu_sublevel = create(:level, name: 'Multi CFU Level', type: 'Multi',
+      properties: {display_name: 'Multi CFU Display Name', questions: [{text: 'Multi question text'}], answers: multi_level_answers}
+    )
+    match_cfu_sublevel = create(:level, name: 'Match CFU Level', type: 'Match',
+      properties: {display_name: 'Match CFU Display Name', content1: 'Match question text', answers: match_level_answers}
+    )
+    free_res_cfu_sublevel = create(:level, name: 'Free Response CFU Level', type: 'FreeResponse',
+      properties: {display_name: 'Free Response CFU Display Name', long_instructions: 'Free Response question text', answers: nil}
+    )
+    level_group_dsl = <<~DSL
+      name 'LevelGroupLevel1'
+      title 'Level Group'
+      anonymous 'true'
+
+      page
+      level 'Multi CFU Level'
+      level 'Match CFU Level'
+      level 'Free Response CFU Level'
+    DSL
+    level_group = LevelGroup.create_from_level_builder({}, {name: 'LevelGroupLevel1', dsl_text: level_group_dsl})
+    create(:script_level, script: @unit, lesson: @lesson1, progression: 'Check Your Understanding', levels: [level_group], assessment: true)
+
+    student_with_submitted_levels = create(:student)
+    # Even if the LevelGroup has a 'submitted' value of 'false', if the student has submitted each sublevel the response will return 'submitted' as 'true'
+    create(:user_level, user: student_with_submitted_levels, script: @unit, level: level_group, submitted: false)
+    create(:user_level, user: student_with_submitted_levels, script: @unit, level: multi_cfu_sublevel, level_source: create(:level_source, data: '1'))
+    create(:user_level, user: student_with_submitted_levels, script: @unit, level: match_cfu_sublevel, level_source: create(:level_source, data: '0,2,1'))
+    create(:user_level, user: student_with_submitted_levels, script: @unit, level: free_res_cfu_sublevel, level_source: create(:level_source, data: 'Sample free response text'))
+
+    student_with_unsubmitted_levels = create(:student)
+    create(:user_level, user: student_with_unsubmitted_levels, script: @unit, level: level_group, submitted: false)
+    create(:user_level, user: student_with_unsubmitted_levels, script: @unit, level: multi_cfu_sublevel, level_source: create(:level_source, data: '-1'))
+    create(:user_level, user: student_with_unsubmitted_levels, script: @unit, level: match_cfu_sublevel, level_source: create(:level_source, data: ''))
+    create(:user_level, user: student_with_unsubmitted_levels, script: @unit, level: free_res_cfu_sublevel, level_source: create(:level_source, data: ''))
+
+    get :cfu_responses, params: {lesson_id: @lesson1.id, student_id: student_with_submitted_levels.id}
+    assert_response :ok
+    response_data = JSON.parse(response.body)
+    student_response = response_data['cfu_responses'].first
+
+    assert_equal true, student_response['submitted']
+
+    get :cfu_responses, params: {lesson_id: @lesson1.id, student_id: student_with_unsubmitted_levels.id}
+    assert_response :ok
+    response_data = JSON.parse(response.body)
+    student_response = response_data['cfu_responses'].first
+
+    assert_equal false, student_response['submitted']
   end
 end

--- a/dashboard/test/models/match_test.rb
+++ b/dashboard/test/models/match_test.rb
@@ -1,6 +1,20 @@
 require 'test_helper'
 
 class MatchLevelTest < ActiveSupport::TestCase
+  test 'parses question text when context text field' do
+    level = Match.create(name: "__q1", level_num: "custom", type: 'Match',
+      properties: {content1: 'Question text'}
+    )
+    assert_equal(level.get_question_text, 'Question text')
+  end
+
+  test 'parses question text when markdown field' do
+    level = Match.create(name: "__q1", level_num: "custom", type: 'Match',
+      properties: {markdown: 'Question text'}
+    )
+    assert_equal(level.get_question_text, 'Question text')
+  end
+
   test 'shuffled answer indexes never exactly match default order' do
     @level = create(
       :match,


### PR DESCRIPTION
Ensures the Student Snapshot CFU Widget is able to fetch questions, possible answers, and student responses regardless of level type. The current CFU Widget prints the raw data its receiving from the endpoint calls for level data and student response data, so I have those screenshots below:

### `cfu_levels` fetches question text and possible answers
Match level:
<img width="379" height="212" alt="match LEVEL" src="https://github.com/user-attachments/assets/fc5d2c63-afab-4fb3-8863-77e64eb8c651" />

Multi level:
<img width="383" height="274" alt="multi LEVEL" src="https://github.com/user-attachments/assets/8e316810-9219-412a-b9a4-f580fd85d795" />

Free response level (also shows that `LevelGroups` work too):
<img width="383" height="251" alt="free response LEVEL" src="https://github.com/user-attachments/assets/52b30f49-0719-4f64-bccb-398d5857f8cf" />

### `cfu_responses` fetches student responses and properly tracks if they've submitted the level or level group
Match level:
<img width="117" height="209" alt="match RESPONSE" src="https://github.com/user-attachments/assets/6e8a2b95-1c2b-4dbb-b928-e62755939e88" />

Multi level:
<img width="124" height="122" alt="multi RESPONSE" src="https://github.com/user-attachments/assets/73b86056-a57f-4ded-afe6-813d30a70915" />

Free response level (also shows that `LevelGroups` work too):
<img width="347" height="226" alt="free response RESPONSE 1" src="https://github.com/user-attachments/assets/0186ae1e-20e3-4a1f-9e1f-c00ab0c0accc" />
<img width="347" height="220" alt="free response RESPONSE 2" src="https://github.com/user-attachments/assets/4d94a38b-d3f4-4a77-8e95-ba89016d18c7" />

## Links
Jira ticket: [here](https://codedotorg.atlassian.net/jira/software/c/projects/TEACHING/boards/678?assignee=60d62161f65054006980bd71&selectedIssue=TEACHING-52)

## Testing story
Local testing and adding unit tests.
