### PR TITLE
Web lab 2: speculative fix for Safari issue

### DIFF
--- a/apps/src/weblab2/htmlPreview/useProjectServiceWorker.ts
+++ b/apps/src/weblab2/htmlPreview/useProjectServiceWorker.ts
@@ -47,8 +47,10 @@ function useProjectServiceWorker(
             const installingWorker = registration.installing;
             if (installingWorker) {
               installingWorker.addEventListener('statechange', () => {
-                if (installingWorker.state === 'installed') {
-                  // If we get a message that we have a new active service worker, update our reference.
+                if (installingWorker.state === 'activated') {
+                  // Wait for the service worker to be fully activated (and call clients.claim())
+                  // before updating our reference. Safari requires the worker to be controlling
+                  // the page before it will intercept fetch requests from iframes.
                   setServiceWorker(installingWorker);
                 }
               });


### PR DESCRIPTION
Alice noticed that often on Safari the web lab 2 preview does not load, but often if you have the dev tools open it does. Very mysterious.

Here is Claude's suggestion for a fix, which I am not 100% confident in but I don't think will cause issues. I unfortunately can't repro the issue locally because we can't run web lab 2 locally on Safari. However, this change causes no issues on Chrome. 

The fix is to wait for the service worker "activated" event rather than the "installed" event so we can be sure the service worker responds to the fetch request when it occurs and returns code back to the iframe. This makes good sense, but I'm not confident it will fix the issue because if that were the case, I would expect that refreshing the preview would cause the code to show up, but it does not. But it could be that I'm missing something here.

However, this is a quick change, with no apparent downside, and we can see if it works. It's probably quicker to deploy this than set up an adhoc because a web lab 2-enabled adhoc takes an incredibly long time to deploy.

## Links

- Jira: [AFL-493](https://codedotorg.atlassian.net/browse/AFL-493)

## Testing story
Tested that this does not break Chrome locally.



## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
