### PR TITLE
Lab2 instructions: open external links in new tab

### DIFF
--- a/apps/src/lab2/views/components/Instructions/MainInstructionsContent.tsx
+++ b/apps/src/lab2/views/components/Instructions/MainInstructionsContent.tsx
@@ -85,6 +85,7 @@ const MainInstructionsContent = forwardRef<
       >
         <EnhancedSafeMarkdown
           markdown={markdown}
+          openExternalLinksInNewTab={true}
           className={classNames(
             moduleStyles.markdownText,
             showTts ? moduleStyles.markdownTts : undefined,


### PR DESCRIPTION
Emily noticed while looking at some AIF curriculum that links in the instructions open in the same tab, which is disruptive. Brendan pointed out we can open in a new tab with a setting on `EnhancedSafeMarkdown`. This uses this setting for the instructions in Lab2; I can't think of a time we would not want to open links in a new tab here.

## Before

https://github.com/user-attachments/assets/517efe1d-4b13-4cf0-af63-821a19138f44


## After

https://github.com/user-attachments/assets/cc60417e-696c-4bb4-a91b-e1642a0fa022


## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
