### PR TITLE
Fix yarn.lock for `react-is` upgrade

### DIFF
--- a/apps/yarn.lock
+++ b/apps/yarn.lock
@@ -25691,7 +25691,7 @@ canvg@gabelerner/canvg:
   languageName: node
   linkType: hard
 
-"react-is@npm:^17.0.1, react-is@npm:^17.0.2":
+"react-is@npm:^17.0.1":
   version: 17.0.2
   resolution: "react-is@npm:17.0.2"
   checksum: 10/73b36281e58eeb27c9cc6031301b6ae19ecdc9f18ae2d518bdb39b0ac564e65c5779405d623f1df9abf378a13858b79442480244bd579968afc1faf9a2ce5e05


### PR DESCRIPTION
yarn.lock got mixed up between React 17/18 in this PR https://github.com/code-dot-org/code-dot-org/pull/71501, fixing