### PR TITLE
Add back event for viewing progress

### DIFF
--- a/apps/src/metrics/AnalyticsConstants.js
+++ b/apps/src/metrics/AnalyticsConstants.js
@@ -180,8 +180,7 @@ const EVENTS = {
     'Section students table save all clicked',
 
   // Section progress v2
-  PROGRESS_V2_VIEW_NEW_PROGRESS: 'New Progress Link Clicked',
-  PROGRESS_V2_VIEW_OLD_PROGRESS: 'Old Progress Link Clicked',
+  PROGRESS_V2_VIEW: 'Section New Progress Viewed ',
   PROGRESS_V2_CHANGE_UNIT: 'Section New Progress Unit Changed',
   PROGRESS_V2_LESSON_EXPAND: 'Section New Progress Lesson Expand',
   PROGRESS_V2_LESSON_COLLAPSE: 'Section New Progress Lesson Collapse',

--- a/apps/src/templates/sectionProgressV2/SectionProgressV2.jsx
+++ b/apps/src/templates/sectionProgressV2/SectionProgressV2.jsx
@@ -4,6 +4,8 @@ import React from 'react';
 import {connect} from 'react-redux';
 import {useParams} from 'react-router-dom';
 
+import {EVENTS} from '@cdo/apps/metrics/AnalyticsConstants';
+import analyticsReporter from '@cdo/apps/metrics/AnalyticsReporter';
 import {
   getSelectedCourseId,
   getSelectedUnitPosition,
@@ -41,6 +43,12 @@ function SectionProgressV2({
   const params = useParams();
   React.useEffect(() => {
     loadExpandedLessonsFromLocalStorage(scriptId, sectionId);
+    analyticsReporter.sendEvent(EVENTS.PROGRESS_V2_VIEW, {
+      sectionId: sectionId,
+      unitId: scriptId,
+      windowWidth: window.innerWidth,
+      windowHeight: window.innerHeight,
+    });
   }, [scriptId, sectionId, loadExpandedLessonsFromLocalStorage]);
 
   const levelDataInitialized = React.useMemo(() => {


### PR DESCRIPTION
This event was mistakenly marked for removal and subsequently removed in https://github.com/code-dot-org/code-dot-org/pull/71187. We use this event to measure how much the progress view is used.

I confirmed this event now appears locally when viewing the progress page.
```
[STATSIG ANALYTICS EVENT]: Section New Progress Viewed . Payload: {"payload":{"sectionId":31,"unitId":162,"windowWidth":1078,"windowHeight":730}}
```





