### PR TITLE
Fix optional chaining for tips and misconceptions

### DIFF
--- a/apps/src/templates/teacherNavigation/lessonMaterials/LessonMaterialsContainer.tsx
+++ b/apps/src/templates/teacherNavigation/lessonMaterials/LessonMaterialsContainer.tsx
@@ -430,7 +430,7 @@ const LessonMaterialsContainer: React.FC<LessonMaterialsContainerProps> = ({
                   {i18n.tipsHeader()}
                 </Typography>
                 <ol>
-                  {aiTALessonSummaryInfo?.tips.map((tip, index) => (
+                  {aiTALessonSummaryInfo?.tips?.map((tip, index) => (
                     <li key={`tip-${index}`}>
                       <Typography variant="body3" gutterBottom>
                         {tip}
@@ -444,7 +444,7 @@ const LessonMaterialsContainer: React.FC<LessonMaterialsContainerProps> = ({
                   {i18n.commonMisconceptions()}
                 </Typography>
                 <ul>
-                  {aiTALessonSummaryInfo?.misconceptions.map(
+                  {aiTALessonSummaryInfo?.misconceptions?.map(
                     (misconception, index) => (
                       <li key={`misconception-${index}`}>
                         <Typography variant="body3" gutterBottom>


### PR DESCRIPTION
We had a Zendesk ticket that shows a JavaScript error trying to call `map` on `undefined`. Based on the line number provided in the stack trace it looks to have been `aiTALessonSummaryInfo.tips` that was undefined. This change adds a `?` in two spots to make the statement return null rather than causing an error.

<!--
  Summary of the change: background, motivation, and context.
  Include screenshots, videos, or before/after comparisons for UI changes.
-->



## Links
[Zendesk](https://codeorg.zendesk.com/agent/tickets/578394)

## Testing story
<!-- How was this tested? Manual steps, adhoc links, automated tests, or why testing isn't needed. -->



## Deployment notes
<!-- Delete this section if it's a standard merge-and-deploy.
     Otherwise: migrations, feature flags, coordination, caching impacts, etc. -->



## Privacy and security
<!-- Delete this section if there is no privacy/security impact.
     Otherwise: new PII, auth changes, API surface changes, etc. -->

