### PR TITLE
chore: argocd helm probe 1

### DIFF
--- a/k8s/helm/values.yaml
+++ b/k8s/helm/values.yaml
@@ -1,6 +1,7 @@
 # Default configuration, overridden by:
 # - development.values.yml
 # - production.values.yml
+# argocd-detect-probe: code-dot-org run 1 at 2026-03-21T16:14:30-10:00
 
 image: code-dot-org:latest
 command: ["bin/dashboard-server"]


### PR DESCRIPTION
Comment-only probe change to measure ArgoCD repo refresh latency.