### PR TITLE
Web Lab 2: allow forms but no form actions

### DIFF
--- a/apps/src/weblab2/htmlPreview/HTMLPreview.tsx
+++ b/apps/src/weblab2/htmlPreview/HTMLPreview.tsx
@@ -467,7 +467,7 @@ export const HTMLPreview: React.FC = () => {
             aria-label="Web Preview Frame"
           >
             <iframe
-              sandbox="allow-scripts allow-same-origin"
+              sandbox="allow-scripts allow-same-origin allow-forms"
               allow="self"
               title="Web Preview"
               ref={iframeRef}

--- a/apps/src/weblab2/htmlPreview/InnerHTMLPreview.tsx
+++ b/apps/src/weblab2/htmlPreview/InnerHTMLPreview.tsx
@@ -138,7 +138,9 @@ const InnerHTMLPreview = () => {
       return (
         <iframe
           ref={iframeRef}
-          sandbox={`${allowScripts ? 'allow-scripts ' : ''}allow-same-origin`}
+          sandbox={`${
+            allowScripts ? 'allow-scripts ' : ''
+          }allow-same-origin allow-forms`}
           allow="self"
           title="Inner HTML Preview"
           id="inner-preview"

--- a/apps/src/weblab2/htmlPreview/contentSecurityPolicyHelper.ts
+++ b/apps/src/weblab2/htmlPreview/contentSecurityPolicyHelper.ts
@@ -43,6 +43,7 @@ export function generateContentSecurityPolicyForPreview(codeStudioUrl: string) {
     `style-src ${style_src}`,
     `img-src ${img_src}`,
     `font-src ${font_src}`,
+    "form-action 'none'",
   ];
 
   if (!isDevelopmentEnvironment() || !isTestEnvironment()) {

--- a/dashboard/app/controllers/codeprojects_preview_controller.rb
+++ b/dashboard/app/controllers/codeprojects_preview_controller.rb
@@ -103,7 +103,8 @@ class CodeprojectsPreviewController < ApplicationController
       "script-src #{script_src}",
       "style-src #{style_src}",
       "img-src #{img_src}",
-      "font-src #{font_src}"
+      "font-src #{font_src}",
+      "form-action 'none'",
     ]
 
     unless rack_env?(:development) || rack_env?(:test)


### PR DESCRIPTION
We want to provide minimal support for forms in Web Lab 2. What we want to support is projects that submit forms via a "submit" button, but all that button does is trigger an event handler that does some benign operation, not write to an external url.

We can support this by allowing forms on the iframe sandbox, but setting `form-action` to `none` in the content security policy. This allows submit buttons on forms to work, but you must call `preventDefault` on that submit action to avoid throwing a content security policy error. 


## Links

- Jira: [AFL-463](https://codedotorg.atlassian.net/browse/AFL-463)
- [Slack thread](https://codedotorg.slack.com/archives/C03CK49G9/p1770673455336179)

## Testing story
Tested locally. Before this a submit button event handler would not work. Now it does, but if you don't call `preventDefault` you see an error.


## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
