### PR TITLE
feat(core): integrate `core` into `apps`

### DIFF
--- a/apps/package.json
+++ b/apps/package.json
@@ -204,6 +204,7 @@
     "@code-dot-org/artist": "0.2.1",
     "@code-dot-org/component-library": "portal:../frontend/packages/component-library/",
     "@code-dot-org/component-library-styles": "portal:../frontend/packages/component-library-styles/",
+    "@code-dot-org/core": "portal:../frontend/packages/core/",
     "@code-dot-org/craft": "0.2.2",
     "@code-dot-org/dance-party": "2.0.4",
     "@code-dot-org/fonts": "portal:../frontend/packages/fonts/",

--- a/apps/script/build-frontend-dependencies.sh
+++ b/apps/script/build-frontend-dependencies.sh
@@ -4,9 +4,10 @@
 # At present, the following dependencies are consumed:
 # 1. **@code-dot-org/component-library**: Component Library
 # 2. **@code-dot-org/fonts**: Fonts
+# 3. **@code-dot-org/core**: Core utilities and components
 
 set -x
 
 cd ../frontend && \
   yarn && \
-  yarn run build --filter @code-dot-org/component-library --filter @code-dot-org/fonts --output-logs errors-only
+  yarn run build --filter @code-dot-org/component-library --filter @code-dot-org/fonts --filter @code-dot-org/core --output-logs errors-only

--- a/apps/yarn.lock
+++ b/apps/yarn.lock
@@ -3913,6 +3913,16 @@ __metadata:
   languageName: node
   linkType: soft
 
+"@code-dot-org/core@portal:../frontend/packages/core/::locator=blockly-mooc%40workspace%3A.":
+  version: 0.0.0-use.local
+  resolution: "@code-dot-org/core@portal:../frontend/packages/core/::locator=blockly-mooc%40workspace%3A."
+  dependencies:
+    tldts: "npm:^7.0.23"
+  peerDependencies:
+    react: ^17.0.0 || ^18.0.0 || ^19.0.0
+  languageName: node
+  linkType: soft
+
 "@code-dot-org/craft@npm:0.2.2":
   version: 0.2.2
   resolution: "@code-dot-org/craft@npm:0.2.2"
@@ -11263,6 +11273,7 @@ __metadata:
     "@code-dot-org/artist": "npm:0.2.1"
     "@code-dot-org/component-library": "portal:../frontend/packages/component-library/"
     "@code-dot-org/component-library-styles": "portal:../frontend/packages/component-library-styles/"
+    "@code-dot-org/core": "portal:../frontend/packages/core/"
     "@code-dot-org/craft": "npm:0.2.2"
     "@code-dot-org/dance-party": "npm:2.0.4"
     "@code-dot-org/fonts": "portal:../frontend/packages/fonts/"
@@ -29720,6 +29731,13 @@ canvg@gabelerner/canvg:
   languageName: node
   linkType: hard
 
+"tldts-core@npm:^7.0.23":
+  version: 7.0.23
+  resolution: "tldts-core@npm:7.0.23"
+  checksum: 10/e6e19d6cab67defd93c7f7e8d63eb2dd90a3ef45ab15087d9fa1aa2ddedc1430709146dff0535f9672aa36b874843e6b540417280059960e0b88bbbb8c932e68
+  languageName: node
+  linkType: hard
+
 "tldts@npm:^6.1.32":
   version: 6.1.85
   resolution: "tldts@npm:6.1.85"
@@ -29728,6 +29746,17 @@ canvg@gabelerner/canvg:
   bin:
     tldts: bin/cli.js
   checksum: 10/f3270f24ed57efcbb34364e827dc1cace9b5b95a2668051e69e21ad75df49466cfeaef47e7e9b56541ef633eff1e083a43b006b6306a9d2d24e5c36a038cb400
+  languageName: node
+  linkType: hard
+
+"tldts@npm:^7.0.23":
+  version: 7.0.23
+  resolution: "tldts@npm:7.0.23"
+  dependencies:
+    tldts-core: "npm:^7.0.23"
+  bin:
+    tldts: bin/cli.js
+  checksum: 10/752da855c98fc5dd9601e9ec0090b80d5ac83f2b31027756f0acc79e05dc280539b3aa3583da73559ce8d4bcc328ebab84c4c7600a3e44dfc7cda099cc96fcb0
   languageName: node
   linkType: hard
 

--- a/frontend/packages/core/package.json
+++ b/frontend/packages/core/package.json
@@ -21,7 +21,7 @@
     ".": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.mjs",
-      "require": "./dist/index.js"
+      "require": "./dist/index.cjs"
     }
   },
   "scripts": {
@@ -36,7 +36,7 @@
   },
   "prettier": "@code-dot-org/lint-config/prettier/index.mjs",
   "dependencies": {
-    "tldjs": "^2.3.2"
+    "tldts": "^7.0.23"
   },
   "devDependencies": {
     "@code-dot-org/lint-config": "workspace:*",

--- a/frontend/packages/core/src/brand/__tests__/getBrandFromHostname.test.ts
+++ b/frontend/packages/core/src/brand/__tests__/getBrandFromHostname.test.ts
@@ -1,19 +1,19 @@
 import {getBrandFromHostname} from '../getBrandFromHostname';
-import tldjs from 'tldjs';
+import tldts from 'tldts';
 
 describe('getBrandFromHostname', () => {
   it('should return the correct brand for code.org', () => {
-    const parsedHostname = tldjs.parse('code.org');
+    const parsedHostname = tldts.parse('code.org');
     expect(getBrandFromHostname(parsedHostname)).toBe('code.org');
   });
 
   it('should return the correct brand for aiday.org', () => {
-    const parsedHostname = tldjs.parse('aiday.org');
+    const parsedHostname = tldts.parse('aiday.org');
     expect(getBrandFromHostname(parsedHostname)).toBe('aiday');
   });
 
   it('should default to code.org for unknown domains', () => {
-    const parsedHostname = tldjs.parse('unknown.org');
+    const parsedHostname = tldts.parse('unknown.org');
     expect(getBrandFromHostname(parsedHostname)).toBe('code.org');
   });
 });

--- a/frontend/packages/core/src/brand/getBrandFromHostname.ts
+++ b/frontend/packages/core/src/brand/getBrandFromHostname.ts
@@ -1,4 +1,4 @@
-import type {parse} from 'tldjs';
+import type {parse} from 'tldts';
 import type {Brand} from './brand';
 
 export function getBrandFromHostname(

--- a/frontend/packages/core/src/config/SiteConfig.ts
+++ b/frontend/packages/core/src/config/SiteConfig.ts
@@ -2,7 +2,7 @@ import type {Brand} from '../brand/brand';
 import {getBrandFromHostname} from '../brand/getBrandFromHostname';
 import {getDashboardApiUrl} from '../dashboard/getDashboardApiUrl';
 import {getEnvironmentFromHostname, type Environment} from '../environment';
-import tldjs from 'tldjs';
+import {parse} from 'tldts';
 
 declare global {
   interface Window {
@@ -11,13 +11,13 @@ declare global {
 }
 
 export class SiteConfig {
-  public readonly host: ReturnType<typeof tldjs.parse>;
+  public readonly host: ReturnType<typeof parse>;
   public readonly brand: Brand;
   public readonly environment: Environment;
   public readonly dashboardApiUrl: string;
 
   constructor() {
-    this.host = tldjs.parse(window.location.hostname);
+    this.host = parse(window.location.hostname);
     this.brand = getBrandFromHostname(this.host);
     this.environment = getEnvironmentFromHostname();
     this.dashboardApiUrl = getDashboardApiUrl(this.environment);

--- a/frontend/packages/core/src/dashboard/getDashboardApiUrl.ts
+++ b/frontend/packages/core/src/dashboard/getDashboardApiUrl.ts
@@ -2,6 +2,8 @@ import type {Environment} from '../environment';
 
 export function getDashboardApiUrl(environment: Environment): string {
   switch (environment) {
+    case 'adhoc':
+      return window.location.origin;
     case 'development':
       return 'http://localhost-studio.code.org:3000';
     case 'staging':

--- a/frontend/packages/core/src/environment/getEnvironmentFromHostname.ts
+++ b/frontend/packages/core/src/environment/getEnvironmentFromHostname.ts
@@ -1,5 +1,5 @@
 import type {Environment} from './environment';
-import {parse} from 'tldjs';
+import {parse} from 'tldts';
 
 /**
  * Get the current environment.

--- a/frontend/packages/core/vite.config.ts
+++ b/frontend/packages/core/vite.config.ts
@@ -13,7 +13,7 @@ function getRollupOutputConfig(format: 'es' | 'cjs'): OutputOptions {
   return {
     format,
     exports: 'auto',
-    entryFileNames: format === 'es' ? '[name].mjs' : '[name].js',
+    entryFileNames: format === 'es' ? '[name].mjs' : '[name].cjs',
     preserveModules: true,
     preserveModulesRoot: 'src',
   };

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -1343,7 +1343,7 @@ __metadata:
     eslint-plugin-react-refresh: "npm:^0.4.24"
     prettier: "npm:3.4.2"
     react: "npm:^19.2.0"
-    tldjs: "npm:^2.3.2"
+    tldts: "npm:^7.0.23"
     typescript: "npm:~5.9.3"
     vite: "npm:^7.2.4"
     vite-plugin-dts: "npm:^4.5.4"
@@ -17284,7 +17284,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"punycode@npm:^2.0.0, punycode@npm:^2.1.0, punycode@npm:^2.1.1, punycode@npm:^2.3.1":
+"punycode@npm:^2.1.0, punycode@npm:^2.1.1, punycode@npm:^2.3.1":
   version: 2.3.1
   resolution: "punycode@npm:2.3.1"
   checksum: 10c0/14f76a8206bc3464f794fb2e3d3cc665ae416c01893ad7a02b23766eb07159144ee612ad67af5e84fa4479ccfe67678c4feb126b0485651b302babf66f04f9e9
@@ -19653,12 +19653,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tldjs@npm:^2.3.2":
-  version: 2.3.2
-  resolution: "tldjs@npm:2.3.2"
+"tldts-core@npm:^7.0.23":
+  version: 7.0.23
+  resolution: "tldts-core@npm:7.0.23"
+  checksum: 10c0/b3d936a75b5f65614c356a58ef37563681c6224187dcce9f57aac76d92aae83b1a6fe6ab910f77472b35456bc145a8441cb3e572b4850be43cb4f3465e0610ec
+  languageName: node
+  linkType: hard
+
+"tldts@npm:^7.0.23":
+  version: 7.0.23
+  resolution: "tldts@npm:7.0.23"
   dependencies:
-    punycode: "npm:^2.0.0"
-  checksum: 10c0/2f77a376e2f0fb6e4ff2d1b92b89bb6078ede87a9170c18132e121421f5b9e19f6b98bef1f7e8c256111cf03a7426720580a1b7f50cb4a46de47b24a6d2d5644
+    tldts-core: "npm:^7.0.23"
+  bin:
+    tldts: bin/cli.js
+  checksum: 10c0/492874770afaade724a10f8a97cce511d74bed07735c7f1100b7957254d7a5bbbc18becaf5cd049f9d7b0feeb945a64af64d5a300dfb851a4ac57cf3a5998afc
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This PR adds `@code-dot-org/core` into `apps` to begin to modularize core foundations of the frontend. This adds the ability for site detection and configuration to be detected based on browser environment and local context. Due to `apps` requiring commonjs and core using a dual-publish model, this PR also fixes the incorrect usage of `.js` when the package `type: 'module'` which erroneously marked those as ESM files. This was corrected by renaming the extension to `.cjs` to be explicit about CommonJS formatting on those files.

This PR also converts `tldjs` to `tldts` which is the more modern version of the same library. `tldjs` used node specific libraries which made it incompatible in our webpack bundled version (necessitating the use of polyfills which I'd like to avoid)