### PR TITLE
AI Tutor: close AI Tutor on legacy labs by default

### DIFF
--- a/apps/src/templates/instructions/InstructionsWithWorkspace.jsx
+++ b/apps/src/templates/instructions/InstructionsWithWorkspace.jsx
@@ -13,7 +13,6 @@ import {AI_TUTOR_LEGACY_LABS} from '@cdo/apps/aiTutor/views/legacyLabs/constants
 
 import {AiTutorContainer} from '../../aiTutor/views/legacyLabs/AiTutorContainer';
 import {setInstructionsMaxHeightAvailable} from '../../redux/instructions';
-import experiments from '../../util/experiments';
 import CodeWorkspaceContainer from '../CodeWorkspaceContainer';
 
 import TopInstructions from './TopInstructions';
@@ -35,15 +34,14 @@ export class UnwrappedInstructionsWithWorkspace extends React.Component {
     instructionsHeight: PropTypes.number.isRequired,
     setInstructionsMaxHeightAvailable: PropTypes.func.isRequired,
     labType: PropTypes.string,
-    aiTutorEnabledForPilot: PropTypes.bool,
     aiChatAccessLevel: PropTypes.string,
   };
 
-  // only used so that we can rerender when resized
   state = {
+    aiChatOpen: false,
+    // only used so that we can rerender when resized
     windowWidth: undefined,
     windowHeight: undefined,
-    aiChatOpen: true,
   };
 
   setCodeWorkspaceContainerRef = element => {
@@ -118,7 +116,6 @@ export class UnwrappedInstructionsWithWorkspace extends React.Component {
       workspaceStyle,
       instructionsHeight,
       labType,
-      aiTutorEnabledForPilot,
       aiChatAccessLevel,
       children,
     } = this.props;
@@ -133,13 +130,11 @@ export class UnwrappedInstructionsWithWorkspace extends React.Component {
 
     const showAiTutor =
       AI_TUTOR_LEGACY_LABS.includes(labType) &&
-      (experiments.isEnabled(experiments.LEGACY_LAB_AI_TUTOR) ||
-        shouldShowAiTutor({
-          appName: labType,
-          tutorPilot: aiTutorEnabledForPilot,
-          tutorLevel: aiTutorAvailableForLevel,
-          aiChatAccessLevel,
-        }));
+      shouldShowAiTutor({
+        appName: labType,
+        tutorLevel: aiTutorAvailableForLevel,
+        aiChatAccessLevel,
+      });
 
     const chatContainerSpace = 335; // 325px chat container + 10px margin = 335px
     const sidebarSpace = 55; // 45px sidebar + 10px margin = 55px
@@ -188,7 +183,6 @@ export default connect(
   state => ({
     instructionsHeight: state.instructions.renderedHeight,
     labType: state.pageConstants.appType,
-    aiTutorEnabledForPilot: state.currentUser.aiTutorEnabledForPilot,
     aiChatAccessLevel: state.currentUser.aiChatAccessLevel,
   }),
   dispatch => ({

--- a/apps/src/util/experiments.js
+++ b/apps/src/util/experiments.js
@@ -49,8 +49,6 @@ experiments.BLOCKLY_KEYBOARD_NAVIGATION = 'blockly-keyboard-navigation';
 experiments.MODULARITY = 'modularity';
 // LocalizeJS
 experiments.LOCALIZEJS = 'localizejs';
-// Show AI Tutor in legacy labs
-experiments.LEGACY_LAB_AI_TUTOR = 'legacy-lab-ai-tutor';
 // Enable ActionCable load testing
 experiments.ACTIONCABLE_LOAD_TESTING = 'actioncable-load-testing';
 // Use AI Tutor system prompts from Langfuse

--- a/apps/test/unit/templates/instructions/InstructionsWithWorkspaceTest.jsx
+++ b/apps/test/unit/templates/instructions/InstructionsWithWorkspaceTest.jsx
@@ -27,7 +27,7 @@ describe('InstructionsWithWorkspace', () => {
     expect(wrapper.state()).toEqual({
       windowWidth: undefined,
       windowHeight: undefined,
-      aiChatOpen: true,
+      aiChatOpen: false,
     });
   });
 


### PR DESCRIPTION
https://codedotorg.atlassian.net/browse/TEACHING-112

After making AI Tutor generally available, we were getting reports from CSP and CSD teachers that it was distracting for their students to see AI Tutor and that Tutor UI was making it difficult to review student work since it compresses the workspace. This PR closes AI Tutor by default for legacy labs. 

Additionally, I did a little bit of clean up to remove a reference to the now defunct AI Tutor pilot and no-longer-needed ai tutor legacy lab experiment flag. 
