### PR TITLE
fix(cl): resolve non-deterministic CSS output

### DIFF
--- a/frontend/packages/component-library/vite.config.ts
+++ b/frontend/packages/component-library/vite.config.ts
@@ -13,8 +13,10 @@ const entryPoints = glob.sync('./src/**/index.ts', {
 });
 
 /**
- * Changes .module.css/.scss files to index.css under each component folder
- * This is to indicate that upstream bundlers should not re-modularize the CSS.
+ * Changes .module.css/.scss files to {base}.css under each component folder,
+ * stripping the ".module" suffix to avoid host bundlers re-modularizing the CSS.
+ * Using the source base name (rather than a hardcoded "index") ensures deterministic
+ * output when a component directory contains multiple .module.scss files.
  * @param assetInfo Vite config asset info
  * @returns Asset file name
  */
@@ -22,8 +24,9 @@ function getAssetFileNames(assetInfo: PreRenderedAsset) {
   const name = assetInfo.names[0];
 
   if (/\.module\.(scss|css)$/.test(name)) {
-    const componentName = path.dirname(name); // e.g., "button"
-    return `${componentName}/index.css`;
+    const componentName = path.dirname(name); // e.g., "dialog"
+    const base = path.basename(name).replace(/\.module\.(scss|css)$/, ''); // e.g., "dialog", "customDialog"
+    return `${componentName}/${base}.css`; // e.g., "dialog/dialog.css", "dialog/customDialog.css"
   }
 
   return '[name]/[name].[ext]';


### PR DESCRIPTION
When a component directory contained multiple `.module.scss` files, `getAssetFileNames` mapped all of them to the same `index.css` path. Rollup resolved the collision by appending a counter (e.g. `index2.css`), but the order was non-deterministic, making the mapping between filenames and their contents unreliable across builds.

Fix by using the source file's base name instead of the hardcoded `index`, stripping the `.module` suffix to prevent host bundlers from re-processing the output as a CSS Module. This produces stable, unique names like `dialog/dialog.css` and `dialog/customDialog.css`.

- Replace hardcoded `index.css` output name with source base name
- Strip `.module.(scss|css)` suffix from output filename
- Update comment to document determinism guarantee

<!--
  Summary of the change: background, motivation, and context.
  Include screenshots, videos, or before/after comparisons for UI changes.
-->



## Links
<!-- Jira tickets, design docs, Slack threads, related PRs, etc. -->

- Jira:

## Testing story
<!-- How was this tested? Manual steps, adhoc links, automated tests, or why testing isn't needed. -->



## Deployment notes
<!-- Delete this section if it's a standard merge-and-deploy.
     Otherwise: migrations, feature flags, coordination, caching impacts, etc. -->



## Privacy and security
<!-- Delete this section if there is no privacy/security impact.
     Otherwise: new PII, auth changes, API surface changes, etc. -->

