### PR TITLE
Lesson Feedback - fix bug on teacher saving side

### DIFF
--- a/apps/src/templates/studentSnapshot/lessonFeedbackWidget/LessonFeedbackWidget.tsx
+++ b/apps/src/templates/studentSnapshot/lessonFeedbackWidget/LessonFeedbackWidget.tsx
@@ -108,7 +108,7 @@ const LessonFeedbackWidget: React.FC<LessonFeedbackWidgetProps> = ({
             studentId,
             sectionId
           );
-          if (aiData && aiData.json) {
+          if (aiData && aiData.record) {
             const aiGeneratedInitialFeedbackRecord = aiData.record;
             setExistingFeedbackData(aiGeneratedInitialFeedbackRecord);
             setFeedbackText(aiGeneratedInitialFeedbackRecord.saved_feedback);

--- a/apps/src/templates/studentSnapshot/lessonFeedbackWidget/LessonFeedbackWidget.tsx
+++ b/apps/src/templates/studentSnapshot/lessonFeedbackWidget/LessonFeedbackWidget.tsx
@@ -78,7 +78,6 @@ const LessonFeedbackWidget: React.FC<LessonFeedbackWidgetProps> = ({
           );
         }
         const data = await response.json();
-        console.log('AI lesson feedback data:', data);
         return data;
       } catch (err) {
         console.error('AI lesson feedback error:', err);
@@ -101,7 +100,6 @@ const LessonFeedbackWidget: React.FC<LessonFeedbackWidgetProps> = ({
 
         if (!response.ok) {
           // Try getting AI feedback from student work.
-          // I owonder if here is where I need to clear out the "existingFeedbackData"
           const aiData = await getAiLessonFeedback(
             lessonId,
             unitId,

--- a/apps/src/templates/studentSnapshot/lessonFeedbackWidget/LessonFeedbackWidget.tsx
+++ b/apps/src/templates/studentSnapshot/lessonFeedbackWidget/LessonFeedbackWidget.tsx
@@ -78,6 +78,7 @@ const LessonFeedbackWidget: React.FC<LessonFeedbackWidgetProps> = ({
           );
         }
         const data = await response.json();
+        console.log('AI lesson feedback data:', data);
         return data;
       } catch (err) {
         console.error('AI lesson feedback error:', err);
@@ -100,6 +101,7 @@ const LessonFeedbackWidget: React.FC<LessonFeedbackWidgetProps> = ({
 
         if (!response.ok) {
           // Try getting AI feedback from student work.
+          // I owonder if here is where I need to clear out the "existingFeedbackData"
           const aiData = await getAiLessonFeedback(
             lessonId,
             unitId,
@@ -107,8 +109,9 @@ const LessonFeedbackWidget: React.FC<LessonFeedbackWidgetProps> = ({
             sectionId
           );
           if (aiData && aiData.json) {
-            const aiGeneratedInitialFeedback = JSON.parse(aiData.json).feedback;
-            setFeedbackText(aiGeneratedInitialFeedback);
+            const aiGeneratedInitialFeedbackRecord = aiData.record;
+            setExistingFeedbackData(aiGeneratedInitialFeedbackRecord);
+            setFeedbackText(aiGeneratedInitialFeedbackRecord.saved_feedback);
             setResourceData([DEFAULT_RESOURCE]);
           }
         } else {

--- a/dashboard/app/helpers/ai_student_snapshot_helper.rb
+++ b/dashboard/app/helpers/ai_student_snapshot_helper.rb
@@ -56,7 +56,7 @@ module AiStudentSnapshotHelper
       saved_record = save_lesson_feedback(feedback_string, student_id, lesson_id, section_id, teacher_id)
       return {status: evaluation[:status], record: saved_record}
     else
-      raise StandardError.new("Recieved status code #{response.code} when processing AI lesson feedback: #{response.body}")
+      raise StandardError.new("Received status code #{response.code} when processing AI lesson feedback: #{response.body}")
     end
   end
 

--- a/dashboard/app/helpers/ai_student_snapshot_helper.rb
+++ b/dashboard/app/helpers/ai_student_snapshot_helper.rb
@@ -8,6 +8,7 @@ module AiStudentSnapshotHelper
     feedback_record.section_id = section_id
     feedback_record.saved_feedback = feedback_json
     feedback_record.save!
+    feedback_record
   end
 
   API_KEY = CDO.openai_lesson_summaries_api_key # TODO before merge: CHANGE TO NEW KEY
@@ -52,8 +53,8 @@ module AiStudentSnapshotHelper
 
       feedback_json = JSON.parse(response_body)
       feedback_string = feedback_json.is_a?(Hash) ? feedback_json['feedback'] : feedback_json
-      save_lesson_feedback(feedback_string, student_id, lesson_id, section_id, teacher_id)
-      return {status: evaluation[:status], json: evaluation[:json]}
+      saved_record = save_lesson_feedback(feedback_string, student_id, lesson_id, section_id, teacher_id)
+      return {status: evaluation[:status], json: evaluation[:json], record: saved_record}
     else
       raise StandardError.new("Recieved status code #{response.code} when processing AI lesson feedback: #{response.body}")
     end

--- a/dashboard/app/helpers/ai_student_snapshot_helper.rb
+++ b/dashboard/app/helpers/ai_student_snapshot_helper.rb
@@ -54,7 +54,7 @@ module AiStudentSnapshotHelper
       feedback_json = JSON.parse(response_body)
       feedback_string = feedback_json.is_a?(Hash) ? feedback_json['feedback'] : feedback_json
       saved_record = save_lesson_feedback(feedback_string, student_id, lesson_id, section_id, teacher_id)
-      return {status: evaluation[:status], json: evaluation[:json], record: saved_record}
+      return {status: evaluation[:status], record: saved_record}
     else
       raise StandardError.new("Recieved status code #{response.code} when processing AI lesson feedback: #{response.body}")
     end


### PR DESCRIPTION
While testing out the lesson feedback, I noticed that occasionally feedback would save to the wrong location.  This was due to the fact that the state was not updating when NEW AI GENERATED feedback was being pulled, leaving old feedback to be updated where new feedback should be.  

This fixes this bug. 