### PR TITLE
K8S: kargotecture, iteration 7

### DIFF
--- a/k8s/TODO.md
+++ b/k8s/TODO.md
@@ -49,3 +49,5 @@ Move ArgoCD management out of Tofu and into ArgoCD itself. When doing this, foll
 
 In `k8s/tofu/codeai-k8s-dex/tofu.tfvars`, update `google_email_with_groups_readonly_scope`
 to a non-personal email.
+
+- Create one `github_organization_webhook` in tofu (for both push and package), publish as an AWS secret, synced down to Kargo, and use in new ProjectConfig, then a warehouse with both subscriptions will be nearly instant (+ clone time lol :-P)

--- a/k8s/TODO.md
+++ b/k8s/TODO.md
@@ -30,6 +30,11 @@ we have existing (broken?) code that does this, and it could be repurposed.
 Figure out how to most cleanly inject prometheus into clusters, including dev clusters. Maybe
 include prometheus as a helm chart dependency??
 
+## Kargo
+
+- Create one `github_organization_webhook` in tofu (for both push and package), publish as an AWS secret, synced down to Kargo, and use in new ProjectConfig, then a warehouse with both subscriptions will be nearly instant (+ clone time lol :-P)
+- set `org.opencontainers.image.source=https://github.com/code-dot-org/code-dot-org` and `org.opencontainers.image.revision=<git sha>` OCI tags in `k8s.yml` GH action so Kargo links Freight to source code in the UX, see: <https://docs.kargo.io/user-guide/how-to-guides/working-with-freight#oci-image-annotations>
+
 ## Tofu EKS Cluster
 
 See `k8s/tofu/eks-addons/TODO.argocd.diskfill.bug.md` for the Argo CD
@@ -49,5 +54,3 @@ Move ArgoCD management out of Tofu and into ArgoCD itself. When doing this, foll
 
 In `k8s/tofu/codeai-k8s-dex/tofu.tfvars`, update `google_email_with_groups_readonly_scope`
 to a non-personal email.
-
-- Create one `github_organization_webhook` in tofu (for both push and package), publish as an AWS secret, synced down to Kargo, and use in new ProjectConfig, then a warehouse with both subscriptions will be nearly instant (+ clone time lol :-P)

--- a/k8s/TODO.md
+++ b/k8s/TODO.md
@@ -54,3 +54,7 @@ Move ArgoCD management out of Tofu and into ArgoCD itself. When doing this, foll
 
 In `k8s/tofu/codeai-k8s-dex/tofu.tfvars`, update `google_email_with_groups_readonly_scope`
 to a non-personal email.
+
+## Helm / Kustomize parity
+
+- Allow `verify-helm-parity` to still check parity when `k8s-gitops` / kustomize + helm charts are modified locally, so we can verify them before we commit.

--- a/k8s/docs/kargotecture/PRs.md
+++ b/k8s/docs/kargotecture/PRs.md
@@ -1,0 +1,30 @@
+- `helm/argo-refs-code-dot-org-commit`
+  - [code-dot-org #71561](https://github.com/code-dot-org/code-dot-org/pull/71561)
+  - [k8s-gitops #1](https://github.com/code-dot-org/k8s-gitops/pull/1)
+- `helm/common-case-rendered-branches`
+  - [code-dot-org #71562](https://github.com/code-dot-org/code-dot-org/pull/71562)
+  - [k8s-gitops #2](https://github.com/code-dot-org/k8s-gitops/pull/2)
+- `helm/oci-release-capsule`
+  - [code-dot-org #71563](https://github.com/code-dot-org/code-dot-org/pull/71563)
+  - [k8s-gitops #6](https://github.com/code-dot-org/k8s-gitops/pull/6)
+- `helm/rendered-branches`
+  - [code-dot-org #71565](https://github.com/code-dot-org/code-dot-org/pull/71565)
+  - [k8s-gitops #4](https://github.com/code-dot-org/k8s-gitops/pull/4)
+- `helm/source-snapshot-rendered-branches`
+  - [code-dot-org #71566](https://github.com/code-dot-org/code-dot-org/pull/71566)
+  - [k8s-gitops #5](https://github.com/code-dot-org/k8s-gitops/pull/5)
+- `kustomize/argo-refs-code-dot-org-commit`
+  - [code-dot-org #71564](https://github.com/code-dot-org/code-dot-org/pull/71564)
+  - [k8s-gitops #3](https://github.com/code-dot-org/k8s-gitops/pull/3)
+- `kustomize/common-case-rendered-branches`
+  - [code-dot-org #71567](https://github.com/code-dot-org/code-dot-org/pull/71567)
+  - [k8s-gitops #7](https://github.com/code-dot-org/k8s-gitops/pull/7)
+- `kustomize/oci-release-capsule`
+  - [code-dot-org #71569](https://github.com/code-dot-org/code-dot-org/pull/71569)
+  - [k8s-gitops #8](https://github.com/code-dot-org/k8s-gitops/pull/8)
+- `kustomize/rendered-branches`
+  - [code-dot-org #71568](https://github.com/code-dot-org/code-dot-org/pull/71568)
+  - [k8s-gitops #9](https://github.com/code-dot-org/k8s-gitops/pull/9)
+- `kustomize/source-snapshot-rendered-branches`
+  - [code-dot-org #71570](https://github.com/code-dot-org/code-dot-org/pull/71570)
+  - [k8s-gitops #10](https://github.com/code-dot-org/k8s-gitops/pull/10)

--- a/k8s/docs/kargotecture/implementations.md
+++ b/k8s/docs/kargotecture/implementations.md
@@ -1,0 +1,41 @@
+- Base dir: `/Users/seth/src/kargo-architecture/worker`
+
+- `Argo Refs code-dot-org Commit`
+  - Helm:
+    - `code-dot-org`: dir: `helm/argo-refs-code-dot-org-commit/code-dot-org`, branch: `kargo/argo-refs-code-dot-org-commit/helm`, pr: `#71561`
+    - `k8s-gitops`: dir: `helm/argo-refs-code-dot-org-commit/k8s-gitops`, branch: `kargo/argo-refs-code-dot-org-commit/helm`, pr: `#1`
+  - Kustomize:
+    - `code-dot-org`: dir: `kustomize/argo-refs-code-dot-org-commit/code-dot-org`, branch: `kargo/argo-refs-code-dot-org-commit/kustomize`, pr: `#71564`
+    - `k8s-gitops`: dir: `kustomize/argo-refs-code-dot-org-commit/k8s-gitops`, branch: `kargo/argo-refs-code-dot-org-commit/kustomize`, pr: `#3`
+
+- `Common-Case Freight + Rendered Branches`
+  - Helm:
+    - `code-dot-org`: dir: `helm/common-case-rendered-branches/code-dot-org`, branch: `kargo/common-case-rendered-branches/helm`, pr: `#71562`
+    - `k8s-gitops`: dir: `helm/common-case-rendered-branches/k8s-gitops`, branch: `kargo/common-case-rendered-branches/helm`, pr: `#2`
+  - Kustomize:
+    - `code-dot-org`: dir: `kustomize/common-case-rendered-branches/code-dot-org`, branch: `kargo/common-case-rendered-branches/kustomize`, pr: `#71567`
+    - `k8s-gitops`: dir: `kustomize/common-case-rendered-branches/k8s-gitops`, branch: `kargo/common-case-rendered-branches/kustomize`, pr: `#7`
+
+- `OCI Release Capsule`
+  - Helm:
+    - `code-dot-org`: dir: `helm/oci-release-capsule/code-dot-org`, branch: `kargo/oci-release-capsule/helm`, pr: `#71563`
+    - `k8s-gitops`: dir: `helm/oci-release-capsule/k8s-gitops`, branch: `kargo/oci-release-capsule/helm`, pr: `#6`
+  - Kustomize:
+    - `code-dot-org`: dir: `kustomize/oci-release-capsule/code-dot-org`, branch: `kargo/oci-release-capsule/kustomize`, pr: `#71569`
+    - `k8s-gitops`: dir: `kustomize/oci-release-capsule/k8s-gitops`, branch: `kargo/oci-release-capsule/kustomize`, pr: `#8`
+
+- `Rendered Branches from a Thin Lock`
+  - Helm:
+    - `code-dot-org`: dir: `helm/rendered-branches/code-dot-org`, branch: `kargo/rendered-branches/helm`, pr: `#71565`
+    - `k8s-gitops`: dir: `helm/rendered-branches/k8s-gitops`, branch: `kargo/rendered-branches/helm`, pr: `#4`
+  - Kustomize:
+    - `code-dot-org`: dir: `kustomize/rendered-branches/code-dot-org`, branch: `kargo/rendered-branches/kustomize`, pr: `#71568`
+    - `k8s-gitops`: dir: `kustomize/rendered-branches/k8s-gitops`, branch: `kargo/rendered-branches/kustomize`, pr: `#9`
+
+- `Source Snapshot (Helm or Kustomize) + Rendered Branches`
+  - Helm:
+    - `code-dot-org`: dir: `helm/source-snapshot-rendered-branches/code-dot-org`, branch: `kargo/source-snapshot-rendered-branches/helm`, pr: `#71566`
+    - `k8s-gitops`: dir: `helm/source-snapshot-rendered-branches/k8s-gitops`, branch: `kargo/source-snapshot-rendered-branches/helm`, pr: `#5`
+  - Kustomize:
+    - `code-dot-org`: dir: `kustomize/source-snapshot-rendered-branches/code-dot-org`, branch: `kargo/source-snapshot-rendered-branches/kustomize`, pr: `#71570`
+    - `k8s-gitops`: dir: `kustomize/source-snapshot-rendered-branches/k8s-gitops`, branch: `kargo/source-snapshot-rendered-branches/kustomize`, pr: `#10`

--- a/k8s/docs/kargotecture/plans/iteration-7/argo-refs-code-dot-org-commit.md
+++ b/k8s/docs/kargotecture/plans/iteration-7/argo-refs-code-dot-org-commit.md
@@ -1,0 +1,939 @@
+# Argo Refs code-dot-org Commit
+
+**Short name:** Argo refs commit
+
+**Catchy description:** Write one tiny release record to `warehouses/codeai/`,
+then let Argo CD deploy Helm or Kustomize source pinned to a `code-dot-org`
+commit.
+
+## Detailed Technical Description of Plan
+This plan is the simplest source-driven Kargo design in iteration 7. Kargo does
+not snapshot a release package or render review output into Freight; instead it
+promotes a tiny Git build-lock record from `k8s-gitops` that names one exact
+`code-dot-org` commit and one exact image tag/digest. The build-lock is the
+release record, and `current.yaml` is just a stable parse path to that same
+record. The whole point is to keep Freight small, deterministic, and easy to
+audit while still letting the real deploy source live in `code-dot-org`.
+
+The plan then forks into two packaging variants that share the same release
+identity model. In the Helm variant, Argo points directly at `code-dot-org`
+`k8s/helm` at the pinned commit and uses `k8s-gitops` only for env values and
+deployment metadata. In the Kustomize variant, Argo points at
+`k8s-gitops/apps/codeai/deployments/<deployment>/deploy/`, where the rendered
+deploy tree is built from the checked-in `code-dot-org/k8s/kustomize/` package
+plus the envType `Component`s under `apps/codeai/envTypes/<envType>/`. That is
+the main conceptual difference from the rendered-branch plans: here the GitOps
+repo does not store rendered output, it stores the deploy entrypoint and env
+policy that tell Argo how to materialize source at the right commit.
+
+The tricky part is that the plan looks deceptively simple until you try to make
+promotion and deploy truth line up. The build-lock file must be written
+atomically as both `git-<full-commit-sha>.yaml` and `current.yaml`, the GH
+action must keep the image tag and the lock file in sync, and Kargo must
+distinguish Helm vs Kustomize with `packaging.kind` and `sourcePath` before it
+mutates GitOps. The Helm path is the lower-friction migration path, while the
+Kustomize path is the cleaner long-term form if the team wants source-backed
+Kustomize deploy truth without moving to rendered stage branches.
+
+- **Type:** Source-driven plan family
+- **Pattern:** Source-driven
+- **Rendered manifests pattern:** No
+
+## Shared architecture summary
+This is one plan family with two packaging variants:
+
+- **Helm variant:** lower-migration, simpler, and closer to today
+- **Kustomize variant:** deeper refactor, but cleaner if the team really wants
+  long-lived Kustomize deploy truth
+
+Both variants share the same release identity model:
+
+- Kargo promotes a thin Git build-lock record from `k8s-gitops`
+- that build lock pins the image and the real `code-dot-org` commit
+- Argo later deploys source-oriented truth that ultimately points at that
+  commit, instead of Kargo snapshotting or rendering the package into Git
+
+The key distinction between variants is:
+
+- **Helm variant:** Argo entrypoint is `code-dot-org` at a pinned commit.
+- **Kustomize variant:** Argo entrypoint is
+  `k8s-gitops/apps/codeai/deployments/<deployment>/deploy/`, built from the
+  checked-in `code-dot-org/k8s/kustomize/` tree plus the existing
+  `k8s-gitops/apps/codeai/envTypes/*` envType components.
+
+Pick one variant for a given implementation pass; do not try to mix both
+deploy-truth models in one first pass.
+
+## What Freight Looks Like
+This plan promotes only a tiny Git lock file. Kargo never snapshots the package
+itself; it promotes one release record that pins the real source commit and
+image.
+
+Canonical Freight shape:
+
+```text
+warehouses/codeai/builds/
+  current.yaml
+  git-<full-commit-sha>.yaml
+```
+
+```yaml
+schemaVersion: v1
+releaseId: git-<full-commit-sha>
+gitCommit: <full-commit-sha>
+image:
+  ref: ghcr.io/code-dot-org/code-dot-org:git-<full-commit-sha>
+  digest: sha256:...
+packaging:
+  kind: helm # or kustomize
+  sourceRepo: https://github.com/code-dot-org/code-dot-org.git
+  sourcePath: k8s/helm # or k8s/kustomize
+createdAt: 2026-03-22T12:34:56Z
+```
+
+The exact same schema is stored in:
+
+- `git-<full-commit-sha>.yaml` for historical auditability
+- `current.yaml` for a stable promotion-time parse path
+
+## Warehouse artifact
+On each successful `staging` build, the GH action writes:
+
+```text
+warehouses/
+  codeai/
+    builds/
+      current.yaml
+      git-<full-commit-sha>.yaml
+```
+
+The file is intentionally small and reviewable. It is the only Warehouse input
+for this plan family.
+
+## Freight
+Freight is **Git-only**.
+
+The CodeAI Warehouse watches:
+
+```yaml
+apiVersion: kargo.akuity.io/v1alpha1
+kind: Warehouse
+metadata:
+  name: codeai-builds
+  namespace: kargo-project-codeai
+spec:
+  subscriptions:
+    - git:
+        repoURL: https://github.com/code-dot-org/k8s-gitops.git
+        branch: main
+        includePaths:
+          - warehouses/codeai/builds
+```
+
+Each new `git-<full-commit-sha>.yaml` commit becomes a new piece of Freight.
+
+Pros:
+- extremely simple
+- Warehouse discovery is fast and deterministic
+- `$gitcommit` is the single release coordinate
+
+Cons:
+- Kargo does not natively know about the image repo or packaging repo
+- rendered manifest diffs are not first-class unless added later
+
+## Shared Kargo project
+Stages:
+- `staging`: direct from Warehouse
+- `test`: from `staging`, then automated tests
+- `levelbuilder`: from `test`
+- `review-infra-changes`: from `test`, PR-oriented gate for production changes
+- `production`: from `review-infra-changes`
+
+Shared promotion behavior:
+1. Clone `k8s-gitops` at the exact promoted Freight commit to a read-only path
+   such as `./freight`.
+2. Clone `k8s-gitops` `main` to a writable path such as `./gitops`.
+3. Parse `./freight/warehouses/codeai/builds/current.yaml`.
+4. Update the target deployment to point at the promoted `gitCommit` and image.
+5. Commit and push.
+
+`review-infra-changes` should push to a generated branch and open a PR instead
+of pushing directly to `main`.
+
+## Stage-by-stage promotion flow
+- `staging`: promote the chosen `gitCommit` and image into the staging
+  deployment target
+- `test`: copy the exact same release into the test deployment target, then run
+  automated checks
+- `levelbuilder`: copy the same release after `test`
+- `review-infra-changes`: prepare the production update on a PR branch
+- `production`: merge or apply the already-reviewed production update
+
+`test` is where automated checks run. The release should not advance to
+`levelbuilder` or `review-infra-changes` until those checks pass.
+
+## Shared GH runner sketch
+The GH action is intentionally small in this plan family:
+
+Helm and Kustomize use the same GH action shape here; only
+`packaging.kind` and `sourcePath` differ.
+
+1. Build and stitch the multiplatform image.
+2. Keep publishing immutable `git-<full-commit-sha>` tags.
+3. Write `warehouses/codeai/builds/git-<full-commit-sha>.yaml`.
+4. Copy the same contents to `warehouses/codeai/builds/current.yaml`.
+5. Commit and push both files together.
+
+The hard part is keeping the stable alias and the historical file identical in
+the same commit.
+
+## Shared testing and gating summary
+Recommended automation:
+- Extend [k8s.yml](/Users/seth/.codex/worktrees/684f/code-dot-org/.github/workflows/k8s.yml) or call a small reusable workflow from it for repo-specific contract and smoke checks.
+- Use existing Drone results on the promoted `gitCommit` as the app/unit/UI
+  gate before downstream promotion.
+- Use Kargo `verification` with `AnalysisTemplate`s for lightweight post-sync
+  rollout, health, and smoke checks where that fits the variant.
+
+Simple shared tests to automate:
+- In `k8s.yml`, after the workflow step that writes
+  `warehouses/codeai/builds/`, generate the proposed `current.yaml` and
+  `git-<full-commit-sha>.yaml`, parse both, and fail unless they have identical contents.
+- In the same workflow, assert the produced image tag matches `git-<full-commit-sha>` and
+  the lock file `image.ref` uses that same tag.
+
+This plan family also reuses
+[Gate Promotion On Legacy Gitflow Branches](../modules/gate-promotion-on-legacy-gitflow-branches.md)
+for migration-era gating.
+
+## Shared core tradeoff
+This is the core tradeoff of the whole family:
+
+- Argo deploys source-oriented truth that points at a pinned
+  `code-dot-org` commit
+- Kargo promotes a tiny release record instead of rendered output
+
+That makes the plan simple and migration-friendly, but less reviewable than the
+rendered-branch plans.
+
+## modules that are part of implementing this plan
+- [Gate Promotion On Legacy Gitflow Branches](../modules/gate-promotion-on-legacy-gitflow-branches.md)
+- [Git Build-Lock Freight Record](../modules/git-build-lock-freight-record.md)
+
+# Sketch of Pivotal Implementation Details
+
+## Shared mechanics
+
+This plan family reuses:
+- [Git Build-Lock Freight Record](../modules/git-build-lock-freight-record.md)
+- [Gate Promotion On Legacy Gitflow Branches](../modules/gate-promotion-on-legacy-gitflow-branches.md)
+
+Both variants:
+- promote the same thin build-lock Freight
+- parse the same stable `current.yaml` path
+- rely on the same stage ladder and GH runner shape
+- differ only in what Argo ultimately deploys after that lock is parsed
+
+## Helm implementation starting point
+
+Treat the checked-in `code-dot-org/k8s/helm/` tree as the starting point, not a
+frozen contract. The implementor may modify or reshape `k8s/helm/` if this plan
+benefits from it, but should preserve current behavior unless the change
+materially improves the plan.
+
+## Kustomize implementation starting point
+
+Treat the checked-in `code-dot-org/k8s/kustomize/` tree as the starting point,
+not a frozen contract. The implementor may modify or reshape `k8s/kustomize/`
+as needed for this plan, especially the base/components layout.
+
+Use the current `k8s-gitops/apps/codeai/envTypes/<envType>/kustomization.yaml`
+files as the starting envType contract. `production` may additionally layer in
+`apps/codeai/envTypes/components/autoscaling/`.
+
+Do not treat `code-dot-org/k8s/kustomize/overlays/*` as the production deploy
+contract unless the plan explicitly chooses to adopt them. Those directories are
+currently local-dev/parity support.
+
+The Kustomize deploy-wrapper contract is shared across all Kustomize stages:
+`staging`, `test`, `levelbuilder`, and `review-infra-changes` all use the same
+mutation pattern against their own deployment wrapper, changing only the
+deployment-specific metadata and release inputs.
+
+## Shared Warehouse sketch
+
+```yaml
+apiVersion: kargo.akuity.io/v1alpha1
+kind: Warehouse
+metadata:
+  name: codeai-builds
+  namespace: kargo-project-codeai
+spec:
+  subscriptions:
+    - git:
+        repoURL: https://github.com/code-dot-org/k8s-gitops.git
+        branch: main
+        includePaths:
+          - warehouses/codeai/builds
+```
+
+## Shared hard part
+
+The hard part in this plan family is no longer lookup. It is keeping the
+historical `git-<full-commit-sha>.yaml` file and the stable `current.yaml` parse path
+identical in one commit, while still replaying promotions onto writable
+`k8s-gitops` `main`.
+
+Variant selection is also part of the build-lock contract:
+
+- Helm stages are only valid when the lock says `packaging.kind: helm` and
+  `packaging.sourcePath: k8s/helm`
+- Kustomize stages are only valid when the lock says
+  `packaging.kind: kustomize` and `packaging.sourcePath: k8s/kustomize`
+
+For iteration 7, enforce that with repo contract tests in `k8s.yml` instead of
+inventing a custom pre-mutation Kargo helper just for this family.
+
+## Helm variant
+This is the lower-migration variant.
+
+### `code-dot-org`
+No structural change is required for the first implementation.
+
+Helm can stay:
+
+```text
+k8s/helm/
+  Chart.yaml
+  values.yaml
+  staging.values.yaml
+  test.values.yaml
+  levelbuilder.values.yaml
+  production.values.yaml
+```
+
+### `k8s-gitops`
+Keep:
+
+```text
+apps/codeai/deployments/<deployment>/
+  deployment.yaml
+  values.yaml
+```
+
+Add:
+
+```text
+warehouses/codeai/builds/
+  current.yaml
+  git-<full-commit-sha>.yaml
+```
+
+### Concrete file examples
+
+#### Changed existing file: `apps/codeai/deployments/<deployment>/deployment.yaml`
+
+This variant should rename the existing `branch` key to `targetRevision`. That
+key then carries the promoted full commit SHA instead of an environment branch
+name such as `staging`.
+
+Example:
+
+```yaml
+envType: staging
+namespace: staging
+targetRevision: 0cc4cd87f40ae606d1822d5652b552f8c50a4668
+```
+
+#### Changed existing file: `apps/codeai/deployments/<deployment>/values.yaml`
+
+Kargo only updates the `image` field.
+
+Example:
+
+```yaml
+image: ghcr.io/code-dot-org/code-dot-org:git-0cc4cd87f40ae606d1822d5652b552f8c50a4668
+autoscaling:
+  maxReplicas: 1
+locals.yml:
+  stack_name: staging
+```
+
+If the team later prefers digest-first deploy refs, the same file can instead
+carry a digest-pinned image string.
+
+#### Changed existing file: `apps/codeai/applicationset.yaml`
+
+Argo must read `targetRevision` from `deployment.yaml`.
+
+Example source stanza:
+
+```yaml
+sources:
+  - repoURL: https://github.com/code-dot-org/code-dot-org.git
+    targetRevision: '{{targetRevision}}'
+    path: k8s/helm
+    helm:
+      releaseName: '{{path.basename}}'
+      valueFiles:
+        - $values/apps/codeai/envTypes/{{envType}}.values.yaml
+        - $values/apps/codeai/deployments/{{path.basename}}/values.yaml
+  - repoURL: https://github.com/code-dot-org/k8s-gitops.git
+    targetRevision: main
+    ref: values
+```
+
+### Example `staging` Stage
+
+```yaml
+apiVersion: kargo.akuity.io/v1alpha1
+kind: Stage
+metadata:
+  name: staging
+  namespace: kargo-project-codeai
+spec:
+  requestedFreight:
+    - origin:
+        kind: Warehouse
+        name: codeai-builds
+      sources:
+        direct: true
+  promotionTemplate:
+    spec:
+      steps:
+        - uses: git-clone
+          config:
+            repoURL: https://github.com/code-dot-org/k8s-gitops.git
+            checkout:
+              - commit: ${{ commitFrom('https://github.com/code-dot-org/k8s-gitops.git', warehouse('codeai-builds')).ID }}
+                path: ./freight
+              - branch: main
+                path: ./gitops
+
+        - uses: yaml-parse
+          as: build-lock
+          config:
+            path: ./freight/warehouses/codeai/builds/current.yaml
+            outputs:
+              - name: releaseId
+                fromExpression: releaseId
+              - name: gitCommit
+                fromExpression: gitCommit
+              - name: imageRef
+                fromExpression: image.ref
+              - name: packagingKind
+                fromExpression: packaging.kind
+              - name: sourcePath
+                fromExpression: packaging.sourcePath
+
+        - uses: yaml-update
+          config:
+            path: ./gitops/apps/codeai/deployments/staging/deployment.yaml
+            updates:
+              - key: targetRevision
+                value: ${{ outputs['build-lock'].gitCommit }}
+
+        - uses: yaml-update
+          config:
+            path: ./gitops/apps/codeai/deployments/staging/values.yaml
+            updates:
+              - key: image
+                value: ${{ outputs['build-lock'].imageRef }}
+
+        - uses: git-commit
+          config:
+            path: ./gitops
+            message: Promote staging to ${{ outputs['build-lock'].releaseId }}
+
+        - uses: git-push
+          config:
+            path: ./gitops
+```
+
+### Example `review-infra-changes` Stage
+
+```yaml
+apiVersion: kargo.akuity.io/v1alpha1
+kind: Stage
+metadata:
+  name: review-infra-changes
+  namespace: kargo-project-codeai
+spec:
+  requestedFreight:
+    - origin:
+        kind: Warehouse
+        name: codeai-builds
+      sources:
+        stages:
+          - test
+  promotionTemplate:
+    spec:
+      steps:
+        - uses: git-clone
+          config:
+            repoURL: https://github.com/code-dot-org/k8s-gitops.git
+            checkout:
+              - commit: ${{ commitFrom('https://github.com/code-dot-org/k8s-gitops.git', warehouse('codeai-builds')).ID }}
+                path: ./freight
+              - branch: main
+                path: ./gitops
+        - uses: yaml-parse
+          as: build-lock
+          config:
+            path: ./freight/warehouses/codeai/builds/current.yaml
+            outputs:
+              - name: releaseId
+                fromExpression: releaseId
+              - name: gitCommit
+                fromExpression: gitCommit
+              - name: imageRef
+                fromExpression: image.ref
+              - name: packagingKind
+                fromExpression: packaging.kind
+              - name: sourcePath
+                fromExpression: packaging.sourcePath
+        - uses: yaml-update
+          config:
+            path: ./gitops/apps/codeai/deployments/production/deployment.yaml
+            updates:
+              - key: targetRevision
+                value: ${{ outputs['build-lock'].gitCommit }}
+        - uses: yaml-update
+          config:
+            path: ./gitops/apps/codeai/deployments/production/values.yaml
+            updates:
+              - key: image
+                value: ${{ outputs['build-lock'].imageRef }}
+        - uses: git-commit
+          config:
+            path: ./gitops
+            message: Review production update for ${{ outputs['build-lock'].releaseId }}
+        - uses: git-push
+          as: push
+          config:
+            path: ./gitops
+            generateTargetBranch: true
+        - uses: git-open-pr
+          config:
+            repoURL: https://github.com/code-dot-org/k8s-gitops.git
+            sourceBranch: ${{ outputs.push.branch }}
+            targetBranch: main
+            title: Review CodeAI production release
+```
+
+### Variant-specific notes
+- Local Skaffold remains basically unchanged.
+- This is the best boring fallback and the easier migration path.
+- Infra review is weaker here because reviewers mostly approve ref changes, not
+  rendered manifests.
+
+### Helm migration notes
+- Rename `apps/codeai/deployments/production/deployment.yaml.disabled` to
+  `apps/codeai/deployments/production/deployment.yaml`.
+- Rename `apps/codeai/deployments/levelbuilder/deployment.yaml.disabled` to
+  `apps/codeai/deployments/levelbuilder/deployment.yaml`.
+- Rename `apps/codeai/deployments/*/deployment.yaml` key `branch` to
+  `targetRevision`.
+- Fix `apps/codeai/applicationset.yaml` to use `{{targetRevision}}` instead of
+  `{{sourceRevision}}`.
+- Update the current writeback workflow to write warehouse files instead of env
+  `values.yaml`.
+
+### Helm Testing Plan
+
+Shared checks still apply. For the Helm variant, also:
+- In `k8s.yml`, validate every `warehouses/codeai/builds/current.yaml` and
+  `git-<full-commit-sha>.yaml` written for the Helm variant has `packaging.kind: helm`
+  and `packaging.sourcePath: k8s/helm`.
+- In `k8s.yml`, validate every
+  `apps/codeai/deployments/<deployment>/deployment.yaml` has `envType`,
+  `namespace`, and `targetRevision`.
+- In the same workflow, validate every
+  `apps/codeai/deployments/<deployment>/values.yaml` updates `image`
+  correctly.
+- In the same workflow, validate
+  [applicationset.yaml](/Users/seth/src/k8s-gitops/apps/codeai/applicationset.yaml)
+  uses `targetRevision: '{{targetRevision}}'` for the Helm source.
+- In the same workflow, run one local `helm template` smoke render using:
+  - `apps/codeai/envTypes/{{envType}}.values.yaml`
+  - `apps/codeai/deployments/{{path.basename}}/values.yaml`
+
+## Kustomize variant
+This is the deeper-refactor variant.
+
+### `code-dot-org`
+Replace rough `targets/` layout with a durable shared-source tree:
+
+```text
+k8s/kustomize/
+  base/
+  components/
+  local/
+    overlays/
+      development/
+      setup-db/
+      setup-s3/
+```
+
+There should be no long-lived deploy-target Kustomizations in `code-dot-org`
+other than local-dev helpers.
+
+### `k8s-gitops`
+Keep deployment wrappers and envType components here:
+
+```text
+apps/codeai/
+  deployments/
+    <deployment>/
+      deployment.yaml
+      deploy/
+        kustomization.yaml
+  envTypes/
+    <envType>/
+      kustomization.yaml
+      deployment.patch.yaml
+      deployment.resources.patch.yaml
+      locals.yml.patch.yaml
+    components/
+      autoscaling/
+```
+
+Per [README.md](/Users/seth/src/k8s-gitops/README.md#L27), a deployment exists
+when `apps/codeai/deployments/<deployment>/` exists and contains
+`deployment.yaml`. For this variant, `deployment.yaml` is metadata only. It
+must contain at least `envType` and `namespace`. Unlike the Helm variant, it
+does not carry the deploy pin; the pin lives in `deploy/kustomization.yaml`.
+
+### Concrete file examples
+
+#### `apps/codeai/deployments/<deployment>/deployment.yaml`
+
+This variant uses deployment metadata only to resolve `envType` and
+`namespace`. Unlike the Helm variant, it does **not** use `targetRevision`;
+Argo stays on `main` and the deploy pin lives in `deploy/kustomization.yaml`.
+
+```yaml
+envType: staging
+namespace: staging
+```
+
+#### `apps/codeai/deployments/<deployment>/deploy/kustomization.yaml`
+
+```yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: staging
+resources:
+  - github.com/code-dot-org/code-dot-org//k8s/kustomize/base?ref=0cc4cd87f40ae606d1822d5652b552f8c50a4668
+components:
+  - ../../envTypes/staging
+images:
+  - name: code-dot-org
+    newName: ghcr.io/code-dot-org/code-dot-org
+    newTag: git-0cc4cd87f40ae606d1822d5652b552f8c50a4668
+```
+
+`resources[0]` pins the shared Kustomize base by full commit SHA.
+`components[0]` selects the reusable envType layer.
+`images[0].name` must be `code-dot-org` because that is the real image name in
+[dashboard-deployment.yaml](/Users/seth/.codex/worktrees/684f/code-dot-org/k8s/kustomize/base/dashboard-deployment.yaml).
+`images[0].newName` rewrites that local-dev base naming to the real deploy repo
+and `images[0].newTag` selects the immutable `git-<full-commit-sha>` image tag.
+Promotion rewrites the full `resources`, `components`, and `images` arrays to
+that exact shape. All other fields in this file should be treated as immutable
+deployment policy.
+
+After the initial bootstrap migration seeds
+`apps/codeai/deployments/<deployment>/deploy/kustomization.yaml`, that file is
+machine-owned and should not be hand-edited.
+
+#### `apps/codeai/envTypes/<envType>/kustomization.yaml`
+
+```yaml
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+namePrefix: staging-
+labels:
+  - pairs:
+      app.kubernetes.io/name: cdo
+      app.kubernetes.io/instance: staging
+    includeSelectors: true
+    includeTemplates: true
+patches:
+  - path: deployment.patch.yaml
+```
+
+Top-level envTypes are now `Component`s. Production currently composes
+`../components/autoscaling`. Deployment wrappers consume envTypes through
+`components:`, not `resources:`.
+
+#### `codeai/applicationset.yaml` sketch
+
+The implementor must update
+[applicationset.yaml](/Users/seth/src/k8s-gitops/apps/codeai/applicationset.yaml)
+so this variant keeps Argo on `main` and deploys the Kustomize entrypoint under
+each deployment:
+
+```yaml
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: codeai
+  namespace: argocd
+spec:
+  generators:
+    - git:
+        repoURL: https://github.com/code-dot-org/k8s-gitops.git
+        revision: main
+        files:
+          - path: apps/codeai/deployments/*/deployment.yaml
+  template:
+    metadata:
+      name: codeai-{{path.basename}}
+    spec:
+      sources:
+        - repoURL: https://github.com/code-dot-org/k8s-gitops.git
+          targetRevision: main
+          path: apps/codeai/deployments/{{path.basename}}/deploy
+      destination:
+        server: https://kubernetes.default.svc
+        namespace: '{{namespace}}'
+```
+
+#### Seeded wrapper requirement
+
+Kargo built-ins do not include a generic file writer, and `yaml-update` fails
+if the target file does not exist. This variant therefore requires a one-time
+migration that seeds `apps/codeai/deployments/<deployment>/deploy/kustomization.yaml`
+for every real deployment. Seed each wrapper with the canonical file shape
+above, using that deployment's current live commit and tag as initial values.
+After the first promotion, Kargo rewrites that existing file on every
+promotion. Kargo does not create deployments or envTypes.
+
+### Example `staging` Stage
+
+```yaml
+apiVersion: kargo.akuity.io/v1alpha1
+kind: Stage
+metadata:
+  name: staging
+  namespace: kargo-project-codeai
+spec:
+  requestedFreight:
+    - origin:
+        kind: Warehouse
+        name: codeai-builds
+      sources:
+        direct: true
+  promotionTemplate:
+    spec:
+      steps:
+        - uses: git-clone
+          config:
+            repoURL: https://github.com/code-dot-org/k8s-gitops.git
+            checkout:
+              - commit: ${{ commitFrom('https://github.com/code-dot-org/k8s-gitops.git', warehouse('codeai-builds')).ID }}
+                path: ./freight
+              - branch: main
+                path: ./gitops
+
+        - uses: yaml-parse
+          as: build-lock
+          config:
+            path: ./freight/warehouses/codeai/builds/current.yaml
+            outputs:
+              - name: releaseId
+                fromExpression: releaseId
+              - name: gitCommit
+                fromExpression: gitCommit
+              - name: packagingKind
+                fromExpression: packaging.kind
+              - name: sourcePath
+                fromExpression: packaging.sourcePath
+
+        - uses: yaml-parse
+          as: deployment-meta
+          config:
+            path: ./gitops/apps/codeai/deployments/staging/deployment.yaml
+            outputs:
+              - name: envType
+                fromExpression: envType
+              - name: namespace
+                fromExpression: namespace
+
+        - uses: yaml-update
+          config:
+            path: ./gitops/apps/codeai/deployments/staging/deploy/kustomization.yaml
+            updates:
+              - key: namespace
+                value: ${{ outputs['deployment-meta'].namespace }}
+              - key: resources
+                value:
+                  - github.com/code-dot-org/code-dot-org//k8s/kustomize/base?ref=${{ outputs['build-lock'].gitCommit }}
+              - key: components
+                value:
+                  - ../../envTypes/${{ outputs['deployment-meta'].envType }}
+
+        - uses: kustomize-set-image
+          config:
+            path: ./gitops/apps/codeai/deployments/staging/deploy
+            images:
+              - image: code-dot-org
+                newName: ghcr.io/code-dot-org/code-dot-org
+                tag: ${{ outputs['build-lock'].releaseId }}
+
+        - uses: git-commit
+          config:
+            path: ./gitops
+            message: Promote staging deploy to ${{ outputs['build-lock'].releaseId }}
+
+        - uses: git-push
+          config:
+            path: ./gitops
+```
+
+### Example `review-infra-changes` Stage
+
+```yaml
+apiVersion: kargo.akuity.io/v1alpha1
+kind: Stage
+metadata:
+  name: review-infra-changes
+  namespace: kargo-project-codeai
+spec:
+  requestedFreight:
+    - origin:
+        kind: Warehouse
+        name: codeai-builds
+      sources:
+        stages:
+          - test
+  promotionTemplate:
+    spec:
+      steps:
+        - uses: git-clone
+          config:
+            repoURL: https://github.com/code-dot-org/k8s-gitops.git
+            checkout:
+              - commit: ${{ commitFrom('https://github.com/code-dot-org/k8s-gitops.git', warehouse('codeai-builds')).ID }}
+                path: ./freight
+              - branch: main
+                path: ./gitops
+        - uses: yaml-parse
+          as: build-lock
+          config:
+            path: ./freight/warehouses/codeai/builds/current.yaml
+            outputs:
+              - name: releaseId
+                fromExpression: releaseId
+              - name: gitCommit
+                fromExpression: gitCommit
+              - name: packagingKind
+                fromExpression: packaging.kind
+              - name: sourcePath
+                fromExpression: packaging.sourcePath
+        - uses: yaml-parse
+          as: deployment-meta
+          config:
+            path: ./gitops/apps/codeai/deployments/production/deployment.yaml
+            outputs:
+              - name: envType
+                fromExpression: envType
+              - name: namespace
+                fromExpression: namespace
+        - uses: yaml-update
+          config:
+            path: ./gitops/apps/codeai/deployments/production/deploy/kustomization.yaml
+            updates:
+              - key: namespace
+                value: ${{ outputs['deployment-meta'].namespace }}
+              - key: resources
+                value:
+                  - github.com/code-dot-org/code-dot-org//k8s/kustomize/base?ref=${{ outputs['build-lock'].gitCommit }}
+              - key: components
+                value:
+                  - ../../envTypes/${{ outputs['deployment-meta'].envType }}
+        - uses: kustomize-set-image
+          config:
+            path: ./gitops/apps/codeai/deployments/production/deploy
+            images:
+              - image: code-dot-org
+                newName: ghcr.io/code-dot-org/code-dot-org
+                tag: ${{ outputs['build-lock'].releaseId }}
+        - uses: git-commit
+          config:
+            path: ./gitops
+            message: Review production deploy update for ${{ outputs['build-lock'].releaseId }}
+        - uses: git-push
+          as: push
+          config:
+            path: ./gitops
+            generateTargetBranch: true
+        - uses: git-open-pr
+          config:
+            repoURL: https://github.com/code-dot-org/k8s-gitops.git
+            sourceBranch: ${{ outputs.push.branch }}
+            targetBranch: main
+            title: Review CodeAI production deploy
+```
+
+### Variant-specific notes
+- Argo CD repo-server must be able to fetch the **public**
+  `code-dot-org` repo at sync time when this variant keeps Argo pointed at the
+  checked-in `k8s/kustomize/` source tree.
+- Outbound access from repo-server to
+  `https://github.com/code-dot-org/code-dot-org.git` must work.
+- Validate outbound access and unauthenticated GitHub fetch assumptions during
+  cluster bring-up.
+- Credentials are only needed if cluster or network policy blocks anonymous
+  GitHub fetches.
+- This variant becomes much stronger if paired with a render-preview job for
+  `review-infra-changes`.
+
+### Kustomize migration notes
+- Add `deploy/kustomization.yaml` under each real deployment in `k8s-gitops`.
+- Update `apps/codeai/applicationset.yaml` so Argo points at
+  `apps/codeai/deployments/{{path.basename}}/deploy` on `main`.
+- Keep `code-dot-org/k8s/kustomize/local/` as local-dev-only support, not
+  production deploy truth.
+- Leave top-level envTypes as `Component`s.
+
+### Kustomize Testing Plan
+
+Shared checks still apply. For the Kustomize variant, also:
+- In `k8s.yml`, validate every `warehouses/codeai/builds/current.yaml` and
+  `git-<full-commit-sha>.yaml` written for the Kustomize variant has
+  `packaging.kind: kustomize` and `packaging.sourcePath: k8s/kustomize`.
+- In `k8s.yml`, validate every
+  `apps/codeai/deployments/<deployment>/deployment.yaml` has `envType` and
+  `namespace`.
+- In the same workflow, validate every
+  `apps/codeai/envTypes/<envType>/kustomization.yaml` exists and is
+  `kind: Component`.
+- In the same workflow, validate every
+  `apps/codeai/deployments/<deployment>/deploy/kustomization.yaml` already
+  exists before promotion.
+- In the same workflow, validate promotion rewrites the full `namespace`,
+  `resources`, `components`, and `images` sections exactly as documented:
+  `resources[0]` ends with `//k8s/kustomize/base?ref=<full-commit-sha>`,
+  `components[0]` is `../../envTypes/<envType>`,
+  `images[0].name` is `code-dot-org`,
+  `images[0].newName` is `ghcr.io/code-dot-org/code-dot-org`, and
+  `images[0].newTag` is `git-<full-commit-sha>`.
+- In the same workflow, validate
+  [applicationset.yaml](/Users/seth/src/k8s-gitops/apps/codeai/applicationset.yaml)
+  keeps `targetRevision: main` for the Kustomize source and deploys
+  `apps/codeai/deployments/{{path.basename}}/deploy`.
+- In the same workflow, run one local `kustomize build` smoke test against a
+  seeded deployment wrapper such as
+  `apps/codeai/deployments/staging/deploy`.
+
+## Variant comparison / tradeoffs
+- **Helm variant:** lower migration, fewer repo changes, and the easiest way to
+  adopt this family.
+- **Kustomize variant:** deeper restructure, cleaner Kustomize separation, and
+  a better long-term fit if the team really wants Kustomize as deploy truth.
+- **Shared downside:** both variants are less reviewable than rendered-branch
+  plans because Argo deploys source-oriented truth instead of rendered output.
+- **Shared upside:** both variants keep the release trigger tiny and easy to
+  audit.

--- a/k8s/docs/kargotecture/plans/iteration-7/common-case-rendered-branches.md
+++ b/k8s/docs/kargotecture/plans/iteration-7/common-case-rendered-branches.md
@@ -1,0 +1,856 @@
+# Common-Case Freight + Rendered Branches
+
+**Short name:** Common-case render
+
+**Catchy description:** Stop manufacturing a fake build-lock commit. Let Kargo assemble the real monorepo commit and the real image into one Freight, then render stage branches from sparse checkouts of the huge repo.
+
+## Detailed Technical Description of Plan
+This plan is the “use the real artifacts, not a synthetic release record” option. Kargo watches the actual app image in GHCR and the real `code-dot-org` Git history, then creates one Freight item only when those two match on the same `git-<full-commit-sha>` identity. That means the release coordinate is not a warehouse file in `k8s-gitops`; it is the pairing of the published image and the source commit that produced it. The Warehouse logic is therefore the heart of the plan: if the image tag and Git commit do not line up exactly, there is no promotion candidate.
+
+On the GH action side, Helm and Kustomize are identical for this plan: CI only builds and publishes the immutable `git-<full-commit-sha>` image tag, and it writes no package artifact and no Git Freight record.
+
+Promotion then uses that single Freight item to render deploy output into long-lived stage branches in `k8s-gitops`. The critical implementation detail is that render-time input comes from a sparse checkout of `code-dot-org` at the promoted commit, not from the moving `staging` branch tip. Kargo clones `k8s-gitops` once for env policy and metadata, clones `code-dot-org` once for the source package, renders the stage-specific output, and commits that rendered output to `stage/<deployment>`. The review stage is not a special case in architecture, only in Git behavior: production output gets rendered to a generated branch and opened as a PR against `stage/production` so humans review the actual manifests before production sync.
+
+This plan differs from the thin-lock and snapshot families in where trust lives. The thin-lock family trusts a tiny build-lock file, and the snapshot family trusts a frozen copy of the package. Common-Case trusts the live source commit plus the live image tag, so the tricky part is making promotion deterministic without snapshotting anything into Freight. The hard implementation points are the exact `git-<full-commit-sha>` pairing rule, the sparse checkout at the promoted source commit, and the Kustomize temporary-wrapper flow that assembles render input from `k8s-gitops` envType components plus the shared deploy template before `kustomize-set-image` runs.
+
+- **Type:** Packaging-agnostic
+- **Pattern:** Hybrid
+- **Rendered manifests pattern:** Yes
+
+## What Freight Looks Like
+This plan does not create any `warehouses/codeai/` release record. Kargo
+discovers Freight directly from the real image and the real `code-dot-org`
+commit and promotes that pair.
+
+```text
+warehouses/codeai/
+  (unused)
+```
+
+```yaml
+apiVersion: kargo.akuity.io/v1alpha1
+kind: Warehouse
+spec:
+  subscriptions:
+    - image:
+        repoURL: ghcr.io/code-dot-org/code-dot-org
+        allowTagsRegexes:
+          - ^git-[0-9a-f]{40}$
+    - git:
+        repoURL: https://github.com/code-dot-org/code-dot-org.git
+        branch: staging
+  freightCreationCriteria:
+    expression: |
+      imageFrom('ghcr.io/code-dot-org/code-dot-org').Tag ==
+      'git-' + commitFrom('https://github.com/code-dot-org/code-dot-org.git').ID
+```
+
+## Warehouse artifact
+This plan intentionally does **not** use a synthetic `warehouses/codeai/` tree.
+
+Instead of teaching Kargo about a release by committing a release record into
+`k8s-gitops`, let Kargo discover the release directly from the real artifacts:
+
+- the built image in `ghcr.io/code-dot-org/code-dot-org`
+- the matching `code-dot-org` commit on `staging`
+
+Suggested Warehouse shape:
+
+```yaml
+apiVersion: kargo.akuity.io/v1alpha1
+kind: Warehouse
+metadata:
+  name: codeai
+spec:
+  freightCreationPolicy: Automatic
+  subscriptions:
+    - image:
+        repoURL: ghcr.io/code-dot-org/code-dot-org
+        allowTagsRegexes:
+          - ^git-[0-9a-f]{40}$
+    - git:
+        repoURL: https://github.com/code-dot-org/code-dot-org.git
+        branch: staging
+        commitSelectionStrategy: NewestFromBranch
+  freightCreationCriteria:
+    expression: |
+      imageFrom('ghcr.io/code-dot-org/code-dot-org').Tag ==
+      'git-' + commitFrom('https://github.com/code-dot-org/code-dot-org.git').ID
+```
+
+The `freightCreationCriteria` expression shown above is the intended contract for this plan, but the first implementation task should validate that exact syntax against the deployed Kargo version; if the syntax is not supported as written, the contractor should document the fallback before proceeding.
+
+Operationally, `warehouses/codeai/` becomes “nothing.” The image and the source
+commit are the release record.
+
+## Freight
+Freight is a **single multi-artifact Freight** from one Warehouse:
+
+- one image revision
+- one `code-dot-org` Git commit
+
+Those two artifacts are promoted together as a unit.
+
+The image must publish an immutable `git-<full-commit-sha>` tag in addition to any
+human-friendly branch tags.
+
+## Kargo project
+Stages:
+- `staging`
+- `test`
+- `levelbuilder`
+- `review-infra-changes`
+- `production`
+
+Recommended stage rules:
+- `staging`: direct from Warehouse
+- `test`: from `staging`, ideally using `MatchUpstream`
+- `levelbuilder`: from `test`, ideally using `MatchUpstream`
+- `review-infra-changes`: from `test`, ideally using `MatchUpstream`
+- `production`: from `review-infra-changes`
+
+Recommended promotion task shape:
+1. Clone `k8s-gitops` `main` to `./meta` for env policy and app metadata.
+2. Clone `k8s-gitops` `stage/<deployment>` to `./out`.
+3. Clone `code-dot-org` at the Freight commit to `./src` using sparse checkout.
+4. `git-clear` `./out`.
+5. Render the stage output from `./src` + `./meta`.
+6. Commit and push `./out`.
+7. Ask Argo CD to sync the stage app to the rendered branch commit.
+
+This is basically Kargo’s documented **Common Case** plus **Rendered Configs**
+plus the maintainers’ preferred **stage-specific branches** storage shape.
+
+## Stage-by-stage promotion flow
+- `staging`: render the staging deployment from the exact Freight commit/image pair to `stage/staging`
+- `test`: render `stage/test`, sync, then run verification against the exact same Freight already running in `staging`
+- `levelbuilder`: render `stage/levelbuilder` from the exact Freight verified in `test`
+- `review-infra-changes`: render production output to a generated branch, open a PR against `stage/production`, and wait for review/merge
+- `production`: sync the already-reviewed `stage/production` branch after the PR merge
+
+The crucial point is that the Freight shape does **not** change across stages.
+Only the rendered view changes.
+
+## `review infra changes` stage behavior
+This stage should behave like a real Git review gate:
+1. Clone `stage/production` to `./out`.
+2. Render production manifests from the Freight commit and production env config.
+3. Commit to a generated branch.
+4. Open a PR against `stage/production`.
+5. Wait for merge.
+
+Use `git-wait-for-pr` by default.
+
+`git-merge-pr` is a valid later optimization if the team wants “open a PR for
+audit, but auto-merge when checks pass,” but it should not be the first design.
+
+## `test` stage automation behavior
+After `stage/test` is updated and synced, run verification before allowing
+promotion onward.
+
+Good fits:
+- Kargo `verification` with `AnalysisTemplate`s for rollout, health, and smoke checks
+- existing Drone unit/UI results for the same promoted `gitCommit`
+- `MatchUpstream` so downstream stages always follow the exact Freight verified in `test`, not merely the newest discovered Freight
+
+## Does it break/awkwardize skaffold or local-dev in any way?
+No.
+
+Local dev keeps using source packaging in `code-dot-org`, exactly where it lives
+today. Promotion-time rendering is isolated to Kargo.
+
+## Proposed Helm / Kustomize directory structure
+### `code-dot-org`
+Helm can stay where it is:
+
+```text
+k8s/helm/
+```
+
+Future Kustomize should become more explicit:
+
+```text
+k8s/kustomize/
+  base/
+  components/
+  overlays/
+  bin/
+```
+
+Use `base/` and `components/` in Kargo/Argo production code paths. The
+checked-in `overlays/` and `bin/` trees are currently local-dev/parity support.
+
+### `k8s-gitops`
+`main` keeps only env policy and Argo metadata:
+
+```text
+apps/codeai/
+  envTypes/
+  deployments/
+    <deployment>/
+      deployment.yaml
+      values.yaml
+  kargo/
+    templates/
+      deploy/
+        kustomization.yaml
+```
+
+For the Kustomize-shaped form, envType components live under
+`apps/codeai/envTypes/<envType>/`, the generic temp-wrapper template lives at
+`apps/codeai/kargo/templates/deploy/`, and `deploy/` is reserved for
+rendered output on stage branches instead of committed source on `main`.
+
+Rendered output lives on stage branches, not on `main`:
+
+```text
+stage/staging        -> apps/codeai/deployments/staging/deploy/
+stage/test           -> apps/codeai/deployments/test/deploy/
+stage/levelbuilder   -> apps/codeai/deployments/levelbuilder/deploy/
+stage/production     -> apps/codeai/deployments/production/deploy/
+```
+
+That keeps the review surface honest and avoids feedback loops.
+
+## Pros
+- removes the synthetic warehouse writeback workflow entirely
+- uses Kargo the way the current docs/examples actually want to be used
+- keeps source of truth in `code-dot-org`
+- preserves excellent reviewability through rendered output
+- sparse checkout makes promotion-time monorepo reads realistic
+
+## Cons
+- requires immutable `git-<full-commit-sha>` image tags
+- depends on two upstream artifacts becoming available in lockstep
+- more Kargo expression logic than the thin-lock control plan
+- still clones source during promotion instead of using a frozen package snapshot
+
+## Migration notes
+- Stop writing release records into `k8s-gitops`.
+- Make the image build publish immutable `git-<full-commit-sha>` tags.
+- Replace the current image-only Warehouse with the combined image+git Warehouse.
+- Move Argo CD apps to rendered stage branches.
+- Use sparse checkout aggressively so Kargo does not slurp the whole monorepo.
+
+## Additional implementation notes
+- This is the first plan in the set that really uses Kargo’s newer freight
+  assembly features instead of building a sidecar release-record system.
+- If the image+git pairing turns out to be awkward in practice, the next thing
+  to try is not “go back to build locks.” It is “let the image carry the commit
+  via OCI annotations and make the Warehouse image-only.”
+
+## Iteration 7 notes
+- Keep this as the pure-Kargo benchmark.
+- Use it to ask whether other plans are buying real repo-fit advantages or just adding machinery.
+
+# Code changes
+## `k8s-gitops` changes
+- Delete the need for `warehouses/codeai/`
+- Replace the current CodeAI Warehouse with a combined image+git Warehouse
+- Rewrite Stages around rendered stage branches such as `stage/staging`
+- Update Argo Applications to deploy from
+  `apps/codeai/deployments/<deployment>/deploy` on rendered stage branches in
+  `k8s-gitops`
+- Add `apps/codeai/kargo/templates/deploy/kustomization.yaml` as the generic
+  Kustomize temp-wrapper template copied into promotion work dirs
+- Add `review-infra-changes` PR behavior against `stage/production`
+
+## `code-dot-org` changes
+- Remove `k8s-commit-to-kargo-warehouse.yml` from the release path
+- Publish immutable `git-<full-commit-sha>` image tags
+- No required Helm restructure for the first version
+- Later Kustomize work can happen in-place without changing the release identity model
+
+## modules that are part of implementing this plan
+- [Gate Promotion On Legacy Gitflow Branches](../modules/gate-promotion-on-legacy-gitflow-branches.md)
+- [Rendered Stage Branches and PR Review](../modules/rendered-stage-branches-and-pr-review.md)
+- [Live Source Checkout at Freight Commit](../modules/live-source-checkout-at-freight-commit.md)
+
+# Sketch of Pivotal Implementation Details
+
+## Shared mechanics
+
+This plan reuses:
+- [Rendered Stage Branches and PR Review](../modules/rendered-stage-branches-and-pr-review.md)
+- [Gate Promotion On Legacy Gitflow Branches](../modules/gate-promotion-on-legacy-gitflow-branches.md)
+- [Live Source Checkout at Freight Commit](../modules/live-source-checkout-at-freight-commit.md)
+
+## Helm implementation starting point
+
+Treat the checked-in `code-dot-org/k8s/helm/` tree as the starting point, not a
+frozen contract. The implementor may modify or reshape `k8s/helm/` if this plan
+benefits from it, but should preserve current behavior unless the change
+materially improves the plan.
+
+## Kustomize implementation starting point
+
+Treat the checked-in `code-dot-org/k8s/kustomize/` tree as the starting point,
+not a frozen contract. The implementor may modify or reshape `k8s/kustomize/`
+as needed for this plan, especially the base/components layout.
+
+Use the current `k8s-gitops/apps/codeai/envTypes/<envType>/kustomization.yaml`
+files as the starting envType Component contract. `production` may
+additionally layer in `apps/codeai/envTypes/components/autoscaling/`.
+
+Rendered-family Kustomize stages should not read a committed
+`apps/codeai/deployments/<deployment>/deploy/` tree from `main`. Instead, keep
+a generic deploy-dir template at `apps/codeai/kargo/templates/deploy/`, copy
+that directory into a temp work dir during promotion, then update the copied
+`kustomization.yaml` `namespace`, `resources`, and `components` before running
+`kustomize-set-image`.
+
+Do not treat `code-dot-org/k8s/kustomize/overlays/*` as the production deploy
+contract unless the plan explicitly chooses to adopt them. Those directories are
+currently local-dev/parity support, as is `code-dot-org/k8s/kustomize/bin/`.
+
+## `codeai/applicationset.yaml` sketch
+
+This plan should keep using `apps/codeai/deployments/*/deployment.yaml` on
+`main` as the generator input, but Argo should deploy from the rendered
+`deploy/` dir on each stage branch:
+
+```yaml
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: codeai
+  namespace: argocd
+spec:
+  generators:
+    - git:
+        repoURL: https://github.com/code-dot-org/k8s-gitops.git
+        revision: main
+        files:
+          - path: apps/codeai/deployments/*/deployment.yaml
+  template:
+    metadata:
+      name: codeai-{{path.basename}}
+    spec:
+      sources:
+        - repoURL: https://github.com/code-dot-org/k8s-gitops.git
+          targetRevision: stage/{{path.basename}}
+          path: apps/codeai/deployments/{{path.basename}}/deploy
+      destination:
+        server: https://kubernetes.default.svc
+        namespace: '{{namespace}}'
+```
+
+## Warehouse sketch
+
+This plan is the main non-writeback plan, so the Warehouse itself is a pivotal
+part of the design:
+
+```yaml
+apiVersion: kargo.akuity.io/v1alpha1
+kind: Warehouse
+metadata:
+  name: codeai
+  namespace: kargo-project-codeai
+spec:
+  freightCreationPolicy: Automatic
+  subscriptions:
+    - image:
+        repoURL: ghcr.io/code-dot-org/code-dot-org
+        allowTagsRegexes:
+          - ^git-[0-9a-f]{40}$
+    - git:
+        repoURL: https://github.com/code-dot-org/code-dot-org.git
+        branch: staging
+  freightCreationCriteria:
+    expression: |
+      imageFrom('ghcr.io/code-dot-org/code-dot-org').Tag ==
+      'git-' + commitFrom('https://github.com/code-dot-org/code-dot-org.git').ID
+```
+
+This expression is the locked pairing rule for the plan. The architecture is
+the important point: Kargo assembles Freight directly from upstream image and
+source streams.
+
+## Hard parts
+
+This plan has two real hard parts:
+
+1. pair image Freight with Git Freight using the same `git-<full-commit-sha>` identity
+2. render from the exact promoted monorepo commit using sparse checkout instead
+   of reading the moving branch tip
+
+The first part is why the Warehouse expression matters. The second part is why
+the live-source checkout must be shown explicitly.
+
+## Example `staging` Stage
+
+```yaml
+apiVersion: kargo.akuity.io/v1alpha1
+kind: Stage
+metadata:
+  name: staging
+  namespace: kargo-project-codeai
+spec:
+  requestedFreight:
+    - origin:
+        kind: Warehouse
+        name: codeai
+      sources:
+        direct: true
+  vars:
+    - name: gitopsRepo
+      value: https://github.com/code-dot-org/k8s-gitops.git
+    - name: sourceRepo
+      value: https://github.com/code-dot-org/code-dot-org.git
+    - name: imageRepo
+      value: ghcr.io/code-dot-org/code-dot-org
+    - name: targetBranch
+      value: stage/${{ ctx.stage }}
+  promotionTemplate:
+    spec:
+      steps:
+        - uses: git-clone
+          config:
+            repoURL: ${{ vars.gitopsRepo }}
+            checkout:
+              - branch: main
+                path: ./meta
+              - branch: ${{ vars.targetBranch }}
+                create: true
+                path: ./out
+
+        - uses: git-clone
+          config:
+            repoURL: ${{ vars.sourceRepo }}
+            checkout:
+              - commit: ${{ commitFrom(vars.sourceRepo, warehouse('codeai')).ID }}
+                path: ./src
+                sparse:
+                  - k8s/helm
+                  - k8s/kustomize
+
+        - uses: yaml-parse
+          as: deployment-meta
+          config:
+            path: ./meta/apps/codeai/deployments/${{ ctx.stage }}/deployment.yaml
+            outputs:
+              - name: envType
+                fromExpression: envType
+              - name: namespace
+                fromExpression: namespace
+
+        - uses: git-clear
+          config:
+            path: ./out/apps/codeai/deployments/${{ ctx.stage }}/deploy
+
+        - uses: helm-template
+          config:
+            path: ./src/k8s/helm
+            releaseName: codeai
+            outPath: ./out/apps/codeai/deployments/${{ ctx.stage }}/deploy
+            valuesFiles:
+              - ./meta/apps/codeai/envTypes/${{ outputs['deployment-meta'].envType }}.values.yaml
+              - ./meta/apps/codeai/deployments/${{ ctx.stage }}/values.yaml
+            setValues:
+              - key: image.repository
+                value: ${{ vars.imageRepo }}
+              - key: image.tag
+                value: ${{ imageFrom(vars.imageRepo).Tag }}
+
+        - uses: git-commit
+          config:
+            path: ./out
+            message: Render ${{ ctx.stage }} for ${{ imageFrom(vars.imageRepo).Tag }}
+
+        - uses: git-push
+          config:
+            path: ./out
+            branch: ${{ vars.targetBranch }}
+```
+
+## Example `staging` Stage for Kustomize
+
+```yaml
+apiVersion: kargo.akuity.io/v1alpha1
+kind: Stage
+metadata:
+  name: staging
+  namespace: kargo-project-codeai
+spec:
+  requestedFreight:
+    - origin:
+        kind: Warehouse
+        name: codeai
+      sources:
+        direct: true
+  vars:
+    - name: gitopsRepo
+      value: https://github.com/code-dot-org/k8s-gitops.git
+    - name: sourceRepo
+      value: https://github.com/code-dot-org/code-dot-org.git
+    - name: imageRepo
+      value: ghcr.io/code-dot-org/code-dot-org
+    - name: targetBranch
+      value: stage/${{ ctx.stage }}
+  promotionTemplate:
+    spec:
+      steps:
+        - uses: git-clone
+          config:
+            repoURL: ${{ vars.gitopsRepo }}
+            checkout:
+              - branch: main
+                path: ./meta
+              - branch: ${{ vars.targetBranch }}
+                create: true
+                path: ./out
+
+        - uses: git-clone
+          config:
+            repoURL: ${{ vars.sourceRepo }}
+            checkout:
+              - commit: ${{ commitFrom(vars.sourceRepo, warehouse('codeai')).ID }}
+                path: ./src
+                sparse:
+                  - k8s/kustomize
+
+        - uses: yaml-parse
+          as: deployment-meta
+          config:
+            path: ./meta/apps/codeai/deployments/${{ ctx.stage }}/deployment.yaml
+            outputs:
+              - name: envType
+                fromExpression: envType
+
+        - uses: git-clear
+          config:
+            path: ./out/apps/codeai/deployments/${{ ctx.stage }}/deploy
+
+        - uses: copy
+          config:
+            inPath: ./src/k8s/kustomize
+            outPath: ./work/deployments/source
+
+        - uses: copy
+          config:
+            inPath: ./meta/apps/codeai/envTypes/${{ outputs['deployment-meta'].envType }}
+            outPath: ./work/deployments/envTypes/${{ outputs['deployment-meta'].envType }}
+
+        - uses: copy
+          config:
+            inPath: ./meta/apps/codeai/envTypes/components
+            outPath: ./work/deployments/envTypes/components
+
+        - uses: copy
+          config:
+            inPath: ./meta/apps/codeai/kargo/templates/deploy
+            outPath: ./work/deployments/${{ ctx.stage }}/deploy
+
+        # The temp wrapper template provides apiVersion/kind and one
+        # `images` entry whose match key is `code-dot-org`.
+        - uses: yaml-update
+          config:
+            path: ./work/deployments/${{ ctx.stage }}/deploy/kustomization.yaml
+            updates:
+              - key: namespace
+                value: ${{ outputs['deployment-meta'].namespace }}
+              - key: resources
+                value:
+                  - ../../source/base
+              - key: components
+                value:
+                  - ../../envTypes/${{ outputs['deployment-meta'].envType }}
+
+        - uses: kustomize-set-image
+          config:
+            path: ./work/deployments/${{ ctx.stage }}/deploy
+            images:
+              - image: code-dot-org
+                newName: ${{ vars.imageRepo }}
+                tag: ${{ imageFrom(vars.imageRepo).Tag }}
+
+        - uses: kustomize-build
+          config:
+            path: ./work/deployments/${{ ctx.stage }}/deploy
+            outPath: ./out/apps/codeai/deployments/${{ ctx.stage }}/deploy
+
+        - uses: git-commit
+          config:
+            path: ./out
+            message: Render ${{ ctx.stage }} for ${{ imageFrom(vars.imageRepo).Tag }}
+
+        - uses: git-push
+          config:
+            path: ./out
+            branch: ${{ vars.targetBranch }}
+```
+
+## Example `review-infra-changes` Stage
+
+```yaml
+apiVersion: kargo.akuity.io/v1alpha1
+kind: Stage
+metadata:
+  name: review-infra-changes
+  namespace: kargo-project-codeai
+spec:
+  requestedFreight:
+    - origin:
+        kind: Warehouse
+        name: codeai
+      sources:
+        stages:
+          - test
+  vars:
+    - name: gitopsRepo
+      value: https://github.com/code-dot-org/k8s-gitops.git
+    - name: sourceRepo
+      value: https://github.com/code-dot-org/code-dot-org.git
+    - name: imageRepo
+      value: ghcr.io/code-dot-org/code-dot-org
+    - name: targetBranch
+      value: stage/production
+    - name: renderDeployment
+      value: production
+    - name: renderPath
+      value: apps/codeai/deployments/production/deploy
+  promotionTemplate:
+    spec:
+      steps:
+        - uses: git-clone
+          config:
+            repoURL: ${{ vars.gitopsRepo }}
+            checkout:
+              - branch: main
+                path: ./meta
+              - branch: ${{ vars.targetBranch }}
+                create: true
+                path: ./out
+
+        - uses: git-clone
+          config:
+            repoURL: ${{ vars.sourceRepo }}
+            checkout:
+              - commit: ${{ commitFrom(vars.sourceRepo, warehouse('codeai')).ID }}
+                path: ./src
+                sparse:
+                  - k8s/helm
+
+        - uses: yaml-parse
+          as: deployment-meta
+          config:
+            path: ./meta/apps/codeai/deployments/${{ vars.renderDeployment }}/deployment.yaml
+            outputs:
+              - name: envType
+                fromExpression: envType
+              - name: namespace
+                fromExpression: namespace
+
+        - uses: git-clear
+          config:
+            path: ./out/${{ vars.renderPath }}
+
+        - uses: helm-template
+          config:
+            path: ./src/k8s/helm
+            releaseName: codeai
+            outPath: ./out/${{ vars.renderPath }}
+            valuesFiles:
+              - ./meta/apps/codeai/envTypes/${{ outputs['deployment-meta'].envType }}.values.yaml
+              - ./meta/apps/codeai/deployments/${{ vars.renderDeployment }}/values.yaml
+            setValues:
+              - key: image.repository
+                value: ${{ vars.imageRepo }}
+              - key: image.tag
+                value: ${{ imageFrom(vars.imageRepo).Tag }}
+
+        - uses: git-commit
+          config:
+            path: ./out
+            message: Review production render for ${{ imageFrom(vars.imageRepo).Tag }}
+
+        - uses: git-push
+          as: push
+          config:
+            path: ./out
+            generateTargetBranch: true
+
+        - uses: git-open-pr
+          as: open-pr
+          config:
+            repoURL: ${{ vars.gitopsRepo }}
+            sourceBranch: ${{ outputs.push.branch }}
+            targetBranch: ${{ vars.targetBranch }}
+            title: Review CodeAI production render for ${{ imageFrom(vars.imageRepo).Tag }}
+
+        - uses: git-wait-for-pr
+          config:
+            repoURL: ${{ vars.gitopsRepo }}
+            prNumber: ${{ outputs['open-pr'].pr.id }}
+```
+
+## Example `review-infra-changes` Stage for Kustomize
+
+```yaml
+apiVersion: kargo.akuity.io/v1alpha1
+kind: Stage
+metadata:
+  name: review-infra-changes
+  namespace: kargo-project-codeai
+spec:
+  requestedFreight:
+    - origin:
+        kind: Warehouse
+        name: codeai
+      sources:
+        stages:
+          - test
+  vars:
+    - name: gitopsRepo
+      value: https://github.com/code-dot-org/k8s-gitops.git
+    - name: sourceRepo
+      value: https://github.com/code-dot-org/code-dot-org.git
+    - name: imageRepo
+      value: ghcr.io/code-dot-org/code-dot-org
+    - name: targetBranch
+      value: stage/production
+    - name: renderDeployment
+      value: production
+    - name: renderPath
+      value: apps/codeai/deployments/production/deploy
+  promotionTemplate:
+    spec:
+      steps:
+        - uses: git-clone
+          config:
+            repoURL: ${{ vars.gitopsRepo }}
+            checkout:
+              - branch: main
+                path: ./meta
+              - branch: ${{ vars.targetBranch }}
+                create: true
+                path: ./out
+
+        - uses: git-clone
+          config:
+            repoURL: ${{ vars.sourceRepo }}
+            checkout:
+              - commit: ${{ commitFrom(vars.sourceRepo, warehouse('codeai')).ID }}
+                path: ./src
+                sparse:
+                  - k8s/kustomize
+
+        - uses: yaml-parse
+          as: deployment-meta
+          config:
+            path: ./meta/apps/codeai/deployments/${{ vars.renderDeployment }}/deployment.yaml
+            outputs:
+              - name: envType
+                fromExpression: envType
+
+        - uses: git-clear
+          config:
+            path: ./out/${{ vars.renderPath }}
+
+        - uses: copy
+          config:
+            inPath: ./src/k8s/kustomize
+            outPath: ./work/deployments/source
+
+        - uses: copy
+          config:
+            inPath: ./meta/apps/codeai/envTypes/${{ outputs['deployment-meta'].envType }}
+            outPath: ./work/deployments/envTypes/${{ outputs['deployment-meta'].envType }}
+
+        - uses: copy
+          config:
+            inPath: ./meta/apps/codeai/envTypes/components
+            outPath: ./work/deployments/envTypes/components
+
+        - uses: copy
+          config:
+            inPath: ./meta/apps/codeai/kargo/templates/deploy
+            outPath: ./work/deployments/${{ vars.renderDeployment }}/deploy
+
+        # The temp wrapper template provides apiVersion/kind and one
+        # `images` entry whose match key is `code-dot-org`.
+        - uses: yaml-update
+          config:
+            path: ./work/deployments/${{ vars.renderDeployment }}/deploy/kustomization.yaml
+            updates:
+              - key: namespace
+                value: ${{ outputs['deployment-meta'].namespace }}
+              - key: resources
+                value:
+                  - ../../source/base
+              - key: components
+                value:
+                  - ../../envTypes/${{ outputs['deployment-meta'].envType }}
+
+        - uses: kustomize-set-image
+          config:
+            path: ./work/deployments/${{ vars.renderDeployment }}/deploy
+            images:
+              - image: code-dot-org
+                newName: ${{ vars.imageRepo }}
+                tag: ${{ imageFrom(vars.imageRepo).Tag }}
+
+        - uses: kustomize-build
+          config:
+            path: ./work/deployments/${{ vars.renderDeployment }}/deploy
+            outPath: ./out/${{ vars.renderPath }}
+
+        - uses: git-commit
+          config:
+            path: ./out
+            message: Review production render for ${{ imageFrom(vars.imageRepo).Tag }}
+
+        - uses: git-push
+          as: push
+          config:
+            path: ./out
+            generateTargetBranch: true
+
+        - uses: git-open-pr
+          as: open-pr
+          config:
+            repoURL: ${{ vars.gitopsRepo }}
+            sourceBranch: ${{ outputs.push.branch }}
+            targetBranch: ${{ vars.targetBranch }}
+            title: Review CodeAI production render for ${{ imageFrom(vars.imageRepo).Tag }}
+
+        - uses: git-wait-for-pr
+          config:
+            repoURL: ${{ vars.gitopsRepo }}
+            prNumber: ${{ outputs['open-pr'].pr.id }}
+```
+
+The exact live-source sparse checkout pattern is still shared in
+[Live Source Checkout at Freight Commit](../modules/live-source-checkout-at-freight-commit.md).
+
+## GH runner sketch
+
+This is the least Kargo-specific runner shape:
+
+1. Build and stitch the multiplatform app image.
+2. Publish immutable `git-<full-commit-sha>` tag.
+3. Optionally also publish the branch alias tag such as `staging`.
+4. Do not check out `k8s-gitops`.
+5. Do not write `warehouses/codeai/*`.
+6. Let the Warehouse discover Freight directly from the image repo and source
+   repo.
+
+That is why this is the pure-Kargo benchmark. The CI job only produces the real
+upstream artifacts; Kargo does the pairing.
+
+### Testing Plan
+
+Recommended automation:
+- Extend [k8s.yml](/Users/seth/.codex/worktrees/684f/code-dot-org/.github/workflows/k8s.yml) or call a small reusable workflow from it for repo-specific contract and render smoke checks.
+- Use existing Drone results on the promoted `gitCommit` as the app/unit/UI gate before downstream promotion.
+- Use Kargo `verification` with `AnalysisTemplate`s for post-sync rollout/health/smoke checks in `test`.
+
+Simple tests to automate:
+- In `k8s.yml`, immediately after `stitch-multiplatform-image`, assert the produced image tag is exactly `git-<full-commit-sha>`.
+- In the same workflow, check out `k8s-gitops` read-only and validate [applicationset.yaml](/Users/seth/src/k8s-gitops/apps/codeai/applicationset.yaml) reads deployment metadata from `main` and deploys `apps/codeai/deployments/{{path.basename}}/deploy` from `stage/{{path.basename}}`.
+- In the same workflow, validate every `apps/codeai/deployments/<deployment>/deployment.yaml` has `envType` and `namespace`, because this plan resolves envType from deployment metadata at promotion time.
+- For the Helm variant, run `helm template` from [/Users/seth/.codex/worktrees/684f/code-dot-org/k8s/helm](/Users/seth/.codex/worktrees/684f/code-dot-org/k8s/helm) using deployment metadata from `apps/codeai/deployments/<deployment>/deployment.yaml`, envType values from `apps/codeai/envTypes/<envType>.values.yaml`, and deployment values from `apps/codeai/deployments/<deployment>/values.yaml`, writing to a temp `apps/codeai/deployments/<deployment>/deploy/` tree.
+- For the Kustomize variant, run `kustomize build` from a temp tree assembled from the checked-in `k8s/kustomize/` source, `apps/codeai/envTypes/<envType>/` as a Component, any referenced `apps/codeai/envTypes/components/` subcomponents such as `autoscaling`, and a copied `apps/codeai/kargo/templates/deploy/` dir whose `kustomization.yaml` `namespace`, `resources`, and `components` fields are updated before `kustomize-set-image` rewrites `code-dot-org` to `ghcr.io/code-dot-org/code-dot-org:git-<full-commit-sha>`. Do not use `k8s/kustomize/overlays` or `bin/` in production code paths.
+
+Avoid as baseline coverage:
+- A live Kargo or expr-engine harness whose main purpose is proving `freightCreationCriteria` works inside the controller. If upstream later provides a first-class preflight for that expression shape, use it instead of custom harness code.

--- a/k8s/docs/kargotecture/plans/iteration-7/implementations/argo-refs-code-dot-org-commit.md
+++ b/k8s/docs/kargotecture/plans/iteration-7/implementations/argo-refs-code-dot-org-commit.md
@@ -1,0 +1,47 @@
+# Argo Refs code-dot-org Commit Implementation Review
+
+## Helm
+
+- `code-dot-org` branch: `kargo/argo-refs-code-dot-org-commit/helm`, PR `#71561`
+- `k8s-gitops` branch: `kargo/argo-refs-code-dot-org-commit/helm`, PR `#1`
+- `code-dot-org` repo: `Cumulative Lines Added: 457 (added: 364, deleted: 93)` across 8 files
+- `k8s-gitops` repo: `Cumulative Lines Added: 319 (added: 256, deleted: 63)` across 21 files
+- `Implementation looks complete?` Mostly complete
+
+What landed:
+- `code-dot-org` adds the expected GH workflow plumbing plus dedicated helpers for writing the build lock and legacy gitflow metadata.
+- `k8s-gitops` adds the thin-lock Warehouse at `warehouses/codeai/builds`, a full stage ladder, updated deployment metadata, and an ApplicationSet wired to GitOps-managed deploy refs.
+- `review-infra-changes` opens a PR and `production` merges that PR and updates Argo CD.
+
+Missing or suspicious:
+- The `test` stage updates GitOps and Argo, but it does not add an explicit Kargo `verification` block or an analysis template. That keeps it short, but it means test automation is lighter than the plan doc implied.
+
+Final freight complexity:
+- Low to medium.
+- Freight itself stays small: one Git build-lock record under `warehouses/codeai/builds/current.yaml` plus per-release history files.
+- The complexity is mostly outside Freight, in the fact that Argo deploys source-oriented truth and Kargo only moves the lock.
+
+## Kustomize
+
+- `code-dot-org` branch: `kargo/argo-refs-code-dot-org-commit/kustomize`, PR `#71564`
+- `k8s-gitops` branch: `kargo/argo-refs-code-dot-org-commit/kustomize`, PR `#3`
+- `code-dot-org` repo: `Cumulative Lines Added: 447 (added: 370, deleted: 77)` across 11 files
+- `k8s-gitops` repo: `Cumulative Lines Added: 539 (added: 464, deleted: 75)` across 27 files
+- `Implementation looks complete?` Mostly complete
+
+What landed:
+- `code-dot-org` adds Kustomize-specific helper scripts and adjusts local overlay support.
+- `k8s-gitops` adds per-deployment `deploy/kustomization.yaml` entrypoints, envType Kustomize components, a test verification template, the Warehouse, and the full stage ladder.
+- `test` has a real `verification` block, `review-infra-changes` opens a PR, and `production` merges the PR.
+
+Missing or suspicious:
+- The deploy truth is more complex than the plan headline suggests because the thin build lock, envType components, and deploy-entrypoint Kustomizations all have to stay aligned.
+
+Final freight complexity:
+- Low to medium.
+- Freight is still just the thin Git build-lock record under `warehouses/codeai/builds/`.
+- The implementation complexity moved into GitOps-side Kustomize wiring rather than into Freight itself.
+
+## Overall
+
+This implementation family stayed faithful to the thin-lock idea. The final system looks small in Freight and larger in deploy wiring. The Helm branch is the lighter migration path; the Kustomize branch is more complete from a Kargo-verification standpoint.

--- a/k8s/docs/kargotecture/plans/iteration-7/implementations/argo-refs-code-dot-org-commit.md
+++ b/k8s/docs/kargotecture/plans/iteration-7/implementations/argo-refs-code-dot-org-commit.md
@@ -6,6 +6,7 @@
 - `k8s-gitops` branch: `kargo/argo-refs-code-dot-org-commit/helm`, PR `#1`
 - `code-dot-org` repo: `Cumulative Lines Added: 457 (added: 364, deleted: 93)` across 8 files
 - `k8s-gitops` repo: `Cumulative Lines Added: 319 (added: 256, deleted: 63)` across 21 files
+- `Legacy gitflow gate implemented?` Yes
 - `Implementation looks complete?` Mostly complete
 
 What landed:
@@ -27,6 +28,7 @@ Final freight complexity:
 - `k8s-gitops` branch: `kargo/argo-refs-code-dot-org-commit/kustomize`, PR `#3`
 - `code-dot-org` repo: `Cumulative Lines Added: 447 (added: 370, deleted: 77)` across 11 files
 - `k8s-gitops` repo: `Cumulative Lines Added: 539 (added: 464, deleted: 75)` across 27 files
+- `Legacy gitflow gate implemented?` Yes
 - `Implementation looks complete?` Mostly complete
 
 What landed:

--- a/k8s/docs/kargotecture/plans/iteration-7/implementations/common-case-rendered-branches.md
+++ b/k8s/docs/kargotecture/plans/iteration-7/implementations/common-case-rendered-branches.md
@@ -5,12 +5,14 @@
 - `code-dot-org` branch: `kargo/common-case-rendered-branches/helm`, PR `#71562`
 - `k8s-gitops` branch: `kargo/common-case-rendered-branches/helm`, PR `#2`
 - `code-dot-org` repo: `Cumulative Lines Added: 153 (added: 11, deleted: 142)` across 5 files
-- `k8s-gitops` repo: `Cumulative Lines Added: 469 (added: 396, deleted: 73)` across 20 files
+- `k8s-gitops` repo: `Cumulative Lines Added: 525 (added: 452, deleted: 73)` across 20 files
+- `Legacy gitflow gate implemented?` Yes
 - `Implementation looks complete?` Mostly complete
 
 What landed:
 - `code-dot-org` mostly removes writeback-oriented workflow behavior instead of adding new packaging machinery.
 - `k8s-gitops` adds the image+git Warehouse, ApplicationSet changes, full rendered-branch stage flow, and a rollout analysis template for `test`.
+- `k8s-gitops` now also enforces downstream promotion gates against matching `warehouses/codeai/legacy-gitflow/<env>/merged/git-<sha>.yaml` records on `main`.
 - `review-infra-changes` renders to a PR branch, waits for review, and `production` updates Argo CD to the reviewed `stage/production` commit.
 
 Missing or suspicious:
@@ -26,12 +28,14 @@ Final freight complexity:
 - `code-dot-org` branch: `kargo/common-case-rendered-branches/kustomize`, PR `#71567`
 - `k8s-gitops` branch: `kargo/common-case-rendered-branches/kustomize`, PR `#7`
 - `code-dot-org` repo: `Cumulative Lines Added: 157 (added: 14, deleted: 143)` across 5 files
-- `k8s-gitops` repo: `Cumulative Lines Added: 530 (added: 418, deleted: 112)` across 23 files
+- `k8s-gitops` repo: `Cumulative Lines Added: 621 (added: 518, deleted: 103)` across 23 files
+- `Legacy gitflow gate implemented?` Yes
 - `Implementation looks complete?` Mostly complete
 
 What landed:
 - `k8s-gitops` adds the same common-case Warehouse shape plus Kustomize envType components, a shared deploy wrapper template, rendered stage branches, and a service-health analysis template.
 - Stages sparse-check out `k8s/kustomize`, copy GitOps-side env inputs, run `kustomize-build`, and publish rendered output to `stage/*`.
+- Downstream stages now gate promotion on matching `warehouses/codeai/legacy-gitflow/<env>/merged/git-<full-commit-sha>.yaml` records from `main`.
 - `production` is intentionally thin: it points Argo CD at the reviewed render commit captured from `review-infra-changes`.
 
 Missing or suspicious:

--- a/k8s/docs/kargotecture/plans/iteration-7/implementations/common-case-rendered-branches.md
+++ b/k8s/docs/kargotecture/plans/iteration-7/implementations/common-case-rendered-branches.md
@@ -1,0 +1,47 @@
+# Common-Case Freight + Rendered Branches Implementation Review
+
+## Helm
+
+- `code-dot-org` branch: `kargo/common-case-rendered-branches/helm`, PR `#71562`
+- `k8s-gitops` branch: `kargo/common-case-rendered-branches/helm`, PR `#2`
+- `code-dot-org` repo: `Cumulative Lines Added: 153 (added: 11, deleted: 142)` across 5 files
+- `k8s-gitops` repo: `Cumulative Lines Added: 469 (added: 396, deleted: 73)` across 20 files
+- `Implementation looks complete?` Mostly complete
+
+What landed:
+- `code-dot-org` mostly removes writeback-oriented workflow behavior instead of adding new packaging machinery.
+- `k8s-gitops` adds the image+git Warehouse, ApplicationSet changes, full rendered-branch stage flow, and a rollout analysis template for `test`.
+- `review-infra-changes` renders to a PR branch, waits for review, and `production` updates Argo CD to the reviewed `stage/production` commit.
+
+Missing or suspicious:
+- Very little changed in `code-dot-org`, which is consistent with the design, but it means most of the implementation burden lands in `k8s-gitops`.
+
+Final freight complexity:
+- Low.
+- Freight is the cleanest in the whole set: one Warehouse watches the real app image and the real `code-dot-org` branch, then pairs them with `freightCreationCriteria`.
+- There is no synthetic lock file and no snapshot archive under `warehouses/codeai/`.
+
+## Kustomize
+
+- `code-dot-org` branch: `kargo/common-case-rendered-branches/kustomize`, PR `#71567`
+- `k8s-gitops` branch: `kargo/common-case-rendered-branches/kustomize`, PR `#7`
+- `code-dot-org` repo: `Cumulative Lines Added: 157 (added: 14, deleted: 143)` across 5 files
+- `k8s-gitops` repo: `Cumulative Lines Added: 530 (added: 418, deleted: 112)` across 23 files
+- `Implementation looks complete?` Mostly complete
+
+What landed:
+- `k8s-gitops` adds the same common-case Warehouse shape plus Kustomize envType components, a shared deploy wrapper template, rendered stage branches, and a service-health analysis template.
+- Stages sparse-check out `k8s/kustomize`, copy GitOps-side env inputs, run `kustomize-build`, and publish rendered output to `stage/*`.
+- `production` is intentionally thin: it points Argo CD at the reviewed render commit captured from `review-infra-changes`.
+
+Missing or suspicious:
+- The Kustomize flow depends on wrapper-template assembly in `k8s-gitops`, so the operational simplicity is still better than the other variants, but the implementation is not “small” in absolute terms.
+
+Final freight complexity:
+- Low.
+- The Freight model is identical to Helm: native image+git pairing and no Git warehouse payload.
+- The extra complexity is in render-time assembly, not in the Freight object.
+
+## Overall
+
+This is the cleanest implementation family after code lands. The branches keep Freight small and native, and the added complexity is concentrated in rendered-branch review flow rather than in release bookkeeping.

--- a/k8s/docs/kargotecture/plans/iteration-7/implementations/oci-release-capsule.md
+++ b/k8s/docs/kargotecture/plans/iteration-7/implementations/oci-release-capsule.md
@@ -1,0 +1,49 @@
+# OCI Release Capsule Implementation Review
+
+## Helm
+
+- `code-dot-org` branch: `kargo/oci-release-capsule/helm`, PR `#71563`
+- `k8s-gitops` branch: `kargo/oci-release-capsule/helm`, PR `#6`
+- `code-dot-org` repo: `Cumulative Lines Added: 524 (added: 388, deleted: 136)` across 10 files
+- `k8s-gitops` repo: `Cumulative Lines Added: 1340 (added: 1277, deleted: 63)` across 35 files
+- `Implementation looks complete?` Mostly complete
+
+What landed:
+- `code-dot-org` adds a dedicated release-capsule publishing workflow and a build-context script.
+- `k8s-gitops` adds an image+capsule Warehouse with tag-matching criteria, rendered deploy trees, and production-stage logic that downloads the capsule, validates `release.yaml`, opens a PR, waits for merge, and then updates Argo CD.
+- Legacy gitflow metadata is also wired in.
+
+Missing or suspicious:
+- The implementation does not keep a separate `review-infra-changes` stage file. The Helm branch folds review behavior into `production`, which is workable but diverges from the iteration 7 plan shape.
+- Test verification is lighter than the plan narrative. The core render path exists, but the verification story is not as explicit as the Kustomize branch.
+
+Final freight complexity:
+- High.
+- Freight is a real two-artifact pair: the app image plus `ghcr.io/code-dot-org/codeai-release-capsule`, matched by tag in the Warehouse.
+- On top of that, production still checks legacy-gitflow metadata and validates in-capsule metadata before rendering.
+
+## Kustomize
+
+- `code-dot-org` branch: `kargo/oci-release-capsule/kustomize`, PR `#71569`
+- `k8s-gitops` branch: `kargo/oci-release-capsule/kustomize`, PR `#8`
+- `code-dot-org` repo: `Cumulative Lines Added: 890 (added: 799, deleted: 91)` across 10 files
+- `k8s-gitops` repo: `Cumulative Lines Added: 1261 (added: 1207, deleted: 54)` across 26 files
+- `Implementation looks complete?` Mostly complete
+
+What landed:
+- `code-dot-org` adds the richest implementation-specific tooling in the set: capsule build logic, a release-verifier service contract, and tests for that verifier.
+- `k8s-gitops` adds the verifier deployment/service/configmap, a smoke analysis template, release metadata templates, rendered-branch flow, and the full stage ladder.
+- `production` re-validates the approved release by calling an in-cluster verifier service before stamping metadata.
+
+Missing or suspicious:
+- The Warehouse only subscribes to the app image, not the capsule. That means the final implementation is not a native paired Freight model the way the plan doc described; the capsule is looked up and verified later.
+- Several `deploy/README.md` placeholders suggest the steady-state rendered output lives on stage branches, but the on-`main` deploy tree is still mostly scaffolding.
+
+Final freight complexity:
+- Very high.
+- The effective release contract spans image Freight, out-of-band capsule verification, release metadata files, verifier service state, and legacy-gitflow records.
+- This is the strongest provenance story, but it is clearly the most operationally heavy implementation.
+
+## Overall
+
+These branches prove the capsule idea can be built, but they also prove why it scored lower on KISS. Even when the main path works, the system ends up carrying more moving parts than the rendered-Git winners.

--- a/k8s/docs/kargotecture/plans/iteration-7/implementations/oci-release-capsule.md
+++ b/k8s/docs/kargotecture/plans/iteration-7/implementations/oci-release-capsule.md
@@ -6,6 +6,7 @@
 - `k8s-gitops` branch: `kargo/oci-release-capsule/helm`, PR `#6`
 - `code-dot-org` repo: `Cumulative Lines Added: 524 (added: 388, deleted: 136)` across 10 files
 - `k8s-gitops` repo: `Cumulative Lines Added: 1340 (added: 1277, deleted: 63)` across 35 files
+- `Legacy gitflow gate implemented?` Yes
 - `Implementation looks complete?` Mostly complete
 
 What landed:
@@ -28,6 +29,7 @@ Final freight complexity:
 - `k8s-gitops` branch: `kargo/oci-release-capsule/kustomize`, PR `#8`
 - `code-dot-org` repo: `Cumulative Lines Added: 890 (added: 799, deleted: 91)` across 10 files
 - `k8s-gitops` repo: `Cumulative Lines Added: 1261 (added: 1207, deleted: 54)` across 26 files
+- `Legacy gitflow gate implemented?` Yes
 - `Implementation looks complete?` Mostly complete
 
 What landed:

--- a/k8s/docs/kargotecture/plans/iteration-7/implementations/rendered-branches.md
+++ b/k8s/docs/kargotecture/plans/iteration-7/implementations/rendered-branches.md
@@ -5,7 +5,8 @@
 - `code-dot-org` branch: `kargo/rendered-branches/helm`, PR `#71565`
 - `k8s-gitops` branch: `kargo/rendered-branches/helm`, PR `#4`
 - `code-dot-org` repo: `Cumulative Lines Added: 285 (added: 213, deleted: 72)` across 4 files
-- `k8s-gitops` repo: `Cumulative Lines Added: 569 (added: 469, deleted: 100)` across 23 files
+- `k8s-gitops` repo: `Cumulative Lines Added: 575 (added: 475, deleted: 100)` across 23 files
+- `Legacy gitflow gate implemented?` Yes
 - `Implementation looks complete?` Mostly complete
 
 What landed:
@@ -27,7 +28,8 @@ Final freight complexity:
 - `code-dot-org` branch: `kargo/rendered-branches/kustomize`, PR `#71568`
 - `k8s-gitops` branch: `kargo/rendered-branches/kustomize`, PR `#9`
 - `code-dot-org` repo: `Cumulative Lines Added: 440 (added: 342, deleted: 98)` across 9 files
-- `k8s-gitops` repo: `Cumulative Lines Added: 600 (added: 498, deleted: 102)` across 24 files
+- `k8s-gitops` repo: `Cumulative Lines Added: 606 (added: 504, deleted: 102)` across 24 files
+- `Legacy gitflow gate implemented?` Yes
 - `Implementation looks complete?` Mostly complete
 
 What landed:

--- a/k8s/docs/kargotecture/plans/iteration-7/implementations/rendered-branches.md
+++ b/k8s/docs/kargotecture/plans/iteration-7/implementations/rendered-branches.md
@@ -1,0 +1,48 @@
+# Rendered Branches from a Thin Lock Implementation Review
+
+## Helm
+
+- `code-dot-org` branch: `kargo/rendered-branches/helm`, PR `#71565`
+- `k8s-gitops` branch: `kargo/rendered-branches/helm`, PR `#4`
+- `code-dot-org` repo: `Cumulative Lines Added: 285 (added: 213, deleted: 72)` across 4 files
+- `k8s-gitops` repo: `Cumulative Lines Added: 569 (added: 469, deleted: 100)` across 23 files
+- `Implementation looks complete?` Mostly complete
+
+What landed:
+- `code-dot-org` keeps the app-side changes minimal and mostly workflow-driven.
+- `k8s-gitops` adds the thin-lock Warehouse, rendered stage branches, ApplicationSet changes, and the full five-stage ladder.
+- `review-infra-changes` opens a PR against `stage/production`, and `production` acts as a final legacy-gate approval hop after reviewed output already exists on the production stage branch.
+
+Missing or suspicious:
+- `test` renders and pushes, but it does not add explicit Kargo verification or an analysis template.
+- `production` is intentionally narrow; it does not perform an explicit Argo update step because the reviewed `stage/production` branch is treated as deploy truth.
+
+Final freight complexity:
+- Medium.
+- Freight itself is still small: one thin build-lock record under `warehouses/codeai/builds/`.
+- The end-state system is more complex than Argo Refs because it adds rendered stage branches and PR review on top of that thin lock.
+
+## Kustomize
+
+- `code-dot-org` branch: `kargo/rendered-branches/kustomize`, PR `#71568`
+- `k8s-gitops` branch: `kargo/rendered-branches/kustomize`, PR `#9`
+- `code-dot-org` repo: `Cumulative Lines Added: 440 (added: 342, deleted: 98)` across 9 files
+- `k8s-gitops` repo: `Cumulative Lines Added: 600 (added: 498, deleted: 102)` across 24 files
+- `Implementation looks complete?` Mostly complete
+
+What landed:
+- `code-dot-org` adds Kustomize base/parity tweaks.
+- `k8s-gitops` adds envType patches, a shared deploy wrapper template, the thin-lock Warehouse, and rendered-branch stage flow.
+- The render path is the expected one: parse build lock, clone source at the pinned commit, assemble a deploy wrapper, build Kustomize output, and publish to `stage/*`.
+
+Missing or suspicious:
+- `production` is literally a no-op stage with `steps: []`. That may be intentional if merge-to-`stage/production` is the real deployment event, but it still reads as less finished than the top-ranked branches.
+- `test` also lacks an explicit verification block.
+
+Final freight complexity:
+- Medium.
+- Freight stays thin and synthetic, but the deploy system is no longer thin once rendered branches, wrapper assembly, and legacy gating are added.
+
+## Overall
+
+These branches make the thin-lock rendered-review idea real. The result is substantially more reviewable than Argo Refs, but the implementation confirms the ranking outcome: the build lock stays as permanent system furniture even after the rendered-branch machinery is added.

--- a/k8s/docs/kargotecture/plans/iteration-7/implementations/source-snapshot-rendered-branches.md
+++ b/k8s/docs/kargotecture/plans/iteration-7/implementations/source-snapshot-rendered-branches.md
@@ -4,13 +4,15 @@
 
 - `code-dot-org` branch: `kargo/source-snapshot-rendered-branches/helm`, PR `#71566`
 - `k8s-gitops` branch: `kargo/source-snapshot-rendered-branches/helm`, PR `#5`
-- `code-dot-org` repo: `Cumulative Lines Added: 202 (added: 148, deleted: 54)` across 6 files
-- `k8s-gitops` repo: `Cumulative Lines Added: 460 (added: 367, deleted: 93)` across 25 files
+- `code-dot-org` repo: `Cumulative Lines Added: 218 (added: 164, deleted: 54)` across 6 files
+- `k8s-gitops` repo: `Cumulative Lines Added: 517 (added: 424, deleted: 93)` across 25 files
+- `Legacy gitflow gate implemented?` Yes
 - `Implementation looks complete?` Partial
 
 What landed:
 - `code-dot-org` adds workflow changes plus a small amount of Helm package shaping.
 - `k8s-gitops` adds the freight Warehouse, ApplicationSets, envType values files, rendered-branch stages, and the expected snapshot-oriented render path from `warehouses/codeai/freight/current/helm`.
+- The legacy-gitflow coexistence module is now present end-to-end: `code-dot-org` writes merged gate markers and downstream stages parse them before promotion.
 - `review-infra-changes` exists and follows the rendered-branch review pattern.
 
 Missing or suspicious:
@@ -28,12 +30,14 @@ Final freight complexity:
 - `code-dot-org` branch: `kargo/source-snapshot-rendered-branches/kustomize`, PR `#71570`
 - `k8s-gitops` branch: `kargo/source-snapshot-rendered-branches/kustomize`, PR `#10`
 - `code-dot-org` repo: `Cumulative Lines Added: 165 (added: 121, deleted: 44)` across 3 files
-- `k8s-gitops` repo: `Cumulative Lines Added: 536 (added: 449, deleted: 87)` across 26 files
+- `k8s-gitops` repo: `Cumulative Lines Added: 542 (added: 455, deleted: 87)` across 26 files
+- `Legacy gitflow gate implemented?` Yes
 - `Implementation looks complete?` Partial
 
 What landed:
 - `k8s-gitops` carries most of the implementation: a Git Warehouse over `warehouses/codeai/freight`, deploy-entrypoint Kustomizations, envType patches, a shared wrapper template, and rendered-branch stages.
 - Staging/test/levelbuilder render from the frozen snapshot under `warehouses/codeai/freight/current/kustomize`.
+- The downstream stages now also enforce the legacy-gitflow merged-marker gate before promotion.
 - `review-infra-changes` exists and follows the expected rendered-branch flow.
 
 Missing or suspicious:

--- a/k8s/docs/kargotecture/plans/iteration-7/implementations/source-snapshot-rendered-branches.md
+++ b/k8s/docs/kargotecture/plans/iteration-7/implementations/source-snapshot-rendered-branches.md
@@ -1,0 +1,51 @@
+# Source Snapshot (Helm or Kustomize) + Rendered Branches Implementation Review
+
+## Helm
+
+- `code-dot-org` branch: `kargo/source-snapshot-rendered-branches/helm`, PR `#71566`
+- `k8s-gitops` branch: `kargo/source-snapshot-rendered-branches/helm`, PR `#5`
+- `code-dot-org` repo: `Cumulative Lines Added: 202 (added: 148, deleted: 54)` across 6 files
+- `k8s-gitops` repo: `Cumulative Lines Added: 460 (added: 367, deleted: 93)` across 25 files
+- `Implementation looks complete?` Partial
+
+What landed:
+- `code-dot-org` adds workflow changes plus a small amount of Helm package shaping.
+- `k8s-gitops` adds the freight Warehouse, ApplicationSets, envType values files, rendered-branch stages, and the expected snapshot-oriented render path from `warehouses/codeai/freight/current/helm`.
+- `review-infra-changes` exists and follows the rendered-branch review pattern.
+
+Missing or suspicious:
+- `production.yaml` is effectively unfinished. It declares `requestedFreight` from `review-infra-changes` and nothing else.
+- The Helm Warehouse only subscribes to `warehouses/codeai/freight/current`, not the broader `freight/` tree, which makes the historical snapshot story feel less explicit than the plan doc.
+- `test` renders and updates Argo but does not add an explicit verification block.
+
+Final freight complexity:
+- Medium to high.
+- Freight is Git-only, but it is much heavier than the thin-lock or common-case variants because it duplicates the package into both a historical release directory and a stable `current/` mirror.
+- The result is very explicit, but no longer especially small.
+
+## Kustomize
+
+- `code-dot-org` branch: `kargo/source-snapshot-rendered-branches/kustomize`, PR `#71570`
+- `k8s-gitops` branch: `kargo/source-snapshot-rendered-branches/kustomize`, PR `#10`
+- `code-dot-org` repo: `Cumulative Lines Added: 165 (added: 121, deleted: 44)` across 3 files
+- `k8s-gitops` repo: `Cumulative Lines Added: 536 (added: 449, deleted: 87)` across 26 files
+- `Implementation looks complete?` Partial
+
+What landed:
+- `k8s-gitops` carries most of the implementation: a Git Warehouse over `warehouses/codeai/freight`, deploy-entrypoint Kustomizations, envType patches, a shared wrapper template, and rendered-branch stages.
+- Staging/test/levelbuilder render from the frozen snapshot under `warehouses/codeai/freight/current/kustomize`.
+- `review-infra-changes` exists and follows the expected rendered-branch flow.
+
+Missing or suspicious:
+- `production.yaml` only clones and parses Freight; it never performs a final sync/update action.
+- There is no explicit Kargo verification block in `test`.
+- The branch proves the main render loop, but the final promotion handoff still reads as unfinished.
+
+Final freight complexity:
+- Medium to high.
+- Freight is a full frozen package snapshot mirrored through `current/`, which is much richer than a thin lock and much less native than common-case Freight.
+- The implementation confirms the design tradeoff: reviewability stays high, but the release object is now permanent system furniture.
+
+## Overall
+
+These branches demonstrate the snapshot design, but they also show the cost of that explicitness. The frozen-input story is strong; the implementation polish is weaker than the top-ranked common-case branches, especially around the final production hop.

--- a/k8s/docs/kargotecture/plans/iteration-7/oci-release-capsule.md
+++ b/k8s/docs/kargotecture/plans/iteration-7/oci-release-capsule.md
@@ -1,0 +1,1462 @@
+# OCI Release Capsule
+
+- Short name: OCI Capsule
+- Catchy description: Make one immutable registry object the center of release
+  truth, then render from that object instead of chasing source at promotion
+  time.
+
+## Detailed Technical Description of Plan
+This plan makes the release object itself an OCI artifact, not a Git commit or a
+rendered branch. The app image and the capsule share the same `git-<full-commit-sha>`
+identity, and the capsule carries the exact deploy package plus release
+metadata. Promotion is therefore a two-step trust chain: first verify that the
+promoted image and capsule belong to the same release identity, then unpack the
+capsule and render from the package stored inside it. That is what makes this
+plan different from the rendered-branch plans: the output is still reviewable,
+but the thing Kargo promotes is an immutable registry object instead of a live
+source checkout or a synthetic Git release record.
+
+The capsule should be thought of as a frozen release bundle with a small,
+explicit schema. `release.yaml` names the image ref, digest, package kind, and
+package path; the `package/` tree contains either Helm chart files or a shared
+Kustomize package; `metadata/` carries provenance and SBOM data. Promotion must
+download the capsule, confirm the tag/digest/package metadata match the Freight
+identity, and then render from the exact path recorded in the capsule. The
+important tricky part is that the capsule is not a generic blob archive: the
+package path inside the artifact is part of the contract, so Helm and Kustomize
+must each have a predictable internal layout that downstream steps can trust.
+
+For Helm, the capsule is mostly a frozen chart plus values; for Kustomize, it is
+the shared `k8s/kustomize` package plus GitOps-side env policy and wrapper
+inputs. That means the Kustomize form still depends on `k8s-gitops` for
+environment shaping, but it does not depend on live `code-dot-org` source at
+promotion time. The alternate package-pair form in this doc is intentionally
+weaker and more incremental: it keeps the same image+package pairing but splits
+the release witness into Git plus OCI artifacts. The full capsule is the
+stronger, more opinionated version when the team wants one registry-native
+release object to own both the deploy payload and its provenance.
+For this handoff, the full capsule form is the required implementation target.
+Treat the package-pair text below as future-only context, not as a co-equal
+first-pass option.
+- It is: packaging-agnostic plan
+- It uses: hybrid pattern
+
+## What Freight Looks Like
+This plan promotes the real application image and a matching OCI release
+capsule. The capsule carries the deploy package plus release metadata.
+
+```text
+registry:
+  ghcr.io/code-dot-org/code-dot-org:git-<full-commit-sha>
+  ghcr.io/code-dot-org/codeai-release-capsule:git-<full-commit-sha>
+
+# inside the capsule
+capsule/
+  release.yaml
+  package/
+    helm/...
+  # or
+    kustomize/...
+  metadata/
+    provenance.json
+    sbom.json
+```
+
+```yaml
+gitCommit: <full-commit-sha>
+image:
+  repoURL: ghcr.io/code-dot-org/code-dot-org
+  tag: git-<full-commit-sha>
+  digest: sha256:...
+package:
+  kind: helm # or kustomize
+  path: package/helm # or package/kustomize
+metadata:
+  sbomPath: metadata/sbom.json
+  provenancePath: metadata/provenance.json
+```
+
+## Capsule build-context layout before packaging
+
+```text
+release-capsule-build/
+  git-<full-commit-sha>/
+    release.yaml
+    package/
+      helm/...
+      kustomize/...
+    metadata/
+      sbom.json
+      provenance.json
+```
+
+This CI build-context directory is packaged into a single OCI artifact such as
+`ghcr.io/code-dot-org/codeai-release-capsule:git-<full-commit-sha>`.
+It is not a Git warehouse path that Kargo watches.
+
+The capsule contains the frozen deploy package and release metadata. It does
+not need to contain the app image bytes themselves. Instead, `release.yaml`
+records the exact image ref/digest that the capsule must be paired with.
+
+### Helm capsule contents
+
+```text
+release.yaml
+package/
+  helm/
+    Chart.yaml
+    values.yaml
+    templates/...
+metadata/
+  sbom.json
+  provenance.json
+```
+
+### Kustomize capsule contents
+
+```text
+release.yaml
+package/
+  kustomize/
+    base/
+    components/
+metadata/
+  sbom.json
+  provenance.json
+```
+
+The Kustomize capsule should contain only the shared app package. Promotion
+must take its Kustomize package input from inside `package/kustomize/`.
+Long-lived env overlays stay outside the capsule in `k8s-gitops`.
+
+Both OCI sub-plans in this doc should get `package/kustomize/` from a GH action
+running in the `code-dot-org` repo that sources from `k8s/kustomize/**`.
+The path inside the uploaded OCI artifact is part of the contract: the GH
+action must lay out the artifact so that after `oci-download` and unpack,
+Kargo finds the package exactly at `package.path` from the release metadata
+(`package/kustomize` for Kustomize, `package/helm` for the capsule Helm form).
+For the Kustomize form, this means Kargo should expect to find files such as
+`package/kustomize/base/kustomization.yaml` and
+`package/kustomize/components/...` after unpack, and should use
+`package/kustomize/base` as the shared package base input.
+Implementors should not use the checked-in `overlays/` or `bin/` subdirs in
+Kargo or Argo production code paths. Those are currently local-dev/parity
+support surfaces.
+
+## Freight definition
+
+Freight is anchored on the app image tag `git-<full-commit-sha>`. The matching OCI release
+capsule uses the same tag. Promotion verifies that:
+- image tag and capsule tag match
+- `release.yaml` inside the capsule names the same `$gitcommit`
+- image digest in the capsule matches the actual image digest from Freight
+
+## Future alternate implementation: OCI Package Pair
+This section is kept for context only. It is not part of the required first
+implementation for this plan.
+
+The same OCI-forward family can also be implemented as a looser pair instead of
+one capsule:
+
+- app image: `ghcr.io/code-dot-org/code-dot-org:git-<full-commit-sha>`
+- package artifact:
+  - Helm subvariant: `oci://ghcr.io/code-dot-org/codeai-chart:0.0.0-git.<full-commit-sha>`
+  - Generic subvariant: `ghcr.io/code-dot-org/codeai-packages@sha256:...`
+- small Git witness:
+
+```text
+warehouses/codeai/releases/git-<full-commit-sha>/
+  release.yaml
+```
+
+```yaml
+releaseId: git-<full-commit-sha>
+gitCommit: <full-commit-sha>
+image:
+  ref: ghcr.io/code-dot-org/code-dot-org:git-<full-commit-sha>
+  digest: sha256:...
+package:
+  ref: ghcr.io/code-dot-org/codeai-packages@sha256:...
+  digest: sha256:...
+  kind: helm-chart # or generic-bundle
+  format: helm-chart-tgz # or kustomize-tar
+  path: . # helm chart root, or package/kustomize for the Kustomize pair form
+```
+
+Use the pair form if the team wants:
+- a smaller adoption step
+- a more explicit Git witness
+- less custom OCI capsule tooling
+
+Use the capsule form if the team wants:
+- one richer OCI release object
+- one place for package metadata, provenance, and SBOM
+- the cleaner long-term OCI-native story
+
+For the required implementation in this repo, use the capsule form.
+
+### Package Pair contents
+
+Helm pair form:
+
+```text
+image:
+  ghcr.io/code-dot-org/code-dot-org:git-<full-commit-sha>
+
+package artifact:
+  oci://ghcr.io/code-dot-org/codeai-chart:0.0.0-git.<full-commit-sha>
+
+git witness:
+  warehouses/codeai/releases/git-<full-commit-sha>/release.yaml
+```
+
+Kustomize pair form:
+
+```text
+image:
+  ghcr.io/code-dot-org/code-dot-org:git-<full-commit-sha>
+
+package artifact:
+  ghcr.io/code-dot-org/codeai-packages:git-<full-commit-sha>
+
+# inside the generic package artifact
+package/
+  kustomize/
+    base/
+    components/
+
+git witness:
+  warehouses/codeai/releases/git-<full-commit-sha>/release.yaml
+```
+
+The Kustomize package-pair form follows the same packaging rule as the capsule
+form: the package input comes from `package/kustomize/`, and that package is
+built by a GH action running in the `code-dot-org` repo that sources from
+`k8s/kustomize/**`.
+The path inside the uploaded artifact is part of the contract here too: the GH
+action must publish the package so that after download and unpack, Kargo finds
+the package at the exact `package.path` recorded in the witness.
+For the Kustomize pair form, that means the witness should record
+`package.path: package/kustomize`, and Kargo should expect to find
+`package/kustomize/base/kustomization.yaml` after unpack.
+Implementors should not use the checked-in `overlays/` or `bin/` subdirs in
+Kargo or Argo production code paths.
+
+### Package Pair promotion skeleton
+
+The pair form uses the same rendered-output destination as the capsule form,
+but promotion resolves two release objects instead of one:
+
+1. Clone `k8s-gitops` for env policy and rendered output.
+2. Resolve the promoted image Freight.
+3. Read the Git witness at `warehouses/codeai/releases/git-<full-commit-sha>/release.yaml`.
+4. Verify:
+   - promoted image tag matches witness `releaseId`
+   - witness `gitCommit` matches the `git-<full-commit-sha>` identity
+   - witness `image.digest` matches the promoted image digest
+   - witness `package.ref`, `package.digest`, and `package.path` are present
+5. Download the package artifact named by the witness:
+   - Helm: OCI Helm chart ref
+   - Kustomize: generic OCI bundle ref
+6. Unpack the package artifact into a temp working directory and read the
+   package from the exact `package.path` recorded in the witness.
+7. Render the target stage using the unpacked package plus env policy from
+   `k8s-gitops`.
+8. Commit rendered output to the target stage branch/path.
+
+### Package Pair GH runner sketch
+
+If the team chooses the pair form instead of the full capsule, the GH runner
+should do this:
+
+1. Build and stitch the app image exactly as today.
+2. Resolve the final pushed image digest.
+3. Create a temp package worktree such as:
+   - Helm: chart package created from `k8s/helm/`
+   - Kustomize:
+     - `package/kustomize/base/...`
+     - `package/kustomize/components/...`
+4. For the Kustomize package, have the GH action populate `package/kustomize/`
+   from `k8s/kustomize/**` in the `code-dot-org` repo. Implementors should not
+   use the checked-in `overlays/` or `bin/` subdirs in Kargo or Argo production
+   code paths.
+5. Publish the package artifact:
+   - Helm: `helm package` then `helm push`
+   - Kustomize: archive the package directory and push it as a generic OCI
+     artifact such as `ghcr.io/code-dot-org/codeai-packages:git-<full-commit-sha>`
+6. Write the Git witness at
+   `warehouses/codeai/releases/git-<full-commit-sha>/release.yaml` with:
+   - `releaseId`
+   - `gitCommit`
+   - image ref/digest
+   - package ref/digest
+   - package kind/format
+   - package path that Kargo will later read after unpack
+7. Commit and push the witness to `k8s-gitops`.
+8. Keep the Kargo Warehouse image-led and have promotion derive the witness path
+   from the promoted image tag.
+
+This is future-only context and should not be used to scope the first
+contractor implementation.
+
+## Full Kargo project design
+
+- `Warehouse codeai-image` subscribes to the app image repo as it does today.
+- Stages use `oci-download` to fetch the matching release capsule by image tag.
+- `staging` verifies the image/capsule pair, unpacks the capsule, renders
+  staging output, and commits rendered manifests to `k8s-gitops`.
+- `test` rehydrates the same capsule, renders test output, syncs, and runs
+  verification.
+- `levelbuilder` and `review-infra-changes` both promote the exact Freight
+  verified in `test`, rehydrate the same capsule, and render with different
+  stage policy.
+- `production` syncs the already-reviewed `stage/production` output after the
+  PR merge.
+- ArgoCD still consumes rendered manifests from Git, not OCI artifacts
+  directly.
+
+### Common promotion skeleton
+
+Every stage uses the same common steps:
+
+1. Clone `k8s-gitops` for env policy and rendered output.
+2. Resolve the promoted image Freight.
+3. `oci-download` the capsule whose tag matches that image.
+4. Verify:
+   - image tag matches capsule tag
+   - `release.yaml.gitCommit` matches the tag identity
+   - `release.yaml.image.digest` matches the promoted image digest
+5. Unpack the capsule into a temp working directory.
+6. Render the target stage using the unpacked package plus env policy from
+   `k8s-gitops`.
+7. Commit rendered output to the target stage branch/path.
+8. Sync Argo or open a PR, depending on the stage.
+
+### Helm-specific render path
+
+Use the unpacked chart plus env values from `k8s-gitops`:
+
+1. Unpack `package/helm/`.
+2. Read env values from:
+   - `apps/codeai/envTypes/<envType>.values.yaml`
+   - `apps/codeai/deployments/<deployment>/values.yaml`
+3. Run `helm-template` against the unpacked chart.
+4. Write rendered output to the stage branch/path in `k8s-gitops`.
+
+This is the easier packaging form for the capsule because Kargo already has a
+clear story for `oci-download` plus Helm rendering.
+
+### Kustomize-specific render path
+
+Use the unpacked shared base/components plus envType Components and a copied
+temp wrapper from `k8s-gitops`:
+
+1. Unpack `package/kustomize/` from inside the capsule. Use only its shared
+   `base/` and `components/` package inputs.
+   Kargo should expect files such as `package/kustomize/base/kustomization.yaml`
+   after unpack.
+2. Copy the generic wrapper template dir from `k8s-gitops` at
+   `apps/codeai/kargo/templates/deploy/`.
+3. Assemble a temp source tree combining:
+   - capsule base/components
+   - GitOps envType Component and any referenced `envTypes/components/`
+     subcomponents
+   - the copied temp wrapper
+4. Update the copied wrapper with `deployment.yaml.namespace`,
+   `resources: ../../source/base`, and
+   `components: ../../envTypes/<envType>`.
+5. Set the promoted image tag in the temp wrapper with `kustomize-set-image`,
+   matching the real base image name `code-dot-org`.
+6. Run `kustomize-build`.
+7. Write rendered output to the stage branch/path in `k8s-gitops`.
+
+Do not pull Kustomize packaging input from `code-dot-org/k8s/kustomize/overlays`
+or `code-dot-org/k8s/kustomize/bin` in production code paths. Those are
+currently local-dev/parity support surfaces, not release payload.
+
+This is still workable, but it needs more composition glue than the Helm path.
+
+## Stage-by-stage promotion flow
+
+1. CI builds the image and pushes `git-<full-commit-sha>`.
+2. CI snapshots the deploy package at that same `$gitcommit` and publishes it
+   as an OCI release capsule with the same tag.
+3. `staging` downloads the capsule, verifies it against the image Freight, and
+   renders staging.
+4. `test` downloads the same capsule, renders test, syncs, and runs
+   verification.
+5. `levelbuilder` and `review-infra-changes` both reuse the exact capsule
+   verified in `test`.
+6. `review-infra-changes` opens a PR against `stage/production`.
+7. `production` syncs the already-reviewed `stage/production` branch after the
+   PR merge.
+
+The important point is that the shared app package is frozen once in the
+capsule, while stage-specific policy stays outside the capsule and is layered in
+at promotion time.
+
+## `review infra changes` stage behavior
+
+- The review PR contains generated manifest diffs plus capsule metadata.
+- Reviewers do not inspect the OCI artifact directly in normal flow; they review
+  rendered Git output and metadata links.
+- A failed capsule/image verification blocks PR creation.
+- For Helm, the PR diff is the rendered result of the frozen chart plus
+  production values.
+- For Kustomize, the PR diff is the rendered result of the frozen base/components
+  plus production overlay/policy.
+
+## `test` stage automation behavior
+
+- Pull the capsule again and verify digest consistency.
+- Sync the test Application.
+- Use Kargo `verification` / `AnalysisTemplate`s for rollout, health, and smoke checks.
+- Require existing Drone unit/UI results for the same promoted `gitCommit` before downstream promotion.
+- Keep the same capsule across all downstream stages; only the stage policy
+  input changes.
+
+## Does it break/awkwardize skaffold or local-dev in any way?
+
+No for day-to-day local work. Skaffold continues to use the live Helm chart in
+`code-dot-org`. The OCI capsule is a CI/CD release artifact, not a local author
+surface.
+
+## Proposed Helm/Kustomize directory structure in both repos if the plan changes them
+
+`code-dot-org`:
+
+```text
+k8s/
+  helm/
+  kustomize/
+    base/
+    components/
+    overlays/
+    bin/
+  release/
+    capsule/
+```
+
+Use only `k8s/kustomize/base/` and `k8s/kustomize/components/` in Kargo/Argo
+production code paths. The checked-in `overlays/` and `bin/` trees are
+currently local-dev/parity support.
+
+`k8s-gitops`:
+
+```text
+apps/codeai/
+  envTypes/
+  deployments/
+    <deployment>/
+      deployment.yaml
+      values.yaml
+  kargo/
+    templates/
+      deploy/
+        kustomization.yaml
+```
+
+Helm-shaped capsule use should keep:
+
+```text
+apps/codeai/
+  envTypes/
+    <envType>.values.yaml
+  deployments/
+    <deployment>/
+      deployment.yaml
+      values.yaml
+```
+
+Kustomize-shaped capsule use should keep:
+
+```text
+apps/codeai/
+  envTypes/
+    <envType>/
+    components/
+  deployments/
+    <deployment>/
+      deployment.yaml
+  kargo/
+    templates/
+      deploy/
+        kustomization.yaml
+```
+
+For the Kustomize-shaped form, `main` keeps envType Components and the generic
+temp-wrapper template at `apps/codeai/kargo/templates/deploy/`. The
+rendered `deploy/` tree stays on `stage/*` as generated output only.
+
+## Pros / cons
+
+### Pros
+
+- Clean immutable object model.
+- No giant-monorepo promotion reads.
+- Good artifact integrity story without abandoning Git-based review output.
+- Keeps the release payload together instead of pairing artifacts loosely later.
+
+### Cons
+
+- Generic OCI artifacts are still less native to Warehouse subscriptions than
+  images and Git.
+- Requires custom capsule packaging and verification glue.
+- Operators need one more registry-native concept to understand.
+
+## Migration notes
+
+- Start by publishing capsules alongside the current image-only flow.
+- Add capsule verification in staging before making it mandatory everywhere.
+- Keep Argo on rendered Git output to avoid combining too many big changes at
+  once.
+
+## Any useful implementation notes that do not fit neatly elsewhere
+
+- Reuse the image tag as the capsule tag to avoid extra identity mapping.
+- Include the exact image digest in `release.yaml`.
+- Keep the capsule schema stable across Helm and future Kustomize packaging.
+- Keep env-specific values or overlays out of the capsule so environment policy
+  can still evolve in GitOps.
+- If the capsule is generic OCI content rather than an OCI Helm chart, Kargo is
+  using it as a promotion-time downloaded artifact, not as the cleanest
+  first-class Warehouse subscription type.
+
+## Iteration 7 notes
+- Keep this as the primary OCI-forward plan and implement the full capsule form
+  first.
+- Keep `OCI Package Pair` only as future-context text, not as a co-equal first
+  pass target.
+- The real evaluation question is whether the capsule is cleaner enough than
+  the pair to justify the extra packaging/verification glue, but that is a
+  follow-on question, not the initial contractor scope.
+
+# Code changes
+
+## k8s-gitops changes
+
+- Add rendered output directories.
+- Add `apps/codeai/kargo/templates/deploy/kustomization.yaml` as the generic
+  Kustomize temp-wrapper template copied into promotion work dirs.
+- Add a `review-infra-changes` Stage.
+- Update Argo to deploy rendered output from Git.
+- Add metadata recording the approved capsule digest per environment.
+
+## `codeai/applicationset.yaml` sketch
+
+This plan should keep using `apps/codeai/deployments/*/deployment.yaml` on
+`main` as the generator input, but Argo should deploy from the rendered
+`deploy/` dir on each stage branch:
+
+```yaml
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: codeai
+  namespace: argocd
+spec:
+  generators:
+    - git:
+        repoURL: https://github.com/code-dot-org/k8s-gitops.git
+        revision: main
+        files:
+          - path: apps/codeai/deployments/*/deployment.yaml
+  template:
+    metadata:
+      name: codeai-{{path.basename}}
+    spec:
+      sources:
+        - repoURL: https://github.com/code-dot-org/k8s-gitops.git
+          targetRevision: stage/{{path.basename}}
+          path: apps/codeai/deployments/{{path.basename}}/deploy
+      destination:
+        server: https://kubernetes.default.svc
+        namespace: '{{namespace}}'
+```
+
+## code-dot-org changes
+
+- Add CI packaging and push for the OCI release capsule.
+- Add the plan-owned `codeai-release-verify` helper/service used by Kargo
+  promotion steps.
+- Replace image-only assumptions in release metadata generation.
+
+## modules that are part of implementing this plan
+
+- [Rendered Stage Branches and PR Review](../modules/rendered-stage-branches-and-pr-review.md)
+- [Gate Promotion On Legacy Gitflow Branches](../modules/gate-promotion-on-legacy-gitflow-branches.md)
+
+# Sketch of Pivotal Implementation Details
+
+This section is intentionally more concrete than the rest of the plan. It is
+still a sketch, but it is meant to answer "what would the actual Kargo objects
+look like?"
+
+## Shared mechanics
+
+This plan reuses:
+- [Rendered Stage Branches and PR Review](../modules/rendered-stage-branches-and-pr-review.md)
+- [Gate Promotion On Legacy Gitflow Branches](../modules/gate-promotion-on-legacy-gitflow-branches.md)
+
+## Helm implementation starting point
+
+Treat the checked-in `code-dot-org/k8s/helm/` tree as the starting point, not a
+frozen contract. The implementor may modify or reshape `k8s/helm/` if this plan
+benefits from it, but should preserve current behavior unless the change
+materially improves the plan before packaging it into the capsule.
+
+## Kustomize implementation starting point
+
+Treat the checked-in `code-dot-org/k8s/kustomize/` tree as the starting point,
+not a frozen contract. The implementor may modify or reshape `k8s/kustomize/`
+as needed for this plan, especially the base/components layout, before
+packaging it into the capsule.
+
+Use the current `k8s-gitops/apps/codeai/envTypes/<envType>/kustomization.yaml`
+files as the starting envType Component contract. `production` may
+additionally layer in `apps/codeai/envTypes/components/autoscaling/`.
+
+Rendered-family Kustomize stages should not read a committed
+`apps/codeai/deployments/<deployment>/deploy/` tree from `main`. Instead, keep
+a generic deploy-dir template at `apps/codeai/kargo/templates/deploy/`, copy
+that directory into a temp work dir during promotion, then update the copied
+`kustomization.yaml` `namespace`, `resources`, and `components` before running
+`kustomize-set-image`.
+
+Do not treat `code-dot-org/k8s/kustomize/overlays/*` as the production deploy
+contract unless the plan explicitly chooses to adopt them. Those directories are
+currently local-dev/parity support, as is `code-dot-org/k8s/kustomize/bin/`.
+
+## Required verifier contract
+
+This plan is not handoff-ready unless capsule verification is concrete. The
+required contract is:
+
+`codeai-release-verify` is part of this plan's required implementation and
+should live in the `code-dot-org` repo for the first pass.
+
+- service name: `codeai-release-verify`
+- invocation: Kargo `http` step, `POST`
+- inputs:
+  - promoted image repo, tag, digest
+  - parsed `release.yaml`
+  - expected capsule ref
+- assertions:
+  - promoted image tag equals `release.yaml.image.tag`
+  - promoted image digest equals `release.yaml.image.digest`
+  - `release.yaml.gitCommit` matches the `git-<full-commit-sha>` tag suffix
+- `release.yaml.package.kind` is one of `helm` or `kustomize`
+- `release.yaml.package.path` stays under `package/`
+- success output:
+  - verified release metadata object
+  - normalized `packageKind`
+  - normalized `packagePath`
+  - verified `gitCommit`
+- failure behavior:
+  - return a non-2xx or `ok: false` with a readable mismatch reason
+- Kargo treats that as a terminal failure and stops promotion before render
+
+For the required implementation, this contract is the only allowed verifier
+shape.
+
+## Example capsule `release.yaml`
+
+```yaml
+schemaVersion: codeai/v1alpha1
+gitCommit: 0cc4cd87f40ae606d1822d5652b552f8c50a4668
+image:
+  repoURL: ghcr.io/code-dot-org/code-dot-org
+  tag: git-0cc4cd87f40ae606d1822d5652b552f8c50a4668
+  digest: sha256:1111111111111111111111111111111111111111111111111111111111111111
+package:
+  kind: helm
+  path: package/helm
+metadata:
+  sbomPath: metadata/sbom.json
+  provenancePath: metadata/provenance.json
+```
+
+For the Kustomize form, `package.kind` becomes `kustomize` and `package.path`
+points at `package/kustomize/`.
+
+## Example Warehouse
+
+The capsule plan stays image-anchored. The Warehouse only needs to discover the
+real application image stream. Promotion derives the matching capsule ref from
+the promoted image tag.
+
+```yaml
+apiVersion: kargo.akuity.io/v1alpha1
+kind: Warehouse
+metadata:
+  name: codeai-image
+  namespace: kargo-project-codeai
+spec:
+  subscriptions:
+    - image:
+        repoURL: ghcr.io/code-dot-org/code-dot-org
+```
+
+## Example `staging` Stage using a Helm capsule
+
+```yaml
+apiVersion: kargo.akuity.io/v1alpha1
+kind: Stage
+metadata:
+  name: staging
+  namespace: kargo-project-codeai
+spec:
+  requestedFreight:
+    - origin:
+        kind: Warehouse
+        name: codeai-image
+      sources:
+        direct: true
+  vars:
+    - name: gitopsRepo
+      value: https://github.com/code-dot-org/k8s-gitops.git
+    - name: imageRepo
+      value: ghcr.io/code-dot-org/code-dot-org
+    - name: capsuleRepo
+      value: ghcr.io/code-dot-org/codeai-release-capsule
+    - name: targetBranch
+      value: stage/${{ ctx.stage }}
+    - name: releaseName
+      value: codeai
+  promotionTemplate:
+    spec:
+      steps:
+        - uses: git-clone
+          config:
+            repoURL: ${{ vars.gitopsRepo }}
+            checkout:
+              - branch: main
+                path: ./src
+              - branch: ${{ vars.targetBranch }}
+                create: true
+                path: ./out
+
+        - uses: yaml-parse
+          as: deployment-meta
+          config:
+            path: ./src/apps/codeai/deployments/${{ ctx.stage }}/deployment.yaml
+            outputs:
+              - name: envType
+                fromExpression: envType
+              - name: namespace
+                fromExpression: namespace
+
+        - uses: git-clear
+          config:
+            path: ./out/apps/codeai/deployments/${{ ctx.stage }}/deploy
+
+        - uses: oci-download
+          config:
+            imageRef: ${{ vars.capsuleRepo }}:${{ imageFrom(vars.imageRepo).Tag }}
+            outPath: ./capsule.tgz
+
+        - uses: untar
+          config:
+            inPath: ./capsule.tgz
+            outPath: ./capsule
+
+        - uses: yaml-parse
+          as: capsule-release
+          config:
+            path: ./capsule/release.yaml
+            outputs:
+              - name: gitCommit
+                fromExpression: gitCommit
+              - name: imageRepo
+                fromExpression: image.repoURL
+              - name: imageTag
+                fromExpression: image.tag
+              - name: imageDigest
+                fromExpression: image.digest
+              - name: packageKind
+                fromExpression: package.kind
+              - name: packagePath
+                fromExpression: package.path
+
+        - uses: http
+          as: verify-release
+          config:
+            method: POST
+            url: http://codeai-release-verify.kargo-project-codeai.svc.cluster.local/verify
+            headers:
+              - name: Content-Type
+                value: application/json
+            body: |
+              ${{ quote({
+                "image": {
+                  "repoURL": imageFrom(vars.imageRepo).RepoURL,
+                  "tag": imageFrom(vars.imageRepo).Tag,
+                  "digest": imageFrom(vars.imageRepo).Digest
+                },
+                "capsule": {
+                  "repoURL": vars.capsuleRepo,
+                  "tag": imageFrom(vars.imageRepo).Tag
+                },
+                "release": {
+                  "gitCommit": outputs['capsule-release'].gitCommit,
+                  "imageRepo": outputs['capsule-release'].imageRepo,
+                  "imageTag": outputs['capsule-release'].imageTag,
+                  "imageDigest": outputs['capsule-release'].imageDigest,
+                  "packageKind": outputs['capsule-release'].packageKind,
+                  "packagePath": outputs['capsule-release'].packagePath
+                }
+              }) }}
+            successExpression: response.status == 200 && response.body.ok == true
+            failureExpression: response.status >= 400 || response.body.ok == false
+            outputs:
+              - name: verifiedGitCommit
+                fromExpression: response.body.release.gitCommit
+              - name: verifiedPackageKind
+                fromExpression: response.body.release.packageKind
+              - name: verifiedPackagePath
+                fromExpression: response.body.release.packagePath
+              - name: mismatchReason
+                fromExpression: response.body.reason
+
+        - uses: set-metadata
+          config:
+            updates:
+              - kind: Stage
+                name: staging
+                values:
+                  promotedImage:
+                    repoURL: ${{ imageFrom(vars.imageRepo).RepoURL }}
+                    tag: ${{ imageFrom(vars.imageRepo).Tag }}
+                    digest: ${{ imageFrom(vars.imageRepo).Digest }}
+                  capsule:
+                    repoURL: ${{ vars.capsuleRepo }}
+                    tag: ${{ outputs['capsule-release'].imageTag }}
+                    packageKind: ${{ outputs['verify-release'].verifiedPackageKind }}
+                    gitCommit: ${{ outputs['verify-release'].verifiedGitCommit }}
+
+        - uses: helm-template
+          config:
+            path: ./capsule/package/helm
+            releaseName: ${{ vars.releaseName }}
+            outPath: ./out/apps/codeai/deployments/${{ ctx.stage }}/deploy
+            valuesFiles:
+              - ./src/apps/codeai/envTypes/${{ outputs['deployment-meta'].envType }}.values.yaml
+              - ./src/apps/codeai/deployments/${{ ctx.stage }}/values.yaml
+            setValues:
+              - key: image.repository
+                value: ${{ vars.imageRepo }}
+              - key: image.tag
+                value: ${{ imageFrom(vars.imageRepo).Tag }}
+
+        - uses: git-commit
+          config:
+            path: ./out
+            message: |
+              Render ${{ ctx.stage }} from OCI release capsule
+
+              image: ${{ imageFrom(vars.imageRepo).RepoURL }}:${{ imageFrom(vars.imageRepo).Tag }}
+              digest: ${{ imageFrom(vars.imageRepo).Digest }}
+              capsule: ${{ vars.capsuleRepo }}:${{ imageFrom(vars.imageRepo).Tag }}
+
+        - uses: git-push
+          config:
+            path: ./out
+            branch: ${{ vars.targetBranch }}
+```
+
+## Example `staging` Stage using a Kustomize capsule
+
+```yaml
+apiVersion: kargo.akuity.io/v1alpha1
+kind: Stage
+metadata:
+  name: staging
+  namespace: kargo-project-codeai
+spec:
+  requestedFreight:
+    - origin:
+        kind: Warehouse
+        name: codeai-image
+      sources:
+        direct: true
+  vars:
+    - name: gitopsRepo
+      value: https://github.com/code-dot-org/k8s-gitops.git
+    - name: imageRepo
+      value: ghcr.io/code-dot-org/code-dot-org
+    - name: capsuleRepo
+      value: ghcr.io/code-dot-org/codeai-release-capsule
+    - name: targetBranch
+      value: stage/${{ ctx.stage }}
+  promotionTemplate:
+    spec:
+      steps:
+        - uses: git-clone
+          config:
+            repoURL: ${{ vars.gitopsRepo }}
+            checkout:
+              - branch: main
+                path: ./src
+              - branch: ${{ vars.targetBranch }}
+                create: true
+                path: ./out
+
+        - uses: yaml-parse
+          as: deployment-meta
+          config:
+            path: ./src/apps/codeai/deployments/${{ ctx.stage }}/deployment.yaml
+            outputs:
+              - name: envType
+                fromExpression: envType
+
+        - uses: git-clear
+          config:
+            path: ./out/apps/codeai/deployments/${{ ctx.stage }}/deploy
+
+        - uses: oci-download
+          config:
+            imageRef: ${{ vars.capsuleRepo }}:${{ imageFrom(vars.imageRepo).Tag }}
+            outPath: ./capsule.tgz
+
+        - uses: untar
+          config:
+            inPath: ./capsule.tgz
+            outPath: ./capsule
+
+        - uses: yaml-parse
+          as: capsule-release
+          config:
+            path: ./capsule/release.yaml
+            outputs:
+              - name: gitCommit
+                fromExpression: gitCommit
+              - name: imageRepo
+                fromExpression: image.repoURL
+              - name: imageTag
+                fromExpression: image.tag
+              - name: imageDigest
+                fromExpression: image.digest
+              - name: packageKind
+                fromExpression: package.kind
+              - name: packagePath
+                fromExpression: package.path
+
+        - uses: http
+          as: verify-release
+          config:
+            method: POST
+            url: http://codeai-release-verify.kargo-project-codeai.svc.cluster.local/verify
+            headers:
+              - name: Content-Type
+                value: application/json
+            body: |
+              ${{ quote({
+                "image": {
+                  "repoURL": imageFrom(vars.imageRepo).RepoURL,
+                  "tag": imageFrom(vars.imageRepo).Tag,
+                  "digest": imageFrom(vars.imageRepo).Digest
+                },
+                "capsule": {
+                  "repoURL": vars.capsuleRepo,
+                  "tag": imageFrom(vars.imageRepo).Tag
+                },
+                "release": {
+                  "gitCommit": outputs['capsule-release'].gitCommit,
+                  "imageRepo": outputs['capsule-release'].imageRepo,
+                  "imageTag": outputs['capsule-release'].imageTag,
+                  "imageDigest": outputs['capsule-release'].imageDigest,
+                  "packageKind": outputs['capsule-release'].packageKind,
+                  "packagePath": outputs['capsule-release'].packagePath
+                }
+              }) }}
+            successExpression: response.status == 200 && response.body.ok == true
+            failureExpression: response.status >= 400 || response.body.ok == false
+            outputs:
+              - name: verifiedGitCommit
+                fromExpression: response.body.release.gitCommit
+              - name: verifiedPackageKind
+                fromExpression: response.body.release.packageKind
+              - name: verifiedPackagePath
+                fromExpression: response.body.release.packagePath
+              - name: mismatchReason
+                fromExpression: response.body.reason
+
+        - uses: set-metadata
+          config:
+            updates:
+              - kind: Stage
+                name: staging
+                values:
+                  promotedImage:
+                    repoURL: ${{ imageFrom(vars.imageRepo).RepoURL }}
+                    tag: ${{ imageFrom(vars.imageRepo).Tag }}
+                    digest: ${{ imageFrom(vars.imageRepo).Digest }}
+                  capsule:
+                    repoURL: ${{ vars.capsuleRepo }}
+                    tag: ${{ outputs['capsule-release'].imageTag }}
+                    packageKind: ${{ outputs['verify-release'].verifiedPackageKind }}
+                    gitCommit: ${{ outputs['verify-release'].verifiedGitCommit }}
+
+        - uses: copy
+          config:
+            inPath: ./capsule/package/kustomize
+            outPath: ./work/deployments/source
+
+        - uses: copy
+          config:
+            inPath: ./src/apps/codeai/envTypes/${{ outputs['deployment-meta'].envType }}
+            outPath: ./work/deployments/envTypes/${{ outputs['deployment-meta'].envType }}
+
+        - uses: copy
+          config:
+            inPath: ./src/apps/codeai/envTypes/components
+            outPath: ./work/deployments/envTypes/components
+
+        - uses: copy
+          config:
+            inPath: ./src/apps/codeai/kargo/templates/deploy
+            outPath: ./work/deployments/${{ ctx.stage }}/deploy
+
+        # The temp wrapper template provides apiVersion/kind and one
+        # `images` entry whose match key is `code-dot-org`.
+        - uses: yaml-update
+          config:
+            path: ./work/deployments/${{ ctx.stage }}/deploy/kustomization.yaml
+            updates:
+              - key: namespace
+                value: ${{ outputs['deployment-meta'].namespace }}
+              - key: resources
+                value:
+                  - ../../source/base
+              - key: components
+                value:
+                  - ../../envTypes/${{ outputs['deployment-meta'].envType }}
+
+        - uses: kustomize-set-image
+          config:
+            path: ./work/deployments/${{ ctx.stage }}/deploy
+            images:
+              - image: code-dot-org
+                newName: ${{ vars.imageRepo }}
+                tag: ${{ imageFrom(vars.imageRepo).Tag }}
+
+        - uses: kustomize-build
+          config:
+            path: ./work/deployments/${{ ctx.stage }}/deploy
+            outPath: ./out/apps/codeai/deployments/${{ ctx.stage }}/deploy
+
+        - uses: git-commit
+          config:
+            path: ./out
+            message: |
+              Render ${{ ctx.stage }} from OCI release capsule
+
+              image: ${{ imageFrom(vars.imageRepo).RepoURL }}:${{ imageFrom(vars.imageRepo).Tag }}
+              digest: ${{ imageFrom(vars.imageRepo).Digest }}
+              capsule: ${{ vars.capsuleRepo }}:${{ imageFrom(vars.imageRepo).Tag }}
+
+        - uses: git-push
+          config:
+            path: ./out
+            branch: ${{ vars.targetBranch }}
+```
+
+## Example `review-infra-changes` Stage
+
+This is the same capsule flow, but instead of syncing directly it pushes to a
+generated branch and opens a PR against the long-lived stage branch.
+
+```yaml
+apiVersion: kargo.akuity.io/v1alpha1
+kind: Stage
+metadata:
+  name: review-infra-changes
+  namespace: kargo-project-codeai
+spec:
+  requestedFreight:
+    - origin:
+        kind: Warehouse
+        name: codeai-image
+      sources:
+        stages:
+          - test
+  vars:
+    - name: gitopsRepo
+      value: https://github.com/code-dot-org/k8s-gitops.git
+    - name: imageRepo
+      value: ghcr.io/code-dot-org/code-dot-org
+    - name: capsuleRepo
+      value: ghcr.io/code-dot-org/codeai-release-capsule
+    - name: targetBranch
+      value: stage/production
+    - name: releaseName
+      value: codeai
+  promotionTemplate:
+    spec:
+      steps:
+        - uses: git-clone
+          config:
+            repoURL: ${{ vars.gitopsRepo }}
+            checkout:
+              - branch: main
+                path: ./src
+              - branch: ${{ vars.targetBranch }}
+                create: true
+                path: ./out
+        - uses: yaml-parse
+          as: deployment-meta
+          config:
+            path: ./src/apps/codeai/deployments/production/deployment.yaml
+            outputs:
+              - name: envType
+                fromExpression: envType
+              - name: namespace
+                fromExpression: namespace
+        - uses: git-clear
+          config:
+            path: ./out/apps/codeai/deployments/production/deploy
+        - uses: oci-download
+          config:
+            imageRef: ${{ vars.capsuleRepo }}:${{ imageFrom(vars.imageRepo).Tag }}
+            outPath: ./capsule.tgz
+        - uses: untar
+          config:
+            inPath: ./capsule.tgz
+            outPath: ./capsule
+        - uses: yaml-parse
+          as: capsule-release
+          config:
+            path: ./capsule/release.yaml
+            outputs:
+              - name: gitCommit
+                fromExpression: gitCommit
+              - name: imageRepo
+                fromExpression: image.repoURL
+              - name: imageTag
+                fromExpression: image.tag
+              - name: imageDigest
+                fromExpression: image.digest
+              - name: packageKind
+                fromExpression: package.kind
+              - name: packagePath
+                fromExpression: package.path
+        - uses: http
+          as: verify-release
+          config:
+            method: POST
+            url: http://codeai-release-verify.kargo-project-codeai.svc.cluster.local/verify
+            headers:
+              - name: Content-Type
+                value: application/json
+            body: |
+              ${{ quote({
+                "image": {
+                  "repoURL": imageFrom(vars.imageRepo).RepoURL,
+                  "tag": imageFrom(vars.imageRepo).Tag,
+                  "digest": imageFrom(vars.imageRepo).Digest
+                },
+                "capsule": {
+                  "repoURL": vars.capsuleRepo,
+                  "tag": imageFrom(vars.imageRepo).Tag
+                },
+                "release": {
+                  "gitCommit": outputs['capsule-release'].gitCommit,
+                  "imageRepo": outputs['capsule-release'].imageRepo,
+                  "imageTag": outputs['capsule-release'].imageTag,
+                  "imageDigest": outputs['capsule-release'].imageDigest,
+                  "packageKind": outputs['capsule-release'].packageKind,
+                  "packagePath": outputs['capsule-release'].packagePath
+                }
+              }) }}
+            successExpression: response.status == 200 && response.body.ok == true
+            failureExpression: response.status >= 400 || response.body.ok == false
+            outputs:
+              - name: verifiedPackageKind
+                fromExpression: response.body.release.packageKind
+        - uses: helm-template
+          config:
+            path: ./capsule/package/helm
+            releaseName: ${{ vars.releaseName }}
+            outPath: ./out/apps/codeai/deployments/production/deploy
+            valuesFiles:
+              - ./src/apps/codeai/envTypes/${{ outputs['deployment-meta'].envType }}.values.yaml
+              - ./src/apps/codeai/deployments/production/values.yaml
+            setValues:
+              - key: image.repository
+                value: ${{ vars.imageRepo }}
+              - key: image.tag
+                value: ${{ imageFrom(vars.imageRepo).Tag }}
+        - uses: git-commit
+          config:
+            path: ./out
+            message: |
+              Review production render from OCI capsule
+
+              image: ${{ imageFrom(vars.imageRepo).RepoURL }}:${{ imageFrom(vars.imageRepo).Tag }}
+              capsule: ${{ vars.capsuleRepo }}:${{ imageFrom(vars.imageRepo).Tag }}
+        - uses: git-push
+          as: push
+          config:
+            path: ./out
+            generateTargetBranch: true
+        - uses: git-open-pr
+          as: open-pr
+          config:
+            repoURL: ${{ vars.gitopsRepo }}
+            sourceBranch: ${{ outputs.push.branch }}
+            targetBranch: ${{ vars.targetBranch }}
+            title: Review CodeAI production render for ${{ imageFrom(vars.imageRepo).Tag }}
+        - uses: git-wait-for-pr
+          config:
+            repoURL: ${{ vars.gitopsRepo }}
+            prNumber: ${{ outputs['open-pr'].pr.id }}
+```
+
+## Example `review-infra-changes` Stage using a Kustomize capsule
+
+```yaml
+apiVersion: kargo.akuity.io/v1alpha1
+kind: Stage
+metadata:
+  name: review-infra-changes
+  namespace: kargo-project-codeai
+spec:
+  requestedFreight:
+    - origin:
+        kind: Warehouse
+        name: codeai-image
+      sources:
+        stages:
+          - test
+  vars:
+    - name: gitopsRepo
+      value: https://github.com/code-dot-org/k8s-gitops.git
+    - name: imageRepo
+      value: ghcr.io/code-dot-org/code-dot-org
+    - name: capsuleRepo
+      value: ghcr.io/code-dot-org/codeai-release-capsule
+    - name: targetBranch
+      value: stage/production
+  promotionTemplate:
+    spec:
+      steps:
+        - uses: git-clone
+          config:
+            repoURL: ${{ vars.gitopsRepo }}
+            checkout:
+              - branch: main
+                path: ./src
+              - branch: ${{ vars.targetBranch }}
+                create: true
+                path: ./out
+        - uses: yaml-parse
+          as: deployment-meta
+          config:
+            path: ./src/apps/codeai/deployments/production/deployment.yaml
+            outputs:
+              - name: envType
+                fromExpression: envType
+        - uses: git-clear
+          config:
+            path: ./out/apps/codeai/deployments/production/deploy
+        - uses: oci-download
+          config:
+            imageRef: ${{ vars.capsuleRepo }}:${{ imageFrom(vars.imageRepo).Tag }}
+            outPath: ./capsule.tgz
+        - uses: untar
+          config:
+            inPath: ./capsule.tgz
+            outPath: ./capsule
+        - uses: yaml-parse
+          as: capsule-release
+          config:
+            path: ./capsule/release.yaml
+            outputs:
+              - name: gitCommit
+                fromExpression: gitCommit
+              - name: imageRepo
+                fromExpression: image.repoURL
+              - name: imageTag
+                fromExpression: image.tag
+              - name: imageDigest
+                fromExpression: image.digest
+              - name: packageKind
+                fromExpression: package.kind
+              - name: packagePath
+                fromExpression: package.path
+        - uses: http
+          as: verify-release
+          config:
+            method: POST
+            url: http://codeai-release-verify.kargo-project-codeai.svc.cluster.local/verify
+            headers:
+              - name: Content-Type
+                value: application/json
+            body: |
+              ${{ quote({
+                "image": {
+                  "repoURL": imageFrom(vars.imageRepo).RepoURL,
+                  "tag": imageFrom(vars.imageRepo).Tag,
+                  "digest": imageFrom(vars.imageRepo).Digest
+                },
+                "capsule": {
+                  "repoURL": vars.capsuleRepo,
+                  "tag": imageFrom(vars.imageRepo).Tag
+                },
+                "release": {
+                  "gitCommit": outputs['capsule-release'].gitCommit,
+                  "imageRepo": outputs['capsule-release'].imageRepo,
+                  "imageTag": outputs['capsule-release'].imageTag,
+                  "imageDigest": outputs['capsule-release'].imageDigest,
+                  "packageKind": outputs['capsule-release'].packageKind,
+                  "packagePath": outputs['capsule-release'].packagePath
+                }
+              }) }}
+            successExpression: response.status == 200 && response.body.ok == true
+            failureExpression: response.status >= 400 || response.body.ok == false
+            outputs:
+              - name: verifiedPackageKind
+                fromExpression: response.body.release.packageKind
+        - uses: copy
+          config:
+            inPath: ./capsule/package/kustomize
+            outPath: ./work/deployments/source
+        - uses: copy
+          config:
+            inPath: ./src/apps/codeai/envTypes/${{ outputs['deployment-meta'].envType }}
+            outPath: ./work/deployments/envTypes/${{ outputs['deployment-meta'].envType }}
+        - uses: copy
+          config:
+            inPath: ./src/apps/codeai/envTypes/components
+            outPath: ./work/deployments/envTypes/components
+        - uses: copy
+          config:
+            inPath: ./src/apps/codeai/kargo/templates/deploy
+            outPath: ./work/deployments/production/deploy
+        # The temp wrapper template provides apiVersion/kind and one
+        # `images` entry whose match key is `code-dot-org`.
+        - uses: yaml-update
+          config:
+            path: ./work/deployments/production/deploy/kustomization.yaml
+            updates:
+              - key: namespace
+                value: ${{ outputs['deployment-meta'].namespace }}
+              - key: resources
+                value:
+                  - ../../source/base
+              - key: components
+                value:
+                  - ../../envTypes/${{ outputs['deployment-meta'].envType }}
+        - uses: kustomize-set-image
+          config:
+            path: ./work/deployments/production/deploy
+            images:
+              - image: code-dot-org
+                newName: ${{ vars.imageRepo }}
+                tag: ${{ imageFrom(vars.imageRepo).Tag }}
+        - uses: kustomize-build
+          config:
+            path: ./work/deployments/production/deploy
+            outPath: ./out/apps/codeai/deployments/production/deploy
+        - uses: git-commit
+          config:
+            path: ./out
+            message: |
+              Review production render from OCI capsule
+
+              image: ${{ imageFrom(vars.imageRepo).RepoURL }}:${{ imageFrom(vars.imageRepo).Tag }}
+              capsule: ${{ vars.capsuleRepo }}:${{ imageFrom(vars.imageRepo).Tag }}
+        - uses: git-push
+          as: push
+          config:
+            path: ./out
+            generateTargetBranch: true
+        - uses: git-open-pr
+          as: open-pr
+          config:
+            repoURL: ${{ vars.gitopsRepo }}
+            sourceBranch: ${{ outputs.push.branch }}
+            targetBranch: ${{ vars.targetBranch }}
+            title: Review CodeAI production render for ${{ imageFrom(vars.imageRepo).Tag }}
+        - uses: git-wait-for-pr
+          config:
+            repoURL: ${{ vars.gitopsRepo }}
+            prNumber: ${{ outputs['open-pr'].pr.id }}
+```
+
+That is the main reason the capsule plan is more natural in Helm first and more
+glue-heavy in packaging-agnostic/Kustomize mode.
+
+## Verifier response shape
+
+`codeai-release-verify` should return JSON shaped like:
+
+```json
+{
+  "ok": true,
+  "reason": "",
+  "release": {
+    "gitCommit": "0cc4cd87f40ae606d1822d5652b552f8c50a4668",
+    "packageKind": "helm",
+    "packagePath": "package/helm"
+  }
+}
+```
+
+On mismatch, return `ok: false` plus a short `reason`, for example
+`image digest mismatch between Freight and capsule release.yaml`.
+
+## GH runner sketch
+
+This runner is materially different from the Git-only plans:
+
+1. Build and stitch the app image exactly as today.
+2. Resolve the final pushed image digest.
+3. Create a temp capsule worktree such as:
+   - `release.yaml`
+   - `package/helm/...` or `package/kustomize/...`
+   - `metadata/sbom.json`
+   - `metadata/provenance.json`
+4. Copy the deploy package from:
+   - `k8s/helm/`
+   - or, for Kustomize, have the GH action populate `package/kustomize/` from
+     `k8s/kustomize/**`
+     - do not use `overlays/` or `bin/` from that tree in Kargo or Argo
+       production code paths; those are local-dev/parity support surfaces
+5. Write `release.yaml` with:
+   - `gitCommit`
+   - image repo/tag/digest
+   - `package.kind`
+   - `package.path`
+   - where `package.path` exactly matches the path Kargo will later read after
+     `oci-download` and unpack
+6. Package and push the OCI artifact to
+   `ghcr.io/code-dot-org/codeai-release-capsule:git-<full-commit-sha>`.
+7. Do not write a Git Freight record for the capsule form.
+8. Let the Kargo Warehouse stay image-led and have promotion derive the capsule
+   ref from the promoted image tag.
+
+If the team chooses the alternate OCI pair form instead of the full capsule,
+the GH runner should follow the pair-specific flow documented earlier in this
+plan: publish the package artifact separately, then write the Git witness that
+pairs image and package identity.
+The required implementation for this repo does not use that pair-specific flow.
+It implements the full capsule path above.
+
+### Testing Plan
+
+Recommended automation:
+- Extend [k8s.yml](/Users/seth/.codex/worktrees/684f/code-dot-org/.github/workflows/k8s.yml) or call a small reusable workflow from it for repo-specific capsule contract and render smoke checks.
+- Use existing Drone results on the promoted `gitCommit` as the app/unit/UI gate before downstream promotion.
+- Use Kargo `verification` with `AnalysisTemplate`s for post-sync rollout/health/smoke checks in `test`.
+
+Simple tests to automate:
+- In `k8s.yml`, after the capsule packaging step, unpack the OCI capsule build artifact in a temp dir and fail unless it contains `release.yaml`, `package/`, `metadata/sbom.json`, and `metadata/provenance.json`.
+- In the same workflow, parse `release.yaml` and fail unless `gitCommit`, `image.repoURL`, `image.tag`, `image.digest`, `package.kind`, and `package.path` are all present and internally consistent with the built `git-<full-commit-sha>` image tag, and unless the unpacked OCI artifact actually contains the package at that exact `package.path`.
+- For the Helm variant, run `helm template` from `package/helm` using deployment metadata from `apps/codeai/deployments/<deployment>/deployment.yaml`, envType values from `apps/codeai/envTypes/<envType>.values.yaml`, and deployment values from `apps/codeai/deployments/<deployment>/values.yaml`.
+- For the Kustomize variant, run `kustomize build` from a temp tree assembled from `package/kustomize/base`, `package/kustomize/components`, `apps/codeai/envTypes/<envType>/` as a Component, any referenced `apps/codeai/envTypes/components/` subcomponents such as `autoscaling`, and a copied `apps/codeai/kargo/templates/deploy/` dir whose `kustomization.yaml` `namespace`, `resources`, and `components` fields are updated before `kustomize-set-image` rewrites `code-dot-org` to `ghcr.io/code-dot-org/code-dot-org:git-<full-commit-sha>`. Do not use `code-dot-org/k8s/kustomize/overlays` or `bin/` in production code paths; those are local-dev/parity support only.
+- If `codeai-release-verify` is implemented in `code-dot-org`, test it with small local fixture/request-response contract cases in this repo, because that helper is our code and not part of Kargo itself.
+- In the same workflow, check out `k8s-gitops` read-only and validate [applicationset.yaml](/Users/seth/src/k8s-gitops/apps/codeai/applicationset.yaml) deploys `apps/codeai/deployments/{{path.basename}}/deploy` from `stage/{{path.basename}}`, because capsule plans still hand Argo rendered Git output.
+
+Avoid as baseline coverage:
+- A live registry + live `oci-download` + live controller test whose main purpose is re-testing OCI transport or Kargo internals. If upstream later documents a first-class OCI promotion verification flow, prefer that over bespoke harnessing.

--- a/k8s/docs/kargotecture/plans/iteration-7/rankings.md
+++ b/k8s/docs/kargotecture/plans/iteration-7/rankings.md
@@ -1,0 +1,118 @@
+# Iteration 7 Rankings
+
+This is a fresh ranking of the five iteration 7 finalists.
+
+This pass is intentionally anchored to:
+- long-term operational simplicity
+- a clear, understandable system
+- a real rendered diff review before production
+- the iteration 5 three-expert signal as continuity context, not as a veto
+
+The key interpretation rule for this iteration is:
+
+- if two plans can both give us the final rendered review gate we want, prefer
+  the one that leaves behind the simpler 10-year operating model
+
+## Weights
+
+| Axis | Weight |
+| --- | ---: |
+| KISS / operational simplicity | 3.0 |
+| Reviewability | 2.0 |
+| Future Kustomize fit | 0.7 |
+| Current Helm fit | 0.3 |
+| Does it break/awkwardize skaffold or local-dev in any way? | 1.0 |
+| Kargo-native fit | 1.0 |
+| Migration complexity | 0.2 |
+| Promotion clarity | 0.3 |
+| Artifact integrity / immutability | 0.3 |
+| Day-2 operability | 0.8 |
+
+## Best for
+
+- Best for KISS:
+  [Common-Case Freight + Rendered Branches](./common-case-rendered-branches.md)
+- Best for reviewability:
+  [Source Snapshot (Helm or Kustomize) + Rendered Branches](./source-snapshot-rendered-branches.md)
+- Best for future Kustomize:
+  [Source Snapshot (Helm or Kustomize) + Rendered Branches](./source-snapshot-rendered-branches.md)
+- Best for Kargo Native:
+  [Common-Case Freight + Rendered Branches](./common-case-rendered-branches.md)
+
+## Plan list
+
+1. [Common-Case Freight + Rendered Branches](./common-case-rendered-branches.md)
+2. [Source Snapshot (Helm or Kustomize) + Rendered Branches](./source-snapshot-rendered-branches.md)
+3. [Rendered Branches from a Thin Lock](./rendered-branches.md)
+4. [Argo Refs code-dot-org Commit](./argo-refs-code-dot-org-commit.md)
+5. [OCI Release Capsule](./oci-release-capsule.md)
+
+## Iteration 5 expert continuity
+
+Iteration 5 already produced an unusually strong consensus cluster:
+
+- Jesse normalized ranking:
+  `Source Snapshot + Render` `#1`, `Common-Case + Render` `#2`,
+  `Rendered Branches` `#3`
+- Original architect normalized ranking:
+  `Common-Case + Render` `#1`, `Rendered Branches` `#2`,
+  `Source Snapshot + Render` `#3`
+- Advisor rerank:
+  `Source Snapshot + Render` `#1`, `Common-Case + Render` `#2`,
+  `Rendered Branches` `#3`
+
+That means the real unresolved choice was never "which family wins?"
+
+It was:
+- `Common-Case` vs `Source Snapshot` for the best long-lived foundation
+- with `Rendered Branches from a Thin Lock` as the strongest explicit-control
+  variant
+
+Iteration 7 keeps that same top-three cluster.
+The main change is that this pass breaks the tie in favor of
+`Common-Case Freight + Rendered Branches` because it preserves the mandatory
+rendered review gate while deleting more synthetic release machinery than the
+snapshot family.
+
+## Why the top few landed where they did
+
+- `Common-Case Freight + Rendered Branches` won because it keeps the rendered
+  diff gate before production, uses the real release artifacts instead of a
+  synthetic lock or snapshot archive, and leaves behind the cleanest long-lived
+  operating model.
+- `Source Snapshot (Helm or Kustomize) + Rendered Branches` landed a very close
+  second because it gives the cleanest frozen-input review story and the
+  clearest explicit release payload, but it permanently carries a package-copy
+  system inside GitOps.
+- `Rendered Branches from a Thin Lock` stayed in the finalist tier because the
+  review surface is still excellent, but the tiny lock record becomes permanent
+  system furniture without beating the winner on simplicity.
+- `Argo Refs code-dot-org Commit` fell behind the rendered-branch leaders
+  because it gives up the thing we explicitly want most: final review of the
+  rendered Helm/Kustomize output before production.
+- `OCI Release Capsule` remained the strongest immutable-artifact alternative,
+  but it still adds more release-system machinery than the simpler rendered-Git
+  winners.
+
+## What changed since the prior iteration
+
+- This pass does not treat the current repo layout as the ranking anchor.
+  Current repos were used as feasibility context only.
+- The ranking is re-centered on the 10-year operating model:
+  simpler, clearer, more elegant, and still able to produce a true final diff
+  review before production.
+- That shift moves the source-driven `Argo Refs` family down, because it does
+  not make rendered review first-class.
+- It also moves `Common-Case + Render` slightly ahead of
+  `Source Snapshot + Render`: once both satisfy reviewability, removing
+  synthetic release artifacts matters more.
+
+## Weighted rankings
+
+| Rank | Plan | KISS | Review | Kustomize | Helm | Local Dev | Kargo | Migration | Clarity | Immutable | Day-2 | Weighted |
+| ---: | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| 1 | [Common-Case Freight + Rendered Branches](./common-case-rendered-branches.md) | 4 | 5 | 5 | 4 | 5 | 5 | 3 | 4 | 3 | 4 | **42.6** |
+| 2 | [Source Snapshot (Helm or Kustomize) + Rendered Branches](./source-snapshot-rendered-branches.md) | 4 | 5 | 5 | 4 | 5 | 3 | 3 | 5 | 5 | 4 | **41.5** |
+| 3 | [Rendered Branches from a Thin Lock](./rendered-branches.md) | 3 | 5 | 5 | 4 | 5 | 4 | 4 | 5 | 3 | 4 | **39.1** |
+| 4 | [Argo Refs code-dot-org Commit](./argo-refs-code-dot-org-commit.md) | 4 | 2 | 4 | 4 | 5 | 3 | 4 | 3 | 3 | 4 | **33.8** |
+| 5 | [OCI Release Capsule](./oci-release-capsule.md) | 2 | 4 | 4 | 3 | 5 | 3 | 2 | 4 | 5 | 3 | **31.2** |

--- a/k8s/docs/kargotecture/plans/iteration-7/rendered-branches.md
+++ b/k8s/docs/kargotecture/plans/iteration-7/rendered-branches.md
@@ -1,0 +1,798 @@
+# Rendered Branches from a Thin Lock
+
+**Short name:** Rendered branches
+
+**Catchy description:** Keep the warehouse artifact tiny, but make every promotion render full stage-specific manifests into stage branches so humans review the real output, not just a ref change.
+
+## Detailed Technical Description of Plan
+This plan keeps the release signal intentionally small: a single Git build-lock record in `k8s-gitops` identifies the exact `code-dot-org` commit and image tag to promote, but it does not store rendered manifests as Freight. Kargo uses that lock only as the release coordinate. The real work happens during promotion, where Kargo checks out the exact source commit, combines it with the latest GitOps environment policy, and writes stage-specific rendered output into `k8s-gitops` stage branches. Argo CD then deploys from those rendered branches, so the thing humans review is the actual manifest output that will hit the cluster.
+
+The technical trick is that the plan supports both Helm and Kustomize without changing the release model. For Helm, promotion renders directly from `code-dot-org/k8s/helm` using values from `k8s-gitops/apps/codeai/envTypes/` and `apps/codeai/deployments/<deployment>/values.yaml`. For Kustomize, promotion starts from the checked-in `code-dot-org/k8s/kustomize/` tree plus the GitOps envType components and a reusable deploy-wrapper template in `k8s-gitops`; the wrapper is copied into a temp work dir, rewritten for the target deployment, and then built into the rendered branch. The important distinction is that Helm and Kustomize differ only in how the package is materialized at promotion time, not in how Freight is identified or how the stage branches are consumed.
+
+The tricky parts are the ones that make the reviewable-output model honest. Promotion has to render from the exact promoted commit, not from the moving branch tip, and it has to write into a stage-specific branch/path that Argo can watch directly. `review-infra-changes` is the key control point: production output is rendered to a PR branch, reviewed as generated manifests, and only then merged into `stage/production`. That makes this plan fundamentally different from the thin-lock or source-snapshot families: the lock is tiny, but the review surface is the full rendered manifest tree, so the implementation must preserve a clean split between source checkout, GitOps policy, and generated output.
+
+- **Type:** Packaging-agnostic
+- **Pattern:** Hybrid
+- **Rendered manifests pattern:** Yes
+
+## What Freight Looks Like
+This plan promotes a tiny Git lock file, then does the real rendering work
+during promotion.
+
+```text
+warehouses/codeai/builds/
+  current.yaml
+  git-<full-commit-sha>.yaml
+```
+
+```yaml
+releaseId: git-<full-commit-sha>
+gitCommit: <full-commit-sha>
+image:
+  ref: ghcr.io/code-dot-org/code-dot-org:git-<full-commit-sha>
+  digest: sha256:...
+packaging:
+  kind: helm # or kustomize
+  sourcePath: k8s/helm # or k8s/kustomize
+```
+
+## Warehouse artifact
+Same release record shape as Argo Refs code-dot-org Commit:
+
+```text
+warehouses/
+  codeai/
+    builds/
+      current.yaml
+      git-<full-commit-sha>.yaml
+```
+
+The lock file contains:
+- `$gitcommit`
+- image ref + digest
+- packaging kind
+- source path
+
+The canonical lock-file schema lives in
+[Git Build-Lock Freight Record](../modules/git-build-lock-freight-record.md)
+and must be followed exactly.
+
+## Freight
+Freight is **Git-only** from `warehouses/codeai/builds/`.
+
+The build lock is just the trigger. Promotion does the expensive work.
+
+## Kargo project
+Stages:
+- `staging`
+- `test`
+- `levelbuilder`
+- `review-infra-changes`
+- `production`
+
+Promotion pattern:
+1. Clone `k8s-gitops` at the exact promoted Freight commit to `./freight`.
+2. Clone `k8s-gitops` `main` to `./meta`.
+3. Parse `./freight/warehouses/codeai/builds/current.yaml`.
+4. Clone `code-dot-org` at `$gitcommit` to `./src`.
+5. Clone the target stage branch to `./out`.
+6. Render the stage’s manifests from source + env config.
+7. Commit and push rendered output.
+8. Let Argo CD deploy from the long-lived stage branch tip.
+
+This is the closest CodeAI analogue to `kargo-advanced`.
+
+## Stage-by-stage promotion flow
+- `staging`: render manifests for the staging env and commit to a staging output branch/path
+- `test`: render manifests for the test env from the same freight and run automated tests
+- `levelbuilder`: render levelbuilder manifests from the same freight after `test`
+- `review-infra-changes`: render production manifests to a generated branch and open a PR
+- `production`: merge or fast-forward the reviewed rendered output
+
+This model keeps freight stable but changes how each stage materializes it.
+
+## Helm / Kustomize structure
+This plan works with both Helm and Kustomize.
+
+### Helm shape
+Render from:
+- `code-dot-org/k8s/helm`
+- plus env values in `k8s-gitops/apps/codeai/...`
+
+### Kustomize shape
+Render from:
+- `code-dot-org/k8s/kustomize/...`
+- plus envType Components and render templates in `k8s-gitops`
+
+The copied `apps/codeai/kargo/templates/deploy/kustomization.yaml` is a shared
+contract for this plan family. Contractors should start from that canonical
+wrapper and mutate it in place for the target deployment; they should not
+invent plan-local wrapper contents.
+
+### Suggested `k8s-gitops` addition
+
+```text
+apps/codeai/
+  deployments/
+    <deployment>/
+      deployment.yaml
+      values.yaml
+  envTypes/
+    <envType>/
+  kargo/
+    templates/
+      deploy/
+        kustomization.yaml
+```
+
+Argo apps should point at rendered stage paths or rendered stage branches.
+
+## Does it break/awkwardize skaffold or local-dev in any way?
+No. Local Skaffold still uses source packaging in `code-dot-org`. Rendering happens only in Kargo promotion.
+
+## Pros
+- much stronger reviewability
+- Argo deploys exactly what Kargo rendered
+- supports both Helm now and Kustomize later
+- maps closely to upstream Kargo’s rendered-branch pattern
+
+## Cons
+- more moving parts than Thin Lock
+- requires rendered-output paths/branches and corresponding Argo changes
+- stage output is derived, not hand-edited
+
+## Migration notes
+- Add rendered output locations and move Argo apps to them.
+- Introduce `helm-template` or `kustomize-build` promotion steps.
+- Add PR-based `review-infra-changes`.
+
+## Additional implementation notes
+- For Helm, prefer `helm-template` to render into a directory so diffs stay readable.
+- For Kustomize, prefer `kustomize-build` with directory output.
+- This is likely to score very highly on reviewability.
+
+## Iteration 7 notes
+- Keep this as the strongest explicit-control / rendered-review variant.
+- This is the natural answer if the team wants strong PR review of real output without snapshotting the package into Freight.
+
+# Code changes
+## `k8s-gitops` changes
+- Add `warehouses/codeai/builds/`
+- Add `apps/codeai/deployments/<deployment>/deploy/` on long-lived
+  `stage/<deployment>` branches
+- Add `apps/codeai/kargo/templates/deploy/kustomization.yaml` as the generic
+  Kustomize temp-wrapper template copied into promotion work dirs
+- Rewrite CodeAI stages to:
+  - parse build lock
+  - clone `code-dot-org` at `$gitcommit`
+  - render stage manifests
+  - commit rendered output
+- Update Argo Applications to point at rendered output
+- Add `review-infra-changes` PR stage
+
+## `code-dot-org` changes
+- Rewrite `k8s-commit-to-kargo-warehouse.yml` to write build locks only
+- No required packaging-tree change for the first version
+
+## modules that are part of implementing this plan
+- [Gate Promotion On Legacy Gitflow Branches](../modules/gate-promotion-on-legacy-gitflow-branches.md)
+- [Git Build-Lock Freight Record](../modules/git-build-lock-freight-record.md)
+- [Rendered Stage Branches and PR Review](../modules/rendered-stage-branches-and-pr-review.md)
+- [Live Source Checkout at Freight Commit](../modules/live-source-checkout-at-freight-commit.md)
+
+# Sketch of Pivotal Implementation Details
+
+## Shared mechanics
+
+This plan reuses:
+- [Git Build-Lock Freight Record](../modules/git-build-lock-freight-record.md)
+- [Rendered Stage Branches and PR Review](../modules/rendered-stage-branches-and-pr-review.md)
+- [Gate Promotion On Legacy Gitflow Branches](../modules/gate-promotion-on-legacy-gitflow-branches.md)
+- [Live Source Checkout at Freight Commit](../modules/live-source-checkout-at-freight-commit.md)
+
+## Helm implementation starting point
+
+Treat the checked-in `code-dot-org/k8s/helm/` tree as the starting point, not a
+frozen contract. The implementor may modify or reshape `k8s/helm/` if this plan
+benefits from it, but should preserve current behavior unless the change
+materially improves the plan.
+
+## Kustomize implementation starting point
+
+Treat the checked-in `code-dot-org/k8s/kustomize/` tree as the starting point,
+not a frozen contract. The implementor may modify or reshape `k8s/kustomize/`
+as needed for this plan, especially the base/components layout.
+
+Use the current `k8s-gitops/apps/codeai/envTypes/<envType>/kustomization.yaml`
+files as the starting envType Component contract. `production` may
+additionally layer in `apps/codeai/envTypes/components/autoscaling/`.
+
+Rendered-family Kustomize stages should not read a committed
+`apps/codeai/deployments/<deployment>/deploy/` tree from `main`. Instead, keep
+a generic deploy-dir template at `apps/codeai/kargo/templates/deploy/`, copy
+that directory into a temp work dir during promotion, then update the copied
+`kustomization.yaml` `namespace`, `resources`, and `components` before running
+`kustomize-set-image`.
+
+Do not treat `code-dot-org/k8s/kustomize/overlays/*` as the production deploy
+contract unless the plan explicitly chooses to adopt them. Those directories are
+currently local-dev/parity support, as is `code-dot-org/k8s/kustomize/bin/`.
+
+## `codeai/applicationset.yaml` sketch
+
+This plan should keep using `apps/codeai/deployments/*/deployment.yaml` on
+`main` as the generator input, but Argo should deploy from the rendered
+`deploy/` dir on each stage branch:
+
+```yaml
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: codeai
+  namespace: argocd
+spec:
+  generators:
+    - git:
+        repoURL: https://github.com/code-dot-org/k8s-gitops.git
+        revision: main
+        files:
+          - path: apps/codeai/deployments/*/deployment.yaml
+  template:
+    metadata:
+      name: codeai-{{path.basename}}
+    spec:
+      sources:
+        - repoURL: https://github.com/code-dot-org/k8s-gitops.git
+          targetRevision: stage/{{path.basename}}
+          path: apps/codeai/deployments/{{path.basename}}/deploy
+      destination:
+        server: https://kubernetes.default.svc
+        namespace: '{{namespace}}'
+```
+
+## Warehouse sketch
+
+The Warehouse is the shared Git-only build-lock form. The interesting work in
+this plan starts after the lock file is parsed.
+
+## Hard parts
+
+This plan has two real hard parts:
+
+1. keep the promoted build-lock parse path deterministic with `current.yaml`
+   while still preserving one historical `git-<full-commit-sha>.yaml` per release
+2. check out the exact promoted `code-dot-org` commit sparsely enough that the
+   huge monorepo does not make promotion too expensive
+
+Both are shown explicitly below.
+
+## Example `staging` Stage
+
+```yaml
+apiVersion: kargo.akuity.io/v1alpha1
+kind: Stage
+metadata:
+  name: staging
+  namespace: kargo-project-codeai
+spec:
+  requestedFreight:
+    - origin:
+        kind: Warehouse
+        name: codeai-builds
+      sources:
+        direct: true
+  vars:
+    - name: gitopsRepo
+      value: https://github.com/code-dot-org/k8s-gitops.git
+    - name: sourceRepo
+      value: https://github.com/code-dot-org/code-dot-org.git
+    - name: imageRepo
+      value: ghcr.io/code-dot-org/code-dot-org
+    - name: targetBranch
+      value: stage/${{ ctx.stage }}
+  promotionTemplate:
+    spec:
+      steps:
+        - uses: git-clone
+          config:
+            repoURL: ${{ vars.gitopsRepo }}
+            checkout:
+              - commit: ${{ commitFrom(vars.gitopsRepo, warehouse('codeai-builds')).ID }}
+                path: ./freight
+              - branch: main
+                path: ./meta
+              - branch: ${{ vars.targetBranch }}
+                create: true
+                path: ./out
+
+        - uses: yaml-parse
+          as: build-lock
+          config:
+            path: ./freight/warehouses/codeai/builds/current.yaml
+            outputs:
+              - name: releaseId
+                fromExpression: releaseId
+              - name: gitCommit
+                fromExpression: gitCommit
+
+        - uses: yaml-parse
+          as: deployment-meta
+          config:
+            path: ./meta/apps/codeai/deployments/${{ ctx.stage }}/deployment.yaml
+            outputs:
+              - name: envType
+                fromExpression: envType
+
+        - uses: git-clone
+          config:
+            repoURL: ${{ vars.sourceRepo }}
+            checkout:
+              - commit: ${{ outputs['build-lock'].gitCommit }}
+                path: ./src
+                sparse:
+                  - k8s/helm
+                  - k8s/kustomize
+
+        - uses: git-clear
+          config:
+            path: ./out/apps/codeai/deployments/${{ ctx.stage }}/deploy
+
+        # For Helm:
+        - uses: helm-template
+          config:
+            path: ./src/k8s/helm
+            releaseName: codeai
+            outPath: ./out/apps/codeai/deployments/${{ ctx.stage }}/deploy
+            valuesFiles:
+              - ./meta/apps/codeai/envTypes/${{ outputs['deployment-meta'].envType }}.values.yaml
+              - ./meta/apps/codeai/deployments/${{ ctx.stage }}/values.yaml
+            setValues:
+              - key: image.repository
+                value: ${{ vars.imageRepo }}
+              - key: image.tag
+                value: ${{ outputs['build-lock'].releaseId }}
+
+        - uses: git-commit
+          config:
+            path: ./out
+            message: Render ${{ ctx.stage }} for ${{ outputs['build-lock'].releaseId }}
+
+        - uses: git-push
+          config:
+            path: ./out
+            branch: ${{ vars.targetBranch }}
+```
+
+## Example `staging` Stage for Kustomize
+
+```yaml
+apiVersion: kargo.akuity.io/v1alpha1
+kind: Stage
+metadata:
+  name: staging
+  namespace: kargo-project-codeai
+spec:
+  requestedFreight:
+    - origin:
+        kind: Warehouse
+        name: codeai-builds
+      sources:
+        direct: true
+  vars:
+    - name: gitopsRepo
+      value: https://github.com/code-dot-org/k8s-gitops.git
+    - name: sourceRepo
+      value: https://github.com/code-dot-org/code-dot-org.git
+    - name: imageRepo
+      value: ghcr.io/code-dot-org/code-dot-org
+    - name: targetBranch
+      value: stage/${{ ctx.stage }}
+  promotionTemplate:
+    spec:
+      steps:
+        - uses: git-clone
+          config:
+            repoURL: ${{ vars.gitopsRepo }}
+            checkout:
+              - commit: ${{ commitFrom(vars.gitopsRepo, warehouse('codeai-builds')).ID }}
+                path: ./freight
+              - branch: main
+                path: ./meta
+              - branch: ${{ vars.targetBranch }}
+                create: true
+                path: ./out
+
+        - uses: yaml-parse
+          as: build-lock
+          config:
+            path: ./freight/warehouses/codeai/builds/current.yaml
+            outputs:
+              - name: releaseId
+                fromExpression: releaseId
+              - name: gitCommit
+                fromExpression: gitCommit
+
+        - uses: yaml-parse
+          as: deployment-meta
+          config:
+            path: ./meta/apps/codeai/deployments/${{ ctx.stage }}/deployment.yaml
+            outputs:
+              - name: envType
+                fromExpression: envType
+              - name: namespace
+                fromExpression: namespace
+
+        - uses: git-clone
+          config:
+            repoURL: ${{ vars.sourceRepo }}
+            checkout:
+              - commit: ${{ outputs['build-lock'].gitCommit }}
+                path: ./src
+                sparse:
+                  - k8s/kustomize
+
+        - uses: git-clear
+          config:
+            path: ./out/apps/codeai/deployments/${{ ctx.stage }}/deploy
+
+        - uses: copy
+          config:
+            inPath: ./src/k8s/kustomize
+            outPath: ./work/deployments/source
+
+        - uses: copy
+          config:
+            inPath: ./meta/apps/codeai/envTypes/${{ outputs['deployment-meta'].envType }}
+            outPath: ./work/deployments/envTypes/${{ outputs['deployment-meta'].envType }}
+
+        - uses: copy
+          config:
+            inPath: ./meta/apps/codeai/envTypes/components
+            outPath: ./work/deployments/envTypes/components
+
+        - uses: copy
+          config:
+            inPath: ./meta/apps/codeai/kargo/templates/deploy
+            outPath: ./work/deployments/${{ ctx.stage }}/deploy
+
+        # The temp wrapper template provides apiVersion/kind and one
+        # `images` entry whose match key is `code-dot-org`.
+        - uses: yaml-update
+          config:
+            path: ./work/deployments/${{ ctx.stage }}/deploy/kustomization.yaml
+            updates:
+              - key: namespace
+                value: ${{ outputs['deployment-meta'].namespace }}
+              - key: resources
+                value:
+                  - ../../source/base
+              - key: components
+                value:
+                  - ../../envTypes/${{ outputs['deployment-meta'].envType }}
+
+        - uses: kustomize-set-image
+          config:
+            path: ./work/deployments/${{ ctx.stage }}/deploy
+            images:
+              - image: code-dot-org
+                newName: ${{ vars.imageRepo }}
+                tag: ${{ outputs['build-lock'].releaseId }}
+
+        - uses: kustomize-build
+          config:
+            path: ./work/deployments/${{ ctx.stage }}/deploy
+            outPath: ./out/apps/codeai/deployments/${{ ctx.stage }}/deploy
+
+        - uses: git-commit
+          config:
+            path: ./out
+            message: Render ${{ ctx.stage }} for ${{ outputs['build-lock'].releaseId }}
+
+        - uses: git-push
+          config:
+            path: ./out
+            branch: ${{ vars.targetBranch }}
+```
+
+## Example `review-infra-changes` Stage
+
+```yaml
+apiVersion: kargo.akuity.io/v1alpha1
+kind: Stage
+metadata:
+  name: review-infra-changes
+  namespace: kargo-project-codeai
+spec:
+  requestedFreight:
+    - origin:
+        kind: Warehouse
+        name: codeai-builds
+      sources:
+        stages:
+          - test
+  vars:
+    - name: gitopsRepo
+      value: https://github.com/code-dot-org/k8s-gitops.git
+    - name: sourceRepo
+      value: https://github.com/code-dot-org/code-dot-org.git
+    - name: imageRepo
+      value: ghcr.io/code-dot-org/code-dot-org
+    - name: targetBranch
+      value: stage/production
+    - name: renderDeployment
+      value: production
+    - name: renderPath
+      value: apps/codeai/deployments/production/deploy
+  promotionTemplate:
+    spec:
+      steps:
+        - uses: git-clone
+          config:
+            repoURL: ${{ vars.gitopsRepo }}
+            checkout:
+              - commit: ${{ commitFrom(vars.gitopsRepo, warehouse('codeai-builds')).ID }}
+                path: ./freight
+              - branch: main
+                path: ./meta
+              - branch: ${{ vars.targetBranch }}
+                create: true
+                path: ./out
+
+        - uses: yaml-parse
+          as: build-lock
+          config:
+            path: ./freight/warehouses/codeai/builds/current.yaml
+            outputs:
+              - name: releaseId
+                fromExpression: releaseId
+              - name: gitCommit
+                fromExpression: gitCommit
+
+        - uses: yaml-parse
+          as: deployment-meta
+          config:
+            path: ./meta/apps/codeai/deployments/${{ vars.renderDeployment }}/deployment.yaml
+            outputs:
+              - name: envType
+                fromExpression: envType
+              - name: namespace
+                fromExpression: namespace
+
+        - uses: git-clone
+          config:
+            repoURL: ${{ vars.sourceRepo }}
+            checkout:
+              - commit: ${{ outputs['build-lock'].gitCommit }}
+                path: ./src
+                sparse:
+                  - k8s/helm
+
+        - uses: git-clear
+          config:
+            path: ./out/${{ vars.renderPath }}
+
+        - uses: helm-template
+          config:
+            path: ./src/k8s/helm
+            releaseName: codeai
+            outPath: ./out/${{ vars.renderPath }}
+            valuesFiles:
+              - ./meta/apps/codeai/envTypes/${{ outputs['deployment-meta'].envType }}.values.yaml
+              - ./meta/apps/codeai/deployments/${{ vars.renderDeployment }}/values.yaml
+            setValues:
+              - key: image.repository
+                value: ${{ vars.imageRepo }}
+              - key: image.tag
+                value: ${{ outputs['build-lock'].releaseId }}
+
+        - uses: git-commit
+          config:
+            path: ./out
+            message: Review production render for ${{ outputs['build-lock'].releaseId }}
+
+        - uses: git-push
+          as: push
+          config:
+            path: ./out
+            generateTargetBranch: true
+
+        - uses: git-open-pr
+          as: open-pr
+          config:
+            repoURL: ${{ vars.gitopsRepo }}
+            sourceBranch: ${{ outputs.push.branch }}
+            targetBranch: ${{ vars.targetBranch }}
+            title: Review CodeAI production render for ${{ outputs['build-lock'].releaseId }}
+
+        - uses: git-wait-for-pr
+          config:
+            repoURL: ${{ vars.gitopsRepo }}
+            prNumber: ${{ outputs['open-pr'].pr.id }}
+```
+
+## Example `review-infra-changes` Stage for Kustomize
+
+```yaml
+apiVersion: kargo.akuity.io/v1alpha1
+kind: Stage
+metadata:
+  name: review-infra-changes
+  namespace: kargo-project-codeai
+spec:
+  requestedFreight:
+    - origin:
+        kind: Warehouse
+        name: codeai-builds
+      sources:
+        stages:
+          - test
+  vars:
+    - name: gitopsRepo
+      value: https://github.com/code-dot-org/k8s-gitops.git
+    - name: sourceRepo
+      value: https://github.com/code-dot-org/code-dot-org.git
+    - name: imageRepo
+      value: ghcr.io/code-dot-org/code-dot-org
+    - name: targetBranch
+      value: stage/production
+    - name: renderDeployment
+      value: production
+    - name: renderPath
+      value: apps/codeai/deployments/production/deploy
+  promotionTemplate:
+    spec:
+      steps:
+        - uses: git-clone
+          config:
+            repoURL: ${{ vars.gitopsRepo }}
+            checkout:
+              - commit: ${{ commitFrom(vars.gitopsRepo, warehouse('codeai-builds')).ID }}
+                path: ./freight
+              - branch: main
+                path: ./meta
+              - branch: ${{ vars.targetBranch }}
+                create: true
+                path: ./out
+
+        - uses: yaml-parse
+          as: build-lock
+          config:
+            path: ./freight/warehouses/codeai/builds/current.yaml
+            outputs:
+              - name: releaseId
+                fromExpression: releaseId
+              - name: gitCommit
+                fromExpression: gitCommit
+
+        - uses: yaml-parse
+          as: deployment-meta
+          config:
+            path: ./meta/apps/codeai/deployments/${{ vars.renderDeployment }}/deployment.yaml
+            outputs:
+              - name: envType
+                fromExpression: envType
+              - name: namespace
+                fromExpression: namespace
+
+        - uses: git-clone
+          config:
+            repoURL: ${{ vars.sourceRepo }}
+            checkout:
+              - commit: ${{ outputs['build-lock'].gitCommit }}
+                path: ./src
+                sparse:
+                  - k8s/kustomize
+
+        - uses: git-clear
+          config:
+            path: ./out/${{ vars.renderPath }}
+
+        - uses: copy
+          config:
+            inPath: ./src/k8s/kustomize
+            outPath: ./work/deployments/source
+
+        - uses: copy
+          config:
+            inPath: ./meta/apps/codeai/envTypes/${{ outputs['deployment-meta'].envType }}
+            outPath: ./work/deployments/envTypes/${{ outputs['deployment-meta'].envType }}
+
+        - uses: copy
+          config:
+            inPath: ./meta/apps/codeai/envTypes/components
+            outPath: ./work/deployments/envTypes/components
+
+        - uses: copy
+          config:
+            inPath: ./meta/apps/codeai/kargo/templates/deploy
+            outPath: ./work/deployments/${{ vars.renderDeployment }}/deploy
+
+        # The temp wrapper template provides apiVersion/kind and one
+        # `images` entry whose match key is `code-dot-org`.
+        - uses: yaml-update
+          config:
+            path: ./work/deployments/${{ vars.renderDeployment }}/deploy/kustomization.yaml
+            updates:
+              - key: namespace
+                value: ${{ outputs['deployment-meta'].namespace }}
+              - key: resources
+                value:
+                  - ../../source/base
+              - key: components
+                value:
+                  - ../../envTypes/${{ outputs['deployment-meta'].envType }}
+
+        - uses: kustomize-set-image
+          config:
+            path: ./work/deployments/${{ vars.renderDeployment }}/deploy
+            images:
+              - image: code-dot-org
+                newName: ${{ vars.imageRepo }}
+                tag: ${{ outputs['build-lock'].releaseId }}
+
+        - uses: kustomize-build
+          config:
+            path: ./work/deployments/${{ vars.renderDeployment }}/deploy
+            outPath: ./out/${{ vars.renderPath }}
+
+        - uses: git-commit
+          config:
+            path: ./out
+            message: Review production render for ${{ outputs['build-lock'].releaseId }}
+
+        - uses: git-push
+          as: push
+          config:
+            path: ./out
+            generateTargetBranch: true
+
+        - uses: git-open-pr
+          as: open-pr
+          config:
+            repoURL: ${{ vars.gitopsRepo }}
+            sourceBranch: ${{ outputs.push.branch }}
+            targetBranch: ${{ vars.targetBranch }}
+            title: Review CodeAI production render for ${{ outputs['build-lock'].releaseId }}
+
+        - uses: git-wait-for-pr
+          config:
+            repoURL: ${{ vars.gitopsRepo }}
+            prNumber: ${{ outputs['open-pr'].pr.id }}
+```
+
+The exact live-source sparse checkout pattern is still shared in
+[Live Source Checkout at Freight Commit](../modules/live-source-checkout-at-freight-commit.md).
+
+## GH runner sketch
+
+The runner is the same thin build-lock writer used by Argo Refs code-dot-org Commit:
+
+1. Build and stitch the image.
+2. Publish immutable `git-<full-commit-sha>` tag.
+3. Write `warehouses/codeai/builds/git-<full-commit-sha>.yaml`.
+4. Do not render in CI.
+5. Let Kargo do the rendering during promotion.
+
+Helm and Kustomize are identical on the CI side; the workflow only emits image
+tags and build-lock metadata, and the variants diverge later at promotion time
+through `packaging.kind` and `sourcePath`.
+
+That is the key difference from `Source Snapshot`: this plan keeps CI cheap and
+pushes the expensive render/source read into Kargo promotion time.
+
+### Testing Plan
+
+Recommended automation:
+- Extend [k8s.yml](/Users/seth/.codex/worktrees/684f/code-dot-org/.github/workflows/k8s.yml) or call a small reusable workflow from it for repo-specific contract and render smoke checks.
+- Use existing Drone results on the promoted `gitCommit` as the app/unit/UI gate before downstream promotion.
+- Use Kargo `verification` with `AnalysisTemplate`s for post-sync rollout/health/smoke checks in `test`.
+
+Simple tests to automate:
+- In `k8s.yml`, after the build-lock writeback step, parse `warehouses/codeai/builds/current.yaml` and `git-<full-commit-sha>.yaml` and fail unless they are schema-valid and identical.
+- In the same workflow, check out `k8s-gitops` read-only and validate [applicationset.yaml](/Users/seth/src/k8s-gitops/apps/codeai/applicationset.yaml) reads `apps/codeai/deployments/*/deployment.yaml` from `main` and deploys `apps/codeai/deployments/{{path.basename}}/deploy` from `stage/{{path.basename}}`.
+- In the same workflow, validate every deployment dir on `main` has `deployment.yaml`, and that rendered-review plans reserve `deploy/` as the render target path.
+- For the Helm variant, run `helm template` from [/Users/seth/.codex/worktrees/684f/code-dot-org/k8s/helm](/Users/seth/.codex/worktrees/684f/code-dot-org/k8s/helm) using deployment metadata from `apps/codeai/deployments/<deployment>/deployment.yaml`, envType values from `apps/codeai/envTypes/<envType>.values.yaml`, and deployment values from `apps/codeai/deployments/<deployment>/values.yaml`, writing to a temp `apps/codeai/deployments/<deployment>/deploy/` tree.
+- For the Kustomize variant, run `kustomize build` from a temp tree assembled from the checked-in `k8s/kustomize/` source, `apps/codeai/envTypes/<envType>/` as a Component, any referenced `apps/codeai/envTypes/components/` subcomponents such as `autoscaling`, and a copied `apps/codeai/kargo/templates/deploy/` dir whose `kustomization.yaml` `namespace`, `resources`, and `components` fields are updated before `kustomize-set-image` rewrites `code-dot-org` to `ghcr.io/code-dot-org/code-dot-org:git-<full-commit-sha>`. Do not use `k8s/kustomize/overlays` or `bin/` in production code paths.
+
+Avoid as baseline coverage:
+- A live Kargo controller harness whose main purpose is proving sparse checkout behaves inside the controller. If upstream later documents a first-class promotion-template test or preflight for this pattern, prefer that over custom harness code.

--- a/k8s/docs/kargotecture/plans/iteration-7/source-snapshot-rendered-branches.md
+++ b/k8s/docs/kargotecture/plans/iteration-7/source-snapshot-rendered-branches.md
@@ -1,0 +1,1000 @@
+# Source Snapshot (Helm or Kustomize) + Rendered Branches
+
+**Short name:** Source snapshot + render
+
+**Catchy description:** Freeze the deploy source package once per release, keep environment policy in GitOps, and let Kargo render stage-specific outputs from that frozen snapshot into reviewable rendered branches.
+
+## Detailed Technical Description of Plan
+This plan is the middle ground between live-source rendering and a richer OCI release artifact: CI freezes the deploy package once, writes that snapshot into `warehouses/codeai/freight/git-<full-commit-sha>/`, mirrors the exact same contents to `current/`, and then Kargo renders every downstream stage from that frozen release record. Promotion does not chase the moving `code-dot-org` branch tip. It reads `warehouses/codeai/freight/current/freight.yaml`, resolves the release identity and package type from there, and uses GitOps-side env policy to materialize the stage-specific output into a rendered branch. That gives you a release object that is still plain Git, still reviewable, and still easy to audit by path, but without the ambiguity of reconstructing release truth from live source during promotion.
+
+The Helm and Kustomize forms share the same Freight contract but differ in how the snapshot is consumed. In the Helm form, the snapshot is just the chart source under `helm/`, so promotion is mostly `helm-template` plus the usual values files from `k8s-gitops`. In the Kustomize form, the snapshot is the durable `k8s/kustomize/` tree, but promotion still does not render from that tree directly. Instead, Kargo assembles a temporary deploy wrapper from `k8s-gitops/apps/codeai/kargo/templates/deploy/`, layers in the envType `Component` files from `apps/codeai/envTypes/<envType>/`, and points that wrapper at the frozen `base/` and `components/` payload in the snapshot before running `kustomize-build`. The important implementation detail is that the snapshot stays literal while the stage branch becomes the only mutable review surface.
+
+The tricky part is not the rendering step itself; it is keeping the snapshot contract disciplined. `current/` must remain an exact mirror of the historical `git-<full-commit-sha>/` directory in the same commit, because promotion reads only `current/` while humans and audit tooling may inspect the historical release directory. That makes this plan easier to reason about than the live-source plans, which must sparse-checkout the huge monorepo at the promoted commit, but less compact than the thin-lock family because it duplicates the deploy package into GitOps-adjacent Freight. In practice, this is the plan to choose when you want frozen release inputs and rendered-branch reviewability without introducing a second artifact system.
+
+- **Type:** Packaging-agnostic
+- **Pattern:** Hybrid
+- **Rendered manifests pattern:** Yes
+
+## What Freight Looks Like
+This plan promotes one frozen Git snapshot per release. The snapshot already
+contains the exact deploy package Kargo should render from.
+
+```text
+warehouses/codeai/freight/git-<full-commit-sha>/
+  freight.yaml
+  helm/
+# or
+  kustomize/
+    kustomization.yaml
+warehouses/codeai/freight/current/
+  freight.yaml
+  helm/
+# or
+  kustomize/
+    kustomization.yaml
+```
+
+```yaml
+revision: <full-commit-sha>
+tag: git-<full-commit-sha>
+image:
+  ref: ghcr.io/code-dot-org/code-dot-org:git-<full-commit-sha>
+  digest: sha256:...
+packageType: helm # or kustomize
+```
+
+## Warehouse artifact
+On each successful build, publish one freight directory:
+
+```text
+warehouses/
+  codeai/
+    freight/
+      current/
+        freight.yaml
+        helm/         # Helm
+        # or:
+        kustomize/    # Kustomize
+          kustomization.yaml
+      git-<full-commit-sha>/
+        freight.yaml
+        helm/         # Helm
+        # or:
+        kustomize/    # Kustomize
+          kustomization.yaml
+```
+
+Recommended `freight.yaml`:
+
+```yaml
+schemaVersion: v1
+revision: <full-commit-sha>
+tag: git-<full-commit-sha>
+image:
+  ref: ghcr.io/code-dot-org/code-dot-org:git-<full-commit-sha>
+  digest: sha256:...
+packageType: helm # or kustomize
+createdAt: 2026-03-22T12:34:56Z
+```
+
+Common rules:
+- use `git-<full-commit-sha>` as the operator-facing release/tag shape
+- keep the full 40-character SHA in structured metadata
+- snapshot only the deploy package, not the whole monorepo
+- keep env-specific policy out of the snapshot and in `k8s-gitops`
+- do not mutate or normalize the package in CI; the snapshot is a literal source-package copy
+- `packageType: helm` means the payload lives in `helm/`
+- `packageType: kustomize` means the payload lives in `kustomize/`
+- write both the historical `git-<full-commit-sha>/` directory and the stable `current/`
+  directory in the same commit
+
+### Helm-specific snapshot payload
+
+```text
+warehouses/codeai/freight/git-<full-commit-sha>/
+  freight.yaml
+  helm/
+    Chart.yaml
+    values.yaml
+    templates/...
+```
+
+The snapshot is copied from `code-dot-org/k8s/helm` at the release commit.
+
+### Kustomize-specific snapshot payload
+
+```text
+warehouses/codeai/freight/git-<full-commit-sha>/
+  freight.yaml
+  kustomize/
+    base/
+    components/
+    overlays/
+    bin/
+```
+
+The snapshot is copied literally from the checked-in `code-dot-org/k8s/kustomize/`
+tree, including `overlays/` and `bin/`. CI must preserve that full tree in the
+Freight snapshot so the release record is a literal source-package copy rather
+than a normalized subset. Promotion-time production code paths should still use
+only `kustomize/base/` and `kustomize/components/`; the copied `overlays/` and
+`bin/` subtrees are part of the snapshot contract, but not release-promotion
+inputs.
+
+## Freight
+Freight is **Git-only** on `warehouses/codeai/freight/`.
+
+Suggested Warehouse shape:
+
+```yaml
+git:
+  repoURL: https://github.com/code-dot-org/k8s-gitops.git
+  branch: main
+  includePaths:
+    - warehouses/codeai/freight
+```
+
+Each Freight contains:
+- the frozen source snapshot
+- the image ref + digest
+- the package type
+- the release identity
+
+The Freight shape stays stable across stages. Stages only change the rendered environment view.
+
+### Helm-specific interpretation
+The frozen package is the full Helm chart source.
+
+### Kustomize-specific interpretation
+The frozen package is the shared base/components tree, combined during
+promotion with GitOps-side envType Components and a copied temp-wrapper
+template.
+
+## Kargo project
+Promotion should render from the snapshot, not mutate live source.
+
+Recommended stages:
+- `staging`
+- `test`
+- `levelbuilder`
+- `review-infra-changes`
+- `production`
+
+Common promotion pattern:
+1. Clone `k8s-gitops` at the exact Freight commit to a read-only path such as `./freight`.
+2. Clone `k8s-gitops` `main` to `./meta` so env policy comes from the latest writable branch tip.
+3. Clone the target rendered stage branch to `./out`.
+4. Read `warehouses/codeai/freight/current/freight.yaml` from `./freight`.
+5. Render the target stage from the frozen package plus GitOps env policy from `./meta`.
+6. Commit and push rendered output to the stage branch.
+7. In `review-infra-changes`, open a PR instead of pushing directly to the production branch.
+
+Preferred rendered branch shape:
+
+```text
+stage/staging
+stage/test
+stage/levelbuilder
+stage/production
+```
+
+### Helm-specific render path
+1. Run `helm-template` against `./freight/warehouses/codeai/freight/current/helm/`.
+2. Supply env values from:
+   - `apps/codeai/envTypes/<envType>.values.yaml`
+   - `apps/codeai/deployments/<deployment>/values.yaml`
+
+### Kustomize-specific render path
+1. Assemble a temp source tree from:
+   - `./freight/warehouses/codeai/freight/current/kustomize/`
+   - `./meta/apps/codeai/envTypes/<envType>/`
+   - any referenced `./meta/apps/codeai/envTypes/components/` subcomponents
+   - `./meta/apps/codeai/kargo/templates/deploy/`
+2. Update the copied temp wrapper with `deployment.yaml.namespace`,
+   `resources: ../../source/base`, and
+   `components: ../../envTypes/<envType>`.
+3. Set the promoted image tag in the assembled temp wrapper with
+   `kustomize-set-image`, matching the real base image name `code-dot-org`.
+4. Run `kustomize-build`.
+
+## Stage-by-stage promotion flow
+- `staging`: render staging output from the frozen package snapshot to `stage/staging`
+- `test`: render test output from the same snapshot to `stage/test` and run automated tests
+- `levelbuilder`: render levelbuilder output from the same snapshot after `test`
+- `review-infra-changes`: render production output to a generated branch against `stage/production` and open a PR
+- `production`: merge the reviewed production render, then sync Argo to `stage/production`
+
+This is effectively the rendered-branches review model, but with a frozen source snapshot instead of a live-source read from `code-dot-org` during promotion.
+
+## `review infra changes` stage behavior
+This stage is the same for both packaging variants:
+1. Render production manifests from the frozen source snapshot plus production env policy.
+2. Commit to a generated branch.
+3. Open a PR against `stage/production`.
+4. Wait for merge before production sync.
+
+The review surface is the rendered deploy output, not raw source refs.
+
+## `test` stage automation behavior
+After syncing `stage/test`, run verification before downstream promotion.
+
+Good fits:
+- Kargo `verification` / `AnalysisTemplate`s for rollout, health, and smoke checks
+- existing Drone unit/UI results for the same promoted `gitCommit`
+- stage promotion rules that ensure downstream stages follow the exact Freight already verified in `test`
+
+## Proposed Helm / Kustomize directory structure
+### `code-dot-org`
+
+#### Helm-specific
+No required structural change for v1:
+
+```text
+k8s/helm/
+  Chart.yaml
+  values.yaml
+  staging.values.yaml
+  test.values.yaml
+  levelbuilder.values.yaml
+  production.values.yaml
+```
+
+#### Kustomize-specific
+This variant assumes a durable shared Kustomize tree:
+
+```text
+k8s/kustomize/
+  base/
+  components/
+  overlays/
+  bin/
+```
+
+Use only `base/` and `components/` in Kargo/Argo production code paths. The
+checked-in `overlays/` and `bin/` trees are currently local-dev/parity support.
+
+### `k8s-gitops`
+
+#### Common
+
+```text
+apps/codeai/
+  envTypes/
+  deployments/
+    <deployment>/
+      deployment.yaml
+      values.yaml
+  kargo/
+    templates/
+      deploy/
+        kustomization.yaml
+warehouses/codeai/freight/git-<full-commit-sha>/
+  freight.yaml
+```
+
+#### Helm-specific
+
+```text
+apps/codeai/
+  envTypes/
+    <envType>.values.yaml
+  deployments/
+    <deployment>/
+      deployment.yaml
+      values.yaml
+warehouses/codeai/freight/git-<full-commit-sha>/
+  helm/
+```
+
+#### Kustomize-specific
+
+```text
+apps/codeai/
+  envTypes/
+    <envType>/
+    components/
+  deployments/
+    <deployment>/
+      deployment.yaml
+  kargo/
+    templates/
+      deploy/
+        kustomization.yaml
+warehouses/codeai/freight/git-<full-commit-sha>/
+  kustomize/
+    base/
+    components/
+```
+
+## Does it break/awkwardize skaffold or local-dev in any way?
+No.
+
+Common rule:
+- local dev keeps using source packaging in `code-dot-org`
+- the warehouse snapshot is only a CI/promotion artifact
+
+Helm-specific note:
+- Skaffold keeps using `code-dot-org/k8s/helm`
+
+Kustomize-specific note:
+- if Helm is retired for local dev, Skaffold needs a durable source-based Kustomize path
+
+## Pros
+- combines the strongest review model with a frozen, explicit release input
+- avoids promotion-time reconstruction from the live monorepo
+- keeps release truth legible in Git
+- works now for Helm and later for Kustomize
+- keeps the long-lived architecture clear without inventing extra artifact layers
+
+## Cons
+- duplicates the deploy package into `k8s-gitops`
+- creates more Git storage churn than thin-lock plans
+- requires rendered branch plumbing and Argo changes
+
+Helm-specific downside:
+- narrower and more transitional than the Kustomize-shaped form
+
+Kustomize-specific downside:
+- requires a real long-lived base/components/overlay structure decision
+
+## Migration notes
+- This merged plan supersedes both the old `Immutable Package Snapshot + Rendered Branches` plan and the old `Source Snapshot` family plan.
+- If the team wants the lowest-friction first form, start with the Helm-shaped source snapshot.
+- If the team wants to optimize more aggressively for the long-term packaging model, adopt the Kustomize-shaped variant.
+- In both cases, the core architectural move is the same: freeze the source package once, keep env policy in GitOps, and render from the snapshot during promotion.
+
+## Additional implementation notes
+- Keep the image only in `freight.yaml`, not baked into copied source files.
+- Prefer directory-rendered output over single-file output for PR readability.
+- If Git storage churn later becomes painful, the next refinement to evaluate is storing the snapshot package in OCI while keeping the same architectural shape.
+
+## Iteration 7 notes
+- Keep the concrete `freight.yaml` contract with `packageType`, and make the payload directory match it.
+- Keep this as the "copy the package into Freight" side of the comparison with the Kustomize variant of [Argo Refs code-dot-org Commit](./argo-refs-code-dot-org-commit.md).
+- Keep the legacy-gitflow gate module linked into this plan.
+
+# Code changes
+## `k8s-gitops` changes
+
+### Common
+- Add `warehouses/codeai/freight/`
+- Add rendered stage branches and rendered output paths
+- Rewrite CodeAI Kargo stages around snapshot-driven rendering
+- Keep `review-infra-changes` as a PR gate on rendered output
+- Point Argo apps at rendered stage branches using
+  `apps/codeai/deployments/<deployment>/deploy`
+
+### Helm-specific
+- Keep env values and deployment metadata in `apps/codeai/...`
+- Render from Helm snapshots using GitOps-side values
+
+### Kustomize-specific
+- Add `apps/codeai/kargo/templates/deploy/kustomization.yaml` as the generic
+  Kustomize temp-wrapper template copied into promotion work dirs
+- Rewrite stages to assemble `kustomize + envType Component + temp wrapper`,
+  then render
+
+## `code-dot-org` changes
+
+### Common
+- Update the warehouse writeback workflow to snapshot the deploy package into the freight dir
+- Stop direct environment writeback as the primary release mechanism
+
+### Helm-specific
+- Snapshot `k8s/helm` into `warehouses/codeai/freight/git-<full-commit-sha>/helm/`
+
+### Kustomize-specific
+- Snapshot the checked-in `k8s/kustomize/` tree from `code-dot-org` into `warehouses/codeai/freight/git-<full-commit-sha>/kustomize/`
+- Keep local overlays and `bin/` in source repo for Skaffold/local dev
+- Treat the existing `k8s-gitops/apps/codeai/envTypes/*/kustomization.yaml`
+  files as the starting GitOps-side Kustomize Component inputs. `production`
+  currently also layers in `envTypes/components/autoscaling`.
+
+## modules that are part of implementing this plan
+- [Gate Promotion On Legacy Gitflow Branches](../modules/gate-promotion-on-legacy-gitflow-branches.md)
+- [Rendered Stage Branches and PR Review](../modules/rendered-stage-branches-and-pr-review.md)
+
+# Sketch of Pivotal Implementation Details
+
+## Shared mechanics
+
+This plan reuses:
+- [Rendered Stage Branches and PR Review](../modules/rendered-stage-branches-and-pr-review.md)
+- [Gate Promotion On Legacy Gitflow Branches](../modules/gate-promotion-on-legacy-gitflow-branches.md)
+
+## Helm implementation starting point
+
+Treat the checked-in `code-dot-org/k8s/helm/` tree as the starting point, not a
+frozen contract. The implementor may modify or reshape `k8s/helm/` if this plan
+benefits from it, but should preserve current behavior unless the change
+materially improves the plan.
+
+## Kustomize implementation starting point
+
+Treat the checked-in `code-dot-org/k8s/kustomize/` tree as the starting point,
+not a frozen contract. The implementor may modify or reshape `k8s/kustomize/`
+as needed for this plan, especially the base/components layout, before
+snapshotting it.
+
+Use the current `k8s-gitops/apps/codeai/envTypes/<envType>/kustomization.yaml`
+files as the starting envType Component contract. `production` may
+additionally layer in `apps/codeai/envTypes/components/autoscaling/`.
+
+Rendered-family Kustomize stages should not read a committed
+`apps/codeai/deployments/<deployment>/deploy/` tree from `main`. Instead, keep
+a generic deploy-dir template at `apps/codeai/kargo/templates/deploy/`, copy
+that directory into a temp work dir during promotion, then update the copied
+`kustomization.yaml` `namespace`, `resources`, and `components` before running
+`kustomize-set-image`.
+
+Do not treat `code-dot-org/k8s/kustomize/overlays/*` as the production deploy
+contract unless the plan explicitly chooses to adopt them. Those directories are
+currently local-dev/parity support, as is `code-dot-org/k8s/kustomize/bin/`.
+
+## `codeai/applicationset.yaml` sketch
+
+This plan should keep using `apps/codeai/deployments/*/deployment.yaml` on
+`main` as the generator input, but Argo should deploy from the rendered
+`deploy/` dir on each stage branch:
+
+```yaml
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: codeai
+  namespace: argocd
+spec:
+  generators:
+    - git:
+        repoURL: https://github.com/code-dot-org/k8s-gitops.git
+        revision: main
+        files:
+          - path: apps/codeai/deployments/*/deployment.yaml
+  template:
+    metadata:
+      name: codeai-{{path.basename}}
+    spec:
+      sources:
+        - repoURL: https://github.com/code-dot-org/k8s-gitops.git
+          targetRevision: stage/{{path.basename}}
+          path: apps/codeai/deployments/{{path.basename}}/deploy
+      destination:
+        server: https://kubernetes.default.svc
+        namespace: '{{namespace}}'
+```
+
+## Warehouse sketch
+
+The Warehouse is Git-only on the frozen package snapshot tree:
+
+```yaml
+apiVersion: kargo.akuity.io/v1alpha1
+kind: Warehouse
+metadata:
+  name: codeai-freight
+  namespace: kargo-project-codeai
+spec:
+  subscriptions:
+    - git:
+        repoURL: https://github.com/code-dot-org/k8s-gitops.git
+        branch: main
+        includePaths:
+          - warehouses/codeai/freight
+```
+
+Each Freight commit should introduce exactly one new
+`warehouses/codeai/freight/git-<full-commit-sha>/` directory and also refresh the stable
+`warehouses/codeai/freight/current/` mirror. Promotion reads only `current/`,
+while humans and audit tooling use the historical `git-<full-commit-sha>/` directories.
+
+## Hard parts
+
+The hard parts in this plan are:
+
+1. keep the historical `git-<full-commit-sha>/` directory and the stable `current/`
+   mirror identical in the same Freight commit
+2. keep the frozen snapshot small and literal, without smuggling env-specific
+   config into it
+
+The first part is the actual implementation risk. Promotion-side lookup is
+made deterministic on purpose: Stages always read
+`warehouses/codeai/freight/current/`.
+
+## Example `staging` Stage
+
+```yaml
+apiVersion: kargo.akuity.io/v1alpha1
+kind: Stage
+metadata:
+  name: staging
+  namespace: kargo-project-codeai
+spec:
+  requestedFreight:
+    - origin:
+        kind: Warehouse
+        name: codeai-freight
+      sources:
+        direct: true
+  vars:
+    - name: gitopsRepo
+      value: https://github.com/code-dot-org/k8s-gitops.git
+    - name: imageRepo
+      value: ghcr.io/code-dot-org/code-dot-org
+    - name: targetBranch
+      value: stage/${{ ctx.stage }}
+  promotionTemplate:
+    spec:
+      steps:
+        - uses: git-clone
+          config:
+            repoURL: ${{ vars.gitopsRepo }}
+            checkout:
+              - commit: ${{ commitFrom(vars.gitopsRepo, warehouse('codeai-freight')).ID }}
+                path: ./freight
+              - branch: main
+                path: ./meta
+              - branch: ${{ vars.targetBranch }}
+                create: true
+                path: ./out
+
+        - uses: yaml-parse
+          as: freight
+          config:
+            path: ./freight/warehouses/codeai/freight/current/freight.yaml
+            outputs:
+              - name: packageType
+                fromExpression: packageType
+              - name: imageRef
+                fromExpression: image.ref
+              - name: releaseId
+                fromExpression: tag
+
+        - uses: yaml-parse
+          as: deployment-meta
+          config:
+            path: ./meta/apps/codeai/deployments/${{ ctx.stage }}/deployment.yaml
+            outputs:
+              - name: envType
+                fromExpression: envType
+
+        - uses: git-clear
+          config:
+            path: ./out/apps/codeai/deployments/${{ ctx.stage }}/deploy
+
+        - uses: helm-template
+          config:
+            path: ./freight/warehouses/codeai/freight/current/helm
+            releaseName: codeai
+            outPath: ./out/apps/codeai/deployments/${{ ctx.stage }}/deploy
+            valuesFiles:
+              - ./meta/apps/codeai/envTypes/${{ outputs['deployment-meta'].envType }}.values.yaml
+              - ./meta/apps/codeai/deployments/${{ ctx.stage }}/values.yaml
+            setValues:
+              - key: image.repository
+                value: ${{ vars.imageRepo }}
+              - key: image.tag
+                value: ${{ outputs.freight.releaseId }}
+
+        - uses: git-commit
+          config:
+            path: ./out
+            message: Render ${{ ctx.stage }} from ${{ outputs.freight.releaseId }}
+
+        - uses: git-push
+          config:
+            path: ./out
+            branch: ${{ vars.targetBranch }}
+```
+
+For the Kustomize-shaped variant, replace the `helm-template` step with
+the concrete Kustomize render path below.
+
+## Example `staging` Stage for Kustomize
+
+```yaml
+apiVersion: kargo.akuity.io/v1alpha1
+kind: Stage
+metadata:
+  name: staging
+  namespace: kargo-project-codeai
+spec:
+  requestedFreight:
+    - origin:
+        kind: Warehouse
+        name: codeai-freight
+      sources:
+        direct: true
+  vars:
+    - name: gitopsRepo
+      value: https://github.com/code-dot-org/k8s-gitops.git
+    - name: targetBranch
+      value: stage/${{ ctx.stage }}
+    - name: imageRepo
+      value: ghcr.io/code-dot-org/code-dot-org
+  promotionTemplate:
+    spec:
+      steps:
+        - uses: git-clone
+          config:
+            repoURL: ${{ vars.gitopsRepo }}
+            checkout:
+              - commit: ${{ commitFrom(vars.gitopsRepo, warehouse('codeai-freight')).ID }}
+                path: ./freight
+              - branch: main
+                path: ./meta
+              - branch: ${{ vars.targetBranch }}
+                create: true
+                path: ./out
+
+        - uses: yaml-parse
+          as: freight
+          config:
+            path: ./freight/warehouses/codeai/freight/current/freight.yaml
+            outputs:
+              - name: packageType
+                fromExpression: packageType
+              - name: releaseId
+                fromExpression: tag
+
+        - uses: yaml-parse
+          as: deployment-meta
+          config:
+            path: ./meta/apps/codeai/deployments/${{ ctx.stage }}/deployment.yaml
+            outputs:
+              - name: envType
+                fromExpression: envType
+              - name: namespace
+                fromExpression: namespace
+
+        - uses: git-clear
+          config:
+            path: ./out/apps/codeai/deployments/${{ ctx.stage }}/deploy
+
+        - uses: copy
+          config:
+            inPath: ./freight/warehouses/codeai/freight/current/kustomize
+            outPath: ./work/deployments/source
+
+        - uses: copy
+          config:
+            inPath: ./meta/apps/codeai/envTypes/${{ outputs['deployment-meta'].envType }}
+            outPath: ./work/deployments/envTypes/${{ outputs['deployment-meta'].envType }}
+
+        - uses: copy
+          config:
+            inPath: ./meta/apps/codeai/envTypes/components
+            outPath: ./work/deployments/envTypes/components
+
+        - uses: copy
+          config:
+            inPath: ./meta/apps/codeai/kargo/templates/deploy
+            outPath: ./work/deployments/${{ ctx.stage }}/deploy
+
+        # The temp wrapper template provides apiVersion/kind and one
+        # `images` entry whose match key is `code-dot-org`.
+        - uses: yaml-update
+          config:
+            path: ./work/deployments/${{ ctx.stage }}/deploy/kustomization.yaml
+            updates:
+              - key: namespace
+                value: ${{ outputs['deployment-meta'].namespace }}
+              - key: resources
+                value:
+                  - ../../source/base
+              - key: components
+                value:
+                  - ../../envTypes/${{ outputs['deployment-meta'].envType }}
+
+        - uses: kustomize-set-image
+          config:
+            path: ./work/deployments/${{ ctx.stage }}/deploy
+            images:
+              - image: code-dot-org
+                newName: ${{ vars.imageRepo }}
+                tag: ${{ outputs.freight.releaseId }}
+
+        - uses: kustomize-build
+          config:
+            path: ./work/deployments/${{ ctx.stage }}/deploy
+            outPath: ./out/apps/codeai/deployments/${{ ctx.stage }}/deploy
+
+        - uses: git-commit
+          config:
+            path: ./out
+            message: Render ${{ ctx.stage }} from ${{ outputs.freight.releaseId }}
+
+        - uses: git-push
+          config:
+            path: ./out
+            branch: ${{ vars.targetBranch }}
+```
+
+## Example `review-infra-changes` Stage
+
+```yaml
+apiVersion: kargo.akuity.io/v1alpha1
+kind: Stage
+metadata:
+  name: review-infra-changes
+  namespace: kargo-project-codeai
+spec:
+  requestedFreight:
+    - origin:
+        kind: Warehouse
+        name: codeai-freight
+      sources:
+        stages:
+          - test
+  vars:
+    - name: gitopsRepo
+      value: https://github.com/code-dot-org/k8s-gitops.git
+    - name: targetBranch
+      value: stage/production
+    - name: renderDeployment
+      value: production
+    - name: renderPath
+      value: apps/codeai/deployments/production/deploy
+    - name: releaseName
+      value: codeai
+    - name: imageRepo
+      value: ghcr.io/code-dot-org/code-dot-org
+  promotionTemplate:
+    spec:
+      steps:
+        - uses: git-clone
+          config:
+            repoURL: ${{ vars.gitopsRepo }}
+            checkout:
+              - commit: ${{ commitFrom(vars.gitopsRepo, warehouse('codeai-freight')).ID }}
+                path: ./freight
+              - branch: main
+                path: ./meta
+              - branch: ${{ vars.targetBranch }}
+                create: true
+                path: ./out
+
+        - uses: yaml-parse
+          as: freight
+          config:
+            path: ./freight/warehouses/codeai/freight/current/freight.yaml
+            outputs:
+              - name: releaseId
+                fromExpression: tag
+
+        - uses: yaml-parse
+          as: deployment-meta
+          config:
+            path: ./meta/apps/codeai/deployments/${{ vars.renderDeployment }}/deployment.yaml
+            outputs:
+              - name: envType
+                fromExpression: envType
+              - name: namespace
+                fromExpression: namespace
+
+        - uses: git-clear
+          config:
+            path: ./out/${{ vars.renderPath }}
+
+        - uses: helm-template
+          config:
+            path: ./freight/warehouses/codeai/freight/current/helm
+            releaseName: ${{ vars.releaseName }}
+            outPath: ./out/${{ vars.renderPath }}
+            valuesFiles:
+              - ./meta/apps/codeai/envTypes/${{ outputs['deployment-meta'].envType }}.values.yaml
+              - ./meta/apps/codeai/deployments/${{ vars.renderDeployment }}/values.yaml
+            setValues:
+              - key: image.repository
+                value: ${{ vars.imageRepo }}
+              - key: image.tag
+                value: ${{ outputs.freight.releaseId }}
+
+        - uses: git-commit
+          config:
+            path: ./out
+            message: Review production render for ${{ outputs.freight.releaseId }}
+
+        - uses: git-push
+          as: push
+          config:
+            path: ./out
+            generateTargetBranch: true
+
+        - uses: git-open-pr
+          as: open-pr
+          config:
+            repoURL: ${{ vars.gitopsRepo }}
+            sourceBranch: ${{ outputs.push.branch }}
+            targetBranch: ${{ vars.targetBranch }}
+            title: Review CodeAI production render for ${{ outputs.freight.releaseId }}
+
+        - uses: git-wait-for-pr
+          config:
+            repoURL: ${{ vars.gitopsRepo }}
+            prNumber: ${{ outputs['open-pr'].pr.id }}
+```
+
+## Example `review-infra-changes` Stage for Kustomize
+
+```yaml
+apiVersion: kargo.akuity.io/v1alpha1
+kind: Stage
+metadata:
+  name: review-infra-changes
+  namespace: kargo-project-codeai
+spec:
+  requestedFreight:
+    - origin:
+        kind: Warehouse
+        name: codeai-freight
+      sources:
+        stages:
+          - test
+  vars:
+    - name: gitopsRepo
+      value: https://github.com/code-dot-org/k8s-gitops.git
+    - name: targetBranch
+      value: stage/production
+    - name: renderDeployment
+      value: production
+    - name: renderPath
+      value: apps/codeai/deployments/production/deploy
+    - name: imageRepo
+      value: ghcr.io/code-dot-org/code-dot-org
+  promotionTemplate:
+    spec:
+      steps:
+        - uses: git-clone
+          config:
+            repoURL: ${{ vars.gitopsRepo }}
+            checkout:
+              - commit: ${{ commitFrom(vars.gitopsRepo, warehouse('codeai-freight')).ID }}
+                path: ./freight
+              - branch: main
+                path: ./meta
+              - branch: ${{ vars.targetBranch }}
+                create: true
+                path: ./out
+
+        - uses: yaml-parse
+          as: freight
+          config:
+            path: ./freight/warehouses/codeai/freight/current/freight.yaml
+            outputs:
+              - name: releaseId
+                fromExpression: tag
+
+        - uses: yaml-parse
+          as: deployment-meta
+          config:
+            path: ./meta/apps/codeai/deployments/${{ vars.renderDeployment }}/deployment.yaml
+            outputs:
+              - name: envType
+                fromExpression: envType
+
+        - uses: git-clear
+          config:
+            path: ./out/${{ vars.renderPath }}
+
+        - uses: copy
+          config:
+            inPath: ./freight/warehouses/codeai/freight/current/kustomize
+            outPath: ./work/deployments/source
+
+        - uses: copy
+          config:
+            inPath: ./meta/apps/codeai/envTypes/${{ outputs['deployment-meta'].envType }}
+            outPath: ./work/deployments/envTypes/${{ outputs['deployment-meta'].envType }}
+
+        - uses: copy
+          config:
+            inPath: ./meta/apps/codeai/envTypes/components
+            outPath: ./work/deployments/envTypes/components
+
+        - uses: copy
+          config:
+            inPath: ./meta/apps/codeai/kargo/templates/deploy
+            outPath: ./work/deployments/${{ vars.renderDeployment }}/deploy
+
+        # The temp wrapper template provides apiVersion/kind and one
+        # `images` entry whose match key is `code-dot-org`.
+        - uses: yaml-update
+          config:
+            path: ./work/deployments/${{ vars.renderDeployment }}/deploy/kustomization.yaml
+            updates:
+              - key: namespace
+                value: ${{ outputs['deployment-meta'].namespace }}
+              - key: resources
+                value:
+                  - ../../source/base
+              - key: components
+                value:
+                  - ../../envTypes/${{ outputs['deployment-meta'].envType }}
+
+        - uses: kustomize-set-image
+          config:
+            path: ./work/deployments/${{ vars.renderDeployment }}/deploy
+            images:
+              - image: code-dot-org
+                newName: ${{ vars.imageRepo }}
+                tag: ${{ outputs.freight.releaseId }}
+
+        - uses: kustomize-build
+          config:
+            path: ./work/deployments/${{ vars.renderDeployment }}/deploy
+            outPath: ./out/${{ vars.renderPath }}
+
+        - uses: git-commit
+          config:
+            path: ./out
+            message: Review production render for ${{ outputs.freight.releaseId }}
+
+        - uses: git-push
+          as: push
+          config:
+            path: ./out
+            generateTargetBranch: true
+
+        - uses: git-open-pr
+          as: open-pr
+          config:
+            repoURL: ${{ vars.gitopsRepo }}
+            sourceBranch: ${{ outputs.push.branch }}
+            targetBranch: ${{ vars.targetBranch }}
+            title: Review CodeAI production render for ${{ outputs.freight.releaseId }}
+
+        - uses: git-wait-for-pr
+          config:
+            repoURL: ${{ vars.gitopsRepo }}
+            prNumber: ${{ outputs['open-pr'].pr.id }}
+```
+
+## GH runner sketch
+
+This runner does more than the build-lock plans:
+
+1. Build and stitch the app image.
+2. Resolve the final image digest.
+3. Check out `k8s-gitops` `main`.
+4. Create `warehouses/codeai/freight/git-<full-commit-sha>/`.
+5. Refresh `warehouses/codeai/freight/current/` with the same package contents.
+6. Copy the full checked-in `code-dot-org/k8s/kustomize/` tree literally when
+   the plan is Kustomize-shaped, including `overlays/` and `bin/`, and copy the
+   full checked-in `code-dot-org/k8s/helm/` tree literally when the plan is
+   Helm-shaped. Do not trim the Kustomize snapshot to only `base/` and
+   `components/`.
+7. Copy either:
+   - `k8s/helm/` to `warehouses/codeai/freight/git-<full-commit-sha>/helm/`
+   - or `k8s/kustomize/` to `warehouses/codeai/freight/git-<full-commit-sha>/kustomize/`
+8. Write `freight.yaml` with `revision`, image ref/digest, and `packageType`.
+9. Copy the same `freight.yaml` to `warehouses/codeai/freight/current/freight.yaml`.
+10. Commit and push the historical directory and the `current/` mirror together.
+
+This is the pivotal architectural move in the plan: freeze the deploy package
+once in CI, then promote only from that frozen package.
+
+The promotion-time hardness is now explicit but simpler than a helper:
+the GH runner must keep the historical `git-<full-commit-sha>/` directory and the stable
+`current/` mirror identical in the same commit so Stages can always read:
+- `warehouses/codeai/freight/current/freight.yaml`
+- `warehouses/codeai/freight/current/helm/` or `.../kustomize/`
+- for Kustomize, that copied snapshot must include `base/`, `components/`,
+  `overlays/`, and `bin/` exactly as checked in, even though promotion only
+  consumes `base/` and `components/`
+
+### Testing Plan
+
+Recommended automation:
+- Extend [k8s.yml](/Users/seth/.codex/worktrees/684f/code-dot-org/.github/workflows/k8s.yml) or call a small reusable workflow from it for repo-specific contract and render smoke checks.
+- Use existing Drone results on the promoted `gitCommit` as the app/unit/UI gate before downstream promotion.
+- Use Kargo `verification` with `AnalysisTemplate`s for post-sync rollout/health/smoke checks in `test`.
+
+Simple tests to automate:
+- In `k8s.yml`, after the snapshot-writing step, build the proposed `warehouses/codeai/freight/git-<full-commit-sha>/` directory in a temp workspace and fail unless `current/` is byte-for-byte identical to the historical directory.
+- In the same workflow, parse `warehouses/codeai/freight/current/freight.yaml` and fail unless it contains `revision`, `tag`, `image.ref`, `image.digest`, `packageType`, and `createdAt`.
+- For the Helm variant, run `helm template` from `warehouses/codeai/freight/current/helm` using deployment metadata from `apps/codeai/deployments/<deployment>/deployment.yaml`, envType values from `apps/codeai/envTypes/<envType>.values.yaml`, and deployment values from `apps/codeai/deployments/<deployment>/values.yaml`.
+- For the Kustomize variant, run `kustomize build` from a temp tree assembled from `warehouses/codeai/freight/current/kustomize`, `apps/codeai/envTypes/<envType>/` as a Component, any referenced `apps/codeai/envTypes/components/` subcomponents such as `autoscaling`, and a copied `apps/codeai/kargo/templates/deploy/` dir whose `kustomization.yaml` `namespace`, `resources`, and `components` fields are updated before `kustomize-set-image` rewrites `code-dot-org` to `ghcr.io/code-dot-org/code-dot-org:git-<full-commit-sha>`. The snapshot itself must still contain the full checked-in `overlays/` and `bin/` directories, but production promotion code must not consume them. Do not trim the snapshot tree differently in a later implementation.
+- In the same workflow, check out `k8s-gitops` read-only and validate [applicationset.yaml](/Users/seth/src/k8s-gitops/apps/codeai/applicationset.yaml) deploys `apps/codeai/deployments/{{path.basename}}/deploy` from `stage/{{path.basename}}` and that every deployment metadata file carries `envType`.
+
+Avoid as baseline coverage:
+- A fake controller harness whose only job is to re-test Kargo Git checkout behavior. The useful Kustomize smoke test now is just: snapshot the checked-in `k8s/kustomize/` tree, then build it locally with the current envType Component inputs plus the copied deploy-template dir.

--- a/k8s/docs/kargotecture/plans/modules/gate-promotion-on-legacy-gitflow-branches.md
+++ b/k8s/docs/kargotecture/plans/modules/gate-promotion-on-legacy-gitflow-branches.md
@@ -1,0 +1,313 @@
+# Gate Promotion On Legacy Gitflow Branches
+
+**Short name:** Legacy gitflow gate
+
+**Purpose:** During the coexistence period, do not let Kargo promote a release
+to the next environment until the same `git-<full-commit-sha>` has already been merged
+into the matching legacy gitflow branch.
+
+This is a **module**, not a complete release architecture. It layers onto plans
+that already have an explicit release identity and normal Kargo promotion flow.
+
+## Detailed Technical Description of Module
+This module is a coexistence gate, not a release-truth source. Its job is to
+make Kargo promotion respect the legacy Gitflow branch narrative while the old
+fleet and the k8s fleet run in parallel. The release itself still comes from
+the consuming plan's Freight model, but before a downstream stage is allowed to
+advance, the plan must prove that the same `git-<full-commit-sha>` has already
+been merged into the corresponding legacy branch. That keeps the k8s rollout
+from getting ahead of the legacy system's release progression signal.
+
+The implementation deliberately uses per-branch metadata files under
+`warehouses/codeai/legacy-gitflow/<env>/merged/` instead of scanning commit
+history or inferring branch state from Freight. `current.yaml` records the
+latest observed legacy branch tip, while `merged/git-<full-commit-sha>.yaml`
+is the actual yes/no gate. A promotion step clones `k8s-gitops` `main`, reads
+the legacy branch's `merged/` record at gate time, and fails fast if the file is
+missing. That means the gate always reflects the current legacy branch state,
+not only the frozen Freight checkout.
+
+What makes this module different from the other shared modules is that it does
+not tell a plan how to discover Freight or how to render manifests. It only
+adds a pre-promotion dependency that must pass before the plan's normal sync,
+verification, or review flow can continue. In practice, this means the module
+is usually inserted near the top of a downstream promotion stage, before any
+rendering work, so the plan can stop immediately if the matching legacy merge
+record is absent.
+
+## What this module is for
+
+Use this when:
+- the legacy fleet and the k8s fleet will run in parallel for a while
+- the legacy system still treats merges into `staging`, `test`,
+  `levelbuilder`, or `production` as the release progression signal
+- you want k8s promotion to follow the same release narrative instead of
+  drifting ahead or sideways
+
+Do **not** use this as the only promotion gate. It complements normal
+verification and review. It does not replace them.
+
+## File layout
+
+These files live alongside the plan's normal release metadata for convenience,
+but they are **not Freight inputs**.
+
+```text
+warehouses/codeai/
+  legacy-gitflow/
+    staging/
+      current.yaml
+      merged/
+        git-<full-commit-sha>.yaml
+    test/
+      current.yaml
+      merged/
+        git-<full-commit-sha>.yaml
+    levelbuilder/
+      current.yaml
+      merged/
+        git-<full-commit-sha>.yaml
+    production/
+      current.yaml
+      merged/
+        git-<full-commit-sha>.yaml
+```
+
+`current.yaml` answers:
+- what revision is this legacy branch at right now?
+
+`merged/git-<full-commit-sha>.yaml` answers:
+- was this exact release ever merged into this legacy branch?
+
+That second question is the real promotion gate.
+
+## File contents
+
+Recommended `current.yaml`:
+
+```yaml
+revision: <full-commit-sha>
+tag: git-<full-commit-sha>
+mergedAt: 2026-03-22T12:34:56Z
+```
+
+Recommended `merged/git-<full-commit-sha>.yaml`:
+
+```yaml
+revision: <full-commit-sha>
+tag: git-<full-commit-sha>
+mergedAt: 2026-03-22T12:34:56Z
+```
+
+Use the path to carry the target branch identity. Do not duplicate the branch
+name inside each file.
+
+## Why this layout is better than one flat directory
+
+This is better than a single directory such as:
+
+```text
+legacy-gitflow/
+  git-<full-commit-sha>.yaml
+```
+
+with `branch: test` inside the file because:
+- promotion can check file existence directly:
+  `legacy-gitflow/test/merged/git-<full-commit-sha>.yaml`
+- no file scanning is required
+- the path is already the environment/stage key
+- `current.yaml` and `merged/` stay colocated per legacy branch
+
+## How these files get written
+
+GitHub Actions triggered by merges into the legacy branches should update them.
+
+On merge into `test`, the workflow should:
+1. write `legacy-gitflow/test/current.yaml`
+2. write `legacy-gitflow/test/merged/git-<full-commit-sha>.yaml`
+
+Do the same for `staging`, `levelbuilder`, and `production`.
+
+## Important rule: do not make this a Warehouse subscription
+
+These files may live under `warehouses/codeai/` because that is a convenient
+place for release-adjacent metadata, but they should **not** be subscribed as
+Freight.
+
+Why:
+- a legacy merge is not a new k8s release artifact
+- gate decisions should read the latest observed legacy state
+- if the gate read only the frozen Freight commit, it could miss later legacy
+  merges and get stuck incorrectly
+
+So the promotion step should read the current metadata repo head at gate time,
+not only the Freight checkout.
+
+## How the gate works
+
+For a release with tag `git-0cc4cd87f40ae606d1822d5652b552f8c50a4668`:
+
+- `staging -> test` requires:
+  `legacy-gitflow/test/merged/git-0cc4cd87f40ae606d1822d5652b552f8c50a4668.yaml`
+- `test -> levelbuilder` requires:
+  `legacy-gitflow/levelbuilder/merged/git-0cc4cd87f40ae606d1822d5652b552f8c50a4668.yaml`
+- `review-infra-changes -> production` or `test -> production` requires:
+  `legacy-gitflow/production/merged/git-0cc4cd87f40ae606d1822d5652b552f8c50a4668.yaml`
+
+This means:
+- k8s can lag legacy without getting stuck forever
+- older releases still pass if they were merged earlier
+- the gate is based on historical merge fact, not only current branch head
+
+## Relationship to normal test verification
+
+This module does **not** replace the plan's normal `test` stage verification.
+
+Plans using this module should still:
+- sync `test`
+- run Drone unit tests
+- run Drone UI tests
+- run Kargo or cluster smoke checks
+
+Downstream promotion should require both:
+- the same release passed `test` verification
+- the matching legacy branch has a `merged/git-<full-commit-sha>.yaml` record
+
+## Where this fits in a plan
+
+This module is best described as:
+- a migration-era coexistence gate
+- a downstream-stage promotion rule
+- an overlay on top of the plan's real Freight/release architecture
+
+It is **not**:
+- a packaging model
+- a Freight shape
+- a replacement for rendered Git review
+
+## Iteration 5 compatibility
+
+Compatible live iteration 5 plans:
+- [Common-Case Freight + Rendered Branches](../iteration-5/common-case-rendered-branches.md)
+- [GitOps Truth with Generated Mirror](../iteration-5/gitops-truth-generated-mirror.md)
+- [Helm Source Snapshot](../iteration-5/helm-source-snapshot.md)
+- [Image Provenance + Rendered Branches](../iteration-5/image-provenance-rendered-branches.md)
+- [Kustomize Base Snapshot](../iteration-5/kustomize-base-snapshot.md)
+- [Kustomize Split Overlays](../iteration-5/kustomize-split-overlays.md)
+- [Multi-Warehouse Base + Overlay](../iteration-5/multi-warehouse-base-overlay.md)
+- [OCI Package Pair (Helm or Kustomize) + Rendered Branches](../iteration-5/oci-package-pair-rendered-branches.md)
+- [Rendered Branches from a Thin Lock](../iteration-5/rendered-branches.md)
+- [Pre-Rendered Release Bundle](../iteration-5/rendered-release-bundle.md)
+- [Source Snapshot (Helm or Kustomize) + Rendered Branches](../iteration-5/source-snapshot-rendered-branches.md)
+- [Thin Build Lock](../iteration-5/thin-build-lock.md)
+
+Incompatible live iteration 5 plans:
+- none
+
+# Sketch of Pivotal Implementation Details
+
+## Metadata files written by legacy-branch workflows
+
+```text
+warehouses/codeai/legacy-gitflow/
+  staging/
+    current.yaml
+    merged/git-<full-commit-sha>.yaml
+  test/
+    current.yaml
+    merged/git-<full-commit-sha>.yaml
+  levelbuilder/
+    current.yaml
+    merged/git-<full-commit-sha>.yaml
+  production/
+    current.yaml
+    merged/git-<full-commit-sha>.yaml
+```
+
+Suggested `current.yaml`:
+
+```yaml
+revision: <full-commit-sha>
+tag: git-<full-commit-sha>
+mergedAt: 2026-03-22T12:34:56Z
+```
+
+Suggested `merged/git-<full-commit-sha>.yaml`:
+
+```yaml
+revision: <full-commit-sha>
+tag: git-<full-commit-sha>
+mergedAt: 2026-03-22T12:34:56Z
+```
+
+## Concrete shared gate check contract
+
+This module should be implemented the same way in every consuming plan:
+
+- clone `k8s-gitops` `main` to `./gate`
+- set `legacyEnv` to the downstream legacy branch name
+- set `releaseTag` to the release being promoted, for example `git-<full-commit-sha>`
+- parse:
+  `./gate/warehouses/codeai/legacy-gitflow/${{ vars.legacyEnv }}/merged/${{ vars.releaseTag }}.yaml`
+- if that file is missing, `yaml-parse` fails and the promotion stops
+- if the file exists, expose:
+  - `revision`
+  - `tag`
+  - `mergedAt`
+
+The cleanest place to run this is near the start of the downstream promotion
+Stage, before any render or sync work.
+
+```yaml
+apiVersion: kargo.akuity.io/v1alpha1
+kind: Stage
+metadata:
+  name: review-infra-changes
+  namespace: kargo-project-codeai
+spec:
+  vars:
+    - name: legacyEnv
+      value: production
+    - name: releaseTag
+      value: git-0cc4cd87f40ae606d1822d5652b552f8c50a4668
+  promotionTemplate:
+    spec:
+      steps:
+        - uses: git-clone
+          config:
+            repoURL: https://github.com/code-dot-org/k8s-gitops.git
+            checkout:
+              - branch: main
+                path: ./gate
+
+        - uses: yaml-parse
+          as: legacy-merge
+          config:
+            path: ./gate/warehouses/codeai/legacy-gitflow/${{ vars.legacyEnv }}/merged/${{ vars.releaseTag }}.yaml
+            outputs:
+              - name: revision
+                fromExpression: revision
+              - name: tag
+                fromExpression: tag
+              - name: mergedAt
+                fromExpression: mergedAt
+```
+
+There is no plan-specific glue here. Missing file means terminal gate failure.
+Existing file means the gate has passed and the consuming plan may continue.
+
+## GH runner sketch
+
+This module needs one lightweight metadata writer flow for the legacy branches.
+
+On merge into `staging`, `test`, `levelbuilder`, or `production`, the GH
+workflow should:
+
+1. Derive `git-<full-commit-sha>` from the merged commit SHA.
+2. Check out `k8s-gitops` `main`.
+3. Write `warehouses/codeai/legacy-gitflow/<branch>/current.yaml`.
+4. Write `warehouses/codeai/legacy-gitflow/<branch>/merged/git-<full-commit-sha>.yaml`.
+5. Commit and push those metadata files.
+
+This is intentionally not Freight publication. It is only release-adjacent gate
+metadata.

--- a/k8s/docs/kargotecture/plans/modules/git-build-lock-freight-record.md
+++ b/k8s/docs/kargotecture/plans/modules/git-build-lock-freight-record.md
@@ -1,0 +1,149 @@
+# Git Build-Lock Freight Record
+
+**Short name:** Build-lock freight
+
+**Purpose:** Reuse one tiny Git release record shape across plans that want
+Kargo to discover Freight from `k8s-gitops`, but do the real deployment work
+later.
+
+## Detailed Technical Description of Module
+This module is the smallest possible release contract for the thin-lock family:
+it says, in Git, exactly which `code-dot-org` commit and image digest Kargo
+should promote, and nothing more. The file is not a rendered manifest, not a
+snapshot of the package, and not a deployment target. It is a release witness.
+That distinction matters because the downstream plan is free to decide whether
+the promoted release will later mutate Helm values, pin a Kustomize entrypoint,
+or render full stage output. The build-lock itself stays intentionally boring so
+the promotion logic can be deterministic and easy to audit.
+
+The module uses two paths for the same payload on purpose. `git-<full-commit-sha>.yaml`
+is the immutable historical record, while `current.yaml` is the stable parse
+path Kargo reads at promotion time. The key implementation detail is that CI
+must write both files atomically in one commit, because promotion should never
+have to guess whether `current.yaml` and the historical lock disagree. That
+makes the module different from the rendered-review module, which owns output
+branches, and from the live-source checkout module, which owns how to fetch the
+source tree once the lock has already identified it.
+
+The other subtlety is that this module deliberately carries just enough extra
+metadata to let a downstream plan choose the right deployment strategy without
+changing Freight shape. `packaging.kind` and `sourcePath` are not the release
+record itself; they are hints for the stage that consumes it. A plan can use
+those hints to decide whether to update Helm refs, render source into a branch,
+or pin a Kustomize deployment entrypoint, but the shared contract remains the
+same: one exact source commit, one exact image, one stable `current.yaml`
+parse path.
+
+This module is shared by:
+- Argo Refs code-dot-org Commit
+- Rendered Branches from a Thin Lock
+
+## Canonical file paths
+
+```text
+warehouses/codeai/builds/
+  current.yaml
+  git-<full-commit-sha>.yaml
+```
+
+## Recommended file contents
+
+```yaml
+schemaVersion: v1
+releaseId: git-<full-commit-sha>
+gitCommit: <full-commit-sha>
+image:
+  ref: ghcr.io/code-dot-org/code-dot-org:git-<full-commit-sha>
+  digest: sha256:...
+packaging:
+  kind: helm # or kustomize
+  sourceRepo: https://github.com/code-dot-org/code-dot-org.git
+  sourcePath: k8s/helm # or k8s/kustomize
+createdAt: 2026-03-22T12:34:56Z
+```
+
+Use this as the lowest-common-denominator contract:
+- `gitCommit` is the real source identity
+- `image.ref` and `image.digest` pin the built image
+- `packaging.kind` tells the stage whether it should later run Helm or Kustomize
+- `sourcePath` tells the stage where to clone/render from if it needs live source
+
+## Warehouse sketch
+
+```yaml
+apiVersion: kargo.akuity.io/v1alpha1
+kind: Warehouse
+metadata:
+  name: codeai-builds
+  namespace: kargo-project-codeai
+spec:
+  subscriptions:
+    - git:
+        repoURL: https://github.com/code-dot-org/k8s-gitops.git
+        branch: main
+        includePaths:
+          - warehouses/codeai/builds
+```
+
+This keeps Freight discovery:
+- deterministic
+- Git-native
+- independent of Argo env files
+
+Both files carry the same schema:
+- `git-<full-commit-sha>.yaml` is the historical audit record
+- `current.yaml` is the stable promotion-time parse path
+
+`current.yaml` is intentionally not treated as a dangerous mutable "latest"
+pointer because promotion always checks out an exact promoted Git Freight
+commit. The promoted commit pins the exact `current.yaml` contents.
+
+## GH runner sketch
+
+This is the shared CI shape for build-lock plans:
+
+1. Build and publish the app image tagged `git-<full-commit-sha>`.
+2. Resolve the final pushed image digest after the multiplatform image exists.
+3. Check out `k8s-gitops` `main`.
+4. Write `warehouses/codeai/builds/git-<full-commit-sha>.yaml`.
+5. Copy the same contents to `warehouses/codeai/builds/current.yaml`.
+6. Commit and push both files in the same commit.
+
+In practice, this means the current
+`k8s-commit-to-kargo-warehouse.yml` workflow stops editing
+`apps/codeai/deployments/*/values.yaml` and starts writing this build-lock file
+instead.
+
+## Hard part: keep history and the stable parse path in sync
+
+The tricky part is no longer promotion-time lookup. It is making the CI write
+path explicit enough that an implementation agent does not accidentally update
+the historical file and `current.yaml` in different commits.
+
+The required rule is:
+
+1. CI writes `git-<full-commit-sha>.yaml` and `current.yaml` atomically in one commit.
+2. Promotion only parses `warehouses/codeai/builds/current.yaml`.
+3. Humans and audit tooling read `git-<full-commit-sha>.yaml`.
+
+That is the implementation tradeoff:
+- keep the historical per-release file for legibility
+- add one stable path so promotion does not need unsupported custom Kargo steps
+
+One more rule is just as important:
+
+1. read `current.yaml` from an exact checkout of the promoted Freight commit
+2. make mutable GitOps edits against a separate checkout of `main`
+
+Do not branch or push from the promoted Freight commit directly. That would
+turn older promotions into stale-base Git edits instead of replaying the chosen
+release onto the latest writable GitOps branch.
+
+## What varies plan-to-plan
+
+The build-lock record is intentionally boring. What changes by plan is what the
+promotion stage does after parsing it:
+
+- Argo Refs code-dot-org Commit (Helm variant): update env refs only
+- Rendered Branches from a Thin Lock: clone source, render, and commit output
+- Argo Refs code-dot-org Commit (Kustomize variant): update deployment Kustomization refs and image pins

--- a/k8s/docs/kargotecture/plans/modules/live-source-checkout-at-freight-commit.md
+++ b/k8s/docs/kargotecture/plans/modules/live-source-checkout-at-freight-commit.md
@@ -1,0 +1,105 @@
+# Live Source Checkout at Freight Commit
+
+**Short name:** Live source checkout
+
+**Purpose:** Reuse the exact promotion-time checkout pattern for plans that
+render from the real `code-dot-org` repository instead of from a frozen package
+snapshot.
+
+## Detailed Technical Description of Module
+This module is the shared promotion-time source checkout contract for plans
+that render from live `code-dot-org` source. Its job is narrowly defined: take
+an already-chosen release identity, resolve the exact source commit behind it,
+and clone only the packaging tree needed for rendering. The module is not about
+Freight discovery, and it is not about rendered-output storage. It exists to
+make sure Kargo renders from the exact promoted commit instead of the moving
+branch tip, while keeping the checkout small enough that the huge monorepo does
+not become the bottleneck.
+
+The key implementation detail is the separation between commit resolution and
+checkout shape. A consuming plan must provide `sourceCommit` from its own
+Freight model, then use Kargo's `git-clone` step with an exact commit checkout
+plus sparse paths. For Helm that means narrowing the sparse checkout to
+`k8s/helm`; for Kustomize that means narrowing it to `k8s/kustomize`. The
+rendered-output branch checkout, if present, still comes from `k8s-gitops` and
+is a separate concern. That split is what keeps the module reusable: one plan
+may feed `sourceCommit` from a build-lock file, another may feed it from live
+Freight discovery, but both use the same checkout mechanics once the commit is
+known.
+
+The tricky part is that this module only works if the consuming plan is strict
+about provenance. If `sourceCommit` comes from the wrong branch, or if the
+sparse checkout includes the wrong packaging tree, the render step can still
+succeed while producing the wrong manifests. So the module's real rule is not
+just "use sparse checkout"; it is "resolve the exact promoted commit first, then
+render only the packaging subtree that belongs to that release." That makes it
+different from the build-lock module, which defines how Freight is recorded, and
+different from the rendered-branch module, which defines where the output ends
+up after rendering.
+
+This module is shared by:
+- Common-Case Freight + Rendered Branches
+- Rendered Branches from a Thin Lock
+
+## Why this is the hard part
+
+These plans are only sane if promotion reads the **exact promoted source
+commit**, not the moving branch tip, while also avoiding a full clone of the
+giant monorepo.
+
+Fortunately, Kargo's `git-clone` step supports both:
+- exact `checkout[].commit`
+- `checkout[].sparse`
+
+So the right shape is:
+- resolve the exact source commit first
+- sparse-check out only the packaging tree that render needs
+
+## Generic checkout sketch
+
+```yaml
+- uses: git-clone
+  config:
+    repoURL: ${{ vars.sourceRepo }}
+    checkout:
+      - as: source
+        commit: ${{ vars.sourceCommit }}
+        path: ./src
+        sparse:
+          - k8s/helm
+          - k8s/kustomize
+```
+
+In practice:
+- `vars.sourceCommit` comes from the build-lock helper or from Git Freight
+  itself
+- for Helm-first phases, sparse checkout can be narrowed to just `k8s/helm`
+- for Kustomize-first phases, sparse checkout can be narrowed to just
+  `k8s/kustomize`
+- the rendered-output branch checkout still comes from the separate
+  `k8s-gitops` clone described in
+  [Rendered Stage Branches and PR Review](./rendered-stage-branches-and-pr-review.md)
+
+## Plan-specific source-commit inputs
+
+Rendered Branches from a Thin Lock:
+
+```yaml
+vars:
+  - name: sourceCommit
+    value: ${{ outputs['build-lock'].gitCommit }}
+```
+
+Common-Case Freight + Rendered Branches:
+
+```yaml
+vars:
+  - name: sourceCommit
+    value: ${{ commitFrom(vars.sourceRepo, warehouse("codeai")).ID }}
+```
+
+## Why this should stay a module
+
+The checkout mechanics are identical. What differs between plans is only:
+- where `sourceCommit` comes from
+- whether the plan has synthetic Freight writeback at all

--- a/k8s/docs/kargotecture/plans/modules/rendered-stage-branches-and-pr-review.md
+++ b/k8s/docs/kargotecture/plans/modules/rendered-stage-branches-and-pr-review.md
@@ -1,0 +1,236 @@
+# Rendered Stage Branches and PR Review
+
+**Short name:** Rendered branch review
+
+**Purpose:** Reuse one common GitOps and Kargo shape for plans that want humans
+to review rendered output instead of only ref changes.
+
+## Detailed Technical Description of Module
+This module defines the rendered-output half of the release system. Its job is
+to make `k8s-gitops` hold two different kinds of truth at the same time without
+confusing them: `main` keeps deployment metadata, environment policy, and any
+shared render templates, while `stage/<deployment>` branches hold the generated
+manifest output that Argo CD actually deploys. The important design point is
+that the review surface is no longer “did a ref move?” but “did the rendered
+deployment tree change the way we expected?” That makes the module a review
+mechanism, not a Freight mechanism.
+
+The implementation hinge is the `apps/codeai/deployments/<deployment>/deploy/`
+path. On `main`, that path name may describe authored Kustomize inputs or a
+template directory that promotion copies into a temp workspace; on
+`stage/*`, the same path name refers to generated output. The module therefore
+requires each plan to be explicit about what is source-owned versus what is
+rendered. Kargo reads deployment metadata from `main`, renders into the stage
+branch, opens a PR for `review-infra-changes`, and only then lets production
+advance. The tricky part is keeping the branch-local output shape stable so
+Argo can deploy it directly while still allowing plans to vary in how the
+render step assembles Helm or Kustomize inputs.
+
+What makes this module different from the build-lock, live-source-checkout, and
+gate modules is that it owns the output contract, not the release identity or
+the source checkout mechanics. Those other modules answer “what release is
+this?” or “where does source come from?” This one answers “where does rendered
+truth live, and how do humans review it safely?” If a plan uses this module
+correctly, the implementor can change the rendering strategy later without
+changing the core GitOps review model.
+
+This module is shared by:
+- Common-Case Freight + Rendered Branches
+- Source Snapshot (Helm or Kustomize) + Rendered Branches
+- Rendered Branches from a Thin Lock
+- OCI Release Capsule
+
+## Branch layout
+
+```text
+stage/staging
+stage/test
+stage/levelbuilder
+stage/production
+```
+
+Each branch contains the rendered deployment output, typically rooted at:
+
+```text
+apps/codeai/deployments/<deployment>/deploy/
+```
+
+## `k8s-gitops` layout this module assumes
+
+`main` should keep environment policy and Kargo/Argo metadata, while rendered
+stage branches keep generated deploy output.
+
+Common shape on `main`:
+
+```text
+apps/codeai/
+```
+
+Helm-shaped plans typically keep:
+
+```text
+apps/codeai/
+  envTypes/
+    <envType>.values.yaml
+  deployments/
+    <deployment>/
+      deployment.yaml
+      values.yaml
+```
+
+Kustomize-shaped plans typically keep:
+
+```text
+apps/codeai/
+  envTypes/
+    <envType>/
+  deployments/
+    <deployment>/
+      deployment.yaml
+  kargo/
+    templates/
+      deploy/
+        kustomization.yaml
+```
+
+For Kustomize-shaped rendered plans, `main` keeps deployment metadata, env
+policy, and any reusable temp-wrapper templates such as
+`apps/codeai/kargo/templates/deploy/`. The rendered `deploy/` tree exists only
+on `stage/*`, where it is generated output that Argo deploys.
+
+Rendered stage branches typically keep:
+
+```text
+apps/codeai/deployments/<deployment>/deploy/
+```
+
+## Argo ApplicationSet sketch
+
+The common move is: Argo should deploy rendered output from `k8s-gitops`, not
+render live source itself. To avoid losing namespace/env metadata, keep using
+the existing `apps/codeai/deployments/*/deployment.yaml` files on `main` as the
+generator source. `{{path.basename}}` is the deployment name; `{{envType}}`
+comes from the generated `deployment.yaml`.
+
+```yaml
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: codeai
+  namespace: argocd
+spec:
+  generators:
+    - git:
+        repoURL: https://github.com/code-dot-org/k8s-gitops.git
+        revision: main
+        files:
+          - path: apps/codeai/deployments/*/deployment.yaml
+  template:
+    metadata:
+      name: codeai-{{path.basename}}
+      labels:
+        app.kubernetes.io/managed-by: kargo
+        kargo.akuity.io/project: kargo-project-codeai
+    spec:
+      project: default
+      sources:
+        - repoURL: https://github.com/code-dot-org/k8s-gitops.git
+          targetRevision: stage/{{path.basename}}
+          path: apps/codeai/deployments/{{path.basename}}/deploy
+      destination:
+        server: https://kubernetes.default.svc
+        namespace: '{{namespace}}'
+      syncPolicy:
+        automated:
+          prune: true
+          selfHeal: true
+        syncOptions:
+          - ServerSideApply=true
+```
+
+The exact labels/project can vary, but the important shift is:
+- rendered branches become deploy truth
+- `main` stays env-policy / metadata / Kargo config
+- branch-local rendered output stays at `apps/codeai/deployments/<deployment>/deploy/`
+
+One prerequisite is non-optional:
+- every managed deployment must have a real
+  `apps/codeai/deployments/<deployment>/deployment.yaml` file on `main`
+- if `levelbuilder` and `production` still use `.disabled` placeholders,
+  rename them before switching to this ApplicationSet shape
+
+## Common `review-infra-changes` Stage sketch
+
+This is the shared review gate pattern. Each consuming plan must provide its
+own `requestedFreight` block and render inputs.
+
+```yaml
+apiVersion: kargo.akuity.io/v1alpha1
+kind: Stage
+metadata:
+  name: review-infra-changes
+  namespace: kargo-project-codeai
+spec:
+  vars:
+    - name: gitopsRepo
+      value: https://github.com/code-dot-org/k8s-gitops.git
+    - name: targetBranch
+      value: stage/production
+    - name: renderDeployment
+      value: production
+    - name: renderPath
+      value: apps/codeai/deployments/production/deploy
+  promotionTemplate:
+    spec:
+      steps:
+        - uses: git-clone
+          config:
+            repoURL: ${{ vars.gitopsRepo }}
+            checkout:
+              - branch: main
+                path: ./src
+              - branch: ${{ vars.targetBranch }}
+                create: true
+                path: ./out
+
+        - uses: git-clear
+          config:
+            path: ./out/${{ vars.renderPath }}
+
+        # Plan-specific render logic goes here and should:
+        # 1. read production deployment policy, not ctx.stage
+        # 2. write only under ./out/${{ vars.renderPath }}
+
+        - uses: git-commit
+          config:
+            path: ./out
+            message: Review ${{ vars.renderDeployment }} render for PR
+
+        - uses: git-push
+          as: push
+          config:
+            path: ./out
+            generateTargetBranch: true
+
+        - uses: git-open-pr
+          as: open-pr
+          config:
+            repoURL: ${{ vars.gitopsRepo }}
+            sourceBranch: ${{ outputs.push.branch }}
+            targetBranch: ${{ vars.targetBranch }}
+            title: Review ${{ vars.renderDeployment }} render
+
+        - uses: git-wait-for-pr
+          config:
+            repoURL: ${{ vars.gitopsRepo }}
+            prNumber: ${{ outputs['open-pr'].pr.id }}
+```
+
+## What varies plan-to-plan
+
+This module does not define Freight or rendering inputs. Each plan decides:
+- where Freight comes from
+- the exact `requestedFreight` block
+- whether render input is live source, a frozen Git snapshot, or an OCI capsule
+- whether the render engine is Helm or Kustomize
+- whether staging/test sync directly after push or through a separate approval step

--- a/k8s/docs/kargotecture/report-iteration-7.md
+++ b/k8s/docs/kargotecture/report-iteration-7.md
@@ -77,7 +77,7 @@ while still keeping `Source Snapshot + Rendered Branches` extremely close.
 
 ## Ranked Ideas
 
-### 1. [Common-Case Freight + Rendered Branches](./plans/iteration-7/common-case-rendered-branches.md)
+### 1. [Common-Case Freight + Rendered Branches](./plans/iteration-7/common-case-rendered-branches.md) ([Helm](https://github.com/code-dot-org/code-dot-org/pull/71562) | [Kustomize](https://github.com/code-dot-org/code-dot-org/pull/71567))
 `Iteration 7 Weighted: **42.6**`
 
 Let Kargo assemble one Freight from the real image and the real source commit,
@@ -86,7 +86,7 @@ cleanest long-lived answer because it keeps the rendered review gate we want
 while removing both the synthetic build-lock layer and the package snapshot
 archive layer.
 
-### 2. [Source Snapshot (Helm or Kustomize) + Rendered Branches](./plans/iteration-7/source-snapshot-rendered-branches.md)
+### 2. [Source Snapshot (Helm or Kustomize) + Rendered Branches](./plans/iteration-7/source-snapshot-rendered-branches.md) ([Helm](https://github.com/code-dot-org/code-dot-org/pull/71566) | [Kustomize](https://github.com/code-dot-org/code-dot-org/pull/71570))
 `Iteration 7 Weighted: **41.5**`
 
 Freeze the deploy package once per release, then render every stage from that
@@ -94,7 +94,7 @@ frozen snapshot into rendered branches. This remains the strongest explicit
 release-payload design and the cleanest frozen-input review model, but it keeps
 more system furniture than the winner.
 
-### 3. [Rendered Branches from a Thin Lock](./plans/iteration-7/rendered-branches.md)
+### 3. [Rendered Branches from a Thin Lock](./plans/iteration-7/rendered-branches.md) ([Helm](https://github.com/code-dot-org/code-dot-org/pull/71565) | [Kustomize](https://github.com/code-dot-org/code-dot-org/pull/71568))
 `Iteration 7 Weighted: **39.1**`
 
 Keep a tiny build-lock record, but make every promotion render real
@@ -102,14 +102,14 @@ stage-specific output into stage branches. This is still the strongest
 explicit-control variant, but the build-lock stays as permanent machinery
 without buying enough extra simplicity over `Common-Case`.
 
-### 4. [Argo Refs code-dot-org Commit](./plans/iteration-7/argo-refs-code-dot-org-commit.md)
+### 4. [Argo Refs code-dot-org Commit](./plans/iteration-7/argo-refs-code-dot-org-commit.md) ([Helm](https://github.com/code-dot-org/code-dot-org/pull/71561) | [Kustomize](https://github.com/code-dot-org/code-dot-org/pull/71564))
 `Iteration 7 Weighted: **33.8**`
 
 Write one tiny release record and let Argo deploy source pinned to the promoted
 commit. This is attractive on pure source-driven simplicity, but it gives up
 the final rendered review surface that the higher-ranked plans preserve.
 
-### 5. [OCI Release Capsule](./plans/iteration-7/oci-release-capsule.md)
+### 5. [OCI Release Capsule](./plans/iteration-7/oci-release-capsule.md) ([Helm](https://github.com/code-dot-org/code-dot-org/pull/71563) | [Kustomize](https://github.com/code-dot-org/code-dot-org/pull/71569))
 `Iteration 7 Weighted: **31.2**`
 
 Make one immutable OCI artifact the center of release truth, then render from

--- a/k8s/docs/kargotecture/report-iteration-7.md
+++ b/k8s/docs/kargotecture/report-iteration-7.md
@@ -1,0 +1,285 @@
+# Kargo Systems Plans
+
+This report summarizes the final live iteration 7 finalist set:
+
+- [Common-Case Freight + Rendered Branches](./plans/iteration-7/common-case-rendered-branches.md) ([Helm](https://github.com/code-dot-org/code-dot-org/pull/71562) | [Kustomize](https://github.com/code-dot-org/code-dot-org/pull/71567))
+- [Source Snapshot (Helm or Kustomize) + Rendered Branches](./plans/iteration-7/source-snapshot-rendered-branches.md) ([Helm](https://github.com/code-dot-org/code-dot-org/pull/71566) | [Kustomize](https://github.com/code-dot-org/code-dot-org/pull/71570))
+- [Rendered Branches from a Thin Lock](./plans/iteration-7/rendered-branches.md) ([Helm](https://github.com/code-dot-org/code-dot-org/pull/71565) | [Kustomize](https://github.com/code-dot-org/code-dot-org/pull/71568))
+- [Argo Refs code-dot-org Commit](./plans/iteration-7/argo-refs-code-dot-org-commit.md) ([Helm](https://github.com/code-dot-org/code-dot-org/pull/71561) | [Kustomize](https://github.com/code-dot-org/code-dot-org/pull/71564))
+- [OCI Release Capsule](./plans/iteration-7/oci-release-capsule.md) ([Helm](https://github.com/code-dot-org/code-dot-org/pull/71563) | [Kustomize](https://github.com/code-dot-org/code-dot-org/pull/71569))
+
+The detailed plans live in:
+- [`k8s/docs/kargo-architecture/plans/iteration-7/`](./plans/iteration-7/)
+
+The ranking file lives in:
+- [Iteration 7 rankings](./plans/iteration-7/rankings.md)
+
+This report intentionally mirrors the synthesis style of
+[report-iteration-5.md](./report-iteration-5.md).
+
+## Best-Of Callouts
+
+- **Best for KISS:** [Common-Case Freight + Rendered Branches](./plans/iteration-7/common-case-rendered-branches.md) ([Helm](https://github.com/code-dot-org/code-dot-org/pull/71562) | [Kustomize](https://github.com/code-dot-org/code-dot-org/pull/71567))
+- **Best for reviewability:** [Source Snapshot (Helm or Kustomize) + Rendered Branches](./plans/iteration-7/source-snapshot-rendered-branches.md) ([Helm](https://github.com/code-dot-org/code-dot-org/pull/71566) | [Kustomize](https://github.com/code-dot-org/code-dot-org/pull/71570))
+- **Best for future Kustomize:** [Source Snapshot (Helm or Kustomize) + Rendered Branches](./plans/iteration-7/source-snapshot-rendered-branches.md) ([Helm](https://github.com/code-dot-org/code-dot-org/pull/71566) | [Kustomize](https://github.com/code-dot-org/code-dot-org/pull/71570))
+- **Best for Kargo Native:** [Common-Case Freight + Rendered Branches](./plans/iteration-7/common-case-rendered-branches.md) ([Helm](https://github.com/code-dot-org/code-dot-org/pull/71562) | [Kustomize](https://github.com/code-dot-org/code-dot-org/pull/71567))
+
+## Recommendation Frame
+
+- **Best foundation for the 10-year system:** [Common-Case Freight + Rendered Branches](./plans/iteration-7/common-case-rendered-branches.md) ([Helm](https://github.com/code-dot-org/code-dot-org/pull/71562) | [Kustomize](https://github.com/code-dot-org/code-dot-org/pull/71567))
+- **Best frozen-input foundation:** [Source Snapshot (Helm or Kustomize) + Rendered Branches](./plans/iteration-7/source-snapshot-rendered-branches.md) ([Helm](https://github.com/code-dot-org/code-dot-org/pull/71566) | [Kustomize](https://github.com/code-dot-org/code-dot-org/pull/71570))
+- **Best explicit control variant:** [Rendered Branches from a Thin Lock](./plans/iteration-7/rendered-branches.md) ([Helm](https://github.com/code-dot-org/code-dot-org/pull/71565) | [Kustomize](https://github.com/code-dot-org/code-dot-org/pull/71568))
+- **Best source-driven fallback:** [Argo Refs code-dot-org Commit](./plans/iteration-7/argo-refs-code-dot-org-commit.md) ([Helm](https://github.com/code-dot-org/code-dot-org/pull/71561) | [Kustomize](https://github.com/code-dot-org/code-dot-org/pull/71564))
+- **Best immutable artifact-forward alternative:** [OCI Release Capsule](./plans/iteration-7/oci-release-capsule.md) ([Helm](https://github.com/code-dot-org/code-dot-org/pull/71563) | [Kustomize](https://github.com/code-dot-org/code-dot-org/pull/71569))
+
+Interpretation:
+- If you want the simplest elegant long-lived system that still gives a true
+  final rendered diff review before production, choose
+  **Common-Case Freight + Rendered Branches**.
+- If you want the clearest frozen-input release object and are willing to keep a
+  package snapshot/archive system in Git, choose
+  **Source Snapshot + Rendered Branches**.
+- If you want the strongest explicit-control version of the rendered-review
+  family, keep **Rendered Branches from a Thin Lock** in view.
+- If you want the simplest source-driven path and are willing to give up the
+  rendered final review surface, **Argo Refs code-dot-org Commit** is the
+  fallback, not the main answer.
+
+## Iteration 5 Expert Continuity
+
+Iteration 5 is still highly relevant because three separate scoring voices all
+converged on the same top cluster:
+
+- Jesse normalized ranking:
+  `Source Snapshot + Render` `#1`,
+  `Common-Case + Render` `#2`,
+  `Rendered Branches` `#3`
+- Original architect normalized ranking:
+  `Common-Case + Render` `#1`,
+  `Rendered Branches` `#2`,
+  `Source Snapshot + Render` `#3`
+- Advisor rerank:
+  `Source Snapshot + Render` `#1`,
+  `Common-Case + Render` `#2`,
+  `Rendered Branches` `#3`
+
+So the important fact is not that iteration 7 found a totally new winner.
+It did not.
+
+The important fact is that iteration 7 keeps the same consensus top family and
+then breaks the `Common-Case` vs `Source Snapshot` tie using a simpler rule:
+
+- both satisfy the mandatory rendered diff review requirement
+- `Common-Case` leaves behind less synthetic release machinery
+
+That is why this report puts `Common-Case Freight + Rendered Branches` first,
+while still keeping `Source Snapshot + Rendered Branches` extremely close.
+
+## Ranked Ideas
+
+### 1. [Common-Case Freight + Rendered Branches](./plans/iteration-7/common-case-rendered-branches.md)
+`Iteration 7 Weighted: **42.6**`
+
+Let Kargo assemble one Freight from the real image and the real source commit,
+then render stage-specific output into long-lived stage branches. This is the
+cleanest long-lived answer because it keeps the rendered review gate we want
+while removing both the synthetic build-lock layer and the package snapshot
+archive layer.
+
+### 2. [Source Snapshot (Helm or Kustomize) + Rendered Branches](./plans/iteration-7/source-snapshot-rendered-branches.md)
+`Iteration 7 Weighted: **41.5**`
+
+Freeze the deploy package once per release, then render every stage from that
+frozen snapshot into rendered branches. This remains the strongest explicit
+release-payload design and the cleanest frozen-input review model, but it keeps
+more system furniture than the winner.
+
+### 3. [Rendered Branches from a Thin Lock](./plans/iteration-7/rendered-branches.md)
+`Iteration 7 Weighted: **39.1**`
+
+Keep a tiny build-lock record, but make every promotion render real
+stage-specific output into stage branches. This is still the strongest
+explicit-control variant, but the build-lock stays as permanent machinery
+without buying enough extra simplicity over `Common-Case`.
+
+### 4. [Argo Refs code-dot-org Commit](./plans/iteration-7/argo-refs-code-dot-org-commit.md)
+`Iteration 7 Weighted: **33.8**`
+
+Write one tiny release record and let Argo deploy source pinned to the promoted
+commit. This is attractive on pure source-driven simplicity, but it gives up
+the final rendered review surface that the higher-ranked plans preserve.
+
+### 5. [OCI Release Capsule](./plans/iteration-7/oci-release-capsule.md)
+`Iteration 7 Weighted: **31.2**`
+
+Make one immutable OCI artifact the center of release truth, then render from
+that artifact. This is the strongest artifact-integrity story in the set, but
+it is still more exotic and more operationally heavy than the simpler rendered
+Git winners.
+
+## Top 5 Freight Shapes
+
+This is the simple version: what Kargo is really promoting in the five
+finalists, and how those shapes differ.
+
+### 1. [Common-Case Freight + Rendered Branches](./plans/iteration-7/common-case-rendered-branches.md)
+This plan does not write a release record into `warehouses/codeai/` at all.
+Kargo watches the real image and the real `code-dot-org` branch, pairs them
+into one Freight, and renders stage output from that pair.
+
+```text
+warehouses/codeai/
+  (unused)
+```
+
+```yaml
+apiVersion: kargo.akuity.io/v1alpha1
+kind: Warehouse
+spec:
+  subscriptions:
+    - image:
+        repoURL: ghcr.io/code-dot-org/code-dot-org
+    - git:
+        repoURL: https://github.com/code-dot-org/code-dot-org.git
+        branch: staging
+  freightCreationCriteria:
+    expression: imageTag == 'git-' + gitCommit
+```
+
+### 2. [Source Snapshot (Helm or Kustomize) + Rendered Branches](./plans/iteration-7/source-snapshot-rendered-branches.md)
+This plan saves a frozen copy of the deploy package for every release, then
+promotes that frozen source snapshot into rendered stage branches.
+
+```text
+warehouses/codeai/freight/git-<full-commit-sha>/
+  freight.yaml
+  helm/
+  # or:
+  kustomize/
+warehouses/codeai/freight/current/
+  freight.yaml
+  helm/
+  # or:
+  kustomize/
+```
+
+```yaml
+revision: <full-commit-sha>
+tag: git-<full-commit-sha>
+image:
+  ref: ghcr.io/code-dot-org/code-dot-org:git-<full-commit-sha>
+  digest: sha256:...
+packageType: helm # or kustomize
+```
+
+### 3. [Rendered Branches from a Thin Lock](./plans/iteration-7/rendered-branches.md)
+This plan writes only a tiny release note into GitOps, then Kargo uses that
+note to fetch source and render the real manifests.
+
+```text
+warehouses/codeai/builds/
+  current.yaml
+  git-<full-commit-sha>.yaml
+```
+
+```yaml
+releaseId: git-<full-commit-sha>
+gitCommit: <full-commit-sha>
+image:
+  ref: ghcr.io/code-dot-org/code-dot-org:git-<full-commit-sha>
+  digest: sha256:...
+packaging:
+  kind: helm # or kustomize
+  sourcePath: k8s/helm # or k8s/kustomize
+```
+
+### 4. [Argo Refs code-dot-org Commit](./plans/iteration-7/argo-refs-code-dot-org-commit.md)
+This is the smallest release record in the finalist set. Kargo promotes only a
+thin Git lock, and Argo later deploys source-oriented truth pinned to that
+commit.
+
+```text
+warehouses/codeai/builds/
+  current.yaml
+  git-<full-commit-sha>.yaml
+```
+
+```yaml
+releaseId: git-<full-commit-sha>
+gitCommit: <full-commit-sha>
+image:
+  ref: ghcr.io/code-dot-org/code-dot-org:git-<full-commit-sha>
+  digest: sha256:...
+packaging:
+  kind: helm # or kustomize
+  sourceRepo: https://github.com/code-dot-org/code-dot-org.git
+```
+
+### 5. [OCI Release Capsule](./plans/iteration-7/oci-release-capsule.md)
+This plan promotes the app image and a matching OCI release capsule. The
+capsule carries the deploy package plus release metadata.
+
+```text
+registry:
+  ghcr.io/code-dot-org/code-dot-org:git-<full-commit-sha>
+  ghcr.io/code-dot-org/codeai-release-capsule:git-<full-commit-sha>
+```
+
+```yaml
+gitCommit: <full-commit-sha>
+image:
+  repoURL: ghcr.io/code-dot-org/code-dot-org
+  tag: git-<full-commit-sha>
+  digest: sha256:...
+package:
+  kind: helm # or kustomize
+  path: package/helm # or package/kustomize
+```
+
+## Cross-Cutting Add-Ons
+
+### PR-based `review-infra-changes`
+For any rendered-output plan, keep `review-infra-changes` as a PR gate against
+the production rendered branch. That is the most honest form of final infra
+review in this whole doc set.
+
+### Image digest recording
+Even when a plan stays Git-centric, keep the image digest in the promoted
+record. This is the minimum viable integrity baseline.
+
+### OCI as later hardening, not phase-1 architecture
+If the eventual winner later needs stronger immutable payload handling, OCI
+looks better as a phase-2 refinement than as the first architecture move.
+
+### Kustomize refactor direction
+If Kustomize becomes the durable packaging model, the shared long-lived app
+package should continue to converge toward:
+
+```text
+code-dot-org/k8s/kustomize/
+  base/
+  components/
+  local/
+    overlays/
+```
+
+with environment policy and deploy wrappers living in `k8s-gitops`.
+
+## Detailed Plans and Rankings
+
+- Iteration 7 rankings:
+  [`k8s/docs/kargo-architecture/plans/iteration-7/rankings.md`](./plans/iteration-7/rankings.md)
+- Iteration 7 notes:
+  [`k8s/docs/kargo-architecture/plans/iteration-7/NOTES.md`](./plans/iteration-7/NOTES.md)
+- Finalist plans:
+  [`k8s/docs/kargo-architecture/plans/iteration-7/`](./plans/iteration-7/)
+
+## Weighted Rankings Table
+
+| Rank | Plan | Helm PR | Kustomize PR | KISS | Review | Kustomize | Helm | Local Dev | Kargo | Migration | Clarity | Immutable | Day-2 | Weighted |
+| ---: | --- | --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| 1 | [Common-Case Freight + Rendered Branches](./plans/iteration-7/common-case-rendered-branches.md) | [PR #71562](https://github.com/code-dot-org/code-dot-org/pull/71562) | [PR #71567](https://github.com/code-dot-org/code-dot-org/pull/71567) | 4 | 5 | 5 | 4 | 5 | 5 | 3 | 4 | 3 | 4 | **42.6** |
+| 2 | [Source Snapshot (Helm or Kustomize) + Rendered Branches](./plans/iteration-7/source-snapshot-rendered-branches.md) | [PR #71566](https://github.com/code-dot-org/code-dot-org/pull/71566) | [PR #71570](https://github.com/code-dot-org/code-dot-org/pull/71570) | 4 | 5 | 5 | 4 | 5 | 3 | 3 | 5 | 5 | 4 | **41.5** |
+| 3 | [Rendered Branches from a Thin Lock](./plans/iteration-7/rendered-branches.md) | [PR #71565](https://github.com/code-dot-org/code-dot-org/pull/71565) | [PR #71568](https://github.com/code-dot-org/code-dot-org/pull/71568) | 3 | 5 | 5 | 4 | 5 | 4 | 4 | 5 | 3 | 4 | **39.1** |
+| 4 | [Argo Refs code-dot-org Commit](./plans/iteration-7/argo-refs-code-dot-org-commit.md) | [PR #71561](https://github.com/code-dot-org/code-dot-org/pull/71561) | [PR #71564](https://github.com/code-dot-org/code-dot-org/pull/71564) | 4 | 2 | 4 | 4 | 5 | 3 | 4 | 3 | 3 | 4 | **33.8** |
+| 5 | [OCI Release Capsule](./plans/iteration-7/oci-release-capsule.md) | [PR #71563](https://github.com/code-dot-org/code-dot-org/pull/71563) | [PR #71569](https://github.com/code-dot-org/code-dot-org/pull/71569) | 2 | 4 | 4 | 3 | 5 | 3 | 2 | 4 | 5 | 3 | **31.2** |

--- a/k8s/docs/kargotecture/report-iteration-7.md
+++ b/k8s/docs/kargotecture/report-iteration-7.md
@@ -9,7 +9,7 @@ This report summarizes the final live iteration 7 finalist set:
 - [OCI Release Capsule](./plans/iteration-7/oci-release-capsule.md) ([Helm](https://github.com/code-dot-org/code-dot-org/pull/71563) | [Kustomize](https://github.com/code-dot-org/code-dot-org/pull/71569))
 
 The detailed plans live in:
-- [`k8s/docs/kargo-architecture/plans/iteration-7/`](./plans/iteration-7/)
+- [`k8s/docs/kargotecture/plans/iteration-7/`](./plans/iteration-7/)
 
 The ranking file lives in:
 - [Iteration 7 rankings](./plans/iteration-7/rankings.md)
@@ -268,11 +268,11 @@ with environment policy and deploy wrappers living in `k8s-gitops`.
 ## Detailed Plans and Rankings
 
 - Iteration 7 rankings:
-  [`k8s/docs/kargo-architecture/plans/iteration-7/rankings.md`](./plans/iteration-7/rankings.md)
+  [`k8s/docs/kargotecture/plans/iteration-7/rankings.md`](./plans/iteration-7/rankings.md)
 - Iteration 7 notes:
-  [`k8s/docs/kargo-architecture/plans/iteration-7/NOTES.md`](./plans/iteration-7/NOTES.md)
+  [`k8s/docs/kargotecture/plans/iteration-7/NOTES.md`](./plans/iteration-7/NOTES.md)
 - Finalist plans:
-  [`k8s/docs/kargo-architecture/plans/iteration-7/`](./plans/iteration-7/)
+  [`k8s/docs/kargotecture/plans/iteration-7/`](./plans/iteration-7/)
 
 ## Weighted Rankings Table
 

--- a/k8s/docs/kargotecture/research-plan.md
+++ b/k8s/docs/kargotecture/research-plan.md
@@ -1,0 +1,354 @@
+# Plan for the Iterative Kargo System Planning Doc Set
+
+## Summary
+Produce a multi-pass Kargo system planning doc set for CodeAI.
+
+Final deliverables:
+- Approved research-plan snapshot:
+  - `k8s/docs/kargo-architecture/research-plan.md`
+- Iteration summary reports:
+  - `k8s/docs/kargo-architecture/report-iteration-${N}.md`
+- Iteration outputs:
+  - `k8s/docs/kargo-architecture/plans/iteration-${N}/*.md`
+  - `k8s/docs/kargo-architecture/plans/iteration-${N}/rankings.md`
+  - `k8s/docs/kargo-architecture/plans/iteration-${N}/NOTES.md`
+- Prior iteration snapshots:
+  - `k8s/docs/kargo-architecture/plans/iteration-1/*`
+  - `k8s/docs/kargo-architecture/plans/iteration-2/*`
+  - `...`
+
+This work should be iterative and creative. Treat the whole system as editable:
+- GH actions
+- Kargo warehouse/freight/stages
+- ArgoCD layout
+- `k8s-gitops` structure
+- `code-dot-org/k8s` Helm structure
+- future Kustomize structure
+- rendered vs source-driven promotion
+- review flow
+
+If a really good plan needs a structural refactor, include it. Do not preserve today’s layout by default.
+
+The user will not mind if planning takes 2 hours, as long as each iteration is still improving the rankings or generating new very creative ideas, keep iterating.
+
+## Step 1
+Before doing any `make_plans` research/iteration work, write the finally approved research plan **verbatim** to:
+
+- `k8s/docs/kargo-architecture/research-plan.md`
+
+This file becomes the canonical instruction sheet for the planning effort.
+
+Before each stage of every `make_plans` iteration:
+- load `k8s/docs/kargo-architecture/research-plan.md` freshly into context
+
+If context gets compacted:
+- reload `k8s/docs/kargo-architecture/research-plan.md` again before continuing
+
+Treat this as mandatory process, not optional housekeeping.
+
+## Deliverables
+### Canonical iteration output
+For each `make_plans` iteration, write the plan set directly to:
+- `k8s/docs/kargo-architecture/plans/iteration-${N}/`
+
+This iteration directory is the canonical output for iteration `N`.
+
+Do not maintain a separate "latest working set" in:
+- `k8s/docs/kargo-architecture/plans/*.md`
+- `k8s/docs/kargo-architecture/plans/rankings.md`
+
+Do not write files to top-level `k8s/docs/kargo-architecture/plans/` first and then copy them into an iteration directory. Author the iteration output directly inside `iteration-${N}/`.
+
+Each iteration directory must contain:
+- that iteration’s plan docs
+- `rankings.md`
+- `NOTES.md`
+
+`NOTES.md` should be meta notes about the iteration:
+- what improved
+- what got worse
+- what ideas converged
+- what new ideas appeared
+- what unresolved tensions remain
+- whether another iteration is justified
+
+Think of `NOTES.md` as a research-advisor meeting note.
+
+### Iteration summary reports
+As the final step of each `make_plans` iteration, write:
+- `k8s/docs/kargo-architecture/report-iteration-${N}.md`
+
+Each iteration report should:
+- start with:
+  - Best for KISS
+  - Best for reviewability
+  - Best for future Kustomize
+  - Best for Kargo Native
+- present the ranked idea list for that iteration
+  - in each idea include the weighted ranking from rankings.md
+  - link each idea directly to its detailed plan doc in `k8s/docs/kargo-architecture/plans/iteration-${N}/`
+- link directly to `k8s/docs/kargo-architecture/plans/iteration-${N}/rankings.md`
+- include cross-cutting add-ons / variations
+- avoid a long appendix
+- at the bottom put a weighted rankings table, example:
+```
+| Rank | Plan | KISS | Review | Kustomize | Helm | Local Dev | Kargo | Migration | Clarity | Immutable | Day-2 | Weighted |
+| ---: | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| 1 | [Common-Case Freight + Rendered Branches](./plans/iteration-5/common-case-rendered-branches.md) | 4 | 5 | 5 | 4 | 5 | 5 | 3 | 5 | 4 | 5 | 44.0 |
+| 2 | [Rendered Branches](./rendered-branches.md) | 4 | 5 | 5 | 4 | 5 | 5 | 3 | 5 | 4 | 4 | 43.2 |
+| 3 | [Immutable Package Snapshot + Rendered Branches](.plans/iteration-5/immutable-package-rendered-branches.md) | 4 | 5 | 5 | 5 | 5 | 4 | 3 | 5 | 5 | 4 | 42.8 |
+| 4 | [Image Provenance + Rendered Branches](.plans/iteration-5/image-provenance-rendered-branches.md) | 4 | 5 | 5 | 4 | 5 | 4 | 4 | 4 | 4 | 4 | 42.1 |
+| 5 | [Thin Build Lock](.plans/iteration-5/thin-build-lock.md) | 5 | 2 | 4 | 5 | 5 | 4 | 5 | 4 | 3 | 4 | 38.6 |
+| 6 | [Helm Source Snapshot](.plans/iteration-5/helm-source-snapshot.md) | 4 | 4 | 2 | 5 | 5 | 4 | 3 | 4 | 4 | 4 | 38.1 |
+| 7 | [Pre-Rendered Release Bundle](.plans/iteration-5/rendered-release-bundle.md) | 3 | 5 | 4 | 4 | 5 | 3 | 2 | 5 | 5 | 3 | 36.8 |
+| 8 | [Kustomize Base Snapshot](.plans/iteration-5/kustomize-base-snapshot.md) | 3 | 4 | 5 | 1 | 4 | 5 | 2 | 4 | 5 | 4 | 36.1 |
+| 9 | [OCI Chart Release Pair](.plans/iteration-5/oci-chart-release-pair.md) | 3 | 4 | 2 | 5 | 5 | 4 | 2 | 4 | 5 | 4 | 35.2 |
+| 10 | [Kustomize Split Overlays](.plans/iteration-5/kustomize-split-overlays.md) | 3 | 3 | 5 | 1 | 3 | 4 | 2 | 3 | 4 | 4 | 31.5 |
+| 11 | [Multi-Warehouse Base + Overlay](.plans/iteration-5/multi-warehouse-base-overlay.md) | 2 | 4 | 5 | 1 | 3 | 5 | 2 | 3 | 5 | 4 | 31.4 |
+| 12 | [OCI Bundle Pointer](.plans/iteration-5/oci-bundle-pointer.md) | 2 | 4 | 4 | 3 | 5 | 3 | 2 | 3 | 5 | 3 | 30.9 |
+| 13 | [GitOps Truth with Generated Mirror](./gitops-truth-generated-mirror.md) | 2 | 4 | 4 | 3 | 2 | 3 | 1 | 3 | 3 | 3 | 27.1 |
+```
+
+Of course the ranking categories can change, this is just an example, this should also be in the rankings.md file you output earlier
+
+Put final weighted values in **bold** unlike this example.
+
+
+## Detailed Plan Requirements
+Each plan doc in `k8s/docs/kargo-architecture/plans/iteration-${N}/` must be self-contained and implementable on its own.
+
+Each plan doc must include:
+- Title
+- Short name
+- Catchy description
+- Whether it is:
+  - Helm plan
+  - Kustomize plan
+  - packaging-agnostic plan
+- Whether it uses:
+  - rendered manifests pattern
+  - source-driven pattern
+  - hybrid pattern
+- Warehouse artifact structure under `warehouses/codeai/`
+- Freight definition
+- Full Kargo project design
+- Stage-by-stage promotion flow
+- `review infra changes` stage behavior
+- `test` stage automation behavior
+- `Does it break/awkwardize skaffold or local-dev in any way?`
+- Proposed Helm/Kustomize directory structure in both repos if the plan changes them
+- Pros / cons
+- Migration notes
+- Any useful implementation notes that do not fit neatly elsewhere
+- `# Code changes`
+  - `## k8s-gitops changes`
+  - `## code-dot-org changes`
+
+## Iterative Process
+Run this loop multiple times:
+
+### `make_plans` loop
+1. Before starting iteration `N`, read:
+- `k8s/docs/kargo-architecture/research-plan.md`
+- all prior `k8s/docs/kargo-architecture/plans/iteration-*/rankings.md`
+- all prior `k8s/docs/kargo-architecture/plans/iteration-*/NOTES.md`
+- enough of the prior iteration plan docs to avoid repeating the same ping-pong edits
+
+2. Create or update the iteration working set directly in:
+- `k8s/docs/kargo-architecture/plans/iteration-${N}/`
+
+Do not use top-level `k8s/docs/kargo-architecture/plans/*.md` as an intermediate or mirrored output location.
+
+3. Before each major stage within the iteration, reload:
+- `k8s/docs/kargo-architecture/research-plan.md`
+
+Major stages include at least:
+- research sweep
+- plan writing/revision
+- compare/contrast
+- scoring/ranking
+- generate new ideas
+- synthesis/new-plan generation
+- finalizing the iteration snapshot
+- writing the iteration report
+
+4. Compare and contrast all current plans.
+
+5. Score all current plans and write:
+- `k8s/docs/kargo-architecture/plans/iteration-${N}/rankings.md`
+
+6. After ranking, explicitly generate new ideas:
+- propose at least 1-2 new candidate ideas, hybrids, or reframings if the ranking or comparison suggests a gap
+- prefer doing this even after a boring iteration if there is still any plausible opening for a better framing
+
+7. Decide whether to:
+- improve existing plans
+- merge overlapping plans
+- split overloaded plans
+- add 1–2 new plans if comparison/ranking or idea generation reveals a missing hybrid or better framing
+
+8. Ensure the whole iteration is written directly into:
+- `k8s/docs/kargo-architecture/plans/iteration-${N}/`
+
+All plan docs and rankings for that iteration should already live there; do not keep a duplicated top-level copy.
+
+9. Write:
+- `k8s/docs/kargo-architecture/plans/iteration-${N}/NOTES.md`
+
+10. As the final step of the iteration, write:
+- `k8s/docs/kargo-architecture/report-iteration-${N}.md`
+
+11. Read the latest rankings, notes, and iteration report before deciding whether another iteration is warranted.
+
+Repeat until:
+- iterations stop producing materially new ideas, or
+- rankings stop improving in meaningful ways, or
+- further changes are mostly ping-pong rather than new synthesis
+- and even then, prefer a couple of incremental "boring" iterations if they might still unlock a new idea before stopping entirely
+
+Important rules:
+- `10` plans is not a hard limit.
+- If iteration produces more strong plans, keep them.
+- If ranking reveals a plan can be made significantly better, revise it and iterate again.
+- Prefer improving plans over churning names or making cosmetic reshuffles.
+
+## Rankings File Requirements
+### `iteration-${N}/rankings.md`
+For each iteration, include:
+- the same "Best for" list used at the top of the iteration report:
+  - Best for KISS
+  - Best for reviewability
+  - Best for future Kustomize
+  - Best for Kargo Native
+- linked plan list for that iteration
+- per-axis score for every plan
+- weighted total score
+- short explanation of why the top few landed where they did
+- short explanation of what changed since the prior iteration
+
+## Ranking Axes
+Use 1–5 scoring per axis.
+
+Required axes and weights:
+- KISS / operational simplicity: **3.0**
+- Reviewability: **2.0**
+- Future Kustomize fit: **0.7**
+- Current Helm fit: **0.3**
+- `Does it break/awkwardize skaffold or local-dev in any way?`: **1.0**
+- Kargo-native fit: **1.0**
+- Migration complexity: **0.2**
+- Promotion clarity: **0.3**
+- Artifact integrity / immutability: **0.3**
+- Day-2 operability: **0.8**
+
+You may add a few extra axes if they genuinely help, but:
+- keep their weights low
+- do not dilute the user-specified axes much
+- do not let new axes materially overpower the existing priorities
+
+Guidance:
+- KISS dominates.
+- Reviewability is second.
+- Future Kustomize fit matters more than current Helm fit.
+- KISS should primarily mean simplicity of the operating model and the on-disk structure.
+- Do not treat lower KLOC or simpler implementation code as the main definition of KISS; that is nice when it happens, but it is not the primary goal.
+- The Skaffold/local-dev axis should focus on user pain, awkwardness, mirroring, local drift risk, or degraded workflows.
+- Migration complexity is intentionally low weight.
+
+## Research Scope
+Continue researching during execution, not just at the start.
+
+Required research inputs:
+- current `code-dot-org` GH workflows
+- current `skaffold.yaml`
+- current `k8s/helm`
+- current `k8s-gitops` CodeAI app and Kargo config
+- upstream Kargo docs
+- upstream examples:
+  - `kargo-simple`
+  - `kargo-helm`
+  - `kargo-advanced`
+- local `k8s/kustomize` branch as inspiration, but not as a fixed target
+
+Also, while writing plans, continue looking up any Kargo feature or pattern that becomes relevant:
+- chart subscriptions
+- OCI download patterns
+- rendered branch patterns
+- PR review patterns
+- multiple-warehouse composition
+- verification and gating patterns
+
+## Required Constraints
+- `$gitcommit` always means the `code-dot-org` `staging` commit that triggered the warehouse upload.
+- That `$gitcommit` is the canonical release identity for both image and matching chart/base source.
+- Default bias: keep source of truth in `code-dot-org`.
+- Alternative source-of-truth models are allowed only if they preserve or credibly replace local Skaffold workflows.
+- Current Kargo boilerplate in `k8s-gitops` should not anchor the design.
+- Helm and Kustomize structure are both fair game for redesign.
+- Any part of the system may be changed if it unlocks a materially better plan.
+
+## Specific Kustomize/Helm Refactor Expectations
+The plans should not treat current directory names as sacred. In particular:
+- Kustomize plans should seriously consider renaming `targets/` to `overlays/`.
+- Kustomize plans should seriously consider splitting:
+  - shared base/components in `code-dot-org/k8s/...`
+  - env-specific overlays in `k8s-gitops/apps/codeai/...`
+- Some strong plans may keep all overlays in `code-dot-org`.
+- Some strong plans may move only env-type overlays to `k8s-gitops`, for example near `apps/codeai/envTypes/`.
+- Helm plans may also propose a cleaner separation between:
+  - reusable chart source in `code-dot-org`
+  - env values / env overlays / rendered output in `k8s-gitops`
+
+Every plan that changes structure must show the proposed tree explicitly. If a plan requires no structure changes, it should say so explicitly.
+
+## What Every Plan Must Decide
+Every detailed plan doc must make concrete decisions for:
+- what the GH action publishes under `warehouses/codeai/`
+- what the Warehouse subscribes to
+- what freight is
+- whether freight stays the same shape across stages
+- how `staging -> test -> [production, levelbuilder]` works
+- what `review infra changes` means in that model
+- how `test` runs automated checks
+- whether artifacts are source, rendered, OCI, or hybrid
+- whether the plan uses rendered manifests pattern or not
+- whether the plan is Helm-specific, Kustomize-specific, or agnostic
+- how ArgoCD consumes promoted output
+- whether Helm/Kustomize directory structure changes are needed
+- if structure changes are needed, what the proposed tree looks like in:
+  - `code-dot-org/k8s/...`
+  - `k8s-gitops/...`
+- exact repo changes in both repos
+- any plan-specific notes that would help implementation even if they do not fit a rigid template
+
+## Acceptance Criteria
+This is done when:
+- the approved research plan has first been written verbatim to `k8s/docs/kargo-architecture/research-plan.md`
+- the `make_plans` loop has been run multiple times
+- each new iteration reads prior iteration rankings and notes first
+- each iteration reloads `k8s/docs/kargo-architecture/research-plan.md` before each major stage
+- after any context compaction, `k8s/docs/kargo-architecture/research-plan.md` is reloaded before continuing
+- each iteration writes:
+  - detailed plans directly in `k8s/docs/kargo-architecture/plans/iteration-${N}/`
+  - `k8s/docs/kargo-architecture/plans/iteration-${N}/rankings.md`
+  - `k8s/docs/kargo-architecture/plans/iteration-${N}/NOTES.md`
+  - `k8s/docs/kargo-architecture/report-iteration-${N}.md`
+- there are at least 6 detailed plans, with no upper cap if more strong plans appear
+- there is a final iteration rankings file in the final iteration directory
+- there is a latest iteration report at `k8s/docs/kargo-architecture/report-iteration-${N}.md`
+- the iteration report clearly links directly to plan docs and `rankings.md` in the matching iteration directory
+- every plan explicitly covers whether it breaks or awkwardizes Skaffold/local-dev
+- every plan explicitly defines freight and promotion shape
+- every plan explicitly states rendered vs non-rendered
+- every plan explicitly states Helm-specific, Kustomize-specific, or agnostic
+- every plan details any required Helm/Kustomize directory changes
+- the latest iteration report clearly identifies the best KISS, reviewability, future-Kustomize, and Kargo Native options
+
+## Assumptions / Defaults
+- Use `k8s/docs/kargo-architecture/plans/iteration-${N}/` as the canonical output location for each iteration's detailed plans.
+- Do not maintain a duplicated top-level `k8s/docs/kargo-architecture/plans/*.md` latest mirror.
+- Use `k8s/docs/kargo-architecture/report-iteration-${N}.md` for the report written at the end of each iteration.
+- Use the weights above exactly unless later user feedback changes them.
+- Keep iterating until the plan set feels saturated rather than arbitrarily stopping after one pass.
+- If changes are still being made, prefer continuing for a couple more iterations even if the last step was only incrementally better.
+- Prefer decision-complete detailed plans over uniform formatting when the two are in tension.

--- a/k8s/docs/kargotecture/research-plan.md
+++ b/k8s/docs/kargotecture/research-plan.md
@@ -5,16 +5,16 @@ Produce a multi-pass Kargo system planning doc set for CodeAI.
 
 Final deliverables:
 - Approved research-plan snapshot:
-  - `k8s/docs/kargo-architecture/research-plan.md`
+  - `k8s/docs/kargotecture/research-plan.md`
 - Iteration summary reports:
-  - `k8s/docs/kargo-architecture/report-iteration-${N}.md`
+  - `k8s/docs/kargotecture/report-iteration-${N}.md`
 - Iteration outputs:
-  - `k8s/docs/kargo-architecture/plans/iteration-${N}/*.md`
-  - `k8s/docs/kargo-architecture/plans/iteration-${N}/rankings.md`
-  - `k8s/docs/kargo-architecture/plans/iteration-${N}/NOTES.md`
+  - `k8s/docs/kargotecture/plans/iteration-${N}/*.md`
+  - `k8s/docs/kargotecture/plans/iteration-${N}/rankings.md`
+  - `k8s/docs/kargotecture/plans/iteration-${N}/NOTES.md`
 - Prior iteration snapshots:
-  - `k8s/docs/kargo-architecture/plans/iteration-1/*`
-  - `k8s/docs/kargo-architecture/plans/iteration-2/*`
+  - `k8s/docs/kargotecture/plans/iteration-1/*`
+  - `k8s/docs/kargotecture/plans/iteration-2/*`
   - `...`
 
 This work should be iterative and creative. Treat the whole system as editable:
@@ -34,30 +34,30 @@ The user will not mind if planning takes 2 hours, as long as each iteration is s
 ## Step 1
 Before doing any `make_plans` research/iteration work, write the finally approved research plan **verbatim** to:
 
-- `k8s/docs/kargo-architecture/research-plan.md`
+- `k8s/docs/kargotecture/research-plan.md`
 
 This file becomes the canonical instruction sheet for the planning effort.
 
 Before each stage of every `make_plans` iteration:
-- load `k8s/docs/kargo-architecture/research-plan.md` freshly into context
+- load `k8s/docs/kargotecture/research-plan.md` freshly into context
 
 If context gets compacted:
-- reload `k8s/docs/kargo-architecture/research-plan.md` again before continuing
+- reload `k8s/docs/kargotecture/research-plan.md` again before continuing
 
 Treat this as mandatory process, not optional housekeeping.
 
 ## Deliverables
 ### Canonical iteration output
 For each `make_plans` iteration, write the plan set directly to:
-- `k8s/docs/kargo-architecture/plans/iteration-${N}/`
+- `k8s/docs/kargotecture/plans/iteration-${N}/`
 
 This iteration directory is the canonical output for iteration `N`.
 
 Do not maintain a separate "latest working set" in:
-- `k8s/docs/kargo-architecture/plans/*.md`
-- `k8s/docs/kargo-architecture/plans/rankings.md`
+- `k8s/docs/kargotecture/plans/*.md`
+- `k8s/docs/kargotecture/plans/rankings.md`
 
-Do not write files to top-level `k8s/docs/kargo-architecture/plans/` first and then copy them into an iteration directory. Author the iteration output directly inside `iteration-${N}/`.
+Do not write files to top-level `k8s/docs/kargotecture/plans/` first and then copy them into an iteration directory. Author the iteration output directly inside `iteration-${N}/`.
 
 Each iteration directory must contain:
 - that iteration’s plan docs
@@ -76,7 +76,7 @@ Think of `NOTES.md` as a research-advisor meeting note.
 
 ### Iteration summary reports
 As the final step of each `make_plans` iteration, write:
-- `k8s/docs/kargo-architecture/report-iteration-${N}.md`
+- `k8s/docs/kargotecture/report-iteration-${N}.md`
 
 Each iteration report should:
 - start with:
@@ -86,8 +86,8 @@ Each iteration report should:
   - Best for Kargo Native
 - present the ranked idea list for that iteration
   - in each idea include the weighted ranking from rankings.md
-  - link each idea directly to its detailed plan doc in `k8s/docs/kargo-architecture/plans/iteration-${N}/`
-- link directly to `k8s/docs/kargo-architecture/plans/iteration-${N}/rankings.md`
+  - link each idea directly to its detailed plan doc in `k8s/docs/kargotecture/plans/iteration-${N}/`
+- link directly to `k8s/docs/kargotecture/plans/iteration-${N}/rankings.md`
 - include cross-cutting add-ons / variations
 - avoid a long appendix
 - at the bottom put a weighted rankings table, example:
@@ -115,7 +115,7 @@ Put final weighted values in **bold** unlike this example.
 
 
 ## Detailed Plan Requirements
-Each plan doc in `k8s/docs/kargo-architecture/plans/iteration-${N}/` must be self-contained and implementable on its own.
+Each plan doc in `k8s/docs/kargotecture/plans/iteration-${N}/` must be self-contained and implementable on its own.
 
 Each plan doc must include:
 - Title
@@ -149,18 +149,18 @@ Run this loop multiple times:
 
 ### `make_plans` loop
 1. Before starting iteration `N`, read:
-- `k8s/docs/kargo-architecture/research-plan.md`
-- all prior `k8s/docs/kargo-architecture/plans/iteration-*/rankings.md`
-- all prior `k8s/docs/kargo-architecture/plans/iteration-*/NOTES.md`
+- `k8s/docs/kargotecture/research-plan.md`
+- all prior `k8s/docs/kargotecture/plans/iteration-*/rankings.md`
+- all prior `k8s/docs/kargotecture/plans/iteration-*/NOTES.md`
 - enough of the prior iteration plan docs to avoid repeating the same ping-pong edits
 
 2. Create or update the iteration working set directly in:
-- `k8s/docs/kargo-architecture/plans/iteration-${N}/`
+- `k8s/docs/kargotecture/plans/iteration-${N}/`
 
-Do not use top-level `k8s/docs/kargo-architecture/plans/*.md` as an intermediate or mirrored output location.
+Do not use top-level `k8s/docs/kargotecture/plans/*.md` as an intermediate or mirrored output location.
 
 3. Before each major stage within the iteration, reload:
-- `k8s/docs/kargo-architecture/research-plan.md`
+- `k8s/docs/kargotecture/research-plan.md`
 
 Major stages include at least:
 - research sweep
@@ -175,7 +175,7 @@ Major stages include at least:
 4. Compare and contrast all current plans.
 
 5. Score all current plans and write:
-- `k8s/docs/kargo-architecture/plans/iteration-${N}/rankings.md`
+- `k8s/docs/kargotecture/plans/iteration-${N}/rankings.md`
 
 6. After ranking, explicitly generate new ideas:
 - propose at least 1-2 new candidate ideas, hybrids, or reframings if the ranking or comparison suggests a gap
@@ -188,15 +188,15 @@ Major stages include at least:
 - add 1–2 new plans if comparison/ranking or idea generation reveals a missing hybrid or better framing
 
 8. Ensure the whole iteration is written directly into:
-- `k8s/docs/kargo-architecture/plans/iteration-${N}/`
+- `k8s/docs/kargotecture/plans/iteration-${N}/`
 
 All plan docs and rankings for that iteration should already live there; do not keep a duplicated top-level copy.
 
 9. Write:
-- `k8s/docs/kargo-architecture/plans/iteration-${N}/NOTES.md`
+- `k8s/docs/kargotecture/plans/iteration-${N}/NOTES.md`
 
 10. As the final step of the iteration, write:
-- `k8s/docs/kargo-architecture/report-iteration-${N}.md`
+- `k8s/docs/kargotecture/report-iteration-${N}.md`
 
 11. Read the latest rankings, notes, and iteration report before deciding whether another iteration is warranted.
 
@@ -323,19 +323,19 @@ Every detailed plan doc must make concrete decisions for:
 
 ## Acceptance Criteria
 This is done when:
-- the approved research plan has first been written verbatim to `k8s/docs/kargo-architecture/research-plan.md`
+- the approved research plan has first been written verbatim to `k8s/docs/kargotecture/research-plan.md`
 - the `make_plans` loop has been run multiple times
 - each new iteration reads prior iteration rankings and notes first
-- each iteration reloads `k8s/docs/kargo-architecture/research-plan.md` before each major stage
-- after any context compaction, `k8s/docs/kargo-architecture/research-plan.md` is reloaded before continuing
+- each iteration reloads `k8s/docs/kargotecture/research-plan.md` before each major stage
+- after any context compaction, `k8s/docs/kargotecture/research-plan.md` is reloaded before continuing
 - each iteration writes:
-  - detailed plans directly in `k8s/docs/kargo-architecture/plans/iteration-${N}/`
-  - `k8s/docs/kargo-architecture/plans/iteration-${N}/rankings.md`
-  - `k8s/docs/kargo-architecture/plans/iteration-${N}/NOTES.md`
-  - `k8s/docs/kargo-architecture/report-iteration-${N}.md`
+  - detailed plans directly in `k8s/docs/kargotecture/plans/iteration-${N}/`
+  - `k8s/docs/kargotecture/plans/iteration-${N}/rankings.md`
+  - `k8s/docs/kargotecture/plans/iteration-${N}/NOTES.md`
+  - `k8s/docs/kargotecture/report-iteration-${N}.md`
 - there are at least 6 detailed plans, with no upper cap if more strong plans appear
 - there is a final iteration rankings file in the final iteration directory
-- there is a latest iteration report at `k8s/docs/kargo-architecture/report-iteration-${N}.md`
+- there is a latest iteration report at `k8s/docs/kargotecture/report-iteration-${N}.md`
 - the iteration report clearly links directly to plan docs and `rankings.md` in the matching iteration directory
 - every plan explicitly covers whether it breaks or awkwardizes Skaffold/local-dev
 - every plan explicitly defines freight and promotion shape
@@ -345,9 +345,9 @@ This is done when:
 - the latest iteration report clearly identifies the best KISS, reviewability, future-Kustomize, and Kargo Native options
 
 ## Assumptions / Defaults
-- Use `k8s/docs/kargo-architecture/plans/iteration-${N}/` as the canonical output location for each iteration's detailed plans.
-- Do not maintain a duplicated top-level `k8s/docs/kargo-architecture/plans/*.md` latest mirror.
-- Use `k8s/docs/kargo-architecture/report-iteration-${N}.md` for the report written at the end of each iteration.
+- Use `k8s/docs/kargotecture/plans/iteration-${N}/` as the canonical output location for each iteration's detailed plans.
+- Do not maintain a duplicated top-level `k8s/docs/kargotecture/plans/*.md` latest mirror.
+- Use `k8s/docs/kargotecture/report-iteration-${N}.md` for the report written at the end of each iteration.
 - Use the weights above exactly unless later user feedback changes them.
 - Keep iterating until the plan set feels saturated rather than arbitrarily stopping after one pass.
 - If changes are still being made, prefer continuing for a couple more iterations even if the last step was only incrementally better.

--- a/k8s/helm/templates/dashboard/_dashboard.yaml
+++ b/k8s/helm/templates/dashboard/_dashboard.yaml
@@ -62,6 +62,8 @@ spec:
             value: {{ .Values.RAILS_ENV }}
           - name: RACK_ENV
             value: {{ .Values.RAILS_ENV }}
+          - name: PERMIT_UNKNOWN_PROPERTIES_IN_CDO
+            value: "1"
           {{- if .Values.localDev.mounts.mountDotAWS }}
           - name: AWS_PROFILE
             value: {{ .Values.localDev.mounts.AWS_PROFILE }}

--- a/k8s/kustomize/base/dashboard-deployment.yaml
+++ b/k8s/kustomize/base/dashboard-deployment.yaml
@@ -26,6 +26,8 @@ spec:
               value: MISSING_RAILS_ENV
             - name: RACK_ENV
               value: MISSING_RAILS_ENV
+            - name: PERMIT_UNKNOWN_PROPERTIES_IN_CDO
+              value: "1"
           envFrom:
             - prefix: CDO_
               configMapRef:

--- a/k8s/kustomize/components/dashboard-job-setup-db/job.yaml
+++ b/k8s/kustomize/components/dashboard-job-setup-db/job.yaml
@@ -26,6 +26,8 @@ spec:
               value: development
             - name: RACK_ENV
               value: development
+            - name: PERMIT_UNKNOWN_PROPERTIES_IN_CDO
+              value: "1"
           envFrom:
             - prefix: CDO_
               configMapRef:

--- a/k8s/tofu/codeai-k8s/eks-cluster-addons/dex.tf
+++ b/k8s/tofu/codeai-k8s/eks-cluster-addons/dex.tf
@@ -83,7 +83,8 @@ resource "helm_release" "dex" {
           id           = "${local.kargo_hostname}-cli"
           name         = "Kargo CLI"
           public       = true
-          redirectURIs = ["http://localhost/auth/callback"]
+          # Leave redirectURIs unset so Dex accepts localhost callbacks on the
+          # ephemeral loopback port that the Kargo CLI binds for SSO login.
         }
       ]
 


### PR DESCRIPTION
# Kargo Systems Plans

This report summarizes the final live iteration 7 finalist set:

- [Common-Case Freight + Rendered Branches](https://github.com/code-dot-org/code-dot-org/blob/53392ebb468290f43c5759bd44ea5dd5daeafb42/k8s/docs/kargotecture/plans/iteration-7/common-case-rendered-branches.md) ([Helm](https://github.com/code-dot-org/code-dot-org/pull/71562) | [Kustomize](https://github.com/code-dot-org/code-dot-org/pull/71567))
- [Source Snapshot (Helm or Kustomize) + Rendered Branches](https://github.com/code-dot-org/code-dot-org/blob/53392ebb468290f43c5759bd44ea5dd5daeafb42/k8s/docs/kargotecture/plans/iteration-7/source-snapshot-rendered-branches.md) ([Helm](https://github.com/code-dot-org/code-dot-org/pull/71566) | [Kustomize](https://github.com/code-dot-org/code-dot-org/pull/71570))
- [Rendered Branches from a Thin Lock](https://github.com/code-dot-org/code-dot-org/blob/53392ebb468290f43c5759bd44ea5dd5daeafb42/k8s/docs/kargotecture/plans/iteration-7/rendered-branches.md) ([Helm](https://github.com/code-dot-org/code-dot-org/pull/71565) | [Kustomize](https://github.com/code-dot-org/code-dot-org/pull/71568))
- [Argo Refs code-dot-org Commit](https://github.com/code-dot-org/code-dot-org/blob/53392ebb468290f43c5759bd44ea5dd5daeafb42/k8s/docs/kargotecture/plans/iteration-7/argo-refs-code-dot-org-commit.md) ([Helm](https://github.com/code-dot-org/code-dot-org/pull/71561) | [Kustomize](https://github.com/code-dot-org/code-dot-org/pull/71564))
- [OCI Release Capsule](https://github.com/code-dot-org/code-dot-org/blob/53392ebb468290f43c5759bd44ea5dd5daeafb42/k8s/docs/kargotecture/plans/iteration-7/oci-release-capsule.md) ([Helm](https://github.com/code-dot-org/code-dot-org/pull/71563) | [Kustomize](https://github.com/code-dot-org/code-dot-org/pull/71569))

The detailed plans live in:
- [`k8s/docs/kargo-architecture/plans/iteration-7/`](https://github.com/code-dot-org/code-dot-org/blob/53392ebb468290f43c5759bd44ea5dd5daeafb42/k8s/docs/kargotecture/plans/iteration-7/)

The ranking file lives in:
- [Iteration 7 rankings](https://github.com/code-dot-org/code-dot-org/blob/53392ebb468290f43c5759bd44ea5dd5daeafb42/k8s/docs/kargotecture/plans/iteration-7/rankings.md)

This report intentionally mirrors the synthesis style of
[report-iteration-5.md](https://github.com/code-dot-org/code-dot-org/blob/53392ebb468290f43c5759bd44ea5dd5daeafb42/k8s/docs/kargotecture/report-iteration-5.md).

## Best-Of Callouts

- **Best for KISS:** [Common-Case Freight + Rendered Branches](https://github.com/code-dot-org/code-dot-org/blob/53392ebb468290f43c5759bd44ea5dd5daeafb42/k8s/docs/kargotecture/plans/iteration-7/common-case-rendered-branches.md) ([Helm](https://github.com/code-dot-org/code-dot-org/pull/71562) | [Kustomize](https://github.com/code-dot-org/code-dot-org/pull/71567))
- **Best for reviewability:** [Source Snapshot (Helm or Kustomize) + Rendered Branches](https://github.com/code-dot-org/code-dot-org/blob/53392ebb468290f43c5759bd44ea5dd5daeafb42/k8s/docs/kargotecture/plans/iteration-7/source-snapshot-rendered-branches.md) ([Helm](https://github.com/code-dot-org/code-dot-org/pull/71566) | [Kustomize](https://github.com/code-dot-org/code-dot-org/pull/71570))
- **Best for future Kustomize:** [Source Snapshot (Helm or Kustomize) + Rendered Branches](https://github.com/code-dot-org/code-dot-org/blob/53392ebb468290f43c5759bd44ea5dd5daeafb42/k8s/docs/kargotecture/plans/iteration-7/source-snapshot-rendered-branches.md) ([Helm](https://github.com/code-dot-org/code-dot-org/pull/71566) | [Kustomize](https://github.com/code-dot-org/code-dot-org/pull/71570))
- **Best for Kargo Native:** [Common-Case Freight + Rendered Branches](https://github.com/code-dot-org/code-dot-org/blob/53392ebb468290f43c5759bd44ea5dd5daeafb42/k8s/docs/kargotecture/plans/iteration-7/common-case-rendered-branches.md) ([Helm](https://github.com/code-dot-org/code-dot-org/pull/71562) | [Kustomize](https://github.com/code-dot-org/code-dot-org/pull/71567))

## Recommendation Frame

- **Best foundation for the 10-year system:** [Common-Case Freight + Rendered Branches](https://github.com/code-dot-org/code-dot-org/blob/53392ebb468290f43c5759bd44ea5dd5daeafb42/k8s/docs/kargotecture/plans/iteration-7/common-case-rendered-branches.md) ([Helm](https://github.com/code-dot-org/code-dot-org/pull/71562) | [Kustomize](https://github.com/code-dot-org/code-dot-org/pull/71567))
- **Best frozen-input foundation:** [Source Snapshot (Helm or Kustomize) + Rendered Branches](https://github.com/code-dot-org/code-dot-org/blob/53392ebb468290f43c5759bd44ea5dd5daeafb42/k8s/docs/kargotecture/plans/iteration-7/source-snapshot-rendered-branches.md) ([Helm](https://github.com/code-dot-org/code-dot-org/pull/71566) | [Kustomize](https://github.com/code-dot-org/code-dot-org/pull/71570))
- **Best explicit control variant:** [Rendered Branches from a Thin Lock](https://github.com/code-dot-org/code-dot-org/blob/53392ebb468290f43c5759bd44ea5dd5daeafb42/k8s/docs/kargotecture/plans/iteration-7/rendered-branches.md) ([Helm](https://github.com/code-dot-org/code-dot-org/pull/71565) | [Kustomize](https://github.com/code-dot-org/code-dot-org/pull/71568))
- **Best source-driven fallback:** [Argo Refs code-dot-org Commit](https://github.com/code-dot-org/code-dot-org/blob/53392ebb468290f43c5759bd44ea5dd5daeafb42/k8s/docs/kargotecture/plans/iteration-7/argo-refs-code-dot-org-commit.md) ([Helm](https://github.com/code-dot-org/code-dot-org/pull/71561) | [Kustomize](https://github.com/code-dot-org/code-dot-org/pull/71564))
- **Best immutable artifact-forward alternative:** [OCI Release Capsule](https://github.com/code-dot-org/code-dot-org/blob/53392ebb468290f43c5759bd44ea5dd5daeafb42/k8s/docs/kargotecture/plans/iteration-7/oci-release-capsule.md) ([Helm](https://github.com/code-dot-org/code-dot-org/pull/71563) | [Kustomize](https://github.com/code-dot-org/code-dot-org/pull/71569))

Interpretation:
- If you want the simplest elegant long-lived system that still gives a true
  final rendered diff review before production, choose
  **Common-Case Freight + Rendered Branches**.
- If you want the clearest frozen-input release object and are willing to keep a
  package snapshot/archive system in Git, choose
  **Source Snapshot + Rendered Branches**.
- If you want the strongest explicit-control version of the rendered-review
  family, keep **Rendered Branches from a Thin Lock** in view.
- If you want the simplest source-driven path and are willing to give up the
  rendered final review surface, **Argo Refs code-dot-org Commit** is the
  fallback, not the main answer.

## Iteration 5 Expert Continuity

Iteration 5 is still highly relevant because three separate scoring voices all
converged on the same top cluster:

- Jesse normalized ranking:
  `Source Snapshot + Render` `#1`,
  `Common-Case + Render` `#2`,
  `Rendered Branches` `#3`
- Original architect normalized ranking:
  `Common-Case + Render` `#1`,
  `Rendered Branches` `#2`,
  `Source Snapshot + Render` `#3`
- Advisor rerank:
  `Source Snapshot + Render` `#1`,
  `Common-Case + Render` `#2`,
  `Rendered Branches` `#3`

So the important fact is not that iteration 7 found a totally new winner.
It did not.

The important fact is that iteration 7 keeps the same consensus top family and
then breaks the `Common-Case` vs `Source Snapshot` tie using a simpler rule:

- both satisfy the mandatory rendered diff review requirement
- `Common-Case` leaves behind less synthetic release machinery

That is why this report puts `Common-Case Freight + Rendered Branches` first,
while still keeping `Source Snapshot + Rendered Branches` extremely close.

## Ranked Ideas

### 1. **[Common-Case Freight + Rendered Branches](https://github.com/code-dot-org/code-dot-org/blob/53392ebb468290f43c5759bd44ea5dd5daeafb42/k8s/docs/kargotecture/plans/iteration-7/common-case-rendered-branches.md)** ([Helm](https://github.com/code-dot-org/code-dot-org/pull/71562) | [Kustomize](https://github.com/code-dot-org/code-dot-org/pull/71567))
`Iteration 7 Weighted: **42.6**`

Let Kargo assemble one Freight from the real image and the real source commit,
then render stage-specific output into long-lived stage branches. This is the
cleanest long-lived answer because it keeps the rendered review gate we want
while removing both the synthetic build-lock layer and the package snapshot
archive layer.

### 2. **[Source Snapshot (Helm or Kustomize) + Rendered Branches](https://github.com/code-dot-org/code-dot-org/blob/53392ebb468290f43c5759bd44ea5dd5daeafb42/k8s/docs/kargotecture/plans/iteration-7/source-snapshot-rendered-branches.md)** ([Helm](https://github.com/code-dot-org/code-dot-org/pull/71566) | [Kustomize](https://github.com/code-dot-org/code-dot-org/pull/71570))
`Iteration 7 Weighted: **41.5**`

Freeze the deploy package once per release, then render every stage from that
frozen snapshot into rendered branches. This remains the strongest explicit
release-payload design and the cleanest frozen-input review model, but it keeps
more system furniture than the winner.

### 3. **[Rendered Branches from a Thin Lock](https://github.com/code-dot-org/code-dot-org/blob/53392ebb468290f43c5759bd44ea5dd5daeafb42/k8s/docs/kargotecture/plans/iteration-7/rendered-branches.md)** ([Helm](https://github.com/code-dot-org/code-dot-org/pull/71565) | [Kustomize](https://github.com/code-dot-org/code-dot-org/pull/71568))
`Iteration 7 Weighted: **39.1**`

Keep a tiny build-lock record, but make every promotion render real
stage-specific output into stage branches. This is still the strongest
explicit-control variant, but the build-lock stays as permanent machinery
without buying enough extra simplicity over `Common-Case`.

### 4. **[Argo Refs code-dot-org Commit](https://github.com/code-dot-org/code-dot-org/blob/53392ebb468290f43c5759bd44ea5dd5daeafb42/k8s/docs/kargotecture/plans/iteration-7/argo-refs-code-dot-org-commit.md)** ([Helm](https://github.com/code-dot-org/code-dot-org/pull/71561) | [Kustomize](https://github.com/code-dot-org/code-dot-org/pull/71564))
`Iteration 7 Weighted: **33.8**`

Write one tiny release record and let Argo deploy source pinned to the promoted
commit. This is attractive on pure source-driven simplicity, but it gives up
the final rendered review surface that the higher-ranked plans preserve.

### 5. **[OCI Release Capsule](https://github.com/code-dot-org/code-dot-org/blob/53392ebb468290f43c5759bd44ea5dd5daeafb42/k8s/docs/kargotecture/plans/iteration-7/oci-release-capsule.md)** ([Helm](https://github.com/code-dot-org/code-dot-org/pull/71563) | [Kustomize](https://github.com/code-dot-org/code-dot-org/pull/71569))
`Iteration 7 Weighted: **31.2**`

Make one immutable OCI artifact the center of release truth, then render from
that artifact. This is the strongest artifact-integrity story in the set, but
it is still more exotic and more operationally heavy than the simpler rendered
Git winners.

## Top 5 Freight Shapes

This is the simple version: what Kargo is really promoting in the five
finalists, and how those shapes differ.

### 1. **[Common-Case Freight + Rendered Branches](https://github.com/code-dot-org/code-dot-org/blob/53392ebb468290f43c5759bd44ea5dd5daeafb42/k8s/docs/kargotecture/plans/iteration-7/common-case-rendered-branches.md)**
This plan does not write a release record into `warehouses/codeai/` at all.
Kargo watches the real image and the real `code-dot-org` branch, pairs them
into one Freight, and renders stage output from that pair.

```text
warehouses/codeai/
  (unused)
```

```yaml
apiVersion: kargo.akuity.io/v1alpha1
kind: Warehouse
spec:
  subscriptions:
    - image:
        repoURL: ghcr.io/code-dot-org/code-dot-org
    - git:
        repoURL: https://github.com/code-dot-org/code-dot-org.git
        branch: staging
  freightCreationCriteria:
    expression: imageTag == 'git-' + gitCommit
```

### 2. **[Source Snapshot (Helm or Kustomize) + Rendered Branches](https://github.com/code-dot-org/code-dot-org/blob/53392ebb468290f43c5759bd44ea5dd5daeafb42/k8s/docs/kargotecture/plans/iteration-7/source-snapshot-rendered-branches.md)**
This plan saves a frozen copy of the deploy package for every release, then
promotes that frozen source snapshot into rendered stage branches.

```text
warehouses/codeai/freight/git-<full-commit-sha>/
  freight.yaml
  helm/
  # or:
  kustomize/
warehouses/codeai/freight/current/
  freight.yaml
  helm/
  # or:
  kustomize/
```

```yaml
revision: <full-commit-sha>
tag: git-<full-commit-sha>
image:
  ref: ghcr.io/code-dot-org/code-dot-org:git-<full-commit-sha>
  digest: sha256:...
packageType: helm # or kustomize
```

### 3. **[Rendered Branches from a Thin Lock](https://github.com/code-dot-org/code-dot-org/blob/53392ebb468290f43c5759bd44ea5dd5daeafb42/k8s/docs/kargotecture/plans/iteration-7/rendered-branches.md)**
This plan writes only a tiny release note into GitOps, then Kargo uses that
note to fetch source and render the real manifests.

```text
warehouses/codeai/builds/
  current.yaml
  git-<full-commit-sha>.yaml
```

```yaml
releaseId: git-<full-commit-sha>
gitCommit: <full-commit-sha>
image:
  ref: ghcr.io/code-dot-org/code-dot-org:git-<full-commit-sha>
  digest: sha256:...
packaging:
  kind: helm # or kustomize
  sourcePath: k8s/helm # or k8s/kustomize
```

### 4. **[Argo Refs code-dot-org Commit](https://github.com/code-dot-org/code-dot-org/blob/53392ebb468290f43c5759bd44ea5dd5daeafb42/k8s/docs/kargotecture/plans/iteration-7/argo-refs-code-dot-org-commit.md)**
This is the smallest release record in the finalist set. Kargo promotes only a
thin Git lock, and Argo later deploys source-oriented truth pinned to that
commit.

```text
warehouses/codeai/builds/
  current.yaml
  git-<full-commit-sha>.yaml
```

```yaml
releaseId: git-<full-commit-sha>
gitCommit: <full-commit-sha>
image:
  ref: ghcr.io/code-dot-org/code-dot-org:git-<full-commit-sha>
  digest: sha256:...
packaging:
  kind: helm # or kustomize
  sourceRepo: https://github.com/code-dot-org/code-dot-org.git
```

### 5. **[OCI Release Capsule](https://github.com/code-dot-org/code-dot-org/blob/53392ebb468290f43c5759bd44ea5dd5daeafb42/k8s/docs/kargotecture/plans/iteration-7/oci-release-capsule.md)**
This plan promotes the app image and a matching OCI release capsule. The
capsule carries the deploy package plus release metadata.

```text
registry:
  ghcr.io/code-dot-org/code-dot-org:git-<full-commit-sha>
  ghcr.io/code-dot-org/codeai-release-capsule:git-<full-commit-sha>
```

```yaml
gitCommit: <full-commit-sha>
image:
  repoURL: ghcr.io/code-dot-org/code-dot-org
  tag: git-<full-commit-sha>
  digest: sha256:...
package:
  kind: helm # or kustomize
  path: package/helm # or package/kustomize
```

## Cross-Cutting Add-Ons

### PR-based `review-infra-changes`
For any rendered-output plan, keep `review-infra-changes` as a PR gate against
the production rendered branch. That is the most honest form of final infra
review in this whole doc set.

### Image digest recording
Even when a plan stays Git-centric, keep the image digest in the promoted
record. This is the minimum viable integrity baseline.

### OCI as later hardening, not phase-1 architecture
If the eventual winner later needs stronger immutable payload handling, OCI
looks better as a phase-2 refinement than as the first architecture move.

### Kustomize refactor direction
If Kustomize becomes the durable packaging model, the shared long-lived app
package should continue to converge toward:

```text
code-dot-org/k8s/kustomize/
  base/
  components/
  local/
    overlays/
```

with environment policy and deploy wrappers living in `k8s-gitops`.

## Detailed Plans and Rankings

- Iteration 7 rankings:
  **[`k8s/docs/kargo-architecture/plans/iteration-7/rankings.md`](https://github.com/code-dot-org/code-dot-org/blob/53392ebb468290f43c5759bd44ea5dd5daeafb42/k8s/docs/kargotecture/plans/iteration-7/rankings.md)**
- Iteration 7 notes:
  **[`k8s/docs/kargo-architecture/plans/iteration-7/NOTES.md`](https://github.com/code-dot-org/code-dot-org/blob/53392ebb468290f43c5759bd44ea5dd5daeafb42/k8s/docs/kargotecture/plans/iteration-7/NOTES.md)**
- Finalist plans:
  **[`k8s/docs/kargo-architecture/plans/iteration-7/`](https://github.com/code-dot-org/code-dot-org/blob/53392ebb468290f43c5759bd44ea5dd5daeafb42/k8s/docs/kargotecture/plans/iteration-7/)**

## Weighted Rankings Table

| Rank | Plan | Helm PR | Kustomize PR | KISS | Review | Kustomize | Helm | Local Dev | Kargo | Migration | Clarity | Immutable | Day-2 | Weighted |
| ---: | --- | --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| 1 | **[Common-Case Freight + Rendered Branches](https://github.com/code-dot-org/code-dot-org/blob/53392ebb468290f43c5759bd44ea5dd5daeafb42/k8s/docs/kargotecture/plans/iteration-7/common-case-rendered-branches.md)** | [PR #71562](https://github.com/code-dot-org/code-dot-org/pull/71562) | [PR #71567](https://github.com/code-dot-org/code-dot-org/pull/71567) | 4 | 5 | 5 | 4 | 5 | 5 | 3 | 4 | 3 | 4 | **42.6** |
| 2 | **[Source Snapshot (Helm or Kustomize) + Rendered Branches](https://github.com/code-dot-org/code-dot-org/blob/53392ebb468290f43c5759bd44ea5dd5daeafb42/k8s/docs/kargotecture/plans/iteration-7/source-snapshot-rendered-branches.md)** | [PR #71566](https://github.com/code-dot-org/code-dot-org/pull/71566) | [PR #71570](https://github.com/code-dot-org/code-dot-org/pull/71570) | 4 | 5 | 5 | 4 | 5 | 3 | 3 | 5 | 5 | 4 | **41.5** |
| 3 | **[Rendered Branches from a Thin Lock](https://github.com/code-dot-org/code-dot-org/blob/53392ebb468290f43c5759bd44ea5dd5daeafb42/k8s/docs/kargotecture/plans/iteration-7/rendered-branches.md)** | [PR #71565](https://github.com/code-dot-org/code-dot-org/pull/71565) | [PR #71568](https://github.com/code-dot-org/code-dot-org/pull/71568) | 3 | 5 | 5 | 4 | 5 | 4 | 4 | 5 | 3 | 4 | **39.1** |
| 4 | **[Argo Refs code-dot-org Commit](https://github.com/code-dot-org/code-dot-org/blob/53392ebb468290f43c5759bd44ea5dd5daeafb42/k8s/docs/kargotecture/plans/iteration-7/argo-refs-code-dot-org-commit.md)** | [PR #71561](https://github.com/code-dot-org/code-dot-org/pull/71561) | [PR #71564](https://github.com/code-dot-org/code-dot-org/pull/71564) | 4 | 2 | 4 | 4 | 5 | 3 | 4 | 3 | 3 | 4 | **33.8** |
| 5 | **[OCI Release Capsule](https://github.com/code-dot-org/code-dot-org/blob/53392ebb468290f43c5759bd44ea5dd5daeafb42/k8s/docs/kargotecture/plans/iteration-7/oci-release-capsule.md)** | [PR #71563](https://github.com/code-dot-org/code-dot-org/pull/71563) | [PR #71569](https://github.com/code-dot-org/code-dot-org/pull/71569) | 2 | 4 | 4 | 3 | 5 | 3 | 2 | 4 | 5 | 3 | **31.2** |
