### PR TITLE
Sketch Lab: always clone initial state so it is not frozen and can be modified

### DIFF
--- a/apps/src/sketchlab/SketchlabView.tsx
+++ b/apps/src/sketchlab/SketchlabView.tsx
@@ -12,6 +12,7 @@ import {
   ExcalidrawInitialDataState,
   DataURL,
 } from '@excalidraw/excalidraw/types/types';
+import cloneDeep from 'lodash/cloneDeep';
 import React, {useEffect, useCallback, useRef, useState, useMemo} from 'react';
 
 import useLevelEditMode from '@cdo/apps/lab2/hooks/useLevelEditMode';
@@ -133,17 +134,21 @@ const SketchlabView: React.FC<LabProps<LevelProperties>> = ({
     console.error(error);
   }, []);
 
-  const initialData = useMemo(
-    () =>
-      experiments.isEnabledAllowingQueryString(S3_IMAGE_EXPERIMENT)
-        ? populateInitialExcalidrawState(
-            currentSources.source,
-            downloadedFilesDataRef.current,
-            onError
-          )
-        : (currentSources.source as ExcalidrawInitialDataState),
-    [currentSources.source, onError]
-  );
+  const initialData = useMemo(() => {
+    // Clone the sources to ensure we don't accidentally mutate the original object (which is frozen/immutable),
+    // since Excalidraw mutates the initial data object that is passed in.
+    const clonedSource = cloneDeep(
+      currentSources.source
+    ) as ExcalidrawInitialDataState;
+
+    return experiments.isEnabledAllowingQueryString(S3_IMAGE_EXPERIMENT)
+      ? populateInitialExcalidrawState(
+          clonedSource,
+          downloadedFilesDataRef.current,
+          onError
+        )
+      : clonedSource;
+  }, [currentSources.source, onError]);
 
   const currentUserId = useAppSelector(state => state.currentUser.userId);
   const backpackContext = useMemo(() => {

--- a/apps/src/sketchlab/utils/populateInitialExcalidrawState.ts
+++ b/apps/src/sketchlab/utils/populateInitialExcalidrawState.ts
@@ -3,7 +3,6 @@ import {
   ExcalidrawInitialDataState,
   DataURL,
 } from '@excalidraw/excalidraw/types/types';
-import cloneDeep from 'lodash/cloneDeep';
 
 import {ExcalidrawSourceWithExternalFiles} from '@cdo/apps/lab2/types';
 
@@ -14,14 +13,12 @@ export const populateInitialExcalidrawState = async (
   downloadedFileData: Record<ExcalidrawElement['id'], DataURL>,
   onError: (error: Error) => void
 ) => {
-  const excalidrawInitialState = cloneDeep(sourcesWithExternalFiles);
-
-  if (excalidrawInitialState.files) {
+  if (sourcesWithExternalFiles.files) {
     const imageDownloadPromises = Object.values(
-      excalidrawInitialState.files
+      sourcesWithExternalFiles.files
     ).map(async file => {
       if (!Object.keys(downloadedFileData).includes(file.id)) {
-        const fileUrl = excalidrawInitialState.externalFiles?.[file.id].url;
+        const fileUrl = sourcesWithExternalFiles.externalFiles?.[file.id].url;
         if (fileUrl) {
           // While we're still storing base64 encodings of strings in parallel with S3 uploads,
           // delete these so that we can confirm that the load from S3 is working.
@@ -52,6 +49,6 @@ export const populateInitialExcalidrawState = async (
 
   // Excalidraw does not need to access externalFiles, so we remove it
   // before passing this initial state to Excalidraw.
-  delete excalidrawInitialState.externalFiles;
-  return excalidrawInitialState as ExcalidrawInitialDataState;
+  delete sourcesWithExternalFiles.externalFiles;
+  return sourcesWithExternalFiles as ExcalidrawInitialDataState;
 };


### PR DESCRIPTION
Angelina noticed an issue with Sketch Lab pages not [loading](https://codedotorg.slack.com/archives/C036XVC3CBF/p1770232936832779) -- locally, this reproed as:

<img width="511" height="534" alt="image" src="https://github.com/user-attachments/assets/e3f5122f-a323-40ec-a9d2-ba3b404b88e6" />

I knew that you are not supposed to modify Redux/React state directly. I...did not realize there was a hard "this object is frozen and will fully error if you try to modify it". We were passing in a frozen object to Excalidraw, and it was erroring when it tried to modify it.

This updates the logic that passes initial data to Excalidraw and deep clones it in all cases in order to avoid any direct modifications to it.

I'm still not entirely sure whether this is specific to Redux Toolkit (eg, start sources seems to cause this problem and comes from Redux), or also a problem if you ever try and modify React state directly? I was also reading that this behavior (ie, hard freezing of objects) is sometimes development-only in order to catch bugs, but it repro'd on levelbuilder at least, which I believe is production-esque?

## Testing story

Without this change, I reproduced the error. With this change in place, I do not. I also did some breakpoint checking and such to examine the frozen state of the object being passed to Excalidraw.