### PR TITLE
Add teacher markdown to AI Chat levels

### DIFF
--- a/dashboard/app/views/levels/editors/_aichat.html.haml
+++ b/dashboard/app/views/levels/editors/_aichat.html.haml
@@ -1,4 +1,5 @@
 = render partial: 'levels/editors/fields/instructions_area', locals: {f: f}
+= render partial: 'levels/editors/fields/teacher_only_markdown', locals: {f: f}
 = render partial: 'levels/editors/fields/aichat_settings', locals: {f: f}
 = render partial: 'levels/editors/fields/starter_assets', locals: {f: f}
 = render partial: 'levels/editors/fields/special_level_types', locals: {f: f}


### PR DESCRIPTION
Adds the teacher markdown editor to AI Chat levels.

<img width="1016" height="458" alt="Screenshot 2026-03-17 at 10 59 22 AM" src="https://github.com/user-attachments/assets/bdf79eb9-fc36-48bf-a0a0-e0ae4ce4b6a5" />

<img width="471" height="776" alt="Screenshot 2026-03-17 at 10 58 41 AM" src="https://github.com/user-attachments/assets/37b13597-f3d6-4898-9ca7-866b6e3cee2a" />

## Testing story
Tested locally with allthethings level.