### PR TITLE
Updates shade of Teal in Headers

### DIFF
--- a/dashboard/app/assets/stylesheets/application.scss
+++ b/dashboard/app/assets/stylesheets/application.scss
@@ -50,6 +50,8 @@ $selectUserTypeButtonTextColorHover: #000;
 $selectUserTypeButtonBackgroundColorSelected: #0093a4;
 $selectUserTypeButtonTextColorSelected: #fff;
 
+$contrastTealHeader: #00818f;
+
 @import "bootstrap";
 
 p,pre,span {
@@ -200,7 +202,7 @@ img.video_thumbnail {
     padding-top: 0;
     padding-bottom: 0;
     height: 50px;
-    background-color: $teal;
+    background-color: $contrastTealHeader;
     color: $header_text;
     a:link {
       color: $header_text;
@@ -303,9 +305,6 @@ img.video_thumbnail {
   }
 
   .header_button {
-    &.header_button_light {
-      background-color: $teal;
-    }
     @include main-font-regular;
     display: flex;
     align-items: center;

--- a/pegasus/sites.v3/code.org/styles_min/040-page.css
+++ b/pegasus/sites.v3/code.org/styles_min/040-page.css
@@ -11,6 +11,7 @@
   --brand_primary_light: #abdfe5;
   --brand_primary_medium: #7bc6cf;
   --brand_primary_default: #0093a4;
+  --brand_primary_contrast: #00818f;
   --brand_primary_dark: #008291;
   --brand_secondary_light: #e0d1ec;
   --brand_secondary_default: #8c52ba;
@@ -520,7 +521,7 @@ td {
 
 /* Start top navigation bar styles ------------------------ */
 nav.main {
-  background-color: var(--brand_primary_default);
+  background-color: var(--brand_primary_contrast);;
   margin: 0;
   padding: 0.375rem 0.875rem;
   position: relative;


### PR DESCRIPTION
It's so beautiful😭🥹

This PR addresses both signed out and signed in teal headers, making them a couple shades darker to eliminate the WCAG contrast violations and make them a bit easier on the eyes. It also required I remove the teal background of some of the buttons in the header, otherwise they would have the two different teals. Without specifying a background, they end up with the teal background of the parent.

I know this will cause massive eyes diffs. I'll be in touch with the appropriate DOTD and ready to review them with @moshebaricdo 

Signed out Header Before:
<img width="1145" height="244" alt="Screenshot 2026-02-12 at 3 20 00 PM" src="https://github.com/user-attachments/assets/832366aa-6e06-46f0-ac5d-7f1d23c591d4" />

Signed out Header After:
<img width="1150" height="243" alt="Screenshot 2026-02-12 at 3 20 51 PM" src="https://github.com/user-attachments/assets/15b546da-219e-4a24-bc01-719b43185d26" />

Signed out project Before:
<img width="1131" height="160" alt="Screenshot 2026-02-12 at 3 52 02 PM" src="https://github.com/user-attachments/assets/901fafc8-e71b-4d91-832d-8a09d87c8bc5" />


Signed out project After:
<img width="1147" height="103" alt="Screenshot 2026-02-12 at 3 32 23 PM" src="https://github.com/user-attachments/assets/b49aa674-0f8b-4ea0-8051-d42c56086f3a" />

Signed in Headers Before:
<img width="1342" height="217" alt="Screenshot 2026-02-12 at 3 12 14 PM" src="https://github.com/user-attachments/assets/60f17ac6-23a6-4a67-bb92-cc1fde4d1a72" />

Signed in Headers After:
<img width="1143" height="199" alt="Screenshot 2026-02-12 at 3 18 26 PM" src="https://github.com/user-attachments/assets/757d57f1-02e9-455c-99d6-350808fe3c20" />




Contrast violations before:
<img width="571" height="331" alt="Screenshot 2026-02-12 at 3 16 43 PM" src="https://github.com/user-attachments/assets/f7fb98cd-31dd-4d55-af0e-6deaabddb837" />

Contrast violations after:
<img width="570" height="383" alt="Screenshot 2026-02-12 at 3 18 45 PM" src="https://github.com/user-attachments/assets/afe18746-903d-497f-8778-7a36768c043d" />

Contrast violations signed out before:
<img width="567" height="365" alt="Screenshot 2026-02-12 at 3 20 22 PM" src="https://github.com/user-attachments/assets/12bbf485-e8c7-4501-8a25-de3f3c3e44d4" />

Contrast violations signed out after:
<img width="569" height="407" alt="Screenshot 2026-02-12 at 3 21 22 PM" src="https://github.com/user-attachments/assets/773f0580-53b5-49f0-9845-dd857ee7aeb2" />


## Links

- Jira: https://codedotorg.atlassian.net/browse/SL-1566

## Testing story
<!--  Does your change include appropriate tests?
      - If so, please describe how the tests included in this PR are sufficient.
      - If not, please explain why this change does not need to be tested. -->



## Deployment strategy
<!--  Any special steps required to deploy this, besides merging?
      - Are there database migrations or manual steps?
      - Does this require coordination with other teams or systems? -->



## Follow-up work
<!--  List any clean-up or technical debt that will be addressed in future work.
      - Include Jira links where applicable.
      - Are there any known limitations or improvements planned? -->



## Privacy
<!--  How does this change impact Student & Teacher privacy?
      - Does this collect, use, share, or modify PII, either new or existing? -->



## Security
<!--  How does this change impact our security surface-area?
      - Do API's touched have the right auth?
      - Do infra changes impact our attack surface or encryption?
-->



## Caching
<!--  How does this change impact caching behavior?
      - Are cache keys or invalidation strategies affected?
      - Will this require cache warming or invalidation after deployment? -->



## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
