### PR TITLE
chore: remove pegasus tests

### DIFF
--- a/dashboard/test/ui/features/platform/policy_compliance/policy_compliance.feature
+++ b/dashboard/test/ui/features/platform/policy_compliance/policy_compliance.feature
@@ -12,10 +12,6 @@ Feature: Policy Compliance
     Then I wait to see "#lockout-panel-form"
     And element "#permission-status" contains text "Not Submitted"
 
-    # The sign out button should navigate and show the sign in button
-    And I click "#lockout-signout" to load a new page
-    Then check that the URL contains "http://code.org"
-
   Scenario: Existing under 13 account in Colorado should not be locked out.
     Given I am on "http://studio.code.org"
     Given CPA all user lockout phase

--- a/dashboard/test/ui/features/star_labs/sharepage_logo.feature
+++ b/dashboard/test/ui/features/star_labs/sharepage_logo.feature
@@ -50,36 +50,6 @@ Feature: Lab share page logo
     And I press the first "#logo-img img" element to load a new page
     And check that I am on "http://studio.code.org/home"
 
-  @no_mobile
-  @pegasus_content
-  Scenario: Select the logo on a playlab share page while logged out and visit the homepage
-    Given I am on "http://studio.code.org/projects/playlab"
-    And I wait for the lab page to fully load
-    Then I click selector ".project_share"
-    And I wait until element "#sharing-dialog-copy-button" is visible
-    And I navigate to the share URL
-    And I wait to see "#runButton"
-    And I sign out
-    And I navigate to the last shared URL
-    And element "div:contains('STUDIO')" does not exist
-    And I click "#logo-img img" once it exists to load a new page
-    And check that the URL contains "http://code.org"
-
-  @no_mobile
-  @pegasus_content
-  Scenario: Select the logo on a gamelab share page while logged out and visit the homepage
-    Given I am on "http://studio.code.org/projects/gamelab"
-    And I wait for the lab page to fully load
-    Then I click selector ".project_share"
-    And I wait until element "#sharing-dialog-copy-button" is visible
-    And I navigate to the share URL
-    And I wait to see "#runButton"
-    And I sign out
-    And I navigate to the last shared URL
-    And element "div:contains('STUDIO')" does not exist
-    And I click "#logo-img img" once it exists to load a new page
-    And check that the URL contains "http://code.org"
-
   @only_mobile
   Scenario: When on an applab share page while logged out on mobile, there is no logo.
     Given I am on "http://studio.code.org/projects/applab"

--- a/dashboard/test/ui/features/xteam/gdpr_dialog.feature
+++ b/dashboard/test/ui/features/xteam/gdpr_dialog.feature
@@ -7,8 +7,6 @@ Feature: GDPR Dialog - data transfer agreement
     And I am a teacher
     And I am on "http://studio.code.org/home"
     When element ".ui-test-gdpr-dialog" is visible
-    And I click ".ui-test-gdpr-dialog-logout" to load a new page
-    Then check that the URL contains "http://code.org"
 
   Scenario: EU user sees the GDPR Dialog on dashboard, opt in, don't show again
     Given I am in Europe


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->



## Links
<!--  Links to relevant external resources.
      - spec docs, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- Jira: 

## Testing story
<!--  Does your change include appropriate tests?
      - If so, please describe how the tests included in this PR are sufficient.
      - If not, please explain why this change does not need to be tested. -->



## Deployment strategy
<!--  Any special steps required to deploy this, besides merging?
      - Are there database migrations or manual steps?
      - Does this require coordination with other teams or systems? -->



## Follow-up work
<!--  List any clean-up or technical debt that will be addressed in future work.
      - Include Jira links where applicable.
      - Are there any known limitations or improvements planned? -->



## Privacy
<!--  How does this change impact Student & Teacher privacy?
      - Does this collect, use, share, or modify PII, either new or existing? -->



## Security
<!--  How does this change impact our security surface-area?
      - Do API's touched have the right auth?
      - Do infra changes impact our attack surface or encryption?
-->



## Caching
<!--  How does this change impact caching behavior?
      - Are cache keys or invalidation strategies affected?
      - Will this require cache warming or invalidation after deployment? -->



## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
