### PR TITLE
Sketch Lab: mark file as successfully uploaded

### DIFF
--- a/apps/src/lab2/types.ts
+++ b/apps/src/lab2/types.ts
@@ -129,7 +129,7 @@ export type ExcalidrawSourceWithExternalFiles = Omit<
 };
 
 export type SketchlabProjectFile = Pick<ProjectFile, 'id' | 'url'> & {
-  uploadFailed?: boolean;
+  uploaded?: boolean;
   starterAsset?: boolean;
   filenameWithExtension?: string;
 };

--- a/apps/src/sketchlab/SketchlabView.tsx
+++ b/apps/src/sketchlab/SketchlabView.tsx
@@ -247,11 +247,22 @@ const SketchlabView: React.FC<LabProps<LevelProperties>> = ({
         });
 
         if (newFiles && !readonlyWorkspace) {
-          uploadExternalFiles(
+          const newFilesWithUploadStatus = await uploadExternalFiles(
             newFiles,
             serializedData.files,
             filesBeingUploadedRef
           );
+
+          // We update sources again on upload completion to update the upload status of the new files.
+          updateSources({
+            source: {
+              ...serializedData,
+              externalFiles: {
+                ...currentSources.source.externalFiles,
+                ...newFilesWithUploadStatus,
+              },
+            },
+          });
         }
       }, DEBOUNCED_WORKSPACE_SERIALIZATION_MS);
     },

--- a/apps/src/sketchlab/utils/uploadExternalFiles.ts
+++ b/apps/src/sketchlab/utils/uploadExternalFiles.ts
@@ -9,7 +9,7 @@ export const uploadExternalFiles = async (
   filesToUpload: SketchlabExternalFiles,
   excalidrawFiles: ExcalidrawFilesWithOptionalData,
   filesBeingUploadedRef: React.MutableRefObject<Set<string>>
-) => {
+): Promise<SketchlabExternalFiles> => {
   for (const [fileId, fileContents] of Object.entries(filesToUpload)) {
     filesBeingUploadedRef.current.add(fileId);
 
@@ -25,6 +25,8 @@ export const uploadExternalFiles = async (
           !!fileContents?.starterAsset,
           fileContents?.filenameWithExtension || ''
         );
+
+        fileContents.uploaded = true;
       }
     } catch {
       // https://codedotorg.atlassian.net/browse/AFL-345
@@ -33,4 +35,6 @@ export const uploadExternalFiles = async (
 
     filesBeingUploadedRef.current.delete(fileId);
   }
+
+  return filesToUpload;
 };


### PR DESCRIPTION
In preparation for turning on Sketch Lab S3 image storage everywhere, this PR adds a flag to successful uploads (`uploaded`).

To take the save to S3 feature out of experiment, we need to delete the base64 encoding of the image every time we save sources (which is scary!). I only want to do this for images that we are sure have been uploaded successfully, so we can use this flag to only delete the base64 encoding if we have a successful upload to S3.

## Testing story

I tested manually that the `uploaded` boolean was successfully set and stored to sources when an image is uploaded successfully.