### PR TITLE
feat: prevents users from enrolling in workshops unless they have a school_info with us country

### DIFF
--- a/apps/src/code-studio/pd/workshop_enrollment/constants.ts
+++ b/apps/src/code-studio/pd/workshop_enrollment/constants.ts
@@ -7,6 +7,8 @@ export const SUBMISSION_STATUSES = {
   CLOSED: 'closed',
   FULL: 'full',
   NOT_FOUND: 'not found',
+  NO_SCHOOL: 'no school',
+  NOT_USA: 'not usa',
   SUCCESS: 'success',
   UNKNOWN_ERROR: 'error',
 };

--- a/apps/src/code-studio/pd/workshops/hooks/useWorkshopEnrollment.ts
+++ b/apps/src/code-studio/pd/workshops/hooks/useWorkshopEnrollment.ts
@@ -71,6 +71,18 @@ export function useWorkshopEnrollment({
           text: 'Sorry, we could not find this workshop. Please check the link and try again.',
         });
         break;
+      case SUBMISSION_STATUSES.NO_SCHOOL:
+        setAlertState({
+          show: true,
+          text: 'Please add your school information in account settings.',
+        });
+        break;
+      case SUBMISSION_STATUSES.NOT_USA:
+        setAlertState({
+          show: true,
+          text: 'Sorry, we are only accepting workshop enrollments from the US at this time.',
+        });
+        break;
       case SUBMISSION_STATUSES.SUCCESS:
         sessionStorage.setItem('rpName', regionalPartnerName || '');
         sessionStorage.setItem('workshopId', `${workshopId}`);

--- a/dashboard/app/controllers/api/v1/pd/workshop_enrollments_controller.rb
+++ b/dashboard/app/controllers/api/v1/pd/workshop_enrollments_controller.rb
@@ -15,6 +15,8 @@ class Api::V1::Pd::WorkshopEnrollmentsController < ApplicationController
     OWN: "own".freeze,
     CLOSED: "closed".freeze,
     FULL: "full".freeze,
+    NO_SCHOOL: "no school".freeze,
+    NOT_USA: "not usa".freeze,
     NOT_FOUND: "not found".freeze,
     ERROR: "error".freeze
   }
@@ -58,6 +60,10 @@ class Api::V1::Pd::WorkshopEnrollmentsController < ApplicationController
       render_unsuccessful RESPONSE_MESSAGES[:CLOSED]
     elsif workshop_full?
       render_unsuccessful RESPONSE_MESSAGES[:FULL]
+    elsif user.school_info.nil?
+      render_unsuccessful RESPONSE_MESSAGES[:NO_SCHOOL]
+    elsif !user.school_info&.usa?
+      render_unsuccessful RESPONSE_MESSAGES[:NOT_USA]
     else
       ActiveRecord::Base.transaction do
         school_info = user.school_info

--- a/dashboard/test/controllers/api/v1/pd/workshop_enrollments_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/pd/workshop_enrollments_controller_test.rb
@@ -249,7 +249,7 @@ class Api::V1::Pd::WorkshopEnrollmentsControllerTest < ActionController::TestCas
   end
 
   test 'enrollments can be created' do
-    @teacher = create(:teacher, given_name: 'Firstname', family_name: 'Lastname')
+    @teacher = create(:teacher, :with_school_info, given_name: 'Firstname', family_name: 'Lastname')
     assert_creates(Pd::Enrollment) do
       post :create, params: {
         workshop_id: @workshop.id,
@@ -265,7 +265,7 @@ class Api::V1::Pd::WorkshopEnrollmentsControllerTest < ActionController::TestCas
   test 'sends enrollment receipt email to both the users email and alternate summer email if available and for a summer workshop' do
     Pd::WorkshopMailer.expects(:teacher_enrollment_receipt).returns(stub(:deliver_now)).times(2)
 
-    @teacher = create(:teacher, given_name: 'Firstname', family_name: 'Lastname')
+    @teacher = create(:teacher, :with_school_info, given_name: 'Firstname', family_name: 'Lastname')
     sign_in @teacher
     workshop = create(:summer_workshop, course: Pd::SharedWorkshopConstants::COURSE_CSD)
     create(:pd_teacher_application, course: 'csd', application_year: workshop.school_year, user: @teacher, status: 'accepted')
@@ -307,7 +307,7 @@ class Api::V1::Pd::WorkshopEnrollmentsControllerTest < ActionController::TestCas
   end
 
   test 'creating a duplicate enrollment sends \'duplicate\' workshop enrollment status' do
-    @teacher = create(:teacher, given_name: 'Firstname', family_name: 'Lastname')
+    @teacher = create(:teacher, :with_school_info, given_name: 'Firstname', family_name: 'Lastname')
     post :create, params: {
       workshop_id: @workshop.id,
       user_id: @teacher.id
@@ -348,8 +348,29 @@ class Api::V1::Pd::WorkshopEnrollmentsControllerTest < ActionController::TestCas
     assert_equal RESPONSE_MESSAGES[:OWN], JSON.parse(@response.body)["workshop_enrollment_status"]
   end
 
+  test 'creating an enrollment without school info sends \'no school\' workshop enrollment status' do
+    @teacher = create(:teacher, given_name: 'Firstname', family_name: 'Lastname')
+    post :create, params: {
+      workshop_id: @workshop.id,
+      user_id: @teacher.id
+    }
+    assert_response 400
+    assert_equal RESPONSE_MESSAGES[:NO_SCHOOL], JSON.parse(@response.body)["workshop_enrollment_status"]
+  end
+
+  test 'creating an enrollment with a non-US based user sends \'not usa\' workshop enrollment status' do
+    school_info = create(:school_info_non_us)
+    @teacher = create(:teacher, given_name: 'Firstname', family_name: 'Lastname', school_info: school_info)
+    post :create, params: {
+      workshop_id: @workshop.id,
+      user_id: @teacher.id
+    }
+    assert_response 400
+    assert_equal RESPONSE_MESSAGES[:NOT_USA], JSON.parse(@response.body)["workshop_enrollment_status"]
+  end
+
   test 'creating an enrollment with errors sends \'error\' workshop enrollment status' do
-    @teacher = create(:teacher, given_name: '')
+    @teacher = create(:teacher, :with_school_info, given_name: '')
     post :create, params: {
       workshop_id: @workshop.id,
       user_id: @teacher.id
@@ -359,7 +380,7 @@ class Api::V1::Pd::WorkshopEnrollmentsControllerTest < ActionController::TestCas
   end
 
   test 'creating an enrollment on an unknown workshop id returns 404' do
-    @teacher = create(:teacher, given_name: 'Firstname', family_name: 'Lastname')
+    @teacher = create(:teacher, :with_school_info, given_name: 'Firstname', family_name: 'Lastname')
     post :create, params: {
       workshop_id: 'nonsense',
       user_id: @teacher.id


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
Prevents users with a school info set to a non-US school from enrolling in pd workshops, both regional and national. Also adds an explicit guard in the controller preventing users completely without school info from enrolling, though that is also guarded in the front end


https://github.com/user-attachments/assets/4f4997c0-4e85-4cad-816b-f4ffe2d3e6d5





## Links
<!--  Links to relevant external resources.
      - spec docs, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- Jira: https://codedotorg.atlassian.net/browse/TEACHING-12

## Testing story
<!--  Does your change include appropriate tests?
      - If so, please describe how the tests included in this PR are sufficient.
      - If not, please explain why this change does not need to be tested. -->



## Deployment strategy
<!--  Any special steps required to deploy this, besides merging?
      - Are there database migrations or manual steps?
      - Does this require coordination with other teams or systems? -->



## Follow-up work
<!--  List any clean-up or technical debt that will be addressed in future work.
      - Include Jira links where applicable.
      - Are there any known limitations or improvements planned? -->



## Privacy
<!--  How does this change impact Student & Teacher privacy?
      - Does this collect, use, share, or modify PII, either new or existing? -->



## Security
<!--  How does this change impact our security surface-area?
      - Do API's touched have the right auth?
      - Do infra changes impact our attack surface or encryption?
-->



## Caching
<!--  How does this change impact caching behavior?
      - Are cache keys or invalidation strategies affected?
      - Will this require cache warming or invalidation after deployment? -->



## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
