### PR TITLE
feat(core): add ky based api client

### DIFF
--- a/apps/yarn.lock
+++ b/apps/yarn.lock
@@ -3919,6 +3919,7 @@ __metadata:
   dependencies:
     tldts: "npm:^7.0.23"
   peerDependencies:
+    ky: ^1.14.3
     react: ^17.0.0 || ^18.0.0 || ^19.0.0
   languageName: node
   linkType: soft

--- a/dashboard/config/initializers/development_cors.rb
+++ b/dashboard/config/initializers/development_cors.rb
@@ -1,0 +1,12 @@
+if Rails.env.development?
+  Rails.application.config.middleware.insert_before 0, Rack::Cors do
+    allow do
+      origins %r{\Ahttp://localhost-studio.code.org:\d+\z}
+
+      resource '*',
+               headers: :any,
+               methods: :any,
+               credentials: true
+    end
+  end
+end

--- a/frontend/apps/studio/package.json
+++ b/frontend/apps/studio/package.json
@@ -27,6 +27,7 @@
     "@mui/material": "^7.3.4",
     "@tanstack/react-router": "^1.139.14",
     "@tanstack/react-router-devtools": "^1.139.14",
+    "ky": "^1.14.3",
     "react": "^19.1.1",
     "react-dom": "^19.1.1"
   },

--- a/frontend/packages/core/package.json
+++ b/frontend/packages/core/package.json
@@ -22,6 +22,11 @@
       "types": "./dist/index.d.ts",
       "import": "./dist/index.mjs",
       "require": "./dist/index.cjs"
+    },
+    "./api": {
+      "types": "./dist/api/index.d.ts",
+      "import": "./dist/api/index.mjs",
+      "require": "./dist/api/index.js"
     }
   },
   "scripts": {
@@ -45,6 +50,7 @@
     "eslint": "^9.39.1",
     "eslint-plugin-react-hooks": "^7.0.1",
     "eslint-plugin-react-refresh": "^0.4.24",
+    "ky": "^1.14.3",
     "prettier": "3.4.2",
     "react": "^19.2.0",
     "typescript": "~5.9.3",
@@ -54,6 +60,7 @@
     "vitest": "^4.0.17"
   },
   "peerDependencies": {
+    "ky": "^1.14.3",
     "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
   }
 }

--- a/frontend/packages/core/src/api/dashboard/SingletonDashboardApiClient.ts
+++ b/frontend/packages/core/src/api/dashboard/SingletonDashboardApiClient.ts
@@ -1,0 +1,19 @@
+import {CodeStudioConfig} from '@/config';
+import {createDashboardApiClient} from './createDashboardApiClient';
+import {getDashboardApiUrl} from '@/dashboard';
+import ky from 'ky';
+
+// Re-export Types
+export * from './labs/types';
+export * from './users/types';
+
+const httpTransport = ky.extend({
+  prefixUrl: getDashboardApiUrl(CodeStudioConfig.environment),
+  // In development, we need to include credentials to ensure cookies are sent with requests to the dashboard API
+  // In production, the dashboard API is served from the same origin as the frontend, so credentials are included by default and we don't need to specify this.
+  ...(CodeStudioConfig.environment === 'development' && {
+    credentials: 'include',
+  }),
+});
+
+export default createDashboardApiClient(httpTransport);

--- a/frontend/packages/core/src/api/dashboard/createDashboardApiClient.ts
+++ b/frontend/packages/core/src/api/dashboard/createDashboardApiClient.ts
@@ -1,0 +1,32 @@
+import type {KyInstance} from 'ky';
+import labs from './labs';
+import users from './users';
+
+type BoundApiClient<T> = T extends (http: KyInstance) => infer R
+  ? R
+  : // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    T extends Record<string, any>
+    ? {[K in keyof T]: BoundApiClient<T[K]>}
+    : T;
+
+function bindApiClient<T>(api: T, kyInstance: KyInstance): BoundApiClient<T> {
+  if (typeof api === 'function') {
+    return api(kyInstance) as BoundApiClient<T>;
+  }
+  if (typeof api === 'object' && api !== null) {
+    const bound = {} as BoundApiClient<T>;
+    for (const [key, value] of Object.entries(api)) {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (bound as any)[key] = bindApiClient(value, kyInstance);
+    }
+    return bound;
+  }
+  return api as BoundApiClient<T>;
+}
+
+export function createDashboardApiClient(httpTransport: KyInstance) {
+  return {
+    labs: bindApiClient(labs, httpTransport),
+    users: bindApiClient(users, httpTransport),
+  };
+}

--- a/frontend/packages/core/src/api/dashboard/index.ts
+++ b/frontend/packages/core/src/api/dashboard/index.ts
@@ -1,0 +1,2 @@
+export * from './labs/types';
+export * from './users/types';

--- a/frontend/packages/core/src/api/dashboard/labs/index.ts
+++ b/frontend/packages/core/src/api/dashboard/labs/index.ts
@@ -1,0 +1,5 @@
+import levels from './levels';
+
+export default {
+  levels,
+};

--- a/frontend/packages/core/src/api/dashboard/labs/levels/index.ts
+++ b/frontend/packages/core/src/api/dashboard/labs/levels/index.ts
@@ -1,0 +1,15 @@
+import type {KyInstance} from 'ky';
+import type {LevelPropertiesRequest, LevelPropertiesResponse} from './types';
+
+export * from './types';
+
+export default {
+  /** GET /levels/:levelId/level_properties */
+  getLevelProperties:
+    (http: KyInstance) =>
+    ({levelId}: LevelPropertiesRequest) => {
+      return http
+        .get(`levels/${levelId}/level_properties`)
+        .json<LevelPropertiesResponse>();
+    },
+};

--- a/frontend/packages/core/src/api/dashboard/labs/levels/types/index.ts
+++ b/frontend/packages/core/src/api/dashboard/labs/levels/types/index.ts
@@ -1,0 +1,29 @@
+export interface LevelData {
+  library: string;
+  showSoundFilters: boolean;
+  toolbox: {
+    includeAi: boolean;
+  };
+  allowChangeStartingPlayheadPosition: boolean;
+}
+export interface LevelProperties {
+  background: string;
+  isProjectLevel: string;
+  encrypted: string;
+  levelData: LevelData;
+  hideShareAndRemix: string;
+  instructionsImportant: string;
+  offerBrowserTts: string;
+  useSecondaryFinishButton: string;
+  name: string;
+  id: number;
+  type: string;
+  appName: string;
+  useRestrictedSongs: boolean;
+  usesProjects: string;
+  baseAssetUrl: string;
+}
+export interface LevelPropertiesRequest {
+  levelId: string;
+}
+export type LevelPropertiesResponse = Record<string, LevelProperties>;

--- a/frontend/packages/core/src/api/dashboard/labs/types.ts
+++ b/frontend/packages/core/src/api/dashboard/labs/types.ts
@@ -1,0 +1,1 @@
+export * from './levels/types';

--- a/frontend/packages/core/src/api/dashboard/users/index.ts
+++ b/frontend/packages/core/src/api/dashboard/users/index.ts
@@ -1,0 +1,5 @@
+import userPreference from './userPreference';
+
+export default {
+  userPreference,
+};

--- a/frontend/packages/core/src/api/dashboard/users/types.ts
+++ b/frontend/packages/core/src/api/dashboard/users/types.ts
@@ -1,0 +1,1 @@
+export * from './userPreference/types';

--- a/frontend/packages/core/src/api/dashboard/users/userPreference/index.ts
+++ b/frontend/packages/core/src/api/dashboard/users/userPreference/index.ts
@@ -1,0 +1,18 @@
+import type {KyInstance} from 'ky';
+import type {
+  UserPreferenceThemeRequest,
+  UserPreferenceThemeResponse,
+} from './types';
+
+export default {
+  /** GET /user_preference/theme */
+  getTheme: (http: KyInstance) => () => {
+    return http
+      .get(`user_preference/theme`)
+      .json<UserPreferenceThemeResponse>();
+  },
+  /** PUT /user_preference/theme */
+  updateTheme: (http: KyInstance) => (data: UserPreferenceThemeRequest) => {
+    return http.put(`user_preference/theme`, {json: data}).json();
+  },
+};

--- a/frontend/packages/core/src/api/dashboard/users/userPreference/types/index.ts
+++ b/frontend/packages/core/src/api/dashboard/users/userPreference/types/index.ts
@@ -1,0 +1,11 @@
+export type UserPreferenceThemeResponse = {
+  theme: {
+    blockly: string;
+  };
+};
+
+export type UserPreferenceThemeRequest = {
+  theme: {
+    blockly: string;
+  };
+};

--- a/frontend/packages/core/src/api/index.ts
+++ b/frontend/packages/core/src/api/index.ts
@@ -1,0 +1,5 @@
+import DashboardApiClient from './dashboard/SingletonDashboardApiClient';
+
+export * from './dashboard';
+
+export {DashboardApiClient};

--- a/frontend/packages/core/vite.config.ts
+++ b/frontend/packages/core/vite.config.ts
@@ -44,7 +44,7 @@ export default defineConfig({
     sourcemap: true,
     cssCodeSplit: true,
     lib: {
-      entry: 'src/index.ts',
+      entry: ['src/index.ts', 'src/api/index.ts'],
       name: 'core',
     },
     rollupOptions: {

--- a/frontend/packages/labs/music/src/App.tsx
+++ b/frontend/packages/labs/music/src/App.tsx
@@ -1,8 +1,26 @@
-import {useState} from 'react';
+import {useEffect, useState} from 'react';
 import {CodeStudioConfig} from '@code-dot-org/core';
+import {DashboardApiClient} from '@code-dot-org/core/api';
+import type {
+  LevelPropertiesResponse,
+  UserPreferenceThemeResponse,
+} from '@code-dot-org/core/api';
 
 function App() {
   const [count, setCount] = useState(0);
+  const [levelProperties, setLevelProperties] = useState<
+    LevelPropertiesResponse | undefined
+  >();
+  const [theme, setTheme] = useState<UserPreferenceThemeResponse | undefined>();
+
+  useEffect(() => {
+    DashboardApiClient.labs.levels
+      .getLevelProperties({levelId: '46446'})
+      .then(res => setLevelProperties(res));
+    DashboardApiClient.users.userPreference
+      .getTheme()
+      .then(res => setTheme(res));
+  }, []);
 
   return (
     <>
@@ -13,6 +31,19 @@ function App() {
         </button>
       </div>
       <p>Dashboard: {CodeStudioConfig.dashboardApiUrl}</p>
+      <p>
+        <strong>Level Properties</strong>
+      </p>
+      <pre style={{height: 400, overflow: 'auto'}}>
+        {levelProperties && JSON.stringify(levelProperties, null, 2)}
+      </pre>
+
+      <p>
+        <strong>Theme</strong>
+      </p>
+      <pre style={{height: 400, overflow: 'auto'}}>
+        {theme && JSON.stringify(theme, null, 2)}
+      </pre>
     </>
   );
 }

--- a/frontend/packages/labs/music/vite.config.ts
+++ b/frontend/packages/labs/music/vite.config.ts
@@ -15,6 +15,9 @@ export default defineConfig({
     // Instead, they are expected to be provided by the host application.
     externalizeDeps(),
   ],
+  server: {
+    allowedHosts: ['localhost-studio.code.org'],
+  },
   build: {
     lib: {
       entry: ['src/App.tsx'],

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -1341,6 +1341,7 @@ __metadata:
     eslint: "npm:^9.39.1"
     eslint-plugin-react-hooks: "npm:^7.0.1"
     eslint-plugin-react-refresh: "npm:^0.4.24"
+    ky: "npm:^1.14.3"
     prettier: "npm:3.4.2"
     react: "npm:^19.2.0"
     tldts: "npm:^7.0.23"
@@ -1350,6 +1351,7 @@ __metadata:
     vite-plugin-externalize-deps: "npm:^0.10.0"
     vitest: "npm:^4.0.17"
   peerDependencies:
+    ky: ^1.14.3
     react: ^17.0.0 || ^18.0.0 || ^19.0.0
   languageName: unknown
   linkType: soft
@@ -1522,6 +1524,7 @@ __metadata:
     eslint-plugin-react-hooks: "npm:^5.2.0"
     eslint-plugin-react-refresh: "npm:^0.4.22"
     globals: "npm:^16.4.0"
+    ky: "npm:^1.14.3"
     react: "npm:^19.1.1"
     react-dom: "npm:^19.1.1"
     typescript: "npm:~5.9.3"
@@ -14945,6 +14948,13 @@ __metadata:
   version: 0.30.0
   resolution: "ky@npm:0.30.0"
   checksum: 10c0/ad77939194804dc02a5a4d6708cbf0402cd265627b23dd2a8407f1d57640f3f13d088ae9355cc5f15525aeb50b1231309f9ca09fe2822eace86709e6232b3f79
+  languageName: node
+  linkType: hard
+
+"ky@npm:^1.14.3":
+  version: 1.14.3
+  resolution: "ky@npm:1.14.3"
+  checksum: 10c0/8e91c9512c8f1501201108ad58ed437eaf3f5b0a0da842bd846d785932426e84a31cf51d0fffce1921d4e70e26465a9b2b89ed2477822975568258a1fa68a740
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This PR introduces a new API client for interacting with Dashboard. The client uses "type-ahead" syntax to improve the understanding of different API nouns and predict what data may be retrieved.

Additionally, this PR adds a blanket allow for the development rails server to allow CORS when visiting code studio via `localhost-studio.code.org:*`. This allows the vite local and rails-vite apps to be able to communicate with the development server. This does not allow CORS outside of development.