### PR TITLE
Update Statsig flagged image report to include more data

### DIFF
--- a/apps/src/aichat/api/client/generateChatResponse.ts
+++ b/apps/src/aichat/api/client/generateChatResponse.ts
@@ -14,7 +14,7 @@ import {
   PendingChatMessage,
 } from '../../types';
 
-import {generatedFileToAsset} from './helpers/fileHelpers';
+import {generatedFileToAssetAndUrl} from './helpers/fileHelpers';
 import {
   formatChatMessage,
   formatSystemMessages,
@@ -86,12 +86,16 @@ export async function generateChatResponse(
   const assets: ChatAsset[] = [];
   for (const file of files) {
     let asset: ChatAsset;
+    let assetUrl: string;
     try {
-      asset = await generatedFileToAsset(
-        file,
-        buildAssetUrl,
-        ACCEPTED_IMAGE_MEDIA_TYPES // Currently only image files are supported.
-      );
+      const {asset: resolvedAsset, assetUrl: resolvedAssetUrl} =
+        await generatedFileToAssetAndUrl(
+          file,
+          buildAssetUrl,
+          ACCEPTED_IMAGE_MEDIA_TYPES // Currently only image files are supported.
+        );
+      asset = resolvedAsset;
+      assetUrl = resolvedAssetUrl;
     } catch (error) {
       // Log and skip files with unsupported or unrecognized media types so the
       // text response is still returned to the user.
@@ -104,7 +108,7 @@ export async function generateChatResponse(
     if (file.mediaType.startsWith('image/')) {
       sendLab2AnalyticsEvent(EVENTS.MODEL_OUTPUT_IMAGE_CREATED);
       // Check generated images for safety.
-      const imageSafe = await isImageSafe(file);
+      const imageSafe = await isImageSafe(file, assetUrl);
       if (!imageSafe) {
         return {
           response: text,

--- a/apps/src/aichat/api/client/generateChatResponse.ts
+++ b/apps/src/aichat/api/client/generateChatResponse.ts
@@ -14,7 +14,7 @@ import {
   PendingChatMessage,
 } from '../../types';
 
-import {generatedFileToAssetAndUrl} from './helpers/fileHelpers';
+import {generatedFileToAsset} from './helpers/fileHelpers';
 import {
   formatChatMessage,
   formatSystemMessages,
@@ -86,16 +86,12 @@ export async function generateChatResponse(
   const assets: ChatAsset[] = [];
   for (const file of files) {
     let asset: ChatAsset;
-    let assetUrl: string;
     try {
-      const {asset: resolvedAsset, assetUrl: resolvedAssetUrl} =
-        await generatedFileToAssetAndUrl(
-          file,
-          buildAssetUrl,
-          ACCEPTED_IMAGE_MEDIA_TYPES // Currently only image files are supported.
-        );
-      asset = resolvedAsset;
-      assetUrl = resolvedAssetUrl;
+      asset = await generatedFileToAsset(
+        file,
+        buildAssetUrl,
+        ACCEPTED_IMAGE_MEDIA_TYPES // Currently only image files are supported.
+      );
     } catch (error) {
       // Log and skip files with unsupported or unrecognized media types so the
       // text response is still returned to the user.
@@ -108,7 +104,7 @@ export async function generateChatResponse(
     if (file.mediaType.startsWith('image/')) {
       sendLab2AnalyticsEvent(EVENTS.MODEL_OUTPUT_IMAGE_CREATED);
       // Check generated images for safety.
-      const imageSafe = await isImageSafe(file, assetUrl);
+      const imageSafe = await isImageSafe(file, buildAssetUrl(asset));
       if (!imageSafe) {
         return {
           response: text,

--- a/apps/src/aichat/api/client/helpers/fileHelpers.ts
+++ b/apps/src/aichat/api/client/helpers/fileHelpers.ts
@@ -62,7 +62,8 @@ export async function assetToFilePart(
 }
 
 /**
- * Converts a model generated file to a ChatAsset by uploading the file's contents to the user's project.
+ * Converts a model generated file to a ChatAsset by uploading the file's contents to the user's project
+ * and returns the asset and asset URL.
  */
 export async function generatedFileToAssetAndUrl(
   file: GeneratedFile,

--- a/apps/src/aichat/api/client/helpers/fileHelpers.ts
+++ b/apps/src/aichat/api/client/helpers/fileHelpers.ts
@@ -64,11 +64,11 @@ export async function assetToFilePart(
 /**
  * Converts a model generated file to a ChatAsset by uploading the file's contents to the user's project.
  */
-export async function generatedFileToAsset(
+export async function generatedFileToAssetAndUrl(
   file: GeneratedFile,
   buildAssetUrl: (asset: ChatAsset) => string,
   accepts: string[]
-): Promise<ChatAsset> {
+): Promise<{asset: ChatAsset; assetUrl: string}> {
   const {filename, fileBuffer} = prepareGeneratedFile(file, accepts);
   const asset: ChatAsset = {
     filename,
@@ -81,7 +81,7 @@ export async function generatedFileToAsset(
     'Content-Type': file.mediaType,
   });
 
-  return asset;
+  return {asset, assetUrl};
 }
 
 interface PreparedFile {

--- a/apps/src/aichat/api/client/helpers/fileHelpers.ts
+++ b/apps/src/aichat/api/client/helpers/fileHelpers.ts
@@ -62,14 +62,13 @@ export async function assetToFilePart(
 }
 
 /**
- * Converts a model generated file to a ChatAsset by uploading the file's contents to the user's project
- * and returns the asset and asset URL.
+ * Converts a model generated file to a ChatAsset by uploading the file's contents to the user's project.
  */
-export async function generatedFileToAssetAndUrl(
+export async function generatedFileToAsset(
   file: GeneratedFile,
   buildAssetUrl: (asset: ChatAsset) => string,
   accepts: string[]
-): Promise<{asset: ChatAsset; assetUrl: string}> {
+): Promise<ChatAsset> {
   const {filename, fileBuffer} = prepareGeneratedFile(file, accepts);
   const asset: ChatAsset = {
     filename,
@@ -82,7 +81,7 @@ export async function generatedFileToAssetAndUrl(
     'Content-Type': file.mediaType,
   });
 
-  return {asset, assetUrl};
+  return asset;
 }
 
 interface PreparedFile {

--- a/apps/src/aichat/api/client/helpers/safetyHelpers.ts
+++ b/apps/src/aichat/api/client/helpers/safetyHelpers.ts
@@ -55,7 +55,10 @@ export async function isTextSafe(
   return classification === 'OK';
 }
 
-export async function isImageSafe(file: GeneratedFile): Promise<boolean> {
+export async function isImageSafe(
+  file: GeneratedFile,
+  assetUrl: string
+): Promise<boolean> {
   const {filename, fileBuffer, mediaType} = prepareGeneratedFile(
     file,
     ACCEPTED_IMAGE_MEDIA_TYPES
@@ -64,6 +67,7 @@ export async function isImageSafe(file: GeneratedFile): Promise<boolean> {
   const moderationStatus = await moderateImage(image, 'aichat', {
     moderateEvent: EVENTS.MODERATE_MODEL_OUTPUT_IMAGE_AZURE,
     flaggedEvent: EVENTS.FLAGGED_MODEL_OUTPUT_IMAGE_AZURE,
+    assetUrl,
   });
   return moderationStatus === 'ok' || moderationStatus === 'skipped';
 }

--- a/apps/src/util/moderateImage.ts
+++ b/apps/src/util/moderateImage.ts
@@ -175,7 +175,7 @@ export const moderateImage = async (
       moderationService: useAiContentSafety
         ? 'AI Content Safety'
         : 'Content Moderator',
-      moderationResult: json,
+      moderationResult: JSON.stringify(json),
       assetUrl: assetUrl ? `${window.location.origin}${assetUrl}` : undefined,
     });
     return 'flagged';

--- a/apps/src/util/moderateImage.ts
+++ b/apps/src/util/moderateImage.ts
@@ -38,6 +38,7 @@ interface AnalyticsData {
   uploaderType?: 'Lab2FileUploader' | 'AnimationPicker' | 'n/a';
   moderateEvent?: string;
   flaggedEvent?: string;
+  assetUrl?: string;
 }
 
 /**
@@ -109,6 +110,7 @@ export const moderateImage = async (
     uploaderType = 'n/a',
     moderateEvent = EVENTS.MODERATE_CUSTOM_IMAGE,
     flaggedEvent = EVENTS.FLAGGED_CUSTOM_IMAGE,
+    assetUrl,
   }: AnalyticsData
 ): Promise<'ok' | 'flagged' | 'skipped'> => {
   const fileExtension = mimeToExtension(file.type) || '';
@@ -170,6 +172,11 @@ export const moderateImage = async (
       UploaderType: uploaderType,
       appName,
       levelPath: window.location.pathname,
+      moderationService: useAiContentSafety
+        ? 'AI Content Safety'
+        : 'Content Moderator',
+      moderationResult: json,
+      assetUrl: assetUrl ? `${window.location.origin}${assetUrl}` : undefined,
     });
     return 'flagged';
   } catch (error) {


### PR DESCRIPTION
<!--
  Summary of the change: background, motivation, and context.
  Include screenshots, videos, or before/after comparisons for UI changes.
-->
Follow-up to https://github.com/code-dot-org/code-dot-org/pull/71577: This PR updates the Statsig events `FLAGGED_MODEL_OUTPUT_IMAGE_AZURE` and `FLAGGED_CUSTOM_IMAGE` to include the following data:
- moderation service (AI Content Safety or Content Moderator)
- moderation result
- asset URL (if available) - this is provided only in AI Chat Lab when an image is generated by the model.

Product expressed a desire to know why an image is blocked by our moderation service. [Slack thread](https://codedotorg.slack.com/archives/C0ACVGPJ0AY/p1773691633088759?thread_ts=1773684153.812279&cid=C0ACVGPJ0AY)

I updated `generatedFileToAsset` to `generatedFileToAssetAndUrl` so that we can view the generated image if flagged. All model-generated images whether flagged or not are saved to the project's assets bucket, but flagged images are NOT displayed to user or user's teacher.




## Links
<!-- Jira tickets, design docs, Slack threads, related PRs, etc. -->

- Jira: https://codedotorg.atlassian.net/browse/SL-1635

## Testing story
<!-- How was this tested? Manual steps, adhoc links, automated tests, or why testing isn't needed. -->

Tested locally.

In `aichat` with experiment (AI Content Safety): Prompt text was deemed safe but blocked with severity level blocked at `2` (low) for one category:

https://github.com/user-attachments/assets/e3f09ab7-e8ab-431d-9a86-7272aa6249ca

Statsig event sent in `aichat` with experiment:
<img width="677" height="141" alt="Screenshot 2026-03-24 at 11 18 41 AM" src="https://github.com/user-attachments/assets/36fc8231-4578-4f8e-8c80-12c4b07bb847" />

In `weblab2` with experiment (AI Content Safety):


https://github.com/user-attachments/assets/04178b59-8fe6-45f9-9973-5f36c0c10e04

Statsig event sent in `weblab2` with experiment:
<img width="541" height="146" alt="weblab2-expt" src="https://github.com/user-attachments/assets/2775d28e-1bad-4bb9-9b26-d78798855830" />


In `weblab2` without experiment (Content Moderator):

https://github.com/user-attachments/assets/05447aba-187b-4743-973f-81a5da9b4022

Statsig event sent in `weblab2` without experiment:
<img width="544" height="102" alt="content-moderator-weblab2" src="https://github.com/user-attachments/assets/92f36aea-50b2-432d-9039-4383156e1c6f" />



## Deployment notes
<!-- Delete this section if it's a standard merge-and-deploy.
     Otherwise: migrations, feature flags, coordination, caching impacts, etc. -->



## Privacy and security
<!-- Delete this section if there is no privacy/security impact.
     Otherwise: new PII, auth changes, API surface changes, etc. -->

