### PR TITLE
Updates sketchlab to keep track of loading errors and display one via setToast

### DIFF
--- a/apps/src/sketchlab/SketchlabView.tsx
+++ b/apps/src/sketchlab/SketchlabView.tsx
@@ -115,7 +115,7 @@ const SketchlabView: React.FC<LabProps<LevelProperties>> = ({
       // Signal any loading errors
       if (initialErrors.current.length > 0) {
         api.setToast({
-          message: initialErrors.current[0].message,
+          message: `\u{2757} ${initialErrors.current[0].message}`,
         });
       }
     },
@@ -127,7 +127,7 @@ const SketchlabView: React.FC<LabProps<LevelProperties>> = ({
     if (api) {
       // The app is loaded, so just pop up the error
       api.setToast({
-        message: error.message,
+        message: `\u{2757} ${error.message}`,
       });
     } else {
       // Defer the error until the application loads

--- a/apps/src/sketchlab/SketchlabView.tsx
+++ b/apps/src/sketchlab/SketchlabView.tsx
@@ -114,7 +114,6 @@ const SketchlabView: React.FC<LabProps<LevelProperties>> = ({
 
       // Signal any loading errors
       if (initialErrors.current.length > 0) {
-        console.log('setToast initialError', initialErrors.current[0].message);
         api.setToast({
           message: initialErrors.current[0].message,
         });
@@ -127,7 +126,6 @@ const SketchlabView: React.FC<LabProps<LevelProperties>> = ({
     const api = excalidrawApiRef.current;
     if (api) {
       // The app is loaded, so just pop up the error
-      console.log('setToast onError', error.message);
       api.setToast({
         message: error.message,
       });

--- a/apps/src/sketchlab/SketchlabView.tsx
+++ b/apps/src/sketchlab/SketchlabView.tsx
@@ -82,6 +82,8 @@ const SketchlabView: React.FC<LabProps<LevelProperties>> = ({
   // while a request is in flight.
   const filesBeingUploadedRef = useRef<Set<string>>(new Set());
 
+  const initialErrors = useRef<Error[]>([]);
+
   // Keeps a cache of files that we already have downloaded, so that we don't request them repeatedly.
   const downloadedFilesDataRef = useRef<
     Record<ExcalidrawElement['id'], DataURL>
@@ -104,6 +106,49 @@ const SketchlabView: React.FC<LabProps<LevelProperties>> = ({
   // We remount (ie, reset) Excalidraw any time we observe
   // sources being initialized (eg, when level changes, teacher views a student's project, etc).
   const [excalidrawMountKey, setExcalidrawMountKey] = useState(0);
+
+  const onLoad = useCallback(
+    (api: ExcalidrawImperativeAPI) => {
+      // Retain the API reference
+      excalidrawApiRef.current = api;
+
+      // Signal any loading errors
+      if (initialErrors.current.length > 0) {
+        console.log('setToast initialError', initialErrors.current[0].message);
+        api.setToast({
+          message: initialErrors.current[0].message,
+        });
+      }
+    },
+    [excalidrawApiRef]
+  );
+
+  const onError = useCallback((error: Error) => {
+    const api = excalidrawApiRef.current;
+    if (api) {
+      // The app is loaded, so just pop up the error
+      console.log('setToast onError', error.message);
+      api.setToast({
+        message: error.message,
+      });
+    } else {
+      // Defer the error until the application loads
+      initialErrors.current.push(error);
+    }
+    console.error(error);
+  }, []);
+
+  const initialData = useMemo(
+    () =>
+      experiments.isEnabledAllowingQueryString(S3_IMAGE_EXPERIMENT)
+        ? populateInitialExcalidrawState(
+            currentSources.source,
+            downloadedFilesDataRef.current,
+            onError
+          )
+        : (currentSources.source as ExcalidrawInitialDataState),
+    [currentSources.source, onError]
+  );
 
   const currentUserId = useAppSelector(state => state.currentUser.userId);
   const backpackContext = useMemo(() => {
@@ -343,16 +388,9 @@ const SketchlabView: React.FC<LabProps<LevelProperties>> = ({
               <TeacherViewingStudentProjectAlert inWorkspaceContainer />
             )}
             <Excalidraw
-              initialData={
-                experiments.isEnabledAllowingQueryString(S3_IMAGE_EXPERIMENT)
-                  ? populateInitialExcalidrawState(
-                      currentSources.source,
-                      downloadedFilesDataRef.current
-                    )
-                  : (currentSources.source as ExcalidrawInitialDataState)
-              }
+              initialData={initialData}
               onChange={debouncedSerializeAndSaveWorkspace}
-              excalidrawAPI={api => (excalidrawApiRef.current = api)}
+              excalidrawAPI={onLoad}
               key={excalidrawMountKey}
               theme={theme.toLowerCase() as ExcalidrawTheme}
               viewModeEnabled={readonlyWorkspace}

--- a/apps/src/sketchlab/styles/sketchlab-view.module.scss
+++ b/apps/src/sketchlab/styles/sketchlab-view.module.scss
@@ -12,3 +12,11 @@
 :global(.excalidraw .popover) {
   display: block;
 }
+
+:global(.excalidraw .Toast) {
+  background-color: var(--background-error-primary);
+
+  p {
+    color: var(--text-error-primary);
+  }
+}

--- a/apps/src/sketchlab/styles/sketchlab-view.module.scss
+++ b/apps/src/sketchlab/styles/sketchlab-view.module.scss
@@ -12,11 +12,3 @@
 :global(.excalidraw .popover) {
   display: block;
 }
-
-:global(.excalidraw .Toast) {
-  background-color: var(--background-error-primary);
-
-  p {
-    color: var(--text-error-primary);
-  }
-}

--- a/apps/src/sketchlab/utils/populateInitialExcalidrawState.ts
+++ b/apps/src/sketchlab/utils/populateInitialExcalidrawState.ts
@@ -52,8 +52,5 @@ export const populateInitialExcalidrawState = async (
   // Excalidraw does not need to access externalFiles, so we remove it
   // before passing this initial state to Excalidraw.
   delete excalidrawInitialState.externalFiles;
-
-  onError(new Error('test error'));
-
   return excalidrawInitialState as ExcalidrawInitialDataState;
 };

--- a/apps/src/sketchlab/utils/populateInitialExcalidrawState.ts
+++ b/apps/src/sketchlab/utils/populateInitialExcalidrawState.ts
@@ -11,7 +11,8 @@ import {imageUrlToBase64} from './imageUrlToBase64';
 
 export const populateInitialExcalidrawState = async (
   sourcesWithExternalFiles: ExcalidrawSourceWithExternalFiles,
-  downloadedFileData: Record<ExcalidrawElement['id'], DataURL>
+  downloadedFileData: Record<ExcalidrawElement['id'], DataURL>,
+  onError: (error: Error) => void
 ) => {
   const excalidrawInitialState = cloneDeep(sourcesWithExternalFiles);
 
@@ -35,7 +36,9 @@ export const populateInitialExcalidrawState = async (
             // so proceed if we fail to encode an image for now.
             // Error handling investigation tracked here:
             // https://codedotorg.atlassian.net/browse/AFL-345
-            console.error(error);
+            if (error instanceof Error) {
+              onError(new Error('Cannot load image from sources.'));
+            }
           }
         }
       } else {
@@ -49,5 +52,8 @@ export const populateInitialExcalidrawState = async (
   // Excalidraw does not need to access externalFiles, so we remove it
   // before passing this initial state to Excalidraw.
   delete excalidrawInitialState.externalFiles;
+
+  onError(new Error('test error'));
+
   return excalidrawInitialState as ExcalidrawInitialDataState;
 };

--- a/apps/src/sketchlab/utils/populateInitialExcalidrawState.ts
+++ b/apps/src/sketchlab/utils/populateInitialExcalidrawState.ts
@@ -33,9 +33,8 @@ export const populateInitialExcalidrawState = async (
             downloadedFileData[file.id] = base64;
           } catch (error) {
             // Excalidraw handles files it can't load pretty well (ie, shows a placeholder image),
-            // so proceed if we fail to encode an image for now.
-            // Error handling investigation tracked here:
-            // https://codedotorg.atlassian.net/browse/AFL-345
+            // so proceed if we fail to encode an image for now and just track the error via this
+            // upcall.
             if (error instanceof Error) {
               onError(new Error('Cannot load image from sources.'));
             }

--- a/apps/src/sketchlab/utils/populateInitialExcalidrawState.ts
+++ b/apps/src/sketchlab/utils/populateInitialExcalidrawState.ts
@@ -36,7 +36,9 @@ export const populateInitialExcalidrawState = async (
             // so proceed if we fail to encode an image for now and just track the error via this
             // upcall.
             if (error instanceof Error) {
-              onError(new Error(`Cannot load image '${file.id}' from sources.`));
+              onError(
+                new Error(`Cannot load image '${file.id}' from sources.`)
+              );
             }
           }
         }

--- a/apps/src/sketchlab/utils/populateInitialExcalidrawState.ts
+++ b/apps/src/sketchlab/utils/populateInitialExcalidrawState.ts
@@ -36,7 +36,7 @@ export const populateInitialExcalidrawState = async (
             // so proceed if we fail to encode an image for now and just track the error via this
             // upcall.
             if (error instanceof Error) {
-              onError(new Error('Cannot load image from sources.'));
+              onError(new Error(`Cannot load image '${file.id}' from sources.`));
             }
           }
         }


### PR DESCRIPTION
Updates the SketchLab main view and file loading utilities to surface errors as toast messages.

<img width="527" height="242" alt="image" src="https://github.com/user-attachments/assets/fde245f2-73cc-465b-a44d-60e1f674349f" />

## Links
<!--  Links to relevant external resources.
      - spec docs, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- Jira: [AFL-345](https://codedotorg.atlassian.net/browse/AFL-345)

## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
