### PR TITLE
AI Tutor - UI/UX updates to support smaller size JSON video player 

### DIFF
--- a/apps/src/jsonVideo/jsonVideoElement.js
+++ b/apps/src/jsonVideo/jsonVideoElement.js
@@ -45,9 +45,6 @@ export class JsonVideo extends HTMLElement {
             <iframe id="scene-renderer" src="about:blank" scrolling="no"></iframe>
             <div id="closed-caption-overlay" class="hidden"><span class="cc-text"></span></div>
             <div id="controls-bar">
-                <div id="progress-container">
-                    <input type="range" id="progress-bar" min="0" max="100" value="0" step="0.1">
-                </div>
                 <div class="controls-row">
                     <button id="play-btn" class="control-btn"></button>
                     <div class="volume-control">
@@ -59,6 +56,9 @@ export class JsonVideo extends HTMLElement {
                     </div>
                     <div style="flex-grow: 1;"></div>
                     <button id="cc-btn" class="control-btn"></button>
+                </div>
+                <div id="progress-container">
+                    <input type="range" id="progress-bar" min="0" max="100" value="0" step="0.1">
                 </div>
             </div>
         `;
@@ -81,6 +81,25 @@ export class JsonVideo extends HTMLElement {
     };
 
     this._bindEvents();
+    this._setupResizeObserver();
+  }
+
+  _setupResizeObserver() {
+    const resizeObserver = new ResizeObserver(entries => {
+      for (const entry of entries) {
+        if (entry.target !== this) {
+          console.error('unexpected ResizeObserver target:', entry.target);
+        } else {
+          let timeDisplay = 'none';
+          if (entry.contentRect.width > 275) {
+            timeDisplay = 'block';
+          }
+          this.style.setProperty('--time-display', timeDisplay);
+        }
+      }
+    });
+
+    resizeObserver.observe(this);
   }
 
   _bindEvents() {
@@ -253,6 +272,10 @@ export class JsonVideo extends HTMLElement {
     this.ui.progress.value =
       (this._currentTimeMs / this._totalDurationMs) * 100 || 0;
     this.ui.curTime.textContent = this._formatTime(this._currentTimeMs);
+    this.ui.progress.style.setProperty(
+      '--progress-value',
+      this.ui.progress.value + '%'
+    );
   }
 
   _formatTime(ms) {

--- a/apps/src/jsonVideo/jsonVideoStyles.ts
+++ b/apps/src/jsonVideo/jsonVideoStyles.ts
@@ -10,132 +10,246 @@ const styles = `
     overflow: hidden;
 }
 
-#video-container { width: 100%; height: 100%; position: relative; cursor: pointer; }
-iframe { width: 100%; height: 100%; border: none; background-color: white; pointer-events: none; }
+#video-container {
+    width: 100%;
+    height: 100%;
+    position: relative;
+    cursor: pointer;
+}
+
+iframe {
+    width: 100%;
+    height: 100%;
+    border: none;
+    background-color: white;
+    pointer-events: none;
+}
 
 /* Captions Overlay */
 #closed-caption-overlay {
-    position: absolute; inset-x: 0; bottom: 1.5rem; padding: 0 1rem;
-    text-align: center; pointer-events: none; z-index: 10;
+    position: absolute;
+    inset-x: 0;
+    bottom: 1.5rem;
+    padding: 0 1rem;
+    text-align: center;
+    pointer-events: none;
+    z-index: 10;
     transition: bottom 0.2s ease-in-out;
 }
+
 :host([controls]:not(.playing)) #closed-caption-overlay,
-:host([controls].playing:hover) #closed-caption-overlay { 
-    bottom: 5.5rem; 
+:host([controls].playing:hover) #closed-caption-overlay {
+    bottom: 5.5rem;
 }
 
 .cc-text {
-    display: inline-block; background-color: rgba(0, 0, 0, 0.8);
-    color: white; font-size: 1.125rem; padding: 0.25rem 0.75rem; border-radius: 0.25rem;
+    display: inline-block;
+    background-color: rgba(0, 0, 0, 0.8);
+    color: white;
+    font-size: 1.125rem;
+    padding: 0.25rem 0.75rem;
+    border-radius: 0.25rem;
 }
 
 /* Controls Bar */
 #controls-bar {
-    position: absolute; bottom: 0; left: 0; right: 0;
-    background: linear-gradient(transparent, rgba(0,0,0,0.9));
-    display: flex; flex-direction: column; padding: 0 12px 8px 12px;
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    background: linear-gradient(transparent, rgba(0, 0, 0, 0.9));
+    display: flex;
+    flex-direction: column;
+    padding: 0 12px 8px 12px;
     gap: 0;
     transition: opacity 0.2s ease-in-out;
 }
-:host([controls]) #controls-bar { opacity: 1; }
-:host([controls].playing:not(:hover)) #controls-bar { opacity: 0; }
-:host(:not([controls])) #controls-bar { display: none; }
 
-.controls-row { display: flex; align-items: center; gap: 8px; color: white; height: 48px; }
+:host([controls]) #controls-bar {
+    opacity: 1;
+}
+
+:host([controls].playing:not(:hover)) #controls-bar {
+    opacity: 0;
+}
+
+:host(:not([controls])) #controls-bar {
+    display: none;
+}
+
+.controls-row {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    color: white;
+    height: 48px;
+}
 
 /* Progress Bar */
-#progress-container { width: 100%; height: 4px; display: flex; align-items: center; margin-bottom: 4px; }
-#progress-bar { 
-    width: 100%; height: 4px; cursor: pointer; accent-color: white; 
-    margin: 0; padding: 0; transition: height 0.1s;
+#progress-container {
+    width: 100%;
+    height: 4px;
+    display: flex;
+    align-items: center;
+    margin-bottom: 4px;
 }
-#progress-bar:hover { height: 6px; }
+
+#progress-bar {
+    width: 100%;
+    height: 4px;
+    cursor: pointer;
+    accent-color: white;
+    margin: 0;
+    padding: 0;
+    transition: height 0.1s;
+}
+
+#progress-bar:hover {
+    height: 6px;
+}
 
 /* Control Buttons (Data URIs) */
 .control-btn {
-    width: 40px; height: 40px; flex-shrink: 0;
-    background-color: transparent; background-repeat: no-repeat;
-    background-position: center; background-size: 26px;
-    border: none; cursor: pointer; opacity: 0.9; transition: all 0.2s;
+    width: 40px;
+    height: 40px;
+    flex-shrink: 0;
+    background-color: transparent;
+    background-repeat: no-repeat;
+    background-position: center;
+    background-size: 26px;
+    border: none;
+    cursor: pointer;
+    opacity: 0.9;
+    transition: all 0.2s;
 }
-.control-btn:hover { background-color: rgba(255,255,255,0.15); border-radius: 50%; }
 
-#play-btn { background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath fill='white' d='M8 5v14l11-7z'/%3E%3C/svg%3E"); }
-:host(.playing) #play-btn { background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath fill='white' d='M6 19h4V5H6v14zm8-14v14h4V5h-4z'/%3E%3C/svg%3E"); }
+.control-btn:hover {
+    background-color: rgba(255, 255, 255, 0.15);
+    border-radius: 50%;
+}
 
-#mute-btn { background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath fill='none' stroke='white' stroke-width='2' d='M11 5L6 9H2v6h4l5 4V5z'/%3E%3Cpath fill='none' stroke='white' stroke-width='2' d='M15.54 8.46a5 5 0 0 1 0 7.07M19.07 4.93a10 10 0 0 1 0 14.14'/%3E%3C/svg%3E"); }
-#mute-btn.muted { background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath fill='none' stroke='white' stroke-width='2' d='M11 5L6 9H2v6h4l5 4V5z'/%3E%3Cline x1='23' y1='9' x2='17' y2='15' stroke='white' stroke-width='2'/%3E%3Cline x1='17' y1='9' x2='23' y2='15' stroke='white' stroke-width='2'/%3E%3C/svg%3E"); }
+#play-btn {
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath fill='white' d='M8 5v14l11-7z'/%3E%3C/svg%3E");
+}
+
+:host(.playing) #play-btn {
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath fill='white' d='M6 19h4V5H6v14zm8-14v14h4V5h-4z'/%3E%3C/svg%3E");
+}
+
+#mute-btn {
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath fill='none' stroke='white' stroke-width='2' d='M11 5L6 9H2v6h4l5 4V5z'/%3E%3Cpath fill='none' stroke='white' stroke-width='2' d='M15.54 8.46a5 5 0 0 1 0 7.07M19.07 4.93a10 10 0 0 1 0 14.14'/%3E%3C/svg%3E");
+}
+
+#mute-btn.muted {
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath fill='none' stroke='white' stroke-width='2' d='M11 5L6 9H2v6h4l5 4V5z'/%3E%3Cline x1='23' y1='9' x2='17' y2='15' stroke='white' stroke-width='2'/%3E%3Cline x1='17' y1='9' x2='23' y2='15' stroke='white' stroke-width='2'/%3E%3C/svg%3E");
+}
 
 /* CC Icons with Physical Gapped Border */
-#cc-btn { background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Crect x='3' y='5' width='18' height='14' rx='2' fill='none' stroke='white' stroke-width='2'/%3E%3Cpath fill='white' d='M7 15h3c.55 0 1-.45 1-1v-1H9.5v.5h-2v-3h2v.5H11v-1c0-.55-.45-1-1-1H7c-.55 0-1 .45-1 1v4c0 .55.45 1 1 1zm7 0h3c.55 0 1-.45 1-1v-1h-1.5v.5h-2v-3h2v.5H18v-1c0-.55-.45-1-1-1h-3c-.55 0-1 .45-1 1v4c0 .55.45 1 1 1z'/%3E%3C/svg%3E"); }
-#cc-btn.disabled { background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath fill='none' stroke='white' stroke-width='2' d='M16 5h3a2 2 0 0 1 2 2v10a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V7a2 2 0 0 1 2-2h8'/%3E%3Cpath fill='white' d='M7 15h3c.55 0 1-.45 1-1v-1H9.5v.5h-2v-3h2v.5H11v-1c0-.55-.45-1-1-1H7c-.55 0-1 .45-1 1v4c0 .55.45 1 1 1zm7 0h3c.55 0 1-.45 1-1v-1h-1.5v.5h-2v-3h2v.5H18v-1c0-.55-.45-1-1-1h-3c-.55 0-1 .45-1 1v4c0 .55.45 1 1 1z'/%3E%3Cline x1='19' y1='3' x2='5' y2='21' stroke='white' stroke-width='2'/%3E%3C/svg%3E"); }
+#cc-btn {
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Crect x='3' y='5' width='18' height='14' rx='2' fill='none' stroke='white' stroke-width='2'/%3E%3Cpath fill='white' d='M7 15h3c.55 0 1-.45 1-1v-1H9.5v.5h-2v-3h2v.5H11v-1c0-.55-.45-1-1-1H7c-.55 0-1 .45-1 1v4c0 .55.45 1 1 1zm7 0h3c.55 0 1-.45 1-1v-1h-1.5v.5h-2v-3h2v.5H18v-1c0-.55-.45-1-1-1h-3c-.55 0-1 .45-1 1v4c0 .55.45 1 1 1z'/%3E%3C/svg%3E");
+}
+
+#cc-btn.disabled {
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath fill='none' stroke='white' stroke-width='2' d='M16 5h3a2 2 0 0 1 2 2v10a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V7a2 2 0 0 1 2-2h8'/%3E%3Cpath fill='white' d='M7 15h3c.55 0 1-.45 1-1v-1H9.5v.5h-2v-3h2v.5H11v-1c0-.55-.45-1-1-1H7c-.55 0-1 .45-1 1v4c0 .55.45 1 1 1zm7 0h3c.55 0 1-.45 1-1v-1h-1.5v.5h-2v-3h2v.5H18v-1c0-.55-.45-1-1-1h-3c-.55 0-1 .45-1 1v4c0 .55.45 1 1 1z'/%3E%3Cline x1='19' y1='3' x2='5' y2='21' stroke='white' stroke-width='2'/%3E%3C/svg%3E");
+}
 
 /* Volume Slider */
-.volume-control { display: flex; align-items: center; }
-#volume-slider { width: 0px; height: 4px; accent-color: white; cursor: pointer; opacity: 0; transition: width 0.3s ease, opacity 0.2s ease; margin: 0; }
-.volume-control:hover #volume-slider { width: 80px; opacity: 1; margin-left: 8px; margin-right: 8px; }
+.volume-control {
+    display: flex;
+    align-items: center;
+}
 
-.time-display { font-variant-numeric: tabular-nums; font-size: 13px; margin-left: 8px; }
-.hidden { display: none !important; }
+#volume-slider {
+    width: 0px;
+    height: 4px;
+    accent-color: white;
+    cursor: pointer;
+    opacity: 0;
+    transition: width 0.3s ease, opacity 0.2s ease;
+    margin: 0;
+}
+
+.volume-control:hover #volume-slider {
+    width: 80px;
+    opacity: 1;
+    margin-left: 8px;
+    margin-right: 8px;
+}
+
+.time-display {
+    font-variant-numeric: tabular-nums;
+    font-size: 13px;
+    margin-left: 8px;
+}
+
+.hidden {
+    display: none !important;
+}
 
 /* Progress bar */
 input[type=range] {
-  -webkit-appearance: none; /* Hides the slider so that custom slider can be made */
-  width: 100%; /* Specific width is required for Firefox. */
-  background: transparent; /* Otherwise white in Chrome */
+    -webkit-appearance: none;
+    /* Hides the slider so that custom slider can be made */
+    width: 100%;
+    /* Specific width is required for Firefox. */
+    background: transparent;
+    /* Otherwise white in Chrome */
 }
 
 input[type=range]:focus {
-  outline: none; /* Removes the blue border. Should probably style this for accessibility */
+    outline: none;
+    /* Removes the blue border. Should probably style this for accessibility */
 }
 
 /* Progress bar -  Webkit (Chrome, Safari, Edge) */
 input[type=range]::-webkit-slider-thumb {
-  -webkit-appearance: none; /* CRITICAL: This fixes the oblong shape in Safari */
-  height: 16px;
-  width: 16px;
-  border-radius: 50%;
-  background: #ffffff;
-  border: 1px solid #ddd; /* Add a border if you like */
-  cursor: pointer;
-  
-  /* Vertical alignment logic */
-  /* margin-top = (track-height / 2) - (thumb-height / 2) */
-  /* Example: track is 4px, thumb is 16px. (4/2) - (16/2) = 2 - 8 = -6px */
-  margin-top: -6px; 
-  
-  /* box-shadow for depth */
-  box-shadow: 0 1px 3px rgba(0,0,0,0.3);
+    -webkit-appearance: none;
+    /* CRITICAL: This fixes the oblong shape in Safari */
+    height: 16px;
+    width: 16px;
+    border-radius: 50%;
+    background: #ffffff;
+    border: 1px solid #ddd;
+    /* Add a border if you like */
+    cursor: pointer;
+
+    /* Vertical alignment logic */
+    /* margin-top = (track-height / 2) - (thumb-height / 2) */
+    /* Example: track is 4px, thumb is 16px. (4/2) - (16/2) = 2 - 8 = -6px */
+    margin-top: -6px;
+
+    /* box-shadow for depth */
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.3);
 }
 
 /* Progress bar - Firefox */
 input[type=range]::-moz-range-thumb {
-  height: 16px;
-  width: 16px;
-  border-radius: 50%;
-  background: #ffffff;
-  border: 1px solid #ddd; /* Firefox adds a grey border by default, override it */
-  cursor: pointer;
-  box-shadow: 0 1px 3px rgba(0,0,0,0.3);
-  /* Firefox centers the thumb on the track automatically, no margin-top needed */
+    height: 16px;
+    width: 16px;
+    border-radius: 50%;
+    background: #ffffff;
+    border: 1px solid #ddd;
+    /* Firefox adds a grey border by default, override it */
+    cursor: pointer;
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.3);
+    /* Firefox centers the thumb on the track automatically, no margin-top needed */
 }
 
 input[type=range]::-webkit-slider-runnable-track {
-  width: 100%;
-  height: 4px;
-  cursor: pointer;
-  background: #cccccc;
-  border-radius: 2px;
+    width: 100%;
+    height: 4px;
+    cursor: pointer;
+    background: #cccccc;
+    border-radius: 2px;
 }
 
 input[type=range]::-moz-range-track {
-  width: 100%;
-  height: 4px;
-  cursor: pointer;
-  background: #cccccc;
-  border-radius: 2px;
+    width: 100%;
+    height: 4px;
+    cursor: pointer;
+    background: #cccccc;
+    border-radius: 2px;
 }
-
 `;
 
 export default styles;

--- a/apps/src/jsonVideo/jsonVideoStyles.ts
+++ b/apps/src/jsonVideo/jsonVideoStyles.ts
@@ -82,13 +82,13 @@ iframe {
     align-items: center;
     gap: 8px;
     color: white;
-    height: 48px;
+    height: 40px;
 }
 
 /* Progress Bar */
 #progress-container {
     width: 100%;
-    height: 4px;
+    height: 5px;
     display: flex;
     align-items: center;
     margin-bottom: 4px;
@@ -96,7 +96,7 @@ iframe {
 
 #progress-bar {
     width: 100%;
-    height: 4px;
+    height: 5px;
     cursor: pointer;
     accent-color: white;
     margin: 0;
@@ -104,14 +104,11 @@ iframe {
     transition: height 0.1s;
 }
 
-#progress-bar:hover {
-    height: 6px;
-}
 
 /* Control Buttons (Data URIs) */
 .control-btn {
-    width: 40px;
-    height: 40px;
+    width: 20px;
+    height: 20px;
     flex-shrink: 0;
     background-color: transparent;
     background-repeat: no-repeat;
@@ -125,7 +122,6 @@ iframe {
 
 .control-btn:hover {
     background-color: rgba(255, 255, 255, 0.15);
-    border-radius: 50%;
 }
 
 #play-btn {
@@ -180,6 +176,7 @@ iframe {
     font-variant-numeric: tabular-nums;
     font-size: 13px;
     margin-left: 8px;
+    display: var(--time-display, block);
 }
 
 .hidden {
@@ -191,9 +188,9 @@ input[type=range] {
     -webkit-appearance: none;
     /* Hides the slider so that custom slider can be made */
     width: 100%;
+    --progress-value: 0%;
     /* Specific width is required for Firefox. */
-    background: transparent;
-    /* Otherwise white in Chrome */
+    background: linear-gradient(to right, #ffffff 0%, #ffffff var(--progress-value), #ccc var(--progress-value), #ccc 100%);
 }
 
 input[type=range]:focus {
@@ -204,19 +201,20 @@ input[type=range]:focus {
 /* Progress bar -  Webkit (Chrome, Safari, Edge) */
 input[type=range]::-webkit-slider-thumb {
     -webkit-appearance: none;
-    /* CRITICAL: This fixes the oblong shape in Safari */
-    height: 16px;
-    width: 16px;
+    /* This fixes the oblong shape in Safari */
+    height: 12px;
+    width: 12px;
     border-radius: 50%;
     background: #ffffff;
     border: 1px solid #ddd;
-    /* Add a border if you like */
+    transition: opacity 0.2s ease-in-out;
+
     cursor: pointer;
 
     /* Vertical alignment logic */
-    /* margin-top = (track-height / 2) - (thumb-height / 2) */
-    /* Example: track is 4px, thumb is 16px. (4/2) - (16/2) = 2 - 8 = -6px */
-    margin-top: -6px;
+    /* margin-top = (track-height + / 2) + border-size (when not using border-box sixing) - (thumb-height / 2) */
+    /* Example: track is 5px, thumb is 10px. (5/2) + 2 - (12/2) = 2.5 + 2 - 6 = -1.5px */
+    margin-top: -1.5px;
 
     /* box-shadow for depth */
     box-shadow: 0 1px 3px rgba(0, 0, 0, 0.3);
@@ -224,32 +222,29 @@ input[type=range]::-webkit-slider-thumb {
 
 /* Progress bar - Firefox */
 input[type=range]::-moz-range-thumb {
-    height: 16px;
-    width: 16px;
+    height: 12px;
+    width: 12px;
     border-radius: 50%;
     background: #ffffff;
     border: 1px solid #ddd;
+    transition: opacity 0.2s ease-in-out;
+
     /* Firefox adds a grey border by default, override it */
     cursor: pointer;
     box-shadow: 0 1px 3px rgba(0, 0, 0, 0.3);
     /* Firefox centers the thumb on the track automatically, no margin-top needed */
 }
 
-input[type=range]::-webkit-slider-runnable-track {
-    width: 100%;
-    height: 4px;
-    cursor: pointer;
-    background: #cccccc;
-    border-radius: 2px;
+#progress-container:not(:hover) > input[type=range]::-webkit-slider-thumb {
+    opacity: 0;
+    pointer-events: none;
+}
+#progress-container:not(:hover) > input[type=range]::-moz-range-thumb {
+    opacity: 0;
+    pointer-events: none;
 }
 
-input[type=range]::-moz-range-track {
-    width: 100%;
-    height: 4px;
-    cursor: pointer;
-    background: #cccccc;
-    border-radius: 2px;
-}
+
 `;
 
 export default styles;


### PR DESCRIPTION
This PR makes the following UI/UX changes to the JSON video player:

1. Hide elapsed/total time UI when not enough room (video is pretty small at tutor's default opening width).
2. Reorder controls so progress bar is at the bottom (beneath play/pause/etc) matching chrome's rendering of built-in video element.
3. Make elapsed progress a different color and make thumb control (circle on top of progress bar) hide when not hovering (previously had a single progress bar color and thumb control was always showing)

### Small size with no time display:

<img width="991" height="793" alt="Screenshot 2026-02-02 at 5 55 26 PM" src="https://github.com/user-attachments/assets/9b2d9687-6edb-4e99-a232-8039ff0f3428" />

### Small size with no time display (hovering over progress bar): 

<img width="999" height="788" alt="Screenshot 2026-02-02 at 5 55 21 PM" src="https://github.com/user-attachments/assets/3e352be7-fbf6-43d3-80ab-e7875c45d4f3" />

### Larger size with time display:

<img width="1055" height="793" alt="Screenshot 2026-02-02 at 5 55 31 PM" src="https://github.com/user-attachments/assets/9b9e1cb2-a9a2-402f-b268-432967a34ee4" />

### Video showing interaction:

https://github.com/user-attachments/assets/7b33d643-5406-4a65-8962-6749478694ed



## Links
These issues were some of the known UI/UX issues mentioned in the original [JSON video PR](https://github.com/code-dot-org/code-dot-org/pull/70532).