### PR TITLE
Add WorkableQueuedJobCount metric to ActiveJob metrics

### DIFF
--- a/dashboard/app/jobs/concerns/active_job_metrics.rb
+++ b/dashboard/app/jobs/concerns/active_job_metrics.rb
@@ -55,12 +55,12 @@ module ActiveJobMetrics
   end
 
   # Workable jobs are queued jobs that are eligible to run now (run_at is not in the future)
-  def self.workable_jobs
+  def self.workable_queued_jobs
     queued_jobs.where('run_at <= ?', _now_utc)
   end
 
-  def workable_jobs
-    mine(ActiveJobMetrics.workable_jobs)
+  def workable_queued_jobs
+    mine(ActiveJobMetrics.workable_queued_jobs)
   end
 
   # Overridable for testing
@@ -118,8 +118,8 @@ module ActiveJobMetrics
         dimensions: dimensions,
       },
       {
-        metric_name: 'WorkableJobCount',
-        value: job_class.workable_jobs.count,
+        metric_name: 'WorkableQueuedJobCount',
+        value: job_class.workable_queued_jobs.count,
         unit: 'Count',
         timestamp: Time.now,
         dimensions: dimensions,

--- a/dashboard/app/jobs/concerns/active_job_metrics.rb
+++ b/dashboard/app/jobs/concerns/active_job_metrics.rb
@@ -54,6 +54,15 @@ module ActiveJobMetrics
     mine(ActiveJobMetrics.queued_jobs)
   end
 
+  # Workable jobs are queued jobs that are eligible to run now (run_at is not in the future)
+  def self.workable_jobs
+    queued_jobs.where('run_at <= ?', _now_utc)
+  end
+
+  def workable_jobs
+    mine(ActiveJobMetrics.workable_jobs)
+  end
+
   # Overridable for testing
   def self._now_utc
     Time.now.utc
@@ -104,6 +113,13 @@ module ActiveJobMetrics
       {
         metric_name: 'QueuedJobCount',
         value: job_class.queued_jobs.count,
+        unit: 'Count',
+        timestamp: Time.now,
+        dimensions: dimensions,
+      },
+      {
+        metric_name: 'WorkableJobCount',
+        value: job_class.workable_jobs.count,
         unit: 'Count',
         timestamp: Time.now,
         dimensions: dimensions,

--- a/dashboard/test/jobs/application_job_test.rb
+++ b/dashboard/test/jobs/application_job_test.rb
@@ -37,11 +37,13 @@ class ApplicationJobTest < ActiveJob::TestCase
     @expected_my_failed_count = 1
     @expected_my_waiting_to_start_count = 1
     @expected_my_pending_count = 2
+    @expected_my_workable_count = 2
     @expected_my_queued_count = 3
 
     @expected_failed_count = @expected_my_failed_count * 2
     @expected_waiting_to_start_count = @expected_my_waiting_to_start_count * 2
     @expected_pending_count = @expected_my_pending_count * 2
+    @expected_workable_count = @expected_my_workable_count * 2
     @expected_queued_count = @expected_my_queued_count * 2
   end
 
@@ -78,6 +80,11 @@ class ApplicationJobTest < ActiveJob::TestCase
     assert_equal @expected_my_failed_count, ApplicationJob.new.failed_jobs.count
   end
 
+  test 'workable_jobs.count returns the number of workable jobs' do
+    assert_equal @expected_workable_count, ActiveJobMetrics.workable_jobs.count
+    assert_equal @expected_my_workable_count, ApplicationJob.new.workable_jobs.count
+  end
+
   test 'waiting_to_start_jobs.count returns the number of jobs waiting to start' do
     assert_equal @expected_waiting_to_start_count, ActiveJobMetrics.waiting_to_start_jobs.count
     assert_equal @expected_my_waiting_to_start_count, ApplicationJob.new.waiting_to_start_jobs.count
@@ -104,11 +111,13 @@ class ApplicationJobTest < ActiveJob::TestCase
       all_of(
         includes_metrics(
           QueuedJobCount: @expected_queued_count,
+          WorkableJobCount: @expected_workable_count,
           FailedJobCount: @expected_failed_count,
           PendingJobCount: @expected_pending_count,
           WaitingToStartJobCount: @expected_waiting_to_start_count,
         ),
         includes_dimensions(:QueuedJobCount, Environment: CDO.rack_env),
+        includes_dimensions(:WorkableJobCount, Environment: CDO.rack_env),
         includes_dimensions(:FailedJobCount, Environment: CDO.rack_env),
         includes_dimensions(:PendingJobCount, Environment: CDO.rack_env),
         includes_dimensions(:WaitingToStartJobCount, Environment: CDO.rack_env),
@@ -121,11 +130,13 @@ class ApplicationJobTest < ActiveJob::TestCase
       all_of(
         includes_metrics(
           QueuedJobCount: @expected_my_queued_count,
+          WorkableJobCount: @expected_my_workable_count,
           FailedJobCount: @expected_my_failed_count,
           PendingJobCount: @expected_my_pending_count,
           WaitingToStartJobCount: @expected_my_waiting_to_start_count,
         ),
         includes_dimensions(:QueuedJobCount, Environment: CDO.rack_env, JobName: 'ApplicationJobTest::TestableJob'),
+        includes_dimensions(:WorkableJobCount, Environment: CDO.rack_env, JobName: 'ApplicationJobTest::TestableJob'),
         includes_dimensions(:FailedJobCount, Environment: CDO.rack_env, JobName: 'ApplicationJobTest::TestableJob'),
         includes_dimensions(:PendingJobCount, Environment: CDO.rack_env, JobName: 'ApplicationJobTest::TestableJob'),
         includes_dimensions(:WaitingToStartJobCount, Environment: CDO.rack_env, JobName: 'ApplicationJobTest::TestableJob'),

--- a/dashboard/test/jobs/application_job_test.rb
+++ b/dashboard/test/jobs/application_job_test.rb
@@ -80,9 +80,9 @@ class ApplicationJobTest < ActiveJob::TestCase
     assert_equal @expected_my_failed_count, ApplicationJob.new.failed_jobs.count
   end
 
-  test 'workable_jobs.count returns the number of workable jobs' do
-    assert_equal @expected_workable_count, ActiveJobMetrics.workable_jobs.count
-    assert_equal @expected_my_workable_count, ApplicationJob.new.workable_jobs.count
+  test 'workable_queued_jobs.count returns the number of workable jobs' do
+    assert_equal @expected_workable_count, ActiveJobMetrics.workable_queued_jobs.count
+    assert_equal @expected_my_workable_count, ApplicationJob.new.workable_queued_jobs.count
   end
 
   test 'waiting_to_start_jobs.count returns the number of jobs waiting to start' do
@@ -111,13 +111,13 @@ class ApplicationJobTest < ActiveJob::TestCase
       all_of(
         includes_metrics(
           QueuedJobCount: @expected_queued_count,
-          WorkableJobCount: @expected_workable_count,
+          WorkableQueuedJobCount: @expected_workable_count,
           FailedJobCount: @expected_failed_count,
           PendingJobCount: @expected_pending_count,
           WaitingToStartJobCount: @expected_waiting_to_start_count,
         ),
         includes_dimensions(:QueuedJobCount, Environment: CDO.rack_env),
-        includes_dimensions(:WorkableJobCount, Environment: CDO.rack_env),
+        includes_dimensions(:WorkableQueuedJobCount, Environment: CDO.rack_env),
         includes_dimensions(:FailedJobCount, Environment: CDO.rack_env),
         includes_dimensions(:PendingJobCount, Environment: CDO.rack_env),
         includes_dimensions(:WaitingToStartJobCount, Environment: CDO.rack_env),
@@ -130,13 +130,13 @@ class ApplicationJobTest < ActiveJob::TestCase
       all_of(
         includes_metrics(
           QueuedJobCount: @expected_my_queued_count,
-          WorkableJobCount: @expected_my_workable_count,
+          WorkableQueuedJobCount: @expected_my_workable_count,
           FailedJobCount: @expected_my_failed_count,
           PendingJobCount: @expected_my_pending_count,
           WaitingToStartJobCount: @expected_my_waiting_to_start_count,
         ),
         includes_dimensions(:QueuedJobCount, Environment: CDO.rack_env, JobName: 'ApplicationJobTest::TestableJob'),
-        includes_dimensions(:WorkableJobCount, Environment: CDO.rack_env, JobName: 'ApplicationJobTest::TestableJob'),
+        includes_dimensions(:WorkableQueuedJobCount, Environment: CDO.rack_env, JobName: 'ApplicationJobTest::TestableJob'),
         includes_dimensions(:FailedJobCount, Environment: CDO.rack_env, JobName: 'ApplicationJobTest::TestableJob'),
         includes_dimensions(:PendingJobCount, Environment: CDO.rack_env, JobName: 'ApplicationJobTest::TestableJob'),
         includes_dimensions(:WaitingToStartJobCount, Environment: CDO.rack_env, JobName: 'ApplicationJobTest::TestableJob'),


### PR DESCRIPTION
Reports the count of queued jobs eligible to run now (run_at <= now), excluding jobs scheduled for the future. Emitted alongside QueuedJobCount on every enqueue event.

<!--
  Summary of the change: background, motivation, and context.
  Include screenshots, videos, or before/after comparisons for UI changes.
-->



## Links
<!-- Jira tickets, design docs, Slack threads, related PRs, etc. -->

- Jira:

## Testing story
<!-- How was this tested? Manual steps, adhoc links, automated tests, or why testing isn't needed. -->

Added new unit tests.