### PR TITLE
Increase timeout for flaky TeacherHomepageTest

### DIFF
--- a/apps/test/unit/templates/studioHomepages/teacherHomepageV2/TeacherHomepageTest.tsx
+++ b/apps/test/unit/templates/studioHomepages/teacherHomepageV2/TeacherHomepageTest.tsx
@@ -223,7 +223,7 @@ describe('TeacherHomepage', () => {
 
     await screen.findByText('Picture password', {}, {timeout: 5000});
     screen.getByRole('button', {name: 'Cancel'});
-  }, 15000);
+  }, 25000);
 
   it('teaching/archived toggle', async () => {
     renderComponent();

--- a/apps/test/unit/templates/studioHomepages/teacherHomepageV2/TeacherHomepageTest.tsx
+++ b/apps/test/unit/templates/studioHomepages/teacherHomepageV2/TeacherHomepageTest.tsx
@@ -223,6 +223,7 @@ describe('TeacherHomepage', () => {
 
     await screen.findByText('Picture password', {}, {timeout: 5000});
     screen.getByRole('button', {name: 'Cancel'});
+    // This is a hail mary quick flakiness mitigation attempt. If we see continued failures, we should look for underlying causes.
   }, 25000);
 
   it('teaching/archived toggle', async () => {


### PR DESCRIPTION
Increasing timeout to decrease flakiness 🤞🏼 
```FAIL test/unit/templates/studioHomepages/teacherHomepageV2/TeacherHomepageTest.tsx (22.722 s)
  ● TeacherHomepage › teaching/archived toggle

    thrown: "Exceeded timeout of 5000 ms for a test.
    Add a timeout value to this test to increase the timeout, if this is a long-running test. See https://jestjs.io/docs/api#testname-fn-timeout."

      226 |   }, 15000);
      227 |
    > 228 |   it('teaching/archived toggle', async () => {
          |   ^
      229 |     renderComponent();
      230 |     await act(async () => await new Promise(process.nextTick));
      231 |     screen.getByRole('button', {name: 'Teaching'});

      at test/unit/templates/studioHomepages/teacherHomepageV2/TeacherHomepageTest.tsx:228:3
      at Object.<anonymous> (test/unit/templates/studioHomepages/teacherHomepageV2/TeacherHomepageTest.tsx:36:1)```
