### PR TITLE
Tutor Permissions: Fix bug where ai chat alert doesn't show for CSD

### DIFF
--- a/dashboard/app/models/course_offering.rb
+++ b/dashboard/app/models/course_offering.rb
@@ -351,7 +351,7 @@ class CourseOffering < ApplicationRecord
 
   def ai_chat_tools_dependency
     # Returns the AI chat tools dependency for this course offering, which is determined by latest course version.
-    unit_group = course_versions.first&.content_root
+    unit_group = latest_published_version&.content_root
     unit_group&.ai_chat_tools_dependency
   end
 


### PR DESCRIPTION
We were previously picking the first `course_version` in the list to calculate `ai_chat_tools_dependency` and now we are picking the latest course version.

<img width="1427" height="506" alt="image" src="https://github.com/user-attachments/assets/ed319291-4450-4816-8039-f1c3fc44d1cd" />
