### PR TITLE
Fix handful of Enzyme tests with one failing test for React 18, batch 2

### DIFF
--- a/apps/test/unit/code-studio/components/SettingsCogTest.js
+++ b/apps/test/unit/code-studio/components/SettingsCogTest.js
@@ -1,5 +1,6 @@
 import {shallow, mount} from 'enzyme'; // eslint-disable-line no-restricted-imports
 import React from 'react';
+import {act} from 'react-dom/test-utils';
 import {Provider} from 'react-redux';
 
 import * as assets from '@cdo/apps/code-studio/assets';
@@ -158,7 +159,7 @@ describe('SettingsCog', () => {
         expect(settings.text()).not.toContain(msg.disableMaker());
       });
 
-      it('does display maker toggle if not a curriculum level (standalone project)', () => {
+      it('does display maker toggle if not a curriculum level (standalone project)', async () => {
         getStore().dispatch(
           setPageConstants({
             isCurriculumLevel: false,
@@ -170,7 +171,9 @@ describe('SettingsCog', () => {
           </Provider>
         );
         let settings = wrapper.find('SettingsCog');
-        settings.instance().open();
+        await act(async () => {
+          settings.instance().open();
+        });
         settings.update();
         expect(settings.text()).toContain(msg.disableMaker());
       });

--- a/apps/test/unit/templates/BackToFrontConfettiTest.js
+++ b/apps/test/unit/templates/BackToFrontConfettiTest.js
@@ -1,5 +1,6 @@
 import {mount} from 'enzyme'; // eslint-disable-line no-restricted-imports
 import React from 'react';
+import {act} from 'react-dom/test-utils';
 
 import BackToFrontConfetti from '@cdo/apps/templates/BackToFrontConfetti';
 
@@ -33,12 +34,20 @@ describe('BackToFrontConfetti', () => {
     expect(wrapper).to.have.style('zIndex', '-1');
   });
 
-  it('switches to a positive zIndex shortly after activation', () => {
+  it('switches to a positive zIndex shortly after activation', async () => {
     const wrapper = mount(<BackToFrontConfetti />);
-    wrapper.setProps({active: true});
-    jest.advanceTimersByTime(600);
+    await act(async () => {
+      wrapper.setProps({active: true});
+    });
+    await act(async () => {
+      jest.advanceTimersByTime(600);
+    });
+    wrapper.update();
     expect(wrapper).to.have.style('zIndex', '-1');
-    jest.advanceTimersByTime(100);
+    await act(async () => {
+      jest.advanceTimersByTime(100);
+    });
+    wrapper.update();
     expect(wrapper).to.have.style('zIndex', '1');
   });
 });

--- a/apps/test/unit/templates/instructions/BackgroundMusicMuteButtonTest.jsx
+++ b/apps/test/unit/templates/instructions/BackgroundMusicMuteButtonTest.jsx
@@ -1,5 +1,6 @@
 import {mount} from 'enzyme'; // eslint-disable-line no-restricted-imports
 import React from 'react';
+import {act} from 'react-dom/test-utils';
 import sinon from 'sinon'; // eslint-disable-line no-restricted-imports
 
 import {UnconnectedBackgroundMusicMuteButton as BackgroundMusicMuteButton} from '@cdo/apps/templates/instructions/BackgroundMusicMuteButton';
@@ -40,17 +41,25 @@ describe('SignedInUser', () => {
     assert(wrapper.text() === i18n.backgroundMusicOff());
   });
 
-  it('calls mute and unmute functions accordingly', () => {
+  it('calls mute and unmute functions accordingly', async () => {
     let onMuteSpy = sinon.spy();
     let onUnmuteSpy = sinon.spy();
     const wrapper = setUp({
       muteBackgroundMusic: onMuteSpy,
       unmuteBackgroundMusic: onUnmuteSpy,
     });
-    wrapper.find('.uitest-mute-music-button').simulate('click');
-    server.respond();
+    await act(async () => {
+      wrapper.find('.uitest-mute-music-button').simulate('click');
+    });
+    await act(async () => {
+      server.respond();
+    });
+    wrapper.update();
     expect(onMuteSpy).to.have.been.calledOnce;
-    wrapper.find('.uitest-mute-music-button').simulate('click');
+    await act(async () => {
+      wrapper.find('.uitest-mute-music-button').simulate('click');
+    });
+    wrapper.update();
     expect(onUnmuteSpy).to.have.been.calledOnce;
   });
 

--- a/apps/test/unit/templates/instructions/HeightResizerTest.jsx
+++ b/apps/test/unit/templates/instructions/HeightResizerTest.jsx
@@ -1,10 +1,11 @@
 import {mount} from 'enzyme'; // eslint-disable-line no-restricted-imports
 import React from 'react';
+import {act} from 'react-dom/test-utils';
 
 import HeightResizer from '@cdo/apps/templates/instructions/HeightResizer';
 
 describe('HeightResizer', () => {
-  it('handles a drag event', () => {
+  it('handles a drag event', async () => {
     const resizeItemTopCallback = jest.fn().mockReturnValue(5);
     const onResizeCallback = jest.fn();
     const wrapper = mount(
@@ -21,7 +22,10 @@ describe('HeightResizer', () => {
       pageY: 20,
       cancelable: true,
     });
-    wrapper.instance().onMouseDown(mouseDownEvent);
+    await act(async () => {
+      wrapper.instance().onMouseDown(mouseDownEvent);
+    });
+    wrapper.update();
 
     expect(resizeItemTopCallback).toHaveBeenCalledTimes(1);
     expect(onResizeCallback).not.toHaveBeenCalled();
@@ -33,7 +37,10 @@ describe('HeightResizer', () => {
       pageY: 30,
       cancelable: true,
     });
-    wrapper.instance().onMouseMove(mouseMoveEvent);
+    await act(async () => {
+      wrapper.instance().onMouseMove(mouseMoveEvent);
+    });
+    wrapper.update();
 
     expect(resizeItemTopCallback).toHaveBeenCalledTimes(2);
     expect(onResizeCallback).toHaveBeenCalledWith(10);
@@ -46,7 +53,10 @@ describe('HeightResizer', () => {
       pageY: 40,
       cancelable: true,
     });
-    wrapper.instance().onMouseUp(mouseUpEvent);
+    await act(async () => {
+      wrapper.instance().onMouseUp(mouseUpEvent);
+    });
+    wrapper.update();
 
     expect(resizeItemTopCallback).toHaveBeenCalledTimes(2);
     expect(onResizeCallback).toHaveBeenCalledTimes(1);

--- a/apps/test/unit/templates/manageStudents/MoveStudentsTest.js
+++ b/apps/test/unit/templates/manageStudents/MoveStudentsTest.js
@@ -1,5 +1,6 @@
 import {mount} from 'enzyme'; // eslint-disable-line no-restricted-imports
 import React from 'react';
+import {act} from 'react-dom/test-utils';
 
 import {
   blankStudentTransfer,
@@ -51,7 +52,7 @@ describe('MoveStudents', () => {
     expect(dropdownOptions[1].name).toBe('Other teacher');
   });
 
-  it('renders additional inputs if other teacher is selected', () => {
+  it('renders additional inputs if other teacher is selected', async () => {
     const transferData = {
       ...blankStudentTransfer,
       otherTeacher: true,
@@ -60,7 +61,9 @@ describe('MoveStudents', () => {
       <MoveStudents {...DEFAULT_PROPS} transferData={transferData} />
     );
 
-    wrapper.instance().openDialog();
+    await act(async () => {
+      wrapper.instance().openDialog();
+    });
     wrapper.update();
     expect(wrapper.find('#uitest-other-teacher').exists()).toBe(true);
   });

--- a/apps/test/unit/templates/teacherDashboard/RosterDialogTest.js
+++ b/apps/test/unit/templates/teacherDashboard/RosterDialogTest.js
@@ -1,5 +1,6 @@
 import {shallow, mount} from 'enzyme'; // eslint-disable-line no-restricted-imports
 import React from 'react';
+import {act} from 'react-dom/test-utils';
 import sinon from 'sinon'; // eslint-disable-line no-restricted-imports
 
 import {OAuthSectionTypes} from '@cdo/apps/accounts/constants';
@@ -86,7 +87,7 @@ describe('RosterDialog', () => {
     expect(wrapper.text()).not.contains('ARCHIVED');
   });
 
-  it('sends section set up completed analytics event when import is called', () => {
+  it('sends section set up completed analytics event when import is called', async () => {
     const rosterDialog = mount(
       <RosterDialog
         handleImport={() => {}}
@@ -99,8 +100,13 @@ describe('RosterDialog', () => {
     );
     const analyticsSpy = sinon.spy(analyticsReporter, 'sendEvent');
 
-    rosterDialog.instance().setState({selectedId: '2'});
-    rosterDialog.instance().importClassroom();
+    await act(async () => {
+      rosterDialog.instance().setState({selectedId: '2'});
+    });
+    rosterDialog.update();
+    await act(async () => {
+      rosterDialog.instance().importClassroom();
+    });
     assert(analyticsSpy.calledOnce);
     assert.equal(analyticsSpy.getCall(0).firstArg, 'Section Setup Completed');
     assert.deepEqual(


### PR DESCRIPTION
These are some test suites that were failing on React 18. Because only a single test was failing in each, I decided to make more minimal fixes rather than pursuing full conversions to React Testing Library.

## Testing story

Unit tests passing.