### PR TITLE
Restrict Full Engineer Redshift Permissions

### DIFF
--- a/aws/cloudformation/iam.yml.erb
+++ b/aws/cloudformation/iam.yml.erb
@@ -22,6 +22,9 @@ Parameters:
     Type: CommaDelimitedList
     Default: 6938fd4d98bab03faadb97b34396831e3780aea1, 1c58a3a8518e8759bf075b76b750d4f2df264fcd
     Description: List of thumbprints of GitHub intermediate certificates that sign the certificates used by GitHub Actions.
+  RedshiftAdminSQLUser:
+    Type: String
+    Description: The admin (`SUPERUSER`) SQL user for the Redshift cluster.
 Resources:
   # Admin Service Role for managing all resources in CloudFormation stacks.
   # Only admins can update stacks using this service role.
@@ -674,93 +677,100 @@ roles.each do |name, config| %>
               - !Sub arn:aws:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:adhoc/cdo/*
 
   EngineerDataPolicy:
-      Type: AWS::IAM::ManagedPolicy
-      Properties:
-        ManagedPolicyName: EngineersDataPolicy
-        Path: /engineering/
-        Description: Prevent accidental or malicious deletion of production data in S3, Aurora databases, etc.
-        PolicyDocument:
-          Version: 2012-10-17
-          Statement:
-            - Sid: DenyS3BucketDestructiveOperations
-              Effect: Deny
-              Action:
-                - s3:DeleteBucket
-                - s3:DeleteBucketPolicy
-                - s3:DeleteBucketWebsite
-                - s3:PutBucketAcl
-                - s3:PutBucketPolicy
-                - s3:PutBucketPublicAccessBlock
-                - s3:PutLifecycleConfiguration
+    Type: AWS::IAM::ManagedPolicy
+    Properties:
+      ManagedPolicyName: EngineersDataPolicy
+      Path: /engineering/
+      Description: Prevent accidental or malicious deletion of production data in S3, Aurora databases, etc.
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Sid: DenyS3BucketDestructiveOperations
+            Effect: Deny
+            Action:
+              - s3:DeleteBucket
+              - s3:DeleteBucketPolicy
+              - s3:DeleteBucketWebsite
+              - s3:PutBucketAcl
+              - s3:PutBucketPolicy
+              - s3:PutBucketPublicAccessBlock
+              - s3:PutLifecycleConfiguration
 
-                # S3 Batch Operations - prevent mass operations
-                - s3:CreateJob
-                - s3:UpdateJobPriority
-                - s3:UpdateJobStatus
+              # S3 Batch Operations - prevent mass operations
+              - s3:CreateJob
+              - s3:UpdateJobPriority
+              - s3:UpdateJobStatus
 
-                - s3:PutBucketVersioning
-                - s3:PutReplicationConfiguration
-                - s3:PutBucketCORS
-                - s3:PutBucketLogging
-                - s3:PutEncryptionConfiguration
-                - s3:BypassGovernanceRetention
-                - s3:DeleteObjectVersionTagging
-                - s3:PutObjectLegalHold
-                - s3:PutObjectRetention
-              NotResource:
-                - arn:aws:s3:::org.cdn-code.adhoc-*.*
-                - arn:aws:s3:::org.cdn-code.adhoc-*.*/*
-            - Sid: DenyDestructiveRDSOperationsOnProduction
-              Effect: Deny
-              Action:
-                - rds:DeleteDBInstance
-                - rds:DeleteDBCluster
-                - rds:DeleteDBSnapshot
-                - rds:DeleteDBClusterSnapshot
-                - rds:DeleteDBInstanceAutomatedBackup
+              - s3:PutBucketVersioning
+              - s3:PutReplicationConfiguration
+              - s3:PutBucketCORS
+              - s3:PutBucketLogging
+              - s3:PutEncryptionConfiguration
+              - s3:BypassGovernanceRetention
+              - s3:DeleteObjectVersionTagging
+              - s3:PutObjectLegalHold
+              - s3:PutObjectRetention
+            NotResource:
+              - arn:aws:s3:::org.cdn-code.adhoc-*.*
+              - arn:aws:s3:::org.cdn-code.adhoc-*.*/*
+          - Sid: DenyDestructiveRDSOperationsOnProduction
+            Effect: Deny
+            Action:
+              - rds:DeleteDBInstance
+              - rds:DeleteDBCluster
+              - rds:DeleteDBSnapshot
+              - rds:DeleteDBClusterSnapshot
+              - rds:DeleteDBInstanceAutomatedBackup
 
-                - rds:StopDBInstance
-                - rds:StopDBCluster
-                - rds:RebootDBInstance
-                - rds:RebootDBCluster
+              - rds:StopDBInstance
+              - rds:StopDBCluster
+              - rds:RebootDBInstance
+              - rds:RebootDBCluster
 
-                - rds:ModifyDBInstance
-                - rds:ModifyDBCluster
-                - rds:ModifyDBParameterGroup
-                - rds:ModifyDBClusterParameterGroup
-                - rds:ResetDBParameterGroup
-                - rds:ResetDBClusterParameterGroup
+              - rds:ModifyDBInstance
+              - rds:ModifyDBCluster
+              - rds:ModifyDBParameterGroup
+              - rds:ModifyDBClusterParameterGroup
+              - rds:ResetDBParameterGroup
+              - rds:ResetDBClusterParameterGroup
 
-                - rds:RestoreDBInstanceFromDBSnapshot
-                - rds:RestoreDBClusterFromSnapshot
-                - rds:RestoreDBInstanceToPointInTime
-                - rds:RestoreDBClusterToPointInTime
+              - rds:RestoreDBInstanceFromDBSnapshot
+              - rds:RestoreDBClusterFromSnapshot
+              - rds:RestoreDBInstanceToPointInTime
+              - rds:RestoreDBClusterToPointInTime
 
-                - rds:FailoverDBCluster
-                - rds:BacktrackDBCluster
-                - rds:ModifyCurrentDBClusterCapacity
+              - rds:FailoverDBCluster
+              - rds:BacktrackDBCluster
+              - rds:ModifyCurrentDBClusterCapacity
 
-              Resource:
-                - !Sub 'arn:aws:rds:*:${AWS::AccountId}:db:*'
-                - !Sub 'arn:aws:rds:*:${AWS::AccountId}:cluster:*'
-                - !Sub 'arn:aws:rds:*:${AWS::AccountId}:snapshot:*'
-                - !Sub 'arn:aws:rds:*:${AWS::AccountId}:cluster-snapshot:*'
-              Condition:
-                StringEquals:
-                  'aws:ResourceTag/environment': 'production'
-            - Sid: DenyTagModificationOnProductionRDS
-              Effect: Deny
-              Action:
-                - rds:RemoveTagsFromResource
-                - rds:AddTagsToResource
-              Resource:
-                - !Sub 'arn:aws:rds:*:${AWS::AccountId}:db:*'
-                - !Sub 'arn:aws:rds:*:${AWS::AccountId}:cluster:*'
-                - !Sub 'arn:aws:rds:*:${AWS::AccountId}:snapshot:*'
-                - !Sub 'arn:aws:rds:*:${AWS::AccountId}:cluster-snapshot:*'
-              Condition:
-                StringEquals:
-                  'aws:ResourceTag/environment': 'production'
+            Resource:
+              - !Sub 'arn:aws:rds:*:${AWS::AccountId}:db:*'
+              - !Sub 'arn:aws:rds:*:${AWS::AccountId}:cluster:*'
+              - !Sub 'arn:aws:rds:*:${AWS::AccountId}:snapshot:*'
+              - !Sub 'arn:aws:rds:*:${AWS::AccountId}:cluster-snapshot:*'
+            Condition:
+              StringEquals:
+                'aws:ResourceTag/environment': 'production'
+          - Sid: DenyTagModificationOnProductionRDS
+            Effect: Deny
+            Action:
+              - rds:RemoveTagsFromResource
+              - rds:AddTagsToResource
+            Resource:
+              - !Sub 'arn:aws:rds:*:${AWS::AccountId}:db:*'
+              - !Sub 'arn:aws:rds:*:${AWS::AccountId}:cluster:*'
+              - !Sub 'arn:aws:rds:*:${AWS::AccountId}:snapshot:*'
+              - !Sub 'arn:aws:rds:*:${AWS::AccountId}:cluster-snapshot:*'
+            Condition:
+              StringEquals:
+                'aws:ResourceTag/environment': 'production'
+          - Sid: DenyRedshiftSuperuserAccess
+            Effect: Deny
+            Action:
+              - redshift:GetClusterCredentials
+              - redshift:GetClusterCredentialsWithIAM
+            Resource:
+              - !Sub 'arn:aws:redshift:*:${AWS::AccountId}:dbuser:*/${RedshiftAdminSQLUser}'
 
   ContributorSecretsPolicy:
     Type: AWS::IAM::ManagedPolicy


### PR DESCRIPTION
https://codedotorg.atlassian.net/browse/INF-1793

Restrict engineers (except Infrastructure Engineers who have admin IAM permissions) from authenticating to the Redshift cluster with the admin `SUPERUSER` SQL user.


## Testing story
```bash
code-dot-org $ export AWS_PROFILE=codeorg-admin
code-dot-org $ bundle exec rake stack:iam:validate RAILS_ENV=production ADMIN=true REDSHIFT_ADMIN_SQL_USER=[REDACTED]
Finished stack:iam:environment (less than a minute)
Parameters:
RedshiftAdminSQLUser: [REDACTED]
Pending update for stack `IAM`:
Modify EngineerDataPolicy [AWS::IAM::ManagedPolicy] Properties (PolicyDocument, PolicyDocument)
Finished stack:iam:validate (less than a minute)
```


## Deployment notes
<!-- Delete this section if it's a standard merge-and-deploy.
     Otherwise: migrations, feature flags, coordination, caching impacts, etc. -->



## Privacy and security

Improves the security of #71058 

