### PR TITLE
Fix programming method/class editor tests for React 18

### DIFF
--- a/apps/test/unit/levelbuilder/code-docs-editor/ProgrammingClassEditorTest.jsx
+++ b/apps/test/unit/levelbuilder/code-docs-editor/ProgrammingClassEditorTest.jsx
@@ -154,7 +154,6 @@ describe('ProgrammingClassEditor', () => {
 
     const saveAndCloseButton = saveBar.find('button').at(2);
     expect(saveAndCloseButton.contains('Save and Close')).to.be.true;
-    saveAndCloseButton.simulate('click');
     await act(async () => {
       saveAndCloseButton.simulate('click');
     });

--- a/apps/test/unit/levelbuilder/code-docs-editor/ProgrammingClassEditorTest.jsx
+++ b/apps/test/unit/levelbuilder/code-docs-editor/ProgrammingClassEditorTest.jsx
@@ -1,5 +1,6 @@
 import {shallow, mount} from 'enzyme'; // eslint-disable-line no-restricted-imports
 import React from 'react';
+import {act} from 'react-dom/test-utils';
 import {Provider} from 'react-redux';
 import sinon from 'sinon'; // eslint-disable-line no-restricted-imports
 
@@ -140,7 +141,7 @@ describe('ProgrammingClassEditor', () => {
     expect(orderableMethodList.props().list.length).to.equal(1);
   });
 
-  it('attempts to save when save is pressed', () => {
+  it('attempts to save when save is pressed', async () => {
     const store = getStore();
     const wrapper = mount(
       <Provider store={store}>
@@ -154,6 +155,10 @@ describe('ProgrammingClassEditor', () => {
     const saveAndCloseButton = saveBar.find('button').at(2);
     expect(saveAndCloseButton.contains('Save and Close')).to.be.true;
     saveAndCloseButton.simulate('click');
+    await act(async () => {
+      saveAndCloseButton.simulate('click');
+    });
+    wrapper.update();
 
     expect(fetchSpy).to.be.called.once;
     const fetchCall = fetchSpy.getCall(0);

--- a/apps/test/unit/levelbuilder/code-docs-editor/ProgrammingClassEditorTest.jsx
+++ b/apps/test/unit/levelbuilder/code-docs-editor/ProgrammingClassEditorTest.jsx
@@ -158,7 +158,6 @@ describe('ProgrammingClassEditor', () => {
     await act(async () => {
       saveAndCloseButton.simulate('click');
     });
-    wrapper.update();
 
     expect(fetchSpy).to.be.called.once;
     const fetchCall = fetchSpy.getCall(0);

--- a/apps/test/unit/levelbuilder/code-docs-editor/ProgrammingMethodEditorTest.jsx
+++ b/apps/test/unit/levelbuilder/code-docs-editor/ProgrammingMethodEditorTest.jsx
@@ -190,7 +190,6 @@ describe('ProgrammingMethodEditor', () => {
     await act(async () => {
       saveAndCloseButton.simulate('click');
     });
-    wrapper.update();
 
     expect(fetchSpy).to.be.called.once;
     const fetchCall = fetchSpy.getCall(0);

--- a/apps/test/unit/levelbuilder/code-docs-editor/ProgrammingMethodEditorTest.jsx
+++ b/apps/test/unit/levelbuilder/code-docs-editor/ProgrammingMethodEditorTest.jsx
@@ -1,5 +1,6 @@
 import {shallow, mount} from 'enzyme'; // eslint-disable-line no-restricted-imports
 import React from 'react';
+import {act} from 'react-dom/test-utils';
 import {Provider} from 'react-redux';
 import sinon from 'sinon'; // eslint-disable-line no-restricted-imports
 
@@ -158,7 +159,7 @@ describe('ProgrammingMethodEditor', () => {
     expect(orderableExampleList.props().list.length).to.equal(1);
   });
 
-  it('attempts to save when save is pressed', () => {
+  it('attempts to save when save is pressed', async () => {
     const store = getStore();
     const wrapper = mount(
       <Provider store={store}>
@@ -186,7 +187,10 @@ describe('ProgrammingMethodEditor', () => {
 
     const saveAndCloseButton = saveBar.find('button').at(2);
     expect(saveAndCloseButton.contains('Save and Close')).to.be.true;
-    saveAndCloseButton.simulate('click');
+    await act(async () => {
+      saveAndCloseButton.simulate('click');
+    });
+    wrapper.update();
 
     expect(fetchSpy).to.be.called.once;
     const fetchCall = fetchSpy.getCall(0);


### PR DESCRIPTION
Targeted fixes for two more tests failing on React 18, where we need to wait for some async work to finish before the test completes. The error was:

> _Error: The `document` global was defined when React was initialized, but is not defined anymore. This can happen in a test environment if a component schedules an update from an asynchronous callback, but the test has already finished running. To solve this, you can either unmount the component at the end of your test (and ensure that any asynchronous operations get canceled in `componentWillUnmount`), or you can change the test itself to be asynchronous._

## Links

- [React 18 upgrade tracker](https://docs.google.com/spreadsheets/d/1HEi20Ndj3r-fsCxuxxemm6QVIncMW_KVUzYMDsC6suU/edit?gid=1368456503#gid=1368456503)

## Testing story

Tested this passed on React 17 and 18 locally. Slightly confused by this because it didn't fail when I inventoried failing tests in January, but it did fail locally before I made these changes...