### PR TITLE
Fix spacing on lesson materials page

### DIFF
--- a/apps/src/templates/teacherNavigation/lessonMaterials/LessonMaterialsContainer.tsx
+++ b/apps/src/templates/teacherNavigation/lessonMaterials/LessonMaterialsContainer.tsx
@@ -485,11 +485,9 @@ const LessonMaterialsContainer: React.FC<LessonMaterialsContainerProps> = ({
           </div>
         ) : (
           <>
-            <div>
-              {renderTeacherResources()}
-              {renderStudentResources()}
-              {renderCustomResources()}
-            </div>
+            {renderTeacherResources()}
+            {renderStudentResources()}
+            {renderCustomResources()}
           </>
         )}
       </div>


### PR DESCRIPTION
Fixes spacing on the lesson materials page

Eyes test failure:
<img width="2105" height="893" alt="image" src="https://github.com/user-attachments/assets/ad0a6636-88ee-43a2-b8c3-4fa5a30157ce" />


Discussion:
https://codedotorg.slack.com/archives/C0T0PNTM3/p1771017016207279