### PR TITLE
Add error handling for old dates being returned by the OpenWeather API

### DIFF
--- a/bin/cron/applab_datasets/daily_weather
+++ b/bin/cron/applab_datasets/daily_weather
@@ -206,7 +206,18 @@ def main
     puts "No data returned from OpenWeather API. No records will be written to datablock storage."
     Honeybadger.notify_cronjob_error(
       error_message: "No data returned from OpenWeather API. No records will be written to datablock storage."
-      )
+    )
+    return
+  end
+
+  # For some reason, we're getting dates from the API in August 2025 sometimes.
+  # Better to fail and have slightly stale data than overwrite with obviously wrong data.
+  days_old = (Time.now.to_i - records.first[:'UTC Timestamp']) / (24 * 60 * 60)
+  if days_old > 30
+    puts "Data returned from OpenWeather API is #{days_old} days old. No records will be written to datablock storage."
+    Honeybadger.notify_cronjob_error(
+      error_message: "Data returned from OpenWeather API is #{days_old} days old. No records will be written to datablock storage."
+    )
     return
   end
 

--- a/bin/cron/applab_datasets/daily_weather
+++ b/bin/cron/applab_datasets/daily_weather
@@ -6,6 +6,7 @@ abort 'Script already running' unless only_one_running?(__FILE__)
 # This script fetches weather forecast data from api.openweathermap and uploads to the shared datablock storage table.
 require_relative '../../../dashboard/config/environment'
 require_relative '../../../deployment'
+require 'cdo/chat_client'
 require 'net/http'
 require 'json'
 require 'ostruct'
@@ -213,10 +214,11 @@ def main
   # For some reason, we're getting dates from the API in August 2025 sometimes.
   # Better to fail and have slightly stale data than overwrite with obviously wrong data.
   days_old = (Time.now.to_i - records.first[:'UTC Timestamp']) / (24 * 60 * 60)
-  if days_old > 30
-    puts "Data returned from OpenWeather API is #{days_old} days old. No records will be written to datablock storage."
-    Honeybadger.notify_cronjob_error(
-      error_message: "Data returned from OpenWeather API is #{days_old} days old. No records will be written to datablock storage."
+  if days_old > (NUM_DAYS+2)
+    ChatClient.message(
+      'cron-daily',
+      "Daily Weather dataset not updated because data returned from the OpenWeather API is #{days_old} days old from #{records.first[:Date]}.",
+      color: 'yellow'
     )
     return
   end


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

We've had a few instances of the daily weather table in app lab datasets reverting to a set of dates in August last year for a day which disrupts classrooms working on the Random Forecaster App in AP CSP.  This PR updates the cron job to avoid overwriting the current daily weather table with old data returned from the OpenWeather API.

## Links
<!--  Links to relevant external resources.
      - spec docs, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- [Jira](https://codedotorg.atlassian.net/browse/SL-1543?atlOrigin=eyJpIjoiNDEyYTVjZDMzYWYyNDg3OGE5ZjM5Y2Y2MDNhOTM0ODIiLCJwIjoiamlyYS1zbGFjay1pbnQifQ)
- [Slack Thread](https://codedotorg.slack.com/archives/C03DBDN67B7/p1769468041396029)

## Testing story
<!--  Does your change include appropriate tests?
      - If so, please describe how the tests included in this PR are sufficient.
      - If not, please explain why this change does not need to be tested. -->

Grabbed the OpenWeather API key and tested the script locally.

## Deployment strategy
<!--  Any special steps required to deploy this, besides merging?
      - Are there database migrations or manual steps?
      - Does this require coordination with other teams or systems? -->



## Follow-up work
<!--  List any clean-up or technical debt that will be addressed in future work.
      - Include Jira links where applicable.
      - Are there any known limitations or improvements planned? -->

Monitor the #cron-daily channel on slack to see how often this is happening. If it's happening a lot, and for days in a row, maybe we should consider putting more effort into a better fix.
