### PR TITLE
Remove new tag and clean up sectionTag as it is no longer used

### DIFF
--- a/apps/src/templates/teacherNavigation/TeacherNavigationBar.tsx
+++ b/apps/src/templates/teacherNavigation/TeacherNavigationBar.tsx
@@ -1,5 +1,4 @@
 import {SimpleDropdown} from '@code-dot-org/component-library/dropdown';
-import Tags from '@code-dot-org/component-library/tags';
 import {Typography} from '@mui/material';
 import _ from 'lodash';
 import React, {useState, useEffect} from 'react';
@@ -135,19 +134,14 @@ const TeacherNavigationBar: React.FC<{
     {
       title: coursecontentSectionTitle,
       keys: courseContentKeys,
-      sectionTag: (
-        <Tags tagsList={[{label: 'New'}]} className={styles.sidebarNewTags} />
-      ),
     },
     {
       title: performanceSectionTitle,
       keys: performanceContentKeys,
-      sectionTag: null,
     },
     {
       title: classroomContentSectionTitle,
       keys: classroomContentKeys,
-      sectionTag: null,
     },
   ];
 
@@ -244,15 +238,12 @@ const TeacherNavigationBar: React.FC<{
   };
 
   const navbarComponents = teacherNavigationBarContent.map(
-    ({title, keys, sectionTag}, index) => {
+    ({title, keys}, index) => {
       const sidebarOptions = getSidebarOptionsForSection(keys);
 
       return (
         <div key={`section-${index}`}>
-          <div className={styles.sidebarSectionHeader}>
-            {title}
-            {sectionTag}
-          </div>
+          <div className={styles.sidebarSectionHeader}>{title}</div>
           {sidebarOptions}
         </div>
       );

--- a/apps/src/templates/teacherNavigation/teacher-navigation.module.scss
+++ b/apps/src/templates/teacherNavigation/teacher-navigation.module.scss
@@ -52,18 +52,6 @@
   margin-bottom: 2px;
 }
 
-.sidebarNewTags {
-  margin-inline-start: 10px;
-}
-
-.sidebarSectionHeader .sidebarNewTags div {
-  background-color: var(--background-brand-teal-primary);
-}
-
-.sidebarSectionHeader .sidebarNewTags div span {
-  color: white;
-}
-
 .sectionDropdown {
   padding-left: 16px;
   width: 210px;


### PR DESCRIPTION
Slack thread: https://codedotorg.slack.com/archives/C045UAX4WKH/p1771547832965399

After this change:

<img width="293" height="796" alt="image" src="https://github.com/user-attachments/assets/fb63f991-9e26-466d-baa4-e78c53b9361d" />

I decided to remove all the support for sectionTags as I don't love keeping around code we _might_ use in the future. If I'm missing some context, please let me know! 





