### PR TITLE
Grant Bedrock knowledge base access to Engineering_Contributor role

### DIFF
--- a/aws/cloudformation/iam.yml.erb
+++ b/aws/cloudformation/iam.yml.erb
@@ -320,6 +320,7 @@ roles = {
     ManagedPolicyArns: [
       '!Ref ContributorS3Policy',
       '!Ref ContributorSecretsPolicy',
+      '!Ref BedrockKnowledgeBaseInvocationPolicy',
       'arn:aws:iam::aws:policy/CloudFrontReadOnlyAccess'
     ]
   },


### PR DESCRIPTION
## Summary
- The AI Teaching Assistant (aidiff) feature calls `bedrock:RetrieveAndGenerate` on a knowledge base, but the `Engineering_Contributor` IAM role was missing the `BedrockKnowledgeBaseInvocationPolicy`, causing `AccessDeniedException` for contractors.
- Adds the existing `BedrockKnowledgeBaseInvocationPolicy` (which grants `bedrock:InvokeModel`, `bedrock:Retrieve`, and `bedrock:RetrieveAndGenerate` on knowledge base resources) to the `Engineering_Contributor` role, matching what `ProductManager_FullAccess` already has.

## Test plan
- [ ] Deploy IAM stack update and verify a user with the `Engineering_Contributor` role can use the AI Teaching Assistant without getting `AccessDeniedException`
- [ ] Verify no other IAM changes are introduced by the stack update

🤖 Generated with [Claude Code](https://claude.com/claude-code)