### PR TITLE
Revert "FIX: Export Large Tables to Redshift via Zero-ETL"

### DIFF
--- a/aws/cloudformation/components/database.yml.erb
+++ b/aws/cloudformation/components/database.yml.erb
@@ -323,11 +323,7 @@
         - "arn:aws:rds:${AWS::Region}:${AWS::AccountId}:cluster:${ClusterId}"
         - ClusterId: <%=rack_env?(:production) ? PRODUCTION_DB_CLUSTER_ID : '!Ref AuroraCluster' %>
       TargetArn: !ImportValue DATA-production-RedshiftClusterNamespace
-      DataFilter:
-        - !Sub "include: dashboard_<%=rack_env%>.levels"
-        - !Sub "include: dashboard_<%=rack_env%>.user_levels"
-        - !Sub "include: dashboard_<%=rack_env%>.level_sources"
-        - !Sub "include: dashboard_<%=rack_env%>.projects"
+      DataFilter: !Sub "include: dashboard_<%=rack_env %>.levels"
       Tags:
         - Key: environment
           Value: "<%=rack_env %>"

--- a/aws/cloudformation/components/database.yml.erb
+++ b/aws/cloudformation/components/database.yml.erb
@@ -323,11 +323,11 @@
         - "arn:aws:rds:${AWS::Region}:${AWS::AccountId}:cluster:${ClusterId}"
         - ClusterId: <%=rack_env?(:production) ? PRODUCTION_DB_CLUSTER_ID : '!Ref AuroraCluster' %>
       TargetArn: !ImportValue DATA-production-RedshiftClusterNamespace
-      DataFilter: >-
-        include: dashboard_<%=rack_env%>.levels,
-        include: dashboard_<%=rack_env%>.user_levels,
-        include: dashboard_<%=rack_env%>.level_sources,
-        include: dashboard_<%=rack_env%>.projects
+      DataFilter:
+        - !Sub "include: dashboard_<%=rack_env%>.levels"
+        - !Sub "include: dashboard_<%=rack_env%>.user_levels"
+        - !Sub "include: dashboard_<%=rack_env%>.level_sources"
+        - !Sub "include: dashboard_<%=rack_env%>.projects"
       Tags:
         - Key: environment
           Value: "<%=rack_env %>"


### PR DESCRIPTION
Reverts code-dot-org/code-dot-org#71185

CloudFormation isn't really capable of deploying this type of change to Zero ETL because it waits for the new tables to sync and these are large tables that take longer to sync than the CloudFormation Resource update timeout.