### PR TITLE
Simplify Widget Template Rendering Logic

### DIFF
--- a/dashboard/app/models/levels/widget.rb
+++ b/dashboard/app/models/levels/widget.rb
@@ -77,4 +77,8 @@ class Widget < Level
   def inline_template
     File.read(Rails.root.join('public', properties['href']))
   end
+
+  def inline_template_type
+    File.extname(properties['href'])[1..].to_sym
+  end
 end

--- a/dashboard/app/models/levels/widget.rb
+++ b/dashboard/app/models/levels/widget.rb
@@ -58,40 +58,23 @@ class Widget < Level
     return app_options
   end
 
-  # Determines the location of the widget template.
-  #
-  # This will negotiate templates even if the href does not explicitly specify
-  # them. For instance, an href of 'pixelation.html' will use
-  # 'pixelation.html.haml' if it exists.
-  #
-  # Otherwise, it will return the href intact. If this is an HTML file, it would
-  # then have to be rendered inline.
-  def template
-    # Determine the template from the level and try to find it within the views
-    # path for the application.
-    href = properties['href']
-    path = Rails.root.join('app', 'views', 'levels', File.basename(href))
-
-    # Ensure we are looking for a 'haml' template, if it isn't already one.
-    if File.extname(path)[1..] == "html"
-      path = "#{path}.haml"
-    end
-
-    # Add an underscore, as it is expecting.
-    path = File.join(File.dirname(path), "_" + File.basename(path))
-
-    # If it exists, then the haml file should be preferred, so return it without
-    # the underscore.
-    if File.exist?(path)
-      return "levels/" + File.basename(path)[1..]
-    end
-
-    # Otherwise, we assume the widget exists within the public path.
-    Rails.root.join('public', href).to_s
+  # Identify the ActionView template associated with this level type. Currently
+  # only Pixelation levels have such a template; all others will have to fall
+  # back to `inline_template`.
+  def partial_template
+    File.join('levels', game.app)
   end
 
-  # Determines the type of template being rendered for this widget.
-  def template_type
-    File.extname(template)[1..].to_sym
+  # Identify the static HTML/HAML file associated with this level. Note that
+  # despite us in theory allowing each individual level to specify a custom
+  # href, in practice each model assigns a static value in a
+  # `before_validation` block based on the specific type of level.
+  #
+  # TODO: update this logic so that all levels of a given type work the same,
+  # rather than supporting per-level customization. Or just update all level
+  # types to use `partial_template` instead, at which point we can remove both
+  # this method and the `href` property.
+  def inline_template
+    File.read(Rails.root.join('public', properties['href']))
   end
 end

--- a/dashboard/app/views/levels/_widget.html.haml
+++ b/dashboard/app/views/levels/_widget.html.haml
@@ -9,10 +9,11 @@
   dashboard.widget.setupWidgetLevel();
 
 #external
-  / If there is no actual template, the template won't be found and the returned
-  / path will be an absolute path. These are intended to be rendered inline.
-  - if @level.template.start_with?("/")
-    = render inline: File.read(@level.template), type: @level.template_type
+  - if template_exists?(@level.partial_template)
+    / We eventually want to convert all of these over to use Rails templates,
+    / so always prefer that if it exists.
+    = render partial: @level.partial_template
   - else
-    = render partial: @level.template, type: @level.template_type
+    / Otherwise, fall back to the original static implementation.
+    = render inline: @level.inline_template
 .clear

--- a/dashboard/app/views/levels/_widget.html.haml
+++ b/dashboard/app/views/levels/_widget.html.haml
@@ -15,5 +15,5 @@
     = render partial: @level.partial_template
   - else
     / Otherwise, fall back to the original static implementation.
-    = render inline: @level.inline_template
+    = render inline: @level.inline_template, type: @level.inline_template_type
 .clear

--- a/dashboard/app/views/levels/_widget.html.haml
+++ b/dashboard/app/views/levels/_widget.html.haml
@@ -9,7 +9,7 @@
   dashboard.widget.setupWidgetLevel();
 
 #external
-  - if template_exists?(@level.partial_template)
+  - if lookup_context.template_exists?(@level.partial_template, [], true)
     / We eventually want to convert all of these over to use Rails templates,
     / so always prefer that if it exists.
     = render partial: @level.partial_template


### PR DESCRIPTION
Part of our ongoing work to prepare for an update to Rails 7, which [removed support for specifying file extensions when rendering partials](https://github.com/rails/rails/pull/39164).

### Background

Right now, we have some complex logic in `Widget#template` to support a wide range of flexibility. Each level has an `href` property which it can use to indicate either an ActionView template or a static HTML/HAML file; based on that, we attempt to find an appropriate template from among several possible options.

However, we've actually hardcoded these values into the model file definitions, so every level of a given type always has the exact same `href` property:

- https://github.com/code-dot-org/code-dot-org/blob/05944611a590535934f6e88dd28d2c5c6c159cc9/dashboard/app/models/levels/frequency_analysis.rb#L29-L31
- https://github.com/code-dot-org/code-dot-org/blob/93cab998c569b892f6a44ef02c614e61e2bc13ce/dashboard/app/models/levels/odometer.rb#L29-L31
- https://github.com/code-dot-org/code-dot-org/blob/05944611a590535934f6e88dd28d2c5c6c159cc9/dashboard/app/models/levels/pixelation.rb#L39-L41
- https://github.com/code-dot-org/code-dot-org/blob/93cab998c569b892f6a44ef02c614e61e2bc13ce/dashboard/app/models/levels/public_key_cryptography.rb#L34-L36
- https://github.com/code-dot-org/code-dot-org/blob/93cab998c569b892f6a44ef02c614e61e2bc13ce/dashboard/app/models/levels/text_compression.rb#L34-L36
- https://github.com/code-dot-org/code-dot-org/blob/05944611a590535934f6e88dd28d2c5c6c159cc9/dashboard/app/models/levels/vigenere.rb#L29-L31

That means that despite in theory supporting a wide range of options, in practice we only ever use these templates for each level type:

```ruby
[production] dashboard * Widget.all.to_a.reduce({}) do |result, widget|
[production] dashboard *   result[widget.game.app] = Set[] unless result.has_key?(widget.game.app)
[production] dashboard *   result[widget.game.app].add(widget.template)
[production] dashboard *   result
[production] dashboard > end
=>
{"frequency_analysis"=>#<Set: {"/home/ubuntu/production/dashboard/public/frequency/frequency.html"}>,
 "odometer"=>#<Set: {"/home/ubuntu/production/dashboard/public/odometer/odometer.html"}>,
 "pixelation"=>#<Set: {"levels/pixelation.html.haml"}>,
 "public_key_cryptography"=>
  #<Set: {"/home/ubuntu/production/dashboard/public/public_key_cryptography/public_key_cryptography.html.haml"}>,
 "text_compression"=>#<Set: {"/home/ubuntu/production/dashboard/public/text-compression/text-compression.html"}>,
 "vigenere"=>#<Set: {"/home/ubuntu/production/dashboard/public/vigenere/vigenere.html"}>}
```

Pixelation levels are currently the only type that use an ActionView template, which in Rails 7 we would like to identify without any extensions as just `levels/pixelation`. For all other level types, the `href` property exactly specifies the static file to be rendered.

### Changes

It seems clear that not only are we not utilizing the full range of options for Widget templates, we also don't *want* to be. This PR proposes that we remove most of the unused flexibility we built for ourselves here, in the interests of maintainability.

Specifically:
- for the "ActionView template" case, we now just construct the template identifier directly from the level type identifier (which also addresses the Rails 7 incompatibility issue)
- for the "static template" case, we expect the level's `href` to specify the template precisely, with no negotiation
- to distinguish between the two, we rely on ActionView's inbuilt `find_template` method rather than our own implementation

## Testing story

Manually verified that all level types still work with this change on Rails 6.1 and 7.0:

- [x] http://localhost-studio.code.org:3000/courses/frequency-analysis/units/1/lessons/1/levels/1
- [x] http://localhost-studio.code.org:3000/courses/odometer/units/1/lessons/1/levels/1
- [x] http://localhost-studio.code.org:3000/courses/pixelation/units/1/lessons/5/levels/1
- [x] http://localhost-studio.code.org:3000/courses/public-key-cryptography/units/1/lessons/1/levels/1
- [x] http://localhost-studio.code.org:3000/courses/text-compression/units/1/lessons/1/levels/2
- [x] http://localhost-studio.code.org:3000/courses/vigenere/units/1/lessons/1/levels/1

Several of these are also exercised by UI tests

## Follow-up work
<!--  List any clean-up or technical debt that will be addressed in future work.
      - Include Jira links where applicable.
      - Are there any known limitations or improvements planned? -->

A good next step here would be to remove the `href` property entirely. Either by updating all static templates such that we can consistently find them just from the level type identifier, or by specifying the template on a per-type rather than per-level basis.