### PR TITLE
Fix sketch lab introjs flow regression (now triggered on first load)

### DIFF
--- a/apps/src/sketchlab/SketchlabView.tsx
+++ b/apps/src/sketchlab/SketchlabView.tsx
@@ -332,7 +332,7 @@ const SketchlabView: React.FC<LabProps<LevelProperties>> = ({
   return (
     <BackpackAPIContext.Provider value={backpackContext}>
       <div className={moduleStyles.sketchlabContainer}>
-        <IntroJSTourWrapper>
+        <IntroJSTourWrapper enabled={true}>
           <SketchlabTourSteps />
         </IntroJSTourWrapper>
         <div style={{width: leftPanelWidth}} className={panelClassName}>


### PR DESCRIPTION
<!--
  Summary of the change: background, motivation, and context.
  Include screenshots, videos, or before/after comparisons for UI changes.
-->
This fixes a regression that was introduced by [this PR](https://github.com/code-dot-org/code-dot-org/pull/70633) that implemented an `IntroJSTourWrapper`. When I set the `enabled` prop default value to `undefined`, I neglected to go back and set the value to `true` in `SketchLabView`.




## Links
<!-- Jira tickets, design docs, Slack threads, related PRs, etc. -->

- [Slack post reporting bug](https://codedotorg.slack.com/archives/C06JELCAPT9/p1772567642605229)

## Testing story
<!-- How was this tested? Manual steps, adhoc links, automated tests, or why testing isn't needed. -->

Tested locally and see that introjs flow is now triggered if local storage value is not yet stored.

## Deployment notes
<!-- Delete this section if it's a standard merge-and-deploy.
     Otherwise: migrations, feature flags, coordination, caching impacts, etc. -->



## Privacy and security
<!-- Delete this section if there is no privacy/security impact.
     Otherwise: new PII, auth changes, API surface changes, etc. -->

