### PR TITLE
Removes over-zealous setting of the language_ cookie when resetting the language for the TMS

### DIFF
--- a/apps/src/localization/entrypoint.js
+++ b/apps/src/localization/entrypoint.js
@@ -235,7 +235,6 @@ if (projectKeys.length > 0 && (inExperiment || isLive)) {
    */
   const locale = get('language_') || 'en';
   if (!locale.startsWith('en')) {
-    set('language_', 'en-US');
     set('language_', 'en-US', {domain: '.code.org'});
     window.location.reload();
   } else {


### PR DESCRIPTION
I shouldn't set the base cookie because that has precedence over the `.code.org` cookie which is the one that actually gets set right now.
