### PR TITLE
Tutor Permissions: pass missing aiChatToolsDependency prop to UnitOverviewActionRow

### DIFF
--- a/apps/src/code-studio/components/progress/UnitOverview.jsx
+++ b/apps/src/code-studio/components/progress/UnitOverview.jsx
@@ -222,6 +222,7 @@ class UnitOverview extends React.Component {
               scriptResourcesPdfUrl={scriptResourcesPdfUrl}
               teacherResources={teacherResources}
               isMigrated={isMigrated}
+              aiChatToolsDependency={aiChatToolsDependency}
             />
             {experiments.isEnabled(experiments.AI_CHAT_NEW_PERMISSIONS) &&
               viewAs === ViewType.Instructor &&


### PR DESCRIPTION
We missed one spot for the multi assign dialog ai chat tools alert. This change adds it which enables the alert to show up on when assigning a unit from the Unit Overview page.

| before | after |
| --- | --- |
| <img width="658" height="527" alt="image" src="https://github.com/user-attachments/assets/b14eeecf-1d6d-4af9-b116-e2c62528b09c" /> | <img width="659" height="628" alt="image" src="https://github.com/user-attachments/assets/f404eea6-e158-4dba-9f97-74fe6d52ac77" /> |
| warning on MultipleSectionsAssigner component: Warning: Failed prop type: The prop `aiChatToolsDependency` is marked as required in `MultipleSectionsAssigner`, but its value is `undefined`.  | no warning! woo! |



## Links
<!--  Links to relevant external resources.
      - spec docs, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- [design](https://www.figma.com/design/nl4nXJLuUHb9Aj4gfCAaNL/AI-Tutor--Settings?node-id=3372-8532&m=dev)
- #70681
