### PR TITLE
Revert "Revert "refactor(aichat): move request controller helpers to chat helpers""

### DIFF
--- a/dashboard/app/controllers/aichat_requests_controller.rb
+++ b/dashboard/app/controllers/aichat_requests_controller.rb
@@ -87,33 +87,10 @@ class AichatRequestsController < ApplicationController
   end
 
   def create_request
-    safe_params = params.permit(
-      :locale,
-      newMessage: [
-        :role,
-        :chatMessageText,
-        :chatMessageDisplayText,
-        :status,
-        :hiddenContext,
-        :timestamp,
-        {assets: [:filename, :source]},
-        {userAddedSelectionContext: [:sourceCode, :filename, :displayName, {lineReference: [:start, :end]}]}
-      ],
-      storedMessages: [
-        :role,
-        :chatMessageText,
-        :status,
-        :timestamp,
-        {assets: [:filename, :source]},
-      ],
-      modelParameters: [
-        :selectedModelId, :temperature, :systemPrompt,
-        {retrievalContexts: [], responseJsonSchema: {}}
-      ],
-      aichatContext: [:clientType, :currentLevelId, :scriptId, :channelId]
-    ).to_h.deep_symbolize_keys
+    # TODO: confirm request shape and data usage https://codedotorg.atlassian.net/browse/TEACHING-60
+    request_params = params.permit!.to_h.deep_symbolize_keys
 
-    attributes = AichatAiHelper.build_request_attributes(current_user.id, safe_params)
+    attributes = AichatAiHelper.build_request_attributes(current_user.id, request_params)
 
     AichatRequest.new(attributes).tap(&:save!)
   end

--- a/dashboard/app/controllers/aichat_requests_controller.rb
+++ b/dashboard/app/controllers/aichat_requests_controller.rb
@@ -89,8 +89,23 @@ class AichatRequestsController < ApplicationController
   def create_request
     safe_params = params.permit(
       :locale,
-      newMessage: [:role, :chatMessageText, :status, :hiddenContext, :timestamp],
-      storedMessages: [:role, :chatMessageText, :status],
+      newMessage: [
+        :role,
+        :chatMessageText,
+        :chatMessageDisplayText,
+        :status,
+        :hiddenContext,
+        :timestamp,
+        {assets: [:filename, :source]},
+        {userAddedSelectionContext: [:sourceCode, :filename, :displayName, {lineReference: [:start, :end]}]}
+      ],
+      storedMessages: [
+        :role,
+        :chatMessageText,
+        :status,
+        :timestamp,
+        {assets: [:filename, :source]},
+      ],
       modelParameters: [
         :selectedModelId, :temperature, :systemPrompt,
         {retrievalContexts: [], responseJsonSchema: {}}

--- a/dashboard/app/controllers/aichat_requests_controller.rb
+++ b/dashboard/app/controllers/aichat_requests_controller.rb
@@ -46,24 +46,9 @@ class AichatRequestsController < ApplicationController
       return head :too_many_requests
     end
 
-    # Filter out non-OK messages (e.g. errors).
-    messages_for_model = params[:storedMessages].select {|message| message[:status] == SharedConstants::AI_INTERACTION_STATUS[:OK]}
-    context = params[:aichatContext]
-
-    # Add client type to model parameters.
-    params[:modelParameters][:clientType] = params[:aichatContext][:clientType]
-
     # Create the request object.
     begin
-      request = AichatRequest.create!(
-        user_id: current_user.id,
-        model_customizations: params[:modelParameters],
-        stored_messages: messages_for_model,
-        new_message: params[:newMessage],
-        level_id: context[:currentLevelId],
-        script_id: context[:scriptId],
-        project_id: get_project_id(context)
-      )
+      request = create_request
     rescue StandardError => exception
       return render status: :bad_request, json: {error: exception.message}
     end
@@ -99,6 +84,23 @@ class AichatRequestsController < ApplicationController
       response: request.response
     }
     render(status: :ok, json: response_body)
+  end
+
+  def create_request
+    safe_params = params.permit(
+      :locale,
+      newMessage: [:role, :chatMessageText, :status, :hiddenContext, :timestamp],
+      storedMessages: [:role, :chatMessageText, :status],
+      modelParameters: [
+        :selectedModelId, :temperature, :systemPrompt,
+        {retrievalContexts: [], responseJsonSchema: {}}
+      ],
+      aichatContext: [:clientType, :currentLevelId, :scriptId, :channelId]
+    ).to_h.deep_symbolize_keys
+
+    attributes = AichatAiHelper.build_request_attributes(current_user.id, safe_params)
+
+    AichatRequest.new(attributes).tap(&:save!)
   end
 
   private def can_access_ai_tutor_chat_completion?(client_type)
@@ -152,13 +154,6 @@ class AichatRequestsController < ApplicationController
     if params[:aichatModelCustomizations].present?
       params[:modelParameters] = params[:aichatModelCustomizations]
       params.delete(:aichatModelCustomizations)
-    end
-  end
-
-  private def get_project_id(context)
-    if context[:channelId]
-      _, project_id = get_storage_id_and_project_id(context[:channelId])
-      project_id
     end
   end
 

--- a/dashboard/app/helpers/aichat_ai_helper.rb
+++ b/dashboard/app/helpers/aichat_ai_helper.rb
@@ -1,4 +1,5 @@
 require 'cdo/aws/metrics'
+require_relative '../../../shared/middleware/helpers/storage_id'
 
 class OpenaiUserInputResponseTimeout < StandardError; end
 
@@ -206,5 +207,54 @@ module AichatAiHelper
     # "/user/" included to leave space for potential throttling at the classroom/teacher level.
     # Token throttling also only currently in place for gpt-4o-mini, but inclusion of model ID leaves space for other models.
     TOKEN_THROTTLING_PREFIX + 'model/' + model_id + '/user/' + user_id.to_s
+  end
+
+  def self.handle_error(source, exception, request, locale)
+    if rack_env?(:development)
+      puts "#{source} Error: #{exception.full_message}"
+    end
+
+    request.update!(response: exception.message, execution_status: SharedConstants::AI_REQUEST_EXECUTION_STATUS[:FAILURE])
+    Honeybadger.notify(
+      "#{source} failed with unexpected error: #{exception.message}",
+      context: {
+        request: request.to_json,
+        user_id: request.user_id,
+        locale: locale
+      }
+    )
+  end
+
+  def self.build_request_attributes(user_id, params)
+    context = params[:aichatContext] || {}
+    model_customizations = params[:modelParameters] || {}
+
+    # Add client type to model parameters.
+    model_customizations[:clientType] ||= context[:clientType]
+
+    {
+      user_id:              user_id,
+      model_customizations: model_customizations,
+      stored_messages:      successful_stored_chat_messages(params[:storedMessages]),
+      new_message:          params[:newMessage] || {},
+      level_id:             context[:currentLevelId],
+      script_id:            context[:scriptId],
+      project_id:           project_id_from_context(context),
+    }
+  end
+
+  def self.successful_stored_chat_messages(stored_messages)
+    # Filter out non-OK messages (e.g. errors).
+    Array(stored_messages).select do |message|
+      message[:status] == SharedConstants::AI_INTERACTION_STATUS[:OK] &&
+        message[:chatMessageText].present?
+    end
+  end
+
+  def self.project_id_from_context(context)
+    if context[:channelId]
+      _, project_id = get_storage_id_and_project_id(context[:channelId])
+      project_id
+    end
   end
 end

--- a/dashboard/app/jobs/aichat_request_chat_completion_job.rb
+++ b/dashboard/app/jobs/aichat_request_chat_completion_job.rb
@@ -24,18 +24,10 @@ class AichatRequestChatCompletionJob < ApplicationJob
 
   # Catch any exceptions that occur during the job and update the request status accordingly.
   rescue_from StandardError do |exception|
-    if rack_env?(:development)
-      puts "AichatRequestChatCompletionJob Error: #{exception.full_message}"
-    end
-
     request = arguments.first[:request]
-    request.update!(response: exception.message, execution_status: SharedConstants::AI_REQUEST_EXECUTION_STATUS[:FAILURE])
-    Honeybadger.notify(
-      "AichatRequestChatCompletionJob failed with unexpected error: #{exception.message}",
-      context: {
-        request: request.to_json
-      }
-    )
+    locale = arguments.first[:locale]
+
+    AichatAiHelper.handle_error("AichatRequestChatCompletionJob", exception, request, locale)
 
     # Report metrics for the failed job (after_perform doesn't run on failure).
     report_job_finish(request)

--- a/dashboard/test/controllers/aichat_requests_controller_test.rb
+++ b/dashboard/test/controllers/aichat_requests_controller_test.rb
@@ -33,7 +33,7 @@ class AichatRequestsControllerTest < ActionController::TestCase
   end
 
   setup do
-    @controller.stubs(:get_storage_id_and_project_id).returns([123, @project_id])
+    AichatAiHelper.stubs(:project_id_from_context).returns(@project_id)
     DCDO.stubs(:get).with('block_ai_tutor_chat_completion', anything).returns(false)
     DCDO.stubs(:get).with('block_aichat_chat_completion', anything).returns(false)
     DCDO.stubs(:get).with('aichat_request_limit_per_min', anything).returns(AichatRequestsController::DEFAULT_REQUEST_LIMIT_PER_MIN)

--- a/dashboard/test/helpers/aichat_ai_helper_test.rb
+++ b/dashboard/test/helpers/aichat_ai_helper_test.rb
@@ -1,0 +1,268 @@
+require 'test_helper'
+
+class AichatAiHelperTest < ActionView::TestCase
+  describe '.get_api_model' do
+    it 'returns latest OpenAI model version for gpt-4o-mini' do
+      _(AichatAiHelper.get_api_model('gpt-4o-mini')).must_equal SharedConstants::AICHAT_MODEL_VERSION
+    end
+
+    it 'returns the provided model id for non-OpenAI models' do
+      _(AichatAiHelper.get_api_model('gemini-1.5-flash')).must_equal 'gemini-1.5-flash'
+    end
+  end
+
+  describe '.format_message_parts' do
+    let(:encrypted_channel_id) {'encrypted-id'}
+    let(:level_name) {'Level Name'}
+    let(:message_payload) do
+      {
+        'chatMessageText' => 'Hello AI',
+        'assets' => [
+          {'filename' => 'image.png', 'source' => 'project'},
+          {'filename' => 'notes.pdf', 'source' => 'level'}
+        ]
+      }
+    end
+
+    before do
+      AichatAssetHelper.expects(:get_asset_base64_string).
+        with('image.png', 'project', encrypted_channel_id, level_name).
+        returns('image-base64')
+      AichatAssetHelper.expects(:get_asset_base64_string).
+        with('notes.pdf', 'level', encrypted_channel_id, level_name).
+        returns('pdf-base64')
+    end
+
+    it 'includes text and file message parts with mime types' do
+      parts = AichatAiHelper.format_message_parts(message_payload, encrypted_channel_id, level_name)
+
+      _(parts.length).must_equal 3
+      _(parts.first.type).must_equal 'text'
+      _(parts.first.content).must_equal 'Hello AI'
+
+      _(parts.second.type).must_equal 'file'
+      _(parts.second.content.name).must_equal 'image.png'
+      _(parts.second.content.mimeType).must_equal 'image/png'
+      _(parts.second.content.data).must_equal 'image-base64'
+
+      _(parts.third.type).must_equal 'file'
+      _(parts.third.content.name).must_equal 'notes.pdf'
+      _(parts.third.content.mimeType).must_equal 'application/pdf'
+      _(parts.third.content.data).must_equal 'pdf-base64'
+    end
+  end
+
+  describe '.convert_json_schema_to_ruby_types' do
+    it 'builds nested RubyTypes objects for objects and arrays' do
+      schema = {
+        'type' => 'object',
+        'description' => 'Root object',
+        'properties' => {
+          'items' => {
+            'type' => 'array',
+            'description' => 'List of strings',
+            'items' => {
+              'type' => 'string',
+              'description' => 'Item name'
+            }
+          }
+        },
+        'required' => ['items'],
+        'additionalProperties' => false
+      }
+
+      result = AichatAiHelper.convert_json_schema_to_ruby_types(schema)
+
+      _(result).must_be_instance_of AichatAiClientTypes::JsonObjectSchema
+      _(result.description).must_equal 'Root object'
+      _(result.required).must_equal ['items']
+      _(result.additionalProperties).must_equal false
+
+      array_schema = result.properties.items
+      _(array_schema).must_be_instance_of AichatAiClientTypes::JsonArraySchema
+      _(array_schema.description).must_equal 'List of strings'
+
+      _(array_schema.items).must_be_instance_of AichatAiClientTypes::JsonStringSchema
+      _(array_schema.items.description).must_equal 'Item name'
+    end
+
+    it 'raises an error for unsupported schema types' do
+      err = _(-> {AichatAiHelper.convert_json_schema_to_ruby_types({'type' => 'date'})}).must_raise StandardError
+      _(err.message).must_include "Unexpected schema type='date'"
+    end
+  end
+
+  describe '.get_config_request_context' do
+    let(:level_id) {123}
+    let(:model_id) {'gpt-4o-mini'}
+    let(:temperature) {0.4}
+    let(:system_prompt) {'System prompt'}
+    let(:retrieval_contexts) {['retrieved context']}
+    let(:encrypted_channel_id) {'encrypted-channel'}
+    let(:user_id) {456}
+    let(:project_id) {789}
+    let(:client_type) {SharedConstants::AI_CHAT_CLIENT_TYPES[:AI_CHAT_LAB]}
+    let(:json_schema) do
+      {
+        'type' => 'object',
+        'properties' => {'answer' => {'type' => 'string'}},
+        'required' => ['answer'],
+        'additionalProperties' => false
+      }
+    end
+    let(:stored_messages) do
+      [
+        {'role' => 'user', 'chatMessageText' => 'Hi there'},
+        {'role' => 'assistant', 'chatMessageText' => 'Hello'}
+      ]
+    end
+    let(:new_message) do
+      {
+        'role' => 'user',
+        'chatMessageText' => 'New question',
+        'hiddenContext' => 'hidden context'
+      }
+    end
+
+    before do
+      level = OpenStruct.new(
+        properties: {'aichat_settings' => {'levelSystemPrompt' => 'Level system prompt'}},
+        name: 'Level Name'
+      )
+      Level.stubs(:find_by).with(id: level_id).returns(level)
+      DCDO.stubs(:get).with('openai_temperature_scaling_factor', 1.5).returns(1.25)
+
+      @new_message_parts = [AichatAiClientTypes::TextMessagePart.new(type: 'text', content: 'new')]
+      @stored_message_parts = [
+        [AichatAiClientTypes::TextMessagePart.new(type: 'text', content: 'old user')],
+        [AichatAiClientTypes::TextMessagePart.new(type: 'text', content: 'old assistant')]
+      ]
+
+      AichatAiHelper.stubs(:format_message_parts).
+        with(new_message, encrypted_channel_id, 'Level Name').
+        returns(@new_message_parts)
+      AichatAiHelper.stubs(:format_message_parts).
+        with(stored_messages.first, encrypted_channel_id, 'Level Name').
+        returns(@stored_message_parts.first)
+      AichatAiHelper.stubs(:format_message_parts).
+        with(stored_messages.second, encrypted_channel_id, 'Level Name').
+        returns(@stored_message_parts.second)
+    end
+
+    it 'returns config, request, and context with scaled temperature and system instructions' do
+      config, request, context = AichatAiHelper.get_config_request_context(
+        stored_messages,
+        new_message,
+        temperature,
+        system_prompt,
+        retrieval_contexts,
+        model_id,
+        level_id,
+        encrypted_channel_id,
+        user_id,
+        project_id,
+        client_type,
+        json_schema
+      )
+
+      _(config.model).must_equal SharedConstants::AICHAT_MODEL_VERSION
+      _(config.temperature).must_equal temperature * 1.25
+      _(config.systemInstructions.map(&:content)).must_equal [
+        'Level system prompt',
+        system_prompt,
+        'retrieved context',
+        'hidden context'
+      ]
+      _(config.response).must_be_instance_of AichatAiClientTypes::JsonResponseConfig
+
+      _(request).must_equal @new_message_parts
+
+      _(context.length).must_equal 2
+      _(context.first.role).must_equal 'user'
+      _(context.first.parts).must_equal @stored_message_parts.first
+      _(context.second.role).must_equal 'model'
+      _(context.second.parts).must_equal @stored_message_parts.second
+    end
+  end
+
+  describe '.build_request_attributes' do
+    let(:stored_messages) do
+      [
+        {
+          status: SharedConstants::AI_INTERACTION_STATUS[:OK],
+          chatMessageText: 'keep this'
+        },
+        {
+          status: 'ERROR',
+          chatMessageText: 'drop this'
+        },
+        {
+          status: SharedConstants::AI_INTERACTION_STATUS[:OK],
+          chatMessageText: ''
+        }
+      ]
+    end
+
+    let(:params) do
+      {
+        aichatContext: {
+          clientType: SharedConstants::AI_CHAT_CLIENT_TYPES[:AI_CHAT_LAB],
+          currentLevelId: 7,
+          scriptId: 3,
+        },
+        modelParameters: {temperature: 0.8},
+        storedMessages: stored_messages,
+        newMessage: {chatMessageText: 'latest message'}
+      }
+    end
+
+    it 'builds attributes with filtered messages and context' do
+      attributes = AichatAiHelper.build_request_attributes(10, params)
+
+      _(attributes[:user_id]).must_equal 10
+      _(attributes[:model_customizations][:temperature]).must_equal 0.8
+      _(attributes[:model_customizations][:clientType]).must_equal SharedConstants::AI_CHAT_CLIENT_TYPES[:AI_CHAT_LAB]
+
+      _(attributes[:stored_messages]).must_equal [stored_messages.first]
+      _(attributes[:new_message]).must_equal params[:newMessage]
+      _(attributes[:level_id]).must_equal 7
+      _(attributes[:script_id]).must_equal 3
+      _(attributes[:project_id]).must_be_nil
+    end
+  end
+
+  describe '.successful_stored_chat_messages' do
+    it 'filters out non-OK or blank messages' do
+      messages = [
+        {status: SharedConstants::AI_INTERACTION_STATUS[:OK], chatMessageText: 'keep'},
+        {status: SharedConstants::AI_INTERACTION_STATUS[:ERROR], chatMessageText: 'drop'},
+        {status: SharedConstants::AI_INTERACTION_STATUS[:OK], chatMessageText: ''}
+      ]
+
+      result = AichatAiHelper.successful_stored_chat_messages(messages)
+
+      _(result).must_equal [messages.first]
+    end
+  end
+
+  describe '.project_id_from_context' do
+    it 'returns decrypted project id from channel id' do
+      AichatAiHelper.stubs(:get_storage_id_and_project_id).with('encrypted').returns([456, 789])
+
+      _(AichatAiHelper.project_id_from_context({channelId: 'encrypted'})).must_equal 789
+    end
+
+    it 'returns nil if no channel id' do
+      AichatAiHelper.stubs(:get_storage_id_and_project_id).with('encrypted').returns([456, 789])
+
+      _(AichatAiHelper.project_id_from_context({})).must_be_nil
+    end
+
+    it 'raises an error when decryption fails' do
+      AichatAiHelper.stubs(:get_storage_id_and_project_id).raises(StandardError.new('boom'))
+
+      err = _(-> {AichatAiHelper.project_id_from_context({channelId: 'encrypted'})}).must_raise StandardError
+      _(err.message).must_include "boom"
+    end
+  end
+end


### PR DESCRIPTION
Reverts code-dot-org/code-dot-org#70366

reverts a revert for https://github.com/code-dot-org/code-dot-org/pull/70249 where I added strong parameters to the aichat request controller, but missed a few

instead of updating the permitted params, I'm permitting all like it was before. I've created a ticket to follow up and add strong parameters in a future pr https://codedotorg.atlassian.net/browse/TEACHING-60