### PR TITLE
Make AI Chat Permissions and Tutor Generally Available

### DIFF
--- a/apps/src/aichat/aichatApi.ts
+++ b/apps/src/aichat/aichatApi.ts
@@ -1,4 +1,3 @@
-import experiments from '@cdo/apps/util/experiments';
 import HttpClient from '@cdo/apps/util/HttpClient';
 import {
   AiInteractionStatus,
@@ -80,9 +79,8 @@ export async function postLogChatEvent(
     newChatEvent,
     aichatContext,
   };
-  // REMOVE getAiChatNewPermissionsParam hack after experiment ships!!!
   const response = await HttpClient.post(
-    paths.LOG_CHAT_EVENT_URL + getAiChatNewPermissionsParam(),
+    paths.LOG_CHAT_EVENT_URL,
     JSON.stringify(payload),
     true,
     {
@@ -174,9 +172,8 @@ export async function postAichatCompletionMessage(
   maxPollingTimeMs =
     maxPollingTimeMs || AiChatReadTimeouts[aichatContext.clientType] * 1500;
 
-  // REMOVE getAiChatNewPermissionsParam hack after experiment ships!!!
   const response = await HttpClient.post(
-    paths.START_CHAT_COMPLETION_URL + getAiChatNewPermissionsParam(),
+    paths.START_CHAT_COMPLETION_URL,
     JSON.stringify(payload),
     true,
     {
@@ -319,23 +316,12 @@ function getUpdatedMessages(
 }
 
 /**
- * *** REMOVE THIS AND ALL CALLERS AFTER THE EXPERIMENT ENDS ***
- * This is a temporary method to pass on the experiment flag to the backend until we remove the experiment.
- */
-function getAiChatNewPermissionsParam(): string {
-  if (!experiments.isEnabled(experiments.AI_CHAT_NEW_PERMISSIONS)) {
-    return '';
-  }
-  return '?' + new URLSearchParams({'ai-chat-new-permissions': '1'});
-}
-
-/**
  * This function sends a GET request to the aichat's userHasAichatLabAccess backend controller action,
  * then returns true if the user has aichat lab access and false otherwise.
  */
 export async function getUserHasAichatLabAccess(): Promise<boolean> {
   const response = await HttpClient.fetchJson<UserHasAichatLabAccessResponse>(
-    `${paths.USER_HAS_AICHAT_LAB_ACCESS_URL}${getAiChatNewPermissionsParam()}`
+    `${paths.USER_HAS_AICHAT_LAB_ACCESS_URL}`
   );
   return response.value.userHasAccess;
 }

--- a/apps/src/aichat/helpers/aiChatAccess.ts
+++ b/apps/src/aichat/helpers/aiChatAccess.ts
@@ -1,5 +1,4 @@
 import {AiChatAccessLevel} from '@cdo/apps/aichat/types/accessControls';
-import experiments from '@cdo/apps/util/experiments';
 import {AiChatAccessLevels} from '@cdo/generated-scripts/sharedConstants';
 
 // A list of app names for which AI Chat tools (tutor or chat in ai chat lab) are considered essential to the app experience.
@@ -49,10 +48,6 @@ export const areAiChatToolsEnabled = ({
   appName: string;
   aiChatAccessLevel: AiChatAccessLevel;
 }): boolean => {
-  if (!experiments.isEnabled(experiments.AI_CHAT_NEW_PERMISSIONS)) {
-    // only disable AI Chat tools based on AiChatAccessLevel if the new permissions experiment is enabled!
-    return true;
-  }
   if (APPS_WITH_ESSENTIAL_AI_CHAT.includes(appName)) {
     // either ESSENTIAL_ONLY or ENABLED access level permits AI Chat tools for apps that consider AI Chat essential
     return aiChatAccessLevel !== AiChatAccessLevels.DISABLED;

--- a/apps/src/aichat/helpers/aiChatAccess.ts
+++ b/apps/src/aichat/helpers/aiChatAccess.ts
@@ -12,19 +12,15 @@ export const APPS_WITH_ESSENTIAL_AI_CHAT = [
 export const shouldShowAiTutor = ({
   appName,
   tutorLevel,
-  tutorPilot,
   aiChatAccessLevel,
 }: {
   appName: string;
   tutorLevel?: boolean;
-  tutorPilot?: boolean;
   aiChatAccessLevel: AiChatAccessLevel;
 }) => {
   return (
     APPS_WHERE_AI_TUTOR_IS_ESSENTIAL.includes(appName) ||
-    // user is in ai tutor pilot and it's a tutor enabled level
-    (tutorPilot &&
-      tutorLevel &&
+    (tutorLevel &&
       // For now, we are going to fully hide optional tutor rather than showing the disabled ui,
       // to avoid disrupting classrooms that are in the middle of the school year working on
       // courses where optional tutor is available.

--- a/apps/src/code-studio/components/progress/UnitOverview.jsx
+++ b/apps/src/code-studio/components/progress/UnitOverview.jsx
@@ -23,7 +23,6 @@ import {
   onDismissRedirectDialog,
   dismissedRedirectDialog,
 } from '@cdo/apps/util/dismissVersionRedirect';
-import experiments from '@cdo/apps/util/experiments';
 import {AiChatToolsDependency} from '@cdo/generated-scripts/sharedConstants';
 import i18n from '@cdo/locale';
 
@@ -224,8 +223,7 @@ class UnitOverview extends React.Component {
               isMigrated={isMigrated}
               aiChatToolsDependency={aiChatToolsDependency}
             />
-            {experiments.isEnabled(experiments.AI_CHAT_NEW_PERMISSIONS) &&
-              viewAs === ViewType.Instructor &&
+            {viewAs === ViewType.Instructor &&
               aiChatToolsDependency === AiChatToolsDependency.ESSENTIAL && (
                 <RequiresAiChatToolsAlert />
               )}

--- a/apps/src/lab2/views/components/Instructions/ResourcePanel/index.tsx
+++ b/apps/src/lab2/views/components/Instructions/ResourcePanel/index.tsx
@@ -184,9 +184,6 @@ const ResourcePanel: React.FC<ResourcePanelProps> = ({
   const floatingPanelRef = useRef<HTMLDivElement | null>(null);
   const tabContentRefs = useRef<{[key in Tabs]?: HTMLDivElement | null}>({});
   const isUserTeacher = useAppSelector(state => state.currentUser.isTeacher);
-  const aiTutorEnabledForPilot = useAppSelector(
-    state => state.currentUser.aiTutorEnabledForPilot
-  );
   const [selectedVersion, setSelectedVersion] = useState<string>('');
   const isViewingOldVersion = useAppSelector(
     state => state.lab2Project.viewingOldVersion
@@ -228,7 +225,6 @@ const ResourcePanel: React.FC<ResourcePanelProps> = ({
   const aiTutorVisible =
     shouldShowAiTutor({
       appName,
-      tutorPilot: aiTutorEnabledForPilot,
       tutorLevel: levelProperties.aiTutorAvailable,
       aiChatAccessLevel: aiChatAccessLevel,
     }) ||

--- a/apps/src/pythonlab/PythonlabView.tsx
+++ b/apps/src/pythonlab/PythonlabView.tsx
@@ -114,9 +114,6 @@ const PythonlabView: React.FunctionComponent<
   );
   const hasRun = useAppSelector(state => state.lab2System.hasRun);
   const hasEdited = useAppSelector(state => state.lab2Project.hasEdited);
-  const aiTutorEnabledForPilot = useAppSelector(
-    state => state.currentUser.aiTutorEnabledForPilot
-  );
   const aiChatAccessLevel = useAppSelector(
     state => state.currentUser.aiChatAccessLevel
   );
@@ -125,7 +122,6 @@ const PythonlabView: React.FunctionComponent<
 
   const isAiTutorEnabled =
     shouldShowAiTutor({
-      tutorPilot: aiTutorEnabledForPilot,
       appName: levelProperties.appName,
       tutorLevel: levelProperties.aiTutorAvailable,
       aiChatAccessLevel: aiChatAccessLevel,

--- a/apps/src/templates/CurrentUserState.ts
+++ b/apps/src/templates/CurrentUserState.ts
@@ -43,6 +43,5 @@ export interface CurrentUserState {
   hasSeenHomepageWelcome: boolean;
   inUSA: boolean;
   isLevelbuilder: boolean;
-  aiTutorEnabledForPilot: boolean;
   aiChatAccessLevel: AiChatAccessLevel;
 }

--- a/apps/src/templates/MultipleSectionsAssigner.jsx
+++ b/apps/src/templates/MultipleSectionsAssigner.jsx
@@ -15,7 +15,6 @@ import {
   unassignSection,
   sectionHasNewData,
 } from '@cdo/apps/templates/teacherDashboard/teacherSectionsRedux';
-import experiments from '@cdo/apps/util/experiments';
 import {AiChatToolsDependency} from '@cdo/generated-scripts/sharedConstants';
 import i18n from '@cdo/locale';
 
@@ -246,14 +245,12 @@ const MultipleSectionsAssigner = ({
             styleAsText
             color={Button.ButtonColor.brandSecondaryDefault}
           />
-          {experiments.isEnabled(experiments.AI_CHAT_NEW_PERMISSIONS) &&
-            aiChatToolsDependency === AiChatToolsDependency.ESSENTIAL && (
-              <AssigningEssentialAiChatToolsAlert />
-            )}
-          {experiments.isEnabled(experiments.AI_CHAT_NEW_PERMISSIONS) &&
-            aiChatToolsDependency === AiChatToolsDependency.AVAILABLE && (
-              <AssigningAvailableAiChatToolsAlert />
-            )}
+          {aiChatToolsDependency === AiChatToolsDependency.ESSENTIAL && (
+            <AssigningEssentialAiChatToolsAlert />
+          )}
+          {aiChatToolsDependency === AiChatToolsDependency.AVAILABLE && (
+            <AssigningAvailableAiChatToolsAlert />
+          )}
         </div>
       </div>
       <div className={moduleStyle.buttonContainer}>

--- a/apps/src/templates/courseOverview/CourseOverview.js
+++ b/apps/src/templates/courseOverview/CourseOverview.js
@@ -26,7 +26,6 @@ import {
   onDismissRedirectWarning,
   dismissedRedirectWarning,
 } from '@cdo/apps/util/dismissVersionRedirect';
-import experiments from '@cdo/apps/util/experiments';
 import {AiChatToolsDependency} from '@cdo/generated-scripts/sharedConstants';
 import i18n from '@cdo/locale';
 
@@ -224,8 +223,7 @@ class CourseOverview extends Component {
           participantAudience={participantAudience}
           aiChatToolsDependency={aiChatToolsDependency}
         />
-        {experiments.isEnabled(experiments.AI_CHAT_NEW_PERMISSIONS) &&
-          viewAsTeacher &&
+        {viewAsTeacher &&
           aiChatToolsDependency === AiChatToolsDependency.ESSENTIAL && (
             <RequiresAiChatToolsAlert />
           )}

--- a/apps/src/templates/currentUserRedux.js
+++ b/apps/src/templates/currentUserRedux.js
@@ -268,7 +268,6 @@ export default function currentUser(state = initialState, action) {
       educator_role,
       sharing_disabled,
       has_seen_homepage_welcome,
-      ai_tutor_enabled_for_pilot,
       ai_chat_access_level,
     } = action.serverUser;
     // TODO: Once Amplitude is fully removed, the StatsigReporter class should be
@@ -306,7 +305,6 @@ export default function currentUser(state = initialState, action) {
       userCreatedAt: created_at,
       userSharingDisabled: sharing_disabled,
       hasSeenHomepageWelcome: has_seen_homepage_welcome,
-      aiTutorEnabledForPilot: ai_tutor_enabled_for_pilot,
       aiChatAccessLevel: ai_chat_access_level,
     };
   }

--- a/apps/src/templates/curriculumCatalog/ExpandedCurriculumCatalogCard.jsx
+++ b/apps/src/templates/curriculumCatalog/ExpandedCurriculumCatalogCard.jsx
@@ -12,7 +12,6 @@ import React, {useEffect, useRef} from 'react';
 import FontAwesome from '@cdo/apps/legacySharedComponents/FontAwesome';
 import {EVENTS} from '@cdo/apps/metrics/AnalyticsConstants';
 import analyticsReporter from '@cdo/apps/metrics/AnalyticsReporter';
-import experiments from '@cdo/apps/util/experiments';
 import {AiChatToolsDependency} from '@cdo/generated-scripts/sharedConstants';
 import i18n from '@cdo/locale';
 
@@ -275,19 +274,18 @@ const ExpandedCurriculumCatalogCard = ({
                       </div>
                     )
                 )}
-                {experiments.isEnabled(experiments.AI_CHAT_NEW_PERMISSIONS) &&
-                  aiChatToolsDependency === AiChatToolsDependency.ESSENTIAL && (
-                    <div className={style.iconWithDescription}>
-                      <FontAwesomeV6Icon
-                        iconName="ai-bot-solid"
-                        iconFamily="kit"
-                        className={style.aiBotIcon}
-                      />
-                      <Typography variant="body2" gutterBottom>
-                        Requires AI chat tools
-                      </Typography>
-                    </div>
-                  )}
+                {aiChatToolsDependency === AiChatToolsDependency.ESSENTIAL && (
+                  <div className={style.iconWithDescription}>
+                    <FontAwesomeV6Icon
+                      iconName="ai-bot-solid"
+                      iconFamily="kit"
+                      className={style.aiBotIcon}
+                    />
+                    <Typography variant="body2" gutterBottom>
+                      Requires AI chat tools
+                    </Typography>
+                  </div>
+                )}
               </div>
               <hr className={style.horizontalDivider} />
               <div className={style.buttonsContainer}>

--- a/apps/src/templates/sectionsRefresh/CurriculumQuickAssign.jsx
+++ b/apps/src/templates/sectionsRefresh/CurriculumQuickAssign.jsx
@@ -12,7 +12,6 @@ import {
   ParticipantAudience,
 } from '@cdo/apps/generated/curriculum/sharedCourseConstants';
 import Spinner from '@cdo/apps/sharedComponents/Spinner';
-import experiments from '@cdo/apps/util/experiments';
 import {AiChatToolsDependency} from '@cdo/generated-scripts/sharedConstants';
 import i18n from '@cdo/locale';
 
@@ -359,14 +358,12 @@ export default function CurriculumQuickAssign({
               isNewSection={isNewSection}
             />
           )}
-          {experiments.isEnabled(experiments.AI_CHAT_NEW_PERMISSIONS) &&
-            aiChatToolsDependency === AiChatToolsDependency.ESSENTIAL && (
-              <AssigningEssentialAiChatToolsAlert />
-            )}
-          {experiments.isEnabled(experiments.AI_CHAT_NEW_PERMISSIONS) &&
-            aiChatToolsDependency === AiChatToolsDependency.AVAILABLE && (
-              <AssigningAvailableAiChatToolsAlert />
-            )}
+          {aiChatToolsDependency === AiChatToolsDependency.ESSENTIAL && (
+            <AssigningEssentialAiChatToolsAlert />
+          )}
+          {aiChatToolsDependency === AiChatToolsDependency.AVAILABLE && (
+            <AssigningAvailableAiChatToolsAlert />
+          )}
         </>
       )}
     </div>

--- a/apps/src/templates/teacherNavigation/TeacherNavigationBar.tsx
+++ b/apps/src/templates/teacherNavigation/TeacherNavigationBar.tsx
@@ -207,7 +207,6 @@ const TeacherNavigationBar: React.FC<{
   const shouldShowErrorIcon = React.useCallback(
     (key: string) => {
       return (
-        experiments.isEnabled(experiments.AI_CHAT_NEW_PERMISSIONS) &&
         key === TEACHER_NAVIGATION_PATH_NAMES.aiChatSettings &&
         selectedSection?.assignedAiChatToolsDependency ===
           AiChatToolsDependency.ESSENTIAL &&

--- a/apps/src/templates/teacherNavigation/TeacherNavigationRouter.tsx
+++ b/apps/src/templates/teacherNavigation/TeacherNavigationRouter.tsx
@@ -97,11 +97,7 @@ const TeacherNavigationRouter: React.FC<TeacherNavigationRouterProps> = ({
   );
 
   const showAiChatSettings = React.useMemo(
-    () =>
-      !!selectedSection &&
-      experiments.isEnabledAllowingQueryString(
-        experiments.AI_CHAT_NEW_PERMISSIONS
-      ),
+    () => !!selectedSection,
     [selectedSection]
   );
 

--- a/apps/src/util/experiments.js
+++ b/apps/src/util/experiments.js
@@ -44,8 +44,6 @@ experiments.GENDER_FEATURE_ENABLED = 'gender';
 experiments.AI_DIFFERENTIATION = 'ai-differentiation';
 // Experiment for enabling the AI-TA differentiation artifacts
 experiments.AI_ARTIFACT = 'ai-artifact';
-// Experiment for showing the ai chat new permissions page and enabling permissions to take effect
-experiments.AI_CHAT_NEW_PERMISSIONS = 'ai-chat-new-permissions';
 // Adds a "Get help with this block" option to block context menus if docs exist (e.g. Sprite Lab)
 experiments.BLOCKLY_DOCS = 'blockly_docs';
 // Allows the playspace to be dragged to take up a larger portion of the screen

--- a/apps/test/unit/aichat/helpers/aiChatAccessTest.ts
+++ b/apps/test/unit/aichat/helpers/aiChatAccessTest.ts
@@ -6,11 +6,10 @@ import {
 
 describe('shouldShowAiTutor', () => {
   describe('when app always shows AI tutor (essential tutor apps)', () => {
-    it('returns true for weblab2 regardless of pilot or level flags', () => {
+    it('returns true for weblab2 regardless of level flags', () => {
       const result = shouldShowAiTutor({
         appName: 'weblab2',
         tutorLevel: false,
-        tutorPilot: false,
         aiChatAccessLevel: 'essential_only',
       });
       expect(result).toBe(true);
@@ -22,7 +21,6 @@ describe('shouldShowAiTutor', () => {
       const result = shouldShowAiTutor({
         appName: 'applab',
         tutorLevel: true,
-        tutorPilot: true,
         aiChatAccessLevel: 'enabled',
       });
       expect(result).toBe(true);
@@ -32,29 +30,6 @@ describe('shouldShowAiTutor', () => {
       const result = shouldShowAiTutor({
         appName: 'applab',
         tutorLevel: false,
-        tutorPilot: true,
-        aiChatAccessLevel: 'enabled',
-      });
-      expect(result).toBe(false);
-    });
-  });
-
-  describe('when tutorPilot is disabled', () => {
-    it('returns false when tutorLevel is true', () => {
-      const result = shouldShowAiTutor({
-        appName: 'applab',
-        tutorLevel: true,
-        tutorPilot: false,
-        aiChatAccessLevel: 'enabled',
-      });
-      expect(result).toBe(false);
-    });
-
-    it('returns false when tutorLevel is false', () => {
-      const result = shouldShowAiTutor({
-        appName: 'applab',
-        tutorLevel: false,
-        tutorPilot: false,
         aiChatAccessLevel: 'enabled',
       });
       expect(result).toBe(false);
@@ -62,11 +37,10 @@ describe('shouldShowAiTutor', () => {
   });
 
   describe('when aiChatAccessLevel is disabled', () => {
-    it('returns false even when tutorPilot and tutorLevel are true', () => {
+    it('returns false even when tutorLevel is true', () => {
       const result = shouldShowAiTutor({
         appName: 'applab',
         tutorLevel: true,
-        tutorPilot: true,
         aiChatAccessLevel: 'disabled',
       });
       expect(result).toBe(false);

--- a/apps/test/unit/aichat/helpers/aiChatAccessTest.ts
+++ b/apps/test/unit/aichat/helpers/aiChatAccessTest.ts
@@ -3,7 +3,6 @@ import {
   areAiChatToolsEnabled,
   APPS_WITH_ESSENTIAL_AI_CHAT,
 } from '@cdo/apps/aichat/helpers/aiChatAccess';
-import experiments from '@cdo/apps/util/experiments';
 
 describe('shouldShowAiTutor', () => {
   describe('when app always shows AI tutor (essential tutor apps)', () => {
@@ -64,7 +63,6 @@ describe('shouldShowAiTutor', () => {
 
   describe('when aiChatAccessLevel is disabled', () => {
     it('returns false even when tutorPilot and tutorLevel are true', () => {
-      experiments.isEnabled = jest.fn(() => true);
       const result = shouldShowAiTutor({
         appName: 'applab',
         tutorLevel: true,
@@ -77,90 +75,61 @@ describe('shouldShowAiTutor', () => {
 });
 
 describe('areAiChatToolsEnabled', () => {
-  describe('when AI_CHAT_NEW_PERMISSIONS experiment is disabled', () => {
-    beforeEach(() => {
-      experiments.isEnabled = jest.fn(() => false);
-    });
-
-    it('returns true for an essential app regardless of access level', () => {
+  describe('for apps with essential AI chat (weblab2, aichat)', () => {
+    it('returns true when access level is enabled', () => {
       APPS_WITH_ESSENTIAL_AI_CHAT.forEach(appName => {
         expect(
-          areAiChatToolsEnabled({appName, aiChatAccessLevel: 'disabled'})
+          areAiChatToolsEnabled({appName, aiChatAccessLevel: 'enabled'})
         ).toBe(true);
       });
     });
 
-    it('returns true for a non-essential app regardless of access level', () => {
+    it('returns true when access level is essential_only', () => {
+      APPS_WITH_ESSENTIAL_AI_CHAT.forEach(appName => {
+        expect(
+          areAiChatToolsEnabled({
+            appName,
+            aiChatAccessLevel: 'essential_only',
+          })
+        ).toBe(true);
+      });
+    });
+
+    it('returns false when access level is disabled', () => {
+      APPS_WITH_ESSENTIAL_AI_CHAT.forEach(appName => {
+        expect(
+          areAiChatToolsEnabled({appName, aiChatAccessLevel: 'disabled'})
+        ).toBe(false);
+      });
+    });
+  });
+
+  describe('for non-essential apps (e.g. applab)', () => {
+    it('returns true when access level is enabled', () => {
+      expect(
+        areAiChatToolsEnabled({
+          appName: 'applab',
+          aiChatAccessLevel: 'enabled',
+        })
+      ).toBe(true);
+    });
+
+    it('returns false when access level is essential_only', () => {
+      expect(
+        areAiChatToolsEnabled({
+          appName: 'applab',
+          aiChatAccessLevel: 'essential_only',
+        })
+      ).toBe(false);
+    });
+
+    it('returns false when access level is disabled', () => {
       expect(
         areAiChatToolsEnabled({
           appName: 'applab',
           aiChatAccessLevel: 'disabled',
         })
-      ).toBe(true);
-    });
-  });
-
-  describe('when AI_CHAT_NEW_PERMISSIONS experiment is enabled', () => {
-    beforeEach(() => {
-      experiments.isEnabled = jest.fn(() => true);
-    });
-
-    describe('for apps with essential AI chat (weblab2, aichat)', () => {
-      it('returns true when access level is enabled', () => {
-        APPS_WITH_ESSENTIAL_AI_CHAT.forEach(appName => {
-          expect(
-            areAiChatToolsEnabled({appName, aiChatAccessLevel: 'enabled'})
-          ).toBe(true);
-        });
-      });
-
-      it('returns true when access level is essential_only', () => {
-        APPS_WITH_ESSENTIAL_AI_CHAT.forEach(appName => {
-          expect(
-            areAiChatToolsEnabled({
-              appName,
-              aiChatAccessLevel: 'essential_only',
-            })
-          ).toBe(true);
-        });
-      });
-
-      it('returns false when access level is disabled', () => {
-        APPS_WITH_ESSENTIAL_AI_CHAT.forEach(appName => {
-          expect(
-            areAiChatToolsEnabled({appName, aiChatAccessLevel: 'disabled'})
-          ).toBe(false);
-        });
-      });
-    });
-
-    describe('for non-essential apps (e.g. applab)', () => {
-      it('returns true when access level is enabled', () => {
-        expect(
-          areAiChatToolsEnabled({
-            appName: 'applab',
-            aiChatAccessLevel: 'enabled',
-          })
-        ).toBe(true);
-      });
-
-      it('returns false when access level is essential_only', () => {
-        expect(
-          areAiChatToolsEnabled({
-            appName: 'applab',
-            aiChatAccessLevel: 'essential_only',
-          })
-        ).toBe(false);
-      });
-
-      it('returns false when access level is disabled', () => {
-        expect(
-          areAiChatToolsEnabled({
-            appName: 'applab',
-            aiChatAccessLevel: 'disabled',
-          })
-        ).toBe(false);
-      });
+      ).toBe(false);
     });
   });
 });

--- a/dashboard/app/controllers/aichat_controller.rb
+++ b/dashboard/app/controllers/aichat_controller.rb
@@ -3,8 +3,7 @@ class AichatController < ApplicationController
 
   # GET /aichat/user_has_access
   def user_has_access
-    ai_chat_new_permissions = params[:'ai-chat-new-permissions'].present?
-    render(status: :ok, json: {userHasAccess: current_user&.has_aichat_lab_access?(new_permissions_enabled: ai_chat_new_permissions)})
+    render(status: :ok, json: {userHasAccess: current_user&.has_aichat_lab_access?})
   end
 
   # POST /aichat/find_toxicity

--- a/dashboard/app/controllers/aichat_events_controller.rb
+++ b/dashboard/app/controllers/aichat_events_controller.rb
@@ -126,8 +126,7 @@ class AichatEventsController < ApplicationController
   end
 
   private def can_log_aichat_events?(client_type)
-    ai_chat_new_permissions = params[:'ai-chat-new-permissions'].present?
-    current_user.has_aichat_lab_access?(new_permissions_enabled: ai_chat_new_permissions) || current_user.trust_chat_client?(client_type)
+    current_user.has_aichat_lab_access? || current_user.trust_chat_client?(client_type)
   end
 
   private def can_view_chat_history?(user_id)

--- a/dashboard/app/controllers/aichat_requests_controller.rb
+++ b/dashboard/app/controllers/aichat_requests_controller.rb
@@ -102,8 +102,7 @@ class AichatRequestsController < ApplicationController
 
   private def can_access_aichat_lab_chat_completion?
     return false if DCDO.get("block_aichat_lab_chat_completion", false)
-    ai_chat_new_permissions = params[:'ai-chat-new-permissions'].present?
-    current_user.has_aichat_lab_access?(new_permissions_enabled: ai_chat_new_permissions)
+    current_user.has_aichat_lab_access?
   end
 
   private def should_throttle_request_count?

--- a/dashboard/app/controllers/api/v1/sections_controller.rb
+++ b/dashboard/app/controllers/api/v1/sections_controller.rb
@@ -358,9 +358,7 @@ class Api::V1::SectionsController < Api::V1::JSONApiController
     return previous_access_level if previous_access_level != SharedConstants::AI_CHAT_ACCESS_LEVELS[:DISABLED]
 
     # Auto-enable access if the course needs it.
-    # TODO: Once pilot goes GA, we can enable for any @course&.has_ai_chat_tools?
-    return SharedConstants::AI_CHAT_ACCESS_LEVELS[:ENABLED] if @course&.requires_ai_chat_tools?
-    return SharedConstants::AI_CHAT_ACCESS_LEVELS[:ENABLED] if @course&.has_ai_chat_tools? && current_user.ai_tutor_enabled_for_pilot?
+    return SharedConstants::AI_CHAT_ACCESS_LEVELS[:ENABLED] if @course&.has_ai_chat_tools?
 
     SharedConstants::AI_CHAT_ACCESS_LEVELS[:DISABLED]
   end

--- a/dashboard/app/controllers/api/v1/users_controller.rb
+++ b/dashboard/app/controllers/api/v1/users_controller.rb
@@ -73,7 +73,6 @@ class Api::V1::UsersController < Api::V1::JSONApiController
         educator_role: current_user.educator_role,
         sharing_disabled: current_user.sharing_disabled,
         is_levelbuilder: current_user.levelbuilder?,
-        ai_tutor_enabled_for_pilot: current_user.ai_tutor_enabled_for_pilot?,
         ai_chat_access_level: current_user.ai_chat_access_level,
       }
     else

--- a/dashboard/app/controllers/test_controller.rb
+++ b/dashboard/app/controllers/test_controller.rb
@@ -79,7 +79,7 @@ class TestController < ApplicationController
     raise "Unit not found for course #{unit_group.name} at position #{unit_position}" unless unit_group_unit
     unit = unit_group_unit.script
 
-    ai_chat_access_level = params[:ai_chat_access_level] || SharedConstants::AI_CHAT_ACCESS_LEVELS[:DISABLED]
+    ai_chat_access_level = params[:ai_chat_access_level] || Section::AI_CHAT_ACCESS_LEVELS[:DISABLED]
     section = Section.create!(name: "New Section", user: user, script: unit, unit_group: unit_group, participant_type: Curriculum::SharedCourseConstants::PARTICIPANT_AUDIENCE.student, ai_chat_access_level: ai_chat_access_level)
 
     render json: {section_code: section.code}

--- a/dashboard/app/controllers/test_controller.rb
+++ b/dashboard/app/controllers/test_controller.rb
@@ -79,7 +79,8 @@ class TestController < ApplicationController
     raise "Unit not found for course #{unit_group.name} at position #{unit_position}" unless unit_group_unit
     unit = unit_group_unit.script
 
-    section = Section.create!(name: "New Section", user: user, script: unit, unit_group: unit_group, participant_type: Curriculum::SharedCourseConstants::PARTICIPANT_AUDIENCE.student)
+    ai_chat_access_level = params[:ai_chat_access_level] || SharedConstants::AI_CHAT_ACCESS_LEVELS[:DISABLED]
+    section = Section.create!(name: "New Section", user: user, script: unit, unit_group: unit_group, participant_type: Curriculum::SharedCourseConstants::PARTICIPANT_AUDIENCE.student, ai_chat_access_level: ai_chat_access_level)
 
     render json: {section_code: section.code}
   end

--- a/dashboard/app/models/concerns/user/ai_accessible.rb
+++ b/dashboard/app/models/concerns/user/ai_accessible.rb
@@ -28,19 +28,13 @@ module User::AiAccessible
     teacher? && (verified_instructor? || oauth? || Policies::Lti.lti?(self))
   end
 
-  def student_can_access_ai_chat_lab?(new_permissions_enabled: false)
-    # REMOVE getAiChatNewPermissionsParam hack after experiment ships!!!
-    if new_permissions_enabled
-      teachers.any?(&:teacher_can_access_ai_chat_lab?) &&
-        ai_chat_access_level != AI_CHAT_ACCESS_LEVELS[:DISABLED]
-    else
-      teachers.any?(&:teacher_can_access_ai_chat_lab?) &&
-        sections_as_student.any?(&:assigned_ai_chat?)
-    end
+  def student_can_access_ai_chat_lab?
+    teachers.any?(&:teacher_can_access_ai_chat_lab?) &&
+      ai_chat_access_level != AI_CHAT_ACCESS_LEVELS[:DISABLED]
   end
 
-  def has_aichat_lab_access?(new_permissions_enabled: false)
-    teacher_can_access_ai_chat_lab? || student_can_access_ai_chat_lab?(new_permissions_enabled: new_permissions_enabled)
+  def has_aichat_lab_access?
+    teacher_can_access_ai_chat_lab? || student_can_access_ai_chat_lab?
   end
 
   def ai_chat_access_level

--- a/dashboard/app/models/concerns/user/ai_accessible.rb
+++ b/dashboard/app/models/concerns/user/ai_accessible.rb
@@ -1,10 +1,4 @@
 # Adds methods for determining and enforcing AI access rules.
-# Relies on these serialized attributes:
-# - ai_tutor_access_denied
-# - ai_rubrics_disabled
-# - ai_rubrics_tour_seen
-# - ai_differentiation_toggled_off
-# - has_completed_ai_differentiation_welcome
 module User::AiAccessible
   extend ActiveSupport::Concern
   include SharedConstants

--- a/dashboard/app/models/concerns/user/ai_accessible.rb
+++ b/dashboard/app/models/concerns/user/ai_accessible.rb
@@ -9,8 +9,6 @@ module User::AiAccessible
   extend ActiveSupport::Concern
   include SharedConstants
 
-  AI_TUTOR_PILOT_NAME = 'ai-tutor-pilot'.freeze
-
   # Chat apis trust the client to decide if it can access chat features
   # This allows us the flexibility to do things like turn on the tutor UI
   # with a url param, or experiment with new lab types with low friction.
@@ -44,34 +42,11 @@ module User::AiAccessible
     return AI_CHAT_ACCESS_LEVELS[:DISABLED]
   end
 
-  def ai_tutor_enabled_for_pilot?
-    return false if ai_tutor_feature_globally_disabled?
-
-    ai_tutor_enabled_for_pilot_teacher? || ai_tutor_enabled_for_pilot_student?
-  rescue => exception
-    Honeybadger.notify(exception, error_message: 'Error computing ai_tutor_enabled_for_pilot')
-    false
-  end
-
-  # Teachers: enabled if they are in the pilot single user experiment
-  private def ai_tutor_enabled_for_pilot_teacher?
-    teacher? && SingleUserExperiment.enabled?(user: self, experiment_name: AI_TUTOR_PILOT_NAME)
-  end
-
-  # Students: enabled if any of their teachers are in the pilot
-  private def ai_tutor_enabled_for_pilot_student?
-    student? && Queries::User::TeacherEnabledExperiments.call(self).include?(AI_TUTOR_PILOT_NAME)
-  end
-
   private def in_section_with_ai_chat_access_enabled?
     sections_as_student.any? {|s| s.ai_chat_access_level == AI_CHAT_ACCESS_LEVELS[:ENABLED]}
   end
 
   private def in_section_with_ai_chat_access_essential_only?
     sections_as_student.any? {|s| s.ai_chat_access_level == AI_CHAT_ACCESS_LEVELS[:ESSENTIAL_ONLY]}
-  end
-
-  private def ai_tutor_feature_globally_disabled?
-    DCDO.get('ai-tutor-disabled', false)
   end
 end

--- a/dashboard/lib/tasks/seed.rake
+++ b/dashboard/lib/tasks/seed.rake
@@ -656,9 +656,7 @@ namespace :seed do
   UI_TEST_SEED_TASKS = [:check_migrations, :videos, :concepts, :scripts_ui_tests, :courses_ui_tests, :reseed_scripts_ui_tests, :callouts, :school_districts, :schools, :secret_words, :secret_pictures, :donors, :datablock_storage].freeze
   ADHOC_SEED_TASKS = [:check_migrations, :videos, :concepts, :course_offerings_adhoc, :scripts_adhoc, :courses_adhoc, :callouts, :school_districts, :schools, :secret_words, :secret_pictures, :donors, :datablock_storage].freeze
 
-  # THIS CHANGE IS FOR ADHOC TO SEED THE FULL CURRICULUM CATALOG.
-  # ************ UNDO BEFORE MERGING!!!!!!!!!!!!!!!!!!! *******
-  DEFAULT_SEED_TASKS = FULL_SEED_TASKS
+  DEFAULT_SEED_TASKS = if rack_env == :test then UI_TEST_SEED_TASKS elsif rack_env == :adhoc then ADHOC_SEED_TASKS else FULL_SEED_TASKS end
 
   desc "seed the data needed for this type of environment by default"
   timed_task_with_logging default: DEFAULT_SEED_TASKS

--- a/dashboard/lib/tasks/seed.rake
+++ b/dashboard/lib/tasks/seed.rake
@@ -656,7 +656,9 @@ namespace :seed do
   UI_TEST_SEED_TASKS = [:check_migrations, :videos, :concepts, :scripts_ui_tests, :courses_ui_tests, :reseed_scripts_ui_tests, :callouts, :school_districts, :schools, :secret_words, :secret_pictures, :donors, :datablock_storage].freeze
   ADHOC_SEED_TASKS = [:check_migrations, :videos, :concepts, :course_offerings_adhoc, :scripts_adhoc, :courses_adhoc, :callouts, :school_districts, :schools, :secret_words, :secret_pictures, :donors, :datablock_storage].freeze
 
-  DEFAULT_SEED_TASKS = if rack_env == :test then UI_TEST_SEED_TASKS elsif rack_env == :adhoc then ADHOC_SEED_TASKS else FULL_SEED_TASKS end
+  # THIS CHANGE IS FOR ADHOC TO SEED THE FULL CURRICULUM CATALOG.
+  # ************ UNDO BEFORE MERGING!!!!!!!!!!!!!!!!!!! *******
+  DEFAULT_SEED_TASKS = FULL_SEED_TASKS
 
   desc "seed the data needed for this type of environment by default"
   timed_task_with_logging default: DEFAULT_SEED_TASKS

--- a/dashboard/test/controllers/aichat_controller_test.rb
+++ b/dashboard/test/controllers/aichat_controller_test.rb
@@ -4,8 +4,10 @@ class AichatControllerTest < ActionController::TestCase
   setup_all do
     @authorized_teacher1 = create(:authorized_teacher)
     unit_group = create(:unit_group, name: 'exploring-gen-ai-2024')
-    section = create(:section, user: @authorized_teacher1, unit_group: unit_group)
+    section = create(:section, user: @authorized_teacher1, unit_group: unit_group, ai_chat_access_level: Section::AI_CHAT_ACCESS_LEVELS[:ENABLED])
+    section2 = create(:section, user: @authorized_teacher1, unit_group: unit_group, ai_chat_access_level: Section::AI_CHAT_ACCESS_LEVELS[:ESSENTIAL_ONLY])
     @authorized_student1 = create(:follower, section: section).student_user
+    @authorized_student2 = create(:follower, section: section2).student_user
   end
 
   # *****
@@ -38,8 +40,15 @@ class AichatControllerTest < ActionController::TestCase
     assert_equal json_response['userHasAccess'], false
   end
 
-  test 'GET user_has_access returns true for student of authorized teacher' do
+  test 'GET user_has_access returns true for student of authorized teacher with enabled access' do
     sign_in(@authorized_student1)
+    get :user_has_access, format: :json
+    assert_response :success
+    assert_equal json_response['userHasAccess'], true
+  end
+
+  test 'GET user_has_access returns true for student of authorized teacher with essential_only access' do
+    sign_in(@authorized_student2)
     get :user_has_access, format: :json
     assert_response :success
     assert_equal json_response['userHasAccess'], true

--- a/dashboard/test/controllers/aichat_events_controller_test.rb
+++ b/dashboard/test/controllers/aichat_events_controller_test.rb
@@ -7,7 +7,7 @@ class AichatEventsControllerTest < ActionController::TestCase
     @unauthorized_student = create(:student)
     @unauthorized_teacher = create(:teacher)
     unit_group = create(:unit_group, name: 'exploring-gen-ai-2024')
-    @section = create(:section, user: @authorized_teacher1, unit_group: unit_group)
+    @section = create(:section, user: @authorized_teacher1, unit_group: unit_group, ai_chat_access_level: Section::AI_CHAT_ACCESS_LEVELS[:ESSENTIAL_ONLY])
     @authorized_student1 = create(:follower, section: @section).student_user
 
     @level = create(:level)

--- a/dashboard/test/controllers/aichat_requests_controller_test.rb
+++ b/dashboard/test/controllers/aichat_requests_controller_test.rb
@@ -4,7 +4,7 @@ class AichatRequestsControllerTest < ActionController::TestCase
   setup_all do
     @authorized_teacher1 = create(:authorized_teacher)
     unit_group = create(:unit_group, name: 'exploring-gen-ai-2024')
-    section = create(:section, user: @authorized_teacher1, unit_group: unit_group)
+    section = create(:section, user: @authorized_teacher1, unit_group: unit_group, ai_chat_access_level: Section::AI_CHAT_ACCESS_LEVELS[:ESSENTIAL_ONLY])
     @authorized_student1 = create(:follower, section: section).student_user
     @unauthorized_student = create(:student)
     @unauthorized_teacher = create(:teacher)

--- a/dashboard/test/models/concerns/user/ai_accessible_test.rb
+++ b/dashboard/test/models/concerns/user/ai_accessible_test.rb
@@ -4,13 +4,13 @@ class UserAiAccessibleTest < ActiveSupport::TestCase
   include Minitest::RSpecMocks
 
   let(:user) {create(:user)}
-  let(:section) {create(:section, ai_tutor_enabled: true)}
+  let(:disabled_section) {create(:section, ai_chat_access_level: Section::AI_CHAT_ACCESS_LEVELS[:DISABLED])}
 
   before do
     user.extend(User::AiAccessible)
 
     allow(user).to receive(:teachers).and_return([])
-    allow(user).to receive(:sections_as_student).and_return([section])
+    allow(user).to receive(:sections_as_student).and_return([disabled_section])
     allow(user).to receive(:teacher?).and_return(false)
     allow(user).to receive(:student?).and_return(true)
     allow(user).to receive(:verified_instructor?).and_return(false)
@@ -61,19 +61,91 @@ class UserAiAccessibleTest < ActiveSupport::TestCase
 
   describe '#student_can_access_ai_chat_lab?' do
     subject(:student_can_access_ai_chat_lab?) {user.student_can_access_ai_chat_lab?}
-    it 'returns true if teacher can access and section has AI chat enabled' do
-      teacher = create(:teacher)
-      allow(section).to receive(:assigned_ai_chat?).and_return(true)
 
-      allow(teacher).to receive(:teacher_can_access_ai_chat_lab?).and_return(true)
-      allow(user).to receive(:teachers).and_return([teacher])
-      allow(user).to receive(:sections_as_student).and_return([section])
+    let(:qualified_teacher) {create(:teacher).tap {|t| allow(t).to receive(:teacher_can_access_ai_chat_lab?).and_return(true)}}
 
-      _student_can_access_ai_chat_lab?.must_equal true
+    context 'when teacher can access and access level is ENABLED' do
+      it 'returns true' do
+        enabled_section = create(:section, ai_chat_access_level: Section::AI_CHAT_ACCESS_LEVELS[:ENABLED])
+        allow(user).to receive(:teachers).and_return([qualified_teacher])
+        allow(user).to receive(:sections_as_student).and_return([enabled_section])
+        _student_can_access_ai_chat_lab?.must_equal true
+      end
     end
 
-    it 'returns false otherwise' do
-      _student_can_access_ai_chat_lab?.must_equal false
+    context 'when teacher can access and access level is ESSENTIAL_ONLY' do
+      it 'returns true' do
+        essential_section = create(:section, ai_chat_access_level: Section::AI_CHAT_ACCESS_LEVELS[:ESSENTIAL_ONLY])
+        allow(user).to receive(:teachers).and_return([qualified_teacher])
+        allow(user).to receive(:sections_as_student).and_return([essential_section])
+        _student_can_access_ai_chat_lab?.must_equal true
+      end
+    end
+
+    context 'when teacher can access but access level is DISABLED' do
+      it 'returns false' do
+        allow(user).to receive(:teachers).and_return([qualified_teacher])
+        # sections_as_student returns disabled_section from before block
+        _student_can_access_ai_chat_lab?.must_equal false
+      end
+    end
+
+    context 'when teacher cannot access' do
+      it 'returns false' do
+        enabled_section = create(:section, ai_chat_access_level: Section::AI_CHAT_ACCESS_LEVELS[:ENABLED])
+        allow(user).to receive(:sections_as_student).and_return([enabled_section])
+        # teachers returns [] from before block
+        _student_can_access_ai_chat_lab?.must_equal false
+      end
+    end
+  end
+
+  describe '#ai_chat_access_level' do
+    subject(:ai_chat_access_level) {user.ai_chat_access_level}
+
+    context 'when user is a teacher' do
+      it 'returns ENABLED' do
+        allow(user).to receive(:teacher?).and_return(true)
+        _ai_chat_access_level.must_equal Section::AI_CHAT_ACCESS_LEVELS[:ENABLED]
+      end
+    end
+
+    context 'when student is in a section with ENABLED access' do
+      it 'returns ENABLED' do
+        enabled_section = create(:section, ai_chat_access_level: Section::AI_CHAT_ACCESS_LEVELS[:ENABLED])
+        allow(user).to receive(:sections_as_student).and_return([enabled_section])
+        _ai_chat_access_level.must_equal Section::AI_CHAT_ACCESS_LEVELS[:ENABLED]
+      end
+    end
+
+    context 'when student is in a section with ESSENTIAL_ONLY access' do
+      it 'returns ESSENTIAL_ONLY' do
+        essential_section = create(:section, ai_chat_access_level: Section::AI_CHAT_ACCESS_LEVELS[:ESSENTIAL_ONLY])
+        allow(user).to receive(:sections_as_student).and_return([essential_section])
+        _ai_chat_access_level.must_equal Section::AI_CHAT_ACCESS_LEVELS[:ESSENTIAL_ONLY]
+      end
+    end
+
+    context 'when student is only in sections with DISABLED access' do
+      it 'returns DISABLED' do
+        # sections_as_student returns disabled_section from before block
+        _ai_chat_access_level.must_equal Section::AI_CHAT_ACCESS_LEVELS[:DISABLED]
+      end
+    end
+
+    context 'when student has no sections' do
+      it 'returns DISABLED' do
+        allow(user).to receive(:sections_as_student).and_return([])
+        _ai_chat_access_level.must_equal Section::AI_CHAT_ACCESS_LEVELS[:DISABLED]
+      end
+    end
+
+    context 'when student is in multiple sections and one has ENABLED access' do
+      it 'returns ENABLED' do
+        enabled_section = create(:section, ai_chat_access_level: Section::AI_CHAT_ACCESS_LEVELS[:ENABLED])
+        allow(user).to receive(:sections_as_student).and_return([disabled_section, enabled_section])
+        _ai_chat_access_level.must_equal Section::AI_CHAT_ACCESS_LEVELS[:ENABLED]
+      end
     end
   end
 

--- a/dashboard/test/models/concerns/user/ai_accessible_test.rb
+++ b/dashboard/test/models/concerns/user/ai_accessible_test.rb
@@ -18,44 +18,6 @@ class UserAiAccessibleTest < ActiveSupport::TestCase
 
     allow(Policies::Lti).to receive(:lti?).and_return(false)
     allow(DCDO).to receive(:get).and_call_original
-    allow(DCDO).to receive(:get).with('ai-tutor-disabled', false).and_return(false)
-    allow(SingleUserExperiment).to receive(:enabled?).with(user: user, experiment_name: User::AiAccessible::AI_TUTOR_PILOT_NAME).and_return(false)
-    allow(Queries::User::TeacherEnabledExperiments).to receive(:call).with(user).and_return([])
-  end
-
-  describe '#ai_tutor_enabled_for_pilot?' do
-    subject(:ai_tutor_enabled_for_pilot?) {user.ai_tutor_enabled_for_pilot?}
-
-    it 'returns false if ai_tutor_access_denied is true' do
-      user.update!(ai_tutor_access_denied: true)
-      _ai_tutor_enabled_for_pilot?.must_equal false
-    end
-
-    it 'returns false if globally disabled' do
-      allow(DCDO).to receive(:get).with('ai-tutor-disabled', false).and_return(true)
-      _ai_tutor_enabled_for_pilot?.must_equal false
-    end
-
-    it 'returns true if student has a teacher in the pilot' do
-      allow(Queries::User::TeacherEnabledExperiments).to receive(:call).with(user).and_return([User::AiAccessible::AI_TUTOR_PILOT_NAME])
-      _ai_tutor_enabled_for_pilot?.must_equal true
-    end
-
-    it 'returns false if student does not have a teacher in the pilot' do
-      _ai_tutor_enabled_for_pilot?.must_equal false
-    end
-
-    it 'returns true if teacher is in the pilot' do
-      allow(user).to receive(:teacher?).and_return(true)
-
-      allow(SingleUserExperiment).to receive(:enabled?).with(user: user, experiment_name: User::AiAccessible::AI_TUTOR_PILOT_NAME).and_return(true)
-      _ai_tutor_enabled_for_pilot?.must_equal true
-    end
-
-    it 'returns false if teacher is not in the pilot' do
-      allow(user).to receive(:teacher?).and_return(true)
-      _ai_tutor_enabled_for_pilot?.must_equal false
-    end
   end
 
   describe '#can_use_ai_iteration_tools?' do

--- a/dashboard/test/models/user_test.rb
+++ b/dashboard/test/models/user_test.rb
@@ -4456,10 +4456,9 @@ class UserTest < ActiveSupport::TestCase
       end
     end
 
-    context 'when user is a student with verified teacher and in appropriate section' do
-      let(:unit_group) {create(:unit_group, name: 'exploring-gen-ai-2024')}
+    context 'when user is a student with verified teacher in a section with ESSENTIAL_ONLY access' do
       let(:teacher) {create(:authorized_teacher)}
-      let(:section) {create(:section, teacher: teacher, unit_group: unit_group)}
+      let(:section) {create(:section, teacher: teacher, ai_chat_access_level: Section::AI_CHAT_ACCESS_LEVELS[:ESSENTIAL_ONLY])}
       let(:student) {create(:student)}
       let!(:follower) {create(:follower, section: section, student_user: student, user: teacher)}
 
@@ -4468,7 +4467,29 @@ class UserTest < ActiveSupport::TestCase
       end
     end
 
-    context 'when user is a student with verified teacher but not in appropriate section' do
+    context 'when user is a student with verified teacher in a section with ENABLED access' do
+      let(:teacher) {create(:authorized_teacher)}
+      let(:section) {create(:section, teacher: teacher, ai_chat_access_level: Section::AI_CHAT_ACCESS_LEVELS[:ENABLED])}
+      let(:student) {create(:student)}
+      let!(:follower) {create(:follower, section: section, student_user: student, user: teacher)}
+
+      it 'can access AI Chat Lab' do
+        _(student.student_can_access_ai_chat_lab?).must_equal true
+      end
+    end
+
+    context 'when user is a student with verified teacher in a section with DISABLED access' do
+      let(:teacher) {create(:authorized_teacher)}
+      let(:section) {create(:section, teacher: teacher, ai_chat_access_level: Section::AI_CHAT_ACCESS_LEVELS[:DISABLED])}
+      let(:student) {create(:student)}
+      let!(:follower) {create(:follower, section: section, student_user: student, user: teacher)}
+
+      it 'cannot access AI Chat Lab' do
+        _(student.student_can_access_ai_chat_lab?).must_equal false
+      end
+    end
+
+    context 'when user is a student with verified teacher but no section configured' do
       let(:teacher) {create(:authorized_teacher)}
       let(:section) {create(:section, teacher: teacher)}
       let(:student) {create(:student)}
@@ -4481,12 +4502,76 @@ class UserTest < ActiveSupport::TestCase
 
     context 'when user is a student with regular teacher' do
       let(:teacher) {create(:teacher)}
-      let(:section) {create(:section, teacher: teacher)}
+      let(:section) {create(:section, teacher: teacher, ai_chat_access_level: Section::AI_CHAT_ACCESS_LEVELS[:ENABLED])}
       let(:student) {create(:student)}
       let!(:follower) {create(:follower, section: section, student_user: student, user: teacher)}
 
       it 'does not have access' do
         _(student.student_can_access_ai_chat_lab?).must_equal false
+      end
+    end
+  end
+
+  describe '#ai_chat_access_level' do
+    context 'when user is a teacher' do
+      let(:teacher) {create(:teacher)}
+
+      it 'returns ENABLED' do
+        _(teacher.ai_chat_access_level).must_equal Section::AI_CHAT_ACCESS_LEVELS[:ENABLED]
+      end
+    end
+
+    context 'when user is a student in a section with ENABLED access' do
+      let(:teacher) {create(:authorized_teacher)}
+      let(:section) {create(:section, teacher: teacher, ai_chat_access_level: Section::AI_CHAT_ACCESS_LEVELS[:ENABLED])}
+      let(:student) {create(:student)}
+      let!(:follower) {create(:follower, section: section, student_user: student, user: teacher)}
+
+      it 'returns ENABLED' do
+        _(student.ai_chat_access_level).must_equal Section::AI_CHAT_ACCESS_LEVELS[:ENABLED]
+      end
+    end
+
+    context 'when user is a student in a section with ESSENTIAL_ONLY access' do
+      let(:teacher) {create(:authorized_teacher)}
+      let(:section) {create(:section, teacher: teacher, ai_chat_access_level: Section::AI_CHAT_ACCESS_LEVELS[:ESSENTIAL_ONLY])}
+      let(:student) {create(:student)}
+      let!(:follower) {create(:follower, section: section, student_user: student, user: teacher)}
+
+      it 'returns ESSENTIAL_ONLY' do
+        _(student.ai_chat_access_level).must_equal Section::AI_CHAT_ACCESS_LEVELS[:ESSENTIAL_ONLY]
+      end
+    end
+
+    context 'when user is a student in a section with DISABLED access' do
+      let(:teacher) {create(:authorized_teacher)}
+      let(:section) {create(:section, teacher: teacher, ai_chat_access_level: Section::AI_CHAT_ACCESS_LEVELS[:DISABLED])}
+      let(:student) {create(:student)}
+      let!(:follower) {create(:follower, section: section, student_user: student, user: teacher)}
+
+      it 'returns DISABLED' do
+        _(student.ai_chat_access_level).must_equal Section::AI_CHAT_ACCESS_LEVELS[:DISABLED]
+      end
+    end
+
+    context 'when user is a student with no sections' do
+      let(:student) {create(:student)}
+
+      it 'returns DISABLED' do
+        _(student.ai_chat_access_level).must_equal Section::AI_CHAT_ACCESS_LEVELS[:DISABLED]
+      end
+    end
+
+    context 'when student is in multiple sections and one has ENABLED access' do
+      let(:teacher) {create(:authorized_teacher)}
+      let(:section_disabled) {create(:section, teacher: teacher, ai_chat_access_level: Section::AI_CHAT_ACCESS_LEVELS[:DISABLED])}
+      let(:section_enabled) {create(:section, teacher: teacher, ai_chat_access_level: Section::AI_CHAT_ACCESS_LEVELS[:ENABLED])}
+      let(:student) {create(:student)}
+      let!(:follower_disabled) {create(:follower, section: section_disabled, student_user: student, user: teacher)}
+      let!(:follower_enabled) {create(:follower, section: section_enabled, student_user: student, user: teacher)}
+
+      it 'returns ENABLED' do
+        _(student.ai_chat_access_level).must_equal Section::AI_CHAT_ACCESS_LEVELS[:ENABLED]
       end
     end
   end

--- a/dashboard/test/ui/features/star_labs/aichat/view_student_chat_history.feature
+++ b/dashboard/test/ui/features/star_labs/aichat/view_student_chat_history.feature
@@ -7,7 +7,7 @@ Feature: Teacher viewing student chat history in AI Chat Lab
 Background:
   Given I create a teacher named "Simone"
   And I give user "Simone" authorized teacher permission
-  And I create a new student section assigned to course "customizing-llms-2024" unit 1 and save the section
+  And I create a new student section assigned to course "customizing-llms-2024" unit 1 with AI chat enabled and save the section
 
   Given I create a student named "Hermione"
   And I join the section

--- a/dashboard/test/ui/features/step_definitions/section_management_steps.rb
+++ b/dashboard/test/ui/features/step_definitions/section_management_steps.rb
@@ -56,11 +56,13 @@ Given(/^I am a teacher with student sections named Section 1 and Section 2/) do
   )
 end
 
-Given(/^I create a new student section assigned to course "([^"]*)" unit (\d+)( and save the section)?$/) do |course_name, unit_position, save|
+Given(/^I create a new student section assigned to course "([^"]*)" unit (\d+)( with AI chat enabled)?( and save the section)?$/) do |course_name, unit_position, ai_chat_enabled, save|
+  body = {course_name: course_name, unit_position: unit_position}
+  body[:ai_chat_access_level] = SharedConstants::AI_CHAT_ACCESS_LEVELS[:ESSENTIAL_ONLY] if ai_chat_enabled
   response = JSON.parse(browser_request(
                           url: '/api/test/create_student_section_assigned_to_course_and_unit',
                           method: 'POST',
-                          body: {course_name: course_name, unit_position: unit_position}
+                          body: body
     )
   )
   if save

--- a/dashboard/test/ui/features/step_definitions/section_management_steps.rb
+++ b/dashboard/test/ui/features/step_definitions/section_management_steps.rb
@@ -58,7 +58,7 @@ end
 
 Given(/^I create a new student section assigned to course "([^"]*)" unit (\d+)( with AI chat enabled)?( and save the section)?$/) do |course_name, unit_position, ai_chat_enabled, save|
   body = {course_name: course_name, unit_position: unit_position}
-  body[:ai_chat_access_level] = SharedConstants::AI_CHAT_ACCESS_LEVELS[:ESSENTIAL_ONLY] if ai_chat_enabled
+  body[:ai_chat_access_level] = 'essential_only' if ai_chat_enabled
   response = JSON.parse(browser_request(
                           url: '/api/test/create_student_section_assigned_to_course_and_unit',
                           method: 'POST',


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
We've been testing new permissions for AI Chat Tools under the experiment `AI_CHAT_NEW_PERMISSIONS` and broad tutor in CSD and CDP in a pilot. This PR takes those permissions out from behind the experiment and tutor out from behind the pilot making them generally available. There are also some extra test changes updating and adding coverage. 

Try it out on this adhoc https://adhoc-cassi-ship-it-studio.cdn-code.org/ 

## Links
<!--  Links to relevant external resources.
      - spec docs, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- [project task board](https://www.figma.com/board/47n4NNAkS9lV2KbKhPiJSp/AI-Tutor-Permissions-Dumplink?node-id=0-1&p=f&t=ZR8orDfBNTpU0Xdm-0)
- [designs ](https://www.figma.com/design/nl4nXJLuUHb9Aj4gfCAaNL/AI-Tutor--Settings?node-id=3372-8026&m=dev)
- [jira](https://codedotorg.atlassian.net/browse/OM-64)

## Testing story
<!--  Does your change include appropriate tests?
      - If so, please describe how the tests included in this PR are sufficient.
      - If not, please explain why this change does not need to be tested. -->

Updated tests and added more coverage in this PR.

Testing this branch on an adhoc as our release candidate.


## Deployment strategy
<!--  Any special steps required to deploy this, besides merging?
      - Are there database migrations or manual steps?
      - Does this require coordination with other teams or systems? -->

Auto-enablement of ai chat tools went live for everyone in the background in #70804 and afterward, I enabled all sections edited within the last 2 years in production according to this logic:
```
dependency = section.assigned_ai_chat_tools_dependency
should_enable =
        dependency == SharedConstants::AI_CHAT_TOOLS_DEPENDENCY[:ESSENTIAL] ||
        (dependency == SharedConstants::AI_CHAT_TOOLS_DEPENDENCY[:AVAILABLE] &&
          SingleUserExperiment.enabled?(user: section.user, experiment_name: User::AiAccessible::AI_TUTOR_PILOT_NAME))
```

So existing sections using chat tools should not lose access when this deploys.

## Follow-up work
<!--  List any clean-up or technical debt that will be addressed in future work.
      - Include Jira links where applicable.
      - Are there any known limitations or improvements planned? -->

Remove the tutor pilot from the incubator.
Publish the zendesk article.