### PR TITLE
k8s: build on merge to staging/test/levelbuilder/production

### DIFF
--- a/.github/workflows/k8s.yml
+++ b/.github/workflows/k8s.yml
@@ -9,10 +9,9 @@ on:
   # PRs down to PRs where the source-branch is *k8s* using `if:` blocks below.
   push:
     branches:
-      # Disabled while we get used to this:
-      # - staging
-      # - levelbuilder
+      - staging
       - test
+      - levelbuilder
       - production
   pull_request:
 


### PR DESCRIPTION
This PR enables the k8s.yml github action on PR merges to:
1. staging
2. test
3. levelbuilder
4. production

This action is set to not mark the build "failed" if there's an error but continue. However, it is possible this will result in ❌ emojis appearing in github on branches. Its safe to revert this PR, or completely turn it off by commenting out the staging, test, levelbuilder and production list items in k8s.yml.

## Cost of enabling

Using last weeks average k8s build time of 47 CPU-minutes, and github runner cost, it shoudl be ~$0.27 per build. A build happens on a merge to staging, test, levelbuilder or production branches, so we can count PRs.

For the last 30 days:
staging: 381 merges -> ~$104/month
test: 119 merges -> ~$33/month
production: 30 merges -> ~$8/month
levelbuilder: 24 merges -> ~$7/month

Total estimated cost of this PR: **554 merges -> ~$152/month**

## Expected impact if it goes wrong: visual

Its set to skip on fail, so if it goes wrong, the biggest impact I anticipate would be a red X on staging when you visit our repo like this amazing mockup:
<img width="419" height="80" alt="image" src="https://github.com/user-attachments/assets/de4507f8-cc90-491f-87ff-44ce1c1ff04e" />


## Why enable?

This PR will let us compare how frequently the k8s build system was able to produce usable results relative to the existing DOTD system. We need some history on the graph, so letting this run while I'm on vacation is perfect.

If it causes an annoyance to anyone, please disable!