### PR TITLE
Fix flaky test_script_progress_for_users test

### DIFF
--- a/dashboard/test/helpers/users_helper_test.rb
+++ b/dashboard/test/helpers/users_helper_test.rb
@@ -362,6 +362,9 @@ class UsersHelperTest < ActionView::TestCase
     # for user_2
     sublevel1_user_level_2 = create(:user_level, user: user_2, level: sublevel1_contained_level, script: script, best_result: ActivityConstants::BEST_PASS_RESULT, time_spent: 180)
     sublevel2_user_level_2 = create(:user_level, user: user_2, level: sublevel2, script: script, best_result: 20, time_spent: 300)
+    # Travel forward to ensure teacher_feedback.updated_at > user_level.updated_at,
+    # making the teacher_feedback_new flag deterministically true.
+    travel 1.second
     create(:teacher_feedback, student: user_2, teacher: teacher, level: sublevel2, script: script, review_state: TeacherFeedback::REVIEW_STATES.keepWorking)
     create(:teacher_feedback, student: user_3, teacher: teacher, level: sublevel1, script: script, review_state: TeacherFeedback::REVIEW_STATES.keepWorking)
     create(:teacher_feedback, student: user_3, teacher: teacher, level: sublevel2, script: script, comment: 'Better get working on this one!')
@@ -403,14 +406,16 @@ class UsersHelperTest < ActionView::TestCase
             result: 20,
             last_progress_at: sublevel2_last_progress_2,
             time_spent: 300,
-            teacher_feedback_review_state: TeacherFeedback::REVIEW_STATES.keepWorking
+            teacher_feedback_review_state: TeacherFeedback::REVIEW_STATES.keepWorking,
+            teacher_feedback_new: true
           },
           level.id => {
             status: LEVEL_STATUS.passed,
             result: 20,
             last_progress_at: sublevel2_last_progress_2,
             time_spent: 480, # sum of time spent on sublevels
-            teacher_feedback_review_state: TeacherFeedback::REVIEW_STATES.keepWorking
+            teacher_feedback_review_state: TeacherFeedback::REVIEW_STATES.keepWorking,
+            teacher_feedback_new: true
           }
         },
         user_3.id => {
@@ -445,6 +450,7 @@ class UsersHelperTest < ActionView::TestCase
     assert_equal expected_progress[0][user_3.id], progress[user_3.id]
 
     assert_equal expected_progress[1], last_progress_times
+    travel_back
   end
 
   def test_level_with_best_progress_one_level


### PR DESCRIPTION
## Summary
- Fixes a flaky `test_script_progress_for_users` test in `UsersHelperTest`
- The `teacher_feedback_new` flag compares `teacher_feedback.updated_at` vs `user_level.updated_at` as integer seconds — when both records are created within the same second the flag is `nil`, but on slower CI they get different timestamps making it `true`
- Adds `travel 1.second` before creating teacher_feedback records to make timestamps deterministic, and updates expected output to include `teacher_feedback_new: true`

## Test plan
- [x] `test_script_progress_for_users` passes locally
- [x] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)