### PR TITLE
UI Fix for spritelab picker

### DIFF
--- a/apps/src/blockly/addons/cdoCss.ts
+++ b/apps/src/blockly/addons/cdoCss.ts
@@ -14,8 +14,8 @@ export default function initializeCss(blocklyWrapper: BlocklyWrapperType) {
       margin: 5px;
     }
     .blocklyFieldGrid .blocklyFieldGridItem {
-      border: none;
-      padding: 0px;
+      border: none !important;
+      padding: 0px !important;
       margin: 0px;
     }
     .blocklyFieldGrid .blocklyFieldGridItem img {

--- a/apps/src/blockly/blocklyWrapper.ts
+++ b/apps/src/blockly/blocklyWrapper.ts
@@ -33,7 +33,6 @@ import initializeCdoConstants from './addons/cdoConstants';
 import initializeCss from './addons/cdoCss';
 import CdoFieldColour from './addons/cdoFieldColour';
 import CdoFieldDropdown from './addons/cdoFieldDropdown';
-import {CdoFieldImageDropdown} from './addons/cdoFieldImageDropdown';
 import CdoFieldLabel from './addons/cdoFieldLabel';
 import CdoFieldNumber from './addons/cdoFieldNumber';
 import CdoFieldParameter from './addons/cdoFieldParameter';
@@ -232,7 +231,6 @@ function initializeBlocklyWrapper(blocklyInstance: BlocklyCoreInstance) {
     ['field_number', CdoFieldNumber],
     ['field_parameter', CdoFieldParameter],
     ['field_variable', CdoFieldVariable],
-    ['field_image_dropdown', CdoFieldImageDropdown],
   ];
   // Tell Blockly to use our custom versions of fields
   fieldsToRegister.forEach(override => {

--- a/apps/src/blockly/blocklyWrapper.ts
+++ b/apps/src/blockly/blocklyWrapper.ts
@@ -33,6 +33,7 @@ import initializeCdoConstants from './addons/cdoConstants';
 import initializeCss from './addons/cdoCss';
 import CdoFieldColour from './addons/cdoFieldColour';
 import CdoFieldDropdown from './addons/cdoFieldDropdown';
+import {CdoFieldImageDropdown} from './addons/cdoFieldImageDropdown';
 import CdoFieldLabel from './addons/cdoFieldLabel';
 import CdoFieldNumber from './addons/cdoFieldNumber';
 import CdoFieldParameter from './addons/cdoFieldParameter';
@@ -231,6 +232,7 @@ function initializeBlocklyWrapper(blocklyInstance: BlocklyCoreInstance) {
     ['field_number', CdoFieldNumber],
     ['field_parameter', CdoFieldParameter],
     ['field_variable', CdoFieldVariable],
+    ['field_image_dropdown', CdoFieldImageDropdown],
   ];
   // Tell Blockly to use our custom versions of fields
   fieldsToRegister.forEach(override => {


### PR DESCRIPTION
After #71119 we noticed the spritelab picker spacing got off. It seems to be due with css imports getting reordered and the border and spacing we set getting overridden. I set that css to be `!important` to ensure we have the right border and spacing on the field images

## Before
<img width="490" height="475" alt="Screenshot 2026-03-04 at 3 08 58 PM" src="https://github.com/user-attachments/assets/793a2653-09d4-46a9-8b77-03708e9a684b" />

## After
<img width="490" height="475" alt="Screenshot 2026-03-04 at 3 09 02 PM" src="https://github.com/user-attachments/assets/45336a8f-ff57-44cf-8309-40cd608f3f2f" />




## Links
- [slack](https://codedotorg.slack.com/archives/C043ZKQ4BS6/p1772663361492409)

## Testing story
Tested locally

