### PR TITLE
Lab2: remove unused props from instructions

### DIFF
--- a/apps/src/codebridge/InfoPanel/InfoPanel.tsx
+++ b/apps/src/codebridge/InfoPanel/InfoPanel.tsx
@@ -38,7 +38,6 @@ export const InfoPanel: React.FunctionComponent<InfoPanelProps> = ({
     levelProperties,
     onRun,
     onStop,
-    AiTutorResponseView,
     hiddenContextCallback,
     startSources,
     aiTutorSystemPrompt,
@@ -143,7 +142,6 @@ export const InfoPanel: React.FunctionComponent<InfoPanelProps> = ({
           isValidating,
           isValidateDisabled: !hasLoadedEnvironment || isRunning,
         }}
-        AiTutorResponseView={AiTutorResponseView}
         className={moduleStyles.instructionsContainer}
         headerClassName={moduleStyles.infoPanelHeader}
         levelProperties={levelProperties}

--- a/apps/src/codebridge/codebridgeContext/codebridgeContext.tsx
+++ b/apps/src/codebridge/codebridgeContext/codebridgeContext.tsx
@@ -24,7 +24,6 @@ export type CodebridgeContextType = {
   levelProperties: CodebridgeLevelProperties;
   projectPickerSettings?: ProjectPickerSettings;
   hiddenContextCallback?: () => Promise<string>;
-  AiTutorResponseView?: React.ReactNode;
   onImageFlagged?: (
     file: File,
     fileType: string,

--- a/apps/src/lab2/views/components/Instructions/InstructionsV2.tsx
+++ b/apps/src/lab2/views/components/Instructions/InstructionsV2.tsx
@@ -1,6 +1,6 @@
 import {Theme, useTheme} from '@code-dot-org/component-library/common/contexts';
 import classNames from 'classnames';
-import React, {useRef, MutableRefObject} from 'react';
+import React, {useRef, MutableRefObject, memo} from 'react';
 
 import InstructorsOnly from '@cdo/apps/code-studio/components/InstructorsOnly';
 import {queryParams} from '@cdo/apps/code-studio/utils';
@@ -23,22 +23,14 @@ export interface InstructionsProps {
   hasRun: boolean;
   /** Whether the lab's code has been edited on this level. */
   hasEdited: boolean;
-  /** If the instructions panel should be rendered vertically or horizontally. Defaults to vertical. */
-  layout?: 'vertical' | 'horizontal';
   /**
    * A callback when the user clicks on clickable text.
    */
   handleInstructionsTextClick?: (id: string) => void;
-  /** Optional classname for the container */
-  className?: string;
   /** Optional component to render at the bottom of the main instructions. */
   bottomComponent?: React.ReactNode;
-  /** Props for in-panel validation button and results table. */
-  validationSettings?: ValidationSettings;
   /** If the instructions panel should always have a dark background, regardless of theme */
   fixedDarkBackground?: boolean;
-  /** Component to use for AI Tutor responses, if any. */
-  AiTutorResponseView?: React.ReactNode;
   overrideTheme?: Theme;
   /** If the lab requires the user to click run in order to continue.
    * Only applies to non-validated levels. */
@@ -47,13 +39,6 @@ export interface InstructionsProps {
   hideNavigation?: boolean;
   /** If the continue button should be hidden if disabled. */
   hideContinueIfDisabled?: boolean;
-}
-
-export interface ValidationSettings {
-  onValidate: () => void;
-  onStopValidation: () => void;
-  isValidating: boolean;
-  isValidateDisabled: boolean;
 }
 
 /**
@@ -66,31 +51,26 @@ export interface ValidationSettings {
  */
 const Instructions: React.FunctionComponent<InstructionsProps> = ({
   levelProperties,
-  layout = 'vertical',
   handleInstructionsTextClick,
-  className,
   bottomComponent,
-  validationSettings,
   fixedDarkBackground,
-  AiTutorResponseView,
   overrideTheme,
   hideNavigation = false,
   hideContinueIfDisabled = false,
   ...feedbackProps
 }) => {
-  const {longInstructions, predictSettings, offerBrowserTts} = levelProperties;
+  const {longInstructions, predictSettings, offerBrowserTts, appName} =
+    levelProperties;
   const isPredictLevel = predictSettings?.isPredictLevel;
   const showTts = offerBrowserTts || queryParams('show-tts') === 'true';
   const {theme: defaultTheme} = useTheme();
   const ref: MutableRefObject<HTMLDivElement | null> = useRef(null);
-  const appName = levelProperties.appName;
 
   // Don't render anything if we don't have any instructions.
   if (longInstructions === undefined) {
     return null;
   }
 
-  const vertical = layout === 'vertical';
   return (
     <div
       id="instructions"
@@ -99,20 +79,14 @@ const Instructions: React.FunctionComponent<InstructionsProps> = ({
         fixedDarkBackground
           ? moduleStyles.fixedDarkBackground
           : moduleStyles.standardBackground,
-        moduleStyles['instructions-' + layout],
-        vertical && moduleStyles.vertical,
-        'instructions',
-        className
+        'instructions'
       )}
       data-theme={overrideTheme || defaultTheme}
     >
       <div
         id="instructions-panel"
         aria-live="polite"
-        className={classNames(
-          moduleStyles.item,
-          vertical && moduleStyles.itemVertical
-        )}
+        className={classNames(moduleStyles.item, moduleStyles.itemVertical)}
       >
         <div
           key={longInstructions}
@@ -143,7 +117,6 @@ const Instructions: React.FunctionComponent<InstructionsProps> = ({
             </div>
           )}
         </div>
-        {AiTutorResponseView && AiTutorResponseView}
         {isPredictLevel && (
           <>
             <InstructorsOnly>
@@ -173,4 +146,4 @@ const Instructions: React.FunctionComponent<InstructionsProps> = ({
     </div>
   );
 };
-export default Instructions;
+export default memo(Instructions);

--- a/apps/src/lab2/views/components/Instructions/ResourcePanel/ValidationPanel.tsx
+++ b/apps/src/lab2/views/components/Instructions/ResourcePanel/ValidationPanel.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 
-import {ValidationSettings} from '../InstructionsV2';
 import ValidationButton from '../ValidationButton';
 
 import {
@@ -10,6 +9,13 @@ import {
 import ValidationTable from './ValidationTable';
 
 import validationStyles from './validation-panel.module.scss';
+
+export interface ValidationSettings {
+  onValidate: () => void;
+  onStopValidation: () => void;
+  isValidating: boolean;
+  isValidateDisabled: boolean;
+}
 
 const ValidationPanel: React.FC<ValidationSettings> = ({
   onValidate,

--- a/apps/src/lab2/views/components/Instructions/ResourcePanel/ValidationTourSteps.tsx
+++ b/apps/src/lab2/views/components/Instructions/ResourcePanel/ValidationTourSteps.tsx
@@ -2,7 +2,6 @@ import {Steps} from 'intro.js-react';
 import React, {useState, useEffect} from 'react';
 
 import {sendLab2AnalyticsEvent} from '@cdo/apps/lab2/utils';
-import {ValidationSettings} from '@cdo/apps/lab2/views/components/Instructions/InstructionsV2';
 import {EVENTS} from '@cdo/apps/metrics/AnalyticsConstants';
 import {commonI18n} from '@cdo/apps/types/locale';
 import {tryGetLocalStorage, trySetLocalStorage} from '@cdo/apps/utils';
@@ -26,7 +25,7 @@ const VALIDATION_FLOW_NAME = 'Resource Panel Validation';
 
 interface ValidationTourStepsProps {
   hasValidationConditions: boolean;
-  validationSettings: ValidationSettings | undefined;
+  hasValidationSettings: boolean;
   setCurrentTab: (tab: Tabs) => void;
   onValidate: (() => void) | undefined;
 }
@@ -35,7 +34,7 @@ interface ValidationTourStepsProps {
 // have a validation system similar to Python Lab.
 const ValidationTourSteps: React.FC<ValidationTourStepsProps> = ({
   hasValidationConditions,
-  validationSettings,
+  hasValidationSettings,
   setCurrentTab,
   onValidate,
 }) => {
@@ -69,7 +68,7 @@ const ValidationTourSteps: React.FC<ValidationTourStepsProps> = ({
 
   useEffect(() => {
     const shouldShowValidationTour =
-      validationSettings &&
+      hasValidationSettings &&
       hasValidationConditions &&
       validationTourSeen !== 'yes' &&
       onboardingTourSeen === 'yes'; // If user hasn't seen both tours, show onboarding tour first.
@@ -77,7 +76,7 @@ const ValidationTourSteps: React.FC<ValidationTourStepsProps> = ({
       setValidationTourEnabled(true);
     }
   }, [
-    validationSettings,
+    hasValidationSettings,
     hasValidationConditions,
     validationTourSeen,
     onboardingTourSeen,

--- a/apps/src/lab2/views/components/Instructions/ResourcePanel/index.tsx
+++ b/apps/src/lab2/views/components/Instructions/ResourcePanel/index.tsx
@@ -52,7 +52,7 @@ import ResourcePanelExtraLinks from './ResourcePanelExtraLinks';
 import setFooterVisibility from './setFooterVisibility';
 import SettingsPanel from './SettingsPanel';
 import {Tabs} from './types';
-import ValidationPanel from './ValidationPanel';
+import ValidationPanel, {ValidationSettings} from './ValidationPanel';
 import ValidationTourSteps from './ValidationTourSteps';
 import {VersionHistoryPanel} from './VersionHistory';
 
@@ -145,6 +145,7 @@ type ResourcePanelProps = InstructionsProps & {
     uploadFunction: () => Promise<void>
   ) => void;
   hasInstructionsDrawer?: boolean;
+  validationSettings?: ValidationSettings;
 };
 
 /**
@@ -172,6 +173,7 @@ const ResourcePanel: React.FC<ResourcePanelProps> = ({
   backpackProps,
   onImageFlagged,
   hasInstructionsDrawer,
+  validationSettings,
   ...instructionsProps
 }) => {
   const {theme} = useTheme();
@@ -251,35 +253,26 @@ const ResourcePanel: React.FC<ResourcePanelProps> = ({
       tabMap[Tabs.Instructions] = instructionsContent;
     }
 
-    if (instructionsProps.validationSettings && hasValidationConditions) {
-      tabMap[Tabs.Validation] = (
-        <ValidationPanel {...instructionsProps.validationSettings} />
-      );
+    if (validationSettings && hasValidationConditions) {
+      tabMap[Tabs.Validation] = <ValidationPanel {...validationSettings} />;
     }
 
     if (hiddenContextCallback && aiTutorVisible) {
+      const aiTutorProps = {
+        hiddenContextCallback,
+        aiTutorMultimodalEnabled,
+        levelName,
+        channelId,
+        aiTutorChatButtonData,
+        aiTutorSystemPrompt,
+        aiTutorResponseSchemaSettings,
+      };
       if (!hasInstructionsDrawer || !levelProperties.longInstructions) {
-        tabMap[Tabs.AiTutor] = (
-          <AiTutorChat
-            hiddenContextCallback={hiddenContextCallback}
-            aiTutorMultimodalEnabled={aiTutorMultimodalEnabled}
-            levelName={levelName}
-            channelId={channelId}
-            aiTutorChatButtonData={aiTutorChatButtonData}
-            aiTutorSystemPrompt={aiTutorSystemPrompt}
-            aiTutorResponseSchemaSettings={aiTutorResponseSchemaSettings}
-          />
-        );
+        tabMap[Tabs.AiTutor] = <AiTutorChat {...aiTutorProps} />;
       } else {
         tabMap[Tabs.AiTutor] = (
           <AiTutorChatWithInstructionDrawer
-            hiddenContextCallback={hiddenContextCallback}
-            aiTutorMultimodalEnabled={aiTutorMultimodalEnabled}
-            levelName={levelName}
-            channelId={channelId}
-            aiTutorChatButtonData={aiTutorChatButtonData}
-            aiTutorSystemPrompt={aiTutorSystemPrompt}
-            aiTutorResponseSchemaSettings={aiTutorResponseSchemaSettings}
+            {...aiTutorProps}
             instructionsContent={instructionsContent}
             isCollapsedByDefault={!!viewAsUserId}
           />
@@ -371,6 +364,7 @@ const ResourcePanel: React.FC<ResourcePanelProps> = ({
     backpackRefreshKey,
     onImageFlagged,
     hasInstructionsDrawer,
+    validationSettings,
   ]);
 
   const hasTabs = useMemo(() => {
@@ -518,9 +512,9 @@ const ResourcePanel: React.FC<ResourcePanelProps> = ({
         <IntroJSTourWrapper enabled={isValidationTourEnabled}>
           <ValidationTourSteps
             hasValidationConditions={hasValidationConditions}
-            validationSettings={instructionsProps.validationSettings}
+            hasValidationSettings={!!validationSettings}
             setCurrentTab={setCurrentTab}
-            onValidate={instructionsProps.validationSettings?.onValidate}
+            onValidate={validationSettings?.onValidate}
           />
         </IntroJSTourWrapper>
         <div


### PR DESCRIPTION
Went down a bit of a rabbit hole related to ResourcePanel during some other work and noticed some unused props in Lab2 Instructions were causing extra re-renders. No major functional or performance change, but react devtools show that instructions now re-render much less frequently - for example, no renders during workspace typing or resizing.

## Testing story
Tested locally with React devtools