### PR TITLE
Skip preview execution for share view in spritelab

### DIFF
--- a/apps/src/p5lab/spritelab/SpriteLab.js
+++ b/apps/src/p5lab/spritelab/SpriteLab.js
@@ -72,7 +72,8 @@ export default class SpriteLab extends P5Lab {
       this.initInterpreter(false /* attachDebugger */);
       this.onP5Setup();
       this.p5Wrapper.p5.redraw();
-    } else {
+    } else if (!studioApp().share) {
+      // in the share view, run is executed on load, so we can skip the preview execution
       this.p5Wrapper.startExecution();
       this.p5Wrapper.setLoop(false);
     }

--- a/apps/src/p5lab/spritelab/SpriteLab.js
+++ b/apps/src/p5lab/spritelab/SpriteLab.js
@@ -73,7 +73,7 @@ export default class SpriteLab extends P5Lab {
       this.onP5Setup();
       this.p5Wrapper.p5.redraw();
     } else if (!studioApp().share) {
-      // in the share view, run is executed on load, so we can skip the preview execution
+      // In the share view, run is executed on load, so we can skip the preview execution.
       this.p5Wrapper.startExecution();
       this.p5Wrapper.setLoop(false);
     }


### PR DESCRIPTION
We got a zendesk ticket about some funky behavior of spritelab seen in the share view but not in the edit view. It seems like the sprites generated under the `when run` block are being duplicated and are stuck on screen. This only happens in the "share" view, and not in the edit view.

We believe we have some race condition between the preview and the normal run of the code when those things happen at the same time like they do in "share" view.  Some preview state is not getting cleaned up before the js interpreter initializes again and runs the code for real, and they're somehow getting orphaned and stuck on screen.

Conversely, when viewing the project with code side-by-side, the preview is executed when the page loads, but you need to press the `run` button manually so we're much less likely to run into this race.

Here's an example of a project that hits this bug: https://studio.code.org/projects/game_design/fcb71214-dd9d-41c0-98a6-8526e10a573f - and a video of the race condition being hit - 

https://github.com/user-attachments/assets/ae0608c4-3cae-4902-b653-cd1ba7972649


This fix isn't the most surgical / specific, but we can avoid hitting this race condition when in share mode by not executing the preview code when in share mode. Since we run the app immediately on load when in this mode, it shouldn't be a problem to not have the preview.

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->



## Links
<!--  Links to relevant external resources.
      - spec docs, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- [zendesk ticket](https://codeorg.zendesk.com/agent/tickets/573916) 

## Testing story
<!--  Does your change include appropriate tests?
      - If so, please describe how the tests included in this PR are sufficient.
      - If not, please explain why this change does not need to be tested. -->

Tested that we only call initInterpreter() once when in share mode, and preview still works correctly in view and edit modes.  We haven't been able to repro the race condition locally, but believe this should fix the issue we're seeing and confirmed locally that doing the initialization just once in share mode does not have any negative side effects. 
