### PR TITLE
[All Labs] Fixing images crop for bubble choice levels

### DIFF
--- a/apps/src/bubbleChoice/BubbleChoice.module.scss
+++ b/apps/src/bubbleChoice/BubbleChoice.module.scss
@@ -68,8 +68,9 @@
           position: relative;
 
           .sublevelImage {
-            width: 800px;
-            object-fit: contain;
+            width: 100%;
+            height: 100%;
+            object-fit: cover;
             opacity: 1;
           }
 


### PR DESCRIPTION
The old school bubble choice levels didn't have a consistent image crop the way the new bubble choice levels do. This update makes the images fit the container, and zooms them to fit for a consistent aspect ratio.


Before:
<img width="1109" height="872" alt="Screenshot 2026-03-17 at 12 25 06 PM" src="https://github.com/user-attachments/assets/4e9499b8-950a-45ca-bf9b-24acb45ac2f7" />



After:
<img width="1109" height="850" alt="Screenshot 2026-03-17 at 12 31 43 PM" src="https://github.com/user-attachments/assets/1efaf974-8b3d-4f7b-bbf7-68c33bbaa048" />



## Links

- Jira: https://codedotorg.atlassian.net/browse/AFL-489

## Testing story
<!-- How was this tested? Manual steps, adhoc links, automated tests, or why testing isn't needed. -->



## Deployment notes
<!-- Delete this section if it's a standard merge-and-deploy.
     Otherwise: migrations, feature flags, coordination, caching impacts, etc. -->



## Privacy and security
<!-- Delete this section if there is no privacy/security impact.
     Otherwise: new PII, auth changes, API surface changes, etc. -->

