### PR TITLE
disable unit caching specifically in rake tasks

### DIFF
--- a/dashboard/app/models/unit.rb
+++ b/dashboard/app/models/unit.rb
@@ -351,6 +351,12 @@ class Unit < ApplicationRecord
   def self.should_cache?
     return false if Rails.application.config.levelbuilder_mode
     return false unless Rails.application.config.cache_classes
+    # Unit caching is designed for use within the running web application, but we
+    # can't easily limit it to that scenario until the CDO.running_web_application?
+    # helper is fixed (see https://github.com/code-dot-org/code-dot-org/pull/71525).
+    # In the interim, make sure we skip caching during rake seed tasks, which
+    # sometimes break when caching is enabled.
+    return false if File.basename($0) == 'rake'
     return false if ENV['UNIT_TEST'] || ENV['CI']
     true
   end

--- a/dashboard/config/initializers/script_preload.rb
+++ b/dashboard/config/initializers/script_preload.rb
@@ -2,8 +2,6 @@
 # This speeds up load time of new Unicorn child worker processes
 # and Spring application preloader (Rails console, unit tests).
 Rails.application.config.to_prepare do
-  # Skip if this is running a Rake task (e.g. rake db:setup) or when caching is disabled
-  next if File.basename($0) == 'rake'
   next unless Unit.should_cache? && !ENV['SKIP_SCRIPT_PRELOAD']
 
   # Populate the shared in-memory cache from the database.


### PR DESCRIPTION
Follow-up from:
- https://github.com/code-dot-org/code-dot-org/pull/71467
- https://github.com/code-dot-org/code-dot-org/pull/71503

https://github.com/code-dot-org/code-dot-org/pull/71467 attempted to limit unit caching to running (puma) web servers, but this exposed an error in our existing logic in `CDO.running_web_application?` leading to performance issues in production.

A fix has been opened for the logic in `CDO.running_web_application?`, but I don't want [this work](https://github.com/code-dot-org/code-dot-org/pull/71285) to take a dependency on that work, so this PR offers a more scoped fix of just disabling caching within rake tasks.

## Testing story
- all rake tasks for building and testing have already been validated to some extent as part of shipping #71467 -- we didn't notice any issues with that PR until we hit peak traffic the following morning.
- manually verified this has the intended effect locally:
```
[10:42:13] Dave-M4:~/src/cdo/dashboard (skip-unit-cache-in-rake *)$ git diff
diff --git a/dashboard/config/environments/development.rb b/dashboard/config/environments/development.rb
-  config.cache_classes = false
-  config.cache_store = :null_store
+  config.cache_classes = true
diff --git a/dashboard/lib/services/script_seed.rb b/dashboard/lib/services/script_seed.rb
         seed_context.script = import_script(script_data, md5: md5)
+        puts "Unit.should_cache? #{Unit.should_cache?}"

[10:35:25] Dave-M4:~/src/cdo/dashboard (staging *)$ bundle exec rake seed:single_script SCRIPT_NAME=allthethings
Unit.should_cache? true
Finished seed:single_script (1 second)

[10:42:01] Dave-M4:~/src/cdo/dashboard (skip-unit-cache-in-rake *)$ bundle exec rake seed:single_script SCRIPT_NAME=allthethings
Unit.should_cache? false
Finished seed:single_script (1 second)
```
