### PR TITLE
Fix Provisioning of `node` Lambdas

### DIFF
--- a/lib/cdo/cloud_formation/lambda.rb
+++ b/lib/cdo/cloud_formation/lambda.rb
@@ -198,7 +198,7 @@ module Cdo::CloudFormation
     # Zip an array of JS files (along with the `node_modules` folder), and upload to S3.
     def js_zip(files)
       Dir.chdir(aws_dir('cloudformation')) do
-        RakeUtils.yarn_install '--production'
+        RakeUtils.npm_install('--omit=dev')
       end
       lambda_zip(*files, 'node_modules', key_prefix: 'lambdajs')
     end


### PR DESCRIPTION
We are using a deprecated `yarn` command line argument. Use this an an opportunity to switch to `npm`.

## Testing story
`bundle exec rake stack:lambda:validate RAILS_ENV=production ADMIN=true`


## Deployment notes
<!-- Delete this section if it's a standard merge-and-deploy.
     Otherwise: migrations, feature flags, coordination, caching impacts, etc. -->



## Privacy and security
<!-- Delete this section if there is no privacy/security impact.
     Otherwise: new PII, auth changes, API surface changes, etc. -->

