### PR TITLE
Add honeybadger ID to sync course cloudwatch log

### DIFF
--- a/dashboard/app/controllers/lti_v1_controller.rb
+++ b/dashboard/app/controllers/lti_v1_controller.rb
@@ -256,16 +256,17 @@ class LtiV1Controller < ApplicationController
     honeybadger_id = Honeybadger.notify(
       'LTI roster sync error',
       context: {
-        reason: reason,
+        reason:,
         details: message,
       }
     )
     Clients::LtiLogger.log_event(
       message,
       {
-        reason: reason,
-        status: status,
-        error: error,
+        reason:,
+        status:,
+        error:,
+        honeybadger_id:,
       }
     )
     @lti_section_sync_result = {error: error, message: message}


### PR DESCRIPTION
The Honeybadger client seems to generate an ID for a notification even when we've hit our monthly quota and the error isn't logged. I noticed this while working a Zendesk ticket, where a teacher hit an error during LTI sync, and reported the error with a Honeybadger ID from the error popup, but the error was throttled and didn't show up in Honeybadger. By adding this ID to the Cloudwatch log, we can look it up in Cloudwatch even when it never makes it to Honeybadger.

This PR also cleans up the call by using shorthand to reference the variables.

## Links
<!--  Links to relevant external resources.
      - spec docs, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- Jira: 

## Testing story
<!--  Does your change include appropriate tests?
      - If so, please describe how the tests included in this PR are sufficient.
      - If not, please explain why this change does not need to be tested. -->



## Deployment strategy
<!--  Any special steps required to deploy this, besides merging?
      - Are there database migrations or manual steps?
      - Does this require coordination with other teams or systems? -->



## Follow-up work
<!--  List any clean-up or technical debt that will be addressed in future work.
      - Include Jira links where applicable.
      - Are there any known limitations or improvements planned? -->



## Privacy
<!--  How does this change impact Student & Teacher privacy?
      - Does this collect, use, share, or modify PII, either new or existing? -->



## Security
<!--  How does this change impact our security surface-area?
      - Do API's touched have the right auth?
      - Do infra changes impact our attack surface or encryption?
-->



## Caching
<!--  How does this change impact caching behavior?
      - Are cache keys or invalidation strategies affected?
      - Will this require cache warming or invalidation after deployment? -->



## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
