### PR TITLE
Update Clever students API call to v3

### DIFF
--- a/dashboard/app/controllers/api_controller.rb
+++ b/dashboard/app/controllers/api_controller.rb
@@ -102,7 +102,7 @@ class ApiController < ApplicationController
     course_id = params[:courseId].to_s
     course_name = params[:courseName].to_s
 
-    query_clever_service(api_version: AuthenticationOption::Clever::VERSION[:v2], endpoint: "sections/#{course_id}/students") do |students|
+    query_clever_service(api_version: AuthenticationOption::Clever::VERSION[:v3], endpoint: "sections/#{course_id}/users?role=student") do |students|
       section = CleverSection.from_service(course_id, current_user.id, students, course_name)
       render json: section.summarize
     end

--- a/dashboard/app/models/sections/clever_section.rb
+++ b/dashboard/app/models/sections/clever_section.rb
@@ -44,7 +44,7 @@ class CleverSection < OmniAuthSection
   def self.from_service(course_id, owner_id, student_list, section_name)
     code = "#{CODE_PREFIX}#{course_id}"
 
-    students = student_list.map do |student|
+    students = student_list.filter_map do |student|
       data = student['data']
       student_role_data = data['roles']['student']
       next if student_role_data.blank?
@@ -58,7 +58,7 @@ class CleverSection < OmniAuthSection
           dob: student_role_data['dob'],
         },
       )
-    end.compact
+    end
 
     from_omniauth(
       code: code,

--- a/dashboard/app/models/sections/clever_section.rb
+++ b/dashboard/app/models/sections/clever_section.rb
@@ -47,7 +47,7 @@ class CleverSection < OmniAuthSection
     students = student_list.map do |student|
       data = student['data']
       student_role_data = data['roles']['student']
-      return nil unless student_role_data.present?
+      next if student_role_data.blank?
 
       OmniAuth::AuthHash.new(
         uid: data['id'],

--- a/dashboard/app/models/sections/clever_section.rb
+++ b/dashboard/app/models/sections/clever_section.rb
@@ -44,20 +44,21 @@ class CleverSection < OmniAuthSection
   def self.from_service(course_id, owner_id, student_list, section_name)
     code = "#{CODE_PREFIX}#{course_id}"
 
-    set_family_name = DCDO.get('clever_family_name', false)
-
     students = student_list.map do |student|
       data = student['data']
+      student_role_data = data['roles']['student']
+      return nil unless student_role_data.present?
+
       OmniAuth::AuthHash.new(
         uid: data['id'],
         provider: 'clever',
         info: {
-          name: set_family_name ? data['name']['first'] : data['name'],
-          family_name: set_family_name ? data['name']['last'] : nil,
-          dob: data['dob'],
+          name: data['name']['first'],
+          family_name: data['name']['last'],
+          dob: student_role_data['dob'],
         },
       )
-    end
+    end.compact
 
     from_omniauth(
       code: code,

--- a/dashboard/lib/services/roster/clever/section_syncer.rb
+++ b/dashboard/lib/services/roster/clever/section_syncer.rb
@@ -15,7 +15,7 @@ module Services
 
         # @return [OmniAuthSection] Synchronized section
         def call
-          clever_students = clever_client.get("sections/#{section.clever_id}/students").fetch('data')
+          clever_students = clever_client.get("sections/#{section.clever_id}/users?role=student").fetch('data')
           CleverSection.from_service(section.clever_id, teacher.id, clever_students, section.name)
         end
 

--- a/dashboard/test/lib/services/roster/clever/section_syncer_test.rb
+++ b/dashboard/test/lib/services/roster/clever/section_syncer_test.rb
@@ -24,7 +24,7 @@ class Services::Roster::Clever::SectionSyncerTest < ActiveSupport::TestCase
     end
 
     before do
-      clever_client_mock.stubs(:get).with("sections/#{section.clever_id}/students").returns({'data' => clever_students_data})
+      clever_client_mock.stubs(:get).with("sections/#{section.clever_id}/users?role=student").returns({'data' => clever_students_data})
     end
 
     it 'returns synced Clever section' do

--- a/dashboard/test/models/sections/clever_section_test.rb
+++ b/dashboard/test/models/sections/clever_section_test.rb
@@ -2,44 +2,19 @@ require 'test_helper'
 
 class CleverSectionTest < ActiveSupport::TestCase
   subject(:described_instance) {build(:section, :from_clever)}
-
-  test 'from clever service without family name import' do
-    owner = create(:teacher)
-    student_list = [
-      {'data' => {'dob' => '2002-09-04T00:00:00.000Z', 'name' => {'first' => 'Ethan', 'last' => 'Doe'}, 'id' => '5966ed736b21538e3c000004'}},
-      {'data' => {'dob' => '2000-02-11T00:00:00.000Z', 'name' => {'first' => 'Lily', 'last' => 'Fake'}, 'id' => '5966ed736b21538e3c000005'}},
-      {'data' => {'dob' => '2002-05-21T00:00:00.000Z', 'name' => {'first' => 'Elizabeth', 'last' => 'Smith'}, 'id' => '5966ed736b21538e3c000006'}},
+  let(:student_list) do
+    [
+      {'data' => {'roles' => {'student' => {'dob' => '2002-09-04T00:00:00.000Z'}}, 'name' => {'first' => 'Ethan', 'last' => 'Doe'}, 'id' => '5966ed736b21538e3c000004'}},
+      {'data' => {'roles' => {'student' => {'dob' => '2000-02-11T00:00:00.000Z'}}, 'name' => {'first' => 'Lily', 'last' => 'Fake'}, 'id' => '5966ed736b21538e3c000005'}},
+      {'data' => {'roles' => {'student' => {'dob' => '2002-05-21T00:00:00.000Z'}}, 'name' => {'first' => 'Elizabeth', 'last' => 'Smith'}, 'id' => '5966ed736b21538e3c000006'}},
     ]
-
-    section = CleverSection.from_service('101', owner.id, student_list, 'Clever Section A')
-    section.reload
-    assert section.provider_managed?
-    assert_equal 'C-101', section.code
-    assert_equal 'Clever Section A', section.name
-    assert_equal 'Elizabeth Smith', section.students.first.name
-    assert_nil section.students.first.family_name
-
-    assert_no_difference 'User.count' do
-      # Should find the existing Clever section.
-      section_2 = CleverSection.from_service('101', owner.id, student_list, 'Clever Section B')
-      assert_equal section.id, section_2.id
-
-      # Should update the name to match the imported name.
-      assert_equal 'Clever Section B', section_2.name
-    end
   end
 
-  test 'from clever service with family name import' do
-    DCDO.stubs(:get).with('clever_family_name', false).returns(true)
+  test 'from clever service' do
     DCDO.stubs(:get).with(I18nStringUrlTracker::I18N_STRING_TRACKING_DCDO_KEY, false).returns(false)
     DCDO.stubs(:get).with('migration_service_enabled', false).returns(false)
 
     owner = create(:teacher)
-    student_list = [
-      {'data' => {'dob' => '2002-09-04T00:00:00.000Z', 'name' => {'first' => 'Ethan', 'last' => 'Doe'}, 'id' => '5966ed736b21538e3c000004'}},
-      {'data' => {'dob' => '2000-02-11T00:00:00.000Z', 'name' => {'first' => 'Lily', 'last' => 'Fake'}, 'id' => '5966ed736b21538e3c000005'}},
-      {'data' => {'dob' => '2002-05-21T00:00:00.000Z', 'name' => {'first' => 'Elizabeth', 'last' => 'Smith'}, 'id' => '5966ed736b21538e3c000006'}},
-    ]
 
     section = CleverSection.from_service('101', owner.id, student_list, 'Clever Section A')
     section.reload

--- a/dashboard/test/vcr_cassettes/api/get_import_clever_classroom/with_expired_oauth_token.yml
+++ b/dashboard/test/vcr_cassettes/api/get_import_clever_classroom/with_expired_oauth_token.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://api.clever.com/v2.1/sections/expected_course_id/students
+    uri: https://api.clever.com/v3.0/sections/expected_course_id/users?role=student
     body:
       encoding: US-ASCII
       string: ''


### PR DESCRIPTION
This updates the `import_clever_classroom` route to call the new v3 Clever endpoint to retrieve section rosters. The endpoint has changed from `/sections/:id/students` to `sections/:id/users?role=student`. Also, the format of the response is slightly different. Most of the fields we utilize are in the same location, except for `dob`, which is now nested inside the roles object. Other than that, the v3 endpoint should "just work" - the v2.1 and v3.0 access tokens both work against the new API, and section and student IDs remain unchanged.

While I was in the code I also removed logic around the `clever_family_name` DCDO flag. I confirmed with Teacher Tools that this flag is no longer useful since the family name feature is now permanently enabled elsewhere in the code.

## Links
[JIRA](https://codedotorg.atlassian.net/browse/P20-1657)

## Testing story
<!--  Does your change include appropriate tests?
      - If so, please describe how the tests included in this PR are sufficient.
      - If not, please explain why this change does not need to be tested. -->



## Deployment strategy
<!--  Any special steps required to deploy this, besides merging?
      - Are there database migrations or manual steps?
      - Does this require coordination with other teams or systems? -->



## Follow-up work
<!--  List any clean-up or technical debt that will be addressed in future work.
      - Include Jira links where applicable.
      - Are there any known limitations or improvements planned? -->



## Privacy
<!--  How does this change impact Student & Teacher privacy?
      - Does this collect, use, share, or modify PII, either new or existing? -->



## Security
<!--  How does this change impact our security surface-area?
      - Do API's touched have the right auth?
      - Do infra changes impact our attack surface or encryption?
-->



## Caching
<!--  How does this change impact caching behavior?
      - Are cache keys or invalidation strategies affected?
      - Will this require cache warming or invalidation after deployment? -->



## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
