### PR TITLE
Switch experiment name from _ to -

### DIFF
--- a/apps/src/templates/teacherNavigation/TeacherNavigationBar.tsx
+++ b/apps/src/templates/teacherNavigation/TeacherNavigationBar.tsx
@@ -118,7 +118,7 @@ const TeacherNavigationBar: React.FC<{
   const defaultPerformanceContentKeys: (keyof typeof LABELED_TEACHER_NAVIGATION_PATHS)[] =
     ['progress', 'assessments', 'projects', 'stats', 'textResponses'];
   const performanceContentKeys: (keyof typeof LABELED_TEACHER_NAVIGATION_PATHS)[] =
-    experiments.isEnabled('student_snapshot')
+    experiments.isEnabled('student-snapshot')
       ? [...defaultPerformanceContentKeys, 'studentSnapshot']
       : defaultPerformanceContentKeys;
 

--- a/apps/src/templates/teacherNavigation/TeacherNavigationRouter.tsx
+++ b/apps/src/templates/teacherNavigation/TeacherNavigationRouter.tsx
@@ -295,7 +295,7 @@ const TeacherNavigationRouter: React.FC<TeacherNavigationRouterProps> = ({
               path={TEACHER_NAVIGATION_PATHS.unitOverview}
               element={<TeacherUnitOverview />}
             />
-            {experiments.isEnabled('student_snapshot') && (
+            {experiments.isEnabled('student-snapshot') && (
               <Route
                 path={TEACHER_NAVIGATION_PATHS.studentSnapshot}
                 element={

--- a/apps/src/util/experiments.js
+++ b/apps/src/util/experiments.js
@@ -74,6 +74,8 @@ experiments.ACCEPT_REJECT_UNIFIED_DIFF = 'accept-reject-unified-diff';
 experiments.ACCEPT_REJECT_SPLIT_DIFF = 'accept-reject-split-diff';
 // Show debug panel in Web Lab 2
 experiments.WEBLAB2_DEBUG_PANEL = 'weblab2-show-debug';
+// Enable the new teacher dashboard student snapshot page and features
+experiments.STUDENT_SNAPSHOT = 'student-snapshot';
 
 /**
  * This was a gamified version of the finish dialog, built in 2018,


### PR DESCRIPTION
Pilots have [regex](https://github.com/code-dot-org/code-dot-org/blob/staging/dashboard/app/models/experiments/pilot.rb#L18) that only allows hyphens (-) and not underscores (_).

This quickly changes the snapshot flag to be able to be pilottable.


Note that this will reset all local and production account flags. We will need to re-enable for all users on all platforms.

