### PR TITLE
Web lab 2: add line wrapping for markdown

### DIFF
--- a/apps/src/codebridge/Editor/Editor.tsx
+++ b/apps/src/codebridge/Editor/Editor.tsx
@@ -162,6 +162,9 @@ export const Editor = ({langMapping, editableFileTypes}: EditorProps) => {
             },
           })
         );
+      } else if (fileExt === 'md') {
+        // Wrap lines for markdown files.
+        extensions.push(EditorView.lineWrapping);
       }
     }
     if (hasUnifiedDiffView) {


### PR DESCRIPTION
This makes it so markdown files in web lab 2 have line wrapping, per curriculum's request. Other file types will not have line wrapping.


https://github.com/user-attachments/assets/4518d709-477b-496e-adef-1b48f83e8d08



## Links
- [Slack thread](https://codedotorg.slack.com/archives/C06JELCAPT9/p1773179152517639)

## Testing story
Tested locally.



