### PR TITLE
Add in Lesson Resources button in collaposed view

### DIFF
--- a/apps/src/templates/progress/SummaryProgressRow.jsx
+++ b/apps/src/templates/progress/SummaryProgressRow.jsx
@@ -127,19 +127,18 @@ function SummaryProgressRow({
             )}
             {lesson.isFocusArea && <FocusAreaIndicator />}
           </div>
-          {viewAs === ViewType.Participant &&
-            lesson.student_lesson_plan_html_url && (
-              <Button
-                __useDeprecatedTag
-                className="ui-test-lesson-resources"
-                href={lesson.student_lesson_plan_html_url}
-                text={i18n.lessonResources()}
-                icon="file-text"
-                color="white"
-                target="_blank"
-                style={styles.buttonStyle}
-              />
-            )}
+          {lesson.student_lesson_plan_html_url && (
+            <Button
+              __useDeprecatedTag
+              className="ui-test-lesson-resources"
+              href={lesson.student_lesson_plan_html_url}
+              text={i18n.lessonResources()}
+              icon="file-text"
+              color="white"
+              target="_blank"
+              style={styles.buttonStyle}
+            />
+          )}
         </div>
       </td>
     </tr>

--- a/apps/src/templates/progress/SummaryProgressRow.jsx
+++ b/apps/src/templates/progress/SummaryProgressRow.jsx
@@ -6,6 +6,7 @@ import ReactTooltip from 'react-tooltip';
 
 import {ViewType} from '@cdo/apps/code-studio/viewAsRedux';
 import fontConstants from '@cdo/apps/fontConstants';
+import Button from '@cdo/apps/legacySharedComponents/Button';
 import FontAwesome from '@cdo/apps/legacySharedComponents/FontAwesome';
 import color from '@cdo/apps/util/color';
 import i18n from '@cdo/locale';
@@ -112,17 +113,34 @@ function SummaryProgressRow({
           ...(isLockedForUser && styles.fadedCol),
         }}
       >
-        {levels.length === 0 ? (
-          i18n.lessonContainsNoLevels()
-        ) : (
-          <ProgressBubbleSet
-            levels={levels}
-            disabled={isLockedForUser}
-            style={lesson.isFocusArea ? styles.focusAreaMargin : undefined}
-            lessonName={lesson.name}
-          />
-        )}
-        {lesson.isFocusArea && <FocusAreaIndicator />}
+        <div style={styles.col2Content}>
+          <div style={styles.col2Left}>
+            {levels.length === 0 ? (
+              i18n.lessonContainsNoLevels()
+            ) : (
+              <ProgressBubbleSet
+                levels={levels}
+                disabled={isLockedForUser}
+                style={lesson.isFocusArea ? styles.focusAreaMargin : undefined}
+                lessonName={lesson.name}
+              />
+            )}
+            {lesson.isFocusArea && <FocusAreaIndicator />}
+          </div>
+          {viewAs === ViewType.Participant &&
+            lesson.student_lesson_plan_html_url && (
+              <Button
+                __useDeprecatedTag
+                className="ui-test-lesson-resources"
+                href={lesson.student_lesson_plan_html_url}
+                text={i18n.lessonResources()}
+                icon="file-text"
+                color="white"
+                target="_blank"
+                style={styles.buttonStyle}
+              />
+            )}
+        </div>
       </td>
     </tr>
   );
@@ -171,6 +189,18 @@ export const styles = {
     width: '100%',
     paddingLeft: 20,
     paddingRight: 20,
+  },
+  col2Content: {
+    display: 'flex',
+    alignItems: 'center',
+    width: '100%',
+  },
+  col2Left: {
+    flex: 1,
+  },
+  buttonStyle: {
+    marginLeft: 10,
+    boxShadow: 'none',
   },
   // When we set our opacity on the row element instead of on individual tds,
   // there are weird interactions with our tooltips in Chrome, and borders end

--- a/apps/test/unit/templates/progress/SummaryProgressRowTest.js
+++ b/apps/test/unit/templates/progress/SummaryProgressRowTest.js
@@ -81,6 +81,30 @@ describe('SummaryProgressRow', () => {
       );
     });
 
+    it('shows lesson resources button when lesson has student_lesson_plan_html_url', () => {
+      const lessonWithUrl = {
+        ...fakeLesson('Maze', 1, false, 3),
+        student_lesson_plan_html_url: 'https://example.com/lesson-plan',
+      };
+      const wrapper = setUp({
+        lesson: lessonWithUrl,
+        viewAs: ViewType.Participant,
+      });
+
+      const button = wrapper.find('Button');
+      expect(button).toHaveLength(1);
+      expect(button.props().href).toEqual('https://example.com/lesson-plan');
+      expect(button.props().className).toEqual('ui-test-lesson-resources');
+    });
+
+    it('does not show lesson resources button when lesson has no student_lesson_plan_html_url', () => {
+      const wrapper = setUp({
+        viewAs: ViewType.Participant,
+      });
+
+      expect(wrapper.find('Button')).toHaveLength(0);
+    });
+
     it('has a lock icon when lockable and locked for user', () => {
       const wrapper = setUp({
         lesson: fakeLesson('Maze', 1, true),
@@ -176,6 +200,19 @@ describe('SummaryProgressRow', () => {
       });
 
       expect(wrapper.find('FontAwesome').at(0).props().icon).toEqual('unlock');
+    });
+
+    it('does not show lesson resources button when viewing as instructor', () => {
+      const lessonWithUrl = {
+        ...fakeLesson('Maze', 1, false, 3),
+        student_lesson_plan_html_url: 'https://example.com/lesson-plan',
+      };
+      const wrapper = setUp({
+        lesson: lessonWithUrl,
+        viewAs: ViewType.Instructor,
+      });
+
+      expect(wrapper.find('Button')).toHaveLength(0);
     });
   });
 });

--- a/apps/test/unit/templates/progress/SummaryProgressRowTest.js
+++ b/apps/test/unit/templates/progress/SummaryProgressRowTest.js
@@ -88,7 +88,6 @@ describe('SummaryProgressRow', () => {
       };
       const wrapper = setUp({
         lesson: lessonWithUrl,
-        viewAs: ViewType.Participant,
       });
 
       const button = wrapper.find('Button');
@@ -98,9 +97,7 @@ describe('SummaryProgressRow', () => {
     });
 
     it('does not show lesson resources button when lesson has no student_lesson_plan_html_url', () => {
-      const wrapper = setUp({
-        viewAs: ViewType.Participant,
-      });
+      const wrapper = setUp();
 
       expect(wrapper.find('Button')).toHaveLength(0);
     });
@@ -200,19 +197,6 @@ describe('SummaryProgressRow', () => {
       });
 
       expect(wrapper.find('FontAwesome').at(0).props().icon).toEqual('unlock');
-    });
-
-    it('does not show lesson resources button when viewing as instructor', () => {
-      const lessonWithUrl = {
-        ...fakeLesson('Maze', 1, false, 3),
-        student_lesson_plan_html_url: 'https://example.com/lesson-plan',
-      };
-      const wrapper = setUp({
-        lesson: lessonWithUrl,
-        viewAs: ViewType.Instructor,
-      });
-
-      expect(wrapper.find('Button')).toHaveLength(0);
     });
   });
 });


### PR DESCRIPTION
Adds "Lesson Resources" button to collapsed view.

Note I DMed Tess to get a thumbs up on this look.  The tradeoff is that on smaller screens the bubbles will wrap more frequently.

BEFORE:
<img width="1010" height="710" alt="image" src="https://github.com/user-attachments/assets/8dc61d7a-f99e-4451-875f-d69050a0c866" />


AFTER:
<img width="889" height="646" alt="image" src="https://github.com/user-attachments/assets/1fd99b21-35d3-4467-9a1a-c1db060067a1" />




## Links
[Ticket](https://codedotorg.atlassian.net/browse/TEACHING-116)

## Testing story
Added to exisiting tests.

Will notify DOTD that this will cause eyes tests diffs.
