### PR TITLE
Wrap state updates in act in VersionHistoryTest for React 18

### DIFF
--- a/apps/test/unit/templates/VersionHistoryTest.jsx
+++ b/apps/test/unit/templates/VersionHistoryTest.jsx
@@ -1,5 +1,6 @@
 import {mount} from 'enzyme'; // eslint-disable-line no-restricted-imports
 import React from 'react';
+import {act} from 'react-dom/test-utils';
 
 import {sources as sourcesApi, files as filesApi} from '@cdo/apps/clientApi';
 import project from '@cdo/apps/code-studio/initApp/project';
@@ -70,15 +71,30 @@ describe('VersionHistory', () => {
         isReadOnly: false,
       },
       finishVersionHistoryLoad: () => {
-        sourcesApi.ajax.mock.calls[0][2](FAKE_VERSION_LIST_RESPONSE);
+        act(() => {
+          sourcesApi.ajax.mock.calls[0][2](FAKE_VERSION_LIST_RESPONSE);
+        });
         wrapper.update();
       },
-      failVersionHistoryLoad: () => sourcesApi.ajax.mock.calls[0][3](),
+      failVersionHistoryLoad: () => {
+        act(() => {
+          sourcesApi.ajax.mock.calls[0][3]();
+        });
+        wrapper.update();
+      },
       restoreSpy: () => sourcesApi.restorePreviousFileVersion,
-      finishRestoreVersion: () =>
-        sourcesApi.restorePreviousFileVersion.mock.calls[0][2](),
-      failRestoreVersion: () =>
-        sourcesApi.restorePreviousFileVersion.mock.calls[0][3](),
+      finishRestoreVersion: () => {
+        act(() => {
+          sourcesApi.restorePreviousFileVersion.mock.calls[0][2]();
+        });
+        wrapper.update();
+      },
+      failRestoreVersion: () => {
+        act(() => {
+          sourcesApi.restorePreviousFileVersion.mock.calls[0][3]();
+        });
+        wrapper.update();
+      },
     });
   });
 
@@ -107,16 +123,32 @@ describe('VersionHistory', () => {
         isReadOnly: false,
       },
       finishVersionHistoryLoad: () => {
-        filesApi.getVersionHistory.mock.calls[0][0](FAKE_VERSION_LIST_RESPONSE);
+        act(() => {
+          filesApi.getVersionHistory.mock.calls[0][0](
+            FAKE_VERSION_LIST_RESPONSE
+          );
+        });
         wrapper.update();
       },
-      failVersionHistoryLoad: () =>
-        filesApi.getVersionHistory.mock.calls[0][1](),
+      failVersionHistoryLoad: () => {
+        act(() => {
+          filesApi.getVersionHistory.mock.calls[0][1]();
+        });
+        wrapper.update();
+      },
       restoreSpy: () => filesApi.restorePreviousVersion,
-      finishRestoreVersion: () =>
-        filesApi.restorePreviousVersion.mock.calls[0][1](),
-      failRestoreVersion: () =>
-        filesApi.restorePreviousVersion.mock.calls[0][2](),
+      finishRestoreVersion: () => {
+        act(() => {
+          filesApi.restorePreviousVersion.mock.calls[0][1]();
+        });
+        wrapper.update();
+      },
+      failRestoreVersion: () => {
+        act(() => {
+          filesApi.restorePreviousVersion.mock.calls[0][2]();
+        });
+        wrapper.update();
+      },
     });
   });
 
@@ -128,6 +160,13 @@ describe('VersionHistory', () => {
     finishRestoreVersion,
     failRestoreVersion,
   }) {
+    const clickAndUpdate = node => {
+      act(() => {
+        node.simulate('click');
+      });
+      wrapper.update();
+    };
+
     it('renders loading spinner at first', () => {
       wrapper = mount(<VersionHistory {...props} />);
       expect(
@@ -164,14 +203,14 @@ describe('VersionHistory', () => {
       finishVersionHistoryLoad();
       expect(restoreSpy()).not.toHaveBeenCalled();
 
-      wrapper.find('.img-upload').first().simulate('click');
+      clickAndUpdate(wrapper.find('.img-upload').first());
       expect(restoreSpy()).toHaveBeenCalledTimes(1);
     });
 
     it('renders an error on failed restore', () => {
       wrapper = mount(<VersionHistory {...props} />);
       finishVersionHistoryLoad();
-      wrapper.find('.img-upload').first().simulate('click');
+      clickAndUpdate(wrapper.find('.img-upload').first());
 
       failRestoreVersion();
       expect(wrapper.text()).toContain('An error occurred.');
@@ -180,7 +219,7 @@ describe('VersionHistory', () => {
     it('reloads the page on successful restore', () => {
       wrapper = mount(<VersionHistory {...props} />);
       finishVersionHistoryLoad();
-      wrapper.find('.img-upload').first().simulate('click');
+      clickAndUpdate(wrapper.find('.img-upload').first());
       expect(utils.reload).not.toHaveBeenCalled();
 
       finishRestoreVersion();
@@ -192,7 +231,7 @@ describe('VersionHistory', () => {
       finishVersionHistoryLoad();
 
       // Click "Start Over"
-      wrapper.find('.btn-danger').simulate('click');
+      clickAndUpdate(wrapper.find('.btn-danger'));
 
       // Expect confirmation to show
       expect(
@@ -218,7 +257,7 @@ describe('VersionHistory', () => {
       finishVersionHistoryLoad();
 
       // Click "Start Over"
-      wrapper.find('.btn-danger').simulate('click');
+      clickAndUpdate(wrapper.find('.btn-danger'));
 
       // Expect confirmation to show
       expect(
@@ -239,7 +278,7 @@ describe('VersionHistory', () => {
       ).toBeTruthy();
 
       // Click "Cancel"
-      wrapper.find('#again-button').simulate('click');
+      clickAndUpdate(wrapper.find('#again-button'));
 
       // Rendered two version rows
       expect(wrapper.find(VersionRow)).toHaveLength(2);
@@ -250,7 +289,7 @@ describe('VersionHistory', () => {
       finishVersionHistoryLoad();
 
       // Click "Start Over"
-      wrapper.find('.btn-danger').simulate('click');
+      clickAndUpdate(wrapper.find('.btn-danger'));
 
       expect(wrapper.find('.template-level-warning')).toBeDefined();
     });
@@ -264,8 +303,8 @@ describe('VersionHistory', () => {
           <VersionHistory {...props} handleClearPuzzle={handleClearPuzzle} />
         );
         finishVersionHistoryLoad();
-        wrapper.find('.btn-danger').simulate('click');
-        wrapper.find('#start-over-button').simulate('click');
+        clickAndUpdate(wrapper.find('.btn-danger'));
+        clickAndUpdate(wrapper.find('#start-over-button'));
       });
 
       afterEach(async () => {


### PR DESCRIPTION
Updates a test failing in React 18 to wrap all state updates in `act`. 🤞 this is the last test to update to allow us to get on React 18!

## Links

- [React 18 Upgrade Tracker](https://docs.google.com/spreadsheets/d/1HEi20Ndj3r-fsCxuxxemm6QVIncMW_KVUzYMDsC6suU/edit?gid=1368456503#gid=1368456503)

## Testing story

Tested this passes in React 18 and 17.