### PR TITLE
Revert "Hot Module Replacement: don't write to disk"

### DIFF
--- a/apps/Gruntfile.js
+++ b/apps/Gruntfile.js
@@ -404,7 +404,6 @@ module.exports = function (grunt) {
       options: {force: true},
       src: ['build/karma'],
     },
-    package: ['build/package'],
   };
 
   const piskelDevMode = PISKEL_DEVELOPMENT_MODE;
@@ -617,13 +616,7 @@ module.exports = function (grunt) {
     // Unless explicitly overridden, set HOT=1 and DEV=1 when running `grunt dev`
     process.env.HOT ||= 1;
     process.env.DEV ||= 1;
-    grunt.task.run([
-      'clean:package',
-      'prebuild',
-      'newer:sass',
-      'concurrent:watch',
-      'postbuild',
-    ]);
+    grunt.task.run(['prebuild', 'newer:sass', 'concurrent:watch', 'postbuild']);
   });
 
   grunt.registerTask('default', ['rebuild', 'test']);

--- a/apps/webpack.config.js
+++ b/apps/webpack.config.js
@@ -816,6 +816,9 @@ function createWebpackConfig({
           host: '0.0.0.0',
           hot: envConstants.HOT,
           liveReload: envConstants.HOT,
+          devMiddleware: {
+            writeToDisk: true,
+          },
         }
       : undefined,
   };


### PR DESCRIPTION
In #60076, which we're reverting, we tried not writing webpack devserver files to disk, both because its not a typical configuration, because its slow, and because it slowly builds up zillions of little `hot-update` files that don't get automatically cleaned.

We ran into a few issues:
1. A number of people were still using port 3000, and Rails could of course no longer access the built files since they were in devserver memory. If we do a future attempt at keeping the files in memory, a pre-project is to get everyone happily on port 9000 / hmr first.
2. We ran into 404 errors on local dev `/blockly/*` urls:
- `http://localhost-studio.code.org:9000/blockly/media/trash.png`
-  `http://localhost-studio.code.org:9000/blockly/js/pyodide/0.28.3/python_stdlib.zip`

Reverts code-dot-org/code-dot-org#60076