### PR TITLE
Argo Refs code-dot-org Commit

### DIFF
--- a/.github/workflows/k8s-commit-to-kargo-warehouse.yml
+++ b/.github/workflows/k8s-commit-to-kargo-warehouse.yml
@@ -9,6 +9,9 @@ on:
       codeai_docker_image_ref:
         required: true
         type: string
+      codeai_docker_image_digest:
+        required: true
+        type: string
       codeai_docker_tag:
         required: true
         type: string
@@ -21,6 +24,12 @@ jobs:
     name: commit to kargo warehouse
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout code-dot-org sources
+        uses: actions/checkout@v6.0.2
+        with:
+          sparse-checkout: |
+            k8s
+
       - name: Checkout k8s-gitops
         uses: actions/checkout@v6.0.2
         with:
@@ -29,87 +38,33 @@ jobs:
           path: k8s-gitops
           token: ${{ secrets.K8S_GITOPS_REPO_WRITE_TOKEN }}
 
-      - name: Update codeai deployment image
+      - name: Write CodeAI build-lock metadata
         shell: ruby {0}
         env:
           BRANCH_NAME: ${{ inputs.branch_name }}
           CODEAI_DOCKER_IMAGE_REF: ${{ inputs.codeai_docker_image_ref }}
+          CODEAI_DOCKER_IMAGE_DIGEST: ${{ inputs.codeai_docker_image_digest }}
           CODEAI_DOCKER_TAG: ${{ inputs.codeai_docker_tag }}
-          K8S_GITOPS_REPO_WRITE_TOKEN: ${{ secrets.K8S_GITOPS_REPO_WRITE_TOKEN }}
-
-        # if you're on vscode install this to get syntax highlighting in here:
-        # https://marketplace.visualstudio.com/items?itemName=harrydowning.yaml-embedded-languages
+          K8S_GITOPS_ROOT: k8s-gitops
         run: | # ruby
-          # We'll throw an error if we can't find a values.yaml for these branches
-          UPDATE_OR_ERROR_BRANCHES = %w[staging test levelbuilder production]
-
-          # This is the code-dot-org repo branch that was committed to / merged into.
-          BRANCH_NAME = ENV.fetch("BRANCH_NAME")
-
-          # We normalize deployment names with the same rule as docker tags in k8s-skaffold-build.yml
-          DEPLOYMENT_NAME = BRANCH_NAME.gsub(/[^a-zA-Z0-9_.-]/, '-')
-
-          # This is the newly built docker image ref that we'll be writing to values.yaml.
-          CODEAI_DOCKER_IMAGE_REF = ENV.fetch("CODEAI_DOCKER_IMAGE_REF")
-          CODEAI_DOCKER_TAG = ENV.fetch("CODEAI_DOCKER_TAG")
-          abort('ERROR: CODEAI_DOCKER_IMAGE_REF is empty, refusing to write back.') if CODEAI_DOCKER_IMAGE_REF.strip.empty?
-
-          # This is the values.yaml file in k8s-gitops repo that we'll update the `image: ` line in:
-          DEPLOYMENT_VALUES_YAML = "apps/codeai/deployments/#{DEPLOYMENT_NAME}/values.yaml"
-
-          # This is the updated line that we'll write to $DEPLOYMENT_VALUES_YAML:
-          UPDATED_DOCKER_IMAGE_LINE = "image: #{CODEAI_DOCKER_IMAGE_REF} # updated by k8s-commit-to-kargo-warehouse.yml\n"
-
           def system!(*cmd)
             ok = system(*cmd)
-            rendered_cmd = cmd.map(&:inspect).join(' ')
+            rendered_cmd = cmd.map(&:inspect).join(" ")
             raise "Command failed (exitstatus=#{Process.last_status&.exitstatus}): #{rendered_cmd}" unless ok
           end
 
+          system! "ruby", "k8s/kustomize/bin/write-build-lock"
+
           Dir.chdir("k8s-gitops") do
-            unless File.exist?(DEPLOYMENT_VALUES_YAML)
-              values_yaml_was_not_found_msg = "Tried to update image ref, but no values.yaml was found at: https://github.com/code-dot-org/k8s-gitops/tree/main/#{DEPLOYMENT_VALUES_YAML}"
-              if UPDATE_OR_ERROR_BRANCHES.include?(BRANCH_NAME)
-                abort("ERROR: deployment `#{DEPLOYMENT_NAME}` failed! #{values_yaml_was_not_found_msg}")
-              else
-                puts "::notice::Skipping deployment `#{DEPLOYMENT_NAME}`. #{values_yaml_was_not_found_msg}"
-                exit 0
-              end
-            end
+            system! "git", "config", "user.name", "github-actions[bot]"
+            system! "git", "config", "user.email", "41898282+github-actions[bot]@users.noreply.github.com"
+            system! "git", "add", "warehouses/codeai"
 
-            # Update values.yaml file line `image: *` with the newly built docker image's ref
-            updated_line = false
-            File.write(DEPLOYMENT_VALUES_YAML,
-              File.readlines(DEPLOYMENT_VALUES_YAML)
-                .map do |line|
-                  if line.start_with?('image: ')
-                    updated_line = true
-                    UPDATED_DOCKER_IMAGE_LINE
-                  else
-                    line
-                  end
-                end
-                .then { |lines| updated_line ? lines : [UPDATED_DOCKER_IMAGE_LINE] + lines }
-                .join
-            )
-
-            system! 'git config user.name "github-actions[bot]"'
-            system! 'git config user.email "41898282+github-actions[bot]@users.noreply.github.com"'
-            system! 'git', 'add', DEPLOYMENT_VALUES_YAML
-
-            if system('git diff --cached --quiet')
-              puts "Success: no diff of #{DEPLOYMENT_VALUES_YAML} detected, no commit+push needed."
+            if system("git diff --cached --quiet")
+              puts "Success: no release metadata diff detected, no commit+push needed."
               exit 0
             end
 
-            puts "Committing #{DEPLOYMENT_VALUES_YAML} to k8s-gitops repo"
-            system! 'git', 'commit', '-m', <<~MSG.chomp
-              #{DEPLOYMENT_VALUES_YAML} => #{CODEAI_DOCKER_TAG}
-            MSG
-
-            # Push to https://github.com/code-dot-org/k8s-gitops
-            puts "Pushing to https://github.com/code-dot-org/k8s-gitops"
-            system! 'git push origin HEAD:main'
-
-            puts "Success: committed+pushed newly built docker image tag #{CODEAI_DOCKER_TAG} to #{DEPLOYMENT_VALUES_YAML} on https://github.com/code-dot-org/k8s-gitops at #{Time.now.utc.strftime('%Y-%m-%dT%H:%M:%SZ')}"
+            system! "git", "commit", "-m", "Publish CodeAI release metadata for #{ENV.fetch("CODEAI_DOCKER_TAG")}"
+            system! "git", "push", "origin", "HEAD:main"
           end

--- a/.github/workflows/k8s-stitch-multiplatform-image.yml
+++ b/.github/workflows/k8s-stitch-multiplatform-image.yml
@@ -20,6 +20,9 @@ on:
       codeai_docker_image_ref:
         description: "Fully qualified docker image reference for the final multi-platform image"
         value: ${{ jobs.stitch-multi-platform.outputs.codeai_docker_image_ref }}
+      codeai_docker_image_digest:
+        description: "Digest for the final multi-platform image"
+        value: ${{ jobs.stitch-multi-platform.outputs.codeai_docker_image_digest }}
       codeai_docker_tag:
         description: "Docker tag for the final multi-platform image"
         value: ${{ jobs.stitch-multi-platform.outputs.codeai_docker_tag }}
@@ -42,6 +45,7 @@ jobs:
     name: stitch multi-platform image
     outputs:
       codeai_docker_image_ref: ${{ steps.export-image.outputs.codeai_docker_image_ref }}
+      codeai_docker_image_digest: ${{ steps.export-image.outputs.codeai_docker_image_digest }}
       codeai_docker_tag: ${{ steps.export-image.outputs.codeai_docker_tag }}
 
     # while we're experimental, we /never/ want to block a normal PR:
@@ -94,5 +98,7 @@ jobs:
       - name: Export stitched image ref
         id: export-image
         run: |
+          IMAGE_DIGEST=$(docker buildx imagetools inspect "$MULTI_PLATFORM_IMAGE" --format '{{json .Manifest}}' | jq -r '.digest')
           echo "codeai_docker_image_ref=$MULTI_PLATFORM_IMAGE" >> "$GITHUB_OUTPUT"
+          echo "codeai_docker_image_digest=$IMAGE_DIGEST" >> "$GITHUB_OUTPUT"
           echo "codeai_docker_tag=${{ inputs.docker_tag }}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/k8s-validate.yml
+++ b/.github/workflows/k8s-validate.yml
@@ -15,6 +15,7 @@ jobs:
         uses: actions/checkout@v6.0.2
         with:
           sparse-checkout: |
+            .github/workflows
             k8s
 
       - name: Checkout k8s-gitops

--- a/.github/workflows/k8s-validate.yml
+++ b/.github/workflows/k8s-validate.yml
@@ -1,7 +1,5 @@
-# Use this workflow to do any validation of k8s related files, this could
-# be linting, simple tests, etc. This runs in parallel with the skaffold
-# build, but before we commit to k8s-gitops our changes, so anything
-# that's faster than that won't hold up the overall flow.
+# Use this workflow to validate the source-driven Kustomize package and the
+# GitOps wrapper contract before release metadata is published.
 
 name: k8s-validate
 
@@ -13,16 +11,21 @@ jobs:
     name: validate
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout sources
+      - name: Checkout code-dot-org sources
         uses: actions/checkout@v6.0.2
         with:
           sparse-checkout: |
             k8s
 
-      - name: Setup Helm
-        uses: azure/setup-helm@v4
+      - name: Checkout k8s-gitops
+        uses: actions/checkout@v6.0.2
         with:
-          version: v3.19.0
+          repository: code-dot-org/k8s-gitops
+          ref: main
+          path: k8s-gitops
+          sparse-checkout: |
+            apps/codeai
+            apps/kargo-project-codeai
 
       - name: Setup Kustomize
         run: |
@@ -32,5 +35,5 @@ jobs:
           tar -xzf /tmp/kustomize.tar.gz -C /tmp
           sudo install /tmp/kustomize /usr/local/bin/kustomize
 
-      - name: Verify kustomize/helm parity
-        run: k8s/kustomize/bin/verify-helm-parity
+      - name: Verify thin-lock Kustomize contract
+        run: ruby k8s/kustomize/bin/verify-contract

--- a/.github/workflows/k8s.yml
+++ b/.github/workflows/k8s.yml
@@ -49,6 +49,7 @@ jobs:
   # deployments in apps/codeai/deployments/*
   commit-to-kargo-warehouse:
     name: commit to kargo warehouse
+    if: github.event_name == 'push'
     uses: ./.github/workflows/k8s-commit-to-kargo-warehouse.yml
     needs:
       - stitch-multiplatform-image
@@ -56,6 +57,7 @@ jobs:
     with:
       branch_name: ${{ github.head_ref || github.ref_name }}
       codeai_docker_image_ref: ${{ needs.stitch-multiplatform-image.outputs.codeai_docker_image_ref }}
+      codeai_docker_image_digest: ${{ needs.stitch-multiplatform-image.outputs.codeai_docker_image_digest }}
       codeai_docker_tag: ${{ needs.stitch-multiplatform-image.outputs.codeai_docker_tag }}
     secrets: inherit
 

--- a/k8s/kustomize/README.md
+++ b/k8s/kustomize/README.md
@@ -1,0 +1,14 @@
+# Code.org Kustomize Package
+
+This package is the source-oriented deploy entrypoint for CodeAI.
+
+## Layout
+
+- `base/`: shared deployable resources published for Argo CD consumption
+- `components/`: reusable package-local components
+- `local/`: local-development helper entrypoints only
+- `overlays/`: existing local/server-shaped helpers retained for parity and migration
+- `bin/`: helper scripts used by CI validation and release metadata writeback
+
+Argo CD should consume the remote `base/` path pinned to an exact `code-dot-org`
+commit from `k8s-gitops/apps/codeai/deployments/<deployment>/deploy/`.

--- a/k8s/kustomize/bin/verify-contract
+++ b/k8s/kustomize/bin/verify-contract
@@ -1,0 +1,156 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require 'fileutils'
+require 'open3'
+require 'pathname'
+require 'tmpdir'
+require 'yaml'
+
+CODE_DOT_ORG_ROOT = Pathname(ENV.fetch('CODE_DOT_ORG_ROOT', Dir.pwd))
+GITOPS_ROOT = Pathname(ENV.fetch('K8S_GITOPS_ROOT', CODE_DOT_ORG_ROOT.join('k8s-gitops').to_s))
+KUSTOMIZE_ROOT = CODE_DOT_ORG_ROOT.join('k8s/kustomize')
+SOURCE_PATH = 'k8s/kustomize'
+RESOURCE_REF_REGEX = %r{\Agithub\.com/code-dot-org/code-dot-org//#{Regexp.escape(SOURCE_PATH)}/base\?ref=[0-9a-f]{40}\z}
+
+def load_yaml(path)
+  Psych.safe_load_file(path)
+end
+
+def assert(condition, message)
+  return if condition
+
+  warn("ERROR: #{message}")
+  exit 1
+end
+
+def run!(*command, chdir: nil)
+  env = command.first.is_a?(Hash) ? command.shift : {}
+  options = {}
+  options[:chdir] = chdir if chdir
+  stdout, stderr, status =
+    if env.empty?
+      Open3.capture3(*command, **options)
+    else
+      Open3.capture3(env, *command, **options)
+    end
+  return stdout if status.success?
+
+  warn stdout unless stdout.empty?
+  warn stderr unless stderr.empty?
+  warn("ERROR: command failed: #{command.join(' ')}")
+  exit status.exitstatus
+end
+
+def ensure_kustomization_build(path)
+  run!('kustomize', 'build', path.to_s)
+end
+
+assert(KUSTOMIZE_ROOT.join('base/kustomization.yaml').exist?, 'missing k8s/kustomize/base/kustomization.yaml')
+assert(KUSTOMIZE_ROOT.join('local/overlays/development/kustomization.yaml').exist?, 'missing k8s/kustomize/local/overlays/development/kustomization.yaml')
+assert(KUSTOMIZE_ROOT.join('local/overlays/setup-db/kustomization.yaml').exist?, 'missing k8s/kustomize/local/overlays/setup-db/kustomization.yaml')
+assert(KUSTOMIZE_ROOT.join('local/overlays/setup-s3/kustomization.yaml').exist?, 'missing k8s/kustomize/local/overlays/setup-s3/kustomization.yaml')
+
+ensure_kustomization_build(KUSTOMIZE_ROOT.join('base'))
+ensure_kustomization_build(KUSTOMIZE_ROOT.join('local/overlays/development'))
+
+deployment_dirs = Dir.children(GITOPS_ROOT.join('apps/codeai/deployments')).sort
+deployment_dirs.each do |deployment|
+  deployment_root = GITOPS_ROOT.join('apps/codeai/deployments', deployment)
+  metadata_path = deployment_root.join('deployment.yaml')
+  next unless metadata_path.exist?
+
+  metadata = load_yaml(metadata_path)
+  assert(metadata['envType'].is_a?(String) && !metadata['envType'].empty?, "#{metadata_path} must set envType")
+  assert(metadata['namespace'].is_a?(String) && !metadata['namespace'].empty?, "#{metadata_path} must set namespace")
+
+  wrapper_path = deployment_root.join('deploy/kustomization.yaml')
+  assert(wrapper_path.exist?, "#{wrapper_path} must exist")
+  wrapper = load_yaml(wrapper_path)
+
+  assert(wrapper['apiVersion'] == 'kustomize.config.k8s.io/v1beta1', "#{wrapper_path} must be a v1beta1 Kustomization")
+  assert(wrapper['kind'] == 'Kustomization', "#{wrapper_path} must be kind Kustomization")
+  assert(wrapper['namespace'] == metadata['namespace'], "#{wrapper_path} namespace must match deployment metadata")
+
+  resources = wrapper['resources']
+  components = wrapper['components']
+  images = wrapper['images']
+
+  assert(resources.is_a?(Array) && resources.length == 1, "#{wrapper_path} must define exactly one resource")
+  assert(resources.first.match?(RESOURCE_REF_REGEX), "#{wrapper_path} resource must pin code-dot-org base by full sha")
+  assert(components == ["../../envTypes/#{metadata['envType']}"], "#{wrapper_path} must reference ../../envTypes/#{metadata['envType']}")
+  assert(images.is_a?(Array) && images.length == 1, "#{wrapper_path} must define exactly one image rewrite")
+  image = images.first
+  assert(image['name'] == 'code-dot-org', "#{wrapper_path} image name must be code-dot-org")
+  assert(image['newName'] == 'ghcr.io/code-dot-org/code-dot-org', "#{wrapper_path} image newName must target ghcr.io/code-dot-org/code-dot-org")
+  assert(image['newTag'].match?(/\Agit-[0-9a-f]{40}\z/), "#{wrapper_path} image newTag must be git-<full-commit-sha>")
+end
+
+env_type_dirs = Dir.children(GITOPS_ROOT.join('apps/codeai/envTypes')).sort
+env_type_dirs.each do |env_type|
+  path = GITOPS_ROOT.join('apps/codeai/envTypes', env_type)
+  next unless path.directory?
+
+  kustomization_path = path.join('kustomization.yaml')
+  next unless kustomization_path.exist?
+
+  doc = load_yaml(kustomization_path)
+  assert(doc['kind'] == 'Component', "#{kustomization_path} must be kind Component")
+end
+
+applicationset = load_yaml(GITOPS_ROOT.join('apps/codeai/applicationset.yaml'))
+source = applicationset.dig('spec', 'template', 'spec', 'sources', 0)
+assert(source['repoURL'] == 'https://github.com/code-dot-org/k8s-gitops.git', 'ApplicationSet must source deployments from k8s-gitops')
+assert(source['targetRevision'] == 'main', 'ApplicationSet must keep targetRevision on main')
+assert(source['path'] == 'apps/codeai/deployments/{{path.basename}}/deploy', 'ApplicationSet must deploy wrapper paths')
+
+k8s_workflow = File.read(CODE_DOT_ORG_ROOT.join('.github/workflows/k8s.yml'))
+assert(k8s_workflow.include?('source_commit_sha'), 'k8s.yml must pass source_commit_sha to k8s-skaffold-build')
+assert(k8s_workflow.include?('branch_tag_alias'), 'k8s.yml must pass branch_tag_alias to k8s-stitch-multiplatform-image')
+assert(k8s_workflow.include?('k8s-commit-to-kargo-warehouse.yml'), 'k8s.yml must call k8s-commit-to-kargo-warehouse.yml')
+
+Dir.mktmpdir('build-lock') do |tmpdir|
+  gitops_tmp = Pathname(tmpdir).join('k8s-gitops')
+  FileUtils.cp_r(GITOPS_ROOT, gitops_tmp)
+
+  env = {
+    'BRANCH_NAME' => 'staging',
+    'GIT_COMMIT' => '0123456789abcdef0123456789abcdef01234567',
+    'CODEAI_DOCKER_IMAGE_REF' => 'ghcr.io/code-dot-org/code-dot-org:git-0123456789abcdef0123456789abcdef01234567',
+    'CODEAI_DOCKER_TAG' => 'git-0123456789abcdef0123456789abcdef01234567',
+    'CODEAI_DOCKER_IMAGE_DIGEST' => 'sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef',
+    'K8S_GITOPS_ROOT' => gitops_tmp.to_s,
+    'CREATED_AT' => '2026-03-22T12:34:56Z'
+  }
+  run!(env, 'ruby', KUSTOMIZE_ROOT.join('bin/write-build-lock').to_s, chdir: CODE_DOT_ORG_ROOT.to_s)
+
+  current_path = gitops_tmp.join('warehouses/codeai/builds/current.yaml')
+  historical_path = gitops_tmp.join('warehouses/codeai/builds/git-0123456789abcdef0123456789abcdef01234567.yaml')
+  assert(current_path.exist?, 'write-build-lock must produce current.yaml')
+  assert(historical_path.exist?, 'write-build-lock must produce historical build-lock file')
+  assert(File.read(current_path) == File.read(historical_path), 'current.yaml and historical build-lock must be identical')
+
+  build_lock = load_yaml(current_path)
+  assert(build_lock.dig('packaging', 'kind') == 'kustomize', 'build-lock packaging.kind must be kustomize')
+  assert(build_lock.dig('packaging', 'sourcePath') == SOURCE_PATH, 'build-lock packaging.sourcePath must be k8s/kustomize')
+  assert(build_lock['releaseId'] == 'git-0123456789abcdef0123456789abcdef01234567', 'build-lock releaseId must match git commit tag')
+  assert(build_lock.dig('image', 'ref') == 'ghcr.io/code-dot-org/code-dot-org:git-0123456789abcdef0123456789abcdef01234567', 'build-lock image.ref must match immutable git tag')
+
+  env['BRANCH_NAME'] = 'test'
+  run!(env, 'ruby', KUSTOMIZE_ROOT.join('bin/write-build-lock').to_s, chdir: CODE_DOT_ORG_ROOT.to_s)
+  legacy_current_path = gitops_tmp.join('warehouses/codeai/legacy-gitflow/test/current.yaml')
+  legacy_merged_path = gitops_tmp.join('warehouses/codeai/legacy-gitflow/test/merged/git-0123456789abcdef0123456789abcdef01234567.yaml')
+  assert(legacy_current_path.exist?, 'write-build-lock must produce legacy current.yaml for test merges')
+  assert(legacy_merged_path.exist?, 'write-build-lock must produce legacy merged marker for test merges')
+
+  wrapper_path = GITOPS_ROOT.join('apps/codeai/deployments/staging/deploy/kustomization.yaml')
+  wrapper = load_yaml(wrapper_path)
+  Dir.mktmpdir('wrapper-smoke', GITOPS_ROOT.to_s) do |wrapper_tmp|
+    smoke_wrapper_path = Pathname(wrapper_tmp).join('kustomization.yaml')
+    smoke_wrapper = wrapper.dup
+    smoke_wrapper['resources'] = [KUSTOMIZE_ROOT.join('base').relative_path_from(smoke_wrapper_path.dirname).to_s]
+    smoke_wrapper['components'] = [GITOPS_ROOT.join('apps/codeai/envTypes/staging').relative_path_from(smoke_wrapper_path.dirname).to_s]
+    File.write(smoke_wrapper_path, YAML.dump(smoke_wrapper))
+    ensure_kustomization_build(smoke_wrapper_path.dirname)
+  end
+end

--- a/k8s/kustomize/bin/verify-contract
+++ b/k8s/kustomize/bin/verify-contract
@@ -107,6 +107,7 @@ assert(source['path'] == 'apps/codeai/deployments/{{path.basename}}/deploy', 'Ap
 k8s_workflow = File.read(CODE_DOT_ORG_ROOT.join('.github/workflows/k8s.yml'))
 assert(k8s_workflow.include?('source_commit_sha'), 'k8s.yml must pass source_commit_sha to k8s-skaffold-build')
 assert(k8s_workflow.include?('branch_tag_alias'), 'k8s.yml must pass branch_tag_alias to k8s-stitch-multiplatform-image')
+assert(k8s_workflow.include?('codeai_docker_image_digest'), 'k8s.yml must pass codeai_docker_image_digest to k8s-commit-to-kargo-warehouse.yml')
 assert(k8s_workflow.include?('k8s-commit-to-kargo-warehouse.yml'), 'k8s.yml must call k8s-commit-to-kargo-warehouse.yml')
 
 Dir.mktmpdir('build-lock') do |tmpdir|
@@ -135,6 +136,7 @@ Dir.mktmpdir('build-lock') do |tmpdir|
   assert(build_lock.dig('packaging', 'sourcePath') == SOURCE_PATH, 'build-lock packaging.sourcePath must be k8s/kustomize')
   assert(build_lock['releaseId'] == 'git-0123456789abcdef0123456789abcdef01234567', 'build-lock releaseId must match git commit tag')
   assert(build_lock.dig('image', 'ref') == 'ghcr.io/code-dot-org/code-dot-org:git-0123456789abcdef0123456789abcdef01234567', 'build-lock image.ref must match immutable git tag')
+  assert(build_lock.dig('image', 'digest') == 'sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef', 'build-lock image.digest must match the stitched image digest')
 
   env['BRANCH_NAME'] = 'test'
   run!(env, 'ruby', KUSTOMIZE_ROOT.join('bin/write-build-lock').to_s, chdir: CODE_DOT_ORG_ROOT.to_s)

--- a/k8s/kustomize/bin/verify-contract
+++ b/k8s/kustomize/bin/verify-contract
@@ -11,7 +11,7 @@ CODE_DOT_ORG_ROOT = Pathname(ENV.fetch('CODE_DOT_ORG_ROOT', Dir.pwd))
 GITOPS_ROOT = Pathname(ENV.fetch('K8S_GITOPS_ROOT', CODE_DOT_ORG_ROOT.join('k8s-gitops').to_s))
 KUSTOMIZE_ROOT = CODE_DOT_ORG_ROOT.join('k8s/kustomize')
 SOURCE_PATH = 'k8s/kustomize'
-RESOURCE_REF_REGEX = %r{\Agithub\.com/code-dot-org/code-dot-org//#{Regexp.escape(SOURCE_PATH)}/base\?ref=[0-9a-f]{40}\z}
+RESOURCE_REF_REGEX = %r{\Agithub\.com/code-dot-org/code-dot-org//#{Regexp.escape(SOURCE_PATH)}/base\?ref=[0-9a-f]{40}&timeout=120s\z}
 
 def load_yaml(path)
   Psych.safe_load_file(path)
@@ -43,7 +43,7 @@ def run!(*command, chdir: nil)
 end
 
 def ensure_kustomization_build(path)
-  run!('kustomize', 'build', path.to_s)
+  run!({'GIT_LFS_SKIP_SMUDGE' => '1'}, 'kustomize', 'build', path.to_s)
 end
 
 assert(KUSTOMIZE_ROOT.join('base/kustomization.yaml').exist?, 'missing k8s/kustomize/base/kustomization.yaml')
@@ -78,7 +78,7 @@ deployment_dirs.each do |deployment|
 
   assert(resources.is_a?(Array) && resources.length == 1, "#{wrapper_path} must define exactly one resource")
   assert(resources.first.match?(RESOURCE_REF_REGEX), "#{wrapper_path} resource must pin code-dot-org base by full sha")
-  assert(components == ["../../envTypes/#{metadata['envType']}"], "#{wrapper_path} must reference ../../envTypes/#{metadata['envType']}")
+  assert(components == ["../../../envTypes/#{metadata['envType']}"], "#{wrapper_path} must reference ../../../envTypes/#{metadata['envType']}")
   assert(images.is_a?(Array) && images.length == 1, "#{wrapper_path} must define exactly one image rewrite")
   image = images.first
   assert(image['name'] == 'code-dot-org', "#{wrapper_path} image name must be code-dot-org")
@@ -138,21 +138,43 @@ Dir.mktmpdir('build-lock') do |tmpdir|
   assert(build_lock.dig('image', 'ref') == 'ghcr.io/code-dot-org/code-dot-org:git-0123456789abcdef0123456789abcdef01234567', 'build-lock image.ref must match immutable git tag')
   assert(build_lock.dig('image', 'digest') == 'sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef', 'build-lock image.digest must match the stitched image digest')
 
-  env['BRANCH_NAME'] = 'test'
-  run!(env, 'ruby', KUSTOMIZE_ROOT.join('bin/write-build-lock').to_s, chdir: CODE_DOT_ORG_ROOT.to_s)
-  legacy_current_path = gitops_tmp.join('warehouses/codeai/legacy-gitflow/test/current.yaml')
-  legacy_merged_path = gitops_tmp.join('warehouses/codeai/legacy-gitflow/test/merged/git-0123456789abcdef0123456789abcdef01234567.yaml')
-  assert(legacy_current_path.exist?, 'write-build-lock must produce legacy current.yaml for test merges')
-  assert(legacy_merged_path.exist?, 'write-build-lock must produce legacy merged marker for test merges')
+  Dir.mktmpdir('legacy-merge-repo') do |repo_tmp|
+    repo_root = Pathname(repo_tmp)
+    run!('git', 'init', '-b', 'test', chdir: repo_root.to_s)
+    run!('git', 'config', 'user.name', 'Codex', chdir: repo_root.to_s)
+    run!('git', 'config', 'user.email', 'codex@example.com', chdir: repo_root.to_s)
 
-  wrapper_path = GITOPS_ROOT.join('apps/codeai/deployments/staging/deploy/kustomization.yaml')
-  wrapper = load_yaml(wrapper_path)
-  Dir.mktmpdir('wrapper-smoke', GITOPS_ROOT.to_s) do |wrapper_tmp|
-    smoke_wrapper_path = Pathname(wrapper_tmp).join('kustomization.yaml')
-    smoke_wrapper = wrapper.dup
-    smoke_wrapper['resources'] = [KUSTOMIZE_ROOT.join('base').relative_path_from(smoke_wrapper_path.dirname).to_s]
-    smoke_wrapper['components'] = [GITOPS_ROOT.join('apps/codeai/envTypes/staging').relative_path_from(smoke_wrapper_path.dirname).to_s]
-    File.write(smoke_wrapper_path, YAML.dump(smoke_wrapper))
-    ensure_kustomization_build(smoke_wrapper_path.dirname)
+    File.write(repo_root.join('README.md'), "base\n")
+    run!('git', 'add', 'README.md', chdir: repo_root.to_s)
+    run!('git', 'commit', '-m', 'base', chdir: repo_root.to_s)
+
+    run!('git', 'checkout', '-b', 'staging', chdir: repo_root.to_s)
+    File.write(repo_root.join('STAGING.txt'), "staging release\n")
+    run!('git', 'add', 'STAGING.txt', chdir: repo_root.to_s)
+    run!('git', 'commit', '-m', 'staging release', chdir: repo_root.to_s)
+    upstream_release_commit = run!('git', 'rev-parse', 'HEAD', chdir: repo_root.to_s).strip
+
+    run!('git', 'checkout', 'test', chdir: repo_root.to_s)
+    File.write(repo_root.join('TEST.txt'), "test branch\n")
+    run!('git', 'add', 'TEST.txt', chdir: repo_root.to_s)
+    run!('git', 'commit', '-m', 'test branch', chdir: repo_root.to_s)
+    run!('git', 'merge', '--no-ff', 'staging', '-m', 'merge staging into test', chdir: repo_root.to_s)
+    merge_commit = run!('git', 'rev-parse', 'HEAD', chdir: repo_root.to_s).strip
+
+    env['BRANCH_NAME'] = 'test'
+    env['GIT_COMMIT'] = merge_commit
+    env['CODEAI_DOCKER_TAG'] = "git-#{merge_commit}"
+    env['CODEAI_DOCKER_IMAGE_REF'] = "ghcr.io/code-dot-org/code-dot-org:git-#{merge_commit}"
+    run!(env, 'ruby', KUSTOMIZE_ROOT.join('bin/write-build-lock').to_s, chdir: repo_root.to_s)
+
+    legacy_current_path = gitops_tmp.join('warehouses/codeai/legacy-gitflow/test/current.yaml')
+    legacy_current = load_yaml(legacy_current_path)
+    assert(legacy_current_path.exist?, 'write-build-lock must produce legacy current.yaml for test merges')
+    assert(legacy_current['revision'] == upstream_release_commit, 'legacy current.yaml must track the merged-in release commit')
+    assert(legacy_current['tag'] == "git-#{upstream_release_commit}", 'legacy current.yaml tag must track the merged-in release commit')
+    assert(gitops_tmp.join('warehouses/codeai/legacy-gitflow/test/merged', "git-#{upstream_release_commit}.yaml").exist?, 'write-build-lock must key the merged marker from the merged-in release commit')
+    assert(!gitops_tmp.join('warehouses/codeai/legacy-gitflow/test/merged', "git-#{merge_commit}.yaml").exist?, 'write-build-lock must not key the merged marker from the downstream merge commit')
   end
+
+  ensure_kustomization_build(GITOPS_ROOT.join('apps/codeai/deployments/staging/deploy'))
 end

--- a/k8s/kustomize/bin/write-build-lock
+++ b/k8s/kustomize/bin/write-build-lock
@@ -14,10 +14,15 @@ image_tag = ENV.fetch('CODEAI_DOCKER_TAG')
 gitops_root = File.expand_path(ENV.fetch('K8S_GITOPS_ROOT'))
 created_at = ENV.fetch('CREATED_AT', Time.now.utc.iso8601)
 git_commit = ENV.fetch('GIT_COMMIT', image_tag.delete_prefix('git-'))
+image_digest = ENV.fetch('CODEAI_DOCKER_IMAGE_DIGEST', nil)
 
 expected_release_tag = "git-#{git_commit}"
 abort("Expected CODEAI_DOCKER_TAG=#{expected_release_tag}, got #{image_tag}") if image_tag != expected_release_tag
 abort("Expected CODEAI_DOCKER_IMAGE_REF to end with :#{image_tag}") unless image_ref.end_with?(":#{image_tag}")
+if branch_name == RELEASE_BRANCH
+  abort('Expected CODEAI_DOCKER_IMAGE_DIGEST to be set for release metadata') if image_digest.to_s.empty?
+  abort("Expected CODEAI_DOCKER_IMAGE_DIGEST to look like sha256:<64 hex>, got #{image_digest}") unless image_digest.match?(/\Asha256:[0-9a-f]{64}\z/)
+end
 
 def write_yaml(path, payload)
   FileUtils.mkdir_p(File.dirname(path))
@@ -31,7 +36,7 @@ if branch_name == RELEASE_BRANCH
     'gitCommit' => git_commit,
     'image' => {
       'ref' => image_ref,
-      'digest' => ENV['CODEAI_DOCKER_IMAGE_DIGEST'] || ''
+      'digest' => image_digest
     },
     'packaging' => {
       'kind' => 'kustomize',

--- a/k8s/kustomize/bin/write-build-lock
+++ b/k8s/kustomize/bin/write-build-lock
@@ -2,6 +2,7 @@
 # frozen_string_literal: true
 
 require 'fileutils'
+require 'open3'
 require 'time'
 require 'yaml'
 
@@ -17,11 +18,30 @@ git_commit = ENV.fetch('GIT_COMMIT', image_tag.delete_prefix('git-'))
 image_digest = ENV.fetch('CODEAI_DOCKER_IMAGE_DIGEST', nil)
 
 expected_release_tag = "git-#{git_commit}"
-abort("Expected CODEAI_DOCKER_TAG=#{expected_release_tag}, got #{image_tag}") if image_tag != expected_release_tag
 abort("Expected CODEAI_DOCKER_IMAGE_REF to end with :#{image_tag}") unless image_ref.end_with?(":#{image_tag}")
 if branch_name == RELEASE_BRANCH
+  abort("Expected CODEAI_DOCKER_TAG=#{expected_release_tag}, got #{image_tag}") if image_tag != expected_release_tag
   abort('Expected CODEAI_DOCKER_IMAGE_DIGEST to be set for release metadata') if image_digest.to_s.empty?
   abort("Expected CODEAI_DOCKER_IMAGE_DIGEST to look like sha256:<64 hex>, got #{image_digest}") unless image_digest.match?(/\Asha256:[0-9a-f]{64}\z/)
+end
+
+def legacy_release_git_commit(branch_name, default_git_commit)
+  return default_git_commit if branch_name == RELEASE_BRANCH
+
+  explicit = ENV.fetch('LEGACY_RELEASE_GIT_COMMIT', nil)
+  return explicit unless explicit.to_s.empty?
+
+  stdout, stderr, status = Open3.capture3('git', 'rev-list', '--parents', '-n', '1', 'HEAD')
+  warn stderr unless status.success? || stderr.empty?
+  return default_git_commit unless status.success?
+
+  parents = stdout.split.drop(1)
+  return default_git_commit unless parents.length >= 2
+
+  # Legacy promotions merge the upstream release branch into the downstream branch.
+  # The promoted release identity is the merged-in branch tip (second parent), not the
+  # downstream merge commit written to the legacy branch itself.
+  parents[1]
 end
 
 def write_yaml(path, payload)
@@ -56,12 +76,14 @@ if branch_name == RELEASE_BRANCH
 end
 
 if LEGACY_BRANCHES.include?(branch_name)
+  release_git_commit = legacy_release_git_commit(branch_name, git_commit)
+  release_tag = "git-#{release_git_commit}"
   payload = {
-    'revision' => git_commit,
-    'tag' => image_tag,
+    'revision' => release_git_commit,
+    'tag' => release_tag,
     'mergedAt' => created_at
   }
   branch_dir = File.join(gitops_root, 'warehouses/codeai/legacy-gitflow', branch_name)
   write_yaml(File.join(branch_dir, 'current.yaml'), payload)
-  write_yaml(File.join(branch_dir, 'merged', "#{image_tag}.yaml"), payload)
+  write_yaml(File.join(branch_dir, 'merged', "#{release_tag}.yaml"), payload)
 end

--- a/k8s/kustomize/bin/write-build-lock
+++ b/k8s/kustomize/bin/write-build-lock
@@ -1,0 +1,62 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require 'fileutils'
+require 'time'
+require 'yaml'
+
+RELEASE_BRANCH = 'staging'
+LEGACY_BRANCHES = %w[staging test levelbuilder production].freeze
+
+branch_name = ENV.fetch('BRANCH_NAME')
+image_ref = ENV.fetch('CODEAI_DOCKER_IMAGE_REF')
+image_tag = ENV.fetch('CODEAI_DOCKER_TAG')
+gitops_root = File.expand_path(ENV.fetch('K8S_GITOPS_ROOT'))
+created_at = ENV.fetch('CREATED_AT', Time.now.utc.iso8601)
+git_commit = ENV.fetch('GIT_COMMIT', image_tag.delete_prefix('git-'))
+
+expected_release_tag = "git-#{git_commit}"
+abort("Expected CODEAI_DOCKER_TAG=#{expected_release_tag}, got #{image_tag}") if image_tag != expected_release_tag
+abort("Expected CODEAI_DOCKER_IMAGE_REF to end with :#{image_tag}") unless image_ref.end_with?(":#{image_tag}")
+
+def write_yaml(path, payload)
+  FileUtils.mkdir_p(File.dirname(path))
+  File.write(path, YAML.dump(payload))
+end
+
+if branch_name == RELEASE_BRANCH
+  payload = {
+    'schemaVersion' => 'v1',
+    'releaseId' => image_tag,
+    'gitCommit' => git_commit,
+    'image' => {
+      'ref' => image_ref,
+      'digest' => ENV['CODEAI_DOCKER_IMAGE_DIGEST'] || ''
+    },
+    'packaging' => {
+      'kind' => 'kustomize',
+      'sourceRepo' => 'https://github.com/code-dot-org/code-dot-org.git',
+      'sourcePath' => 'k8s/kustomize'
+    },
+    'createdAt' => created_at
+  }
+
+  builds_dir = File.join(gitops_root, 'warehouses/codeai/builds')
+  historical_path = File.join(builds_dir, "#{image_tag}.yaml")
+  current_path = File.join(builds_dir, 'current.yaml')
+  rendered = YAML.dump(payload)
+  FileUtils.mkdir_p(builds_dir)
+  File.write(historical_path, rendered)
+  File.write(current_path, rendered)
+end
+
+if LEGACY_BRANCHES.include?(branch_name)
+  payload = {
+    'revision' => git_commit,
+    'tag' => image_tag,
+    'mergedAt' => created_at
+  }
+  branch_dir = File.join(gitops_root, 'warehouses/codeai/legacy-gitflow', branch_name)
+  write_yaml(File.join(branch_dir, 'current.yaml'), payload)
+  write_yaml(File.join(branch_dir, 'merged', "#{image_tag}.yaml"), payload)
+end

--- a/k8s/kustomize/local/overlays/development/deployment.patch.yaml
+++ b/k8s/kustomize/local/overlays/development/deployment.patch.yaml
@@ -1,0 +1,16 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: cdo-dashboard
+spec:
+  template:
+    spec:
+      containers:
+        - name: dashboard
+          env:
+            - name: RAILS_ENV
+              value: development
+            - name: RACK_ENV
+              value: development
+          securityContext:
+            allowPrivilegeEscalation: true

--- a/k8s/kustomize/local/overlays/development/kustomization.yaml
+++ b/k8s/kustomize/local/overlays/development/kustomization.yaml
@@ -1,0 +1,19 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../../base
+patches:
+  - path: deployment.patch.yaml
+  - target:
+      kind: Deployment
+      name: cdo-dashboard
+    patch: |-
+      - op: replace
+        path: /spec/template/spec/containers/0/envFrom/1/secretRef/optional
+        value: true
+labels:
+  - pairs:
+      app.kubernetes.io/name: cdo
+      app.kubernetes.io/instance: cdo
+    includeSelectors: true
+    includeTemplates: true

--- a/k8s/kustomize/local/overlays/setup-db/kustomization.yaml
+++ b/k8s/kustomize/local/overlays/setup-db/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../../overlays/setup-db

--- a/k8s/kustomize/local/overlays/setup-s3/kustomization.yaml
+++ b/k8s/kustomize/local/overlays/setup-s3/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../../overlays/setup-s3


### PR DESCRIPTION
# Argo Refs code-dot-org Commit

**Short name:** Argo refs commit

**Catchy description:** Write one tiny release record to `warehouses/codeai/`,
then let Argo CD deploy Kustomize source pinned to a `code-dot-org` commit.

## Detailed Technical Description of Plan
This plan is the simplest source-driven Kargo design in iteration 7. Kargo does
not snapshot a release package or render review output into Freight; instead it
promotes a tiny Git build-lock record from `k8s-gitops` that names one exact
`code-dot-org` commit and one exact image tag/digest. The build-lock is the
release record, and `current.yaml` is just a stable parse path to that same
record. The whole point is to keep Freight small, deterministic, and easy to
audit while still letting the real deploy source live in `code-dot-org`.

Argo points at `k8s-gitops/apps/codeai/deployments/<deployment>/deploy/`, where
the deploy tree is built from the checked-in `code-dot-org/k8s/kustomize/`
package plus the envType `Component`s under `apps/codeai/envTypes/<envType>/`.
That is the main conceptual difference from the rendered-branch plans: here the
GitOps repo does not store rendered output, it stores the deploy entrypoint and
env policy that tell Argo how to materialize source at the right commit.

The tricky part is that the plan looks deceptively simple until you try to make
promotion and deploy truth line up. The build-lock file must be written
atomically as both `git-<full-commit-sha>.yaml` and `current.yaml`, and the GH
action must keep the image tag and the lock file in sync.

- **Type:** Source-driven plan
- **Pattern:** Source-driven
- **Rendered manifests pattern:** No


argo-refs-code-dot-org-commit

Other PR: https://github.com/code-dot-org/k8s-gitops/pull/3
