### PR TITLE
[Video Player] Removing deprecated scrolling attribute

### DIFF
--- a/apps/src/code-studio/videos.js
+++ b/apps/src/code-studio/videos.js
@@ -102,7 +102,6 @@ function createVideo(options) {
   const videoDiv = $('<iframe id="video"/>').addClass('video-player').attr({
     src: options.src,
     allowfullscreen: 'true',
-    scrolling: 'no',
   });
 
   const videoTabContainerDiv = $("<div id='videoTabContainer'></div>").append(


### PR DESCRIPTION
Our VPAT says this role is outdated and should be removed. Easy enough!

<img width="861" height="201" alt="Screenshot 2026-03-03 at 4 50 00 PM" src="https://github.com/user-attachments/assets/46e55c2e-ed36-4a1f-80c4-090c8370d318" />

Before:
<img width="1631" height="757" alt="Screenshot 2026-03-03 at 4 51 06 PM" src="https://github.com/user-attachments/assets/8d36ecb2-5939-49d2-9b51-cfc8d79c716d" />

After:
<img width="1194" height="771" alt="Screenshot 2026-03-03 at 4 51 47 PM" src="https://github.com/user-attachments/assets/af47f1cc-412a-4a83-abeb-2dc4ad92c422" />



## Links

- Jira: https://codedotorg.atlassian.net/browse/SL-1612
- VPAT: https://app.getstark.co/organization/ced5459c-437e-48a0-8737-90ad0ef005c0/projects/aiOk8eUknKEfWPEE3SIO/assets/5bAQbcRUbbfgXK1uQydr/reports/CqhN8GGQ8oByoEkjrLvu

## Testing story
<!-- How was this tested? Manual steps, adhoc links, automated tests, or why testing isn't needed. -->



## Deployment notes
<!-- Delete this section if it's a standard merge-and-deploy.
     Otherwise: migrations, feature flags, coordination, caching impacts, etc. -->



## Privacy and security
<!-- Delete this section if there is no privacy/security impact.
     Otherwise: new PII, auth changes, API surface changes, etc. -->

