### PR TITLE
Fix Violations of and Reenable `FactoryBot/CreateList`

### DIFF
--- a/.config/rubocop/todo.yml
+++ b/.config/rubocop/todo.yml
@@ -454,13 +454,6 @@ Style/TernaryParentheses:
 Style/TrailingUnderscoreVariable:
   Enabled: false
 
-# Offense count: 38
-# This cop supports safe autocorrection (--autocorrect).
-# Configuration parameters: EnforcedStyle, ExplicitOnly.
-# SupportedStyles: create_list, n_times
-FactoryBot/CreateList:
-  Enabled: false
-
 # Offense count: 55
 # This cop supports safe autocorrection (--autocorrect).
 FactoryBot/FactoryClassName:

--- a/dashboard/test/controllers/api/v1/pd/workshop_survey_foorm_report_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/pd/workshop_survey_foorm_report_controller_test.rb
@@ -207,7 +207,7 @@ module Api::V1::Pd
       csf_workshop = build(:csf_workshop,
                             started_at:  Time.now.utc - 1.day,
                             ended_at: Time.now.utc - 1.hour,
-                            facilitators: [create(:facilitator), create(:facilitator)]
+                            facilitators: create_list(:facilitator, 2)
 )
       csf_workshop.save(validate: false)
       facilitator = csf_workshop.facilitators[0]
@@ -235,7 +235,7 @@ module Api::V1::Pd
       csf_workshop = build(:csf_workshop,
         started_at:  Time.now.utc - 1.day,
         ended_at: Time.now.utc - 1.hour,
-        facilitators: [create(:facilitator), create(:facilitator)]
+        facilitators: create_list(:facilitator, 2)
 )
       csf_workshop.save(validate: false)
       facilitator_1 = csf_workshop.facilitators[0]
@@ -273,7 +273,7 @@ module Api::V1::Pd
       csf_workshop = build(:csf_workshop,
                             started_at:  Time.now.utc - 1.day,
                             ended_at: Time.now.utc - 1.hour,
-                            facilitators: [create(:facilitator), create(:facilitator)]
+                            facilitators: create_list(:facilitator, 2)
 )
       csf_workshop.save(validate: false)
       facilitator = csf_workshop.facilitators[0]
@@ -488,7 +488,7 @@ module Api::V1::Pd
       csf_workshop = build(:csf_workshop,
         started_at:  Time.now.utc - 1.day,
         ended_at: Time.now.utc - 1.hour,
-        facilitators: [create(:facilitator), create(:facilitator)]
+        facilitators: create_list(:facilitator, 2)
       )
       csf_workshop.save(validate: false)
       facilitator_1 = csf_workshop.facilitators[0]

--- a/dashboard/test/controllers/api/v1/pd/workshops_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/pd/workshops_controller_test.rb
@@ -297,9 +297,7 @@ class Api::V1::Pd::WorkshopsControllerTest < ActionController::TestCase
 
   test 'filter limit' do
     # 10 more workshops, bringing the total to 12
-    10.times do
-      create(:workshop)
-    end
+    create_list(:workshop, 10)
 
     sign_in create :admin
     get :filter, params: {limit: 5}
@@ -312,9 +310,7 @@ class Api::V1::Pd::WorkshopsControllerTest < ActionController::TestCase
 
   test 'filters' do
     # 10 workshops from different organizers that will be filtered out
-    10.times do
-      create(:workshop)
-    end
+    create_list(:workshop, 10)
 
     # Same organizer
     organizer = create(:workshop_organizer)
@@ -673,9 +669,7 @@ class Api::V1::Pd::WorkshopsControllerTest < ActionController::TestCase
     sign_in create :admin
 
     # create some enrollments
-    5.times do
-      create(:pd_enrollment, workshop: @workshop)
-    end
+    create_list(:pd_enrollment, 5, workshop: @workshop)
     Pd::WorkshopMailjetMailer.expects(:send_teacher_workshop_detail_change_notification).never
     Pd::WorkshopMailjetMailer.expects(:send_rp_workshop_detail_change_notification).never
 

--- a/dashboard/test/controllers/api/v1/sections_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/sections_controller_test.rb
@@ -188,7 +188,7 @@ class Api::V1::SectionsControllerTest < ActionController::TestCase
     sign_in student
     section = create(:section, login_type: 'email')
 
-    create_list(:follower, 500, section: section)
+    create_list(:follower, 500, section: section) # rubocop:disable FactoryBot/ExcessiveCreateList
 
     post :join, params: {id: section.code}
     assert_response :forbidden

--- a/dashboard/test/controllers/api/v1/sections_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/sections_controller_test.rb
@@ -188,9 +188,7 @@ class Api::V1::SectionsControllerTest < ActionController::TestCase
     sign_in student
     section = create(:section, login_type: 'email')
 
-    500.times do
-      create(:follower, section: section)
-    end
+    create_list(:follower, 500, section: section)
 
     post :join, params: {id: section.code}
     assert_response :forbidden

--- a/dashboard/test/controllers/api/v1/sections_students_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/sections_students_controller_test.rb
@@ -306,7 +306,7 @@ class Api::V1::SectionsStudentsControllerTest < ActionController::TestCase
   test 'teacher can not add students to a section at capacity' do
     sign_in @teacher
     @section = create(:section, user: @teacher, login_type: 'word')
-    create_list(:follower, 500, section: @section)
+    create_list(:follower, 500, section: @section) # rubocop:disable FactoryBot/ExcessiveCreateList
     post :bulk_add, params: {section_id: @section.id, students: [{gender_teacher_input: 'f', age: 9, name: 'name'}]}
     assert_response :forbidden
     assert_equal(

--- a/dashboard/test/controllers/api/v1/sections_students_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/sections_students_controller_test.rb
@@ -306,9 +306,7 @@ class Api::V1::SectionsStudentsControllerTest < ActionController::TestCase
   test 'teacher can not add students to a section at capacity' do
     sign_in @teacher
     @section = create(:section, user: @teacher, login_type: 'word')
-    500.times do
-      create(:follower, section: @section)
-    end
+    create_list(:follower, 500, section: @section)
     post :bulk_add, params: {section_id: @section.id, students: [{gender_teacher_input: 'f', age: 9, name: 'name'}]}
     assert_response :forbidden
     assert_equal(

--- a/dashboard/test/controllers/api_controller_test.rb
+++ b/dashboard/test/controllers/api_controller_test.rb
@@ -177,9 +177,7 @@ class ApiControllerTest < ActionController::TestCase
     level2.save!
     create(:script_level, script: script, levels: [level2], lesson: lesson2)
     # create some other random levels
-    7.times do
-      create(:script_level, script: script)
-    end
+    create_list(:script_level, 7, script: script)
 
     # student_1 has two answers
     level_source1a = create(:level_source, level: level1,
@@ -256,9 +254,7 @@ class ApiControllerTest < ActionController::TestCase
     level2.save!
     create(:script_level, script: script, levels: [level2], lesson: lesson2)
     # create some other random levels
-    7.times do
-      create(:script_level, script: script)
-    end
+    create_list(:script_level, 7, script: script)
 
     get :section_text_responses, params: {
       section_id: @section.id,

--- a/dashboard/test/controllers/followers_controller_test.rb
+++ b/dashboard/test/controllers/followers_controller_test.rb
@@ -138,9 +138,7 @@ class FollowersControllerTest < ActionController::TestCase
     sign_in @student
     section = create(:section, login_type: 'email')
 
-    500.times do
-      create(:follower, section: section)
-    end
+    create_list(:follower, 500, section: section)
 
     assert_does_not_create(Follower) do
       get :student_user_new, params: {section_code: section.code}

--- a/dashboard/test/controllers/followers_controller_test.rb
+++ b/dashboard/test/controllers/followers_controller_test.rb
@@ -138,7 +138,7 @@ class FollowersControllerTest < ActionController::TestCase
     sign_in @student
     section = create(:section, login_type: 'email')
 
-    create_list(:follower, 500, section: section)
+    create_list(:follower, 500, section: section) # rubocop:disable FactoryBot/ExcessiveCreateList
 
     assert_does_not_create(Follower) do
       get :student_user_new, params: {section_code: section.code}

--- a/dashboard/test/controllers/programming_classes_controller_test.rb
+++ b/dashboard/test/controllers/programming_classes_controller_test.rb
@@ -194,9 +194,7 @@ class ProgrammingClassesControllerTest < ActionController::TestCase
       [@programming_environment1, @programming_environment2].each do |programming_environment|
         3.times do
           category = create(:programming_environment_category, programming_environment: programming_environment)
-          4.times do
-            create(:programming_class, programming_environment: programming_environment, programming_environment_category: category)
-          end
+          create_list(:programming_class, 4, programming_environment: programming_environment, programming_environment_category: category)
         end
       end
 

--- a/dashboard/test/controllers/programming_expressions_controller_test.rb
+++ b/dashboard/test/controllers/programming_expressions_controller_test.rb
@@ -204,9 +204,7 @@ class ProgrammingExpressionsControllerTest < ActionController::TestCase
       [@programming_environment1, @programming_environment2].each do |programming_environment|
         3.times do
           category = create(:programming_environment_category, programming_environment: programming_environment)
-          4.times do
-            create(:programming_expression, programming_environment: programming_environment, programming_environment_category: category)
-          end
+          create_list(:programming_expression, 4, programming_environment: programming_environment, programming_environment_category: category)
         end
       end
 

--- a/dashboard/test/controllers/scripts_controller_test.rb
+++ b/dashboard/test/controllers/scripts_controller_test.rb
@@ -830,11 +830,7 @@ class ScriptsControllerTest < ActionController::TestCase
     stub_file_writes(unit.name)
 
     course_version = create(:course_version, content_root: unit.original_unit_group)
-    teacher_resources = [
-      create(:resource, course_version: course_version),
-      create(:resource, course_version: course_version),
-      create(:resource, course_version: course_version)
-    ]
+    teacher_resources = create_list(:resource, 3, course_version: course_version)
 
     unit.reload
     post :update, params: {
@@ -856,10 +852,7 @@ class ScriptsControllerTest < ActionController::TestCase
     stub_file_writes(unit.name)
 
     course_version = create(:course_version, content_root: unit.original_unit_group)
-    student_resources = [
-      create(:resource, course_version: course_version),
-      create(:resource, course_version: course_version)
-    ]
+    student_resources = create_list(:resource, 2, course_version: course_version)
 
     unit.reload
     post :update, params: {

--- a/dashboard/test/controllers/transfers_controller_test.rb
+++ b/dashboard/test/controllers/transfers_controller_test.rb
@@ -247,9 +247,7 @@ class TransfersControllerTest < ActionController::TestCase
   end
 
   test "returns an error when the new_section will be over it's section capacity" do
-    500.times do
-      create(:follower, section: @picture_section)
-    end
+    create_list(:follower, 500, section: @picture_section)
 
     post :create, params: @params
     assert_response :forbidden

--- a/dashboard/test/controllers/transfers_controller_test.rb
+++ b/dashboard/test/controllers/transfers_controller_test.rb
@@ -247,7 +247,7 @@ class TransfersControllerTest < ActionController::TestCase
   end
 
   test "returns an error when the new_section will be over it's section capacity" do
-    create_list(:follower, 500, section: @picture_section)
+    create_list(:follower, 500, section: @picture_section) # rubocop:disable FactoryBot/ExcessiveCreateList
 
     post :create, params: @params
     assert_response :forbidden

--- a/dashboard/test/factories/factories.rb
+++ b/dashboard/test/factories/factories.rb
@@ -132,7 +132,7 @@ FactoryBot.define do
 
     trait :with_units do
       transient do
-        units {[create(:unit), create(:unit)]}
+        units {create_list(:unit, 2)}
       end
       after(:create) do |unit_group, evaluator|
         evaluator.units.each_with_index do |unit, index|
@@ -1636,7 +1636,7 @@ FactoryBot.define do
     # create real sublevels, and update pages to match.
     trait :with_sublevels do
       after(:create) do |lg|
-        levels_and_texts_by_page = [[create(:sublevel), create(:sublevel)], [create(:sublevel)]]
+        levels_and_texts_by_page = [create_list(:sublevel, 2), [create(:sublevel)]]
         lg.update_levels_and_texts_by_page(levels_and_texts_by_page)
       end
     end

--- a/dashboard/test/lib/expired_child_account_purger_test.rb
+++ b/dashboard/test/lib/expired_child_account_purger_test.rb
@@ -68,7 +68,7 @@ class ExpiredChildAccountPurgerTest < ActiveSupport::TestCase
   end
 
   test 'only expired child accounts are purged' do
-    expired_accounts = Array.new(3) {|_| create(:locked_out_child, :expired)}
+    expired_accounts = create_list(:locked_out_child, 3, :expired)
     locked_account = create(:locked_out_child)
     u13_colorado_account = create(:student, :U13, :in_colorado)
     student_account = create(:student)
@@ -87,7 +87,7 @@ class ExpiredChildAccountPurgerTest < ActiveSupport::TestCase
   end
 
   test 'expired child accounts are reported in metrics' do
-    expired_accounts = Array.new(3) {|_| create(:locked_out_child, :expired)}
+    expired_accounts = create_list(:locked_out_child, 3, :expired)
     Cdo::Metrics.expects(:push).with(
       'ExpiredChildAccountPurger',
       includes_metrics(

--- a/dashboard/test/lib/queries/child_account_test.rb
+++ b/dashboard/test/lib/queries/child_account_test.rb
@@ -4,7 +4,7 @@ class Queries::ChildAccountTest < ActiveSupport::TestCase
   freeze_time
 
   test 'expired_accounts' do
-    expired_accounts = Array.new(3) {|_| create(:locked_out_child, :expired)}
+    expired_accounts = create_list(:locked_out_child, 3, :expired)
     locked_account = create(:locked_out_child)
     u13_colorado_account = create(:student, :U13, :in_colorado)
     student_account = create(:student)

--- a/dashboard/test/models/concerns/user/level_progressable_test.rb
+++ b/dashboard/test/models/concerns/user/level_progressable_test.rb
@@ -642,11 +642,7 @@ class LevelProgressableTest < ActiveSupport::TestCase
     let(:lesson_group) {create(:lesson_group, script: script)}
     let(:lesson) {create(:lesson, script: script, lesson_group: lesson_group)}
     let!(:script_levels) do
-      [
-        create(:script_level, script: script, lesson: lesson, levels: [create(:level)]),
-        create(:script_level, script: script, lesson: lesson, levels: [create(:level)]),
-        create(:script_level, script: script, lesson: lesson, levels: [create(:level)]),
-      ]
+      3.times.map { create(:script_level, script: script, lesson: lesson, levels: [create(:level)]) }
     end
 
     before do

--- a/dashboard/test/models/concerns/user/level_progressable_test.rb
+++ b/dashboard/test/models/concerns/user/level_progressable_test.rb
@@ -642,7 +642,9 @@ class LevelProgressableTest < ActiveSupport::TestCase
     let(:lesson_group) {create(:lesson_group, script: script)}
     let(:lesson) {create(:lesson, script: script, lesson_group: lesson_group)}
     let!(:script_levels) do
-      3.times.map { create(:script_level, script: script, lesson: lesson, levels: [create(:level)]) }
+      create_list(:script_level, 3, script: script, lesson: lesson) do |script_level, _|
+        script_level.levels = create_list(:level, 1)
+      end
     end
 
     before do

--- a/dashboard/test/models/course_offering_test.rb
+++ b/dashboard/test/models/course_offering_test.rb
@@ -907,7 +907,7 @@ class CourseOfferingTest < ActiveSupport::TestCase
     lesson_group = create(:lesson_group, script: unit)
 
     lesson = create(:lesson, script: unit, lesson_group: lesson_group)
-    6.times {create(:lesson_activity, lesson: lesson, duration: 1000)}
+    create_list(:lesson_activity, 6, lesson: lesson, duration: 1000)
 
     # A course_offering of this unit should have a 'school_year' duration since a school year is labeled as 5000+ minutes.
     co = CourseOffering.add_course_offering(unit.original_unit_group)

--- a/dashboard/test/models/experiment_test.rb
+++ b/dashboard/test/models/experiment_test.rb
@@ -217,9 +217,7 @@ class ExperimentTest < ActiveSupport::TestCase
   test 'can only create up to max_count single section experiments' do
     SingleSectionExperiment.any_instance.stubs(:max_count).returns(3)
 
-    3.times do
-      create(:single_section_experiment)
-    end
+    create_list(:single_section_experiment, 3)
 
     # creating a 4th experiment should fail
     assert_raises ActiveRecord::RecordInvalid do

--- a/dashboard/test/models/levels/level_test.rb
+++ b/dashboard/test/models/levels/level_test.rb
@@ -312,7 +312,7 @@ class LevelTest < ActiveSupport::TestCase
 
   test 'returns concept videos with related videos' do
     level = create(:level)
-    level.concepts = [create(:concept, :with_video), create(:concept, :with_video)]
+    level.concepts = create_list(:concept, 2, :with_video)
     assert_includes(level.related_videos, level.concepts.first.related_video)
     assert_includes(level.related_videos, level.concepts.second.related_video)
   end
@@ -654,19 +654,13 @@ class LevelTest < ActiveSupport::TestCase
     assert_nil level.ideal_level_source_id
 
     right = create(:level_source, level: level, data: "<xml><right/></xml>")
-    6.times do
-      create(:activity, level: level, level_source: right, test_result: 100)
-    end
+    create_list(:activity, 6, level: level, level_source: right, test_result: 100)
 
     wrong = create(:level_source, level: level, data: "<xml><wrong/></xml>")
-    10.times do
-      create(:activity, level: level, level_source: wrong, test_result: 0)
-    end
+    create_list(:activity, 10, level: level, level_source: wrong, test_result: 0)
 
     right_but_unpopular = create(:level_source, level: level, data: "<xml><right_but_unpopular/></xml>")
-    2.times do
-      create(:activity, level: level, level_source: right_but_unpopular, test_result: 100)
-    end
+    create_list(:activity, 2, level: level, level_source: right_but_unpopular, test_result: 100)
 
     level.calculate_ideal_level_source_id
     assert_equal right, level.ideal_level_source

--- a/dashboard/test/models/pd/session_test.rb
+++ b/dashboard/test/models/pd/session_test.rb
@@ -133,9 +133,7 @@ class Pd::SessionTest < ActiveSupport::TestCase
   end
 
   test 'assign unique 4 character codes' do
-    sessions = Array.new(10) do
-      create(:pd_session, :with_assigned_code)
-    end
+    sessions = create_list(:pd_session, 10, :with_assigned_code)
 
     codes = sessions.pluck(:code)
     assert(codes.all? {|code| code.present? && code.length == 4})

--- a/dashboard/test/models/pd/workshop_test.rb
+++ b/dashboard/test/models/pd/workshop_test.rb
@@ -658,7 +658,7 @@ class Pd::WorkshopTest < ActiveSupport::TestCase
     user1 = create(:teacher)
     user2 = create(:teacher)
     user3 = create(:teacher)
-    workshop = create(:workshop, facilitators: [create(:facilitator), create(:facilitator)])
+    workshop = create(:workshop, facilitators: create_list(:facilitator, 2))
     create(:pd_enrollment, workshop: workshop, user: user1)
     create(:pd_enrollment, workshop: workshop, user: user2)
     create(:pd_enrollment, workshop: workshop, user: user3)
@@ -727,7 +727,7 @@ class Pd::WorkshopTest < ActiveSupport::TestCase
     user1 = create(:teacher)
     user2 = create(:teacher)
     user3 = create(:teacher)
-    workshop = create(:workshop, facilitators: [create(:facilitator), create(:facilitator)])
+    workshop = create(:workshop, facilitators: create_list(:facilitator, 2))
     create(:pd_enrollment, workshop: workshop, user: user1)
     create(:pd_enrollment, workshop: workshop, user: user2)
     create(:pd_enrollment, workshop: workshop, user: user3)
@@ -751,7 +751,7 @@ class Pd::WorkshopTest < ActiveSupport::TestCase
     user1 = create(:teacher)
     user2 = create(:teacher)
     user3 = create(:teacher)
-    workshop = create(:workshop, facilitators: [create(:facilitator), create(:facilitator)])
+    workshop = create(:workshop, facilitators: create_list(:facilitator, 2))
     create(:pd_enrollment, workshop: workshop, user: user1)
     create(:pd_enrollment, workshop: workshop, user: user2)
     create(:pd_enrollment, workshop: workshop, user: user3)
@@ -881,9 +881,7 @@ class Pd::WorkshopTest < ActiveSupport::TestCase
     end
 
     # 2 enrollments without attendance
-    enrollments = Array.new(2) do
-      create(:pd_enrollment, workshop: @workshop)
-    end
+    enrollments = create_list(:pd_enrollment, 2, workshop: @workshop)
 
     assert_equal enrollments.pluck(:id).sort, @workshop.unattended_enrollments.pluck(:id).sort
   end

--- a/dashboard/test/models/script_level_test.rb
+++ b/dashboard/test/models/script_level_test.rb
@@ -751,10 +751,7 @@ class ScriptLevelTest < ActiveSupport::TestCase
     script.stubs(:show_unit_overview_between_lessons?).returns true
     lesson_group = create(:lesson_group, script: script)
 
-    levels = [
-      create(:level),
-      create(:level)
-    ]
+    levels = create_list(:level, 2)
 
     script_levels = levels.map.with_index(1) do |level, pos|
       lesson = create(:lesson, script: script, absolute_position: pos, lesson_group: lesson_group)
@@ -776,10 +773,7 @@ class ScriptLevelTest < ActiveSupport::TestCase
     unit1.stubs(:next_unit).returns(unit2)
 
     lesson_group = create(:lesson_group, script: unit1)
-    levels = [
-      create(:level),
-      create(:level)
-    ]
+    levels = create_list(:level, 2)
 
     script_levels = levels.map.with_index(1) do |level, pos|
       lesson = create(:lesson, script: unit1, absolute_position: pos, lesson_group: lesson_group)

--- a/dashboard/test/models/unit_group_test.rb
+++ b/dashboard/test/models/unit_group_test.rb
@@ -106,7 +106,7 @@ class UnitGroupTest < ActiveSupport::TestCase
     create(:unit_group_unit, unit_group: unit_group, position: 1, script: create(:script, name: "unit1"))
     create(:unit_group_unit, unit_group: unit_group, position: 2, script: create(:script, name: "unit2"))
     create(:unit_group_unit, unit_group: unit_group, position: 3, script: create(:script, name: "unit3"))
-    unit_group.resources = [create(:resource, course_version: course_version), create(:resource, course_version: course_version)]
+    unit_group.resources = create_list(:resource, 2, course_version: course_version)
     unit_group.student_resources = [create(:resource, course_version: course_version)]
 
     serialization = unit_group.serialize
@@ -165,7 +165,7 @@ class UnitGroupTest < ActiveSupport::TestCase
     create(:unit_group_unit, unit_group: unit_group, position: 1, script: create(:script, name: "unit1"))
     create(:unit_group_unit, unit_group: unit_group, position: 2, script: create(:script, name: "unit2"))
     create(:unit_group_unit, unit_group: unit_group, position: 3, script: create(:script, name: "unit3"))
-    unit_group.resources = [create(:resource, course_version: course_version), create(:resource, course_version: course_version)]
+    unit_group.resources = create_list(:resource, 2, course_version: course_version)
     unit_group.student_resources = [create(:resource, course_version: course_version)]
 
     serialization = unit_group.serialize
@@ -211,7 +211,7 @@ class UnitGroupTest < ActiveSupport::TestCase
     create(:unit_group_unit, unit_group: unit_group, position: 1, script: create(:script, name: "unit1"))
     create(:unit_group_unit, unit_group: unit_group, position: 2, script: create(:script, name: "unit2"))
     create(:unit_group_unit, unit_group: unit_group, position: 3, script: create(:script, name: "unit3"))
-    unit_group.resources = [create(:resource, course_version: course_version), create(:resource, course_version: course_version)]
+    unit_group.resources = create_list(:resource, 2, course_version: course_version)
 
     serialization = unit_group.serialize
     unit_group.original_units.each {|u| u.update!(original_unit_group: nil)}


### PR DESCRIPTION
TIL about FactoryBot's `create_list`!

I generated the initial changes automatically with `bundle exec rubocop --autocorrect-all --only FactoryBot/CreateList`, then manually fixed up one complicated use case and added a few ignores for some intentionally-excessive use cases.

## Links

https://www.rubydoc.info/gems/rubocop-factory_bot/RuboCop/Cop/FactoryBot/CreateList