### PR TITLE
Trim Pull Request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,70 +1,27 @@
 <!--
-  A summary of the change, including any relevant background, motivation, and context.
-  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
+  Summary of the change: background, motivation, and context.
+  Include screenshots, videos, or before/after comparisons for UI changes.
 -->
 
 
 
 ## Links
-<!--  Links to relevant external resources.
-      - spec docs, Jira tickets, related PRs, Honeybadger errors, etc.
--->
+<!-- Jira tickets, design docs, Slack threads, related PRs, etc. -->
 
-- Jira: 
+- Jira:
 
 ## Testing story
-<!--  Does your change include appropriate tests?
-      - If so, please describe how the tests included in this PR are sufficient.
-      - If not, please explain why this change does not need to be tested. -->
+<!-- How was this tested? Manual steps, adhoc links, automated tests, or why testing isn't needed. -->
 
 
 
-## Deployment strategy
-<!--  Any special steps required to deploy this, besides merging?
-      - Are there database migrations or manual steps?
-      - Does this require coordination with other teams or systems? -->
+## Deployment notes
+<!-- Delete this section if it's a standard merge-and-deploy.
+     Otherwise: migrations, feature flags, coordination, caching impacts, etc. -->
 
 
 
-## Follow-up work
-<!--  List any clean-up or technical debt that will be addressed in future work.
-      - Include Jira links where applicable.
-      - Are there any known limitations or improvements planned? -->
+## Privacy and security
+<!-- Delete this section if there is no privacy/security impact.
+     Otherwise: new PII, auth changes, API surface changes, etc. -->
 
-
-
-## Privacy
-<!--  How does this change impact Student & Teacher privacy?
-      - Does this collect, use, share, or modify PII, either new or existing? -->
-
-
-
-## Security
-<!--  How does this change impact our security surface-area?
-      - Do API's touched have the right auth?
-      - Do infra changes impact our attack surface or encryption?
--->
-
-
-
-## Caching
-<!--  How does this change impact caching behavior?
-      - Are cache keys or invalidation strategies affected?
-      - Will this require cache warming or invalidation after deployment? -->
-
-
-
-## PR Creation Checklist:
-<!--
-  The final step! Before you create your PR, double-check that everything is in order.
-  Change [ ] to [X] during creation to check boxes.
--->
-
-- [ ] Tests provide adequate coverage
-- [ ] Privacy impacts have been documented
-- [ ] Security impacts have been documented
-- [ ] Code is well-commented
-- [ ] New features are translatable or updates will not break translations
-- [ ] Relevant documentation has been added or updated
-- [ ] User impact is well-understood and desirable
-- [ ] Follow-up work items (including potential tech debt) are tracked and linked


### PR DESCRIPTION
<!--
  Summary of the change: background, motivation, and context.
  Include screenshots, videos, or before/after comparisons for UI changes.
-->

This updates our Pull Request template to be much more concise, based on analysis of actual use.


I used Claude Code to analyze all **542 merged pull requests** by human authors in 2026 (excluding deploy-code-org and dependabot). Details on how I used Claude Code to perform the analysis are below, but first the key findings.

### Finding 1: The checklist isn't used

The template ends with an 8-item "PR Creation Checklist" asking authors to confirm things like test coverage, privacy documentation, and security review. In practice:

- **235 PRs (43.4%)** kept the checklist but left every single box unchecked
- **304 PRs (56.1%)** deleted the checklist entirely
- **0 PRs** partially checked some boxes
- **3 PRs (0.6%)** checked all 8 boxes

Nobody engages with it. It's either ignored wholesale or deleted.

### Finding 2: Most sections go unfilled

Even when authors keep the full template, the section fill rates tell a clear story:

| Section | Fill rate | 
|---|---|
| Description | ~100% |
| Links / Jira | 36% |
| Testing story | 31% |
| Follow-up work | 8% |
| Deployment strategy | 4% |
| Security | ~1% |
| Privacy | ~1% |
| Caching | ~1% |

Privacy, Security, and Caching are each filled in roughly 1% of PRs — about 4-5 times total across 542 PRs. They exist as empty HTML comment stubs in hundreds of merged PRs.

### Finding 3: Over half of authors abandon the template

304 PRs (56%) don't contain the template checklist at all. Within that group:

- **~177** wrote completely freeform descriptions with no template sections
- **~74** kept just 1-2 sections (usually Links + Testing story) and deleted the rest
- **~53** appear to have used an older version of the template

The authors who go freeform often write excellent PRs — with inline before/after screenshots, manual test checklists, and clear narratives. The template isn't helping them; they're working around it.

### Finding 4: Authors are adding things the template doesn't ask for

- **35% of PRs include screenshots or before/after comparisons** — more common than filling in the Testing story section, yet the template has no dedicated space for visuals
- **14% link to Slack threads** for context and discussion
- **4% link to Figma designs**
- Authors commonly add adhoc environment URLs, experiment/DCDO flag details, and manual verification checklists — all improvised outside the template structure

### The bottom line

The template is 71 lines long with 8 sections and an 8-item checklist. In practice, authors use 2-3 sections (Description, Links, Testing story), ignore or delete everything else, and frequently add content the template doesn't account for. The checklist has a 99.4% non-engagement rate. The template's length and rigidity appears to train authors to skip it entirely rather than engage with the parts that matter.

## Links
<!-- Jira tickets, design docs, Slack threads, related PRs, etc. -->

- Jira: n/a

## Testing story
<!-- How was this tested? Manual steps, adhoc links, automated tests, or why testing isn't needed. -->
n/a


## Deployment notes
<!-- Delete this section if it's a standard merge-and-deploy.
     Otherwise: migrations, feature flags, coordination, caching impacts, etc. -->
This is just the `.github/pull_request_template`, once merged to staging, all new PR's will use it.

## Privacy and security
<!-- Delete this section if there is no privacy/security impact.
     Otherwise: new PII, auth changes, API surface changes, etc. -->
This PR removes some security checkboxes, but keeps the Privacy & Security prompt in the template, this is an important consideration that we don't want to lose.

---


## How I used AI to audit our PR template

### The question

Our PR template includes an 8-item checklist and 7 sections. How are people using it? How are they using it? What should we change? I started focusing on the checklist, then expanded to the entire list.

### What Claude Opus 4.6 in Claude Code did

**Data collection.** Claude used the GitHub GraphQL API to fetch the author and full description of all 798 merged pull requests to code-dot-org/code-dot-org in 2026. Each PR was saved as an individual markdown file in a `pull_requests/` folder for traceability. After excluding automated authors (deploy-code-org, dependabot), we had 542 human-authored PRs to analyze.

**Checklist analysis.** Claude wrote a Python script that parsed every PR body, detected the presence of the template's "PR Creation Checklist" by matching against the known checklist item text, and classified each PR into four buckets: no checklist present, all boxes unchecked, some boxes checked, or all boxes checked.

**Section usage analysis.** Claude read a broad sample of PRs across both groups (those with the template and those without) and measured how often each template section — Links, Testing story, Deployment strategy, Follow-up work, Privacy, Security, Caching — was actually filled in with real content versus left as an empty HTML comment stub.

**Pattern discovery.** Beyond what the template asks for, Claude identified what authors were *adding on their own* that the template didn't account for: screenshots and before/after comparisons (35% of PRs), Slack thread links (14%), Figma links (4%), adhoc environment URLs, and manual verification checklists improvised inside the Testing story section.

**Template redesign.** Based on the data, Claude drafted a new template that cuts 71 lines down to 27 — keeping the three sections people actually use (Description, Links, Testing story), combining three near-zero-usage sections (Privacy, Security, Caching) into one optional section, folding Deployment strategy into a "Deployment notes" section marked as deletable, removing the checklist entirely, and updating the prompt text to explicitly invite the content authors were already adding on their own (screenshots, Slack threads, adhoc links).
