### PR TITLE
Use resource panel extra links in pythonlab UI tests

### DIFF
--- a/apps/src/lab2/views/components/Instructions/ResourcePanel/ResourcePanelExtraLinks.tsx
+++ b/apps/src/lab2/views/components/Instructions/ResourcePanel/ResourcePanelExtraLinks.tsx
@@ -37,7 +37,7 @@ const ResourcePanelExtraLinks: React.FunctionComponent<
     <ButtonWithDialog
       text={'Extra Links'}
       ariaLabel={lab2I18n.extraLinks()}
-      id={'extra-links'}
+      id={'resource-panel-extra-links'}
       theme={theme}
       Dialog={innerDialog}
       iconName={'link'}

--- a/dashboard/test/ui/features/code_tools/pythonlab/pythonlab_start_mode.feature
+++ b/dashboard/test/ui/features/code_tools/pythonlab/pythonlab_start_mode.feature
@@ -6,9 +6,9 @@ Feature: Python Lab start mode
 Background:
   Given I create a levelbuilder named "Penelope"
   And I am on "http://studio.code.org/courses/allthethingscourse/units/1/lessons/50/levels/1?noIntrojs=true"
-  And I wait until element "#uitest-extra-links-button" is visible
+  And I wait until element "#uitest-resource-panel-extra-links-button" is visible
   And I wait until element ".project_updated_at" contains text "Saved"
-  And I press "uitest-extra-links-button"
+  And I press "uitest-resource-panel-extra-links-button"
   And I wait until element "a:contains([s]tart)" is visible
   Then I click selector "a:contains([s]tart)" to load a new page
   And I wait to see "#uitest-codebridge-run"

--- a/dashboard/test/ui/features/code_tools/pythonlab/pythonlab_start_mode_eyes.feature
+++ b/dashboard/test/ui/features/code_tools/pythonlab/pythonlab_start_mode_eyes.feature
@@ -8,9 +8,9 @@ Feature: Python Lab start mode eyes
 Background:
   Given I create a levelbuilder named "Penelope"
   And I am on "http://studio.code.org/courses/allthethingscourse/units/1/lessons/50/levels/1?noIntrojs=true&show-ai-tutor=true"
-  And I wait until element "#uitest-extra-links-button" is visible
+  And I wait until element "#uitest-resource-panel-extra-links-button" is visible
   And I wait until element ".project_updated_at" contains text "Saved"
-  And I press "uitest-extra-links-button"
+  And I press "uitest-resource-panel-extra-links-button"
   And I wait until element "a:contains([s]tart)" is visible
   Then I click selector "a:contains([s]tart)" to load a new page
   And I wait to see "#uitest-codebridge-run"


### PR DESCRIPTION
Updates the Python Lab UI and eyes start mode tests to access Extra Links via the resource panel sidebar rather than the extra links button. This test was previously flaky because both extra links button shared the same the UI test ID, but the extra links (non-resource panel) button would appear briefly before the lab loaded in, causing a weird state with the wrong dialog open, or getting dismounted. This fix makes the UI test ID for the resource panel extra links button distinct, so the test can wait for the resource panel to render in and then click the correct button.

## Links

https://codedotorg.slack.com/archives/C03DBDN67B7/p1769619611709859

## Testing story
- Tested with local server running against sauce labs, using sauce connect.