### PR TITLE
FIX: Export Large Tables to Redshift via Zero-ETL

### DIFF
--- a/aws/cloudformation/components/database.yml.erb
+++ b/aws/cloudformation/components/database.yml.erb
@@ -323,11 +323,11 @@
         - "arn:aws:rds:${AWS::Region}:${AWS::AccountId}:cluster:${ClusterId}"
         - ClusterId: <%=rack_env?(:production) ? PRODUCTION_DB_CLUSTER_ID : '!Ref AuroraCluster' %>
       TargetArn: !ImportValue DATA-production-RedshiftClusterNamespace
-      DataFilter:
-        - !Sub "include: dashboard_<%=rack_env%>.levels"
-        - !Sub "include: dashboard_<%=rack_env%>.user_levels"
-        - !Sub "include: dashboard_<%=rack_env%>.level_sources"
-        - !Sub "include: dashboard_<%=rack_env%>.projects"
+      DataFilter: >-
+        include: dashboard_<%=rack_env%>.levels,
+        include: dashboard_<%=rack_env%>.user_levels,
+        include: dashboard_<%=rack_env%>.level_sources,
+        include: dashboard_<%=rack_env%>.projects
       Tags:
         - Key: environment
           Value: "<%=rack_env %>"


### PR DESCRIPTION
Fix Forward #71018
Which failed to deploy to the `test` Stack with:
```
Aws::CloudFormation::Errors::InvalidChangeSetStatus: ChangeSet [arn:aws:cloudformation:us-east-1:[REDACTED]:changeSet/test-ae3f3af5c91b076d22ea1c091302fc5c/2aa7917d-a135-405c-8bab-bb0396be7fd3] cannot be executed in its current status of [FAILED]
```

## Testing story
<!-- How was this tested? Manual steps, adhoc links, automated tests, or why testing isn't needed. -->



## Deployment notes
<!-- Delete this section if it's a standard merge-and-deploy.
     Otherwise: migrations, feature flags, coordination, caching impacts, etc. -->



## Privacy and security
<!-- Delete this section if there is no privacy/security impact.
     Otherwise: new PII, auth changes, API surface changes, etc. -->

