### PR TITLE
Fix Karma unit tests for React 18

### DIFF
--- a/apps/src/templates/VisualizationOverlay.jsx
+++ b/apps/src/templates/VisualizationOverlay.jsx
@@ -34,11 +34,13 @@ export class VisualizationOverlay extends React.Component {
     mouseY: -1,
   };
 
+  rootRef = React.createRef();
+
   componentDidMount() {
     /** @type {SVGMatrix} */
     this.screenSpaceToAppSpaceTransform = null;
     /** @private {SVGPoint} Build a reusable position point for efficient transforms */
-    this.mousePos_ = this.refs.root.createSVGPoint();
+    this.mousePos_ = this.rootRef.current.createSVGPoint();
     this.recalculateTransform();
 
     // Note: This is currently used within a ProtectedStatefulDiv, so we need
@@ -67,7 +69,7 @@ export class VisualizationOverlay extends React.Component {
   }
 
   recalculateTransform = () => {
-    const svg = this.refs.root;
+    const svg = this.rootRef.current;
     if (!svg) {
       return;
     }
@@ -126,7 +128,7 @@ export class VisualizationOverlay extends React.Component {
   render() {
     return (
       <svg
-        ref="root"
+        ref={this.rootRef}
         id="visualizationOverlay"
         className={this.props.className}
         width={this.props.width}

--- a/apps/src/templates/certificates/SocialShare.jsx
+++ b/apps/src/templates/certificates/SocialShare.jsx
@@ -10,6 +10,20 @@ import i18n from '@cdo/locale';
 
 import moduleStyles from './social_share.module.scss';
 
+// Avoids setting state on unmounted components in tests, which produce console.error messsages from React.
+function testAvailability(url, setAvailability) {
+  let isMounted = true;
+  testImageAccess(url, () => {
+    if (isMounted) {
+      setAvailability(true);
+    }
+  });
+
+  return () => {
+    isMounted = false;
+  };
+}
+
 export default function SocialShare({
   facebook,
   twitter,
@@ -24,20 +38,21 @@ export default function SocialShare({
   const [isLinkedinAvailable, setIsLinkedinAvailable] = useState(false);
 
   useEffect(() => {
-    testImageAccess(
+    return testAvailability(
       'https://facebook.com/favicon.ico' + '?' + Math.random(),
-      () => setIsFacebookAvailable(true)
+      setIsFacebookAvailable
     );
   }, []);
   useEffect(() => {
-    testImageAccess('https://x.com/favicon.ico' + '?' + Math.random(), () =>
-      setIsTwitterAvailable(true)
+    return testAvailability(
+      'https://x.com/favicon.ico' + '?' + Math.random(),
+      setIsTwitterAvailable
     );
   }, []);
   useEffect(() => {
-    testImageAccess(
+    return testAvailability(
       'https://www.linkedin.com/favicon.ico' + '?' + Math.random(),
-      () => setIsLinkedinAvailable(true)
+      setIsLinkedinAvailable
     );
   }, []);
 

--- a/apps/test/unit/templates/certificates/Certificate.karma.test.js
+++ b/apps/test/unit/templates/certificates/Certificate.karma.test.js
@@ -7,6 +7,7 @@ import sinon from 'sinon'; // eslint-disable-line no-restricted-imports
 
 import isRtl from '@cdo/apps/code-studio/isRtlRedux';
 import responsive from '@cdo/apps/code-studio/responsiveRedux';
+import * as urlTestModule from '@cdo/apps/code-studio/url_test';
 import {studio} from '@cdo/apps/lib/util/urlHelpers';
 import Certificate from '@cdo/apps/templates/certificates/Certificate';
 import * as AuthTokenStore from '@cdo/apps/util/AuthenticityTokenStore';
@@ -32,6 +33,9 @@ describe('Certificate', () => {
     window.dashboard = {
       CODE_ORG_URL: '//code.org',
     };
+    sinon
+      .stub(urlTestModule, 'default')
+      .callsFake((url, successCallback = () => {}) => successCallback());
   });
 
   afterEach(() => {
@@ -39,6 +43,7 @@ describe('Certificate', () => {
       wrapper.unmount();
       wrapper = undefined;
     }
+    sinon.restore();
     window.dashboard = storedWindowDashboard;
   });
 
@@ -53,7 +58,6 @@ describe('Certificate', () => {
     });
 
     afterEach(() => {
-      sinon.restore();
       server.restore();
     });
 

--- a/apps/test/unit/templates/certificates/Certificate.karma.test.js
+++ b/apps/test/unit/templates/certificates/Certificate.karma.test.js
@@ -1,5 +1,6 @@
 import {mount} from 'enzyme'; // eslint-disable-line no-restricted-imports
 import React from 'react';
+import {act} from 'react-dom/test-utils';
 import {Provider} from 'react-redux';
 import {combineReducers, createStore} from 'redux';
 import sinon from 'sinon'; // eslint-disable-line no-restricted-imports
@@ -24,6 +25,7 @@ function wrapperWithParams(params) {
 
 describe('Certificate', () => {
   let storedWindowDashboard;
+  let wrapper;
 
   beforeEach(() => {
     storedWindowDashboard = window.dashboard;
@@ -33,6 +35,10 @@ describe('Certificate', () => {
   });
 
   afterEach(() => {
+    if (wrapper) {
+      wrapper.unmount();
+      wrapper = undefined;
+    }
     window.dashboard = storedWindowDashboard;
   });
 
@@ -62,7 +68,7 @@ describe('Certificate', () => {
         [200, {'Content-Type': 'application/json'}, JSON.stringify(data)]
       );
 
-      const wrapper = wrapperWithParams({
+      wrapper = wrapperWithParams({
         certificateData: [
           {
             courseName: 'dance',
@@ -93,7 +99,10 @@ describe('Certificate', () => {
       // `personalizeHocCertificate` awaits the authenticity token before issuing the ajax request.
       // Give the microtask queue a chance to flush so the request is created before responding with the fake server.
       await new Promise(resolve => setTimeout(resolve));
-      server.respond();
+      await act(async () => {
+        server.respond();
+        await Promise.resolve();
+      });
 
       wrapper.update();
       image = wrapper.find('#uitest-certificate img');
@@ -108,7 +117,7 @@ describe('Certificate', () => {
     });
 
     it('passes down full urls to SocialShare', () => {
-      const wrapper = wrapperWithParams({
+      wrapper = wrapperWithParams({
         certificateData: [
           {
             courseName: 'dance',
@@ -124,7 +133,7 @@ describe('Certificate', () => {
   });
 
   it('renders swiper for multiple certificates', () => {
-    const wrapper = wrapperWithParams({
+    wrapper = wrapperWithParams({
       certificateData: [
         {
           courseName: 'csd1-2023',
@@ -147,7 +156,7 @@ describe('Certificate', () => {
   });
 
   it('does not render swiper for single certificate', () => {
-    const wrapper = wrapperWithParams({
+    wrapper = wrapperWithParams({
       certificateData: [
         {
           courseName: 'csd1-2023',

--- a/apps/test/unit/templates/certificates/Certificate.karma.test.js
+++ b/apps/test/unit/templates/certificates/Certificate.karma.test.js
@@ -7,7 +7,6 @@ import sinon from 'sinon'; // eslint-disable-line no-restricted-imports
 
 import isRtl from '@cdo/apps/code-studio/isRtlRedux';
 import responsive from '@cdo/apps/code-studio/responsiveRedux';
-import * as urlTestModule from '@cdo/apps/code-studio/url_test';
 import {studio} from '@cdo/apps/lib/util/urlHelpers';
 import Certificate from '@cdo/apps/templates/certificates/Certificate';
 import * as AuthTokenStore from '@cdo/apps/util/AuthenticityTokenStore';
@@ -33,9 +32,6 @@ describe('Certificate', () => {
     window.dashboard = {
       CODE_ORG_URL: '//code.org',
     };
-    sinon
-      .stub(urlTestModule, 'default')
-      .callsFake((url, successCallback = () => {}) => successCallback());
   });
 
   afterEach(() => {

--- a/apps/test/unit/templates/instructions/InstructionsCSF.karma.test.jsx
+++ b/apps/test/unit/templates/instructions/InstructionsCSF.karma.test.jsx
@@ -20,11 +20,7 @@ import pageConstants, {setPageConstants} from '@cdo/apps/redux/pageConstants';
 import InstructionsCSF from '@cdo/apps/templates/instructions/InstructionsCSF';
 import {convertXmlToBlockly} from '@cdo/apps/templates/instructions/utils';
 
-import {allowConsoleErrors} from '../../../util/testUtils';
-
 describe('InstructionsCSF', () => {
-  allowConsoleErrors();
-
   let wrapper;
 
   beforeEach(() => {

--- a/apps/test/unit/templates/instructions/InstructionsCSF.karma.test.jsx
+++ b/apps/test/unit/templates/instructions/InstructionsCSF.karma.test.jsx
@@ -1,6 +1,7 @@
 import {assert} from 'chai'; // eslint-disable-line no-restricted-imports
 import {mount} from 'enzyme'; // eslint-disable-line no-restricted-imports
 import React from 'react';
+import {act} from 'react-dom/test-utils';
 import {Provider} from 'react-redux';
 
 import isRtl from '@cdo/apps/code-studio/isRtlRedux';
@@ -19,7 +20,13 @@ import pageConstants, {setPageConstants} from '@cdo/apps/redux/pageConstants';
 import InstructionsCSF from '@cdo/apps/templates/instructions/InstructionsCSF';
 import {convertXmlToBlockly} from '@cdo/apps/templates/instructions/utils';
 
+import {allowConsoleErrors} from '../../../util/testUtils';
+
 describe('InstructionsCSF', () => {
+  allowConsoleErrors();
+
+  let wrapper;
+
   beforeEach(() => {
     stubRedux();
     registerReducers({authoredHints, instructions, isRtl, pageConstants});
@@ -37,28 +44,37 @@ describe('InstructionsCSF', () => {
   });
 
   afterEach(() => {
+    if (wrapper) {
+      wrapper.unmount();
+      wrapper = undefined;
+    }
     restoreRedux();
   });
 
   it('can change feedback when rendering different blockly blocks', async () => {
-    const wrapper = mount(
+    wrapper = mount(
       <Provider store={getStore()}>
         <InstructionsCSF {...DEFAULT_PROPS} />
       </Provider>,
       {attachTo: document.getElementById('container')} // needed for getScrollTarget
     );
 
-    failWithMessage('Repeat block: <xml><block type="controls_repeat"/></xml>');
+    await failWithMessage(
+      'Repeat block: <xml><block type="controls_repeat"/></xml>'
+    );
     wrapper.update();
     await assertFeedbackContainsText(wrapper, '>repeat</text>');
 
-    failWithMessage('If block: <xml><block type="controls_if"/></xml>');
+    await failWithMessage('If block: <xml><block type="controls_if"/></xml>');
     wrapper.update();
     await assertFeedbackContainsText(wrapper, '>if</text>');
   });
 
-  function failWithMessage(message) {
-    getStore().dispatch(setFeedback({message, isFailure: true}));
+  async function failWithMessage(message) {
+    await act(async () => {
+      getStore().dispatch(setFeedback({message, isFailure: true}));
+      await Promise.resolve();
+    });
   }
 
   async function assertFeedbackContainsText(wrapper, text) {


### PR DESCRIPTION
A handful of legacy unit tests run via Karma were failing on React 18.

I think a couple of these may have passed with the new "don't fail on console.error" logic introduced [here](https://github.com/code-dot-org/code-dot-org/pull/71450), but they all seem like net improvements regardless.

## Testing story

These tests were failing on the React 18 branch over [here](https://github.com/code-dot-org/code-dot-org/pull/71182), and passing after these changes.

There's a couple small actual changes to the VisualizationOverlay and Social Share components, so I went over to Java Lab (which uses VisualizationOverlay to display crosshairs on the visualization) and the congrats page (which uses SocialShare) and manually tested that it still worked.