### PR TITLE
[LABS] Giving empty alt text default to video thumbnails

### DIFF
--- a/dashboard/app/views/levels/_video.html.haml
+++ b/dashboard/app/views/levels/_video.html.haml
@@ -1,5 +1,5 @@
 = link_to('#', data: video.summarize, :class => 'video_link') do
-  = image_tag(asset_url(video.thumbnail_path), id: 'thumbnail_' + video.youtube_code, class: 'video_thumbnail')
+  = image_tag(asset_url(video.thumbnail_path), id: 'thumbnail_' + video.youtube_code, class: 'video_thumbnail', alt: '')
   .video_name
     %span= data_t('video.name', video.key)
 - if video_counter.odd?


### PR DESCRIPTION
Part of our VPAT prep work: see 1 fewer violation below:

Before:

<img width="1710" height="863" alt="Screenshot 2026-01-22 at 12 54 59 PM" src="https://github.com/user-attachments/assets/f671af7b-ab71-45c4-8c3d-30643adb87ed" />


After:

<img width="787" height="475" alt="Screenshot 2026-01-22 at 12 53 04 PM" src="https://github.com/user-attachments/assets/afe86c51-292f-4acc-8697-0955d2142f81" />


## Links
- Jira: https://codedotorg.atlassian.net/browse/SL-1536

## Testing story
<!--  Does your change include appropriate tests?
      - If so, please describe how the tests included in this PR are sufficient.
      - If not, please explain why this change does not need to be tested. -->



## Deployment strategy
<!--  Any special steps required to deploy this, besides merging?
      - Are there database migrations or manual steps?
      - Does this require coordination with other teams or systems? -->



## Follow-up work
<!--  List any clean-up or technical debt that will be addressed in future work.
      - Include Jira links where applicable.
      - Are there any known limitations or improvements planned? -->



## Privacy
<!--  How does this change impact Student & Teacher privacy?
      - Does this collect, use, share, or modify PII, either new or existing? -->



## Security
<!--  How does this change impact our security surface-area?
      - Do API's touched have the right auth?
      - Do infra changes impact our attack surface or encryption?
-->



## Caching
<!--  How does this change impact caching behavior?
      - Are cache keys or invalidation strategies affected?
      - Will this require cache warming or invalidation after deployment? -->



## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
