### PR TITLE
Web lab 2: hide debug button in share view

### DIFF
--- a/apps/src/weblab2/htmlPreview/HTMLPreviewHeader.tsx
+++ b/apps/src/weblab2/htmlPreview/HTMLPreviewHeader.tsx
@@ -31,7 +31,6 @@ interface HTMLPreviewHeaderProps {
   onStopPreview: () => void;
   isStopEnabled: boolean;
   fetchFileSearchOptions: (value: string) => Promise<string[]>;
-  isShareView?: boolean;
 }
 
 export const HTMLPreviewHeader: React.FC<HTMLPreviewHeaderProps> = ({

--- a/apps/src/weblab2/htmlPreview/HTMLPreviewHeader.tsx
+++ b/apps/src/weblab2/htmlPreview/HTMLPreviewHeader.tsx
@@ -31,6 +31,7 @@ interface HTMLPreviewHeaderProps {
   onStopPreview: () => void;
   isStopEnabled: boolean;
   fetchFileSearchOptions: (value: string) => Promise<string[]>;
+  isShareView?: boolean;
 }
 
 export const HTMLPreviewHeader: React.FC<HTMLPreviewHeaderProps> = ({
@@ -203,33 +204,39 @@ export const HTMLPreviewHeader: React.FC<HTMLPreviewHeaderProps> = ({
         className={moduleStyles.previewViewModeButtons}
         {...previewViewModeButtonsProps}
       />
-      <WithTooltip
-        tooltipProps={{
-          tooltipId: 'toggle-debug-panel',
-          direction: 'onBottom',
-          size: 'xs',
-          text: debugPanelOpen ? 'Close debug panel' : 'Open debug panel',
-        }}
-      >
-        <MuiIconButton
-          variant="outlined"
-          color="tertiary"
-          size="extraSmall"
-          className={
-            debugPanelOpen ? moduleStyles.closeDebugPanelButton : undefined
-          }
-          onClick={() => dispatch(setDebugPanelOpen(!debugPanelOpen))}
-          aria-label={debugPanelOpen ? 'Close debug panel' : 'Open debug panel'}
-          type="button"
-        >
-          <FontAwesomeV6Icon iconName="bug" />
-        </MuiIconButton>
-      </WithTooltip>
+
       {!isShareView && (
-        <ToggleFullScreenButton
-          isFullScreenView={isFullScreenView}
-          onToggleFullScreen={onToggleFullScreen}
-        />
+        // Hide debug panel toggle and full screen toggle buttons in share view.
+        <>
+          <WithTooltip
+            tooltipProps={{
+              tooltipId: 'toggle-debug-panel',
+              direction: 'onBottom',
+              size: 'xs',
+              text: debugPanelOpen ? 'Close debug panel' : 'Open debug panel',
+            }}
+          >
+            <MuiIconButton
+              variant="outlined"
+              color="tertiary"
+              size="extraSmall"
+              className={
+                debugPanelOpen ? moduleStyles.closeDebugPanelButton : undefined
+              }
+              onClick={() => dispatch(setDebugPanelOpen(!debugPanelOpen))}
+              aria-label={
+                debugPanelOpen ? 'Close debug panel' : 'Open debug panel'
+              }
+              type="button"
+            >
+              <FontAwesomeV6Icon iconName="bug" />
+            </MuiIconButton>
+          </WithTooltip>
+          <ToggleFullScreenButton
+            isFullScreenView={isFullScreenView}
+            onToggleFullScreen={onToggleFullScreen}
+          />
+        </>
       )}
     </div>
   );


### PR DESCRIPTION
This hides the debug button in Web Lab 2 share view, per product's request. Most changes in this pr are whitespace.

## Before
<img width="1707" height="251" alt="Screenshot 2026-03-18 at 12 06 38 PM" src="https://github.com/user-attachments/assets/418e5efb-bc2c-4164-9673-f6b08963caad" />


## After
<img width="1707" height="251" alt="Screenshot 2026-03-18 at 12 05 55 PM" src="https://github.com/user-attachments/assets/c5bedc40-23f1-4c38-bbab-8733c876c03f" />


## Links

- Jira: [AFL-519](https://codedotorg.atlassian.net/browse/AFL-519)


