### PR TITLE
Rotate Cookies to Use New Rails 7 Config

### DIFF
--- a/dashboard/config/initializers/cookie_rotator.rb
+++ b/dashboard/config/initializers/cookie_rotator.rb
@@ -1,0 +1,20 @@
+# Temporary cookie rotator to facilitate updating the digest class for key
+# generators from SHA1 (the Rails 6.1 default) to SHA256 (the Rails 7.0
+# default). Will read cookies from either the new or the old format, while
+# consistently writing out to the new format.
+#
+# TODO infra: remove this after 40 days in production (as determined by
+# CDO.dashboard_session_ttl_days)
+#
+# Based on instructions at
+# https://guides.rubyonrails.org/v7.0/upgrading_ruby_on_rails.html#key-generator-digest-class-changing-to-use-sha256
+# and
+# https://guides.rubyonrails.org/v7.0/security.html#rotating-encrypted-and-signed-cookies-configurations
+#
+# See dashboard/config/initializers/new_framework_defaults_7_0.rb for more context
+Rails.application.config.after_initialize do
+  Rails.application.config.action_dispatch.cookies_rotations.tap do |cookies|
+    cookies.rotate :encrypted, digest: OpenSSL::Digest::SHA1
+    cookies.rotate :signed, digest: OpenSSL::Digest::SHA1
+  end
+end

--- a/dashboard/config/initializers/new_framework_defaults_7_0.rb
+++ b/dashboard/config/initializers/new_framework_defaults_7_0.rb
@@ -23,7 +23,7 @@
 #
 # See upgrading guide for more information on how to build a rotator.
 # https://guides.rubyonrails.org/v7.0/upgrading_ruby_on_rails.html
-# Rails.application.config.active_support.key_generator_hash_digest_class = OpenSSL::Digest::SHA256
+Rails.application.config.active_support.key_generator_hash_digest_class = OpenSSL::Digest::SHA256
 
 # Change the digest class for ActiveSupport::Digest.
 # Changing this default means that for example Etags change and


### PR DESCRIPTION
Rails 7 updates the digest class used by the key generator from SHA1 to SHA256, and we'd like to follow suit. To ensure we don't invalidate any existing cookies in the process, we put in place a simple cookie rotator.

## Links

See https://guides.rubyonrails.org/v7.0/upgrading_ruby_on_rails.html#key-generator-digest-class-changing-to-use-sha256 for more context

Follow-up to https://github.com/code-dot-org/code-dot-org/pull/67318

## Testing story

Verified on an adhoc. Specifically, I spun up an adhoc based on staging latest and created a code studio account on it. I then merged this branch into that one, and verified that I remained signed in on that account after the server built and restarted.