### PR TITLE
Revert "Revert "Add support for linting callback in CodeMirror6 wrapper""

### DIFF
--- a/apps/src/code-studio/initializeCodeMirror6.ts
+++ b/apps/src/code-studio/initializeCodeMirror6.ts
@@ -1,10 +1,19 @@
 import {html} from '@codemirror/lang-html';
-import {javascript} from '@codemirror/lang-javascript';
-import {json} from '@codemirror/lang-json';
+import {esLint, javascript} from '@codemirror/lang-javascript';
+import {json, jsonParseLinter} from '@codemirror/lang-json';
 import {markdown} from '@codemirror/lang-markdown';
 import {xml} from '@codemirror/lang-xml';
+import {
+  Diagnostic,
+  forEachDiagnostic,
+  lintGutter,
+  linter,
+} from '@codemirror/lint';
 import {EditorState, Extension} from '@codemirror/state';
 import {EditorView, ViewUpdate} from '@codemirror/view';
+import js from '@eslint/js';
+import * as eslint from 'eslint-linter-browserify';
+import globals from 'globals';
 import React from 'react';
 
 import {editorConfig} from '@cdo/apps/codemirror/editorConfig';
@@ -38,6 +47,11 @@ interface CodeMirrorLegacyAdapter {
 interface Options {
   callback?: (editor: CodeMirrorLegacyAdapter, update: ViewUpdate) => void;
   attachments?: boolean;
+  onUpdateLinting?: (errors: Array<{message: string}>) => void;
+  lintConfig?: {
+    es5?: boolean;
+    disableRecommendedJsConfig?: boolean;
+  };
   preview?: string | Element;
   game?: string;
 }
@@ -47,8 +61,13 @@ type EditorMode = 'javascript' | 'json' | 'markdown' | 'xml' | 'html';
 const levelbuilderEditorTheme = EditorView.theme({
   '&': {
     border: '1px solid #eee',
+    backgroundColor: 'white',
   },
 });
+
+interface Options {
+  callback?: (editor: CodeMirrorLegacyAdapter, update: ViewUpdate) => void;
+}
 
 const languageExtensionMap: Record<EditorMode, Extension> = {
   javascript: javascript(),
@@ -62,13 +81,57 @@ function getLanguageExtension(mode: EditorMode): Extension {
   return languageExtensionMap[mode];
 }
 
-function resolveTarget(target: string | Element): HTMLTextAreaElement {
+const getLintExtension = (
+  mode: EditorMode,
+  lintConfig?: Options['lintConfig']
+): Extension | null => {
+  if (mode === 'json') {
+    return linter(jsonParseLinter());
+  }
+
+  if (mode === 'javascript') {
+    // Our core existing use case is for block editing, which needs to enforce ES5.
+    // It also doesn't want to enforce normal linting rules since the code being edited is often just a snippet that won't run on its own.
+    // So, we allow those existing use cases to override "normal" linting, but still offer the normal config for future use cases that want it.
+    const eslintConfig = {
+      ...(lintConfig?.disableRecommendedJsConfig ? {} : js.configs.recommended),
+      languageOptions: {
+        globals: {
+          ...(lintConfig?.disableRecommendedJsConfig ? {} : globals.browser),
+        },
+        ...(lintConfig?.es5 ? {ecmaVersion: 5, sourceType: 'script'} : {}),
+      },
+    };
+
+    return linter(esLint(new eslint.Linter(), eslintConfig));
+  }
+
+  return null;
+};
+
+const resolveTarget = (target: string | Element): HTMLTextAreaElement => {
   const node =
     typeof target === 'string' ? document.getElementById(target) : target;
   if (!(node instanceof HTMLTextAreaElement)) {
     throw new Error('initializeCodeMirror6 target must resolve to a textarea');
   }
   return node;
+};
+
+function getLintDiagnostics(state: EditorState): Diagnostic[] {
+  const diagnostics: Diagnostic[] = [];
+  forEachDiagnostic(state, diagnostic => {
+    diagnostics.push(diagnostic);
+  });
+  return diagnostics;
+}
+
+function getErrorMessages(diagnostics: Diagnostic[]): Array<{message: string}> {
+  return diagnostics
+    .filter(
+      diagnostic => !diagnostic.severity || diagnostic.severity === 'error'
+    )
+    .map(diagnostic => ({message: diagnostic.message}));
 }
 
 function resolvePreviewElement(
@@ -90,6 +153,8 @@ function resolvePreviewElement(
  * @param {!string} mode - editor syntax mode
  * @param {Object} options - misc optional arguments
  * @param {function} [options.callback] - onChange callback for editor
+ * @param {onUpdateLinting} [options.onUpdateLinting] - callback that receives linting errors on each update.
+ * @param {Object} [options.lintConfig] - configuration options for linting (only applicable for javascript mode).
  * @param {boolean} [options.attachments] - whether to enable attachment
  *        uploading in this editor.
  * @param {(string|Element)} [options.preview] - element or id of element to
@@ -103,9 +168,12 @@ function initializeCodeMirror6(
   options: Options = {}
 ): CodeMirrorLegacyAdapter {
   const node = resolveTarget(target);
-  const {callback, attachments, preview, game} = options;
+
+  const {callback, attachments, onUpdateLinting, preview, game} = options;
   const changeListeners: Array<() => void> = [];
   const dropListeners: Array<(event: DragEvent) => void> = [];
+  const lintExtension = getLintExtension(mode, options.lintConfig);
+
   const editorContainer = document.createElement('div');
   node.style.display = 'none';
   node.insertAdjacentElement('afterend', editorContainer);
@@ -182,21 +250,27 @@ function initializeCodeMirror6(
     getLanguageExtension(mode),
     levelbuilderEditorTheme,
     EditorView.lineWrapping,
+    ...(onUpdateLinting && lintExtension ? [lintExtension, lintGutter()] : []),
     EditorView.domEventHandlers({
       drop(event) {
         dropListeners.forEach(listener => listener(event));
       },
     }),
     EditorView.updateListener.of(update => {
-      if (!update.docChanged) {
-        return;
+      if (update.docChanged) {
+        node.value = update.state.doc.toString();
+        changeListeners.forEach(listener => listener());
+        if (callback) {
+          callback(adapter, update);
+        }
+
+        updatePreview();
       }
-      node.value = update.state.doc.toString();
-      changeListeners.forEach(listener => listener());
-      if (callback) {
-        callback(adapter, update);
+
+      if (onUpdateLinting) {
+        const diagnostics = getLintDiagnostics(update.state);
+        onUpdateLinting(getErrorMessages(diagnostics));
       }
-      updatePreview();
     }),
   ];
 

--- a/apps/src/sites/studio/pages/blocks/edit.js
+++ b/apps/src/sites/studio/pages/blocks/edit.js
@@ -5,7 +5,7 @@ import {getDefaultListMetadata} from '@cdo/apps/assetManagement/animationLibrary
 import {installCustomBlocks} from '@cdo/apps/block_utils';
 import {loadBlocksToWorkspace} from '@cdo/apps/blockly/utils';
 import assetUrl from '@cdo/apps/code-studio/assetUrl';
-import initializeCodeMirror from '@cdo/apps/code-studio/initializeCodeMirror';
+import initializeCodeMirror6 from '@cdo/apps/code-studio/initializeCodeMirror6';
 import {customInputTypes as dancelabCustomInputTypes} from '@cdo/apps/dance/blockly/blocks';
 import animationList, {
   setInitialAnimationList,
@@ -65,14 +65,18 @@ function initializeEditPage(defaultSprites) {
   );
 
   const helperCodeElement = document.getElementById('block_helper_code');
-  configEditor = initializeCodeMirror(blockConfigElement, 'application/json', {
+  configEditor = initializeCodeMirror6(blockConfigElement, 'json', {
     callback: validateBlockConfig,
     onUpdateLinting: onUpdateLinting,
   });
 
-  helperEditor = initializeCodeMirror(helperCodeElement, 'javascript', {
+  helperEditor = initializeCodeMirror6(helperCodeElement, 'javascript', {
     callback: _ => validateBlockConfig(),
     onUpdateLinting: onUpdateLinting,
+    lintConfig: {
+      es5: true,
+      disableRecommendedJsConfig: true,
+    },
   });
   poolField.addEventListener('change', updateBlockPreview);
 
@@ -85,7 +89,7 @@ function initializeEditPage(defaultSprites) {
   $('.alert.alert-success').delay(5000).fadeOut(1000);
 }
 
-function onUpdateLinting(_, errors) {
+function onUpdateLinting(errors) {
   if (errors.length) {
     hasLintingErrors = true;
   } else {

--- a/apps/src/sites/studio/pages/libraries/edit.js
+++ b/apps/src/sites/studio/pages/libraries/edit.js
@@ -1,12 +1,16 @@
-import initializeCodeMirror from '@cdo/apps/code-studio/initializeCodeMirror';
+import initializeCodeMirror6 from '@cdo/apps/code-studio/initializeCodeMirror6';
 
 const submitButton = document.querySelector('#library_submit');
-initializeCodeMirror('library_content', 'javascript', {
-  onUpdateLinting: (_, errors) => {
+initializeCodeMirror6('library_content', 'javascript', {
+  onUpdateLinting: errors => {
     if (errors.length) {
       submitButton.setAttribute('disabled', 'disabled');
     } else {
       submitButton.removeAttribute('disabled');
     }
+  },
+  lintConfig: {
+    es5: true,
+    disableRecommendedJsConfig: true,
   },
 });

--- a/dashboard/test/ui/browsers.json
+++ b/dashboard/test/ui/browsers.json
@@ -38,8 +38,8 @@
   {
     "name": "Safari",
     "browserName": "Safari",
-    "browserVersion": "17",
-    "platformName": "macOS 13"
+    "browserVersion": "14",
+    "platformName": "macOS 11.00"
   },
   {
     "name": "Firefox",

--- a/dashboard/test/ui/browsers.json
+++ b/dashboard/test/ui/browsers.json
@@ -38,8 +38,8 @@
   {
     "name": "Safari",
     "browserName": "Safari",
-    "browserVersion": "14",
-    "platformName": "macOS 11.00"
+    "browserVersion": "17",
+    "platformName": "macOS 13"
   },
   {
     "name": "Firefox",


### PR DESCRIPTION
Restores https://github.com/code-dot-org/code-dot-org/pull/71161 with no changes, which was initially reverted because of a Sauce Labs failure in an old version of Safari.

We've upgraded our version of Safari in Sauce Labs here (https://github.com/code-dot-org/code-dot-org/pull/71456), so this should be good to merge 🤞 .