### PR TITLE
Tutor Permissions: Add the error icon to the AI Settings teacher nav tab when the section is a bad state

### DIFF
--- a/apps/src/templates/teacherNavigation/SidebarOption.tsx
+++ b/apps/src/templates/teacherNavigation/SidebarOption.tsx
@@ -70,15 +70,14 @@ const SidebarOption: React.FC<SidebarOptionProps> = ({
         })}
       >
         {LABELED_TEACHER_NAVIGATION_PATHS[pathKey].label}
-        {showErrorIcon && (
-          // TODO: make the icon float right
-          // make the icon red.
-          <>
-            &nbsp;
-            <FontAwesomeV6Icon iconName="triangle-exclamation" />
-          </>
-        )}
       </BodyTwoText>
+      {showErrorIcon && (
+        <FontAwesomeV6Icon
+          iconName="triangle-exclamation"
+          iconStyle="solid"
+          className={styles.errorIcon}
+        />
+      )}
     </NavLink>
   );
 };

--- a/apps/src/templates/teacherNavigation/SidebarOption.tsx
+++ b/apps/src/templates/teacherNavigation/SidebarOption.tsx
@@ -21,6 +21,7 @@ interface SidebarOptionProps {
   unitPosition?: number;
   unitName: string | null;
   pathKey: keyof typeof LABELED_TEACHER_NAVIGATION_PATHS;
+  showErrorIcon: boolean;
 }
 
 const SidebarOption: React.FC<SidebarOptionProps> = ({
@@ -30,6 +31,7 @@ const SidebarOption: React.FC<SidebarOptionProps> = ({
   unitPosition,
   unitName,
   pathKey,
+  showErrorIcon,
 }) => {
   const reportMetric = (path: string) => () => {
     analyticsReporter.sendEvent(EVENTS.NAVIGATE_TO_PAGE, {
@@ -68,6 +70,14 @@ const SidebarOption: React.FC<SidebarOptionProps> = ({
         })}
       >
         {LABELED_TEACHER_NAVIGATION_PATHS[pathKey].label}
+        {showErrorIcon && (
+          // TODO: make the icon float right
+          // make the icon red.
+          <>
+            &nbsp;
+            <FontAwesomeV6Icon iconName="triangle-exclamation" />
+          </>
+        )}
       </BodyTwoText>
     </NavLink>
   );

--- a/apps/src/templates/teacherNavigation/TeacherNavigationBar.tsx
+++ b/apps/src/templates/teacherNavigation/TeacherNavigationBar.tsx
@@ -17,7 +17,11 @@ import analyticsReporter from '@cdo/apps/metrics/AnalyticsReporter';
 import SidebarOption from '@cdo/apps/templates/teacherNavigation/SidebarOption';
 import experiments from '@cdo/apps/util/experiments';
 import {useAppSelector} from '@cdo/apps/util/reduxHooks';
-import {AiDiffContext} from '@cdo/generated-scripts/sharedConstants';
+import {
+  AiChatAccessLevels,
+  AiChatToolsDependency,
+  AiDiffContext,
+} from '@cdo/generated-scripts/sharedConstants';
 import i18n from '@cdo/locale';
 
 import {selectedSectionSelector} from '../teacherDashboard/teacherSectionsReduxSelectors';
@@ -205,6 +209,18 @@ const TeacherNavigationBar: React.FC<{
     [currentPathName]
   );
 
+  const shouldShowErrorIcon = React.useCallback(
+    (key: string) => {
+      return (
+        key === TEACHER_NAVIGATION_PATH_NAMES.aiChatSettings &&
+        selectedSection?.assignedAiChatToolsDependency ===
+          AiChatToolsDependency.ESSENTIAL &&
+        selectedSection?.aiChatAccessLevel === AiChatAccessLevels.DISABLED
+      );
+    },
+    [selectedSection]
+  );
+
   const getSidebarOptionsForSection = (
     sidebarKeys: (keyof typeof LABELED_TEACHER_NAVIGATION_PATHS)[]
   ) => {
@@ -220,6 +236,7 @@ const TeacherNavigationBar: React.FC<{
         unitPosition={selectedSection.unitPosition}
         unitName={selectedSection.unitName}
         pathKey={key as keyof typeof LABELED_TEACHER_NAVIGATION_PATHS}
+        showErrorIcon={shouldShowErrorIcon(key)}
       />
     ));
   };

--- a/apps/src/templates/teacherNavigation/TeacherNavigationBar.tsx
+++ b/apps/src/templates/teacherNavigation/TeacherNavigationBar.tsx
@@ -212,6 +212,7 @@ const TeacherNavigationBar: React.FC<{
   const shouldShowErrorIcon = React.useCallback(
     (key: string) => {
       return (
+        experiments.isEnabled(experiments.AI_CHAT_NEW_PERMISSIONS) &&
         key === TEACHER_NAVIGATION_PATH_NAMES.aiChatSettings &&
         selectedSection?.assignedAiChatToolsDependency ===
           AiChatToolsDependency.ESSENTIAL &&

--- a/apps/src/templates/teacherNavigation/teacher-navigation.module.scss
+++ b/apps/src/templates/teacherNavigation/teacher-navigation.module.scss
@@ -83,6 +83,13 @@
   }
 }
 
+.errorIcon {
+  margin-left: auto;
+  margin-right: 10px;
+  color: var(--text-error-primary-fixed);
+  font-size: 1rem;
+}
+
 .sidebarOption {
   display: flex;
   height: 32px;


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

This PR adds a red exclamation triangle icon next to the AI Settings link in teacher dashboard when the section is in a bad state such that AI chat is required for the assigned curriculum but it's turned off.  

## Links
<!--  Links to relevant external resources.
      - spec docs, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- [design](https://www.figma.com/design/nl4nXJLuUHb9Aj4gfCAaNL/AI-Tutor--Settings?node-id=3374-14619&m=dev)

## Testing story
<!--  Does your change include appropriate tests?
      - If so, please describe how the tests included in this PR are sufficient.
      - If not, please explain why this change does not need to be tested. -->


https://github.com/user-attachments/assets/3fb9a950-4d07-436d-8eb1-f17fda088877



## Deployment strategy
<!--  Any special steps required to deploy this, besides merging?
      - Are there database migrations or manual steps?
      - Does this require coordination with other teams or systems? -->

 currently behind an experiment flag

## Follow-up work
<!--  List any clean-up or technical debt that will be addressed in future work.
      - Include Jira links where applicable.
      - Are there any known limitations or improvements planned? -->

 - add a "requires ai chat tools" indicator in the curriculum catalog - [design](https://www.figma.com/design/nl4nXJLuUHb9Aj4gfCAaNL/AI-Tutor--Settings?node-id=3372-8661&m=dev)
 - follow-up to #70681 to make section assignment turn on ai chat tools
 - hook up frontend to permissions logic
 - run pre-launch script to enable ai chat tools for all sections requiring it
 - remove the experiment
