### PR TITLE
Allow Student Removal in LTI Sections

### DIFF
--- a/apps/src/templates/manageStudents/ManageStudentsActionsCell.jsx
+++ b/apps/src/templates/manageStudents/ManageStudentsActionsCell.jsx
@@ -49,6 +49,7 @@ class ManageStudentsActionsCell extends Component {
     saveStudent: PropTypes.func,
     addStudent: PropTypes.func,
     loadSectionData: PropTypes.func,
+    syncEnabled: PropTypes.bool,
   };
 
   state = {
@@ -150,30 +151,32 @@ class ManageStudentsActionsCell extends Component {
 
     return (
       <div>
-        {!isEditing && loginType !== SectionLoginType.lti_v1 && (
-          <QuickActionsCell>
-            {this.props.canEdit && (
-              <PopUpMenu.Item onClick={this.onEdit}>
-                {i18n.edit()}
+        {!isEditing &&
+          (loginType !== SectionLoginType.lti_v1 ||
+            !this.props.syncEnabled) && (
+            <QuickActionsCell>
+              {this.props.canEdit && (
+                <PopUpMenu.Item onClick={this.onEdit}>
+                  {i18n.edit()}
+                </PopUpMenu.Item>
+              )}
+              {showWordPictureOptions && (
+                <PopUpMenu.Item onClick={this.onPrintLoginInfo}>
+                  {i18n.printLoginCard()}
+                </PopUpMenu.Item>
+              )}
+              {showWordPictureOptions && (
+                <PopUpMenu.Item onClick={this.onViewParentLetter}>
+                  {i18n.viewParentLetter()}
+                </PopUpMenu.Item>
+              )}
+              {this.props.canEdit && <MenuBreak />}
+              <PopUpMenu.Item onClick={this.onRequestDelete} color={color.red}>
+                <FontAwesome icon="times-circle" style={styles.xIcon} />
+                {i18n.removeStudent()}
               </PopUpMenu.Item>
-            )}
-            {showWordPictureOptions && (
-              <PopUpMenu.Item onClick={this.onPrintLoginInfo}>
-                {i18n.printLoginCard()}
-              </PopUpMenu.Item>
-            )}
-            {showWordPictureOptions && (
-              <PopUpMenu.Item onClick={this.onViewParentLetter}>
-                {i18n.viewParentLetter()}
-              </PopUpMenu.Item>
-            )}
-            {this.props.canEdit && <MenuBreak />}
-            <PopUpMenu.Item onClick={this.onRequestDelete} color={color.red}>
-              <FontAwesome icon="times-circle" style={styles.xIcon} />
-              {i18n.removeStudent()}
-            </PopUpMenu.Item>
-          </QuickActionsCell>
-        )}
+            </QuickActionsCell>
+          )}
         {isEditing && rowType !== RowType.ADD && (
           <div>
             <Button

--- a/apps/src/templates/manageStudents/Table/index.jsx
+++ b/apps/src/templates/manageStudents/Table/index.jsx
@@ -367,6 +367,7 @@ class ManageStudentsTable extends Component {
         dependsOnThisSectionForLogin={rowData.dependsOnThisSectionForLogin}
         canEdit={!this.isTeacher(rowData.userType)}
         rowData={rowData}
+        syncEnabled={this.props.syncEnabled}
       />
     );
   }

--- a/apps/test/unit/templates/manageStudents/ManageStudentsActionsCellTest.js
+++ b/apps/test/unit/templates/manageStudents/ManageStudentsActionsCellTest.js
@@ -69,14 +69,26 @@ describe('ManageStudentsActionsCell', () => {
     expect(wrapper).not.to.contain('Edit');
   });
 
-  it('does not render the edit option when loginType is lti', () => {
+  it('does not render the edit option when loginType is lti and roster sync is enabled', () => {
     const wrapper = shallow(
       <ManageStudentsActionsCell
         {...DEFAULT_PROPS}
         loginType={SectionLoginType.lti_v1}
+        syncEnabled={true}
       />
     );
     expect(wrapper).not.to.contain('Edit');
+  });
+
+  it('renders the edit option when loginType is lti and roster sync is disabled', () => {
+    const wrapper = shallow(
+      <ManageStudentsActionsCell
+        {...DEFAULT_PROPS}
+        loginType={SectionLoginType.lti_v1}
+        syncEnabled={null}
+      />
+    );
+    expect(wrapper).to.contain('Edit');
   });
 
   describe('onDelete', () => {


### PR DESCRIPTION
This PR introduces a change to allow a teacher to remove a student from an LTI rostered section if they have LMS Sync setting disabled. Previously, we blocked the ability to remove students if the section was an LTI section completely.

**NOTE:** This does not support adding students. Directly adding students to a section is only supported in secret picture/word sections. The other non-rostered way to add students to a section is for them to join it via the section code. However, LTI Sections do not have a section code, therefore the only way to add students to an LTI section is via a roster sync.

<img width="1181" height="471" alt="Screenshot 2026-03-23 at 1 50 55 PM" src="https://github.com/user-attachments/assets/c4be8d60-f46c-4649-a55e-fc0054e6fea7" />

## Links
<!-- Jira tickets, design docs, Slack threads, related PRs, etc. -->

- Jira: https://codedotorg.atlassian.net/browse/P20-1826

## Testing story
<!-- How was this tested? Manual steps, adhoc links, automated tests, or why testing isn't needed. -->



## Deployment notes
<!-- Delete this section if it's a standard merge-and-deploy.
     Otherwise: migrations, feature flags, coordination, caching impacts, etc. -->



## Privacy and security
<!-- Delete this section if there is no privacy/security impact.
     Otherwise: new PII, auth changes, API surface changes, etc. -->

