### PR TITLE
Fix jest module mapping config error

### DIFF
--- a/apps/jest.config.js
+++ b/apps/jest.config.js
@@ -23,7 +23,8 @@ const jestAliases = {
  * Imports the application level aliases from webpack
  */
 Object.entries(APPLICATION_ALIASES).forEach(([alias, localPath]) => {
-  jestAliases[`${alias}/(.*)`] = `${localPath}/$1`;
+  // Anchor to avoid matching unrelated packages that merely contain `${alias}/`
+  jestAliases[`^${alias}/(.*)$`] = `${localPath}/$1`;
 });
 
 /**


### PR DESCRIPTION
I was hitting the following error when running js UTs on my local and on drone which was blocking #70684. 

Configuration error:
    
    Could not locate module ../../../../../../../node_modules/emotion-element-f0de968e.browser.esm.js mapped as:
    /home/cassi/code/code-dot-org/apps/node_modules/react/$1.
    
    Please check your configuration for these entries:
    {
      "moduleNameMapper": {
        "/react\/(.*)/": "/home/cassi/code/code-dot-org/apps/node_modules/react/$1"
      },
      "resolver": undefined
    }


This fix was recommended by codex with the following reasoning:

> You’re hitting an over-broad Jest alias: the react alias is being applied to any path containing react/, which accidentally captures @emotion/react/.... I anchored the alias mapping so it only matches the exact alias prefix.


Codex doesn't seem to think that there are any unintended side-effects, and if anything, this will uncover other mapping issues if they exist. 

> Likely no hidden problems. The change anchors the alias regex so it only matches paths that start with the alias, instead of matching any path that merely contains alias/. That fixes the unintended capture of @emotion/react/....
> 
> Potential side effects to be aware of:
> 
> 1. If any test was (incorrectly) relying on a path that contains an alias segment rather than starting with it, it will stop being remapped. That would surface as a new “module not found” error (which is good—it was being mapped by accident).
> 2. This affects all APPLICATION_ALIASES, not just react. If any alias string contained regex special characters, anchoring would still be fine here, but it’s worth noting (none of the current aliases should be problematic).
> 
> So the change should reduce hidden problems rather than create them. If anything breaks, it’ll be a real path issue that was previously being masked.
> 


Not sure why I seem to be the only one with this error but since it's happening in drone I don't think it's anything on my local  env causing it.