### PR TITLE
Fix small footer locale dropdown race

### DIFF
--- a/apps/src/code-studio/components/SmallFooter.jsx
+++ b/apps/src/code-studio/components/SmallFooter.jsx
@@ -76,12 +76,10 @@ export default class SmallFooter extends React.Component {
     );
 
     localization.on('change', info => {
-      debounce(() => {
-        this.setState({
-          localeOptions: localization.locales,
-          currentLocale: info.locale,
-        });
-      }, 100);
+      this.setState({
+        localeOptions: localization.locales,
+        currentLocale: info.locale,
+      });
     });
   }
 


### PR DESCRIPTION
The debounce somehow swallows the state update causing the small footer to think it should be `en-US` (the old default) which doesn't exist in the new TMS (it is `en`) and so it selects the first entry in the dropdown by default instead (`es-LA`)

We just remove the debounce. It isn't necessary.

## Links
<!-- Jira tickets, design docs, Slack threads, related PRs, etc. -->

- Jira: [GERW-1](https://codedotorg.atlassian.net/browse/GERW-1)