### PR TITLE
🧹 Remove Radium from `Overlay` component

### DIFF
--- a/apps/src/templates/Overlay.jsx
+++ b/apps/src/templates/Overlay.jsx
@@ -1,28 +1,15 @@
+import classNames from 'classnames';
 import PropTypes from 'prop-types';
-import Radium from 'radium'; // eslint-disable-line no-restricted-imports
 import React from 'react';
 import {connect} from 'react-redux';
 
 import {hideOverlay} from '../redux/instructions';
 
+import styles from './overlay.module.scss';
+
 // 1020 puts this halfway between the small footer (at 1000) and the
 // video modal backdrop (at 1040)
 export const Z_INDEX = 1020;
-
-const style = {
-  position: 'fixed',
-  top: 0,
-  left: 0,
-  height: '100%',
-  width: '100%',
-  opacity: 0.4,
-  backgroundColor: 'black',
-  zIndex: Z_INDEX,
-};
-
-const craftStyle = {
-  opacity: 0.8,
-};
 
 class Overlay extends React.Component {
   static propTypes = {
@@ -32,13 +19,19 @@ class Overlay extends React.Component {
   };
 
   render() {
-    return this.props.visible ? (
+    const {visible, hide, isMinecraft} = this.props;
+
+    if (!visible) {
+      return null;
+    }
+
+    return (
       <div
         id="overlay"
-        onClick={this.props.hide}
-        style={[style, this.props.isMinecraft && craftStyle]}
+        onClick={hide}
+        className={classNames(styles.overlay, isMinecraft && styles.minecraft)}
       />
-    ) : null;
+    );
   }
 }
 
@@ -56,4 +49,4 @@ export default connect(
       },
     };
   }
-)(Radium(Overlay));
+)(Overlay);

--- a/apps/src/templates/overlay.module.scss
+++ b/apps/src/templates/overlay.module.scss
@@ -1,0 +1,14 @@
+.overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  height: 100%;
+  width: 100%;
+  opacity: 0.4;
+  background-color: black;
+  z-index: 1020;
+}
+
+.minecraft {
+  opacity: 0.8;
+}


### PR DESCRIPTION
Radium is deprecated. We decided to stop using it in 2019 and [settled on the alternative scss modules in 2022](https://docs.google.com/document/d/1Y3uK_iYMhTUaCI6yIDwOAMprIJCuzXSs2fECQggwp60/edit?tab=t.0#heading=h.htf3pg55q2kt). It's 2026 now, and AI has removed some of the tedium of the this task so I've embarked on a side quest to incrementally remove all the usages of Radium. Here's another one!