### PR TITLE
Fix Teacher warning mailer Cronjob

### DIFF
--- a/bin/cron/perform_job
+++ b/bin/cron/perform_job
@@ -34,7 +34,7 @@ job_args = JSON.parse(ARGV[1] || '[]')
 raise OptionParser::MissingArgument, 'JOB_CLASS argument is missing' unless job_class
 
 if job_args.is_a?(Hash)
-  job_class.perform_now(**job_args.symbolize_keys)
+  job_class.perform_later(**job_args.symbolize_keys)
 else
-  job_class.perform_now(*job_args)
+  job_class.perform_later(*job_args)
 end

--- a/bin/cron/perform_job
+++ b/bin/cron/perform_job
@@ -1,9 +1,9 @@
 #!/usr/bin/env ruby
 
-require 'active_support/core_ext/hash/keys'
 require_relative 'only_one'
 abort 'Script already running' unless only_one_running?(__FILE__)
 
+require 'active_support/core_ext/hash/keys'
 require 'json'
 require 'optparse'
 

--- a/bin/cron/perform_job
+++ b/bin/cron/perform_job
@@ -1,5 +1,6 @@
 #!/usr/bin/env ruby
 
+require 'active_support/core_ext/hash/keys'
 require_relative 'only_one'
 abort 'Script already running' unless only_one_running?(__FILE__)
 
@@ -32,4 +33,8 @@ job_args = JSON.parse(ARGV[1] || '[]')
 
 raise OptionParser::MissingArgument, 'JOB_CLASS argument is missing' unless job_class
 
-job_class.perform_later(*job_args)
+if job_args.is_a?(Hash)
+  job_class.perform_now(**job_args.symbolize_keys)
+else
+  job_class.perform_now(*job_args)
+end

--- a/cookbooks/cdo-apps/templates/default/crontab.erb
+++ b/cookbooks/cdo-apps/templates/default/crontab.erb
@@ -122,7 +122,7 @@
       cronjob at:"0 8 * * *", do:"#{deploy_dir('bin', 'cron', 'perform_job')} User::PiiScrubberJob"
 
       # Send Warning Emails to Inactive Teacher Accounts before Deletion
-      cronjob at: "0,30 0-11 * * *", do: "#{deploy_dir('bin', 'cron', 'perform_job')} User::InactiveTeacherDeletionWarningJob limit=1000"
+      cronjob at: "0,30 0-11 * * *", do: "#{deploy_dir('bin', 'cron', 'perform_job')} User::InactiveTeacherDeletionWarningJob '{\"limit\": 1000}'"
     end
 
     # 'daemons' in all environments.


### PR DESCRIPTION
This PR changes the format of the limit argument to JSON in the Teacher Warning Mailer Cronjob.
The job was getting a ` parse': unexpected token at 'limit=1000' (JSON::ParserError) `. We need to also change the `perform_job` to support hash, JSON args.



## Links


- Jira: [here](https://codedotorg.atlassian.net/browse/P20-1777)

## Testing story
`./bin/cron/perform_job User::InactiveTeacherDeletionWarningJob '{"limit": 1000}'`
Output: Starting InactiveTeacherDeletionWarningJob with dry_run=false, limit=1000 


## Deployment strategy
<!--  Any special steps required to deploy this, besides merging?
      - Are there database migrations or manual steps?
      - Does this require coordination with other teams or systems? -->



## Follow-up work
<!--  List any clean-up or technical debt that will be addressed in future work.
      - Include Jira links where applicable.
      - Are there any known limitations or improvements planned? -->



## Privacy
<!--  How does this change impact Student & Teacher privacy?
      - Does this collect, use, share, or modify PII, either new or existing? -->



## Security
<!--  How does this change impact our security surface-area?
      - Do API's touched have the right auth?
      - Do infra changes impact our attack surface or encryption?
-->



## Caching
<!--  How does this change impact caching behavior?
      - Are cache keys or invalidation strategies affected?
      - Will this require cache warming or invalidation after deployment? -->



## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
