### PR TITLE
fix after_save callback in enrollments

### DIFF
--- a/dashboard/app/models/pd/enrollment.rb
+++ b/dashboard/app/models/pd/enrollment.rb
@@ -63,7 +63,7 @@ class Pd::Enrollment < ApplicationRecord
   before_validation :autoupdate_user_field
   before_save :set_application_id
   after_create :set_default_scholarship_info
-  after_save :authorize_teacher_account
+  after_save :authorize_teacher_account, unless: :deleted?
 
   serialized_attrs %w(
     role
@@ -296,7 +296,7 @@ class Pd::Enrollment < ApplicationRecord
   end
 
   protected def authorize_teacher_account
-    user.permission = UserPermission::AUTHORIZED_TEACHER if user&.teacher? && [COURSE_CSD, COURSE_CSP, COURSE_CSA, COURSE_BUILD_YOUR_OWN].include?(workshop.course)
+    user.permission = UserPermission::AUTHORIZED_TEACHER if user&.teacher? && [COURSE_CSD, COURSE_CSP, COURSE_CSA, COURSE_BUILD_YOUR_OWN].include?(workshop&.course)
   end
 
   # Returns true if the given workshop is an Admin or Admin/Counselor workshop


### PR DESCRIPTION
The PII scrubber can error out trying to scrub user PD enrollments for a couple of reasons:
- An `after_save` callback for enrollments runs `authorize_teacher_account`. This is intended to verify teachers if they do a PD course. When the enrollment is scrubbed of PII, it is already in a soft-deleted state, and may or may not have a `course` property, causing a nil pointer error. Since the callback is not intended to run when the record is destroyed, this PR adds an `unless deleted?` condition.
- Course is optional for enrollments, so an `&` operator is added in case this method is ever run on a non-deleted enrollment where the course is missing.



## Links
[JIRA](https://codedotorg.atlassian.net/browse/P20-1807)

## Testing story
<!--  Does your change include appropriate tests?
      - If so, please describe how the tests included in this PR are sufficient.
      - If not, please explain why this change does not need to be tested. -->



## Deployment strategy
<!--  Any special steps required to deploy this, besides merging?
      - Are there database migrations or manual steps?
      - Does this require coordination with other teams or systems? -->



## Follow-up work
<!--  List any clean-up or technical debt that will be addressed in future work.
      - Include Jira links where applicable.
      - Are there any known limitations or improvements planned? -->



## Privacy
<!--  How does this change impact Student & Teacher privacy?
      - Does this collect, use, share, or modify PII, either new or existing? -->



## Security
<!--  How does this change impact our security surface-area?
      - Do API's touched have the right auth?
      - Do infra changes impact our attack surface or encryption?
-->



## Caching
<!--  How does this change impact caching behavior?
      - Are cache keys or invalidation strategies affected?
      - Will this require cache warming or invalidation after deployment? -->



## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
