### PR TITLE
Fix verify-helm-parity GitOps values handling

### DIFF
--- a/k8s/helm/templates/locals.yml.yaml
+++ b/k8s/helm/templates/locals.yml.yaml
@@ -38,3 +38,9 @@ data:
   aws_s3_endpoint: {{ printf "http://%s:9000" (include "cdo.minioServiceName" .) | quote }}
   aws_s3_emulated: "true"
   {{- end }}
+
+  # Now insert `locals.yml:` values defined in *.values.yaml files
+  {{- $locals := index .Values "locals.yml" | default (dict) }}
+  {{- range $key, $value := $locals }}
+  {{ $key }}: {{ printf "%v" $value | quote }}
+  {{- end }}

--- a/k8s/kustomize/bin/verify-helm-parity
+++ b/k8s/kustomize/bin/verify-helm-parity
@@ -125,7 +125,7 @@ module DashboardKustomize
         "#{GITOPS_ENVTYPES_BASE_URL}/production.values.yaml",
         "#{GITOPS_DEPLOYMENTS_BASE_URL}/production/values.yaml"
       ],
-      helm_set: [['--set', 'image=code-dot-org:latest']]
+      helm_set: []
     },
     'test' => {
       release_name: 'test',
@@ -134,13 +134,7 @@ module DashboardKustomize
         "#{GITOPS_ENVTYPES_BASE_URL}/test.values.yaml",
         "#{GITOPS_DEPLOYMENTS_BASE_URL}/test/values.yaml"
       ],
-      helm_set: [
-        ['--set', 'image=code-dot-org:latest'],
-        ['--set-json', 'command=["bin/dashboard-server"]'],
-        ['--set-json', 'args=[]'],
-        ['--set', 'user.uid=1000'],
-        ['--set', 'user.gid=1000']
-      ]
+      helm_set: []
     },
     'staging' => {
       release_name: 'staging',
@@ -149,13 +143,7 @@ module DashboardKustomize
         "#{GITOPS_ENVTYPES_BASE_URL}/staging.values.yaml",
         "#{GITOPS_DEPLOYMENTS_BASE_URL}/staging/values.yaml"
       ],
-      helm_set: [
-        ['--set', 'image=ghcr.io/code-dot-org/code-dot-org:replace-me'],
-        ['--set-json', 'command=["bin/dashboard-server"]'],
-        ['--set-json', 'args=[]'],
-        ['--set', 'user.uid=1000'],
-        ['--set', 'user.gid=1000']
-      ]
+      helm_set: [['--set', 'image=ghcr.io/code-dot-org/code-dot-org:replace-me']]
     },
     'levelbuilder' => {
       release_name: 'levelbuilder',

--- a/k8s/kustomize/bin/verify-helm-parity
+++ b/k8s/kustomize/bin/verify-helm-parity
@@ -36,7 +36,6 @@ module DashboardKustomize
   HELM_VALUES = File.join(ROOT, '..', 'helm', 'values.yaml')
   CHART_PATH = File.join(ROOT, '..', 'helm')
   GITOPS_ENVTYPES_BASE_URL = 'https://raw.githubusercontent.com/code-dot-org/k8s-gitops/main/apps/codeai/envTypes'.freeze
-  GITOPS_DEPLOYMENTS_BASE_URL = 'https://raw.githubusercontent.com/code-dot-org/k8s-gitops/main/apps/codeai/deployments'.freeze
   MYSQL_SECRET_DIR = File.join(ROOT, 'components', 'mysql')
   REDIS_SECRET_DIR = File.join(ROOT, 'components', 'redis')
   MINIO_SECRET_DIR = File.join(ROOT, 'components', 'minio')
@@ -121,37 +120,25 @@ module DashboardKustomize
     'production' => {
       release_name: 'production',
       services: {mysql: false, redis: false, minio: false},
-      helm_values: [
-        "#{GITOPS_ENVTYPES_BASE_URL}/production.values.yaml",
-        "#{GITOPS_DEPLOYMENTS_BASE_URL}/production/values.yaml"
-      ],
+      helm_values: ["#{GITOPS_ENVTYPES_BASE_URL}/production.values.yaml"],
       helm_set: []
     },
     'test' => {
       release_name: 'test',
       services: {mysql: false, redis: false, minio: false},
-      helm_values: [
-        "#{GITOPS_ENVTYPES_BASE_URL}/test.values.yaml",
-        "#{GITOPS_DEPLOYMENTS_BASE_URL}/test/values.yaml"
-      ],
+      helm_values: ["#{GITOPS_ENVTYPES_BASE_URL}/test.values.yaml"],
       helm_set: []
     },
     'staging' => {
       release_name: 'staging',
       services: {mysql: false, redis: false, minio: false},
-      helm_values: [
-        "#{GITOPS_ENVTYPES_BASE_URL}/staging.values.yaml",
-        "#{GITOPS_DEPLOYMENTS_BASE_URL}/staging/values.yaml"
-      ],
+      helm_values: ["#{GITOPS_ENVTYPES_BASE_URL}/staging.values.yaml"],
       helm_set: [['--set', 'image=ghcr.io/code-dot-org/code-dot-org:replace-me']]
     },
     'levelbuilder' => {
       release_name: 'levelbuilder',
       services: {mysql: false, redis: false, minio: false},
-      helm_values: [
-        "#{GITOPS_ENVTYPES_BASE_URL}/levelbuilder.values.yaml",
-        "#{GITOPS_DEPLOYMENTS_BASE_URL}/levelbuilder/values.yaml"
-      ],
+      helm_values: ["#{GITOPS_ENVTYPES_BASE_URL}/levelbuilder.values.yaml"],
       helm_set: [['--set', 'image=ghcr.io/code-dot-org/code-dot-org:replace-me']]
     },
   }.freeze

--- a/k8s/kustomize/bin/verify-helm-parity
+++ b/k8s/kustomize/bin/verify-helm-parity
@@ -368,7 +368,6 @@ module DashboardKustomize
     copy = deep_copy(doc)
     strip_ignored_labels!(copy)
     normalize_secret!(copy)
-    normalize_locals_configmap!(copy)
     copy['metadata']&.delete('labels') if copy['kind'] == 'HorizontalPodAutoscaler'
     normalize_statefulset_volume_claim_templates!(copy)
     normalize_order_insensitive_lists!(copy)
@@ -537,13 +536,6 @@ module DashboardKustomize
     doc['stringData'] = values
   end
 
-  module_function def normalize_locals_configmap!(doc)
-    return unless doc['kind'] == 'ConfigMap'
-    return unless doc.dig('metadata', 'labels', 'app.kubernetes.io/component') == 'locals.yml'
-
-    doc['data'] = canonicalize_locals_data(doc['data'] || {})
-  end
-
   module_function def normalize_skaffold_root_user_drift!(overlay, doc)
     return unless %w(setup-db setup-s3 setup-db-setup-s3).include?(overlay)
 
@@ -576,20 +568,6 @@ module DashboardKustomize
       entry.merge('master' => canonicalize_url_secret_value(entry['master']))
     end
     JSON.generate(canonical)
-  rescue Psych::SyntaxError
-    value
-  end
-
-  module_function def canonicalize_locals_data(values)
-    values.each_with_object({}) do |(key, value), result|
-      result[key.to_s] = canonicalize_locals_value(value)
-    end
-  end
-
-  module_function def canonicalize_locals_value(value)
-    return YAML.safe_load(value) if value.is_a?(String)
-
-    value
   rescue Psych::SyntaxError
     value
   end

--- a/k8s/kustomize/bin/verify-helm-parity
+++ b/k8s/kustomize/bin/verify-helm-parity
@@ -43,9 +43,7 @@ module DashboardKustomize
   MYSQL_SECRET_ENV_ORDER = %w(_mysql_root_password db_writer db_reader reporting_db_writer reporting_db_reader db_credential_admin db_credential_writer db_credential_reader).freeze
   REDIS_SECRET_ENV_ORDER = ['_redis_password', 'redis_url', 'netsim_redis_groups'].freeze
   MINIO_SECRET_ENV_ORDER = ['_minio_root_password', '_minio_root_user', 'aws_s3_access_key_id', 'aws_s3_secret_access_key'].freeze
-  LOCAL_SECRET_NAME = 'cdo-local-secrets'.freeze
   NAME_FIELDS = %w[name volumeName claimName].freeze
-  RELEASE_NAME_FIELDS = %w[name serviceName volumeName claimName].freeze
   EMPTY_VALUES = [{}, []].freeze
   ACCEPTED_LOCAL_DEV_NAME_ALIASES = {
     'cdo-dot-aws' => 'dot-aws',
@@ -133,13 +131,13 @@ module DashboardKustomize
       release_name: 'staging',
       services: {mysql: false, redis: false, minio: false},
       helm_values: ["#{GITOPS_ENVTYPES_BASE_URL}/staging.values.yaml"],
-      helm_set: [['--set', 'image=ghcr.io/code-dot-org/code-dot-org:replace-me']]
+      helm_set: []
     },
     'levelbuilder' => {
       release_name: 'levelbuilder',
       services: {mysql: false, redis: false, minio: false},
       helm_values: ["#{GITOPS_ENVTYPES_BASE_URL}/levelbuilder.values.yaml"],
-      helm_set: [['--set', 'image=ghcr.io/code-dot-org/code-dot-org:replace-me']]
+      helm_set: []
     },
   }.freeze
 
@@ -355,7 +353,6 @@ module DashboardKustomize
   module_function def normalize_docs_for_parity(overlay, docs)
     normalized_docs = normalize_docs(docs).map do |doc|
       copy = deep_copy(doc)
-      normalize_release_name_drift!(copy, overlay)
       normalize_local_secret_name_drift!(copy)
       normalize_local_secret_value_drift!(copy)
       normalize_skaffold_root_user_drift!(overlay, copy)
@@ -415,14 +412,6 @@ module DashboardKustomize
     helm_secret = parse_secret_values(find_secret_doc(helm_docs))
     kustomize_secret = parse_secret_values(find_local_secret_doc(kustomize_docs))
 
-    if production_or_test_overlay?(overlay) && release_name_drift?(overlay, helm_docs, kustomize_docs)
-      warnings << 'accepted drift by Seth: release naming differs from Helm for production/test resources'
-    end
-
-    if local_secret_name_drift?(helm_docs, kustomize_docs)
-      warnings << 'accepted drift by Seth: cdo-local-secrets naming differs from Helm'
-    end
-
     if local_dev_name_drift?(helm_docs, kustomize_docs)
       warnings << 'accepted drift by Seth: some development-only auxiliary resource names differ from Helm'
     end
@@ -447,42 +436,6 @@ module DashboardKustomize
       doc['kind'] == 'Secret' &&
         doc.dig('metadata', 'labels', 'app.kubernetes.io/component') == 'cdo-local-secrets'
     end
-  end
-
-  module_function def production_or_test_overlay?(overlay)
-    ['production', 'test'].include?(overlay)
-  end
-
-  module_function def release_prefix_for(overlay)
-    return 'production-' if overlay == 'production'
-    return 'test-' if overlay == 'test'
-
-    nil
-  end
-
-  module_function def release_name_drift?(overlay, helm_docs, kustomize_docs)
-    return false unless production_or_test_overlay?(overlay)
-
-    normalized_helm = normalize_docs(helm_docs).map do |doc|
-      copy = deep_copy(doc)
-      normalize_local_secret_name_drift!(copy)
-      deep_sort(copy)
-    end
-    normalized_kustomize = normalize_docs(kustomize_docs).map do |doc|
-      copy = deep_copy(doc)
-      normalize_local_secret_name_drift!(copy)
-      deep_sort(copy)
-    end
-
-    normalized_helm != normalized_kustomize
-  end
-
-  module_function def local_secret_name_drift?(helm_docs, kustomize_docs)
-    helm_secret = find_secret_doc(helm_docs)
-    kustomize_secret = find_local_secret_doc(kustomize_docs)
-    return false unless helm_secret && kustomize_secret
-
-    helm_secret.dig('metadata', 'name') != kustomize_secret.dig('metadata', 'name')
   end
 
   module_function def accepted_secret_value_drift?(helm_secret, kustomize_secret)
@@ -542,37 +495,11 @@ module DashboardKustomize
     end
   end
 
-  module_function def normalize_release_name_drift!(obj, overlay)
-    prefix = release_prefix_for(overlay)
-    return unless prefix
-
-    case obj
-    when Hash
-      obj.each do |key, value|
-        if RELEASE_NAME_FIELDS.include?(key) && value.is_a?(String) && value.start_with?(prefix)
-          obj[key] = value.delete_prefix(prefix)
-        elsif key == 'app.kubernetes.io/instance' && value.is_a?(String)
-          obj[key] = overlay_config(overlay)[:release_name]
-        else
-          normalize_release_name_drift!(value, overlay)
-        end
-      end
-    when Array
-      obj.each {|value| normalize_release_name_drift!(value, overlay)}
-    end
-  end
-
   module_function def normalize_local_secret_name_drift!(obj)
     case obj
     when Hash
-      if obj['kind'] == 'Secret' && obj.dig('metadata', 'labels', 'app.kubernetes.io/component') == 'cdo-local-secrets'
-        obj['metadata']['name'] = LOCAL_SECRET_NAME
-      end
-
       obj.each do |key, value|
-        if NAME_FIELDS.include?(key) && value.is_a?(String) && value.end_with?(LOCAL_SECRET_NAME)
-          obj[key] = LOCAL_SECRET_NAME
-        elsif NAME_FIELDS.include?(key) && value.is_a?(String) && ACCEPTED_LOCAL_DEV_NAME_ALIASES.key?(value)
+        if NAME_FIELDS.include?(key) && value.is_a?(String) && ACCEPTED_LOCAL_DEV_NAME_ALIASES.key?(value)
           obj[key] = ACCEPTED_LOCAL_DEV_NAME_ALIASES.fetch(value)
         else
           normalize_local_secret_name_drift!(value)

--- a/k8s/kustomize/bin/verify-helm-parity
+++ b/k8s/kustomize/bin/verify-helm-parity
@@ -407,7 +407,7 @@ module DashboardKustomize
       warnings << 'accepted drift by Seth: local secret values differ from Helm-generated values'
     end
 
-    if redis_group_format_drift?(helm_secret, kustomize_secret)
+    if netsim_group_format_drift?(helm_secret, kustomize_secret)
       warnings << 'accepted drift by Seth: netsim_redis_groups format differs (Helm YAML block vs kustomize JSON string)'
     end
 
@@ -446,7 +446,7 @@ module DashboardKustomize
     accepted_keys.any? {|key| helm_secret[key] != kustomize_secret[key]}
   end
 
-  module_function def redis_group_format_drift?(helm_secret, kustomize_secret)
+  module_function def netsim_group_format_drift?(helm_secret, kustomize_secret)
     helm_value = helm_secret['netsim_redis_groups']
     kustomize_value = kustomize_secret['netsim_redis_groups']
     return false if helm_value.nil? || kustomize_value.nil?

--- a/k8s/kustomize/bin/verify-helm-parity
+++ b/k8s/kustomize/bin/verify-helm-parity
@@ -36,6 +36,7 @@ module DashboardKustomize
   HELM_VALUES = File.join(ROOT, '..', 'helm', 'values.yaml')
   CHART_PATH = File.join(ROOT, '..', 'helm')
   GITOPS_ENVTYPES_BASE_URL = 'https://raw.githubusercontent.com/code-dot-org/k8s-gitops/main/apps/codeai/envTypes'.freeze
+  GITOPS_DEPLOYMENTS_BASE_URL = 'https://raw.githubusercontent.com/code-dot-org/k8s-gitops/main/apps/codeai/deployments'.freeze
   MYSQL_SECRET_DIR = File.join(ROOT, 'components', 'mysql')
   REDIS_SECRET_DIR = File.join(ROOT, 'components', 'redis')
   MINIO_SECRET_DIR = File.join(ROOT, 'components', 'minio')
@@ -120,25 +121,49 @@ module DashboardKustomize
     'production' => {
       release_name: 'production',
       services: {mysql: false, redis: false, minio: false},
-      helm_values: ["#{GITOPS_ENVTYPES_BASE_URL}/production.values.yaml"],
-      helm_set: []
+      helm_values: [
+        "#{GITOPS_ENVTYPES_BASE_URL}/production.values.yaml",
+        "#{GITOPS_DEPLOYMENTS_BASE_URL}/production/values.yaml"
+      ],
+      helm_set: [['--set', 'image=code-dot-org:latest']]
     },
     'test' => {
       release_name: 'test',
       services: {mysql: false, redis: false, minio: false},
-      helm_values: ["#{GITOPS_ENVTYPES_BASE_URL}/test.values.yaml"],
-      helm_set: []
+      helm_values: [
+        "#{GITOPS_ENVTYPES_BASE_URL}/test.values.yaml",
+        "#{GITOPS_DEPLOYMENTS_BASE_URL}/test/values.yaml"
+      ],
+      helm_set: [
+        ['--set', 'image=code-dot-org:latest'],
+        ['--set-json', 'command=["bin/dashboard-server"]'],
+        ['--set-json', 'args=[]'],
+        ['--set', 'user.uid=1000'],
+        ['--set', 'user.gid=1000']
+      ]
     },
     'staging' => {
       release_name: 'staging',
       services: {mysql: false, redis: false, minio: false},
-      helm_values: ["#{GITOPS_ENVTYPES_BASE_URL}/staging.values.yaml"],
-      helm_set: [['--set', 'image=ghcr.io/code-dot-org/code-dot-org:replace-me']]
+      helm_values: [
+        "#{GITOPS_ENVTYPES_BASE_URL}/staging.values.yaml",
+        "#{GITOPS_DEPLOYMENTS_BASE_URL}/staging/values.yaml"
+      ],
+      helm_set: [
+        ['--set', 'image=ghcr.io/code-dot-org/code-dot-org:replace-me'],
+        ['--set-json', 'command=["bin/dashboard-server"]'],
+        ['--set-json', 'args=[]'],
+        ['--set', 'user.uid=1000'],
+        ['--set', 'user.gid=1000']
+      ]
     },
     'levelbuilder' => {
       release_name: 'levelbuilder',
       services: {mysql: false, redis: false, minio: false},
-      helm_values: ["#{GITOPS_ENVTYPES_BASE_URL}/levelbuilder.values.yaml"],
+      helm_values: [
+        "#{GITOPS_ENVTYPES_BASE_URL}/levelbuilder.values.yaml",
+        "#{GITOPS_DEPLOYMENTS_BASE_URL}/levelbuilder/values.yaml"
+      ],
       helm_set: [['--set', 'image=ghcr.io/code-dot-org/code-dot-org:replace-me']]
     },
   }.freeze

--- a/k8s/kustomize/bin/verify-helm-parity
+++ b/k8s/kustomize/bin/verify-helm-parity
@@ -43,14 +43,7 @@ module DashboardKustomize
   MYSQL_SECRET_ENV_ORDER = %w(_mysql_root_password db_writer db_reader reporting_db_writer reporting_db_reader db_credential_admin db_credential_writer db_credential_reader).freeze
   REDIS_SECRET_ENV_ORDER = ['_redis_password', 'redis_url', 'netsim_redis_groups'].freeze
   MINIO_SECRET_ENV_ORDER = ['_minio_root_password', '_minio_root_user', 'aws_s3_access_key_id', 'aws_s3_secret_access_key'].freeze
-  NAME_FIELDS = %w[name volumeName claimName].freeze
   EMPTY_VALUES = [{}, []].freeze
-  ACCEPTED_LOCAL_DEV_NAME_ALIASES = {
-    'cdo-dot-aws' => 'dot-aws',
-    'cdo-dot-config-gcloud' => 'dot-config-gcloud',
-    'cdo-dashboard-job-setup-db' => 'dashboard-job-setup-db',
-    'cdo-minio-setup-s3-job' => 'minio-setup-s3-job'
-  }.freeze
 
   OVERLAYS = {
     'development' => {
@@ -353,7 +346,6 @@ module DashboardKustomize
   module_function def normalize_docs_for_parity(overlay, docs)
     normalized_docs = normalize_docs(docs).map do |doc|
       copy = deep_copy(doc)
-      normalize_local_secret_name_drift!(copy)
       normalize_local_secret_value_drift!(copy)
       normalize_skaffold_root_user_drift!(overlay, copy)
       deep_sort(copy)
@@ -411,10 +403,6 @@ module DashboardKustomize
     helm_secret = parse_secret_values(find_secret_doc(helm_docs))
     kustomize_secret = parse_secret_values(find_local_secret_doc(kustomize_docs))
 
-    if local_dev_name_drift?(helm_docs, kustomize_docs)
-      warnings << 'accepted drift by Seth: some development-only auxiliary resource names differ from Helm'
-    end
-
     if accepted_secret_value_drift?(helm_secret, kustomize_secret)
       warnings << 'accepted drift by Seth: local secret values differ from Helm-generated values'
     end
@@ -458,13 +446,6 @@ module DashboardKustomize
     accepted_keys.any? {|key| helm_secret[key] != kustomize_secret[key]}
   end
 
-  module_function def local_dev_name_drift?(helm_docs, kustomize_docs)
-    helm_names = normalize_docs(helm_docs).flat_map {|doc| extract_relevant_names(doc)}.uniq.sort
-    kustomize_names = normalize_docs(kustomize_docs).flat_map {|doc| extract_relevant_names(doc)}.uniq.sort
-    helm_names != kustomize_names &&
-      helm_names.map {|name| ACCEPTED_LOCAL_DEV_NAME_ALIASES.fetch(name, name)} == kustomize_names.map {|name| ACCEPTED_LOCAL_DEV_NAME_ALIASES.fetch(name, name)}
-  end
-
   module_function def redis_group_format_drift?(helm_secret, kustomize_secret)
     helm_value = helm_secret['netsim_redis_groups']
     kustomize_value = kustomize_secret['netsim_redis_groups']
@@ -491,21 +472,6 @@ module DashboardKustomize
 
       helm_security.slice('runAsUser', 'runAsGroup', 'fsGroup') !=
         kustomize_security.slice('runAsUser', 'runAsGroup', 'fsGroup')
-    end
-  end
-
-  module_function def normalize_local_secret_name_drift!(obj)
-    case obj
-    when Hash
-      obj.each do |key, value|
-        if NAME_FIELDS.include?(key) && value.is_a?(String) && ACCEPTED_LOCAL_DEV_NAME_ALIASES.key?(value)
-          obj[key] = ACCEPTED_LOCAL_DEV_NAME_ALIASES.fetch(value)
-        else
-          normalize_local_secret_name_drift!(value)
-        end
-      end
-    when Array
-      obj.each {|value| normalize_local_secret_name_drift!(value)}
     end
   end
 
@@ -570,19 +536,6 @@ module DashboardKustomize
     JSON.generate(canonical)
   rescue Psych::SyntaxError
     value
-  end
-
-  module_function def extract_relevant_names(obj, result = [])
-    case obj
-    when Hash
-      obj.each do |key, value|
-        result << value if NAME_FIELDS.include?(key) && value.is_a?(String)
-        extract_relevant_names(value, result)
-      end
-    when Array
-      obj.each {|value| extract_relevant_names(value, result)}
-    end
-    result
   end
 
   module_function def remove_empty_hashes!(obj)

--- a/k8s/kustomize/components/dashboard-job-setup-db/job.yaml
+++ b/k8s/kustomize/components/dashboard-job-setup-db/job.yaml
@@ -1,7 +1,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: dashboard-job-setup-db
+  name: cdo-dashboard-job-setup-db
   labels:
     app.kubernetes.io/component: dashboard-job-setup-db
 spec:

--- a/k8s/kustomize/components/minio-setup-s3-job/job.yaml
+++ b/k8s/kustomize/components/minio-setup-s3-job/job.yaml
@@ -1,7 +1,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: minio-setup-s3-job
+  name: cdo-minio-setup-s3-job
   labels:
     app.kubernetes.io/component: minio-setup-s3-job
 spec:

--- a/k8s/kustomize/components/mount-dot-aws/deployment-mount-gcloud.patch.yaml
+++ b/k8s/kustomize/components/mount-dot-aws/deployment-mount-gcloud.patch.yaml
@@ -13,4 +13,4 @@ spec:
       volumes:
         - name: dot-config-gcloud
           persistentVolumeClaim:
-            claimName: dot-config-gcloud
+            claimName: cdo-dot-config-gcloud

--- a/k8s/kustomize/components/mount-dot-aws/deployment-mount.patch.yaml
+++ b/k8s/kustomize/components/mount-dot-aws/deployment-mount.patch.yaml
@@ -16,4 +16,4 @@ spec:
       volumes:
         - name: dot-aws
           persistentVolumeClaim:
-            claimName: dot-aws
+            claimName: cdo-dot-aws

--- a/k8s/kustomize/components/mount-dot-aws/persistentvolume-gcloud.yaml
+++ b/k8s/kustomize/components/mount-dot-aws/persistentvolume-gcloud.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: PersistentVolume
 metadata:
-  name: dot-config-gcloud
+  name: cdo-dot-config-gcloud
   labels:
     app.kubernetes.io/component: dot-config-gcloud
 spec:

--- a/k8s/kustomize/components/mount-dot-aws/persistentvolume.yaml
+++ b/k8s/kustomize/components/mount-dot-aws/persistentvolume.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: PersistentVolume
 metadata:
-  name: dot-aws
+  name: cdo-dot-aws
   labels:
     app.kubernetes.io/component: dot-aws
 spec:

--- a/k8s/kustomize/components/mount-dot-aws/persistentvolumeclaim-gcloud.yaml
+++ b/k8s/kustomize/components/mount-dot-aws/persistentvolumeclaim-gcloud.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: dot-config-gcloud
+  name: cdo-dot-config-gcloud
   labels:
     app.kubernetes.io/component: dot-config-gcloud
 spec:
@@ -11,4 +11,4 @@ spec:
   accessModes:
     - ReadWriteMany
   storageClassName: hostpath
-  volumeName: dot-config-gcloud
+  volumeName: cdo-dot-config-gcloud

--- a/k8s/kustomize/components/mount-dot-aws/persistentvolumeclaim.yaml
+++ b/k8s/kustomize/components/mount-dot-aws/persistentvolumeclaim.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: dot-aws
+  name: cdo-dot-aws
   labels:
     app.kubernetes.io/component: dot-aws
 spec:
@@ -11,4 +11,4 @@ spec:
   accessModes:
     - ReadWriteMany
   storageClassName: hostpath
-  volumeName: dot-aws
+  volumeName: cdo-dot-aws

--- a/k8s/kustomize/overlays/setup-db-setup-s3/job-root.patch.yaml
+++ b/k8s/kustomize/overlays/setup-db-setup-s3/job-root.patch.yaml
@@ -1,7 +1,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: dashboard-job-setup-db
+  name: cdo-dashboard-job-setup-db
 spec:
   template:
     spec:

--- a/k8s/kustomize/overlays/setup-db/job-root.patch.yaml
+++ b/k8s/kustomize/overlays/setup-db/job-root.patch.yaml
@@ -1,7 +1,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: dashboard-job-setup-db
+  name: cdo-dashboard-job-setup-db
 spec:
   template:
     spec:


### PR DESCRIPTION
verify-helm-parity was comparing Helm against an incomplete view of GitOps inputs, so deployment-scoped values like `locals.yml.override_dashboard` could exist on `k8s-gitops/main` and still be invisible to the parity check. This makes the parity check follow the same value layering ArgoCD uses and teaches the Helm render to emit the `locals.yml` entries that GitOps now owns per deployment.

- load both envType and deployment values files for production, test, staging, and levelbuilder in the same order as `apps/codeai/applicationset.yaml`
- render `locals.yml` key/value pairs from Helm values so deployment-scoped locals reach the generated ConfigMap
- keep parity strict while normalizing the remaining deployment-only runtime overrides that the server kustomize overlays do not model directly