### PR TITLE
Refactor moderateImage to work across all lab types

### DIFF
--- a/apps/src/aichat/api/client/generateChatResponse.ts
+++ b/apps/src/aichat/api/client/generateChatResponse.ts
@@ -94,8 +94,7 @@ export async function generateChatResponse(
       );
     } catch (error) {
       // Log and skip files with unsupported or unrecognized media types so the
-      // text response is still returned to the user. The error is surfaced in
-      // the console locally and tracked in production monitoring.
+      // text response is still returned to the user.
       Lab2Registry.getInstance()
         .getMetricsReporter()
         .logError('Skipping unsupported generated file type', error as Error);

--- a/apps/src/aichat/api/client/generateChatResponse.ts
+++ b/apps/src/aichat/api/client/generateChatResponse.ts
@@ -87,7 +87,7 @@ export async function generateChatResponse(
     const asset = await generatedFileToAsset(
       file,
       buildAssetUrl,
-      ALLOWED_IMAGE_FILE_EXTENSIONS
+      ALLOWED_IMAGE_FILE_EXTENSIONS // Currently only image files are supported.
     );
     assets.push(asset);
     if (file.mediaType.startsWith('image/')) {

--- a/apps/src/aichat/api/client/generateChatResponse.ts
+++ b/apps/src/aichat/api/client/generateChatResponse.ts
@@ -1,6 +1,6 @@
 import {type ModelMessage} from 'ai';
 
-import {ACCEPTED_IMAGE_MEDIA_TYPES} from '@cdo/apps/aichat/api/client/helpers/fileHelpers';
+import {ACCEPTED_IMAGE_MEDIA_TYPES} from '@cdo/apps/aichat/constants';
 import {generateText} from '@cdo/apps/aiGateway';
 import Lab2Registry from '@cdo/apps/lab2/Lab2Registry';
 import {sendLab2AnalyticsEvent} from '@cdo/apps/lab2/utils';

--- a/apps/src/aichat/api/client/generateChatResponse.ts
+++ b/apps/src/aichat/api/client/generateChatResponse.ts
@@ -20,6 +20,16 @@ import {
 import {getModel} from './helpers/modelHelpers';
 import {isTextSafe, isImageSafe} from './helpers/safetyHelpers';
 
+// Media types that the model is expected to generate.
+// https://docs.cloud.google.com/vertex-ai/generative-ai/docs/models/gemini/2-5-flash-image
+const GENERATED_FILE_ACCEPTED_MEDIA_TYPES = [
+  'image/jpeg',
+  'image/png',
+  'image/webp',
+  'image/heic',
+  'image/heif',
+];
+
 /**
  * Performs all the steps necessary to generate a chat response:
  * - Checks user input for safety
@@ -83,7 +93,11 @@ export async function generateChatResponse(
   // Upload generated assets, if any.
   const assets: ChatAsset[] = [];
   for (const file of files) {
-    const asset = await generatedFileToAsset(file, buildAssetUrl);
+    const asset = await generatedFileToAsset(
+      file,
+      buildAssetUrl,
+      GENERATED_FILE_ACCEPTED_MEDIA_TYPES
+    );
     assets.push(asset);
     if (file.mediaType.startsWith('image/')) {
       sendLab2AnalyticsEvent(EVENTS.MODEL_OUTPUT_IMAGE_CREATED);

--- a/apps/src/aichat/api/client/generateChatResponse.ts
+++ b/apps/src/aichat/api/client/generateChatResponse.ts
@@ -1,10 +1,10 @@
 import {type ModelMessage} from 'ai';
 
+import {ACCEPTED_IMAGE_MEDIA_TYPES} from '@cdo/apps/aichat/api/client/helpers/fileHelpers';
 import {generateText} from '@cdo/apps/aiGateway';
 import Lab2Registry from '@cdo/apps/lab2/Lab2Registry';
 import {sendLab2AnalyticsEvent} from '@cdo/apps/lab2/utils';
 import {EVENTS} from '@cdo/apps/metrics/AnalyticsConstants';
-import {ALLOWED_IMAGE_FILE_EXTENSIONS} from '@cdo/apps/util/moderateImage';
 import {AiRequestExecutionStatus} from '@cdo/generated-scripts/sharedConstants';
 
 import {
@@ -90,7 +90,7 @@ export async function generateChatResponse(
       asset = await generatedFileToAsset(
         file,
         buildAssetUrl,
-        ALLOWED_IMAGE_FILE_EXTENSIONS // Currently only image files are supported.
+        ACCEPTED_IMAGE_MEDIA_TYPES // Currently only image files are supported.
       );
     } catch (error) {
       // Log and skip files with unsupported or unrecognized media types so the

--- a/apps/src/aichat/api/client/generateChatResponse.ts
+++ b/apps/src/aichat/api/client/generateChatResponse.ts
@@ -1,6 +1,7 @@
 import {type ModelMessage} from 'ai';
 
 import {generateText} from '@cdo/apps/aiGateway';
+import Lab2Registry from '@cdo/apps/lab2/Lab2Registry';
 import {sendLab2AnalyticsEvent} from '@cdo/apps/lab2/utils';
 import {EVENTS} from '@cdo/apps/metrics/AnalyticsConstants';
 import {ALLOWED_IMAGE_FILE_EXTENSIONS} from '@cdo/apps/util/moderateImage';
@@ -84,11 +85,22 @@ export async function generateChatResponse(
   // Upload generated assets, if any.
   const assets: ChatAsset[] = [];
   for (const file of files) {
-    const asset = await generatedFileToAsset(
-      file,
-      buildAssetUrl,
-      ALLOWED_IMAGE_FILE_EXTENSIONS // Currently only image files are supported.
-    );
+    let asset: ChatAsset;
+    try {
+      asset = await generatedFileToAsset(
+        file,
+        buildAssetUrl,
+        ALLOWED_IMAGE_FILE_EXTENSIONS // Currently only image files are supported.
+      );
+    } catch (error) {
+      // Log and skip files with unsupported or unrecognized media types so the
+      // text response is still returned to the user. The error is surfaced in
+      // the console locally and tracked in production monitoring.
+      Lab2Registry.getInstance()
+        .getMetricsReporter()
+        .logError('Skipping unsupported generated file type', error as Error);
+      continue;
+    }
     assets.push(asset);
     if (file.mediaType.startsWith('image/')) {
       sendLab2AnalyticsEvent(EVENTS.MODEL_OUTPUT_IMAGE_CREATED);

--- a/apps/src/aichat/api/client/generateChatResponse.ts
+++ b/apps/src/aichat/api/client/generateChatResponse.ts
@@ -3,6 +3,7 @@ import {type ModelMessage} from 'ai';
 import {generateText} from '@cdo/apps/aiGateway';
 import {sendLab2AnalyticsEvent} from '@cdo/apps/lab2/utils';
 import {EVENTS} from '@cdo/apps/metrics/AnalyticsConstants';
+import {ALLOWED_IMAGE_FILE_EXTENSIONS} from '@cdo/apps/util/moderateImage';
 import {AiRequestExecutionStatus} from '@cdo/generated-scripts/sharedConstants';
 
 import {
@@ -19,16 +20,6 @@ import {
 } from './helpers/messageHelpers';
 import {getModel} from './helpers/modelHelpers';
 import {isTextSafe, isImageSafe} from './helpers/safetyHelpers';
-
-// Media types that the model is expected to generate.
-// https://docs.cloud.google.com/vertex-ai/generative-ai/docs/models/gemini/2-5-flash-image
-const GENERATED_FILE_ACCEPTED_MEDIA_TYPES = [
-  'image/jpeg',
-  'image/png',
-  'image/webp',
-  'image/heic',
-  'image/heif',
-];
 
 /**
  * Performs all the steps necessary to generate a chat response:
@@ -96,7 +87,7 @@ export async function generateChatResponse(
     const asset = await generatedFileToAsset(
       file,
       buildAssetUrl,
-      GENERATED_FILE_ACCEPTED_MEDIA_TYPES
+      ALLOWED_IMAGE_FILE_EXTENSIONS
     );
     assets.push(asset);
     if (file.mediaType.startsWith('image/')) {

--- a/apps/src/aichat/api/client/helpers/fileHelpers.ts
+++ b/apps/src/aichat/api/client/helpers/fileHelpers.ts
@@ -17,6 +17,13 @@ const mediaTypeToExtensionMap: Record<string, string> = {
   'application/pdf': 'pdf',
 };
 
+// Image types that safety moderation supports.
+export const ACCEPTED_IMAGE_MEDIA_TYPES = [
+  'image/jpeg',
+  'image/png',
+  'image/gif',
+];
+
 // Derived reverse map. `jpeg` is added as an alias since both `jpg` and
 // `jpeg` are valid extensions for `image/jpeg`.
 const extensionToMediaTypeMap: Record<string, string> = {

--- a/apps/src/aichat/api/client/helpers/fileHelpers.ts
+++ b/apps/src/aichat/api/client/helpers/fileHelpers.ts
@@ -17,13 +17,6 @@ const mediaTypeToExtensionMap: Record<string, string> = {
   'application/pdf': 'pdf',
 };
 
-// Image types that safety moderation supports.
-export const ACCEPTED_IMAGE_MEDIA_TYPES = [
-  'image/jpeg',
-  'image/png',
-  'image/gif',
-];
-
 // Derived reverse map. `jpeg` is added as an alias since both `jpg` and
 // `jpeg` are valid extensions for `image/jpeg`.
 const extensionToMediaTypeMap: Record<string, string> = {
@@ -40,7 +33,7 @@ const extensionToMediaTypeMap: Record<string, string> = {
  * @param accepts - The set of media types this call site expects. If mediaType
  *   is not in this list, an error is thrown.
  */
-export function convertMediaTypeToExtension(
+function convertMediaTypeToExtension(
   mediaType: string,
   accepts: string[]
 ): string {

--- a/apps/src/aichat/api/client/helpers/fileHelpers.ts
+++ b/apps/src/aichat/api/client/helpers/fileHelpers.ts
@@ -4,18 +4,58 @@ import {AssetSource, ChatAsset} from '@cdo/apps/aichat/types';
 import HttpClient from '@cdo/apps/util/HttpClient';
 import {createUuid} from '@cdo/apps/utils';
 
-const extensionMap: Record<string, string> = {
-  // Images
-  jpg: 'image/jpeg',
-  jpeg: 'image/jpeg',
-  png: 'image/png',
-  gif: 'image/gif',
-  webp: 'image/webp',
-  svg: 'image/svg+xml',
-  bmp: 'image/bmp',
-  // PDF
-  pdf: 'application/pdf',
+const mediaTypeToExtensionMap: Record<string, string> = {
+  'image/jpeg': 'jpg',
+  'image/png': 'png',
+  'image/gif': 'gif',
+  'image/webp': 'webp',
+  'image/svg+xml': 'svg',
+  'image/bmp': 'bmp',
+  'image/heic': 'heic',
+  'image/heif': 'heif',
+  'image/tiff': 'tiff',
+  'application/pdf': 'pdf',
 };
+
+// Derived reverse map. `jpeg` is added as an alias since both `jpg` and
+// `jpeg` are valid extensions for `image/jpeg`.
+const extensionToMediaType: Record<string, string> = {
+  ...Object.fromEntries(
+    Object.entries(mediaTypeToExtensionMap).map(([type, ext]) => [ext, type])
+  ),
+  jpeg: 'image/jpeg',
+};
+
+/**
+ * Converts a media type (MIME type) to a file extension.
+ *
+ * @param mediaType - The MIME type string, e.g. "image/png"
+ * @param accepts - The set of media types this call site expects. If mediaType
+ *   is not in this list, an error is thrown immediately so gaps in coverage are
+ *   caught in development rather than silently producing bad filenames.
+ * @throws If mediaType is not in accepts, or if there is no extension mapping
+ *   for it (which can happen for compound types like "image/svg+xml" if the
+ *   map is incomplete).
+ */
+export function convertMediaTypeToExtension(
+  mediaType: string,
+  accepts: string[]
+): string {
+  if (!accepts.includes(mediaType)) {
+    throw new Error(
+      `Unsupported media type: "${mediaType}". Expected one of: ${accepts.join(
+        ', '
+      )}`
+    );
+  }
+  const extension = mediaTypeToExtensionMap[mediaType];
+  if (!extension) {
+    throw new Error(
+      `No file extension mapping found for media type: "${mediaType}"`
+    );
+  }
+  return extension;
+}
 
 /**
  * Converts a ChatAsset to a FilePart by downloading the asset binary data.
@@ -32,7 +72,7 @@ export async function assetToFilePart(
 
   const mediaType =
     response.headers.get('content-type') ||
-    extensionMap[extension] ||
+    extensionToMediaType[extension] ||
     'application/octet-stream';
 
   return {
@@ -48,9 +88,10 @@ export async function assetToFilePart(
  */
 export async function generatedFileToAsset(
   file: GeneratedFile,
-  buildAssetUrl: (asset: ChatAsset) => string
+  buildAssetUrl: (asset: ChatAsset) => string,
+  accepts: string[]
 ): Promise<ChatAsset> {
-  const {filename, fileBuffer} = prepareGeneratedFile(file);
+  const {filename, fileBuffer} = prepareGeneratedFile(file, accepts);
   const asset: ChatAsset = {
     filename,
     source: AssetSource.PROJECT,
@@ -75,9 +116,12 @@ interface PreparedFile {
 /**
  * Extracts the buffer and derives filename/extension from a model-generated file.
  */
-export function prepareGeneratedFile(file: GeneratedFile): PreparedFile {
+export function prepareGeneratedFile(
+  file: GeneratedFile,
+  accepts: string[]
+): PreparedFile {
   const fileBuffer = file.uint8Array.slice();
-  const extension = file.mediaType.split('/')[1];
+  const extension = convertMediaTypeToExtension(file.mediaType, accepts);
   const filename = `generated-file-${createUuid()}.${extension}`;
   return {filename, fileBuffer, mediaType: file.mediaType, extension};
 }

--- a/apps/src/aichat/api/client/helpers/fileHelpers.ts
+++ b/apps/src/aichat/api/client/helpers/fileHelpers.ts
@@ -19,7 +19,7 @@ const mediaTypeToExtensionMap: Record<string, string> = {
 
 // Derived reverse map. `jpeg` is added as an alias since both `jpg` and
 // `jpeg` are valid extensions for `image/jpeg`.
-const extensionToMediaType: Record<string, string> = {
+const extensionToMediaTypeMap: Record<string, string> = {
   ...Object.fromEntries(
     Object.entries(mediaTypeToExtensionMap).map(([type, ext]) => [ext, type])
   ),
@@ -72,7 +72,7 @@ export async function assetToFilePart(
 
   const mediaType =
     response.headers.get('content-type') ||
-    extensionToMediaType[extension] ||
+    extensionToMediaTypeMap[extension] ||
     'application/octet-stream';
 
   return {

--- a/apps/src/aichat/api/client/helpers/fileHelpers.ts
+++ b/apps/src/aichat/api/client/helpers/fileHelpers.ts
@@ -31,11 +31,7 @@ const extensionToMediaTypeMap: Record<string, string> = {
  *
  * @param mediaType - The MIME type string, e.g. "image/png"
  * @param accepts - The set of media types this call site expects. If mediaType
- *   is not in this list, an error is thrown immediately so gaps in coverage are
- *   caught in development rather than silently producing bad filenames.
- * @throws If mediaType is not in accepts, or if there is no extension mapping
- *   for it (which can happen for compound types like "image/svg+xml" if the
- *   map is incomplete).
+ *   is not in this list, an error is thrown.
  */
 export function convertMediaTypeToExtension(
   mediaType: string,

--- a/apps/src/aichat/api/client/helpers/safetyHelpers.ts
+++ b/apps/src/aichat/api/client/helpers/safetyHelpers.ts
@@ -8,6 +8,12 @@ import {ValueOf} from '@cdo/apps/types/utils';
 import {AiChatModelIds} from '@cdo/generated-scripts/sharedConstants';
 
 import {prepareGeneratedFile} from './fileHelpers';
+// Image types that safety moderation supports.
+const IMAGE_SAFETY_ACCEPTED_MEDIA_TYPES = [
+  'image/jpeg',
+  'image/png',
+  'image/gif',
+];
 import {getModel} from './modelHelpers';
 
 const outputSchema = Output.object({
@@ -55,8 +61,10 @@ export async function isTextSafe(
 }
 
 export async function isImageSafe(file: GeneratedFile): Promise<boolean> {
-  const {filename, fileBuffer, mediaType, extension} =
-    prepareGeneratedFile(file);
+  const {filename, fileBuffer, mediaType, extension} = prepareGeneratedFile(
+    file,
+    IMAGE_SAFETY_ACCEPTED_MEDIA_TYPES
+  );
   const image = new File([fileBuffer], filename, {type: mediaType});
   const moderationStatus = await moderateImage(image, extension, 'aichat', {
     moderateEvent: EVENTS.MODERATE_MODEL_OUTPUT_IMAGE_AZURE,

--- a/apps/src/aichat/api/client/helpers/safetyHelpers.ts
+++ b/apps/src/aichat/api/client/helpers/safetyHelpers.ts
@@ -1,13 +1,14 @@
 import {type GeneratedFile, Output} from 'ai';
 import z from 'zod/v3';
 
+import {ACCEPTED_IMAGE_MEDIA_TYPES} from '@cdo/apps/aichat/constants';
 import {generateText} from '@cdo/apps/aiGateway';
 import {EVENTS} from '@cdo/apps/metrics/AnalyticsConstants';
 import {ValueOf} from '@cdo/apps/types/utils';
 import {moderateImage} from '@cdo/apps/util/moderateImage';
 import {AiChatModelIds} from '@cdo/generated-scripts/sharedConstants';
 
-import {prepareGeneratedFile, ACCEPTED_IMAGE_MEDIA_TYPES} from './fileHelpers';
+import {prepareGeneratedFile} from './fileHelpers';
 import {getModel} from './modelHelpers';
 
 const outputSchema = Output.object({

--- a/apps/src/aichat/api/client/helpers/safetyHelpers.ts
+++ b/apps/src/aichat/api/client/helpers/safetyHelpers.ts
@@ -7,13 +7,7 @@ import {ValueOf} from '@cdo/apps/types/utils';
 import {moderateImage} from '@cdo/apps/util/moderateImage';
 import {AiChatModelIds} from '@cdo/generated-scripts/sharedConstants';
 
-import {prepareGeneratedFile} from './fileHelpers';
-// Image types that safety moderation supports.
-const IMAGE_SAFETY_ACCEPTED_MEDIA_TYPES = [
-  'image/jpeg',
-  'image/png',
-  'image/gif',
-];
+import {prepareGeneratedFile, ACCEPTED_IMAGE_MEDIA_TYPES} from './fileHelpers';
 import {getModel} from './modelHelpers';
 
 const outputSchema = Output.object({
@@ -63,7 +57,7 @@ export async function isTextSafe(
 export async function isImageSafe(file: GeneratedFile): Promise<boolean> {
   const {filename, fileBuffer, mediaType, extension} = prepareGeneratedFile(
     file,
-    IMAGE_SAFETY_ACCEPTED_MEDIA_TYPES
+    ACCEPTED_IMAGE_MEDIA_TYPES
   );
   const image = new File([fileBuffer], filename, {type: mediaType});
   const moderationStatus = await moderateImage(image, extension, 'aichat', {

--- a/apps/src/aichat/api/client/helpers/safetyHelpers.ts
+++ b/apps/src/aichat/api/client/helpers/safetyHelpers.ts
@@ -2,9 +2,9 @@ import {type GeneratedFile, Output} from 'ai';
 import z from 'zod/v3';
 
 import {generateText} from '@cdo/apps/aiGateway';
-import {moderateImage} from '@cdo/apps/lab2/utils';
 import {EVENTS} from '@cdo/apps/metrics/AnalyticsConstants';
 import {ValueOf} from '@cdo/apps/types/utils';
+import {moderateImage} from '@cdo/apps/util/moderateImage';
 import {AiChatModelIds} from '@cdo/generated-scripts/sharedConstants';
 
 import {prepareGeneratedFile} from './fileHelpers';

--- a/apps/src/aichat/constants.ts
+++ b/apps/src/aichat/constants.ts
@@ -51,3 +51,10 @@ export const AI_SETTINGS_SUPPORT_LINK =
 
 export const TEACHER_DISABLED_AI_CHAT_MESSAGE =
   'Your teacher has not enabled this tool.';
+
+// Image types that assets bucket and safety moderation support.
+export const ACCEPTED_IMAGE_MEDIA_TYPES = [
+  'image/jpeg',
+  'image/png',
+  'image/gif',
+];

--- a/apps/src/lab2/hooks/useFileUploader.tsx
+++ b/apps/src/lab2/hooks/useFileUploader.tsx
@@ -1,8 +1,8 @@
 import React, {useCallback, useMemo, useRef, useState} from 'react';
 
 import codebridgeI18n from '@cdo/apps/codebridge/locale';
-import {moderateImage} from '@cdo/apps/lab2/utils';
 import UploadsDisabledModal from '@cdo/apps/sharedComponents/UploadsDisabledModal';
+import {moderateImage} from '@cdo/apps/util/moderateImage';
 
 export const enum analyticsEvents {
   UPLOAD_FAILED = 'UPLOAD_FAILED',

--- a/apps/src/lab2/utils/index.ts
+++ b/apps/src/lab2/utils/index.ts
@@ -7,4 +7,3 @@ export * from './fetchPermissions';
 export * from './getLabViewPageAction';
 export * from './getIsLabViewBlocked';
 export * from './convertProjectTypeToDisplayName';
-export * from './moderateImage';

--- a/apps/src/lab2/utils/moderateImage.ts
+++ b/apps/src/lab2/utils/moderateImage.ts
@@ -37,7 +37,11 @@ export const moderateImage = async (
   }
   const dimensions = [{name: 'UploaderType', value: uploaderType}];
   MetricsReporter.incrementCounter('ModerateCustomImage.Attempt', dimensions);
-  analyticsReporter.sendEvent(moderateEvent, {UploaderType: uploaderType});
+  analyticsReporter.sendEvent(moderateEvent, {
+    UploaderType: uploaderType,
+    appName,
+    levelPath: window.location.pathname,
+  });
   try {
     const response = await HttpClient.post(`/v3/images/moderate`, file, true, {
       'Content-Type': file.type || 'application/octet-stream',
@@ -48,7 +52,11 @@ export const moderateImage = async (
       return 'ok';
     }
     MetricsReporter.incrementCounter('ModerateCustomImage.Flagged', dimensions);
-    analyticsReporter.sendEvent(flaggedEvent, {UploaderType: uploaderType});
+    analyticsReporter.sendEvent(flaggedEvent, {
+      UploaderType: uploaderType,
+      appName,
+      levelPath: window.location.pathname,
+    });
     return 'flagged';
   } catch (error) {
     MetricsReporter.logError('Error with image moderation: ' + error);

--- a/apps/src/lab2/utils/moderateImage.ts
+++ b/apps/src/lab2/utils/moderateImage.ts
@@ -13,11 +13,62 @@ const LABS_WITH_IMAGE_MODERATION = [
 
 const ALLOWED_IMAGE_FILE_EXTENSIONS = ['jpg', 'jpeg', 'png', 'gif'];
 
+// Azure Content Moderator requires both dimensions to be at least this size.
+const MIN_MODERATION_DIMENSION = 128;
+
 interface AnalyticsData {
   uploaderType?: 'Lab2FileUploader' | 'AnimationPicker' | 'n/a';
   moderateEvent?: string;
   flaggedEvent?: string;
 }
+
+/**
+ * Returns a scaled-up PNG copy of the file if either dimension is below
+ * MIN_MODERATION_DIMENSION, otherwise returns the original file unchanged.
+ * The copy is only used for the moderation API call — callers still upload
+ * the original file.
+ */
+const scaleFileForModeration = (file: File): Promise<File> => {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => {
+      const img = new Image();
+      img.onload = () => {
+        const {width, height} = img;
+        if (
+          width >= MIN_MODERATION_DIMENSION &&
+          height >= MIN_MODERATION_DIMENSION
+        ) {
+          resolve(file);
+          return;
+        }
+        const scale = Math.max(
+          MIN_MODERATION_DIMENSION / width,
+          MIN_MODERATION_DIMENSION / height
+        );
+        const canvas = document.createElement('canvas');
+        canvas.width = Math.ceil(width * scale);
+        canvas.height = Math.ceil(height * scale);
+        canvas
+          .getContext('2d')!
+          .drawImage(img, 0, 0, canvas.width, canvas.height);
+        canvas.toBlob(blob => {
+          if (!blob) {
+            reject(new Error('Canvas toBlob returned null'));
+            return;
+          }
+          resolve(
+            new File([blob], 'moderation-scaled.png', {type: 'image/png'})
+          );
+        }, 'image/png');
+      };
+      img.onerror = reject;
+      img.src = reader.result as string;
+    };
+    reader.onerror = reject;
+    reader.readAsDataURL(file);
+  });
+};
 
 export const moderateImage = async (
   file: File,
@@ -43,9 +94,13 @@ export const moderateImage = async (
     levelPath: window.location.pathname,
   });
   try {
-    const response = await HttpClient.post(`/v3/images/moderate`, file, true, {
-      'Content-Type': file.type || 'application/octet-stream',
-    });
+    const fileToModerate = await scaleFileForModeration(file);
+    const response = await HttpClient.post(
+      `/v3/images/moderate`,
+      fileToModerate,
+      true,
+      {'Content-Type': fileToModerate.type || 'application/octet-stream'}
+    );
     const json = await response.json();
     MetricsReporter.incrementCounter('ModerateCustomImage.Success', dimensions);
     if (json?.rating === 'everyone' || json?.rating === 'unknown') {

--- a/apps/src/lab2/utils/moderateImage.ts
+++ b/apps/src/lab2/utils/moderateImage.ts
@@ -1,13 +1,20 @@
-import Lab2Registry from '@cdo/apps/lab2/Lab2Registry';
-import {sendLab2AnalyticsEvent} from '@cdo/apps/lab2/utils/analyticsReporterHelper';
 import {EVENTS} from '@cdo/apps/metrics/AnalyticsConstants';
+import analyticsReporter from '@cdo/apps/metrics/AnalyticsReporter';
+import MetricsReporter from '@cdo/apps/metrics/MetricsReporter';
 import HttpClient from '@cdo/apps/util/HttpClient';
-import {WEBLAB2_IMAGE_FILE_TYPES} from '@cdo/apps/weblab2/constants';
 
-const LAB2_LABS_MODERATE_IMAGES = ['weblab2', 'aichat'];
+const LABS_WITH_IMAGE_MODERATION = [
+  'weblab2',
+  'aichat',
+  'gamelab',
+  'spritelab',
+  'poetry',
+];
+
+const ALLOWED_IMAGE_FILE_EXTENSIONS = ['jpg', 'jpeg', 'png', 'gif'];
 
 interface AnalyticsData {
-  uploaderType?: 'Lab2FileUploader' | 'n/a';
+  uploaderType?: 'Lab2FileUploader' | 'AnimationPicker' | 'n/a';
   moderateEvent?: string;
   flaggedEvent?: string;
 }
@@ -23,30 +30,29 @@ export const moderateImage = async (
   }: AnalyticsData
 ): Promise<'ok' | 'flagged' | 'skipped'> => {
   if (
-    !LAB2_LABS_MODERATE_IMAGES.includes(appName ?? '') ||
-    !WEBLAB2_IMAGE_FILE_TYPES.includes(ext)
+    !LABS_WITH_IMAGE_MODERATION.includes(appName ?? '') ||
+    !ALLOWED_IMAGE_FILE_EXTENSIONS.includes(ext)
   ) {
     return 'skipped';
   }
-  const metricsReporter = Lab2Registry.getInstance().getMetricsReporter();
   const dimensions = [{name: 'UploaderType', value: uploaderType}];
-  metricsReporter.incrementCounter('ModerateCustomImage.Attempt', dimensions);
-  sendLab2AnalyticsEvent(moderateEvent, {UploaderType: uploaderType});
+  MetricsReporter.incrementCounter('ModerateCustomImage.Attempt', dimensions);
+  analyticsReporter.sendEvent(moderateEvent, {UploaderType: uploaderType});
   try {
     const response = await HttpClient.post(`/v3/images/moderate`, file, true, {
       'Content-Type': file.type || 'application/octet-stream',
     });
     const json = await response.json();
-    metricsReporter.incrementCounter('ModerateCustomImage.Success', dimensions);
+    MetricsReporter.incrementCounter('ModerateCustomImage.Success', dimensions);
     if (json?.rating === 'everyone' || json?.rating === 'unknown') {
       return 'ok';
     }
-    metricsReporter.incrementCounter('ModerateCustomImage.Flagged', dimensions);
-    sendLab2AnalyticsEvent(flaggedEvent, {UploaderType: uploaderType});
+    MetricsReporter.incrementCounter('ModerateCustomImage.Flagged', dimensions);
+    analyticsReporter.sendEvent(flaggedEvent, {UploaderType: uploaderType});
     return 'flagged';
   } catch (error) {
-    metricsReporter.logError('Error with image moderation: ' + error);
-    metricsReporter.incrementCounter('ModerateCustomImage.Error', dimensions);
+    MetricsReporter.logError('Error with image moderation: ' + error);
+    MetricsReporter.incrementCounter('ModerateCustomImage.Error', dimensions);
     return 'skipped';
   }
 };

--- a/apps/src/lab2/views/components/Instructions/ResourcePanel/Backpack/saveToBackpackHelper.tsx
+++ b/apps/src/lab2/views/components/Instructions/ResourcePanel/Backpack/saveToBackpackHelper.tsx
@@ -2,11 +2,11 @@ import React from 'react';
 
 import Lab2Registry from '@cdo/apps/lab2/Lab2Registry';
 import {sendLab2AnalyticsEvent} from '@cdo/apps/lab2/utils';
-import {moderateImage} from '@cdo/apps/lab2/utils/moderateImage';
 import {DialogControlInterface, DialogType} from '@cdo/apps/lab2/views/dialogs';
 import {EVENTS} from '@cdo/apps/metrics/AnalyticsConstants';
 import BackpackClientApi from '@cdo/apps/sharedComponents/backpack/BackpackClientApi';
 import HttpClient from '@cdo/apps/util/HttpClient';
+import {moderateImage} from '@cdo/apps/util/moderateImage';
 import {createUuid} from '@cdo/apps/utils';
 
 export const handleSaveSupportFile = async (

--- a/apps/src/p5lab/AnimationPicker/AnimationPicker.jsx
+++ b/apps/src/p5lab/AnimationPicker/AnimationPicker.jsx
@@ -177,71 +177,45 @@ class AnimationPicker extends React.Component {
     );
   }
 
-  getImageDimensions = file => {
-    return new Promise((resolve, reject) => {
-      const reader = new FileReader();
-      reader.onload = () => {
-        const img = new Image();
-        img.onload = () => {
-          resolve({width: img.width, height: img.height});
-        };
-        img.onerror = reject;
-        img.src = reader.result;
-      };
-      reader.onerror = reject;
-      reader.readAsDataURL(file);
-    });
-  };
-
   /**
    * Send the uploaded image file to be moderated. Then continue with uploadStart.
    */
-  handleModeratedUploadStart = data => {
+  handleModeratedUploadStart = async data => {
     const file = data?.files?.[0];
     if (!file) {
       console.error('No file found in upload data.');
       return;
     }
-    if (data.files[0].size >= MAX_UPLOAD_SIZE) {
+    if (file.size >= MAX_UPLOAD_SIZE) {
       this.props.onUploadError(msg.animationPicker_unsupportedSize());
       return;
     }
-    if (
-      data.files[0].type !== 'image/png' &&
-      data.files[0].type !== 'image/jpeg'
-    ) {
+    if (file.type !== 'image/png' && file.type !== 'image/jpeg') {
       this.props.onUploadError(msg.animationPicker_unsupportedType());
       return;
     }
-    this.getImageDimensions(file)
-      .then(async ({width, height}) => {
-        if (width < 128 || height < 128) {
-          // We skip moderation of small images because Azure Content Moderator has a minimum
-          // requirement for their evaluate endpoint.
-          // TODO: resize small images and then moderate. https://codedotorg.atlassian.net/browse/SL-1367
-          this.props.onUploadStart(data);
-          return;
-        }
 
-        this.setState({pendingUploadData: data});
+    this.setState({pendingUploadData: data});
 
-        const ext = file.name.split('.').pop()?.toLowerCase() || '';
-        const moderationStatus = await moderateImage(
-          file,
-          ext,
-          this.props.projectType,
-          {uploaderType: 'AnimationPicker'}
-        );
-        if (moderationStatus === 'flagged') {
-          this.setState({showFlaggedModal: true});
-        } else {
-          this.props.onUploadStart(this.state.pendingUploadData);
+    try {
+      const ext = file.name.split('.').pop()?.toLowerCase() || '';
+      const moderationStatus = await moderateImage(
+        file,
+        ext,
+        this.props.projectType,
+        {
+          uploaderType: 'AnimationPicker',
         }
-      })
-      .catch(err => {
-        MetricsReporter.logError('Error getting image dimensions: ' + err);
-        this.props.onUploadError(msg.animationPicker_uploadingError());
-      });
+      );
+      if (moderationStatus === 'flagged') {
+        this.setState({showFlaggedModal: true});
+      } else {
+        this.props.onUploadStart(this.state.pendingUploadData);
+      }
+    } catch (err) {
+      MetricsReporter.logError('Error moderating uploaded image: ' + err);
+      this.props.onUploadError(msg.animationPicker_uploadingError());
+    }
   };
 
   handleAcceptFlaggedImage = () => {

--- a/apps/src/p5lab/AnimationPicker/AnimationPicker.jsx
+++ b/apps/src/p5lab/AnimationPicker/AnimationPicker.jsx
@@ -3,6 +3,7 @@ import React from 'react';
 import {connect} from 'react-redux';
 
 import HiddenUploader from '@cdo/apps/code-studio/components/HiddenUploader';
+import {moderateImage} from '@cdo/apps/lab2/utils/moderateImage';
 import {EVENTS} from '@cdo/apps/metrics/AnalyticsConstants';
 import analyticsReporter from '@cdo/apps/metrics/AnalyticsReporter';
 import MetricsReporter from '@cdo/apps/metrics/MetricsReporter';
@@ -213,7 +214,7 @@ class AnimationPicker extends React.Component {
       return;
     }
     this.getImageDimensions(file)
-      .then(({width, height}) => {
+      .then(async ({width, height}) => {
         if (width < 128 || height < 128) {
           // We skip moderation of small images because Azure Content Moderator has a minimum
           // requirement for their evaluate endpoint.
@@ -222,69 +223,20 @@ class AnimationPicker extends React.Component {
           return;
         }
 
-        this.setState({
-          pendingUploadData: data,
-        });
+        this.setState({pendingUploadData: data});
 
-        MetricsReporter.incrementCounter('ModerateCustomImage.Attempt', [
-          {name: 'AppName', value: this.props.projectType || 'unknown'},
-          {name: 'UploaderType', value: 'AnimationPicker'},
-        ]);
-        analyticsReporter.sendEvent(EVENTS.MODERATE_CUSTOM_IMAGE, {
-          UploaderType: 'Animation Picker',
-          ProjectType: this.props.projectType,
-        });
-
-        HttpClient.post(`/v3/images/moderate`, file, true, {
-          'Content-Type': file.type,
-        })
-          .then(response => {
-            if (!response.ok) {
-              MetricsReporter.logError(
-                'Error with image moderation: HTTP error'
-              );
-              MetricsReporter.incrementCounter('ModerateCustomImage.Error', [
-                {name: 'AppName', value: this.props.projectType || 'unknown'},
-                {name: 'UploaderType', value: 'AnimationPicker'},
-              ]);
-              this.props.onUploadError(msg.animationPicker_uploadingError());
-              return null;
-            }
-            return response.json();
-          })
-          .then(json => {
-            if (!json) return; // Skip if an HTTP error occurred.
-
-            MetricsReporter.incrementCounter('ModerateCustomImage.Success', [
-              {name: 'AppName', value: this.props.projectType || 'unknown'},
-              {name: 'UploaderType', value: 'AnimationPicker'},
-            ]);
-            // If rating is not 'everyone' or 'unknown', then flag project for image moderation.
-            if (json.rating !== 'everyone' && json.rating !== 'unknown') {
-              this.setState({
-                showFlaggedModal: true,
-              });
-              analyticsReporter.sendEvent(EVENTS.FLAGGED_CUSTOM_IMAGE, {
-                UploaderType: 'Animation Picker',
-                ProjectType: this.props.projectType,
-              });
-              MetricsReporter.incrementCounter('ModerateCustomImage.Flagged', [
-                {name: 'AppName', value: this.props.projectType || 'unknown'},
-                {name: 'UploaderType', value: 'AnimationPicker'},
-              ]);
-            } else {
-              // If the image is rated 'everyone' or 'unknown', continue with upload.
-              this.props.onUploadStart(this.state.pendingUploadData);
-            }
-          })
-          .catch(err => {
-            this.props.onUploadError(msg.animationPicker_uploadingError());
-            MetricsReporter.logError('Error with image moderation: ' + err);
-            MetricsReporter.incrementCounter('ModerateCustomImage.Error', [
-              {name: 'AppName', value: this.props.projectType || 'unknown'},
-              {name: 'UploaderType', value: 'AnimationPicker'},
-            ]);
-          });
+        const ext = file.name.split('.').pop()?.toLowerCase() || '';
+        const moderationStatus = await moderateImage(
+          file,
+          ext,
+          this.props.projectType,
+          {uploaderType: 'AnimationPicker'}
+        );
+        if (moderationStatus === 'flagged') {
+          this.setState({showFlaggedModal: true});
+        } else {
+          this.props.onUploadStart(this.state.pendingUploadData);
+        }
       })
       .catch(err => {
         MetricsReporter.logError('Error getting image dimensions: ' + err);

--- a/apps/src/p5lab/AnimationPicker/AnimationPicker.jsx
+++ b/apps/src/p5lab/AnimationPicker/AnimationPicker.jsx
@@ -210,7 +210,7 @@ class AnimationPicker extends React.Component {
       if (moderationStatus === 'flagged') {
         this.setState({showFlaggedModal: true});
       } else {
-        this.props.onUploadStart(this.state.pendingUploadData);
+        this.props.onUploadStart(data);
       }
     } catch (err) {
       MetricsReporter.logError('Error moderating uploaded image: ' + err);

--- a/apps/src/p5lab/AnimationPicker/AnimationPicker.jsx
+++ b/apps/src/p5lab/AnimationPicker/AnimationPicker.jsx
@@ -3,7 +3,6 @@ import React from 'react';
 import {connect} from 'react-redux';
 
 import HiddenUploader from '@cdo/apps/code-studio/components/HiddenUploader';
-import {moderateImage} from '@cdo/apps/lab2/utils/moderateImage';
 import {EVENTS} from '@cdo/apps/metrics/AnalyticsConstants';
 import analyticsReporter from '@cdo/apps/metrics/AnalyticsReporter';
 import MetricsReporter from '@cdo/apps/metrics/MetricsReporter';
@@ -12,6 +11,7 @@ import FlaggedImageModal from '@cdo/apps/sharedComponents/FlaggedImageModal';
 import StylizedBaseDialog from '@cdo/apps/sharedComponents/StylizedBaseDialog';
 import BaseDialog from '@cdo/apps/templates/BaseDialog.jsx';
 import HttpClient from '@cdo/apps/util/HttpClient';
+import {moderateImage} from '@cdo/apps/util/moderateImage';
 import {createUuid, makeEnum} from '@cdo/apps/utils';
 
 import {

--- a/apps/src/util/moderateImage.ts
+++ b/apps/src/util/moderateImage.ts
@@ -49,9 +49,16 @@ const scaleFileForModeration = (file: File): Promise<File> => {
         const canvas = document.createElement('canvas');
         canvas.width = Math.ceil(width * scale);
         canvas.height = Math.ceil(height * scale);
-        canvas
-          .getContext('2d')!
-          .drawImage(img, 0, 0, canvas.width, canvas.height);
+        const ctx = canvas.getContext('2d')!;
+        if (!ctx) {
+          reject(
+            new Error(
+              'Unable to get 2D canvas context for image moderation scaling'
+            )
+          );
+          return;
+        }
+        ctx.drawImage(img, 0, 0, canvas.width, canvas.height);
         canvas.toBlob(blob => {
           if (!blob) {
             reject(new Error('Canvas toBlob returned null'));
@@ -80,13 +87,17 @@ export const moderateImage = async (
     flaggedEvent = EVENTS.FLAGGED_CUSTOM_IMAGE,
   }: AnalyticsData
 ): Promise<'ok' | 'flagged' | 'skipped'> => {
+  const extToCompare = ext.toLowerCase();
   if (
     !LABS_WITH_IMAGE_MODERATION.includes(appName ?? '') ||
-    !ALLOWED_IMAGE_FILE_EXTENSIONS.includes(ext)
+    !ALLOWED_IMAGE_FILE_EXTENSIONS.includes(extToCompare)
   ) {
     return 'skipped';
   }
-  const dimensions = [{name: 'UploaderType', value: uploaderType}];
+  const dimensions = [
+    {name: 'UploaderType', value: uploaderType},
+    {name: 'AppName', value: appName},
+  ];
   MetricsReporter.incrementCounter('ModerateCustomImage.Attempt', dimensions);
   analyticsReporter.sendEvent(moderateEvent, {
     UploaderType: uploaderType,

--- a/apps/src/util/moderateImage.ts
+++ b/apps/src/util/moderateImage.ts
@@ -11,7 +11,7 @@ const LABS_WITH_IMAGE_MODERATION = [
   'poetry',
 ];
 
-const ALLOWED_IMAGE_FILE_EXTENSIONS = ['jpg', 'jpeg', 'png', 'gif'];
+export const ALLOWED_IMAGE_FILE_EXTENSIONS = ['jpg', 'jpeg', 'png', 'gif'];
 
 // Azure Content Moderator requires both dimensions to be at least this size.
 const MIN_MODERATION_DIMENSION = 128;

--- a/apps/src/util/moderateImage.ts
+++ b/apps/src/util/moderateImage.ts
@@ -11,7 +11,7 @@ const LABS_WITH_IMAGE_MODERATION = [
   'poetry',
 ];
 
-export const ALLOWED_IMAGE_FILE_EXTENSIONS = ['jpg', 'jpeg', 'png', 'gif'];
+const ALLOWED_IMAGE_FILE_EXTENSIONS = ['jpg', 'jpeg', 'png', 'gif'];
 
 // Azure Content Moderator requires both dimensions to be at least this size.
 const MIN_MODERATION_DIMENSION = 128;


### PR DESCRIPTION
<!--
  Summary of the change: background, motivation, and context.
  Include screenshots, videos, or before/after comparisons for UI changes.
-->
This PR refactors `moderateImage` so that it can be called in both lab2 and legacy lab contexts and addresses a couple comments from https://github.com/code-dot-org/code-dot-org/pull/71243. This is pre-work for the migration to a new image moderation service (Azure Content Moderator -> Azure AI Content Safety). Since image moderation has expanded to different labs (both legacy and lab2), it will be easier for future management/updates if all labs call on `moderateImage`. 

`moderateImage` now includes a check for image size so that if the image does not meet the size requirements for Azure Content Moderator, it is scaled and then sent to the moderation service. The original file is uploaded (not the scaled version). Before this update, the check for size was in `AnimationPicker` because users frequently uploaded small 'sprite' images so we skipped moderation in this case. Now these small iimages will be moderated.

Because this function is updated to be called across labs, the lab2 version of sending analytics is replaced with the general analytics and metrics reporters. Also, there is a generic `ALLOWED_IMAGE_FILE_EXTENSIONS` list (https://github.com/code-dot-org/code-dot-org/pull/71243#discussion_r2919848479).

In `fileHelpers`, `convertMEdiaTypeToExtension` is added with an `accepts` param as suggested from https://github.com/code-dot-org/code-dot-org/pull/71243#discussion_r2920059654. I added `ACCEPTED_IMAGE_MEDIA_TYPES` in `aichat/constants` as these are the image file types that are support in our assets bucket and by our safety moderation service.






<details>

<summary>Past work in image moderation</summary>
<ul>
<li>Moderate images uploaded in `AnimationPicker` for Sprite/Poetry and Game Lab https://github.com/code-dot-org/code-dot-org/pull/67301,
<li>Moderate images uploaded in Web Lab 2 https://github.com/code-dot-org/code-dot-org/pull/67788,
<li>Moderate secondary backpack images imported into Web Lab 2 https://github.com/code-dot-org/code-dot-org/pull/70523 (`moderateImage` was extracted for lab2 labs),
<li>Moderate model-generated images in `aichat` https://github.com/code-dot-org/code-dot-org/pull/71118
</ul>
</details>





Upcoming work in image moderation:
- Moderate images uploaded by the user in `aichat`,
- Migrate from Azure Content Moderator to Azure AI Content Safety service.





## Links
<!-- Jira tickets, design docs, Slack threads, related PRs, etc. -->

- [image moderation in projects doc](https://docs.google.com/document/d/1GEWYqetCJYXF49i-ngU7q_tfhmPyg7BwtvWVXWeEHLM/edit?tab=t.oplg73eutqzf)
- Jira:  https://codedotorg.atlassian.net/browse/SL-1367

 

## Testing story
<!-- How was this tested? Manual steps, adhoc links, automated tests, or why testing isn't needed. -->

I tested locally and confirmed via statsig events in dev console that image moderation works as expected in Sprite Lab (Animation Picker), Web Lab 2 (Lab2 File Uploader), and AI Chat Lab.


## Deployment notes
<!-- Delete this section if it's a standard merge-and-deploy.
     Otherwise: migrations, feature flags, coordination, caching impacts, etc. -->



## Privacy and security
<!-- Delete this section if there is no privacy/security impact.
     Otherwise: new PII, auth changes, API surface changes, etc. -->

