### PR TITLE
🧹 Remove Radium from `ResourceLink`

### DIFF
--- a/apps/src/templates/instructions/ResourceLink.jsx
+++ b/apps/src/templates/instructions/ResourceLink.jsx
@@ -1,11 +1,12 @@
+import classNames from 'classnames';
 import PropTypes from 'prop-types';
-import Radium from 'radium'; // eslint-disable-line no-restricted-imports
 import React from 'react';
 
 import FontAwesome from '@cdo/apps/legacySharedComponents/FontAwesome';
-import color from '@cdo/apps/util/color';
 
 import LegacyDialog from '../../code-studio/LegacyDialog';
+
+import styles from './resource-link.module.scss';
 
 class ResourceLink extends React.Component {
   static propTypes = {
@@ -55,22 +56,21 @@ class ResourceLink extends React.Component {
   render() {
     const {icon, text, highlight} = this.props;
 
-    const iconStyle = {
-      ...styles.commonIcon,
-      ...(highlight ? styles.mapIcon : styles.resourceIcon),
-    };
-    const thumbnailStyle = {
-      ...styles.commonThumbnail,
-      ...(highlight && styles.mapThumbnail),
-    };
+    const iconClass = classNames(styles.commonIcon, {
+      [styles.mapIcon]: highlight,
+      [styles.resourceIcon]: !highlight,
+    });
+    const thumbnailClass = classNames(styles.commonThumbnail, {
+      [styles.mapThumbnail]: highlight,
+    });
 
     return (
       <div>
-        <div style={styles.resourceStyle} onClick={this.selectResource}>
-          <span style={thumbnailStyle}>
-            <FontAwesome icon={icon} style={iconStyle} title={text} />
+        <div className={styles.resourceStyle} onClick={this.selectResource}>
+          <span className={thumbnailClass}>
+            <FontAwesome icon={icon} className={iconClass} title={text} />
           </span>
-          <a href={this.props.reference} style={styles.textLink}>
+          <a href={this.props.reference} className={styles.textLink}>
             {text}
           </a>
         </div>
@@ -79,38 +79,4 @@ class ResourceLink extends React.Component {
   }
 }
 
-const styles = {
-  textLink: {
-    display: 'inline-block',
-    margin: 8,
-    fontWeight: 'bold',
-    fontSize: 16,
-    lineHeight: '25px',
-    cursor: 'pointer',
-    maxWidth: '90%',
-  },
-  mapThumbnail: {
-    backgroundColor: color.teal,
-  },
-  commonThumbnail: {
-    borderRadius: 5,
-    paddingLeft: 26,
-    paddingRight: 26,
-    paddingTop: 16,
-    paddingBottom: 9,
-  },
-  commonIcon: {
-    fontSize: 22,
-  },
-  mapIcon: {
-    color: color.white,
-  },
-  resourceIcon: {
-    color: color.teal,
-  },
-  resourceStyle: {
-    margin: 8,
-  },
-};
-
-export default Radium(ResourceLink);
+export default ResourceLink;

--- a/apps/src/templates/instructions/resource-link.module.scss
+++ b/apps/src/templates/instructions/resource-link.module.scss
@@ -1,0 +1,36 @@
+@import 'color';
+
+.textLink {
+  display: inline-block;
+  margin: 8px;
+  font-weight: bold;
+  font-size: 16px;
+  line-height: 25px;
+  cursor: pointer;
+  max-width: 90%;
+}
+
+.mapThumbnail {
+  background-color: $teal;
+}
+
+.commonThumbnail {
+  border-radius: 5px;
+  padding: 16px 26px 9px 26px;
+}
+
+.commonIcon {
+  font-size: 22px;
+}
+
+.mapIcon {
+  color: $white;
+}
+
+.resourceIcon {
+  color: $teal;
+}
+
+.resourceStyle {
+  margin: 8px;
+}


### PR DESCRIPTION
This work was originally done in https://github.com/code-dot-org/code-dot-org/pull/70513 but was reverted because of unexpected eyes diffs in https://github.com/code-dot-org/code-dot-org/pull/70626. I've opened https://github.com/code-dot-org/code-dot-org/pull/70626 to re-introduce the changes. However, rather than trying to merge the changes to all 11 of the instructions components at once, I'm going to incrementally reduce the diff on that PR by merging components in isolation to better identify where the eyes issues are coming from.