### PR TITLE
Remove Statsig Events Marked for Deprecation

### DIFF
--- a/apps/src/StudioApp.js
+++ b/apps/src/StudioApp.js
@@ -2179,24 +2179,25 @@ StudioApp.prototype.configureDom = function (config) {
     trailing: false,
   });
 
+  const shouldLogLevelActivity = () =>
+    !runButtonWasClicked && !config.level.isProjectLevel;
+
+  const logLevelActivity = () => {
+    analyticsReporter.sendEvent(EVENTS.LEVEL_ACTIVITY, {
+      signedIn: config.isSignedIn,
+      unitName: config.scriptName,
+      levelId: config.serverLevelId,
+      levelName: config.level.name,
+    });
+    runButtonWasClicked = true;
+  };
+
   // Modify throttledRunClick to include metrics logging
   const originalThrottledRunClick = throttledRunClick;
   throttledRunClick = () => {
     originalThrottledRunClick();
-    let eventName;
-    if (!!config.level.isProjectLevel) {
-      eventName = EVENTS.PROJECT_ACTIVITY;
-    } else {
-      eventName = EVENTS.LEVEL_ACTIVITY;
-    }
-    if (!runButtonWasClicked) {
-      analyticsReporter.sendEvent(eventName, {
-        signedIn: config.isSignedIn,
-        unitName: config.scriptName,
-        levelId: config.serverLevelId,
-        levelName: config.level.name,
-      });
-      runButtonWasClicked = true;
+    if (shouldLogLevelActivity()) {
+      logLevelActivity();
     }
   };
 

--- a/apps/src/code-studio/components/AssetManager.jsx
+++ b/apps/src/code-studio/components/AssetManager.jsx
@@ -7,8 +7,6 @@ import {
   starterAssets as starterAssetsApi,
   files as filesApi,
 } from '@cdo/apps/clientApi';
-import {EVENTS} from '@cdo/apps/metrics/AnalyticsConstants';
-import analyticsReporter from '@cdo/apps/metrics/AnalyticsReporter';
 import i18n from '@cdo/locale';
 
 import assetListStore from '../assets/assetListStore';
@@ -156,7 +154,6 @@ export default class AssetManager extends React.Component {
 
   /**
    * Called when user initiates an upload.
-   * If the file is an image, log event.
    * @param data - Upload data from jquery.fileupload
    */
   onUploadStart = data => {
@@ -166,20 +163,6 @@ export default class AssetManager extends React.Component {
       this.setState({statusMessage: 'Error: No file selected for upload.'});
       return;
     }
-    const isImage = [
-      'image/png',
-      'image/jpeg',
-      'image/jpg',
-      'image/gif',
-    ].includes(file.type);
-
-    if (isImage) {
-      analyticsReporter.sendEvent(EVENTS.UPLOAD_CUSTOM_IMAGE, {
-        UploaderType: 'Asset Uploader',
-        ProjectType: this.state.projectType,
-      });
-    }
-
     this.setState({statusMessage: 'Uploading...'});
     data.submit();
   };

--- a/apps/src/code-studio/videos.js
+++ b/apps/src/code-studio/videos.js
@@ -61,7 +61,6 @@ window.onYouTubeIframeAPIReady = function () {
   // requires there be an iframe#video present on the page
   new YT.Player('video', {
     events: {
-      onReady: function (event) {},
       onStateChange: function (state) {
         if (state.data === YT.PlayerState.ENDED) {
           onVideoEnded();

--- a/apps/src/code-studio/videos.js
+++ b/apps/src/code-studio/videos.js
@@ -3,8 +3,6 @@ import _ from 'lodash';
 import React from 'react';
 import videojs from 'video.js';
 
-import {EVENTS} from '@cdo/apps/metrics/AnalyticsConstants';
-import analyticsReporter from '@cdo/apps/metrics/AnalyticsReporter';
 import {createReactRoot} from '@cdo/apps/util/createReactRoot';
 import i18n from '@cdo/locale';
 
@@ -61,29 +59,10 @@ var currentVideoOptions;
 // This is a good candidate to circle back to and refactor.
 window.onYouTubeIframeAPIReady = function () {
   // requires there be an iframe#video present on the page
-  const player = new YT.Player('video', {
+  new YT.Player('video', {
     events: {
-      onReady: function (event) {
-        analyticsReporter.sendEvent(EVENTS.VIDEO_LOADED, {
-          url: location.href,
-          video: player.getVideoUrl(),
-        });
-      },
+      onReady: function (event) {},
       onStateChange: function (state) {
-        const amplitudeEventMap = {
-          [YT.PlayerState.PLAYING]: EVENTS.VIDEO_STARTED,
-          [YT.PlayerState.PAUSED]: EVENTS.VIDEO_PAUSED,
-          [YT.PlayerState.ENDED]: EVENTS.VIDEO_ENDED,
-        };
-
-        const amplitudeEvent = amplitudeEventMap[state.data];
-        if (amplitudeEvent) {
-          analyticsReporter.sendEvent(amplitudeEvent, {
-            url: location.href,
-            video: player.getVideoUrl(),
-          });
-        }
-
         if (state.data === YT.PlayerState.ENDED) {
           onVideoEnded();
         }
@@ -420,12 +399,6 @@ function addFallbackVideoPlayer(videoInfo, playerWidth, playerHeight) {
 
   var fallbackPlayerID = 'fallbackPlayer' + Date.now();
 
-  analyticsReporter.sendEvent(EVENTS.VIDEO_FALLBACK_LOADED, {
-    url: location.href,
-    forced: !!videoInfo.force_fallback,
-    video: videoInfo.download,
-  });
-
   // If we have want the video player to be at 100% width & 100% height, then
   // let's assume we are attaching to a container that is relative, and we want
   // to expand to its edges.  This is currently implemented by a standalone
@@ -508,24 +481,7 @@ function addFallbackVideoPlayer(videoInfo, playerWidth, playerHeight) {
     }
   );
 
-  const analyticsData = {
-    url: location.href,
-    video: videoInfo.download,
-    fallback: 'code.org',
-  };
-
-  videoPlayer.on('ready', () =>
-    analyticsReporter.sendEvent(EVENTS.VIDEO_LOADED, analyticsData)
-  );
-  videoPlayer.on('play', () =>
-    analyticsReporter.sendEvent(EVENTS.VIDEO_STARTED, analyticsData)
-  );
-  videoPlayer.on('pause', () =>
-    analyticsReporter.sendEvent(EVENTS.VIDEO_PAUSED, analyticsData)
-  );
-
   videoPlayer.on('ended', () => {
-    analyticsReporter.sendEvent(EVENTS.VIDEO_ENDED, analyticsData);
     onVideoEnded();
   });
   showFallbackPlayerCaptionLink(videoInfo.inDialog);

--- a/apps/src/codebridge/Console/ControlButtons.tsx
+++ b/apps/src/codebridge/Console/ControlButtons.tsx
@@ -19,9 +19,7 @@ import {
   setHasError,
 } from '@cdo/apps/lab2/redux/systemRedux';
 import {MultiFileSource} from '@cdo/apps/lab2/types';
-import {sendLab2AnalyticsEvent} from '@cdo/apps/lab2/utils/analyticsReporterHelper';
 import {LifecycleEvent} from '@cdo/apps/lab2/utils/LifecycleNotifier';
-import {EVENTS} from '@cdo/apps/metrics/AnalyticsConstants';
 import {logUserLevelInteraction} from '@cdo/apps/userLevelInteractionsLogger/userLevelInteractionsApi';
 import {useAppDispatch, useAppSelector} from '@cdo/apps/util/reduxHooks';
 import {UserLevelInteractions} from '@cdo/generated-scripts/sharedConstants';
@@ -74,7 +72,6 @@ const ControlButtons: React.FunctionComponent = () => {
   const handleRun = () => {
     if (onRun) {
       dispatch(setIsRunning(true));
-      sendLab2AnalyticsEvent(EVENTS.CODEBRIDGE_RUN_CLICK);
       logUserLevelInteraction({
         levelId: levelId,
         scriptId: scriptId,

--- a/apps/src/dance/Dance.js
+++ b/apps/src/dance/Dance.js
@@ -597,15 +597,6 @@ Dance.prototype.onPuzzleComplete = function (result, message) {
   } else {
     this.studioApp_.playAudio('failure');
   }
-  const state = getStore().getState();
-  const validationResult = result ? 'PASSED' : 'FAILED';
-  analyticsReporter.sendEvent(EVENTS.DANCE_PARTY_VALIDATION, {
-    levelPath: state.pageConstants.currentScriptLevelUrl,
-    result: validationResult,
-    message, // feedback message key
-    userId: state.currentUser.userId,
-  });
-
   const sendReport = () => {
     this.studioApp_.report({
       app: 'dance',

--- a/apps/src/dance/ai/DanceAiModal.tsx
+++ b/apps/src/dance/ai/DanceAiModal.tsx
@@ -339,12 +339,8 @@ const DanceAiModal: React.FunctionComponent<DanceAiModalProps> = ({
   }, [startAi]);
 
   const handleGenerateClick = useCallback(() => {
-    analyticsReporter.sendEvent(EVENTS.DANCE_PARTY_AI_BACKGROUND_GENERATED, {
-      emojis: inputs,
-    });
-
     startGenerating();
-  }, [startGenerating, inputs]);
+  }, [startGenerating]);
 
   const onClose = useCallback(() => dispatch(closeAiModal()), [dispatch]);
 
@@ -555,15 +551,8 @@ const DanceAiModal: React.FunctionComponent<DanceAiModalProps> = ({
   }, [currentAiModalField, onClose, inputs]);
 
   const handleOnClose = useCallback(() => {
-    analyticsReporter.sendEvent(EVENTS.DANCE_PARTY_AI_MODAL_CLOSED, {
-      emojis: inputs,
-      mode,
-      currentToggle,
-      generatingStep: generatingProgress.step,
-    });
-
     onClose();
-  }, [inputs, mode, currentToggle, generatingProgress.step, onClose]);
+  }, [onClose]);
 
   const showUseButton =
     mode === DanceAiModalMode.RESULTS &&

--- a/apps/src/feedback.js
+++ b/apps/src/feedback.js
@@ -402,10 +402,6 @@ FeedbackUtils.prototype.displayFeedback = function (
 
     dom.addClickTouchEvent(continueButton, function () {
       feedbackDialog.hide();
-      recordFinishShare(
-        'FINISH_BUTTON_CERTIFICATE',
-        project.getStandaloneApp()
-      );
 
       if (options.response && options.response.puzzle_ratings_enabled) {
         puzzleRatingUtils.cachePuzzleRating(feedback, {

--- a/apps/src/javalab/JavabuilderConnection.js
+++ b/apps/src/javalab/JavabuilderConnection.js
@@ -1,7 +1,5 @@
 import project from '@cdo/apps/code-studio/initApp/project';
 import logToCloud from '@cdo/apps/logToCloud';
-import {EVENTS} from '@cdo/apps/metrics/AnalyticsConstants';
-import analyticsReporter from '@cdo/apps/metrics/AnalyticsReporter';
 import {ConsoleSignalType} from '@cdo/apps/miniApps/neighborhood/constants';
 import {SignInState} from '@cdo/apps/templates/currentUserRedux';
 import javalabMsg from '@cdo/javalab/locale';
@@ -14,7 +12,6 @@ import {
   AuthorizerSignalType,
   CsaViewMode,
   JavabuilderLockoutType,
-  JavabuilderExceptionType,
 } from './constants';
 import {handleException} from './javabuilderExceptionHandler';
 import {onTestResult} from './testResultHandler';
@@ -255,9 +252,6 @@ export default class JavabuilderConnection {
         lineBreakCount = 1;
         break;
       case StatusMessageType.COMPILATION_SUCCESSFUL:
-        analyticsReporter.sendEvent(EVENTS.JAVALAB_COMPILATION_SUCCESS, {
-          levelId: this.levelId,
-        });
         message = javalabMsg.compilationSuccess();
         lineBreakCount = 1;
         break;
@@ -354,11 +348,6 @@ export default class JavabuilderConnection {
         }
         break;
       case WebSocketMessageType.EXCEPTION:
-        if (data.value === JavabuilderExceptionType.COMPILER_ERROR) {
-          analyticsReporter.sendEvent(EVENTS.JAVALAB_COMPILATION_ERROR, {
-            levelId: this.levelId,
-          });
-        }
         this.onNewlineMessage();
         handleException(data, this.onOutputMessage, this.miniAppType);
         this.onNewlineMessage();

--- a/apps/src/javalab/Javalab.js
+++ b/apps/src/javalab/Javalab.js
@@ -373,9 +373,6 @@ Javalab.prototype.onRun = function () {
     scriptId: this.scriptIdForAnalytics,
     interaction: UserLevelInteractions.click_run,
   });
-  analyticsReporter.sendEvent(EVENTS.JAVALAB_RUN_BUTTON_CLICK, {
-    levelId: this.levelIdForAnalytics,
-  });
   this.executeJavabuilder(ExecutionType.RUN);
 };
 

--- a/apps/src/lab2/header/lab2HeaderShare.js
+++ b/apps/src/lab2/header/lab2HeaderShare.js
@@ -2,8 +2,6 @@ import React from 'react';
 import {Provider} from 'react-redux';
 
 import {showShareDialog} from '@cdo/apps/code-studio/components/shareDialogRedux';
-import {EVENTS} from '@cdo/apps/metrics/AnalyticsConstants';
-import analyticsReporter from '@cdo/apps/metrics/AnalyticsReporter';
 import {getStore} from '@cdo/apps/redux';
 import {createReactRoot} from '@cdo/apps/util/createReactRoot';
 import trackEvent from '@cdo/apps/util/trackEvent';
@@ -44,11 +42,6 @@ export function shareLab2Project(dialogId, finishUrl) {
 
     getStore().dispatch(showShareDialog());
     const projectType = projectManager.getProjectType();
-    analyticsReporter.sendEvent(EVENTS.SHARING_DIALOG_OPEN, {
-      lab_type: projectType,
-      channel_id: projectManager.getChannelId(),
-      dialog_id: dialogId,
-    });
     trackEvent('share', 'share_open_dialog', {
       value:
         dialogId === 'hoc2024'

--- a/apps/src/lab2/hooks/useFileUploader.tsx
+++ b/apps/src/lab2/hooks/useFileUploader.tsx
@@ -2,8 +2,6 @@ import React, {useCallback, useMemo, useRef, useState} from 'react';
 
 import codebridgeI18n from '@cdo/apps/codebridge/locale';
 import {moderateImage} from '@cdo/apps/lab2/utils';
-import {EVENTS} from '@cdo/apps/metrics/AnalyticsConstants';
-import analyticsReporter from '@cdo/apps/metrics/AnalyticsReporter';
 import UploadsDisabledModal from '@cdo/apps/sharedComponents/UploadsDisabledModal';
 
 export const enum analyticsEvents {
@@ -173,10 +171,6 @@ export const useFileUploader = ({
           }
         };
       } else {
-        analyticsReporter.sendEvent(EVENTS.UPLOAD_CUSTOM_IMAGE, {
-          UploaderType: 'Lab2 File Uploader',
-          ProjectType: appName,
-        });
         try {
           if (onImageFlagged) {
             const ext = file.name.split('.').pop()?.toLowerCase() || '';

--- a/apps/src/lab2/hooks/useLevelActivityMetrics.ts
+++ b/apps/src/lab2/hooks/useLevelActivityMetrics.ts
@@ -7,8 +7,8 @@ import {useAppSelector} from '@cdo/apps/util/reduxHooks';
 import {LevelProperties} from '../types';
 
 /**
- * Custom hook that provides a callback to log LEVEL_ACTIVITY or PROJECT_ACTIVITY
- * analytics events when a user performs their first activity in a Lab2 environment.
+ * Custom hook that provides a callback to log a LEVEL_ACTIVITY
+ * analytics event when a user performs their first activity in a Lab2 environment.
  *
  * This hook returns a callback function that labs should call when activity occurs.
  * The callback will log exactly once per level, preventing duplicate events.

--- a/apps/src/lab2/hooks/useLevelActivityMetrics.ts
+++ b/apps/src/lab2/hooks/useLevelActivityMetrics.ts
@@ -39,22 +39,21 @@ export function useLevelActivityMetrics(
     if (hasLoggedRef.current) {
       return;
     }
+    if (levelProperties.isProjectLevel) {
+      return;
+    }
 
     hasLoggedRef.current = true;
 
-    const eventName = levelProperties.isProjectLevel
-      ? EVENTS.PROJECT_ACTIVITY
-      : EVENTS.LEVEL_ACTIVITY;
-
-    sendLab2AnalyticsEvent(eventName, {
+    sendLab2AnalyticsEvent(EVENTS.LEVEL_ACTIVITY, {
       signedIn: signedIn,
       unitName: scriptName ?? '',
       levelId: levelProperties.id,
       levelName: levelProperties.name,
     });
   }, [
-    levelProperties.isProjectLevel,
     levelProperties.id,
+    levelProperties.isProjectLevel,
     levelProperties.name,
     signedIn,
     scriptName,

--- a/apps/src/lab2/views/Lab2ShareDialogWrapper.tsx
+++ b/apps/src/lab2/views/Lab2ShareDialogWrapper.tsx
@@ -116,7 +116,6 @@ const Lab2ShareDialogWrapper: React.FunctionComponent<
         projectType={projectType}
         onSubmitClick={onSubmitClick}
         submissionStatus={submissionStatus}
-        channelId={channelId}
         userSharingDisabled={userSharingDisabled}
       />
     ) : (

--- a/apps/src/lab2/views/dialogs/CopyToClipboardButton.tsx
+++ b/apps/src/lab2/views/dialogs/CopyToClipboardButton.tsx
@@ -3,8 +3,6 @@ import {Button as MuiButton} from '@mui/material';
 import React, {useCallback, useState} from 'react';
 
 import {ProjectType} from '@cdo/apps/lab2/types';
-import {EVENTS} from '@cdo/apps/metrics/AnalyticsConstants';
-import analyticsReporter from '@cdo/apps/metrics/AnalyticsReporter';
 import {commonI18n as i18n} from '@cdo/apps/types/locale';
 import copyToClipboard from '@cdo/apps/util/copyToClipboard';
 import trackEvent from '@cdo/apps/util/trackEvent';
@@ -14,8 +12,7 @@ import moduleStyles from './share-dialog.module.scss';
 export const CopyToClipboardButton: React.FunctionComponent<{
   shareUrl: string;
   projectType: ProjectType;
-  channelId: string | undefined;
-}> = ({shareUrl, projectType, channelId}) => {
+}> = ({shareUrl, projectType}) => {
   const [copiedToClipboard, setCopiedToClipboard] = useState(false);
 
   const handleCopyToClipboard = useCallback(() => {
@@ -23,11 +20,7 @@ export const CopyToClipboardButton: React.FunctionComponent<{
       setCopiedToClipboard(true);
     });
     trackEvent('share', 'share_copy_url', {value: projectType});
-    analyticsReporter.sendEvent(EVENTS.SHARING_LINK_COPY, {
-      lab_type: projectType,
-      channel_id: channelId,
-    });
-  }, [shareUrl, projectType, channelId]);
+  }, [shareUrl, projectType]);
 
   return (
     <MuiButton

--- a/apps/src/lab2/views/dialogs/ShareDialog.tsx
+++ b/apps/src/lab2/views/dialogs/ShareDialog.tsx
@@ -11,8 +11,6 @@ import {hideShareDialog} from '@cdo/apps/code-studio/components/shareDialogRedux
 import DCDO from '@cdo/apps/dcdo';
 import Lab2Registry from '@cdo/apps/lab2/Lab2Registry';
 import {ProjectType, ShareDialogId} from '@cdo/apps/lab2/types';
-import {EVENTS} from '@cdo/apps/metrics/AnalyticsConstants';
-import analyticsReporter from '@cdo/apps/metrics/AnalyticsReporter';
 import {SignInState} from '@cdo/apps/templates/currentUserRedux';
 import {SubmissionStatusType} from '@cdo/apps/templates/projects/submitProjectDialog/submitProjectApi';
 import {commonI18n as i18n} from '@cdo/apps/types/locale';
@@ -118,7 +116,6 @@ const ShareDialog: React.FunctionComponent<{
   projectType: ProjectType;
   onSubmitClick: () => void;
   submissionStatus: SubmissionStatusType | undefined;
-  channelId: string;
   userSharingDisabled: boolean | undefined;
 }> = ({
   dialogId,
@@ -127,7 +124,6 @@ const ShareDialog: React.FunctionComponent<{
   projectType,
   onSubmitClick,
   submissionStatus,
-  channelId,
   userSharingDisabled,
 }) => {
   const dispatch = useAppDispatch();
@@ -136,11 +132,7 @@ const ShareDialog: React.FunctionComponent<{
 
   const handleClose = useCallback(() => {
     dispatch(hideShareDialog());
-    analyticsReporter.sendEvent(EVENTS.SHARING_CLOSE_ESCAPE, {
-      lab_type: projectType,
-      channel_id: channelId,
-    });
-  }, [channelId, dispatch, projectType]);
+  }, [dispatch]);
 
   const feedbackLink = useAppSelector(state => {
     const {userType, signInState} = state.currentUser;
@@ -162,7 +154,6 @@ const ShareDialog: React.FunctionComponent<{
         finishUrl={finishUrl}
         shareUrl={shareUrl}
         projectType={projectType}
-        channelId={channelId}
         theme={theme}
       />
     );
@@ -218,7 +209,6 @@ const ShareDialog: React.FunctionComponent<{
                 <CopyToClipboardButton
                   shareUrl={shareUrl}
                   projectType={projectType}
-                  channelId={channelId}
                 />
                 <SubmitButtonInfo
                   submissionStatus={submissionStatus}

--- a/apps/src/lab2/views/dialogs/finishDialogs/HoaiCongrats.tsx
+++ b/apps/src/lab2/views/dialogs/finishDialogs/HoaiCongrats.tsx
@@ -20,7 +20,6 @@ interface Props {
   finishUrl: string;
   shareUrl: string;
   projectType: ProjectType;
-  channelId: string | undefined;
   theme?: Theme;
 }
 
@@ -33,7 +32,6 @@ const HoaiCongrats: React.FC<Props> = ({
   shareUrl,
   theme,
   projectType,
-  channelId,
 }) => {
   return (
     <Modal
@@ -58,7 +56,6 @@ const HoaiCongrats: React.FC<Props> = ({
               <CopyToClipboardButton
                 shareUrl={shareUrl}
                 projectType={projectType}
-                channelId={channelId}
               />
             </div>
           </div>

--- a/apps/src/metrics/AnalyticsConstants.js
+++ b/apps/src/metrics/AnalyticsConstants.js
@@ -14,10 +14,7 @@ const EVENTS = {
   TEACHER_LOGIN_EVENT: 'Teacher Login',
   STUDENT_LOGIN_EVENT: 'Student Login',
   ACCOUNT_SETTINGS_PAGE_VISITED: 'Account Settings Page Visited',
-  LOGIN_PAGE_VISITED: 'Login Page Visited',
   LOGIN_PAGE_CREATE_ACCOUNT_CLICKED: 'Login Page Create Account Button Clicked',
-  LOGIN_PAGE_SIGN_IN_CLICKED: 'Login Page Sign In Button Clicked',
-  LOGIN_PAGE_OAUTH_CLICKED: 'Login Page OAuth Button Clicked',
   LOGIN_PAGE_COURSE_BLOCK_CLICKED: 'Login Page Course Block Clicked',
   CURRICULUM_FREE_DIALOG_BUTTON_CLICKED:
     'Curriculum Free Dialog Button Clicked',
@@ -90,8 +87,6 @@ const EVENTS = {
   // Course/Unit info
   COURSE_OVERVIEW_PAGE_VISITED_BY_TEACHER_EVENT:
     'Course Overview Page Visited By Teacher',
-  COURSE_OVERVIEW_PAGE_VISITED_BY_STUDENT_EVENT:
-    'Course Overview Page Visited By Student',
   COURSE_OVERVIEW_PAGE_VISITED_BY_SIGNED_OUT_USER_EVENT:
     'Course Overview Page Visited By Signed Out User',
   UNIT_OVERVIEW_PAGE_VISITED_BY_TEACHER_EVENT:
@@ -192,7 +187,6 @@ const EVENTS = {
     'Section students table save all clicked',
 
   // Section progress v2
-  PROGRESS_V2_VIEW: 'Section New Progress Viewed ',
   PROGRESS_V2_VIEW_NEW_PROGRESS: 'New Progress Link Clicked',
   PROGRESS_V2_VIEW_OLD_PROGRESS: 'Old Progress Link Clicked',
   PROGRESS_V2_CHANGE_UNIT: 'Section New Progress Unit Changed',
@@ -228,9 +222,6 @@ const EVENTS = {
   SUMMARY_PAGE_NEXT_LEVEL_CLICKED: 'Summary Page Next Level Clicked',
   SUMMARY_PAGE_BACK_TO_LEVEL_CLICKED: 'Summary Page Back To Level Clicked',
   LEVEL_ACTIVITY: 'Level Activity',
-
-  // Projects
-  PROJECT_ACTIVITY: 'Project Activity',
 
   // Check for understanding
   CFU_NAMES_TOGGLED_ON: 'Summary Page Names Toggled On',
@@ -331,10 +322,7 @@ const EVENTS = {
   AI_TUTOR_FILE_ADDED_TO_CONTEXT: 'AI Tutor File Added to Context',
 
   // Javalab
-  JAVALAB_RUN_BUTTON_CLICK: 'Javalab Run Button Clicked',
   JAVALAB_TEST_BUTTON_CLICK: 'Javalab Test Button Clicked',
-  JAVALAB_COMPILATION_ERROR: 'Javalab Compilation Error',
-  JAVALAB_COMPILATION_SUCCESS: 'Javalab Compilation Success',
   JAVALAB_TEST_PASSED: 'Javalab Test Passed',
   JAVALAB_TEST_FAILED: 'Javalab Test Failed',
 
@@ -342,13 +330,10 @@ const EVENTS = {
   AGE_21_SELECTED_EVENT: 'Age 21+ Selected',
   HOC_GUIDE_DIALOG_SHOWN: 'HOC Guide Dialog Shown',
   GUIDE_SENT_EVENT: 'Guide Sent',
-  HOC_ACTIVITY_START_BUTTON_CLICKED:
-    'Hour of Code Activity Start Button Clicked',
 
   // Hour of Code - Dance Party
   DANCE_PARTY_ACTIVITY_STARTED: 'Dance Party Activity Started',
   DANCE_PARTY_LEVEL_COMPLETED: 'Dance Party Level Completed',
-  DANCE_PARTY_AI_BACKGROUND_GENERATED: 'Dance Party AI Background Generated',
   DANCE_PARTY_AI_BACKGROUND_REGENERATED:
     'Dance Party AI Background Regenerated',
   DANCE_PARTY_AI_BACKGROUND_USED: 'Dance Party AI Background Used',
@@ -359,15 +344,8 @@ const EVENTS = {
   DANCE_PARTY_SONG_UNAVAILABLE: 'Dance Party Song Unavailable',
   DANCE_PARTY_RESTRICTED_SONG_AUTH_ERROR:
     'Dance Party Restricted Song Auth Error',
-  DANCE_PARTY_VALIDATION: 'Dance Party Validation',
-  DANCE_PARTY_AI_MODAL_CLOSED: 'Dance Party AI Modal Closed',
 
   // videos
-  VIDEO_LOADED: 'Video Loaded',
-  VIDEO_FALLBACK_LOADED: 'Video Fallback Loaded',
-  VIDEO_STARTED: 'Video Started',
-  VIDEO_PAUSED: 'Video Paused',
-  VIDEO_ENDED: 'Video Played To Completion',
 
   // congrats and certificates
   BATCH_CERTIFICATES_PAGE_VIEWED: 'Batch Certificates Page Viewed',
@@ -399,32 +377,20 @@ const EVENTS = {
     'Signed Out User Selects Create Dropdown Option',
 
   // Header navigation - signed in
-  SIGNED_IN_USER_CLICKS_HEADER_LINK: 'Signed In User Clicks Header Link',
-  SIGNED_IN_USER_CLICKS_HAMBURGER_LINK: 'Signed In User Clicks Hamburger Link',
   SIGNED_IN_USER_CLICKS_HAMBURGER_OPTION:
     'Signed In User Clicks Hamburger Dropdown Option',
   SIGNED_IN_USER_CLICKS_HELP_MENU: 'Signed In User Clicks Help Menu',
   SIGNED_IN_USER_CLICKS_HELP_MENU_OPTION:
     'Signed In User Clicks Help Menu Option',
-  SIGNED_IN_USER_CLICKS_USER_MENU: 'Signed In User Clicks User Menu',
-  SIGNED_IN_USER_CLICKS_USER_MENU_OPTION:
-    'Signed In User Clicks User Menu Option',
 
   // Header Create menu - signed in
-  SIGNED_IN_USER_CLICKS_CREATE_DROPDOWN:
-    'Signed In User Clicks Create Dropdown',
-  SIGNED_IN_USER_SELECTS_CREATE_DROPDOWN_OPTION:
-    'Signed In User Selects Create Dropdown Option',
 
   // Project sharing via 'Share' button
-  SHARING_DIALOG_OPEN: 'User Opens Project Share Dialog',
-  SHARING_LINK_COPY: 'User Clicks Project Copy Link In Share Dialog',
   SHARING_PUBLISH: 'User Clicks Publish In Project Share Dialog',
   SHARING_FB: 'User Clicks Facebook Icon In Project Share Dialog',
   SHARING_TWITTER: 'User Clicks Twitter Icon In Project Share Dialog',
   SHARING_LINK_SEND_TO_PHONE:
     'User Clicks Send To Phone In Project Share Dialog',
-  SHARING_CLOSE_ESCAPE: 'User Clicks X Or Esc Button In Project Share Dialog',
 
   // Project sharing via 'Finish' button
   FINISH_SHARING_LINK_COPY:
@@ -434,8 +400,6 @@ const EVENTS = {
   FINISH_SHARING_TWITTER: 'User Clicks Twitter Icon In Finish Congrats Dialog',
   FINISH_SHARING_LINK_SEND_TO_PHONE:
     'User Clicks Send To Phone In Finish Congrats Dialog',
-  FINISH_BUTTON_CERTIFICATE:
-    'User Clicks on Finish Button in Finish Congrats Dialog - Certificate',
 
   // Project submission
   SHARING_DIALOG_SUBMIT_TO_BE_FEATURED:
@@ -443,7 +407,6 @@ const EVENTS = {
   SUBMIT_PROJECT_DIALOG_SUBMIT: 'User Clicks Submit In Submit Project Dialog',
 
   // Add custom image to project
-  UPLOAD_CUSTOM_IMAGE: 'User clicks on upload image to project',
   MODERATE_CUSTOM_IMAGE: 'User-submitted image is moderated',
   SUBMIT_IMAGE_URL: 'User clicks on submit image URL to project',
   FLAGGED_CUSTOM_IMAGE:
@@ -550,7 +513,6 @@ const EVENTS = {
   CODEBRIDGE_CLEAR_CONSOLE: 'Console cleared on codebridge',
   CODEBRIDGE_MOVE_CONSOLE: 'Console moved on codebridge',
   CODEBRIDGE_POP_OUT_IMAGE: 'Image popped out of console on codebridge',
-  CODEBRIDGE_RUN_CLICK: 'Run button clicked on codebridge',
   CODEBRIDGE_VALIDATE_CLICK: 'Validate button clicked on codebridge',
   CODEBRIDGE_ZOOM: 'Zoomed in or out on codebridge',
 
@@ -565,7 +527,6 @@ const EVENTS = {
 
   // Teacher Navigation V2
   NAVIGATE_TO_SECTION: 'Local Nav Class Section Selected',
-  NAVIGATE_TO_PAGE: 'Local Nav Page Clicked',
   SECTION_LOAD_FAILURE: 'Local Nav Section Load Failure',
   UNIT_CALENDAR_FAILURE: 'Local Nav Unit Calendar Load Failure',
   VIEW_UNIT_CALENDAR: 'Local Nav View Unit Calendar',
@@ -718,7 +679,6 @@ const EVENT_GROUPS = {
   // Hour of Code - Dance Party
   [EVENTS.DANCE_PARTY_ACTIVITY_STARTED]: EVENT_GROUP_NAMES.DANCE_PARTY,
   [EVENTS.DANCE_PARTY_LEVEL_COMPLETED]: EVENT_GROUP_NAMES.DANCE_PARTY,
-  [EVENTS.DANCE_PARTY_AI_BACKGROUND_GENERATED]: EVENT_GROUP_NAMES.DANCE_PARTY,
   [EVENTS.DANCE_PARTY_AI_BACKGROUND_REGENERATED]: EVENT_GROUP_NAMES.DANCE_PARTY,
   [EVENTS.DANCE_PARTY_AI_BACKGROUND_USED]: EVENT_GROUP_NAMES.DANCE_PARTY,
   [EVENTS.DANCE_PARTY_AI_BACKGROUND_RESTARTED]: EVENT_GROUP_NAMES.DANCE_PARTY,
@@ -726,21 +686,12 @@ const EVENT_GROUPS = {
   [EVENTS.DANCE_PARTY_AI_BACKGROUND_EXPLAINED]: EVENT_GROUP_NAMES.DANCE_PARTY,
   [EVENTS.DANCE_PARTY_AI_EMOJI_USED]: EVENT_GROUP_NAMES.DANCE_PARTY,
   [EVENTS.DANCE_PARTY_SONG_UNAVAILABLE]: EVENT_GROUP_NAMES.DANCE_PARTY,
-  [EVENTS.DANCE_PARTY_AI_MODAL_CLOSED]: EVENT_GROUP_NAMES.DANCE_PARTY,
-
-  // videos
-  [EVENTS.VIDEO_LOADED]: EVENT_GROUP_NAMES.VIDEO_EVENTS,
-  [EVENTS.VIDEO_STARTED]: EVENT_GROUP_NAMES.VIDEO_EVENTS,
-  [EVENTS.VIDEO_PAUSED]: EVENT_GROUP_NAMES.VIDEO_EVENTS,
-  [EVENTS.VIDEO_ENDED]: EVENT_GROUP_NAMES.VIDEO_EVENTS,
 
   // Project sharing via 'Share' button
-  [EVENTS.SHARING_LINK_COPY]: EVENT_GROUP_NAMES.PROJECT_SHARING,
   [EVENTS.SHARING_PUBLISH]: EVENT_GROUP_NAMES.PROJECT_SHARING,
   [EVENTS.SHARING_FB]: EVENT_GROUP_NAMES.PROJECT_SHARING,
   [EVENTS.SHARING_TWITTER]: EVENT_GROUP_NAMES.PROJECT_SHARING,
   [EVENTS.SHARING_LINK_SEND_TO_PHONE]: EVENT_GROUP_NAMES.PROJECT_SHARING,
-  [EVENTS.SHARING_CLOSE_ESCAPE]: EVENT_GROUP_NAMES.PROJECT_SHARING,
 
   // Project sharing via 'Finish' button
   [EVENTS.FINISH_SHARING_LINK_COPY]: EVENT_GROUP_NAMES.FINISH_PROJECT_SHARING,
@@ -749,7 +700,6 @@ const EVENT_GROUPS = {
   [EVENTS.FINISH_SHARING_TWITTER]: EVENT_GROUP_NAMES.FINISH_PROJECT_SHARING,
   [EVENTS.FINISH_SHARING_LINK_SEND_TO_PHONE]:
     EVENT_GROUP_NAMES.FINISH_PROJECT_SHARING,
-  [EVENTS.FINISH_BUTTON_CERTIFICATE]: EVENT_GROUP_NAMES.FINISH_PROJECT_SHARING,
 };
 
 const EXPERIMENTS = {

--- a/apps/src/metrics/StatsigReporter.js
+++ b/apps/src/metrics/StatsigReporter.js
@@ -218,7 +218,13 @@ class StatsigReporter {
     }
     if (this.shouldPutRecord(ALWAYS_SEND)) {
       const client = new StatsigClient(this.api_key, this.user, this.options);
-      runStatsigAutoCapture(client);
+      runStatsigAutoCapture(client, {
+        eventFilterFunc: event =>
+          ![
+            'auto_capture::performance',
+            'auto_capture::page_view_end',
+          ].includes(event.eventName),
+      });
       await client.initializeAsync();
     }
   }

--- a/apps/src/music/analytics/AnalyticsReporter.ts
+++ b/apps/src/music/analytics/AnalyticsReporter.ts
@@ -133,10 +133,12 @@ export default class MusicAnalyticsReporter {
   }
 
   onKeyPressed(keyName: string, properties?: object) {
-    this.trackUIEvent('Key pressed', {
-      keyName,
-      ...properties,
-    });
+    this.log(
+      `Key pressed. Payload: ${JSON.stringify({
+        keyName,
+        ...properties,
+      })}`
+    );
   }
 
   onValidationAttempt(passed: boolean, message: string) {
@@ -148,7 +150,9 @@ export default class MusicAnalyticsReporter {
   }
 
   onGenerateAiPatternStart(temperature: number) {
-    this.trackUIEvent('Generate AI pattern start', {temperature});
+    this.log(
+      `Generate AI pattern start. Payload: ${JSON.stringify({temperature})}`
+    );
   }
 
   onGenerateAiPatternEnd(
@@ -156,11 +160,13 @@ export default class MusicAnalyticsReporter {
     isInitialGenerate: boolean,
     temperature: number
   ) {
-    this.trackUIEvent('Generate AI pattern end', {
-      timeSeconds,
-      isInitialGenerate,
-      temperature,
-    });
+    this.log(
+      `Generate AI pattern end. Payload: ${JSON.stringify({
+        timeSeconds,
+        isInitialGenerate,
+        temperature,
+      })}`
+    );
   }
 
   private trackUIEvent(eventType: string, payload: object = {}) {

--- a/apps/src/p5lab/AnimationPicker/AnimationUploadButton.jsx
+++ b/apps/src/p5lab/AnimationPicker/AnimationUploadButton.jsx
@@ -7,8 +7,6 @@ import {
   refreshInRestrictedShareMode,
   refreshTeacherHasConfirmedUploadWarning,
 } from '@cdo/apps/code-studio/projectRedux';
-import {EVENTS} from '@cdo/apps/metrics/AnalyticsConstants';
-import analyticsReporter from '@cdo/apps/metrics/AnalyticsReporter';
 import ImageUploadModal from '@cdo/apps/templates/imageUploadWarning/ImageUploadModal';
 import msg from '@cdo/locale';
 
@@ -29,7 +27,6 @@ export function UnconnectedAnimationUploadButton({
   onUploadClick,
   shouldWarnOnAnimationUpload,
   isBackgroundsTab,
-  projectType,
   teacherHasConfirmedUploadWarning,
   inRestrictedShareMode,
   refreshInRestrictedShareMode,
@@ -71,12 +68,6 @@ export function UnconnectedAnimationUploadButton({
       showUploadModal();
     } else {
       onUploadClick();
-      if (projectType) {
-        analyticsReporter.sendEvent(EVENTS.UPLOAD_CUSTOM_IMAGE, {
-          UploaderType: 'Animation Picker',
-          ProjectType: projectType,
-        });
-      }
     }
   };
 
@@ -125,7 +116,6 @@ UnconnectedAnimationUploadButton.propTypes = {
   onUploadClick: PropTypes.func.isRequired,
   shouldWarnOnAnimationUpload: PropTypes.bool.isRequired,
   isBackgroundsTab: PropTypes.bool.isRequired,
-  projectType: PropTypes.string,
   // populated from redux
   inRestrictedShareMode: PropTypes.bool.isRequired,
   teacherHasConfirmedUploadWarning: PropTypes.bool.isRequired,

--- a/apps/src/panels/PanelsLabView.tsx
+++ b/apps/src/panels/PanelsLabView.tsx
@@ -85,16 +85,13 @@ const PanelsLabView: React.FunctionComponent<
     nextPanel: number,
     timeSpentOnPanelSeconds: number
   ) => {
-    sendAnalyticsEvent(
-      source === 'button'
-        ? 'Panels Next Button Clicked'
-        : 'Panels Bubble Clicked',
-      {
+    if (source === 'bubble') {
+      sendAnalyticsEvent('Panels Bubble Clicked', {
         currentPanel,
         nextPanel,
         timeSpentOnPanelSeconds,
-      }
-    );
+      });
+    }
   };
 
   const onClickContinue = (

--- a/apps/src/sites/studio/pages/devise/sessions/_login.js
+++ b/apps/src/sites/studio/pages/devise/sessions/_login.js
@@ -6,8 +6,6 @@ import {USER_RETURN_TO_SESSION_KEY} from '@cdo/apps/signUpFlow/signUpFlowConstan
 import getScriptData from '@cdo/apps/util/getScriptData';
 
 $(document).ready(() => {
-  analyticsReporter.sendEvent(EVENTS.LOGIN_PAGE_VISITED, {});
-
   const userReturnTo = getScriptData('userReturnTo');
 
   if (userReturnTo) {
@@ -16,38 +14,6 @@ $(document).ready(() => {
 
   document.getElementById('user_signup').addEventListener('click', () => {
     analyticsReporter.sendEvent(EVENTS.LOGIN_PAGE_CREATE_ACCOUNT_CLICKED, {});
-  });
-
-  document.getElementById('signin-button').addEventListener('click', () => {
-    analyticsReporter.sendEvent(EVENTS.LOGIN_PAGE_SIGN_IN_CLICKED, {});
-  });
-
-  document
-    .getElementById('google_oauth2-sign-in')
-    .addEventListener('click', () => {
-      analyticsReporter.sendEvent(EVENTS.LOGIN_PAGE_OAUTH_CLICKED, {
-        provider: 'google',
-      });
-    });
-
-  document.getElementById('facebook-sign-in').addEventListener('click', () => {
-    analyticsReporter.sendEvent(EVENTS.LOGIN_PAGE_OAUTH_CLICKED, {
-      provider: 'facebook',
-    });
-  });
-
-  document
-    .getElementById('microsoft_v2_auth-sign-in')
-    .addEventListener('click', () => {
-      analyticsReporter.sendEvent(EVENTS.LOGIN_PAGE_OAUTH_CLICKED, {
-        provider: 'microsoft',
-      });
-    });
-
-  document.getElementById('clever-sign-in').addEventListener('click', () => {
-    analyticsReporter.sendEvent(EVENTS.LOGIN_PAGE_OAUTH_CLICKED, {
-      provider: 'clever',
-    });
   });
 
   const courseBlocks = document.querySelectorAll('.courseblock-tall');

--- a/apps/src/templates/courseOverview/CourseOverview.js
+++ b/apps/src/templates/courseOverview/CourseOverview.js
@@ -79,13 +79,6 @@ class CourseOverview extends Component {
           'unit group name': props.name,
         }
       );
-    } else if (props.userType === 'student') {
-      analyticsReporter.sendEvent(
-        EVENTS.COURSE_OVERVIEW_PAGE_VISITED_BY_STUDENT_EVENT,
-        {
-          'unit group name': props.name,
-        }
-      );
     } else {
       analyticsReporter.sendEvent(
         EVENTS.COURSE_OVERVIEW_PAGE_VISITED_BY_SIGNED_OUT_USER_EVENT,

--- a/apps/src/templates/sectionProgressV2/SectionProgressV2.jsx
+++ b/apps/src/templates/sectionProgressV2/SectionProgressV2.jsx
@@ -4,8 +4,6 @@ import React from 'react';
 import {connect} from 'react-redux';
 import {useParams} from 'react-router-dom';
 
-import {EVENTS} from '@cdo/apps/metrics/AnalyticsConstants';
-import analyticsReporter from '@cdo/apps/metrics/AnalyticsReporter';
 import {
   getSelectedCourseId,
   getSelectedUnitPosition,
@@ -43,12 +41,6 @@ function SectionProgressV2({
   const params = useParams();
   React.useEffect(() => {
     loadExpandedLessonsFromLocalStorage(scriptId, sectionId);
-    analyticsReporter.sendEvent(EVENTS.PROGRESS_V2_VIEW, {
-      sectionId: sectionId,
-      unitId: scriptId,
-      windowWidth: window.innerWidth,
-      windowHeight: window.innerHeight,
-    });
   }, [scriptId, sectionId, loadExpandedLessonsFromLocalStorage]);
 
   const levelDataInitialized = React.useMemo(() => {

--- a/apps/src/templates/teacherNavigation/SidebarOption.tsx
+++ b/apps/src/templates/teacherNavigation/SidebarOption.tsx
@@ -7,9 +7,6 @@ import classNames from 'classnames';
 import React from 'react';
 import {NavLink, generatePath} from 'react-router-dom';
 
-import {EVENTS} from '@cdo/apps/metrics/AnalyticsConstants';
-import analyticsReporter from '@cdo/apps/metrics/AnalyticsReporter';
-
 import {LABELED_TEACHER_NAVIGATION_PATHS} from './TeacherNavigationPaths';
 
 import styles from './teacher-navigation.module.scss';
@@ -33,12 +30,6 @@ const SidebarOption: React.FC<SidebarOptionProps> = ({
   pathKey,
   showErrorIcon,
 }) => {
-  const reportMetric = (path: string) => () => {
-    analyticsReporter.sendEvent(EVENTS.NAVIGATE_TO_PAGE, {
-      nextPage: path,
-    });
-  };
-
   return (
     <NavLink
       key={LABELED_TEACHER_NAVIGATION_PATHS[pathKey].label}
@@ -51,7 +42,6 @@ const SidebarOption: React.FC<SidebarOptionProps> = ({
       className={classNames(styles.sidebarOption, {
         [styles.selected]: isSelected,
       })}
-      onClick={reportMetric(pathKey)}
     >
       <div className={styles.iconContainer}>
         <FontAwesomeV6Icon

--- a/apps/src/userHeaderEventLogger/userHeaderEventLogger.js
+++ b/apps/src/userHeaderEventLogger/userHeaderEventLogger.js
@@ -4,7 +4,6 @@ import {EVENTS} from '@cdo/apps/metrics/AnalyticsConstants';
 import analyticsReporter from '@cdo/apps/metrics/AnalyticsReporter';
 import getScriptData from '@cdo/apps/util/getScriptData';
 
-const USER_MENU_OPTION_IDS = ['my-projects', 'user-edit', 'user-signout'];
 const HELP_ICON_OPTION_IDS = ['support', 'report-bug', 'teacher-community'];
 const HAMBURGER_OPTION_IDS = [
   'learn',
@@ -36,14 +35,14 @@ const addCreateMenuMetrics = (
 ) => {
   if (headerCreateMenu) {
     // Log if a signed-out user clicks the "Create" menu dropdown
-    headerCreateMenu.addEventListener('click', () => {
-      analyticsReporter.sendEvent(
-        isSignedIn
-          ? EVENTS.SIGNED_IN_USER_CLICKS_CREATE_DROPDOWN
-          : EVENTS.SIGNED_OUT_USER_CLICKS_CREATE_DROPDOWN,
-        additionalOptions
-      );
-    });
+    if (!isSignedIn) {
+      headerCreateMenu.addEventListener('click', () => {
+        analyticsReporter.sendEvent(
+          EVENTS.SIGNED_OUT_USER_CLICKS_CREATE_DROPDOWN,
+          additionalOptions
+        );
+      });
+    }
 
     // Log if a signed-out user clicks an option in the "Create" menu dropdown
     const createMenuOptions = getScriptData('createMenuOptions');
@@ -51,15 +50,15 @@ const addCreateMenuMetrics = (
       document
         .getElementById(`create_menu_option_${option}`)
         .addEventListener('click', () => {
-          analyticsReporter.sendEvent(
-            isSignedIn
-              ? EVENTS.SIGNED_IN_USER_SELECTS_CREATE_DROPDOWN_OPTION
-              : EVENTS.SIGNED_OUT_USER_SELECTS_CREATE_DROPDOWN_OPTION,
-            {
-              option: option,
-              ...additionalOptions,
-            }
-          );
+          if (!isSignedIn) {
+            analyticsReporter.sendEvent(
+              EVENTS.SIGNED_OUT_USER_SELECTS_CREATE_DROPDOWN_OPTION,
+              {
+                option: option,
+                ...additionalOptions,
+              }
+            );
+          }
         });
     });
   }
@@ -76,7 +75,9 @@ const addMenuMetrics = (
   if (menu) {
     // Log if a signed-out user clicks the "Create" menu dropdown
     menu.addEventListener('click', () => {
-      analyticsReporter.sendEvent(dropdownEventName, additionalOptions);
+      if (dropdownEventName) {
+        analyticsReporter.sendEvent(dropdownEventName, additionalOptions);
+      }
     });
 
     // Log if a signed-out user clicks an option in the "Create" menu dropdown
@@ -84,10 +85,12 @@ const addMenuMetrics = (
       const optionElement = document.getElementById(option);
       if (optionElement) {
         optionElement.addEventListener('click', () => {
-          analyticsReporter.sendEvent(optionEventName, {
-            option: option,
-            ...additionalOptions,
-          });
+          if (optionEventName) {
+            analyticsReporter.sendEvent(optionEventName, {
+              option: option,
+              ...additionalOptions,
+            });
+          }
         });
       }
     });
@@ -136,19 +139,7 @@ const addSignedInMetrics = (pageUrl, headerCreateMenu) => {
   };
 
   // Log if a header link is clicked
-  addClickEventToLinks(
-    'headerlink',
-    EVENTS.SIGNED_IN_USER_CLICKS_HEADER_LINK,
-    additionalOptions
-  );
-
-  addMenuMetrics(
-    'header_user_menu',
-    USER_MENU_OPTION_IDS,
-    EVENTS.SIGNED_IN_USER_CLICKS_USER_MENU,
-    EVENTS.SIGNED_IN_USER_CLICKS_USER_MENU_OPTION,
-    additionalOptions
-  );
+  // Intentionally do not log signed-in header link and user menu events.
 
   addMenuMetrics(
     'help-icon',
@@ -161,7 +152,7 @@ const addSignedInMetrics = (pageUrl, headerCreateMenu) => {
   addMenuMetrics(
     'hamburger-icon',
     HAMBURGER_OPTION_IDS,
-    EVENTS.SIGNED_IN_USER_CLICKS_HAMBURGER_LINK,
+    null,
     EVENTS.SIGNED_IN_USER_CLICKS_HAMBURGER_OPTION,
     additionalOptions
   );

--- a/apps/test/unit/lab2/hooks/useLevelActivityMetricsTest.tsx
+++ b/apps/test/unit/lab2/hooks/useLevelActivityMetricsTest.tsx
@@ -40,13 +40,6 @@ const defaultLevelProperties: LevelProperties = {
   appName: 'weblab2',
 };
 
-const projectLevelProperties: LevelProperties = {
-  isProjectLevel: true,
-  id: 456,
-  name: 'Project Level',
-  appName: 'weblab2',
-};
-
 const differentLevelProperties: LevelProperties = {
   isProjectLevel: false,
   id: 789,
@@ -117,25 +110,6 @@ describe('useLevelActivityMetrics', () => {
           unitName: 'test-script',
           levelId: 123,
           levelName: 'Test Level',
-        }
-      );
-      expect(mockSendLab2AnalyticsEvent).toHaveBeenCalledTimes(1);
-    });
-
-    it('logs PROJECT_ACTIVITY event when callback is invoked for project level', () => {
-      const {result} = renderHookWithRedux(projectLevelProperties);
-
-      act(() => {
-        result.current();
-      });
-
-      expect(mockSendLab2AnalyticsEvent).toHaveBeenCalledWith(
-        EVENTS.PROJECT_ACTIVITY,
-        {
-          signedIn: true,
-          unitName: 'test-script',
-          levelId: 456,
-          levelName: 'Project Level',
         }
       );
       expect(mockSendLab2AnalyticsEvent).toHaveBeenCalledTimes(1);
@@ -220,30 +194,6 @@ describe('useLevelActivityMetrics', () => {
           levelId: 789,
           levelName: 'Different Level',
         }
-      );
-    });
-
-    it('can log again for new level after reset', () => {
-      const {result: result1} = renderHookWithRedux(defaultLevelProperties);
-
-      act(() => {
-        result1.current();
-      });
-
-      const {result: result2} = renderHookWithRedux(projectLevelProperties);
-
-      act(() => {
-        result2.current();
-      });
-
-      expect(mockSendLab2AnalyticsEvent).toHaveBeenCalledTimes(2);
-
-      expect(mockSendLab2AnalyticsEvent).toHaveBeenLastCalledWith(
-        EVENTS.PROJECT_ACTIVITY,
-        expect.objectContaining({
-          levelId: 456,
-          levelName: 'Project Level',
-        })
       );
     });
   });

--- a/dashboard/config/initializers/devise.rb
+++ b/dashboard/config/initializers/devise.rb
@@ -360,14 +360,6 @@ Devise.setup do |config|
     end
   end
 
-  OmniAuth.config.before_request_phase do |env|
-    session = env['rack.session']
-    Metrics::Events.log_event(
-      session: session,
-      event_name: "#{env['omniauth.strategy'].options[:name]}-begin-auth",
-    )
-  end
-
   # ==> Mountable engine configurations
   # When using Devise inside an engine, let's call it `MyEngine`, and this engine
   # is mountable, there are some extra configurations to be taken into account.


### PR DESCRIPTION
This PR removes Statsig events marked as `Proposed for deprecation`, both `tier 1` and `tier 2`, in [this spreadsheet](https://docs.google.com/spreadsheets/d/1-uWJsG6qbws-4vJT7cOoGyVvL_X4GpCM4R23FP7f5Y8/edit?gid=512924262).

The events span many different areas of the code, in places it was necessary to update logic to account for removing events.

## Open Questions

I'm looking for input/answers for the following questions:

**Can we remove the following events that aren't flagged for deprecation? These events are tightly coupled with other events that are flagged for deprecation, but likely not flagged due to not generating enough event volume. However, it would clean up the code to also remove them, saving some clunky logic.**

- `Panels Bubble Clicked`
  - [ ] Yes
  - [ ] No
- `Signed Out User Clicks Create Dropdown`
  - [ ] Yes
  - [ ] No
- `Signed Out User Selects Create Dropdown Option`
  - [ ] Yes
  - [ ] No
- `Signed In User Clicks Hamburger Dropdown Option`
  - [ ] Yes
  - [ ] No

**There are a view places in the Music Lab AnalyticsReporter.ts were events are no longer sent to Statsig, but the local console.log functionality was retained. Is this helpful for development, or can we remove these `.log()` statements? [Example](https://github.com/code-dot-org/code-dot-org/pull/71187/changes#diff-4866ed60fcfbecda67246b071d61f8c5b5f59522e5f990d69dfb8bd87fe4f15aR136)**
- [ ] Ok to remove
- [ ] Please keep the `.log()`


## Additional Context
Below is a concise list of events removed in this PR:

* User Clicks on Finish Button in Finish Congrats Dialog - Certificate
* User clicks on upload image to project
* Video Loaded
* Project Activity
* Video Started
* Login Page Visited
* Dance Party Validation
* Video Paused
* Signed In User Clicks User Menu
* google\_oauth2-begin-auth (actually *-begin-auth)
* Run button clicked on codebridge
* Login Page OAuth Button Clicked
* User Clicks Project Copy Link In Share Dialog
* Hour of Code Activity Start Button Clicked
* Javalab Run Button Clicked
* Signed In User Clicks User Menu Option
* Signed In User Clicks Header Link
* Video Played To Completion
* Hour of Code Activities Page Visited
* auto\_capture::performance
* User Opens Project Share Dialog
* Javalab Compilation Success
* Signed In User Clicks Create Dropdown
* auto\_capture::page\_view\_end
* Section New Progress Viewed
* Signed In User Clicks Hamburger Link
* Login Page Sign In Button Clicked
* Panels Next Button Clicked
* User Clicks X Or Esc Button In Project Share Dialog
* Signed In User Selects Create Dropdown Option
* Course Overview Page Visited By Student
* Video Fallback Loaded
* Javalab Compilation Error
* Dance Party AI Background Generated
* Music Lab Generate AI pattern start
* Music Lab Generate AI pattern end
* Local Nav Page Clicked
* Dance Party AI Modal Closed
* Music Lab Key pressed

## Links
<!-- Jira tickets, design docs, Slack threads, related PRs, etc. -->

- Jira:

## Testing story
<!-- How was this tested? Manual steps, adhoc links, automated tests, or why testing isn't needed. -->



## Deployment notes
<!-- Delete this section if it's a standard merge-and-deploy.
     Otherwise: migrations, feature flags, coordination, caching impacts, etc. -->



## Privacy and security
<!-- Delete this section if there is no privacy/security impact.
     Otherwise: new PII, auth changes, API surface changes, etc. -->

