### PR TITLE
remove support for Clever v2.1 APIs

### DIFF
--- a/dashboard/app/controllers/api_controller.rb
+++ b/dashboard/app/controllers/api_controller.rb
@@ -73,14 +73,8 @@ class ApiController < ApplicationController
   def clever_classrooms
     return head :forbidden unless current_user
 
-    v3_ao = current_user.authentication_options.find_by(
-      credential_type: AuthenticationOption::CLEVER,
-      version: AuthenticationOption::Clever::VERSION[:v3]
-    )
-    api_version = v3_ao.present? ? AuthenticationOption::Clever::VERSION[:v3] : AuthenticationOption::Clever::VERSION[:v2]
-    uid = v3_ao.present? ? v3_ao.authentication_id : current_user.uid_for_provider(AuthenticationOption::CLEVER)
-
-    query_clever_service(api_version:, endpoint: clever_sections_url_path(api_version:, uid:)) do |response|
+    uid = current_user.uid_for_provider(AuthenticationOption::CLEVER)
+    query_clever_service("users/#{uid}/sections") do |response|
       json = response.map do |section|
         data = section['data']
         {
@@ -102,7 +96,7 @@ class ApiController < ApplicationController
     course_id = params[:courseId].to_s
     course_name = params[:courseName].to_s
 
-    query_clever_service(api_version: AuthenticationOption::Clever::VERSION[:v3], endpoint: "sections/#{course_id}/users?role=student") do |students|
+    query_clever_service("sections/#{course_id}/users?role=student") do |students|
       section = CleverSection.from_service(course_id, current_user.id, students, course_name)
       render json: section.summarize
     end
@@ -688,9 +682,9 @@ class ApiController < ApplicationController
     )
   end
 
-  private def query_clever_service(api_version:, endpoint:)
+  private def query_clever_service(endpoint)
     tokens = current_user.oauth_tokens_for_provider(AuthenticationOption::CLEVER)
-    clever_client = Clients::CleverRest.new(oauth_token: tokens[:oauth_token], api_version:)
+    clever_client = Clients::CleverRest.new(oauth_token: tokens[:oauth_token])
     begin
       yield clever_client.get(endpoint)['data']
     rescue RestClient::ExceptionWithResponse => exception
@@ -699,21 +693,6 @@ class ApiController < ApplicationController
       else
         render status: exception.response.code, json: {error: exception.response.body}
       end
-    end
-  end
-
-  # The sections endpoint path varies between Clever API versions.
-  # v3 wants users/:uid/sections with the new role-agnostic Clever ID
-  # instead of the old teachers endpoint that used the now-deprecated teacher ID.
-  # TODO: Remove this method when we drop support for Clever API v2.1
-  private def clever_sections_url_path(api_version:, uid:)
-    case api_version
-    when AuthenticationOption::Clever::VERSION[:v2]
-      "teachers/#{uid}/sections"
-    when AuthenticationOption::Clever::VERSION[:v3]
-      "users/#{uid}/sections"
-    else
-      raise "Unsupported Clever API version: #{api_version}"
     end
   end
 

--- a/dashboard/app/models/authentication_option.rb
+++ b/dashboard/app/models/authentication_option.rb
@@ -87,7 +87,6 @@ class AuthenticationOption < ApplicationRecord
   module Clever
     VERSION = {
       v3: 'v3',
-      v2: 'v2',
     }.freeze
   end
 

--- a/dashboard/lib/clients/clever_rest.rb
+++ b/dashboard/lib/clients/clever_rest.rb
@@ -5,7 +5,7 @@ class Clients::CleverRest
 
   attr_reader :oauth_token, :api_version
 
-  def initialize(oauth_token:, api_version: AuthenticationOption::Clever::VERSION[:v2])
+  def initialize(oauth_token:, api_version: AuthenticationOption::Clever::VERSION[:v3])
     @oauth_token = oauth_token
     @api_version = api_version
   end
@@ -26,8 +26,6 @@ class Clients::CleverRest
 
   private def version_path
     case api_version
-    when AuthenticationOption::Clever::VERSION[:v2]
-      'v2.1'
     when AuthenticationOption::Clever::VERSION[:v3]
       'v3.0'
     else

--- a/dashboard/lib/user_multi_auth_helper.rb
+++ b/dashboard/lib/user_multi_auth_helper.rb
@@ -24,11 +24,23 @@ module UserMultiAuthHelper
     end
   end
 
-  def uid_for_provider(provider)
+  # Returns the authentication_id (uid) for the given provider.
+  # If a version is provided, returns the authentication_id for the latest
+  # authentication option matching that version. Otherwise, simply returns the uid
+  # from the most recently created authentication option for the provider.
+  # If no matching authentication option is found, returns nil.
+  # Backwards compatible with pre-multi-auth users by returning the user's uid property.
+  def uid_for_provider(provider, version = nil)
     if migrated?
-      authentication_options.find_by(
-        credential_type: provider
-      )&.authentication_id
+      auth_options = authentication_options.where(credential_type: provider).order(created_at: :desc)
+      authentication_option =
+        if version.nil?
+          auth_options.first
+        else
+          auth_options.find {|ao| ao.version == version}
+        end
+
+      authentication_option&.authentication_id
     else
       uid
     end

--- a/dashboard/lib/user_multi_auth_helper.rb
+++ b/dashboard/lib/user_multi_auth_helper.rb
@@ -3,12 +3,13 @@ require 'cdo/honeybadger'
 module UserMultiAuthHelper
   def oauth_tokens_for_provider(provider)
     if migrated?
-      # Grab the most recently updated authentication option with the
-      # given credential type
+      # Grab the most recently created authentication option with the
+      # given credential type. This ensures we pull the newest token for
+      # providers with multiple versions of authentication options (e.g. Clever v2 and v3).
       authentication_option = AuthenticationOption.where(
         credential_type: provider,
         user_id: id
-      ).order(updated_at: :desc).first
+      ).order(created_at: :desc).first
       authentication_option_data = authentication_option&.data_hash || {}
       {
         oauth_token: authentication_option_data[:oauth_token],

--- a/dashboard/test/controllers/api_controller_test.rb
+++ b/dashboard/test/controllers/api_controller_test.rb
@@ -1680,30 +1680,6 @@ class ApiControllerTest < ActionController::TestCase
     assert_response :forbidden
   end
 
-  test 'clever_classrooms queries clever with user uid for unmigrated user' do
-    teacher = create(:teacher, :sso_provider, :demigrated, provider: AuthenticationOption::CLEVER)
-    sign_in teacher
-
-    expected_uri = "https://api.clever.com/v2.1/teachers/#{teacher.uid}/sections"
-    auth = {authorization: "Bearer #{teacher.oauth_token}"}
-    mock_response = {data: []}.to_json
-    RestClient.expects(:get).with(expected_uri, auth).returns(mock_response)
-    get :clever_classrooms
-  end
-
-  test 'clever_classrooms queries clever with clever authentication_id for migrated user' do
-    teacher = create(:teacher, :with_clever_authentication_option)
-    auth_option = teacher.authentication_options.find_by(credential_type: AuthenticationOption::CLEVER)
-    sign_in teacher
-    assert_nil teacher.uid
-
-    expected_uri = "https://api.clever.com/v2.1/teachers/#{auth_option.authentication_id}/sections"
-    auth = {authorization: "Bearer #{auth_option.data_hash[:oauth_token]}"}
-    mock_response = {data: []}.to_json
-    RestClient.expects(:get).with(expected_uri, auth).returns(mock_response)
-    get :clever_classrooms
-  end
-
   test 'google_classrooms is Forbidden when not signed in' do
     sign_out :user
     get :google_classrooms
@@ -2127,33 +2103,12 @@ class ApiControllerTest < ActionController::TestCase
       sign_in teacher
     end
 
-    context 'when v2.1 auth option' do
-      it 'creates REST client for v2.1' do
-        clever_client = mock('clever_client')
-        Clients::CleverRest.expects(:new).with(oauth_token:, api_version: AuthenticationOption::Clever::VERSION[:v2]).returns(clever_client)
-        clever_client.stubs(:get).returns({'data' => []})
-
-        get_clever_classrooms
-        assert_response :ok
-      end
-
-      it 'calls /teachers/:id/sections endpoint' do
-        clever_client = mock('clever_client')
-        expected_uid = teacher.uid_for_provider(AuthenticationOption::CLEVER)
-        Clients::CleverRest.expects(:new).with(oauth_token:, api_version: AuthenticationOption::Clever::VERSION[:v2]).returns(clever_client)
-        clever_client.expects(:get).with("teachers/#{expected_uid}/sections").returns({'data' => []})
-
-        get_clever_classrooms
-        assert_response :ok
-      end
-    end
-
     context 'when v3 auth option' do
       let(:teacher) {create(:teacher, :with_clever_authentication_option, auth_option_version: AuthenticationOption::Clever::VERSION[:v3])}
 
       it 'creates REST client for v3' do
         clever_client = mock('clever_client')
-        Clients::CleverRest.expects(:new).with(oauth_token:, api_version: AuthenticationOption::Clever::VERSION[:v3]).returns(clever_client)
+        Clients::CleverRest.expects(:new).with(oauth_token:).returns(clever_client)
         clever_client.stubs(:get).returns({'data' => []})
 
         get_clever_classrooms
@@ -2163,7 +2118,7 @@ class ApiControllerTest < ActionController::TestCase
       it 'calls /users/:id/sections endpoint' do
         clever_client = mock('clever_client')
         expected_uid = clever_auth_option.authentication_id
-        Clients::CleverRest.expects(:new).with(oauth_token:, api_version: AuthenticationOption::Clever::VERSION[:v3]).returns(clever_client)
+        Clients::CleverRest.expects(:new).with(oauth_token:).returns(clever_client)
         clever_client.expects(:get).with("users/#{expected_uid}/sections").returns({'data' => []})
 
         get_clever_classrooms

--- a/dashboard/test/lib/clients/clever_rest_test.rb
+++ b/dashboard/test/lib/clients/clever_rest_test.rb
@@ -11,12 +11,12 @@ class Clients::CleverRestTest < ActiveSupport::TestCase
 
     let(:endpoint) {'expected/endpoint'}
 
-    it 'returns parsed JSON response from Clever v2.1 API endpoint' do
+    it 'returns parsed JSON response from Clever v3.0 API endpoint' do
       expected_response = 'expected_response'
 
       RestClient.
         expects(:get).
-        with("https://api.clever.com/v2.1/#{endpoint}", {authorization: "Bearer #{oauth_token}"}).
+        with("https://api.clever.com/v3.0/#{endpoint}", {authorization: "Bearer #{oauth_token}"}).
         returns(expected_response.to_json)
 
       _get_request.must_equal expected_response

--- a/dashboard/test/lib/user_multi_auth_helper_test.rb
+++ b/dashboard/test/lib/user_multi_auth_helper_test.rb
@@ -17,7 +17,7 @@ class UserMultiAuthHelperTest < ActiveSupport::TestCase
     assert_nil garbage_token
   end
 
-  test 'oauth_tokens_for_provider returns most recently updated tokens for migrated teacher' do
+  test 'oauth_tokens_for_provider returns most recently created tokens for migrated teacher' do
     Timecop.freeze do
       user = create(:teacher)
       create(:authentication_option,

--- a/dashboard/test/lib/user_multi_auth_helper_test.rb
+++ b/dashboard/test/lib/user_multi_auth_helper_test.rb
@@ -73,6 +73,96 @@ class UserMultiAuthHelperTest < ActiveSupport::TestCase
     assert_equal 'fake-oauth-token', clever_token
   end
 
+  describe '#uid_for_provider' do
+    let(:user) {create(:teacher)}
+    let(:provider) {AuthenticationOption::CLEVER}
+    let(:version) {nil}
+    let(:v3) {AuthenticationOption::Clever::VERSION[:v3]}
+    subject(:uid_for_provider) {user.uid_for_provider(provider, version)}
+
+    context 'when version is nil' do
+      it 'returns the latest authentication option for the provider' do
+        Timecop.freeze do
+          create(:authentication_option,
+            user: user,
+            credential_type: provider,
+            authentication_id: 'legacy-id',
+            version: nil
+          )
+
+          Timecop.travel(1.minute) do
+            create(:authentication_option,
+              user: user,
+              credential_type: provider,
+              authentication_id: 'new-id',
+              version: v3
+            )
+          end
+        end
+
+        _(uid_for_provider).must_equal 'new-id'
+      end
+    end
+
+    context 'when a version is provided' do
+      context 'when matching authentication options exist' do
+        let(:version) {v3}
+
+        it 'returns the latest authentication option for that version' do
+          # Note: this is a rare edge case but could happen, since users can have multiple
+          # Clever auth options with different authentication_ids.
+          Timecop.freeze do
+            create(:authentication_option,
+              user: user,
+              credential_type: provider,
+              authentication_id: 'legacy-id',
+              version: nil
+            )
+            Timecop.travel(1.minute) do
+              create(:authentication_option,
+                user: user,
+                credential_type: provider,
+                authentication_id: 'newer-v3-id',
+                version: v3
+              )
+            end
+            Timecop.travel(2.minutes) do
+              create(:authentication_option,
+                user: user,
+                credential_type: provider,
+                authentication_id: 'newest-v3-id',
+                version: v3
+              )
+            end
+          end
+
+          _(uid_for_provider).must_equal 'newest-v3-id'
+        end
+      end
+
+      context 'when no matching authentication options exist' do
+        let(:version) {'invalid-version'}
+
+        it 'returns nil' do
+          create(:authentication_option,
+            user: user,
+            credential_type: provider,
+            authentication_id: 'default-version-id',
+            version: nil
+          )
+          create(:authentication_option,
+            user: user,
+            credential_type: provider,
+            authentication_id: 'v3-id',
+            version: v3
+          )
+
+          _(uid_for_provider).must_be_nil
+        end
+      end
+    end
+  end
+
   test 'does nothing if user is already migrated' do
     user = create(:teacher)
     assert user.migrated?


### PR DESCRIPTION
Removes the logic to call Clever v2.1 APIs for users with v2 auth options. Now that users have been backfilled with v3 auth options, we can reliably call v3 APIs across the board.

Logic from https://github.com/code-dot-org/code-dot-org/pull/71042 will guard against any issues if pre-v3 users from districts not included in the Clever migration CSVs attempt to log in. They will end up with v3 auth options before they are able to access the rostering functionality that calls v3 APIs.


## Links
[JIRA](https://codedotorg.atlassian.net/browse/P20-1661)

## Testing story
<!--  Does your change include appropriate tests?
      - If so, please describe how the tests included in this PR are sufficient.
      - If not, please explain why this change does not need to be tested. -->



## Deployment strategy
<!--  Any special steps required to deploy this, besides merging?
      - Are there database migrations or manual steps?
      - Does this require coordination with other teams or systems? -->



## Follow-up work
<!--  List any clean-up or technical debt that will be addressed in future work.
      - Include Jira links where applicable.
      - Are there any known limitations or improvements planned? -->



## Privacy
<!--  How does this change impact Student & Teacher privacy?
      - Does this collect, use, share, or modify PII, either new or existing? -->



## Security
<!--  How does this change impact our security surface-area?
      - Do API's touched have the right auth?
      - Do infra changes impact our attack surface or encryption?
-->



## Caching
<!--  How does this change impact caching behavior?
      - Are cache keys or invalidation strategies affected?
      - Will this require cache warming or invalidation after deployment? -->



## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
