### PR TITLE
Create cronjob for inactive teacher deletion warning job

### DIFF
--- a/cookbooks/cdo-apps/templates/default/crontab.erb
+++ b/cookbooks/cdo-apps/templates/default/crontab.erb
@@ -122,8 +122,7 @@
       cronjob at:"0 8 * * *", do:"#{deploy_dir('bin', 'cron', 'perform_job')} User::PiiScrubberJob"
 
       # Send Warning Emails to Inactive Teacher Accounts before Deletion
-      cronjob at: "0,30 16-23 * * *", do: "#{deploy_dir('bin', 'cron', 'perform_job')} User::InactiveTeacherDeletionWarningJob limit=1000"
-      cronjob at: "0,30 0-3 * * *", do: "#{deploy_dir('bin', 'cron', 'perform_job')} User::InactiveTeacherDeletionWarningJob limit=1000"
+      cronjob at: "0,30 0-11 * * *", do: "#{deploy_dir('bin', 'cron', 'perform_job')} User::InactiveTeacherDeletionWarningJob limit=1000"
     end
 
     # 'daemons' in all environments.

--- a/cookbooks/cdo-apps/templates/default/crontab.erb
+++ b/cookbooks/cdo-apps/templates/default/crontab.erb
@@ -120,6 +120,10 @@
 
       # Scrub PII from expired deleted accounts nightly at 8:00 AM UTC.
       cronjob at:"0 8 * * *", do:"#{deploy_dir('bin', 'cron', 'perform_job')} User::PiiScrubberJob"
+
+      # Send Warning Emails to Inactive Teacher Accounts before Deletion
+      cronjob at: "0,30 16-23 * * *", do: "#{deploy_dir('bin', 'cron', 'perform_job')} User::InactiveTeacherDeletionWarningJob limit=1000"
+      cronjob at: "0,30 0-3 * * *", do: "#{deploy_dir('bin', 'cron', 'perform_job')} User::InactiveTeacherDeletionWarningJob limit=1000"
     end
 
     # 'daemons' in all environments.

--- a/dashboard/app/jobs/user/inactive_teacher_deletion_warning_job.rb
+++ b/dashboard/app/jobs/user/inactive_teacher_deletion_warning_job.rb
@@ -7,6 +7,7 @@ class User
     rescue_from StandardError, with: :report_exception
 
     def perform(dry_run: false, limit: nil)
+      return unless DCDO.get('inactive_teacher_deletion_warning', false)
       InactiveTeacherDeletionWarningMailer.new(dry_run:, limit:).call
     end
   end


### PR DESCRIPTION
Schedules the InactiveTeacherDeletionWarningJob to run on a recurring cron schedule to send warning emails to teachers whose accounts are approaching deletion due to inactivity.

Schedule

- Runs every 30 minutes
- Active window: 4:00 PM – 3:30 AM PST
- Total runs per day: 33


Throughput & Performance
- Average processing time: ~1.5 seconds per teacher
- Limit per run: 1,000 teachers
- Estimated runtime per job: ~20 minutes
- Maximum daily capacity: ~33,000 teachers per day

## Links


- Jira: [here](https://codedotorg.atlassian.net/browse/P20-1758)

