### PR TITLE
AI Tutor - Enable vertex as default with DCDO kill switch

### DIFF
--- a/apps/src/aichat/redux/thunks/submitChatContents.ts
+++ b/apps/src/aichat/redux/thunks/submitChatContents.ts
@@ -15,7 +15,6 @@ import Lab2Registry from '@cdo/apps/lab2/Lab2Registry';
 import {EVENTS} from '@cdo/apps/metrics/AnalyticsConstants';
 import {commonI18n} from '@cdo/apps/types/locale';
 import {RootState} from '@cdo/apps/types/redux';
-import experiments from '@cdo/apps/util/experiments';
 import {NetworkError} from '@cdo/apps/util/HttpClient';
 import {AppDispatch} from '@cdo/apps/util/reduxHooks';
 import {createUuid} from '@cdo/apps/utils';
@@ -40,14 +39,6 @@ import {getNewRemoveId} from '../utils';
 import {addChatEvent} from './addChatEvent';
 import {notifyErrorUnauthorized} from './helpers/notifyErrorUnauthorized';
 import {sendAnalytics} from './sendAnalytics';
-
-// We currently default to using the legacy Gemini API unless use vertex query param set.
-// This will be removed once we switch over to Vertex completely.
-const useVertex =
-  experiments.isEnabledAllowingQueryString('aitutor-use-vertex');
-
-// Log whether using Vertex API or not in case query param entered incorrectly.
-console.log(`🤖: Tutor set to use Vertex API? ${useVertex ? 'YES' : 'NO'}`);
 
 // This thunk's callback function submits a user's chat content and AI customizations to
 // the chat completion endpoint, then waits for a chat completion response, and updates
@@ -176,7 +167,7 @@ export const submitChatContents = createAsyncThunk(
       messages = await postAichatCompletionMessage(
         newUserMessage,
         chatEventsCurrent.filter(isCompletedChatMessage),
-        {...modelParameters, useVertex},
+        {...modelParameters},
         aichatContext
       );
 

--- a/apps/src/aichat/types/customizations.ts
+++ b/apps/src/aichat/types/customizations.ts
@@ -14,8 +14,6 @@ export interface ModelParameters {
   systemPrompt: string;
   retrievalContexts: string[];
   responseJsonSchema?: object;
-  // TODO - remove once moved over to Vertex API completely.
-  useVertex?: boolean;
 }
 
 /**

--- a/dashboard/app/helpers/aichat_ai_helper.rb
+++ b/dashboard/app/helpers/aichat_ai_helper.rb
@@ -209,7 +209,7 @@ module AichatAiHelper
 
     usage_reporter = AichatAiUsageReporter.new(model_id, user_id, project_id, level_id)
 
-    use_legacy = !aichat_model_customizations['useVertex']
+    use_legacy = DCDO.get('aichat_disable_vertex_ai', false)
 
     client = use_legacy ?
       create_ai_client_instance_legacy(client_type, model_id, usage_reporter)


### PR DESCRIPTION
This PR follows up on https://github.com/code-dot-org/code-dot-org/pull/70768 and makes Vertex the default API endpoint for Gemini model requests, removing the queryParam/experiment.  There is now a DCDO flag `'aichat_disable_vertex_ai'` that if set to `true` will revert back to the original Gemini API endpoint.

## Links

The original jira ticket is [here](https://codedotorg.atlassian.net/browse/TEACHING-58?atlOrigin=eyJpIjoiNWFmYzIxMzZjYWI2NDQ1OTkxNDY1OGI0M2I5ODY5YjciLCJwIjoiaiJ9)

## Testing story
We tested Vertex in a bug bash last Friday and no adverse effects were found.

## Deployment strategy
The plan is to remain on Vertex unless we have any issues, in which case we can revert to the original endpoint using the DCDO flag.

## Follow-up work
We should remove the DCDO flagsonce Vertex has been stable in production for some time.

## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
