### PR TITLE
Cron Job to Monitor Zero ETL Integration

### DIFF
--- a/bin/cron/monitor_mysql_to_redshift_zeroetl_integration
+++ b/bin/cron/monitor_mysql_to_redshift_zeroetl_integration
@@ -1,0 +1,54 @@
+#!/usr/bin/env ruby
+
+require_relative 'only_one'
+require_relative '../../dashboard/config/environment'
+require 'cdo/aws/redshift'
+require 'cdo/chat_client'
+
+NOTIFY_CHANNEL = 'data-alerts'
+ENVIRONMENT_TYPE = CDO.rack_env.to_s
+TARGET_DB = "#{ENVIRONMENT_TYPE}_learningplatform_mysql_zeroetl"
+REDSHIFT_SQL_USER = 'etl_client'
+
+# @param message [String] the (base) error message to log.
+def alert(message)
+  CDO.log.warn message
+  ChatClient.message(NOTIFY_CHANNEL, message, color: 'red') if ENVIRONMENT_TYPE == 'production'
+end
+
+def main
+  redshift = Cdo::Redshift.new(db_user: REDSHIFT_SQL_USER)
+
+  # Check Integration-level status
+  # Expected healthy states are 'Active' or temporarily 'Syncing'
+  integration_query = <<~SQL
+    SELECT integration_id, state, error_message
+    FROM SVV_INTEGRATION
+    WHERE target_database = '#{TARGET_DB}'
+      AND state NOT IN ('Active', 'Syncing');
+  SQL
+
+  integrations = redshift.execute(integration_query)
+  integrations.each do |integration|
+    alert("🚨 *Zero-ETL Integration Alert (#{ENVIRONMENT_TYPE})*\nIntegration `#{integration['integration_id']}` is in state `#{integration['state']}`.\nError: #{integration['error_message']}")
+  end
+
+  # Check Table-level sync status
+  # We specifically look for the 'Failed' state to avoid alerting on tables actively backfilling
+  table_query = <<~SQL
+    SELECT schema_name, table_name, state, error_message, last_refresh_time
+    FROM SVV_INTEGRATION_TABLE_STATE
+    WHERE database_name = '#{TARGET_DB}'
+      AND state = 'Failed';
+  SQL
+
+  tables = redshift.execute(table_query)
+  tables.each do |table|
+    alert("🚨 *Zero-ETL Table Sync Alert (#{ENVIRONMENT_TYPE})*\nTable `#{table['schema_name']}.#{table['table_name']}` failed to sync.\nError: #{table['error_message']}\nLast Refresh: #{table['last_refresh_time']}")
+  end
+rescue => exception
+  alert("💥 *Zero-ETL Monitor Script Failed (#{ENVIRONMENT_TYPE})*\nException: #{exception.message}")
+  raise exception
+end
+
+main

--- a/bin/cron/monitor_mysql_to_redshift_zeroetl_integration
+++ b/bin/cron/monitor_mysql_to_redshift_zeroetl_integration
@@ -19,32 +19,33 @@ end
 def main
   redshift = Cdo::Redshift.new(db_user: REDSHIFT_SQL_USER)
 
-  # Check Integration-level status
-  # Expected healthy states are 'Active' or temporarily 'Syncing'
+  # Check Integration-level status.
+  # Expected healthy states are `PendingDbConnectState`, `SchemaDiscoveryState`, and `CdcRefreshState`
+  # Unhealthy state: `ErrorState`
   integration_query = <<~SQL
-    SELECT integration_id, state, error_message
+    SELECT *
     FROM SVV_INTEGRATION
-    WHERE target_database = '#{TARGET_DB}'
-      AND state NOT IN ('Active', 'Syncing');
+    WHERE target_database = '#{TARGET_DB}';
   SQL
 
   integrations = redshift.execute(integration_query)
   integrations.each do |integration|
-    alert("🚨 *Zero-ETL Integration Alert (#{ENVIRONMENT_TYPE})*\nIntegration `#{integration['integration_id']}` is in state `#{integration['state']}`.\nError: #{integration['error_message']}")
+    alert("Zero-ETL Integration Alert (#{ENVIRONMENT_TYPE})*\nIntegration `#{integration['integration_id']}` is in state `#{integration['state']}`. #{integration.to_json}") if integration['state'] == 'ErrorState'
   end
 
-  # Check Table-level sync status
-  # We specifically look for the 'Failed' state to avoid alerting on tables actively backfilling
+  # Check Table-level sync status.
+  # https://docs.aws.amazon.com/redshift/latest/dg/r_SVV_INTEGRATION_TABLE_STATE.html
+  # Possible values: `Synced`, `Failed`, `Deleted`, `ResyncRequired`, `ResyncInitiated`, and `DroppedSource`.
   table_query = <<~SQL
-    SELECT schema_name, table_name, state, error_message, last_refresh_time
+    SELECT *
     FROM SVV_INTEGRATION_TABLE_STATE
-    WHERE database_name = '#{TARGET_DB}'
-      AND state = 'Failed';
+    WHERE target_database = '#{TARGET_DB}'
+      AND (state != 'Synced' AND state != 'ResyncInitiated');
   SQL
 
   tables = redshift.execute(table_query)
   tables.each do |table|
-    alert("🚨 *Zero-ETL Table Sync Alert (#{ENVIRONMENT_TYPE})*\nTable `#{table['schema_name']}.#{table['table_name']}` failed to sync.\nError: #{table['error_message']}\nLast Refresh: #{table['last_refresh_time']}")
+    alert("Zero-ETL Table Sync Alert (#{ENVIRONMENT_TYPE})*\nTable `#{table['schema_name']}.#{table['table_name']}` failed to sync.\nDetails: #{table.to_json}")
   end
 rescue => exception
   alert("💥 *Zero-ETL Monitor Script Failed (#{ENVIRONMENT_TYPE})*\nException: #{exception.message}")

--- a/bin/cron/monitor_mysql_to_redshift_zeroetl_integration
+++ b/bin/cron/monitor_mysql_to_redshift_zeroetl_integration
@@ -40,7 +40,8 @@ def main
     SELECT *
     FROM SVV_INTEGRATION_TABLE_STATE
     WHERE target_database = '#{TARGET_DB}'
-      AND (state != 'Synced' AND state != 'ResyncInitiated');
+      AND table_state != 'Synced'
+      AND table_state != 'ResyncInitiated';
   SQL
 
   tables = redshift.execute(table_query)

--- a/cookbooks/cdo-apps/templates/default/crontab.erb
+++ b/cookbooks/cdo-apps/templates/default/crontab.erb
@@ -76,6 +76,7 @@
       # This should be run shortly after the commit_content job run on levelbuilder.
       cronjob at:'*/2 * * * *', do:deploy_dir('bin', 'cron', 'deploy_to_test')
       cronjob at:'*/5 * * * *', do:deploy_dir('bin', 'snapshot')
+      cronjob at:'* 1 * * *', do:deploy_dir('bin', 'cron', 'monitor_mysql_to_redshift_zeroetl_integration')
     end
 
     if node.chef_environment == 'levelbuilder'
@@ -106,6 +107,7 @@
       cronjob at:'5 12 * * *', do:deploy_dir('bin', 'cron', 'applab_datasets', 'daily_weather')
       cronjob at:'0 12 * * *', do:deploy_dir('bin', 'cron', 'applab_datasets', 'spotify')
       cronjob at:'00 23 * * *', do:deploy_dir('bin', 'cron', 'export_mysql_database_to_redshift')
+      cronjob at:'* 1 * * *', do:deploy_dir('bin', 'cron', 'monitor_mysql_to_redshift_zeroetl_integration')
       cronjob at:'0 0 * * *', do:deploy_dir('bin', 'cron', 'build_contact_rollups_v2')
       cronjob at:'0 2 * * *', do:deploy_dir('bin', 'cron', 'hoc_student_name_cleanup')
       cronjob at:'0 0 * * *', do:deploy_dir('bin', 'cron', 'send_permission_email_reminders')


### PR DESCRIPTION
Add cron job that monitors and publishes status of the Zero ETL Integration that exports data from MySQL to Redshift.

https://codedotorg.atlassian.net/browse/INF-1793
## Testing story

I manually tested the logic in the `main` method using the `dashboard-console` on the `test` server.

I manually provisioned a CloudWatch Alarm [Zero ETL MySQL to Redshift Integration - One or More Tables Failing Replication](https://us-east-1.console.aws.amazon.com/cloudwatch/home?region=us-east-1#alarmsV2:alarm/Zero+ETL+MySQL+to+Redshift+Integration+-+One+or+More+Tables+Failing+Replication?~(timeRange~(startDate~'P2D~endDate~'PT0S))) that has a `CDO-LowPriority` Action. It will trigger when one or more tables have been failing replication for 4 consecutive hours.

I also added metrics to our Learning Platform Overview CloudWatch Dashboard that track basic Zero ETL metrics
<img width="1280" height="290" alt="image" src="https://github.com/user-attachments/assets/1312f2c7-18e5-4ecb-9688-e8a5235e89a4" />


## Deployment notes
<!-- Delete this section if it's a standard merge-and-deploy.
     Otherwise: migrations, feature flags, coordination, caching impacts, etc. -->



## Privacy and security
<!-- Delete this section if there is no privacy/security impact.
     Otherwise: new PII, auth changes, API surface changes, etc. -->

