### PR TITLE
AI Chat: speech to text analytics

### DIFF
--- a/apps/src/aiComponentLibrary/userMessageEditor/UserMessageEditor.tsx
+++ b/apps/src/aiComponentLibrary/userMessageEditor/UserMessageEditor.tsx
@@ -99,16 +99,13 @@ const UserMessageEditor = React.forwardRef<
     const [speechToTextCount, setSpeechToTextCount] = useState(0);
     const [clearedMessageCount, setClearedMessageCount] = useState(0);
     /** True after the field becomes empty following STT use, until the next successful transcription. */
-    const [
-      dictationClearedSinceLastTranscription,
-      setDictationClearedSinceLastTranscription,
-    ] = useState(false);
+    const [lastDictationCleared, setLastDictationCleared] = useState(false);
 
     useEffect(() => {
       // Track how many times the message was cleared after using speech to text.
       if (speechToTextCount > 0 && !userMessage) {
         setClearedMessageCount(c => c + 1);
-        setDictationClearedSinceLastTranscription(true);
+        setLastDictationCleared(true);
       }
     }, [speechToTextCount, userMessage]);
 
@@ -118,17 +115,17 @@ const UserMessageEditor = React.forwardRef<
           dictationEnabled: speechToTextEnabled,
           dictationUsageCount: speechToTextCount,
           dictationMessageClearedCount: clearedMessageCount,
-          dictationClearedSinceLastTranscription,
+          dictationClearedSinceLastTranscription: lastDictationCleared,
         });
         setSpeechToTextCount(0);
         setClearedMessageCount(0);
-        setDictationClearedSinceLastTranscription(false);
+        setLastDictationCleared(false);
       },
       [
         speechToTextCount,
         speechToTextEnabled,
         clearedMessageCount,
-        dictationClearedSinceLastTranscription,
+        lastDictationCleared,
         onSubmit,
       ]
     );
@@ -178,7 +175,7 @@ const UserMessageEditor = React.forwardRef<
                   onChange(`${userMessage ? userMessage + ' ' : ''}${text}`);
                   setIsRecording(false);
                   setSpeechToTextCount(c => c + 1);
-                  setDictationClearedSinceLastTranscription(false);
+                  setLastDictationCleared(false);
                 }}
                 onRecordStart={() => setIsRecording(true)}
               />

--- a/apps/src/aiComponentLibrary/userMessageEditor/UserMessageEditor.tsx
+++ b/apps/src/aiComponentLibrary/userMessageEditor/UserMessageEditor.tsx
@@ -98,11 +98,17 @@ const UserMessageEditor = React.forwardRef<
 
     const [speechToTextCount, setSpeechToTextCount] = useState(0);
     const [clearedMessageCount, setClearedMessageCount] = useState(0);
+    /** True after the field becomes empty following STT use, until the next successful transcription. */
+    const [
+      dictationClearedSinceLastTranscription,
+      setDictationClearedSinceLastTranscription,
+    ] = useState(false);
 
     useEffect(() => {
       // Track how many times the message was cleared after using speech to text.
       if (speechToTextCount > 0 && !userMessage) {
         setClearedMessageCount(c => c + 1);
+        setDictationClearedSinceLastTranscription(true);
       }
     }, [speechToTextCount, userMessage]);
 
@@ -112,11 +118,19 @@ const UserMessageEditor = React.forwardRef<
           dictationEnabled: speechToTextEnabled,
           dictationUsageCount: speechToTextCount,
           dictationMessageClearedCount: clearedMessageCount,
+          dictationClearedSinceLastTranscription,
         });
         setSpeechToTextCount(0);
         setClearedMessageCount(0);
+        setDictationClearedSinceLastTranscription(false);
       },
-      [speechToTextCount, speechToTextEnabled, clearedMessageCount, onSubmit]
+      [
+        speechToTextCount,
+        speechToTextEnabled,
+        clearedMessageCount,
+        dictationClearedSinceLastTranscription,
+        onSubmit,
+      ]
     );
 
     return (
@@ -164,6 +178,7 @@ const UserMessageEditor = React.forwardRef<
                   onChange(`${userMessage ? userMessage + ' ' : ''}${text}`);
                   setIsRecording(false);
                   setSpeechToTextCount(c => c + 1);
+                  setDictationClearedSinceLastTranscription(false);
                 }}
                 onRecordStart={() => setIsRecording(true)}
               />

--- a/apps/src/aiComponentLibrary/userMessageEditor/UserMessageEditor.tsx
+++ b/apps/src/aiComponentLibrary/userMessageEditor/UserMessageEditor.tsx
@@ -110,8 +110,8 @@ const UserMessageEditor = React.forwardRef<
       (userMessage: string) => {
         onSubmit(userMessage, {
           dictationEnabled: speechToTextEnabled,
-          dictationUses: speechToTextCount,
-          dictationMessageCleared: clearedMessageCount,
+          dictationUsageCount: speechToTextCount,
+          dictationMessageClearedCount: clearedMessageCount,
         });
         setSpeechToTextCount(0);
         setClearedMessageCount(0);

--- a/apps/src/aiComponentLibrary/userMessageEditor/UserMessageEditor.tsx
+++ b/apps/src/aiComponentLibrary/userMessageEditor/UserMessageEditor.tsx
@@ -1,8 +1,9 @@
 import FontAwesomeV6Icon from '@code-dot-org/component-library/fontAwesomeV6Icon';
 import {Button as MuiButton, IconButton as MuiIconButton} from '@mui/material';
 import classnames from 'classnames';
-import React, {useState, useMemo, useEffect, useRef} from 'react';
+import React, {useState, useMemo, useEffect, useRef, useCallback} from 'react';
 
+import {AnalyticsProperties} from '@cdo/apps/aichat/types';
 import {commonI18n} from '@cdo/apps/types/locale';
 
 import SpeechToTextButton from './speechToTextButton/SpeechToTextButton';
@@ -18,7 +19,10 @@ const MAX_MESSAGE_LENGTH = 10000;
 export interface UserMessageEditorProps {
   userMessage: string;
   onChange: (userMessage: string) => void;
-  onSubmit: (userMessage: string) => void;
+  onSubmit: (
+    userMessage: string,
+    analyticsProperties?: AnalyticsProperties
+  ) => void;
   disabled: boolean;
   showSubmitLabel?: boolean;
   /** Custom className for editor container */
@@ -63,7 +67,7 @@ const UserMessageEditor = React.forwardRef<
     const handleKeyPress = (e: React.KeyboardEvent, userMessage: string) => {
       if (e.key === 'Enter' && !e.shiftKey && userMessage.trim() !== '') {
         e.preventDefault(); // Prevent the text box from having just a blank line.
-        onSubmit(userMessage);
+        submitMessage(userMessage);
       }
     };
 
@@ -85,12 +89,35 @@ const UserMessageEditor = React.forwardRef<
       id: 'uitest-chat-submit',
       onClick: (e: React.MouseEvent) => {
         e.stopPropagation();
-        onSubmit(userMessage);
+        submitMessage(userMessage);
       },
       'aria-label': commonI18n.submit(),
       type: 'button' as const,
       component: 'button' as const,
     };
+
+    const [speechToTextCount, setSpeechToTextCount] = useState(0);
+    const [clearedMessageCount, setClearedMessageCount] = useState(0);
+
+    useEffect(() => {
+      // Track how many times the message was cleared after using speech to text.
+      if (speechToTextCount > 0 && !userMessage) {
+        setClearedMessageCount(c => c + 1);
+      }
+    }, [speechToTextCount, userMessage]);
+
+    const submitMessage = useCallback(
+      (userMessage: string) => {
+        onSubmit(userMessage, {
+          dictationEnabled: speechToTextEnabled,
+          dictationUses: speechToTextCount,
+          dictationMessageCleared: clearedMessageCount,
+        });
+        setSpeechToTextCount(0);
+        setClearedMessageCount(0);
+      },
+      [speechToTextCount, speechToTextEnabled, clearedMessageCount, onSubmit]
+    );
 
     return (
       <div
@@ -136,6 +163,7 @@ const UserMessageEditor = React.forwardRef<
                 onTranscribed={text => {
                   onChange(`${userMessage ? userMessage + ' ' : ''}${text}`);
                   setIsRecording(false);
+                  setSpeechToTextCount(c => c + 1);
                 }}
                 onRecordStart={() => setIsRecording(true)}
               />


### PR DESCRIPTION
Adds speech to text (dictation) analytics data to the `'User submits aichat request'` Statsig event. These include:

```
dictationEnabled: boolean (whether STT is enabled on this level)
dictationUsageCount: number (the number of times the user successfully used dictation before sending this message)
dictationMessageClearedCount: number (the number of times the user cleared the message text after using dictation at least once, before sending the message)
```

<img width="872" height="112" alt="Screenshot 2026-03-25 at 12 19 20 PM" src="https://github.com/user-attachments/assets/ec88a8ce-d05b-44c9-b805-4705cf9785a5" />


## Links
<!-- Jira tickets, design docs, Slack threads, related PRs, etc. -->

- Jira: https://codedotorg.atlassian.net/browse/SL-1621

## Testing story
Tested locally.