### PR TITLE
Lab2: fix exemplar links

### DIFF
--- a/apps/src/code-studio/components/progress/teacherPanel/TeacherPanel.jsx
+++ b/apps/src/code-studio/components/progress/teacherPanel/TeacherPanel.jsx
@@ -26,6 +26,7 @@ import {loadLevelsWithProgress} from '@cdo/apps/code-studio/teacherPanelRedux';
 import {updateQueryParam, queryParams} from '@cdo/apps/code-studio/utils';
 import {setViewType, ViewType} from '@cdo/apps/code-studio/viewAsRedux';
 import fontConstants from '@cdo/apps/fontConstants';
+import {getExampleSolutionLink} from '@cdo/apps/lab2/redux/lab2ReduxSelectors';
 import Button from '@cdo/apps/legacySharedComponents/Button';
 import FontAwesome from '@cdo/apps/legacySharedComponents/FontAwesome';
 import SortByNameDropdown from '@cdo/apps/templates/SortByNameDropdown';
@@ -360,7 +361,7 @@ export default connect(
       isSortedByFamilyName: state.currentUser.isSortedByFamilyName,
       exampleSolutions: state.pageConstants?.exampleSolutions,
       currentLevelId: state.progress.currentLevelId,
-      lab2ExampleSolutions: state.lab?.levelProperties?.exampleSolutions,
+      lab2ExampleSolutions: getExampleSolutionLink(state),
       isCurrentLevelLab2: getCurrentLevel(state)?.usesLab2,
     };
   },

--- a/apps/src/lab2/redux/lab2ReduxSelectors.ts
+++ b/apps/src/lab2/redux/lab2ReduxSelectors.ts
@@ -71,6 +71,8 @@ export const isReadOnlyWorkspace = (state: RootState) => {
   );
 };
 
+// If the level should show an exemplar link, the exemplar link is the current url
+// with the query parameter exemplar=true at the end.
 export const getExampleSolutionLink = (state: RootState) => {
   if (state.lab.levelProperties?.showExemplarLink) {
     const url = new URL(window.location.href);

--- a/apps/src/lab2/redux/lab2ReduxSelectors.ts
+++ b/apps/src/lab2/redux/lab2ReduxSelectors.ts
@@ -71,6 +71,15 @@ export const isReadOnlyWorkspace = (state: RootState) => {
   );
 };
 
+export const getExampleSolutionLink = (state: RootState) => {
+  if (state.lab.levelProperties?.showExemplarLink) {
+    const url = new URL(window.location.href);
+    url.searchParams.set('exemplar', 'true');
+    return [url.toString()];
+  }
+  return [];
+};
+
 // Helper functions
 
 // Returns if the current state represents a predict level that should be read only.

--- a/apps/src/lab2/types.ts
+++ b/apps/src/lab2/types.ts
@@ -228,7 +228,7 @@ export interface LevelProperties {
   referenceLinks?: string[];
   helpVideos?: VideoData[];
   // Exemplars
-  exampleSolutions?: string[];
+  showExemplarLink?: boolean;
   exemplarSources?: ProjectSources | MultiFileSource;
   exemplarSettings?: ExemplarSettings;
   // For Teachers Only value

--- a/dashboard/app/models/levels/level.rb
+++ b/dashboard/app/models/levels/level.rb
@@ -925,9 +925,7 @@ class Level < ApplicationRecord
     properties_camelized["exemplarSettings"] = localized_exemplar_settings if get_exemplar_settings
     properties_camelized["panels"] = localized_panels if properties_camelized["panels"]
     properties_camelized["longInstructions"] = (get_localized_property("long_instructions") || long_instructions) if properties_camelized["longInstructions"]
-    if script_level
-      properties_camelized[:exampleSolutions] = script_level.get_example_solutions(self, current_user, nil, unit_group_unit: unit_group_unit)
-    end
+    properties_camelized[:showExemplarLink] = script_level && try(:exemplar_sources).present? && current_user&.verified_instructor?
     is_verified_instructor = current_user&.verified_instructor? || current_user&.permission?(UserPermission::LEVELBUILDER)
     if is_verified_instructor || try(:exemplar_settings)
       # Verified instructors can view exemplars and levelbuilders can edit them, so we include them in the properties

--- a/dashboard/app/models/script_level.rb
+++ b/dashboard/app/models/script_level.rb
@@ -738,7 +738,9 @@ class ScriptLevel < ApplicationRecord
 
     return [] if !Policies::InlineAnswer.visible_for_script_level?(current_user, self) || CDO.properties_encryption_key.blank?
 
-    # exemplar_sources is used by Javalab and Code Bridge levels to store level solutions
+    # exemplar_sources is used by Javalab and Code Bridge levels to store level solutions.
+    # This should not be used for modular script levels, as it will always return the exemplar link for the
+    # "home course". This can lead to confusing permissions issues.
     if level.try(:exemplar_sources).present? && current_user&.verified_instructor?
       if oldest_active_level.is_a? BubbleChoice
         # If the script level has sublevels, get a link for the sublevel that looks like


### PR DESCRIPTION
The way we were generating exemplar links on the backend for lab2 didn't take into account the new modular ability for the same script level to be in different courses. However, we don't need to generate the link on the backend; the exemplar link for lab2 levels should just be the script level with the query parameter `exemplar=true` at the end. This updates our logic for lab2 level properties to just return a flag as to whether we should show an exemplar link, then generate the link on the frontend.


## Links

- Jira: [AFL-460](https://codedotorg.atlassian.net/browse/AFL-460)

## Testing story
Tested locally on various lab2 levels, including on bubble choice sublevels and levels without exemplars.




## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
