### PR TITLE
K8S: get ExternalDNS working for dashboard

### DIFF
--- a/k8s/TODO.md
+++ b/k8s/TODO.md
@@ -40,6 +40,11 @@ include prometheus as a helm chart dependency??
 See `k8s/tofu/eks-addons/TODO.argocd.diskfill.bug.md` for the Argo CD
 repo-server disk-fill investigation notes.
 
+Manage AWS Load Balancer Controller CRDs explicitly in `k8s/tofu/codeai-k8s/eks-cluster/`.
+Helm install creates them, but Helm upgrade does not update them, and we already hit stale
+live CRDs missing newer `IngressClassParams` fields like `certificateArn`, `targetType`,
+and `sslRedirectPort`.
+
 In `k8s/tofu/codeai-k8s/eks-cluster-addons/`, Dex and ArgoCD are still exposed through ALB
 `Ingress` resources. Migrate them to Gateway API so the public entry path is consistent with
 the Gateway-based direction.

--- a/k8s/helm/templates/dashboard/ingress.yaml
+++ b/k8s/helm/templates/dashboard/ingress.yaml
@@ -5,10 +5,6 @@ metadata:
   labels:
     {{ include "cdo.labels" (merge (dict "component" "dashboard") .) | nindent 4 }}
     code.ai/dns-name: {{ .Values.dnsName }}
-  annotations:
-    alb.ingress.kubernetes.io/target-type: ip
-    alb.ingress.kubernetes.io/listen-ports: '[{"HTTP":80},{"HTTPS":443}]'
-    alb.ingress.kubernetes.io/ssl-redirect: "443"
 spec:
   rules:
     - http:

--- a/k8s/helm/templates/dashboard/ingress.yaml
+++ b/k8s/helm/templates/dashboard/ingress.yaml
@@ -1,0 +1,22 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "cdo.fullname" (merge (dict "component" "dashboard") .) }}
+  labels:
+    {{ include "cdo.labels" (merge (dict "component" "dashboard") .) | nindent 4 }}
+    code.ai/dns-name: {{ .Values.dnsName }}
+  annotations:
+    alb.ingress.kubernetes.io/target-type: ip
+    alb.ingress.kubernetes.io/listen-ports: '[{"HTTP":80},{"HTTPS":443}]'
+    alb.ingress.kubernetes.io/ssl-redirect: "443"
+spec:
+  rules:
+    - http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ include "cdo.fullname" (merge (dict "component" "dashboard") .) }}
+                port:
+                  name: http

--- a/k8s/helm/values.yaml
+++ b/k8s/helm/values.yaml
@@ -9,6 +9,7 @@ args:
 
 # Override to set RAILS_ENV
 RAILS_ENV:
+dnsName: studio-development
 dashboard_workers: 0
 
 locals.yml:

--- a/k8s/kustomize/base/dashboard-ingress.yaml
+++ b/k8s/kustomize/base/dashboard-ingress.yaml
@@ -5,10 +5,6 @@ metadata:
   labels:
     app.kubernetes.io/component: dashboard
     code.ai/dns-name: studio-development
-  annotations:
-    alb.ingress.kubernetes.io/target-type: ip
-    alb.ingress.kubernetes.io/listen-ports: '[{"HTTP":80},{"HTTPS":443}]'
-    alb.ingress.kubernetes.io/ssl-redirect: "443"
 spec:
   rules:
     - http:

--- a/k8s/kustomize/base/dashboard-ingress.yaml
+++ b/k8s/kustomize/base/dashboard-ingress.yaml
@@ -1,0 +1,22 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: cdo-dashboard
+  labels:
+    app.kubernetes.io/component: dashboard
+    code.ai/dns-name: studio-development
+  annotations:
+    alb.ingress.kubernetes.io/target-type: ip
+    alb.ingress.kubernetes.io/listen-ports: '[{"HTTP":80},{"HTTPS":443}]'
+    alb.ingress.kubernetes.io/ssl-redirect: "443"
+spec:
+  rules:
+    - http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: cdo-dashboard
+                port:
+                  name: http

--- a/k8s/kustomize/base/kustomization.yaml
+++ b/k8s/kustomize/base/kustomization.yaml
@@ -2,6 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - dashboard-deployment.yaml
+  - dashboard-ingress.yaml
   - dashboard-service.yaml
   - locals.yml.yaml
   - cdo-local-secrets.yaml

--- a/k8s/tofu/codeai-k8s/eks-cluster-addons/.terraform.lock.hcl
+++ b/k8s/tofu/codeai-k8s/eks-cluster-addons/.terraform.lock.hcl
@@ -63,6 +63,23 @@ provider "registry.opentofu.org/hashicorp/helm" {
   ]
 }
 
+provider "registry.opentofu.org/hashicorp/http" {
+  version = "3.5.0"
+  hashes = [
+    "h1:eClUBisXme48lqiUl3U2+H2a2mzDawS9biqfkd9synw=",
+    "zh:0a2b33494eec6a91a183629cf217e073be063624c5d3f70870456ddb478308e9",
+    "zh:180f40124fa01b98b3d2f79128646b151818e09d6a1a9ca08e0b032a0b1e9cb1",
+    "zh:3e29e1de149dc10bf78620526c7cb8c62cd76087f5630dfaba0e93cda1f3aa7b",
+    "zh:4420950200cf86042ec940d0e2c9b7c89966bf556bf8038ba36217eae663bca5",
+    "zh:5d1f7d02109b2e2dca7ec626e5563ee765583792d0fd64081286f16f9433bd0d",
+    "zh:8500b138d338b1994c4206aa577b5c44e1d7260825babcf43245a7075bfa52a5",
+    "zh:b42165a6c4cfb22825938272d12b676e4a6946ac4e750f85df870c947685df2d",
+    "zh:b919bf3ee8e3b01051a0da3433b443a925e272893d3724ee8fc0f666ec7012c9",
+    "zh:d13b81ea6755cae785b3e11634936cdff2dc1ec009dc9610d8e3c7eb32f42e69",
+    "zh:f1c9d2eb1a6b618ae77ad86649679241bd8d6aacec06d0a68d86f748687f4eb3",
+  ]
+}
+
 provider "registry.opentofu.org/hashicorp/kubernetes" {
   version     = "3.0.1"
   constraints = ">= 2.20.0, >= 2.24.0"

--- a/k8s/tofu/codeai-k8s/eks-cluster-addons/argocd.tf
+++ b/k8s/tofu/codeai-k8s/eks-cluster-addons/argocd.tf
@@ -85,10 +85,9 @@ resource "helm_release" "argocd" {
 
     server = {
       ingress = {
-        enabled          = true
-        controller       = "generic"
-        ingressClassName = "alb"
-        hostname         = local.argocd_hostname
+        enabled    = true
+        controller = "generic"
+        hostname   = local.argocd_hostname
         annotations = {
           "alb.ingress.kubernetes.io/scheme"           = "internet-facing"
           "alb.ingress.kubernetes.io/target-type"      = "ip"

--- a/k8s/tofu/codeai-k8s/eks-cluster-addons/aws-load-balancer-controller-addon.tf
+++ b/k8s/tofu/codeai-k8s/eks-cluster-addons/aws-load-balancer-controller-addon.tf
@@ -10,7 +10,7 @@ locals {
   #    https://github.com/kubernetes-sigs/aws-load-balancer-controller/blob/v2.17.1/docs/guide/gateway/gateway.md?plain=1#L19
   # 2. Find Helm Chart version (e.g. v1.17.1) here:
   #    https://github.com/kubernetes-sigs/aws-load-balancer-controller/blob/v2.17.1/helm/aws-load-balancer-controller/Chart.yaml#L1-L9
-  
+
   # Align with gateway_api_version in: ../eks-cluster/gateway-api-crds.tf:
   aws_load_balancer_controller_chart_version = "1.17.1"
   cluster_version                            = data.terraform_remote_state.eks_cluster.outputs.cluster_version
@@ -66,7 +66,7 @@ module "aws_load_balancer_controller_addon" {
   enable_aws_load_balancer_controller = true
 
   aws_load_balancer_controller = {
-    chart_version = local.aws_load_balancer_controller_chart_version
+    chart_version     = local.aws_load_balancer_controller_chart_version
     policy_statements = local.aws_load_balancer_controller_policy_statements
 
     set = [
@@ -77,6 +77,10 @@ module "aws_load_balancer_controller_addon" {
       {
         name  = "vpcId"
         value = local.vpc_id
+      },
+      {
+        name  = "ingressClass"
+        value = "aws-alb"
       },
       {
         name  = "ingressClassConfig.default"

--- a/k8s/tofu/codeai-k8s/eks-cluster-addons/aws-load-balancer-controller-addon.tf
+++ b/k8s/tofu/codeai-k8s/eks-cluster-addons/aws-load-balancer-controller-addon.tf
@@ -95,6 +95,14 @@ module "aws_load_balancer_controller_addon" {
         value = local.ingress_certificate_arn
       },
       {
+        name  = "ingressClassParams.spec.targetType"
+        value = "ip"
+      },
+      {
+        name  = "ingressClassParams.spec.sslRedirectPort"
+        value = "443"
+      },
+      {
         name  = "ingressClassConfig.default"
         value = "true"
       },

--- a/k8s/tofu/codeai-k8s/eks-cluster-addons/aws-load-balancer-controller-addon.tf
+++ b/k8s/tofu/codeai-k8s/eks-cluster-addons/aws-load-balancer-controller-addon.tf
@@ -95,7 +95,7 @@ module "aws_load_balancer_controller_addon" {
         value = local.ingress_certificate_arn
       },
       {
-        name  = "ingressClassParams.spec.targetType"
+        name  = "defaultTargetType"
         value = "ip"
       },
       {

--- a/k8s/tofu/codeai-k8s/eks-cluster-addons/aws-load-balancer-controller-addon.tf
+++ b/k8s/tofu/codeai-k8s/eks-cluster-addons/aws-load-balancer-controller-addon.tf
@@ -101,6 +101,7 @@ module "aws_load_balancer_controller_addon" {
       {
         name  = "ingressClassParams.spec.sslRedirectPort"
         value = "443"
+        type  = "string"
       },
       {
         name  = "ingressClassConfig.default"

--- a/k8s/tofu/codeai-k8s/eks-cluster-addons/aws-load-balancer-controller-addon.tf
+++ b/k8s/tofu/codeai-k8s/eks-cluster-addons/aws-load-balancer-controller-addon.tf
@@ -83,6 +83,18 @@ module "aws_load_balancer_controller_addon" {
         value = "aws-alb"
       },
       {
+        name  = "ingressClassParams.name"
+        value = "aws-alb"
+      },
+      {
+        name  = "ingressClassParams.spec.scheme"
+        value = "internet-facing"
+      },
+      {
+        name  = "ingressClassParams.spec.certificateArn[0]"
+        value = local.ingress_certificate_arn
+      },
+      {
         name  = "ingressClassConfig.default"
         value = "true"
       },

--- a/k8s/tofu/codeai-k8s/eks-cluster-addons/dex.tf
+++ b/k8s/tofu/codeai-k8s/eks-cluster-addons/dex.tf
@@ -127,8 +127,7 @@ resource "helm_release" "dex" {
     ]
 
     ingress = {
-      enabled   = true
-      className = "alb"
+      enabled = true
       annotations = {
         "alb.ingress.kubernetes.io/scheme"           = "internet-facing"
         "alb.ingress.kubernetes.io/target-type"      = "ip"

--- a/k8s/tofu/codeai-k8s/eks-cluster-addons/gateway-class-aws-alb.tf
+++ b/k8s/tofu/codeai-k8s/eks-cluster-addons/gateway-class-aws-alb.tf
@@ -1,0 +1,19 @@
+#============================================================
+# Create a shared GatewayClass for AWS Load Balancer Controller-backed Gateways.
+# Individual services should reference this class instead of creating their own.
+#============================================================
+
+resource "kubernetes_manifest" "gateway_class_aws_alb" {
+  manifest = {
+    apiVersion = "gateway.networking.k8s.io/v1"
+    kind       = "GatewayClass"
+    metadata = {
+      name = "aws-alb"
+    }
+    spec = {
+      controllerName = "gateway.k8s.aws/alb"
+    }
+  }
+
+  depends_on = [module.aws_load_balancer_controller_addon]
+}

--- a/k8s/tofu/codeai-k8s/eks-cluster-addons/gateway-class-aws-alb.tf
+++ b/k8s/tofu/codeai-k8s/eks-cluster-addons/gateway-class-aws-alb.tf
@@ -3,6 +3,28 @@
 # Individual services should reference this class instead of creating their own.
 #============================================================
 
+resource "kubernetes_manifest" "gateway_class_aws_alb_load_balancer_configuration" {
+  manifest = {
+    apiVersion = "gateway.k8s.aws/v1beta1"
+    kind       = "LoadBalancerConfiguration"
+    metadata = {
+      name      = "aws-alb"
+      namespace = "kube-system"
+    }
+    spec = {
+      scheme = "internet-facing"
+      listenerConfigurations = [
+        {
+          protocolPort       = "HTTPS:443"
+          defaultCertificate = local.ingress_certificate_arn
+        }
+      ]
+    }
+  }
+
+  depends_on = [module.aws_load_balancer_controller_addon]
+}
+
 resource "kubernetes_manifest" "gateway_class_aws_alb" {
   manifest = {
     apiVersion = "gateway.networking.k8s.io/v1"
@@ -12,8 +34,17 @@ resource "kubernetes_manifest" "gateway_class_aws_alb" {
     }
     spec = {
       controllerName = "gateway.k8s.aws/alb"
+      parametersRef = {
+        group     = "gateway.k8s.aws"
+        kind      = "LoadBalancerConfiguration"
+        name      = "aws-alb"
+        namespace = "kube-system"
+      }
     }
   }
 
-  depends_on = [module.aws_load_balancer_controller_addon]
+  depends_on = [
+    module.aws_load_balancer_controller_addon,
+    kubernetes_manifest.gateway_class_aws_alb_load_balancer_configuration,
+  ]
 }

--- a/k8s/tofu/codeai-k8s/eks-cluster-addons/test/test-gateway-http.sh
+++ b/k8s/tofu/codeai-k8s/eks-cluster-addons/test/test-gateway-http.sh
@@ -78,8 +78,6 @@ cleanup() {
 
   kubectl delete httproute/"${ROUTE_NAME}" gateway/"${GATEWAY_NAME}" \
     service/"${DEPLOYMENT_NAME}" deployment/"${DEPLOYMENT_NAME}" \
-    loadbalancerconfiguration.gateway.k8s.aws/"${DEPLOYMENT_NAME}" \
-    targetgroupconfiguration.gateway.k8s.aws/"${DEPLOYMENT_NAME}" \
     -n "${NAMESPACE}" --ignore-not-found --wait=false >/dev/null 2>&1 || true
   kubectl delete namespace "${NAMESPACE}" --ignore-not-found --wait=false >/dev/null 2>&1 || true
 
@@ -88,8 +86,6 @@ cleanup() {
   wait_until_gone gateway/"${GATEWAY_NAME}" "${NAMESPACE}" || failed=true
   wait_until_gone service/"${DEPLOYMENT_NAME}" "${NAMESPACE}" || failed=true
   wait_until_gone deployment/"${DEPLOYMENT_NAME}" "${NAMESPACE}" || failed=true
-  wait_until_gone loadbalancerconfiguration.gateway.k8s.aws/"${DEPLOYMENT_NAME}" "${NAMESPACE}" || failed=true
-  wait_until_gone targetgroupconfiguration.gateway.k8s.aws/"${DEPLOYMENT_NAME}" "${NAMESPACE}" || failed=true
   namespace_deletion_timestamp="$(
     kubectl get namespace "${NAMESPACE}" -o jsonpath='{.metadata.deletionTimestamp}' 2>/dev/null || true
   )"
@@ -120,10 +116,10 @@ cleanup true
 service_deployment_started_at="$(date +%s)"
 echo "Gateway namespace: ${NAMESPACE}"
 echo "Gateway hostname: ${TEST_HOSTNAME}"
+kubectl create namespace "${NAMESPACE}" >/dev/null
 sed \
-  -e "s|__TEST_NAMESPACE__|${NAMESPACE}|g" \
   -e "s|__TEST_HOSTNAME__|${TEST_HOSTNAME}|g" \
-  test-gateway-http.yaml | kubectl apply -f - >/dev/null
+  test-gateway-http.yaml | kubectl apply -n "${NAMESPACE}" -f - >/dev/null
 kubectl wait --for=condition=available deployment/"${DEPLOYMENT_NAME}" -n "${NAMESPACE}" --timeout=180s >/dev/null
 
 echo "Waiting for Gateway address..."
@@ -152,18 +148,18 @@ fi
 echo "Gateway address: ${gateway_address}"
 echo "HTTPRoute hostname: ${route_host}"
 
-echo "Phase 1: testing Gateway public reachability..."
+echo "Phase 1: testing Gateway public reachability over HTTPS..."
 rm -f /tmp/hello-gateway-phase1-response.txt /tmp/hello-gateway-phase2-response.txt
 phase_1_passed=false
 for _ in {1..60}; do
   gateway_ip="$(dig +short "${gateway_address}" A @1.1.1.1 | head -n1 || true)"
   gateway_ip="${gateway_ip:-${gateway_address}}"
   if [[ -n "${gateway_ip}" ]]; then
-    if curl -fsS --max-time 5 --resolve "${route_host}:80:${gateway_ip}" "http://${route_host}/" >/tmp/hello-gateway-phase1-response.txt 2>/dev/null; then
+    if curl -fsS --max-time 5 --resolve "${route_host}:443:${gateway_ip}" "https://${route_host}/" >/tmp/hello-gateway-phase1-response.txt 2>/dev/null; then
       echo "Resolved assigned address ${gateway_address} via 1.1.1.1 to ${gateway_ip}"
       echo "Response sample:"
       sed -n '1,3p' /tmp/hello-gateway-phase1-response.txt
-      echo "PASS ✅ phase 1: gateway is publicly reachable by its assigned address."
+      echo "PASS ✅ phase 1: gateway is publicly reachable by its assigned address over HTTPS."
       phase_1_passed=true
       break
     fi
@@ -174,7 +170,7 @@ done
 if [[ "${phase_1_passed}" != "true" ]]; then
   kubectl describe gateway "${GATEWAY_NAME}" -n "${NAMESPACE}" | sed -n '1,200p' || true
   kubectl describe httproute "${ROUTE_NAME}" -n "${NAMESPACE}" | sed -n '1,200p' || true
-  echo "FAIL ❌: gateway address exists but the routed HTTP endpoint was not reachable."
+  echo "FAIL ❌: gateway address exists but the routed HTTPS endpoint was not reachable."
   exit 1
 fi
 
@@ -186,13 +182,13 @@ for _ in {1..60}; do
   # then connect to that resolved IP while keeping the public hostname in the URL.
   resolved_ip="$(dig +short "${route_host}" A @1.1.1.1 | head -n1 || true)"
   if [[ -n "${resolved_ip}" ]]; then
-    if curl -fsS --max-time 5 --resolve "${route_host}:80:${resolved_ip}" "http://${route_host}/" >/tmp/hello-gateway-phase2-response.txt 2>/dev/null; then
+    if curl -fsS --max-time 5 --resolve "${route_host}:443:${resolved_ip}" "https://${route_host}/" >/tmp/hello-gateway-phase2-response.txt 2>/dev/null; then
       echo "Resolved ${route_host} via 1.1.1.1 to ${resolved_ip}"
       echo "Response sample:"
       sed -n '1,3p' /tmp/hello-gateway-phase2-response.txt
       elapsed_seconds="$(( $(date +%s) - service_deployment_started_at ))"
-      printf '\nTime from service deployment to externally reachable by HTTP:\n\033[1m%s\033[0m\n\n' "$(format_elapsed "${elapsed_seconds}")"
-      echo "PASS ✅ phase 2: external DNS hostname (${route_host}) was reachable by HTTP."
+      printf '\nTime from service deployment to externally reachable by HTTPS:\n\033[1m%s\033[0m\n\n' "$(format_elapsed "${elapsed_seconds}")"
+      echo "PASS ✅ phase 2: external DNS hostname (${route_host}) was reachable by HTTPS."
       phase_2_passed=true
       break
     fi
@@ -208,5 +204,5 @@ kubectl describe gateway "${GATEWAY_NAME}" -n "${NAMESPACE}" | sed -n '1,200p' |
 kubectl describe httproute "${ROUTE_NAME}" -n "${NAMESPACE}" | sed -n '1,200p' || true
 echo "Gateway address at failure time: ${gateway_address}"
 echo "HTTPRoute hostname at failure time: ${route_host}"
-echo "FAIL ❌: gateway worked, but the public hostname was not reachable."
+echo "FAIL ❌: gateway worked, but the public hostname was not reachable over HTTPS."
 exit 1

--- a/k8s/tofu/codeai-k8s/eks-cluster-addons/test/test-gateway-http.sh
+++ b/k8s/tofu/codeai-k8s/eks-cluster-addons/test/test-gateway-http.sh
@@ -4,10 +4,45 @@ set -euo pipefail
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 cd "$DIR"
 
-NAMESPACE="gateway-test"
-GATEWAY_NAME="hello"
-ROUTE_NAME="hello"
-DEPLOYMENT_NAME="hello"
+GATEWAY_NAME="hello-gateway"
+ROUTE_NAME="hello-gateway"
+DEPLOYMENT_NAME="hello-gateway"
+HOSTNAME_PREFIX="gateway-test"
+
+random_alpha_suffix() {
+  local chars="abcdefghijklmnopqrstuvwxyz"
+  printf '%s%s' \
+    "${chars:$((RANDOM % ${#chars})):1}" \
+    "${chars:$((RANDOM % ${#chars})):1}"
+}
+
+format_elapsed() {
+  local elapsed_seconds="$1"
+  if (( elapsed_seconds >= 60 )); then printf '%s minutes and %02s seconds' "$((elapsed_seconds / 60))" "$((elapsed_seconds % 60))"; else printf '%s seconds' "${elapsed_seconds}"; fi
+}
+
+TEST_SUFFIX="$(random_alpha_suffix)"
+NAMESPACE="${HOSTNAME_PREFIX}-${TEST_SUFFIX}"
+
+cluster_dns_suffix() {
+  local suffix
+  suffix="$(
+    kubectl -n external-dns get deploy external-dns \
+      -o go-template='{{range .spec.template.spec.containers}}{{range .args}}{{println .}}{{end}}{{end}}' 2>/dev/null |
+      sed -n 's/^--domain-filter=//p' |
+      head -n1
+  )"
+
+  if [[ -z "${suffix}" ]]; then
+    echo "FAIL ❌: could not determine cluster DNS suffix from external-dns deployment." >&2
+    exit 1
+  fi
+
+  printf '%s\n' "${suffix}"
+}
+
+DNS_SUFFIX="$(cluster_dns_suffix)"
+TEST_HOSTNAME="${HOSTNAME_PREFIX}-${TEST_SUFFIX}.${DNS_SUFFIX}"
 
 wait_until_gone() {
   local resource="$1"
@@ -29,15 +64,24 @@ wait_until_gone() {
   return 1
 }
 
+force_finalize_namespace() {
+  local namespace="$1"
+
+  kubectl get namespace "${namespace}" -o json 2>/dev/null |
+    jq '.spec.finalizers = []' |
+    kubectl replace --raw "/api/v1/namespaces/${namespace}/finalize" -f - >/dev/null 2>&1 || true
+}
+
 cleanup() {
   local strict="${1:-false}"
+  local namespace_deletion_timestamp=""
 
   kubectl delete httproute/"${ROUTE_NAME}" gateway/"${GATEWAY_NAME}" \
     service/"${DEPLOYMENT_NAME}" deployment/"${DEPLOYMENT_NAME}" \
     loadbalancerconfiguration.gateway.k8s.aws/"${DEPLOYMENT_NAME}" \
     targetgroupconfiguration.gateway.k8s.aws/"${DEPLOYMENT_NAME}" \
     -n "${NAMESPACE}" --ignore-not-found --wait=false >/dev/null 2>&1 || true
-  kubectl delete gatewayclass aws-alb --ignore-not-found --wait=false >/dev/null 2>&1 || true
+  kubectl delete namespace "${NAMESPACE}" --ignore-not-found --wait=false >/dev/null 2>&1 || true
 
   local failed=false
   wait_until_gone httproute/"${ROUTE_NAME}" "${NAMESPACE}" || failed=true
@@ -46,7 +90,18 @@ cleanup() {
   wait_until_gone deployment/"${DEPLOYMENT_NAME}" "${NAMESPACE}" || failed=true
   wait_until_gone loadbalancerconfiguration.gateway.k8s.aws/"${DEPLOYMENT_NAME}" "${NAMESPACE}" || failed=true
   wait_until_gone targetgroupconfiguration.gateway.k8s.aws/"${DEPLOYMENT_NAME}" "${NAMESPACE}" || failed=true
-  wait_until_gone gatewayclass/aws-alb || failed=true
+  namespace_deletion_timestamp="$(
+    kubectl get namespace "${NAMESPACE}" -o jsonpath='{.metadata.deletionTimestamp}' 2>/dev/null || true
+  )"
+  if [[ -n "${namespace_deletion_timestamp}" ]]; then
+    force_finalize_namespace "${NAMESPACE}"
+  fi
+  if ! wait_until_gone namespace/"${NAMESPACE}"; then
+    if [[ -z "${namespace_deletion_timestamp}" ]]; then
+      force_finalize_namespace "${NAMESPACE}"
+    fi
+    wait_until_gone namespace/"${NAMESPACE}" || failed=true
+  fi
 
   if [[ "${strict}" == "true" && "${failed}" == "true" ]]; then
     echo "FAIL ❌: previous gateway test resources did not finish deleting." >&2
@@ -55,9 +110,20 @@ cleanup() {
 }
 trap cleanup EXIT
 
+if ! kubectl get gatewayclass aws-alb >/dev/null 2>&1; then
+  echo "FAIL ❌: gatewayclass aws-alb not found. Apply the eks-cluster-addons Tofu changes first." >&2
+  exit 1
+fi
+
 echo "Applying test-gateway-http resources..."
 cleanup true
-kubectl apply -f test-gateway-http.yaml >/dev/null
+service_deployment_started_at="$(date +%s)"
+echo "Gateway namespace: ${NAMESPACE}"
+echo "Gateway hostname: ${TEST_HOSTNAME}"
+sed \
+  -e "s|__TEST_NAMESPACE__|${NAMESPACE}|g" \
+  -e "s|__TEST_HOSTNAME__|${TEST_HOSTNAME}|g" \
+  test-gateway-http.yaml | kubectl apply -f - >/dev/null
 kubectl wait --for=condition=available deployment/"${DEPLOYMENT_NAME}" -n "${NAMESPACE}" --timeout=180s >/dev/null
 
 echo "Waiting for Gateway address..."
@@ -90,12 +156,17 @@ echo "Phase 1: testing Gateway public reachability..."
 rm -f /tmp/hello-gateway-phase1-response.txt /tmp/hello-gateway-phase2-response.txt
 phase_1_passed=false
 for _ in {1..60}; do
-  if curl -fsS --max-time 5 -H "Host: ${route_host}" "http://${gateway_address}/" >/tmp/hello-gateway-phase1-response.txt 2>/dev/null; then
-    echo "Response sample:"
-    sed -n '1,3p' /tmp/hello-gateway-phase1-response.txt
-    echo "PASS ✅ phase 1: gateway is publicly reachable by its assigned address."
-    phase_1_passed=true
-    break
+  gateway_ip="$(dig +short "${gateway_address}" A @1.1.1.1 | head -n1 || true)"
+  gateway_ip="${gateway_ip:-${gateway_address}}"
+  if [[ -n "${gateway_ip}" ]]; then
+    if curl -fsS --max-time 5 --resolve "${route_host}:80:${gateway_ip}" "http://${route_host}/" >/tmp/hello-gateway-phase1-response.txt 2>/dev/null; then
+      echo "Resolved assigned address ${gateway_address} via 1.1.1.1 to ${gateway_ip}"
+      echo "Response sample:"
+      sed -n '1,3p' /tmp/hello-gateway-phase1-response.txt
+      echo "PASS ✅ phase 1: gateway is publicly reachable by its assigned address."
+      phase_1_passed=true
+      break
+    fi
   fi
   sleep 3
 done
@@ -119,7 +190,9 @@ for _ in {1..60}; do
       echo "Resolved ${route_host} via 1.1.1.1 to ${resolved_ip}"
       echo "Response sample:"
       sed -n '1,3p' /tmp/hello-gateway-phase2-response.txt
-      echo "PASS ✅ phase 2: external DNS hostname is resolving and reachable."
+      elapsed_seconds="$(( $(date +%s) - service_deployment_started_at ))"
+      printf '\nTime from service deployment to externally reachable by HTTP:\n\033[1m%s\033[0m\n\n' "$(format_elapsed "${elapsed_seconds}")"
+      echo "PASS ✅ phase 2: external DNS hostname (${route_host}) was reachable by HTTP."
       phase_2_passed=true
       break
     fi

--- a/k8s/tofu/codeai-k8s/eks-cluster-addons/test/test-gateway-http.yaml
+++ b/k8s/tofu/codeai-k8s/eks-cluster-addons/test/test-gateway-http.yaml
@@ -1,21 +1,7 @@
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: __TEST_NAMESPACE__
----
-apiVersion: gateway.k8s.aws/v1beta1
-kind: LoadBalancerConfiguration
-metadata:
-  name: hello-gateway
-  namespace: __TEST_NAMESPACE__
-spec:
-  scheme: internet-facing
----
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: hello-gateway
-  namespace: __TEST_NAMESPACE__
 spec:
   replicas: 1
   selector:
@@ -36,7 +22,6 @@ apiVersion: v1
 kind: Service
 metadata:
   name: hello-gateway
-  namespace: __TEST_NAMESPACE__
 spec:
   selector:
     app: hello-gateway
@@ -44,33 +29,16 @@ spec:
     - port: 80
       targetPort: 80
 ---
-apiVersion: gateway.k8s.aws/v1beta1
-kind: TargetGroupConfiguration
-metadata:
-  name: hello-gateway
-  namespace: __TEST_NAMESPACE__
-spec:
-  targetReference:
-    name: hello-gateway
-  defaultConfiguration:
-    targetType: ip
----
 apiVersion: gateway.networking.k8s.io/v1
 kind: Gateway
 metadata:
   name: hello-gateway
-  namespace: __TEST_NAMESPACE__
 spec:
   gatewayClassName: aws-alb
-  infrastructure:
-    parametersRef:
-      group: gateway.k8s.aws
-      kind: LoadBalancerConfiguration
-      name: hello-gateway
   listeners:
-    - name: http
-      protocol: HTTP
-      port: 80
+    - name: https
+      protocol: HTTPS
+      port: 443
       allowedRoutes:
         namespaces:
           from: Same
@@ -79,11 +47,10 @@ apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
   name: hello-gateway
-  namespace: __TEST_NAMESPACE__
 spec:
   parentRefs:
     - name: hello-gateway
-      sectionName: http
+      sectionName: https
   hostnames:
     - __TEST_HOSTNAME__
   rules:

--- a/k8s/tofu/codeai-k8s/eks-cluster-addons/test/test-gateway-http.yaml
+++ b/k8s/tofu/codeai-k8s/eks-cluster-addons/test/test-gateway-http.yaml
@@ -1,30 +1,30 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: gateway-test
+  name: __TEST_NAMESPACE__
 ---
 apiVersion: gateway.k8s.aws/v1beta1
 kind: LoadBalancerConfiguration
 metadata:
-  name: hello
-  namespace: gateway-test
+  name: hello-gateway
+  namespace: __TEST_NAMESPACE__
 spec:
   scheme: internet-facing
 ---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: hello
-  namespace: gateway-test
+  name: hello-gateway
+  namespace: __TEST_NAMESPACE__
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: hello
+      app: hello-gateway
   template:
     metadata:
       labels:
-        app: hello
+        app: hello-gateway
     spec:
       containers:
         - name: hello
@@ -35,11 +35,11 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: hello
-  namespace: gateway-test
+  name: hello-gateway
+  namespace: __TEST_NAMESPACE__
 spec:
   selector:
-    app: hello
+    app: hello-gateway
   ports:
     - port: 80
       targetPort: 80
@@ -47,33 +47,26 @@ spec:
 apiVersion: gateway.k8s.aws/v1beta1
 kind: TargetGroupConfiguration
 metadata:
-  name: hello
-  namespace: gateway-test
+  name: hello-gateway
+  namespace: __TEST_NAMESPACE__
 spec:
   targetReference:
-    name: hello
+    name: hello-gateway
   defaultConfiguration:
     targetType: ip
 ---
 apiVersion: gateway.networking.k8s.io/v1
-kind: GatewayClass
-metadata:
-  name: aws-alb
-spec:
-  controllerName: gateway.k8s.aws/alb
----
-apiVersion: gateway.networking.k8s.io/v1
 kind: Gateway
 metadata:
-  name: hello
-  namespace: gateway-test
+  name: hello-gateway
+  namespace: __TEST_NAMESPACE__
 spec:
   gatewayClassName: aws-alb
   infrastructure:
     parametersRef:
       group: gateway.k8s.aws
       kind: LoadBalancerConfiguration
-      name: hello
+      name: hello-gateway
   listeners:
     - name: http
       protocol: HTTP
@@ -85,19 +78,19 @@ spec:
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
-  name: hello
-  namespace: gateway-test
+  name: hello-gateway
+  namespace: __TEST_NAMESPACE__
 spec:
   parentRefs:
-    - name: hello
+    - name: hello-gateway
       sectionName: http
   hostnames:
-    - hello.k8s.code.org
+    - __TEST_HOSTNAME__
   rules:
     - matches:
         - path:
             type: PathPrefix
             value: /
       backendRefs:
-        - name: hello
+        - name: hello-gateway
           port: 80

--- a/k8s/tofu/codeai-k8s/eks-cluster-addons/test/test-ingress.sh
+++ b/k8s/tofu/codeai-k8s/eks-cluster-addons/test/test-ingress.sh
@@ -106,10 +106,10 @@ cleanup true
 service_deployment_started_at="$(date +%s)"
 echo "Ingress namespace: ${NAMESPACE}"
 echo "Ingress hostname: ${TEST_HOSTNAME}"
+kubectl create namespace "${NAMESPACE}" >/dev/null
 sed \
-  -e "s|__TEST_NAMESPACE__|${NAMESPACE}|g" \
   -e "s|__TEST_HOSTNAME__|${TEST_HOSTNAME}|g" \
-  test-ingress.yaml | kubectl apply -f - >/dev/null
+  test-ingress.yaml | kubectl apply -n "${NAMESPACE}" -f - >/dev/null
 kubectl wait --for=condition=available deployment/hello -n "${NAMESPACE}" --timeout=180s >/dev/null
 
 echo "Waiting for ALB hostname..."
@@ -130,18 +130,18 @@ fi
 
 echo "Ingress host: ${host}"
 
-echo "Phase 1: testing ingress public reachability..."
+echo "Phase 1: testing ingress public reachability over HTTPS..."
 rm -f /tmp/hello-ingress-response.txt
 phase_1_passed=false
 for _ in {1..60}; do
   ingress_ip="$(dig +short "${host}" A @1.1.1.1 | head -n1 || true)"
   ingress_ip="${ingress_ip:-${host}}"
   if [[ -n "${ingress_ip}" ]]; then
-    if curl -fsS --max-time 5 --resolve "${TEST_HOSTNAME}:80:${ingress_ip}" "http://${TEST_HOSTNAME}/" >/tmp/hello-ingress-response.txt 2>/dev/null; then
+    if curl -fsS --max-time 5 --resolve "${TEST_HOSTNAME}:443:${ingress_ip}" "https://${TEST_HOSTNAME}/" >/tmp/hello-ingress-response.txt 2>/dev/null; then
       echo "Resolved assigned address ${host} via 1.1.1.1 to ${ingress_ip}"
       echo "Response sample:"
       sed -n '1,3p' /tmp/hello-ingress-response.txt
-      echo "PASS ✅ phase 1: ingress is publicly reachable by its assigned address."
+      echo "PASS ✅ phase 1: ingress is publicly reachable by its assigned address over HTTPS."
       phase_1_passed=true
       break
     fi
@@ -151,7 +151,7 @@ done
 
 if [[ "${phase_1_passed}" != "true" ]]; then
   kubectl get ingress hello -n "${NAMESPACE}" -o wide
-  echo "FAIL ❌: ingress hostname exists but HTTP was not reachable."
+  echo "FAIL ❌: ingress hostname exists but HTTPS was not reachable."
   exit 1
 fi
 
@@ -159,13 +159,13 @@ echo "Phase 2: testing ExternalDNS hostname..."
 for _ in {1..60}; do
   resolved_ip="$(dig +short "${TEST_HOSTNAME}" A @1.1.1.1 | head -n1 || true)"
   if [[ -n "${resolved_ip}" ]]; then
-    if curl -fsS --max-time 5 --resolve "${TEST_HOSTNAME}:80:${resolved_ip}" "http://${TEST_HOSTNAME}/" >/tmp/hello-ingress-response.txt 2>/dev/null; then
+    if curl -fsS --max-time 5 --resolve "${TEST_HOSTNAME}:443:${resolved_ip}" "https://${TEST_HOSTNAME}/" >/tmp/hello-ingress-response.txt 2>/dev/null; then
       echo "Resolved ${TEST_HOSTNAME} via 1.1.1.1 to ${resolved_ip}"
       echo "Response sample:"
       sed -n '1,3p' /tmp/hello-ingress-response.txt
       elapsed_seconds="$(( $(date +%s) - service_deployment_started_at ))"
-      printf '\nTime from service deployment to externally reachable by HTTP:\n\033[1m%s\033[0m\n\n' "$(format_elapsed "${elapsed_seconds}")"
-      echo "PASS ✅ phase 2: external DNS hostname (${TEST_HOSTNAME}) was reachable by HTTP."
+      printf '\nTime from service deployment to externally reachable by HTTPS:\n\033[1m%s\033[0m\n\n' "$(format_elapsed "${elapsed_seconds}")"
+      echo "PASS ✅ phase 2: external DNS hostname (${TEST_HOSTNAME}) was reachable by HTTPS."
       exit 0
     fi
   fi
@@ -173,5 +173,5 @@ for _ in {1..60}; do
 done
 
 kubectl get ingress hello -n "${NAMESPACE}" -o wide
-echo "FAIL ❌: ingress worked, but the public hostname was not reachable."
+echo "FAIL ❌: ingress worked, but the public hostname was not reachable over HTTPS."
 exit 1

--- a/k8s/tofu/codeai-k8s/eks-cluster-addons/test/test-ingress.sh
+++ b/k8s/tofu/codeai-k8s/eks-cluster-addons/test/test-ingress.sh
@@ -4,6 +4,43 @@ set -euo pipefail
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 cd "$DIR"
 
+HOSTNAME_PREFIX="ingress-test"
+
+random_alpha_suffix() {
+  local chars="abcdefghijklmnopqrstuvwxyz"
+  printf '%s%s' \
+    "${chars:$((RANDOM % ${#chars})):1}" \
+    "${chars:$((RANDOM % ${#chars})):1}"
+}
+
+format_elapsed() {
+  local elapsed_seconds="$1"
+  if (( elapsed_seconds >= 60 )); then printf '%s minutes and %02s seconds' "$((elapsed_seconds / 60))" "$((elapsed_seconds % 60))"; else printf '%s seconds' "${elapsed_seconds}"; fi
+}
+
+TEST_SUFFIX="$(random_alpha_suffix)"
+NAMESPACE="${HOSTNAME_PREFIX}-${TEST_SUFFIX}"
+
+cluster_dns_suffix() {
+  local suffix
+  suffix="$(
+    kubectl -n external-dns get deploy external-dns \
+      -o go-template='{{range .spec.template.spec.containers}}{{range .args}}{{println .}}{{end}}{{end}}' 2>/dev/null |
+      sed -n 's/^--domain-filter=//p' |
+      head -n1
+  )"
+
+  if [[ -z "${suffix}" ]]; then
+    echo "FAIL ❌: could not determine cluster DNS suffix from external-dns deployment." >&2
+    exit 1
+  fi
+
+  printf '%s\n' "${suffix}"
+}
+
+DNS_SUFFIX="$(cluster_dns_suffix)"
+TEST_HOSTNAME="${HOSTNAME_PREFIX}-${TEST_SUFFIX}.${DNS_SUFFIX}"
+
 wait_until_gone() {
   local resource="$1"
   local namespace="${2:-}"
@@ -24,15 +61,38 @@ wait_until_gone() {
   return 1
 }
 
+force_finalize_namespace() {
+  local namespace="$1"
+
+  kubectl get namespace "${namespace}" -o json 2>/dev/null |
+    jq '.spec.finalizers = []' |
+    kubectl replace --raw "/api/v1/namespaces/${namespace}/finalize" -f - >/dev/null 2>&1 || true
+}
+
 cleanup() {
   local strict="${1:-false}"
+  local namespace_deletion_timestamp=""
 
-  kubectl delete ingress/hello service/hello deployment/hello -n default --ignore-not-found --wait=false >/dev/null 2>&1 || true
+  kubectl delete ingress/hello service/hello deployment/hello -n "${NAMESPACE}" --ignore-not-found --wait=false >/dev/null 2>&1 || true
+  kubectl delete namespace "${NAMESPACE}" --ignore-not-found --wait=false >/dev/null 2>&1 || true
 
   local failed=false
-  wait_until_gone ingress/hello default || failed=true
-  wait_until_gone service/hello default || failed=true
-  wait_until_gone deployment/hello default || failed=true
+  wait_until_gone ingress/hello "${NAMESPACE}" || failed=true
+  wait_until_gone service/hello "${NAMESPACE}" || failed=true
+  wait_until_gone deployment/hello "${NAMESPACE}" || failed=true
+
+  namespace_deletion_timestamp="$(
+    kubectl get namespace "${NAMESPACE}" -o jsonpath='{.metadata.deletionTimestamp}' 2>/dev/null || true
+  )"
+  if [[ -n "${namespace_deletion_timestamp}" ]]; then
+    force_finalize_namespace "${NAMESPACE}"
+  fi
+  if ! wait_until_gone namespace/"${NAMESPACE}"; then
+    if [[ -z "${namespace_deletion_timestamp}" ]]; then
+      force_finalize_namespace "${NAMESPACE}"
+    fi
+    wait_until_gone namespace/"${NAMESPACE}" || failed=true
+  fi
 
   if [[ "${strict}" == "true" && "${failed}" == "true" ]]; then
     echo "FAIL ❌: previous ingress test resources did not finish deleting." >&2
@@ -43,13 +103,19 @@ trap cleanup EXIT
 
 echo "Applying test-ingress resources..."
 cleanup true
-kubectl apply -f test-ingress.yaml >/dev/null
-kubectl wait --for=condition=available deployment/hello -n default --timeout=180s >/dev/null
+service_deployment_started_at="$(date +%s)"
+echo "Ingress namespace: ${NAMESPACE}"
+echo "Ingress hostname: ${TEST_HOSTNAME}"
+sed \
+  -e "s|__TEST_NAMESPACE__|${NAMESPACE}|g" \
+  -e "s|__TEST_HOSTNAME__|${TEST_HOSTNAME}|g" \
+  test-ingress.yaml | kubectl apply -f - >/dev/null
+kubectl wait --for=condition=available deployment/hello -n "${NAMESPACE}" --timeout=180s >/dev/null
 
 echo "Waiting for ALB hostname..."
 host=""
 for _ in {1..60}; do
-  host="$(kubectl get ingress hello -n default -o jsonpath='{.status.loadBalancer.ingress[0].hostname}' 2>/dev/null || true)"
+  host="$(kubectl get ingress hello -n "${NAMESPACE}" -o jsonpath='{.status.loadBalancer.ingress[0].hostname}' 2>/dev/null || true)"
   if [[ -n "${host}" ]]; then
     break
   fi
@@ -57,23 +123,55 @@ for _ in {1..60}; do
 done
 
 if [[ -z "${host}" ]]; then
-  kubectl describe ingress hello -n default | sed -n '1,120p'
+  kubectl describe ingress hello -n "${NAMESPACE}" | sed -n '1,120p'
   echo "FAIL ❌: ingress hostname not assigned."
   exit 1
 fi
 
 echo "Ingress host: ${host}"
-echo "Waiting for HTTP 200..."
+
+echo "Phase 1: testing ingress public reachability..."
+rm -f /tmp/hello-ingress-response.txt
+phase_1_passed=false
 for _ in {1..60}; do
-  if curl -fsS --max-time 5 "http://${host}/" >/tmp/hello-ingress-response.txt 2>/dev/null; then
-    echo "Response sample:"
-    sed -n '1,3p' /tmp/hello-ingress-response.txt
-    echo "PASS ✅: ingress is publicly reachable."
-    exit 0
+  ingress_ip="$(dig +short "${host}" A @1.1.1.1 | head -n1 || true)"
+  ingress_ip="${ingress_ip:-${host}}"
+  if [[ -n "${ingress_ip}" ]]; then
+    if curl -fsS --max-time 5 --resolve "${TEST_HOSTNAME}:80:${ingress_ip}" "http://${TEST_HOSTNAME}/" >/tmp/hello-ingress-response.txt 2>/dev/null; then
+      echo "Resolved assigned address ${host} via 1.1.1.1 to ${ingress_ip}"
+      echo "Response sample:"
+      sed -n '1,3p' /tmp/hello-ingress-response.txt
+      echo "PASS ✅ phase 1: ingress is publicly reachable by its assigned address."
+      phase_1_passed=true
+      break
+    fi
   fi
   sleep 3
 done
 
-kubectl get ingress hello -n default -o wide
-echo "FAIL ❌: ingress hostname exists but HTTP was not reachable."
+if [[ "${phase_1_passed}" != "true" ]]; then
+  kubectl get ingress hello -n "${NAMESPACE}" -o wide
+  echo "FAIL ❌: ingress hostname exists but HTTP was not reachable."
+  exit 1
+fi
+
+echo "Phase 2: testing ExternalDNS hostname..."
+for _ in {1..60}; do
+  resolved_ip="$(dig +short "${TEST_HOSTNAME}" A @1.1.1.1 | head -n1 || true)"
+  if [[ -n "${resolved_ip}" ]]; then
+    if curl -fsS --max-time 5 --resolve "${TEST_HOSTNAME}:80:${resolved_ip}" "http://${TEST_HOSTNAME}/" >/tmp/hello-ingress-response.txt 2>/dev/null; then
+      echo "Resolved ${TEST_HOSTNAME} via 1.1.1.1 to ${resolved_ip}"
+      echo "Response sample:"
+      sed -n '1,3p' /tmp/hello-ingress-response.txt
+      elapsed_seconds="$(( $(date +%s) - service_deployment_started_at ))"
+      printf '\nTime from service deployment to externally reachable by HTTP:\n\033[1m%s\033[0m\n\n' "$(format_elapsed "${elapsed_seconds}")"
+      echo "PASS ✅ phase 2: external DNS hostname (${TEST_HOSTNAME}) was reachable by HTTP."
+      exit 0
+    fi
+  fi
+  sleep 5
+done
+
+kubectl get ingress hello -n "${NAMESPACE}" -o wide
+echo "FAIL ❌: ingress worked, but the public hostname was not reachable."
 exit 1

--- a/k8s/tofu/codeai-k8s/eks-cluster-addons/test/test-ingress.yaml
+++ b/k8s/tofu/codeai-k8s/eks-cluster-addons/test/test-ingress.yaml
@@ -1,7 +1,13 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: __TEST_NAMESPACE__
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: hello
+  namespace: __TEST_NAMESPACE__
 spec:
   replicas: 1
   selector:
@@ -22,6 +28,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: hello
+  namespace: __TEST_NAMESPACE__
 spec:
   selector:
     app: hello
@@ -33,13 +40,14 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: hello
+  namespace: __TEST_NAMESPACE__
   annotations:
     alb.ingress.kubernetes.io/scheme: internet-facing
     alb.ingress.kubernetes.io/target-type: ip
 spec:
-  ingressClassName: alb
   rules:
-    - http:
+    - host: __TEST_HOSTNAME__
+      http:
         paths:
           - path: /
             pathType: Prefix

--- a/k8s/tofu/codeai-k8s/eks-cluster-addons/test/test-ingress.yaml
+++ b/k8s/tofu/codeai-k8s/eks-cluster-addons/test/test-ingress.yaml
@@ -1,13 +1,7 @@
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: __TEST_NAMESPACE__
----
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: hello
-  namespace: __TEST_NAMESPACE__
 spec:
   replicas: 1
   selector:
@@ -28,7 +22,6 @@ apiVersion: v1
 kind: Service
 metadata:
   name: hello
-  namespace: __TEST_NAMESPACE__
 spec:
   selector:
     app: hello
@@ -40,10 +33,6 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: hello
-  namespace: __TEST_NAMESPACE__
-  annotations:
-    alb.ingress.kubernetes.io/scheme: internet-facing
-    alb.ingress.kubernetes.io/target-type: ip
 spec:
   rules:
     - host: __TEST_HOSTNAME__

--- a/k8s/tofu/codeai-k8s/eks-cluster/external-dns.tf
+++ b/k8s/tofu/codeai-k8s/eks-cluster/external-dns.tf
@@ -44,7 +44,7 @@ module "external_dns_addon" {
       extraArgs = [
         "--aws-zone-type=public",
 
-        # Setup ExternalDNS so if a Service or Ingress has label `code.ai/dns-nam: <host name>`,
+        # Setup ExternalDNS so if a Service or Ingress has label `code.ai/dns-name: <host name>`,
         # ExternalDNS will map it as <host name>.<cluster_subdomain>.<primary_domain>
         #
         # For example: `code.ai/dns-name: boo` => boo.k8s.code.org

--- a/k8s/tofu/codeai-k8s/eks-cluster/external-dns.tf
+++ b/k8s/tofu/codeai-k8s/eks-cluster/external-dns.tf
@@ -43,6 +43,14 @@ module "external_dns_addon" {
 
       extraArgs = [
         "--aws-zone-type=public",
+
+        # Setup ExternalDNS so if a Service or Ingress has label `code.ai/dns-nam: <host name>`,
+        # ExternalDNS will map it as <host name>.<cluster_subdomain>.<primary_domain>
+        #
+        # For example: `code.ai/dns-name: boo` => boo.k8s.code.org
+        #
+        "--fqdn-template={{ with index .Labels \"code.ai/dns-name\" }}{{ . }}{{ else }}ignore{{ end }}.${var.cluster_subdomain}.${var.parent_domain}",
+        "--exclude-domains=ignore.${var.cluster_subdomain}.${var.parent_domain}",
       ]
     })]
   }

--- a/k8s/tofu/codeai-k8s/eks-cluster/external-dns.tf
+++ b/k8s/tofu/codeai-k8s/eks-cluster/external-dns.tf
@@ -49,7 +49,7 @@ module "external_dns_addon" {
         #
         # For example: `code.ai/dns-name: boo` => boo.k8s.code.org
         #
-        "--fqdn-template={{ with index .Labels \"code.ai/dns-name\" }}{{ . }}{{ else }}ignore{{ end }}.${var.cluster_subdomain}.${var.parent_domain}",
+        "--fqdn-template={{ printf \"{{ with index .Labels %q }}{{ . }}{{ else }}ignore{{ end }}\" \"code.ai/dns-name\" }}.${var.cluster_subdomain}.${var.parent_domain}",
         "--exclude-domains=ignore.${var.cluster_subdomain}.${var.parent_domain}",
       ]
     })]


### PR DESCRIPTION
# Enables ExternalDNS for dashboard

Example: https://studio-staging.k8s.code.org

All examples in this file will be for staging.

## This PR 

1. Adds ingresses with `code.ai/dns-name: studio-staging` labels
  - Helm: values.yaml `dnsName:` param
  - Kustomize: via `ingress.dns-name.patch.yaml` patches in envTypes (not right since this is a deployment value not an envType, but kustomize is only half in place so the real thing can't be done and works for now)
2. test-gateway-http.sh: cleanup, doesn't install GatewayClass, includes timing
3. test-ingress.sh: cleanup, uses ExternalDNS, includes timing
4. Setup IngressClass `aws-alb` and default IngressClassParams so that Ingresses aren't bound unnecessarily to AWS implementation details.
  - Sets `default` on the IngressClass, so charts that don't specify get `aws-alb`
6. Install GatewayClass from opentofu
7. ExternalDNS now applies `code.ai/dns-name: studio-staging` labels when present, combining with the tofu-level defined cluster subdomain and domain, to give FQDNs, e.g.: staging.k8s.code.org

## Timings for creating an ingress vs gateway (time to dns+http) 

- Ingress: 2 minutes and 32 seconds
- Gateway: 2 minutes and 17 seconds