### PR TITLE
Lock TimerSet before ScheduledTask to avoid deadlock

### DIFF
--- a/lib/cdo/buffer.rb
+++ b/lib/cdo/buffer.rb
@@ -95,13 +95,18 @@ module Cdo
       # @yieldreturn [Float] number of seconds to wait for before executing the task.
       #   Passed as a block instead of an argument for thread-safety.
       def reschedule
-        synchronize do
-          delay = yield
-          if compare_and_set_state(:pending, :fulfilled, :rejected, :unscheduled)
-            event.reset
-            ns_schedule(delay)
-          else
-            super(delay)
+        # Lock TimerSet.synchronize before ScheduledTask.synchronize to avoid deadlock
+        # this makes it match the order that TimerSet#process_tasks background thread uses
+        # the locks so there's no risk of lock inversion.
+        Concurrent.global_timer_set.send(:synchronize) do
+          synchronize do
+            delay = yield
+            if compare_and_set_state(:pending, :fulfilled, :rejected, :unscheduled)
+              event.reset
+              ns_schedule(delay)
+            else
+              super(delay)
+            end
           end
         end
       end

--- a/lib/cdo/buffer.rb
+++ b/lib/cdo/buffer.rb
@@ -98,6 +98,8 @@ module Cdo
         # Lock TimerSet.synchronize before ScheduledTask.synchronize to avoid deadlock
         # this makes it match the order that TimerSet#process_tasks background thread uses
         # the locks so there's no risk of lock inversion.
+        #
+        # See: https://github.com/ruby-concurrency/concurrent-ruby/issues/1099
         Concurrent.global_timer_set.send(:synchronize) do
           synchronize do
             delay = yield


### PR DESCRIPTION
We were experiencing deadlocks, which showed up as "infinitely growing" (actually started erroring out when we ran out of file descriptor count) puma queues, with a huge number of sockets per process (thousands or more). 

The deadlocks appear to be caused by an underlying ruby-concurency issue. Specifically, ScheduledTask#reschedule (used heavily by buffer.rb) can cause a deadlock with the background thread (Concurrency::TimerSet) starting the workers. 

For more details see: https://github.com/ruby-concurrency/concurrent-ruby/issues/1099

This PR eliminates the deadlock without modifying ruby-concurrency. By injecting a forced locking of the global Concurrent::TimerSet instance (kinda a monkeypatch, not quite), we can ensure the order of locking in `reschedule()` in buffer.rb matches the order of locking done by `TimerSet#process_tasks` in the background. This should eliminate the deadlock.

# Testing

We hot-patched one server instance and ran it for 2 hrs. All other active instances (unpatched) ended up building a puma queue backlog ("the issue"), but the hot patched instance did not.

These two backtraces show the deadlock:
```
# put_metric_data request #2 (TID-dh2ik puma srv tp 005)
#
# Lock Conditions: 
# - TimerSet: trying to lock
# - ScheduledTask: locked
# - @buffer (irrelevant but including): locked
#
[171733] Thread: TID-dh2ik puma srv tp 005
concurrent-ruby-1.2.3/lib/concurrent-ruby/concurrent/synchronization/mutex_lockable_object.rb:48:in 'synchronize'
concurrent-ruby-1.2.3/lib/concurrent-ruby/concurrent/synchronization/mutex_lockable_object.rb:48:in 'synchronize'
#### <---- TRY TO LOCK TimerSet.synchronize ####
concurrent-ruby-1.2.3/lib/concurrent-ruby/concurrent/executor/timer_set.rb:116:in 'remove_task' 
concurrent-ruby-1.2.3/lib/concurrent-ruby/concurrent/scheduled_task.rb:328:in 'ns_reschedule'
#### <---- LOCK ScheduledTask.synchronize ####
concurrent-ruby-1.2.3/lib/concurrent-ruby/concurrent/scheduled_task.rb:265:in 'block in reschedule' 
concurrent-ruby-1.2.3/lib/concurrent-ruby/concurrent/synchronization/mutex_lockable_object.rb:46:in 'synchronize'
concurrent-ruby-1.2.3/lib/concurrent-ruby/concurrent/scheduled_task.rb:265:in 'reschedule'
lib/cdo/buffer.rb:104:in 'block in reschedule'
concurrent-ruby-1.2.3/lib/concurrent-ruby/concurrent/synchronization/mutex_lockable_object.rb:48:in 'block in synchronize'
concurrent-ruby-1.2.3/lib/concurrent-ruby/concurrent/synchronization/mutex_lockable_object.rb:48:in 'synchronize'
concurrent-ruby-1.2.3/lib/concurrent-ruby/concurrent/synchronization/mutex_lockable_object.rb:48:in 'synchronize'
lib/cdo/buffer.rb:98:in 'reschedule'            #### <---- LOCK ScheduledTask.synchronize ####
lib/cdo/buffer.rb:126:in 'block in schedule_flush'
ruby/3.1.0/monitor.rb:202:in 'synchronize'
ruby/3.1.0/monitor.rb:202:in 'mon_synchronize'
lib/cdo/buffer.rb:125:in 'schedule_flush'                             # @buffer.sychronize
lib/cdo/buffer.rb:73:in 'block in buffer'
ruby/3.1.0/monitor.rb:202:in 'synchronize'
ruby/3.1.0/monitor.rb:202:in 'mon_synchronize'
lib/cdo/buffer.rb:71:in 'buffer'                                      # @buffer.sychronize
lib/cdo/aws/metrics.rb:87:in 'put_metric'
lib/cdo/aws/metrics.rb:95:in 'block in push'
lib/cdo/aws/metrics.rb:94:in 'each'
lib/cdo/aws/metrics.rb:94:in 'push'
dashboard/app/controllers/browser_events_controller.rb:43:in 'put_metric_data'
#### SNIP: cut hundreds of lines of backtrace with NO REFERENCES to buffer.rb or concurrent-ruby SNIP ####



# concurrent-ruby scheduled_task (TID-4jpio worker-1)
#
# Lock Conditions: 
# - TimerSet: locked
# - ScheduledTask: trying to lock
# - @buffer (irrelevant but including): not locked
#
[171733] Thread: TID-4jpio worker-1
concurrent-ruby-1.2.3/lib/concurrent-ruby/concurrent/synchronization/mutex_lockable_object.rb:48:in 'synchronize'
concurrent-ruby-1.2.3/lib/concurrent-ruby/concurrent/synchronization/mutex_lockable_object.rb:48:in 'synchronize'
#### <---- TRY TO LOCK ScheduledTask.synchronize ####
concurrent-ruby-1.2.3/lib/concurrent-ruby/concurrent/scheduled_task.rb:207:in 'schedule_time' 
concurrent-ruby-1.2.3/lib/concurrent-ruby/concurrent/scheduled_task.rb:214:in '<=>'
concurrent-ruby-1.2.3/lib/concurrent-ruby/concurrent/collection/ruby_non_concurrent_priority_queue.rb:120:in 'ordered?'
concurrent-ruby-1.2.3/lib/concurrent-ruby/concurrent/collection/ruby_non_concurrent_priority_queue.rb:133:in 'sink'
concurrent-ruby-1.2.3/lib/concurrent-ruby/concurrent/collection/ruby_non_concurrent_priority_queue.rb:70:in 'pop'
concurrent-ruby-1.2.3/lib/concurrent-ruby/concurrent/executor/timer_set.rb:164:in 'block (2 levels) in process_tasks'
concurrent-ruby-1.2.3/lib/concurrent-ruby/concurrent/synchronization/mutex_lockable_object.rb:48:in 'block in synchronize'
concurrent-ruby-1.2.3/lib/concurrent-ruby/concurrent/synchronization/mutex_lockable_object.rb:48:in 'synchronize'
concurrent-ruby-1.2.3/lib/concurrent-ruby/concurrent/synchronization/mutex_lockable_object.rb:48:in 'synchronize'
process_tasks' #### <---- LOCK TimerSet.synchronize ####
concurrent-ruby-1.2.3/lib/concurrent-ruby/concurrent/executor/timer_set.rb:164:in 'block in 
concurrent-ruby-1.2.3/lib/concurrent-ruby/concurrent/executor/timer_set.rb:144:in 'loop'
concurrent-ruby-1.2.3/lib/concurrent-ruby/concurrent/executor/timer_set.rb:144:in 'process_tasks'
concurrent-ruby-1.2.3/lib/concurrent-ruby/concurrent/executor/ruby_thread_pool_executor.rb:359:in 'run_task'
concurrent-ruby-1.2.3/lib/concurrent-ruby/concurrent/executor/ruby_thread_pool_executor.rb:350:in 'block (3 levels) in create_worker'
concurrent-ruby-1.2.3/lib/concurrent-ruby/concurrent/executor/ruby_thread_pool_executor.rb:341:in 'loop'
concurrent-ruby-1.2.3/lib/concurrent-ruby/concurrent/executor/ruby_thread_pool_executor.rb:341:in 'block (2 levels) in create_worker'
concurrent-ruby-1.2.3/lib/concurrent-ruby/concurrent/executor/ruby_thread_pool_executor.rb:340:in 'catch'
concurrent-ruby-1.2.3/lib/concurrent-ruby/concurrent/executor/ruby_thread_pool_executor.rb:340:in 'block in create_worker'
```
