### PR TITLE
Update auth option for resurrected clever users

### DIFF
--- a/dashboard/app/controllers/omniauth_callbacks_controller.rb
+++ b/dashboard/app/controllers/omniauth_callbacks_controller.rb
@@ -329,7 +329,12 @@ class OmniauthCallbacksController < Devise::OmniauthCallbacksController
       id: auth_hash.uid
   end
 
-  # Temporary method to find existing Clever users by their legacy_id field
+  # Temporary method to find existing Clever users by their legacy_id field. This
+  # method also updates the user's credentials to use the new Clever v3 id and logs a metric for the migration.
+  # This is here to handle the edge case where an existing user's Clever auth option wasn't updated to the new v3 id
+  # during the migration, due to a district disabling the Clever integration, and then re-enabling it after the migration
+  # was complete. We want to make sure these users can still sign in without losing access to their account,
+  # and we also want to log a metric so we can understand how many users this is impacting and when it's no longer needed.
   private def find_clever_user_by_legacy_id
     return nil unless auth_hash
     # Teacher and staff users in Clever have a legacy_id field in the v3 API response.
@@ -344,9 +349,25 @@ class OmniauthCallbacksController < Devise::OmniauthCallbacksController
     end
     return nil unless legacy_id
 
-    User.find_by_credential \
+    user = User.find_by_credential \
       type: auth_hash.provider,
       id: legacy_id
+
+    if user
+      ao = user.authentication_options.find_by(credential_type: auth_hash.provider, authentication_id: legacy_id)
+      ao.update(authentication_id: auth_hash.uid, version: AuthenticationOption::Clever::VERSION[:v3]) if ao
+
+      Metrics::Events.log_event(
+        user: user,
+        event_name: 'clever_legacy_id_migration',
+        metadata: {
+          legacy_id: legacy_id,
+          new_id: auth_hash.uid
+        }
+      )
+    end
+
+    return user
   end
 
   private def auth_hash

--- a/dashboard/app/controllers/omniauth_callbacks_controller.rb
+++ b/dashboard/app/controllers/omniauth_callbacks_controller.rb
@@ -355,15 +355,11 @@ class OmniauthCallbacksController < Devise::OmniauthCallbacksController
 
     if user
       ao = user.authentication_options.find_by(credential_type: auth_hash.provider, authentication_id: legacy_id)
-      ao.update(authentication_id: auth_hash.uid, version: AuthenticationOption::Clever::VERSION[:v3]) if ao
+      ao.update!(authentication_id: auth_hash.uid, version: AuthenticationOption::Clever::VERSION[:v3]) if ao
 
       Metrics::Events.log_event(
         user: user,
         event_name: 'clever_legacy_id_migration',
-        metadata: {
-          legacy_id: legacy_id,
-          new_id: auth_hash.uid
-        }
       )
     end
 

--- a/dashboard/test/controllers/omniauth_callbacks_controller_test.rb
+++ b/dashboard/test/controllers/omniauth_callbacks_controller_test.rb
@@ -425,15 +425,11 @@ class OmniauthCallbacksControllerTest < ActionController::TestCase
     assert_equal user.id, signed_in_user_id
   end
 
-  test 'clever: signs in user if user is found by legacy_id' do
+  test 'clever: signs in user and updates auth option if user is found by legacy_id' do
     legacy_id = SecureRandom.alphanumeric(10)
-    user = create(:teacher)
-    create(
-      :authentication_option,
-      user: user,
-      credential_type: AuthenticationOption::CLEVER,
-      authentication_id: legacy_id
-    )
+    user = create(:teacher, :with_clever_authentication_option)
+    auth_option = user.authentication_options.find_by(credential_type: AuthenticationOption::CLEVER)
+    auth_option.update!(authentication_id: legacy_id)
 
     auth = generate_auth_user_hash \
       provider: AuthenticationOption::CLEVER,
@@ -442,12 +438,17 @@ class OmniauthCallbacksControllerTest < ActionController::TestCase
 
     @request.env['omniauth.auth'] = auth
     @request.env['omniauth.params'] = {}
-    assert_does_not_create(User) do
-      get :clever
+    assert_no_difference('AuthenticationOption.count') do
+      assert_does_not_create(User) do
+        get :clever
+      end
     end
 
     user.reload
+    auth_option.reload
     assert_equal user.id, signed_in_user_id
+    assert_equal auth[:uid], auth_option.authentication_id
+    assert_equal AuthenticationOption::Clever::VERSION[:v3], auth_option.version
   end
 
   test 'clever: updates tokens when unmigrated user is found by credentials' do

--- a/dashboard/test/controllers/omniauth_callbacks_controller_test.rb
+++ b/dashboard/test/controllers/omniauth_callbacks_controller_test.rb
@@ -429,6 +429,7 @@ class OmniauthCallbacksControllerTest < ActionController::TestCase
     legacy_id = SecureRandom.alphanumeric(10)
     user = create(:teacher, :with_clever_authentication_option)
     auth_option = user.authentication_options.find_by(credential_type: AuthenticationOption::CLEVER)
+    refute_equal AuthenticationOption::Clever::VERSION[:v3], auth_option.version
     auth_option.update!(authentication_id: legacy_id)
 
     auth = generate_auth_user_hash \


### PR DESCRIPTION
This PR updates `find_clever_user_by_legacy_id` to update Clever auth option to v3 and new id if user is found by legacy id. This is to account for the edge case where a user is still using an old Clever auth option due to a district disabling Code.org before the Clever V2 -> V3 auth option migration, then enabling it after. This would result in existing users being forced to create new accounts.

This logic also includes a Statsig event, so we can tell how often this path is being hit, and will give insight into when we can delete the `find_clever_user_by_legacy_id` completely.

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->



## Links
<!--  Links to relevant external resources.
      - spec docs, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- Jira: 

## Testing story
<!--  Does your change include appropriate tests?
      - If so, please describe how the tests included in this PR are sufficient.
      - If not, please explain why this change does not need to be tested. -->



## Deployment strategy
<!--  Any special steps required to deploy this, besides merging?
      - Are there database migrations or manual steps?
      - Does this require coordination with other teams or systems? -->



## Follow-up work
<!--  List any clean-up or technical debt that will be addressed in future work.
      - Include Jira links where applicable.
      - Are there any known limitations or improvements planned? -->



## Privacy
<!--  How does this change impact Student & Teacher privacy?
      - Does this collect, use, share, or modify PII, either new or existing? -->



## Security
<!--  How does this change impact our security surface-area?
      - Do API's touched have the right auth?
      - Do infra changes impact our attack surface or encryption?
-->



## Caching
<!--  How does this change impact caching behavior?
      - Are cache keys or invalidation strategies affected?
      - Will this require cache warming or invalidation after deployment? -->



## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
