### PR TITLE
🧹 Remove Radium from `JsDebugger`

### DIFF
--- a/apps/src/lib/tools/jsdebugger/JsDebugger.jsx
+++ b/apps/src/lib/tools/jsdebugger/JsDebugger.jsx
@@ -5,7 +5,6 @@
 import classNames from 'classnames';
 import $ from 'jquery';
 import PropTypes from 'prop-types';
-import Radium from 'radium'; // eslint-disable-line no-restricted-imports
 import React from 'react';
 import {connect} from 'react-redux';
 
@@ -438,11 +437,11 @@ class JsDebugger extends React.Component {
     return (
       <div
         id="debug-area"
-        style={[
-          {transition: debugAreaTransitionValue},
-          this.props.style,
-          {height},
-        ]}
+        style={{
+          transition: debugAreaTransitionValue,
+          ...this.props.style,
+          height,
+        }}
         onTransitionEnd={this.onTransitionEnd}
         ref={root => (this.root = root)}
       >
@@ -652,4 +651,4 @@ export default connect(
     open,
     close,
   }
-)(Radium(JsDebugger));
+)(JsDebugger);


### PR DESCRIPTION
One more down! 

I didn't notice any visual diffs and was able to resize and use the debugger in App Lab in English and RTL. 

dashboard/test/ui/features/star_labs/applab/eyes4.feature covers the debugger so if there are any unintended diffs, we'll catch there and we can confirm if they're innocuous.

