### PR TITLE
Update createReactRoot to react 18

### DIFF
--- a/apps/src/code-studio/levels/dialogHelper.js
+++ b/apps/src/code-studio/levels/dialogHelper.js
@@ -31,7 +31,7 @@ export function showDialog(component, callback, onHidden) {
     return;
   }
   const div = document.createElement('div');
-  createReactRoot(component, div);
+  createReactRoot(component, div, {flushSync: true});
   const content = div.childNodes[0];
   const dialog = new LegacyDialog({
     // Content is a div with a specific expected structure. See LegacyDialog.

--- a/apps/src/util/createReactRoot.tsx
+++ b/apps/src/util/createReactRoot.tsx
@@ -4,6 +4,7 @@ import '@code-dot-org/component-library-styles/primitiveColors.css';
 import {CdoTheme} from '@code-dot-org/component-library/themes';
 import {ThemeProvider as MuiThemeProvider} from '@mui/material/styles';
 import React, {ReactElement} from 'react';
+import {flushSync} from 'react-dom';
 import {createRoot} from 'react-dom/client';
 
 /**
@@ -17,7 +18,8 @@ import {createRoot} from 'react-dom/client';
  */
 export function createReactRoot(
   component: ReactElement,
-  container: Element | string
+  container: Element | string,
+  options?: {flushSync?: boolean}
 ): void {
   const containerElement =
     typeof container === 'string'
@@ -30,7 +32,16 @@ export function createReactRoot(
     );
   }
 
-  createRoot(containerElement).render(
+  const root = createRoot(containerElement);
+  const element = (
     <MuiThemeProvider theme={CdoTheme}>{component}</MuiThemeProvider>
   );
+
+  if (options?.flushSync) {
+    flushSync(() => {
+      root.render(element);
+    });
+  } else {
+    root.render(element);
+  }
 }

--- a/apps/src/util/createReactRoot.tsx
+++ b/apps/src/util/createReactRoot.tsx
@@ -4,7 +4,7 @@ import '@code-dot-org/component-library-styles/primitiveColors.css';
 import {CdoTheme} from '@code-dot-org/component-library/themes';
 import {ThemeProvider as MuiThemeProvider} from '@mui/material/styles';
 import React, {ReactElement} from 'react';
-import ReactDOM from 'react-dom';
+import {createRoot} from 'react-dom/client';
 
 /**
  * Global bootstrapper function that wraps rendered DOM trees with configured providers
@@ -30,8 +30,7 @@ export function createReactRoot(
     );
   }
 
-  ReactDOM.render(
-    <MuiThemeProvider theme={CdoTheme}>{component}</MuiThemeProvider>,
-    containerElement
+  createRoot(containerElement).render(
+    <MuiThemeProvider theme={CdoTheme}>{component}</MuiThemeProvider>
   );
 }

--- a/apps/test/unit/accounts/AddParentEmailControllerTest.js
+++ b/apps/test/unit/accounts/AddParentEmailControllerTest.js
@@ -3,6 +3,7 @@ import ReactDOM from 'react-dom';
 import {spy, stub} from 'sinon'; // eslint-disable-line no-restricted-imports
 
 import AddParentEmailController from '@cdo/apps/accounts/AddParentEmailController';
+import * as createReactRootModule from '@cdo/apps/util/createReactRoot';
 
 import {expect} from '../../util/reconfiguredChai'; // eslint-disable-line no-restricted-imports
 
@@ -48,33 +49,33 @@ describe('AddParentEmailController', () => {
   describe('controls AddParentEmailModal', () => {
     beforeEach(() => {
       controller = newController();
-      spy(ReactDOM, 'render');
+      spy(createReactRootModule, 'createReactRoot');
       spy(ReactDOM, 'unmountComponentAtNode');
     });
 
     afterEach(() => {
       controller.hideAddParentEmailModal();
-      ReactDOM.render.restore();
+      createReactRootModule.createReactRoot.restore();
       ReactDOM.unmountComponentAtNode.restore();
     });
 
     it('shows on showAddParentEmailModal', () => {
-      expect(ReactDOM.render).not.to.have.been.called;
+      expect(createReactRootModule.createReactRoot).not.to.have.been.called;
       controller.showAddParentEmailModal();
-      expect(ReactDOM.render).to.have.been.calledOnce;
+      expect(createReactRootModule.createReactRoot).to.have.been.calledOnce;
     });
 
     it('show is idempotent', () => {
-      expect(ReactDOM.render).not.to.have.been.called;
+      expect(createReactRootModule.createReactRoot).not.to.have.been.called;
       controller.showAddParentEmailModal();
       controller.showAddParentEmailModal();
-      expect(ReactDOM.render).to.have.been.calledOnce;
+      expect(createReactRootModule.createReactRoot).to.have.been.calledOnce;
     });
 
     it('shows when the link is clicked', () => {
-      expect(ReactDOM.render).not.to.have.been.called;
+      expect(createReactRootModule.createReactRoot).not.to.have.been.called;
       link.click();
-      expect(ReactDOM.render).to.have.been.calledOnce;
+      expect(createReactRootModule.createReactRoot).to.have.been.calledOnce;
     });
 
     it('hides on hideAddParentEmailModal', () => {

--- a/apps/test/unit/accounts/AddPasswordControllerTest.js
+++ b/apps/test/unit/accounts/AddPasswordControllerTest.js
@@ -1,8 +1,8 @@
 import $ from 'jquery';
-import ReactDOM from 'react-dom';
 import {spy, stub} from 'sinon'; // eslint-disable-line no-restricted-imports
 
 import AddPasswordController from '@cdo/apps/accounts/AddPasswordController';
+import * as createReactRootModule from '@cdo/apps/util/createReactRoot';
 
 import {expect, assert} from '../../util/reconfiguredChai'; // eslint-disable-line no-restricted-imports
 
@@ -20,19 +20,19 @@ describe('AddPasswordController', () => {
     document.body.appendChild(mockMountPoint);
     controller = new AddPasswordController(form, mockMountPoint);
 
-    spy(ReactDOM, 'render');
+    spy(createReactRootModule, 'createReactRoot');
   });
 
   afterEach(() => {
-    ReactDOM.render.restore();
+    createReactRootModule.createReactRoot.restore();
     document.body.removeChild(mockMountPoint);
   });
 
   describe('renderAddPasswordForm', () => {
     it('renders AddPasswordForm', () => {
-      expect(ReactDOM.render).not.to.have.been.called;
+      expect(createReactRootModule.createReactRoot).not.to.have.been.called;
       controller.renderAddPasswordForm();
-      expect(ReactDOM.render).to.have.been.calledOnce;
+      expect(createReactRootModule.createReactRoot).to.have.been.calledOnce;
     });
   });
 

--- a/apps/test/unit/accounts/ChangeUserTypeControllerTest.js
+++ b/apps/test/unit/accounts/ChangeUserTypeControllerTest.js
@@ -3,6 +3,7 @@ import ReactDOM from 'react-dom';
 import {spy, stub} from 'sinon'; // eslint-disable-line no-restricted-imports
 
 import ChangeUserTypeController from '@cdo/apps/accounts/ChangeUserTypeController';
+import * as createReactRootModule from '@cdo/apps/util/createReactRoot';
 import * as utils from '@cdo/apps/utils';
 import i18n from '@cdo/locale';
 
@@ -13,14 +14,14 @@ describe('ChangeUserTypeController', () => {
 
   beforeEach(() => {
     stub(utils, 'reload');
-    spy(ReactDOM, 'render');
+    spy(createReactRootModule, 'createReactRoot');
     spy(ReactDOM, 'unmountComponentAtNode');
   });
 
   afterEach(() => {
     controller && controller.hideChangeUserTypeModal();
     utils.reload.restore();
-    ReactDOM.render.restore();
+    createReactRootModule.createReactRoot.restore();
     ReactDOM.unmountComponentAtNode.restore();
   });
 
@@ -111,23 +112,23 @@ describe('ChangeUserTypeController', () => {
       dropdown.val(OTHER_USER_TYPE);
       dropdown.change();
 
-      expect(ReactDOM.render).not.to.have.been.called;
+      expect(createReactRootModule.createReactRoot).not.to.have.been.called;
       button.click();
-      expect(ReactDOM.render).to.have.been.calledOnce;
+      expect(createReactRootModule.createReactRoot).to.have.been.calledOnce;
     });
 
     it('show is idempotent', () => {
-      expect(ReactDOM.render).not.to.have.been.called;
+      expect(createReactRootModule.createReactRoot).not.to.have.been.called;
       controller.showChangeUserTypeModal();
       controller.showChangeUserTypeModal();
-      expect(ReactDOM.render).to.have.been.calledOnce;
+      expect(createReactRootModule.createReactRoot).to.have.been.calledOnce;
     });
 
     it('can hide the modal dialog', () => {
       dropdown.val(OTHER_USER_TYPE);
       dropdown.change();
       button.click();
-      expect(ReactDOM.render).to.have.been.calledOnce;
+      expect(createReactRootModule.createReactRoot).to.have.been.calledOnce;
 
       expect(ReactDOM.unmountComponentAtNode).not.to.have.been.called;
       controller.hideChangeUserTypeModal();

--- a/apps/test/unit/sites/studio/pages/levelbuilder_edit_scriptTest.js
+++ b/apps/test/unit/sites/studio/pages/levelbuilder_edit_scriptTest.js
@@ -1,6 +1,5 @@
-import ReactDOM from 'react-dom';
-
 import initPage from '@cdo/apps/sites/studio/pages/scripts/edit';
+import * as createReactRootModule from '@cdo/apps/util/createReactRoot';
 
 import {allowConsoleWarnings} from '../../../../util/throwOnConsole';
 
@@ -11,7 +10,7 @@ describe('the level builder page init script', () => {
 
   let container;
   beforeEach(() => {
-    jest.spyOn(ReactDOM, 'render').mockClear();
+    jest.spyOn(createReactRootModule, 'createReactRoot').mockClear();
     container = document.createElement('div');
     document.body.appendChild(container);
     container.className = 'edit_container';
@@ -42,10 +41,13 @@ describe('the level builder page init script', () => {
   });
 
   afterEach(() => {
-    ReactDOM.render.mockRestore();
+    createReactRootModule.createReactRoot.mockRestore();
   });
 
   it('renders to a div with the edit_container class', () => {
-    expect(ReactDOM.render).toHaveBeenCalledWith(expect.any(Object), container);
+    expect(createReactRootModule.createReactRoot).toHaveBeenCalledWith(
+      expect.any(Object),
+      container
+    );
   });
 });


### PR DESCRIPTION
Update `createReactRoot` which should be used by all webpack endpoints to the react 18 version of creating a root. This should prevent errors in console and future proofing.

See details [here](https://react.dev/blog/2022/03/08/react-18-upgrade-guide#updates-to-client-rendering-apis)
