### PR TITLE
[A11y linter] Reenables non-interactive interactive elements rule

### DIFF
--- a/apps/.eslintrc.js
+++ b/apps/.eslintrc.js
@@ -9,7 +9,6 @@ const rulesToEventuallyReenable = {
   'jsx-a11y/anchor-is-valid': 'off',
   'jsx-a11y/click-events-have-key-events': 'off',
   'jsx-a11y/label-has-associated-control': 'off',
-  'jsx-a11y/no-noninteractive-element-interactions': 'off',
   'jsx-a11y/no-static-element-interactions': 'off',
 };
 

--- a/apps/src/code-studio/components/AdvancedShareOptions.jsx
+++ b/apps/src/code-studio/components/AdvancedShareOptions.jsx
@@ -172,6 +172,7 @@ class AdvancedShareOptions extends React.Component {
 
   renderAdvancedListItem = (option, name) => {
     return (
+      /* eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions */
       <li
         className={classNames(styles.navItem, {
           [styles.navItemSelected]: this.state.selectedOption === option,

--- a/apps/src/code-studio/components/SoundPicker.jsx
+++ b/apps/src/code-studio/components/SoundPicker.jsx
@@ -56,17 +56,22 @@ export default class SoundPicker extends React.Component {
 
   render() {
     const isFileMode = this.state.mode === MODE.files;
+    const modeSwitchButtonBase = {
+      fontSize: 16,
+      cursor: 'pointer',
+      background: 'none',
+      border: 'none',
+      padding: 0,
+    };
     const headerStyles = {
       soundModeToggle: {
+        ...modeSwitchButtonBase,
         float: 'left',
         margin: '0 20px 0 0',
-        fontSize: 16,
-        cursor: 'pointer',
       },
       fileModeToggle: {
+        ...modeSwitchButtonBase,
         margin: 0,
-        fontSize: 16,
-        cursor: 'pointer',
       },
     };
 
@@ -96,12 +101,20 @@ export default class SoundPicker extends React.Component {
 
     modeSwitch = (
       <div id="modeSwitch">
-        <p onClick={this.setSoundMode} style={headerStyles.soundModeToggle}>
+        <button
+          type="button"
+          onClick={this.setSoundMode}
+          style={headerStyles.soundModeToggle}
+        >
           {i18n.soundLibrary()}
-        </p>
-        <p onClick={this.setFileMode} style={headerStyles.fileModeToggle}>
+        </button>
+        <button
+          type="button"
+          onClick={this.setFileMode}
+          style={headerStyles.fileModeToggle}
+        >
           {i18n.makeNewSounds()}
-        </p>
+        </button>
       </div>
     );
 

--- a/apps/src/lab2/levelEditors/neighborhood/NeighborhoodMazeGenerator.tsx
+++ b/apps/src/lab2/levelEditors/neighborhood/NeighborhoodMazeGenerator.tsx
@@ -157,6 +157,7 @@ const NeighborhoodMazeGenerator: React.FunctionComponent<
                   selectedCell[1] === columnIndex) ||
                 false;
               return (
+                /* eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions */
                 <img
                   src={imageTiles[cell.assetId]}
                   alt="neighborhood cell"
@@ -186,6 +187,7 @@ const NeighborhoodMazeGenerator: React.FunctionComponent<
             }}
           >
             {categoryTiles.map((tile, index) => (
+              /* eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions */
               <img
                 src={imageTiles[tile]}
                 alt="neighborhood tile"

--- a/apps/src/music/views/SoundsPanel.tsx
+++ b/apps/src/music/views/SoundsPanel.tsx
@@ -166,7 +166,6 @@ const SoundsPanelRow: React.FunctionComponent<SoundsPanelRowProps> = ({
   );
 
   return (
-    /* eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions */
     <div
       className={classNames(
         'sounds-panel-sound-row',
@@ -186,7 +185,7 @@ const SoundsPanelRow: React.FunctionComponent<SoundsPanelRowProps> = ({
         String(getLengthRepresentation(sound.length))
       }
       tabIndex={0}
-      role="tabpanel"
+      role="button"
     >
       <div className={styles.soundRowLeft}>
         <FontAwesomeV6Icon

--- a/apps/src/music/views/SoundsPanel.tsx
+++ b/apps/src/music/views/SoundsPanel.tsx
@@ -166,6 +166,7 @@ const SoundsPanelRow: React.FunctionComponent<SoundsPanelRowProps> = ({
   );
 
   return (
+    /* eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions */
     <div
       className={classNames(
         'sounds-panel-sound-row',
@@ -357,6 +358,7 @@ const SoundsPanel: React.FunctionComponent<SoundsPanelProps> = ({
 
   return (
     <FocusLock>
+      {/* eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions */}
       <div
         id="sounds-panel"
         className={classNames(styles.soundsPanel)}


### PR DESCRIPTION
This rule only had 7 violations! I was able to actually fix two- the sound picker dialog had `<p>` tags acting as buttons in the dialog that pops up on the playSound block. I converted those to native buttons and added some styling to preserve the visuals- see the after image (matches the before, but now keyboard interactions work). 

The others are a bit more complex (see the files for why) so adding a linter exception rule for now so I can turn this rule on to prevent future violations. 

<img width="746" height="429" alt="Screenshot 2026-03-09 at 3 40 41 PM" src="https://github.com/user-attachments/assets/2bc04c9a-5853-44a8-8f69-75bc99d39fd8" />



## Links

- Jira: https://codedotorg.atlassian.net/browse/SL-1618

## Testing story
<!-- How was this tested? Manual steps, adhoc links, automated tests, or why testing isn't needed. -->



## Deployment notes
<!-- Delete this section if it's a standard merge-and-deploy.
     Otherwise: migrations, feature flags, coordination, caching impacts, etc. -->



## Privacy and security
<!-- Delete this section if there is no privacy/security impact.
     Otherwise: new PII, auth changes, API surface changes, etc. -->

