### PR TITLE
move signin-callout ui tests off of production courses

### DIFF
--- a/dashboard/config/locales/courses/en.yml
+++ b/dashboard/config/locales/courses/en.yml
@@ -6790,6 +6790,12 @@ en:
           description_student: ''
           description_teacher: ''
           version_title: Pilot 2026
+        ui-test-csf:
+          title: ui-test-csf
+          description_short: ''
+          description_student: ''
+          description_teacher: ''
+          version_title: ''
         teaching-aif-design-build-ai-facilitators-2026:
           title: 'Teaching AIF: Designing & Building with AI'
           description_short: ''

--- a/dashboard/config/locales/scripts/en.yml
+++ b/dashboard/config/locales/scripts/en.yml
@@ -27166,6 +27166,17 @@ en:
             - Use AI as a collaborative partner to brainstorm, debug, and refine code.
             - Develop a personal framework for deciding when to write code themselves and when to seek AI assistance.
             - Describe how the tasks of planning, writing, and testing interactive code relate to the professional roles of a Front-End Developer and QA Engineer.
+        ui-test-csf:
+          lessons:
+            lesson-1:
+              name: Lesson One
+          lesson_groups: {}
+          name: ui-test-csf
+          title: UI Test CSF
+          description_audience: ''
+          description_short: ''
+          description: ''
+          student_description: ''
         pl-facilitators-aif2-intro-2026:
           lessons: {}
           lesson_groups: {}

--- a/dashboard/lib/tasks/seed.rake
+++ b/dashboard/lib/tasks/seed.rake
@@ -72,6 +72,7 @@ namespace :seed do
   SCRIPTS_GLOB = Dir.glob("#{CURRICULUM_CONTENT_DIR}/config/scripts_json/**/*.script_json").sort.flatten.freeze
   SPECIAL_UI_TEST_SCRIPTS = %w(
     ui-test-artist
+    ui-test-csf
     ui-test-script-in-course-2017
     ui-test-script-in-course-2019
     ui-test-script-2-in-course-2017
@@ -359,6 +360,7 @@ namespace :seed do
     end
     %w(
       ui-test-artist
+      ui-test-csf
       ui-test-course-2017
       ui-test-course-2019
       ui-test-original-course-2017

--- a/dashboard/lib/tasks/seed.rake
+++ b/dashboard/lib/tasks/seed.rake
@@ -106,7 +106,6 @@ namespace :seed do
     coursea-2019
     coursec-2019
     coursee-2019
-    coursea-2020
     csd3-2023
     interactive-games-animations-2023
     focus-on-creativity3-2023
@@ -333,7 +332,6 @@ namespace :seed do
        coursea-2019
        coursec-2019
        coursee-2019
-       coursea-2020
        csp-ap
        interactive-games-animations-2023
        interactive-games-animations-2024

--- a/dashboard/lib/tasks/seed.rake
+++ b/dashboard/lib/tasks/seed.rake
@@ -103,8 +103,6 @@ namespace :seed do
     coursed-2017
     coursee-2017
     coursef-2017
-    pre-express-2017
-    express-2017
     coursea-2019
     coursec-2019
     coursee-2019
@@ -332,8 +330,6 @@ namespace :seed do
        coursed-2017
        coursee-2017
        coursef-2017
-       pre-express-2017
-       express-2017
        coursea-2019
        coursec-2019
        coursee-2019

--- a/dashboard/test/ui/config/course_offerings/ui-test-csf.json
+++ b/dashboard/test/ui/config/course_offerings/ui-test-csf.json
@@ -1,0 +1,23 @@
+{
+  "key": "ui-test-csf",
+  "display_name": "ui-test-csf",
+  "is_featured": false,
+  "assignable": true,
+  "curriculum_type": "Course",
+  "marketing_initiative": "CSF",
+  "grade_levels": null,
+  "header": null,
+  "image": null,
+  "cs_topic": null,
+  "school_subject": null,
+  "device_compatibility": "{\"computer\":\"ideal\",\"chromebook\":\"not_recommended\",\"tablet\":\"not_recommended\",\"mobile\":\"incompatible\",\"no_device\":\"incompatible\"}",
+  "description": null,
+  "professional_learning_program": null,
+  "video": null,
+  "published_date": null,
+  "self_paced_pl_course_offering_key": null,
+  "ai_teaching_assistant_available": false,
+  "facilitator_course_permissions": [
+
+  ]
+}

--- a/dashboard/test/ui/config/courses/ui-test-csf.course
+++ b/dashboard/test/ui/config/courses/ui-test-csf.course
@@ -1,0 +1,24 @@
+{
+  "name": "ui-test-csf",
+  "script_names": [
+    "ui-test-csf"
+  ],
+  "original_script_names": [
+    "ui-test-csf"
+  ],
+  "published_state": "preview",
+  "instruction_type": "teacher_led",
+  "participant_audience": "student",
+  "instructor_audience": "teacher",
+  "properties": {
+    "family_name": "ui-test-csf",
+    "numbered_units": "auto",
+    "version_year": "unversioned"
+  },
+  "resources": [
+
+  ],
+  "student_resources": [
+
+  ]
+}

--- a/dashboard/test/ui/config/scripts_json/ui-test-csf.script_json
+++ b/dashboard/test/ui/config/scripts_json/ui-test-csf.script_json
@@ -1,0 +1,154 @@
+{
+  "script": {
+    "name": "ui-test-csf",
+    "wrapup_video_id": null,
+    "login_required": false,
+    "properties": {
+      "curriculum_umbrella": "CSF",
+      "is_migrated": true
+    },
+    "new_name": null,
+    "family_name": null,
+    "serialized_at": "2026-03-24 16:44:24 UTC",
+    "hide_within_course": false,
+    "published_state": "in_development",
+    "instruction_type": null,
+    "instructor_audience": null,
+    "participant_audience": null,
+    "seeding_key": {
+      "script.name": "ui-test-csf"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "ui-test-csf"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "lesson-1",
+      "name": "Lesson One",
+      "absolute_position": 1,
+      "lockable": false,
+      "has_lesson_plan": true,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "lesson-1",
+        "lesson_group.key": "",
+        "script.name": "ui-test-csf"
+      }
+    }
+  ],
+  "lesson_activities": [
+    {
+      "key": "49698413-1471-4335-8a9c-0e9a64d34d02",
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_activity.key": "49698413-1471-4335-8a9c-0e9a64d34d02",
+        "lesson.key": "lesson-1",
+        "lesson_group.key": "",
+        "script.name": "ui-test-csf"
+      }
+    }
+  ],
+  "activity_sections": [
+    {
+      "key": "2dda9127-3cc5-4874-b697-59af6f22da1e",
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "activity_section.key": "2dda9127-3cc5-4874-b697-59af6f22da1e",
+        "lesson_activity.key": "49698413-1471-4335-8a9c-0e9a64d34d02"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "activity_section_position": 1,
+      "assessment": false,
+      "properties": {
+      },
+      "bonus": false,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "K-1 Artist1 1"
+        ],
+        "lesson.key": "lesson-1",
+        "lesson_group.key": "",
+        "script.name": "ui-test-csf",
+        "activity_section.key": "2dda9127-3cc5-4874-b697-59af6f22da1e"
+      },
+      "level_keys": [
+        "K-1 Artist1 1"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "K-1 Artist1 1",
+        "script_level.level_keys": [
+          "K-1 Artist1 1"
+        ],
+        "lesson.key": "lesson-1",
+        "lesson_group.key": "",
+        "script.name": "ui-test-csf",
+        "activity_section.key": "2dda9127-3cc5-4874-b697-59af6f22da1e"
+      }
+    }
+  ],
+  "resources": [
+
+  ],
+  "lessons_resources": [
+
+  ],
+  "scripts_resources": [
+
+  ],
+  "scripts_student_resources": [
+
+  ],
+  "vocabularies": [
+
+  ],
+  "lessons_vocabularies": [
+
+  ],
+  "lessons_programming_expressions": [
+
+  ],
+  "objectives": [
+
+  ],
+  "lessons_standards": [
+
+  ],
+  "lessons_opportunity_standards": [
+
+  ],
+  "rubrics": [
+
+  ],
+  "learning_goals": [
+
+  ],
+  "learning_goal_evidence_levels": [
+
+  ]
+}

--- a/dashboard/test/ui/features/star_labs/signin_callout.feature
+++ b/dashboard/test/ui/features/star_labs/signin_callout.feature
@@ -3,7 +3,7 @@ Feature: Viewing and dismissing the login callout
 
 @no_mobile
 Scenario: Should be able to clear cookies and session storage to see callout again
-  Given I am on "http://studio.code.org/courses/coursea-2020/units/1/lessons/4/levels/2?noautoplay=true"
+  Given I am on "http://studio.code.org/courses/ui-test-csf/units/1/lessons/1/levels/1?noautoplay=true"
   And I wait for the lab page to fully load
   And element ".uitest-signincallout" is visible
   And I dismiss the login reminder
@@ -16,6 +16,6 @@ Scenario: Should be able to clear cookies and session storage to see callout aga
 
 @as_student
 Scenario: Should not see callout on CSF coursea lesson if logged in
-  Given I am on "http://studio.code.org/courses/coursea-2020/units/1/lessons/4/levels/2?noautoplay=true"
+  Given I am on "http://studio.code.org/courses/ui-test-csf/units/1/lessons/1/levels/1?noautoplay=true"
   And I wait for the lab page to fully load
   And element ".uitest-signincallout" is not visible

--- a/dashboard/test/ui/features/star_labs/signin_callout2.feature
+++ b/dashboard/test/ui/features/star_labs/signin_callout2.feature
@@ -2,11 +2,11 @@ Feature: Viewing and dismissing the login callout
 
   @no_mobile
   Scenario: Clicking anywhere should dismiss the login reminder
-    Given I am on "http://studio.code.org/courses/coursea-2020/units/1/lessons/5/levels/3?noautoplay=true"
+    Given I am on "http://studio.code.org/courses/ui-test-csf/units/1/lessons/1/levels/1?noautoplay=true"
     And I wait for the lab page to fully load
     And element ".uitest-signincallout" is visible
     And I dismiss the login reminder
-    And element ".instructions-markdown p" has text "Use 2 movement blocks to get the Scrat to the acorn."
+    And element ".instructions-markdown p" has text "Draw the foot of the man with one line"
     Then element "#runButton" is visible
     And I delete the cookie named "hide_signin_callout"
     And I clear session storage
@@ -20,7 +20,7 @@ Feature: Viewing and dismissing the login callout
 
   @no_mobile
   Scenario: After dismissing the callout, it should not reappear upon refresh
-    Given I am on "http://studio.code.org/courses/coursea-2020/units/1/lessons/5/levels/3?noautoplay=true"
+    Given I am on "http://studio.code.org/courses/ui-test-csf/units/1/lessons/1/levels/1?noautoplay=true"
     And I wait for the lab page to fully load
     And element ".uitest-signincallout" is visible
     And I dismiss the login reminder
@@ -31,7 +31,7 @@ Feature: Viewing and dismissing the login callout
 
   @no_mobile
   Scenario: Nested callouts should work as expected
-    Given I am on "http://studio.code.org/courses/coursea-2020/units/1/lessons/2/levels/2?noautoplay=true"
+    Given I am on "http://studio.code.org/courses/ui-test-csf/units/1/lessons/1/levels/1?noautoplay=true"
     And I wait for the lab page to fully load
     And element ".uitest-signincallout" is visible
     And I dismiss the login reminder
@@ -40,7 +40,7 @@ Feature: Viewing and dismissing the login callout
     And I clear session storage
 
   Scenario: Should be immediately redirected to sign in if pressing sign in button
-    Given I am on "http://studio.code.org/courses/coursea-2020/units/1/lessons/2/levels/2?noautoplay=true"
+    Given I am on "http://studio.code.org/courses/ui-test-csf/units/1/lessons/1/levels/1?noautoplay=true"
     And I wait for the lab page to fully load
     And element ".uitest-signincallout" is visible
     And I click selector ".header_button" if I see it


### PR DESCRIPTION
The reason for this change is to make UI tests no longer depend on production courses. For background, see [partitioned curriculum data proposal](https://docs.google.com/document/d/1iiJXtPODakjuZ7-2yKJ941H56dcyUmUFtWa7zGgqKdw/edit?tab=t.0#heading=h.qx67631q1z2d).

Done as part of this PR:
- added a new `ui-test-csf` unit / course / course offering via levelbuilder UI
  - mark the unit as 'CSF' to trigger the sign in callout here: https://github.com/code-dot-org/code-dot-org/blob/30865d1df227cd9f0a15ac21510205491553a33d/dashboard/app/models/unit.rb#L1438 
- update signin-callout ui tests to use new course
- stop seeding the following courses / units in test: 
  - `express-2017` and `pre-express-2017` (already unused)
  - `coursea-2020` (freed up by this PR)

## Testing story
- drone shows new ui test is passing
- the `[reset db]` commit tag ensures we properly test removal of ui test courses + units from seed.rake
