### PR TITLE
AI Chat: fix chat bubble width

### DIFF
--- a/apps/src/aiComponentLibrary/chatMessage/ChatMessage.tsx
+++ b/apps/src/aiComponentLibrary/chatMessage/ChatMessage.tsx
@@ -116,7 +116,7 @@ const ChatMessage: React.FunctionComponent<ChatMessageProps> = ({
             )}
           </div>
         )}
-        <div className={moduleStyles.messageAndHeader}>
+        <div className={moduleStyles[`message-and-header-${role}`]}>
           {header && <div className={moduleStyles.header}>{header}</div>}
           {(text || postText) && (
             <div

--- a/apps/src/aiComponentLibrary/chatMessage/chat-message.module.scss
+++ b/apps/src/aiComponentLibrary/chatMessage/chat-message.module.scss
@@ -187,10 +187,20 @@ json-video {
   margin: 15px 0;
 }
 
-.messageAndHeader {
+%message-and-header {
   display: flex;
   flex-direction: column;
   gap: $vertical-gap;
+}
+
+.message-and-header-assistant {
+  @extend %message-and-header;
+  align-items: flex-start;
+}
+
+.message-and-header-user {
+  @extend %message-and-header;
+  align-items: flex-end;
 }
 
 .grid {


### PR DESCRIPTION
Fixes a minor regression from https://github.com/code-dot-org/code-dot-org/pull/71484 where the chat bubble would extend to match the width of the header (asset row) rather than constraining its width to the message contents.

Before:
<img width="586" height="736" alt="Screenshot 2026-03-24 at 12 44 28 PM" src="https://github.com/user-attachments/assets/b53761c8-04ff-4d22-8322-4ec00e7388b8" />

After:
<img width="583" height="733" alt="Screenshot 2026-03-24 at 12 45 38 PM" src="https://github.com/user-attachments/assets/7582e9f4-a0e6-467a-8b9a-de746ddd6a36" />