### PR TITLE
AI Tutor - Move enabling of vertex from query param to experiment

### DIFF
--- a/apps/src/aichat/redux/thunks/submitChatContents.ts
+++ b/apps/src/aichat/redux/thunks/submitChatContents.ts
@@ -10,12 +10,12 @@ import {
 } from '@cdo/apps/aichat/redux/slice';
 import {Role} from '@cdo/apps/aiComponentLibrary/chatMessage/types';
 import {sendProgressReport} from '@cdo/apps/code-studio/progressRedux';
-import {queryParams} from '@cdo/apps/code-studio/utils';
 import {TestResults} from '@cdo/apps/constants';
 import Lab2Registry from '@cdo/apps/lab2/Lab2Registry';
 import {EVENTS} from '@cdo/apps/metrics/AnalyticsConstants';
 import {commonI18n} from '@cdo/apps/types/locale';
 import {RootState} from '@cdo/apps/types/redux';
+import experiments from '@cdo/apps/util/experiments';
 import {NetworkError} from '@cdo/apps/util/HttpClient';
 import {AppDispatch} from '@cdo/apps/util/reduxHooks';
 import {createUuid} from '@cdo/apps/utils';
@@ -43,7 +43,8 @@ import {sendAnalytics} from './sendAnalytics';
 
 // We currently default to using the legacy Gemini API unless use vertex query param set.
 // This will be removed once we switch over to Vertex completely.
-const useVertex = queryParams('aitutor-use-vertex') === 'true' ? true : false;
+const useVertex =
+  experiments.isEnabledAllowingQueryString('aitutor-use-vertex');
 
 // Log whether using Vertex API or not in case query param entered incorrectly.
 console.log(`🤖: Tutor set to use Vertex API? ${useVertex ? 'YES' : 'NO'}`);


### PR DESCRIPTION
This PR changes the enabling of the Vertex AI API backend for Gemini from the query param `aitutor-use-vertex`  to the experiment `aitutor-use-vertex`.