### PR TITLE
Refine Data Analyst IAM S3 Policies

### DIFF
--- a/aws/cloudformation/iam.yml.erb
+++ b/aws/cloudformation/iam.yml.erb
@@ -477,10 +477,20 @@ roles.each do |name, config| %>
           - Sid: DataAnalystS3ImportExportBucket
             Effect: Allow
             Action:
-              - 's3:*'
+              - 's3:GetObject'
+              - 's3:GetObjectVersion'
+              - 's3:PutObject'
+              - 's3:DeleteObject'
+              - 's3:ListBucket'
+              - 's3:GetBucketLocation'
+              - 's3:ListBucketMultipartUploads'
+              - 's3:AbortMultipartUpload'
+              - 's3:ListMultipartUploadParts'
             Resource:
               - 'arn:aws:s3:::cdo-data-sharing-internal/*'
               - 'arn:aws:s3:::cdo-data-sharing-internal'
+              - 'arn:aws:s3:::cdo-data-sharing/*'
+              - 'arn:aws:s3:::cdo-data-sharing'
               - 'arn:aws:s3:::cdo-census/*'
               - 'arn:aws:s3:::cdo-census'
               - 'arn:aws:s3:::cdo-nces/*'


### PR DESCRIPTION
Grant permission to `cdo-data-sharing` bucket and restrict S3 to just essential read/write Object Actions.

## Testing story
```
code-dot-org $ bundle exec rake stack:iam:validate RAILS_ENV=production ADMIN=true

Finished stack:iam:environment (less than a minute)
Pending update for stack `IAM`:
Modify DataAnalystPolicy [AWS::IAM::ManagedPolicy] Properties (PolicyDocument)
Finished stack:iam:validate (less than a minute)
```

## Deployment notes
```
code-dot-org $ bundle exec rake stack:iam:start RAILS_ENV=production ADMIN=true
```


## Privacy and security
<!-- Delete this section if there is no privacy/security impact.
     Otherwise: new PII, auth changes, API surface changes, etc. -->

