### PR TITLE
Tutor Permissions: Hook up ai_chat_access_level section property to AI Settings UI

### DIFF
--- a/apps/src/aichat/accessControlsApi.ts
+++ b/apps/src/aichat/accessControlsApi.ts
@@ -1,6 +1,6 @@
 import {MetricEvent} from '@cdo/apps/metrics/events';
 import MetricsReporter from '@cdo/apps/metrics/MetricsReporter';
-// import HttpClient from '@cdo/apps/util/HttpClient';
+import HttpClient from '@cdo/apps/util/HttpClient';
 
 import {repackageError} from '../metrics/analyticsUtils';
 
@@ -11,15 +11,14 @@ export const handleUpdateSectionAiChatAccessLevel = async (
   newAccessLevel: AiChatAccessLevel
 ) => {
   try {
-    // TODO-AICHAT-PERMISSIONS: uncomment when ai_chat_access_level endpoint implemented.
-    // await HttpClient.post(
-    //   `/api/v1/sections/${sectionId}/ai_chat_access_level`,
-    //   JSON.stringify({ai_chat_access_level: newAccessLevel}),
-    //   true,
-    //   {
-    //     'Content-Type': 'application/json; charset=UTF-8',
-    //   }
-    // );
+    await HttpClient.post(
+      `/api/v1/sections/${sectionId}/ai_chat_access_level`,
+      JSON.stringify({ai_chat_access_level: newAccessLevel}),
+      true,
+      {
+        'Content-Type': 'application/json; charset=UTF-8',
+      }
+    );
   } catch (error) {
     MetricsReporter.logError({
       event: MetricEvent.AI_SETTINGS_UPDATE_SECTION_ACCESS_FAIL,

--- a/apps/src/aichat/views/accessControls/AiChatAccessControls.tsx
+++ b/apps/src/aichat/views/accessControls/AiChatAccessControls.tsx
@@ -12,8 +12,9 @@ import React, {useEffect, useState} from 'react';
 import {EVENTS} from '@cdo/apps/metrics/AnalyticsConstants';
 import analyticsReporter from '@cdo/apps/metrics/AnalyticsReporter';
 import Spinner from '@cdo/apps/sharedComponents/Spinner';
+import {updateSectionAiChatAccessLevel} from '@cdo/apps/templates/teacherDashboard/teacherSectionsRedux';
 import {selectedSectionSelector} from '@cdo/apps/templates/teacherDashboard/teacherSectionsReduxSelectors';
-import {useAppSelector} from '@cdo/apps/util/reduxHooks';
+import {useAppDispatch, useAppSelector} from '@cdo/apps/util/reduxHooks';
 import {AiChatAccessLevels} from '@cdo/generated-scripts/sharedConstants';
 
 import {handleUpdateSectionAiChatAccessLevel} from '../../accessControlsApi';
@@ -26,13 +27,7 @@ import style from './ai-chat-access-controls.module.scss';
 /**
  * Renders toggles to control student access to AI chat features.
  * Used in Teacher Dashboard (not in lab2).
- *
- * TODO-AICHAT-PERMISSIONS: uncomment references to Section.aiChatAccessLevel
- * and updateSectionAiChatAccessLevel once implemented
  */
-
-// TODO-AICHAT-PERMISSIONS: the default should be based on the curriculum assigned to the section.
-const defaultAccessLevel = AiChatAccessLevels.DISABLED;
 
 const calculateAccessLevel = (
   accessToggle: boolean,
@@ -48,14 +43,12 @@ const calculateAccessLevel = (
 };
 
 const essentialOnlyCheckboxState = (
-  accessLevel: AiChatAccessLevel | undefined
+  accessLevel: AiChatAccessLevel
 ): boolean => {
   return accessLevel !== AiChatAccessLevels.DISABLED;
 };
 
-const accessToggleState = (
-  accessLevel: AiChatAccessLevel | undefined
-): boolean => {
+const accessToggleState = (accessLevel: AiChatAccessLevel): boolean => {
   return accessLevel === AiChatAccessLevels.ENABLED;
 };
 
@@ -69,10 +62,10 @@ const AiChatAccessControls: React.FC = () => {
   );
 
   const [accessToggle, setAccessToggle] = useState(
-    accessToggleState(/*section.aiChatAccessLevel*/ defaultAccessLevel)
+    accessToggleState(section.aiChatAccessLevel)
   );
   const [essentialOnlyCheckbox, setEssentialOnlyCheckbox] = useState(
-    essentialOnlyCheckboxState(/*section.aiChatAccessLevel*/ defaultAccessLevel)
+    essentialOnlyCheckboxState(section.aiChatAccessLevel)
   );
 
   const shouldShowAlert =
@@ -80,16 +73,16 @@ const AiChatAccessControls: React.FC = () => {
     calculateAccessLevel(accessToggle, essentialOnlyCheckbox) ===
       AiChatAccessLevels.DISABLED;
 
-  // const dispatch = useAppDispatch();
+  const dispatch = useAppDispatch();
 
   const updateAccessLevel = async (newAccessLevel: AiChatAccessLevel) => {
     await handleUpdateSectionAiChatAccessLevel(section.id, newAccessLevel);
-    // dispatch(
-    //   updateSectionAiChatAccessLevel({
-    //     sectionId: section.id,
-    //     aiChatAccessLevel: newAccessLevel,
-    //   })
-    // );
+    dispatch(
+      updateSectionAiChatAccessLevel({
+        sectionId: section.id,
+        aiChatAccessLevel: newAccessLevel,
+      })
+    );
     analyticsReporter.sendEvent(EVENTS.AI_CHAT_SECTION_ACCESS_LEVEL_UPDATED, {
       sectionId: section.id,
       newAccessLevel: newAccessLevel,
@@ -123,7 +116,7 @@ const AiChatAccessControls: React.FC = () => {
   };
 
   useEffect(() => {
-    const accessLevel = /*section.aiChatAccessLevel ||*/ defaultAccessLevel;
+    const accessLevel = section.aiChatAccessLevel;
     setEssentialOnlyCheckbox(essentialOnlyCheckboxState(accessLevel));
     setAccessToggle(accessToggleState(accessLevel));
   }, [section]);

--- a/apps/src/templates/teacherDashboard/teacherSectionsRedux.ts
+++ b/apps/src/templates/teacherDashboard/teacherSectionsRedux.ts
@@ -381,6 +381,17 @@ const sectionSlice = createSlice({
 
       state.sections[sectionId].aiTutorEnabled = aiTutorEnabled;
     },
+    updateSectionAiChatAccessLevel(
+      state,
+      action: PayloadAction<{
+        sectionId: number;
+        aiChatAccessLevel: string;
+      }>
+    ) {
+      const {sectionId, aiChatAccessLevel} = action.payload;
+
+      state.sections[sectionId].aiChatAccessLevel = aiChatAccessLevel;
+    },
     setCourseOfferings(
       state,
       action: PayloadAction<AssignmentCourseOffering[]>
@@ -1207,6 +1218,7 @@ export const {
   setAvailableParticipantTypes,
   startLoadingSectionData,
   updateSectionAiTutorEnabled,
+  updateSectionAiChatAccessLevel,
   updateSelectedSection,
   sectionHasNewData,
   sectionDoesNotHaveNewData,

--- a/apps/src/templates/teacherDashboard/teacherSectionsReduxSelectors.js
+++ b/apps/src/templates/teacherDashboard/teacherSectionsReduxSelectors.js
@@ -188,7 +188,6 @@ export const sectionFromServerSection = serverSection => ({
     ? Date.parse(serverSection.code_review_expires_at)
     : null,
   isAssignedCSA: serverSection.is_assigned_csa,
-  isAssignedEssentialAiChat: serverSection.is_assigned_essential_ai_chat,
   participantType: serverSection.participant_type,
   sectionInstructors: serverSection.sectionInstructors?.map(instructor => ({
     id: instructor?.id,
@@ -206,6 +205,8 @@ export const sectionFromServerSection = serverSection => ({
   atRiskAgeGatedUsState: serverSection.at_risk_age_gated_us_state,
   avatar_color: serverSection.avatar_color,
   avatar_emoji: serverSection.avatar_emoji,
+  isAssignedEssentialAiChat: serverSection.is_assigned_essential_ai_chat,
+  aiChatAccessLevel: serverSection.ai_chat_access_level,
 });
 
 /**

--- a/apps/src/templates/teacherDashboard/types/teacherSectionTypes.ts
+++ b/apps/src/templates/teacherDashboard/types/teacherSectionTypes.ts
@@ -27,7 +27,6 @@ export interface Section {
   hidden: boolean;
   id: number;
   isAssignedCSA?: boolean;
-  isAssignedEssentialAiChat?: boolean;
   lessonExtras: boolean;
   loginType?: keyof typeof SectionLoginType;
   loginTypeName?: string;
@@ -47,6 +46,8 @@ export interface Section {
   unitPosition: string | null;
   avatar_color?: number | null;
   avatar_emoji?: number | null;
+  isAssignedEssentialAiChat?: boolean;
+  aiChatAccessLevel?: string;
 }
 
 type Course = {

--- a/apps/test/unit/templates/teacherDashboard/teacherSectionsReduxTest.js
+++ b/apps/test/unit/templates/teacherDashboard/teacherSectionsReduxTest.js
@@ -586,7 +586,6 @@ describe('teacherSectionsRedux', () => {
         postMilestoneDisabled: false,
         codeReviewExpiresAt: null,
         isAssignedCSA: undefined,
-        isAssignedEssentialAiChat: undefined,
         sectionInstructors: [
           {
             id: 2,
@@ -613,6 +612,8 @@ describe('teacherSectionsRedux', () => {
         atRiskAgeGatedUsState: undefined,
         avatar_color: 1,
         avatar_emoji: 1,
+        isAssignedEssentialAiChat: undefined,
+        aiChatAccessLevel: undefined,
       });
     });
   });
@@ -951,7 +952,6 @@ describe('teacherSectionsRedux', () => {
           postMilestoneDisabled: false,
           codeReviewExpiresAt: null,
           isAssignedCSA: undefined,
-          isAssignedEssentialAiChat: undefined,
           sectionInstructors: [
             {
               id: 1,
@@ -972,6 +972,8 @@ describe('teacherSectionsRedux', () => {
           atRiskAgeGatedUsState: undefined,
           avatar_color: undefined,
           avatar_emoji: undefined,
+          isAssignedEssentialAiChat: undefined,
+          aiChatAccessLevel: undefined,
         },
       });
     });

--- a/dashboard/app/controllers/api/v1/sections_controller.rb
+++ b/dashboard/app/controllers/api/v1/sections_controller.rb
@@ -70,6 +70,7 @@ class Api::V1::SectionsController < Api::V1::JSONApiController
         restrict_section: params[:restrict_section].nil? ? false : params[:restrict_section],
         avatar_color: params[:avatar_color].nil? ? 0 : params[:avatar_color],
         avatar_emoji: params[:avatar_emoji].nil? ? 0 : params[:avatar_emoji],
+        ai_chat_access_level: params[:ai_chat_access_level].nil? ? SharedConstants::AI_CHAT_ACCESS_LEVELS[:DISABLED] : params[:ai_chat_access_level],
       }
     )
     return head :bad_request unless section.persisted?
@@ -122,6 +123,7 @@ class Api::V1::SectionsController < Api::V1::JSONApiController
     fields[:ai_tutor_enabled] = params[:ai_tutor_enabled] unless params[:ai_tutor_enabled].nil?
     fields[:avatar_color] = params[:avatar_color].nil? ? 0 : params[:avatar_color]
     fields[:avatar_emoji] = params[:avatar_emoji].nil? ? 0 : params[:avatar_emoji]
+    fields[:ai_chat_access_level] = params[:ai_chat_access_level] unless params[:ai_chat_access_level].nil?
 
     section.update!(fields)
     if @unit
@@ -300,6 +302,14 @@ class Api::V1::SectionsController < Api::V1::JSONApiController
   def set_ai_tutor_enabled
     @section.update!(ai_tutor_enabled: params[:ai_tutor_enabled])
     render json: {result: 'success'}
+  end
+
+  # POST /api/v1/sections/<id>/ai_chat_access_level
+  def set_ai_chat_access_level
+    @section.update!(ai_chat_access_level: params[:ai_chat_access_level])
+    render json: {result: 'success'}
+  rescue ActiveRecord::RecordInvalid
+    render json: {result: 'invalid ai_chat_access_level'}, status: :bad_request
   end
 
   private def find_follower

--- a/dashboard/app/models/sections/section.rb
+++ b/dashboard/app/models/sections/section.rb
@@ -116,6 +116,8 @@ class Section < ApplicationRecord
 
   scope :visible, -> {where(hidden: false)}
 
+  validates :ai_chat_access_level, inclusion: {in: SharedConstants::AI_CHAT_ACCESS_LEVELS.values}
+
   # PL courses which are run with adults should be set up with teacher accounts so they must use
   # email logins
   def pl_sections_must_use_email_logins
@@ -482,6 +484,7 @@ class Section < ApplicationRecord
         avatar_color: avatar_color,
         avatar_emoji: avatar_emoji,
         is_assigned_essential_ai_chat: assigned_essential_ai_chat?,
+        ai_chat_access_level: ai_chat_access_level,
       }
     end
   end
@@ -569,6 +572,7 @@ class Section < ApplicationRecord
           avatar_color: avatar_color,
           avatar_emoji: avatar_emoji,
           is_assigned_essential_ai_chat: assigned_essential_ai_chat?,
+          ai_chat_access_level: ai_chat_access_level,
         }
       )
     end

--- a/dashboard/config/routes.rb
+++ b/dashboard/config/routes.rb
@@ -213,6 +213,7 @@ Dashboard::Application.routes.draw do
           post 'code_review_groups', to: 'sections#set_code_review_groups'
           post 'code_review_enabled', to: 'sections#set_code_review_enabled'
           post 'ai_tutor_enabled', to: 'sections#set_ai_tutor_enabled'
+          post 'ai_chat_access_level', to: 'sections#set_ai_chat_access_level'
         end
         collection do
           get 'membership'

--- a/dashboard/test/controllers/api/v1/sections_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/sections_controller_test.rb
@@ -1505,6 +1505,43 @@ class Api::V1::SectionsControllerTest < ActionController::TestCase
     assert_response :forbidden
   end
 
+  test 'can set ai_chat_access_level by the section teacher' do
+    sign_in @teacher
+    post :set_ai_chat_access_level, params: {id: @section.id, ai_chat_access_level: SharedConstants::AI_CHAT_ACCESS_LEVELS[:ENABLED]}
+    assert_response :success
+    @section.reload
+    assert_equal SharedConstants::AI_CHAT_ACCESS_LEVELS[:ENABLED], @section.ai_chat_access_level
+  end
+
+  test 'cannot set ai_chat_access_level by a different teacher' do
+    sign_in @following_teacher
+    post :set_ai_chat_access_level, params: {id: @section.id, ai_chat_access_level: SharedConstants::AI_CHAT_ACCESS_LEVELS[:ENABLED]}
+    assert_response :forbidden
+  end
+
+  test 'set ai_chat_access_level returns 403 for unauthorized access' do
+    post :set_ai_chat_access_level, params: {id: @section.id, ai_chat_access_level: SharedConstants::AI_CHAT_ACCESS_LEVELS[:ENABLED]}
+    assert_response :forbidden
+  end
+
+  test 'set ai_chat_access_level fails when section does not exist' do
+    sign_in @teacher
+    post :set_ai_chat_access_level, params: {id: -1, ai_chat_access_level: SharedConstants::AI_CHAT_ACCESS_LEVELS[:ENABLED]}
+    assert_response :forbidden
+  end
+
+  test 'set ai_chat_access_level fails for invalid value' do
+    sign_in @teacher
+    post :set_ai_chat_access_level, params: {id: @section.id, ai_chat_access_level: 'invalid_value'}
+    assert_response :bad_request
+  end
+
+  test 'set ai_chat_access_level fails when passed nil' do
+    sign_in @teacher
+    post :set_ai_chat_access_level, params: {id: @section.id, ai_chat_access_level: nil}
+    assert_response :bad_request
+  end
+
   test 'valid_course_offerings includes only published courses' do
     sign_in @teacher
     get :valid_course_offerings, params: {login_type: Section::LOGIN_TYPE_EMAIL}

--- a/dashboard/test/models/sections/section_test.rb
+++ b/dashboard/test/models/sections/section_test.rb
@@ -802,6 +802,7 @@ class SectionTest < ActiveSupport::TestCase
         avatar_color: nil,
         avatar_emoji: nil,
         is_assigned_essential_ai_chat: false,
+        ai_chat_access_level: "disabled",
       }
       # Compare created_at separately because the object's created_at microseconds
       # don't match Time.zone.now's microseconds (different levels of precision)
@@ -836,6 +837,7 @@ class SectionTest < ActiveSupport::TestCase
         avatar_color: nil,
         avatar_emoji: nil,
         is_assigned_essential_ai_chat: false,
+        ai_chat_access_level: "disabled",
       }
       # Compare created_at separately because the object's created_at microseconds
       # don't match Time.zone.now's microseconds (different levels of precision)
@@ -969,6 +971,7 @@ class SectionTest < ActiveSupport::TestCase
         avatar_color: nil,
         avatar_emoji: nil,
         is_assigned_essential_ai_chat: false,
+        ai_chat_access_level: "disabled",
       }
       # Compare created_at separately because the object's created_at microseconds
       # don't match Time.zone.now's microseconds (different levels of precision)
@@ -1030,6 +1033,7 @@ class SectionTest < ActiveSupport::TestCase
         avatar_color: nil,
         avatar_emoji: nil,
         is_assigned_essential_ai_chat: false,
+        ai_chat_access_level: "disabled",
       }
       # Compare created_at separately because the object's created_at microseconds
       # don't match Time.zone.now's microseconds (different levels of precision)
@@ -1097,6 +1101,7 @@ class SectionTest < ActiveSupport::TestCase
         avatar_color: nil,
         avatar_emoji: nil,
         is_assigned_essential_ai_chat: false,
+        ai_chat_access_level: "disabled",
       }
       # Compare created_at separately because the object's created_at microseconds
       # don't match Time.zone.now's microseconds (different levels of precision)
@@ -1164,6 +1169,7 @@ class SectionTest < ActiveSupport::TestCase
         avatar_color: nil,
         avatar_emoji: nil,
         is_assigned_essential_ai_chat: false,
+        ai_chat_access_level: "disabled",
       }
       # Compare created_at separately because the object's created_at microseconds
       # don't match Time.zone.now's microseconds (different levels of precision)
@@ -1222,6 +1228,7 @@ class SectionTest < ActiveSupport::TestCase
         avatar_color: nil,
         avatar_emoji: nil,
         is_assigned_essential_ai_chat: false,
+        ai_chat_access_level: "disabled",
       }
       # Compare created_at separately because the object's created_at microseconds
       # don't match Time.zone.now's microseconds (different levels of precision)


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

This PR builds on #70437 and sets the new section property `ai_chat_access_level` from the AI Settings page.

## Links
<!--  Links to relevant external resources.
      - spec docs, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- [Task](https://www.figma.com/board/47n4NNAkS9lV2KbKhPiJSp/AI-Tutor-Permissions-Dumplink?node-id=2008-263&t=ZHG8KDpdgcxnKzNj-4)

## Testing story
<!--  Does your change include appropriate tests?
      - If so, please describe how the tests included in this PR are sufficient.
      - If not, please explain why this change does not need to be tested. -->

Tested manually with the experiment enabled. Added UTs. 


https://github.com/user-attachments/assets/355b7659-eac1-4038-adfc-ddad999f6bbf



## Deployment strategy
<!--  Any special steps required to deploy this, besides merging?
      - Are there database migrations or manual steps?
      - Does this require coordination with other teams or systems? -->

This functionality is behind an experiment

## Follow-up work
<!--  List any clean-up or technical debt that will be addressed in future work.
      - Include Jira links where applicable.
      - Are there any known limitations or improvements planned? -->

Next up: updating access level on section assignment and ui affordances [designs ](https://www.figma.com/design/nl4nXJLuUHb9Aj4gfCAaNL/AI-Tutor--Settings?node-id=3372-8026&m=dev)
