### PR TITLE
🧹 Remove Radium from `ChatBubble` and `ChatBubbleTip`

### DIFF
--- a/apps/src/templates/instructions/ChatBubble.jsx
+++ b/apps/src/templates/instructions/ChatBubble.jsx
@@ -1,5 +1,5 @@
+import classNames from 'classnames';
 import PropTypes from 'prop-types';
-import Radium from 'radium'; // eslint-disable-line no-restricted-imports
 import React from 'react';
 
 import color from '@cdo/apps/util/color';
@@ -8,38 +8,7 @@ import ChatBubbleTip from './ChatBubbleTip';
 import InlineAudio from './InlineAudio';
 import {shouldDisplayChatTips} from './utils';
 
-const styles = {
-  container: {
-    position: 'relative',
-  },
-
-  main: {
-    backgroundColor: color.white,
-    borderRadius: 10,
-    margin: '5px 0',
-    paddingTop: 5,
-    paddingBottom: 5,
-    paddingLeft: 10,
-    paddingRight: 10,
-    position: 'relative',
-    borderWidth: 2,
-  },
-
-  minecraft: {
-    borderRadius: 4,
-    borderWidth: 0,
-  },
-
-  withAudioControls: {
-    paddingRight: 76,
-  },
-
-  audioControls: {
-    position: 'absolute',
-    top: 7,
-    right: 12,
-  },
-};
+import styles from './chat-bubble.module.scss';
 
 var audioStyle = {
   wrapper: {
@@ -74,17 +43,20 @@ const ChatBubble = ({
   isDashed = isDashed || false;
   const showAudioControls = textToSpeechEnabled && (ttsUrl || ttsMessage);
 
+  const mainClassName = classNames(styles.main, {
+    [styles.minecraft]: isMinecraft,
+    [styles.withAudioControls]: showAudioControls,
+  });
+
   return (
-    <div style={styles.container}>
+    <div className={styles.container}>
       <div
-        style={[
-          styles.main,
-          isMinecraft && styles.minecraft,
-          showAudioControls && styles.withAudioControls,
-          {borderColor},
-          {backgroundColor},
-          {borderStyle: isDashed ? 'dashed' : 'solid'},
-        ]}
+        className={mainClassName}
+        style={{
+          borderColor,
+          backgroundColor,
+          borderStyle: isDashed ? 'dashed' : 'solid',
+        }}
       >
         {children}
         {shouldDisplayChatTips(skinId) && (
@@ -96,7 +68,7 @@ const ChatBubble = ({
         )}
       </div>
       {showAudioControls && (
-        <div style={styles.audioControls}>
+        <div className={styles.audioControls}>
           <InlineAudio src={ttsUrl} message={ttsMessage} style={audioStyle} />
         </div>
       )}
@@ -116,4 +88,4 @@ ChatBubble.propTypes = {
   textToSpeechEnabled: PropTypes.bool,
 };
 
-export default Radium(ChatBubble);
+export default ChatBubble;

--- a/apps/src/templates/instructions/ChatBubbleTip.jsx
+++ b/apps/src/templates/instructions/ChatBubbleTip.jsx
@@ -1,33 +1,28 @@
 import PropTypes from 'prop-types';
-import Radium from 'radium'; // eslint-disable-line no-restricted-imports
 import React from 'react';
 import {connect} from 'react-redux';
+
+import styles from './chat-bubble-tip.module.scss';
 
 const ChatBubbleTip = ({isRtl, color, background, isDashed}) => {
   background = background || 'white';
   color = color || 'none';
   isDashed = isDashed || false;
 
-  const styles = {
-    svg: {
-      position: 'absolute',
-      left: isRtl ? undefined : -24,
-      right: isRtl ? -24 : undefined,
-      bottom: 5,
-    },
-    polyline: {
-      stroke: color,
-      strokeWidth: 2,
-      fill: background,
-    },
-  };
-
   return (
-    <svg height="30" width="30" style={styles.svg}>
+    <svg
+      height="30"
+      width="30"
+      className={isRtl ? styles.svgRtl : styles.svgLtr}
+    >
       <polyline
         points={isRtl ? '6,25 25,25 5,5' : '24,24 5,24 25,5'}
-        style={styles.polyline}
-        strokeDasharray={isDashed ? '5,5' : '0,0'}
+        style={{
+          stroke: color,
+          strokeWidth: 2,
+          fill: background,
+          strokeDasharray: isDashed ? '5,5' : '0,0',
+        }}
       />
     </svg>
   );
@@ -44,4 +39,4 @@ export default connect(state => {
   return {
     isRtl: state.isRtl,
   };
-})(Radium(ChatBubbleTip));
+})(ChatBubbleTip);

--- a/apps/src/templates/instructions/chat-bubble-tip.module.scss
+++ b/apps/src/templates/instructions/chat-bubble-tip.module.scss
@@ -1,0 +1,11 @@
+.svgLtr {
+  position: absolute;
+  left: -24px;
+  bottom: 5px;
+}
+
+.svgRtl {
+  position: absolute;
+  right: -24px;
+  bottom: 5px;
+}

--- a/apps/src/templates/instructions/chat-bubble.module.scss
+++ b/apps/src/templates/instructions/chat-bubble.module.scss
@@ -1,0 +1,28 @@
+.container {
+  position: relative;
+}
+
+.main {
+  background-color: white;
+  border-radius: 10px;
+  margin: 5px 0;
+  padding: 5px 10px;
+  position: relative;
+  border-width: 2px;
+  border-style: solid;
+}
+
+.minecraft {
+  border-radius: 4px;
+  border-width: 0;
+}
+
+.withAudioControls {
+  padding-right: 76px;
+}
+
+.audioControls {
+  position: absolute;
+  top: 7px;
+  right: 12px;
+}


### PR DESCRIPTION
This work was originally done in https://github.com/code-dot-org/code-dot-org/pull/70513 but was reverted because of unexpected eyes diffs in https://github.com/code-dot-org/code-dot-org/pull/70626. I've opened https://github.com/code-dot-org/code-dot-org/pull/70626 to re-introduce the changes. However, rather than trying to merge the changes to all 11 of the instructions components at once, I'm going to incrementally reduce the diff on that PR by merging components in isolation to better identify where the eyes issues are coming from.