### PR TITLE
Bug: Fix tutor sidebar width in legacy labs

### DIFF
--- a/apps/src/aiTutor/views/legacyLabs/AiTutorSidebar.module.scss
+++ b/apps/src/aiTutor/views/legacyLabs/AiTutorSidebar.module.scss
@@ -36,6 +36,7 @@
 // AiTutorSidebarSuggestedPrompts styles
 .ai-tutor-suggested-prompt-item {
   width: 45px;
+  min-width: 45px;
   height: 45px;
   margin: 0;
   background-color: white;


### PR DESCRIPTION
<!--
  Summary of the change: background, motivation, and context.
  Include screenshots, videos, or before/after comparisons for UI changes.
-->

The suggested prompt buttons in the tutor sidebar changed to 64px due to mui button styles added in #71142

Add a min-width to our suggested-prompt-items to override that min-width prop that is forcing our sidebar to be an inconsistent width.

## Testing story
<!-- How was this tested? Manual steps, adhoc links, automated tests, or why testing isn't needed. -->

| before | after | 
| --- | --- |
| <img width="96" height="302" alt="image" src="https://github.com/user-attachments/assets/4b3a9b23-0fb1-4015-91f0-080d4f50d057" /> | <img width="85" height="293" alt="image" src="https://github.com/user-attachments/assets/2c58c80d-e93a-4463-9be2-5c037bbf8dee" /> |



