### PR TITLE
Backpack v2: disable buttons while action is in progress

### DIFF
--- a/apps/src/lab2/views/components/Instructions/ResourcePanel/Backpack/BackpackFileChip.tsx
+++ b/apps/src/lab2/views/components/Instructions/ResourcePanel/Backpack/BackpackFileChip.tsx
@@ -31,6 +31,8 @@ interface BackpackFileChipProps extends BackpackProps {
   backpackApi: BackpackClientApi;
   addAlert: (type: 'success' | 'danger', message: string) => void;
   isRecentlyAdded?: boolean;
+  disableActions: boolean;
+  setActionInProgress: (inProgress: boolean) => void;
 }
 
 const EXTENSIONS_WITH_PREVIEWS = ['png', 'jpg', 'jpeg', 'gif'];
@@ -46,6 +48,8 @@ const BackpackFileChip: React.FC<BackpackFileChipProps> = ({
   findIdForFileName,
   isRecentlyAdded,
   supportedFileTypes,
+  disableActions,
+  setActionInProgress,
 }) => {
   const fileExtension = fileName.split('.').pop()?.toLowerCase();
   const fileIcon = useMemo(
@@ -65,17 +69,19 @@ const BackpackFileChip: React.FC<BackpackFileChipProps> = ({
   const inReadOnly = useAppSelector(isReadOnlyWorkspace);
   const isFileSupported =
     fileExtension && supportedFileTypes.includes(fileExtension);
-  // If we are in read-only mode or the file type is unsupported, disable the add button.
-  const addButtonDisabled = inReadOnly || !isFileSupported;
+  // If the parent tells us to, we are in read-only mode, or the file type is unsupported, disable the add button.
+  const addButtonDisabled = inReadOnly || !isFileSupported || disableActions;
   const addButtonTooltipText = useMemo(() => {
-    if (inReadOnly) {
+    if (disableActions) {
+      return 'An operation is currently in progress';
+    } else if (inReadOnly) {
       return 'Cannot add files in read-only mode';
     } else if (!isFileSupported) {
       return 'File type not supported in this project';
     } else {
       return 'Add to project';
     }
-  }, [inReadOnly, isFileSupported]);
+  }, [disableActions, inReadOnly, isFileSupported]);
 
   const filePreviewUrl = useMemo(() => {
     if (fileExtension && EXTENSIONS_WITH_PREVIEWS.includes(fileExtension)) {
@@ -89,9 +95,10 @@ const BackpackFileChip: React.FC<BackpackFileChipProps> = ({
   }, [backpackApi, fileExtension, fileName, isRecentlyAdded]);
 
   const handleAdd = async () => {
+    setActionInProgress(true);
     const {isSupportFileName, newFileName} = validateFileName(fileName);
     if (isSupportFileName) {
-      handleSaveSupportFile(
+      await handleSaveSupportFile(
         dialogControl,
         backpackApi,
         channelId,
@@ -102,10 +109,8 @@ const BackpackFileChip: React.FC<BackpackFileChipProps> = ({
         fileName,
         newFileName
       );
-      return;
-    }
-    if (newFileName !== fileName) {
-      handleSaveDuplicateFile(
+    } else if (newFileName !== fileName) {
+      await handleSaveDuplicateFile(
         dialogControl,
         backpackApi,
         channelId,
@@ -116,7 +121,6 @@ const BackpackFileChip: React.FC<BackpackFileChipProps> = ({
         fileName,
         newFileName
       );
-      return;
     } else {
       // Fetch backpack file content and import new file to project - not a duplicate file name.
       await fetchAndSaveFile(
@@ -130,9 +134,11 @@ const BackpackFileChip: React.FC<BackpackFileChipProps> = ({
         fileName
       );
     }
+    setActionInProgress(false);
   };
 
   const handleDelete = async () => {
+    setActionInProgress(true);
     // Show confirmation modal
     const results = await dialogControl?.showDialog({
       type: DialogType.GenericConfirmation,
@@ -152,9 +158,11 @@ const BackpackFileChip: React.FC<BackpackFileChipProps> = ({
           Lab2Registry.getInstance()
             .getMetricsReporter()
             .logError('Backpack file delete error', error);
+          setActionInProgress(false);
         },
         () => {
           // TODO: log to statsig
+          setActionInProgress(false);
         }
       );
     }
@@ -242,6 +250,7 @@ const BackpackFileChip: React.FC<BackpackFileChipProps> = ({
             size: 'xs',
           }}
           menuPlacement="right"
+          disabled={disableActions}
         />
       </div>
     </div>

--- a/apps/src/lab2/views/components/Instructions/ResourcePanel/Backpack/BackpackPanel.tsx
+++ b/apps/src/lab2/views/components/Instructions/ResourcePanel/Backpack/BackpackPanel.tsx
@@ -37,6 +37,7 @@ const BackpackPanel: React.FC<BackpackPanelProps> = ({
   const currentUserId = useAppSelector(state => state.currentUser.userId);
   const [alertList, setAlertList] = useState<AlertConfig[]>([]);
   const [recentlyAddedFiles, setRecentlyAddedFiles] = useState<string[]>([]);
+  const [actionInProgress, setActionInProgress] = useState<boolean>(false);
 
   const loadBackpackFiles = useCallback(
     (showLoading: boolean) => {
@@ -195,6 +196,8 @@ const BackpackPanel: React.FC<BackpackPanelProps> = ({
             findIdForFileName={findIdForFileName}
             isRecentlyAdded={recentlyAddedFiles.includes(fileName)}
             supportedFileTypes={supportedFileTypes}
+            setActionInProgress={setActionInProgress}
+            disableActions={actionInProgress}
           />
         ))}
       </div>


### PR DESCRIPTION
I noticed you could double click on the add button and end up with duplicate versions of a file in your project, which we don't want. To fix this, if we are currently adding or deleting a file from the backpack panel, disable all the add/delete buttons in the panel. Delete has less risk, but if a user deleted a file, and while that delete was in progress tried to add that file to their project, we might hit a weird error.

## Screen recording

https://github.com/user-attachments/assets/c986aa53-6614-4534-8f7a-e9f933d27fba


## Testing story
Tested locally. I confirmed we will correctly re-enable the buttons even if the request fails.



## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
