### PR TITLE
fix: revert css classname merge conflict

### DIFF
--- a/apps/webpack.config.js
+++ b/apps/webpack.config.js
@@ -280,10 +280,7 @@ const WEBPACK_BASE_CONFIG = {
             loader: 'css-loader',
             options: {
               modules: {
-                auto: resourcePath => {
-                  // Do not treat CSS files in node_modules as CSS modules
-                  return !/node_modules/.test(resourcePath);
-                },
+                auto: true,
                 localIdentName: process.env.DEV
                   ? '[path][name]__[local]'
                   : '[hash:base64]',


### PR DESCRIPTION
#70003 had a merge conflict but was not fixed the correct way. It reintroduced a bug that was fixed in a later iteration of #69987 but was present in an earlier iteration of #69987. #70003 was based on the earlier iteration.

This PR reverts to the previous behavior, consistent with the fixed version of #69987 .