### PR TITLE
[AI Chat library] Refactors image library display

### DIFF
--- a/apps/src/lab2/views/components/starterAssetsDialog/FileIcon.tsx
+++ b/apps/src/lab2/views/components/starterAssetsDialog/FileIcon.tsx
@@ -18,7 +18,6 @@ interface FileIconProps extends AssetData {
   onSelect?: (selected: boolean) => void;
   selected?: boolean;
   canSelect?: boolean;
-  onDelete?: (filename: string) => void;
   showWarnings?: boolean;
 }
 
@@ -31,13 +30,14 @@ const FileIcon: React.FC<FileIconProps> = ({
   onSelect,
   canSelect = true,
   selected,
-  onDelete,
   showWarnings = false,
 }) => {
   const url = `${getFileUrl(filename, levelName)}?${timestamp}`;
   const [pageCount, setPageCount] = useState<number>();
   const [dimensions, setDimensions] = useState<[number, number]>();
-  const [loadingMetadata, setLoadingMetadata] = useState(true);
+  const [loadingMetadata, setLoadingMetadata] = useState(
+    category === 'image' || category === 'pdf'
+  );
 
   useEffect(() => {
     if (filename.endsWith('.pdf')) {

--- a/apps/src/lab2/views/components/starterAssetsDialog/FileIcon.tsx
+++ b/apps/src/lab2/views/components/starterAssetsDialog/FileIcon.tsx
@@ -104,7 +104,7 @@ const FileIcon: React.FC<FileIconProps> = ({
           </Typography>
           <MuiIconButton
             size="extraSmall"
-            onClick={() => window.open(url, '_blank')}
+            onClick={() => window.open(url, '_blank', 'noopener,noreferrer')}
             type="button"
             aria-label={`Preview ${filename}`}
             className={styles.previewButton}

--- a/apps/src/lab2/views/components/starterAssetsDialog/FileIcon.tsx
+++ b/apps/src/lab2/views/components/starterAssetsDialog/FileIcon.tsx
@@ -61,86 +61,86 @@ const FileIcon: React.FC<FileIconProps> = ({
   // Large PDF and image warnings are currently levelbuilder only,
   // so they are not translated.
   return (
-    <div className={styles.fileIconWrapper}>
-      {onSelect && !loadingMetadata && (
-        <Checkbox
-          checked={selected || false}
-          onChange={event => onSelect(event.target.checked)}
-          name={`select-${filename}`}
-          size="s"
-          disabled={!selected && !canSelect}
-        />
-      )}
-      {onDelete && !loadingMetadata && (
-        <MuiIconButton
-          variant="outlined"
-          color="error"
-          size="extraSmall"
-          onClick={() => onDelete(filename)}
-          type="button"
-          aria-label={`Delete ${filename}`}
-        >
-          <FontAwesomeV6Icon iconName="trash" />
-        </MuiIconButton>
-      )}
-      {loadingMetadata && (
-        <div className={styles.loadingIcon}>
-          <FontAwesomeV6Icon iconName="spinner" animationType={'spin'} />
-        </div>
-      )}
-      <button
-        className={styles[`file-icon-${category}`]}
-        type="button"
-        onClick={() => window.open(url, '_blank')}
-      >
+    <div className={styles.fileIconCard}>
+      <div className={styles.fileIconImageArea}>
+        {loadingMetadata && (
+          <div className={styles.loadingIcon}>
+            <FontAwesomeV6Icon iconName="spinner" animationType={'spin'} />
+          </div>
+        )}
         {category === 'image' && (
-          <img onLoad={onImgLoad} ref={imgRef} src={url} alt={filename} />
+          <img
+            onLoad={onImgLoad}
+            ref={imgRef}
+            src={url}
+            alt={filename}
+            className={styles.fileIconImage}
+            style={loadingMetadata ? {display: 'none'} : undefined}
+          />
         )}
         {category === 'pdf' && (
           <div className={styles.pdfIcon}>
             <FontAwesomeV6Icon iconName="file-pdf" />
           </div>
         )}
-        <div className={styles.fileInfo}>
-          <Typography className={styles.filename} variant="body3" gutterBottom>
-            {truncateFilename(filename)}
+        {onSelect && !loadingMetadata && (
+          <div className={styles.checkboxOverlay}>
+            <Checkbox
+              checked={selected || false}
+              onChange={event => onSelect(event.target.checked)}
+              name={`select-${filename}`}
+              size="s"
+              disabled={!selected && !canSelect}
+              aria-label={`Select ${filename}`}
+            />
+          </div>
+        )}
+      </div>
+
+      <div className={styles.fileInfo}>
+        <div className={styles.filenameRow}>
+          <Typography className={styles.filename} variant="body3">
+            <strong>{truncateFilename(filename)}</strong>
           </Typography>
-          <Typography className={styles.fileSize} variant="body3" gutterBottom>
+          <MuiIconButton
+            size="extraSmall"
+            onClick={() => window.open(url, '_blank')}
+            type="button"
+            aria-label={`Preview ${filename}`}
+            className={styles.previewButton}
+          >
+            <FontAwesomeV6Icon iconName="arrow-up-right-from-square" />
+          </MuiIconButton>
+        </div>
+        {width && height && (
+          <div className={styles.fileInfoRow}>
+            <Typography className={styles.fileDetail} variant="body3">
+              {width} x {height} px · {getSizeText(size)}
+            </Typography>
+            {showWarnings &&
+              (width > IMAGE_DIMENSION_WARNING ||
+                height > IMAGE_DIMENSION_WARNING) && (
+                <WarningIcon text="This image is large and may result in degraded performance." />
+              )}
+          </div>
+        )}
+        {pageCount && (
+          <div className={styles.fileInfoRow}>
+            <Typography className={styles.fileDetail} variant="body3">
+              {pageCount} {pageCount === 1 ? lab2I18n.page() : lab2I18n.pages()}{' '}
+              · {getSizeText(size)}
+            </Typography>
+            {showWarnings && pageCount > PDF_PAGE_WARNING && (
+              <WarningIcon text="This PDF has many pages and may result in degraded performance." />
+            )}
+          </div>
+        )}
+        {!width && !pageCount && (
+          <Typography className={styles.fileDetail} variant="body3">
             {getSizeText(size)}
           </Typography>
-          {pageCount && (
-            <div className={styles.fileInfoRow}>
-              <Typography
-                className={styles.fileDetail}
-                variant="body3"
-                gutterBottom
-              >
-                {pageCount}{' '}
-                {pageCount === 1 ? lab2I18n.page() : lab2I18n.pages()}
-              </Typography>
-              {showWarnings && pageCount > PDF_PAGE_WARNING && (
-                <WarningIcon text="This PDF has many pages and may result in degraded performance." />
-              )}
-            </div>
-          )}
-          {width && height && (
-            <div className={styles.fileInfoRow}>
-              <Typography
-                className={styles.fileDetail}
-                variant="body3"
-                gutterBottom
-              >
-                {width} x {height}
-              </Typography>
-              {showWarnings &&
-                (width > IMAGE_DIMENSION_WARNING ||
-                  height > IMAGE_DIMENSION_WARNING) && (
-                  <WarningIcon text="This image is large and may result in degraded performance." />
-                )}
-            </div>
-          )}
-        </div>
-      </button>
+        )}
+      </div>
     </div>
   );
 };

--- a/apps/src/lab2/views/components/starterAssetsDialog/SelectAssetsDialog.tsx
+++ b/apps/src/lab2/views/components/starterAssetsDialog/SelectAssetsDialog.tsx
@@ -44,6 +44,7 @@ const SelectAssetsDialog: React.FC<DialogProps & SelectProps> = ({
       id="starter-assets-dialog"
       onClose={onClose}
       title={lab2I18n.library()}
+      className={styles.starterAssetsModal}
       primaryButtonProps={{
         text: lab2I18n.attach(),
         onClick: primaryOnClick,

--- a/apps/src/lab2/views/components/starterAssetsDialog/UploadAssetDialog.tsx
+++ b/apps/src/lab2/views/components/starterAssetsDialog/UploadAssetDialog.tsx
@@ -133,6 +133,7 @@ const UploadAssetDialog: React.FC<UploadDialogProps & UploadProps> = ({
       id="starter-assets-dialog"
       onClose={onClose}
       title={'Manage Starter Assets'}
+      className={styles.starterAssetsModal}
       primaryButtonProps={{
         text: buttonText,
         onClick: () => {

--- a/apps/src/lab2/views/components/starterAssetsDialog/UploadAssetDialog.tsx
+++ b/apps/src/lab2/views/components/starterAssetsDialog/UploadAssetDialog.tsx
@@ -1,3 +1,4 @@
+import {Button} from '@code-dot-org/component-library/button';
 import Modal from '@code-dot-org/component-library/modal';
 import React, {ChangeEvent, useCallback, useState} from 'react';
 
@@ -47,6 +48,7 @@ const UploadAssetDialog: React.FC<UploadDialogProps & UploadProps> = ({
   const [requestInProgress, setRequestInProgress] = useState<
     'upload' | 'delete'
   >();
+  const [selectedFiles, setSelectedFiles] = useState<string[]>([]);
 
   const onFilesSelected = async (event: ChangeEvent<HTMLInputElement>) => {
     const files = event.target.files;
@@ -102,24 +104,28 @@ const UploadAssetDialog: React.FC<UploadDialogProps & UploadProps> = ({
     ACCEPTED_FILE_TYPES.join(',')
   );
 
-  const onDelete = useCallback(
-    async (filename: string) => {
-      clearAlert();
-      setRequestInProgress('delete');
-      try {
-        await deleteFile(filename, levelName);
-        removeAsset(filename);
-      } catch (error) {
-        updateAlert(
-          'Error deleting file. Please try again',
-          'danger',
-          error as Error
-        );
-      }
-      setRequestInProgress(undefined);
-    },
-    [clearAlert, levelName, removeAsset, updateAlert]
-  );
+  const onSelectAsset = useCallback((selected: boolean, filename: string) => {
+    setSelectedFiles(prev =>
+      selected ? [...prev, filename] : prev.filter(f => f !== filename)
+    );
+  }, []);
+
+  const onDeleteSelected = useCallback(async () => {
+    clearAlert();
+    setRequestInProgress('delete');
+    try {
+      await Promise.all(selectedFiles.map(f => deleteFile(f, levelName)));
+      selectedFiles.forEach(f => removeAsset(f));
+      setSelectedFiles([]);
+    } catch (error) {
+      updateAlert(
+        'Error deleting file. Please try again',
+        'danger',
+        error as Error
+      );
+    }
+    setRequestInProgress(undefined);
+  }, [clearAlert, levelName, removeAsset, selectedFiles, updateAlert]);
 
   const buttonText =
     requestInProgress === 'upload'
@@ -135,18 +141,10 @@ const UploadAssetDialog: React.FC<UploadDialogProps & UploadProps> = ({
       title={'Manage Starter Assets'}
       className={styles.starterAssetsModal}
       primaryButtonProps={{
-        text: buttonText,
-        onClick: () => {
-          clearAlert();
-          openFileInput();
-        },
-        iconLeft: {
-          iconName: requestInProgress ? 'spinner' : 'upload',
-          animationType: requestInProgress ? 'spin' : undefined,
-        },
-        disabled: loading || !!requestInProgress,
+        text: 'Upload',
+        onClick: () => {},
+        style: {display: 'none'},
       }}
-      secondaryButtonProps={{text: 'Cancel', onClick: onClose}}
       customContent={
         loading ? (
           <Loading />
@@ -159,7 +157,8 @@ const UploadAssetDialog: React.FC<UploadDialogProps & UploadProps> = ({
                   {...asset}
                   key={asset.filename}
                   levelName={levelName}
-                  onDelete={onDelete}
+                  onSelect={selected => onSelectAsset(selected, asset.filename)}
+                  selected={selectedFiles.includes(asset.filename)}
                   showWarnings={true}
                 />
               ))}
@@ -167,7 +166,45 @@ const UploadAssetDialog: React.FC<UploadDialogProps & UploadProps> = ({
           </>
         )
       }
-      customBottomContent={alert && <DialogAlert {...alert} />}
+      customBottomContent={
+        <>
+          <div className={styles.modalActionsRow}>
+            <Button
+              type="secondary"
+              color="black"
+              text="Cancel"
+              onClick={onClose}
+            />
+            {selectedFiles.length > 0 && (
+              <Button
+                type="primary"
+                color="destructive"
+                text={`Delete ${selectedFiles.length} ${
+                  selectedFiles.length === 1 ? 'file' : 'files'
+                }`}
+                onClick={onDeleteSelected}
+                disabled={!!requestInProgress}
+                iconLeft={{iconName: 'trash'}}
+              />
+            )}
+            <Button
+              type="primary"
+              color="purple"
+              text={buttonText}
+              onClick={() => {
+                clearAlert();
+                openFileInput();
+              }}
+              iconLeft={{
+                iconName: requestInProgress ? 'spinner' : 'upload',
+                animationType: requestInProgress ? 'spin' : undefined,
+              }}
+              disabled={loading || !!requestInProgress}
+            />
+          </div>
+          {alert && <DialogAlert {...alert} />}
+        </>
+      }
     />
   );
 };

--- a/apps/src/lab2/views/components/starterAssetsDialog/starter-assets-dialog.module.scss
+++ b/apps/src/lab2/views/components/starterAssetsDialog/starter-assets-dialog.module.scss
@@ -1,4 +1,5 @@
-@import '../../../../mixins.scss';
+$card-width: 160px;
+$card-gap: 16px;
 
 .loading {
   width: 100%;
@@ -11,63 +12,88 @@
   }
 }
 
+.starterAssetsModal {
+  width: 85vw;
+  min-width: 200px;
+  max-width: calc($card-width * 4 + $card-gap * 3);
+}
+
 .modalBody {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 16px;
-  justify-content: space-evenly;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, $card-width);
+  gap: $card-gap;
+  width: 100%;
 }
 
-.file {
-  width: 100px;
-  text-align: center;
-  padding: 16px;
-  border: 1px solid black;
+.fileIconCard {
+  border: 1px solid #d0d0d0;
+  border-radius: 4px;
+  overflow: hidden;
 }
 
-.fileIconWrapper {
+.fileIconImageArea {
+  position: relative;
+  height: calc($card-width / 2);
+  background-color: var(--background-neutral-subtle);
   display: flex;
-  gap: 8px;
-  padding: 16px;
-  align-items: flex-start;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+}
+
+.fileIconImage {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  border-radius: 0 !important;
+}
+
+.checkboxOverlay {
+  position: absolute;
+  top: 0;
+  left: 0;
+  background-color: white;
+  border-radius: 0 0 4px 0;
+  padding: 5px;
 }
 
 .loadingIcon {
   font-size: 13px;
-  min-width: 1.5rem;
 }
 
-%file-icon {
-  @include remove-button-styles;
+.fileInfo {
   display: flex;
-  align-items: center;
   flex-direction: column;
-  width: 100px;
-  text-align: center;
-  gap: 8px;
+  padding: 6px 8px;
+  gap: 2px;
 
-  .fileInfo {
+  .filenameRow {
     display: flex;
-    flex-direction: column;
     align-items: center;
-    text-align: center;
+    justify-content: space-between;
+    gap: 4px;
+  }
 
-    .fileInfoRow {
-      display: flex;
-      flex-direction: row;
-      align-items: baseline;
-      gap: 4px;
-    }
+  .fileInfoRow {
+    display: flex;
+    align-items: baseline;
+    gap: 4px;
   }
 
   .filename {
-    width: 100%;
-    overflow-wrap: break-word;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    font-size: 12px;
   }
 
   .fileDetail {
     color: var(--text-neutral-quaternary);
+    font-size: 10px;
   }
+}
+
+.previewButton {
+  flex-shrink: 0;
 }
 
 .warningIcon {
@@ -78,30 +104,17 @@
   }
 }
 
-.file-icon-image {
-  @extend %file-icon;
-  img {
-    opacity: 1;
-    max-height: 75px;
-    width: auto;
-    border-radius: 0;
-  }
-}
+.pdfIcon {
+  display: flex;
+  border-radius: 4px;
+  height: 50px;
+  width: 50px;
+  background-color: var(--background-brand-teal-primary);
 
-.file-icon-pdf {
-  @extend %file-icon;
-  .pdfIcon {
-    display: flex;
-    border-radius: 4px;
-    height: 50px;
-    width: 50px;
-    background-color: var(--background-brand-teal-primary);
-
-    i {
-      margin: auto;
-      color: white;
-      font-size: 1.5rem;
-    }
+  i {
+    margin: auto;
+    color: white;
+    font-size: 1.5rem;
   }
 }
 

--- a/apps/src/lab2/views/components/starterAssetsDialog/starter-assets-dialog.module.scss
+++ b/apps/src/lab2/views/components/starterAssetsDialog/starter-assets-dialog.module.scss
@@ -26,7 +26,7 @@ $card-gap: 16px;
 }
 
 .fileIconCard {
-  border: 1px solid #d0d0d0;
+  border: 1px solid var(--borders-neutral-primary);
   border-radius: 4px;
   overflow: hidden;
 }
@@ -64,7 +64,7 @@ $card-gap: 16px;
 .fileInfo {
   display: flex;
   flex-direction: column;
-  padding: 6px 8px;
+  padding: 4px 8px 6px 8px;
   gap: 2px;
 
   .filenameRow {
@@ -83,12 +83,12 @@ $card-gap: 16px;
   .filename {
     overflow: hidden;
     text-overflow: ellipsis;
-    font-size: 12px;
+    font-size: 13px;
   }
 
   .fileDetail {
     color: var(--text-neutral-quaternary);
-    font-size: 10px;
+    font-size: 11px;
   }
 }
 

--- a/apps/src/lab2/views/components/starterAssetsDialog/starter-assets-dialog.module.scss
+++ b/apps/src/lab2/views/components/starterAssetsDialog/starter-assets-dialog.module.scss
@@ -126,3 +126,11 @@ $card-gap: 16px;
     flex: 1;
   }
 }
+
+.modalActionsRow {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  padding: 8px 0 4px;
+  width: 100%;
+}


### PR DESCRIPTION
This updates the image display. I had to override the default modal behavior to give it a smaller min width and a set max width that was calculated based on the card width. The image widths are fixed and the images are zoomed to fit so they all look standard, which means tall skinny images will be zoomed in and cut off. See second screen recording below for responsive adjustment, click interactions, and loading states.

We chose to follow best accessibility practices here and not nest the two buttons within one another. The user must click either the checkbox or the icon to preview in a new tab. See first screen recording below for keyboard interactions.

Additionally, this refactors the levelbuilder experience so instead of the asset being immediately deleted via trash icon, there is the checkbox and then a delete button below. These pics are included in the before/after (and again, is only visible for levelbuilders). 

Before:

https://github.com/user-attachments/assets/e3b545d4-63c2-4dac-867e-3692ecda4e34


<img width="886" height="470" alt="Screenshot 2026-03-11 at 2 47 22 PM" src="https://github.com/user-attachments/assets/bfe06afb-e701-47dc-9935-66d7955b3526" />

<img width="937" height="637" alt="Screenshot 2026-03-12 at 11 15 44 AM" src="https://github.com/user-attachments/assets/7cfca6ba-7a66-4aae-8783-e79813e438b4" />



After:

<img width="875" height="449" alt="Screenshot 2026-03-11 at 3 04 21 PM" src="https://github.com/user-attachments/assets/9f722b56-d0c2-493a-9a1e-d1fc38051bf3" />

<img width="1764" height="1200" alt="Screenshot 2026-03-12 at 11 07 01 AM" src="https://github.com/user-attachments/assets/b7ae14d8-3e53-4d3b-ab1f-5fb8051a989b" />



https://github.com/user-attachments/assets/0ca305d1-7752-495c-8ef8-644401d06cac

https://github.com/user-attachments/assets/697f16b5-0ed5-4b98-a58d-5ac2e27a28f1



## Links

- Jira: https://codedotorg.atlassian.net/browse/AFL-492
- Slack context: https://codedotorg.slack.com/archives/C09EHQE4DGD/p1771612170590019

## Testing story
<!-- How was this tested? Manual steps, adhoc links, automated tests, or why testing isn't needed. -->



## Deployment notes
<!-- Delete this section if it's a standard merge-and-deploy.
     Otherwise: migrations, feature flags, coordination, caching impacts, etc. -->



## Privacy and security
<!-- Delete this section if there is no privacy/security impact.
     Otherwise: new PII, auth changes, API surface changes, etc. -->

