### PR TITLE
Convert useRegionalPartnerTest to React Testing Library, use renderHook

### DIFF
--- a/apps/test/unit/code-studio/pd/components/useRegionalPartnerTest.js
+++ b/apps/test/unit/code-studio/pd/components/useRegionalPartnerTest.js
@@ -35,7 +35,9 @@ describe('useRegionalPartner tests', () => {
   });
 
   it('returns undefined when loading', () => {
+    // Mock fetch to never resolve, so that the hook stays in the loading state.
     fetchStub.mockImplementation(() => new Promise(() => {}));
+
     const {result} = renderHook(() => useRegionalPartner({}));
 
     expect(result.current[0]).toBe(undefined);
@@ -51,7 +53,12 @@ describe('useRegionalPartner tests', () => {
   });
 
   it('errors when server errors', async () => {
-    fetchStub.mockResolvedValue(mockApiResponse(500, GOOD_RESPONSE));
+    fetchStub.mockResolvedValue(
+      mockApiResponse(500, {
+        error: 'server error',
+      })
+    );
+
     const {result, waitFor} = renderHook(() =>
       useRegionalPartner({
         school: '-1',
@@ -60,6 +67,7 @@ describe('useRegionalPartner tests', () => {
         program: PROGRAM_CSA,
       })
     );
+
     await waitFor(() => result.current[1] === true);
     expect(result.current).toEqual([null, true]);
   });

--- a/apps/test/unit/code-studio/pd/components/useRegionalPartnerTest.js
+++ b/apps/test/unit/code-studio/pd/components/useRegionalPartnerTest.js
@@ -1,34 +1,11 @@
-import {mount} from 'enzyme'; // eslint-disable-line no-restricted-imports
+import {act, renderHook} from '@testing-library/react-hooks';
 import _ from 'lodash';
-import PropTypes from 'prop-types';
-import React from 'react';
-import {act} from 'react-dom/test-utils';
-import sinon from 'sinon'; // eslint-disable-line no-restricted-imports
 
 import {
   PROGRAM_CSD,
   PROGRAM_CSA,
 } from '@cdo/apps/code-studio/pd/application/teacher/TeacherApplicationConstants';
 import {useRegionalPartner} from '@cdo/apps/code-studio/pd/components/useRegionalPartner';
-
-import {expect} from '../../../../util/reconfiguredChai'; // eslint-disable-line no-restricted-imports
-
-let regionalPartnerData, regionalPartnerError;
-
-const RegionalPartnerUser = props => {
-  const {data} = props;
-  const [regionalPartner, error] = useRegionalPartner(data);
-  regionalPartnerData = regionalPartner;
-  regionalPartnerError = error;
-  return null;
-};
-RegionalPartnerUser.propTypes = {
-  data: PropTypes.object,
-};
-
-const getRegionalPartnerData = () => {
-  return [regionalPartnerData, regionalPartnerError];
-};
 
 const GOOD_RESPONSE = {
   id: 1,
@@ -44,118 +21,82 @@ const mockApiResponse = (status = 200, body = {}) => {
 };
 
 describe('useRegionalPartner tests', () => {
-  let clock, fetchStub, debounceStub;
+  let fetchStub;
+  let debounceStub;
+
   beforeEach(() => {
-    regionalPartnerData = undefined;
-    regionalPartnerError = false;
-    clock = sinon.useFakeTimers();
-    fetchStub = sinon.stub(window, 'fetch');
-    debounceStub = sinon.stub(_, 'debounce').callsFake(f => f);
-  });
-  afterEach(() => {
-    clock.restore();
-    fetchStub.restore();
-    debounceStub.restore();
+    fetchStub = jest.spyOn(window, 'fetch');
+    debounceStub = jest.spyOn(_, 'debounce').mockImplementation(f => f);
   });
 
-  it('returns undefined when loading', async () => {
-    let rendered;
-    fetch.resetBehavior();
-    rendered = await mount(<RegionalPartnerUser data={{}} />);
-    const [regionalPartner, regionalPartnerError] =
-      getRegionalPartnerData(rendered);
-    expect(regionalPartner).to.equal(undefined);
-    expect(regionalPartnerError).to.equal(false);
-    rendered.unmount();
+  afterEach(() => {
+    fetchStub.mockRestore();
+    debounceStub.mockRestore();
+  });
+
+  it('returns undefined when loading', () => {
+    fetchStub.mockImplementation(() => new Promise(() => {}));
+    const {result} = renderHook(() => useRegionalPartner({}));
+
+    expect(result.current[0]).toBe(undefined);
+    expect(result.current[1]).toBe(false);
   });
 
   it('errors when parameters are bad', async () => {
-    let rendered;
-    // do a bunch of waiting around for the hooks state to resolve itself
+    const {result} = renderHook(() => useRegionalPartner({}));
     await act(async () => {
-      rendered = await mount(<RegionalPartnerUser data={{}} />);
+      await Promise.resolve();
     });
-    const [regionalPartner, regionalPartnerError] =
-      getRegionalPartnerData(rendered);
-    expect(regionalPartner).to.equal(null);
-    expect(regionalPartnerError).to.equal(true);
-    rendered.unmount();
+    expect(result.current).toEqual([null, true]);
   });
 
   it('errors when server errors', async () => {
-    let rendered;
-    fetch.resolves(mockApiResponse(500, GOOD_RESPONSE));
-    await act(async () => {
-      rendered = await mount(
-        <RegionalPartnerUser
-          data={{
-            school: '-1',
-            schoolZipCode: '12345',
-            schoolState: 'AK',
-            program: PROGRAM_CSA,
-          }}
-        />
-      );
-    });
-    await clock.runAllAsync();
-    const [regionalPartner, regionalPartnerError] =
-      getRegionalPartnerData(rendered);
-    expect(regionalPartner).to.equal(null);
-    expect(regionalPartnerError).to.equal(true);
-    rendered.unmount();
+    fetchStub.mockResolvedValue(mockApiResponse(500, GOOD_RESPONSE));
+    const {result, waitFor} = renderHook(() =>
+      useRegionalPartner({
+        school: '-1',
+        schoolZipCode: '12345',
+        schoolState: 'AK',
+        program: PROGRAM_CSA,
+      })
+    );
+    await waitFor(() => result.current[1] === true);
+    expect(result.current).toEqual([null, true]);
   });
 
   it('returns No Partner if RP does not offer selected program', async () => {
-    let rendered;
-    fetch.resolves(mockApiResponse(200, GOOD_RESPONSE));
-    await act(async () => {
-      rendered = await mount(
-        <RegionalPartnerUser
-          data={{
-            school: '-1',
-            schoolZipCode: '12345',
-            schoolState: 'AK',
-            program: PROGRAM_CSD,
-          }}
-        />
-      );
-    });
-    await clock.runAllAsync();
-
-    const [regionalPartner, regionalPartnerError] =
-      getRegionalPartnerData(rendered);
-    expect(fetch).to.be.calledWith(
-      `/api/v1/pd/regional_partner_workshops/find?course=CS+Discoveries&subject=5-day+Summer&zip_code=12345&state=AK`
+    fetchStub.mockResolvedValue(mockApiResponse(200, GOOD_RESPONSE));
+    const {result, waitFor} = renderHook(() =>
+      useRegionalPartner({
+        school: '-1',
+        schoolZipCode: '12345',
+        schoolState: 'AK',
+        program: PROGRAM_CSD,
+      })
     );
-    expect(regionalPartner).to.equal(null);
-    expect(regionalPartnerError).to.equal(false);
-    rendered.unmount();
+    await waitFor(
+      () => result.current[0] === null && result.current[1] === false
+    );
+    expect(result.current).toEqual([null, false]);
+    expect(fetchStub).toHaveBeenCalledWith(
+      '/api/v1/pd/regional_partner_workshops/find?course=CS+Discoveries&subject=5-day+Summer&zip_code=12345&state=AK'
+    );
   });
 
   it('fetches the regional partner data', async () => {
-    let rendered;
-    fetch.resolves(mockApiResponse(200, GOOD_RESPONSE));
-    await act(async () => {
-      rendered = await mount(
-        <RegionalPartnerUser
-          data={{
-            school: '-1',
-            schoolZipCode: '12345',
-            schoolState: 'AK',
-            program: PROGRAM_CSA,
-          }}
-        />
-      );
-    });
-    await clock.runAllAsync();
-
-    const [regionalPartner, regionalPartnerError] =
-      getRegionalPartnerData(rendered);
-    expect(fetch).to.be.calledWith(
-      `/api/v1/pd/regional_partner_workshops/find?course=Computer+Science+A&subject=5-day+Summer&zip_code=12345&state=AK`
+    fetchStub.mockResolvedValue(mockApiResponse(200, GOOD_RESPONSE));
+    const {result, waitFor} = renderHook(() =>
+      useRegionalPartner({
+        school: '-1',
+        schoolZipCode: '12345',
+        schoolState: 'AK',
+        program: PROGRAM_CSA,
+      })
     );
-    expect(regionalPartner).to.deep.equal(GOOD_RESPONSE);
-    expect(regionalPartnerError).to.equal(false);
-    rendered.unmount();
+    await waitFor(() => result.current[0] !== undefined);
+    expect(result.current).toEqual([GOOD_RESPONSE, false]);
+    expect(fetchStub).toHaveBeenCalledWith(
+      '/api/v1/pd/regional_partner_workshops/find?course=Computer+Science+A&subject=5-day+Summer&zip_code=12345&state=AK'
+    );
   });
 });


### PR DESCRIPTION
Converts/simplifies a test of a hook (`useRegionalPartner`) to use a helper called `renderHook`, which allows you to test data-only hooks more easily.

One bit of confusion is `renderHook` is now a part included of the core React Testing Library, but you need to be on React 18 to get to the RTL version that exposes it (v13). So, upgrading RTL is something we could do after we upgrade React.

## Links

- [React 18 upgrade tracker](https://docs.google.com/spreadsheets/d/1HEi20Ndj3r-fsCxuxxemm6QVIncMW_KVUzYMDsC6suU/edit?gid=1368456503#gid=1368456503)

## Testing story

Tested that this passed in React 18 and 17.