### PR TITLE
Fix dynamic FA icon usages (v4 → v7 manual review)

### DIFF
--- a/apps/src/javalab/PreviewPaneHeader.jsx
+++ b/apps/src/javalab/PreviewPaneHeader.jsx
@@ -54,7 +54,7 @@ export default function PreviewPaneHeader({
         {/* TODO: Uncomment fullscreen button when we are ready to implement fullscreen.
         <PaneButton
           headerHasFocus
-          iconClass={isFullscreen ? 'fa fa-compress' : 'fa fa-arrows-alt'}
+          iconClass={isFullscreen ? 'fa-solid fa-compress' : 'fa-solid fa-up-down-left-right'}
           onClick={() => {}}
           label=""
           isRtl={false}

--- a/apps/src/levelbuilder/reference-guide-editor/ReferenceGuideEditAll.jsx
+++ b/apps/src/levelbuilder/reference-guide-editor/ReferenceGuideEditAll.jsx
@@ -53,15 +53,16 @@ DeleteWarningDialog.propTypes = {
   deleteGuide: PropTypes.func,
 };
 
-const MiniIconButton = ({icon, alt, func, href}) => (
+const MiniIconButton = ({icon, iconStyle, alt, func, href}) => (
   <TextLink
     onClick={func}
     href={href}
-    icon={<FontAwesome icon={icon} title={alt} />}
+    icon={<FontAwesome icon={icon} iconStyle={iconStyle} title={alt} />}
   />
 );
 MiniIconButton.propTypes = {
   icon: FontAwesome.propTypes.icon,
+  iconStyle: PropTypes.string,
   alt: PropTypes.string,
   func: PropTypes.func,
   href: PropTypes.string,
@@ -197,7 +198,8 @@ export default function ReferenceGuideEditAll(props) {
           return [
             <div key={`${guide.key}-actions`} className="actions-box">
               <MiniIconButton
-                icon="pencil-square-o"
+                icon="pen-to-square"
+                iconStyle="regular"
                 alt="edit"
                 href={`${baseUrl}/${guide.key}/edit`}
               />

--- a/apps/src/templates/instructions/BackgroundMusicMuteButton.jsx
+++ b/apps/src/templates/instructions/BackgroundMusicMuteButton.jsx
@@ -65,7 +65,11 @@ function BackgroundMusicMuteButton({
     <PaneButton
       id={className}
       headerHasFocus={true}
-      iconClass={isBackgroundMusicMuted ? 'fa fa-volume-off' : 'fa fa-music'}
+      iconClass={
+        isBackgroundMusicMuted
+          ? 'fa-solid fa-volume-xmark'
+          : 'fa-solid fa-music'
+      }
       label={
         isBackgroundMusicMuted
           ? i18n.backgroundMusicOff()

--- a/apps/src/templates/lessonOverview/activities/LessonTip.jsx
+++ b/apps/src/templates/lessonOverview/activities/LessonTip.jsx
@@ -12,7 +12,8 @@ import styles from './lesson-tip.module.scss';
 export const tipTypes = {
   teachingTip: {
     displayName: i18n.teachingTip(),
-    icon: 'lightbulb-o',
+    icon: 'lightbulb',
+    iconStyle: 'regular',
     color: color.orange,
     backgroundColor: color.lightest_orange,
   },
@@ -81,6 +82,7 @@ class LessonTip extends Component {
         >
           <FontAwesome
             icon={tipTypes[this.props.tip.type].icon}
+            iconStyle={tipTypes[this.props.tip.type].iconStyle}
             className={styles.icon}
           />
           <span>{tipTypes[this.props.tip.type].displayName}</span>

--- a/apps/src/templates/progress/LessonGroup.jsx
+++ b/apps/src/templates/progress/LessonGroup.jsx
@@ -93,7 +93,7 @@ class LessonGroup extends React.Component {
           {hasLessonGroupInfo && (
             <span>
               <FontAwesome
-                icon="info-circle"
+                icon="circle-info"
                 style={styles.lessonGroupInfo}
                 onClick={this.openLessonGroupInfoDialog}
               />

--- a/apps/src/templates/progress/ProgressLegend.jsx
+++ b/apps/src/templates/progress/ProgressLegend.jsx
@@ -98,7 +98,7 @@ export default class ProgressLegend extends Component {
     const column1 = [
       <td key={_.uniqueId()} />,
       <td key={_.uniqueId()}>
-        {this.getLevelDetails('file-text', i18n.text())}
+        {this.getLevelDetails('file-lines', i18n.text())}
       </td>,
       <td key={_.uniqueId()}>
         {this.getLevelDetails('scissors', i18n.unplugged())}
@@ -107,9 +107,7 @@ export default class ProgressLegend extends Component {
     ];
     const column2 = [
       <td key={_.uniqueId()} />,
-      <td key={_.uniqueId()}>
-        {this.getLevelDetails('video-camera', i18n.video())}
-      </td>,
+      <td key={_.uniqueId()}>{this.getLevelDetails('video', i18n.video())}</td>,
       <td key={_.uniqueId()}>
         {this.getLevelDetails('desktop', i18n.online())}
         {this.getLevelDetails('check-circle', i18n.progressLegendAssessment())}


### PR DESCRIPTION
## Summary
- Fixes the 7 dynamic/conditional FA icon usages that were flagged for manual review by the codemod in #71307
- These were skipped by the automated codemod because they use ternaries, variable lookups, or config objects
- Each icon name has been updated from v4 → v7, with appropriate style (`regular`/`solid`) applied

### Changes by file:
- **BackgroundMusicMuteButton.jsx**: `fa fa-volume-off` → `fa-solid fa-volume-xmark`, `fa fa-music` → `fa-solid fa-music`
- **LessonGroup.jsx**: `info-circle` → `circle-info`
- **ReferenceGuideEditAll.jsx**: `pencil-square-o` → `pen-to-square` (regular style); also updated `MiniIconButton` to pass through `iconStyle` prop
- **ProgressLegend.jsx**: `file-text` → `file-lines`, `video-camera` → `video`
- **LessonTip.jsx**: `lightbulb-o` → `lightbulb` (regular style); passes `iconStyle` through to `FontAwesome`
- **PreviewPaneHeader.jsx**: `fa fa-arrows-alt` → `fa-solid fa-up-down-left-right` (in commented-out code)

## Test plan
- [x] All 4 relevant unit test suites pass (16 tests): LessonTipTest, ProgressLegendTest, BackgroundMusicMuteButtonTest, LessonGroupTest
- [x] Lint passes
- [ ] Visual verification in browser that icons render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)