### PR TITLE
[A11y Linter] Turn back on no positive tabIndex rule

### DIFF
--- a/apps/.eslintrc.js
+++ b/apps/.eslintrc.js
@@ -11,7 +11,6 @@ const rulesToEventuallyReenable = {
   'jsx-a11y/label-has-associated-control': 'off',
   'jsx-a11y/no-noninteractive-element-interactions': 'off',
   'jsx-a11y/no-static-element-interactions': 'off',
-  'jsx-a11y/tabindex-no-positive': 'off',
 };
 
 const accessibilityTestingMessage =

--- a/apps/src/accounts/AddParentEmailModal.jsx
+++ b/apps/src/accounts/AddParentEmailModal.jsx
@@ -166,7 +166,6 @@ export default class AddParentEmailModal extends React.Component {
               type="email"
               value={values.parentEmail}
               disabled={saving}
-              tabIndex="1"
               onKeyDown={this.onKeyDown}
               onChange={this.onParentEmailChange}
               autoComplete="off"
@@ -184,7 +183,6 @@ export default class AddParentEmailModal extends React.Component {
               type="email"
               value={values.confirmedParentEmail}
               disabled={saving}
-              tabIndex="1"
               onKeyDown={this.onKeyDown}
               onChange={this.onConfirmedParentEmailChange}
               autoComplete="off"

--- a/apps/src/accounts/AddPasswordForm.jsx
+++ b/apps/src/accounts/AddPasswordForm.jsx
@@ -179,7 +179,6 @@ class PasswordField extends React.Component {
         <input
           type="password"
           value={value}
-          tabIndex="1"
           onChange={onChange}
           maxLength="255"
           size="255"

--- a/apps/src/accounts/BootstrapButton.jsx
+++ b/apps/src/accounts/BootstrapButton.jsx
@@ -55,7 +55,6 @@ export default class BootstrapButton extends React.Component {
         className={this.buttonClasses()}
         style={{...styles.button, ...style}}
         onClick={onClick}
-        tabIndex="1"
         disabled={disabled}
       >
         {text}

--- a/apps/src/accounts/ChangeUserTypeForm.jsx
+++ b/apps/src/accounts/ChangeUserTypeForm.jsx
@@ -55,12 +55,7 @@ export default class ChangeUserTypeForm extends React.Component {
     return (
       <span>
         {i18n.changeUserTypeModal_emailOptIn_description()}{' '}
-        <a
-          href={pegasus('/privacy')}
-          tabIndex="3"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
+        <a href={pegasus('/privacy')} target="_blank" rel="noopener noreferrer">
           {i18n.changeUserTypeModal_emailOptIn_privacyPolicy()}
         </a>
       </span>
@@ -81,7 +76,6 @@ export default class ChangeUserTypeForm extends React.Component {
             type="email"
             value={values.email}
             disabled={disabled}
-            tabIndex="1"
             onKeyDown={this.onKeyDown}
             onChange={this.onEmailChange}
             autoComplete="off"
@@ -98,7 +92,6 @@ export default class ChangeUserTypeForm extends React.Component {
           <select
             value={values.emailOptIn}
             disabled={disabled}
-            tabIndex="1"
             onKeyDown={this.onKeyDown}
             onChange={this.onEmailOptInChange}
             style={{

--- a/apps/src/accounts/PersonalLoginDialog.jsx
+++ b/apps/src/accounts/PersonalLoginDialog.jsx
@@ -67,7 +67,6 @@ export class PersonalLoginDialog extends React.Component {
                 color={Button.ButtonColor.blue}
                 size={Button.ButtonSize.large}
                 style={styles.button}
-                tabIndex="1"
               />
               <p>{i18n.personalLoginDialog_body6()}</p>
             </>

--- a/apps/src/p5lab/P5LabVisualizationColumn.jsx
+++ b/apps/src/p5lab/P5LabVisualizationColumn.jsx
@@ -173,7 +173,6 @@ class P5LabVisualizationColumn extends React.Component {
             <Pointable
               id="divGameLab"
               style={divGameLabStyle}
-              tabIndex="1"
               onPointerMove={this.pickerPointerMove}
               onPointerUp={this.pickerPointerUp}
               elementRef={el => (this.divGameLab = el)}


### PR DESCRIPTION
The Tab Index rule is a bit more straightforward: manually changing the tabIndex forces the tab order to be non-natural, which can be confusing for keyboard and screenreader users. Removing these positive TabIndex values allows the tab order to return to how these fields appear in the dom. Most of these are forms, and I was able to check the few that had storybook stories to verify that the order makes sense. 

I was able to validate with both Google and Claude that this is a safe approach, and that there are good accessibility advantages without much risk. 

Fixing the existing issues also allows me to enable the rule, ensuring we don't make this mistake again.


## Links

- Jira: https://codedotorg.atlassian.net/browse/SL-1590

## Testing story
<!--  Does your change include appropriate tests?
      - If so, please describe how the tests included in this PR are sufficient.
      - If not, please explain why this change does not need to be tested. -->



## Deployment strategy
<!--  Any special steps required to deploy this, besides merging?
      - Are there database migrations or manual steps?
      - Does this require coordination with other teams or systems? -->



## Follow-up work
<!--  List any clean-up or technical debt that will be addressed in future work.
      - Include Jira links where applicable.
      - Are there any known limitations or improvements planned? -->



## Privacy
<!--  How does this change impact Student & Teacher privacy?
      - Does this collect, use, share, or modify PII, either new or existing? -->



## Security
<!--  How does this change impact our security surface-area?
      - Do API's touched have the right auth?
      - Do infra changes impact our attack surface or encryption?
-->



## Caching
<!--  How does this change impact caching behavior?
      - Are cache keys or invalidation strategies affected?
      - Will this require cache warming or invalidation after deployment? -->



## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
