### PR TITLE
AI Chat image moderation follow-ups

### DIFF
--- a/apps/src/aichat/api/client/generateChatResponse.ts
+++ b/apps/src/aichat/api/client/generateChatResponse.ts
@@ -12,17 +12,13 @@ import {
   PendingChatMessage,
 } from '../../types';
 
-import {
-  fileToAsset,
-  fileToImage,
-  prepareGeneratedFile,
-} from './helpers/fileHelpers';
+import {generatedFileToAsset} from './helpers/fileHelpers';
 import {
   formatChatMessage,
   formatSystemMessages,
 } from './helpers/messageHelpers';
 import {getModel} from './helpers/modelHelpers';
-import {isTextSafe, isModelOutputImageSafe} from './helpers/safetyHelpers';
+import {isTextSafe, isImageSafe} from './helpers/safetyHelpers';
 
 /**
  * Performs all the steps necessary to generate a chat response:
@@ -67,7 +63,7 @@ export async function generateChatResponse(
   });
 
   if (['content-filter', 'other'].includes(finishReason)) {
-    // response.body is expected to be an object with a "candidates" array
+    // Gemini stores moderation information in a non-standard place so we need to dig into the raw HTTP body.
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const candidate = (response.body as any)?.candidates?.[0];
 
@@ -87,22 +83,13 @@ export async function generateChatResponse(
   // Upload generated assets, if any.
   const assets: ChatAsset[] = [];
   for (const file of files) {
-    const {filename, fileBuffer, mediaType, extension} =
-      prepareGeneratedFile(file);
-
-    const asset = await fileToAsset(
-      filename,
-      fileBuffer,
-      mediaType,
-      buildAssetUrl
-    );
+    const asset = await generatedFileToAsset(file, buildAssetUrl);
     assets.push(asset);
-
-    if (mediaType.startsWith('image/')) {
+    if (file.mediaType.startsWith('image/')) {
       sendLab2AnalyticsEvent(EVENTS.MODEL_OUTPUT_IMAGE_CREATED);
-      const imageFile = fileToImage(filename, fileBuffer, mediaType);
-      const modelImageSafe = await isModelOutputImageSafe(imageFile, extension);
-      if (!modelImageSafe) {
+      // Check generated images for safety.
+      const imageSafe = await isImageSafe(file);
+      if (!imageSafe) {
         return {
           response: text,
           status: AiRequestExecutionStatus.MODEL_IMAGE_FLAGGED,

--- a/apps/src/aichat/api/client/helpers/fileHelpers.ts
+++ b/apps/src/aichat/api/client/helpers/fileHelpers.ts
@@ -2,6 +2,7 @@ import {type FilePart, type GeneratedFile} from 'ai';
 
 import {AssetSource, ChatAsset} from '@cdo/apps/aichat/types';
 import HttpClient from '@cdo/apps/util/HttpClient';
+import {createUuid} from '@cdo/apps/utils';
 
 const extensionMap: Record<string, string> = {
   // Images
@@ -45,12 +46,11 @@ export async function assetToFilePart(
 /**
  * Converts a model generated file to a ChatAsset by uploading the file's contents to the user's project.
  */
-export async function fileToAsset(
-  filename: string,
-  fileBuffer: ArrayBuffer,
-  mediaType: string,
+export async function generatedFileToAsset(
+  file: GeneratedFile,
   buildAssetUrl: (asset: ChatAsset) => string
 ): Promise<ChatAsset> {
+  const {filename, fileBuffer} = prepareGeneratedFile(file);
   const asset: ChatAsset = {
     filename,
     source: AssetSource.PROJECT,
@@ -59,39 +59,25 @@ export async function fileToAsset(
 
   // Upload file contents to assetUrl
   await HttpClient.put(assetUrl, fileBuffer, true, {
-    'Content-Type': mediaType,
+    'Content-Type': file.mediaType,
   });
 
   return asset;
 }
 
-export function fileToImage(
-  filename: string,
-  fileBuffer: ArrayBuffer,
-  mediaType: string
-): File {
-  const blob = new Blob([fileBuffer], {type: mediaType});
-  return new File([blob], filename, {type: mediaType});
-}
-
-export interface PreparedFile {
+interface PreparedFile {
   filename: string;
-  fileBuffer: ArrayBuffer;
+  fileBuffer: Uint8Array<ArrayBuffer>;
   mediaType: string;
   extension: string;
 }
 
 /**
- * Extracts the buffer and derives filename/extension from a model-generated file,
- * ready to be passed to fileToAsset or fileToImage.
+ * Extracts the buffer and derives filename/extension from a model-generated file.
  */
 export function prepareGeneratedFile(file: GeneratedFile): PreparedFile {
-  const fileBuffer = file.uint8Array.buffer.slice(
-    file.uint8Array.byteOffset,
-    file.uint8Array.byteOffset + file.uint8Array.byteLength
-  ) as ArrayBuffer;
-  const {mediaType} = file;
-  const extension = mediaType.split('/')[1];
-  const filename = `generated-file-${crypto.randomUUID()}.${extension}`;
-  return {filename, fileBuffer, mediaType, extension};
+  const fileBuffer = file.uint8Array.slice();
+  const extension = file.mediaType.split('/')[1];
+  const filename = `generated-file-${createUuid()}.${extension}`;
+  return {filename, fileBuffer, mediaType: file.mediaType, extension};
 }

--- a/apps/src/aichat/api/client/helpers/safetyHelpers.ts
+++ b/apps/src/aichat/api/client/helpers/safetyHelpers.ts
@@ -58,8 +58,7 @@ export async function isImageSafe(file: GeneratedFile): Promise<boolean> {
   const {filename, fileBuffer, mediaType, extension} =
     prepareGeneratedFile(file);
   const image = new File([fileBuffer], filename, {type: mediaType});
-  const moderationStatus = await moderateImage(image, extension, {
-    appName: 'aichat',
+  const moderationStatus = await moderateImage(image, extension, 'aichat', {
     moderateEvent: EVENTS.MODERATE_MODEL_OUTPUT_IMAGE_AZURE,
     flaggedEvent: EVENTS.FLAGGED_MODEL_OUTPUT_IMAGE_AZURE,
   });

--- a/apps/src/aichat/api/client/helpers/safetyHelpers.ts
+++ b/apps/src/aichat/api/client/helpers/safetyHelpers.ts
@@ -1,11 +1,13 @@
-import {Output} from 'ai';
+import {type GeneratedFile, Output} from 'ai';
 import z from 'zod/v3';
 
 import {generateText} from '@cdo/apps/aiGateway/generateTextThroughProxyOrGateway';
 import {moderateImage} from '@cdo/apps/lab2/utils';
+import {EVENTS} from '@cdo/apps/metrics/AnalyticsConstants';
 import {ValueOf} from '@cdo/apps/types/utils';
 import {AiChatModelIds} from '@cdo/generated-scripts/sharedConstants';
 
+import {prepareGeneratedFile} from './fileHelpers';
 import {getModel} from './modelHelpers';
 
 const outputSchema = Output.object({
@@ -52,10 +54,14 @@ export async function isTextSafe(
   return classification === 'OK';
 }
 
-export async function isModelOutputImageSafe(
-  image: File,
-  ext: string
-): Promise<boolean> {
-  const moderationStatus = await moderateImage(image, ext, 'aichat', true); // isModelOutputImage = true
+export async function isImageSafe(file: GeneratedFile): Promise<boolean> {
+  const {filename, fileBuffer, mediaType, extension} =
+    prepareGeneratedFile(file);
+  const image = new File([fileBuffer], filename, {type: mediaType});
+  const moderationStatus = await moderateImage(image, extension, {
+    appName: 'aichat',
+    moderateEvent: EVENTS.MODERATE_MODEL_OUTPUT_IMAGE_AZURE,
+    flaggedEvent: EVENTS.FLAGGED_MODEL_OUTPUT_IMAGE_AZURE,
+  });
   return moderationStatus === 'ok' || moderationStatus === 'skipped';
 }

--- a/apps/src/lab2/hooks/useFileUploader.tsx
+++ b/apps/src/lab2/hooks/useFileUploader.tsx
@@ -182,7 +182,7 @@ export const useFileUploader = ({
             const ext = file.name.split('.').pop()?.toLowerCase() || '';
             const moderationStatus = await moderateImage(file, ext, {
               appName,
-              uploaderType: 'Lab2 File Uploader',
+              uploaderType: 'Lab2FileUploader',
             });
             if (moderationStatus === 'flagged') {
               const uploadFunction = async () => {

--- a/apps/src/lab2/hooks/useFileUploader.tsx
+++ b/apps/src/lab2/hooks/useFileUploader.tsx
@@ -180,7 +180,10 @@ export const useFileUploader = ({
         try {
           if (onImageFlagged) {
             const ext = file.name.split('.').pop()?.toLowerCase() || '';
-            const moderationStatus = await moderateImage(file, ext, appName);
+            const moderationStatus = await moderateImage(file, ext, {
+              appName,
+              uploaderType: 'Lab2 File Uploader',
+            });
             if (moderationStatus === 'flagged') {
               const uploadFunction = async () => {
                 const url = await uploadExternalFile(file);

--- a/apps/src/lab2/hooks/useFileUploader.tsx
+++ b/apps/src/lab2/hooks/useFileUploader.tsx
@@ -180,8 +180,7 @@ export const useFileUploader = ({
         try {
           if (onImageFlagged) {
             const ext = file.name.split('.').pop()?.toLowerCase() || '';
-            const moderationStatus = await moderateImage(file, ext, {
-              appName,
+            const moderationStatus = await moderateImage(file, ext, appName, {
               uploaderType: 'Lab2FileUploader',
             });
             if (moderationStatus === 'flagged') {

--- a/apps/src/lab2/utils/moderateImage.ts
+++ b/apps/src/lab2/utils/moderateImage.ts
@@ -7,7 +7,6 @@ import {WEBLAB2_IMAGE_FILE_TYPES} from '@cdo/apps/weblab2/constants';
 const LAB2_LABS_MODERATE_IMAGES = ['weblab2', 'aichat'];
 
 interface AnalyticsData {
-  appName: string;
   uploaderType?: 'Lab2FileUploader' | 'n/a';
   moderateEvent?: string;
   flaggedEvent?: string;
@@ -16,8 +15,8 @@ interface AnalyticsData {
 export const moderateImage = async (
   file: File,
   ext: string,
+  appName: string,
   {
-    appName,
     uploaderType = 'n/a',
     moderateEvent = EVENTS.MODERATE_CUSTOM_IMAGE,
     flaggedEvent = EVENTS.FLAGGED_CUSTOM_IMAGE,

--- a/apps/src/lab2/utils/moderateImage.ts
+++ b/apps/src/lab2/utils/moderateImage.ts
@@ -8,7 +8,7 @@ const LAB2_LABS_MODERATE_IMAGES = ['weblab2', 'aichat'];
 
 interface AnalyticsData {
   appName: string;
-  uploaderType?: 'Lab2 File Uploader' | 'n/a';
+  uploaderType?: 'Lab2FileUploader' | 'n/a';
   moderateEvent?: string;
   flaggedEvent?: string;
 }

--- a/apps/src/lab2/utils/moderateImage.ts
+++ b/apps/src/lab2/utils/moderateImage.ts
@@ -6,11 +6,22 @@ import {WEBLAB2_IMAGE_FILE_TYPES} from '@cdo/apps/weblab2/constants';
 
 const LAB2_LABS_MODERATE_IMAGES = ['weblab2', 'aichat'];
 
+interface AnalyticsData {
+  appName: string;
+  uploaderType?: 'Lab2 File Uploader' | 'n/a';
+  moderateEvent?: string;
+  flaggedEvent?: string;
+}
+
 export const moderateImage = async (
   file: File,
   ext: string,
-  appName: string,
-  isModelOutputImage?: boolean
+  {
+    appName,
+    uploaderType = 'n/a',
+    moderateEvent = EVENTS.MODERATE_CUSTOM_IMAGE,
+    flaggedEvent = EVENTS.FLAGGED_CUSTOM_IMAGE,
+  }: AnalyticsData
 ): Promise<'ok' | 'flagged' | 'skipped'> => {
   if (
     !LAB2_LABS_MODERATE_IMAGES.includes(appName ?? '') ||
@@ -19,51 +30,24 @@ export const moderateImage = async (
     return 'skipped';
   }
   const metricsReporter = Lab2Registry.getInstance().getMetricsReporter();
-  const uploaderType = isModelOutputImage ? 'n/a' : 'Lab2FileUploader';
-  metricsReporter.incrementCounter('ModerateCustomImage.Attempt', [
-    {name: 'UploaderType', value: uploaderType},
-  ]);
-  const moderateImageStatsigEvent = isModelOutputImage
-    ? EVENTS.MODERATE_MODEL_OUTPUT_IMAGE_AZURE
-    : EVENTS.MODERATE_CUSTOM_IMAGE;
-  sendLab2AnalyticsEvent(
-    moderateImageStatsigEvent,
-    !isModelOutputImage ? {UploaderType: 'Lab2 File Uploader'} : {}
-  );
+  const dimensions = [{name: 'UploaderType', value: uploaderType}];
+  metricsReporter.incrementCounter('ModerateCustomImage.Attempt', dimensions);
+  sendLab2AnalyticsEvent(moderateEvent, {UploaderType: uploaderType});
   try {
     const response = await HttpClient.post(`/v3/images/moderate`, file, true, {
       'Content-Type': file.type || 'application/octet-stream',
     });
-    if (!response.ok) {
-      metricsReporter.logError('Error with image moderation: HTTP error');
-      metricsReporter.incrementCounter('ModerateCustomImage.Error', [
-        {name: 'UploaderType', value: uploaderType},
-      ]);
-      return 'skipped';
-    }
     const json = await response.json();
-    metricsReporter.incrementCounter('ModerateCustomImage.Success', [
-      {name: 'UploaderType', value: uploaderType},
-    ]);
+    metricsReporter.incrementCounter('ModerateCustomImage.Success', dimensions);
     if (json?.rating === 'everyone' || json?.rating === 'unknown') {
       return 'ok';
     }
-    metricsReporter.incrementCounter('ModerateCustomImage.Flagged', [
-      {name: 'UploaderType', value: uploaderType},
-    ]);
-    const flaggedImageStatsigEvent = isModelOutputImage
-      ? EVENTS.FLAGGED_MODEL_OUTPUT_IMAGE_AZURE
-      : EVENTS.FLAGGED_CUSTOM_IMAGE;
-    sendLab2AnalyticsEvent(
-      flaggedImageStatsigEvent,
-      !isModelOutputImage ? {UploaderType: 'Lab2 File Uploader'} : {}
-    );
+    metricsReporter.incrementCounter('ModerateCustomImage.Flagged', dimensions);
+    sendLab2AnalyticsEvent(flaggedEvent, {UploaderType: uploaderType});
     return 'flagged';
   } catch (error) {
     metricsReporter.logError('Error with image moderation: ' + error);
-    metricsReporter.incrementCounter('ModerateCustomImage.Error', [
-      {name: 'UploaderType', value: uploaderType},
-    ]);
+    metricsReporter.incrementCounter('ModerateCustomImage.Error', dimensions);
     return 'skipped';
   }
 };

--- a/apps/src/lab2/views/components/Instructions/ResourcePanel/Backpack/saveToBackpackHelper.tsx
+++ b/apps/src/lab2/views/components/Instructions/ResourcePanel/Backpack/saveToBackpackHelper.tsx
@@ -170,11 +170,10 @@ export const fetchAndSaveFile = async ({
       const file = new File([blob], selectedFileName, {type: contentType});
       const appName = Lab2Registry.getInstance().getAppName();
 
-      const moderationStatus = await moderateImage(
-        file,
-        fileType,
-        appName ?? ''
-      );
+      const moderationStatus = await moderateImage(file, fileType, {
+        appName: appName ?? '',
+        uploaderType: 'Lab2 File Uploader',
+      });
       if (moderationStatus === 'flagged') {
         // Callback function so if user accepts flagged image, we can save the image to the project.
         const saveBackpackImageFileToProjectFunction = async () => {

--- a/apps/src/lab2/views/components/Instructions/ResourcePanel/Backpack/saveToBackpackHelper.tsx
+++ b/apps/src/lab2/views/components/Instructions/ResourcePanel/Backpack/saveToBackpackHelper.tsx
@@ -170,10 +170,12 @@ export const fetchAndSaveFile = async ({
       const file = new File([blob], selectedFileName, {type: contentType});
       const appName = Lab2Registry.getInstance().getAppName();
 
-      const moderationStatus = await moderateImage(file, fileType, {
-        appName: appName ?? '',
-        uploaderType: 'Lab2FileUploader',
-      });
+      const moderationStatus = await moderateImage(
+        file,
+        fileType,
+        appName ?? '',
+        {uploaderType: 'Lab2FileUploader'}
+      );
       if (moderationStatus === 'flagged') {
         // Callback function so if user accepts flagged image, we can save the image to the project.
         const saveBackpackImageFileToProjectFunction = async () => {

--- a/apps/src/lab2/views/components/Instructions/ResourcePanel/Backpack/saveToBackpackHelper.tsx
+++ b/apps/src/lab2/views/components/Instructions/ResourcePanel/Backpack/saveToBackpackHelper.tsx
@@ -172,7 +172,7 @@ export const fetchAndSaveFile = async ({
 
       const moderationStatus = await moderateImage(file, fileType, {
         appName: appName ?? '',
-        uploaderType: 'Lab2 File Uploader',
+        uploaderType: 'Lab2FileUploader',
       });
       if (moderationStatus === 'flagged') {
         // Callback function so if user accepts flagged image, we can save the image to the project.


### PR DESCRIPTION
A couple of fast-follows from https://github.com/code-dot-org/code-dot-org/pull/71162 and https://github.com/code-dot-org/code-dot-org/pull/71177. Discussed some of these with @fisher-alice offline before she left for vacation.

- Update comment about Gemini filtering response.
- Refactor file helper functions for clarity
- Parameterize/clean up `moderateImage` for better modularity (and future reuse with `AnimationPicker`)
- Replace `crypto.randomUUID()` (which doesn't work in insecure contexts) with `createUuid()`

This does make a minor change to the `UploaderType` data sent to Statsig; in order to make code simpler, I kept the value the same between Cloudwatch and Statsig which means that the Statsig value for `"Lab2 File Uploader"` no longer has spaces (`"Lab2FileUploader"`). Checking [here](https://codedotorg.slack.com/archives/C06JELCAPT9/p1773097098156679) if this ok.

### Testing story
Checked image uploading and moderation in AI Chat and Weblab2 including backpack.
