### PR TITLE
remove section name in pii scrubber

### DIFF
--- a/dashboard/lib/services/user/pii_scrubber.rb
+++ b/dashboard/lib/services/user/pii_scrubber.rb
@@ -91,6 +91,9 @@ module Services
 
         # Project IP addresses (but no other project data)
         scrub_project_ips
+
+        # Sections
+        scrub_sections
       end
 
       # Legacy delete acccounts helper client for purging data from deprecated tables
@@ -154,6 +157,14 @@ module Services
       # other methods since it is not reversible.
       private def scrub_external_data
         MailJet.delete_contact(email) if email.present? && !::User.exists?(email: email)
+      end
+
+      private def scrub_sections
+        if user.teacher?
+          user.sections.with_deleted.find_each do |section|
+            section.update!(name: REDACTED_STRING)
+          end
+        end
       end
 
       private def mark_scrubbed

--- a/dashboard/test/lib/services/user/pii_scrubber_test.rb
+++ b/dashboard/test/lib/services/user/pii_scrubber_test.rb
@@ -19,6 +19,7 @@ class Services::User::PiiScrubberTest < ActiveSupport::TestCase
       full_address: '123 Main St, Springfield, USA',
     )
   end
+  let(:section) {create(:section, user: user, name: 'Test Section')}
   let(:described_instance) {described_class.new(user: user)}
 
   describe '#call' do
@@ -54,6 +55,13 @@ class Services::User::PiiScrubberTest < ActiveSupport::TestCase
     it 'removes data from external sources' do
       expect(described_instance).to receive(:scrub_external_data)
       scrub_pii
+    end
+
+    it 'redacts section names' do
+      scrub_pii
+      user.sections.with_deleted.each do |section|
+        _(section.reload.name).must_equal Services::User::PiiScrubber::REDACTED_STRING
+      end
     end
 
     context 'when user has PD data with PII' do


### PR DESCRIPTION
Removes section names in the PII scrubber. RED discovered this oversight during a QC check.

## Links
<!--  Links to relevant external resources.
      - spec docs, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- Jira: 

## Testing story
<!--  Does your change include appropriate tests?
      - If so, please describe how the tests included in this PR are sufficient.
      - If not, please explain why this change does not need to be tested. -->



## Deployment strategy
<!--  Any special steps required to deploy this, besides merging?
      - Are there database migrations or manual steps?
      - Does this require coordination with other teams or systems? -->



## Follow-up work
<!--  List any clean-up or technical debt that will be addressed in future work.
      - Include Jira links where applicable.
      - Are there any known limitations or improvements planned? -->



## Privacy
<!--  How does this change impact Student & Teacher privacy?
      - Does this collect, use, share, or modify PII, either new or existing? -->



## Security
<!--  How does this change impact our security surface-area?
      - Do API's touched have the right auth?
      - Do infra changes impact our attack surface or encryption?
-->



## Caching
<!--  How does this change impact caching behavior?
      - Are cache keys or invalidation strategies affected?
      - Will this require cache warming or invalidation after deployment? -->



## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
