### PR TITLE
Web lab 2: make debug panel resizable and closeable

### DIFF
--- a/apps/src/weblab2/debugPanel/DebugPanel.tsx
+++ b/apps/src/weblab2/debugPanel/DebugPanel.tsx
@@ -1,3 +1,4 @@
+import CloseButton from '@code-dot-org/component-library/closeButton';
 import FontAwesomeV6Icon from '@code-dot-org/component-library/fontAwesomeV6Icon';
 import {
   BodyFourText,
@@ -7,11 +8,12 @@ import {
 import React, {useEffect, useMemo} from 'react';
 
 import PanelContainer from '@cdo/apps/lab2/views/components/PanelContainer';
-import {useAppSelector} from '@cdo/apps/util/reduxHooks';
+import {useAppDispatch, useAppSelector} from '@cdo/apps/util/reduxHooks';
 import RequestFailureDivider from '@cdo/apps/weblab2/debugPanel/images/RequestFailure.svg';
 import ResponseFailureDivider from '@cdo/apps/weblab2/debugPanel/images/ResponseFailure.svg';
 import SuccessDivider from '@cdo/apps/weblab2/debugPanel/images/Success.svg';
 import {NetworkEntry} from '@cdo/apps/weblab2/redux/networkRedux';
+import {setDebugPanelOpen} from '@cdo/apps/weblab2/weblab2Redux';
 
 import DetailsBox from './DetailsBox';
 import NetworkRequestChip from './NetworkRequestChip';
@@ -33,6 +35,7 @@ const DebugPanel: React.FunctionComponent<DebugPanelProps> = ({className}) => {
       ? networkRequests[networkRequests.length - 1]
       : undefined
   );
+  const dispatch = useAppDispatch();
 
   useEffect(() => {
     if (!selectedRequest && networkRequests.length > 0) {
@@ -136,6 +139,12 @@ const DebugPanel: React.FunctionComponent<DebugPanelProps> = ({className}) => {
       id={'debug-panel-container'}
       headerContent={'Debug'}
       className={className}
+      rightHeaderContent={
+        <CloseButton
+          onClick={() => dispatch(setDebugPanelOpen(false))}
+          aria-label="Close debug panel"
+        />
+      }
     >
       {networkRequests.length === 0 ? (
         <div>No network requests</div>

--- a/apps/src/weblab2/debugPanel/DebugPanel.tsx
+++ b/apps/src/weblab2/debugPanel/DebugPanel.tsx
@@ -90,7 +90,7 @@ const DebugPanel: React.FunctionComponent<DebugPanelProps> = ({className}) => {
             value: selectedRequest?.response?.status,
           },
           {
-            label: 'Time',
+            label: 'Duration',
             value: selectedRequest?.response?.timeElapsed + ' ms',
           },
         ],

--- a/apps/src/weblab2/debugPanel/DebugPanel.tsx
+++ b/apps/src/weblab2/debugPanel/DebugPanel.tsx
@@ -30,16 +30,12 @@ const DebugPanel: React.FunctionComponent<DebugPanelProps> = ({className}) => {
   );
   const [selectedRequest, setSelectedRequest] = React.useState<
     NetworkEntry | undefined
-  >(
-    networkRequests.length > 0
-      ? networkRequests[networkRequests.length - 1]
-      : undefined
-  );
+  >(networkRequests.length > 0 ? networkRequests[0] : undefined);
   const dispatch = useAppDispatch();
 
   useEffect(() => {
     if (!selectedRequest && networkRequests.length > 0) {
-      setSelectedRequest(networkRequests[networkRequests.length - 1]);
+      setSelectedRequest(networkRequests[0]);
     } else if (networkRequests.length === 0 && selectedRequest !== undefined) {
       setSelectedRequest(undefined);
     }

--- a/apps/src/weblab2/htmlPreview/HTMLPreviewHeader.tsx
+++ b/apps/src/weblab2/htmlPreview/HTMLPreviewHeader.tsx
@@ -7,8 +7,11 @@ import classNames from 'classnames';
 import React, {useEffect, ChangeEvent, useCallback, useRef} from 'react';
 
 import {AutocompleteInput} from '@cdo/apps/templates/autocompleteInput/AutocompleteInput';
-import {useAppSelector} from '@cdo/apps/util/reduxHooks';
+import experiments from '@cdo/apps/util/experiments';
+import {useAppDispatch, useAppSelector} from '@cdo/apps/util/reduxHooks';
 import weblab2I18n from '@cdo/apps/weblab2/locale';
+
+import {setDebugPanelOpen} from '../weblab2Redux';
 
 import {PreviewViewMode} from './constants';
 
@@ -47,6 +50,11 @@ export const HTMLPreviewHeader: React.FC<HTMLPreviewHeaderProps> = ({
   fetchFileSearchOptions,
 }) => {
   const isFullScreenView = useAppSelector(state => state.lab.isFullScreenView);
+  const enableDebugPanel = experiments.isEnabledAllowingQueryString(
+    experiments.WEBLAB2_DEBUG_PANEL
+  );
+  const debugPanelOpen = useAppSelector(state => state.weblab2.debugPanelOpen);
+  const dispatch = useAppDispatch();
 
   // Supports our preview page "navigation" feature so the autocomplete suggestions
   // are only shown for user input and not for programmatic changes to the URL bar.
@@ -193,6 +201,31 @@ export const HTMLPreviewHeader: React.FC<HTMLPreviewHeaderProps> = ({
         className={moduleStyles.previewViewModeButtons}
         {...previewViewModeButtonsProps}
       />
+      {enableDebugPanel && (
+        <WithTooltip
+          tooltipProps={{
+            tooltipId: 'toggle-debug-panel',
+            direction: 'onBottom',
+            size: 'xs',
+            text: debugPanelOpen ? 'Close debug panel' : 'Open debug panel',
+          }}
+        >
+          <Button
+            onClick={() => dispatch(setDebugPanelOpen(!debugPanelOpen))}
+            aria-label={
+              debugPanelOpen ? 'Close debug panel' : 'Open debug panel'
+            }
+            size="xs"
+            type="secondary"
+            color={'gray'}
+            icon={{iconName: 'bug'}}
+            isIconOnly={true}
+            className={
+              debugPanelOpen ? moduleStyles.closeDebugPanelButton : undefined
+            }
+          />
+        </WithTooltip>
+      )}
       <ToggleFullScreenButton
         isFullScreenView={isFullScreenView}
         onToggleFullScreen={onToggleFullScreen}

--- a/apps/src/weblab2/htmlPreview/styles/html-preview-header.module.scss
+++ b/apps/src/weblab2/htmlPreview/styles/html-preview-header.module.scss
@@ -77,3 +77,14 @@
 .fullScreenPreviewHeaderContainer {
   border-radius: 0.25rem 0.25rem 0 0;
 }
+
+
+.closeDebugPanelButton.closeDebugPanelButton {
+  background-color: var(--background-brand-teal-primary);
+  color: var(--text-neutral-white-fixed);
+
+  &:hover {
+    background-color: var(--background-brand-teal-strong);
+    color: var(--text-neutral-white-fixed);
+  }
+}

--- a/apps/src/weblab2/layout/VerticalLayout.tsx
+++ b/apps/src/weblab2/layout/VerticalLayout.tsx
@@ -54,9 +54,7 @@ const VerticalLayout: React.FunctionComponent<LayoutProps> = ({
     state => state.weblab2.aiTutorVersionFiles
   );
 
-  const debugPanelCollapsed = useAppSelector(
-    state => state.weblab2.debugPanelCollapsed
-  );
+  const debugPanelOpen = useAppSelector(state => state.weblab2.debugPanelOpen);
 
   const dispatch = useAppDispatch();
 
@@ -176,7 +174,7 @@ const VerticalLayout: React.FunctionComponent<LayoutProps> = ({
 
   const showDebugPanel =
     experiments.isEnabledAllowingQueryString(experiments.WEBLAB2_DEBUG_PANEL) &&
-    !debugPanelCollapsed;
+    debugPanelOpen;
 
   return (
     <div className={lab2Styles.defaultContainer}>

--- a/apps/src/weblab2/layout/VerticalLayout.tsx
+++ b/apps/src/weblab2/layout/VerticalLayout.tsx
@@ -7,9 +7,11 @@ import HeaderButtons from '@codebridge/Workspace/HeaderButtons';
 import Workspace from '@codebridge/Workspace/Workspace';
 import classNames from 'classnames';
 import React, {useEffect} from 'react';
+import {useResizable} from 'react-resizable-layout';
 
 import AiTutorVersionAlert from '@cdo/apps/aiComponentLibrary/aiTutorVersionAlert/AiTutorVersionAlert';
 import {useVerticalLayout} from '@cdo/apps/lab2/hooks/useVerticalLayout';
+import {logOnResize} from '@cdo/apps/lab2/utils/resizeUtils';
 import ResizeBar from '@cdo/apps/lab2/views/components/layout/ResizeBar';
 import PanelContainer from '@cdo/apps/lab2/views/components/PanelContainer';
 import WorkspaceHeader from '@cdo/apps/lab2/views/components/WorkspaceHeader';
@@ -34,6 +36,8 @@ const INITIAL_PREVIEW_WIDTH = 400;
 const INITIAL_PREVIEW_WIDTH_WIDGET = 900;
 const INITIAL_INFO_PANEL_WIDTH_COLLAPSED = 55;
 const INITIAL_PREVIEW_WIDTH_COLLAPSED = 650;
+const DEBUG_PANEL_INITIAL_HEIGHT = 300;
+const MIN_DEBUG_PANEL_HEIGHT = 100;
 
 const VerticalLayout: React.FunctionComponent<LayoutProps> = ({
   isWidgetView,
@@ -48,6 +52,10 @@ const VerticalLayout: React.FunctionComponent<LayoutProps> = ({
 
   const aiTutorVersionFiles = useAppSelector(
     state => state.weblab2.aiTutorVersionFiles
+  );
+
+  const debugPanelCollapsed = useAppSelector(
+    state => state.weblab2.debugPanelCollapsed
   );
 
   const dispatch = useAppDispatch();
@@ -92,6 +100,22 @@ const VerticalLayout: React.FunctionComponent<LayoutProps> = ({
       name: 'preview',
     },
     appName: 'weblab2',
+  });
+
+  const {
+    position: debugPanelHeight,
+    separatorProps: debugPanelSeparatorProps,
+    isDragging: debugPanelDragging,
+  } = useResizable({
+    axis: 'y',
+    initial: DEBUG_PANEL_INITIAL_HEIGHT,
+    min: MIN_DEBUG_PANEL_HEIGHT,
+    reverse: true,
+    onResizeStart: () =>
+      logOnResize('weblab2', {
+        layout: 'vertical',
+        resizeBar: 'debugPanel',
+      }),
   });
 
   const viewModeButtonsProps: SegmentedButtonsProps = {
@@ -150,9 +174,9 @@ const VerticalLayout: React.FunctionComponent<LayoutProps> = ({
     );
   }, [setLeftPanelSize, isWidgetView, isStandaloneCollapsed]);
 
-  const showDebugPanel = experiments.isEnabledAllowingQueryString(
-    experiments.WEBLAB2_DEBUG_PANEL
-  );
+  const showDebugPanel =
+    experiments.isEnabledAllowingQueryString(experiments.WEBLAB2_DEBUG_PANEL) &&
+    !debugPanelCollapsed;
 
   return (
     <div className={lab2Styles.defaultContainer}>
@@ -200,7 +224,8 @@ const VerticalLayout: React.FunctionComponent<LayoutProps> = ({
                     style={{width: middlePanelWidth}}
                     className={classNames(
                       lab2Styles.shrinkAndGrow,
-                      panelClassName
+                      panelClassName,
+                      debugPanelDragging && lab2Styles.resizingPanel
                     )}
                     hideHeaders
                   />
@@ -216,7 +241,8 @@ const VerticalLayout: React.FunctionComponent<LayoutProps> = ({
                   style={{width: rightPanelWidth}}
                   className={classNames(
                     lab2Styles.shrinkAndGrow,
-                    panelClassName
+                    panelClassName,
+                    debugPanelDragging && lab2Styles.resizingPanel
                   )}
                 >
                   <HTMLPreview />
@@ -225,7 +251,16 @@ const VerticalLayout: React.FunctionComponent<LayoutProps> = ({
             </div>
           </div>
           {showDebugPanel && (
-            <DebugPanel className={weblab2Styles.debugPanelContainer} />
+            <>
+              <ResizeBar
+                isVertical={false}
+                separatorProps={debugPanelSeparatorProps}
+                isDragging={debugPanelDragging}
+              />
+              <div style={{height: debugPanelHeight}}>
+                <DebugPanel className={weblab2Styles.debugPanelContainer} />
+              </div>
+            </>
           )}
         </div>
       </div>

--- a/apps/src/weblab2/layout/VerticalLayout.tsx
+++ b/apps/src/weblab2/layout/VerticalLayout.tsx
@@ -257,7 +257,10 @@ const VerticalLayout: React.FunctionComponent<LayoutProps> = ({
               />
               <div
                 style={{height: debugPanelHeight}}
-                className={lab2Styles.flexShrink0}
+                className={classNames(
+                  lab2Styles.flexShrink0,
+                  debugPanelDragging && lab2Styles.resizingPanel
+                )}
               >
                 <DebugPanel />
               </div>

--- a/apps/src/weblab2/layout/VerticalLayout.tsx
+++ b/apps/src/weblab2/layout/VerticalLayout.tsx
@@ -37,7 +37,7 @@ const INITIAL_PREVIEW_WIDTH_WIDGET = 900;
 const INITIAL_INFO_PANEL_WIDTH_COLLAPSED = 55;
 const INITIAL_PREVIEW_WIDTH_COLLAPSED = 650;
 const DEBUG_PANEL_INITIAL_HEIGHT = 300;
-const MIN_DEBUG_PANEL_HEIGHT = 100;
+const MIN_DEBUG_PANEL_HEIGHT = 200;
 
 const VerticalLayout: React.FunctionComponent<LayoutProps> = ({
   isWidgetView,

--- a/apps/src/weblab2/layout/VerticalLayout.tsx
+++ b/apps/src/weblab2/layout/VerticalLayout.tsx
@@ -257,8 +257,11 @@ const VerticalLayout: React.FunctionComponent<LayoutProps> = ({
                 separatorProps={debugPanelSeparatorProps}
                 isDragging={debugPanelDragging}
               />
-              <div style={{height: debugPanelHeight}}>
-                <DebugPanel className={weblab2Styles.debugPanelContainer} />
+              <div
+                style={{height: debugPanelHeight}}
+                className={lab2Styles.flexShrink0}
+              >
+                <DebugPanel />
               </div>
             </>
           )}

--- a/apps/src/weblab2/layout/vertical-layout.module.scss
+++ b/apps/src/weblab2/layout/vertical-layout.module.scss
@@ -25,10 +25,6 @@
   text-overflow: ellipsis;
 }
 
-.debugPanelContainer {
-  flex: none;
-}
-
 .aiTutorVersionContainer {
   border-left: 1px solid var(--borders-brand-aqua-primary);
 }

--- a/apps/src/weblab2/layout/vertical-layout.module.scss
+++ b/apps/src/weblab2/layout/vertical-layout.module.scss
@@ -26,9 +26,7 @@
 }
 
 .debugPanelContainer {
-  height: 300px;
   flex: none;
-  border-top: variables.$default-border;
 }
 
 .aiTutorVersionContainer {

--- a/apps/src/weblab2/weblab2Redux.ts
+++ b/apps/src/weblab2/weblab2Redux.ts
@@ -15,14 +15,14 @@ export type Weblab2State = {
   viewMode: ViewMode;
   aiFilePathToPreview: AiFilePathToPreview | undefined;
   aiTutorVersionFiles: ProjectFile[] | undefined;
-  debugPanelCollapsed: boolean;
+  debugPanelOpen: boolean;
 };
 
 const initialState: Weblab2State = {
   viewMode: ViewMode.SPLIT,
   aiFilePathToPreview: undefined,
   aiTutorVersionFiles: undefined,
-  debugPanelCollapsed: false,
+  debugPanelOpen: false,
 };
 
 const weblab2Slice = createSlice({
@@ -44,8 +44,8 @@ const weblab2Slice = createSlice({
     ) => {
       state.aiTutorVersionFiles = action.payload;
     },
-    setDebugPanelCollapsed: (state, action: PayloadAction<boolean>) => {
-      state.debugPanelCollapsed = action.payload;
+    setDebugPanelOpen: (state, action: PayloadAction<boolean>) => {
+      state.debugPanelOpen = action.payload;
     },
   },
 });
@@ -56,5 +56,5 @@ export const {
   setViewMode,
   setAiFilePathToPreview,
   setAiTutorVersionFiles,
-  setDebugPanelCollapsed,
+  setDebugPanelOpen,
 } = weblab2Slice.actions;

--- a/apps/src/weblab2/weblab2Redux.ts
+++ b/apps/src/weblab2/weblab2Redux.ts
@@ -15,12 +15,14 @@ export type Weblab2State = {
   viewMode: ViewMode;
   aiFilePathToPreview: AiFilePathToPreview | undefined;
   aiTutorVersionFiles: ProjectFile[] | undefined;
+  debugPanelCollapsed: boolean;
 };
 
 const initialState: Weblab2State = {
   viewMode: ViewMode.SPLIT,
   aiFilePathToPreview: undefined,
   aiTutorVersionFiles: undefined,
+  debugPanelCollapsed: false,
 };
 
 const weblab2Slice = createSlice({
@@ -42,10 +44,17 @@ const weblab2Slice = createSlice({
     ) => {
       state.aiTutorVersionFiles = action.payload;
     },
+    setDebugPanelCollapsed: (state, action: PayloadAction<boolean>) => {
+      state.debugPanelCollapsed = action.payload;
+    },
   },
 });
 
 registerReducers({weblab2: weblab2Slice.reducer});
 
-export const {setViewMode, setAiFilePathToPreview, setAiTutorVersionFiles} =
-  weblab2Slice.actions;
+export const {
+  setViewMode,
+  setAiFilePathToPreview,
+  setAiTutorVersionFiles,
+  setDebugPanelCollapsed,
+} = weblab2Slice.actions;


### PR DESCRIPTION
This adds an open/close debug panel button to the preview header, adds a close button to the debug panel, and makes the debug panel resizable.

I also made a couple minor tweaks to the panel: changed "Time" to "Duration" as discussed in #70790, and updated the logic to select a request to always pick the first request in the list. The reason for this is the panel doesn't currently have auto-scroll, so picking the last request now that we can open/close the panel lead to picking a request that was off-screen. I started a [slack thread](https://codedotorg.slack.com/archives/C06JELCAPT9/p1771358691106319) to discuss whether we want auto-scroll.

## Screen shots/screen recordings
### All behavior
Note: when I screen record I see the highlighting behavior shown in this video sometimes. I have pointer-events set to none when dragging, and I can't repro the behavior when not screen recording, so I'm chalking it up to a quirk of the screen recording.

https://github.com/user-attachments/assets/dec52015-f984-477e-8f41-4f4be32edda5


### Keyboard navigable

https://github.com/user-attachments/assets/0f912b6e-ade2-4843-8c0b-5dcfa6053965


### Screenshots of new buttons
<img width="402" height="89" alt="Screenshot 2026-02-17 at 12 09 21 PM" src="https://github.com/user-attachments/assets/c072689c-bd30-497f-a953-53860ecafc75" />

<img width="1308" height="433" alt="Screenshot 2026-02-17 at 12 10 22 PM" src="https://github.com/user-attachments/assets/1f66b842-0008-498f-b429-3e93b66368d6" />
<img width="402" height="89" alt="Screenshot 2026-02-17 at 12 09 27 PM" src="https://github.com/user-attachments/assets/f6d8b3f1-9c66-477b-b655-551159958a44" />

## Links

- Jira: [AFL-461](https://codedotorg.atlassian.net/browse/AFL-461)

## Testing story
Tested locally. This feature is still behind a flag, `weblab2-show-debug`.



## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
