### PR TITLE
Update PanelsView.tsx to wrap background image URLs in translation calls

### DIFF
--- a/apps/src/panels/PanelsView.tsx
+++ b/apps/src/panels/PanelsView.tsx
@@ -12,6 +12,7 @@ import React, {
 import Typist from 'react-typist';
 
 import TextToSpeech from '@cdo/apps/lab2/views/components/TextToSpeech';
+import localization from '@cdo/apps/localization';
 
 import {queryParams} from '../code-studio/utils';
 import FontAwesome from '../legacySharedComponents/FontAwesome';
@@ -224,21 +225,21 @@ const PanelsView: React.FunctionComponent<PanelsProps> = ({
           <div
             className={styles.image}
             style={{
-              backgroundImage: `url("${previousPanel.imageUrl}")`,
+              backgroundImage: `url("${localization.translate(previousPanel.imageUrl, ['lz-image'])}")`,
             }}
           />
         )}
         <div
           className={classNames(styles.image, styles.imageCurrent)}
           style={{
-            backgroundImage: `url("${panel.imageUrl}")`,
+            backgroundImage: `url("${localization.translate(panel.imageUrl, ['lz-image'])}")`,
           }}
         />
         {nextPanel && (
           <div
             className={classNames(styles.image, styles.imageInvisible)}
             style={{
-              backgroundImage: `url("${nextPanel.imageUrl}")`,
+              backgroundImage: `url("${localization.translate(nextPanel.imageUrl, ['lz-image'])}")`,
             }}
           />
         )}

--- a/apps/src/panels/PanelsView.tsx
+++ b/apps/src/panels/PanelsView.tsx
@@ -225,21 +225,29 @@ const PanelsView: React.FunctionComponent<PanelsProps> = ({
           <div
             className={styles.image}
             style={{
-              backgroundImage: `url("${localization.translate(previousPanel.imageUrl, ['lz-image'])}")`,
+              backgroundImage: `url("${localization.translate(
+                previousPanel.imageUrl,
+                ['lz-image']
+              )}")`,
             }}
           />
         )}
         <div
           className={classNames(styles.image, styles.imageCurrent)}
           style={{
-            backgroundImage: `url("${localization.translate(panel.imageUrl, ['lz-image'])}")`,
+            backgroundImage: `url("${localization.translate(panel.imageUrl, [
+              'lz-image',
+            ])}")`,
           }}
         />
         {nextPanel && (
           <div
             className={classNames(styles.image, styles.imageInvisible)}
             style={{
-              backgroundImage: `url("${localization.translate(nextPanel.imageUrl, ['lz-image'])}")`,
+              backgroundImage: `url("${localization.translate(
+                nextPanel.imageUrl,
+                ['lz-image']
+              )}")`,
             }}
           />
         )}


### PR DESCRIPTION
Wraps the image URLs being used as background images in panels levels such that they are translatable. This is because some levels abuse the background image to provide 'slideshow'-like content with text that we would need to swap out.

## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
