### PR TITLE
Ceara/aitt add icon to prompt chips

### DIFF
--- a/apps/src/aiComponentLibrary/suggestedPrompt/SuggestedPrompts.tsx
+++ b/apps/src/aiComponentLibrary/suggestedPrompt/SuggestedPrompts.tsx
@@ -1,3 +1,4 @@
+import FontAwesomeV6Icon from '@code-dot-org/component-library/fontAwesomeV6Icon';
 import classNames from 'classnames';
 import React from 'react';
 
@@ -11,6 +12,7 @@ export interface SuggestedPrompt {
   label: string;
   show: boolean;
   selected: boolean;
+  icon?: string;
 }
 
 interface SuggestedPromptsProps {
@@ -46,6 +48,7 @@ const SuggestedPrompts: React.FC<SuggestedPromptsProps> = ({
             aria-label={prompt.label}
           >
             <span>{prompt.label}</span>
+            {prompt.icon && <FontAwesomeV6Icon iconName={prompt.icon} />}
           </button>
         );
       })}

--- a/apps/src/aiComponentLibrary/suggestedPrompt/suggested-prompt.module.scss
+++ b/apps/src/aiComponentLibrary/suggestedPrompt/suggested-prompt.module.scss
@@ -52,5 +52,9 @@
         background-color: var(--neutral-base-white);
       }
     }
+
+    i {
+      margin-left: 8px;
+    }
   }
 }

--- a/apps/src/aiDifferentiation/AiDiffChat.tsx
+++ b/apps/src/aiDifferentiation/AiDiffChat.tsx
@@ -29,11 +29,7 @@ import AiDiffChatHeader from './AiDiffChatHeader';
 import AiDiffCreateArtifactButtons from './AiDiffCreateArtifactButtons';
 import AiDiffSuggestedPrompts from './AiDiffSuggestedPrompts';
 import {DEFAULT_THREAD_TITLE} from './constants';
-import {
-  EXIT_TICKET_PROMPT,
-  LESSON_HOOK_PROMPT,
-  SUGGESTED_PROMPTS_FOR_SELECTION,
-} from './predefinedPrompts';
+import {SUGGESTED_PROMPTS_FOR_SELECTION} from './predefinedPrompts';
 import {
   AiArtifact,
   ChatItem,
@@ -263,11 +259,8 @@ const AiDiffChat: React.FC<AiDiffChatProps> = ({
       if (!prompt.followUpPrompts && !prompt.response) {
         getAIResponse(prompt.prompt, true, prompt.label);
       }
-      if (prompt === EXIT_TICKET_PROMPT) {
-        dispatch(setArtifactType(AiDiffArtifactType.EXIT_TICKET));
-      }
-      if (prompt === LESSON_HOOK_PROMPT) {
-        dispatch(setArtifactType(AiDiffArtifactType.LESSON_HOOK));
+      if (prompt.artifactCandidateType) {
+        dispatch(setArtifactType(prompt.artifactCandidateType));
       }
     },
     [dispatch, getAIResponse, threadTitle]

--- a/apps/src/aiDifferentiation/AiDiffSidebar.tsx
+++ b/apps/src/aiDifferentiation/AiDiffSidebar.tsx
@@ -77,7 +77,7 @@ const TitleAndIcon: React.FC<{
   title: string;
 }> = ({title}) => (
   <div className={styles.sidebarArtifactIconContainer}>
-    <text>{title}</text>
+    <Typography variant="body3">{title}</Typography>
     <FontAwesomeV6Icon
       iconName="shapes"
       className={styles.artifactThreadIcon}

--- a/apps/src/aiDifferentiation/AiDiffSuggestedPrompts.tsx
+++ b/apps/src/aiDifferentiation/AiDiffSuggestedPrompts.tsx
@@ -43,6 +43,7 @@ const AiDiffSuggestedPrompts: React.FC<ComponentProps> = ({
         selected: prompt === selectedPrompt,
         onClick: onClick(prompt),
         show: true,
+        icon: prompt.artifactCandidateType ? 'shapes' : undefined,
       };
     });
 

--- a/apps/src/aiDifferentiation/predefinedPrompts/context/activityPrompts.ts
+++ b/apps/src/aiDifferentiation/predefinedPrompts/context/activityPrompts.ts
@@ -12,6 +12,7 @@
  */
 
 import {ChatPrompt} from '@cdo/apps/aiDifferentiation/types';
+import {AiDiffArtifactType} from '@cdo/generated-scripts/sharedConstants';
 
 export const FINISH_EARLY_PROMPT: ChatPrompt = {
   label: 'Write an extension activity for students who finish early',
@@ -29,6 +30,7 @@ export const EXIT_TICKET_PROMPT: ChatPrompt = {
   label: 'Write an exit ticket',
   prompt:
     'I need an exit ticket to quickly assess if my class understood a concept. You can ask me a follow-up question to find out what concept needs to be assessed and if they have a preference in question type.',
+  artifactCandidateType: AiDiffArtifactType.EXIT_TICKET,
 };
 
 export const MINI_LESSON_PROMPT: ChatPrompt = {
@@ -56,4 +58,5 @@ export const LESSON_HOOK_PROMPT: ChatPrompt = {
     Use this information to create a relevant, 1-2 minute hook that connects to students' experiences and creates curiosity about the new concept.
 
     Format the questions as a clear, easy-to-read list`,
+  artifactCandidateType: AiDiffArtifactType.LESSON_HOOK,
 };

--- a/apps/src/aiDifferentiation/types.ts
+++ b/apps/src/aiDifferentiation/types.ts
@@ -49,6 +49,7 @@ export type ChatTextMessage = {
 export type ChatPrompt = {
   label: string;
   prompt: string;
+  artifactCandidateType?: (typeof AiDiffArtifactType)[keyof typeof AiDiffArtifactType];
   response?: string;
   followUpPrompts?: ChatPrompt[];
 };


### PR DESCRIPTION
Adds an icon to the prompt chip if the prompt can create an artifact

Also does a little bit of clean-up and simplification for adding the artifact type to the prompt definition and using that to set the artifact state type

<img width="1406" height="1300" alt="Screenshot 2026-02-25 at 4 45 15 PM" src="https://github.com/user-attachments/assets/8d617429-2807-4bc2-89ec-7f4668e41bfd" />

Selected:
<img width="1408" height="1296" alt="Screenshot 2026-02-25 at 4 46 45 PM" src="https://github.com/user-attachments/assets/aaea335e-e6f9-4b2f-baca-a3b817d5d68c" />

## Testing story
This will cause an eyes diff for the aidiff tests!


## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
