### PR TITLE
🧹 Remove Radium from `OverlayButton`

### DIFF
--- a/apps/src/maker/ui/OverlayButton.jsx
+++ b/apps/src/maker/ui/OverlayButton.jsx
@@ -1,69 +1,31 @@
 /** Button for use in Maker connection status overlays */
+import classNames from 'classnames';
 import PropTypes from 'prop-types';
-import Radium from 'radium'; // eslint-disable-line no-restricted-imports
-import React, {Component} from 'react';
+import React from 'react';
 
-import fontConstants from '@cdo/apps/fontConstants';
+import styles from './overlay-button.module.scss';
 
-import color from '../../util/color';
-
-const style = {
-  height: 40,
-  paddingLeft: 30,
-  paddingRight: 30,
-  boxSizing: 'border-box',
-  overflow: 'hidden',
-  ...fontConstants['main-font-regular'],
-  fontSize: 12,
-  fontWeight: 'bold',
-  color: color.charcoal,
-  textDecoration: 'none',
-  backgroundColor: 'transparent',
-  borderStyle: 'solid',
-  borderColor: color.charcoal,
-  borderWidth: 1,
-  borderRadius: 3,
-  outline: 'none',
-  ':hover': {
-    color: color.charcoal,
-    borderColor: color.white,
-    backgroundColor: color.white,
-    cursor: 'pointer',
-    boxShadow: 'none',
-  },
+const OverlayButton = ({className, primary, text, onClick}) => {
+  return (
+    <button
+      type="button"
+      className={classNames(
+        styles.overlayButton,
+        primary && styles.primary,
+        className
+      )}
+      onClick={onClick}
+    >
+      {text}
+    </button>
+  );
 };
 
-const primaryStyle = {
-  backgroundColor: color.charcoal,
-  borderColor: color.charcoal,
-  color: color.lighter_gray,
+OverlayButton.propTypes = {
+  className: PropTypes.string,
+  primary: PropTypes.bool,
+  text: PropTypes.string.isRequired,
+  onClick: PropTypes.func.isRequired,
 };
 
-class OverlayButton extends Component {
-  static propTypes = {
-    className: PropTypes.string,
-    primary: PropTypes.bool,
-    text: PropTypes.string.isRequired,
-    onClick: PropTypes.func.isRequired,
-  };
-
-  render() {
-    const composedStyle = {
-      ...style,
-      ...(this.props.primary && primaryStyle),
-    };
-
-    return (
-      <button
-        type="button"
-        className={this.props.className}
-        style={composedStyle}
-        onClick={this.props.onClick}
-      >
-        {this.props.text}
-      </button>
-    );
-  }
-}
-
-export default Radium(OverlayButton);
+export default OverlayButton;

--- a/apps/src/maker/ui/overlay-button.module.scss
+++ b/apps/src/maker/ui/overlay-button.module.scss
@@ -1,0 +1,33 @@
+@import 'color.scss';
+@import 'font.scss';
+
+.overlayButton {
+  @include main-font-regular;
+  height: 40px;
+  padding-left: 30px;
+  padding-right: 30px;
+  box-sizing: border-box;
+  overflow: hidden;
+  font-size: 12px;
+  font-weight: bold;
+  color: $charcoal;
+  text-decoration: none;
+  background-color: transparent;
+  border: 1px solid $charcoal;
+  border-radius: 3px;
+  outline: none;
+
+  &:hover {
+    color: $charcoal;
+    border-color: $white;
+    background-color: $white;
+    cursor: pointer;
+    box-shadow: none;
+  }
+}
+
+.primary {
+  background-color: $charcoal;
+  border-color: $charcoal;
+  color: $lighter_gray;
+}


### PR DESCRIPTION
Radium is deprecated. We decided to stop using it in 2019 and [settled on the alternative scss modules in 2022](https://docs.google.com/document/d/1Y3uK_iYMhTUaCI6yIDwOAMprIJCuzXSs2fECQggwp60/edit?tab=t.0#heading=h.htf3pg55q2kt). It's 2026 now, and AI has removed some of the tedium of the this task so I've embarked on a side quest to incrementally remove all the usages of Radium. Here's another one! 
