### PR TITLE
Migration for adding student and lesson index

### DIFF
--- a/dashboard/app/models/lesson_feedback.rb
+++ b/dashboard/app/models/lesson_feedback.rb
@@ -14,5 +14,11 @@
 #  created_at         :datetime         not null
 #  updated_at         :datetime         not null
 #
+# Indexes
+#
+#  index_lesson_feedbacks_on_lesson_student  (lesson_id,student_id) UNIQUE
+#
 class LessonFeedback < ApplicationRecord
+  validates :lesson_id, :student_id, :teacher_id, presence: true
+  validates :lesson_id, uniqueness: {scope: :student_id}
 end

--- a/dashboard/db/migrate/20260128232147_add_unique_index_to_lesson_feedbacks.rb
+++ b/dashboard/db/migrate/20260128232147_add_unique_index_to_lesson_feedbacks.rb
@@ -1,0 +1,8 @@
+class AddUniqueIndexToLessonFeedbacks < ActiveRecord::Migration[6.1]
+  def change
+    add_index :lesson_feedbacks,
+      [:lesson_id, :student_id],
+      unique: true,
+      name: "index_lesson_feedbacks_on_lesson_student"
+  end
+end

--- a/dashboard/db/schema.rb
+++ b/dashboard/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2026_01_20_193121) do
+ActiveRecord::Schema.define(version: 2026_01_28_232147) do
 
   create_table "activities", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "user_id"
@@ -927,6 +927,7 @@ ActiveRecord::Schema.define(version: 2026_01_20_193121) do
     t.json "resources"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.index ["lesson_id", "student_id"], name: "index_lesson_feedbacks_on_lesson_student", unique: true
   end
 
   create_table "lesson_groups", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|


### PR DESCRIPTION
We want the table for the student/lesson pair to be updated every time:

- The student hits submit on a level
- A teacher saves or sends feedback to a student

This will allow us to find and then update the previous record for a student / lesson. 

