### PR TITLE
feat(prometheus): allow daemon and frontends to write to AMP

### DIFF
--- a/aws/cloudformation/cloud_formation_stack.yml.erb
+++ b/aws/cloudformation/cloud_formation_stack.yml.erb
@@ -281,6 +281,7 @@ Resources:
             Resource:
               - 'arn:aws:bedrock:us-east-1::foundation-model/anthropic.claude-3-sonnet-20240229-v1:0'
           # Allow Frontend and Daemon servers to write to Amazon Managed Prometheus (AMP)
+          # TODO: Replace with SSM - https://codedotorg.atlassian.net/browse/INF-2079
           - Effect: Allow
             Action:
               - 'aps:RemoteWrite'

--- a/aws/cloudformation/cloud_formation_stack.yml.erb
+++ b/aws/cloudformation/cloud_formation_stack.yml.erb
@@ -280,7 +280,7 @@ Resources:
               - 'bedrock:InvokeModel'
             Resource:
               - 'arn:aws:bedrock:us-east-1::foundation-model/anthropic.claude-3-sonnet-20240229-v1:0'
-          # Allow Frontend and Daemon servers to write to AWS Managed Prometheus
+          # Allow Frontend and Daemon servers to write to Amazon Managed Prometheus (AMP)
           - Effect: Allow
             Action:
               - 'aps:RemoteWrite'

--- a/aws/cloudformation/cloud_formation_stack.yml.erb
+++ b/aws/cloudformation/cloud_formation_stack.yml.erb
@@ -280,6 +280,11 @@ Resources:
               - 'bedrock:InvokeModel'
             Resource:
               - 'arn:aws:bedrock:us-east-1::foundation-model/anthropic.claude-3-sonnet-20240229-v1:0'
+          # Allow Frontend and Daemon servers to write to AWS Managed Prometheus
+          - Effect: Allow
+            Action:
+              - 'aps:RemoteWrite'
+            Resource: '*'
 
   # ---------------------------------------------
   # Frontend Servers


### PR DESCRIPTION
This commit grants access on the frontends and daemon servers to write to Amazon Managed Prometheus.