### PR TITLE
safely retrieve units

### DIFF
--- a/dashboard/app/models/concerns/user/assigned_courses_and_scripts.rb
+++ b/dashboard/app/models/concerns/user/assigned_courses_and_scripts.rb
@@ -14,7 +14,7 @@ module User::AssignedCoursesAndScripts
 
   # Returns the set of courses the user has been assigned to or has progress in.
   def courses_as_participant
-    unit_groups = user_scripts.map do |us|
+    unit_groups = Queries::ScriptActivity.in_progress_and_completed_scripts(self).map do |us|
       us.unit_group || us.script.original_unit_group
     end.compact.uniq
     unit_groups.filter!(&:launched?)

--- a/dashboard/lib/queries/script_activity.rb
+++ b/dashboard/lib/queries/script_activity.rb
@@ -26,7 +26,7 @@ class Queries::ScriptActivity
   def self.working_on_user_scripts(user)
     user.user_scripts.where(user_scripts: {completed_at: nil}).reject do |user_script|
       user_script.script.nil?
-    rescue
+    rescue ActiveRecord::RecordNotFound
       # Getting user_script.script can raise if the script does not exist.
       # In that case we should also reject this user_script.
       true
@@ -62,7 +62,7 @@ class Queries::ScriptActivity
   def self.in_progress_and_completed_scripts(user)
     user.user_scripts.compact.reject do |user_script|
       user_script.script.nil?
-    rescue
+    rescue ActiveRecord::RecordNotFound
       # Getting user_script.script can raise if the script does not exist
       # In that case we should also reject this user_script.
       true

--- a/dashboard/lib/queries/script_activity.rb
+++ b/dashboard/lib/queries/script_activity.rb
@@ -24,13 +24,9 @@ class Queries::ScriptActivity
   #
   # return [UserScript]
   def self.working_on_user_scripts(user)
-    user.user_scripts.where(user_scripts: {completed_at: nil}).reject do |user_script|
-      user_script.script.nil?
-    rescue ActiveRecord::RecordNotFound
-      # Getting user_script.script can raise if the script does not exist.
-      # In that case we should also reject this user_script.
-      true
-    end
+    user.user_scripts.
+      joins(:script).
+      where(user_scripts: {completed_at: nil})
   end
 
   # Retrieve all UserScripts for scripts this user has completed

--- a/dashboard/lib/queries/script_activity.rb
+++ b/dashboard/lib/queries/script_activity.rb
@@ -24,7 +24,13 @@ class Queries::ScriptActivity
   #
   # return [UserScript]
   def self.working_on_user_scripts(user)
-    user.user_scripts.where(user_scripts: {completed_at: nil})
+    user.user_scripts.where(user_scripts: {completed_at: nil}).reject do |user_script|
+      user_script.script.nil?
+    rescue
+      # Getting user_script.script can raise if the script does not exist.
+      # In that case we should also reject this user_script.
+      true
+    end
   end
 
   # Retrieve all UserScripts for scripts this user has completed

--- a/dashboard/test/controllers/home_controller_test.rb
+++ b/dashboard/test/controllers/home_controller_test.rb
@@ -531,4 +531,20 @@ class HomeControllerTest < ActionController::TestCase
     assert_equal "/s/#{script.name}", top_course[:linkToOverview]
     assert_equal "/s/#{script.name}/next", top_course[:linkToLesson]
   end
+
+  test "home does not 404 for users with deleted unit references" do
+    student = create(:student)
+    real_script = create(:script, :with_levels)
+    fake_script = create(:script, :with_levels)
+
+    create(:user_script, user: student, script: real_script, started_at: 2.days.ago)
+    create(:user_script, user: student, script: fake_script, started_at: 1.day.ago)
+
+    fake_script.destroy!
+
+    sign_in student
+    get :home
+
+    assert_response :success
+  end
 end

--- a/dashboard/test/controllers/home_controller_test.rb
+++ b/dashboard/test/controllers/home_controller_test.rb
@@ -534,13 +534,13 @@ class HomeControllerTest < ActionController::TestCase
 
   test "home does not 404 for users with deleted unit references" do
     student = create(:student)
-    real_script = create(:script, :with_levels)
-    fake_script = create(:script, :with_levels)
+    current_script = create(:script, :with_levels)
+    deleted_script = create(:script, :with_levels)
 
-    create(:user_script, user: student, script: real_script, started_at: 2.days.ago)
-    create(:user_script, user: student, script: fake_script, started_at: 1.day.ago)
+    create(:user_script, user: student, script: current_script, started_at: 2.days.ago)
+    create(:user_script, user: student, script: deleted_script, started_at: 1.day.ago)
 
-    fake_script.destroy!
+    deleted_script.destroy!
 
     sign_in student
     get :home

--- a/dashboard/test/lib/queries/script_activity_test.rb
+++ b/dashboard/test/lib/queries/script_activity_test.rb
@@ -114,17 +114,17 @@ class Queries::ScriptActivityTest < ActiveSupport::TestCase
   end
 
   test 'primary_student_unit_context skips deleted scripts' do
-    new_script = create(:script)
-    old_script = create(:script)
+    current_script = create(:script)
+    deleted_script = create(:script)
 
-    create(:user_script, user: @user, script: new_script, started_at: 3.days.ago)
-    create(:user_script, user: @user, script: old_script, started_at: 1.day.ago)
+    create(:user_script, user: @user, script: current_script, started_at: 3.days.ago)
+    create(:user_script, user: @user, script: deleted_script, started_at: 1.day.ago)
 
-    old_script.destroy!
+    deleted_script.destroy!
 
     context = Queries::ScriptActivity.primary_student_unit_context(@user)
     refute_nil context
-    assert_equal new_script, context[:unit]
+    assert_equal current_script, context[:unit]
   end
 
   test 'user is working on pl scripts' do

--- a/dashboard/test/lib/queries/script_activity_test.rb
+++ b/dashboard/test/lib/queries/script_activity_test.rb
@@ -113,6 +113,20 @@ class Queries::ScriptActivityTest < ActiveSupport::TestCase
     assert_equal unit_group_2, context[:unit_group_unit].unit_group
   end
 
+  test 'primary_student_unit_context skips deleted scripts' do
+    new_script = create(:script)
+    old_script = create(:script)
+
+    create(:user_script, user: @user, script: new_script, started_at: 3.days.ago)
+    create(:user_script, user: @user, script: old_script, started_at: 1.day.ago)
+
+    old_script.destroy!
+
+    context = Queries::ScriptActivity.primary_student_unit_context(@user)
+    refute_nil context
+    assert_equal new_script, context[:unit]
+  end
+
   test 'user is working on pl scripts' do
     teacher = create(:teacher)
     script1 = create(:single_unit_course, :pl_course, published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.stable).first_unit


### PR DESCRIPTION
Fixes a bug where students see a 404 on the homepage, but not other pages. [Reports](https://codedotorg.slack.com/archives/C046G4TRLEN/p1763668861527789) have come from old test accounts for Code.org employees, but this likely affects some small subset of older student accounts. This error can be reproduced by viewing the homepage as a student with a `UserScript` entry referencing a non-existent `Unit`.

This PR fixes the bug by:
- Updating `User::AssignedCoursesAndScripts#courses_as_participant` to call `Queries::ScriptActivity.in_progress_and_completed_scripts`, which guards against nil references, instead of a bare call for the user's `user_scripts`.
- Adds the same nil check from the `in_progress_and_completed_scripts` query to the `working_on_user_scripts` query.

**Repro steps:**

- Create student account assigned to a unit/script
- Leave the UserScript record in place, but delete the script/unit itself, so that the script_id in the UserScript references a nil entry.
- View the home page, get a 404

**Video Repro:**

https://github.com/user-attachments/assets/362165a8-1e83-4e00-bd61-f7a8137fb066

**Video Post-fix:**

https://github.com/user-attachments/assets/731e7584-8665-49f1-99a3-7f18fb26a42a



**Technical Explanation:**

1. When a user hits the homepage, it calls [HomeController#init_homepage](https://github.com/code-dot-org/code-dot-org/blob/staging/dashboard/app/controllers/home_controller.rb#L120), which fetches the user's [unit context](https://github.com/code-dot-org/code-dot-org/blob/staging/dashboard/app/controllers/home_controller.rb#L147). This calls `Queries::ScriptActivity.working_on_user_scripts`, which doesn't have a check for bad Unit references.
2. If the user has UserScript entries that point to invalid/missing scripts/units, [Unit.get_from_cache](https://github.com/code-dot-org/code-dot-org/blob/staging/dashboard/app/models/unit.rb#L470-L492) fails and raises `ActiveRecord::RecordNotFound`.
3. Rails is somehow mapping this error to an HTTP 404, which ultimately calls the [render_404 route](https://github.com/code-dot-org/code-dot-org/blob/staging/dashboard/app/controllers/application_controller.rb#L92-L97) in ApplicationController.

The [error message](https://github.com/code-dot-org/code-dot-org/blob/staging/dashboard/app/models/unit.rb#L490) that gets raised in the Unit model can be seen in New Relic transaction errors:
```
Controller/application/render_404::ActiveRecord::RecordNotFound
Couldn't find Unit with id|name=441
```


## Links
[JIRA](https://codedotorg.atlassian.net/browse/P20-1746)

## Testing story
<!-- How was this tested? Manual steps, adhoc links, automated tests, or why testing isn't needed. -->



## Deployment notes
<!-- Delete this section if it's a standard merge-and-deploy.
     Otherwise: migrations, feature flags, coordination, caching impacts, etc. -->



## Privacy and security
<!-- Delete this section if there is no privacy/security impact.
     Otherwise: new PII, auth changes, API surface changes, etc. -->

