### PR TITLE
s3_packaging.rb: save unified diff to disk if packages differ

### DIFF
--- a/lib/cdo/aws/s3_packaging.rb
+++ b/lib/cdo/aws/s3_packaging.rb
@@ -172,11 +172,10 @@ class S3Packaging
     ) while Dir[glob].sum {|f| File.size(f)} > max_size_bytes
   end
 
-  private def warn_packages_differ(diff_output, dir1, dir2)
-    diff_dir = File.join(Dir.home, 'generated-different-packages')
+  private def warn_packages_differ(diff_output, dir1, dir2, max_size_gb: 20, diff_dir: File.join(Dir.home, 'generated-different-packages'))
     FileUtils.mkdir_p(diff_dir)
 
-    delete_oldest_file_until_smaller_than("#{diff_dir}/*.diff", max_size_gb: 20)
+    delete_oldest_file_until_smaller_than("#{diff_dir}/*.diff", max_size_gb: max_size_gb)
 
     timestamp = Time.now.utc.strftime('%Y%m%dT%H%M%SZ')
     diff_path = "#{diff_dir}/s3-vs-local-#{timestamp}.diff"

--- a/lib/cdo/aws/s3_packaging.rb
+++ b/lib/cdo/aws/s3_packaging.rb
@@ -165,6 +165,31 @@ class S3Packaging
     packages_equivalent(old_package, package, log_if_different: log_if_different)
   end
 
+  private def delete_oldest_file_until_smaller_than(glob, max_size_gb:)
+    max_size_bytes = max_size_gb * 1024 * 1024 * 1024
+    FileUtils.rm_f(
+      Dir[glob].min_by {|f| File.mtime(f)}
+    ) while Dir[glob].sum {|f| File.size(f)} > max_size_bytes
+  end
+
+  private def warn_packages_differ(diff_output, dir1, dir2)
+    diff_dir = File.join(Dir.home, 'generated-different-packages')
+    FileUtils.mkdir_p(diff_dir)
+
+    delete_oldest_file_until_smaller_than("#{diff_dir}/*.diff", max_size_gb: 20)
+
+    timestamp = Time.now.utc.strftime('%Y%m%dT%H%M%SZ')
+    diff_path = "#{diff_dir}/s3-vs-local-#{timestamp}.diff"
+    RakeUtils.system__("diff -ruN #{dir1} #{dir2} > #{diff_path}")
+
+    @logger.warn <<~TEXT
+      Packages differed:
+      #{diff_output}
+
+      For a unified diff, see: #{diff_path}
+    TEXT
+  end
+
   # Checks to see if two packages are equivalent by unpacking them into tempfiles
   # and comparing the results. Simply comparing the packages themselves is not
   # sufficient, because they can contain metadata.
@@ -173,11 +198,11 @@ class S3Packaging
       RakeUtils.system "tar -zxf #{package1.path} -C #{dir1}"
       Dir.mktmpdir do |dir2|
         RakeUtils.system "tar -zxf #{package2.path} -C #{dir2}"
-        _, output = RakeUtils.system__ "diff -rq #{dir1} #{dir2}"
-        output
+        _, diff_output = RakeUtils.system__ "diff -rq #{dir1} #{dir2}"
+        warn_packages_differ(diff_output, dir1, dir2) if !diff_output.empty? && log_if_different
+        diff_output
       end
     end
-    @logger.warn "Packages differed:\n#{diff}" if log_if_different && !diff.empty?
     diff.empty?
   end
 

--- a/shared/test/test_s3_packaging.rb
+++ b/shared/test/test_s3_packaging.rb
@@ -181,6 +181,50 @@ class S3PackagingTest < Minitest::Test
     assert threw
   end
 
+  def test_warn_packages_differ_writes_diff
+    diff_dir, dir1, dir2 = Array.new(3) {Dir.mktmpdir}
+
+    # Write a different file to each dir
+    File.write(File.join(dir1, 'file.txt'), "same\nold\n")
+    File.write(File.join(dir2, 'file.txt'), "same\nnew\n")
+
+    Time.stubs(:now).returns(Time.utc(2026, 3, 19, 12, 34, 56))
+    @packager.send(:warn_packages_differ, "file.txt differs\n", dir1, dir2, diff_dir: diff_dir)
+
+    diff_path = File.join(diff_dir, 's3-vs-local-20260319T123456Z.diff')
+    assert File.size(diff_path) > 0
+    assert_includes File.read(diff_path), '-old'
+    assert_includes File.read(diff_path), '+new'
+  ensure
+    [diff_dir, dir1, dir2].compact.each {|dir| FileUtils.remove_entry_secure(dir)}
+  end
+
+  def test_warn_packages_differ_deletes_oldest_diff_files
+    diff_dir, dir1, dir2 = Array.new(3) {Dir.mktmpdir}
+
+    # Write 5x 1kb files
+    5.times do |i|
+      path = File.join(diff_dir, "old-#{i}.diff")
+      File.write(path, 'x' * 1024)
+      time = Time.utc(2026, 3, 19, 12, 0, i)
+      File.utime(time, time, path)
+    end
+
+    # call warn_packages_differ with max_size of 3.1kb
+    @packager.send(:warn_packages_differ, "file.txt differs\n", dir1, dir2, diff_dir: diff_dir, max_size_gb: 3.1 / 1024 / 1024)
+
+    # expect the oldest two 1kb diff files to be deleted
+    refute File.exist?(File.join(diff_dir, 'old-0.diff'))
+    refute File.exist?(File.join(diff_dir, 'old-1.diff'))
+
+    # expect the youngest three 1kb diff files to still exist
+    assert File.exist?(File.join(diff_dir, 'old-2.diff'))
+    assert File.exist?(File.join(diff_dir, 'old-3.diff'))
+    assert File.exist?(File.join(diff_dir, 'old-4.diff'))
+  ensure
+    [diff_dir, dir1, dir2].compact.each {|dir| FileUtils.remove_entry_secure(dir)}
+  end
+
   def test_download_anonymous
     RakeUtils.expects(:git_folder_hash).returns(ORIGINAL_HASH)
     package = @packager.send(:create_package, 'build')


### PR DESCRIPTION
### On `Generated different package for same contents`:
- Saves a full unified diff to `~/generated-different-packages/*.diff` 
  - logs unified diff filename to slack, does not log unified diff since 4GB => slack => problems
- Deletes the oldest saved diffs when the diff directory exceeds 20GB to prevent disk overflow
  - 20GB is potentially only 5 diffs if packages vary completely, as each package is ~2GB
  - Deletes before saving new diff, so you're guaranteed at least one
  - Staging currently has 120GB free, test has 150GB free

### Testing
- Adds a test to check if unified diffs are added to disk
- Adds a test to make sure the "delete oldest when over max_size" code works