### PR TITLE
Lesson Feedback - add saving and sending to students

### DIFF
--- a/apps/src/templates/studentSnapshot/lessonFeedbackWidget/ActionButtons.tsx
+++ b/apps/src/templates/studentSnapshot/lessonFeedbackWidget/ActionButtons.tsx
@@ -6,11 +6,13 @@ import styles from './lessonFeeedback.module.scss';
 interface ActionButtonsProps {
   onSaveAsDraft: () => void;
   onSendToStudent: () => void;
+  isSaving: boolean;
 }
 
 const ActionButtons: React.FC<ActionButtonsProps> = ({
   onSaveAsDraft,
   onSendToStudent,
+  isSaving,
 }) => {
   return (
     <div className={styles.actionButtons}>
@@ -20,12 +22,14 @@ const ActionButtons: React.FC<ActionButtonsProps> = ({
         size="xs"
         color="gray"
         onClick={onSaveAsDraft}
+        disabled={isSaving}
       />
       <Button
         text="Send feedback to student"
         size="xs"
         type="primary"
         onClick={onSendToStudent}
+        disabled={isSaving}
       />
     </div>
   );

--- a/apps/src/templates/studentSnapshot/lessonFeedbackWidget/LessonFeedbackWidget.tsx
+++ b/apps/src/templates/studentSnapshot/lessonFeedbackWidget/LessonFeedbackWidget.tsx
@@ -22,12 +22,23 @@ interface LessonFeedbackWidgetProps {
 interface LessonFeedbackData {
   id?: number;
   saved_feedback?: string;
+  submitted_feedback?: string;
+  submitted_at?: Date;
   resources?: Array<{
     recommended_action?: string;
     resource_name?: string;
     resource_link?: string;
   }>;
 }
+
+// Constants
+const DEFAULT_RESOURCE = {
+  recommended_action: '',
+  resource_name: '',
+  resource_link: '',
+};
+
+const DEFAULT_RESOURCES = [DEFAULT_RESOURCE];
 
 const LessonFeedbackWidget: React.FC<LessonFeedbackWidgetProps> = ({
   lessonId,
@@ -45,14 +56,9 @@ const LessonFeedbackWidget: React.FC<LessonFeedbackWidgetProps> = ({
       resource_name: string;
       resource_link: string;
     }>
-  >([
-    {
-      recommended_action: '',
-      resource_name: '',
-      resource_link: '',
-    },
-  ]);
+  >(DEFAULT_RESOURCES);
   const [isLoading, setIsLoading] = React.useState<boolean>(false);
+  const [isSaving, setIsSaving] = React.useState<boolean>(false);
 
   // Fetch lesson feedback from backend, and if not found, try generating ai feedback
   React.useEffect(() => {
@@ -82,15 +88,11 @@ const LessonFeedbackWidget: React.FC<LessonFeedbackWidgetProps> = ({
     async function fetchLessonFeedback() {
       if (!lessonId || !studentId || !unitId || !sectionId) {
         setFeedbackText('');
-        setResourceData([
-          {recommended_action: '', resource_name: '', resource_link: ''},
-        ]);
+        setResourceData([DEFAULT_RESOURCE]);
         return;
       }
       setFeedbackText('');
-      setResourceData([
-        {recommended_action: '', resource_name: '', resource_link: ''},
-      ]);
+      setResourceData([DEFAULT_RESOURCE]);
       try {
         const response = await fetch(
           `/lesson_feedbacks/saved_feedback?lesson_id=${lessonId}&student_id=${studentId}`
@@ -107,9 +109,7 @@ const LessonFeedbackWidget: React.FC<LessonFeedbackWidgetProps> = ({
           if (aiData && aiData.json) {
             const aiGeneratedInitialFeedback = JSON.parse(aiData.json).feedback;
             setFeedbackText(aiGeneratedInitialFeedback);
-            setResourceData([
-              {recommended_action: '', resource_name: '', resource_link: ''},
-            ]);
+            setResourceData([DEFAULT_RESOURCE]);
           }
         } else {
           const data = await response.json();
@@ -120,16 +120,12 @@ const LessonFeedbackWidget: React.FC<LessonFeedbackWidgetProps> = ({
           if (data.resources && data.resources.length > 0) {
             setResourceData(data.resources);
           } else {
-            setResourceData([
-              {recommended_action: '', resource_name: '', resource_link: ''},
-            ]);
+            setResourceData([DEFAULT_RESOURCE]);
           }
         }
       } catch (error) {
         console.error('Error fetching feedback:', error);
-        setResourceData([
-          {recommended_action: '', resource_name: '', resource_link: ''},
-        ]);
+        setResourceData([DEFAULT_RESOURCE]);
       } finally {
         setIsLoading(false);
       }
@@ -140,31 +136,25 @@ const LessonFeedbackWidget: React.FC<LessonFeedbackWidgetProps> = ({
     }
   }, [lessonId, sectionId, studentId, unitId]);
 
-  // Save as draft: update local state and persist to backend
-  const handleSaveAsDraft = async () => {
-    // Update local state
-    setExistingFeedbackData((prev: LessonFeedbackData | null) => ({
-      ...prev,
-      saved_feedback: feedbackText,
-      resources: resourceData,
-    }));
+  // Helper function to handle API requests
+  const persistFeedbackToBackend = async (
+    payload: LessonFeedbackData,
+    feedbackId?: number
+  ) => {
+    if (!lessonId || !studentId) return null;
 
-    // Persist to backend
-    if (!lessonId || !studentId) return;
     try {
       let response;
-      if (existingFeedbackData && existingFeedbackData.id) {
+      if (feedbackId) {
+        setIsSaving(true);
         // Update existing feedback
-        response = await fetch(`/lesson_feedbacks/${existingFeedbackData.id}`, {
+        response = await fetch(`/lesson_feedbacks/${feedbackId}`, {
           method: 'PATCH',
           headers: {
             'Content-Type': 'application/json',
             'X-CSRF-Token': await getAuthenticityToken(),
           },
-          body: JSON.stringify({
-            saved_feedback: feedbackText,
-            resources: resourceData,
-          }),
+          body: JSON.stringify(payload),
         });
       } else {
         // Create new feedback
@@ -177,19 +167,62 @@ const LessonFeedbackWidget: React.FC<LessonFeedbackWidgetProps> = ({
           body: JSON.stringify({
             lesson_id: lessonId,
             student_id: studentId,
-            saved_feedback: feedbackText,
-            resources: resourceData,
+            ...payload,
           }),
         });
       }
+
       if (!response.ok) {
-        throw new Error('Failed to save draft feedback');
+        throw new Error('Failed to save feedback');
       }
-      const data = await response.json();
-      setExistingFeedbackData(data);
+      setIsSaving(false);
+      return await response.json();
     } catch (err) {
-      console.error('Error saving draft feedback:', err);
+      console.error('Error saving feedback:', err);
+      throw err;
     }
+  };
+
+  const handleSaveAsDraft = async () => {
+    const newFeedbackData = {
+      ...existingFeedbackData,
+      saved_feedback: feedbackText,
+      resources: resourceData,
+    };
+
+    setExistingFeedbackData(newFeedbackData);
+
+    await persistFeedbackToBackend(
+      {
+        saved_feedback: feedbackText,
+        resources: resourceData,
+      },
+      existingFeedbackData?.id
+    );
+  };
+
+  const handleSendToStudent = async () => {
+    // Create the new feedback data
+    const newFeedbackData = {
+      ...existingFeedbackData,
+      saved_feedback: feedbackText,
+      submitted_feedback: feedbackText,
+      resources: resourceData,
+      submitted_at: new Date(),
+    };
+
+    // Update local state
+    setExistingFeedbackData(newFeedbackData);
+
+    await persistFeedbackToBackend(
+      {
+        saved_feedback: feedbackText,
+        resources: resourceData,
+        submitted_feedback: feedbackText,
+        submitted_at: new Date(),
+      },
+      existingFeedbackData?.id
+    );
   };
 
   // TO DO: Use Loading widget when needed here.
@@ -215,9 +248,8 @@ const LessonFeedbackWidget: React.FC<LessonFeedbackWidgetProps> = ({
       />
       <ActionButtons
         onSaveAsDraft={handleSaveAsDraft}
-        onSendToStudent={() => {
-          console.log('Send to student:', feedbackText, resourceData);
-        }}
+        onSendToStudent={handleSendToStudent}
+        isSaving={isSaving}
       />
     </div>
   );

--- a/apps/src/templates/studentSnapshot/lessonFeedbackWidget/LessonFeedbackWidget.tsx
+++ b/apps/src/templates/studentSnapshot/lessonFeedbackWidget/LessonFeedbackWidget.tsx
@@ -23,7 +23,7 @@ interface LessonFeedbackData {
   id?: number;
   saved_feedback?: string;
   submitted_feedback?: string;
-  submitted_at?: Date;
+  submitted_at?: Date | string;
   resources?: Array<{
     recommended_action?: string;
     resource_name?: string;
@@ -145,8 +145,8 @@ const LessonFeedbackWidget: React.FC<LessonFeedbackWidgetProps> = ({
 
     try {
       let response;
+      setIsSaving(true);
       if (feedbackId) {
-        setIsSaving(true);
         // Update existing feedback
         response = await fetch(`/lesson_feedbacks/${feedbackId}`, {
           method: 'PATCH',
@@ -167,6 +167,7 @@ const LessonFeedbackWidget: React.FC<LessonFeedbackWidgetProps> = ({
           body: JSON.stringify({
             lesson_id: lessonId,
             student_id: studentId,
+            section_id: sectionId,
             ...payload,
           }),
         });
@@ -175,11 +176,12 @@ const LessonFeedbackWidget: React.FC<LessonFeedbackWidgetProps> = ({
       if (!response.ok) {
         throw new Error('Failed to save feedback');
       }
-      setIsSaving(false);
       return await response.json();
     } catch (err) {
       console.error('Error saving feedback:', err);
       throw err;
+    } finally {
+      setIsSaving(false);
     }
   };
 
@@ -192,13 +194,12 @@ const LessonFeedbackWidget: React.FC<LessonFeedbackWidgetProps> = ({
 
     setExistingFeedbackData(newFeedbackData);
 
-    await persistFeedbackToBackend(
-      {
-        saved_feedback: feedbackText,
-        resources: resourceData,
-      },
+    const savedData = await persistFeedbackToBackend(
+      newFeedbackData,
       existingFeedbackData?.id
     );
+
+    setExistingFeedbackData(savedData);
   };
 
   const handleSendToStudent = async () => {
@@ -214,15 +215,12 @@ const LessonFeedbackWidget: React.FC<LessonFeedbackWidgetProps> = ({
     // Update local state
     setExistingFeedbackData(newFeedbackData);
 
-    await persistFeedbackToBackend(
-      {
-        saved_feedback: feedbackText,
-        resources: resourceData,
-        submitted_feedback: feedbackText,
-        submitted_at: new Date(),
-      },
+    const savedData = await persistFeedbackToBackend(
+      newFeedbackData,
       existingFeedbackData?.id
     );
+
+    setExistingFeedbackData(savedData);
   };
 
   // TO DO: Use Loading widget when needed here.


### PR DESCRIPTION
Does the following:

- Adds "send to student" feature on the teacher side (will need to modify student side later)
- Adds a `isSaving` state so that the save/send buttons are disabled while saving is in process. 

TODO:
- Add to the student side for displaying the SENT to feedback 
- There is still a bug that occasionally makes data save to the wrong lesson... that was exisiting before and will be done in a separate PR (up next on my to-do list)
- Add "last saved at" or "last submitted at" time stamp on the teacher view.
