### PR TITLE
incrementally seed scripts in non-test environments

### DIFF
--- a/bin/watch-and-test-levelbuilder
+++ b/bin/watch-and-test-levelbuilder
@@ -42,7 +42,7 @@ Dir.chdir(REPO_DIR + '/dashboard')
 
 # This test suite can be modified - we can test a smaller set or add UI tests
 # here.
-test_result = system 'rake seed:incremental'
+test_result = system 'rake seed:all'
 
 Dir.chdir REPO_DIR
 

--- a/dashboard/lib/services/script_seed.rb
+++ b/dashboard/lib/services/script_seed.rb
@@ -227,6 +227,14 @@ module Services
         # Course version must be set before resources and vocabulary are imported. If the
         # script is in a unit group, we must wait and let the next seed step set
         # the course version on the unit group before resources and vocabulary can be imported.
+        #
+        # If this script has resources or vocabulary to import but is missing its
+        # course version, clear the md5 so incremental seeding will retry this
+        # script on the next run (once the course version is established).
+        if md5 && !seed_context.script.get_course_version &&
+            (resources_data&.any? || vocabularies_data&.any?)
+          seed_context.script.update_column(:md5, nil)
+        end
 
         seed_context.lesson_groups = import_lesson_groups(lesson_groups_data, seed_context)
         seed_context.lessons = import_lessons(lessons_data, seed_context)

--- a/dashboard/lib/tasks/seed.rake
+++ b/dashboard/lib/tasks/seed.rake
@@ -286,7 +286,7 @@ namespace :seed do
   end
 
   timed_task_with_logging scripts: SCRIPTS_DEPENDENCIES do
-    update_scripts(incremental: false)
+    update_scripts(incremental: true)
   end
 
   timed_task_with_logging scripts_incremental: SCRIPTS_DEPENDENCIES do

--- a/dashboard/lib/tasks/seed.rake
+++ b/dashboard/lib/tasks/seed.rake
@@ -289,10 +289,6 @@ namespace :seed do
     update_scripts(incremental: true)
   end
 
-  timed_task_with_logging scripts_incremental: SCRIPTS_DEPENDENCIES do
-    update_scripts(incremental: true)
-  end
-
   # Moved course offerings ui test seed after regular course offerings are seeded
   # because the regular course offerings seed task removes any course_offerings records
   # left in the database that do not have a corresponding json file in config/course_offerings.
@@ -667,9 +663,6 @@ namespace :seed do
   desc "seed all dashboard data"
   timed_task_with_logging all: FULL_SEED_TASKS
   timed_task_with_logging ui_test: UI_TEST_SEED_TASKS
-
-  desc "seed all dashboard data that has changed since last seed"
-  timed_task_with_logging incremental: [:check_migrations, :videos, :concepts, :scripts_incremental, :callouts, :school_districts, :schools, :secret_words, :secret_pictures, :courses, :donors, :foorms]
 
   desc "seed only dashboard data required for tests"
   timed_task_with_logging test: [:check_migrations, :videos, :games, :concepts, :secret_words, :secret_pictures, :school_districts, :schools, :standards, :foorms]

--- a/dashboard/test/lib/services/script_seed_test.rb
+++ b/dashboard/test/lib/services/script_seed_test.rb
@@ -1157,6 +1157,59 @@ module Services
       assert_equal 'Validation failed: Module type is not included in the list', e.message
     end
 
+    test 'seed clears md5 when course version is missing and resources are present' do
+      script = create_script_tree(name_prefix: 'test-md5-clear')
+      assert script.get_course_version
+      json = ScriptSeed.serialize_seeding_json(script)
+
+      # Verify the JSON contains resources and vocabularies
+      data = JSON.parse(json)
+      assert data['resources'].any?, 'expected resources in serialized data'
+      assert data['vocabularies'].any?, 'expected vocabularies in serialized data'
+
+      # Destroy the unit group and course version so they won't be available during seed
+      script.get_original_unit_group.course_version.resources.destroy_all
+      script.get_original_unit_group.course_version.vocabularies.destroy_all
+      script_to_destroy = Unit.find(script.id)
+      unit_group_to_destroy = script_to_destroy.get_original_unit_group
+      script_to_destroy.original_unit_group.course_version.destroy!
+      script_to_destroy.destroy!
+      unit_group_to_destroy.destroy!
+
+      md5 = Digest::MD5.hexdigest(json)
+      ScriptSeed.seed_from_json(json, md5: md5)
+
+      seeded_script = Unit.find_by_name(script.name)
+      assert_nil seeded_script.md5, 'md5 should be nil because course version was missing and resources/vocab were present'
+    end
+
+    test 'seed preserves md5 when course version is missing but no resources or vocabularies' do
+      script = create_script_tree(
+        name_prefix: 'test-md5-no-resources',
+        num_resources_per_lesson: 0,
+        num_resources_per_script: 0,
+        num_vocabularies_per_lesson: 0
+      )
+      json = ScriptSeed.serialize_seeding_json(script)
+
+      data = JSON.parse(json)
+      assert_empty data['resources'], 'expected no resources in serialized data'
+      assert_empty data['vocabularies'], 'expected no vocabularies in serialized data'
+
+      # Destroy the unit group and course version
+      script_to_destroy = Unit.find(script.id)
+      unit_group_to_destroy = script_to_destroy.get_original_unit_group
+      script_to_destroy.original_unit_group.course_version.destroy!
+      script_to_destroy.destroy!
+      unit_group_to_destroy.destroy!
+
+      md5 = Digest::MD5.hexdigest(json)
+      ScriptSeed.seed_from_json(json, md5: md5)
+
+      seeded_script = Unit.find_by_name(script.name)
+      assert_equal md5, seeded_script.md5, 'md5 should be preserved when no resources or vocabularies need importing'
+    end
+
     test 'seed_from_json_file stores md5 when provided' do
       script = create_script_tree(name_prefix: 'test-md5-storage')
       json = ScriptSeed.serialize_seeding_json(script)


### PR DESCRIPTION
## Background

https://github.com/code-dot-org/code-dot-org/pull/70356 reimplements incremental script seeding more reliably by detecting changes to individual script files. This implementation has been validated by running in drone and DTTs for 4 weeks. The goal of that PR was primarily to eliminate race conditions when seeding UI tests, however it also had the side benefit of speeding up seeding on the test machine.

## Description

- starts using the new incremental seeding implementation for scripts whenever we seed in non-test environments
- modifies the way we seed to ensure that vocabularies and resources are still seeded correctly when seeding for a second time. 
- removes `seed:scripts_incremental` which was made obsolete by this change.

This change is expected to give the following time savings:
- save developers 5-10 minutes during `rake build`, which most developers run ~daily
- speed up deploys to staging by 11 minutes
- speed up deploys to production by 19 minutes

## Performance data

This table shows improvements in the time taken to `seed:scripts` when no changes are present in the `.script_json` files:

| environment | before | after |
|--------|--------|--------|
| M4 MacBook Air | 5 minutes and 21 seconds | 1 second |
| dev ec2, m7i.4xlarge | 12 minutes and 54 seconds | 2 seconds |
| staging, m7i.4xlarge | 11 minutes and 32 seconds | 2 seconds (estimated) |
| production-daemon, m5.12xlarge | 18 minutes and 53 seconds | 3 seconds (estimated) |

## Testing story

- [x] verified that `scripts.md5` field is already set in staging and production DB for all records which still have `.script_json` files, just to help confirm that #70356 is working
- [x] new unit tests verify md5 field is not set when resources and vocab fail to seed
- [x] manual verification that resources and vocab are properly seeded after 2nd seeding:
```
[development] dashboard > Unit.find_by_name('artist').destroy
[development] dashboard > UnitGroup.find_by_name('artist').destroy

[12:26:31] Dave-M4:~/src/cdo/dashboard (use-more-md5-incremental-seeding)$ bundle exec rake seed:all
...
Finished seed:course_offerings (less than 1 second)
WARNING: unable to import resources into script artist because course version is missing. This is only to be expected if the script is being seeded for the first time.
WARNING: unable to import vocabulary into script artist because course version is missing. This is only to be expected if the script is being seeded for the first time.
Finished seed:scripts (1 second)
Finished seed:courses (7 seconds)
...

[development] dashboard > Unit.find_by_name('artist').lessons.map(&:vocabularies).flatten.any?
=> false

[12:28:20] Dave-M4:~/src/cdo/dashboard (use-more-md5-incremental-seeding)$ bundle exec rake seed:all
...
Finished seed:course_offerings (less than 1 second)
Finished seed:scripts (1 second)
Finished seed:courses (7 seconds)
...

[development] dashboard > Unit.find_by_name('artist').lessons.map(&:vocabularies).flatten.any?
=> true
```

## Deployment strategy
- [x] before merging, give DOTDs a heads up in case there are any deploy issues
