### PR TITLE
Web Lab 2: Add Statsig analytics for instructions drawer in resource panel

### DIFF
--- a/apps/src/lab2/views/components/Instructions/ResourcePanel/AiTutorChatWithInstructionDrawer.tsx
+++ b/apps/src/lab2/views/components/Instructions/ResourcePanel/AiTutorChatWithInstructionDrawer.tsx
@@ -81,15 +81,15 @@ const AiTutorChatWithInstructionDrawer: React.FunctionComponent<
       const startHeight = instructionsHeightAtDragStartRef.current;
       instructionsHeightAtDragStartRef.current = null;
       const endHeight = rawInstructionsHeight;
-      if (endHeight > startHeight) {
-        sendLab2AnalyticsEvent(
-          EVENTS.RESOURCE_PANEL_INSTRUCTIONS_DRAWER_RESIZED_INCREASED
-        );
-      } else if (endHeight < startHeight) {
-        sendLab2AnalyticsEvent(
-          EVENTS.RESOURCE_PANEL_INSTRUCTIONS_DRAWER_RESIZED_DECREASED
-        );
-      }
+      const eventToReport =
+        endHeight > startHeight
+          ? EVENTS.RESOURCE_PANEL_INSTRUCTIONS_DRAWER_RESIZED_INCREASED
+          : EVENTS.RESOURCE_PANEL_INSTRUCTIONS_DRAWER_RESIZED_DECREASED;
+
+      sendLab2AnalyticsEvent(eventToReport, {
+        startHeight: startHeight,
+        endHeight: endHeight,
+      });
     }
   }, [isDragging, rawInstructionsHeight]);
 

--- a/apps/src/lab2/views/components/Instructions/ResourcePanel/AiTutorChatWithInstructionDrawer.tsx
+++ b/apps/src/lab2/views/components/Instructions/ResourcePanel/AiTutorChatWithInstructionDrawer.tsx
@@ -81,11 +81,15 @@ const AiTutorChatWithInstructionDrawer: React.FunctionComponent<
       const startHeight = instructionsHeightAtDragStartRef.current;
       instructionsHeightAtDragStartRef.current = null;
       const endHeight = rawInstructionsHeight;
-      const dragType = endHeight > startHeight ? 'increase' : 'decrease';
-      sendLab2AnalyticsEvent(
-        EVENTS.RESOURCE_PANEL_INSTRUCTIONS_DRAWER_RESIZED,
-        {dragType: dragType}
-      );
+      if (endHeight > startHeight) {
+        sendLab2AnalyticsEvent(
+          EVENTS.RESOURCE_PANEL_INSTRUCTIONS_DRAWER_RESIZED_INCREASED
+        );
+      } else if (endHeight < startHeight) {
+        sendLab2AnalyticsEvent(
+          EVENTS.RESOURCE_PANEL_INSTRUCTIONS_DRAWER_RESIZED_DECREASED
+        );
+      }
     }
   }, [isDragging, rawInstructionsHeight]);
 
@@ -146,10 +150,10 @@ const AiTutorChatWithInstructionDrawer: React.FunctionComponent<
   }, [instructionsContent, setRawInstructionsHeight]);
 
   const toggleInstructions = useCallback(() => {
-    const toggleType = isCollapsed ? 'expand' : 'collapse';
-    sendLab2AnalyticsEvent(EVENTS.RESOURCE_PANEL_INSTRUCTIONS_DRAWER_TOGGLED, {
-      toggleType: toggleType,
-    });
+    const eventToReport = isCollapsed
+      ? EVENTS.RESOURCE_PANEL_INSTRUCTIONS_DRAWER_EXPANDED
+      : EVENTS.RESOURCE_PANEL_INSTRUCTIONS_DRAWER_COLLAPSED;
+    sendLab2AnalyticsEvent(eventToReport);
     setIsCollapsed(prev => !prev);
   }, [isCollapsed]);
 

--- a/apps/src/lab2/views/components/Instructions/ResourcePanel/AiTutorChatWithInstructionDrawer.tsx
+++ b/apps/src/lab2/views/components/Instructions/ResourcePanel/AiTutorChatWithInstructionDrawer.tsx
@@ -85,11 +85,12 @@ const AiTutorChatWithInstructionDrawer: React.FunctionComponent<
         endHeight > startHeight
           ? EVENTS.RESOURCE_PANEL_INSTRUCTIONS_DRAWER_RESIZED_INCREASED
           : EVENTS.RESOURCE_PANEL_INSTRUCTIONS_DRAWER_RESIZED_DECREASED;
-
-      sendLab2AnalyticsEvent(eventToReport, {
-        startHeight: startHeight,
-        endHeight: endHeight,
-      });
+      if (endHeight !== startHeight) {
+        sendLab2AnalyticsEvent(eventToReport, {
+          startHeight: startHeight,
+          endHeight: endHeight,
+        });
+      }
     }
   }, [isDragging, rawInstructionsHeight]);
 

--- a/apps/src/lab2/views/components/Instructions/ResourcePanel/AiTutorChatWithInstructionDrawer.tsx
+++ b/apps/src/lab2/views/components/Instructions/ResourcePanel/AiTutorChatWithInstructionDrawer.tsx
@@ -48,6 +48,7 @@ const AiTutorChatWithInstructionDrawer: React.FunctionComponent<
 }) => {
   const containerRef = useRef<HTMLDivElement>(null);
   const instructionsContentRef = useRef<HTMLDivElement>(null);
+  const instructionsHeightAtDragStartRef = useRef<number | null>(null);
   const [chatHeight, setChatHeight] = useState<number | undefined>(undefined);
   const [instructionsHeight, setInstructionsHeight] = useState<
     number | undefined
@@ -68,7 +69,29 @@ const AiTutorChatWithInstructionDrawer: React.FunctionComponent<
     min: MIN_INSTRUCTIONS_HEIGHT,
     max: maxInstructionsHeight,
     containerRef,
+    onResizeStart: () => {
+      instructionsHeightAtDragStartRef.current = rawInstructionsHeight;
+    },
   });
+
+  // Report increase/decrease when drag ends; use effect so we read the final
+  // position after state has updated (avoids stale closure in onResizeEnd).
+  useEffect(() => {
+    if (!isDragging && instructionsHeightAtDragStartRef.current !== null) {
+      const startHeight = instructionsHeightAtDragStartRef.current;
+      instructionsHeightAtDragStartRef.current = null;
+      const endHeight = rawInstructionsHeight;
+      if (endHeight > startHeight) {
+        sendLab2AnalyticsEvent(
+          EVENTS.RESOURCE_PANEL_INSTRUCTIONS_DRAWER_RESIZED_INCREASED
+        );
+      } else if (endHeight < startHeight) {
+        sendLab2AnalyticsEvent(
+          EVENTS.RESOURCE_PANEL_INSTRUCTIONS_DRAWER_RESIZED_DECREASED
+        );
+      }
+    }
+  }, [isDragging, rawInstructionsHeight]);
 
   const adjustChatHeight = useCallback(() => {
     const containerElement = containerRef.current;

--- a/apps/src/lab2/views/components/Instructions/ResourcePanel/AiTutorChatWithInstructionDrawer.tsx
+++ b/apps/src/lab2/views/components/Instructions/ResourcePanel/AiTutorChatWithInstructionDrawer.tsx
@@ -4,10 +4,12 @@ import React, {useState, useCallback, useMemo, useEffect, useRef} from 'react';
 import {useResizable} from 'react-resizable-layout';
 
 import {ChatButtonData, ResponseSchemaSettings} from '@cdo/apps/aichat/types';
+import {sendLab2AnalyticsEvent} from '@cdo/apps/lab2/utils';
 import AiTutorChat from '@cdo/apps/lab2/views/components/AiTutorChat';
 import ResizeBar, {
   RESIZE_BAR_SIZE_PX,
 } from '@cdo/apps/lab2/views/components/layout/ResizeBar';
+import {EVENTS} from '@cdo/apps/metrics/AnalyticsConstants';
 
 import styles from './ai-tutor-chat-with-instructions-drawer.module.scss';
 
@@ -125,8 +127,12 @@ const AiTutorChatWithInstructionDrawer: React.FunctionComponent<
   }, [instructionsContent, setRawInstructionsHeight]);
 
   const toggleInstructions = useCallback(() => {
+    const eventToReport = isCollapsed
+      ? EVENTS.RESOURCE_PANEL_INSTRUCTIONS_DRAWER_EXPANDED
+      : EVENTS.RESOURCE_PANEL_INSTRUCTIONS_DRAWER_COLLAPSED;
+    sendLab2AnalyticsEvent(eventToReport);
     setIsCollapsed(prev => !prev);
-  }, []);
+  }, [isCollapsed]);
 
   return (
     <div ref={containerRef} className={styles.container}>

--- a/apps/src/lab2/views/components/Instructions/ResourcePanel/AiTutorChatWithInstructionDrawer.tsx
+++ b/apps/src/lab2/views/components/Instructions/ResourcePanel/AiTutorChatWithInstructionDrawer.tsx
@@ -81,15 +81,11 @@ const AiTutorChatWithInstructionDrawer: React.FunctionComponent<
       const startHeight = instructionsHeightAtDragStartRef.current;
       instructionsHeightAtDragStartRef.current = null;
       const endHeight = rawInstructionsHeight;
-      if (endHeight > startHeight) {
-        sendLab2AnalyticsEvent(
-          EVENTS.RESOURCE_PANEL_INSTRUCTIONS_DRAWER_RESIZED_INCREASED
-        );
-      } else if (endHeight < startHeight) {
-        sendLab2AnalyticsEvent(
-          EVENTS.RESOURCE_PANEL_INSTRUCTIONS_DRAWER_RESIZED_DECREASED
-        );
-      }
+      const dragType = endHeight > startHeight ? 'increase' : 'decrease';
+      sendLab2AnalyticsEvent(
+        EVENTS.RESOURCE_PANEL_INSTRUCTIONS_DRAWER_RESIZED,
+        {dragType: dragType}
+      );
     }
   }, [isDragging, rawInstructionsHeight]);
 
@@ -150,10 +146,10 @@ const AiTutorChatWithInstructionDrawer: React.FunctionComponent<
   }, [instructionsContent, setRawInstructionsHeight]);
 
   const toggleInstructions = useCallback(() => {
-    const eventToReport = isCollapsed
-      ? EVENTS.RESOURCE_PANEL_INSTRUCTIONS_DRAWER_EXPANDED
-      : EVENTS.RESOURCE_PANEL_INSTRUCTIONS_DRAWER_COLLAPSED;
-    sendLab2AnalyticsEvent(eventToReport);
+    const toggleType = isCollapsed ? 'expand' : 'collapse';
+    sendLab2AnalyticsEvent(EVENTS.RESOURCE_PANEL_INSTRUCTIONS_DRAWER_TOGGLED, {
+      toggleType: toggleType,
+    });
     setIsCollapsed(prev => !prev);
   }, [isCollapsed]);
 

--- a/apps/src/metrics/AnalyticsConstants.js
+++ b/apps/src/metrics/AnalyticsConstants.js
@@ -631,10 +631,14 @@ const EVENTS = {
   RESOURCE_PANEL_SETTINGS_CHANGE: 'Resource Panel Settings Change',
 
   // Resource Panel - Instructions Drawer
-  RESOURCE_PANEL_INSTRUCTIONS_DRAWER_TOGGLED:
-    'Resource Panel Instructions Drawer Toggled',
-  RESOURCE_PANEL_INSTRUCTIONS_DRAWER_RESIZED:
-    'Resource Panel Instructions Drawer Resized',
+  RESOURCE_PANEL_INSTRUCTIONS_DRAWER_COLLAPSED:
+    'Resource Panel Instructions Drawer Collapsed',
+  RESOURCE_PANEL_INSTRUCTIONS_DRAWER_EXPANDED:
+    'Resource Panel Instructions Drawer Expanded',
+  RESOURCE_PANEL_INSTRUCTIONS_DRAWER_RESIZED_INCREASED:
+    'Resource Panel Instructions Drawer Resized Increased',
+  RESOURCE_PANEL_INSTRUCTIONS_DRAWER_RESIZED_DECREASED:
+    'Resource Panel Instructions Drawer Resized Decreased',
 
   // IntroJS flows
   INTROJS_FLOW_STARTED: 'IntroJS Flow Started',

--- a/apps/src/metrics/AnalyticsConstants.js
+++ b/apps/src/metrics/AnalyticsConstants.js
@@ -631,14 +631,10 @@ const EVENTS = {
   RESOURCE_PANEL_SETTINGS_CHANGE: 'Resource Panel Settings Change',
 
   // Resource Panel - Instructions Drawer
-  RESOURCE_PANEL_INSTRUCTIONS_DRAWER_COLLAPSED:
-    'Resource Panel Instructions Drawer Collapsed',
-  RESOURCE_PANEL_INSTRUCTIONS_DRAWER_EXPANDED:
-    'Resource Panel Instructions Drawer Expanded',
-  RESOURCE_PANEL_INSTRUCTIONS_DRAWER_RESIZED_INCREASED:
-    'Resource Panel Instructions Drawer Resized Increased',
-  RESOURCE_PANEL_INSTRUCTIONS_DRAWER_RESIZED_DECREASED:
-    'Resource Panel Instructions Drawer Resized Decreased',
+  RESOURCE_PANEL_INSTRUCTIONS_DRAWER_TOGGLED:
+    'Resource Panel Instructions Drawer Toggled',
+  RESOURCE_PANEL_INSTRUCTIONS_DRAWER_RESIZED:
+    'Resource Panel Instructions Drawer Resized',
 
   // IntroJS flows
   INTROJS_FLOW_STARTED: 'IntroJS Flow Started',

--- a/apps/src/metrics/AnalyticsConstants.js
+++ b/apps/src/metrics/AnalyticsConstants.js
@@ -630,6 +630,12 @@ const EVENTS = {
   RESOURCE_PANEL_LANGUAGE_CHANGE: 'Resource Panel Language Change',
   RESOURCE_PANEL_SETTINGS_CHANGE: 'Resource Panel Settings Change',
 
+  // Resource Panel - Instructions Drawer
+  RESOURCE_PANEL_INSTRUCTIONS_DRAWER_COLLAPSED:
+    'Resource Panel Instructions Drawer Collapsed',
+  RESOURCE_PANEL_INSTRUCTIONS_DRAWER_EXPANDED:
+    'Resource Panel Instructions Drawer Expanded',
+
   // IntroJS flows
   INTROJS_FLOW_STARTED: 'IntroJS Flow Started',
   INTROJS_FLOW_EXIT: 'IntroJS Flow Exited',

--- a/apps/src/metrics/AnalyticsConstants.js
+++ b/apps/src/metrics/AnalyticsConstants.js
@@ -635,6 +635,10 @@ const EVENTS = {
     'Resource Panel Instructions Drawer Collapsed',
   RESOURCE_PANEL_INSTRUCTIONS_DRAWER_EXPANDED:
     'Resource Panel Instructions Drawer Expanded',
+  RESOURCE_PANEL_INSTRUCTIONS_DRAWER_RESIZED_INCREASED:
+    'Resource Panel Instructions Drawer Resized Increased',
+  RESOURCE_PANEL_INSTRUCTIONS_DRAWER_RESIZED_DECREASED:
+    'Resource Panel Instructions Drawer Resized Decreased',
 
   // IntroJS flows
   INTROJS_FLOW_STARTED: 'IntroJS Flow Started',


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
This PR adds Statsig analytics for the instructions drawer in the AI Tutor panel. 
We report when the user toggles the drawer open/close, and when they drag the drawer to increase/decrease the instructions drawer's height.

## After update


https://github.com/user-attachments/assets/a3091441-1578-47ec-a484-88db6f96e63d



## Links
<!--  Links to relevant external resources.
      - spec docs, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- Jira: https://codedotorg.atlassian.net/browse/AFL-469
- [Slack thread](https://codedotorg.slack.com/archives/C09EHQE4DGD/p1770848632936429)

## Testing story
<!--  Does your change include appropriate tests?
      - If so, please describe how the tests included in this PR are sufficient.
      - If not, please explain why this change does not need to be tested. -->

Tested locally in `weblab2` levels and confirmed events reported as expected in dev console.

## Deployment strategy
<!--  Any special steps required to deploy this, besides merging?
      - Are there database migrations or manual steps?
      - Does this require coordination with other teams or systems? -->



## Follow-up work
<!--  List any clean-up or technical debt that will be addressed in future work.
      - Include Jira links where applicable.
      - Are there any known limitations or improvements planned? -->



## Privacy
<!--  How does this change impact Student & Teacher privacy?
      - Does this collect, use, share, or modify PII, either new or existing? -->



## Security
<!--  How does this change impact our security surface-area?
      - Do API's touched have the right auth?
      - Do infra changes impact our attack surface or encryption?
-->



## Caching
<!--  How does this change impact caching behavior?
      - Are cache keys or invalidation strategies affected?
      - Will this require cache warming or invalidation after deployment? -->



## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
