### PR TITLE
Send analytics event for final question of JIT Personalization quiz

### DIFF
--- a/apps/src/aiDifferentiation/personalization/PersonalizationCollectorContainer.tsx
+++ b/apps/src/aiDifferentiation/personalization/PersonalizationCollectorContainer.tsx
@@ -44,16 +44,17 @@ const PersonalizationCollectorContainer: React.FC = () => {
     useTeachingProfileData();
 
   const onCarouselPress = async (direction: number) => {
+    if (direction === NEXT && !showInterstitialState) {
+      analyticsReporter.sendEvent(EVENTS.PERSONALIZATION_ANSWER_SUBMITTED, {
+        question: PERSONALIZATION_PROMPTS[questionsNumber].question,
+        questionNumber: questionsNumber + 1,
+      });
+    }
+
     if (
       direction === NEXT &&
       questionsNumber < PERSONALIZATION_PROMPTS.length - 1
     ) {
-      if (!showInterstitialState) {
-        analyticsReporter.sendEvent(EVENTS.PERSONALIZATION_ANSWER_SUBMITTED, {
-          question: PERSONALIZATION_PROMPTS[questionsNumber].question,
-          questionNumber: questionsNumber + 1,
-        });
-      }
       setIsSaving(true);
       try {
         await saveTeachingProfileData(personalizationData);


### PR DESCRIPTION
The Statsig event hasn't been firing for the final screen of the personalization quiz due to a classic off-by-one error. Given how many conditionals are involved here, I pulled out firing the statsig event as I think we want it to fire no mattter what question we're on, but we only want to fire it when the user hits next on a non-interstitial page.

I manually verified there was no statsig event on the staging branch but the event did fire with this change.



