### PR TITLE
P20-1798: Sync Clever sections sequentially to avoid DB connection timeouts

### DIFF
--- a/dashboard/app/jobs/roster/clever/sync_sections_job.rb
+++ b/dashboard/app/jobs/roster/clever/sync_sections_job.rb
@@ -3,17 +3,13 @@
 module Roster
   module Clever
     class SyncSectionsJob < ApplicationJob
-      THREADS = 6
-
       rescue_from StandardError, with: :report_exception
 
       def perform(teacher_id:)
         teacher = Teacher.find(teacher_id)
 
-        CleverSection.visible.where(teacher:).in_batches do |sections_batch|
-          Parallel.each(sections_batch, in_threads: THREADS) do |section|
-            Services::Roster::Clever::SectionSyncer.call(teacher:, section:)
-          end
+        CleverSection.visible.where(teacher:).find_each do |section|
+          Services::Roster::Clever::SectionSyncer.call(teacher:, section:)
         end
       end
     end


### PR DESCRIPTION
Previously, sections were processed using `Parallel.each`, which allowed multiple `SectionSyncer` executions to run at the same time. Each execution performs an external HTTP request and multiple database operations. Under load, this led to multiple threads holding ActiveRecord connections concurrently or for longer than expected, which could exhaust the connection pool and cause `ConnectionTimeoutError`: https://github.com/grosser/parallel/tree/v1.26.2?tab=readme-ov-file#connection-lost

Since section synchronization does not require concurrent database writes and reliability is more important than parallelism in this path, processing sections sequentially avoids pool contention and ensures connections are used and released in a predictable way.

<img alt="connection_error" src="https://github.com/user-attachments/assets/b3b006c8-a9d0-455c-a2f1-2d35471999eb" />

## Links
- JIRA task: [P20-1798](https://codedotorg.atlassian.net/browse/P20-1798)
- Related PR: https://github.com/code-dot-org/code-dot-org/pull/70162