### PR TITLE
Remove CodeMirror5 type reference from DropletPaletteSelector

### DIFF
--- a/apps/src/levelbuilder/level-editor/DropletPaletteSelector.jsx
+++ b/apps/src/levelbuilder/level-editor/DropletPaletteSelector.jsx
@@ -1,4 +1,3 @@
-import CodeMirror from 'codemirror';
 import PropTypes from 'prop-types';
 import React from 'react';
 
@@ -9,7 +8,11 @@ import React from 'react';
  */
 export default class DropletPaletteSelector extends React.Component {
   static propTypes = {
-    editor: PropTypes.instanceOf(CodeMirror).isRequired,
+    editor: PropTypes.shape({
+      getValue: PropTypes.func.isRequired,
+      setValue: PropTypes.func.isRequired,
+      on: PropTypes.func.isRequired,
+    }).isRequired,
     palette: PropTypes.object.isRequired,
   };
 

--- a/apps/test/unit/levelbuilder/level-editor/DropletPaletteSelectorTest.js
+++ b/apps/test/unit/levelbuilder/level-editor/DropletPaletteSelectorTest.js
@@ -7,8 +7,8 @@ import DropletPaletteSelector from '@cdo/apps/levelbuilder/level-editor/DropletP
 describe('DropletPaletteSelector', () => {
   let editor;
 
-  function createMockEditor(initialValue = '') {
-    let value = initialValue;
+  function createMockEditor() {
+    let value = '';
     const changeListeners = [];
 
     return {

--- a/apps/test/unit/levelbuilder/level-editor/DropletPaletteSelectorTest.js
+++ b/apps/test/unit/levelbuilder/level-editor/DropletPaletteSelectorTest.js
@@ -1,4 +1,3 @@
-import CodeMirror from 'codemirror';
 import {mount} from 'enzyme'; // eslint-disable-line no-restricted-imports
 import React from 'react';
 import {act} from 'react-dom/test-utils';
@@ -6,18 +5,30 @@ import {act} from 'react-dom/test-utils';
 import DropletPaletteSelector from '@cdo/apps/levelbuilder/level-editor/DropletPaletteSelector';
 
 describe('DropletPaletteSelector', () => {
-  let textArea, editor;
-  beforeEach(() => {
-    textArea = document.createElement('textarea');
-    document.body.appendChild(textArea);
-    editor = CodeMirror.fromTextArea(textArea);
-  });
+  let editor;
 
-  afterEach(() => {
-    // Removes the CodeMirror editor and restores the original textarea.
-    // @see https://codemirror.net/doc/manual.html#api_static
-    editor.toTextArea();
-    document.body.removeChild(textArea);
+  function createMockEditor(initialValue = '') {
+    let value = initialValue;
+    const changeListeners = [];
+
+    return {
+      on(event, callback) {
+        if (event === 'change') {
+          changeListeners.push(callback);
+        }
+      },
+      getValue() {
+        return value;
+      },
+      setValue(newValue) {
+        value = newValue;
+        changeListeners.forEach(listener => listener());
+      },
+    };
+  }
+
+  beforeEach(() => {
+    editor = createMockEditor();
   });
 
   describe('when the editor is empty and no blocks are provided in the palette', () => {
@@ -97,7 +108,7 @@ describe('DropletPaletteSelector', () => {
           />
         );
         await act(() => {
-          editor.setValue('invalud json');
+          editor.setValue('invalid json');
         });
         selector.update();
         expect(


### PR DESCRIPTION
Removes a CM5 reference that was only used for typing the prop passed in. Also updates the associated test file to use a mocked editor rather than an actual CM editor instance.

## Testing story

No behavior change, so I didn't test this manually.