### PR TITLE
Increase Redshift Export Timeout

### DIFF
--- a/bin/cron/export_mysql_database_to_redshift
+++ b/bin/cron/export_mysql_database_to_redshift
@@ -11,8 +11,8 @@ require 'cdo/redshift_import'
 
 # Delay between each check on task status.
 TASK_STATUS_DELAY = 10.minutes
-# As of early 2025, the Task that exports `user_levels` takes about 18.5 hours to complete and is the longest daily task.
-DAILY_TASK_MAX_EXECUTION_TIME = 19.hours
+# As of early 2026, the Task that exports `user_levels` takes about 19.5 hours to complete and is the longest daily task.
+DAILY_TASK_MAX_EXECUTION_TIME = 20.hours
 # As of early 2020, the Task that exports 'level_sources' takes about 30 hours to complete.
 WEEKLY_TASK_MAX_EXECUTION_TIME = 40.hours
 # We want to notify the RED team about the export status.


### PR DESCRIPTION
#70033 didn't quite give us enough time.

This is a temporary mitigation while we work on [switching to using Zero ETL Integration](https://codedotorg.atlassian.net/browse/INF-1793) to export data from MySQL to Redshift. 

## Testing story
<!--  Does your change include appropriate tests?
      - If so, please describe how the tests included in this PR are sufficient.
      - If not, please explain why this change does not need to be tested. -->



## Deployment strategy
<!--  Any special steps required to deploy this, besides merging?
      - Are there database migrations or manual steps?
      - Does this require coordination with other teams or systems? -->



## Follow-up work
<!--  List any clean-up or technical debt that will be addressed in future work.
      - Include Jira links where applicable.
      - Are there any known limitations or improvements planned? -->



## Privacy
<!--  How does this change impact Student & Teacher privacy?
      - Does this collect, use, share, or modify PII, either new or existing? -->



## Security
<!--  How does this change impact our security surface-area?
      - Do API's touched have the right auth?
      - Do infra changes impact our attack surface or encryption?
-->



## Caching
<!--  How does this change impact caching behavior?
      - Are cache keys or invalidation strategies affected?
      - Will this require cache warming or invalidation after deployment? -->



## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
