### PR TITLE
work around DevTools port issue when running ui tests with chromedriver

### DIFF
--- a/dashboard/test/ui/utils/selenium_browser.rb
+++ b/dashboard/test/ui/utils/selenium_browser.rb
@@ -5,6 +5,8 @@ module SeleniumBrowser
     options = Selenium::WebDriver::Options.send(browser)
     options.add_argument('--window-size=1280,1024') if [:chrome, :firefox].include?(browser)
     options.add_argument('--headless') if headless
+    # Pipe mode avoids flaky DevTools port handshakes in some local containerized Chromium setups.
+    options.add_argument('--remote-debugging-pipe') if browser == :chrome
     return options
   end
 

--- a/dashboard/test/ui/utils/selenium_browser.rb
+++ b/dashboard/test/ui/utils/selenium_browser.rb
@@ -5,7 +5,7 @@ module SeleniumBrowser
     options = Selenium::WebDriver::Options.send(browser)
     options.add_argument('--window-size=1280,1024') if [:chrome, :firefox].include?(browser)
     options.add_argument('--headless') if headless
-    # Pipe mode avoids flaky DevTools port handshakes in some local containerized Chromium setups.
+    # Pipe mode avoids flaky DevTools port handshakes in some environments.
     options.add_argument('--remote-debugging-pipe') if browser == :chrome
     return options
   end


### PR DESCRIPTION
## Background

When trying to run UI tests via chromedriver on a dev ec2 instance, I ran into a `DevToolsActivePort file doesn't exist` error in the output html file:
```
session not created: DevToolsActivePort file doesn't exist (Selenium::WebDriver::Error::SessionNotCreatedError)
:90:in `tap'
./utils/selenium_browser.rb:14:in `local'
./features/support/connect.rb:82:in `get_browser'
./features/support/connect.rb:124:in `Before'
./features/support/hooks.rb:28:in `block in '
```

## Description

Use `--remote-debugging-pipe` when starting chrome via selenium. In addition to fixing the issue in my ec2 dev environment, this seems like a net improvement because Chromium’s ChromeDriver source explicitly says pipe mode is “more reliable and more secure” than the default port-based mode: https://chromium.googlesource.com/chromium/src/+/master/chrome/test/chromedriver/chrome_launcher.cc#510

## Testing story
- fixes the issue on ubuntu EC2 dev instance
- no regression when running ui tests on M4 mac
- passing drone run
- not tested on the chef-managed test system because we do not currently run chromedriver there