### PR TITLE
Fixes localizejs on the landing page of AIF 2025.

### DIFF
--- a/apps/src/localization/entrypoint.js
+++ b/apps/src/localization/entrypoint.js
@@ -83,7 +83,7 @@ const live = [
   '/courses/elementaryai-2024',
   '/courses/3-5gamedesign-2024',
   '/courses/elem-game-design-2024',
-  '/courses/artificial-intelligence-foundations-2025/',
+  '/courses/artificial-intelligence-foundations-2025',
   '/courses/mix-move-ai-2025',
   '/courses/teaching-ai-foundations-2025',
   '/courses/oceans',


### PR DESCRIPTION
Just fixes a small issue with the prefix for the AIF course. The extra slash means that it never matches the unit overview page.

## Links
<!-- Jira tickets, design docs, Slack threads, related PRs, etc. -->

- Jira: [GERW-2](https://codedotorg.atlassian.net/browse/GERW-2)
