### PR TITLE
Fix section info loading on lesson plan page etc., add empty state

### DIFF
--- a/apps/src/aiDifferentiation/AiDiffArtifactSavePage.tsx
+++ b/apps/src/aiDifferentiation/AiDiffArtifactSavePage.tsx
@@ -167,7 +167,7 @@ const AiDiffArtifactSavePage: React.FC<Props> = ({message}) => {
     setToggleValue(oldValue => !oldValue);
   };
 
-  return (
+  return activeStudentSections.length && unitMenuList.length ? (
     <div className={style.artifactConfiguration}>
       <div className={style.artifactConfigurationSection}>
         <h3>Which class sections do you want to save this artifact for?</h3>
@@ -253,6 +253,24 @@ const AiDiffArtifactSavePage: React.FC<Props> = ({message}) => {
             !selectedUnitId ||
             !selectedLessonId
           }
+        />
+      </div>
+    </div>
+  ) : (
+    <div className={style.artifactConfiguration}>
+      <div className={style.artifactConfigurationSection}>
+        You are required to have at least one active section with curriculum
+        assigned in order to create an artifact. Please create a section from
+        your <a href="/teacher_dashboard/home">dashboard</a> and then try to
+        create this artifact again.
+      </div>
+      <div className={style.artifactConfigurationSaveButtons}>
+        <Button
+          size="m"
+          type="secondary"
+          color="black"
+          onClick={() => dispatch(clearPendingArtifactMessage())}
+          text="Cancel"
         />
       </div>
     </div>

--- a/apps/src/aiDifferentiation/AiDiffWorkspace.tsx
+++ b/apps/src/aiDifferentiation/AiDiffWorkspace.tsx
@@ -56,8 +56,8 @@ const AiDiffWorkSpace: React.FC<AiDiffWorkSpaceProps> = ({
 
   useEffect(() => {
     fetchThreads();
-    asyncLoadSectionData();
-  }, [fetchThreads]);
+    dispatch(asyncLoadSectionData());
+  }, [fetchThreads, dispatch]);
 
   const aiPromptOutsideChatClicked = useCallback(
     (label: string, prompt: string) => {


### PR DESCRIPTION
Two small things:
1) Bug fix to load lesson info for AI differentiation on the lesson plan pages and anywhere else it wasn't already present.
2) Empty state message for teachers without sections.
<img width="785" height="717" alt="image" src="https://github.com/user-attachments/assets/3a062378-6014-4d17-9a17-d13bbc602a74" />


## Links
<!--  Links to relevant external resources.
      - spec docs, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- Jira: 

## Testing story
<!--  Does your change include appropriate tests?
      - If so, please describe how the tests included in this PR are sufficient.
      - If not, please explain why this change does not need to be tested. -->



## Deployment strategy
<!--  Any special steps required to deploy this, besides merging?
      - Are there database migrations or manual steps?
      - Does this require coordination with other teams or systems? -->



## Follow-up work
<!--  List any clean-up or technical debt that will be addressed in future work.
      - Include Jira links where applicable.
      - Are there any known limitations or improvements planned? -->



## Privacy
<!--  How does this change impact Student & Teacher privacy?
      - Does this collect, use, share, or modify PII, either new or existing? -->



## Security
<!--  How does this change impact our security surface-area?
      - Do API's touched have the right auth?
      - Do infra changes impact our attack surface or encryption?
-->



## Caching
<!--  How does this change impact caching behavior?
      - Are cache keys or invalidation strategies affected?
      - Will this require cache warming or invalidation after deployment? -->



## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
