### PR TITLE
AI Tutor: add "en" to locale check for `AiTutorEnglishOnlyWarning`

### DIFF
--- a/apps/src/aiTutor/views/AiTutorEnglishOnlyWarning.tsx
+++ b/apps/src/aiTutor/views/AiTutorEnglishOnlyWarning.tsx
@@ -12,7 +12,7 @@ const AiTutorEnglishOnlyWarning: React.FunctionComponent = () => {
   const lab2Locale = useLocalization();
   const locale = legacyLabState ? legacyLabState.locale : lab2Locale;
   const isEnglishLocale =
-    locale && ['en_us', 'en_gb', 'en-US', 'en-GB'].includes(locale);
+    locale && ['en_us', 'en_gb', 'en-US', 'en-GB', 'en'].includes(locale);
 
   const showEnglishOnlyWarning =
     !isEnglishLocale && clientType === AiChatClientTypes.AI_TUTOR;


### PR DESCRIPTION
We discovered that the English-only support warning for AI Tutor was erroneously appearing users viewing the site in English on https://studio.code.org/courses/artificial-intelligence-foundations-2025/units/2/lessons/4/levels/1, but interestingly correctly not showing on https://studio.code.org/courses/artificial-intelligence-foundations-2026/units/2/lessons/4/levels/1.  This occurs because the locale on the 2025 version of the course is set to "en" whereas on the 2026 version of the course, it sets to "en-US". I was already accounting for legacy lab locale with "en_us". I added "en" to the values we're checking for and it correctly hides the warning on the 2025 version. 