### PR TITLE
Remove migrated env values files from k8s/helm

### DIFF
--- a/k8s/helm/levelbuilder.values.yaml
+++ b/k8s/helm/levelbuilder.values.yaml
@@ -1,4 +1,0 @@
-RAILS_ENV: levelbuilder
-dashboard_workers: 27
-healthChecks:
-  enabled: true

--- a/k8s/helm/production.values.yaml
+++ b/k8s/helm/production.values.yaml
@@ -1,9 +1,0 @@
-RAILS_ENV: production
-dashboard_workers: 32
-autoscaling:
-  enabled: true
-  minReplicas: 1
-  maxReplicas: 10
-healthChecks:
-  enabled: true
-require_external_secrets: true

--- a/k8s/helm/staging.values.yaml
+++ b/k8s/helm/staging.values.yaml
@@ -1,4 +1,0 @@
-RAILS_ENV: staging
-dashboard_workers: 10
-healthChecks:
-  enabled: true

--- a/k8s/helm/test.values.yaml
+++ b/k8s/helm/test.values.yaml
@@ -1,4 +1,0 @@
-RAILS_ENV: test
-dashboard_workers: 65
-healthChecks:
-  enabled: true

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -89,18 +89,6 @@ deploy:
 
 profiles:
 
-- name: production
-  patches:
-    - op: add
-      path: /deploy/helm/releases/0/valuesFiles/-
-      value: k8s/helm/production.values.yaml
-
-- name: test
-  patches:
-    - op: add
-      path: /deploy/helm/releases/0/valuesFiles/-
-      value: k8s/helm/test.values.yaml
-
 - name: development
   activation:
     - command: dev


### PR DESCRIPTION
## Summary
- delete the `levelbuilder`, `production`, `staging`, and `test` values files from `k8s/helm`
- reflect any env-specific differences in the corresponding `k8s-gitops` envType values files as commented-out values
- leave already-matched settings out of the migration to avoid duplicating existing gitops config
- corresponding `k8s-gitops` commit: https://github.com/code-dot-org/k8s-gitops/commit/db618f6

