### PR TITLE
Tutor Permissions: Auto enable ai chat tools on assignment of curriculum that needs them

### DIFF
--- a/dashboard/app/controllers/api/v1/sections_controller.rb
+++ b/dashboard/app/controllers/api/v1/sections_controller.rb
@@ -70,7 +70,7 @@ class Api::V1::SectionsController < Api::V1::JSONApiController
         restrict_section: params[:restrict_section].nil? ? false : params[:restrict_section],
         avatar_color: params[:avatar_color].nil? ? 0 : params[:avatar_color],
         avatar_emoji: params[:avatar_emoji].nil? ? 0 : params[:avatar_emoji],
-        ai_chat_access_level: params[:ai_chat_access_level].nil? ? SharedConstants::AI_CHAT_ACCESS_LEVELS[:DISABLED] : params[:ai_chat_access_level],
+        ai_chat_access_level: get_ai_chat_access_level,
       }
     )
     return head :bad_request unless section.persisted?
@@ -106,6 +106,10 @@ class Api::V1::SectionsController < Api::V1::JSONApiController
       return head :forbidden unless Section.can_be_assigned_course?(participant_audience, section.participant_type)
     end
 
+    # If assigning a new course, derive the new ai_chat_access_level, otherwise leave it as-is.
+    is_updating_course = @course && @course.id != section.course_id
+    ai_chat_access_level = is_updating_course ? get_ai_chat_access_level(section.ai_chat_access_level) : params[:ai_chat_access_level]
+
     # TODO: (madelynkasula) refactor to use strong params
     fields = {}
     fields[:course_id] = @course&.id
@@ -123,7 +127,7 @@ class Api::V1::SectionsController < Api::V1::JSONApiController
     fields[:ai_tutor_enabled] = params[:ai_tutor_enabled] unless params[:ai_tutor_enabled].nil?
     fields[:avatar_color] = params[:avatar_color].nil? ? 0 : params[:avatar_color]
     fields[:avatar_emoji] = params[:avatar_emoji].nil? ? 0 : params[:avatar_emoji]
-    fields[:ai_chat_access_level] = params[:ai_chat_access_level] unless params[:ai_chat_access_level].nil?
+    fields[:ai_chat_access_level] = ai_chat_access_level unless ai_chat_access_level.nil?
 
     section.update!(fields)
     if @unit
@@ -341,5 +345,19 @@ class Api::V1::SectionsController < Api::V1::JSONApiController
       # Should not get a unit_id unless also get a course version which is course
       return head :bad_request if params[:unit_id]
     end
+  end
+
+  private def get_ai_chat_access_level(previous_access_level = nil)
+    previous_access_level ||= SharedConstants::AI_CHAT_ACCESS_LEVELS[:DISABLED]
+
+    # Leave it as is if it was already turned on or to essential_only
+    return previous_access_level if previous_access_level != SharedConstants::AI_CHAT_ACCESS_LEVELS[:DISABLED]
+
+    # Auto-enable access if the course needs it.
+    # TODO: Once pilot goes GA, we can enable for any @course&.has_ai_chat_tools?
+    return SharedConstants::AI_CHAT_ACCESS_LEVELS[:ENABLED] if @course&.requires_ai_chat_tools?
+    return SharedConstants::AI_CHAT_ACCESS_LEVELS[:ENABLED] if @course&.has_ai_chat_tools? && current_user.ai_tutor_enabled_for_pilot?
+
+    SharedConstants::AI_CHAT_ACCESS_LEVELS[:DISABLED]
   end
 end

--- a/dashboard/test/controllers/api/v1/sections_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/sections_controller_test.rb
@@ -308,6 +308,48 @@ class Api::V1::SectionsControllerTest < ActionController::TestCase
       returned_json.with_indifferent_access
   end
 
+  test 'create: enables ai_chat_access_level for courses requiring ai chat tools' do
+    sign_in @teacher
+    unit_group = create_unit_group_with_essential_ai_chat_tools
+
+    post :create, params: {
+      login_type: Section::LOGIN_TYPE_EMAIL,
+      participant_type: Curriculum::SharedCourseConstants::PARTICIPANT_AUDIENCE.student,
+      course_version_id: unit_group.course_version.id,
+    }
+
+    assert_response :success
+    assert_equal SharedConstants::AI_CHAT_ACCESS_LEVELS[:ENABLED], returned_section.ai_chat_access_level
+  end
+
+  test 'create: enables ai_chat_access_level for courses with optional ai chat tools when teacher is in pilot' do
+    sign_in @teacher
+    SingleUserExperiment.stubs(:enabled?).returns(true)
+    unit_group = create_unit_group_with_optional_ai_chat_tools
+
+    post :create, params: {
+      login_type: Section::LOGIN_TYPE_EMAIL,
+      participant_type: Curriculum::SharedCourseConstants::PARTICIPANT_AUDIENCE.student,
+      course_version_id: unit_group.course_version.id,
+    }
+
+    assert_response :success
+    assert_equal SharedConstants::AI_CHAT_ACCESS_LEVELS[:ENABLED], returned_section.ai_chat_access_level
+  end
+
+  test 'create: does not enable ai_chat_access_level for courses without ai chat tools' do
+    sign_in @teacher
+    unit_group = @csp_unit_group
+    post :create, params: {
+      login_type: Section::LOGIN_TYPE_EMAIL,
+      participant_type: Curriculum::SharedCourseConstants::PARTICIPANT_AUDIENCE.student,
+      course_version_id: unit_group.course_version.id,
+    }
+
+    assert_response :success
+    assert_equal SharedConstants::AI_CHAT_ACCESS_LEVELS[:DISABLED], returned_section.ai_chat_access_level
+  end
+
   test 'invalid params does not create section and returns an error' do
     sign_in @facilitator
 
@@ -1032,6 +1074,72 @@ class Api::V1::SectionsControllerTest < ActionController::TestCase
     assert_nil section.script_id
   end
 
+  test "update: enables ai_chat_access_level when assigning a course that requires ai chat tools" do
+    sign_in @teacher
+    unit_group = create_unit_group_with_essential_ai_chat_tools
+    section = create(:section, user: @teacher, ai_chat_access_level: SharedConstants::AI_CHAT_ACCESS_LEVELS[:DISABLED])
+
+    post :update, params: {
+      id: section.id,
+      course_version_id: unit_group.course_version.id,
+    }
+
+    assert_response :success
+    section.reload
+    assert_equal SharedConstants::AI_CHAT_ACCESS_LEVELS[:ENABLED], section.ai_chat_access_level
+  end
+
+  test "update: preserves ai_chat_access_level when already enabled and course changes" do
+    sign_in @teacher
+    unit_group = create(:unit_group, :stable)
+    CourseOffering.add_course_offering(unit_group)
+    unit_group.reload
+    section = create(:section, user: @teacher, course_id: nil, ai_chat_access_level: SharedConstants::AI_CHAT_ACCESS_LEVELS[:ENABLED])
+
+    post :update, params: {
+      id: section.id,
+      course_version_id: unit_group.course_version.id,
+    }
+
+    assert_response :success
+    section.reload
+    assert_equal SharedConstants::AI_CHAT_ACCESS_LEVELS[:ENABLED], section.ai_chat_access_level
+  end
+
+  test "update: preserves ai_chat_access_level when set to essential_only and course changes" do
+    sign_in @teacher
+    unit_group = create(:unit_group, :stable)
+    CourseOffering.add_course_offering(unit_group)
+    unit_group.reload
+    section = create(:section, user: @teacher, course_id: nil, ai_chat_access_level: SharedConstants::AI_CHAT_ACCESS_LEVELS[:ESSENTIAL_ONLY])
+
+    post :update, params: {
+      id: section.id,
+      course_version_id: unit_group.course_version.id,
+    }
+
+    assert_response :success
+    section.reload
+    assert_equal SharedConstants::AI_CHAT_ACCESS_LEVELS[:ESSENTIAL_ONLY], section.ai_chat_access_level
+  end
+
+  test "update: preserves ai_chat_access_level when course does not change" do
+    sign_in @teacher
+    unit_group = create(:unit_group, :stable)
+    CourseOffering.add_course_offering(unit_group)
+    unit_group.reload
+    section = create(:section, user: @teacher, course_id: unit_group.id, ai_chat_access_level: SharedConstants::AI_CHAT_ACCESS_LEVELS[:DISABLED])
+
+    post :update, params: {
+      id: section.id,
+      course_version_id: unit_group.course_version.id,
+    }
+
+    assert_response :success
+    section.reload
+    assert_equal SharedConstants::AI_CHAT_ACCESS_LEVELS[:DISABLED], section.ai_chat_access_level
+  end
+
   test "update: course_id is not updated if invalid" do
     UnitGroup.stubs(:course_assignable?).returns(false)
 
@@ -1596,5 +1704,27 @@ class Api::V1::SectionsControllerTest < ActionController::TestCase
     create(:code_review_group_member, follower: @followers[0], code_review_group: @group1)
     create(:code_review_group_member, follower: @followers[1], code_review_group: @group1)
     create(:code_review_group_member, follower: @followers[2], code_review_group: @group2)
+  end
+
+  private def create_unit_group_with_essential_ai_chat_tools
+    unit = create(:unit, :with_lessons, lessons_count: 1)
+    lesson = unit.lessons.first
+    activity_section = lesson.activity_sections.first
+    create(:script_level, levels: [create(:aichat)], activity_section: activity_section)
+    unit_group = create(:unit_group, :stable)
+    create(:unit_group_unit, unit_group: unit_group, script: unit, position: 1)
+    CourseOffering.add_course_offering(unit_group)
+    unit_group.reload
+    unit_group
+  end
+
+  private def create_unit_group_with_optional_ai_chat_tools
+    unit = create(:unit, :with_levels, lessons_count: 1, levels_count: 1)
+    unit.levels.first.update!(ai_tutor_available: true)
+    unit_group = create(:unit_group, :stable)
+    create(:unit_group_unit, unit_group: unit_group, script: unit, position: 1)
+    CourseOffering.add_course_offering(unit_group)
+    unit_group.reload
+    unit_group
   end
 end


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

This PR auto-enables the section property ai_chat_access_level on section creation and re-assignment based on the assigned curriculum. If the teacher has previously set this value to a non-disabled state, we leave it be (in accordance with [this flow-chart](https://www.figma.com/board/47n4NNAkS9lV2KbKhPiJSp/AI-Tutor-Permissions-Dumplink?node-id=2105-283&t=sQNCV7XGjHP7LDjq-4)) and if the curriculum has AI Chat Tools available (and are in the tutor pilot) or requires them, we enable them.

We have alerts (that are behind an experiment currently) on our section creation and assignment UI to warn teachers that we will do this, letting them know that assigning the section is consenting to enabling the tools, and giving information about how to control the settings.

## Links
<!--  Links to relevant external resources.
      - spec docs, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- [task](https://www.figma.com/board/47n4NNAkS9lV2KbKhPiJSp/AI-Tutor-Permissions-Dumplink?node-id=2006-100&t=sQNCV7XGjHP7LDjq-4)
- [pilot related task](https://www.figma.com/board/47n4NNAkS9lV2KbKhPiJSp/AI-Tutor-Permissions-Dumplink?node-id=2186-243&t=sQNCV7XGjHP7LDjq-4)
- [flow-chart for re-assignment logic](https://www.figma.com/board/47n4NNAkS9lV2KbKhPiJSp/AI-Tutor-Permissions-Dumplink?node-id=2105-283&t=sQNCV7XGjHP7LDjq-4)

## Testing story
<!--  Does your change include appropriate tests?
      - If so, please describe how the tests included in this PR are sufficient.
      - If not, please explain why this change does not need to be tested. -->

 - UTs
 - Did the following manual tests
   - [x] test creating a section without assigning - disabled
   - [x] test creating a section and assigning non-ai - disabled
   - [x] test creating a section and assigning ai - enabled
   - [x] test creating a section with optional ai (csd) while not in the pilot - disabled
   - [x] test creating a section with option ai (csd) while in the pilot - enabled
   - [x] assigning csd to an existing section with chat tools disabled while in the pilot - enabled
   - [x] test re-assigning from each scenario
     - [x] from section with no assignment
     - [x] with ai to no ai - no change
     - [x] without ai to ai - enabled 
   - [x] test re-assigning from essential_only
   - [x] test updating a section without changing curriculum assigned (especially after assigning ai and disabling it)


## Deployment strategy
<!--  Any special steps required to deploy this, besides merging?
      - Are there database migrations or manual steps?
      - Does this require coordination with other teams or systems? -->

This functionality is not behind an experiment, but the ai_chat_access_level property on sections does not yet have any affect on students' access to AI Chat Tools. This is part of a staged deploy. The next step will be a batch job to enable ai_chat_access_level on all relevant existing sections, followed by full deployment of the Permissions feature. This is to avoid any current students losing access to the tools when Permissions go live.

## Follow-up work
<!--  List any clean-up or technical debt that will be addressed in future work.
      - Include Jira links where applicable.
      - Are there any known limitations or improvements planned? -->

 - batch migration to enable ai_chat_access_level on existing sections
 - apply permissions behind the experiment on all student facing chat tools UI
 - final testing and removal of the experiment


