### PR TITLE
Web lab 2: cleanup of prompt

### DIFF
--- a/apps/src/weblab2/helpers/aiTutorPromptGenerator.ts
+++ b/apps/src/weblab2/helpers/aiTutorPromptGenerator.ts
@@ -139,7 +139,7 @@ export const generateAiTutorPrompt = (
   const parsedAnswerTypes = generateFinalAnswerTypeList(answerTypes);
   const contracts = parsedAnswerTypes
     .map(answerType => {
-      const baseContract = ANSWER_TYPE_CONTRACTS[answerType].trim();
+      const baseContract = ANSWER_TYPE_CONTRACTS[answerType]?.trim();
       const customization = answerTypeCustomizations?.[answerType]?.trim();
       return customization ? `${baseContract}\n${customization}` : baseContract;
     })

--- a/apps/src/weblab2/helpers/aiTutorStructuredResponseHelper.ts
+++ b/apps/src/weblab2/helpers/aiTutorStructuredResponseHelper.ts
@@ -41,7 +41,7 @@ const getAnswerJsonSchema = (): JsonObjectSchema => {
           additionalProperties: false,
         },
         description:
-          '`html`, `css`, or `js` fences. Limit to one language (html, css, or js) across the entire list. ' +
+          '`text`, `html`, `css`, or `js` fences. Limit to one language (text, html, css, or js) across the entire list. ' +
           'The list can be empty. Code should be formatted with appropriate newlines and indentation. ' +
           'When providing modifications to a file in the student code, provide the entire contents of the file. ' +
           'Code should be formatted with appropriate newlines and indentation.',

--- a/apps/src/weblab2/helpers/aiTutorStructuredResponseHelper.ts
+++ b/apps/src/weblab2/helpers/aiTutorStructuredResponseHelper.ts
@@ -16,19 +16,19 @@ const getAnswerJsonSchema = (): JsonObjectSchema => {
       tutorMode: {
         type: 'string',
         enum: [
-          'Build HTML',
-          'Build CSS',
-          'Build JavaScript',
-          'Ask',
-          'Hint',
-          'Debug',
-          'Explain Code',
-          'Example',
-          'Pseudocode',
-          'Documentation',
-          'Test Case',
-          'Refusal JavaScript Snippet',
-          'Refusal',
+          'buildHTML',
+          'buildCSS',
+          'buildJavaScript',
+          'ask',
+          'hint',
+          'debug',
+          'explainCode',
+          'example',
+          'pseudocode',
+          'documentation',
+          'testCase',
+          'refusalJavaScriptSnippets',
+          'refusal',
         ],
       },
       goal: {
@@ -95,9 +95,9 @@ const getAnswerJsonSchema = (): JsonObjectSchema => {
 // for which we format the model response with formatAcceptRejectResponse. Otherwise, we format
 // the model response with formatCopyPasteResponse.
 export const acceptRejectAnswerTypes = [
-  'Build HTML',
-  'Build CSS',
-  'Build JavaScript',
+  'buildHTML',
+  'buildCSS',
+  'buildJavaScript',
 ];
 
 const acceptRejectCodeFileTypes = ['html', 'css', 'js'];
@@ -136,7 +136,7 @@ const formatSection = (title: string, content?: string): string => {
   return content ? `**${title}**\n\n${content}\n\n` : '';
 };
 
-// This is used when the AI Tutor response's tutorMode is not 'Build HTML', 'Build CSS', nor 'Build JavaScript'.
+// This is used when the AI Tutor response's tutorMode is not 'buildHTML', 'buildCSS', nor 'buildJavaScript'.
 // Parsed json comes in as 'any', but it follows the structure defined in getAnswerJsonSchemaAcceptReject().
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const formatCopyPasteResponse = (response: any): string => {
@@ -170,7 +170,7 @@ type AcceptRejectFormattedResponse = {
   answerType: string;
 };
 
-// This is used when the AI Tutor response's tutorMode is 'Build HTML', 'Build CSS', or 'Build JavaScript'.
+// This is used when the AI Tutor response's tutorMode is 'buildHTML', 'buildCSS', or 'buildJavaScript'.
 // Parsed json comes in as 'any', but it follows the structure defined in acceptRejectJsonSchema.
 export const formatAcceptRejectResponse = (
   // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/apps/src/weblab2/helpers/aiTutorStructuredResponseHelper.ts
+++ b/apps/src/weblab2/helpers/aiTutorStructuredResponseHelper.ts
@@ -8,6 +8,7 @@ import {
   getFileExtension,
   getNextFileId,
 } from '@cdo/apps/lab2/utils/multiFileSourceUtils';
+import {AI_TUTOR_ANSWER_TYPES} from '@cdo/apps/weblab2/types';
 
 const getAnswerJsonSchema = (): JsonObjectSchema => {
   return {
@@ -15,21 +16,7 @@ const getAnswerJsonSchema = (): JsonObjectSchema => {
     properties: {
       tutorMode: {
         type: 'string',
-        enum: [
-          'buildHTML',
-          'buildCSS',
-          'buildJavaScript',
-          'ask',
-          'hint',
-          'debug',
-          'explainCode',
-          'example',
-          'pseudocode',
-          'documentation',
-          'testCase',
-          'refusalJavaScriptSnippets',
-          'refusal',
-        ],
+        enum: [...AI_TUTOR_ANSWER_TYPES],
       },
       goal: {
         type: 'string',

--- a/apps/src/weblab2/prompts/answerTypeContracts/ask.md
+++ b/apps/src/weblab2/prompts/answerTypeContracts/ask.md
@@ -1,2 +1,2 @@
-### Ask
+### ask
 - **Guarantee**: Ask the student 1-2 questions

--- a/apps/src/weblab2/prompts/answerTypeContracts/buildCSS.md
+++ b/apps/src/weblab2/prompts/answerTypeContracts/buildCSS.md
@@ -1,4 +1,4 @@
-### Build-CSS
+### buildCSS
 - **Guarantee**: Output each runnable CSS in a `css` fence with file name.
 - Default to simple black-and-white styling.
 - Do not add semantics/responsiveness/accessibility **unless explicitly requested**.

--- a/apps/src/weblab2/prompts/answerTypeContracts/buildHTML.md
+++ b/apps/src/weblab2/prompts/answerTypeContracts/buildHTML.md
@@ -1,4 +1,4 @@
-### Build-HTML
+### buildHTML
 - **Guarantee**: Output each runnable HTML in an `html` fence with file name.
 - Then list **Assumptions** and **Questions**, if any.
 - Keep HTML plain (basic tags, descriptive IDs/classes). Link `style.css`.

--- a/apps/src/weblab2/prompts/answerTypeContracts/buildJavaScript.md
+++ b/apps/src/weblab2/prompts/answerTypeContracts/buildJavaScript.md
@@ -1,4 +1,4 @@
-### Build-JavaScript
+### buildJavaScript
 - **Guarantee**: Output each runnable JavaScript in a `js` fence with file name.
 - Never output a complete solution to the learner's **specific JavaScript** task.
 - Functions must use **arrow notation** (e.g., `const handleClick = () => { … }`), never the `function` keyword.

--- a/apps/src/weblab2/prompts/answerTypeContracts/debug.md
+++ b/apps/src/weblab2/prompts/answerTypeContracts/debug.md
@@ -1,3 +1,3 @@
-### Debug
+### debug
 - **Guarantee**: Analyze pasted code; respond with suggested debugging steps and critical lines to look at.  No diffs
 - Do not assume that students can use the developer tools in the browser. Use other debugging techniques such as printing onto the webpage itself.

--- a/apps/src/weblab2/prompts/answerTypeContracts/documentation.md
+++ b/apps/src/weblab2/prompts/answerTypeContracts/documentation.md
@@ -1,4 +1,4 @@
-### Documentation
+### documentation
 - **Guarantee:** Name built-in JavaScript methods, properties, events, objects or fact based information about HTML, CSS or JavaScript languages. Explain the concept in general, language-level **terms, not tied to the learner's current project.**
 - Never generate new code.
 - Include **≥2 placeholders** (e.g., `‹ID_HERE›`, `‹EVENT_HERE›`, `‹HANDLER_NAME›`), and

--- a/apps/src/weblab2/prompts/answerTypeContracts/example.md
+++ b/apps/src/weblab2/prompts/answerTypeContracts/example.md
@@ -1,4 +1,4 @@
-### Example
+### example
 - **Guarantee**: tiny **different-context** snippet (≤5 lines) with placeholders to teach a pattern (non-runnable `txt` fence).
 - If using functions, functions must use **arrow notation** (e.g., `const handleClick = () => { … }`), never the `function` keyword.
 - Use a `txt` fence (never `javascript`), and

--- a/apps/src/weblab2/prompts/answerTypeContracts/explainCode.md
+++ b/apps/src/weblab2/prompts/answerTypeContracts/explainCode.md
@@ -1,4 +1,4 @@
-### Explain-Code
+### explainCode
 - **Guarantee**: Explain what a line, block, or file of HTML, CSS, or JavaScript does, and how it works **in the context of the student's project**.
 - Do not add new runnable lines
 - Keep explanations conceptual (flow, data, events)

--- a/apps/src/weblab2/prompts/answerTypeContracts/hint.md
+++ b/apps/src/weblab2/prompts/answerTypeContracts/hint.md
@@ -1,2 +1,2 @@
-### Hint
+### hint
 - **Guarantee**: micro-hints that are conceptual/procedural. No token-complete JS. (no exact method + exact literal combos that let them paste a line).

--- a/apps/src/weblab2/prompts/answerTypeContracts/pseudocode.md
+++ b/apps/src/weblab2/prompts/answerTypeContracts/pseudocode.md
@@ -1,4 +1,4 @@
-### Pseudocode
+### pseudocode
 - **Guarantee:** Provide clear, **structured pseudocode using plain English** and indentation to express logic, sequence, and decisions. Never include actual JavaScript syntax, keywords, or runnable elements.
 - Must use natural language (no JS syntax, keywords, or punctuation such as {} or ;).
 - Should describe intent and flow (steps, loops, conditions, outcomes).

--- a/apps/src/weblab2/prompts/answerTypeContracts/refusal.md
+++ b/apps/src/weblab2/prompts/answerTypeContracts/refusal.md
@@ -1,3 +1,3 @@
-### Refusal
+### refusal
 - **Guarantee**: restate purpose; offer next steps.
 - **Refusal (tutor) pattern:** "My purpose is to tutor you so you can build this yourself. That request is outside my scope. Would you like a hint, example, or documentation instead?"

--- a/apps/src/weblab2/prompts/answerTypeContracts/refusalJavaScriptSnippets.md
+++ b/apps/src/weblab2/prompts/answerTypeContracts/refusalJavaScriptSnippets.md
@@ -1,2 +1,2 @@
-### Refusal-JavaScript-Snippets
-- **Guarantee**: The **student writes the logic**. You mentor/debug: ask, analyze, provide minimal diffs.  **Do not** output a completed line or final solution. Rotate: **Ask → Hint → Example → Pseudocode → Refusal (tutor)**
+### refusalJavaScriptSnippets
+- **Guarantee**: The **student writes the logic**. You mentor/debug: ask, analyze, provide minimal diffs.  **Do not** output a completed line or final solution. Rotate: **ask → hint → example → pseudocode → refusal**

--- a/apps/src/weblab2/prompts/answerTypeContracts/testCase.md
+++ b/apps/src/weblab2/prompts/answerTypeContracts/testCase.md
@@ -1,2 +1,2 @@
-### Test-Case
+### testCase
 - **Guarantee**: Provide 3-5 step-by-step test cases which a user can use to verify their project is meeting the requirements

--- a/apps/src/weblab2/prompts/answerTypeTriggers/ask.md
+++ b/apps/src/weblab2/prompts/answerTypeTriggers/ask.md
@@ -1,1 +1,1 @@
-**Ask**: Trigger when need more information from the user or when you can ask guiding questions to help the student think through the problem. (use for conceptual blocks; **not** for wireframe→page requests).
+**ask**: Trigger when need more information from the user or when you can ask guiding questions to help the student think through the problem. (use for conceptual blocks; **not** for wireframe→page requests).

--- a/apps/src/weblab2/prompts/answerTypeTriggers/buildCSS.md
+++ b/apps/src/weblab2/prompts/answerTypeTriggers/buildCSS.md
@@ -1,1 +1,1 @@
-**Build-CSS** (runnable): Trigger when the user requests styling or CSS.
+**buildCSS** (runnable): Trigger when the user requests styling or CSS.

--- a/apps/src/weblab2/prompts/answerTypeTriggers/buildHTML.md
+++ b/apps/src/weblab2/prompts/answerTypeTriggers/buildHTML.md
@@ -1,1 +1,1 @@
-**Build-HTML** (runnable): Trigger when the user mentions any of: *wireframe, layout, mock, create the page, HTML structure, build the page/site/screen* or when they asked for both HTML **and** CSS.
+**buildHTML** (runnable): Trigger when the user mentions any of: *wireframe, layout, mock, create the page, HTML structure, build the page/site/screen* or when they asked for both HTML **and** CSS.

--- a/apps/src/weblab2/prompts/answerTypeTriggers/buildJavaScript.md
+++ b/apps/src/weblab2/prompts/answerTypeTriggers/buildJavaScript.md
@@ -1,1 +1,1 @@
-**Build-JavaScript** (runnable): Trigger when the user requests interactivity or JavaScript.
+**buildJavaScript** (runnable): Trigger when the user requests interactivity or JavaScript.

--- a/apps/src/weblab2/prompts/answerTypeTriggers/debug.md
+++ b/apps/src/weblab2/prompts/answerTypeTriggers/debug.md
@@ -1,1 +1,1 @@
-**Debug**: Trigger when user says something is not working or asks for help debugging.
+**debug**: Trigger when user says something is not working or asks for help debugging.

--- a/apps/src/weblab2/prompts/answerTypeTriggers/documentation.md
+++ b/apps/src/weblab2/prompts/answerTypeTriggers/documentation.md
@@ -1,1 +1,1 @@
-**Documentation:** Trigger when a student asks about JavaScript methods, properties, objects, events, syntax, or other language features they might find in documentation.
+**documentation:** Trigger when a student asks about JavaScript methods, properties, objects, events, syntax, or other language features they might find in documentation.

--- a/apps/src/weblab2/prompts/answerTypeTriggers/example.md
+++ b/apps/src/weblab2/prompts/answerTypeTriggers/example.md
@@ -1,1 +1,1 @@
-**Example**: Trigger when the student asks for an example or hints have not worked.
+**example**: Trigger when the student asks for an example or hints have not worked.

--- a/apps/src/weblab2/prompts/answerTypeTriggers/explainCode.md
+++ b/apps/src/weblab2/prompts/answerTypeTriggers/explainCode.md
@@ -1,1 +1,1 @@
-**Explain-Code:** Trigger when asked "What does this line do?", "explain this file," "walk me through this CSS/HTML/JS," "why is this here?" when the intent is understanding, not getting new code.
+**explainCode:** Trigger when asked "What does this line do?", "explain this file," "walk me through this CSS/HTML/JS," "why is this here?" when the intent is understanding, not getting new code.

--- a/apps/src/weblab2/prompts/answerTypeTriggers/hint.md
+++ b/apps/src/weblab2/prompts/answerTypeTriggers/hint.md
@@ -1,1 +1,1 @@
-**Hint**: Trigger when student needs a quick hint on a concept
+**hint**: Trigger when student needs a quick hint on a concept

--- a/apps/src/weblab2/prompts/answerTypeTriggers/pseudocode.md
+++ b/apps/src/weblab2/prompts/answerTypeTriggers/pseudocode.md
@@ -1,1 +1,1 @@
-**Pseudocode:** Trigger when a student asks for pseudocode, help planning logic, describing how a program should work, or outlining code structure.
+**pseudocode:** Trigger when a student asks for pseudocode, help planning logic, describing how a program should work, or outlining code structure.

--- a/apps/src/weblab2/prompts/answerTypeTriggers/refusal.md
+++ b/apps/src/weblab2/prompts/answerTypeTriggers/refusal.md
@@ -1,1 +1,1 @@
-**Refusal (tutor)**: Trigger when you should not do the thing the student asked or if the student is off topic.
+**refusal**: Trigger when you should not do the thing the student asked or if the student is off topic.

--- a/apps/src/weblab2/prompts/answerTypeTriggers/refusalJavaScriptSnippets.md
+++ b/apps/src/weblab2/prompts/answerTypeTriggers/refusalJavaScriptSnippets.md
@@ -1,4 +1,4 @@
-**Refusal-JavaScript-Snippets**: Trigger when:
+**refusalJavaScriptSnippets**: Trigger when:
     - asked for runnable JavaScript code that would complete the learner's current micro-task
     - asked for "the line", "the code", "the answer", etc. and they are not working on HTML or CSS
     - user says "just give me the code"

--- a/apps/src/weblab2/prompts/answerTypeTriggers/testCase.md
+++ b/apps/src/weblab2/prompts/answerTypeTriggers/testCase.md
@@ -1,1 +1,1 @@
-**Test-Case**: Trigger when a student asks for test cases or ways to test their code.
+**testCase**: Trigger when a student asks for test cases or ways to test their code.

--- a/apps/src/weblab2/prompts/preReplyCheckAllowJs.md
+++ b/apps/src/weblab2/prompts/preReplyCheckAllowJs.md
@@ -1,3 +1,3 @@
 ## Pre-Reply Leak Check (must pass before sending)
-- If the user asked for a page/layout/wireframe and your draft reply does **not** include runnable `html` (and `css` if asked/implied), **restart the reply in Build-HTML** (and **Build-CSS**) mode and output the code first.
+- If the user asked for a page/layout/wireframe and your draft reply does **not** include runnable `html` (and `css` if asked/implied), **restart the reply in buildHTML** (and **buildCSS**) mode and output the code first.
 - If the next reply would combine HTML + CSS + JS in one reply → **Stop and pivot** use proper Build mode answer contract with only 1 language at a time.

--- a/apps/src/weblab2/prompts/preReplyCheckNoJs.md
+++ b/apps/src/weblab2/prompts/preReplyCheckNoJs.md
@@ -1,8 +1,8 @@
 ## Pre-Reply Leak Check (must pass before sending)
-- If the user asked for a page/layout/wireframe and your draft reply does **not** include runnable `html` (and `css` if asked/implied), **restart the reply in Build-HTML** (and **Build-CSS**) mode and output the code first.
+- If the user asked for a page/layout/wireframe and your draft reply does **not** include runnable `html` (and `css` if asked/implied), **restart the reply in buildHTML** (and **buildCSS**) mode and output the code first.
 - If the next reply would combine HTML + CSS + JS in one reply → **Stop and pivot** use proper Build mode answer contract with only 1 language at a time.
 - If the next reply would:
-    - Output runnable `javascript` (except a 1–2 line **Debug diff** with placeholders), or
+    - Output runnable `javascript` (except a 1–2 line **debug diff** with placeholders), or
     - Include a user literal inside a JS fence, or
-    - Provide a single-placeholder, paste-ready JS template, 
+    - Provide a single-placeholder, paste-ready JS template,
         → **Stop and pivot** use proper Tutor mode answer contract.

--- a/apps/src/weblab2/types.ts
+++ b/apps/src/weblab2/types.ts
@@ -25,20 +25,23 @@ export enum ViewMode {
   PREVIEW = 'preview',
 }
 
-export type AiTutorAnswerType =
-  | 'ask'
-  | 'buildCSS'
-  | 'buildHTML'
-  | 'buildJavaScript'
-  | 'debug'
-  | 'documentation'
-  | 'example'
-  | 'explainCode'
-  | 'hint'
-  | 'pseudocode'
-  | 'refusal'
-  | 'refusalJavaScriptSnippets'
-  | 'testCase';
+export const AI_TUTOR_ANSWER_TYPES = [
+  'ask',
+  'buildCSS',
+  'buildHTML',
+  'buildJavaScript',
+  'debug',
+  'documentation',
+  'example',
+  'explainCode',
+  'hint',
+  'pseudocode',
+  'refusal',
+  'refusalJavaScriptSnippets',
+  'testCase',
+] as const;
+
+export type AiTutorAnswerType = (typeof AI_TUTOR_ANSWER_TYPES)[number];
 
 export type AiTutorMode =
   | 'suggest'


### PR DESCRIPTION
I was working on adding a new prompt answer type for web lab 2 and noticed there's inconsistencies in how we are formatting answer types, which leads to us having to duplicate them more than we need to. This updates the answer types as written in the prompt itself to match what we are storing on our end, which are camel cased answer types. I tested and this does not seem to have any change in how the tutor responds. There was also no effect on showing old messages in the user's history.

While I was testing this I also noticed that the tutor would often say it was giving you an example but not actually give you one. I believe this is because it thinks the example should go in a code block, but the structured response does not allow `txt` in a code block. I updated the structured output to allow `txt` and was immediately able to generate an example as expected.

I also added a null check on generating the prompt, which was helpful for local testing since I had created a branch with an answer type and then switched to a branch without that answer type.

## Testing story
Tested locally across a bunch of AIF levels to ensure AI Tutor still worked as expected.

