### PR TITLE
Increase timeout for WorkshopForm validation test to 10s

### DIFF
--- a/apps/test/unit/code-studio/pd/workshop_dashboard/workshop_form/WorkshopFormTest.jsx
+++ b/apps/test/unit/code-studio/pd/workshop_dashboard/workshop_form/WorkshopFormTest.jsx
@@ -224,6 +224,7 @@ describe('WorkshopForm', () => {
       expect(screen.getAllByText(REQUIRED_ERROR)).toHaveLength(
         expectedErrorLength
       );
-    }
+    },
+    10000
   );
 });


### PR DESCRIPTION
this test was failing in drone due to timeouts:
https://drone.cdn-code.org/code-dot-org/code-dot-org/50381/1/5 
```
FAIL test/unit/code-studio/pd/workshop_dashboard/workshop_form/WorkshopFormTest.jsx (20.63 s)
  ● WorkshopForm › displays required validation errors for Build Your Own Workshop

    thrown: "Exceeded timeout of 5000 ms for a test.
    Add a timeout value to this test to increase the timeout, if this is a long-running test. See https://jestjs.io/docs/api#testname-fn-timeout."

      143 |   );
      144 |
    > 145 |   it.each(testConfigs)(
          |                       ^
      146 |     'displays required validation errors for %s',
      147 |     async (_, config) => {
      148 |       renderDefault({config});

      at node_modules/jest-each/build/bind.js:47:15
          at Array.forEach (<anonymous>)
      at test/unit/code-studio/pd/workshop_dashboard/workshop_form/WorkshopFormTest.jsx:145:23
      at Object.describe (test/unit/code-studio/pd/workshop_dashboard/workshop_form/WorkshopFormTest.jsx:24:1)
```

## Testing story
- test-only change is adequately covered by drone