### PR TITLE
Lab2: fix for progress bubbles not always updating

### DIFF
--- a/apps/src/code-studio/progressRedux.ts
+++ b/apps/src/code-studio/progressRedux.ts
@@ -36,7 +36,7 @@ import {getBubbleUrl} from '../templates/progress/BubbleFactory';
 import {AppDispatch} from '../util/reduxHooks';
 import {navigateToHref} from '../utils';
 
-import {mergeActivityResult} from './activityUtils';
+import {activityCssClass, mergeActivityResult} from './activityUtils';
 import {
   canChangeLevelInPage,
   updateBrowserForLevelNavigation,
@@ -221,6 +221,33 @@ const progressSlice = createSlice({
         );
       });
       state.levelResults = newLevelResults;
+    },
+    mergeUnitProgress(
+      state,
+      action: PayloadAction<{levelId: number; result: number}>
+    ) {
+      const {levelId, result} = action.payload;
+      const status = activityCssClass(result);
+      const existing = state.unitProgress[levelId];
+      if (existing) {
+        state.unitProgress[levelId] = {
+          ...existing,
+          result: mergeActivityResult(existing.result, result),
+          status,
+        };
+      } else {
+        state.unitProgress[levelId] = {
+          lastTimestamp: undefined,
+          locked: false,
+          pages: null,
+          paired: false,
+          result,
+          status,
+          teacherFeedbackReviewState: undefined,
+          teacherFeedbackNew: false,
+          timeSpent: undefined,
+        };
+      }
     },
     overwriteResults(state, action: PayloadAction<LevelResults>) {
       state.levelResults = action.payload;
@@ -523,10 +550,13 @@ function sendReportForLevel(
       // Update the progress store by merging in this
       // particular result immediately.
       dispatch(mergeResults({[levelId]: result}));
+      dispatch(mergeUnitProgress({levelId: parseInt(levelId), result}));
       // If the level is the sublevel of a bubble level,
       // also update the status of the parent level.
       if (currentLevel.parentLevelId) {
         dispatch(mergeResults({[currentLevel.parentLevelId]: result}));
+        const parentId = parseInt(currentLevel.parentLevelId);
+        dispatch(mergeUnitProgress({levelId: parentId, result}));
       }
 
       // After we log the reported time we should update the start time of the milestone
@@ -647,6 +677,7 @@ export const {
   clearResults,
   useDbProgress,
   mergeResults,
+  mergeUnitProgress,
   overwriteResults,
   mergePeerReviewProgress,
   updateFocusArea,


### PR DESCRIPTION
We've seen some Zendesk reports of bubbles not turning green. I (with heavy assistance from Claude 😅) found a culprit!

If a user already has started a level when they load the page, then they finish the level (should go from green outline -> green), it stays at "started". The reason for this is if a level already has progress when we load the page, we will use `unitProgress` to determine bubble color, not `levelResults` (see [progressReduxSelectors](https://github.com/code-dot-org/code-dot-org/blob/5a51112c583d559e7d73eaf39e560655166de6d8/apps/src/code-studio/progressReduxSelectors.js#L151-L169)). But when we do a milestone update, we [only update the level results](https://github.com/code-dot-org/code-dot-org/blob/5a51112c583d559e7d73eaf39e560655166de6d8/apps/src/code-studio/progressRedux.ts#L525-L530). So if there was already progress, the progress bubble continues to use the now-outdated unit progress.

I checked out if this issue exists for pre-lab2 labs, since I am fairly confident we copied this logic from old levels. It does, but it's much less obvious to users. Once they click continue, the bubble turns green because we reload the page, and therefore reload all the progress data. In lab2 there's no reload, and therefore no refresh of data from the server.

This should fix at least some of the progress bubbles not turning green issues we've seen, although I'm not sure if there are other issues floating around.

## Before

https://github.com/user-attachments/assets/8861d5b1-4e2b-4430-9430-6480253d85fb


## After


https://github.com/user-attachments/assets/976eb05c-499d-45fa-8417-02252576736f


## Links

- Jira: [SL-1561](https://codedotorg.atlassian.net/browse/SL-1561)

## Testing story
Tested locally.



## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
