### PR TITLE
Increase puma Open File Descriptor Limit

### DIFF
--- a/cookbooks/cdo-apps/templates/default/puma.service.erb
+++ b/cookbooks/cdo-apps/templates/default/puma.service.erb
@@ -10,6 +10,9 @@ After=network.target
 Type=notify
 WatchdogSec=10
 
+# Maximum number of open files (descriptors).
+LimitNOFILE=65536
+
 # Our servers can take a while to start up; wait ten full minutes for them to
 # do so before giving up.
 TimeoutStartSec=600


### PR DESCRIPTION
https://codedotorg.atlassian.net/browse/INF-2021

Since the upgrade to puma 7.2 we're seeing "Too many open files" errors from dashboard puma.
https://codedotorg.slack.com/archives/C03CK49G9/p1769736412157789?thread_ts=1767805495.631049&cid=C03CK49G9

Set a higher open file descriptor soft limit that the default 1024.

## Testing story
`bundle exec rake adhoc:start RAILS_ENV=adhoc STACK_NAME=adhoc-puma-file-limit`



## Deployment strategy
<!--  Any special steps required to deploy this, besides merging?
      - Are there database migrations or manual steps?
      - Does this require coordination with other teams or systems? -->



## Follow-up work
<!--  List any clean-up or technical debt that will be addressed in future work.
      - Include Jira links where applicable.
      - Are there any known limitations or improvements planned? -->



## Privacy
<!--  How does this change impact Student & Teacher privacy?
      - Does this collect, use, share, or modify PII, either new or existing? -->



## Security
<!--  How does this change impact our security surface-area?
      - Do API's touched have the right auth?
      - Do infra changes impact our attack surface or encryption?
-->



## Caching
<!--  How does this change impact caching behavior?
      - Are cache keys or invalidation strategies affected?
      - Will this require cache warming or invalidation after deployment? -->



## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
