### PR TITLE
chore: do not instrument if not running app

### DIFF
--- a/dashboard/config/initializers/opentelemetry.rb
+++ b/dashboard/config/initializers/opentelemetry.rb
@@ -1,6 +1,7 @@
 # Only configure OpenTelemetry if enabled in CDO config, to avoid unnecessary overhead in environments where it's not needed.
-# Also skip in unit tests to avoid instrumentation overhead.
-if CDO.enable_opentelemetry && !ENV['UNIT_TEST']
+# Also skip when not running a web server (e.g., unit tests) to avoid instrumentation overhead.
+# Note: ENV['UNIT_TEST'] is set too late (in test_helper.rb) to be reliable here.
+if CDO.enable_opentelemetry && CDO.running_web_application?
   require 'opentelemetry/sdk'
   require 'opentelemetry/instrumentation/all'
   require 'opentelemetry-exporter-otlp'


### PR DESCRIPTION
This commit ensures instrumentation only occurs if running in web application mode and ensures all flavors of unit test execution do not instrument opentelemetry.