### PR TITLE
Hide tutor in legacy labs share view

### DIFF
--- a/apps/src/templates/instructions/InstructionsWithWorkspace.jsx
+++ b/apps/src/templates/instructions/InstructionsWithWorkspace.jsx
@@ -35,6 +35,7 @@ export class UnwrappedInstructionsWithWorkspace extends React.Component {
     setInstructionsMaxHeightAvailable: PropTypes.func.isRequired,
     labType: PropTypes.string,
     aiChatAccessLevel: PropTypes.string,
+    isShareView: PropTypes.bool,
   };
 
   state = {
@@ -117,6 +118,7 @@ export class UnwrappedInstructionsWithWorkspace extends React.Component {
       instructionsHeight,
       labType,
       aiChatAccessLevel,
+      isShareView,
       children,
     } = this.props;
 
@@ -129,6 +131,7 @@ export class UnwrappedInstructionsWithWorkspace extends React.Component {
     });
 
     const showAiTutor =
+      !isShareView &&
       AI_TUTOR_LEGACY_LABS.includes(labType) &&
       shouldShowAiTutor({
         appName: labType,
@@ -184,6 +187,7 @@ export default connect(
     instructionsHeight: state.instructions.renderedHeight,
     labType: state.pageConstants.appType,
     aiChatAccessLevel: state.currentUser.aiChatAccessLevel,
+    isShareView: state.pageConstants.isShareView,
   }),
   dispatch => ({
     setInstructionsMaxHeightAvailable(maxHeight) {

--- a/apps/test/unit/templates/instructions/InstructionsWithWorkspaceTest.jsx
+++ b/apps/test/unit/templates/instructions/InstructionsWithWorkspaceTest.jsx
@@ -4,6 +4,11 @@ import React from 'react';
 
 import {UnwrappedInstructionsWithWorkspace as InstructionsWithWorkspace} from '@cdo/apps/templates/instructions/InstructionsWithWorkspace';
 
+jest.mock('@cdo/apps/aichat/helpers/aiChatAccess', () => ({
+  shouldShowAiTutor: jest.fn(() => true),
+  areAiChatToolsEnabled: jest.fn(() => true),
+}));
+
 describe('InstructionsWithWorkspace', () => {
   it('renders instructions and code workspace', () => {
     const wrapper = shallow(
@@ -28,6 +33,40 @@ describe('InstructionsWithWorkspace', () => {
       windowWidth: undefined,
       windowHeight: undefined,
       aiChatOpen: false,
+    });
+  });
+
+  describe('AI tutor visibility', () => {
+    beforeEach(() => {
+      window.appOptions = {level: {aiTutorAvailable: true}};
+    });
+
+    afterEach(() => {
+      delete window.appOptions;
+    });
+
+    it('does not render AI tutor in share view', () => {
+      const wrapper = shallow(
+        <InstructionsWithWorkspace
+          instructionsHeight={400}
+          setInstructionsMaxHeightAvailable={() => {}}
+          labType="applab"
+          isShareView={true}
+        />
+      );
+      expect(wrapper.find('AiTutorContainer')).toHaveLength(0);
+    });
+
+    it('renders AI tutor when not in share view', () => {
+      const wrapper = shallow(
+        <InstructionsWithWorkspace
+          instructionsHeight={400}
+          setInstructionsMaxHeightAvailable={() => {}}
+          labType="applab"
+          isShareView={false}
+        />
+      );
+      expect(wrapper.find('AiTutorContainer')).toHaveLength(1);
     });
   });
 


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

Hide tutor in legacy labs share view.

## Links
<!--  Links to relevant external resources.
      - spec docs, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- Zendesk tickets: [1](https://codeorg.zendesk.com/agent/tickets/578912) [2 ](https://codeorg.zendesk.com/agent/tickets/578908)
- [slack thread](https://codedotorg.slack.com/archives/C09V7TWT4Q2/p1772488252528289)

## Testing story
<!--  Does your change include appropriate tests?
      - If so, please describe how the tests included in this PR are sufficient.
      - If not, please explain why this change does not need to be tested. -->
Tested manually on game lab.
Added UTs.
For lab2, tutor is in the resource panel which doesn't render in share view. The bug is only in legacy labs.


Before:
<img width="1024" height="837" alt="image" src="https://github.com/user-attachments/assets/96daf1f2-64d2-438b-bab6-6ff35f2e4649" />

After:
<img width="1027" height="835" alt="image" src="https://github.com/user-attachments/assets/1ca64100-5ad7-4e41-9541-4c61acd2a531" />

