### PR TITLE
Tutor Permissions: Gate optional/available ai chat alert on the tutor pilot

### DIFF
--- a/apps/src/aiComponentLibrary/aiChatToolsDependencyAlerts/AssigningAvailableAiChatToolsAlert.tsx
+++ b/apps/src/aiComponentLibrary/aiChatToolsDependencyAlerts/AssigningAvailableAiChatToolsAlert.tsx
@@ -14,7 +14,7 @@ import AiChatToolsInfoAlert from './AiChatToolsInfoAlert';
  */
 const AssigningAvailableAiChatToolsAlert: React.FC = () => {
   const aiTutorEnabledForPilot = useAppSelector(
-    state => state.currentUser?.aiTutorEnabledForPilot
+    state => state.currentUser.aiTutorEnabledForPilot
   );
 
   if (!aiTutorEnabledForPilot) {

--- a/apps/src/aiComponentLibrary/aiChatToolsDependencyAlerts/AssigningAvailableAiChatToolsAlert.tsx
+++ b/apps/src/aiComponentLibrary/aiChatToolsDependencyAlerts/AssigningAvailableAiChatToolsAlert.tsx
@@ -1,12 +1,26 @@
 import React from 'react';
 
+import {useAppSelector} from '@cdo/apps/util/reduxHooks';
+
 import AiChatToolsInfoAlert from './AiChatToolsInfoAlert';
 
 /**
  * Warns that the assigned course or unit needs AI chat tools enabled.
  * Used when a teacher assigns a section to AI-dependent curriculum.
+ *
+ * Currently, all non-essential AI Chat Tools (i.e. ai tutor on non weblab2 levels) are gated behind
+ * the ai tutor pilot. This alert and the accompanying auto-enablement of AI Chat Tools only applies
+ * when the user is in the pilot.
  */
 const AssigningAvailableAiChatToolsAlert: React.FC = () => {
+  const aiTutorEnabledForPilot = useAppSelector(
+    state => state.currentUser?.aiTutorEnabledForPilot
+  );
+
+  if (!aiTutorEnabledForPilot) {
+    return null;
+  }
+
   return (
     <AiChatToolsInfoAlert text="This course has AI chat tools available for students. By assigning this course, you consent to enabling access to AI chat tools for this class section. You can disable access on the AI Settings page at any time." />
   );


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

We only auto-enable ai chat tools for curriculum that has optional tutor for folks in the tutor pilot.  This PR makes it so we also only show the alert if the user is in the pilot.

## Links
<!--  Links to relevant external resources.
      - spec docs, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- [slack documentation](https://codedotorg.slack.com/archives/C09V7TWT4Q2/p1771012489175339) of decisions on when to auto-enable tutor

## Testing story
<!--  Does your change include appropriate tests?
      - If so, please describe how the tests included in this PR are sufficient.
      - If not, please explain why this change does not need to be tested. -->


https://github.com/user-attachments/assets/05ac6b08-a7e3-4b19-adaa-6cfd113a74a7

In the pilot:
<img width="529" height="619" alt="image" src="https://github.com/user-attachments/assets/17f48c72-4035-42ed-afa5-bf5e9d009339" />

Not in the pilot:
<img width="526" height="545" alt="image" src="https://github.com/user-attachments/assets/dcd4bb69-2a82-4472-9bd7-4e29ee3c2c4c" />
