### PR TITLE
P20-1796: Fix LTI course duplication

### DIFF
--- a/dashboard/app/controllers/lti_v1_controller.rb
+++ b/dashboard/app/controllers/lti_v1_controller.rb
@@ -324,13 +324,17 @@ class LtiV1Controller < ApplicationController
         return render_sync_course_error('LTI Integration not found', :bad_request, 'no_integration')
       end
       nrps_url = params[:nrps_url]
+
+      lti_deployment = lti_integration.lti_deployments.find_by(id: params[:deployment_id])
+      return render_sync_course_error('LTI Deployment not found', :bad_request, 'no_deployment') unless lti_deployment
+
       # Temporary lock to prevent concurrent requests from racing past
       # the ActiveRecord level uniqueness check and creating LtiCourse duplicates.
       # TODO(P20-1796): Remove the lock once a DB-level unique constraint
       #                 on (lti_integration_id, context_id) prevents duplicates.
-      lti_integration.with_lock do
+      lti_deployment.with_lock do
         lti_course = lti_integration.lti_courses.find_or_create_by!(context_id: params[:context_id]) do |new_record|
-          new_record.assign_attributes(lti_deployment_id: params[:deployment_id], nrps_url:, resource_link_id:)
+          new_record.assign_attributes(lti_deployment:, nrps_url:, resource_link_id:)
         end
       end
     end

--- a/dashboard/app/controllers/lti_v1_controller.rb
+++ b/dashboard/app/controllers/lti_v1_controller.rb
@@ -301,7 +301,6 @@ class LtiV1Controller < ApplicationController
       end
     end
 
-    lti_course, lti_integration, deployment_id, context_id,  nrps_url = nil
     resource_link_id = params[:rlid]
 
     if params[:section_code].present?
@@ -312,8 +311,6 @@ class LtiV1Controller < ApplicationController
         return render_sync_course_error('We couldn\'t find the given section.', :bad_request, 'no_section')
       end
       lti_integration = lti_course.lti_integration
-      deployment_id = lti_course.lti_deployment_id
-      context_id = lti_course.context_id
       nrps_url = lti_course.nrps_url
       # Requests from the sync button will not include a resource link ID, so it will generally
       # be nil at this point. Use the one from the lti_course record if present.
@@ -326,21 +323,21 @@ class LtiV1Controller < ApplicationController
       rescue
         return render_sync_course_error('LTI Integration not found', :bad_request, 'no_integration')
       end
-      deployment_id = params[:deployment_id]
-      context_id = params[:context_id]
       nrps_url = params[:nrps_url]
+      # Temporary lock to prevent concurrent requests from racing past
+      # the ActiveRecord level uniqueness check and creating LtiCourse duplicates.
+      # TODO(P20-1796): Remove the lock once a DB-level unique constraint
+      #                 on (lti_integration_id, context_id) prevents duplicates.
+      lti_integration.with_lock do
+        lti_course = lti_integration.lti_courses.find_or_create_by!(context_id: params[:context_id]) do |new_record|
+          new_record.assign_attributes(lti_deployment_id: params[:deployment_id], nrps_url:, resource_link_id:)
+        end
+      end
     end
 
-    # This query is also responsible for updating the RLID if it has changed.
-    # This has to happen before we call NRPS, or we will get an error back if the LMS
-    # platform requires an RLID (like Canvas) and the one we have is stale.
-    lti_course ||= Queries::Lti.find_or_create_lti_course(
-      lti_integration_id: lti_integration.id,
-      context_id: context_id,
-      deployment_id: deployment_id,
-      nrps_url: nrps_url,
-      resource_link_id: resource_link_id
-    )
+    # The LTI course `resource_link_id` update must happen before we call NRPS,
+    # or we will get an error if the LMS platform requires an RLID (such as Canvas) and the one we have is stale.
+    lti_course.update!(resource_link_id:) if resource_link_id && lti_course.resource_link_id != resource_link_id
 
     lti_advantage_client = Clients::LtiAdvantageClient.new(lti_integration.client_id, lti_integration.issuer)
     begin

--- a/dashboard/lib/queries/lti.rb
+++ b/dashboard/lib/queries/lti.rb
@@ -48,20 +48,4 @@ class Queries::Lti
   def self.get_lti_course_from_section_code(section_code)
     Section.find_by(code: section_code)&.lti_course
   end
-
-  def self.find_or_create_lti_course(lti_integration_id:, context_id:, deployment_id:, nrps_url:, resource_link_id:)
-    lti_course = LtiCourse.find_or_create_by(lti_integration_id: lti_integration_id, context_id: context_id) do |c|
-      c.lti_deployment_id = deployment_id
-      c.nrps_url = nrps_url
-      c.resource_link_id = resource_link_id
-    end
-
-    # Update the resource link id if the resource link has changed
-    unless lti_course.resource_link_id == resource_link_id
-      lti_course.resource_link_id = resource_link_id
-      lti_course.save!
-    end
-
-    lti_course
-  end
 end

--- a/dashboard/test/controllers/lti_v1_controller_test.rb
+++ b/dashboard/test/controllers/lti_v1_controller_test.rb
@@ -667,7 +667,14 @@ class LtiV1ControllerTest < ActionDispatch::IntegrationTest
     Services::Lti.expects(:parse_nrps_response).returns(@parsed_nrps_sections)
     Services::Lti.expects(:sync_course_roster).returns(@sync_course_result_with_changes)
 
-    get '/lti/v1/sync_course', params: {lti_integration_id: lti_integration.id, deployment_id: 'foo', context_id: lti_course.context_id, rlid: lti_course.resource_link_id, nrps_url: lti_course.nrps_url}
+    get '/lti/v1/sync_course', params: {
+      lti_integration_id: lti_integration.id,
+      deployment_id: lti_course.lti_deployment_id,
+      context_id: lti_course.context_id,
+      rlid: lti_course.resource_link_id,
+      nrps_url: lti_course.nrps_url,
+    }
+
     assert_response :ok
   end
 
@@ -681,7 +688,13 @@ class LtiV1ControllerTest < ActionDispatch::IntegrationTest
     Services::Lti.expects(:parse_nrps_response).returns(@parsed_nrps_sections)
     Services::Lti.expects(:sync_course_roster).returns(@sync_course_result_with_changes)
 
-    get '/lti/v1/sync_course', params: {lti_integration_id: lti_integration.id, deployment_id: 'foo', context_id: lti_course.context_id, rlid: new_resource_id, nrps_url: lti_course.nrps_url}
+    get '/lti/v1/sync_course', params: {
+      lti_integration_id: lti_integration.id,
+      deployment_id: lti_course.lti_deployment_id,
+      context_id: lti_course.context_id,
+      rlid: new_resource_id,
+      nrps_url: lti_course.nrps_url,
+    }
 
     lti_course.reload
     assert_response :ok
@@ -695,9 +708,11 @@ class LtiV1ControllerTest < ActionDispatch::IntegrationTest
 
     user = create(:teacher, :with_lti_auth)
     lti_integration = create(:lti_integration)
+    lti_deployment = create(:lti_deployment, lti_integration:)
     create(
       :lti_course,
       lti_integration: lti_integration,
+      lti_deployment:,
       context_id: lti_course_context_id,
       resource_link_id: lti_course_resource_link_id,
       nrps_url: lti_course_nrps_url
@@ -712,7 +727,7 @@ class LtiV1ControllerTest < ActionDispatch::IntegrationTest
     assert_no_difference 'LtiCourse.count' do
       get '/lti/v1/sync_course', params: {
         lti_integration_id: lti_integration.id,
-        deployment_id: 'foo',
+        deployment_id: lti_deployment.id,
         context_id: lti_course_context_id,
         rlid: lti_course_resource_link_id,
         nrps_url: lti_course_nrps_url
@@ -811,7 +826,14 @@ class LtiV1ControllerTest < ActionDispatch::IntegrationTest
     Services::Lti.expects(:parse_nrps_response).returns(@parsed_nrps_sections)
     Services::Lti.expects(:sync_course_roster).returns(@sync_course_result_no_changes)
 
-    get '/lti/v1/sync_course', params: {lti_integration_id: lti_integration.id, deployment_id: 'foo', context_id: lti_course.context_id, rlid: lti_course.resource_link_id, nrps_url: lti_course.nrps_url}
+    get '/lti/v1/sync_course', params: {
+      lti_integration_id: lti_integration.id,
+      deployment_id: lti_course.lti_deployment_id,
+      context_id: lti_course.context_id,
+      rlid: lti_course.resource_link_id,
+      nrps_url: lti_course.nrps_url,
+    }
+
     assert_response :redirect
   end
 
@@ -844,7 +866,14 @@ class LtiV1ControllerTest < ActionDispatch::IntegrationTest
     # creating the first Section and LtiSection in the course sync method.
     Services::Lti.expects(:sync_section_roster).raises(Exception, 'sync error')
 
-    get '/lti/v1/sync_course', params: {lti_integration_id: lti_integration.id, deployment_id: 'foo', context_id: lti_course.context_id, rlid: lti_course.resource_link_id, nrps_url: lti_course.nrps_url}
+    get '/lti/v1/sync_course', params: {
+      lti_integration_id: lti_integration.id,
+      deployment_id: lti_course.lti_deployment_id,
+      context_id: lti_course.context_id,
+      rlid: lti_course.resource_link_id,
+      nrps_url: lti_course.nrps_url
+    }
+
     assert_empty lti_course.lti_sections
     assert_response :internal_server_error
   end
@@ -901,7 +930,14 @@ class LtiV1ControllerTest < ActionDispatch::IntegrationTest
     Services::Lti.expects(:parse_nrps_response).never
     Services::Lti.expects(:sync_course_roster).never
 
-    get '/lti/v1/sync_course', params: {lti_integration_id: lti_integration.id, deployment_id: 'foo', context_id: lti_course.context_id, rlid: lti_course.resource_link_id, nrps_url: lti_course.nrps_url}
+    get '/lti/v1/sync_course', params: {
+      lti_integration_id: lti_integration.id,
+      deployment_id: lti_course.lti_deployment_id,
+      context_id: lti_course.context_id,
+      rlid: lti_course.resource_link_id,
+      nrps_url: lti_course.nrps_url,
+    }
+
     assert_response :redirect
   end
 

--- a/dashboard/test/controllers/lti_v1_controller_test.rb
+++ b/dashboard/test/controllers/lti_v1_controller_test.rb
@@ -733,6 +733,7 @@ class LtiV1ControllerTest < ActionDispatch::IntegrationTest
 
     user = create(:teacher, :with_lti_auth)
     lti_integration = create(:lti_integration)
+    lti_deployment = create(:lti_deployment, lti_integration:)
 
     Clients::LtiAdvantageClient.
       any_instance.
@@ -752,10 +753,10 @@ class LtiV1ControllerTest < ActionDispatch::IntegrationTest
 
     sign_in user
 
-    assert_no_difference 'LtiCourse.count' do
+    assert_difference 'LtiCourse.count' do
       get '/lti/v1/sync_course', params: {
         lti_integration_id: lti_integration.id,
-        deployment_id: 'foo',
+        deployment_id: lti_deployment.id,
         context_id: lti_course_context_id,
         rlid: lti_course_resource_link_id,
         nrps_url: lti_course_nrps_url
@@ -778,6 +779,7 @@ class LtiV1ControllerTest < ActionDispatch::IntegrationTest
 
     user = create(:teacher, :with_lti_auth)
     lti_integration = create(:lti_integration)
+    lti_deployment = create(:lti_deployment, lti_integration:)
 
     Clients::LtiAdvantageClient.any_instance.expects(:get_context_membership).with(lti_course_nrps_url, lti_course_resource_link_id).returns({})
     Policies::Lti.expects(:issuer_accepts_resource_link?).with(lti_integration.issuer).returns(false)
@@ -787,10 +789,10 @@ class LtiV1ControllerTest < ActionDispatch::IntegrationTest
 
     sign_in user
 
-    assert_no_difference 'LtiCourse.count' do
+    assert_difference 'LtiCourse.count' do
       get '/lti/v1/sync_course', params: {
         lti_integration_id: lti_integration.id,
-        deployment_id: 'foo',
+        deployment_id: lti_deployment.id,
         context_id: lti_course_context_id,
         rlid: lti_course_resource_link_id,
         nrps_url: lti_course_nrps_url

--- a/dashboard/test/lib/queries/lti_test.rb
+++ b/dashboard/test/lib/queries/lti_test.rb
@@ -63,18 +63,6 @@ class Services::LtiTest < ActiveSupport::TestCase
     assert_equal lti_course, Queries::Lti.get_lti_course_from_section_code(section_code)
   end
 
-  test 'creates an LTI course given metadata from an LTI launch ID token' do
-    lti_integration = create(:lti_integration)
-    lti_course = Queries::Lti.find_or_create_lti_course(lti_integration_id: lti_integration.id, context_id: 'context-id', deployment_id: 'deployment-id', nrps_url: 'http://some-nrps-url.com', resource_link_id: 'rlid')
-    assert lti_course
-  end
-
-  test 'finds an existing LTI course given metadata from an LTI launch ID token' do
-    lti_integration = create(:lti_integration)
-    lti_course = create(:lti_course, lti_integration: lti_integration, context_id: SecureRandom.uuid)
-    assert_equal lti_course, Queries::Lti.find_or_create_lti_course(lti_integration_id: lti_integration.id, context_id: lti_course.context_id, deployment_id: 'deployment-id', nrps_url: 'http://some-nrps-url.com', resource_link_id: 'rlid')
-  end
-
   test 'lti_user_ids should return the subjects (user id) for a given user' do
     lti_integration = create(:lti_integration)
     lti_user_identity = create(:lti_user_identity, lti_integration: lti_integration)


### PR DESCRIPTION
Under concurrent requests to `LtiV1Controller#sync_course`, the application can create more than one `LtiCourse` record for the same `lti_integration_id` and `context_id`.

The current flow relies only on ActiveRecord-level uniqueness validations and "find then create" logic (`validates_uniqueness_of`). This is not concurrency safe because it is not atomic across requests: when two requests run at the same time, both can read "no matching row exists" before either inserts or commits. Without a database-level unique constraint, the database will accept both inserts, resulting in duplicate `LtiCourse` records.

This is most likely triggered by multiple Sync requests being sent close together, for example, rapid repeated clicks before the UI fully disables the button, or retries from the browser or LMS, or a user clicking Sync in multiple tabs.

## Fix steps

1. **Mitigate duplicate creation**
   Add a temporary pessimistic (transactional) lock around the `LtiCourse` "find or create" logic, so concurrent sync requests for the same integration cannot create duplicates. This eliminates the race condition at the application level.

2. **Data cleanup**
   Identify existing duplicates for `(lti_integration_id, context_id)` and keep a single canonical record, typically the most recently created or last updated one, then soft delete or remove the rest. If duplicates have divergent `resource_link_id` values, decide which value is correct and migrate it to the canonical row before deleting the others.

3. **Database enforcement**
   Add a database unique constraint to prevent duplicate active `LtiCourse` records for `(lti_integration_id, context_id, deleted_at)`, then replace the lock with logic that rescues `ActiveRecord::RecordNotUnique` and loads the existing row, making the operation idempotent under concurrency.

4. **Frontend hardening**
   Reduce the chance of duplicate requests by disabling the Sync button immediately on click, before waiting for a rerender.

## Links
- JIRA task: [P20-1796](https://codedotorg.atlassian.net/browse/P20-1796)
- Related PR: https://github.com/code-dot-org/code-dot-org/pull/55379