### PR TITLE
Fix invalid rubric level

### DIFF
--- a/dashboard/config/scripts_json/ai-generated-design-2026.script_json
+++ b/dashboard/config/scripts_json/ai-generated-design-2026.script_json
@@ -7691,7 +7691,7 @@
       }
     },
     {
-      "level_name": "ai-generated-design-lesson3-level8_2026",
+      "level_name": "ai-generated-design-lesson3-sketch-lab-choice_2026",
       "seeding_key": {
         "lesson.key": "Lesson 3: Build Your First Web Page with AI",
         "lesson_group.key": "lessonGroup-3",


### PR DESCRIPTION
A rubric in one of these lessons was associated with a level not in the lesson itself, which was breaking the build during seeding. Fix here is to just switch to a valid level within the lesson so the script can seed properly.