### PR TITLE
Sketch Lab backpack: fix error message typo

### DIFF
--- a/apps/src/sketchlab/utils/handleSaveToBackpack.ts
+++ b/apps/src/sketchlab/utils/handleSaveToBackpack.ts
@@ -32,7 +32,7 @@ export const handleSaveToBackpack = async (
     if (!containsValidCharacters) {
       return {
         type: 'error',
-        text: 'Sketch names can only contain letters, numbers, hypens and underscores.',
+        text: 'Sketch names can only contain letters, numbers, hyphens and underscores.',
       };
     }
     if (backpackFileList.includes(sketchName + '.png')) {


### PR DESCRIPTION
Fix a small typo in an error message for sketch lab backpack name validation.

## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
