### PR TITLE
Codebridge: update titles and add labels on GenericPrompt modals

### DIFF
--- a/apps/src/codebridge/FileBrowser/prompts/openNewFilePrompt.tsx
+++ b/apps/src/codebridge/FileBrowser/prompts/openNewFilePrompt.tsx
@@ -54,11 +54,7 @@ export const openNewFilePrompt = async ({
       selectedValue: validFileTypes ? validFileTypes[0] : '',
       styleAsFormField: true,
     },
-    buttons: {
-      confirm: {
-        text: 'Create file',
-      },
-    },
+    confirmButtonText: 'Create file',
     validateInput: (fileName: string, dropdownValue?: string) =>
       validateFileNameForModal({
         fileName,

--- a/apps/src/codebridge/FileBrowser/prompts/openNewFolderPrompt.tsx
+++ b/apps/src/codebridge/FileBrowser/prompts/openNewFolderPrompt.tsx
@@ -3,7 +3,6 @@ import {DEFAULT_FOLDER_ID} from '@codebridge/constants';
 import {FolderId} from '@codebridge/types';
 import {validateFolderNameForModal} from '@codebridge/utils';
 
-import codebridgeI18n from '@cdo/apps/codebridge/locale';
 import {MultiFileSource} from '@cdo/apps/lab2/types';
 import {
   DialogType,
@@ -29,7 +28,12 @@ export const openNewFolderPrompt = async ({
 }: OpenNewFilePromptArgsType) => {
   const results = await dialogControl.showDialog({
     type: DialogType.GenericPrompt,
-    title: codebridgeI18n.newFolderPrompt(),
+    title: 'Create a new folder',
+    message: 'Give your folder a name.',
+    textFieldProps: {
+      label: 'Folder name',
+    },
+    confirmButtonText: 'Create folder',
     validateInput: (folderName: string) => {
       return validateFolderNameForModal({
         folderName,

--- a/apps/src/codebridge/FileBrowser/prompts/openRenameFilePrompt.tsx
+++ b/apps/src/codebridge/FileBrowser/prompts/openRenameFilePrompt.tsx
@@ -2,7 +2,6 @@ import {RenameFileFunction} from '@codebridge/codebridgeContext/types';
 import {ProjectFile, FileId} from '@codebridge/types';
 import {validateFileNameForModal} from '@codebridge/utils';
 
-import codebridgeI18n from '@cdo/apps/codebridge/locale';
 import {MultiFileSource} from '@cdo/apps/lab2/types';
 import {
   DialogType,
@@ -38,7 +37,12 @@ export const openRenameFilePrompt = async ({
   const file = projectFiles[fileId];
   const results = await dialogControl?.showDialog({
     type: DialogType.GenericPrompt,
-    title: codebridgeI18n.renameFile(),
+    title: 'Rename file',
+    message: 'Give your file a new name.',
+    textFieldProps: {
+      label: 'New file name',
+    },
+    confirmButtonText: 'Rename file',
     value: file.name,
     validateInput: (newName: string) => {
       if (!newName.length) {

--- a/apps/src/codebridge/FileBrowser/prompts/openRenameFolderPrompt.tsx
+++ b/apps/src/codebridge/FileBrowser/prompts/openRenameFolderPrompt.tsx
@@ -2,7 +2,6 @@ import {RenameFolderFunction} from '@codebridge/codebridgeContext/types';
 import {FolderId} from '@codebridge/types';
 import {validateFolderNameForModal} from '@codebridge/utils';
 
-import codebridgeI18n from '@cdo/apps/codebridge/locale';
 import {MultiFileSource} from '@cdo/apps/lab2/types';
 import {
   DialogType,
@@ -29,7 +28,12 @@ export const openRenameFolderPrompt = async ({
   const folder = projectFolders[folderId];
   const results = await dialogControl?.showDialog({
     type: DialogType.GenericPrompt,
-    title: codebridgeI18n.renameFolder(),
+    title: 'Rename folder',
+    message: 'Give your folder a new name.',
+    textFieldProps: {
+      label: 'New folder name',
+    },
+    confirmButtonText: 'Rename folder',
     value: folder.name,
     validateInput: (newName: string) => {
       if (!newName.length || newName === folder.name) {


### PR DESCRIPTION
Updates the titles, message, input label, and confirm button text on the following modals used in Lab2 labs (Web Lab 2 and Python Lab):
- Create a new file
- Create a new folder
- Rename file
- Rename folder

## Links
Jira ticket: [AFL-430](https://codedotorg.atlassian.net/browse/AFL-430)

## Testing story
Tested locally

----

## Create a new file
Just the confirm button text is updated.

<img width="1373" height="774" alt="CreateNewFile" src="https://github.com/user-attachments/assets/4808b63d-0b30-498c-8aea-5b6083b762cc" />

## Create a new folder

<img width="1373" height="774" alt="CreateNewFolder" src="https://github.com/user-attachments/assets/ead60e8d-f6b8-4420-acc8-0d7fc5adf025" />

## Rename file

<img width="1373" height="774" alt="RenameFile" src="https://github.com/user-attachments/assets/445f33f0-0326-4901-872d-e00b85563e37" />

## Rename folder

<img width="1373" height="774" alt="RenameFolder" src="https://github.com/user-attachments/assets/52b5c231-5797-4cc4-b3bf-44db81d71732" />



