### PR TITLE
Lab2: fix instructions styling

### DIFF
--- a/apps/src/lab2/views/components/Instructions/InstructionsV2.tsx
+++ b/apps/src/lab2/views/components/Instructions/InstructionsV2.tsx
@@ -79,6 +79,7 @@ const Instructions: React.FunctionComponent<InstructionsProps> = ({
         fixedDarkBackground
           ? moduleStyles.fixedDarkBackground
           : moduleStyles.standardBackground,
+        moduleStyles.vertical,
         'instructions'
       )}
       data-theme={overrideTheme || defaultTheme}

--- a/apps/src/lab2/views/components/Instructions/InstructionsV2.tsx
+++ b/apps/src/lab2/views/components/Instructions/InstructionsV2.tsx
@@ -79,7 +79,6 @@ const Instructions: React.FunctionComponent<InstructionsProps> = ({
         fixedDarkBackground
           ? moduleStyles.fixedDarkBackground
           : moduleStyles.standardBackground,
-        moduleStyles.vertical,
         'instructions'
       )}
       data-theme={overrideTheme || defaultTheme}
@@ -87,7 +86,7 @@ const Instructions: React.FunctionComponent<InstructionsProps> = ({
       <div
         id="instructions-panel"
         aria-live="polite"
-        className={classNames(moduleStyles.item, moduleStyles.itemVertical)}
+        className={classNames(moduleStyles.item)}
       >
         <div
           key={longInstructions}

--- a/apps/src/lab2/views/components/Instructions/instructions.module.scss
+++ b/apps/src/lab2/views/components/Instructions/instructions.module.scss
@@ -22,10 +22,7 @@
   line-height: 1.5;
   display: flex;
   overflow: hidden;
-
-  &.vertical {
-    flex-direction: column;
-  }
+  flex-direction: column;
 }
 
 .fixedDarkBackground {
@@ -42,10 +39,7 @@
   flex: 1;
   opacity: 1;
   height: 100%;
-
-  &.itemVertical {
-    flex-direction: column;
-  }
+  flex-direction: column;
 }
 
 .mainInstructions {


### PR DESCRIPTION
Accidentally removed a `vertical` class name in https://github.com/code-dot-org/code-dot-org/pull/71231 which resulted in a UI regression. Fixed by just moving the relevant styling rules into the main class since we no longer need the `vertical` distinction.

https://codedotorg.slack.com/archives/C0T0PNTM3/p1773104047208509?thread_ts=1773094900.179899&cid=C0T0PNTM3

Before:
<img width="892" height="829" alt="Screenshot 2026-03-10 at 1 24 30 PM" src="https://github.com/user-attachments/assets/91b89095-d75c-4800-a7e2-07abe3da18ed" />

After:
<img width="965" height="830" alt="Screenshot 2026-03-10 at 1 23 39 PM" src="https://github.com/user-attachments/assets/a67c8ee8-dc33-4ecf-a935-99d268c6195d" />