### PR TITLE
[Blockly] Remove custom field classes from wrapper

### DIFF
--- a/apps/src/block_utils.js
+++ b/apps/src/block_utils.js
@@ -1,6 +1,7 @@
 import * as BlocklyCore from 'blockly/core';
 import _ from 'lodash';
 
+import CdoFieldVariable from '@cdo/apps/blockly/addons/cdoFieldVariable';
 import {
   updatePointerBlockImage,
   updatePointerBlockWarning,
@@ -635,7 +636,7 @@ const STANDARD_INPUT_TYPES = {
       // Add the variable field to the block
       currentInputRow
         .appendField(inputConfig.label)
-        .appendField(new Blockly.FieldVariable(null), inputConfig.name);
+        .appendField(new CdoFieldVariable(null), inputConfig.name);
     },
     generateCode(block, inputConfig) {
       return Blockly.JavaScript.translateVarName(

--- a/apps/src/block_utils.js
+++ b/apps/src/block_utils.js
@@ -17,6 +17,8 @@ import {
 } from '@cdo/apps/blockly/utils/fields/miniToolbox';
 import {spriteLabPointers} from '@cdo/apps/p5lab/spritelab/blockly/constants';
 
+import CdoFieldDropdown from './blockly/addons/cdoFieldDropdown';
+import CdoFieldImage from './blockly/addons/cdoFieldImage';
 import MetricsReporter from './metrics/MetricsReporter';
 import xml from './xml';
 
@@ -190,7 +192,7 @@ exports.generateSimpleBlock = function (blockly, generator, options) {
         input.appendField(title);
       }
       if (titleImage) {
-        input.appendField(new blockly.FieldImage(titleImage));
+        input.appendField(new CdoFieldImage(titleImage));
       }
       this.setPreviousStatement(true);
       this.setNextStatement(true);
@@ -581,7 +583,7 @@ const STANDARD_INPUT_TYPES = {
         currentInputRow
           .appendField(inputConfig.label)
           .appendField(
-            new Blockly.FieldImage(
+            new CdoFieldImage(
               Blockly.assetUrl(inputConfig.customOptions.assetUrl),
               inputConfig.customOptions.width,
               inputConfig.customOptions.height
@@ -604,7 +606,7 @@ const STANDARD_INPUT_TYPES = {
   [DROPDOWN_INPUT]: {
     addInput(blockly, block, inputConfig, currentInputRow) {
       const options = sanitizeOptions(inputConfig.options);
-      const dropdown = new blockly.FieldDropdown(options);
+      const dropdown = new CdoFieldDropdown(options);
       currentInputRow
         .appendField(inputConfig.label)
         .appendField(dropdown, inputConfig.name);

--- a/apps/src/block_utils.js
+++ b/apps/src/block_utils.js
@@ -1,6 +1,7 @@
 import * as BlocklyCore from 'blockly/core';
 import _ from 'lodash';
 
+import CdoFieldNumber from '@cdo/apps/blockly/addons/cdoFieldNumber';
 import CdoFieldVariable from '@cdo/apps/blockly/addons/cdoFieldVariable';
 import {
   updatePointerBlockImage,
@@ -649,13 +650,13 @@ const STANDARD_INPUT_TYPES = {
       const {type} = inputConfig;
       let field;
       if (type === Blockly.BlockValueType.NUMBER) {
-        field = new Blockly.FieldNumber();
+        field = new CdoFieldNumber();
       } else if (type.includes('ClampedNumber')) {
         const clampedNumberMatch = type.match(CLAMPED_NUMBER_REGEX);
         if (clampedNumberMatch) {
           const min = parseFloat(clampedNumberMatch[1]);
           const max = parseFloat(clampedNumberMatch[2]);
-          field = new Blockly.FieldNumber(0, min, max);
+          field = new CdoFieldNumber(0, min, max);
         }
       } else {
         field = new Blockly.FieldTextInput();

--- a/apps/src/blockly/addons/cdoFieldAngleDropdown.ts
+++ b/apps/src/blockly/addons/cdoFieldAngleDropdown.ts
@@ -88,7 +88,7 @@ export default class CdoFieldAngleDropdown extends CdoFieldDropdown {
   private initializeAngleHelper(): void {
     const container = this.createAngleHelperContainer();
     const sourceBlock = this.getSourceBlock() as BlocklyCore.Block;
-    this.angleHelper = new Blockly.AngleHelper(this.getDirection(), {
+    this.angleHelper = new CdoAngleHelper(this.getDirection(), {
       onUpdate: this.updateDropdownMenuOptions.bind(this),
       snapPoints: this.getOptions().map(option => parseInt(option[1])),
       arcColour: (sourceBlock as ExtendedBlockSvg)?.style.colourPrimary,

--- a/apps/src/blockly/addons/cdoFieldColour.ts
+++ b/apps/src/blockly/addons/cdoFieldColour.ts
@@ -55,7 +55,7 @@ export default class CdoFieldColour extends FieldColour {
 
   /**
    * Create and show the colour field's editor.
-   * Artist modifies blockly.FieldColour.COLOURS and blockly.FieldColour.COLUMNS directly.
+   * Artist modifies CdoFieldColour.COLOURS and CdoFieldColour.COLUMNS directly.
    * Therefore, wait to read these values until we need to create the field dropdown.
    * For pre-reader blocks (CSF Course A-B, Course 1 and Pre-Reader Express), we add a
    * class to manually increase the size of the field.

--- a/apps/src/blockly/addons/cdoFieldNumber.ts
+++ b/apps/src/blockly/addons/cdoFieldNumber.ts
@@ -1,7 +1,7 @@
 import * as BlocklyCore from 'blockly/core';
 
 import {EMPTY_OPTION} from '../constants';
-import {ExtendedBlockSvg, AngleHelperOptions} from '../types';
+import {AngleHelperOptions, ExtendedBlockSvg} from '../types';
 
 import CdoAngleHelper from './cdoAngleHelper';
 import {AngleHelperConnection} from './cdoAngleHelperOptions';
@@ -80,7 +80,7 @@ export default class CdoFieldNumber extends BlocklyCore.FieldNumber {
    */
   private initializeAngleHelper() {
     const sourceBlock = this.getSourceBlock();
-    this.angleHelper = new Blockly.AngleHelper(this.getAnglePickerDirection(), {
+    this.angleHelper = new CdoAngleHelper(this.getAnglePickerDirection(), {
       arcColour: (sourceBlock as ExtendedBlockSvg)?.style.colourPrimary,
       onUpdate: this.updateAngleValue.bind(this),
       angle: parseInt(`${this.getValue()}`),

--- a/apps/src/blockly/blocklyWrapper.ts
+++ b/apps/src/blockly/blocklyWrapper.ts
@@ -1,6 +1,6 @@
 import {
-  ObservableProcedureModel,
   ObservableParameterModel,
+  ObservableProcedureModel,
 } from '@blockly/block-shareable-procedures';
 import {installAllBlocks as installFieldColourBlocks} from '@blockly/field-colour';
 import {CrossTabCopyPaste} from '@blockly/plugin-cross-tab-copy-paste';
@@ -32,21 +32,12 @@ import CdoBlockSerializer from './addons/cdoBlockSerializer';
 import CdoConnectionChecker from './addons/cdoConnectionChecker';
 import initializeCdoConstants from './addons/cdoConstants';
 import initializeCss from './addons/cdoCss';
-import CdoFieldAngleDropdown from './addons/cdoFieldAngleDropdown';
-import CdoFieldAngleTextInput from './addons/cdoFieldAngleTextInput';
-import CdoFieldAnimationDropdown from './addons/cdoFieldAnimationDropdown';
-import CdoFieldBehaviorPicker from './addons/cdoFieldBehaviorPicker';
 import {CdoFieldBitmap} from './addons/cdoFieldBitmap';
-import CdoFieldButton from './addons/cdoFieldButton';
 import CdoFieldColour from './addons/cdoFieldColour';
 import CdoFieldDropdown from './addons/cdoFieldDropdown';
-import CdoFieldFlyout from './addons/cdoFieldFlyout';
-import CdoFieldImage from './addons/cdoFieldImage';
-import {CdoFieldImageDropdown} from './addons/cdoFieldImageDropdown';
 import CdoFieldLabel from './addons/cdoFieldLabel';
 import CdoFieldNumber from './addons/cdoFieldNumber';
 import CdoFieldParameter from './addons/cdoFieldParameter';
-import CdoFieldToggle from './addons/cdoFieldToggle';
 import CdoFieldVariable from './addons/cdoFieldVariable';
 import initializeGenerator from './addons/cdoGenerator';
 import {gestureOverrides} from './addons/cdoGesture';
@@ -74,7 +65,7 @@ import {filterFunctionArgVariables} from './addons/plusMinusBlocks/advancedProce
 import registerIfMutator from './addons/plusMinusBlocks/if';
 import registerTextJoinMutator from './addons/plusMinusBlocks/text_join';
 import {UNKNOWN_BLOCK} from './addons/unknownBlock';
-import {Themes, Renderers} from './constants';
+import {Renderers, Themes} from './constants';
 import {flyoutCategory as behaviorsFlyoutCategory} from './customBlocks/behaviorBlocks';
 import {flyoutCategory as functionsFlyoutCategory} from './customBlocks/proceduresBlocks';
 import {flyoutCategory as variablesFlyoutCategory} from './customBlocks/variableBlocks';
@@ -89,13 +80,13 @@ import {
   updateBlockLimits,
 } from './eventHandlers';
 import {
-  CdoProtanopiaDarkTheme,
   CdoDeuteranopiaDarkTheme,
+  CdoProtanopiaDarkTheme,
   CdoTritanopiaDarkTheme,
 } from './themes/cdoAccessibleDarkThemes';
 import {
-  CdoProtanopiaTheme,
   CdoDeuteranopiaTheme,
+  CdoProtanopiaTheme,
   CdoTritanopiaTheme,
 } from './themes/cdoAccessibleThemes';
 import CdoDarkTheme from './themes/cdoDark';
@@ -104,23 +95,23 @@ import CdoHighContrastDarkTheme from './themes/cdoHighContrastDark';
 import CdoJigsawTheme from './themes/cdoJigsaw';
 import CdoTheme from './themes/cdoTheme';
 import {
+  BlocklyCoreInstance,
   BlocklyWrapperType,
   ExtendedBlocklyOptions,
   ExtendedJavascriptGenerator,
   ExtendedWorkspace,
   ExtendedWorkspaceSvg,
-  BlocklyCoreInstance,
 } from './types';
 import {
+  cleanUp,
+  createBlockLimitMap,
+  getUserTheme,
   handleCodeGenerationFailure,
-  strip,
   initializeVariableLocalization,
   isDarkTheme,
-  setThemeAndRenderBlocks,
-  getUserTheme,
-  createBlockLimitMap,
   loadBlocksToWorkspace,
-  cleanUp,
+  setThemeAndRenderBlocks,
+  strip,
 } from './utils';
 
 const options: {contextMenu: true; shortcut: true} = {
@@ -177,19 +168,11 @@ const BlocklyWrapper = function (
   this.overrideFields = function (overrides) {
     overrides.forEach(override => {
       const fieldRegistryName = override[0];
-      const fieldClassName = override[1];
-      const fieldClass = override[2];
+      const fieldClass = override[1];
 
       // Force Blockly to use our custom versions of fields
       this.fieldRegistry.unregister(fieldRegistryName);
       this.fieldRegistry.register(fieldRegistryName, fieldClass);
-
-      // Add each field for when our wrapper is accessed in /apps code
-      // This method helps us avoid duplicated boilerplate, but we would
-      // need the type of fieldClass to align with fieldClassName
-      // in order to avoid using any here.
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (this as any)[fieldClassName] = fieldClass;
     });
   };
 };
@@ -255,24 +238,16 @@ function initializeBlocklyWrapper(blocklyInstance: BlocklyCoreInstance) {
   type registrableFieldType = BlocklyCore.fieldRegistry.RegistrableField;
   // elements in this list should be structured as follows:
   // [field registry name for field, class name of field being overridden, class to use as override]
-  const fieldOverrides: [string, string, registrableFieldType][] = [
-    ['field_variable', 'FieldVariable', CdoFieldVariable],
-    ['field_dropdown', 'FieldDropdown', CdoFieldDropdown],
-    ['field_number', 'FieldNumber', CdoFieldNumber],
+  const fieldOverrides: [string, registrableFieldType][] = [
+    ['field_variable', CdoFieldVariable],
+    ['field_dropdown', CdoFieldDropdown],
+    ['field_number', CdoFieldNumber],
     // CdoFieldBitmap and CdoFieldColour extend from plugins.
     // We know they're fields, so it's safe to cast as unknown.
-    [
-      'field_bitmap',
-      'FieldBitmap',
-      CdoFieldBitmap as unknown as registrableFieldType,
-    ],
-    [
-      'field_colour',
-      'FieldColour',
-      CdoFieldColour as unknown as registrableFieldType,
-    ],
-    ['field_label', 'FieldLabel', CdoFieldLabel],
-    ['field_parameter', 'FieldParameter', CdoFieldParameter],
+    ['field_bitmap', CdoFieldBitmap as unknown as registrableFieldType],
+    ['field_colour', CdoFieldColour as unknown as registrableFieldType],
+    ['field_label', CdoFieldLabel],
+    ['field_parameter', CdoFieldParameter],
   ];
   blocklyWrapper.overrideFields(fieldOverrides);
 
@@ -282,15 +257,6 @@ function initializeBlocklyWrapper(blocklyInstance: BlocklyCoreInstance) {
 
   // Code.org custom fields
   blocklyWrapper.AngleHelper = CdoAngleHelper;
-  blocklyWrapper.FieldButton = CdoFieldButton;
-  blocklyWrapper.FieldImage = CdoFieldImage;
-  blocklyWrapper.FieldImageDropdown = CdoFieldImageDropdown;
-  blocklyWrapper.FieldToggle = CdoFieldToggle;
-  blocklyWrapper.FieldFlyout = CdoFieldFlyout;
-  blocklyWrapper.FieldBehaviorPicker = CdoFieldBehaviorPicker;
-  blocklyWrapper.FieldAnimationDropdown = CdoFieldAnimationDropdown;
-  blocklyWrapper.FieldAngleDropdown = CdoFieldAngleDropdown;
-  blocklyWrapper.FieldAngleTextInput = CdoFieldAngleTextInput;
 
   blocklyWrapper.registry.register(
     blocklyWrapper.registry.Type.FLYOUTS_VERTICAL_TOOLBOX,

--- a/apps/src/blockly/blocklyWrapper.ts
+++ b/apps/src/blockly/blocklyWrapper.ts
@@ -32,7 +32,6 @@ import CdoBlockSerializer from './addons/cdoBlockSerializer';
 import CdoConnectionChecker from './addons/cdoConnectionChecker';
 import initializeCdoConstants from './addons/cdoConstants';
 import initializeCss from './addons/cdoCss';
-import {CdoFieldBitmap} from './addons/cdoFieldBitmap';
 import CdoFieldColour from './addons/cdoFieldColour';
 import CdoFieldDropdown from './addons/cdoFieldDropdown';
 import CdoFieldLabel from './addons/cdoFieldLabel';
@@ -219,19 +218,20 @@ function initializeBlocklyWrapper(blocklyInstance: BlocklyCoreInstance) {
     console.warn(e);
   }
 
+  // Custom fields need to be registered for two reasons:
+  // 1. To be used in JSON block definitions, e.g. in Music Lab
+  // 2. To be used by core Blockly blocks to override default field functionality, e.g. colour blocks
   type registrableFieldType = BlocklyCore.fieldRegistry.RegistrableField;
   // elements in this list should be structured as follows:
   // [field registry name for field, class to use as override]
   const fieldsToRegister: [string, registrableFieldType][] = [
-    ['field_variable', CdoFieldVariable],
-    ['field_dropdown', CdoFieldDropdown],
-    ['field_number', CdoFieldNumber],
-    // CdoFieldBitmap and CdoFieldColour extend from plugins.
-    // We know they're fields, so it's safe to cast as unknown.
-    ['field_bitmap', CdoFieldBitmap as unknown as registrableFieldType],
+    // CdoFieldColour extends from a plugin. We know it's a field, so it's safe to cast as unknown.
     ['field_colour', CdoFieldColour as unknown as registrableFieldType],
+    ['field_dropdown', CdoFieldDropdown],
     ['field_label', CdoFieldLabel],
+    ['field_number', CdoFieldNumber],
     ['field_parameter', CdoFieldParameter],
+    ['field_variable', CdoFieldVariable],
   ];
   // Tell Blockly to use our custom versions of fields
   fieldsToRegister.forEach(override => {

--- a/apps/src/blockly/blocklyWrapper.ts
+++ b/apps/src/blockly/blocklyWrapper.ts
@@ -159,22 +159,6 @@ const BlocklyWrapper = function (
       },
     });
   };
-
-  /**
-   * Override core Blockly fields with Code.org customized versions,
-   * and sets the field on our wrapper for use by our code.
-   * @param {array} overrides (elements are arrays of shape [fieldRegistryName, fieldClassName, fieldClass])
-   */
-  this.overrideFields = function (overrides) {
-    overrides.forEach(override => {
-      const fieldRegistryName = override[0];
-      const fieldClass = override[1];
-
-      // Force Blockly to use our custom versions of fields
-      this.fieldRegistry.unregister(fieldRegistryName);
-      this.fieldRegistry.register(fieldRegistryName, fieldClass);
-    });
-  };
 };
 
 function initializeBlocklyWrapper(blocklyInstance: BlocklyCoreInstance) {
@@ -237,8 +221,8 @@ function initializeBlocklyWrapper(blocklyInstance: BlocklyCoreInstance) {
 
   type registrableFieldType = BlocklyCore.fieldRegistry.RegistrableField;
   // elements in this list should be structured as follows:
-  // [field registry name for field, class name of field being overridden, class to use as override]
-  const fieldOverrides: [string, registrableFieldType][] = [
+  // [field registry name for field, class to use as override]
+  const fieldsToRegister: [string, registrableFieldType][] = [
     ['field_variable', CdoFieldVariable],
     ['field_dropdown', CdoFieldDropdown],
     ['field_number', CdoFieldNumber],
@@ -249,7 +233,13 @@ function initializeBlocklyWrapper(blocklyInstance: BlocklyCoreInstance) {
     ['field_label', CdoFieldLabel],
     ['field_parameter', CdoFieldParameter],
   ];
-  blocklyWrapper.overrideFields(fieldOverrides);
+  // Tell Blockly to use our custom versions of fields
+  fieldsToRegister.forEach(override => {
+    const fieldRegistryName = override[0];
+    const fieldClass = override[1];
+    blocklyWrapper.fieldRegistry.unregister(fieldRegistryName);
+    blocklyWrapper.fieldRegistry.register(fieldRegistryName, fieldClass);
+  });
 
   // TODO: Can/should we make CdoTrashcan have the same type as Trashcan?
   // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/apps/src/blockly/blocklyWrapper.ts
+++ b/apps/src/blockly/blocklyWrapper.ts
@@ -27,7 +27,6 @@ import * as utils from '@cdo/apps/utils';
 import {START_BLOCKS} from '../constants';
 import {START_SOURCES} from '../lab2/constants';
 
-import CdoAngleHelper from './addons/cdoAngleHelper';
 import CdoBlockSerializer from './addons/cdoBlockSerializer';
 import CdoConnectionChecker from './addons/cdoConnectionChecker';
 import initializeCdoConstants from './addons/cdoConstants';
@@ -244,9 +243,6 @@ function initializeBlocklyWrapper(blocklyInstance: BlocklyCoreInstance) {
   // TODO: Can/should we make CdoTrashcan have the same type as Trashcan?
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   blocklyWrapper.Trashcan = CdoTrashcan as any;
-
-  // Code.org custom fields
-  blocklyWrapper.AngleHelper = CdoAngleHelper;
 
   blocklyWrapper.registry.register(
     blocklyWrapper.registry.Type.FLYOUTS_VERTICAL_TOOLBOX,

--- a/apps/src/blockly/customBlocks/proceduresBlocks.ts
+++ b/apps/src/blockly/customBlocks/proceduresBlocks.ts
@@ -144,7 +144,7 @@ BlocklyCore.Extensions.register(
       toolboxConfigurationSupportsEditButton(this) &&
       !Blockly.isEmbeddedWorkspace(this.workspace)
     ) {
-      const button = new Blockly.FieldButton({
+      const button = new CdoFieldButton({
         value: commonI18n.edit(),
         onClick: editButtonHandler,
         colorOverrides: {button: 'blue', text: 'white'},

--- a/apps/src/blockly/customBlocks/variableBlocks.ts
+++ b/apps/src/blockly/customBlocks/variableBlocks.ts
@@ -1,5 +1,6 @@
 import * as BlocklyCore from 'blockly/core';
 
+import CdoFieldVariable from '@cdo/apps/blockly/addons/cdoFieldVariable';
 import {getCategoryBlocksJson} from '@cdo/apps/blockly/utils/';
 import {commonI18n} from '@cdo/apps/types/locale';
 
@@ -45,7 +46,7 @@ const getNewVariableButtonWithCallback = (
 ) => {
   const callbackkey = 'newVariableCallback';
   workspace.registerButtonCallback(callbackkey, () => {
-    Blockly.FieldVariable.variableNamePrompt({
+    CdoFieldVariable.variableNamePrompt({
       promptText: commonI18n.renameThisPromptTitle(),
       confirmButtonLabel: commonI18n.create(),
       defaultText: '',

--- a/apps/src/blockly/types.ts
+++ b/apps/src/blockly/types.ts
@@ -124,9 +124,6 @@ export interface BlocklyWrapperType extends BlocklyCoreType {
 
   wrapReadOnlyProperty: (propertyName: string) => void;
   wrapSettableProperty: (propertyName: string) => void;
-  overrideFields: (
-    overrides: [string, BlocklyCore.fieldRegistry.RegistrableField][]
-  ) => void;
   getWorkspaceCode: () => string;
   getGenerator: () => ExtendedJavascriptGenerator;
   addEmbeddedWorkspace: (workspace: BlocklyCore.Workspace) => void;

--- a/apps/src/blockly/types.ts
+++ b/apps/src/blockly/types.ts
@@ -2,7 +2,6 @@ import {
   ObservableParameterModel,
   ObservableProcedureModel,
 } from '@blockly/block-shareable-procedures';
-import {FieldColour} from '@blockly/field-colour';
 import {KeyboardNavigation} from '@blockly/keyboard-navigation';
 import * as BlocklyCore from 'blockly/core';
 import {javascriptGenerator} from 'blockly/javascript';
@@ -10,17 +9,6 @@ import {javascriptGenerator} from 'blockly/javascript';
 import BlockSvgFrame from './addons/blockSvgFrame';
 import BlockSvgLimitIndicator from './addons/blockSvgLimitIndicator';
 import CdoAngleHelper from './addons/cdoAngleHelper';
-import CdoFieldAngleDropdown from './addons/cdoFieldAngleDropdown';
-import CdoFieldAngleTextInput from './addons/cdoFieldAngleTextInput';
-import CdoFieldAnimationDropdown from './addons/cdoFieldAnimationDropdown';
-import CdoFieldBehaviorPicker from './addons/cdoFieldBehaviorPicker';
-import {CdoFieldBitmap} from './addons/cdoFieldBitmap';
-import CdoFieldButton from './addons/cdoFieldButton';
-import CdoFieldFlyout from './addons/cdoFieldFlyout';
-import {CdoFieldImageDropdown} from './addons/cdoFieldImageDropdown';
-import CdoFieldParameter from './addons/cdoFieldParameter';
-import CdoFieldToggle from './addons/cdoFieldToggle';
-import CdoFieldVariable from './addons/cdoFieldVariable';
 import FunctionEditor from './addons/functionEditor';
 import WorkspaceSvgFrame from './addons/workspaceSvgFrame';
 import {BLOCK_TYPES, BlockStyles, Themes, WORKSPACE_EVENTS} from './constants';
@@ -114,18 +102,6 @@ export interface BlocklyWrapperType extends BlocklyCoreType {
   };
 
   AngleHelper: typeof CdoAngleHelper;
-  FieldAngleDropdown: typeof CdoFieldAngleDropdown;
-  FieldAngleTextInput: typeof CdoFieldAngleTextInput;
-  FieldBehaviorPicker: typeof CdoFieldBehaviorPicker;
-  FieldButton: typeof CdoFieldButton;
-  FieldImageDropdown: typeof CdoFieldImageDropdown;
-  FieldAnimationDropdown: typeof CdoFieldAnimationDropdown;
-  FieldToggle: typeof CdoFieldToggle;
-  FieldFlyout: typeof CdoFieldFlyout;
-  FieldBitmap: typeof CdoFieldBitmap;
-  FieldColour: typeof FieldColour;
-  FieldVariable: typeof CdoFieldVariable;
-  FieldParameter: typeof CdoFieldParameter;
   JavaScript: JavascriptGeneratorType;
   assetUrl: (path: string) => string;
   customSimpleDialog: (config: object) => void;
@@ -149,7 +125,7 @@ export interface BlocklyWrapperType extends BlocklyCoreType {
   wrapReadOnlyProperty: (propertyName: string) => void;
   wrapSettableProperty: (propertyName: string) => void;
   overrideFields: (
-    overrides: [string, string, BlocklyCore.fieldRegistry.RegistrableField][]
+    overrides: [string, BlocklyCore.fieldRegistry.RegistrableField][]
   ) => void;
   getWorkspaceCode: () => string;
   getGenerator: () => ExtendedJavascriptGenerator;

--- a/apps/src/blockly/types.ts
+++ b/apps/src/blockly/types.ts
@@ -8,7 +8,6 @@ import {javascriptGenerator} from 'blockly/javascript';
 
 import BlockSvgFrame from './addons/blockSvgFrame';
 import BlockSvgLimitIndicator from './addons/blockSvgLimitIndicator';
-import CdoAngleHelper from './addons/cdoAngleHelper';
 import FunctionEditor from './addons/functionEditor';
 import WorkspaceSvgFrame from './addons/workspaceSvgFrame';
 import {BLOCK_TYPES, BlockStyles, Themes, WORKSPACE_EVENTS} from './constants';
@@ -101,7 +100,6 @@ export interface BlocklyWrapperType extends BlocklyCoreType {
     onMainBlockSpaceCreated: (callback: () => void) => void;
   };
 
-  AngleHelper: typeof CdoAngleHelper;
   JavaScript: JavascriptGeneratorType;
   assetUrl: (path: string) => string;
   customSimpleDialog: (config: object) => void;

--- a/apps/src/blockly/utils/fields/location.ts
+++ b/apps/src/blockly/utils/fields/location.ts
@@ -1,3 +1,4 @@
+import CdoFieldButton from '@cdo/apps/blockly/addons/cdoFieldButton';
 import {APP_HEIGHT} from '@cdo/apps/p5lab/constants';
 
 export function locationField(icon: SVGElement, onClick: () => void) {
@@ -12,7 +13,7 @@ export function locationField(icon: SVGElement, onClick: () => void) {
     }
     return '';
   };
-  return new Blockly.FieldButton({
+  return new CdoFieldButton({
     onClick,
     transformText: transformTextSetField,
     icon,

--- a/apps/src/blockly/utils/fields/miniToolbox.ts
+++ b/apps/src/blockly/utils/fields/miniToolbox.ts
@@ -10,7 +10,7 @@ import {SVG_NS} from '@cdo/apps/constants';
 import Button from '@cdo/apps/legacySharedComponents/Button';
 import i18n from '@cdo/locale';
 
-import {readBooleanAttribute, FALSEY_DEFAULT} from '../xml/booleanAttributes';
+import {FALSEY_DEFAULT, readBooleanAttribute} from '../xml/booleanAttributes';
 
 const INPUTS = {
   FLYOUT: 'flyout_input',
@@ -26,7 +26,7 @@ export function initializeMiniToolbox(renderToolboxBeforeStack = false) {
   // Function to create the flyout
   const createFlyoutField = function (block: BlocklyCore.Block) {
     const flyoutKey = CdoFieldFlyout.getFlyoutId(block);
-    const flyoutField = new Blockly.FieldFlyout('', {
+    const flyoutField = new CdoFieldFlyout('', {
       flyoutKey: flyoutKey,
       name: 'FLYOUT',
     });
@@ -77,7 +77,7 @@ export function initializeMiniToolbox(renderToolboxBeforeStack = false) {
     button: Button.ButtonColor.blue,
   };
 
-  const flyoutToggleButton = new Blockly.FieldToggle({
+  const flyoutToggleButton = new CdoFieldToggle({
     onClick: toggleFlyout,
     defaultIcon,
     alternateIcon,

--- a/apps/src/blockly/utils/fields/sounds.ts
+++ b/apps/src/blockly/utils/fields/sounds.ts
@@ -1,4 +1,5 @@
 import {SOUND_PREFIX} from '@cdo/apps/assetManagement/assetPrefix';
+import CdoFieldButton from '@cdo/apps/blockly/addons/cdoFieldButton';
 import {DEFAULT_SOUND} from '@cdo/apps/blockly/constants';
 
 function capitalizeFirstLetter(string: string) {
@@ -51,7 +52,7 @@ export function soundField(
     }
     return newValue;
   };
-  return new Blockly.FieldButton({
+  return new CdoFieldButton({
     value: DEFAULT_SOUND,
     validator,
     onClick,

--- a/apps/src/blocksCommon.js
+++ b/apps/src/blocksCommon.js
@@ -5,6 +5,7 @@
 import {nonnegativeIntegerValidator} from '@cdo/apps/blockly/utils';
 import commonMsg from '@cdo/locale';
 
+import CdoFieldImage from './blockly/addons/cdoFieldImage';
 import {BLOCK_TYPES, BlockColors, BlockStyles} from './blockly/constants';
 import {
   addSerializationHooksToBlock,
@@ -58,7 +59,7 @@ function installControlsRepeatSimplified(blockly, skin) {
           'TIMES'
         );
       this.appendStatementInput('DO').appendField(
-        new blockly.FieldImage(skin.repeatImage)
+        new CdoFieldImage(skin.repeatImage)
       );
       this.setPreviousStatement(true);
       this.setNextStatement(true);
@@ -77,7 +78,7 @@ function installControlsRepeatSimplified(blockly, skin) {
         )
         .appendField(new blockly.FieldDropdown(), 'TIMES');
       this.appendStatementInput('DO').appendField(
-        new blockly.FieldImage(skin.repeatImage)
+        new CdoFieldImage(skin.repeatImage)
       );
       this.setPreviousStatement(true);
       this.setNextStatement(true);
@@ -205,7 +206,7 @@ function installWhenRun(blockly, skin, isK1) {
       if (isK1) {
         this.appendDummyInput()
           .appendField(commonMsg.whenRun())
-          .appendField(new blockly.FieldImage(skin.runArrow, 22, 26));
+          .appendField(new CdoFieldImage(skin.runArrow, 22, 26));
       } else {
         this.appendDummyInput().appendField(commonMsg.whenRun());
       }

--- a/apps/src/blocksCommon.js
+++ b/apps/src/blocksCommon.js
@@ -5,6 +5,7 @@
 import {nonnegativeIntegerValidator} from '@cdo/apps/blockly/utils';
 import commonMsg from '@cdo/locale';
 
+import CdoFieldDropdown from './blockly/addons/cdoFieldDropdown';
 import CdoFieldImage from './blockly/addons/cdoFieldImage';
 import {BLOCK_TYPES, BlockColors, BlockStyles} from './blockly/constants';
 import {
@@ -76,7 +77,7 @@ function installControlsRepeatSimplified(blockly, skin) {
         .appendField(
           blockly.Msg.CONTROLS_REPEAT_TITLE_REPEAT || commonMsg.repeat()
         )
-        .appendField(new blockly.FieldDropdown(), 'TIMES');
+        .appendField(new CdoFieldDropdown(), 'TIMES');
       this.appendStatementInput('DO').appendField(
         new CdoFieldImage(skin.repeatImage)
       );
@@ -103,7 +104,7 @@ function installControlsRepeatDropdown(blockly) {
         .appendField(
           blockly.Msg.CONTROLS_REPEAT_TITLE_REPEAT || commonMsg.repeat()
         )
-        .appendField(new blockly.FieldDropdown(), 'TIMES')
+        .appendField(new CdoFieldDropdown(), 'TIMES')
         .appendField(
           blockly.Msg.CONTROLS_REPEAT_TITLE_TIMES || commonMsg.times()
         );
@@ -125,7 +126,7 @@ function installNumberDropdown(blockly) {
     init: function () {
       this.setHelpUrl(blockly.Msg.MATH_NUMBER_HELPURL);
       this.setStyle(BlockStyles.MATH);
-      this.appendDummyInput().appendField(new blockly.FieldDropdown(), 'NUM');
+      this.appendDummyInput().appendField(new CdoFieldDropdown(), 'NUM');
       this.setOutput(true, Blockly.BlockValueType.NUMBER);
       this.setTooltip(blockly.Msg.MATH_NUMBER_TOOLTIP);
     },
@@ -177,7 +178,7 @@ function installCategory(blockly) {
       this.setStyle(BlockStyles.LOOP);
       this.setInputsInline(true);
 
-      var customDropdown = new blockly.FieldDropdown([
+      var customDropdown = CdoFieldDropdown([
         ['Variables', 'VARIABLE'],
         ['Functions', 'PROCEDURE'],
         ['Behaviors', 'Behavior'],

--- a/apps/src/bounce/blocks.js
+++ b/apps/src/bounce/blocks.js
@@ -1,3 +1,4 @@
+import CdoFieldDropdown from '../blockly/addons/cdoFieldDropdown';
 import {CdoFieldImageDropdown} from '../blockly/addons/cdoFieldImageDropdown';
 
 /**
@@ -237,7 +238,7 @@ exports.install = function (blockly, blockInstallOptions) {
     init: function () {
       this.setStyle('default');
       this.appendDummyInput().appendField(
-        new blockly.FieldDropdown(this.SOUNDS),
+        new CdoFieldDropdown(this.SOUNDS),
         'SOUND'
       );
       this.setPreviousStatement(true);
@@ -339,7 +340,7 @@ exports.install = function (blockly, blockInstallOptions) {
     // Block for setting ball speed
     helpUrl: '',
     init: function () {
-      var dropdown = new blockly.FieldDropdown(this.VALUES);
+      var dropdown = new CdoFieldDropdown(this.VALUES);
       dropdown.setValue(this.VALUES[3][1]); // default to normal
 
       this.setStyle('default');
@@ -367,7 +368,7 @@ exports.install = function (blockly, blockInstallOptions) {
     // Block for setting paddle speed
     helpUrl: '',
     init: function () {
-      var dropdown = new blockly.FieldDropdown(this.VALUES);
+      var dropdown = new CdoFieldDropdown(this.VALUES);
       dropdown.setValue(this.VALUES[3][1]); // default to normal
 
       this.setStyle('default');
@@ -397,7 +398,7 @@ exports.install = function (blockly, blockInstallOptions) {
   blockly.Blocks.bounce_setBackground = {
     helpUrl: '',
     init: function () {
-      var dropdown = new blockly.FieldDropdown(this.VALUES);
+      var dropdown = new CdoFieldDropdown(this.VALUES);
       dropdown.setValue(this.VALUES[1][1]); // default to hardcourt
 
       this.setStyle('variable_blocks');
@@ -428,7 +429,7 @@ exports.install = function (blockly, blockInstallOptions) {
   blockly.Blocks.bounce_setTeam = {
     helpUrl: '',
     init: function () {
-      var dropdown = new blockly.FieldDropdown(this.VALUES);
+      var dropdown = new CdoFieldDropdown(this.VALUES);
 
       // default to warriors if we can
       if (this.VALUES.length > 14) {
@@ -458,7 +459,7 @@ exports.install = function (blockly, blockInstallOptions) {
   blockly.Blocks.bounce_setBall = {
     helpUrl: '',
     init: function () {
-      var dropdown = new blockly.FieldDropdown(this.VALUES);
+      var dropdown = new CdoFieldDropdown(this.VALUES);
       dropdown.setValue(this.VALUES[1][1]); // default to hardcourt
 
       this.setStyle('variable_blocks');
@@ -484,7 +485,7 @@ exports.install = function (blockly, blockInstallOptions) {
   blockly.Blocks.bounce_setPaddle = {
     helpUrl: '',
     init: function () {
-      var dropdown = new blockly.FieldDropdown(this.VALUES);
+      var dropdown = new CdoFieldDropdown(this.VALUES);
       dropdown.setValue(this.VALUES[1][1]); // default to hardcourt
 
       this.setStyle('variable_blocks');

--- a/apps/src/bounce/blocks.js
+++ b/apps/src/bounce/blocks.js
@@ -1,3 +1,5 @@
+import {CdoFieldImageDropdown} from '../blockly/addons/cdoFieldImageDropdown';
+
 /**
  * Blockly App: Bounce
  *
@@ -510,7 +512,7 @@ exports.install = function (blockly, blockInstallOptions) {
   blockly.Blocks.bounce_setPaddleDropdown = {
     helpUrl: '',
     init: function () {
-      var dropdown = new blockly.FieldImageDropdown(this.VALUES, 54, 61);
+      var dropdown = new CdoFieldImageDropdown(this.VALUES, 54, 61);
       if (this.VALUES.length > 1) {
         dropdown.setValue(this.VALUES[1][1]);
       }

--- a/apps/src/craft/agent/blocks.js
+++ b/apps/src/craft/agent/blocks.js
@@ -1,4 +1,5 @@
 import CdoFieldDropdown from '@cdo/apps/blockly/addons/cdoFieldDropdown';
+import CdoFieldLabel from '@cdo/apps/blockly/addons/cdoFieldLabel';
 import {BlockStyles} from '@cdo/apps/blockly/constants';
 import {registerCustomProcedureBlocks} from '@cdo/apps/blockly/utils';
 
@@ -75,7 +76,7 @@ exports.install = function (blockly, blockInstallOptions) {
     init: function () {
       this.setStyle(BlockStyles.DEFAULT);
       this.appendDummyInput().appendField(
-        new blockly.FieldLabel(i18n.blockMoveForward())
+        new CdoFieldLabel(i18n.blockMoveForward())
       );
       this.setPreviousStatement(true);
       this.setNextStatement(true);
@@ -91,7 +92,7 @@ exports.install = function (blockly, blockInstallOptions) {
     init: function () {
       this.setStyle(BlockStyles.DEFAULT);
       this.appendDummyInput().appendField(
-        new blockly.FieldLabel(i18n.blockMoveBackward())
+        new CdoFieldLabel(i18n.blockMoveBackward())
       );
       this.setPreviousStatement(true);
       this.setNextStatement(true);
@@ -133,7 +134,7 @@ exports.install = function (blockly, blockInstallOptions) {
     init: function () {
       this.setStyle(BlockStyles.DEFAULT);
       this.appendDummyInput().appendField(
-        new blockly.FieldLabel(i18n.blockDestroyBlock())
+        new CdoFieldLabel(i18n.blockDestroyBlock())
       );
       this.setPreviousStatement(true);
       this.setNextStatement(true);

--- a/apps/src/craft/agent/blocks.js
+++ b/apps/src/craft/agent/blocks.js
@@ -1,3 +1,4 @@
+import CdoFieldDropdown from '@cdo/apps/blockly/addons/cdoFieldDropdown';
 import {BlockStyles} from '@cdo/apps/blockly/constants';
 import {registerCustomProcedureBlocks} from '@cdo/apps/blockly/utils';
 
@@ -107,7 +108,7 @@ exports.install = function (blockly, blockInstallOptions) {
     init: function () {
       this.setStyle(BlockStyles.DEFAULT);
       this.appendDummyInput().appendField(
-        new blockly.FieldDropdown(this.DIRECTIONS),
+        new CdoFieldDropdown(this.DIRECTIONS),
         'DIR'
       );
       this.setPreviousStatement(true);
@@ -149,7 +150,7 @@ exports.install = function (blockly, blockInstallOptions) {
       var dropdownOptions = blockTypesToDropdownOptions(
         craftBlockOptions.ifBlockOptions || allDropdownBlocks
       );
-      var dropdown = new blockly.FieldDropdown(dropdownOptions);
+      var dropdown = new CdoFieldDropdown(dropdownOptions);
       dropdown.setValue(dropdownOptions[0][1]);
       this.setStyle(BlockStyles.LOGIC);
       this.appendDummyInput()
@@ -204,7 +205,7 @@ exports.install = function (blockly, blockInstallOptions) {
       var dropdownOptions = blockTypesToDropdownOptions(
         craftBlockOptions.placeBlockOptions || allDropdownBlocks
       );
-      var dropdown = new blockly.FieldDropdown(dropdownOptions);
+      var dropdown = new CdoFieldDropdown(dropdownOptions);
       dropdown.setValue(dropdownOptions[0][1]);
 
       this.setStyle(BlockStyles.DEFAULT);
@@ -234,7 +235,7 @@ exports.install = function (blockly, blockInstallOptions) {
       var dropdownOptions = blockTypesToDropdownOptions(
         craftBlockOptions.placeBlockOptions || allDropdownBlocks
       );
-      var dropdown = new blockly.FieldDropdown(dropdownOptions);
+      var dropdown = new CdoFieldDropdown(dropdownOptions);
       dropdown.setValue(dropdownOptions[0][1]);
 
       this.setStyle(BlockStyles.DEFAULT);
@@ -242,7 +243,7 @@ exports.install = function (blockly, blockInstallOptions) {
         .appendField(i18n.blockPlaceXPlace())
         .appendField(dropdown, 'TYPE')
         .appendField(' ')
-        .appendField(new blockly.FieldDropdown(fourDirections), 'DIR');
+        .appendField(new CdoFieldDropdown(fourDirections), 'DIR');
       this.setPreviousStatement(true);
       this.setNextStatement(true);
     },

--- a/apps/src/craft/code-connection/blocks.js
+++ b/apps/src/craft/code-connection/blocks.js
@@ -1,5 +1,6 @@
 import CdoFieldDropdown from '@cdo/apps/blockly/addons/cdoFieldDropdown';
 import {CdoFieldImageDropdown} from '@cdo/apps/blockly/addons/cdoFieldImageDropdown';
+import CdoFieldLabel from '@cdo/apps/blockly/addons/cdoFieldLabel';
 
 import items from './items';
 
@@ -90,13 +91,13 @@ export const install = (blockly, blockInstallOptions) => {
       this.setInputsInline(true);
       this.appendValueInput('X')
         .setCheck('Number')
-        .appendField(new blockly.FieldLabel('X:'));
+        .appendField(new CdoFieldLabel('X:'));
       this.appendValueInput('Y')
         .setCheck('Number')
-        .appendField(new blockly.FieldLabel('Y:'));
+        .appendField(new CdoFieldLabel('Y:'));
       this.appendValueInput('Z')
         .setCheck('Number')
-        .appendField(new blockly.FieldLabel('Z:'));
+        .appendField(new CdoFieldLabel('Z:'));
       this.setOutput(true, 'Number');
     },
   };
@@ -128,7 +129,7 @@ export const install = (blockly, blockInstallOptions) => {
     helpUrl: '',
     init: function () {
       this.appendDummyInput()
-        .appendField(new blockly.FieldLabel(i18n.blockMove()))
+        .appendField(new CdoFieldLabel(i18n.blockMove()))
         .appendField(new CdoFieldDropdown(sixDirections), 'DIR');
       this.setPreviousStatement(true);
       this.setNextStatement(true);
@@ -144,7 +145,7 @@ export const install = (blockly, blockInstallOptions) => {
     helpUrl: '',
     init: function () {
       this.appendDummyInput()
-        .appendField(new blockly.FieldLabel(i18n.blockTurn()))
+        .appendField(new CdoFieldLabel(i18n.blockTurn()))
         .appendField(new CdoFieldDropdown(rotateDirections), 'DIR');
       this.setPreviousStatement(true);
       this.setNextStatement(true);
@@ -160,11 +161,11 @@ export const install = (blockly, blockInstallOptions) => {
     helpUrl: '',
     init: function () {
       this.appendDummyInput()
-        .appendField(new blockly.FieldLabel(i18n.blockPlace()))
+        .appendField(new CdoFieldLabel(i18n.blockPlace()))
         .appendField(new CdoFieldDropdown(sixDirections), 'DIR');
       this.appendValueInput('SLOTNUM')
         .setCheck('Number')
-        .appendField(new blockly.FieldLabel(i18n.inSlotNumber()));
+        .appendField(new CdoFieldLabel(i18n.inSlotNumber()));
       this.setPreviousStatement(true);
       this.setNextStatement(true);
     },
@@ -184,7 +185,7 @@ export const install = (blockly, blockInstallOptions) => {
     helpUrl: '',
     init: function () {
       this.appendDummyInput()
-        .appendField(new blockly.FieldLabel(i18n.blockTill()))
+        .appendField(new CdoFieldLabel(i18n.blockTill()))
         .appendField(new CdoFieldDropdown(sixDirections), 'DIR');
       this.setPreviousStatement(true);
       this.setNextStatement(true);
@@ -200,7 +201,7 @@ export const install = (blockly, blockInstallOptions) => {
     helpUrl: '',
     init: function () {
       this.appendDummyInput()
-        .appendField(new blockly.FieldLabel(i18n.blockActionAttack()))
+        .appendField(new CdoFieldLabel(i18n.blockActionAttack()))
         .appendField(new CdoFieldDropdown(sixDirections), 'DIR');
       this.setPreviousStatement(true);
       this.setNextStatement(true);
@@ -216,7 +217,7 @@ export const install = (blockly, blockInstallOptions) => {
     helpUrl: '',
     init: function () {
       this.appendDummyInput()
-        .appendField(new blockly.FieldLabel(i18n.blockDestroyBlock()))
+        .appendField(new CdoFieldLabel(i18n.blockDestroyBlock()))
         .appendField(new CdoFieldDropdown(sixDirections), 'DIR');
       this.setPreviousStatement(true);
       this.setNextStatement(true);
@@ -232,7 +233,7 @@ export const install = (blockly, blockInstallOptions) => {
     helpUrl: '',
     init: function () {
       this.appendDummyInput().appendField(
-        new blockly.FieldLabel(i18n.blockActionCollectAll())
+        new CdoFieldLabel(i18n.blockActionCollectAll())
       );
       this.setPreviousStatement(true);
       this.setNextStatement(true);
@@ -248,7 +249,7 @@ export const install = (blockly, blockInstallOptions) => {
     init: function () {
       this.appendValueInput('ITEM')
         .setCheck(ITEM_TYPE)
-        .appendField(new blockly.FieldLabel(i18n.blockActionCollect()));
+        .appendField(new CdoFieldLabel(i18n.blockActionCollect()));
       this.setPreviousStatement(true);
       this.setNextStatement(true);
     },
@@ -267,14 +268,14 @@ export const install = (blockly, blockInstallOptions) => {
     helpUrl: '',
     init: function () {
       this.appendDummyInput()
-        .appendField(new blockly.FieldLabel(i18n.blockActionDrop()))
+        .appendField(new CdoFieldLabel(i18n.blockActionDrop()))
         .appendField(new CdoFieldDropdown(fourDirections), 'DIR');
       this.appendValueInput('SLOTNUM')
         .setCheck('Number')
-        .appendField(new blockly.FieldLabel(i18n.inSlotNumber()));
+        .appendField(new CdoFieldLabel(i18n.inSlotNumber()));
       this.appendValueInput('QUANTITY')
         .setCheck('Number')
-        .appendField(new blockly.FieldLabel(i18n.quantity()));
+        .appendField(new CdoFieldLabel(i18n.quantity()));
       this.setPreviousStatement(true);
       this.setNextStatement(true);
     },
@@ -299,7 +300,7 @@ export const install = (blockly, blockInstallOptions) => {
     helpUrl: '',
     init: function () {
       this.appendDummyInput()
-        .appendField(new blockly.FieldLabel(i18n.blockActionDropAll()))
+        .appendField(new CdoFieldLabel(i18n.blockActionDropAll()))
         .appendField(new CdoFieldDropdown(fourDirections), 'DIR');
       this.setPreviousStatement(true);
       this.setNextStatement(true);
@@ -315,7 +316,7 @@ export const install = (blockly, blockInstallOptions) => {
     helpUrl: '',
     init: function () {
       this.appendDummyInput()
-        .appendField(new blockly.FieldLabel(i18n.blockActionDetect()))
+        .appendField(new CdoFieldLabel(i18n.blockActionDetect()))
         .appendField(new CdoFieldDropdown(sixDirections), 'DIR');
       this.setOutput(true, Blockly.BlockValueType.BOOLEAN);
     },
@@ -333,7 +334,7 @@ export const install = (blockly, blockInstallOptions) => {
     helpUrl: '',
     init: function () {
       this.appendDummyInput()
-        .appendField(new blockly.FieldLabel(i18n.blockActionInspect()))
+        .appendField(new CdoFieldLabel(i18n.blockActionInspect()))
         .appendField(new CdoFieldDropdown(sixDirections), 'DIR');
       this.setOutput(true, Blockly.JavaScript.STRING);
     },
@@ -351,7 +352,7 @@ export const install = (blockly, blockInstallOptions) => {
     helpUrl: '',
     init: function () {
       this.appendDummyInput()
-        .appendField(new blockly.FieldLabel(i18n.blockActionInspectData()))
+        .appendField(new CdoFieldLabel(i18n.blockActionInspectData()))
         .appendField(new CdoFieldDropdown(sixDirections), 'DIR');
       this.setOutput(true, Blockly.BlockValueType.NUMBER);
     },
@@ -369,7 +370,7 @@ export const install = (blockly, blockInstallOptions) => {
     helpUrl: '',
     init: function () {
       this.appendDummyInput()
-        .appendField(new blockly.FieldLabel(i18n.blockActionDetectRedstone()))
+        .appendField(new CdoFieldLabel(i18n.blockActionDetectRedstone()))
         .appendField(new CdoFieldDropdown(sixDirections), 'DIR');
       this.setOutput(true, Blockly.BlockValueType.BOOLEAN);
     },
@@ -389,7 +390,7 @@ export const install = (blockly, blockInstallOptions) => {
       this.appendValueInput('SLOTNUM')
         .setCheck('Number')
         .appendField(
-          new blockly.FieldLabel(i18n.blockActionGetItemDetailInSlotNumber())
+          new CdoFieldLabel(i18n.blockActionGetItemDetailInSlotNumber())
         );
       this.setOutput(true, Blockly.BlockValueType.STRING);
     },
@@ -413,7 +414,7 @@ export const install = (blockly, blockInstallOptions) => {
       this.appendValueInput('SLOTNUM')
         .setCheck('Number')
         .appendField(
-          new blockly.FieldLabel(i18n.blockActionGetItemSpaceInSlotNumber())
+          new CdoFieldLabel(i18n.blockActionGetItemSpaceInSlotNumber())
         );
       this.setOutput(true, Blockly.BlockValueType.NUMBER);
     },
@@ -437,7 +438,7 @@ export const install = (blockly, blockInstallOptions) => {
       this.appendValueInput('SLOTNUM')
         .setCheck('Number')
         .appendField(
-          new blockly.FieldLabel(i18n.blockActionGetItemCountInSlotNumber())
+          new CdoFieldLabel(i18n.blockActionGetItemCountInSlotNumber())
         );
       this.setOutput(true, Blockly.BlockValueType.NUMBER);
     },
@@ -459,17 +460,17 @@ export const install = (blockly, blockInstallOptions) => {
     helpUrl: '',
     init: function () {
       this.appendDummyInput().appendField(
-        new blockly.FieldLabel(i18n.blockActionTransfer())
+        new CdoFieldLabel(i18n.blockActionTransfer())
       );
       this.appendValueInput('SRCSLOTNUM')
         .setCheck('Number')
-        .appendField(new blockly.FieldLabel(i18n.inSlotNumber()));
+        .appendField(new CdoFieldLabel(i18n.inSlotNumber()));
       this.appendValueInput('DSTSLOTNUM')
         .setCheck('Number')
-        .appendField(new blockly.FieldLabel(i18n.toSlotNumber()));
+        .appendField(new CdoFieldLabel(i18n.toSlotNumber()));
       this.appendValueInput('QUANTITY')
         .setCheck('Number')
-        .appendField(new blockly.FieldLabel(i18n.quantity()));
+        .appendField(new CdoFieldLabel(i18n.quantity()));
       this.setPreviousStatement(true);
       this.setNextStatement(true);
     },
@@ -498,7 +499,7 @@ export const install = (blockly, blockInstallOptions) => {
     helpUrl: '',
     init: function () {
       this.appendDummyInput().appendField(
-        new blockly.FieldLabel(i18n.blockActionTeleportToPlayer())
+        new CdoFieldLabel(i18n.blockActionTeleportToPlayer())
       );
       this.setPreviousStatement(true);
       this.setNextStatement(true);
@@ -513,7 +514,7 @@ export const install = (blockly, blockInstallOptions) => {
     helpUrl: '',
     init: function () {
       this.appendDummyInput()
-        .appendField(new blockly.FieldLabel(i18n.blockActionWait()))
+        .appendField(new CdoFieldLabel(i18n.blockActionWait()))
         .appendField(
           new blockly.FieldTextInput(
             '1000',
@@ -521,7 +522,7 @@ export const install = (blockly, blockInstallOptions) => {
           ),
           'MILLISECONDS'
         )
-        .appendField(new blockly.FieldLabel('ms'));
+        .appendField(new CdoFieldLabel('ms'));
       this.setPreviousStatement(true);
       this.setNextStatement(true);
     },
@@ -536,15 +537,15 @@ export const install = (blockly, blockInstallOptions) => {
     helpUrl: '',
     init: function () {
       this.appendDummyInput()
-        .appendField(new blockly.FieldLabel(i18n.blockActionExecute()))
+        .appendField(new CdoFieldLabel(i18n.blockActionExecute()))
         .appendField(new blockly.FieldTextInput(''), 'COMMAND');
       this.appendDummyInput()
-        .appendField(new blockly.FieldLabel(i18n.onBehalfOf()))
+        .appendField(new CdoFieldLabel(i18n.onBehalfOf()))
         .appendField(new blockly.FieldTextInput(''), 'TARGET');
       this.appendValueInput('VEC3')
         .setCheck('Number')
         .setAlign(Blockly.inputs.Align.RIGHT)
-        .appendField(new blockly.FieldLabel(i18n.at()))
+        .appendField(new CdoFieldLabel(i18n.at()))
         .appendField(new CdoFieldDropdown(positionTypes), 'POSITIONTYPE');
       this.setPreviousStatement(true);
       this.setNextStatement(true);
@@ -567,7 +568,7 @@ export const install = (blockly, blockInstallOptions) => {
     helpUrl: '',
     init: function () {
       this.appendDummyInput()
-        .appendField(new blockly.FieldLabel(i18n.timeSet()))
+        .appendField(new CdoFieldLabel(i18n.timeSet()))
         .appendField(new CdoFieldDropdown(timeTypes), 'TIME');
       this.setPreviousStatement(true);
       this.setNextStatement(true);
@@ -583,9 +584,7 @@ export const install = (blockly, blockInstallOptions) => {
     helpUrl: '',
     init: function () {
       this.setInputsInline(true);
-      this.appendDummyInput().appendField(
-        new blockly.FieldLabel(i18n.timeSet())
-      );
+      this.appendDummyInput().appendField(new CdoFieldLabel(i18n.timeSet()));
       this.appendValueInput('TIME').setCheck('Number');
       this.setPreviousStatement(true);
       this.setNextStatement(true);
@@ -606,7 +605,7 @@ export const install = (blockly, blockInstallOptions) => {
     helpUrl: '',
     init: function () {
       this.appendDummyInput()
-        .appendField(new blockly.FieldLabel(i18n.weather()))
+        .appendField(new CdoFieldLabel(i18n.weather()))
         .appendField(new CdoFieldDropdown(weatherTypes), 'WEATHER');
       this.setPreviousStatement(true);
       this.setNextStatement(true);
@@ -623,10 +622,10 @@ export const install = (blockly, blockInstallOptions) => {
     init: function () {
       this.setInputsInline(true);
       this.appendDummyInput()
-        .appendField(new blockly.FieldLabel(i18n.blockActionTeleport()))
+        .appendField(new CdoFieldLabel(i18n.blockActionTeleport()))
         .appendField(new blockly.FieldTextInput(''), 'VICTIM');
       this.appendDummyInput()
-        .appendField(new blockly.FieldLabel(i18n.to()))
+        .appendField(new CdoFieldLabel(i18n.to()))
         .appendField(new blockly.FieldTextInput(''), 'DESTINATION');
       this.setPreviousStatement(true);
       this.setNextStatement(true);
@@ -643,12 +642,12 @@ export const install = (blockly, blockInstallOptions) => {
     helpUrl: '',
     init: function () {
       this.appendDummyInput()
-        .appendField(new blockly.FieldLabel(i18n.blockActionTeleport()))
+        .appendField(new CdoFieldLabel(i18n.blockActionTeleport()))
         .appendField(new blockly.FieldTextInput(''), 'VICTIM');
       this.appendValueInput('VEC3')
         .setCheck('Number')
         .setAlign(Blockly.inputs.Align.RIGHT)
-        .appendField(new blockly.FieldLabel(i18n.to()))
+        .appendField(new CdoFieldLabel(i18n.to()))
         .appendField(new CdoFieldDropdown(positionTypes), 'POSITIONTYPE');
       this.setPreviousStatement(true);
       this.setNextStatement(true);
@@ -670,7 +669,7 @@ export const install = (blockly, blockInstallOptions) => {
     helpUrl: '',
     init: function () {
       this.appendDummyInput().appendField(
-        new blockly.FieldLabel(i18n.blockActionFill())
+        new CdoFieldLabel(i18n.blockActionFill())
       );
       this.appendValueInput('FROM_VEC3')
         .setCheck('Number')
@@ -679,12 +678,12 @@ export const install = (blockly, blockInstallOptions) => {
       this.appendValueInput('TO_VEC3')
         .setCheck('Number')
         .setAlign(Blockly.inputs.Align.RIGHT)
-        .appendField(new blockly.FieldLabel(i18n.to()))
+        .appendField(new CdoFieldLabel(i18n.to()))
         .appendField(new CdoFieldDropdown(positionTypes), 'TOPOSITIONTYPE');
       this.appendValueInput('ITEM')
         .setCheck(ITEM_TYPE)
         .setAlign(Blockly.inputs.Align.RIGHT)
-        .appendField(new blockly.FieldLabel(i18n.blockActionWith()));
+        .appendField(new CdoFieldLabel(i18n.blockActionWith()));
       this.setPreviousStatement(true);
       this.setNextStatement(true);
     },
@@ -716,13 +715,13 @@ export const install = (blockly, blockInstallOptions) => {
     init: function () {
       this.appendValueInput('AMOUNT')
         .setCheck('Number')
-        .appendField(new blockly.FieldLabel(i18n.blockActionGive()));
+        .appendField(new CdoFieldLabel(i18n.blockActionGive()));
       this.appendValueInput('ITEM')
         .setCheck(ITEM_TYPE)
         .setAlign(Blockly.inputs.Align.RIGHT)
-        .appendField(new blockly.FieldLabel(i18n.itemsOfBlockType()));
+        .appendField(new CdoFieldLabel(i18n.itemsOfBlockType()));
       this.appendDummyInput()
-        .appendField(new blockly.FieldLabel(i18n.to()))
+        .appendField(new CdoFieldLabel(i18n.to()))
         .appendField(new blockly.FieldTextInput(''), 'PLAYER');
       this.setPreviousStatement(true);
       this.setNextStatement(true);
@@ -750,7 +749,7 @@ export const install = (blockly, blockInstallOptions) => {
     init: function () {
       this.setInputsInline(true);
       this.appendDummyInput()
-        .appendField(new blockly.FieldLabel(i18n.blockActionKill()))
+        .appendField(new CdoFieldLabel(i18n.blockActionKill()))
         .appendField(new blockly.FieldTextInput(''), 'TARGET');
       this.setPreviousStatement(true);
       this.setNextStatement(true);
@@ -766,14 +765,14 @@ export const install = (blockly, blockInstallOptions) => {
     helpUrl: '',
     init: function () {
       this.appendDummyInput().appendField(
-        new blockly.FieldLabel(i18n.blockActionSetBlock())
+        new CdoFieldLabel(i18n.blockActionSetBlock())
       );
       this.appendDummyInput()
         .appendField(
           new CdoFieldDropdown(oldBlockHandlings),
           'OLDBLOCKHANDLING'
         )
-        .appendField(new blockly.FieldLabel(i18n.oldBlockHandling()));
+        .appendField(new CdoFieldLabel(i18n.oldBlockHandling()));
       this.appendValueInput('VEC3')
         .setCheck('Number')
         .setAlign(Blockly.inputs.Align.RIGHT)
@@ -781,7 +780,7 @@ export const install = (blockly, blockInstallOptions) => {
       this.appendValueInput('ITEM')
         .setCheck(ITEM_TYPE)
         .setAlign(Blockly.inputs.Align.RIGHT)
-        .appendField(new blockly.FieldLabel(i18n.blockActionWith()));
+        .appendField(new CdoFieldLabel(i18n.blockActionWith()));
       this.setPreviousStatement(true);
       this.setNextStatement(true);
     },
@@ -807,14 +806,14 @@ export const install = (blockly, blockInstallOptions) => {
     helpUrl: '',
     init: function () {
       this.appendDummyInput().appendField(
-        new blockly.FieldLabel(i18n.blockActionSummon())
+        new CdoFieldLabel(i18n.blockActionSummon())
       );
       this.appendDummyInput()
-        .appendField(new blockly.FieldLabel(i18n.entityType()))
+        .appendField(new CdoFieldLabel(i18n.entityType()))
         .appendField(new blockly.FieldTextInput(''), 'ENTITYTYPE');
       this.appendValueInput('VEC3')
         .setCheck('Number')
-        .appendField(new blockly.FieldLabel(i18n.at()))
+        .appendField(new CdoFieldLabel(i18n.at()))
         .appendField(new CdoFieldDropdown(positionTypes), 'POSITIONTYPE');
       this.setPreviousStatement(true);
       this.setNextStatement(true);
@@ -836,17 +835,17 @@ export const install = (blockly, blockInstallOptions) => {
     helpUrl: '',
     init: function () {
       this.appendDummyInput().appendField(
-        new blockly.FieldLabel(i18n.blockActionTestForBlock())
+        new CdoFieldLabel(i18n.blockActionTestForBlock())
       );
       this.appendValueInput('VEC3')
         .setCheck('Number')
         .setAlign(Blockly.inputs.Align.RIGHT)
-        .appendField(new blockly.FieldLabel(i18n.at()))
+        .appendField(new CdoFieldLabel(i18n.at()))
         .appendField(new CdoFieldDropdown(positionTypes), 'POSITIONTYPE');
       this.appendValueInput('ITEM')
         .setCheck(ITEM_TYPE)
         .setAlign(Blockly.inputs.Align.RIGHT)
-        .appendField(new blockly.FieldLabel(i18n.blockIs()));
+        .appendField(new CdoFieldLabel(i18n.blockIs()));
       this.setOutput(true, Blockly.BlockValueType.BOOLEAN);
     },
   };
@@ -874,22 +873,22 @@ export const install = (blockly, blockInstallOptions) => {
     helpUrl: '',
     init: function () {
       this.appendDummyInput().appendField(
-        new blockly.FieldLabel(i18n.blockActionTestForBlocks())
+        new CdoFieldLabel(i18n.blockActionTestForBlocks())
       );
       this.appendValueInput('FROM_VEC3')
         .setCheck('Number')
         .setAlign(Blockly.inputs.Align.RIGHT)
-        .appendField(new blockly.FieldLabel(i18n.from()))
+        .appendField(new CdoFieldLabel(i18n.from()))
         .appendField(new CdoFieldDropdown(positionTypes), 'FROMPOSITIONTYPE');
       this.appendValueInput('TO_VEC3')
         .setCheck('Number')
         .setAlign(Blockly.inputs.Align.RIGHT)
-        .appendField(new blockly.FieldLabel(i18n.to()))
+        .appendField(new CdoFieldLabel(i18n.to()))
         .appendField(new CdoFieldDropdown(positionTypes), 'TOPOSITIONTYPE');
       this.appendValueInput('VEC3')
         .setCheck('Number')
         .setAlign(Blockly.inputs.Align.RIGHT)
-        .appendField(new blockly.FieldLabel(i18n.destination()))
+        .appendField(new CdoFieldLabel(i18n.destination()))
         .appendField(new CdoFieldDropdown(positionTypes), 'POSITIONTYPE');
       this.appendDummyInput()
         .setAlign(Blockly.inputs.Align.RIGHT)
@@ -928,28 +927,28 @@ export const install = (blockly, blockInstallOptions) => {
     helpUrl: '',
     init: function () {
       this.appendDummyInput().appendField(
-        new blockly.FieldLabel(i18n.blockActionClone())
+        new CdoFieldLabel(i18n.blockActionClone())
       );
       this.appendValueInput('FROM_VEC3')
         .setCheck('Number')
         .setAlign(Blockly.inputs.Align.RIGHT)
-        .appendField(new blockly.FieldLabel(i18n.from()))
+        .appendField(new CdoFieldLabel(i18n.from()))
         .appendField(new CdoFieldDropdown(positionTypes), 'FROMPOSITIONTYPE');
       this.appendValueInput('TO_VEC3')
         .setCheck('Number')
         .setAlign(Blockly.inputs.Align.RIGHT)
-        .appendField(new blockly.FieldLabel(i18n.to()))
+        .appendField(new CdoFieldLabel(i18n.to()))
         .appendField(new CdoFieldDropdown(positionTypes), 'TOPOSITIONTYPE');
       this.appendValueInput('VEC3')
         .setCheck('Number')
         .setAlign(Blockly.inputs.Align.RIGHT)
-        .appendField(new blockly.FieldLabel(i18n.destination()))
+        .appendField(new CdoFieldLabel(i18n.destination()))
         .appendField(new CdoFieldDropdown(positionTypes), 'POSITIONTYPE');
       this.appendDummyInput()
-        .appendField(new blockly.FieldLabel(i18n.maskMode()))
+        .appendField(new CdoFieldLabel(i18n.maskMode()))
         .appendField(new CdoFieldDropdown(maskModes), 'MASKMODE');
       this.appendDummyInput()
-        .appendField(new blockly.FieldLabel(i18n.cloneMode()))
+        .appendField(new CdoFieldLabel(i18n.cloneMode()))
         .appendField(new CdoFieldDropdown(cloneModes), 'CLONEMODE');
       this.setPreviousStatement(true);
       this.setNextStatement(true);
@@ -986,24 +985,24 @@ export const install = (blockly, blockInstallOptions) => {
       this.appendValueInput('ITEM')
         .setCheck(ITEM_TYPE)
         .setAlign(Blockly.inputs.Align.RIGHT)
-        .appendField(new blockly.FieldLabel(i18n.blockActionCloneFiltered()));
+        .appendField(new CdoFieldLabel(i18n.blockActionCloneFiltered()));
       this.appendValueInput('FROM_VEC3')
         .setCheck('Number')
         .setAlign(Blockly.inputs.Align.RIGHT)
-        .appendField(new blockly.FieldLabel(i18n.from()))
+        .appendField(new CdoFieldLabel(i18n.from()))
         .appendField(new CdoFieldDropdown(positionTypes), 'FROMPOSITIONTYPE');
       this.appendValueInput('TO_VEC3')
         .setCheck('Number')
         .setAlign(Blockly.inputs.Align.RIGHT)
-        .appendField(new blockly.FieldLabel(i18n.to()))
+        .appendField(new CdoFieldLabel(i18n.to()))
         .appendField(new CdoFieldDropdown(positionTypes), 'TOPOSITIONTYPE');
       this.appendValueInput('VEC3')
         .setCheck('Number')
         .setAlign(Blockly.inputs.Align.RIGHT)
-        .appendField(new blockly.FieldLabel(i18n.destination()))
+        .appendField(new CdoFieldLabel(i18n.destination()))
         .appendField(new CdoFieldDropdown(positionTypes), 'POSITIONTYPE');
       this.appendDummyInput()
-        .appendField(new blockly.FieldLabel(i18n.cloneMode()))
+        .appendField(new CdoFieldLabel(i18n.cloneMode()))
         .appendField(new CdoFieldDropdown(cloneModes), 'CLONEMODE');
       this.setPreviousStatement(true);
       this.setNextStatement(true);
@@ -1044,10 +1043,10 @@ export const install = (blockly, blockInstallOptions) => {
     init: function () {
       this.appendValueInput('BLOCKTYPE')
         .setCheck(Blockly.JavaScript.STRING)
-        .appendField(new blockly.FieldLabel(i18n.blockType()));
+        .appendField(new CdoFieldLabel(i18n.blockType()));
       this.appendValueInput('BLOCKDATA')
         .setCheck(Blockly.JavaScript.STRING)
-        .appendField(new blockly.FieldLabel(i18n.blockData()));
+        .appendField(new CdoFieldLabel(i18n.blockData()));
       this.setOutput(true, ITEM_TYPE);
     },
   };
@@ -1072,7 +1071,7 @@ export const install = (blockly, blockInstallOptions) => {
   blockly.Blocks.craft_block = {
     init: function () {
       this.appendDummyInput()
-        .appendField(new blockly.FieldLabel(i18n.itemTypeBlock()))
+        .appendField(new CdoFieldLabel(i18n.itemTypeBlock()))
         .appendField(new CdoFieldImageDropdown(items.blocks, 32, 32), 'BLOCK');
       this.setOutput(true, ITEM_TYPE);
     },
@@ -1089,7 +1088,7 @@ export const install = (blockly, blockInstallOptions) => {
   blockly.Blocks.craft_miscellaneous = {
     init: function () {
       this.appendDummyInput()
-        .appendField(new blockly.FieldLabel(i18n.itemTypeMiscellaneous()))
+        .appendField(new CdoFieldLabel(i18n.itemTypeMiscellaneous()))
         .appendField(
           new CdoFieldImageDropdown(items.miscellaneous, 32, 32),
           'ITEM'
@@ -1109,7 +1108,7 @@ export const install = (blockly, blockInstallOptions) => {
   blockly.Blocks.craft_decoration = {
     init: function () {
       this.appendDummyInput()
-        .appendField(new blockly.FieldLabel(i18n.itemTypeDecoration()))
+        .appendField(new CdoFieldLabel(i18n.itemTypeDecoration()))
         .appendField(
           new CdoFieldImageDropdown(items.decorations, 32, 32),
           'ITEM'
@@ -1129,7 +1128,7 @@ export const install = (blockly, blockInstallOptions) => {
   blockly.Blocks.craft_tool = {
     init: function () {
       this.appendDummyInput()
-        .appendField(new blockly.FieldLabel(i18n.itemTypeTool()))
+        .appendField(new CdoFieldLabel(i18n.itemTypeTool()))
         .appendField(new CdoFieldImageDropdown(items.tools, 32, 32), 'ITEM');
       this.setOutput(true, ITEM_TYPE);
     },
@@ -1147,7 +1146,7 @@ export const install = (blockly, blockInstallOptions) => {
     init: function () {
       this.appendValueInput('ITEM')
         .setCheck(ITEM_TYPE)
-        .appendField(new blockly.FieldLabel(i18n.getnameof()));
+        .appendField(new CdoFieldLabel(i18n.getnameof()));
       this.setOutput(true, Blockly.JavaScript.STRING);
     },
   };
@@ -1165,7 +1164,7 @@ export const install = (blockly, blockInstallOptions) => {
     init: function () {
       this.appendValueInput('ITEM')
         .setCheck(ITEM_TYPE)
-        .appendField(new blockly.FieldLabel(i18n.getdataof()));
+        .appendField(new CdoFieldLabel(i18n.getdataof()));
       this.setOutput(true, Blockly.JavaScript.STRING);
     },
   };

--- a/apps/src/craft/code-connection/blocks.js
+++ b/apps/src/craft/code-connection/blocks.js
@@ -1,3 +1,5 @@
+import {CdoFieldImageDropdown} from '@cdo/apps/blockly/addons/cdoFieldImageDropdown';
+
 import items from './items';
 
 var i18n = require('../locale');
@@ -1094,10 +1096,7 @@ export const install = (blockly, blockInstallOptions) => {
     init: function () {
       this.appendDummyInput()
         .appendField(new blockly.FieldLabel(i18n.itemTypeBlock()))
-        .appendField(
-          new blockly.FieldImageDropdown(items.blocks, 32, 32),
-          'BLOCK'
-        );
+        .appendField(new CdoFieldImageDropdown(items.blocks, 32, 32), 'BLOCK');
       this.setOutput(true, ITEM_TYPE);
     },
   };
@@ -1115,7 +1114,7 @@ export const install = (blockly, blockInstallOptions) => {
       this.appendDummyInput()
         .appendField(new blockly.FieldLabel(i18n.itemTypeMiscellaneous()))
         .appendField(
-          new blockly.FieldImageDropdown(items.miscellaneous, 32, 32),
+          new CdoFieldImageDropdown(items.miscellaneous, 32, 32),
           'ITEM'
         );
       this.setOutput(true, ITEM_TYPE);
@@ -1135,7 +1134,7 @@ export const install = (blockly, blockInstallOptions) => {
       this.appendDummyInput()
         .appendField(new blockly.FieldLabel(i18n.itemTypeDecoration()))
         .appendField(
-          new blockly.FieldImageDropdown(items.decorations, 32, 32),
+          new CdoFieldImageDropdown(items.decorations, 32, 32),
           'ITEM'
         );
       this.setOutput(true, ITEM_TYPE);
@@ -1154,10 +1153,7 @@ export const install = (blockly, blockInstallOptions) => {
     init: function () {
       this.appendDummyInput()
         .appendField(new blockly.FieldLabel(i18n.itemTypeTool()))
-        .appendField(
-          new blockly.FieldImageDropdown(items.tools, 32, 32),
-          'ITEM'
-        );
+        .appendField(new CdoFieldImageDropdown(items.tools, 32, 32), 'ITEM');
       this.setOutput(true, ITEM_TYPE);
     },
   };

--- a/apps/src/craft/code-connection/blocks.js
+++ b/apps/src/craft/code-connection/blocks.js
@@ -1,3 +1,4 @@
+import CdoFieldDropdown from '@cdo/apps/blockly/addons/cdoFieldDropdown';
 import {CdoFieldImageDropdown} from '@cdo/apps/blockly/addons/cdoFieldImageDropdown';
 
 import items from './items';
@@ -128,7 +129,7 @@ export const install = (blockly, blockInstallOptions) => {
     init: function () {
       this.appendDummyInput()
         .appendField(new blockly.FieldLabel(i18n.blockMove()))
-        .appendField(new blockly.FieldDropdown(sixDirections), 'DIR');
+        .appendField(new CdoFieldDropdown(sixDirections), 'DIR');
       this.setPreviousStatement(true);
       this.setNextStatement(true);
     },
@@ -144,7 +145,7 @@ export const install = (blockly, blockInstallOptions) => {
     init: function () {
       this.appendDummyInput()
         .appendField(new blockly.FieldLabel(i18n.blockTurn()))
-        .appendField(new blockly.FieldDropdown(rotateDirections), 'DIR');
+        .appendField(new CdoFieldDropdown(rotateDirections), 'DIR');
       this.setPreviousStatement(true);
       this.setNextStatement(true);
     },
@@ -160,7 +161,7 @@ export const install = (blockly, blockInstallOptions) => {
     init: function () {
       this.appendDummyInput()
         .appendField(new blockly.FieldLabel(i18n.blockPlace()))
-        .appendField(new blockly.FieldDropdown(sixDirections), 'DIR');
+        .appendField(new CdoFieldDropdown(sixDirections), 'DIR');
       this.appendValueInput('SLOTNUM')
         .setCheck('Number')
         .appendField(new blockly.FieldLabel(i18n.inSlotNumber()));
@@ -184,7 +185,7 @@ export const install = (blockly, blockInstallOptions) => {
     init: function () {
       this.appendDummyInput()
         .appendField(new blockly.FieldLabel(i18n.blockTill()))
-        .appendField(new blockly.FieldDropdown(sixDirections), 'DIR');
+        .appendField(new CdoFieldDropdown(sixDirections), 'DIR');
       this.setPreviousStatement(true);
       this.setNextStatement(true);
     },
@@ -200,7 +201,7 @@ export const install = (blockly, blockInstallOptions) => {
     init: function () {
       this.appendDummyInput()
         .appendField(new blockly.FieldLabel(i18n.blockActionAttack()))
-        .appendField(new blockly.FieldDropdown(sixDirections), 'DIR');
+        .appendField(new CdoFieldDropdown(sixDirections), 'DIR');
       this.setPreviousStatement(true);
       this.setNextStatement(true);
     },
@@ -216,7 +217,7 @@ export const install = (blockly, blockInstallOptions) => {
     init: function () {
       this.appendDummyInput()
         .appendField(new blockly.FieldLabel(i18n.blockDestroyBlock()))
-        .appendField(new blockly.FieldDropdown(sixDirections), 'DIR');
+        .appendField(new CdoFieldDropdown(sixDirections), 'DIR');
       this.setPreviousStatement(true);
       this.setNextStatement(true);
     },
@@ -267,7 +268,7 @@ export const install = (blockly, blockInstallOptions) => {
     init: function () {
       this.appendDummyInput()
         .appendField(new blockly.FieldLabel(i18n.blockActionDrop()))
-        .appendField(new blockly.FieldDropdown(fourDirections), 'DIR');
+        .appendField(new CdoFieldDropdown(fourDirections), 'DIR');
       this.appendValueInput('SLOTNUM')
         .setCheck('Number')
         .appendField(new blockly.FieldLabel(i18n.inSlotNumber()));
@@ -299,7 +300,7 @@ export const install = (blockly, blockInstallOptions) => {
     init: function () {
       this.appendDummyInput()
         .appendField(new blockly.FieldLabel(i18n.blockActionDropAll()))
-        .appendField(new blockly.FieldDropdown(fourDirections), 'DIR');
+        .appendField(new CdoFieldDropdown(fourDirections), 'DIR');
       this.setPreviousStatement(true);
       this.setNextStatement(true);
     },
@@ -315,7 +316,7 @@ export const install = (blockly, blockInstallOptions) => {
     init: function () {
       this.appendDummyInput()
         .appendField(new blockly.FieldLabel(i18n.blockActionDetect()))
-        .appendField(new blockly.FieldDropdown(sixDirections), 'DIR');
+        .appendField(new CdoFieldDropdown(sixDirections), 'DIR');
       this.setOutput(true, Blockly.BlockValueType.BOOLEAN);
     },
   };
@@ -333,7 +334,7 @@ export const install = (blockly, blockInstallOptions) => {
     init: function () {
       this.appendDummyInput()
         .appendField(new blockly.FieldLabel(i18n.blockActionInspect()))
-        .appendField(new blockly.FieldDropdown(sixDirections), 'DIR');
+        .appendField(new CdoFieldDropdown(sixDirections), 'DIR');
       this.setOutput(true, Blockly.JavaScript.STRING);
     },
   };
@@ -351,7 +352,7 @@ export const install = (blockly, blockInstallOptions) => {
     init: function () {
       this.appendDummyInput()
         .appendField(new blockly.FieldLabel(i18n.blockActionInspectData()))
-        .appendField(new blockly.FieldDropdown(sixDirections), 'DIR');
+        .appendField(new CdoFieldDropdown(sixDirections), 'DIR');
       this.setOutput(true, Blockly.BlockValueType.NUMBER);
     },
   };
@@ -369,7 +370,7 @@ export const install = (blockly, blockInstallOptions) => {
     init: function () {
       this.appendDummyInput()
         .appendField(new blockly.FieldLabel(i18n.blockActionDetectRedstone()))
-        .appendField(new blockly.FieldDropdown(sixDirections), 'DIR');
+        .appendField(new CdoFieldDropdown(sixDirections), 'DIR');
       this.setOutput(true, Blockly.BlockValueType.BOOLEAN);
     },
   };
@@ -544,7 +545,7 @@ export const install = (blockly, blockInstallOptions) => {
         .setCheck('Number')
         .setAlign(Blockly.inputs.Align.RIGHT)
         .appendField(new blockly.FieldLabel(i18n.at()))
-        .appendField(new blockly.FieldDropdown(positionTypes), 'POSITIONTYPE');
+        .appendField(new CdoFieldDropdown(positionTypes), 'POSITIONTYPE');
       this.setPreviousStatement(true);
       this.setNextStatement(true);
     },
@@ -567,7 +568,7 @@ export const install = (blockly, blockInstallOptions) => {
     init: function () {
       this.appendDummyInput()
         .appendField(new blockly.FieldLabel(i18n.timeSet()))
-        .appendField(new blockly.FieldDropdown(timeTypes), 'TIME');
+        .appendField(new CdoFieldDropdown(timeTypes), 'TIME');
       this.setPreviousStatement(true);
       this.setNextStatement(true);
     },
@@ -606,7 +607,7 @@ export const install = (blockly, blockInstallOptions) => {
     init: function () {
       this.appendDummyInput()
         .appendField(new blockly.FieldLabel(i18n.weather()))
-        .appendField(new blockly.FieldDropdown(weatherTypes), 'WEATHER');
+        .appendField(new CdoFieldDropdown(weatherTypes), 'WEATHER');
       this.setPreviousStatement(true);
       this.setNextStatement(true);
     },
@@ -648,7 +649,7 @@ export const install = (blockly, blockInstallOptions) => {
         .setCheck('Number')
         .setAlign(Blockly.inputs.Align.RIGHT)
         .appendField(new blockly.FieldLabel(i18n.to()))
-        .appendField(new blockly.FieldDropdown(positionTypes), 'POSITIONTYPE');
+        .appendField(new CdoFieldDropdown(positionTypes), 'POSITIONTYPE');
       this.setPreviousStatement(true);
       this.setNextStatement(true);
     },
@@ -674,18 +675,12 @@ export const install = (blockly, blockInstallOptions) => {
       this.appendValueInput('FROM_VEC3')
         .setCheck('Number')
         .setAlign(Blockly.inputs.Align.RIGHT)
-        .appendField(
-          new blockly.FieldDropdown(positionTypes),
-          'FROMPOSITIONTYPE'
-        );
+        .appendField(new CdoFieldDropdown(positionTypes), 'FROMPOSITIONTYPE');
       this.appendValueInput('TO_VEC3')
         .setCheck('Number')
         .setAlign(Blockly.inputs.Align.RIGHT)
         .appendField(new blockly.FieldLabel(i18n.to()))
-        .appendField(
-          new blockly.FieldDropdown(positionTypes),
-          'TOPOSITIONTYPE'
-        );
+        .appendField(new CdoFieldDropdown(positionTypes), 'TOPOSITIONTYPE');
       this.appendValueInput('ITEM')
         .setCheck(ITEM_TYPE)
         .setAlign(Blockly.inputs.Align.RIGHT)
@@ -775,14 +770,14 @@ export const install = (blockly, blockInstallOptions) => {
       );
       this.appendDummyInput()
         .appendField(
-          new blockly.FieldDropdown(oldBlockHandlings),
+          new CdoFieldDropdown(oldBlockHandlings),
           'OLDBLOCKHANDLING'
         )
         .appendField(new blockly.FieldLabel(i18n.oldBlockHandling()));
       this.appendValueInput('VEC3')
         .setCheck('Number')
         .setAlign(Blockly.inputs.Align.RIGHT)
-        .appendField(new blockly.FieldDropdown(positionTypes), 'POSITIONTYPE');
+        .appendField(new CdoFieldDropdown(positionTypes), 'POSITIONTYPE');
       this.appendValueInput('ITEM')
         .setCheck(ITEM_TYPE)
         .setAlign(Blockly.inputs.Align.RIGHT)
@@ -820,7 +815,7 @@ export const install = (blockly, blockInstallOptions) => {
       this.appendValueInput('VEC3')
         .setCheck('Number')
         .appendField(new blockly.FieldLabel(i18n.at()))
-        .appendField(new blockly.FieldDropdown(positionTypes), 'POSITIONTYPE');
+        .appendField(new CdoFieldDropdown(positionTypes), 'POSITIONTYPE');
       this.setPreviousStatement(true);
       this.setNextStatement(true);
     },
@@ -847,7 +842,7 @@ export const install = (blockly, blockInstallOptions) => {
         .setCheck('Number')
         .setAlign(Blockly.inputs.Align.RIGHT)
         .appendField(new blockly.FieldLabel(i18n.at()))
-        .appendField(new blockly.FieldDropdown(positionTypes), 'POSITIONTYPE');
+        .appendField(new CdoFieldDropdown(positionTypes), 'POSITIONTYPE');
       this.appendValueInput('ITEM')
         .setCheck(ITEM_TYPE)
         .setAlign(Blockly.inputs.Align.RIGHT)
@@ -885,26 +880,20 @@ export const install = (blockly, blockInstallOptions) => {
         .setCheck('Number')
         .setAlign(Blockly.inputs.Align.RIGHT)
         .appendField(new blockly.FieldLabel(i18n.from()))
-        .appendField(
-          new blockly.FieldDropdown(positionTypes),
-          'FROMPOSITIONTYPE'
-        );
+        .appendField(new CdoFieldDropdown(positionTypes), 'FROMPOSITIONTYPE');
       this.appendValueInput('TO_VEC3')
         .setCheck('Number')
         .setAlign(Blockly.inputs.Align.RIGHT)
         .appendField(new blockly.FieldLabel(i18n.to()))
-        .appendField(
-          new blockly.FieldDropdown(positionTypes),
-          'TOPOSITIONTYPE'
-        );
+        .appendField(new CdoFieldDropdown(positionTypes), 'TOPOSITIONTYPE');
       this.appendValueInput('VEC3')
         .setCheck('Number')
         .setAlign(Blockly.inputs.Align.RIGHT)
         .appendField(new blockly.FieldLabel(i18n.destination()))
-        .appendField(new blockly.FieldDropdown(positionTypes), 'POSITIONTYPE');
+        .appendField(new CdoFieldDropdown(positionTypes), 'POSITIONTYPE');
       this.appendDummyInput()
         .setAlign(Blockly.inputs.Align.RIGHT)
-        .appendField(new blockly.FieldDropdown(testModes), 'TESTMODE');
+        .appendField(new CdoFieldDropdown(testModes), 'TESTMODE');
       this.setOutput(true, Blockly.BlockValueType.BOOLEAN);
     },
   };
@@ -945,29 +934,23 @@ export const install = (blockly, blockInstallOptions) => {
         .setCheck('Number')
         .setAlign(Blockly.inputs.Align.RIGHT)
         .appendField(new blockly.FieldLabel(i18n.from()))
-        .appendField(
-          new blockly.FieldDropdown(positionTypes),
-          'FROMPOSITIONTYPE'
-        );
+        .appendField(new CdoFieldDropdown(positionTypes), 'FROMPOSITIONTYPE');
       this.appendValueInput('TO_VEC3')
         .setCheck('Number')
         .setAlign(Blockly.inputs.Align.RIGHT)
         .appendField(new blockly.FieldLabel(i18n.to()))
-        .appendField(
-          new blockly.FieldDropdown(positionTypes),
-          'TOPOSITIONTYPE'
-        );
+        .appendField(new CdoFieldDropdown(positionTypes), 'TOPOSITIONTYPE');
       this.appendValueInput('VEC3')
         .setCheck('Number')
         .setAlign(Blockly.inputs.Align.RIGHT)
         .appendField(new blockly.FieldLabel(i18n.destination()))
-        .appendField(new blockly.FieldDropdown(positionTypes), 'POSITIONTYPE');
+        .appendField(new CdoFieldDropdown(positionTypes), 'POSITIONTYPE');
       this.appendDummyInput()
         .appendField(new blockly.FieldLabel(i18n.maskMode()))
-        .appendField(new blockly.FieldDropdown(maskModes), 'MASKMODE');
+        .appendField(new CdoFieldDropdown(maskModes), 'MASKMODE');
       this.appendDummyInput()
         .appendField(new blockly.FieldLabel(i18n.cloneMode()))
-        .appendField(new blockly.FieldDropdown(cloneModes), 'CLONEMODE');
+        .appendField(new CdoFieldDropdown(cloneModes), 'CLONEMODE');
       this.setPreviousStatement(true);
       this.setNextStatement(true);
     },
@@ -1008,26 +991,20 @@ export const install = (blockly, blockInstallOptions) => {
         .setCheck('Number')
         .setAlign(Blockly.inputs.Align.RIGHT)
         .appendField(new blockly.FieldLabel(i18n.from()))
-        .appendField(
-          new blockly.FieldDropdown(positionTypes),
-          'FROMPOSITIONTYPE'
-        );
+        .appendField(new CdoFieldDropdown(positionTypes), 'FROMPOSITIONTYPE');
       this.appendValueInput('TO_VEC3')
         .setCheck('Number')
         .setAlign(Blockly.inputs.Align.RIGHT)
         .appendField(new blockly.FieldLabel(i18n.to()))
-        .appendField(
-          new blockly.FieldDropdown(positionTypes),
-          'TOPOSITIONTYPE'
-        );
+        .appendField(new CdoFieldDropdown(positionTypes), 'TOPOSITIONTYPE');
       this.appendValueInput('VEC3')
         .setCheck('Number')
         .setAlign(Blockly.inputs.Align.RIGHT)
         .appendField(new blockly.FieldLabel(i18n.destination()))
-        .appendField(new blockly.FieldDropdown(positionTypes), 'POSITIONTYPE');
+        .appendField(new CdoFieldDropdown(positionTypes), 'POSITIONTYPE');
       this.appendDummyInput()
         .appendField(new blockly.FieldLabel(i18n.cloneMode()))
-        .appendField(new blockly.FieldDropdown(cloneModes), 'CLONEMODE');
+        .appendField(new CdoFieldDropdown(cloneModes), 'CLONEMODE');
       this.setPreviousStatement(true);
       this.setNextStatement(true);
     },

--- a/apps/src/craft/designer/blocks.js
+++ b/apps/src/craft/designer/blocks.js
@@ -2,6 +2,7 @@ import {EventType} from '@code-dot-org/craft';
 import _ from 'lodash';
 
 import CdoFieldDropdown from '@cdo/apps/blockly/addons/cdoFieldDropdown';
+import CdoFieldLabel from '@cdo/apps/blockly/addons/cdoFieldLabel';
 import {BlockStyles} from '@cdo/apps/blockly/constants';
 import {addSerializationHooksToBlock} from '@cdo/apps/blockly/utils';
 
@@ -471,7 +472,7 @@ export const install = (blockly, blockInstallOptions) => {
         }
         this.setStyle(BlockStyles.DEFAULT);
         this.appendDummyInput()
-          .appendField(new blockly.FieldLabel(blockText))
+          .appendField(new CdoFieldLabel(blockText))
           .appendField(dropdown, 'TYPE');
         this.setPreviousStatement(true);
         this.setNextStatement(true);
@@ -489,7 +490,7 @@ export const install = (blockly, blockInstallOptions) => {
       helpUrl: '',
       init: function () {
         this.setStyle(BlockStyles.DEFAULT);
-        this.appendDummyInput().appendField(new blockly.FieldLabel(blockText));
+        this.appendDummyInput().appendField(new CdoFieldLabel(blockText));
         this.setPreviousStatement(true);
         this.setNextStatement(true);
       },
@@ -514,7 +515,7 @@ export const install = (blockly, blockInstallOptions) => {
         dropdown.setValue(dropdownOptions[0][1]);
         this.setStyle(BlockStyles.DEFAULT);
         this.appendDummyInput()
-          .appendField(new blockly.FieldLabel(blockText))
+          .appendField(new CdoFieldLabel(blockText))
           .appendField(dropdown, 'TYPE');
         this.setPreviousStatement(true);
         this.setNextStatement(true);
@@ -668,9 +669,9 @@ export const install = (blockly, blockInstallOptions) => {
 
       this.setStyle(BlockStyles.DEFAULT);
       this.appendDummyInput()
-        .appendField(new blockly.FieldLabel(i18n.blockActionSpawn()))
+        .appendField(new CdoFieldLabel(i18n.blockActionSpawn()))
         .appendField(entityTypeDropdown, 'TYPE')
-        .appendField(new blockly.FieldLabel(' '))
+        .appendField(new CdoFieldLabel(' '))
         .appendField(locationDropdown, 'DIRECTION');
       this.setPreviousStatement(true);
       this.setNextStatement(true);
@@ -696,7 +697,7 @@ export const install = (blockly, blockInstallOptions) => {
 
       this.setStyle(BlockStyles.DEFAULT);
       this.appendDummyInput()
-        .appendField(new blockly.FieldLabel('spawn'))
+        .appendField(new CdoFieldLabel('spawn'))
         .appendField(entityTypeDropdown, 'TYPE');
       this.setPreviousStatement(true);
       this.setNextStatement(true);
@@ -712,7 +713,7 @@ export const install = (blockly, blockInstallOptions) => {
     helpUrl: '',
     init: function () {
       this.setStyle(BlockStyles.DEFAULT);
-      this.appendDummyInput().appendField(new blockly.FieldLabel('move north'));
+      this.appendDummyInput().appendField(new CdoFieldLabel('move north'));
       this.setPreviousStatement(true);
       this.setNextStatement(true);
     },
@@ -726,7 +727,7 @@ export const install = (blockly, blockInstallOptions) => {
     helpUrl: '',
     init: function () {
       this.setStyle(BlockStyles.DEFAULT);
-      this.appendDummyInput().appendField(new blockly.FieldLabel('move south'));
+      this.appendDummyInput().appendField(new CdoFieldLabel('move south'));
       this.setPreviousStatement(true);
       this.setNextStatement(true);
     },
@@ -740,7 +741,7 @@ export const install = (blockly, blockInstallOptions) => {
     helpUrl: '',
     init: function () {
       this.setStyle(BlockStyles.DEFAULT);
-      this.appendDummyInput().appendField(new blockly.FieldLabel('move east'));
+      this.appendDummyInput().appendField(new CdoFieldLabel('move east'));
       this.setPreviousStatement(true);
       this.setNextStatement(true);
     },
@@ -754,7 +755,7 @@ export const install = (blockly, blockInstallOptions) => {
     helpUrl: '',
     init: function () {
       this.setStyle(BlockStyles.DEFAULT);
-      this.appendDummyInput().appendField(new blockly.FieldLabel('move west'));
+      this.appendDummyInput().appendField(new CdoFieldLabel('move west'));
       this.setPreviousStatement(true);
       this.setNextStatement(true);
     },

--- a/apps/src/craft/designer/blocks.js
+++ b/apps/src/craft/designer/blocks.js
@@ -1,6 +1,7 @@
 import {EventType} from '@code-dot-org/craft';
 import _ from 'lodash';
 
+import CdoFieldDropdown from '@cdo/apps/blockly/addons/cdoFieldDropdown';
 import {BlockStyles} from '@cdo/apps/blockly/constants';
 import {addSerializationHooksToBlock} from '@cdo/apps/blockly/utils';
 
@@ -15,7 +16,7 @@ const ENTITY_INPUT_EXTRA_SPACING = 14;
 const NUMBERS_TO_DISPLAY_TEXT = {
   // prettier wants to remove quotes here
   // eslint-disable-next-line prettier/prettier
-  '0.4': i18n.timeVeryShort(),
+  0.4: i18n.timeVeryShort(),
   '1.0': i18n.timeShort(),
   '2.0': i18n.timeMedium(),
   '4.0': i18n.timeLong(),
@@ -183,7 +184,7 @@ export const install = (blockly, blockInstallOptions) => {
     init: function () {
       this.setStyle(BlockStyles.DEFAULT);
       this.appendDummyInput().appendField(
-        new blockly.FieldDropdown(this.DIRECTIONS),
+        new CdoFieldDropdown(this.DIRECTIONS),
         'DIR'
       );
       this.setPreviousStatement(true);
@@ -213,9 +214,7 @@ export const install = (blockly, blockInstallOptions) => {
     init: function () {
       this.setStyle(BlockStyles.DEFAULT);
       this.appendDummyInput().appendField(
-        new blockly.FieldDropdown(
-          blockly.Blocks.craft_entityTurn.ENTITY_DIRECTIONS
-        ),
+        new CdoFieldDropdown(blockly.Blocks.craft_entityTurn.ENTITY_DIRECTIONS),
         'DIR'
       );
       this.setPreviousStatement(true);
@@ -246,7 +245,7 @@ export const install = (blockly, blockInstallOptions) => {
     init: function () {
       this.setStyle(BlockStyles.DEFAULT);
       this.appendDummyInput().appendField(
-        new blockly.FieldDropdown(
+        new CdoFieldDropdown(
           blockly.Blocks.craft_entityTurnLR.ENTITY_DIRECTIONS
         ),
         'DIR'
@@ -465,7 +464,7 @@ export const install = (blockly, blockInstallOptions) => {
       helpUrl: '',
       init: function () {
         let dropdownOptions = keysToDropdownOptions(dropdownArray);
-        const dropdown = new blockly.FieldDropdown(dropdownOptions);
+        const dropdown = new CdoFieldDropdown(dropdownOptions);
         dropdown.setValue(dropdownOptions[0][1]);
         if (doSort) {
           dropdownOptions = _.sortBy(dropdownOptions, 0);
@@ -511,7 +510,7 @@ export const install = (blockly, blockInstallOptions) => {
       helpUrl: '',
       init: function () {
         const dropdownOptions = keysToDropdownOptions(types);
-        const dropdown = new blockly.FieldDropdown(dropdownOptions);
+        const dropdown = new CdoFieldDropdown(dropdownOptions);
         dropdown.setValue(dropdownOptions[0][1]);
         this.setStyle(BlockStyles.DEFAULT);
         this.appendDummyInput()
@@ -628,7 +627,7 @@ export const install = (blockly, blockInstallOptions) => {
         k.toString(),
         k.toString(),
       ]);
-      const dropdown = new blockly.FieldDropdown(dropdownOptions);
+      const dropdown = new CdoFieldDropdown(dropdownOptions);
       dropdown.setValue(dropdownOptions[0][1]);
 
       this.setStyle(BlockStyles.LOOP);
@@ -660,11 +659,11 @@ export const install = (blockly, blockInstallOptions) => {
       const entityTypeDropdownOptions = keysToDropdownOptions(
         SPAWNABLE_ENTITY_TYPES
       );
-      const entityTypeDropdown = new blockly.FieldDropdown(
+      const entityTypeDropdown = new CdoFieldDropdown(
         entityTypeDropdownOptions
       );
       entityTypeDropdown.setValue(entityTypeDropdownOptions[0][1]);
-      const locationDropdown = new blockly.FieldDropdown(locationOptions);
+      const locationDropdown = new CdoFieldDropdown(locationOptions);
       locationDropdown.setValue(locationOptions[0][1]);
 
       this.setStyle(BlockStyles.DEFAULT);
@@ -690,7 +689,7 @@ export const install = (blockly, blockInstallOptions) => {
       const entityTypeDropdownOptions = keysToDropdownOptions(
         SPAWNABLE_ENTITY_TYPES
       );
-      const entityTypeDropdown = new blockly.FieldDropdown(
+      const entityTypeDropdown = new CdoFieldDropdown(
         entityTypeDropdownOptions
       );
       entityTypeDropdown.setValue(entityTypeDropdownOptions[0][1]);
@@ -779,10 +778,7 @@ export const install = (blockly, blockInstallOptions) => {
         return [SOUNDS_TO_DISPLAY_TEXT[key] || key, key];
       });
       dropdownOptions = _.sortBy(dropdownOptions, 0);
-      const dropdown = new blockly.FieldDropdown(
-        dropdownOptions,
-        onSoundSelected
-      );
+      const dropdown = new CdoFieldDropdown(dropdownOptions, onSoundSelected);
       dropdown.setValue(dropdownOptions[0][1]);
 
       this.setStyle(BlockStyles.DEFAULT);
@@ -805,7 +801,7 @@ export const install = (blockly, blockInstallOptions) => {
       const dropdownOptions = keysToDropdownOptions(
         _.range(1, 11).map(x => x.toString())
       );
-      const dropdown = new blockly.FieldDropdown(dropdownOptions);
+      const dropdown = new CdoFieldDropdown(dropdownOptions);
       dropdown.setValue(dropdownOptions[0][1]);
 
       this.setStyle(BlockStyles.DEFAULT);

--- a/apps/src/craft/designer/blocks.js
+++ b/apps/src/craft/designer/blocks.js
@@ -17,7 +17,7 @@ const ENTITY_INPUT_EXTRA_SPACING = 14;
 const NUMBERS_TO_DISPLAY_TEXT = {
   // prettier wants to remove quotes here
   // eslint-disable-next-line prettier/prettier
-  0.4: i18n.timeVeryShort(),
+  '0.4': i18n.timeVeryShort(),
   '1.0': i18n.timeShort(),
   '2.0': i18n.timeMedium(),
   '4.0': i18n.timeLong(),

--- a/apps/src/craft/simple/blocks.js
+++ b/apps/src/craft/simple/blocks.js
@@ -1,3 +1,4 @@
+import CdoFieldDropdown from '@cdo/apps/blockly/addons/cdoFieldDropdown';
 import {BlockStyles} from '@cdo/apps/blockly/constants';
 
 import {blockTypesToDropdownOptions} from '../utils';
@@ -89,7 +90,7 @@ exports.install = function (blockly, blockInstallOptions) {
     init: function () {
       this.setStyle(BlockStyles.DEFAULT);
       this.appendDummyInput().appendField(
-        new blockly.FieldDropdown(this.DIRECTIONS),
+        new CdoFieldDropdown(this.DIRECTIONS),
         'DIR'
       );
       this.setPreviousStatement(true);
@@ -147,7 +148,7 @@ exports.install = function (blockly, blockInstallOptions) {
       var dropdownOptions = blockTypesToDropdownOptions(
         craftBlockOptions.ifBlockOptions || allDropdownBlocks
       );
-      var dropdown = new blockly.FieldDropdown(dropdownOptions);
+      var dropdown = new CdoFieldDropdown(dropdownOptions);
       dropdown.setValue(dropdownOptions[0][1]);
       this.setStyle(BlockStyles.LOGIC);
       this.appendDummyInput()
@@ -202,7 +203,7 @@ exports.install = function (blockly, blockInstallOptions) {
       var dropdownOptions = blockTypesToDropdownOptions(
         craftBlockOptions.placeBlockOptions || allDropdownBlocks
       );
-      var dropdown = new blockly.FieldDropdown(dropdownOptions);
+      var dropdown = new CdoFieldDropdown(dropdownOptions);
       dropdown.setValue(dropdownOptions[0][1]);
 
       this.setStyle(BlockStyles.DEFAULT);
@@ -267,7 +268,7 @@ exports.install = function (blockly, blockInstallOptions) {
       var dropdownOptions = blockTypesToDropdownOptions(
         craftBlockOptions.placeBlockOptions || allDropdownBlocks
       );
-      var dropdown = new blockly.FieldDropdown(dropdownOptions);
+      var dropdown = new CdoFieldDropdown(dropdownOptions);
       dropdown.setValue(dropdownOptions[0][1]);
 
       this.setStyle(BlockStyles.DEFAULT);

--- a/apps/src/craft/simple/blocks.js
+++ b/apps/src/craft/simple/blocks.js
@@ -1,4 +1,5 @@
 import CdoFieldDropdown from '@cdo/apps/blockly/addons/cdoFieldDropdown';
+import CdoFieldLabel from '@cdo/apps/blockly/addons/cdoFieldLabel';
 import {BlockStyles} from '@cdo/apps/blockly/constants';
 
 import {blockTypesToDropdownOptions} from '../utils';
@@ -73,7 +74,7 @@ exports.install = function (blockly, blockInstallOptions) {
     init: function () {
       this.setStyle(BlockStyles.DEFAULT);
       this.appendDummyInput().appendField(
-        new blockly.FieldLabel(i18n.blockMoveForward())
+        new CdoFieldLabel(i18n.blockMoveForward())
       );
       this.setPreviousStatement(true);
       this.setNextStatement(true);
@@ -115,7 +116,7 @@ exports.install = function (blockly, blockInstallOptions) {
     init: function () {
       this.setStyle(BlockStyles.DEFAULT);
       this.appendDummyInput().appendField(
-        new blockly.FieldLabel(i18n.blockDestroyBlock())
+        new CdoFieldLabel(i18n.blockDestroyBlock())
       );
       this.setPreviousStatement(true);
       this.setNextStatement(true);
@@ -130,9 +131,7 @@ exports.install = function (blockly, blockInstallOptions) {
     helpUrl: '',
     init: function () {
       this.setStyle(BlockStyles.DEFAULT);
-      this.appendDummyInput().appendField(
-        new blockly.FieldLabel(i18n.blockShear())
-      );
+      this.appendDummyInput().appendField(new CdoFieldLabel(i18n.blockShear()));
       this.setPreviousStatement(true);
       this.setNextStatement(true);
     },

--- a/apps/src/dance/blockly/blocks.js
+++ b/apps/src/dance/blockly/blocks.js
@@ -1,5 +1,6 @@
 import CdoFieldImage from '@cdo/apps/blockly/addons/cdoFieldImage';
 import {CdoFieldImageDropdown} from '@cdo/apps/blockly/addons/cdoFieldImageDropdown';
+import CdoFieldLabel from '@cdo/apps/blockly/addons/cdoFieldLabel';
 import FunctionEditor from '@cdo/apps/blockly/addons/functionEditor';
 import {BlockStyles} from '@cdo/apps/blockly/constants';
 import {registerCustomProcedureBlocks} from '@cdo/apps/blockly/utils';
@@ -168,7 +169,7 @@ export default {
     Blockly.Blocks.sprite_variables_get = {
       // Variable getter.
       init: function () {
-        var fieldLabel = new Blockly.FieldLabel(Blockly.Msg.VARIABLES_GET_ITEM);
+        var fieldLabel = new CdoFieldLabel(Blockly.Msg.VARIABLES_GET_ITEM);
         // Must be marked EDITABLE so that cloned blocks share the same var name
         fieldLabel.EDITABLE = true;
         this.setHelpUrl(Blockly.Msg.VARIABLES_GET_HELPURL);
@@ -215,7 +216,7 @@ export default {
 
     Blockly.Blocks.sprite_parameter_get = {
       init() {
-        var fieldLabel = new Blockly.FieldLabel(Blockly.Msg.VARIABLES_GET_ITEM);
+        var fieldLabel = new CdoFieldLabel(Blockly.Msg.VARIABLES_GET_ITEM);
         // Must be marked EDITABLE so that cloned blocks share the same var name
         fieldLabel.EDITABLE = true;
         this.setHelpUrl(Blockly.Msg.VARIABLES_GET_HELPURL);
@@ -238,7 +239,7 @@ export default {
 
     Blockly.Blocks.gamelab_behavior_get = {
       init() {
-        var fieldLabel = new Blockly.FieldLabel(Blockly.Msg.VARIABLES_GET_ITEM);
+        var fieldLabel = new CdoFieldLabel(Blockly.Msg.VARIABLES_GET_ITEM);
         // Must be marked EDITABLE so that cloned blocks share the same var name
         fieldLabel.EDITABLE = true;
         this.setHelpUrl(Blockly.Msg.VARIABLES_GET_HELPURL);

--- a/apps/src/dance/blockly/blocks.js
+++ b/apps/src/dance/blockly/blocks.js
@@ -1,3 +1,5 @@
+import CdoFieldImage from '@cdo/apps/blockly/addons/cdoFieldImage';
+import {CdoFieldImageDropdown} from '@cdo/apps/blockly/addons/cdoFieldImageDropdown';
 import FunctionEditor from '@cdo/apps/blockly/addons/functionEditor';
 import {BlockStyles} from '@cdo/apps/blockly/constants';
 import {registerCustomProcedureBlocks} from '@cdo/apps/blockly/utils';
@@ -108,7 +110,7 @@ const customInputTypes = {
       currentInputRow
         .appendField(inputConfig.label)
         .appendField(
-          new Blockly.FieldImageDropdown(options, 40, 40),
+          new CdoFieldImageDropdown(options, 40, 40),
           inputConfig.name
         );
     },
@@ -121,7 +123,11 @@ const customInputTypes = {
       currentInputRow
         .appendField(inputConfig.label)
         .appendField(
-          new Blockly.FieldImage(getGeneratedDancerHeadUrl(), 40, 40),
+          new CdoFieldImage(
+            [[getGeneratedDancerHeadUrl(), GENERATED_DANCER]],
+            40,
+            40
+          ),
           inputConfig.name
         );
     },

--- a/apps/src/dance/blockly/blocks.js
+++ b/apps/src/dance/blockly/blocks.js
@@ -1,3 +1,4 @@
+import CdoFieldColour from '@cdo/apps/blockly/addons/cdoFieldColour';
 import CdoFieldImage from '@cdo/apps/blockly/addons/cdoFieldImage';
 import {CdoFieldImageDropdown} from '@cdo/apps/blockly/addons/cdoFieldImageDropdown';
 import CdoFieldLabel from '@cdo/apps/blockly/addons/cdoFieldLabel';
@@ -75,10 +76,7 @@ const customInputTypes = {
       };
       currentInputRow
         .appendField(inputConfig.label)
-        .appendField(
-          new Blockly.FieldColour('#ff0000', undefined, options),
-          'VAL'
-        );
+        .appendField(new CdoFieldColour('#ff0000', undefined, options), 'VAL');
     },
     generateCode(block, arg) {
       return `'${block.getFieldValue(arg.name)}'`;

--- a/apps/src/dance/blockly/blocks.js
+++ b/apps/src/dance/blockly/blocks.js
@@ -1,6 +1,7 @@
 import CdoFieldImage from '@cdo/apps/blockly/addons/cdoFieldImage';
 import {CdoFieldImageDropdown} from '@cdo/apps/blockly/addons/cdoFieldImageDropdown';
 import CdoFieldLabel from '@cdo/apps/blockly/addons/cdoFieldLabel';
+import CdoFieldVariable from '@cdo/apps/blockly/addons/cdoFieldVariable';
 import FunctionEditor from '@cdo/apps/blockly/addons/functionEditor';
 import {BlockStyles} from '@cdo/apps/blockly/constants';
 import {registerCustomProcedureBlocks} from '@cdo/apps/blockly/utils';
@@ -52,7 +53,7 @@ const customInputTypes = {
       currentInputRow
         .appendField(inputConfig.label)
         .appendField(
-          new Blockly.FieldVariable(
+          new CdoFieldVariable(
             null,
             null,
             null,
@@ -178,7 +179,7 @@ export default {
           .appendField(
             Blockly.disableVariableEditing
               ? fieldLabel
-              : new Blockly.FieldVariable(
+              : new CdoFieldVariable(
                   Blockly.Msg.VARIABLES_SET_ITEM,
                   null,
                   null,

--- a/apps/src/flappy/blocks.js
+++ b/apps/src/flappy/blocks.js
@@ -5,6 +5,7 @@
  *
  */
 
+import CdoFieldDropdown from '@cdo/apps/blockly/addons/cdoFieldDropdown';
 import CdoFieldImage from '@cdo/apps/blockly/addons/cdoFieldImage';
 import {CdoFieldImageDropdown} from '@cdo/apps/blockly/addons/cdoFieldImageDropdown';
 import {numberValidator} from '@cdo/apps/blockly/utils';
@@ -168,7 +169,7 @@ exports.install = function (blockly, blockInstallOptions) {
     // Block for flapping (flying upwards)
     helpUrl: '',
     init: function () {
-      var dropdown = new blockly.FieldDropdown(this.VALUES);
+      var dropdown = new CdoFieldDropdown(this.VALUES);
       dropdown.setValue(this.VALUES[3][1]); // default to normal
 
       this.setStyle('default');
@@ -205,10 +206,7 @@ exports.install = function (blockly, blockInstallOptions) {
     helpUrl: '',
     init: function () {
       this.VALUES = isK1 ? this.k1SoundChoices : this.soundChoices;
-      var soundDropdown = new blockly.FieldDropdown(
-        this.VALUES,
-        onSoundSelected
-      );
+      var soundDropdown = new CdoFieldDropdown(this.VALUES, onSoundSelected);
       soundDropdown.setValue(this.WING_FLAP_SOUND);
 
       if (isK1) {
@@ -329,7 +327,7 @@ exports.install = function (blockly, blockInstallOptions) {
           .appendField(msg.setSpeed())
           .appendField(fieldImageDropdown, 'VALUE');
       } else {
-        var dropdown = new blockly.FieldDropdown(this.VALUES);
+        var dropdown = new CdoFieldDropdown(this.VALUES);
         dropdown.setValue(this.VALUES[3][1]); // default to normal
         this.appendDummyInput().appendField(dropdown, 'VALUE');
       }
@@ -365,7 +363,7 @@ exports.install = function (blockly, blockInstallOptions) {
   blockly.Blocks.flappy_setGapHeight = {
     helpUrl: '',
     init: function () {
-      var dropdown = new blockly.FieldDropdown(this.VALUES);
+      var dropdown = new CdoFieldDropdown(this.VALUES);
       dropdown.setValue(this.VALUES[3][1]); // default to normal
 
       this.setStyle('variable_blocks');
@@ -404,7 +402,7 @@ exports.install = function (blockly, blockInstallOptions) {
         dropdown = new CdoFieldImageDropdown(this.K1_CHOICES, 50, 30);
         dropdown.setValue(FLAPPY_VALUE);
       } else {
-        dropdown = new blockly.FieldDropdown(this.VALUES);
+        dropdown = new CdoFieldDropdown(this.VALUES);
         dropdown.setValue(FLAPPY_VALUE);
       }
 
@@ -455,7 +453,7 @@ exports.install = function (blockly, blockInstallOptions) {
         dropdown = new CdoFieldImageDropdown(this.K1_CHOICES, 34, 24);
         dropdown.setValue(FLAPPY_VALUE);
       } else {
-        dropdown = new blockly.FieldDropdown(this.VALUES);
+        dropdown = new CdoFieldDropdown(this.VALUES);
         dropdown.setValue(FLAPPY_VALUE);
       }
       input.appendField(dropdown, 'VALUE');
@@ -521,7 +519,7 @@ exports.install = function (blockly, blockInstallOptions) {
         dropdown = new CdoFieldImageDropdown(this.K1_CHOICES, 50, 30);
         dropdown.setValue(FLAPPY_VALUE);
       } else {
-        dropdown = new blockly.FieldDropdown(this.VALUES);
+        dropdown = new CdoFieldDropdown(this.VALUES);
         dropdown.setValue(FLAPPY_VALUE);
       }
 
@@ -571,7 +569,7 @@ exports.install = function (blockly, blockInstallOptions) {
         dropdown = new CdoFieldImageDropdown(this.K1_CHOICES, 50, 30);
         dropdown.setValue(FLAPPY_VALUE);
       } else {
-        dropdown = new blockly.FieldDropdown(this.VALUES);
+        dropdown = new CdoFieldDropdown(this.VALUES);
         dropdown.setValue(FLAPPY_VALUE);
       }
       input.appendField(dropdown, 'VALUE');
@@ -613,7 +611,7 @@ exports.install = function (blockly, blockInstallOptions) {
   blockly.Blocks.flappy_setGravity = {
     helpUrl: '',
     init: function () {
-      var dropdown = new blockly.FieldDropdown(this.VALUES);
+      var dropdown = new CdoFieldDropdown(this.VALUES);
       dropdown.setValue(this.VALUES[3][1]); // default to normal
 
       this.setStyle('variable_blocks');

--- a/apps/src/flappy/blocks.js
+++ b/apps/src/flappy/blocks.js
@@ -5,6 +5,8 @@
  *
  */
 
+import CdoFieldImage from '@cdo/apps/blockly/addons/cdoFieldImage';
+import {CdoFieldImageDropdown} from '@cdo/apps/blockly/addons/cdoFieldImageDropdown';
 import {numberValidator} from '@cdo/apps/blockly/utils';
 
 var _ = require('lodash');
@@ -51,7 +53,7 @@ exports.install = function (blockly, blockInstallOptions) {
       if (isK1) {
         this.appendDummyInput()
           .appendField(commonMsg.when())
-          .appendField(new blockly.FieldImage(skin.clickIcon));
+          .appendField(new CdoFieldImage(skin.clickIcon));
       } else {
         this.appendDummyInput().appendField(msg.whenClick());
       }
@@ -74,7 +76,7 @@ exports.install = function (blockly, blockInstallOptions) {
       if (isK1) {
         this.appendDummyInput()
           .appendField(commonMsg.when())
-          .appendField(new blockly.FieldImage(skin.collideGroundIcon));
+          .appendField(new CdoFieldImage(skin.collideGroundIcon));
       } else {
         this.appendDummyInput().appendField(msg.whenCollideGround());
       }
@@ -97,7 +99,7 @@ exports.install = function (blockly, blockInstallOptions) {
       if (isK1) {
         this.appendDummyInput()
           .appendField(commonMsg.when())
-          .appendField(new blockly.FieldImage(skin.collideObstacleIcon));
+          .appendField(new CdoFieldImage(skin.collideObstacleIcon));
       } else {
         this.appendDummyInput().appendField(msg.whenCollideObstacle());
       }
@@ -120,7 +122,7 @@ exports.install = function (blockly, blockInstallOptions) {
       if (isK1) {
         this.appendDummyInput()
           .appendField(commonMsg.when())
-          .appendField(new blockly.FieldImage(skin.enterObstacleIcon));
+          .appendField(new CdoFieldImage(skin.enterObstacleIcon));
       } else {
         this.appendDummyInput().appendField(msg.whenEnterObstacle());
       }
@@ -143,7 +145,7 @@ exports.install = function (blockly, blockInstallOptions) {
       if (isK1) {
         this.appendDummyInput()
           .appendField(msg.flap())
-          .appendField(new blockly.FieldImage(skin.flapIcon));
+          .appendField(new CdoFieldImage(skin.flapIcon));
       } else {
         this.appendDummyInput().appendField(msg.flap());
       }
@@ -212,7 +214,7 @@ exports.install = function (blockly, blockInstallOptions) {
       if (isK1) {
         this.appendDummyInput()
           .appendField(commonMsg.play())
-          .appendField(new blockly.FieldImage(skin.soundIcon))
+          .appendField(new CdoFieldImage(skin.soundIcon))
           .appendField(soundDropdown, 'VALUE');
       } else {
         this.appendDummyInput().appendField(soundDropdown, 'VALUE');
@@ -271,7 +273,7 @@ exports.install = function (blockly, blockInstallOptions) {
       if (isK1) {
         this.appendDummyInput()
           .appendField(commonMsg.score())
-          .appendField(new blockly.FieldImage(skin.scoreCard));
+          .appendField(new CdoFieldImage(skin.scoreCard));
       } else {
         this.appendDummyInput().appendField(msg.incrementPlayerScore());
       }
@@ -294,7 +296,7 @@ exports.install = function (blockly, blockInstallOptions) {
       if (isK1) {
         this.appendDummyInput()
           .appendField(commonMsg.end())
-          .appendField(new blockly.FieldImage(skin.endIcon));
+          .appendField(new CdoFieldImage(skin.endIcon));
       } else {
         this.appendDummyInput().appendField(msg.endGame());
       }
@@ -317,7 +319,7 @@ exports.install = function (blockly, blockInstallOptions) {
     init: function () {
       this.setStyle('variable_blocks');
       if (isK1) {
-        var fieldImageDropdown = new blockly.FieldImageDropdown(
+        var fieldImageDropdown = new CdoFieldImageDropdown(
           this.K1_VALUES,
           63,
           33
@@ -399,7 +401,7 @@ exports.install = function (blockly, blockInstallOptions) {
       var input = this.appendDummyInput();
       if (isK1) {
         input.appendField(msg.setBackground());
-        dropdown = new blockly.FieldImageDropdown(this.K1_CHOICES, 50, 30);
+        dropdown = new CdoFieldImageDropdown(this.K1_CHOICES, 50, 30);
         dropdown.setValue(FLAPPY_VALUE);
       } else {
         dropdown = new blockly.FieldDropdown(this.VALUES);
@@ -450,7 +452,7 @@ exports.install = function (blockly, blockInstallOptions) {
       var input = this.appendDummyInput();
       if (isK1) {
         input.appendField(msg.setPlayer());
-        dropdown = new blockly.FieldImageDropdown(this.K1_CHOICES, 34, 24);
+        dropdown = new CdoFieldImageDropdown(this.K1_CHOICES, 34, 24);
         dropdown.setValue(FLAPPY_VALUE);
       } else {
         dropdown = new blockly.FieldDropdown(this.VALUES);
@@ -516,7 +518,7 @@ exports.install = function (blockly, blockInstallOptions) {
       var input = this.appendDummyInput();
       if (isK1) {
         input.appendField(msg.setObstacle());
-        dropdown = new blockly.FieldImageDropdown(this.K1_CHOICES, 50, 30);
+        dropdown = new CdoFieldImageDropdown(this.K1_CHOICES, 50, 30);
         dropdown.setValue(FLAPPY_VALUE);
       } else {
         dropdown = new blockly.FieldDropdown(this.VALUES);
@@ -566,7 +568,7 @@ exports.install = function (blockly, blockInstallOptions) {
       var input = this.appendDummyInput();
       if (isK1) {
         input.appendField(msg.setGround());
-        dropdown = new blockly.FieldImageDropdown(this.K1_CHOICES, 50, 30);
+        dropdown = new CdoFieldImageDropdown(this.K1_CHOICES, 50, 30);
         dropdown.setValue(FLAPPY_VALUE);
       } else {
         dropdown = new blockly.FieldDropdown(this.VALUES);

--- a/apps/src/jigsaw/blocks.js
+++ b/apps/src/jigsaw/blocks.js
@@ -5,6 +5,7 @@
  *
  */
 import CdoFieldImage from '@cdo/apps/blockly/addons/cdoFieldImage';
+import CdoFieldLabel from '@cdo/apps/blockly/addons/cdoFieldLabel';
 import '@cdo/apps/blockly/addons/extensions/jigsawFillPatternMixin';
 
 var levels = require('./levels');
@@ -214,7 +215,7 @@ function generateBlankBlock(blockly, skin, name, hsv, width, label) {
       this.appendDummyInput()
         .appendField(new CdoFieldImage(skin.blank, width, 54))
         .appendField(
-          new blockly.FieldLabel(label, {
+          new CdoFieldLabel(label, {
             fixedSize: {width: width, height: 64},
             fontSize: 32,
           })

--- a/apps/src/jigsaw/blocks.js
+++ b/apps/src/jigsaw/blocks.js
@@ -4,6 +4,7 @@
  * Copyright 2013 Code.org
  *
  */
+import CdoFieldImage from '@cdo/apps/blockly/addons/cdoFieldImage';
 import '@cdo/apps/blockly/addons/extensions/jigsawFillPatternMixin';
 
 var levels = require('./levels');
@@ -211,7 +212,7 @@ function generateBlankBlock(blockly, skin, name, hsv, width, label) {
       const [h, s, v] = hsv;
       this.setColour(Blockly.utils.colour.hsvToHex(h, s, v * 255));
       this.appendDummyInput()
-        .appendField(new blockly.FieldImage(skin.blank, width, 54))
+        .appendField(new CdoFieldImage(skin.blank, width, 54))
         .appendField(
           new blockly.FieldLabel(label, {
             fixedSize: {width: width, height: 64},
@@ -248,7 +249,7 @@ function generateJigsawBlocksForLevel(blockly, skin, options) {
       init: function () {
         Blockly.Extensions.apply('jigsaw_fill_pattern_mixin', this, false);
         this.appendDummyInput().appendField(
-          new blockly.FieldImage(skin.blank, titleWidth, titleHeight)
+          new CdoFieldImage(skin.blank, titleWidth, titleHeight)
         );
         this.setPreviousStatement(blockNum !== 1 || notchedEnds);
         this.setNextStatement(blockNum !== numBlocks || notchedEnds);

--- a/apps/src/maze/beeBlocks.js
+++ b/apps/src/maze/beeBlocks.js
@@ -2,6 +2,7 @@
  * Blocks specific to Bee
  */
 
+import CdoFieldDropdown from '@cdo/apps/blockly/addons/cdoFieldDropdown';
 import {interpolateMsg, numberValidator} from '@cdo/apps/blockly/utils';
 
 var blockUtils = require('../block_utils');
@@ -175,7 +176,7 @@ function addIfFlowerHive(blockly, generator) {
       this.setStyle(BlockStyles.LOGIC);
       this.appendDummyInput().appendField(msg.ifCode());
       this.appendDummyInput().appendField(
-        new blockly.FieldDropdown(LOCATIONS),
+        new CdoFieldDropdown(LOCATIONS),
         'LOC'
       );
       this.setInputsInline(true);
@@ -214,7 +215,7 @@ function addIfElseFlowerHive(blockly, generator) {
       this.setStyle(BlockStyles.LOGIC);
       this.appendDummyInput().appendField(msg.ifCode());
       this.appendDummyInput().appendField(
-        new blockly.FieldDropdown(LOCATIONS),
+        new CdoFieldDropdown(LOCATIONS),
         'LOC'
       );
       this.setInputsInline(true);
@@ -303,13 +304,10 @@ function addConditionalComparisonBlock(blockly, generator, name, type, arg1) {
       }
 
       this.appendDummyInput().appendField(conditionalMsg);
-      this.appendDummyInput().appendField(
-        new blockly.FieldDropdown(arg1),
-        'ARG1'
-      );
+      this.appendDummyInput().appendField(new CdoFieldDropdown(arg1), 'ARG1');
       this.appendDummyInput().appendField(' ');
       this.appendDummyInput().appendField(
-        new blockly.FieldDropdown(Blockly.RTL ? RTL_OPERATORS : OPERATORS),
+        new CdoFieldDropdown(Blockly.RTL ? RTL_OPERATORS : OPERATORS),
         'OP'
       );
       this.appendDummyInput().appendField(' ');

--- a/apps/src/maze/blocks.js
+++ b/apps/src/maze/blocks.js
@@ -25,6 +25,7 @@
 import {utils as mazeUtils} from '@code-dot-org/maze';
 
 import CdoFieldDropdown from '@cdo/apps/blockly/addons/cdoFieldDropdown';
+import CdoFieldLabel from '@cdo/apps/blockly/addons/cdoFieldLabel';
 import {
   INFINITE_LOOP_TRAP,
   loopHighlight,
@@ -98,7 +99,7 @@ exports.install = function (blockly, blockInstallOptions) {
           this.setStyle(BlockStyles.DEFAULT);
           this.appendDummyInput()
             .appendField(
-              new blockly.FieldLabel(directionConfig.letter, {
+              new CdoFieldLabel(directionConfig.letter, {
                 fixedSize: {width: 12, height: 18},
               })
             )

--- a/apps/src/maze/blocks.js
+++ b/apps/src/maze/blocks.js
@@ -24,6 +24,7 @@
 
 import {utils as mazeUtils} from '@code-dot-org/maze';
 
+import CdoFieldDropdown from '@cdo/apps/blockly/addons/cdoFieldDropdown';
 import {
   INFINITE_LOOP_TRAP,
   loopHighlight,
@@ -150,7 +151,7 @@ exports.install = function (blockly, blockInstallOptions) {
     init: function () {
       this.setStyle(BlockStyles.DEFAULT);
       this.appendDummyInput().appendField(
-        new blockly.FieldDropdown(this.DIRECTIONS),
+        new CdoFieldDropdown(this.DIRECTIONS),
         'DIR'
       );
       this.setPreviousStatement(true);
@@ -176,7 +177,7 @@ exports.install = function (blockly, blockInstallOptions) {
     init: function () {
       this.setStyle(BlockStyles.DEFAULT);
       this.appendDummyInput().appendField(
-        new blockly.FieldDropdown(this.DIRECTIONS),
+        new CdoFieldDropdown(this.DIRECTIONS),
         'DIR'
       );
       this.setPreviousStatement(true);
@@ -203,7 +204,7 @@ exports.install = function (blockly, blockInstallOptions) {
       this.setStyle(BlockStyles.LOGIC);
       this.setOutput(true, blockly.BlockValueType.NUMBER);
       this.appendDummyInput().appendField(
-        new blockly.FieldDropdown(this.DIRECTIONS),
+        new CdoFieldDropdown(this.DIRECTIONS),
         'DIR'
       );
       this.setTooltip(msg.isPathTooltip());
@@ -228,7 +229,7 @@ exports.install = function (blockly, blockInstallOptions) {
     init: function () {
       this.setStyle(BlockStyles.LOGIC);
       this.appendDummyInput().appendField(
-        new blockly.FieldDropdown(this.DIRECTIONS),
+        new CdoFieldDropdown(this.DIRECTIONS),
         'DIR'
       );
       this.setInputsInline(true);
@@ -256,7 +257,7 @@ exports.install = function (blockly, blockInstallOptions) {
     init: function () {
       this.setStyle(BlockStyles.LOGIC);
       this.appendDummyInput().appendField(
-        new blockly.FieldDropdown(this.DIRECTIONS),
+        new CdoFieldDropdown(this.DIRECTIONS),
         'DIR'
       );
       this.setInputsInline(true);
@@ -288,7 +289,7 @@ exports.install = function (blockly, blockInstallOptions) {
       this.setStyle(BlockStyles.LOGIC);
       this.appendDummyInput().appendField(msg.ifCode());
       this.appendDummyInput().appendField(
-        new blockly.FieldDropdown(this.DIRECTIONS),
+        new CdoFieldDropdown(this.DIRECTIONS),
         'DIR'
       );
       this.setInputsInline(true);
@@ -322,7 +323,7 @@ exports.install = function (blockly, blockInstallOptions) {
       this.setStyle(BlockStyles.LOGIC);
       this.appendDummyInput().appendField(msg.ifCode());
       this.appendDummyInput().appendField(
-        new blockly.FieldDropdown(this.DIRECTIONS),
+        new CdoFieldDropdown(this.DIRECTIONS),
         'DIR'
       );
       this.setInputsInline(true);
@@ -352,7 +353,7 @@ exports.install = function (blockly, blockInstallOptions) {
     init: function () {
       this.setStyle(BlockStyles.LOOP);
       this.appendDummyInput().appendField(
-        new blockly.FieldDropdown(this.DIRECTIONS),
+        new CdoFieldDropdown(this.DIRECTIONS),
         'DIR'
       );
       this.appendStatementInput('DO').appendField(msg.doCode());
@@ -420,7 +421,7 @@ exports.install = function (blockly, blockInstallOptions) {
     init: function () {
       this.setStyle(BlockStyles.LOOP);
       this.appendDummyInput().appendField(
-        new blockly.FieldDropdown(this.DIRECTIONS),
+        new CdoFieldDropdown(this.DIRECTIONS),
         'DIR'
       );
       this.appendStatementInput('DO').appendField(msg.doCode());

--- a/apps/src/maze/blocks.js
+++ b/apps/src/maze/blocks.js
@@ -32,6 +32,7 @@ import {
 import commonMsg from '@cdo/locale';
 
 import blockUtils from '../block_utils';
+import CdoFieldImage from '../blockly/addons/cdoFieldImage';
 import {BlockStyles} from '../blockly/constants';
 
 import msg from './locale';
@@ -100,7 +101,7 @@ exports.install = function (blockly, blockInstallOptions) {
                 fixedSize: {width: 12, height: 18},
               })
             )
-            .appendField(new blockly.FieldImage(directionConfig.image));
+            .appendField(new CdoFieldImage(directionConfig.image));
           this.setPreviousStatement(true);
           this.setNextStatement(true);
           this.setTooltip(directionConfig.tooltip);
@@ -400,7 +401,7 @@ exports.install = function (blockly, blockInstallOptions) {
       this.setStyle(BlockStyles.LOOP);
       this.appendDummyInput()
         .appendField(msg.repeatUntil())
-        .appendField(new blockly.FieldImage(skin.maze_forever, 35, 35));
+        .appendField(new CdoFieldImage(skin.maze_forever, 35, 35));
       this.appendStatementInput('DO').appendField(msg.doCode());
       this.setPreviousStatement(true);
       this.setTooltip(msg.whileTooltip());

--- a/apps/src/maze/harvesterBlocks.js
+++ b/apps/src/maze/harvesterBlocks.js
@@ -2,6 +2,7 @@
  * Blocks specific to Harvester
  */
 
+import CdoFieldDropdown from '@cdo/apps/blockly/addons/cdoFieldDropdown';
 import {INFINITE_LOOP_TRAP} from '@cdo/apps/blockly/utils';
 
 var blockUtils = require('../block_utils');
@@ -238,7 +239,7 @@ exports.install = function (blockly, blockInstallOptions) {
       this.setStyle(BlockStyles.LOGIC);
       this.appendDummyInput().appendField([msg.ifCode(), msg.at()].join(' '));
       this.appendDummyInput().appendField(
-        new blockly.FieldDropdown(AT_OPTIONS),
+        new CdoFieldDropdown(AT_OPTIONS),
         'LOC'
       );
       this.setInputsInline(true);
@@ -261,7 +262,7 @@ exports.install = function (blockly, blockInstallOptions) {
       this.setStyle(BlockStyles.LOGIC);
       this.appendDummyInput().appendField([msg.ifCode(), msg.at()].join(' '));
       this.appendDummyInput().appendField(
-        new blockly.FieldDropdown(AT_OPTIONS),
+        new CdoFieldDropdown(AT_OPTIONS),
         'LOC'
       );
       this.setInputsInline(true);
@@ -288,7 +289,7 @@ exports.install = function (blockly, blockInstallOptions) {
         [msg.repeatUntil(), msg.at()].join(' ')
       );
       this.appendDummyInput().appendField(
-        new blockly.FieldDropdown(AT_OPTIONS),
+        new CdoFieldDropdown(AT_OPTIONS),
         'LOC'
       );
       this.setInputsInline(true);
@@ -312,7 +313,7 @@ exports.install = function (blockly, blockInstallOptions) {
       this.setStyle(BlockStyles.LOGIC);
       this.appendDummyInput().appendField(msg.ifCode());
       this.appendDummyInput().appendField(
-        new blockly.FieldDropdown(HAS_OPTIONS),
+        new CdoFieldDropdown(HAS_OPTIONS),
         'LOC'
       );
       this.setInputsInline(true);
@@ -337,7 +338,7 @@ exports.install = function (blockly, blockInstallOptions) {
       this.setStyle(BlockStyles.LOGIC);
       this.appendDummyInput().appendField(msg.ifCode());
       this.appendDummyInput().appendField(
-        new blockly.FieldDropdown(HAS_OPTIONS),
+        new CdoFieldDropdown(HAS_OPTIONS),
         'LOC'
       );
       this.setInputsInline(true);
@@ -364,7 +365,7 @@ exports.install = function (blockly, blockInstallOptions) {
       this.setStyle(BlockStyles.LOOP);
       this.appendDummyInput().appendField(msg.whileMsg());
       this.appendDummyInput().appendField(
-        new blockly.FieldDropdown(HAS_OPTIONS),
+        new CdoFieldDropdown(HAS_OPTIONS),
         'LOC'
       );
       this.setInputsInline(true);
@@ -390,7 +391,7 @@ exports.install = function (blockly, blockInstallOptions) {
       this.setStyle(BlockStyles.LOOP);
       this.appendDummyInput().appendField(msg.repeatUntil());
       this.appendDummyInput().appendField(
-        new blockly.FieldDropdown(HAS_OPTIONS),
+        new CdoFieldDropdown(HAS_OPTIONS),
         'LOC'
       );
       this.setInputsInline(true);

--- a/apps/src/music/blockly/extensions.js
+++ b/apps/src/music/blockly/extensions.js
@@ -1,20 +1,23 @@
+import CdoFieldDropdown from '@cdo/apps/blockly/addons/cdoFieldDropdown';
+import CdoFieldImage from '@cdo/apps/blockly/addons/cdoFieldImage';
+
 import {TICKS_PER_MEASURE} from '../constants';
 import MusicLibrary from '../player/MusicLibrary';
 
 import {BlockTypes} from './blockTypes';
 import {
+  DEFAULT_EFFECT_VALUE,
   EXTRA_SOUND_INPUT_PREFIX,
+  FIELD_EFFECTS_NAME,
+  FIELD_EFFECTS_VALUE,
+  FIELD_EFFECTS_VALUE_OPTIONS,
+  FIELD_PATTERN_AI_NAME,
+  FIELD_PATTERN_NAME,
+  FIELD_SOUNDS_NAME,
   MINUS_IMAGE,
   PLUS_IMAGE,
   SOUND_VALUE_TYPE,
   TRACK_NAME_FIELD,
-  FIELD_EFFECTS_NAME,
-  FIELD_EFFECTS_VALUE,
-  FIELD_EFFECTS_VALUE_OPTIONS,
-  DEFAULT_EFFECT_VALUE,
-  FIELD_SOUNDS_NAME,
-  FIELD_PATTERN_NAME,
-  FIELD_PATTERN_AI_NAME,
 } from './constants';
 
 export const getDefaultTrackNameExtension = player =>
@@ -79,7 +82,7 @@ export const playMultiMutator = {
 
     if (shouldShow) {
       this.appendDummyInput('PLUS').appendField(
-        new Blockly.FieldImage(PLUS_IMAGE, 20, 20),
+        new CdoFieldImage(PLUS_IMAGE, 20, 20),
         'PLUS',
         'plus'
       );
@@ -101,7 +104,7 @@ export const playMultiMutator = {
       }
       input.insertFieldAt(
         0,
-        new Blockly.FieldImage(MINUS_IMAGE, 20, 20),
+        new CdoFieldImage(MINUS_IMAGE, 20, 20),
         'MINUS',
         'minus'
       );
@@ -147,7 +150,7 @@ export const nextConnectionMutator = {
 export const effectsFieldExtension = function () {
   // Set the initial state when the block gets created
   const thisBlock = this;
-  const valuesDropdown = new Blockly.FieldDropdown(function () {
+  const valuesDropdown = new CdoFieldDropdown(function () {
     return FIELD_EFFECTS_VALUE_OPTIONS[
       thisBlock.getFieldValue(FIELD_EFFECTS_NAME)
     ];

--- a/apps/src/p5lab/spritelab/blocks.js
+++ b/apps/src/p5lab/spritelab/blocks.js
@@ -1,5 +1,6 @@
 import {Order} from 'blockly/javascript';
 
+import CdoFieldButton from '@cdo/apps/blockly/addons/cdoFieldButton';
 import CdoFieldImage from '@cdo/apps/blockly/addons/cdoFieldImage';
 import CdoFieldLabel from '@cdo/apps/blockly/addons/cdoFieldLabel';
 import CdoFieldVariable from '@cdo/apps/blockly/addons/cdoFieldVariable';
@@ -346,7 +347,7 @@ const customInputTypes = {
         block.workspace.id === Blockly.getMainWorkspace().id &&
         toolboxConfigurationSupportsEditButton(block)
       ) {
-        const editButton = new Blockly.FieldButton({
+        const editButton = new CdoFieldButton({
           value: i18n.edit(),
           onClick: editButtonHandler,
           colorOverrides: {button: 'blue', text: 'white'},

--- a/apps/src/p5lab/spritelab/blocks.js
+++ b/apps/src/p5lab/spritelab/blocks.js
@@ -2,6 +2,7 @@ import {Order} from 'blockly/javascript';
 
 import CdoFieldImage from '@cdo/apps/blockly/addons/cdoFieldImage';
 import CdoFieldLabel from '@cdo/apps/blockly/addons/cdoFieldLabel';
+import CdoFieldVariable from '@cdo/apps/blockly/addons/cdoFieldVariable';
 import FunctionEditor from '@cdo/apps/blockly/addons/functionEditor';
 import {BLOCK_TYPES, NO_OPTIONS_MESSAGE} from '@cdo/apps/blockly/constants';
 import {blocks as behaviorBlocks} from '@cdo/apps/blockly/customBlocks/behaviorBlocks';
@@ -285,7 +286,7 @@ const customInputTypes = {
       currentInputRow
         .appendField(inputConfig.label)
         .appendField(
-          new Blockly.FieldVariable(
+          new CdoFieldVariable(
             null,
             null,
             null,
@@ -438,7 +439,7 @@ const customInputTypes = {
     addInput(blockly, block, inputConfig, currentInputRow) {
       currentInputRow
         .appendField(inputConfig.label)
-        .appendField(new Blockly.FieldVariable(), inputConfig.name);
+        .appendField(new CdoFieldVariable(), inputConfig.name);
     },
 
     generateCode(block, arg) {
@@ -630,7 +631,7 @@ export default {
           .appendField(
             Blockly.disableVariableEditing
               ? fieldLabel
-              : new Blockly.FieldVariable(
+              : new CdoFieldVariable(
                   Blockly.Msg.VARIABLES_SET_ITEM,
                   null,
                   null,

--- a/apps/src/p5lab/spritelab/blocks.js
+++ b/apps/src/p5lab/spritelab/blocks.js
@@ -1,5 +1,6 @@
 import {Order} from 'blockly/javascript';
 
+import CdoFieldImage from '@cdo/apps/blockly/addons/cdoFieldImage';
 import FunctionEditor from '@cdo/apps/blockly/addons/functionEditor';
 import {BLOCK_TYPES, NO_OPTIONS_MESSAGE} from '@cdo/apps/blockly/constants';
 import {blocks as behaviorBlocks} from '@cdo/apps/blockly/customBlocks/behaviorBlocks';
@@ -253,7 +254,7 @@ const customInputTypes = {
       currentInputRow
         .appendField(label)
         .appendField(
-          new Blockly.FieldImage(imageUrl, width, block.thumbnailSize),
+          new CdoFieldImage(imageUrl, width, block.thumbnailSize),
           inputConfig.name
         );
     },

--- a/apps/src/p5lab/spritelab/blocks.js
+++ b/apps/src/p5lab/spritelab/blocks.js
@@ -1,6 +1,10 @@
 import {Order} from 'blockly/javascript';
 
+import CdoFieldAnimationDropdown from '@cdo/apps/blockly/addons/cdoFieldAnimationDropdown';
+import CdoFieldBehaviorPicker from '@cdo/apps/blockly/addons/cdoFieldBehaviorPicker';
+import {CdoFieldBitmap} from '@cdo/apps/blockly/addons/cdoFieldBitmap';
 import CdoFieldButton from '@cdo/apps/blockly/addons/cdoFieldButton';
+import CdoFieldColour from '@cdo/apps/blockly/addons/cdoFieldColour';
 import CdoFieldImage from '@cdo/apps/blockly/addons/cdoFieldImage';
 import CdoFieldLabel from '@cdo/apps/blockly/addons/cdoFieldLabel';
 import CdoFieldVariable from '@cdo/apps/blockly/addons/cdoFieldVariable';
@@ -173,7 +177,7 @@ const customInputTypes = {
       currentInputRow
         .appendField(inputConfig.label)
         .appendField(
-          new Blockly.FieldAnimationDropdown(costumeList, 32, 32, buttons),
+          new CdoFieldAnimationDropdown(costumeList, 32, 32, buttons),
           inputConfig.name
         );
     },
@@ -202,7 +206,7 @@ const customInputTypes = {
       currentInputRow
         .appendField(inputConfig.label)
         .appendField(
-          new Blockly.FieldAnimationDropdown(backgroundList, 40, 40, buttons),
+          new CdoFieldAnimationDropdown(backgroundList, 40, 40, buttons),
           inputConfig.name
         );
     },
@@ -329,9 +333,7 @@ const customInputTypes = {
         return behaviorOptions;
       };
 
-      const dropdownField = new Blockly.FieldBehaviorPicker(
-        menuGeneratorFunction
-      );
+      const dropdownField = new CdoFieldBehaviorPicker(menuGeneratorFunction);
       currentInputRow
         .appendField(inputConfig.label)
         .appendField(dropdownField, inputConfig.name);
@@ -407,10 +409,7 @@ const customInputTypes = {
       };
       currentInputRow
         .appendField(inputConfig.label)
-        .appendField(
-          new Blockly.FieldColour('#ff0000', undefined, options),
-          'VAL'
-        );
+        .appendField(new CdoFieldColour('#ff0000', undefined, options), 'VAL');
     },
     generateCode(block, arg) {
       return `'${block.getFieldValue(arg.name)}'`;
@@ -463,10 +462,7 @@ const customInputTypes = {
       };
       currentInputRow
         .appendField(inputConfig.label)
-        .appendField(
-          new Blockly.FieldBitmap(null, null, config),
-          inputConfig.name
-        );
+        .appendField(new CdoFieldBitmap(null, null, config), inputConfig.name);
     },
     generateCode(block, arg) {
       // Convert 2d array into a string.

--- a/apps/src/p5lab/spritelab/blocks.js
+++ b/apps/src/p5lab/spritelab/blocks.js
@@ -1,6 +1,7 @@
 import {Order} from 'blockly/javascript';
 
 import CdoFieldImage from '@cdo/apps/blockly/addons/cdoFieldImage';
+import CdoFieldLabel from '@cdo/apps/blockly/addons/cdoFieldLabel';
 import FunctionEditor from '@cdo/apps/blockly/addons/functionEditor';
 import {BLOCK_TYPES, NO_OPTIONS_MESSAGE} from '@cdo/apps/blockly/constants';
 import {blocks as behaviorBlocks} from '@cdo/apps/blockly/customBlocks/behaviorBlocks';
@@ -620,7 +621,7 @@ export default {
     Blockly.Blocks.sprite_variables_get = {
       // Variable getter.
       init: function () {
-        var fieldLabel = new Blockly.FieldLabel(Blockly.Msg.VARIABLES_GET_ITEM);
+        var fieldLabel = new CdoFieldLabel(Blockly.Msg.VARIABLES_GET_ITEM);
         // Must be marked EDITABLE so that cloned blocks share the same var name
         fieldLabel.EDITABLE = true;
         this.setHelpUrl('/docs/spritelab/codestudio_spriteName');

--- a/apps/src/studio/blocks.js
+++ b/apps/src/studio/blocks.js
@@ -11,6 +11,7 @@ import _ from 'lodash';
 import CdoFieldDropdown from '@cdo/apps/blockly/addons/cdoFieldDropdown';
 import CdoFieldImage from '@cdo/apps/blockly/addons/cdoFieldImage';
 import {CdoFieldImageDropdown} from '@cdo/apps/blockly/addons/cdoFieldImageDropdown';
+import CdoFieldLabel from '@cdo/apps/blockly/addons/cdoFieldLabel';
 import {
   addSerializationHooksToBlock,
   interpolateMsg,
@@ -2391,7 +2392,7 @@ exports.install = function (blockly, blockInstallOptions) {
       this.setStyle(BlockStyles.EVENT);
 
       var dropdown1 = spriteNumberTextDropdown(msg.whenSpriteN);
-      var endLabel = new Blockly.FieldLabel();
+      var endLabel = new CdoFieldLabel();
       var dropdown2 = createSpriteGroupDropdown(
         msg.collidesWithAnySpriteName,
         value =>
@@ -3181,7 +3182,7 @@ exports.install = function (blockly, blockInstallOptions) {
   blockly.Blocks.studio_ask = {
     helpUrl: '',
     init: function () {
-      var fieldLabel = new Blockly.FieldLabel(Blockly.Msg.VARIABLES_GET_ITEM);
+      var fieldLabel = new CdoFieldLabel(Blockly.Msg.VARIABLES_GET_ITEM);
       // Must be marked EDITABLE so that cloned blocks share the same var name
       fieldLabel.EDITABLE = true;
       this.setStyle(BlockStyles.VARIABLE);

--- a/apps/src/studio/blocks.js
+++ b/apps/src/studio/blocks.js
@@ -15,24 +15,26 @@ import {
 } from '@cdo/apps/blockly/utils';
 import commonMsg from '@cdo/locale';
 
+import CdoFieldImage from '../blockly/addons/cdoFieldImage';
+import {CdoFieldImageDropdown} from '../blockly/addons/cdoFieldImageDropdown';
 import {BlockStyles} from '../blockly/constants';
 import {singleton as studioApp} from '../StudioApp';
 import {stripQuotes, valueOr} from '../utils';
 
 import {
-  CardinalDirections,
-  Direction,
-  Emotions,
-  Position,
   BEHAVIOR_CHASE,
   BEHAVIOR_FLEE,
   BEHAVIOR_WANDER,
+  CardinalDirections,
   CLICK_VALUE,
+  Direction,
+  Emotions,
   EMPTY_QUOTES,
   HIDDEN_VALUE,
+  IMAGE_SIZES,
+  Position,
   RANDOM_VALUE,
   VISIBLE_VALUE,
-  IMAGE_SIZES,
 } from './constants';
 import i18n from './locale';
 import paramLists from './paramLists';
@@ -179,7 +181,7 @@ exports.install = function (blockly, blockInstallOptions) {
 
   /**
    * Creates a dropdown with thumbnails for each starting sprite
-   * @returns {Blockly.FieldImageDropdown}
+   * @returns {CdoFieldImageDropdown}
    */
   function startingSpriteImageDropdown() {
     var spriteNumbers = _.range(0, spriteCount);
@@ -187,7 +189,7 @@ exports.install = function (blockly, blockInstallOptions) {
       var skinId = startAvatars[index];
       return [skin[skinId].dropdownThumbnail, index.toString()];
     });
-    return new blockly.FieldImageDropdown(
+    return new CdoFieldImageDropdown(
       choices,
       skin.dropdownThumbnailWidth,
       skin.dropdownThumbnailHeight
@@ -281,7 +283,7 @@ exports.install = function (blockly, blockInstallOptions) {
       if (isK1) {
         this.appendDummyInput()
           .appendField(commonMsg.when())
-          .appendField(new Blockly.FieldImage(skin.whenLeft));
+          .appendField(new CdoFieldImage(skin.whenLeft));
       } else {
         this.appendDummyInput().appendField(msg.whenLeft());
       }
@@ -302,7 +304,7 @@ exports.install = function (blockly, blockInstallOptions) {
       if (isK1) {
         this.appendDummyInput()
           .appendField(commonMsg.when())
-          .appendField(new Blockly.FieldImage(skin.whenRight));
+          .appendField(new CdoFieldImage(skin.whenRight));
       } else {
         this.appendDummyInput().appendField(msg.whenRight());
       }
@@ -323,7 +325,7 @@ exports.install = function (blockly, blockInstallOptions) {
       if (isK1) {
         this.appendDummyInput()
           .appendField(commonMsg.when())
-          .appendField(new Blockly.FieldImage(skin.whenUp));
+          .appendField(new CdoFieldImage(skin.whenUp));
       } else {
         this.appendDummyInput().appendField(msg.whenUp());
       }
@@ -344,7 +346,7 @@ exports.install = function (blockly, blockInstallOptions) {
       if (isK1) {
         this.appendDummyInput()
           .appendField(commonMsg.when())
-          .appendField(new Blockly.FieldImage(skin.whenDown));
+          .appendField(new CdoFieldImage(skin.whenDown));
       } else {
         this.appendDummyInput().appendField(msg.whenDown());
       }
@@ -365,7 +367,7 @@ exports.install = function (blockly, blockInstallOptions) {
       this.appendDummyInput().appendField(commonMsg.when());
       if (isK1) {
         this.appendDummyInput().appendField(
-          new blockly.FieldImageDropdown(
+          new CdoFieldImageDropdown(
             this.K1_VALUES,
             IMAGE_SIZES.K1_ARROW_KEY.width,
             IMAGE_SIZES.K1_ARROW_KEY.height,
@@ -413,7 +415,7 @@ exports.install = function (blockly, blockInstallOptions) {
       if (isK1) {
         this.appendDummyInput().appendField(commonMsg.repeat());
         this.appendStatementInput('DO').appendField(
-          new blockly.FieldImage(skin.repeatImage)
+          new CdoFieldImage(skin.repeatImage)
         );
       } else {
         this.appendDummyInput().appendField(msg.repeatForever());
@@ -442,7 +444,7 @@ exports.install = function (blockly, blockInstallOptions) {
         if (isK1) {
           this.appendDummyInput()
             .appendField(commonMsg.when())
-            .appendField(new blockly.FieldImage(skin.clickIcon))
+            .appendField(new CdoFieldImage(skin.clickIcon))
             .appendField(startingSpriteImageDropdown(), 'SPRITE');
         } else {
           this.appendDummyInput().appendField(
@@ -454,9 +456,9 @@ exports.install = function (blockly, blockInstallOptions) {
         if (isK1) {
           this.appendDummyInput()
             .appendField(commonMsg.when())
-            .appendField(new blockly.FieldImage(skin.clickIcon))
+            .appendField(new CdoFieldImage(skin.clickIcon))
             .appendField(
-              new blockly.FieldImage(
+              new CdoFieldImage(
                 skin[startAvatars[0]].dropdownThumbnail,
                 skin.dropdownThumbnailWidth,
                 skin.dropdownThumbnailHeight
@@ -610,7 +612,7 @@ exports.install = function (blockly, blockInstallOptions) {
         dropdown2 = startingSpriteImageDropdown();
         this.appendDummyInput()
           .appendField(commonMsg.when())
-          .appendField(new blockly.FieldImage(skin.collide))
+          .appendField(new CdoFieldImage(skin.collide))
           .appendField(dropdown1, 'SPRITE1');
         this.appendDummyInput()
           .appendField(commonMsg.and())
@@ -1274,7 +1276,7 @@ exports.install = function (blockly, blockInstallOptions) {
           this.setStyle(BlockStyles.DEFAULT);
           this.appendDummyInput()
             .appendField(msg.moveSprite()) // move
-            .appendField(new blockly.FieldImage(directionConfig.image)) // arrow
+            .appendField(new CdoFieldImage(directionConfig.image)) // arrow
             .appendField(directionConfig.letter); // NESW
 
           if (spriteCount > 1) {
@@ -1286,7 +1288,7 @@ exports.install = function (blockly, blockInstallOptions) {
 
           if (hasLengthInput) {
             this.appendDummyInput().appendField(
-              new blockly.FieldImageDropdown(
+              new CdoFieldImageDropdown(
                 SimpleMove.DISTANCES,
                 IMAGE_SIZES.K1_MOVE_LINE.width,
                 IMAGE_SIZES.K1_MOVE_LINE.height
@@ -1360,7 +1362,7 @@ exports.install = function (blockly, blockInstallOptions) {
 
       if (isK1) {
         this.appendDummyInput().appendField(
-          new blockly.FieldImageDropdown(
+          new CdoFieldImageDropdown(
             this.K1_DIR,
             IMAGE_SIZES.K1_DIR.width,
             IMAGE_SIZES.K1_DIR.height,
@@ -1437,7 +1439,7 @@ exports.install = function (blockly, blockInstallOptions) {
 
       if (isK1) {
         this.appendDummyInput().appendField(
-          new blockly.FieldImageDropdown(
+          new CdoFieldImageDropdown(
             this.K1_DIR,
             IMAGE_SIZES.K1_DIR.width,
             IMAGE_SIZES.K1_DIR.height,
@@ -1462,7 +1464,7 @@ exports.install = function (blockly, blockInstallOptions) {
       } else {
         if (isK1) {
           this.appendDummyInput().appendField(
-            new blockly.FieldImageDropdown(
+            new CdoFieldImageDropdown(
               this.K1_DISTANCE,
               IMAGE_SIZES.K1_MOVE_LINE.width,
               IMAGE_SIZES.K1_MOVE_LINE.height
@@ -1698,7 +1700,7 @@ exports.install = function (blockly, blockInstallOptions) {
       if (isK1) {
         this.appendDummyInput()
           .appendField(commonMsg.play())
-          .appendField(new blockly.FieldImage(skin.soundIcon))
+          .appendField(new CdoFieldImage(skin.soundIcon))
           .appendField(
             new blockly.FieldDropdown(this.soundChoices(), onSoundSelected),
             'SOUND'
@@ -1747,7 +1749,7 @@ exports.install = function (blockly, blockInstallOptions) {
       if (isK1) {
         this.appendDummyInput()
           .appendField(commonMsg.score())
-          .appendField(new blockly.FieldImage(skin.scoreCard));
+          .appendField(new CdoFieldImage(skin.scoreCard));
       } else {
         this.appendDummyInput().appendField(
           new blockly.FieldDropdown(this.VALUES),
@@ -2029,7 +2031,7 @@ exports.install = function (blockly, blockInstallOptions) {
       }
 
       if (isK1) {
-        var fieldImageDropdown = new blockly.FieldImageDropdown(
+        var fieldImageDropdown = new CdoFieldImageDropdown(
           this.K1_VALUES,
           IMAGE_SIZES.K1_SPEEDS.width,
           IMAGE_SIZES.K1_SPEEDS.height
@@ -2455,7 +2457,7 @@ exports.install = function (blockly, blockInstallOptions) {
       var dropdown;
       if (isK1) {
         this.VALUES = skin.backgroundChoicesK1;
-        dropdown = new blockly.FieldImageDropdown(
+        dropdown = new CdoFieldImageDropdown(
           skin.backgroundChoicesK1,
           skin.dropdownThumbnailWidth,
           skin.dropdownThumbnailHeight
@@ -2601,23 +2603,23 @@ exports.install = function (blockly, blockInstallOptions) {
         this.appendDummyInput()
           .appendField(msg.showTitleScreenTitle())
           .appendField(
-            new Blockly.FieldImage(Blockly.assetUrl('media/quote0.png'), 12, 12)
+            new CdoFieldImage(Blockly.assetUrl('media/quote0.png'), 12, 12)
           )
           .appendField(
             new Blockly.FieldTextInput(msg.showTSDefTitle()),
             'TITLE'
           )
           .appendField(
-            new Blockly.FieldImage(Blockly.assetUrl('media/quote1.png'), 12, 12)
+            new CdoFieldImage(Blockly.assetUrl('media/quote1.png'), 12, 12)
           );
         this.appendDummyInput()
           .appendField(msg.showTitleScreenText())
           .appendField(
-            new Blockly.FieldImage(Blockly.assetUrl('media/quote0.png'), 12, 12)
+            new CdoFieldImage(Blockly.assetUrl('media/quote0.png'), 12, 12)
           )
           .appendField(new Blockly.FieldTextInput(msg.showTSDefText()), 'TEXT')
           .appendField(
-            new Blockly.FieldImage(Blockly.assetUrl('media/quote1.png'), 12, 12)
+            new CdoFieldImage(Blockly.assetUrl('media/quote1.png'), 12, 12)
           );
       }
       this.setPreviousStatement(true);
@@ -2830,7 +2832,7 @@ exports.install = function (blockly, blockInstallOptions) {
       }
 
       if (isK1) {
-        var fieldImageDropdown = new blockly.FieldImageDropdown(
+        var fieldImageDropdown = new CdoFieldImageDropdown(
           this.K1_VALUES,
           IMAGE_SIZES.K1_EMOTIONS.width,
           IMAGE_SIZES.K1_EMOTIONS.height
@@ -2942,17 +2944,15 @@ exports.install = function (blockly, blockInstallOptions) {
       } else {
         var quotedTextInput = this.appendDummyInput();
         if (isK1) {
-          quotedTextInput.appendField(
-            new Blockly.FieldImage(skin.speechBubble)
-          );
+          quotedTextInput.appendField(new CdoFieldImage(skin.speechBubble));
         }
         quotedTextInput
           .appendField(
-            new Blockly.FieldImage(Blockly.assetUrl('media/quote0.png'), 12, 12)
+            new CdoFieldImage(Blockly.assetUrl('media/quote0.png'), 12, 12)
           )
           .appendField(new Blockly.FieldTextInput(msg.defaultSayText()), 'TEXT')
           .appendField(
-            new Blockly.FieldImage(Blockly.assetUrl('media/quote1.png'), 12, 12)
+            new CdoFieldImage(Blockly.assetUrl('media/quote1.png'), 12, 12)
           );
       }
       if (options.time) {
@@ -3069,7 +3069,7 @@ exports.install = function (blockly, blockInstallOptions) {
           dropdown.setValue('1000');
           this.appendDummyInput()
             .appendField(msg.wait())
-            .appendField(new blockly.FieldImage(skin.clockIcon))
+            .appendField(new CdoFieldImage(skin.clockIcon))
             .appendField(dropdown, 'VALUE')
             .appendField(msg.waitSeconds());
         } else {
@@ -3188,11 +3188,11 @@ exports.install = function (blockly, blockInstallOptions) {
       this.setInputsInline(true);
       this.appendDummyInput()
         .appendField(
-          new Blockly.FieldImage(Blockly.assetUrl('media/quote0.png'), 12, 12)
+          new CdoFieldImage(Blockly.assetUrl('media/quote0.png'), 12, 12)
         )
         .appendField(new Blockly.FieldTextInput(''), 'TEXT')
         .appendField(
-          new Blockly.FieldImage(Blockly.assetUrl('media/quote1.png'), 12, 12)
+          new CdoFieldImage(Blockly.assetUrl('media/quote1.png'), 12, 12)
         );
       this.appendDummyInput().appendField(msg.toSet());
       this.appendDummyInput()
@@ -3507,7 +3507,7 @@ function installVanish(
         this.appendDummyInput()
           .appendField(msg.vanish())
           .appendField(
-            new blockly.FieldImage(blockInstallOptions.skin.explosionThumbnail)
+            new CdoFieldImage(blockInstallOptions.skin.explosionThumbnail)
           )
           .appendField(startingSpriteImageDropdown(), 'SPRITE');
       } else {
@@ -3592,7 +3592,7 @@ function installConditionals(
       appendActorSelect(this, actorSelectDropdown);
 
       if (blockInstallOptions.isK1) {
-        const fieldImageDropdown = new blockly.FieldImageDropdown(
+        const fieldImageDropdown = new CdoFieldImageDropdown(
           K1_EMOTION_VALUES,
           IMAGE_SIZES.K1_EMOTIONS.width,
           IMAGE_SIZES.K1_EMOTIONS.height

--- a/apps/src/studio/blocks.js
+++ b/apps/src/studio/blocks.js
@@ -176,7 +176,7 @@ exports.install = function (blockly, blockInstallOptions) {
    * Creates a dropdown with options for each sprite number
    * @param {function} stringGenerator A function that takes a spriteIndex and
    *   creates a string from it.
-   * @returns {Blockly.FieldDropdown}
+   * @returns {CdoFieldDropdown}
    */
   function spriteNumberTextDropdown(stringGenerator) {
     return new CdoFieldDropdown(spriteNumberTextArray(stringGenerator));

--- a/apps/src/studio/blocks.js
+++ b/apps/src/studio/blocks.js
@@ -8,6 +8,9 @@
 import {Order} from 'blockly/javascript';
 import _ from 'lodash';
 
+import CdoFieldDropdown from '@cdo/apps/blockly/addons/cdoFieldDropdown';
+import CdoFieldImage from '@cdo/apps/blockly/addons/cdoFieldImage';
+import {CdoFieldImageDropdown} from '@cdo/apps/blockly/addons/cdoFieldImageDropdown';
 import {
   addSerializationHooksToBlock,
   interpolateMsg,
@@ -15,8 +18,6 @@ import {
 } from '@cdo/apps/blockly/utils';
 import commonMsg from '@cdo/locale';
 
-import CdoFieldImage from '../blockly/addons/cdoFieldImage';
-import {CdoFieldImageDropdown} from '../blockly/addons/cdoFieldImageDropdown';
 import {BlockStyles} from '../blockly/constants';
 import {singleton as studioApp} from '../StudioApp';
 import {stripQuotes, valueOr} from '../utils';
@@ -176,7 +177,7 @@ exports.install = function (blockly, blockInstallOptions) {
    * @returns {Blockly.FieldDropdown}
    */
   function spriteNumberTextDropdown(stringGenerator) {
-    return new blockly.FieldDropdown(spriteNumberTextArray(stringGenerator));
+    return new CdoFieldDropdown(spriteNumberTextArray(stringGenerator));
   }
 
   /**
@@ -378,7 +379,7 @@ exports.install = function (blockly, blockInstallOptions) {
         );
       } else {
         this.appendDummyInput().appendField(
-          new blockly.FieldDropdown(this.VALUES),
+          new CdoFieldDropdown(this.VALUES),
           'VALUE'
         );
       }
@@ -529,7 +530,7 @@ exports.install = function (blockly, blockInstallOptions) {
     init: function () {
       this.setStyle(BlockStyles.EVENT);
       this.appendDummyInput().appendField(
-        new blockly.FieldDropdown(this.VALUES),
+        new CdoFieldDropdown(this.VALUES),
         'VALUE'
       );
       this.setPreviousStatement(false);
@@ -575,7 +576,7 @@ exports.install = function (blockly, blockInstallOptions) {
     init: function () {
       this.setStyle(BlockStyles.EVENT);
       this.appendDummyInput().appendField(
-        new blockly.FieldDropdown(this.VALUES),
+        new CdoFieldDropdown(this.VALUES),
         'VALUE'
       );
       this.setPreviousStatement(false);
@@ -630,7 +631,7 @@ exports.install = function (blockly, blockInstallOptions) {
         }
         dropdownArray2 = dropdownArray2.concat(this.GROUPINGS.slice(3, 6));
         dropdownArray2 = dropdownArray2.concat(this.EDGES);
-        dropdown2 = new blockly.FieldDropdown(dropdownArray2);
+        dropdown2 = new CdoFieldDropdown(dropdownArray2);
         this.appendDummyInput().appendField(dropdown1, 'SPRITE1');
         this.appendDummyInput().appendField(dropdown2, 'SPRITE2');
       }
@@ -674,7 +675,7 @@ exports.install = function (blockly, blockInstallOptions) {
     init: function () {
       this.setStyle(BlockStyles.DEFAULT);
       this.appendDummyInput().appendField(
-        new blockly.FieldDropdown([
+        new CdoFieldDropdown([
           [msg.allowActorsToLeaveThePlayspace(), 'true'],
           [msg.dontAllowActorsToLeaveThePlayspace(), 'false'],
         ]),
@@ -754,7 +755,7 @@ exports.install = function (blockly, blockInstallOptions) {
       this.setStyle(BlockStyles.DEFAULT);
       this.appendDummyInput().appendField(msg.addCharacter());
       this.appendDummyInput().appendField(
-        new blockly.FieldDropdown(skin.itemChoices),
+        new CdoFieldDropdown(skin.itemChoices),
         'VALUE'
       );
       this.setPreviousStatement(true);
@@ -785,11 +786,11 @@ exports.install = function (blockly, blockInstallOptions) {
     init: function () {
       this.setStyle(BlockStyles.DEFAULT);
       this.appendDummyInput().appendField(
-        new blockly.FieldDropdown(skin.activityChoices),
+        new CdoFieldDropdown(skin.activityChoices),
         'TYPE'
       );
       this.appendDummyInput().appendField(
-        new blockly.FieldDropdown(skin.itemChoices),
+        new CdoFieldDropdown(skin.itemChoices),
         'VALUE'
       );
       this.setPreviousStatement(true);
@@ -835,11 +836,11 @@ exports.install = function (blockly, blockInstallOptions) {
 
       this.appendDummyInput().appendField(msg.setItemSpeedSet());
       this.appendDummyInput().appendField(
-        new blockly.FieldDropdown(skin.itemChoices),
+        new CdoFieldDropdown(skin.itemChoices),
         'CLASS'
       );
 
-      var dropdown = new blockly.FieldDropdown(this.VALUES);
+      var dropdown = new CdoFieldDropdown(this.VALUES);
       dropdown.setValue(this.VALUES[1][1]); // default to slow
       this.appendDummyInput().appendField(dropdown, 'VALUE');
 
@@ -879,12 +880,12 @@ exports.install = function (blockly, blockInstallOptions) {
       appendActorSelect(this, actorSelectDropdown);
       this.appendDummyInput().appendField(msg.throwSprite());
       this.appendDummyInput().appendField(
-        new blockly.FieldDropdown(skin.projectileChoices),
+        new CdoFieldDropdown(skin.projectileChoices),
         'VALUE'
       );
       this.appendDummyInput().appendField('\t');
       this.appendDummyInput().appendField(
-        new blockly.FieldDropdown(blockly.Blocks.studio_throw.DIR),
+        new CdoFieldDropdown(blockly.Blocks.studio_throw.DIR),
         'DIR'
       );
       this.setPreviousStatement(true);
@@ -941,12 +942,12 @@ exports.install = function (blockly, blockInstallOptions) {
     init: function () {
       this.setStyle(BlockStyles.DEFAULT);
       this.appendDummyInput().appendField(
-        new blockly.FieldDropdown(this.VALUES),
+        new CdoFieldDropdown(this.VALUES),
         'VALUE'
       );
       this.appendDummyInput().appendField('\t');
       this.appendDummyInput().appendField(
-        new blockly.FieldDropdown(this.ACTIONS),
+        new CdoFieldDropdown(this.ACTIONS),
         'ACTION'
       );
       this.setPreviousStatement(true);
@@ -980,8 +981,8 @@ exports.install = function (blockly, blockInstallOptions) {
     // Block for jumping a sprite (selected by dropdown) to different position.
     helpUrl: '',
     init: function () {
-      var dropdown = new blockly.FieldDropdown(this.VALUES);
-      var spriteIndexDropdown = new blockly.FieldDropdown(
+      var dropdown = new CdoFieldDropdown(this.VALUES);
+      var spriteIndexDropdown = new CdoFieldDropdown(
         spriteNumberTextArray(s => s.spriteIndex.toString())
       );
 
@@ -1030,7 +1031,7 @@ exports.install = function (blockly, blockInstallOptions) {
     // Block for jumping a sprite (selected by block param) to different position.
     helpUrl: '',
     init: function () {
-      var dropdown = new blockly.FieldDropdown(POSITION_VALUES);
+      var dropdown = new CdoFieldDropdown(POSITION_VALUES);
       dropdown.setValue(POSITION_VALUES[1][1]); // default to top-left
       this.setStyle(BlockStyles.DEFAULT);
       interpolateMsg(
@@ -1116,7 +1117,7 @@ exports.install = function (blockly, blockInstallOptions) {
     // Block for adding a goal flag at a specified position
     helpUrl: '',
     init: function () {
-      var dropdown = new blockly.FieldDropdown(this.VALUES);
+      var dropdown = new CdoFieldDropdown(this.VALUES);
       dropdown.setValue(this.VALUES[1][1]); // default to top-left
       this.setStyle(BlockStyles.DEFAULT);
       interpolateMsg(
@@ -1373,7 +1374,7 @@ exports.install = function (blockly, blockInstallOptions) {
         );
       } else {
         this.appendDummyInput().appendField(
-          new blockly.FieldDropdown(this.DIR),
+          new CdoFieldDropdown(this.DIR),
           'DIR'
         );
       }
@@ -1450,7 +1451,7 @@ exports.install = function (blockly, blockInstallOptions) {
         );
       } else {
         this.appendDummyInput().appendField(
-          new blockly.FieldDropdown(this.DIR),
+          new CdoFieldDropdown(this.DIR),
           'DIR'
         );
       }
@@ -1473,7 +1474,7 @@ exports.install = function (blockly, blockInstallOptions) {
           );
         } else {
           this.appendDummyInput().appendField(
-            new blockly.FieldDropdown(this.DISTANCE),
+            new CdoFieldDropdown(this.DISTANCE),
             'DISTANCE'
           );
         }
@@ -1627,7 +1628,7 @@ exports.install = function (blockly, blockInstallOptions) {
     init: function () {
       this.setStyle(BlockStyles.DEFAULT);
       this.appendDummyInput().appendField(
-        new blockly.FieldDropdown(this.DIRECTIONS),
+        new CdoFieldDropdown(this.DIRECTIONS),
         'DIR'
       );
       this.setPreviousStatement(true);
@@ -1653,7 +1654,7 @@ exports.install = function (blockly, blockInstallOptions) {
     init: function () {
       this.setStyle(BlockStyles.DEFAULT);
       this.appendDummyInput().appendField(
-        new blockly.FieldDropdown(this.DIRECTIONS),
+        new CdoFieldDropdown(this.DIRECTIONS),
         'DIR'
       );
       this.setPreviousStatement(true);
@@ -1702,12 +1703,12 @@ exports.install = function (blockly, blockInstallOptions) {
           .appendField(commonMsg.play())
           .appendField(new CdoFieldImage(skin.soundIcon))
           .appendField(
-            new blockly.FieldDropdown(this.soundChoices(), onSoundSelected),
+            new CdoFieldDropdown(this.soundChoices(), onSoundSelected),
             'SOUND'
           );
       } else {
         this.appendDummyInput().appendField(
-          new blockly.FieldDropdown(this.soundChoices(), onSoundSelected),
+          new CdoFieldDropdown(this.soundChoices(), onSoundSelected),
           'SOUND'
         );
       }
@@ -1752,7 +1753,7 @@ exports.install = function (blockly, blockInstallOptions) {
           .appendField(new CdoFieldImage(skin.scoreCard));
       } else {
         this.appendDummyInput().appendField(
-          new blockly.FieldDropdown(this.VALUES),
+          new CdoFieldDropdown(this.VALUES),
           'VALUE'
         );
       }
@@ -1786,7 +1787,7 @@ exports.install = function (blockly, blockInstallOptions) {
     init: function () {
       this.setStyle(BlockStyles.DEFAULT);
       this.appendDummyInput().appendField(
-        new blockly.FieldDropdown(this.VALUES),
+        new CdoFieldDropdown(this.VALUES),
         'VALUE'
       );
       this.setPreviousStatement(true);
@@ -1820,7 +1821,7 @@ exports.install = function (blockly, blockInstallOptions) {
     init: function () {
       this.setStyle(BlockStyles.DEFAULT);
       this.appendDummyInput().appendField(
-        new blockly.FieldDropdown(this.VALUES),
+        new CdoFieldDropdown(this.VALUES),
         'VALUE'
       );
       this.setPreviousStatement(true);
@@ -1982,7 +1983,7 @@ exports.install = function (blockly, blockInstallOptions) {
     helpUrl: '',
     init: function () {
       this.setStyle(BlockStyles.DEFAULT);
-      var dropdown = new blockly.FieldDropdown(this.VALUES);
+      var dropdown = new CdoFieldDropdown(this.VALUES);
       dropdown.setValue(this.VALUES[2][1]); // default to normal
       this.appendDummyInput().appendField(dropdown, 'VALUE');
       this.setInputsInline(true);
@@ -2041,7 +2042,7 @@ exports.install = function (blockly, blockInstallOptions) {
           .appendField(msg.speed())
           .appendField(fieldImageDropdown, 'VALUE');
       } else {
-        var dropdown = new blockly.FieldDropdown(this.VALUES);
+        var dropdown = new CdoFieldDropdown(this.VALUES);
         dropdown.setValue(this.VALUES[3][1]); // default to normal
         this.appendDummyInput().appendField(dropdown, 'VALUE');
       }
@@ -2129,7 +2130,7 @@ exports.install = function (blockly, blockInstallOptions) {
         this.appendDummyInput().appendField(msg.setSprite());
       }
 
-      var dropdown = new blockly.FieldDropdown(this.VALUES);
+      var dropdown = new CdoFieldDropdown(this.VALUES);
       dropdown.setValue(this.VALUES[3][1]); // default to normal
       this.appendDummyInput().appendField(dropdown, 'VALUE');
 
@@ -2205,7 +2206,7 @@ exports.install = function (blockly, blockInstallOptions) {
         const spriteName = stripQuotes(opt[1]);
         return [createMsg({spriteName: `${msg[spriteName]()}`}), opt[1]];
       });
-    const dropdown = new blockly.FieldDropdown(
+    const dropdown = new CdoFieldDropdown(
       values,
       changeCallback,
       true /* opt_alwaysCallChangeHandler */
@@ -2341,7 +2342,7 @@ exports.install = function (blockly, blockInstallOptions) {
         [msg.setSpriteFlee(), BEHAVIOR_FLEE],
         [msg.toWander(), BEHAVIOR_WANDER],
       ].map(kv => [kv[0], `"${kv[1]}"`]);
-      const behaviorDropdown = new blockly.FieldDropdown(
+      const behaviorDropdown = new CdoFieldDropdown(
         behaviorValues,
         value => {
           // Strip the quotes before comparing
@@ -2467,7 +2468,7 @@ exports.install = function (blockly, blockInstallOptions) {
           .appendField(dropdown, 'VALUE');
       } else {
         this.VALUES = skin.backgroundChoices;
-        dropdown = new blockly.FieldDropdown(skin.backgroundChoices);
+        dropdown = new CdoFieldDropdown(skin.backgroundChoices);
         this.appendDummyInput().appendField(dropdown, 'VALUE');
       }
       dropdown.setValue('"' + skin.defaultBackground + '"');
@@ -2524,7 +2525,7 @@ exports.install = function (blockly, blockInstallOptions) {
         opt[1] === RANDOM_VALUE ? opt[1] : `"${opt[1]}"`,
       ]);
 
-      var dropdown = new blockly.FieldDropdown(this.VALUES);
+      var dropdown = new CdoFieldDropdown(this.VALUES);
       this.appendDummyInput().appendField(dropdown, 'VALUE');
       // default to first item after random
       dropdown.setValue(skin.mapChoices[1][1]);
@@ -2553,7 +2554,7 @@ exports.install = function (blockly, blockInstallOptions) {
         opt[1] === RANDOM_VALUE ? opt[1] : `"${opt[1]}"`,
       ]);
 
-      var dropdown = new blockly.FieldDropdown(this.VALUES);
+      var dropdown = new CdoFieldDropdown(this.VALUES);
       this.appendDummyInput().appendField(dropdown, 'VALUE');
       // default to first item after random
       dropdown.setValue(skin.mapChoices[1][1]);
@@ -2680,7 +2681,7 @@ exports.install = function (blockly, blockInstallOptions) {
       helpUrl: '',
       init: function () {
         this.setStyle(BlockStyles.VARIABLE);
-        var visibilityTextDropdown = new blockly.FieldDropdown(this.VALUES);
+        var visibilityTextDropdown = new CdoFieldDropdown(this.VALUES);
         visibilityTextDropdown.setValue(VISIBLE_VALUE); // default to visible
         this.appendDummyInput().appendField(visibilityTextDropdown, 'VALUE');
         if (spriteCount > 1) {
@@ -2726,7 +2727,7 @@ exports.install = function (blockly, blockInstallOptions) {
             this.VALUES[i][0] = prefix + this.VALUES[i][0];
           }
         }
-        var dropdown = new blockly.FieldDropdown(this.VALUES);
+        var dropdown = new CdoFieldDropdown(this.VALUES);
         // default to first item after random/hidden
         dropdown.setValue(skin.spriteChoices[2][1]);
         this.appendDummyInput().appendField(dropdown, 'VALUE');
@@ -2742,7 +2743,7 @@ exports.install = function (blockly, blockInstallOptions) {
     helpUrl: '',
     init: function () {
       this.VALUES = skin.spriteChoices;
-      var dropdown = new blockly.FieldDropdown(skin.spriteChoices);
+      var dropdown = new CdoFieldDropdown(skin.spriteChoices);
       // default to first item after random/hidden
       dropdown.setValue(skin.spriteChoices[2][1]);
 
@@ -2842,7 +2843,7 @@ exports.install = function (blockly, blockInstallOptions) {
           .appendField(msg.emotion())
           .appendField(fieldImageDropdown, 'VALUE');
       } else {
-        var dropdown = new blockly.FieldDropdown(this.VALUES);
+        var dropdown = new CdoFieldDropdown(this.VALUES);
         dropdown.setValue(this.VALUES[1][1]); // default to normal
         this.appendDummyInput().appendField(dropdown, 'VALUE');
       }
@@ -2860,7 +2861,7 @@ exports.install = function (blockly, blockInstallOptions) {
       this.appendValueInput('SPRITE')
         .setCheck(blockly.BlockValueType.NUMBER)
         .appendField(msg.setSpriteN({spriteIndex: ''}));
-      var dropdown = new blockly.FieldDropdown(this.VALUES);
+      var dropdown = new CdoFieldDropdown(this.VALUES);
       dropdown.setValue(this.VALUES[1][1]); // default to normal
       this.appendDummyInput().appendField(dropdown, 'VALUE');
       this.setInputsInline(true);
@@ -2937,7 +2938,7 @@ exports.install = function (blockly, blockInstallOptions) {
           var string = msg['saySpriteChoices_' + i]();
           functionElement[0] = functionElement[1] = string;
         }
-        var dropdown = new blockly.FieldDropdown(functionArray);
+        var dropdown = new CdoFieldDropdown(functionArray);
         this.appendDummyInput().appendField(dropdown, 'VALUE');
       } else if (options.params) {
         this.appendValueInput('TEXT');
@@ -3060,7 +3061,7 @@ exports.install = function (blockly, blockInstallOptions) {
         this.appendDummyInput().appendField(msg.waitSeconds());
       } else {
         if (isK1) {
-          let dropdown = new blockly.FieldDropdown(
+          let dropdown = new CdoFieldDropdown(
             [1, 2, 3, 4, 5].map(val => [
               val.toString(),
               (val * 1000).toString(),
@@ -3073,7 +3074,7 @@ exports.install = function (blockly, blockInstallOptions) {
             .appendField(dropdown, 'VALUE')
             .appendField(msg.waitSeconds());
         } else {
-          let dropdown = new blockly.FieldDropdown(this.VALUES);
+          let dropdown = new CdoFieldDropdown(this.VALUES);
           dropdown.setValue(this.VALUES[2][1]); // default to half second
 
           this.appendDummyInput().appendField(dropdown, 'VALUE');
@@ -3129,7 +3130,7 @@ exports.install = function (blockly, blockInstallOptions) {
     helpUrl: '',
     init: function () {
       this.setStyle(BlockStyles.DEFAULT);
-      var dropdown = new blockly.FieldDropdown(this.VALUES);
+      var dropdown = new CdoFieldDropdown(this.VALUES);
       dropdown.setValue(this.VALUES[0][1]); // default to win
       this.appendDummyInput().appendField(dropdown, 'VALUE');
       this.setInputsInline(true);
@@ -3602,7 +3603,7 @@ function installConditionals(
           .appendField(msg.emotion())
           .appendField(fieldImageDropdown, 'EMOTION');
       } else {
-        const dropdown = new blockly.FieldDropdown(EMOTION_VALUES);
+        const dropdown = new CdoFieldDropdown(EMOTION_VALUES);
         dropdown.setValue(EMOTION_VALUES[1][1]); // default to normal
         this.appendDummyInput().appendField(dropdown, 'EMOTION');
       }
@@ -3670,12 +3671,12 @@ function installConditionals(
 
       this.appendDummyInput().appendField(' ');
 
-      const positionDropdown = new blockly.FieldDropdown(POSITION_VALUES);
+      const positionDropdown = new CdoFieldDropdown(POSITION_VALUES);
       positionDropdown.setValue(POSITION_VALUES[0][1]);
 
       this.appendDummyInput().appendField(positionDropdown, 'POSITION');
 
-      const operatorDropdown = new Blockly.FieldDropdown(OPERATORS);
+      const operatorDropdown = new CdoFieldDropdown(OPERATORS);
       this.appendDummyInput().appendField(operatorDropdown, 'OPERATOR');
 
       this.appendValueInput('COMPARED_VALUE');
@@ -3739,7 +3740,7 @@ function installConditionals(
 
       appendActorSelect(this, actorSelectDropdown);
 
-      const dropdown = new blockly.FieldDropdown(VISIBILITY_VALUES);
+      const dropdown = new CdoFieldDropdown(VISIBILITY_VALUES);
       dropdown.setValue(VISIBILITY_VALUES[0][1]);
 
       this.appendDummyInput().appendField(dropdown, 'VISIBILITY');
@@ -3791,7 +3792,7 @@ function installConditionals(
 
       appendActorSelect(this, actorSelectDropdown);
 
-      const dropdown = new blockly.FieldDropdown(SPRITE_VALUES);
+      const dropdown = new CdoFieldDropdown(SPRITE_VALUES);
       dropdown.setValue(SPRITE_VALUES[0][1]);
 
       this.appendDummyInput().appendField(dropdown, 'VALUE');

--- a/apps/src/studio/blocks.js
+++ b/apps/src/studio/blocks.js
@@ -12,6 +12,7 @@ import CdoFieldDropdown from '@cdo/apps/blockly/addons/cdoFieldDropdown';
 import CdoFieldImage from '@cdo/apps/blockly/addons/cdoFieldImage';
 import {CdoFieldImageDropdown} from '@cdo/apps/blockly/addons/cdoFieldImageDropdown';
 import CdoFieldLabel from '@cdo/apps/blockly/addons/cdoFieldLabel';
+import CdoFieldVariable from '@cdo/apps/blockly/addons/cdoFieldVariable';
 import {
   addSerializationHooksToBlock,
   interpolateMsg,
@@ -3202,7 +3203,7 @@ exports.install = function (blockly, blockInstallOptions) {
         .appendField(
           Blockly.disableVariableEditing
             ? fieldLabel
-            : new Blockly.FieldVariable(Blockly.Msg.VARIABLES_GET_ITEM),
+            : new CdoFieldVariable(Blockly.Msg.VARIABLES_GET_ITEM),
           'VAR'
         )
         .appendField(Blockly.Msg.VARIABLES_GET_TAIL);

--- a/apps/src/turtle/api.js
+++ b/apps/src/turtle/api.js
@@ -1,3 +1,4 @@
+import CdoFieldColour from '../blockly/addons/cdoFieldColour';
 import {randomValue} from '../utils';
 
 var _ = require('lodash');
@@ -30,7 +31,7 @@ ArtistAPI.prototype.drawSnowflake = function (type, id) {
 
   // mirors Blockly.JavaScript.colour_random.
   var random_colour = function () {
-    var colors = Blockly.FieldColour.COLOURS;
+    var colors = CdoFieldColour.COLOURS;
     return colors[Math.floor(Math.random() * colors.length)];
   };
 

--- a/apps/src/turtle/artist.js
+++ b/apps/src/turtle/artist.js
@@ -27,11 +27,12 @@
 
 import Visualization from '@code-dot-org/artist';
 
+import CdoFieldColour from '@cdo/apps/blockly/addons/cdoFieldColour';
 import {
-  loadBlocksToWorkspace,
+  getAllGeneratedCode,
   getCode,
   getCodeFromBlockXmlSource,
-  getAllGeneratedCode,
+  loadBlocksToWorkspace,
 } from '@cdo/apps/blockly/utils';
 import {DEFAULT_EXECUTION_INFO} from '@cdo/apps/lib/tools/jsinterpreter/CustomMarshalingInterpreter';
 import {SignInState} from '@cdo/apps/templates/currentUserRedux';
@@ -576,7 +577,7 @@ Artist.prototype.afterInject_ = function (config) {
         var func = [];
         func.push('function ' + functionName + '() {');
         func.push(
-          '   var colors = ' + JSON.stringify(Blockly.FieldColour.COLOURS) + ';'
+          '   var colors = ' + JSON.stringify(CdoFieldColour.COLOURS) + ';'
         );
         func.push('  return colors[Math.floor(Math.random()*colors.length)];');
         func.push('}');

--- a/apps/src/turtle/blocks.js
+++ b/apps/src/turtle/blocks.js
@@ -22,6 +22,7 @@
  * @author fraser@google.com (Neil Fraser)
  */
 import CdoFieldDropdown from '@cdo/apps/blockly/addons/cdoFieldDropdown';
+import CdoFieldLabel from '@cdo/apps/blockly/addons/cdoFieldLabel';
 import {BlockStyles} from '@cdo/apps/blockly/constants';
 import {
   interpolateMsg,
@@ -489,7 +490,7 @@ exports.install = function (blockly, blockInstallOptions) {
       this.setStyle(BlockStyles.VARIABLE);
       this.appendDummyInput()
         .appendField(blockly.Msg.VARIABLES_GET_TITLE)
-        .appendField(new blockly.FieldLabel(msg.loopVariable()), 'VAR');
+        .appendField(new CdoFieldLabel(msg.loopVariable()), 'VAR');
       this.setOutput(true);
       this.setTooltip(blockly.Msg.VARIABLES_GET_TOOLTIP);
     },
@@ -509,7 +510,7 @@ exports.install = function (blockly, blockInstallOptions) {
       this.setStyle(BlockStyles.VARIABLE);
       this.appendDummyInput()
         .appendField(blockly.Msg.VARIABLES_GET_TITLE)
-        .appendField(new blockly.FieldLabel(msg.lengthParameter()), 'VAR');
+        .appendField(new CdoFieldLabel(msg.lengthParameter()), 'VAR');
       this.setOutput(true);
       this.setTooltip(blockly.Msg.VARIABLES_GET_TOOLTIP);
     },
@@ -527,7 +528,7 @@ exports.install = function (blockly, blockInstallOptions) {
       this.setStyle(BlockStyles.VARIABLE);
       this.appendDummyInput()
         .appendField(blockly.Msg.VARIABLES_GET_TITLE)
-        .appendField(new blockly.FieldLabel('sides'), 'VAR');
+        .appendField(new CdoFieldLabel('sides'), 'VAR');
       this.setOutput(true);
       this.setTooltip(blockly.Msg.VARIABLES_GET_TOOLTIP);
     },
@@ -656,7 +657,7 @@ exports.install = function (blockly, blockInstallOptions) {
         .appendField(
           blockly.Msg.CONTROLS_FOR_INPUT_WITH || msg.controlsForInputWith()
         )
-        .appendField(new blockly.FieldLabel(msg.loopVariable()), 'VAR');
+        .appendField(new CdoFieldLabel(msg.loopVariable()), 'VAR');
       interpolateMsg(
         this,
         blockly.Msg.CONTROLS_FOR_INPUT_FROM_TO_BY ||
@@ -973,7 +974,7 @@ exports.install = function (blockly, blockInstallOptions) {
             input.appendField(commonMsg.jump());
           }
           input.appendField(
-            new blockly.FieldLabel(directionConfig.title, {
+            new CdoFieldLabel(directionConfig.title, {
               fixedSize: {width: directionLetterWidth, height: 18},
             })
           );

--- a/apps/src/turtle/blocks.js
+++ b/apps/src/turtle/blocks.js
@@ -24,13 +24,15 @@
 
 import {BlockStyles} from '@cdo/apps/blockly/constants';
 import {
-  registerCustomProcedureBlocks,
-  numberValidator,
   interpolateMsg,
+  numberValidator,
+  registerCustomProcedureBlocks,
 } from '@cdo/apps/blockly/utils';
 import commonMsg from '@cdo/locale';
 
 import {setAngleHelperOptions} from '../blockly/addons/cdoAngleHelperOptions';
+import CdoFieldImage from '../blockly/addons/cdoFieldImage';
+import {CdoFieldImageDropdown} from '../blockly/addons/cdoFieldImageDropdown';
 import {Position} from '../constants';
 
 import Colours from './colours';
@@ -978,20 +980,20 @@ exports.install = function (blockly, blockInstallOptions) {
 
           if (directionConfig.imageDimensions) {
             input.appendField(
-              new blockly.FieldImage(
+              new CdoFieldImage(
                 directionConfig.image,
                 directionConfig.imageDimensions.width,
                 directionConfig.imageDimensions.height
               )
             );
           } else {
-            input.appendField(new blockly.FieldImage(directionConfig.image));
+            input.appendField(new CdoFieldImage(directionConfig.image));
           }
           this.setPreviousStatement(true);
           this.setNextStatement(true);
           this.setTooltip(directionConfig.tooltip);
           if (hasLengthInput) {
-            var dropdown = new blockly.FieldImageDropdown(
+            var dropdown = new CdoFieldImageDropdown(
               directionConfig.lengths,
               directionConfig.imageDimensions.width,
               directionConfig.imageDimensions.height
@@ -1384,7 +1386,7 @@ exports.install = function (blockly, blockInstallOptions) {
       this.appendDummyInput()
         .appendField(msg.setPattern())
         .appendField(
-          new blockly.FieldImageDropdown(skin.lineStylePatternOptions, 150, 20),
+          new CdoFieldImageDropdown(skin.lineStylePatternOptions, 150, 20),
           'VALUE'
         );
       this.setTooltip(msg.setPattern());
@@ -1470,7 +1472,7 @@ exports.install = function (blockly, blockInstallOptions) {
           var url = skin.stickers[name];
           values.push([url, name]);
         }
-        dropdown = new blockly.FieldImageDropdown(values, 40, 40);
+        dropdown = new CdoFieldImageDropdown(values, 40, 40);
 
         input.appendField(dropdown, 'VALUE');
 
@@ -1558,7 +1560,7 @@ exports.install = function (blockly, blockInstallOptions) {
           var url = skin[shapeNames][name];
           values.push([url, name]);
         }
-        dropdown = new blockly.FieldImageDropdown(values, 40, 40);
+        dropdown = new CdoFieldImageDropdown(values, 40, 40);
 
         input.appendField(dropdown, 'VALUE');
 

--- a/apps/src/turtle/blocks.js
+++ b/apps/src/turtle/blocks.js
@@ -103,7 +103,7 @@ exports.install = function (blockly, blockInstallOptions) {
 
   if (skin.id === 'anna' || skin.id === 'elsa') {
     // Create a smaller palette.
-    blockly.FieldColour.COLOURS = [
+    CdoFieldColour.COLOURS = [
       Colours.FROZEN1,
       Colours.FROZEN2,
       Colours.FROZEN3,
@@ -114,10 +114,10 @@ exports.install = function (blockly, blockInstallOptions) {
       Colours.FROZEN8,
       Colours.FROZEN9,
     ];
-    blockly.FieldColour.COLUMNS = 3;
+    CdoFieldColour.COLUMNS = 3;
   } else {
     // Create a smaller palette.
-    blockly.FieldColour.COLOURS = [
+    CdoFieldColour.COLOURS = [
       // Row 1.
       Colours.BLACK,
       Colours.GREY,
@@ -134,7 +134,7 @@ exports.install = function (blockly, blockInstallOptions) {
       Colours.AQUAMARINE,
       Colours.PLUM,
     ];
-    blockly.FieldColour.COLUMNS = 4;
+    CdoFieldColour.COLUMNS = 4;
   }
 
   // Block definitions.

--- a/apps/src/turtle/blocks.js
+++ b/apps/src/turtle/blocks.js
@@ -21,7 +21,7 @@
  * @fileoverview Demonstration of Blockly: Turtle Graphics.
  * @author fraser@google.com (Neil Fraser)
  */
-
+import CdoFieldDropdown from '@cdo/apps/blockly/addons/cdoFieldDropdown';
 import {BlockStyles} from '@cdo/apps/blockly/constants';
 import {
   interpolateMsg,
@@ -140,7 +140,7 @@ exports.install = function (blockly, blockInstallOptions) {
     init: function () {
       this.setStyle(BlockStyles.DEFAULT);
       this.appendDummyInput().appendField(
-        new blockly.FieldDropdown(MOVE_BY_DIRECTION_VALUES),
+        new CdoFieldDropdown(MOVE_BY_DIRECTION_VALUES),
         'DIR'
       );
       this.appendDummyInput()
@@ -162,11 +162,11 @@ exports.install = function (blockly, blockInstallOptions) {
     init: function () {
       this.setStyle(BlockStyles.DEFAULT);
       this.appendDummyInput().appendField(
-        new blockly.FieldDropdown(MOVE_BY_DIRECTION_VALUES),
+        new CdoFieldDropdown(MOVE_BY_DIRECTION_VALUES),
         'DIR'
       );
       this.appendDummyInput()
-        .appendField(new blockly.FieldDropdown(), 'VALUE')
+        .appendField(new CdoFieldDropdown(), 'VALUE')
         .appendField(msg.dots());
       this.setInputsInline(true);
       this.setPreviousStatement(true);
@@ -197,7 +197,7 @@ exports.install = function (blockly, blockInstallOptions) {
     init: function () {
       this.setStyle(BlockStyles.DEFAULT);
       this.appendDummyInput().appendField(
-        new blockly.FieldDropdown(TURN_BY_DIRECTION_VALUES),
+        new CdoFieldDropdown(TURN_BY_DIRECTION_VALUES),
         'DIR'
       );
       this.appendDummyInput()
@@ -243,7 +243,7 @@ exports.install = function (blockly, blockInstallOptions) {
     init: function () {
       this.setStyle(BlockStyles.DEFAULT);
       this.appendDummyInput().appendField(
-        new blockly.FieldDropdown(TURN_BY_DIRECTION_VALUES),
+        new CdoFieldDropdown(TURN_BY_DIRECTION_VALUES),
         'DIR'
       );
       this.appendDummyInput()
@@ -267,7 +267,7 @@ exports.install = function (blockly, blockInstallOptions) {
     init: function () {
       this.setStyle(BlockStyles.DEFAULT);
       this.appendDummyInput().appendField(
-        new blockly.FieldDropdown(TURN_BY_DIRECTION_VALUES),
+        new CdoFieldDropdown(TURN_BY_DIRECTION_VALUES),
         'DIR'
       );
       this.appendDummyInput()
@@ -321,7 +321,7 @@ exports.install = function (blockly, blockInstallOptions) {
     init: function () {
       this.setStyle(BlockStyles.DEFAULT);
       this.appendDummyInput().appendField(
-        new blockly.FieldDropdown(TURN_BY_DIRECTION_VALUES),
+        new CdoFieldDropdown(TURN_BY_DIRECTION_VALUES),
         'DIR'
       );
       this.appendDummyInput()
@@ -367,7 +367,7 @@ exports.install = function (blockly, blockInstallOptions) {
     init: function () {
       this.setStyle(BlockStyles.DEFAULT);
       this.appendDummyInput().appendField(
-        new blockly.FieldDropdown(TURN_BY_DIRECTION_VALUES),
+        new CdoFieldDropdown(TURN_BY_DIRECTION_VALUES),
         'DIR'
       );
       this.appendDummyInput()
@@ -712,7 +712,7 @@ exports.install = function (blockly, blockInstallOptions) {
         msg.moveDirectionByPixels(),
         () => {
           this.appendDummyInput().appendField(
-            new blockly.FieldDropdown(DIRECTION_VALUES),
+            new CdoFieldDropdown(DIRECTION_VALUES),
             'DIR'
           );
         },
@@ -751,7 +751,7 @@ exports.install = function (blockly, blockInstallOptions) {
         msg.jumpByDirection(),
         () => {
           this.appendDummyInput().appendField(
-            new blockly.FieldDropdown(JUMP_DIRECTION_VALUES),
+            new CdoFieldDropdown(JUMP_DIRECTION_VALUES),
             'DIR'
           );
         },
@@ -1050,7 +1050,7 @@ exports.install = function (blockly, blockInstallOptions) {
     init: function () {
       this.setStyle(BlockStyles.DEFAULT);
       this.appendDummyInput().appendField(
-        new blockly.FieldDropdown(JUMP_BY_DIRECTION_VALUES),
+        new CdoFieldDropdown(JUMP_BY_DIRECTION_VALUES),
         'DIR'
       );
       this.appendDummyInput()
@@ -1073,11 +1073,11 @@ exports.install = function (blockly, blockInstallOptions) {
     init: function () {
       this.setStyle(BlockStyles.DEFAULT);
       this.appendDummyInput().appendField(
-        new blockly.FieldDropdown(JUMP_BY_DIRECTION_VALUES),
+        new CdoFieldDropdown(JUMP_BY_DIRECTION_VALUES),
         'DIR'
       );
       this.appendDummyInput()
-        .appendField(new blockly.FieldDropdown(), 'VALUE')
+        .appendField(new CdoFieldDropdown(), 'VALUE')
         .appendField(msg.dots());
       this.setInputsInline(true);
       this.setPreviousStatement(true);
@@ -1106,7 +1106,7 @@ exports.install = function (blockly, blockInstallOptions) {
     // Block for jumping to a specified position
     helpUrl: '',
     init: function () {
-      var dropdown = new blockly.FieldDropdown(this.VALUES);
+      var dropdown = new CdoFieldDropdown(this.VALUES);
       dropdown.setValue(this.VALUES[1][1]); // default to top-left
       this.setStyle(BlockStyles.DEFAULT);
       interpolateMsg(
@@ -1182,7 +1182,7 @@ exports.install = function (blockly, blockInstallOptions) {
         msg.turnDirection(),
         () => {
           this.appendDummyInput().appendField(
-            new blockly.FieldDropdown(TURN_DIRECTION_VALUES),
+            new CdoFieldDropdown(TURN_DIRECTION_VALUES),
             'DIR'
           );
         },
@@ -1270,7 +1270,7 @@ exports.install = function (blockly, blockInstallOptions) {
     init: function () {
       this.setStyle(BlockStyles.DEFAULT);
       this.appendDummyInput().appendField(
-        new blockly.FieldDropdown(this.STATE),
+        new CdoFieldDropdown(this.STATE),
         'PEN'
       );
       this.setPreviousStatement(true);
@@ -1408,7 +1408,7 @@ exports.install = function (blockly, blockInstallOptions) {
       this.setPreviousStatement(true, null);
       this.setNextStatement(true, null);
       this.appendDummyInput().appendField(
-        new blockly.FieldDropdown(this.STATE),
+        new CdoFieldDropdown(this.STATE),
         'VISIBILITY'
       );
       this.setTooltip(msg.turtleVisibilityTooltip());
@@ -1431,7 +1431,7 @@ exports.install = function (blockly, blockInstallOptions) {
       this.setPreviousStatement(true, null);
       this.setNextStatement(true, null);
       this.appendDummyInput().appendField(
-        new blockly.FieldDropdown(this.STATE),
+        new CdoFieldDropdown(this.STATE),
         'VISIBILITY'
       );
       this.setTooltip(msg.turtleVisibilityTooltip());
@@ -1649,7 +1649,7 @@ exports.install = function (blockly, blockInstallOptions) {
         artist,
       ]);
       this.appendDummyInput().appendField(
-        new blockly.FieldDropdown(values),
+        new CdoFieldDropdown(values),
         'VALUE'
       );
       this.setPreviousStatement(true);

--- a/apps/src/turtle/blocks.js
+++ b/apps/src/turtle/blocks.js
@@ -21,6 +21,9 @@
  * @fileoverview Demonstration of Blockly: Turtle Graphics.
  * @author fraser@google.com (Neil Fraser)
  */
+import CdoFieldAngleDropdown from '@cdo/apps/blockly/addons/cdoFieldAngleDropdown';
+import CdoFieldAngleTextInput from '@cdo/apps/blockly/addons/cdoFieldAngleTextInput';
+import CdoFieldColour from '@cdo/apps/blockly/addons/cdoFieldColour';
 import CdoFieldDropdown from '@cdo/apps/blockly/addons/cdoFieldDropdown';
 import CdoFieldLabel from '@cdo/apps/blockly/addons/cdoFieldLabel';
 import {BlockStyles} from '@cdo/apps/blockly/constants';
@@ -203,7 +206,7 @@ exports.install = function (blockly, blockInstallOptions) {
       );
       this.appendDummyInput()
         .appendField(
-          new blockly.FieldAngleDropdown({
+          new CdoFieldAngleDropdown({
             directionTitleName: 'DIR',
             menuGenerator: this.VALUE,
           }),
@@ -249,7 +252,7 @@ exports.install = function (blockly, blockInstallOptions) {
       );
       this.appendDummyInput()
         .appendField(
-          new blockly.FieldAngleTextInput('90', {
+          new CdoFieldAngleTextInput('90', {
             directionTitle: 'DIR',
           }),
           'VALUE'
@@ -273,7 +276,7 @@ exports.install = function (blockly, blockInstallOptions) {
       );
       this.appendDummyInput()
         .appendField(
-          new blockly.FieldAngleDropdown({
+          new CdoFieldAngleDropdown({
             directionTitleName: 'DIR',
           }),
           'VALUE'
@@ -327,7 +330,7 @@ exports.install = function (blockly, blockInstallOptions) {
       );
       this.appendDummyInput()
         .appendField(
-          new blockly.FieldAngleDropdown({
+          new CdoFieldAngleDropdown({
             directionTitleName: 'DIR',
             menuGenerator: this.VALUE,
           }),
@@ -373,7 +376,7 @@ exports.install = function (blockly, blockInstallOptions) {
       );
       this.appendDummyInput()
         .appendField(
-          new blockly.FieldAngleTextInput('90', {
+          new CdoFieldAngleTextInput('90', {
             directionTitle: 'DIR',
           }),
           'VALUE'
@@ -408,7 +411,7 @@ exports.install = function (blockly, blockInstallOptions) {
     block
       .appendDummyInput()
       .appendField(
-        new blockly.FieldAngleTextInput('0', {
+        new CdoFieldAngleTextInput('0', {
           direction: 'turnRight',
         }),
         'DIRECTION'
@@ -447,7 +450,7 @@ exports.install = function (blockly, blockInstallOptions) {
       block
         .appendDummyInput()
         .appendField(
-          new blockly.FieldAngleDropdown({
+          new CdoFieldAngleDropdown({
             direction: 'turnRight',
             menuGenerator: block.VALUE,
           }),
@@ -1355,7 +1358,7 @@ exports.install = function (blockly, blockInstallOptions) {
       ];
       this.setStyle(BlockStyles.LOGIC);
       // 3-column colour field with an increased height/width for menu options and the field itself.
-      const colourField = new Blockly.FieldColour(
+      const colourField = new CdoFieldColour(
         colours[0],
         undefined,
         {colourOptions: colours, columns: 3},

--- a/apps/src/turtle/customLevelBlocks.js
+++ b/apps/src/turtle/customLevelBlocks.js
@@ -2,6 +2,8 @@
  * A set of blocks used by some of our custom levels (i.e. built by level builder)
  */
 
+import CdoFieldDropdown from '@cdo/apps/blockly/addons/cdoFieldDropdown';
+
 import {BlockStyles} from '../blockly/constants';
 
 var msg = require('./locale');
@@ -581,7 +583,7 @@ function installCreateASnowflakeDropdown(blockly, generator, gensym) {
     init: function () {
       this.setStyle(BlockStyles.PROCEDURE);
 
-      var title = new blockly.FieldDropdown(snowflakes);
+      var title = new CdoFieldDropdown(snowflakes);
       this.appendDummyInput().appendField(title, 'TYPE');
 
       this.setPreviousStatement(true);

--- a/apps/test/unit/blockUtils.karma.test.js
+++ b/apps/test/unit/blockUtils.karma.test.js
@@ -387,9 +387,6 @@ describe('block utils', () => {
         ])
       );
 
-      expect(fakeBlockly.FieldDropdown).to.have.been.calledOnce;
-      const dropdownArg = fakeBlockly.FieldDropdown.firstCall.args[0];
-      expect(dropdownArg).to.deep.equal(TEST_SPRITES);
       expect(appendEndRowInput).to.have.been.calledOnce;
       expect(appendField).to.have.been.calledWith(sinon.match.any, 'ANIMATION');
     });


### PR DESCRIPTION
This work is in service of the goal of removing the Blockly wrapper. Here, I am interested in removing our custom field classes (e.g. `CdoFieldNumber`) from the wrapper (ie. `Blockly.FieldNumber`). We can still use our custom field classes by importing them directly. The majority of changes are to switch from the wrapped classes to standard classes. By changing over all references to wrapped field classes, we can also stop storing those classes on the wrapper. This does not change any functionality but gets us a step closer to removing the wrapper.

What changes:
- All instances of `Blockly.FieldXX` (where `FieldXX` represents a custom class) are changed to `CdoFieldXX` using direct imports.
- `blocklyWrapper.overrideFields` is removed. We no longer need to assign these classes to the wrapper object (but we do still need to register several of them with Blockly).
- Remove `CdoAngleHelper` from the wrapper (used by various angle fields in Artist)

What doesn't change:
- Fields that are never extended (e.g `FieldIcon, `FieldTextInput`) continue to be referenced off of `Blockly`. Once the wrapper is removed, these references should begin to point to Blockly core itself and continue to work.
- We will still register some custom fields with Blockly so that they can be used by modern JSON block definitions.

## Testing story
For manual testing, I kept a tab open with each Blockly lab while I worked. I've ensured that blocks in each lab still are created without error as before.

