### PR TITLE
K8S: gh action verifies k8s and helm match

### DIFF
--- a/.github/workflows/k8s-validate.yml
+++ b/.github/workflows/k8s-validate.yml
@@ -1,0 +1,36 @@
+# Use this workflow to do any validation of k8s related files, this could
+# be linting, simple tests, etc. This runs in parallel with the skaffold
+# build, but before we commit to k8s-gitops our changes, so anything
+# that's faster than that won't hold up the overall flow.
+
+name: k8s-validate
+
+on:
+  workflow_call:
+
+jobs:
+  validate:
+    name: validate
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v6.0.2
+        with:
+          sparse-checkout: |
+            k8s
+
+      - name: Setup Helm
+        uses: azure/setup-helm@v4
+        with:
+          version: v3.19.0
+
+      - name: Setup Kustomize
+        run: |
+          KUSTOMIZE_VERSION=v5.8.1
+          ARCH=$(uname -m | sed -e 's/x86_64/amd64/' -e 's/aarch64/arm64/')
+          curl -fsSLo /tmp/kustomize.tar.gz "https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2F${KUSTOMIZE_VERSION}/kustomize_${KUSTOMIZE_VERSION}_linux_${ARCH}.tar.gz"
+          tar -xzf /tmp/kustomize.tar.gz -C /tmp
+          sudo install /tmp/kustomize /usr/local/bin/kustomize
+
+      - name: Verify kustomize/helm parity
+        run: k8s/kustomize/bin/verify-parity

--- a/.github/workflows/k8s.yml
+++ b/.github/workflows/k8s.yml
@@ -34,12 +34,19 @@ jobs:
       docker_tag: ${{ needs.skaffold-build.outputs.docker_tag }}
     secrets: inherit
 
+  # In parallel with skaffold: verify our kustomize and helm packages, etc
+  validate:
+    name: validate
+    uses: ./.github/workflows/k8s-validate.yml
+
   # Step 3: commit+push the new docker image ref to a deployment values.yaml file in the
   # k8s-gitops repo, which is constantly monitored by ArgoCD to sync deployments/deploy
   commit-image-ref-to-argocd:
     name: commit image ref to argocd
     uses: ./.github/workflows/k8s-commit-image-ref-to-argocd.yml
-    needs: stitch-multiplatform-image
+    needs:
+      - stitch-multiplatform-image
+      - validate
     with:
       branch_name: ${{ github.head_ref || github.ref_name }}
       codeai_docker_image_ref: ${{ needs.stitch-multiplatform-image.outputs.codeai_docker_image_ref }}


### PR DESCRIPTION
This adds a fast validation gate to the k8s GitHub Actions flow so we catch Helm/Kustomize drift before we build images and update k8s-gitops. The goal is to fail early if our rendered packages stop matching closely enough, instead of discovering that after the deployment handoff step.

- add a reusable `k8s-validate` workflow that sparse-checks out `k8s/`, installs Helm and Kustomize, and runs `k8s/kustomize/bin/verify-parity`
- add a new `validate` job to `k8s.yml`
- make `commit-image-ref-to-argocd` depend on `validate` so we do not push image refs when parity is broken