### PR TITLE
Convert BackpackTest to React Testing Library

### DIFF
--- a/apps/src/javalab/Backpack.jsx
+++ b/apps/src/javalab/Backpack.jsx
@@ -337,6 +337,7 @@ class Backpack extends Component {
           isLegacyStyles
           isRtl={false}
           label={javalabMsg.backpackLabel()}
+          ariaLabel={javalabMsg.backpackLabel()}
           leftJustified
           isDisabled={isButtonDisabled}
           style={{

--- a/apps/test/unit/javalab/BackpackTest.js
+++ b/apps/test/unit/javalab/BackpackTest.js
@@ -1,4 +1,4 @@
-import {mount} from 'enzyme'; // eslint-disable-line no-restricted-imports
+import {act, render} from '@testing-library/react';
 import React from 'react';
 import sinon from 'sinon'; // eslint-disable-line no-restricted-imports
 
@@ -34,56 +34,67 @@ describe('Java Lab Backpack Test', () => {
   });
 
   const renderWithProps = props => {
-    return mount(
+    const backpackRef = React.createRef();
+    const utils = render(
       <BackpackAPIContext.Provider value={backpackApiStub}>
-        <Backpack {...{...defaultProps, ...props}} />
+        <Backpack ref={backpackRef} {...{...defaultProps, ...props}} />
       </BackpackAPIContext.Provider>
     );
+    return {backpackRef, ...utils};
   };
 
   it('updates selected files correctly', () => {
-    const wrapper = renderWithProps({});
-    wrapper
-      .instance()
-      .handleFileCheckboxChange({target: {name: 'Class1.java', checked: true}});
-    wrapper
-      .instance()
-      .handleFileCheckboxChange({target: {name: 'Class2.java', checked: true}});
-    wrapper
-      .instance()
-      .handleFileCheckboxChange({target: {name: 'Class3.java', checked: true}});
-    wrapper.instance().handleFileCheckboxChange({
-      target: {name: 'Class1.java', checked: false},
+    const {backpackRef} = renderWithProps({});
+    act(() => {
+      backpackRef.current.handleFileCheckboxChange({
+        target: {name: 'Class1.java', checked: true},
+      });
     });
-    const selectedFiles = wrapper.instance().state.selectedFiles;
+    act(() => {
+      backpackRef.current.handleFileCheckboxChange({
+        target: {name: 'Class2.java', checked: true},
+      });
+    });
+    act(() => {
+      backpackRef.current.handleFileCheckboxChange({
+        target: {name: 'Class3.java', checked: true},
+      });
+    });
+    act(() => {
+      backpackRef.current.handleFileCheckboxChange({
+        target: {name: 'Class1.java', checked: false},
+      });
+    });
+    const selectedFiles = backpackRef.current.state.selectedFiles;
     expect(selectedFiles.length).to.equal(2);
     expect(selectedFiles[0]).to.equal('Class2.java');
     expect(selectedFiles[1]).to.equal('Class3.java');
   });
 
   it('expand dropdown triggers getFileList', () => {
-    const wrapper = renderWithProps({});
-    const getFileListStub = sinon.stub(
-      BackpackClientApi.prototype,
-      'getFileList'
-    );
-    wrapper.instance().expandDropdown();
-    expect(getFileListStub.calledOnce);
-    getFileListStub.restore();
+    const {backpackRef} = renderWithProps({});
+    act(() => {
+      backpackRef.current.expandDropdown();
+    });
+    expect(backpackApiStub.getFileList.calledOnce).to.be.true;
   });
 
   it('expand dropdown resets state correctly', () => {
-    const wrapper = renderWithProps({});
+    const {backpackRef} = renderWithProps({});
     // set state to something that should be cleared by expandDropdown
-    wrapper.instance().setState({
-      dropdownOpen: false,
-      backpackLoadError: true,
-      selectedFiles: ['file1', 'file2'],
-      backpackFilenames: ['file1', 'file2', 'file3'],
+    act(() => {
+      backpackRef.current.setState({
+        dropdownOpen: false,
+        backpackLoadError: true,
+        selectedFiles: ['file1', 'file2'],
+        backpackFilenames: ['file1', 'file2', 'file3'],
+      });
     });
 
-    wrapper.instance().expandDropdown();
-    const state = wrapper.instance().state;
+    act(() => {
+      backpackRef.current.expandDropdown();
+    });
+    const state = backpackRef.current.state;
     assert(state.dropdownOpen);
     assert.isFalse(state.backpackLoadError);
     expect(state.selectedFiles.length).to.equal(0);
@@ -94,17 +105,21 @@ describe('Java Lab Backpack Test', () => {
     const otherProps = {
       sources: {file1: {isVisible: true}, file2: {isVisible: true}},
     };
-    const wrapper = renderWithProps(otherProps);
+    const {backpackRef} = renderWithProps(otherProps);
     // set state to something that should be cleared by expandDropdown
-    wrapper.instance().setState({
-      dropdownOpen: true,
-      backpackFilenames: ['file1', 'file2', 'file3'],
-      selectedFiles: ['file1', 'file3'],
+    act(() => {
+      backpackRef.current.setState({
+        dropdownOpen: true,
+        backpackFilenames: ['file1', 'file2', 'file3'],
+        selectedFiles: ['file1', 'file3'],
+      });
     });
 
-    wrapper.instance().handleImport();
+    act(() => {
+      backpackRef.current.handleImport();
+    });
 
-    const state = wrapper.instance().state;
+    const state = backpackRef.current.state;
     expect(state.openDialog).to.equal('IMPORT_WARNING');
   });
 
@@ -112,54 +127,66 @@ describe('Java Lab Backpack Test', () => {
     const otherProps = {
       sources: {visibleFile: {isVisible: true}, hiddenFile: {isVisible: false}},
     };
-    const wrapper = renderWithProps(otherProps);
+    const {backpackRef} = renderWithProps(otherProps);
     // set state to something that should be cleared by expandDropdown
-    wrapper.instance().setState({
-      dropdownOpen: true,
-      backpackFilenames: ['visibleFile', 'hiddenFile', 'file3'],
-      selectedFiles: ['hiddenFile', 'file3'],
+    act(() => {
+      backpackRef.current.setState({
+        dropdownOpen: true,
+        backpackFilenames: ['visibleFile', 'hiddenFile', 'file3'],
+        selectedFiles: ['hiddenFile', 'file3'],
+      });
     });
 
-    wrapper.instance().handleImport();
+    act(() => {
+      backpackRef.current.handleImport();
+    });
 
-    const state = wrapper.instance().state;
+    const state = backpackRef.current.state;
     expect(state.openDialog).to.equal('IMPORT_ERROR');
   });
 
   it('no dialog shown if there are no duplicate file names', () => {
-    const wrapper = renderWithProps({});
+    const {backpackRef} = renderWithProps({});
     // set state to something that should be cleared by expandDropdown
-    wrapper.instance().setState({
-      dropdownOpen: true,
-      backpackFilenames: ['file1', 'file2', 'file3'],
-      selectedFiles: ['file2', 'file3'],
+    act(() => {
+      backpackRef.current.setState({
+        dropdownOpen: true,
+        backpackFilenames: ['file1', 'file2', 'file3'],
+        selectedFiles: ['file2', 'file3'],
+      });
     });
 
-    wrapper.instance().handleImport();
+    act(() => {
+      backpackRef.current.handleImport();
+    });
 
-    const state = wrapper.instance().state;
+    const state = backpackRef.current.state;
     expect(state.openDialog).to.equal(null);
   });
 
   it('renders nothing if backpack is disabled', () => {
-    const wrapper = renderWithProps({backpackEnabled: false});
-    expect(wrapper.isEmptyRender()).to.be.true;
+    const {container} = renderWithProps({backpackEnabled: false});
+    expect(container.firstChild).to.equal(null);
   });
 
   it('delete shows warning before deleting files', () => {
     const otherProps = {
       sources: {file1: {isVisible: true}, file2: {isVisible: true}},
     };
-    const wrapper = renderWithProps(otherProps);
-    wrapper.instance().setState({
-      dropdownOpen: true,
-      backpackFilenames: ['file1', 'file2', 'file3'],
-      selectedFiles: ['file1', 'file3'],
+    const {backpackRef} = renderWithProps(otherProps);
+    act(() => {
+      backpackRef.current.setState({
+        dropdownOpen: true,
+        backpackFilenames: ['file1', 'file2', 'file3'],
+        selectedFiles: ['file1', 'file3'],
+      });
     });
 
-    wrapper.instance().confirmAndDeleteFiles();
+    act(() => {
+      backpackRef.current.confirmAndDeleteFiles();
+    });
 
-    const state = wrapper.instance().state;
+    const state = backpackRef.current.state;
     expect(state.openDialog).to.equal('DELETE_CONFIRM');
   });
 
@@ -167,21 +194,27 @@ describe('Java Lab Backpack Test', () => {
     const otherProps = {
       sources: {file1: {isVisible: true}, file2: {isVisible: true}},
     };
-    const wrapper = renderWithProps(otherProps);
-    wrapper.instance().setState({
-      dropdownOpen: true,
-      backpackFilenames: ['file1', 'file2', 'file3'],
-      selectedFiles: ['file1', 'file3'],
+    const {backpackRef} = renderWithProps(otherProps);
+    act(() => {
+      backpackRef.current.setState({
+        dropdownOpen: true,
+        backpackFilenames: ['file1', 'file2', 'file3'],
+        selectedFiles: ['file1', 'file3'],
+      });
     });
     // set up delete files to call success callback
     backpackApiStub.deleteFiles.callsArg(2);
 
     // open modal
-    wrapper.instance().confirmAndDeleteFiles();
+    act(() => {
+      backpackRef.current.confirmAndDeleteFiles();
+    });
     // click delete
-    wrapper.instance().handleDelete();
+    act(() => {
+      backpackRef.current.handleDelete();
+    });
 
-    const state = wrapper.instance().state;
+    const state = backpackRef.current.state;
     expect(state.openDialog).to.equal(null);
   });
 
@@ -189,21 +222,27 @@ describe('Java Lab Backpack Test', () => {
     const otherProps = {
       sources: {file1: {isVisible: true}, file2: {isVisible: true}},
     };
-    const wrapper = renderWithProps(otherProps);
-    wrapper.instance().setState({
-      dropdownOpen: true,
-      backpackFilenames: ['file1', 'file2', 'file3'],
-      selectedFiles: ['file1', 'file3'],
+    const {backpackRef} = renderWithProps(otherProps);
+    act(() => {
+      backpackRef.current.setState({
+        dropdownOpen: true,
+        backpackFilenames: ['file1', 'file2', 'file3'],
+        selectedFiles: ['file1', 'file3'],
+      });
     });
     // set up delete files to call failure callback
     backpackApiStub.deleteFiles.callsArgWith(1, null, ['file1', 'file3']);
 
     // open modal
-    wrapper.instance().confirmAndDeleteFiles();
+    act(() => {
+      backpackRef.current.confirmAndDeleteFiles();
+    });
     // click delete
-    wrapper.instance().handleDelete();
+    act(() => {
+      backpackRef.current.handleDelete();
+    });
 
-    const state = wrapper.instance().state;
+    const state = backpackRef.current.state;
     expect(state.openDialog).to.equal('DELETE_ERROR');
   });
 
@@ -211,21 +250,27 @@ describe('Java Lab Backpack Test', () => {
     const otherProps = {
       sources: {file1: {isVisible: true}, file2: {isVisible: true}},
     };
-    const wrapper = renderWithProps(otherProps);
-    wrapper.instance().setState({
-      dropdownOpen: true,
-      backpackFilenames: ['file1', 'file2', 'file3'],
-      selectedFiles: ['file1', 'file3'],
+    const {backpackRef} = renderWithProps(otherProps);
+    act(() => {
+      backpackRef.current.setState({
+        dropdownOpen: true,
+        backpackFilenames: ['file1', 'file2', 'file3'],
+        selectedFiles: ['file1', 'file3'],
+      });
     });
     // set up delete files to call failure callback where only file 1 failed to delete
     backpackApiStub.deleteFiles.callsArgWith(1, null, ['file1']);
 
     // open modal
-    wrapper.instance().confirmAndDeleteFiles();
+    act(() => {
+      backpackRef.current.confirmAndDeleteFiles();
+    });
     // click delete
-    wrapper.instance().handleDelete();
+    act(() => {
+      backpackRef.current.handleDelete();
+    });
 
-    const state = wrapper.instance().state;
+    const state = backpackRef.current.state;
     const selectedFiles = state.selectedFiles;
     // selected files should only contain the file that failed to delete (file1).
     expect(selectedFiles.length).to.equal(1);

--- a/apps/test/unit/javalab/BackpackTest.js
+++ b/apps/test/unit/javalab/BackpackTest.js
@@ -44,7 +44,9 @@ describe('Java Lab Backpack Test', () => {
   };
 
   const openBackpack = async user => {
-    await user.click(screen.getByRole('button', {name: /backpack/i}));
+    await user.click(
+      screen.getByRole('button', {name: javalabMsg.backpackLabel()})
+    );
   };
 
   it('updates selected files correctly', async () => {

--- a/apps/test/unit/javalab/BackpackTest.js
+++ b/apps/test/unit/javalab/BackpackTest.js
@@ -43,7 +43,7 @@ describe('Java Lab Backpack Test', () => {
     );
   };
 
-  const openBackpack = async user => {
+  const toggleBackpack = async user => {
     await user.click(
       screen.getByRole('button', {name: javalabMsg.backpackLabel()})
     );
@@ -58,7 +58,7 @@ describe('Java Lab Backpack Test', () => {
       'Class3.java',
     ]);
 
-    await openBackpack(user);
+    await toggleBackpack(user);
     await screen.findByLabelText('Class1.java');
     await user.click(screen.getByLabelText('Class1.java'));
     await user.click(screen.getByLabelText('Class2.java'));
@@ -66,22 +66,13 @@ describe('Java Lab Backpack Test', () => {
     await user.click(screen.getByLabelText('Class1.java'));
     await user.click(screen.getByRole('button', {name: javalabMsg.delete()}));
 
-    const confirmMessage = await screen.findByText(
-      javalabMsg.fileDeleteConfirm()
-    );
-    const dialog = confirmMessage.closest('.modal');
-    expect(dialog).to.not.equal(null);
-    const dialogQueries = within(dialog);
-    expect(dialogQueries.queryByText('Class1.java')).to.equal(null);
-    expect(dialogQueries.getByText('Class2.java')).to.not.equal(null);
-    expect(dialogQueries.getByText('Class3.java')).to.not.equal(null);
-  });
+    const class1Checkbox = screen.getByLabelText('Class1.java');
+    const class2Checkbox = screen.getByLabelText('Class2.java');
+    const class3Checkbox = screen.getByLabelText('Class3.java');
 
-  it('expand dropdown triggers getFileList', async () => {
-    const user = userEvent.setup();
-    renderWithProps({});
-    await openBackpack(user);
-    expect(backpackApiStub.getFileList.calledOnce).to.be.true;
+    expect(class1Checkbox.checked).to.be.false;
+    expect(class2Checkbox.checked).to.be.true;
+    expect(class3Checkbox.checked).to.be.true;
   });
 
   it('expand dropdown resets state correctly', async () => {
@@ -90,14 +81,14 @@ describe('Java Lab Backpack Test', () => {
     backpackApiStub.getFileList.onCall(0).callsArgWith(1, ['file1', 'file2']);
     backpackApiStub.getFileList.onCall(1).callsArgWith(1, ['file1', 'file2']);
 
-    await openBackpack(user);
+    await toggleBackpack(user);
     await screen.findByLabelText('file1');
     await user.click(screen.getByLabelText('file1'));
     expect(
       screen.getByRole('button', {name: javalabMsg.import()}).disabled
     ).to.equal(false);
-    await openBackpack(user);
-    await openBackpack(user);
+    await toggleBackpack(user);
+    await toggleBackpack(user);
     await screen.findByLabelText('file1');
     expect(
       screen.getByRole('button', {name: javalabMsg.import()}).disabled
@@ -112,7 +103,7 @@ describe('Java Lab Backpack Test', () => {
     renderWithProps(otherProps);
     backpackApiStub.getFileList.callsArgWith(1, ['file1', 'file2', 'file3']);
 
-    await openBackpack(user);
+    await toggleBackpack(user);
     await screen.findByLabelText('file1');
     await user.click(screen.getByLabelText('file1'));
     await user.click(screen.getByLabelText('file3'));
@@ -140,7 +131,7 @@ describe('Java Lab Backpack Test', () => {
       'file3',
     ]);
 
-    await openBackpack(user);
+    await toggleBackpack(user);
     await screen.findByLabelText('hiddenFile');
     await user.click(screen.getByLabelText('hiddenFile'));
     await user.click(screen.getByLabelText('file3'));
@@ -158,7 +149,7 @@ describe('Java Lab Backpack Test', () => {
     renderWithProps({});
     backpackApiStub.getFileList.callsArgWith(1, ['file1', 'file2', 'file3']);
 
-    await openBackpack(user);
+    await toggleBackpack(user);
     await screen.findByLabelText('file2');
     await user.click(screen.getByLabelText('file2'));
     await user.click(screen.getByLabelText('file3'));
@@ -184,7 +175,7 @@ describe('Java Lab Backpack Test', () => {
     renderWithProps(otherProps);
     backpackApiStub.getFileList.callsArgWith(1, ['file1', 'file2', 'file3']);
 
-    await openBackpack(user);
+    await toggleBackpack(user);
     await screen.findByLabelText('file1');
     await user.click(screen.getByLabelText('file1'));
     await user.click(screen.getByLabelText('file3'));
@@ -210,7 +201,7 @@ describe('Java Lab Backpack Test', () => {
     backpackApiStub.deleteFiles.callsArg(2);
     backpackApiStub.getFileList.callsArgWith(1, ['file1', 'file2', 'file3']);
 
-    await openBackpack(user);
+    await toggleBackpack(user);
     await screen.findByLabelText('file1');
     await user.click(screen.getByLabelText('file1'));
     await user.click(screen.getByLabelText('file3'));
@@ -238,7 +229,7 @@ describe('Java Lab Backpack Test', () => {
     backpackApiStub.deleteFiles.callsArgWith(1, null, ['file1', 'file3']);
     backpackApiStub.getFileList.callsArgWith(1, ['file1', 'file2', 'file3']);
 
-    await openBackpack(user);
+    await toggleBackpack(user);
     await screen.findByLabelText('file1');
     await user.click(screen.getByLabelText('file1'));
     await user.click(screen.getByLabelText('file3'));
@@ -265,7 +256,7 @@ describe('Java Lab Backpack Test', () => {
     backpackApiStub.deleteFiles.callsArgWith(1, null, ['file1']);
     backpackApiStub.getFileList.callsArgWith(1, ['file1', 'file2', 'file3']);
 
-    await openBackpack(user);
+    await toggleBackpack(user);
     await screen.findByLabelText('file1');
     await user.click(screen.getByLabelText('file1'));
     await user.click(screen.getByLabelText('file3'));
@@ -280,6 +271,10 @@ describe('Java Lab Backpack Test', () => {
       within(dialog).getByRole('button', {name: javalabMsg.delete()})
     );
     await screen.findByText(javalabMsg.fileDeleteError());
+
+    const file1Checkbox = screen.getByLabelText('file1');
+    expect(file1Checkbox.checked).to.be.true;
+
     expect(screen.queryByLabelText('file3')).to.equal(null);
   });
 });

--- a/apps/test/unit/javalab/BackpackTest.js
+++ b/apps/test/unit/javalab/BackpackTest.js
@@ -49,32 +49,6 @@ describe('Java Lab Backpack Test', () => {
     );
   };
 
-  it('updates selected files correctly', async () => {
-    const user = userEvent.setup();
-    renderWithProps({});
-    backpackApiStub.getFileList.callsArgWith(1, [
-      'Class1.java',
-      'Class2.java',
-      'Class3.java',
-    ]);
-
-    await toggleBackpack(user);
-    await screen.findByLabelText('Class1.java');
-    await user.click(screen.getByLabelText('Class1.java'));
-    await user.click(screen.getByLabelText('Class2.java'));
-    await user.click(screen.getByLabelText('Class3.java'));
-    await user.click(screen.getByLabelText('Class1.java'));
-    await user.click(screen.getByRole('button', {name: javalabMsg.delete()}));
-
-    const class1Checkbox = screen.getByLabelText('Class1.java');
-    const class2Checkbox = screen.getByLabelText('Class2.java');
-    const class3Checkbox = screen.getByLabelText('Class3.java');
-
-    expect(class1Checkbox.checked).to.be.false;
-    expect(class2Checkbox.checked).to.be.true;
-    expect(class3Checkbox.checked).to.be.true;
-  });
-
   it('expand dropdown resets state correctly', async () => {
     const user = userEvent.setup();
     renderWithProps({});

--- a/apps/test/unit/javalab/BackpackTest.js
+++ b/apps/test/unit/javalab/BackpackTest.js
@@ -1,4 +1,5 @@
-import {act, render} from '@testing-library/react';
+import {render, screen, within} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import React from 'react';
 import sinon from 'sinon'; // eslint-disable-line no-restricted-imports
 
@@ -8,8 +9,9 @@ import javalab from '@cdo/apps/javalab/redux/javalabRedux';
 import {registerReducers, stubRedux, restoreRedux} from '@cdo/apps/redux';
 import {BackpackAPIContext} from '@cdo/apps/sharedComponents/backpack/BackpackAPIContext';
 import BackpackClientApi from '@cdo/apps/sharedComponents/backpack/BackpackClientApi';
+import javalabMsg from '@cdo/javalab/locale';
 
-import {expect, assert} from '../../util/reconfiguredChai'; // eslint-disable-line no-restricted-imports
+import {expect} from '../../util/reconfiguredChai'; // eslint-disable-line no-restricted-imports
 
 describe('Java Lab Backpack Test', () => {
   let defaultProps, backpackApiStub;
@@ -34,134 +36,137 @@ describe('Java Lab Backpack Test', () => {
   });
 
   const renderWithProps = props => {
-    const backpackRef = React.createRef();
-    const utils = render(
+    return render(
       <BackpackAPIContext.Provider value={backpackApiStub}>
-        <Backpack ref={backpackRef} {...{...defaultProps, ...props}} />
+        <Backpack {...{...defaultProps, ...props}} />
       </BackpackAPIContext.Provider>
     );
-    return {backpackRef, ...utils};
   };
 
-  it('updates selected files correctly', () => {
-    const {backpackRef} = renderWithProps({});
-    act(() => {
-      backpackRef.current.handleFileCheckboxChange({
-        target: {name: 'Class1.java', checked: true},
-      });
-    });
-    act(() => {
-      backpackRef.current.handleFileCheckboxChange({
-        target: {name: 'Class2.java', checked: true},
-      });
-    });
-    act(() => {
-      backpackRef.current.handleFileCheckboxChange({
-        target: {name: 'Class3.java', checked: true},
-      });
-    });
-    act(() => {
-      backpackRef.current.handleFileCheckboxChange({
-        target: {name: 'Class1.java', checked: false},
-      });
-    });
-    const selectedFiles = backpackRef.current.state.selectedFiles;
-    expect(selectedFiles.length).to.equal(2);
-    expect(selectedFiles[0]).to.equal('Class2.java');
-    expect(selectedFiles[1]).to.equal('Class3.java');
+  const openBackpack = async user => {
+    await user.click(screen.getByRole('button', {name: /backpack/i}));
+  };
+
+  it('updates selected files correctly', async () => {
+    const user = userEvent.setup();
+    renderWithProps({});
+    backpackApiStub.getFileList.callsArgWith(1, [
+      'Class1.java',
+      'Class2.java',
+      'Class3.java',
+    ]);
+
+    await openBackpack(user);
+    await screen.findByLabelText('Class1.java');
+    await user.click(screen.getByLabelText('Class1.java'));
+    await user.click(screen.getByLabelText('Class2.java'));
+    await user.click(screen.getByLabelText('Class3.java'));
+    await user.click(screen.getByLabelText('Class1.java'));
+    await user.click(screen.getByRole('button', {name: javalabMsg.delete()}));
+
+    const confirmMessage = await screen.findByText(
+      javalabMsg.fileDeleteConfirm()
+    );
+    const dialog = confirmMessage.closest('.modal');
+    expect(dialog).to.not.equal(null);
+    const dialogQueries = within(dialog);
+    expect(dialogQueries.queryByText('Class1.java')).to.equal(null);
+    expect(dialogQueries.getByText('Class2.java')).to.not.equal(null);
+    expect(dialogQueries.getByText('Class3.java')).to.not.equal(null);
   });
 
-  it('expand dropdown triggers getFileList', () => {
-    const {backpackRef} = renderWithProps({});
-    act(() => {
-      backpackRef.current.expandDropdown();
-    });
+  it('expand dropdown triggers getFileList', async () => {
+    const user = userEvent.setup();
+    renderWithProps({});
+    await openBackpack(user);
     expect(backpackApiStub.getFileList.calledOnce).to.be.true;
   });
 
-  it('expand dropdown resets state correctly', () => {
-    const {backpackRef} = renderWithProps({});
-    // set state to something that should be cleared by expandDropdown
-    act(() => {
-      backpackRef.current.setState({
-        dropdownOpen: false,
-        backpackLoadError: true,
-        selectedFiles: ['file1', 'file2'],
-        backpackFilenames: ['file1', 'file2', 'file3'],
-      });
-    });
+  it('expand dropdown resets state correctly', async () => {
+    const user = userEvent.setup();
+    renderWithProps({});
+    backpackApiStub.getFileList.onCall(0).callsArgWith(1, ['file1', 'file2']);
+    backpackApiStub.getFileList.onCall(1).callsArgWith(1, ['file1', 'file2']);
 
-    act(() => {
-      backpackRef.current.expandDropdown();
-    });
-    const state = backpackRef.current.state;
-    assert(state.dropdownOpen);
-    assert.isFalse(state.backpackLoadError);
-    expect(state.selectedFiles.length).to.equal(0);
-    expect(state.backpackFilenames.length).to.equal(0);
+    await openBackpack(user);
+    await screen.findByLabelText('file1');
+    await user.click(screen.getByLabelText('file1'));
+    expect(
+      screen.getByRole('button', {name: javalabMsg.import()}).disabled
+    ).to.equal(false);
+    await openBackpack(user);
+    await openBackpack(user);
+    await screen.findByLabelText('file1');
+    expect(
+      screen.getByRole('button', {name: javalabMsg.import()}).disabled
+    ).to.equal(true);
   });
 
-  it('import shows warning before overwriting files', () => {
+  it('import shows warning before overwriting files', async () => {
+    const user = userEvent.setup();
     const otherProps = {
       sources: {file1: {isVisible: true}, file2: {isVisible: true}},
     };
-    const {backpackRef} = renderWithProps(otherProps);
-    // set state to something that should be cleared by expandDropdown
-    act(() => {
-      backpackRef.current.setState({
-        dropdownOpen: true,
-        backpackFilenames: ['file1', 'file2', 'file3'],
-        selectedFiles: ['file1', 'file3'],
-      });
-    });
+    renderWithProps(otherProps);
+    backpackApiStub.getFileList.callsArgWith(1, ['file1', 'file2', 'file3']);
 
-    act(() => {
-      backpackRef.current.handleImport();
-    });
+    await openBackpack(user);
+    await screen.findByLabelText('file1');
+    await user.click(screen.getByLabelText('file1'));
+    await user.click(screen.getByLabelText('file3'));
+    await user.click(screen.getByRole('button', {name: javalabMsg.import()}));
 
-    const state = backpackRef.current.state;
-    expect(state.openDialog).to.equal('IMPORT_WARNING');
+    const warningMessage = await screen.findByText(
+      javalabMsg.fileImportWarning()
+    );
+    const dialog = warningMessage.closest('.modal');
+    expect(dialog).to.not.equal(null);
+    const dialogQueries = within(dialog);
+    expect(dialogQueries.getByText('file1')).to.not.equal(null);
+    expect(dialogQueries.queryByText('file3')).to.equal(null);
   });
 
-  it('import shows error if hidden file name is used', () => {
+  it('import shows error if hidden file name is used', async () => {
+    const user = userEvent.setup();
     const otherProps = {
       sources: {visibleFile: {isVisible: true}, hiddenFile: {isVisible: false}},
     };
-    const {backpackRef} = renderWithProps(otherProps);
-    // set state to something that should be cleared by expandDropdown
-    act(() => {
-      backpackRef.current.setState({
-        dropdownOpen: true,
-        backpackFilenames: ['visibleFile', 'hiddenFile', 'file3'],
-        selectedFiles: ['hiddenFile', 'file3'],
-      });
-    });
+    renderWithProps(otherProps);
+    backpackApiStub.getFileList.callsArgWith(1, [
+      'visibleFile',
+      'hiddenFile',
+      'file3',
+    ]);
 
-    act(() => {
-      backpackRef.current.handleImport();
-    });
+    await openBackpack(user);
+    await screen.findByLabelText('hiddenFile');
+    await user.click(screen.getByLabelText('hiddenFile'));
+    await user.click(screen.getByLabelText('file3'));
+    await user.click(screen.getByRole('button', {name: javalabMsg.import()}));
 
-    const state = backpackRef.current.state;
-    expect(state.openDialog).to.equal('IMPORT_ERROR');
+    const errorMessage = await screen.findByText(javalabMsg.fileImportError());
+    const dialog = errorMessage.closest('.modal');
+    expect(dialog).to.not.equal(null);
+    const dialogQueries = within(dialog);
+    expect(dialogQueries.getByText('hiddenFile')).to.not.equal(null);
   });
 
-  it('no dialog shown if there are no duplicate file names', () => {
-    const {backpackRef} = renderWithProps({});
-    // set state to something that should be cleared by expandDropdown
-    act(() => {
-      backpackRef.current.setState({
-        dropdownOpen: true,
-        backpackFilenames: ['file1', 'file2', 'file3'],
-        selectedFiles: ['file2', 'file3'],
-      });
-    });
+  it('no dialog shown if there are no duplicate file names', async () => {
+    const user = userEvent.setup();
+    renderWithProps({});
+    backpackApiStub.getFileList.callsArgWith(1, ['file1', 'file2', 'file3']);
 
-    act(() => {
-      backpackRef.current.handleImport();
-    });
+    await openBackpack(user);
+    await screen.findByLabelText('file2');
+    await user.click(screen.getByLabelText('file2'));
+    await user.click(screen.getByLabelText('file3'));
+    await user.click(screen.getByRole('button', {name: javalabMsg.import()}));
 
-    const state = backpackRef.current.state;
-    expect(state.openDialog).to.equal(null);
+    expect(screen.queryByText(javalabMsg.fileImportWarning())).to.equal(null);
+    expect(screen.queryByText(javalabMsg.fileImportError())).to.equal(null);
+    expect(screen.queryByRole('button', {name: javalabMsg.import()})).to.equal(
+      null
+    );
   });
 
   it('renders nothing if backpack is disabled', () => {
@@ -169,113 +174,110 @@ describe('Java Lab Backpack Test', () => {
     expect(container.firstChild).to.equal(null);
   });
 
-  it('delete shows warning before deleting files', () => {
+  it('delete shows warning before deleting files', async () => {
+    const user = userEvent.setup();
     const otherProps = {
       sources: {file1: {isVisible: true}, file2: {isVisible: true}},
     };
-    const {backpackRef} = renderWithProps(otherProps);
-    act(() => {
-      backpackRef.current.setState({
-        dropdownOpen: true,
-        backpackFilenames: ['file1', 'file2', 'file3'],
-        selectedFiles: ['file1', 'file3'],
-      });
-    });
+    renderWithProps(otherProps);
+    backpackApiStub.getFileList.callsArgWith(1, ['file1', 'file2', 'file3']);
 
-    act(() => {
-      backpackRef.current.confirmAndDeleteFiles();
-    });
+    await openBackpack(user);
+    await screen.findByLabelText('file1');
+    await user.click(screen.getByLabelText('file1'));
+    await user.click(screen.getByLabelText('file3'));
+    await user.click(screen.getByRole('button', {name: javalabMsg.delete()}));
 
-    const state = backpackRef.current.state;
-    expect(state.openDialog).to.equal('DELETE_CONFIRM');
+    const confirmMessage = await screen.findByText(
+      javalabMsg.fileDeleteConfirm()
+    );
+    const dialog = confirmMessage.closest('.modal');
+    expect(dialog).to.not.equal(null);
+    const dialogQueries = within(dialog);
+    expect(dialogQueries.getByText('file1')).to.not.equal(null);
+    expect(dialogQueries.getByText('file3')).to.not.equal(null);
   });
 
-  it('dropdown and modal are closed if delete succeeds', () => {
+  it('dropdown and modal are closed if delete succeeds', async () => {
+    const user = userEvent.setup();
     const otherProps = {
       sources: {file1: {isVisible: true}, file2: {isVisible: true}},
     };
-    const {backpackRef} = renderWithProps(otherProps);
-    act(() => {
-      backpackRef.current.setState({
-        dropdownOpen: true,
-        backpackFilenames: ['file1', 'file2', 'file3'],
-        selectedFiles: ['file1', 'file3'],
-      });
-    });
+    renderWithProps(otherProps);
     // set up delete files to call success callback
     backpackApiStub.deleteFiles.callsArg(2);
+    backpackApiStub.getFileList.callsArgWith(1, ['file1', 'file2', 'file3']);
 
-    // open modal
-    act(() => {
-      backpackRef.current.confirmAndDeleteFiles();
-    });
-    // click delete
-    act(() => {
-      backpackRef.current.handleDelete();
-    });
+    await openBackpack(user);
+    await screen.findByLabelText('file1');
+    await user.click(screen.getByLabelText('file1'));
+    await user.click(screen.getByLabelText('file3'));
+    await user.click(screen.getByRole('button', {name: javalabMsg.delete()}));
 
-    const state = backpackRef.current.state;
-    expect(state.openDialog).to.equal(null);
+    const confirmMessage = await screen.findByText(
+      javalabMsg.fileDeleteConfirm()
+    );
+    const dialog = confirmMessage.closest('.modal');
+    expect(dialog).to.not.equal(null);
+    await user.click(
+      within(dialog).getByRole('button', {name: javalabMsg.delete()})
+    );
+    expect(screen.queryByText(javalabMsg.fileDeleteConfirm())).to.equal(null);
+    expect(screen.queryByLabelText('file1')).to.equal(null);
   });
 
-  it('Delete error modal is shown if delete fails', () => {
+  it('Delete error modal is shown if delete fails', async () => {
+    const user = userEvent.setup();
     const otherProps = {
       sources: {file1: {isVisible: true}, file2: {isVisible: true}},
     };
-    const {backpackRef} = renderWithProps(otherProps);
-    act(() => {
-      backpackRef.current.setState({
-        dropdownOpen: true,
-        backpackFilenames: ['file1', 'file2', 'file3'],
-        selectedFiles: ['file1', 'file3'],
-      });
-    });
+    renderWithProps(otherProps);
     // set up delete files to call failure callback
     backpackApiStub.deleteFiles.callsArgWith(1, null, ['file1', 'file3']);
+    backpackApiStub.getFileList.callsArgWith(1, ['file1', 'file2', 'file3']);
 
-    // open modal
-    act(() => {
-      backpackRef.current.confirmAndDeleteFiles();
-    });
-    // click delete
-    act(() => {
-      backpackRef.current.handleDelete();
-    });
+    await openBackpack(user);
+    await screen.findByLabelText('file1');
+    await user.click(screen.getByLabelText('file1'));
+    await user.click(screen.getByLabelText('file3'));
+    await user.click(screen.getByRole('button', {name: javalabMsg.delete()}));
 
-    const state = backpackRef.current.state;
-    expect(state.openDialog).to.equal('DELETE_ERROR');
+    const confirmMessage = await screen.findByText(
+      javalabMsg.fileDeleteConfirm()
+    );
+    const dialog = confirmMessage.closest('.modal');
+    expect(dialog).to.not.equal(null);
+    await user.click(
+      within(dialog).getByRole('button', {name: javalabMsg.delete()})
+    );
+    await screen.findByText(javalabMsg.fileDeleteError());
   });
 
-  it('Deleted files are removed from dropdown on partial delete success', () => {
+  it('Deleted files are removed from dropdown on partial delete success', async () => {
+    const user = userEvent.setup();
     const otherProps = {
       sources: {file1: {isVisible: true}, file2: {isVisible: true}},
     };
-    const {backpackRef} = renderWithProps(otherProps);
-    act(() => {
-      backpackRef.current.setState({
-        dropdownOpen: true,
-        backpackFilenames: ['file1', 'file2', 'file3'],
-        selectedFiles: ['file1', 'file3'],
-      });
-    });
+    renderWithProps(otherProps);
     // set up delete files to call failure callback where only file 1 failed to delete
     backpackApiStub.deleteFiles.callsArgWith(1, null, ['file1']);
+    backpackApiStub.getFileList.callsArgWith(1, ['file1', 'file2', 'file3']);
 
-    // open modal
-    act(() => {
-      backpackRef.current.confirmAndDeleteFiles();
-    });
-    // click delete
-    act(() => {
-      backpackRef.current.handleDelete();
-    });
+    await openBackpack(user);
+    await screen.findByLabelText('file1');
+    await user.click(screen.getByLabelText('file1'));
+    await user.click(screen.getByLabelText('file3'));
+    await user.click(screen.getByRole('button', {name: javalabMsg.delete()}));
 
-    const state = backpackRef.current.state;
-    const selectedFiles = state.selectedFiles;
-    // selected files should only contain the file that failed to delete (file1).
-    expect(selectedFiles.length).to.equal(1);
-    expect(selectedFiles[0]).to.equal('file1');
-    // backpackFilenames should have length 2 (file3 should be gone)
-    expect(state.backpackFilenames.length).to.equal(2);
+    const confirmMessage = await screen.findByText(
+      javalabMsg.fileDeleteConfirm()
+    );
+    const dialog = confirmMessage.closest('.modal');
+    expect(dialog).to.not.equal(null);
+    await user.click(
+      within(dialog).getByRole('button', {name: javalabMsg.delete()})
+    );
+    await screen.findByText(javalabMsg.fileDeleteError());
+    expect(screen.queryByLabelText('file3')).to.equal(null);
   });
 });


### PR DESCRIPTION
Converts our `BackpackTest` (specifically Javalab's usage of the backpack) from Enzyme to React Testing Library (RTL), with a heavy assist from Codex.

Codex started ([commit](https://github.com/code-dot-org/code-dot-org/pull/70358/commits/418f8ac540f1a566bc35baf7043672d68bf5594c)) by doing a conversion to RTL that didn't quite embrace best practices (eg, it was still setting state via calling `setState`, rather than interacting with the UI to produce state changes).

I then asked it to take a second pass ([commit](https://github.com/code-dot-org/code-dot-org/pull/70358/commits/85f6d51966e7ff404c116ac7446c8ecea3ce7be8)) and convert the test file to a more RTL best practice approach. I'm not super familiar with RTL, so I didn't feel like I could skim it well and get a sense of how well it had done. I ended up taking a pretty deep manual pass through this and made some updates ([commit](https://github.com/code-dot-org/code-dot-org/pull/70358/commits/c44bc6444203daaca2016ca180cc4b0b359e842c)), but overall I was pretty happy with what it came up with!

I started with converting this file because a bunch of these tests failed on React 18. These commits are cherry picked from there, where I confirmed that these tests also pass when run against React 18. So, a baby step towards that upgrade.