### PR TITLE
deflake policy compliance ui test

### DIFF
--- a/dashboard/test/ui/features/platform/policy_compliance/policy_compliance.feature
+++ b/dashboard/test/ui/features/platform/policy_compliance/policy_compliance.feature
@@ -72,7 +72,7 @@ Feature: Policy Compliance
 
     # Have the student pick a state (outside the policy region)
     Given I select the "Alabama" option in dropdown "user_us_state"
-    Then I click "#submit-update"
+    Then I click "#submit-update" to load a new page
     Then I wait until element "div#account-update-success" is visible
 
     # Right now, we have to assert that the experiment is active

--- a/dashboard/test/ui/features/platform/policy_compliance/policy_compliance.feature
+++ b/dashboard/test/ui/features/platform/policy_compliance/policy_compliance.feature
@@ -1,6 +1,5 @@
 @no_mobile
 Feature: Policy Compliance
-  @pegasus_content
   Scenario: New under 13 account should be able to elect to sign out at the lockout.
     Given I am on "http://studio.code.org"
     Given CPA all user lockout phase


### PR DESCRIPTION
This test has a 48% flakiness rate according to the DTT output ([slack](https://codedotorg.slack.com/archives/C03CM903Y/p1773760430326649)). 

Example failure:  
* https://cucumber-logs.s3.amazonaws.com/test/test/Safari_platform_policy_compliance_policy_compliance_output.html?versionId=CDMyJ_YRhSoRFYB0xLE9xgiBLq54f2.S
* https://app.saucelabs.com/tests/82480f3be312453cbfb369c494384a6a#70
* <img width="1270" height="635" alt="Screenshot 2026-03-17 at 11 06 12 AM" src="https://github.com/user-attachments/assets/2f4133dd-c347-4604-b068-f07736c885b8" />

## root cause + fix

the failing step cannot find jquery even though the step contains an explicit wait for jquery: https://github.com/code-dot-org/code-dot-org/blob/12dae6d2cc3a82bda03655ef7587b0e533e8e1d5/dashboard/test/ui/features/step_definitions/steps.rb#L313-L314 this suggests there is a race condition due to the previous step doing a page load. the saucelabs video confirms that the button click in the previous step does cause the page to reload. 

the fix is for the previous step to use the "to load a new page" option.

## Testing story
- drone is adequate coverage to make sure this test-only change hasn't completely broken anything
- we'll have to wait and see if the flakiness issue is resolved