### PR TITLE
Provide an AWS Account ID Lookup

### DIFF
--- a/lib/cdo/aws/ec2.rb
+++ b/lib/cdo/aws/ec2.rb
@@ -1,5 +1,6 @@
 require 'net/http'
 require 'uri'
+require 'json'
 require 'active_support/core_ext/integer/time'
 
 module AWS
@@ -20,6 +21,21 @@ module AWS
     def self.region
       return @region if defined?(@region) && @region
       @region = fetch_metadata('placement/region')
+    end
+
+    # AWS Account ID of the compute resource (EC2, Lambda, ECS Task) that we're currently executing in.
+    def self.account_id
+      return @account_id if defined?(@account_id) && @account_id
+
+      response = fetch_metadata('identity-credentials/ec2/info')
+      return nil unless response
+
+      begin
+        parsed_info = JSON.parse(response)
+        @account_id = parsed_info['AccountId']
+      rescue JSON::ParserError
+        nil
+      end
     end
 
     private_class_method def self.fetch_metadata(path)

--- a/lib/test/cdo/aws/test_ec2.rb
+++ b/lib/test/cdo/aws/test_ec2.rb
@@ -6,7 +6,7 @@ describe AWS::EC2 do
 
   # Reset memoized variables to ensure fresh metadata lookups
   before do
-    [:@instance_id, :@region].each do |var|
+    [:@instance_id, :@region, :@account_id].each do |var|
       described_class.remove_instance_variable(var) if described_class.instance_variable_defined?(var)
     end
   end
@@ -56,6 +56,53 @@ describe AWS::EC2 do
         returns(mock_region_resp)
 
       _(described_class.region).must_equal 'us-west-2'
+    end
+  end
+
+  describe '.account_id' do
+    let(:mock_token_resp) {mock {stubs(code: '200', body: 'test_token')}}
+
+    before do
+      # Common stub for the token request needed by all metadata calls
+      described_class.stubs(:http_request).
+        with {|method, uri, _| method == Net::HTTP::Put && uri.path.include?('token')}.
+        returns(mock_token_resp)
+    end
+
+    it 'returns current AWS Account ID by parsing the identity-credentials JSON' do
+      json_body = {
+        'Code' => 'Success',
+        'LastUpdated' => '2023-10-27T10:00:00Z',
+        'AccountId' => '123456789012'
+      }.to_json
+
+      mock_info_resp = mock {stubs(code: '200', body: json_body)}
+
+      described_class.stubs(:http_request).
+        with {|method, uri, _| method == Net::HTTP::Get && uri.path.include?('identity-credentials/ec2/info')}.
+        returns(mock_info_resp)
+
+      _(described_class.account_id).must_equal '123456789012'
+    end
+
+    it 'returns nil if the metadata response is invalid JSON' do
+      mock_bad_resp = mock {stubs(code: '200', body: 'not-json-content')}
+
+      described_class.stubs(:http_request).
+        with {|method, uri, _| method == Net::HTTP::Get && uri.path.include?('identity-credentials')}.
+        returns(mock_bad_resp)
+
+      _(described_class.account_id).must_be_nil
+    end
+
+    it 'returns nil if the metadata service returns a 404' do
+      mock_404_resp = mock {stubs(code: '404', body: 'Not Found')}
+
+      described_class.stubs(:http_request).
+        with {|method, uri, _| method == Net::HTTP::Get && uri.path.include?('identity-credentials')}.
+        returns(mock_404_resp)
+
+      _(described_class.account_id).must_be_nil
     end
   end
 end


### PR DESCRIPTION
Provide a way for web application server or other server-side Rails code to lookup the current AWS Account ID.

This can specifically help #71526 avoid hard coding the AWS Account ID in the Bedrock Model ARN.

## Testing story
<!-- How was this tested? Manual steps, adhoc links, automated tests, or why testing isn't needed. -->



## Deployment notes
<!-- Delete this section if it's a standard merge-and-deploy.
     Otherwise: migrations, feature flags, coordination, caching impacts, etc. -->



## Privacy and security
<!-- Delete this section if there is no privacy/security impact.
     Otherwise: new PII, auth changes, API surface changes, etc. -->

