### PR TITLE
chore(component-library): do not bundle mui

### DIFF
--- a/apps/yarn.lock
+++ b/apps/yarn.lock
@@ -3879,7 +3879,6 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@code-dot-org/component-library@portal:../frontend/packages/component-library/::locator=blockly-mooc%40workspace%3A."
   dependencies:
-    "@mui/material": "npm:^7.3.2"
     lodash: "npm:^4.17.21"
     react-player: "npm:^3.4.0"
     react-schemaorg: "npm:^2.0.0"

--- a/frontend/packages/component-library/package.json
+++ b/frontend/packages/component-library/package.json
@@ -406,7 +406,6 @@
     "extends": "@code-dot-org/lint-config/stylelint/index.mjs"
   },
   "dependencies": {
-    "@mui/material": "^7.3.2",
     "lodash": "^4.17.21",
     "react-player": "^3.4.0",
     "react-schemaorg": "^2.0.0"
@@ -416,6 +415,7 @@
     "@code-dot-org/component-library-styles": "workspace:*",
     "@code-dot-org/fonts": "workspace:*",
     "@code-dot-org/lint-config": "workspace:*",
+    "@mui/material": "^7.3.2",
     "@release-it/conventional-changelog": "^10.0.0",
     "@swc/core": "^1.9.3",
     "@swc/jest": "^0.2.37",


### PR DESCRIPTION
This PR changes the component library to no longer bundle MUI as a dependency but rather as a devDependency. This ensures that MUI is provided by the host application rather than duplicated within the component library. This reduces the bundle size by approximately 700kb.