### PR TITLE
Add Statsig analytics for model output image moderation

### DIFF
--- a/apps/src/aichat/api/client/generateChatResponse.ts
+++ b/apps/src/aichat/api/client/generateChatResponse.ts
@@ -1,6 +1,8 @@
 import {type ModelMessage} from 'ai';
 
 import {generateText} from '@cdo/apps/aiGateway/generateTextThroughProxyOrGateway';
+import {sendLab2AnalyticsEvent} from '@cdo/apps/lab2/utils';
+import {EVENTS} from '@cdo/apps/metrics/AnalyticsConstants';
 import {AiRequestExecutionStatus} from '@cdo/generated-scripts/sharedConstants';
 
 import {
@@ -83,6 +85,7 @@ export async function generateChatResponse(
 
   for (const file of files) {
     if (file.mediaType.startsWith('image/')) {
+      sendLab2AnalyticsEvent(EVENTS.MODEL_OUTPUT_IMAGE_CREATED);
       const ext = file.mediaType.split('/')[1];
       const imageFile = generatedFileToImageFile(file, ext);
       const modelImageSafe = await isModelOutputImageSafe(imageFile, ext);

--- a/apps/src/aichat/api/client/generateChatResponse.ts
+++ b/apps/src/aichat/api/client/generateChatResponse.ts
@@ -19,7 +19,7 @@ import {
   formatSystemMessages,
 } from './helpers/messageHelpers';
 import {getModel} from './helpers/modelHelpers';
-import {isTextSafe, isImageSafe} from './helpers/safetyHelpers';
+import {isTextSafe, isModelOutputImageSafe} from './helpers/safetyHelpers';
 
 /**
  * Performs all the steps necessary to generate a chat response:
@@ -85,7 +85,7 @@ export async function generateChatResponse(
     if (file.mediaType.startsWith('image/')) {
       const ext = file.mediaType.split('/')[1];
       const imageFile = generatedFileToImageFile(file, ext);
-      const modelImageSafe = await isImageSafe(imageFile, ext);
+      const modelImageSafe = await isModelOutputImageSafe(imageFile, ext);
       if (!modelImageSafe) {
         return {
           response: text,

--- a/apps/src/aichat/api/client/generateChatResponse.ts
+++ b/apps/src/aichat/api/client/generateChatResponse.ts
@@ -12,7 +12,11 @@ import {
   PendingChatMessage,
 } from '../../types';
 
-import {fileToAsset, fileToImage} from './helpers/fileHelpers';
+import {
+  fileToAsset,
+  fileToImage,
+  prepareGeneratedFile,
+} from './helpers/fileHelpers';
 import {
   formatChatMessage,
   formatSystemMessages,
@@ -83,13 +87,8 @@ export async function generateChatResponse(
   // Upload generated assets, if any.
   const assets: ChatAsset[] = [];
   for (const file of files) {
-    const fileBuffer = file.uint8Array.buffer.slice(
-      file.uint8Array.byteOffset,
-      file.uint8Array.byteOffset + file.uint8Array.byteLength
-    ) as ArrayBuffer;
-    const mediaType = file.mediaType;
-    const extension = mediaType.split('/')[1];
-    const filename = `generated-file-${crypto.randomUUID()}.${extension}`;
+    const {filename, fileBuffer, mediaType, extension} =
+      prepareGeneratedFile(file);
 
     const asset = await fileToAsset(
       filename,

--- a/apps/src/aichat/api/client/generateChatResponse.ts
+++ b/apps/src/aichat/api/client/generateChatResponse.ts
@@ -12,10 +12,7 @@ import {
   PendingChatMessage,
 } from '../../types';
 
-import {
-  generatedFileToAsset,
-  generatedFileToImageFile,
-} from './helpers/fileHelpers';
+import {fileToAsset, fileToImage} from './helpers/fileHelpers';
 import {
   formatChatMessage,
   formatSystemMessages,
@@ -83,12 +80,29 @@ export async function generateChatResponse(
     };
   }
 
+  // Upload generated assets, if any.
+  const assets: ChatAsset[] = [];
   for (const file of files) {
-    if (file.mediaType.startsWith('image/')) {
+    const fileBuffer = file.uint8Array.buffer.slice(
+      file.uint8Array.byteOffset,
+      file.uint8Array.byteOffset + file.uint8Array.byteLength
+    ) as ArrayBuffer;
+    const mediaType = file.mediaType;
+    const extension = mediaType.split('/')[1];
+    const filename = `generated-file-${crypto.randomUUID()}.${extension}`;
+
+    const asset = await fileToAsset(
+      filename,
+      fileBuffer,
+      mediaType,
+      buildAssetUrl
+    );
+    assets.push(asset);
+
+    if (mediaType.startsWith('image/')) {
       sendLab2AnalyticsEvent(EVENTS.MODEL_OUTPUT_IMAGE_CREATED);
-      const ext = file.mediaType.split('/')[1];
-      const imageFile = generatedFileToImageFile(file, ext);
-      const modelImageSafe = await isModelOutputImageSafe(imageFile, ext);
+      const imageFile = fileToImage(filename, fileBuffer, mediaType);
+      const modelImageSafe = await isModelOutputImageSafe(imageFile, extension);
       if (!modelImageSafe) {
         return {
           response: text,
@@ -102,13 +116,6 @@ export async function generateChatResponse(
   const modelOutputSafe = await isTextSafe(text);
   if (!modelOutputSafe) {
     return {response: text, status: AiRequestExecutionStatus.MODEL_PROFANITY};
-  }
-
-  // Upload generated assets, if any.
-  const assets: ChatAsset[] = [];
-  for (const file of files) {
-    const asset = await generatedFileToAsset(file, buildAssetUrl);
-    assets.push(asset);
   }
 
   return {response: text, assets, status: AiRequestExecutionStatus.SUCCESS};

--- a/apps/src/aichat/api/client/helpers/fileHelpers.ts
+++ b/apps/src/aichat/api/client/helpers/fileHelpers.ts
@@ -1,4 +1,4 @@
-import {type FilePart, type GeneratedFile} from 'ai';
+import {type FilePart} from 'ai';
 
 import {AssetSource, ChatAsset} from '@cdo/apps/aichat/types';
 import HttpClient from '@cdo/apps/util/HttpClient';
@@ -45,12 +45,12 @@ export async function assetToFilePart(
 /**
  * Converts a model generated file to a ChatAsset by uploading the file's contents to the user's project.
  */
-export async function generatedFileToAsset(
-  file: GeneratedFile,
+export async function fileToAsset(
+  filename: string,
+  fileBuffer: ArrayBuffer,
+  mediaType: string,
   buildAssetUrl: (asset: ChatAsset) => string
 ): Promise<ChatAsset> {
-  const extension = file.mediaType.split('/')[1];
-  const filename = `generated-file-${Date.now()}.${extension}`;
   const asset: ChatAsset = {
     filename,
     source: AssetSource.PROJECT,
@@ -58,25 +58,18 @@ export async function generatedFileToAsset(
   const assetUrl = buildAssetUrl(asset);
 
   // Upload file contents to assetUrl
-  const arrayBuffer = file.uint8Array.buffer.slice(
-    file.uint8Array.byteOffset,
-    file.uint8Array.byteOffset + file.uint8Array.byteLength
-  ) as ArrayBuffer;
-  await HttpClient.put(assetUrl, arrayBuffer, true, {
-    'Content-Type': file.mediaType,
+  await HttpClient.put(assetUrl, fileBuffer, true, {
+    'Content-Type': mediaType,
   });
 
   return asset;
 }
 
-export function generatedFileToImageFile(
-  file: GeneratedFile,
-  ext: string
+export function fileToImage(
+  filename: string,
+  fileBuffer: ArrayBuffer,
+  mediaType: string
 ): File {
-  const arrayBuffer = file.uint8Array.buffer.slice(
-    file.uint8Array.byteOffset,
-    file.uint8Array.byteOffset + file.uint8Array.byteLength
-  ) as ArrayBuffer;
-  const blob = new Blob([arrayBuffer], {type: file.mediaType});
-  return new File([blob], `image.${ext}`, {type: file.mediaType});
+  const blob = new Blob([fileBuffer], {type: mediaType});
+  return new File([blob], filename, {type: mediaType});
 }

--- a/apps/src/aichat/api/client/helpers/fileHelpers.ts
+++ b/apps/src/aichat/api/client/helpers/fileHelpers.ts
@@ -1,4 +1,4 @@
-import {type FilePart} from 'ai';
+import {type FilePart, type GeneratedFile} from 'ai';
 
 import {AssetSource, ChatAsset} from '@cdo/apps/aichat/types';
 import HttpClient from '@cdo/apps/util/HttpClient';
@@ -72,4 +72,26 @@ export function fileToImage(
 ): File {
   const blob = new Blob([fileBuffer], {type: mediaType});
   return new File([blob], filename, {type: mediaType});
+}
+
+export interface PreparedFile {
+  filename: string;
+  fileBuffer: ArrayBuffer;
+  mediaType: string;
+  extension: string;
+}
+
+/**
+ * Extracts the buffer and derives filename/extension from a model-generated file,
+ * ready to be passed to fileToAsset or fileToImage.
+ */
+export function prepareGeneratedFile(file: GeneratedFile): PreparedFile {
+  const fileBuffer = file.uint8Array.buffer.slice(
+    file.uint8Array.byteOffset,
+    file.uint8Array.byteOffset + file.uint8Array.byteLength
+  ) as ArrayBuffer;
+  const {mediaType} = file;
+  const extension = mediaType.split('/')[1];
+  const filename = `generated-file-${crypto.randomUUID()}.${extension}`;
+  return {filename, fileBuffer, mediaType, extension};
 }

--- a/apps/src/aichat/api/client/helpers/safetyHelpers.ts
+++ b/apps/src/aichat/api/client/helpers/safetyHelpers.ts
@@ -52,7 +52,10 @@ export async function isTextSafe(
   return classification === 'OK';
 }
 
-export async function isImageSafe(image: File, ext: string): Promise<boolean> {
-  const moderationStatus = await moderateImage(image, ext, 'aichat');
+export async function isModelOutputImageSafe(
+  image: File,
+  ext: string
+): Promise<boolean> {
+  const moderationStatus = await moderateImage(image, ext, 'aichat', true); // isModelOutputImage = true
   return moderationStatus === 'ok' || moderationStatus === 'skipped';
 }

--- a/apps/src/lab2/hooks/useFileUploader.tsx
+++ b/apps/src/lab2/hooks/useFileUploader.tsx
@@ -30,7 +30,7 @@ export type FileUploaderProps = {
     eventName: analyticsEvents,
     payload: Record<string, string>
   ) => void;
-  appName?: string;
+  appName: string;
   isBlockedAbuse?: boolean;
   onImageFlagged?: (
     file: File,

--- a/apps/src/lab2/utils/analyticsReporterHelper.ts
+++ b/apps/src/lab2/utils/analyticsReporterHelper.ts
@@ -4,7 +4,6 @@ import analyticsReporter from '@cdo/apps/metrics/AnalyticsReporter';
  * Sends an analytics event to the analytics reporter.
  *
  * @param eventName - The name of the event to send.
- * @param labType - An optional string representing the lab type.
  * @param payload - An optional object containing additional key-value pairs to include in the event payload.
  */
 export function sendLab2AnalyticsEvent(

--- a/apps/src/lab2/utils/moderateImage.ts
+++ b/apps/src/lab2/utils/moderateImage.ts
@@ -1,5 +1,5 @@
 import Lab2Registry from '@cdo/apps/lab2/Lab2Registry';
-import {sendLab2AnalyticsEvent} from '@cdo/apps/lab2/utils';
+import {sendLab2AnalyticsEvent} from '@cdo/apps/lab2/utils/analyticsReporterHelper';
 import {EVENTS} from '@cdo/apps/metrics/AnalyticsConstants';
 import HttpClient from '@cdo/apps/util/HttpClient';
 import {WEBLAB2_IMAGE_FILE_TYPES} from '@cdo/apps/weblab2/constants';

--- a/apps/src/lab2/utils/moderateImage.ts
+++ b/apps/src/lab2/utils/moderateImage.ts
@@ -9,7 +9,8 @@ const LAB2_LABS_MODERATE_IMAGES = ['weblab2', 'aichat'];
 export const moderateImage = async (
   file: File,
   ext: string,
-  appName?: string
+  appName: string,
+  isModelOutputImage?: boolean
 ): Promise<'ok' | 'flagged' | 'skipped'> => {
   if (
     !LAB2_LABS_MODERATE_IMAGES.includes(appName ?? '') ||
@@ -21,7 +22,10 @@ export const moderateImage = async (
   metricsReporter.incrementCounter('ModerateCustomImage.Attempt', [
     {name: 'UploaderType', value: 'Lab2FileUploader'},
   ]);
-  analyticsReporter.sendEvent(EVENTS.MODERATE_CUSTOM_IMAGE, {
+  const moderateImageStatsigEvent = isModelOutputImage
+    ? EVENTS.MODERATE_MODEL_OUTPUT_IMAGE_AZURE
+    : EVENTS.MODERATE_CUSTOM_IMAGE;
+  analyticsReporter.sendEvent(moderateImageStatsigEvent, {
     UploaderType: 'Lab2 File Uploader',
     ProjectType: appName,
   });
@@ -46,7 +50,10 @@ export const moderateImage = async (
     metricsReporter.incrementCounter('ModerateCustomImage.Flagged', [
       {name: 'UploaderType', value: 'Lab2FileUploader'},
     ]);
-    analyticsReporter.sendEvent(EVENTS.FLAGGED_CUSTOM_IMAGE, {
+    const flaggedImageStatsigEvent = isModelOutputImage
+      ? EVENTS.FLAGGED_MODEL_OUTPUT_IMAGE_AZURE
+      : EVENTS.FLAGGED_CUSTOM_IMAGE;
+    analyticsReporter.sendEvent(flaggedImageStatsigEvent, {
       UploaderType: 'Lab2 File Uploader',
       ProjectType: appName,
     });

--- a/apps/src/lab2/utils/moderateImage.ts
+++ b/apps/src/lab2/utils/moderateImage.ts
@@ -19,8 +19,9 @@ export const moderateImage = async (
     return 'skipped';
   }
   const metricsReporter = Lab2Registry.getInstance().getMetricsReporter();
+  const uploaderType = isModelOutputImage ? 'n/a' : 'Lab2FileUploader';
   metricsReporter.incrementCounter('ModerateCustomImage.Attempt', [
-    {name: 'UploaderType', value: 'Lab2FileUploader'},
+    {name: 'UploaderType', value: uploaderType},
   ]);
   const moderateImageStatsigEvent = isModelOutputImage
     ? EVENTS.MODERATE_MODEL_OUTPUT_IMAGE_AZURE
@@ -36,19 +37,19 @@ export const moderateImage = async (
     if (!response.ok) {
       metricsReporter.logError('Error with image moderation: HTTP error');
       metricsReporter.incrementCounter('ModerateCustomImage.Error', [
-        {name: 'UploaderType', value: 'Lab2FileUploader'},
+        {name: 'UploaderType', value: uploaderType},
       ]);
       return 'skipped';
     }
     const json = await response.json();
     metricsReporter.incrementCounter('ModerateCustomImage.Success', [
-      {name: 'UploaderType', value: 'Lab2FileUploader'},
+      {name: 'UploaderType', value: uploaderType},
     ]);
     if (json?.rating === 'everyone' || json?.rating === 'unknown') {
       return 'ok';
     }
     metricsReporter.incrementCounter('ModerateCustomImage.Flagged', [
-      {name: 'UploaderType', value: 'Lab2FileUploader'},
+      {name: 'UploaderType', value: uploaderType},
     ]);
     const flaggedImageStatsigEvent = isModelOutputImage
       ? EVENTS.FLAGGED_MODEL_OUTPUT_IMAGE_AZURE
@@ -61,7 +62,7 @@ export const moderateImage = async (
   } catch (error) {
     metricsReporter.logError('Error with image moderation: ' + error);
     metricsReporter.incrementCounter('ModerateCustomImage.Error', [
-      {name: 'UploaderType', value: 'Lab2FileUploader'},
+      {name: 'UploaderType', value: uploaderType},
     ]);
     return 'skipped';
   }

--- a/apps/src/lab2/utils/moderateImage.ts
+++ b/apps/src/lab2/utils/moderateImage.ts
@@ -1,6 +1,6 @@
 import Lab2Registry from '@cdo/apps/lab2/Lab2Registry';
+import {sendLab2AnalyticsEvent} from '@cdo/apps/lab2/utils';
 import {EVENTS} from '@cdo/apps/metrics/AnalyticsConstants';
-import analyticsReporter from '@cdo/apps/metrics/AnalyticsReporter';
 import HttpClient from '@cdo/apps/util/HttpClient';
 import {WEBLAB2_IMAGE_FILE_TYPES} from '@cdo/apps/weblab2/constants';
 
@@ -25,10 +25,10 @@ export const moderateImage = async (
   const moderateImageStatsigEvent = isModelOutputImage
     ? EVENTS.MODERATE_MODEL_OUTPUT_IMAGE_AZURE
     : EVENTS.MODERATE_CUSTOM_IMAGE;
-  analyticsReporter.sendEvent(moderateImageStatsigEvent, {
-    UploaderType: 'Lab2 File Uploader',
-    ProjectType: appName,
-  });
+  sendLab2AnalyticsEvent(
+    moderateImageStatsigEvent,
+    !isModelOutputImage ? {UploaderType: 'Lab2 File Uploader'} : {}
+  );
   try {
     const response = await HttpClient.post(`/v3/images/moderate`, file, true, {
       'Content-Type': file.type || 'application/octet-stream',
@@ -53,10 +53,10 @@ export const moderateImage = async (
     const flaggedImageStatsigEvent = isModelOutputImage
       ? EVENTS.FLAGGED_MODEL_OUTPUT_IMAGE_AZURE
       : EVENTS.FLAGGED_CUSTOM_IMAGE;
-    analyticsReporter.sendEvent(flaggedImageStatsigEvent, {
-      UploaderType: 'Lab2 File Uploader',
-      ProjectType: appName,
-    });
+    sendLab2AnalyticsEvent(
+      flaggedImageStatsigEvent,
+      !isModelOutputImage ? {UploaderType: 'Lab2 File Uploader'} : {}
+    );
     return 'flagged';
   } catch (error) {
     metricsReporter.logError('Error with image moderation: ' + error);

--- a/apps/src/lab2/views/components/Instructions/ResourcePanel/Backpack/saveToBackpackHelper.tsx
+++ b/apps/src/lab2/views/components/Instructions/ResourcePanel/Backpack/saveToBackpackHelper.tsx
@@ -173,7 +173,7 @@ export const fetchAndSaveFile = async ({
       const moderationStatus = await moderateImage(
         file,
         fileType,
-        appName || undefined
+        appName ?? ''
       );
       if (moderationStatus === 'flagged') {
         // Callback function so if user accepts flagged image, we can save the image to the project.

--- a/apps/src/metrics/AnalyticsConstants.js
+++ b/apps/src/metrics/AnalyticsConstants.js
@@ -457,7 +457,6 @@ const EVENTS = {
   MODERATE_MODEL_OUTPUT_IMAGE_AZURE: 'Model output image moderated by Azure',
   FLAGGED_MODEL_OUTPUT_IMAGE_AZURE:
     'Model output image flagged by Azure moderation service',
-  MODEL_OUTPUT_IMAGE_FLAGGED_BY_MODEL: 'Model output image flagged by model',
 
   // Export app
   EXPORT_APP: 'User Exports App From Share Advanced Options',

--- a/apps/src/metrics/AnalyticsConstants.js
+++ b/apps/src/metrics/AnalyticsConstants.js
@@ -452,6 +452,13 @@ const EVENTS = {
     'User accepts and uploads a flagged custom image',
   CANCEL_FLAGGED_CUSTOM_IMAGE: 'User cancels upload of flagged custom image',
 
+  // Moderate model output image
+  MODEL_OUTPUT_IMAGE_CREATED: 'Model output image created',
+  MODERATE_MODEL_OUTPUT_IMAGE_AZURE: 'Model output image moderated by Azure',
+  FLAGGED_MODEL_OUTPUT_IMAGE_AZURE:
+    'Model output image flagged by Azure moderation service',
+  MODEL_OUTPUT_IMAGE_FLAGGED_BY_MODEL: 'Model output image flagged by model',
+
   // Export app
   EXPORT_APP: 'User Exports App From Share Advanced Options',
 


### PR DESCRIPTION
<!--
  Summary of the change: background, motivation, and context.
  Include screenshots, videos, or before/after comparisons for UI changes.
-->
This PR follows up https://github.com/code-dot-org/code-dot-org/pull/71118 and adds Statsig reporting for when a model output image is generated and then moderated by the Azure content moderator service.

The added events are:
```
  MODEL_OUTPUT_IMAGE_CREATED: 'Model output image created',
  MODERATE_MODEL_OUTPUT_IMAGE_AZURE: 'Model output image moderated by Azure',
  FLAGGED_MODEL_OUTPUT_IMAGE_AZURE:
    'Model output image flagged by Azure moderation service',
```

In both Statsig and metrics reporting if the image is from model output, the uploader type is 'n/a'.

Also included in this PR is the saving of generated images to a user's project, even if flagged by Azure. Because the  `MODEL_IMAGE_FLAGGED` execution status is returned, a user will not see a flagged image and instead will see the following error message in the workspace:

<img width="501" height="82" alt="Screenshot 2026-03-05 at 3 01 55 PM" src="https://github.com/user-attachments/assets/4911d2ac-d444-416f-9908-1ec3190fe8e8" />

## Links
<!-- Jira tickets, design docs, Slack threads, related PRs, etc. -->

- Jira: https://codedotorg.atlassian.net/browse/SL-1614

## Testing story
<!-- How was this tested? Manual steps, adhoc links, automated tests, or why testing isn't needed. -->

I tested locally on aichat levels with query param ?use-ai-gateway=true and multi-modal enabled and the Gemini 2.5 Flash Image model selected.

Screenshots of dev console:

When image was moderated and safe:

<img width="1318" height="143" alt="safe-dev-console" src="https://github.com/user-attachments/assets/39aee509-6dfa-4aa2-80f9-7bc2b08f5481" />



When image was moderated and flagged:

<img width="1315" height="212" alt="flagged-dev-console" src="https://github.com/user-attachments/assets/a0e83307-de4a-4e86-a388-d0a1bb844d76" />

I saw that the flagged image was not displayed in the chat workspace but still stored in the project's assets bucket.



## Deployment notes
<!-- Delete this section if it's a standard merge-and-deploy.
     Otherwise: migrations, feature flags, coordination, caching impacts, etc. -->



## Privacy and security
<!-- Delete this section if there is no privacy/security impact.
     Otherwise: new PII, auth changes, API surface changes, etc. -->

