### PR TITLE
Strip HTML from survey_data URL param in Foorm

### DIFF
--- a/dashboard/app/controllers/foorm/simple_survey_forms_controller.rb
+++ b/dashboard/app/controllers/foorm/simple_survey_forms_controller.rb
@@ -82,7 +82,7 @@ module Foorm
           formQuestions: form_questions,
           formName: form_data[:form_name],
           formVersion: form_data[:form_version] || 0,
-          surveyData: params[:survey_data] || form_data.survey_data,
+          surveyData: sanitize_survey_data(params[:survey_data]) || form_data.survey_data,
           submitApi: FOORM_SIMPLE_SURVEY_SUBMIT_API,
           submitParams: key_params
         }.to_json
@@ -134,7 +134,7 @@ module Foorm
           formQuestions: form_questions,
           formName: form_data[:form_name],
           formVersion: form_data[:form_version] || 0,
-          surveyData: params[:survey_data] || form_data.survey_data,
+          surveyData: sanitize_survey_data(params[:survey_data]) || form_data.survey_data,
           submitApi: FOORM_SIMPLE_SURVEY_SUBMIT_API,
           submitParams: key_params
         }.to_json
@@ -176,6 +176,14 @@ module Foorm
       end
 
       survey_data
+    end
+
+    # Sanitize survey_data URL params to prevent XSS by stripping HTML tags from values.
+    # Returns nil if params are blank (callers fall back to DB-stored survey data).
+    private def sanitize_survey_data(survey_data_params)
+      return nil if survey_data_params.blank?
+
+      survey_data_params.transform_values {|value| helpers.strip_tags(value.to_s)}
     end
   end
 end

--- a/dashboard/test/controllers/foorm/simple_survey_forms_controller_test.rb
+++ b/dashboard/test/controllers/foorm/simple_survey_forms_controller_test.rb
@@ -174,5 +174,43 @@ module Foorm
 
       assert_equal 'Must provide a name and value for any survey variables.', JSON.parse(@response.body)['error']
     end
+
+    test 'show passes through clean survey_data URL params' do
+      anonymous_form = create(:foorm_simple_survey_form,
+        form_name: @foorm_form.name,
+        properties: {allow_signed_out: true}
+      )
+
+      get "/form/#{anonymous_form.path}", params: {survey_data: {course: 'CS Principles'}}
+      assert_response :success
+      script_data = JSON.parse(assigns(:script_data)[:props])
+      assert_equal({'course' => 'CS Principles'}, script_data['surveyData'])
+    end
+
+    test 'show strips HTML tags from survey_data URL param values' do
+      anonymous_form = create(:foorm_simple_survey_form,
+        form_name: @foorm_form.name,
+        properties: {allow_signed_out: true}
+      )
+
+      get "/form/#{anonymous_form.path}",
+        params: {survey_data: {course: "<script>alert('xss')</script>"}}
+      assert_response :success
+      script_data = JSON.parse(assigns(:script_data)[:props])
+      # strip_tags removes script tag content entirely, not just the tag markup
+      assert_equal({'course' => ''}, script_data['surveyData'])
+    end
+
+    test 'configuration strips HTML tags from survey_data URL param values' do
+      sign_in @teacher
+
+      get "/form/#{@simple_survey_form.path}/configuration",
+        params: {survey_data: {course: "<script>alert('xss')</script>"}}
+      assert_response :success
+      response_data = JSON.parse(@response.body)
+      script_data = JSON.parse(response_data['props'])
+      # strip_tags removes script tag content entirely, not just the tag markup
+      assert_equal({'course' => ''}, script_data['surveyData'])
+    end
   end
 end


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->



## Links
<!--  Links to relevant external resources.
      - spec docs, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- Jira: 

## Testing story
<!--  Does your change include appropriate tests?
      - If so, please describe how the tests included in this PR are sufficient.
      - If not, please explain why this change does not need to be tested. -->



## Deployment strategy
<!--  Any special steps required to deploy this, besides merging?
      - Are there database migrations or manual steps?
      - Does this require coordination with other teams or systems? -->



## Follow-up work
<!--  List any clean-up or technical debt that will be addressed in future work.
      - Include Jira links where applicable.
      - Are there any known limitations or improvements planned? -->



## Privacy
<!--  How does this change impact Student & Teacher privacy?
      - Does this collect, use, share, or modify PII, either new or existing? -->



## Security
<!--  How does this change impact our security surface-area?
      - Do API's touched have the right auth?
      - Do infra changes impact our attack surface or encryption?
-->



## Caching
<!--  How does this change impact caching behavior?
      - Are cache keys or invalidation strategies affected?
      - Will this require cache warming or invalidation after deployment? -->



## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
