### PR TITLE
Web Lab 2: add browser TTS as an option for levelbuilders

### DIFF
--- a/dashboard/app/views/levels/editors/_weblab2.html.haml
+++ b/dashboard/app/views/levels/editors/_weblab2.html.haml
@@ -6,6 +6,7 @@
 = render partial: 'levels/editors/fields/widget_view', locals: {f: f}
 = render partial: 'levels/editors/fields/sharing', locals: {f: f}
 = render partial: 'levels/editors/fields/special_level_types', locals: {f: f}
+= render partial: 'levels/editors/fields/browser_tts', locals: {f: f}
 = render partial: 'levels/editors/fields/predict_settings', locals: {f: f}
 = render partial: 'levels/editors/fields/product_tour_settings', locals: {f: f}
 = render partial: 'levels/editors/fields/audit_log', locals: {f: f}


### PR DESCRIPTION
Adds ability for levelbuilder to add a TTS option for instructions in Web Lab 2.

## Links

- Jira: https://codedotorg.atlassian.net/browse/AFL-532

## Testing story

Tested manually updating a file resulted in being able to play instruction text via audio.