### PR TITLE
P20-1796: Add one-off script to remove duplicate LTI courses

### DIFF
--- a/bin/oneoff/wipe_data/remove_duplicate_lti_courses
+++ b/bin/oneoff/wipe_data/remove_duplicate_lti_courses
@@ -3,9 +3,8 @@
 # This script deletes duplicate LTI course records
 # See: https://codedotorg.atlassian.net/browse/P20-1796
 
-options = {dry_run: false}
-
 require 'optparse'
+options = {dry_run: false, limit: 10_000, batch_size: 1000}
 OptionParser.new do |opts|
   opts.banner = <<~BANNER
     Usage: #{File.basename(__FILE__)} [options]
@@ -20,6 +19,14 @@ OptionParser.new do |opts|
     options[:dry_run] = true
   end
 
+  opts.on('-l', '--limit COUNT', Integer, "Stop after processing COUNT records (default: #{options[:limit]})") do |limit|
+    options[:limit] = limit
+  end
+
+  opts.on('-b', '--batch-size SIZE', Integer, "Number of records to process per batch (default: #{options[:batch_size]})") do |batch_size|
+    options[:batch_size] = batch_size
+  end
+
   opts.on('-h', '--help') do
     puts opts
     exit
@@ -32,24 +39,24 @@ abort unless $stdin.gets&.strip&.downcase == 'y'
 require 'ruby-progressbar'
 require_relative '../../../dashboard/config/environment'
 
-duplicate_pair_query = LtiCourse.group(:lti_integration_id, :context_id).having('COUNT(*) > 1').order(:lti_integration_id, :context_id)
-duplicate_pair_count = LtiCourse.unscoped.from(duplicate_pair_query.select('1'), :dupes).count
+duplicate_pairs_query = LtiCourse.group(:lti_integration_id, :context_id).having('COUNT(*) > 1').limit(options[:limit])
+duplicate_pairs_count = LtiCourse.unscoped.from(duplicate_pairs_query.select('1'), :dupes).count
 
-progress_bar = ProgressBar.create(total: duplicate_pair_count, format: 'Deleted duplicate pairs[%c/%C]: |%W| %a')
-batch_size = 1000
-loop do
-  duplicated_data_batch = duplicate_pair_query.limit(batch_size).pluck(:lti_integration_id, :context_id)
+progress_bar = ProgressBar.create(total: duplicate_pairs_count, format: 'Deleted duplicate pairs[%c/%C]: |%W| %a')
+while progress_bar.progress < options[:limit]
+  batch_size = [options[:batch_size], options[:limit] - progress_bar.progress].min
+  duplicate_data_batch = duplicate_pairs_query.limit(batch_size).pluck(:lti_integration_id, :context_id)
 
-  duplicated_data_batch.each do |lti_integration_id, context_id|
-    duplicate_pair_records = LtiCourse.where(lti_integration_id:, context_id:).order(updated_at: :desc, id: :desc).to_a
-    progress_bar.log "\n[Duplicated data] lti_integration_id: #{lti_integration_id}, context_id: #{context_id}, count: #{duplicate_pair_records.size}".bold.cyan
+  duplicate_data_batch.each do |lti_integration_id, context_id|
+    duplicate_pair_query = LtiCourse.where(lti_integration_id:, context_id:)
+    progress_bar.log "\n[Duplicate data] lti_integration_id: #{lti_integration_id}, context_id: #{context_id}".bold.cyan
 
-    relevant_record = duplicate_pair_records.max_by(&:updated_at)
+    relevant_record = duplicate_pair_query.order(updated_at: :desc, created_at: :desc).first
     progress_bar.log "[Relevant record] #{relevant_record.inspect}".green
 
-    (duplicate_pair_records - [relevant_record]).each do |duplicate_record|
+    duplicate_pair_query.where.not(id: relevant_record.id).find_each do |duplicate_record|
       if options[:dry_run]
-        progress_bar.log "[Duplicated record] #{duplicate_record.inspect}".yellow
+        progress_bar.log "[Duplicate record] #{duplicate_record.inspect}".yellow
       else
         duplicate_record.destroy!
         progress_bar.log "[Deleted duplicate] #{duplicate_record.inspect}".red
@@ -62,6 +69,6 @@ loop do
     progress_bar.increment
   end
 
-  break if duplicated_data_batch.size < batch_size
+  break if duplicate_data_batch.size < batch_size
 end
 progress_bar.finish

--- a/bin/oneoff/wipe_data/remove_duplicate_lti_courses
+++ b/bin/oneoff/wipe_data/remove_duplicate_lti_courses
@@ -1,0 +1,67 @@
+#!/usr/bin/env ruby
+
+# This script deletes duplicate LTI course records
+# See: https://codedotorg.atlassian.net/browse/P20-1796
+
+options = {dry_run: false}
+
+require 'optparse'
+OptionParser.new do |opts|
+  opts.banner = <<~BANNER
+    Usage: #{File.basename(__FILE__)} [options]
+
+    This script deletes duplicate LTI course records.
+    See: https://codedotorg.atlassian.net/browse/P20-1796
+
+    Options:
+  BANNER
+
+  opts.on('-d', '--dry-run', 'Enables read-only mode where no changes are written to the database') do
+    options[:dry_run] = true
+  end
+
+  opts.on('-h', '--help') do
+    puts opts
+    exit
+  end
+end.parse!
+
+print "Proceed with options #{options} (y/N): "
+abort unless $stdin.gets&.strip&.downcase == 'y'
+
+require 'ruby-progressbar'
+require_relative '../../../dashboard/config/environment'
+
+duplicate_pair_query = LtiCourse.group(:lti_integration_id, :context_id).having('COUNT(*) > 1').order(:lti_integration_id, :context_id)
+duplicate_pair_count = LtiCourse.unscoped.from(duplicate_pair_query.select('1'), :dupes).count
+
+progress_bar = ProgressBar.create(total: duplicate_pair_count, format: 'Deleted duplicate pairs[%c/%C]: |%W| %a')
+batch_size = 1000
+loop do
+  duplicated_data_batch = duplicate_pair_query.limit(batch_size).pluck(:lti_integration_id, :context_id)
+
+  duplicated_data_batch.each do |lti_integration_id, context_id|
+    duplicate_pair_records = LtiCourse.where(lti_integration_id:, context_id:).order(updated_at: :desc, id: :desc).to_a
+    progress_bar.log "\n[Duplicated data] lti_integration_id: #{lti_integration_id}, context_id: #{context_id}, count: #{duplicate_pair_records.size}".bold.cyan
+
+    relevant_record = duplicate_pair_records.max_by(&:updated_at)
+    progress_bar.log "[Relevant record] #{relevant_record.inspect}".green
+
+    (duplicate_pair_records - [relevant_record]).each do |duplicate_record|
+      if options[:dry_run]
+        progress_bar.log "[Duplicated record] #{duplicate_record.inspect}".yellow
+      else
+        duplicate_record.destroy!
+        progress_bar.log "[Deleted duplicate] #{duplicate_record.inspect}".red
+      end
+    rescue StandardError => exception
+      progress_bar.log "[Error deleting duplicate] #{duplicate_record.inspect}".red
+      progress_bar.log exception.message
+    end
+  ensure
+    progress_bar.increment
+  end
+
+  break if duplicated_data_batch.size < batch_size
+end
+progress_bar.finish


### PR DESCRIPTION
```
Usage: ./bin/oneoff/wipe_data/remove_duplicate_lti_courses [options]

Options:
    -d, --dry-run            Enables read-only mode where no changes are written to the database
    -l, --limit COUNT        Stop after processing COUNT records (default: 10000)
    -b, --batch-size SIZE    Number of records to process per batch (default: 1000)
    -h, --help

```

## Links
- JIRA task: [P20-1796](https://codedotorg.atlassian.net/browse/P20-1796)
- Related PR: https://github.com/code-dot-org/code-dot-org/pull/70711