### PR TITLE
switch back to drone-runner-docker mainline

### DIFF
--- a/aws/cloudformation/drone-stack.yml
+++ b/aws/cloudformation/drone-stack.yml
@@ -409,8 +409,7 @@ Resources:
             # BEGIN: Settings for the Drone Runner ("worker"/"agent") executing on the EC2 Instances provisioned by Autoscaler.
             -
               Name: DRONE_AGENT_IMAGE
-              # TODO move back to mainline after drone-runners/drone-runner-docker#79 or similar is merged to update Docker Go client
-              Value: codedotorg/drone-runner-docker
+              Value: drone-runners/drone-runner-docker
             -
               Name: DRONE_AGENT_CONCURRENCY
               Value: 1

--- a/aws/cloudformation/drone-stack.yml
+++ b/aws/cloudformation/drone-stack.yml
@@ -409,7 +409,7 @@ Resources:
             # BEGIN: Settings for the Drone Runner ("worker"/"agent") executing on the EC2 Instances provisioned by Autoscaler.
             -
               Name: DRONE_AGENT_IMAGE
-              Value: drone-runners/drone-runner-docker
+              Value: drone/drone-runner-docker
             -
               Name: DRONE_AGENT_CONCURRENCY
               Value: 1


### PR DESCRIPTION
Now that the Go upgrade has been merged upstream, we can switch back to the mainline docker image instead of our fork.

## Links
<!-- Jira tickets, design docs, Slack threads, related PRs, etc. -->

- Upstream fix: https://github.com/drone-runners/drone-runner-docker/releases/tag/v1.8.5
- Jira: https://codedotorg.atlassian.net/browse/INF-1946

## Testing story

Haven't tested, can revert if we see failures

## Deployment notes
<!-- Delete this section if it's a standard merge-and-deploy.
     Otherwise: migrations, feature flags, coordination, caching impacts, etc. -->

- [ ] Deploy drone-stack.yml manually


## Privacy and security
<!-- Delete this section if there is no privacy/security impact.
     Otherwise: new PII, auth changes, API surface changes, etc. -->

n/a