### PR TITLE
When teacher views a level, make tutor use the ai_chat_access_level of the selected section

### DIFF
--- a/apps/src/code-studio/components/progress/teacherPanel/teacherPanelData.js
+++ b/apps/src/code-studio/components/progress/teacherPanel/teacherPanelData.js
@@ -32,6 +32,7 @@ export const queryLockStatus = async scriptId => {
     const teacherSections = Object.values(data).map(section => ({
       id: section.section_id,
       name: section.section_name,
+      ai_chat_access_level: section.ai_chat_access_level,
     }));
 
     return {

--- a/apps/src/templates/instructions/InstructionsWithWorkspace.jsx
+++ b/apps/src/templates/instructions/InstructionsWithWorkspace.jsx
@@ -10,6 +10,7 @@ import {
   shouldShowAiTutor,
 } from '@cdo/apps/aichat/helpers/aiChatAccess';
 import {AI_TUTOR_LEGACY_LABS} from '@cdo/apps/aiTutor/views/legacyLabs/constants';
+import {selectedSectionSelector} from '@cdo/apps/templates/teacherDashboard/teacherSectionsReduxSelectors';
 
 import {AiTutorContainer} from '../../aiTutor/views/legacyLabs/AiTutorContainer';
 import {setInstructionsMaxHeightAvailable} from '../../redux/instructions';
@@ -186,8 +187,10 @@ export default connect(
   state => ({
     instructionsHeight: state.instructions.renderedHeight,
     labType: state.pageConstants.appType,
-    aiChatAccessLevel: state.currentUser.aiChatAccessLevel,
     isShareView: state.pageConstants.isShareView,
+    aiChatAccessLevel:
+      selectedSectionSelector(state)?.aiChatAccessLevel ??
+      state.currentUser.aiChatAccessLevel,
   }),
   dispatch => ({
     setInstructionsMaxHeightAvailable(maxHeight) {

--- a/apps/src/templates/instructions/InstructionsWithWorkspace.jsx
+++ b/apps/src/templates/instructions/InstructionsWithWorkspace.jsx
@@ -189,8 +189,9 @@ export default connect(
     labType: state.pageConstants.appType,
     isShareView: state.pageConstants.isShareView,
     aiChatAccessLevel:
-      selectedSectionSelector(state)?.aiChatAccessLevel ??
-      state.currentUser.aiChatAccessLevel,
+      (state.teacherSections
+        ? selectedSectionSelector(state)?.aiChatAccessLevel
+        : undefined) ?? state.currentUser.aiChatAccessLevel,
   }),
   dispatch => ({
     setInstructionsMaxHeightAvailable(maxHeight) {

--- a/apps/test/unit/templates/instructions/InstructionsWithWorkspaceTest.jsx
+++ b/apps/test/unit/templates/instructions/InstructionsWithWorkspaceTest.jsx
@@ -4,16 +4,6 @@ import React from 'react';
 
 import {UnwrappedInstructionsWithWorkspace as InstructionsWithWorkspace} from '@cdo/apps/templates/instructions/InstructionsWithWorkspace';
 
-jest.mock('@cdo/apps/aichat/helpers/aiChatAccess', () => ({
-  shouldShowAiTutor: jest.fn(() => true),
-  areAiChatToolsEnabled: jest.fn(() => true),
-}));
-
-jest.mock('@cdo/apps/aichat/helpers/aiChatAccess', () => ({
-  shouldShowAiTutor: jest.fn(() => true),
-  areAiChatToolsEnabled: jest.fn(() => true),
-}));
-
 describe('InstructionsWithWorkspace', () => {
   it('renders instructions and code workspace', () => {
     const wrapper = shallow(
@@ -69,6 +59,7 @@ describe('InstructionsWithWorkspace', () => {
           setInstructionsMaxHeightAvailable={() => {}}
           labType="applab"
           isShareView={false}
+          aiChatAccessLevel="enabled"
         />
       );
       expect(wrapper.find('AiTutorContainer')).toHaveLength(1);

--- a/apps/test/unit/templates/instructions/InstructionsWithWorkspaceTest.jsx
+++ b/apps/test/unit/templates/instructions/InstructionsWithWorkspaceTest.jsx
@@ -9,6 +9,11 @@ jest.mock('@cdo/apps/aichat/helpers/aiChatAccess', () => ({
   areAiChatToolsEnabled: jest.fn(() => true),
 }));
 
+jest.mock('@cdo/apps/aichat/helpers/aiChatAccess', () => ({
+  shouldShowAiTutor: jest.fn(() => true),
+  areAiChatToolsEnabled: jest.fn(() => true),
+}));
+
 describe('InstructionsWithWorkspace', () => {
   it('renders instructions and code workspace', () => {
     const wrapper = shallow(
@@ -67,6 +72,32 @@ describe('InstructionsWithWorkspace', () => {
         />
       );
       expect(wrapper.find('AiTutorContainer')).toHaveLength(1);
+    });
+
+    it('renders AI tutor when selected section has AI enabled', () => {
+      const wrapper = shallow(
+        <InstructionsWithWorkspace
+          instructionsHeight={400}
+          setInstructionsMaxHeightAvailable={() => {}}
+          labType="applab"
+          isShareView={false}
+          aiChatAccessLevel="enabled"
+        />
+      );
+      expect(wrapper.find('AiTutorContainer')).toHaveLength(1);
+    });
+
+    it('does not render AI tutor when selected section has AI disabled', () => {
+      const wrapper = shallow(
+        <InstructionsWithWorkspace
+          instructionsHeight={400}
+          setInstructionsMaxHeightAvailable={() => {}}
+          labType="applab"
+          isShareView={false}
+          aiChatAccessLevel="disabled"
+        />
+      );
+      expect(wrapper.find('AiTutorContainer')).toHaveLength(0);
     });
   });
 

--- a/dashboard/app/controllers/api_controller.rb
+++ b/dashboard/app/controllers/api_controller.rb
@@ -198,6 +198,7 @@ class ApiController < ApplicationController
       section_hash[section.id] = {
         section_id: section.id,
         section_name: section.name,
+        ai_chat_access_level: section.ai_chat_access_level,
         lessons: script.lessons.each_with_object({}) do |lesson, lesson_hash|
           lesson_state = lesson.lockable_state(section.students)
           lesson_hash[lesson.id] = lesson_state unless lesson_state.nil?

--- a/dashboard/test/controllers/api_controller_test.rb
+++ b/dashboard/test/controllers/api_controller_test.rb
@@ -283,6 +283,7 @@ class ApiControllerTest < ActionController::TestCase
     section_response = body[@section.id.to_s]
     assert_equal @section.id, section_response['section_id']
     assert_equal @section.name, section_response['section_name']
+    assert_equal @section.ai_chat_access_level, section_response['ai_chat_access_level']
     assert_equal 1, section_response['lessons'].length
 
     lessons_response = section_response['lessons']


### PR DESCRIPTION
<!--
  Summary of the change: background, motivation, and context.
  Include screenshots, videos, or before/after comparisons for UI changes.
-->

This PR adds ai_chat_access_level to the data loaded by the teacher panel at minimum. This allows us to use the currently selected section to derive our ai_chat_access_level for the current level, so the teacher can see a view that is closer to what the student sees.

We previously implemented the feature to let the teacher see tutor all the time, but have gotten loud and clear feedback in the first day that teachers don't want to see tutor if they have it disabled for their students, particularly while grading.

This means teachers aren't going to see or be able to play with tutor unless they enable it for a section (or navigate to a level without a section selected). If teachers want to play with it, they can make an empty section and enable it for themselves to play with, or navigate to levels without a section selected. 

NOTES: 
 - This is implemented only for legacy labs at the moment. I will follow up with lab2.
 - This is not a perfect proxy for what the student will see. The student might have access to tutor via another section.
 - Teachers can still see tutor if they navigate to a level without a section_id or user_id set.  I'm not sure if it's possible to get a url without a section_id as a teacher navigating the site, so it might only be possible if the teacher manually modifies the url.

## Links
<!-- Jira tickets, design docs, Slack threads, related PRs, etc. -->

- [slack discussion](https://codedotorg.slack.com/archives/C09V7TWT4Q2/p1772513982560179)

## Testing story
<!-- How was this tested? Manual steps, adhoc links, automated tests, or why testing isn't needed. -->

Teacher navigates via progress view. Teacher panel is set to teacher view of student's work in a given section in a given level via query params: http://localhost-studio.code.org:3000/courses/csd-2025/units/2/lessons/2/levels/6/sublevel/1?section_id=6&user_id=7

If ai_chat_access_level enabled in the section, teacher sees student's chat history:
<img width="1029" height="832" alt="image" src="https://github.com/user-attachments/assets/e9aa19f9-0c32-4cb2-9b72-bc0db46dd934" />

If disabled, teacher sees no tutor:
<img width="1026" height="806" alt="image" src="https://github.com/user-attachments/assets/df756e83-353c-49bc-84a2-d3e378709895" />

Teacher navigates to level with just the section_id set:
http://localhost-studio.code.org:3000/courses/csd-2025/units/2/lessons/2/levels/6/sublevel/1?section_id=6

Tutor is hidden if disabled:
<img width="353" height="509" alt="image" src="https://github.com/user-attachments/assets/28902d55-6ef0-4bbc-84d4-a4f38449551b" />

Teacher navigates to level without section_id or user_id set:
Tutor is visible for teacher, no selected section exists in teacher panel
<img width="318" height="423" alt="image" src="https://github.com/user-attachments/assets/a99e4199-11c0-4baf-bed5-03f7a5abba11" />

## Follow-up

Implement for lab2 (python lab, and discuss whether we want this in weblab2 and chat lab)
