### PR TITLE
Lab2: collapse version history

### DIFF
--- a/apps/src/lab2/views/components/Instructions/ResourcePanel/index.tsx
+++ b/apps/src/lab2/views/components/Instructions/ResourcePanel/index.tsx
@@ -377,6 +377,13 @@ const ResourcePanel: React.FC<ResourcePanelProps> = ({
     return Object.keys(availableTabs).length > 0;
   }, [availableTabs]);
 
+  const hasOnlyVersionHistoryTab = useMemo(() => {
+    return (
+      Object.keys(availableTabs).length === 1 &&
+      availableTabs[Tabs.VersionHistory] !== undefined
+    );
+  }, [availableTabs]);
+
   const floatingSettingsPanelStyles = usePanelPosition(
     isFloatingSettingsOpen,
     hasTabs,
@@ -386,12 +393,17 @@ const ResourcePanel: React.FC<ResourcePanelProps> = ({
 
   useEffect(() => {
     // Auto-collapse on initial mount if on a standalone project and there are no available tabs.
+    // Also auto-collapse if the only available tab is version history.
     // Only run this once to allow user to toggle the panel.
-    if (!hasAutoCollapsedNoTabs.current && isProjectLevel && !hasTabs) {
+    if (
+      !hasAutoCollapsedNoTabs.current &&
+      isProjectLevel &&
+      (!hasTabs || hasOnlyVersionHistoryTab)
+    ) {
       dispatch(setIsStandaloneCollapsed(true));
       hasAutoCollapsedNoTabs.current = true;
     }
-  }, [isProjectLevel, hasTabs, dispatch]);
+  }, [isProjectLevel, hasTabs, dispatch, hasOnlyVersionHistoryTab]);
 
   useEffect(() => {
     if (currentTab === undefined && Object.keys(availableTabs).length > 0) {


### PR DESCRIPTION
This small PR proposes auto-collapsing the resource panel if the only tab upon initial render is version history.

This impetus for this change was visiting https://studio.code.org/projects/music/new and seeing a version history pane for a new project.  It feels much cleaner to collapse this when presenting the blank slate of a new project.

### before

<img width="1105" height="679" alt="Screenshot 2026-03-03 at 8 03 52 PM" src="https://github.com/user-attachments/assets/769827b8-5b33-430d-b0c9-f50d73b0949d" />

### after

<img width="1105" height="679" alt="Screenshot 2026-03-03 at 8 04 34 PM" src="https://github.com/user-attachments/assets/9f744b82-600f-41b6-acf3-309de4010324" />
