### PR TITLE
Move original_script_names for AIF units

### DIFF
--- a/dashboard/config/courses/artificial-intelligence-foundations-2026.course
+++ b/dashboard/config/courses/artificial-intelligence-foundations-2026.course
@@ -9,7 +9,12 @@
     "aif6-v2-2025"
   ],
   "original_script_names": [
-
+    "aif1-v2-2025",
+    "aif2-v2-2025",
+    "aif3-v2-2025",
+    "aif4-v2-2025",
+    "aif6-v2-2025",
+    "aif5-v3"
   ],
   "published_state": "stable",
   "instruction_type": "teacher_led",

--- a/dashboard/config/courses/artificial-intelligence-foundations-v2-2025.course
+++ b/dashboard/config/courses/artificial-intelligence-foundations-v2-2025.course
@@ -9,12 +9,6 @@
     "aif6-v2-2025"
   ],
   "original_script_names": [
-    "aif1-v2-2025",
-    "aif2-v2-2025",
-    "aif3-v2-2025",
-    "aif4-v2-2025",
-    "aif6-v2-2025",
-    "aif5-v3"
   ],
   "published_state": "in_development",
   "instruction_type": "teacher_led",


### PR DESCRIPTION
This PR is intended to ensure that the units connected to the in_development version of AIF are connected to a stable version of AIF as their `original_unit_group`.   You can see [this](https://codedotorg.slack.com/archives/C045UAX4WKH/p1770239149897089) thread for part of the discussion.  Originally this came up when it came to generating PDFs, but we ran into another issue this week with assessment data not being available to teachers because of this quirk.

The core issue here is that the `original_unit_group` for these units was tied to [/courses/artificial-intelligence-foundations-v2-2025](https://levelbuilder-studio.code.org/courses/artificial-intelligence-foundations-v2-2025) which is marked as `in_development`.  There are no plans to make this course stable.  However, the units in this course are connected to other courses that are `stable`.  This is causing some unexpected behaviors when we are referencing the scripts connected to these units (see the above thread).

By merging this change in, we will be able to re-seed these courses and then set the `original_unit_group_ids` for the impacted units ([as described in this file](https://github.com/code-dot-org/code-dot-org/blob/0930bc72af6a42f27269c429c9391d52e1a895fa/dashboard/lib/services/script_seed.rb#L291)).

