### PR TITLE
Set ai_chat_access_level for sections in eyes tests

### DIFF
--- a/dashboard/app/controllers/api/v1/sections_controller.rb
+++ b/dashboard/app/controllers/api/v1/sections_controller.rb
@@ -112,7 +112,7 @@ class Api::V1::SectionsController < Api::V1::JSONApiController
 
     # If assigning a new course, derive the new ai_chat_access_level, otherwise leave it as-is.
     is_updating_course = @course && @course.id != section.course_id
-    ai_chat_access_level = is_updating_course ? AichatAccessHelper.get_ai_chat_access_level(@course, section.ai_chat_access_level) : params[:ai_chat_access_level]
+    ai_chat_access_level = is_updating_course ? AichatAccessHelper.compute_ai_chat_access_level(@course, section.ai_chat_access_level) : params[:ai_chat_access_level]
 
     # TODO: (madelynkasula) refactor to use strong params
     fields = {}

--- a/dashboard/app/controllers/api/v1/sections_controller.rb
+++ b/dashboard/app/controllers/api/v1/sections_controller.rb
@@ -70,7 +70,7 @@ class Api::V1::SectionsController < Api::V1::JSONApiController
         restrict_section: params[:restrict_section].nil? ? false : params[:restrict_section],
         avatar_color: params[:avatar_color].nil? ? 0 : params[:avatar_color],
         avatar_emoji: params[:avatar_emoji].nil? ? 0 : params[:avatar_emoji],
-        ai_chat_access_level: get_ai_chat_access_level,
+        ai_chat_access_level: AichatAccessHelper.compute_ai_chat_access_level(@course),
       }
     )
     return head :bad_request unless section.persisted?
@@ -112,7 +112,7 @@ class Api::V1::SectionsController < Api::V1::JSONApiController
 
     # If assigning a new course, derive the new ai_chat_access_level, otherwise leave it as-is.
     is_updating_course = @course && @course.id != section.course_id
-    ai_chat_access_level = is_updating_course ? get_ai_chat_access_level(section.ai_chat_access_level) : params[:ai_chat_access_level]
+    ai_chat_access_level = is_updating_course ? AichatAccessHelper.get_ai_chat_access_level(@course, section.ai_chat_access_level) : params[:ai_chat_access_level]
 
     # TODO: (madelynkasula) refactor to use strong params
     fields = {}
@@ -349,17 +349,5 @@ class Api::V1::SectionsController < Api::V1::JSONApiController
       # Should not get a unit_id unless also get a course version which is course
       return head :bad_request if params[:unit_id]
     end
-  end
-
-  private def get_ai_chat_access_level(previous_access_level = nil)
-    previous_access_level ||= SharedConstants::AI_CHAT_ACCESS_LEVELS[:DISABLED]
-
-    # Leave it as is if it was already turned on or to essential_only
-    return previous_access_level if previous_access_level != SharedConstants::AI_CHAT_ACCESS_LEVELS[:DISABLED]
-
-    # Auto-enable access if the course needs it.
-    return SharedConstants::AI_CHAT_ACCESS_LEVELS[:ENABLED] if @course&.has_ai_chat_tools?
-
-    SharedConstants::AI_CHAT_ACCESS_LEVELS[:DISABLED]
   end
 end

--- a/dashboard/app/controllers/test_controller.rb
+++ b/dashboard/app/controllers/test_controller.rb
@@ -79,8 +79,14 @@ class TestController < ApplicationController
     raise "Unit not found for course #{unit_group.name} at position #{unit_position}" unless unit_group_unit
     unit = unit_group_unit.script
 
-    ai_chat_access_level = params[:ai_chat_access_level] || Section::AI_CHAT_ACCESS_LEVELS[:DISABLED]
-    section = Section.create!(name: "New Section", user: user, script: unit, unit_group: unit_group, participant_type: Curriculum::SharedCourseConstants::PARTICIPANT_AUDIENCE.student, ai_chat_access_level: ai_chat_access_level)
+    ai_chat_access_level = AichatAccessHelper.compute_ai_chat_access_level(unit_group)
+    section = Section.create!(name: "New Section",
+                              user: user,
+                              script: unit,
+                              unit_group: unit_group,
+                              participant_type: Curriculum::SharedCourseConstants::PARTICIPANT_AUDIENCE.student,
+                              ai_chat_access_level: ai_chat_access_level
+)
 
     render json: {section_code: section.code}
   end

--- a/dashboard/app/helpers/aichat_access_helper.rb
+++ b/dashboard/app/helpers/aichat_access_helper.rb
@@ -1,0 +1,16 @@
+module AichatAccessHelper
+  # Determines the ai_chat_access_level to use when creating or updating a section.
+  # If the section already has a non-disabled access level, it is preserved.
+  # Otherwise, access is auto-enabled if the course has AI chat tools.
+  def self.compute_ai_chat_access_level(assigned_course, previous_access_level = nil)
+    previous_access_level ||= SharedConstants::AI_CHAT_ACCESS_LEVELS[:DISABLED]
+
+    # Leave it as is if it was already turned on or to essential_only
+    return previous_access_level if previous_access_level != SharedConstants::AI_CHAT_ACCESS_LEVELS[:DISABLED]
+
+    # Auto-enable access if the course needs it.
+    return SharedConstants::AI_CHAT_ACCESS_LEVELS[:ENABLED] if assigned_course&.has_ai_chat_tools?
+
+    SharedConstants::AI_CHAT_ACCESS_LEVELS[:DISABLED]
+  end
+end


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

A few teacher dashboard eyes tests are showing error UI for a test section with allthethings course not having `ai_chat_access_level` enabled. This is because we're creating the section / assigning the course via the `test_controller` rather than the `sections_controller` which would auto-enable access.

It's not technically wrong since this error UI is by design in this state, but it could be confusing for people looking at eyes tests because in production, the teacher should never be able to get themselves into this state when creating a section / assigning stuff without explicitly turning off access.

This change moves the logic to compute the access level into a helper and uses it in the test_controller to set the value on the section when assigning.


## Testing story
<!--  Does your change include appropriate tests?
      - If so, please describe how the tests included in this PR are sufficient.
      - If not, please explain why this change does not need to be tested. -->

I don't think [test eyes] actually worked? because this should give us eyes failures when it goes in. But all other tests pass.