### PR TITLE
[All Labs] makes tooltip 'x' keyboard navigable

### DIFF
--- a/apps/src/code-studio/callouts.js
+++ b/apps/src/code-studio/callouts.js
@@ -116,11 +116,19 @@ export function addCallouts(callouts) {
         title: {
           button: $(
             '<div class="tooltip-x-close" tabindex="0" role="button" aria-label="Close tooltip"/>'
-          ).on('keydown', function (e) {
-            if (e.key === 'Enter' || e.key === ' ') {
-              $(this).trigger('click'); // Simulate a click when Enter or Space is pressed
-            }
-          }),
+          )
+            .on('keydown', function (e) {
+              if (e.key === 'Enter') {
+                e.preventDefault(); // Prevent default behavior for Enter
+                $(this).trigger('click'); // Trigger click on Enter key
+              }
+            })
+            .on('keyup', function (e) {
+              if (e.key === ' ' || e.code === 'Space') {
+                e.preventDefault(); // Prevent page scrolling
+                $(this).trigger('click'); // Trigger click on Space key
+              }
+            }),
         },
       },
       style: {

--- a/apps/src/code-studio/callouts.js
+++ b/apps/src/code-studio/callouts.js
@@ -114,7 +114,13 @@ export function addCallouts(callouts) {
       content: {
         text: callout.localized_text,
         title: {
-          button: $('<div class="tooltip-x-close"/>'),
+          button: $(
+            '<div class="tooltip-x-close" tabindex="0" role="button" aria-label="Close tooltip"/>'
+          ).on('keydown', function (e) {
+            if (e.key === 'Enter' || e.key === ' ') {
+              $(this).trigger('click'); // Simulate a click when Enter or Space is pressed
+            }
+          }),
         },
       },
       style: {


### PR DESCRIPTION
The small callouts (little tooltips) were not keyboard navigable. This gives them a tab index and keyboard events (they are divs so do not automatically work with keyboard) and an aria label. See video for example:



https://github.com/user-attachments/assets/e51cd9ca-b622-43ca-acbd-0a6dee602e03



## Links

- Jira: https://codedotorg.atlassian.net/browse/SL-1605
- VPAT: https://app.getstark.co/organization/ced5459c-437e-48a0-8737-90ad0ef005c0/projects/aiOk8eUknKEfWPEE3SIO/assets/5bAQbcRUbbfgXK1uQydr/reports/CqhN8GGQ8oByoEkjrLvu

## Testing story
<!-- How was this tested? Manual steps, adhoc links, automated tests, or why testing isn't needed. -->



## Deployment notes
<!-- Delete this section if it's a standard merge-and-deploy.
     Otherwise: migrations, feature flags, coordination, caching impacts, etc. -->



## Privacy and security
<!-- Delete this section if there is no privacy/security impact.
     Otherwise: new PII, auth changes, API surface changes, etc. -->

