### PR TITLE
Update Level/Project Activity metrics

### DIFF
--- a/apps/src/StudioApp.js
+++ b/apps/src/StudioApp.js
@@ -2199,6 +2199,7 @@ StudioApp.prototype.configureDom = function (config) {
           unitName: config.scriptName,
           levelId: config.serverLevelId,
           levelName: config.level.name,
+          appName: config.appName,
         },
         PLATFORMS.BOTH
       );

--- a/apps/src/StudioApp.js
+++ b/apps/src/StudioApp.js
@@ -2192,10 +2192,14 @@ StudioApp.prototype.configureDom = function (config) {
       eventName = EVENTS.LEVEL_ACTIVITY;
     }
     if (!runButtonWasClicked) {
+      // For publicly cached pages, config.isSignedIn will be false even when signed in.
+      // Check the Redux store for the actual sign-in state.
+      const state = getStore().getState();
+      const signedIn = state.currentUser?.signInState;
       analyticsReporter.sendEvent(
         eventName,
         {
-          signedIn: config.isSignedIn,
+          signedIn,
           unitName: config.scriptName,
           levelId: config.serverLevelId,
           levelName: config.level.name,

--- a/apps/src/StudioApp.js
+++ b/apps/src/StudioApp.js
@@ -2199,7 +2199,7 @@ StudioApp.prototype.configureDom = function (config) {
           unitName: config.scriptName,
           levelId: config.serverLevelId,
           levelName: config.level.name,
-          appName: config.appName,
+          appName: project.getStandaloneApp(),
           levelPath: window.location.pathname,
         },
         PLATFORMS.STATSIG

--- a/apps/src/StudioApp.js
+++ b/apps/src/StudioApp.js
@@ -2199,7 +2199,7 @@ StudioApp.prototype.configureDom = function (config) {
           unitName: config.scriptName,
           levelId: config.serverLevelId,
           levelName: config.level.name,
-          appName: project.getStandaloneApp(),
+          appName: config.app,
           levelPath: window.location.pathname,
         },
         PLATFORMS.STATSIG

--- a/apps/src/StudioApp.js
+++ b/apps/src/StudioApp.js
@@ -2195,11 +2195,11 @@ StudioApp.prototype.configureDom = function (config) {
       // For publicly cached pages, config.isSignedIn will be false even when signed in.
       // Check the Redux store for the actual sign-in state.
       const state = getStore().getState();
-      const signedIn = state.currentUser?.signInState;
+      const signedIn = state.currentUser?.signInState === 'SignedIn' || false;
       analyticsReporter.sendEvent(
         eventName,
         {
-          signedIn,
+          signedIn: signedIn.toString(),
           unitName: config.scriptName,
           levelId: config.serverLevelId,
           levelName: config.level.name,

--- a/apps/src/StudioApp.js
+++ b/apps/src/StudioApp.js
@@ -2200,8 +2200,9 @@ StudioApp.prototype.configureDom = function (config) {
           levelId: config.serverLevelId,
           levelName: config.level.name,
           appName: config.appName,
+          levelPath: window.location.pathname,
         },
-        PLATFORMS.BOTH
+        PLATFORMS.STATSIG
       );
       runButtonWasClicked = true;
     }

--- a/apps/src/StudioApp.js
+++ b/apps/src/StudioApp.js
@@ -2199,7 +2199,7 @@ StudioApp.prototype.configureDom = function (config) {
       analyticsReporter.sendEvent(
         eventName,
         {
-          signedIn: signedIn.toString(),
+          signedIn: signedIn,
           unitName: config.scriptName,
           levelId: config.serverLevelId,
           levelName: config.level.name,

--- a/apps/src/fish/Fish.js
+++ b/apps/src/fish/Fish.js
@@ -70,6 +70,7 @@ Fish.prototype.init = function (config) {
         unitName: config.scriptName,
         levelId: config.serverLevelId,
         levelName: config.level.name,
+        appName: config.appName,
       },
       PLATFORMS.BOTH
     );

--- a/apps/src/fish/Fish.js
+++ b/apps/src/fish/Fish.js
@@ -119,11 +119,6 @@ Fish.prototype.init = function (config) {
 
 // Called by the fish app when it wants to go to the next level.
 Fish.prototype.onContinue = function () {
-  // Report level activity before continuing (which causes a page reload)
-  if (this.reportActivityEvent_) {
-    this.reportActivityEvent_();
-  }
-
   const onReportComplete = result => {
     this.studioApp_.onContinue();
   };

--- a/apps/src/fish/Fish.js
+++ b/apps/src/fish/Fish.js
@@ -68,7 +68,7 @@ Fish.prototype.init = function (config) {
         unitName: config.scriptName,
         levelId: config.serverLevelId,
         levelName: config.level.name,
-        appName: config.appName,
+        appName: 'fish',
         levelPath: window.location.pathname,
       },
       PLATFORMS.STATSIG

--- a/apps/src/fish/Fish.js
+++ b/apps/src/fish/Fish.js
@@ -64,11 +64,11 @@ Fish.prototype.init = function (config) {
     // For publicly cached pages, config.isSignedIn will be false even when signed in.
     // Check the Redux store for the actual sign-in state.
     const state = getStore().getState();
-    const signedIn = state.currentUser?.signInState === 'SignedIn';
+    const signedIn = state.currentUser?.signInState === 'SignedIn' || false;
     analyticsReporter.sendEvent(
       EVENTS.LEVEL_ACTIVITY,
       {
-        signedIn,
+        signedIn: signedIn.toString(),
         unitName: config.scriptName,
         levelId: config.serverLevelId,
         levelName: config.level.name,

--- a/apps/src/fish/Fish.js
+++ b/apps/src/fish/Fish.js
@@ -61,10 +61,8 @@ Fish.prototype.init = function (config) {
   config.pinWorkspaceToBottom = true;
 
   const reportActivityEvent = () => {
-    const {isProjectLevel} = getStore().getState().pageConstants;
-
     analyticsReporter.sendEvent(
-      isProjectLevel ? EVENTS.PROJECT_ACTIVITY : EVENTS.LEVEL_ACTIVITY,
+      EVENTS.LEVEL_ACTIVITY,
       {
         signedIn: config.isSignedIn,
         unitName: config.scriptName,
@@ -121,6 +119,11 @@ Fish.prototype.init = function (config) {
 
 // Called by the fish app when it wants to go to the next level.
 Fish.prototype.onContinue = function () {
+  // Report level activity before continuing (which causes a page reload)
+  if (this.reportActivityEvent_) {
+    this.reportActivityEvent_();
+  }
+
   const onReportComplete = result => {
     this.studioApp_.onContinue();
   };

--- a/apps/src/fish/Fish.js
+++ b/apps/src/fish/Fish.js
@@ -71,8 +71,9 @@ Fish.prototype.init = function (config) {
         levelId: config.serverLevelId,
         levelName: config.level.name,
         appName: config.appName,
+        levelPath: window.location.pathname,
       },
-      PLATFORMS.BOTH
+      PLATFORMS.STATSIG
     );
   };
 

--- a/apps/src/fish/Fish.js
+++ b/apps/src/fish/Fish.js
@@ -61,14 +61,18 @@ Fish.prototype.init = function (config) {
   config.pinWorkspaceToBottom = true;
 
   const reportActivityEvent = () => {
+    // For publicly cached pages, config.isSignedIn will be false even when signed in.
+    // Check the Redux store for the actual sign-in state.
+    const state = getStore().getState();
+    const signedIn = state.currentUser?.signInState === 'SignedIn';
     analyticsReporter.sendEvent(
       EVENTS.LEVEL_ACTIVITY,
       {
-        signedIn: config.isSignedIn,
+        signedIn,
         unitName: config.scriptName,
         levelId: config.serverLevelId,
         levelName: config.level.name,
-        appName: 'fish',
+        appName: config.app,
         levelPath: window.location.pathname,
       },
       PLATFORMS.STATSIG

--- a/apps/src/fish/Fish.js
+++ b/apps/src/fish/Fish.js
@@ -68,7 +68,7 @@ Fish.prototype.init = function (config) {
     analyticsReporter.sendEvent(
       EVENTS.LEVEL_ACTIVITY,
       {
-        signedIn: signedIn.toString(),
+        signedIn: signedIn,
         unitName: config.scriptName,
         levelId: config.serverLevelId,
         levelName: config.level.name,

--- a/apps/src/lab2/hooks/useLevelActivityMetrics.ts
+++ b/apps/src/lab2/hooks/useLevelActivityMetrics.ts
@@ -1,7 +1,7 @@
 import {useCallback, useEffect, useRef} from 'react';
 
+import {sendLab2AnalyticsEvent} from '@cdo/apps/lab2/utils';
 import {EVENTS} from '@cdo/apps/metrics/AnalyticsConstants';
-import analyticsReporter from '@cdo/apps/metrics/AnalyticsReporter';
 import {useAppSelector} from '@cdo/apps/util/reduxHooks';
 
 import {LevelProperties} from '../types';
@@ -44,18 +44,16 @@ export function useLevelActivityMetrics(
       ? EVENTS.PROJECT_ACTIVITY
       : EVENTS.LEVEL_ACTIVITY;
 
-    analyticsReporter.sendEvent(eventName, {
+    sendLab2AnalyticsEvent(eventName, {
       signedIn,
-      unitName: scriptName,
-      levelId: levelProperties.id,
+      unitName: scriptName ?? '',
+      levelId: levelProperties.id.toString(),
       levelName: levelProperties.name,
-      appName: levelProperties.appName,
     });
   }, [
     levelProperties.isProjectLevel,
     levelProperties.id,
     levelProperties.name,
-    levelProperties.appName,
     signedIn,
     scriptName,
   ]);

--- a/apps/src/lab2/hooks/useLevelActivityMetrics.ts
+++ b/apps/src/lab2/hooks/useLevelActivityMetrics.ts
@@ -24,7 +24,9 @@ import {LevelProperties} from '../types';
 export function useLevelActivityMetrics(
   levelProperties: LevelProperties
 ): () => void {
-  const signedIn = useAppSelector(state => state.currentUser.signInState);
+  const signedIn =
+    useAppSelector(state => state.currentUser.signInState) === 'SignedIn' ||
+    false;
   const scriptName = useAppSelector(state => state.progress.scriptName);
 
   const hasLoggedRef = useRef(false);
@@ -45,7 +47,7 @@ export function useLevelActivityMetrics(
       : EVENTS.LEVEL_ACTIVITY;
 
     sendLab2AnalyticsEvent(eventName, {
-      signedIn,
+      signedIn: signedIn.toString(),
       unitName: scriptName ?? '',
       levelId: levelProperties.id.toString(),
       levelName: levelProperties.name,

--- a/apps/src/lab2/hooks/useLevelActivityMetrics.ts
+++ b/apps/src/lab2/hooks/useLevelActivityMetrics.ts
@@ -4,11 +4,7 @@ import {EVENTS} from '@cdo/apps/metrics/AnalyticsConstants';
 import analyticsReporter from '@cdo/apps/metrics/AnalyticsReporter';
 import {useAppSelector} from '@cdo/apps/util/reduxHooks';
 
-interface LevelProperties {
-  isProjectLevel?: boolean;
-  id?: number;
-  name?: string;
-}
+import {LevelProperties} from '../types';
 
 /**
  * Custom hook that provides a callback to log LEVEL_ACTIVITY or PROJECT_ACTIVITY
@@ -53,11 +49,13 @@ export function useLevelActivityMetrics(
       unitName: scriptName,
       levelId: levelProperties.id,
       levelName: levelProperties.name,
+      appName: levelProperties.appName,
     });
   }, [
     levelProperties.isProjectLevel,
     levelProperties.id,
     levelProperties.name,
+    levelProperties.appName,
     signedIn,
     scriptName,
   ]);

--- a/apps/src/lab2/hooks/useLevelActivityMetrics.ts
+++ b/apps/src/lab2/hooks/useLevelActivityMetrics.ts
@@ -47,9 +47,9 @@ export function useLevelActivityMetrics(
       : EVENTS.LEVEL_ACTIVITY;
 
     sendLab2AnalyticsEvent(eventName, {
-      signedIn: signedIn.toString(),
+      signedIn: signedIn,
       unitName: scriptName ?? '',
-      levelId: levelProperties.id.toString(),
+      levelId: levelProperties.id,
       levelName: levelProperties.name,
     });
   }, [

--- a/apps/src/lab2/utils/analyticsReporterHelper.ts
+++ b/apps/src/lab2/utils/analyticsReporterHelper.ts
@@ -10,7 +10,7 @@ import analyticsReporter from '@cdo/apps/metrics/AnalyticsReporter';
  */
 export function sendLab2AnalyticsEvent(
   eventName: string,
-  payload?: Record<string, string>
+  payload?: Record<string, string | number | boolean>
 ) {
   analyticsReporter.sendEvent(eventName, payload, PLATFORMS.STATSIG, true);
 }

--- a/apps/src/metrics/AnalyticsReporter.js
+++ b/apps/src/metrics/AnalyticsReporter.js
@@ -75,7 +75,7 @@ class AnalyticsReporter {
     includeProjectProperties = false
   ) {
     if ([PLATFORMS.STATSIG, PLATFORMS.BOTH].includes(analyticsTool)) {
-      // Include project properties in Statsig events.
+      // Include project properties in Statsig events (levelPath, appName).
       const statsigPayload = includeProjectProperties
         ? {...payload, ...this.projectContext}
         : payload;

--- a/apps/test/unit/lab2/hooks/useLevelActivityMetricsTest.tsx
+++ b/apps/test/unit/lab2/hooks/useLevelActivityMetricsTest.tsx
@@ -4,6 +4,7 @@ import {Provider} from 'react-redux';
 import {Store} from 'redux';
 
 import {useLevelActivityMetrics} from '@cdo/apps/lab2/hooks/useLevelActivityMetrics';
+import {LevelProperties} from '@cdo/apps/lab2/types';
 import {EVENTS} from '@cdo/apps/metrics/AnalyticsConstants';
 import analyticsReporter from '@cdo/apps/metrics/AnalyticsReporter';
 import {
@@ -31,28 +32,25 @@ const mockProgress = (
   action: any
 ) => state;
 
-interface LevelProperties {
-  isProjectLevel?: boolean;
-  id?: number;
-  name?: string;
-}
-
 const defaultLevelProperties: LevelProperties = {
   isProjectLevel: false,
   id: 123,
   name: 'Test Level',
+  appName: 'weblab2',
 };
 
 const projectLevelProperties: LevelProperties = {
   isProjectLevel: true,
   id: 456,
   name: 'Project Level',
+  appName: 'weblab2',
 };
 
 const differentLevelProperties: LevelProperties = {
   isProjectLevel: false,
   id: 789,
   name: 'Different Level',
+  appName: 'weblab2',
 };
 
 describe('useLevelActivityMetrics', () => {
@@ -118,6 +116,7 @@ describe('useLevelActivityMetrics', () => {
           unitName: 'test-script',
           levelId: 123,
           levelName: 'Test Level',
+          appName: 'weblab2',
         }
       );
       expect(mockAnalyticsReporter.sendEvent).toHaveBeenCalledTimes(1);
@@ -137,6 +136,7 @@ describe('useLevelActivityMetrics', () => {
           unitName: 'test-script',
           levelId: 456,
           levelName: 'Project Level',
+          appName: 'weblab2',
         }
       );
       expect(mockAnalyticsReporter.sendEvent).toHaveBeenCalledTimes(1);
@@ -156,6 +156,7 @@ describe('useLevelActivityMetrics', () => {
           unitName: expect.any(String),
           levelId: expect.any(Number),
           levelName: expect.any(String),
+          appName: 'weblab2',
         })
       );
     });
@@ -220,6 +221,7 @@ describe('useLevelActivityMetrics', () => {
           unitName: 'test-script',
           levelId: 789,
           levelName: 'Different Level',
+          appName: 'weblab2',
         }
       );
     });
@@ -244,6 +246,7 @@ describe('useLevelActivityMetrics', () => {
         expect.objectContaining({
           levelId: 456,
           levelName: 'Project Level',
+          appName: 'weblab2',
         })
       );
     });

--- a/apps/test/unit/lab2/hooks/useLevelActivityMetricsTest.tsx
+++ b/apps/test/unit/lab2/hooks/useLevelActivityMetricsTest.tsx
@@ -5,8 +5,8 @@ import {Store} from 'redux';
 
 import {useLevelActivityMetrics} from '@cdo/apps/lab2/hooks/useLevelActivityMetrics';
 import {LevelProperties} from '@cdo/apps/lab2/types';
+import {sendLab2AnalyticsEvent} from '@cdo/apps/lab2/utils';
 import {EVENTS} from '@cdo/apps/metrics/AnalyticsConstants';
-import analyticsReporter from '@cdo/apps/metrics/AnalyticsReporter';
 import {
   getStore,
   registerReducers,
@@ -14,14 +14,15 @@ import {
   stubRedux,
 } from '@cdo/apps/redux';
 
-jest.mock('@cdo/apps/metrics/AnalyticsReporter');
-const mockAnalyticsReporter = analyticsReporter as jest.Mocked<
-  typeof analyticsReporter
->;
+jest.mock('@cdo/apps/lab2/utils', () => ({
+  sendLab2AnalyticsEvent: jest.fn(),
+}));
+const mockSendLab2AnalyticsEvent =
+  sendLab2AnalyticsEvent as jest.MockedFunction<typeof sendLab2AnalyticsEvent>;
 
 const mockCurrentUser = (
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  state: any = {signInState: 'signedIn'},
+  state: any = {signInState: 'SignedIn'},
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   action: any
 ) => state;
@@ -90,14 +91,14 @@ describe('useLevelActivityMetrics', () => {
     it('does not trigger analytics when hook is initialized', () => {
       renderHookWithRedux(defaultLevelProperties);
 
-      expect(mockAnalyticsReporter.sendEvent).not.toHaveBeenCalled();
+      expect(mockSendLab2AnalyticsEvent).not.toHaveBeenCalled();
     });
 
     it('hook initializes without errors', () => {
       const {result} = renderHookWithRedux(defaultLevelProperties);
 
       expect(result.error).toBeUndefined();
-      expect(mockAnalyticsReporter.sendEvent).not.toHaveBeenCalled();
+      expect(mockSendLab2AnalyticsEvent).not.toHaveBeenCalled();
     });
   });
 
@@ -109,17 +110,16 @@ describe('useLevelActivityMetrics', () => {
         result.current();
       });
 
-      expect(mockAnalyticsReporter.sendEvent).toHaveBeenCalledWith(
+      expect(mockSendLab2AnalyticsEvent).toHaveBeenCalledWith(
         EVENTS.LEVEL_ACTIVITY,
         {
-          signedIn: 'signedIn',
+          signedIn: 'true',
           unitName: 'test-script',
-          levelId: 123,
+          levelId: '123',
           levelName: 'Test Level',
-          appName: 'weblab2',
         }
       );
-      expect(mockAnalyticsReporter.sendEvent).toHaveBeenCalledTimes(1);
+      expect(mockSendLab2AnalyticsEvent).toHaveBeenCalledTimes(1);
     });
 
     it('logs PROJECT_ACTIVITY event when callback is invoked for project level', () => {
@@ -129,17 +129,16 @@ describe('useLevelActivityMetrics', () => {
         result.current();
       });
 
-      expect(mockAnalyticsReporter.sendEvent).toHaveBeenCalledWith(
+      expect(mockSendLab2AnalyticsEvent).toHaveBeenCalledWith(
         EVENTS.PROJECT_ACTIVITY,
         {
-          signedIn: 'signedIn',
+          signedIn: 'true',
           unitName: 'test-script',
-          levelId: 456,
+          levelId: '456',
           levelName: 'Project Level',
-          appName: 'weblab2',
         }
       );
-      expect(mockAnalyticsReporter.sendEvent).toHaveBeenCalledTimes(1);
+      expect(mockSendLab2AnalyticsEvent).toHaveBeenCalledTimes(1);
     });
 
     it('includes complete payload with all required fields', () => {
@@ -149,14 +148,13 @@ describe('useLevelActivityMetrics', () => {
         result.current();
       });
 
-      expect(mockAnalyticsReporter.sendEvent).toHaveBeenCalledWith(
+      expect(mockSendLab2AnalyticsEvent).toHaveBeenCalledWith(
         EVENTS.LEVEL_ACTIVITY,
         expect.objectContaining({
           signedIn: expect.any(String),
           unitName: expect.any(String),
-          levelId: expect.any(Number),
+          levelId: expect.any(String),
           levelName: expect.any(String),
-          appName: 'weblab2',
         })
       );
     });
@@ -172,7 +170,7 @@ describe('useLevelActivityMetrics', () => {
         result.current();
       });
 
-      expect(mockAnalyticsReporter.sendEvent).toHaveBeenCalledTimes(1);
+      expect(mockSendLab2AnalyticsEvent).toHaveBeenCalledTimes(1);
     });
 
     it('verifies hasLoggedRef prevents duplicate events', () => {
@@ -186,7 +184,7 @@ describe('useLevelActivityMetrics', () => {
         result.current();
       });
 
-      expect(mockAnalyticsReporter.sendEvent).toHaveBeenCalledTimes(1);
+      expect(mockSendLab2AnalyticsEvent).toHaveBeenCalledTimes(1);
     });
   });
 
@@ -198,7 +196,7 @@ describe('useLevelActivityMetrics', () => {
         result1.current();
       });
 
-      expect(mockAnalyticsReporter.sendEvent).toHaveBeenCalledTimes(1);
+      expect(mockSendLab2AnalyticsEvent).toHaveBeenCalledTimes(1);
 
       const wrapper = ({children}: {children: React.ReactNode}) => (
         <Provider store={store}>{children}</Provider>
@@ -213,15 +211,14 @@ describe('useLevelActivityMetrics', () => {
         result2.current();
       });
 
-      expect(mockAnalyticsReporter.sendEvent).toHaveBeenCalledTimes(2);
-      expect(mockAnalyticsReporter.sendEvent).toHaveBeenLastCalledWith(
+      expect(mockSendLab2AnalyticsEvent).toHaveBeenCalledTimes(2);
+      expect(mockSendLab2AnalyticsEvent).toHaveBeenLastCalledWith(
         EVENTS.LEVEL_ACTIVITY,
         {
-          signedIn: 'signedIn',
+          signedIn: 'true',
           unitName: 'test-script',
-          levelId: 789,
+          levelId: '789',
           levelName: 'Different Level',
-          appName: 'weblab2',
         }
       );
     });
@@ -239,14 +236,13 @@ describe('useLevelActivityMetrics', () => {
         result2.current();
       });
 
-      expect(mockAnalyticsReporter.sendEvent).toHaveBeenCalledTimes(2);
+      expect(mockSendLab2AnalyticsEvent).toHaveBeenCalledTimes(2);
 
-      expect(mockAnalyticsReporter.sendEvent).toHaveBeenLastCalledWith(
+      expect(mockSendLab2AnalyticsEvent).toHaveBeenLastCalledWith(
         EVENTS.PROJECT_ACTIVITY,
         expect.objectContaining({
-          levelId: 456,
+          levelId: '456',
           levelName: 'Project Level',
-          appName: 'weblab2',
         })
       );
     });

--- a/apps/test/unit/lab2/hooks/useLevelActivityMetricsTest.tsx
+++ b/apps/test/unit/lab2/hooks/useLevelActivityMetricsTest.tsx
@@ -113,9 +113,9 @@ describe('useLevelActivityMetrics', () => {
       expect(mockSendLab2AnalyticsEvent).toHaveBeenCalledWith(
         EVENTS.LEVEL_ACTIVITY,
         {
-          signedIn: 'true',
+          signedIn: true,
           unitName: 'test-script',
-          levelId: '123',
+          levelId: 123,
           levelName: 'Test Level',
         }
       );
@@ -132,9 +132,9 @@ describe('useLevelActivityMetrics', () => {
       expect(mockSendLab2AnalyticsEvent).toHaveBeenCalledWith(
         EVENTS.PROJECT_ACTIVITY,
         {
-          signedIn: 'true',
+          signedIn: true,
           unitName: 'test-script',
-          levelId: '456',
+          levelId: 456,
           levelName: 'Project Level',
         }
       );
@@ -151,9 +151,9 @@ describe('useLevelActivityMetrics', () => {
       expect(mockSendLab2AnalyticsEvent).toHaveBeenCalledWith(
         EVENTS.LEVEL_ACTIVITY,
         expect.objectContaining({
-          signedIn: expect.any(String),
+          signedIn: expect.any(Boolean),
           unitName: expect.any(String),
-          levelId: expect.any(String),
+          levelId: expect.any(Number),
           levelName: expect.any(String),
         })
       );
@@ -215,9 +215,9 @@ describe('useLevelActivityMetrics', () => {
       expect(mockSendLab2AnalyticsEvent).toHaveBeenLastCalledWith(
         EVENTS.LEVEL_ACTIVITY,
         {
-          signedIn: 'true',
+          signedIn: true,
           unitName: 'test-script',
-          levelId: '789',
+          levelId: 789,
           levelName: 'Different Level',
         }
       );
@@ -241,7 +241,7 @@ describe('useLevelActivityMetrics', () => {
       expect(mockSendLab2AnalyticsEvent).toHaveBeenLastCalledWith(
         EVENTS.PROJECT_ACTIVITY,
         expect.objectContaining({
-          levelId: '456',
+          levelId: 456,
           levelName: 'Project Level',
         })
       );


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
This PR adds `appName` and `levelPath` to Level/Project Activity events and removes logging to Amplitude so now these events are sent to Statsig only. This was a request from product: [Slack thread](https://codedotorg.slack.com/archives/C043ZKQ4BS6/p1768419768017209?thread_ts=1768414365.958359&cid=C043ZKQ4BS6) and follows up https://github.com/code-dot-org/code-dot-org/pull/68656 which added level/project activity logging for most `lab2` labs. 

I also updated `signedIn` logging in legacy labs since `signedIn` was not being set accurately for cached levels as we were using `appOptions`. Currently, legacy labs are set values of `true`/`false`/`undefined` and lab2 labs (already using current user redux), are set values of ’SignedIn”, “Signedout”, “Unknown”. I updated so `signedIn` `"true"` or `"false"` for all labs.

Note that I did check in with @nataliazm99  and Marina from the RED team about updates and they were good with it!

## Before update
`appName` and `levelPath` are not included in logging:
<img width="459" height="124" alt="Screenshot 2026-01-26 at 10 38 26 AM" src="https://github.com/user-attachments/assets/5dab8e5e-8ad6-4b03-9796-24c933796f75" />

`signedIn` is not included in logging because `undefined` on cached `fish` levels:
<img width="546" height="94" alt="Screenshot 2026-01-27 at 12 57 52 PM" src="https://github.com/user-attachments/assets/24530c47-2155-48bb-965b-52a943299d7a" />



## After update

Sprite Lab project activity logged:
<img width="468" height="80" alt="spritelab-project" src="https://github.com/user-attachments/assets/9da5bbad-e2ed-44bc-88f3-c36375f0ab5a" />


Dance 2 level activity logged:
<img width="527" height="85" alt="dance2-level" src="https://github.com/user-attachments/assets/d8378fb2-5a3a-429e-af8e-fdf5f7c0805d" />

Python Lab project activity logged:
<img width="509" height="95" alt="pythonlab-project" src="https://github.com/user-attachments/assets/b9693918-caab-4c39-9fe4-39ae5237e323" />


AI for Oceans level activity logged with signed-in user (on page load):
<img width="805" height="55" alt="fish-level-signed-in" src="https://github.com/user-attachments/assets/52dba31a-dc86-4afc-9798-ecf29be71609" />

AI for Oceans level activity logged with signed-out user (on page load):
<img width="537" height="80" alt="fish-level-signed-out" src="https://github.com/user-attachments/assets/37b3008c-0bf9-48df-a1db-6db61f4b7e19" />



## Links
<!--  Links to relevant external resources.
      - spec docs, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- Jira: https://codedotorg.atlassian.net/browse/AFL-429

## Testing story
<!--  Does your change include appropriate tests?
      - If so, please describe how the tests included in this PR are sufficient.
      - If not, please explain why this change does not need to be tested. -->



## Deployment strategy
<!--  Any special steps required to deploy this, besides merging?
      - Are there database migrations or manual steps?
      - Does this require coordination with other teams or systems? -->



## Follow-up work
<!--  List any clean-up or technical debt that will be addressed in future work.
      - Include Jira links where applicable.
      - Are there any known limitations or improvements planned? -->



## Privacy
<!--  How does this change impact Student & Teacher privacy?
      - Does this collect, use, share, or modify PII, either new or existing? -->



## Security
<!--  How does this change impact our security surface-area?
      - Do API's touched have the right auth?
      - Do infra changes impact our attack surface or encryption?
-->



## Caching
<!--  How does this change impact caching behavior?
      - Are cache keys or invalidation strategies affected?
      - Will this require cache warming or invalidation after deployment? -->



## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
