### PR TITLE
Add support for user-content bucket

### DIFF
--- a/docker/developers/install-s3.sh
+++ b/docker/developers/install-s3.sh
@@ -39,6 +39,7 @@ bucket_names=(\
   "cdo-v3-files"\
   "cdo-v3-libraries"\
   "cdo-v3-sources"\
+  "org.code.localhost-studio.user-content"\
   "videos.code.org"\
 )
 

--- a/k8s/helm/templates/services/minio.yaml
+++ b/k8s/helm/templates/services/minio.yaml
@@ -109,6 +109,7 @@ spec:
               "cdo-v3-files"\
               "cdo-v3-libraries"\
               "cdo-v3-sources"\
+              "org.code.localhost-studio.user-content"\
               "videos.code.org"\
             )
 

--- a/lib/cdo.rb
+++ b/lib/cdo.rb
@@ -101,6 +101,15 @@ module Cdo
       canonical_hostname('studio.code.org')
     end
 
+    # Returns the S3 bucket name for user-generated content in the current environment.
+    # Matches the naming convention used by the CloudFormation stack (s3.yml.erb):
+    #   {reversed dashboard hostname}.user-content
+    # e.g., "org.code.studio.user-content" in production,
+    #        "org.code.staging-studio.user-content" in staging.
+    def user_content_s3_bucket
+      dashboard_hostname.split('.').reverse.join('.') + '.user-content'
+    end
+
     def pegasus_hostname
       canonical_hostname('code.org')
     end

--- a/lib/test/test_cdo.rb
+++ b/lib/test/test_cdo.rb
@@ -13,6 +13,20 @@ class CdoTest < Minitest::Test
     assert_includes CDO.curriculum_languages, "zh-tw"
   end
 
+  def test_user_content_s3_bucket
+    CDO.stubs(:dashboard_hostname).returns('studio.code.org')
+    assert_equal 'org.code.studio.user-content', CDO.user_content_s3_bucket
+
+    CDO.stubs(:dashboard_hostname).returns('staging-studio.code.org')
+    assert_equal 'org.code.staging-studio.user-content', CDO.user_content_s3_bucket
+
+    CDO.stubs(:dashboard_hostname).returns('test-studio.code.org')
+    assert_equal 'org.code.test-studio.user-content', CDO.user_content_s3_bucket
+
+    CDO.stubs(:dashboard_hostname).returns('localhost-studio.code.org')
+    assert_equal 'org.code.localhost-studio.user-content', CDO.user_content_s3_bucket
+  end
+
   def test_curriculum_url
     CDO.stubs(:curriculum_languages).returns(["es-mx"])
 


### PR DESCRIPTION
Add user-content bucket to local docker setup, and provide a function to access the bucket name in code.

## Links
<!--  Links to relevant external resources.
      - spec docs, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- Jira: 

## Testing story
<!--  Does your change include appropriate tests?
      - If so, please describe how the tests included in this PR are sufficient.
      - If not, please explain why this change does not need to be tested. -->



## Deployment strategy
<!--  Any special steps required to deploy this, besides merging?
      - Are there database migrations or manual steps?
      - Does this require coordination with other teams or systems? -->



## Follow-up work
<!--  List any clean-up or technical debt that will be addressed in future work.
      - Include Jira links where applicable.
      - Are there any known limitations or improvements planned? -->



## Privacy
<!--  How does this change impact Student & Teacher privacy?
      - Does this collect, use, share, or modify PII, either new or existing? -->



## Security
<!--  How does this change impact our security surface-area?
      - Do API's touched have the right auth?
      - Do infra changes impact our attack surface or encryption?
-->



## Caching
<!--  How does this change impact caching behavior?
      - Are cache keys or invalidation strategies affected?
      - Will this require cache warming or invalidation after deployment? -->



## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
