### PR TITLE
Add agent skills directories, aka claude skills

### DIFF
--- a/.agents/skills/README.md
+++ b/.agents/skills/README.md
@@ -1,0 +1,13 @@
+Agent skills extend AGENTS.md to specialized domains and tasks without
+filling everyone's context all the time.
+
+See standard at: https://agentskills.io/
+
+Rather than lengthening AGENTS.md, consider adding a new skill and comitting
+it to git for everyone to benefit from.
+
+Skills matching `.agents/skills/*.local` are not committed to git, use this
+directory for personal skills.
+
+NOTE: `.claude/skills` is symlinked to this directory, all other agents
+should discover `.agents/skills` automatically.

--- a/.claude/skills
+++ b/.claude/skills
@@ -1,0 +1,1 @@
+../.agents/skills

--- a/.gitignore
+++ b/.gitignore
@@ -114,7 +114,13 @@ dashboard/brakeman_security_report.htm
 
 skaffold-build-tags.json
 
-# ai
+# claude
 .claude/worktrees
 CLAUDE.local.md
-.claude/*.local.*
+.claude/**/*.local.*
+.claude/skills/*.local
+
+# agent skills standard: https://agentskills.io/
+.agents/**/*.local.*
+.agents/skills/*.local
+

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -86,3 +86,8 @@
 - next, test as much as you can with rails runner, mysql commands, in the browser, etc (as relevant)
 - finally, if there's a relevant test suite, run it
 - once you've done all that, if you need any testing that requires the UI or secrets, or you're ready for a full drone run, let the user know what you'd like tested that you could not test on your own
+
+# Agent skills
+- Add agent skills to the `.agents/skills` directory shared by all agents.
+- Skill directories matching `.agents/skills/*.local` are not committed to git.
+- Prefer adding agent skills to extending AGENTS.md.


### PR DESCRIPTION
Agent skills extend AGENTS.md to specialized domains and tasks without filling everyone's context all the time. 

See standard at: https://agentskills.io/

## Details

The basic skills format is supported by most agents, e.g.: Codex, Claude Code, Antigravity, OpenCode, etc. Going forward, rather than lengthening AGENTS.md, consider adding a new skill and comitting it to git for everyone to benefit from.

Motivated to add this by @levadadenys creating a nice PR [Add design system docs to AGENTS.md](https://github.com/code-dot-org/code-dot-org/pull/71222#top). I suggested he use .agents/skills, and realize we hadn't setup a skeleton yet. So here it is.

## This PR:

1) Adds a .agents/skills directory and symlinks it to .claude/skills. Virtually all agents except claude code support the .agents/skills directory as of Mar 2026 ([relevant standards PR](https://github.com/agentskills/agentskills/issues/15)).
2) Adds the emerging `.agents/**/*.local.*`convention to .gitignore, as well as `*.agents/skills/*.local`. This convention can be used to build a library of personal use skills that are not committed to git.
3) Adds 47 tokens to AGENTS.md length, hopefully offset by future gains.
