### PR TITLE
Refactor lab2 aichat disabled state

### DIFF
--- a/apps/src/lab2/hooks/useAiChatDisabledState.ts
+++ b/apps/src/lab2/hooks/useAiChatDisabledState.ts
@@ -1,0 +1,97 @@
+import {useEffect} from 'react';
+
+import {useAiChatDisabled} from '@cdo/apps/aichat/context/aiChatDisabledContext';
+import {areAiChatToolsEnabled} from '@cdo/apps/aichat/helpers/aiChatAccess';
+import lab2I18n from '@cdo/apps/lab2/locale';
+import {getIsStartMode} from '@cdo/apps/lab2/projects/utils';
+import {selectedSectionSelector} from '@cdo/apps/templates/teacherDashboard/teacherSectionsReduxSelectors';
+import {useAppSelector} from '@cdo/apps/util/reduxHooks';
+
+interface UseAiChatDisabledStateParams {
+  appName?: string;
+  isPredictLevel: boolean;
+  hasSubmittedPredictResponse: boolean;
+}
+
+export interface AiChatDisabledState {
+  chatDisabled: boolean;
+  chatDisabledMessage?: string;
+}
+
+/**
+ * Computes whether AI chat is disabled and what message to show, consolidating:
+ * - which aiChatAccessLevel applies (section override for teachers, or user's own)
+ * - whether the access level permits chat for the current app & access level
+ * - predict level gating
+ * - teacher vs. student messaging
+ */
+export function useAiChatDisabledState({
+  appName,
+  isPredictLevel,
+  hasSubmittedPredictResponse,
+}: UseAiChatDisabledStateParams) {
+  const {setChatDisabledState} = useAiChatDisabled();
+  const isTeacher = useAppSelector(state => state.currentUser.isTeacher);
+  const sectionAccessLevel = useAppSelector(
+    state => selectedSectionSelector(state)?.aiChatAccessLevel
+  );
+  const userAccessLevel = useAppSelector(
+    state => state.currentUser.aiChatAccessLevel
+  );
+  const enabledForUser = appName
+    ? areAiChatToolsEnabled({appName, aiChatAccessLevel: userAccessLevel})
+    : false;
+  let disabledState: AiChatDisabledState;
+
+  if (!appName) {
+    disabledState = {chatDisabled: true};
+  } else if (
+    isPredictLevel &&
+    !hasSubmittedPredictResponse &&
+    !getIsStartMode()
+  ) {
+    // Disabled on predict levels until the student has submitted a response to avoid spoiling the experience.
+    disabledState = {
+      chatDisabled: true,
+      chatDisabledMessage: lab2I18n.predictTutorDisabledMessage(),
+    };
+  } else if (isTeacher) {
+    if (
+      enabledForUser &&
+      !areAiChatToolsEnabled({
+        appName: appName!,
+        aiChatAccessLevel: sectionAccessLevel,
+      })
+    ) {
+      // If teacher has access but the currently selected section access level doesn't grant access,
+      // show the appropriate message to more closely match the student experience.
+      // Note: It might not EXACTLY match the student experience, since the student could
+      // technically have access from another teacher's section.
+      disabledState = {
+        chatDisabled: true,
+        chatDisabledMessage: 'This tool is disabled for the selected section.',
+      };
+    } else if (!enabledForUser) {
+      // If the teacher doesn't have access, show the appropriate message to direct the teacher on how to get access.
+      disabledState = {
+        chatDisabled: true,
+        chatDisabledMessage:
+          'You must be a verified teacher or sign in via Google, Microsoft, Facebook, or an LMS to use and assign this tool.',
+      };
+    } else {
+      disabledState = {chatDisabled: false};
+    }
+  } else {
+    // User is a student.
+    disabledState = enabledForUser
+      ? {chatDisabled: false}
+      : {
+          chatDisabled: true,
+          chatDisabledMessage: 'Your teacher has not enabled this tool.',
+        };
+  }
+
+  useEffect(() => {
+    setChatDisabledState(disabledState);
+  }, [disabledState, setChatDisabledState]);
+}

--- a/apps/src/lab2/views/LabViewsRenderer.tsx
+++ b/apps/src/lab2/views/LabViewsRenderer.tsx
@@ -5,18 +5,12 @@
  */
 import React, {createContext, Suspense, useEffect, useState} from 'react';
 
-import {TEACHER_DISABLED_AI_CHAT_MESSAGE} from '@cdo/apps/aichat/constants';
-import {useAiChatDisabled} from '@cdo/apps/aichat/context/aiChatDisabledContext';
-import {areAiChatToolsEnabled} from '@cdo/apps/aichat/helpers/aiChatAccess';
 import {queryParams} from '@cdo/apps/code-studio/utils';
 import {PERMISSIONS} from '@cdo/apps/lab2/constants';
+import {useAiChatDisabledState} from '@cdo/apps/lab2/hooks/useAiChatDisabledState';
 import {useInitialLabTheme} from '@cdo/apps/lab2/hooks/useInitialLabTheme';
-import lab2I18n from '@cdo/apps/lab2/locale';
 import ProgressContainer from '@cdo/apps/lab2/progress/ProgressContainer';
-import {
-  getAppOptionsViewingExemplar,
-  getIsStartMode,
-} from '@cdo/apps/lab2/projects/utils';
+import {getAppOptionsViewingExemplar} from '@cdo/apps/lab2/projects/utils';
 import {getLabViewPageAction, getIsLabViewBlocked} from '@cdo/apps/lab2/utils';
 import analyticsReporter from '@cdo/apps/metrics/AnalyticsReporter';
 import useRequiredContext from '@cdo/apps/util/hooks/useRequiredContext';
@@ -83,38 +77,11 @@ const LabViewsRenderer: React.FunctionComponent = () => {
     state => state.predictLevel.hasSubmittedResponse
   );
 
-  const aiChatAccessLevel = useAppSelector(
-    state => state.currentUser.aiChatAccessLevel
-  );
-  const {setChatDisabledState} = useAiChatDisabled();
-  useEffect(() => {
-    if (
-      currentAppName &&
-      !areAiChatToolsEnabled({appName: currentAppName, aiChatAccessLevel})
-    ) {
-      setChatDisabledState({
-        chatDisabled: true,
-        chatDisabledMessage: TEACHER_DISABLED_AI_CHAT_MESSAGE,
-      });
-    } else if (
-      isPredictLevel &&
-      !hasSubmittedPredictResponse &&
-      !getIsStartMode()
-    ) {
-      setChatDisabledState({
-        chatDisabled: true,
-        chatDisabledMessage: lab2I18n.predictTutorDisabledMessage(),
-      });
-    } else {
-      setChatDisabledState({chatDisabled: false});
-    }
-  }, [
-    currentAppName,
-    aiChatAccessLevel,
+  useAiChatDisabledState({
+    appName: currentAppName,
     isPredictLevel,
     hasSubmittedPredictResponse,
-    setChatDisabledState,
-  ]);
+  });
 
   const blockLabView = getIsLabViewBlocked(
     pageAction,


### PR DESCRIPTION
<!--
  Summary of the change: background, motivation, and context.
  Include screenshots, videos, or before/after comparisons for UI changes.
-->

updates the disabled logic to disable when selected section doesn't grant access (follow up from When teacher views a level, make tutor use the ai_chat_access_level of the selected section #71106 which did this for legacy labs)

## Links
<!-- Jira tickets, design docs, Slack threads, related PRs, etc. -->

- Jira:

## Testing story
<!-- How was this tested? Manual steps, adhoc links, automated tests, or why testing isn't needed. -->



## Deployment notes
<!-- Delete this section if it's a standard merge-and-deploy.
     Otherwise: migrations, feature flags, coordination, caching impacts, etc. -->



## Privacy and security
<!-- Delete this section if there is no privacy/security impact.
     Otherwise: new PII, auth changes, API surface changes, etc. -->

