### PR TITLE
AI Tutor Permissions: remove old AI Tutor enablement toggle

### DIFF
--- a/apps/src/templates/sectionsRefresh/AdvancedSettingToggles.jsx
+++ b/apps/src/templates/sectionsRefresh/AdvancedSettingToggles.jsx
@@ -2,20 +2,12 @@ import Toggle from '@code-dot-org/component-library/toggle';
 import PropTypes from 'prop-types';
 import React from 'react';
 
-import {EVENTS} from '@cdo/apps/metrics/AnalyticsConstants';
-import analyticsReporter from '@cdo/apps/metrics/AnalyticsReporter';
 import InfoHelpTip from '@cdo/apps/sharedComponents/InfoHelpTip';
 import i18n from '@cdo/locale';
 
 import style from './sections-refresh.module.scss';
 
-export default function AdvancedSettingToggles({
-  updateSection,
-  section,
-  // aiTutorAvailable refers to whether the selected assignment has AI Tutor available,
-  // i.e. have we trained AI to answer questions about that specific course or unit.
-  aiTutorAvailable,
-}) {
+export default function AdvancedSettingToggles({updateSection, section}) {
   const handlePairProgrammingToggle = e => {
     const updatedValue = !section.pairingAllowed;
     updateSection('pairingAllowed', updatedValue);
@@ -34,18 +26,6 @@ export default function AdvancedSettingToggles({
   const handleTtsAutoplayEnabledToggle = e => {
     const updatedValue = !section.ttsAutoplayEnabled;
     updateSection('ttsAutoplayEnabled', updatedValue);
-  };
-
-  const handleAITutorEnabledToggle = e => {
-    const updatedValue = !section.aiTutorEnabled;
-    const event = section.aiTutorEnabled
-      ? EVENTS.AI_TUTOR_DISABLED
-      : EVENTS.AI_TUTOR_ENABLED;
-    analyticsReporter.sendEvent(event, {
-      sectionId: section.id,
-      uiLocation: 'sectionEditAdvancedSettings',
-    });
-    updateSection('aiTutorEnabled', updatedValue);
   };
 
   return (
@@ -106,20 +86,6 @@ export default function AdvancedSettingToggles({
           />
         </div>
       )}
-      {aiTutorAvailable && (
-        <div className={style.toolTipContainer}>
-          <Toggle
-            id={'uitest-ai-tutor-toggle'}
-            checked={section.aiTutorEnabled}
-            onChange={e => handleAITutorEnabledToggle(e)}
-            label={i18n.enableAITutor()}
-          />
-          <InfoHelpTip
-            id={'ai-tutor-toggle-info'}
-            content={i18n.enableAITutorTooltip()}
-          />
-        </div>
-      )}
     </div>
   );
 }
@@ -127,5 +93,4 @@ export default function AdvancedSettingToggles({
 AdvancedSettingToggles.propTypes = {
   section: PropTypes.object.isRequired,
   updateSection: PropTypes.func.isRequired,
-  aiTutorAvailable: PropTypes.bool,
 };

--- a/apps/src/templates/sectionsRefresh/SectionsSetUpContainer.jsx
+++ b/apps/src/templates/sectionsRefresh/SectionsSetUpContainer.jsx
@@ -17,7 +17,6 @@ import Notification, {
 import Spinner from '@cdo/apps/sharedComponents/Spinner';
 import GlobalEditionWrapper from '@cdo/apps/templates/GlobalEditionWrapper';
 import CoteacherSettings from '@cdo/apps/templates/sectionsRefresh/coteacherSettings/CoteacherSettings';
-import experiments from '@cdo/apps/util/experiments';
 import {navigateToHref} from '@cdo/apps/utils';
 import {
   CapLinks,
@@ -366,21 +365,7 @@ export default function SectionsSetUpContainer({
     );
   };
 
-  // TODO-AITUTOR: can we allow this for any course that has a unit with Unit.has_ai_tutor_level?
-  // TODO: This will probably eventually be a setting on the course similar to textToSpeechEnabled
-  // The ticket to track that work is https://codedotorg.atlassian.net/browse/CT-1063
-  const aiTutorAllowedForCourse = section =>
-    [
-      '[PILOT] Programming Fundamentals (AI Tutor)',
-      'Computer Science A',
-    ].includes(section?.course?.displayName);
-
   const renderAdvancedSettings = () => {
-    const aiTutorAvailable =
-      experiments.isEnabledAllowingQueryString(
-        experiments.AI_CHAT_NEW_PERMISSIONS
-      ) && aiTutorAllowedForCourse(sections[0]);
-
     return renderExpandableSection(
       'uitest-expandable-settings',
       () => i18n.advancedSettings(),
@@ -390,7 +375,6 @@ export default function SectionsSetUpContainer({
             updateSectionAndSetEditInProgress(0, key, val)
           }
           section={sections[0]}
-          aiTutorAvailable={aiTutorAvailable}
           label={i18n.pairProgramming()}
         />
       ),

--- a/apps/test/unit/templates/sectionsRefresh/AdvancedSettingTogglesTest.jsx
+++ b/apps/test/unit/templates/sectionsRefresh/AdvancedSettingTogglesTest.jsx
@@ -23,8 +23,6 @@ describe('AdvancedSettingToggles', () => {
       i18n.enableLessonExtrasToggle()
     );
     expect(lessonExtrasToggle).toBeNull();
-    const aiTutorToggle = screen.queryByText(i18n.enableAITutor());
-    expect(aiTutorToggle).toBeNull();
   });
 
   it('renders Lesson Extras toggle when available, enabled', () => {
@@ -55,19 +53,5 @@ describe('AdvancedSettingToggles', () => {
     );
     const ttsToggle = screen.getByLabelText(i18n.enableTtsAutoplayToggle());
     expect(ttsToggle).not.toHaveAttribute('checked');
-  });
-
-  it('renders enable AI Tutor toggle when available, enabled', () => {
-    render(
-      <AdvancedSettingToggles
-        updateSection={() => {}}
-        section={{
-          aiTutorEnabled: true,
-        }}
-        aiTutorAvailable={true}
-      />
-    );
-    const aiTutorToggle = screen.getByLabelText(i18n.enableAITutor());
-    expect(aiTutorToggle).toHaveAttribute('checked');
   });
 });


### PR DESCRIPTION
We have a fancy new permissions system for ai chat tools and a whole teacher dashboard page to manage the settings 🎉 . 

Which means this toggle from AI Tutor v1 early days is no longer relevant, and we can delete it. 
<img width="712" height="223" alt="Screenshot 2026-02-24 at 9 41 22 PM" src="https://github.com/user-attachments/assets/41c1c87d-8b85-43af-a960-05c2f2f31f5e" />
