### PR TITLE
Ceara/aitt remove artifact experiment

### DIFF
--- a/apps/src/aiDifferentiation/AiDiffChat.tsx
+++ b/apps/src/aiDifferentiation/AiDiffChat.tsx
@@ -10,7 +10,6 @@ import {
 import ChatMessage from '@cdo/apps/aiComponentLibrary/chatMessage/ChatMessage';
 import {Role} from '@cdo/apps/aiComponentLibrary/chatMessage/types';
 import {PersonalizationData} from '@cdo/apps/aiDifferentiation/hooks/useTeachingProfileData';
-import experiments from '@cdo/apps/util/experiments';
 import {useAppDispatch, useAppSelector} from '@cdo/apps/util/reduxHooks';
 import {
   AiInteractionStatus as Status,
@@ -158,11 +157,7 @@ const AiDiffChat: React.FC<AiDiffChatProps> = ({
         presetChipText,
         ...(threadId === 0 ? {context} : {}),
         ...(context.type === AiDiffContext.LEVEL ? {viewAsUserId} : {}),
-        ...(artifactType &&
-        experiments.isEnabled(experiments.AI_ARTIFACT) &&
-        !isPreset
-          ? {artifactType}
-          : {}),
+        ...(artifactType && !isPreset ? {artifactType} : {}),
       });
 
       HttpClient.post(endpoint, body, true, {

--- a/apps/src/templates/teacherNavigation/lessonMaterials/LessonMaterialsContainer.tsx
+++ b/apps/src/templates/teacherNavigation/lessonMaterials/LessonMaterialsContainer.tsx
@@ -300,7 +300,7 @@ const LessonMaterialsContainer: React.FC<LessonMaterialsContainerProps> = ({
   };
 
   const renderCustomResources = () => {
-    if (selectedLesson && experiments.isEnabled(experiments.AI_ARTIFACT)) {
+    if (selectedLesson) {
       return (
         <CustomLessonResources
           unitId={selectedSection.unitId}

--- a/apps/src/util/experiments.js
+++ b/apps/src/util/experiments.js
@@ -42,8 +42,6 @@ experiments.SECTION_SETUP_REFRESH = 'sectionSetupRefresh';
 experiments.GENDER_FEATURE_ENABLED = 'gender';
 // Experiment for enabling the AI-TA differentiation chat
 experiments.AI_DIFFERENTIATION = 'ai-differentiation';
-// Experiment for enabling the AI-TA differentiation artifacts
-experiments.AI_ARTIFACT = 'ai-artifact';
 // Experiment for showing the ai chat new permissions page and enabling permissions to take effect
 experiments.AI_CHAT_NEW_PERMISSIONS = 'ai-chat-new-permissions';
 // Adds a "Get help with this block" option to block context menus if docs exist (e.g. Sprite Lab)

--- a/dashboard/app/models/ability.rb
+++ b/dashboard/app/models/ability.rb
@@ -302,14 +302,12 @@ class Ability
           can?(:manage, message.aidiff_thread)
         end
         can [:index, :show, :chat_completion, :curriculum_courses], AidiffThread, user_id: user.id
-        if Experiment.enabled?(user: user, experiment_name: 'ai-artifact')
-          can :create, AidiffArtifact
-          can :create, AidiffExitTicket
-          can :create, AidiffLessonHook
-          can [:index], AidiffArtifact, user_id: user.id
-          can [:index, :update, :show], AidiffExitTicket, user_id: user.id
-          can [:index, :update, :show], AidiffLessonHook, user_id: user.id
-        end
+        can :create, AidiffArtifact
+        can :create, AidiffExitTicket
+        can :create, AidiffLessonHook
+        can [:index], AidiffArtifact, user_id: user.id
+        can [:index, :update, :show], AidiffExitTicket, user_id: user.id
+        can [:index, :update, :show], AidiffLessonHook, user_id: user.id
       end
 
       can :show, Rubric

--- a/dashboard/test/controllers/aidiff_artifacts_controller_test.rb
+++ b/dashboard/test/controllers/aidiff_artifacts_controller_test.rb
@@ -8,8 +8,6 @@ class AidiffArtifactsControllerTest < ActionController::TestCase
     @teacher = create(:teacher)
 
     create(:single_user_experiment, min_user_id: @teacher.id, name: 'ai-differentiation')
-    create(:single_user_experiment, min_user_id: @teacher_sans_experiment.id, name: 'ai-differentiation')
-    create(:single_user_experiment, min_user_id: @teacher.id, name: 'ai-artifact')
 
     @unit_group = create(:unit_group, family_name: 'beepboop')
     @course_offering = create(:course_offering, display_name: 'Course Name')

--- a/dashboard/test/controllers/aidiff_exit_tickets_controller_test.rb
+++ b/dashboard/test/controllers/aidiff_exit_tickets_controller_test.rb
@@ -16,8 +16,6 @@ class AidiffExitTicketsControllerTest < ActionController::TestCase
     @teacher = create(:teacher)
 
     create(:single_user_experiment, min_user_id: @teacher.id, name: 'ai-differentiation')
-    create(:single_user_experiment, min_user_id: @teacher_sans_experiment.id, name: 'ai-differentiation')
-    create(:single_user_experiment, min_user_id: @teacher.id, name: 'ai-artifact')
   end
 
   test "index redirects to signin when teacher not signed in" do

--- a/dashboard/test/controllers/aidiff_lesson_hooks_controller_test.rb
+++ b/dashboard/test/controllers/aidiff_lesson_hooks_controller_test.rb
@@ -16,8 +16,6 @@ class AidiffLessonHooksControllerTest < ActionController::TestCase
     @teacher = create(:teacher)
 
     create(:single_user_experiment, min_user_id: @teacher.id, name: 'ai-differentiation')
-    create(:single_user_experiment, min_user_id: @teacher_sans_experiment.id, name: 'ai-differentiation')
-    create(:single_user_experiment, min_user_id: @teacher.id, name: 'ai-artifact')
   end
 
   test "index redirects to signin when teacher not signed in" do


### PR DESCRIPTION
Removes the `ai-artifact` experiment flag from the front and back end

## Testing story
Backend unit tests are updated to remove the `ai-artifact` experiment requirement


## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
