### PR TITLE
Fix eyes diff for rubrics notification number

### DIFF
--- a/apps/src/templates/rubrics/rubrics.module.scss
+++ b/apps/src/templates/rubrics/rubrics.module.scss
@@ -84,7 +84,11 @@ p.countText {
   margin-bottom: 0 !important;
   padding: 0 2px;
 
-  color: var(--light-white, #fff);
+  strong {
+    span {
+      color: var(--text-neutral-white-fixed, #fff);
+    }
+  }
   font-variant-ligatures: no-common-ligatures;
 }
 


### PR DESCRIPTION
Fixes an eyes diff on the rubric notification that stemmed from [this](https://github.com/code-dot-org/code-dot-org/pull/70735) PR.

[Eyes diff:](https://eyes.applitools.com/app/test-results/00000251630765613482/00000251630765540916/steps/1?accountId=mG4DoRfv0ntEgI3XIYBulrKxlZqrHtGwbP3V103ojvLFU110&display=details&mode=step-editor&top=00000251630765613482%2830%29)
<img width="1776" height="664" alt="image" src="https://github.com/user-attachments/assets/a18ea85d-a7cf-48d4-a047-029895a1d16d" />


After:
<img width="94" height="81" alt="image" src="https://github.com/user-attachments/assets/145a5ea6-509f-4512-b5d9-ff608ce8d3e2" />

## Links
Slack discussion: https://codedotorg.slack.com/archives/C0T0PNTM3/p1771536506740229