### PR TITLE
deflake iphone teacher tools callouts uitest

### DIFF
--- a/dashboard/test/ui/features/teacher_tools/callouts.feature
+++ b/dashboard/test/ui/features/teacher_tools/callouts.feature
@@ -19,7 +19,6 @@ Feature: Callouts
     | http://studio.code.org/hoc/1?noautoplay=true                                                                  | 0          | Drag a "move" block and snap it below the other block                                                   | [data-id='moveForward']    |
     | http://studio.code.org/hoc/9?noautoplay=true                                                                  | 0          | Blocks that are grey can't be deleted. Can you solve the puzzle anyway?                                 | g                 |
     | http://studio.code.org/hoc/14?noautoplay=true                                                                 | 0          | Click here to see the code for the program you're making                                                | #show-code-header |
-    | http://studio.code.org/courses/allthethingscourse/units/1/lessons/3/levels/7?noautoplay=true&show_callouts=1  | 0          | You have all the same blocks but they've now been arranged in categories                                | .blocklyToolboxCategoryGroup |
 
   # See #101702822. "Watch video" section inaccessible from iPhone.
   @no_mobile
@@ -32,8 +31,9 @@ Feature: Callouts
     And I close callout "<callout_id>"
     And callout "<callout_id>" is hidden
   Examples:
-    | url                                                                                | callout_id | text                                                                             | close_target           |
-    | http://studio.code.org/hoc/6?noautoplay=true                                       | 0          | Click here to watch the video again                                              | #thumbnail_mgooqyWMTxk |
+    | url                                                                                                           | callout_id | text                                                                             | close_target           |
+    | http://studio.code.org/hoc/6?noautoplay=true                                                                  | 0          | Click here to watch the video again                                              | #thumbnail_mgooqyWMTxk |
+    | http://studio.code.org/courses/allthethingscourse/units/1/lessons/3/levels/7?noautoplay=true&show_callouts=1  | 0          | You have all the same blocks but they've now been arranged in categories                                | .blocklyToolboxCategoryGroup |
 
   Scenario: Modal ordering
     Given I am on "http://studio.code.org/courses/allthethingscourse/units/1/lessons/2/levels/7?noautoplay=true&show_callouts=1"


### PR DESCRIPTION
`iPhone_teacher_tools_callouts ` has a failure rate of 32% during DTT. in each of the past 5 failure logs, the test fails during the final example of the scenario (see [example](https://cucumber-logs.s3.amazonaws.com/test/test/iPhone_teacher_tools_callouts_output.html?versionId=tuBJAR7esBbDV0BODXTzhzE7HNuBrnDN)). when I try to repro locally by loading that page using device emulator button in chrome devtools, I see that callouts do not appear at all on small screens.

the solution I'm proposing is to skip the problem example on mobile.

## Testing story
- passing drone run shows that I'm not completely breaking the test in Chrome
- because the problem example is now getting skipped in iPhone, this seems like a strong indicator that the fix will be successful at deflaking
