### PR TITLE
Sketch Lab: prevent possible race condition on image upload

### DIFF
--- a/apps/src/lab2/views/SourcesContainer.tsx
+++ b/apps/src/lab2/views/SourcesContainer.tsx
@@ -33,7 +33,10 @@ const isToolboxMode = getAppOptionsEditBlocks() === TOOLBOX_BLOCKS;
 
 interface SourcesContextType<T extends ProjectSources = ProjectSources> {
   currentSources: T;
-  updateSources: (newSources: T, forceSave?: boolean) => void;
+  updateSources: (
+    newSourcesOrUpdater: T | ((prev: T) => T),
+    forceSave?: boolean
+  ) => void;
   showStartOverDialog: (type: MessageType, message?: string) => void;
   setReinitializationHandler: (handler: () => void) => void;
   startOver: () => void;
@@ -130,21 +133,37 @@ const SourcesContainer: React.FC<SourcesContainerProps> = ({
       : ((templateSources || startSources || defaultSources) as ProjectSources);
   }, [defaultSources, levelProperties]);
 
+  // In order to avoid possible stale state updates,
+  // we support passing a function that can take in the most up-to-date state as an argument
+  // and return new state.
   const updateSources = useCallback(
-    (newSources: ProjectSources, forceSave = false) => {
+    (
+      newSourcesOrUpdater:
+        | ProjectSources
+        | ((prev: ProjectSources) => ProjectSources),
+      forceSave = false
+    ) => {
       setCurrentSources(prev => {
+        // Handle both direct value and updater function
+        const newSources =
+          typeof newSourcesOrUpdater === 'function'
+            ? newSourcesOrUpdater(prev)
+            : newSourcesOrUpdater;
+
         // Perform a deep equality check to prevent unnecessary re-renders
         if (isEqual(prev, newSources)) {
           return prev;
         }
+
+        // Save if needed
+        if (!readonlyWorkspaceRef.current) {
+          (
+            projectManager || Lab2Registry.getInstance().getProjectManager()
+          )?.save(newSources, forceSave);
+        }
+
         return newSources;
       });
-
-      if (!readonlyWorkspaceRef.current) {
-        (
-          projectManager || Lab2Registry.getInstance().getProjectManager()
-        )?.save(newSources, forceSave);
-      }
     },
     [setCurrentSources, projectManager]
   );

--- a/apps/src/sketchlab/SketchlabView.tsx
+++ b/apps/src/sketchlab/SketchlabView.tsx
@@ -240,7 +240,7 @@ const SketchlabView: React.FC<LabProps<LevelProperties>> = ({
           source: {
             ...serializedData,
             externalFiles: {
-              ...prevSources.source?.externalFiles,
+              ...prevSources.source.externalFiles,
               ...newFiles,
             },
           },
@@ -257,7 +257,7 @@ const SketchlabView: React.FC<LabProps<LevelProperties>> = ({
             source: {
               ...prevSources.source,
               externalFiles: {
-                ...prevSources.source?.externalFiles,
+                ...prevSources.source.externalFiles,
                 ...newFilesWithUploadStatus,
               },
             },

--- a/apps/src/sketchlab/SketchlabView.tsx
+++ b/apps/src/sketchlab/SketchlabView.tsx
@@ -104,10 +104,6 @@ const SketchlabView: React.FC<LabProps<LevelProperties>> = ({
   // sources being initialized (eg, when level changes, teacher views a student's project, etc).
   const [excalidrawMountKey, setExcalidrawMountKey] = useState(0);
 
-  // Used to track the most recent serialization of the workspace,
-  // so that if multiple serializations are in-flight at once, we only save the most recent one.
-  const latestSerializationIdRef = useRef(0);
-
   const onLoad = useCallback(
     (api: ExcalidrawImperativeAPI) => {
       // Retain the API reference
@@ -208,10 +204,6 @@ const SketchlabView: React.FC<LabProps<LevelProperties>> = ({
       }
 
       saveSourcesTimeoutRef.current = setTimeout(async () => {
-        // Increment the counter and capture this serialization's ID
-        latestSerializationIdRef.current = latestSerializationIdRef.current + 1;
-        const thisSerializationId = latestSerializationIdRef.current;
-
         const serializedData: SerializedExcalidrawState = JSON.parse(
           serializeAsJSON(elements, state, files, 'local')
         );
@@ -244,15 +236,15 @@ const SketchlabView: React.FC<LabProps<LevelProperties>> = ({
           channelId
         );
 
-        updateSources({
+        updateSources(prevSources => ({
           source: {
             ...serializedData,
             externalFiles: {
-              ...currentSources.source.externalFiles,
+              ...prevSources.source?.externalFiles,
               ...newFiles,
             },
           },
-        });
+        }));
 
         if (newFiles && !readonlyWorkspace) {
           const newFilesWithUploadStatus = await uploadExternalFiles(
@@ -261,32 +253,15 @@ const SketchlabView: React.FC<LabProps<LevelProperties>> = ({
             filesBeingUploadedRef
           );
 
-          const updatedExternalFiles = {
-            ...currentSources.source.externalFiles,
-            ...newFilesWithUploadStatus,
-          };
-
-          // Check if this is still the most recent serialization.
-          const isStillLatest =
-            thisSerializationId === latestSerializationIdRef.current;
-
-          if (isStillLatest) {
-            // If still the latest, update everything, including serialized Excalidraw state.
-            updateSources({
-              source: {
-                ...serializedData,
-                externalFiles: updatedExternalFiles,
+          updateSources(prevSources => ({
+            source: {
+              ...prevSources.source,
+              externalFiles: {
+                ...prevSources.source?.externalFiles,
+                ...newFilesWithUploadStatus,
               },
-            });
-          } else {
-            // If the serialization is stale, only save the external files upload status.
-            updateSources({
-              source: {
-                ...currentSources.source,
-                externalFiles: updatedExternalFiles,
-              },
-            });
-          }
+            },
+          }));
         }
       }, DEBOUNCED_WORKSPACE_SERIALIZATION_MS);
     },

--- a/apps/src/sketchlab/SketchlabView.tsx
+++ b/apps/src/sketchlab/SketchlabView.tsx
@@ -104,6 +104,10 @@ const SketchlabView: React.FC<LabProps<LevelProperties>> = ({
   // sources being initialized (eg, when level changes, teacher views a student's project, etc).
   const [excalidrawMountKey, setExcalidrawMountKey] = useState(0);
 
+  // Used to track the most recent serialization of the workspace,
+  // so that if multiple serializations are in-flight at once, we only save the most recent one.
+  const latestSerializationIdRef = useRef(0);
+
   const onLoad = useCallback(
     (api: ExcalidrawImperativeAPI) => {
       // Retain the API reference
@@ -204,6 +208,10 @@ const SketchlabView: React.FC<LabProps<LevelProperties>> = ({
       }
 
       saveSourcesTimeoutRef.current = setTimeout(async () => {
+        // Increment the counter and capture this serialization's ID
+        latestSerializationIdRef.current = latestSerializationIdRef.current + 1;
+        const thisSerializationId = latestSerializationIdRef.current;
+
         const serializedData: SerializedExcalidrawState = JSON.parse(
           serializeAsJSON(elements, state, files, 'local')
         );
@@ -253,16 +261,32 @@ const SketchlabView: React.FC<LabProps<LevelProperties>> = ({
             filesBeingUploadedRef
           );
 
-          // We update sources again on upload completion to update the upload status of the new files.
-          updateSources({
-            source: {
-              ...serializedData,
-              externalFiles: {
-                ...currentSources.source.externalFiles,
-                ...newFilesWithUploadStatus,
+          const updatedExternalFiles = {
+            ...currentSources.source.externalFiles,
+            ...newFilesWithUploadStatus,
+          };
+
+          // Check if this is still the most recent serialization.
+          const isStillLatest =
+            thisSerializationId === latestSerializationIdRef.current;
+
+          if (isStillLatest) {
+            // If still the latest, update everything, including serialized Excalidraw state.
+            updateSources({
+              source: {
+                ...serializedData,
+                externalFiles: updatedExternalFiles,
               },
-            },
-          });
+            });
+          } else {
+            // If the serialization is stale only save the external files upload status.
+            updateSources({
+              source: {
+                ...currentSources.source,
+                externalFiles: updatedExternalFiles,
+              },
+            });
+          }
         }
       }, DEBOUNCED_WORKSPACE_SERIALIZATION_MS);
     },

--- a/apps/src/sketchlab/SketchlabView.tsx
+++ b/apps/src/sketchlab/SketchlabView.tsx
@@ -279,7 +279,7 @@ const SketchlabView: React.FC<LabProps<LevelProperties>> = ({
               },
             });
           } else {
-            // If the serialization is stale only save the external files upload status.
+            // If the serialization is stale, only save the external files upload status.
             updateSources({
               source: {
                 ...currentSources.source,


### PR DESCRIPTION
Follow-up to https://github.com/code-dot-org/code-dot-org/pull/70674

In adding an update to sources that waits for image uploads to finish in the PR above, I realized that I think there's a possible race condition here, where an out of date set of serialized data from Excalidraw could be saved to sources.

I think the solution here is to make our source state updates use an updater function, which is the recommended way to make state updates that depend on previous state: https://react.dev/reference/react/useState#updating-state-based-on-the-previous-state

We already do this in our SourcesContainer, but the update here is to allow a consumer of SourcesContainer (eg, SketchlabView) to also use this previous state.

## Testing story

I tested manually that I'm still able to upload images / update state successfully with the ?s3-images=true URL param.

## Follow-up work

I think after this I'm ready to turn on S3 image storage! 🎉 