### PR TITLE
Update styling of shepherdjs tours

### DIFF
--- a/apps/src/sharedComponents/productTour/shepherd.scss
+++ b/apps/src/sharedComponents/productTour/shepherd.scss
@@ -48,6 +48,7 @@
   h3 {
     font-size: 1.25rem;
     font-weight: 500;
+    line-height: 28px;
   }
 
   .shepherd-button {

--- a/apps/src/sharedComponents/productTour/shepherd.scss
+++ b/apps/src/sharedComponents/productTour/shepherd.scss
@@ -1,53 +1,101 @@
 @import 'shepherd.js/dist/css/shepherd.css';
 
+// Style the shepherd step container to approximately match the dsco popover.
 .custom-shepherd-step-container {
   font-family: Figtree, sans-serif;
+  color: var(--text-neutral-primary);
   background-color: var(--background-neutral-primary);
   box-shadow: 0 12px 40px rgb(28 45 94 / 16%);
   border-radius: 8px;
 
   &.shepherd-has-title .shepherd-content .shepherd-header {
     background-color: var(--background-neutral-primary);
+    padding: 0;
+    margin-bottom: 8px;
+  }
+
+  &.shepherd-has-title .shepherd-content .shepherd-cancel-icon {
+    color: var(--text-neutral-tertiary);
+    position: absolute;
+    top: 12px;
+    right: 12px;
+
+    &:hover {
+      color: var(--text-neutral-primary);
+    }
+
+    &:focus-visible {
+      outline: 2px solid var(--borders-brand-teal-primary);
+      outline-offset: 2px;
+    }
+  }
+
+  .shepherd-content {
+    padding: 24px;
+  }
+
+  .shepherd-text {
+    padding: 0;
+    margin-bottom: 16px;
+    color: var(--text-neutral-tertiary);
+  }
+
+  .shepherd-footer {
+    padding: 0;
+    gap: 8px;
   }
 
   h3 {
     font-size: 1.25rem;
     font-weight: 500;
   }
-}
 
-// Aligned with purple primary button styles.
-.custom-shepherd-button-primary {
-  background-color: var(--background-brand-purple-primary);
-  color: var(--text-neutral-white-fixed);
-
-  &:not(:disabled):hover {
-    background-color: var(--background-brand-purple-strong);
+  .shepherd-button {
+    margin: 0;
+    padding: 8px 16px;
+    transition: none;
+    font-size: 16px;
+    font-weight: 600;
   }
 
-  &:disabled,
-  &[aria-disabled='true']  {
-      background-color: var(--background-neutral-disabled);
-      color: var(--text-neutral-disabled-inverse);
+  .shepherd-button:focus-visible {
+    outline: 2px solid var(--borders-brand-teal-primary);
+    outline-offset: 2px;
   }
-}
 
-// Aligned with secondary black button styles.
-.custom-shepherd-button-secondary {
-  border: 1px solid var(--borders-neutral-solid);
-  background-color: var(--background-neutral-primary);
-  color: var(--text-neutral-primary);
+  // Aligned with purple primary button styles.
+  .custom-shepherd-button-primary {
+    background: var(--background-brand-purple-primary);
+    color: var(--text-neutral-white-fixed);
 
-  &:not(:disabled):hover {
-    background-color: var(--background-neutral-tertiary);
+    &:not(:disabled):hover {
+      background: var(--background-brand-purple-strong);
+    }
+
+    &:disabled,
+    &[aria-disabled='true']  {
+        background: var(--background-neutral-disabled);
+        color: var(--text-neutral-disabled-inverse);
+    }
+  }
+
+  // Aligned with secondary black button styles.
+  .custom-shepherd-button-secondary {
     border: 1px solid var(--borders-neutral-solid);
-    color: var(--text-neutral-primary);
-  }
-
-  &:disabled,
-  &[aria-disabled='true'] {
-    border-color: var(--borders-neutral-disabled) !important;
-    color: var(--text-neutral-disabled);
     background-color: var(--background-neutral-primary);
+    color: var(--text-neutral-primary);
+
+    &:not(:disabled):hover {
+      background-color: var(--background-neutral-tertiary);
+      border: 1px solid var(--borders-neutral-solid);
+      color: var(--text-neutral-primary);
+    }
+
+    &:disabled,
+    &[aria-disabled='true'] {
+      border-color: var(--borders-neutral-disabled) !important;
+      color: var(--text-neutral-disabled);
+      background-color: var(--background-neutral-primary);
+    }
   }
 }

--- a/apps/src/sharedComponents/productTour/shepherd.scss
+++ b/apps/src/sharedComponents/productTour/shepherd.scss
@@ -2,6 +2,13 @@
 
 .custom-shepherd-step-container {
   font-family: Figtree, sans-serif;
+  background-color: var(--background-neutral-primary);
+  box-shadow: 0 12px 40px rgb(28 45 94 / 16%);
+  border-radius: 8px;
+
+  &.shepherd-has-title .shepherd-content .shepherd-header {
+    background-color: var(--background-neutral-primary);
+  }
 
   h3 {
     font-size: 1.25rem;


### PR DESCRIPTION
This updates the styling of shepherdjs product tours to more closely match the [dsco popover](https://code-dot-org.github.io/code-dot-org/component-library-storybook/?path=/story/designsystem-popover--default-popover).

## Before
<img width="425" height="235" alt="Screenshot 2026-03-11 at 3 30 42 PM" src="https://github.com/user-attachments/assets/24077ebe-c804-4441-aac5-aa50b898efbd" />

## After
<img width="425" height="235" alt="Screenshot 2026-03-11 at 3 29 24 PM" src="https://github.com/user-attachments/assets/5cf2555a-e348-4d31-af18-7987bd878a30" />

## Testing story
Manual testing
