### PR TITLE
Revert "Revert "Shrink Blockly Wrapper - Part 1""

### DIFF
--- a/apps/src/StudioApp.js
+++ b/apps/src/StudioApp.js
@@ -1,3 +1,4 @@
+import * as BlocklyCore from 'blockly/core';
 import {EventEmitter} from 'events';
 import $ from 'jquery';
 import _ from 'lodash';
@@ -551,9 +552,6 @@ StudioApp.prototype.init = function (config) {
         BlocklyUtils.updateLocale(info.rtl);
       });
     }
-    Blockly.mainBlockSpaceEditor.addUnusedBlocksHelpListener(function (e) {
-      utils.showUnusedBlockQtip(e.target);
-    });
     // Store result so that we can cleanup later in tests
     this.changeListener = Blockly.mainBlockSpaceEditor.addChangeListener(
       _.bind(function () {
@@ -905,7 +903,7 @@ StudioApp.prototype.handleClearPuzzle = function (config) {
     if (Blockly.functionEditor) {
       Blockly.functionEditor.hideIfOpen();
     }
-    Blockly.clearAllStudentWorkspaces();
+    BlocklyUtils.clearAllStudentWorkspaces();
     this.setStartBlocks_(config, false);
     if (config.level.openFunctionDefinition) {
       this.openFunctionDefinition_(config);
@@ -1114,14 +1112,11 @@ StudioApp.prototype.runChangeHandlers = function (e) {
 StudioApp.prototype.setupChangeHandlers = function () {
   const runAllHandlers = this.runChangeHandlers.bind(this);
   if (this.isUsingBlockly()) {
-    Blockly.addChangeListener(Blockly.mainBlockSpace, runAllHandlers);
+    Blockly.mainBlockSpace.addChangeListener(runAllHandlers);
     if (Blockly.getHiddenDefinitionWorkspace()) {
       // If we have a hidden definition workspace, run change listeners on it too.
       // This ensures code changes in the hidden workspace trigger updates.
-      Blockly.addChangeListener(
-        Blockly.getHiddenDefinitionWorkspace(),
-        runAllHandlers
-      );
+      Blockly.getHiddenDefinitionWorkspace().addChangeListener(runAllHandlers);
     }
   } else {
     this.editor.on('change', runAllHandlers);
@@ -1921,10 +1916,6 @@ StudioApp.prototype.resetButtonClick = function () {
   this.toggleRunReset('run');
   this.clearHighlighting();
   getStore().dispatch(setFeedback(null));
-  if (this.isUsingBlockly()) {
-    Blockly.mainBlockSpaceEditor.setEnableToolbox(true);
-    Blockly.mainBlockSpace.traceOn(false);
-  }
   this.reset(false);
 };
 
@@ -2193,21 +2184,15 @@ StudioApp.prototype.configureDom = function (config) {
       eventName = EVENTS.LEVEL_ACTIVITY;
     }
     if (!runButtonWasClicked) {
-      // For publicly cached pages, config.isSignedIn will be false even when signed in.
-      // Check the Redux store for the actual sign-in state.
-      const state = getStore().getState();
-      const signedIn = state.currentUser?.signInState === 'SignedIn' || false;
       analyticsReporter.sendEvent(
         eventName,
         {
-          signedIn: signedIn,
+          signedIn: config.isSignedIn,
           unitName: config.scriptName,
           levelId: config.serverLevelId,
           levelName: config.level.name,
-          appName: config.app,
-          levelPath: window.location.pathname,
         },
-        PLATFORMS.STATSIG
+        PLATFORMS.BOTH
       );
       runButtonWasClicked = true;
     }
@@ -2881,7 +2866,7 @@ StudioApp.prototype.setStartBlocks_ = function (config, loadLastAttempt) {
   } catch (e) {
     if (loadLastAttempt) {
       try {
-        Blockly.clearAllStudentWorkspaces();
+        BlocklyUtils.clearAllStudentWorkspaces();
         // Try loading the default start blocks instead.
         this.setStartBlocks_(config, false);
       } catch (otherException) {
@@ -3027,7 +3012,12 @@ StudioApp.prototype.handleUsingBlockly_ = function (config) {
   // https://openradar.appspot.com/31725316
   // Resize the Blockly workspace after 500ms when clientWidth/Height
   // should be correct.
-  window.setTimeout(() => Blockly.fireUiEvent(window, 'resize'), 500);
+  window.setTimeout(() => {
+    const workspace = BlocklyCore.getMainWorkspace();
+    if (workspace) {
+      BlocklyCore.svgResize(workspace);
+    }
+  }, 500);
 };
 
 /**
@@ -3248,9 +3238,9 @@ StudioApp.prototype.hasDuplicateVariablesInForLoops = function () {
   if (this.editCode) {
     return false;
   }
-  return Blockly.mainBlockSpace
-    .getAllUsedBlocks()
-    .some(this.forLoopHasDuplicatedNestedVariables_);
+  return BlocklyUtils.getAllUsedBlocks(Blockly.getMainWorkspace()).some(
+    this.forLoopHasDuplicatedNestedVariables_
+  );
 };
 
 /**
@@ -3454,13 +3444,17 @@ if (IN_UNIT_TEST) {
     instance.removeAllListeners();
     instance.libraries = {};
     if (instance.changeListener) {
-      Blockly.removeChangeListener(instance.changeListener);
+      Blockly.getMainWorkspace().removeChangeListener(instance.changeListener);
     }
     if (instance.hiddenWorkspaceChangeListener) {
-      Blockly.removeChangeListener(instance.hiddenWorkspaceChangeListener);
+      Blockly.getHiddenDefinitionWorkspace().removeChangeListener(
+        instance.hiddenWorkspaceChangeListener
+      );
     }
     if (instance.mainWorkspaceChangeListener) {
-      Blockly.removeChangeListener(instance.mainWorkspaceChangeListener);
+      Blockly.getMainWorkspace().removeChangeListener(
+        instance.mainWorkspaceChangeListener
+      );
     }
     instance = __oldInstance;
     __oldInstance = null;

--- a/apps/src/appMain.js
+++ b/apps/src/appMain.js
@@ -113,7 +113,6 @@ export default function (app, levels, options) {
         }
       }
     }
-    Blockly.setInfiniteLoopTrap();
   }
 
   function onReady() {

--- a/apps/src/applab/applab.js
+++ b/apps/src/applab/applab.js
@@ -1119,9 +1119,6 @@ Applab.serializeAndSave = function (callback) {
 Applab.runButtonClick = function () {
   Sounds.getSingleton().unmuteURLs();
   studioApp().toggleRunReset('reset');
-  if (studioApp().isUsingBlockly()) {
-    Blockly.mainBlockSpace.traceOn(true);
-  }
   Applab.execute();
   const analyticsData = studioApp().analyticsData();
   // We don't want to log a User Level Interaction if we don't have a scriptId, which is the case

--- a/apps/src/block_utils.js
+++ b/apps/src/block_utils.js
@@ -1,3 +1,4 @@
+import * as BlocklyCore from 'blockly/core';
 import _ from 'lodash';
 
 import {
@@ -553,12 +554,8 @@ const STANDARD_INPUT_TYPES = {
     addInputRow(blockly, block, inputConfig) {
       const inputRow = block
         .appendValueInput(inputConfig.name)
-        .setAlign(blockly.ALIGN_RIGHT);
-      if (inputConfig.strict) {
-        inputRow.setStrictCheck(inputConfig.type);
-      } else {
-        inputRow.setCheck(inputConfig.type);
-      }
+        .setAlign(BlocklyCore.inputs.Align.RIGHT);
+      inputRow.setCheck(inputConfig.type);
       return inputRow;
     },
     generateCode(block, inputConfig) {
@@ -935,10 +932,12 @@ exports.createJsWrapperBlockCreator = function (
       init: function () {
         this.setStyle(style || BlockStyles.DEFAULT);
 
+        const check =
+          returnType === Blockly.BlockValueType.NONE ? null : returnType;
         if (returnType) {
           this.setOutput(
             true,
-            returnType,
+            check,
             strictOutput || strictTypes.includes(returnType)
           );
         } else if (eventLoopBlock) {

--- a/apps/src/blockly/addons/cdoAngleHelperOptions.ts
+++ b/apps/src/blockly/addons/cdoAngleHelperOptions.ts
@@ -1,0 +1,25 @@
+import * as BlocklyCore from 'blockly/core';
+
+import {AngleHelperOptions} from '../types';
+
+const KEY = 'angleHelperOptions' as const;
+
+export type AngleHelperConnection = BlocklyCore.Connection & {
+  [KEY]?: AngleHelperOptions;
+};
+
+export function setAngleHelperOptions(
+  connection: BlocklyCore.Connection | null,
+  options: AngleHelperOptions
+): void {
+  if (!connection) return;
+  (connection as AngleHelperConnection)[KEY] = options;
+}
+
+export function getAngleHelperOptions(
+  connection: BlocklyCore.Connection | null
+): AngleHelperOptions | undefined {
+  if (!connection) return undefined;
+  console.log('Getting angle helper options for connection', connection);
+  return (connection as AngleHelperConnection)[KEY];
+}

--- a/apps/src/blockly/addons/cdoFieldAngleTextInput.ts
+++ b/apps/src/blockly/addons/cdoFieldAngleTextInput.ts
@@ -1,5 +1,5 @@
 import {CLOCKWISE_TURN_DIRECTION} from '../constants';
-import {FieldHelperOptions} from '../types';
+import {AngleHelperOptions} from '../types';
 
 import CdoFieldNumber from './cdoFieldNumber';
 
@@ -41,13 +41,11 @@ export default class CdoFieldAngleTextInput extends CdoFieldNumber {
     return direction || CLOCKWISE_TURN_DIRECTION;
   }
 
-  getFieldHelperOptions(field_helper: string) {
-    if (field_helper === Blockly.BlockFieldHelper.ANGLE_HELPER) {
-      return {
-        direction: this.direction,
-        directionTitle: this.directionFieldName,
-        block: this.getSourceBlock(),
-      } as FieldHelperOptions;
-    }
+  getAngleHelperOptions() {
+    return {
+      direction: this.direction,
+      directionTitle: this.directionFieldName,
+      block: this.getSourceBlock(),
+    } as AngleHelperOptions;
   }
 }

--- a/apps/src/blockly/addons/cdoFieldNumber.ts
+++ b/apps/src/blockly/addons/cdoFieldNumber.ts
@@ -1,13 +1,10 @@
 import * as BlocklyCore from 'blockly/core';
 
 import {EMPTY_OPTION} from '../constants';
-import {
-  ExtendedBlockSvg,
-  ExtendedConnection,
-  FieldHelperOptions,
-} from '../types';
+import {ExtendedBlockSvg, AngleHelperOptions} from '../types';
 
 import CdoAngleHelper from './cdoAngleHelper';
+import {AngleHelperConnection} from './cdoAngleHelperOptions';
 
 export default class CdoFieldNumber extends BlocklyCore.FieldNumber {
   private config: string | null | undefined;
@@ -48,28 +45,25 @@ export default class CdoFieldNumber extends BlocklyCore.FieldNumber {
 
   /**
    * If this field is attached to a block whose output connection is attached to a
-   * connection that has the specified field helper, get the options for that
-   * field helper.
+   * connection that has an angle helper, get the options for it.
    * For example, with a math_number block containing this field, we will look at
-   * the input connection of parent block. A draw_turn block will have field helper
+   * the input connection of parent block. A draw_turn block will have angle helper
    * options whereas other blocks, like draw_move, will not. These options are found
    * on the connection of the parent block's input.
-   * @param {string} fieldHelper - the field helper to retrieve. One of
-   *        Blockly.BlockFieldHelper
    * @return {Object|undefined} the options object if it exists
    */
-  getFieldHelperOptions(fieldHelper: string) {
+  getAngleHelperOptions() {
     return (this.sourceBlock_ &&
       this.sourceBlock_.outputConnection &&
       this.sourceBlock_.outputConnection.targetConnection &&
       (
         this.sourceBlock_.outputConnection
-          .targetConnection as ExtendedConnection
-      ).getFieldHelperOptions(fieldHelper)) as FieldHelperOptions | undefined;
+          .targetConnection as AngleHelperConnection
+      ).angleHelperOptions) as AngleHelperOptions | undefined;
   }
 
   shouldShowAngleHelper() {
-    return this.getFieldHelperOptions(Blockly.BlockFieldHelper.ANGLE_HELPER);
+    return this.getAngleHelperOptions();
   }
 
   protected showEditor_(e?: Event, quietInput?: boolean): void {
@@ -105,9 +99,7 @@ export default class CdoFieldNumber extends BlocklyCore.FieldNumber {
    */
   getAnglePickerDirection(): string {
     const defaultDirection = 'turnRight';
-    const options = this.getFieldHelperOptions(
-      Blockly.BlockFieldHelper.ANGLE_HELPER
-    );
+    const options = this.getAngleHelperOptions();
 
     if (!options) {
       return defaultDirection;

--- a/apps/src/blockly/addons/extensions/jigsawFillPatternMixin.ts
+++ b/apps/src/blockly/addons/extensions/jigsawFillPatternMixin.ts
@@ -1,0 +1,24 @@
+import * as BlocklyCore from 'blockly/core';
+
+type FillPatternBlock = BlocklyCore.Block & {
+  fillPattern?: string;
+  setFillPattern(pattern: string): void;
+  getFillPattern(): string | undefined;
+};
+
+const JIGSAW_FILL_PATTERN_MIXIN = {
+  setFillPattern(this: FillPatternBlock, pattern: string) {
+    console.log('Setting fill pattern to ' + pattern);
+    this.fillPattern = pattern;
+  },
+
+  getFillPattern(this: FillPatternBlock) {
+    console.log('Getting fill pattern: ' + this.fillPattern);
+    return this.fillPattern;
+  },
+};
+
+Blockly.Extensions.registerMixin(
+  'jigsaw_fill_pattern_mixin',
+  JIGSAW_FILL_PATTERN_MIXIN
+);

--- a/apps/src/blockly/addons/extensions/logic_compare.ts
+++ b/apps/src/blockly/addons/extensions/logic_compare.ts
@@ -25,7 +25,7 @@ const LOGIC_COMPARE_ONCHANGE_MIXIN = {
  */
 const LOGIC_COMPARE_EXTENSION = function (this: CompareBlock) {
   // Add onchange handler to ensure types are compatible.
-  this.mixin(LOGIC_COMPARE_ONCHANGE_MIXIN);
+  this.mixin(LOGIC_COMPARE_ONCHANGE_MIXIN, true);
 };
 export default function registerMutator() {
   if (BlocklyCore.Extensions.isRegistered('logic_compare')) {

--- a/apps/src/blockly/blocklyWrapper.ts
+++ b/apps/src/blockly/blocklyWrapper.ts
@@ -12,7 +12,6 @@ import * as BlocklyCore from 'blockly/core';
 import {javascriptGenerator} from 'blockly/javascript';
 
 import {
-  BlockColors,
   READ_ONLY_PROPERTIES,
   SETTABLE_PROPERTIES,
   WORKSPACE_EVENTS,
@@ -83,6 +82,7 @@ import {
   adjustCalloutsOnViewportChange,
   bumpRTLBlocks,
   disableOrphans,
+  handleGrayUndeletableBlocks,
   reflowToolbox,
   setPathFill,
   storeWorkspaceWidth,
@@ -105,25 +105,16 @@ import CdoJigsawTheme from './themes/cdoJigsaw';
 import CdoTheme from './themes/cdoTheme';
 import {
   BlocklyWrapperType,
-  ExtendedBlock,
-  ExtendedBlockSvg,
   ExtendedBlocklyOptions,
-  ExtendedConnection,
-  ExtendedInput,
   ExtendedJavascriptGenerator,
-  ExtendedVariableMap,
   ExtendedWorkspace,
   ExtendedWorkspaceSvg,
-  FieldHelperOptions,
   BlocklyCoreInstance,
 } from './types';
 import {
-  INFINITE_LOOP_TRAP,
-  LOOP_HIGHLIGHT,
   handleCodeGenerationFailure,
   strip,
   initializeVariableLocalization,
-  interpolateMsg,
   isDarkTheme,
   setThemeAndRenderBlocks,
   getUserTheme,
@@ -213,28 +204,6 @@ function initializeBlocklyWrapper(blocklyInstance: BlocklyCoreInstance) {
   const blocklyWrapper = new (BlocklyWrapper as any)(
     blocklyInstance
   ) as BlocklyWrapperType;
-
-  blocklyWrapper.setInfiniteLoopTrap = function () {
-    Blockly.JavaScript.INFINITE_LOOP_TRAP = INFINITE_LOOP_TRAP;
-  };
-
-  blocklyWrapper.clearInfiniteLoopTrap = function () {
-    Blockly.JavaScript.INFINITE_LOOP_TRAP = '';
-  };
-
-  blocklyWrapper.getInfiniteLoopTrap = function () {
-    return Blockly.JavaScript.INFINITE_LOOP_TRAP;
-  };
-
-  blocklyWrapper.loopHighlight = function (apiName, blockId) {
-    let args = "'block_id_" + blockId + "'";
-    if (blockId === undefined) {
-      args = '%1';
-    }
-    return (
-      '  ' + apiName + '.' + LOOP_HIGHLIGHT.replace('()', '(' + args + ')')
-    );
-  };
 
   blocklyWrapper.getWorkspaceCode = function () {
     return getWorkspaceCodeHelper(0, this.getHiddenDefinitionWorkspace());
@@ -394,11 +363,6 @@ function initializeBlocklyWrapper(blocklyInstance: BlocklyCoreInstance) {
       return this.mainWorkspace || this.blockly_.getMainWorkspace();
     },
   });
-  Object.defineProperty(blocklyWrapper, 'SVG_NS', {
-    get: function () {
-      return this.blockly_.utils.dom.SVG_NS;
-    },
-  });
   Object.defineProperty(blocklyWrapper, 'selected', {
     get: function () {
       // In the event that the block is no longer focused, we can
@@ -417,22 +381,11 @@ function initializeBlocklyWrapper(blocklyInstance: BlocklyCoreInstance) {
       return Blockly.getSelected();
     },
   });
-  Object.defineProperty(blocklyWrapper, 'BlockFieldHelper', {
-    get: function () {
-      return {
-        ANGLE_HELPER: 'Angle Helper',
-      };
-    },
-  });
 
   // Properties cannot be modified until wrapSettableProperty has been called
   SETTABLE_PROPERTIES.forEach(property =>
     blocklyWrapper.wrapSettableProperty(property)
   );
-
-  blocklyWrapper.ALIGN_CENTRE = blocklyWrapper.inputs.Align.CENTRE;
-  blocklyWrapper.ALIGN_LEFT = blocklyWrapper.inputs.Align.LEFT;
-  blocklyWrapper.ALIGN_RIGHT = blocklyWrapper.inputs.Align.RIGHT;
 
   // Allows for dynamically setting the workspace theme with workspace.setTheme()
   blocklyWrapper.themes = {
@@ -455,188 +408,8 @@ function initializeBlocklyWrapper(blocklyInstance: BlocklyCoreInstance) {
 
   blocklyWrapper.JavaScript = javascriptGenerator;
 
-  // Wrap SNAP_RADIUS property, and in the setter make sure we keep SNAP_RADIUS and CONNECTING_SNAP_RADIUS in sync.
-  // See https://github.com/google/blockly/issues/2217
-  Object.defineProperty(blocklyWrapper, 'SNAP_RADIUS', {
-    get: function () {
-      return this.blockly_.SNAP_RADIUS;
-    },
-    set: function (snapRadius) {
-      this.blockly_.SNAP_RADIUS = snapRadius;
-      this.blockly_.CONNECTING_SNAP_RADIUS = snapRadius;
-    },
-  });
-
-  blocklyWrapper.addChangeListener = function (blockspace, handler) {
-    blockspace.addChangeListener(handler);
-  };
-
-  blocklyWrapper.removeChangeListener = function (
-    handler,
-    blockspace = Blockly.getMainWorkspace()
-  ) {
-    blockspace.removeChangeListener(handler);
-  };
-
-  const googleBlocklyMixin = blocklyWrapper.BlockSvg.prototype.mixin;
-  blocklyWrapper.BlockSvg.prototype.mixin = function (mixinObj) {
-    googleBlocklyMixin.call(this, mixinObj, true);
-  };
-
-  const extendedBlockSvg = blocklyWrapper.BlockSvg
-    .prototype as ExtendedBlockSvg;
-
-  extendedBlockSvg.isUserVisible = function () {
-    // Used for EXTRA_TOP_BLOCKS_FAIL feedback
-    // Mainline Blockly doesn't support invisible blocks. If a block should be
-    // invisible, we instead load it to the hidden workspace. We use custom
-    // serialization hooks to manage this block state.
-    // Any block on the main workspace is visible.
-    return this.workspace === Blockly.getMainWorkspace();
-  };
-
-  // Labs like Maze and Artist turn undeletable blocks gray.
-  extendedBlockSvg.shouldBeGrayedOut = function () {
-    return (
-      blocklyWrapper.grayOutUndeletableBlocks &&
-      !this.workspace.isReadOnly() &&
-      !this.isDeletable()
-    );
-  };
-
-  const originalSetDeletable = blocklyWrapper.Block.prototype.setDeletable;
-  // Replace the original setDeletable with a version that will also re-color
-  // blocks if they are meant to be gray.
-  extendedBlockSvg.setDeletable = function (deletable) {
-    originalSetDeletable.call(this, deletable);
-    if (this.shouldBeGrayedOut()) {
-      const [h, s, v] = BlockColors.DISABLED;
-      this.setColour(Blockly.utils.colour.hsvToHex(h, s, v * 255));
-    }
-  };
-
-  const originalSetInputsInline =
-    blocklyWrapper.Block.prototype.setInputsInline;
-  // Replace the original setInputsInline with a version that forces a
-  // two-row Play Lab block to always use inline inputs..
-  extendedBlockSvg.setInputsInline = function (inline) {
-    originalSetInputsInline.call(this, inline);
-    if (
-      this.type === 'studio_whenSpriteAndGroupCollide' &&
-      !this.getInputsInline()
-    ) {
-      this.setInputsInline(true);
-    }
-  };
-
-  const originalToCopyData = blocklyWrapper.BlockSvg.prototype.toCopyData;
-  extendedBlockSvg.toCopyData = function () {
-    const blockCopyData = originalToCopyData.call(this);
-    if (blockCopyData) {
-      blockCopyData.blockState = BlocklyCore.serialization.blocks.save(this, {
-        addCoordinates: true,
-        addNextBlocks: false,
-        // We intentionally do not save IDs, because this can break student code
-        // on the hidden procedure definition workspace.
-        // https://github.com/google/blockly/issues/9226
-        saveIds: false,
-      })!;
-    }
-    return blockCopyData;
-  };
-
-  const extendedInput = blocklyWrapper.Input.prototype as ExtendedInput;
-  const extendedConnection = blocklyWrapper.Connection
-    .prototype as ExtendedConnection;
-
-  extendedInput.setStrictCheck = function (check) {
-    return this.setCheck(check);
-  };
-
-  // We use fieldRow because it is public.
-  extendedInput.getFieldRow = function () {
-    return this.fieldRow;
-  };
-
-  /**
-   * Enable the specified field helper with the specified options for this
-   * input's connection
-   * @param {string} fieldHelper the field helper to retrieve. One of
-   *        Blockly.BlockFieldHelper
-   * @param {*} options for this helper
-   * @return {!Blockly.Input} The input being modified (to allow chaining).
-   */
-  extendedInput.addFieldHelper = function (
-    fieldHelper: string,
-    options: FieldHelperOptions
-  ) {
-    (this.connection as ExtendedConnection).addFieldHelper(
-      fieldHelper,
-      options
-    );
-    return this;
-  };
-
-  extendedConnection.addFieldHelper = function (
-    fieldHelper: string,
-    options: FieldHelperOptions
-  ) {
-    if (!this.fieldHelpers_) {
-      this.fieldHelpers_ = {};
-    }
-    this.fieldHelpers_[fieldHelper] = options;
-  };
-  extendedConnection.getFieldHelperOptions = function (fieldHelper: string) {
-    return this.fieldHelpers_ && this.fieldHelpers_[fieldHelper];
-  };
-  const extendedBlock = blocklyWrapper.Block.prototype as ExtendedBlock;
-
-  extendedBlock.interpolateMsg = interpolateMsg;
-  extendedBlock.setStrictOutput = function (isOutput, check) {
-    return this.setOutput(isOutput, check);
-  };
-
-  const originalSetOutput = blocklyWrapper.Block.prototype.setOutput;
-  // Replaces the original setOutput method with a custom version that will handle the case when "None" is passed appropriately
-  // See: https://github.com/code-dot-org/code-dot-org/blob/9d63cbcbfd84b8179ae2519adbb5869cbc319643/apps/src/blocklyAddons/cdoConstants.js#L9
-  extendedBlock.setOutput = function (isOutput, check) {
-    if (check === 'None') {
-      return originalSetOutput.call(this, isOutput, null);
-    } else {
-      return originalSetOutput.call(this, isOutput, check);
-    }
-  };
-
-  // Block fields are referred to as titles in CDO Blockly.
-  extendedBlock.setTitleValue = function (newValue, name) {
-    return this.setFieldValue(newValue, name);
-  };
-  /**
-   * Change the fill pattern of a block
-   * @param {string} pattern The id of the pattern
-   */
-  extendedBlock.setFillPattern = function (pattern: string) {
-    this.fillPattern = pattern;
-  };
-
-  /**
-   * Get the fill pattern for the block
-   * @return {string} Pattern name xlink
-   */
-  extendedBlock.getFillPattern = function () {
-    return this.fillPattern;
-  };
   const extendedWorkspaceSvg = blocklyWrapper.WorkspaceSvg
     .prototype as ExtendedWorkspaceSvg;
-
-  // Called by StudioApp, but only implemented for CDO Blockly.
-  extendedWorkspaceSvg.addUnusedBlocksHelpListener = function () {};
-
-  extendedWorkspaceSvg.getAllUsedBlocks = function () {
-    return this.getAllBlocks().filter(
-      block => block.isEnabled() && block.getRootBlock().isEnabled()
-    );
-  };
 
   // Used in levels when starting over or resetting Version History
   const googleBlocklyBlocklyClear = blocklyWrapper.WorkspaceSvg.prototype.clear;
@@ -645,37 +418,20 @@ function initializeBlocklyWrapper(blocklyInstance: BlocklyCoreInstance) {
     // After clearing the workspace, we need to reinitialize global variables
     // if there are any.
     if (this.globalVariables) {
-      this.getVariableMap().addVariables(this.globalVariables);
+      const variableMap = this.getVariableMap();
+      this.globalVariables.forEach(varName => {
+        variableMap.createVariable(varName);
+      });
     }
   };
 
   // Used in levels with pre-defined "Blockly Variables"
   extendedWorkspaceSvg.registerGlobalVariables = function (variableList) {
     this.globalVariables = variableList;
-    this.getVariableMap().addVariables(variableList);
-  };
-
-  extendedWorkspaceSvg.getContainer = function () {
-    return this.svgGroup_.parentNode;
-  };
-
-  extendedWorkspaceSvg.events = {
-    dispatchEvent: () => {}, // TODO
-  };
-
-  // TODO - called by StudioApp, not sure whether they're still needed.
-  extendedWorkspaceSvg.setEnableToolbox = function () {};
-  extendedWorkspaceSvg.traceOn = function () {};
-
-  extendedWorkspaceSvg.getBlockCount = function () {
-    return this.getAllBlocks().length;
-  };
-
-  const extendedVariableMap = blocklyWrapper.VariableMap
-    .prototype as ExtendedVariableMap;
-
-  extendedVariableMap.addVariables = function (variableList) {
-    variableList.forEach(varName => this.createVariable(varName));
+    const variableMap = this.getVariableMap();
+    variableList.forEach(varName => {
+      variableMap.createVariable(varName);
+    });
   };
 
   gestureOverrides(blocklyWrapper);
@@ -903,14 +659,16 @@ function initializeBlocklyWrapper(blocklyInstance: BlocklyCoreInstance) {
         options.theme as BlocklyCore.Theme
       );
     });
-    workspace.defs = Blockly.createSvgElement(
+    workspace.defs = BlocklyCore.utils.dom.createSvgElement(
       'defs',
       {id: 'blocklySvgDefs'},
       workspace.svgGroup_
     );
 
-    blocklyWrapper.grayOutUndeletableBlocks =
-      !!options.grayOutUndeletableBlocks;
+    if (!!options.grayOutUndeletableBlocks) {
+      workspace.addChangeListener(handleGrayUndeletableBlocks);
+    }
+
     blocklyWrapper.topLevelProcedureAutopopulate =
       !!options.topLevelProcedureAutopopulate;
     blocklyWrapper.showBlockHelp = !!optOptionsExtended.showBlockHelp;
@@ -1062,13 +820,6 @@ function initializeBlocklyWrapper(blocklyInstance: BlocklyCoreInstance) {
     return workspace;
   };
 
-  // Used by StudioApp to tell Blockly to resize for Mobile Safari.
-  blocklyWrapper.fireUiEvent = function (element, eventName) {
-    if (eventName === 'resize') {
-      blocklyWrapper.svgResize(blocklyWrapper.mainBlockSpace);
-    }
-  };
-
   blocklyWrapper.setMainWorkspace = function (mainWorkspace) {
     this.mainWorkspace = mainWorkspace;
   };
@@ -1089,29 +840,6 @@ function initializeBlocklyWrapper(blocklyInstance: BlocklyCoreInstance) {
 
   blocklyWrapper.getFunctionEditorWorkspace = function () {
     return blocklyWrapper.functionEditor?.getWorkspace();
-  };
-
-  blocklyWrapper.createSvgElement = blocklyWrapper.utils.dom.createSvgElement;
-
-  // Blockly labs also need to clear separate workspaces for the function editor.
-  blocklyWrapper.clearAllStudentWorkspaces = function () {
-    // Disable Blockly events to prevent unnecessary event mirroring
-    Blockly.Events.disable();
-
-    const studentWorkspaces = [
-      Blockly.getMainWorkspace(),
-      Blockly.getFunctionEditorWorkspace(),
-      Blockly.getHiddenDefinitionWorkspace(),
-    ];
-
-    studentWorkspaces.forEach(workspace => {
-      if (workspace) {
-        workspace.clear();
-        workspace.getProcedureMap().clear();
-      }
-    });
-
-    Blockly.Events.enable();
   };
 
   // Initialize metadata houses for original English source strings for

--- a/apps/src/blockly/constants.ts
+++ b/apps/src/blockly/constants.ts
@@ -264,6 +264,7 @@ export const SETTABLE_PROPERTIES = [
   'JavaScript',
   'readOnly',
   'showUnusedBlocks',
+  'SNAP_RADIUS',
   'Trashcan',
   'typeHints',
   'valueTypeTabShapeMap',

--- a/apps/src/blockly/customBlocks/behaviorBlocks.ts
+++ b/apps/src/blockly/customBlocks/behaviorBlocks.ts
@@ -66,7 +66,6 @@ export const blocks = BlocklyCore.common.createBlockDefinitionsFromJsonArray([
       'procedure_def_validator_helper',
       'procedure_defnoreturn_get_caller_block_mixin',
       'procedure_def_set_no_return_helper',
-      'procedure_def_no_gray_out',
       'behaviors_block_frame',
       'procedure_def_mini_toolbox',
       'modal_procedures_no_destroy',

--- a/apps/src/blockly/customBlocks/proceduresBlocks.ts
+++ b/apps/src/blockly/customBlocks/proceduresBlocks.ts
@@ -71,7 +71,6 @@ export const blocks = BlocklyCore.common.createBlockDefinitionsFromJsonArray([
       'procedures_block_frame',
       'procedure_def_mini_toolbox',
       'modal_procedures_no_destroy',
-      'procedure_def_no_gray_out',
       'procedure_def_get_info',
     ],
     mutator: 'procedure_def_mutator',
@@ -341,14 +340,6 @@ BlocklyCore.Extensions.registerMixin(
   'procedure_caller_onchange_mixin',
   procedureCallerOnChangeMixin
 );
-
-// Labs like Maze and Artist turn undeletable blocks gray. This is not
-// done for special blocks like "when run" or procedure definitions.
-BlocklyCore.Extensions.registerMixin('procedure_def_no_gray_out', {
-  shouldBeGrayedOut: function () {
-    return false;
-  },
-});
 
 // Used for giving feedback about empty function definition blocks.
 BlocklyCore.Extensions.registerMixin('procedure_def_get_info', {

--- a/apps/src/blockly/eventHandlers.ts
+++ b/apps/src/blockly/eventHandlers.ts
@@ -6,7 +6,7 @@ import {handleWorkspaceResizeOrScroll} from '@cdo/apps/code-studio/callouts';
 import color from '@cdo/apps/util/color';
 
 import BlockSvgLimitIndicator from './addons/blockSvgLimitIndicator';
-import {BLOCK_TYPES} from './constants';
+import {BLOCK_TYPES, BlockColors} from './constants';
 import {
   ExtendedBlock,
   ExtendedBlockSvg,
@@ -138,10 +138,10 @@ export function setPathFill(e: BlocklyCore.Events.Abstract) {
       .getAllBlocks()
       .map(block => block as ExtendedBlock)
       .forEach(block => {
-        const pattern = block.getFillPattern();
+        const pattern = block.getFillPattern?.();
         if (block instanceof BlocklyCore.BlockSvg) {
           if (!block.svgPathFill) {
-            block.svgPathFill = Blockly.createSvgElement(
+            block.svgPathFill = BlocklyCore.utils.dom.createSvgElement(
               'path',
               {class: 'blocklyPath'},
               block.getSvgRoot()
@@ -256,4 +256,39 @@ export function updateBlockCountMap(workspace: ExtendedWorkspaceSvg) {
       );
     }
   });
+}
+
+export function handleGrayUndeletableBlocks(
+  event: BlocklyCore.Events.Abstract
+) {
+  const expectedEventTypes: string[] = [
+    Blockly.Events.BLOCK_CREATE,
+    Blockly.Events.FINISHED_LOADING,
+    Blockly.Events.SELECTED,
+  ];
+
+  // Common top blocks that we do not want to gray out.
+  const unexpectedBlockTypes: string[] = [
+    BLOCK_TYPES.whenRun,
+    BLOCK_TYPES.procedureDefinition,
+  ];
+
+  if (expectedEventTypes.includes(event.type) && event.workspaceId) {
+    const workspace = Blockly.Workspace.getById(
+      `${event.workspaceId}`
+    ) as ExtendedWorkspaceSvg;
+    if (workspace && !workspace.isReadOnly()) {
+      workspace
+        .getAllBlocks()
+        .filter(
+          block =>
+            block.isDeletable() === false &&
+            !unexpectedBlockTypes.includes(block.type)
+        )
+        .forEach(block => {
+          const [h, s, v] = BlockColors.DISABLED;
+          block.setColour(Blockly.utils.colour.hsvToHex(h, s, v * 255));
+        });
+    }
+  }
 }

--- a/apps/src/blockly/types.ts
+++ b/apps/src/blockly/types.ts
@@ -91,19 +91,13 @@ export interface BlocklyWrapperType extends BlocklyCoreType {
   isDarkTheme: boolean | undefined;
   varsInGlobals: boolean;
   disableVariableEditing: boolean;
-  ALIGN_CENTRE: BlocklyCore.inputs.Align.CENTRE;
-  ALIGN_LEFT: BlocklyCore.inputs.Align.LEFT;
-  ALIGN_RIGHT: BlocklyCore.inputs.Align.RIGHT;
   inputTypes: typeof BlocklyCore.inputs.inputTypes;
-  createSvgElement: typeof BlocklyCore.utils.dom.createSvgElement;
   analyticsData: AnalyticsData;
   showUnusedBlocks: boolean | undefined;
-  BlockFieldHelper: {[fieldHelper: string]: string};
   enableParamEditing: boolean;
   selected: BlocklyCore.BlockSvg;
   blockCountMap: Map<string, number> | undefined;
   blockLimitMap: Map<string, number> | undefined;
-  grayOutUndeletableBlocks: boolean;
   topLevelProcedureAutopopulate: boolean;
   isJigsaw: boolean;
   blockly_: typeof BlocklyCore;
@@ -157,19 +151,7 @@ export interface BlocklyWrapperType extends BlocklyCoreType {
   overrideFields: (
     overrides: [string, string, BlocklyCore.fieldRegistry.RegistrableField][]
   ) => void;
-  setInfiniteLoopTrap: () => void;
-  clearInfiniteLoopTrap: () => void;
-  getInfiniteLoopTrap: () => string | null;
-  loopHighlight: (apiName: string, blockId: string) => string;
   getWorkspaceCode: () => string;
-  addChangeListener: (
-    blockspace: BlocklyCore.Workspace,
-    handler: (e: BlocklyCore.Events.Abstract) => void
-  ) => void;
-  removeChangeListener: (
-    handler: (e: BlocklyCore.Events.Abstract) => void,
-    blockspace: BlocklyCore.Workspace
-  ) => void;
   getGenerator: () => ExtendedJavascriptGenerator;
   addEmbeddedWorkspace: (workspace: BlocklyCore.Workspace) => void;
   isEmbeddedWorkspace: (workspace: BlocklyCore.Workspace) => boolean;
@@ -187,7 +169,6 @@ export interface BlocklyWrapperType extends BlocklyCoreType {
   getHiddenDefinitionWorkspace: () => ExtendedWorkspace;
   fireUiEvent: (element: Element, eventName: string) => void;
   getFunctionEditorWorkspace: () => ExtendedWorkspaceSvg | undefined;
-  clearAllStudentWorkspaces: () => void;
   getPointerBlockImageUrl: (
     block: ExtendedBlockSvg,
     pointerMetadataMap: PointerMetadataMap,
@@ -231,7 +212,6 @@ export type BlocklyCoreInstance = typeof BlocklyCore;
 
 export interface ExtendedBlockSvg extends BlocklyCore.BlockSvg {
   canSerializeNextConnection?: boolean;
-  isUserVisible: () => boolean;
   shouldBeGrayedOut: () => boolean;
   // imageSourceId, shortString, longString and thumbnailSize are used for sprite pointer blocks
   imageSourceId?: string;
@@ -244,44 +224,15 @@ export interface ExtendedBlockSvg extends BlocklyCore.BlockSvg {
   workspace: ExtendedWorkspaceSvg;
 }
 
-export interface FieldHelperOptions {
+export interface AngleHelperOptions {
   block: BlocklyCore.Block;
   directionTitle?: string; // Ex. 'DIR'
   direction?: string; // Ex. 'turnRight'
 }
-
-export interface FieldHelpers {
-  [fieldHelper: string]: FieldHelperOptions;
-}
-export interface ExtendedInput extends BlocklyCore.Input {
-  addFieldHelper: (
-    fieldHelper: string,
-    options: FieldHelperOptions
-  ) => ExtendedInput;
-  setStrictCheck: (check: string | string[] | null) => BlocklyCore.Input;
-  // Blockly explicitly uses any for this type
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  getFieldRow: () => BlocklyCore.Field<any>[];
-}
-export interface ExtendedConnection extends BlocklyCore.Connection {
-  getFieldHelperOptions: (fieldHelper: string) => FieldHelperOptions;
-  fieldHelpers_: FieldHelpers;
-  addFieldHelper(fieldHelper: string, options: FieldHelperOptions): unknown;
-}
-
 export interface ExtendedBlock extends BlocklyCore.Block {
-  getFillPattern: () => string | undefined;
+  getFillPattern?: () => string | undefined;
   fillPattern?: string;
-  setFillPattern: (pattern: string) => void;
-  interpolateMsg: (
-    this: ExtendedBlock,
-    msg: string,
-    ...inputArgs: [...([string, string, number] | (() => void))[], number]
-  ) => void;
-  setStrictOutput: (isOutput: boolean, check: string | string[] | null) => void;
-  // Blockly uses any for value.
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  setTitleValue: (newValue: any, name: string) => void;
+  setFillPattern?: (pattern: string) => void;
   skipNextBlockGeneration?: boolean;
   svgPathFill: SVGElement;
 }
@@ -296,24 +247,13 @@ export interface ExtendedWorkspaceSvg extends BlocklyCore.WorkspaceSvg {
   events: {
     dispatchEvent: () => void;
   };
-  addUnusedBlocksHelpListener: () => void;
-  getAllUsedBlocks: () => BlocklyCore.Block[];
   registerGlobalVariables: (variableList: string[]) => void;
-  getVariableMap: () => ExtendedVariableMap;
-  getContainer: () => ParentNode | null;
-  setEnableToolbox: () => void;
-  traceOn: () => void;
   isReadOnly: () => boolean;
   cleanUp: (includeImmovableBlocks?: boolean) => void;
-  getBlockCount: () => number;
 }
 
 export interface EditorWorkspaceSvg extends ExtendedWorkspaceSvg {
   svgFrame_: WorkspaceSvgFrame;
-}
-
-export interface ExtendedVariableMap extends BlocklyCore.VariableMap {
-  addVariables: (variableList: string[]) => void;
 }
 
 export interface ExtendedBlocklyOptions extends BlocklyCore.BlocklyOptions {

--- a/apps/src/blockly/utils/blocks/interpolateMsg.ts
+++ b/apps/src/blockly/utils/blocks/interpolateMsg.ts
@@ -6,6 +6,7 @@ type InputArgs = [...(InputTuple | InputCallback)[], number];
 
 /**
  * Interpolate a message string, creating fields and inputs.
+ * @param {!ExtendedBlock} block The block to append inputs and fields to.
  * @param {string} msg The message string to parse.  %1, %2, etc. are symbols
  *     for value inputs.
  * @param {!Array.<string|number>|number} inputArgs A series of tuples or
@@ -22,7 +23,7 @@ type InputArgs = [...(InputTuple | InputCallback)[], number];
  * https://github.com/code-dot-org/blockly/blob/v4.1.0/core/ui/block.js#L2632-L2692
  */
 export function interpolateMsg(
-  this: ExtendedBlock,
+  block: ExtendedBlock,
   msg: string,
   ...inputArgs: InputArgs
 ): void {
@@ -47,10 +48,11 @@ export function interpolateMsg(
       const inputArg = inputArgs[digit - 1];
 
       if (typeof inputArg === 'function') {
-        this.appendDummyInput().appendField(text);
+        block.appendDummyInput().appendField(text);
         inputArg();
       } else if (Array.isArray(inputArg)) {
-        this.appendValueInput(inputArg[0])
+        block
+          .appendValueInput(inputArg[0])
           .setCheck(inputArg[1])
           .setAlign(inputArg[2])
           .appendField(text);
@@ -58,7 +60,7 @@ export function interpolateMsg(
       usedArgs[digit - 1] = true; // Mark input as used.
     } else if (text) {
       // Trailing dummy input.
-      this.appendDummyInput().setAlign(dummyAlign).appendField(text);
+      block.appendDummyInput().setAlign(dummyAlign).appendField(text);
     }
   }
 
@@ -72,5 +74,5 @@ export function interpolateMsg(
   }
 
   // Make the inputs inline unless there is only one input and no text follows it.
-  this.setInputsInline(!msg.match(/%1\s*$/));
+  block.setInputsInline(!msg.match(/%1\s*$/));
 }

--- a/apps/src/blockly/utils/fields/miniToolbox.ts
+++ b/apps/src/blockly/utils/fields/miniToolbox.ts
@@ -103,7 +103,7 @@ export function appendMiniToolboxToggle(
   // We set the inputs to align left so that if the flyout is larger than the
   // inputs will be aligned with the left edge of the block.
   parentBlock.inputList.forEach(input => {
-    input.setAlign(Blockly.ALIGN_LEFT);
+    input.setAlign(Blockly.inputs.Align.LEFT);
   });
 
   // Insert the toggle field at the beginning for the first input row.

--- a/apps/src/blockly/utils/index.ts
+++ b/apps/src/blockly/utils/index.ts
@@ -23,6 +23,7 @@ export * from './toolbox/metrics';
 export * from './toolbox/retrieval';
 export * from './toolbox/validateBlockCategories';
 export * from './workspace/blocks';
+export * from './workspace/clearAllStudentWorkspaces';
 export * from './workspace/getCode';
 export * from './workspace/disabledBlocks';
 export * from './workspace/layout';

--- a/apps/src/blockly/utils/workspace/blocks.ts
+++ b/apps/src/blockly/utils/workspace/blocks.ts
@@ -1,5 +1,7 @@
 import * as BlocklyCore from 'blockly/core';
 
+import {LOOP_HIGHLIGHT} from '../code/strip';
+
 type BlockList = Array<BlocklyCore.Block | BlocklyCore.BlockSvg>;
 /**
  * Retrieves the top-level Blockly blocks from the students Blockly workspace and
@@ -36,9 +38,23 @@ export function getCodeBlocks(): BlockList {
  */
 export function getAllBlocks(): BlockList {
   return [
-    ...Blockly.mainBlockSpace.getAllUsedBlocks(),
+    ...getAllUsedBlocks(Blockly.getMainWorkspace()),
     ...(Blockly.getHiddenDefinitionWorkspace()
       ? Blockly.getHiddenDefinitionWorkspace().getAllBlocks()
       : []),
   ];
+}
+
+export function loopHighlight(apiName: string, blockId: string) {
+  let args = "'block_id_" + blockId + "'";
+  if (blockId === undefined) {
+    args = '%1';
+  }
+  return '  ' + apiName + '.' + LOOP_HIGHLIGHT.replace('()', '(' + args + ')');
+}
+
+export function getAllUsedBlocks(workspace: BlocklyCore.Workspace) {
+  return workspace
+    .getAllBlocks()
+    .filter(block => block.isEnabled() && block.getRootBlock().isEnabled());
 }

--- a/apps/src/blockly/utils/workspace/clearAllStudentWorkspaces.ts
+++ b/apps/src/blockly/utils/workspace/clearAllStudentWorkspaces.ts
@@ -1,0 +1,20 @@
+// Blockly labs also need to clear separate workspaces for the function editor.
+export function clearAllStudentWorkspaces() {
+  // Disable Blockly events to prevent unnecessary event mirroring
+  Blockly.Events.disable();
+
+  const studentWorkspaces = [
+    Blockly.getMainWorkspace(),
+    Blockly.getFunctionEditorWorkspace(),
+    Blockly.getHiddenDefinitionWorkspace(),
+  ];
+
+  studentWorkspaces.forEach(workspace => {
+    if (workspace) {
+      workspace.clear();
+      workspace.getProcedureMap().clear();
+    }
+  });
+
+  Blockly.Events.enable();
+}

--- a/apps/src/blockly/utils/workspace/resize.ts
+++ b/apps/src/blockly/utils/workspace/resize.ts
@@ -13,7 +13,7 @@ export function shrinkBlockSpaceContainer(
   workspace: ExtendedWorkspaceSvg,
   withPadding: boolean
 ) {
-  const container = workspace.getContainer();
+  const container = workspace.svgGroup_.parentNode;
 
   // Calculate the minimum required size for the container,
   const metrics = workspace.getMetrics();

--- a/apps/src/bounce/bounce.js
+++ b/apps/src/bounce/bounce.js
@@ -188,9 +188,9 @@ var goalNormalize = function (x, y) {
 Bounce.createBallElements = function (i) {
   var svg = document.getElementById('svgBounce');
   // Ball's clipPath element, whose (x, y) is reset by Bounce.displayBall
-  var ballClip = document.createElementNS(Blockly.SVG_NS, 'clipPath');
+  var ballClip = document.createElementNS(Blockly.utils.dom.SVG_NS, 'clipPath');
   ballClip.setAttribute('id', 'ballClipPath' + i);
-  var ballClipRect = document.createElementNS(Blockly.SVG_NS, 'rect');
+  var ballClipRect = document.createElementNS(Blockly.utils.dom.SVG_NS, 'rect');
   ballClipRect.setAttribute('id', 'ballClipRect' + i);
   ballClipRect.setAttribute('width', Bounce.PEGMAN_WIDTH);
   ballClipRect.setAttribute('height', Bounce.PEGMAN_HEIGHT);
@@ -198,7 +198,7 @@ Bounce.createBallElements = function (i) {
   svg.appendChild(ballClip);
 
   // Add ball.
-  var ballIcon = document.createElementNS(Blockly.SVG_NS, 'image');
+  var ballIcon = document.createElementNS(Blockly.utils.dom.SVG_NS, 'image');
   ballIcon.setAttribute('id', 'ball' + i);
   ballIcon.setAttributeNS(
     'http://www.w3.org/1999/xlink',
@@ -237,7 +237,7 @@ var drawMap = function () {
   visualizationColumn.style.width = Bounce.MAZE_WIDTH + 'px';
 
   if (skin.background) {
-    tile = document.createElementNS(Blockly.SVG_NS, 'image');
+    tile = document.createElementNS(Blockly.utils.dom.SVG_NS, 'image');
     tile.setAttributeNS(
       'http://www.w3.org/1999/xlink',
       'xlink:href',
@@ -292,9 +292,15 @@ var drawMap = function () {
       }
       if (tile !== 'null0' && Bounce.drawTiles) {
         // Tile's clipPath element.
-        var tileClip = document.createElementNS(Blockly.SVG_NS, 'clipPath');
+        var tileClip = document.createElementNS(
+          Blockly.utils.dom.SVG_NS,
+          'clipPath'
+        );
         tileClip.setAttribute('id', 'tileClipPath' + tileId);
-        var tileClipRect = document.createElementNS(Blockly.SVG_NS, 'rect');
+        var tileClipRect = document.createElementNS(
+          Blockly.utils.dom.SVG_NS,
+          'rect'
+        );
         tileClipRect.setAttribute('width', Bounce.SQUARE_SIZE);
         tileClipRect.setAttribute('height', Bounce.SQUARE_SIZE);
 
@@ -304,7 +310,10 @@ var drawMap = function () {
         tileClip.appendChild(tileClipRect);
         svg.appendChild(tileClip);
         // Tile sprite.
-        var tileElement = document.createElementNS(Blockly.SVG_NS, 'image');
+        var tileElement = document.createElementNS(
+          Blockly.utils.dom.SVG_NS,
+          'image'
+        );
         tileElement.setAttribute('id', 'tileElement' + tileId);
         tileElement.setAttributeNS(
           'http://www.w3.org/1999/xlink',
@@ -321,7 +330,10 @@ var drawMap = function () {
         tileElement.setAttribute('y', (y - top) * Bounce.SQUARE_SIZE);
         svg.appendChild(tileElement);
         // Tile animation
-        var tileAnimation = document.createElementNS(Blockly.SVG_NS, 'animate');
+        var tileAnimation = document.createElementNS(
+          Blockly.utils.dom.SVG_NS,
+          'animate'
+        );
         tileAnimation.setAttribute('id', 'tileAnimation' + tileId);
         tileAnimation.setAttribute('attributeType', 'CSS');
         tileAnimation.setAttribute('attributeName', 'opacity');
@@ -343,9 +355,15 @@ var drawMap = function () {
 
   if (Bounce.paddleStart_) {
     // Paddle's clipPath element, whose (x, y) is reset by Bounce.displayPaddle
-    var paddleClip = document.createElementNS(Blockly.SVG_NS, 'clipPath');
+    var paddleClip = document.createElementNS(
+      Blockly.utils.dom.SVG_NS,
+      'clipPath'
+    );
     paddleClip.setAttribute('id', 'paddleClipPath');
-    var paddleClipRect = document.createElementNS(Blockly.SVG_NS, 'rect');
+    var paddleClipRect = document.createElementNS(
+      Blockly.utils.dom.SVG_NS,
+      'rect'
+    );
     paddleClipRect.setAttribute('id', 'paddleClipRect');
     paddleClipRect.setAttribute('width', Bounce.PEGMAN_WIDTH);
     paddleClipRect.setAttribute('height', Bounce.PEGMAN_HEIGHT);
@@ -353,7 +371,10 @@ var drawMap = function () {
     svg.appendChild(paddleClip);
 
     // Add paddle.
-    var paddleIcon = document.createElementNS(Blockly.SVG_NS, 'image');
+    var paddleIcon = document.createElementNS(
+      Blockly.utils.dom.SVG_NS,
+      'image'
+    );
     paddleIcon.setAttribute('id', 'paddle');
     paddleIcon.setAttributeNS(
       'http://www.w3.org/1999/xlink',
@@ -370,7 +391,7 @@ var drawMap = function () {
     for (i = 0; i < Bounce.paddleFinishCount; i++) {
       // Add finish markers.
       var paddleFinishMarker = document.createElementNS(
-        Blockly.SVG_NS,
+        Blockly.utils.dom.SVG_NS,
         'image'
       );
       paddleFinishMarker.setAttribute('id', 'paddlefinish' + i);
@@ -387,7 +408,10 @@ var drawMap = function () {
 
   if (Bounce.ballFinish_) {
     // Add ball finish marker.
-    var ballFinishMarker = document.createElementNS(Blockly.SVG_NS, 'image');
+    var ballFinishMarker = document.createElementNS(
+      Blockly.utils.dom.SVG_NS,
+      'image'
+    );
     ballFinishMarker.setAttribute('id', 'ballfinish');
     ballFinishMarker.setAttributeNS(
       'http://www.w3.org/1999/xlink',
@@ -399,7 +423,7 @@ var drawMap = function () {
     svg.appendChild(ballFinishMarker);
   }
 
-  var score = document.createElementNS(Blockly.SVG_NS, 'text');
+  var score = document.createElementNS(Blockly.utils.dom.SVG_NS, 'text');
   score.setAttribute('id', 'score');
   score.setAttribute('class', 'bounce-score');
   score.setAttribute('x', Bounce.MAZE_WIDTH / 2);
@@ -410,7 +434,10 @@ var drawMap = function () {
 
   // Add wall hitting animation
   if (skin.hittingWallAnimation) {
-    var wallAnimationIcon = document.createElementNS(Blockly.SVG_NS, 'image');
+    var wallAnimationIcon = document.createElementNS(
+      Blockly.utils.dom.SVG_NS,
+      'image'
+    );
     wallAnimationIcon.setAttribute('id', 'wallAnimation');
     wallAnimationIcon.setAttribute('height', Bounce.SQUARE_SIZE);
     wallAnimationIcon.setAttribute('width', Bounce.SQUARE_SIZE);
@@ -423,7 +450,10 @@ var drawMap = function () {
   for (y = 0; y < Bounce.ROWS; y++) {
     for (x = 0; x < Bounce.COLS; x++) {
       if (Bounce.map[y][x] === SquareType.OBSTACLE) {
-        var obsIcon = document.createElementNS(Blockly.SVG_NS, 'image');
+        var obsIcon = document.createElementNS(
+          Blockly.utils.dom.SVG_NS,
+          'image'
+        );
         obsIcon.setAttribute('id', 'obstacle' + obsId);
         obsIcon.setAttribute(
           'height',
@@ -1072,7 +1102,6 @@ Bounce.runButtonClick = function () {
     resetButton.style.minWidth = runButton.offsetWidth + 'px';
   }
   studioApp().toggleRunReset('reset');
-  Blockly.mainBlockSpace.traceOn(true);
   studioApp().reset(false);
   studioApp().attempts++;
   Bounce.execute();

--- a/apps/src/craft/agent/craft.js
+++ b/apps/src/craft/agent/craft.js
@@ -648,7 +648,6 @@ export default class Craft {
     }
 
     studioApp().toggleRunReset('reset');
-    Blockly.mainBlockSpace.traceOn(true);
     studioApp().attempts++;
 
     Craft.executeUserCode();
@@ -684,9 +683,6 @@ export default class Craft {
     }
 
     studioApp().playAudio('start');
-
-    // Start tracing calls.
-    Blockly.mainBlockSpace.traceOn(true);
 
     const appCodeOrgAPI = Craft.gameController.codeOrgAPI;
     appCodeOrgAPI.startCommandCollection();

--- a/apps/src/craft/aquatic/craft.js
+++ b/apps/src/craft/aquatic/craft.js
@@ -491,7 +491,6 @@ Craft.runButtonClick = function () {
   }
 
   studioApp().toggleRunReset('reset');
-  Blockly.mainBlockSpace.traceOn(true);
   studioApp().attempts++;
 
   Craft.executeUserCode();
@@ -528,9 +527,6 @@ Craft.executeUserCode = function () {
 
   studioApp().playAudio('start');
   let interpreter;
-
-  // Start tracing calls.
-  Blockly.mainBlockSpace.traceOn(true);
 
   var appCodeOrgAPI = Craft.gameController.codeOrgAPI;
   appCodeOrgAPI.startCommandCollection();

--- a/apps/src/craft/code-connection/blocks.js
+++ b/apps/src/craft/code-connection/blocks.js
@@ -540,7 +540,7 @@ export const install = (blockly, blockInstallOptions) => {
         .appendField(new blockly.FieldTextInput(''), 'TARGET');
       this.appendValueInput('VEC3')
         .setCheck('Number')
-        .setAlign(Blockly.ALIGN_RIGHT)
+        .setAlign(Blockly.inputs.Align.RIGHT)
         .appendField(new blockly.FieldLabel(i18n.at()))
         .appendField(new blockly.FieldDropdown(positionTypes), 'POSITIONTYPE');
       this.setPreviousStatement(true);
@@ -644,7 +644,7 @@ export const install = (blockly, blockInstallOptions) => {
         .appendField(new blockly.FieldTextInput(''), 'VICTIM');
       this.appendValueInput('VEC3')
         .setCheck('Number')
-        .setAlign(Blockly.ALIGN_RIGHT)
+        .setAlign(Blockly.inputs.Align.RIGHT)
         .appendField(new blockly.FieldLabel(i18n.to()))
         .appendField(new blockly.FieldDropdown(positionTypes), 'POSITIONTYPE');
       this.setPreviousStatement(true);
@@ -671,14 +671,14 @@ export const install = (blockly, blockInstallOptions) => {
       );
       this.appendValueInput('FROM_VEC3')
         .setCheck('Number')
-        .setAlign(Blockly.ALIGN_RIGHT)
+        .setAlign(Blockly.inputs.Align.RIGHT)
         .appendField(
           new blockly.FieldDropdown(positionTypes),
           'FROMPOSITIONTYPE'
         );
       this.appendValueInput('TO_VEC3')
         .setCheck('Number')
-        .setAlign(Blockly.ALIGN_RIGHT)
+        .setAlign(Blockly.inputs.Align.RIGHT)
         .appendField(new blockly.FieldLabel(i18n.to()))
         .appendField(
           new blockly.FieldDropdown(positionTypes),
@@ -686,7 +686,7 @@ export const install = (blockly, blockInstallOptions) => {
         );
       this.appendValueInput('ITEM')
         .setCheck(ITEM_TYPE)
-        .setAlign(Blockly.ALIGN_RIGHT)
+        .setAlign(Blockly.inputs.Align.RIGHT)
         .appendField(new blockly.FieldLabel(i18n.blockActionWith()));
       this.setPreviousStatement(true);
       this.setNextStatement(true);
@@ -722,7 +722,7 @@ export const install = (blockly, blockInstallOptions) => {
         .appendField(new blockly.FieldLabel(i18n.blockActionGive()));
       this.appendValueInput('ITEM')
         .setCheck(ITEM_TYPE)
-        .setAlign(Blockly.ALIGN_RIGHT)
+        .setAlign(Blockly.inputs.Align.RIGHT)
         .appendField(new blockly.FieldLabel(i18n.itemsOfBlockType()));
       this.appendDummyInput()
         .appendField(new blockly.FieldLabel(i18n.to()))
@@ -779,11 +779,11 @@ export const install = (blockly, blockInstallOptions) => {
         .appendField(new blockly.FieldLabel(i18n.oldBlockHandling()));
       this.appendValueInput('VEC3')
         .setCheck('Number')
-        .setAlign(Blockly.ALIGN_RIGHT)
+        .setAlign(Blockly.inputs.Align.RIGHT)
         .appendField(new blockly.FieldDropdown(positionTypes), 'POSITIONTYPE');
       this.appendValueInput('ITEM')
         .setCheck(ITEM_TYPE)
-        .setAlign(Blockly.ALIGN_RIGHT)
+        .setAlign(Blockly.inputs.Align.RIGHT)
         .appendField(new blockly.FieldLabel(i18n.blockActionWith()));
       this.setPreviousStatement(true);
       this.setNextStatement(true);
@@ -843,12 +843,12 @@ export const install = (blockly, blockInstallOptions) => {
       );
       this.appendValueInput('VEC3')
         .setCheck('Number')
-        .setAlign(Blockly.ALIGN_RIGHT)
+        .setAlign(Blockly.inputs.Align.RIGHT)
         .appendField(new blockly.FieldLabel(i18n.at()))
         .appendField(new blockly.FieldDropdown(positionTypes), 'POSITIONTYPE');
       this.appendValueInput('ITEM')
         .setCheck(ITEM_TYPE)
-        .setAlign(Blockly.ALIGN_RIGHT)
+        .setAlign(Blockly.inputs.Align.RIGHT)
         .appendField(new blockly.FieldLabel(i18n.blockIs()));
       this.setOutput(true, Blockly.BlockValueType.BOOLEAN);
     },
@@ -881,7 +881,7 @@ export const install = (blockly, blockInstallOptions) => {
       );
       this.appendValueInput('FROM_VEC3')
         .setCheck('Number')
-        .setAlign(Blockly.ALIGN_RIGHT)
+        .setAlign(Blockly.inputs.Align.RIGHT)
         .appendField(new blockly.FieldLabel(i18n.from()))
         .appendField(
           new blockly.FieldDropdown(positionTypes),
@@ -889,7 +889,7 @@ export const install = (blockly, blockInstallOptions) => {
         );
       this.appendValueInput('TO_VEC3')
         .setCheck('Number')
-        .setAlign(Blockly.ALIGN_RIGHT)
+        .setAlign(Blockly.inputs.Align.RIGHT)
         .appendField(new blockly.FieldLabel(i18n.to()))
         .appendField(
           new blockly.FieldDropdown(positionTypes),
@@ -897,11 +897,11 @@ export const install = (blockly, blockInstallOptions) => {
         );
       this.appendValueInput('VEC3')
         .setCheck('Number')
-        .setAlign(Blockly.ALIGN_RIGHT)
+        .setAlign(Blockly.inputs.Align.RIGHT)
         .appendField(new blockly.FieldLabel(i18n.destination()))
         .appendField(new blockly.FieldDropdown(positionTypes), 'POSITIONTYPE');
       this.appendDummyInput()
-        .setAlign(Blockly.ALIGN_RIGHT)
+        .setAlign(Blockly.inputs.Align.RIGHT)
         .appendField(new blockly.FieldDropdown(testModes), 'TESTMODE');
       this.setOutput(true, Blockly.BlockValueType.BOOLEAN);
     },
@@ -941,7 +941,7 @@ export const install = (blockly, blockInstallOptions) => {
       );
       this.appendValueInput('FROM_VEC3')
         .setCheck('Number')
-        .setAlign(Blockly.ALIGN_RIGHT)
+        .setAlign(Blockly.inputs.Align.RIGHT)
         .appendField(new blockly.FieldLabel(i18n.from()))
         .appendField(
           new blockly.FieldDropdown(positionTypes),
@@ -949,7 +949,7 @@ export const install = (blockly, blockInstallOptions) => {
         );
       this.appendValueInput('TO_VEC3')
         .setCheck('Number')
-        .setAlign(Blockly.ALIGN_RIGHT)
+        .setAlign(Blockly.inputs.Align.RIGHT)
         .appendField(new blockly.FieldLabel(i18n.to()))
         .appendField(
           new blockly.FieldDropdown(positionTypes),
@@ -957,7 +957,7 @@ export const install = (blockly, blockInstallOptions) => {
         );
       this.appendValueInput('VEC3')
         .setCheck('Number')
-        .setAlign(Blockly.ALIGN_RIGHT)
+        .setAlign(Blockly.inputs.Align.RIGHT)
         .appendField(new blockly.FieldLabel(i18n.destination()))
         .appendField(new blockly.FieldDropdown(positionTypes), 'POSITIONTYPE');
       this.appendDummyInput()
@@ -1000,11 +1000,11 @@ export const install = (blockly, blockInstallOptions) => {
     init: function () {
       this.appendValueInput('ITEM')
         .setCheck(ITEM_TYPE)
-        .setAlign(Blockly.ALIGN_RIGHT)
+        .setAlign(Blockly.inputs.Align.RIGHT)
         .appendField(new blockly.FieldLabel(i18n.blockActionCloneFiltered()));
       this.appendValueInput('FROM_VEC3')
         .setCheck('Number')
-        .setAlign(Blockly.ALIGN_RIGHT)
+        .setAlign(Blockly.inputs.Align.RIGHT)
         .appendField(new blockly.FieldLabel(i18n.from()))
         .appendField(
           new blockly.FieldDropdown(positionTypes),
@@ -1012,7 +1012,7 @@ export const install = (blockly, blockInstallOptions) => {
         );
       this.appendValueInput('TO_VEC3')
         .setCheck('Number')
-        .setAlign(Blockly.ALIGN_RIGHT)
+        .setAlign(Blockly.inputs.Align.RIGHT)
         .appendField(new blockly.FieldLabel(i18n.to()))
         .appendField(
           new blockly.FieldDropdown(positionTypes),
@@ -1020,7 +1020,7 @@ export const install = (blockly, blockInstallOptions) => {
         );
       this.appendValueInput('VEC3')
         .setCheck('Number')
-        .setAlign(Blockly.ALIGN_RIGHT)
+        .setAlign(Blockly.inputs.Align.RIGHT)
         .appendField(new blockly.FieldLabel(i18n.destination()))
         .appendField(new blockly.FieldDropdown(positionTypes), 'POSITIONTYPE');
       this.appendDummyInput()

--- a/apps/src/craft/code-connection/craft.js
+++ b/apps/src/craft/code-connection/craft.js
@@ -598,8 +598,6 @@ export default class Craft {
         }
 
         studioApp().toggleRunReset('reset');
-        // Turn on call tracing
-        Blockly.mainBlockSpace.traceOn(true);
         studioApp().attempts++;
 
         const codeBlocks = Blockly.mainBlockSpace.getTopBlocks(true);

--- a/apps/src/craft/designer/craft.js
+++ b/apps/src/craft/designer/craft.js
@@ -717,7 +717,6 @@ Craft.runButtonClick = function () {
   }
 
   studioApp().toggleRunReset('reset');
-  Blockly.mainBlockSpace.traceOn(true);
   studioApp().attempts++;
 
   Craft.executeUserCode();
@@ -753,9 +752,6 @@ Craft.executeUserCode = function () {
   }
 
   studioApp().playAudio('start');
-
-  // Start tracing calls.
-  Blockly.mainBlockSpace.traceOn(true);
 
   var appCodeOrgAPI = Craft.gameController.codeOrgAPI;
   appCodeOrgAPI.startCommandCollection();

--- a/apps/src/craft/simple/craft.js
+++ b/apps/src/craft/simple/craft.js
@@ -705,7 +705,6 @@ Craft.runButtonClick = function () {
   }
 
   studioApp().toggleRunReset('reset');
-  Blockly.mainBlockSpace.traceOn(true);
   studioApp().attempts++;
 
   Craft.executeUserCode();
@@ -741,9 +740,6 @@ Craft.executeUserCode = function () {
   }
 
   studioApp().playAudio('start');
-
-  // Start tracing calls.
-  Blockly.mainBlockSpace.traceOn(true);
 
   var appCodeOrgAPI = Craft.gameController.codeOrgAPI;
   appCodeOrgAPI.startCommandCollection();

--- a/apps/src/dance/Dance.js
+++ b/apps/src/dance/Dance.js
@@ -673,7 +673,6 @@ Dance.prototype.runButtonClick = async function () {
     value: getStore().getState().dance.selectedSong,
   });
 
-  Blockly.mainBlockSpace.traceOn(true);
   this.studioApp_.attempts++;
 
   try {

--- a/apps/src/dance/blockly/blocks.js
+++ b/apps/src/dance/blockly/blocks.js
@@ -181,7 +181,7 @@ export default {
             'VAR'
           )
           .appendField(Blockly.Msg.VARIABLES_GET_TAIL);
-        this.setStrictOutput(true, Blockly.BlockValueType.SPRITE);
+        this.setOutput(true, Blockly.BlockValueType.SPRITE);
         this.setTooltip(Blockly.Msg.VARIABLES_GET_TOOLTIP);
       },
       getVars: function () {
@@ -191,7 +191,7 @@ export default {
       },
       renameVar: function (oldName, newName) {
         if (Blockly.Names.equals(oldName, this.getFieldValue('VAR'))) {
-          this.setTitleValue(newName, 'VAR');
+          this.setFieldValue(newName, 'VAR');
         }
       },
       removeVar: Blockly.Blocks.variables_get.removeVar,
@@ -217,7 +217,7 @@ export default {
           .appendField(Blockly.Msg.VARIABLES_GET_TITLE)
           .appendField(fieldLabel, 'VAR')
           .appendField(Blockly.Msg.VARIABLES_GET_TAIL);
-        this.setStrictOutput(true, Blockly.BlockValueType.SPRITE);
+        this.setOutput(true, Blockly.BlockValueType.SPRITE);
         this.setTooltip(Blockly.Msg.VARIABLES_GET_TOOLTIP);
       },
       renameVar(oldName, newName) {
@@ -252,7 +252,7 @@ export default {
           mainTitle.appendField(editLabel);
         }
 
-        this.setStrictOutput(true, Blockly.BlockValueType.BEHAVIOR);
+        this.setOutput(true, Blockly.BlockValueType.BEHAVIOR);
         this.setTooltip(Blockly.Msg.VARIABLES_GET_TOOLTIP);
         this.currentParameterNames_ = [];
       },
@@ -270,13 +270,13 @@ export default {
 
       renameVar(oldName, newName) {
         if (Blockly.Names.equals(oldName, this.getFieldValue('VAR'))) {
-          this.setTitleValue(newName, 'VAR');
+          this.setFieldValue(newName, 'VAR');
         }
       },
 
       renameProcedure(oldName, newName) {
         if (Blockly.Names.equals(oldName, this.getFieldValue('VAR'))) {
-          this.setTitleValue(newName, 'VAR');
+          this.setFieldValue(newName, 'VAR');
         }
       },
 

--- a/apps/src/dance/blockly/setup.ts
+++ b/apps/src/dance/blockly/setup.ts
@@ -14,7 +14,6 @@ export function setupBlocklyEnvironment() {
   registerCustomProcedureBlocks();
   delete Blockly.Blocks.procedures_defreturn;
   delete Blockly.Blocks.procedures_ifreturn;
-  Blockly.setInfiniteLoopTrap();
 
   for (const {definition, generator, extendedOptions} of blockDefinitions) {
     Blockly.Blocks[definition.type] = {

--- a/apps/src/feedback.js
+++ b/apps/src/feedback.js
@@ -666,7 +666,11 @@ FeedbackUtils.prototype.getFeedbackMessage = function (options) {
         var hasWhenRun = Blockly.mainBlockSpace
           .getTopBlocks()
           .some(function (block) {
-            return block.type === 'when_run' && block.isUserVisible();
+            return (
+              block.type === 'when_run' &&
+              // Ignore blocks on the hidden workspace (unlikely but possible?)
+              block.workspace === Blockly.getMainWorkspace()
+            );
           });
 
         var defaultMessage = hasWhenRun

--- a/apps/src/flappy/flappy.js
+++ b/apps/src/flappy/flappy.js
@@ -166,7 +166,7 @@ var drawMap = function () {
   visualizationColumn.style.width = Flappy.MAZE_WIDTH + 'px';
 
   if (skin.background) {
-    tile = document.createElementNS(Blockly.SVG_NS, 'image');
+    tile = document.createElementNS(Blockly.utils.dom.SVG_NS, 'image');
     tile.setAttributeNS(
       'http://www.w3.org/1999/xlink',
       'xlink:href',
@@ -182,7 +182,10 @@ var drawMap = function () {
 
   // Add obstacles
   Flappy.obstacles.forEach(function (obstacle, index) {
-    var obstacleTopIcon = document.createElementNS(Blockly.SVG_NS, 'image');
+    var obstacleTopIcon = document.createElementNS(
+      Blockly.utils.dom.SVG_NS,
+      'image'
+    );
     obstacleTopIcon.setAttributeNS(
       'http://www.w3.org/1999/xlink',
       'xlink:href',
@@ -193,7 +196,10 @@ var drawMap = function () {
     obstacleTopIcon.setAttribute('width', Flappy.OBSTACLE_WIDTH);
     svg.appendChild(obstacleTopIcon);
 
-    var obstacleBottomIcon = document.createElementNS(Blockly.SVG_NS, 'image');
+    var obstacleBottomIcon = document.createElementNS(
+      Blockly.utils.dom.SVG_NS,
+      'image'
+    );
     obstacleBottomIcon.setAttributeNS(
       'http://www.w3.org/1999/xlink',
       'xlink:href',
@@ -207,7 +213,10 @@ var drawMap = function () {
 
   if (level.ground) {
     for (i = 0; i < Flappy.MAZE_WIDTH / Flappy.GROUND_WIDTH + 1; i++) {
-      var groundIcon = document.createElementNS(Blockly.SVG_NS, 'image');
+      var groundIcon = document.createElementNS(
+        Blockly.utils.dom.SVG_NS,
+        'image'
+      );
       groundIcon.setAttributeNS(
         'http://www.w3.org/1999/xlink',
         'xlink:href',
@@ -223,7 +232,7 @@ var drawMap = function () {
   }
 
   if (level.goal && level.goal.startX) {
-    var goal = document.createElementNS(Blockly.SVG_NS, 'image');
+    var goal = document.createElementNS(Blockly.utils.dom.SVG_NS, 'image');
     goal.setAttribute('id', 'goal');
     goal.setAttributeNS(
       'http://www.w3.org/1999/xlink',
@@ -237,9 +246,15 @@ var drawMap = function () {
     svg.appendChild(goal);
   }
 
-  var avatArclip = document.createElementNS(Blockly.SVG_NS, 'clipPath');
+  var avatArclip = document.createElementNS(
+    Blockly.utils.dom.SVG_NS,
+    'clipPath'
+  );
   avatArclip.setAttribute('id', 'avatArclipPath');
-  var avatArclipRect = document.createElementNS(Blockly.SVG_NS, 'rect');
+  var avatArclipRect = document.createElementNS(
+    Blockly.utils.dom.SVG_NS,
+    'rect'
+  );
   avatArclipRect.setAttribute('id', 'avatArclipRect');
   avatArclipRect.setAttribute('width', Flappy.MAZE_WIDTH);
   avatArclipRect.setAttribute(
@@ -250,7 +265,7 @@ var drawMap = function () {
   svg.appendChild(avatArclip);
 
   // Add avatar.
-  var avatarIcon = document.createElementNS(Blockly.SVG_NS, 'image');
+  var avatarIcon = document.createElementNS(Blockly.utils.dom.SVG_NS, 'image');
   avatarIcon.setAttribute('id', 'avatar');
   avatarIcon.setAttributeNS(
     'http://www.w3.org/1999/xlink',
@@ -264,7 +279,10 @@ var drawMap = function () {
   }
   svg.appendChild(avatarIcon);
 
-  var instructions = document.createElementNS(Blockly.SVG_NS, 'image');
+  var instructions = document.createElementNS(
+    Blockly.utils.dom.SVG_NS,
+    'image'
+  );
   instructions.setAttributeNS(
     'http://www.w3.org/1999/xlink',
     'xlink:href',
@@ -278,7 +296,7 @@ var drawMap = function () {
   instructions.setAttribute('visibility', 'hidden');
   svg.appendChild(instructions);
 
-  var getready = document.createElementNS(Blockly.SVG_NS, 'image');
+  var getready = document.createElementNS(Blockly.utils.dom.SVG_NS, 'image');
   getready.setAttributeNS(
     'http://www.w3.org/1999/xlink',
     'xlink:href',
@@ -292,7 +310,7 @@ var drawMap = function () {
   getready.setAttribute('visibility', 'hidden');
   svg.appendChild(getready);
 
-  var clickrun = document.createElementNS(Blockly.SVG_NS, 'image');
+  var clickrun = document.createElementNS(Blockly.utils.dom.SVG_NS, 'image');
   clickrun.setAttributeNS(
     'http://www.w3.org/1999/xlink',
     'xlink:href',
@@ -306,7 +324,7 @@ var drawMap = function () {
   clickrun.setAttribute('visibility', 'visibile');
   svg.appendChild(clickrun);
 
-  var gameover = document.createElementNS(Blockly.SVG_NS, 'image');
+  var gameover = document.createElementNS(Blockly.utils.dom.SVG_NS, 'image');
   gameover.setAttributeNS(
     'http://www.w3.org/1999/xlink',
     'xlink:href',
@@ -320,7 +338,7 @@ var drawMap = function () {
   gameover.setAttribute('visibility', 'hidden');
   svg.appendChild(gameover);
 
-  var score = document.createElementNS(Blockly.SVG_NS, 'text');
+  var score = document.createElementNS(Blockly.utils.dom.SVG_NS, 'text');
   score.setAttribute('id', 'score');
   score.setAttribute('class', 'flappy-score');
   score.setAttribute('x', Flappy.MAZE_WIDTH / 2);
@@ -329,7 +347,7 @@ var drawMap = function () {
   score.setAttribute('visibility', 'hidden');
   svg.appendChild(score);
 
-  var clickRect = document.createElementNS(Blockly.SVG_NS, 'rect');
+  var clickRect = document.createElementNS(Blockly.utils.dom.SVG_NS, 'rect');
   clickRect.setAttribute('width', Flappy.MAZE_WIDTH);
   clickRect.setAttribute('height', Flappy.MAZE_HEIGHT);
   clickRect.setAttribute('fill-opacity', 0);
@@ -752,8 +770,6 @@ Flappy.runButtonClick = function () {
   document.getElementById('getready').setAttribute('visibility', 'visible');
 
   studioApp().toggleRunReset('reset');
-  Blockly.mainBlockSpace.traceOn(true);
-  // studioApp().reset(false);
   studioApp().attempts++;
   Flappy.execute();
 

--- a/apps/src/jigsaw/blocks.js
+++ b/apps/src/jigsaw/blocks.js
@@ -4,6 +4,8 @@
  * Copyright 2013 Code.org
  *
  */
+import '@cdo/apps/blockly/addons/extensions/jigsawFillPatternMixin';
+
 var levels = require('./levels');
 
 var patternCache = {
@@ -99,7 +101,7 @@ var addPattern = function (id, imagePath, width, height, offsetX, offsetY) {
     // add the pattern
     x = typeof offsetX === 'function' ? -offsetX() : -offsetX;
     y = typeof offsetY === 'function' ? -offsetY() : -offsetY;
-    pattern = Blockly.createSvgElement(
+    pattern = Blockly.utils.dom.createSvgElement(
       'pattern',
       {
         id: id,
@@ -111,7 +113,7 @@ var addPattern = function (id, imagePath, width, height, offsetX, offsetY) {
       },
       svgDefs
     );
-    patternImage = Blockly.createSvgElement(
+    patternImage = Blockly.utils.dom.createSvgElement(
       'image',
       {
         width: width,
@@ -244,6 +246,7 @@ function generateJigsawBlocksForLevel(blockly, skin, options) {
     blockly.Blocks[blockName] = {
       helpUrl: '',
       init: function () {
+        Blockly.Extensions.apply('jigsaw_fill_pattern_mixin', this, false);
         this.appendDummyInput().appendField(
           new blockly.FieldImage(skin.blank, titleWidth, titleHeight)
         );

--- a/apps/src/jigsaw/jigsaw.js
+++ b/apps/src/jigsaw/jigsaw.js
@@ -118,7 +118,7 @@ var drawMap = function () {
 
   if (level.ghost) {
     var blockCanvas = Blockly.mainBlockSpace.getCanvas();
-    Blockly.createSvgElement(
+    Blockly.utils.dom.createSvgElement(
       'rect',
       {
         fill: 'url(#pat_' + level.id + 'A)',
@@ -208,7 +208,7 @@ Jigsaw.init = function (config) {
 function checkForSuccess() {
   var success = level.goal.successCondition();
   if (success) {
-    Blockly.removeChangeListener(Jigsaw.successListener);
+    Blockly.getMainWorkspace().removeChangeListener(Jigsaw.successListener);
 
     Jigsaw.result = ResultType.SUCCESS;
     Jigsaw.onPuzzleComplete();

--- a/apps/src/maze/beeBlocks.js
+++ b/apps/src/maze/beeBlocks.js
@@ -2,7 +2,7 @@
  * Blocks specific to Bee
  */
 
-import {numberValidator} from '@cdo/apps/blockly/utils';
+import {interpolateMsg, numberValidator} from '@cdo/apps/blockly/utils';
 
 var blockUtils = require('../block_utils');
 var BlockStyles = require('../blockly/constants').BlockStyles;
@@ -253,10 +253,11 @@ function addRepeatedActionBlock(
     helpUrl: '',
     init: function () {
       this.setStyle(BlockStyles.DEFAULT);
-      this.interpolateMsg(
+      interpolateMsg(
+        this,
         blockMsg,
-        ['NUM', 'Number', Blockly.ALIGN_RIGHT],
-        Blockly.ALIGN_RIGHT
+        ['NUM', 'Number', Blockly.inputs.Align.RIGHT],
+        Blockly.inputs.Align.RIGHT
       );
 
       this.setInputsInline(true);

--- a/apps/src/maze/blocks.js
+++ b/apps/src/maze/blocks.js
@@ -24,7 +24,11 @@
 
 import {utils as mazeUtils} from '@code-dot-org/maze';
 
-import {registerCustomProcedureBlocks} from '@cdo/apps/blockly/utils';
+import {
+  INFINITE_LOOP_TRAP,
+  loopHighlight,
+  registerCustomProcedureBlocks,
+} from '@cdo/apps/blockly/utils';
 import commonMsg from '@cdo/locale';
 
 import blockUtils from '../block_utils';
@@ -361,7 +365,7 @@ exports.install = function (blockly, blockInstallOptions) {
     var argument =
       'Maze.' + this.getFieldValue('DIR') + "('block_id_" + this.id + "')";
     var branch = generator.statementToCode(this, 'DO');
-    branch = Blockly.getInfiniteLoopTrap() + branch;
+    branch = INFINITE_LOOP_TRAP + branch;
     return 'while (' + argument + ') {\n' + branch + '}\n';
   };
 
@@ -385,7 +389,7 @@ exports.install = function (blockly, blockInstallOptions) {
   generator.maze_untilBlocked = function () {
     var argument = 'Maze.isPathForward' + "('block_id_" + this.id + "')";
     var branch = generator.statementToCode(this, 'DO');
-    branch = Blockly.getInfiniteLoopTrap() + branch;
+    branch = INFINITE_LOOP_TRAP + branch;
     return 'while (' + argument + ') {\n' + branch + '}\n';
   };
 
@@ -406,10 +410,7 @@ exports.install = function (blockly, blockInstallOptions) {
   generator.maze_forever = function () {
     // Generate JavaScript for do forever loop.
     var branch = generator.statementToCode(this, 'DO');
-    branch =
-      Blockly.getInfiniteLoopTrap() +
-      Blockly.loopHighlight('Maze', this.id) +
-      branch;
+    branch = INFINITE_LOOP_TRAP + loopHighlight('Maze', this.id) + branch;
     return 'while (Maze.notFinished()) {\n' + branch + '}\n';
   };
 
@@ -432,7 +433,7 @@ exports.install = function (blockly, blockInstallOptions) {
     var argument =
       'Maze.' + this.getFieldValue('DIR') + "('block_id_" + this.id + "')";
     var branch = generator.statementToCode(this, 'DO');
-    branch = Blockly.getInfiniteLoopTrap() + branch;
+    branch = INFINITE_LOOP_TRAP + branch;
     return 'while (' + argument + ') {\n' + branch + '}\n';
   };
 

--- a/apps/src/maze/collectorBlocks.js
+++ b/apps/src/maze/collectorBlocks.js
@@ -1,3 +1,5 @@
+import {INFINITE_LOOP_TRAP} from '@cdo/apps/blockly/utils';
+
 var blockUtils = require('../block_utils');
 var BlockStyles = require('../blockly/constants').BlockStyles;
 
@@ -73,7 +75,7 @@ exports.install = function (blockly, blockInstallOptions) {
   generator.collector_whileCollectible = function () {
     var argument = `Maze.pilePresent('block_id_${this.id}')`;
     var branch = generator.statementToCode(this, 'DO');
-    branch = Blockly.getInfiniteLoopTrap() + branch;
+    branch = INFINITE_LOOP_TRAP + branch;
     return `while (${argument}) {\n${branch}}\n`;
   };
 };

--- a/apps/src/maze/harvesterBlocks.js
+++ b/apps/src/maze/harvesterBlocks.js
@@ -2,6 +2,8 @@
  * Blocks specific to Harvester
  */
 
+import {INFINITE_LOOP_TRAP} from '@cdo/apps/blockly/utils';
+
 var blockUtils = require('../block_utils');
 var BlockStyles = require('../blockly/constants').BlockStyles;
 
@@ -83,7 +85,7 @@ function addUntilAtSpecificCropBlock(blockly, generator, crop) {
   generator[`harvester_untilAt${capitalizeFirstLetter(crop)}`] = function () {
     var atCrop = `Maze.at${capitalizeFirstLetter(crop)}('block_id_${this.id}')`;
     var branch = generator.statementToCode(this, 'DO');
-    branch = Blockly.getInfiniteLoopTrap() + branch;
+    branch = INFINITE_LOOP_TRAP + branch;
     var code = `while (!${atCrop}) {\n${branch}}\n`;
     return code;
   };
@@ -161,7 +163,7 @@ function addWhileSpecificCropHasBlock(blockly, generator, crop) {
       this.id
     }')`;
     var branch = generator.statementToCode(this, 'DO');
-    branch = Blockly.getInfiniteLoopTrap() + branch;
+    branch = INFINITE_LOOP_TRAP + branch;
     var code = `while (${argument}) {\n${branch}}\n`;
     return code;
   };
@@ -187,7 +189,7 @@ function addUntilSpecificCropHasBlock(blockly, generator, crop) {
       this.id
     }')`;
     var branch = generator.statementToCode(this, 'DO');
-    branch = Blockly.getInfiniteLoopTrap() + branch;
+    branch = INFINITE_LOOP_TRAP + branch;
     var code = `while (!${argument}) {\n${branch}}\n`;
     return code;
   };
@@ -299,7 +301,7 @@ exports.install = function (blockly, blockInstallOptions) {
   generator.harvester_untilAtCrop = function () {
     var atCrop = `Maze.at${this.getFieldValue('LOC')}('block_id_${this.id}')`;
     var branch = generator.statementToCode(this, 'DO');
-    branch = Blockly.getInfiniteLoopTrap() + branch;
+    branch = INFINITE_LOOP_TRAP + branch;
     var code = `while (!${atCrop}) {\n${branch}}\n`;
     return code;
   };
@@ -377,7 +379,7 @@ exports.install = function (blockly, blockInstallOptions) {
       this.id
     }')`;
     var branch = generator.statementToCode(this, 'DO');
-    branch = Blockly.getInfiniteLoopTrap() + branch;
+    branch = INFINITE_LOOP_TRAP + branch;
     var code = `while (${argument}) {\n${branch}}\n`;
     return code;
   };
@@ -403,7 +405,7 @@ exports.install = function (blockly, blockInstallOptions) {
       this.id
     }')`;
     var branch = generator.statementToCode(this, 'DO');
-    branch = Blockly.getInfiniteLoopTrap() + branch;
+    branch = INFINITE_LOOP_TRAP + branch;
     var code = `while (!${argument}) {\n${branch}}\n`;
     return code;
   };

--- a/apps/src/maze/maze.js
+++ b/apps/src/maze/maze.js
@@ -153,8 +153,6 @@ module.exports = class Maze {
         // This prevents students from overriding these with their own
         // functions/variables.
         Blockly.JavaScript.addReservedWords('Maze,code');
-
-        Blockly.setInfiniteLoopTrap();
       }
 
       const svg = document.getElementById('svgMaze');
@@ -292,9 +290,6 @@ module.exports = class Maze {
       resetButton.style.minWidth = runButton.offsetWidth + 'px';
     }
     studioApp().toggleRunReset('reset');
-    if (studioApp().isUsingBlockly()) {
-      Blockly.mainBlockSpace.traceOn(true);
-    }
     studioApp().reset(false);
     studioApp().attempts++;
   }

--- a/apps/src/music/blockly/MusicBlocklyWorkspace.ts
+++ b/apps/src/music/blockly/MusicBlocklyWorkspace.ts
@@ -78,10 +78,6 @@ export default class MusicBlocklyWorkspace {
     }
     setUpBlocklyForMusicLab();
 
-    if (blockMode !== BlockMode.SIMPLE2) {
-      Blockly.setInfiniteLoopTrap();
-    }
-
     this.isBlocklyEnvironmentSetup = true;
   }
 

--- a/apps/src/music/blockly/extensions.js
+++ b/apps/src/music/blockly/extensions.js
@@ -38,7 +38,7 @@ export const playMultiMutator = {
     const shadowBlockXml = `<shadow type="${BlockTypes.VALUE_SAMPLE}"/>`;
     this.appendValueInput(EXTRA_SOUND_INPUT_PREFIX + this.extraSoundInputCount_)
       .setShadowDom(Blockly.Xml.textToDom(shadowBlockXml))
-      .setAlign(Blockly.ALIGN_RIGHT)
+      .setAlign(Blockly.inputs.Align.RIGHT)
       .setCheck(SOUND_VALUE_TYPE)
       .appendField('and');
 

--- a/apps/src/p5lab/P5Lab.js
+++ b/apps/src/p5lab/P5Lab.js
@@ -728,9 +728,6 @@ export default class P5Lab {
         ].join(',')
       );
       Blockly.JavaScript.addReservedWords(SpritelabReservedWords.join(','));
-
-      // Don't add infinite loop protection
-      Blockly.clearInfiniteLoopTrap();
     }
 
     if (this.level.blocklyVariables) {
@@ -962,10 +959,6 @@ export default class P5Lab {
    */
   runButtonClick() {
     this.studioApp_.toggleRunReset('reset');
-    // document.getElementById('spinner').style.visibility = 'visible';
-    if (this.studioApp_.isUsingBlockly()) {
-      Blockly.mainBlockSpace.traceOn(true);
-    }
     this.studioApp_.attempts++;
     this.execute();
 

--- a/apps/src/p5lab/spritelab/SpriteLab.js
+++ b/apps/src/p5lab/spritelab/SpriteLab.js
@@ -2,7 +2,6 @@ import React from 'react';
 
 import {getStore} from '@cdo/apps/redux';
 import Sounds from '@cdo/apps/Sounds';
-import * as utils from '@cdo/apps/utils';
 import msg from '@cdo/spritelab/locale';
 
 import {closeWorkspaceAlert} from '../../code-studio/projectRedux';
@@ -132,26 +131,6 @@ export default class SpriteLab extends P5Lab {
   onPromptAnswer(variableName, value) {
     getStore().dispatch(popPrompt());
     this.library.onPromptAnswer(variableName, value);
-  }
-
-  setupReduxSubscribers(store) {
-    super.setupReduxSubscribers(store);
-    let state = {};
-    store.subscribe(function () {
-      const lastState = state;
-      state = store.getState();
-
-      if (
-        lastState.animationList?.propsByKey !== state.animationList?.propsByKey
-      ) {
-        if (window.Blockly && Blockly.mainBlockSpace) {
-          const customEvent = utils.createEvent(
-            Blockly.BlockSpace.EVENTS.ANIMATIONS_CHANGED
-          );
-          Blockly.mainBlockSpace.events.dispatchEvent(customEvent);
-        }
-      }
-    });
   }
 
   /**

--- a/apps/src/p5lab/spritelab/blocks.js
+++ b/apps/src/p5lab/spritelab/blocks.js
@@ -127,7 +127,7 @@ const customInputTypes = {
       icon.style.fontFamily = 'FontAwesome';
       icon.textContent = ' \uf08e '; // arrow-up-right-from-square
       const onSelect = function (soundValue) {
-        block.setTitleValue(soundValue, inputConfig.name);
+        block.setFieldValue(soundValue, inputConfig.name);
       };
       const onClick = () => {
         dashboard.assets.showAssetManager(onSelect, 'audio', null, {
@@ -638,7 +638,7 @@ export default {
             'VAR'
           )
           .appendField(Blockly.Msg.VARIABLES_GET_TAIL);
-        this.setStrictOutput(true, Blockly.BlockValueType.SPRITE);
+        this.setOutput(true, Blockly.BlockValueType.SPRITE);
         this.setTooltip(Blockly.Msg.VARIABLES_GET_TOOLTIP);
         this.setStyle('sprite_blocks');
       },
@@ -649,7 +649,7 @@ export default {
       },
       renameVar: function (oldName, newName) {
         if (Blockly.Names.equals(oldName, this.getFieldValue('VAR'))) {
-          this.setTitleValue(newName, 'VAR');
+          this.setFieldValue(newName, 'VAR');
         }
       },
       removeVar: Blockly.Blocks.variables_get.removeVar,

--- a/apps/src/sites/studio/pages/blocks/edit.js
+++ b/apps/src/sites/studio/pages/blocks/edit.js
@@ -201,7 +201,7 @@ function updateBlockPreview() {
   const block = `<block type="${blockName}" />`;
   Blockly.mainBlockSpace.clear();
   loadBlocksToWorkspace(Blockly.mainBlockSpace, block);
-  Blockly.addChangeListener(Blockly.mainBlockSpace, onBlockSpaceChange);
+  Blockly.mainBlockSpace.addChangeListener(onBlockSpaceChange);
 }
 
 function onBlockSpaceChange() {

--- a/apps/src/sites/studio/pages/shared_blockly_functions/edit.js
+++ b/apps/src/sites/studio/pages/shared_blockly_functions/edit.js
@@ -56,7 +56,7 @@ const block = Blockly.mainBlockSpace.getTopBlocks()[0];
 const name = getInput('name').value || DEFAULT_NAME;
 
 if (name) {
-  block.setTitleValue(name, 'NAME');
+  block.setFieldValue(name, 'NAME');
 }
 const [names, types] = unzip(JSON.parse(getInput('arguments').value || '[]'));
 if (names && types) {

--- a/apps/src/studio/blocks.js
+++ b/apps/src/studio/blocks.js
@@ -10,6 +10,7 @@ import _ from 'lodash';
 
 import {
   addSerializationHooksToBlock,
+  interpolateMsg,
   registerCustomProcedureBlocks,
 } from '@cdo/apps/blockly/utils';
 import commonMsg from '@cdo/locale';
@@ -985,7 +986,8 @@ exports.install = function (blockly, blockInstallOptions) {
       dropdown.setValue(this.VALUES[1][1]); // default to top-left
       this.setStyle(BlockStyles.DEFAULT);
       if (spriteCount > 1) {
-        this.interpolateMsg(
+        interpolateMsg(
+          this,
           msg.setSpritePosition(),
           () => {
             this.appendDummyInput().appendField(spriteIndexDropdown, 'SPRITE');
@@ -993,15 +995,16 @@ exports.install = function (blockly, blockInstallOptions) {
           () => {
             this.appendDummyInput().appendField(dropdown, 'VALUE');
           },
-          blockly.ALIGN_RIGHT
+          blockly.inputs.Align.RIGHT
         );
       } else {
-        this.interpolateMsg(
+        interpolateMsg(
+          this,
           msg.setPosition(),
           () => {
             this.appendDummyInput().appendField(dropdown, 'VALUE');
           },
-          blockly.ALIGN_RIGHT
+          blockly.inputs.Align.RIGHT
         );
       }
       this.setPreviousStatement(true);
@@ -1028,7 +1031,8 @@ exports.install = function (blockly, blockInstallOptions) {
       var dropdown = new blockly.FieldDropdown(POSITION_VALUES);
       dropdown.setValue(POSITION_VALUES[1][1]); // default to top-left
       this.setStyle(BlockStyles.DEFAULT);
-      this.interpolateMsg(
+      interpolateMsg(
+        this,
         msg.setSpritePosition(),
         () => {
           this.appendValueInput('SPRITE').setCheck(
@@ -1038,7 +1042,7 @@ exports.install = function (blockly, blockInstallOptions) {
         () => {
           this.appendDummyInput().appendField(dropdown, 'VALUE');
         },
-        blockly.ALIGN_RIGHT
+        blockly.inputs.Align.RIGHT
       );
       this.setPreviousStatement(true);
       this.setInputsInline(true);
@@ -1113,12 +1117,13 @@ exports.install = function (blockly, blockInstallOptions) {
       var dropdown = new blockly.FieldDropdown(this.VALUES);
       dropdown.setValue(this.VALUES[1][1]); // default to top-left
       this.setStyle(BlockStyles.DEFAULT);
-      this.interpolateMsg(
+      interpolateMsg(
+        this,
         msg.addGoalPosition(),
         () => {
           this.appendDummyInput().appendField(dropdown, 'VALUE');
         },
-        blockly.ALIGN_RIGHT
+        blockly.inputs.Align.RIGHT
       );
       this.setPreviousStatement(true);
       this.setInputsInline(true);
@@ -2401,6 +2406,7 @@ exports.install = function (blockly, blockInstallOptions) {
       this.setPreviousStatement(false);
       this.setNextStatement(true);
       this.setTooltip(msg.whenSpriteAndGroupCollideTooltip());
+      this.setInputsInline(true);
     },
   };
 
@@ -2585,11 +2591,11 @@ exports.install = function (blockly, blockInstallOptions) {
       if (options.params) {
         this.appendValueInput('TITLE')
           .setCheck(blockly.BlockValueType.STRING)
-          .setAlign(Blockly.ALIGN_RIGHT)
+          .setAlign(Blockly.inputs.Align.RIGHT)
           .appendField(msg.showTitleScreenTitle());
         this.appendValueInput('TEXT')
           .setCheck(blockly.BlockValueType.STRING)
-          .setAlign(Blockly.ALIGN_RIGHT)
+          .setAlign(Blockly.inputs.Align.RIGHT)
           .appendField(msg.showTitleScreenText());
       } else {
         this.appendDummyInput()

--- a/apps/src/studio/studio.js
+++ b/apps/src/studio/studio.js
@@ -2944,9 +2944,6 @@ Studio.runButtonClick = function () {
     resetButton.style.minWidth = runButton.offsetWidth + 'px';
   }
   studioApp().toggleRunReset('reset');
-  if (studioApp().isUsingBlockly()) {
-    Blockly.mainBlockSpace.traceOn(true);
-  }
 
   // Stop the music the first time the run button is pressed (hoc2015)
   Studio.musicController.fadeOut();

--- a/apps/src/templates/instructions/utils.js
+++ b/apps/src/templates/instructions/utils.js
@@ -190,7 +190,7 @@ function createEmbeddedWorkspace(
   // resize after initial render, so we also want to resize the container
   // whenever a blockSpaceChange results in the content size changing.
   let metrics = workspace.getMetrics();
-  Blockly.addChangeListener(workspace, function () {
+  workspace.addChangeListener(function () {
     const oldHeight = metrics.contentHeight;
     const oldWidth = metrics.contentWidth;
     const newHeight = workspace.getMetrics().contentHeight;

--- a/apps/src/turtle/artist.js
+++ b/apps/src/turtle/artist.js
@@ -792,9 +792,6 @@ Artist.prototype.runButtonClick = function () {
   this.shouldAnimate_ = !this.instant_;
   this.studioApp_.toggleRunReset('reset');
   document.getElementById('spinner').style.visibility = 'visible';
-  if (this.studioApp_.isUsingBlockly()) {
-    Blockly.mainBlockSpace.traceOn(true);
-  }
   this.studioApp_.attempts++;
   this.execute(this.executionInfo);
 };

--- a/apps/src/turtle/blocks.js
+++ b/apps/src/turtle/blocks.js
@@ -26,9 +26,11 @@ import {BlockStyles} from '@cdo/apps/blockly/constants';
 import {
   registerCustomProcedureBlocks,
   numberValidator,
+  interpolateMsg,
 } from '@cdo/apps/blockly/utils';
 import commonMsg from '@cdo/locale';
 
+import {setAngleHelperOptions} from '../blockly/addons/cdoAngleHelperOptions';
 import {Position} from '../constants';
 
 import Colours from './colours';
@@ -418,13 +420,13 @@ exports.install = function (blockly, blockInstallOptions) {
 
   blockly.Blocks.point_to_param = createPointToBlocks(function (block) {
     // Block for pointing to a specified direction
-    block
+    const input = block
       .appendValueInput('VALUE')
-      .setCheck(blockly.BlockValueType.NUMBER)
-      .addFieldHelper(blockly.BlockFieldHelper.ANGLE_HELPER, {
-        block,
-        direction: 'turnRight',
-      });
+      .setCheck(blockly.BlockValueType.NUMBER);
+    setAngleHelperOptions(input.connection, {
+      block,
+      direction: 'turnRight',
+    });
     block.appendDummyInput().appendField(msg.degrees());
   });
 
@@ -541,7 +543,7 @@ exports.install = function (blockly, blockInstallOptions) {
       this.setStyle(BlockStyles.PROCEDURE);
       this.appendDummyInput().appendField(msg.drawASquare());
       this.appendValueInput('VALUE')
-        .setAlign(blockly.ALIGN_RIGHT)
+        .setAlign(blockly.inputs.Align.RIGHT)
         .setCheck(blockly.BlockValueType.NUMBER)
         .appendField(msg.lengthParameter() + ':');
       this.setPreviousStatement(true);
@@ -575,7 +577,7 @@ exports.install = function (blockly, blockInstallOptions) {
       this.setStyle(BlockStyles.PROCEDURE);
       this.appendDummyInput().appendField(msg.drawASnowman());
       this.appendValueInput('VALUE')
-        .setAlign(blockly.ALIGN_RIGHT)
+        .setAlign(blockly.inputs.Align.RIGHT)
         .setCheck(blockly.BlockValueType.NUMBER)
         .appendField(msg.lengthParameter() + ':');
       this.setPreviousStatement(true);
@@ -653,13 +655,14 @@ exports.install = function (blockly, blockInstallOptions) {
           blockly.Msg.CONTROLS_FOR_INPUT_WITH || msg.controlsForInputWith()
         )
         .appendField(new blockly.FieldLabel(msg.loopVariable()), 'VAR');
-      this.interpolateMsg(
+      interpolateMsg(
+        this,
         blockly.Msg.CONTROLS_FOR_INPUT_FROM_TO_BY ||
           msg.controlsForInputFromToBy(),
-        ['FROM', 'Number', blockly.ALIGN_RIGHT],
-        ['TO', 'Number', blockly.ALIGN_RIGHT],
-        ['BY', 'Number', blockly.ALIGN_RIGHT],
-        blockly.ALIGN_RIGHT
+        ['FROM', 'Number', blockly.inputs.Align.RIGHT],
+        ['TO', 'Number', blockly.inputs.Align.RIGHT],
+        ['BY', 'Number', blockly.inputs.Align.RIGHT],
+        blockly.inputs.Align.RIGHT
       );
       this.appendStatementInput('DO').appendField(
         Blockly.Msg.CONTROLS_FOR_INPUT_DO
@@ -686,7 +689,7 @@ exports.install = function (blockly, blockInstallOptions) {
     // deserialize the counter variable name
     domToMutation: function (xmlElement) {
       var counter = xmlElement.getAttribute('counter');
-      this.setTitleValue(counter, 'VAR');
+      this.setFieldValue(counter, 'VAR');
     },
   };
   generator.controls_for_counter = generator.forBlock.controls_for;
@@ -702,7 +705,8 @@ exports.install = function (blockly, blockInstallOptions) {
     helpUrl: '',
     init: function () {
       this.setStyle(BlockStyles.DEFAULT);
-      this.interpolateMsg(
+      interpolateMsg(
+        this,
         msg.moveDirectionByPixels(),
         () => {
           this.appendDummyInput().appendField(
@@ -710,8 +714,8 @@ exports.install = function (blockly, blockInstallOptions) {
             'DIR'
           );
         },
-        ['VALUE', 'Number', blockly.ALIGN_RIGHT],
-        blockly.ALIGN_RIGHT
+        ['VALUE', 'Number', blockly.inputs.Align.RIGHT],
+        blockly.inputs.Align.RIGHT
       );
       this.setInputsInline(true);
       this.setPreviousStatement(true);
@@ -740,7 +744,8 @@ exports.install = function (blockly, blockInstallOptions) {
     helpUrl: '',
     init: function () {
       this.setStyle(BlockStyles.DEFAULT);
-      this.interpolateMsg(
+      interpolateMsg(
+        this,
         msg.jumpByDirection(),
         () => {
           this.appendDummyInput().appendField(
@@ -748,8 +753,8 @@ exports.install = function (blockly, blockInstallOptions) {
             'DIR'
           );
         },
-        ['VALUE', 'Number', blockly.ALIGN_RIGHT],
-        blockly.ALIGN_RIGHT
+        ['VALUE', 'Number', blockly.inputs.Align.RIGHT],
+        blockly.inputs.Align.RIGHT
       );
       this.setInputsInline(true);
       this.setPreviousStatement(true);
@@ -1102,12 +1107,13 @@ exports.install = function (blockly, blockInstallOptions) {
       var dropdown = new blockly.FieldDropdown(this.VALUES);
       dropdown.setValue(this.VALUES[1][1]); // default to top-left
       this.setStyle(BlockStyles.DEFAULT);
-      this.interpolateMsg(
+      interpolateMsg(
+        this,
         msg.jumpToPosition(),
         () => {
           this.appendDummyInput().appendField(dropdown, 'VALUE');
         },
-        blockly.ALIGN_RIGHT
+        blockly.inputs.Align.RIGHT
       );
       this.setPreviousStatement(true);
       this.setInputsInline(true);
@@ -1134,7 +1140,8 @@ exports.install = function (blockly, blockInstallOptions) {
     helpUrl: '',
     init: function () {
       this.setStyle(BlockStyles.DEFAULT);
-      this.interpolateMsg(
+      interpolateMsg(
+        this,
         msg.jumpToOverDown(),
         () => {
           this.appendDummyInput().appendField(
@@ -1148,7 +1155,7 @@ exports.install = function (blockly, blockInstallOptions) {
             'YPOS'
           );
         },
-        blockly.ALIGN_RIGHT
+        blockly.inputs.Align.RIGHT
       );
       this.setPreviousStatement(true);
       this.setInputsInline(true);
@@ -1168,7 +1175,8 @@ exports.install = function (blockly, blockInstallOptions) {
     helpUrl: '',
     init: function () {
       this.setStyle(BlockStyles.DEFAULT);
-      this.interpolateMsg(
+      interpolateMsg(
+        this,
         msg.turnDirection(),
         () => {
           this.appendDummyInput().appendField(
@@ -1177,15 +1185,13 @@ exports.install = function (blockly, blockInstallOptions) {
           );
         },
         () => {
-          this.appendValueInput('VALUE').addFieldHelper(
-            blockly.BlockFieldHelper.ANGLE_HELPER,
-            {
-              block: this,
-              directionTitle: 'DIR',
-            }
-          );
+          const input = this.appendValueInput('VALUE');
+          setAngleHelperOptions(input.connection, {
+            block: this,
+            directionTitle: 'DIR',
+          });
         },
-        blockly.ALIGN_RIGHT
+        blockly.inputs.Align.RIGHT
       );
       this.setInputsInline(true);
       this.setPreviousStatement(true);

--- a/apps/src/turtle/customLevelBlocks.js
+++ b/apps/src/turtle/customLevelBlocks.js
@@ -65,7 +65,7 @@ function makeBlockInitializer(title, parameter) {
 
       if (parameter !== undefined) {
         this.appendValueInput('VALUE')
-          .setAlign(Blockly.ALIGN_RIGHT)
+          .setAlign(Blockly.inputs.Align.RIGHT)
           .setCheck(Blockly.BlockValueType.NUMBER)
           .appendField(parameter + ':');
       }

--- a/apps/src/utils.js
+++ b/apps/src/utils.js
@@ -370,18 +370,6 @@ export function showGenericQtip(targetElement, title, message, position) {
     .qtip('show');
 }
 
-export function showUnusedBlockQtip(targetElement) {
-  const msg = require('@cdo/locale');
-  const title = msg.unattachedBlockTipTitle();
-  const message = msg.unattachedBlockTipBody();
-  const position = {
-    my: 'bottom left',
-    at: 'top right',
-  };
-
-  showGenericQtip(targetElement, title, message, position);
-}
-
 /**
  * @param {string} key
  * @param {string} defaultValue

--- a/apps/test/integration/blockUtilTests.js
+++ b/apps/test/integration/blockUtilTests.js
@@ -16,9 +16,9 @@ describe('blockUtils', function () {
   it('can create a block from XML', function () {
     var blockXMLString =
       '<block type="math_number"><field name="NUM">10</field></block>';
-    assert(Blockly.mainBlockSpace.getBlockCount() === 0);
+    assert(Blockly.mainBlockSpace.getAllBlocks().length === 0);
     var newBlock = blockUtils.domStringToBlock(blockXMLString);
-    assert(Blockly.mainBlockSpace.getBlockCount() === 1);
+    assert(Blockly.mainBlockSpace.getAllBlocks().length === 1);
     assert(newBlock.getFieldValue('NUM') === 10);
     assert(getBlockFields(newBlock).length === 1);
   });
@@ -26,11 +26,11 @@ describe('blockUtils', function () {
   it('can create a block from XML and remove it from the workspace', function () {
     var blockXMLString =
       '<block type="math_number"><field name="NUM">10</field></block>';
-    assert(Blockly.mainBlockSpace.getBlockCount() === 0);
+    assert(Blockly.mainBlockSpace.getAllBlocks().length === 0);
     var newBlock = blockUtils.domStringToBlock(blockXMLString);
-    assert(Blockly.mainBlockSpace.getBlockCount() === 1);
+    assert(Blockly.mainBlockSpace.getAllBlocks().length === 1);
     newBlock.dispose();
-    assert(Blockly.mainBlockSpace.getBlockCount() === 0);
+    assert(Blockly.mainBlockSpace.getAllBlocks().length === 0);
   });
 });
 

--- a/apps/test/integration/util/testBlockly.js
+++ b/apps/test/integration/util/testBlockly.js
@@ -27,7 +27,7 @@ exports.setupTestBlockly = function () {
 
   Blockly.mainBlockSpace.clear();
   assert(
-    Blockly.mainBlockSpace.getBlockCount() === 0,
+    Blockly.mainBlockSpace.getAllBlocks().length === 0,
     'Blockly workspace is empty'
   );
 };

--- a/apps/test/unit/blockly/blocklyWrapperTest.js
+++ b/apps/test/unit/blockly/blocklyWrapperTest.js
@@ -33,11 +33,4 @@ describe('Blockly Wrapper', () => {
   it('getGenerator returns the JS Generator', () => {
     expect(Blockly.getGenerator()).to.deep.equal(Blockly.blockly_.JavaScript);
   });
-
-  it('Setting SNAP_RADIUS also sets CONNECTING_SNAP_RADIUS', () => {
-    Blockly.SNAP_RADIUS = 0;
-    expect(Blockly.blockly_.CONNECTING_SNAP_RADIUS).to.equal(0);
-    Blockly.SNAP_RADIUS = 100;
-    expect(Blockly.blockly_.CONNECTING_SNAP_RADIUS).to.equal(100);
-  });
 });

--- a/apps/test/unit/p5lab/spritelab/SpritelabTest.js
+++ b/apps/test/unit/p5lab/spritelab/SpritelabTest.js
@@ -1,11 +1,6 @@
 import ReactDOM from 'react-dom';
 
 import reducers from '@cdo/apps/p5lab/reducers';
-import {
-  addAnimation,
-  editAnimation,
-  setInitialAnimationList,
-} from '@cdo/apps/p5lab/redux/animationList';
 import SpriteLab from '@cdo/apps/p5lab/spritelab/SpriteLab';
 import {
   getStore,
@@ -195,91 +190,6 @@ describe('SpriteLab', () => {
         it('does nothing if there is no executionError message', () => {
           instance.reactToExecutionError(undefined);
           expect(alertSpy).not.toHaveBeenCalled();
-        });
-      });
-
-      describe('dispatching Blockly events', () => {
-        let store, eventSpy, originalMainBlockSpace;
-        beforeEach(() => {
-          store = getStore();
-          instance.setupReduxSubscribers(store);
-          originalMainBlockSpace = Blockly.mainBlockSpace;
-          eventSpy = jest.fn();
-          Blockly.mainBlockSpace = {events: {dispatchEvent: eventSpy}};
-
-          const initialAnimationList = {
-            orderedKeys: ['key1'],
-            propsByKey: {
-              key1: {
-                name: 'bear',
-                sourceUrl:
-                  'https://studio.code.org/api/v1/animation-library/spritelab/wAQoTe9lNAp19q.JxOmT6hRtv1GceGwp/category_animals/bear.png',
-                frameSize: {
-                  x: 254,
-                  y: 333,
-                },
-                frameCount: 1,
-                looping: true,
-                frameDelay: 2,
-                version: 'wAQoTe9lNAp19q.JxOmT6hRtv1GceGwp',
-                categories: ['animals'],
-              },
-            },
-          };
-          store.dispatch(
-            setInitialAnimationList(initialAnimationList, false, true)
-          );
-          eventSpy.mockReset();
-        });
-
-        afterEach(() => {
-          eventSpy.mockRestore();
-          Blockly.mainBlockSpace = originalMainBlockSpace;
-        });
-
-        it('dispatches event when animations are added', () => {
-          const newAnimation = {
-            name: 'purple bunny',
-            sourceUrl:
-              'https://studio.code.org/api/v1/animation-library/spritelab/kBiszeGACcLTGTrqmS4laPVQKPGQnDln/category_animals/bunny2.png',
-            frameSize: {
-              x: 152,
-              y: 193,
-            },
-            frameCount: 1,
-            looping: true,
-            frameDelay: 2,
-            version: 'kBiszeGACcLTGTrqmS4laPVQKPGQnDln',
-            categories: ['animals', 'characters'],
-          };
-
-          store.dispatch(addAnimation('key2', newAnimation));
-          expect(eventSpy).toHaveBeenCalled();
-        });
-
-        it('dispatches event when animations change', () => {
-          const newProps = {
-            name: 'bear',
-            sourceUrl:
-              'https://studio.code.org/api/v1/animation-library/spritelab/kBiszeGACcLTGTrqmS4laPVQKPGQnDln/category_animals/bunny2.png',
-            frameSize: {
-              x: 254,
-              y: 333,
-            },
-            frameCount: 1,
-            looping: true,
-            frameDelay: 2,
-            version: 'wAQoTe9lNAp19q.JxOmT6hRtv1GceGwp',
-            categories: ['animals'],
-          };
-          store.dispatch(editAnimation('key1', newProps));
-          expect(eventSpy).toHaveBeenCalled();
-        });
-
-        it('does not dispatch event when animations do not change', () => {
-          // Dispatch an action so the subscriber gets called
-          store.dispatch(setIsRunning(true));
-          expect(eventSpy).not.toHaveBeenCalled();
         });
       });
     });


### PR DESCRIPTION
Reverts code-dot-org/code-dot-org#70771

This PR is a redo of #70680. In the previous PR, we removed the now-unused `dispatchEvent` implementation from our Blockly wrapper. That change exposed new JS errors because Sprite Lab still contained legacy code and tests expecting Blockly workspace events to be dispatched when animations changed. The purpose of the event firing was to update the preview of options for block dropdown fields. However, modern dropdown fields refresh dynamically and do not rely on workspace-level animation events. The event dispatch path was effectively dead code and existed only to satisfy legacy tests.
This PR removes obsolete the Sprite Lab test coverage asserting that a Blockly `ANIMATIONS_CHANGED `event is dispatched when the animation list updates.
This aligns test expectations with the current architecture, where animation updates are not connected to Blockly workspace events.
No functional behavior is changed. This simply removes an unwanted call site, and test coverage for an implementation detail that is no longer supported or required.