### PR TITLE
Ceara/aitt convert aidiff to utf8mb4

### DIFF
--- a/dashboard/app/models/aidiff_message.rb
+++ b/dashboard/app/models/aidiff_message.rb
@@ -4,14 +4,14 @@
 #
 #  id                      :bigint           not null, primary key
 #  aidiff_thread_id        :bigint           not null
-#  external_id             :text(65535)      not null
+#  external_id             :text(16777215)   not null
 #  role                    :integer          not null
-#  content                 :text(65535)      not null
+#  content                 :text(16777215)   not null
 #  is_preset               :boolean          not null
 #  created_at              :datetime         not null
 #  updated_at              :datetime         not null
-#  preset_chip_text        :text(65535)
-#  raw_content             :text(65535)
+#  preset_chip_text        :text(16777215)
+#  raw_content             :text(16777215)
 #  source_links            :json
 #  is_artifact_candidate   :boolean          default(FALSE)
 #  artifact_candidate_type :string(255)

--- a/dashboard/app/models/aidiff_thread.rb
+++ b/dashboard/app/models/aidiff_thread.rb
@@ -4,9 +4,9 @@
 #
 #  id              :bigint           not null, primary key
 #  user_id         :bigint           not null
-#  external_id     :text(65535)      not null
-#  llm_version     :text(65535)      not null
-#  title           :text(65535)
+#  external_id     :text(16777215)   not null
+#  llm_version     :text(16777215)   not null
+#  title           :text(16777215)
 #  unit_id         :integer
 #  lesson_id       :integer
 #  created_at      :datetime         not null
@@ -23,7 +23,7 @@
 class AidiffThread < ApplicationRecord
   belongs_to :user
   has_one :aidiff_artifact
-  has_many :aidiff_messages
+  has_many :aidiff_messages, :dependent => :destroy
 
   validates :context_type, inclusion: {in: SharedConstants::AI_DIFF_CONTEXT.values}
 

--- a/dashboard/app/models/aidiff_thread.rb
+++ b/dashboard/app/models/aidiff_thread.rb
@@ -23,7 +23,7 @@
 class AidiffThread < ApplicationRecord
   belongs_to :user
   has_one :aidiff_artifact
-  has_many :aidiff_messages, :dependent => :destroy
+  has_many :aidiff_messages, dependent: :destroy
 
   validates :context_type, inclusion: {in: SharedConstants::AI_DIFF_CONTEXT.values}
 

--- a/dashboard/db/migrate/20260318191529_convert_aidiff_to_utf8mb4.rb
+++ b/dashboard/db/migrate/20260318191529_convert_aidiff_to_utf8mb4.rb
@@ -1,0 +1,14 @@
+class ConvertAidiffToUtf8mb4 < ActiveRecord::Migration[7.0]
+  def change
+    reversible do |dir|
+      dir.up do
+        execute "ALTER TABLE aidiff_messages CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci"
+        execute "ALTER TABLE aidiff_threads CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci"
+      end
+      dir.down do
+        execute "ALTER TABLE aidiff_messages CONVERT TO CHARACTER SET utf8 COLLATE utf8_unicode_ci"
+        execute "ALTER TABLE aidiff_threads CONVERT TO CHARACTER SET utf8 COLLATE utf8_unicode_ci"
+      end
+    end
+  end
+end

--- a/dashboard/db/schema.rb
+++ b/dashboard/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2026_02_26_192420) do
+ActiveRecord::Schema[7.0].define(version: 2026_03_18_191529) do
   create_table "activities", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "user_id"
     t.integer "level_id"
@@ -171,27 +171,27 @@ ActiveRecord::Schema[7.0].define(version: 2026_02_26_192420) do
     t.index ["aidiff_message_id"], name: "index_aidiff_message_feedbacks_on_aidiff_message_id", unique: true
   end
 
-  create_table "aidiff_messages", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "aidiff_messages", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.bigint "aidiff_thread_id", null: false
-    t.text "external_id", null: false
+    t.text "external_id", size: :medium, null: false
     t.integer "role", null: false
-    t.text "content", null: false
+    t.text "content", size: :medium, null: false
     t.boolean "is_preset", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.text "preset_chip_text"
-    t.text "raw_content"
+    t.text "preset_chip_text", size: :medium
+    t.text "raw_content", size: :medium
     t.json "source_links"
     t.boolean "is_artifact_candidate", default: false
     t.string "artifact_candidate_type"
     t.index ["aidiff_thread_id"], name: "index_aidiff_messages_on_aidiff_thread_id"
   end
 
-  create_table "aidiff_threads", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "aidiff_threads", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.bigint "user_id", null: false
-    t.text "external_id", null: false
-    t.text "llm_version", null: false
-    t.text "title"
+    t.text "external_id", size: :medium, null: false
+    t.text "llm_version", size: :medium, null: false
+    t.text "title", size: :medium
     t.integer "unit_id"
     t.integer "lesson_id"
     t.datetime "created_at", null: false


### PR DESCRIPTION
To support a claude model update that outputs emojis, converting the aidiff_messages and aidiff_threads to utf8mb4 so we can store text with emojis. This will also support user messages with emojis and (maybe?) other languages/writing systems in the future

Table sizes (small):
```
mysql> SELECT COUNT(*) FROM `aidiff_threads`;
+----------+
| COUNT(*) |
+----------+
|    93171 |
+----------+
1 row in set (0.09 sec)

mysql> SELECT COUNT(*) FROM `aidiff_messages`;
+----------+
| COUNT(*) |
+----------+
|   246935 |
+----------+
1 row in set (0.13 sec)
```

## Links
Slack thread about this: https://codedotorg.slack.com/archives/C03CK49G9/p1773853881027869

## Testing story
Tested the migration (and rollback) locally:

Without migration:
<img width="1324" height="605" alt="Screenshot 2026-03-18 at 4 16 33 PM" src="https://github.com/user-attachments/assets/053fbdb2-5282-405a-8c82-24f727356f54" />


With migration:
<img width="1334" height="539" alt="Screenshot 2026-03-18 at 4 18 16 PM" src="https://github.com/user-attachments/assets/06a51c46-c60d-43d2-a28d-3706e733d7a4" />

## Deployment notes
<!-- Delete this section if it's a standard merge-and-deploy.
     Otherwise: migrations, feature flags, coordination, caching impacts, etc. -->



## Privacy and security
<!-- Delete this section if there is no privacy/security impact.
     Otherwise: new PII, auth changes, API surface changes, etc. -->

