### PR TITLE
Revert "add lti_user_identity to deployment if missing during auth"

### DIFF
--- a/dashboard/app/controllers/lti_v1_controller.rb
+++ b/dashboard/app/controllers/lti_v1_controller.rb
@@ -200,10 +200,6 @@ class LtiV1Controller < ApplicationController
           session: session,
         )
 
-        # Ensure the LTI user identity and deployment association exists
-        lti_user_identity = user.lti_user_identities&.find_by(lti_integration_id: integration.id, subject: decoded_jwt[:sub])
-        deployment.lti_user_identities << lti_user_identity if lti_user_identity && deployment.lti_user_identities.exclude?(lti_user_identity)
-
         # If this is the user's first login, send them into the account linking flow
         unless user.lms_landing_opted_out
           Services::Lti.initialize_lms_landing_session(session, integration[:platform_name], 'continue', user.user_type)

--- a/dashboard/test/controllers/lti_v1_controller_test.rb
+++ b/dashboard/test/controllers/lti_v1_controller_test.rb
@@ -402,22 +402,6 @@ class LtiV1ControllerTest < ActionDispatch::IntegrationTest
     refute_nil parsed_url[:nonce]
   end
 
-  describe '#authenticate' do
-    let(:payload) {get_valid_payload}
-    let(:jwt) {create_jwt_and_stub(payload)}
-    subject(:authenticate) {post '/lti/v1/authenticate', params: {id_token: jwt, state: @state}}
-
-    context 'when user not associated with deployment' do
-      it 'associates LtiUserIdentity with LtiDeployment' do
-        create_preexisting_user(payload)
-        assert @integration.lti_deployments.empty?
-        authenticate
-        deployment = @integration.lti_deployments.find_by(deployment_id: @deployment_id)
-        assert(deployment.lti_user_identities.any? {|identity| identity.subject == payload[:sub]})
-      end
-    end
-  end
-
   test 'auth - given no params, return unauthorized' do
     post '/lti/v1/authenticate'
     assert_response :unauthorized


### PR DESCRIPTION
Reverts code-dot-org/code-dot-org#71181