### PR TITLE
AI Chat: handle gemini image filtering

### DIFF
--- a/apps/src/aiGateway/aiSdkCompatibleGateway.ts
+++ b/apps/src/aiGateway/aiSdkCompatibleGateway.ts
@@ -59,16 +59,6 @@ const rehydrateAIResponse = <TOOLS extends SDKTools, OUTPUT extends SDKOutput>(
     toolCalls: serialized.toolCalls ?? [],
     toolResults: serialized.toolResults ?? [],
     warnings: serialized.warnings ?? [],
-
-    get text() {
-      if (serialized.text === undefined) {
-        throw new Error(
-          'No text was generated. The model likely finished due to tool calls.'
-        );
-      }
-      return serialized.text;
-    },
-
     files: serialized.files?.map(file => ({
       mediaType: file.mediaType,
       base64: file.base64,

--- a/apps/src/aichat/api/client/generateChatResponse.ts
+++ b/apps/src/aichat/api/client/generateChatResponse.ts
@@ -57,11 +57,29 @@ export async function generateChatResponse(
   }
 
   // Generate a response with the model.
-  const {text, files} = await generateText({
+  const {text, files, finishReason, response} = await generateText({
     model: getModel(modelParameters.selectedModelId),
     messages,
     temperature: modelParameters.temperature,
   });
+
+  if (['content-filter', 'other'].includes(finishReason)) {
+    // response.body is expected to be an object with a "candidates" array
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const candidate = (response.body as any)?.candidates?.[0];
+
+    return {
+      response: `Blocked reason: ${candidate?.finishReason}. ${candidate?.finishMessage}`,
+      status: AiRequestExecutionStatus.MODEL_PROFANITY,
+    };
+  }
+
+  if (finishReason !== 'stop') {
+    return {
+      response: `Unexpected finish reason: ${finishReason}`,
+      status: AiRequestExecutionStatus.FAILURE,
+    };
+  }
 
   for (const file of files) {
     if (file.mediaType.startsWith('image/')) {


### PR DESCRIPTION
Accompanies https://github.com/code-dot-org/ai-gateway/pull/9. If Gemini detects that it generated an inappropriate message, it will generate a finishReason of 'content-filter' or 'other'. This updates our client code to handle these cases.

## Testing story
Tested locally with deployed worker code.