### PR TITLE
use rake_stream_output when setting up unit test db in drone

### DIFF
--- a/lib/rake/install.rake
+++ b/lib/rake/install.rake
@@ -47,7 +47,7 @@ namespace :install do
         if ENV['CI']
           if ENV['CI_JOB'] == 'unit_tests'
             # Prepare for dashboard unit tests to run.
-            RakeUtils.rake 'db:create db:test:prepare'
+            RakeUtils.rake_stream_output 'db:create db:test:prepare'
           else
             # If we don't already have a database that's been restored from a
             # cache, prepare one from scratch by creating the database and loading


### PR DESCRIPTION
A [recent drone run](https://drone.cdn-code.org/code-dot-org/code-dot-org/49315/1/5) was hard to debug because it failed without detailed error output while initializing the unit test DB. This PR makes it easier to debug this kind of failure. This adds about 20 lines of output to the drone unit test output (everything after the first line is added):
```
RAILS_ENV=test RACK_ENV=test bundle exec rake db:create db:test:prepare
WARNING: MYSQL_OPT_RECONNECT is deprecated and will be removed in a future version.
WARNING: MYSQL_OPT_RECONNECT is deprecated and will be removed in a future version.
Created database 'dashboard_test'
WARNING: MYSQL_OPT_RECONNECT is deprecated and will be removed in a future version.
WARNING: MYSQL_OPT_RECONNECT is deprecated and will be removed in a future version.
WARNING: MYSQL_OPT_RECONNECT is deprecated and will be removed in a future version.
WARNING: MYSQL_OPT_RECONNECT is deprecated and will be removed in a future version.
WARNING: MYSQL_OPT_RECONNECT is deprecated and will be removed in a future version.
Finished seed:check_migrations (less than 1 second)
Finished seed:videos (less than 1 second)
Finished seed:games (less than 1 second)
Finished seed:concepts (less than 1 second)
Finished seed:secret_words (less than 1 second)
Finished seed:secret_pictures (less than 1 second)
Finished seed:school_districts (less than 1 second)
Finished seed:schools (less than 1 second)
Finished seed:standards (42 seconds)
Finished seed:foorms (2 seconds)
Finished seed:test (less than 1 second)
Finished install:dashboard (2 minutes)
```

## Testing story
- passing drone run provides good coverage that I didn't break anything here