### PR TITLE
fix: allow otel to read syslog

### DIFF
--- a/cookbooks/cdo-otel-collector/recipes/default.rb
+++ b/cookbooks/cdo-otel-collector/recipes/default.rb
@@ -90,6 +90,13 @@ template '/etc/datadog-agent/otel-config.yaml' do
   notifies :restart, 'service[datadog-agent]', :delayed
 end
 
+# Allow OTel Collector to read the syslog
+group 'syslog' do
+  action :modify
+  members 'dd-agent'
+  append true
+end
+
 # Manage the DataDog agent service
 service 'datadog-agent' do
   action [:enable, :start]

--- a/cookbooks/cdo-otel-collector/templates/otel-config.yaml.erb
+++ b/cookbooks/cdo-otel-collector/templates/otel-config.yaml.erb
@@ -125,7 +125,7 @@ service:
     # Traces pipeline
     traces:
       receivers: [otlp]
-      processors: [resource, transform/rails_resource_name_from_rack, batch]
+      processors: [resource, transform/datadog_errors, transform/rails_resource_name_from_rack, batch]
       exporters: [datadog/connector, datadog]
     
     # Metrics pipeline


### PR DESCRIPTION
This PR allows the otel collector to read syslog and fixes a missing reference to the error span interpreter. 