### PR TITLE
Stop removing locals.yml from cached build in drone

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -87,8 +87,6 @@ steps:
       - git config user.name "Drone"
       - git config user.email "drone-fake-user@code.org"
       - git merge origin/$DRONE_TARGET_BRANCH
-      # ensure no stale locals.yml from cache
-      - rm -f locals.yml
 
   - name: unit-tests
     # see: docker/ci/Dockerfile
@@ -211,8 +209,6 @@ steps:
       - git config user.name "Drone"
       - git config user.email "drone-fake-user@code.org"
       - git merge origin/$DRONE_TARGET_BRANCH
-      # ensure no stale locals.yml from cache
-      - rm -f locals.yml
 
   - name: ui-tests
     # see: docker/ci/Dockerfile
@@ -346,6 +342,6 @@ trigger:
 
 ---
 kind: signature
-hmac: b8d6c0921f5aefdfe0325259e54bba589b098b57e48cbdea74996d4420bf09d0
+hmac: 8380ec279dc40128beca1b341a9fff3212255c2a343d9fed59c9c839ab095669
 
 ...


### PR DESCRIPTION
Follow-up from
* https://github.com/code-dot-org/code-dot-org/pull/69968. 

This PR stops removing locals.yml from the drone build cache. this was needed as a temporary measure in #69968, since existing cached builds still contained locals.yml at the time that PR was merged. Once the `cache-staging-build` pipeline completes after that PR is merged to staging, the cached staging build will no longer contain a locals.yml file and we'll no longer need to explicitly remove it after pulling down the cache.

## testing story
- [x] wait for #69968 to be merged
- [x] wait for subsequent drone push build to complete
- [x] rerun drone on this PR and confirm that it passes
