### PR TITLE
Do not load Student Learning OpenAI key on app start

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -106,7 +106,6 @@ External contributors can supply alternate placeholder values for secrets normal
 slack_bot_token: localoverride
 pardot_private_key: localoverride
 properties_encryption_key: ''
-openai_student_learning_api_key: localoverride
 ```
 
 ## OS-specific prerequisites

--- a/dashboard/app/helpers/aichat_safety_helper.rb
+++ b/dashboard/app/helpers/aichat_safety_helper.rb
@@ -2,7 +2,6 @@ require 'cdo/aws/metrics'
 
 # Provides functionality to detect toxicity in user input and model output used in the AI Chat Lab.
 module AichatSafetyHelper
-  API_KEY = CDO.openai_student_learning_api_key
   MODEL = SharedConstants::AICHAT_MODEL_VERSION
 
   class ToxicityDetector
@@ -94,7 +93,11 @@ module AichatSafetyHelper
     end
 
     private def client
-      AichatOpenaiResponsesHelper::Client.new(API_KEY, MODEL)
+      AichatOpenaiResponsesHelper::Client.new(api_key, MODEL)
+    end
+
+    private def api_key
+      @api_key ||= CDO.openai_student_learning_api_key
     end
 
     private def get_safety_system_prompt(level_id)

--- a/dashboard/app/helpers/aichat_safety_helper.rb
+++ b/dashboard/app/helpers/aichat_safety_helper.rb
@@ -93,11 +93,7 @@ module AichatSafetyHelper
     end
 
     private def client
-      AichatOpenaiResponsesHelper::Client.new(api_key, MODEL)
-    end
-
-    private def api_key
-      @api_key ||= CDO.openai_student_learning_api_key
+      AichatOpenaiResponsesHelper::Client.new(CDO.openai_student_learning_api_key, MODEL)
     end
 
     private def get_safety_system_prompt(level_id)

--- a/dashboard/test/lib/aws_creds_must_be_optional_test.rb
+++ b/dashboard/test/lib/aws_creds_must_be_optional_test.rb
@@ -25,7 +25,6 @@ class AWSCredsMustBeOptionalTest < ActiveSupport::TestCase
       slack_bot_token
       openai_lesson_summaries_api_key
       elevenlabs_api_key
-      openai_student_learning_api_key
     ).map {|secret| "CDO_#{secret}"}.index_with('')
 
     # Start a new `rails runner` process and make sure it boots w/o AWS access


### PR DESCRIPTION
We want to be able to boot our Rails app without access to AWS secrets, and we are trying to load our student learning OpenAI key from AWS Secrets Manager when the app starts, causing the app to be unable to start if you don't have access.

Putting it inside of a method body should allow the app to start, and produce errors if it's unavailable at runtime.

## Links

- Slack discussion: https://codedotorg.slack.com/archives/C03CK49G9/p1773224406769729

## Testing story

I was able to get a response from OpenAI with the key moved into its new location.