### PR TITLE
Ensure stale RLID is updated during sync

### DIFF
--- a/dashboard/app/controllers/lti_v1_controller.rb
+++ b/dashboard/app/controllers/lti_v1_controller.rb
@@ -315,11 +315,8 @@ class LtiV1Controller < ApplicationController
       deployment_id = lti_course.lti_deployment_id
       context_id = lti_course.context_id
       nrps_url = lti_course.nrps_url
-      # Prefer the resource link from the SSO parameter instead of the course one. The resource link could have changed.
-      # For example, the teacher could have had Code.org in one material/module but deleted that material/module and
-      # made a new one (deleted the old LtiResourceLink and created a brand new one). This results in a mismatch between
-      # what is stored on Code.org's LtiCourse. Therefore, when doing an SSO sync, prefer the latest RLID and update our
-      # records with that.
+      # Requests from the sync button will not include a resource link ID, so it will generally
+      # be nil at this point. Use the one from the lti_course record if present.
       resource_link_id ||= lti_course.resource_link_id
     else
       # Section code isn't present, meaning this is a sync from an LTI launch.
@@ -333,6 +330,17 @@ class LtiV1Controller < ApplicationController
       context_id = params[:context_id]
       nrps_url = params[:nrps_url]
     end
+
+    # This query is also responsible for updating the RLID if it has changed.
+    # This has to happen before we call NRPS, or we will get an error back if the LMS
+    # platform requires an RLID (like Canvas) and the one we have is stale.
+    lti_course ||= Queries::Lti.find_or_create_lti_course(
+      lti_integration_id: lti_integration.id,
+      context_id: context_id,
+      deployment_id: deployment_id,
+      nrps_url: nrps_url,
+      resource_link_id: resource_link_id
+    )
 
     lti_advantage_client = Clients::LtiAdvantageClient.new(lti_integration.client_id, lti_integration.issuer)
     begin
@@ -359,14 +367,6 @@ class LtiV1Controller < ApplicationController
     total_sections = 0
     total_students = 0
     ActiveRecord::Base.transaction do
-      lti_course ||= Queries::Lti.find_or_create_lti_course(
-        lti_integration_id: lti_integration.id,
-        context_id: context_id,
-        deployment_id: deployment_id,
-        nrps_url: nrps_url,
-        resource_link_id: resource_link_id
-      )
-
       result = Services::Lti.sync_course_roster(lti_integration: lti_integration, lti_course: lti_course, nrps_sections: nrps_sections, current_user: current_user)
       had_changes ||= !result[:changed].empty?
 


### PR DESCRIPTION
We have code to update stale RLIDs, but the query happens in the wrong spot. The Canvas NRPS requires a valid RLID , so the update has to happen before we attempt to call NRPS. Otherwise, the stale RLID will cause the NRPS call to fail, which short circuits the whole sync process before the RLID can be updated. This PR moves the `Queries::Lti.find_or_create_lti_course` call earlier in the `sync_course` function to ensure the RLID is updated before we attempt the NRPS call.

This also updates the comment around preferring a fresh RLID from the request params in the code for handling sync button requests. For these requests, the RLID param will always be nil from what I can tell, so that comment was somewhat misleading.

## Links
[JIRA](https://codedotorg.atlassian.net/browse/P20-1787)

## Testing story
<!--  Does your change include appropriate tests?
      - If so, please describe how the tests included in this PR are sufficient.
      - If not, please explain why this change does not need to be tested. -->



## Deployment strategy
<!--  Any special steps required to deploy this, besides merging?
      - Are there database migrations or manual steps?
      - Does this require coordination with other teams or systems? -->



## Follow-up work
<!--  List any clean-up or technical debt that will be addressed in future work.
      - Include Jira links where applicable.
      - Are there any known limitations or improvements planned? -->



## Privacy
<!--  How does this change impact Student & Teacher privacy?
      - Does this collect, use, share, or modify PII, either new or existing? -->



## Security
<!--  How does this change impact our security surface-area?
      - Do API's touched have the right auth?
      - Do infra changes impact our attack surface or encryption?
-->



## Caching
<!--  How does this change impact caching behavior?
      - Are cache keys or invalidation strategies affected?
      - Will this require cache warming or invalidation after deployment? -->



## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
