### PR TITLE
Fix AFE "Learn More" link

### DIFF
--- a/apps/src/templates/studioHomepages/teacherHomepageV2/TeacherHomepageDrawer.tsx
+++ b/apps/src/templates/studioHomepages/teacherHomepageV2/TeacherHomepageDrawer.tsx
@@ -196,7 +196,9 @@ export const TeacherHomepageDrawer: React.FC<TeacherHomepageDrawerProps> = ({
           color="primary"
           size="medium"
           onClick={handlePrimaryButtonClick}
-          type="button"
+          href={pegasus('/resources/amazon-future-engineer#eligibility')}
+          target="_blank"
+          rel="noopener noreferrer"
           endIcon={<FontAwesomeV6Icon iconName="up-right-from-square" />}
         >
           {i18n.learnMore()}
@@ -323,11 +325,6 @@ export const TeacherHomepageDrawer: React.FC<TeacherHomepageDrawerProps> = ({
           'Content-Type': 'application/json',
         }
       ).catch(error => console.error(error));
-
-      // redirect to form on amazon-future-engineer page if user accepted
-      if (afeParticipate) {
-        window.location.assign(pegasus('/amazon-future-engineer#eligibility'));
-      }
     }
     setSchoolInfoInterstitialOpen(false);
     setSchoolInfoConfirmationOpen(false);

--- a/apps/src/templates/studioHomepages/teacherHomepageV2/TeacherHomepageDrawer.tsx
+++ b/apps/src/templates/studioHomepages/teacherHomepageV2/TeacherHomepageDrawer.tsx
@@ -51,7 +51,6 @@ export const TeacherHomepageDrawer: React.FC<TeacherHomepageDrawerProps> = ({
     React.useState(false);
   const [success, setSuccess] = React.useState(false);
   const [AFEDrawerOpen, setAFEDrawerOpen] = React.useState(afeOpenInitially);
-  const [AFEParticipate, setAFEParticipate] = React.useState(false);
   const [NPSOpen, setNPSOpen] = React.useState(npsOpenInitially);
   const [NPSSuccess, setNPSSuccess] = React.useState(false);
 
@@ -213,7 +212,7 @@ export const TeacherHomepageDrawer: React.FC<TeacherHomepageDrawerProps> = ({
           variant="outlined"
           color="tertiary"
           size="medium"
-          onClick={onDrawerClose}
+          onClick={() => onDrawerClose()}
           type="button"
         >
           {i18n.imStillTeachingHere()}
@@ -227,7 +226,7 @@ export const TeacherHomepageDrawer: React.FC<TeacherHomepageDrawerProps> = ({
           variant="outlined"
           color="tertiary"
           size="medium"
-          onClick={onDrawerClose}
+          onClick={() => onDrawerClose()}
           type="button"
         >
           {i18n.notInterested()}
@@ -239,7 +238,7 @@ export const TeacherHomepageDrawer: React.FC<TeacherHomepageDrawerProps> = ({
           variant="outlined"
           color="tertiary"
           size="medium"
-          onClick={onDrawerClose}
+          onClick={() => onDrawerClose()}
           type="button"
         >
           {i18n.dismiss()}
@@ -301,12 +300,11 @@ export const TeacherHomepageDrawer: React.FC<TeacherHomepageDrawerProps> = ({
     } else if (AFEDrawerOpen) {
       analyticsReporter.sendEvent(EVENTS.AFE_HOMEPAGE_BANNER_SUBMIT, {});
 
-      setAFEParticipate(true);
-      onDrawerClose();
+      onDrawerClose(true);
     }
   };
 
-  const onDrawerClose = () => {
+  const onDrawerClose = (participate: boolean = false) => {
     if (schoolInfoInterstitialOpen) {
       analyticsReporter.sendEvent(EVENTS.SCHOOL_INTERSTITIAL_DISMISS, {});
     } else if (schoolInfoConfirmationOpen) {
@@ -317,7 +315,7 @@ export const TeacherHomepageDrawer: React.FC<TeacherHomepageDrawerProps> = ({
       HttpClient.post(
         '/dashboardapi/v1/users/me/dismiss_donor_teacher_banner',
         JSON.stringify({
-          participate: AFEParticipate,
+          participate: participate,
           source: 'teacher_home',
         }),
         true,
@@ -327,7 +325,7 @@ export const TeacherHomepageDrawer: React.FC<TeacherHomepageDrawerProps> = ({
       ).catch(error => console.error(error));
 
       // redirect to form on amazon-future-engineer page if user accepted
-      if (AFEParticipate) {
+      if (participate) {
         window.location.assign(pegasus('/amazon-future-engineer#eligibility'));
       }
     }
@@ -350,7 +348,7 @@ export const TeacherHomepageDrawer: React.FC<TeacherHomepageDrawerProps> = ({
       <div id={'ui-test-drawer-toolbar'} className={styles.toolbar}>
         <CloseButton
           aria-label={'close button'}
-          onClick={onDrawerClose}
+          onClick={() => onDrawerClose()}
           color={'light'}
           size="l"
           className={''}

--- a/apps/src/templates/studioHomepages/teacherHomepageV2/TeacherHomepageDrawer.tsx
+++ b/apps/src/templates/studioHomepages/teacherHomepageV2/TeacherHomepageDrawer.tsx
@@ -304,7 +304,7 @@ export const TeacherHomepageDrawer: React.FC<TeacherHomepageDrawerProps> = ({
     }
   };
 
-  const onDrawerClose = (participate: boolean = false) => {
+  const onDrawerClose = (afeParticipate: boolean = false) => {
     if (schoolInfoInterstitialOpen) {
       analyticsReporter.sendEvent(EVENTS.SCHOOL_INTERSTITIAL_DISMISS, {});
     } else if (schoolInfoConfirmationOpen) {
@@ -315,7 +315,7 @@ export const TeacherHomepageDrawer: React.FC<TeacherHomepageDrawerProps> = ({
       HttpClient.post(
         '/dashboardapi/v1/users/me/dismiss_donor_teacher_banner',
         JSON.stringify({
-          participate: participate,
+          participate: afeParticipate,
           source: 'teacher_home',
         }),
         true,
@@ -325,7 +325,7 @@ export const TeacherHomepageDrawer: React.FC<TeacherHomepageDrawerProps> = ({
       ).catch(error => console.error(error));
 
       // redirect to form on amazon-future-engineer page if user accepted
-      if (participate) {
+      if (afeParticipate) {
         window.location.assign(pegasus('/amazon-future-engineer#eligibility'));
       }
     }


### PR DESCRIPTION
I was looking into some AFE metrics and noticed that the "Learn More" button on the AFE banner didn't seem to do anything. I added logging and `AFEParticipate` was not evaluating to true in the `onDrawerClose` method. Claude pointed out that this is likely because the state was stale when we hit that method. Given we don't use `AFEParticipate` elsewhere, I took its suggestion to remove that state and pass it through as a parameter.

While I was here, I also turned it into a link instead of a button.

The drawer looks the same:

<img width="1902" height="908" alt="image" src="https://github.com/user-attachments/assets/472012a0-3711-425d-b30b-ce3878a6b470" />



Claude's Plan for updating AFEParticipate: https://gist.github.com/bethanyaconnor/cc1fec012592226f1626b265bee6056a
Claude's Plan for updating to a link: https://gist.github.com/bethanyaconnor/ada7bcbfd07f33926a08c47acd05e32d

(Side note: this was totally overkill for Claude. But I'm trying to practice using Claude for coding tasks and I don't know this code very well.)



