### PR TITLE
Rendered Branches from a Thin Lock

### DIFF
--- a/.github/workflows/k8s-commit-legacy-gitflow-gate.yml
+++ b/.github/workflows/k8s-commit-legacy-gitflow-gate.yml
@@ -1,0 +1,191 @@
+name: k8s-commit-legacy-gitflow-gate
+
+on:
+  workflow_call:
+    inputs:
+      branch_name:
+        required: true
+        type: string
+      git_commit:
+        required: true
+        type: string
+    secrets:
+      K8S_GITOPS_REPO_WRITE_TOKEN:
+        required: true
+
+jobs:
+  commit-legacy-gitflow-gate:
+    name: commit legacy gitflow gate metadata
+    runs-on: ubuntu-latest
+    steps:
+      - name: Wait for required legacy-branch CI
+        shell: ruby {0}
+        env:
+          BRANCH_NAME: ${{ inputs.branch_name }}
+          GIT_COMMIT: ${{ inputs.git_commit }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          GITHUB_TOKEN: ${{ github.token }}
+        run: | # ruby
+          require "json"
+          require "net/http"
+          require "time"
+          require "uri"
+
+          LEGACY_BRANCHES = %w[staging test levelbuilder production].freeze
+          DRONE_CONTEXT_PREFIX = "continuous-integration/drone/".freeze
+          WAIT_FOR_DRONE_BRANCHES = %w[test].freeze
+          POLL_INTERVAL_SECONDS = 30
+          TIMEOUT_SECONDS = 60 * 60
+
+          branch_name = ENV.fetch("BRANCH_NAME")
+          git_commit = ENV.fetch("GIT_COMMIT")
+          repo = ENV.fetch("GITHUB_REPOSITORY")
+          token = ENV.fetch("GITHUB_TOKEN")
+
+          abort("ERROR: unsupported branch #{branch_name.inspect}") unless LEGACY_BRANCHES.include?(branch_name)
+          abort("ERROR: invalid git commit #{git_commit.inspect}") unless git_commit.match?(/\A[0-9a-f]{40}\z/)
+
+          unless WAIT_FOR_DRONE_BRANCHES.include?(branch_name)
+            puts "Skipping external CI wait for #{branch_name}; no additional test gate is required on this branch."
+            exit 0
+          end
+
+          def fetch_json(uri_string, token)
+            uri = URI(uri_string)
+            request = Net::HTTP::Get.new(uri)
+            request["Accept"] = "application/vnd.github+json"
+            request["Authorization"] = "Bearer #{token}"
+            request["X-GitHub-Api-Version"] = "2022-11-28"
+
+            response = Net::HTTP.start(uri.host, uri.port, use_ssl: true) do |http|
+              http.request(request)
+            end
+
+            unless response.is_a?(Net::HTTPSuccess)
+              abort("ERROR: GitHub API request failed (#{response.code}): #{response.body}")
+            end
+
+            JSON.parse(response.body)
+          end
+
+          deadline = Time.now + TIMEOUT_SECONDS
+
+          loop do
+            payload = fetch_json("https://api.github.com/repos/#{repo}/commits/#{git_commit}/status", token)
+            statuses = payload.fetch("statuses", [])
+              .select { |status| status.fetch("context", "").start_with?(DRONE_CONTEXT_PREFIX) }
+
+            latest_statuses = statuses
+              .group_by { |status| status.fetch("context") }
+              .transform_values { |entries| entries.max_by { |entry| Time.parse(entry.fetch("updated_at")) } }
+              .values
+
+            if latest_statuses.any? { |status| %w[failure error].include?(status.fetch("state")) }
+              failed = latest_statuses
+                .select { |status| %w[failure error].include?(status.fetch("state")) }
+                .map { |status| "#{status.fetch('context')}=#{status.fetch('state')}" }
+              abort("ERROR: required Drone status failed for #{git_commit}: #{failed.join(', ')}")
+            end
+
+            if latest_statuses.any? && latest_statuses.all? { |status| status.fetch("state") == "success" }
+              contexts = latest_statuses.map { |status| status.fetch("context") }.sort
+              puts "Required Drone statuses passed for #{git_commit}: #{contexts.join(', ')}"
+              break
+            end
+
+            if Time.now >= deadline
+              observed = latest_statuses.map { |status| "#{status.fetch('context')}=#{status.fetch('state')}" }.sort
+              abort("ERROR: timed out waiting for Drone status on #{git_commit}. Observed: #{observed.join(', ')}")
+            end
+
+            puts "Waiting for Drone status on #{git_commit}; observed #{latest_statuses.length} matching context(s)."
+            sleep POLL_INTERVAL_SECONDS
+          end
+
+      - name: Checkout k8s-gitops
+        uses: actions/checkout@v6.0.2
+        with:
+          repository: code-dot-org/k8s-gitops
+          ref: main
+          path: k8s-gitops
+          token: ${{ secrets.K8S_GITOPS_REPO_WRITE_TOKEN }}
+
+      - name: Publish legacy gitflow gate metadata
+        shell: ruby {0}
+        env:
+          BRANCH_NAME: ${{ inputs.branch_name }}
+          GIT_COMMIT: ${{ inputs.git_commit }}
+        run: | # ruby
+          require "fileutils"
+          require "time"
+          require "yaml"
+
+          LEGACY_BRANCHES = %w[staging test levelbuilder production].freeze
+
+          branch_name = ENV.fetch("BRANCH_NAME")
+          git_commit = ENV.fetch("GIT_COMMIT")
+
+          abort("ERROR: unsupported branch #{branch_name.inspect}") unless LEGACY_BRANCHES.include?(branch_name)
+          abort("ERROR: invalid git commit #{git_commit.inspect}") unless git_commit.match?(/\A[0-9a-f]{40}\z/)
+
+          release_id = "git-#{git_commit}"
+
+          def read_yaml(path)
+            return unless File.exist?(path)
+
+            YAML.safe_load(File.read(path), permitted_classes: [], permitted_symbols: [], aliases: false)
+          end
+
+          def write_yaml(path, data)
+            FileUtils.mkdir_p(File.dirname(path))
+            File.write(path, YAML.dump(data))
+          end
+
+          def assert_hash!(name, data, required_keys)
+            abort("ERROR: #{name} was not a YAML mapping") unless data.is_a?(Hash)
+
+            missing = required_keys.reject { |key| data.key?(key) }
+            abort("ERROR: #{name} missing keys: #{missing.join(', ')}") unless missing.empty?
+          end
+
+          def system!(*cmd)
+            ok = system(*cmd)
+            rendered_cmd = cmd.map(&:inspect).join(" ")
+            abort("ERROR: command failed: #{rendered_cmd}") unless ok
+          end
+
+          Dir.chdir("k8s-gitops") do
+            legacy_history_path = "warehouses/codeai/legacy-gitflow/#{branch_name}/merged/#{release_id}.yaml"
+            legacy_current_path = "warehouses/codeai/legacy-gitflow/#{branch_name}/current.yaml"
+
+            existing_legacy = read_yaml(legacy_history_path)
+            now = Time.now.utc.iso8601
+
+            legacy_gate = {
+              "revision" => git_commit,
+              "tag" => release_id,
+              "mergedAt" => existing_legacy&.fetch("mergedAt", nil) || now,
+            }
+
+            write_yaml(legacy_history_path, legacy_gate)
+            write_yaml(legacy_current_path, legacy_gate)
+
+            parsed_legacy_history = read_yaml(legacy_history_path)
+            parsed_legacy_current = read_yaml(legacy_current_path)
+
+            assert_hash!("legacy history", parsed_legacy_history, %w[revision tag mergedAt])
+            assert_hash!("legacy current", parsed_legacy_current, %w[revision tag mergedAt])
+            abort("ERROR: legacy current.yaml diverged from #{legacy_history_path}") unless parsed_legacy_history == parsed_legacy_current
+
+            system!("git", "config", "user.name", "github-actions[bot]")
+            system!("git", "config", "user.email", "41898282+github-actions[bot]@users.noreply.github.com")
+            system!("git", "add", legacy_history_path, legacy_current_path)
+
+            if system("git", "diff", "--cached", "--quiet")
+              puts "Success: legacy gitflow metadata already up to date for #{branch_name} #{release_id}."
+              exit 0
+            end
+
+            system!("git", "commit", "-m", "Publish CodeAI legacy gate #{branch_name} #{release_id}")
+            system!("git", "push", "origin", "HEAD:main")
+          end

--- a/.github/workflows/k8s-commit-to-kargo-warehouse.yml
+++ b/.github/workflows/k8s-commit-to-kargo-warehouse.yml
@@ -6,10 +6,13 @@ on:
       branch_name:
         required: true
         type: string
+      git_commit:
+        required: true
+        type: string
       codeai_docker_image_ref:
         required: true
         type: string
-      codeai_docker_tag:
+      codeai_docker_image_digest:
         required: true
         type: string
     secrets:
@@ -17,8 +20,8 @@ on:
         required: true
 
 jobs:
-  commit-to-kargo-warehouse:
-    name: commit to kargo warehouse
+  commit-build-lock-to-kargo-warehouse:
+    name: commit build lock to kargo warehouse
     runs-on: ubuntu-latest
     steps:
       - name: Checkout k8s-gitops
@@ -29,87 +32,116 @@ jobs:
           path: k8s-gitops
           token: ${{ secrets.K8S_GITOPS_REPO_WRITE_TOKEN }}
 
-      - name: Update codeai deployment image
+      - name: Publish build lock and legacy gate metadata
         shell: ruby {0}
         env:
           BRANCH_NAME: ${{ inputs.branch_name }}
+          GIT_COMMIT: ${{ inputs.git_commit }}
           CODEAI_DOCKER_IMAGE_REF: ${{ inputs.codeai_docker_image_ref }}
-          CODEAI_DOCKER_TAG: ${{ inputs.codeai_docker_tag }}
-          K8S_GITOPS_REPO_WRITE_TOKEN: ${{ secrets.K8S_GITOPS_REPO_WRITE_TOKEN }}
-
-        # if you're on vscode install this to get syntax highlighting in here:
-        # https://marketplace.visualstudio.com/items?itemName=harrydowning.yaml-embedded-languages
+          CODEAI_DOCKER_IMAGE_DIGEST: ${{ inputs.codeai_docker_image_digest }}
         run: | # ruby
-          # We'll throw an error if we can't find a values.yaml for these branches
-          UPDATE_OR_ERROR_BRANCHES = %w[staging test levelbuilder production]
+          require "fileutils"
+          require "time"
+          require "yaml"
 
-          # This is the code-dot-org repo branch that was committed to / merged into.
-          BRANCH_NAME = ENV.fetch("BRANCH_NAME")
+          LEGACY_BRANCHES = %w[staging test levelbuilder production].freeze
+          SOURCE_REPO = "https://github.com/code-dot-org/code-dot-org.git"
+          SOURCE_PATH = "k8s/kustomize"
 
-          # We normalize deployment names with the same rule as docker tags in k8s-skaffold-build.yml
-          DEPLOYMENT_NAME = BRANCH_NAME.gsub(/[^a-zA-Z0-9_.-]/, '-')
+          branch_name = ENV.fetch("BRANCH_NAME")
+          git_commit = ENV.fetch("GIT_COMMIT")
+          image_ref = ENV.fetch("CODEAI_DOCKER_IMAGE_REF")
+          image_digest = ENV.fetch("CODEAI_DOCKER_IMAGE_DIGEST")
 
-          # This is the newly built docker image ref that we'll be writing to values.yaml.
-          CODEAI_DOCKER_IMAGE_REF = ENV.fetch("CODEAI_DOCKER_IMAGE_REF")
-          CODEAI_DOCKER_TAG = ENV.fetch("CODEAI_DOCKER_TAG")
-          abort('ERROR: CODEAI_DOCKER_IMAGE_REF is empty, refusing to write back.') if CODEAI_DOCKER_IMAGE_REF.strip.empty?
+          abort("ERROR: unsupported branch #{branch_name.inspect}") unless LEGACY_BRANCHES.include?(branch_name)
+          abort("ERROR: invalid git commit #{git_commit.inspect}") unless git_commit.match?(/\A[0-9a-f]{40}\z/)
+          abort("ERROR: invalid image digest #{image_digest.inspect}") unless image_digest.match?(/\Asha256:[0-9a-f]{64}\z/)
 
-          # This is the values.yaml file in k8s-gitops repo that we'll update the `image: ` line in:
-          DEPLOYMENT_VALUES_YAML = "apps/codeai/deployments/#{DEPLOYMENT_NAME}/values.yaml"
+          release_id = "git-#{git_commit}"
 
-          # This is the updated line that we'll write to $DEPLOYMENT_VALUES_YAML:
-          UPDATED_DOCKER_IMAGE_LINE = "image: #{CODEAI_DOCKER_IMAGE_REF} # updated by k8s-commit-to-kargo-warehouse.yml\n"
+          def read_yaml(path)
+            return unless File.exist?(path)
+
+            YAML.safe_load(File.read(path), permitted_classes: [], permitted_symbols: [], aliases: false)
+          end
+
+          def write_yaml(path, data)
+            FileUtils.mkdir_p(File.dirname(path))
+            File.write(path, YAML.dump(data))
+          end
+
+          def assert_hash!(name, data, required_keys)
+            abort("ERROR: #{name} was not a YAML mapping") unless data.is_a?(Hash)
+
+            missing = required_keys.reject { |key| data.key?(key) }
+            abort("ERROR: #{name} missing keys: #{missing.join(', ')}") unless missing.empty?
+          end
 
           def system!(*cmd)
             ok = system(*cmd)
-            rendered_cmd = cmd.map(&:inspect).join(' ')
-            raise "Command failed (exitstatus=#{Process.last_status&.exitstatus}): #{rendered_cmd}" unless ok
+            rendered_cmd = cmd.map(&:inspect).join(" ")
+            abort("ERROR: command failed: #{rendered_cmd}") unless ok
           end
 
           Dir.chdir("k8s-gitops") do
-            unless File.exist?(DEPLOYMENT_VALUES_YAML)
-              values_yaml_was_not_found_msg = "Tried to update image ref, but no values.yaml was found at: https://github.com/code-dot-org/k8s-gitops/tree/main/#{DEPLOYMENT_VALUES_YAML}"
-              if UPDATE_OR_ERROR_BRANCHES.include?(BRANCH_NAME)
-                abort("ERROR: deployment `#{DEPLOYMENT_NAME}` failed! #{values_yaml_was_not_found_msg}")
-              else
-                puts "::notice::Skipping deployment `#{DEPLOYMENT_NAME}`. #{values_yaml_was_not_found_msg}"
-                exit 0
-              end
-            end
+            build_history_path = "warehouses/codeai/builds/#{release_id}.yaml"
+            build_current_path = "warehouses/codeai/builds/current.yaml"
+            legacy_history_path = "warehouses/codeai/legacy-gitflow/#{branch_name}/merged/#{release_id}.yaml"
+            legacy_current_path = "warehouses/codeai/legacy-gitflow/#{branch_name}/current.yaml"
 
-            # Update values.yaml file line `image: *` with the newly built docker image's ref
-            updated_line = false
-            File.write(DEPLOYMENT_VALUES_YAML,
-              File.readlines(DEPLOYMENT_VALUES_YAML)
-                .map do |line|
-                  if line.start_with?('image: ')
-                    updated_line = true
-                    UPDATED_DOCKER_IMAGE_LINE
-                  else
-                    line
-                  end
-                end
-                .then { |lines| updated_line ? lines : [UPDATED_DOCKER_IMAGE_LINE] + lines }
-                .join
-            )
+            existing_build = read_yaml(build_history_path)
+            existing_legacy = read_yaml(legacy_history_path)
+            now = Time.now.utc.iso8601
 
-            system! 'git config user.name "github-actions[bot]"'
-            system! 'git config user.email "41898282+github-actions[bot]@users.noreply.github.com"'
-            system! 'git', 'add', DEPLOYMENT_VALUES_YAML
+            build_lock = {
+              "schemaVersion" => "v1",
+              "releaseId" => release_id,
+              "gitCommit" => git_commit,
+              "image" => {
+                "ref" => image_ref,
+                "digest" => image_digest,
+              },
+              "packaging" => {
+                "kind" => "kustomize",
+                "sourceRepo" => SOURCE_REPO,
+                "sourcePath" => SOURCE_PATH,
+              },
+              "createdAt" => existing_build&.fetch("createdAt", nil) || now,
+            }
 
-            if system('git diff --cached --quiet')
-              puts "Success: no diff of #{DEPLOYMENT_VALUES_YAML} detected, no commit+push needed."
+            legacy_gate = {
+              "revision" => git_commit,
+              "tag" => release_id,
+              "mergedAt" => existing_legacy&.fetch("mergedAt", nil) || now,
+            }
+
+            write_yaml(build_history_path, build_lock)
+            write_yaml(build_current_path, build_lock)
+            write_yaml(legacy_history_path, legacy_gate)
+            write_yaml(legacy_current_path, legacy_gate)
+
+            parsed_history = read_yaml(build_history_path)
+            parsed_current = read_yaml(build_current_path)
+            parsed_legacy_history = read_yaml(legacy_history_path)
+            parsed_legacy_current = read_yaml(legacy_current_path)
+
+            assert_hash!("build history", parsed_history, %w[schemaVersion releaseId gitCommit image packaging createdAt])
+            assert_hash!("build current", parsed_current, %w[schemaVersion releaseId gitCommit image packaging createdAt])
+            assert_hash!("legacy history", parsed_legacy_history, %w[revision tag mergedAt])
+            assert_hash!("legacy current", parsed_legacy_current, %w[revision tag mergedAt])
+
+            abort("ERROR: build lock current.yaml diverged from #{build_history_path}") unless parsed_history == parsed_current
+            abort("ERROR: legacy current.yaml diverged from #{legacy_history_path}") unless parsed_legacy_history == parsed_legacy_current
+
+            system!("git", "config", "user.name", "github-actions[bot]")
+            system!("git", "config", "user.email", "41898282+github-actions[bot]@users.noreply.github.com")
+            system!("git", "add", build_history_path, build_current_path, legacy_history_path, legacy_current_path)
+
+            if system("git", "diff", "--cached", "--quiet")
+              puts "Success: build-lock and legacy metadata already up to date for #{release_id}."
               exit 0
             end
 
-            puts "Committing #{DEPLOYMENT_VALUES_YAML} to k8s-gitops repo"
-            system! 'git', 'commit', '-m', <<~MSG.chomp
-              #{DEPLOYMENT_VALUES_YAML} => #{CODEAI_DOCKER_TAG}
-            MSG
-
-            # Push to https://github.com/code-dot-org/k8s-gitops
-            puts "Pushing to https://github.com/code-dot-org/k8s-gitops"
-            system! 'git push origin HEAD:main'
-
-            puts "Success: committed+pushed newly built docker image tag #{CODEAI_DOCKER_TAG} to #{DEPLOYMENT_VALUES_YAML} on https://github.com/code-dot-org/k8s-gitops at #{Time.now.utc.strftime('%Y-%m-%dT%H:%M:%SZ')}"
+            system!("git", "commit", "-m", "Publish CodeAI build lock #{release_id}")
+            system!("git", "push", "origin", "HEAD:main")
           end

--- a/.github/workflows/k8s-commit-to-kargo-warehouse.yml
+++ b/.github/workflows/k8s-commit-to-kargo-warehouse.yml
@@ -3,9 +3,6 @@ name: k8s-commit-to-kargo-warehouse
 on:
   workflow_call:
     inputs:
-      branch_name:
-        required: true
-        type: string
       git_commit:
         required: true
         type: string
@@ -32,10 +29,9 @@ jobs:
           path: k8s-gitops
           token: ${{ secrets.K8S_GITOPS_REPO_WRITE_TOKEN }}
 
-      - name: Publish build lock and legacy gate metadata
+      - name: Publish build lock metadata
         shell: ruby {0}
         env:
-          BRANCH_NAME: ${{ inputs.branch_name }}
           GIT_COMMIT: ${{ inputs.git_commit }}
           CODEAI_DOCKER_IMAGE_REF: ${{ inputs.codeai_docker_image_ref }}
           CODEAI_DOCKER_IMAGE_DIGEST: ${{ inputs.codeai_docker_image_digest }}
@@ -44,16 +40,13 @@ jobs:
           require "time"
           require "yaml"
 
-          LEGACY_BRANCHES = %w[staging test levelbuilder production].freeze
           SOURCE_REPO = "https://github.com/code-dot-org/code-dot-org.git"
           SOURCE_PATH = "k8s/kustomize"
 
-          branch_name = ENV.fetch("BRANCH_NAME")
           git_commit = ENV.fetch("GIT_COMMIT")
           image_ref = ENV.fetch("CODEAI_DOCKER_IMAGE_REF")
           image_digest = ENV.fetch("CODEAI_DOCKER_IMAGE_DIGEST")
 
-          abort("ERROR: unsupported branch #{branch_name.inspect}") unless LEGACY_BRANCHES.include?(branch_name)
           abort("ERROR: invalid git commit #{git_commit.inspect}") unless git_commit.match?(/\A[0-9a-f]{40}\z/)
           abort("ERROR: invalid image digest #{image_digest.inspect}") unless image_digest.match?(/\Asha256:[0-9a-f]{64}\z/)
 
@@ -86,11 +79,8 @@ jobs:
           Dir.chdir("k8s-gitops") do
             build_history_path = "warehouses/codeai/builds/#{release_id}.yaml"
             build_current_path = "warehouses/codeai/builds/current.yaml"
-            legacy_history_path = "warehouses/codeai/legacy-gitflow/#{branch_name}/merged/#{release_id}.yaml"
-            legacy_current_path = "warehouses/codeai/legacy-gitflow/#{branch_name}/current.yaml"
 
             existing_build = read_yaml(build_history_path)
-            existing_legacy = read_yaml(legacy_history_path)
             now = Time.now.utc.iso8601
 
             build_lock = {
@@ -109,36 +99,23 @@ jobs:
               "createdAt" => existing_build&.fetch("createdAt", nil) || now,
             }
 
-            legacy_gate = {
-              "revision" => git_commit,
-              "tag" => release_id,
-              "mergedAt" => existing_legacy&.fetch("mergedAt", nil) || now,
-            }
-
             write_yaml(build_history_path, build_lock)
             write_yaml(build_current_path, build_lock)
-            write_yaml(legacy_history_path, legacy_gate)
-            write_yaml(legacy_current_path, legacy_gate)
 
             parsed_history = read_yaml(build_history_path)
             parsed_current = read_yaml(build_current_path)
-            parsed_legacy_history = read_yaml(legacy_history_path)
-            parsed_legacy_current = read_yaml(legacy_current_path)
 
             assert_hash!("build history", parsed_history, %w[schemaVersion releaseId gitCommit image packaging createdAt])
             assert_hash!("build current", parsed_current, %w[schemaVersion releaseId gitCommit image packaging createdAt])
-            assert_hash!("legacy history", parsed_legacy_history, %w[revision tag mergedAt])
-            assert_hash!("legacy current", parsed_legacy_current, %w[revision tag mergedAt])
 
             abort("ERROR: build lock current.yaml diverged from #{build_history_path}") unless parsed_history == parsed_current
-            abort("ERROR: legacy current.yaml diverged from #{legacy_history_path}") unless parsed_legacy_history == parsed_legacy_current
 
             system!("git", "config", "user.name", "github-actions[bot]")
             system!("git", "config", "user.email", "41898282+github-actions[bot]@users.noreply.github.com")
-            system!("git", "add", build_history_path, build_current_path, legacy_history_path, legacy_current_path)
+            system!("git", "add", build_history_path, build_current_path)
 
             if system("git", "diff", "--cached", "--quiet")
-              puts "Success: build-lock and legacy metadata already up to date for #{release_id}."
+              puts "Success: build-lock metadata already up to date for #{release_id}."
               exit 0
             end
 

--- a/.github/workflows/k8s-stitch-multiplatform-image.yml
+++ b/.github/workflows/k8s-stitch-multiplatform-image.yml
@@ -20,9 +20,9 @@ on:
       codeai_docker_image_ref:
         description: "Fully qualified docker image reference for the final multi-platform image"
         value: ${{ jobs.stitch-multi-platform.outputs.codeai_docker_image_ref }}
-      codeai_docker_tag:
-        description: "Docker tag for the final multi-platform image"
-        value: ${{ jobs.stitch-multi-platform.outputs.codeai_docker_tag }}
+      codeai_docker_image_digest:
+        description: "Digest for the final multi-platform image"
+        value: ${{ jobs.stitch-multi-platform.outputs.codeai_docker_image_digest }}
     inputs:
       branch_tag_alias:
         description: "Branch-name tag alias for the final multi-platform image"
@@ -42,7 +42,7 @@ jobs:
     name: stitch multi-platform image
     outputs:
       codeai_docker_image_ref: ${{ steps.export-image.outputs.codeai_docker_image_ref }}
-      codeai_docker_tag: ${{ steps.export-image.outputs.codeai_docker_tag }}
+      codeai_docker_image_digest: ${{ steps.export-image.outputs.codeai_docker_image_digest }}
 
     # while we're experimental, we /never/ want to block a normal PR:
     continue-on-error: true
@@ -94,5 +94,7 @@ jobs:
       - name: Export stitched image ref
         id: export-image
         run: |
+          IMAGE_DIGEST="$(docker buildx imagetools inspect "$MULTI_PLATFORM_IMAGE" | awk '/^Digest:/ {print $2; exit}')"
+          test -n "$IMAGE_DIGEST"
           echo "codeai_docker_image_ref=$MULTI_PLATFORM_IMAGE" >> "$GITHUB_OUTPUT"
-          echo "codeai_docker_tag=${{ inputs.docker_tag }}" >> "$GITHUB_OUTPUT"
+          echo "codeai_docker_image_digest=$IMAGE_DIGEST" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/k8s-validate.yml
+++ b/.github/workflows/k8s-validate.yml
@@ -1,7 +1,6 @@
-# Use this workflow to do any validation of k8s related files, this could
-# be linting, simple tests, etc. This runs in parallel with the skaffold
-# build, but before we commit to k8s-gitops our changes, so anything
-# that's faster than that won't hold up the overall flow.
+# Use this workflow to do lightweight validation of the k8s packaging contract.
+# It runs in parallel with the image build and finishes before we publish the
+# build-lock metadata to k8s-gitops.
 
 name: k8s-validate
 
@@ -19,11 +18,6 @@ jobs:
           sparse-checkout: |
             k8s
 
-      - name: Setup Helm
-        uses: azure/setup-helm@v4
-        with:
-          version: v3.19.0
-
       - name: Setup Kustomize
         run: |
           KUSTOMIZE_VERSION=v5.8.1
@@ -32,5 +26,5 @@ jobs:
           tar -xzf /tmp/kustomize.tar.gz -C /tmp
           sudo install /tmp/kustomize /usr/local/bin/kustomize
 
-      - name: Verify kustomize/helm parity
-        run: k8s/kustomize/bin/verify-helm-parity
+      - name: Verify Kustomize render contract
+        run: k8s/kustomize/bin/verify-parity

--- a/.github/workflows/k8s.yml
+++ b/.github/workflows/k8s.yml
@@ -48,6 +48,7 @@ jobs:
   # Kargo is then responsible for promoting the change to ArgoCD codeai
   # deployments in apps/codeai/deployments/*
   commit-to-kargo-warehouse:
+    if: github.event_name == 'push'
     name: commit to kargo warehouse
     uses: ./.github/workflows/k8s-commit-to-kargo-warehouse.yml
     needs:
@@ -55,8 +56,9 @@ jobs:
       - validate
     with:
       branch_name: ${{ github.head_ref || github.ref_name }}
+      git_commit: ${{ github.sha }}
       codeai_docker_image_ref: ${{ needs.stitch-multiplatform-image.outputs.codeai_docker_image_ref }}
-      codeai_docker_tag: ${{ needs.stitch-multiplatform-image.outputs.codeai_docker_tag }}
+      codeai_docker_image_digest: ${{ needs.stitch-multiplatform-image.outputs.codeai_docker_image_digest }}
     secrets: inherit
 
 # Grant the GITHUB_TOKEN the necessary permissions for checkout and publishing to GitHub Packages

--- a/.github/workflows/k8s.yml
+++ b/.github/workflows/k8s.yml
@@ -42,23 +42,32 @@ jobs:
     name: validate
     uses: ./.github/workflows/k8s-validate.yml
 
-  # Step 3: commit+push the new docker image ref into the k8s-gitops repo
-  # for kargo to discover.
-  #
-  # Kargo is then responsible for promoting the change to ArgoCD codeai
-  # deployments in apps/codeai/deployments/*
-  commit-to-kargo-warehouse:
-    if: github.event_name == 'push'
-    name: commit to kargo warehouse
+  # Step 3: staging is the only branch that publishes new Freight into Kargo.
+  commit-build-lock-to-kargo-warehouse:
+    if: github.event_name == 'push' && github.ref_name == 'staging'
+    name: commit build lock to kargo warehouse
     uses: ./.github/workflows/k8s-commit-to-kargo-warehouse.yml
     needs:
       - stitch-multiplatform-image
       - validate
     with:
-      branch_name: ${{ github.head_ref || github.ref_name }}
       git_commit: ${{ github.sha }}
       codeai_docker_image_ref: ${{ needs.stitch-multiplatform-image.outputs.codeai_docker_image_ref }}
       codeai_docker_image_digest: ${{ needs.stitch-multiplatform-image.outputs.codeai_docker_image_digest }}
+    secrets: inherit
+
+  # Legacy branch merges still publish coexistence metadata, but that metadata
+  # is not Freight and can be gated independently from staging build ingress.
+  commit-legacy-gitflow-gate:
+    if: github.event_name == 'push'
+    name: commit legacy gitflow gate metadata
+    uses: ./.github/workflows/k8s-commit-legacy-gitflow-gate.yml
+    needs:
+      - stitch-multiplatform-image
+      - validate
+    with:
+      branch_name: ${{ github.ref_name }}
+      git_commit: ${{ github.sha }}
     secrets: inherit
 
 # Grant the GITHUB_TOKEN the necessary permissions for checkout and publishing to GitHub Packages
@@ -67,3 +76,6 @@ permissions:
   contents: read
   # permission to publish container images to ghcr.io
   packages: write
+  # permission to read commit status contexts when deciding whether a legacy
+  # branch merge is promotable.
+  statuses: read

--- a/k8s/kustomize/base/deployment.yaml
+++ b/k8s/kustomize/base/deployment.yaml
@@ -1,0 +1,24 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: cdo-dashboard
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: cdo-dashboard
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: cdo-dashboard
+    spec:
+      containers:
+        - name: dashboard
+          image: code-dot-org:replace-me
+          imagePullPolicy: IfNotPresent
+          envFrom:
+            - configMapRef:
+                name: cdo-locals.yml
+          ports:
+            - containerPort: 3000
+              name: http

--- a/k8s/kustomize/base/kustomization.yaml
+++ b/k8s/kustomize/base/kustomization.yaml
@@ -1,7 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - dashboard-deployment.yaml
-  - dashboard-service.yaml
-  - locals.yml.yaml
-  - cdo-local-secrets.yaml
+  - deployment.yaml
+  - locals-configmap.yaml

--- a/k8s/kustomize/base/locals-configmap.yaml
+++ b/k8s/kustomize/base/locals-configmap.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cdo-locals.yml
+data:
+  dashboard_workers: "1"
+  stack_name: default

--- a/k8s/kustomize/bin/verify-parity
+++ b/k8s/kustomize/bin/verify-parity
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "$0")/../../.." && pwd)"
+kustomize build "$repo_root/k8s/kustomize/base" >/dev/null


### PR DESCRIPTION
# Rendered Branches from a Thin Lock

**Short name:** Rendered branches

**Catchy description:** Keep the warehouse artifact tiny, but make every promotion render full stage-specific manifests into stage branches so humans review the real output, not just a ref change.

## Detailed Technical Description of Plan
This plan keeps the release signal intentionally small: a single Git build-lock record in `k8s-gitops` identifies the exact `code-dot-org` commit and image tag to promote, but it does not store rendered manifests as Freight. Kargo uses that lock only as the release coordinate. The real work happens during promotion, where Kargo checks out the exact source commit, combines it with the latest GitOps environment policy, and writes stage-specific rendered output into `k8s-gitops` stage branches. Argo CD then deploys from those rendered branches, so the thing humans review is the actual manifest output that will hit the cluster.

The technical trick is that the plan is Kustomize-only without changing the release model. Promotion starts from the checked-in `code-dot-org/k8s/kustomize/` tree plus the GitOps envType components and a reusable deploy-wrapper template in `k8s-gitops`; the wrapper is copied into a temp work dir, rewritten for the target deployment, and then built into the rendered branch. The important distinction is that the package is materialized at promotion time, not in Freight, and the stage branches are consumed the same way.

The tricky parts are the ones that make the reviewable-output model honest. Promotion has to render from the exact promoted commit, not from the moving branch tip, and it has to write into a stage-specific branch/path that Argo can watch directly. `review-infra-changes` is the key control point: production output is rendered to a PR branch, reviewed as generated manifests, and only then merged into `stage/production`. That makes this plan fundamentally different from the thin-lock or source-snapshot families: the lock is tiny, but the review surface is the full rendered manifest tree, so the implementation must preserve a clean split between source checkout, GitOps policy, and generated output.

- **Type:** Kustomize
- **Pattern:** Hybrid
- **Rendered manifests pattern:** Yes

rendered-branches

Sibling PR: https://github.com/code-dot-org/k8s-gitops/pull/9
