### PR TITLE
AI Tutor Permissions: add a couple more details to AI settings Statsig logging

### DIFF
--- a/apps/src/aichat/views/accessControls/AiChatAccessControls.tsx
+++ b/apps/src/aichat/views/accessControls/AiChatAccessControls.tsx
@@ -84,7 +84,9 @@ const AiChatAccessControls: React.FC = () => {
     );
     analyticsReporter.sendEvent(EVENTS.AI_CHAT_SECTION_ACCESS_LEVEL_UPDATED, {
       sectionId: section.id,
+      oldAccessLevel: section.aiChatAccessLevel,
       newAccessLevel: newAccessLevel,
+      courseAssigned: section.courseVersionName,
       uiLocation: 'aiSettingsTeacherDashboardTab',
     });
   };

--- a/apps/src/aichat/views/accessControls/AiChatAccessControls.tsx
+++ b/apps/src/aichat/views/accessControls/AiChatAccessControls.tsx
@@ -22,7 +22,6 @@ import {AiChatAccessLevel} from '../../types';
 import InfoTooltipIcon from '../InfoTooltipIcon';
 
 import style from './ai-chat-access-controls.module.scss';
-import {assign} from 'lodash';
 
 /**
  * Renders toggles to control student access to AI chat features.

--- a/apps/src/aichat/views/accessControls/AiChatAccessControls.tsx
+++ b/apps/src/aichat/views/accessControls/AiChatAccessControls.tsx
@@ -22,6 +22,7 @@ import {AiChatAccessLevel} from '../../types';
 import InfoTooltipIcon from '../InfoTooltipIcon';
 
 import style from './ai-chat-access-controls.module.scss';
+import {assign} from 'lodash';
 
 /**
  * Renders toggles to control student access to AI chat features.
@@ -87,6 +88,7 @@ const AiChatAccessControls: React.FC = () => {
       oldAccessLevel: section.aiChatAccessLevel,
       newAccessLevel: newAccessLevel,
       courseAssigned: section.courseVersionName,
+      assignedAiAccessDependency: section.assignedAiChatToolsDependency,
       uiLocation: 'aiSettingsTeacherDashboardTab',
     });
   };


### PR DESCRIPTION
Adds a couple of additional fields to what we log to Statsig when a teacher changes AI chat settings for a section from the teacher dashboard. We now additionally know what the previous setting was so we can identify things like "changed from disabled to essential-only" and what course is assigned to the section. 

A couple examples with different courses assigned and different before and after access settings. 

<img width="506" height="76" alt="Screenshot 2026-02-25 at 10 49 22 AM" src="https://github.com/user-attachments/assets/d0b925a1-6bd0-45dd-868a-6f3dd0c3e223" />

<img width="519" height="68" alt="Screenshot 2026-02-25 at 10 48 16 AM" src="https://github.com/user-attachments/assets/d6d39242-9699-478f-8dad-e14a2b46ee11" />
