### PR TITLE
Don't Hide Internal Tables

### DIFF
--- a/pegasus/test/fixtures/fake_dashboard.rb
+++ b/pegasus/test/fixtures/fake_dashboard.rb
@@ -147,8 +147,11 @@ module FakeDashboard
     end
 
     # Temporary tables may shadow persistent tables we don't want to drop.
-    def data_source_exists?(_)
-      false
+    def data_source_exists?(table_name)
+      return [
+        ActiveRecord::Base.schema_migrations_table_name,
+        ActiveRecord::Base.internal_metadata_table_name
+      ].include?(table_name)
     end
 
     # Temporary tables don't support foreign key indexes, so ignore them.


### PR DESCRIPTION
We override `table_exists` for our temporary mock dashboard database, but this also ends up overriding the check for tables that we don't consider temporary; most notably, the schema migrations table. This has worked up until now because Rails in versions earlier than 7.0 has a small bug in that it actually checks for the presence of the schema migrations table in the schema cache rather than checking for the actual table.

This [was fixed in Rails 7.0](https://github.com/rails/rails/pull/43877), which caused our tests to start failing with:

    Minitest::UnexpectedError:         ActiveRecord::RecordNotUnique: Mysql2::Error: Duplicate entry '20260120193121' for key 'schema_migrations.PRIMARY'

As they attempted to recreate a table which already exists.

The simple fix is to update our override logic to return the correct result when checking for the existence of these tables.