### PR TITLE
Backpack: re-enable delete after cancel

### DIFF
--- a/apps/src/lab2/views/components/Instructions/ResourcePanel/Backpack/BackpackFileChip.tsx
+++ b/apps/src/lab2/views/components/Instructions/ResourcePanel/Backpack/BackpackFileChip.tsx
@@ -180,6 +180,8 @@ const BackpackFileChip: React.FC<BackpackFileChipProps> = ({
           });
         }
       );
+    } else {
+      setActionInProgress(false);
     }
   };
 


### PR DESCRIPTION
Emma found a bug where if you cancelled a delete from the new backpack panel, the buttons stayed disabled. This fixes that.

## Before

https://github.com/user-attachments/assets/4c668a7d-966d-4d67-9837-7beab0c7b017


## After

https://github.com/user-attachments/assets/52fab52d-e5fa-4ab1-a0c3-1fc762bb2062


## Testing story
Tested locally.



## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
