### PR TITLE
Associate LtiDeployment and LtiUserIdentity in authenticate method

### DIFF
--- a/dashboard/app/controllers/lti_v1_controller.rb
+++ b/dashboard/app/controllers/lti_v1_controller.rb
@@ -85,9 +85,9 @@ class LtiV1Controller < ApplicationController
     return log_unauthorized('Missing aud or iss from ID token') unless extracted_client_id.present? && extracted_issuer_id.present?
     # set cache key
     integration_cache_key = "#{extracted_issuer_id}/#{extracted_client_id}"
-    # 'integration' can come back as a hash from the cache or as a class instance returned by ActiveRecord. In the case of the former, we are
-    # unable to access values using dot notation and instead must use brackets. This still works with the value returned by Active Record,
-    # as it has a '[]' method that behaves in the same way https://api.rubyonrails.org/classes/ActiveRecord/AttributeMethods.html#method-i-5B-5D
+    # `read_cache` returns a symbolized hash, and a cache miss falls back to an
+    # ActiveRecord object. Use bracket notation, not dot notation because it works for both.
+    # Example: integration[:id] not integration.id
     integration = read_cache(integration_cache_key)
     unless integration
       integration = LtiIntegration.find_by({client_id: extracted_client_id, issuer: extracted_issuer_id})
@@ -201,7 +201,7 @@ class LtiV1Controller < ApplicationController
         )
 
         # Ensure the LTI user identity and deployment association exists
-        lti_user_identity = user.lti_user_identities&.find_by(lti_integration_id: integration.id, subject: decoded_jwt[:sub])
+        lti_user_identity = user.lti_user_identities&.find_by(lti_integration_id: integration[:id], subject: decoded_jwt[:sub])
         deployment.lti_user_identities << lti_user_identity if lti_user_identity && deployment.lti_user_identities.exclude?(lti_user_identity)
 
         # If this is the user's first login, send them into the account linking flow

--- a/dashboard/app/controllers/lti_v1_controller.rb
+++ b/dashboard/app/controllers/lti_v1_controller.rb
@@ -200,6 +200,10 @@ class LtiV1Controller < ApplicationController
           session: session,
         )
 
+        # Ensure the LTI user identity and deployment association exists
+        lti_user_identity = user.lti_user_identities&.find_by(lti_integration_id: integration.id, subject: decoded_jwt[:sub])
+        deployment.lti_user_identities << lti_user_identity if lti_user_identity && !deployment.lti_user_identities.include?(lti_user_identity)
+
         # If this is the user's first login, send them into the account linking flow
         unless user.lms_landing_opted_out
           Services::Lti.initialize_lms_landing_session(session, integration[:platform_name], 'continue', user.user_type)

--- a/dashboard/app/controllers/lti_v1_controller.rb
+++ b/dashboard/app/controllers/lti_v1_controller.rb
@@ -202,7 +202,7 @@ class LtiV1Controller < ApplicationController
 
         # Ensure the LTI user identity and deployment association exists
         lti_user_identity = user.lti_user_identities&.find_by(lti_integration_id: integration.id, subject: decoded_jwt[:sub])
-        deployment.lti_user_identities << lti_user_identity if lti_user_identity && !deployment.lti_user_identities.include?(lti_user_identity)
+        deployment.lti_user_identities << lti_user_identity if lti_user_identity && deployment.lti_user_identities.exclude?(lti_user_identity)
 
         # If this is the user's first login, send them into the account linking flow
         unless user.lms_landing_opted_out

--- a/dashboard/test/controllers/lti_v1_controller_test.rb
+++ b/dashboard/test/controllers/lti_v1_controller_test.rb
@@ -406,14 +406,14 @@ class LtiV1ControllerTest < ActionDispatch::IntegrationTest
     let(:payload) {get_valid_payload}
     let(:jwt) {create_jwt_and_stub(payload)}
     subject(:authenticate) {post '/lti/v1/authenticate', params: {id_token: jwt, state: @state}}
-    
+
     context 'when user not associated with deployment' do
       it 'associates LtiUserIdentity with LtiDeployment' do
         create_preexisting_user(payload)
         assert @integration.lti_deployments.empty?
         authenticate
         deployment = @integration.lti_deployments.find_by(deployment_id: @deployment_id)
-        assert deployment.lti_user_identities.any? {|identity| identity.subject == payload[:sub]}
+        assert(deployment.lti_user_identities.any? {|identity| identity.subject == payload[:sub]})
       end
     end
   end

--- a/dashboard/test/controllers/lti_v1_controller_test.rb
+++ b/dashboard/test/controllers/lti_v1_controller_test.rb
@@ -402,6 +402,22 @@ class LtiV1ControllerTest < ActionDispatch::IntegrationTest
     refute_nil parsed_url[:nonce]
   end
 
+  describe '#authenticate' do
+    let(:payload) {get_valid_payload}
+    let(:jwt) {create_jwt_and_stub(payload)}
+    subject(:authenticate) {post '/lti/v1/authenticate', params: {id_token: jwt, state: @state}}
+    
+    context 'when user not associated with deployment' do
+      it 'associates LtiUserIdentity with LtiDeployment' do
+        create_preexisting_user(payload)
+        assert @integration.lti_deployments.empty?
+        authenticate
+        deployment = @integration.lti_deployments.find_by(deployment_id: @deployment_id)
+        assert deployment.lti_user_identities.any? {|identity| identity.subject == payload[:sub]}
+      end
+    end
+  end
+
   test 'auth - given no params, return unauthorized' do
     post '/lti/v1/authenticate'
     assert_response :unauthorized

--- a/dashboard/test/controllers/lti_v1_controller_test.rb
+++ b/dashboard/test/controllers/lti_v1_controller_test.rb
@@ -416,6 +416,24 @@ class LtiV1ControllerTest < ActionDispatch::IntegrationTest
         assert(deployment.lti_user_identities.any? {|identity| identity.subject == payload[:sub]})
       end
     end
+
+    context 'when integration comes from cache as a hash' do
+      let(:user) {create_preexisting_user(payload)}
+      let(:deployment) {create(:lti_deployment, deployment_id: @deployment_id, lti_integration: @integration)}
+
+      # Simulate read_cache, which returns JSON.parse(json_value).symbolize_keys
+      let(:cached_integration) {@integration.attributes.symbolize_keys}
+
+      it 'associates LtiUserIdentity with LtiDeployment' do
+        user
+        deployment
+        LtiV1Controller.any_instance.stubs(:read_cache).with(@state).returns({state: @state, nonce: @nonce})
+        LtiV1Controller.any_instance.stubs(:read_cache).with("#{@integration.issuer}/#{@integration.client_id}").returns(cached_integration)
+
+        authenticate
+        assert_includes deployment.reload.lti_user_identities, user.lti_user_identities.first
+      end
+    end
   end
 
   test 'auth - given no params, return unauthorized' do


### PR DESCRIPTION
This is a fixed version of https://github.com/code-dot-org/code-dot-org/pull/71181, which was reverted after causing 500s for users attempting to log in via LTI. The issue was that the `integration` object in the `authenticate` method can be either a Ruby hash with symbolized keys or an ActiveRecord object depending on whether the cache hits or misses.

I tried a couple different fixes including:

- Always calling the DB for the integration instead of caching. Since this adds the overhead of an additional DB call for every launch, and since the caching logic is already working (despite potentially being unnecessary), this implementation felt like it added risk and degraded performance.
- In the event of a cache hit, `new`ing up an ActiveRecord LtiIntegration object. This ensures consistent access to ActiveRecord methods, including dot notation for referencing properties, regardless of cache hit or miss, and doesn't require a call to the DB. However, it felt more complex, and like we didn't gain much considering we are already using bracket notation throughout the method.

Ultimately landed on:

- Keeping the caching/fallback logic the same
- Referencing the integration ID using bracket notation in the new code
- Adding a test that stubs out the integration as a hash with symbolized keys. All the other tests return a real ActiveRecord object from the lti_integration factory, which is why this wasn't caught in tests.



## Links
[JIRA](https://codedotorg.atlassian.net/browse/P20-1747)

- Jira:

## Testing story
<!-- How was this tested? Manual steps, adhoc links, automated tests, or why testing isn't needed. -->



## Deployment notes
<!-- Delete this section if it's a standard merge-and-deploy.
     Otherwise: migrations, feature flags, coordination, caching impacts, etc. -->



## Privacy and security
<!-- Delete this section if there is no privacy/security impact.
     Otherwise: new PII, auth changes, API surface changes, etc. -->

