### PR TITLE
add md5 column to scripts table via db migration

### DIFF
--- a/dashboard/app/models/unit.rb
+++ b/dashboard/app/models/unit.rb
@@ -18,6 +18,7 @@
 #  participant_audience   :string(255)
 #  original_unit_group_id :integer
 #  hide_within_course     :boolean          default(FALSE)
+#  md5                    :string(255)
 #
 # Indexes
 #

--- a/dashboard/db/migrate/20260115211939_add_md5_to_scripts.rb
+++ b/dashboard/db/migrate/20260115211939_add_md5_to_scripts.rb
@@ -1,0 +1,5 @@
+class AddMd5ToScripts < ActiveRecord::Migration[6.1]
+  def change
+    add_column :scripts, :md5, :string
+  end
+end

--- a/dashboard/db/schema.rb
+++ b/dashboard/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2026_01_07_212238) do
+ActiveRecord::Schema.define(version: 2026_01_15_211939) do
 
   create_table "activities", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "user_id"
@@ -2083,6 +2083,7 @@ ActiveRecord::Schema.define(version: 2026_01_07_212238) do
     t.string "participant_audience"
     t.integer "original_unit_group_id"
     t.boolean "hide_within_course", default: false
+    t.string "md5"
     t.index ["family_name"], name: "index_scripts_on_family_name"
     t.index ["instruction_type"], name: "index_scripts_on_instruction_type"
     t.index ["instructor_audience"], name: "index_scripts_on_instructor_audience"


### PR DESCRIPTION
migration PR to add `md5` column to the `scripts` table (`Unit` model), done in a separate PR per best practice so that code PR is easier to revert if needed. see https://github.com/code-dot-org/code-dot-org/pull/70356 for context.