### PR TITLE
Add extra links for levelbuilders and admins to teacher dashboard

### DIFF
--- a/dashboard/app/views/home/_levelbuilder.html.haml
+++ b/dashboard/app/views/home/_levelbuilder.html.haml
@@ -1,16 +1,17 @@
 - if current_user && current_user.levelbuilder?
   = render layout: 'shared/extra_links' do
-    %li= link_to 'Videos', videos_path
-    %li= link_to 'Images', '/images/new'
-    %li
-      = link_to 'Scripts', scripts_path
-      = link_to '(Update all)', scripts_path(rake: '1'), data: { confirm: 'Are you sure want to re-seed script data?'}
-    %li= link_to 'Courses', all_courses_path
-    %li= link_to t('builder.manage'), levels_path
-    %li= link_to 'Block Pools', pools_path
-    %li= link_to 'Shared Functions', shared_blockly_functions_path
-    %li= link_to 'Helper Libraries', libraries_path
-    %li= link_to 'Gallery', 'projects/public'
-    %li= link_to 'Foorm Surveys (preview)', 'foorm/forms/editor'
-    %li= link_to '(BETA) Sprite Lab Sprite Management', 'sprites'
-    %li= link_to 'Helpful Links', helpful_links_path
+    %ul
+      %li= link_to 'Videos', videos_path
+      %li= link_to 'Images', '/images/new'
+      %li
+        = link_to 'Scripts', scripts_path
+        = link_to '(Update all)', scripts_path(rake: '1'), data: { confirm: 'Are you sure want to re-seed script data?'}
+      %li= link_to 'Courses', all_courses_path
+      %li= link_to t('builder.manage'), levels_path
+      %li= link_to 'Block Pools', pools_path
+      %li= link_to 'Shared Functions', shared_blockly_functions_path
+      %li= link_to 'Helper Libraries', libraries_path
+      %li= link_to 'Gallery', 'projects/public'
+      %li= link_to 'Foorm Surveys (preview)', 'foorm/forms/editor'
+      %li= link_to '(BETA) Sprite Lab Sprite Management', 'sprites'
+      %li= link_to 'Helpful Links', helpful_links_path

--- a/dashboard/app/views/teacher_dashboard/show.html.haml
+++ b/dashboard/app/views/teacher_dashboard/show.html.haml
@@ -33,3 +33,6 @@
     %div#ai-differentiation-fab-mount-point
 
 #teacher-dashboard
+
+= render partial: 'home/admin'
+= render partial: 'home/levelbuilder'


### PR DESCRIPTION
Adds the "Extra Links" that used to be visible to levelbuilders and admins on the homepage to the teacher dashboard, which is the de-facto homepage now. Also tidies the levelbuilder menu to render the bullets correctly.

<img width="3360" height="1878" alt="image" src="https://github.com/user-attachments/assets/6cbfedb1-ccec-4f5c-9454-516ac707171b" />

<img width="3360" height="1876" alt="image" src="https://github.com/user-attachments/assets/e5f9c882-a980-4b4a-8663-9c55c08a20b5" />

## Links

- Slack discussion: https://codedotorg.slack.com/archives/C046G4TRLEN/p1772065726951539