### PR TITLE
Fixes bug with uid auth option lookup

### DIFF
--- a/dashboard/lib/user_multi_auth_helper.rb
+++ b/dashboard/lib/user_multi_auth_helper.rb
@@ -42,7 +42,8 @@ module UserMultiAuthHelper
     if migrated?
       # TODO: Delete this block once Clever users have been migrated to V3 auth options
       if auth_hash[:provider] == AuthenticationOption::CLEVER
-        legacy_id = auth_hash.dig(:extra, :raw_info, :canonical, :data, :roles, :teacher, :legacy_id) # We know for sure we don't need to check for staff here, because that role is not enabled in our Clever app settings.
+        # We know for sure we don't need to check for staff here, because that role is not enabled in our Clever app settings.
+        legacy_id = auth_hash.dig(:extra, :raw_info, :canonical, :data, :roles, :teacher, :legacy_id)
         auth_option = authentication_options.find_by(credential_type: AuthenticationOption::CLEVER, authentication_id: auth_hash[:uid]) || authentication_options.find_by(credential_type: AuthenticationOption::CLEVER, authentication_id: legacy_id)
         auth_option&.update_oauth_credential_tokens(credentials_hash)
         return

--- a/dashboard/lib/user_multi_auth_helper.rb
+++ b/dashboard/lib/user_multi_auth_helper.rb
@@ -40,6 +40,14 @@ module UserMultiAuthHelper
 
     credentials_hash = auth_hash[:credentials]
     if migrated?
+      # TODO: Delete this block once Clever users have been migrated to V3 auth options
+      if auth_hash[:provider] == AuthenticationOption::CLEVER
+        legacy_id = auth_hash.dig(:extra, :raw_info, :canonical, :data, :roles, :teacher, :legacy_id) # We know for sure we don't need to check for staff here, because that role is not enabled in our Clever app settings.
+        auth_option = authentication_options.find_by(credential_type: AuthenticationOption::CLEVER, authentication_id: auth_hash[:uid]) || authentication_options.find_by(credential_type: AuthenticationOption::CLEVER, authentication_id: legacy_id)
+        auth_option&.update_oauth_credential_tokens(credentials_hash)
+        return
+      end
+      # end TODO
       auth_option = authentication_options.find_by(credential_type: auth_hash[:provider], authentication_id: auth_hash[:uid])
       auth_option&.update_oauth_credential_tokens(credentials_hash)
     else

--- a/dashboard/lib/user_multi_auth_helper.rb
+++ b/dashboard/lib/user_multi_auth_helper.rb
@@ -44,7 +44,16 @@ module UserMultiAuthHelper
       if auth_hash[:provider] == AuthenticationOption::CLEVER
         # We know for sure we don't need to check for staff here, because that role is not enabled in our Clever app settings.
         legacy_id = auth_hash.dig(:extra, :raw_info, :canonical, :data, :roles, :teacher, :legacy_id)
-        auth_option = authentication_options.find_by(credential_type: AuthenticationOption::CLEVER, authentication_id: auth_hash[:uid]) || authentication_options.find_by(credential_type: AuthenticationOption::CLEVER, authentication_id: legacy_id)
+        auth_option = authentication_options.find_by(
+          credential_type: AuthenticationOption::CLEVER,
+          authentication_id: auth_hash[:uid]
+        )
+        if auth_option.nil? && legacy_id.present?
+          auth_option = authentication_options.find_by(
+            credential_type: AuthenticationOption::CLEVER,
+            authentication_id: legacy_id
+          )
+        end
         auth_option&.update_oauth_credential_tokens(credentials_hash)
         return
       end


### PR DESCRIPTION
There is a bug in the current system when trying to update the auth data for Clever users. It uses the `uid` from the auth hash to lookup the auth option, however now that we are on the V3 API, this will be a new ID and that lookup will return nil, effectively not updating the auth data. This change adds a temporary block that can be deleted once we've migrated all user's auth options to v3, that also looks up the auth option via the `legacy_id`.

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->



## Links
<!--  Links to relevant external resources.
      - spec docs, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- Jira: 

## Testing story
<!--  Does your change include appropriate tests?
      - If so, please describe how the tests included in this PR are sufficient.
      - If not, please explain why this change does not need to be tested. -->



## Deployment strategy
<!--  Any special steps required to deploy this, besides merging?
      - Are there database migrations or manual steps?
      - Does this require coordination with other teams or systems? -->



## Follow-up work
<!--  List any clean-up or technical debt that will be addressed in future work.
      - Include Jira links where applicable.
      - Are there any known limitations or improvements planned? -->



## Privacy
<!--  How does this change impact Student & Teacher privacy?
      - Does this collect, use, share, or modify PII, either new or existing? -->



## Security
<!--  How does this change impact our security surface-area?
      - Do API's touched have the right auth?
      - Do infra changes impact our attack surface or encryption?
-->



## Caching
<!--  How does this change impact caching behavior?
      - Are cache keys or invalidation strategies affected?
      - Will this require cache warming or invalidation after deployment? -->



## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
