### PR TITLE
chore: slightly increase max build memory

### DIFF
--- a/apps/build-in-parallel.sh
+++ b/apps/build-in-parallel.sh
@@ -4,13 +4,13 @@
 #
 # Environment variables:
 #   APPS_BUILD_WORKERS - Number of workers for thread-loader and TerserPlugin (default: 4)
-#   APPS_BUILD_MAX_MEMORY - Max memory in MB for Node.js heap (default: 8192)
+#   APPS_BUILD_MAX_MEMORY - Max memory in MB for Node.js heap (default: 10240 MB / 10 GB)
 
 set -e
 
 # Default values optimized for local development
 DEFAULT_WORKERS=4
-DEFAULT_MAX_MEMORY=8192
+DEFAULT_MAX_MEMORY=10240
 
 # Read environment variables or use defaults
 APPS_BUILD_WORKERS=${APPS_BUILD_WORKERS:-$DEFAULT_WORKERS}


### PR DESCRIPTION
Webpack is running close to a memory size limit which requires a lengthy amount of work to decrease bundle sizes to a more manageable size. To keep the pipeline clear, increase the maximum memory to 10 GB.