### PR TITLE
Gemfile: only reference rails engines under dashboard/

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -420,9 +420,9 @@ gem 'opentelemetry-sdk', '~> 1.10'
 # pinned due to rails 7, upgrade on rails 7.1
 gem "opentelemetry-instrumentation-all", "0.85.0"
 
-# Automatically include all rails engines
-Dir[Bundler.root.join('**/engines/*/*.gemspec')].sort.each do |gemspec_path|
-  gem File.basename(gemspec_path, '.gemspec'), path: '.', glob: '**/engines/*/*.gemspec'
+# Automatically include all rails engines under dashboard/
+Dir[Bundler.root.join('{,dashboard/}engines/*/*.gemspec')].sort.each do |gemspec_path|
+  gem File.basename(gemspec_path, '.gemspec'), path: '.', glob: '{,dashboard/}engines/*/*.gemspec'
 end
 
 # OpenSSL 3.6 broke Ruby's OpenSSL bindings, see: https://github.com/ruby/openssl/issues/949

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -97,7 +97,7 @@ GIT
       nio4r (~> 2.0)
 
 PATH
-  remote: ..
+  remote: .
   glob: {,dashboard/}engines/*/*.gemspec
   specs:
     cdo_contentful (0.1.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -97,8 +97,8 @@ GIT
       nio4r (~> 2.0)
 
 PATH
-  remote: .
-  glob: **/engines/*/*.gemspec
+  remote: ..
+  glob: {,dashboard/}engines/*/*.gemspec
   specs:
     cdo_contentful (0.1.0)
       contentful (~> 2.18)
@@ -344,7 +344,7 @@ GEM
       fiber-annotation
       fiber-local
       json
-    contentful (2.18.0)
+    contentful (2.19.0)
       http (> 0.8, < 6.0)
       multi_json (~> 1.15)
     crack (0.4.5)


### PR DESCRIPTION
This PR narrows the `Gemfile` glob for Rails Engines from `**/engines` to require them to be under `dashboard/engines`.

Fixes this warning on many commands that use `bundle exec`:
```
code-dot-org git:(staging) ./bin/dashboard-console-skip-preload 
/Users/seth/src/code-dot-org/k8s/mimic/code-dot-org/dashboard/engines/cdo_contentful/lib/cdo_contentful/version.rb:4: warning: already initialized constant CdoContentful::VERSION
/Users/seth/src/code-dot-org/k8s/mimic/cdo-no-symlinks/dashboard/engines/cdo_contentful/lib/cdo_contentful/version.rb:4: warning: previous definition of VERSION was here
/Users/seth/src/code-dot-org/k8s/mimic/code-dot-org/dashboard/engines/cdo_contentful/lib/cdo_contentful/version.rb:4: warning: already initialized constant CdoContentful::VERSION
/Users/seth/src/code-dot-org/k8s/mimic/cdo-no-symlinks/dashboard/engines/cdo_contentful/lib/cdo_contentful/version.rb:4: warning: previous definition of VERSION was here
```

These are symlinks, needed for k8s/docker development, see below for more detail.

## Testing

1) `bundle install` works in both `/` and `/dashboard`. Gemfile.lock isn't modified.
2) Warnings are gone

## Reason for Change

We have directories `k8s/mimic/code-dot-org/dashboard/engines

The kubernetes "mimic" in [k8s/mimic/codeo-dot-org](https://github.com/code-dot-org/code-dot-org/tree/staging/k8s/mimic/code-dot-org) allows us to validate our real docker builds against mocked content. This is because our repo is so huge, its hard to iterate on docker with the real content (20GB images suck to iterate on).

Because our real Gemfile references engines, we have to symlink the real engines in to have the actual Gemfile dependencies.

But the currently `**/engines/*/*.gemspec` glob sees those symlinks, and currently produces the warning.
