### PR TITLE
Fix styling for mui typography, include course css for better printing

### DIFF
--- a/apps/src/sites/studio/pages/aidiff_exit_tickets/show.js
+++ b/apps/src/sites/studio/pages/aidiff_exit_tickets/show.js
@@ -1,7 +1,7 @@
 import React from 'react';
-import ReactDOM from 'react-dom';
 
 import AiDiffExitTicket from '@cdo/apps/aiDifferentiation/AiDiffExitTicket';
+import {createReactRoot} from '@cdo/apps/util/createReactRoot';
 import getScriptData from '@cdo/apps/util/getScriptData';
 
 $(document).ready(function () {
@@ -11,7 +11,7 @@ $(document).ready(function () {
 function displayExitTicket() {
   const exitTicketData = getScriptData('artifact');
 
-  ReactDOM.render(
+  createReactRoot(
     <AiDiffExitTicket
       title={exitTicketData['title']}
       updated={new Date(exitTicketData['updated_at'])}

--- a/apps/src/sites/studio/pages/aidiff_lesson_hooks/show.js
+++ b/apps/src/sites/studio/pages/aidiff_lesson_hooks/show.js
@@ -1,7 +1,7 @@
 import React from 'react';
-import ReactDOM from 'react-dom';
 
 import AiDiffLessonHook from '@cdo/apps/aiDifferentiation/AiDiffLessonHook';
+import {createReactRoot} from '@cdo/apps/util/createReactRoot';
 import getScriptData from '@cdo/apps/util/getScriptData';
 
 $(document).ready(function () {
@@ -11,7 +11,7 @@ $(document).ready(function () {
 function displayLessonHook() {
   const lessonHookData = getScriptData('artifact');
 
-  ReactDOM.render(
+  createReactRoot(
     <AiDiffLessonHook
       title={lessonHookData['title']}
       updated={new Date(lessonHookData['updated_at'])}

--- a/dashboard/app/views/aidiff_exit_tickets/show.html.haml
+++ b/dashboard/app/views/aidiff_exit_tickets/show.html.haml
@@ -1,3 +1,4 @@
+%link{href: asset_path('css/courses.css'), rel: 'stylesheet', type: 'text/css'}
 %script{src: webpack_asset_path('js/aidiff_exit_tickets/show.js'),
         data: {artifact: @aidiff_exit_ticket.summarize.to_json}}
 

--- a/dashboard/app/views/aidiff_lesson_hooks/show.html.haml
+++ b/dashboard/app/views/aidiff_lesson_hooks/show.html.haml
@@ -1,3 +1,4 @@
+%link{href: asset_path('css/courses.css'), rel: 'stylesheet', type: 'text/css'}
 %script{src: webpack_asset_path('js/aidiff_lesson_hooks/show.js'),
         data: {artifact: @aidiff_lesson_hook.summarize.to_json}}
 


### PR DESCRIPTION
Fixing the mui typography stying on the projection view page- it requires using `createReactRoot` instead of `ReactDom.render` on the react entry point for the page. This was missed in the original conversion because it's a new page.

## Links
<!--  Links to relevant external resources.
      - spec docs, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- Jira: 

## Testing story
<!--  Does your change include appropriate tests?
      - If so, please describe how the tests included in this PR are sufficient.
      - If not, please explain why this change does not need to be tested. -->



## Deployment strategy
<!--  Any special steps required to deploy this, besides merging?
      - Are there database migrations or manual steps?
      - Does this require coordination with other teams or systems? -->



## Follow-up work
<!--  List any clean-up or technical debt that will be addressed in future work.
      - Include Jira links where applicable.
      - Are there any known limitations or improvements planned? -->



## Privacy
<!--  How does this change impact Student & Teacher privacy?
      - Does this collect, use, share, or modify PII, either new or existing? -->



## Security
<!--  How does this change impact our security surface-area?
      - Do API's touched have the right auth?
      - Do infra changes impact our attack surface or encryption?
-->



## Caching
<!--  How does this change impact caching behavior?
      - Are cache keys or invalidation strategies affected?
      - Will this require cache warming or invalidation after deployment? -->



## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
