### PR TITLE
[All Labs] adds empty alt text to video note decorative images

### DIFF
--- a/apps/src/code-studio/videos.js
+++ b/apps/src/code-studio/videos.js
@@ -165,8 +165,17 @@ videos.showVideoDialog = function (options, forceShowVideo) {
     options.key,
     function (data) {
       notesDiv.children('#notes').html(data);
-      // Ensure all <img> elements inside #notes default to empty alt text
-      notesDiv.children('#notes').find('img').attr('alt', '');
+      // Ensure all <img> elements inside #notes default to empty alt text,
+      // but do not overwrite any existing descriptive alt text.
+      notesDiv
+        .children('#notes')
+        .find('img')
+        .each(function () {
+          var $img = $(this);
+          if (!$img.is('[alt]')) {
+            $img.attr('alt', '');
+          }
+        });
     },
     function () {
       openVideoTab();

--- a/apps/src/code-studio/videos.js
+++ b/apps/src/code-studio/videos.js
@@ -165,6 +165,8 @@ videos.showVideoDialog = function (options, forceShowVideo) {
     options.key,
     function (data) {
       notesDiv.children('#notes').html(data);
+      // Ensure all <img> elements inside #notes default to empty alt text
+      notesDiv.children('#notes').find('img').attr('alt', '');
     },
     function () {
       openVideoTab();


### PR DESCRIPTION
We have WCAG violations for video notes because we didn't have any alt text for those images. These notes operate as a video transcript, and the accompanying images are largely decorative. If we decide any of these notes need alt descriptions, we can add them later. For now, we can at least add empty text to the images so screen reader users don't scan through hearing image links, and the WCAG violations are removed.

An example of the images:
<img width="1148" height="751" alt="Screenshot 2026-03-02 at 2 31 06 PM" src="https://github.com/user-attachments/assets/fdfc2960-9f8b-4737-808d-456c8263032b" />



## Links

- Jira: https://codedotorg.atlassian.net/browse/SL-1603
- VPAT: https://app.getstark.co/organization/ced5459c-437e-48a0-8737-90ad0ef005c0/projects/aiOk8eUknKEfWPEE3SIO/assets/5bAQbcRUbbfgXK1uQydr/reports/CqhN8GGQ8oByoEkjrLvu

## Testing story
<!-- How was this tested? Manual steps, adhoc links, automated tests, or why testing isn't needed. -->



## Deployment notes
<!-- Delete this section if it's a standard merge-and-deploy.
     Otherwise: migrations, feature flags, coordination, caching impacts, etc. -->



## Privacy and security
<!-- Delete this section if there is no privacy/security impact.
     Otherwise: new PII, auth changes, API surface changes, etc. -->

