### PR TITLE
Add nginx Error Log to CloudWatch syslog Log Group

### DIFF
--- a/cookbooks/cdo-cloudwatch-agent/attributes/default.rb
+++ b/cookbooks/cdo-cloudwatch-agent/attributes/default.rb
@@ -1,6 +1,11 @@
 default['cdo-cloudwatch-agent'] = {
   log_files: {
     amazon_cloudwatch_agent: '/opt/aws/amazon-cloudwatch-agent/logs/amazon-cloudwatch-agent.log',
-    syslog: %W[/var/log/syslog #{node[:home]}/#{node.chef_environment}/dashboard/log/puma_stdout.log #{node[:home]}/#{node.chef_environment}/dashboard/log/puma_stderr.log]
+    syslog: %W[
+      /var/log/syslog
+      #{node[:home]}/#{node.chef_environment}/dashboard/log/puma_stdout.log
+      #{node[:home]}/#{node.chef_environment}/dashboard/log/puma_stderr.log
+      /var/log/nginx/error.log
+    ]
   }
 }


### PR DESCRIPTION
Helps investigate and diagnose intermitted queued/errored HTTP requests issues.
https://codedotorg.atlassian.net/browse/INF-2021

## Testing story
`bundle exec rake adhoc:start RAILS_ENV=adhoc STACK_NAME=adhoc-nginx-error-logs`

Confirmed that an error that nginx logs during startup of the dashboard service "upstream timed out"  in `/var/log/nginx/error.log` was logged to `adhoc-syslog` CloudWatch Log Group.


## Deployment strategy
<!--  Any special steps required to deploy this, besides merging?
      - Are there database migrations or manual steps?
      - Does this require coordination with other teams or systems? -->



## Follow-up work
<!--  List any clean-up or technical debt that will be addressed in future work.
      - Include Jira links where applicable.
      - Are there any known limitations or improvements planned? -->



## Privacy
<!--  How does this change impact Student & Teacher privacy?
      - Does this collect, use, share, or modify PII, either new or existing? -->



## Security
<!--  How does this change impact our security surface-area?
      - Do API's touched have the right auth?
      - Do infra changes impact our attack surface or encryption?
-->



## Caching
<!--  How does this change impact caching behavior?
      - Are cache keys or invalidation strategies affected?
      - Will this require cache warming or invalidation after deployment? -->



## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
