### PR TITLE
Web Lab 2: update csp to include placeholder image

### DIFF
--- a/apps/src/weblab2/htmlPreview/contentSecurityPolicyHelper.ts
+++ b/apps/src/weblab2/htmlPreview/contentSecurityPolicyHelper.ts
@@ -29,7 +29,7 @@ export function generateContentSecurityPolicyForPreview(codeStudioUrl: string) {
   const script_src_inline = "'unsafe-inline'";
   const style_src_base = `'self' blob: ${allowedFontSrc}`;
   const style_src_inline = "'unsafe-inline'";
-  const img_src = `'self' blob: ${codeStudioUrl} ${allowedImageSrc}`;
+  const img_src = `'self' blob: ${codeStudioUrl} ${allowedImageSrc} https://studio.code.org/lab_resources/html-placeholder-image.avif`;
   const frame_ancestors = `${codeStudioUrl} 'self' ${previewUrl}`;
   const script_src = `${script_src_base} ${script_src_eval} ${script_src_inline}`;
   const style_src = `${style_src_base} ${style_src_inline}`;

--- a/dashboard/app/controllers/codeprojects_preview_controller.rb
+++ b/dashboard/app/controllers/codeprojects_preview_controller.rb
@@ -82,7 +82,9 @@ class CodeprojectsPreviewController < ApplicationController
 
     # Security Control: Restrict image loading sources (overrides default-src for images)
     # Goal: Allow student images while preventing external image injection
-    img_src = "'self' blob: #{code_studio_url} #{allowed_image_src}"
+    # We explicitly allow the placeholder image url on all environments so it works across environments. The placeholder image gets hard-coded
+    # into starter code.
+    img_src = "'self' blob: #{code_studio_url} #{allowed_image_src} https://studio.code.org/lab_resources/html-placeholder-image.avif"
 
     # Security Control: Restrict which sites can embed this page in iframes
     # Goal: Prevent clickjacking attacks by controlling frame embedding


### PR DESCRIPTION
This updates the Web Lab 2 content security policy for the preview iframe to explicitly allow an image-src of `https://studio.code.org/lab_resources/html-placeholder-image.avif`. This is the preview image provided by the system prompt. In levelbuilder we currently fail to load this image because we by default only allow access to the current environment's version of code.org in the csp.

## Links
- [slack thread](https://codedotorg.slack.com/archives/C092QHW09KJ/p1770404407062109)

## Testing story
Tested locally--before if you tried to set an image src to `https://studio.code.org/lab_resources/html-placeholder-image.avif` on a non-prod environment, it would fail. Now it works.



## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
