### PR TITLE
Add a storybook default decorator that adds MUI

### DIFF
--- a/apps/.storybook/decorators.d.ts
+++ b/apps/.storybook/decorators.d.ts
@@ -6,3 +6,5 @@ export declare const reduxStore: (reducers?: object, state?: object) => Store;
 export declare const reduxStoreDecorator: DecoratorFunction;
 
 export declare const withGlobalEdition: DecoratorFunction;
+
+export declare const MuiDecorator: DecoratorFunction;

--- a/apps/.storybook/decorators.js
+++ b/apps/.storybook/decorators.js
@@ -1,3 +1,5 @@
+import {CdoTheme} from '@code-dot-org/component-library/themes';
+import {ThemeProvider as MuiThemeProvider} from '@mui/material';
 import {merge} from 'lodash';
 import {Provider} from 'react-redux';
 import {createStore, combineReducers, applyMiddleware} from 'redux';
@@ -20,6 +22,13 @@ export const reduxStoreDecorator = function (Story, context) {
   return Provider({
     children: Story(),
     store: reduxStore(this.reducers, state),
+  });
+};
+
+export const MuiDecorator = Story => {
+  return MuiThemeProvider({
+    theme: CdoTheme,
+    children: Story(),
   });
 };
 

--- a/apps/.storybook/preview.js
+++ b/apps/.storybook/preview.js
@@ -3,6 +3,8 @@ import '@code-dot-org/component-library-styles/colors.css';
 import {injectFontAwesome} from '@code-dot-org/fonts';
 import $ from 'jquery';
 
+import {MuiDecorator} from './decorators';
+
 injectFontAwesome();
 
 //Stub jquery fileupload library function
@@ -16,4 +18,5 @@ export const parameters = {
     },
   },
 };
+export const decorators = [MuiDecorator];
 export const tags = ['autodocs'];

--- a/apps/src/templates/studentSnapshot/lessonInsightWidget/LessonInsightWidget.story.tsx
+++ b/apps/src/templates/studentSnapshot/lessonInsightWidget/LessonInsightWidget.story.tsx
@@ -1,5 +1,3 @@
-import {CdoTheme} from '@code-dot-org/component-library/themes';
-import {ThemeProvider as MuiThemeProvider} from '@mui/material/styles';
 import type {Meta, StoryObj} from '@storybook/react';
 import React from 'react';
 import {Provider} from 'react-redux';
@@ -19,21 +17,19 @@ const meta: Meta<typeof LessonInsightWidget> = {
   component: LessonInsightWidget,
   decorators: [
     Story => (
-      <MuiThemeProvider theme={CdoTheme}>
-        <Provider store={mockStore}>
-          <div
-            style={{
-              display: 'grid',
-              gridTemplateColumns: '1fr 1fr 1fr',
-              gridAutoRows: '200px',
-              gap: '12px',
-              minWidth: '600px',
-            }}
-          >
-            <Story />
-          </div>
-        </Provider>
-      </MuiThemeProvider>
+      <Provider store={mockStore}>
+        <div
+          style={{
+            display: 'grid',
+            gridTemplateColumns: '1fr 1fr 1fr',
+            gridAutoRows: '200px',
+            gap: '12px',
+            minWidth: '600px',
+          }}
+        >
+          <Story />
+        </div>
+      </Provider>
     ),
   ],
   parameters: {

--- a/apps/src/templates/studentSnapshot/lessonInsightWidget/lessonInsightWidget.module.scss
+++ b/apps/src/templates/studentSnapshot/lessonInsightWidget/lessonInsightWidget.module.scss
@@ -55,7 +55,7 @@
   }
 }
 
-p.aiGeneratedLabel {
+span.aiGeneratedLabel {
   padding: 4px 8px;
   color: var(--text-neutral-tertiary);
   font-size: 10px;

--- a/apps/src/templates/temp/typography/MuiTypography.story.tsx
+++ b/apps/src/templates/temp/typography/MuiTypography.story.tsx
@@ -1,5 +1,3 @@
-import {CdoTheme} from '@code-dot-org/component-library/themes';
-import {ThemeProvider as MuiThemeProvider} from '@mui/material/styles';
 import MuiTypography from '@mui/material/Typography';
 import type {Meta, StoryObj} from '@storybook/react';
 import React from 'react';
@@ -7,13 +5,6 @@ import React from 'react';
 export default {
   title: 'DesignSystem/MUITypography', // eslint-disable-line storybook/no-title-property-in-meta
   component: MuiTypography,
-  decorators: [
-    Story => (
-      <MuiThemeProvider theme={CdoTheme}>
-        <Story />
-      </MuiThemeProvider>
-    ),
-  ],
 } as Meta;
 
 type Story = StoryObj<typeof MuiTypography>;


### PR DESCRIPTION
Adds a default decorator to all /apps storybooks that wraps it in the relevant <ThemeProvider> from MUI using the default CDO theme
