### PR TITLE
Add customizing-llms-latm-2025 to list of Spanish language AI Chat scripts

### DIFF
--- a/dashboard/app/helpers/aichat_safety_helper.rb
+++ b/dashboard/app/helpers/aichat_safety_helper.rb
@@ -98,7 +98,7 @@ module AichatSafetyHelper
     end
 
     private def get_safety_system_prompt(level_id)
-      spanish_script_names = ['customizing-llms-latm-pilot']
+      spanish_script_names = ['customizing-llms-latm-pilot', 'customizing-llms-latm-2025']
 
       in_spanish_script = false
       if level_id


### PR DESCRIPTION
Add the new `customizing-llms-latm-2025` to the list of script names we check for in the AI Chat safety layer when constructing the safety prompt. Note that we will likely look into a more modular/flexible prompt composition solution in the future, but keeping this list up to date for now for when partners start using this script.

## Links
<!--  Links to relevant external resources.
      - spec docs, Jira tickets, related PRs, Honeybadger errors, etc.
-->

See: https://codedotorg.slack.com/archives/CFGAVL2CA/p1770760422842879

## Testing story

Tested locally; confirmed we use the right system prompt in this script.