### PR TITLE
Enable Zero-ETL on Test & Production Aurora Clusters

### DIFF
--- a/aws/cloudformation/components/database.yml.erb
+++ b/aws/cloudformation/components/database.yml.erb
@@ -313,7 +313,23 @@
       # Credentials (username and password) for the SQL User this Resource is provisioning.
       DBCredentialSecret: !Ref DatabaseSecretReader
       Privileges: ['SELECT']
-
+  ZeroETLIntegration:
+      Type: AWS::Redshift::Integration
+  <% unless rack_env?(:production) -%>
+      # Ensure Aurora instances are provisioned before creating the integration link.
+      DependsOn: [<%= DB_INSTANCE_RANGE.map {|i| "Aurora#{i}"}.join(',') %>]
+  <% end -%>
+      Properties:
+        IntegrationName: !Sub "${AWS::StackName}-zero-etl"
+        Description: "Export transactional tables from MySQL to Redshift via Zero-ETL integration."
+        SourceArn: !Sub
+          - "arn:aws:rds:${AWS::Region}:${AWS::AccountId}:cluster:${ClusterId}"
+          - ClusterId: <%= rack_env?(:production) ? PRODUCTION_DB_CLUSTER_ID : '!Ref AuroraCluster' %>
+        TargetArn: !ImportValue DATA-production-RedshiftClusterNamespace
+        DataFilter: !Sub "include: dashboard_<%= rack_env %>.levels"
+        Tags:
+          - Key: environment
+            Value: "<%= rack_env %>"
 <% # We don't provision DB Cluster and Instances in production via CloudFormation ... yet!
   unless rack_env?(:production)
 -%>

--- a/aws/cloudformation/components/database.yml.erb
+++ b/aws/cloudformation/components/database.yml.erb
@@ -313,7 +313,7 @@
       # Credentials (username and password) for the SQL User this Resource is provisioning.
       DBCredentialSecret: !Ref DatabaseSecretReader
       Privileges: ['SELECT']
-<% if rack_env?(:production) # Provision Zero ETL Integration to Redshift in production only. -%>
+<% if rack_env?(:production) || rack_env?(:test) # Provision Zero ETL on managed test server and production. -%>
   ZeroETLIntegration:
     Type: AWS::RDS::Integration
     Properties:

--- a/aws/cloudformation/components/database.yml.erb
+++ b/aws/cloudformation/components/database.yml.erb
@@ -314,22 +314,22 @@
       DBCredentialSecret: !Ref DatabaseSecretReader
       Privileges: ['SELECT']
   ZeroETLIntegration:
-      Type: AWS::Redshift::Integration
-  <% unless rack_env?(:production) -%>
-      # Ensure Aurora instances are provisioned before creating the integration link.
-      DependsOn: [<%= DB_INSTANCE_RANGE.map {|i| "Aurora#{i}"}.join(',') %>]
-  <% end -%>
-      Properties:
-        IntegrationName: !Sub "${AWS::StackName}-zero-etl"
-        Description: "Export transactional tables from MySQL to Redshift via Zero-ETL integration."
-        SourceArn: !Sub
-          - "arn:aws:rds:${AWS::Region}:${AWS::AccountId}:cluster:${ClusterId}"
-          - ClusterId: <%= rack_env?(:production) ? PRODUCTION_DB_CLUSTER_ID : '!Ref AuroraCluster' %>
-        TargetArn: !ImportValue DATA-production-RedshiftClusterNamespace
-        DataFilter: !Sub "include: dashboard_<%= rack_env %>.levels"
-        Tags:
-          - Key: environment
-            Value: "<%= rack_env %>"
+    Type: AWS::Redshift::Integration
+<% unless rack_env?(:production) -%>
+    # Ensure Aurora instances are provisioned before creating the integration link.
+    DependsOn: [<%=DB_INSTANCE_RANGE.map {|i| "Aurora#{i}"}.join(',') %>]
+<% end -%>
+    Properties:
+      IntegrationName: !Sub "${AWS::StackName}-zero-etl"
+      Description: "Export transactional tables from MySQL to Redshift via Zero-ETL integration."
+      SourceArn: !Sub
+        - "arn:aws:rds:${AWS::Region}:${AWS::AccountId}:cluster:${ClusterId}"
+        - ClusterId: <%=rack_env?(:production) ? PRODUCTION_DB_CLUSTER_ID : '!Ref AuroraCluster' %>
+      TargetArn: !ImportValue DATA-production-RedshiftClusterNamespace
+      DataFilter: !Sub "include: dashboard_<%=rack_env %>.levels"
+      Tags:
+        - Key: environment
+          Value: "<%=rack_env %>"
 <% # We don't provision DB Cluster and Instances in production via CloudFormation ... yet!
   unless rack_env?(:production)
 -%>

--- a/aws/cloudformation/components/database.yml.erb
+++ b/aws/cloudformation/components/database.yml.erb
@@ -314,7 +314,7 @@
       DBCredentialSecret: !Ref DatabaseSecretReader
       Privileges: ['SELECT']
   ZeroETLIntegration:
-    Type: AWS::Redshift::Integration
+    Type: AWS::RDS::Integration
 <% unless rack_env?(:production) -%>
     # Ensure Aurora instances are provisioned before creating the integration link.
     DependsOn: [<%=DB_INSTANCE_RANGE.map {|i| "Aurora#{i}"}.join(',') %>]

--- a/aws/cloudformation/components/database.yml.erb
+++ b/aws/cloudformation/components/database.yml.erb
@@ -313,12 +313,9 @@
       # Credentials (username and password) for the SQL User this Resource is provisioning.
       DBCredentialSecret: !Ref DatabaseSecretReader
       Privileges: ['SELECT']
+<% if rack_env?(:production) # Provision Zero ETL Integration to Redshift in production only. -%>
   ZeroETLIntegration:
     Type: AWS::RDS::Integration
-<% unless rack_env?(:production) -%>
-    # Ensure Aurora instances are provisioned before creating the integration link.
-    DependsOn: [<%=DB_INSTANCE_RANGE.map {|i| "Aurora#{i}"}.join(',') %>]
-<% end -%>
     Properties:
       IntegrationName: !Sub "${AWS::StackName}-zero-etl"
       Description: "Export transactional tables from MySQL to Redshift via Zero-ETL integration."
@@ -330,6 +327,7 @@
       Tags:
         - Key: environment
           Value: "<%=rack_env %>"
+<% end -%>
 <% # We don't provision DB Cluster and Instances in production via CloudFormation ... yet!
   unless rack_env?(:production)
 -%>

--- a/aws/cloudformation/data.yml.erb
+++ b/aws/cloudformation/data.yml.erb
@@ -79,23 +79,27 @@ Resources:
       PreferredMaintenanceWindow: 'Tue:01:00-Tue:01:30'
       PubliclyAccessible: true
       VpcSecurityGroupIds: [!ImportValue VPC-RedshiftSecurityGroup]
-  RedshiftZeroETLResourcePolicy:
-    Type: AWS::Redshift::ResourcePolicy
-    Properties:
-      ResourceArn: !GetAtt Tableau.ClusterNamespaceArn
-      Policy:
-        Version: "2012-10-17"
-        Statement:
-          - Sid: AllowZeroETLFromProductionAurora
-            Effect: Allow
-            Principal:
-              Service: "redshift.amazonaws.com"
-            Action:
-              - "redshift:AuthorizeInboundIntegration"
-            Resource: !GetAtt Tableau.ClusterNamespaceArn
-            Condition:
-              ArnEquals:
-                "redshift:SourceArn": !Ref ProductionAuroraClusterARN
+#  Redshift does not yet support configuring a Resource Policy on a Provisioned Cluster. We configure this one policy
+#  manually.
+#  TODO: Move our Redshift datawarehouse to a Serverless and/or implement this via CloudFormation when Provisioned
+#  cluster Resources are supported.
+#  RedshiftZeroETLResourcePolicy:
+#    Type: AWS::RedshiftServerless::ResourcePolicy
+#    Properties:
+#      ResourceArn: !GetAtt Tableau.ClusterNamespaceArn
+#      Policy:
+#        Version: "2012-10-17"
+#        Statement:
+#          - Sid: AllowZeroETLFromProductionAurora
+#            Effect: Allow
+#            Principal:
+#              Service: "redshift.amazonaws.com"
+#            Action:
+#              - "redshift:AuthorizeInboundIntegration"
+#            Resource: !GetAtt Tableau.ClusterNamespaceArn
+#            Condition:
+#              ArnEquals:
+#                "redshift:SourceArn": !Ref ProductionAuroraClusterARN
   DMSReplicationInstance:
     Type: AWS::DMS::ReplicationInstance
     Properties:
@@ -766,6 +770,6 @@ Resources:
 Outputs:
   RedshiftClusterNamespace:
     Value: !GetAtt Tableau.ClusterNamespaceArn
-    Description: "Redshift Cluster Namespace for Zero-ETL targeting"
+    Description: "Redshift Cluster Namespace for Zero-ETL targeting."
     Export:
       Name: !Sub "${AWS::StackName}-RedshiftClusterNamespace"

--- a/aws/cloudformation/data.yml.erb
+++ b/aws/cloudformation/data.yml.erb
@@ -32,6 +32,9 @@ Parameters:
   # Typically in the form: `cluster-[random-AWS-assigned-string].[region].rds.amazonaws.com` without leading dot.
   RDSClusterEndpointRootDomain:
     Type: String
+  ProductionAuroraClusterARN:
+    Type: String
+    Description: The ARN of the production Aurora cluster so we can authorize it as a Redshift source for Zero-ETL.
   ReportingCluster:
     Type: String
   RedshiftDatabase:
@@ -76,6 +79,23 @@ Resources:
       PreferredMaintenanceWindow: 'Tue:01:00-Tue:01:30'
       PubliclyAccessible: true
       VpcSecurityGroupIds: [!ImportValue VPC-RedshiftSecurityGroup]
+  RedshiftZeroETLResourcePolicy:
+    Type: AWS::Redshift::ResourcePolicy
+    Properties:
+      ResourceArn: !GetAtt Tableau.ClusterNamespaceArn
+      Policy:
+        Version: "2012-10-17"
+        Statement:
+          - Sid: AllowZeroETLFromProductionAurora
+            Effect: Allow
+            Principal:
+              Service: "redshift.amazonaws.com"
+            Action:
+              - "redshift:AuthorizeInboundIntegration"
+            Resource: !GetAtt Tableau.ClusterNamespaceArn
+            Condition:
+              ArnEquals:
+                "redshift:SourceArn": !Ref ProductionAuroraClusterARN
   DMSReplicationInstance:
     Type: AWS::DMS::ReplicationInstance
     Properties:
@@ -743,3 +763,9 @@ Resources:
           InputFormat: org.apache.hadoop.mapred.TextInputFormat
           SerdeInfo:
             SerializationLibrary: org.openx.data.jsonserde.JsonSerDe
+Outputs:
+  RedshiftClusterNamespace:
+    Value: !GetAtt Tableau.ClusterNamespaceArn
+    Description: "Redshift Cluster Namespace for Zero-ETL targeting"
+    Export:
+      Name: !Sub "${AWS::StackName}-RedshiftClusterNamespace"

--- a/aws/cloudformation/data.yml.erb
+++ b/aws/cloudformation/data.yml.erb
@@ -61,6 +61,8 @@ Resources:
   Tableau:
     Type: AWS::Redshift::Cluster
     DeletionPolicy: Retain
+    Metadata:
+      UpdateTrigger: "Force output export - 2026-01-26"
     Properties:
       AllowVersionUpgrade: true
       AutomatedSnapshotRetentionPeriod: 5


### PR DESCRIPTION
https://codedotorg.atlassian.net/browse/INF-1793

Create a Zero ETL integration on our Redshift cluster and our test and production Aurora MySQL clusters, with a short, hard-coded list of small tables to export. This is one of many components needed to implement an end-to-end integration from Aurora MySQL to Redshift as outlined in the [AWS Zero ETL documentation](https://docs.aws.amazon.com/redshift/latest/mgmt/zero-etl-using.setting-up.html).

Prerequisites already implemented (manually, unless Pull Request referenced):
- [Set Redshift `enable_case_sensitive_identifier=ON`](https://docs.aws.amazon.com/redshift/latest/mgmt/zero-etl-setting-up.case-sensitivity.html) 
- Add [Authorized Principals and Authorized Integration Sources](https://docs.aws.amazon.com/redshift/latest/mgmt/zero-etl-using.redshift-iam.html) to Redshift cluster

This feature branch [implements the Zero ETL Integration on the production Aurora cluster](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/zero-etl.creating.html#zero-etl.create).

After this change is released to production, we will [manually create the destination Databases (`test_learningplatform_mysql_zeroetl` and `production_learningplatform_mysql_zeroetl`) in the Redshift cluster](https://docs.aws.amazon.com/redshift/latest/mgmt/zero-etl-using.creating-db.html) to start syncing data from the tables identified in this Pull Request and we will execute a SQL statement to configure the target Redshift Zero ETL schema to permit invalid UTF8 byte sequences / characters and also to truncate values longer than the Redshift VARCHAR max of 65,535 bytes by executing:
```sql
-- Set Truncate Columns
ALTER DATABASE test_learningplatform_mysql_zeroetl 
INTEGRATION SET TRUNCATECOLUMNS TRUE;

-- Set Accept Invalid Characters with a replacement character
ALTER DATABASE test_learningplatform_mysql_zeroetl 
INTEGRATION SET ACCEPTINVCHARS TRUE;
```


## Testing story

Test changes to Data template:
```bash
code-dot-org $ export AWS_PROFILE=codeorg-admin
code-dot-org $ bundle exec rake stack:data:validate RAILS_ENV=production ADMIN=true PRODUCTION_AURORA_CLUSTER_ARN=arn:aws:rds:us-east-1:[REDACTED]:cluster:[REDACTED]
Finished stack:data:environment (less than a minute)
Parameters:
ProductionAuroraClusterARN: !Required
Pending update for stack `DATA-production`:
No changes
```

Manually authenticated an adhoc's cluster to write to the Redshift cluster via Zero ETL, and successfully exported the tables specified in the Aurora Zero ETL Integration.


## Deployment strategy

- [x] Manually deploy changes to Data Stack: `code-dot-org % bundle exec rake stack:data:start RAILS_ENV=production ADMIN=true PRODUCTION_AURORA_CLUSTER_ARN=arn:aws:rds:us-east-1:[REDACTED]:cluster:[REDACTED]`
- [x] Manually grant the production Aurora cluster and the managed test Aurora cluster permissions to export via Zero ETL to our Redshift cluster.
- [x] Merge this feature branch to enable Zero ETL Integration on the production Aurora cluster and the managed test system's Aurora cluster
- [x] - Manually create `test_learningplatform_mysql_zeroetl` and `production_learningplatform_mysql_zeroetl`
- [x] - Manually configure destination databases in Redshift to permit invalid UTF8 characters:
```sql
-- Set Truncate Columns
ALTER DATABASE test_learningplatform_mysql_zeroetl 
INTEGRATION SET TRUNCATECOLUMNS TRUE;

-- Set Accept Invalid Characters with a replacement character
ALTER DATABASE test_learningplatform_mysql_zeroetl 
INTEGRATION SET ACCEPTINVCHARS TRUE;
```



## Follow-up work
<!--  List any clean-up or technical debt that will be addressed in future work.
      - Include Jira links where applicable.
      - Are there any known limitations or improvements planned? -->



## Privacy
<!--  How does this change impact Student & Teacher privacy?
      - Does this collect, use, share, or modify PII, either new or existing? -->



## Security
<!--  How does this change impact our security surface-area?
      - Do API's touched have the right auth?
      - Do infra changes impact our attack surface or encryption?
-->



## Caching
<!--  How does this change impact caching behavior?
      - Are cache keys or invalidation strategies affected?
      - Will this require cache warming or invalidation after deployment? -->



## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
