### PR TITLE
Update Aurora Engine to v3.12.0

### DIFF
--- a/aws/cloudformation/components/database.yml.erb
+++ b/aws/cloudformation/components/database.yml.erb
@@ -341,7 +341,7 @@
       # Updating a Stack with a change to EngineVersion causes "Some Interruption".
       # Each Database Instance in the cluster is restarted.
       # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-rds-dbcluster.html#cfn-rds-dbcluster-engineversion
-      EngineVersion: 8.0.mysql_aurora.3.11.0
+      EngineVersion: 8.0.mysql_aurora.3.12.0
       MasterUsername: !Sub "{{resolve:secretsmanager:${DatabaseSecretAdmin}:SecretString:username}}"
       MasterUserPassword: !Sub "{{resolve:secretsmanager:${DatabaseSecretAdmin}:SecretString:password}}"
       EnableIAMDatabaseAuthentication: true


### PR DESCRIPTION
The AWS Aurora service does not appear to permit launching new clusters with v3.11.0. We can't provision new Stacks with an Aurora cluster (adhocs where `DATABASE=true`).

## Testing story
`bundle exec rake adhoc:start RAILS_ENV=adhoc STACK_NAME=adhoc-upgrade-aurora DATABASE=true`


## Deployment notes
This change will automatically deploy to every AWS Stack except production. For production, we'll need to manually deploy this change during a low usage time period using our standard production database operations procedure due to brief periods of downtime when the reader and writer database instances restart.


## Privacy and security
<!-- Delete this section if there is no privacy/security impact.
     Otherwise: new PII, auth changes, API surface changes, etc. -->

