### PR TITLE
update pegasus content scenarios in gdpr_dialog.feature

### DIFF
--- a/dashboard/test/ui/features/xteam/gdpr_dialog.feature
+++ b/dashboard/test/ui/features/xteam/gdpr_dialog.feature
@@ -1,7 +1,6 @@
 @no_mobile
 Feature: GDPR Dialog - data transfer agreement
 
-  @pegasus_content
   Scenario: EU user sees the GDPR Dialog on dashboard, opt out
     Given I am in Europe
     And I am a teacher
@@ -26,16 +25,12 @@ Feature: GDPR Dialog - data transfer agreement
     And I am on "http://studio.code.org/home"
     Then element ".ui-test-gdpr-dialog" is not visible
 
-  @pegasus_content
-  # Broken during the marketing-sites cutover
-  @skip
   Scenario: GDPR Dialog privacy link works from dashboard
     Given I am in Europe
     And I am a teacher
     And I am on "http://studio.code.org/home"
-    When element ".ui-test-gdpr-dialog" is visible
-    Then I press the first ".ui-test-gdpr-dialog-privacy-link" element to load a new tab
-    Then check that I am on "http://code.org/privacy"
+    When element "#gdpr-dialog" is visible
+    And the link reading "Visit Code.org" within element "#gdpr-dialog" goes to "http://code.org/privacy"
 
   Scenario: Accept, sign out, sign in again, no dialog
     Given I am in Europe


### PR DESCRIPTION
before the move to the CMS, we were using the `@pegasus_content` flag to conditionally skip UI tests that  depended on pegasus content. when the marketing site moved to the CMS, we marked any of these tests that were failing with `@skip`. now that pegasus content has actually been removed, I'm doing a final pass to remove the skips and `@pegasus_content` taggings. some comments inline about what's being done to each scenario.

## additional GDPR dialog background

You can see and interact with it here: https://studio.code.org/teacher_dashboard/home?force_in_eu=1 (signed in)
<img width="749" height="319" alt="Screenshot 2026-03-17 at 7 18 26 AM" src="https://github.com/user-attachments/assets/b26cc237-b960-484f-9a47-39843e95a6b8" />

<img width="579" height="306" alt="Screenshot 2026-03-17 at 7 19 23 AM" src="https://github.com/user-attachments/assets/6e590f07-ee54-4efc-bbb1-5754fd80d573" />

the UI string appears to come from here: https://github.com/code-dot-org/code-dot-org/blob/bf36f974425f2afdf4d7d03085e52ecfd9b12719/apps/i18n/common/en_us.json#L1484

I am using a prefix of the UI string to avoid the special right-quote character.
 