### PR TITLE
📐 Fix alignment of "print" and "other lessons" buttons on student unit overview page

### DIFF
--- a/apps/src/templates/lessonOverview/StudentLessonOverview.jsx
+++ b/apps/src/templates/lessonOverview/StudentLessonOverview.jsx
@@ -56,7 +56,7 @@ class StudentLessonOverview extends Component {
             >
               {`< ${lesson.unit.displayName}`}
             </a>
-            <div>
+            <div style={{display: 'flex', alignItems: 'center'}}>
               {lesson.studentLessonPlanPdfUrl && (
                 <Button
                   __useDeprecatedTag


### PR DESCRIPTION
Before 
<img width="1667" height="276" alt="Screenshot 2026-03-19 at 2 51 41 PM" src="https://github.com/user-attachments/assets/d06854d3-749f-411b-b57a-f1f88524441d" />

After 
<img width="1677" height="267" alt="Screenshot 2026-03-19 at 2 51 10 PM" src="https://github.com/user-attachments/assets/9c5319e0-7d5e-4412-9f21-a80ab1f63786" />
