### PR TITLE
re-add lib/test/fixtures/webpack-manifest.json as tracked by lfs

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -43,7 +43,7 @@ steps:
   - name: get-cached-staging-build
     image: plugins/s3-cache
     settings:
-      filename: cache-staging-ci-build.tar.gz
+      filename: cache-staging-ci-build-PR-71497.tar.gz
       endpoint: s3://cdo-drone
       restore: true
       debug: true
@@ -164,7 +164,7 @@ steps:
       - name: mysql
         path: /drone/src/var/lib/mysql
     settings:
-      filename: cache-staging-ci-build.tar.gz
+      filename: cache-staging-ci-build-PR-71497.tar.gz
       endpoint: s3://cdo-drone
       restore: true
       debug: true
@@ -342,6 +342,6 @@ trigger:
 
 ---
 kind: signature
-hmac: 8380ec279dc40128beca1b341a9fff3212255c2a343d9fed59c9c839ab095669
+hmac: 139c96a42f6dd3f28dfea789cb3ec2021603b90bec95302927edd6e16da948f7
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -43,7 +43,7 @@ steps:
   - name: get-cached-staging-build
     image: plugins/s3-cache
     settings:
-      filename: cache-staging-ci-build-PR-71497.tar.gz
+      filename: cache-staging-ci-build.tar.gz
       endpoint: s3://cdo-drone
       restore: true
       debug: true
@@ -164,7 +164,7 @@ steps:
       - name: mysql
         path: /drone/src/var/lib/mysql
     settings:
-      filename: cache-staging-ci-build-PR-71497.tar.gz
+      filename: cache-staging-ci-build.tar.gz
       endpoint: s3://cdo-drone
       restore: true
       debug: true
@@ -342,6 +342,6 @@ trigger:
 
 ---
 kind: signature
-hmac: 139c96a42f6dd3f28dfea789cb3ec2021603b90bec95302927edd6e16da948f7
+hmac: 8380ec279dc40128beca1b341a9fff3212255c2a343d9fed59c9c839ab095669
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -289,7 +289,7 @@ steps:
       # DRONE_REPO_OWNER = organization name (e.g., "code-dot-org")
       # DRONE_REPO_NAME = repository name (e.g., "code-dot-org")
       - AUTHENTICATED_GITHUB_URL="https://$GITHUB_TOKEN@github.com/$DRONE_REPO_OWNER/$DRONE_REPO_NAME.git"
-      - git clone --branch $DRONE_SOURCE_BRANCH $AUTHENTICATED_GITHUB_URL .
+      - git clone --branch $DRONE_BRANCH $AUTHENTICATED_GITHUB_URL .
 
   # Do all the work necessary to run UI tests so we can capture a complete
   # snapshot of the fully-built project and resulting database, but don't
@@ -320,7 +320,7 @@ steps:
       - name: mysql
         path: /var/lib/mysql
     settings:
-      filename: cache-staging-ci-build-PR-71497.tar.gz
+      filename: cache-staging-ci-build.tar.gz
       endpoint: s3://cdo-drone
       rebuild: true
       debug: true
@@ -339,10 +339,9 @@ trigger:
     - "staging-next"
   event:
     - push
-    - pull_request
 
 ---
 kind: signature
-hmac: 3d357819cf992187cb82aff4e3f1d07f8bd0f576a373a66f187b6542bbf2c645
+hmac: 8380ec279dc40128beca1b341a9fff3212255c2a343d9fed59c9c839ab095669
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -289,7 +289,7 @@ steps:
       # DRONE_REPO_OWNER = organization name (e.g., "code-dot-org")
       # DRONE_REPO_NAME = repository name (e.g., "code-dot-org")
       - AUTHENTICATED_GITHUB_URL="https://$GITHUB_TOKEN@github.com/$DRONE_REPO_OWNER/$DRONE_REPO_NAME.git"
-      - git clone --branch $DRONE_BRANCH $AUTHENTICATED_GITHUB_URL .
+      - git clone --branch $DRONE_SOURCE_BRANCH $AUTHENTICATED_GITHUB_URL .
 
   # Do all the work necessary to run UI tests so we can capture a complete
   # snapshot of the fully-built project and resulting database, but don't
@@ -320,7 +320,7 @@ steps:
       - name: mysql
         path: /var/lib/mysql
     settings:
-      filename: cache-staging-ci-build.tar.gz
+      filename: cache-staging-ci-build-PR-71497.tar.gz
       endpoint: s3://cdo-drone
       rebuild: true
       debug: true
@@ -339,9 +339,10 @@ trigger:
     - "staging-next"
   event:
     - push
+    - pull_request
 
 ---
 kind: signature
-hmac: 8380ec279dc40128beca1b341a9fff3212255c2a343d9fed59c9c839ab095669
+hmac: 3d357819cf992187cb82aff4e3f1d07f8bd0f576a373a66f187b6542bbf2c645
 
 ...

--- a/lib/test/fixtures/webpack-manifest.json
+++ b/lib/test/fixtures/webpack-manifest.json
@@ -1,7 +1,3 @@
-{
-  "js/webpack-runtime.js": "/assets/js/webpack-runtime.338c9dacc207fe9b1eb4.min.js",
-  "js/vendors.js": "/assets/js/vendors.b54aa8aa165e50793d97.min.js",
-  "js/code.org/public/educate/curriculum/courses.js": "/assets/js/code.org/public/educate/curriculum/courses.f757a2800a643278c289.min.js",
-  "js/code.org/views/theme_common_head_after.js": "/assets/js/code.org/views/theme_common_head_after.475288729fcf6b3540bb.min.js",
-  "js/cookieBanner.js": "/assets/js/cookieBanner.d90978a8439431440869.min.js"
-}
+version https://git-lfs.github.com/spec/v1
+oid sha256:4453687988fd38de478428f7d4777639a8e6017c2dd0eccda08fd13c01a1c03b
+size 506


### PR DESCRIPTION
## Background

unexpected follow-on to https://github.com/code-dot-org/code-dot-org/pull/71493 . this PR addresses the following issue during `git clone` in the `cache-staging-build` drone pipeline:
```
Encountered 1 file that should have been a pointer, but wasn't:
	lib/test/fixtures/webpack-manifest.json
```
until the drone cache is rebuild with this change, the `lib` and `dashboard` unit tests are likely to get triggered on all drone runs.

## Description

the issue is resolved by removing the file from git and then re-adding it:
```
git rm --cached lib/test/fixtures/webpack-manifest.json
git add lib/test/fixtures/webpack-manifest.json
git commit
```
this causes the file to be properly tracked by git lfs.

## Testing story
- [x] passing `cached-staging-build` run on [86ab8a6](https://github.com/code-dot-org/code-dot-org/pull/71497/commits/86ab8a6083685d42000ca55f282d43bce4588e6b) shows that this fix makes the problematic warning go away
- [x] passing unit and ui runs on [63491de](https://github.com/code-dot-org/code-dot-org/pull/71497/commits/63491de14912b1470ad13bdeea999b769c6edd3d) show that drone will start passing once this PR is merged and the drone cache is updated ~1hr later. however, failing drone runs in this PR indicate that there will be some drone failures for builds started during the interim

## Deployment strategy
- wait until after hours to merge
- warn developers that all drone runs will most likely fail between when this PR is merged and ~1hr later when the drone cache is updated