### PR TITLE
Source Snapshot (Helm) + Rendered Branches

### DIFF
--- a/.github/workflows/k8s-commit-to-kargo-warehouse.yml
+++ b/.github/workflows/k8s-commit-to-kargo-warehouse.yml
@@ -6,7 +6,13 @@ on:
       branch_name:
         required: true
         type: string
+      source_commit_sha:
+        required: true
+        type: string
       codeai_docker_image_ref:
+        required: true
+        type: string
+      codeai_docker_image_digest:
         required: true
         type: string
       codeai_docker_tag:
@@ -21,6 +27,13 @@ jobs:
     name: commit to kargo warehouse
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout code-dot-org deploy source
+        uses: actions/checkout@v6.0.2
+        with:
+          sparse-checkout: |
+            k8s/helm
+          path: code-dot-org
+
       - name: Checkout k8s-gitops
         uses: actions/checkout@v6.0.2
         with:
@@ -29,36 +42,60 @@ jobs:
           path: k8s-gitops
           token: ${{ secrets.K8S_GITOPS_REPO_WRITE_TOKEN }}
 
-      - name: Update codeai deployment image
+      - name: Publish frozen codeai freight
         shell: ruby {0}
         env:
           BRANCH_NAME: ${{ inputs.branch_name }}
+          SOURCE_COMMIT_SHA: ${{ inputs.source_commit_sha }}
           CODEAI_DOCKER_IMAGE_REF: ${{ inputs.codeai_docker_image_ref }}
+          CODEAI_DOCKER_IMAGE_DIGEST: ${{ inputs.codeai_docker_image_digest }}
           CODEAI_DOCKER_TAG: ${{ inputs.codeai_docker_tag }}
           K8S_GITOPS_REPO_WRITE_TOKEN: ${{ secrets.K8S_GITOPS_REPO_WRITE_TOKEN }}
 
         # if you're on vscode install this to get syntax highlighting in here:
         # https://marketplace.visualstudio.com/items?itemName=harrydowning.yaml-embedded-languages
         run: | # ruby
-          # We'll throw an error if we can't find a values.yaml for these branches
-          UPDATE_OR_ERROR_BRANCHES = %w[staging test levelbuilder production]
+          require "fileutils"
+          require "time"
+          require "yaml"
 
-          # This is the code-dot-org repo branch that was committed to / merged into.
+          MANAGED_BRANCHES = %w[staging test levelbuilder production]
+
           BRANCH_NAME = ENV.fetch("BRANCH_NAME")
-
-          # We normalize deployment names with the same rule as docker tags in k8s-skaffold-build.yml
-          DEPLOYMENT_NAME = BRANCH_NAME.gsub(/[^a-zA-Z0-9_.-]/, '-')
-
-          # This is the newly built docker image ref that we'll be writing to values.yaml.
+          SOURCE_COMMIT_SHA = ENV.fetch("SOURCE_COMMIT_SHA")
           CODEAI_DOCKER_IMAGE_REF = ENV.fetch("CODEAI_DOCKER_IMAGE_REF")
+          CODEAI_DOCKER_IMAGE_DIGEST = ENV.fetch("CODEAI_DOCKER_IMAGE_DIGEST")
           CODEAI_DOCKER_TAG = ENV.fetch("CODEAI_DOCKER_TAG")
-          abort('ERROR: CODEAI_DOCKER_IMAGE_REF is empty, refusing to write back.') if CODEAI_DOCKER_IMAGE_REF.strip.empty?
 
-          # This is the values.yaml file in k8s-gitops repo that we'll update the `image: ` line in:
-          DEPLOYMENT_VALUES_YAML = "apps/codeai/deployments/#{DEPLOYMENT_NAME}/values.yaml"
+          RELEASE_TAG = "git-#{SOURCE_COMMIT_SHA}"
+          abort("ERROR: CODEAI_DOCKER_IMAGE_REF is empty, refusing to write freight.") if CODEAI_DOCKER_IMAGE_REF.strip.empty?
+          abort("ERROR: CODEAI_DOCKER_IMAGE_DIGEST is empty, refusing to write freight.") if CODEAI_DOCKER_IMAGE_DIGEST.strip.empty?
+          abort("ERROR: CODEAI_DOCKER_TAG=#{CODEAI_DOCKER_TAG.inspect} did not match expected #{RELEASE_TAG.inspect}.") unless CODEAI_DOCKER_TAG == RELEASE_TAG
 
-          # This is the updated line that we'll write to $DEPLOYMENT_VALUES_YAML:
-          UPDATED_DOCKER_IMAGE_LINE = "image: #{CODEAI_DOCKER_IMAGE_REF} # updated by k8s-commit-to-kargo-warehouse.yml\n"
+          unless MANAGED_BRANCHES.include?(BRANCH_NAME)
+            puts "::notice::Skipping warehouse publish for branch #{BRANCH_NAME.inspect}. Managed branches: #{MANAGED_BRANCHES.join(', ')}"
+            exit 0
+          end
+
+          SOURCE_HELM_DIR = File.expand_path("code-dot-org/k8s/helm", Dir.pwd)
+          abort("ERROR: expected Helm source at #{SOURCE_HELM_DIR}") unless Dir.exist?(SOURCE_HELM_DIR)
+
+          FREIGHT_RELATIVE_DIR = "warehouses/codeai/freight"
+          CURRENT_RELATIVE_DIR = "#{FREIGHT_RELATIVE_DIR}/current"
+          RELEASE_RELATIVE_DIR = "#{FREIGHT_RELATIVE_DIR}/#{RELEASE_TAG}"
+
+          created_at = Time.now.utc.iso8601
+          freight_yaml = {
+            "schemaVersion" => "v1",
+            "revision" => SOURCE_COMMIT_SHA,
+            "tag" => RELEASE_TAG,
+            "image" => {
+              "ref" => CODEAI_DOCKER_IMAGE_REF,
+              "digest" => CODEAI_DOCKER_IMAGE_DIGEST,
+            },
+            "packageType" => "helm",
+            "createdAt" => created_at,
+          }.to_yaml(line_width: -1)
 
           def system!(*cmd)
             ok = system(*cmd)
@@ -66,50 +103,33 @@ jobs:
             raise "Command failed (exitstatus=#{Process.last_status&.exitstatus}): #{rendered_cmd}" unless ok
           end
 
-          Dir.chdir("k8s-gitops") do
-            unless File.exist?(DEPLOYMENT_VALUES_YAML)
-              values_yaml_was_not_found_msg = "Tried to update image ref, but no values.yaml was found at: https://github.com/code-dot-org/k8s-gitops/tree/main/#{DEPLOYMENT_VALUES_YAML}"
-              if UPDATE_OR_ERROR_BRANCHES.include?(BRANCH_NAME)
-                abort("ERROR: deployment `#{DEPLOYMENT_NAME}` failed! #{values_yaml_was_not_found_msg}")
-              else
-                puts "::notice::Skipping deployment `#{DEPLOYMENT_NAME}`. #{values_yaml_was_not_found_msg}"
-                exit 0
-              end
-            end
+          def rebuild_freight_dir(relative_dir, freight_yaml:, source_helm_dir:)
+            FileUtils.rm_rf(relative_dir)
+            FileUtils.mkdir_p("#{relative_dir}/helm")
+            File.write("#{relative_dir}/freight.yaml", freight_yaml)
+            FileUtils.cp_r("#{source_helm_dir}/.", "#{relative_dir}/helm")
+          end
 
-            # Update values.yaml file line `image: *` with the newly built docker image's ref
-            updated_line = false
-            File.write(DEPLOYMENT_VALUES_YAML,
-              File.readlines(DEPLOYMENT_VALUES_YAML)
-                .map do |line|
-                  if line.start_with?('image: ')
-                    updated_line = true
-                    UPDATED_DOCKER_IMAGE_LINE
-                  else
-                    line
-                  end
-                end
-                .then { |lines| updated_line ? lines : [UPDATED_DOCKER_IMAGE_LINE] + lines }
-                .join
-            )
+          Dir.chdir("k8s-gitops") do
+            rebuild_freight_dir(CURRENT_RELATIVE_DIR, freight_yaml: freight_yaml, source_helm_dir: SOURCE_HELM_DIR)
+            rebuild_freight_dir(RELEASE_RELATIVE_DIR, freight_yaml: freight_yaml, source_helm_dir: SOURCE_HELM_DIR)
 
             system! 'git config user.name "github-actions[bot]"'
             system! 'git config user.email "41898282+github-actions[bot]@users.noreply.github.com"'
-            system! 'git', 'add', DEPLOYMENT_VALUES_YAML
+            system! "git", "add", CURRENT_RELATIVE_DIR, RELEASE_RELATIVE_DIR
 
-            if system('git diff --cached --quiet')
-              puts "Success: no diff of #{DEPLOYMENT_VALUES_YAML} detected, no commit+push needed."
+            if system("git diff --cached --quiet")
+              puts "Success: no diff in #{CURRENT_RELATIVE_DIR} or #{RELEASE_RELATIVE_DIR}, no commit+push needed."
               exit 0
             end
 
-            puts "Committing #{DEPLOYMENT_VALUES_YAML} to k8s-gitops repo"
-            system! 'git', 'commit', '-m', <<~MSG.chomp
-              #{DEPLOYMENT_VALUES_YAML} => #{CODEAI_DOCKER_TAG}
+            puts "Committing #{RELEASE_TAG} freight snapshot to k8s-gitops repo"
+            system! "git", "commit", "-m", <<~MSG.chomp
+              Publish codeai freight #{RELEASE_TAG}
             MSG
 
-            # Push to https://github.com/code-dot-org/k8s-gitops
             puts "Pushing to https://github.com/code-dot-org/k8s-gitops"
-            system! 'git push origin HEAD:main'
+            system! "git", "push", "origin", "HEAD:main"
 
-            puts "Success: committed+pushed newly built docker image tag #{CODEAI_DOCKER_TAG} to #{DEPLOYMENT_VALUES_YAML} on https://github.com/code-dot-org/k8s-gitops at #{Time.now.utc.strftime('%Y-%m-%dT%H:%M:%SZ')}"
+            puts "Success: committed+pushed freight #{RELEASE_TAG} to #{FREIGHT_RELATIVE_DIR} on https://github.com/code-dot-org/k8s-gitops at #{Time.now.utc.strftime('%Y-%m-%dT%H:%M:%SZ')}"
           end

--- a/.github/workflows/k8s-commit-to-kargo-warehouse.yml
+++ b/.github/workflows/k8s-commit-to-kargo-warehouse.yml
@@ -42,7 +42,7 @@ jobs:
           path: k8s-gitops
           token: ${{ secrets.K8S_GITOPS_REPO_WRITE_TOKEN }}
 
-      - name: Publish frozen codeai freight
+      - name: Publish frozen codeai freight and legacy-gitflow metadata
         shell: ruby {0}
         env:
           BRANCH_NAME: ${{ inputs.branch_name }}
@@ -69,6 +69,7 @@ jobs:
           CODEAI_DOCKER_TAG = ENV.fetch("CODEAI_DOCKER_TAG")
 
           RELEASE_TAG = "git-#{SOURCE_COMMIT_SHA}"
+          LEGACY_GITFLOW_RELATIVE_DIR = "warehouses/codeai/legacy-gitflow"
           abort("ERROR: CODEAI_DOCKER_IMAGE_REF is empty, refusing to write freight.") if CODEAI_DOCKER_IMAGE_REF.strip.empty?
           abort("ERROR: CODEAI_DOCKER_IMAGE_DIGEST is empty, refusing to write freight.") if CODEAI_DOCKER_IMAGE_DIGEST.strip.empty?
           abort("ERROR: CODEAI_DOCKER_TAG=#{CODEAI_DOCKER_TAG.inspect} did not match expected #{RELEASE_TAG.inspect}.") unless CODEAI_DOCKER_TAG == RELEASE_TAG
@@ -80,10 +81,13 @@ jobs:
 
           SOURCE_HELM_DIR = File.expand_path("code-dot-org/k8s/helm", Dir.pwd)
           abort("ERROR: expected Helm source at #{SOURCE_HELM_DIR}") unless Dir.exist?(SOURCE_HELM_DIR)
+          MERGED_AT = `git -C code-dot-org show -s --format=%cI HEAD`.strip
+          abort("ERROR: unable to determine mergedAt for #{RELEASE_TAG}.") if MERGED_AT.empty?
 
           FREIGHT_RELATIVE_DIR = "warehouses/codeai/freight"
           CURRENT_RELATIVE_DIR = "#{FREIGHT_RELATIVE_DIR}/current"
           RELEASE_RELATIVE_DIR = "#{FREIGHT_RELATIVE_DIR}/#{RELEASE_TAG}"
+          LEGACY_BRANCH_RELATIVE_DIR = "#{LEGACY_GITFLOW_RELATIVE_DIR}/#{BRANCH_NAME}"
 
           EXPECTED_FREIGHT = {
             "schemaVersion" => "v1",
@@ -94,6 +98,11 @@ jobs:
               "digest" => CODEAI_DOCKER_IMAGE_DIGEST,
             },
             "packageType" => "helm",
+          }.freeze
+          EXPECTED_LEGACY_GATE = {
+            "revision" => SOURCE_COMMIT_SHA,
+            "tag" => RELEASE_TAG,
+            "mergedAt" => MERGED_AT,
           }.freeze
 
           def system!(*cmd)
@@ -155,6 +164,12 @@ jobs:
             FileUtils.cp_r("#{source_relative_dir}/.", destination_relative_dir)
           end
 
+          def write_legacy_gate_dir(relative_dir, gate_hash:, release_tag:)
+            FileUtils.mkdir_p(File.join(relative_dir, "merged"))
+            File.write(File.join(relative_dir, "current.yaml"), gate_hash.to_yaml(line_width: -1))
+            File.write(File.join(relative_dir, "merged", "#{release_tag}.yaml"), gate_hash.to_yaml(line_width: -1))
+          end
+
           Dir.chdir("k8s-gitops") do
             release_freight_exists = Dir.exist?(RELEASE_RELATIVE_DIR)
 
@@ -173,10 +188,11 @@ jobs:
             end
 
             mirror_freight_dir(RELEASE_RELATIVE_DIR, CURRENT_RELATIVE_DIR)
+            write_legacy_gate_dir(LEGACY_BRANCH_RELATIVE_DIR, gate_hash: EXPECTED_LEGACY_GATE, release_tag: RELEASE_TAG)
 
             system! 'git config user.name "github-actions[bot]"'
             system! 'git config user.email "41898282+github-actions[bot]@users.noreply.github.com"'
-            system! "git", "add", CURRENT_RELATIVE_DIR, RELEASE_RELATIVE_DIR
+            system! "git", "add", CURRENT_RELATIVE_DIR, RELEASE_RELATIVE_DIR, LEGACY_BRANCH_RELATIVE_DIR
 
             if system("git diff --cached --quiet")
               puts "Success: no diff in #{CURRENT_RELATIVE_DIR} or #{RELEASE_RELATIVE_DIR}, no commit+push needed."

--- a/.github/workflows/k8s-commit-to-kargo-warehouse.yml
+++ b/.github/workflows/k8s-commit-to-kargo-warehouse.yml
@@ -56,6 +56,7 @@ jobs:
         # https://marketplace.visualstudio.com/items?itemName=harrydowning.yaml-embedded-languages
         run: | # ruby
           require "fileutils"
+          require "find"
           require "time"
           require "yaml"
 
@@ -84,8 +85,7 @@ jobs:
           CURRENT_RELATIVE_DIR = "#{FREIGHT_RELATIVE_DIR}/current"
           RELEASE_RELATIVE_DIR = "#{FREIGHT_RELATIVE_DIR}/#{RELEASE_TAG}"
 
-          created_at = Time.now.utc.iso8601
-          freight_yaml = {
+          EXPECTED_FREIGHT = {
             "schemaVersion" => "v1",
             "revision" => SOURCE_COMMIT_SHA,
             "tag" => RELEASE_TAG,
@@ -94,8 +94,7 @@ jobs:
               "digest" => CODEAI_DOCKER_IMAGE_DIGEST,
             },
             "packageType" => "helm",
-            "createdAt" => created_at,
-          }.to_yaml(line_width: -1)
+          }.freeze
 
           def system!(*cmd)
             ok = system(*cmd)
@@ -103,16 +102,77 @@ jobs:
             raise "Command failed (exitstatus=#{Process.last_status&.exitstatus}): #{rendered_cmd}" unless ok
           end
 
-          def rebuild_freight_dir(relative_dir, freight_yaml:, source_helm_dir:)
+          def snapshot_tree(root)
+            entries = {}
+
+            Find.find(root) do |path|
+              next if path == root
+
+              relative_path = path.delete_prefix("#{root}/")
+              if File.directory?(path)
+                entries[relative_path] = :directory
+              else
+                entries[relative_path] = [:file, File.binread(path)]
+              end
+            end
+
+            entries
+          end
+
+          def validate_existing_freight!(relative_dir, expected_freight:, source_helm_dir:)
+            freight_path = File.join(relative_dir, "freight.yaml")
+            helm_path = File.join(relative_dir, "helm")
+
+            abort("ERROR: existing frozen freight is missing #{freight_path}") unless File.exist?(freight_path)
+            abort("ERROR: existing frozen freight is missing #{helm_path}") unless Dir.exist?(helm_path)
+
+            actual_freight = YAML.load_file(freight_path)
+            comparable_freight = actual_freight.reject {|key, _value| key == "createdAt" }
+
+            unless comparable_freight == expected_freight
+              abort <<~MSG
+                ERROR: existing frozen freight at #{relative_dir} does not match the current workflow inputs.
+                Expected: #{expected_freight.inspect}
+                Actual:   #{comparable_freight.inspect}
+              MSG
+            end
+
+            unless snapshot_tree(source_helm_dir) == snapshot_tree(helm_path)
+              abort("ERROR: existing frozen freight at #{relative_dir} does not match #{source_helm_dir}; refusing to mutate historical freight.")
+            end
+          end
+
+          def rebuild_freight_dir(relative_dir, freight_hash:, source_helm_dir:)
             FileUtils.rm_rf(relative_dir)
             FileUtils.mkdir_p("#{relative_dir}/helm")
-            File.write("#{relative_dir}/freight.yaml", freight_yaml)
+            File.write("#{relative_dir}/freight.yaml", freight_hash.to_yaml(line_width: -1))
             FileUtils.cp_r("#{source_helm_dir}/.", "#{relative_dir}/helm")
           end
 
+          def mirror_freight_dir(source_relative_dir, destination_relative_dir)
+            FileUtils.rm_rf(destination_relative_dir)
+            FileUtils.mkdir_p(destination_relative_dir)
+            FileUtils.cp_r("#{source_relative_dir}/.", destination_relative_dir)
+          end
+
           Dir.chdir("k8s-gitops") do
-            rebuild_freight_dir(CURRENT_RELATIVE_DIR, freight_yaml: freight_yaml, source_helm_dir: SOURCE_HELM_DIR)
-            rebuild_freight_dir(RELEASE_RELATIVE_DIR, freight_yaml: freight_yaml, source_helm_dir: SOURCE_HELM_DIR)
+            release_freight_exists = Dir.exist?(RELEASE_RELATIVE_DIR)
+
+            if release_freight_exists
+              validate_existing_freight!(
+                RELEASE_RELATIVE_DIR,
+                expected_freight: EXPECTED_FREIGHT,
+                source_helm_dir: SOURCE_HELM_DIR,
+              )
+            else
+              rebuild_freight_dir(
+                RELEASE_RELATIVE_DIR,
+                freight_hash: EXPECTED_FREIGHT.merge("createdAt" => Time.now.utc.iso8601),
+                source_helm_dir: SOURCE_HELM_DIR,
+              )
+            end
+
+            mirror_freight_dir(RELEASE_RELATIVE_DIR, CURRENT_RELATIVE_DIR)
 
             system! 'git config user.name "github-actions[bot]"'
             system! 'git config user.email "41898282+github-actions[bot]@users.noreply.github.com"'

--- a/.github/workflows/k8s-stitch-multiplatform-image.yml
+++ b/.github/workflows/k8s-stitch-multiplatform-image.yml
@@ -20,6 +20,9 @@ on:
       codeai_docker_image_ref:
         description: "Fully qualified docker image reference for the final multi-platform image"
         value: ${{ jobs.stitch-multi-platform.outputs.codeai_docker_image_ref }}
+      codeai_docker_image_digest:
+        description: "Registry digest for the final multi-platform image manifest"
+        value: ${{ jobs.stitch-multi-platform.outputs.codeai_docker_image_digest }}
       codeai_docker_tag:
         description: "Docker tag for the final multi-platform image"
         value: ${{ jobs.stitch-multi-platform.outputs.codeai_docker_tag }}
@@ -42,6 +45,7 @@ jobs:
     name: stitch multi-platform image
     outputs:
       codeai_docker_image_ref: ${{ steps.export-image.outputs.codeai_docker_image_ref }}
+      codeai_docker_image_digest: ${{ steps.export-image.outputs.codeai_docker_image_digest }}
       codeai_docker_tag: ${{ steps.export-image.outputs.codeai_docker_tag }}
 
     # while we're experimental, we /never/ want to block a normal PR:
@@ -94,5 +98,8 @@ jobs:
       - name: Export stitched image ref
         id: export-image
         run: |
+          CODEAI_DOCKER_IMAGE_DIGEST=$(docker buildx imagetools inspect "$MULTI_PLATFORM_IMAGE" | awk '$1 == "Digest:" {print $2; exit}')
+          test -n "$CODEAI_DOCKER_IMAGE_DIGEST"
           echo "codeai_docker_image_ref=$MULTI_PLATFORM_IMAGE" >> "$GITHUB_OUTPUT"
+          echo "codeai_docker_image_digest=$CODEAI_DOCKER_IMAGE_DIGEST" >> "$GITHUB_OUTPUT"
           echo "codeai_docker_tag=${{ inputs.docker_tag }}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/k8s.yml
+++ b/.github/workflows/k8s.yml
@@ -42,11 +42,8 @@ jobs:
     name: validate
     uses: ./.github/workflows/k8s-validate.yml
 
-  # Step 3: commit+push the new docker image ref into the k8s-gitops repo
-  # for kargo to discover.
-  #
-  # Kargo is then responsible for promoting the change to ArgoCD codeai
-  # deployments in apps/codeai/deployments/*
+  # Step 3: commit+push the frozen Helm snapshot and image metadata into the
+  # k8s-gitops warehouse for Kargo to discover and render from.
   commit-to-kargo-warehouse:
     name: commit to kargo warehouse
     uses: ./.github/workflows/k8s-commit-to-kargo-warehouse.yml
@@ -55,7 +52,9 @@ jobs:
       - validate
     with:
       branch_name: ${{ github.head_ref || github.ref_name }}
+      source_commit_sha: ${{ github.event.pull_request.head.sha || github.sha }}
       codeai_docker_image_ref: ${{ needs.stitch-multiplatform-image.outputs.codeai_docker_image_ref }}
+      codeai_docker_image_digest: ${{ needs.stitch-multiplatform-image.outputs.codeai_docker_image_digest }}
       codeai_docker_tag: ${{ needs.stitch-multiplatform-image.outputs.codeai_docker_tag }}
     secrets: inherit
 

--- a/k8s/helm/templates/_helpers.tpl
+++ b/k8s/helm/templates/_helpers.tpl
@@ -77,6 +77,8 @@ Usage:
 {{- index .secret.data .key | b64dec -}}
 {{- else if hasKey . "default" -}}
 {{- .default -}}
+{{- else if and (hasKey . "deterministicValue") .deterministicValue -}}
+{{- .deterministicValue -}}
 {{- else -}}
 {{- randAlphaNum .randLen -}}
 {{- end -}}

--- a/k8s/helm/templates/cdo-local-secrets.yaml
+++ b/k8s/helm/templates/cdo-local-secrets.yaml
@@ -21,7 +21,7 @@ stringData:
 
 
   # To change the MySQL root password, edit _mysql_root_password and redeploy this chart.
-  {{ $mysqlRootPassword := include "cdo.secretValue" (dict "secret" $existing "key" "_mysql_root_password" "randLen" 24) }}
+  {{ $mysqlRootPassword := include "cdo.secretValue" (dict "secret" $existing "key" "_mysql_root_password" "randLen" 24 "deterministicValue" (ternary (printf "%s-mysql-root-password" .Release.Name) "" .Values.renderedBranches.deterministicLocalSecrets)) }}
   _mysql_root_password: {{ $mysqlRootPassword | quote }} # caches the generated password
   {{ $mysqlHost := include "cdo.mysqlServiceName" . }}
   {{ $mysqlUsername := "root" }}
@@ -42,7 +42,7 @@ stringData:
 
 
   # To change the Redis password, edit _redis_password and redeploy this chart.
-  {{ $redisPassword := include "cdo.secretValue" (dict "secret" $existing "key" "_redis_password" "randLen" 24) }}
+  {{ $redisPassword := include "cdo.secretValue" (dict "secret" $existing "key" "_redis_password" "randLen" 24 "deterministicValue" (ternary (printf "%s-redis-password" .Release.Name) "" .Values.renderedBranches.deterministicLocalSecrets)) }}
   _redis_password: {{ $redisPassword | quote }} # caches the generated password
 
   {{ $redisHost := include "cdo.redisServiceName" . }}
@@ -57,11 +57,11 @@ stringData:
 
 
   # To change the MinIO root password, edit _minio_root_password and redeploy this chart.
-  {{ $minioRootPassword := include "cdo.secretValue" (dict "secret" $existing "key" "_minio_root_password" "randLen" 24) }}
+  {{ $minioRootPassword := include "cdo.secretValue" (dict "secret" $existing "key" "_minio_root_password" "randLen" 24 "deterministicValue" (ternary (printf "%s-minio-root-password" .Release.Name) "" .Values.renderedBranches.deterministicLocalSecrets)) }}
   _minio_root_password: {{ $minioRootPassword | quote }} # caches the generated password
 
   # To change the MinIO root user, edit _minio_root_user and redeploy this chart.
-  {{ $minioRootUser := include "cdo.secretValue" (dict "secret" $existing "key" "_minio_root_user" "default" "local-development") }}
+  {{ $minioRootUser := include "cdo.secretValue" (dict "secret" $existing "key" "_minio_root_user" "default" "local-development" "deterministicValue" (ternary (printf "%s-minio-root-user" .Release.Name) "" .Values.renderedBranches.deterministicLocalSecrets)) }}
   _minio_root_user: {{ $minioRootUser | quote }} # caches the generated username
 
 # MinIO CDO secrets for dashboard.

--- a/k8s/helm/values.yaml
+++ b/k8s/helm/values.yaml
@@ -29,6 +29,12 @@ autoscaling:
   maxReplicas: 1
   replicasWhenAutoscaleDisabled: 1
 
+renderedBranches:
+  # Rendered-branch promotions need stable manifests, so they can opt into
+  # deterministic placeholders for local service secrets when no existing
+  # Secret can be looked up.
+  deterministicLocalSecrets: false
+
 dashboardJob:
   enabled: false
   name: zsh


### PR DESCRIPTION
# Source Snapshot (Helm) + Rendered Branches

**Short name:** Source snapshot + render

**Catchy description:** Freeze the deploy source package once per release, keep environment policy in GitOps, and let Kargo render stage-specific outputs from that frozen snapshot into reviewable rendered branches.

## Detailed Technical Description of Plan
This plan sits between live-source rendering and a richer OCI release artifact: CI freezes the deploy package once, writes that snapshot into `warehouses/codeai/freight/git-<full-commit-sha>/`, mirrors the exact same contents to `current/`, and then Kargo renders every downstream stage from that frozen release record. Promotion does not chase the moving `code-dot-org` branch tip. It reads `warehouses/codeai/freight/current/freight.yaml`, resolves the release identity and package type from there, and uses GitOps-side env policy to materialize the stage-specific output into a rendered branch. That gives you a release object that is still plain Git, still reviewable, and still easy to audit by path, but without the ambiguity of reconstructing release truth from live source during promotion.

The Helm form shares the same Freight contract and keeps the snapshot focused on chart source under `helm/`, so promotion is mostly `helm-template` plus the usual values files from `k8s-gitops`. The important implementation detail is that the snapshot stays literal while the stage branch becomes the only mutable review surface.

The tricky part is not the rendering step itself; it is keeping the snapshot contract disciplined. `current/` must remain an exact mirror of the historical `git-<full-commit-sha>/` directory in the same commit, because promotion reads only `current/` while humans and audit tooling may inspect the historical release directory. That makes this plan easier to reason about than the live-source plans, which must sparse-checkout the huge monorepo at the promoted commit, but less compact than the thin-lock family because it duplicates the deploy package into GitOps-adjacent Freight. In practice, this is the plan to choose when you want frozen release inputs and rendered-branch reviewability without introducing a second artifact system.

- **Type:** Helm
- **Pattern:** Hybrid
- **Rendered manifests pattern:** Yes

## What Freight Looks Like

source-snapshot-rendered-branches

[k8s-gitops PR #5](https://github.com/code-dot-org/k8s-gitops/pull/5)
