### PR TITLE
AI Tutor: add empty state view for teacher view of student chat history

### DIFF
--- a/apps/src/aichat/views/ChatEventsList.tsx
+++ b/apps/src/aichat/views/ChatEventsList.tsx
@@ -1,6 +1,6 @@
 import Button from '@code-dot-org/component-library/button';
 import classNames from 'classnames';
-import React, {useEffect, useRef, useState, useCallback} from 'react';
+import React, {useEffect, useRef, useState, useCallback, useMemo} from 'react';
 
 import {useAiChatDisabled} from '@cdo/apps/aichat/context/aiChatDisabledContext';
 import {Role} from '@cdo/apps/aiComponentLibrary/chatMessage/types';
@@ -11,6 +11,7 @@ import {ChatAsset, ChatEvent, isChatMessage} from '../types';
 
 import {ChatDisabled} from './ChatDisabled';
 import ChatEventView from './ChatEventView';
+import EmptyStudentChatHistory from './EmptyStudentChatHistory';
 import WaitingAnimation from './WaitingAnimation';
 
 import moduleStyles from './chatWorkspace.module.scss';
@@ -85,6 +86,10 @@ const ChatEventsList: React.FunctionComponent<ChatEventsListProps> = ({
       finalEventRef.current?.focus();
     }
   };
+
+  const isTeacherViewEmptyStudentChatHistory = useMemo(() => {
+    return isTeacherView && events.length === 0;
+  }, [isTeacherView, events]);
 
   useEffect(() => {
     const container = conversationContainerRef.current;
@@ -188,6 +193,9 @@ const ChatEventsList: React.FunctionComponent<ChatEventsListProps> = ({
           <>
             {hasInstructionsDrawer && (
               <div className={moduleStyles.instructionsDrawerInset} />
+            )}
+            {isTeacherViewEmptyStudentChatHistory && (
+              <EmptyStudentChatHistory />
             )}
             {events.map((event, index) => {
               const isLastMessage = index === events.length - 1;

--- a/apps/src/aichat/views/EmptyStudentChatHistory.tsx
+++ b/apps/src/aichat/views/EmptyStudentChatHistory.tsx
@@ -1,0 +1,25 @@
+import FontAwesomeV6Icon from '@code-dot-org/component-library/fontAwesomeV6Icon';
+import {Typography} from '@mui/material';
+import React from 'react';
+
+import styles from './empty-student-chat-history.module.scss';
+
+const EmptyStudentChatHistory: React.FunctionComponent = () => {
+  return (
+    <div className={styles.emptyStudentChatHistoryContainer}>
+      <div className={styles.iconContainer}>
+        <FontAwesomeV6Icon iconName={'message-slash'} className={styles.icon} />
+      </div>
+      <div className={styles.textContainer}>
+        <Typography variant="body2">
+          <strong>No activity to show</strong>
+        </Typography>
+        <Typography variant="body4">
+          There were no interactions with AI Tutor on this level.
+        </Typography>
+      </div>
+    </div>
+  );
+};
+
+export default EmptyStudentChatHistory;

--- a/apps/src/aichat/views/empty-student-chat-history.module.scss
+++ b/apps/src/aichat/views/empty-student-chat-history.module.scss
@@ -1,0 +1,40 @@
+.iconContainer {
+    background: var(--background-neutral-septenary, #768699);
+    border-radius: 100px;
+    display: flex;
+    width: 48px;
+    height: 48px;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    aspect-ratio: 1/1;
+}
+.icon {
+    color: var(--background-neutral-primary, #FFF);
+    width: 30.67px;
+    text-align: center;
+    font-size: 24px;
+    font-style: normal;
+    font-weight: 900;
+    line-height: 125%; /* 30px */
+}
+
+.emptyStudentChatHistoryContainer {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 12px;
+    padding: 10px;
+    flex: 1 0 0;
+    align-self: stretch;
+}
+
+.textContainer {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 2px;
+    align-self: stretch;
+    text-align: center;
+}

--- a/apps/src/lab2/views/components/Instructions/ResourcePanel/AiTutorChatWithInstructionDrawer.tsx
+++ b/apps/src/lab2/views/components/Instructions/ResourcePanel/AiTutorChatWithInstructionDrawer.tsx
@@ -55,7 +55,6 @@ const AiTutorChatWithInstructionDrawer: React.FunctionComponent<
   const [maxInstructionsHeight, setMaxInstructionsHeight] = useState<
     number | undefined
   >(undefined);
-  console.log('isCollapsedByDefault', isCollapsedByDefault);
   const [isCollapsed, setIsCollapsed] = useState(isCollapsedByDefault);
 
   const {

--- a/apps/src/lab2/views/components/Instructions/ResourcePanel/AiTutorChatWithInstructionDrawer.tsx
+++ b/apps/src/lab2/views/components/Instructions/ResourcePanel/AiTutorChatWithInstructionDrawer.tsx
@@ -20,6 +20,7 @@ interface AiTutorChatWithInstructionDrawerProps {
   aiTutorSystemPromptName?: string;
   aiTutorResponseSchemaSettings?: ResponseSchemaSettings;
   instructionsContent?: React.ReactNode;
+  isCollapsedByDefault: boolean;
 }
 
 const MIN_CHAT_HEIGHT = 133; // Minimum so that user message editor is always visible + some chat.
@@ -43,6 +44,7 @@ const AiTutorChatWithInstructionDrawer: React.FunctionComponent<
   aiTutorSystemPromptName,
   aiTutorResponseSchemaSettings,
   instructionsContent,
+  isCollapsedByDefault,
 }) => {
   const containerRef = useRef<HTMLDivElement>(null);
   const instructionsContentRef = useRef<HTMLDivElement>(null);
@@ -53,7 +55,8 @@ const AiTutorChatWithInstructionDrawer: React.FunctionComponent<
   const [maxInstructionsHeight, setMaxInstructionsHeight] = useState<
     number | undefined
   >(undefined);
-  const [isCollapsed, setIsCollapsed] = useState(false);
+  console.log('isCollapsedByDefault', isCollapsedByDefault);
+  const [isCollapsed, setIsCollapsed] = useState(isCollapsedByDefault);
 
   const {
     position: rawInstructionsHeight,
@@ -106,6 +109,10 @@ const AiTutorChatWithInstructionDrawer: React.FunctionComponent<
       window.removeEventListener('resize', throttledAdjustChatHeight);
     };
   }, [throttledAdjustChatHeight]);
+
+  useEffect(() => {
+    setIsCollapsed(isCollapsedByDefault);
+  }, [isCollapsedByDefault]);
 
   // Measure the instructions content height once when loaded
   // and adjust the initial height if content is smaller.

--- a/apps/src/lab2/views/components/Instructions/ResourcePanel/index.tsx
+++ b/apps/src/lab2/views/components/Instructions/ResourcePanel/index.tsx
@@ -281,6 +281,7 @@ const ResourcePanel: React.FC<ResourcePanelProps> = ({
             aiTutorSystemPromptName={aiTutorSystemPromptName}
             aiTutorResponseSchemaSettings={aiTutorResponseSchemaSettings}
             instructionsContent={instructionsContent}
+            isCollapsedByDefault={!!viewAsUserId}
           />
         );
       }


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
This adds an empty chat history state view for teachers viewing chat history of students who have not yet interacted with AI Tutor. The instructions drawer by default is collapsed when in teacher view. Currently, the chat workspace is just blank when there is no student chat history.

## After update


https://github.com/user-attachments/assets/9ef9c756-f050-4748-b661-892a3fa7b901




## Links
<!--  Links to relevant external resources.
      - spec docs, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- Jira: https://codedotorg.atlassian.net/browse/AFL-462

## Testing story
<!--  Does your change include appropriate tests?
      - If so, please describe how the tests included in this PR are sufficient.
      - If not, please explain why this change does not need to be tested. -->

Tested locally in Web Lab 2 levels with teacher account with section that includes student that has chat history and student that doesn't.

## Deployment strategy
<!--  Any special steps required to deploy this, besides merging?
      - Are there database migrations or manual steps?
      - Does this require coordination with other teams or systems? -->



## Follow-up work
<!--  List any clean-up or technical debt that will be addressed in future work.
      - Include Jira links where applicable.
      - Are there any known limitations or improvements planned? -->



## Privacy
<!--  How does this change impact Student & Teacher privacy?
      - Does this collect, use, share, or modify PII, either new or existing? -->



## Security
<!--  How does this change impact our security surface-area?
      - Do API's touched have the right auth?
      - Do infra changes impact our attack surface or encryption?
-->



## Caching
<!--  How does this change impact caching behavior?
      - Are cache keys or invalidation strategies affected?
      - Will this require cache warming or invalidation after deployment? -->



## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
