### PR TITLE
Tutor Video - Add failed to load image

### DIFF
--- a/apps/src/jsonVideo/TutorVideo.tsx
+++ b/apps/src/jsonVideo/TutorVideo.tsx
@@ -1,0 +1,52 @@
+import React, {useEffect, useRef, useState} from 'react';
+
+import errorPosterImg from '@cdo/static/tutorVideo/tutor-video-did-not-load-2x.png';
+
+interface TutorVideoProps {
+  href: string;
+}
+
+const TutorVideo: React.FC<TutorVideoProps> = ({href}) => {
+  const videoRef = useRef<HTMLElement>(null);
+
+  const [hasError, setHasError] = useState<boolean>(false);
+
+  useEffect(() => {
+    const videoElement = videoRef.current;
+    if (!videoElement) {
+      return;
+    }
+
+    const handleVideoError = () => {
+      setHasError(true);
+    };
+
+    const handleVideoSuccess = () => {
+      setHasError(false);
+    };
+
+    videoElement.addEventListener('error', handleVideoError);
+    videoElement.addEventListener('loadeddata', handleVideoSuccess);
+
+    return () => {
+      videoElement.removeEventListener('error', handleVideoError);
+      videoElement.removeEventListener('loadeddata', handleVideoSuccess);
+    };
+  }, []);
+
+  return (
+    <json-video
+      ref={videoRef}
+      controls="true"
+      src={href}
+      {...(hasError
+        ? {
+            poster: errorPosterImg,
+            'aria-label': 'The Video is Unavailable',
+          }
+        : {})}
+    />
+  );
+};
+
+export default TutorVideo;

--- a/apps/src/jsonVideo/jsonVideoElement.js
+++ b/apps/src/jsonVideo/jsonVideoElement.js
@@ -1,8 +1,21 @@
 import styles from './jsonVideoStyles';
 
+// Simulated MediaError to match native <video> behavior
+class SimulatedMediaError {
+  constructor(code, message) {
+    this.code = code;
+    this.message = message;
+    // Standard codes: 1=ABORTED, 2=NETWORK, 3=DECODE, 4=SRC_NOT_SUPPORTED
+    this.MEDIA_ERR_ABORTED = 1;
+    this.MEDIA_ERR_NETWORK = 2;
+    this.MEDIA_ERR_DECODE = 3;
+    this.MEDIA_ERR_SRC_NOT_SUPPORTED = 4;
+  }
+}
+
 export class JsonVideo extends HTMLElement {
   static get observedAttributes() {
-    return ['src', 'controls'];
+    return ['src', 'controls', 'poster'];
   }
 
   constructor() {
@@ -19,6 +32,9 @@ export class JsonVideo extends HTMLElement {
     this._animationFrameId = null;
     this._showCaptions = false;
     this._volume = 1.0;
+
+    // Mimic standard video properties
+    this.error = null;
 
     this._mainAudio = new Audio();
     this._sceneAudio = new Audio();
@@ -42,6 +58,7 @@ export class JsonVideo extends HTMLElement {
     container.id = 'video-container';
 
     container.innerHTML = `
+            <img id="poster" class="hidden" alt="">
             <iframe id="scene-renderer" src="about:blank" scrolling="no"></iframe>
             <div id="closed-caption-overlay" class="hidden"><span class="cc-text"></span></div>
             <div id="controls-bar">
@@ -67,6 +84,7 @@ export class JsonVideo extends HTMLElement {
     this.shadowRoot.appendChild(container);
 
     this.renderer = this.shadowRoot.querySelector('#scene-renderer');
+    this.posterImg = this.shadowRoot.querySelector('#poster');
     this.ccOverlay = this.shadowRoot.querySelector('#closed-caption-overlay');
     this.ccText = this.shadowRoot.querySelector('.cc-text');
 
@@ -126,13 +144,17 @@ export class JsonVideo extends HTMLElement {
     this.shadowRoot.querySelector('#video-container').onclick = e => {
       if (
         e.target.id === 'video-container' ||
-        e.target.id === 'scene-renderer'
+        e.target.id === 'scene-renderer' ||
+        e.target.id === 'poster'
       ) {
         this.paused ? this.play() : this.pause();
       }
     };
 
-    this.addEventListener('play', () => this.classList.add('playing'));
+    this.addEventListener('play', () => {
+      this.classList.add('playing');
+      this.posterImg.classList.add('hidden'); // Hide poster on play
+    });
     this.addEventListener('pause', () => this.classList.remove('playing'));
     this.addEventListener('timeupdate', () => this._updateUI());
   }
@@ -166,15 +188,44 @@ export class JsonVideo extends HTMLElement {
   get paused() {
     return !this._isPlaying;
   }
+  get poster() {
+    return this.getAttribute('poster');
+  }
+  set poster(val) {
+    if (val) this.setAttribute('poster', val);
+    else this.removeAttribute('poster');
+  }
 
   attributeChangedCallback(name, oldVal, newVal) {
-    if (name === 'src' && newVal) this.load();
+    if (name === 'src' && newVal !== oldVal) this.load();
+    if (name === 'poster') this._updatePosterUI(newVal);
+  }
+
+  _updatePosterUI(url) {
+    if (url) {
+      this.posterImg.src = url;
+      // Only show the poster if we haven't started playing yet
+      if (!this._isPlaying) {
+        this.posterImg.classList.remove('hidden');
+      }
+    } else {
+      this.posterImg.src = '';
+      this.posterImg.classList.add('hidden');
+    }
   }
 
   async load() {
     const source = this.src;
     if (!source) return;
+
     this.pause();
+    this.error = null; // Reset error state on new load
+
+    // Show poster while loading if one exists
+    if (this.poster) {
+      this.posterImg.classList.remove('hidden');
+    }
+
     let data = null;
     try {
       if (source.startsWith('data:application/json')) {
@@ -182,11 +233,29 @@ export class JsonVideo extends HTMLElement {
         data = JSON.parse(decodeURIComponent(source.substring(commaIndex + 1)));
       } else {
         const response = await fetch(source);
+        if (!response.ok) {
+          // Throw so we catch it below and simulate a network error
+          throw new SimulatedMediaError(
+            2,
+            `Network response was not ok: ${response.status}`
+          );
+        }
         data = await response.json();
       }
       this._processLoadedData(data);
     } catch (e) {
       console.error('JsonVideo load error:', e);
+
+      this.classList.add('has-error');
+
+      // If it's not our SimulatedMediaError (e.g., a JSON parse error), classify as DECODE error
+      this.error =
+        e instanceof SimulatedMediaError
+          ? e
+          : new SimulatedMediaError(3, e.message);
+
+      // Dispatch standard error event
+      this.dispatchEvent(new Event('error'));
     }
   }
 
@@ -199,7 +268,10 @@ export class JsonVideo extends HTMLElement {
     }
     this.seekTo(0);
     this.ui.totTime.textContent = this._formatTime(this._totalDurationMs);
+
+    // Dispatch success events similar to native <video>
     this.dispatchEvent(new Event('loadedmetadata'));
+    this.dispatchEvent(new Event('loadeddata'));
   }
 
   play() {
@@ -340,9 +412,7 @@ export class JsonVideo extends HTMLElement {
     const scene = this._processedScenes[this._currentSceneIndex];
     if (!scene) return;
 
-    // 1. Handle HTML Rendering via Blob URL
     if (scene.html) {
-      // Clean up previous blob to prevent memory leaks
       if (this._currentBlobUrl) {
         URL.revokeObjectURL(this._currentBlobUrl);
       }
@@ -370,14 +440,12 @@ export class JsonVideo extends HTMLElement {
       this.renderer.src = 'about:blank';
     }
 
-    // 2. Handle Captions
     this.ccText.textContent = scene.speech || '';
     this.ccOverlay.classList.toggle(
       'hidden',
       !(this._showCaptions && scene.speech)
     );
 
-    // 3. Handle Audio Synchronization
     const sceneTime = (this._currentTimeMs - scene.startTimeMs) / 1000;
     if (scene.audio) {
       if (this._sceneAudio.getAttribute('src') !== scene.audio) {
@@ -385,7 +453,6 @@ export class JsonVideo extends HTMLElement {
         this._sceneAudio.load();
       }
 
-      // Only sync if the drift is significant (>200ms)
       try {
         if (Math.abs(this._sceneAudio.currentTime - sceneTime) > 0.2) {
           this._sceneAudio.currentTime = Math.max(0, sceneTime);

--- a/apps/src/jsonVideo/jsonVideoRehypeMap.tsx
+++ b/apps/src/jsonVideo/jsonVideoRehypeMap.tsx
@@ -1,11 +1,13 @@
 import React from 'react';
+
 import '@cdo/apps/jsonVideo/jsonVideoElement';
+import TutorVideo from './TutorVideo';
 
 const LinkWrapper: React.FunctionComponent<
   React.AnchorHTMLAttributes<HTMLAnchorElement>
 > = ({children, ...props}) => {
   if (props.href?.includes('assets/js/json')) {
-    return <json-video controls="true" src={props.href} />;
+    return <TutorVideo href={props.href} />;
   }
   return <a {...props}>{children}</a>;
 };

--- a/apps/src/jsonVideo/jsonVideoStyles.ts
+++ b/apps/src/jsonVideo/jsonVideoStyles.ts
@@ -25,6 +25,19 @@ iframe {
     pointer-events: none;
 }
 
+/* Poster Image */
+#poster {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: auto;
+    object-fit: contain;
+    background-color: #000;
+    z-index: 5;
+    pointer-events: auto; /* Ensures clicks register for play/pause */
+}
+
 /* Captions Overlay */
 #closed-caption-overlay {
     position: absolute;
@@ -63,6 +76,7 @@ iframe {
     padding: 0 12px 8px 12px;
     gap: 0;
     transition: opacity 0.2s ease-in-out;
+    z-index: 10; /* Ensures controls stay above the poster */
 }
 
 :host([controls]) #controls-bar {
@@ -77,6 +91,13 @@ iframe {
     display: none;
 }
 
+/* Make controls look disabled on error */
+:host(.has-error) #controls-bar {
+    opacity: 0.5;
+    pointer-events: none; /* Prevents clicking play/volume/scrubber */
+    filter: grayscale(100%);
+}
+    
 .controls-row {
     display: flex;
     align-items: center;
@@ -243,8 +264,6 @@ input[type=range]::-moz-range-thumb {
     opacity: 0;
     pointer-events: none;
 }
-
-
 `;
 
 export default styles;

--- a/apps/static/tutorVideo/tutor-video-did-not-load-2x.png
+++ b/apps/static/tutorVideo/tutor-video-did-not-load-2x.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a2c093f478586caa86cf75442664911336cb512d387997f9aaede894f30f941a
-size 63460
+oid sha256:034dfdc7e543e79a6843de8293549e15ebe86e8b2848037f7f731cae1fd63f7d
+size 29836

--- a/apps/static/tutorVideo/tutor-video-did-not-load-2x.png
+++ b/apps/static/tutorVideo/tutor-video-did-not-load-2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a2c093f478586caa86cf75442664911336cb512d387997f9aaede894f30f941a
+size 63460


### PR DESCRIPTION
This PR adds a failed-to-load ("The video is unavailable") "poster" to the video when it fails to load.  It also adds an `aria-label` with the same text for accessibility.

@MollyPeredo The original [figma file](https://www.figma.com/design/0N1omhsslc169UbQ8PQGUc/AI-Tutor--Lab-Integration?node-id=5475-573&p=f&t=8FP9kz2S1I8ZuUu4-0) ended up with text much to small at small video sizes and mostly had the text obscured with the video controls (that are disabled but still there when video fails to load as normal html videos do and to make it clear it was supposed to be a video).
 
Original image size:
<img width="1207" height="748" alt="Screenshot 2026-02-24 at 6 52 28 PM" src="https://github.com/user-attachments/assets/c95ebb25-6e73-41ac-a09d-4ae7c12c75c3" />

I quickly updated the image/text  to address these issues but I'm sure it could use further tweaking:

New image size at various video sizes:

https://github.com/user-attachments/assets/061a4ca4-27e0-482a-9012-337e1c456cad


@MollyPeredo here is the png currently being used if you want to use the proportions/locations to tweak further.
<img width="750" height="481" alt="Video Generation Error - Tutor (3)" src="https://github.com/user-attachments/assets/88da4aee-174f-4a21-94fa-481b83d6a640" />

## Testing story
In order to test this functionality if you don't have a failed video, you can inspect the page, then change the `src` attribute within the `json-video` element to a bad image url:
<img width="1088" height="553" alt="Screenshot 2026-02-25 at 2 08 44 PM" src="https://github.com/user-attachments/assets/884e6d2a-d949-4ab6-9aa4-566ee4638ab4" />

## Follow-up work
<!--  List any clean-up or technical debt that will be addressed in future work.
      - Include Jira links where applicable.
      - Are there any known limitations or improvements planned? -->
      
The poster approach embeds the text in the image which does not support internationalization, but as the videos themselves are currently not internationalized, we can address this when we make a push to do so.
