### PR TITLE
[AI Chat] Ensure submit button always shows

### DIFF
--- a/apps/src/aiComponentLibrary/userMessageEditor/user-message-editor.module.scss
+++ b/apps/src/aiComponentLibrary/userMessageEditor/user-message-editor.module.scss
@@ -42,6 +42,13 @@
   .chatActionsContainer {
     display: flex;
     justify-content: space-between;
+    position: sticky;
+    bottom: 0;
+    // Ensure chat actions container background hides chat content when pinned
+    background: var(--background-neutral-primary);
+    margin: -10px;
+    padding: 10px;
+    border-radius: 0.25rem;
 
     // If there's only one child element, align it to the right
     & > *:only-child {


### PR DESCRIPTION
This is a bit of a hacky css to avoid a larger refactor that pins the action buttons to the bottom of the chat with position: sticky so they are always visible. I opted to use a negative margin w equal/opposite padding instead of rearranging the dom. 

Before:

https://github.com/user-attachments/assets/a74f6f8c-ff51-4879-9e23-66eda05567a5



After:

https://github.com/user-attachments/assets/31e7dd17-b683-479f-b3e7-4dd90b56d215




## Links

- Jira: https://codedotorg.atlassian.net/browse/AFL-524

## Testing story
<!-- How was this tested? Manual steps, adhoc links, automated tests, or why testing isn't needed. -->



## Deployment notes
<!-- Delete this section if it's a standard merge-and-deploy.
     Otherwise: migrations, feature flags, coordination, caching impacts, etc. -->



## Privacy and security
<!-- Delete this section if there is no privacy/security impact.
     Otherwise: new PII, auth changes, API surface changes, etc. -->

