### PR TITLE
Deflake test_log_repeat_flushes in BufferTest

### DIFF
--- a/lib/cdo/buffer.rb
+++ b/lib/cdo/buffer.rb
@@ -33,9 +33,10 @@ module Cdo
       @max_interval = max_interval
       @min_interval = min_interval
       @log = log
+      @flushing = false
 
       @task = RescheduledTask.new(0.0) {flush_batch}.
-        with_observer {schedule_flush}
+        with_observer {schedule_flush unless @flushing}
 
       @buffer = []
       @buffer.extend(MonitorMixin)
@@ -78,6 +79,7 @@ module Cdo
     # @param [Float] timeout seconds to wait for buffered objects to finish flushing.
     def flush!(timeout = Float::INFINITY)
       reset_if_forked
+      @flushing = true
       timeout_at = now + timeout
       until (wait = timeout_at - now) < 0 || @buffer.empty?
         @log.debug "Flushing #{self.class}, waiting #{wait} seconds"
@@ -85,6 +87,9 @@ module Cdo
         # Block until the pending flush is completed or timeout is reached.
         @task.wait(wait.infinite? ? nil : wait)
       end
+    ensure
+      @flushing = false
+      schedule_flush unless @buffer.empty?
     end
 
     # Extend ScheduledTask to support rescheduling after being executed.


### PR DESCRIPTION

# TODO(dave): validate
* what unit test would confirm the existence of the original issue and the fix?

## Background

the following test has flaky failures in drone: https://drone.cdn-code.org/code-dot-org/code-dot-org/50594/1/5
```
  BufferTest                                                                                                                         
    test_max_interval                                               PASS (0.20s)                                                     
    test_batch_size_given_small_data_should_succeed                 PASS (0.00s)                                                     
    test_log_repeat_flushes                                         FAIL (0.10s)                                                     
  Minitest::Assertion:         Expected /(Flushing BufferTest.*){10}/m to match "D, [2026-03-16T23:22:42.103664 #45495] DEBUG -- :   
  Flushing BufferTest::ReBuffer, waiting 0.09999938100008876 seconds\nD, [2026-03-16T23:22:42.104148 #45495] DEBUG -- : Flushing     
  BufferTest::ReBuffer, waiting 0.09951060599996708 seconds\n".                                                                      
          /drone/src/lib/test/cdo/test_buffer.rb:120:in `test_log_repeat_flushes'
```

## AI analysis + fix

Root cause: A race condition in `flush!` where the worker thread completed a task cycle (set event → observer reschedules → reset event, increment `@iteration`) entirely before the main thread entered `event.wait`. The Event's `@iteration` counter only protects against set+reset happening while already waiting, not before. So the main thread entered `event.wait` with iteration = N+1 (post-reset) and blocked for the full remaining timeout.                                                                                                
                                                                                                                                         
  Fix (lib/cdo/buffer.rb, 5 lines):

  1. Added `@flushing = false` flag in `initialize`
  2. Observer now skips rescheduling when `flush!` is running: `{schedule_flush unless @flushing}`
  3. `flush!` sets `@flushing = true` on entry, and ensure clears it and restarts scheduling if items remain

  When `@flushing` is true, the task completes and stays in `:fulfilled` state with the event set. `@task.wait` sees `incomplete? == false` and returns immediately (skipping `event.wait` entirely — see Obligation#wait line 75), eliminating the race. The ensure block resets the flag and hands scheduling back to the normal observer-driven mechanism.