### PR TITLE
Decommission unused CDO.localize_apps config value

### DIFF
--- a/config.yml.erb
+++ b/config.yml.erb
@@ -476,8 +476,6 @@ default_teacher_application_mode: 'closed' # overridden by 'teacher_application_
 
 default_courses_show_ai: false # overridden by 'courses_show_ai' DCDO param, except in :test
 
-localize_apps: false
-
 partners: []
 
 # Default Rack server ports for PDF-generation scripts.


### PR DESCRIPTION
Follow-up from 
* https://github.com/code-dot-org/code-dot-org/pull/69968

This step was deferred into this PR to help de-risk #69968.

## Testing story
- [x] wait for #69968 to be merged
- [x] wait for subsequent drone "push" build to complete
- [x] rerun drone on this PR and confirm it passed

## Deployment strategy

I'll drop a note in slack about removing the missing key from locals.yml .