### PR TITLE
🧹 Remove Radium from `ToggleButton`

### DIFF
--- a/apps/src/templates/ToggleButton.jsx
+++ b/apps/src/templates/ToggleButton.jsx
@@ -25,6 +25,7 @@ class ToggleButton extends Component {
         type="button"
         role="tab"
         aria-selected={String(this.props.active)}
+        tabIndex={this.props.active ? 0 : -1}
         id={this.props.id}
         style={this.getStyle()}
         className={this.props.className || ''}

--- a/apps/src/templates/ToggleButton.jsx
+++ b/apps/src/templates/ToggleButton.jsx
@@ -1,6 +1,5 @@
 /** @file Button that can be active or inactive, for use inside ToggleGroup */
 import PropTypes from 'prop-types';
-import Radium from 'radium'; // eslint-disable-line no-restricted-imports
 import React, {Component} from 'react';
 
 import styles from './ToggleButtonStyles';
@@ -58,4 +57,4 @@ class ToggleButton extends Component {
   }
 }
 
-export default Radium(ToggleButton);
+export default ToggleButton;

--- a/apps/src/templates/ToggleButtonStyles.js
+++ b/apps/src/templates/ToggleButtonStyles.js
@@ -50,10 +50,4 @@ module.exports = {
     color: color.light_black,
     boxShadow: '0px 1px 5px ' + color.shadow,
   },
-  hiddenStyle: {
-    display: 'none',
-  },
-  iconStyle: {
-    margin: '0 0.3em',
-  },
 };

--- a/apps/src/templates/ToggleButtonStyles.js
+++ b/apps/src/templates/ToggleButtonStyles.js
@@ -17,7 +17,7 @@ module.exports = {
     fontSize: 14,
   },
   toggleButtonStyle: {
-    borderRightWidth: '0 !important',
+    borderRightWidth: 0,
     borderTopLeftRadius: 0,
     borderTopRightRadius: 0,
     borderBottomRightRadius: 0,
@@ -28,7 +28,7 @@ module.exports = {
     borderTopLeftRadius: 4,
   },
   lastButtonStyle: {
-    borderRightWidth: '1px !important',
+    borderRightWidth: 1,
     borderBottomRightRadius: 4,
     borderTopRightRadius: 4,
   },

--- a/dashboard/db/migrate/20240806035905_rename_cap_columns_in_users.rb
+++ b/dashboard/db/migrate/20240806035905_rename_cap_columns_in_users.rb
@@ -1,0 +1,6 @@
+class RenameCAPColumnsInUsers < ActiveRecord::Migration[6.1]
+  def change
+    rename_column :users, :cap_state, :cap_status
+    rename_column :users, :cap_state_date, :cap_status_date
+  end
+end

--- a/dashboard/db/migrate/20240806035905_rename_cap_columns_in_users.rb
+++ b/dashboard/db/migrate/20240806035905_rename_cap_columns_in_users.rb
@@ -1,6 +1,0 @@
-class RenameCAPColumnsInUsers < ActiveRecord::Migration[6.1]
-  def change
-    rename_column :users, :cap_state, :cap_status
-    rename_column :users, :cap_state_date, :cap_status_date
-  end
-end


### PR DESCRIPTION
`ToggleButton` is a legacy component that is rendered in `ToggleGroup`. This removes the deprecated style package, Radium. 

### Testing
Here are the pre and post Radium refactor side-by-sides for the components`ToggleGroup` is rendered in: 

**applab/PlaySpaceHeader.jsx**
<img width="1539" height="132" alt="Screenshot 2026-03-17 at 8 28 29 PM" src="https://github.com/user-attachments/assets/112b4f0c-eeb9-4332-848c-4ed9c4e32929" />

**p5lab/P5LabVisualizationHeader.jsx**
<img width="1604" height="188" alt="Screenshot 2026-03-17 at 8 31 07 PM" src="https://github.com/user-attachments/assets/2a37a10d-5628-496e-b22a-e07248497d96" />

**levelbuilder/lesson-editor/AddLevelDialogTop.jsx**
<img width="1469" height="320" alt="Screenshot 2026-03-17 at 8 37 44 PM" src="https://github.com/user-attachments/assets/a22a9f51-8091-473c-bf80-a68226098a74" />
<img width="1461" height="278" alt="Screenshot 2026-03-17 at 8 37 17 PM" src="https://github.com/user-attachments/assets/468ccf83-c9f0-466c-95c0-481773850bda" />

**code-studio/components/progress/ViewAsToggle.jsx**
<img width="1454" height="285" alt="Screenshot 2026-03-17 at 8 41 13 PM" src="https://github.com/user-attachments/assets/85af4b29-2a6b-4df0-a3a5-b4d3235789ad" />

**publicKeyCryptography/PublicKeyCryptographyWidget.jsx**
<img width="1666" height="175" alt="Screenshot 2026-03-17 at 8 21 42 PM" src="https://github.com/user-attachments/assets/55cf2bb5-6ce2-4448-b9de-8ec41c375e46" />

**code-studio/pd/foorm/editor/components/FoormEntityEditorHeader.jsx**
<img width="1627" height="378" alt="Screenshot 2026-03-17 at 8 55 47 PM" src="https://github.com/user-attachments/assets/3805f078-5a2c-425e-8729-95631da78152" />

**templates/progress/ProgressDetailToggle.jsx**
Deprecated, but not yet fully deleted, in favor of Progress V2

### Deployment 
I can't discern a noticeable difference in the Radium v. non Radium toggles, but there might be subtle eyes differences that should be ok to accept. 

### Future work 
If we were to upgrade these to a newer component, I think we'd use `SegmentedButton`. 
