### PR TITLE
DB migration for JIT PL tables

### DIFF
--- a/dashboard/app/models/jit_pl_concept.rb
+++ b/dashboard/app/models/jit_pl_concept.rb
@@ -1,0 +1,13 @@
+# == Schema Information
+#
+# Table name: jit_pl_concepts
+#
+#  id           :bigint           not null, primary key
+#  name         :string(255)
+#  display_name :string(255)
+#  properties   :text(65535)
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#
+class JitPlConcept < ApplicationRecord
+end

--- a/dashboard/app/models/jit_pl_concept.rb
+++ b/dashboard/app/models/jit_pl_concept.rb
@@ -14,8 +14,8 @@ class JitPlConcept < ApplicationRecord
 
   has_many :jit_pl_exemplars, dependent: :destroy
   has_many :jit_pl_misconceptions, dependent: :destroy
-  has_and_belongs_to_many :lessons, join_table: :jit_pl_concepts_resources
-  has_and_belongs_to_many :resources, join_table: :jit_pl_concepts_lessons
+  has_and_belongs_to_many :resources, join_table: :jit_pl_concepts_resources
+  has_and_belongs_to_many :lessons, join_table: :jit_pl_concepts_lessons
   has_and_belongs_to_many :rubrics, join_table: :jit_pl_concepts_rubrics
 
   serialized_attrs %w(

--- a/dashboard/app/models/jit_pl_concept.rb
+++ b/dashboard/app/models/jit_pl_concept.rb
@@ -10,4 +10,15 @@
 #  updated_at   :datetime         not null
 #
 class JitPlConcept < ApplicationRecord
+  include SerializedProperties
+
+  has_many :jit_pl_exemplars, dependent: :destroy
+  has_many :jit_pl_misconceptions, dependent: :destroy
+  has_and_belongs_to_many :lessons, join_table: :jit_pl_concepts_resources
+  has_and_belongs_to_many :resources, join_table: :jit_pl_concepts_lessons
+  has_and_belongs_to_many :rubrics, join_table: :jit_pl_concepts_rubrics
+
+  serialized_attrs %w(
+    text_content
+  )
 end

--- a/dashboard/app/models/jit_pl_exemplar.rb
+++ b/dashboard/app/models/jit_pl_exemplar.rb
@@ -1,0 +1,19 @@
+# == Schema Information
+#
+# Table name: jit_pl_exemplars
+#
+#  id                      :bigint           not null, primary key
+#  name                    :string(255)
+#  properties              :text(65535)
+#  jit_pl_concept_id       :bigint
+#  jit_pl_misconception_id :bigint
+#  created_at              :datetime         not null
+#  updated_at              :datetime         not null
+#
+# Indexes
+#
+#  index_jit_pl_exemplars_on_jit_pl_concept_id        (jit_pl_concept_id)
+#  index_jit_pl_exemplars_on_jit_pl_misconception_id  (jit_pl_misconception_id)
+#
+class JitPlExemplar < ApplicationRecord
+end

--- a/dashboard/app/models/jit_pl_exemplar.rb
+++ b/dashboard/app/models/jit_pl_exemplar.rb
@@ -16,4 +16,15 @@
 #  index_jit_pl_exemplars_on_jit_pl_misconception_id  (jit_pl_misconception_id)
 #
 class JitPlExemplar < ApplicationRecord
+  include SerializedProperties
+
+  belongs_to :jit_pl_concept
+  belongs_to :jit_pl_misconception
+  has_and_belongs_to_many :resources, join_table: :jit_pl_exemplars_resources
+
+  serialized_attrs %w(
+    code_content
+    text_content
+    exemplar_type
+  )
 end

--- a/dashboard/app/models/jit_pl_misconception.rb
+++ b/dashboard/app/models/jit_pl_misconception.rb
@@ -1,0 +1,18 @@
+# == Schema Information
+#
+# Table name: jit_pl_misconceptions
+#
+#  id                :bigint           not null, primary key
+#  name              :string(255)
+#  ai_context        :json
+#  properties        :text(65535)
+#  jit_pl_concept_id :bigint           not null
+#  created_at        :datetime         not null
+#  updated_at        :datetime         not null
+#
+# Indexes
+#
+#  index_jit_pl_misconceptions_on_jit_pl_concept_id  (jit_pl_concept_id)
+#
+class JitPlMisconception < ApplicationRecord
+end

--- a/dashboard/app/models/jit_pl_misconception.rb
+++ b/dashboard/app/models/jit_pl_misconception.rb
@@ -15,4 +15,13 @@
 #  index_jit_pl_misconceptions_on_jit_pl_concept_id  (jit_pl_concept_id)
 #
 class JitPlMisconception < ApplicationRecord
+  include SerializedProperties
+
+  belongs_to :jit_pl_concept
+  has_many :jit_pl_exemplars, dependent: :destroy
+  has_and_belongs_to_many :resources, join_table: :jit_pl_misconceptions_resources
+
+  serialized_attrs %w(
+    text_content
+  )
 end

--- a/dashboard/app/models/lesson.rb
+++ b/dashboard/app/models/lesson.rb
@@ -40,6 +40,7 @@ class Lesson < ApplicationRecord
   has_and_belongs_to_many :resources, join_table: :lessons_resources
   has_and_belongs_to_many :vocabularies, join_table: :lessons_vocabularies
   has_and_belongs_to_many :programming_expressions, join_table: :lessons_programming_expressions
+  has_and_belongs_to_many :jit_pl_concepts, join_table: :jit_pl_concepts_resources
   has_many :objectives, dependent: :destroy
 
   # join tables needed for seeding logic

--- a/dashboard/app/models/lesson.rb
+++ b/dashboard/app/models/lesson.rb
@@ -40,7 +40,7 @@ class Lesson < ApplicationRecord
   has_and_belongs_to_many :resources, join_table: :lessons_resources
   has_and_belongs_to_many :vocabularies, join_table: :lessons_vocabularies
   has_and_belongs_to_many :programming_expressions, join_table: :lessons_programming_expressions
-  has_and_belongs_to_many :jit_pl_concepts, join_table: :jit_pl_concepts_resources
+  has_and_belongs_to_many :jit_pl_concepts, join_table: :jit_pl_concepts_lessons
   has_many :objectives, dependent: :destroy
 
   # join tables needed for seeding logic

--- a/dashboard/app/models/resource.rb
+++ b/dashboard/app/models/resource.rb
@@ -41,6 +41,9 @@ class Resource < ApplicationRecord
   has_and_belongs_to_many :lessons, join_table: :lessons_resources
   has_and_belongs_to_many :scripts, class_name: 'Unit', join_table: :scripts_resources, association_foreign_key: 'script_id'
   has_and_belongs_to_many :unit_groups, join_table: :unit_groups_resources
+  has_and_belongs_to_many :jit_pl_concepts, join_table: :jit_pl_concepts_lessons
+  has_and_belongs_to_many :jit_pl_exemplars, join_table: :jit_pl_exemplars_resources
+  has_and_belongs_to_many :jit_pl_misconceptions, join_table: :jit_pl_misconceptions_resources
   belongs_to :course_version, optional: true
 
   before_validation :generate_key, on: :create

--- a/dashboard/app/models/resource.rb
+++ b/dashboard/app/models/resource.rb
@@ -41,7 +41,7 @@ class Resource < ApplicationRecord
   has_and_belongs_to_many :lessons, join_table: :lessons_resources
   has_and_belongs_to_many :scripts, class_name: 'Unit', join_table: :scripts_resources, association_foreign_key: 'script_id'
   has_and_belongs_to_many :unit_groups, join_table: :unit_groups_resources
-  has_and_belongs_to_many :jit_pl_concepts, join_table: :jit_pl_concepts_lessons
+  has_and_belongs_to_many :jit_pl_concepts, join_table: :jit_pl_concepts_resources
   has_and_belongs_to_many :jit_pl_exemplars, join_table: :jit_pl_exemplars_resources
   has_and_belongs_to_many :jit_pl_misconceptions, join_table: :jit_pl_misconceptions_resources
   belongs_to :course_version, optional: true

--- a/dashboard/app/models/rubric.rb
+++ b/dashboard/app/models/rubric.rb
@@ -16,6 +16,7 @@ class Rubric < ApplicationRecord
   has_many :learning_goals, -> {order(:position)}, dependent: :destroy, inverse_of: :rubric
   belongs_to :level
   belongs_to :lesson
+  has_and_belongs_to_many :jit_pl_concepts, join_table: :jit_pl_concepts_rubrics
 
   def get_script_level
     lesson.script_levels.find {|sl| sl.levels.include?(level)}

--- a/dashboard/db/migrate/20260226192420_add_jit_pl_tables.rb
+++ b/dashboard/db/migrate/20260226192420_add_jit_pl_tables.rb
@@ -1,0 +1,62 @@
+class AddJitPlTables < ActiveRecord::Migration[7.0]
+  def change
+    # Represents a teaching concept for just-in-time PL
+    create_table :jit_pl_concepts do |t|
+      t.string :name
+      t.string :display_name
+      t.text :properties
+
+      t.timestamps
+    end
+
+    # Resources can be created for each concept, containing video/doc links
+    create_join_table :jit_pl_concepts, :resources do |t|
+      t.index [:jit_pl_concept_id, :resource_id], unique: true, name: 'index_concepts_resources_on_concept_id_and_resource_id'
+      t.index [:resource_id, :jit_pl_concept_id], unique: true, name: 'index_concepts_resources_on_resource_id_and_concept_id'
+    end
+
+    # Concepts will be linked to lessons in a many-to-many relationship
+    create_join_table :jit_pl_concepts, :lessons do |t|
+      t.index [:jit_pl_concept_id, :lesson_id], unique: true
+      t.index [:lesson_id, :jit_pl_concept_id], unique: true
+    end
+
+    # Concepts will also be linked to rubrics in a many-to-many relationship
+    create_join_table :jit_pl_concepts, :rubrics do |t|
+      t.index [:jit_pl_concept_id, :rubric_id], unique: true
+      t.index [:rubric_id, :jit_pl_concept_id], unique: true
+    end
+
+    # A concept can contain many common misconceptions to be debunked
+    create_table :jit_pl_misconceptions do |t|
+      t.string :name
+      t.json :ai_context
+      t.text :properties
+
+      t.references :jit_pl_concept, null: false, foreign_key: true, type: :bigint
+      t.timestamps
+    end
+
+    # Misconceptions can have video/doc resources attached
+    create_join_table :jit_pl_misconceptions, :resources do |t|
+      t.index [:jit_pl_misconception_id, :resource_id], unique: true, name: 'index_misconceptions_resources_on_misconception_and_resource_ids'
+      t.index [:resource_id, :jit_pl_misconception_id], unique: true, name: 'index_misconceptions_resources_on_resource_and_misconception_ids'
+    end
+
+    # Exemplars can be created to explain either a concept or misconception
+    create_table :jit_pl_exemplars do |t|
+      t.string :name
+      t.text :properties
+
+      t.references :jit_pl_concept, null: true, foreign_key: true, type: :bigint
+      t.references :jit_pl_misconception, null: true, foreign_key: true, type: :bigint
+      t.timestamps
+    end
+
+    # Exemplars can have video/doc resources attached
+    create_join_table :jit_pl_exemplars, :resources do |t|
+      t.index [:jit_pl_exemplar_id, :resource_id], unique: true, name: 'index_exemplars_resources_on_exemplar_id_and_resource_id'
+      t.index [:resource_id, :jit_pl_exemplar_id], unique: true, name: 'index_exemplars_resources_on_resource_id_and_exemplar_id'
+    end
+  end
+end

--- a/dashboard/db/schema.rb
+++ b/dashboard/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2026_02_11_145245) do
+ActiveRecord::Schema[7.0].define(version: 2026_02_26_192420) do
   create_table "activities", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "user_id"
     t.integer "level_id"
@@ -836,6 +836,70 @@ ActiveRecord::Schema[7.0].define(version: 2026_02_11_145245) do
     t.datetime "updated_at", precision: nil, null: false
     t.index ["script_id", "level_id"], name: "index_hint_view_requests_on_script_id_and_level_id"
     t.index ["user_id"], name: "index_hint_view_requests_on_user_id"
+  end
+
+  create_table "jit_pl_concepts", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+    t.string "name"
+    t.string "display_name"
+    t.text "properties"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "jit_pl_concepts_lessons", id: false, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+    t.bigint "jit_pl_concept_id", null: false
+    t.bigint "lesson_id", null: false
+    t.index ["jit_pl_concept_id", "lesson_id"], name: "index_jit_pl_concepts_lessons_on_jit_pl_concept_id_and_lesson_id", unique: true
+    t.index ["lesson_id", "jit_pl_concept_id"], name: "index_jit_pl_concepts_lessons_on_lesson_id_and_jit_pl_concept_id", unique: true
+  end
+
+  create_table "jit_pl_concepts_resources", id: false, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+    t.bigint "jit_pl_concept_id", null: false
+    t.bigint "resource_id", null: false
+    t.index ["jit_pl_concept_id", "resource_id"], name: "index_concepts_resources_on_concept_id_and_resource_id", unique: true
+    t.index ["resource_id", "jit_pl_concept_id"], name: "index_concepts_resources_on_resource_id_and_concept_id", unique: true
+  end
+
+  create_table "jit_pl_concepts_rubrics", id: false, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+    t.bigint "jit_pl_concept_id", null: false
+    t.bigint "rubric_id", null: false
+    t.index ["jit_pl_concept_id", "rubric_id"], name: "index_jit_pl_concepts_rubrics_on_jit_pl_concept_id_and_rubric_id", unique: true
+    t.index ["rubric_id", "jit_pl_concept_id"], name: "index_jit_pl_concepts_rubrics_on_rubric_id_and_jit_pl_concept_id", unique: true
+  end
+
+  create_table "jit_pl_exemplars", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+    t.string "name"
+    t.text "properties"
+    t.bigint "jit_pl_concept_id"
+    t.bigint "jit_pl_misconception_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["jit_pl_concept_id"], name: "index_jit_pl_exemplars_on_jit_pl_concept_id"
+    t.index ["jit_pl_misconception_id"], name: "index_jit_pl_exemplars_on_jit_pl_misconception_id"
+  end
+
+  create_table "jit_pl_exemplars_resources", id: false, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+    t.bigint "jit_pl_exemplar_id", null: false
+    t.bigint "resource_id", null: false
+    t.index ["jit_pl_exemplar_id", "resource_id"], name: "index_exemplars_resources_on_exemplar_id_and_resource_id", unique: true
+    t.index ["resource_id", "jit_pl_exemplar_id"], name: "index_exemplars_resources_on_resource_id_and_exemplar_id", unique: true
+  end
+
+  create_table "jit_pl_misconceptions", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+    t.string "name"
+    t.json "ai_context"
+    t.text "properties"
+    t.bigint "jit_pl_concept_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["jit_pl_concept_id"], name: "index_jit_pl_misconceptions_on_jit_pl_concept_id"
+  end
+
+  create_table "jit_pl_misconceptions_resources", id: false, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+    t.bigint "jit_pl_misconception_id", null: false
+    t.bigint "resource_id", null: false
+    t.index ["jit_pl_misconception_id", "resource_id"], name: "index_misconceptions_resources_on_misconception_and_resource_ids", unique: true
+    t.index ["resource_id", "jit_pl_misconception_id"], name: "index_misconceptions_resources_on_resource_and_misconception_ids", unique: true
   end
 
   create_table "learning_goal_ai_evaluation_feedbacks", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
@@ -2730,6 +2794,9 @@ ActiveRecord::Schema[7.0].define(version: 2026_02_11_145245) do
   add_foreign_key "census_summaries", "schools"
   add_foreign_key "external_notifications", "users"
   add_foreign_key "hint_view_requests", "users"
+  add_foreign_key "jit_pl_exemplars", "jit_pl_concepts"
+  add_foreign_key "jit_pl_exemplars", "jit_pl_misconceptions"
+  add_foreign_key "jit_pl_misconceptions", "jit_pl_concepts"
   add_foreign_key "learning_goal_ai_evaluations", "learning_goals"
   add_foreign_key "learning_goal_ai_evaluations", "rubric_ai_evaluations"
   add_foreign_key "level_concept_difficulties", "levels"


### PR DESCRIPTION
This change adds necessary data tables for the just-in-time PL effort, plus skeletons of ActiveRecord models that describe the associations between these tables.

For Google Drive/video content to be attached to these objects I propose reusing the existing `Resource` model we have built for attaching these types of content to other curriculum objects. This will simplify the effort to add support for these JIT PL objects to levelbuilder, AI TA knowledge base embedding, etc.

<!--
  Summary of the change: background, motivation, and context.
  Include screenshots, videos, or before/after comparisons for UI changes.
-->



## Links
[Data model spec](https://docs.google.com/document/d/1ujBIOA3juQyZVvHGPINYSlW4a8qRBMrILPBuBFL67Fc/edit?pli=1&tab=t.0)

## Testing story
<!-- How was this tested? Manual steps, adhoc links, automated tests, or why testing isn't needed. -->



## Deployment notes
<!-- Delete this section if it's a standard merge-and-deploy.
     Otherwise: migrations, feature flags, coordination, caching impacts, etc. -->



## Privacy and security
<!-- Delete this section if there is no privacy/security impact.
     Otherwise: new PII, auth changes, API surface changes, etc. -->

