### PR TITLE
🧹 Remove Radium from `AnigifPreview`

### DIFF
--- a/apps/src/templates/instructions/AniGifPreview.jsx
+++ b/apps/src/templates/instructions/AniGifPreview.jsx
@@ -1,5 +1,4 @@
 import PropTypes from 'prop-types';
-import Radium from 'radium'; // eslint-disable-line no-restricted-imports
 import React from 'react';
 import {connect} from 'react-redux';
 
@@ -33,6 +32,11 @@ class ImagePreviewUnwrapped extends React.Component {
       ariaLabel = `${ariaLabel}. ${alt}`;
     }
 
+    const previewStyle = {
+      ...styles.aniGifPreview(url),
+      ...(noVisualization ? styles.bigPreview : {}),
+    };
+
     return (
       <div id="ani-gif-preview-wrapper" style={styles.wrapper}>
         <div
@@ -40,10 +44,7 @@ class ImagePreviewUnwrapped extends React.Component {
           role="button"
           tabIndex={0}
           aria-label={ariaLabel}
-          style={[
-            styles.aniGifPreview(url),
-            noVisualization && styles.bigPreview,
-          ]}
+          style={previewStyle}
           onClick={showInstructionsDialog}
           onKeyDown={this.handleKeyDown}
         />
@@ -69,7 +70,7 @@ const styles = {
   },
 };
 
-export const ImagePreview = Radium(ImagePreviewUnwrapped);
+export const ImagePreview = ImagePreviewUnwrapped;
 export default connect(
   state => ({
     url: state.pageConstants.aniGifURL,


### PR DESCRIPTION
This work was originally done in #70513 but was reverted because of unexpected eyes diffs in https://github.com/code-dot-org/code-dot-org/pull/70626. I've opened https://github.com/code-dot-org/code-dot-org/pull/70626 to re-introduce the changes. However, rather than trying to merge the changes to all 11 of the instructions components at once, I'm going to incrementally reduce the diff on that PR by merging components in isolation to better identify where the eyes issues are coming from. 