### PR TITLE
Add allow list for console.error messages shown in Karma tests

### DIFF
--- a/apps/test/util/throwOnConsole.js
+++ b/apps/test/util/throwOnConsole.js
@@ -7,11 +7,16 @@
  * Thank you!
  */
 
+// These are warnings that React surfaces in React 18 as console.error messages.
+// Please do not add to this list!
 const ERROR_ALLOW_LIST = [
-  "Warning: ReactDOM.render is no longer supported in React 18. Use createRoot instead. Until you switch to the new API, your app will behave as if it's running React 17. Learn more: https://reactjs.org/link/switch-to-createroot",
-  'uses the legacy childContextTypes API which is no longer supported and will be removed in the next major release. Use React.createContext() instead',
-  'Support for defaultProps will be removed from function components in a future major release. Use JavaScript default parameters instead',
-  'findDOMNode is deprecated and will be removed in the next major release. Instead, add a ref directly to the element you want to reference. Learn more about using refs safely here: https://reactjs.org/link/strict-mode-find-node',
+  'Warning: ReactDOM.render is no longer supported in React 18. Use createRoot instead.',
+  'uses the legacy childContextTypes API which is no longer supported and will be removed in the next major release.',
+  'uses the legacy contextTypes API which is no longer supported and will be removed in the next major release.',
+  'Support for defaultProps will be removed from function components in a future major release.',
+  'Support for string refs will be removed in a future major release.',
+  'findDOMNode is deprecated and will be removed in the next major release.',
+  '`ReactDOMTestUtils.act` is deprecated in favor of `React.act`.',
 ];
 
 /**

--- a/apps/test/util/throwOnConsole.js
+++ b/apps/test/util/throwOnConsole.js
@@ -7,6 +7,13 @@
  * Thank you!
  */
 
+const ERROR_ALLOW_LIST = [
+  "Warning: ReactDOM.render is no longer supported in React 18. Use createRoot instead. Until you switch to the new API, your app will behave as if it's running React 17. Learn more: https://reactjs.org/link/switch-to-createroot",
+  'uses the legacy childContextTypes API which is no longer supported and will be removed in the next major release. Use React.createContext() instead',
+  'Support for defaultProps will be removed from function components in a future major release. Use JavaScript default parameters instead',
+  'findDOMNode is deprecated and will be removed in the next major release. Instead, add a ref directly to the element you want to reference. Learn more about using refs safely here: https://reactjs.org/link/strict-mode-find-node',
+];
+
 /**
  * We want to be able to have test throw by default on console error/warning, but
  * also be able to allow these calls in specific tests. This method creates two
@@ -16,7 +23,7 @@
  * method - allow - overrides that behavior, allowing calls to the console method.
  * Note: Intentionally not using sinon for this, to keep test bundle sizes down.
  */
-function throwOnConsoleEverywhere(methodName) {
+function throwOnConsoleEverywhere(methodName, ignoreList = []) {
   let throwing = true;
   let wrappedMethod = null;
 
@@ -37,7 +44,10 @@ function throwOnConsoleEverywhere(methodName) {
           wrappedMethod.call(console, prefix, msg);
 
           // Throw error with stack trace of call
-          if (throwing) {
+          if (
+            throwing &&
+            !ignoreList.some(allowedMsg => msg.includes(allowedMsg))
+          ) {
             console[methodName] = wrappedMethod;
             wrappedMethod = null;
             throw new Error(
@@ -83,7 +93,10 @@ function getStack() {
 }
 
 // Create/export methods for both console.error and console.warn
-const consoleErrorFunctions = throwOnConsoleEverywhere('error');
+const consoleErrorFunctions = throwOnConsoleEverywhere(
+  'error',
+  ERROR_ALLOW_LIST
+);
 export const throwOnConsoleErrorsEverywhere =
   consoleErrorFunctions.throwEverywhere;
 export const allowConsoleErrors = consoleErrorFunctions.allow;


### PR DESCRIPTION
The React 18 upgrade produces a number of deprecation warnings via `console.error` messages.

We ignore these in our Jest tests, but we have some special sauce in our Karma tests that fails the test if we see a call to console.error. Side note, we also used to fail tests on calls to console.warn, but turned off that feature in the React 16 upgrade 🙃 .

As an in-between solution (ie, in-between turning off the "fail on console.error" feature and fixing all of these warnings), I add a list of console.error messages that will not fail tests.

## Testing story

I tested this against my [React 18 branch](https://github.com/code-dot-org/code-dot-org/pull/71182) (which is now passing!), but pulling this out on it's own for easier review.