### PR TITLE
Add speech to text button to AI Chat

### DIFF
--- a/apps/src/aiComponentLibrary/userMessageEditor/UserMessageEditor.tsx
+++ b/apps/src/aiComponentLibrary/userMessageEditor/UserMessageEditor.tsx
@@ -24,6 +24,7 @@ export interface UserMessageEditorProps {
   /** Custom className for editor container */
   editorContainerClassName?: string;
   customPlaceholder?: string;
+  speechToTextEnabled?: boolean;
   children?: React.ReactNode;
 }
 
@@ -42,6 +43,7 @@ const UserMessageEditor = React.forwardRef<
       editorContainerClassName,
       customPlaceholder,
       showSubmitLabel = false,
+      speechToTextEnabled = false,
       children,
     },
     externalInputRef
@@ -126,13 +128,15 @@ const UserMessageEditor = React.forwardRef<
         <div className={moduleStyles.chatActionsContainer}>
           {children}
           <div className={moduleStyles.actionButtons}>
-            <SpeechToTextButton
-              onTranscribed={text => {
-                onChange(`${userMessage ? userMessage + ' ' : ''}${text}`);
-                setIsRecording(false);
-              }}
-              onRecordStart={() => setIsRecording(true)}
-            />
+            {speechToTextEnabled && (
+              <SpeechToTextButton
+                onTranscribed={text => {
+                  onChange(`${userMessage ? userMessage + ' ' : ''}${text}`);
+                  setIsRecording(false);
+                }}
+                onRecordStart={() => setIsRecording(true)}
+              />
+            )}
             {showSubmitLabel ? (
               <MuiButton
                 {...editorButtonCommonProps}

--- a/apps/src/aiComponentLibrary/userMessageEditor/UserMessageEditor.tsx
+++ b/apps/src/aiComponentLibrary/userMessageEditor/UserMessageEditor.tsx
@@ -5,6 +5,8 @@ import React, {useState, useMemo, useEffect, useRef} from 'react';
 
 import {commonI18n} from '@cdo/apps/types/locale';
 
+import SpeechToTextButton from './speechToTextButton/SpeechToTextButton';
+
 import moduleStyles from './user-message-editor.module.scss';
 
 const MAX_MESSAGE_LENGTH = 10000;
@@ -48,6 +50,7 @@ const UserMessageEditor = React.forwardRef<
     // Track focus state on textarea to apply focus styles to container since
     // :focus-visible doesn't work on divs and :has() is not supported in Firefox.
     const [focused, setFocused] = useState(false);
+    const [isRecording, setIsRecording] = useState(false);
 
     const userMessageIsEmpty = useMemo(() => {
       return userMessage.trim() === '';
@@ -74,7 +77,7 @@ const UserMessageEditor = React.forwardRef<
       variant: 'contained' as const,
       color: 'primary' as const,
       size: 'extraSmall' as const,
-      disabled: disabled || !userMessage || userMessageIsEmpty,
+      disabled: disabled || !userMessage || userMessageIsEmpty || isRecording,
       id: 'uitest-chat-submit',
       onClick: (e: React.MouseEvent) => {
         e.stopPropagation();
@@ -112,7 +115,7 @@ const UserMessageEditor = React.forwardRef<
           }
           onChange={e => onChange(e.target.value)}
           value={userMessage}
-          disabled={disabled}
+          disabled={disabled || isRecording}
           onKeyDown={e => handleKeyPress(e, userMessage)}
           maxLength={MAX_MESSAGE_LENGTH}
           rows={1}
@@ -122,18 +125,27 @@ const UserMessageEditor = React.forwardRef<
         />
         <div className={moduleStyles.chatActionsContainer}>
           {children}
-          {showSubmitLabel ? (
-            <MuiButton
-              {...editorButtonCommonProps}
-              startIcon={<EditorButtonIcon />}
-            >
-              {commonI18n.submit()}
-            </MuiButton>
-          ) : (
-            <MuiIconButton {...editorButtonCommonProps}>
-              <EditorButtonIcon />
-            </MuiIconButton>
-          )}
+          <div className={moduleStyles.actionButtons}>
+            <SpeechToTextButton
+              onTranscribed={text => {
+                onChange(`${userMessage ? userMessage + ' ' : ''}${text}`);
+                setIsRecording(false);
+              }}
+              onRecordStart={() => setIsRecording(true)}
+            />
+            {showSubmitLabel ? (
+              <MuiButton
+                {...editorButtonCommonProps}
+                startIcon={<EditorButtonIcon />}
+              >
+                {commonI18n.submit()}
+              </MuiButton>
+            ) : (
+              <MuiIconButton {...editorButtonCommonProps}>
+                <EditorButtonIcon />
+              </MuiIconButton>
+            )}
+          </div>
         </div>
       </div>
     );

--- a/apps/src/aiComponentLibrary/userMessageEditor/speechToTextButton/SpeechToTextButton.tsx
+++ b/apps/src/aiComponentLibrary/userMessageEditor/speechToTextButton/SpeechToTextButton.tsx
@@ -36,9 +36,7 @@ const SpeechToTextButton: React.FC<SpeechToTextButtonProps> = ({
         onRecordStart?.();
       } else {
         setErrorMessage(
-          startState === 'Unsupported'
-            ? 'Audio recording is not supported on your device.'
-            : startState === 'PermissionDenied'
+          startState === 'PermissionDenied'
             ? 'Permission to access the microphone was denied.'
             : unknownErrorMessage
         );
@@ -70,9 +68,7 @@ const SpeechToTextButton: React.FC<SpeechToTextButtonProps> = ({
     ? {iconName: 'spinner-third', iconFamily: 'duotone', animationType: 'spin'}
     : {iconName: 'microphone'};
 
-  if (!recorderRef.current?.canRecord()) {
-    return null;
-  }
+  const canRecord = recorderRef.current?.canRecord();
 
   return (
     <div className={styles.row}>
@@ -103,16 +99,30 @@ const SpeechToTextButton: React.FC<SpeechToTextButtonProps> = ({
       )}
       <div className={styles.buttonContainer}>
         {isRecording && <div className={styles.ping} />}
-        <MuiIconButton
-          variant="outlined"
-          size="extraSmall"
-          onClick={isRecording ? onEndRecording : onStartRecording}
-          disabled={isTranscribing}
-          color={isRecording ? 'white' : 'secondary'}
-          className={classNames(isRecording && styles.recording)}
+        <WithTooltip
+          tooltipProps={{
+            size: 'xs',
+            tooltipId: 'error-tooltip',
+            text: !canRecord
+              ? 'Audio recording is not supported on your device.'
+              : undefined,
+            direction: 'onLeft',
+            className: classNames(canRecord && styles.hide),
+          }}
         >
-          <FontAwesomeV6Icon {...iconProps} />
-        </MuiIconButton>
+          <div>
+            <MuiIconButton
+              variant="outlined"
+              size="extraSmall"
+              onClick={isRecording ? onEndRecording : onStartRecording}
+              disabled={!canRecord || isTranscribing}
+              color={isRecording ? 'white' : 'secondary'}
+              className={classNames(isRecording && styles.recording)}
+            >
+              <FontAwesomeV6Icon {...iconProps} />
+            </MuiIconButton>
+          </div>
+        </WithTooltip>
       </div>
     </div>
   );

--- a/apps/src/aiComponentLibrary/userMessageEditor/speechToTextButton/SpeechToTextButton.tsx
+++ b/apps/src/aiComponentLibrary/userMessageEditor/speechToTextButton/SpeechToTextButton.tsx
@@ -1,0 +1,118 @@
+import FontAwesomeV6Icon, {
+  FontAwesomeV6IconProps,
+} from '@code-dot-org/component-library/fontAwesomeV6Icon';
+import {WithTooltip} from '@code-dot-org/component-library/tooltip';
+import {IconButton as MuiIconButton} from '@mui/material';
+import classNames from 'classnames';
+import React, {useRef, useState} from 'react';
+
+import {getClientApi} from '@cdo/apps/aichat/api/client';
+import {AudioRecorder} from '@cdo/apps/util/AudioRecorder';
+
+import styles from './styles.module.scss';
+
+const unknownErrorMessage = 'An unknown error occurred.';
+
+interface SpeechToTextButtonProps {
+  onTranscribed: (text: string) => void;
+  onRecordStart?: () => void;
+}
+
+const SpeechToTextButton: React.FC<SpeechToTextButtonProps> = ({
+  onTranscribed,
+  onRecordStart,
+}) => {
+  const [isRecording, setIsRecording] = useState(false);
+  const [isTranscribing, setIsTranscribing] = useState(false);
+  const [errorMessage, setErrorMessage] = useState<string>();
+  const recorderRef = useRef<AudioRecorder>(new AudioRecorder());
+
+  const onStartRecording = async () => {
+    try {
+      setErrorMessage(undefined);
+      const startState = await recorderRef.current.start();
+      if (startState === 'Started') {
+        setIsRecording(true);
+        onRecordStart?.();
+      } else {
+        setErrorMessage(
+          startState === 'Unsupported'
+            ? 'Audio recording is not supported on your device.'
+            : startState === 'PermissionDenied'
+            ? 'Permission to access the microphone was denied.'
+            : unknownErrorMessage
+        );
+      }
+    } catch (error) {
+      console.error(error);
+      setErrorMessage(unknownErrorMessage);
+    }
+  };
+
+  const onEndRecording = async () => {
+    setIsRecording(false);
+    setIsTranscribing(true);
+    try {
+      const audio = await recorderRef.current.stop();
+      const aichatClientApi = await getClientApi();
+      const text = await aichatClientApi.transcribeAudio(audio);
+      setIsTranscribing(false);
+      onTranscribed(text);
+    } catch (error) {
+      console.error(error);
+      setErrorMessage(unknownErrorMessage);
+    } finally {
+      setIsTranscribing(false);
+    }
+  };
+
+  const iconProps: FontAwesomeV6IconProps = isTranscribing
+    ? {iconName: 'spinner-third', iconFamily: 'duotone', animationType: 'spin'}
+    : {iconName: 'microphone'};
+
+  if (!recorderRef.current?.canRecord()) {
+    return null;
+  }
+
+  return (
+    <div className={styles.row}>
+      {errorMessage && (
+        <div className={styles.iconContainer}>
+          <WithTooltip
+            tooltipProps={{
+              size: 'xs',
+              tooltipId: 'error-tooltip',
+              text: errorMessage,
+              direction: 'onLeft',
+            }}
+          >
+            <FontAwesomeV6Icon
+              className={styles.error}
+              iconName="exclamation-circle"
+            />
+          </WithTooltip>
+        </div>
+      )}
+      {isRecording && !isTranscribing && (
+        <div className={styles.iconContainer}>
+          <FontAwesomeV6Icon iconName={'waveform-lines'} />
+        </div>
+      )}
+      <div className={styles.buttonContainer}>
+        {isRecording && <div className={styles.ping} />}
+        <MuiIconButton
+          variant="outlined"
+          size="extraSmall"
+          onClick={isRecording ? onEndRecording : onStartRecording}
+          disabled={isTranscribing}
+          color={isRecording ? 'white' : 'secondary'}
+          className={classNames(isRecording && styles.recording)}
+        >
+          <FontAwesomeV6Icon {...iconProps} />
+        </MuiIconButton>
+      </div>
+    </div>
+  );
+};
+
+export default SpeechToTextButton;

--- a/apps/src/aiComponentLibrary/userMessageEditor/speechToTextButton/SpeechToTextButton.tsx
+++ b/apps/src/aiComponentLibrary/userMessageEditor/speechToTextButton/SpeechToTextButton.tsx
@@ -95,7 +95,10 @@ const SpeechToTextButton: React.FC<SpeechToTextButtonProps> = ({
       )}
       {isRecording && !isTranscribing && (
         <div className={styles.iconContainer}>
-          <FontAwesomeV6Icon iconName={'waveform-lines'} />
+          <FontAwesomeV6Icon
+            className={styles.waveform}
+            iconName={'waveform-lines'}
+          />
         </div>
       )}
       <div className={styles.buttonContainer}>

--- a/apps/src/aiComponentLibrary/userMessageEditor/speechToTextButton/styles.module.scss
+++ b/apps/src/aiComponentLibrary/userMessageEditor/speechToTextButton/styles.module.scss
@@ -8,6 +8,10 @@
     &.error {
       color: var(--text-error-primary);
     }
+
+    &.waveform {
+      color: var(--text-info-primary);
+    }
   }
 }
 

--- a/apps/src/aiComponentLibrary/userMessageEditor/speechToTextButton/styles.module.scss
+++ b/apps/src/aiComponentLibrary/userMessageEditor/speechToTextButton/styles.module.scss
@@ -1,0 +1,54 @@
+.row {
+  display: flex;
+  gap: 0.5rem;
+
+  .iconContainer i {
+    font-size: 16px;
+
+    &.error {
+      color: var(--text-error-primary);
+    }
+  }
+}
+
+.buttonContainer {
+  position: relative;
+  display: flex;
+}
+
+@keyframes ping {
+  0% {
+    opacity: 100%;
+    transform: scale(1);
+    box-shadow: inset 0 0 5px var(--background-info-primary);
+  }
+  100% {
+    opacity: 0;
+    transform: scale(1.4);
+    box-shadow: inset 0 0 0 var(--background-info-primary);
+  }
+}
+
+.iconContainer {
+  display: flex;
+  align-items: center;
+}
+
+.ping {
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  border-radius: 0.25rem;
+  border: 1px solid var(--background-info-primary);
+  box-sizing: border-box;
+  animation: ping 1.25s infinite;
+}
+
+button.recording.recording {
+  background-color: var(--background-info-primary);
+  border: 1px solid var(--background-info-primary);
+  &:hover {
+    background-color: var(--background-info-strong);
+    border: 1px solid var(--background-info-strong);
+  }
+}

--- a/apps/src/aiComponentLibrary/userMessageEditor/speechToTextButton/styles.module.scss
+++ b/apps/src/aiComponentLibrary/userMessageEditor/speechToTextButton/styles.module.scss
@@ -56,3 +56,7 @@ button.recording.recording {
     border: 1px solid var(--background-info-strong);
   }
 }
+
+.hide {
+  display: none;
+}

--- a/apps/src/aiComponentLibrary/userMessageEditor/user-message-editor.module.scss
+++ b/apps/src/aiComponentLibrary/userMessageEditor/user-message-editor.module.scss
@@ -49,3 +49,8 @@
     }
   }
 }
+
+.actionButtons {
+  display: flex;
+  gap: 0.5rem;
+}

--- a/apps/src/aiGateway/index.ts
+++ b/apps/src/aiGateway/index.ts
@@ -4,14 +4,9 @@ import {
 } from 'ai';
 
 import {generateText as generateTextThroughGateway} from '@cdo/apps/aiGateway/aiSdkCompatibleGateway';
-import {queryParams} from '@cdo/apps/code-studio/utils';
-import DCDO from '@cdo/apps/dcdo';
 
+import {isAiGatewayEnabled} from './isAiGatewayEnabled';
 import transcribeThroughGateway from './transcribeThroughGateway';
-
-const isAiGatewayEnabled =
-  DCDO.get('ai-gateway-enabled', true) ||
-  queryParams('use-ai-gateway') === 'true';
 
 const generateText = isAiGatewayEnabled
   ? generateTextThroughGateway
@@ -21,4 +16,4 @@ const transcribe = isAiGatewayEnabled
   ? transcribeThroughGateway
   : transcribeThroughProxy;
 
-export {isAiGatewayEnabled, generateText, transcribe};
+export {generateText, transcribe};

--- a/apps/src/aiGateway/isAiGatewayEnabled.ts
+++ b/apps/src/aiGateway/isAiGatewayEnabled.ts
@@ -1,0 +1,6 @@
+import {queryParams} from '@cdo/apps/code-studio/utils';
+import DCDO from '@cdo/apps/dcdo';
+
+export const isAiGatewayEnabled =
+  DCDO.get('ai-gateway-enabled', true) ||
+  queryParams('use-ai-gateway') === 'true';

--- a/apps/src/aichat/api/performClientApiChatCompletion.ts
+++ b/apps/src/aichat/api/performClientApiChatCompletion.ts
@@ -1,5 +1,5 @@
 import {Role} from '@cdo/apps/aiComponentLibrary/chatMessage/types';
-import {isAiGatewayEnabled} from '@cdo/apps/aiGateway';
+import {isAiGatewayEnabled} from '@cdo/apps/aiGateway/isAiGatewayEnabled';
 import {ValueOf} from '@cdo/apps/types/utils';
 import {
   AiChatModelIds,

--- a/apps/src/aichat/api/performClientApiChatCompletion.ts
+++ b/apps/src/aichat/api/performClientApiChatCompletion.ts
@@ -1,5 +1,8 @@
 import {Role} from '@cdo/apps/aiComponentLibrary/chatMessage/types';
+import {isAiGatewayEnabled} from '@cdo/apps/aiGateway';
+import {ValueOf} from '@cdo/apps/types/utils';
 import {
+  AiChatModelIds,
   AiInteractionStatus,
   AiRequestExecutionStatus,
 } from '@cdo/generated-scripts/sharedConstants';
@@ -17,6 +20,12 @@ import {
   createAichatRequest,
   updateAichatRequest,
 } from './client/helpers/aichatRequestHelpers';
+
+export function canUseClientApi(modelId: ValueOf<typeof AiChatModelIds>) {
+  return (
+    isAiGatewayEnabled && modelId === AiChatModelIds.GEMINI_2_5_FLASH_IMAGE
+  );
+}
 
 /**
  * Performs client-side chat completion submission flow, which involves creating a new AichatRequest record,

--- a/apps/src/aichat/api/performClientApiChatCompletion.ts
+++ b/apps/src/aichat/api/performClientApiChatCompletion.ts
@@ -1,8 +1,5 @@
 import {Role} from '@cdo/apps/aiComponentLibrary/chatMessage/types';
-import {isAiGatewayEnabled} from '@cdo/apps/aiGateway/isAiGatewayEnabled';
-import {ValueOf} from '@cdo/apps/types/utils';
 import {
-  AiChatModelIds,
   AiInteractionStatus,
   AiRequestExecutionStatus,
 } from '@cdo/generated-scripts/sharedConstants';
@@ -20,12 +17,6 @@ import {
   createAichatRequest,
   updateAichatRequest,
 } from './client/helpers/aichatRequestHelpers';
-
-export function canUseClientApi(modelId: ValueOf<typeof AiChatModelIds>) {
-  return (
-    isAiGatewayEnabled && modelId === AiChatModelIds.GEMINI_2_5_FLASH_IMAGE
-  );
-}
 
 /**
  * Performs client-side chat completion submission flow, which involves creating a new AichatRequest record,

--- a/apps/src/aichat/api/supportsClientApi.ts
+++ b/apps/src/aichat/api/supportsClientApi.ts
@@ -1,0 +1,9 @@
+import {ValueOf} from '@cdo/apps/types/utils';
+import {AiChatModelIds} from '@cdo/generated-scripts/sharedConstants';
+
+type ModelId = ValueOf<typeof AiChatModelIds>;
+const supportedModels: ModelId[] = [AiChatModelIds.GEMINI_2_5_FLASH_IMAGE];
+
+export default function supportsClientApi(modelId: ModelId) {
+  return supportedModels.includes(modelId);
+}

--- a/apps/src/aichat/redux/thunks/submitChatContents.ts
+++ b/apps/src/aichat/redux/thunks/submitChatContents.ts
@@ -26,10 +26,8 @@ import {
 } from '@cdo/generated-scripts/sharedConstants';
 
 import {postAichatCompletionMessage} from '../../aichatApi';
-import {
-  canUseClientApi,
-  performClientApiChatCompletion,
-} from '../../api/performClientApiChatCompletion';
+import {performClientApiChatCompletion} from '../../api/performClientApiChatCompletion';
+import supportsClientApi from '../../api/supportsClientApi';
 import {logChatEvent} from '../../helpers/logChatEvent';
 import {formatUserAddedSelectionContextForPrompt} from '../../helpers/userAddedSelectionContextFormatter';
 import {
@@ -174,7 +172,7 @@ export const submitChatContents = createAsyncThunk(
         sendAnalytics(EVENTS.SUBMIT_AICHAT_REQUEST_INITIATED, eventData)
       );
 
-      if (canUseClientApi(modelParameters.selectedModelId)) {
+      if (supportsClientApi(modelParameters.selectedModelId)) {
         const levelProperties = state.lab.levelProperties;
         const levelName = levelProperties?.name;
         const levelSystemPrompt =

--- a/apps/src/aichat/redux/thunks/submitChatContents.ts
+++ b/apps/src/aichat/redux/thunks/submitChatContents.ts
@@ -10,14 +10,12 @@ import {
 } from '@cdo/apps/aichat/redux/slice';
 import {getAssetUrl} from '@cdo/apps/aichat/utils';
 import {Role} from '@cdo/apps/aiComponentLibrary/chatMessage/types';
-import {isAiGatewayEnabled} from '@cdo/apps/aiGateway';
 import {sendProgressReport} from '@cdo/apps/code-studio/progressRedux';
 import {TestResults} from '@cdo/apps/constants';
 import Lab2Registry from '@cdo/apps/lab2/Lab2Registry';
 import {EVENTS} from '@cdo/apps/metrics/AnalyticsConstants';
 import {commonI18n} from '@cdo/apps/types/locale';
 import {RootState} from '@cdo/apps/types/redux';
-import {ValueOf} from '@cdo/apps/types/utils';
 import {NetworkError} from '@cdo/apps/util/HttpClient';
 import {AppDispatch} from '@cdo/apps/util/reduxHooks';
 import {createUuid} from '@cdo/apps/utils';
@@ -28,7 +26,10 @@ import {
 } from '@cdo/generated-scripts/sharedConstants';
 
 import {postAichatCompletionMessage} from '../../aichatApi';
-import {performClientApiChatCompletion} from '../../api/performClientApiChatCompletion';
+import {
+  canUseClientApi,
+  performClientApiChatCompletion,
+} from '../../api/performClientApiChatCompletion';
 import {logChatEvent} from '../../helpers/logChatEvent';
 import {formatUserAddedSelectionContextForPrompt} from '../../helpers/userAddedSelectionContextFormatter';
 import {
@@ -48,9 +49,6 @@ import {getNewRemoveId} from '../utils';
 import {addChatEvent} from './addChatEvent';
 import {notifyErrorUnauthorized} from './helpers/notifyErrorUnauthorized';
 import {sendAnalytics} from './sendAnalytics';
-
-const useClientApi = (modelId: ValueOf<typeof AiChatModelIds>) =>
-  isAiGatewayEnabled && modelId === AiChatModelIds.GEMINI_2_5_FLASH_IMAGE;
 
 // This thunk's callback function submits a user's chat content and AI customizations to
 // the chat completion endpoint, then waits for a chat completion response, and updates
@@ -176,7 +174,7 @@ export const submitChatContents = createAsyncThunk(
         sendAnalytics(EVENTS.SUBMIT_AICHAT_REQUEST_INITIATED, eventData)
       );
 
-      if (useClientApi(modelParameters.selectedModelId)) {
+      if (canUseClientApi(modelParameters.selectedModelId)) {
         const levelProperties = state.lab.levelProperties;
         const levelName = levelProperties?.name;
         const levelSystemPrompt =

--- a/apps/src/aichat/views/UserChatMessageEditor.tsx
+++ b/apps/src/aichat/views/UserChatMessageEditor.tsx
@@ -5,6 +5,7 @@ import UserMessageEditor from '@cdo/apps/aiComponentLibrary/userMessageEditor/Us
 import AiTutorEnglishOnlyWarning from '@cdo/apps/aiTutor/views/AiTutorEnglishOnlyWarning';
 import {useAppDispatch, useAppSelector} from '@cdo/apps/util/reduxHooks';
 
+import {canUseClientApi} from '../api/performClientApiChatCompletion';
 import {selectIsWaitingForChatResponse, submitChatContents} from '../redux';
 import {
   AiChatClientType,
@@ -136,6 +137,9 @@ const UserChatMessageEditor: React.FunctionComponent<
     }
   }, [disabled]);
 
+  // Speech to text is only enabled with the client API since it makes use of the AI Gateway.
+  const speechToTextEnabled = canUseClientApi(modelParameters.selectedModelId);
+
   return (
     <>
       {chatButtons && chatButtons.length > 0 && !chatDisabled && (
@@ -151,6 +155,7 @@ const UserChatMessageEditor: React.FunctionComponent<
         onSubmit={handleSubmit}
         disabled={disabled}
         editorContainerClassName={editorContainerClassName}
+        speechToTextEnabled={speechToTextEnabled}
         ref={inputRef}
       >
         {multimodalAvailable && buildAssetUrl && levelName && (

--- a/apps/src/aichat/views/UserChatMessageEditor.tsx
+++ b/apps/src/aichat/views/UserChatMessageEditor.tsx
@@ -3,9 +3,10 @@ import React, {useCallback, useEffect, useRef, useState} from 'react';
 import {useAiChatDisabled} from '@cdo/apps/aichat/context/aiChatDisabledContext';
 import UserMessageEditor from '@cdo/apps/aiComponentLibrary/userMessageEditor/UserMessageEditor';
 import AiTutorEnglishOnlyWarning from '@cdo/apps/aiTutor/views/AiTutorEnglishOnlyWarning';
+import experiments from '@cdo/apps/util/experiments';
 import {useAppDispatch, useAppSelector} from '@cdo/apps/util/reduxHooks';
 
-import {canUseClientApi} from '../api/performClientApiChatCompletion';
+import supportsClientApi from '../api/supportsClientApi';
 import {selectIsWaitingForChatResponse, submitChatContents} from '../redux';
 import {
   AiChatClientType,
@@ -137,8 +138,11 @@ const UserChatMessageEditor: React.FunctionComponent<
     }
   }, [disabled]);
 
-  // Speech to text is only enabled with the client API since it makes use of the AI Gateway.
-  const speechToTextEnabled = canUseClientApi(modelParameters.selectedModelId);
+  // Speech to text is only enabled if the client API is supported for the current model
+  // since it makes use of the AI Gateway.
+  const speechToTextEnabled =
+    supportsClientApi(modelParameters.selectedModelId) ||
+    experiments.isEnabledAllowingQueryString('enable-speech-to-text');
 
   return (
     <>

--- a/apps/src/code-studio/components/recorders.js
+++ b/apps/src/code-studio/components/recorders.js
@@ -69,6 +69,10 @@ export const RecordingFileType = {
   WAV: '.wav',
 };
 
+/**
+ * Recorder for MP3/WAV file recording.
+ * For native browser recording, use {@link AudioRecorder.ts}
+ */
 const getRecorder = extension => {
   if (extension === RecordingFileType.WAV) {
     return new WavRecorder();

--- a/apps/src/util/AudioRecorder.ts
+++ b/apps/src/util/AudioRecorder.ts
@@ -9,10 +9,6 @@ function getSupportedMimeType(mediaRecorderClass: typeof MediaRecorder) {
   );
 }
 
-export interface RecordingResult {
-  file: File;
-}
-
 enum StartState {
   Started = 'Started',
   Unsupported = 'Unsupported',
@@ -31,7 +27,9 @@ export class AudioRecorder {
   constructor(
     // For testing only
     private readonly getUserMedia = navigator?.mediaDevices?.getUserMedia,
-    private readonly MediaRecorderClass = MediaRecorder
+    private readonly MediaRecorderClass = typeof MediaRecorder !== 'undefined'
+      ? MediaRecorder
+      : undefined
   ) {}
 
   get isRecording(): boolean {
@@ -47,7 +45,7 @@ export class AudioRecorder {
   /**
    * Requests microphone access and starts recording.
    *
-   * @returns StartState corresponding to the outcome.
+   * @returns StartState corresponding to thåe outcome.
    */
   async start(): Promise<StartState> {
     if (!this.canRecord()) {
@@ -64,10 +62,10 @@ export class AudioRecorder {
       return StartState.UnknownError;
     }
 
-    const mimeType = getSupportedMimeType(this.MediaRecorderClass);
+    const mimeType = getSupportedMimeType(this.MediaRecorderClass!);
     this.chunks = [];
 
-    this.recorder = new this.MediaRecorderClass(this.stream, {mimeType});
+    this.recorder = new this.MediaRecorderClass!(this.stream, {mimeType});
     this.recorder.ondataavailable = e => {
       if (e.data.size > 0) {
         this.chunks.push(e.data);
@@ -77,7 +75,9 @@ export class AudioRecorder {
     return StartState.Started;
   }
 
-  /** Stops recording and returns the recorded data. */
+  /**
+   * Stops recording and returns the recorded data.
+   */
   async stop(): Promise<Blob> {
     if (!this.recorder) {
       throw new Error('AudioRecorder: call start() before stop()');

--- a/apps/src/util/AudioRecorder.ts
+++ b/apps/src/util/AudioRecorder.ts
@@ -26,7 +26,9 @@ export class AudioRecorder {
 
   constructor(
     // For testing only
-    private readonly getUserMedia = navigator?.mediaDevices?.getUserMedia,
+    private readonly getUserMedia = navigator?.mediaDevices?.getUserMedia.bind(
+      navigator?.mediaDevices
+    ),
     private readonly MediaRecorderClass = typeof MediaRecorder !== 'undefined'
       ? MediaRecorder
       : undefined
@@ -45,7 +47,7 @@ export class AudioRecorder {
   /**
    * Requests microphone access and starts recording.
    *
-   * @returns StartState corresponding to thåe outcome.
+   * @returns StartState corresponding to the outcome.
    */
   async start(): Promise<StartState> {
     if (!this.canRecord()) {

--- a/apps/src/util/AudioRecorder.ts
+++ b/apps/src/util/AudioRecorder.ts
@@ -1,0 +1,111 @@
+const PREFERRED_MIME_TYPES = [
+  'audio/webm', // Chrome, Edge, Firefox
+  'audio/mp4', // Safari 14.1+
+];
+
+function getSupportedMimeType(mediaRecorderClass: typeof MediaRecorder) {
+  return PREFERRED_MIME_TYPES.find(type =>
+    mediaRecorderClass.isTypeSupported(type)
+  );
+}
+
+export interface RecordingResult {
+  file: File;
+}
+
+enum StartState {
+  Started = 'Started',
+  Unsupported = 'Unsupported',
+  PermissionDenied = 'PermissionDenied',
+  UnknownError = 'UnknownError',
+}
+
+/**
+ * Browser native audio recorder.
+ */
+export class AudioRecorder {
+  private recorder: MediaRecorder | null = null;
+  private stream: MediaStream | null = null;
+  private chunks: Blob[] = [];
+
+  constructor(
+    // For testing only
+    private readonly getUserMedia = navigator?.mediaDevices?.getUserMedia,
+    private readonly MediaRecorderClass = MediaRecorder
+  ) {}
+
+  get isRecording(): boolean {
+    return this.recorder?.state === 'recording';
+  }
+
+  canRecord(): boolean {
+    return (
+      typeof this.MediaRecorderClass !== 'undefined' && !!this.getUserMedia
+    );
+  }
+
+  /**
+   * Requests microphone access and starts recording.
+   *
+   * @returns StartState corresponding to the outcome.
+   */
+  async start(): Promise<StartState> {
+    if (!this.canRecord()) {
+      return StartState.Unsupported;
+    }
+
+    try {
+      this.stream = await this.getUserMedia({audio: true});
+    } catch (e) {
+      if (e instanceof DOMException && e.name === 'NotAllowedError') {
+        return StartState.PermissionDenied;
+      }
+      console.error('Unexpected error while requesting microphone access', e);
+      return StartState.UnknownError;
+    }
+
+    const mimeType = getSupportedMimeType(this.MediaRecorderClass);
+    this.chunks = [];
+
+    this.recorder = new this.MediaRecorderClass(this.stream, {mimeType});
+    this.recorder.ondataavailable = e => {
+      if (e.data.size > 0) {
+        this.chunks.push(e.data);
+      }
+    };
+    this.recorder.start();
+    return StartState.Started;
+  }
+
+  /** Stops recording and returns the recorded data. */
+  async stop(): Promise<Blob> {
+    if (!this.recorder) {
+      throw new Error('AudioRecorder: call start() before stop()');
+    }
+
+    await new Promise<void>(resolve => {
+      this.recorder!.onstop = () => resolve();
+      this.recorder!.stop();
+    });
+
+    const blob = new Blob(this.chunks);
+    this.release();
+    return blob;
+  }
+
+  cancel(): void {
+    if (!this.recorder) {
+      return;
+    }
+    this.recorder.ondataavailable = null;
+    this.recorder.stop();
+    this.release();
+  }
+
+  private release(): void {
+    this.stream?.getTracks().forEach(t => t.stop());
+    this.stream = null;
+    this.recorder = null;
+    this.chunks = [];
+  }
+}

--- a/apps/test/unit/util/AudioRecorderTest.ts
+++ b/apps/test/unit/util/AudioRecorderTest.ts
@@ -1,0 +1,174 @@
+import {AudioRecorder} from '@cdo/apps/util/AudioRecorder';
+
+interface MockMediaRecorder {
+  ondataavailable: ((event: BlobEvent) => void) | null;
+  onstop: (() => void) | null;
+  start: jest.Mock;
+  stop: jest.Mock;
+  state: RecordingState;
+}
+
+const mimeType = 'audio/webm';
+
+describe('AudioRecorder', () => {
+  let mediaRecorder: MockMediaRecorder;
+  let MediaRecorderClass: typeof MediaRecorder;
+  let getUserMedia: jest.Mock;
+  let stream: MediaStream;
+  let track: MediaStreamTrack;
+  let audioRecorder: AudioRecorder;
+  let unsupportedRecorder: AudioRecorder;
+
+  beforeEach(() => {
+    track = {stop: jest.fn()} as unknown as MediaStreamTrack;
+    stream = {
+      getTracks: jest.fn(() => [track]),
+    } as unknown as MediaStream;
+
+    getUserMedia = jest.fn().mockResolvedValue(stream);
+
+    mediaRecorder = {
+      ondataavailable: null,
+      onstop: null,
+      start: jest.fn(),
+      stop: jest.fn().mockImplementation(() => {
+        mediaRecorder.onstop?.();
+        mediaRecorder.state = 'inactive';
+      }),
+      state: 'inactive',
+    };
+
+    MediaRecorderClass = jest.fn(
+      () => mediaRecorder
+    ) as unknown as typeof MediaRecorder;
+
+    MediaRecorderClass.isTypeSupported = jest.fn(
+      (type: string) => type === mimeType
+    );
+
+    audioRecorder = new AudioRecorder(getUserMedia, MediaRecorderClass);
+    unsupportedRecorder = new AudioRecorder(undefined, undefined);
+  });
+
+  describe('canRecord()', () => {
+    it('returns true when both getUserMedia and MediaRecorder are defined', () => {
+      expect(audioRecorder.canRecord()).toBe(true);
+    });
+
+    it('returns false when getUserMedia is not available', () => {
+      expect(unsupportedRecorder.canRecord()).toBe(false);
+    });
+  });
+
+  describe('isRecording', () => {
+    it('returns false before start() is called', () => {
+      expect(audioRecorder.isRecording).toBe(false);
+    });
+
+    it('returns true when the underlying recorder is in recording state', async () => {
+      await audioRecorder.start();
+      mediaRecorder.state = 'recording';
+      expect(audioRecorder.isRecording).toBe(true);
+    });
+
+    it('returns false when the underlying recorder is inactive', async () => {
+      await audioRecorder.start();
+      mediaRecorder.state = 'inactive';
+      expect(audioRecorder.isRecording).toBe(false);
+    });
+  });
+
+  describe('start()', () => {
+    it('returns "Started", initializes stream, and starts recorder on success', async () => {
+      const result = await audioRecorder.start();
+
+      expect(getUserMedia).toHaveBeenCalledWith({audio: true});
+      expect(MediaRecorderClass).toHaveBeenCalledWith(stream, {
+        mimeType,
+      });
+      expect(mediaRecorder.ondataavailable).toBeDefined();
+      expect(mediaRecorder.start).toHaveBeenCalled();
+      expect(result).toBe('Started');
+    });
+
+    it('returns "Unsupported" when canRecord() is false', async () => {
+      const result = await unsupportedRecorder.start();
+      expect(result).toBe('Unsupported');
+      expect(getUserMedia).not.toHaveBeenCalled();
+    });
+
+    it('returns "PermissionDenied" when getUserMedia throws NotAllowedError', async () => {
+      getUserMedia.mockRejectedValue(
+        new DOMException('Permission denied', 'NotAllowedError')
+      );
+      const result = await audioRecorder.start();
+      expect(result).toBe('PermissionDenied');
+    });
+
+    it('returns "UnknownError" when getUserMedia throws an unexpected error', async () => {
+      getUserMedia.mockRejectedValue(new Error('unknown'));
+      const result = await audioRecorder.start();
+      expect(result).toBe('UnknownError');
+    });
+
+    it('collects chunks from ondataavailable events', async () => {
+      await audioRecorder.start();
+      const blob1 = new Blob(['a']);
+      const blob2 = new Blob(['b']);
+      mediaRecorder.ondataavailable?.({data: blob1} as BlobEvent);
+      mediaRecorder.ondataavailable?.({data: blob2} as BlobEvent);
+      const result = await audioRecorder.stop();
+      expect(result.size).toBe(blob1.size + blob2.size);
+    });
+
+    it('ignores zero-size chunks in ondataavailable', async () => {
+      await audioRecorder.start();
+      mediaRecorder.ondataavailable?.({
+        data: new Blob([]),
+      } as BlobEvent);
+      const result = await audioRecorder.stop();
+      expect(result.size).toBe(0);
+    });
+  });
+
+  describe('stop()', () => {
+    it('throws when called before start()', async () => {
+      await expect(audioRecorder.stop()).rejects.toThrow();
+    });
+
+    it('resolves with a Blob after recording', async () => {
+      await audioRecorder.start();
+      const blob = new Blob(['a']);
+      mediaRecorder.ondataavailable?.({data: blob} as BlobEvent);
+
+      const result = await audioRecorder.stop();
+      expect(result).toBeInstanceOf(Blob);
+      expect(result.size).toBe(blob.size);
+    });
+
+    it('stops all media stream tracks', async () => {
+      await audioRecorder.start();
+      mediaRecorder.state = 'recording';
+
+      await audioRecorder.stop();
+      expect(track.stop).toHaveBeenCalled();
+      expect(audioRecorder.isRecording).toBe(false);
+    });
+  });
+
+  describe('cancel()', () => {
+    it('does nothing when called before start()', () => {
+      expect(() => audioRecorder.cancel()).not.toThrow();
+    });
+
+    it('stops the recorder and releases all resources', async () => {
+      await audioRecorder.start();
+      audioRecorder.cancel();
+
+      expect(mediaRecorder.stop).toHaveBeenCalled();
+      expect(mediaRecorder.ondataavailable).toBeNull();
+      expect(track.stop).toHaveBeenCalled();
+      expect(audioRecorder.isRecording).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
Adds the ability to dictate messages using speech to text in AI Chat, powered by OpenAI whisper-1 over our AI Gateway. As this uses our new AI Gateway technology which is still somewhat experimental, usage is limited to instances where users are already using the AI Gateway for image generation with the gemini 2.5 flash image model.


(Technically this UI demo fakes the recording since media recording is not available in insecure http contexts. During testing I used 127.0.0.1 which Chrome treats as a secure context, but icons don't load so the UI isn't accurate).

https://github.com/user-attachments/assets/1c3b7c13-8858-477d-addd-51666d3b746e

Error/Unsupported States
| Unsupported | Permission Denied | Unknown Error |
|----------|----------|----------|
| <img width="586" height="779" alt="Screenshot 2026-03-16 at 4 08 19 PM" src="https://github.com/user-attachments/assets/e34af9e1-a3d8-4352-8d45-60c5e48e04e0" /> | <img width="586" height="777" alt="Screenshot 2026-03-13 at 12 45 19 PM" src="https://github.com/user-attachments/assets/42c38266-efe5-44d4-86b8-98a5499552f6" />| <img width="582" height="776" alt="Screenshot 2026-03-13 at 12 46 54 PM" src="https://github.com/user-attachments/assets/4a6a9e88-d710-478c-b70b-54b765a236dd" /> |

## Links

https://codedotorg.atlassian.net/browse/SL-1578

## Testing story

Tested locally + unit test for AudioRecorder.