### PR TITLE
Add json support to Web Lab 2 and Python Lab

### DIFF
--- a/apps/package.json
+++ b/apps/package.json
@@ -222,6 +222,7 @@
     "@codemirror/lang-html": "^6.4.9",
     "@codemirror/lang-java": "^6.0.1",
     "@codemirror/lang-javascript": "^6.2.4",
+    "@codemirror/lang-json": "^6.0.2",
     "@codemirror/lang-markdown": "^6.3.4",
     "@codemirror/lang-python": "^6.1.7",
     "@codemirror/language": "^6.11.0",

--- a/apps/src/codebridge/utils/fileUtils.ts
+++ b/apps/src/codebridge/utils/fileUtils.ts
@@ -11,6 +11,11 @@ const FILE_TYPE_ICON_MAP = {
   md: {iconName: 'markdown', iconStyle: 'regular' as const, isBrand: true},
   html: {iconName: 'file-code', iconStyle: 'solid' as const, isBrand: false},
   js: {iconName: 'js', iconStyle: 'regular' as const, isBrand: true},
+  json: {
+    iconName: 'file-brackets-curly',
+    iconStyle: 'solid' as const,
+    isBrand: false,
+  },
   css: {iconName: 'css', iconStyle: 'regular' as const, isBrand: true},
   jpg: {iconName: 'image', iconStyle: 'solid' as const, isBrand: false},
   png: {iconName: 'image', iconStyle: 'solid' as const, isBrand: false},

--- a/apps/src/codebridge/utils/fileUtils.ts
+++ b/apps/src/codebridge/utils/fileUtils.ts
@@ -12,7 +12,7 @@ const FILE_TYPE_ICON_MAP = {
   html: {iconName: 'file-code', iconStyle: 'solid' as const, isBrand: false},
   js: {iconName: 'js', iconStyle: 'regular' as const, isBrand: true},
   json: {
-    iconName: 'file-brackets-curly',
+    iconName: 'brackets-curly',
     iconStyle: 'solid' as const,
     isBrand: false,
   },

--- a/apps/src/pythonlab/PythonlabView.tsx
+++ b/apps/src/pythonlab/PythonlabView.tsx
@@ -2,6 +2,7 @@
 import {Codebridge} from '@codebridge/Codebridge';
 import {useSource} from '@codebridge/hooks/useSource';
 import {CodebridgeLevelProperties, ConfigType} from '@codebridge/types';
+import {json} from '@codemirror/lang-json';
 import {python} from '@codemirror/lang-python';
 import {LanguageSupport} from '@codemirror/language';
 import React, {useContext, useEffect, useMemo, useState} from 'react';
@@ -56,6 +57,7 @@ const aiTutorHelper = new AiTutorPythonLabContextHelper();
 
 const pythonlabLangMapping: {[key: string]: LanguageSupport} = {
   py: python(),
+  json: json(),
 };
 
 const standaloneStartSources: {[key: string]: ProjectSources} = {

--- a/apps/src/pythonlab/constants.ts
+++ b/apps/src/pythonlab/constants.ts
@@ -71,6 +71,6 @@ export const STANDALONE_NEIGHBORHOOD_PROJECT: ProjectSources = {
   },
 };
 
-export const PYTHONLAB_EDITABLE_FILE_TYPES = ['py', 'csv', 'txt'];
+export const PYTHONLAB_EDITABLE_FILE_TYPES = ['py', 'csv', 'txt', 'json'];
 
 export const PYTHONLAB_SUPPORTED_FILE_TYPES = PYTHONLAB_EDITABLE_FILE_TYPES;

--- a/apps/src/weblab2/Weblab2View.tsx
+++ b/apps/src/weblab2/Weblab2View.tsx
@@ -4,6 +4,7 @@ import {ConfigType} from '@codebridge/types';
 import {css} from '@codemirror/lang-css';
 import {html} from '@codemirror/lang-html';
 import {javascript} from '@codemirror/lang-javascript';
+import {json} from '@codemirror/lang-json';
 import {markdown} from '@codemirror/lang-markdown';
 import {LanguageSupport} from '@codemirror/language';
 import React, {useEffect, useState} from 'react';
@@ -36,6 +37,7 @@ const weblab2LangMapping: {[key: string]: LanguageSupport} = {
   css: css(),
   js: javascript(),
   md: markdown(),
+  json: json(),
 };
 
 const defaultConfig: ConfigType = {

--- a/apps/src/weblab2/constants.ts
+++ b/apps/src/weblab2/constants.ts
@@ -5,6 +5,7 @@ export const WEBLAB2_EDITABLE_FILE_TYPES = [
   'md',
   'txt',
   'csv',
+  'json',
 ];
 
 export const WEBLAB2_IMAGE_FILE_TYPES = ['jpg', 'jpeg', 'png', 'gif'];

--- a/apps/yarn.lock
+++ b/apps/yarn.lock
@@ -4145,6 +4145,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@codemirror/lang-json@npm:^6.0.2":
+  version: 6.0.2
+  resolution: "@codemirror/lang-json@npm:6.0.2"
+  dependencies:
+    "@codemirror/language": "npm:^6.0.0"
+    "@lezer/json": "npm:^1.0.0"
+  checksum: 10/a8e57ad5c6cc53edd0d8bce4c26fa189dd5a95c371e72d32957d4a5c857f814761d9dfab81361f8e8ae9da7bcf657e7e1343f39694f9cffb1c144dd3ef7092a0
+  languageName: node
+  linkType: hard
+
 "@codemirror/lang-markdown@npm:^6.3.4":
   version: 6.3.4
   resolution: "@codemirror/lang-markdown@npm:6.3.4"
@@ -5531,6 +5541,17 @@ __metadata:
     "@lezer/highlight": "npm:^1.1.3"
     "@lezer/lr": "npm:^1.3.0"
   checksum: 10/2ebdfae4968e7d0ff1a6b21b13b511cfcc78ee08f548de0133d5dc6fa4e45f089ef35368ff82ab4370f22881768958e70d3d2d5c662784add0170a0fc48c9be0
+  languageName: node
+  linkType: hard
+
+"@lezer/json@npm:^1.0.0":
+  version: 1.0.3
+  resolution: "@lezer/json@npm:1.0.3"
+  dependencies:
+    "@lezer/common": "npm:^1.2.0"
+    "@lezer/highlight": "npm:^1.0.0"
+    "@lezer/lr": "npm:^1.0.0"
+  checksum: 10/48e7b945fdfa2b5b6f862e27bc31f3991cba93f18df7fed0059b25f119b64dedd50bbc709d279e16e2b3eee10e7758d7d80c6d98d21bc15c284809d268837897
   languageName: node
   linkType: hard
 
@@ -11190,6 +11211,7 @@ __metadata:
     "@codemirror/lang-html": "npm:^6.4.9"
     "@codemirror/lang-java": "npm:^6.0.1"
     "@codemirror/lang-javascript": "npm:^6.2.4"
+    "@codemirror/lang-json": "npm:^6.0.2"
     "@codemirror/lang-markdown": "npm:^6.3.4"
     "@codemirror/lang-python": "npm:^6.1.7"
     "@codemirror/language": "npm:^6.11.0"

--- a/dashboard/legacy/middleware/helpers/library_bucket.rb
+++ b/dashboard/legacy/middleware/helpers/library_bucket.rb
@@ -8,7 +8,7 @@ class LibraryBucket < BucketHelper
 
   def allowed_file_types
     # The Library bucket is used by App Lab (json), Java Lab (java, csv, txt),
-    # Python Lab (py, csv, txt), and Web Lab 2 (html, css, js, md, jpeg, jpg, png, gif).
+    # Python Lab (py, csv, txt), and Web Lab 2 (html, css, js, json, md, jpeg, jpg, png, gif).
     %w(.json .java .py .csv .txt .js .html .css .md .jpeg .jpg .png .gif)
   end
 

--- a/dashboard/legacy/middleware/helpers/library_bucket.rb
+++ b/dashboard/legacy/middleware/helpers/library_bucket.rb
@@ -8,7 +8,7 @@ class LibraryBucket < BucketHelper
 
   def allowed_file_types
     # The Library bucket is used by App Lab (json), Java Lab (java, csv, txt),
-    # Python Lab (py, csv, txt), and Web Lab 2 (html, css, js, json, md, jpeg, jpg, png, gif).
+    # Python Lab (py, csv, txt, json), and Web Lab 2 (html, css, js, json, md, jpeg, jpg, png, gif).
     %w(.json .java .py .csv .txt .js .html .css .md .jpeg .jpg .png .gif)
   end
 


### PR DESCRIPTION
Curriculum requested support for json files in web lab 2 and python lab. To do this I did the following:
- added json as a supported file type to both Web Lab 2 and Python Lab's supported file type configs.
- Since codemirror has a json language package, I installed that and added it to Web Lab 2 and Python Lab's language mappings. It does some highlighting and auto-indenting.
- Added a comment to `library_bucket` indicating Python Lab and Web Lab 2 use json now. We already supported json in the library bucket (what we use for the backpack) because app lab libraries use json.
- Added a file icon for json files.

## Screenshot
<img width="937" height="369" alt="Screenshot 2026-01-20 at 10 22 39 AM" src="https://github.com/user-attachments/assets/c3953e24-966e-433f-b035-9d51ff36514f" />


## Links

- Jira: [AFL-439](https://codedotorg.atlassian.net/browse/AFL-439)

## Testing story
Tested in python lab and web lab 2. Confirmed I can create/edit/rename json files, and can add them to and import them from the backpack.



## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
