### PR TITLE
Python Lab: add `scikit-learn` experimentally

### DIFF
--- a/apps/lib/pyodide/joblib-1.4.2-py3-none-any.whl
+++ b/apps/lib/pyodide/joblib-1.4.2-py3-none-any.whl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:55a8ee286a30916ba70189b59a494d5d7df160c2709f04d9e28f464bd159d2c0
+size 175432

--- a/apps/lib/pyodide/libopenblas-0.3.26.zip
+++ b/apps/lib/pyodide/libopenblas-0.3.26.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:15c2c82b0fdfdde83a81190f35f5f4a0d15bf236a7e93944c433ae5ac6bf3ee5
+size 1916561

--- a/apps/lib/pyodide/scikit_learn-1.7.0-cp313-cp313-pyodide_2025_0_wasm32.whl
+++ b/apps/lib/pyodide/scikit_learn-1.7.0-cp313-cp313-pyodide_2025_0_wasm32.whl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:212ae2f90eb1f017421c44e51468fcf4eb9d9a2d7f262cd7dda35b3919032b6a
+size 6385320

--- a/apps/lib/pyodide/threadpoolctl-3.5.0-py3-none-any.whl
+++ b/apps/lib/pyodide/threadpoolctl-3.5.0-py3-none-any.whl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6b8ba5df6d6de2cf40a29c0b5f858b3479782dcdeb31aa3345e432dbc2a0c84a
+size 18414


### PR DESCRIPTION
Makes it possible to use `scikit-learn` in Python Lab by adding its wheel file to our repo, as well as its dependencies. Molly worked out which dependencies needed to be added to get `scikit-learn` to work.

## Links

- Jira: https://codedotorg.atlassian.net/browse/AFL-458
- Slack discussion: https://codedotorg.slack.com/archives/C06JELCAPT9/p1770745168249929

## Testing story

I tested manually using `scikit-learn` built-in datasets to fit models a bit. Here's an example snippet that fits a model and plots its results (slightly modified from [here](https://scikit-learn.org/stable/visualizations.html)):

```
import matplotlib.pyplot as plt
from sklearn.model_selection import train_test_split
from sklearn.linear_model import LogisticRegression
from sklearn.metrics import RocCurveDisplay
from sklearn.datasets import load_iris

X, y = load_iris(return_X_y=True)
y = y == 2  # make binary
X_train, X_test, y_train, y_test = train_test_split(
   X, y, test_size=.8, random_state=42
)
clf = LogisticRegression(random_state=42, C=.01)
clf.fit(X_train, y_train)

clf_disp = RocCurveDisplay.from_estimator(clf, X_test, y_test)
plt.show()
```

`scikit-learn` is a pretty sprawling package, so I wouldn't say I've tested every nook and cranny. But per discussion in Slack, that sounds ok for now.