### PR TITLE
Add Primary Key to Tables that are Missing One to Support Zero ETL Integration

### DIFF
--- a/dashboard/app/models/lesson.rb
+++ b/dashboard/app/models/lesson.rb
@@ -49,14 +49,14 @@ class Lesson < ApplicationRecord
   has_many :lessons_programming_expressions
 
   has_one :plc_learning_module, class_name: 'Plc::LearningModule', inverse_of: :lesson, foreign_key: 'stage_id', dependent: :destroy
-  has_and_belongs_to_many :standards, foreign_key: 'stage_id'
+  has_and_belongs_to_many :standards, -> {order('standards.shortcode ASC')}, foreign_key: 'stage_id'
   has_many :lessons_standards, foreign_key: 'stage_id' # join table. we need this association for seeding logic
 
   # the dependent: :destroy clause is needed to ensure that the associated join
   # models are deleted when this lesson is deleted. in order for this to work,
   # the join model must have an :id column.
   has_many :lessons_opportunity_standards,  dependent: :destroy
-  has_many :opportunity_standards, through: :lessons_opportunity_standards, source: :standard
+  has_many :opportunity_standards, -> {order('standards.shortcode ASC')}, through: :lessons_opportunity_standards, source: :standard
 
   has_one :rubric, dependent: :destroy
 

--- a/dashboard/app/models/lessons_programming_expression.rb
+++ b/dashboard/app/models/lessons_programming_expression.rb
@@ -2,8 +2,8 @@
 #
 # Table name: lessons_programming_expressions
 #
-#  lesson_id                 :bigint           not null
-#  programming_expression_id :bigint           not null
+#  lesson_id                 :bigint           not null, primary key
+#  programming_expression_id :bigint           not null, primary key
 #
 # Indexes
 #

--- a/dashboard/app/models/lessons_resource.rb
+++ b/dashboard/app/models/lessons_resource.rb
@@ -2,8 +2,8 @@
 #
 # Table name: lessons_resources
 #
-#  lesson_id   :integer          not null
-#  resource_id :integer          not null
+#  lesson_id   :integer          not null, primary key
+#  resource_id :integer          not null, primary key
 #
 # Indexes
 #

--- a/dashboard/app/models/lessons_standard.rb
+++ b/dashboard/app/models/lessons_standard.rb
@@ -2,8 +2,8 @@
 #
 # Table name: stages_standards
 #
-#  stage_id    :integer          not null
-#  standard_id :integer          not null
+#  stage_id    :integer          not null, primary key
+#  standard_id :integer          not null, primary key
 #  created_at  :datetime         not null
 #  updated_at  :datetime         not null
 #

--- a/dashboard/app/models/lessons_vocabulary.rb
+++ b/dashboard/app/models/lessons_vocabulary.rb
@@ -2,8 +2,8 @@
 #
 # Table name: lessons_vocabularies
 #
-#  lesson_id     :bigint           not null
-#  vocabulary_id :bigint           not null
+#  lesson_id     :bigint           not null, primary key
+#  vocabulary_id :bigint           not null, primary key
 #
 # Indexes
 #

--- a/dashboard/app/models/levels_script_level.rb
+++ b/dashboard/app/models/levels_script_level.rb
@@ -2,8 +2,8 @@
 #
 # Table name: levels_script_levels
 #
-#  level_id        :integer          not null
-#  script_level_id :integer          not null
+#  level_id        :integer          not null, primary key
+#  script_level_id :integer          not null, primary key
 #
 # Indexes
 #

--- a/dashboard/app/models/levels_skill.rb
+++ b/dashboard/app/models/levels_skill.rb
@@ -2,8 +2,8 @@
 #
 # Table name: levels_skills
 #
-#  level_id :bigint           not null
-#  skill_id :bigint           not null
+#  level_id :bigint           not null, primary key
+#  skill_id :bigint           not null, primary key
 #
 # Indexes
 #

--- a/dashboard/app/models/scripts_resource.rb
+++ b/dashboard/app/models/scripts_resource.rb
@@ -2,8 +2,8 @@
 #
 # Table name: scripts_resources
 #
-#  script_id   :integer
-#  resource_id :integer
+#  script_id   :integer          not null, primary key
+#  resource_id :integer          not null, primary key
 #
 # Indexes
 #

--- a/dashboard/app/models/unit_groups_resource.rb
+++ b/dashboard/app/models/unit_groups_resource.rb
@@ -2,8 +2,8 @@
 #
 # Table name: unit_groups_resources
 #
-#  unit_group_id :integer
-#  resource_id   :integer
+#  unit_group_id :integer          not null, primary key
+#  resource_id   :integer          not null, primary key
 #
 # Indexes
 #

--- a/dashboard/db/migrate/20260325183412_add_missing_primary_keys_for_zero_etl.rb
+++ b/dashboard/db/migrate/20260325183412_add_missing_primary_keys_for_zero_etl.rb
@@ -1,0 +1,49 @@
+class AddMissingPrimaryKeysForZeroEtl < ActiveRecord::Migration[7.0]
+  def up
+    # Add composite primary keys to join tables.
+    composite_key_tables = {
+      census_submissions_school_infos: [:census_submission_id, :school_info_id],
+      code_review_group_members: [:code_review_group_id, :follower_id],
+      course_offerings_pd_workshops: [:course_offering_id, :pd_workshop_id],
+      lessons_programming_expressions: [:lesson_id, :programming_expression_id],
+      lessons_resources: [:lesson_id, :resource_id],
+      lessons_vocabularies: [:lesson_id, :vocabulary_id],
+      levels_script_levels: [:level_id, :script_level_id],
+      levels_skills: [:level_id, :skill_id],
+      lti_deployments_user_identities: [:lti_deployment_id, :lti_user_identity_id],
+      pd_application_tags_applications: [:pd_application_id, :pd_application_tag_id],
+      pd_regional_partner_cohorts_users: [:pd_regional_partner_cohort_id, :user_id],
+      pd_workshops_facilitators: [:pd_workshop_id, :user_id],
+      regional_partners_school_districts: [:regional_partner_id, :school_district_id],
+      scripts_resources: [:script_id, :resource_id],
+      stages_standards: [:stage_id, :standard_id],
+      unit_groups_resources: [:unit_group_id, :resource_id]
+    }
+
+    composite_key_tables.each do |table, columns|
+      execute "ALTER TABLE #{table} ADD PRIMARY KEY (#{columns.join(', ')});"
+    end
+
+    # Tables requiring single-column primary keys.
+    execute "ALTER TABLE schools ADD PRIMARY KEY (id);"
+  end
+
+  def down
+    # Drop composite primary keys.
+    composite_tables = %i[
+      census_submissions_school_infos code_review_group_members course_offerings_pd_workshops
+      lessons_programming_expressions lessons_resources lessons_vocabularies
+      levels_script_levels levels_skills lti_deployments_user_identities
+      pd_application_tags_applications pd_regional_partner_cohorts_users
+      pd_workshops_facilitators regional_partners_school_districts
+      scripts_resources stages_standards unit_groups_resources
+    ]
+
+    composite_tables.each do |table|
+      execute "ALTER TABLE #{table} DROP PRIMARY KEY;"
+    end
+
+    # Drop single-column primary keys.
+    execute "ALTER TABLE schools DROP PRIMARY KEY;"
+  end
+end

--- a/dashboard/db/schema.rb
+++ b/dashboard/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2026_03_18_191529) do
+ActiveRecord::Schema[7.0].define(version: 2026_03_25_183412) do
   create_table "activities", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "user_id"
     t.integer "level_id"
@@ -356,7 +356,7 @@ ActiveRecord::Schema[7.0].define(version: 2026_03_18_191529) do
     t.index ["school_year", "id"], name: "index_census_submissions_on_school_year_and_id"
   end
 
-  create_table "census_submissions_school_infos", id: false, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "census_submissions_school_infos", primary_key: ["census_submission_id", "school_info_id"], charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "census_submission_id", null: false
     t.integer "school_info_id", null: false
     t.datetime "created_at", precision: nil, null: false
@@ -399,7 +399,7 @@ ActiveRecord::Schema[7.0].define(version: 2026_03_18_191529) do
     t.index ["code_review_id"], name: "index_code_review_comments_on_code_review_id"
   end
 
-  create_table "code_review_group_members", id: false, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "code_review_group_members", primary_key: ["code_review_group_id", "follower_id"], charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.bigint "code_review_group_id", null: false
     t.bigint "follower_id", null: false
     t.datetime "created_at", precision: nil, null: false
@@ -552,7 +552,7 @@ ActiveRecord::Schema[7.0].define(version: 2026_03_18_191529) do
     t.index ["key"], name: "index_course_offerings_on_key", unique: true
   end
 
-  create_table "course_offerings_pd_workshops", id: false, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "course_offerings_pd_workshops", primary_key: ["course_offering_id", "pd_workshop_id"], charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.bigint "pd_workshop_id", null: false
     t.bigint "course_offering_id", null: false
     t.datetime "created_at", null: false
@@ -1011,21 +1011,21 @@ ActiveRecord::Schema[7.0].define(version: 2026_03_18_191529) do
     t.index ["standard_id", "lesson_id"], name: "index_lessons_opportunity_standards_on_standard_id_and_lesson_id"
   end
 
-  create_table "lessons_programming_expressions", id: false, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "lessons_programming_expressions", primary_key: ["lesson_id", "programming_expression_id"], charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.bigint "lesson_id", null: false
     t.bigint "programming_expression_id", null: false
     t.index ["lesson_id", "programming_expression_id"], name: "lesson_programming_expression", unique: true
     t.index ["programming_expression_id", "lesson_id"], name: "programming_expression_lesson"
   end
 
-  create_table "lessons_resources", id: false, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "lessons_resources", primary_key: ["lesson_id", "resource_id"], charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "lesson_id", null: false
     t.integer "resource_id", null: false
     t.index ["lesson_id", "resource_id"], name: "index_lessons_resources_on_lesson_id_and_resource_id", unique: true
     t.index ["resource_id", "lesson_id"], name: "index_lessons_resources_on_resource_id_and_lesson_id"
   end
 
-  create_table "lessons_vocabularies", id: false, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "lessons_vocabularies", primary_key: ["lesson_id", "vocabulary_id"], charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.bigint "lesson_id", null: false
     t.bigint "vocabulary_id", null: false
     t.index ["lesson_id", "vocabulary_id"], name: "index_lessons_vocabularies_on_lesson_id_and_vocabulary_id", unique: true
@@ -1097,7 +1097,7 @@ ActiveRecord::Schema[7.0].define(version: 2026_03_18_191529) do
     t.index ["type"], name: "index_levels_on_type"
   end
 
-  create_table "levels_script_levels", id: false, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "levels_script_levels", primary_key: ["level_id", "script_level_id"], charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "level_id", null: false
     t.integer "script_level_id", null: false
     t.index ["level_id"], name: "index_levels_script_levels_on_level_id"
@@ -1105,7 +1105,7 @@ ActiveRecord::Schema[7.0].define(version: 2026_03_18_191529) do
     t.index ["script_level_id"], name: "index_levels_script_levels_on_script_level_id"
   end
 
-  create_table "levels_skills", id: false, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "levels_skills", primary_key: ["level_id", "skill_id"], charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.bigint "level_id", null: false
     t.bigint "skill_id", null: false
     t.index ["level_id", "skill_id"], name: "index_levels_skills_on_level_id_and_skill_id"
@@ -1146,7 +1146,7 @@ ActiveRecord::Schema[7.0].define(version: 2026_03_18_191529) do
     t.index ["lti_integration_id"], name: "index_lti_deployments_on_lti_integration_id"
   end
 
-  create_table "lti_deployments_user_identities", id: false, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "lti_deployments_user_identities", primary_key: ["lti_deployment_id", "lti_user_identity_id"], charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.bigint "lti_deployment_id", null: false
     t.bigint "lti_user_identity_id", null: false
     t.index ["lti_deployment_id"], name: "index_lti_deployments_user_identities_on_lti_deployment_id"
@@ -1285,7 +1285,7 @@ ActiveRecord::Schema[7.0].define(version: 2026_03_18_191529) do
     t.index ["name"], name: "index_pd_application_tags_on_name", unique: true
   end
 
-  create_table "pd_application_tags_applications", id: false, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "pd_application_tags_applications", primary_key: ["pd_application_id", "pd_application_tag_id"], charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "pd_application_id", null: false
     t.integer "pd_application_tag_id", null: false
     t.datetime "created_at", precision: nil, null: false
@@ -1496,7 +1496,7 @@ ActiveRecord::Schema[7.0].define(version: 2026_03_18_191529) do
     t.index ["summer_workshop_id"], name: "index_pd_regional_partner_cohorts_on_summer_workshop_id"
   end
 
-  create_table "pd_regional_partner_cohorts_users", id: false, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "pd_regional_partner_cohorts_users", primary_key: ["pd_regional_partner_cohort_id", "user_id"], charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "pd_regional_partner_cohort_id", null: false
     t.integer "user_id", null: false
     t.index ["pd_regional_partner_cohort_id"], name: "index_pd_regional_partner_cohorts_users_on_cohort_id"
@@ -1703,7 +1703,7 @@ ActiveRecord::Schema[7.0].define(version: 2026_03_18_191529) do
     t.index ["regional_partner_id"], name: "index_pd_workshops_on_regional_partner_id"
   end
 
-  create_table "pd_workshops_facilitators", id: false, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "pd_workshops_facilitators", primary_key: ["pd_workshop_id", "user_id"], charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "pd_workshop_id", null: false
     t.integer "user_id", null: false
     t.index ["pd_workshop_id"], name: "index_pd_workshops_facilitators_on_pd_workshop_id"
@@ -1973,7 +1973,7 @@ ActiveRecord::Schema[7.0].define(version: 2026_03_18_191529) do
     t.boolean "is_active", null: false
   end
 
-  create_table "regional_partners_school_districts", id: false, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "regional_partners_school_districts", primary_key: ["regional_partner_id", "school_district_id"], charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "regional_partner_id", null: false
     t.integer "school_district_id", null: false
     t.string "course", comment: "Course for a given workshop"
@@ -2088,8 +2088,7 @@ ActiveRecord::Schema[7.0].define(version: 2026_03_18_191529) do
     t.index ["school_id"], name: "index_school_stats_by_years_on_school_id"
   end
 
-  create_table "schools", id: false, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
-    t.string "id", limit: 12, null: false, comment: "NCES public school ID"
+  create_table "schools", id: { type: :string, limit: 12, comment: "NCES public school ID" }, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "school_district_id"
     t.string "name", null: false
     t.string "city", null: false
@@ -2162,9 +2161,9 @@ ActiveRecord::Schema[7.0].define(version: 2026_03_18_191529) do
     t.index ["wrapup_video_id"], name: "index_scripts_on_wrapup_video_id"
   end
 
-  create_table "scripts_resources", id: false, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
-    t.integer "script_id"
-    t.integer "resource_id"
+  create_table "scripts_resources", primary_key: ["script_id", "resource_id"], charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.integer "script_id", null: false
+    t.integer "resource_id", null: false
     t.index ["resource_id", "script_id"], name: "index_scripts_resources_on_resource_id_and_script_id"
     t.index ["script_id", "resource_id"], name: "index_scripts_resources_on_script_id_and_resource_id", unique: true
   end
@@ -2313,7 +2312,7 @@ ActiveRecord::Schema[7.0].define(version: 2026_03_18_191529) do
     t.index ["script_id", "key"], name: "index_stages_on_script_id_and_key", unique: true
   end
 
-  create_table "stages_standards", id: false, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "stages_standards", primary_key: ["stage_id", "standard_id"], charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "stage_id", null: false
     t.integer "standard_id", null: false
     t.datetime "created_at", precision: nil, null: false
@@ -2477,9 +2476,9 @@ ActiveRecord::Schema[7.0].define(version: 2026_03_18_191529) do
     t.index ["published_state"], name: "index_unit_groups_on_published_state"
   end
 
-  create_table "unit_groups_resources", id: false, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
-    t.integer "unit_group_id"
-    t.integer "resource_id"
+  create_table "unit_groups_resources", primary_key: ["unit_group_id", "resource_id"], charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.integer "unit_group_id", null: false
+    t.integer "resource_id", null: false
     t.index ["resource_id", "unit_group_id"], name: "index_unit_groups_resources_on_resource_id_and_unit_group_id"
     t.index ["unit_group_id", "resource_id"], name: "index_unit_groups_resources_on_unit_group_id_and_resource_id", unique: true
   end

--- a/dashboard/test/lib/services/script_seed_test.rb
+++ b/dashboard/test/lib/services/script_seed_test.rb
@@ -525,11 +525,9 @@ module Services
       assert_equal expected_descriptions, lesson.standards.map(&:description)
     end
 
-    test 'seed reorders existing lesson standards by key' do
+    test 'seed lesson standards are ordered by shortcode' do
       script = create_script_tree
 
-      # give the new standard a shortcode that will make it appear before the
-      # existing standards in the sort order.
       new_standard = create(:standard, framework: @framework, shortcode: 'abc', description: 'New Standard')
 
       expected_shortcodes = [
@@ -537,17 +535,10 @@ module Services
         script.lessons.first.standards.last.shortcode,
       ]
 
-      expected_descriptions = [
-        new_standard.description,
-        script.lessons.first.standards.last.description,
-      ]
-
-      _script_with_changes, json = get_script_and_json_with_change_and_rollback(script) do
+      _, json = get_script_and_json_with_change_and_rollback(script) do
         lesson = script.lessons.first
         lesson.standards.first.destroy
         lesson.standards.push(new_standard)
-        shortcodes = lesson.standards.map(&:shortcode)
-        refute_equal shortcodes, shortcodes.sort
       end
 
       ScriptSeed.seed_from_json(json)
@@ -555,7 +546,6 @@ module Services
 
       lesson = script.lessons.first
       assert_equal expected_shortcodes, lesson.standards.map(&:shortcode)
-      assert_equal expected_descriptions, lesson.standards.map(&:description)
     end
 
     test 'seed updates lesson opportunity standards' do
@@ -590,41 +580,33 @@ module Services
       assert_equal expected_descriptions, lesson.opportunity_standards.map(&:description)
     end
 
-    test 'seed does not reorder existing opportunity standards by key' do
+    test 'seed lesson opportunity standards are ordered by shortcode' do
       script = create_script_tree
 
-      # give the new standard a shortcode that will make it appear before the
+      # Give the new standard a shortcode that will make it appear before the
       # existing standards in the sort order.
       new_standard = create(:standard, framework: @framework, shortcode: 'abc', description: 'New Standard')
 
-      # when the order of the serialized lessons_opportunity_standards changes,
-      # the sort order of opportunity standards in the database is preserved.
-      # strangely, the same is not true for lessons_standards. this may be
-      # related to the fact that LessonsOpportunityStandard contains an id
-      # column, while LessonsStandard does not.
-
       expected_shortcodes = [
-        script.lessons.first.opportunity_standards.last.shortcode,
         new_standard.shortcode,
+        script.lessons.first.opportunity_standards.last.shortcode,
       ]
 
       expected_descriptions = [
-        script.lessons.first.opportunity_standards.last.description,
         new_standard.description,
+        script.lessons.first.opportunity_standards.last.description,
       ]
 
-      script_with_changes, json = get_script_and_json_with_change_and_rollback(script) do
+      _, json = get_script_and_json_with_change_and_rollback(script) do
         lesson = script.lessons.first
         lesson.opportunity_standards.first.destroy
         lesson.opportunity_standards.push(new_standard)
-        shortcodes = lesson.opportunity_standards.map(&:shortcode)
-        refute_equal shortcodes, shortcodes.sort
       end
 
       ScriptSeed.seed_from_json(json)
       script = Unit.with_seed_models.find(script.id)
 
-      assert_script_trees_equal script_with_changes, script
+      # The model's default scope now guarantees these are ordered alphabetically by shortcode.
       lesson = script.lessons.first
       assert_equal expected_shortcodes, lesson.opportunity_standards.map(&:shortcode)
       assert_equal expected_descriptions, lesson.opportunity_standards.map(&:description)


### PR DESCRIPTION
https://codedotorg.atlassian.net/browse/INF-1793

Zero ETL requires that all source MySQL tables have a primary key to be able replicate them to Redshift.
https://docs.aws.amazon.com/redshift/latest/mgmt/zero-etl.reqs-lims.html
> Tables in the integration source must have a primary key. Otherwise, your tables can't be replicated to the target data warehouse in Amazon Redshift.

Most of the tables missing a primary key are join tables. Add composite primary keys for those.

## Testing story
<!-- How was this tested? Manual steps, adhoc links, automated tests, or why testing isn't needed. -->



## Deployment notes
<!-- Delete this section if it's a standard merge-and-deploy.
     Otherwise: migrations, feature flags, coordination, caching impacts, etc. -->



## Privacy and security
<!-- Delete this section if there is no privacy/security impact.
     Otherwise: new PII, auth changes, API surface changes, etc. -->

