### PR TITLE
Lab2: fetch lesson level properties by lesson ID

### DIFF
--- a/apps/src/lab2/hooks/useLoadLevelProperties.ts
+++ b/apps/src/lab2/hooks/useLoadLevelProperties.ts
@@ -1,11 +1,17 @@
 import {useEffect, useState} from 'react';
 
+import DCDO from '@cdo/apps/dcdo';
 import HttpClient from '@cdo/apps/util/HttpClient';
 import {useAppDispatch, useAppSelector} from '@cdo/apps/util/reduxHooks';
 
 import {setPageError} from '../lab2Redux';
 import {LevelPropertiesMapValidator} from '../responseValidators';
 import {LevelPropertiesMap} from '../types';
+
+const useLessonIdPath = DCDO.get(
+  'lab2-fetch-level-properties-by-lesson-id',
+  true
+);
 
 async function loadLevelProperties(path: string) {
   const response = await HttpClient.fetchJson<LevelPropertiesMap>(
@@ -30,7 +36,9 @@ export default function useLoadLevelProperties() {
       lesson => lesson.id === currentLessonId
     )?.position;
     if (scriptName && lessonPosition) {
-      return `/s/${scriptName}/lessons/${lessonPosition}/level_properties`;
+      return useLessonIdPath
+        ? `/lessons/${currentLessonId}/level_properties`
+        : `/s/${scriptName}/lessons/${lessonPosition}/level_properties`;
     }
     if (currentLevelId) {
       return `/levels/${currentLevelId}/level_properties`;

--- a/dashboard/app/controllers/lessons_controller.rb
+++ b/dashboard/app/controllers/lessons_controller.rb
@@ -1,7 +1,9 @@
 class LessonsController < ApplicationController
   load_and_authorize_resource
 
-  before_action :require_levelbuilder_mode_or_test_env, except: [:show, :student_lesson_plan, :level_properties]
+  skip_authorize_resource only: :level_properties_by_id
+
+  before_action :require_levelbuilder_mode_or_test_env, except: [:show, :student_lesson_plan, :level_properties, :level_properties_by_id]
   before_action :disallow_legacy_script_levels, only: [:edit, :update]
   before_action :disable_session_for_cached_pages, only: [:show]
   before_action :redirect_to_canonical_path, only: [:show, :student_lesson_plan]
@@ -201,6 +203,15 @@ class LessonsController < ApplicationController
     end
     raise ActiveRecord::RecordNotFound unless @lesson
 
+    render json: @lesson.summarize_for_lab2_properties(@current_user, unit_group_unit: unit_group_unit)
+  end
+
+  # GET /lessons/:id/level_properties
+  def level_properties_by_id
+    unit_context = Queries::Courses.get_course_context(@lesson.script_id)
+    # TODO: unit_group_unit is only used here for a couple user-specific properties in level.rb,
+    # which should be moved to a different user-specific API, after which we can remove this parameter.
+    unit_group_unit = unit_context[:unit_group_unit]
     render json: @lesson.summarize_for_lab2_properties(@current_user, unit_group_unit: unit_group_unit)
   end
 

--- a/dashboard/app/models/ability.rb
+++ b/dashboard/app/models/ability.rb
@@ -350,7 +350,7 @@ class Ability
       end
     end
 
-    can [:read, :show_by_id, :student_lesson_plan, :level_properties], Lesson do |lesson, context_unit_group|
+    can [:read, :show_by_id, :student_lesson_plan, :level_properties, :level_properties_by_id], Lesson do |lesson, context_unit_group|
       script = lesson.script
       unit_group = context_unit_group || script.original_unit_group
       can?(:read, script, unit_group)

--- a/dashboard/config/routes.rb
+++ b/dashboard/config/routes.rb
@@ -559,6 +559,7 @@ Dashboard::Application.routes.draw do
     resources :lessons, only: [:edit, :update] do
       member do
         get :show, to: 'lessons#show_by_id'
+        get :level_properties, to: 'lessons#level_properties_by_id', format: false
         post :clone
       end
     end

--- a/dashboard/test/controllers/lessons_controller_test.rb
+++ b/dashboard/test/controllers/lessons_controller_test.rb
@@ -247,6 +247,11 @@ class LessonsControllerTest < ActionController::TestCase
                               params: -> {{course_course_name: @course.name, unit_position: 1, lesson_position: @lesson2.relative_position}},
                               name: 'anyone can fetch lesson level properties on a lesson without a lesson plan'
 
+  # anyone can fetch lesson level properties by ID
+  test_user_gets_response_for :level_properties_by_id, params: -> {{id: @lesson.id}}, user: nil, response: :success
+
+  test_user_gets_response_for :level_properties_by_id, user: nil, response: :success, params: -> {{id: @lesson2.id}}, name: 'anyone can fetch lesson level properties by ID on a lesson without a lesson plan'
+
   test 'show includes correct SEO data' do
     get :show, params: {
       course_course_name: @course.name,

--- a/lib/dynamic_config/dcdo.rb
+++ b/lib/dynamic_config/dcdo.rb
@@ -72,7 +72,8 @@ class DCDOBase < DynamicConfigBase
       'hoai2025-share-enabled': DCDO.get('hoai2025-share-enabled', true),
       'ai-lesson-summaries-notifications-enabled': DCDO.get('ai-lesson-summaries-notifications-enabled', false),
       # TODO: Remove this after the ClassLink LMS launch
-      classlink_lms_enabled: DCDO.get('classlink_lms_enabled', false)
+      classlink_lms_enabled: DCDO.get('classlink_lms_enabled', false),
+      'lab2-fetch-level-properties-by-lesson-id': DCDO.get('lab2-fetch-level-properties-by-lesson-id', true)
     }
   end
 end


### PR DESCRIPTION
Follow-up to https://github.com/code-dot-org/code-dot-org/pull/70416. We had an issue where the `level_properties` API for a lesson would sometimes return the wrong lesson's level properties since we were looking up the lesson by relative position, and there were certain cases where two lessons in the same unit would share the same relative position. As a quick fix, the previous PR switched to using absolute position for the lookup. This fix adds a new API to look up the level properties by lesson ID directly, rather than position, to remove any position-related ambiguity. I also included a DCDO flag just in case we need a quick revert as we've had a few incidents related to this API already.

## Testing story
Tested this across a few lab2 scripts, including all the scripts that we previously had issues on.