### PR TITLE
K8S: disable honeybadger, pagerduty, sentry and slack via secrets overrides

### DIFF
--- a/k8s/helm/templates/cdo-local-secrets.yaml
+++ b/k8s/helm/templates/cdo-local-secrets.yaml
@@ -15,6 +15,21 @@ metadata:
     {{- include "cdo.labels" (merge (dict "component" "cdo-local-secrets") .) | nindent 4 }}
 type: Opaque
 stringData:
+  # TODO: override keys to DISABLE monitoring services while we get operational:
+  #
+  # DISABLE: HONEYBADGER, PAGERDUTY, SENTRY, SLACK
+  cronjobs_honeybadger_api_key: ""
+  dashboard_honeybadger_api_key: ""
+  pagerduty_token: ""
+  pegasus_honeybadger_api_key: ""
+  sentry_api_key: ""
+  sentry_auth_token: ""
+  sentry_dsn: ""
+  slack_bot_token: ""
+  slack_endpoint: ""
+  slack_endpoint_broken_links: ""
+  slack_start_build_token: ""
+  slack_token: ""
 
 {{- if .Values.services.mysql.enabled }}
   {{- $mysqlRootPassword := required "services.mysql.password must be set when services.mysql.enabled=true. Skaffold development injects this from cdo-local-secrets.env." .Values.services.mysql.password }}

--- a/k8s/kustomize/base/cdo-local-secrets.yaml
+++ b/k8s/kustomize/base/cdo-local-secrets.yaml
@@ -7,4 +7,20 @@ metadata:
   labels:
     app.kubernetes.io/component: cdo-local-secrets
 type: Opaque
-stringData: {}
+stringData:
+  # TODO: override keys to DISABLE monitoring services while we get operational:
+  #
+  # DISABLE: HONEYBADGER, PAGERDUTY, SENTRY, SLACK
+  cronjobs_honeybadger_api_key: ""
+  dashboard_honeybadger_api_key: ""
+  pagerduty_token: ""
+  pegasus_honeybadger_api_key: ""
+  sentry_api_key: ""
+  sentry_auth_token: ""
+  sentry_dsn: ""
+  slack_bot_token: ""
+  slack_endpoint: ""
+  slack_endpoint_broken_links: ""
+  slack_start_build_token: ""
+  slack_token: ""
+


### PR DESCRIPTION
Kubernetes deployments are just becoming operational. Until they're rolling smoothly, this PR overrides cdo-local-secrets on both helm and kustomize in order to disable their access to monitoring systems. If they log weird errors, it'll cause unnecessary investigation and alarm. Because `cdo-local-secrets` has higher precedence than `cdo-external-secrets` it will ellide access to these systems.

Once things are running smoothly, we can slowly turn these back on, potentially with k8s-specific tags on them so we can differentiate real staging from "staging", etc.