### PR TITLE
Fix LTI course dupe one-off script

### DIFF
--- a/bin/oneoff/wipe_data/remove_duplicate_lti_courses
+++ b/bin/oneoff/wipe_data/remove_duplicate_lti_courses
@@ -2,7 +2,9 @@
 
 # This script deletes duplicate LTI course records
 # See: https://codedotorg.atlassian.net/browse/P20-1796
+# Note: Manually review any duplicate records before running this script to ensure that the correct record is retained.
 
+require_relative '../../../dashboard/config/environment'
 require 'optparse'
 options = {dry_run: false, limit: 10_000, batch_size: 1000}
 OptionParser.new do |opts|
@@ -37,7 +39,6 @@ print "Proceed with options #{options} (y/N): "
 abort unless $stdin.gets&.strip&.downcase == 'y'
 
 require 'ruby-progressbar'
-require_relative '../../../dashboard/config/environment'
 
 duplicate_pairs_query = LtiCourse.group(:lti_integration_id, :context_id).having('COUNT(*) > 1').limit(options[:limit])
 duplicate_pairs_count = LtiCourse.unscoped.from(duplicate_pairs_query.select('1'), :dupes).count
@@ -51,7 +52,7 @@ while progress_bar.progress < options[:limit]
     duplicate_pair_query = LtiCourse.where(lti_integration_id:, context_id:)
     progress_bar.log "\n[Duplicate data] lti_integration_id: #{lti_integration_id}, context_id: #{context_id}".bold.cyan
 
-    relevant_record = duplicate_pair_query.order(updated_at: :desc, created_at: :desc).first
+    relevant_record = duplicate_pair_query.order(:updated_at, :created_at).first
     progress_bar.log "[Relevant record] #{relevant_record.inspect}".green
 
     duplicate_pair_query.where.not(id: relevant_record.id).find_each do |duplicate_record|


### PR DESCRIPTION
Fixes two issues with this oneoff script, in case it ever needs to be run again:

- moves the require_relative for dashboard env to the top to avoid issues in the production environment
- reverses the logic for which record is considered relevant vs. duplicate. After manually inspecting each pair of records, we determined that the first created/updated course record was always the one with active sections.



## Links
<!--  Links to relevant external resources.
      - spec docs, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- JIRA task: [P20-1796](https://codedotorg.atlassian.net/browse/P20-1796)
- Related PR: https://github.com/code-dot-org/code-dot-org/pull/70775

## Testing story
<!--  Does your change include appropriate tests?
      - If so, please describe how the tests included in this PR are sufficient.
      - If not, please explain why this change does not need to be tested. -->



## Deployment strategy
<!--  Any special steps required to deploy this, besides merging?
      - Are there database migrations or manual steps?
      - Does this require coordination with other teams or systems? -->



## Follow-up work
<!--  List any clean-up or technical debt that will be addressed in future work.
      - Include Jira links where applicable.
      - Are there any known limitations or improvements planned? -->



## Privacy
<!--  How does this change impact Student & Teacher privacy?
      - Does this collect, use, share, or modify PII, either new or existing? -->



## Security
<!--  How does this change impact our security surface-area?
      - Do API's touched have the right auth?
      - Do infra changes impact our attack surface or encryption?
-->



## Caching
<!--  How does this change impact caching behavior?
      - Are cache keys or invalidation strategies affected?
      - Will this require cache warming or invalidation after deployment? -->



## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
