### PR TITLE
Web Lab 2: enable debug panel by default

### DIFF
--- a/apps/src/util/experiments.js
+++ b/apps/src/util/experiments.js
@@ -61,8 +61,6 @@ experiments.WEBLAB2_FULL_URLS = 'weblab2-full-urls';
 experiments.ACCEPT_REJECT_UNIFIED_DIFF = 'accept-reject-unified-diff';
 // Show split diff view in Code Editor.
 experiments.ACCEPT_REJECT_SPLIT_DIFF = 'accept-reject-split-diff';
-// Show debug panel in Web Lab 2
-experiments.WEBLAB2_DEBUG_PANEL = 'weblab2-show-debug';
 // Enable the new teacher dashboard student snapshot page and features
 experiments.STUDENT_SNAPSHOT = 'student-snapshot';
 

--- a/apps/src/weblab2/htmlPreview/HTMLPreviewHeader.tsx
+++ b/apps/src/weblab2/htmlPreview/HTMLPreviewHeader.tsx
@@ -7,7 +7,6 @@ import classNames from 'classnames';
 import React, {useEffect, ChangeEvent, useCallback, useRef} from 'react';
 
 import {AutocompleteInput} from '@cdo/apps/templates/autocompleteInput/AutocompleteInput';
-import experiments from '@cdo/apps/util/experiments';
 import {useAppDispatch, useAppSelector} from '@cdo/apps/util/reduxHooks';
 import weblab2I18n from '@cdo/apps/weblab2/locale';
 
@@ -51,9 +50,6 @@ export const HTMLPreviewHeader: React.FC<HTMLPreviewHeaderProps> = ({
 }) => {
   const isFullScreenView = useAppSelector(state => state.lab.isFullScreenView);
   const isShareView = useAppSelector(state => state.lab.isShareView);
-  const enableDebugPanel = experiments.isEnabledAllowingQueryString(
-    experiments.WEBLAB2_DEBUG_PANEL
-  );
   const debugPanelOpen = useAppSelector(state => state.weblab2.debugPanelOpen);
   const dispatch = useAppDispatch();
 
@@ -202,31 +198,27 @@ export const HTMLPreviewHeader: React.FC<HTMLPreviewHeaderProps> = ({
         className={moduleStyles.previewViewModeButtons}
         {...previewViewModeButtonsProps}
       />
-      {enableDebugPanel && (
-        <WithTooltip
-          tooltipProps={{
-            tooltipId: 'toggle-debug-panel',
-            direction: 'onBottom',
-            size: 'xs',
-            text: debugPanelOpen ? 'Close debug panel' : 'Open debug panel',
-          }}
-        >
-          <Button
-            onClick={() => dispatch(setDebugPanelOpen(!debugPanelOpen))}
-            aria-label={
-              debugPanelOpen ? 'Close debug panel' : 'Open debug panel'
-            }
-            size="xs"
-            type="secondary"
-            color={'gray'}
-            icon={{iconName: 'bug'}}
-            isIconOnly={true}
-            className={
-              debugPanelOpen ? moduleStyles.closeDebugPanelButton : undefined
-            }
-          />
-        </WithTooltip>
-      )}
+      <WithTooltip
+        tooltipProps={{
+          tooltipId: 'toggle-debug-panel',
+          direction: 'onBottom',
+          size: 'xs',
+          text: debugPanelOpen ? 'Close debug panel' : 'Open debug panel',
+        }}
+      >
+        <Button
+          onClick={() => dispatch(setDebugPanelOpen(!debugPanelOpen))}
+          aria-label={debugPanelOpen ? 'Close debug panel' : 'Open debug panel'}
+          size="xs"
+          type="secondary"
+          color={'gray'}
+          icon={{iconName: 'bug'}}
+          isIconOnly={true}
+          className={
+            debugPanelOpen ? moduleStyles.closeDebugPanelButton : undefined
+          }
+        />
+      </WithTooltip>
       {!isShareView && (
         <ToggleFullScreenButton
           isFullScreenView={isFullScreenView}

--- a/apps/src/weblab2/layout/VerticalLayout.tsx
+++ b/apps/src/weblab2/layout/VerticalLayout.tsx
@@ -16,7 +16,6 @@ import {logOnResize} from '@cdo/apps/lab2/utils/resizeUtils';
 import ResizeBar from '@cdo/apps/lab2/views/components/layout/ResizeBar';
 import PanelContainer from '@cdo/apps/lab2/views/components/PanelContainer';
 import WorkspaceHeader from '@cdo/apps/lab2/views/components/WorkspaceHeader';
-import experiments from '@cdo/apps/util/experiments';
 import {useAppSelector, useAppDispatch} from '@cdo/apps/util/reduxHooks';
 import {HTMLPreview} from '@cdo/apps/weblab2/htmlPreview/HTMLPreview';
 import weblab2I18n from '@cdo/apps/weblab2/locale';
@@ -174,10 +173,6 @@ const VerticalLayout: React.FunctionComponent<LayoutProps> = ({
     );
   }, [setLeftPanelSize, hideWorkspaceForWidgetView, isStandaloneCollapsed]);
 
-  const showDebugPanel =
-    experiments.isEnabledAllowingQueryString(experiments.WEBLAB2_DEBUG_PANEL) &&
-    debugPanelOpen;
-
   return (
     <div className={lab2Styles.defaultContainer}>
       <div className={lab2Styles.layoutContainer}>
@@ -250,7 +245,7 @@ const VerticalLayout: React.FunctionComponent<LayoutProps> = ({
               )}
             </div>
           </div>
-          {showDebugPanel && (
+          {debugPanelOpen && (
             <>
               <ResizeBar
                 isVertical={false}


### PR DESCRIPTION
This removes the experiment to enable the debug panel and has the button to show/hide the debug panel on always. The debug panel is by default closed.

## Links

- Jira: [AFL-507](https://codedotorg.atlassian.net/browse/AFL-507)

## Testing story
Tested locally.



## PR Creation Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy impacts have been documented
- [ ] Security impacts have been documented
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
