### PR TITLE
Support preview in CodeMirror6 wrapper

### DIFF
--- a/apps/src/code-studio/initializeCodeMirror6.ts
+++ b/apps/src/code-studio/initializeCodeMirror6.ts
@@ -3,8 +3,13 @@ import {json} from '@codemirror/lang-json';
 import {markdown} from '@codemirror/lang-markdown';
 import {EditorState, Extension} from '@codemirror/state';
 import {EditorView, ViewUpdate} from '@codemirror/view';
+import React from 'react';
 
 import {editorConfig} from '@cdo/apps/codemirror/editorConfig';
+import {createReactRoot} from '@cdo/apps/util/createReactRoot';
+
+import MainInstructionsPreview from '../lab2/views/components/Instructions/MainInstructionsPreview';
+import SafeMarkdown from '../templates/SafeMarkdown';
 
 const levelbuilderEditorTheme = EditorView.theme({
   '&': {
@@ -21,6 +26,8 @@ interface CodeMirrorLegacyAdapter {
 
 interface Options {
   callback?: (editor: CodeMirrorLegacyAdapter, update: ViewUpdate) => void;
+  preview?: string | Element;
+  game?: string;
 }
 
 type EditorMode = 'javascript' | 'json' | 'markdown';
@@ -44,17 +51,31 @@ function resolveTarget(target: string | Element): HTMLTextAreaElement {
   return node;
 }
 
+function resolvePreviewElement(
+  preview: string | Element | undefined,
+  node: HTMLTextAreaElement
+): Element | null {
+  if (preview instanceof Element) {
+    return preview;
+  }
+
+  const selector = preview || (node.id ? `#${node.id}_preview` : undefined);
+  return selector ? document.querySelector(selector) : null;
+}
+
 function initializeCodeMirror6(
   target: string | Element,
   mode: EditorMode,
   options: Options = {}
 ): CodeMirrorLegacyAdapter {
   const node = resolveTarget(target);
-  const {callback} = options;
+  const {callback, preview, game} = options;
   const changeListeners: Array<() => void> = [];
   const editorContainer = document.createElement('div');
   node.style.display = 'none';
   node.insertAdjacentElement('afterend', editorContainer);
+  const previewElement =
+    mode === 'markdown' ? resolvePreviewElement(preview, node) : null;
 
   const adapter: CodeMirrorLegacyAdapter = {
     getValue() {
@@ -72,6 +93,37 @@ function initializeCodeMirror6(
     },
   };
 
+  const updatePreview = () => {
+    if (!previewElement) {
+      return;
+    }
+
+    if (game === 'Pythonlab' || game === 'Weblab2') {
+      createReactRoot(
+        React.createElement(MainInstructionsPreview, {
+          instructionsText: adapter.getValue(),
+          theme: 'Dark',
+        }),
+        previewElement
+      );
+    } else if (game === 'Aichat' || game === 'Music') {
+      createReactRoot(
+        React.createElement(MainInstructionsPreview, {
+          instructionsText: adapter.getValue(),
+          theme: 'Light',
+        }),
+        previewElement
+      );
+    } else {
+      createReactRoot(
+        React.createElement(SafeMarkdown, {
+          markdown: adapter.getValue(),
+        }),
+        previewElement
+      );
+    }
+  };
+
   const extensions: Extension[] = [
     ...editorConfig,
     getLanguageExtension(mode),
@@ -86,6 +138,7 @@ function initializeCodeMirror6(
       if (callback) {
         callback(adapter, update);
       }
+      updatePreview();
     }),
   ];
 
@@ -96,6 +149,8 @@ function initializeCodeMirror6(
     }),
     parent: editorContainer,
   });
+
+  updatePreview();
 
   return adapter;
 }

--- a/apps/src/code-studio/initializeCodeMirror6.ts
+++ b/apps/src/code-studio/initializeCodeMirror6.ts
@@ -63,6 +63,18 @@ function resolvePreviewElement(
   return selector ? document.querySelector(selector) : null;
 }
 
+/**
+ * initializeCodeMirror6 replaces a textarea on the page with a full-featured
+ * CodeMirror6 editor.
+ * @param {!string|!Element} target - element or id of element to replace.
+ * @param {!string} mode - editor syntax mode
+ * @param {Object} options - misc optional arguments
+ * @param {function} [options.callback] - onChange callback for editor
+ * @param {(string|Element)} [options.preview] - element or id of element to
+ *        populate with a preview. If none specified, will look for an element
+ *        by appending "_preview" to the id of the target element. Only supported for markdown mode.
+ * @param {string} [options.game] optional game name, used to determine which preview to use.
+ */
 function initializeCodeMirror6(
   target: string | Element,
   mode: EditorMode,

--- a/dashboard/app/views/levels/editors/fields/_long_instructions.html.haml
+++ b/dashboard/app/views/levels/editors/fields/_long_instructions.html.haml
@@ -17,7 +17,7 @@
 
 
 :javascript
-  var mdEditor = levelbuilder.initializeCodeMirror6('level_long_instructions', 'markdown', {
+  var mdEditor = levelbuilder.initializeCodeMirror('level_long_instructions', 'markdown', {
     callback: function (editor, change) {
       const xmlContainer = document.getElementById('level_long_instructions_preview');
 
@@ -25,6 +25,7 @@
 
       localStorage.setItem('markdown_' + '#{@level.id || html_escape(params[:type])}', editor.getValue());
     },
+    attachments: true,
     game: '#{@level.game&.name}',
   });
 

--- a/dashboard/app/views/levels/editors/fields/_long_instructions.html.haml
+++ b/dashboard/app/views/levels/editors/fields/_long_instructions.html.haml
@@ -17,7 +17,7 @@
 
 
 :javascript
-  var mdEditor = levelbuilder.initializeCodeMirror('level_long_instructions', 'markdown', {
+  var mdEditor = levelbuilder.initializeCodeMirror6('level_long_instructions', 'markdown', {
     callback: function (editor, change) {
       const xmlContainer = document.getElementById('level_long_instructions_preview');
 
@@ -25,7 +25,6 @@
 
       localStorage.setItem('markdown_' + '#{@level.id || html_escape(params[:type])}', editor.getValue());
     },
-    attachments: true,
     game: '#{@level.game&.name}',
   });
 


### PR DESCRIPTION
Adds support for a WYSIWYG preview with the new CM6 wrapper.

I don't actually convert any usages yet (there are a handful) because they all require support for the "attachments" option, which is complicated and I haven't implemented yet in CM6 :).

## Testing story

I tested this manually using the Long Instructions partial that appears in a lot of level editing pages. I tested across the three possible React components used in long instructions by different level types.