### PR TITLE
Update dashboard pod resources for Fargate storage and explicit requests

### DIFF
--- a/k8s/helm/templates/dashboard/_dashboard.yaml
+++ b/k8s/helm/templates/dashboard/_dashboard.yaml
@@ -8,20 +8,21 @@
 {{- $isDeployment := eq (.kind | default "Deployment") "Deployment" }}
 {{- $isJob := eq (.kind | default "Deployment") "Job" }}
 
-# Calculate CPU and memory limits from the original environment sizing table.
+# Calculate CPU and memory resources from the original environment sizing table.
 # Weighted across all environments, floored to 2 decimal places:
 # - 808 GiB / 139 workers = 5.81 GiB per worker
 # - 208 CPU / 139 workers = 1.49 CPU per worker
-# Lowest limits we'll set: 4 CPU and 16 GiB RAM.
+# Lowest resources we'll set: 2 CPU and 8 GiB RAM.
 {{- $dashboardWorkers := int (default 0 .Values.dashboard_workers) }}
-{{- $memoryLimitGi := mulf $dashboardWorkers 5.81 }}
-{{- if lt $memoryLimitGi 16.0 }}
-{{- $memoryLimitGi = 16.0 }}
+{{- $memoryGi := mulf $dashboardWorkers 5.81 }}
+{{- if lt $memoryGi 8.0 }}
+{{- $memoryGi = 8.0 }}
 {{- end }}
-{{- $cpuLimit := mulf $dashboardWorkers 1.49 }}
-{{- if lt $cpuLimit 4.0 }}
-{{- $cpuLimit = 4.0 }}
+{{- $cpu := mulf $dashboardWorkers 1.49 }}
+{{- if lt $cpu 2.0 }}
+{{- $cpu = 2.0 }}
 {{- end }}
+{{- $memory := printf "%.2fGi" $memoryGi }}
 
 apiVersion: {{ .apiVersion | default "apps/v1" }}
 kind: {{ .kind | default "Deployment" }}
@@ -95,9 +96,18 @@ spec:
 
         {{- if $isDeployment }}
         resources:
+          requests:
+            cpu: {{ $cpu }}
+            memory: {{ $memory }}
+            {{- if .Values.resources.ephemeralStorage }}
+            ephemeral-storage: {{ .Values.resources.ephemeralStorage }}
+            {{- end }}
           limits:
-            cpu: {{ $cpuLimit }}
-            memory: {{ printf "%.2fGi" $memoryLimitGi }}
+            cpu: {{ $cpu }}
+            memory: {{ $memory }}
+            {{- if .Values.resources.ephemeralStorage }}
+            ephemeral-storage: {{ .Values.resources.ephemeralStorage }}
+            {{- end }}
         ports:
         - name: http
           containerPort: 3000

--- a/k8s/helm/values.yaml
+++ b/k8s/helm/values.yaml
@@ -19,6 +19,9 @@ require_external_secrets: false
 healthChecks:
   enabled: false
 
+resources:
+  ephemeralStorage: 30Gi
+
 autoscaling:
   enabled: false
   minReplicas: 1


### PR DESCRIPTION
## Summary
- add a default `30Gi` `resources.ephemeralStorage` value for dashboard pods
- render explicit matching CPU, memory, and ephemeral-storage requests and limits in the dashboard deployment template
- lower the minimum CPU and memory floor from `4 CPU / 16 GiB` to `2 CPU / 8 GiB`

## Testing
- `helm template dev k8s/helm -f k8s/helm/values.yaml -f k8s/helm/development.values.yaml`
- `helm template production k8s/helm -f k8s/helm/values.yaml -f k8s/helm/production.values.yaml`
- `./tools/hooks/pre-commit`