### PR TITLE
Web Lab 2: Fix instruction drawer glitching when resource panel resized

### DIFF
--- a/apps/src/lab2/views/components/Instructions/ResourcePanel/AiTutorChatWithInstructionDrawer.tsx
+++ b/apps/src/lab2/views/components/Instructions/ResourcePanel/AiTutorChatWithInstructionDrawer.tsx
@@ -185,7 +185,7 @@ const AiTutorChatWithInstructionDrawer: React.FunctionComponent<
         return;
       }
 
-      // Auto-adjust drawer height when new content heigh is less than the current drawer height.
+      // Auto-adjust drawer height when new content height is less than the current drawer height.
       // This will remove a gap betwen instructions and drawer's edge.
       if (contentHeight < currentHeight) {
         setRawInstructionsHeight(

--- a/apps/src/lab2/views/components/Instructions/ResourcePanel/AiTutorChatWithInstructionDrawer.tsx
+++ b/apps/src/lab2/views/components/Instructions/ResourcePanel/AiTutorChatWithInstructionDrawer.tsx
@@ -54,6 +54,10 @@ const AiTutorChatWithInstructionDrawer: React.FunctionComponent<
   const containerRef = useRef<HTMLDivElement>(null);
   const instructionsContentRef = useRef<HTMLDivElement>(null);
   const instructionsHeightAtDragStartRef = useRef<number | null>(null);
+  const hasSetInitialHeightFromContentRef = useRef(false);
+  const rawInstructionsHeightRef = useRef<number>(
+    DEFAULT_INITIAL_INSTRUCTIONS_HEIGHT
+  );
   const [chatHeight, setChatHeight] = useState<number | undefined>(undefined);
   const [instructionsHeight, setInstructionsHeight] = useState<
     number | undefined
@@ -142,6 +146,18 @@ const AiTutorChatWithInstructionDrawer: React.FunctionComponent<
     setIsCollapsed(isCollapsedByDefault);
   }, [isCollapsedByDefault]);
 
+  // Reset so that when drawer is expanded again, we set height from content.
+  useEffect(() => {
+    if (isCollapsed) {
+      hasSetInitialHeightFromContentRef.current = false;
+    }
+  }, [isCollapsed]);
+
+  // Keep ref in sync with current height.
+  useEffect(() => {
+    rawInstructionsHeightRef.current = rawInstructionsHeight;
+  }, [rawInstructionsHeight]);
+
   // Measure the instructions content height on load and when it changes,
   // (e.g., details elements expanded/collapsed), and set the drawer height to match.
   useEffect(() => {
@@ -157,13 +173,24 @@ const AiTutorChatWithInstructionDrawer: React.FunctionComponent<
 
     const updateMaxHeight = () => {
       const contentHeight = instructionsContentElement.scrollHeight;
+      const currentHeight = rawInstructionsHeightRef.current;
+      setMaxInstructionsHeight(contentHeight);
 
-      if (contentHeight > 0) {
-        // Include drawer padding so the scroll area height matches content (no extra scroll).
-        const drawerHeight =
-          contentHeight + INSTRUCTIONS_DRAWER_VERTICAL_PADDING_PX;
-        setMaxInstructionsHeight(drawerHeight);
-        setRawInstructionsHeight(drawerHeight);
+      // Set initial drawer height to full content height (maxInstructionsHeight).
+      if (!hasSetInitialHeightFromContentRef.current) {
+        hasSetInitialHeightFromContentRef.current = true;
+        setRawInstructionsHeight(
+          contentHeight + INSTRUCTIONS_DRAWER_VERTICAL_PADDING_PX
+        );
+        return;
+      }
+
+      // Auto-adjust drawer height when new content heigh is less than the current drawer height.
+      // This will remove a gap betwen instructions and drawer's edge.
+      if (contentHeight < currentHeight) {
+        setRawInstructionsHeight(
+          contentHeight + INSTRUCTIONS_DRAWER_VERTICAL_PADDING_PX
+        );
       }
     };
 


### PR DESCRIPTION
<!--
  Summary of the change: background, motivation, and context.
  Include screenshots, videos, or before/after comparisons for UI changes.
-->
This PR updates the logic for resizing the instructions drawer's height. Currently, when a user manually resizes the instructions drawer and then resizes the resource panel's width, the drawer snaps back to its full content height, overriding the user's resize resulting in an unexpected glitching effect.

To resolve this, the drawer height is now only set to full content height on initial open. Subsequent content changes (e.g. expanding/collapsing details elements) only adjust the drawer height if the new content is smaller than the current height, to remove any gap at the bottom. Otherwise, the drawer height remains intact.

This essentially reverts this [last commit](38e0069b12308e25f09c468a4cfd8bb67e7cf6dc) from https://github.com/code-dot-org/code-dot-org/pull/70960 (but keeping the padding).

Thanks to @molly-moen for first reporting!

## Before update

https://github.com/user-attachments/assets/6378544c-a693-472c-a84d-fcafbba2d32d


https://github.com/user-attachments/assets/81077088-b58d-4c8a-bf70-fab7307bce4d




## After update


https://github.com/user-attachments/assets/7ea6f0e1-d076-4491-ad20-82f2016ca09b


https://github.com/user-attachments/assets/81dd92ca-98c1-4c8c-93d3-ceb10e07e5a7



## Links
<!-- Jira tickets, design docs, Slack threads, related PRs, etc. -->

- Jira: https://codedotorg.atlassian.net/browse/AFL-506
- [Slack post reporting bug](https://codedotorg.slack.com/archives/C06JELCAPT9/p1772561584037559)

## Testing story
<!-- How was this tested? Manual steps, adhoc links, automated tests, or why testing isn't needed. -->

Tested locally on `weblab2` levels including instructions with expandable sections and predict levels.

## Deployment notes
<!-- Delete this section if it's a standard merge-and-deploy.
     Otherwise: migrations, feature flags, coordination, caching impacts, etc. -->



## Privacy and security
<!-- Delete this section if there is no privacy/security impact.
     Otherwise: new PII, auth changes, API surface changes, etc. -->

