### PR TITLE
Make EmptyStudentChatHistory string generic between aichat clients

### DIFF
--- a/apps/src/aichat/views/EmptyStudentChatHistory.tsx
+++ b/apps/src/aichat/views/EmptyStudentChatHistory.tsx
@@ -15,7 +15,7 @@ const EmptyStudentChatHistory: React.FunctionComponent = () => {
           <strong>No activity to show</strong>
         </Typography>
         <Typography variant="body4">
-          There were no interactions with AI Tutor on this level.
+          There have been no chat interactions on this level.
         </Typography>
       </div>
     </div>


### PR DESCRIPTION
<!--
  Summary of the change: background, motivation, and context.
  Include screenshots, videos, or before/after comparisons for UI changes.
-->

String for this component was worded for AI Tutor but it shows in both chat lab and tutor, so I made it generic for either!


## Testing story
<!-- How was this tested? Manual steps, adhoc links, automated tests, or why testing isn't needed. -->

before:
<img width="500" height="521" alt="image" src="https://github.com/user-attachments/assets/92139b61-a4ba-47ba-ad53-9ec1584db4b3" />


after:
<img width="502" height="526" alt="image" src="https://github.com/user-attachments/assets/c2fcde05-49eb-4748-b617-ec9291c4903b" />



