### PR TITLE
Sketch Lab: Hide Libraries feature via global CSS

### DIFF
--- a/apps/src/sketchlab/styles/sketchlab-view.module.scss
+++ b/apps/src/sketchlab/styles/sketchlab-view.module.scss
@@ -12,3 +12,7 @@
 :global(.excalidraw .popover) {
   display: block;
 }
+
+:global(.excalidraw .sidebar-trigger) {
+  display: none;
+}


### PR DESCRIPTION
Hides the libraries side panel, which currently breaks the page on reload if you try to use them 😅 

## Links

- Slack thread: https://codedotorg.slack.com/archives/C036XVC3CBF/p1770232936832779
- GitHub issue on Excalidraw issue on how to fix this (no prop or anything currently 😞 ): https://github.com/excalidraw/excalidraw/issues/7425

## Testing story

Tested manually that the sidebar / "Library" button to open the sidebar do not appear either in the standard or mobile view after this change.