### PR TITLE
[Project Dropdown, Header] Adds empty alt text for decorative images in project dropdown

### DIFF
--- a/shared/haml/user_header.haml
+++ b/shared/haml/user_header.haml
@@ -50,11 +50,11 @@
     .create_options{style: 'display: none', dir: language_dir_class}
       - create_drop_down_items.each do |entry|
         %a.project_link_box{id: "create_menu_option_#{entry[:title]}", href: entry[:url]}
-          %img{src: "/shared/images/fill-70x70/courses/#{entry[:image]}"}
+          %img{src: "/shared/images/fill-70x70/courses/#{entry[:image]}", alt: ""}
           .project_link{ id: entry[:id]}
             .text= I18n.t("#{loc_prefix}#{entry[:title]}")
       %a.project_link_box{id: "create_menu_option_view_all", href: CDO.studio_url('projects', ge_region: ge_region)}
-        %img{src: "/shared/images/courses/header-all-projects-icon.png"}
+        %img{src: "/shared/images/courses/header-all-projects-icon.png", alt: ""}
         .project_link#view_all_projects
           = I18n.t("#{loc_prefix}view_all")
 


### PR DESCRIPTION
Another win that covers all pages with the project dropdown!! The images are all decorative so should have empty alt text. This PR adds it:)

VPAT faulures:
<img width="978" height="376" alt="Screenshot 2026-03-03 at 2 28 51 PM" src="https://github.com/user-attachments/assets/9fab1390-a01b-4247-822c-74a1874f37a4" />

Before:
<img width="956" height="691" alt="Screenshot 2026-03-03 at 2 32 38 PM" src="https://github.com/user-attachments/assets/bb621358-e71d-4afa-8a71-f4b9985c4104" />

After:
<img width="852" height="404" alt="Screenshot 2026-03-03 at 2 38 44 PM" src="https://github.com/user-attachments/assets/bf2a5bd0-a537-4123-a5fa-e0ae95451551" />



## Links

- Jira: https://codedotorg.atlassian.net/browse/SL-1609
- VPAT: https://app.getstark.co/organization/ced5459c-437e-48a0-8737-90ad0ef005c0/projects/aiOk8eUknKEfWPEE3SIO/assets/5bAQbcRUbbfgXK1uQydr/reports/CqhN8GGQ8oByoEkjrLvu

## Testing story
<!-- How was this tested? Manual steps, adhoc links, automated tests, or why testing isn't needed. -->



## Deployment notes
<!-- Delete this section if it's a standard merge-and-deploy.
     Otherwise: migrations, feature flags, coordination, caching impacts, etc. -->



## Privacy and security
<!-- Delete this section if there is no privacy/security impact.
     Otherwise: new PII, auth changes, API surface changes, etc. -->

