### PR TITLE
[All labs, all site] Remove redundant banner role

### DIFF
--- a/dashboard/app/views/layouts/_header.html.haml
+++ b/dashboard/app/views/layouts/_header.html.haml
@@ -70,7 +70,7 @@
 
 %link{:href=>'/shared/css/hamburger.css', :rel=>'stylesheet'}
 
-%header{class: header_class, role: "banner"}
+%header{class: header_class}
   .navbar-static-top.header
     .container{style: "width: 100%; display: flex; justify-content: space-between; height: 50px;"}
       .header_left


### PR DESCRIPTION
Our new VPAT platform is much more strict than the AxeDevtools scanner, and therefore catches violations like this one! The header is a good place to start with tackling issues because it's caught across all 10 pages scanned (fix it once, fix it 9 times for free). 

Vpat issue: 
<img width="908" height="239" alt="Screenshot 2026-03-03 at 2 16 41 PM" src="https://github.com/user-attachments/assets/7543d24f-ab30-440a-91ea-4d7192d2dfaa" />


Before:
<img width="827" height="203" alt="Screenshot 2026-03-03 at 2 20 18 PM" src="https://github.com/user-attachments/assets/3bacf778-d58a-46fb-9dd6-7d46a752b1cd" />


After:
<img width="861" height="257" alt="Screenshot 2026-03-03 at 2 21 49 PM" src="https://github.com/user-attachments/assets/8ef8cd78-d478-4d44-8127-cf5cd5009b49" />


## Links

- Jira: https://codedotorg.atlassian.net/browse/SL-1608
- VPAT: https://app.getstark.co/organization/ced5459c-437e-48a0-8737-90ad0ef005c0/projects/aiOk8eUknKEfWPEE3SIO/assets/5bAQbcRUbbfgXK1uQydr/reports/CqhN8GGQ8oByoEkjrLvu

## Testing story
<!-- How was this tested? Manual steps, adhoc links, automated tests, or why testing isn't needed. -->



## Deployment notes
<!-- Delete this section if it's a standard merge-and-deploy.
     Otherwise: migrations, feature flags, coordination, caching impacts, etc. -->



## Privacy and security
<!-- Delete this section if there is no privacy/security impact.
     Otherwise: new PII, auth changes, API surface changes, etc. -->

