### PR TITLE
Set Web Lab 2 initial tab to AI tutor (with instructions drawer)

### DIFF
--- a/apps/src/aichat/views/ChatEventsList.tsx
+++ b/apps/src/aichat/views/ChatEventsList.tsx
@@ -20,7 +20,7 @@ interface ChatEventsListProps {
   isTeacherView?: boolean;
   buildAssetUrl?: (asset: ChatAsset) => string;
   isAiTutorVersion?: boolean;
-  hasCollapsedInstructionsDrawer?: boolean;
+  hasInstructionsDrawer?: boolean;
 }
 
 /**
@@ -31,7 +31,7 @@ const ChatEventsList: React.FunctionComponent<ChatEventsListProps> = ({
   isTeacherView,
   buildAssetUrl,
   isAiTutorVersion,
-  hasCollapsedInstructionsDrawer,
+  hasInstructionsDrawer,
 }) => {
   const {chatDisabled, chatDisabledMessage} = useAiChatDisabled();
   const [isInChatNavigationMode, setIsInChatNavigationMode] = useState(false);
@@ -186,8 +186,8 @@ const ChatEventsList: React.FunctionComponent<ChatEventsListProps> = ({
           <ChatDisabled message={chatDisabledMessage} />
         ) : (
           <>
-            {hasCollapsedInstructionsDrawer && (
-              <div className={moduleStyles.collapsedInstructionsDrawerInset} />
+            {hasInstructionsDrawer && (
+              <div className={moduleStyles.instructionsDrawerInset} />
             )}
             {events.map((event, index) => {
               const isLastMessage = index === events.length - 1;

--- a/apps/src/aichat/views/ChatWorkspace.tsx
+++ b/apps/src/aichat/views/ChatWorkspace.tsx
@@ -62,7 +62,7 @@ interface ChatWorkspaceProps {
   // Optional callback to log level activity
   logLevelActivity?: () => void;
 
-  hasCollapsedInstructionsDrawer?: boolean;
+  hasInstructionsDrawer?: boolean;
 }
 
 /**
@@ -80,7 +80,7 @@ const ChatWorkspace: React.FunctionComponent<ChatWorkspaceProps> = ({
   hideModelChangeMessage = false,
   responseCallback,
   logLevelActivity,
-  hasCollapsedInstructionsDrawer,
+  hasInstructionsDrawer,
 }) => {
   const {chatDisabled} = useAiChatDisabled();
   if (multimodalEnabled && (!levelName || !channelId)) {
@@ -325,7 +325,7 @@ const ChatWorkspace: React.FunctionComponent<ChatWorkspaceProps> = ({
           isTeacherView={isTeacherView}
           buildAssetUrl={buildAssetUrlValue}
           isAiTutorVersion={isAiTutorVersion}
-          hasCollapsedInstructionsDrawer={hasCollapsedInstructionsDrawer}
+          hasInstructionsDrawer={hasInstructionsDrawer}
         />
       )}
       <div className={moduleStyles.footer}>

--- a/apps/src/aichat/views/chatWorkspace.module.scss
+++ b/apps/src/aichat/views/chatWorkspace.module.scss
@@ -70,8 +70,9 @@ $tabs-default-spacing: 4px;
   padding: 0.625rem;
 }
 
-.collapsedInstructionsDrawerInset {
-  height: 50px;
+.instructionsDrawerInset {
+  flex-shrink: 0;
+  height: 10px;
 }
 
 .floatingScrollToBottomButtonContainer {

--- a/apps/src/aichat/views/chatWorkspace.module.scss
+++ b/apps/src/aichat/views/chatWorkspace.module.scss
@@ -72,7 +72,7 @@ $tabs-default-spacing: 4px;
 
 .instructionsDrawerInset {
   flex-shrink: 0;
-  height: 10px;
+  height: 18px;
 }
 
 .floatingScrollToBottomButtonContainer {

--- a/apps/src/lab2/views/components/AiTutorChat.tsx
+++ b/apps/src/lab2/views/components/AiTutorChat.tsx
@@ -30,7 +30,7 @@ interface AiTutorChatProps {
   aiTutorChatButtonData?: ChatButtonData[];
   aiTutorSystemPromptName?: string;
   aiTutorResponseSchemaSettings?: ResponseSchemaSettings;
-  hasCollapsedInstructionsDrawer?: boolean;
+  hasInstructionsDrawer?: boolean;
 }
 
 // A free chat with lab-supplied context added to each question.
@@ -42,7 +42,7 @@ const AiTutorChat: React.FunctionComponent<AiTutorChatProps> = ({
   aiTutorChatButtonData,
   aiTutorSystemPromptName,
   aiTutorResponseSchemaSettings,
-  hasCollapsedInstructionsDrawer,
+  hasInstructionsDrawer,
 }) => {
   const {modelParameters, loading} = useAiTutorModelParameters({
     aiTutorSystemPromptName,
@@ -96,7 +96,7 @@ const AiTutorChat: React.FunctionComponent<AiTutorChatProps> = ({
         channelId={channelId}
         hideModelChangeMessage={true}
         responseCallback={aiTutorResponseSchemaSettings?.responseCallback}
-        hasCollapsedInstructionsDrawer={hasCollapsedInstructionsDrawer}
+        hasInstructionsDrawer={hasInstructionsDrawer}
       />
     </div>
   );

--- a/apps/src/lab2/views/components/Instructions/ResourcePanel/AiTutorChatWithInstructionDrawer.tsx
+++ b/apps/src/lab2/views/components/Instructions/ResourcePanel/AiTutorChatWithInstructionDrawer.tsx
@@ -132,6 +132,7 @@ const AiTutorChatWithInstructionDrawer: React.FunctionComponent<
     <div ref={containerRef} className={styles.container}>
       {!isCollapsed && (
         <div
+          id="instructions-drawer"
           className={styles.instructionsDrawer}
           style={{height: instructionsHeight}}
         >

--- a/apps/src/lab2/views/components/Instructions/ResourcePanel/AiTutorChatWithInstructionDrawer.tsx
+++ b/apps/src/lab2/views/components/Instructions/ResourcePanel/AiTutorChatWithInstructionDrawer.tsx
@@ -130,14 +130,16 @@ const AiTutorChatWithInstructionDrawer: React.FunctionComponent<
 
   return (
     <div ref={containerRef} className={styles.container}>
-      <div
-        className={styles.instructionsDrawer}
-        style={{height: instructionsHeight}}
-      >
-        <div className={styles.instructionsScrollArea}>
-          <div ref={instructionsContentRef}>{instructionsContent}</div>
+      {!isCollapsed && (
+        <div
+          className={styles.instructionsDrawer}
+          style={{height: instructionsHeight}}
+        >
+          <div className={styles.instructionsScrollArea}>
+            <div ref={instructionsContentRef}>{instructionsContent}</div>
+          </div>
         </div>
-      </div>
+      )}
       <div
         className={styles.toggleButtonContainer}
         style={{top: instructionsHeight}}
@@ -174,7 +176,7 @@ const AiTutorChatWithInstructionDrawer: React.FunctionComponent<
             aiTutorChatButtonData={aiTutorChatButtonData}
             aiTutorSystemPromptName={aiTutorSystemPromptName}
             aiTutorResponseSchemaSettings={aiTutorResponseSchemaSettings}
-            hasCollapsedInstructionsDrawer={isCollapsed}
+            hasInstructionsDrawer={true}
           />
         </div>
       </div>

--- a/apps/src/lab2/views/components/Instructions/ResourcePanel/index.tsx
+++ b/apps/src/lab2/views/components/Instructions/ResourcePanel/index.tsx
@@ -401,14 +401,14 @@ const ResourcePanel: React.FC<ResourcePanelProps> = ({
   }, [currentTab, availableTabs]);
 
   useEffect(() => {
-    // Reset current tab to instructions when switching levels or viewAsUserId unless there is an instructions drawer.
-    // If there is an instructions drawer, we set initial tab to the AI Tutor tab.
-    if (hasInstructionsDrawer) {
+    // Reset current tab to instructions when switching levels or viewAsUserId unless there is an AI tutor tab with instructions drawer.
+    // If there is, then we set initial tab to the AI Tutor tab.
+    if (availableTabs[Tabs.AiTutor] && hasInstructionsDrawer) {
       setCurrentTab(Tabs.AiTutor);
     } else {
       setCurrentTab(Tabs.Instructions);
     }
-  }, [levelId, viewAsUserId, hasInstructionsDrawer]);
+  }, [levelId, viewAsUserId, hasInstructionsDrawer, availableTabs]);
 
   // Move focus to panel content when AI Tutor or Version History tab is selected via keyboard.
   useEffect(() => {

--- a/apps/src/lab2/views/components/Instructions/ResourcePanel/index.tsx
+++ b/apps/src/lab2/views/components/Instructions/ResourcePanel/index.tsx
@@ -403,12 +403,12 @@ const ResourcePanel: React.FC<ResourcePanelProps> = ({
   useEffect(() => {
     // Reset current tab to instructions when switching levels or viewAsUserId unless there is an AI tutor tab with instructions drawer.
     // If there is, then we set initial tab to the AI Tutor tab.
-    if (availableTabs[Tabs.AiTutor] && hasInstructionsDrawer) {
+    if (hasInstructionsDrawer && aiTutorVisible) {
       setCurrentTab(Tabs.AiTutor);
     } else {
       setCurrentTab(Tabs.Instructions);
     }
-  }, [levelId, viewAsUserId, hasInstructionsDrawer, availableTabs]);
+  }, [levelId, viewAsUserId, hasInstructionsDrawer, aiTutorVisible]);
 
   // Move focus to panel content when AI Tutor or Version History tab is selected via keyboard.
   useEffect(() => {

--- a/apps/src/lab2/views/components/Instructions/ResourcePanel/index.tsx
+++ b/apps/src/lab2/views/components/Instructions/ResourcePanel/index.tsx
@@ -401,9 +401,14 @@ const ResourcePanel: React.FC<ResourcePanelProps> = ({
   }, [currentTab, availableTabs]);
 
   useEffect(() => {
-    // Reset current tab to instructions when switching levels or viewAsUserId.
-    setCurrentTab(Tabs.Instructions);
-  }, [levelId, viewAsUserId]);
+    // Reset current tab to instructions when switching levels or viewAsUserId unless there is an instructions drawer.
+    // If there is an instructions drawer, we set initial tab to the AI Tutor tab.
+    if (hasInstructionsDrawer) {
+      setCurrentTab(Tabs.AiTutor);
+    } else {
+      setCurrentTab(Tabs.Instructions);
+    }
+  }, [levelId, viewAsUserId, hasInstructionsDrawer]);
 
   // Move focus to panel content when AI Tutor or Version History tab is selected via keyboard.
   useEffect(() => {

--- a/dashboard/test/ui/features/code_tools/pythonlab/pythonlab_run.feature
+++ b/dashboard/test/ui/features/code_tools/pythonlab/pythonlab_run.feature
@@ -34,6 +34,7 @@ Scenario: Continue button and progress status shows up correctly
   And I wait until current URL contains "http://studio.code.org/courses/allthethingscourse/units/1/lessons/50/levels/2"
   # Check that progress has been updated for the previous level
   Then I verify progress in the header of the current page is "perfect" for level 1
+  And I wait until element "#resource-panel-tab-validation" is visible
   And I press "resource-panel-tab-validation"
   And I wait to see "#uitest-validate-button"
   And I wait until "#uitest-validate-button" is not disabled

--- a/dashboard/test/ui/features/student_learning/weblab2/weblab2_general.feature
+++ b/dashboard/test/ui/features/student_learning/weblab2/weblab2_general.feature
@@ -9,8 +9,8 @@ Feature: Web Lab 2 Preview
 # general loading of the editor/instructions into two separate tests.
 Scenario: Web Lab 2 Instructions and Editor load
   Given I create a student named "Penelope"
-  When I am on "http://studio.code.org/courses/allthethingscourse/units/1/lessons/51/levels/11"
-  And I wait until element "#instructions-panel" is visible
-  Then element with ID "instructions-panel" contains text "This is the level for a basic Web Lab 2 UI Test. Please do not change the start code for this level without changing the UI test!"
+  When I am on "http://studio.code.org/courses/allthethingscourse/units/1/lessons/51/levels/11?noIntrojs=true"
+  And I wait until element "#instructions-drawer" is visible
+  Then element with ID "instructions-drawer" contains text "This is the level for a basic Web Lab 2 UI Test. Please do not change the start code for this level without changing the UI test!"
   And element with ID "uitest-files-list" contains text "index.html"
   And I wait until element ".codemirror-container" contains text "Hello world!"


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
This follows up https://github.com/code-dot-org/code-dot-org/pull/70696 which added the instructions drawer to AI Tutor panel in Web Lab 2. This PR sets the initial resource panel tab to AI Tutor on `weblab2` levels.
It also includes minor styling updates to the instructions drawer.

## After update

Screencast of user on music and pythonlab, initial tab is Instructions. But then user navigates to weblab2, initial tab is AI Tutor.

https://github.com/user-attachments/assets/a56a9196-90d6-4cf6-b691-590125e727a9



Screencast of updated styling of AI tutor panel with instructions drawer. Note that there is now an inset in the chat workspace for both collapsed and expanded instructions drawer.

https://github.com/user-attachments/assets/e1b4e24d-90e5-47fa-89b1-52fc41636205


## Links
<!--  Links to relevant external resources.
      - spec docs, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- Jira: https://codedotorg.atlassian.net/browse/AFL-467

## Testing story
<!--  Does your change include appropriate tests?
      - If so, please describe how the tests included in this PR are sufficient.
      - If not, please explain why this change does not need to be tested. -->

I confirmed locally that initial tab on `weblab2` is AI tutor, but check on on other labs (music, aichat, pythonlab) that initial tab is still Instructions.

## Deployment strategy
<!--  Any special steps required to deploy this, besides merging?
      - Are there database migrations or manual steps?
      - Does this require coordination with other teams or systems? -->



## Follow-up work
<!--  List any clean-up or technical debt that will be addressed in future work.
      - Include Jira links where applicable.
      - Are there any known limitations or improvements planned? -->



## Privacy
<!--  How does this change impact Student & Teacher privacy?
      - Does this collect, use, share, or modify PII, either new or existing? -->



## Security
<!--  How does this change impact our security surface-area?
      - Do API's touched have the right auth?
      - Do infra changes impact our attack surface or encryption?
-->



## Caching
<!--  How does this change impact caching behavior?
      - Are cache keys or invalidation strategies affected?
      - Will this require cache warming or invalidation after deployment? -->



## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
