### PR TITLE
s3_packaging: log diffs for easier debugging

### DIFF
--- a/lib/cdo/aws/s3_packaging.rb
+++ b/lib/cdo/aws/s3_packaging.rb
@@ -55,7 +55,7 @@ class S3Packaging
   # Uploads the created package to s3
   # @return package
   def upload_package_to_s3(package)
-    raise "Generated different package for same contents" unless package_matches_download(package)
+    raise "Generated different package for same contents, see diff in logs" unless package_matches_download(package, log_if_different: true)
     upload_package(package)
     package
   end
@@ -153,7 +153,7 @@ class S3Packaging
   # its own). This validates that the one we created is identical to the one
   # that was uploaded.
   # @return [Boolean] True unless we have an existing package and it's different
-  private def package_matches_download(package)
+  private def package_matches_download(package, log_if_different: false)
     begin
       old_package = download_package
     rescue Aws::S3::Errors::NoSuchKey
@@ -162,13 +162,13 @@ class S3Packaging
     end
 
     @logger.info 'Existing package on s3. Validating equivalence'
-    packages_equivalent(old_package, package)
+    packages_equivalent(old_package, package, log_if_different: log_if_different)
   end
 
   # Checks to see if two packages are equivalent by unpacking them into tempfiles
   # and comparing the results. Simply comparing the packages themselves is not
   # sufficient, because they can contain metadata.
-  private def packages_equivalent(package1, package2)
+  private def packages_equivalent(package1, package2, log_if_different: false)
     diff = Dir.mktmpdir do |dir1|
       RakeUtils.system "tar -zxf #{package1.path} -C #{dir1}"
       Dir.mktmpdir do |dir2|
@@ -177,6 +177,7 @@ class S3Packaging
         output
       end
     end
+    @logger.warn "Packages differed:\n#{diff}" if log_if_different && !diff.empty?
     diff.empty?
   end
 

--- a/shared/test/test_s3_packaging.rb
+++ b/shared/test/test_s3_packaging.rb
@@ -171,6 +171,7 @@ class S3PackagingTest < Minitest::Test
     assert @packager.upload_package_to_s3(@packager.create_package('/build'))
 
     # try uploading a different package under the same name, it fails
+    @packager.instance_variable_get(:@logger).expects(:warn).with(includes('Packages differed:'))
     threw = false
     begin
       refute @packager.upload_package_to_s3(@packager.create_package('/src'))


### PR DESCRIPTION
Its not uncommon for staging to break with race conditions related to test running at the same time (/earlier). These are easier to debug with a log off the diffs between the packages.

This PR changes `upload_package_to_s3` so it logs the `diff -rq` output as a warning prior to raising. This includes which filenames differ, but not the contents of the diff (e.g. not a unified diff).