### PR TITLE
Lab2: move loading user app options to Lab2Wrapper

### DIFF
--- a/apps/src/lab2/lab2Redux.ts
+++ b/apps/src/lab2/lab2Redux.ts
@@ -14,15 +14,10 @@ import {
 
 import {OPEN_ENDED_LAB2_PROJECT_TYPES} from '@cdo/apps/constants';
 import {
-  getPublicCaching,
   getAppOptionsEditBlocks,
   getAppOptionsEditingExemplar,
   getAppOptionsViewingExemplar,
 } from '@cdo/apps/lab2/projects/utils';
-import {
-  setUserRoleInCourse,
-  CourseRoles,
-} from '@cdo/apps/templates/currentUserRedux';
 
 import {
   setProjectUpdatedAt,
@@ -32,7 +27,7 @@ import {
 } from '../code-studio/projectRedux';
 import {queryParams, updateQueryParam} from '../code-studio/utils';
 import {RootState} from '../types/redux';
-import HttpClient, {NetworkError} from '../util/HttpClient';
+import {NetworkError} from '../util/HttpClient';
 import {AppDispatch} from '../util/reduxHooks';
 
 import Lab2Registry from './Lab2Registry';
@@ -45,13 +40,7 @@ import ProjectManagerFactory from './projects/ProjectManagerFactory';
 import {getPredictResponse} from './projects/userLevelsApi';
 import {setProjectTooLarge} from './redux/lab2ProjectRedux';
 import {isReadOnlyWorkspace} from './redux/lab2ReduxSelectors';
-import {
-  Channel,
-  LevelProperties,
-  ProjectSources,
-  PartialUserAppOptions,
-  Validation,
-} from './types';
+import {Channel, LevelProperties, ProjectSources, Validation} from './types';
 import {LifecycleEvent} from './utils/LifecycleNotifier';
 
 interface PageError {
@@ -128,7 +117,6 @@ export const setUpWithLevel = createAsyncThunk<
     levelId: number;
     scriptId?: number;
     levelProperties: LevelProperties;
-    userAppOptionsPath?: string;
     channelId?: string;
     userId?: number;
   },
@@ -154,20 +142,6 @@ export const setUpWithLevel = createAsyncThunk<
     const levelProperties = payload.levelProperties;
 
     Lab2Registry.getInstance().setAppName(levelProperties.appName);
-
-    // If we are cached, and there is a user app options path because we are in a script
-    // level, then make an async call to the server to find out whether the user is an
-    // instructor, and if they are, then update the user role.  This is needed for the
-    // teacher panel to appear in cached levels.
-    if (getPublicCaching()) {
-      if (payload.userAppOptionsPath) {
-        loadUserAppOptions(payload.userAppOptionsPath).then(result => {
-          if (result.isInstructor) {
-            thunkAPI.dispatch(setUserRoleInCourse(CourseRoles.Instructor));
-          }
-        });
-      }
-    }
 
     if (!levelProperties.usesProjects) {
       // If projects are disabled on this level, we can skip loading projects data.
@@ -497,15 +471,6 @@ function setProjectAndLevelData(
       data.sharingDisabled,
       data.isTeacherOfProjectOwner
     );
-}
-
-async function loadUserAppOptions(
-  userAppOptionsPath: string
-): Promise<PartialUserAppOptions> {
-  const response = await HttpClient.fetchJson<PartialUserAppOptions>(
-    userAppOptionsPath
-  );
-  return response.value;
 }
 
 async function cleanUpProjectManager() {

--- a/apps/src/lab2/projects/ProjectContainer.tsx
+++ b/apps/src/lab2/projects/ProjectContainer.tsx
@@ -5,11 +5,9 @@
  */
 
 import React, {useEffect} from 'react';
-import {useSelector} from 'react-redux';
 
 import header from '@cdo/apps/code-studio/header';
 import {clearHeader} from '@cdo/apps/code-studio/headerRedux';
-import {getUserAppOptionsPath} from '@cdo/apps/code-studio/progressReduxSelectors';
 import useLifecycleNotifier from '@cdo/apps/lab2/hooks/useLifecycleNotifier';
 import {setUpWithLevel} from '@cdo/apps/lab2/lab2Redux';
 import Lab2Registry from '@cdo/apps/lab2/Lab2Registry';
@@ -43,8 +41,6 @@ const ProjectContainer: React.FunctionComponent<ProjectContainerProps> = ({
     state => state.lab.channel && state.lab.channel.isOwner
   );
 
-  const userAppOptionsPath = useSelector(getUserAppOptionsPath);
-
   const dispatch = useAppDispatch();
   const isReadOnly = useAppSelector(isReadOnlyWorkspace);
 
@@ -71,7 +67,6 @@ const ProjectContainer: React.FunctionComponent<ProjectContainerProps> = ({
           userId,
           scriptId,
           levelProperties,
-          userAppOptionsPath,
           channelId,
         })
       );
@@ -81,15 +76,7 @@ const ProjectContainer: React.FunctionComponent<ProjectContainerProps> = ({
       // An early return could happen if the level is changed mid-load.
       promise?.abort();
     };
-  }, [
-    channelId,
-    currentLevelId,
-    scriptId,
-    levelProperties,
-    userAppOptionsPath,
-    dispatch,
-    userId,
-  ]);
+  }, [channelId, currentLevelId, scriptId, levelProperties, dispatch, userId]);
 
   useEffect(() => {
     window.addEventListener('beforeunload', event => {

--- a/apps/src/lab2/views/Lab2Wrapper.tsx
+++ b/apps/src/lab2/views/Lab2Wrapper.tsx
@@ -12,10 +12,12 @@ import React, {useEffect} from 'react';
 import {useSelector} from 'react-redux';
 
 import {setCurrentLevelId} from '@cdo/apps/code-studio/progressRedux';
+import {getUserAppOptionsPath} from '@cdo/apps/code-studio/progressReduxSelectors';
 import {
   getAppOptionsLevelId,
   getAppOptionsTheme,
   getIsShareView,
+  getPublicCaching,
 } from '@cdo/apps/lab2/projects/utils';
 import {
   hasPageError,
@@ -23,7 +25,12 @@ import {
 } from '@cdo/apps/lab2/redux/lab2ReduxSelectors';
 import fetchPermissions from '@cdo/apps/lab2/utils/fetchPermissions';
 import {useBrowserTextToSpeech} from '@cdo/apps/sharedComponents/BrowserTextToSpeechWrapper';
+import {
+  CourseRoles,
+  setUserRoleInCourse,
+} from '@cdo/apps/templates/currentUserRedux';
 import {capitalizeFirstLetter} from '@cdo/apps/util/capitalizeFirstLetter';
+import HttpClient from '@cdo/apps/util/HttpClient';
 import {useAppDispatch, useAppSelector} from '@cdo/apps/util/reduxHooks';
 
 import {PERMISSIONS} from '../constants';
@@ -32,6 +39,7 @@ import useLifecycleNotifier from '../hooks/useLifecycleNotifier';
 import useLoadLevelProperties from '../hooks/useLoadLevelProperties';
 import {LabState, setIsShareView, setPermissions} from '../lab2Redux';
 import Lab2Registry from '../Lab2Registry';
+import {PartialUserAppOptions} from '../types';
 import {LifecycleEvent} from '../utils';
 
 import {ErrorFallbackPage, ErrorUI} from './ErrorFallbackPage';
@@ -116,6 +124,23 @@ const Lab2Wrapper: React.FunctionComponent<Lab2WrapperProps> = ({children}) => {
       dispatch(setIsShareView(isShareView));
     }
   }, [isShareView, dispatch]);
+
+  // If we are cached, and there is a user app options path because we are in a script
+  // level, then make an async call to the server to find out whether the user is an
+  // instructor, and if they are, then update the user role.  This is needed for the
+  // teacher panel to appear in cached levels.
+  const userAppOptionsPath = useSelector(getUserAppOptionsPath);
+  useEffect(() => {
+    if (getPublicCaching() && userAppOptionsPath) {
+      HttpClient.fetchJson<PartialUserAppOptions>(userAppOptionsPath).then(
+        ({value}) => {
+          if (value.isInstructor) {
+            dispatch(setUserRoleInCourse(CourseRoles.Instructor));
+          }
+        }
+      );
+    }
+  }, [dispatch, userAppOptionsPath]);
 
   // Add listeners to cancel in any-progress text to speech on level change or reload.
   useLifecycleNotifier(LifecycleEvent.LevelChangeRequested, cancel);


### PR DESCRIPTION
Bit of a random refactor, but I'm trying to do some groundwork for initially integrating https://github.com/code-dot-org/code-dot-org/pull/70301, and part of that is moving some non-project related logic out of `setUpWithLevel`. This just moves the API call to user app options into LabViewsRenderer out of setupWithLevel/ProjectContainer, since it's not really project-related anyway. No functional changes.

## Testing story
Tested with a cached script (hoai 2025) and confirmed we still load user app options as expected.