### PR TITLE
🧹 Tidy `DatePicker` component 

### DIFF
--- a/apps/src/code-studio/pd/international_opt_in/InternationalOptIn.jsx
+++ b/apps/src/code-studio/pd/international_opt_in/InternationalOptIn.jsx
@@ -9,7 +9,7 @@ import i18n from '@cdo/locale';
 
 import FormComponent from '../form_components/FormComponent';
 import FormController from '../form_components/FormController';
-import DatePicker from '../workshop_dashboard/components/date_picker';
+import DatePicker from '../../../sharedComponents/DatePicker';
 import {DATE_FORMAT} from '../workshop_dashboard/workshopConstants';
 
 export default class InternationalOptIn extends FormController {

--- a/apps/src/code-studio/pd/international_opt_in/InternationalOptIn.jsx
+++ b/apps/src/code-studio/pd/international_opt_in/InternationalOptIn.jsx
@@ -7,9 +7,9 @@ import {Row, Col, ControlLabel, FormGroup} from 'react-bootstrap'; // eslint-dis
 import {pegasus} from '@cdo/apps/lib/util/urlHelpers';
 import i18n from '@cdo/locale';
 
+import DatePicker from '../../../sharedComponents/DatePicker';
 import FormComponent from '../form_components/FormComponent';
 import FormController from '../form_components/FormController';
-import DatePicker from '../../../sharedComponents/DatePicker';
 import {DATE_FORMAT} from '../workshop_dashboard/workshopConstants';
 
 export default class InternationalOptIn extends FormController {

--- a/apps/src/code-studio/pd/workshop_dashboard/reports/foorm/submissions_download_form.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/reports/foorm/submissions_download_form.jsx
@@ -16,8 +16,8 @@ import Select from 'react-select/lib/Select';
 import ReactTooltip from 'react-tooltip';
 
 import FontAwesome from '../../../../../legacySharedComponents/FontAwesome.jsx';
-import {SelectStyleProps} from '../../../constants.js';
 import DatePicker from '../../../../../sharedComponents/DatePicker.jsx';
+import {SelectStyleProps} from '../../../constants.js';
 
 export default class SubmissionsDownloadForm extends React.Component {
   static propTypes = {

--- a/apps/src/code-studio/pd/workshop_dashboard/reports/foorm/submissions_download_form.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/reports/foorm/submissions_download_form.jsx
@@ -17,7 +17,7 @@ import ReactTooltip from 'react-tooltip';
 
 import FontAwesome from '../../../../../legacySharedComponents/FontAwesome.jsx';
 import {SelectStyleProps} from '../../../constants.js';
-import DatePicker from '../../components/date_picker.jsx';
+import DatePicker from '../../../../../sharedComponents/DatePicker.jsx';
 
 export default class SubmissionsDownloadForm extends React.Component {
   static propTypes = {

--- a/apps/src/code-studio/pd/workshop_dashboard/reports/report_view.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/reports/report_view.jsx
@@ -20,7 +20,7 @@ import {
 
 import {RouterContext} from '@cdo/apps/code-studio/legacyDashboardRoutingCompatibility';
 
-import DatePicker from '../components/date_picker';
+import DatePicker from '../../../../sharedComponents/DatePicker';
 
 import {
   QUERY_BY_OPTIONS,

--- a/apps/src/code-studio/pd/workshop_dashboard/workshop_filter.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/workshop_filter.jsx
@@ -39,7 +39,7 @@ import RegionalPartnerDropdown, {
 } from '../components/regional_partner_dropdown';
 import {SelectStyleProps, DATE_ORDER_ASC, DATE_ORDER_DESC} from '../constants';
 
-import DatePicker from './components/date_picker';
+import DatePicker from '../../../sharedComponents/DatePicker';
 import ServerSortWorkshopTable from './components/server_sort_workshop_table';
 import {PermissionPropType, WorkshopAdmin} from './permission';
 import {DATE_FORMAT} from './workshopConstants';

--- a/apps/src/code-studio/pd/workshop_dashboard/workshop_filter.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/workshop_filter.jsx
@@ -34,12 +34,12 @@ import {
   States,
 } from '@cdo/apps/generated/pd/sharedWorkshopConstants';
 
+import DatePicker from '../../../sharedComponents/DatePicker';
 import RegionalPartnerDropdown, {
   RegionalPartnerPropType,
 } from '../components/regional_partner_dropdown';
 import {SelectStyleProps, DATE_ORDER_ASC, DATE_ORDER_DESC} from '../constants';
 
-import DatePicker from '../../../sharedComponents/DatePicker';
 import ServerSortWorkshopTable from './components/server_sort_workshop_table';
 import {PermissionPropType, WorkshopAdmin} from './permission';
 import {DATE_FORMAT} from './workshopConstants';

--- a/apps/src/levelbuilder/CourseOfferingEditor.jsx
+++ b/apps/src/levelbuilder/CourseOfferingEditor.jsx
@@ -26,7 +26,7 @@ import {linkWithQueryParams, navigateToHref} from '@cdo/apps/utils';
 import {StudentGradeLevels} from '@cdo/generated-scripts/sharedConstants';
 import i18n from '@cdo/locale';
 
-import DatePicker from '../code-studio/pd/workshop_dashboard/components/date_picker';
+import DatePicker from '../sharedComponents/DatePicker';
 
 import ImageInput from './ImageInput';
 

--- a/apps/src/sharedComponents/DatePicker.jsx
+++ b/apps/src/sharedComponents/DatePicker.jsx
@@ -12,7 +12,7 @@ import ReactDOM from 'react-dom';
 
 import FontAwesome from '@cdo/apps/legacySharedComponents/FontAwesome';
 
-import {DATE_FORMAT} from '../workshopConstants';
+import {DATE_FORMAT} from '../code-studio/pd/workshop_dashboard/workshopConstants';
 
 import 'react-datepicker/dist/react-datepicker.css';
 import '@cdo/apps/code-studio/assets/date_picker.scss';

--- a/apps/src/sharedComponents/DatePicker.jsx
+++ b/apps/src/sharedComponents/DatePicker.jsx
@@ -3,8 +3,8 @@
  * It's basically a wrapper around react-datepicker (with limited props) that displays
  * as a React-Bootstrap select with a calendar icon Addon.
  */
+import classNames from 'classnames';
 import PropTypes from 'prop-types';
-import Radium from 'radium'; // eslint-disable-line no-restricted-imports
 import React from 'react';
 import {InputGroup, FormGroup, FormControl} from 'react-bootstrap'; // eslint-disable-line no-restricted-imports
 import ReactDatePicker from 'react-datepicker';
@@ -16,6 +16,7 @@ import {DATE_FORMAT} from '../code-studio/pd/workshop_dashboard/workshopConstant
 
 import 'react-datepicker/dist/react-datepicker.css';
 import '@cdo/apps/code-studio/assets/date_picker.scss';
+import styles from './date-picker.module.scss';
 
 class DateInputWithIconUnwrapped extends React.Component {
   static propTypes = {
@@ -51,7 +52,7 @@ class DateInputWithIconUnwrapped extends React.Component {
             type="text"
             value={this.props.value}
             onChange={this.props.onChange}
-            style={this.props.disabled ? styles.readOnlyInput : null}
+            className={classNames(this.props.disabled && styles.readOnlyInput)}
             disabled={this.props.disabled}
             onBlur={this.props.onBlur}
             ref={ref => (this.inputControl = ReactDOM.findDOMNode(ref))}
@@ -59,7 +60,7 @@ class DateInputWithIconUnwrapped extends React.Component {
           {!this.props.disabled && this.props.value && this.props.onClear && (
             <FormControl.Feedback>
               <span
-                style={styles.clearElement}
+                className={styles.clearElement}
                 onClick={this.handleClear}
                 title="Clear value"
               >
@@ -75,7 +76,7 @@ class DateInputWithIconUnwrapped extends React.Component {
     );
   }
 }
-const DateInputWithIcon = Radium(DateInputWithIconUnwrapped);
+const DateInputWithIcon = DateInputWithIconUnwrapped;
 
 export default class DatePicker extends React.Component {
   static propTypes = {
@@ -128,21 +129,3 @@ export default class DatePicker extends React.Component {
     );
   }
 }
-
-const styles = {
-  readOnlyInput: {
-    backgroundColor: 'inherit',
-    cursor: 'default',
-    border: 'none',
-  },
-  clearElement: {
-    color: '#999',
-    fontSize: '18px',
-    zIndex: 10,
-    cursor: 'pointer',
-    pointerEvents: 'all',
-    ':hover': {
-      color: '#D0021B',
-    },
-  },
-};

--- a/apps/src/sharedComponents/DatePicker.story.jsx
+++ b/apps/src/sharedComponents/DatePicker.story.jsx
@@ -2,7 +2,7 @@ import {action} from '@storybook/addon-actions';
 import moment from 'moment';
 import React from 'react';
 
-import DatePicker from './date_picker';
+import DatePicker from './DatePicker';
 
 export default {
   component: DatePicker,

--- a/apps/src/sharedComponents/date-picker.module.scss
+++ b/apps/src/sharedComponents/date-picker.module.scss
@@ -1,0 +1,17 @@
+.readOnlyInput {
+  background-color: inherit;
+  cursor: default;
+  border: none;
+}
+
+.clearElement {
+  color: #999;
+  font-size: 18px;
+  z-index: 10;
+  cursor: pointer;
+  pointer-events: all;
+
+  &:hover {
+    color: #d0021b;
+  }
+}


### PR DESCRIPTION
A few little updates: 
- rename `date_picker` to `DatePicker` to align with convention 
- move `DatePicker` into sharedComponents since it's used in both levelbuilder and pd workshops 
- update import paths to match changes 
- extract styles from `DatePicker` into scss module 
- remove Radium import for `DatePicker`
- reorder imports in touched files to appease linter 