### PR TITLE
fix: packaging and build on levelbuilder and production environments

### DIFF
--- a/lib/cdo/aws/turbo_s3_packaging.rb
+++ b/lib/cdo/aws/turbo_s3_packaging.rb
@@ -27,6 +27,7 @@ class TurboS3Packaging < S3Packaging
   # initialize and again inside create_package to detect mid-build changes.
   def regenerate_commit_hash
     Dir.chdir(@frontend_dir) do
+      RakeUtils.yarn_install
       output = `yarn turbo build --filter #{@turbo_filter} --dry-run=json 2>/dev/null`
       data = JSON.parse(output)
       task_id = "#{@turbo_filter}#build"

--- a/lib/rake/build.rake
+++ b/lib/rake/build.rake
@@ -223,7 +223,7 @@ namespace :build do
 
   tasks = []
   tasks << :apps if CDO.build_apps
-  tasks << :studio if CDO.build_studio && !Rails.env.levelbuilder? && !Rails.env.production?
+  tasks << :studio if CDO.build_studio && !rack_env?(:levelbuilder) && !rack_env?(:production)
   tasks << :dashboard if CDO.build_dashboard
   tasks << :pegasus if CDO.build_pegasus
   tasks << :i18n if CDO.build_i18n

--- a/lib/rake/build.rake
+++ b/lib/rake/build.rake
@@ -223,7 +223,7 @@ namespace :build do
 
   tasks = []
   tasks << :apps if CDO.build_apps
-  tasks << :studio if CDO.build_studio
+  tasks << :studio if CDO.build_studio && !Rails.env.levelbuilder? && !Rails.env.production?
   tasks << :dashboard if CDO.build_dashboard
   tasks << :pegasus if CDO.build_pegasus
   tasks << :i18n if CDO.build_i18n

--- a/lib/rake/package.rake
+++ b/lib/rake/package.rake
@@ -76,6 +76,9 @@ namespace :package do
 
     desc 'Update studio static asset package.'
     timed_task_with_logging 'update' do
+      # temporarily skip if levelbuilder or production
+      next if Rails.env.levelbuilder? || Rails.env.production?
+
       # never download if we build our own and we're not building a package ourselves.
       next if CDO.use_my_studio && !BUILD_PACKAGE
 
@@ -90,6 +93,9 @@ namespace :package do
 
     desc 'Build and test studio package and upload to S3.'
     timed_task_with_logging 'build' do
+      # temporarily skip if levelbuilder or production
+      next if Rails.env.levelbuilder? || Rails.env.production?
+
       # Store initial turbo hash to make sure inputs don't change during the build.
       # Turborepo's hash covers all source inputs, replacing the git-tree-hash
       # approach used for apps.

--- a/lib/rake/package.rake
+++ b/lib/rake/package.rake
@@ -77,7 +77,7 @@ namespace :package do
     desc 'Update studio static asset package.'
     timed_task_with_logging 'update' do
       # temporarily skip if levelbuilder or production
-      next if Rails.env.levelbuilder? || Rails.env.production?
+      next if rack_env?(:levelbuilder) || rack_env?(:production)
 
       # never download if we build our own and we're not building a package ourselves.
       next if CDO.use_my_studio && !BUILD_PACKAGE
@@ -94,7 +94,7 @@ namespace :package do
     desc 'Build and test studio package and upload to S3.'
     timed_task_with_logging 'build' do
       # temporarily skip if levelbuilder or production
-      next if Rails.env.levelbuilder? || Rails.env.production?
+      next if rack_env?(:levelbuilder) || rack_env?(:production)
 
       # Store initial turbo hash to make sure inputs don't change during the build.
       # Turborepo's hash covers all source inputs, replacing the git-tree-hash


### PR DESCRIPTION
This PR fixes a levelbuilder and production build order issue for packaging and building the `studio` app.

- Removes extraneous committed files in `dashbard/public`
- Disables packaging and building in levelbuilder and production