### PR TITLE
Explicitly Specify Through Record in Unit Test

### DIFF
--- a/dashboard/test/helpers/ai_lesson_summaries_helper_test.rb
+++ b/dashboard/test/helpers/ai_lesson_summaries_helper_test.rb
@@ -443,9 +443,10 @@ class AiLessonSummariesHelperTest < ActionView::TestCase
   test "perform_ai_lesson_summaries_by_unit enqueues job with lesson IDs that have lesson plans" do
     # Create a unit with lessons, some with lesson plans and some without
     unit = create(:unit)
-    lesson_with_plan = create(:lesson, script: unit, has_lesson_plan: true)
-    create(:lesson, script: unit, has_lesson_plan: false)
-    lesson_with_plan_2 = create(:lesson, script: unit, has_lesson_plan: true)
+    lesson_group = create(:lesson_group, script: unit)
+    lesson_with_plan = create(:lesson, lesson_group: lesson_group, has_lesson_plan: true)
+    create(:lesson, lesson_group: lesson_group, has_lesson_plan: false)
+    lesson_with_plan_2 = create(:lesson, lesson_group: lesson_group, has_lesson_plan: true)
 
     expected_request = {
       user_id: @user.id,


### PR DESCRIPTION
Otherwise, we get the following error in this test on Rails 7:

```ruby
 FAIL["test_perform_ai_lesson_summaries_by_unit_enqueues_job_with_lesson_IDs_that_have_lesson_plans", "AiLessonSummariesHelperTest", 120.09239305392839]
 test_perform_ai_lesson_summaries_by_unit_enqueues_job_with_lesson_IDs_that_have_lesson_plans#AiLessonSummariesHelperTest (120.09s)
        unexpected invocation: AiLessonSummariesJob.perform_later(:request => {:user_id => 34, :lesson_ids => [], :unit_id => 2699})
        unsatisfied expectations:
        - expected exactly once, not yet invoked: AiLessonSummariesJob.perform_later(:request => {:user_id => 34, :lesson_ids => [487778, 487780], :unit_id => 2699})
```

Specifically, it appears that in Rails 7, the `through` relationship `unit.lessons` does not automatically pick up the newly-created `lesson` objects unless we also create the intermediary `lesson_group` object.

I don't know what changed in that version such that this started happening; but since this is the only test in our entire suite that's manifesting the problem, this PR proposes we apply a simple spot-fix rather than investing the time to do a full investigation.

I'm happy to fall down the rabbit hole here if anyone thinks it'd be worthwhile, though :upside_down_face: 

## Links

Follow-up to https://github.com/code-dot-org/code-dot-org/pull/70866
Required for https://github.com/code-dot-org/code-dot-org/pull/67318