### PR TITLE
Adjust margin on version unit dropdown label for section set up 

### DIFF
--- a/apps/src/templates/sectionsRefresh/VersionUnitDropdowns.jsx
+++ b/apps/src/templates/sectionsRefresh/VersionUnitDropdowns.jsx
@@ -76,7 +76,9 @@ export default function VersionUnitDropdowns({
           orderedUnits &&
           Object.entries(orderedUnits).length > 1 && (
             <span className={moduleStyles.unitDropdown}>
-              <div>{i18n.startWithUnit()}</div>
+              <div className={moduleStyles.unitDropdownLabel}>
+                {i18n.startWithUnit()}
+              </div>
               <select
                 id="uitest-secondary-assignment"
                 value={selectedUnitId}

--- a/apps/src/templates/sectionsRefresh/sections-refresh.module.scss
+++ b/apps/src/templates/sectionsRefresh/sections-refresh.module.scss
@@ -179,6 +179,10 @@ label.typographyLabelTwo {
   padding: 0.3em;
 }
 
+.unitDropdownLabel {
+  margin-bottom: 7px;
+}
+
 button.advancedSettingsButton {
   margin: 5px;
   font-size: unset;


### PR DESCRIPTION
While adding in new alerts underneath these dropdowns for AI Tutor permissions work, I noticed that they were vertically misaligned. It's been haunting me. Fixed it. 

**Before**
<img width="501" height="83" alt="Screenshot 2026-02-25 at 3 34 30 PM" src="https://github.com/user-attachments/assets/be7d0537-c91f-4945-b2ea-7647660f38fd" /> 

**After** 
<img width="571" height="99" alt="Screenshot 2026-02-25 at 3 26 56 PM" src="https://github.com/user-attachments/assets/1ab29b1c-1ff2-4b37-8b75-45af3b7ee95f" />
