### PR TITLE
Web Lab 2: Widget2 header

### DIFF
--- a/apps/src/weblab2/htmlPreview/HTMLPreview.tsx
+++ b/apps/src/weblab2/htmlPreview/HTMLPreview.tsx
@@ -471,22 +471,24 @@ export const HTMLPreview: React.FC = () => {
           isFullScreenView && moduleStyles.fullScreenPreviewContainer
         )}
       >
-        <HTMLPreviewHeader
-          value={inputValue}
-          onChange={setInputValue}
-          onSubmit={handleUrlSubmit}
-          canNavigateBack={canNavigateBack}
-          canNavigateForward={canNavigateForward}
-          onNavigateBack={onNavigateBack}
-          onNavigateForward={onNavigateForward}
-          onRefresh={onRefresh}
-          onToggleFullScreen={toggleFullScreen}
-          previewViewMode={previewViewMode}
-          setPreviewViewMode={setPreviewViewMode}
-          onStopPreview={onStopPreview}
-          isStopEnabled={!isStopped}
-          fetchFileSearchOptions={fetchHtmlFileOptions}
-        />
+        {!widget2 && (
+          <HTMLPreviewHeader
+            value={inputValue}
+            onChange={setInputValue}
+            onSubmit={handleUrlSubmit}
+            canNavigateBack={canNavigateBack}
+            canNavigateForward={canNavigateForward}
+            onNavigateBack={onNavigateBack}
+            onNavigateForward={onNavigateForward}
+            onRefresh={onRefresh}
+            onToggleFullScreen={toggleFullScreen}
+            previewViewMode={previewViewMode}
+            setPreviewViewMode={setPreviewViewMode}
+            onStopPreview={onStopPreview}
+            isStopEnabled={!isStopped}
+            fetchFileSearchOptions={fetchHtmlFileOptions}
+          />
+        )}
         {isEmptyProject ? (
           <PreviewEmptyState />
         ) : isStopped ? (


### PR DESCRIPTION
This tiny follow-up to #70917 hides the preview header when viewing a widget2 level. 

### before

<img width="1105" height="522" alt="Screenshot 2026-02-28 at 1 13 49 PM" src="https://github.com/user-attachments/assets/784ea574-b824-4ffc-880c-92ad7bc7cefc" />

### after

<img width="1105" height="522" alt="Screenshot 2026-02-28 at 1 12 54 PM" src="https://github.com/user-attachments/assets/a28192ba-865b-4353-bcdd-dcc88219dd04" />
