### PR TITLE
Moderate GIF files in Web Lab 2

### DIFF
--- a/apps/src/lab2/utils/moderateImage.ts
+++ b/apps/src/lab2/utils/moderateImage.ts
@@ -9,11 +9,7 @@ export const moderateImage = async (
   ext: string,
   appName?: string
 ): Promise<'ok' | 'flagged' | 'skipped'> => {
-  if (
-    appName !== 'weblab2' ||
-    ext.toLowerCase() === 'gif' || // Our current moderation API does not support GIFs, so we skip them.
-    !WEBLAB2_IMAGE_FILE_TYPES.includes(ext)
-  ) {
+  if (appName !== 'weblab2' || !WEBLAB2_IMAGE_FILE_TYPES.includes(ext)) {
     return 'skipped';
   }
   const metricsReporter = Lab2Registry.getInstance().getMetricsReporter();

--- a/dashboard/legacy/middleware/files_api.rb
+++ b/dashboard/legacy/middleware/files_api.rb
@@ -1073,7 +1073,7 @@ class FilesApi < Sinatra::Base
     # Validate allowed content types
     unless ['image/png', 'image/jpeg', 'image/gif'].include?(content_type_header)
       status 400
-      return {error: 'Unsupported image type. Only PNG and JPEG files are allowed.'}.to_json
+      return {error: 'Unsupported image type. Only PNG, JPEG, and GIF files are allowed.'}.to_json
     end
 
     # Optionally record the URL for metrics, if passed as a query param.

--- a/dashboard/legacy/middleware/files_api.rb
+++ b/dashboard/legacy/middleware/files_api.rb
@@ -1071,7 +1071,7 @@ class FilesApi < Sinatra::Base
     content_type_header = request.content_type
 
     # Validate allowed content types
-    unless ['image/png', 'image/jpeg'].include?(content_type_header)
+    unless ['image/png', 'image/jpeg', 'image/gif'].include?(content_type_header)
       status 400
       return {error: 'Unsupported image type. Only PNG and JPEG files are allowed.'}.to_json
     end

--- a/dashboard/legacy/test/middleware/test_files.rb
+++ b/dashboard/legacy/test/middleware/test_files.rb
@@ -886,10 +886,10 @@ class FilesTest < FilesApiTestBase
   end
 
   def test_moderate_image_unsupported_type
-    header 'CONTENT_TYPE', 'image/gif'
-    post '/v3/images/moderate', 'fake-gif-bytes'
+    header 'CONTENT_TYPE', 'image/bmp'
+    post '/v3/images/moderate', 'fake-bmp-bytes'
     assert_equal 400, last_response.status
-    assert_equal({'error' => 'Unsupported image type. Only PNG and JPEG files are allowed.'}, JSON.parse(last_response.body))
+    assert_equal({'error' => 'Unsupported image type. Only PNG, JPEG, and GIF files are allowed.'}, JSON.parse(last_response.body))
   end
 
   private def delete_all_files(bucket)


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
When I was looking into replacing Azure Content Moderator, I realized that it actually has the ability to moderate gif files! So allowing moderation of GIF files in Web Lab 2. 

The Animation Picker doesn't allow upload of GIFs so not necessary to update.


## Links
<!--  Links to relevant external resources.
      - spec docs, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- Jira: https://codedotorg.atlassian.net/browse/AFL-453

## Testing story
<!--  Does your change include appropriate tests?
      - If so, please describe how the tests included in this PR are sufficient.
      - If not, please explain why this change does not need to be tested. -->

Locally, I added a `put` statement in `azure_content_moderator` and confirmed that when I uploaded a GIF file in `weblab2`, a result was returned from the call to endpoint. 

https://github.com/code-dot-org/code-dot-org/blob/dcc2a63a2fee665f9b78e0bd72bf7b399db81fbf/lib/cdo/azure_content_moderator.rb#L93-L101

## Deployment strategy
<!--  Any special steps required to deploy this, besides merging?
      - Are there database migrations or manual steps?
      - Does this require coordination with other teams or systems? -->



## Follow-up work
<!--  List any clean-up or technical debt that will be addressed in future work.
      - Include Jira links where applicable.
      - Are there any known limitations or improvements planned? -->



## Privacy
<!--  How does this change impact Student & Teacher privacy?
      - Does this collect, use, share, or modify PII, either new or existing? -->



## Security
<!--  How does this change impact our security surface-area?
      - Do API's touched have the right auth?
      - Do infra changes impact our attack surface or encryption?
-->



## Caching
<!--  How does this change impact caching behavior?
      - Are cache keys or invalidation strategies affected?
      - Will this require cache warming or invalidation after deployment? -->



## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
