### PR TITLE
Stream Cloud Init log to CloudWatch Logs

### DIFF
--- a/aws/cloudformation/cloud_formation_stack.yml.erb
+++ b/aws/cloudformation/cloud_formation_stack.yml.erb
@@ -796,9 +796,15 @@ Outputs:
     Description: Codeprojects URL
     Value: !Sub preview.${CodeprojectsBaseDomainName}
 <% end -%>
-# display information about how to ssh to console if this is a single instance adhoc environment
-<% if rack_env?(:adhoc) && !frontends -%>
-  SSHServerName:
-    Value: <%=cdn_enabled ? subdomain('origin') : stack_name%>
-    Description: SSH server name
-<%end-%>
+<% if rack_env?(:adhoc) -%>
+  DaemonSSHCommand:
+    Description: "AWS CLI command to connect to the daemon instance via AWS Systems Manager (SSM) Session Manager."
+    Value: !Sub
+      - "aws ssm start-session --target ${InstanceId}"
+      - InstanceId: !Ref <%=daemon%>
+  DaemonProvisioningLog:
+    Description: "Link to CloudWatch Log that the daemon EC2 Instance Cloud Init Output logs are streamed to for diagnosis of provisioning issues."
+    Value: !Sub
+      - "https://${AWS::Region}.console.aws.amazon.com/cloudwatch/home?region=${AWS::Region}#logsV2:log-groups/log-group/adhoc-syslog/log-events/${InstanceId}"
+      - InstanceId: !Ref <%=daemon%>
+<% end -%>

--- a/cookbooks/cdo-apps/recipes/default.rb
+++ b/cookbooks/cdo-apps/recipes/default.rb
@@ -10,6 +10,7 @@ chef_client_updater 'install' do
 end
 
 include_recipe 'apt'
+include_recipe 'cdo-cloudwatch-agent'
 
 include_recipe 'cdo-apps::hostname'
 
@@ -86,7 +87,6 @@ node.default['cdo-secrets']['daemon'] = node['cdo-apps']['daemon'] if node['cdo-
 include_recipe 'cdo-secrets'
 include_recipe 'cdo-mysql'
 include_recipe 'cdo-postfix'
-include_recipe 'cdo-cloudwatch-agent'
 include_recipe 'cdo-otel-collector'
 include_recipe 'cdo-syslog'
 

--- a/cookbooks/cdo-cloudwatch-agent/attributes/default.rb
+++ b/cookbooks/cdo-cloudwatch-agent/attributes/default.rb
@@ -6,6 +6,7 @@ default['cdo-cloudwatch-agent'] = {
       #{node[:home]}/#{node.chef_environment}/dashboard/log/puma_stdout.log
       #{node[:home]}/#{node.chef_environment}/dashboard/log/puma_stderr.log
       /var/log/nginx/error.log
+      /var/log/cloud-init-output.log
     ]
   }
 }


### PR DESCRIPTION
To help monitor and debug provisioning of our application on EC2 Instances, which are initiated by Cloud Init invoking Chef client, install CloudWatch Agent as soon as possible and stream the Cloud Init output log to our CloudWatch `syslog` Log Stream.

## Testing story

`bundle exec rake adhoc:start RAILS_ENV=adhoc STACK_NAME=adhoc-cloud-init-log`

Correctly shows errors that occur in Chef provisioning *after* installation of CloudWatch Agent
<img width="1693" height="611" alt="image" src="https://github.com/user-attachments/assets/8eabae33-2e81-4950-a248-b0edbf099e33" />

Also successfully completed adhoc:

`bundle exec rake adhoc:start RAILS_ENV=adhoc STACK_NAME=adhoc-cloud-init-log3`

Cloud Init logs streamed to adhoc-syslog https://us-east-1.console.aws.amazon.com/cloudwatch/home?region=us-east-1#logsV2:log-groups/log-group/adhoc-syslog/log-events/i-0bb1e4f41af402664

## Deployment strategy

I've updated our "Getting Started as a Developer" document to 



## Follow-up work
<!--  List any clean-up or technical debt that will be addressed in future work.
      - Include Jira links where applicable.
      - Are there any known limitations or improvements planned? -->



## Privacy
<!--  How does this change impact Student & Teacher privacy?
      - Does this collect, use, share, or modify PII, either new or existing? -->



## Security
<!--  How does this change impact our security surface-area?
      - Do API's touched have the right auth?
      - Do infra changes impact our attack surface or encryption?
-->



## Caching
<!--  How does this change impact caching behavior?
      - Are cache keys or invalidation strategies affected?
      - Will this require cache warming or invalidation after deployment? -->



## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
