### PR TITLE
AI Chat: remove modelDescriptions.json from LFS

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -38,6 +38,7 @@ shared/images/** filter=lfs diff=lfs merge=lfs -text
 # EXCLUDE these files from our Git LFS dirs:
 apps/i18n/**/en_us.json !text !filter !merge !diff
 apps/i18n/tts_keys/** !text !filter !merge !diff
+apps/static/aichat/modelDescriptions.json !text !filter !merge !diff
 dashboard/app/assets/javascripts/** !text !filter !merge !diff
 dashboard/app/assets/stylesheets/** !text !filter !merge !diff
 dashboard/config/locales/**/*en.yml !text !filter !merge !diff

--- a/apps/static/aichat/modelDescriptions.json
+++ b/apps/static/aichat/modelDescriptions.json
@@ -1,3 +1,36 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:dc041dfd646103a1cdaf4777f804148b0532eeca58853fbc8d1295147e4581b9
-size 1196
+[
+  {
+    "id": "gen-ai-mistral-7b-inst-v01",
+    "name": "Mistral 7B Instruct v01",
+    "overview": "A generative language model pre-trained with 7 billion parameters, designed for following instructions.",
+    "trainingData": "The MistralAI team trained Mistral-7B-v0.1 on datasets taken directly from the openWeb. The v0.1 model took the base model and finetuned it using additional data from several sources, focusing on improving logic and reasoning or recalling trivia or other facts."
+  },
+  {
+    "id": "gpt-4o-mini",
+    "name": "GPT-4o mini",
+    "overview": "...",
+    "trainingData": "...",
+    "multimodal": true
+  },
+  {
+    "id": "gemini-2.5-flash-lite",
+    "name": "[EXPERIMENTAL, LEVELBUILDER USE ONLY] Gemini 2.5 Flash-Lite",
+    "overview": "...",
+    "trainingData": "...",
+    "multimodal": true
+  },
+  {
+    "id": "gemini-2.5-flash",
+    "name": "[EXPERIMENTAL, LEVELBUILDER USE ONLY] Gemini 2.5 Flash",
+    "overview": "...",
+    "trainingData": "...",
+    "multimodal": true
+  },
+  {
+    "id": "gemini-3-pro-preview",
+    "name": "[EXPERIMENTAL, LEVELBUILDER USE ONLY] Gemini 3 Pro Preview",
+    "overview": "...",
+    "trainingData": "...",
+    "multimodal": true
+  }
+]


### PR DESCRIPTION
Quick change to remove the model descriptions JSON from LFS, since we reference it pretty heavily in code and so it's easier to see diffs. We recently removed fine-tuned model references [here](https://github.com/code-dot-org/code-dot-org/pull/70964) and will be soon adding at least one more model ID [here](https://github.com/code-dot-org/code-dot-org/pull/70728).

## Testing story
No functional changes. Tested AI Chat still works as expected.