### PR TITLE
Revert "Revert "[Design2-342] Pt.1 Replace all DSCO Button usages with MUI Button across all dashboard pages""

### DIFF
--- a/apps/src/aiComponentLibrary/aiTutorVersionActions/AiTutorVersionActions.tsx
+++ b/apps/src/aiComponentLibrary/aiTutorVersionActions/AiTutorVersionActions.tsx
@@ -1,4 +1,5 @@
-import Button from '@code-dot-org/component-library/button';
+import FontAwesomeV6Icon from '@code-dot-org/component-library/fontAwesomeV6Icon';
+import {Button as MuiButton} from '@mui/material';
 import React, {useState, useCallback} from 'react';
 
 import AiTutorVersionFileChip from '@cdo/apps/aiComponentLibrary/aiTutorVersionFileChip/AiTutorVersionFileChip';
@@ -59,32 +60,40 @@ const AiTutorVersionActions: React.FC<AiTutorVersionActionsProps> = ({
       </div>
       {!isAcceptMode && (
         <div className={moduleStyles.buttonContainer}>
-          <Button
-            text="Reject"
-            size="s"
-            color="gray"
-            type="secondary"
-            iconLeft={{
-              iconStyle: 'solid',
-              iconName: 'close',
-              title: 'Reject',
-            }}
+          <MuiButton
+            variant="outlined"
+            color="tertiary"
+            size="small"
+            className={moduleStyles.actionButton}
             onClick={handleReject}
+            type="button"
+            startIcon={
+              <FontAwesomeV6Icon
+                iconStyle="solid"
+                iconName="close"
+                title="Reject"
+              />
+            }
+          >
+            Reject
+          </MuiButton>
+          <MuiButton
+            variant="contained"
+            color="primary"
+            size="small"
             className={moduleStyles.actionButton}
-          />
-          <Button
-            text="Accept"
-            size="s"
-            type="primary"
-            color="purple"
-            iconLeft={{
-              iconStyle: 'solid',
-              iconName: 'check',
-              title: 'Accept',
-            }}
             onClick={() => setIsAcceptMode(true)}
-            className={moduleStyles.actionButton}
-          />
+            type="button"
+            startIcon={
+              <FontAwesomeV6Icon
+                iconStyle="solid"
+                iconName="check"
+                title="Accept"
+              />
+            }
+          >
+            Accept
+          </MuiButton>
         </div>
       )}
       {isAcceptMode && (
@@ -102,19 +111,19 @@ const AiTutorVersionActions: React.FC<AiTutorVersionActionsProps> = ({
             />
             This is what you'll see in the version history.
           </div>
-          <Button
-            id="save-ai-tutor-version-button"
-            size="s"
-            type="primary"
-            iconLeft={{
-              iconName: 'save',
-              iconStyle: 'solid',
-            }}
+          <MuiButton
+            variant="contained"
+            color="primary"
+            size="small"
             className={moduleStyles.saveAiTutorVersionButton}
-            text={'Accept and save version'}
-            onClick={handleSaveAiTutorVersion}
+            id="save-ai-tutor-version-button"
             disabled={isSaving || commitDescription.trim() === ''}
-          />
+            onClick={handleSaveAiTutorVersion}
+            type="button"
+            startIcon={<FontAwesomeV6Icon iconName="save" iconStyle="solid" />}
+          >
+            Accept and save version
+          </MuiButton>
         </div>
       )}
     </div>

--- a/apps/src/aiDifferentiation/AiDiffChat.tsx
+++ b/apps/src/aiDifferentiation/AiDiffChat.tsx
@@ -1,4 +1,5 @@
-import {LinkButton} from '@code-dot-org/component-library/button';
+import FontAwesomeV6Icon from '@code-dot-org/component-library/fontAwesomeV6Icon';
+import {Button as MuiButton} from '@mui/material';
 import React, {useEffect, useRef, useState} from 'react';
 
 import {
@@ -63,16 +64,18 @@ const AiDiffArtifactLink: React.FC<{artifact: AiArtifact | undefined}> = ({
       : `Lesson Hook`;
     return (
       <div className={style.artifactShowButtons}>
-        <LinkButton
-          color="gray"
-          size="s"
-          type="secondary"
-          target="_blank"
+        <MuiButton
+          variant="outlined"
+          color="tertiary"
+          size="small"
+          aria-label="Open artifact"
           href={artifact.url}
-          aria-label={'Open artifact'}
-          iconLeft={{iconName: 'shapes'}}
-          text={title}
-        />
+          target="_blank"
+          rel="noopener noreferrer"
+          startIcon={<FontAwesomeV6Icon iconName="shapes" />}
+        >
+          {title}
+        </MuiButton>
       </div>
     );
   } else {

--- a/apps/src/aiDifferentiation/AiDiffSidebar.tsx
+++ b/apps/src/aiDifferentiation/AiDiffSidebar.tsx
@@ -1,4 +1,3 @@
-import Button, {buttonColors} from '@code-dot-org/component-library/button';
 import FontAwesomeV6Icon from '@code-dot-org/component-library/fontAwesomeV6Icon';
 import {WithTooltip} from '@code-dot-org/component-library/tooltip';
 import {
@@ -8,6 +7,8 @@ import {
   ListItemButton,
   ListItemText,
   Typography,
+  Button as MuiButton,
+  IconButton as MuiIconButton,
 } from '@mui/material';
 import classNames from 'classnames';
 import React, {useCallback, useState} from 'react';
@@ -193,19 +194,20 @@ const AiDiffSidebar: React.FC<AiDiffSidebarProps> = ({
               size: 's',
             }}
           >
-            <Button
-              isIconOnly
-              onClick={toggleSidebar}
-              icon={{
-                iconName: isCollapsed
-                  ? 'arrow-right-to-line'
-                  : 'arrow-left-to-line',
-              }}
-              color="gray"
-              type="secondary"
-              size="s"
+            <MuiIconButton
+              variant="outlined"
+              color="tertiary"
+              size="small"
               className={styles.sidebarToggleButton}
-            />
+              onClick={toggleSidebar}
+              type="button"
+            >
+              <FontAwesomeV6Icon
+                iconName={
+                  isCollapsed ? 'arrow-right-to-line' : 'arrow-left-to-line'
+                }
+              />
+            </MuiIconButton>
           </WithTooltip>
           {isCollapsed ? (
             <WithTooltip
@@ -218,26 +220,29 @@ const AiDiffSidebar: React.FC<AiDiffSidebarProps> = ({
                 size: 's',
               }}
             >
-              <Button
-                color={buttonColors.purple}
-                size="s"
-                type="primary"
+              <MuiIconButton
+                variant="contained"
+                color="primary"
+                size="small"
                 onClick={onNewChatButtonClick}
-                isIconOnly
-                icon={{iconName: 'plus'}}
                 aria-label={commonI18n.aiDifferentiation_new_chat()}
-              />
+                type="button"
+              >
+                <FontAwesomeV6Icon iconName="plus" />
+              </MuiIconButton>
             </WithTooltip>
           ) : (
-            <Button
-              color={buttonColors.purple}
-              size="s"
-              type="primary"
-              onClick={onNewChatButtonClick}
-              iconLeft={{iconName: 'plus'}}
-              text={commonI18n.aiDifferentiation_new_chat()}
+            <MuiButton
+              variant="contained"
+              color="primary"
+              size="small"
               className={styles.expandedNewChatButton}
-            />
+              onClick={onNewChatButtonClick}
+              type="button"
+              startIcon={<FontAwesomeV6Icon iconName="plus" />}
+            >
+              {commonI18n.aiDifferentiation_new_chat()}
+            </MuiButton>
           )}
         </Box>
         {isCollapsed ? (
@@ -252,18 +257,19 @@ const AiDiffSidebar: React.FC<AiDiffSidebarProps> = ({
                 size: 's',
               }}
             >
-              <Button
-                isIconOnly
-                onClick={onNotificationsButtonClick}
+              <MuiIconButton
+                variant="text"
+                color="secondary"
+                size="small"
                 className={classNames(
                   unreadNotificationCount > 0 && styles.buttonWithUnreadDot
                 )}
-                color="black"
-                type="tertiary"
-                size="s"
-                icon={{iconName: 'bell'}}
+                onClick={onNotificationsButtonClick}
                 aria-label={commonI18n.notifications()}
-              />
+                type="button"
+              >
+                <FontAwesomeV6Icon iconName="bell" />
+              </MuiIconButton>
             </WithTooltip>
             {experiments.isEnabled('daily-bytes') && (
               <WithTooltip
@@ -276,15 +282,16 @@ const AiDiffSidebar: React.FC<AiDiffSidebarProps> = ({
                   size: 's',
                 }}
               >
-                <Button
-                  isIconOnly
+                <MuiIconButton
+                  variant="text"
+                  color="secondary"
+                  size="small"
                   onClick={onDailyBytesButtonClick}
-                  color="black"
-                  type="tertiary"
-                  size="s"
-                  icon={{iconName: 'podcast'}}
                   aria-label="Daily Bytes"
-                />
+                  type="button"
+                >
+                  <FontAwesomeV6Icon iconName="podcast" />
+                </MuiIconButton>
               </WithTooltip>
             )}
           </Box>

--- a/apps/src/aiDifferentiation/personalization/PersonalizationCollectorContainer.tsx
+++ b/apps/src/aiDifferentiation/personalization/PersonalizationCollectorContainer.tsx
@@ -1,4 +1,5 @@
-import Button from '@code-dot-org/component-library/button';
+import FontAwesomeV6Icon from '@code-dot-org/component-library/fontAwesomeV6Icon';
+import {Button as MuiButton} from '@mui/material';
 import React from 'react';
 
 import PersonalizationInterstitial from '@cdo/apps/aiDifferentiation/personalization/components/personalizationInterstitial/PersonalizationInterstitial';
@@ -297,24 +298,33 @@ const PersonalizationCollectorContainer: React.FC = () => {
               </>
             )}
             <div className={style.navigationButtons}>
-              <Button
-                id={'back-button'}
-                text={i18n.back()}
-                type="secondary"
-                color="gray"
-                size="m"
+              <MuiButton
+                variant="outlined"
+                color="tertiary"
+                size="medium"
+                id="back-button"
                 onClick={() => onCarouselPress(BACK)}
-                iconLeft={{iconName: 'angle-left'}}
-              />
-              <Button
-                id={'next-button'}
-                text={isSaving ? i18n.saving() : i18n.next()}
-                type="primary"
-                size="m"
+                type="button"
+                startIcon={<FontAwesomeV6Icon iconName="angle-left" />}
+              >
+                {i18n.back()}
+              </MuiButton>
+              <MuiButton
+                variant="contained"
+                color="primary"
+                size="medium"
+                id="next-button"
                 onClick={() => onCarouselPress(NEXT)}
+                type="button"
                 disabled={isSaving}
-                iconRight={isSaving ? undefined : {iconName: 'angle-right'}}
-              />
+                endIcon={
+                  isSaving ? undefined : (
+                    <FontAwesomeV6Icon iconName="angle-right" />
+                  )
+                }
+              >
+                {isSaving ? i18n.saving() : i18n.next()}
+              </MuiButton>
             </div>
           </>
         )}

--- a/apps/src/aiTutor/views/legacyLabs/AiTutorContainer.tsx
+++ b/apps/src/aiTutor/views/legacyLabs/AiTutorContainer.tsx
@@ -1,5 +1,5 @@
-import Button from '@code-dot-org/component-library/button';
-import {Typography} from '@mui/material';
+import FontAwesomeV6Icon from '@code-dot-org/component-library/fontAwesomeV6Icon';
+import {Typography, IconButton as MuiIconButton} from '@mui/material';
 import classNames from 'classnames';
 import React, {FC} from 'react';
 
@@ -99,15 +99,16 @@ export const AiTutorContainer: FC<{
           <Typography className={styles['header-text']} variant="body3">
             AI Tutor
           </Typography>
-          <Button
-            aria-label="Close AI tutor"
-            isIconOnly
-            icon={{iconName: 'dash'}}
+          <MuiIconButton
+            variant="text"
+            color="secondary"
+            size="extraSmall"
             onClick={toggleAiChat}
-            size="xs"
-            type="tertiary"
-            color="black"
-          />
+            aria-label="Close AI tutor"
+            type="button"
+          >
+            <FontAwesomeV6Icon iconName="dash" />
+          </MuiIconButton>
         </div>
         <AiTutorChat
           hiddenContextCallback={getHiddenContext}

--- a/apps/src/aiTutor/views/legacyLabs/AiTutorSidebar.tsx
+++ b/apps/src/aiTutor/views/legacyLabs/AiTutorSidebar.tsx
@@ -1,4 +1,5 @@
-import Button from '@code-dot-org/component-library/button';
+import FontAwesomeV6Icon from '@code-dot-org/component-library/fontAwesomeV6Icon';
+import {IconButton as MuiIconButton} from '@mui/material';
 import React from 'react';
 
 import {EVENTS} from '@cdo/apps/metrics/AnalyticsConstants';
@@ -47,16 +48,17 @@ const AiTutorSidebar: React.FC<AiTutorSidebarProps> = ({
         <img src={aiBotOutlineIcon} alt="" className={styles['bot-icon']} />
       </div>
       <div className={styles['ai-tutor-sidebar-content']}>
-        <Button
-          className={styles['ai-tutor-suggested-prompt-item']}
-          aria-label="Open AI tutor"
-          isIconOnly
-          icon={{iconName: 'arrow-from-right'}}
-          onClick={openTutor}
-          size="m"
-          type="primary"
+        <MuiIconButton
+          variant="contained"
           color="white"
-        />
+          size="medium"
+          className={styles['ai-tutor-suggested-prompt-item']}
+          onClick={openTutor}
+          aria-label="Open AI tutor"
+          type="button"
+        >
+          <FontAwesomeV6Icon iconName="arrow-from-right" />
+        </MuiIconButton>
         <AiTutorSidebarSuggestedPrompts
           suggestedPrompts={suggestedPrompts}
           hiddenContextCallback={hiddenContextCallback}

--- a/apps/src/aiTutor/views/legacyLabs/AiTutorSidebarSuggestedPrompts.tsx
+++ b/apps/src/aiTutor/views/legacyLabs/AiTutorSidebarSuggestedPrompts.tsx
@@ -1,5 +1,7 @@
-import Button from '@code-dot-org/component-library/button';
-import {FontAwesomeV6IconProps} from '@code-dot-org/component-library/fontAwesomeV6Icon';
+import FontAwesomeV6Icon, {
+  FontAwesomeV6IconProps,
+} from '@code-dot-org/component-library/fontAwesomeV6Icon';
+import {Button as MuiButton} from '@mui/material';
 import classNames from 'classnames';
 import React, {useCallback} from 'react';
 
@@ -75,26 +77,25 @@ const AiTutorSidebarSuggestedPrompts: React.FC<
   return (
     <div className={styles['ai-tutor-suggested-prompts-list']}>
       {suggestedPrompts.map(prompt => (
-        <Button
-          className={styles['ai-tutor-suggested-prompt-item']}
-          aria-label={prompt.label}
-          isIconOnly
-          icon={
-            {
-              ...prompt.icon,
-              className: classNames({
-                [styles['icon']]: true,
-                [styles[`icon-${prompt.icon?.iconName}`]]: prompt.icon,
-              }),
-            } as FontAwesomeV6IconProps
-          }
-          onClick={() => handleSubmit(prompt.value, prompt.analyticsProperties)}
+        <MuiButton
           key={prompt.id}
-          size="m"
-          type="primary"
+          variant="contained"
           color="white"
+          size="medium"
+          className={styles['ai-tutor-suggested-prompt-item']}
+          onClick={() => handleSubmit(prompt.value, prompt.analyticsProperties)}
+          aria-label={prompt.label}
+          type="button"
           disabled={!modelParameters}
-        />
+        >
+          <FontAwesomeV6Icon
+            {...(prompt.icon as FontAwesomeV6IconProps)}
+            className={classNames(
+              styles['icon'],
+              prompt.icon?.iconName && styles[`icon-${prompt.icon.iconName}`]
+            )}
+          />
+        </MuiButton>
       ))}
     </div>
   );

--- a/apps/src/aichat/views/modelCustomization/SetupCustomization.tsx
+++ b/apps/src/aichat/views/modelCustomization/SetupCustomization.tsx
@@ -1,6 +1,6 @@
-import Button from '@code-dot-org/component-library/button';
 import SimpleDropdown from '@code-dot-org/component-library/dropdown/simpleDropdown';
 import Slider, {SliderProps} from '@code-dot-org/component-library/slider';
+import {Button as MuiButton} from '@mui/material';
 import classNames from 'classnames';
 import React, {useState, useMemo} from 'react';
 import {useSelector} from 'react-redux';
@@ -107,14 +107,17 @@ const SetupCustomization: React.FunctionComponent = () => {
           disabled={isDisabled(selectedModelId) || readOnlyWorkspace}
         />
         {canCompare && (
-          <Button
-            text={aichatI18n.modelCustomization_compareButtonText()}
-            onClick={() => setIsShowingModelDialog(true)}
-            type="secondary"
-            color="gray"
-            className={classNames(styles.compareModelsButton)}
+          <MuiButton
+            variant="outlined"
+            color="tertiary"
+            size="medium"
             disabled={readOnlyWorkspace}
-          />
+            className={classNames(styles.compareModelsButton)}
+            onClick={() => setIsShowingModelDialog(true)}
+            type="button"
+          >
+            {aichatI18n.modelCustomization_compareButtonText()}
+          </MuiButton>
         )}
         {isShowingModelDialog && (
           <CompareModelsDialog

--- a/apps/src/bubbleChoice/BubbleChoice.tsx
+++ b/apps/src/bubbleChoice/BubbleChoice.tsx
@@ -3,8 +3,7 @@
 // This is a React client for a bubble_choice level.  Note that this is
 // only used for levels that use Lab2.  For levels that don't use Lab2,
 // they will get an older-style level.
-import {Button} from '@code-dot-org/component-library/button';
-import {Typography} from '@mui/material';
+import {Typography, Button as MuiButton} from '@mui/material';
 import classNames from 'classnames';
 import _ from 'lodash';
 import React, {useEffect, useMemo, useRef} from 'react';
@@ -227,12 +226,17 @@ const BubbleChoice: React.FC<LabProps<BubbleChoiceLevelProperties>> = ({
         </div>
       </div>
       <div className={styles.buttonRow}>
-        <Button
-          ariaLabel={commonI18n.continue()}
-          text={commonI18n.continue()}
-          onClick={() => dispatch(continueOrFinishLesson())}
+        <MuiButton
+          variant="contained"
+          color="primary"
+          size="medium"
           className={styles.continueButton}
-        />
+          onClick={() => dispatch(continueOrFinishLesson())}
+          aria-label={commonI18n.continue()}
+          type="button"
+        >
+          {commonI18n.continue()}
+        </MuiButton>
       </div>
     </div>
   );

--- a/apps/src/code-studio/components/RedirectDialog.jsx
+++ b/apps/src/code-studio/components/RedirectDialog.jsx
@@ -1,4 +1,4 @@
-import Button from '@code-dot-org/component-library/button';
+import {Button as MuiButton} from '@mui/material';
 import PropTypes from 'prop-types';
 import React from 'react';
 
@@ -30,20 +30,24 @@ const RedirectDialog = ({
         {details}
       </div>
       <DialogFooter>
-        <Button
-          text={i18n.stayHere()}
+        <MuiButton
+          variant="outlined"
+          color="tertiary"
+          size="small"
           onClick={handleClose}
-          type="secondary"
-          color="gray"
-          size="s"
-        />
-        <Button
-          text={redirectButtonText}
+          type="button"
+        >
+          {i18n.stayHere()}
+        </MuiButton>
+        <MuiButton
+          variant="contained"
+          color="primary"
+          size="small"
           onClick={redirect}
-          type="primary"
-          color="purple"
-          size="s"
-        />
+          type="button"
+        >
+          {redirectButtonText}
+        </MuiButton>
       </DialogFooter>
     </BaseDialog>
   );

--- a/apps/src/code-studio/components/ShareDisallowedDialog.jsx
+++ b/apps/src/code-studio/components/ShareDisallowedDialog.jsx
@@ -1,4 +1,4 @@
-import Button, {buttonColors} from '@code-dot-org/component-library/button';
+import {Button as MuiButton} from '@mui/material';
 import PropTypes from 'prop-types';
 import React, {Component} from 'react';
 import {connect} from 'react-redux';
@@ -29,17 +29,23 @@ class ShareDisallowedDialog extends Component {
             {i18n.createAccountToShareDescription()}
           </div>
           <div style={styles.bottom}>
-            <Button
-              text={i18n.cancel()}
+            <MuiButton
+              variant="outlined"
+              color="tertiary"
+              size="medium"
               onClick={this.props.hideShareDialog}
-              type="secondary"
-              color={buttonColors.gray}
-            />
-            <Button
-              useAsLink={true}
+              type="button"
+            >
+              {i18n.cancel()}
+            </MuiButton>
+            <MuiButton
+              variant="contained"
+              color="primary"
+              size="medium"
               href={`/users/sign_up/account_type?user_return_to=${location.pathname}`}
-              text={i18n.createAccount()}
-            />
+            >
+              {i18n.createAccount()}
+            </MuiButton>
           </div>
         </div>
       </BaseDialog>

--- a/apps/src/code-studio/components/SmallFooter.jsx
+++ b/apps/src/code-studio/components/SmallFooter.jsx
@@ -5,7 +5,9 @@ https://github.com/code-dot-org/code-dot-org/blob/b2efc7ca8331f8261ebd55a326e23f
 */
 
 /* eslint-disable react/jsx-no-target-blank */
-import {Button} from '@code-dot-org/component-library/button';
+
+import FontAwesomeV6Icon from '@code-dot-org/component-library/fontAwesomeV6Icon';
+import {IconButton as MuiIconButton} from '@mui/material';
 import _ from 'lodash';
 import debounce from 'lodash/debounce';
 import PropTypes from 'prop-types';
@@ -215,19 +217,17 @@ export default class SmallFooter extends React.Component {
 
   renderCopyright() {
     return (
-      <Button
-        aria-label={i18n.copyrightInfoButton()}
+      <MuiIconButton
+        variant="outlined"
+        color="tertiary"
+        size="extraSmall"
         className="copyright-button no-mc"
-        color="gray"
-        icon={{
-          iconName: 'copyright',
-          iconStyle: 'light',
-        }}
-        isIconOnly
         onClick={this.clickBaseCopyright}
-        size="xs"
-        type="secondary"
-      />
+        aria-label={i18n.copyrightInfoButton()}
+        type="button"
+      >
+        <FontAwesomeV6Icon iconName="copyright" iconStyle="light" />
+      </MuiIconButton>
     );
   }
 

--- a/apps/src/code-studio/pd/workshop_dashboard/workshop_form/components/SessionsEditor.tsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/workshop_form/components/SessionsEditor.tsx
@@ -1,4 +1,5 @@
-import Button from '@code-dot-org/component-library/button';
+import FontAwesomeV6Icon from '@code-dot-org/component-library/fontAwesomeV6Icon';
+import {Button as MuiButton} from '@mui/material';
 import moment from 'moment-timezone';
 import React, {Dispatch, FC, memo, useCallback} from 'react';
 
@@ -57,13 +58,17 @@ export const SessionsEditor: FC<{
         />
       ))}
       <div className={commonStyles.row}>
-        <Button
-          onClick={addSession}
-          iconLeft={{iconName: 'plus'}}
-          type="tertiary"
-          text="Add Date"
+        <MuiButton
+          variant="text"
+          color="primary"
+          size="medium"
           className={styles.addDateButton}
-        />
+          onClick={addSession}
+          type="button"
+          startIcon={<FontAwesomeV6Icon iconName="plus" />}
+        >
+          Add Date
+        </MuiButton>
       </div>
     </>
   );

--- a/apps/src/code-studio/pd/workshop_dashboard/workshop_form/components/TimeZoneEditor.tsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/workshop_form/components/TimeZoneEditor.tsx
@@ -1,7 +1,6 @@
-import {Button} from '@code-dot-org/component-library/button';
 import {SimpleDropdown} from '@code-dot-org/component-library/dropdown';
 import FontAwesomeV6Icon from '@code-dot-org/component-library/fontAwesomeV6Icon';
-import {Typography} from '@mui/material';
+import {Typography, Button as MuiButton} from '@mui/material';
 import moment from 'moment-timezone';
 import React, {FC, memo, useState} from 'react';
 
@@ -54,14 +53,16 @@ export const TimeZoneEditor: FC<{
         </Typography>
       )}
       {!editMode && (
-        <Button
-          type="tertiary"
-          color="black"
-          size="xs"
-          iconLeft={{iconName: 'pencil'}}
-          text={'Edit'}
+        <MuiButton
+          variant="text"
+          color="secondary"
+          size="extraSmall"
           onClick={() => setEditMode(true)}
-        />
+          type="button"
+          startIcon={<FontAwesomeV6Icon iconName="pencil" />}
+        >
+          Edit
+        </MuiButton>
       )}
       {editMode && tzChanged && (
         <FontAwesomeV6Icon

--- a/apps/src/code-studio/pd/workshop_dashboard/workshops/WorkshopLayout.tsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/workshops/WorkshopLayout.tsx
@@ -1,6 +1,6 @@
 import Alert from '@code-dot-org/component-library/alert';
-import {LinkButton} from '@code-dot-org/component-library/button';
 import {SegmentedButtonsProps} from '@code-dot-org/component-library/segmentedButtons';
+import {Button as MuiButton} from '@mui/material';
 import React, {
   FC,
   useMemo,
@@ -246,10 +246,14 @@ export const WorkshopLayout: FC<WorkshopLayoutProps> = ({
       </nav>
       <main>
         {showLegacySurveyLinkButton ? (
-          <LinkButton
+          <MuiButton
+            variant="contained"
+            color="primary"
+            size="medium"
             href={`/pd/workshop_dashboard/workshop_daily_survey_results/${workshopId}`}
-            text="Survey results"
-          />
+          >
+            Survey results
+          </MuiButton>
         ) : (
           <>
             {showNoSurveyResponses && <NoSurveyResponses />}

--- a/apps/src/code-studio/pd/workshop_dashboard/workshops/components/CopyButton.tsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/workshops/components/CopyButton.tsx
@@ -1,4 +1,5 @@
-import {Button, buttonColors} from '@code-dot-org/component-library/button';
+import FontAwesomeV6Icon from '@code-dot-org/component-library/fontAwesomeV6Icon';
+import {Button as MuiButton} from '@mui/material';
 import React, {useState, useEffect} from 'react';
 
 import copyToClipboard from '@cdo/apps/util/copyToClipboard';
@@ -32,14 +33,16 @@ export const CopyButton: React.FC<CopyButtonProps> = ({
   }, [icon, setIcon]);
 
   return (
-    <Button
-      text={icon === 'copy' ? buttonText : 'Copied!'}
-      type="secondary"
-      size="xs"
-      color={buttonColors.gray}
-      iconLeft={{iconName: icon, iconStyle: 'solid'}}
+    <MuiButton
+      variant="outlined"
+      color="tertiary"
+      size="extraSmall"
       onClick={() => copyToClipboard(textToCopy, () => setIcon('check'))}
-      ariaLabel={ariaLabel}
-    />
+      aria-label={ariaLabel}
+      type="button"
+      startIcon={<FontAwesomeV6Icon iconName={icon} iconStyle="solid" />}
+    >
+      {icon === 'copy' ? buttonText : 'Copied!'}
+    </MuiButton>
   );
 };

--- a/apps/src/code-studio/pd/workshop_dashboard/workshops/enrollments/WorkshopEnrollments.tsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/workshops/enrollments/WorkshopEnrollments.tsx
@@ -1,7 +1,8 @@
 import Alert from '@code-dot-org/component-library/alert';
-import {Button, buttonColors} from '@code-dot-org/component-library/button';
+import {buttonColors} from '@code-dot-org/component-library/button';
 import Checkbox from '@code-dot-org/component-library/checkbox';
 import Dialog from '@code-dot-org/component-library/dialog';
+import FontAwesomeV6Icon from '@code-dot-org/component-library/fontAwesomeV6Icon';
 import TextField from '@code-dot-org/component-library/textField';
 import {
   Table,
@@ -15,6 +16,8 @@ import {
   Box,
   Divider,
   Typography,
+  Button as MuiButton,
+  IconButton as MuiIconButton,
 } from '@mui/material';
 import classNames from 'classnames';
 import React, {
@@ -250,28 +253,32 @@ export const WorkshopEnrollments: FC = () => {
   return (
     <>
       <Box className={styles.bulkActionRow}>
-        <Button
-          ariaLabel="Refresh enrollment table data"
-          icon={{
-            iconName: 'refresh',
-            animationType:
-              animateRefreshButton || enrollmentsLoading ? 'spin' : undefined,
-          }}
-          isIconOnly
+        <MuiIconButton
+          variant="contained"
+          color="primary"
+          size="small"
           onClick={handleRefreshClick}
-          size="s"
-        />
-        <Button
-          ariaLabel="Export all enrollment data as csv"
-          iconLeft={{
-            iconName: 'download',
-          }}
+          aria-label="Refresh enrollment table data"
+          type="button"
+        >
+          <FontAwesomeV6Icon
+            iconName="refresh"
+            animationType={
+              animateRefreshButton || enrollmentsLoading ? 'spin' : undefined
+            }
+          />
+        </MuiIconButton>
+        <MuiButton
+          variant="outlined"
+          color="tertiary"
+          size="small"
           onClick={handleDownload}
-          size="s"
-          type="secondary"
-          color={buttonColors.gray}
-          text="Export all"
-        />
+          aria-label="Export all enrollment data as csv"
+          type="button"
+          startIcon={<FontAwesomeV6Icon iconName="download" />}
+        >
+          Export all
+        </MuiButton>
         {selected.length > 0 && (
           <>
             <Divider
@@ -282,22 +289,22 @@ export const WorkshopEnrollments: FC = () => {
             <Typography className={styles.numSelectedText} variant="overline2">
               {selected.length} selected
             </Typography>
-            <Button
-              ariaLabel={`Move selected enrollment${s}`}
+            <MuiButton
+              variant="outlined"
+              color="tertiary"
+              size="small"
               onClick={() => setActiveDialog('move')}
-              size="s"
-              type="secondary"
-              color={buttonColors.gray}
-              text={`Move selected enrollment${s}`}
-            />
-            <Button
-              ariaLabel={`Remove selected enrollment${s}`}
+              aria-label={`Move selected enrollment${s}`}
+              type="button"
+            >{`Move selected enrollment${s}`}</MuiButton>
+            <MuiButton
+              variant="outlined"
+              color="error"
+              size="small"
               onClick={() => setActiveDialog('remove')}
-              size="s"
-              type="secondary"
-              color={buttonColors.destructive}
-              text={`Remove selected enrollment${s}`}
-            />
+              aria-label={`Remove selected enrollment${s}`}
+              type="button"
+            >{`Remove selected enrollment${s}`}</MuiButton>
           </>
         )}
       </Box>

--- a/apps/src/code-studio/pd/workshop_dashboard/workshops/overview/sections/WorkshopStatusSection.tsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/workshops/overview/sections/WorkshopStatusSection.tsx
@@ -1,9 +1,16 @@
 import Alert, {alertTypes} from '@code-dot-org/component-library/alert';
-import {Button, buttonColors} from '@code-dot-org/component-library/button';
+import {buttonColors} from '@code-dot-org/component-library/button';
 import {Dialog} from '@code-dot-org/component-library/dialog';
 import Link from '@code-dot-org/component-library/link';
 import Tags from '@code-dot-org/component-library/tags';
-import {Card, CardContent, CardHeader, Box, Typography} from '@mui/material';
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  Box,
+  Typography,
+  Button as MuiButton,
+} from '@mui/material';
 import classNames from 'classnames';
 import React, {useCallback, useState} from 'react';
 import {useNavigate} from 'react-router-dom';
@@ -150,22 +157,26 @@ export const WorkshopStatusSection: React.FC<WorkshopStatusSectionProps> = ({
                 />
               </Box>
               {isWorkshopAdmin && inProgress && (
-                <Button
-                  text="Unstart (admin)"
-                  size="xs"
-                  type="secondary"
-                  color={buttonColors.gray}
+                <MuiButton
+                  variant="outlined"
+                  color="tertiary"
+                  size="extraSmall"
                   onClick={() => handleClick('unstart')}
-                />
+                  type="button"
+                >
+                  Unstart (admin)
+                </MuiButton>
               )}
               {isWorkshopAdmin && ended && (
-                <Button
-                  text="Reopen (admin)"
-                  size="xs"
-                  type="secondary"
-                  color={buttonColors.gray}
+                <MuiButton
+                  variant="outlined"
+                  color="tertiary"
+                  size="extraSmall"
                   onClick={() => handleClick('reopen')}
-                />
+                  type="button"
+                >
+                  Reopen (admin)
+                </MuiButton>
               )}
             </Box>
           }
@@ -304,23 +315,29 @@ export const WorkshopStatusSection: React.FC<WorkshopStatusSectionProps> = ({
 
               <Box>
                 {notStarted && (
-                  <Button
-                    size="s"
-                    text="Start Workshop"
+                  <MuiButton
+                    variant="contained"
+                    color="primary"
+                    size="small"
                     onClick={() => handleClick('start')}
+                    type="button"
                     disabled={isUpdating}
-                  />
+                  >
+                    Start Workshop
+                  </MuiButton>
                 )}
 
                 {inProgress && (
-                  <Button
-                    size="s"
-                    text="End workshop"
-                    type="secondary"
-                    color={buttonColors.destructive}
+                  <MuiButton
+                    variant="outlined"
+                    color="error"
+                    size="small"
                     onClick={() => handleClick('end')}
+                    type="button"
                     disabled={isUpdating}
-                  />
+                  >
+                    End workshop
+                  </MuiButton>
                 )}
               </Box>
             </Box>

--- a/apps/src/code-studio/pd/workshops/components/UserPassport.tsx
+++ b/apps/src/code-studio/pd/workshops/components/UserPassport.tsx
@@ -1,7 +1,6 @@
-import {LinkButton} from '@code-dot-org/component-library/button';
 import FontAwesomeV6Icon from '@code-dot-org/component-library/fontAwesomeV6Icon';
 import Tags from '@code-dot-org/component-library/tags';
-import {Typography} from '@mui/material';
+import {Typography, Button as MuiButton} from '@mui/material';
 import classNames from 'classnames';
 import React from 'react';
 
@@ -100,13 +99,18 @@ const UserPassport: React.FunctionComponent<{
             ]}
           />
         ) : (
-          <LinkButton
-            text="Edit"
-            size="xs"
-            iconLeft={{iconName: 'pencil', iconStyle: 'solid'}}
+          <MuiButton
+            variant="contained"
+            color="primary"
+            size="extraSmall"
             className={style.editButton}
             href={buildEditLink()}
-          />
+            startIcon={
+              <FontAwesomeV6Icon iconName="pencil" iconStyle="solid" />
+            }
+          >
+            {'Edit'}
+          </MuiButton>
         )}
       </span>
       {!isUserEnrolled && (

--- a/apps/src/code-studio/pd/workshops/components/WorkshopFacilitatorsList.tsx
+++ b/apps/src/code-studio/pd/workshops/components/WorkshopFacilitatorsList.tsx
@@ -1,7 +1,6 @@
-import Button from '@code-dot-org/component-library/button';
 import FontAwesomeV6Icon from '@code-dot-org/component-library/fontAwesomeV6Icon';
 import Image from '@code-dot-org/component-library/image';
-import {Typography} from '@mui/material';
+import {Typography, Button as MuiButton} from '@mui/material';
 import classNames from 'classnames';
 import React, {useState} from 'react';
 
@@ -34,15 +33,22 @@ const FacilitatorItem: React.FC<{facilitator: FacilitatorInfo}> = ({
         </div>
         {facilitator.bio && (
           <div>
-            <Button
-              type="tertiary"
-              size="s"
+            <MuiButton
+              variant="text"
+              color="primary"
+              size="small"
               className={moduleStyles.showBioButton}
-              text={showBio ? 'Hide biography' : 'Show biography'}
-              iconRight={{iconName: showBio ? 'chevron-up' : 'chevron-down'}}
               onClick={() => handleShowBio(!showBio)}
+              type="button"
               aria-expanded={showBio}
-            />
+              endIcon={
+                <FontAwesomeV6Icon
+                  iconName={showBio ? 'chevron-up' : 'chevron-down'}
+                />
+              }
+            >
+              {showBio ? 'Hide biography' : 'Show biography'}
+            </MuiButton>
           </div>
         )}
       </div>

--- a/apps/src/codebridge/Workspace/HeaderButtons.tsx
+++ b/apps/src/codebridge/Workspace/HeaderButtons.tsx
@@ -1,4 +1,5 @@
-import {Button} from '@code-dot-org/component-library/button';
+import FontAwesomeV6Icon from '@code-dot-org/component-library/fontAwesomeV6Icon';
+import {Button as MuiButton} from '@mui/material';
 import React, {useCallback} from 'react';
 
 import codebridgeI18n from '@cdo/apps/codebridge/locale';
@@ -59,38 +60,49 @@ const WorkspaceHeaderButtons: React.FunctionComponent = () => {
   return (
     <div className={moduleStyles.rightHeaderButtons}>
       {projectPickerSettings && (
-        <Button
-          iconRight={{iconName: 'rotate'}}
-          size={'xs'}
-          text={projectPickerSettings.currentType}
+        <MuiButton
+          variant="contained"
+          color="secondary"
+          size="extraSmall"
           onClick={projectPickerSettings.showProjectTypePicker}
-          type={'primary'}
           aria-label={codebridgeI18n.projectPickerAriaLabel()}
-          color={'black'}
-        />
+          type="button"
+          endIcon={<FontAwesomeV6Icon iconName="rotate" />}
+        >
+          {projectPickerSettings.currentType}
+        </MuiButton>
       )}
       {enableMicroBit && (
-        <Button
-          iconRight={{iconStyle: 'solid', iconName: 'arrow-right-from-arc'}}
+        <MuiButton
+          variant="text"
+          color="secondary"
+          size="extraSmall"
           onClick={onClickFlash}
-          size={'xs'}
-          type={'tertiary'}
-          text={codebridgeI18n.sendToMicroBit()}
-          color={'black'}
-        />
+          type="button"
+          endIcon={
+            <FontAwesomeV6Icon
+              iconStyle="solid"
+              iconName="arrow-right-from-arc"
+            />
+          }
+        >
+          {codebridgeI18n.sendToMicroBit()}
+        </MuiButton>
       )}
       {skipUrl && (
-        <Button
-          iconRight={{iconStyle: 'solid', iconName: 'arrow-right'}}
-          onClick={onClickSkip}
-          size={'xs'}
-          type={'tertiary'}
-          text={commonI18n.skipToProject()}
+        <MuiButton
+          variant="text"
+          color="secondary"
+          size="extraSmall"
           className={moduleStyles.buttonSkip}
-          color={'black'}
+          onClick={onClickSkip}
+          type="button"
+          endIcon={
+            <FontAwesomeV6Icon iconStyle="solid" iconName="arrow-right" />
+          }
         >
-          <span>{commonI18n.skipToProject()}</span>
-        </Button>
+          {commonI18n.skipToProject()}
+        </MuiButton>
       )}
     </div>
   );

--- a/apps/src/lab2/views/components/Instructions/ResourcePanel/Backpack/BackpackFileChip.tsx
+++ b/apps/src/lab2/views/components/Instructions/ResourcePanel/Backpack/BackpackFileChip.tsx
@@ -1,9 +1,8 @@
-import {Button} from '@code-dot-org/component-library/button';
 import {ActionDropdown} from '@code-dot-org/component-library/dropdown';
 import FontAwesomeV6Icon from '@code-dot-org/component-library/fontAwesomeV6Icon';
 import Tags from '@code-dot-org/component-library/tags';
 import {WithTooltip} from '@code-dot-org/component-library/tooltip';
-import {Typography} from '@mui/material';
+import {Typography, IconButton as MuiIconButton} from '@mui/material';
 import React, {useMemo} from 'react';
 
 import {getFileIconNameAndStyle} from '@cdo/apps/codebridge';
@@ -249,15 +248,16 @@ const BackpackFileChip: React.FC<BackpackFileChipProps> = ({
             }}
           >
             <div>
-              <Button
-                size="xs"
-                isIconOnly
-                icon={{iconName: 'plus'}}
-                color="gray"
-                type="secondary"
+              <MuiIconButton
+                variant="outlined"
+                color="tertiary"
+                size="extraSmall"
                 onClick={() => handleAdd(isSecondaryBackpack)}
+                type="button"
                 disabled={addButtonDisabled}
-              />
+              >
+                <FontAwesomeV6Icon iconName="plus" />
+              </MuiIconButton>
             </div>
           </WithTooltip>
         )}

--- a/apps/src/lab2/views/components/Instructions/ResourcePanel/VersionHistory/SaveVersionPanel.tsx
+++ b/apps/src/lab2/views/components/Instructions/ResourcePanel/VersionHistory/SaveVersionPanel.tsx
@@ -1,4 +1,5 @@
-import {Button} from '@code-dot-org/component-library/button';
+import FontAwesomeV6Icon from '@code-dot-org/component-library/fontAwesomeV6Icon';
+import {Button as MuiButton} from '@mui/material';
 import React, {useCallback, useState} from 'react';
 
 import Lab2Registry from '@cdo/apps/lab2/Lab2Registry';
@@ -101,20 +102,19 @@ const SaveVersionPanel: React.FC<SaveVersionPanelProps> = ({
             placeholder={lab2I18n.describeYourChanges()}
           />
         </div>
-        <Button
-          id="save-version-button"
-          size="s"
-          type="secondary"
-          color="gray"
-          iconLeft={{
-            iconName: 'save',
-            iconStyle: 'solid',
-          }}
+        <MuiButton
+          variant="outlined"
+          color="tertiary"
+          size="small"
           className={moduleStyles.versionButton}
-          text={buttonLabel}
+          id="save-version-button"
           onClick={onSaveVersion}
+          type="button"
           disabled={disabled || isSaving || commitDescription.trim() === ''}
-        />
+          startIcon={<FontAwesomeV6Icon iconName="save" iconStyle="solid" />}
+        >
+          {buttonLabel}
+        </MuiButton>
       </div>
     </div>
   );

--- a/apps/src/lab2/views/components/Instructions/ResourcePanel/VersionHistory/VersionHistoryPanel.tsx
+++ b/apps/src/lab2/views/components/Instructions/ResourcePanel/VersionHistory/VersionHistoryPanel.tsx
@@ -1,6 +1,6 @@
 import Alert from '@code-dot-org/component-library/alert';
-import Button from '@code-dot-org/component-library/button';
 import FontAwesomeV6Icon from '@code-dot-org/component-library/fontAwesomeV6Icon';
+import {Button as MuiButton} from '@mui/material';
 import classNames from 'classnames';
 import React, {useCallback, useEffect, useMemo, useRef, useState} from 'react';
 
@@ -571,23 +571,25 @@ const VersionHistoryPanel: React.FunctionComponent<
                 return (
                   <React.Fragment key={`group-${groupIndex}`}>
                     {hasMultipleVersions && !alwaysShowAutoSaves && (
-                      <Button
+                      <MuiButton
+                        variant="text"
+                        color="secondary"
+                        size="extraSmall"
                         className={moduleStyles.collapseButton}
-                        text={
-                          isCollapsed
-                            ? `Show ${versions.length} auto-saves`
-                            : `Hide ${versions.length} auto-saves`
-                        }
-                        iconLeft={{
-                          iconName: isCollapsed ? 'angles-down' : 'angles-up',
-                        }}
-                        color="black"
-                        size="xs"
-                        type="tertiary"
-                        aria-expanded={!isCollapsed}
                         onClick={() => toggleGroupCollapsed(groupIndex)}
+                        type="button"
                         disabled={disabled}
-                      />
+                        aria-expanded={!isCollapsed}
+                        startIcon={
+                          <FontAwesomeV6Icon
+                            iconName={isCollapsed ? 'angles-down' : 'angles-up'}
+                          />
+                        }
+                      >
+                        {isCollapsed
+                          ? `Show ${versions.length} auto-saves`
+                          : `Hide ${versions.length} auto-saves`}
+                      </MuiButton>
                     )}
                     {!isCollapsed &&
                       versions.map(version =>

--- a/apps/src/lab2/views/components/starterAssetsDialog/FileIcon.tsx
+++ b/apps/src/lab2/views/components/starterAssetsDialog/FileIcon.tsx
@@ -1,8 +1,7 @@
-import {Button} from '@code-dot-org/component-library/button';
 import Checkbox from '@code-dot-org/component-library/checkbox';
 import FontAwesomeV6Icon from '@code-dot-org/component-library/fontAwesomeV6Icon';
 import {WithTooltip} from '@code-dot-org/component-library/tooltip';
-import {Typography} from '@mui/material';
+import {Typography, IconButton as MuiIconButton} from '@mui/material';
 import React, {memo, useEffect, useRef, useState} from 'react';
 
 import lab2I18n from '@cdo/apps/lab2/locale';
@@ -73,14 +72,16 @@ const FileIcon: React.FC<FileIconProps> = ({
         />
       )}
       {onDelete && !loadingMetadata && (
-        <Button
-          size="xs"
-          isIconOnly={true}
+        <MuiIconButton
+          variant="outlined"
+          color="error"
+          size="extraSmall"
           onClick={() => onDelete(filename)}
-          icon={{iconName: 'trash'}}
-          color="destructive"
-          type="secondary"
-        />
+          type="button"
+          aria-label={`Delete ${filename}`}
+        >
+          <FontAwesomeV6Icon iconName="trash" />
+        </MuiIconButton>
       )}
       {loadingMetadata && (
         <div className={styles.loadingIcon}>

--- a/apps/src/lab2/views/dialogs/CopyToClipboardButton.tsx
+++ b/apps/src/lab2/views/dialogs/CopyToClipboardButton.tsx
@@ -1,4 +1,5 @@
-import {Button} from '@code-dot-org/component-library/button';
+import FontAwesomeV6Icon from '@code-dot-org/component-library/fontAwesomeV6Icon';
+import {Button as MuiButton} from '@mui/material';
 import React, {useCallback, useState} from 'react';
 
 import {ProjectType} from '@cdo/apps/lab2/types';
@@ -29,17 +30,21 @@ export const CopyToClipboardButton: React.FunctionComponent<{
   }, [shareUrl, projectType, channelId]);
 
   return (
-    <Button
-      iconLeft={{
-        iconName: copiedToClipboard ? 'clipboard-check' : 'clipboard',
-      }}
-      ariaLabel={i18n.copyLinkToProject()}
-      text={i18n.copyLinkToProject()}
-      type="secondary"
-      color="black"
-      size="m"
-      onClick={handleCopyToClipboard}
+    <MuiButton
+      variant="outlined"
+      color="secondary"
+      size="medium"
       className={moduleStyles.shareDialogButton}
-    />
+      onClick={handleCopyToClipboard}
+      aria-label={i18n.copyLinkToProject()}
+      type="button"
+      startIcon={
+        <FontAwesomeV6Icon
+          iconName={copiedToClipboard ? 'clipboard-check' : 'clipboard'}
+        />
+      }
+    >
+      {i18n.copyLinkToProject()}
+    </MuiButton>
   );
 };

--- a/apps/src/signUpFlow/AccountType.tsx
+++ b/apps/src/signUpFlow/AccountType.tsx
@@ -1,6 +1,5 @@
-import Button from '@code-dot-org/component-library/button';
 import FontAwesomeV6Icon from '@code-dot-org/component-library/fontAwesomeV6Icon';
-import {Typography} from '@mui/material';
+import {Typography, Button as MuiButton} from '@mui/material';
 import React, {useState, useEffect} from 'react';
 
 import {studio} from '@cdo/apps/lib/util/urlHelpers';
@@ -135,15 +134,19 @@ const AccountType: React.FunctionComponent<{
           <Typography component="h2" variant="h6" gutterBottom>
             {locale.free_curriculum_forever()}
           </Typography>
-          <Button
+          <MuiButton
+            variant="contained"
+            color="primary"
+            size="small"
             className={style.dialogButton}
-            size="s"
-            text={locale.read_our_commitment_free()}
             onClick={() => {
               sendCurriculumAnalyticsEvent();
               setIsFreeCurriculumDialogOpen(true);
             }}
-          />
+            type="button"
+          >
+            {locale.read_our_commitment_free()}
+          </MuiButton>
         </div>
       </div>
     </main>

--- a/apps/src/signUpFlow/FreeCurriculumDialog.tsx
+++ b/apps/src/signUpFlow/FreeCurriculumDialog.tsx
@@ -1,5 +1,4 @@
-import Button from '@code-dot-org/component-library/button';
-import {Typography} from '@mui/material';
+import {Typography, Button as MuiButton} from '@mui/material';
 import React from 'react';
 
 import AccessibleDialog from '@cdo/apps/sharedComponents/AccessibleDialog';
@@ -43,11 +42,15 @@ const FreeCurriculumDialog: React.FunctionComponent<
           {locale.dedicated_to_expanding()}
         </Typography>
       </div>
-      <Button
+      <MuiButton
+        variant="contained"
+        color="primary"
+        size="small"
         onClick={closeModal}
-        size={'s'}
-        text={locale.return_to_signup()}
-      />
+        type="button"
+      >
+        {locale.return_to_signup()}
+      </MuiButton>
     </AccessibleDialog>
   ) : null;
 };

--- a/apps/src/signUpFlow/LoginTypeSelection.tsx
+++ b/apps/src/signUpFlow/LoginTypeSelection.tsx
@@ -1,7 +1,6 @@
-import Button from '@code-dot-org/component-library/button';
 import FontAwesomeV6Icon from '@code-dot-org/component-library/fontAwesomeV6Icon';
 import TextField from '@code-dot-org/component-library/textField';
-import {Typography} from '@mui/material';
+import {Typography, Button as MuiButton} from '@mui/material';
 import cookies from 'js-cookie';
 import React, {useState, useEffect} from 'react';
 
@@ -246,43 +245,76 @@ const LoginTypeSelection: React.FunctionComponent<{
             </Typography>
           </div>
           <form action="/users/auth/google_oauth2" method="POST">
-            <Button
-              text={locale.sign_up_google()}
-              onClick={() => selectOauthLoginType('google')}
-              iconLeft={{iconName: 'brands fa-google', iconStyle: 'solid'}}
+            <MuiButton
+              variant="contained"
+              color="primary"
+              size="medium"
               className={style.googleButton}
-              buttonTagTypeAttribute="submit"
-            />
+              onClick={() => selectOauthLoginType('google')}
+              type="submit"
+              startIcon={
+                <FontAwesomeV6Icon
+                  iconName="brands fa-google"
+                  iconStyle="solid"
+                />
+              }
+            >
+              {locale.sign_up_google()}
+            </MuiButton>
             <input type="hidden" name="authenticity_token" value={authToken} />
           </form>
           <form action="/users/auth/microsoft_v2_auth" method="POST">
-            <Button
-              text={locale.sign_up_microsoft()}
-              onClick={() => selectOauthLoginType('microsoft')}
-              iconLeft={{iconName: 'brands fa-microsoft', iconStyle: 'light'}}
+            <MuiButton
+              variant="contained"
+              color="primary"
+              size="medium"
               className={style.microsoftButton}
-              buttonTagTypeAttribute="submit"
-            />
+              onClick={() => selectOauthLoginType('microsoft')}
+              type="submit"
+              startIcon={
+                <FontAwesomeV6Icon
+                  iconName="brands fa-microsoft"
+                  iconStyle="light"
+                />
+              }
+            >
+              {locale.sign_up_microsoft()}
+            </MuiButton>
             <input type="hidden" name="authenticity_token" value={authToken} />
           </form>
           <form action="/users/auth/facebook" method="POST">
-            <Button
-              text={locale.sign_up_facebook()}
-              onClick={() => selectOauthLoginType('facebook')}
-              iconLeft={{iconName: 'brands fa-facebook-f', iconStyle: 'solid'}}
+            <MuiButton
+              variant="contained"
+              color="primary"
+              size="medium"
               className={style.facebookButton}
-              buttonTagTypeAttribute="submit"
-            />
+              onClick={() => selectOauthLoginType('facebook')}
+              type="submit"
+              startIcon={
+                <FontAwesomeV6Icon
+                  iconName="brands fa-facebook-f"
+                  iconStyle="solid"
+                />
+              }
+            >
+              {locale.sign_up_facebook()}
+            </MuiButton>
             <input type="hidden" name="authenticity_token" value={authToken} />
           </form>
           <form action="/users/auth/clever" method="POST">
-            <Button
-              text={locale.sign_up_clever()}
-              onClick={() => selectOauthLoginType('clever')}
-              iconLeft={{iconName: 'kit fa-clever', iconStyle: 'solid'}}
+            <MuiButton
+              variant="contained"
+              color="primary"
+              size="medium"
               className={style.cleverButton}
-              buttonTagTypeAttribute="submit"
-            />
+              onClick={() => selectOauthLoginType('clever')}
+              type="submit"
+              startIcon={
+                <FontAwesomeV6Icon iconName="kit fa-clever" iconStyle="solid" />
+              }
+            >
+              {locale.sign_up_clever()}
+            </MuiButton>
             <input type="hidden" name="authenticity_token" value={authToken} />
           </form>
           {/* TODO: once the Classlink icon has been added to our Font Awesome account,
@@ -428,14 +460,18 @@ const LoginTypeSelection: React.FunctionComponent<{
               )}
             </div>
           </div>
-          <Button
-            id="createAccountButton"
+          <MuiButton
+            variant="contained"
+            color="primary"
+            size="medium"
             className={style.shortButton}
-            text={locale.create_my_account()}
+            id="createAccountButton"
             onClick={submitLoginType}
+            type="submit"
             disabled={createAccountButtonDisabled}
-            buttonTagTypeAttribute="submit"
-          />
+          >
+            {locale.create_my_account()}
+          </MuiButton>
         </div>
       </div>
       <SafeMarkdown

--- a/apps/src/signUpFlow/signUpFlowStyles.module.scss
+++ b/apps/src/signUpFlow/signUpFlowStyles.module.scss
@@ -50,7 +50,7 @@ label {
   gap: 0 0.5rem !important;
 }
 
-span {
+span:not(:global(.MuiButton-icon)) {
   margin-bottom: 0.125rem !important;
 }
 
@@ -186,10 +186,6 @@ span {
       button {
         width: 100%;
         margin: 0 0 0.5rem 0;
-      }
-
-      i {
-        margin-bottom: 0.25rem;
       }
     }
 

--- a/apps/src/simpleSignUp/lti/link/LtiLinkAccountPage/cards/LtiExistingAccountCard/index.tsx
+++ b/apps/src/simpleSignUp/lti/link/LtiLinkAccountPage/cards/LtiExistingAccountCard/index.tsx
@@ -1,5 +1,5 @@
-import {buttonColors, Button} from '@code-dot-org/component-library/button';
 import FontAwesomeV6Icon from '@code-dot-org/component-library/fontAwesomeV6Icon';
+import {Button as MuiButton} from '@mui/material';
 import classNames from 'classnames';
 import React, {useContext} from 'react';
 
@@ -60,14 +60,16 @@ const LtiExistingAccountCard = () => {
         })}
       </CardContent>
       <CardActions>
-        <Button
+        <MuiButton
+          variant="contained"
+          color="primary"
+          size="medium"
           className={styles.button}
-          color={buttonColors.purple}
-          type={'primary'}
-          size="m"
           onClick={handleExistingAccountSubmit}
-          text={i18n.ltiLinkAccountExistingAccountCardActionLabel()}
-        />
+          type="button"
+        >
+          {i18n.ltiLinkAccountExistingAccountCardActionLabel()}
+        </MuiButton>
       </CardActions>
     </Card>
   );

--- a/apps/src/templates/ChallengeDialog.jsx
+++ b/apps/src/templates/ChallengeDialog.jsx
@@ -1,4 +1,4 @@
-import Button, {buttonColors} from '@code-dot-org/component-library/button';
+import {Button as MuiButton} from '@mui/material';
 import classNames from 'classnames';
 import PropTypes from 'prop-types';
 import React from 'react';
@@ -104,21 +104,27 @@ class ChallengeDialog extends React.Component {
           )}
           {this.props.children}
         </div>
-        <Button
+        <MuiButton
+          variant="outlined"
+          color="tertiary"
+          size="medium"
           id="challengeCancelButton"
           onClick={this.handleCancel}
-          text={this.props.cancelButtonLabel}
-          type="secondary"
-          color={buttonColors.gray}
-        />
-        <Button
+          type="button"
+        >
+          {this.props.cancelButtonLabel}
+        </MuiButton>
+        <MuiButton
+          variant="contained"
+          color="primary"
+          size="medium"
+          className={isRtl ? styles.primaryButtonRtl : styles.primaryButton}
           id="challengePrimaryButton"
           onClick={this.handlePrimary}
-          text={this.props.primaryButtonLabel}
-          type="primary"
-          color={buttonColors.purple}
-          className={isRtl ? styles.primaryButtonRtl : styles.primaryButton}
-        />
+          type="button"
+        >
+          {this.props.primaryButtonLabel}
+        </MuiButton>
         {this.props.showPuzzleRatingButtons && (
           <div className={styles.footer}>
             <PuzzleRatingButtons

--- a/apps/src/templates/feedback/LessonRecommendedAction.tsx
+++ b/apps/src/templates/feedback/LessonRecommendedAction.tsx
@@ -1,5 +1,5 @@
-import {Button} from '@code-dot-org/component-library/button';
-import {Typography} from '@mui/material';
+import FontAwesomeV6Icon from '@code-dot-org/component-library/fontAwesomeV6Icon';
+import {Typography, Button as MuiButton} from '@mui/material';
 import React from 'react';
 
 import styles from './LessonFeedback.module.scss';
@@ -33,13 +33,16 @@ function LessonRecommendedAction({resource}: LessonRecommendedActionProps) {
         </Typography>
       )}
       {resource.resource_name && resource.resource_link && (
-        <Button
+        <MuiButton
+          variant="contained"
+          color="primary"
+          size="extraSmall"
           onClick={handleViewResource}
-          text={resource.resource_name || 'View Resource'}
-          type="primary"
-          size="xs"
-          iconLeft={{iconName: 'link'}}
-        />
+          type="button"
+          startIcon={<FontAwesomeV6Icon iconName="link" />}
+        >
+          {resource.resource_name || 'View Resource'}
+        </MuiButton>
       )}
     </div>
   );

--- a/apps/src/templates/instructions/ContainedLevelResetButton.jsx
+++ b/apps/src/templates/instructions/ContainedLevelResetButton.jsx
@@ -1,4 +1,5 @@
-import {Button, buttonColors} from '@code-dot-org/component-library/button';
+import FontAwesomeV6Icon from '@code-dot-org/component-library/fontAwesomeV6Icon';
+import {Button as MuiButton} from '@mui/material';
 import PropTypes from 'prop-types';
 import React, {useState} from 'react';
 import {connect} from 'react-redux';
@@ -30,9 +31,11 @@ export const UnconnectedContainedLevelResetButton = ({
   }
   return (
     <div>
-      <Button
+      <MuiButton
+        variant="outlined"
+        color="error"
+        size="small"
         name="containedLevelResetButton"
-        text={i18n.deleteAnswer()}
         onClick={() => {
           resetContainedLevel().then(
             () => {
@@ -42,12 +45,12 @@ export const UnconnectedContainedLevelResetButton = ({
             () => setResetFailed(true)
           );
         }}
-        size={'s'}
         disabled={!hasLevelResults || !!codeIsRunning}
-        color={buttonColors.destructive}
-        iconLeft={{iconStyle: 'solid', iconName: 'trash'}}
-        type={'secondary'}
-      />
+        type="button"
+        startIcon={<FontAwesomeV6Icon iconStyle="solid" iconName="trash" />}
+      >
+        {i18n.deleteAnswer()}
+      </MuiButton>
       <HelpTip>{i18n.deleteAnswerHelpTip()}</HelpTip>
       {resetFailed && (
         <span style={styles.error}>{i18n.errorResettingAnswer()}</span>

--- a/apps/src/templates/levelSummary/AiEvaluationFeedbackModal.tsx
+++ b/apps/src/templates/levelSummary/AiEvaluationFeedbackModal.tsx
@@ -1,6 +1,5 @@
-import Button from '@code-dot-org/component-library/button';
 import Checkbox from '@code-dot-org/component-library/checkbox';
-import {Typography} from '@mui/material';
+import {Typography, Button as MuiButton} from '@mui/material';
 import React, {useState, useRef} from 'react';
 
 import {
@@ -135,18 +134,24 @@ const AiEvaluationFeedbackModal: React.FC<AiEvaluationFeedbackModalProps> = ({
           renderOptionsForStudentAiInteractionFeedback()}
         <hr />
         <div className={style.feedbackPortalButtonContainer}>
-          <Button
+          <MuiButton
+            variant="outlined"
+            color="secondary"
+            size="medium"
             onClick={closeModalHandler}
-            type="secondary"
-            color="black"
-            text={i18n.closeDialog()}
-          />
-          <Button
+            type="button"
+          >
+            {i18n.closeDialog()}
+          </MuiButton>
+          <MuiButton
+            variant="contained"
+            color="primary"
+            size="medium"
             onClick={handleSubmitButtonClick}
-            type="primary"
-            color="purple"
-            text={i18n.aiFeedbackSubmit()}
-          />
+            type="button"
+          >
+            {i18n.aiFeedbackSubmit()}
+          </MuiButton>
         </div>
       </div>
     </AccessibleDialog>

--- a/apps/src/templates/manageStudents/Table/UsStateColumn/BulkSetModal/index.tsx
+++ b/apps/src/templates/manageStudents/Table/UsStateColumn/BulkSetModal/index.tsx
@@ -1,5 +1,4 @@
-import Button, {buttonColors} from '@code-dot-org/component-library/button';
-import {Typography} from '@mui/material';
+import {Typography, Button as MuiButton} from '@mui/material';
 import React, {useState} from 'react';
 import {ControlLabel, Fade, FormControl, FormGroup} from 'react-bootstrap'; // eslint-disable-line no-restricted-imports
 import {connect} from 'react-redux';
@@ -91,19 +90,24 @@ const BulkSetModal: React.FC<BulkSetModalProps> = ({
         <hr aria-hidden="true" />
 
         <div id="us-state-column-bulk-set-modal-footer">
-          <Button
-            text={i18n.cancel()}
-            type="secondary"
-            size="s"
-            color={buttonColors.gray}
+          <MuiButton
+            variant="outlined"
+            color="tertiary"
+            size="small"
             onClick={onClose}
-          />
-          <Button
-            text={i18n.add()}
-            type="primary"
-            size="s"
+            type="button"
+          >
+            {i18n.cancel()}
+          </MuiButton>
+          <MuiButton
+            variant="contained"
+            color="primary"
+            size="small"
             onClick={bulkSetUsState}
-          />
+            type="button"
+          >
+            {i18n.add()}
+          </MuiButton>
         </div>
       </AccessibleDialog>
     </Fade>

--- a/apps/src/templates/projects/ProjectNameFailureDialog.tsx
+++ b/apps/src/templates/projects/ProjectNameFailureDialog.tsx
@@ -1,5 +1,4 @@
-import {Button, buttonColors} from '@code-dot-org/component-library/button';
-import {Typography} from '@mui/material';
+import {Typography, Button as MuiButton} from '@mui/material';
 import React from 'react';
 
 import i18n from '@cdo/locale';
@@ -31,11 +30,15 @@ const ProjectNameFailureDialog: React.FunctionComponent<
         <p>{i18n.nameFailureDialogBody({text: flaggedText})}</p>
       </div>
       <DialogFooter rightAlign>
-        <Button
-          text={i18n.ok()}
+        <MuiButton
+          variant="contained"
+          color="primary"
+          size="medium"
           onClick={handleClose}
-          color={buttonColors.purple}
-        />
+          type="button"
+        >
+          {i18n.ok()}
+        </MuiButton>
       </DialogFooter>
     </BaseDialog>
   );

--- a/apps/src/templates/projects/submitProjectDialog/SubmitProjectDialog.tsx
+++ b/apps/src/templates/projects/submitProjectDialog/SubmitProjectDialog.tsx
@@ -1,7 +1,7 @@
 import Alert from '@code-dot-org/component-library/alert';
-import Button from '@code-dot-org/component-library/button';
+import FontAwesomeV6Icon from '@code-dot-org/component-library/fontAwesomeV6Icon';
 import Link from '@code-dot-org/component-library/link';
-import {Typography} from '@mui/material';
+import {Typography, Button as MuiButton} from '@mui/material';
 import React, {useCallback, useEffect, useState} from 'react';
 
 import {EVENTS} from '@cdo/apps/metrics/AnalyticsConstants';
@@ -152,20 +152,26 @@ const SubmitProjectDialog: React.FunctionComponent<
           />
         </div>
         <div className={moduleStyles.bottomSectionButtons}>
-          <Button
-            iconLeft={{iconName: 'arrow-left'}}
+          <MuiButton
+            variant="outlined"
+            color="white"
+            size="medium"
             onClick={onGoBack}
-            type="secondary"
+            type="button"
+            startIcon={<FontAwesomeV6Icon iconName="arrow-left" />}
+          >
+            {i18n.submitProjectGallery_goBack()}
+          </MuiButton>
+          <MuiButton
+            variant="contained"
             color="white"
-            text={i18n.submitProjectGallery_goBack()}
-          />
-          <Button
+            size="medium"
             onClick={onSubmit}
-            type="primary"
-            color="white"
-            text={i18n.submit()}
+            type="button"
             disabled={isSubmitButtonDisabled}
-          />
+          >
+            {i18n.submit()}
+          </MuiButton>
         </div>
       </div>
     </AccessibleDialog>

--- a/apps/src/templates/studioHomepages/TopCourse.jsx
+++ b/apps/src/templates/studioHomepages/TopCourse.jsx
@@ -1,4 +1,4 @@
-import Button, {buttonColors} from '@code-dot-org/component-library/button';
+import {Button as MuiButton} from '@mui/material';
 import PropTypes from 'prop-types';
 import React, {Component} from 'react';
 import {connect} from 'react-redux';
@@ -33,24 +33,25 @@ class TopCourse extends Component {
           <div className={styles.details}>{i18n.topCourseExplanation()}</div>
         </div>
         <div className={`${styles.buttonBox} ${localeStyle}`}>
-          <Button
-            useAsLink={true}
+          <MuiButton
+            variant="outlined"
+            color="tertiary"
+            size="small"
+            aria-label={i18n.viewCourse()}
             href={linkToOverview}
-            ariaLabel={i18n.viewCourse()}
-            color={buttonColors.gray}
-            text={i18n.viewCourse()}
-            type="secondary"
-            size="s"
-          />
+          >
+            {i18n.viewCourse()}
+          </MuiButton>
           <span className={styles.lessonButton}>
-            <Button
-              useAsLink={true}
+            <MuiButton
+              variant="contained"
+              color="primary"
+              size="small"
+              aria-label={i18n.viewCourse()}
               href={linkToLesson}
-              ariaLabel={i18n.viewCourse()}
-              color={buttonColors.purple}
-              text={i18n.continueLesson()}
-              size="s"
-            />
+            >
+              {i18n.continueLesson()}
+            </MuiButton>
           </span>
         </div>
       </div>

--- a/apps/src/templates/studioHomepages/teacherHomepageV2/SectionCard.tsx
+++ b/apps/src/templates/studioHomepages/teacherHomepageV2/SectionCard.tsx
@@ -1,7 +1,7 @@
-import {Button} from '@code-dot-org/component-library/button';
+import FontAwesomeV6Icon from '@code-dot-org/component-library/fontAwesomeV6Icon';
 import {useSortable} from '@dnd-kit/sortable';
 import {CSS} from '@dnd-kit/utilities';
-import {Typography} from '@mui/material';
+import {Typography, IconButton as MuiIconButton} from '@mui/material';
 import React from 'react';
 
 import {Section} from '@cdo/apps/templates/teacherDashboard/types/teacherSectionTypes';
@@ -46,17 +46,18 @@ export const SectionCard: React.FC<SectionCardProps> = ({
       <div className={styles.sectionCardHeader}>
         <div className={styles.sectionCardHeaderLeft}>
           {!section.hidden && (
-            <Button
+            <MuiIconButton
               {...attributes}
               {...listeners}
+              variant="text"
+              color="tertiary"
+              size="small"
               onClick={() => {}} // Uses attributes and listeners to make the button draggable
-              isIconOnly
-              icon={{iconName: 'grip-vertical'}}
-              color="gray"
-              size="s"
               aria-label={i18n.dragSection()}
-              type="tertiary"
-            />
+              type="button"
+            >
+              <FontAwesomeV6Icon iconName="grip-vertical" />
+            </MuiIconButton>
           )}
           <SectionAvatar
             color={section.avatar_color || 0}

--- a/apps/test/unit/lab2/views/components/Instructions/ResourcePanel/VersionHistory/VersionHistoryPanelTest.tsx
+++ b/apps/test/unit/lab2/views/components/Instructions/ResourcePanel/VersionHistory/VersionHistoryPanelTest.tsx
@@ -359,12 +359,11 @@ describe('VersionHistoryPanel', () => {
       {timeout: 2000}
     );
 
-    // Click to expand auto-saved version group if necessary
+    // Collapse/expand control itself should be disabled
     const collapseButton = screen.getByRole('button', {
       name: /Show \d+ auto-saves/,
     });
-    const user = userEvent.setup();
-    await user.click(collapseButton);
+    expect(collapseButton).toBeDisabled();
 
     const restoreButton = screen.queryByRole('button', {name: 'Restore'});
     if (restoreButton) {


### PR DESCRIPTION
Reverts code-dot-org/code-dot-org#71135



Updated Sign Up flow social buttons styles. 

<img width="1295" height="721" alt="Знімок екрана 2026-03-04 о 11 57 23" src="https://github.com/user-attachments/assets/2ce546a0-5113-4bed-b445-f408bc07aae3" />
