### PR TITLE
AI Chat (redux, across labs): memoize chat messages

### DIFF
--- a/apps/src/aichat/redux/selectors/index.ts
+++ b/apps/src/aichat/redux/selectors/index.ts
@@ -51,10 +51,14 @@ export const selectIsWaitingForChatResponse = (state: RootState) => {
   );
 };
 
-export const selectAllVisibleMessages = (state: RootState) => {
-  const {chatEventsPast, chatEventsCurrent} = state.aichat;
-  return [...chatEventsPast, ...chatEventsCurrent];
-};
+export const selectAllVisibleMessages = createSelector(
+  (state: RootState) => state.aichat.chatEventsPast,
+  (state: RootState) => state.aichat.chatEventsCurrent,
+  (chatEventsPast, chatEventsCurrent) => [
+    ...chatEventsPast,
+    ...chatEventsCurrent,
+  ]
+);
 
 export const selectHavePropertiesChanged = (state: RootState) =>
   findChangedProperties(

--- a/apps/src/aichat/views/ChatWorkspace.tsx
+++ b/apps/src/aichat/views/ChatWorkspace.tsx
@@ -99,15 +99,13 @@ const ChatWorkspace: React.FunctionComponent<ChatWorkspaceProps> = ({
   );
   const currentLevelId = useAppSelector(state => state.progress.currentLevelId);
   const scriptId = useAppSelector(state => state.progress.scriptId);
-  const visibleItems = useAppSelector(state => {
+  const unfilteredVisibleItems = useAppSelector(selectAllVisibleMessages);
+  const visibleItems = useMemo(() => {
     if (hideModelChangeMessage) {
-      return selectAllVisibleMessages(state).filter(
-        message => !isModelUpdate(message)
-      );
-    } else {
-      return selectAllVisibleMessages(state);
+      return unfilteredVisibleItems.filter(message => !isModelUpdate(message));
     }
-  });
+    return unfilteredVisibleItems;
+  }, [hideModelChangeMessage, unfilteredVisibleItems]);
   const currentUserId = useAppSelector(state => state.currentUser.userId);
 
   const isAiTutorVersion = useAppSelector(


### PR DESCRIPTION
Started seeing an error when loading Web Lab 2, seemingly particularly on levels with chat history:

```
installHook.js:1 Warning: Maximum update depth exceeded. This can happen when a component calls setState inside useEffect, but useEffect either doesn't have a dependency array, or one of the dependencies changes on every render. Error Component Stack
```

We were selecting Redux state in a way that did not retain a stable reference to an unchanged list of messages, which I think put us into some version of a loop of new messages -> redux update produced by new messages -> new messages -> ....

Replaced the `selectAllVisibleMessages` selector with a memoized version, such that we're not returning a new array every time the function is called.

Here's a video of what I saw when I had a console log printing "render" in the `ChatWorkspace` component before this change. After this change, no chaotic rerendering.

https://github.com/user-attachments/assets/186a9980-0714-4ee9-901a-7a1eca5ff23c

## Links

- `createSelector` docs: https://reselect.js.org/api/createselector/

## Testing story

I tested manually that we are no longer continuously rerendering after this change.