### PR TITLE
Add test to assert AWS Creds are optional

### DIFF
--- a/dashboard/test/lib/aws_creds_must_be_optional_test.rb
+++ b/dashboard/test/lib/aws_creds_must_be_optional_test.rb
@@ -24,6 +24,7 @@ class AWSCredsMustBeOptionalTest < ActiveSupport::TestCase
     LEGACY_SECRETS_THAT_ALREADY_BREAK_THINGS = %w(
       slack_bot_token
       openai_lesson_summaries_api_key
+      elevenlabs_api_key
       openai_student_learning_api_key
       langfuse_secret_key
       langfuse_public_key
@@ -40,6 +41,7 @@ class AWSCredsMustBeOptionalTest < ActiveSupport::TestCase
         we_have_aws_access = Aws::STS::Client.new.get_caller_identity rescue false
         raise "Test invalidated: we have AWS access here and should not" if we_have_aws_access
 
+        # Success! We ran `rails runner` without AWS access
         puts :rails_booted_without_aws
       RUBY
       chdir: Rails.root.to_s

--- a/dashboard/test/lib/aws_creds_must_be_optional_test.rb
+++ b/dashboard/test/lib/aws_creds_must_be_optional_test.rb
@@ -8,29 +8,40 @@ class AWSCredsMustBeOptionalTest < ActiveSupport::TestCase
   # that is not invoked when all the ruby code is loaded.
   test 'dashboard boots in RAILS_ENV=development without requiring !Secret AWS credentials' do
     ENV_VARS = {
+      'RAILS_ENV' => 'development',
+      'DISABLE_SPRING' => '1',
+
       # This is a hack, but it effectively disables access to existing AWS creds:
       'AWS_PROFILE' => 'nope',
-      'DISABLE_SPRING' => '1',
-      'RAILS_ENV' => 'development',
+      'AWS_EC2_METADATA_DISABLED' => 'true', # defend against IMDS
+      'AWS_ACCESS_KEY_ID' => '',
+      'AWS_SECRET_ACCESS_KEY' => '',
+      'AWS_SESSION_TOKEN' => '',
     }
 
     # Please do not add to this list. Instead, seek to remove from the list.
     # Then you will see that it is not the list that grows, it is your mind.
-    LOCALOVERRIDE_LEGACY_SECRETS = %w(
+    LEGACY_SECRETS_THAT_ALREADY_BREAK_THINGS = %w(
       slack_bot_token
       openai_lesson_summaries_api_key
       openai_student_learning_api_key
       langfuse_secret_key
       langfuse_public_key
       openai_measures_of_learning_api_key
-    ).index_with {'localoverride'}.transform_keys {|key| "CDO_#{key}"}
+    ).map {|secret| "CDO_#{secret}"}.index_with('')
 
-    # Start a new `rails runner` process and make sure it boots
+    # Start a new `rails runner` process and make sure it boots w/o AWS access
     stdout, stderr, status = Open3.capture3(
-      {**ENV_VARS, **LOCALOVERRIDE_LEGACY_SECRETS},
+      {**ENV_VARS, **LEGACY_SECRETS_THAT_ALREADY_BREAK_THINGS},
       'bin/rails',
       'runner',
-      'puts :rails_booted_ok',
+      <<~RUBY,
+        # Getting here means nothing if we hadn't correctly disabled AWS access for this process
+        we_have_aws_access = Aws::STS::Client.new.get_caller_identity rescue false
+        raise "Test invalidated: we have AWS access here and should not" if we_have_aws_access
+
+        puts :rails_booted_without_aws
+      RUBY
       chdir: Rails.root.to_s
     )
 
@@ -47,6 +58,6 @@ class AWSCredsMustBeOptionalTest < ActiveSupport::TestCase
       #{stderr}
     MSG
 
-    assert_includes stdout, 'rails_booted_ok'
+    assert_includes stdout, 'rails_booted_without_aws'
   end
 end

--- a/dashboard/test/lib/aws_creds_must_be_optional_test.rb
+++ b/dashboard/test/lib/aws_creds_must_be_optional_test.rb
@@ -1,0 +1,53 @@
+require 'test_helper'
+require 'open3'
+
+class AWSCredsMustBeOptionalTest < ActiveSupport::TestCase
+  # This test enforces this rule: if you add a new `mynewsecret: !Secret` override to development.yml
+  # the dashboard rails app must still be able to start in RAILS_ENV=development. That means if
+  # you access CDO.mynewsecret, you must either catch exceptions or reference it inside a function
+  # that is not invoked when all the ruby code is loaded.
+  test 'dashboard boots in RAILS_ENV=development without requiring !Secret AWS credentials' do
+    ENV_VARS = {
+      # This is a hack, but it effectively disables access to existing AWS creds:
+      'AWS_PROFILE' => 'nope',
+      'DISABLE_SPRING' => '1',
+      'RAILS_ENV' => 'development',
+    }
+
+    # Please do not add to this list. Instead, seek to remove from the list.
+    # Then you will see that it is not the list that grows, it is your mind.
+    LOCALOVERRIDE_LEGACY_SECRETS = %w(
+      slack_bot_token
+      openai_lesson_summaries_api_key
+      elevenlabs_api_key
+      openai_student_learning_api_key
+      langfuse_secret_key
+      langfuse_public_key
+      openai_measures_of_learning_api_key
+    ).index_with {'localoverride'}.transform_keys {|key| "CDO_#{key}"}
+
+    # Start a new `rails runner` process and make sure it boots
+    stdout, stderr, status = Open3.capture3(
+      {**ENV_VARS, **LOCALOVERRIDE_LEGACY_SECRETS},
+      'bin/rails',
+      'runner',
+      'puts :rails_booted_ok',
+      chdir: Rails.root.to_s
+    )
+
+    assert status.success?, <<~MSG
+      Expected dashboard to boot in RAILS_ENV=development without requiring AWS credentials
+
+      Tip: if you just added a `mynewsecret: !Secret` override to development.yml.erb, you shouldn't
+      be accessing it from top-level code (outside functions), or if you do, you need an exception handler.
+
+      stdout:
+      #{stdout}
+
+      stderr:
+      #{stderr}
+    MSG
+
+    assert_includes stdout, 'rails_booted_ok'
+  end
+end

--- a/dashboard/test/lib/aws_creds_must_be_optional_test.rb
+++ b/dashboard/test/lib/aws_creds_must_be_optional_test.rb
@@ -19,6 +19,7 @@ class AWSCredsMustBeOptionalTest < ActiveSupport::TestCase
     LOCALOVERRIDE_LEGACY_SECRETS = %w(
       slack_bot_token
       openai_lesson_summaries_api_key
+      elevenlabs_api_key
       openai_student_learning_api_key
       langfuse_secret_key
       langfuse_public_key

--- a/dashboard/test/lib/aws_creds_must_be_optional_test.rb
+++ b/dashboard/test/lib/aws_creds_must_be_optional_test.rb
@@ -19,7 +19,6 @@ class AWSCredsMustBeOptionalTest < ActiveSupport::TestCase
     LOCALOVERRIDE_LEGACY_SECRETS = %w(
       slack_bot_token
       openai_lesson_summaries_api_key
-      elevenlabs_api_key
       openai_student_learning_api_key
       langfuse_secret_key
       langfuse_public_key


### PR DESCRIPTION
This PR adds a test which boots rails without AWS creds, using `AWS_PROFILE=none RAILS_ENV=development bin/rails runner`, and makes sure it succeeds. This helps us not make AWS secrets mandatory for running dashboard.

## Context

As part of our eng excellence initiative last year, we got our app running without requiring AWS creds. This is good for open source contributors, and for certain kinds of technical development (e.g. kubernetes).

In the last year, we've had a number of new `mynewsecret: !Secret` overrides get added to development.yml.erb, which is great! It makes sense people want to use secrets in dev, needing to add special locals.yml secrets to your file makes parts of the codebase less accesible to all developers.

However, there's a catch that's easy to miss: when a !Secret override is added to development.erb.yml, it must not be loaded while the rails apps is booting. Its OK to have features that require a secret to be set to work, but the app must start without them so you can work on other parts / "use most of dashboard w/o access to AWS".

## Testing

- Catches new secrets added locally on my dev machine
- Removing a key from the existing legacy secrets "grandparented in" list breaks test
- Tried drone runs that both pass and fail by adding/removing legacy secrets from the list
- Breaks if inside the inner `rails runner` it finds it actually does have AWS access (defense against future CI changes that inject AWS creds another way)
