### PR TITLE
[All Labs] Remove additional margin for predict questions

### DIFF
--- a/apps/src/lab2/views/components/Instructions/instructions.module.scss
+++ b/apps/src/lab2/views/components/Instructions/instructions.module.scss
@@ -271,7 +271,6 @@
 
 .predictQuestion {
   width: auto;
-  margin: 4px;
 }
 
 .button {


### PR DESCRIPTION
This makes the margins/padding consistent in the instructions panel instead of indenting predict questions.

Before:
<img width="634" height="845" alt="Screenshot 2026-03-17 at 12 44 17 PM" src="https://github.com/user-attachments/assets/f6f59b7c-56c6-4ab7-a6ed-75d89352256f" />


After:
<img width="582" height="772" alt="Screenshot 2026-03-17 at 12 44 23 PM" src="https://github.com/user-attachments/assets/ff1f4386-2f08-4c1c-b6c5-b76c34c82ef6" />




## Links

- Jira: https://codedotorg.atlassian.net/browse/AFL-496

## Testing story
<!-- How was this tested? Manual steps, adhoc links, automated tests, or why testing isn't needed. -->



## Deployment notes
<!-- Delete this section if it's a standard merge-and-deploy.
     Otherwise: migrations, feature flags, coordination, caching impacts, etc. -->



## Privacy and security
<!-- Delete this section if there is no privacy/security impact.
     Otherwise: new PII, auth changes, API surface changes, etc. -->

