### PR TITLE
aichat: ensure requestId added to completed chat messages

### DIFF
--- a/apps/src/aichat/redux/slice.ts
+++ b/apps/src/aichat/redux/slice.ts
@@ -34,6 +34,7 @@ import {
   UserAddedSelectionContextItem,
   ChatMessage,
   isPendingOrCompletedChatMessage,
+  CompletedChatMessage,
 } from '../types';
 import {
   DEFAULT_VISIBILITIES,
@@ -198,6 +199,18 @@ const aichatSlice = createSlice({
       );
       if (!event) return;
       event.status = action.payload.status;
+    },
+    updateRequestId: (
+      state,
+      action: PayloadAction<{updateId: string; requestId: number}>
+    ) => {
+      const event = state.chatEventsCurrent.find(
+        (event): event is ChatMessage =>
+          isPendingOrCompletedChatMessage(event) &&
+          event.updateId === action.payload.updateId
+      );
+      if (!event) return;
+      (event as CompletedChatMessage).requestId = action.payload.requestId;
     },
     setChatMessageSent: (state, action: PayloadAction<boolean>) => {
       state.hasSentMessage = action.payload;
@@ -447,6 +460,7 @@ export const {
   addEventToChatEventsCurrent,
   startSave,
   updateChatMessageStatus,
+  updateRequestId,
   setChatMessageSent,
   setSavedAiCustomizations,
   updateChatMessageFeedback,

--- a/apps/src/aichat/redux/thunks/submitChatContents.ts
+++ b/apps/src/aichat/redux/thunks/submitChatContents.ts
@@ -6,6 +6,7 @@ import {
   clearUserAddedSelectionContext,
   setChatMessageSent,
   updateChatMessageStatus,
+  updateRequestId,
 } from '@cdo/apps/aichat/redux/slice';
 import {Role} from '@cdo/apps/aiComponentLibrary/chatMessage/types';
 import {sendProgressReport} from '@cdo/apps/code-studio/progressRedux';
@@ -212,6 +213,12 @@ export const submitChatContents = createAsyncThunk(
           updateChatMessageStatus({
             updateId: newUserMessage.updateId,
             status: message.status,
+          })
+        );
+        dispatch(
+          updateRequestId({
+            updateId: newUserMessage.updateId,
+            requestId: message.requestId,
           })
         );
         logChatEvent(message, state.progress.viewAsUserId);


### PR DESCRIPTION
Fixes an issue where we were accidentally stripping user messages before sending them to the model. This was because we had inadvertently removed the `requestId` field from completed chat messages, and our code looks for the presence of a `requestId` to determine if a given message is valid and can be sent to the backend for chat completion. This fix just adds the request ID back to the generated user message. There's certainly potential to simplify and clean up this code as the various IDs and models can be tricky to follow 🙂 but this should fix the immediate issue.

Before (notice the model does not reference previous messages, and only `"assistant"` messages are sent in the network request):
<img width="3024" height="1660" alt="Screenshot 2026-02-06 at 3 32 30 PM" src="https://github.com/user-attachments/assets/1cff902b-88aa-463c-a89b-95c841574ffe" />

After (the model references previous user messages, and both `"user"` and `"assisstant"` messages are sent in the network request):
<img width="1511" height="926" alt="Screenshot 2026-02-09 at 3 07 12 PM" src="https://github.com/user-attachments/assets/6e382ed1-9f1e-4631-b76f-fbcfd80c6d4f" />

## Links

https://codedotorg.slack.com/archives/C06FELVTV0Q/p1770420809426299

## Testing story
Tested locally on AI Chat & AI Tutor levels.