### PR TITLE
AI Chat: show message if model is no longer supported

### DIFF
--- a/apps/src/aichat/redux/index.ts
+++ b/apps/src/aichat/redux/index.ts
@@ -11,7 +11,6 @@ export {
   setModelCardProperty,
   setNewChatSession,
   setShowModalType,
-  setStartingAiCustomizations,
   setStudentChatHistory,
   setUserHasAichatAccess,
   setClientType,

--- a/apps/src/aichat/redux/index.ts
+++ b/apps/src/aichat/redux/index.ts
@@ -21,6 +21,6 @@ export {
   stagedFilesLimitExceeded,
   clearStagedFilesAlert,
   clearStagedFiles,
-  clearHasSetStartingCustomizations,
+  clearHasSetInitialCustomizations,
   setChatWorkspaceSelectedTab,
 } from './slice';

--- a/apps/src/aichat/redux/slice.ts
+++ b/apps/src/aichat/redux/slice.ts
@@ -77,6 +77,7 @@ const initialState: AichatState = {
   hasUpdatedCustomizations: false,
   saveError: undefined,
   showResetMessage: false,
+  showUnsupportedModelMessage: false,
   hasSetStartingCustomizations: false,
   chatWorkspaceSelectedTab: null,
   userAddedSelectionContext: {},
@@ -242,54 +243,26 @@ const aichatSlice = createSlice({
     setViewMode: (state, action: PayloadAction<ViewMode>) => {
       state.viewMode = action.payload;
     },
-    setStartingAiCustomizations: (
+    setInitialConfiguration: (
       state,
       action: PayloadAction<{
-        levelAichatSettings?: LevelAichatSettings;
-        studentAiCustomizations: AiCustomizations;
+        customizations: AiCustomizations;
+        visibilities: {[key in keyof AiCustomizations]: Visibility};
+        showUnsupportedModelMessage: boolean;
       }>
     ) => {
-      const {levelAichatSettings, studentAiCustomizations} = action.payload;
-
-      let reconciledAiCustomizations: AiCustomizations = {
-        ...(levelAichatSettings?.initialCustomizations ||
-          EMPTY_AI_CUSTOMIZATIONS),
-      };
-
-      for (const customizationUntyped in reconciledAiCustomizations) {
-        const customization = customizationUntyped as keyof AiCustomizations;
-
-        if (
-          (levelAichatSettings?.visibilities || DEFAULT_VISIBILITIES)[
-            customization
-          ] === Visibility.EDITABLE &&
-          studentAiCustomizations[customization]
-        ) {
-          reconciledAiCustomizations = {
-            ...reconciledAiCustomizations,
-            [customization]: studentAiCustomizations[customization],
-          };
-        }
-      }
-
-      // Make sure model ID is valid
-      reconciledAiCustomizations = {
-        ...reconciledAiCustomizations,
-        selectedModelId: validateModelId(
-          reconciledAiCustomizations.selectedModelId
-        ),
-      };
-
-      state.initialAiCustomizations = reconciledAiCustomizations;
-      state.savedAiCustomizations = reconciledAiCustomizations;
-      state.currentAiCustomizations = reconciledAiCustomizations;
-      state.fieldVisibilities =
-        levelAichatSettings?.visibilities || DEFAULT_VISIBILITIES;
+      const {customizations, visibilities, showUnsupportedModelMessage} =
+        action.payload;
+      state.initialAiCustomizations = customizations;
+      state.savedAiCustomizations = customizations;
+      state.currentAiCustomizations = customizations;
+      state.fieldVisibilities = visibilities;
 
       // Reset sent message and updated customizations flags
       state.hasSentMessage = false;
       state.hasUpdatedCustomizations = false;
       state.hasSetStartingCustomizations = true;
+      state.showUnsupportedModelMessage = showUnsupportedModelMessage;
     },
     clearHasSetStartingCustomizations: state => {
       state.hasSetStartingCustomizations = false;
@@ -307,8 +280,9 @@ const aichatSlice = createSlice({
       defaultAiCustomizations = {
         ...defaultAiCustomizations,
         selectedModelId: validateModelId(
-          defaultAiCustomizations.selectedModelId
-        ),
+          defaultAiCustomizations.selectedModelId,
+          levelAichatSettings?.availableModelIds
+        ).modelId,
       };
 
       state.currentAiCustomizations = defaultAiCustomizations;
@@ -339,6 +313,7 @@ const aichatSlice = createSlice({
       // Clear save error and reset message, if any.
       state.saveError = undefined;
       state.showResetMessage = false;
+      state.showUnsupportedModelMessage = false;
     },
     setModelCardProperty: <T extends keyof ModelCardInfo>(
       state: AichatState,
@@ -354,12 +329,14 @@ const aichatSlice = createSlice({
       };
       state.currentAiCustomizations.modelCardInfo = updatedModelCardInfo;
       state.showResetMessage = false;
+      state.showUnsupportedModelMessage = false;
     },
     startSave(state, action: PayloadAction<SaveType>) {
       state.saveInProgress = true;
       state.currentSaveType = action.payload;
       // Clear save error, if any.
       state.saveError = undefined;
+      state.showUnsupportedModelMessage = false;
     },
     endSave(state) {
       state.saveInProgress = false;
@@ -484,7 +461,7 @@ export const {
   setNewChatSession,
   setInitialChatMessage,
   setShowModalType,
-  setStartingAiCustomizations,
+  setInitialConfiguration,
   setStudentChatHistory,
   setOwnChatHistory,
   setUserHasAichatAccess,

--- a/apps/src/aichat/redux/slice.ts
+++ b/apps/src/aichat/redux/slice.ts
@@ -78,7 +78,7 @@ const initialState: AichatState = {
   saveError: undefined,
   showResetMessage: false,
   showUnsupportedModelMessage: false,
-  hasSetStartingCustomizations: false,
+  hasSetInitialCustomizations: false,
   chatWorkspaceSelectedTab: null,
   userAddedSelectionContext: {},
   artifactType: undefined,
@@ -261,11 +261,11 @@ const aichatSlice = createSlice({
       // Reset sent message and updated customizations flags
       state.hasSentMessage = false;
       state.hasUpdatedCustomizations = false;
-      state.hasSetStartingCustomizations = true;
+      state.hasSetInitialCustomizations = true;
       state.showUnsupportedModelMessage = showUnsupportedModelMessage;
     },
-    clearHasSetStartingCustomizations: state => {
-      state.hasSetStartingCustomizations = false;
+    clearHasSetInitialCustomizations: state => {
+      state.hasSetInitialCustomizations = false;
     },
     resetToDefaultAiCustomizations: (
       state,
@@ -485,7 +485,7 @@ export const {
   stagedFilesLimitExceeded,
   clearStagedFilesAlert,
   setSaveError,
-  clearHasSetStartingCustomizations,
+  clearHasSetInitialCustomizations,
   setChatWorkspaceSelectedTab,
   addItemToUserAddedSelectionContext,
   removeItemFromUserAddedSelectionContext,

--- a/apps/src/aichat/redux/state.ts
+++ b/apps/src/aichat/redux/state.ts
@@ -81,8 +81,8 @@ export interface AichatState extends AiDiffChatState {
     | undefined;
   // If the user has a sent a message on this level
   hasSentMessage: boolean;
-  // If starting customizations have been set on this level
-  hasSetStartingCustomizations: boolean;
+  // If initial customizations have been set on this level
+  hasSetInitialCustomizations: boolean;
   // If the user has updated customizations on this level
   hasUpdatedCustomizations: boolean;
   // Error message to display if a save fails

--- a/apps/src/aichat/redux/state.ts
+++ b/apps/src/aichat/redux/state.ts
@@ -20,7 +20,8 @@ import {
   UserAddedSelectionContext,
 } from '../types';
 
-export interface AichatState {
+// State pertaining to AI TA Differentiation chat. TODO: Move this to a separate slice.
+interface AiDiffChatState {
   chatIsOpen: boolean;
   clientType?: AiChatClientType;
   // Id of the current thread open
@@ -44,6 +45,9 @@ export interface AichatState {
   threadKeyId: number;
   // AI TA's opening message for a thread
   initialChatMessage: string;
+}
+
+export interface AichatState extends AiDiffChatState {
   // Content from previous chat sessions that we track purely for visibility to the user
   // and do not send to the model as history.
   chatEventsPast: ChatEvent[];
@@ -85,6 +89,8 @@ export interface AichatState {
   saveError: SaveError | undefined;
   // If the model customizations were just reset to the default level values.
   showResetMessage: boolean;
+  // If the user had previously selected a model that is no longer available.
+  showUnsupportedModelMessage: boolean;
   // The tab selected when a teacher is viewing a student's chat history.
   chatWorkspaceSelectedTab: WorkspaceTeacherViewTab | null;
   userAddedSelectionContext: UserAddedSelectionContext;

--- a/apps/src/aichat/redux/thunks/index.ts
+++ b/apps/src/aichat/redux/thunks/index.ts
@@ -10,3 +10,4 @@ export {submitChatContents} from './submitChatContents';
 export {submitTeacherFeedback} from './submitTeacherFeedback';
 export {updateAiCustomization} from './updateAiCustomization';
 export {fetchThreadMessages} from './fetchThreadMessages';
+export {initializeAiCustomizations} from './initializeAiCustomizations';

--- a/apps/src/aichat/redux/thunks/initializeAiCustomizations.ts
+++ b/apps/src/aichat/redux/thunks/initializeAiCustomizations.ts
@@ -1,0 +1,71 @@
+import {EVENTS} from '@cdo/apps/metrics/AnalyticsConstants';
+import {getTypedKeys} from '@cdo/apps/types/utils';
+import {AppDispatch} from '@cdo/apps/util/reduxHooks';
+
+import {AiCustomizations, LevelAichatSettings, Visibility} from '../../types';
+import {
+  DEFAULT_VISIBILITIES,
+  EMPTY_AI_CUSTOMIZATIONS,
+} from '../../views/modelCustomization/constants';
+import {validateModelId} from '../../views/modelCustomization/utils';
+import {setInitialConfiguration} from '../slice';
+
+import {sendAnalytics} from './sendAnalytics';
+
+/**
+ * Initialize AI customizations for the level by reconciling student customizations
+ * with level settings.
+ */
+export const initializeAiCustomizations =
+  (
+    studentAiCustomizations: AiCustomizations,
+    levelAichatSettings?: LevelAichatSettings
+  ) =>
+  (dispatch: AppDispatch) => {
+    const visibilities =
+      levelAichatSettings?.visibilities || DEFAULT_VISIBILITIES;
+
+    let reconciledAiCustomizations: AiCustomizations = {
+      ...(levelAichatSettings?.initialCustomizations ||
+        EMPTY_AI_CUSTOMIZATIONS),
+    };
+
+    for (const customization of getTypedKeys(reconciledAiCustomizations)) {
+      if (
+        visibilities[customization] === Visibility.EDITABLE &&
+        studentAiCustomizations[customization]
+      ) {
+        reconciledAiCustomizations = {
+          ...reconciledAiCustomizations,
+          [customization]: studentAiCustomizations[customization],
+        };
+      }
+    }
+
+    const {isValid, modelId: correctedModelId} = validateModelId(
+      reconciledAiCustomizations.selectedModelId,
+      levelAichatSettings?.availableModelIds
+    );
+
+    if (!isValid) {
+      dispatch(
+        sendAnalytics(EVENTS.AICHAT_UNSUPPORTED_MODEL_SELECTED, {
+          previousModelId: reconciledAiCustomizations.selectedModelId,
+          correctedModelId,
+        })
+      );
+    }
+
+    reconciledAiCustomizations = {
+      ...reconciledAiCustomizations,
+      selectedModelId: correctedModelId,
+    };
+
+    dispatch(
+      setInitialConfiguration({
+        customizations: reconciledAiCustomizations,
+        visibilities,
+        showUnsupportedModelMessage: !isValid,
+      })
+    );
+  };

--- a/apps/src/aichat/views/AichatView.tsx
+++ b/apps/src/aichat/views/AichatView.tsx
@@ -45,10 +45,10 @@ import {
   selectAllFieldsHidden,
   sendAnalytics,
   setShowModalType,
-  setStartingAiCustomizations,
   setUserHasAichatAccess,
   setViewMode,
   updateAiCustomization,
+  initializeAiCustomizations,
 } from '../redux';
 import {AichatLevelProperties, ModelParameters, ViewMode} from '../types';
 
@@ -144,10 +144,7 @@ const AichatView: React.FunctionComponent<LabProps<AichatLevelProperties>> = ({
       (initialSources?.source as string) || '{}'
     );
     dispatch(
-      setStartingAiCustomizations({
-        levelAichatSettings,
-        studentAiCustomizations,
-      })
+      initializeAiCustomizations(studentAiCustomizations, levelAichatSettings)
     );
     dispatch(
       addChatEvent({

--- a/apps/src/aichat/views/AichatView.tsx
+++ b/apps/src/aichat/views/AichatView.tsx
@@ -40,7 +40,7 @@ import {
   onSaveComplete,
   onSaveFail,
   onSaveNoop,
-  clearHasSetStartingCustomizations,
+  clearHasSetInitialCustomizations,
   resetToDefaultAiCustomizations,
   selectAllFieldsHidden,
   sendAnalytics,
@@ -106,8 +106,8 @@ const AichatView: React.FunctionComponent<LabProps<AichatLevelProperties>> = ({
     state.lab.permissions?.includes(PERMISSIONS.LEVELBUILDER)
   );
 
-  const hasSetStartingCustomizations = useAppSelector(
-    state => state.aichat.hasSetStartingCustomizations
+  const hasSetInitialCustomizations = useAppSelector(
+    state => state.aichat.hasSetInitialCustomizations
   );
 
   const projectManager = Lab2Registry.getInstance().getProjectManager();
@@ -282,7 +282,7 @@ const AichatView: React.FunctionComponent<LabProps<AichatLevelProperties>> = ({
   }, [dialogControl, resetProject]);
 
   useLifecycleNotifier(LifecycleEvent.LevelLoadStarted, () => {
-    dispatch(clearHasSetStartingCustomizations());
+    dispatch(clearHasSetInitialCustomizations());
   });
 
   // Only recreate modelParameters when relevant customizations are updated.
@@ -381,7 +381,7 @@ const AichatView: React.FunctionComponent<LabProps<AichatLevelProperties>> = ({
               headerClassName={moduleStyles.panelHeader}
               rightHeaderContent={<AiChatHeaderButtons />}
             >
-              {hasSetStartingCustomizations && (
+              {hasSetInitialCustomizations && (
                 <ChatWorkspace
                   modelParameters={modelParameters}
                   clientType={AiChatClientTypes.AI_CHAT_LAB}

--- a/apps/src/aichat/views/modelCustomization/SaveChangesAlerts.tsx
+++ b/apps/src/aichat/views/modelCustomization/SaveChangesAlerts.tsx
@@ -9,7 +9,7 @@ import {
 import {commonI18n} from '@cdo/apps/types/locale';
 import {useAppSelector} from '@cdo/apps/util/reduxHooks';
 
-import {FAQ_LINK} from '../../constants';
+import {FAQ_LINK, modelDescriptions} from '../../constants';
 import aichatI18n from '../../locale';
 
 import styles from '../model-customization-workspace.module.scss';
@@ -26,6 +26,15 @@ const SaveChangesAlerts: React.FunctionComponent<{isReadOnly: boolean}> = ({
   const saveError = useAppSelector(state => state.aichat.saveError);
   const showResetMessage = useAppSelector(
     state => state.aichat.showResetMessage
+  );
+  const showUnsupportedModelMessage = useAppSelector(
+    state => state.aichat.showUnsupportedModelMessage
+  );
+  const currentModelName = useAppSelector(
+    state =>
+      modelDescriptions.find(
+        ({id}) => id === state.aichat.currentAiCustomizations.selectedModelId
+      )?.name
   );
 
   const alerts = {
@@ -56,6 +65,12 @@ const SaveChangesAlerts: React.FunctionComponent<{isReadOnly: boolean}> = ({
       text: aichatI18n.modelResetNotification(),
       type: alertTypes.success,
     },
+    unsupportedModel: {
+      text: `Your previously selected model is no longer available. ${
+        currentModelName && `We've switched you to ${currentModelName}.`
+      }`,
+      type: alertTypes.warning,
+    },
   };
 
   const showError = !!saveError;
@@ -65,6 +80,8 @@ const SaveChangesAlerts: React.FunctionComponent<{isReadOnly: boolean}> = ({
 
   const alert = showError
     ? alerts.error
+    : showUnsupportedModelMessage
+    ? alerts.unsupportedModel
     : showResetMessage
     ? alerts.reset
     : showReminder

--- a/apps/src/aichat/views/modelCustomization/utils.ts
+++ b/apps/src/aichat/views/modelCustomization/utils.ts
@@ -1,8 +1,13 @@
+import MetricsReporter from '@cdo/apps/metrics/MetricsReporter';
 import {ValueOf} from '@cdo/apps/types/utils';
 import {AiChatModelIds} from '@cdo/generated-scripts/sharedConstants';
 
 import {modelDescriptions} from '../../constants';
 import {Visibility} from '../../types';
+
+type ModelId = ValueOf<typeof AiChatModelIds>;
+
+const SUPPORTED_MODEL_IDS = modelDescriptions.map(model => model.id);
 
 export const isVisible = (visibility: Visibility) =>
   visibility !== Visibility.HIDDEN;
@@ -13,11 +18,28 @@ export const isEditable = (visibility: Visibility) =>
 
 // Ensures that the given model ID is part of the available models.
 // If not, returns the first available model ID.
-export const validateModelId = (modelId: ValueOf<typeof AiChatModelIds>) => {
-  const availableModelIds = modelDescriptions.map(model => model.id);
-  if (availableModelIds.includes(modelId)) {
-    return modelId;
+export const validateModelId = (
+  modelId: ModelId,
+  allowedModelIds?: ModelId[],
+  supportedModelIds = SUPPORTED_MODEL_IDS // For testing
+) => {
+  if (
+    supportedModelIds.includes(modelId) &&
+    (!allowedModelIds || allowedModelIds.includes(modelId))
+  ) {
+    return {isValid: true, modelId};
   }
 
-  return availableModelIds[0];
+  const supportedAndAllowed = allowedModelIds
+    ? supportedModelIds.filter(id => allowedModelIds.includes(id))
+    : supportedModelIds;
+
+  if (supportedAndAllowed.length === 0) {
+    MetricsReporter.logWarning(
+      'No overlap between levelbuilder-allowed models and supported models. Defaulting to first supported model.'
+    );
+    return {isValid: false, modelId: supportedModelIds[0]};
+  }
+
+  return {isValid: false, modelId: supportedAndAllowed[0]};
 };

--- a/apps/src/aichat/views/modelCustomization/utils.ts
+++ b/apps/src/aichat/views/modelCustomization/utils.ts
@@ -1,4 +1,4 @@
-import MetricsReporter from '@cdo/apps/metrics/MetricsReporter';
+import Lab2Registry from '@cdo/apps/lab2/Lab2Registry';
 import {ValueOf} from '@cdo/apps/types/utils';
 import {AiChatModelIds} from '@cdo/generated-scripts/sharedConstants';
 
@@ -35,9 +35,11 @@ export const validateModelId = (
     : supportedModelIds;
 
   if (supportedAndAllowed.length === 0) {
-    MetricsReporter.logWarning(
-      'No overlap between levelbuilder-allowed models and supported models. Defaulting to first supported model.'
-    );
+    Lab2Registry.getInstance()
+      .getMetricsReporter()
+      .logWarning(
+        'No overlap between levelbuilder-allowed models and supported models. Defaulting to first supported model.'
+      );
     return {isValid: false, modelId: supportedModelIds[0]};
   }
 

--- a/apps/src/metrics/AnalyticsConstants.js
+++ b/apps/src/metrics/AnalyticsConstants.js
@@ -520,6 +520,8 @@ const EVENTS = {
   SUBMIT_AICHAT_TEACHER_FEEDBACK: 'Teacher submits feedback on aichat message',
   AICHAT_MULTIMODAL_UPLOAD_OPENED: 'User clicks to upload multimodal assets',
   AICHAT_MULTIMODAL_UPLOAD_STAGED: 'User stages multimodal assets',
+  AICHAT_UNSUPPORTED_MODEL_SELECTED:
+    'User had previously selected a model that is no longer supported',
 
   // AI chat response copied. Shared across features; check event properties for usage and clientType
   // to determine feature.

--- a/apps/test/unit/aichat/redux/thunks/initializeAiCustomizationsTest.ts
+++ b/apps/test/unit/aichat/redux/thunks/initializeAiCustomizationsTest.ts
@@ -1,0 +1,272 @@
+import {setInitialConfiguration} from '@cdo/apps/aichat/redux/slice';
+import {initializeAiCustomizations} from '@cdo/apps/aichat/redux/thunks/initializeAiCustomizations';
+import {sendAnalytics} from '@cdo/apps/aichat/redux/thunks/sendAnalytics';
+import {
+  AiCustomizations,
+  LevelAichatSettings,
+  Visibility,
+} from '@cdo/apps/aichat/types';
+import {
+  DEFAULT_VISIBILITIES,
+  EMPTY_AI_CUSTOMIZATIONS,
+  EMPTY_MODEL_CARD_INFO,
+} from '@cdo/apps/aichat/views/modelCustomization/constants';
+import {validateModelId} from '@cdo/apps/aichat/views/modelCustomization/utils';
+import {EVENTS} from '@cdo/apps/metrics/AnalyticsConstants';
+import {ValueOf} from '@cdo/apps/types/utils';
+import {AiChatModelIds} from '@cdo/generated-scripts/sharedConstants';
+
+jest.mock('@cdo/apps/aichat/redux/thunks/sendAnalytics', () => ({
+  sendAnalytics: jest.fn(),
+}));
+
+jest.mock('@cdo/apps/aichat/views/modelCustomization/utils', () => ({
+  validateModelId: jest.fn(),
+}));
+
+const mockSendAnalytics = sendAnalytics as jest.Mock;
+const mockValidateModelId = validateModelId as jest.Mock;
+
+const studentCustomizations: AiCustomizations = {
+  selectedModelId: AiChatModelIds.MISTRAL,
+  temperature: 0.8,
+  systemPrompt: 'Student system prompt',
+  retrievalContexts: ['student context'],
+  modelCardInfo: EMPTY_MODEL_CARD_INFO,
+};
+
+const makeLevelSettings = (
+  overrides: Partial<LevelAichatSettings> = {}
+): LevelAichatSettings => ({
+  initialCustomizations: EMPTY_AI_CUSTOMIZATIONS,
+  visibilities: DEFAULT_VISIBILITIES,
+  levelSystemPrompt: '',
+  hidePresentationPanel: false,
+  availableModelIds: [AiChatModelIds.MISTRAL, AiChatModelIds.CHATGPT],
+  ...overrides,
+});
+
+describe('initializeAiCustomizations', () => {
+  let dispatch: jest.Mock;
+
+  beforeEach(() => {
+    dispatch = jest.fn();
+    mockSendAnalytics.mockClear();
+    // Default: model is valid, model ID is unchanged
+    mockValidateModelId.mockReturnValue({
+      isValid: true,
+      modelId: EMPTY_AI_CUSTOMIZATIONS.selectedModelId,
+    });
+  });
+
+  describe('without levelAichatSettings', () => {
+    it('dispatches setInitialConfiguration with DEFAULT_VISIBILITIES', () => {
+      initializeAiCustomizations(studentCustomizations)(dispatch);
+
+      expect(dispatch).toHaveBeenCalledWith(
+        setInitialConfiguration({
+          customizations: expect.any(Object),
+          visibilities: DEFAULT_VISIBILITIES,
+          showUnsupportedModelMessage: false,
+        })
+      );
+    });
+
+    it('uses EMPTY_AI_CUSTOMIZATIONS as the base, so the student selected model ID is ignored', () => {
+      initializeAiCustomizations({
+        ...studentCustomizations,
+        selectedModelId: AiChatModelIds.CHATGPT,
+      })(dispatch);
+
+      expect(dispatch).toHaveBeenCalledWith(
+        setInitialConfiguration(
+          expect.objectContaining({
+            customizations: expect.objectContaining({
+              selectedModelId: EMPTY_AI_CUSTOMIZATIONS.selectedModelId,
+            }),
+          })
+        )
+      );
+    });
+
+    it('uses student values for editable fields', () => {
+      initializeAiCustomizations(studentCustomizations)(dispatch);
+
+      expect(dispatch).toHaveBeenCalledWith(
+        setInitialConfiguration(
+          expect.objectContaining({
+            customizations: expect.objectContaining({
+              temperature: studentCustomizations.temperature,
+              systemPrompt: studentCustomizations.systemPrompt,
+              retrievalContexts: studentCustomizations.retrievalContexts,
+            }),
+          })
+        )
+      );
+    });
+  });
+
+  describe('with levelAichatSettings', () => {
+    it('uses levelAichatSettings visibilities', () => {
+      const customVisibilities = {
+        ...DEFAULT_VISIBILITIES,
+        systemPrompt: Visibility.HIDDEN,
+      };
+      const levelSettings = makeLevelSettings({
+        visibilities: customVisibilities,
+      });
+
+      initializeAiCustomizations(
+        studentCustomizations,
+        levelSettings
+      )(dispatch);
+
+      expect(dispatch).toHaveBeenCalledWith(
+        setInitialConfiguration(
+          expect.objectContaining({visibilities: customVisibilities})
+        )
+      );
+    });
+
+    it('uses student values for editable fields over level settings', () => {
+      const levelSettings = makeLevelSettings({
+        initialCustomizations: {
+          ...EMPTY_AI_CUSTOMIZATIONS,
+          temperature: 0.3,
+          systemPrompt: 'Level system prompt',
+        },
+      });
+
+      initializeAiCustomizations(
+        studentCustomizations,
+        levelSettings
+      )(dispatch);
+
+      expect(dispatch).toHaveBeenCalledWith(
+        setInitialConfiguration(
+          expect.objectContaining({
+            customizations: expect.objectContaining({
+              temperature: studentCustomizations.temperature,
+              systemPrompt: studentCustomizations.systemPrompt,
+            }),
+          })
+        )
+      );
+    });
+
+    it('ignores student values for readonly or hidden level fields', () => {
+      const levelSettings = makeLevelSettings({
+        initialCustomizations: {
+          ...EMPTY_AI_CUSTOMIZATIONS,
+          temperature: 0.3,
+          systemPrompt: 'Level system prompt',
+        },
+        visibilities: {
+          ...DEFAULT_VISIBILITIES,
+          temperature: Visibility.READONLY,
+          systemPrompt: Visibility.HIDDEN,
+        },
+      });
+
+      initializeAiCustomizations(
+        studentCustomizations,
+        levelSettings
+      )(dispatch);
+
+      expect(dispatch).toHaveBeenCalledWith(
+        setInitialConfiguration(
+          expect.objectContaining({
+            customizations: expect.objectContaining({
+              temperature: 0.3,
+              systemPrompt: 'Level system prompt',
+            }),
+          })
+        )
+      );
+    });
+  });
+
+  describe('model validation', () => {
+    it('sets showUnsupportedModelMessage to false when model ID is valid', () => {
+      initializeAiCustomizations(studentCustomizations)(dispatch);
+
+      expect(dispatch).toHaveBeenCalledWith(
+        setInitialConfiguration(
+          expect.objectContaining({showUnsupportedModelMessage: false})
+        )
+      );
+      expect(mockSendAnalytics).not.toHaveBeenCalled();
+    });
+
+    it('sets showUnsupportedModelMessage to true when model ID is invalid', () => {
+      mockValidateModelId.mockReturnValue({
+        isValid: false,
+        modelId: AiChatModelIds.CHATGPT,
+      });
+
+      initializeAiCustomizations(studentCustomizations)(dispatch);
+
+      expect(dispatch).toHaveBeenCalledWith(
+        setInitialConfiguration(
+          expect.objectContaining({showUnsupportedModelMessage: true})
+        )
+      );
+    });
+
+    it('uses the corrected modelId returned by validateModelId', () => {
+      mockValidateModelId.mockReturnValue({
+        isValid: false,
+        modelId: AiChatModelIds.CHATGPT,
+      });
+
+      initializeAiCustomizations(studentCustomizations)(dispatch);
+
+      expect(dispatch).toHaveBeenCalledWith(
+        setInitialConfiguration(
+          expect.objectContaining({
+            customizations: expect.objectContaining({
+              selectedModelId: AiChatModelIds.CHATGPT,
+            }),
+          })
+        )
+      );
+    });
+
+    it('dispatches sendAnalytics with previousModelId and correctedModelId when model ID is invalid', () => {
+      const levelSettings = makeLevelSettings({
+        visibilities: {
+          ...DEFAULT_VISIBILITIES,
+          selectedModelId: Visibility.EDITABLE,
+        },
+      });
+
+      const mockAnalyticsThunk = jest.fn();
+      mockSendAnalytics.mockReturnValue(mockAnalyticsThunk);
+      mockValidateModelId.mockReturnValue({
+        isValid: false,
+        modelId: AiChatModelIds.CHATGPT,
+      });
+
+      const deprecatedModelId = 'deprecated-model-id' as ValueOf<
+        typeof AiChatModelIds
+      >;
+
+      initializeAiCustomizations(
+        {
+          ...studentCustomizations,
+          selectedModelId: deprecatedModelId,
+        },
+        levelSettings
+      )(dispatch);
+
+      expect(mockSendAnalytics).toHaveBeenCalledWith(
+        EVENTS.AICHAT_UNSUPPORTED_MODEL_SELECTED,
+        {
+          previousModelId: deprecatedModelId,
+          correctedModelId: AiChatModelIds.CHATGPT,
+        }
+      );
+      expect(dispatch).toHaveBeenCalledWith(mockAnalyticsThunk);
+    });
+  });
+});

--- a/apps/test/unit/aichat/views/modelCustomization/utilsTest.ts
+++ b/apps/test/unit/aichat/views/modelCustomization/utilsTest.ts
@@ -1,0 +1,88 @@
+import {validateModelId} from '@cdo/apps/aichat/views/modelCustomization/utils';
+import {ValueOf} from '@cdo/apps/types/utils';
+import {AiChatModelIds} from '@cdo/generated-scripts/sharedConstants';
+
+const SUPPORTED_IDS = [AiChatModelIds.MISTRAL, AiChatModelIds.CHATGPT];
+const UNSUPPORTED_ID = 'deprecated-model-id' as ValueOf<typeof AiChatModelIds>;
+
+describe('validateModelId', () => {
+  describe('when the model ID is supported', () => {
+    it('returns isValid: true with the same modelId when no allowedModelIds are provided', () => {
+      expect(
+        validateModelId(AiChatModelIds.MISTRAL, undefined, SUPPORTED_IDS)
+      ).toEqual({
+        isValid: true,
+        modelId: AiChatModelIds.MISTRAL,
+      });
+    });
+
+    it('returns isValid: true when the model ID is in allowedModelIds', () => {
+      expect(
+        validateModelId(
+          AiChatModelIds.CHATGPT,
+          [AiChatModelIds.CHATGPT],
+          SUPPORTED_IDS
+        )
+      ).toEqual({
+        isValid: true,
+        modelId: AiChatModelIds.CHATGPT,
+      });
+    });
+  });
+
+  describe('when the model ID is invalid', () => {
+    it('returns isValid: false when the model ID is not in supportedModelIds', () => {
+      const result = validateModelId(UNSUPPORTED_ID, undefined, SUPPORTED_IDS);
+
+      expect(result.isValid).toBe(false);
+    });
+
+    it('returns isValid: false when the model ID is supported but not in allowedModelIds', () => {
+      const result = validateModelId(
+        AiChatModelIds.MISTRAL,
+        [AiChatModelIds.CHATGPT],
+        SUPPORTED_IDS
+      );
+
+      expect(result.isValid).toBe(false);
+    });
+
+    it('corrects to the first supported model when no allowedModelIds are provided', () => {
+      const result = validateModelId(UNSUPPORTED_ID, undefined, SUPPORTED_IDS);
+
+      expect(result.modelId).toBe(SUPPORTED_IDS[0]);
+    });
+
+    it('corrects to the first model that is both supported and in allowedModelIds', () => {
+      const result = validateModelId(
+        UNSUPPORTED_ID,
+        [AiChatModelIds.CHATGPT],
+        SUPPORTED_IDS
+      );
+
+      expect(result.modelId).toBe(AiChatModelIds.CHATGPT);
+    });
+  });
+
+  describe('when there is no overlap between allowedModelIds and supportedModelIds', () => {
+    it('returns isValid: false', () => {
+      const result = validateModelId(
+        UNSUPPORTED_ID,
+        [AiChatModelIds.MISTRAL],
+        [AiChatModelIds.CHATGPT]
+      );
+
+      expect(result.isValid).toBe(false);
+    });
+
+    it('falls back to the first supported model', () => {
+      const result = validateModelId(
+        UNSUPPORTED_ID,
+        [AiChatModelIds.MISTRAL],
+        [AiChatModelIds.CHATGPT]
+      );
+
+      expect(result.modelId).toBe(AiChatModelIds.CHATGPT);
+    });
+  });
+});


### PR DESCRIPTION
In preparation of turning off our fine-tuned model endpoints, this change displays a message to the user if their previously chosen model is no longer supported. By default, we will fall back to the first available model.

We already had some fallback logic in place, but it was a bit incomplete, and in order to report analytics for this case, I ended up moving the `setStartingAiCustomizations` redux action into a separate thunk, `initializeAiCustomizations`. Most of the logic is the same otherwise.

<img width="1514" height="832" alt="Screenshot 2026-02-18 at 11 31 08 AM" src="https://github.com/user-attachments/assets/7af2331e-48e7-4e4d-88ce-626200e7838b" />

Statsig event:
<img width="1040" height="630" alt="Screenshot 2026-02-18 at 11 27 11 AM" src="https://github.com/user-attachments/assets/2979b4c9-a757-488b-960f-38c4f1b98eab" />


## Links

https://docs.google.com/document/d/1R-YFtQTVjgwRjewAZnshwerlrT0sIXuQ9Pt4_6ro_5o/edit?tab=t.0#heading=h.iyzykbezwcpc

## Testing story
Tested locally + unit tests for new thunk and validation logic.

## Follow-up work
After this is deployed, we should be good to remove the fine tuned models from our model description JSON and shared IDs.