### PR TITLE
Enable puma Control Server

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -147,6 +147,7 @@ gem 'open_uri_redirections', require: false
 # Optimizes copy-on-write memory usage with GC before web-application fork.
 gem 'nakayoshi_fork'
 
+gem 'jmespath', '~> 1.4' # Used by our pumactl wrapper shell script to filter JSON output.
 gem 'puma', '~> 7.2'
 gem 'puma_worker_killer'
 gem 'sd_notify' # required for Puma to support systemd's Type=notify

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1077,6 +1077,7 @@ DEPENDENCIES
   image_optim_pack (~> 0.5.0)!
   image_optim_rails (~> 0.4.0)
   image_size
+  jmespath (~> 1.4)
   jquery-rails
   jquery-ui-rails (~> 6.0.1)
   json-jwt (~> 1.15)

--- a/bin/pumactl_admin
+++ b/bin/pumactl_admin
@@ -8,8 +8,9 @@
 # EXAMPLES:
 #   bin/pumactl_admin stats
 #   bin/pumactl_admin stats --query=booted_workers
-#   bin/pumactl_admin stats -q=worker_status.0.last_status.backlog
+#   bin/pumactl_admin stats --query=worker_status.0.last_status.backlog
 #   bin/pumactl_admin phased-restart
+#   bin/pumactl_admin thread-backtraces
 #
 # CUSTOM ARGUMENTS:
 #   --query, -q    JSON path to extract specific data from the output.

--- a/bin/pumactl_admin
+++ b/bin/pumactl_admin
@@ -3,7 +3,6 @@ require_relative '../deployment'
 require 'json'
 require 'open3'
 
-# Extract our custom --query argument before passing the rest to pumactl.
 query_path = nil
 ARGV.reject! do |arg|
   if arg.start_with?('--query=', '-q=')
@@ -16,6 +15,7 @@ end
 
 raise 'CDO.puma_control_server_token is not defined' unless CDO.puma_control_server_token
 token = CDO.puma_control_server_token
+
 socket_url = "unix://#{dashboard_dir('tmp', 'pumactl.sock')}"
 
 cmd = [
@@ -27,11 +27,10 @@ cmd = [
 stdout, stderr, status = Open3.capture3(*cmd)
 
 if status.success?
-  # Pretty print JSON output and also allow dig expressions on the JSON output.
+  # pumactl sometimes outputs a preamble ("command stats sent success") before JSON output.
   json_start_index = stdout.index('{')
 
   if json_start_index
-    # pumactl often outputs a preamble like ("Command stats sent success") before the JSON result.
     preamble = stdout[0...json_start_index]
     json_part = stdout[json_start_index..].strip
 
@@ -39,25 +38,36 @@ if status.success?
       data = JSON.parse(json_part)
 
       if query_path
-        # Support dot-notation (e.g., "worker_status.0.last_status.backlog"). Dig handles nested hashes and arrays.
+        # Send preamble STDERR so it doesn't corrupt the pipe.
+        warn preamble unless preamble.strip.empty?
+
+        # Navigate the JSON safely using the query path.
         keys = query_path.split('.').map {|k| /^\d+$/.match?(k) ? k.to_i : k}
         result = data.dig(*keys)
-        puts preamble
-        puts (result.is_a?(Hash) || result.is_a?(Array)) ? JSON.generate(result) : result
+
+        # Output ONLY the data to STDOUT.
+        if result.is_a?(Hash) || result.is_a?(Array)
+          puts JSON.generate(result)
+        else
+          puts result
+        end
       else
-        # Standard human-friendly mode: print preamble + pretty JSON.
+        # HUMAN MODE: Preamble and Pretty JSON go to STDOUT.
         puts preamble unless preamble.strip.empty?
         puts JSON.pretty_generate(data)
       end
     rescue JSON::ParserError
+      # Fallback for parsing failures.
       puts stdout
     end
   else
-    puts stdout # Commands like 'restart' don't output JSON.
+    # Non-JSON output (e.g. 'restart' command).
+    puts stdout unless stdout.empty?
   end
 else
+  # Error Handling
   warn "Error executing pumactl:"
-  warn stdout # For some non-success results, pumactl returns useful information in standard output.
+  warn stdout
   warn stderr
   exit status.exitstatus
 end

--- a/bin/pumactl_admin
+++ b/bin/pumactl_admin
@@ -7,10 +7,12 @@
 #
 # EXAMPLES:
 #   bin/pumactl_admin stats
-#   bin/pumactl_admin stats --query=booted_workers
-#   bin/pumactl_admin stats --query=worker_status.0.last_status.backlog
+#   bin/pumactl_admin stats --query="booted_workers"
+#   bin/pumactl_admin stats --query="worker_status[0].last_status.backlog"
+#   bin/pumactl_admin stats --query="worker_status[?pid == \`433276\`].last_status.backlog | [0]"
+#   bin/pumactl_admin stats --query="length(worker_status)"
 #   bin/pumactl_admin phased-restart
-#   bin/pumactl_admin thread-backtraces
+#   bin/pumactl_admin thread-backtraces   # Only outputs for parent puma process threads.
 #
 # CUSTOM ARGUMENTS:
 #   --query, -q    JMESPath to extract specific data from the output; similar to AWS CLI --query. https://jmespath.org

--- a/bin/pumactl_admin
+++ b/bin/pumactl_admin
@@ -61,16 +61,15 @@ if status.success?
       data = JSON.parse(json_part)
 
       if query_path
-        # Send preamble STDERR so it doesn't corrupt the pipe.
-        warn preamble.strip unless preamble.strip.empty?
+        # Send the preamble to STDERR.
+        warn preamble.strip.chomp unless preamble.strip.empty?
 
         # Navigate the JSON safely using the query path.
         keys = query_path.split('.').map {|k| /^\d+$/.match?(k) ? k.to_i : k}
         result = data.dig(*keys)
 
-        # Output ONLY the data to STDOUT.
         if result.is_a?(Hash) || result.is_a?(Array)
-          puts JSON.generate(result)
+          puts JSON.pretty_generate(result)
         else
           puts result
         end
@@ -80,7 +79,8 @@ if status.success?
         puts JSON.pretty_generate(data)
       end
     rescue JSON::ParserError
-      # Fallback for parsing failures.
+      # If parsing fails, we warn the error and output the raw pumactl response.
+      warn "Failed to parse JSON part."
       puts stdout
     end
   else

--- a/bin/pumactl_admin
+++ b/bin/pumactl_admin
@@ -1,17 +1,31 @@
 #!/usr/bin/env ruby
 require_relative '../deployment'
-require 'shellwords'
+require 'json'
+require 'open3'
 
 raise 'CDO.puma_control_server_token is not defined' unless CDO.puma_control_server_token
 token = CDO.puma_control_server_token
-socket_path = dashboard_dir(CDO.puma_control_server_relative_socket_path)
+socket_path = "unix://#{dashboard_dir(CDO.puma_control_server_relative_socket_path)}"
 
-# Use Shellwords to ensure arguments are safely escaped.
-args = [
+cmd = [
   'bundle', 'exec', 'pumactl',
   '-S', socket_path,
   '-T', token
 ] + ARGV
 
-# Use exec to replace the current process with pumactl to ensure token remains in the Ruby process memory until execution.
-exec(*args)
+stdout, stderr, status = Open3.capture3(*cmd)
+
+if status.success?
+  begin
+    # Attempt to parse and pretty-print if the output is JSON.
+    parsed = JSON.parse(stdout)
+    puts JSON.pretty_generate(parsed)
+  rescue JSON::ParserError
+    # Default to raw output for non-JSON commands (like 'status' or 'restart')
+    puts stdout unless stdout.empty?
+  end
+else
+  warn "Error executing pumactl:"
+  warn stderr
+  exit status.exitstatus
+end

--- a/bin/pumactl_admin
+++ b/bin/pumactl_admin
@@ -9,7 +9,7 @@ socket_path = "unix://#{dashboard_dir(CDO.puma_control_server_relative_socket_pa
 
 cmd = [
   'bundle', 'exec', 'pumactl',
-  '-S', socket_path,
+  '-u', socket_path,
   '-T', token
 ] + ARGV
 
@@ -17,11 +17,10 @@ stdout, stderr, status = Open3.capture3(*cmd)
 
 if status.success?
   begin
-    # Attempt to parse and pretty-print if the output is JSON.
-    parsed = JSON.parse(stdout)
-    puts JSON.pretty_generate(parsed)
+    # Attempt to parse and pretty-print if the output is JSON (like for 'stats').
+    puts JSON.pretty_generate(JSON.parse(stdout))
   rescue JSON::ParserError
-    # Default to raw output for non-JSON commands (like 'status' or 'restart')
+    # Default to raw output for non-JSON commands (like 'status' or 'restart').
     puts stdout unless stdout.empty?
   end
 else

--- a/bin/pumactl_admin
+++ b/bin/pumactl_admin
@@ -62,7 +62,7 @@ if status.success?
 
       if query_path
         # Send preamble STDERR so it doesn't corrupt the pipe.
-        warn preamble unless preamble.strip.empty?
+        warn preamble.strip unless preamble.strip.empty?
 
         # Navigate the JSON safely using the query path.
         keys = query_path.split('.').map {|k| /^\d+$/.match?(k) ? k.to_i : k}

--- a/bin/pumactl_admin
+++ b/bin/pumactl_admin
@@ -6,9 +6,8 @@ require 'open3'
 raise 'CDO.puma_control_server_token is not defined' unless CDO.puma_control_server_token
 token = CDO.puma_control_server_token
 
-socket_url = "unix:///#{dashboard_dir('tmp', 'pumactl.sock')}"
+socket_url = "unix://#{dashboard_dir('tmp', 'pumactl.sock')}"
 
-# Using the long-form switches as requested.
 cmd = [
   'bundle', 'exec', 'pumactl',
   '--control-url', socket_url,
@@ -27,6 +26,7 @@ if status.success?
   end
 else
   warn "Error executing pumactl:"
+  warn stdout
   warn stderr
   exit status.exitstatus
 end

--- a/bin/pumactl_admin
+++ b/bin/pumactl_admin
@@ -1,0 +1,17 @@
+#!/usr/bin/env ruby
+require_relative '../deployment'
+require 'shellwords'
+
+raise 'CDO.puma_control_server_token is not defined' unless CDO.puma_control_server_token
+token = CDO.puma_control_server_token
+socket_path = dashboard_dir(CDO.puma_control_server_relative_socket_path)
+
+# Use Shellwords to ensure arguments are safely escaped.
+args = [
+  'bundle', 'exec', 'pumactl',
+  '-S', socket_path,
+  '-T', token
+] + ARGV
+
+# Use exec to replace the current process with pumactl to ensure token remains in the Ruby process memory until execution.
+exec(*args)

--- a/bin/pumactl_admin
+++ b/bin/pumactl_admin
@@ -3,7 +3,7 @@
 # Wrapper for pumactl that handles authentication and socket location automatically.
 #
 # USAGE:
-#   bin/pumactl_admin [COMMAND] [ARGS] [--query=PATH]
+#   bin/pumactl_admin [COMMAND] [ARGS] [--query=JMESPath]
 #
 # EXAMPLES:
 #   bin/pumactl_admin stats
@@ -13,9 +13,7 @@
 #   bin/pumactl_admin thread-backtraces
 #
 # CUSTOM ARGUMENTS:
-#   --query, -q    JSON path to extract specific data from the output.
-#                  Supports dot notation for hashes and arrays (e.g. 'a.b.0.c').
-#                  When used, 'preamble' text is sent to STDERR to allow clean piping.
+#   --query, -q    JMESPath to extract specific data from the output; similar to AWS CLI --query. https://jmespath.org
 #
 # STANDARD ARGUMENTS:
 #   Accepts all standard pumactl commands (stats, stop, restart, etc).
@@ -24,6 +22,7 @@
 require_relative '../deployment'
 require 'json'
 require 'open3'
+require 'jmespath'
 
 # Parse and extract the custom --query argument
 query_path = nil
@@ -64,9 +63,8 @@ if status.success?
         # Send the preamble to STDERR.
         warn preamble.strip.chomp unless preamble.strip.empty?
 
-        # Navigate the JSON safely using the query path.
-        keys = query_path.split('.').map {|k| /^\d+$/.match?(k) ? k.to_i : k}
-        result = data.dig(*keys)
+        # Use JMESPath to search the JSON response.
+        result = JMESPath.search(query_path, data)
 
         if result.is_a?(Hash) || result.is_a?(Array)
           puts JSON.pretty_generate(result)

--- a/bin/pumactl_admin
+++ b/bin/pumactl_admin
@@ -1,8 +1,30 @@
 #!/usr/bin/env ruby
+#
+# Wrapper for pumactl that handles authentication and socket location automatically.
+#
+# USAGE:
+#   bin/pumactl_admin [COMMAND] [ARGS] [--query=PATH]
+#
+# EXAMPLES:
+#   bin/pumactl_admin stats
+#   bin/pumactl_admin stats --query=booted_workers
+#   bin/pumactl_admin stats -q=worker_status.0.last_status.backlog
+#   bin/pumactl_admin phased-restart
+#
+# CUSTOM ARGUMENTS:
+#   --query, -q    JSON path to extract specific data from the output.
+#                  Supports dot notation for hashes and arrays (e.g. 'a.b.0.c').
+#                  When used, 'preamble' text is sent to STDERR to allow clean piping.
+#
+# STANDARD ARGUMENTS:
+#   Accepts all standard pumactl commands (stats, stop, restart, etc).
+#   See https://github.com/puma/puma/blob/master/lib/puma/control_cli.rb
+#
 require_relative '../deployment'
 require 'json'
 require 'open3'
 
+# Parse and extract the custom --query argument
 query_path = nil
 ARGV.reject! do |arg|
   if arg.start_with?('--query=', '-q=')
@@ -65,7 +87,6 @@ if status.success?
     puts stdout unless stdout.empty?
   end
 else
-  # Error Handling
   warn "Error executing pumactl:"
   warn stdout
   warn stderr

--- a/bin/pumactl_admin
+++ b/bin/pumactl_admin
@@ -3,9 +3,19 @@ require_relative '../deployment'
 require 'json'
 require 'open3'
 
+# Extract our custom --query argument before passing the rest to pumactl.
+query_path = nil
+ARGV.reject! do |arg|
+  if arg.start_with?('--query=', '-q=')
+    query_path = arg.split('=', 2).last
+    true
+  else
+    false
+  end
+end
+
 raise 'CDO.puma_control_server_token is not defined' unless CDO.puma_control_server_token
 token = CDO.puma_control_server_token
-
 socket_url = "unix://#{dashboard_dir('tmp', 'pumactl.sock')}"
 
 cmd = [
@@ -17,26 +27,37 @@ cmd = [
 stdout, stderr, status = Open3.capture3(*cmd)
 
 if status.success?
-  # Check if pumactl output JSON (possibly after some preamble text like "Command stats sent success").
+  # Pretty print JSON output and also allow dig expressions on the JSON output.
   json_start_index = stdout.index('{')
 
   if json_start_index
-    # Extract the JSON.
+    # pumactl often outputs a preamble like ("Command stats sent success") before the JSON result.
+    preamble = stdout[0...json_start_index]
     json_part = stdout[json_start_index..].strip
+
     begin
-      # Parse and pretty-generate the extracted JSON.
-      puts JSON.pretty_generate(JSON.parse(json_part))
+      data = JSON.parse(json_part)
+
+      if query_path
+        # Support dot-notation (e.g., "worker_status.0.last_status.backlog"). Dig handles nested hashes and arrays.
+        keys = query_path.split('.').map {|k| /^\d+$/.match?(k) ? k.to_i : k}
+        result = data.dig(*keys)
+        puts preamble
+        puts (result.is_a?(Hash) || result.is_a?(Array)) ? JSON.generate(result) : result
+      else
+        # Standard human-friendly mode: print preamble + pretty JSON.
+        puts preamble unless preamble.strip.empty?
+        puts JSON.pretty_generate(data)
+      end
     rescue JSON::ParserError
-      # If parsing fails, fall back to the raw output.
-      puts stdout unless stdout.empty?
+      puts stdout
     end
   else
-    # Commands like 'phased-restart' or 'stop' don't return JSON.
-    puts stdout unless stdout.empty?
+    puts stdout # Commands like 'restart' don't output JSON.
   end
 else
   warn "Error executing pumactl:"
-  warn stdout # Some types of non-success outcomes contain useful information in standard out.
+  warn stdout # For some non-success results, pumactl returns useful information in standard output.
   warn stderr
   exit status.exitstatus
 end

--- a/bin/pumactl_admin
+++ b/bin/pumactl_admin
@@ -5,12 +5,14 @@ require 'open3'
 
 raise 'CDO.puma_control_server_token is not defined' unless CDO.puma_control_server_token
 token = CDO.puma_control_server_token
-socket_path = "unix://#{dashboard_dir(CDO.puma_control_server_relative_socket_path)}"
 
+socket_url = "unix:///#{dashboard_dir('tmp', 'pumactl.sock')}"
+
+# Using the long-form switches as requested.
 cmd = [
   'bundle', 'exec', 'pumactl',
-  '-u', socket_path,
-  '-T', token
+  '--control-url', socket_url,
+  '--control-token', token
 ] + ARGV
 
 stdout, stderr, status = Open3.capture3(*cmd)
@@ -20,7 +22,7 @@ if status.success?
     # Attempt to parse and pretty-print if the output is JSON (like for 'stats').
     puts JSON.pretty_generate(JSON.parse(stdout))
   rescue JSON::ParserError
-    # Default to raw output for non-JSON commands (like 'status' or 'restart').
+    # Output raw text for non-JSON commands like 'status' or 'phased-restart'.
     puts stdout unless stdout.empty?
   end
 else

--- a/bin/pumactl_admin
+++ b/bin/pumactl_admin
@@ -17,16 +17,26 @@ cmd = [
 stdout, stderr, status = Open3.capture3(*cmd)
 
 if status.success?
-  begin
-    # Attempt to parse and pretty-print if the output is JSON (like for 'stats').
-    puts JSON.pretty_generate(JSON.parse(stdout))
-  rescue JSON::ParserError
-    # Output raw text for non-JSON commands like 'status' or 'phased-restart'.
+  # Check if pumactl output JSON (possibly after some preamble text like "Command stats sent success").
+  json_start_index = stdout.index('{')
+
+  if json_start_index
+    # Extract the JSON.
+    json_part = stdout[json_start_index..].strip
+    begin
+      # Parse and pretty-generate the extracted JSON.
+      puts JSON.pretty_generate(JSON.parse(json_part))
+    rescue JSON::ParserError
+      # If parsing fails, fall back to the raw output.
+      puts stdout unless stdout.empty?
+    end
+  else
+    # Commands like 'phased-restart' or 'stop' don't return JSON.
     puts stdout unless stdout.empty?
   end
 else
   warn "Error executing pumactl:"
-  warn stdout
+  warn stdout # Some types of non-success outcomes contain useful information in standard out.
   warn stderr
   exit status.exitstatus
 end

--- a/config.yml.erb
+++ b/config.yml.erb
@@ -427,7 +427,7 @@ dashboard_port: 3000
 dashboard_workers: 8
 dashboard_web_server_name: dashboard
 dashboard_sock:
-puma_control_server_relative_socket_path: tmp/sockets/pumactl.sock
+puma_control_server_relative_socket_path: tmp/pumactl.sock
 puma_control_server_token: !Secret
 
 # Causes dashboard-server to run pegasus as middleware, starting both in a

--- a/config.yml.erb
+++ b/config.yml.erb
@@ -427,6 +427,8 @@ dashboard_port: 3000
 dashboard_workers: 8
 dashboard_web_server_name: dashboard
 dashboard_sock:
+puma_control_server_relative_socket_path: tmp/sockets/pumactl.sock
+puma_control_server_token: !Secret
 
 # Causes dashboard-server to run pegasus as middleware, starting both in a
 # single command.  This is preferred (and default) in development mode.

--- a/config/adhoc.yml.erb
+++ b/config/adhoc.yml.erb
@@ -17,6 +17,7 @@ custom_error_response: false
 javabuilder_private_key: !Secret
 javabuilder_key_password: !Secret
 properties_encryption_key: !Secret
+puma_control_server_token: !Secret
 
 # Recaptcha (used on Forgot Password page.  Especially important for this to work on the BugCrowd adhoc)
 recaptcha_site_key: !Secret

--- a/config/development.yml.erb
+++ b/config/development.yml.erb
@@ -44,6 +44,7 @@ poste_secret: not a real secret
 channels_api_secret: not a real secret
 dashboard_devise_pepper: not a pepper!
 dashboard_secret_key_base: not a secret
+puma_control_server_token: Tr0ub4dor&3
 
 custom_error_response: false
 

--- a/config/test.yml.erb
+++ b/config/test.yml.erb
@@ -30,6 +30,8 @@ poste_secret: not a real secret
 channels_api_secret: not a real secret
 dashboard_devise_pepper: not a pepper!
 dashboard_secret_key_base: not a secret
+puma_control_server_token: correct-horse-battery-staple
+
 google_maps_api_key: boguskey
 
 db_cluster_id: localhost

--- a/config/test.yml.erb
+++ b/config/test.yml.erb
@@ -11,7 +11,7 @@ slack_start_build_token: !Secret
 azure_content_moderation_key: !Secret
 saucelabs_authkey: !Secret
 saucelabs_username: !Secret
-
+puma_control_server_token: !Secret
 <% else %>
 
 ##

--- a/dashboard/config/puma.rb
+++ b/dashboard/config/puma.rb
@@ -40,3 +40,9 @@ end
 after_booted do
   Cdo::AppServerHooks.after_booted
 end
+
+# Enable the Puma control server with a Unix socket.
+if CDO.puma_control_server_token
+  control_socket = "unix://#{dashboard_dir(CDO.puma_control_server_relative_socket_path)}"
+  activate_control_app control_socket, {auth_token: CDO.puma_control_server_token}
+end


### PR DESCRIPTION
https://codedotorg.atlassian.net/browse/INF-2021

Enable better interactive diagnostics and control of puma.

## Testing story
`bundle exec rake adhoc:start RAILS_ENV=adhoc STACK_NAME=adhoc-puma-control-server`

```bash
ubuntu@adhoc-puma-control-server:~/adhoc$ bin/pumactl_admin stats
GetSecretValue: adhoc/cdo/puma_control_server_token
Command stats sent success
{
  "started_at": "2026-02-04T23:42:38Z",
  "workers": 5,
  "phase": 0,
  "booted_workers": 5,
  "old_workers": 0,
  "worker_status": [
    {
      "started_at": "2026-02-04T23:43:36Z",
      "pid": 275974,
      "index": 0,
      "phase": 0,
      "booted": true,
      "last_checkin": "2026-02-05T00:00:47Z",
      "last_status": {
        "backlog": 0,
        "running": 1,
        "pool_capacity": 5,
        "busy_threads": 0,
        "backlog_max": 0,
        "max_threads": 5,
        "requests_count": 1
      }
    },
    {
      "started_at": "2026-02-04T23:43:36Z",
      "pid": 275983,
      "index": 1,
      "phase": 0,
      "booted": true,
      "last_checkin": "2026-02-05T00:00:47Z",
      "last_status": {
        "backlog": 0,
        "running": 1,
        "pool_capacity": 5,
        "busy_threads": 0,
        "backlog_max": 0,
        "max_threads": 5,
        "requests_count": 1
      }
    },
    {
      "started_at": "2026-02-04T23:43:37Z",
      "pid": 275992,
      "index": 2,
      "phase": 0,
      "booted": true,
      "last_checkin": "2026-02-05T00:00:47Z",
      "last_status": {
        "backlog": 0,
        "running": 1,
        "pool_capacity": 5,
        "busy_threads": 0,
        "backlog_max": 0,
        "max_threads": 5,
        "requests_count": 0
      }
    },
    {
      "started_at": "2026-02-04T23:43:37Z",
      "pid": 276001,
      "index": 3,
      "phase": 0,
      "booted": true,
      "last_checkin": "2026-02-05T00:00:47Z",
      "last_status": {
        "backlog": 0,
        "running": 1,
        "pool_capacity": 5,
        "busy_threads": 0,
        "backlog_max": 0,
        "max_threads": 5,
        "requests_count": 0
      }
    },
    {
      "started_at": "2026-02-04T23:43:37Z",
      "pid": 276010,
      "index": 4,
      "phase": 0,
      "booted": true,
      "last_checkin": "2026-02-05T00:00:47Z",
      "last_status": {
        "backlog": 0,
        "running": 1,
        "pool_capacity": 5,
        "busy_threads": 0,
        "backlog_max": 0,
        "max_threads": 5,
        "requests_count": 0
      }
    }
  ],
  "versions": {
    "puma": "7.2.0",
    "ruby": {
      "engine": "ruby",
      "version": "3.1.7",
      "patchlevel": 261
    }
  }
}
```

Check a specific worker's `backlog`:
```
ubuntu@adhoc-puma-control-server:~/adhoc$ bin/pumactl_admin stats --query=worker_status.0.last_status.backlog
GetSecretValue: adhoc/cdo/puma_control_server_token
Command stats sent success
0
```

Count of booted workers:
```
ubuntu@adhoc-puma-control-server:~/adhoc$ bin/pumactl_admin stats --query=booted_workers
GetSecretValue: adhoc/cdo/puma_control_server_token
Command stats sent success
5
```



## Deployment strategy
<!--  Any special steps required to deploy this, besides merging?
      - Are there database migrations or manual steps?
      - Does this require coordination with other teams or systems? -->



## Follow-up work
Switch from running the control server on a Unix socket to TCP and enable daemon/console servers in the current stack to communicate to the puma control server port internally within our VPC, but not externally.



## Privacy
<!--  How does this change impact Student & Teacher privacy?
      - Does this collect, use, share, or modify PII, either new or existing? -->



## Security
<!--  How does this change impact our security surface-area?
      - Do API's touched have the right auth?
      - Do infra changes impact our attack surface or encryption?
-->



## Caching
<!--  How does this change impact caching behavior?
      - Are cache keys or invalidation strategies affected?
      - Will this require cache warming or invalidation after deployment? -->



## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
