### PR TITLE
Update slack.rb to get display_name when querying user_name for mentions

### DIFF
--- a/bin/cron/update_dotd
+++ b/bin/cron/update_dotd
@@ -18,12 +18,12 @@ def main
 
   primary_dotd_user = nil
   if primary_dotd_email
-    primary_dotd_user = Slack.user_name(primary_dotd_email)
+    primary_dotd_user = Slack.user_mention_tag(primary_dotd_email)
   end
   primary_dotd_user ||= '(ERROR: check schedule)'
 
   # Set the new developers room topic
-  new_topic = current_topic.sub(/^.+?;/, "DOTD: @#{primary_dotd_user};")
+  new_topic = current_topic.sub(/^.+?;/, "DOTD: #{primary_dotd_user};")
   Slack.update_topic('developers', new_topic) unless new_topic == current_topic
 end
 

--- a/lib/cdo/slack.rb
+++ b/lib/cdo/slack.rb
@@ -50,6 +50,7 @@ class Slack
     raise "Failed to query users.list" unless members
     user = members.find {|member| email == member['profile']['email']}
     raise "Slack email #{email} not found" unless user
+    return user['profile']['display_name'] unless user['profile']['display_name'] == ""
     user['name']
   end
 

--- a/lib/cdo/slack.rb
+++ b/lib/cdo/slack.rb
@@ -50,7 +50,6 @@ class Slack
     raise "Failed to query users.list" unless members
     user = members.find {|member| email == member['profile']['email']}
     raise "Slack email #{email} not found" unless user
-    return user['profile']['display_name'] unless user['profile']['display_name'] == ""
     user['name']
   end
 

--- a/lib/cdo/slack.rb
+++ b/lib/cdo/slack.rb
@@ -54,6 +54,18 @@ class Slack
     user['name']
   end
 
+  # Returns a mention tag '<@id>' for a user based on their email.
+  # @param email [String] The email of the Slack user.
+  # @raise [ArgumentError] If the email does not correspond to a Slack user.
+  # @return [nil | String] The user (mention) tag for the Slack user.
+  def self.user_mention_tag(email)
+    members = post_to_slack("https://slack.com/api/users.list")['members']
+    raise "Failed to query users.list" unless members
+    user = members.find {|member| email == member['profile']['email']}
+    raise "Slack email #{email} not found" unless user
+    "<@#{user['id']}>"
+  end
+
   def self.user_id(name)
     members = post_to_slack("https://slack.com/api/users.list")['members']
     raise "Failed to query users.list" unless members


### PR DESCRIPTION
I'm being mistaken for somebody else and it is pinging them when I'm the DOTD and that's annoying to both of us!!

It is difficult to tell from Slack's api documentation, but `display_name` seems to be the deciding factor for the mention name. However, it is strongly advocated to use the `id` in a special encoding instead to account for spaces in the display name.

Manually ran the code in update_dotd and had it successfully tag me (@wilkie) in the channel topic by using the `<@id>` encoding.

## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
