### PR TITLE
feat(otel): enable process/network monitoring and add syslog collection

### DIFF
--- a/cookbooks/cdo-otel-collector/templates/datadog.yaml.erb
+++ b/cookbooks/cdo-otel-collector/templates/datadog.yaml.erb
@@ -23,13 +23,18 @@ agent_ipc:
   port: 5009
   config_refresh_interval: 60
 
-# Process monitoring (disabled by default)
+# Process monitoring
 process_config:
-  enabled: false
+  process_collection:
+    enabled: true
+  container_collection:
+    enabled: true
+  process_discovery:
+    enabled: true
 
-# Network monitoring (disabled by default) 
+# Network monitoring
 network_config:
-  enabled: false
+  enabled: true
 
 # Enable DogStatsD for metric collection
 dogstatsd_config:
@@ -48,5 +53,6 @@ logs_enabled: <%= @logs_enabled %>
 logs_config:
   logs_dd_url: https://http-intake.logs.<%= @site %>
 
-# Enable additional integrations as needed
-# Additional configuration will be placed here by other recipes/cookbooks
+# System Probe
+system_probe_config:
+  enabled: true

--- a/cookbooks/cdo-otel-collector/templates/otel-config.yaml.erb
+++ b/cookbooks/cdo-otel-collector/templates/otel-config.yaml.erb
@@ -20,6 +20,35 @@ receivers:
           static_configs:
             - targets: ["0.0.0.0:8888"]
 
+  # Reads Ubuntu formatted syslog
+  # TODO: Replace with rsyslog implementation using standardized log format to eliminate reliance on Regex.
+  filelog/syslog:
+    include:
+      - /var/log/syslog
+    start_at: end
+    include_file_name: true
+    include_file_path: true
+    operators:
+      - type: regex_parser
+        regex: '^(?P<timestamp>\w{3}\s+\d+\s+\d{2}:\d{2}:\d{2})\s+(?P<hostname>\S+)\s+(?P<process>[^\[:\s]+)\[(?P<pid>\d+)\]:\s+(?P<message>.*)$'
+        timestamp:
+          parse_from: attributes.timestamp
+          layout: '%b %d %H:%M:%S'
+          location: Local
+      - type: move
+        from: attributes.message
+        to: body
+      - type: move
+        from: attributes.hostname
+        to: resource["host.name"]
+      - type: move
+        from: attributes.process
+        to: attributes["process.name"]
+      - type: move
+        from: attributes.pid
+        to: attributes["process.pid"]
+
+
 processors:
   # Batch processor for efficient data transmission
   batch:
@@ -38,6 +67,21 @@ processors:
           - set(attributes["resource.name"], name)
             where instrumentation_scope.name == "OpenTelemetry::Instrumentation::Rack"
               and span.kind == SPAN_KIND_SERVER
+
+  # Converts OpenTelemetry error spans to Datadog formatted error spans
+  # OpenTelemetry specs are different than what Datadog expects for where the error lives.
+  # See: https://docs.datadoghq.com/tracing/error_tracking/
+  transform/datadog_errors:
+    error_mode: ignore
+    trace_statements:
+      - context: spanevent
+        statements:
+          - set(span.attributes["error.type"], attributes["exception.type"])
+            where name == "exception" and attributes["exception.type"] != nil
+          - set(span.attributes["error.message"], attributes["exception.message"])
+            where name == "exception" and attributes["exception.message"] != nil
+          - set(span.attributes["error.stack"], attributes["exception.stacktrace"])
+            where name == "exception" and attributes["exception.stacktrace"] != nil
 
   # Resource processor to add additional resource attributes
   resource:
@@ -92,6 +136,6 @@ service:
     
     # Logs pipeline  
     logs:
-      receivers: [otlp]
+      receivers: [filelog/syslog, otlp]
       processors: [resource, batch]
       exporters: [datadog]


### PR DESCRIPTION
- Enable process collection, container collection, process discovery, network monitoring, and system probe in Datadog agent config
- Add filelog/syslog receiver to OTel collector for Ubuntu syslog ingestion using regex parsing until rsyslog standardization is complete
- Add transform/datadog_errors processor to map OTel exception span events to Datadog error tracking format
- Wire syslog receiver into the logs pipeline

<img width="1022" height="538" alt="image" src="https://github.com/user-attachments/assets/abdaef81-c0b3-49e1-a824-babfaa8f998d" />
