### PR TITLE
Use absolute position to find level properties

### DIFF
--- a/apps/src/lab2/hooks/useLoadLevelProperties.ts
+++ b/apps/src/lab2/hooks/useLoadLevelProperties.ts
@@ -28,7 +28,7 @@ export default function useLoadLevelProperties() {
     const {scriptName, currentLevelId, lessons, currentLessonId} = progress;
     const lessonPosition = lessons?.find(
       lesson => lesson.id === currentLessonId
-    )?.relative_position;
+    )?.position;
     if (scriptName && lessonPosition) {
       return `/s/${scriptName}/lessons/${lessonPosition}/level_properties`;
     }

--- a/dashboard/app/controllers/lessons_controller.rb
+++ b/dashboard/app/controllers/lessons_controller.rb
@@ -196,9 +196,8 @@ class LessonsController < ApplicationController
     unit_context = get_unit_context(params)
     script = unit_context[:unit]
     unit_group_unit = unit_context[:unit_group_unit]
-
     @lesson = script.lessons.find do |l|
-      l.relative_position == params[:lesson_position].to_i
+      l.absolute_position == params[:lesson_position].to_i
     end
     raise ActiveRecord::RecordNotFound unless @lesson
 


### PR DESCRIPTION
[Slack thread](https://codedotorg.slack.com/archives/C03DBDN67B7/p1768927234058889) with details here.
Short version: it turns out there are two "lessons" with relative_position 1 if there is a pre-assessment. This switches to use absolute position to find level properties, which seems to always be unique.

After this change, the levels that were not loading now load.



## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
