### PR TITLE
chore(ParentalPermission): lazy load modal

### DIFF
--- a/apps/src/templates/policy_compliance/ParentalPermissionBanner/index.tsx
+++ b/apps/src/templates/policy_compliance/ParentalPermissionBanner/index.tsx
@@ -10,11 +10,19 @@ import {ParentalPermissionRequest} from '@cdo/apps/redux/parentalPermissionReque
 import Notification, {
   NotificationType,
 } from '@cdo/apps/sharedComponents/Notification';
-import ParentalPermissionModal from '@cdo/apps/templates/policy_compliance/ParentalPermissionModal';
+import Spinner from '@cdo/apps/sharedComponents/Spinner';
 import {RootState} from '@cdo/apps/types/redux';
 import color from '@cdo/apps/util/color';
 import getCurrentLocale from '@cdo/apps/util/currentLocale';
 import i18n from '@cdo/locale';
+
+const LazyParentalPermissionModal = React.lazy(
+  () =>
+    import(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      '@cdo/apps/templates/policy_compliance/ParentalPermissionModal' as any
+    )
+);
 
 interface ParentalPermissionBannerProps {
   lockoutDate: string;
@@ -119,14 +127,16 @@ const ParentalPermissionBanner: React.FC<ParentalPermissionBannerProps> = ({
   return (
     <Fade in={show} mountOnEnter unmountOnExit>
       <div id="parental-permission-banner">
-        <ParentalPermissionModal
-          lockoutDate={lockoutDate}
-          show={showModal}
-          onClose={handleModalClose}
-          onSubmit={handleModalSubmit}
-          onResend={handleModalResend}
-          onUpdate={handleModalUpdate}
-        />
+        <React.Suspense fallback={<Spinner />}>
+          <LazyParentalPermissionModal
+            lockoutDate={lockoutDate}
+            show={showModal}
+            onClose={handleModalClose}
+            onSubmit={handleModalSubmit}
+            onResend={handleModalResend}
+            onUpdate={handleModalUpdate}
+          />
+        </React.Suspense>
 
         <Notification
           type={NotificationType.warning}


### PR DESCRIPTION
This PR lazy loads the parental permission modal to extract out the bootstrap scss file from the common bundle. This bootstrap file is approximately 465kb and is only needed for the modal. To accomplish this, a react lazy load has been implemented which will render a spinner. Once the bundle is loaded (if needed), the modal will be made avaialble. In normal circumstances, the user will not see any delay as the modal is eagerly loaded when the notification is needed behind the scenes. However, the spinner may still be present on slow networks.

Overall, this greatly improves performance for all users even on slow networks as the overall size of the website is decreased.