### PR TITLE
Rubrics: Allow grading on sublevels

### DIFF
--- a/apps/src/lab2/types.ts
+++ b/apps/src/lab2/types.ts
@@ -258,6 +258,7 @@ export interface LevelProperties {
   customHelperLibrary?: string;
   validationCode?: string;
   hideVersionHistory?: boolean;
+  parentLevelName?: string;
 }
 
 export type LevelPropertiesMap = {[levelId: string]: LevelProperties};

--- a/apps/src/lab2/views/components/rubrics/RubricFABContainer.tsx
+++ b/apps/src/lab2/views/components/rubrics/RubricFABContainer.tsx
@@ -16,7 +16,7 @@ import {useRubric} from './RubricWrapper';
 const RubricFABContainer: React.FC = () => {
   const {rubricData, showRubric, isLoading: isLoadingRubric} = useRubric();
   const {levelProperties} = useLevelProperties();
-  const {name: levelName, appName} = levelProperties;
+  const {name: levelName, appName, parentLevelName} = levelProperties;
 
   const isTeacher = useAppSelector(state => state.currentUser.isTeacher);
   const labLoading = useAppSelector(isLabLoading);
@@ -99,6 +99,7 @@ const RubricFABContainer: React.FC = () => {
         aiEnabled={rubric.learningGoals?.some(lg => lg?.aiEnabled)}
         canShowTaScoresAlert={canShowTaScoresAlert}
         reloadOnStudentChange={false}
+        parentLevelName={parentLevelName}
       />
     </div>
   );

--- a/apps/src/lab2/views/components/rubrics/RubricFABContainer.tsx
+++ b/apps/src/lab2/views/components/rubrics/RubricFABContainer.tsx
@@ -16,7 +16,7 @@ import {useRubric} from './RubricWrapper';
 const RubricFABContainer: React.FC = () => {
   const {rubricData, showRubric, isLoading: isLoadingRubric} = useRubric();
   const {levelProperties} = useLevelProperties();
-  const {name: levelName, appName, parentLevelName} = levelProperties;
+  const {name: levelName, appName, parentLevelName, type} = levelProperties;
 
   const isTeacher = useAppSelector(state => state.currentUser.isTeacher);
   const labLoading = useAppSelector(isLabLoading);
@@ -100,6 +100,7 @@ const RubricFABContainer: React.FC = () => {
         canShowTaScoresAlert={canShowTaScoresAlert}
         reloadOnStudentChange={false}
         parentLevelName={parentLevelName}
+        levelType={type}
       />
     </div>
   );

--- a/apps/src/sites/studio/pages/levels/show.js
+++ b/apps/src/sites/studio/pages/levels/show.js
@@ -86,7 +86,14 @@ function initPage() {
 
   if (hasScriptData('script[data-rubricdata]')) {
     const rubricData = getScriptData('rubricdata');
-    const {rubric, studentLevelInfo, canShowTaScoresAlert} = rubricData;
+    const {
+      rubric,
+      studentLevelInfo,
+      canShowTaScoresAlert,
+      parentLevelName,
+      levelType,
+    } = rubricData;
+
     const reportingData = {
       unitName: config.script_name,
       courseName: config.course_name,
@@ -121,7 +128,9 @@ function initPage() {
             reportingData={reportingData}
             currentLevelName={config.level_name}
             aiEnabled={rubric.learningGoals.some(lg => lg.aiEnabled)}
+            parentLevelName={parentLevelName}
             canShowTaScoresAlert={canShowTaScoresAlert}
+            levelType={levelType}
           />
         </Provider>,
         rubricFabMountPoint

--- a/apps/src/templates/rubrics/RubricFloatingActionButton.jsx
+++ b/apps/src/templates/rubrics/RubricFloatingActionButton.jsx
@@ -79,6 +79,7 @@ function RubricFloatingActionButton({
   aiEnabled,
   sectionId,
   canShowTaScoresAlert,
+  parentLevelName,
   reloadOnStudentChange = true,
 }) {
   const sessionStorageKey = 'RubricFabOpenStateKey';
@@ -98,7 +99,10 @@ function RubricFloatingActionButton({
 
   const [internalError, setInternalError] = useState(null);
 
-  const onLevelForEvaluation = currentLevelName === rubric.level.name;
+  const onLevelForEvaluation =
+    currentLevelName === rubric.level.name ||
+    parentLevelName === rubric.level.name;
+  console.log({parentLevelName, rubricLevelName: rubric.level.name});
 
   const readyStudentCount = useAppSelector(selectReadyStudentCount);
   const hasLoadedStudentStatus = useAppSelector(selectHasLoadedStudentStatus);
@@ -109,9 +113,17 @@ function RubricFloatingActionButton({
     return {
       ...reportingData,
       viewingStudentWork: !!studentLevelInfo,
-      viewingEvaluationLevel: rubric.level.name === currentLevelName,
+      viewingEvaluationLevel:
+        rubric.level.name === currentLevelName ||
+        rubric.level.name === parentLevelName,
     };
-  }, [reportingData, studentLevelInfo, rubric.level.name, currentLevelName]);
+  }, [
+    reportingData,
+    studentLevelInfo,
+    rubric.level.name,
+    currentLevelName,
+    parentLevelName,
+  ]);
 
   const handleClick = () => {
     const eventName = isOpen
@@ -301,6 +313,7 @@ RubricFloatingActionButton.propTypes = {
   sectionId: PropTypes.number,
   canShowTaScoresAlert: PropTypes.bool,
   reloadOnStudentChange: PropTypes.bool,
+  parentLevelName: PropTypes.string,
 };
 
 export const UnconnectedRubricFloatingActionButton = RubricFloatingActionButton;

--- a/apps/src/templates/rubrics/RubricFloatingActionButton.jsx
+++ b/apps/src/templates/rubrics/RubricFloatingActionButton.jsx
@@ -80,6 +80,7 @@ function RubricFloatingActionButton({
   sectionId,
   canShowTaScoresAlert,
   parentLevelName,
+  levelType,
   reloadOnStudentChange = true,
 }) {
   const sessionStorageKey = 'RubricFabOpenStateKey';
@@ -99,10 +100,14 @@ function RubricFloatingActionButton({
 
   const [internalError, setInternalError] = useState(null);
 
+  // We do not evaluate on Bubble Choice levels directly, we only evaluate on
+  // the child levels. If the level is not a bubble choice level, we evaluate on the
+  // level that matches the rubric level name, or any child levels of the level that
+  // matches the rubric level name (likely the parent in this case is a Bubble Choice level).
   const onLevelForEvaluation =
-    currentLevelName === rubric.level.name ||
-    parentLevelName === rubric.level.name;
-  console.log({parentLevelName, rubricLevelName: rubric.level.name});
+    levelType !== 'BubbleChoice' &&
+    (currentLevelName === rubric.level.name ||
+      parentLevelName === rubric.level.name);
 
   const readyStudentCount = useAppSelector(selectReadyStudentCount);
   const hasLoadedStudentStatus = useAppSelector(selectHasLoadedStudentStatus);
@@ -113,17 +118,9 @@ function RubricFloatingActionButton({
     return {
       ...reportingData,
       viewingStudentWork: !!studentLevelInfo,
-      viewingEvaluationLevel:
-        rubric.level.name === currentLevelName ||
-        rubric.level.name === parentLevelName,
+      viewingEvaluationLevel: onLevelForEvaluation,
     };
-  }, [
-    reportingData,
-    studentLevelInfo,
-    rubric.level.name,
-    currentLevelName,
-    parentLevelName,
-  ]);
+  }, [reportingData, studentLevelInfo, onLevelForEvaluation]);
 
   const handleClick = () => {
     const eventName = isOpen
@@ -314,6 +311,7 @@ RubricFloatingActionButton.propTypes = {
   canShowTaScoresAlert: PropTypes.bool,
   reloadOnStudentChange: PropTypes.bool,
   parentLevelName: PropTypes.string,
+  levelType: PropTypes.string,
 };
 
 export const UnconnectedRubricFloatingActionButton = RubricFloatingActionButton;

--- a/apps/src/templates/rubrics/RubricFloatingActionButton.jsx
+++ b/apps/src/templates/rubrics/RubricFloatingActionButton.jsx
@@ -101,7 +101,7 @@ function RubricFloatingActionButton({
   const [internalError, setInternalError] = useState(null);
 
   // We do not evaluate on Bubble Choice levels directly, we only evaluate on
-  // the child levels. If the level is not a bubble choice level, we evaluate on the
+  // their child levels. If this level is not a bubble choice level, we evaluate on the
   // level that matches the rubric level name, or any child levels of the level that
   // matches the rubric level name (likely the parent in this case is a Bubble Choice level).
   const onLevelForEvaluation = useMemo(

--- a/apps/src/templates/rubrics/RubricFloatingActionButton.jsx
+++ b/apps/src/templates/rubrics/RubricFloatingActionButton.jsx
@@ -104,10 +104,13 @@ function RubricFloatingActionButton({
   // the child levels. If the level is not a bubble choice level, we evaluate on the
   // level that matches the rubric level name, or any child levels of the level that
   // matches the rubric level name (likely the parent in this case is a Bubble Choice level).
-  const onLevelForEvaluation =
-    levelType !== 'BubbleChoice' &&
-    (currentLevelName === rubric.level.name ||
-      parentLevelName === rubric.level.name);
+  const onLevelForEvaluation = useMemo(
+    () =>
+      levelType !== 'BubbleChoice' &&
+      (currentLevelName === rubric.level.name ||
+        parentLevelName === rubric.level.name),
+    [levelType, currentLevelName, rubric.level.name, parentLevelName]
+  );
 
   const readyStudentCount = useAppSelector(selectReadyStudentCount);
   const hasLoadedStudentStatus = useAppSelector(selectHasLoadedStudentStatus);

--- a/apps/test/unit/templates/rubrics/RubricFloatingActionButtonTest.jsx
+++ b/apps/test/unit/templates/rubrics/RubricFloatingActionButtonTest.jsx
@@ -58,6 +58,8 @@ const defaultProps = {
   currentLevelName: 'test_level',
   studentLevelInfo: null,
   aiEnabled: true,
+  parentLevelName: null,
+  levelType: 'Gamelab',
 };
 
 describe('RubricFloatingActionButton', () => {

--- a/dashboard/app/controllers/script_levels_controller.rb
+++ b/dashboard/app/controllers/script_levels_controller.rb
@@ -216,6 +216,8 @@ class ScriptLevelsController < ApplicationController
     if @rubric && ai_rubrics_enabled_for_user
       @rubric_data = {rubric: @rubric.summarize}
       @rubric_data[:canShowTaScoresAlert] = can_show_ta_scores_alert?(@script_level.lesson)
+      @rubric_data[:parentLevelName] = @script_level.level.name if @script_level.bubble_choice?
+      @rubric_data[:levelType] = @level.type
       if @script_level.lesson.rubric && view_as_other
         viewing_user_level = @view_as_user.user_levels.find_by(script: @script_level.script, level: @level)
         @rubric_data[:studentLevelInfo] = {

--- a/dashboard/app/controllers/script_levels_controller.rb
+++ b/dashboard/app/controllers/script_levels_controller.rb
@@ -216,7 +216,7 @@ class ScriptLevelsController < ApplicationController
     if @rubric && ai_rubrics_enabled_for_user
       @rubric_data = {rubric: @rubric.summarize}
       @rubric_data[:canShowTaScoresAlert] = can_show_ta_scores_alert?(@script_level.lesson)
-      @rubric_data[:parentLevelName] = @script_level.level.name if @script_level.bubble_choice?
+      @rubric_data[:parentLevelName] = @level.get_parent_level_for_script(@script.id)&.name
       @rubric_data[:levelType] = @level.type
       if @script_level.lesson.rubric && view_as_other
         viewing_user_level = @view_as_user.user_levels.find_by(script: @script_level.script, level: @level)

--- a/dashboard/app/controllers/script_levels_controller.rb
+++ b/dashboard/app/controllers/script_levels_controller.rb
@@ -216,7 +216,7 @@ class ScriptLevelsController < ApplicationController
     if @rubric && ai_rubrics_enabled_for_user
       @rubric_data = {rubric: @rubric.summarize}
       @rubric_data[:canShowTaScoresAlert] = can_show_ta_scores_alert?(@script_level.lesson)
-      @rubric_data[:parentLevelName] = @level.get_parent_level_for_script(@script.id)&.name
+      @rubric_data[:parentLevelName] = @level.get_parent_level_for_script(@script_level&.script&.id)&.name
       @rubric_data[:levelType] = @level.type
       if @script_level.lesson.rubric && view_as_other
         viewing_user_level = @view_as_user.user_levels.find_by(script: @script_level.script, level: @level)

--- a/dashboard/app/models/levels/level.rb
+++ b/dashboard/app/models/levels/level.rb
@@ -947,9 +947,11 @@ class Level < ApplicationRecord
     # In addition, show the rubric if the evaluation level shares the same project template level as this level.
     # If the level is a sublevel and has a project template level, also show the rubric if the evaluation level has a sublevel
     # with the same project template level.
+    # We don't show rubrics on Bubble choice levels, even if the rubric is defined on that level. The rubric will always instead be shown on
+    # the children of a bubble choice level.
     rubric_level_id = script_level&.lesson&.rubric&.level_id
     if rubric_level_id
-      if rubric_level_id == id || rubric_level_id == current_parent&.id
+      if (rubric_level_id == id && type != 'BubbleChoice') || rubric_level_id == current_parent&.id
         properties_camelized[:showRubric] = true
       else
         rubric_level = Level.find(rubric_level_id)

--- a/dashboard/app/models/levels/level.rb
+++ b/dashboard/app/models/levels/level.rb
@@ -940,11 +940,7 @@ class Level < ApplicationRecord
       properties_camelized["predictSettings"]&.delete("solution")
       properties_camelized["predictSettings"]&.delete("multipleChoiceAnswers")
     end
-    current_parent = parent_levels.find do |parent|
-      parent.script_levels.find do |parent_script|
-        parent_script&.script_id == script_level&.script_id
-      end
-    end
+    current_parent = get_parent_level_for_script(script.id)
     properties_camelized[:parentLevelName] = current_parent&.name
 
     # If there is a rubric for this lesson, show the rubric if it is evaluated on this level or the level's parent.
@@ -1067,6 +1063,14 @@ class Level < ApplicationRecord
   def uses_theme_preference?
     # These are the level types that set and use the theme preference in UserPreferences right now.
     is_a?(Pythonlab) || is_a?(Weblab2) || is_a?(Sketchlab)
+  end
+
+  def get_parent_level_for_script(script_id)
+    parent_levels.find do |parent|
+      parent.script_levels.find do |script|
+        script&.script_id == script_id
+      end
+    end
   end
 
   # Returns the level name, removing the name_suffix first (if present), and

--- a/dashboard/app/models/levels/level.rb
+++ b/dashboard/app/models/levels/level.rb
@@ -940,6 +940,12 @@ class Level < ApplicationRecord
       properties_camelized["predictSettings"]&.delete("solution")
       properties_camelized["predictSettings"]&.delete("multipleChoiceAnswers")
     end
+    current_parent = parent_levels.find do |parent|
+      parent.script_levels.find do |parent_script|
+        parent_script&.script_id == script_level&.script_id
+      end
+    end
+    properties_camelized[:parentLevelName] = current_parent&.name
 
     # If there is a rubric for this lesson, show the rubric if it is evaluated on this level or the level's parent.
     # In addition, show the rubric if the evaluation level shares the same project template level as this level.
@@ -947,11 +953,6 @@ class Level < ApplicationRecord
     # with the same project template level.
     rubric_level_id = script_level&.lesson&.rubric&.level_id
     if rubric_level_id
-      current_parent = parent_levels.find do |parent|
-        parent.script_levels.find do |script|
-          script&.script_id == script_level&.script_id
-        end
-      end
       if rubric_level_id == id || rubric_level_id == current_parent&.id
         properties_camelized[:showRubric] = true
       else

--- a/dashboard/app/models/levels/level.rb
+++ b/dashboard/app/models/levels/level.rb
@@ -940,7 +940,7 @@ class Level < ApplicationRecord
       properties_camelized["predictSettings"]&.delete("solution")
       properties_camelized["predictSettings"]&.delete("multipleChoiceAnswers")
     end
-    current_parent = get_parent_level_for_script(script.id)
+    current_parent = get_parent_level_for_script(script&.id)
     properties_camelized[:parentLevelName] = current_parent&.name
 
     # If there is a rubric for this lesson, show the rubric if it is evaluated on this level or the level's parent.
@@ -1068,6 +1068,9 @@ class Level < ApplicationRecord
   end
 
   def get_parent_level_for_script(script_id)
+    unless script_id
+      return
+    end
     parent_levels.find do |parent|
       parent.script_levels.find do |script|
         script&.script_id == script_id

--- a/dashboard/app/models/levels/level.rb
+++ b/dashboard/app/models/levels/level.rb
@@ -1072,8 +1072,8 @@ class Level < ApplicationRecord
       return
     end
     parent_levels.find do |parent|
-      parent.script_levels.find do |script|
-        script&.script_id == script_id
+      parent.script_levels.find do |script_level|
+        script_level&.script_id == script_id
       end
     end
   end


### PR DESCRIPTION
This PR updates the logic for what level is an "assessment" level when sublevels/bubble choice is involved. If a rubric is defined on a Bubble Choice level, we want to assess on the sublevels of that level, rather than the level itself. This updates to logic on the backend and frontend to support this.

In addition, on legacy labs the rubric is shown on every level within a lesson where the rubric is defined. For lab2, we only show the rubric on levels that share a template with the rubric level (or that share a template with a sublevel of the rubric level, for Bubble Choice). After discussing with curriculum, we will also hide the rubric on the Bubble Choice level itself, even if the rubric is defined on that level, because the teacher will not be evaluating the rubric on the Bubble Choice level but instead on the child level(s).

## Screen recording

https://github.com/user-attachments/assets/de290ff9-0265-4922-8601-f5add6775dc4


## Links

- Jira: [AFL-436](https://codedotorg.atlassian.net/browse/AFL-436)

## Testing story
Tested locally.



## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
