### PR TITLE
Fix formatting issue in web lab 2 readme

### DIFF
--- a/apps/src/weblab2/README.md
+++ b/apps/src/weblab2/README.md
@@ -3,7 +3,7 @@ Web Lab 2 allows students to make web pages using HTML, CSS and vanilla JS.
 
 ## How it works
 See the htmlPreview folder for the bulk of the display logic. There are 2 iframes that support the preview.
-The outer iframe, hosted by HTMLPreview.tsx points to <unique-project-id>.preview.codeprojects.org, 
+The outer iframe, hosted by HTMLPreview.tsx points to `<unique-project-id>.preview.codeprojects.org`, 
 which eventually routes to InnerHTMlPreview.tsx. The outer iframe sends the student code to the inner iframe via
 message passing. The inner iframe sets up a service worker (weblab2_project_service_worker), which acts as a false
 "server" for the student code. This allows file links to work as expected in a student project. The service worker


### PR DESCRIPTION
I should have put the example url in code backticks. Not doing so made the preview url look like `.preview.codeprojects.org` rather than `<unique-project-id>.preview.codeprojects.org`.



## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
