### PR TITLE
Uninstall `pegasus` Service from Existing EC2 Instances

### DIFF
--- a/cookbooks/cdo-apps/recipes/pegasus.rb
+++ b/cookbooks/cdo-apps/recipes/pegasus.rb
@@ -1,2 +1,49 @@
-Chef::Recipe.include CdoApps
-setup_app 'pegasus'
+# Cookbook Name:: cdo-apps
+# Recipe:: pegasus
+#
+# Teardown: Remove the Pegasus service from instances where it was previously installed by undoing resources provisioned
+# by `CdoApps`. Safe to run on instances that never had it (guards ensure no-ops). Once this change has been deployed to
+# all long-running instances (staging, test, levelbuilder, production), this recipe and its inclusion in default.rb can
+# be deleted.
+
+app_name = 'pegasus'
+home = node[:home]
+root = File.join(home, node.chef_environment)
+app_root = File.join(root, app_name)
+unit_file = "/lib/systemd/system/#{app_name}.service"
+
+# Stop and disable the Pegasus service.
+service app_name do
+  action [:stop, :disable]
+  only_if {File.exist?(unit_file)}
+end
+
+# Remove the Pegasus unit file and reload systemd.
+file unit_file do
+  action :delete
+  notifies :run, 'execute[systemctl daemon-reload]', :immediately
+end
+
+execute 'systemctl daemon-reload' do
+  action :nothing
+end
+
+# Remove the Pegasus logrotate configuration.
+file "/etc/logrotate.d/#{app_name}" do
+  action :delete
+end
+
+# Remove Chef cache markers that trigger setup/restart.
+file "#{Chef::Config[:file_cache_path]}/#{app_name}_setup" do
+  action :delete
+end
+
+file "#{Chef::Config[:file_cache_path]}/#{app_name}_listeners" do
+  action :delete
+end
+
+# Remove Pegasus NewRelic configuration, if it exists.
+file "#{app_root}/config/newrelic.yml" do
+  action :delete
+  only_if {File.exist?("#{app_root}/config/newrelic.yml")}
+end

--- a/cookbooks/cdo-apps/recipes/stop.rb
+++ b/cookbooks/cdo-apps/recipes/stop.rb
@@ -4,7 +4,7 @@
 ruby_block 'stop services' do
   block {}
 
-  services = %w(pegasus dashboard nginx)
+  services = %w(dashboard nginx)
   actions = %i(stop disable)
 
   services.each do |service|

--- a/cookbooks/cdo-nginx/recipes/default.rb
+++ b/cookbooks/cdo-nginx/recipes/default.rb
@@ -10,7 +10,7 @@ end
 
 apt_package 'nginx'
 
-%w(dashboard pegasus).each do |app|
+%w(dashboard).each do |app|
   socket_path = File.join node['cdo-nginx']['socket_path'], "#{app}.sock"
   # Ensure stale socket-files are cleaned up
   # (in case OS doesn't automatically remove them, e.g., due to an aborted process)
@@ -53,7 +53,7 @@ service 'nginx' do
   action [:enable, :start]
 
   # Ensure app services are updated to their current listener configuration before (re)starting nginx.
-  %w(pegasus dashboard).each do |app|
+  %w(dashboard).each do |app|
     notifies :create, "file[#{app}_listeners]", :before
   end
 

--- a/lib/rake/build.rake
+++ b/lib/rake/build.rake
@@ -207,9 +207,6 @@ namespace :build do
           raise exception
         end
       end
-
-      ChatClient.log 'Restarting <b>pegasus</b> web server.'
-      RakeUtils.restart_service CDO.pegasus_web_server_name unless rack_env?(:development)
     end
   end
 


### PR DESCRIPTION
Stop and uninstall pegasus service from existing long running EC2 Instances. We've already configured nginx to stop routing HTTP requests to the Pegasus service #71284, and we've scaled down the Pegasus service to 2 child puma processes in #71427 so that dashboard can use most of the CPU and memory.

## Testing story

- [x] 1. Provision an adhoc on a test branch off of the main staging branch: `adhoc-test-remove-pegasus`
- [x] 2. Merge this feature branch into the test branch so that `aws/ci_build` pulls the new cookbook source code (unfortunately, it does not run it, but it does copy the new cookbooks to `/var/chef`
- [x] 3. Execute chef client: `sudo -u ubuntu bash -c "sudo /usr/local/bin/chef-cdo-app"` the way UserData does.
- [x] 4. Confirm Chef removed Pegasus service by inspecting `/var/log/chef-bookstrap-debug.log` :
```
Recipe: cdo-apps::pegasus
  * service[pegasus] action stop
    - stop service service[pegasus]
  * service[pegasus] action disable (up to date)
  * file[/lib/systemd/system/pegasus.service] action delete
    - delete file /lib/systemd/system/pegasus.service
  * execute[systemctl daemon-reload] action run
    - execute systemctl daemon-reload
  * execute[systemctl daemon-reload] action nothing (skipped due to action :nothing)
  * file[/etc/logrotate.d/pegasus] action delete
    - delete file /etc/logrotate.d/pegasus
  * file[/etc/chef/local-mode-cache/cache/pegasus_setup] action delete
    - delete file /etc/chef/local-mode-cache/cache/pegasus_setup
  * file[/etc/chef/local-mode-cache/cache/pegasus_listeners] action delete
    - delete file /etc/chef/local-mode-cache/cache/pegasus_listeners
  * file[/home/ubuntu/adhoc/pegasus/config/newrelic.yml] action delete (skipped due to only_if)
 ```
- [x] 5. Confirm there isn't a `pegasus` service anymore:
```bash
$  systemctl cat pegasus
No files found for pegasus.service.
$  systemctl list-unit-files --type=service | grep pegasus

```
- [x] 5. Re-run the build (`bin/start-build`) to ensure it doesn't try to restart the pegasus service.

## Deployment notes
<!-- Delete this section if it's a standard merge-and-deploy.
     Otherwise: migrations, feature flags, coordination, caching impacts, etc. -->



## Privacy and security
<!-- Delete this section if there is no privacy/security impact.
     Otherwise: new PII, auth changes, API surface changes, etc. -->

