### PR TITLE
Aichat: Fix bug where ChatWorkspace doesn't render for teachers sometimes

### DIFF
--- a/apps/src/aichat/views/AichatView.tsx
+++ b/apps/src/aichat/views/AichatView.tsx
@@ -11,11 +11,9 @@ import {queryParams} from '@cdo/apps/code-studio/utils';
 import FlowLab from '@cdo/apps/flowlab/views/flow/FlowLab';
 import {PERMISSIONS} from '@cdo/apps/lab2/constants';
 import {useLevelActivityMetrics} from '@cdo/apps/lab2/hooks/useLevelActivityMetrics';
-import useLifecycleNotifier from '@cdo/apps/lab2/hooks/useLifecycleNotifier';
 import Lab2Registry from '@cdo/apps/lab2/Lab2Registry';
 import {isProjectTemplateLevel} from '@cdo/apps/lab2/redux/lab2ReduxSelectors';
 import {LabProps} from '@cdo/apps/lab2/types';
-import {LifecycleEvent} from '@cdo/apps/lab2/utils';
 import TeacherViewingStudentProjectAlert from '@cdo/apps/lab2/views/alerts/teacherViewingStudentProject';
 import IconButtonWithTooltip from '@cdo/apps/lab2/views/components/IconButtonWithTooltip';
 import ResourcePanel from '@cdo/apps/lab2/views/components/Instructions/ResourcePanel';
@@ -192,6 +190,10 @@ const AichatView: React.FunctionComponent<LabProps<AichatLevelProperties>> = ({
     dispatch(setShowModalType(modalToShow()));
   }, [isUserTeacher, dispatch]);
 
+  useEffect(() => {
+    dispatch(clearHasSetInitialCustomizations());
+  }, [dispatch, currentLevelId]);
+
   const onCloseModal = useCallback(() => {
     // We only want to show the teacher onboarding modal the first time a teacher user
     // interacts with the aichat tool. Thus, we store a value in local storage when
@@ -283,10 +285,6 @@ const AichatView: React.FunctionComponent<LabProps<AichatLevelProperties>> = ({
       });
     }
   }, [dialogControl, resetProject]);
-
-  useLifecycleNotifier(LifecycleEvent.LevelLoadStarted, () => {
-    dispatch(clearHasSetInitialCustomizations());
-  });
 
   // Only recreate modelParameters when relevant customizations are updated.
   const modelParameters: ModelParameters = useMemo(() => {

--- a/apps/src/aichat/views/AichatView.tsx
+++ b/apps/src/aichat/views/AichatView.tsx
@@ -138,6 +138,10 @@ const AichatView: React.FunctionComponent<LabProps<AichatLevelProperties>> = ({
   }, [currentLevelId, scriptId, channelId]);
 
   useEffect(() => {
+    dispatch(clearHasSetInitialCustomizations());
+  }, [dispatch, currentLevelId]);
+
+  useEffect(() => {
     const studentAiCustomizations = JSON.parse(
       (initialSources?.source as string) || '{}'
     );
@@ -189,10 +193,6 @@ const AichatView: React.FunctionComponent<LabProps<AichatLevelProperties>> = ({
 
     dispatch(setShowModalType(modalToShow()));
   }, [isUserTeacher, dispatch]);
-
-  useEffect(() => {
-    dispatch(clearHasSetInitialCustomizations());
-  }, [dispatch, currentLevelId]);
 
   const onCloseModal = useCallback(() => {
     // We only want to show the teacher onboarding modal the first time a teacher user


### PR DESCRIPTION
If a teacher switches between users that have the same `initialCustomizations` on the level, the ChatWorkspace will not mount on level load.  This is because `hasSetInitialCustomizations` was being cleared on the LoadLevel lifecycle event, which happens when you change levels OR when you change students in the teacher panel, while it was only being set in `initializeAiCustomizations` in a useEffect with `initialSources, levelAichatSettings` as dependencies. As a result, if these dependencies didn't change between users, `hasSetInitialCustomizations` was stuck false and caused `ChatWorkspace` not to mount.

The fix is to use a useEffect with currentLevelId as dependency rather than LifecycleEvent.LevelLoadStarted to clearHasSetInitialCustomizations. 

Before:

https://github.com/user-attachments/assets/abca1500-bb39-4f14-b8ed-4bca91dad8a3

After:

https://github.com/user-attachments/assets/45ebc3b5-d5ac-4be5-9493-477eaf61da49


## Testing story
<!-- How was this tested? Manual steps, adhoc links, automated tests, or why testing isn't needed. -->

Tested locally changing between aichat levels and between users in the teacher panel

