### PR TITLE
Fix `Cdo::Buffer` Deadlock

### DIFF
--- a/lib/cdo/buffer.rb
+++ b/lib/cdo/buffer.rb
@@ -68,10 +68,13 @@ module Cdo
       if (size = size([object])) > @batch_size
         raise ArgumentError, "Object size (#{size}) exceeds batch size (#{@batch_size})"
       end
+
       @buffer.synchronize do
         @buffer << BufferObject.new(object, now)
-        schedule_flush
       end
+
+      # Schedule outside the buffer lock.
+      schedule_flush
     end
 
     # Flush existing buffered objects.
@@ -122,9 +125,15 @@ module Cdo
     # Schedule a flush in the future when the next batch is ready.
     # @param [Boolean] force flush batch even if not full.
     private def schedule_flush(force: false)
+      delay = nil
+
       @buffer.synchronize do
-        @task.reschedule {batch_ready(force)} unless @buffer.empty?
+        return if @buffer.empty?
+        delay = batch_ready(force)
       end
+
+      # Reschedule outside the buffer lock.
+      @task.reschedule {delay}
     end
 
     # Determine when the next batch of existing buffered objects will be ready to be flushed.
@@ -169,13 +178,23 @@ module Cdo
     end
 
     private def reset_if_forked
+      old_task = nil
+
       @buffer.synchronize do
-        if $$ != @ruby_pid
-          @buffer.clear
-          @task.cancel
-          @ruby_pid = $$
-        end
+        return if $$ == @ruby_pid
+
+        @buffer.clear
+        old_task = @task
+
+        # Recreate task in the forked process.
+        @task = RescheduledTask.new(0.0) {flush_batch}.
+          with_observer {schedule_flush}
+
+        @ruby_pid = $$
       end
+
+      # Cancel outside the buffer lock.
+      old_task&.cancel
     end
   end
 end

--- a/lib/test/cdo/test_buffer.rb
+++ b/lib/test/cdo/test_buffer.rb
@@ -182,6 +182,19 @@ class BufferTest < Minitest::Test
     # If old behavior exists, the test will raise before it gets here.
     assert_equal 0, b.flushes
   end
+
+  def test_reset_if_forked_does_not_cancel_while_holding_buffer_lock
+    b = TestBuffer.new(batch_count: 1, max_interval: 999)
+
+    buffer_monitor = b.instance_variable_get(:@buffer)
+    b.instance_variable_set(:@task, AssertNotHoldingBufferLockTask.new(buffer_monitor))
+
+    # Force the fork-detection path
+    b.instance_variable_set(:@ruby_pid, -1)
+
+    # This calls reset_if_forked, which should cancel outside the lock
+    b.buffer('foo')
+  end
 end
 
 require 'minitest/benchmark'

--- a/lib/test/cdo/test_buffer.rb
+++ b/lib/test/cdo/test_buffer.rb
@@ -130,10 +130,10 @@ class BufferTest < Minitest::Test
 
   # Help reproduce a thread-safety bug by prepending `sleep` to several methods.
   class ThreadSafeTestBuffer < TestBuffer
-    %w(flush batch_ready buffer).each do |m|
-      define_method(m) do |*args|
+    %w(flush batch_ready buffer schedule_flush).each do |m|
+      define_method(m) do |*args, **kwargs|
         sleep @max_interval
-        super(*args)
+        super(*args, **kwargs)
       end
     end
   end
@@ -145,6 +145,42 @@ class BufferTest < Minitest::Test
     b = ThreadSafeTestBuffer.new(max_interval: duration.to_f / (n * 2))
     n.times {b.buffer('foo')}
     b.flush!
+  end
+
+  class AssertNotHoldingBufferLockTask
+    def initialize(buffer_monitor)
+      @buffer_monitor = buffer_monitor
+    end
+
+    def reschedule
+      if @buffer_monitor.mon_owned?
+        raise "BUG: called task.reschedule while holding buffer monitor"
+      end
+      yield if block_given?
+    end
+
+    def cancel
+      if @buffer_monitor.mon_owned?
+        raise "BUG: called task.cancel while holding buffer monitor"
+      end
+    end
+
+    def wait(*)
+      true
+    end
+  end
+
+  def test_schedule_flush_does_not_reschedule_while_holding_buffer_lock
+    b = TestBuffer.new(batch_count: 1, max_interval: 999)
+
+    buffer_monitor = b.instance_variable_get(:@buffer)
+    b.instance_variable_set(:@task, AssertNotHoldingBufferLockTask.new(buffer_monitor))
+
+    # This triggers schedule_flush -> @task.reschedule
+    b.buffer('foo')
+
+    # If old behavior exists, the test will raise before it gets here.
+    assert_equal 0, b.flushes
   end
 end
 


### PR DESCRIPTION
https://codedotorg.atlassian.net/browse/INF-2021

@stephenliang obtained thread backtraces from child puma processes that have high queued (`backlog`) requests and identified that stuck threads were due to locks implemented by `Cdo::Buffer`.

ChatGPT created this patch to `Cdo::Buffer` by inspecting the thread backtraces and also this explanation
## Root cause

`Cdo::Buffer` protects its internal state with a single `Monitor` lock. While holding that lock, it sometimes called into `Concurrent::ScheduledTask` (`@task.reschedule` / `@task.cancel`). The scheduled task implementation has its own internal locks. Meanwhile, the scheduled task thread can call back into `Cdo::Buffer` to flush, which needs the buffer lock.

This creates a classic “lock order inversion” risk:

- Thread A (request thread): holds **buffer lock** → tries to acquire **scheduled task lock** (reschedule)
- Thread B (scheduler thread): holds **scheduled task lock** → tries to acquire **buffer lock** (flush)

If that overlap happens, both threads wait forever → the Puma worker runs out of usable request threads → backlog grows.

## Fix

Ensure `Cdo::Buffer` never calls `@task.reschedule` or `@task.cancel` while holding the buffer lock:

- `buffer(object)`: append to the buffer under the monitor, then call `schedule_flush` after releasing it.
- `schedule_flush`: compute the next flush delay under the monitor, then call `@task.reschedule` outside the lock.
- `reset_if_forked`: capture the old task and replace it inside the lock, then cancel the old task outside the lock.

This preserves thread-safety while avoiding lock-order inversion between `Cdo::Buffer` and `concurrent-ruby`.



## Testing story
The 2 new unit tests deterministically fail on the `staging` branch which does not yet have the `Cdo::Buffer` fixes:

```bash
lib % git status

On branch staging
Your branch is up to date with 'origin/staging'.

Changes not staged for commit:
  (use "git add <file>..." to update what will be committed)
  (use "git restore <file>..." to discard changes in working directory)
	modified:   test/cdo/test_buffer.rb

no changes added to commit (use "git add" and/or "git commit -a")
lib % bundle exec ruby -Itest ./test/cdo/test_buffer.rb

WARNING: MYSQL_OPT_RECONNECT is deprecated and will be removed in a future version.
Started with run options --seed 39140

BufferTest
  test_min_interval_no_flush                                      PASS (0.55s)
  test_buffer_thread_safety                                       PASS (1.76s)
  test_max_interval                                               PASS (0.20s)
  test_batch_size_given_small_data_should_succeed                 PASS (0.00s)
  test_log_repeat_flushes                                         PASS (0.10s)
  test_reset_if_forked_does_not_cancel_while_holding_buffer_lock ERROR (0.00s)
Minitest::UnexpectedError:         RuntimeError: BUG: called task.cancel while holding buffer monitor
            ./test/cdo/test_buffer.rb:164:in `cancel'
            /Users/suresh/code-dot-org/lib/cdo/buffer.rb:175:in `block in reset_if_forked'
            /Users/suresh/.rbenv/versions/3.1.7/lib/ruby/3.1.0/monitor.rb:202:in `synchronize'
            /Users/suresh/.rbenv/versions/3.1.7/lib/ruby/3.1.0/monitor.rb:202:in `mon_synchronize'
            /Users/suresh/code-dot-org/lib/cdo/buffer.rb:172:in `reset_if_forked'
            /Users/suresh/code-dot-org/lib/cdo/buffer.rb:67:in `buffer'
            ./test/cdo/test_buffer.rb:196:in `test_reset_if_forked_does_not_cancel_while_holding_buffer_lock'

  test_object_exceeding_batch_size_should_raise_exception         PASS (0.00s)
  test_min_interval                                               PASS (0.31s)
  test_batch_count                                                PASS (0.00s)
  test_fork                                                       PASS (0.06s)
  test_schedule_flush_does_not_reschedule_while_holding_buffer_lockERROR (0.00s)
Minitest::UnexpectedError:         RuntimeError: BUG: called task.reschedule while holding buffer monitor
            ./test/cdo/test_buffer.rb:157:in `reschedule'
            /Users/suresh/code-dot-org/lib/cdo/buffer.rb:126:in `block in schedule_flush'
            /Users/suresh/.rbenv/versions/3.1.7/lib/ruby/3.1.0/monitor.rb:202:in `synchronize'
            /Users/suresh/.rbenv/versions/3.1.7/lib/ruby/3.1.0/monitor.rb:202:in `mon_synchronize'
            /Users/suresh/code-dot-org/lib/cdo/buffer.rb:125:in `schedule_flush'
            /Users/suresh/code-dot-org/lib/cdo/buffer.rb:73:in `block in buffer'
            /Users/suresh/.rbenv/versions/3.1.7/lib/ruby/3.1.0/monitor.rb:202:in `synchronize'
            /Users/suresh/.rbenv/versions/3.1.7/lib/ruby/3.1.0/monitor.rb:202:in `mon_synchronize'
            /Users/suresh/code-dot-org/lib/cdo/buffer.rb:71:in `buffer'
            ./test/cdo/test_buffer.rb:180:in `test_schedule_flush_does_not_reschedule_while_holding_buffer_lock'


BufferBench
bench_linear_performance	 0.000138	 0.000116	 0.021807	 0.020817	 0.034457	 0.075192	 0.141552
  bench_linear_performance                                        PASS (0.53s)

Finished in 3.52514s
12 tests, 20 assertions, 0 failures, 2 errors, 0 skips
```

Also provisioning an adhoc:
`bundle exec rake adhoc:start RAILS_ENV=adhoc STACK_NAME=adhoc-fix-buffer-deadlock`

## Deployment strategy
<!--  Any special steps required to deploy this, besides merging?
      - Are there database migrations or manual steps?
      - Does this require coordination with other teams or systems? -->



## Follow-up work
<!--  List any clean-up or technical debt that will be addressed in future work.
      - Include Jira links where applicable.
      - Are there any known limitations or improvements planned? -->



## Privacy
<!--  How does this change impact Student & Teacher privacy?
      - Does this collect, use, share, or modify PII, either new or existing? -->



## Security
<!--  How does this change impact our security surface-area?
      - Do API's touched have the right auth?
      - Do infra changes impact our attack surface or encryption?
-->



## Caching
<!--  How does this change impact caching behavior?
      - Are cache keys or invalidation strategies affected?
      - Will this require cache warming or invalidation after deployment? -->



## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
