### PR TITLE
Enabled AIF custom prompts in AI Differentiation

### DIFF
--- a/apps/src/aichat/redux/thunks/fetchThreadMessages.ts
+++ b/apps/src/aichat/redux/thunks/fetchThreadMessages.ts
@@ -7,6 +7,10 @@ import {
   DEFAULT_THREAD_TITLE,
 } from '@cdo/apps/aiDifferentiation/constants';
 import {
+  AIF_PHILOSOPHY_MENU,
+  AIF_LOGISTICS_MENU,
+  AIF_TEACHER_PREP_MENU,
+  AIF_MATERIALS_MENU,
   EXAMPLE_PROMPT,
   EXPLAIN_CONCEPT_PROMPT,
   DEBUG_MISTAKES_PROMPT,
@@ -53,6 +57,13 @@ interface FetchThreadMessagesParams {
 }
 
 const APCSP_PROMPTS = [APCSP_DUMMY_CREATE, APCSP_DUMMY_EXAM];
+
+const AIF_PROMPTS = [
+  AIF_PHILOSOPHY_MENU,
+  AIF_LOGISTICS_MENU,
+  AIF_TEACHER_PREP_MENU,
+  AIF_MATERIALS_MENU,
+];
 
 const SUGGESTED_PROMPTS = [
   EXAMPLE_PROMPT,
@@ -136,6 +147,9 @@ export const fetchThreadMessages = createAsyncThunk(
     const additionalPrompts: ChatPrompt[] = [];
     if (curriculumCourses?.includes('csp')) {
       additionalPrompts.push(...APCSP_PROMPTS);
+    }
+    if (curriculumCourses?.includes('artificial-intelligence-foundations')) {
+      additionalPrompts.push(...AIF_PROMPTS);
     }
     if (contextType === AiDiffContext.LEVEL) {
       additionalPrompts.push(DEBUG_THIS_CODE, IMPROVE_THIS_CODE);

--- a/apps/test/unit/aiDifferentiation/AiDiffChatTest.jsx
+++ b/apps/test/unit/aiDifferentiation/AiDiffChatTest.jsx
@@ -27,6 +27,10 @@ import {
   MINI_LESSON_PROMPT,
   APCSP_DUMMY_CREATE,
   APCSP_DUMMY_EXAM,
+  AIF_PHILOSOPHY_MENU,
+  AIF_LOGISTICS_MENU,
+  AIF_TEACHER_PREP_MENU,
+  AIF_MATERIALS_MENU,
   SUGGESTED_PROMPTS_FOR_SELECTION,
 } from '@cdo/apps/aiDifferentiation/predefinedPrompts';
 import {EVENTS, PLATFORMS} from '@cdo/apps/metrics/AnalyticsConstants';
@@ -351,6 +355,117 @@ describe('AiDiffChat', () => {
           inputText: responseEventData.text,
           isPreset: true,
           presetChipText: 'Can I grade the Create Task',
+          context: {
+            type: AiDiffContext.LESSON,
+            lessonId: 2,
+          },
+        }),
+        true,
+        {
+          'Content-Type': 'application/json',
+        }
+      );
+      expect(sendEventSpy).toHaveBeenCalledWith(
+        EVENTS.AI_DIFF_CHAT_EVENT,
+        responseEventData,
+        PLATFORMS.STATSIG
+      );
+      expect(sendEventSpy).toHaveBeenCalledWith(
+        EVENTS.AI_DIFF_CHAT_EVENT,
+        responseEventData2,
+        PLATFORMS.STATSIG
+      );
+    });
+  });
+
+  it('Selecting a 2-stage AIF suggested prompt gives response and adds second set of prompts to thread messages', async () => {
+    const overrideThreadMessages = [
+      {
+        role: Role.ASSISTANT,
+        chatMessageText:
+          SUGGESTED_PROMPTS_FOR_SELECTION['default'].initialMessage,
+        status: Status.OK,
+      },
+      [
+        ...DEFAULT_SUGGESTED_PROMPTS,
+        AIF_PHILOSOPHY_MENU,
+        AIF_LOGISTICS_MENU,
+        AIF_TEACHER_PREP_MENU,
+        AIF_MATERIALS_MENU,
+      ],
+    ];
+    renderDefault(0, overrideThreadMessages);
+
+    // Click a suggested prompt
+    const suggestedPromptsGroup = screen.getByRole('group', {
+      name: 'Suggested Prompts',
+    });
+    expect(within(suggestedPromptsGroup).getAllByRole('button')).toHaveLength(
+      9
+    );
+    const prompt = screen.getByRole('button', {
+      name: 'Course Philosophy & Big Picture',
+    });
+    fireEvent.click(prompt);
+
+    // Bot message should show in the chat
+    const message = screen.getAllByLabelText(i18n.aiChatMessageBot())[1];
+    expect(message).toHaveTextContent(
+      "Let's explore the philosophy and structure of the AI Fundamentals course. Here are some ideas you can ask me, or type your question below"
+    );
+
+    // Second set of suggested prompts
+    // Count buttons across all groups after new prompts are added
+    const allGroups = screen.getAllByRole('group', {
+      name: 'Suggested Prompts',
+    });
+    const totalButtons = allGroups.flatMap(group =>
+      within(group).getAllByRole('button')
+    );
+    expect(totalButtons).toHaveLength(12);
+    screen.getByRole('button', {name: 'More about Pedagogy'});
+    screen.getByRole('button', {name: 'Which units should I teach?'});
+    screen.getByRole('button', {name: 'Explore Prerequisites'});
+
+    // Click a second step suggested prompt
+    const prompt2 = screen.getByRole('button', {
+      name: 'Explore Prerequisites',
+    });
+    fireEvent.click(prompt2);
+
+    const responseEventData = {
+      chatContext: {
+        type: AiDiffContext.LESSON,
+        lessonId: 2,
+      },
+      scriptName: 'test_lesson',
+      role: Role.USER,
+      isPreset: true,
+      text: 'Are there prerequisites for this course?',
+      threadId: defaultChatResponse.thread_id,
+      url: window.location.href,
+    };
+    const responseEventData2 = {
+      chatContext: {
+        type: AiDiffContext.LESSON,
+        lessonId: 2,
+      },
+      scriptName: 'test_lesson',
+      role: Role.ASSISTANT,
+      isPreset: true,
+      text: "Beep boop I'm a bot",
+      threadId: defaultChatResponse.thread_id,
+      url: window.location.href,
+    };
+
+    // Sends the api call then logs the suggested prompt and the bot message
+    await waitFor(() => {
+      expect(postStub).toHaveBeenCalledWith(
+        '/aidiff_threads',
+        JSON.stringify({
+          inputText: responseEventData.text,
+          isPreset: true,
+          presetChipText: 'Explore Prerequisites',
           context: {
             type: AiDiffContext.LESSON,
             lessonId: 2,


### PR DESCRIPTION
This PR adds AIF predefined prompts for AI Differentiation Chat to pages with AIF courses in context.

Initial predefined prompts:
<img width="774" height="937" alt="Screenshot 2026-01-14 at 14 02 56" src="https://github.com/user-attachments/assets/86c7cf86-9459-4986-941d-7adefe1c19d6" />

Follow-up prompts:
<img width="774" height="937" alt="Screenshot 2026-01-14 at 14 03 13" src="https://github.com/user-attachments/assets/1a71854a-8eb0-4103-91fe-a7e4f5e8dde9" />

## What changed?
This PR extends the AI Differentiation Chat to support course-specific predefined prompts for the Artificial Intelligence Foundations (AIF) curriculum, following the same pattern established for AP CSP prompts.
**Changes include:**
- Updated `fetchThreadMessages` thunk to include AIF prompts when `artificial-intelligence-foundations` is in `curriculumCourses`
- Added comprehensive test coverage for AIF prompts, including 2-stage prompt flow

**How it works:**
When a teacher views AI Differentiation Chat in a context that includes an AIF course, they'll see the 4 additional AIF-specific prompts alongside the default prompts. These prompts follow a 2-stage pattern where selecting one displays follow-up prompts for more specific guidance.

## Links

- Jira: [AITT-1249](https://codedotorg.atlassian.net/browse/AITT-1249)
- [AP CSP prompts PR](https://github.com/code-dot-org/code-dot-org/pull/65947)

## Testing story
**Tests included**
This PR includes unit test coverage:
- New test: `'Selecting a 2-stage AIF suggested prompt gives response and adds second set of prompts to thread messages'`
  - Verifies AIF prompts are rendered (9 total buttons: 5 default + 4 AIF)
  - Tests 2-stage prompt flow with first-stage menu selection
  - Verifies second-stage prompts are displayed and functional
  - Confirms API calls and analytics events are logged correctly

**Manual testing:**
- Navigate to a page with AIF course context
- Open AI Differentiation Chat
- Verify 4 AIF-specific prompts appear
- Click "Course Philosophy & Big Picture" prompt
- Verify follow-up prompts appear (e.g., "More about Pedagogy", "Which units should I teach?", "Explore Prerequisites")
- Click a follow-up prompt and verify it generates a response


## Deployment strategy
<!--  Any special steps required to deploy this, besides merging?
      - Are there database migrations or manual steps?
      - Does this require coordination with other teams or systems? -->



## Follow-up work
<!--  List any clean-up or technical debt that will be addressed in future work.
      - Include Jira links where applicable.
      - Are there any known limitations or improvements planned? -->



## Privacy
<!--  How does this change impact Student & Teacher privacy?
      - Does this collect, use, share, or modify PII, either new or existing? -->



## Security
<!--  How does this change impact our security surface-area?
      - Do API's touched have the right auth?
      - Do infra changes impact our attack surface or encryption?
-->



## Caching
<!--  How does this change impact caching behavior?
      - Are cache keys or invalidation strategies affected?
      - Will this require cache warming or invalidation after deployment? -->



## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
