### PR TITLE
Backpack: use generic statsig events

### DIFF
--- a/apps/src/codebridge/FileBrowser/prompts/openSaveToBackpackPrompt.tsx
+++ b/apps/src/codebridge/FileBrowser/prompts/openSaveToBackpackPrompt.tsx
@@ -86,12 +86,12 @@ export const openSaveToBackpackPrompt = async ({
       const selectedFileName =
         results.type === 'confirm' ? file.name : fileNameCopy;
 
-      let successMetric = EVENTS.CODEBRIDGE_SAVE_TO_BACKPACK_NEW;
+      let successMetric = EVENTS.SAVE_TO_BACKPACK_NEW;
       if (isDuplicateFileName) {
         successMetric =
           selectedFileName === file.name
-            ? EVENTS.CODEBRIDGE_SAVE_TO_BACKPACK_REPLACE
-            : EVENTS.CODEBRIDGE_SAVE_TO_BACKPACK_RENAME;
+            ? EVENTS.SAVE_TO_BACKPACK_REPLACE
+            : EVENTS.SAVE_TO_BACKPACK_RENAME;
       }
       const successCallback = () =>
         sendLab2AnalyticsEvent(successMetric, {

--- a/apps/src/lab2/views/components/Instructions/ResourcePanel/Backpack/BackpackFileChip.tsx
+++ b/apps/src/lab2/views/components/Instructions/ResourcePanel/Backpack/BackpackFileChip.tsx
@@ -13,8 +13,10 @@ import React, {useMemo} from 'react';
 import {getFileIconNameAndStyle} from '@cdo/apps/codebridge';
 import Lab2Registry from '@cdo/apps/lab2/Lab2Registry';
 import {isReadOnlyWorkspace} from '@cdo/apps/lab2/redux/lab2ReduxSelectors';
+import {sendLab2AnalyticsEvent} from '@cdo/apps/lab2/utils';
 import {BackpackProps} from '@cdo/apps/lab2/views/components/Instructions/ResourcePanel';
 import {DialogType, useDialogControl} from '@cdo/apps/lab2/views/dialogs';
+import {EVENTS} from '@cdo/apps/metrics/AnalyticsConstants';
 import BackpackClientApi from '@cdo/apps/sharedComponents/backpack/BackpackClientApi';
 import {useAppSelector} from '@cdo/apps/util/reduxHooks';
 
@@ -127,6 +129,7 @@ const BackpackFileChip: React.FC<BackpackFileChipProps> = ({
     } else {
       // Fetch backpack file content and import new file to project - not a duplicate file name.
       await fetchAndSaveFile(
+        EVENTS.IMPORT_FROM_BACKPACK_NEW,
         backpackApi,
         channelId,
         addAlert,
@@ -166,6 +169,9 @@ const BackpackFileChip: React.FC<BackpackFileChipProps> = ({
         () => {
           // TODO: log to statsig
           setActionInProgress(false);
+          sendLab2AnalyticsEvent(EVENTS.DELETE_FROM_BACKPACK, {
+            fileType: fileExtension || '',
+          });
         }
       );
     }

--- a/apps/src/lab2/views/components/Instructions/ResourcePanel/Backpack/saveToBackpackHelper.ts
+++ b/apps/src/lab2/views/components/Instructions/ResourcePanel/Backpack/saveToBackpackHelper.ts
@@ -1,5 +1,7 @@
 import Lab2Registry from '@cdo/apps/lab2/Lab2Registry';
+import {sendLab2AnalyticsEvent} from '@cdo/apps/lab2/utils';
 import {DialogControlInterface, DialogType} from '@cdo/apps/lab2/views/dialogs';
+import {EVENTS} from '@cdo/apps/metrics/AnalyticsConstants';
 import BackpackClientApi from '@cdo/apps/sharedComponents/backpack/BackpackClientApi';
 import HttpClient from '@cdo/apps/util/HttpClient';
 import {createUuid} from '@cdo/apps/utils';
@@ -25,6 +27,7 @@ export const handleSaveSupportFile = async (
   });
   if (results.type === 'confirm') {
     await fetchAndSaveFile(
+      EVENTS.IMPORT_FROM_BACKPACK_RENAME,
       backpackApi,
       channelId,
       addAlert,
@@ -60,6 +63,7 @@ export const handleSaveDuplicateFile = async (
   if (results.type === 'confirm') {
     // Import as replacement
     await fetchAndSaveFile(
+      EVENTS.IMPORT_FROM_BACKPACK_REPLACE,
       backpackApi,
       channelId,
       addAlert,
@@ -71,6 +75,7 @@ export const handleSaveDuplicateFile = async (
   } else if (results.type === 'neutral') {
     // Import as new file
     await fetchAndSaveFile(
+      EVENTS.IMPORT_FROM_BACKPACK_RENAME,
       backpackApi,
       channelId,
       addAlert,
@@ -84,6 +89,7 @@ export const handleSaveDuplicateFile = async (
 };
 
 export const fetchAndSaveFile = async (
+  successMetric: string,
   backpackApi: BackpackClientApi,
   channelId: string,
   addAlert: (type: 'success' | 'danger', message: string) => void,
@@ -136,11 +142,17 @@ export const fetchAndSaveFile = async (
   if (newFileName) {
     createNewFile(newFileName, fileContent, url);
     addAlert('success', successMessage);
+    sendLab2AnalyticsEvent(successMetric, {
+      fileType: newFileName.split('.').pop()?.toLowerCase() || '',
+    });
   } else {
     const fileId = findIdForFileName(selectedFileName);
     if (fileId) {
       saveFile(fileId, fileContent, url);
       addAlert('success', successMessage);
+      sendLab2AnalyticsEvent(successMetric, {
+        fileType: selectedFileName.split('.').pop()?.toLowerCase() || '',
+      });
     } else {
       // If for some reason we can't find the file to replace, show an error.
       // This should not happen, but could theoretically happen if the project was updated while

--- a/apps/src/metrics/AnalyticsConstants.js
+++ b/apps/src/metrics/AnalyticsConstants.js
@@ -548,19 +548,6 @@ const EVENTS = {
     'Attempted upload of unaccepted file on codebridge',
   CODEBRIDGE_UPLOAD_FAILED: 'Failed to upload file on codebridge',
 
-  // Codebridge - Backpack events
-  CODEBRIDGE_SAVE_TO_BACKPACK_NEW: 'Save new file to backpack on codebridge',
-  CODEBRIDGE_SAVE_TO_BACKPACK_REPLACE: 'Replace file in backpack on codebridge',
-  CODEBRIDGE_SAVE_TO_BACKPACK_RENAME:
-    'Save renamed file to backpack on codebridge',
-  CODEBRIDGE_DELETE_FROM_BACKPACK: 'Delete from backpack on codebridge',
-  CODEBRIDGE_IMPORT_FROM_BACKPACK_NEW:
-    'Import new file from backpack on codebridge',
-  CODEBRIDGE_IMPORT_FROM_BACKPACK_REPLACE:
-    'Import a file from backpack on codebridge, replacing existing file',
-  CODEBRIDGE_IMPORT_FROM_BACKPACK_RENAME:
-    'Import a file from backpack on codebridge, renaming it',
-
   // Codebridge - Other events
   CODEBRIDGE_CLEAR_CONSOLE: 'Console cleared on codebridge',
   CODEBRIDGE_MOVE_CONSOLE: 'Console moved on codebridge',
@@ -686,6 +673,16 @@ const EVENTS = {
     'AI Tutor Version File Preview Button Clicked',
   AI_TUTOR_VERSION_FILE_PREVIEWED_IN_URL_BAR:
     'File Previewed in AI Tutor Version View via URL bar',
+
+  // Generic backpack events
+  SAVE_TO_BACKPACK_NEW: 'Save new file to backpack',
+  SAVE_TO_BACKPACK_REPLACE: 'Replace file in backpack',
+  SAVE_TO_BACKPACK_RENAME: 'Save renamed file to backpack',
+  DELETE_FROM_BACKPACK: 'Delete from backpack',
+  IMPORT_FROM_BACKPACK_NEW: 'Import new file from backpack',
+  IMPORT_FROM_BACKPACK_REPLACE:
+    'Import a file from backpack, replacing existing file',
+  IMPORT_FROM_BACKPACK_RENAME: 'Import a file from backpack, renaming it',
 };
 
 const EVENT_GROUP_NAMES = {

--- a/apps/src/sketchlab/utils/handleSaveToBackpack.ts
+++ b/apps/src/sketchlab/utils/handleSaveToBackpack.ts
@@ -1,11 +1,13 @@
 import {exportToBlob} from '@excalidraw/excalidraw';
 import {ExcalidrawImperativeAPI} from '@excalidraw/excalidraw/types/types';
 
+import {sendLab2AnalyticsEvent} from '@cdo/apps/lab2/utils';
 import {
   DialogControlInterface,
   DialogType,
   extractUserInput,
 } from '@cdo/apps/lab2/views/dialogs';
+import {EVENTS} from '@cdo/apps/metrics/AnalyticsConstants';
 import BackpackClientApi from '@cdo/apps/sharedComponents/backpack/BackpackClientApi';
 
 export const handleSaveToBackpack = async (
@@ -60,6 +62,9 @@ export const handleSaveToBackpack = async (
     files: excalidrawApi.getFiles(),
     exportPadding: 10,
   });
+  const eventName = backpackFileList.includes(newFileName)
+    ? EVENTS.SAVE_TO_BACKPACK_REPLACE
+    : EVENTS.SAVE_TO_BACKPACK_NEW;
   backpackApi.saveBlobFile(
     newFileName,
     blobToSave,
@@ -69,7 +74,8 @@ export const handleSaveToBackpack = async (
       );
     },
     () => {
-      // Backpack component handles success.
+      // Backpack component handles success, just log to statsig.
+      sendLab2AnalyticsEvent(eventName, {fileType: 'png'});
     }
   );
 };


### PR DESCRIPTION
This replaces our existing codebridge-specific statsig events for backpack (some of which were removed in the switch to the backpack panel) with generic ones. We are now using the backpack in Sketch Lab, which does not use codebridge. The backpack panel handles import from backpack and delete events, while individual labs handle save events.


## Links

- Jira: [AFL-424](https://codedotorg.atlassian.net/browse/AFL-424)

## Testing story
Tested locally that the correct events are being output.


## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
