### PR TITLE
Switch from Raindrops to Puma Stats for Web Application Server Metrics

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -149,7 +149,6 @@ gem 'nakayoshi_fork'
 
 gem 'puma', '~> 7.2'
 gem 'puma_worker_killer'
-gem 'raindrops'
 gem 'sd_notify' # required for Puma to support systemd's Type=notify
 
 gem 'chronic', '~> 0.10.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -757,7 +757,6 @@ GEM
       rake (>= 12.2)
       thor (~> 1.0)
     rainbow (3.1.1)
-    raindrops (0.20.0)
     rake (13.2.1)
     rambling-trie (2.3.1)
     rb-fsevent (0.11.2)
@@ -1137,7 +1136,6 @@ DEPENDENCIES
   rack_csrf
   rails (~> 6.1)
   rails-controller-testing (~> 1.0.5)
-  raindrops
   rambling-trie (>= 2.1.1)
   recaptcha
   redcarpet (~> 3.6.0)

--- a/dashboard/config.ru
+++ b/dashboard/config.ru
@@ -6,17 +6,6 @@ CDO.cdo_secrets&.required! unless rack_env?(:development)
 
 require File.expand_path('../config/environment',  __FILE__)
 
-unless rack_env?(:development)
-  require 'cdo/app_server_metrics'
-  listener = CDO.dashboard_sock || "0.0.0.0:#{CDO.dashboard_port}"
-  use Cdo::AppServerMetrics,
-    listeners: [listener],
-    dimensions: {
-      Environment: CDO.rack_env,
-      Host: CDO.dashboard_hostname
-    }
-end
-
 use Rack::ContentLength
 require 'rack/ssl-enforcer'
 use Rack::SslEnforcer,

--- a/dashboard/config/puma.rb
+++ b/dashboard/config/puma.rb
@@ -32,6 +32,11 @@ before_fork do
 end
 
 before_worker_boot do |_index|
-  Cdo::AppServerHooks.after_fork(host: CDO.dashboard_hostname)
+  Cdo::AppServerHooks.before_worker_boot(host: CDO.dashboard_hostname)
   ActiveRecord::Base.establish_connection
+end
+
+# Code to run in the Puma parent process after it boots, and also after a phased restart completes.
+after_booted do
+  Cdo::AppServerHooks.after_booted
 end

--- a/lib/cdo/app_server_hooks.rb
+++ b/lib/cdo/app_server_hooks.rb
@@ -1,7 +1,4 @@
 module Cdo
-  # Common app-server hook logic shared between multiple application entry-points
-  # (e.g., dashboard and pegasus).
-  #
   # NOTE: these hooks are only executed when running in puma clustered mode, which spawns worker processes.
   # These hooks will NOT be run in local development unless you set `dashboard_workers: 1` (or greater)
   # in locals.yml, which enables clustered mode.
@@ -30,7 +27,7 @@ module Cdo
       end
     end
 
-    def self.after_fork(host:)
+    def self.before_worker_boot(host:)
       # When the master preloads the app, the forked worker inherits the parent's in memory New Relic state,
       # including connection and background thread state. New Relic recommends calling `after_fork` in the worker
       # to reset that inherited state and start the agent cleanly inside the worker process.
@@ -45,9 +42,36 @@ module Cdo
       Cdo::Metrics.put('App Server', 'WorkerBoot', 1, {Host: host})
 
       # Statsig is initialized here for managed environments. For development, it is
-      # intialized in config/initializers/statsig.rb
+      # initialized in config/initializers/statsig.rb
       require 'cdo/statsig'
       Cdo::StatsigInitializer.init
+    end
+
+    def self.after_booted
+      # Publish puma metrics in production, the managed test server, and adhoc environments.
+      if CDO.rack_env?(:production) || CDO.test_system? || CDO.rack_env?(:adhoc)
+        require 'cdo/app_server_metrics'
+
+        # Default to High Resolution (1s) for Production/Test.
+        interval = 1
+        resolution = 1
+
+        # Use Standard Resolution (60s) for Adhoc to save costs.
+        if CDO.rack_env?(:adhoc)
+          interval = 60
+          resolution = 60
+        end
+
+        @metrics_reporter ||= Cdo::AppServerMetrics.new(
+          interval: interval,
+          resolution: resolution,
+          dimensions: {
+            Environment: CDO.rack_env,
+            Host: CDO.dashboard_hostname
+          }
+        )
+        @metrics_reporter.start_puma_reporting
+      end
     end
   end
 end

--- a/lib/cdo/app_server_metrics.rb
+++ b/lib/cdo/app_server_metrics.rb
@@ -1,54 +1,28 @@
-require 'raindrops'
 require 'cdo/aws/metrics'
 require 'honeybadger/ruby'
 require 'concurrent/timer_task'
-require 'active_support/core_ext/module/attribute_accessors'
 
 module Cdo
-  # AppServerMetrics extends the Raindrops::Middleware class,
-  # which instruments a Rack application to collect the number of
-  # currently-executing requests using an atomic counter shared across
-  # all forked worker-processes.
-  #
-  # Every :interval seconds (default 1), metrics are collected.
-  #
-  # The following metrics are collected and reported:
-  # `active` - the number of active TCP/socket connections
-  # `queued` - the number of queued TCP/socket requests
-  # `calling` - the maximum number of currently-executing requests at any point during the interval.
-  #
-  # The :listeners option accepts an array of strings (TCP or Unix domain socket names).
-  # By default, all listeners used by the Unicorn master process are monitored.
-  #
-  # Any errors are forwarded to Honeybadger for logging and notifying.
-  class AppServerMetrics < Raindrops::Middleware
-    cattr_accessor :instance
-
-    def initialize(app, opts = {})
-      # Track max_calling using a modified Stats implementation.
-      opts[:stats] ||= StatsWithMax.new
-      # Disable the reporting endpoint with an empty-string :path by default.
-      opts[:path] ||= ''
-      super(app, opts)
-      @metrics = %i(active queued calling).map {|name| [name, []]}.to_h
-
+  # Collect puma web application server statistics and publish to AWS CloudWatch.
+  class AppServerMetrics
+    def initialize(opts = {})
       @namespace = opts[:namespace] || 'App Server'
       @dimensions = opts[:dimensions] || {}
+
+      # Default to 1 if not provided, or use the dynamic values from hooks.
       @interval = opts[:interval] || 1
+      @resolution = opts[:resolution] || 1
+
       @instance_id = 'UNKNOWN'
-      self.instance = self
     end
 
     # Fetch or retry the ID.
     def instance_id
-      # Fast path: return the ID if it's already known.
-      unless @instance_id == 'UNKNOWN'
-        return @instance_id
-      end
+      return @instance_id unless @instance_id == 'UNKNOWN'
 
-      if @instance_id == 'UNKNOWN'
-        fetched_id = AWS::EC2.instance_id
-        @instance_id = fetched_id if fetched_id # Update only on success.
+      # Attempt fetch.
+      if (fetched_id = AWS::EC2.instance_id)
+        @instance_id = fetched_id
       end
 
       @instance_id
@@ -58,62 +32,56 @@ module Cdo
       @spawn_reporting_task&.shutdown
     end
 
-    def spawn_reporting_task
-      @spawn_reporting_task ||= Concurrent::TimerTask.new(execution_interval: @interval) {|task| collect_metrics(task)}.
+    def start_puma_reporting
+      # If we already have a running task, don't start another.
+      return @spawn_reporting_task if @spawn_reporting_task&.running?
+
+      @spawn_reporting_task = Concurrent::TimerTask.new(execution_interval: @interval) {|task| collect_puma_stats(task)}.
         with_observer {|_, _, ex| Honeybadger.notify(ex) if ex}.
         execute
     end
 
-    # Periodically collect unicorn-listener metrics.
-    def collect_metrics(*_)
-      # Retrieve the best available ID (UNKNOWN or real i-xxxx)
-      current_instance_id = instance_id
+    # Periodically collect puma metrics.
+    def collect_puma_stats(*_)
+      namespace = @namespace
+      dimensions = @dimensions
 
-      collect_listener_stats.each do |name, value|
+      # Puma.stats_hash provides the true internal state of all workers
+      stats = Puma.stats_hash
+      worker_statuses = stats[:worker_status].map {|w| w[:last_status]}
+
+      # Aggregate metrics across the entire cluster on this instance
+      metrics = {
+        'backlog' => worker_statuses.sum {|s| s[:backlog] || 0},
+        'running' => worker_statuses.sum {|s| s[:running] || 0},
+        'pool_capacity' => worker_statuses.sum {|s| s[:pool_capacity] || 0},
+        'booted_workers' => stats[:booted_workers] || 0
+      }
+
+      metrics.each do |name, value|
+        # Public Deployment-level (Environment + Host) metrics.
         Cdo::Metrics.put(
-          @namespace,
+          namespace,
           name,
           value,
-          @dimensions,
-          storage_resolution: 1,
+          dimensions,
+          storage_resolution: @resolution,
           unit: 'Count'
         )
-        # Also publish active/queued/calling listener metrics with an EC2 Instance ID Dimension.
+
+        # Retrieve the best available ID (UNKNOWN or real i-xxxx).
+        current_instance_id = instance_id
+
+        # Public Instance-level (Environment + Host + InstanceId) metrics.
         Cdo::Metrics.put(
-          @namespace,
+          namespace,
           name,
           value,
-          @dimensions.merge(InstanceId: current_instance_id),
-          storage_resolution: 1,
+          dimensions.merge(InstanceId: current_instance_id),
+          storage_resolution: @resolution,
           unit: 'Count'
         )
       end
-    end
-
-    # Collect current snapshot of tcp/unix listener stats.
-    # @return [Hash{Symbol => Number}]
-    def collect_listener_stats
-      stats = {}
-      stats.merge! Raindrops::Linux.tcp_listener_stats(@tcp.uniq) if @tcp
-      stats.merge! Raindrops::Linux.unix_listener_stats(@unix.uniq) if @unix
-      stats = %i(active queued).map do |name|
-        [name, stats.values.sum(&name)]
-      end.to_h
-      stats[:calling] = @stats.max_calling.tap {@stats.max_calling = 0}
-      stats
-    end
-  end
-
-  # Extends Raindrops::Middleware::Stats (which defines :calling and :writing)
-  # with an additional :max_calling atomic counter.
-  # This allows us to record the peak number of currently-executing
-  # worker-processes at any point, which a one-second sampling interval
-  # might not otherwise capture.
-  class StatsWithMax < Raindrops::Struct.new(:calling, :writing, :max_calling)
-    # Override incr_calling to keep max_calling updated.
-    def incr_calling
-      calling = super
-      self.max_calling = calling if calling > max_calling
     end
   end
 end

--- a/lib/cdo/app_server_metrics.rb
+++ b/lib/cdo/app_server_metrics.rb
@@ -46,15 +46,26 @@ module Cdo
       namespace = @namespace
       dimensions = @dimensions
 
-      # Puma.stats_hash provides the true internal state of all workers
+      # Puma.stats_hash provides the internal state of all workers.
       stats = Puma.stats_hash
       worker_statuses = stats[:worker_status].map {|w| w[:last_status]}
 
-      # Aggregate metrics across the entire cluster on this instance
+      # Aggregate metrics across the entire cluster on this instance.
+      # Descriptions based on Puma 7.2 internal STAT_METHODS:
+      # https://github.com/puma/puma/blob/dc947d90fbe0aeb6aaabae9295ebdf94229b83b1/lib/puma/server.rb#L687
+      #
+      #   backlog - Requests accepted by workers but queued in their internal 'todo' sets waiting for an available thread.
+      #   running - Total spawned worker threads. Fluctuate between min/max thread settings aggregated across all child processes.
+      #   pool_capacity - Total immediate thread availability (max_threads - busy_threads). When 0, requests begin to backlog.
+      #   busy_threads - Number of threads actively processing requests across all child processes.
+      #   max_threads - The upper limit of threads allowed to spawn across all child processes.
+      #   booted_workers - Number of child processes currently alive and reporting to the parent master process.
       metrics = {
         'backlog' => worker_statuses.sum {|s| s[:backlog] || 0},
         'running' => worker_statuses.sum {|s| s[:running] || 0},
         'pool_capacity' => worker_statuses.sum {|s| s[:pool_capacity] || 0},
+        'busy_threads' => worker_statuses.sum {|s| s[:busy_threads] || 0},
+        'max_threads' => worker_statuses.sum {|s| s[:max_threads] || 0},
         'booted_workers' => stats[:booted_workers] || 0
       }
 

--- a/lib/test/cdo/test_app_server_metrics.rb
+++ b/lib/test/cdo/test_app_server_metrics.rb
@@ -6,7 +6,6 @@ module Puma; end unless defined?(Puma)
 
 class AppServerMetricsTest < Minitest::Test
   def setup
-    # Make sure we pass dimensions here, mirroring your production fix
     @metrics = Cdo::AppServerMetrics.new(
       interval: 0.1,
       namespace: 'App Server',
@@ -25,27 +24,32 @@ class AppServerMetricsTest < Minitest::Test
   def test_collect_puma_stats
     AWS::EC2.stubs(:instance_id).returns('i-12345678')
 
-    # Fix 2: Puma constant is now guaranteed to exist due to the module definition above
+    # Simulate a cluster where:
+    # Worker 0: 1 thread busy, 4 capacity remaining.
+    # Worker 1: 5 threads busy (full), 2 requests in backlog.
     fake_puma_stats = {
       worker_status: [
-        {last_status: {backlog: 0, running: 1, pool_capacity: 4, max_threads: 5}},
-        {last_status: {backlog: 2, running: 5, pool_capacity: 0, max_threads: 5}}
+        {last_status: {backlog: 0, running: 1, pool_capacity: 4, busy_threads: 1, max_threads: 5}},
+        {last_status: {backlog: 2, running: 5, pool_capacity: 0, busy_threads: 5, max_threads: 5}}
       ],
       booted_workers: 2
     }
     Puma.stubs(:stats_hash).returns(fake_puma_stats)
 
+    # Summed values across both workers.
     expected_metrics = {
       'backlog' => 2,
       'running' => 6,
       'pool_capacity' => 4,
+      'busy_threads' => 6,
+      'max_threads' => 10,
       'booted_workers' => 2
     }
 
     sequence = sequence('metrics')
 
     expected_metrics.each do |name, value|
-      # Expect Deployment-level metric
+      # Expect Deployment-level metric (no InstanceId).
       Cdo::Metrics.expects(:put).with(
         'App Server',
         name,
@@ -54,7 +58,7 @@ class AppServerMetricsTest < Minitest::Test
         {storage_resolution: 1, unit: 'Count'}
       ).in_sequence(sequence)
 
-      # Expect Instance-level metric
+      # Expect Instance-level metric (with InstanceId).
       Cdo::Metrics.expects(:put).with(
         'App Server',
         name,
@@ -68,32 +72,23 @@ class AppServerMetricsTest < Minitest::Test
   end
 
   def test_start_puma_reporting_is_idempotent
-    # Create a real task object so we satisfy 'assert_kind_of' checks.
     task = Concurrent::TimerTask.new(execution_interval: 0.1) {}
-
-    # Stub 'with_observer' to return self (the task).
-    # This prevents the real method from running and ensures the chain continues on our terms.
     task.stubs(:with_observer).returns(task)
-
-    # Stub 'execute' to return self (the task).
     task.stubs(:execute).returns(task)
-
-    # Stub 'running?' for the idempotency check.
     task.stubs(:running?).returns(true)
 
-    # Force .new to return our prepared task.
     Concurrent::TimerTask.stubs(:new).returns(task)
 
-    # First call: Should return the task.
     task1 = @metrics.start_puma_reporting
     assert_kind_of Concurrent::TimerTask, task1
 
-    # Second call: Should return the SAME task object.
+    # Verify that we don't spawn a second task during phased restarts.
     task2 = @metrics.start_puma_reporting
     assert_same task1, task2
   end
 
   def test_dynamic_resolution
+    # Verify that resolution can be tuned for adhoc/cost management.
     adhoc_metrics = Cdo::AppServerMetrics.new(resolution: 60, interval: 60)
 
     Puma.stubs(:stats_hash).returns({worker_status: [], booted_workers: 0})

--- a/lib/test/cdo/test_app_server_metrics.rb
+++ b/lib/test/cdo/test_app_server_metrics.rb
@@ -1,119 +1,109 @@
 require_relative '../test_helper'
 require 'cdo/app_server_metrics'
 
-class AppServerMetricsTest < Minitest::Test
-  include Rack::Test::Methods
-  TCP_LISTENER = '0.0.0.0:0000'.freeze
-  SOCKET_LISTENER = '/tmp/sock'.freeze
+# Define Puma module if it doesn't exist so we can stub it without loading the full gem.
+module Puma; end unless defined?(Puma)
 
-  # Make sure we don't leak metrics to other tests.
+class AppServerMetricsTest < Minitest::Test
+  def setup
+    # Make sure we pass dimensions here, mirroring your production fix
+    @metrics = Cdo::AppServerMetrics.new(
+      interval: 0.1,
+      namespace: 'App Server',
+      dimensions: {
+        Environment: 'test',
+        Host: 'test.example.net'
+      }
+    )
+  end
+
   def teardown
+    @metrics.shutdown
     Cdo::Metrics.flush!
   end
 
-  def app
-    ok = lambda do |_|
-      @app.collect_metrics
-      [200, {'Content-Type' => 'text/plain'}, ['OK']]
-    end
-
-    @app = Rack::Builder.app do
-      use Cdo::AppServerMetrics,
-        interval: 0,
-        listeners: [TCP_LISTENER, SOCKET_LISTENER]
-      run ok
-    end
-  end
-
-  def expect_metrics(*metrics)
-    @sequence ||= sequence('metrics')
-    # Define the ID we expect to see.
-    # Must match the value stubbed in the test method below.
-    expected_instance_id = 'i-12345678'
-
-    metrics.each do |name, value|
-      # Expect app server metrics published with Dimensions for the current environment/site.
-      Cdo::Metrics.expects(:put).with(
-        "App Server", name, value, {}, {storage_resolution: 1, unit: 'Count'}
-      ).in_sequence(@sequence)
-
-      # Expect app server metrics published with Dimensions for the current environment/site AND current EC2 Instance ID.
-      Cdo::Metrics.expects(:put).with(
-        "App Server",
-        name,
-        value,
-        {InstanceId: expected_instance_id},
-        {storage_resolution: 1, unit: 'Count'}
-      ).in_sequence(@sequence)
-    end
-  end
-
-  def test_app_server_metrics
+  def test_collect_puma_stats
     AWS::EC2.stubs(:instance_id).returns('i-12345678')
 
-    Raindrops::Linux.expects(:tcp_listener_stats).
-      with([TCP_LISTENER]).times(2).
-      returns(
-        {TCP_LISTENER => Raindrops::ListenStats.new(1, 2)},
-        {TCP_LISTENER => Raindrops::ListenStats.new(3, 4)},
-      )
-    Raindrops::Linux.expects(:unix_listener_stats).
-      with([SOCKET_LISTENER]).times(2).
-      returns({SOCKET_LISTENER => Raindrops::ListenStats.new(0, 0)})
+    # Fix 2: Puma constant is now guaranteed to exist due to the module definition above
+    fake_puma_stats = {
+      worker_status: [
+        {last_status: {backlog: 0, running: 1, pool_capacity: 4, max_threads: 5}},
+        {last_status: {backlog: 2, running: 5, pool_capacity: 0, max_threads: 5}}
+      ],
+      booted_workers: 2
+    }
+    Puma.stubs(:stats_hash).returns(fake_puma_stats)
 
-    expect_metrics(
-      [:active, 1],
-      [:queued, 2],
-      [:calling, 1],
-      [:active, 3],
-      [:queued, 4],
-      [:calling, 1]
-    )
+    expected_metrics = {
+      'backlog' => 2,
+      'running' => 6,
+      'pool_capacity' => 4,
+      'booted_workers' => 2
+    }
 
-    get '/'
-    get '/'
+    sequence = sequence('metrics')
+
+    expected_metrics.each do |name, value|
+      # Expect Deployment-level metric
+      Cdo::Metrics.expects(:put).with(
+        'App Server',
+        name,
+        value,
+        {Environment: 'test', Host: 'test.example.net'},
+        {storage_resolution: 1, unit: 'Count'}
+      ).in_sequence(sequence)
+
+      # Expect Instance-level metric
+      Cdo::Metrics.expects(:put).with(
+        'App Server',
+        name,
+        value,
+        {Environment: 'test', Host: 'test.example.net', InstanceId: 'i-12345678'},
+        {storage_resolution: 1, unit: 'Count'}
+      ).in_sequence(sequence)
+    end
+
+    @metrics.collect_puma_stats
   end
 
-  # We want to test functionality within AppServerMetrics that depends on a
-  # concurrent task. This simple Observer class will let us block until that
-  # task has executed at least once.
-  #
-  # See https://www.rubydoc.info/gems/concurrent-ruby/1.2.3/Concurrent/Concern/Observable
-  class TaskExecutionObserver
-    def initialize
-      @task_executed = Concurrent::Event.new
-    end
+  def test_start_puma_reporting_is_idempotent
+    # Create a real task object so we satisfy 'assert_kind_of' checks.
+    task = Concurrent::TimerTask.new(execution_interval: 0.1) {}
 
-    def update(time, result, ex)
-      @task_executed.set
-    end
+    # Stub 'with_observer' to return self (the task).
+    # This prevents the real method from running and ensures the chain continues on our terms.
+    task.stubs(:with_observer).returns(task)
 
-    def wait_until_task_executed
-      @task_executed.wait(1)
-    end
+    # Stub 'execute' to return self (the task).
+    task.stubs(:execute).returns(task)
+
+    # Stub 'running?' for the idempotency check.
+    task.stubs(:running?).returns(true)
+
+    # Force .new to return our prepared task.
+    Concurrent::TimerTask.stubs(:new).returns(task)
+
+    # First call: Should return the task.
+    task1 = @metrics.start_puma_reporting
+    assert_kind_of Concurrent::TimerTask, task1
+
+    # Second call: Should return the SAME task object.
+    task2 = @metrics.start_puma_reporting
+    assert_same task1, task2
   end
 
-  def test_reporting_task
-    # Note: this test only passes on Linux systems, since it relies on Raindrops reading from /proc/net/unix.
-    skip "Skip on non-Linux system" unless File.file? Raindrops::Linux::PROC_NET_UNIX_ARGS.first
+  def test_dynamic_resolution
+    adhoc_metrics = Cdo::AppServerMetrics.new(resolution: 60, interval: 60)
 
-    listener = Cdo::AppServerMetrics.new(nil,
-      interval: 0.01,
-      listeners: [TCP_LISTENER, SOCKET_LISTENER]
-    )
-    observer = TaskExecutionObserver.new
-    task = listener.spawn_reporting_task
-    task.add_observer(observer)
-    Cdo::Metrics.expects(:put).at_least(1)
-    observer.wait_until_task_executed
-  ensure
-    listener&.shutdown
-    task.wait_for_termination(1)
+    Puma.stubs(:stats_hash).returns({worker_status: [], booted_workers: 0})
+    AWS::EC2.stubs(:instance_id).returns('i-adhoc')
 
-    # Because it's possible for a thread spawned by the task prior to
-    # termination to execute even after wait_for_termination has returned, we
-    # delay for a couple extra intervals to ensure that this test's threads
-    # will not interefere with test_app_server_metrics
-    sleep 0.02
+    Cdo::Metrics.expects(:put).with(
+      anything, anything, anything, anything,
+      has_entry(storage_resolution: 60)
+    ).at_least_once
+
+    adhoc_metrics.collect_puma_stats
   end
 end

--- a/pegasus/config.ru
+++ b/pegasus/config.ru
@@ -4,17 +4,6 @@ CDO.cdo_secrets&.required! unless rack_env?(:development) || CDO.unit_test
 
 require File.expand_path('../router', __FILE__)
 
-unless rack_env?(:development)
-  require 'cdo/app_server_metrics'
-  listener = CDO.pegasus_sock || "0.0.0.0:#{CDO.pegasus_port}"
-  use Cdo::AppServerMetrics,
-    listeners: [listener],
-    dimensions: {
-      Environment: CDO.rack_env,
-      Host: CDO.pegasus_hostname
-    }
-end
-
 use Rack::Session::Cookie, secret: (CDO.sinatra_session_secret || 'dev_mode')
 
 require 'rack/ssl-enforcer'


### PR DESCRIPTION
https://codedotorg.atlassian.net/browse/INF-2021

Now that we've upgraded to puma 7.2 #70548 we can use the parent puma process's [`stats_hash`](https://puma.io/puma/Puma.html#stats_hash-class_method) instead of using Raindrops to collect TCP/socket statistics to measure web application server HTTP request metrics.

## Testing story
`bundle exec rake adhoc:start RAILS_ENV=adhoc STACK_NAME=adhoc-puma-stats`



## Deployment strategy

1. Manually delete CloudWatch Queued HTTP Requests Alarm
2. Update CloudWatch Overview Dashboard



## Follow-up work
<!--  List any clean-up or technical debt that will be addressed in future work.
      - Include Jira links where applicable.
      - Are there any known limitations or improvements planned? -->



## Privacy
<!--  How does this change impact Student & Teacher privacy?
      - Does this collect, use, share, or modify PII, either new or existing? -->



## Security
<!--  How does this change impact our security surface-area?
      - Do API's touched have the right auth?
      - Do infra changes impact our attack surface or encryption?
-->



## Caching
<!--  How does this change impact caching behavior?
      - Are cache keys or invalidation strategies affected?
      - Will this require cache warming or invalidation after deployment? -->



## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
