### PR TITLE
Web Lab 2: start mode fixes

### DIFF
--- a/apps/src/lab2/redux/lab2ReduxSelectors.ts
+++ b/apps/src/lab2/redux/lab2ReduxSelectors.ts
@@ -51,6 +51,14 @@ export const isReadOnlyWorkspace = (state: RootState) => {
   // Start with the permanently read-only check.
   const isPermanentlyReadOnly = isPermanentlyReadOnlyWorkspace(state);
 
+  const isEditMode = !!getAppOptionsEditBlocks();
+  const isEditingExemplar = getAppOptionsEditingExemplar();
+
+  // Edit modes should always be editable.
+  if (isEditMode || isEditingExemplar) {
+    return false;
+  }
+
   const hasSubmitted = getCurrentLevel(state)?.status === LevelStatus.submitted;
   const isViewingOldVersion = state.lab2Project.viewingOldVersion;
   const isAiTutorVersion = state.lab2Project.viewingAiTutorVersion;

--- a/apps/src/lab2/views/LabViewsRenderer.tsx
+++ b/apps/src/lab2/views/LabViewsRenderer.tsx
@@ -13,7 +13,10 @@ import {PERMISSIONS} from '@cdo/apps/lab2/constants';
 import {useInitialLabTheme} from '@cdo/apps/lab2/hooks/useInitialLabTheme';
 import lab2I18n from '@cdo/apps/lab2/locale';
 import ProgressContainer from '@cdo/apps/lab2/progress/ProgressContainer';
-import {getAppOptionsViewingExemplar} from '@cdo/apps/lab2/projects/utils';
+import {
+  getAppOptionsViewingExemplar,
+  getIsStartMode,
+} from '@cdo/apps/lab2/projects/utils';
 import {getLabViewPageAction, getIsLabViewBlocked} from '@cdo/apps/lab2/utils';
 import analyticsReporter from '@cdo/apps/metrics/AnalyticsReporter';
 import useRequiredContext from '@cdo/apps/util/hooks/useRequiredContext';
@@ -93,7 +96,11 @@ const LabViewsRenderer: React.FunctionComponent = () => {
         chatDisabled: true,
         chatDisabledMessage: TEACHER_DISABLED_AI_CHAT_MESSAGE,
       });
-    } else if (isPredictLevel && !hasSubmittedPredictResponse) {
+    } else if (
+      isPredictLevel &&
+      !hasSubmittedPredictResponse &&
+      !getIsStartMode()
+    ) {
       setChatDisabledState({
         chatDisabled: true,
         chatDisabledMessage: lab2I18n.predictTutorDisabledMessage(),

--- a/apps/src/weblab2/htmlPreview/HTMLPreview.tsx
+++ b/apps/src/weblab2/htmlPreview/HTMLPreview.tsx
@@ -137,7 +137,8 @@ export const HTMLPreview: React.FC = () => {
   const hasSubmittedPredictResponse = useAppSelector(
     isPredictResponseSubmitted
   );
-  const allowUserScripts = !isPredictLevel || hasSubmittedPredictResponse;
+  const allowUserScripts =
+    !isPredictLevel || hasSubmittedPredictResponse || isStartMode;
   const canNavigateBack = navigationHistoryIndex > 0;
   const canNavigateForward =
     navigationHistoryIndex < navigationHistory.length - 1;

--- a/apps/src/weblab2/layout/VerticalLayout.tsx
+++ b/apps/src/weblab2/layout/VerticalLayout.tsx
@@ -11,6 +11,7 @@ import {useResizable} from 'react-resizable-layout';
 
 import AiTutorVersionAlert from '@cdo/apps/aiComponentLibrary/aiTutorVersionAlert/AiTutorVersionAlert';
 import {useVerticalLayout} from '@cdo/apps/lab2/hooks/useVerticalLayout';
+import {getIsStartMode} from '@cdo/apps/lab2/projects/utils';
 import {logOnResize} from '@cdo/apps/lab2/utils/resizeUtils';
 import ResizeBar from '@cdo/apps/lab2/views/components/layout/ResizeBar';
 import PanelContainer from '@cdo/apps/lab2/views/components/PanelContainer';
@@ -43,6 +44,7 @@ const VerticalLayout: React.FunctionComponent<LayoutProps> = ({
   isWidgetView,
 }) => {
   const viewMode = useAppSelector(state => state.weblab2.viewMode);
+  const hideWorkspaceForWidgetView = !getIsStartMode() && isWidgetView;
   const isStandaloneCollapsed = useAppSelector(
     state => state.lab2View.isStandaloneCollapsed
   );
@@ -60,14 +62,14 @@ const VerticalLayout: React.FunctionComponent<LayoutProps> = ({
 
   const infoPanelInitialWidth = isStandaloneCollapsed
     ? INITIAL_INFO_PANEL_WIDTH_COLLAPSED
-    : isWidgetView
+    : hideWorkspaceForWidgetView
     ? INITIAL_INFO_PANEL_WIDTH_WIDGET
     : INITIAL_INFO_PANEL_WIDTH;
 
-  const editorMinWidth = isWidgetView ? 0 : MIN_EDITOR_WIDTH;
+  const editorMinWidth = hideWorkspaceForWidgetView ? 0 : MIN_EDITOR_WIDTH;
   const previewInitialWidth = isStandaloneCollapsed
     ? INITIAL_PREVIEW_WIDTH_COLLAPSED
-    : isWidgetView
+    : hideWorkspaceForWidgetView
     ? INITIAL_PREVIEW_WIDTH_WIDGET
     : INITIAL_PREVIEW_WIDTH;
 
@@ -156,21 +158,21 @@ const VerticalLayout: React.FunctionComponent<LayoutProps> = ({
     setRightPanelSize(
       isStandaloneCollapsed
         ? INITIAL_PREVIEW_WIDTH_COLLAPSED
-        : isWidgetView
+        : hideWorkspaceForWidgetView
         ? INITIAL_PREVIEW_WIDTH_WIDGET
         : INITIAL_PREVIEW_WIDTH
     );
-  }, [setRightPanelSize, isWidgetView, isStandaloneCollapsed]);
+  }, [setRightPanelSize, hideWorkspaceForWidgetView, isStandaloneCollapsed]);
 
   useEffect(() => {
     setLeftPanelSize(
       isStandaloneCollapsed
         ? INITIAL_INFO_PANEL_WIDTH_COLLAPSED
-        : isWidgetView
+        : hideWorkspaceForWidgetView
         ? INITIAL_INFO_PANEL_WIDTH_WIDGET
         : INITIAL_INFO_PANEL_WIDTH
     );
-  }, [setLeftPanelSize, isWidgetView, isStandaloneCollapsed]);
+  }, [setLeftPanelSize, hideWorkspaceForWidgetView, isStandaloneCollapsed]);
 
   const showDebugPanel =
     experiments.isEnabledAllowingQueryString(experiments.WEBLAB2_DEBUG_PANEL) &&
@@ -200,7 +202,7 @@ const VerticalLayout: React.FunctionComponent<LayoutProps> = ({
             className={weblab2Styles.headerContainer}
             headerContent={<WorkspaceHeader />}
             leftHeaderContent={
-              isWidgetView ? undefined : (
+              hideWorkspaceForWidgetView ? undefined : (
                 <SegmentedButtons {...viewModeButtonsProps} />
               )
             }
@@ -216,7 +218,7 @@ const VerticalLayout: React.FunctionComponent<LayoutProps> = ({
                 isAiTutorVersion && weblab2Styles.aiTutorVersionContainer
               )}
             >
-              {!isWidgetView && viewMode !== ViewMode.PREVIEW && (
+              {!hideWorkspaceForWidgetView && viewMode !== ViewMode.PREVIEW && (
                 <>
                   <Workspace
                     style={{width: middlePanelWidth}}


### PR DESCRIPTION
This fixes a couple places in start mode where we were being too aggressive with keeping read-only state.
- In predict levels scripts are disabled in the preview and editing was disabled until a prediction was submitted
- In predict levels AI tutor was turned off
- In widget mode we hide the workspace

Now in start mode for predict levels and on widget mode levels you can access, edit, use AI tutor and preview without limitations.

## Screen recordings
### Predict

https://github.com/user-attachments/assets/65fd5aa5-5077-48b2-9970-8826eef3a502


### Widget

https://github.com/user-attachments/assets/b52e5c9a-6ab9-493c-bc29-8919d58ed3b4


## Links

- Jira: [AFL-502](https://codedotorg.atlassian.net/browse/AFL-502)

## Testing story
Tested locally.



## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
