### PR TITLE
[Poetry] Adds aria label to pause and play button

### DIFF
--- a/apps/src/templates/PauseButton.jsx
+++ b/apps/src/templates/PauseButton.jsx
@@ -48,6 +48,7 @@ class PauseButton extends React.Component {
         disabled={!this.props.isRunning}
         className="no-focus-outline"
         id="pauseButton"
+        aria-label={this.props.isPaused ? 'Play' : 'Pause'}
       >
         <div style={styles.container}>
           <i


### PR DESCRIPTION
The pause/play button didn't have a text or label (just the icons). This adds a label so assistive tech knows how to identify it. 
<img width="905" height="152" alt="Screenshot 2026-03-03 at 5 00 43 PM" src="https://github.com/user-attachments/assets/ca9b79f1-dbf9-45c2-8f24-85ca7a53beca" />

Before:

https://github.com/user-attachments/assets/9b1c4a5e-e9f1-4a3a-b2be-70c42a58377e


After:

https://github.com/user-attachments/assets/fe9ef4b5-79bc-493f-b4a1-105c305be64d



## Links

- Jira: https://codedotorg.atlassian.net/browse/SL-1613
- VPAT: https://app.getstark.co/organization/ced5459c-437e-48a0-8737-90ad0ef005c0/projects/aiOk8eUknKEfWPEE3SIO/assets/5bAQbcRUbbfgXK1uQydr/reports/CqhN8GGQ8oByoEkjrLvu

## Testing story
<!-- How was this tested? Manual steps, adhoc links, automated tests, or why testing isn't needed. -->



## Deployment notes
<!-- Delete this section if it's a standard merge-and-deploy.
     Otherwise: migrations, feature flags, coordination, caching impacts, etc. -->



## Privacy and security
<!-- Delete this section if there is no privacy/security impact.
     Otherwise: new PII, auth changes, API surface changes, etc. -->

