### PR TITLE
[Blockly Labs] Removing svg version attributes

### DIFF
--- a/apps/src/blockly/addons/cdoAngleHelper.ts
+++ b/apps/src/blockly/addons/cdoAngleHelper.ts
@@ -168,7 +168,6 @@ class CdoAngleHelper {
     this.svg_ = BlocklyCore.utils.dom.createSvgElement(
       'svg',
       {
-        version: '1.1',
         height: `${this.height_}px`,
         width: `${this.width_}px`,
         style: 'background: rgb(255, 255, 255);',

--- a/apps/src/blockly/blocklyWrapper.ts
+++ b/apps/src/blockly/blocklyWrapper.ts
@@ -459,7 +459,6 @@ function initializeBlocklyWrapper(blocklyInstance: BlocklyCoreInstance) {
         xmlns: 'http://www.w3.org/2000/svg',
         'xmlns:html': 'http://www.w3.org/1999/xhtml',
         'xmlns:xlink': 'http://www.w3.org/1999/xlink',
-        version: '1.1',
         class: `${Renderers.DEFAULT}-renderer modern-theme readOnlyBlockSpace injectionDiv`,
       },
       null

--- a/apps/src/bounce/BounceVisualizationColumn.jsx
+++ b/apps/src/bounce/BounceVisualizationColumn.jsx
@@ -21,7 +21,7 @@ var BounceVisualizationColumn = function () {
     <span>
       <ProtectedVisualizationDiv>
         <SwipePrompt />
-        <svg version="1.1" id="svgBounce" />
+        <svg id="svgBounce" />
       </ProtectedVisualizationDiv>
       <GameButtons>
         <ArrowButtons />

--- a/apps/src/flappy/FlappyVisualizationColumn.jsx
+++ b/apps/src/flappy/FlappyVisualizationColumn.jsx
@@ -12,7 +12,7 @@ const FlappyVisualizationColumn = ({showFinishButton}) => {
   return (
     <span>
       <ProtectedVisualizationDiv>
-        <svg version="1.1" id="svgFlappy" />
+        <svg id="svgFlappy" />
       </ProtectedVisualizationDiv>
       <GameButtons>
         {showFinishButton && (

--- a/apps/src/maze/Visualization.jsx
+++ b/apps/src/maze/Visualization.jsx
@@ -11,7 +11,7 @@ import {LOOK_ID, SVG_ID} from './constants';
 // include the option to not use ProtectedVisualizationDiv.
 const Visualization = function ({useProtectedDiv = true}) {
   const innerComponent = (
-    <svg version="1.1" id={SVG_ID}>
+    <svg id={SVG_ID}>
       <g id={LOOK_ID}>
         <path d="M 0,-15 a 15 15 0 0 1 15 15" />
         <path d="M 0,-35 a 35 35 0 0 1 35 35" />

--- a/apps/src/studio/StudioVisualizationColumn.jsx
+++ b/apps/src/studio/StudioVisualizationColumn.jsx
@@ -19,7 +19,7 @@ var StudioVisualizationColumn = function (props) {
     <span>
       <ProtectedVisualizationDiv>
         <SwipePrompt />
-        <svg version="1.1" id="svgStudio" />
+        <svg id="svgStudio" />
         <VisualizationOverlay width={400} height={400}>
           <CrosshairOverlay />
           <TooltipOverlay

--- a/apps/src/templates/PuzzleRatingButtons.jsx
+++ b/apps/src/templates/PuzzleRatingButtons.jsx
@@ -84,7 +84,6 @@ class PuzzleRatingButtons extends Component {
           onClick={this.like}
         >
           <svg
-            version="1.1"
             xmlns="http://www.w3.org/2000/svg"
             xmlnsXlink="http://www.w3.org/1999/xlink"
             x="0px"
@@ -108,7 +107,6 @@ class PuzzleRatingButtons extends Component {
           onClick={this.dislike}
         >
           <svg
-            version="1.1"
             xmlns="http://www.w3.org/2000/svg"
             xmlnsXlink="http://www.w3.org/1999/xlink"
             x="0px"

--- a/apps/src/templates/VisualizationOverlay.jsx
+++ b/apps/src/templates/VisualizationOverlay.jsx
@@ -129,7 +129,6 @@ export class VisualizationOverlay extends React.Component {
         ref="root"
         id="visualizationOverlay"
         className={this.props.className}
-        baseProfile="full"
         width={this.props.width}
         height={this.props.height}
         style={{left: 'auto'}}

--- a/apps/src/templates/VisualizationOverlay.jsx
+++ b/apps/src/templates/VisualizationOverlay.jsx
@@ -129,7 +129,6 @@ export class VisualizationOverlay extends React.Component {
         ref="root"
         id="visualizationOverlay"
         className={this.props.className}
-        version="1.1"
         baseProfile="full"
         width={this.props.width}
         height={this.props.height}

--- a/apps/src/turtle/ArtistVisualizationColumn.jsx
+++ b/apps/src/turtle/ArtistVisualizationColumn.jsx
@@ -26,7 +26,7 @@ export default class ArtistVisualizationColumn extends React.Component {
             <SaveImageButton displayCanvas={this.props.displayCanvas} />
           )}
           <div id="slider-cell">
-            <svg id="slider" version="1.1" width="150" height="50">
+            <svg id="slider" width="150" height="50">
               {/* Slow icon. */}
               <clipPath id="slowClipPath">
                 <rect width="26" height="12" x="5" y="14" />

--- a/apps/test/unit/templates/VisualizationOverlay.karma.test.js
+++ b/apps/test/unit/templates/VisualizationOverlay.karma.test.js
@@ -67,7 +67,6 @@ describe('VisualizationOverlay', () => {
   function verifySvg(element) {
     const svg = element.find('svg').first();
     expect(svg.props().id).to.equal('visualizationOverlay');
-    expect(svg.props().baseProfile).to.equal('full');
     expect(svg.props().width).to.equal(TEST_APP_WIDTH);
     expect(svg.props().height).to.equal(TEST_APP_HEIGHT);
     expect(svg.props().viewBox).to.equal(

--- a/apps/test/unit/templates/VisualizationOverlay.karma.test.js
+++ b/apps/test/unit/templates/VisualizationOverlay.karma.test.js
@@ -67,7 +67,6 @@ describe('VisualizationOverlay', () => {
   function verifySvg(element) {
     const svg = element.find('svg').first();
     expect(svg.props().id).to.equal('visualizationOverlay');
-    expect(svg.props().version).to.equal('1.1');
     expect(svg.props().baseProfile).to.equal('full');
     expect(svg.props().width).to.equal(TEST_APP_WIDTH);
     expect(svg.props().height).to.equal(TEST_APP_HEIGHT);


### PR DESCRIPTION
Our VPAT is strict and is catching that the svg version attribute is [now deprecated](https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Attribute/version) and no longer recommended. This PR removes the instances I could find of us using version. 

<img width="909" height="302" alt="Screenshot 2026-03-04 at 11 31 14 AM" src="https://github.com/user-attachments/assets/d2948cc2-3ca5-4ca3-94ef-ed3f9c3eab15" />



## Links

- Jira: https://codedotorg.atlassian.net/browse/SL-1615
- VPAT: https://app.getstark.co/organization/ced5459c-437e-48a0-8737-90ad0ef005c0/projects/aiOk8eUknKEfWPEE3SIO/assets/5bAQbcRUbbfgXK1uQydr/reports/aYT466VUIzN0OeY9noOF

## Testing story
<!-- How was this tested? Manual steps, adhoc links, automated tests, or why testing isn't needed. -->



## Deployment notes
<!-- Delete this section if it's a standard merge-and-deploy.
     Otherwise: migrations, feature flags, coordination, caching impacts, etc. -->



## Privacy and security
<!-- Delete this section if there is no privacy/security impact.
     Otherwise: new PII, auth changes, API surface changes, etc. -->

