### PR TITLE
Fixes security bug for Google classroom teachers

### DIFF
--- a/dashboard/app/controllers/api_controller.rb
+++ b/dashboard/app/controllers/api_controller.rb
@@ -95,8 +95,10 @@ class ApiController < ApplicationController
 
     course_id = params[:courseId].to_s
     course_name = params[:courseName].to_s
+    section = CleverSection.find_by(code: CleverSection.code_for_section(course_id))
 
     query_clever_service("sections/#{course_id}/users?role=student") do |students|
+      return head :forbidden if section.present? && !section_instructor?(section)
       section = CleverSection.from_service(course_id, current_user.id, students, course_name)
       render json: section.summarize
     end
@@ -114,11 +116,11 @@ class ApiController < ApplicationController
     return head :forbidden unless current_user
     course_id = params[:courseId].to_s
     course_name = params[:courseName].to_s
+    section = GoogleClassroomSection.find_by(code: GoogleClassroomSection.code_for_section(course_id))
 
     query_google_classroom_service do |service|
-      unless google_teacher_for_course?(service, course_id)
-        return head :forbidden
-      end
+      return head :forbidden if section.present? && !section_instructor?(section)
+
       students = []
       next_page_token = nil
       loop do
@@ -644,21 +646,9 @@ class ApiController < ApplicationController
     end
   end
 
-  private def google_teacher_for_course?(service, course_id)
-    google_uid = current_user.uid_for_provider(AuthenticationOption::GOOGLE).to_s
-    return false if google_uid.empty?
-
-    next_page_token = nil
-    loop do
-      response = service.list_course_teachers(course_id, page_token: next_page_token)
-      teachers = response.teachers || []
-      return true if teachers.any? {|teacher| teacher.user_id.to_s == google_uid}
-
-      next_page_token = response.next_page_token
-      break unless next_page_token
-    end
-
-    false
+  private def section_instructor?(section)
+    return false unless current_user
+    section&.instructors&.include?(current_user)
   end
 
   # Gets progress-related app_options for the given script and level for the

--- a/dashboard/app/controllers/api_controller.rb
+++ b/dashboard/app/controllers/api_controller.rb
@@ -96,9 +96,9 @@ class ApiController < ApplicationController
     course_id = params[:courseId].to_s
     course_name = params[:courseName].to_s
     section = CleverSection.find_by(code: CleverSection.code_for_section(course_id))
+    return head :forbidden if section.present? && !section_instructor?(section)
 
     query_clever_service("sections/#{course_id}/users?role=student") do |students|
-      return head :forbidden if section.present? && !section_instructor?(section)
       section = CleverSection.from_service(course_id, current_user.id, students, course_name)
       render json: section.summarize
     end
@@ -117,10 +117,9 @@ class ApiController < ApplicationController
     course_id = params[:courseId].to_s
     course_name = params[:courseName].to_s
     section = GoogleClassroomSection.find_by(code: GoogleClassroomSection.code_for_section(course_id))
+    return head :forbidden if section.present? && !section_instructor?(section)
 
     query_google_classroom_service do |service|
-      return head :forbidden if section.present? && !section_instructor?(section)
-
       students = []
       next_page_token = nil
       loop do
@@ -648,7 +647,7 @@ class ApiController < ApplicationController
 
   private def section_instructor?(section)
     return false unless current_user
-    section&.instructors&.include?(current_user)
+    section&.instructors&.exists?(id: current_user.id)
   end
 
   # Gets progress-related app_options for the given script and level for the

--- a/dashboard/app/controllers/api_controller.rb
+++ b/dashboard/app/controllers/api_controller.rb
@@ -116,6 +116,9 @@ class ApiController < ApplicationController
     course_name = params[:courseName].to_s
 
     query_google_classroom_service do |service|
+      unless google_teacher_for_course?(service, course_id)
+        return head :forbidden
+      end
       students = []
       next_page_token = nil
       loop do
@@ -639,6 +642,23 @@ class ApiController < ApplicationController
     rescue Google::Apis::ClientError, Google::Apis::AuthorizationError => exception
       render status: :forbidden, json: {error: exception}
     end
+  end
+
+  private def google_teacher_for_course?(service, course_id)
+    google_uid = current_user.uid_for_provider(AuthenticationOption::GOOGLE).to_s
+    return false if google_uid.empty?
+
+    next_page_token = nil
+    loop do
+      response = service.list_course_teachers(course_id, page_token: next_page_token)
+      teachers = response.teachers || []
+      return true if teachers.any? {|teacher| teacher.user_id.to_s == google_uid}
+
+      next_page_token = response.next_page_token
+      break unless next_page_token
+    end
+
+    false
   end
 
   # Gets progress-related app_options for the given script and level for the

--- a/dashboard/app/models/sections/google_classroom_section.rb
+++ b/dashboard/app/models/sections/google_classroom_section.rb
@@ -39,8 +39,10 @@
 #
 
 class GoogleClassroomSection < OmniAuthSection
+  CODE_PREFIX = 'G-'.freeze
+
   def self.from_service(course_id, owner_id, student_list, section_name)
-    code = "G-#{course_id}"
+    code = "#{CODE_PREFIX}#{course_id}"
 
     set_family_name = DCDO.get('google_classroom_family_name', false)
 

--- a/dashboard/app/models/sections/omni_auth_section.rb
+++ b/dashboard/app/models/sections/omni_auth_section.rb
@@ -89,4 +89,8 @@ class OmniAuthSection < Section
   def provider_managed?
     true
   end
+
+  def self.code_for_section(section_id)
+    "#{self::CODE_PREFIX}#{section_id}"
+  end
 end

--- a/dashboard/test/controllers/api_controller_test.rb
+++ b/dashboard/test/controllers/api_controller_test.rb
@@ -1571,7 +1571,7 @@ class ApiControllerTest < ActionController::TestCase
 
   test 'import_google_classroom is Forbidden when section exists and current user is not an instructor' do
     mock_service = mock('Google::Apis::ClassroomV1::ClassroomService')
-    course_id = 'existing-google-course-id'
+    course_id = Random.hex(10)
 
     ApiController.any_instance.stubs(:query_google_classroom_service).yields(mock_service)
     mock_service.expects(:list_course_students).never

--- a/dashboard/test/controllers/api_controller_test.rb
+++ b/dashboard/test/controllers/api_controller_test.rb
@@ -1525,8 +1525,6 @@ class ApiControllerTest < ActionController::TestCase
 
   test 'import_google_classroom upgrades eligible teacher to verified' do
     mock_service = mock('Google::Apis::ClassroomV1::ClassroomService')
-    mock_teacher = mock('Google::Apis::ClassroomV1::Teacher')
-    mock_teachers_response = mock('Google::Apis::ClassroomV1::ListTeachersResponse')
     mock_students = Google::Apis::ClassroomV1::ListStudentsResponse.from_json(
       {
         students: (1..5).map do |i|
@@ -1546,20 +1544,16 @@ class ApiControllerTest < ActionController::TestCase
     mock_response = mock('Google::Apis::ClassroomV1::ListStudentsResponse')
     mock_response.stubs(:students).returns(mock_students)
     mock_response.stubs(:next_page_token).returns(nil)
-    mock_teachers_response.stubs(:teachers).returns([mock_teacher])
-    mock_teachers_response.stubs(:next_page_token).returns(nil)
 
     mock_section = mock('GoogleClassroomSection')
     mock_section.stubs(:summarize).returns({section_id: @section.id})
 
     ApiController.any_instance.stubs(:query_google_classroom_service).yields(mock_service)
-    mock_service.stubs(:list_course_teachers).returns(mock_teachers_response)
     mock_service.stubs(:list_course_students).returns(mock_response)
     GoogleClassroomSection.stubs(:from_service).returns(mock_section)
 
     teacher = create(:teacher, :with_google_authentication_option)
     google_auth_option = teacher.authentication_options.find_by(credential_type: AuthenticationOption::GOOGLE)
-    mock_teacher.stubs(:user_id).returns(google_auth_option.authentication_id)
     # change teacher email to @gmail.com, which will the teacher ineligible for verified
     google_auth_option.update(email: 'test@gmail.com')
     @controller.stubs(:current_user).returns(teacher)
@@ -1575,27 +1569,146 @@ class ApiControllerTest < ActionController::TestCase
     assert_equal true, teacher.verified_teacher?
   end
 
-  test 'import_google_classroom is Forbidden when current user is not a teacher in the Google course' do
+  test 'import_google_classroom is Forbidden when section exists and current user is not an instructor' do
     mock_service = mock('Google::Apis::ClassroomV1::ClassroomService')
-    mock_teacher = mock('Google::Apis::ClassroomV1::Teacher')
-    mock_teachers_response = mock('Google::Apis::ClassroomV1::ListTeachersResponse')
-
-    mock_teachers_response.stubs(:teachers).returns([mock_teacher])
-    mock_teachers_response.stubs(:next_page_token).returns(nil)
-    mock_teacher.stubs(:user_id).returns('different-google-user-id')
+    course_id = 'existing-google-course-id'
 
     ApiController.any_instance.stubs(:query_google_classroom_service).yields(mock_service)
-    mock_service.stubs(:list_course_teachers).returns(mock_teachers_response)
     mock_service.expects(:list_course_students).never
     GoogleClassroomSection.expects(:from_service).never
 
-    teacher = create(:teacher, :with_google_authentication_option)
-    section = create(:section, user: teacher)
-    sign_in teacher
+    section_owner = create(:teacher)
+    attacker = create(:teacher, :with_google_authentication_option)
+    create(
+      :section,
+      user: section_owner,
+      login_type: Section::LOGIN_TYPE_GOOGLE_CLASSROOM,
+      code: GoogleClassroomSection.code_for_section(course_id)
+    )
+    sign_in attacker
 
-    get :import_google_classroom, params: {courseId: section.course_id, courseName: section.name}
+    get :import_google_classroom, params: {courseId: course_id, courseName: 'Existing Section'}
 
     assert_response :forbidden
+  end
+
+  test 'import_google_classroom allows first import when section does not exist' do
+    mock_service = mock('Google::Apis::ClassroomV1::ClassroomService')
+    mock_students_response = mock('Google::Apis::ClassroomV1::ListStudentsResponse')
+    course_id = Random.hex(10)
+    course_name = 'New Google Section'
+    students = []
+    teacher = create(:teacher, :with_google_authentication_option)
+    imported_section = mock('GoogleClassroomSection')
+    imported_section.stubs(:summarize).returns({section_id: Random.hex(10)})
+
+    mock_students_response.stubs(:students).returns(students)
+    mock_students_response.stubs(:next_page_token).returns(nil)
+
+    ApiController.any_instance.stubs(:query_google_classroom_service).yields(mock_service)
+    mock_service.expects(:list_course_students).with(course_id, page_token: nil).returns(mock_students_response)
+    GoogleClassroomSection.expects(:from_service).with(course_id, teacher.id, students, course_name).returns(imported_section)
+    sign_in teacher
+
+    get :import_google_classroom, params: {courseId: course_id, courseName: course_name}
+
+    assert_response :ok
+  end
+
+  test 'import_google_classroom allows import when section exists and current user is an instructor' do
+    mock_service = mock('Google::Apis::ClassroomV1::ClassroomService')
+    mock_students_response = mock('Google::Apis::ClassroomV1::ListStudentsResponse')
+    course_id = Random.hex(10)
+    course_name = 'Existing Google Section'
+    students = []
+    section_owner = create(:teacher)
+    teacher = create(:teacher, :with_google_authentication_option)
+    imported_section = mock('GoogleClassroomSection')
+    imported_section.stubs(:summarize).returns({section_id: Random.hex(10)})
+
+    section = create(
+      :section,
+      user: section_owner,
+      login_type: Section::LOGIN_TYPE_GOOGLE_CLASSROOM,
+      code: GoogleClassroomSection.code_for_section(course_id)
+    )
+    create(:section_instructor, section:, instructor: teacher, status: :active)
+
+    mock_students_response.stubs(:students).returns(students)
+    mock_students_response.stubs(:next_page_token).returns(nil)
+
+    ApiController.any_instance.stubs(:query_google_classroom_service).yields(mock_service)
+    mock_service.expects(:list_course_students).with(course_id, page_token: nil).returns(mock_students_response)
+    GoogleClassroomSection.expects(:from_service).with(course_id, teacher.id, students, course_name).returns(imported_section)
+    sign_in teacher
+
+    get :import_google_classroom, params: {courseId: course_id, courseName: course_name}
+
+    assert_response :ok
+  end
+
+  test 'import_clever_classroom is Forbidden when section exists and current user is not an instructor' do
+    course_id = Random.hex(10)
+
+    ApiController.any_instance.stubs(:query_clever_service).yields([])
+    CleverSection.expects(:from_service).never
+
+    section_owner = create(:teacher)
+    attacker = create(:teacher, :with_clever_authentication_option)
+    create(
+      :section,
+      user: section_owner,
+      login_type: Section::LOGIN_TYPE_CLEVER,
+      code: CleverSection.code_for_section(course_id)
+    )
+    sign_in attacker
+
+    get :import_clever_classroom, params: {courseId: course_id, courseName: 'Existing Section'}
+
+    assert_response :forbidden
+  end
+
+  test 'import_clever_classroom allows first import when section does not exist' do
+    course_id = Random.hex(10)
+    course_name = 'New Clever Section'
+    students = []
+    teacher = create(:teacher, :with_clever_authentication_option)
+    imported_section = mock('CleverSection')
+    imported_section.stubs(:summarize).returns({section_id: Random.hex(10)})
+
+    ApiController.any_instance.stubs(:query_clever_service).yields(students)
+    CleverSection.expects(:from_service).with(course_id, teacher.id, students, course_name).returns(imported_section)
+    sign_in teacher
+
+    get :import_clever_classroom, params: {courseId: course_id, courseName: course_name}
+
+    assert_response :ok
+  end
+
+  test 'import_clever_classroom allows import when section exists and current user is an instructor' do
+    course_id = 'existing-clever-course-id-2'
+    course_name = 'Existing Clever Section'
+    students = []
+    section_owner = create(:teacher)
+    teacher = create(:teacher, :with_clever_authentication_option)
+    imported_section = mock('CleverSection')
+    imported_section.stubs(:summarize).returns({section_id: Random.hex(10)})
+
+    section = create(
+      :section,
+      user: section_owner,
+      login_type: Section::LOGIN_TYPE_CLEVER,
+      code: CleverSection.code_for_section(course_id)
+    )
+    create(:section_instructor, section:, instructor: teacher, status: :active)
+
+    ApiController.any_instance.stubs(:query_clever_service).yields(students)
+    CleverSection.expects(:from_service).with(course_id, teacher.id, students, course_name).returns(imported_section)
+    sign_in teacher
+
+    get :import_clever_classroom, params: {courseId: course_id, courseName: course_name}
+
+    assert_response :ok
   end
 
   #

--- a/dashboard/test/controllers/api_controller_test.rb
+++ b/dashboard/test/controllers/api_controller_test.rb
@@ -1525,6 +1525,8 @@ class ApiControllerTest < ActionController::TestCase
 
   test 'import_google_classroom upgrades eligible teacher to verified' do
     mock_service = mock('Google::Apis::ClassroomV1::ClassroomService')
+    mock_teacher = mock('Google::Apis::ClassroomV1::Teacher')
+    mock_teachers_response = mock('Google::Apis::ClassroomV1::ListTeachersResponse')
     mock_students = Google::Apis::ClassroomV1::ListStudentsResponse.from_json(
       {
         students: (1..5).map do |i|
@@ -1544,17 +1546,22 @@ class ApiControllerTest < ActionController::TestCase
     mock_response = mock('Google::Apis::ClassroomV1::ListStudentsResponse')
     mock_response.stubs(:students).returns(mock_students)
     mock_response.stubs(:next_page_token).returns(nil)
+    mock_teachers_response.stubs(:teachers).returns([mock_teacher])
+    mock_teachers_response.stubs(:next_page_token).returns(nil)
 
     mock_section = mock('GoogleClassroomSection')
     mock_section.stubs(:summarize).returns({section_id: @section.id})
 
     ApiController.any_instance.stubs(:query_google_classroom_service).yields(mock_service)
+    mock_service.stubs(:list_course_teachers).returns(mock_teachers_response)
     mock_service.stubs(:list_course_students).returns(mock_response)
-    GoogleClassroomSection.any_instance.stubs(:from_service).returns(mock_section)
+    GoogleClassroomSection.stubs(:from_service).returns(mock_section)
 
     teacher = create(:teacher, :with_google_authentication_option)
+    google_auth_option = teacher.authentication_options.find_by(credential_type: AuthenticationOption::GOOGLE)
+    mock_teacher.stubs(:user_id).returns(google_auth_option.authentication_id)
     # change teacher email to @gmail.com, which will the teacher ineligible for verified
-    teacher.authentication_options.find_by(credential_type: AuthenticationOption::GOOGLE).update(email: 'test@gmail.com')
+    google_auth_option.update(email: 'test@gmail.com')
     @controller.stubs(:current_user).returns(teacher)
     section = create(:section, user: teacher)
     assert_equal false, teacher.verified_teacher?
@@ -1563,9 +1570,32 @@ class ApiControllerTest < ActionController::TestCase
     assert_response :ok
     assert_equal false, teacher.verified_teacher?
     # change email to non google/gmail email, teacher should now be eligible for verified
-    teacher.authentication_options.find_by(credential_type: AuthenticationOption::GOOGLE).update(email: 'test@test.com')
+    google_auth_option.update(email: 'test@test.com')
     get :import_google_classroom, params: {courseId: section.course_id, courseName: section.name}
     assert_equal true, teacher.verified_teacher?
+  end
+
+  test 'import_google_classroom is Forbidden when current user is not a teacher in the Google course' do
+    mock_service = mock('Google::Apis::ClassroomV1::ClassroomService')
+    mock_teacher = mock('Google::Apis::ClassroomV1::Teacher')
+    mock_teachers_response = mock('Google::Apis::ClassroomV1::ListTeachersResponse')
+
+    mock_teachers_response.stubs(:teachers).returns([mock_teacher])
+    mock_teachers_response.stubs(:next_page_token).returns(nil)
+    mock_teacher.stubs(:user_id).returns('different-google-user-id')
+
+    ApiController.any_instance.stubs(:query_google_classroom_service).yields(mock_service)
+    mock_service.stubs(:list_course_teachers).returns(mock_teachers_response)
+    mock_service.expects(:list_course_students).never
+    GoogleClassroomSection.expects(:from_service).never
+
+    teacher = create(:teacher, :with_google_authentication_option)
+    section = create(:section, user: teacher)
+    sign_in teacher
+
+    get :import_google_classroom, params: {courseId: section.course_id, courseName: section.name}
+
+    assert_response :forbidden
   end
 
   #


### PR DESCRIPTION
This PR fixes a bug ([Jira link](https://codedotorg.atlassian.net/browse/BC-92)) where a malicious user could elevate their role to co-teacher in roster synced section.

It implements new logic that only allows roster sync APIs (Clever and Google Classroom) to be invoked by users who are `section_instructors`.

## Links
<!-- Jira tickets, design docs, Slack threads, related PRs, etc. -->

- Platform Jira: https://codedotorg.atlassian.net/browse/P20-1810
- Infra Jira: https://codedotorg.atlassian.net/browse/INF-2051
- Bugcrowd Jira: https://codedotorg.atlassian.net/browse/BC-92

## Testing story
<!-- How was this tested? Manual steps, adhoc links, automated tests, or why testing isn't needed. -->



## Deployment notes
<!-- Delete this section if it's a standard merge-and-deploy.
     Otherwise: migrations, feature flags, coordination, caching impacts, etc. -->



## Privacy and security
<!-- Delete this section if there is no privacy/security impact.
     Otherwise: new PII, auth changes, API surface changes, etc. -->

