### PR TITLE
AI Tutor Permissions: add AI chat tools warnings to `CurriculumQuickAssign`

### DIFF
--- a/apps/src/templates/sectionsRefresh/CurriculumQuickAssign.jsx
+++ b/apps/src/templates/sectionsRefresh/CurriculumQuickAssign.jsx
@@ -7,12 +7,16 @@ import _ from 'lodash';
 import PropTypes from 'prop-types';
 import React, {useState, useEffect, useCallback} from 'react';
 
+import AssigningAvailableAiChatToolsAlert from '@cdo/apps/aiComponentLibrary/aiChatToolsDependencyAlerts/AssigningAvailableAiChatToolsAlert';
+import AssigningEssentialAiChatToolsAlert from '@cdo/apps/aiComponentLibrary/aiChatToolsDependencyAlerts/AssigningEssentialAiChatToolsAlert';
 import {queryParams} from '@cdo/apps/code-studio/utils';
 import {
   CourseOfferingCurriculumTypes as curriculumTypes,
   ParticipantAudience,
 } from '@cdo/apps/generated/curriculum/sharedCourseConstants';
 import Spinner from '@cdo/apps/sharedComponents/Spinner';
+import experiments from '@cdo/apps/util/experiments';
+import {AiChatToolsDependency} from '@cdo/generated-scripts/sharedConstants';
 import i18n from '@cdo/locale';
 
 import CurriculumQuickAssignTopRow from './CurriculumQuickAssignTopRow';
@@ -280,6 +284,10 @@ export default function CurriculumQuickAssign({
       ? QuickAssignTableHocPl
       : QuickAssignTable;
 
+  const aiChatToolsDependency = selectedCourseOffering
+    ? selectedCourseOffering.ai_chat_tools_dependency
+    : AiChatToolsDependency.NONE;
+
   return (
     <div className={moduleStyles.containerWithMarginTop}>
       {isLoading && !isNewSection ? (
@@ -348,6 +356,14 @@ export default function CurriculumQuickAssign({
               isNewSection={isNewSection}
             />
           )}
+          {experiments.isEnabled(experiments.AI_CHAT_NEW_PERMISSIONS) &&
+            aiChatToolsDependency === AiChatToolsDependency.ESSENTIAL && (
+              <AssigningEssentialAiChatToolsAlert />
+            )}
+          {experiments.isEnabled(experiments.AI_CHAT_NEW_PERMISSIONS) &&
+            aiChatToolsDependency === AiChatToolsDependency.AVAILABLE && (
+              <AssigningAvailableAiChatToolsAlert />
+            )}
         </>
       )}
     </div>

--- a/dashboard/app/models/course_offering.rb
+++ b/dashboard/app/models/course_offering.rb
@@ -352,7 +352,7 @@ class CourseOffering < ApplicationRecord
   def ai_chat_tools_dependency
     # Returns the AI chat tools dependency for this course offering, which is determined by latest course version.
     unit_group = course_versions.first&.content_root
-    unit_group.ai_chat_tools_dependency
+    unit_group&.ai_chat_tools_dependency
   end
 
   def summarize_for_edit

--- a/dashboard/app/models/course_offering.rb
+++ b/dashboard/app/models/course_offering.rb
@@ -302,6 +302,7 @@ class CourseOffering < ApplicationRecord
       display_name: any_versions_launched? ? localized_display_name : localized_display_name + ' *',
       course_versions: course_versions.select {|cv| cv.course_assignable?(user)}.map {|cv| cv.summarize_for_assignment_dropdown(user, locale_code)},
       ai_teaching_assistant_available: ai_teaching_assistant_available,
+      ai_chat_tools_dependency: ai_chat_tools_dependency,
     }
   end
 
@@ -432,7 +433,7 @@ class CourseOffering < ApplicationRecord
       published_date: published_date,
       self_paced_pl_course_offering_key: self_paced_pl_course_offering&.key,
       ai_teaching_assistant_available: ai_teaching_assistant_available,
-      facilitator_course_permissions: facilitator_course_permissions
+      facilitator_course_permissions: facilitator_course_permissions,
     }
   end
 


### PR DESCRIPTION
[Figma](https://www.figma.com/design/nl4nXJLuUHb9Aj4gfCAaNL/AI-Tutor--Settings?node-id=3372-8032&m=dev)

When teachers are setting up their sections, they will now see a little warning if the course they select either requires AI chat tools or has AI chat tools available. 

<img width="1076" height="430" alt="Screenshot 2026-02-17 at 3 33 27 PM" src="https://github.com/user-attachments/assets/a143de9c-83b8-4952-8358-ce061ba29c92" />
