### PR TITLE
Don't clear history when system prompt changes in non-AI Chat uses

### DIFF
--- a/apps/src/aichat/redux/slice.ts
+++ b/apps/src/aichat/redux/slice.ts
@@ -121,7 +121,7 @@ const aichatSlice = createSlice({
         // We always reset conversation history when the user clears the chat.
         // In addition, for AI Chat lab, clear the history when the model changes, as the user controls model changes.
         if (
-          (state.clientType !== AiChatClientTypes.AI_CHAT_LAB &&
+          (state.clientType === AiChatClientTypes.AI_CHAT_LAB &&
             isModelUpdate(event) &&
             RESET_CONVERSATION_CUSTOMIZATION_UPDATES.includes(
               event.updatedField

--- a/apps/src/aichat/redux/slice.ts
+++ b/apps/src/aichat/redux/slice.ts
@@ -119,7 +119,8 @@ const aichatSlice = createSlice({
         const event = events[i];
 
         // We always reset conversation history when the user clears the chat.
-        // In addition, for AI Chat lab, clear the history when the model changes, as the user controls model changes.
+        // In addition, for AI Chat lab, clear the history when certain model updates occur,
+        // as the user controls model updates.
         if (
           (state.clientType === AiChatClientTypes.AI_CHAT_LAB &&
             isModelUpdate(event) &&

--- a/apps/src/aichat/redux/slice.ts
+++ b/apps/src/aichat/redux/slice.ts
@@ -13,6 +13,7 @@ import {
   ChatTextMessage,
 } from '@cdo/apps/aiDifferentiation/types';
 import {registerReducers} from '@cdo/apps/redux';
+import {AiChatClientTypes} from '@cdo/generated-scripts/sharedConstants';
 
 import {
   ModalTypes,
@@ -117,8 +118,11 @@ const aichatSlice = createSlice({
       for (let i = events.length - 1; i >= 0; i--) {
         const event = events[i];
 
+        // We always reset conversation history when the user clears the chat.
+        // In addition, for AI Chat lab, clear the history when the model changes, as the user controls model changes.
         if (
-          (isModelUpdate(event) &&
+          (state.clientType !== AiChatClientTypes.AI_CHAT_LAB &&
+            isModelUpdate(event) &&
             RESET_CONVERSATION_CUSTOMIZATION_UPDATES.includes(
               event.updatedField
             )) ||


### PR DESCRIPTION
In AI Chat it makes sense to clear history when the system prompt changes, as users control the system prompt. However, for AI Tutor we control the prompt behind the scenes, and want to make tweaks to it without impacting users. This updates our logic for showing users chat history to only hide chats before a system prompt change for AI Chat lab.

## Links

- Jira: [AFL-512](https://codedotorg.atlassian.net/browse/AFL-512)

## Testing story
Tested locally. Before this change, your chat history in AI Tutor would be hidden if the system prompt changes, now it is not. AI Chat acts as it did before.
