### PR TITLE
fix: conditionally apply buttonFlex style based on language preference

### DIFF
--- a/apps/src/templates/curriculumCatalog/CurriculumCatalogCard.jsx
+++ b/apps/src/templates/curriculumCatalog/CurriculumCatalogCard.jsx
@@ -350,7 +350,10 @@ const CustomizableCurriculumCatalogCard = ({
                   variant="outlined"
                   color="secondary"
                   size="medium"
-                  className={`${style.buttonFlex} ${style.quickViewButton}`}
+                  className={classNames(
+                    style.quickViewButton,
+                    isEnglish && style.buttonFlex
+                  )}
                   aria-label={quickViewButtonDescription}
                   type="button"
                 >
@@ -363,7 +366,10 @@ const CustomizableCurriculumCatalogCard = ({
                     variant="outlined"
                     color="secondary"
                     size="medium"
-                    className={`${style.buttonFlex} ${style.teacherAndSignedOutLearnMoreButton}`}
+                    className={classNames(
+                      style.teacherAndSignedOutLearnMoreButton,
+                      isEnglish && style.buttonFlex
+                    )}
                     aria-label={i18n.learnMoreDescription({
                       course_name: courseDisplayName,
                     })}
@@ -375,7 +381,7 @@ const CustomizableCurriculumCatalogCard = ({
                     variant="contained"
                     color="primary"
                     size="medium"
-                    className={style.buttonFlex}
+                    className={classNames(isEnglish && style.buttonFlex)}
                     onClick={() => handleClickAssign('top-card')}
                     aria-label={assignButtonDescription}
                     type="button"
@@ -389,7 +395,10 @@ const CustomizableCurriculumCatalogCard = ({
                   variant="contained"
                   color="primary"
                   size="medium"
-                  className={`${style.buttonFlex} ${style.studentLearnMoreButton}`}
+                  className={classNames(
+                    style.studentLearnMoreButton,
+                    isEnglish && style.buttonFlex
+                  )}
                   aria-label={i18n.tryCourseNow({
                     course_name: courseDisplayName,
                   })}


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
## fix: conditionally apply buttonFlex style based on language preference
A hotfix after https://github.com/code-dot-org/code-dot-org/pull/70308, more info here: https://codedotorg.slack.com/archives/C0T0PNTM3/p1768541991865849

screenshot shows that in non-english layout everything is displayed correctly 

<img width="1081" height="945" alt="Знімок екрана 2026-01-16 о 16 07 01" src="https://github.com/user-attachments/assets/d37b1c3f-6cca-4434-be73-ce3686c2187a" />



## Links
<!--  Links to relevant external resources.
      - spec docs, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- Jira: 

## Testing story
<!--  Does your change include appropriate tests?
      - If so, please describe how the tests included in this PR are sufficient.
      - If not, please explain why this change does not need to be tested. -->



## Deployment strategy
<!--  Any special steps required to deploy this, besides merging?
      - Are there database migrations or manual steps?
      - Does this require coordination with other teams or systems? -->



## Follow-up work
<!--  List any clean-up or technical debt that will be addressed in future work.
      - Include Jira links where applicable.
      - Are there any known limitations or improvements planned? -->



## Privacy
<!--  How does this change impact Student & Teacher privacy?
      - Does this collect, use, share, or modify PII, either new or existing? -->



## Security
<!--  How does this change impact our security surface-area?
      - Do API's touched have the right auth?
      - Do infra changes impact our attack surface or encryption?
-->



## Caching
<!--  How does this change impact caching behavior?
      - Are cache keys or invalidation strategies affected?
      - Will this require cache warming or invalidation after deployment? -->



## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
