### PR TITLE
Fix aichat locale imports

### DIFF
--- a/apps/src/aichat/redux/thunks/helpers/saveAiCustomization.ts
+++ b/apps/src/aichat/redux/thunks/helpers/saveAiCustomization.ts
@@ -6,7 +6,7 @@ import {
   SaveType,
 } from '@cdo/apps/aichat/types';
 import {extractFieldsToCheckForToxicity} from '@cdo/apps/aichat/utils';
-import {AI_CUSTOMIZATIONS_LABELS} from '@cdo/apps/aichat/views/modelCustomization/constants';
+import {getAiCustomizationsLabels} from '@cdo/apps/aichat/views/modelCustomization/constants';
 import Lab2Registry from '@cdo/apps/lab2/Lab2Registry';
 import {AppDispatch} from '@cdo/apps/util/reduxHooks';
 
@@ -72,7 +72,7 @@ export const saveAiCustomization = async (
 
 const getToxicityErrorMessage = (flaggedFields: FlaggedField[]) => {
   const fieldLabels = flaggedFields.map(
-    flaggedField => AI_CUSTOMIZATIONS_LABELS[flaggedField.field]
+    flaggedField => getAiCustomizationsLabels()[flaggedField.field]
   );
   return `The following customization(s) have been flagged by our content moderation policy: ${fieldLabels.join(
     ', '

--- a/apps/src/aichat/views/ChatEventView.tsx
+++ b/apps/src/aichat/views/ChatEventView.tsx
@@ -22,7 +22,7 @@ import {
 } from '../types';
 
 import ChatMessageView, {getChatMessageDisplayText} from './ChatMessageView';
-import {AI_CUSTOMIZATIONS_LABELS} from './modelCustomization/constants';
+import {getAiCustomizationsLabels} from './modelCustomization/constants';
 
 import styles from './chatWorkspace.module.scss';
 
@@ -48,7 +48,7 @@ interface ChatEventViewProps extends React.HTMLAttributes<HTMLDivElement> {
 
 function formatModelUpdateText(update: ModelUpdate): string {
   const {updatedField, updatedValue, timestamp} = update;
-  const fieldLabel = AI_CUSTOMIZATIONS_LABELS[updatedField]!;
+  const fieldLabel = getAiCustomizationsLabels()[updatedField]!;
 
   let updatedToText = undefined;
   if (updatedField === 'temperature') {

--- a/apps/src/aichat/views/ChatEventView.tsx
+++ b/apps/src/aichat/views/ChatEventView.tsx
@@ -26,15 +26,19 @@ import {getAiCustomizationsLabels} from './modelCustomization/constants';
 
 import styles from './chatWorkspace.module.scss';
 
-const chatEventDescriptionsOwner = {
+const getChatEventDescriptionsOwner = (): {
+  [key in ChatEventDescriptionKey]: string;
+} => ({
   CLEAR_CHAT: aichatI18n.chatEventDescriptions_clearChatOwner(),
   LOAD_LEVEL: aichatI18n.chatEventDescriptions_loadLevelOwner(),
-} as const satisfies {[key in ChatEventDescriptionKey]: string};
+});
 
-const chatEventDescriptionsStudent = {
+const getChatEventDescriptionsStudent = (): {
+  [key in ChatEventDescriptionKey]: string;
+} => ({
   CLEAR_CHAT: aichatI18n.chatEventDescriptions_clearChat(),
   LOAD_LEVEL: aichatI18n.chatEventDescriptions_loadLevel(),
-} as const satisfies {[key in ChatEventDescriptionKey]: string};
+});
 
 interface ChatEventViewProps extends React.HTMLAttributes<HTMLDivElement> {
   event: ChatEvent;
@@ -95,8 +99,8 @@ const ChatEventView = forwardRef<HTMLDivElement, ChatEventViewProps>(
     const dispatch = useAppDispatch();
 
     const chatEventDescriptions = isTeacherView
-      ? chatEventDescriptionsStudent
-      : chatEventDescriptionsOwner;
+      ? getChatEventDescriptionsStudent()
+      : getChatEventDescriptionsOwner();
 
     // Only wrap chat messages in a focusable div for keyboard navigation
     if (isChatMessage(event)) {

--- a/apps/src/aichat/views/aiChatHeaderButtons/CopyChatHistoryButton.tsx
+++ b/apps/src/aichat/views/aiChatHeaderButtons/CopyChatHistoryButton.tsx
@@ -16,7 +16,7 @@ import {
   isModelUpdate,
   isNotification,
 } from '../../types';
-import {AI_CUSTOMIZATIONS_LABELS} from '../modelCustomization/constants';
+import {getAiCustomizationsLabels} from '../modelCustomization/constants';
 
 const CopyChatHistoryButton: React.FunctionComponent = () => {
   const messages = useSelector(selectAllVisibleMessages);
@@ -67,7 +67,7 @@ function chatEventToFormattedString(chatEvent: ChatEvent) {
   if (isModelUpdate(chatEvent)) {
     return aichatI18n.copyChatFormatting_modelUpdate({
       timestamp: formattedTimestamp,
-      updatedFieldLabel: AI_CUSTOMIZATIONS_LABELS[chatEvent.updatedField]!,
+      updatedFieldLabel: getAiCustomizationsLabels()[chatEvent.updatedField]!,
     });
   }
 

--- a/apps/src/aichat/views/assets/StagedFilesPreview.tsx
+++ b/apps/src/aichat/views/assets/StagedFilesPreview.tsx
@@ -17,18 +17,6 @@ import FilePreview from './FilePreview';
 
 import styles from './staged-files-preview.module.scss';
 
-const alerts = {
-  uploadFailed: [aichatI18n.uploadFailedAlert(), 'danger'] as const,
-  fileLimitExceeded: [
-    aichatI18n.uploadFileLimitExceededAlert({maximum: MAX_NUM_FILES}),
-    'warning',
-  ] as const,
-  sizeLimitExceeded: [
-    aichatI18n.uploadSizeLimitExceededAlert({maximum: MAX_FILE_SIZE_MB}),
-    'danger',
-  ] as const,
-} satisfies {[key: string]: [string, AlertProps['type']]};
-
 interface StagedFilesPreviewProps {
   buildAssetUrl: (asset: ChatAsset) => string;
 }
@@ -38,6 +26,18 @@ const StagedFilesPreview: React.FC<StagedFilesPreviewProps> = ({
 }) => {
   const dispatch = useAppDispatch();
   const stagedFiles = useAppSelector(state => state.aichat.stagedFiles);
+
+  const alerts: {[key: string]: [string, AlertProps['type']]} = {
+    uploadFailed: [aichatI18n.uploadFailedAlert(), 'danger'],
+    fileLimitExceeded: [
+      aichatI18n.uploadFileLimitExceededAlert({maximum: MAX_NUM_FILES}),
+      'warning',
+    ],
+    sizeLimitExceeded: [
+      aichatI18n.uploadSizeLimitExceededAlert({maximum: MAX_FILE_SIZE_MB}),
+      'danger',
+    ],
+  };
 
   const [alertMessage, style] = useAppSelector(state => {
     if (!state.aichat.stagedFilesAlert) {

--- a/apps/src/aichat/views/modelCustomization/PublishNotes.tsx
+++ b/apps/src/aichat/views/modelCustomization/PublishNotes.tsx
@@ -17,7 +17,7 @@ import {useAppSelector, useAppDispatch} from '@cdo/apps/util/reduxHooks';
 import aichatI18n from '../../locale';
 import {ModelCardInfo} from '../../types';
 
-import {MODEL_CARD_FIELDS_LABELS_ICONS} from './constants';
+import {getModelCardFieldsLabelsIcons} from './constants';
 import ExampleTopicsInputs from './ExampleTopicsInputs';
 import FieldLabel from './FieldLabel';
 import SaveChangesAlerts from './SaveChangesAlerts';
@@ -60,7 +60,7 @@ const PublishNotes: React.FunctionComponent = () => {
     >
       <div className={modelCustomizationStyles.customizationContainer}>
         {!isReadOnly && <Alert text={alertText} type={type} size="s" />}
-        {MODEL_CARD_FIELDS_LABELS_ICONS.map(data => {
+        {getModelCardFieldsLabelsIcons().map(data => {
           const {property, label, editTooltip} = data;
           const InputTag = getInputTag(property);
 

--- a/apps/src/aichat/views/modelCustomization/constants.ts
+++ b/apps/src/aichat/views/modelCustomization/constants.ts
@@ -14,13 +14,13 @@ export const SET_TEMPERATURE_STEP = 0.1;
 export const MAX_RETRIEVAL_CONTEXTS = 20;
 export const MAX_ASK_ABOUT_TOPICS = 10;
 
-export const MODEL_CARD_FIELDS_LABELS_ICONS: {
+export const getModelCardFieldsLabelsIcons = (): {
   property: keyof ModelCardInfo;
   label: string;
   icon?: string;
   editTooltip: string;
   displayTooltip: string;
-}[] = [
+}[] => [
   {
     property: 'botName',
     label: aichatI18n.modelCard_botNameHeader(),
@@ -64,14 +64,14 @@ export const MODEL_CARD_FIELDS_LABELS_ICONS: {
   },
 ];
 
-export const TECHNICAL_INFO_FIELDS = [
+export const getTechnicalInfoFields = (): string[] => [
   aichatI18n.technicalInfoHeader_modelName(),
   aichatI18n.technicalInfoHeader_overview(),
   aichatI18n.technicalInfoHeader_trainingData(),
   aichatI18n.technicalInfoHeader_systemPrompt(),
   aichatI18n.technicalInfoHeader_temperature(),
   aichatI18n.technicalInfoHeader_retrievalUsed(),
-] as const;
+];
 
 export const EMPTY_MODEL_CARD_INFO: ModelCardInfo = {
   botName: '',
@@ -109,15 +109,15 @@ export const DEFAULT_LEVEL_AICHAT_SETTINGS: LevelAichatSettings = {
   availableModelIds: [modelDescriptions[0].id],
 };
 
-export const AI_CUSTOMIZATIONS_LABELS: {
+export const getAiCustomizationsLabels = (): {
   [key in keyof AiCustomizations]: string;
-} = {
+} => ({
   selectedModelId: aichatI18n.aiCustomizations_selectedModel(),
   temperature: aichatI18n.aiCustomizations_temperature(),
   systemPrompt: aichatI18n.aiCustomizations_systemPrompt(),
   retrievalContexts: aichatI18n.aiCustomizations_retrieval(),
   modelCardInfo: aichatI18n.aiCustomizations_modelCardInfo(),
-};
+});
 
 // Model customization fields that are checked for toxicity before updating.
 export const FIELDS_CHECKED_FOR_TOXICITY = [

--- a/apps/src/aichat/views/presentation/PresentationView.tsx
+++ b/apps/src/aichat/views/presentation/PresentationView.tsx
@@ -3,8 +3,8 @@ import classNames from 'classnames';
 import React, {useMemo} from 'react';
 
 import {
-  MODEL_CARD_FIELDS_LABELS_ICONS,
-  TECHNICAL_INFO_FIELDS,
+  getModelCardFieldsLabelsIcons,
+  getTechnicalInfoFields,
 } from '@cdo/apps/aichat/views/modelCustomization/constants';
 import {useAppSelector} from '@cdo/apps/util/reduxHooks';
 
@@ -30,20 +30,16 @@ const PresentationView: React.FunctionComponent = () => {
   } = modelDescriptions.find(model => model.id === selectedModelId) ?? {};
 
   const technicalInfo = useMemo(() => {
-    const technicalInfoData: {
-      [key in (typeof TECHNICAL_INFO_FIELDS)[number]]:
-        | string
-        | number
-        | boolean;
-    } = {
-      'Model Name': modelName,
-      Overview: overview,
-      'Training Data': trainingData,
-      'System Prompt': systemPrompt,
-      Temperature: temperature,
-      'Retrieval Used': retrievalContexts.length > 0,
+    const technicalInfoFields = getTechnicalInfoFields();
+    const technicalInfoData: Record<string, string | number | boolean> = {
+      [technicalInfoFields[0]]: modelName,
+      [technicalInfoFields[1]]: overview,
+      [technicalInfoFields[2]]: trainingData,
+      [technicalInfoFields[3]]: systemPrompt,
+      [technicalInfoFields[4]]: temperature,
+      [technicalInfoFields[5]]: retrievalContexts.length > 0,
     };
-    const technicalInfo = TECHNICAL_INFO_FIELDS.map(field => {
+    const technicalInfo = technicalInfoFields.map(field => {
       if (typeof technicalInfoData[field] === 'boolean') {
         return `${field}: ${technicalInfoData[field] ? 'Yes' : 'No'}`;
       }
@@ -75,7 +71,7 @@ const PresentationView: React.FunctionComponent = () => {
         {modelCardInfo['botName']}
       </Typography>
       <div className={moduleStyles.modelCardFields}>
-        {MODEL_CARD_FIELDS_LABELS_ICONS.map(
+        {getModelCardFieldsLabelsIcons().map(
           ({property, label, icon, displayTooltip}) => {
             if (property === 'botName' || property === 'isPublished') {
               return null;

--- a/apps/src/lab2/levelEditors/aichatSettings/ModelCardFields.tsx
+++ b/apps/src/lab2/levelEditors/aichatSettings/ModelCardFields.tsx
@@ -2,7 +2,7 @@ import React, {useContext} from 'react';
 
 import {
   MAX_ASK_ABOUT_TOPICS,
-  MODEL_CARD_FIELDS_LABELS_ICONS,
+  getModelCardFieldsLabelsIcons,
 } from '@cdo/apps/aichat/views/modelCustomization/constants';
 import MultiItemInput from '@cdo/apps/templates/MultiItemInput';
 
@@ -16,7 +16,7 @@ const ModelCardFields: React.FunctionComponent = () => {
   const exampleTopics = modelCardInfo.exampleTopics;
   return (
     <div className={moduleStyles['model-card-fields']}>
-      {MODEL_CARD_FIELDS_LABELS_ICONS.map(({property, label}) => {
+      {getModelCardFieldsLabelsIcons().map(({property, label}) => {
         if (property === 'exampleTopics' || property === 'isPublished') {
           return null;
         }


### PR DESCRIPTION
Locally, I keep running into an issue where the aichat locales don't load properly. 
<img width="745" height="344" alt="Screenshot 2026-03-24 at 1 34 36 PM" src="https://github.com/user-attachments/assets/ed4c4e49-5411-4bf7-aa2b-948b91755e1c" />

Others have had a similar issue and it even showed up on Drone awhile back (🧵 [example 1](https://codedotorg.slack.com/archives/C046G4TRLEN/p1763575090268679), [example 2](https://codedotorg.slack.com/archives/C046G4TRLEN/p1761921670644079)) I'm finally getting around to digging deeper. I _think_ what's happening is aichat/redux/slice.ts imports from modelCustomization/constants, and the Redux slice is almost certainly loaded when ChatWorkspace mounts. Sometimes this import chain gets evaluated before the aichat_locale translations are loaded into window.locales. Since the locale isn't initialized yet, I get the error. Instead I'm converting call locale functions into getter functions, so the locale is only called at render time. 