### PR TITLE
Web Lab 2: Set initial drawer height to max height

### DIFF
--- a/apps/src/lab2/views/components/Instructions/ResourcePanel/AiTutorChatWithInstructionDrawer.tsx
+++ b/apps/src/lab2/views/components/Instructions/ResourcePanel/AiTutorChatWithInstructionDrawer.tsx
@@ -27,7 +27,7 @@ interface AiTutorChatWithInstructionDrawerProps {
 
 const MIN_CHAT_HEIGHT = 133; // Minimum so that user message editor is always visible + some chat.
 const MIN_INSTRUCTIONS_HEIGHT = 150;
-const DEFAULT_INITIAL_INSTRUCTIONS_HEIGHT = 250;
+const DEFAULT_INITIAL_INSTRUCTIONS_HEIGHT = 250; // Initial height needed before instructions content is measured.
 
 const TOGGLE_BUTTON_ICONS = {
   left: {iconName: 'info-circle', iconStyle: 'solid'} as const,
@@ -51,6 +51,7 @@ const AiTutorChatWithInstructionDrawer: React.FunctionComponent<
   const containerRef = useRef<HTMLDivElement>(null);
   const instructionsContentRef = useRef<HTMLDivElement>(null);
   const instructionsHeightAtDragStartRef = useRef<number | null>(null);
+  const hasSetInitialHeightFromContentRef = useRef(false);
   const rawInstructionsHeightRef = useRef<number>(
     DEFAULT_INITIAL_INSTRUCTIONS_HEIGHT
   );
@@ -130,7 +131,7 @@ const AiTutorChatWithInstructionDrawer: React.FunctionComponent<
     return () => throttledAdjustChatHeight.cancel();
   }, [throttledAdjustChatHeight]);
 
-  // Listen for window resize events
+  // Listen for window resize events.
   useEffect(() => {
     window.addEventListener('resize', throttledAdjustChatHeight);
     return () => {
@@ -141,6 +142,13 @@ const AiTutorChatWithInstructionDrawer: React.FunctionComponent<
   useEffect(() => {
     setIsCollapsed(isCollapsedByDefault);
   }, [isCollapsedByDefault]);
+
+  // Reset so that when drawer is expanded again we set height from content.
+  useEffect(() => {
+    if (isCollapsed) {
+      hasSetInitialHeightFromContentRef.current = false;
+    }
+  }, [isCollapsed]);
 
   // Keep ref in sync with current height.
   useEffect(() => {
@@ -166,13 +174,16 @@ const AiTutorChatWithInstructionDrawer: React.FunctionComponent<
 
       setMaxInstructionsHeight(contentHeight);
 
+      // Set initial drawer height to full content height (maxInstructionsHeight).
+      if (!hasSetInitialHeightFromContentRef.current) {
+        hasSetInitialHeightFromContentRef.current = true;
+        setRawInstructionsHeight(contentHeight);
+        return;
+      }
+
       // Auto-adjust drawer height when new content height is less than the current drawer height.
       // This will remove a gap between instructions and drawer's edge.
       if (contentHeight < currentHeight) {
-        setRawInstructionsHeight(contentHeight);
-      }
-      // If content is smaller than initial height, adjust to fit content.
-      else if (contentHeight < DEFAULT_INITIAL_INSTRUCTIONS_HEIGHT) {
         setRawInstructionsHeight(contentHeight);
       }
     };

--- a/apps/src/lab2/views/components/Instructions/ResourcePanel/AiTutorChatWithInstructionDrawer.tsx
+++ b/apps/src/lab2/views/components/Instructions/ResourcePanel/AiTutorChatWithInstructionDrawer.tsx
@@ -28,6 +28,8 @@ interface AiTutorChatWithInstructionDrawerProps {
 const MIN_CHAT_HEIGHT = 133; // Minimum so that user message editor is always visible + some chat.
 const MIN_INSTRUCTIONS_HEIGHT = 150;
 const DEFAULT_INITIAL_INSTRUCTIONS_HEIGHT = 250; // Initial height needed before instructions content is measured.
+// Matches .instructionsDrawer padding (8px top + 8px bottom).
+const INSTRUCTIONS_DRAWER_VERTICAL_PADDING_PX = 16;
 
 const TOGGLE_BUTTON_ICONS = {
   left: {iconName: 'info-circle', iconStyle: 'solid'} as const,
@@ -51,10 +53,6 @@ const AiTutorChatWithInstructionDrawer: React.FunctionComponent<
   const containerRef = useRef<HTMLDivElement>(null);
   const instructionsContentRef = useRef<HTMLDivElement>(null);
   const instructionsHeightAtDragStartRef = useRef<number | null>(null);
-  const hasSetInitialHeightFromContentRef = useRef(false);
-  const rawInstructionsHeightRef = useRef<number>(
-    DEFAULT_INITIAL_INSTRUCTIONS_HEIGHT
-  );
   const [chatHeight, setChatHeight] = useState<number | undefined>(undefined);
   const [instructionsHeight, setInstructionsHeight] = useState<
     number | undefined
@@ -143,20 +141,8 @@ const AiTutorChatWithInstructionDrawer: React.FunctionComponent<
     setIsCollapsed(isCollapsedByDefault);
   }, [isCollapsedByDefault]);
 
-  // Reset so that when drawer is expanded again we set height from content.
-  useEffect(() => {
-    if (isCollapsed) {
-      hasSetInitialHeightFromContentRef.current = false;
-    }
-  }, [isCollapsed]);
-
-  // Keep ref in sync with current height.
-  useEffect(() => {
-    rawInstructionsHeightRef.current = rawInstructionsHeight;
-  }, [rawInstructionsHeight]);
-
-  // Measure the instructions content height and update when content change
-  // (e.g., details elements are expanded/collapsed).
+  // Measure the instructions content height on load and when it changes,
+  // (e.g., details elements expanded/collapsed), and set the drawer height to match.
   useEffect(() => {
     // Skip if instructions drawer is collapsed (unmounted).
     if (isCollapsed) {
@@ -170,21 +156,13 @@ const AiTutorChatWithInstructionDrawer: React.FunctionComponent<
 
     const updateMaxHeight = () => {
       const contentHeight = instructionsContentElement.scrollHeight;
-      const currentHeight = rawInstructionsHeightRef.current;
 
-      setMaxInstructionsHeight(contentHeight);
-
-      // Set initial drawer height to full content height (maxInstructionsHeight).
-      if (!hasSetInitialHeightFromContentRef.current) {
-        hasSetInitialHeightFromContentRef.current = true;
-        setRawInstructionsHeight(contentHeight);
-        return;
-      }
-
-      // Auto-adjust drawer height when new content height is less than the current drawer height.
-      // This will remove a gap between instructions and drawer's edge.
-      if (contentHeight < currentHeight) {
-        setRawInstructionsHeight(contentHeight);
+      if (contentHeight > 0) {
+        // Include drawer padding so the scroll area height matches content (no extra scroll).
+        const drawerHeight =
+          contentHeight + INSTRUCTIONS_DRAWER_VERTICAL_PADDING_PX;
+        setMaxInstructionsHeight(drawerHeight);
+        setRawInstructionsHeight(drawerHeight);
       }
     };
 


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
This PR updates the instructions drawer so that the initial height is the max height of instructions content. This came up when viewing predict levels and noticing that the 'Submit' button was not in view.


## Before update

Student viewing `weblab2` predict level:

https://github.com/user-attachments/assets/8fb57f9d-37b7-4c81-8f49-43d4227af922

Teacher viewing `weblab2` predict level:

https://github.com/user-attachments/assets/14893419-ae20-47a8-9deb-a4e973b2dd71


## After update

Student viewing `weblab2` predict level:

https://github.com/user-attachments/assets/f1b1f3e1-7407-4c0b-aacf-6f1292570ee3


Teacher viewing `weblab2` predict level:

https://github.com/user-attachments/assets/be669533-ba56-441c-a033-967cbed207b5


User navigating through multiple `weblab2` levels - initial height depends on instructions content:


https://github.com/user-attachments/assets/8cf8f260-1cb8-4147-b510-78e2a04eb979





## Links
<!--  Links to relevant external resources.
      - spec docs, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- Jira: https://codedotorg.atlassian.net/browse/AFL-485

## Testing story
<!--  Does your change include appropriate tests?
      - If so, please describe how the tests included in this PR are sufficient.
      - If not, please explain why this change does not need to be tested. -->

Tested locally on `weblab2` levels.

## Deployment strategy
<!--  Any special steps required to deploy this, besides merging?
      - Are there database migrations or manual steps?
      - Does this require coordination with other teams or systems? -->



## Follow-up work
<!--  List any clean-up or technical debt that will be addressed in future work.
      - Include Jira links where applicable.
      - Are there any known limitations or improvements planned? -->



## Privacy
<!--  How does this change impact Student & Teacher privacy?
      - Does this collect, use, share, or modify PII, either new or existing? -->



## Security
<!--  How does this change impact our security surface-area?
      - Do API's touched have the right auth?
      - Do infra changes impact our attack surface or encryption?
-->



## Caching
<!--  How does this change impact caching behavior?
      - Are cache keys or invalidation strategies affected?
      - Will this require cache warming or invalidation after deployment? -->



## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
