### PR TITLE
Codebridge: Fixes for pop-up file menu

### DIFF
--- a/apps/src/codebridge/PopUpButton/PopUpButton.tsx
+++ b/apps/src/codebridge/PopUpButton/PopUpButton.tsx
@@ -52,27 +52,6 @@ export const PopUpButton = ({
   // rendered in a portal, outside of the main lab container.
   const {theme} = useTheme();
 
-  // Listen for close events from other dropdowns
-  useEffect(() => {
-    const handleCloseOthers = (e: Event) => {
-      const customEvent = e as CustomEvent<{sourceId: string}>;
-      if (customEvent.detail.sourceId !== instanceId.current) {
-        // Defer state update to avoid updating during render
-        const timeoutId = setTimeout(() => {
-          setIsOpen(false);
-          timeoutsRef.current.delete(timeoutId);
-        }, 0);
-        timeoutsRef.current.add(timeoutId);
-      }
-    };
-    document.addEventListener(CLOSE_OTHER_DROPDOWNS_EVENT, handleCloseOthers);
-    return () =>
-      document.removeEventListener(
-        CLOSE_OTHER_DROPDOWNS_EVENT,
-        handleCloseOthers
-      );
-  }, []);
-
   // Handler to close the dropdown.
   const setIsOpenFalse = useCallback(() => {
     setIsOpen(false);
@@ -87,7 +66,28 @@ export const PopUpButton = ({
       timeoutsRef.current.delete(timeoutId);
     }, 0);
     timeoutsRef.current.add(timeoutId);
-  }, [setIsOpen, className]);
+  }, [className]);
+
+  // Listen for close events from other dropdowns
+  useEffect(() => {
+    const handleCloseOthers = (e: Event) => {
+      const customEvent = e as CustomEvent<{sourceId: string}>;
+      if (customEvent.detail.sourceId !== instanceId.current) {
+        // Defer state update to avoid updating during render
+        const timeoutId = setTimeout(() => {
+          setIsOpenFalse();
+          timeoutsRef.current.delete(timeoutId);
+        }, 0);
+        timeoutsRef.current.add(timeoutId);
+      }
+    };
+    document.addEventListener(CLOSE_OTHER_DROPDOWNS_EVENT, handleCloseOthers);
+    return () =>
+      document.removeEventListener(
+        CLOSE_OTHER_DROPDOWNS_EVENT,
+        handleCloseOthers
+      );
+  }, [setIsOpenFalse]);
 
   // Handler to show the dropdown.
   const clickHandler = useCallback(
@@ -99,30 +99,28 @@ export const PopUpButton = ({
       e.stopPropagation();
       setUpdatedStyles(false);
       setButtonRef(e.target as HTMLElement);
-      setIsOpen(oldIsOpen => {
-        const newIsOpen = !oldIsOpen;
-        if (newIsOpen) {
-          // Tell other dropdowns to close
-          document.dispatchEvent(
-            new CustomEvent(CLOSE_OTHER_DROPDOWNS_EVENT, {
-              detail: {sourceId: instanceId.current},
-            })
-          );
+      if (isOpen) {
+        document.removeEventListener('click', setIsOpenFalse);
+        setIsOpenFalse();
+      } else {
+        // Tell other dropdowns to close
+        document.dispatchEvent(
+          new CustomEvent(CLOSE_OTHER_DROPDOWNS_EVENT, {
+            detail: {sourceId: instanceId.current},
+          })
+        );
 
-          // Defer adding the close handler until the next tick of the event
-          // loop, otherwise it'll fire immediately and re-close the pop up.
-          const timeoutId = setTimeout(() => {
-            document.addEventListener('click', setIsOpenFalse);
-            timeoutsRef.current.delete(timeoutId);
-          }, 0);
-          timeoutsRef.current.add(timeoutId);
-        } else {
-          document.removeEventListener('click', setIsOpenFalse);
-        }
-        return newIsOpen;
-      });
+        // Defer adding the close handler until the next tick of the event
+        // loop, otherwise it'll fire immediately and re-close the pop up.
+        const timeoutId = setTimeout(() => {
+          document.addEventListener('click', setIsOpenFalse);
+          timeoutsRef.current.delete(timeoutId);
+        }, 0);
+        timeoutsRef.current.add(timeoutId);
+        setIsOpen(true);
+      }
     },
-    [setIsOpenFalse]
+    [isOpen, setIsOpenFalse]
   );
 
   // Effect to update dropdown position when it is shown.

--- a/apps/src/codebridge/PopUpButton/PopUpButton.tsx
+++ b/apps/src/codebridge/PopUpButton/PopUpButton.tsx
@@ -132,12 +132,29 @@ export const PopUpButton = ({
         if (buttonRef && dropdownRef.current) {
           const dropdownRect = dropdownRef.current.getBoundingClientRect();
           const buttonRect = buttonRef.getBoundingClientRect();
-          const top =
-            buttonRect.top + buttonRect.height + TOP_PADDING + window.scrollY;
-          const left =
+          // Flip above the button if the dropdown would extend below the viewport
+          const wouldGoOffscreenBelow =
+            buttonRect.bottom + TOP_PADDING + dropdownRect.height >
+            window.innerHeight;
+          const top = wouldGoOffscreenBelow
+            ? buttonRect.top -
+              dropdownRect.height -
+              TOP_PADDING +
+              window.scrollY
+            : buttonRect.bottom + TOP_PADDING + window.scrollY;
+
+          // Clamp horizontally within viewport bounds to prevent side overflow
+          let left =
             alignment === 'right'
               ? buttonRect.right - dropdownRect.width + window.scrollX
               : buttonRect.left + window.scrollX;
+          left = Math.max(
+            window.scrollX,
+            Math.min(
+              left,
+              window.innerWidth - dropdownRect.width + window.scrollX
+            )
+          );
           // Defer all state updates to avoid updating during render
           const timeoutId = setTimeout(() => {
             setDropdownStyles({


### PR DESCRIPTION
This provides a couple fixes for the pop-up file menu in Python Lab and Web Lab 2 (codebridge):
- If the menu would go off-screen, put it above the button rather than below. Also update the position if it would be too far to the left (although I can't actually repro this with our current button positioning)
- Make the ellipsis button visibility less sticky; if the dropdown was closed because another dropdown was opened, or was closed because the user clicked the ellipsis button, it would stay visible. This could lead to seeing a bunch of the ellipsis buttons at once when we only want one visible at a time. It's still possible for 2 to be visible right now if you have one dropdown open and hover over another, but once you click another one the first will disappear.

## Before

https://github.com/user-attachments/assets/c4f0d790-fbe4-4554-b6c9-02375af3b60d


## After

https://github.com/user-attachments/assets/b3ee0af3-b5f8-4215-ac62-ee787917ccb1



## Links

- Jira: [AFL-432](https://codedotorg.atlassian.net/browse/AFL-432)

## Testing story
Tested locally


