### PR TITLE
Revert "Upgrade to puma 7.2"

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -147,7 +147,7 @@ gem 'open_uri_redirections', require: false
 # Optimizes copy-on-write memory usage with GC before web-application fork.
 gem 'nakayoshi_fork'
 
-gem 'puma', '~> 7.2'
+gem 'puma', '~> 6.6', '>= 6.6.1'
 gem 'puma_worker_killer'
 gem 'raindrops'
 gem 'sd_notify' # required for Puma to support systemd's Type=notify

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -696,7 +696,7 @@ GEM
       coderay (~> 1.1)
       method_source (~> 1.0)
     public_suffix (6.0.1)
-    puma (7.2.0)
+    puma (6.6.1)
       nio4r (~> 2.0)
     puma_worker_killer (0.3.1)
       get_process_mem (~> 0.2)
@@ -1126,7 +1126,7 @@ DEPENDENCIES
   pg (~> 1.3.0)
   phantomjs (~> 1.9.7.1)
   pry (~> 0.14.0)
-  puma (~> 7.2)
+  puma (~> 6.6, >= 6.6.1)
   puma_worker_killer
   pusher (~> 1.3.1)
   pycall (>= 1.5.2)

--- a/dashboard/config/puma.rb
+++ b/dashboard/config/puma.rb
@@ -31,7 +31,7 @@ before_fork do
   Cdo::AppServerHooks.before_fork
 end
 
-before_worker_boot do |_index|
+on_worker_boot do |_index|
   Cdo::AppServerHooks.after_fork(host: CDO.dashboard_hostname)
   ActiveRecord::Base.establish_connection
 end

--- a/pegasus/config/puma.rb
+++ b/pegasus/config/puma.rb
@@ -26,6 +26,6 @@ before_fork do
   Cdo::AppServerHooks.before_fork
 end
 
-before_worker_boot do |_index|
+on_worker_boot do |_index|
   Cdo::AppServerHooks.after_fork(host: CDO.pegasus_hostname)
 end


### PR DESCRIPTION
Reverts code-dot-org/code-dot-org#70548

Everything's healthy since the upgrade but puma standard error log is full of `Errno::EMFILE: Too many open files` errors. Getting a revert ready in case we're not able to fix forward.