### PR TITLE
Add image moderation Cloudwatch metrics and update Statsig reporting

### DIFF
--- a/apps/src/code-studio/components/AssetManager.jsx
+++ b/apps/src/code-studio/components/AssetManager.jsx
@@ -7,6 +7,8 @@ import {
   starterAssets as starterAssetsApi,
   files as filesApi,
 } from '@cdo/apps/clientApi';
+import {EVENTS, PLATFORMS} from '@cdo/apps/metrics/AnalyticsConstants';
+import analyticsReporter from '@cdo/apps/metrics/AnalyticsReporter';
 import i18n from '@cdo/locale';
 
 import assetListStore from '../assets/assetListStore';
@@ -152,7 +154,33 @@ export default class AssetManager extends React.Component {
     });
   };
 
+  /**
+   * Called when user initiates an upload.
+   * If the file is an image, log event.
+   * TODO: moderate if file is an image.
+   * @param data - Upload data from jquery.fileupload
+   */
   onUploadStart = data => {
+    const file = data?.files?.[0];
+    if (!file) {
+      console.error('No file found in upload data.');
+      return;
+    }
+    const isImage = [
+      'image/png',
+      'image/jpeg',
+      'image/jpg',
+      'image/gif',
+    ].includes(file.type);
+
+    if (isImage) {
+      analyticsReporter.sendEvent(
+        EVENTS.UPLOAD_CUSTOM_IMAGE,
+        {UploaderType: 'Asset Uploader', ProjectType: this.state.projectType},
+        PLATFORMS.STATSIG
+      );
+    }
+
     this.setState({statusMessage: 'Uploading...'});
     data.submit();
   };

--- a/apps/src/code-studio/components/AssetManager.jsx
+++ b/apps/src/code-studio/components/AssetManager.jsx
@@ -163,6 +163,7 @@ export default class AssetManager extends React.Component {
     const file = data?.files?.[0];
     if (!file) {
       console.error('No file found in upload data.');
+      this.setState({statusMessage: 'Error: No file selected for upload.'});
       return;
     }
     const isImage = [

--- a/apps/src/code-studio/components/AssetManager.jsx
+++ b/apps/src/code-studio/components/AssetManager.jsx
@@ -157,7 +157,6 @@ export default class AssetManager extends React.Component {
   /**
    * Called when user initiates an upload.
    * If the file is an image, log event.
-   * TODO: moderate if file is an image.
    * @param data - Upload data from jquery.fileupload
    */
   onUploadStart = data => {

--- a/apps/src/code-studio/components/AssetUploader.jsx
+++ b/apps/src/code-studio/components/AssetUploader.jsx
@@ -3,8 +3,6 @@ import PropTypes from 'prop-types';
 import React from 'react';
 
 import Button from '@cdo/apps/legacySharedComponents/Button';
-import {EVENTS, PLATFORMS} from '@cdo/apps/metrics/AnalyticsConstants';
-import analyticsReporter from '@cdo/apps/metrics/AnalyticsReporter';
 import i18n from '@cdo/locale';
 
 import {assetButtonStyles} from './AddAssetButtonRow';
@@ -30,11 +28,6 @@ export default class AssetUploader extends React.Component {
    */
   fileUploadClicked = () => {
     this.refs.uploader.openFileChooser();
-    analyticsReporter.sendEvent(
-      EVENTS.UPLOAD_CUSTOM_IMAGE,
-      {UploaderType: 'Asset Uploader', ProjectType: this.props.projectType},
-      PLATFORMS.STATSIG
-    );
   };
 
   render() {

--- a/apps/src/codebridge/Codebridge.tsx
+++ b/apps/src/codebridge/Codebridge.tsx
@@ -216,6 +216,7 @@ export const Codebridge = React.memo(
               <FlaggedImageModal
                 onAccept={handleAcceptFlaggedImage}
                 onCancel={handleCancelFlaggedImage}
+                appName={appName}
               />
             )}
             <InnerLayout

--- a/apps/src/codebridge/hooks/useFlaggedImage.ts
+++ b/apps/src/codebridge/hooks/useFlaggedImage.ts
@@ -2,6 +2,8 @@ import {useState} from 'react';
 
 import {setIsBlockedAbuse} from '@cdo/apps/lab2/lab2Redux';
 import Lab2Registry from '@cdo/apps/lab2/Lab2Registry';
+import {EVENTS, PLATFORMS} from '@cdo/apps/metrics/AnalyticsConstants';
+import analyticsReporter from '@cdo/apps/metrics/AnalyticsReporter';
 import HttpClient from '@cdo/apps/util/HttpClient';
 import {useAppDispatch, useAppSelector} from '@cdo/apps/util/reduxHooks';
 
@@ -26,7 +28,7 @@ export const useFlaggedImage = () => {
     setFlaggedImageData({file, fileType, uploadFunction});
   };
 
-  const handleAcceptFlaggedImage = async () => {
+  const handleAcceptFlaggedImage = async (appName: string) => {
     if (!flaggedImageData) return;
 
     try {
@@ -42,6 +44,14 @@ export const useFlaggedImage = () => {
             {'Content-Type': 'application/json; charset=UTF-8'}
           );
           dispatch(setIsBlockedAbuse(true));
+          analyticsReporter.sendEvent(
+            EVENTS.ACCEPT_FLAGGED_CUSTOM_IMAGE,
+            {
+              UploaderType: 'Lab2 File Uploader',
+              ProjectType: appName,
+            },
+            PLATFORMS.STATSIG
+          );
         } catch (error) {
           Lab2Registry.getInstance()
             .getMetricsReporter()
@@ -59,7 +69,15 @@ export const useFlaggedImage = () => {
     }
   };
 
-  const handleCancelFlaggedImage = () => {
+  const handleCancelFlaggedImage = (appName: string) => {
+    analyticsReporter.sendEvent(
+      EVENTS.CANCEL_FLAGGED_CUSTOM_IMAGE,
+      {
+        UploaderType: 'Lab2 File Uploader',
+        ProjectType: appName,
+      },
+      PLATFORMS.STATSIG
+    );
     setFlaggedImageData(null);
   };
 

--- a/apps/src/lab2/hooks/useFileUploader.tsx
+++ b/apps/src/lab2/hooks/useFileUploader.tsx
@@ -2,6 +2,8 @@ import React, {useCallback, useMemo, useRef, useState} from 'react';
 
 import codebridgeI18n from '@cdo/apps/codebridge/locale';
 import Lab2Registry from '@cdo/apps/lab2/Lab2Registry';
+import {EVENTS, PLATFORMS} from '@cdo/apps/metrics/AnalyticsConstants';
+import analyticsReporter from '@cdo/apps/metrics/AnalyticsReporter';
 import UploadsDisabledModal from '@cdo/apps/sharedComponents/UploadsDisabledModal';
 import HttpClient from '@cdo/apps/util/HttpClient';
 import {WEBLAB2_IMAGE_FILE_TYPES} from '@cdo/apps/weblab2/constants';
@@ -200,6 +202,11 @@ export const useFileUploader = ({
           }
         };
       } else {
+        analyticsReporter.sendEvent(
+          EVENTS.UPLOAD_CUSTOM_IMAGE,
+          {UploaderType: 'Lab2 File Uploader', ProjectType: appName},
+          PLATFORMS.STATSIG
+        );
         try {
           if (onImageFlagged) {
             const ext = file.name.split('.').pop()?.toLowerCase() || '';

--- a/apps/src/lab2/hooks/useFileUploader.tsx
+++ b/apps/src/lab2/hooks/useFileUploader.tsx
@@ -124,6 +124,14 @@ const moderateImage = async (
       {name: 'AppName', value: appName || 'unknown'},
       {name: 'UploaderType', value: 'Lab2FileUploader'},
     ]);
+    analyticsReporter.sendEvent(
+      EVENTS.FLAGGED_CUSTOM_IMAGE,
+      {
+        UploaderType: 'Lab2 File Uploader',
+        ProjectType: appName,
+      },
+      PLATFORMS.STATSIG
+    );
     return 'flagged';
   } catch (error) {
     metricsReporter.logError('Error with image moderation: ' + error);

--- a/apps/src/lab2/hooks/useFileUploader.tsx
+++ b/apps/src/lab2/hooks/useFileUploader.tsx
@@ -88,7 +88,7 @@ const moderateImage = async (
     return 'skipped';
   }
   const metricsReporter = Lab2Registry.getInstance().getMetricsReporter();
-  metricsReporter.incrementCounter('ModerateCustomImage', [
+  metricsReporter.incrementCounter('ModerateCustomImage.Attempt', [
     {name: 'AppName', value: appName || 'unknown'},
     {name: 'UploaderType', value: 'Lab2FileUploader'},
   ]);
@@ -98,28 +98,28 @@ const moderateImage = async (
     });
     if (!response.ok) {
       metricsReporter.logError('Error with image moderation: HTTP error');
-      metricsReporter.incrementCounter('ModerateCustomImageError', [
+      metricsReporter.incrementCounter('ModerateCustomImage.Error', [
         {name: 'AppName', value: appName || 'unknown'},
         {name: 'UploaderType', value: 'Lab2FileUploader'},
       ]);
       return 'skipped';
     }
     const json = await response.json();
-    metricsReporter.incrementCounter('ModerateCustomImageSuccess', [
+    metricsReporter.incrementCounter('ModerateCustomImage.Success', [
       {name: 'AppName', value: appName || 'unknown'},
       {name: 'UploaderType', value: 'Lab2FileUploader'},
     ]);
     if (json?.rating === 'everyone' || json?.rating === 'unknown') {
       return 'ok';
     }
-    metricsReporter.incrementCounter('ModerateCustomImageFlagged', [
+    metricsReporter.incrementCounter('ModerateCustomImage.Flagged', [
       {name: 'AppName', value: appName || 'unknown'},
       {name: 'UploaderType', value: 'Lab2FileUploader'},
     ]);
     return 'flagged';
   } catch (error) {
     metricsReporter.logError('Error with image moderation: ' + error);
-    metricsReporter.incrementCounter('ModerateCustomImageError', [
+    metricsReporter.incrementCounter('ModerateCustomImage.Error', [
       {name: 'AppName', value: appName || 'unknown'},
       {name: 'UploaderType', value: 'Lab2FileUploader'},
     ]);

--- a/apps/src/lab2/hooks/useFileUploader.tsx
+++ b/apps/src/lab2/hooks/useFileUploader.tsx
@@ -105,11 +105,11 @@ const moderateImage = async (
       return 'skipped';
     }
     const json = await response.json();
+    metricsReporter.incrementCounter('ModerateCustomImageSuccess', [
+      {name: 'AppName', value: appName},
+      {name: 'UploaderType', value: 'Lab2FileUploader'},
+    ]);
     if (json?.rating === 'everyone' || json?.rating === 'unknown') {
-      metricsReporter.incrementCounter('ModerateCustomImageSuccess', [
-        {name: 'AppName', value: appName},
-        {name: 'UploaderType', value: 'Lab2FileUploader'},
-      ]);
       return 'ok';
     }
     metricsReporter.incrementCounter('ModerateCustomImageFlagged', [
@@ -234,6 +234,17 @@ export const useFileUploader = ({
         try {
           if (onImageFlagged) {
             const ext = file.name.split('.').pop()?.toLowerCase() || '';
+            Lab2Registry.getInstance()
+              .getMetricsReporter()
+              .incrementCounter('ModerateCustomImage', [
+                {name: 'AppName', value: appName || ''},
+                {name: 'UploaderType', value: 'Lab2FileUploader'},
+              ]);
+            analyticsReporter.sendEvent(
+              EVENTS.MODERATE_CUSTOM_IMAGE,
+              {UploaderType: 'Lab2 File Uploader', ProjectType: appName},
+              PLATFORMS.STATSIG
+            );
             const moderationStatus = await moderateImage(file, ext, appName);
             if (moderationStatus === 'flagged') {
               const uploadFunction = async () => {

--- a/apps/src/lab2/hooks/useFileUploader.tsx
+++ b/apps/src/lab2/hooks/useFileUploader.tsx
@@ -89,7 +89,7 @@ const moderateImage = async (
   }
   const metricsReporter = Lab2Registry.getInstance().getMetricsReporter();
   metricsReporter.incrementCounter('ModerateCustomImage', [
-    {name: 'AppName', value: appName},
+    {name: 'AppName', value: appName || 'unknown'},
     {name: 'UploaderType', value: 'Lab2FileUploader'},
   ]);
   try {
@@ -99,28 +99,28 @@ const moderateImage = async (
     if (!response.ok) {
       metricsReporter.logError('Error with image moderation: HTTP error');
       metricsReporter.incrementCounter('ModerateCustomImageError', [
-        {name: 'AppName', value: appName},
+        {name: 'AppName', value: appName || 'unknown'},
         {name: 'UploaderType', value: 'Lab2FileUploader'},
       ]);
       return 'skipped';
     }
     const json = await response.json();
     metricsReporter.incrementCounter('ModerateCustomImageSuccess', [
-      {name: 'AppName', value: appName},
+      {name: 'AppName', value: appName || 'unknown'},
       {name: 'UploaderType', value: 'Lab2FileUploader'},
     ]);
     if (json?.rating === 'everyone' || json?.rating === 'unknown') {
       return 'ok';
     }
     metricsReporter.incrementCounter('ModerateCustomImageFlagged', [
-      {name: 'AppName', value: appName},
+      {name: 'AppName', value: appName || 'unknown'},
       {name: 'UploaderType', value: 'Lab2FileUploader'},
     ]);
     return 'flagged';
   } catch (error) {
     metricsReporter.logError('Error with image moderation: ' + error);
     metricsReporter.incrementCounter('ModerateCustomImageError', [
-      {name: 'AppName', value: appName},
+      {name: 'AppName', value: appName || 'unknown'},
       {name: 'UploaderType', value: 'Lab2FileUploader'},
     ]);
     return 'skipped';
@@ -237,12 +237,15 @@ export const useFileUploader = ({
             Lab2Registry.getInstance()
               .getMetricsReporter()
               .incrementCounter('ModerateCustomImage', [
-                {name: 'AppName', value: appName || ''},
+                {name: 'AppName', value: appName || 'unknown'},
                 {name: 'UploaderType', value: 'Lab2FileUploader'},
               ]);
             analyticsReporter.sendEvent(
               EVENTS.MODERATE_CUSTOM_IMAGE,
-              {UploaderType: 'Lab2 File Uploader', ProjectType: appName},
+              {
+                UploaderType: 'Lab2 File Uploader',
+                ProjectType: appName,
+              },
               PLATFORMS.STATSIG
             );
             const moderationStatus = await moderateImage(file, ext, appName);

--- a/apps/src/lab2/hooks/useFileUploader.tsx
+++ b/apps/src/lab2/hooks/useFileUploader.tsx
@@ -4,6 +4,7 @@ import codebridgeI18n from '@cdo/apps/codebridge/locale';
 import Lab2Registry from '@cdo/apps/lab2/Lab2Registry';
 import {EVENTS, PLATFORMS} from '@cdo/apps/metrics/AnalyticsConstants';
 import analyticsReporter from '@cdo/apps/metrics/AnalyticsReporter';
+import MetricsReporter from '@cdo/apps/metrics/MetricsReporter';
 import UploadsDisabledModal from '@cdo/apps/sharedComponents/UploadsDisabledModal';
 import HttpClient from '@cdo/apps/util/HttpClient';
 import {WEBLAB2_IMAGE_FILE_TYPES} from '@cdo/apps/weblab2/constants';
@@ -87,6 +88,10 @@ const moderateImage = async (
   ) {
     return 'skipped';
   }
+  MetricsReporter.incrementCounter('ModerateCustomImage', [
+    {name: 'AppName', value: appName},
+    {name: 'UploaderType', value: 'Lab2FileUploader'},
+  ]);
   const response = await HttpClient.post(`/v3/images/moderate`, file, true, {
     'Content-Type': file.type || 'application/octet-stream',
   });
@@ -94,10 +99,22 @@ const moderateImage = async (
     Lab2Registry.getInstance()
       .getMetricsReporter()
       .logError('Error with image moderation');
+    MetricsReporter.incrementCounter('ModerateCustomImageError', [
+      {name: 'AppName', value: appName},
+      {name: 'UploaderType', value: 'Lab2FileUploader'},
+    ]);
     return 'skipped';
   }
   const json = await response.json();
+  MetricsReporter.incrementCounter('ModerateCustomImageSuccess', [
+    {name: 'AppName', value: appName},
+    {name: 'UploaderType', value: 'Lab2FileUploader'},
+  ]);
   if (json?.rating !== 'everyone' && json?.rating !== 'unknown') {
+    MetricsReporter.incrementCounter('ModerateCustomImageFlagged', [
+      {name: 'AppName', value: appName},
+      {name: 'UploaderType', value: 'Lab2FileUploader'},
+    ]);
     return 'flagged';
   }
   return 'ok';

--- a/apps/src/lab2/hooks/useFileUploader.tsx
+++ b/apps/src/lab2/hooks/useFileUploader.tsx
@@ -88,8 +88,9 @@ const moderateImage = async (
     return 'skipped';
   }
   const metricsReporter = Lab2Registry.getInstance().getMetricsReporter();
+  const appNameForMetrics = appName || 'unknown';
   metricsReporter.incrementCounter('ModerateCustomImage.Attempt', [
-    {name: 'AppName', value: appName || 'unknown'},
+    {name: 'AppName', value: appNameForMetrics},
     {name: 'UploaderType', value: 'Lab2FileUploader'},
   ]);
   analyticsReporter.sendEvent(
@@ -107,21 +108,21 @@ const moderateImage = async (
     if (!response.ok) {
       metricsReporter.logError('Error with image moderation: HTTP error');
       metricsReporter.incrementCounter('ModerateCustomImage.Error', [
-        {name: 'AppName', value: appName || 'unknown'},
+        {name: 'AppName', value: appNameForMetrics},
         {name: 'UploaderType', value: 'Lab2FileUploader'},
       ]);
       return 'skipped';
     }
     const json = await response.json();
     metricsReporter.incrementCounter('ModerateCustomImage.Success', [
-      {name: 'AppName', value: appName || 'unknown'},
+      {name: 'AppName', value: appNameForMetrics},
       {name: 'UploaderType', value: 'Lab2FileUploader'},
     ]);
     if (json?.rating === 'everyone' || json?.rating === 'unknown') {
       return 'ok';
     }
     metricsReporter.incrementCounter('ModerateCustomImage.Flagged', [
-      {name: 'AppName', value: appName || 'unknown'},
+      {name: 'AppName', value: appNameForMetrics},
       {name: 'UploaderType', value: 'Lab2FileUploader'},
     ]);
     analyticsReporter.sendEvent(
@@ -136,7 +137,7 @@ const moderateImage = async (
   } catch (error) {
     metricsReporter.logError('Error with image moderation: ' + error);
     metricsReporter.incrementCounter('ModerateCustomImage.Error', [
-      {name: 'AppName', value: appName || 'unknown'},
+      {name: 'AppName', value: appNameForMetrics},
       {name: 'UploaderType', value: 'Lab2FileUploader'},
     ]);
     return 'skipped';

--- a/apps/src/lab2/hooks/useFileUploader.tsx
+++ b/apps/src/lab2/hooks/useFileUploader.tsx
@@ -97,7 +97,7 @@ const moderateImage = async (
       'Content-Type': file.type || 'application/octet-stream',
     });
     if (!response.ok) {
-      metricsReporter.logError('Error with image moderation');
+      metricsReporter.logError('Error with image moderation: HTTP error');
       metricsReporter.incrementCounter('ModerateCustomImageError', [
         {name: 'AppName', value: appName},
         {name: 'UploaderType', value: 'Lab2FileUploader'},

--- a/apps/src/lab2/hooks/useFileUploader.tsx
+++ b/apps/src/lab2/hooks/useFileUploader.tsx
@@ -4,7 +4,6 @@ import codebridgeI18n from '@cdo/apps/codebridge/locale';
 import Lab2Registry from '@cdo/apps/lab2/Lab2Registry';
 import {EVENTS, PLATFORMS} from '@cdo/apps/metrics/AnalyticsConstants';
 import analyticsReporter from '@cdo/apps/metrics/AnalyticsReporter';
-import MetricsReporter from '@cdo/apps/metrics/MetricsReporter';
 import UploadsDisabledModal from '@cdo/apps/sharedComponents/UploadsDisabledModal';
 import HttpClient from '@cdo/apps/util/HttpClient';
 import {WEBLAB2_IMAGE_FILE_TYPES} from '@cdo/apps/weblab2/constants';
@@ -88,36 +87,44 @@ const moderateImage = async (
   ) {
     return 'skipped';
   }
-  MetricsReporter.incrementCounter('ModerateCustomImage', [
+  const metricsReporter = Lab2Registry.getInstance().getMetricsReporter();
+  metricsReporter.incrementCounter('ModerateCustomImage', [
     {name: 'AppName', value: appName},
     {name: 'UploaderType', value: 'Lab2FileUploader'},
   ]);
-  const response = await HttpClient.post(`/v3/images/moderate`, file, true, {
-    'Content-Type': file.type || 'application/octet-stream',
-  });
-  if (!response.ok) {
-    Lab2Registry.getInstance()
-      .getMetricsReporter()
-      .logError('Error with image moderation');
-    MetricsReporter.incrementCounter('ModerateCustomImageError', [
+  try {
+    const response = await HttpClient.post(`/v3/images/moderate`, file, true, {
+      'Content-Type': file.type || 'application/octet-stream',
+    });
+    if (!response.ok) {
+      metricsReporter.logError('Error with image moderation');
+      metricsReporter.incrementCounter('ModerateCustomImageError', [
+        {name: 'AppName', value: appName},
+        {name: 'UploaderType', value: 'Lab2FileUploader'},
+      ]);
+      return 'skipped';
+    }
+    const json = await response.json();
+    if (json?.rating === 'everyone' || json?.rating === 'unknown') {
+      metricsReporter.incrementCounter('ModerateCustomImageSuccess', [
+        {name: 'AppName', value: appName},
+        {name: 'UploaderType', value: 'Lab2FileUploader'},
+      ]);
+      return 'ok';
+    }
+    metricsReporter.incrementCounter('ModerateCustomImageFlagged', [
+      {name: 'AppName', value: appName},
+      {name: 'UploaderType', value: 'Lab2FileUploader'},
+    ]);
+    return 'flagged';
+  } catch (error) {
+    metricsReporter.logError('Error with image moderation: ' + error);
+    metricsReporter.incrementCounter('ModerateCustomImageError', [
       {name: 'AppName', value: appName},
       {name: 'UploaderType', value: 'Lab2FileUploader'},
     ]);
     return 'skipped';
   }
-  const json = await response.json();
-  MetricsReporter.incrementCounter('ModerateCustomImageSuccess', [
-    {name: 'AppName', value: appName},
-    {name: 'UploaderType', value: 'Lab2FileUploader'},
-  ]);
-  if (json?.rating !== 'everyone' && json?.rating !== 'unknown') {
-    MetricsReporter.incrementCounter('ModerateCustomImageFlagged', [
-      {name: 'AppName', value: appName},
-      {name: 'UploaderType', value: 'Lab2FileUploader'},
-    ]);
-    return 'flagged';
-  }
-  return 'ok';
 };
 /**
  * A custom hook that provides functionality for file uploads,

--- a/apps/src/lab2/hooks/useFileUploader.tsx
+++ b/apps/src/lab2/hooks/useFileUploader.tsx
@@ -92,6 +92,14 @@ const moderateImage = async (
     {name: 'AppName', value: appName || 'unknown'},
     {name: 'UploaderType', value: 'Lab2FileUploader'},
   ]);
+  analyticsReporter.sendEvent(
+    EVENTS.MODERATE_CUSTOM_IMAGE,
+    {
+      UploaderType: 'Lab2 File Uploader',
+      ProjectType: appName,
+    },
+    PLATFORMS.STATSIG
+  );
   try {
     const response = await HttpClient.post(`/v3/images/moderate`, file, true, {
       'Content-Type': file.type || 'application/octet-stream',
@@ -234,20 +242,6 @@ export const useFileUploader = ({
         try {
           if (onImageFlagged) {
             const ext = file.name.split('.').pop()?.toLowerCase() || '';
-            Lab2Registry.getInstance()
-              .getMetricsReporter()
-              .incrementCounter('ModerateCustomImage', [
-                {name: 'AppName', value: appName || 'unknown'},
-                {name: 'UploaderType', value: 'Lab2FileUploader'},
-              ]);
-            analyticsReporter.sendEvent(
-              EVENTS.MODERATE_CUSTOM_IMAGE,
-              {
-                UploaderType: 'Lab2 File Uploader',
-                ProjectType: appName,
-              },
-              PLATFORMS.STATSIG
-            );
             const moderationStatus = await moderateImage(file, ext, appName);
             if (moderationStatus === 'flagged') {
               const uploadFunction = async () => {

--- a/apps/src/metrics/AnalyticsConstants.js
+++ b/apps/src/metrics/AnalyticsConstants.js
@@ -449,6 +449,7 @@ const EVENTS = {
 
   // Add custom image to project
   UPLOAD_CUSTOM_IMAGE: 'User clicks on upload image to project',
+  MODERATE_CUSTOM_IMAGE: 'User-submitted image is moderated',
   SUBMIT_IMAGE_URL: 'User clicks on submit image URL to project',
   FLAGGED_CUSTOM_IMAGE:
     'User attempting to upload an image that is flagged for abuse',

--- a/apps/src/p5lab/AnimationPicker/AnimationPicker.jsx
+++ b/apps/src/p5lab/AnimationPicker/AnimationPicker.jsx
@@ -236,7 +236,9 @@ class AnimationPicker extends React.Component {
         })
           .then(response => {
             if (!response.ok) {
-              MetricsReporter.logError('Error with image moderation');
+              MetricsReporter.logError(
+                'Error with image moderation: HTTP error'
+              );
               MetricsReporter.incrementCounter('ModerateCustomImageError', [
                 {name: 'AppName', value: this.props.projectType},
                 {name: 'UploaderType', value: 'AnimationPicker'},
@@ -277,7 +279,7 @@ class AnimationPicker extends React.Component {
           })
           .catch(err => {
             this.props.onUploadError(msg.animationPicker_uploadingError());
-            MetricsReporter.logError('Azure image moderation error: ' + err);
+            MetricsReporter.logError('Error with image moderation: ' + err);
             MetricsReporter.incrementCounter('ModerateCustomImageError', [
               {name: 'AppName', value: this.props.projectType},
               {name: 'UploaderType', value: 'AnimationPicker'},

--- a/apps/src/p5lab/AnimationPicker/AnimationPicker.jsx
+++ b/apps/src/p5lab/AnimationPicker/AnimationPicker.jsx
@@ -226,11 +226,33 @@ class AnimationPicker extends React.Component {
           pendingUploadData: data,
         });
 
+        MetricsReporter.incrementCounter('ModerateCustomImage', [
+          {name: 'AppName', value: this.props.projectType},
+          {name: 'UploaderType', value: 'AnimationPicker'},
+        ]);
+
         HttpClient.post(`/v3/images/moderate`, file, true, {
           'Content-Type': file.type,
         })
-          .then(response => response.json())
+          .then(response => {
+            if (!response.ok) {
+              MetricsReporter.logError('Error with image moderation');
+              MetricsReporter.incrementCounter('ModerateCustomImageError', [
+                {name: 'AppName', value: this.props.projectType},
+                {name: 'UploaderType', value: 'AnimationPicker'},
+              ]);
+              this.props.onUploadError(msg.animationPicker_uploadingError());
+              return null;
+            }
+            return response.json();
+          })
           .then(json => {
+            if (!json) return; // Skip if an HTTP error occurred.
+
+            MetricsReporter.incrementCounter('ModerateCustomImageSuccess', [
+              {name: 'AppName', value: this.props.projectType},
+              {name: 'UploaderType', value: 'AnimationPicker'},
+            ]);
             // If rating is not 'everyone' or 'unknown', then flag project for image moderation.
             if (json.rating !== 'everyone' && json.rating !== 'unknown') {
               this.setState({
@@ -244,6 +266,10 @@ class AnimationPicker extends React.Component {
                 },
                 PLATFORMS.STATSIG
               );
+              MetricsReporter.incrementCounter('ModerateCustomImageFlagged', [
+                {name: 'AppName', value: this.props.projectType},
+                {name: 'UploaderType', value: 'AnimationPicker'},
+              ]);
             } else {
               // If the image is rated 'everyone' or 'unknown', continue with upload.
               this.props.onUploadStart(this.state.pendingUploadData);
@@ -252,6 +278,10 @@ class AnimationPicker extends React.Component {
           .catch(err => {
             this.props.onUploadError(msg.animationPicker_uploadingError());
             MetricsReporter.logError('Azure image moderation error: ' + err);
+            MetricsReporter.incrementCounter('ModerateCustomImageError', [
+              {name: 'AppName', value: this.props.projectType},
+              {name: 'UploaderType', value: 'AnimationPicker'},
+            ]);
           });
       })
       .catch(err => {

--- a/apps/src/p5lab/AnimationPicker/AnimationPicker.jsx
+++ b/apps/src/p5lab/AnimationPicker/AnimationPicker.jsx
@@ -230,6 +230,14 @@ class AnimationPicker extends React.Component {
           {name: 'AppName', value: this.props.projectType},
           {name: 'UploaderType', value: 'AnimationPicker'},
         ]);
+        analyticsReporter.sendEvent(
+          EVENTS.MODERATE_CUSTOM_IMAGE,
+          {
+            UploaderType: 'Animation Picker',
+            ProjectType: this.props.projectType,
+          },
+          PLATFORMS.STATSIG
+        );
 
         HttpClient.post(`/v3/images/moderate`, file, true, {
           'Content-Type': file.type,

--- a/apps/src/p5lab/AnimationPicker/AnimationPicker.jsx
+++ b/apps/src/p5lab/AnimationPicker/AnimationPicker.jsx
@@ -226,7 +226,7 @@ class AnimationPicker extends React.Component {
           pendingUploadData: data,
         });
 
-        MetricsReporter.incrementCounter('ModerateCustomImage', [
+        MetricsReporter.incrementCounter('ModerateCustomImage.Attempt', [
           {name: 'AppName', value: this.props.projectType || 'unknown'},
           {name: 'UploaderType', value: 'AnimationPicker'},
         ]);
@@ -247,7 +247,7 @@ class AnimationPicker extends React.Component {
               MetricsReporter.logError(
                 'Error with image moderation: HTTP error'
               );
-              MetricsReporter.incrementCounter('ModerateCustomImageError', [
+              MetricsReporter.incrementCounter('ModerateCustomImage.Error', [
                 {name: 'AppName', value: this.props.projectType || 'unknown'},
                 {name: 'UploaderType', value: 'AnimationPicker'},
               ]);
@@ -259,7 +259,7 @@ class AnimationPicker extends React.Component {
           .then(json => {
             if (!json) return; // Skip if an HTTP error occurred.
 
-            MetricsReporter.incrementCounter('ModerateCustomImageSuccess', [
+            MetricsReporter.incrementCounter('ModerateCustomImage.Success', [
               {name: 'AppName', value: this.props.projectType || 'unknown'},
               {name: 'UploaderType', value: 'AnimationPicker'},
             ]);
@@ -276,7 +276,7 @@ class AnimationPicker extends React.Component {
                 },
                 PLATFORMS.STATSIG
               );
-              MetricsReporter.incrementCounter('ModerateCustomImageFlagged', [
+              MetricsReporter.incrementCounter('ModerateCustomImage.Flagged', [
                 {name: 'AppName', value: this.props.projectType || 'unknown'},
                 {name: 'UploaderType', value: 'AnimationPicker'},
               ]);
@@ -288,7 +288,7 @@ class AnimationPicker extends React.Component {
           .catch(err => {
             this.props.onUploadError(msg.animationPicker_uploadingError());
             MetricsReporter.logError('Error with image moderation: ' + err);
-            MetricsReporter.incrementCounter('ModerateCustomImageError', [
+            MetricsReporter.incrementCounter('ModerateCustomImage.Error', [
               {name: 'AppName', value: this.props.projectType || 'unknown'},
               {name: 'UploaderType', value: 'AnimationPicker'},
             ]);

--- a/apps/src/p5lab/AnimationPicker/AnimationPicker.jsx
+++ b/apps/src/p5lab/AnimationPicker/AnimationPicker.jsx
@@ -227,7 +227,7 @@ class AnimationPicker extends React.Component {
         });
 
         MetricsReporter.incrementCounter('ModerateCustomImage', [
-          {name: 'AppName', value: this.props.projectType},
+          {name: 'AppName', value: this.props.projectType || 'unknown'},
           {name: 'UploaderType', value: 'AnimationPicker'},
         ]);
         analyticsReporter.sendEvent(
@@ -248,7 +248,7 @@ class AnimationPicker extends React.Component {
                 'Error with image moderation: HTTP error'
               );
               MetricsReporter.incrementCounter('ModerateCustomImageError', [
-                {name: 'AppName', value: this.props.projectType},
+                {name: 'AppName', value: this.props.projectType || 'unknown'},
                 {name: 'UploaderType', value: 'AnimationPicker'},
               ]);
               this.props.onUploadError(msg.animationPicker_uploadingError());
@@ -260,7 +260,7 @@ class AnimationPicker extends React.Component {
             if (!json) return; // Skip if an HTTP error occurred.
 
             MetricsReporter.incrementCounter('ModerateCustomImageSuccess', [
-              {name: 'AppName', value: this.props.projectType},
+              {name: 'AppName', value: this.props.projectType || 'unknown'},
               {name: 'UploaderType', value: 'AnimationPicker'},
             ]);
             // If rating is not 'everyone' or 'unknown', then flag project for image moderation.
@@ -277,7 +277,7 @@ class AnimationPicker extends React.Component {
                 PLATFORMS.STATSIG
               );
               MetricsReporter.incrementCounter('ModerateCustomImageFlagged', [
-                {name: 'AppName', value: this.props.projectType},
+                {name: 'AppName', value: this.props.projectType || 'unknown'},
                 {name: 'UploaderType', value: 'AnimationPicker'},
               ]);
             } else {
@@ -289,7 +289,7 @@ class AnimationPicker extends React.Component {
             this.props.onUploadError(msg.animationPicker_uploadingError());
             MetricsReporter.logError('Error with image moderation: ' + err);
             MetricsReporter.incrementCounter('ModerateCustomImageError', [
-              {name: 'AppName', value: this.props.projectType},
+              {name: 'AppName', value: this.props.projectType || 'unknown'},
               {name: 'UploaderType', value: 'AnimationPicker'},
             ]);
           });

--- a/apps/src/sharedComponents/FlaggedImageModal.tsx
+++ b/apps/src/sharedComponents/FlaggedImageModal.tsx
@@ -5,8 +5,9 @@ import React from 'react';
 import i18n from '@cdo/locale';
 
 interface FlaggedImageModalProps {
-  onAccept: () => void;
-  onCancel: () => void;
+  appName: string;
+  onAccept: (appName: string) => void;
+  onCancel: (appName: string) => void;
   errorMessage?: string;
 }
 
@@ -14,11 +15,12 @@ const FlaggedImageModal: React.FC<FlaggedImageModalProps> = ({
   onAccept,
   onCancel,
   errorMessage,
+  appName,
 }) => {
   return (
     <Modal
       id="image-flagged-modal"
-      onClose={onCancel}
+      onClose={() => onCancel(appName)}
       title={i18n.animationPicker_flaggedImageModalTitle()}
       customContent={
         <div id="dsco-dialog-description">
@@ -47,12 +49,12 @@ const FlaggedImageModal: React.FC<FlaggedImageModalProps> = ({
       }
       primaryButtonProps={{
         text: i18n.accept(),
-        onClick: onAccept,
+        onClick: () => onAccept(appName),
         disabled: !!errorMessage, // Disable if there's an error message.
       }}
       secondaryButtonProps={{
         text: i18n.cancel(),
-        onClick: onCancel,
+        onClick: () => onCancel(appName),
       }}
     />
   );


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
While investigating alternative image moderation services since Azure Content Moderator is deprecated, I looked at current image upload statsig data we collect. I noticed that image upload/moderation Statsig events for Web Lab 2 were never added when we implemented image moderation in Web Lab 2. This PR adds Statsig logging of image upload/moderation events to Web Lab 2. 

I also saw that in Asset Manager, we log this event for an upload of any asset though images are most common. A user can upload an image, audio, or other file types via the Asset Manager (in contrast to Animation Picker which only allows png file uploads). 
https://github.com/code-dot-org/code-dot-org/blob/b656fef4fc0deb4823250751a2ff1c79fdc98011/dashboard/legacy/middleware/helpers/asset_bucket.rb#L16-L18
So I updated so that logging of this event only occurs for image uploads.

I also added a Statsig event for when images are moderated because there are cases when a user uploads an image, but it is not moderated. We currently do not moderate images uploaded via Asset Manager (App Lab), images uploaded as part of start sources, and images whose dimensions are too small for the Azure Content Moderator.

Lastly, I added Cloudwatch metrics for image moderation. I think it may be useful to start collecting metrics so we can compare our current image moderation service to performance when we migrate to new service. [Slack discussion](https://codedotorg.slack.com/archives/C03DBDN67B7/p1768940243795469)
The events I added are:
```
'ModerateCustomImage.Attempt'
'ModerateCustomImage.Success'
'ModerateCustomImage.Error'
'ModerateCustomImage.Flagged'
```
Note that I did not add metrics on whether the user accept or cancelled the upload of a flagged image since this is reported in Statsig and relates more to user activity rather than monitoring health of image moderation service.

## After update
I was able to see Cloudwatch and Statsig logs in dev console locally as expected.

### App Lab (Asset Manager - we do not currently moderate images):
<img width="508" height="128" alt="applab-img" src="https://github.com/user-attachments/assets/7dc3d4d6-8bd5-44a2-97f4-31a7156a4c12" />


### Sprite Lab (Animation Picker):
<img width="482" height="260" alt="spritelab-img" src="https://github.com/user-attachments/assets/c30a4c0d-f144-4c6b-b57e-c8aba1de41ad" />

### Web Lab 2 (Lab2 File Uploader):
<img width="576" height="262" alt="weblab2-img" src="https://github.com/user-attachments/assets/9eee37ab-bae1-484d-97d3-6604cf753cd3" />

### Web Lab 2 - Image flagged and upload accepted:
<img width="919" height="402" alt="weblab2-accept-flagged" src="https://github.com/user-attachments/assets/1479a038-e127-4876-ab10-10f9e8a47dbd" />


### Web Lab 2 - Image flagged and upload cancelled:
<img width="947" height="268" alt="weblab2-cancel-flagged" src="https://github.com/user-attachments/assets/f4866b20-d5b7-4d5f-aef7-fa4fcc96a405" />

## Links
<!--  Links to relevant external resources.
      - spec docs, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- Jira: https://codedotorg.atlassian.net/browse/AFL-440
- [Slack discussion](https://codedotorg.slack.com/archives/C03DBDN67B7/p1768940243795469)
## Testing story
<!--  Does your change include appropriate tests?
      - If so, please describe how the tests included in this PR are sufficient.
      - If not, please explain why this change does not need to be tested. -->

Tested locally - see After Update section above.

## Deployment strategy
<!--  Any special steps required to deploy this, besides merging?
      - Are there database migrations or manual steps?
      - Does this require coordination with other teams or systems? -->



## Follow-up work
<!--  List any clean-up or technical debt that will be addressed in future work.
      - Include Jira links where applicable.
      - Are there any known limitations or improvements planned? -->



## Privacy
<!--  How does this change impact Student & Teacher privacy?
      - Does this collect, use, share, or modify PII, either new or existing? -->



## Security
<!--  How does this change impact our security surface-area?
      - Do API's touched have the right auth?
      - Do infra changes impact our attack surface or encryption?
-->



## Caching
<!--  How does this change impact caching behavior?
      - Are cache keys or invalidation strategies affected?
      - Will this require cache warming or invalidation after deployment? -->



## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
