### PR TITLE
Add Honeybadger context to aichat job error reporting

### DIFF
--- a/dashboard/app/jobs/aichat_request_chat_completion_job.rb
+++ b/dashboard/app/jobs/aichat_request_chat_completion_job.rb
@@ -27,6 +27,14 @@ class AichatRequestChatCompletionJob < ApplicationJob
     request = arguments.first[:request]
     locale = arguments.first[:locale]
 
+    Honeybadger.context(
+      model_id: request.model_customizations['selectedModelId'],
+      client_type: request.model_customizations['clientType'],
+      user_id: request.user_id,
+      level_id: request.level_id,
+      locale: locale
+    )
+
     AichatAiHelper.handle_error("AichatRequestChatCompletionJob", exception, request, locale)
 
     # Report metrics for the failed job (after_perform doesn't run on failure).


### PR DESCRIPTION
Sets thread-local Honeybadger context before re-raising exceptions so the automatic error capture includes model_id, client_type, user_id, level_id, and locale on every failure.

https://claude.ai/code/session_013UxQ5FLjeJePGia6AvaT2p

<!--
  Summary of the change: background, motivation, and context.
  Include screenshots, videos, or before/after comparisons for UI changes.
-->



## Links
<!-- Jira tickets, design docs, Slack threads, related PRs, etc. -->

- Jira:

## Testing story
<!-- How was this tested? Manual steps, adhoc links, automated tests, or why testing isn't needed. -->



## Deployment notes
<!-- Delete this section if it's a standard merge-and-deploy.
     Otherwise: migrations, feature flags, coordination, caching impacts, etc. -->



## Privacy and security
<!-- Delete this section if there is no privacy/security impact.
     Otherwise: new PII, auth changes, API surface changes, etc. -->

