### PR TITLE
disable corepack download prompt during rake build

### DIFF
--- a/lib/cdo/rake_utils.rb
+++ b/lib/cdo/rake_utils.rb
@@ -228,7 +228,12 @@ module RakeUtils
   end
 
   def self.yarn_install(*args)
-    run_packages_with('yarn', ENV.fetch('CI', nil) && '--frozen-lockfile', *args)
+    commands = []
+    commands << 'COREPACK_ENABLE_DOWNLOAD_PROMPT=0'
+    commands << 'yarn'
+    commands << (ENV.fetch('CI', nil) && '--frozen-lockfile')
+    commands += args
+    RakeUtils.system(*commands)
   end
 
   def self.npm_rebuild(*args)

--- a/lib/cdo/rake_utils.rb
+++ b/lib/cdo/rake_utils.rb
@@ -228,12 +228,7 @@ module RakeUtils
   end
 
   def self.yarn_install(*args)
-    commands = []
-    commands << 'COREPACK_ENABLE_DOWNLOAD_PROMPT=0'
-    commands << 'yarn'
-    commands << (ENV.fetch('CI', nil) && '--frozen-lockfile')
-    commands += args
-    RakeUtils.system(*commands)
+    run_packages_with('COREPACK_ENABLE_DOWNLOAD_PROMPT=0 yarn', ENV.fetch('CI', nil) && '--frozen-lockfile', *args)
   end
 
   def self.npm_rebuild(*args)


### PR DESCRIPTION
see [slack](https://codedotorg.slack.com/archives/C046G4TRLEN/p1768498273983129) for context. Prevents a hidden interactive prompt from blocking `rake build` when run in local development, and possibly other environments, by setting the `COREPACK_ENABLE_DOWNLOAD_PROMPT=0` flag when running `yarn`. docs here: https://github.com/nodejs/corepack?tab=readme-ov-file#environment-variables

I was able to verify that the flag works as expected after being prompted on an ec2 dev instance:
```
[20:58:07] ip-10-0-0-7:~/code-dot-org/apps (staging)$ yarn                                                                                                                                                                            [exit code: 130]
! Corepack is about to download https://repo.yarnpkg.com/4.12.0/packages/yarnpkg-cli/bin/yarn.js
? Do you want to continue? [Y/n] ^C
[20:58:32] ip-10-0-0-7:~/code-dot-org/apps (staging)$ COREPACK_ENABLE_DOWNLOAD_PROMPT=0 yarn                                                                                                                                          [exit code: 130]
➤ YN0000: · Yarn 4.12.0
...
➤ YN0000: · Done with warnings in 5s 273ms
[20:58:44] ip-10-0-0-7:~/code-dot-org/apps (staging)$
```