### PR TITLE
Web Lab 2: include local service worker setup in console

### DIFF
--- a/apps/src/weblab2/htmlPreview/useProjectServiceWorker.ts
+++ b/apps/src/weblab2/htmlPreview/useProjectServiceWorker.ts
@@ -66,9 +66,18 @@ function useProjectServiceWorker(
     ) {
       console.error(
         `
-        Unable to use service workers in your development environment. The easiest way to access this functionality locally by using Chrome, then navigating to: chrome://flags/#unsafely-treat-insecure-origin-as-secure.
-        Once you're there, set the value to the following: http://localhost-studio.code.org:9000,http://localhost-studio.code.org:3000,http://localtesting.preview.localhost.codeprojects.org:9000,http://localtesting.preview.localhost.codeprojects.org:3000
-        More information is available in the README in apps/src/weblab2 directory.
+Unable to use service workers in your development environment.
+
+The easiest way to access this functionality locally by using Chrome, then navigating to:
+chrome://flags/#unsafely-treat-insecure-origin-as-secure
+
+Once you're there, set the value to the following (copy all four lines):
+http://localhost-studio.code.org:9000,
+http://localhost-studio.code.org:3000,
+http://localtesting.preview.localhost.codeprojects.org:9000,
+http://localtesting.preview.localhost.codeprojects.org:3000
+
+More information is available in the README in apps/src/weblab2 directory.
         `
       );
       setServiceWorkerUnavailable(true);

--- a/apps/src/weblab2/htmlPreview/useProjectServiceWorker.ts
+++ b/apps/src/weblab2/htmlPreview/useProjectServiceWorker.ts
@@ -60,6 +60,18 @@ function useProjectServiceWorker(
           serviceWorkerRegistration = registration;
           setServiceWorkerRegistration(registration);
         });
+    } else if (
+      window.location.hostname ===
+      'localtesting.preview.localhost.codeprojects.org'
+    ) {
+      console.error(
+        `
+        Unable to use service workers in your development environment. The easiest way to access this functionality locally by using Chrome, then navigating to: chrome://flags/#unsafely-treat-insecure-origin-as-secure.
+        Once you're there, set the value to the following: http://localhost-studio.code.org:9000,http://localhost-studio.code.org:3000,http://localtesting.preview.localhost.codeprojects.org:9000,http://localtesting.preview.localhost.codeprojects.org:3000
+        More information is available in the README in apps/src/weblab2 directory.
+        `
+      );
+      setServiceWorkerUnavailable(true);
     } else {
       console.error('Service workers are not supported in this browser.');
       setServiceWorkerUnavailable(true);


### PR DESCRIPTION
Inspired by [Elijah's helpful error messages for when secrets are removed](https://codedotorg.slack.com/archives/C0T0PNTGD/p1772221714620419), this adds the local development setup instructions for Web Lab 2 to the error message you see if you haven't set them previously.

<img width="1680" height="584" alt="image" src="https://github.com/user-attachments/assets/6ef70f25-5a04-4fbd-baba-5e0e0802477d" />

## Testing story

Tested manually that I saw this error message when I didn't have the flag set, and did not once I set it.