### PR TITLE
Web Lab 2 preview: fix image caching issue

### DIFF
--- a/apps/src/codebridge/FilePreview/weblab2_project_service_worker.js
+++ b/apps/src/codebridge/FilePreview/weblab2_project_service_worker.js
@@ -106,7 +106,8 @@ function main() {
         if (url.startsWith('/level_starter_assets/')) {
           // We fetch level starter assets from the code.org origin for this environment.
           // We use a cache-busting query parameter to ensure that we get the correct response headers,
-          // specifically to avoid CORs issues with Access-Control-Allow-Origin being out of date.
+          // specifically to avoid CORs issues with Access-Control-Allow-Origin being set to someone else's
+          // preview url.
           const cacheBust = `?cache-bust=${cacheBustSuffix}`;
           fetchUrl = codeDotOrgOrigin + url + cacheBust;
           console.log({fetchUrl});

--- a/apps/src/codebridge/FilePreview/weblab2_project_service_worker.js
+++ b/apps/src/codebridge/FilePreview/weblab2_project_service_worker.js
@@ -110,7 +110,6 @@ function main() {
           // preview url.
           const cacheBust = `?cache-bust=${cacheBustSuffix}`;
           fetchUrl = codeDotOrgOrigin + url + cacheBust;
-          console.log({fetchUrl});
         }
         return await fetch(fetchUrl);
       }

--- a/apps/src/codebridge/FilePreview/weblab2_project_service_worker.js
+++ b/apps/src/codebridge/FilePreview/weblab2_project_service_worker.js
@@ -20,6 +20,8 @@ function main() {
     PROJECT_SERVICE_WORKER_BROADCAST_CHANNEL
   );
   const codeDotOrgOrigin = getCodeDotOrgOrigin();
+  // Generate a cache bust suffix for this service worker instance.
+  const cacheBustSuffix = Date.now().toString();
   let contentSecurityPolicyValue = null;
 
   addEventListener('install', () => {
@@ -103,9 +105,11 @@ function main() {
         let fetchUrl = url;
         if (url.startsWith('/level_starter_assets/')) {
           // We fetch level starter assets from the code.org origin for this environment.
-          // Adding a temporary cache bust query parameter to avoid some caching issues with level starter assets.
-          const temporaryCacheBust = '?temp-cache-bust=1';
-          fetchUrl = codeDotOrgOrigin + url + temporaryCacheBust;
+          // We use a cache-busting query parameter to ensure that we get the correct response headers,
+          // specifically to avoid CORs issues with Access-Control-Allow-Origin being out of date.
+          const cacheBust = `?cache-bust=${cacheBustSuffix}`;
+          fetchUrl = codeDotOrgOrigin + url + cacheBust;
+          console.log({fetchUrl});
         }
         return await fetch(fetchUrl);
       }


### PR DESCRIPTION
Emma found an issue where level starter assets were loading for one person but not another. In chrome I got a helpful error message that we were getting a cors error because the Access-Control-Allowed-Origin was set to a preview url that was not this page's preview url. The logic to set that header is [here](https://github.com/code-dot-org/code-dot-org/blob/e522315959759ca8066ceeaa376db1fa71f3936e/dashboard/app/controllers/level_starter_assets_controller.rb#L43-L48).

I believe what is happening here is the response, including the header, is getting cached by one user. Then the next user tries to load the image and gets the cors error because it doesn't match their preview header. To fix this, I am adding a unique cache bust suffix per service worker instance.

## Links
- Jira: [slack](https://codedotorg.slack.com/archives/C06JELCAPT9/p1769538051965709?thread_ts=1767651176.340169&cid=C06JELCAPT9)

## Testing story
I can't repro this locally, but this does not cause any issues.

## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
