### PR TITLE
Backpack Panel: add refresh button

### DIFF
--- a/apps/src/lab2/views/components/Instructions/ResourcePanel/Backpack/BackpackHeaderButtons.tsx
+++ b/apps/src/lab2/views/components/Instructions/ResourcePanel/Backpack/BackpackHeaderButtons.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+
+import IconButtonWithTooltip from '@cdo/apps/lab2/views/components/IconButtonWithTooltip';
+
+interface BackpackHeaderButtonsProps {
+  incrementBackpackRefreshKey: () => void;
+}
+
+const BackpackHeaderButtons: React.FC<BackpackHeaderButtonsProps> = ({
+  incrementBackpackRefreshKey,
+}) => {
+  return (
+    <IconButtonWithTooltip
+      id="refresh-backpack"
+      label="Refresh Backpack"
+      onClick={incrementBackpackRefreshKey}
+      type="tertiary"
+      color="gray"
+      buttonSize="xs"
+      tooltipSize="xs"
+      tooltipDirection="onBottom"
+      hideTooltipTail={true}
+      icon={{iconName: 'refresh', iconStyle: 'solid'}}
+    />
+  );
+};
+
+export default BackpackHeaderButtons;

--- a/apps/src/lab2/views/components/Instructions/ResourcePanel/Backpack/BackpackPanel.tsx
+++ b/apps/src/lab2/views/components/Instructions/ResourcePanel/Backpack/BackpackPanel.tsx
@@ -22,6 +22,7 @@ const SHOW_RECENTLY_ADDED_DURATION_MS = 3000;
 
 interface BackpackPanelProps extends BackpackProps {
   openPanelCallback: () => void;
+  backpackRefreshKey: number;
 }
 
 type AlertConfig = {type: 'success' | 'danger'; message: string};
@@ -35,6 +36,7 @@ const BackpackPanel: React.FC<BackpackPanelProps> = ({
   saveToBackpackButton,
   openPanelCallback,
   supportedFileTypes,
+  backpackRefreshKey,
 }) => {
   const backpackContext = useBackpackAPIContext();
   const primaryBackpackApi = backpackContext?.primaryApi;
@@ -112,6 +114,14 @@ const BackpackPanel: React.FC<BackpackPanelProps> = ({
     // Show the load screen on initial load, and load all backpacks.
     loadBackpackFiles(true);
   }, [loadBackpackFiles]);
+
+  useEffect(() => {
+    // Reload backpack files when the refresh key changes. We don't refresh until the key
+    // is greater than 0. We show the load screen on manual refreshes by the user.
+    if (backpackRefreshKey > 0) {
+      loadBackpackFiles(true);
+    }
+  }, [backpackRefreshKey, loadBackpackFiles]);
 
   useEffect(() => {
     const eventListener =

--- a/apps/src/lab2/views/components/Instructions/ResourcePanel/index.tsx
+++ b/apps/src/lab2/views/components/Instructions/ResourcePanel/index.tsx
@@ -36,6 +36,7 @@ import ForTeachersOnly from '../ForTeachersOnly';
 import Instructions, {InstructionsProps} from '../InstructionsV2';
 import NavigationArea from '../NavigationArea';
 
+import BackpackHeaderButtons from './Backpack/BackpackHeaderButtons';
 import BackpackPanel from './Backpack/BackpackPanel';
 import {
   resourcePanelInstructionsElementId,
@@ -202,6 +203,7 @@ const ResourcePanel: React.FC<ResourcePanelProps> = ({
     () => setCurrentTab(Tabs.Backpack),
     []
   );
+  const [backpackRefreshKey, setBackpackRefreshKey] = useState(0);
 
   // Tooltip should disappear quickly.
   const hideTooltipDelayMs = 10;
@@ -289,6 +291,7 @@ const ResourcePanel: React.FC<ResourcePanelProps> = ({
         <BackpackPanel
           {...backpackProps}
           openPanelCallback={setBackpackTabAsActive}
+          backpackRefreshKey={backpackRefreshKey}
         />
       );
     }
@@ -336,6 +339,7 @@ const ResourcePanel: React.FC<ResourcePanelProps> = ({
     currentTab,
     backpackProps,
     setBackpackTabAsActive,
+    backpackRefreshKey,
   ]);
 
   const hasTabs = useMemo(() => {
@@ -603,6 +607,12 @@ const ResourcePanel: React.FC<ResourcePanelProps> = ({
               rightHeaderContent={
                 currentTab === Tabs.AiTutor ? (
                   <AiChatHeaderButtons />
+                ) : currentTab === Tabs.Backpack ? (
+                  <BackpackHeaderButtons
+                    incrementBackpackRefreshKey={() =>
+                      setBackpackRefreshKey(prev => prev + 1)
+                    }
+                  />
                 ) : (
                   rightHeaderContent
                 )


### PR DESCRIPTION
This adds a refresh button to the backpack panel in the header, styled the same as the header buttons for AI Tutor. The header buttons are created outside of the main panel code. To keep things simple, I added a backpack refresh key to the resource panel component that is passed as a prop to the backpack panel. The header button then gets a prop to increment that key, and when the panel sees a key increase, it reloads the panel. All of the loading logic lived inside the panel and it didn't make sense to move it elsewhere.

If a user adds to or deletes from their backpack with the same tab, it will auto-refresh. But if they have another tab open and update their backpack there, the original tab will not refresh without a level change or page reload. This allows users to manually refresh their backpack if, for example, they added a sketch lab image to their backpack in one tab and want to import it into a web lab 2 project in another tab.

## Screenshots/Screen recording
<img width="471" height="687" alt="Screenshot 2026-01-20 at 2 25 55 PM" src="https://github.com/user-attachments/assets/7c3fe7f2-19ce-46f6-b677-259f7f6c9c61" />

https://github.com/user-attachments/assets/ee20a185-41ab-41ac-8a72-4211675055d3



## Links

- Jira: [AFL-433](https://codedotorg.atlassian.net/browse/AFL-433)

## Testing story
Tested locally.




## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
