### PR TITLE
Fix that teacher description was showing up on course overview

### DIFF
--- a/apps/src/templates/courseOverview/CourseOverview.js
+++ b/apps/src/templates/courseOverview/CourseOverview.js
@@ -160,6 +160,12 @@ class CourseOverview extends Component {
     const showNotification =
       viewAsTeacher && !isVerifiedInstructor && hasVerifiedResources;
 
+    const determineUnitDescription = script => {
+      return viewAs === ViewType.Participant
+        ? script.studentDescription
+        : script.description;
+    };
+
     return (
       <div style={styles.main}>
         {redirectToCourseUrl && !dismissedRedirectDialog(name) && (
@@ -239,7 +245,7 @@ class CourseOverview extends Component {
             name={script.name}
             id={script.id}
             path={script.scriptPath}
-            description={script.description}
+            description={determineUnitDescription(script)}
             assignedSectionId={script.assigned_section_id}
             courseId={id}
             courseOfferingId={courseOfferingId}


### PR DESCRIPTION
Based on [this](https://codeorg.zendesk.com/agent/tickets/577838) ZenDesk ticket...

Apparently we have been showing the teacher overview on the course landing page... maybe for a while?

<img width="902" height="487" alt="image" src="https://github.com/user-attachments/assets/ce9df83f-f454-4df3-8a09-fa5bdc563ca5" />

And no change for the teacher view below

<img width="983" height="520" alt="image" src="https://github.com/user-attachments/assets/03fab6a8-f969-4560-9f65-823ce32e2ff2" />


## Links
<!--  Links to relevant external resources.
      - spec docs, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- Jira: 

## Testing story
<!--  Does your change include appropriate tests?
      - If so, please describe how the tests included in this PR are sufficient.
      - If not, please explain why this change does not need to be tested. -->



## Deployment strategy
<!--  Any special steps required to deploy this, besides merging?
      - Are there database migrations or manual steps?
      - Does this require coordination with other teams or systems? -->



## Follow-up work
<!--  List any clean-up or technical debt that will be addressed in future work.
      - Include Jira links where applicable.
      - Are there any known limitations or improvements planned? -->



## Privacy
<!--  How does this change impact Student & Teacher privacy?
      - Does this collect, use, share, or modify PII, either new or existing? -->



## Security
<!--  How does this change impact our security surface-area?
      - Do API's touched have the right auth?
      - Do infra changes impact our attack surface or encryption?
-->



## Caching
<!--  How does this change impact caching behavior?
      - Are cache keys or invalidation strategies affected?
      - Will this require cache warming or invalidation after deployment? -->



## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
