### PR TITLE
AI Client: enable transcription through proxy or gateway

### DIFF
--- a/apps/src/aiGateway/aiSdkCompatibleGateway.ts
+++ b/apps/src/aiGateway/aiSdkCompatibleGateway.ts
@@ -1,14 +1,12 @@
 import {generateText, type GenerateTextResult} from 'ai';
 
-import HttpClient from '@cdo/apps/util/HttpClient';
+import HttpClient from '../util/HttpClient';
+
+import {AI_GATEWAY_URL, fetchAccessToken, getModelString} from './shared';
 
 type SDKOptions = Parameters<typeof generateText>[0];
 type SDKTools = NonNullable<SDKOptions['tools']>;
 type SDKOutput = NonNullable<SDKOptions['output']>;
-
-type GenerateGatewayOptions = SDKOptions & {
-  token?: string;
-};
 
 type SerializableAIResponse<
   TOOLS extends SDKTools = SDKTools,
@@ -17,8 +15,6 @@ type SerializableAIResponse<
   text?: string;
   files?: {mediaType: string; base64: string}[];
 };
-
-const AI_GATEWAY_URL = `https://ai-gateway.code.org`;
 
 const base64ToUint8Array = (base64: string): Uint8Array => {
   const binaryString = atob(base64);
@@ -71,55 +67,27 @@ const generateTextThroughGateway = async <
   TOOLS extends SDKTools = SDKTools,
   OUTPUT extends SDKOutput = SDKOutput
 >(
-  options: GenerateGatewayOptions
+  options: SDKOptions
 ): Promise<GenerateTextResult<TOOLS, OUTPUT>> => {
   try {
     const {model, ...restOptions} = options;
-
-    let modelString: string;
-
-    if (typeof model === 'string') {
-      modelString = model;
-    } else {
-      const safeModel = model as unknown as Record<string, unknown>;
-      if (
-        safeModel !== null &&
-        typeof safeModel === 'object' &&
-        typeof safeModel.modelId === 'string'
-      ) {
-        modelString = safeModel.modelId;
-      } else {
-        throw new Error('Invalid model provided to Gateway.');
-      }
-    }
 
     const serializedOutput = await serializeOutputSchema(options.output);
 
     const payload = {
       ...restOptions,
-      model: modelString,
+      model: getModelString(model),
       output: serializedOutput,
-      token: '', // Placeholder to be filled after token fetch
     };
 
-    const tokenResponse = await HttpClient.get(
-      '/ai_gateway/access_token',
-      true,
-      {'Content-Type': 'application/json; charset=UTF-8'}
+    const token = await fetchAccessToken();
+
+    const response = await HttpClient.post(
+      AI_GATEWAY_URL,
+      JSON.stringify({...payload, token}),
+      false,
+      {'Content-Type': 'application/json'}
     );
-
-    const {token} = await (tokenResponse.json() as Promise<{token: string}>);
-    payload.token = token;
-
-    const response = await fetch(AI_GATEWAY_URL, {
-      method: 'POST',
-      headers: {'Content-Type': 'application/json'},
-      body: JSON.stringify(payload),
-    });
-
-    if (!response.ok) {
-      throw new Error(`HTTP error! status: ${response.status}`);
-    }
 
     const data = await (response.json() as Promise<
       SerializableAIResponse<TOOLS, OUTPUT>

--- a/apps/src/aiGateway/generateTextThroughProxyOrGateway.ts
+++ b/apps/src/aiGateway/generateTextThroughProxyOrGateway.ts
@@ -1,9 +1,0 @@
-import {generateText as generateTextThroughProxy} from 'ai';
-
-import {generateText as generateTextThroughGateway} from '@cdo/apps/aiGateway/aiSdkCompatibleGateway';
-
-import {isAiGatewayEnabled} from './isAiGatewayEnabled';
-
-export const generateText = isAiGatewayEnabled
-  ? generateTextThroughGateway
-  : generateTextThroughProxy;

--- a/apps/src/aiGateway/index.ts
+++ b/apps/src/aiGateway/index.ts
@@ -1,0 +1,24 @@
+import {
+  generateText as generateTextThroughProxy,
+  experimental_transcribe as transcribeThroughProxy,
+} from 'ai';
+
+import {generateText as generateTextThroughGateway} from '@cdo/apps/aiGateway/aiSdkCompatibleGateway';
+import {queryParams} from '@cdo/apps/code-studio/utils';
+import DCDO from '@cdo/apps/dcdo';
+
+import transcribeThroughGateway from './transcribeThroughGateway';
+
+const isAiGatewayEnabled =
+  DCDO.get('ai-gateway-enabled', true) ||
+  queryParams('use-ai-gateway') === 'true';
+
+const generateText = isAiGatewayEnabled
+  ? generateTextThroughGateway
+  : generateTextThroughProxy;
+
+const transcribe = isAiGatewayEnabled
+  ? transcribeThroughGateway
+  : transcribeThroughProxy;
+
+export {isAiGatewayEnabled, generateText, transcribe};

--- a/apps/src/aiGateway/isAiGatewayEnabled.ts
+++ b/apps/src/aiGateway/isAiGatewayEnabled.ts
@@ -1,6 +1,0 @@
-import {queryParams} from '@cdo/apps/code-studio/utils';
-import DCDO from '@cdo/apps/dcdo';
-
-export const isAiGatewayEnabled =
-  DCDO.get('ai-gateway-enabled', true) ||
-  queryParams('use-ai-gateway') === 'true';

--- a/apps/src/aiGateway/shared.ts
+++ b/apps/src/aiGateway/shared.ts
@@ -1,0 +1,35 @@
+import HttpClient from '../util/HttpClient';
+
+export const AI_GATEWAY_URL = `https://ai-gateway.code.org`;
+
+export async function fetchAccessToken() {
+  const {value} = await HttpClient.fetchJson<{token: string}>(
+    '/ai_gateway/access_token',
+    {
+      headers: {
+        'Content-Type': 'application/json; charset=UTF-8',
+      },
+    }
+  );
+  return value.token;
+}
+
+export function getModelString(model: unknown) {
+  let modelString: string;
+
+  if (typeof model === 'string') {
+    modelString = model;
+  } else {
+    const safeModel = model as unknown as Record<string, unknown>;
+    if (
+      safeModel !== null &&
+      typeof safeModel === 'object' &&
+      typeof safeModel.modelId === 'string'
+    ) {
+      modelString = safeModel.modelId;
+    } else {
+      throw new Error('Invalid model provided to Gateway.');
+    }
+  }
+  return modelString;
+}

--- a/apps/src/aiGateway/transcribeThroughGateway.ts
+++ b/apps/src/aiGateway/transcribeThroughGateway.ts
@@ -1,0 +1,50 @@
+import {
+  experimental_transcribe as transcribe,
+  Experimental_TranscriptionResult as TranscriptionResult,
+} from 'ai';
+
+import HttpClient from '../util/HttpClient';
+
+import {AI_GATEWAY_URL, fetchAccessToken, getModelString} from './shared';
+
+type TranscribeOptions = Parameters<typeof transcribe>[0];
+
+/**
+ * Fulfills the AI SDK transcription API through the AI Gateway.
+ */
+async function transcribeThroughGateway(
+  options: TranscribeOptions
+): Promise<TranscriptionResult> {
+  const {model, audio, ...restOptions} = options;
+
+  const token = await fetchAccessToken();
+
+  const formData = new FormData();
+  formData.append('token', token);
+  const audioBlob = await audioToBlob(audio);
+  formData.append('audio', audioBlob, 'audio');
+  formData.append('model', getModelString(model));
+
+  for (const [key, value] of Object.entries(restOptions)) {
+    formData.append(key, String(value));
+  }
+
+  const response = await HttpClient.post(
+    `${AI_GATEWAY_URL}/transcribe`,
+    formData
+  );
+
+  return await response.json();
+}
+
+async function audioToBlob(audio: TranscribeOptions['audio']): Promise<Blob> {
+  if (audio instanceof Blob) {
+    return audio;
+  } else if (audio instanceof URL) {
+    return await fetch(audio).then(r => r.blob());
+  } else {
+    return new Blob([audio as ArrayBuffer]);
+  }
+}
+
+export default transcribeThroughGateway;

--- a/apps/src/aichat/api/client/aichat-client-api.js
+++ b/apps/src/aichat/api/client/aichat-client-api.js
@@ -1,3 +1,4 @@
 // Allows us to lazy load the generateChatResponse function (which includes the AI SDK)
 // Due to our configuration this needs to be in js so we can use dynamic imports.
 export {generateChatResponse} from './generateChatResponse';
+export {transcribeAudio} from './transcribeAudio';

--- a/apps/src/aichat/api/client/generateChatResponse.ts
+++ b/apps/src/aichat/api/client/generateChatResponse.ts
@@ -1,6 +1,6 @@
 import {type ModelMessage} from 'ai';
 
-import {generateText} from '@cdo/apps/aiGateway/generateTextThroughProxyOrGateway';
+import {generateText} from '@cdo/apps/aiGateway';
 import {sendLab2AnalyticsEvent} from '@cdo/apps/lab2/utils';
 import {EVENTS} from '@cdo/apps/metrics/AnalyticsConstants';
 import {AiRequestExecutionStatus} from '@cdo/generated-scripts/sharedConstants';

--- a/apps/src/aichat/api/client/helpers/modelHelpers.ts
+++ b/apps/src/aichat/api/client/helpers/modelHelpers.ts
@@ -31,3 +31,7 @@ export function getModel(modelId: ValueOf<typeof AiChatModelIds>) {
   }
   return modelMap[modelId]!;
 }
+
+export function getTranscriptionModel() {
+  return openAiProvider.transcription('whisper-1');
+}

--- a/apps/src/aichat/api/client/helpers/safetyHelpers.ts
+++ b/apps/src/aichat/api/client/helpers/safetyHelpers.ts
@@ -1,7 +1,7 @@
 import {Output} from 'ai';
 import z from 'zod/v3';
 
-import {generateText} from '@cdo/apps/aiGateway/generateTextThroughProxyOrGateway';
+import {generateText} from '@cdo/apps/aiGateway';
 import {moderateImage} from '@cdo/apps/lab2/utils';
 import {ValueOf} from '@cdo/apps/types/utils';
 import {AiChatModelIds} from '@cdo/generated-scripts/sharedConstants';

--- a/apps/src/aichat/api/client/transcribeAudio.ts
+++ b/apps/src/aichat/api/client/transcribeAudio.ts
@@ -1,0 +1,15 @@
+import {transcribe} from '@cdo/apps/aiGateway';
+
+import {getTranscriptionModel} from './helpers/modelHelpers';
+
+/**
+ * Transcribes the given audio Blob into text using the Whisper model.
+ */
+export async function transcribeAudio(audio: Blob): Promise<string> {
+  const buffer = await audio.arrayBuffer();
+  const result = await transcribe({
+    model: getTranscriptionModel(),
+    audio: buffer,
+  });
+  return result.text;
+}

--- a/apps/src/aichat/redux/thunks/submitChatContents.ts
+++ b/apps/src/aichat/redux/thunks/submitChatContents.ts
@@ -10,7 +10,7 @@ import {
 } from '@cdo/apps/aichat/redux/slice';
 import {getAssetUrl} from '@cdo/apps/aichat/utils';
 import {Role} from '@cdo/apps/aiComponentLibrary/chatMessage/types';
-import {isAiGatewayEnabled} from '@cdo/apps/aiGateway/isAiGatewayEnabled';
+import {isAiGatewayEnabled} from '@cdo/apps/aiGateway';
 import {sendProgressReport} from '@cdo/apps/code-studio/progressRedux';
 import {TestResults} from '@cdo/apps/constants';
 import Lab2Registry from '@cdo/apps/lab2/Lab2Registry';


### PR DESCRIPTION
Adds a transcription pathway to the aichat client API, that may either use the AI SDK directly or invoke the AI Gateway, similar to `generateText()`. For now, we use the OpenAI whisper-1 model.

Also did a bit of refactoring and clean up to share common code (auth token, shared constants, etc).

AI Gateway PR: https://github.com/code-dot-org/ai-gateway/pull/11

## Testing story
Tested locally against a deployed cloudflare worker.