### PR TITLE
k8s: use components directly with no subdir

### DIFF
--- a/k8s/kustomize/overlays/levelbuilder/kustomization.yaml
+++ b/k8s/kustomize/overlays/levelbuilder/kustomization.yaml
@@ -3,4 +3,4 @@ kind: Kustomization
 resources:
   - ../../base
 components:
-  - git::https://github.com/code-dot-org/k8s-gitops//apps/codeai/envTypes/components/levelbuilder
+  - git::https://github.com/code-dot-org/k8s-gitops//apps/codeai/envTypes/levelbuilder

--- a/k8s/kustomize/overlays/production/kustomization.yaml
+++ b/k8s/kustomize/overlays/production/kustomization.yaml
@@ -3,4 +3,4 @@ kind: Kustomization
 resources:
   - ../../base
 components:
-  - git::https://github.com/code-dot-org/k8s-gitops//apps/codeai/envTypes/components/production
+  - git::https://github.com/code-dot-org/k8s-gitops//apps/codeai/envTypes/production

--- a/k8s/kustomize/overlays/staging/kustomization.yaml
+++ b/k8s/kustomize/overlays/staging/kustomization.yaml
@@ -3,4 +3,4 @@ kind: Kustomization
 resources:
   - ../../base
 components:
-  - git::https://github.com/code-dot-org/k8s-gitops//apps/codeai/envTypes/components/staging
+  - git::https://github.com/code-dot-org/k8s-gitops//apps/codeai/envTypes/staging

--- a/k8s/kustomize/overlays/test/kustomization.yaml
+++ b/k8s/kustomize/overlays/test/kustomization.yaml
@@ -3,4 +3,4 @@ kind: Kustomization
 resources:
   - ../../base
 components:
-  - git::https://github.com/code-dot-org/k8s-gitops//apps/codeai/envTypes/components/test
+  - git::https://github.com/code-dot-org/k8s-gitops//apps/codeai/envTypes/test


### PR DESCRIPTION
The accompanying `k8s-gitops` change moved the env-specific Kustomize components to be the top-level items under `apps/codeai/envTypes/<env>` instead of living under `apps/codeai/envTypes/components/<env>`. This updates dashboard's non-dev overlays to consume those direct component paths.

Accompanying `k8s-gitops` change: [code-dot-org/k8s-gitops@7c206d0](https://github.com/code-dot-org/k8s-gitops/commit/7c206d02b338b798220754a4096feeafd0092367)

Technical changes:
- point the test, staging, production, and levelbuilder overlays at `apps/codeai/envTypes/<env>`
- keep development and local-only overlays unchanged
- validate the updated remote refs with `kustomize build` for the four affected overlays and `k8s/kustomize/bin/verify-parity`