### PR TITLE
Web Lab 2: Instructions drawer's max height is dynamically determined

### DIFF
--- a/apps/src/lab2/views/components/Instructions/ResourcePanel/AiTutorChatWithInstructionDrawer.tsx
+++ b/apps/src/lab2/views/components/Instructions/ResourcePanel/AiTutorChatWithInstructionDrawer.tsx
@@ -51,6 +51,9 @@ const AiTutorChatWithInstructionDrawer: React.FunctionComponent<
   const containerRef = useRef<HTMLDivElement>(null);
   const instructionsContentRef = useRef<HTMLDivElement>(null);
   const instructionsHeightAtDragStartRef = useRef<number | null>(null);
+  const rawInstructionsHeightRef = useRef<number>(
+    DEFAULT_INITIAL_INSTRUCTIONS_HEIGHT
+  );
   const [chatHeight, setChatHeight] = useState<number | undefined>(undefined);
   const [instructionsHeight, setInstructionsHeight] = useState<
     number | undefined
@@ -139,6 +142,11 @@ const AiTutorChatWithInstructionDrawer: React.FunctionComponent<
     setIsCollapsed(isCollapsedByDefault);
   }, [isCollapsedByDefault]);
 
+  // Keep ref in sync with current height.
+  useEffect(() => {
+    rawInstructionsHeightRef.current = rawInstructionsHeight;
+  }, [rawInstructionsHeight]);
+
   // Measure the instructions content height and update when content change
   // (e.g., details elements are expanded/collapsed).
   useEffect(() => {
@@ -154,10 +162,17 @@ const AiTutorChatWithInstructionDrawer: React.FunctionComponent<
 
     const updateMaxHeight = () => {
       const contentHeight = instructionsContentElement.scrollHeight;
+      const currentHeight = rawInstructionsHeightRef.current;
+
       setMaxInstructionsHeight(contentHeight);
 
+      // Auto-adjust drawer height when new content height is less than the current drawer height.
+      // This will remove a gap between instructions and drawer's edge.
+      if (contentHeight < currentHeight) {
+        setRawInstructionsHeight(contentHeight);
+      }
       // If content is smaller than initial height, adjust to fit content.
-      if (contentHeight < DEFAULT_INITIAL_INSTRUCTIONS_HEIGHT) {
+      else if (contentHeight < DEFAULT_INITIAL_INSTRUCTIONS_HEIGHT) {
         setRawInstructionsHeight(contentHeight);
       }
     };

--- a/apps/src/lab2/views/components/Instructions/ResourcePanel/AiTutorChatWithInstructionDrawer.tsx
+++ b/apps/src/lab2/views/components/Instructions/ResourcePanel/AiTutorChatWithInstructionDrawer.tsx
@@ -139,22 +139,42 @@ const AiTutorChatWithInstructionDrawer: React.FunctionComponent<
     setIsCollapsed(isCollapsedByDefault);
   }, [isCollapsedByDefault]);
 
-  // Measure the instructions content height once when loaded
-  // and adjust the initial height if content is smaller.
+  // Measure the instructions content height and update when content change
+  // (e.g., details elements are expanded/collapsed).
   useEffect(() => {
+    // Skip if instructions drawer is collapsed (unmounted).
+    if (isCollapsed) {
+      return;
+    }
+
     const instructionsContentElement = instructionsContentRef.current;
     if (!instructionsContentElement) {
       return;
     }
 
-    const contentHeight = instructionsContentElement.scrollHeight;
-    setMaxInstructionsHeight(contentHeight);
+    const updateMaxHeight = () => {
+      const contentHeight = instructionsContentElement.scrollHeight;
+      setMaxInstructionsHeight(contentHeight);
 
-    // If content is smaller than initial height, adjust to fit content.
-    if (contentHeight < DEFAULT_INITIAL_INSTRUCTIONS_HEIGHT) {
-      setRawInstructionsHeight(contentHeight);
-    }
-  }, [instructionsContent, setRawInstructionsHeight]);
+      // If content is smaller than initial height, adjust to fit content.
+      if (contentHeight < DEFAULT_INITIAL_INSTRUCTIONS_HEIGHT) {
+        setRawInstructionsHeight(contentHeight);
+      }
+    };
+
+    updateMaxHeight();
+
+    // Watch for size changes (e.g., when details elements expand/collapse).
+    const resizeObserver = new ResizeObserver(() => {
+      updateMaxHeight();
+    });
+
+    resizeObserver.observe(instructionsContentElement);
+
+    return () => {
+      resizeObserver.disconnect();
+    };
+  }, [instructionsContent, setRawInstructionsHeight, isCollapsed]);
 
   const toggleInstructions = useCallback(() => {
     const eventToReport = isCollapsed


### PR DESCRIPTION
Currently in Web Lab 2, the instructions drawer has a max height determined by the instructions content so that a user cannot drag the border between instructions and AI tutor past this height.

However, if the instructions contains a details section and expands the contents, the max height is not re-computed.
This PR adds a resize observer to the instructions content so that if a user expands a details section, the max height is re-computed so that the drawer can be expanded to a larger height.

## Before update

https://github.com/user-attachments/assets/1a7aa5cd-0b68-4b9c-89ab-849ef64c9702


## After update

https://github.com/user-attachments/assets/14518a0e-49c5-40c9-89e2-6851be56b997




<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->



## Links
<!--  Links to relevant external resources.
      - spec docs, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- Jira: https://codedotorg.atlassian.net/browse/AFL-470

## Testing story
<!--  Does your change include appropriate tests?
      - If so, please describe how the tests included in this PR are sufficient.
      - If not, please explain why this change does not need to be tested. -->

Tested on `weblab2` levels with `details` sections. Example: '/courses/artificial-intelligence-foundations-semester2-2025/units/1/lessons/6/levels/4'


## Deployment strategy
<!--  Any special steps required to deploy this, besides merging?
      - Are there database migrations or manual steps?
      - Does this require coordination with other teams or systems? -->



## Follow-up work
<!--  List any clean-up or technical debt that will be addressed in future work.
      - Include Jira links where applicable.
      - Are there any known limitations or improvements planned? -->



## Privacy
<!--  How does this change impact Student & Teacher privacy?
      - Does this collect, use, share, or modify PII, either new or existing? -->



## Security
<!--  How does this change impact our security surface-area?
      - Do API's touched have the right auth?
      - Do infra changes impact our attack surface or encryption?
-->



## Caching
<!--  How does this change impact caching behavior?
      - Are cache keys or invalidation strategies affected?
      - Will this require cache warming or invalidation after deployment? -->



## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
