### PR TITLE
P20-1354: Fix `HoneybadgerTest#test_does_NOT_log_encrypted_data`

### DIFF
--- a/dashboard/test/integration/honeybadger_test.rb
+++ b/dashboard/test/integration/honeybadger_test.rb
@@ -1,51 +1,37 @@
 require 'test_helper'
 
-class HoneybadgerErrorController < ApplicationController
-  def raise_error
-    Honeybadger.notify("Test Error!")
-    raise "Test Error!"
-  end
-end
-
 class HoneybadgerTest < ActionDispatch::IntegrationTest
-  setup do
-    Rails.application.routes.draw do
-      get 'raise_error' => 'honeybadger_error#raise_error'
+  describe 'notice' do
+    ERROR_MESSAGE = 'HoneybadgerTest error_message'.freeze
+
+    class ErrorController < ApplicationController
+      def notify
+        Honeybadger.notify(ERROR_MESSAGE)
+      end
     end
 
-    Honeybadger.configure do |config|
-      @original_backend = config.backend
-      config.backend = 'test'
-      @original_api_key = config.api_key
-      config.api_key = 'test_key'
+    subject(:notice) {Honeybadger::Backend::Test.notifications[:notices].find {|n| n.error_message == ERROR_MESSAGE}}
+
+    let(:user) {create(:user)}
+
+    around do |test|
+      Rails.application.routes.draw do
+        get :notify_error, controller: ErrorController.new.controller_path, action: :notify
+      end
+
+      test.call
+    ensure
+      Rails.application.reload_routes!
     end
-  end
 
-  teardown do
-    Rails.application.reload_routes!
-
-    Honeybadger.configure do |config|
-      config.backend = @original_backend
-      config.api_key = @original_api_key
+    before do
+      sign_in user
     end
-  end
 
-  # The value Honeybadger will set a filtered value to.
-  FILTERED = "[FILTERED]"
-
-  test "does NOT log encrypted data" do
-    skip 'races the reconfiguration and errors if it contacts real honeybadger server'
-    student = create(:student)
-    sign_in student
-
-    get raise_error_path
-
-    # Ensure that the notifications hit the backend queue
-    Honeybadger.flush
-
-    # Other tests running in parallel might have logged notices too, but we're only interested in notices about our test controller
-    notice = Honeybadger::Backend::Test.notifications[:notices].find {|n| n.controller == "honeybadger_error"}
-    refute_nil notice
-    assert_equal FILTERED, notice.as_json[:request][:session]["warden.user.user.key"]
+    it 'filters encrypted user data' do
+      get notify_error_path
+      _notice.wont_be_nil
+      _(notice.as_json.dig(:request, :session, 'warden.user.user.key')).must_equal '[FILTERED]'
+    end
   end
 end

--- a/dashboard/test/testing/honeybadger.rb
+++ b/dashboard/test/testing/honeybadger.rb
@@ -1,6 +1,7 @@
 require 'honeybadger'
 
 Honeybadger.configure do |config|
+  config.backend = :test
   # Prevents outbound HTTP requests.
   config.report_data = false
 end


### PR DESCRIPTION
The error should no longer occur, since we explicitly block `Honeybadger` from contacting the external service during unit tests: https://github.com/code-dot-org/code-dot-org/blob/33066a9eec297b4f6f695da5498690cd0eb7cc2b/dashboard/test/testing/honeybadger.rb#L3-L7

## Error
```bash
[0m[1000D[K FAIL["test_does_NOT_log_encrypted_data", "HoneybadgerTest", 189.0804768241942]
 test_does_NOT_log_encrypted_data#HoneybadgerTest (189.08s)
        Expected nil to not be nil.
        test/integration/honeybadger_test.rb:47:in `block in <class:HoneybadgerTest>'
        test/testing/setup_all_and_teardown_all.rb:36:in `run'
```

## Links
- JIRA task: [P20-1354](https://codedotorg.atlassian.net/browse/P20-1354)
- Related PRs: https://github.com/code-dot-org/code-dot-org/pull/53545, https://github.com/code-dot-org/code-dot-org/pull/63667