### PR TITLE
Update New Project Buttons

### DIFF
--- a/apps/i18n/common/en_us.json
+++ b/apps/i18n/common/en_us.json
@@ -2438,6 +2438,7 @@
   "projectTypePlaylab": "Play Lab",
   "projectTypePlaylabPreReader": "Play Lab (Pre-reader)",
   "projectTypePoetry": "Poetry",
+  "projectTypePoetryHoc": "Poem Art",
   "projectTypePythonlab": "Python Lab",
   "projectTypeScience": "Science",
   "projectTypeStarwars": "Star Wars",

--- a/apps/src/templates/projects/NewProjectButtons.jsx
+++ b/apps/src/templates/projects/NewProjectButtons.jsx
@@ -4,7 +4,7 @@ import React from 'react';
 import {connect} from 'react-redux';
 
 import fontConstants from '@cdo/apps/fontConstants';
-import {studio, pegasus} from '@cdo/apps/lib/util/urlHelpers';
+import {pegasus, studio} from '@cdo/apps/lib/util/urlHelpers';
 import i18n from '@cdo/locale';
 
 import styleConstants from '../../styleConstants';
@@ -21,31 +21,23 @@ const PROJECT_INFO = {
   },
   artist: {
     label: i18n.projectTypeArtist(),
-    thumbnail: studio('/shared/images/courses/logo_artist.png'),
+    thumbnail: studio('/shared/images/courses/artist-icon.png'),
   },
   artist_k1: {
     label: i18n.projectTypeArtistPreReader(),
-    thumbnail: studio('/shared/images/courses/logo_artist.png'),
+    thumbnail: studio('/shared/images/courses/artist-icon.png'),
   },
   applab: {
     label: i18n.projectTypeApplab(),
-    thumbnail: studio('/shared/images/courses/logo_applab_square.png'),
+    thumbnail: studio('/shared/images/courses/app-lab-icon.png'),
   },
   gamelab: {
     label: i18n.projectTypeGamelab(),
-    thumbnail: studio('/shared/images/courses/logo_gamelab_square.png'),
+    thumbnail: studio('/shared/images/courses/game-lab-icon.png'),
   },
   weblab: {
     label: i18n.projectTypeWeblab(),
     thumbnail: studio('/shared/images/courses/logo_weblab.png'),
-  },
-  calc: {
-    label: i18n.projectTypeCalc(),
-    thumbnail: studio('/shared/images/courses/logo_calc.png'),
-  },
-  eval: {
-    label: i18n.projectTypeEval(),
-    thumbnail: studio('/shared/images/courses/logo_eval.png'),
   },
   frozen: {
     label: i18n.projectTypeFrozen(),
@@ -107,28 +99,36 @@ const PROJECT_INFO = {
   },
   spritelab: {
     label: i18n.projectTypeSpriteLab(),
-    thumbnail: studio('/shared/images/courses/logo_spritelab.png'),
+    thumbnail: studio('/shared/images/courses/sprite-lab-icon.png'),
+  },
+  game_design: {
+    label: i18n.projectTypeGameDesign(),
+    thumbnail: studio('/shared/images/courses/game-design-icon.png'),
   },
   dance: {
     label: i18n.projectTypeDance(),
-    thumbnail: studio('/shared/images/courses/logo_dance.png'),
+    thumbnail: studio('/shared/images/courses/dance-party-icon.png'),
   },
   poetry: {
     label: i18n.projectTypePoetry(),
     thumbnail: studio('/shared/images/courses/logo_poetry.png'),
   },
+  poetry_hoc: {
+    label: i18n.projectTypePoetryHoc(),
+    thumbnail: studio('/shared/images/courses/logo_poetry.png'),
+  },
   music: {
     label: i18n.projectTypeMusic(),
-    thumbnail: studio('/shared/images/courses/logo_music.png'),
+    thumbnail: studio('/shared/images/courses/music-lab-icon.png'),
     urlOverride: pegasus('/music'),
   },
   pythonlab: {
     label: i18n.projectTypePythonlab(),
-    thumbnail: studio('/shared/images/courses/logo_pythonlab.png'),
+    thumbnail: studio('/shared/images/courses/python-lab-icon.png'),
   },
   music_dance_ai: {
     label: 'Mix & Move with AI',
-    thumbnail: studio('/shared/images/courses/header-music-dance-ai-icon.png'),
+    thumbnail: studio('/shared/images/courses/music-dance-ai-icon.png'),
     urlOverride: pegasus('/mix-move-ai'),
   },
 };

--- a/apps/src/templates/projects/StartNewProject.jsx
+++ b/apps/src/templates/projects/StartNewProject.jsx
@@ -22,9 +22,10 @@ const DEFAULT_PROJECT_TYPES_BASIC = ['spritelab', 'artist', 'dance', 'playlab'];
 const OPEN_ENDED_PROJECT_TYPES = [
   'music_dance_ai',
   'music',
-  'dance',
   'spritelab',
-  'poetry',
+  'game_design',
+  'dance',
+  'poetry_hoc',
 ];
 
 const DRAWING_PROJECT_TYPES = ['artist', 'frozen'];
@@ -49,9 +50,9 @@ const PLAYLAB_PROJECT_TYPES = ['playlab', 'infinity', 'gumball', 'iceage'];
 const ADVANCED_PROJECT_TYPES = [
   'applab',
   'gamelab',
+  'pythonlab',
   'weblab',
   'starwars',
-  'pythonlab',
 ];
 
 const PREREADER_PROJECT_TYPES = ['playlab_k1', 'artist_k1'];

--- a/apps/src/templates/projects/projectConstants.ts
+++ b/apps/src/templates/projects/projectConstants.ts
@@ -82,7 +82,7 @@ export const PROJECT_DEFAULT_CARD_IMAGE_OVERRIDE: {
 export const PROJECT_DEFAULT_THUMBNAIL_IMAGE_OVERRIDE: {
   [projectType: string]: string;
 } = {
-  music: studio('/shared/images/courses/logo_music.png'),
-  pythonlab: studio('/shared/images/courses/logo_pythonlab.png'),
+  music: studio('/shared/images/courses/music-lab-icon.png'),
+  pythonlab: studio('/shared/images/courses/python-lab-icon.png'),
   music_dance_ai: studio('/blockly/media/dance/mix-move-ai-banner-square.png'),
 };

--- a/dashboard/config/locales/base/en.yml
+++ b/dashboard/config/locales/base/en.yml
@@ -482,6 +482,7 @@ en:
       flappy: 'Flappy'
       frozen: 'Frozen'
       gamelab: 'Game Lab'
+      game_design: 'Sprite Lab (Game Design)'
       gamelab_jr: 'Game Lab (beta)'
       gumball: 'The Amazing World of Gumball'
       iceage: 'Ice Age'

--- a/lib/cdo/create_header.rb
+++ b/lib/cdo/create_header.rb
@@ -17,36 +17,45 @@ class CreateHeader
       image: "logo_minecraft_aquatic_square.jpg"
     },
     spritelab: {
-      image: "header-sprite-lab-icon.png"
+      image: "sprite-lab-icon.png"
+    },
+    game_design: {
+      image: "game-design-icon.png"
     },
     artist: {
-      image: "header-artist-icon.png"
+      image: "artist-icon.png"
     },
     applab: {
-      image: "header-app-lab-icon.png"
+      image: "app-lab-icon.png"
     },
     gamelab: {
-      image: "header-game-lab-icon.png"
+      image: "game-lab-icon.png"
     },
     playlab_k1: {
       image: "logo_playlab.png"
     },
     artist_k1: {
-      image: "header-artist-icon.png"
+      image: "artist-icon.png"
     },
     poetry_hoc: {
       image: "logo_poetry.png"
     },
     music: {
-      image: "header-music-lab-icon.png",
+      image: "music-lab-icon.png",
       url: CDO.code_org_url("/music")
     },
     dance: {
-      image: "header-dance-party-icon.png"
+      image: "dance-party-icon.png"
     },
     music_dance_ai: {
-      image: "header-music-dance-ai-icon.png",
+      image: "music-dance-ai-icon.png",
       url: CDO.code_org_url("/mix-move-ai")
+    },
+    javalab: {
+      image: "java-lab-icon.png"
+    },
+    pythonlab: {
+      image: "python-lab-icon.png"
     },
   }.freeze
 

--- a/shared/images/courses/app-lab-icon.png
+++ b/shared/images/courses/app-lab-icon.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c278bf138aa5a06b6c3d53a0274bf48baad75a49616aff35a6082e65e7659c6e
+size 8252

--- a/shared/images/courses/artist-icon.png
+++ b/shared/images/courses/artist-icon.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5193dce164b4d44c26b653982911fa7d01efeedc4b4fc1fd8a82bda8d726fefe
+size 7046

--- a/shared/images/courses/dance-party-icon.png
+++ b/shared/images/courses/dance-party-icon.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a32f85968e8757627268ad3cd64373902683babe4583a03514c4fc21be56e556
+size 9534

--- a/shared/images/courses/game-design-icon.png
+++ b/shared/images/courses/game-design-icon.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:63906a80de017ba706aca1204cef9e27e101399953ac9c94477a7fd3314cd647
+size 36115

--- a/shared/images/courses/game-lab-icon.png
+++ b/shared/images/courses/game-lab-icon.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ea943debcc264643e699eb1651041636db7152e069f6b91f9b008b6c02ee950d
+size 5057

--- a/shared/images/courses/java-lab-icon.png
+++ b/shared/images/courses/java-lab-icon.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:77cf7b95da128b26a331d0836e17b2e12373aba628994446b5931c34add4793d
+size 36882

--- a/shared/images/courses/music-dance-ai-icon.png
+++ b/shared/images/courses/music-dance-ai-icon.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cd59b71adb33744a9471073c03fd755222584794b4ff6773e05c352aae3947cd
+size 20853

--- a/shared/images/courses/music-lab-icon.png
+++ b/shared/images/courses/music-lab-icon.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:87cfcf274ea670519cddc339a47cdd747cdab70c0c026f77aaf531aacba286cd
+size 8077

--- a/shared/images/courses/python-lab-icon.png
+++ b/shared/images/courses/python-lab-icon.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4b4e92f04552ba5a2d4dd7e5f7e6c43dbfe952a3eb266ba3b408a99f0f7d9e63
+size 28775

--- a/shared/images/courses/sprite-lab-icon.png
+++ b/shared/images/courses/sprite-lab-icon.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9ad891f2b138f4a7ed831940c341778eca8655578ad8a86c18b5006f34c2cd22
+size 6505


### PR DESCRIPTION
Slack Discussion for this work: https://codedotorg.slack.com/archives/C03DBDN67B7/p1771883912293599

This updates a subset of our new project buttons with the following goals:
- Add a new project button for the Game Design sub-type of Sprite Lab
- Unify header menu icons with project gallery icons when possible
- Project page options are supported types in a logical order

This task originated from ZenDesk, where a teacher [requested](https://codeorg.zendesk.com/agent/tickets/577796) we add Game Design blocks to core Sprite Lab. The team decided instead to make the Game Design version of the lab available on the projects page. To do this, we needed a new icon, which was provided by @moshebaricdo.

While in this space, I took the opportunity to make sure we were using the most updated icons that we have available, and to make sure we were using them consistently between the site header's Create menu and the projects page. New images are added with this branch that do have a prefix like `header-` or `logo_` as they're intended to be used in both places.
A couple other tweaks were made based on judgement calls:
- The Poetry (full module, unsupported) project type has been replaced by the Poem Art (HoC, supported) project type. This change was long overdue.
- The "Open-Ended Creativity" section was re-ordered, grouping the two Sprite Lab options and moving HoC-only project types (Dance/Poem Art) to the second line.
- The "Beyond Blocks" section was updated to promote Python Lab in the first row with other 6-12 project types. The Droplet version of Star Wars was moved to the second row.
- Removes definitions for buttons for deprecated CS in Algebra labs (Calc and Eval)

<img width="902" height="747" alt="image" src="https://github.com/user-attachments/assets/b027e30b-245a-4716-a4cc-8213e4737076" />
<img width="897" height="397" alt="image" src="https://github.com/user-attachments/assets/8988bc88-0d9d-49c1-96ae-6380fd53538c" />

This work does not change the default contents of the header menu. For context, we show a pre-determined subset of project types in this menu. If we have a label and image, we also show the user's current project type at the top of the list.

|Game Design|Java Lab|Web Lab 2|
|-|-|-|
|<img width="319" height="538" alt="image" src="https://github.com/user-attachments/assets/8bd921e8-3292-4862-9fc9-9c2824ecb7bb" />|<img width="317" height="541" alt="image" src="https://github.com/user-attachments/assets/4c871372-fdd4-4397-b1ab-22696b64200d" />|<img width="318" height="483" alt="image" src="https://github.com/user-attachments/assets/3059bdfb-afb0-4f63-b93e-89135c58ab06" />|

This work also allows us to delete a good handful of images; some net-new, and some effectively renames. I opted to save that for a follow-up branch, here: https://github.com/code-dot-org/code-dot-org/pull/71068 This will make it easier to revert just the deletions in the event there's an unforeseen consequence.

## Links
Slack: https://codedotorg.slack.com/archives/C03DBDN67B7/p1771883912293599



## Follow-up work
<!--  List any clean-up or technical debt that will be addressed in future work.
      - Include Jira links where applicable.
      - Are there any known limitations or improvements planned? -->
- Remove now-unused images.
- The Design team is tracking work to standardize the visual style of the other remaining project icons.



## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
