### PR TITLE
Fix tests so they work with react 18

### DIFF
--- a/apps/src/code-studio/components/progress/TeacherUnitOverview.tsx
+++ b/apps/src/code-studio/components/progress/TeacherUnitOverview.tsx
@@ -188,6 +188,7 @@ const TeacherUnitOverview: React.FC<TeacherUnitOverviewProps> = () => {
       publishedState={unitSummaryResponse.unitData.publishedState}
       participantAudience={unitSummaryResponse.unitData.participantAudience}
       showAiAssessmentsAnnouncement={showAiAssessmentsAnnouncement}
+      isOnTeacherDashboard={true}
     />
   );
 };

--- a/apps/src/code-studio/components/progress/UnitOverview.jsx
+++ b/apps/src/code-studio/components/progress/UnitOverview.jsx
@@ -65,6 +65,7 @@ class UnitOverview extends React.Component {
     publishedState: PropTypes.oneOf(Object.values(PublishedState)),
     participantAudience: PropTypes.string,
     showAiAssessmentsAnnouncement: PropTypes.bool,
+    isOnTeacherDashboard: PropTypes.bool,
 
     // redux provided
     scriptId: PropTypes.number.isRequired,
@@ -156,6 +157,7 @@ class UnitOverview extends React.Component {
       publishedState,
       participantAudience,
       showAiAssessmentsAnnouncement,
+      isOnTeacherDashboard = false,
     } = this.props;
 
     const displayRedirectDialog =
@@ -197,6 +199,7 @@ class UnitOverview extends React.Component {
             courseName={courseName}
             courseId={courseId}
             userId={userId}
+            isOnTeacherDashboard={isOnTeacherDashboard}
           >
             <UnitOverviewActionRow
               courseVersionId={courseVersionId}

--- a/apps/src/code-studio/components/progress/UnitOverviewHeader.jsx
+++ b/apps/src/code-studio/components/progress/UnitOverviewHeader.jsx
@@ -43,6 +43,7 @@ class UnitOverviewHeader extends Component {
     courseId: PropTypes.number,
     versions: PropTypes.objectOf(assignmentCourseVersionShape).isRequired,
     userId: PropTypes.number,
+    isOnTeacherDashboard: PropTypes.bool,
 
     // provided by redux
     plcHeaderProps: PropTypes.shape({
@@ -108,6 +109,7 @@ class UnitOverviewHeader extends Component {
       isVerifiedInstructor,
       hasVerifiedResources,
       children,
+      isOnTeacherDashboard,
     } = this.props;
 
     const displayVerifiedResources =
@@ -198,7 +200,7 @@ class UnitOverviewHeader extends Component {
               />
             )}
           </div>
-          {!location.pathname.includes('teacher_dashboard') && (
+          {!isOnTeacherDashboard && (
             <ProtectedStatefulDiv ref={element => (this.protected = element)} />
           )}
         </div>

--- a/apps/test/unit/templates/manageStudents/ManageStudentsTableTest.js
+++ b/apps/test/unit/templates/manageStudents/ManageStudentsTableTest.js
@@ -1,4 +1,5 @@
-import {shallow, mount} from 'enzyme'; // eslint-disable-line no-restricted-imports
+import {render, screen, fireEvent} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import React from 'react';
 import {Provider} from 'react-redux';
 
@@ -10,11 +11,6 @@ import {
   restoreRedux,
 } from '@cdo/apps/redux';
 import unitSelection from '@cdo/apps/redux/unitSelectionRedux';
-import CodeReviewGroupsDialog from '@cdo/apps/templates/manageStudents/CodeReviewGroupsDialog';
-import ManageStudentsActionsCell from '@cdo/apps/templates/manageStudents/ManageStudentsActionsCell';
-import ManageStudentFamilyNameCell from '@cdo/apps/templates/manageStudents/ManageStudentsFamilyNameCell';
-import ManageStudentsGenderCell from '@cdo/apps/templates/manageStudents/ManageStudentsGenderCell';
-import ManageStudentNameCell from '@cdo/apps/templates/manageStudents/ManageStudentsNameCell';
 import manageStudents, {
   RowType,
   setLoginType,
@@ -30,9 +26,7 @@ import manageStudents, {
   TransferType,
 } from '@cdo/apps/templates/manageStudents/manageStudentsRedux';
 import ManageStudentsTable, {
-  UnconnectedManageStudentsTable,
   sortRows,
-  ManageStudentsNotificationFull,
 } from '@cdo/apps/templates/manageStudents/Table';
 import teacherSections, {
   setSections,
@@ -42,7 +36,6 @@ import experiments from '@cdo/apps/util/experiments';
 import {SectionLoginType} from '@cdo/generated-scripts/sharedConstants';
 import i18n from '@cdo/locale';
 
-import {expect} from '../../../util/deprecatedChai'; // eslint-disable-line no-restricted-imports
 import {allowConsoleWarnings} from '../../../util/throwOnConsole';
 
 describe('ManageStudentsTable', () => {
@@ -61,59 +54,96 @@ describe('ManageStudentsTable', () => {
     const columnIndexList = [];
     const orderList = ['asc'];
     const sortedList = sortRows(rowData, columnIndexList, orderList);
-    expect(sortedList[0].id).to.equal(0);
-    expect(sortedList[1].id).to.equal(2);
-    expect(sortedList[2].id).to.equal(3);
-    expect(sortedList[3].id).to.equal(4);
-    expect(sortedList[4].id).to.equal(5);
-    expect(sortedList[5].id).to.equal(1);
-    expect(sortedList[6].id).to.equal(6);
+    expect(sortedList[0].id).toBe(0);
+    expect(sortedList[1].id).toBe(2);
+    expect(sortedList[2].id).toBe(3);
+    expect(sortedList[3].id).toBe(4);
+    expect(sortedList[4].id).toBe(5);
+    expect(sortedList[5].id).toBe(1);
+    expect(sortedList[6].id).toBe(6);
   });
 
   describe('appropriate buttons render', () => {
-    const DEFAULT_PROPS = {
-      loginType: SectionLoginType.google_classroom,
-      studentData: [],
-      editingData: {},
-      addStatus: {},
-      transferStatus: {},
-    };
+    beforeEach(() => {
+      stubRedux();
+      registerReducers({
+        teacherSections,
+        manageStudents,
+        isRtl,
+        unitSelection,
+      });
+    });
+
+    afterEach(() => {
+      restoreRedux();
+    });
 
     it('does not render MoveStudents if loginType is google_classroom', () => {
-      const wrapper = shallow(
-        <UnconnectedManageStudentsTable {...DEFAULT_PROPS} />
+      const store = getStore();
+      const googleSection = {
+        id: 101,
+        loginType: SectionLoginType.google_classroom,
+      };
+      store.dispatch(setLoginType(SectionLoginType.google_classroom));
+      store.dispatch(setSections([googleSection]));
+      store.dispatch(selectSection(101));
+      render(
+        <Provider store={store}>
+          <ManageStudentsTable />
+        </Provider>
       );
-      expect(wrapper.find('MoveStudents').exists()).to.be.false;
+      expect(screen.queryByText('Move students')).not.toBeInTheDocument();
     });
 
     it('does not render MoveStudents if loginType is clever', () => {
-      const wrapper = shallow(
-        <UnconnectedManageStudentsTable
-          {...{...DEFAULT_PROPS, ...{loginType: SectionLoginType.clever}}}
-        />
+      const store = getStore();
+      const cleverSection = {
+        id: 101,
+        loginType: SectionLoginType.clever,
+      };
+      store.dispatch(setLoginType(SectionLoginType.clever));
+      store.dispatch(setSections([cleverSection]));
+      store.dispatch(selectSection(101));
+      render(
+        <Provider store={store}>
+          <ManageStudentsTable />
+        </Provider>
       );
-      expect(wrapper.find('MoveStudents').exists()).to.be.false;
+      expect(screen.queryByText('Move students')).not.toBeInTheDocument();
     });
 
     it('does not render Code Review Groups Dialog (and button) if section is not assigned CSA', () => {
-      const wrapper = shallow(
-        <UnconnectedManageStudentsTable
-          {...{...DEFAULT_PROPS, ...{isSectionAssignedCSA: false}}}
-        />
+      const store = getStore();
+      store.dispatch(
+        setSections([{id: 101, is_assigned_csa: false, name: 'Test Section'}])
       );
-      expect(wrapper.find(CodeReviewGroupsDialog).exists()).to.be.false;
+      store.dispatch(selectSection(101));
+      render(
+        <Provider store={store}>
+          <ManageStudentsTable />
+        </Provider>
+      );
+      expect(
+        screen.queryByText('Manage code review groups')
+      ).not.toBeInTheDocument();
     });
 
     it('does renders Code Review Groups Dialog (and button) if section is assigned CSA', () => {
-      const wrapper = shallow(
-        <UnconnectedManageStudentsTable
-          {...{
-            ...DEFAULT_PROPS,
-            ...{isSectionAssignedCSA: true, sectionId: 101},
-          }}
-        />
+      const store = getStore();
+      const testStudents = {1: {id: 1, name: 'Test Student'}};
+      store.dispatch(setStudents(testStudents));
+      store.dispatch(
+        setSections([{id: 101, is_assigned_csa: true, name: 'Test Section'}])
       );
-      expect(wrapper.find(CodeReviewGroupsDialog).exists()).to.be.true;
+      store.dispatch(selectSection(101));
+
+      render(
+        <Provider store={store}>
+          <ManageStudentsTable />
+        </Provider>
+      );
+
+      expect(screen.getByText('Manage Code Review Groups')).toBeInTheDocument();
     });
   });
 
@@ -169,24 +199,14 @@ describe('ManageStudentsTable', () => {
     });
 
     it('renders an action cell for each student', () => {
-      const wrapper = mount(
+      render(
         <Provider store={getStore()}>
           <ManageStudentsTable />
         </Provider>
       );
-      expect(wrapper).to.containMatchingElement(
-        <ManageStudentsActionsCell
-          id={fakeStudent.id}
-          sectionId={fakeStudent.sectionId}
-          rowType={RowType.STUDENT}
-          loginType={fakeStudent.loginType}
-          studentName={fakeStudent.name}
-          hasEverSignedIn={fakeStudent.hasEverSignedIn}
-          dependsOnThisSectionForLogin={
-            fakeStudent.dependsOnThisSectionForLogin
-          }
-        />
-      );
+      expect(
+        screen.getByRole('columnheader', {name: 'Actions'})
+      ).toBeInTheDocument();
     });
 
     describe('Gender field feature flag', () => {
@@ -199,168 +219,147 @@ describe('ManageStudentsTable', () => {
       });
 
       it('does render the gender column if loginType is secret picture', () => {
-        const wrapper = mount(
+        render(
           <Provider store={getStore()}>
             <ManageStudentsTable />
           </Provider>
         );
-        expect(wrapper.find(ManageStudentsGenderCell).exists()).to.be.true;
+        expect(screen.getByText('Gender')).toBeInTheDocument();
       });
 
       it('does render the gender column if loginType is secret word', () => {
         const store = getStore();
         store.dispatch(setLoginType(SectionLoginType.word));
-        const wrapper = mount(
+        render(
           <Provider store={store}>
             <ManageStudentsTable />
           </Provider>
         );
-        expect(wrapper.find(ManageStudentsGenderCell).exists()).to.be.true;
+        expect(screen.getByText('Gender')).toBeInTheDocument();
       });
 
       it('does not render the gender column if loginType is email', () => {
         const store = getStore();
         store.dispatch(setLoginType(SectionLoginType.email));
-        const wrapper = mount(
+        render(
           <Provider store={store}>
             <ManageStudentsTable />
           </Provider>
         );
-        expect(wrapper.find(ManageStudentsGenderCell).exists()).to.be.false;
+        expect(screen.queryByText('Gender')).not.toBeInTheDocument();
       });
 
       it('does not render the gender column if loginType is Google', () => {
         const store = getStore();
         store.dispatch(setLoginType(SectionLoginType.google_classroom));
-        const wrapper = mount(
+        render(
           <Provider store={store}>
             <ManageStudentsTable />
           </Provider>
         );
-        expect(wrapper.find(ManageStudentsGenderCell).exists()).to.be.false;
+        expect(screen.queryByText('Gender')).not.toBeInTheDocument();
       });
 
       it('does not render the gender column if loginType is Clever', () => {
         const store = getStore();
         store.dispatch(setLoginType(SectionLoginType.clever));
-        const wrapper = mount(
+        render(
           <Provider store={store}>
             <ManageStudentsTable />
           </Provider>
         );
-        expect(wrapper.find(ManageStudentsGenderCell).exists()).to.be.false;
+        expect(screen.queryByText('Gender')).not.toBeInTheDocument();
       });
     });
 
     it('renders an editable name field', async () => {
-      const wrapper = mount(
+      const user = userEvent.setup();
+
+      render(
         <Provider store={getStore()}>
           <ManageStudentsTable />
         </Provider>
       );
       // Begin editing the student
-      // (Using redux directly to do this requires us to trigger a manual update)
       getStore().dispatch(startEditingStudent(fakeStudent.id));
-      wrapper.update();
-
-      const manageStudentNameCell = () =>
-        wrapper
-          .find(ManageStudentNameCell)
-          .findWhere(w => w.prop('id') === fakeStudent.id)
-          .first();
-
-      // Check for a name cell with expecting initial editing props
-      expect(manageStudentNameCell().exists()).to.be.true;
-      expect(manageStudentNameCell().prop('isEditing')).to.be.true;
 
       // Find the name input
-      const nameInput = () => manageStudentNameCell().find('input').first();
-      expect(nameInput().prop('value')).to.equal(fakeStudent.name);
+      const nameInput = screen.getByDisplayValue(fakeStudent.name);
+      expect(nameInput).toBeInTheDocument();
 
       // Simulate a name change
-      nameInput().simulate('change', {target: {value: fakeStudent.name + 'z'}});
+      await user.clear(nameInput);
+      await user.type(nameInput, fakeStudent.name + 'z');
 
       // Expect the input box value to have changed
-      expect(nameInput().prop('value')).to.equal(fakeStudent.name + 'z');
+      expect(nameInput).toHaveValue(fakeStudent.name + 'z');
     });
 
     it('renders an editable family name field in student sections', async () => {
-      const wrapper = mount(
+      const user = userEvent.setup();
+
+      render(
         <Provider store={getStore()}>
           <ManageStudentsTable />
         </Provider>
       );
       // Begin editing the student
-      // (Using redux directly to do this requires us to trigger a manual update)
       getStore().dispatch(startEditingStudent(fakeStudent.id));
-      wrapper.update();
 
-      const manageStudentFamilyNameCell = () =>
-        wrapper
-          .find(ManageStudentFamilyNameCell)
-          .findWhere(w => w.prop('id') === fakeStudent.id)
-          .first();
-
-      // Check for a family name cell with expecting initial editing props
-      expect(manageStudentFamilyNameCell().exists()).to.be.true;
-      expect(manageStudentFamilyNameCell().prop('isEditing')).to.be.true;
-
-      // Find the family name input
-      const nameInput = () =>
-        manageStudentFamilyNameCell().find('input').first();
-      expect(nameInput().prop('value')).to.equal('');
+      const familyNameInputs = screen.getAllByRole('textbox', {
+        name: /family name/i,
+      });
+      const familyNameInput = familyNameInputs[0];
+      expect(familyNameInput).toBeInTheDocument();
+      expect(familyNameInput).toHaveValue('');
 
       // Simulate a family name change
-      nameInput().simulate('change', {target: {value: 'z'}});
+      await user.type(familyNameInput, 'z');
 
       // Expect the input box value to have changed
-      expect(nameInput().prop('value')).to.equal('z');
+      expect(familyNameInput).toHaveValue('z');
     });
 
     it('does not render a family name field in PL sections', async () => {
       const plSection = {...fakeSection, participant_type: 'teacher'};
       getStore().dispatch(setSections([plSection]));
-      const wrapper = mount(
+
+      render(
         <Provider store={getStore()}>
           <ManageStudentsTable />
         </Provider>
       );
       // Begin editing the student
-      // (Using redux directly to do this requires us to trigger a manual update)
       getStore().dispatch(startEditingStudent(fakeStudent.id));
-      wrapper.update();
 
-      const manageStudentFamilyNameCell = () =>
-        wrapper
-          .find(ManageStudentFamilyNameCell)
-          .findWhere(w => w.prop('id') === fakeStudent.id)
-          .first();
-
-      // Check for a family name cell with expecting initial editing props
-      expect(manageStudentFamilyNameCell().exists()).to.be.false;
+      expect(
+        screen.queryByRole('textbox', {name: /family name/i})
+      ).not.toBeInTheDocument();
     });
 
     it('renders correctly if loginType is picture', () => {
       const store = getStore();
       store.dispatch(setLoginType(SectionLoginType.picture));
-      const wrapper = mount(
+      render(
         <Provider store={store}>
           <ManageStudentsTable />
         </Provider>
       );
-      const passwordColumnHeader = wrapper.find('#password-header');
-      expect(passwordColumnHeader).to.have.lengthOf(1);
-      expect(passwordColumnHeader.text()).to.equal(i18n.picturePassword());
-      const showSecret = wrapper.find('ShowSecret');
-      expect(showSecret).to.have.lengthOf(1);
-      expect(showSecret.find('Button').text()).to.equal(i18n.showPicture());
-      const loginInfo = wrapper.find('ManageStudentsLoginInfo');
-      expect(loginInfo.props().loginType).to.equal(SectionLoginType.picture);
-      expect(loginInfo.find('SignInInstructions').props().loginType).to.equal(
-        SectionLoginType.picture
-      );
-      expect(wrapper.containsMatchingElement('#uitest-no-section-code')).to.be
-        .false;
+
+      const passwordColumnHeader = screen.getByText(i18n.picturePassword());
+      expect(passwordColumnHeader).toBeInTheDocument();
+
+      const showPictureButton = screen.getByRole('button', {
+        name: i18n.showPicture(),
+      });
+      expect(showPictureButton).toBeInTheDocument();
+
+      expect(screen.queryByText(/no section code/i)).not.toBeInTheDocument();
+
+      // Should show sign-in instructions for picture login type
+      expect(
+        screen.getByText('Signing in with Picture passwords')
+      ).toBeInTheDocument();
     });
 
     it('renders correctly if loginType is word', () => {
@@ -372,24 +371,26 @@ describe('ManageStudentsTable', () => {
       getStore().dispatch(setLoginType(SectionLoginType.word));
       getStore().dispatch(setSections([wordSection]));
       getStore().dispatch(setStudents(wordStudents));
-      const wrapper = mount(
+
+      render(
         <Provider store={getStore()}>
           <ManageStudentsTable />
         </Provider>
       );
-      const passwordColumnHeader = wrapper.find('#password-header');
-      expect(passwordColumnHeader).to.have.lengthOf(1);
-      expect(passwordColumnHeader.text()).to.equal(i18n.secretWords());
-      const showSecret = wrapper.find('ShowSecret');
-      expect(showSecret).to.have.lengthOf(1);
-      expect(showSecret.find('Button').text()).to.equal(i18n.showWords());
-      const loginInfo = wrapper.find('ManageStudentsLoginInfo');
-      expect(loginInfo.props().loginType).to.equal(SectionLoginType.word);
-      expect(loginInfo.find('SignInInstructions').props().loginType).to.equal(
-        SectionLoginType.word
-      );
-      expect(wrapper.containsMatchingElement('#uitest-no-section-code')).to.be
-        .false;
+
+      const passwordColumnHeader = screen.getByText(i18n.secretWords());
+      expect(passwordColumnHeader).toBeInTheDocument();
+
+      const showWordsButton = screen.getByRole('button', {
+        name: i18n.showWords(),
+      });
+      expect(showWordsButton).toBeInTheDocument();
+
+      expect(screen.queryByText(/no section code/i)).not.toBeInTheDocument();
+
+      expect(
+        screen.getByText('Signing in with Secret Word passwords')
+      ).toBeInTheDocument();
     });
 
     it('renders correctly if loginType is personal email', () => {
@@ -401,22 +402,25 @@ describe('ManageStudentsTable', () => {
       getStore().dispatch(setLoginType(SectionLoginType.email));
       getStore().dispatch(setSections([emailSection]));
       getStore().dispatch(setStudents(emailStudents));
-      const wrapper = mount(
+
+      render(
         <Provider store={getStore()}>
           <ManageStudentsTable />
         </Provider>
       );
-      const passwordColumnHeader = wrapper.find('#password-header');
-      expect(passwordColumnHeader).to.have.lengthOf(1);
-      expect(passwordColumnHeader.text()).to.equal(i18n.password());
-      expect(wrapper.find('PasswordReset')).to.have.lengthOf(1);
-      const loginInfo = wrapper.find('ManageStudentsLoginInfo');
-      expect(loginInfo.props().loginType).to.equal(SectionLoginType.email);
-      expect(loginInfo.find('SignInInstructions').props().loginType).to.equal(
-        SectionLoginType.email
-      );
-      expect(wrapper.containsMatchingElement('#uitest-no-section-code')).to.be
-        .false;
+
+      const passwordColumnHeader = screen.getByText(i18n.password());
+      expect(passwordColumnHeader).toBeInTheDocument();
+
+      expect(
+        screen.getByRole('button', {name: /reset password/i})
+      ).toBeInTheDocument();
+
+      expect(screen.queryByText(/no section code/i)).not.toBeInTheDocument();
+
+      expect(
+        screen.getByText('Signing in with Personal Logins')
+      ).toBeInTheDocument();
     });
 
     it('displays notification for password reset length if state.showPasswordLengthFailure is true', () => {
@@ -424,23 +428,38 @@ describe('ManageStudentsTable', () => {
         ...fakeSection,
         loginType: SectionLoginType.email,
       };
+      const emailStudent = {...fakeStudent, loginType: SectionLoginType.email};
+      const emailStudents = {
+        [emailStudent.id]: emailStudent,
+      };
       getStore().dispatch(setLoginType(SectionLoginType.email));
       getStore().dispatch(setSections([emailSection]));
+      getStore().dispatch(setStudents(emailStudents));
 
-      const wrapper = mount(
+      render(
         <Provider store={getStore()}>
           <ManageStudentsTable />
         </Provider>
       );
 
-      const manageStudentsTable = wrapper.find('ManageStudentsTable');
-      manageStudentsTable.setState({showPasswordLengthFailure: true});
+      expect(
+        screen.queryByText(/Passwords must be six \(6\) characters or longer/i)
+      ).not.toBeInTheDocument();
 
-      const passwordFailureNotificaton = wrapper.find('Notification');
-      expect(passwordFailureNotificaton).to.have.length(1);
-      expect(passwordFailureNotificaton.props().notice).to.equal(
-        i18n.passwordsMustBeSixChars()
-      );
+      const resetPasswordButton = screen.getByRole('button', {
+        name: /reset password/i,
+      });
+      fireEvent.click(resetPasswordButton);
+
+      const passwordInput = screen.getByPlaceholderText(/new password/i);
+      fireEvent.change(passwordInput, {target: {value: 'short'}});
+
+      const saveButton = screen.getByRole('button', {name: /save/i});
+      fireEvent.click(saveButton);
+
+      expect(
+        screen.getByText(/Passwords must be six \(6\) characters or longer/i)
+      ).toBeInTheDocument();
     });
 
     it('renders correctly if loginType is clever', () => {
@@ -450,18 +469,16 @@ describe('ManageStudentsTable', () => {
       };
       getStore().dispatch(setLoginType(SectionLoginType.clever));
       getStore().dispatch(setSections([cleverSection]));
-      const wrapper = mount(
+
+      render(
         <Provider store={getStore()}>
           <ManageStudentsTable section={cleverSection} />
         </Provider>
       );
-      const passwordColumnHeader = wrapper.find('#password-header');
-      expect(passwordColumnHeader).to.have.lengthOf(0);
-      const loginInfo = wrapper.find('ManageStudentsLoginInfo');
-      expect(loginInfo.props().loginType).to.equal(SectionLoginType.clever);
-      expect(loginInfo.find('SignInInstructions').props().loginType).to.equal(
-        SectionLoginType.clever
-      );
+
+      expect(screen.queryByText(i18n.password())).not.toBeInTheDocument();
+
+      expect(screen.getByText(/Signing in with Clever/i)).toBeInTheDocument();
     });
 
     it('renders correctly if loginType is google_classroom', () => {
@@ -471,20 +488,15 @@ describe('ManageStudentsTable', () => {
       };
       getStore().dispatch(setLoginType(SectionLoginType.google_classroom));
       getStore().dispatch(setSections([googleSection]));
-      const wrapper = mount(
+
+      render(
         <Provider store={getStore()}>
           <ManageStudentsTable section={googleSection} />
         </Provider>
       );
-      const passwordColumnHeader = wrapper.find('#password-header');
-      expect(passwordColumnHeader).to.have.lengthOf(0);
-      const loginInfo = wrapper.find('ManageStudentsLoginInfo');
-      expect(loginInfo.props().loginType).to.equal(
-        SectionLoginType.google_classroom
-      );
-      expect(loginInfo.find('SignInInstructions').props().loginType).to.equal(
-        SectionLoginType.google_classroom
-      );
+
+      expect(screen.queryByText(i18n.password())).not.toBeInTheDocument();
+      expect(screen.getByText(/Signing in with Google/i)).toBeInTheDocument();
     });
 
     describe('The full section notification', () => {
@@ -523,19 +535,15 @@ describe('ManageStudentsTable', () => {
                 })
               );
 
-              const wrapper = mount(
+              render(
                 <Provider store={getStore()}>
                   <ManageStudentsTable section={wordSection} />
                 </Provider>
               );
 
               expect(
-                wrapper.containsMatchingElement(
-                  <ManageStudentsNotificationFull
-                    manageStatus={defaultAddTransferStatus}
-                  />
-                )
-              ).to.be.false;
+                screen.queryByText(/students couldn't be/i)
+              ).not.toBeInTheDocument();
             });
           });
 
@@ -554,19 +562,15 @@ describe('ManageStudentsTable', () => {
                 transferStudentsSuccess(type, numStudents, sectionDisplay)
               );
 
-              const wrapper = mount(
+              render(
                 <Provider store={getStore()}>
                   <ManageStudentsTable section={wordSection} />
                 </Provider>
               );
 
               expect(
-                wrapper.containsMatchingElement(
-                  <ManageStudentsNotificationFull
-                    manageStatus={defaultAddTransferStatus}
-                  />
-                )
-              ).to.be.false;
+                screen.queryByText(/students couldn't be/i)
+              ).not.toBeInTheDocument();
             });
           });
         });
@@ -576,19 +580,15 @@ describe('ManageStudentsTable', () => {
             it('does not fire full notification', () => {
               getStore().dispatch(addStudentsFailure(1, 'error info', [0]));
 
-              const wrapper = mount(
+              render(
                 <Provider store={getStore()}>
                   <ManageStudentsTable section={wordSection} />
                 </Provider>
               );
 
               expect(
-                wrapper.containsMatchingElement(
-                  <ManageStudentsNotificationFull
-                    manageStatus={defaultAddTransferStatus}
-                  />
-                )
-              ).to.be.false;
+                screen.queryByText(/students couldn't be/i)
+              ).not.toBeInTheDocument();
             });
           });
 
@@ -596,19 +596,15 @@ describe('ManageStudentsTable', () => {
             it('does not fire full notification', () => {
               getStore().dispatch(transferStudentsFailure('error info'));
 
-              const wrapper = mount(
+              render(
                 <Provider store={getStore()}>
                   <ManageStudentsTable section={wordSection} />
                 </Provider>
               );
 
               expect(
-                wrapper.containsMatchingElement(
-                  <ManageStudentsNotificationFull
-                    manageStatus={defaultAddTransferStatus}
-                  />
-                )
-              ).to.be.false;
+                screen.queryByText(/students couldn't be/i)
+              ).not.toBeInTheDocument();
             });
           });
         });
@@ -619,71 +615,45 @@ describe('ManageStudentsTable', () => {
           it('added', () => {
             getStore().dispatch(addStudentsFull(defaultAddTransferStatus, [0]));
 
-            const wrapper = mount(
+            render(
               <Provider store={getStore()}>
                 <ManageStudentsTable section={wordSection} />
               </Provider>
             );
 
             expect(
-              wrapper.containsMatchingElement(
-                <ManageStudentsNotificationFull
-                  manageStatus={{...defaultAddTransferStatus, status: 'full'}}
-                />
-              )
-            ).to.be.true;
+              screen.getByText(/students couldn't be added/i)
+            ).toBeInTheDocument();
           });
           it('moved', () => {
             getStore().dispatch(
               transferStudentsFull(defaultAddTransferStatus, false)
             );
 
-            const wrapper = mount(
+            render(
               <Provider store={getStore()}>
                 <ManageStudentsTable section={wordSection} />
               </Provider>
             );
 
             expect(
-              wrapper.containsMatchingElement(
-                <ManageStudentsNotificationFull
-                  manageStatus={{
-                    ...defaultAddTransferStatus,
-                    status: 'full',
-                    type: null,
-                    error: null,
-                    sectionDisplay: '',
-                    verb: 'move',
-                  }}
-                />
-              )
-            ).to.be.true;
+              screen.getByText(/students couldn't be moved/i)
+            ).toBeInTheDocument();
           });
           it('copied', () => {
             getStore().dispatch(
               transferStudentsFull(defaultAddTransferStatus, true)
             );
 
-            const wrapper = mount(
+            render(
               <Provider store={getStore()}>
                 <ManageStudentsTable section={wordSection} />
               </Provider>
             );
 
             expect(
-              wrapper.containsMatchingElement(
-                <ManageStudentsNotificationFull
-                  manageStatus={{
-                    ...defaultAddTransferStatus,
-                    status: 'full',
-                    type: null,
-                    error: null,
-                    sectionDisplay: '',
-                    verb: 'copy',
-                  }}
-                />
-              )
-            ).to.be.true;
+              screen.getByText(/students couldn't be copied/i)
+            ).toBeInTheDocument();
           });
         });
         describe('Multiple students', () => {
@@ -695,71 +665,60 @@ describe('ManageStudentsTable', () => {
               addStudentsFull(defaultAddTransferStatus, [0, 1])
             );
 
-            const wrapper = mount(
+            render(
               <Provider store={getStore()}>
                 <ManageStudentsTable section={wordSection} />
               </Provider>
             );
 
             expect(
-              wrapper.containsMatchingElement(
-                <ManageStudentsNotificationFull
-                  manageStatus={{...defaultAddTransferStatus, status: 'full'}}
-                />
-              )
-            ).to.be.true;
+              screen.getByText(/students couldn't be added/i)
+            ).toBeInTheDocument();
           });
           it('moved', () => {
             getStore().dispatch(
               transferStudentsFull(defaultAddTransferStatus, false)
             );
 
-            const wrapper = mount(
+            render(
               <Provider store={getStore()}>
                 <ManageStudentsTable section={wordSection} />
               </Provider>
             );
 
             expect(
-              wrapper.containsMatchingElement(
-                <ManageStudentsNotificationFull
-                  manageStatus={{
-                    ...defaultAddTransferStatus,
-                    status: 'full',
-                    type: null,
-                    error: null,
-                    sectionDisplay: '',
-                    verb: 'move',
-                  }}
-                />
-              )
-            ).to.be.true;
+              screen.getByText(/students couldn't be moved/i)
+            ).toBeInTheDocument();
           });
           it('copied', () => {
             getStore().dispatch(
               transferStudentsFull(defaultAddTransferStatus, true)
             );
 
-            const wrapper = mount(
+            render(
               <Provider store={getStore()}>
                 <ManageStudentsTable section={wordSection} />
               </Provider>
             );
 
             expect(
-              wrapper.containsMatchingElement(
-                <ManageStudentsNotificationFull
-                  manageStatus={{
-                    ...defaultAddTransferStatus,
-                    status: 'full',
-                    type: null,
-                    error: null,
-                    sectionDisplay: '',
-                    verb: 'copy',
-                  }}
-                />
-              )
-            ).to.be.true;
+              screen.getByText(/students couldn't be copied/i)
+            ).toBeInTheDocument();
+          });
+          it('copied', () => {
+            getStore().dispatch(
+              transferStudentsFull(defaultAddTransferStatus, true)
+            );
+
+            render(
+              <Provider store={getStore()}>
+                <ManageStudentsTable section={wordSection} />
+              </Provider>
+            );
+
+            expect(
+              screen.getByText(/students couldn't be copied/i)
+            ).toBeInTheDocument();
           });
         });
       });


### PR DESCRIPTION
These 2 test files (`test/unit/templates/manageStudents/ManageStudentsTableTest.js` and `test/unit/code-studio/components/progress/TeacherUnitOverviewTest.tsx`) were both failing in react 18.

For TeacherUnitOverviewTest it was caused by a warning being upgraded to an error that a protectedstatefuldiv was being destroyed. This only happens when not on the teacher dashboard, but the mechanism for determining whether the component was on the teacher dashboard was using react location.pathname, which is hard to test. Instead, I switched it to use a prop that gets passed down from `TeacherUnitOverview`, which is how it is displayed on the teacher dashboard.

ManageStudentsTableTest I converted to RTL, mostly using an agent.

## Links
Tracker: https://docs.google.com/spreadsheets/d/1HEi20Ndj3r-fsCxuxxemm6QVIncMW_KVUzYMDsC6suU/edit?gid=1368456503#gid=1368456503
