### PR TITLE
Allow selecting outside selected unit for much easier testing

### DIFF
--- a/apps/src/templates/studentSnapshot/header/index.tsx
+++ b/apps/src/templates/studentSnapshot/header/index.tsx
@@ -135,7 +135,7 @@ const Header: React.FC<HeaderProps> = ({
     <div className={styles.header}>
       <div className={styles.headerColumn}>
         <UnitSelectorV2
-          filterToSelectedCourse={true}
+          filterToSelectedCourse={false}
           className={styles.unitSelector}
           isLabelVisible={true}
           labelText="Unit"


### PR DESCRIPTION
The current unit selector on Student Snapshot only allows lessons in the same unit.

We may want this in the future, but it prevents us from testing on accounts with student progress (e.g. I have an account I am using that currently has AIF 2 assigned, but AIF 1 has progress on it that I want to check)

This PR simply allows for selecting outside the unit.
