### PR TITLE
Enable AI Gateway behind DCDO

### DIFF
--- a/apps/src/aiGateway/isAiGatewayEnabled.ts
+++ b/apps/src/aiGateway/isAiGatewayEnabled.ts
@@ -1,3 +1,6 @@
 import {queryParams} from '@cdo/apps/code-studio/utils';
+import DCDO from '@cdo/apps/dcdo';
 
-export const isAiGatewayEnabled = queryParams('use-ai-gateway') === 'true';
+export const isAiGatewayEnabled =
+  DCDO.get('ai-gateway-enabled', true) ||
+  queryParams('use-ai-gateway') === 'true';

--- a/lib/dynamic_config/dcdo.rb
+++ b/lib/dynamic_config/dcdo.rb
@@ -66,7 +66,8 @@ class DCDOBase < DynamicConfigBase
       'lab2-fetch-level-properties-by-lesson-id': DCDO.get('lab2-fetch-level-proper0ties-by-lesson-id', true),
       'student-snapshot-feedback-link': DCDO.get('student-snapshot-feedback-link', false),
       'sketchlab-s3-image-storage': DCDO.get('sketchlab-s3-image-storage', true),
-      'studio-brand-update-enabled': DCDO.get('studio-brand-update-enabled', false)
+      'studio-brand-update-enabled': DCDO.get('studio-brand-update-enabled', false),
+      'ai-gateway-enabled': DCDO.get('ai-gateway-enabled', true)
     }
   end
 end


### PR DESCRIPTION
Enables the AI Gateway pathway behind a DCDO flag in preparation for AID pilot launch next week. The flag defaults to true but is available as a last-resort kill switch in case something goes wrong.

## Testing story
Tested locally.