### PR TITLE
Lesson Feedback - Show correct Recommended Actions to Students

### DIFF
--- a/apps/src/templates/feedback/LessonFeedback.tsx
+++ b/apps/src/templates/feedback/LessonFeedback.tsx
@@ -16,6 +16,11 @@ interface LessonFeedbackProps {
   submittedAtDate: string | Date;
   lessonTitle?: string;
   lessonStartUrl?: string;
+  resource?: {
+    recommended_action?: string;
+    resource_name?: string;
+    resource_link?: string;
+  };
 }
 
 function LessonFeedback({
@@ -24,6 +29,7 @@ function LessonFeedback({
   teacherName,
   lessonTitle,
   lessonStartUrl,
+  resource,
 }: LessonFeedbackProps) {
   const formattedDate = new Date(submittedAtDate).toLocaleDateString('en-US', {
     year: 'numeric',
@@ -36,6 +42,11 @@ function LessonFeedback({
       window.open(lessonStartUrl, '_blank', 'noopener,noreferrer');
     }
   };
+
+  const showRecommendedAction =
+    resource &&
+    (!!resource.recommended_action ||
+      (resource.resource_name && resource.resource_link));
 
   return (
     <div className={styles.lessonFeedbackContainer}>
@@ -62,12 +73,12 @@ function LessonFeedback({
       </div>
       <hr className={styles.lessonFeedbackDivider} />
       <div className={styles.lessonFeedbackBox}>{feedbackText}</div>
-      <hr className={styles.lessonFeedbackDivider} />
-      {/* TODO: Add in real data here */}
-      <LessonRecommendedAction
-        resourceComment="Review the lesson and complete the exercises to improve your understanding."
-        resourceLink={lessonStartUrl || ''}
-      />
+      {showRecommendedAction && (
+        <>
+          <hr className={styles.lessonFeedbackDivider} />
+          <LessonRecommendedAction resource={resource} />
+        </>
+      )}
     </div>
   );
 }

--- a/apps/src/templates/feedback/LessonFeedbackContainer.tsx
+++ b/apps/src/templates/feedback/LessonFeedbackContainer.tsx
@@ -70,6 +70,7 @@ function LessonFeedbackContainer({studentId}: LessonFeedbackContainerProps) {
               submittedAtDate={lessonFeedback.updated_at}
               lessonTitle={lessonFeedback.lesson_title}
               lessonStartUrl={lessonFeedback.lesson_start_url}
+              resource={lessonFeedback.resources?.[0]}
             />
           );
         })}

--- a/apps/src/templates/feedback/LessonRecommendedAction.tsx
+++ b/apps/src/templates/feedback/LessonRecommendedAction.tsx
@@ -30,7 +30,9 @@ function LessonRecommendedAction({resource}: LessonRecommendedActionProps) {
       <BodyTwoText className={styles.strongText}>
         Recommended action
       </BodyTwoText>
-      <BodyThreeText>{resource.recommended_action}</BodyThreeText>
+      {resource.recommended_action && (
+        <BodyThreeText>{resource.recommended_action}</BodyThreeText>
+      )}
       {resource.resource_name && resource.resource_link && (
         <Button
           onClick={handleViewResource}

--- a/apps/src/templates/feedback/LessonRecommendedAction.tsx
+++ b/apps/src/templates/feedback/LessonRecommendedAction.tsx
@@ -28,7 +28,7 @@ function LessonRecommendedAction({resource}: LessonRecommendedActionProps) {
   return (
     <div>
       <BodyTwoText className={styles.strongText}>
-        Recommended Action
+        Recommended action
       </BodyTwoText>
       <BodyThreeText>{resource.recommended_action}</BodyThreeText>
       {resource.resource_name && resource.resource_link && (

--- a/apps/src/templates/feedback/LessonRecommendedAction.tsx
+++ b/apps/src/templates/feedback/LessonRecommendedAction.tsx
@@ -8,32 +8,38 @@ import React from 'react';
 import styles from './LessonFeedback.module.scss';
 
 interface LessonRecommendedActionProps {
-  resourceComment: string;
-  resourceLink: string;
+  resource: {
+    recommended_action?: string;
+    resource_name?: string;
+    resource_link?: string;
+  };
 }
 
-function LessonRecommendedAction({
-  resourceComment,
-  resourceLink,
-}: LessonRecommendedActionProps) {
+function LessonRecommendedAction({resource}: LessonRecommendedActionProps) {
   const handleViewResource = () => {
-    window.open(resourceLink, '_blank', 'noopener,noreferrer');
+    if (resource.resource_link) {
+      const url = resource.resource_link.match(/^https?:\/\//)
+        ? resource.resource_link
+        : `https://${resource.resource_link}`;
+      window.open(url, '_blank', 'noopener,noreferrer');
+    }
   };
 
   return (
     <div>
       <BodyTwoText className={styles.strongText}>
-        Recommended action
+        Recommended Action
       </BodyTwoText>
-      <BodyThreeText>{resourceComment}</BodyThreeText>
-
-      <Button
-        onClick={handleViewResource}
-        text="View Resource"
-        type="primary"
-        size="xs"
-        iconLeft={{iconName: 'link'}}
-      />
+      <BodyThreeText>{resource.recommended_action}</BodyThreeText>
+      {resource.resource_name && resource.resource_link && (
+        <Button
+          onClick={handleViewResource}
+          text={resource.resource_name || 'View Resource'}
+          type="primary"
+          size="xs"
+          iconLeft={{iconName: 'link'}}
+        />
+      )}
     </div>
   );
 }


### PR DESCRIPTION
Gets accurate Recommended Actions to show for students.  Prior to this there was placeholder data.

What it looks like when there is data and no data for resources
<img width="786" height="478" alt="image" src="https://github.com/user-attachments/assets/c616c300-7025-490a-81dd-3a975824df80" />

Also can include just an "action" with no link:
<img width="792" height="260" alt="image" src="https://github.com/user-attachments/assets/f078a32a-54d0-4751-a5b3-f6d1e8040553" />

