### PR TITLE
Fix collapse button background regression in version history.

### DIFF
--- a/apps/src/lab2/views/components/Instructions/ResourcePanel/VersionHistory/version-history-panel.module.scss
+++ b/apps/src/lab2/views/components/Instructions/ResourcePanel/VersionHistory/version-history-panel.module.scss
@@ -53,13 +53,12 @@
 specificity to override DSCO styles */
 .collapseButton.collapseButton {
   margin-inline-start: 0.75rem;
-  background: var(--background-neutral-primary);
   position: relative;
   z-index: 1;
+  color: var(--text-neutral-tertiary);
 
-  span,
-  i {
-    color: var(--text-neutral-quaternary);
+  &:not(:hover, :active, :focus-visible) {
+    background: var(--background-neutral-primary);
   }
 }
 


### PR DESCRIPTION
Noticed a small regression with the collapse button in version history after it was refactored to use the new MUI component. The reason being that MUI applies hover/active backgrounds via state selectors, and our root override (from before) was accidentally overriding them. Restricting the override to the default state keeps the intended styling for this button without breaking interaction styles. I also removed the icon-specific text styling and just applied the tertiary style to both the label and icon (also gives us a tiny a11y contrast win).

**Screenshot:**
| Before | After |
|--------|--------|
| <img width="155" height="39" alt="Screenshot 2026-03-18 at 2 54 40 PM" src="https://github.com/user-attachments/assets/e1d37642-8867-42f0-a894-06bdf7e7b633" /> | <img width="157" height="45" alt="Screenshot 2026-03-18 at 2 54 24 PM" src="https://github.com/user-attachments/assets/ccd8c7da-442d-4c61-baa0-035adca43a4a" /> |

**Interaction (Before):**

https://github.com/user-attachments/assets/f6684832-d0f2-4372-b4b0-07c893568667

**Interaction (After):**

https://github.com/user-attachments/assets/a25bd424-3b33-417e-b6c4-5f0f45e25a96





<!--
  Summary of the change: background, motivation, and context.
  Include screenshots, videos, or before/after comparisons for UI changes.
-->

## Links
<!-- Jira tickets, design docs, Slack threads, related PRs, etc. -->

- Jira:

## Testing story
<!-- How was this tested? Manual steps, adhoc links, automated tests, or why testing isn't needed. -->



## Deployment notes
<!-- Delete this section if it's a standard merge-and-deploy.
     Otherwise: migrations, feature flags, coordination, caching impacts, etc. -->



## Privacy and security
<!-- Delete this section if there is no privacy/security impact.
     Otherwise: new PII, auth changes, API surface changes, etc. -->

