### PR TITLE
Run Safari tests in Sauce Labs on Safari 17

### DIFF
--- a/dashboard/test/ui/browsers.json
+++ b/dashboard/test/ui/browsers.json
@@ -38,8 +38,8 @@
   {
     "name": "Safari",
     "browserName": "Safari",
-    "browserVersion": "14",
-    "platformName": "macOS 11.00"
+    "browserVersion": "17",
+    "platformName": "macOS 13"
   },
   {
     "name": "Firefox",


### PR DESCRIPTION
Updates Safari tests to run on Safari 17 (from 14). Inspired by a test that was failing on Sauce Labs but seemed fine on newer versions per local testing.

Per Sauce Labs' "Platform Configurator", the oldest OS I could use and get Safari 17 was macOS 13 (no .00 any more apparently): https://saucelabs.com/platform-configurator

## Links

- [Slack discussion](https://codedotorg.slack.com/archives/C0T0PNTM3/p1773851446681319?thread_ts=1773850456.680299&cid=C0T0PNTM3)

## Testing story

UI tests are passing on Safari in Drone via the `[test safari]` flag.