### PR TITLE
fix(bin/cron/perform_job): prevent false duplicate job aborts

### DIFF
--- a/bin/cron/perform_job
+++ b/bin/cron/perform_job
@@ -1,8 +1,5 @@
 #!/usr/bin/env ruby
 
-require_relative 'only_one'
-abort 'Script already running' unless only_one_running?(__FILE__)
-
 require 'active_support/core_ext/hash/keys'
 require 'json'
 require 'optparse'
@@ -32,6 +29,9 @@ job_class = ARGV[0]&.constantize
 job_args = JSON.parse(ARGV[1] || '[]')
 
 raise OptionParser::MissingArgument, 'JOB_CLASS argument is missing' unless job_class
+
+require_relative 'only_one'
+abort "Duplicate job detected: #{job_class} #{job_args}" unless only_one_running?(__FILE__, ARGV.join('/'))
 
 if job_args.is_a?(Hash)
   job_class.perform_later(**job_args.symbolize_keys)

--- a/lib/cdo/only_one.rb
+++ b/lib/cdo/only_one.rb
@@ -4,8 +4,8 @@ require 'tmpdir'
 # Ensure only one instance of a Ruby script is running at a time,
 # using `File#flock` (advisory lock) on a temp file based on the provided script path.
 # @return [Boolean] true if this is the only instance running.
-def only_one_running?(path)
-  lock = File.join(Dir.tmpdir, Digest::MD5.hexdigest(File.absolute_path(path)))
+def only_one_running?(path, key = nil)
+  lock = File.join(Dir.tmpdir, Digest::MD5.hexdigest(File.absolute_path(path) + key.to_s))
   !!File.new(lock, File::CREAT).
     # Prevent locked Files from being auto-closed by garbage-collector.
     tap {|f| f.autoclose = false}.


### PR DESCRIPTION
This change fixes incorrect duplicate job detection in `./bin/cron/perform_job`.

Previously, jobs were treated as duplicates based only on the script path, which could incorrectly abort different job schedules. This change adds the job class and arguments to the uniqueness key, so only true duplicates are aborted.

## Links
- Related PR: https://github.com/code-dot-org/code-dot-org/pull/60716