### PR TITLE
Source Snapshot (Kustomize) + Rendered Branches

### DIFF
--- a/.github/workflows/k8s-commit-to-kargo-warehouse.yml
+++ b/.github/workflows/k8s-commit-to-kargo-warehouse.yml
@@ -6,7 +6,13 @@ on:
       branch_name:
         required: true
         type: string
+      source_commit_sha:
+        required: true
+        type: string
       codeai_docker_image_ref:
+        required: true
+        type: string
+      codeai_docker_image_digest:
         required: true
         type: string
       codeai_docker_tag:
@@ -21,6 +27,12 @@ jobs:
     name: commit to kargo warehouse
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout code-dot-org
+        uses: actions/checkout@v6.0.2
+        with:
+          path: code-dot-org
+          ref: ${{ inputs.source_commit_sha }}
+
       - name: Checkout k8s-gitops
         uses: actions/checkout@v6.0.2
         with:
@@ -29,36 +41,42 @@ jobs:
           path: k8s-gitops
           token: ${{ secrets.K8S_GITOPS_REPO_WRITE_TOKEN }}
 
-      - name: Update codeai deployment image
+      - name: Publish codeai freight and legacy gitflow metadata
         shell: ruby {0}
         env:
           BRANCH_NAME: ${{ inputs.branch_name }}
+          SOURCE_COMMIT_SHA: ${{ inputs.source_commit_sha }}
           CODEAI_DOCKER_IMAGE_REF: ${{ inputs.codeai_docker_image_ref }}
+          CODEAI_DOCKER_IMAGE_DIGEST: ${{ inputs.codeai_docker_image_digest }}
           CODEAI_DOCKER_TAG: ${{ inputs.codeai_docker_tag }}
           K8S_GITOPS_REPO_WRITE_TOKEN: ${{ secrets.K8S_GITOPS_REPO_WRITE_TOKEN }}
 
         # if you're on vscode install this to get syntax highlighting in here:
         # https://marketplace.visualstudio.com/items?itemName=harrydowning.yaml-embedded-languages
         run: | # ruby
-          # We'll throw an error if we can't find a values.yaml for these branches
-          UPDATE_OR_ERROR_BRANCHES = %w[staging test levelbuilder production]
+          require "fileutils"
+          require "tmpdir"
+          require "time"
+          require "yaml"
 
-          # This is the code-dot-org repo branch that was committed to / merged into.
+          # The frozen release snapshot is published exactly once, from staging.
+          # Later legacy branch merges only update coexistence gate metadata.
+          FREIGHT_SOURCE_BRANCHES = %w[staging]
+          LEGACY_GITFLOW_BRANCHES = %w[staging test levelbuilder production]
+
           BRANCH_NAME = ENV.fetch("BRANCH_NAME")
-
-          # We normalize deployment names with the same rule as docker tags in k8s-skaffold-build.yml
-          DEPLOYMENT_NAME = BRANCH_NAME.gsub(/[^a-zA-Z0-9_.-]/, '-')
-
-          # This is the newly built docker image ref that we'll be writing to values.yaml.
+          SOURCE_COMMIT_SHA = ENV.fetch("SOURCE_COMMIT_SHA")
           CODEAI_DOCKER_IMAGE_REF = ENV.fetch("CODEAI_DOCKER_IMAGE_REF")
+          CODEAI_DOCKER_IMAGE_DIGEST = ENV.fetch("CODEAI_DOCKER_IMAGE_DIGEST")
           CODEAI_DOCKER_TAG = ENV.fetch("CODEAI_DOCKER_TAG")
-          abort('ERROR: CODEAI_DOCKER_IMAGE_REF is empty, refusing to write back.') if CODEAI_DOCKER_IMAGE_REF.strip.empty?
+          abort("ERROR: SOURCE_COMMIT_SHA must be a full 40-character SHA.") unless /\A[0-9a-f]{40}\z/.match?(SOURCE_COMMIT_SHA)
+          abort("ERROR: CODEAI_DOCKER_TAG must match git-<full-sha>.") unless CODEAI_DOCKER_TAG == "git-#{SOURCE_COMMIT_SHA}"
+          abort("ERROR: CODEAI_DOCKER_IMAGE_REF is empty, refusing to write back.") if CODEAI_DOCKER_IMAGE_REF.strip.empty?
+          abort("ERROR: CODEAI_DOCKER_IMAGE_DIGEST is empty, refusing to write back.") if CODEAI_DOCKER_IMAGE_DIGEST.strip.empty?
 
-          # This is the values.yaml file in k8s-gitops repo that we'll update the `image: ` line in:
-          DEPLOYMENT_VALUES_YAML = "apps/codeai/deployments/#{DEPLOYMENT_NAME}/values.yaml"
-
-          # This is the updated line that we'll write to $DEPLOYMENT_VALUES_YAML:
-          UPDATED_DOCKER_IMAGE_LINE = "image: #{CODEAI_DOCKER_IMAGE_REF} # updated by k8s-commit-to-kargo-warehouse.yml\n"
+          RELEASE_TAG = CODEAI_DOCKER_TAG
+          NOW = Time.now.utc.iso8601
+          SOURCE_KUSTOMIZE_DIR = "code-dot-org/k8s/kustomize"
 
           def system!(*cmd)
             ok = system(*cmd)
@@ -66,50 +84,95 @@ jobs:
             raise "Command failed (exitstatus=#{Process.last_status&.exitstatus}): #{rendered_cmd}" unless ok
           end
 
+          def write_yaml(path, payload)
+            FileUtils.mkdir_p(File.dirname(path))
+            File.write(path, YAML.dump(payload))
+          end
+
+          def replace_tree(source_dir, destination_dir)
+            FileUtils.rm_rf(destination_dir)
+            FileUtils.mkdir_p(destination_dir)
+            children = Dir.children(source_dir).map {|entry| File.join(source_dir, entry) }
+            FileUtils.cp_r(children, destination_dir) unless children.empty?
+          end
+
+          publish_freight = FREIGHT_SOURCE_BRANCHES.include?(BRANCH_NAME)
+          publish_legacy_gate = LEGACY_GITFLOW_BRANCHES.include?(BRANCH_NAME)
+
+          unless publish_freight || publish_legacy_gate
+            puts "::notice::Skipping warehouse publish for branch #{BRANCH_NAME.inspect}; no freight or legacy-gitflow metadata is defined for it."
+            exit 0
+          end
+
           Dir.chdir("k8s-gitops") do
-            unless File.exist?(DEPLOYMENT_VALUES_YAML)
-              values_yaml_was_not_found_msg = "Tried to update image ref, but no values.yaml was found at: https://github.com/code-dot-org/k8s-gitops/tree/main/#{DEPLOYMENT_VALUES_YAML}"
-              if UPDATE_OR_ERROR_BRANCHES.include?(BRANCH_NAME)
-                abort("ERROR: deployment `#{DEPLOYMENT_NAME}` failed! #{values_yaml_was_not_found_msg}")
-              else
-                puts "::notice::Skipping deployment `#{DEPLOYMENT_NAME}`. #{values_yaml_was_not_found_msg}"
-                exit 0
+            changed_paths = []
+
+            if publish_freight
+              abort("ERROR: #{SOURCE_KUSTOMIZE_DIR} was not found in the checked out source tree.") unless Dir.exist?(File.join("..", SOURCE_KUSTOMIZE_DIR))
+
+              Dir.mktmpdir("codeai-freight-") do |tmpdir|
+                release_dir = File.join(tmpdir, RELEASE_TAG)
+                replace_tree(File.join("..", SOURCE_KUSTOMIZE_DIR), File.join(release_dir, "kustomize"))
+                write_yaml(
+                  File.join(release_dir, "freight.yaml"),
+                  {
+                    "schemaVersion" => "v1",
+                    "revision" => SOURCE_COMMIT_SHA,
+                    "tag" => RELEASE_TAG,
+                    "image" => {
+                      "ref" => CODEAI_DOCKER_IMAGE_REF,
+                      "digest" => CODEAI_DOCKER_IMAGE_DIGEST,
+                    },
+                    "packageType" => "kustomize",
+                    "createdAt" => NOW,
+                  }
+                )
+
+                historical_release_dir = File.join("warehouses", "codeai", "freight", RELEASE_TAG)
+                current_release_dir = File.join("warehouses", "codeai", "freight", "current")
+                replace_tree(release_dir, historical_release_dir)
+                replace_tree(release_dir, current_release_dir)
+                changed_paths.concat([historical_release_dir, current_release_dir])
               end
             end
 
-            # Update values.yaml file line `image: *` with the newly built docker image's ref
-            updated_line = false
-            File.write(DEPLOYMENT_VALUES_YAML,
-              File.readlines(DEPLOYMENT_VALUES_YAML)
-                .map do |line|
-                  if line.start_with?('image: ')
-                    updated_line = true
-                    UPDATED_DOCKER_IMAGE_LINE
-                  else
-                    line
-                  end
-                end
-                .then { |lines| updated_line ? lines : [UPDATED_DOCKER_IMAGE_LINE] + lines }
-                .join
-            )
+            if publish_legacy_gate
+              gate_payload = {
+                "revision" => SOURCE_COMMIT_SHA,
+                "tag" => RELEASE_TAG,
+                "mergedAt" => NOW,
+              }
+
+              legacy_current_path = File.join("warehouses", "codeai", "legacy-gitflow", BRANCH_NAME, "current.yaml")
+              legacy_release_path = File.join("warehouses", "codeai", "legacy-gitflow", BRANCH_NAME, "merged", "#{RELEASE_TAG}.yaml")
+              write_yaml(legacy_current_path, gate_payload)
+              write_yaml(legacy_release_path, gate_payload)
+              changed_paths.concat([legacy_current_path, legacy_release_path])
+            end
 
             system! 'git config user.name "github-actions[bot]"'
             system! 'git config user.email "41898282+github-actions[bot]@users.noreply.github.com"'
-            system! 'git', 'add', DEPLOYMENT_VALUES_YAML
+            system! 'git', 'add', *changed_paths.uniq
 
             if system('git diff --cached --quiet')
-              puts "Success: no diff of #{DEPLOYMENT_VALUES_YAML} detected, no commit+push needed."
+              puts "Success: warehouse metadata for #{RELEASE_TAG} was already up to date, no commit+push needed."
               exit 0
             end
 
-            puts "Committing #{DEPLOYMENT_VALUES_YAML} to k8s-gitops repo"
+            commit_subject =
+              if publish_freight
+                "Publish CodeAI freight #{RELEASE_TAG}"
+              else
+                "Record CodeAI #{BRANCH_NAME} merge #{RELEASE_TAG}"
+              end
+
             system! 'git', 'commit', '-m', <<~MSG.chomp
-              #{DEPLOYMENT_VALUES_YAML} => #{CODEAI_DOCKER_TAG}
+              #{commit_subject}
             MSG
 
             # Push to https://github.com/code-dot-org/k8s-gitops
             puts "Pushing to https://github.com/code-dot-org/k8s-gitops"
             system! 'git push origin HEAD:main'
 
-            puts "Success: committed+pushed newly built docker image tag #{CODEAI_DOCKER_TAG} to #{DEPLOYMENT_VALUES_YAML} on https://github.com/code-dot-org/k8s-gitops at #{Time.now.utc.strftime('%Y-%m-%dT%H:%M:%SZ')}"
+            puts "Success: committed+pushed warehouse metadata for #{RELEASE_TAG} on https://github.com/code-dot-org/k8s-gitops at #{Time.now.utc.strftime('%Y-%m-%dT%H:%M:%SZ')}"
           end

--- a/.github/workflows/k8s-stitch-multiplatform-image.yml
+++ b/.github/workflows/k8s-stitch-multiplatform-image.yml
@@ -20,6 +20,9 @@ on:
       codeai_docker_image_ref:
         description: "Fully qualified docker image reference for the final multi-platform image"
         value: ${{ jobs.stitch-multi-platform.outputs.codeai_docker_image_ref }}
+      codeai_docker_image_digest:
+        description: "Image digest for the final multi-platform image"
+        value: ${{ jobs.stitch-multi-platform.outputs.codeai_docker_image_digest }}
       codeai_docker_tag:
         description: "Docker tag for the final multi-platform image"
         value: ${{ jobs.stitch-multi-platform.outputs.codeai_docker_tag }}
@@ -42,6 +45,7 @@ jobs:
     name: stitch multi-platform image
     outputs:
       codeai_docker_image_ref: ${{ steps.export-image.outputs.codeai_docker_image_ref }}
+      codeai_docker_image_digest: ${{ steps.export-image.outputs.codeai_docker_image_digest }}
       codeai_docker_tag: ${{ steps.export-image.outputs.codeai_docker_tag }}
 
     # while we're experimental, we /never/ want to block a normal PR:
@@ -91,8 +95,16 @@ jobs:
         run: |
           docker buildx imagetools create -t "$IMAGE_NAME:$NORMALIZED_BRANCH_TAG_ALIAS" $MULTI_PLATFORM_IMAGE
 
+      - name: Capture stitched image digest
+        id: image_digest
+        run: |
+          IMAGE_DIGEST=$(docker buildx imagetools inspect "$MULTI_PLATFORM_IMAGE" | sed -n 's/^Digest: //p' | head -n 1)
+          test -n "$IMAGE_DIGEST"
+          echo "codeai_docker_image_digest=$IMAGE_DIGEST" >> "$GITHUB_OUTPUT"
+
       - name: Export stitched image ref
         id: export-image
         run: |
           echo "codeai_docker_image_ref=$MULTI_PLATFORM_IMAGE" >> "$GITHUB_OUTPUT"
+          echo "codeai_docker_image_digest=${{ steps.image_digest.outputs.codeai_docker_image_digest }}" >> "$GITHUB_OUTPUT"
           echo "codeai_docker_tag=${{ inputs.docker_tag }}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/k8s.yml
+++ b/.github/workflows/k8s.yml
@@ -42,8 +42,8 @@ jobs:
     name: validate
     uses: ./.github/workflows/k8s-validate.yml
 
-  # Step 3: commit+push the new docker image ref into the k8s-gitops repo
-  # for kargo to discover.
+  # Step 3: publish the frozen Kustomize snapshot and legacy-gitflow metadata
+  # into the k8s-gitops repo for Kargo to discover.
   #
   # Kargo is then responsible for promoting the change to ArgoCD codeai
   # deployments in apps/codeai/deployments/*
@@ -55,7 +55,9 @@ jobs:
       - validate
     with:
       branch_name: ${{ github.head_ref || github.ref_name }}
+      source_commit_sha: ${{ github.event.pull_request.head.sha || github.sha }}
       codeai_docker_image_ref: ${{ needs.stitch-multiplatform-image.outputs.codeai_docker_image_ref }}
+      codeai_docker_image_digest: ${{ needs.stitch-multiplatform-image.outputs.codeai_docker_image_digest }}
       codeai_docker_tag: ${{ needs.stitch-multiplatform-image.outputs.codeai_docker_tag }}
     secrets: inherit
 


### PR DESCRIPTION
# Source Snapshot (Kustomize) + Rendered Branches

**Short name:** Source snapshot + render

**Catchy description:** Freeze the deploy source package once per release, keep environment policy in GitOps, and let Kargo render stage-specific outputs from that frozen snapshot into reviewable rendered branches.

## Detailed Technical Description of Plan
This plan is the middle ground between live-source rendering and a richer OCI release artifact: CI freezes the deploy package once, writes that snapshot into `warehouses/codeai/freight/git-<full-commit-sha>/`, mirrors the exact same contents to `current/`, and then Kargo renders every downstream stage from that frozen release record. Promotion does not chase the moving `code-dot-org` branch tip. It reads `warehouses/codeai/freight/current/freight.yaml`, resolves the release identity and package type from there, and uses GitOps-side env policy to materialize the stage-specific output into a rendered branch. That gives you a release object that is still plain Git, still reviewable, and still easy to audit by path, but without the ambiguity of reconstructing release truth from live source during promotion.

The snapshot is the durable `k8s/kustomize/` tree, but promotion still does not render from that tree directly. Instead, Kargo assembles a temporary deploy wrapper from `k8s-gitops/apps/codeai/kargo/templates/deploy/`, layers in the envType `Component` files from `apps/codeai/envTypes/<envType>/`, and points that wrapper at the frozen `base/` and `components/` payload in the snapshot before running `kustomize-build`. The important implementation detail is that the snapshot stays literal while the stage branch becomes the only mutable review surface.

The tricky part is not the rendering step itself; it is keeping the snapshot contract disciplined. `current/` must remain an exact mirror of the historical `git-<full-commit-sha>/` directory in the same commit, because promotion reads only `current/` while humans and audit tooling may inspect the historical release directory. That makes this plan easier to reason about than the live-source plans, which must sparse-checkout the huge monorepo at the promoted commit, but less compact than the thin-lock family because it duplicates the deploy package into GitOps-adjacent Freight. In practice, this is the plan to choose when you want frozen release inputs and rendered-branch reviewability without introducing a second artifact system.

- **Type:** Packaging-agnostic
- **Pattern:** Hybrid
- **Rendered manifests pattern:** Yes

source-snapshot-rendered-branches

Sibling PR: [k8s-gitops PR #10](https://github.com/code-dot-org/k8s-gitops/pull/10)
