### PR TITLE
🧹 Refactor `SoundListEntry` to no longer use Radium

### DIFF
--- a/apps/src/code-studio/components/SoundListEntry.jsx
+++ b/apps/src/code-studio/components/SoundListEntry.jsx
@@ -1,8 +1,8 @@
+import classNames from 'classnames';
 import PropTypes from 'prop-types';
-import Radium from 'radium'; // eslint-disable-line no-restricted-imports
 import React from 'react';
 
-import * as color from '../../util/color';
+import styles from './SoundListEntry.module.scss';
 
 /**
  * Component for a single sound tile in the Sound Library.
@@ -56,7 +56,7 @@ class SoundListEntry extends React.Component {
   };
 
   render() {
-    const selectedColor = this.props.isSelected
+    const selectedClass = this.props.isSelected
       ? styles.selected
       : styles.notSelected;
     const playIcon = this.state.isPlaying
@@ -65,22 +65,22 @@ class SoundListEntry extends React.Component {
 
     return (
       <div
-        style={[styles.root, selectedColor]}
+        className={classNames(styles.root, selectedClass)}
         title={this.props.soundMetadata.name}
         onClick={this.props.assetChosen.bind(null, this.props.soundMetadata)}
       >
-        <div style={styles.icon}>
+        <div className={styles.icon}>
           <i
             onClick={this.clickSoundControl}
             className={'fa ' + playIcon + ' fa-2x'}
           />
         </div>
-        <div style={styles.metadata}>
-          <span style={styles.soundName}>
+        <div className={styles.metadata}>
+          <span className={styles.soundName}>
             {this.props.soundMetadata.name + '.mp3'}
           </span>
           <br />
-          <span style={styles.time}>
+          <span className={styles.time}>
             {getTimeString(this.props.soundMetadata.time)}
           </span>
         </div>
@@ -89,43 +89,7 @@ class SoundListEntry extends React.Component {
   }
 }
 
-const styles = {
-  root: {
-    float: 'left',
-    width: 215,
-    height: 35,
-    cursor: 'pointer',
-    margin: 5,
-    padding: 6,
-    border: 'solid 0px',
-    borderRadius: 5,
-  },
-  selected: {
-    backgroundColor: color.lighter_purple,
-  },
-  notSelected: {
-    backgroundColor: color.white,
-  },
-  icon: {
-    float: 'left',
-    padding: '6px 10px 6px 2px',
-  },
-  metadata: {
-    float: 'left',
-    width: 175,
-    overflow: 'hidden',
-    textOverflow: 'ellipsis',
-  },
-  soundName: {
-    fontSize: 14,
-  },
-  time: {
-    color: color.charcoal,
-    fontSize: 11,
-  },
-};
-
-export default Radium(SoundListEntry);
+export default SoundListEntry;
 
 // Adapted from: http://stackoverflow.com/questions/6312993/javascript-seconds-to-time-string-with-format-hhmmss
 // Convert a number, numSeconds, into a string formatted as MM:SS or "Less than 1 second"

--- a/apps/src/code-studio/components/SoundListEntry.module.scss
+++ b/apps/src/code-studio/components/SoundListEntry.module.scss
@@ -1,0 +1,39 @@
+.root {
+  float: left;
+  width: 215px;
+  height: 35px;
+  cursor: pointer;
+  margin: 5px;
+  padding: 6px;
+  border: solid 0;
+  border-radius: 5px;
+}
+
+.selected {
+  background-color: #cfc9de;
+}
+
+.notSelected {
+  background-color: #fff;
+}
+
+.icon {
+  float: left;
+  padding: 6px 10px 6px 2px;
+}
+
+.metadata {
+  float: left;
+  width: 175px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.soundName {
+  font-size: 14px;
+}
+
+.time {
+  color: #5b6770;
+  font-size: 11px;
+}

--- a/apps/test/unit/code-studio/components/SoundListEntryTest.js
+++ b/apps/test/unit/code-studio/components/SoundListEntryTest.js
@@ -3,6 +3,7 @@ import React from 'react';
 
 import SoundListEntry from '@cdo/apps/code-studio/components/SoundListEntry';
 import Sounds from '@cdo/apps/Sounds';
+
 import styles from '@cdo/apps/code-studio/components/SoundListEntry.module.scss';
 
 describe('SoundListEntry', () => {

--- a/apps/test/unit/code-studio/components/SoundListEntryTest.js
+++ b/apps/test/unit/code-studio/components/SoundListEntryTest.js
@@ -3,7 +3,7 @@ import React from 'react';
 
 import SoundListEntry from '@cdo/apps/code-studio/components/SoundListEntry';
 import Sounds from '@cdo/apps/Sounds';
-import color from '@cdo/apps/util/color';
+import styles from '@cdo/apps/code-studio/components/SoundListEntry.module.scss';
 
 describe('SoundListEntry', () => {
   const sounds = new Sounds();
@@ -22,14 +22,14 @@ describe('SoundListEntry', () => {
 
   it('renders with purple background when selected', () => {
     const wrapper = shallow(<SoundListEntry {...defaultProps} />);
-    expect(wrapper.props().style.backgroundColor).toEqual(color.lighter_purple);
+    expect(wrapper.hasClass(styles.selected)).toBe(true);
   });
 
   it('renders with no background when not selected', () => {
     const wrapper = shallow(
       <SoundListEntry {...defaultProps} isSelected={false} />
     );
-    expect(wrapper.props().style.backgroundColor).toEqual(color.white);
+    expect(wrapper.hasClass(styles.notSelected)).toBe(true);
   });
 
   it('renders a play button when not playing', () => {


### PR DESCRIPTION
Refactored `SoundListEntry` to no longer use Radium since it's deprecated and we have had a [years-long tail](https://docs.google.com/document/d/1Y3uK_iYMhTUaCI6yIDwOAMprIJCuzXSs2fECQggwp60/edit?tab=t.0#heading=h.htf3pg55q2kt) of removing it.  Getting AI to remove Radium is not nearly as tedious as doing it manually and the end is in sight! 😁 

`SoundListEntry` is a single tile for a single sound in the sound library dialog used in App Lab and Game Lab. You can get to it like this: 

https://github.com/user-attachments/assets/24fffaac-bb4c-4d8f-99b8-db296f7f401d

There are no visual or functional differences as a result of this change, but I did modify the `SoundListEntry` test to reflect how the styles are now structured. 
