### PR TITLE
Revert "Create an S3 StorageLens Dashboard for Student Project Buckets"

### DIFF
--- a/aws/cloudformation/data.yml.erb
+++ b/aws/cloudformation/data.yml.erb
@@ -338,42 +338,6 @@ Resources:
     Properties:
       AliasName: !Sub "alias/snapshot-${AWS::StackName}"
       TargetKeyId: !Ref DBSnapshotKey
-  # Monitor storage utilization and access patterns for Student Projects buckets to help reduce S3 costs and to aid in
-  # improving student projects backup strategy.
-  StudentProjectsStorageLensDashboard:
-    Type: AWS::S3::StorageLens
-    Properties:
-      StorageLensConfiguration:
-        Id: student-projects-dashboard
-        IsEnabled: true
-        AccountLevel:
-          ActivityMetrics:
-            IsEnabled: true
-          AdvancedCostOptimizationMetrics:
-            IsEnabled: true
-          BucketLevel:
-            ActivityMetrics:
-              IsEnabled: true
-            AdvancedCostOptimizationMetrics:
-              IsEnabled: true
-        Include:
-          Buckets:
-            - !Sub 'arn:aws:s3:::cdo-v3-sources'
-            - !Sub 'arn:aws:s3:::cdo-v3-files'
-            - !Sub 'arn:aws:s3:::cdo-v3-animations'
-            - !Sub 'arn:aws:s3:::cdo-v3-assets'
-            - !Sub 'arn:aws:s3:::cdo-v3-libraries'
-            - !Sub 'arn:aws:s3:::cdo-v3-trained-ml-models'
-            - !Sub 'arn:aws:s3:::cdo-art'
-        DataExport:
-          S3BucketDestination:
-            AccountId: !Ref 'AWS::AccountId'
-            Arn: !Sub 'arn:aws:s3:::cdo-logs'
-            Format: CSV
-            OutputSchemaVersion: V_1
-            Prefix: 'S3StorageLens/student-projects-metrics-export'
-          CloudWatchMetrics:
-            IsEnabled: true
 # ELB Access Logs tables defined in Glue Data Catalog.
   ELBLogsDatabase:
     Type: AWS::Glue::Database


### PR DESCRIPTION
Reverts code-dot-org/code-dot-org#64999

This StorageLens costs ~$1000/month. We have a year of data from it exported to: `s3://cdo-logs/S3StorageLens/student-projects-metrics-export/StorageLens/`

We can delete this reporting tool and still reference the data from it to decide how to optimize our S3 storage costs and how to backup critical student data.

# TEST

```bash
code-dot-org $ bundle exec rake stack:data:validate RAILS_ENV=production ADMIN=true

Finished stack:data:environment (less than a minute)
Pending update for stack `DATA-production`:
Remove StudentProjectsStorageLensDashboard [AWS::S3::StorageLens]
Finished stack:data:validate (less than a minute)
```