### PR TITLE
AI lesson summary podcast bug fix and style update

### DIFF
--- a/apps/i18n/common/en_us.json
+++ b/apps/i18n/common/en_us.json
@@ -367,7 +367,7 @@
   "assignmentSelectorUnit": "Select current unit",
   "audioInitializeError": "Your computer is not set-up to record audio. Please ensure you have a microphone with permission to access audio on this website.",
   "audioSaveError": "There's been an error saving your recording. Please re-record and try again. If this issue persists, please refresh the page and try again.",
-  "audioSummary": "Audio Summary",
+  "audioSummary": "Daily Byte Podcast",
   "audioTranscript": "Audio Transcript",
   "authorizeGoogleClassrooms": "To authorize Google Classroom, click here.",
   "authorizeGoogleClassroomsText": "In order to sync with Google Classroom, Code.org must have up-to-date authorization to access your Google Classroom account.",

--- a/apps/src/sites/studio/pages/teacher_dashboard/show.js
+++ b/apps/src/sites/studio/pages/teacher_dashboard/show.js
@@ -15,6 +15,7 @@ import unitSelection from '@cdo/apps/redux/unitSelectionRedux';
 import currentUser, {
   setShowAITALessonSummary,
   setHasCompletedPersonalizationQuiz,
+  setShowAITAPodcasts,
 } from '@cdo/apps/templates/currentUserRedux';
 import manageStudents from '@cdo/apps/templates/manageStudents/manageStudentsRedux';
 import sectionAssessments from '@cdo/apps/templates/sectionAssessments/sectionAssessmentsRedux';
@@ -40,6 +41,7 @@ const {
   sections,
   localeCode,
   showAITALessonSummary,
+  showAITAPodcasts,
   hasCompletedPersonalizationQuiz,
   sectionOrder,
   providers,
@@ -67,6 +69,7 @@ $(document).ready(function () {
   const store = getStore();
   if (showAITALessonSummary) {
     store.dispatch(setShowAITALessonSummary(true));
+    store.dispatch(setShowAITAPodcasts(showAITAPodcasts));
     store.dispatch(
       setHasCompletedPersonalizationQuiz(hasCompletedPersonalizationQuiz)
     );

--- a/apps/src/templates/teacherNavigation/lessonMaterials/LessonMaterialsContainer.tsx
+++ b/apps/src/templates/teacherNavigation/lessonMaterials/LessonMaterialsContainer.tsx
@@ -356,7 +356,10 @@ const LessonMaterialsContainer: React.FC<LessonMaterialsContainerProps> = ({
             <div className={styles.lessonSummarySection}>
               <div className={styles.lessonSummarySectionHeader}>
                 <div className={styles.lessonSummarySectionTitle}>
-                  <FontAwesomeV6Icon iconName="headphones" iconStyle="solid" />
+                  <FontAwesomeV6Icon
+                    iconFamily="kit"
+                    iconName="solid-flask-sparkle"
+                  />
                   <Typography variant="body2" gutterBottom>
                     {i18n.audioSummary()}
                   </Typography>


### PR DESCRIPTION
There was a logic error the caused the DCDO flag to not correctly activate the new podcast feature. This also updates the title and icon of the podcast component.

Before:
<img width="410" height="123" alt="image" src="https://github.com/user-attachments/assets/9ac7a4f1-a79b-4655-92c8-ec0dd97ef300" />

After:
<img width="425" height="137" alt="image" src="https://github.com/user-attachments/assets/f5eb7d04-5db5-4b1c-ba97-75be9baec01a" />


## Links
<!-- Jira tickets, design docs, Slack threads, related PRs, etc. -->

- Jira:

## Testing story
<!-- How was this tested? Manual steps, adhoc links, automated tests, or why testing isn't needed. -->



## Deployment notes
<!-- Delete this section if it's a standard merge-and-deploy.
     Otherwise: migrations, feature flags, coordination, caching impacts, etc. -->



## Privacy and security
<!-- Delete this section if there is no privacy/security impact.
     Otherwise: new PII, auth changes, API surface changes, etc. -->

