### PR TITLE
Fix Detection of Web Application Server Execution Context

### DIFF
--- a/dashboard/config/puma.rb
+++ b/dashboard/config/puma.rb
@@ -1,6 +1,7 @@
 path = File.expand_path('../../deployment.rb', __FILE__)
 path = File.expand_path('../../../deployment.rb', __FILE__) unless File.file?(path)
 require path
+Cdo.execution_context = :web_application
 
 if CDO.dashboard_sock
   bind "unix://#{CDO.dashboard_sock}"

--- a/dashboard/config/puma.rb
+++ b/dashboard/config/puma.rb
@@ -1,7 +1,7 @@
 path = File.expand_path('../../deployment.rb', __FILE__)
 path = File.expand_path('../../../deployment.rb', __FILE__) unless File.file?(path)
 require path
-Cdo.execution_context = :web_application
+CDO.execution_context = :web_application
 
 if CDO.dashboard_sock
   bind "unix://#{CDO.dashboard_sock}"

--- a/lib/cdo.rb
+++ b/lib/cdo.rb
@@ -7,6 +7,12 @@ require 'cdo/secrets_config'
 ##
 ##########
 module Cdo
+  class << self
+    attr_accessor :execution_context
+  end
+
+  self.execution_context = nil # Default context; may be overridden in puma.rb, active_job_backend.rb, bin/cronjob, etc.
+
   class Impl < Config
     prepend SecretsConfig
     include Singleton
@@ -317,10 +323,7 @@ module Cdo
     # rails console). Some components may operate differently within a web application server. For example, database
     # timeouts are shorter when executing within a web application server.
     def running_web_application?
-      program = $PROGRAM_NAME.to_s
-      # Child puma processes have program names like `puma: cluster worker 0: 971 [dashboard]`.
-      # Be careful to NOT match command line tools like `pumactl` or a script that happens to start with the name `puma_`.
-      program == 'puma' || program.start_with?('puma:')
+      Cdo.execution_context == :web_application
     end
 
     # Whether we are executing within a web application server on the

--- a/lib/cdo.rb
+++ b/lib/cdo.rb
@@ -7,15 +7,11 @@ require 'cdo/secrets_config'
 ##
 ##########
 module Cdo
-  class << self
-    attr_accessor :execution_context
-  end
-
-  self.execution_context = nil # Default context; may be overridden in puma.rb, active_job_backend.rb, bin/cronjob, etc.
-
   class Impl < Config
     prepend SecretsConfig
     include Singleton
+
+    attr_accessor :execution_context
 
     # Match CDO_*, plus RACK_ENV and RAILS_ENV.
     ENV_PREFIX = /^(CDO|(RACK|RAILS)(?=_ENV))_/
@@ -38,6 +34,7 @@ module Cdo
     ].freeze
 
     def initialize
+      @execution_context = nil # Default context; may be overridden in puma.rb, active_job_backend.rb, bin/cronjob, etc.
       super
       root = File.expand_path('..', __dir__)
       load_configuration(
@@ -323,7 +320,7 @@ module Cdo
     # rails console). Some components may operate differently within a web application server. For example, database
     # timeouts are shorter when executing within a web application server.
     def running_web_application?
-      Cdo.execution_context == :web_application
+      execution_context == :web_application
     end
 
     # Whether we are executing within a web application server on the

--- a/lib/cdo.rb
+++ b/lib/cdo.rb
@@ -312,13 +312,15 @@ module Cdo
       rack_env?(:test) && dashboard_hostname == 'test-studio.code.org' && chef_managed
     end
 
-    # Identify whether we are executing within a web application server as most of our Ruby classes and modules
-    # can also be executed in Ruby shell scripts (cron jobs), ActiveJob consumers, or in interactive Ruby tools (irb).
-    # Some components may operate differently within a web application server, such as using a database proxy to
-    # connect to the database. We use the `puma` web application server in most environments, except development, where
-    # we use `thin`.
+    # Identify whether we are executing within a puma web application server as most of our Ruby classes and modules
+    # can also be executed in Ruby shell scripts (cron jobs), ActiveJob consumers, or in interactive Ruby tools (irb,
+    # rails console). Some components may operate differently within a web application server. For example, database
+    # timeouts are shorter when executing within a web application server.
     def running_web_application?
-      %w(puma thin).include?(File.basename($0))
+      program = $PROGRAM_NAME.to_s
+      # Child puma processes have program names like `puma: cluster worker 0: 971 [dashboard]`.
+      # Be careful to NOT match command line tools like `pumactl` or a script that happens to start with the name `puma_`.
+      program == 'puma' || program.start_with?('puma:')
     end
 
     # Whether we are executing within a web application server on the


### PR DESCRIPTION
Improve how we detect whether we are executing within a web application server. Our previous exact string match to `puma` did not match the name used by child puma processes.

Discussion here https://codedotorg.slack.com/archives/C0T0PNTM3/p1773963115713789

## Testing story

On a local development environment:
1. Temporarily set `dashboard_workers: 5` in `locals.yml`
2. Modified the `home#health_check` controller action (`/health_check`) to return `CDO.running_web_application?.to_s` and to `CDO.log.info` `Cdo.execution_context`.
3. `curl localhost-studio.code.org:3000/health_check` --> returned `true` and confirmed that `dashboard/log/development.log` contained the `Cdo.execution_context` log entry `web_application`



## Deployment notes
<!-- Delete this section if it's a standard merge-and-deploy.
     Otherwise: migrations, feature flags, coordination, caching impacts, etc. -->

## Follow up

- Modify `Cdo::ActiveJobBackend` to set execution context to something like `:active_job`



## Privacy and security
<!-- Delete this section if there is no privacy/security impact.
     Otherwise: new PII, auth changes, API surface changes, etc. -->

