### PR TITLE
🧹 Remove Radium from `RubricField`

### DIFF
--- a/apps/src/templates/instructions/teacherFeedback/RubricField.jsx
+++ b/apps/src/templates/instructions/teacherFeedback/RubricField.jsx
@@ -1,13 +1,13 @@
+import classNames from 'classnames';
 import _ from 'lodash';
 import PropTypes from 'prop-types';
-import Radium from 'radium'; // eslint-disable-line no-restricted-imports
 import React, {Component} from 'react';
 import ReactTooltip from 'react-tooltip';
 
-import fontConstants from '@cdo/apps/fontConstants';
 import {CheckedRadioButton} from '@cdo/apps/templates/instructions/teacherFeedback/CheckedRadioButton';
-import color from '@cdo/apps/util/color';
 import i18n from '@cdo/locale';
+
+import styles from './rubric-field.module.scss';
 
 const rubricPerformanceHeaders = {
   performanceLevel1: i18n.rubricLevelOneHeader(),
@@ -42,15 +42,16 @@ class RubricField extends Component {
   };
 
   render() {
-    const performanceHeaderStyle = this.props.currentlyChecked
-      ? styles.performanceLevelHeaderSelected
-      : styles.performanceLevelHeader;
+    const performanceHeaderClass = classNames(
+      styles.performanceLevelHeader,
+      this.props.currentlyChecked && styles.performanceLevelHeaderSelected
+    );
 
     const tooltipId = _.uniqueId();
     return (
-      <div style={styles.rubricPerformanceHeaders}>
+      <div className={styles.rubricPerformanceHeaders}>
         <div
-          style={performanceHeaderStyle}
+          className={performanceHeaderClass}
           data-tip
           data-for={tooltipId}
           aria-describedby={tooltipId}
@@ -66,13 +67,16 @@ class RubricField extends Component {
           )}
           <details
             id={`rubric-details-${this.props.rubricLevel}`}
-            style={styles.detailsArea}
+            className={styles.detailsArea}
             open={this.state.detailsOpen}
           >
-            <summary style={styles.rubricHeader} onClick={this.updateToggle}>
+            <summary
+              className={styles.rubricHeader}
+              onClick={this.updateToggle}
+            >
               {rubricPerformanceHeaders[this.props.rubricLevel]}
             </summary>
-            <p style={styles.rubricDetails}>{this.props.rubricValue}</p>
+            <p className={styles.rubricDetails}>{this.props.rubricValue}</p>
           </details>
         </div>
         <ReactTooltip
@@ -82,66 +86,11 @@ class RubricField extends Component {
           effect="solid"
           disable={this.state.detailsOpen}
         >
-          <div style={styles.tooltip}>{this.props.rubricValue}</div>
+          <div className={styles.tooltip}>{this.props.rubricValue}</div>
         </ReactTooltip>
       </div>
     );
   }
 }
-
-const styles = {
-  rubricLevelHeaders: {
-    width: '100%',
-  },
-  detailsArea: {
-    width: '100%',
-    paddingTop: 2,
-  },
-  rubricHeader: {
-    fontSize: 12,
-    marginLeft: 10,
-    color: color.black,
-    ...fontConstants['main-font-semi-bold'],
-    // Don't show default summary tag outline and background on hover or focus
-    outline: 'none',
-    background: 'none',
-  },
-  performanceLevelHeader: {
-    display: 'flex',
-    justifyContent: 'flex-start',
-    flexDirection: 'row',
-    margin: '0px 8px',
-    padding: 4,
-    borderRadius: 4,
-    border: `solid 1px ${color.white}`,
-    ':hover': {
-      border: `solid 1px ${color.light_cyan}`,
-    },
-  },
-  performanceLevelHeaderSelected: {
-    display: 'flex',
-    justifyContent: 'flex-start',
-    flexDirection: 'row',
-    margin: '0px 8px',
-    padding: 4,
-    backgroundColor: color.lightest_cyan,
-    borderRadius: 4,
-    border: `solid 1px ${color.white}`,
-    ':hover': {
-      border: `solid 1px ${color.light_cyan}`,
-    },
-  },
-  tooltip: {
-    maxWidth: 200,
-    lineHeight: '20px',
-    whiteSpace: 'normal',
-  },
-  rubricDetails: {
-    paddingLeft: 23,
-    paddingTop: 5,
-    fontSize: 12,
-    margin: 0,
-  },
-};
 export const UnwrappedRubricField = RubricField;
-export default Radium(RubricField);
+export default RubricField;

--- a/apps/src/templates/instructions/teacherFeedback/rubric-field.module.scss
+++ b/apps/src/templates/instructions/teacherFeedback/rubric-field.module.scss
@@ -1,0 +1,55 @@
+@import 'color';
+
+.rubricPerformanceHeaders {
+  width: 100%;
+}
+
+.detailsArea {
+  width: 100%;
+  padding-top: 2px;
+}
+
+.rubricHeader {
+  font-size: 12px;
+  margin-left: 10px;
+  color: $black;
+  font-family: Figtree, sans-serif;
+  font-weight: 600;
+  outline: none;
+  background: none;
+}
+
+.performanceLevelHeader {
+  display: flex;
+  justify-content: flex-start;
+  flex-direction: row;
+  margin: 0 8px;
+  padding: 4px;
+  border-radius: 4px;
+  border: 1px solid $white;
+
+  &:hover {
+    border: 1px solid $light_cyan;
+  }
+}
+
+.performanceLevelHeaderSelected {
+  background-color: $lightest_cyan;
+
+  &:hover {
+    border: 1px solid $light_cyan;
+  }
+}
+
+.tooltip {
+  max-width: 200px;
+  line-height: 20px;
+  white-space: normal;
+}
+
+.rubricDetails {
+  padding-left: 23px;
+  padding-top: 5px;
+  font-size: 12px;
+  margin: 0;
+}


### PR DESCRIPTION
This work was originally done in https://github.com/code-dot-org/code-dot-org/pull/70513 but was reverted because of unexpected eyes diffs in https://github.com/code-dot-org/code-dot-org/pull/70626. I've opened https://github.com/code-dot-org/code-dot-org/pull/70626 to re-introduce the changes. However, rather than trying to merge the changes to all 11 of the instructions components at once, I'm going to incrementally reduce the diff on that PR by merging components in isolation to better identify where the eyes issues are coming from.