### PR TITLE
Web lab 2 network tab: prettier no requests placeholder

### DIFF
--- a/apps/src/weblab2/debugPanel/DebugPanel.tsx
+++ b/apps/src/weblab2/debugPanel/DebugPanel.tsx
@@ -15,6 +15,7 @@ import {NetworkEntry} from '@cdo/apps/weblab2/redux/networkRedux';
 
 import DetailsBox from './DetailsBox';
 import NetworkRequestChip from './NetworkRequestChip';
+import NoRequestsPlaceholder from './NoRequestsPlaceholder';
 
 import moduleStyles from './debug-panel.module.scss';
 
@@ -138,7 +139,7 @@ const DebugPanel: React.FunctionComponent<DebugPanelProps> = ({className}) => {
       className={className}
     >
       {networkRequests.length === 0 ? (
-        <div>No network requests</div>
+        <NoRequestsPlaceholder />
       ) : (
         <div className={moduleStyles.debugPanelContainer}>
           <div className={moduleStyles.networkSummary}>

--- a/apps/src/weblab2/debugPanel/NoRequestsPlaceholder.tsx
+++ b/apps/src/weblab2/debugPanel/NoRequestsPlaceholder.tsx
@@ -1,0 +1,29 @@
+import FontAwesomeV6Icon from '@code-dot-org/component-library/fontAwesomeV6Icon';
+import {
+  BodyFourText,
+  BodyTwoText,
+  StrongText,
+} from '@code-dot-org/component-library/typography';
+import React from 'react';
+
+import moduleStyles from './no-requests-placeholder.module.scss';
+
+const NoRequestsPlaceholder: React.FunctionComponent = () => {
+  return (
+    <div className={moduleStyles.container}>
+      <div className={moduleStyles.innerContainer}>
+        <div className={moduleStyles.iconCircle}>
+          <FontAwesomeV6Icon iconName="globe" />
+        </div>
+        <BodyTwoText className={moduleStyles.title}>
+          <StrongText>No network activity</StrongText>
+        </BodyTwoText>
+        <BodyFourText className={moduleStyles.description}>
+          Network requests will appear here when your app makes API calls.
+        </BodyFourText>
+      </div>
+    </div>
+  );
+};
+
+export default NoRequestsPlaceholder;

--- a/apps/src/weblab2/debugPanel/no-requests-placeholder.module.scss
+++ b/apps/src/weblab2/debugPanel/no-requests-placeholder.module.scss
@@ -1,0 +1,37 @@
+.container {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  height: 100%;
+}
+
+.innerContainer {
+  max-width: 250px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.iconCircle {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 48px;
+  height: 48px;
+  border-radius: 100px;
+  background-color: var(--background-neutral-septenary);
+  color: var(--background-neutral-primary);
+  font-size: 24px;
+  margin-bottom: 10px;
+}
+
+.description {
+  color: var(--text-neutral-secondary);
+  margin-bottom: 0;
+}
+
+.title {
+  margin-bottom: 2px;
+}


### PR DESCRIPTION
This updates the network tab to have a prettier no requests placeholder.

<img width="1308" height="300" alt="Screenshot 2026-02-17 at 1 14 04 PM" src="https://github.com/user-attachments/assets/5c36ab07-1d86-476d-9c1e-98a18f2aeb07" />


## Links

- Jira: [AFL-461](https://codedotorg.atlassian.net/browse/AFL-461)




## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
