### PR TITLE
Add ai_rubric_s3_config edit field to rubric editor

### DIFF
--- a/apps/src/levelbuilder/rubrics/RubricEditor.jsx
+++ b/apps/src/levelbuilder/rubrics/RubricEditor.jsx
@@ -2,6 +2,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 
 import Button from '@cdo/apps/legacySharedComponents/Button';
+import HelpTip from '@cdo/apps/sharedComponents/HelpTip';
 
 import LearningGoalItem from './LearningGoalItem';
 import {styles} from './rubricHelper';
@@ -32,6 +33,13 @@ export default function RubricEditor({
       <div style={styles.containerStyle}>
         <label htmlFor="ai_rubric_s3_config">
           AI Rubric S3 config directory name
+          <HelpTip>
+            <p>
+              An engineer must add the appropriate AI rubric configuration to S3
+              and provide you with this directory name before AI can be enabled
+              for any learning goals on this level.
+            </p>
+          </HelpTip>
         </label>
         <input
           id="ai_rubric_s3_config"

--- a/apps/src/levelbuilder/rubrics/RubricEditor.jsx
+++ b/apps/src/levelbuilder/rubrics/RubricEditor.jsx
@@ -4,12 +4,15 @@ import React from 'react';
 import Button from '@cdo/apps/legacySharedComponents/Button';
 
 import LearningGoalItem from './LearningGoalItem';
+import {styles} from './rubricHelper';
 
 export default function RubricEditor({
   addNewConcept,
   deleteLearningGoal,
   learningGoalList,
   updateLearningGoal,
+  aiRubricS3ConfigValue,
+  onAiRubricS3ConfigChange,
 }) {
   const renderLearningGoalItems = learningGoalList?.map(goal => {
     if (!goal._destroy) {
@@ -26,6 +29,18 @@ export default function RubricEditor({
 
   return (
     <div>
+      <div style={styles.containerStyle}>
+        <label htmlFor="ai_rubric_s3_config">
+          AI Rubric S3 config directory name
+        </label>
+        <input
+          id="ai_rubric_s3_config"
+          type="text"
+          value={aiRubricS3ConfigValue || ''}
+          onChange={e => onAiRubricS3ConfigChange(e.target.value)}
+          placeholder="e.g. allthethings-L48"
+        />
+      </div>
       {renderLearningGoalItems}
       <Button
         color={Button.ButtonColor.gray}
@@ -45,4 +60,6 @@ RubricEditor.propTypes = {
   deleteLearningGoal: PropTypes.func,
   addNewConcept: PropTypes.func,
   updateLearningGoal: PropTypes.func,
+  aiRubricS3ConfigValue: PropTypes.string,
+  onAiRubricS3ConfigChange: PropTypes.func,
 };

--- a/apps/src/levelbuilder/rubrics/RubricsContainer.jsx
+++ b/apps/src/levelbuilder/rubrics/RubricsContainer.jsx
@@ -14,9 +14,14 @@ export default function RubricsContainer({
   submittableLevels,
   rubric,
   lessonId,
+  aiRubricS3Config: initialAiRubricS3Config,
 }) {
   const [learningGoalList, setLearningGoalList] = useState(
     !!rubric ? rubric.learningGoals : initialLearningGoal
+  );
+
+  const [aiRubricS3Config, setAiRubricS3Config] = useState(
+    initialAiRubricS3Config || {}
   );
 
   const [saveNotificationText, setSaveNotificationText] = useState('');
@@ -147,7 +152,8 @@ export default function RubricsContainer({
       learningGoalList,
       setLearningGoalList,
       selectedLevelForAssessment,
-      lessonId
+      lessonId,
+      aiRubricS3Config
     );
   };
 
@@ -163,6 +169,23 @@ export default function RubricsContainer({
 
   const handleDropdownChange = event => {
     setSelectedLevelForAssessment(event.target.value);
+  };
+
+  const getSelectedLevelName = () => {
+    const levelId = Number(selectedLevelForAssessment);
+    return submittableLevels.find(l => l.id === levelId)?.name || '';
+  };
+
+  const getAiRubricS3ConfigValue = () => {
+    const levelName = getSelectedLevelName();
+    return levelName ? aiRubricS3Config[levelName] || '' : '';
+  };
+
+  const handleAiRubricS3ConfigChange = newValue => {
+    const levelName = getSelectedLevelName();
+    if (levelName) {
+      setAiRubricS3Config(prev => ({...prev, [levelName]: newValue}));
+    }
   };
 
   const pageHeader = !!rubric ? 'Modify your rubric' : 'Create your rubric';
@@ -207,6 +230,8 @@ export default function RubricsContainer({
             addNewConcept={addNewConceptHandler}
             deleteLearningGoal={deleteLearningGoal}
             updateLearningGoal={updateLearningGoal}
+            aiRubricS3ConfigValue={getAiRubricS3ConfigValue()}
+            onAiRubricS3ConfigChange={handleAiRubricS3ConfigChange}
           />
           <div style={styles.bottomRow}>
             <Button
@@ -252,6 +277,7 @@ RubricsContainer.propTypes = {
   ),
   rubric: PropTypes.object,
   lessonId: PropTypes.number,
+  aiRubricS3Config: PropTypes.object,
 };
 
 const initialLearningGoal = [

--- a/apps/src/levelbuilder/rubrics/rubricHelper.js
+++ b/apps/src/levelbuilder/rubrics/rubricHelper.js
@@ -12,7 +12,8 @@ export async function saveRubricToTable(
   learningGoalList,
   setLearningGoalList,
   selectedLevelForAssessment,
-  lessonId
+  lessonId,
+  aiRubricS3Config
 ) {
   setSaveNotificationText(SAVING_TEXT);
   const dataUrl = !!rubric ? `/rubrics/${rubric.id}` : RUBRIC_PATH;
@@ -31,6 +32,7 @@ export async function saveRubricToTable(
     levelId: selectedLevelForAssessment,
     lessonId: lessonId,
     learningGoalsAttributes: learningGoalListAsData,
+    aiRubricS3Config: aiRubricS3Config,
   };
 
   try {

--- a/apps/src/sites/studio/pages/rubrics/edit.js
+++ b/apps/src/sites/studio/pages/rubrics/edit.js
@@ -7,7 +7,7 @@ import getScriptData from '@cdo/apps/util/getScriptData';
 $(document).ready(() => {
   const rubric = getScriptData('rubricData');
   const lessonData = getScriptData('lessonData');
-  const {unitName, lessonNumber, levels} = lessonData;
+  const {unitName, lessonNumber, levels, aiRubricS3Config} = lessonData;
   const submittableLevels = levels.filter(level => level.isSubmittable);
 
   createReactRoot(
@@ -16,6 +16,7 @@ $(document).ready(() => {
       lessonNumber={lessonNumber}
       submittableLevels={submittableLevels}
       rubric={rubric}
+      aiRubricS3Config={aiRubricS3Config}
     />,
     document.getElementById('form')
   );

--- a/apps/src/sites/studio/pages/rubrics/new.js
+++ b/apps/src/sites/studio/pages/rubrics/new.js
@@ -6,7 +6,7 @@ import getScriptData from '@cdo/apps/util/getScriptData';
 
 $(document).ready(() => {
   const lessonData = getScriptData('lessonData');
-  const {unitName, lessonNumber, levels} = lessonData;
+  const {unitName, lessonNumber, levels, aiRubricS3Config} = lessonData;
   const lessonId = lessonData.id;
   const submittableLevels = levels.filter(level => level.isSubmittable);
 
@@ -16,6 +16,7 @@ $(document).ready(() => {
       lessonNumber={lessonNumber}
       submittableLevels={submittableLevels}
       lessonId={lessonId}
+      aiRubricS3Config={aiRubricS3Config}
     />,
     document.getElementById('form')
   );

--- a/apps/test/unit/levelbuilder/rubrics/RubricEditorTest.js
+++ b/apps/test/unit/levelbuilder/rubrics/RubricEditorTest.js
@@ -13,11 +13,14 @@ describe('RubricEditorTest ', () => {
     {id: 2, learningGoal: 'Goal 2', aiEnabled: false},
     {id: 3, learningGoal: 'Goal 3', aiEnabled: true},
   ];
+  const onAiRubricS3ConfigChangeSpy = jest.fn();
   const defaultProps = {
     learningGoalList: sampleLearningGoalList,
     addNewConcept: addNewConceptSpy,
     deleteItem: () => {},
     updateLearningGoal: () => {},
+    aiRubricS3ConfigValue: 'allthethings-L48',
+    onAiRubricS3ConfigChange: onAiRubricS3ConfigChangeSpy,
   };
 
   beforeEach(() => {
@@ -46,5 +49,26 @@ describe('RubricEditorTest ', () => {
     expect(addButton).toHaveLength(1);
     addButton.simulate('click');
     expect(addNewConceptSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders the AI Rubric S3 config text field with prepopulated value', () => {
+    const input = wrapper.find('input#ai_rubric_s3_config');
+    expect(input).toHaveLength(1);
+    expect(input.prop('value')).toBe('allthethings-L48');
+  });
+
+  it('calls onAiRubricS3ConfigChange when the S3 config field is edited', () => {
+    const input = wrapper.find('input#ai_rubric_s3_config');
+    input.simulate('change', {target: {value: 'csd3-2023-L11'}});
+    expect(onAiRubricS3ConfigChangeSpy).toHaveBeenCalledWith('csd3-2023-L11');
+  });
+
+  it('renders the AI Rubric S3 config text field empty when no value is provided', () => {
+    const emptyWrapper = shallow(
+      <RubricEditor {...defaultProps} aiRubricS3ConfigValue={undefined} />
+    );
+    const input = emptyWrapper.find('input#ai_rubric_s3_config');
+    expect(input).toHaveLength(1);
+    expect(input.prop('value')).toBe('');
   });
 });

--- a/dashboard/app/controllers/rubrics_controller.rb
+++ b/dashboard/app/controllers/rubrics_controller.rb
@@ -23,6 +23,7 @@ class RubricsController < ApplicationController
     @rubric = Rubric.new(rubric_params)
     @lesson = @rubric.lesson
     if @rubric.save
+      update_ai_rubric_s3_config(@lesson.script)
       @rubric.lesson.script.write_script_json
       render json: {redirectUrl: edit_rubric_path(@rubric.id), rubricId: @rubric.id}
     else
@@ -36,6 +37,7 @@ class RubricsController < ApplicationController
     @rubric = Rubric.find(params[:id])
     @lesson = @rubric.lesson
     if @rubric.update(rubric_params)
+      update_ai_rubric_s3_config(@lesson.script)
       @rubric.lesson.script.write_script_json
       render json: @rubric.summarize_for_rubric_edit
     else
@@ -345,6 +347,14 @@ class RubricsController < ApplicationController
   def get_ai_rubrics_tour_seen
     return head :unauthorized unless current_user&.teacher?
     render json: {seen: current_user.ai_rubrics_tour_seen}
+  end
+
+  private def update_ai_rubric_s3_config(unit)
+    raw = params.transform_keys(&:underscore)[:ai_rubric_s3_config]
+    return if raw.blank?
+    config = raw.is_a?(String) ? JSON.parse(raw) : raw.to_unsafe_h
+    unit.ai_rubric_s3_config = config
+    unit.save!
   end
 
   private def rubric_params

--- a/dashboard/app/models/lesson.rb
+++ b/dashboard/app/models/lesson.rb
@@ -611,7 +611,8 @@ class Lesson < ApplicationRecord
       unitName: script.title_for_display,
       lessonNumber: relative_position,
       lessonName: name,
-      levels: level_summary
+      levels: level_summary,
+      aiRubricS3Config: script.ai_rubric_s3_config || {}
     }
   end
 


### PR DESCRIPTION
* This PR is part of a larger effort to make UI tests stop depending on production courses. For background, see https://github.com/code-dot-org/code-dot-org/pull/71016. This PR completes the following step from the future work listed there:
> Step 1: s3 config editable via levelbuilder
> * add ability to edit ai_rubric_s3_config via the rubric edit page on levelbuilder


Done in this PR: Pipe the unit's ai_rubric_s3_config through to the rubric edit page so curriculum authors can specify the S3 config directory name per level directly from the rubric editor. The value is persisted back to the unit when the rubric is saved. A tooltip explains where to find the value and how it fits into the workflow of enabling AI evaluation.

<img width="1271" height="751" alt="Screenshot 2026-03-25 at 10 59 32 AM" src="https://github.com/user-attachments/assets/d71fdf4d-2c26-4686-af92-8f0776924785" />

## AI Assistance
- I told Claude to use an text field (rather than a dropdown) for the new input field, to write unit tests, and to add a tooltip
- Claude wrote the resulting code, which I reviewed without modification

## Testing story

- new unit tests verify state changes within the rubric editor
- I manually verified locally:
  - rubric editor shows correct initial value when editing rubric on allthethings unit
  - changing the value correctly saves the result to the DB and filesystem (without validation, which comes in the next step described in #71016)
- while we are working through that list of next steps, we still have a UI test calling `AiRubricConfig.validate_ai_config` directly to verify during DTT that no values of unit.ai_rubric_s3_config are getting dropped from units. (in the future this will be validated during the seed step on staging instead)