### PR TITLE
Lab2 instructions: fix overlap of inline code blocks

### DIFF
--- a/apps/src/lab2/views/components/Instructions/instructions.module.scss
+++ b/apps/src/lab2/views/components/Instructions/instructions.module.scss
@@ -230,6 +230,7 @@
   code {
     // Allow code to wrap.
     white-space: pre-wrap;
+    line-height: 22px;
   }
 
   p {

--- a/apps/src/lab2/views/components/Instructions/instructions.module.scss
+++ b/apps/src/lab2/views/components/Instructions/instructions.module.scss
@@ -230,7 +230,7 @@
   code {
     // Allow code to wrap.
     white-space: pre-wrap;
-    line-height: 22px;
+    line-height: 1.8;
   }
 
   p {


### PR DESCRIPTION
I noticed inline code blocks in the lab2 instructions can slightly overlap if they are on successive lines. This adds a hard-coded line height to fix this. I made it as small as possible to avoid the lines getting too spaced out, while still having whitespace between code blocks.

## Before
<img width="330" height="658" alt="Screenshot 2026-03-02 at 10 50 31 AM" src="https://github.com/user-attachments/assets/09394558-876d-43a1-8a5b-ff88e09d432a" />

## After
<img width="330" height="712" alt="Screenshot 2026-03-02 at 12 50 19 PM" src="https://github.com/user-attachments/assets/aa3690a3-4e47-45e6-8847-a77308a6f3e1" />



## Links
- Jira: [AFL-480](https://codedotorg.atlassian.net/browse/AFL-480)


## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
