### PR TITLE
Remove Unused `get_and_clear_session_user_return_to`

### DIFF
--- a/dashboard/app/helpers/application_helper.rb
+++ b/dashboard/app/helpers/application_helper.rb
@@ -121,11 +121,6 @@ module ApplicationHelper
     CDO.code_org_url
   end
 
-  # used by sign-up to retrieve the user return_to URL from the session and delete it.
-  def get_and_clear_session_user_return_to
-    return session.delete(:user_return_to) if session[:user_return_to]
-  end
-
   # used by devise to redirect user after signing in
   def signed_in_root_path(resource_or_scope)
     if resource_or_scope.is_a?(User) && resource_or_scope.teacher?


### PR DESCRIPTION
Stumbled across this helper method while working on [other `return_to` changes](https://github.com/code-dot-org/code-dot-org/pull/71416), and it looks like we're not actually using it anywhere.

## Links

- Added in https://github.com/code-dot-org/code-dot-org/pull/8819
- Removed in https://github.com/code-dot-org/code-dot-org/pull/33784

## Testing story

In addition to relying on existing tests to verify that this does not change any functionality, I also just grepped for it:

```bash
[~/code-dot-org]$ git grep get_and_clear_session_user_return_to
dashboard/app/helpers/application_helper.rb:  def get_and_clear_session_user_return_to
```