### PR TITLE
[All labs] Fix copyright dialog label violation

### DIFF
--- a/apps/src/sharedComponents/AccessibleDialog.jsx
+++ b/apps/src/sharedComponents/AccessibleDialog.jsx
@@ -22,6 +22,7 @@ function AccessibleDialog({
   onDeactivate = onClose,
   noMC = false, // exclude MineCraft button styles
   theme,
+  ariaLabel,
 }) {
   // If these styles are provided by the given stylesheet, use them
   const modalStyle = styles?.modal || defaultStyle.modal;
@@ -51,6 +52,7 @@ function AccessibleDialog({
             aria-labelledby={`${id}-title`}
             className={classnames(modalStyle, className)}
             role="dialog"
+            aria-label={ariaLabel}
           >
             <CloseButton
               id="ui-close-dialog"
@@ -79,6 +81,7 @@ AccessibleDialog.propTypes = {
   onDeactivate: PropTypes.func,
   noMC: PropTypes.bool,
   theme: PropTypes.string,
+  ariaLabel: PropTypes.string,
 };
 
 export default AccessibleDialog;

--- a/apps/src/sharedComponents/AccessibleDialog.jsx
+++ b/apps/src/sharedComponents/AccessibleDialog.jsx
@@ -49,7 +49,6 @@ function AccessibleDialog({
           <div
             id={id}
             aria-modal
-            aria-labelledby={`${id}-title`}
             className={classnames(modalStyle, className)}
             role="dialog"
             aria-label={ariaLabel}

--- a/apps/src/sharedComponents/footer/CopyrightDialog/index.tsx
+++ b/apps/src/sharedComponents/footer/CopyrightDialog/index.tsx
@@ -33,7 +33,7 @@ const CopyrightDialog: React.FC<CopyrightDialogProps> = ({
       className="copyrightDialog"
       onClose={closeModal}
       closeOnClickBackdrop={true}
-      ariaLabel="Copyright Information"
+      ariaLabel={i18n.copyright()}
     >
       <div>
         <div>

--- a/apps/src/sharedComponents/footer/CopyrightDialog/index.tsx
+++ b/apps/src/sharedComponents/footer/CopyrightDialog/index.tsx
@@ -33,6 +33,7 @@ const CopyrightDialog: React.FC<CopyrightDialogProps> = ({
       className="copyrightDialog"
       onClose={closeModal}
       closeOnClickBackdrop={true}
+      ariaLabel="Copyright Information"
     >
       <div>
         <div>


### PR DESCRIPTION
The ol' AccessibleDialog didn't have an aria label attribute. This PR adds that param as well as fixing the copyright dialog WCAG violation. See before vs after screenreader experience to hear the difference!

<img width="1533" height="848" alt="Screenshot 2026-03-06 at 3 26 05 PM" src="https://github.com/user-attachments/assets/a63e31fa-d004-4d7c-9681-976186a3134f" />


Before:

https://github.com/user-attachments/assets/0c0a0f28-f6de-42ea-a86d-32e1f38f5e4c


After:

https://github.com/user-attachments/assets/84c405c6-42cc-4ba2-8eff-20b40c3138ac



## Links

- Jira: https://codedotorg.atlassian.net/browse/SL-1617

## Testing story
<!-- How was this tested? Manual steps, adhoc links, automated tests, or why testing isn't needed. -->



## Deployment notes
<!-- Delete this section if it's a standard merge-and-deploy.
     Otherwise: migrations, feature flags, coordination, caching impacts, etc. -->



## Privacy and security
<!-- Delete this section if there is no privacy/security impact.
     Otherwise: new PII, auth changes, API surface changes, etc. -->

