### PR TITLE
Codebridge: fix add file to folder by providing file types whenever creating file

### DIFF
--- a/apps/src/codebridge/FileBrowser/FileBrowserHeaderPopUpButton.tsx
+++ b/apps/src/codebridge/FileBrowser/FileBrowserHeaderPopUpButton.tsx
@@ -18,15 +18,11 @@ import {
 export const FileBrowserHeaderPopUpButton = () => {
   const {openNewFilePrompt, openNewFolderPrompt} = usePrompts();
   const {
-    config: {validMimeTypes, supportedFileTypes, editableFileTypes},
+    config: {validMimeTypes, supportedFileTypes},
     levelProperties,
   } = useCodebridgeContext();
   const {appName} = levelProperties;
   const isBlockedAbuse = useAppSelector(state => state.lab.isBlockedAbuse);
-  const openNewFilePromptArgs = {
-    folderId: DEFAULT_FOLDER_ID,
-    validFileTypes: editableFileTypes,
-  };
   const files = useAppSelector(
     state => (state.lab2Project.projectSources?.source as MultiFileSource).files
   );
@@ -65,7 +61,7 @@ export const FileBrowserHeaderPopUpButton = () => {
         <PopUpButtonOption
           iconName="plus"
           labelText={codebridgeI18n.newFile()}
-          clickHandler={() => openNewFilePrompt(openNewFilePromptArgs)}
+          clickHandler={() => openNewFilePrompt({folderId: DEFAULT_FOLDER_ID})}
           id="uitest-new-file"
         />
         <PopUpButtonOption

--- a/apps/src/codebridge/FileBrowser/hooks/usePrompts.ts
+++ b/apps/src/codebridge/FileBrowser/hooks/usePrompts.ts
@@ -44,7 +44,7 @@ import {useAppDispatch, useAppSelector} from '@cdo/apps/util/reduxHooks';
  *   - **openSaveToBackpackPrompt:** Opens a prompt for saving a file to the user's backpack.
  */
 export const usePrompts = () => {
-  const {levelProperties} = useCodebridgeContext();
+  const {levelProperties, config} = useCodebridgeContext();
   const {validationFile} = levelProperties;
   const isStartMode = getAppOptionsEditBlocks() === START_SOURCES;
   const dialogControl = useDialogControl();
@@ -127,6 +127,7 @@ export const usePrompts = () => {
     sendLab2AnalyticsEvent,
     isStartMode,
     validationFile,
+    validFileTypes: config.editableFileTypes,
   } satisfies PAFunctionArgs<typeof globalOpenNewFilePrompt>);
 
   const openMoveFilePrompt = usePartialApply(globalOpenMoveFilePrompt, {


### PR DESCRIPTION
Updates our new file dialog to always have the available list of file types for the lab. This fixes a bug where you couldn't create a file within a folder because the list of file types wasn't available.

## Links

- Jira: https://codedotorg.atlassian.net/browse/AFL-450
- Slack discussion: https://codedotorg.slack.com/archives/C09EHQE4DGD/p1769638189334019

## Testing story

I tested manually in both Web Lab 2 and Python Lab that I could create files both from the top-level directory and within a folder. I also checked that the appropriate list of file extensions appeared in each lab.