### PR TITLE
undo catchall for including .gif files in lfs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -67,7 +67,6 @@ pegasus/sites*/**/*.redirect !text !filter !merge !diff
 pegasus/sites*/**/*.scss !text !filter !merge !diff
 
 # INCLUDE these binary file types in Git LFS no matter where they occur:
-*.gif filter=lfs diff=lfs merge=lfs -text
 *.jpeg filter=lfs diff=lfs merge=lfs -text
 *.jpg filter=lfs diff=lfs merge=lfs -text
 *.pdf filter=lfs diff=lfs merge=lfs -text


### PR DESCRIPTION
## Background

@bencodeorg reported an issue where drone is triggering dashboard unit tests on apps-only changes. the issue is that some files are not getting pulled down properly because they are `.gif` files with raw contents in the repo, which are marked as belonging in lfs. the problem was introduced in https://github.com/code-dot-org/code-dot-org/pull/71432. 

the good news is that change was added only as a future safeguard, with other `.gitattributes` changes covering the image files that were moved (to lib/test/fixtures) in that PR. that means that the addition of `*.gif` to `.gitattributes` can be simply and safely reverted.

see [slack](https://codedotorg.slack.com/archives/C046G4TRLEN/p1773947577951269?thread_ts=1773946856.295959&cid=C046G4TRLEN) for full context.

## Testing story
- the fact that no `.gif` files show up in the diff in this PR (or its only commit) demonstrates that this change does not accidentally add the raw contents of any `.gif` files to the repo.


## Follow-up work

in a single follow-up PR:
- revert the change from this PR
- re-add any stray .gif files (listed in the drone output above) to the repo

this will fix the problem of unwanted .gif files in the repo without re-triggering the problem ben reported. this will NOT involve a history rewrite, which would be expensive and disruptive -- it just puts the files into LFS at the head of the repo. those files will get removed from repo history later, when we do a single, bigger rewrite.
