### PR TITLE
Update send lesson and level navigation

### DIFF
--- a/dashboard/lib/tasks/seed.rake
+++ b/dashboard/lib/tasks/seed.rake
@@ -99,14 +99,9 @@ namespace :seed do
     allthettsthings
     artist
     coursea-2017
-    courseb-2017
     coursec-2017
-    coursed-2017
-    coursee-2017
-    coursef-2017
     coursea-2019
     coursec-2019
-    coursee-2019
     csd3-2023
     interactive-games-animations-2023
     focus-on-creativity3-2023
@@ -325,14 +320,9 @@ namespace :seed do
        allthettsthings
        artist
        coursea-2017
-       courseb-2017
        coursec-2017
-       coursed-2017
-       coursee-2017
-       coursef-2017
        coursea-2019
        coursec-2019
-       coursee-2019
        csp-ap
        interactive-games-animations-2023
        interactive-games-animations-2024

--- a/dashboard/lib/tasks/seed.rake
+++ b/dashboard/lib/tasks/seed.rake
@@ -99,8 +99,10 @@ namespace :seed do
     allthettsthings
     artist
     coursea-2017
+    courseb-2017
     coursec-2017
     coursea-2019
+    courseb-2019
     coursec-2019
     csd3-2023
     interactive-games-animations-2023
@@ -320,8 +322,10 @@ namespace :seed do
        allthettsthings
        artist
        coursea-2017
+       courseb-2017
        coursec-2017
        coursea-2019
+       courseb-2019
        coursec-2019
        csp-ap
        interactive-games-animations-2023

--- a/dashboard/lib/tasks/seed.rake
+++ b/dashboard/lib/tasks/seed.rake
@@ -102,7 +102,6 @@ namespace :seed do
     courseb-2017
     coursec-2017
     coursea-2019
-    courseb-2019
     coursec-2019
     csd3-2023
     interactive-games-animations-2023
@@ -325,7 +324,6 @@ namespace :seed do
        courseb-2017
        coursec-2017
        coursea-2019
-       courseb-2019
        coursec-2019
        csp-ap
        interactive-games-animations-2023

--- a/dashboard/test/ui/config/scripts_json/ui-test-csf.script_json
+++ b/dashboard/test/ui/config/scripts_json/ui-test-csf.script_json
@@ -9,7 +9,7 @@
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2026-03-24 16:44:24 UTC",
+    "serialized_at": "2026-03-25 02:51:33 UTC",
     "hide_within_course": false,
     "published_state": "in_development",
     "instruction_type": null,
@@ -96,6 +96,27 @@
       "level_keys": [
         "K-1 Artist1 1"
       ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "activity_section_position": 2,
+      "assessment": false,
+      "properties": {
+      },
+      "bonus": false,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "contained_single_multi"
+        ],
+        "lesson.key": "lesson-1",
+        "lesson_group.key": "",
+        "script.name": "ui-test-csf",
+        "activity_section.key": "2dda9127-3cc5-4874-b697-59af6f22da1e"
+      },
+      "level_keys": [
+        "contained_single_multi"
+      ]
     }
   ],
   "levels_script_levels": [
@@ -104,6 +125,18 @@
         "level.key": "K-1 Artist1 1",
         "script_level.level_keys": [
           "K-1 Artist1 1"
+        ],
+        "lesson.key": "lesson-1",
+        "lesson_group.key": "",
+        "script.name": "ui-test-csf",
+        "activity_section.key": "2dda9127-3cc5-4874-b697-59af6f22da1e"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "contained_single_multi",
+        "script_level.level_keys": [
+          "contained_single_multi"
         ],
         "lesson.key": "lesson-1",
         "lesson_group.key": "",

--- a/dashboard/test/ui/features/teacher_tools/level_navigation.feature
+++ b/dashboard/test/ui/features/teacher_tools/level_navigation.feature
@@ -2,13 +2,13 @@ Feature: Continue button on levels
 
 Scenario: External Video Level
   Given I am a teacher
-  Given I am on "http://studio.code.org/courses/coursec-2019/units/1/lessons/14/levels/1"
+  Given I am on "http://studio.code.org/courses/allthethingscourse/units/1/lessons/55/levels/1"
   And I wait until element "#teacher-panel-container" is visible
   And I dismiss the teacher panel
   And I wait to see ".video-download"
   And I wait to see ".submitButton"
   Then I click ".submitButton" to load a new page
-  Then I wait until I am on "http://studio.code.org/courses/coursec-2019/units/1/lessons/15/levels/1"
+  Then I wait until I am on "http://studio.code.org/courses/allthethingscourse/units/1"
 
 Scenario: External Markdown Level
   Given I am on "http://studio.code.org/courses/allthethingscourse/units/1/lessons/21/levels/1"

--- a/dashboard/test/ui/features/teacher_tools/level_types/multiple_choice_contained_levels.feature
+++ b/dashboard/test/ui/features/teacher_tools/level_types/multiple_choice_contained_levels.feature
@@ -46,7 +46,7 @@ Scenario: Unauthorized Teacher on Maze with multiple choice contained level
   When I open my eyes to test "maze multi contained level"
   Given I create a teacher-associated student named "Sally"
   And I sign in as "Teacher_Sally" and go home
-  Then I am on "http://studio.code.org/courses/coursee-2019/units/1/lessons/4/levels/2"
+  Then I am on "http://studio.code.org/courses/allthethingscourse/units/1/lessons/41/levels/1"
   And I wait for the lab page to fully load
   Then I see no difference for "initial load"
   Then I press "unchecked_0"

--- a/dashboard/test/ui/features/teacher_tools/level_types/multiple_choice_contained_levels.feature
+++ b/dashboard/test/ui/features/teacher_tools/level_types/multiple_choice_contained_levels.feature
@@ -42,11 +42,11 @@ Scenario: Gamelab with multiple choice contained level
   Then I close my eyes
 
 @eyes
-Scenario: Unauthorized Teacher on Maze with multiple choice contained level
+Scenario: Unauthorized Teacher on CSF Maze with multiple choice contained level
   When I open my eyes to test "maze multi contained level"
   Given I create a teacher-associated student named "Sally"
   And I sign in as "Teacher_Sally" and go home
-  Then I am on "http://studio.code.org/courses/allthethingscourse/units/1/lessons/41/levels/1"
+  Then I am on "http://studio.code.org/courses/ui-test-csf/units/1/lessons/1/levels/2"
   And I wait for the lab page to fully load
   Then I see no difference for "initial load"
   Then I press "unchecked_0"

--- a/dashboard/test/ui/features/teacher_tools/send_lesson.feature
+++ b/dashboard/test/ui/features/teacher_tools/send_lesson.feature
@@ -4,7 +4,7 @@ Feature: Send Lesson
 @eyes
 Scenario: Send lesson dialog renders properly
   Given I open my eyes to test "send lesson dialog"
-  When I am on "http://studio.code.org/courses/csp-2025/units/3"
+  When I am on "http://studio.code.org/courses/allthethingscourse/units/1"
   Then I see no difference for "unit overview"
   When I open the send lesson dialog for lesson 4
   And I wait until element "span:contains(Google)" is visible
@@ -13,7 +13,7 @@ Scenario: Send lesson dialog renders properly
 
 @no_mobile
 Scenario: Send lesson dialog opens and closes
-  Given I am on "http://studio.code.org/courses/csp-2025/units/3"
+  Given I am on "http://studio.code.org/courses/allthethingscourse/units/1"
   When I open the send lesson dialog for lesson 4
   Then I wait until element ".modal" is visible
   And I wait until element "span:contains(Google)" is visible
@@ -22,7 +22,7 @@ Scenario: Send lesson dialog opens and closes
 
 @no_mobile
 Scenario: Send lesson dialog copy link button works
-  Given I am on "http://studio.code.org/courses/coursec-2019/units/1"
+  Given I am on "http://studio.code.org/courses/allthethingscourse/units/1"
   When I open the send lesson dialog for lesson 2
   Then I wait until element ".modal" is visible
   And I wait until element "#uitest-copy-button" is visible


### PR DESCRIPTION
depends on
- https://github.com/code-dot-org/code-dot-org/pull/71621

as part of [partitioned curriculum data proposal](https://docs.google.com/document/d/1iiJXtPODakjuZ7-2yKJ941H56dcyUmUFtWa7zGgqKdw/edit?tab=t.0#heading=h.qx67631q1z2d), this PR moves some more teacher tools UI tests off of production units and onto the allthethings course.

## Testing story
- expect some diffs during the DTT for the "send lesson dialog" eyes test since it will be pointing at a different unit
- otherwise, ui test updates are covered adequately by drone
