### PR TITLE
Support and migrate usages of XML and HTML editor in CodeMirror6 wrapper

### DIFF
--- a/apps/package.json
+++ b/apps/package.json
@@ -224,6 +224,7 @@
     "@codemirror/lang-json": "^6.0.2",
     "@codemirror/lang-markdown": "^6.3.4",
     "@codemirror/lang-python": "^6.1.7",
+    "@codemirror/lang-xml": "^6.1.0",
     "@codemirror/language": "^6.11.0",
     "@codemirror/lint": "^6.8.5",
     "@codemirror/merge": "^6.11.2",

--- a/apps/src/code-studio/initializeCodeMirror6.ts
+++ b/apps/src/code-studio/initializeCodeMirror6.ts
@@ -1,6 +1,8 @@
+import {html} from '@codemirror/lang-html';
 import {javascript} from '@codemirror/lang-javascript';
 import {json} from '@codemirror/lang-json';
 import {markdown} from '@codemirror/lang-markdown';
+import {xml} from '@codemirror/lang-xml';
 import {EditorState, Extension} from '@codemirror/state';
 import {EditorView, ViewUpdate} from '@codemirror/view';
 
@@ -23,12 +25,14 @@ interface Options {
   callback?: (editor: CodeMirrorLegacyAdapter, update: ViewUpdate) => void;
 }
 
-type EditorMode = 'javascript' | 'json' | 'markdown';
+type EditorMode = 'javascript' | 'json' | 'markdown' | 'xml' | 'html';
 
 const languageExtensionMap: Record<EditorMode, Extension> = {
   javascript: javascript(),
   json: json(),
   markdown: markdown(),
+  xml: xml(),
+  html: html(),
 };
 
 function getLanguageExtension(mode: EditorMode): Extension {

--- a/apps/src/sites/studio/pages/levels/editors/fields/_blockly.js
+++ b/apps/src/sites/studio/pages/levels/editors/fields/_blockly.js
@@ -1,7 +1,7 @@
 import {installCustomBlocks} from '@cdo/apps/block_utils';
 import commonBlocks from '@cdo/apps/blocksCommon';
 import initializeBlockPreview from '@cdo/apps/code-studio/initializeBlockPreview';
-import initializeCodeMirror from '@cdo/apps/code-studio/initializeCodeMirror';
+import initializeCodeMirror6 from '@cdo/apps/code-studio/initializeCodeMirror6';
 import getScriptData from '@cdo/apps/util/getScriptData';
 
 const data = getScriptData('pageOptions');
@@ -89,7 +89,7 @@ Object.keys(fieldConfig).forEach(key => {
   if (!element) {
     return;
   }
-  config.editor = initializeCodeMirror(config.codemirror, mode);
+  config.editor = initializeCodeMirror6(config.codemirror, mode);
   if (config.blockPreview && !data.uses_droplet) {
     initializeBlockPreview(
       config.editor,

--- a/apps/yarn.lock
+++ b/apps/yarn.lock
@@ -4124,6 +4124,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@codemirror/lang-xml@npm:^6.1.0":
+  version: 6.1.0
+  resolution: "@codemirror/lang-xml@npm:6.1.0"
+  dependencies:
+    "@codemirror/autocomplete": "npm:^6.0.0"
+    "@codemirror/language": "npm:^6.4.0"
+    "@codemirror/state": "npm:^6.0.0"
+    "@codemirror/view": "npm:^6.0.0"
+    "@lezer/common": "npm:^1.0.0"
+    "@lezer/xml": "npm:^1.0.0"
+  checksum: 10/f5e54668c30efbb8a78a51e49ccec92a06931f2b98dce35c90be94ded30da02dac525124ce3c40f65c7b071f8db72d16b10a5a1795ccbf10e69939c0a9c1cac8
+  languageName: node
+  linkType: hard
+
 "@codemirror/language@npm:^6.0.0, @codemirror/language@npm:^6.11.0, @codemirror/language@npm:^6.3.0, @codemirror/language@npm:^6.4.0, @codemirror/language@npm:^6.6.0, @codemirror/language@npm:^6.8.0":
   version: 6.11.3
   resolution: "@codemirror/language@npm:6.11.3"
@@ -5535,6 +5549,17 @@ __metadata:
     "@lezer/highlight": "npm:^1.0.0"
     "@lezer/lr": "npm:^1.0.0"
   checksum: 10/51c75546fc47917a5fdb57abdae47923f2b0dc35e1f65f9a9558939fc0c21e23984b7fa9aafbd41df11b7acffe8bba22e3cddc31abe222dc7f8aac598c16e93c
+  languageName: node
+  linkType: hard
+
+"@lezer/xml@npm:^1.0.0":
+  version: 1.0.6
+  resolution: "@lezer/xml@npm:1.0.6"
+  dependencies:
+    "@lezer/common": "npm:^1.2.0"
+    "@lezer/highlight": "npm:^1.0.0"
+    "@lezer/lr": "npm:^1.0.0"
+  checksum: 10/ffdc3fd587c992f86de84bd828e1d92216484a571423b6edb7b0b1f2eb495ff14e9a234ce5fcba4bce1cb00683af50c0e7f5dfb017a0d3da77607b42e77548a2
   languageName: node
   linkType: hard
 
@@ -11167,6 +11192,7 @@ __metadata:
     "@codemirror/lang-json": "npm:^6.0.2"
     "@codemirror/lang-markdown": "npm:^6.3.4"
     "@codemirror/lang-python": "npm:^6.1.7"
+    "@codemirror/lang-xml": "npm:^6.1.0"
     "@codemirror/language": "npm:^6.11.0"
     "@codemirror/lint": "npm:^6.8.5"
     "@codemirror/merge": "npm:^6.11.2"

--- a/dashboard/app/views/levels/editors/fields/_applab_design_mode.html.haml
+++ b/dashboard/app/views/levels/editors/fields/_applab_design_mode.html.haml
@@ -19,4 +19,4 @@
       #{html_escape("<div xmlns='http://www.w3.org/1999/xhtml' id='divApplab'")}...)
     = f.text_area :start_html, placeholder: 'Start html', rows: 4, value: @level.start_html
     :javascript
-      levelbuilder.initializeCodeMirror('level_start_html', 'html');
+      levelbuilder.initializeCodeMirror6('level_start_html', 'html');

--- a/dashboard/app/views/levels/editors/fields/_artist_fields.html.haml
+++ b/dashboard/app/views/levels/editors/fields/_artist_fields.html.haml
@@ -39,7 +39,7 @@
     = link_to 'Edit Predraw Blocks', edit_blocks_level_path(@level, :predraw_blocks) unless @level.new_record?
     = render partial: 'levels/editors/fields/collapsible_block_editor', locals: {f: f, xml_id: 'predraw'}
     :javascript
-      levelbuilder.initializeCodeMirror('level_predraw_blocks', '#{@level.uses_droplet? ? 'javascript' : 'xml'}');
+      levelbuilder.initializeCodeMirror6('level_predraw_blocks', '#{@level.uses_droplet? ? 'javascript' : 'xml'}');
   .field
     = f.label :images, 'Image field in JSON array format, e.g.:'
     %div


### PR DESCRIPTION
Adds support for HTML and XML in the new CodeMirror6 wrapper, and migrates usages of these editor types to the CM6 wrapper.

## Testing story

I tested manually loading/updating/saving in each of these editors. I did note some minor formatting differences in the HTML editor (used in App Lab design mode) -- for example, when highlighting a HTML tag, the tag attributes were not highlighted (only the opening and closing HTML element name was highted), whereas in the existing editor, they are. Thinking I'll post something to content editors when this is done to suggest that they get in touch if they notice any differences that are annoying/disruptive to their workflows.