### PR TITLE
Support new omniauth-clever plugin version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -176,7 +176,7 @@ gem 'devise', '~> 4.9.0'
 gem 'devise_invitable', '~> 2.0.2'
 
 gem 'omniauth-classlink', '~> 0.3.1'
-gem 'omniauth-clever', '~> 2.0.1', github: 'code-dot-org/omniauth-clever', tag: 'v2.0.1'
+gem 'omniauth-clever', '~> 3.0.0', github: 'code-dot-org/omniauth-clever', tag: 'v3.0.0'
 gem 'omniauth-facebook', '~> 10.0.0'
 gem 'omniauth-google-oauth2', '~> 1.1.3'
 gem 'omniauth-microsoft_v2_auth', github: 'dooly-ai/omniauth-microsoft_v2_auth'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -32,10 +32,10 @@ GIT
 
 GIT
   remote: https://github.com/code-dot-org/omniauth-clever.git
-  revision: 995409e9be86a9864e344e360869ca982c834845
-  tag: v2.0.1
+  revision: 279804b3938fb889281e2314f768631288b0d431
+  tag: v3.0.0
   specs:
-    omniauth-clever (2.0.1)
+    omniauth-clever (3.0.0)
       omniauth-oauth2 (>= 1.1, <= 1.8)
 
 GIT
@@ -1110,7 +1110,7 @@ DEPENDENCIES
   octokit
   oj (~> 3.10)
   omniauth-classlink (~> 0.3.1)
-  omniauth-clever (~> 2.0.1)!
+  omniauth-clever (~> 3.0.0)!
   omniauth-facebook (~> 10.0.0)
   omniauth-google-oauth2 (~> 1.1.3)
   omniauth-microsoft_v2_auth!

--- a/dashboard/app/controllers/omniauth_callbacks_controller.rb
+++ b/dashboard/app/controllers/omniauth_callbacks_controller.rb
@@ -428,7 +428,7 @@ class OmniauthCallbacksController < Devise::OmniauthCallbacksController
     dob = auth[:dob] || auth.dig(:extra, :raw_info, :canonical, :data, :dob)
     gender = auth[:gender] || auth.dig(:extra, :raw_info, :canonical, :data, :gender)
 
-    # Get user type from Clever roles to to set in info hash. This maintains compatibility
+    # Get user type from Clever roles to set in info hash. This maintains compatibility
     # with existing logic that reads user_type from info hash during sign up.
     roles = auth&.extra&.raw_info&.canonical&.data&.roles || {}
     teacher_or_staff = roles.any? do |role, value|

--- a/dashboard/app/controllers/omniauth_callbacks_controller.rb
+++ b/dashboard/app/controllers/omniauth_callbacks_controller.rb
@@ -315,8 +315,8 @@ class OmniauthCallbacksController < Devise::OmniauthCallbacksController
     puts "User type determined to be #{user_type} based on Clever roles: #{roles.to_json}"
 
     params = auth_params.presence || {}
-    cookies['sign_up_user_type'] = user_type unless params[:user_type]
-    params[:user_type] = cookies['sign_up_user_type'] unless params[:user_type]
+    cookies['sign_up_user_type'] = user_type
+
     user = User.new.tap do |u|
       User.initialize_new_oauth_user(u, auth_hash, params)
       u.oauth_token = auth_hash.credentials&.token

--- a/dashboard/app/controllers/omniauth_callbacks_controller.rb
+++ b/dashboard/app/controllers/omniauth_callbacks_controller.rb
@@ -38,7 +38,7 @@ class OmniauthCallbacksController < Devise::OmniauthCallbacksController
   def clever
     return connect_provider if should_connect_provider?
 
-    user = find_user_by_credential
+    user = find_user_by_credential || find_clever_user_by_legacy_id # TODO: remove legacy_id lookup once Clever v3 migration is complete
     return link_accounts user if should_link_accounts?
     if user
       sign_in_clever user
@@ -154,6 +154,8 @@ class OmniauthCallbacksController < Devise::OmniauthCallbacksController
       hashed_email: hashed_email || '',
       credential_type: provider,
       authentication_id: auth_hash.uid,
+      # TODO: Change this to :v3 once Carl merges the new Clever OAuth versioning changes.
+      version: provider == AuthenticationOption::CLEVER ? AuthenticationOption::Clever::VERSION[:v3_1] : nil,
       data: new_data
     )
 
@@ -282,12 +284,14 @@ class OmniauthCallbacksController < Devise::OmniauthCallbacksController
   end
 
   private def sign_in_clever(user)
+    puts "Signing in clever user, #{auth_hash.to_json}"
     prepare_locale_cookie user
     user.update_oauth_credential_tokens auth_hash
     sign_in_user user
   end
 
   private def sign_up_clever
+    puts "Signing up clever user, #{auth_hash.to_json}"
     session[:sign_up_type] = AuthenticationOption::CLEVER
 
     auth_hash = inject_clever_data(auth_hash())
@@ -301,13 +305,24 @@ class OmniauthCallbacksController < Devise::OmniauthCallbacksController
       return redirect_to users_existing_account_path({provider: auth_hash.provider, email: email}) if email_already_exists
     end
 
+    # Get user type from Clever roles if not already specified
+    roles = auth_hash&.extra&.raw_info&.canonical&.data&.roles || {}
+    teacher_role_keys = %w[teacher staff].freeze
+    teacher_or_staff = roles.any? do |role, value|
+      teacher_role_keys.include?(role.to_s) && value.present?
+    end
+    user_type = teacher_or_staff ? User::TYPE_TEACHER : User::TYPE_STUDENT
+    puts "User type determined to be #{user_type} based on Clever roles: #{roles.to_json}"
+
     params = auth_params.presence || {}
+    cookies['sign_up_user_type'] = user_type unless params[:user_type]
     params[:user_type] = cookies['sign_up_user_type'] unless params[:user_type]
     user = User.new.tap do |u|
       User.initialize_new_oauth_user(u, auth_hash, params)
       u.oauth_token = auth_hash.credentials&.token
       u.oauth_token_expiration = auth_hash.credentials&.expires_at
       u.oauth_refresh_token = auth_hash.credentials&.refresh_token
+      u.user_type = user_type
       prepare_locale_cookie u
     end
 
@@ -320,6 +335,20 @@ class OmniauthCallbacksController < Devise::OmniauthCallbacksController
     User.find_by_credential \
       type: auth_hash.provider,
       id: auth_hash.uid
+  end
+
+  # Temporary method to find existing Clever users by their legacy_id field
+  private def find_clever_user_by_legacy_id
+    return nil unless auth_hash
+    # Teacher users in Clever have a legacy_id field in the v3 API response.
+    legacy_id = auth_hash.extra&.raw_info&.canonical&.data&.roles&.teacher&.legacy_id
+    return nil unless legacy_id
+
+    puts "Looking up clever user by legacy id: #{legacy_id}"
+
+    User.find_by_credential \
+      type: auth_hash.provider,
+      id: legacy_id
   end
 
   private def auth_hash

--- a/dashboard/app/controllers/omniauth_callbacks_controller.rb
+++ b/dashboard/app/controllers/omniauth_callbacks_controller.rb
@@ -333,7 +333,7 @@ class OmniauthCallbacksController < Devise::OmniauthCallbacksController
   private def find_clever_user_by_legacy_id
     return nil unless auth_hash
     # Teacher and staff users in Clever have a legacy_id field in the v3 API response.
-    roles = auth_hash.extra&.raw_info&.canonical&.data&.roles
+    roles = auth_hash.dig(:extra, :raw_info, :canonical, :data, :roles)
     return nil unless roles
 
     legacy_id = nil

--- a/dashboard/app/controllers/omniauth_callbacks_controller.rb
+++ b/dashboard/app/controllers/omniauth_callbacks_controller.rb
@@ -332,8 +332,16 @@ class OmniauthCallbacksController < Devise::OmniauthCallbacksController
   # Temporary method to find existing Clever users by their legacy_id field
   private def find_clever_user_by_legacy_id
     return nil unless auth_hash
-    # Teacher users in Clever have a legacy_id field in the v3 API response.
-    legacy_id = auth_hash.extra&.raw_info&.canonical&.data&.roles&.teacher&.legacy_id
+    # Teacher and staff users in Clever have a legacy_id field in the v3 API response.
+    roles = auth_hash.extra&.raw_info&.canonical&.data&.roles
+    return nil unless roles
+
+    legacy_id = nil
+    CLEVER_TEACHER_ROLE_KEYS.each do |role_key|
+      role = roles[role_key]
+      legacy_id = role&.legacy_id
+      break if legacy_id
+    end
     return nil unless legacy_id
 
     User.find_by_credential \

--- a/dashboard/app/controllers/omniauth_callbacks_controller.rb
+++ b/dashboard/app/controllers/omniauth_callbacks_controller.rb
@@ -22,6 +22,8 @@ class OmniauthCallbacksController < Devise::OmniauthCallbacksController
   ]
   TYPES_ROUTED_TO_ALL = AuthenticationOption::OAUTH_CREDENTIAL_TYPES - BROKEN_OUT_TYPES
 
+  CLEVER_TEACHER_ROLE_KEYS = %w[teacher staff].freeze
+
   # GET /users/auth/classlink/callback
   def classlink
     return connect_provider if should_connect_provider?
@@ -154,8 +156,7 @@ class OmniauthCallbacksController < Devise::OmniauthCallbacksController
       hashed_email: hashed_email || '',
       credential_type: provider,
       authentication_id: auth_hash.uid,
-      # TODO: Change this to :v3 once Carl merges the new Clever OAuth versioning changes.
-      version: provider == AuthenticationOption::CLEVER ? AuthenticationOption::Clever::VERSION[:v3_1] : nil,
+      version: provider == AuthenticationOption::CLEVER ? AuthenticationOption::Clever::VERSION[:v3] : nil,
       data: new_data
     )
 
@@ -284,14 +285,12 @@ class OmniauthCallbacksController < Devise::OmniauthCallbacksController
   end
 
   private def sign_in_clever(user)
-    puts "Signing in clever user, #{auth_hash.to_json}"
     prepare_locale_cookie user
     user.update_oauth_credential_tokens auth_hash
     sign_in_user user
   end
 
   private def sign_up_clever
-    puts "Signing up clever user, #{auth_hash.to_json}"
     session[:sign_up_type] = AuthenticationOption::CLEVER
 
     auth_hash = inject_clever_data(auth_hash())
@@ -305,14 +304,7 @@ class OmniauthCallbacksController < Devise::OmniauthCallbacksController
       return redirect_to users_existing_account_path({provider: auth_hash.provider, email: email}) if email_already_exists
     end
 
-    # Get user type from Clever roles if not already specified
-    roles = auth_hash&.extra&.raw_info&.canonical&.data&.roles || {}
-    teacher_role_keys = %w[teacher staff].freeze
-    teacher_or_staff = roles.any? do |role, value|
-      teacher_role_keys.include?(role.to_s) && value.present?
-    end
-    user_type = teacher_or_staff ? User::TYPE_TEACHER : User::TYPE_STUDENT
-    puts "User type determined to be #{user_type} based on Clever roles: #{roles.to_json}"
+    user_type = auth_hash.info&.user_type&.downcase
 
     params = auth_params.presence || {}
     cookies['sign_up_user_type'] = user_type
@@ -343,8 +335,6 @@ class OmniauthCallbacksController < Devise::OmniauthCallbacksController
     # Teacher users in Clever have a legacy_id field in the v3 API response.
     legacy_id = auth_hash.extra&.raw_info&.canonical&.data&.roles&.teacher&.legacy_id
     return nil unless legacy_id
-
-    puts "Looking up clever user by legacy id: #{legacy_id}"
 
     User.find_by_credential \
       type: auth_hash.provider,
@@ -429,7 +419,16 @@ class OmniauthCallbacksController < Devise::OmniauthCallbacksController
     return if auth.nil?
     dob = auth[:dob] || auth.dig(:extra, :raw_info, :canonical, :data, :dob)
     gender = auth[:gender] || auth.dig(:extra, :raw_info, :canonical, :data, :gender)
-    clever_data = OmniAuth::AuthHash.new(dob: dob, gender: gender)
+
+    # Get user type from Clever roles to to set in info hash. This maintains compatibility
+    # with existing logic that reads user_type from info hash during sign up.
+    roles = auth&.extra&.raw_info&.canonical&.data&.roles || {}
+    teacher_or_staff = roles.any? do |role, value|
+      CLEVER_TEACHER_ROLE_KEYS.include?(role.to_s) && value.present?
+    end
+    user_type = teacher_or_staff ? User::TYPE_TEACHER : User::TYPE_STUDENT
+
+    clever_data = OmniAuth::AuthHash.new(dob: dob, gender: gender, user_type: user_type)
     auth.info&.merge!(clever_data)
     auth
   end

--- a/dashboard/app/controllers/omniauth_callbacks_controller.rb
+++ b/dashboard/app/controllers/omniauth_callbacks_controller.rb
@@ -430,7 +430,7 @@ class OmniauthCallbacksController < Devise::OmniauthCallbacksController
 
     # Get user type from Clever roles to set in info hash. This maintains compatibility
     # with existing logic that reads user_type from info hash during sign up.
-    roles = auth&.extra&.raw_info&.canonical&.data&.roles || {}
+    roles = auth.dig(:extra, :raw_info, :canonical, :data, :roles) || {}
     teacher_or_staff = roles.any? do |role, value|
       CLEVER_TEACHER_ROLE_KEYS.include?(role.to_s) && value.present?
     end

--- a/dashboard/lib/services/user/multi_auth_migrator.rb
+++ b/dashboard/lib/services/user/multi_auth_migrator.rb
@@ -55,6 +55,8 @@ module Services
           ao.credential_type = provider
           ao.authentication_id = user.uid
           ao.data = oauth_token_json
+          # TODO: Change this to :v3 once Carl merges the new Clever OAuth versioning changes.
+          ao.version = provider == AuthenticationOption::CLEVER ? AuthenticationOption::Clever::VERSION[:v3_1] : nil
         elsif user.email.present? || user.hashed_email.present?
           ao.credential_type = AuthenticationOption::EMAIL
         else

--- a/dashboard/lib/services/user/multi_auth_migrator.rb
+++ b/dashboard/lib/services/user/multi_auth_migrator.rb
@@ -55,8 +55,7 @@ module Services
           ao.credential_type = provider
           ao.authentication_id = user.uid
           ao.data = oauth_token_json
-          # TODO: Change this to :v3 once Carl merges the new Clever OAuth versioning changes.
-          ao.version = provider == AuthenticationOption::CLEVER ? AuthenticationOption::Clever::VERSION[:v3_1] : nil
+          ao.version = provider == AuthenticationOption::CLEVER ? AuthenticationOption::Clever::VERSION[:v3] : nil
         elsif user.email.present? || user.hashed_email.present?
           ao.credential_type = AuthenticationOption::EMAIL
         else

--- a/dashboard/test/controllers/omniauth_callbacks_controller_test.rb
+++ b/dashboard/test/controllers/omniauth_callbacks_controller_test.rb
@@ -15,7 +15,7 @@ class OmniauthCallbacksControllerTest < ActionController::TestCase
         "name": "Maurice Schaefer",
         "first_name": "Maurice",
         "last_name": "Schaefer",
-        "email": "test@example.com",
+        "email": "#{Faker::Internet.email}",
         "user_type": "user"
       },
       "credentials": {
@@ -51,7 +51,7 @@ class OmniauthCallbacksControllerTest < ActionController::TestCase
             "data": {
               "created": "2024-02-13T16:43:22.075Z",
               "district": "54299f6ecc544da87c000070",
-              "email": "test@example.com",
+              "email": "#{Faker::Internet.email}",
               "last_modified": "2024-02-13T16:43:22.075Z",
               "name": {
                 "first": "Maurice",
@@ -193,7 +193,7 @@ class OmniauthCallbacksControllerTest < ActionController::TestCase
     auth = generate_auth_user_hash(
       provider: 'clever',
       uid: '1111',
-      email: 'first_last@clever-teacher.xx',
+      email: Faker::Internet.email,
       user_type: 'user'
     )
     auth.extra[:raw_info][:canonical] = {data: {roles: {teacher: {legacy_id: '123456'}}}}
@@ -236,7 +236,7 @@ class OmniauthCallbacksControllerTest < ActionController::TestCase
     auth = generate_auth_user_hash(
       provider: 'clever',
       uid: '2222',
-      email: 'staff_member@clever-staff.xx',
+      email: Faker::Internet.email,
       user_type: 'user'
     )
     auth.extra[:raw_info][:canonical] = {data: {roles: {staff: {legacy_id: '654321'}}}}

--- a/dashboard/test/controllers/omniauth_callbacks_controller_test.rb
+++ b/dashboard/test/controllers/omniauth_callbacks_controller_test.rb
@@ -10,12 +10,13 @@ class OmniauthCallbacksControllerTest < ActionController::TestCase
   TEST_CLEVER_STUDENT_DATA = OmniAuth::AuthHash.new(JSON.parse(<<~JSON
     {
       "provider": "clever",
-      "uid": "5966ed736b21538e3c000006",
+      "uid": "65cb9c1570fcf808965b9870",
       "info": {
-        "name": "Elizabeth Smith",
-        "first_name": "Elizabeth",
-        "last_name": "Smith",
-        "user_type": "student"
+        "name": "Maurice Schaefer",
+        "first_name": "Maurice",
+        "last_name": "Schaefer",
+        "email": "test@example.com",
+        "user_type": "user"
       },
       "credentials": {
         "token": "faketoken123455678",
@@ -24,11 +25,11 @@ class OmniauthCallbacksControllerTest < ActionController::TestCase
       "extra": {
         "raw_info": {
           "me": {
-            "type": "student",
+            "type": "user",
             "data": {
-              "id": "5966ed736b21538e3c000006",
-              "district": "59484d29ae5dee0001fd3291",
-              "type": "student",
+              "id": "65cb9c1570fcf808965b9870",
+              "district": "54299f6ecc544da87c000070",
+              "type": "user",
               "authorized_by": "district"
             },
             "links": [
@@ -38,40 +39,44 @@ class OmniauthCallbacksControllerTest < ActionController::TestCase
               },
               {
                 "rel": "canonical",
-                "uri": "/v2.1/students/5966ed736b21538e3c000006"
+                "uri": "/v3.0/users/65cb9c1570fcf808965b9870"
               },
               {
                 "rel": "district",
-                "uri": "/v2.1/districts/59484d29ae5dee0001fd3291"
+                "uri": "/v3.0/districts/54299f6ecc544da87c000070"
               }
             ]
           },
           "canonical": {
             "data": {
-              "created": "2017-07-13T03:48:03.512Z",
-              "district": "59484d29ae5dee0001fd3291",
-              "dob": "2000-05-21T00:00:00.000Z",
-              "enrollments": [],
-              "gender": "M",
-              "hispanic_ethnicity": "",
-              "last_modified": "2017-11-02T00:49:40.504Z",
+              "created": "2024-02-13T16:43:22.075Z",
+              "district": "54299f6ecc544da87c000070",
+              "email": "test@example.com",
+              "last_modified": "2024-02-13T16:43:22.075Z",
               "name": {
-                "first": "Elizabeth",
-                "last": "Smith",
-                "middle": ""
+                "first": "Maurice",
+                "last": "Schaefer"
               },
-              "race": "",
-              "school": "5966ed6cf9d478523c000004",
-              "schools": [
-                "5966ed6cf9d478523c000004"
-              ],
-              "sis_id": "202",
-              "id": "5966ed736b21538e3c000006"
+              "roles": {
+                "student": {
+                  "dob": "2012-02-12T00:00:00.000Z",
+                  "enrollments": [],
+                  "gender": "X",
+                  "hispanic_ethnicity": "Y",
+                  "race": "Race",
+                  "school": "65cb9c1570fcf808965b986d",
+                  "schools": [
+                    "65cb9c1570fcf808965b986d"
+                  ],
+                  "sis_id": "10435651"
+                }
+              },
+              "id": "65cb9c1570fcf808965b9870"
             },
             "links": [
               {
                 "rel": "self",
-                "uri": "/v2.1/students/5966ed736b21538e3c000006"
+                "uri": "/v3.0/users/65cb9c1570fcf808965b9870"
               }
             ]
           }
@@ -192,10 +197,23 @@ class OmniauthCallbacksControllerTest < ActionController::TestCase
         nickname: '',
         name: {'first' => 'Hat', 'last' => 'Cat'},
         email: 'first_last@clever-teacher.xx',
-        user_type: 'teacher',
+        user_type: 'user',
         dob: nil,
         gender: nil
       },
+      extra: {
+        raw_info: {
+          canonical: {
+            data: {
+              roles: {
+                teacher: {
+                  sis_id: '123456'
+                }
+              }
+            }
+          }
+        }
+      }
     )
     @request.env['omniauth.auth'] = auth
     @request.env['omniauth.params'] = {}
@@ -219,10 +237,23 @@ class OmniauthCallbacksControllerTest < ActionController::TestCase
         nickname: '',
         name: {'first' => 'Hat', 'last' => 'Cat'},
         email: nil,
-        user_type: 'teacher',
+        user_type: 'user',
         dob: nil,
         gender: nil
       },
+      extra: {
+        raw_info: {
+          canonical: {
+            data: {
+              roles: {
+                teacher: {
+                  sis_id: '123456'
+                }
+              }
+            }
+          }
+        }
+      }
     )
     @request.env['omniauth.auth'] = auth
     @request.env['omniauth.params'] = {}

--- a/dashboard/test/controllers/omniauth_callbacks_controller_test.rb
+++ b/dashboard/test/controllers/omniauth_callbacks_controller_test.rb
@@ -61,9 +61,9 @@ class OmniauthCallbacksControllerTest < ActionController::TestCase
                 "student": {
                   "dob": "2012-02-12T00:00:00.000Z",
                   "enrollments": [],
-                  "gender": "X",
-                  "hispanic_ethnicity": "Y",
-                  "race": "Race",
+                  "gender": "",
+                  "hispanic_ethnicity": "",
+                  "race": "",
                   "school": "65cb9c1570fcf808965b986d",
                   "schools": [
                     "65cb9c1570fcf808965b986d"
@@ -190,31 +190,13 @@ class OmniauthCallbacksControllerTest < ActionController::TestCase
   end
 
   test "login: authorizing with unknown clever teacher account" do
-    auth = OmniAuth::AuthHash.new(
-      uid: '1111',
+    auth = generate_auth_user_hash(
       provider: 'clever',
-      info: {
-        nickname: '',
-        name: {'first' => 'Hat', 'last' => 'Cat'},
-        email: 'first_last@clever-teacher.xx',
-        user_type: 'user',
-        dob: nil,
-        gender: nil
-      },
-      extra: {
-        raw_info: {
-          canonical: {
-            data: {
-              roles: {
-                teacher: {
-                  sis_id: '123456'
-                }
-              }
-            }
-          }
-        }
-      }
+      uid: '1111',
+      email: 'first_last@clever-teacher.xx',
+      user_type: 'user'
     )
+    auth.extra[:raw_info][:canonical] = {data: {roles: {teacher: {sis_id: '123456'}}}}
     @request.env['omniauth.auth'] = auth
     @request.env['omniauth.params'] = {}
 
@@ -230,31 +212,13 @@ class OmniauthCallbacksControllerTest < ActionController::TestCase
   end
 
   test "login: authorizing with unknown clever teacher account needs additional information" do
-    auth = OmniAuth::AuthHash.new(
-      uid: '1111',
+    auth = generate_auth_user_hash(
       provider: 'clever',
-      info: {
-        nickname: '',
-        name: {'first' => 'Hat', 'last' => 'Cat'},
-        email: nil,
-        user_type: 'user',
-        dob: nil,
-        gender: nil
-      },
-      extra: {
-        raw_info: {
-          canonical: {
-            data: {
-              roles: {
-                teacher: {
-                  legacy_id: '123456'
-                }
-              }
-            }
-          }
-        }
-      }
+      uid: '1111',
+      email: nil,
+      user_type: 'user'
     )
+    auth.extra[:raw_info][:canonical] = {data: {roles: {teacher: {legacy_id: '123456'}}}}
     @request.env['omniauth.auth'] = auth
     @request.env['omniauth.params'] = {}
 
@@ -266,6 +230,29 @@ class OmniauthCallbacksControllerTest < ActionController::TestCase
     assert_template 'omniauth/redirect'
     partial_user = User.new_from_partial_registration(session)
     assert_empty partial_user.email
+  end
+
+  test "login: authorizing with unknown clever staff account creates teacher" do
+    auth = generate_auth_user_hash(
+      provider: 'clever',
+      uid: '2222',
+      email: 'staff_member@clever-staff.xx',
+      user_type: 'user'
+    )
+    auth.extra[:raw_info][:canonical] = {data: {roles: {staff: {legacy_id: '654321'}}}}
+    @request.env['omniauth.auth'] = auth
+    @request.env['omniauth.params'] = {}
+
+    assert_does_not_create(User) do
+      get :clever
+    end
+
+    assert_equal 200, @response.status
+    assert_template 'omniauth/redirect'
+    partial_user = User.new_from_partial_registration(session)
+    assert_equal AuthenticationOption::CLEVER, partial_user.provider
+    assert_equal auth.uid, partial_user.uid
+    assert_equal User::TYPE_TEACHER, partial_user.user_type
   end
 
   test "login: authorizing with unknown clever student account creates student" do
@@ -434,6 +421,31 @@ class OmniauthCallbacksControllerTest < ActionController::TestCase
     end
 
     # Then I am signed in
+    user.reload
+    assert_equal user.id, signed_in_user_id
+  end
+
+  test 'clever: signs in user if user is found by legacy_id' do
+    legacy_id = 'legacy-id-123'
+    user = create(:teacher)
+    create(
+      :authentication_option,
+      user: user,
+      credential_type: AuthenticationOption::CLEVER,
+      authentication_id: legacy_id
+    )
+
+    auth = generate_auth_user_hash \
+      provider: AuthenticationOption::CLEVER,
+      uid: 'new-uid'
+    auth.extra[:raw_info][:canonical] = {data: {roles: {teacher: {legacy_id: legacy_id}}}}
+
+    @request.env['omniauth.auth'] = auth
+    @request.env['omniauth.params'] = {}
+    assert_does_not_create(User) do
+      get :clever
+    end
+
     user.reload
     assert_equal user.id, signed_in_user_id
   end

--- a/dashboard/test/controllers/omniauth_callbacks_controller_test.rb
+++ b/dashboard/test/controllers/omniauth_callbacks_controller_test.rb
@@ -247,7 +247,7 @@ class OmniauthCallbacksControllerTest < ActionController::TestCase
             data: {
               roles: {
                 teacher: {
-                  sis_id: '123456'
+                  legacy_id: '123456'
                 }
               }
             }
@@ -285,21 +285,12 @@ class OmniauthCallbacksControllerTest < ActionController::TestCase
   end
 
   test "login: authorizing with known clever student account does not alter email or hashed email" do
-    clever_student = create(:student, provider: 'clever', uid: '111133')
+    clever_student = create(:student, provider: 'clever', uid: TEST_CLEVER_STUDENT_DATA.uid)
     student_hashed_email = clever_student.hashed_email
 
-    auth = OmniAuth::AuthHash.new(
-      uid: '111133',
-      provider: 'clever',
-      info: {
-        nickname: '',
-        name: {'first' => 'Hat', 'last' => 'Cat'},
-        email: 'hat.cat@example.com',
-        user_type: 'student',
-        dob: Time.zone.today - 10.years,
-        gender: 'f'
-      },
-    )
+    auth = TEST_CLEVER_STUDENT_DATA.dup
+    auth.info.email = 'different-email@example.com' # different email than the one on record
+
     @request.env['omniauth.auth'] = auth
     @request.env['omniauth.params'] = {}
 
@@ -1015,8 +1006,8 @@ class OmniauthCallbacksControllerTest < ActionController::TestCase
   end
 
   test 'login: clever does not silently add authentication_option to migrated student with matching email' do
-    email = 'test@foo.xyz'
-    uid = '654321'
+    email = TEST_CLEVER_STUDENT_DATA.info.email
+    uid =  TEST_CLEVER_STUDENT_DATA.uid
     user = create(:student, email: email)
     auth = generate_auth_user_hash(provider: AuthenticationOption::CLEVER, uid: uid, user_type: User::TYPE_STUDENT, email: email)
     @request.env['omniauth.auth'] = auth
@@ -1036,7 +1027,6 @@ class OmniauthCallbacksControllerTest < ActionController::TestCase
 
     auth = generate_auth_user_hash(
       provider: AuthenticationOption::CLEVER,
-      user_type: User::TYPE_TEACHER,
       email: email
     )
     @request.env['omniauth.auth'] = auth

--- a/dashboard/test/controllers/omniauth_callbacks_controller_test.rb
+++ b/dashboard/test/controllers/omniauth_callbacks_controller_test.rb
@@ -276,7 +276,7 @@ class OmniauthCallbacksControllerTest < ActionController::TestCase
     student_hashed_email = clever_student.hashed_email
 
     auth = TEST_CLEVER_STUDENT_DATA.dup
-    auth.info.email = 'different-email@example.com' # different email than the one on record
+    auth.info.email = Faker::Internet.email # different email than the one on record
 
     @request.env['omniauth.auth'] = auth
     @request.env['omniauth.params'] = {}
@@ -426,7 +426,7 @@ class OmniauthCallbacksControllerTest < ActionController::TestCase
   end
 
   test 'clever: signs in user if user is found by legacy_id' do
-    legacy_id = 'legacy-id-123'
+    legacy_id = SecureRandom.alphanumeric(10)
     user = create(:teacher)
     create(
       :authentication_option,

--- a/dashboard/test/controllers/omniauth_callbacks_controller_test.rb
+++ b/dashboard/test/controllers/omniauth_callbacks_controller_test.rb
@@ -196,7 +196,7 @@ class OmniauthCallbacksControllerTest < ActionController::TestCase
       email: 'first_last@clever-teacher.xx',
       user_type: 'user'
     )
-    auth.extra[:raw_info][:canonical] = {data: {roles: {teacher: {sis_id: '123456'}}}}
+    auth.extra[:raw_info][:canonical] = {data: {roles: {teacher: {legacy_id: '123456'}}}}
     @request.env['omniauth.auth'] = auth
     @request.env['omniauth.params'] = {}
 

--- a/dashboard/test/lib/services/user/multi_auth_migrator_test.rb
+++ b/dashboard/test/lib/services/user/multi_auth_migrator_test.rb
@@ -73,7 +73,7 @@ class Services::User::MultiAuthMigratorTest < ActiveSupport::TestCase
         migrate
         _(user.authentication_options.first.credential_type).must_equal AuthenticationOption::CLEVER
         _(user.authentication_options.first.data).wont_be_nil
-        _(user.authentication_options.first.version).must_equal AuthenticationOption::Clever::VERSION[:v3_1]
+        _(user.authentication_options.first.version).must_equal AuthenticationOption::Clever::VERSION[:v3]
       end
     end
 

--- a/dashboard/test/lib/services/user/multi_auth_migrator_test.rb
+++ b/dashboard/test/lib/services/user/multi_auth_migrator_test.rb
@@ -73,6 +73,7 @@ class Services::User::MultiAuthMigratorTest < ActiveSupport::TestCase
         migrate
         _(user.authentication_options.first.credential_type).must_equal AuthenticationOption::CLEVER
         _(user.authentication_options.first.data).wont_be_nil
+        _(user.authentication_options.first.version).must_equal AuthenticationOption::Clever::VERSION[:v3_1]
       end
     end
 


### PR DESCRIPTION
This PR bumps to the newest [omniauth-clever](https://github.com/code-dot-org/omniauth-clever) plugin version, and adds support for the changes in Clever API v3. It does this with the following:

- Update the omniauth_callbacks_controller Clever controller action to find user by `uid` or `legacy_id`. This will allow users to continue logging in before we migrate users' authentication_options to the new v3 version. It does this via a temporary method named `find_clever_user_by_legacy_id`
- For new Clever users, start creating v3 auth options with the new `uid`, and populating the `version` field in the auth option
- For users who add a Clever login auth option, populate the `version` field when creating the new auth option
- Update unit test data to reflect the new Clever v3 auth response
- Add 2 new unit tests to test for 1) staff role type and 2) looking up a user via `legacy_id`

## Additional Context

The auth hash returned from Clever v2.1 contained a `user_type` who's value was the type of user. Example:

```json
{
	"provider": "clever",
	"uid": "<old-uid>",
	"info": {
		"name": "Russell Leon",
		"user_type": "teacher"
	},
  ...
}
```

The auth hash returned from Clever v3.0 now allows for a single user to have multiple user types (e.g. a `staff` and `teacher`). It pushes these identifiers further down into a nested object, and also includes a `legacy_id`, which maps to the old `uid` for each non-student user (student users can only be students, therefore their `uid` value did not change between v2.1 and v3.0).

You'll notice the top level `user_type` has now been changed to `user` rather than denoting the actual type of user.

```json
{
	"provider": "clever",
	"uid": "<new-uid>",
	"info": {
		"name": "Russell Leon",
		"user_type": "user"
	},
	"extra": {
		"raw_info": {
			"canonical": {
				"data": {
					"roles": {
						"teacher": {
							"legacy_id": "<old-uid>"
						}
					}
				}
			}
		}
	}
}
```

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->



## Links
<!--  Links to relevant external resources.
      - spec docs, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- https://codedotorg.atlassian.net/browse/P20-1654
- https://codedotorg.atlassian.net/browse/P20-1788

## Testing story
<!--  Does your change include appropriate tests?
      - If so, please describe how the tests included in this PR are sufficient.
      - If not, please explain why this change does not need to be tested. -->



## Deployment strategy
<!--  Any special steps required to deploy this, besides merging?
      - Are there database migrations or manual steps?
      - Does this require coordination with other teams or systems? -->



## Follow-up work
<!--  List any clean-up or technical debt that will be addressed in future work.
      - Include Jira links where applicable.
      - Are there any known limitations or improvements planned? -->



## Privacy
<!--  How does this change impact Student & Teacher privacy?
      - Does this collect, use, share, or modify PII, either new or existing? -->



## Security
<!--  How does this change impact our security surface-area?
      - Do API's touched have the right auth?
      - Do infra changes impact our attack surface or encryption?
-->



## Caching
<!--  How does this change impact caching behavior?
      - Are cache keys or invalidation strategies affected?
      - Will this require cache warming or invalidation after deployment? -->



## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
