### PR TITLE
Don't seed daily weather dataset

### DIFF
--- a/dashboard/config/datablock_storage/datasets/daily-weather.json
+++ b/dashboard/config/datablock_storage/datasets/daily-weather.json
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:2fe6604bdf4cd2bcf053ee352eabe661041a0c0f952b7755e4c9a7ddef6680fc
-size 90795


### PR DESCRIPTION
The daily weather dataset is updated live every day via the `daily_weather` cronjob. However, we discovered that because it's present in our config files, the stale version that's saved in our repository overrides the current data whenever seeding occurs. Fix here is just to remove the version from our repository, and rely on the cronjob to update it.

See: https://codedotorg.slack.com/archives/C03DBDN67B7/p1770762528134939