### PR TITLE
Remove Music Lab amplitude reporting

### DIFF
--- a/apps/src/music/MusicRegistry.ts
+++ b/apps/src/music/MusicRegistry.ts
@@ -1,4 +1,4 @@
-import AnalyticsReporter from './analytics/AnalyticsReporter';
+import MusicAnalyticsReporter from './analytics/AnalyticsReporter';
 import MusicPlayer from './player/MusicPlayer';
 
 /**
@@ -8,7 +8,7 @@ import MusicPlayer from './player/MusicPlayer';
  */
 class MusicRegistry {
   private playerRef: MusicPlayer | null = null;
-  private analyticsReporterRef: AnalyticsReporter | null = null;
+  private analyticsReporterRef: MusicAnalyticsReporter | null = null;
 
   public showSoundFilters: boolean = false;
   public showSoundsPanelInSoundsMode: boolean = false;
@@ -28,14 +28,14 @@ class MusicRegistry {
     this.playerRef = player;
   }
 
-  public get analyticsReporter(): AnalyticsReporter {
+  public get analyticsReporter(): MusicAnalyticsReporter {
     if (!this.analyticsReporterRef) {
       throw new Error('AnalyticsReporter not set in MusicRegistry');
     }
     return this.analyticsReporterRef;
   }
 
-  public set analyticsReporter(analyticsReporter: AnalyticsReporter) {
+  public set analyticsReporter(analyticsReporter: MusicAnalyticsReporter) {
     this.analyticsReporterRef = analyticsReporter;
   }
 }

--- a/apps/src/music/analytics/AnalyticsReporter.ts
+++ b/apps/src/music/analytics/AnalyticsReporter.ts
@@ -1,32 +1,11 @@
-import {
-  init,
-  track,
-  Identify,
-  identify,
-  setSessionId,
-  flush,
-  setUserId,
-} from '@amplitude/analytics-browser';
 import * as BlocklyCore from 'blockly/core';
 
 import DCDO from '@cdo/apps/dcdo';
-import Lab2Registry from '@cdo/apps/lab2/Lab2Registry';
-// We are transitioning off of a standalone Amplitude project for Music Lab
-// and onto Code.org's main Statsig project.
-// In the short term, we log to both projects to establish parity between the two logging systems.
-import {PLATFORMS} from '@cdo/apps/metrics/AnalyticsConstants';
-import cdoAnalyticsReporter from '@cdo/apps/metrics/AnalyticsReporter';
+import AnalyticsReporter from '@cdo/apps/metrics/AnalyticsReporter';
 import trackEvent from '@cdo/apps/util/trackEvent';
-import {
-  getEnvironment,
-  isDevelopmentEnvironment,
-  isProductionEnvironment,
-} from '@cdo/apps/utils';
 
 import {BlockTypes} from '../blockly/blockTypes';
 import {FIELD_SOUNDS_NAME} from '../blockly/constants';
-
-const API_KEY_ENDPOINT = '/musiclab/analytics_key';
 
 const blockFeatureList = [
   BlockTypes.FOR_LOOP,
@@ -84,104 +63,36 @@ interface ProjectContext {
 }
 
 /**
- * An analytics reporter specifically used for the Music Lab prototype, which logs analytics
- * to Amplitude. For the more general Amplitude Analytics Reporter used across the application
- * outside of Music Lab, check {@link apps/src/metrics/AnalyticsReporter}.
+ * An analytics reporter specifically used for Music Lab, which tracks Music Lab-specific
+ * session information and forwards events to the global Code.org {@link AnalyticsReporter}.
  */
-export default class AnalyticsReporter {
-  private static initialized = false;
-
-  /**
-   * Temporarily available as a public static method so this reporter can be used outside of the
-   * context of Music Lab, specifically for Panels levels in 2024 Hour of Code progression.
-   * TODO: Remove/consolidate reporters after HOC 2024.
-   */
-  public static async initialize() {
-    if (AnalyticsReporter.initialized) {
-      return;
-    }
-
-    const response = await fetch(API_KEY_ENDPOINT);
-    const responseJson = await response.json();
-
-    if (!responseJson.key) {
-      throw new Error('No key for analytics.');
-    }
-
-    AnalyticsReporter.initialized = true;
-    init(responseJson.key);
-  }
-
+export default class MusicAnalyticsReporter {
   private session: Session | undefined;
   private projectContext: ProjectContext | undefined;
-  private startInProgress: boolean = false;
 
-  async startSession() {
-    // If a session is already in the process of starting, do not start another.
-    if (this.startInProgress) {
-      return;
-    }
-    this.startInProgress = true;
-    // Capture start time before making init call
+  startSession() {
     const startTime = Date.now();
 
-    try {
-      await AnalyticsReporter.initialize();
-      this.session = {
-        startTime,
-        soundsUsed: new Set(),
-        soundsPlayed: {},
-        blockStats: {
-          endingBlockCount: 0,
-          endingTriggerBlockCount: 0,
-          endingTriggerBlocksWithCode: 0,
-          maxBlockCount: 0,
-          maxTriggerBlockCount: 0,
-          maxTriggerBlocksWithCode: 0,
-        },
-        featuresUsed: {},
-      };
-      setSessionId(this.session.startTime);
-      this.log(`Session start. Session ID: ${this.session.startTime}`);
-    } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
-      this.log(`Did not initialize analytics reporter.  (${message})`);
-
-      // Log an error if this is not development. On development, this error is expected.
-      if (!isDevelopmentEnvironment()) {
-        Lab2Registry.getInstance()
-          .getMetricsReporter()
-          .logError(message, error as Error);
-      }
-    }
-
+    this.session = {
+      startTime,
+      soundsUsed: new Set(),
+      soundsPlayed: {},
+      blockStats: {
+        endingBlockCount: 0,
+        endingTriggerBlockCount: 0,
+        endingTriggerBlocksWithCode: 0,
+        maxBlockCount: 0,
+        maxTriggerBlockCount: 0,
+        maxTriggerBlocksWithCode: 0,
+      },
+      featuresUsed: {},
+    };
+    this.log(`Session start. Start time: ${this.session.startTime}`);
     trackEvent('music', 'music_session_start');
-    this.startInProgress = false;
   }
 
   isSessionInProgress() {
     return !!this.session;
-  }
-
-  setUserProperties(userId: number, userType: string, signInState: string) {
-    if (!this.session) {
-      this.log('No session in progress');
-      return;
-    }
-
-    if (userId) {
-      setUserId(this.formatUserId(userId));
-    }
-
-    const identifyEvent = new Identify();
-    identifyEvent.set('userType', userType);
-    identifyEvent.set('signInState', signInState);
-
-    identify(identifyEvent);
-
-    this.log(
-      `User properties: userId: ${userId}, userType: ${userType}, signInState: ${signInState}`
-    );
   }
 
   setProjectProperty<K extends keyof ProjectContext>(
@@ -193,20 +104,10 @@ export default class AnalyticsReporter {
       return;
     }
 
-    // For Statsig
     if (!this.projectContext) {
       this.projectContext = {};
     }
     this.projectContext[property] = value;
-
-    // For Amplitude
-    const identifyEvent = new Identify();
-    if (value) {
-      identifyEvent.set(property, value);
-    } else {
-      identifyEvent.unset(property);
-    }
-    identify(identifyEvent);
 
     this.log(`Project property: ${property}: ${value}`);
   }
@@ -272,8 +173,7 @@ export default class AnalyticsReporter {
       this.log(logMessage);
     }
 
-    this.sendStatsigEvent(eventType, payload);
-    track(eventType, payload).promise;
+    this.sendEvent(eventType, payload);
   }
 
   onSoundPlayed(id: string) {
@@ -353,40 +253,19 @@ export default class AnalyticsReporter {
 
     this.session = undefined;
 
-    this.sendStatsigEvent('Session end', payload);
-    track('Session end', payload);
-    flush();
+    this.sendEvent('Session end', payload);
 
     this.log(`Session end. Payload: ${JSON.stringify(payload)}`);
   }
 
   log(message: string) {
-    console.log(`[MUSIC AMPLITUDE ANALYTICS EVENT]: ${message}`);
+    console.log(`[MUSIC ANALYTICS EVENT]: ${message}`);
   }
 
-  private formatUserId(userId: number) {
-    if (!userId) {
-      return 'none';
-    }
-    const userIdString = userId.toString();
-    if (isProductionEnvironment()) {
-      return userIdString.padStart(5, '0');
-    } else {
-      const environment = getEnvironment();
-      return `${environment}-${userIdString}`;
-    }
-  }
-
-  private sendStatsigEvent(eventName: string, payload: object) {
-    // We include project properties as part of the event payload rather than as user properties in Statsig.
-    const combinedPayload = this.projectContext
-      ? {...payload, ...this.projectContext}
-      : payload;
-
-    cdoAnalyticsReporter.sendEvent(
-      `Music Lab ${eventName}`,
-      combinedPayload,
-      PLATFORMS.STATSIG
-    );
+  private sendEvent(eventName: string, payload: object) {
+    AnalyticsReporter.sendEvent(`Music Lab ${eventName}`, {
+      ...payload,
+      ...this.projectContext,
+    });
   }
 }

--- a/apps/src/music/context.ts
+++ b/apps/src/music/context.ts
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import AnalyticsReporter from './analytics/AnalyticsReporter';
+import MusicAnalyticsReporter from './analytics/AnalyticsReporter';
 
 /** Provides access to the Analytics reporter object */
-export const AnalyticsContext: React.Context<AnalyticsReporter | null> =
-  React.createContext<AnalyticsReporter | null>(null);
+export const AnalyticsContext: React.Context<MusicAnalyticsReporter | null> =
+  React.createContext<MusicAnalyticsReporter | null>(null);

--- a/apps/src/music/player/MusicPlayer.ts
+++ b/apps/src/music/player/MusicPlayer.ts
@@ -1,6 +1,6 @@
 import LabMetricsReporter from '@cdo/apps/lab2/Lab2MetricsReporter';
 import Lab2Registry from '@cdo/apps/lab2/Lab2Registry';
-import AnalyticsReporter from '@cdo/apps/music/analytics/AnalyticsReporter';
+import MusicAnalyticsReporter from '@cdo/apps/music/analytics/AnalyticsReporter';
 
 import {DEFAULT_CHORD_LENGTH, MIN_BPM, MAX_BPM} from '../constants';
 import {LoadFinishedCallback, UpdateLoadProgressCallback} from '../types';
@@ -47,7 +47,7 @@ const DEFAULT_KEY = Key.C;
  */
 export default class MusicPlayer {
   private readonly metricsReporter: LabMetricsReporter;
-  private readonly analyticsReporter: AnalyticsReporter | undefined;
+  private readonly analyticsReporter: MusicAnalyticsReporter | undefined;
   private readonly audioPlayer: ToneJSPlayer;
   private updateLoadProgress: UpdateLoadProgressCallback | undefined;
 
@@ -61,7 +61,7 @@ export default class MusicPlayer {
   constructor(
     bpm: number = DEFAULT_BPM,
     key: Key = DEFAULT_KEY,
-    analyticsReporter?: AnalyticsReporter | undefined,
+    analyticsReporter?: MusicAnalyticsReporter | undefined,
     audioPlayer?: ToneJSPlayer,
     metricsReporter: LabMetricsReporter = Lab2Registry.getInstance().getMetricsReporter()
   ) {

--- a/apps/src/music/views/MiniMusicPlayer.tsx
+++ b/apps/src/music/views/MiniMusicPlayer.tsx
@@ -2,9 +2,8 @@ import FontAwesomeV6Icon from '@code-dot-org/component-library/fontAwesomeV6Icon
 import classNames from 'classnames';
 import React, {useCallback, useEffect, useRef, useState} from 'react';
 
-import AnalyticsReporter from '@cdo/apps/music/analytics/AnalyticsReporter';
+import MusicAnalyticsReporter from '@cdo/apps/music/analytics/AnalyticsReporter';
 import {ValueOf} from '@cdo/apps/types/utils';
-import {useAppSelector} from '@cdo/apps/util/reduxHooks';
 
 import Lab2Registry from '../../lab2/Lab2Registry';
 import {SourcesStore} from '../../lab2/projects/SourcesStore';
@@ -36,13 +35,12 @@ const MiniPlayerView: React.FunctionComponent<MiniPlayerViewProps> = ({
   );
 
   const sourcesStoreRef = useRef<SourcesStore>(new SourcesStore());
-  const analyticsReporter = useRef<AnalyticsReporter>(new AnalyticsReporter());
+  const analyticsReporter = useRef<MusicAnalyticsReporter>(
+    new MusicAnalyticsReporter()
+  );
   const [isLoading, setIsLoading] = useState(true);
   const [currentProjectId, setCurrentProjectId] = useState<string | undefined>(
     undefined
-  );
-  const {userId, userType, signInState} = useAppSelector(
-    state => state.currentUser
   );
 
   // Setup library and workspace, and analyticsReporter on mount
@@ -51,16 +49,12 @@ const MiniPlayerView: React.FunctionComponent<MiniPlayerViewProps> = ({
     workspaceRef.current.initHeadless();
     await MusicLibrary.loadLibrary(libraryName);
     setIsLoading(false);
-    await analyticsReporter.current.startSession();
+    analyticsReporter.current.startSession();
   }, [analyticsReporter, libraryName]);
 
   useEffect(() => {
     onMount();
   }, [onMount]);
-
-  useEffect(() => {
-    analyticsReporter.current.setUserProperties(userId, userType, signInState);
-  }, [userId, userType, signInState]);
 
   // This is the main function that is called when a song is played in the mini player
   // Loads code from the server, compiles the song, executes it to generate events,

--- a/apps/src/music/views/MusicLabView.tsx
+++ b/apps/src/music/views/MusicLabView.tsx
@@ -30,7 +30,7 @@ import WorkspaceHeader from '@cdo/apps/lab2/views/components/WorkspaceHeader';
 import {DialogType, useDialogControl} from '@cdo/apps/lab2/views/dialogs';
 import {useAppDispatch, useAppSelector} from '@cdo/apps/util/reduxHooks';
 
-import AnalyticsReporter from '../analytics/AnalyticsReporter';
+import MusicAnalyticsReporter from '../analytics/AnalyticsReporter';
 import AppConfig from '../appConfig';
 import {installFunctionBlocks} from '../blockly/blockUtils';
 import MusicBlocklyWorkspace from '../blockly/MusicBlocklyWorkspace';
@@ -77,7 +77,7 @@ interface MusicLabViewProps {
   validator: MusicValidator;
   player: MusicPlayer;
   allowPackSelection: boolean;
-  analyticsReporter: AnalyticsReporter;
+  analyticsReporter: MusicAnalyticsReporter;
   blocklyWorkspace: MusicBlocklyWorkspace;
   exemplarPlaybackEvents: PlaybackEvent[];
   executeCode: (code: string) => void;

--- a/apps/src/music/views/MusicView.jsx
+++ b/apps/src/music/views/MusicView.jsx
@@ -24,7 +24,7 @@ import {
 } from '@cdo/apps/lab2/projects/utils';
 import {isReadOnlyWorkspace} from '@cdo/apps/lab2/redux/lab2ReduxSelectors';
 import {LifecycleEvent} from '@cdo/apps/lab2/utils/LifecycleNotifier';
-import AnalyticsReporter from '@cdo/apps/music/analytics/AnalyticsReporter';
+import MusicAnalyticsReporter from '@cdo/apps/music/analytics/AnalyticsReporter';
 import {setExtraCopyrightContent} from '@cdo/apps/sharedComponents/footer/CopyrightDialog/index';
 import {SignInState} from '@cdo/apps/templates/currentUserRedux';
 import {LevelStatus} from '@cdo/generated-scripts/sharedConstants';
@@ -151,7 +151,7 @@ class UnconnectedMusicView extends React.Component {
 
     const bpm = AppConfig.getValue('bpm');
     const key = AppConfig.getValue('key');
-    this.analyticsReporter = new AnalyticsReporter();
+    this.analyticsReporter = new MusicAnalyticsReporter();
     this.player = new MusicPlayer(
       bpm,
       key && Key[key.toUpperCase()],

--- a/apps/src/music/views/hooks/useUpdateAnalytics.ts
+++ b/apps/src/music/views/hooks/useUpdateAnalytics.ts
@@ -7,14 +7,14 @@ import {Channel, LevelProperties} from '@cdo/apps/lab2/types';
 import {LifecycleEvent} from '@cdo/apps/lab2/utils/LifecycleNotifier';
 import {useAppSelector} from '@cdo/apps/util/reduxHooks';
 
-import AnalyticsReporter from '../../analytics/AnalyticsReporter';
+import MusicAnalyticsReporter from '../../analytics/AnalyticsReporter';
 
 /**
- * A hook for updating the {@link AnalyticsReporter} when relevant redux state changes and attaching callbacks
+ * A hook for updating the {@link MusicAnalyticsReporter} when relevant redux state changes and attaching callbacks
  * to browser and lifecycle events.
  */
 function useUpdateAnalytics(
-  analyticsReporter: AnalyticsReporter,
+  analyticsReporter: MusicAnalyticsReporter,
   isProjectLevel: boolean,
   channelId?: string
 ) {
@@ -27,7 +27,7 @@ function useUpdateAnalytics(
   useEffect(() => {
     analyticsReporter.startSession();
 
-    const startSession = async (
+    const startSession = (
       levelProperties: LevelProperties,
       channel: Channel | undefined
     ) => {
@@ -35,7 +35,7 @@ function useUpdateAnalytics(
         return;
       }
 
-      await analyticsReporter.startSession();
+      analyticsReporter.startSession();
       analyticsReporter.setProjectProperty(
         'levelType',
         levelProperties.isProjectLevel ? 'Standalone Project' : 'Level'
@@ -88,16 +88,6 @@ function useUpdateAnalytics(
   }, [analyticsReporter]);
 
   const sessionInProgress = analyticsReporter.isSessionInProgress();
-
-  // Update user and project properties whenever they change.
-
-  const {userId, userType, signInState} = useAppSelector(
-    state => state.currentUser
-  );
-  useEffect(() => {
-    sessionInProgress &&
-      analyticsReporter.setUserProperties(userId, userType, signInState);
-  }, [analyticsReporter, sessionInProgress, userId, userType, signInState]);
 
   useEffect(() => {
     sessionInProgress &&

--- a/apps/src/panels/PanelsLabView.tsx
+++ b/apps/src/panels/PanelsLabView.tsx
@@ -3,12 +3,6 @@
 // This is a React client for a panels level.  Note that this is
 // only used for levels that use Lab2.
 
-import {
-  Identify,
-  identify,
-  setSessionId,
-  track,
-} from '@amplitude/analytics-browser';
 import React, {useCallback, useEffect, useRef} from 'react';
 
 import continueOrFinishLesson from '@cdo/apps/lab2/progress/continueOrFinishLesson';
@@ -16,57 +10,21 @@ import {useDialogControl, DialogType} from '@cdo/apps/lab2/views/dialogs';
 import {useAppDispatch, useAppSelector} from '@cdo/apps/util/reduxHooks';
 
 import {sendSuccessReport} from '../code-studio/progressRedux';
-import {getCurrentLevel} from '../code-studio/progressReduxSelectors';
 import {queryParams} from '../code-studio/utils';
 import useLifecycleNotifier from '../lab2/hooks/useLifecycleNotifier';
 import {LabProps} from '../lab2/types';
 import {LifecycleEvent} from '../lab2/utils';
 import analyticsReporter from '../metrics/AnalyticsReporter';
-import MusicAnalyticsReporter from '../music/analytics/AnalyticsReporter';
 import useWindowSize from '../util/hooks/useWindowSize';
 
 import PanelsView from './PanelsView';
 import {PanelsLevelProperties} from './types';
-
-// Only use the soon-to-be-deprecated Amplitude analytics reporter for specific scripts.
-// TODO: remove this special case after migration.
-const AMPLITUDE_SCRIPT_NAMES = ['music-jam-2024', 'pilot-elem-music-lab'];
-function shouldUseAmplitude() {
-  return AMPLITUDE_SCRIPT_NAMES.some(name =>
-    window.location.pathname.includes(name)
-  );
-}
-const resetAnalyticsSession = () => {
-  if (shouldUseAmplitude()) {
-    setSessionId(Date.now());
-  }
-};
 
 const sendAnalyticsEvent = async (event: string, data?: object) => {
   analyticsReporter.sendEvent(event, {
     ...data,
     levelPath: window.location.pathname,
   });
-
-  if (shouldUseAmplitude()) {
-    // We use the Music Analytics reporter so that analytics for the
-    // HOC progression are reported to the same project, and to avoid
-    // API key issues.
-    try {
-      await MusicAnalyticsReporter.initialize();
-      track(event, data);
-    } catch (error) {
-      // Expected on local environments.
-      console.warn(error);
-    }
-  }
-};
-const updateAnalyticsProperty = (key: string, value: string) => {
-  if (shouldUseAmplitude()) {
-    const identifyEvent = new Identify();
-    identifyEvent.set(key, value);
-    identify(identifyEvent);
-  }
 };
 
 const PanelsLabView: React.FunctionComponent<
@@ -108,7 +66,6 @@ const PanelsLabView: React.FunctionComponent<
 
   const startTime = useRef<number | null>(null);
   useEffect(() => {
-    resetAnalyticsSession();
     sendAnalyticsEvent('Panels Level Started');
     startTime.current = Date.now();
   }, [panels]);
@@ -149,11 +106,6 @@ const PanelsLabView: React.FunctionComponent<
       timeSpentOnPanelSeconds,
     });
   };
-
-  const levelPath = useAppSelector(state => getCurrentLevel(state)?.path);
-  useEffect(() => {
-    updateAnalyticsProperty('levelPath', levelPath);
-  }, [levelPath]);
 
   const [windowWidth, windowHeight] = useWindowSize();
 

--- a/config.yml.erb
+++ b/config.yml.erb
@@ -632,10 +632,6 @@ open_weather_api_key: !Secret
 use_localhost_javabuilder:
 local_javabuilder_stack_name:
 
-# Amplitude keys
-
-# Music lab key
-amplitude_api_key: !Secret
 # General CDO key
 cdo_amplitude_api_key:
 

--- a/dashboard/app/controllers/musiclab_controller.rb
+++ b/dashboard/app/controllers/musiclab_controller.rb
@@ -1,5 +1,4 @@
 class MusiclabController < ApplicationController
-  ANALYTICS_KEY = CDO.amplitude_api_key
   # The hard-coded list of channel IDs for the mini player if the 'get_channel_ids_from_featured_projects_gallery'
   # DCDO flag is set to `false`. If the DCDO flag is set to `true`, then the channel IDs are randomly selected from
   # the set of active music lab featured projects. See get_selected_channel_ids below.
@@ -42,18 +41,6 @@ class MusiclabController < ApplicationController
     selected_channel_ids = get_selected_channel_ids(params[:channels], params[:count])
 
     @projects = get_project_details(selected_channel_ids)
-  end
-
-  # TODO: This is a temporary addition to serve the analytics API key
-  # specifically for Music Lab. When we start using Amplitude for other
-  # applications, we should create a dedicated controller/util that serves
-  # API keys for various analytics projects, not just Music Lab.
-  # We may also need to move the Amplitude analytics reporting
-  # client to the back-end to avoid exposing keys (as we are currently).
-
-  # GET /musiclab/analytics_key
-  def get_analytics_key
-    render(json: {key: ANALYTICS_KEY})
   end
 
   private def get_selected_channel_ids(channels_param = nil, count = nil)


### PR DESCRIPTION
Removes all Amplitude reporting from Music Lab, including the API key controller action, now that we've moved onto our new analytics platform Statsig. I also renamed the class to `MusicAnalyticsReporter` to help differentiate from our global `AnalyticsReporter.js`

Statsig dashboard for reference - all events published as expected on 2/17:
<img width="1491" height="809" alt="Screenshot 2026-02-17 at 10 49 01 AM" src="https://github.com/user-attachments/assets/a097db86-1ddf-4b18-8fc4-5eedd26b31d5" />

In comparison to Amplitude dashboard - no events published for the same time frame.
<img width="1493" height="809" alt="Screenshot 2026-02-17 at 10 49 31 AM" src="https://github.com/user-attachments/assets/463605ac-6420-491c-bc35-e96478d3ae2b" />

## Testing story
Tested locally and manually verified events in both Statsig and Amplitude. Confirmed that no events are forwarded to Amplitude, and all events still show up in Statsig as expected.