### PR TITLE
Web Lab 2: disable clear chat while awaiting accept/reject decision

### DIFF
--- a/apps/src/aichat/views/aiChatHeaderButtons/ClearChatButton.tsx
+++ b/apps/src/aichat/views/aiChatHeaderButtons/ClearChatButton.tsx
@@ -14,11 +14,22 @@ const ClearChatButton: React.FunctionComponent = () => {
   const selectedTab = useAppSelector(
     state => state.aichat.chatWorkspaceSelectedTab
   );
+  const isAiTutorVersion = useAppSelector(
+    state => state.lab2Project.viewingAiTutorVersion
+  );
+  const aiTutorVersionFiles = useAppSelector(
+    state => state.weblab2?.aiTutorVersionFiles
+  );
+  const isAwaitingAcceptRejectDecision =
+    !!isAiTutorVersion && !!aiTutorVersionFiles?.length;
 
-  // Disable clearing chat when viewing student chat as a teacher
+  // Disable clearing chat when viewing student chat as a teacher,
+  // or while waiting for the user to accept/reject AI Tutor code changes.
   const isDisabled = useMemo(
-    () => selectedTab === WorkspaceTeacherViewTab.STUDENT_CHAT_HISTORY,
-    [selectedTab]
+    () =>
+      selectedTab === WorkspaceTeacherViewTab.STUDENT_CHAT_HISTORY ||
+      isAwaitingAcceptRejectDecision,
+    [selectedTab, isAwaitingAcceptRejectDecision]
   );
 
   const onClear = useCallback(() => {


### PR DESCRIPTION
Disallows clearing the AI Tutor chat when awaiting the user to accept/reject changes from AI Tutor. This prevents a bug where you can be stuck in the accept/reject state if you clear the chat.

I considered adding a tooltip here describing why the clear chat button is disabled, but our button with tooltip component doesn't appear to support a tooltip when disabled, and I wasn't sure what the accessibility best practice would be here even if we could. More discussion [here](https://codedotorg.slack.com/archives/C09EHQE4DGD/p1774394714133699).

I also thought about whether we could centralize the "awaiting accept/reject" check into a selector, but that was a little complicated because our ChatMessage component (which uses the same logic) does this via a combination of props and internal redux selector. Wondering if we should pull the weblab2-specific redux out of ChatMessage longer term?

https://github.com/code-dot-org/code-dot-org/blob/a18201fb07fc1ccc5312d51be03cadeeaef7a0fe/apps/src/aiComponentLibrary/chatMessage/ChatMessage.tsx#L58-L68

## Links

- Jira: https://codedotorg.atlassian.net/browse/AFL-522

## Testing story

Tested manually that the clear chat button was disabled until I accepted/rejected changes proposed by AI Tutor.

