### PR TITLE
AI Chat: only report to Honeybadger full logs when DCDO flag enabled

### DIFF
--- a/aws/cloudformation/standalone/gen_ai_curriculum/monitoring/alarms/configurations/chatCompletionHighBrowserFailureRate.ts
+++ b/aws/cloudformation/standalone/gen_ai_curriculum/monitoring/alarms/configurations/chatCompletionHighBrowserFailureRate.ts
@@ -14,6 +14,7 @@ export const chatCompletionHighBrowserFailureRateConfiguration: PutMetricAlarmIn
 - Check the [GenAICurriculum Dashboard](https://us-east-1.console.aws.amazon.com/cloudwatch/home?region=us-east-1#dashboards/dashboard/GenAICurriculum)
 - Check [browser logs](https://us-east-1.console.aws.amazon.com/cloudwatch/home?region=us-east-1#logsV2:log-groups/log-group/production-browser-events/log-events/production) in Cloudwatch (filter by **appName: 'aichat'**)
 - If chat completion job failure rates and/or OpenAI failure rates are also elevated, check HoneyBadger for **AichatRequestChatCompletionJob** errors.
+- You can set the DCDO flag \`aichat_verbose_honeybadger_reporting\` to true to get more detailed error reports in HoneyBadger, which may help with debugging.
 - If not, this is likely a browser-specific and/or ActiveJob related issue. Check the [ActiveJob dashboard](https://us-east-1.console.aws.amazon.com/cloudwatch/home?region=us-east-1#dashboards/dashboard/ActiveJob_DelayedJob).
 - Check [Student Learning Tips & Tricks](${SL_HANDBOOK_LINK}) for more details.`,
         ActionsEnabled: true,

--- a/aws/cloudformation/standalone/gen_ai_curriculum/monitoring/alarms/configurations/chatCompletionJobExecutionHighFailureRateOpenai.ts
+++ b/aws/cloudformation/standalone/gen_ai_curriculum/monitoring/alarms/configurations/chatCompletionJobExecutionHighFailureRateOpenai.ts
@@ -20,6 +20,7 @@ export const chatCompletionJobExecutionHighFailureRateOpenaiConfiguration: PutMe
 *Next Steps*:
 - Check the [GenAICurriculum Dashboard](https://us-east-1.console.aws.amazon.com/cloudwatch/home?region=us-east-1#dashboards/dashboard/GenAICurriculum)
 - Check HoneyBadger for **AichatRequestChatCompletionJob** errors
+- You can set the DCDO flag \`aichat_verbose_honeybadger_reporting\` to true to get more detailed error reports in HoneyBadger, which may help with debugging.
 - Check [Student Learning Tips & Tricks](${SL_HANDBOOK_LINK}) for more details.`,
         ActionsEnabled: true,
         OKActions: [],

--- a/aws/cloudformation/standalone/gen_ai_curriculum/monitoring/alarms/configurations/chatCompletionJobExecutionHighFailureRateSagemaker.ts
+++ b/aws/cloudformation/standalone/gen_ai_curriculum/monitoring/alarms/configurations/chatCompletionJobExecutionHighFailureRateSagemaker.ts
@@ -20,6 +20,7 @@ export const chatCompletionJobExecutionHighFailureRateSagemakerConfiguration: Pu
 *Next Steps*:
 - Check the [GenAICurriculum Dashboard](https://us-east-1.console.aws.amazon.com/cloudwatch/home?region=us-east-1#dashboards/dashboard/GenAICurriculum)
 - Check HoneyBadger for **AichatRequestChatCompletionJob** errors
+- You can set the DCDO flag \`aichat_verbose_honeybadger_reporting\` to true to get more detailed error reports in HoneyBadger, which may help with debugging.
 - Check [Student Learning Tips & Tricks](${SL_HANDBOOK_LINK}) for more details.`,
         ActionsEnabled: true,
         OKActions: [],

--- a/dashboard/app/helpers/aichat_ai_helper.rb
+++ b/dashboard/app/helpers/aichat_ai_helper.rb
@@ -215,14 +215,17 @@ module AichatAiHelper
     end
 
     request.update!(response: exception.message, execution_status: SharedConstants::AI_REQUEST_EXECUTION_STATUS[:FAILURE])
-    Honeybadger.notify(
-      "#{source} failed with unexpected error: #{exception.message}",
-      context: {
-        request: request.to_json,
-        user_id: request.user_id,
-        locale: locale
-      }
-    )
+
+    if DCDO.get('aichat_verbose_honeybadger_reporting', false)
+      Honeybadger.notify(
+        "#{source} failed with unexpected error: #{exception.message}",
+        context: {
+          request: request.to_json,
+          user_id: request.user_id,
+          locale: locale
+        }
+      )
+    end
   end
 
   def self.build_request_attributes(user_id, params)


### PR DESCRIPTION
We've had a couple of confused DOTDs recently ([most recent report, also links to first report](https://codedotorg.slack.com/archives/C03DBDN67B7/p1770164759837219)) because we send a duplicate report of all AI Chat Active Job errors under a generic "Notice" to Honeybadger.

Elijah suggested putting this behind a DCDO flag that we can enable if we want more detailed error reports (thanks Elijah!)

## Testing story

Tested manually that DCDO (at least locally) effectively gated behavior with delayed_job turned on as the queue adapter via locals.yml. I also found another instance of DCDO in use in an Active Job, and Suresh noted that DCDO should be fine in Active Job.

## Follow-up work

I added the flag to our alarm configurations as well (will need to redeploy these changes), which hopefully should help with discoverability. I'll also send a message to our team to alert about this change.