### PR TITLE
Only try to show rubric editing buttons if the element exists

### DIFF
--- a/apps/src/sites/studio/pages/levels/editors/fields/_special_level_types.js
+++ b/apps/src/sites/studio/pages/levels/editors/fields/_special_level_types.js
@@ -15,9 +15,13 @@ function initPage() {
       .clone()
       .insertBefore('#plusAnswerContainedLevel');
   });
-
-  ReactDOM.render(
-    <LinkToRubricEditor lessons={lessons} />,
-    document.getElementById('link-to-rubric-editor')
+  const linkToRubricContainer = document.getElementById(
+    'link-to-rubric-editor'
   );
+  if (linkToRubricContainer) {
+    ReactDOM.render(
+      <LinkToRubricEditor lessons={lessons} />,
+      linkToRubricContainer
+    );
+  }
 }


### PR DESCRIPTION
Follow up to #70705.
Ben noticed on Sketch Lab levels we were throwing an error because we were trying to render into a null element. The container will only exist if the submittable property is supported on the level type. This fixes the error by not trying to render the edit buttons if there is no container.



## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
