### PR TITLE
chore: argocd helm probe 4

### DIFF
--- a/k8s/helm/values.yaml
+++ b/k8s/helm/values.yaml
@@ -1,7 +1,7 @@
 # Default configuration, overridden by:
 # - development.values.yml
 # - production.values.yml
-# argocd-detect-probe: code-dot-org run 3 at 2026-03-21T16:20:20-10:00
+# argocd-detect-probe: code-dot-org run 4 at 2026-03-22T10:13:12Z
 
 image: code-dot-org:latest
 command: ["bin/dashboard-server"]


### PR DESCRIPTION
Comment-only probe change to measure ArgoCD repo refresh latency.