### PR TITLE
k8s: set pod cpu/ram limits based on dashboard_worker

### DIFF
--- a/k8s/helm/Chart.yaml
+++ b/k8s/helm/Chart.yaml
@@ -4,4 +4,4 @@ description: Helm chart for the code-dot-org dashboard
 type: application
 
 # Chart version, increment when changing helm templates, follow semver
-version: 0.1.1
+version: 0.1.2

--- a/k8s/helm/adhoc.values.yaml
+++ b/k8s/helm/adhoc.values.yaml
@@ -1,0 +1,4 @@
+RAILS_ENV: adhoc
+dashboard_workers: 5
+healthChecks:
+  enabled: true

--- a/k8s/helm/development.values.yaml
+++ b/k8s/helm/development.values.yaml
@@ -1,4 +1,5 @@
 RAILS_ENV: development
+dashboard_workers: 0
 healthChecks:
   # Disable this if you want pods to start even if they fail an HTTP health check
   # can be useful for inspecting what's going wrong.

--- a/k8s/helm/levelbuilder.values.yaml
+++ b/k8s/helm/levelbuilder.values.yaml
@@ -1,0 +1,4 @@
+RAILS_ENV: levelbuilder
+dashboard_workers: 27
+healthChecks:
+  enabled: true

--- a/k8s/helm/production.values.yaml
+++ b/k8s/helm/production.values.yaml
@@ -1,4 +1,5 @@
 RAILS_ENV: production
+dashboard_workers: 32
 autoscaling:
   enabled: true
   minReplicas: 1

--- a/k8s/helm/staging.values.yaml
+++ b/k8s/helm/staging.values.yaml
@@ -1,0 +1,4 @@
+RAILS_ENV: staging
+dashboard_workers: 10
+healthChecks:
+  enabled: true

--- a/k8s/helm/templates/dashboard/_dashboard.yaml
+++ b/k8s/helm/templates/dashboard/_dashboard.yaml
@@ -8,6 +8,21 @@
 {{- $isDeployment := eq (.kind | default "Deployment") "Deployment" }}
 {{- $isJob := eq (.kind | default "Deployment") "Job" }}
 
+# Calculate CPU and memory limits from the original environment sizing table.
+# Weighted across all environments, floored to 2 decimal places:
+# - 808 GiB / 139 workers = 5.81 GiB per worker
+# - 208 CPU / 139 workers = 1.49 CPU per worker
+# Lowest limits we'll set: 4 CPU and 16 GiB RAM.
+{{- $dashboardWorkers := int (default 0 .Values.dashboard_workers) }}
+{{- $memoryLimitGi := mulf $dashboardWorkers 5.81 }}
+{{- if lt $memoryLimitGi 16.0 }}
+{{- $memoryLimitGi = 16.0 }}
+{{- end }}
+{{- $cpuLimit := mulf $dashboardWorkers 1.49 }}
+{{- if lt $cpuLimit 4.0 }}
+{{- $cpuLimit = 4.0 }}
+{{- end }}
+
 apiVersion: {{ .apiVersion | default "apps/v1" }}
 kind: {{ .kind | default "Deployment" }}
 metadata:
@@ -79,6 +94,10 @@ spec:
           allowPrivilegeEscalation: {{ if .Values.user.allowSudo }}true{{ else }}false{{ end }}
 
         {{- if $isDeployment }}
+        resources:
+          limits:
+            cpu: {{ $cpuLimit }}
+            memory: {{ printf "%.2fGi" $memoryLimitGi }}
         ports:
         - name: http
           containerPort: 3000

--- a/k8s/helm/templates/locals.yml.yaml
+++ b/k8s/helm/templates/locals.yml.yaml
@@ -8,6 +8,7 @@ data:
   locals.yml: |
     build_apps: true
     use_my_apps: true
+    dashboard_workers: {{ .Values.dashboard_workers }}
 
     # FIXME: once mountDotAWS is reliable, we should uncomment this conditional
     # {{- if not .Values.localDev.mounts.mountDotAWS }}

--- a/k8s/helm/test.values.yaml
+++ b/k8s/helm/test.values.yaml
@@ -1,4 +1,4 @@
 RAILS_ENV: test
+dashboard_workers: 65
 healthChecks:
   enabled: true
-

--- a/k8s/helm/values.yaml
+++ b/k8s/helm/values.yaml
@@ -8,6 +8,7 @@ args:
 
 # Override to set RAILS_ENV
 RAILS_ENV:
+dashboard_workers: 0
 
 locals.yml:
 


### PR DESCRIPTION
## Summary
- add `dashboard_workers` to the base Helm values and set explicit defaults for `development`, `adhoc`, `staging`, `levelbuilder`, `production`, and `test`
- pass `dashboard_workers` through the generated `locals.yml` so the pod receives the Rails setting
- set Deployment-only CPU and memory limits from `dashboard_workers` with minimum floors for local and low-worker environments
- add new env-specific Helm values files for `adhoc`, `staging`, and `levelbuilder`
- bump the chart version to `0.1.2`

Related to https://github.com/code-dot-org/code-dot-org/pull/71427