### PR TITLE
Support drag and drop in CodeMirror6 wrapper

### DIFF
--- a/apps/src/code-studio/initializeCodeMirror6.ts
+++ b/apps/src/code-studio/initializeCodeMirror6.ts
@@ -84,12 +84,14 @@ function resolvePreviewElement(
 }
 
 /**
- * initializeCodeMirror6 replaces a textarea on the page with a full-featured
+ * initializeCodeMirror6 syncs a textarea on the page with a full-featured
  * CodeMirror6 editor.
  * @param {!string|!Element} target - element or id of element to replace.
  * @param {!string} mode - editor syntax mode
  * @param {Object} options - misc optional arguments
  * @param {function} [options.callback] - onChange callback for editor
+ * @param {boolean} [options.attachments] - whether to enable attachment
+ *        uploading in this editor.
  * @param {(string|Element)} [options.preview] - element or id of element to
  *        populate with a preview. If none specified, will look for an element
  *        by appending "_preview" to the id of the target element. Only supported for markdown mode.

--- a/apps/src/code-studio/initializeCodeMirror6.ts
+++ b/apps/src/code-studio/initializeCodeMirror6.ts
@@ -12,27 +12,43 @@ import {createReactRoot} from '@cdo/apps/util/createReactRoot';
 
 import MainInstructionsPreview from '../lab2/views/components/Instructions/MainInstructionsPreview';
 import SafeMarkdown from '../templates/SafeMarkdown';
+import './vendor/codemirror.inline-attach';
+
+declare global {
+  interface Window {
+    inlineAttach?: {
+      attachToCodeMirror: (
+        editor: CodeMirrorLegacyAdapter,
+        options: Record<string, unknown>
+      ) => void;
+    };
+  }
+}
+
+// CodeMirror5-compatible adapter used to migrate existing usages of initializeCodeMirror (which uses CM5).
+interface CodeMirrorLegacyAdapter {
+  getValue: () => string;
+  setValue: (value: string) => void;
+  getWrapperElement: () => HTMLElement;
+  getCursor: () => number;
+  setCursor: (position: number) => void;
+  on: (event: string, listener: (...args: unknown[]) => void) => void;
+}
+
+interface Options {
+  callback?: (editor: CodeMirrorLegacyAdapter, update: ViewUpdate) => void;
+  attachments?: boolean;
+  preview?: string | Element;
+  game?: string;
+}
+
+type EditorMode = 'javascript' | 'json' | 'markdown' | 'xml' | 'html';
 
 const levelbuilderEditorTheme = EditorView.theme({
   '&': {
     border: '1px solid #eee',
   },
 });
-
-// CodeMirror5-compatible adapter used to migrate existing usages of initializeCodeMirror (which uses CM5).
-interface CodeMirrorLegacyAdapter {
-  getValue: () => string;
-  setValue: (value: string) => void;
-  on: (event: string, listener: () => void) => void;
-}
-
-interface Options {
-  callback?: (editor: CodeMirrorLegacyAdapter, update: ViewUpdate) => void;
-  preview?: string | Element;
-  game?: string;
-}
-
-type EditorMode = 'javascript' | 'json' | 'markdown' | 'xml' | 'html';
 
 const languageExtensionMap: Record<EditorMode, Extension> = {
   javascript: javascript(),
@@ -85,8 +101,11 @@ function initializeCodeMirror6(
   options: Options = {}
 ): CodeMirrorLegacyAdapter {
   const node = resolveTarget(target);
-  const {callback, preview, game} = options;
+  const {callback, attachments, preview, game} = options;
   const changeListeners: Array<() => void> = [];
+  const dropListeners: Array<
+    (instance: CodeMirrorLegacyAdapter, event: DragEvent) => void
+  > = [];
   const editorContainer = document.createElement('div');
   node.style.display = 'none';
   node.insertAdjacentElement('afterend', editorContainer);
@@ -102,9 +121,29 @@ function initializeCodeMirror6(
         changes: {from: 0, to: editor.state.doc.length, insert: value},
       });
     },
+    getWrapperElement() {
+      return editor.dom;
+    },
+    // inline-attach only uses getCursor/setCursor as a round-trip pair around setValue,
+    // so we simply get/set the cursor position as an absolute offset within the document.
+    getCursor() {
+      return editor.state.selection.main.head;
+    },
+    setCursor(position) {
+      editor.dispatch({
+        selection: {anchor: position},
+      });
+    },
     on(event, listener) {
       if (event === 'change') {
-        changeListeners.push(listener);
+        changeListeners.push(() => listener());
+      } else if (event === 'drop') {
+        dropListeners.push(
+          listener as (
+            instance: CodeMirrorLegacyAdapter,
+            event: DragEvent
+          ) => void
+        );
       }
     },
   };
@@ -145,6 +184,11 @@ function initializeCodeMirror6(
     getLanguageExtension(mode),
     levelbuilderEditorTheme,
     EditorView.lineWrapping,
+    EditorView.domEventHandlers({
+      drop(event) {
+        dropListeners.forEach(listener => listener(adapter, event));
+      },
+    }),
     EditorView.updateListener.of(update => {
       if (!update.docChanged) {
         return;
@@ -167,6 +211,34 @@ function initializeCodeMirror6(
   });
 
   updatePreview();
+
+  if (attachments && window.inlineAttach?.attachToCodeMirror) {
+    const csrfToken =
+      document.querySelector<HTMLMetaElement>('meta[name="csrf-token"]')
+        ?.content || '';
+
+    // Default options assume markdown mode.
+    const attachOptions = {
+      uploadUrl: '/level_assets/upload',
+      uploadFieldName: 'file',
+      downloadFieldName: 'newAssetUrl',
+      allowedTypes: ['image/jpeg', 'image/png', 'image/jpg', 'image/gif'],
+      progressText: '![Uploading file...]()',
+      urlText: '![]({filename})',
+      errorText: 'Error uploading file; images must be no larger than 2MB',
+      extraHeaders: {
+        'X-CSRF-Token': csrfToken,
+      },
+    };
+
+    // Adjust options for javascript mode, which doesn't use markdown syntax for attachments.
+    if (mode === 'javascript') {
+      attachOptions.progressText = '"Uploading file..."';
+      attachOptions.urlText = '"{filename}"';
+    }
+
+    window.inlineAttach.attachToCodeMirror(adapter, attachOptions);
+  }
 
   return adapter;
 }

--- a/apps/src/code-studio/initializeCodeMirror6.ts
+++ b/apps/src/code-studio/initializeCodeMirror6.ts
@@ -105,9 +105,7 @@ function initializeCodeMirror6(
   const node = resolveTarget(target);
   const {callback, attachments, preview, game} = options;
   const changeListeners: Array<() => void> = [];
-  const dropListeners: Array<
-    (instance: CodeMirrorLegacyAdapter, event: DragEvent) => void
-  > = [];
+  const dropListeners: Array<(event: DragEvent) => void> = [];
   const editorContainer = document.createElement('div');
   node.style.display = 'none';
   node.insertAdjacentElement('afterend', editorContainer);
@@ -140,11 +138,9 @@ function initializeCodeMirror6(
       if (event === 'change') {
         changeListeners.push(() => listener());
       } else if (event === 'drop') {
-        dropListeners.push(
-          listener as (
-            instance: CodeMirrorLegacyAdapter,
-            event: DragEvent
-          ) => void
+        // This is here to support inline-attach, and inline-attach doesn't use the first argument to its drop event listener, so we ignore it here as well.
+        dropListeners.push((dropEvent: DragEvent) =>
+          listener(undefined, dropEvent)
         );
       }
     },
@@ -188,7 +184,7 @@ function initializeCodeMirror6(
     EditorView.lineWrapping,
     EditorView.domEventHandlers({
       drop(event) {
-        dropListeners.forEach(listener => listener(adapter, event));
+        dropListeners.forEach(listener => listener(event));
       },
     }),
     EditorView.updateListener.of(update => {

--- a/apps/src/code-studio/initializeEmbeddedMarkdownEditor.js
+++ b/apps/src/code-studio/initializeEmbeddedMarkdownEditor.js
@@ -1,8 +1,4 @@
-/**
- * @file Defines a function for initializing an embedded markdown editor using
- *       CodeMirror
- */
-var initializeCodeMirror = require('./initializeCodeMirror');
+import initializeCodeMirror6 from './initializeCodeMirror6';
 
 /**
  * Initializes a live preview markdown editor that spits its contents out into
@@ -33,7 +29,7 @@ module.exports = function (
   var dslElement = embeddedElement;
   var dslText = dslElement.val();
 
-  var mdEditor = initializeCodeMirror(markdownTextArea, 'markdown', {
+  var mdEditor = initializeCodeMirror6(markdownTextArea, 'markdown', {
     callback: function (editor, change) {
       var editorText = editor.getValue();
       var dslText = dslElement.val();

--- a/dashboard/app/views/levels/editors/fields/_artist_fields.html.haml
+++ b/dashboard/app/views/levels/editors/fields/_artist_fields.html.haml
@@ -55,4 +55,4 @@
       %p Paste or drag images into this field to upload them, similar to adding images to Long Instructions.
     = f.text_area :images, placeholder: 'Images', rows: 4, value: @level.properties['images']
     :javascript
-      levelbuilder.initializeCodeMirror('level_images', 'javascript', {attachments: true});
+      levelbuilder.initializeCodeMirror6('level_images', 'json', {attachments: true});

--- a/dashboard/app/views/levels/editors/fields/_authored_hints.haml
+++ b/dashboard/app/views/levels/editors/fields/_authored_hints.haml
@@ -62,7 +62,7 @@
         wrapper: ".json_editor",
         onNewSpace: function (space) {
           space.find('.hint_id').get(0).setAttribute("required", "");
-          levelbuilder.initializeCodeMirror(
+          levelbuilder.initializeCodeMirror6(
             space.find('.hint_markdown').get(0),
             'markdown',
             {

--- a/dashboard/app/views/levels/editors/fields/_long_instructions.html.haml
+++ b/dashboard/app/views/levels/editors/fields/_long_instructions.html.haml
@@ -17,7 +17,7 @@
 
 
 :javascript
-  var mdEditor = levelbuilder.initializeCodeMirror('level_long_instructions', 'markdown', {
+  var mdEditor = levelbuilder.initializeCodeMirror6('level_long_instructions', 'markdown', {
     callback: function (editor, change) {
       const xmlContainer = document.getElementById('level_long_instructions_preview');
 


### PR DESCRIPTION
Adds the `attachments` option to the CodeMirror6 wrapper, which allows drag and drop of images (and automagic upload) on drop. Migrates existing usages of the CM5 wrapper to CM6 now that this feature is available.

This was implemented by leaving the third party `inline-attach` code intact, and adding a couple more adapter methods to allow it to continue to function as expected. Another option here would have been to implement drag and drop from scratch in a native CM6 way, but I decided against that. It was not super complicated to use the adapter to support the existing add-on, and I didn't want to drag this work out too much 😅 .

https://github.com/user-attachments/assets/4edadece-4fae-4c25-be08-55d4baa7f8b0

## Testing story

I tested this manually in each site where I've migrated from CM5 -> 6 in this PR, including the "long instructions" editor that is very commonly used on level edit pages. I tested both copy/paste and drag and drop functioned as expected.