### PR TITLE
DO_NOT_MERGE Add demo_mode gem for exploration. 

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -82,6 +82,7 @@ gem 'memory_profiler'
 gem 'rack-mini-profiler'
 
 group :development do
+  gem 'demo_mode'
   gem 'annotaterb', '~> 4.19'
   gem 'aws-google', '~> 0.2.3'
   gem 'web-console', '~> 4.2.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -330,6 +330,7 @@ GEM
     cld (0.13.0)
       ffi
     cldr-plurals-runtime-rb (1.1.0)
+    cli-ui (2.7.0)
     climate_control (0.0.3)
       activesupport (>= 3.0)
     cocaine (0.5.8)
@@ -387,6 +388,13 @@ GEM
     delayed_job_active_record (4.1.7)
       activerecord (>= 3.0, < 8.0)
       delayed_job (>= 3.0, < 5)
+    demo_mode (3.2.0)
+      actionpack (>= 6.1, < 8.1)
+      activejob (>= 6.1, < 8.1)
+      activerecord (>= 6.1, < 8.1)
+      activesupport (>= 6.1, < 8.1)
+      cli-ui (~> 2.3)
+      railties (>= 6.1, < 8.1)
     devise (4.9.3)
       bcrypt (~> 3.0)
       orm_adapter (~> 0.1)
@@ -1251,6 +1259,7 @@ DEPENDENCIES
   dalli-elasticache
   database_cleaner-active_record (~> 2.1.0)
   delayed_job_active_record (~> 4.1)
+  demo_mode
   devise (~> 4.9.0)
   devise_invitable (~> 2.0.2)
   dotiw

--- a/dashboard/config/initializers/demo_mode.rb
+++ b/dashboard/config/initializers/demo_mode.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+# See README at https://github.com/Betterment/demo_mode
+
+DemoMode.configure do
+  display_credentials
+  sign_in_path { new_user_session_path }
+  password { SecureRandom.uuid }
+end

--- a/dashboard/config/personas/sample_persona.rb
+++ b/dashboard/config/personas/sample_persona.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+DemoMode.add_persona 'Teacher' do
+  sign_in_as do
+    teacher = Teacher.create!(
+      name: "Demo Teacher #{SecureRandom.hex(4)}",
+      email: "demo_teacher_#{SecureRandom.uuid}@example.com",
+      password: DemoMode.current_password,
+      user_type: User::TYPE_TEACHER,
+      birthday: Date.new(1980, 3, 14),
+      locale: 'en-US',
+      terms_of_service_version: 1,
+    )
+
+    unit = Unit.find_by!(name: 'aif3-2025')
+    section = Section.create!(
+      name: 'Demo Section',
+      user: teacher,
+      login_type: 'email',
+      participant_type: 'student',
+      script_id: unit.id,
+      course_id: unit.original_unit_group_id,
+    )
+
+    ['Dairy queen', 'Coldstone creamery'].each do |student_name|
+      student = Student.create!(
+        name: student_name,
+        email: "#{student_name.downcase.gsub(' ', '_')}_#{SecureRandom.uuid}@example.com",
+        password: '00secret',
+        user_type: User::TYPE_STUDENT,
+        birthday: Time.zone.today - 15.years,
+        locale: 'en-US',
+      )
+      section.add_student(student)
+    end
+
+    teacher
+  end
+
+  features << 'Teacher account'
+  features << 'Section assigned to aif3-2025'
+  features << '2 students: Dairy queen & Coldstone creamery'
+
+  icon :tophat
+  callout true
+
+  display_credentials
+end

--- a/dashboard/config/routes.rb
+++ b/dashboard/config/routes.rb
@@ -2,6 +2,7 @@
 
 Dashboard::Application.routes.draw do
   mount ActionCable.server => '/cable'
+  mount DemoMode::Engine => '/demo'
   get 'chatter/index'
 
   draw :api

--- a/dashboard/db/migrate/20260310183241_add_demo_mode_sessions.demo_mode.rb
+++ b/dashboard/db/migrate/20260310183241_add_demo_mode_sessions.demo_mode.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+# This migration comes from demo_mode (originally 20190503143021)
+class AddDemoModeSessions < ActiveRecord::Migration[5.1]
+  def change
+    # Uncomment this line to enable :uuid support on PostgreSQL >= 9.4
+    # enable_extension 'pgcrypto' unless extension_enabled?('pgcrypto')
+    #
+    # Uncomment this line to enable :uuid support on PostgreSQL < 9.4
+    # enable_extension 'uuid-ossp' unless extension_enabled?('uuid-ossp')
+
+    create_table :demo_mode_sessions, id: primary_key_type do |t|
+      t.string :persona_name, null: false
+      t.references :signinable, polymorphic: true, type: :string
+      t.timestamps
+    end
+  end
+
+  private
+
+  def primary_key_type
+    if connection.adapter_name.casecmp('postgresql').zero? &&
+        (extension_enabled?('pgcrypto') || extension_enabled?('uuid-ossp'))
+      :uuid
+    else
+      :bigint
+    end
+  end
+end

--- a/dashboard/db/migrate/20260310183242_add_demo_mode_sessions_variant.demo_mode.rb
+++ b/dashboard/db/migrate/20260310183242_add_demo_mode_sessions_variant.demo_mode.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+# This migration comes from demo_mode (originally 20201111000000)
+class AddDemoModeSessionsVariant < ActiveRecord::Migration[5.1]
+  def change
+    add_column :demo_mode_sessions, :variant, :string, null: false, default: 'default'
+  end
+end

--- a/dashboard/db/migrate/20260310183243_add_demo_mode_sessions_password.demo_mode.rb
+++ b/dashboard/db/migrate/20260310183243_add_demo_mode_sessions_password.demo_mode.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+# This migration comes from demo_mode (originally 20210505000000)
+class AddDemoModeSessionsPassword < ActiveRecord::Migration[5.1]
+  def change
+    add_column :demo_mode_sessions, :signinable_password, :string, null: false, default: ''
+
+    reversible do |dir|
+      dir.up do
+        change_column :demo_mode_sessions, :signinable_password, :string, null: false, default: nil
+      end
+    end
+  end
+end

--- a/dashboard/db/migrate/20260310183244_add_demo_mode_sessions_status.demo_mode.rb
+++ b/dashboard/db/migrate/20260310183244_add_demo_mode_sessions_status.demo_mode.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+# This migration comes from demo_mode (originally 20250210222933)
+class AddDemoModeSessionsStatus < ActiveRecord::Migration[5.1]
+  def change
+    add_column :demo_mode_sessions, :status, :string, null: false, default: 'processing'
+
+    reversible do |dir|
+      dir.up do
+        execute "UPDATE demo_mode_sessions SET status = 'successful'"
+      end
+    end
+  end
+end

--- a/dashboard/db/schema.rb
+++ b/dashboard/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2026_02_11_145245) do
+ActiveRecord::Schema[7.0].define(version: 2026_03_10_183244) do
   create_table "activities", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "user_id"
     t.integer "level_id"
@@ -649,6 +649,18 @@ ActiveRecord::Schema[7.0].define(version: 2026_02_11_145245) do
     t.datetime "created_at"
     t.datetime "updated_at"
     t.index ["priority", "run_at"], name: "delayed_jobs_priority"
+  end
+
+  create_table "demo_mode_sessions", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+    t.string "persona_name", null: false
+    t.string "signinable_type"
+    t.string "signinable_id"
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
+    t.string "variant", default: "default", null: false
+    t.string "signinable_password", null: false
+    t.string "status", default: "processing", null: false
+    t.index ["signinable_type", "signinable_id"], name: "index_demo_mode_sessions_on_signinable_type_and_signinable_id"
   end
 
   create_table "donor_schools", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
@@ -2427,7 +2439,7 @@ ActiveRecord::Schema[7.0].define(version: 2026_02_11_145245) do
     t.index ["unit_group_id", "resource_id"], name: "index_ug_student_resources_on_unit_group_id_and_resource_id", unique: true
   end
 
-  create_table "user_data_retention_statuses", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "user_data_retention_statuses", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.integer "user_id", null: false
     t.datetime "pii_scrubbed_at", precision: nil
     t.datetime "anonymized_at", precision: nil


### PR DESCRIPTION
Written heavily with claude. This is not polished or releasable, but shows that using `DEMO_MODE=1 bin/dashboard-server` uses the demo_mode gem and allows creation of new teacher accounts with sections.

Account type selection:
<img width="767" height="699" alt="image" src="https://github.com/user-attachments/assets/8c9aaf6b-8b39-43ca-a13b-8e8d4a8b855b" />

Viewing the credentials of the created account (these could be copied and then used to login)
<img width="1225" height="754" alt="image" src="https://github.com/user-attachments/assets/0721c36a-b5a4-4837-9bf3-8b36d9f731a2" />

First login already has a demo section added:
<img width="1293" height="689" alt="image" src="https://github.com/user-attachments/assets/ecf80bb9-0cbb-4fc2-8f94-2738ba74b2c4" />

Demo section already has two students created (progress would also be shown):
<img width="1729" height="725" alt="image" src="https://github.com/user-attachments/assets/1354c4e5-26af-4ac3-952e-9921415dd74b" />




