### PR TITLE
Route sagemaker to production endpoints in all environments

### DIFF
--- a/dashboard/app/helpers/aichat_sagemaker_helper.rb
+++ b/dashboard/app/helpers/aichat_sagemaker_helper.rb
@@ -72,7 +72,7 @@ module AichatSagemakerHelper
   end
 
   def self.get_endpoint_name(model_id)
-    "#{model_id}-#{rack_env?(:production) ? 'production' : 'test'}"
+    "#{model_id}-production"
   end
 end
 


### PR DESCRIPTION
Route all non-prod AI Chat traffic to the production SageMaker endpoints, so we can turn off the test endpoints and deprecate the test cloudformation stack, saving a significant number of AWS resources.

## Testing story
- Tested locally; confirmed we're only using the prod endpoints on localhost