### PR TITLE
Convert TextConsoleTest to RTL

### DIFF
--- a/apps/test/unit/p5lab/spritelab/TextConsoleTest.js
+++ b/apps/test/unit/p5lab/spritelab/TextConsoleTest.js
@@ -1,4 +1,4 @@
-import {mount} from 'enzyme'; // eslint-disable-line no-restricted-imports
+import {fireEvent, render, screen} from '@testing-library/react';
 import React from 'react';
 
 import TextConsole, {
@@ -6,27 +6,24 @@ import TextConsole, {
 } from '@cdo/apps/p5lab/spritelab/TextConsole';
 
 describe('Sprite Lab Text Console', () => {
-  let wrapper;
+  let rerender;
 
   beforeEach(() => {
-    wrapper = mount(<TextConsole consoleMessages={[]} />);
+    ({rerender} = render(<TextConsole consoleMessages={[]} />));
   });
 
   it('is initially closed', () => {
-    expect(wrapper.state().open).toBe(false);
+    expect(screen.getByText('+', {selector: 'button'})).not.toBeVisible();
   });
 
   it('and the button text is +', () => {
-    const button = wrapper.findWhere(node => {
-      return node.type() === 'button' && node.text() === '+';
-    });
-    expect(button).toHaveLength(1);
+    expect(screen.getByText('+', {selector: 'button'})).toBeInTheDocument();
   });
 
   describe('after a line is added', () => {
     beforeEach(() => {
       jest.useFakeTimers();
-      wrapper.setProps({consoleMessages: ['hello world2']});
+      rerender(<TextConsole consoleMessages={['hello world2']} />);
     });
 
     afterEach(() => {
@@ -34,49 +31,46 @@ describe('Sprite Lab Text Console', () => {
     });
 
     it('opens', () => {
-      expect(wrapper.state().open).toBe(true);
+      expect(screen.getByRole('button', {name: '-'})).toBeInTheDocument();
     });
 
     it('the button text is -', () => {
-      const button = wrapper.findWhere(node => {
-        return node.type() === 'button' && node.text() === '-';
-      });
-      expect(button).toHaveLength(1);
+      expect(screen.getByRole('button', {name: '-'})).toBeInTheDocument();
     });
 
     it('closes after AUTO_CLOSE_TIME ms', () => {
+      expect(screen.getByRole('button', {name: '-'})).toBeInTheDocument();
       jest.advanceTimersByTime(AUTO_CLOSE_TIME);
-      expect(wrapper.state().open).toBe(false);
-
-      const button = wrapper.findWhere(node => {
-        return node.type() === 'button' && node.text() === '+';
-      });
-      expect(button).toHaveLength(1);
+      expect(screen.queryByRole('button', {name: '-'})).not.toBeInTheDocument();
+      expect(screen.getByRole('button', {name: '+'})).toBeInTheDocument();
     });
 
     describe('and the console is toggled', () => {
+      let toggleButton;
+
       beforeEach(() => {
-        wrapper.instance().toggleConsole();
+        toggleButton = screen.getByRole('button');
+        fireEvent.click(toggleButton);
       });
 
       it('closes', () => {
-        expect(wrapper.state().open).toBe(false);
+        expect(screen.getByRole('button', {name: '+'})).toBeInTheDocument();
       });
 
       it('the button becomes visible', () => {
-        expect(wrapper.instance().getButtonStyle().display).not.toBe('none');
+        expect(screen.getByRole('button')).toBeVisible();
       });
 
       it('opens when toggled again', () => {
-        wrapper.instance().toggleConsole(AUTO_CLOSE_TIME);
-        expect(wrapper.state().open).toBe(true);
+        fireEvent.click(toggleButton);
+        expect(screen.getByRole('button', {name: '-'})).toBeInTheDocument();
       });
 
       it('opens and stays open when the button is clicked', () => {
-        wrapper.instance().toggleConsole();
-        expect(wrapper.state().open).toBe(true);
+        fireEvent.click(toggleButton);
+        expect(screen.getByRole('button', {name: '-'})).toBeInTheDocument();
         jest.advanceTimersByTime(AUTO_CLOSE_TIME * 2);
-        expect(wrapper.state().open).toBe(true);
+        expect(screen.getByRole('button', {name: '-'})).toBeInTheDocument();
       });
     });
   });


### PR DESCRIPTION
Convert a test of the TextConsole component, which appears in Sprite Lab (see video below in case you're curious like I was -- no behavior change in this PR) to use React Testing Library.


https://github.com/user-attachments/assets/5e109ccb-72c8-43b4-ab5b-69c6b816b1a4

## Links

- [React 18 upgrade tracker](https://docs.google.com/spreadsheets/d/1HEi20Ndj3r-fsCxuxxemm6QVIncMW_KVUzYMDsC6suU/edit?gid=1368456503#gid=1368456503)

## Testing story

Tested passing against React 18 and 17.