### PR TITLE
feat(ci): enable studio via existing ci pipeline

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -89,9 +89,6 @@ group :development do
   # We only use it in development atm to get a feel for it, and the benefit is greatest here.
   gem 'bootsnap', '>= 1.14.0', require: false
   gem 'localhost'
-
-  # This gem is installed in development only for now while the node version in deployed environments is upgraded.
-  gem "vite_rails", "~> 3.0"
 end
 
 # Rack::Cache middleware used in development/test;
@@ -435,3 +432,6 @@ gem 'openssl', '>= 3.3.1'
 
 # Used for Clever Client
 gem 'typhoeus', '~> 1.0', '>= 1.0.1'
+
+# Used for Vite integration, only available in development and adhoc at this time.
+gem "vite_rails", "~> 3.0", group: [:development, :adhoc]

--- a/Gemfile
+++ b/Gemfile
@@ -434,4 +434,4 @@ gem 'openssl', '>= 3.3.1'
 gem 'typhoeus', '~> 1.0', '>= 1.0.1'
 
 # Used for Vite integration, only available in development and adhoc at this time.
-gem "vite_rails", "~> 3.0", group: [:development, :adhoc]
+gem "vite_rails", "~> 3.0", group: [:development, :adhoc, :staging, :test]

--- a/config.yml.erb
+++ b/config.yml.erb
@@ -386,9 +386,16 @@ custom_error_response: true
 # Whether rake:build should rebuild the apps package
 build_apps: false
 
+# Whether rake:build should rebuild the studio package
+build_studio: false
+
 # Whether dashboard should use your local build of the apps package.
 # If false, dashboard will try to use a prepackaged version from S3.
 use_my_apps:
+
+# Whether dashboard should use your local build of the studio package.
+# If false, dashboard will try to use a prepackaged version from S3.
+use_my_studio:
 
 optimize_webpack_assets: true
 

--- a/config/test.yml.erb
+++ b/config/test.yml.erb
@@ -114,6 +114,7 @@ use_geolocation_override: true
 
 # customize build steps in CI
 build_apps: true
+build_studio: true
 use_my_apps: true
 skip_seed_all: true
 

--- a/config/test.yml.erb
+++ b/config/test.yml.erb
@@ -116,6 +116,7 @@ use_geolocation_override: true
 build_apps: true
 build_studio: true
 use_my_apps: true
+use_my_studio: true
 skip_seed_all: true
 
 # Pass in secrets via env vars, since Drone cannot access secrets directly.

--- a/dashboard/.gitignore
+++ b/dashboard/.gitignore
@@ -21,6 +21,8 @@
 
 /public/code-studio-package
 /public/apps-package
+/public/studio-package
+/public/frontend-studio
 
 # Vite Ruby
 /public/vite*

--- a/dashboard/app/controllers/app_controller.rb
+++ b/dashboard/app/controllers/app_controller.rb
@@ -1,7 +1,7 @@
 class AppController < ApplicationController
   def index
     # Only render the app in development mode while the frontend is being built.
-    return head :not_found unless Rails.env.development?
+    return head :not_found if Rails.env.production?
 
     render 'app/index', layout: false
   end

--- a/dashboard/app/controllers/app_controller.rb
+++ b/dashboard/app/controllers/app_controller.rb
@@ -1,6 +1,6 @@
 class AppController < ApplicationController
   def index
-    # Only render the app in development mode while the frontend is being built.
+    # Only render the app in preprod while the frontend is being built.
     return head :not_found if Rails.env.production?
 
     render 'app/index', layout: false

--- a/dashboard/config/routes.rb
+++ b/dashboard/config/routes.rb
@@ -7,7 +7,7 @@ Dashboard::Application.routes.draw do
   draw :api
   draw :marketing
 
-  get "app", to: "app#index"
+  get "app(/*path)", to: "app#index"
 
   # Override Error Codes
   get "404", to: "application#render_404", via: :all

--- a/frontend/apps/studio/.gitignore
+++ b/frontend/apps/studio/.gitignore
@@ -23,5 +23,5 @@ dist-ssr
 *.sln
 *.sw?
 
-/public/vite*
+/public/frontend-studio
 tmp

--- a/frontend/apps/studio/config/vite.json
+++ b/frontend/apps/studio/config/vite.json
@@ -3,6 +3,7 @@
     "sourceCodeDir": ".",
     "root": ".",
     "watchAdditionalPaths": [],
+    "autoBuild": false,
     "publicDir": "dist",
     "publicOutputDir": "frontend-studio"
   },

--- a/frontend/apps/studio/config/vite.json
+++ b/frontend/apps/studio/config/vite.json
@@ -2,12 +2,13 @@
   "all": {
     "sourceCodeDir": ".",
     "root": ".",
-    "watchAdditionalPaths": []
+    "watchAdditionalPaths": [],
+    "publicDir": "dist",
+    "publicOutputDir": "frontend-studio"
   },
   "development": {
     "host": "0.0.0.0",
     "autoBuild": true,
-    "publicOutputDir": "app",
     "port": 3036
   }
 }

--- a/frontend/apps/studio/vite.config.ts
+++ b/frontend/apps/studio/vite.config.ts
@@ -4,11 +4,16 @@ import ViteRails from 'vite-plugin-rails';
 import path from 'node:path';
 import {tanstackRouter} from '@tanstack/router-plugin/vite';
 
+const workspaceRoot = searchForWorkspaceRoot(process.cwd());
+
 // https://vite.dev/config/
 export default defineConfig(({mode}) => {
   const isDev = mode === 'development';
 
   return {
+    build: {
+      outDir: 'dist',
+    },
     server: {
       allowedHosts: isDev ? ['localhost-studio.code.org'] : undefined,
       fs: {
@@ -19,6 +24,8 @@ export default defineConfig(({mode}) => {
     resolve: {
       alias: {
         '@': path.resolve(__dirname, './src'),
+        react: path.resolve(workspaceRoot, 'node_modules/react'),
+        'react-dom': path.resolve(workspaceRoot, 'node_modules/react-dom'),
       },
     },
     plugins: [

--- a/lib/cdo/aws/turbo_s3_packaging.rb
+++ b/lib/cdo/aws/turbo_s3_packaging.rb
@@ -1,0 +1,38 @@
+require_relative 's3_packaging'
+require 'json'
+
+# Subclass of S3Packaging that derives the commit hash from Turborepo's
+# task graph rather than from a git tree hash. This allows skipping
+# builds when an S3 package already exists for the same turbo-computed
+# inputs hash.
+#
+# @param package_name [String] Friendly name, used as part of the S3 key.
+# @param application_location [String] Filesystem path to the app root.
+# @param target_location [String] Filesystem path where the decompressed
+#   package should live (e.g. dashboard/public/studio-package).
+# @param frontend_dir [String] Path to the frontend/ workspace root where
+#   the `yarn turbo` command is executed.
+# @param turbo_filter [String] Turbo package filter, e.g. '@code-dot-org/studio'.
+#   The task hash is read from the '<filter>#build' task in the dry-run output.
+class TurboS3Packaging < S3Packaging
+  def initialize(package_name, application_location, target_location, frontend_dir, turbo_filter)
+    @frontend_dir = frontend_dir
+    @turbo_filter = turbo_filter
+    # source_locations is unused — hash comes from Turborepo, not git.
+    super(package_name, application_location, [], target_location)
+  end
+
+  # Computes @commit_hash by running a Turborepo dry-run and extracting
+  # the hash for the '<turbo_filter>#build' task. Called once during
+  # initialize and again inside create_package to detect mid-build changes.
+  def regenerate_commit_hash
+    Dir.chdir(@frontend_dir) do
+      output = `yarn turbo build --filter #{@turbo_filter} --dry-run=json 2>/dev/null`
+      data = JSON.parse(output)
+      task_id = "#{@turbo_filter}#build"
+      task = data['tasks']&.find {|t| t['taskId'] == task_id}
+      raise "Could not determine turbo hash for #{task_id}" unless task
+      @commit_hash = task['hash']
+    end
+  end
+end

--- a/lib/rake/build.rake
+++ b/lib/rake/build.rake
@@ -42,6 +42,17 @@ namespace :build do
     end
   end
 
+  desc 'Builds new Code Studio App (vite).'
+  timed_task_with_logging :studio do
+    Dir.chdir(frontend_dir) do
+      ChatClient.log 'Installing <b>studio</b> dependencies...'
+      RakeUtils.yarn_install
+
+      ChatClient.log 'Building <b>studio</b>...'
+      RakeUtils.system 'yarn build --filter @code-dot-org/studio'
+    end
+  end
+
   desc 'Builds dashboard (install gems, migrate/seed db, compile assets).'
   timed_task_with_logging dashboard: :package do
     Dir.chdir(dashboard_dir) do

--- a/lib/rake/build.rake
+++ b/lib/rake/build.rake
@@ -223,6 +223,7 @@ namespace :build do
 
   tasks = []
   tasks << :apps if CDO.build_apps
+  tasks << :studio if CDO.build_studio
   tasks << :dashboard if CDO.build_dashboard
   tasks << :pegasus if CDO.build_pegasus
   tasks << :i18n if CDO.build_i18n

--- a/lib/rake/package.rake
+++ b/lib/rake/package.rake
@@ -115,7 +115,7 @@ namespace :package do
 
     desc 'Update Dashboard symlink for studio package.'
     timed_task_with_logging 'symlink' do
-      target = CDO.use_my_studio ? vite_dir('dist', 'frontend-studio') : dashboard_dir('public', 'frontend-studio')
+      target = CDO.use_my_studio ? vite_dir('dist', 'frontend-studio') : dashboard_dir('public', 'studio-package')
       RakeUtils.ln_s target, dashboard_dir('public', 'frontend-studio')
     end
   end

--- a/lib/rake/package.rake
+++ b/lib/rake/package.rake
@@ -1,10 +1,11 @@
 require_relative '../../deployment'
 require 'cdo/chat_client'
 require 'cdo/aws/s3_packaging'
+require 'cdo/aws/turbo_s3_packaging'
 require lib_dir 'cdo/data/logging/rake_task_event_logger'
 include TimedTaskWithLogging
 
-# Rake tasks for asset packages (currently only 'apps').
+# Rake tasks for asset packages (currently only 'apps' and 'studio').
 namespace :package do
   BUILD_PACKAGE = %i[staging test adhoc].include?(rack_env) && !ENV['CI']
 
@@ -67,6 +68,59 @@ namespace :package do
   end
   desc 'Update apps package and create Dashboard symlink.'
   timed_task_with_logging apps: ['apps:update', 'apps:symlink']
+
+  namespace :studio do
+    def studio_packager
+      TurboS3Packaging.new('studio', vite_dir, dashboard_dir('public/studio-package'), frontend_dir, '@code-dot-org/studio')
+    end
+
+    desc 'Update studio static asset package.'
+    timed_task_with_logging 'update' do
+      # never download if we build our own and we're not building a package ourselves.
+      next if CDO.use_my_studio && !BUILD_PACKAGE
+
+      unless studio_packager.update_from_s3
+        if BUILD_PACKAGE
+          Rake::Task['package:studio:build'].invoke
+        else
+          raise 'No valid studio package found'
+        end
+      end
+    end
+
+    desc 'Build and test studio package and upload to S3.'
+    timed_task_with_logging 'build' do
+      # Store initial turbo hash to make sure inputs don't change during the build.
+      # Turborepo's hash covers all source inputs, replacing the git-tree-hash
+      # approach used for apps.
+      packager = studio_packager
+      expected_commit_hash = packager.commit_hash
+
+      ChatClient.wrap('Building studio') {Rake::Task['build:studio'].invoke}
+
+      unless rack_env?(:adhoc)
+        ChatClient.wrap('Testing studio') {Rake::Task['test:studio'].invoke}
+      end
+
+      # upload to s3
+      package = packager.create_package('/dist/frontend-studio', expected_commit_hash: expected_commit_hash)
+
+      unless rack_env?(:adhoc)
+        packager.upload_package_to_s3(package)
+        ChatClient.log "Uploaded studio package to S3: #{packager.commit_hash}"
+      end
+
+      packager.decompress_package(package)
+    end
+
+    desc 'Update Dashboard symlink for studio package.'
+    timed_task_with_logging 'symlink' do
+      target = CDO.use_my_studio ? vite_dir('dist', 'frontend-studio') : dashboard_dir('public', 'frontend-studio')
+      RakeUtils.ln_s target, dashboard_dir('public', 'frontend-studio')
+    end
+  end
+  desc 'Update studio package and create Dashboard symlink.'
+  timed_task_with_logging studio: ['studio:update', 'studio:symlink']
 end
-desc 'Update all packages (apps).'
-timed_task_with_logging package: ['package:apps']
+desc 'Update all packages (apps, studio).'
+timed_task_with_logging package: ['package:apps', 'package:studio']

--- a/lib/rake/test.rake
+++ b/lib/rake/test.rake
@@ -17,6 +17,15 @@ namespace :test do
     TestRunUtils.run_apps_tests
   end
 
+  desc 'Runs studio tests.'
+  timed_task_with_logging :studio do
+    Dir.chdir(frontend_dir) do
+      ChatClient.wrap('studio tests') do
+        RakeUtils.system_stream_output 'yarn test --filter @code-dot-org/studio'
+      end
+    end
+  end
+
   desc 'Run a single eyes test locally using chromedriver.'
   timed_task_with_logging :ui do
     TestRunUtils.run_local_ui_test

--- a/locals.yml.default
+++ b/locals.yml.default
@@ -32,11 +32,16 @@
 # Whether rake:build should rebuild the apps package
 build_apps: true
 
+# Whether rake:build should rebuild the studio package
+build_studio: true
 
 # Whether dashboard should use your local build of the apps package.
 # If false, dashboard will try to use a prepackaged version from S3.
 use_my_apps: true
 
+# Whether dashboard should use your local build of the studio package.
+# If false, dashboard will try to use a prepackaged version from S3.
+use_my_studio: true
 
 # Improves local environment load time by loading only the i18n data for the current locale.
 # Defaults to `true` in the development environment.


### PR DESCRIPTION
This PR adds the ability to build and upload the `studio` vite app using the existing CI pipeline. Some changes include:

- Introduction of TurboS3Packaging which instead of using git hashes, uses the turborepo hash to offload hash detection to Turborepo.
- Rewires and fixes an existing issue with multiple react versions in `studio`.
- Adds wiring to config.yml to enable building studio locally.
- Ensures vite works in development HMR and production static build modes