### PR TITLE
Gemfile: switch to puma 2 commits past 7.2 to get sigpwr backtraces

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -148,9 +148,18 @@ gem 'open_uri_redirections', require: false
 gem 'nakayoshi_fork'
 
 gem 'jmespath', '~> 1.4' # Used by our pumactl wrapper shell script to filter JSON output.
-gem 'puma', '~> 7.2'
 gem 'puma_worker_killer'
 gem 'sd_notify' # required for Puma to support systemd's Type=notify
+
+# We are using Puma just 2 commits past Puma 7.2 release, but crucially this includes a PR
+# that enables Puma to dump backtraces when it receives SIGPWR on Linux. We need this
+# PR for debugging and it is not included in a release (yet).
+#
+# Backtrace PR: https://github.com/puma/puma/pull/3829
+#
+# We should switch to Puma 7.3 as soon as it is released and remove this comment, (expected ~Mar-May 2026)
+gem 'puma', git: 'https://github.com/puma/puma.git', ref: '42161dd0fc3f3ad9d51359e4037c75b351b18219'
+# gem 'puma', '~> 7.2'
 
 gem 'chronic', '~> 0.10.2'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -88,6 +88,14 @@ GIT
   specs:
     full-name-splitter (0.1.2)
 
+GIT
+  remote: https://github.com/puma/puma.git
+  revision: 42161dd0fc3f3ad9d51359e4037c75b351b18219
+  ref: 42161dd0fc3f3ad9d51359e4037c75b351b18219
+  specs:
+    puma (7.2.0)
+      nio4r (~> 2.0)
+
 PATH
   remote: .
   glob: **/engines/*/*.gemspec
@@ -696,8 +704,6 @@ GEM
       coderay (~> 1.1)
       method_source (~> 1.0)
     public_suffix (6.0.1)
-    puma (7.2.0)
-      nio4r (~> 2.0)
     puma_worker_killer (0.3.1)
       get_process_mem (~> 0.2)
       puma (>= 2.7)
@@ -1126,7 +1132,7 @@ DEPENDENCIES
   pg (~> 1.3.0)
   phantomjs (~> 1.9.7.1)
   pry (~> 0.14.0)
-  puma (~> 7.2)
+  puma!
   puma_worker_killer
   pusher (~> 1.3.1)
   pycall (>= 1.5.2)


### PR DESCRIPTION
Current Puma release is 7.2. Right after puma 7.2 was released, they merged a PR that allows getting ruby backtraces of each puma worker by sending a SIGPWR on Linux (already supported on MacOS, but used SIGINFO which is not present on Linux).

This PR switches us temporarily to a git commit just after puma 7.2 was tagged (specifically two commits after).

The main goal is to get this PR in our deployed puma: https://github.com/puma/puma/pull/3829

Which will be useful for further debugging actioncable thread issues.