### PR TITLE
Support rubrics on choice levels

### DIFF
--- a/apps/src/levelbuilder/rubrics/RubricsContainer.jsx
+++ b/apps/src/levelbuilder/rubrics/RubricsContainer.jsx
@@ -170,6 +170,7 @@ export default function RubricsContainer({
   };
 
   const pageHeader = !!rubric ? 'Modify your rubric' : 'Create your rubric';
+
   return (
     <div>
       <Heading1>{pageHeader}</Heading1>

--- a/apps/src/levelbuilder/rubrics/RubricsContainer.jsx
+++ b/apps/src/levelbuilder/rubrics/RubricsContainer.jsx
@@ -159,6 +159,7 @@ export default function RubricsContainer({
     const selectOptions = submittableLevels.map(level => (
       <option key={level.id} value={level.id}>
         {level.name}
+        {level.sublevels?.length > 0 && ' (contains sublevels)'}
       </option>
     ));
     return selectOptions;
@@ -169,7 +170,6 @@ export default function RubricsContainer({
   };
 
   const pageHeader = !!rubric ? 'Modify your rubric' : 'Create your rubric';
-
   return (
     <div>
       <Heading1>{pageHeader}</Heading1>
@@ -177,6 +177,18 @@ export default function RubricsContainer({
         <div>
           <BodyTwoText>
             This rubric will be used for {unitName}, lesson {lessonNumber}.
+            <br />
+            In legacy labs, the rubric will be shown on all levels in the
+            lesson.
+            <br />
+            If you are writing a rubric for a lab2 level (Music Lab, Python Lab,
+            Web Lab 2, AI Chat, etc.), rubrics will only show up on the level
+            they are defined on, as well as any levels that share the same
+            project template level. If you want to define a rubric on a choice
+            level, assign the rubric to the parent level that contains the
+            choice level. The same rubric will be shared for all choice levels
+            under that parent, as well as any levels that share project template
+            levels with those choice levels.
           </BodyTwoText>
           <div style={styles.containerStyle}>
             <label htmlFor="rubric_level_id">
@@ -234,6 +246,7 @@ RubricsContainer.propTypes = {
     PropTypes.shape({
       id: PropTypes.number,
       name: PropTypes.string,
+      sublevels: PropTypes.array,
     })
   ),
   rubric: PropTypes.object,

--- a/apps/src/sites/studio/pages/rubrics/edit.js
+++ b/apps/src/sites/studio/pages/rubrics/edit.js
@@ -8,9 +8,7 @@ $(document).ready(() => {
   const rubric = getScriptData('rubricData');
   const lessonData = getScriptData('lessonData');
   const {unitName, lessonNumber, levels} = lessonData;
-  const submittableLevels = levels.filter(
-    level => level.properties.submittable === 'true'
-  );
+  const submittableLevels = levels.filter(level => level.isSubmittable);
 
   ReactDOM.render(
     <RubricsContainer

--- a/apps/src/sites/studio/pages/rubrics/new.js
+++ b/apps/src/sites/studio/pages/rubrics/new.js
@@ -8,9 +8,7 @@ $(document).ready(() => {
   const lessonData = getScriptData('lessonData');
   const {unitName, lessonNumber, levels} = lessonData;
   const lessonId = lessonData.id;
-  const submittableLevels = levels.filter(
-    level => level.properties.submittable === 'true'
-  );
+  const submittableLevels = levels.filter(level => level.isSubmittable);
 
   ReactDOM.render(
     <RubricsContainer

--- a/dashboard/app/models/lesson.rb
+++ b/dashboard/app/models/lesson.rb
@@ -589,10 +589,7 @@ class Lesson < ApplicationRecord
   def summarize_for_rubric_edit
     level_summary = levels.map do |level|
       if level.type == 'BubbleChoice'
-        {
-          id: level.id,
-          name: level.name,
-          type: level.type,
+        level.attributes.symbolize_keys.merge(
           sublevels: level.sublevels.map do |sublevel|
             {
               id: sublevel.id,
@@ -601,14 +598,11 @@ class Lesson < ApplicationRecord
             }
           end,
           isSubmittable: level.sublevels.any? {|sublevel| sublevel.properties['submittable'] == 'true'}
-        }
+        )
       else
-        {
-          id: level.id,
-          name: level.name,
-          type: level.type,
+        level.attributes.symbolize_keys.merge(
           isSubmittable: level.properties['submittable'] == 'true'
-        }
+        )
       end
     end
     {

--- a/dashboard/app/models/lesson.rb
+++ b/dashboard/app/models/lesson.rb
@@ -587,12 +587,36 @@ class Lesson < ApplicationRecord
   end
 
   def summarize_for_rubric_edit
+    level_summary = levels.map do |level|
+      if level.type == 'BubbleChoice'
+        {
+          id: level.id,
+          name: level.name,
+          type: level.type,
+          sublevels: level.sublevels.map do |sublevel|
+            {
+              id: sublevel.id,
+              name: sublevel.name,
+              type: sublevel.type,
+            }
+          end,
+          isSubmittable: level.sublevels.any? {|sublevel| sublevel.properties['submittable'] == 'true'}
+        }
+      else
+        {
+          id: level.id,
+          name: level.name,
+          type: level.type,
+          isSubmittable: level.properties['submittable'] == 'true'
+        }
+      end
+    end
     {
       id: id,
       unitName: script.title_for_display,
       lessonNumber: relative_position,
       lessonName: name,
-      levels: levels
+      levels: level_summary
     }
   end
 

--- a/dashboard/app/models/levels/level.rb
+++ b/dashboard/app/models/levels/level.rb
@@ -941,15 +941,26 @@ class Level < ApplicationRecord
       properties_camelized["predictSettings"]&.delete("multipleChoiceAnswers")
     end
 
-    # If there is a rubric for this lesson, show the rubric if it is evaluated on this level, or if the evaluation level shares the same
-    # project template level as this level.
+    # If there is a rubric for this lesson, show the rubric if it is evaluated on this level or the level's parent.
+    # In addition, show the rubric if the evaluation level shares the same project template level as this level.
+    # If the level is a sublevel and has a project template level, also show the rubric if the evaluation level has a sublevel
+    # with the same project template level.
     rubric_level_id = script_level&.lesson&.rubric&.level_id
     if rubric_level_id
-      if rubric_level_id == id
+      current_parent = parent_levels.find do |parent|
+        parent.script_levels.find do |script|
+          script&.script_id == script_level&.script_id
+        end
+      end
+      if rubric_level_id == id || rubric_level_id == current_parent&.id
         properties_camelized[:showRubric] = true
       else
-        rubric_template_level = Level.find(rubric_level_id)&.try(:project_template_level)
-        properties_camelized[:showRubric] = rubric_template_level && rubric_template_level == try(:project_template_level)
+        rubric_level = Level.find(rubric_level_id)
+        rubric_template_level = rubric_level&.try(:project_template_level)
+        rubric_templates_for_sublevels = rubric_level&.try(:sublevels)&.map {|sublevel| sublevel.try(:project_template_level)} || []
+        if try(:project_template_level)
+          properties_camelized[:showRubric] = (rubric_template_level && rubric_template_level == try(:project_template_level)) || rubric_templates_for_sublevels.include?(try(:project_template_level))
+        end
       end
     end
     properties_camelized

--- a/dashboard/app/models/levels/level.rb
+++ b/dashboard/app/models/levels/level.rb
@@ -959,7 +959,7 @@ class Level < ApplicationRecord
         rubric_template_level = rubric_level&.try(:project_template_level)
         rubric_templates_for_sublevels = rubric_level&.try(:sublevels)&.map {|sublevel| sublevel.try(:project_template_level)} || []
         if try(:project_template_level)
-          properties_camelized[:showRubric] = (rubric_template_level && rubric_template_level == try(:project_template_level)) || rubric_templates_for_sublevels.include?(try(:project_template_level))
+          properties_camelized[:showRubric] = (rubric_template_level && rubric_template_level == project_template_level) || rubric_templates_for_sublevels.include?(project_template_level)
         end
       end
     end

--- a/dashboard/test/models/lesson_test.rb
+++ b/dashboard/test/models/lesson_test.rb
@@ -1366,4 +1366,99 @@ class LessonTest < ActiveSupport::TestCase
       I18n.locale = I18n.default_locale
     end
   end
+
+  test 'summarize_for_rubric_edit returns lesson info with levels' do
+    script = create(:script, :in_single_unit_course)
+    lesson_group = create(:lesson_group, script: script)
+    lesson = create(:lesson, lesson_group: lesson_group, script: script, name: 'Test Lesson', relative_position: 3)
+    level = create(:level, name: 'test level')
+    create(:script_level, lesson: lesson, script: script, levels: [level])
+
+    summary = lesson.summarize_for_rubric_edit
+
+    assert_equal lesson.id, summary[:id]
+    assert_equal script.title_for_display, summary[:unitName]
+    assert_equal 3, summary[:lessonNumber]
+    assert_equal 'Test Lesson', summary[:lessonName]
+    assert_equal 1, summary[:levels].length
+    assert_equal level.id, summary[:levels].first[:id]
+    assert_equal level.name, summary[:levels].first[:name]
+    assert_equal level.type, summary[:levels].first[:type]
+  end
+
+  test 'summarize_for_rubric_edit includes submittable flag for regular levels' do
+    script = create(:script, :in_single_unit_course)
+    lesson_group = create(:lesson_group, script: script)
+    lesson = create(:lesson, lesson_group: lesson_group, script: script)
+    submittable_level = create(:level, name: 'submittable level', properties: {submittable: 'true'})
+    non_submittable_level = create(:level, name: 'non submittable level')
+    create(:script_level, lesson: lesson, script: script, levels: [submittable_level])
+    create(:script_level, lesson: lesson, script: script, levels: [non_submittable_level])
+
+    summary = lesson.summarize_for_rubric_edit
+
+    assert_equal 2, summary[:levels].length
+    submittable_summary = summary[:levels].find {|l| l[:name] == 'submittable level'}
+    non_submittable_summary = summary[:levels].find {|l| l[:name] == 'non submittable level'}
+    assert_equal true, submittable_summary[:isSubmittable]
+    assert_equal false, non_submittable_summary[:isSubmittable]
+  end
+
+  test 'summarize_for_rubric_edit includes sublevels for BubbleChoice levels' do
+    script = create(:script, :in_single_unit_course)
+    lesson_group = create(:lesson_group, script: script)
+    lesson = create(:lesson, lesson_group: lesson_group, script: script)
+    bubble_choice = create(:bubble_choice_level, name: 'bubble choice level')
+    sublevel1 = create(:level, name: 'sublevel 1')
+    sublevel2 = create(:level, name: 'sublevel 2')
+    bubble_choice.child_levels << sublevel1
+    bubble_choice.child_levels << sublevel2
+    create(:script_level, lesson: lesson, script: script, levels: [bubble_choice])
+
+    summary = lesson.summarize_for_rubric_edit
+
+    assert_equal 1, summary[:levels].length
+    bubble_choice_summary = summary[:levels].first
+    assert_equal bubble_choice.id, bubble_choice_summary[:id]
+    assert_equal 'BubbleChoice', bubble_choice_summary[:type]
+    assert_equal 2, bubble_choice_summary[:sublevels].length
+    assert_equal sublevel1.id, bubble_choice_summary[:sublevels].first[:id]
+    assert_equal sublevel1.name, bubble_choice_summary[:sublevels].first[:name]
+    assert_equal sublevel2.id, bubble_choice_summary[:sublevels].second[:id]
+    assert_equal sublevel2.name, bubble_choice_summary[:sublevels].second[:name]
+  end
+
+  test 'summarize_for_rubric_edit sets isSubmittable true if any BubbleChoice sublevel is submittable' do
+    script = create(:script, :in_single_unit_course)
+    lesson_group = create(:lesson_group, script: script)
+    lesson = create(:lesson, lesson_group: lesson_group, script: script)
+    bubble_choice = create(:bubble_choice_level, name: 'bubble choice with submittable')
+    submittable_sublevel = create(:level, name: 'submittable sublevel', properties: {submittable: 'true'})
+    non_submittable_sublevel = create(:level, name: 'non submittable sublevel')
+    bubble_choice.child_levels << submittable_sublevel
+    bubble_choice.child_levels << non_submittable_sublevel
+    create(:script_level, lesson: lesson, script: script, levels: [bubble_choice])
+
+    summary = lesson.summarize_for_rubric_edit
+
+    bubble_choice_summary = summary[:levels].first
+    assert_equal true, bubble_choice_summary[:isSubmittable]
+  end
+
+  test 'summarize_for_rubric_edit sets isSubmittable false if no BubbleChoice sublevel is submittable' do
+    script = create(:script, :in_single_unit_course)
+    lesson_group = create(:lesson_group, script: script)
+    lesson = create(:lesson, lesson_group: lesson_group, script: script)
+    bubble_choice = create(:bubble_choice_level, name: 'bubble choice without submittable')
+    sublevel1 = create(:level, name: 'sublevel a')
+    sublevel2 = create(:level, name: 'sublevel b')
+    bubble_choice.child_levels << sublevel1
+    bubble_choice.child_levels << sublevel2
+    create(:script_level, lesson: lesson, script: script, levels: [bubble_choice])
+
+    summary = lesson.summarize_for_rubric_edit
+
+    bubble_choice_summary = summary[:levels].first
+    assert_equal false, bubble_choice_summary[:isSubmittable]
+  end
 end

--- a/dashboard/test/models/levels/level_test.rb
+++ b/dashboard/test/models/levels/level_test.rb
@@ -1472,6 +1472,76 @@ class LevelTest < ActiveSupport::TestCase
     assert_equal true, properties["showRubric"]
   end
 
+  test "summarize_for_lab2_properties shows rubric if parent level matches lesson rubric level" do
+    script = create(:script, :in_single_unit_course, tts: true)
+    lesson_group = create(:lesson_group, script: script)
+    lesson = create(:lesson, script: script, lesson_group: lesson_group)
+    parent_level = create(:bubble_choice_level, name: 'parent bubble choice')
+    child_level = create(:music, name: 'music sublevel')
+    parent_level.child_levels << child_level
+    create(:rubric, level: parent_level, lesson: lesson)
+    script_level = create(
+      :script_level,
+      lesson: lesson,
+      script: script,
+      levels: [parent_level]
+    )
+
+    properties = child_level.summarize_for_lab2_properties(script, script_level).stringify_keys
+
+    assert_equal true, properties["showRubric"]
+  end
+
+  test "summarize_for_lab2_properties does not show rubric if parent level is in different script" do
+    script = create(:script, :in_single_unit_course, tts: true)
+    other_script = create(:script, :in_single_unit_course, tts: true)
+    lesson_group = create(:lesson_group, script: script)
+    lesson = create(:lesson, script: script, lesson_group: lesson_group)
+    parent_level = create(:bubble_choice_level, name: 'parent bubble choice 2')
+    child_level = create(:music, name: 'music sublevel 2')
+    parent_level.child_levels << child_level
+    create(:rubric, level: parent_level, lesson: lesson)
+    # Parent is in other_script, not the script with the rubric
+    create(:script_level, script: other_script, levels: [parent_level])
+    script_level = create(
+      :script_level,
+      lesson: lesson,
+      script: script,
+      levels: [child_level]
+    )
+
+    properties = child_level.summarize_for_lab2_properties(script, script_level).stringify_keys
+
+    assert_nil properties["showRubric"]
+  end
+
+  test "summarize_for_lab2_properties shows rubric for sublevel when rubric level has sublevel with same template" do
+    script = create(:script, :in_single_unit_course, tts: true)
+    lesson_group = create(:lesson_group, script: script)
+    lesson = create(:lesson, script: script, lesson_group: lesson_group)
+    template_level = create(:music, name: 'shared music template')
+
+    # Rubric level is a bubble choice with a sublevel that has the template
+    rubric_level = create(:bubble_choice_level, name: 'rubric bubble choice')
+    rubric_sublevel = create(:music, name: 'rubric sublevel', properties: {project_template_level_name: template_level.name})
+    rubric_level.child_levels << rubric_sublevel
+
+    # Current level is a sublevel with the same template
+    current_level = create(:music, name: 'current sublevel', properties: {project_template_level_name: template_level.name})
+
+    create(:rubric, level: rubric_level, lesson: lesson)
+    script_level = create(
+      :script_level,
+      lesson: lesson,
+      script: script,
+      levels: [current_level]
+    )
+
+    properties = current_level.summarize_for_lab2_properties(script, script_level).stringify_keys
+
+    assert_equal true, properties["showRubric"]
+  end
+
   describe '#available_callouts' do
     let(:available_callouts) {level.available_callouts(script_level)}
 


### PR DESCRIPTION
This PR allows rubrics to be defined on the parent of submittable choice levels. Currently only submittable levels can have rubrics defined on them, bubble choice sub-levels are not in the list of levels provided to the rubric editor, and bubble choice parent levels cannot be submittable. We also want to support sharing the same rubric across all sublevels of a bubble choice level.

To support this I updated the following:
- When we send the lesson summary to the rubric editor, set a new `isSubmittable` flag that is true if either the level itself is submittable or any sublevels of the level are submittable.
- For lab2 levels, show the rubric if the parent has a rubric defined, or if this is a sublevel with a shared project template as another sublevel that has a rubric on the parent. For legacy labs, there is no change to how we show rubrics since we show them on every level (sublevel or regular) in a lesson with a rubric.
- Update the text on the rubric editor page to explain the new logic.
- Add new unit tests.

For now, teachers have to grade the rubric on the parent level. Since there won't be any rubrics on sublevels in production yet, I wanted to do that as a follow-up to keep this PR scoped.

## Screen shots/screen recording
### Updates to edit page
<img width="1002" height="287" alt="Screenshot 2026-02-02 at 1 46 40 PM" src="https://github.com/user-attachments/assets/23aec544-6d71-420d-8e84-7d549d9ab7ae" />


### Shared rubric across sublevels
The rubric is defined on the parent level of level 6 in the progression.

https://github.com/user-attachments/assets/c13f4511-93f6-4af3-ae80-8a6760c1c1b8



## Links

- Jira: [AFL-436](https://codedotorg.atlassian.net/browse/AFL-436)

## Testing story
Tested locally and added unit tests




## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
