### PR TITLE
Lab2 extra links: show message if template level not found

### DIFF
--- a/dashboard/app/controllers/levels_controller.rb
+++ b/dashboard/app/controllers/levels_controller.rb
@@ -579,13 +579,17 @@ class LevelsController < ApplicationController
 
       if project_template_level_name = @level.properties['project_template_level_name']
         project_template_level = Level.find_by_name(project_template_level_name)
-        links["Template Level"] = [
-          {text: project_template_level_name, url: level_path(project_template_level)}
-        ]
-        template_level_edit_link = can_edit_level ?
-          {text: 'Edit', url: edit_level_path(project_template_level)} :
-          {text: '(Cannot edit)', url: ''}
-        links["Template Level"] << template_level_edit_link
+        if project_template_level
+          links["Template Level"] = [
+            {text: project_template_level_name, url: level_path(project_template_level)}
+          ]
+          template_level_edit_link = can_edit_level ?
+            {text: 'Edit', url: edit_level_path(project_template_level)} :
+            {text: '(Cannot edit)', url: ''}
+          links["Template Level"] << template_level_edit_link
+        else
+          links["Template Level"] = [{text: "No template level found with name \"#{project_template_level_name}\"", url: ''}]
+        end
       end
     elsif script_level
       links[@level.name] << {


### PR DESCRIPTION
Currently if a lab2 level has a template level that we can't find, the request to extra links fails. This updates the request to instead return a useful error message about the failed level load, and still return all the other extra links data. 

## Screen shot
<img width="635" height="400" alt="Screenshot 2026-02-13 at 1 57 53 PM" src="https://github.com/user-attachments/assets/452b1984-f46f-4ee2-bf93-79349ef1e76e" />

Before, the extra links button would never show up.

## Links

- Jira: [AFL-456](https://codedotorg.atlassian.net/browse/AFL-456)

## Testing story
Tested locally.

## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
