### PR TITLE
Levelbuilder interface and seeding for JIT PL Misconceptions

### DIFF
--- a/apps/src/levelbuilder/jit-pl-concepts-editor/JitPlConceptFormEditor.jsx
+++ b/apps/src/levelbuilder/jit-pl-concepts-editor/JitPlConceptFormEditor.jsx
@@ -10,11 +10,14 @@ import TextareaWithMarkdownPreview from '@cdo/apps/levelbuilder/TextareaWithMark
 import RailsAuthenticityToken from '@cdo/apps/lib/util/RailsAuthenticityToken';
 import {navigateToHref} from '@cdo/apps/utils';
 
+import MisconceptionsEditor from './MisconceptionsEditor';
+
 const JitPlConceptFormEditor = ({
   conceptId,
   originalName,
   originalDisplayName,
   originalTextContent,
+  originalMisconceptions,
   resources,
 }) => {
   const [name, setName] = useState(originalName);
@@ -88,6 +91,11 @@ const JitPlConceptFormEditor = ({
         resourceContext="jitPlConceptResource"
         resources={resources}
       />
+      <h2>Misconceptions</h2>
+      <MisconceptionsEditor
+        conceptId={conceptId}
+        initialMisconceptions={originalMisconceptions}
+      />
       <br />
       <SaveBar
         handleSave={save}
@@ -114,6 +122,7 @@ JitPlConceptFormEditor.propTypes = {
   originalName: PropTypes.string,
   originalDisplayName: PropTypes.string,
   originalTextContent: PropTypes.string,
+  originalMisconceptions: PropTypes.array,
   resources: PropTypes.arrayOf(resourceShape).isRequired,
 };
 

--- a/apps/src/levelbuilder/jit-pl-concepts-editor/MisconceptionsEditor.jsx
+++ b/apps/src/levelbuilder/jit-pl-concepts-editor/MisconceptionsEditor.jsx
@@ -1,0 +1,282 @@
+import $ from 'jquery';
+import PropTypes from 'prop-types';
+import React, {useState} from 'react';
+
+import TextareaWithMarkdownPreview from '@cdo/apps/levelbuilder/TextareaWithMarkdownPreview';
+import {UnconnectedResourcesEditor} from '@cdo/apps/levelbuilder/lesson-editor/ResourcesEditor';
+import {resourceShape} from '@cdo/apps/levelbuilder/shapes';
+
+const misconceptionShape = PropTypes.shape({
+  id: PropTypes.number.isRequired,
+  name: PropTypes.string,
+  text_content: PropTypes.string,
+  resources: PropTypes.arrayOf(resourceShape),
+});
+
+const MisconceptionForm = ({conceptId, initial, onSave, onCancel}) => {
+  const [name, setName] = useState(initial?.name || '');
+  const [textContent, setTextContent] = useState(initial?.text_content || '');
+  const [resources, setResources] = useState(initial?.resources || []);
+  const [isSaving, setIsSaving] = useState(false);
+  const [error, setError] = useState(null);
+
+  const addResource = (_context, resource) =>
+    setResources(prev => [...prev, resource]);
+  const editResource = (_context, resource) =>
+    setResources(prev => prev.map(r => (r.key === resource.key ? resource : r)));
+  const removeResource = (_context, key) =>
+    setResources(prev => prev.filter(r => r.key !== key));
+
+  const save = () => {
+    setIsSaving(true);
+    const isNew = !initial;
+    $.ajax({
+      url: isNew
+        ? `/jit_pl_concepts/${conceptId}/jit_pl_misconceptions`
+        : `/jit_pl_concepts/${conceptId}/jit_pl_misconceptions/${initial.id}`,
+      method: isNew ? 'POST' : 'PUT',
+      data: {
+        name,
+        text_content: textContent,
+        resource_ids: resources.map(r => r.id),
+      },
+    })
+      .done(data => onSave(data))
+      .fail(err => {
+        setIsSaving(false);
+        setError(err.responseText);
+      });
+  };
+
+  return (
+    <div style={styles.form}>
+      {error && <p style={styles.error}>{error}</p>}
+      <label style={styles.label}>
+        Name
+        <input
+          style={styles.input}
+          value={name}
+          onChange={e => setName(e.target.value)}
+        />
+      </label>
+      <TextareaWithMarkdownPreview
+        name="text_content"
+        label="Text Content"
+        handleMarkdownChange={e => setTextContent(e.target.value)}
+        markdown={textContent}
+      />
+      <h4 style={styles.resourcesHeading}>Resources</h4>
+      <UnconnectedResourcesEditor
+        forJitPl
+        resourceContext="jitPlMisconceptionResource"
+        resources={resources}
+        addResource={addResource}
+        editResource={editResource}
+        removeResource={removeResource}
+      />
+      <div style={styles.formButtons}>
+        <button onClick={save} disabled={isSaving} type="button">
+          {isSaving ? 'Saving...' : 'Save'}
+        </button>
+        <button onClick={onCancel} type="button" style={styles.cancelButton}>
+          Cancel
+        </button>
+      </div>
+    </div>
+  );
+};
+
+MisconceptionForm.propTypes = {
+  conceptId: PropTypes.number.isRequired,
+  initial: misconceptionShape,
+  onSave: PropTypes.func.isRequired,
+  onCancel: PropTypes.func.isRequired,
+};
+
+const MisconceptionItem = ({misconception, conceptId, onUpdate, onDelete}) => {
+  const [isEditing, setIsEditing] = useState(false);
+
+  const handleSave = updated => {
+    setIsEditing(false);
+    onUpdate(updated);
+  };
+
+  const handleDelete = () => {
+    if (!confirm(`Delete misconception "${misconception.name}"?`)) {
+      return;
+    }
+    $.ajax({
+      url: `/jit_pl_concepts/${conceptId}/jit_pl_misconceptions/${misconception.id}`,
+      method: 'DELETE',
+    }).done(() => onDelete(misconception.id));
+  };
+
+  if (isEditing) {
+    return (
+      <MisconceptionForm
+        conceptId={conceptId}
+        initial={misconception}
+        onSave={handleSave}
+        onCancel={() => setIsEditing(false)}
+      />
+    );
+  }
+
+  return (
+    <div style={styles.card}>
+      <strong>{misconception.name}</strong>
+      <div style={styles.cardActions}>
+        <button
+          onClick={() => setIsEditing(true)}
+          type="button"
+          style={styles.editButton}
+        >
+          <i className="fa fa-edit" /> Edit
+        </button>
+        <button
+          onClick={handleDelete}
+          type="button"
+          style={styles.deleteButton}
+        >
+          <i className="fa fa-trash" /> Delete
+        </button>
+      </div>
+    </div>
+  );
+};
+
+MisconceptionItem.propTypes = {
+  misconception: misconceptionShape.isRequired,
+  conceptId: PropTypes.number.isRequired,
+  onUpdate: PropTypes.func.isRequired,
+  onDelete: PropTypes.func.isRequired,
+};
+
+const MisconceptionsEditor = ({conceptId, initialMisconceptions}) => {
+  const [misconceptions, setMisconceptions] = useState(
+    initialMisconceptions || []
+  );
+  const [isAdding, setIsAdding] = useState(false);
+
+  const handleAdd = created => {
+    setMisconceptions(prev => [...prev, created]);
+    setIsAdding(false);
+  };
+
+  const handleUpdate = updated => {
+    setMisconceptions(prev =>
+      prev.map(m => (m.id === updated.id ? updated : m))
+    );
+  };
+
+  const handleDelete = id => {
+    setMisconceptions(prev => prev.filter(m => m.id !== id));
+  };
+
+  return (
+    <div>
+      {misconceptions.map(m => (
+        <MisconceptionItem
+          key={m.id}
+          misconception={m}
+          conceptId={conceptId}
+          onUpdate={handleUpdate}
+          onDelete={handleDelete}
+        />
+      ))}
+      {isAdding ? (
+        <MisconceptionForm
+          conceptId={conceptId}
+          initial={null}
+          onSave={handleAdd}
+          onCancel={() => setIsAdding(false)}
+        />
+      ) : (
+        <button
+          onClick={() => setIsAdding(true)}
+          type="button"
+          style={styles.addButton}
+        >
+          + Add Misconception
+        </button>
+      )}
+    </div>
+  );
+};
+
+MisconceptionsEditor.propTypes = {
+  conceptId: PropTypes.number.isRequired,
+  initialMisconceptions: PropTypes.arrayOf(misconceptionShape),
+};
+
+const styles = {
+  form: {
+    border: '1px solid #ddd',
+    borderRadius: 4,
+    padding: 16,
+    marginBottom: 12,
+  },
+  label: {
+    display: 'flex',
+    flexDirection: 'column',
+    marginBottom: 10,
+  },
+  input: {
+    marginTop: 4,
+  },
+  resourcesHeading: {
+    marginTop: 12,
+    marginBottom: 6,
+  },
+  formButtons: {
+    marginTop: 12,
+    display: 'flex',
+    gap: 8,
+  },
+  cancelButton: {
+    marginLeft: 8,
+  },
+  error: {
+    color: 'red',
+  },
+  card: {
+    display: 'flex',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    border: '1px solid #ddd',
+    borderRadius: 4,
+    padding: '8px 12px',
+    marginBottom: 8,
+    background: '#fafafa',
+  },
+  cardActions: {
+    display: 'flex',
+    gap: 8,
+  },
+  editButton: {
+    background: '#337ab7',
+    color: 'white',
+    border: 'none',
+    borderRadius: 3,
+    padding: '4px 10px',
+    cursor: 'pointer',
+  },
+  deleteButton: {
+    background: '#d9534f',
+    color: 'white',
+    border: 'none',
+    borderRadius: 3,
+    padding: '4px 10px',
+    cursor: 'pointer',
+  },
+  addButton: {
+    background: '#eee',
+    border: '1px solid #ddd',
+    borderRadius: 3,
+    padding: 7,
+    marginTop: 8,
+    cursor: 'pointer',
+  },
+};
+
+export default MisconceptionsEditor;

--- a/apps/src/levelbuilder/jit-pl-concepts-editor/MisconceptionsEditor.jsx
+++ b/apps/src/levelbuilder/jit-pl-concepts-editor/MisconceptionsEditor.jsx
@@ -2,9 +2,9 @@ import $ from 'jquery';
 import PropTypes from 'prop-types';
 import React, {useState} from 'react';
 
-import TextareaWithMarkdownPreview from '@cdo/apps/levelbuilder/TextareaWithMarkdownPreview';
 import {UnconnectedResourcesEditor} from '@cdo/apps/levelbuilder/lesson-editor/ResourcesEditor';
 import {resourceShape} from '@cdo/apps/levelbuilder/shapes';
+import TextareaWithMarkdownPreview from '@cdo/apps/levelbuilder/TextareaWithMarkdownPreview';
 
 const misconceptionShape = PropTypes.shape({
   id: PropTypes.number.isRequired,
@@ -23,7 +23,9 @@ const MisconceptionForm = ({conceptId, initial, onSave, onCancel}) => {
   const addResource = (_context, resource) =>
     setResources(prev => [...prev, resource]);
   const editResource = (_context, resource) =>
-    setResources(prev => prev.map(r => (r.key === resource.key ? resource : r)));
+    setResources(prev =>
+      prev.map(r => (r.key === resource.key ? resource : r))
+    );
   const removeResource = (_context, key) =>
     setResources(prev => prev.filter(r => r.key !== key));
 

--- a/apps/src/levelbuilder/jit-pl-concepts-editor/MisconceptionsEditor.tsx
+++ b/apps/src/levelbuilder/jit-pl-concepts-editor/MisconceptionsEditor.tsx
@@ -1,8 +1,13 @@
 import $ from 'jquery';
-import React, {useState} from 'react';
+import React, {useEffect, useRef, useState} from 'react';
+import {useSelector} from 'react-redux';
 
-import {UnconnectedResourcesEditor} from '@cdo/apps/levelbuilder/lesson-editor/ResourcesEditor';
+import ResourcesEditor from '@cdo/apps/levelbuilder/lesson-editor/ResourcesEditor';
+import createResourcesReducer, {
+  initResources,
+} from '@cdo/apps/levelbuilder/lesson-editor/resourcesEditorRedux';
 import TextareaWithMarkdownPreview from '@cdo/apps/levelbuilder/TextareaWithMarkdownPreview';
+import {getStore, registerReducers} from '@cdo/apps/redux';
 
 import moduleStyles from './misconceptionsEditor.module.scss';
 
@@ -41,22 +46,22 @@ const MisconceptionForm: React.FC<MisconceptionFormProps> = ({
   onSave,
   onCancel,
 }) => {
+  const contextKey = `jitPlMisconceptionResource_${initial?.id ?? 'new'}`;
+  const initialResourcesRef = useRef(initial?.resources ?? []);
+
+  useEffect(() => {
+    registerReducers({[contextKey]: createResourcesReducer(contextKey)});
+    getStore().dispatch(initResources(contextKey, initialResourcesRef.current));
+  }, [contextKey]);
+
+  const resources = useSelector(
+    (state: Record<string, Resource[]>) => state[contextKey] ?? []
+  );
+
   const [name, setName] = useState(initial?.name ?? '');
   const [textContent, setTextContent] = useState(initial?.text_content ?? '');
-  const [resources, setResources] = useState<Resource[]>(
-    initial?.resources ?? []
-  );
   const [isSaving, setIsSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
-
-  const addResource = (_context: string, resource: Resource) =>
-    setResources(prev => [...prev, resource]);
-  const editResource = (_context: string, resource: Resource) =>
-    setResources(prev =>
-      prev.map(r => (r.key === resource.key ? resource : r))
-    );
-  const removeResource = (_context: string, key: string) =>
-    setResources(prev => prev.filter(r => r.key !== key));
 
   const save = () => {
     setIsSaving(true);
@@ -99,13 +104,10 @@ const MisconceptionForm: React.FC<MisconceptionFormProps> = ({
         markdown={textContent}
       />
       <h4 className={moduleStyles.resourcesHeading}>Resources</h4>
-      <UnconnectedResourcesEditor
+      <ResourcesEditor
         forJitPl
-        resourceContext="jitPlMisconceptionResource"
+        resourceContext={contextKey}
         resources={resources}
-        addResource={addResource}
-        editResource={editResource}
-        removeResource={removeResource}
       />
       <div className={moduleStyles.formButtons}>
         <button onClick={save} disabled={isSaving} type="button">

--- a/apps/src/levelbuilder/jit-pl-concepts-editor/MisconceptionsEditor.tsx
+++ b/apps/src/levelbuilder/jit-pl-concepts-editor/MisconceptionsEditor.tsx
@@ -1,32 +1,61 @@
 import $ from 'jquery';
-import PropTypes from 'prop-types';
 import React, {useState} from 'react';
 
 import {UnconnectedResourcesEditor} from '@cdo/apps/levelbuilder/lesson-editor/ResourcesEditor';
-import {resourceShape} from '@cdo/apps/levelbuilder/shapes';
 import TextareaWithMarkdownPreview from '@cdo/apps/levelbuilder/TextareaWithMarkdownPreview';
 
-const misconceptionShape = PropTypes.shape({
-  id: PropTypes.number.isRequired,
-  name: PropTypes.string,
-  text_content: PropTypes.string,
-  resources: PropTypes.arrayOf(resourceShape),
-});
+import moduleStyles from './misconceptionsEditor.module.scss';
 
-const MisconceptionForm = ({conceptId, initial, onSave, onCancel}) => {
-  const [name, setName] = useState(initial?.name || '');
-  const [textContent, setTextContent] = useState(initial?.text_content || '');
-  const [resources, setResources] = useState(initial?.resources || []);
+interface Resource {
+  id: number;
+  key: string;
+  name: string;
+  url: string;
+  type?: string;
+  audience?: string;
+  embeddabilityType?: string;
+  curriculumCategory?: string;
+  assessment?: boolean;
+  includeInPdf?: boolean;
+  downloadUrl?: string;
+  isRollup?: boolean;
+}
+
+interface Misconception {
+  id: number;
+  name?: string;
+  text_content?: string;
+  resources?: Resource[];
+}
+
+interface MisconceptionFormProps {
+  conceptId: number;
+  initial: Misconception | null;
+  onSave: (misconception: Misconception) => void;
+  onCancel: () => void;
+}
+
+const MisconceptionForm: React.FC<MisconceptionFormProps> = ({
+  conceptId,
+  initial,
+  onSave,
+  onCancel,
+}) => {
+  const [name, setName] = useState(initial?.name ?? '');
+  const [textContent, setTextContent] = useState(initial?.text_content ?? '');
+  const [resources, setResources] = useState<Resource[]>(
+    initial?.resources ?? []
+  );
   const [isSaving, setIsSaving] = useState(false);
-  const [error, setError] = useState(null);
+  const [error, setError] = useState<string | null>(null);
 
-  const addResource = (_context, resource) =>
+  const addResource = (_context: string, resource: Resource) =>
     setResources(prev => [...prev, resource]);
-  const editResource = (_context, resource) =>
+  const editResource = (_context: string, resource: Resource) =>
     setResources(prev =>
       prev.map(r => (r.key === resource.key ? resource : r))
     );
-  const removeResource = (_context, key) =>
+  const removeResource = (_context: string, key: string) =>
     setResources(prev => prev.filter(r => r.key !== key));
 
   const save = () => {
@@ -35,7 +64,7 @@ const MisconceptionForm = ({conceptId, initial, onSave, onCancel}) => {
     $.ajax({
       url: isNew
         ? `/jit_pl_concepts/${conceptId}/jit_pl_misconceptions`
-        : `/jit_pl_concepts/${conceptId}/jit_pl_misconceptions/${initial.id}`,
+        : `/jit_pl_concepts/${conceptId}/jit_pl_misconceptions/${initial!.id}`,
       method: isNew ? 'POST' : 'PUT',
       data: {
         name,
@@ -43,20 +72,20 @@ const MisconceptionForm = ({conceptId, initial, onSave, onCancel}) => {
         resource_ids: resources.map(r => r.id),
       },
     })
-      .done(data => onSave(data))
-      .fail(err => {
+      .done((data: Misconception) => onSave(data))
+      .fail((err: {responseText: string}) => {
         setIsSaving(false);
         setError(err.responseText);
       });
   };
 
   return (
-    <div style={styles.form}>
-      {error && <p style={styles.error}>{error}</p>}
-      <label style={styles.label}>
+    <div className={moduleStyles.form}>
+      {error && <p className={moduleStyles.error}>{error}</p>}
+      <label className={moduleStyles.label}>
         Name
         <input
-          style={styles.input}
+          className={moduleStyles.input}
           value={name}
           onChange={e => setName(e.target.value)}
         />
@@ -64,10 +93,12 @@ const MisconceptionForm = ({conceptId, initial, onSave, onCancel}) => {
       <TextareaWithMarkdownPreview
         name="text_content"
         label="Text Content"
-        handleMarkdownChange={e => setTextContent(e.target.value)}
+        handleMarkdownChange={(e: React.ChangeEvent<HTMLTextAreaElement>) =>
+          setTextContent(e.target.value)
+        }
         markdown={textContent}
       />
-      <h4 style={styles.resourcesHeading}>Resources</h4>
+      <h4 className={moduleStyles.resourcesHeading}>Resources</h4>
       <UnconnectedResourcesEditor
         forJitPl
         resourceContext="jitPlMisconceptionResource"
@@ -76,11 +107,15 @@ const MisconceptionForm = ({conceptId, initial, onSave, onCancel}) => {
         editResource={editResource}
         removeResource={removeResource}
       />
-      <div style={styles.formButtons}>
+      <div className={moduleStyles.formButtons}>
         <button onClick={save} disabled={isSaving} type="button">
           {isSaving ? 'Saving...' : 'Save'}
         </button>
-        <button onClick={onCancel} type="button" style={styles.cancelButton}>
+        <button
+          onClick={onCancel}
+          type="button"
+          className={moduleStyles.cancelButton}
+        >
           Cancel
         </button>
       </div>
@@ -88,17 +123,22 @@ const MisconceptionForm = ({conceptId, initial, onSave, onCancel}) => {
   );
 };
 
-MisconceptionForm.propTypes = {
-  conceptId: PropTypes.number.isRequired,
-  initial: misconceptionShape,
-  onSave: PropTypes.func.isRequired,
-  onCancel: PropTypes.func.isRequired,
-};
+interface MisconceptionItemProps {
+  misconception: Misconception;
+  conceptId: number;
+  onUpdate: (misconception: Misconception) => void;
+  onDelete: (id: number) => void;
+}
 
-const MisconceptionItem = ({misconception, conceptId, onUpdate, onDelete}) => {
+const MisconceptionItem: React.FC<MisconceptionItemProps> = ({
+  misconception,
+  conceptId,
+  onUpdate,
+  onDelete,
+}) => {
   const [isEditing, setIsEditing] = useState(false);
 
-  const handleSave = updated => {
+  const handleSave = (updated: Misconception) => {
     setIsEditing(false);
     onUpdate(updated);
   };
@@ -125,20 +165,20 @@ const MisconceptionItem = ({misconception, conceptId, onUpdate, onDelete}) => {
   }
 
   return (
-    <div style={styles.card}>
+    <div className={moduleStyles.card}>
       <strong>{misconception.name}</strong>
-      <div style={styles.cardActions}>
+      <div className={moduleStyles.cardActions}>
         <button
           onClick={() => setIsEditing(true)}
           type="button"
-          style={styles.editButton}
+          className={moduleStyles.editButton}
         >
           <i className="fa fa-edit" /> Edit
         </button>
         <button
           onClick={handleDelete}
           type="button"
-          style={styles.deleteButton}
+          className={moduleStyles.deleteButton}
         >
           <i className="fa fa-trash" /> Delete
         </button>
@@ -147,31 +187,32 @@ const MisconceptionItem = ({misconception, conceptId, onUpdate, onDelete}) => {
   );
 };
 
-MisconceptionItem.propTypes = {
-  misconception: misconceptionShape.isRequired,
-  conceptId: PropTypes.number.isRequired,
-  onUpdate: PropTypes.func.isRequired,
-  onDelete: PropTypes.func.isRequired,
-};
+interface MisconceptionsEditorProps {
+  conceptId: number;
+  initialMisconceptions?: Misconception[];
+}
 
-const MisconceptionsEditor = ({conceptId, initialMisconceptions}) => {
-  const [misconceptions, setMisconceptions] = useState(
-    initialMisconceptions || []
+const MisconceptionsEditor: React.FC<MisconceptionsEditorProps> = ({
+  conceptId,
+  initialMisconceptions,
+}) => {
+  const [misconceptions, setMisconceptions] = useState<Misconception[]>(
+    initialMisconceptions ?? []
   );
   const [isAdding, setIsAdding] = useState(false);
 
-  const handleAdd = created => {
+  const handleAdd = (created: Misconception) => {
     setMisconceptions(prev => [...prev, created]);
     setIsAdding(false);
   };
 
-  const handleUpdate = updated => {
+  const handleUpdate = (updated: Misconception) => {
     setMisconceptions(prev =>
       prev.map(m => (m.id === updated.id ? updated : m))
     );
   };
 
-  const handleDelete = id => {
+  const handleDelete = (id: number) => {
     setMisconceptions(prev => prev.filter(m => m.id !== id));
   };
 
@@ -197,88 +238,13 @@ const MisconceptionsEditor = ({conceptId, initialMisconceptions}) => {
         <button
           onClick={() => setIsAdding(true)}
           type="button"
-          style={styles.addButton}
+          className={moduleStyles.addButton}
         >
           + Add Misconception
         </button>
       )}
     </div>
   );
-};
-
-MisconceptionsEditor.propTypes = {
-  conceptId: PropTypes.number.isRequired,
-  initialMisconceptions: PropTypes.arrayOf(misconceptionShape),
-};
-
-const styles = {
-  form: {
-    border: '1px solid #ddd',
-    borderRadius: 4,
-    padding: 16,
-    marginBottom: 12,
-  },
-  label: {
-    display: 'flex',
-    flexDirection: 'column',
-    marginBottom: 10,
-  },
-  input: {
-    marginTop: 4,
-  },
-  resourcesHeading: {
-    marginTop: 12,
-    marginBottom: 6,
-  },
-  formButtons: {
-    marginTop: 12,
-    display: 'flex',
-    gap: 8,
-  },
-  cancelButton: {
-    marginLeft: 8,
-  },
-  error: {
-    color: 'red',
-  },
-  card: {
-    display: 'flex',
-    justifyContent: 'space-between',
-    alignItems: 'center',
-    border: '1px solid #ddd',
-    borderRadius: 4,
-    padding: '8px 12px',
-    marginBottom: 8,
-    background: '#fafafa',
-  },
-  cardActions: {
-    display: 'flex',
-    gap: 8,
-  },
-  editButton: {
-    background: '#337ab7',
-    color: 'white',
-    border: 'none',
-    borderRadius: 3,
-    padding: '4px 10px',
-    cursor: 'pointer',
-  },
-  deleteButton: {
-    background: '#d9534f',
-    color: 'white',
-    border: 'none',
-    borderRadius: 3,
-    padding: '4px 10px',
-    cursor: 'pointer',
-  },
-  addButton: {
-    background: '#eee',
-    border: '1px solid #ddd',
-    borderRadius: 3,
-    padding: 7,
-    marginTop: 8,
-    cursor: 'pointer',
-  },
 };
 
 export default MisconceptionsEditor;

--- a/apps/src/levelbuilder/jit-pl-concepts-editor/misconceptionsEditor.module.scss
+++ b/apps/src/levelbuilder/jit-pl-concepts-editor/misconceptionsEditor.module.scss
@@ -1,0 +1,78 @@
+.form {
+  border: 1px solid #ddd;
+  border-radius: 4px;
+  padding: 16px;
+  margin-bottom: 12px;
+}
+
+.label {
+  display: flex;
+  flex-direction: column;
+  margin-bottom: 10px;
+}
+
+.input {
+  margin-top: 4px;
+}
+
+.resourcesHeading {
+  margin-top: 12px;
+  margin-bottom: 6px;
+}
+
+.formButtons {
+  display: flex;
+  gap: 8px;
+  margin-top: 12px;
+}
+
+.cancelButton {
+  margin-left: 8px;
+}
+
+.error {
+  color: red;
+}
+
+.card {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  border: 1px solid #ddd;
+  border-radius: 4px;
+  padding: 8px 12px;
+  margin-bottom: 8px;
+  background: #fafafa;
+}
+
+.cardActions {
+  display: flex;
+  gap: 8px;
+}
+
+.editButton {
+  background: #337ab7;
+  color: white;
+  border: none;
+  border-radius: 3px;
+  padding: 4px 10px;
+  cursor: pointer;
+}
+
+.deleteButton {
+  background: #d9534f;
+  color: white;
+  border: none;
+  border-radius: 3px;
+  padding: 4px 10px;
+  cursor: pointer;
+}
+
+.addButton {
+  background: #eee;
+  border: 1px solid #ddd;
+  border-radius: 3px;
+  padding: 7px;
+  margin-top: 8px;
+  cursor: pointer;
+}

--- a/apps/src/sites/studio/pages/jit_pl_concepts/edit.js
+++ b/apps/src/sites/studio/pages/jit_pl_concepts/edit.js
@@ -14,7 +14,7 @@ $(document).ready(() => {
     resources: createResourcesReducer('jitPlConceptResource'),
   });
   const store = getStore();
-  const {id, name, display_name, text_content, resources} =
+  const {id, name, display_name, text_content, resources, misconceptions} =
     getScriptData('jitPlConcept');
 
   store.dispatch(initResources('jitPlConceptResource', resources || []));
@@ -26,6 +26,7 @@ $(document).ready(() => {
         originalName={name}
         originalDisplayName={display_name}
         originalTextContent={text_content}
+        originalMisconceptions={misconceptions || []}
       />
     </Provider>,
     document.getElementById('edit-jit-pl-concept')

--- a/dashboard/app/controllers/jit_pl_misconceptions_controller.rb
+++ b/dashboard/app/controllers/jit_pl_misconceptions_controller.rb
@@ -9,7 +9,7 @@ class JitPlMisconceptionsController < ApplicationController
     @misconception = @concept.jit_pl_misconceptions.new(misconception_params)
     if @misconception.save
       @misconception.resources = Resource.where(id: params[:resource_ids] || [])
-      @concept.write_serialization
+      @concept.reload.write_serialization
       render json: @misconception.serialize
     else
       render status: :bad_request, json: @misconception.errors
@@ -20,14 +20,14 @@ class JitPlMisconceptionsController < ApplicationController
   def update
     @misconception.update!(misconception_params)
     @misconception.resources = Resource.where(id: params[:resource_ids] || [])
-    @concept.write_serialization
+    @concept.reload.write_serialization
     render json: @misconception.serialize
   end
 
   # DELETE /jit_pl_concepts/:jit_pl_concept_id/jit_pl_misconceptions/:id
   def destroy
     @misconception.destroy!
-    @concept.write_serialization
+    @concept.reload.write_serialization
     render status: :ok, plain: "Destroyed JitPlMisconception #{@misconception.id}"
   end
 

--- a/dashboard/app/controllers/jit_pl_misconceptions_controller.rb
+++ b/dashboard/app/controllers/jit_pl_misconceptions_controller.rb
@@ -1,0 +1,49 @@
+class JitPlMisconceptionsController < ApplicationController
+  before_action :require_levelbuilder_mode_or_test_env
+  before_action :set_concept
+  before_action :set_misconception, only: [:update, :destroy]
+  authorize_resource
+
+  # POST /jit_pl_concepts/:jit_pl_concept_id/jit_pl_misconceptions
+  def create
+    @misconception = @concept.jit_pl_misconceptions.new(misconception_params)
+    if @misconception.save
+      @misconception.resources = Resource.where(id: params[:resource_ids] || [])
+      @concept.write_serialization
+      render json: @misconception.serialize
+    else
+      render status: :bad_request, json: @misconception.errors
+    end
+  end
+
+  # PUT /jit_pl_concepts/:jit_pl_concept_id/jit_pl_misconceptions/:id
+  def update
+    @misconception.update!(misconception_params)
+    @misconception.resources = Resource.where(id: params[:resource_ids] || [])
+    @concept.write_serialization
+    render json: @misconception.serialize
+  end
+
+  # DELETE /jit_pl_concepts/:jit_pl_concept_id/jit_pl_misconceptions/:id
+  def destroy
+    @misconception.destroy!
+    @concept.write_serialization
+    render status: :ok, plain: "Destroyed JitPlMisconception #{@misconception.id}"
+  end
+
+  private def set_concept
+    @concept = JitPlConcept.find(params[:jit_pl_concept_id])
+  rescue ActiveRecord::RecordNotFound
+    render :not_found
+  end
+
+  private def set_misconception
+    @misconception = @concept.jit_pl_misconceptions.find(params[:id])
+  rescue ActiveRecord::RecordNotFound
+    render :not_found
+  end
+
+  private def misconception_params
+    params.permit(:name, :text_content)
+  end
+end

--- a/dashboard/app/models/ability.rb
+++ b/dashboard/app/models/ability.rb
@@ -439,6 +439,7 @@ class Ability
         Rubric,
         DataDoc,
         JitPlConcept,
+        JitPlMisconception,
         CourseOffering,
         UnitGroup,
         Resource,

--- a/dashboard/app/models/jit_pl_concept.rb
+++ b/dashboard/app/models/jit_pl_concept.rb
@@ -31,6 +31,7 @@ class JitPlConcept < ApplicationRecord
       display_name: display_name,
       text_content: text_content,
       resources: resources.map(&:summarize_for_lesson_edit),
+      misconceptions: jit_pl_misconceptions.map(&:serialize),
     }
   end
 
@@ -47,6 +48,14 @@ class JitPlConcept < ApplicationRecord
                                                  text_content: text_content,
                                                  resources: resources.map {|r| {key: r.key, name: r.name, url: r.url, properties: r.properties.sort.to_h}},
                                                  jit_pl_concepts_resources: resources.map {|r| {seeding_key: {'concept.name' => name, 'resource.key' => r.key}}},
+                                                 misconceptions: jit_pl_misconceptions.map do |m|
+                                                   {
+                                                     name: m.name,
+                                                     text_content: m.text_content,
+                                                     resources: m.resources.map {|r| {key: r.key, name: r.name, url: r.url, properties: r.properties.sort.to_h}},
+                                                     jit_pl_misconceptions_resources: m.resources.map {|r| {seeding_key: {'misconception.name' => m.name, 'resource.key' => r.key}}},
+                                                   }
+                                                 end,
                                                }
                                               )
     )
@@ -73,6 +82,7 @@ class JitPlConcept < ApplicationRecord
       text_content: config['text_content'],
       resources: config['resources'] || [],
       jit_pl_concepts_resources: config['jit_pl_concepts_resources'] || [],
+      misconceptions: config['misconceptions'] || [],
     }
   end
 
@@ -93,6 +103,23 @@ class JitPlConcept < ApplicationRecord
 
     resource_keys = properties[:jit_pl_concepts_resources].map {|r| r['seeding_key']['resource.key']}
     concept.resources = Resource.where(key: resource_keys, course_version: jit_pl_course_version)
+
+    seeded_misconception_names = []
+    properties[:misconceptions].each do |m_data|
+      misconception = JitPlMisconception.find_or_initialize_by(name: m_data['name'], jit_pl_concept: concept)
+      misconception.update!(text_content: m_data['text_content'])
+      seeded_misconception_names << m_data['name']
+
+      (m_data['resources'] || []).each do |resource_data|
+        resource = Resource.find_or_initialize_by(key: resource_data['key'], course_version: jit_pl_course_version)
+        resource.update!(name: resource_data['name'], url: resource_data['url'], properties: resource_data['properties'])
+      end
+
+      m_resource_keys = (m_data['jit_pl_misconceptions_resources'] || []).map {|r| r['seeding_key']['resource.key']}
+      misconception.resources = Resource.where(key: m_resource_keys, course_version: jit_pl_course_version)
+    end
+
+    concept.jit_pl_misconceptions.where.not(name: seeded_misconception_names).destroy_all
 
     concept.id
   end

--- a/dashboard/app/models/jit_pl_misconception.rb
+++ b/dashboard/app/models/jit_pl_misconception.rb
@@ -24,4 +24,13 @@ class JitPlMisconception < ApplicationRecord
   serialized_attrs %w(
     text_content
   )
+
+  def serialize
+    {
+      id: id,
+      name: name,
+      text_content: text_content,
+      resources: resources.map(&:summarize_for_lesson_edit),
+    }
+  end
 end

--- a/dashboard/app/models/resource.rb
+++ b/dashboard/app/models/resource.rb
@@ -156,6 +156,9 @@ class Resource < ApplicationRecord
       scripts_to_serialize = lessons.map(&:script).concat(scripts).uniq
       scripts_to_serialize.each(&:write_script_json)
       unit_groups.each(&:write_serialization)
+      jit_pl_concepts_to_serialize = jit_pl_concepts.to_a +
+        jit_pl_misconceptions.map(&:jit_pl_concept)
+      jit_pl_concepts_to_serialize.uniq.each(&:write_serialization)
     end
   end
 

--- a/dashboard/config/routes.rb
+++ b/dashboard/config/routes.rb
@@ -556,6 +556,7 @@ Dashboard::Application.routes.draw do
     end
 
     resources :jit_pl_concepts, only: [:new, :create, :edit, :update, :destroy] do
+      resources :jit_pl_misconceptions, only: [:create, :update, :destroy]
       collection do
         get '/edit', to: 'jit_pl_concepts#edit_all', as: :edit_all
       end

--- a/dashboard/test/controllers/jit_pl_misconceptions_controller_test.rb
+++ b/dashboard/test/controllers/jit_pl_misconceptions_controller_test.rb
@@ -1,0 +1,118 @@
+require 'test_helper'
+
+class JitPlMisconceptionsControllerTest < ActionController::TestCase
+  include Devise::Test::ControllerHelpers
+
+  setup_all do
+    @levelbuilder = create(:levelbuilder)
+    @concept = create(:jit_pl_concept)
+    @misconception = create(:jit_pl_misconception, jit_pl_concept: @concept)
+  end
+
+  test_user_gets_response_for :create, params: -> {{jit_pl_concept_id: @concept.id, name: 'unique-name'}}, user: nil, response: :redirect, redirected_to: '/users/sign_in'
+  test_user_gets_response_for :create, params: -> {{jit_pl_concept_id: @concept.id, name: 'unique-name'}}, user: :student, response: :forbidden
+  test_user_gets_response_for :create, params: -> {{jit_pl_concept_id: @concept.id, name: 'unique-name'}}, user: :teacher, response: :forbidden
+
+  test_user_gets_response_for :update, method: :put, params: -> {{jit_pl_concept_id: @concept.id, id: @misconception.id}}, user: nil, response: :redirect, redirected_to: '/users/sign_in'
+  test_user_gets_response_for :update, method: :put, params: -> {{jit_pl_concept_id: @concept.id, id: @misconception.id}}, user: :student, response: :forbidden
+  test_user_gets_response_for :update, method: :put, params: -> {{jit_pl_concept_id: @concept.id, id: @misconception.id}}, user: :teacher, response: :forbidden
+
+  test_user_gets_response_for :destroy, method: :delete, params: -> {{jit_pl_concept_id: @concept.id, id: @misconception.id}}, user: nil, response: :redirect, redirected_to: '/users/sign_in'
+  test_user_gets_response_for :destroy, method: :delete, params: -> {{jit_pl_concept_id: @concept.id, id: @misconception.id}}, user: :student, response: :forbidden
+  test_user_gets_response_for :destroy, method: :delete, params: -> {{jit_pl_concept_id: @concept.id, id: @misconception.id}}, user: :teacher, response: :forbidden
+
+  test 'creating a misconception saves it and writes serialization' do
+    sign_in @levelbuilder
+    JitPlConcept.any_instance.expects(:write_serialization).once
+
+    post :create, params: {jit_pl_concept_id: @concept.id, name: 'new-misconception', text_content: 'Some text'}
+    assert_response :ok
+
+    data = JSON.parse(response.body)
+    assert_equal 'new-misconception', data['name']
+    assert_equal 'Some text', data['text_content']
+  end
+
+  test 'creating a misconception returns 400 when invalid' do
+    sign_in @levelbuilder
+    JitPlConcept.any_instance.stubs(:write_serialization)
+    JitPlMisconception.any_instance.stubs(:save).returns(false)
+
+    post :create, params: {jit_pl_concept_id: @concept.id, name: 'bad'}
+    assert_response :bad_request
+  end
+
+  test 'updating a misconception saves it and writes serialization' do
+    sign_in @levelbuilder
+    JitPlConcept.any_instance.expects(:write_serialization).once
+
+    put :update, params: {jit_pl_concept_id: @concept.id, id: @misconception.id, name: 'updated-name', text_content: 'Updated text'}
+    assert_response :ok
+
+    @misconception.reload
+    assert_equal 'updated-name', @misconception.name
+    assert_equal 'Updated text', @misconception.text_content
+  end
+
+  test 'update returns serialized misconception as JSON' do
+    sign_in @levelbuilder
+    JitPlConcept.any_instance.stubs(:write_serialization)
+
+    put :update, params: {jit_pl_concept_id: @concept.id, id: @misconception.id, name: 'renamed'}
+    assert_response :ok
+
+    data = JSON.parse(response.body)
+    assert_equal @misconception.id, data['id']
+    assert_equal 'renamed', data['name']
+  end
+
+  test 'resources are saved when updating a misconception' do
+    sign_in @levelbuilder
+    JitPlConcept.any_instance.stubs(:write_serialization)
+    resource = create(:resource)
+
+    put :update, params: {jit_pl_concept_id: @concept.id, id: @misconception.id, resource_ids: [resource.id]}
+    assert_response :ok
+
+    @misconception.reload
+    assert_equal [resource.id], @misconception.resources.map(&:id)
+  end
+
+  test 'resources are removed when updating with empty resource_ids' do
+    sign_in @levelbuilder
+    JitPlConcept.any_instance.stubs(:write_serialization)
+    resource = create(:resource)
+    @misconception.resources << resource
+
+    put :update, params: {jit_pl_concept_id: @concept.id, id: @misconception.id, resource_ids: []}
+    assert_response :ok
+
+    @misconception.reload
+    assert_empty @misconception.resources
+  end
+
+  test 'destroying a misconception deletes it and writes serialization' do
+    sign_in @levelbuilder
+    JitPlConcept.any_instance.expects(:write_serialization).once
+    misconception_to_delete = create(:jit_pl_misconception, jit_pl_concept: @concept)
+
+    delete :destroy, params: {jit_pl_concept_id: @concept.id, id: misconception_to_delete.id}
+    assert_response :ok
+
+    assert_raises ActiveRecord::RecordNotFound do
+      misconception_to_delete.reload
+    end
+  end
+
+  test 'returns 404 when concept not found' do
+    sign_in @levelbuilder
+    post :create, params: {jit_pl_concept_id: 0, name: 'x'}
+    assert_response :not_found
+  end
+
+  test 'returns 404 when misconception not found' do
+    sign_in @levelbuilder
+    put :update, params: {jit_pl_concept_id: @concept.id, id: 0}
+    assert_response :not_found
+  end
+end

--- a/dashboard/test/factories/curriculum_factories.rb
+++ b/dashboard/test/factories/curriculum_factories.rb
@@ -22,4 +22,10 @@ FactoryBot.define do
     sequence(:display_name) {|n| "JIT PL Concept #{n}"}
     text_content {"Some concept text content"}
   end
+
+  factory :jit_pl_misconception do
+    association :jit_pl_concept
+    sequence(:name) {|n| "jit-pl-misconception-#{n}"}
+    text_content {"Some misconception text content"}
+  end
 end

--- a/dashboard/test/models/jit_pl_concept_test.rb
+++ b/dashboard/test/models/jit_pl_concept_test.rb
@@ -115,6 +115,59 @@ class JitPlConceptTest < ActiveSupport::TestCase
     assert_equal 'my-resource', properties[:jit_pl_concepts_resources].first['seeding_key']['resource.key']
   end
 
+  test "serialize includes misconceptions" do
+    concept = create(:jit_pl_concept)
+    misconception = create(:jit_pl_misconception, jit_pl_concept: concept, name: 'bad-idea', text_content: 'Wrong.')
+
+    serialized = concept.serialize
+    assert_equal 1, serialized[:misconceptions].length
+    assert_equal misconception.id, serialized[:misconceptions].first[:id]
+    assert_equal 'bad-idea', serialized[:misconceptions].first[:name]
+    assert_equal 'Wrong.', serialized[:misconceptions].first[:text_content]
+  end
+
+  test "seed_record creates misconceptions from file" do
+    concept = create(:jit_pl_concept, name: 'functions')
+    data = {
+      name: 'functions',
+      display_name: 'Functions',
+      text_content: 'Reusable code.',
+      resources: [],
+      jit_pl_concepts_resources: [],
+      misconceptions: [
+        {name: 'bad-idea', text_content: 'Wrong.', resources: [], jit_pl_misconceptions_resources: []}
+      ]
+    }
+
+    File.stubs(:read).returns(data.to_json)
+
+    JitPlConcept.seed_record('config/jit_pl_concepts/functions.json')
+
+    concept.reload
+    assert_equal 1, concept.jit_pl_misconceptions.count
+    assert_equal 'bad-idea', concept.jit_pl_misconceptions.first.name
+  end
+
+  test "seed_record removes misconceptions absent from file" do
+    concept = create(:jit_pl_concept, name: 'loops')
+    _to_remove = create(:jit_pl_misconception, jit_pl_concept: concept, name: 'old-idea')
+    data = {
+      name: 'loops',
+      display_name: 'Loops',
+      text_content: 'Repeating.',
+      resources: [],
+      jit_pl_concepts_resources: [],
+      misconceptions: []
+    }
+
+    File.stubs(:read).returns(data.to_json)
+
+    JitPlConcept.seed_record('config/jit_pl_concepts/loops.json')
+
+    concept.reload
+    assert_empty concept.jit_pl_misconceptions
+  end
+
   test "seed_all removes concepts with no corresponding file" do
     concept_to_keep = create(:jit_pl_concept)
     concept_to_remove = create(:jit_pl_concept)

--- a/dashboard/test/models/jit_pl_misconception_test.rb
+++ b/dashboard/test/models/jit_pl_misconception_test.rb
@@ -1,0 +1,37 @@
+require 'test_helper'
+
+class JitPlMisconceptionTest < ActiveSupport::TestCase
+  test "can create jit pl misconception" do
+    misconception = create(:jit_pl_misconception)
+    assert misconception.name
+    assert misconception.jit_pl_concept
+  end
+
+  test "serialize returns correct hash" do
+    concept = create(:jit_pl_concept)
+    misconception = create(:jit_pl_misconception, jit_pl_concept: concept, name: 'bad-idea', text_content: 'This is wrong.')
+
+    serialized = misconception.serialize
+    assert_equal misconception.id, serialized[:id]
+    assert_equal 'bad-idea', serialized[:name]
+    assert_equal 'This is wrong.', serialized[:text_content]
+    assert_equal [], serialized[:resources]
+  end
+
+  test "serialize includes associated resources" do
+    misconception = create(:jit_pl_misconception)
+    resource = create(:resource, name: 'My Resource')
+    misconception.resources << resource
+
+    serialized = misconception.serialize
+    assert_equal 1, serialized[:resources].length
+    assert_equal resource.id, serialized[:resources].first[:id]
+  end
+
+  test "text_content is stored in properties" do
+    misconception = create(:jit_pl_misconception, text_content: 'Some content')
+    misconception.reload
+    assert_equal 'Some content', misconception.text_content
+    assert_equal 'Some content', misconception.properties['text_content']
+  end
+end

--- a/dashboard/test/models/resource_test.rb
+++ b/dashboard/test/models/resource_test.rb
@@ -132,6 +132,39 @@ class ResourceTest < ActiveSupport::TestCase
     resource.serialize_scripts
   end
 
+  test 'serialize_scripts writes serialization for attached jit pl concepts' do
+    Rails.application.config.stubs(:levelbuilder_mode).returns true
+    concept = create(:jit_pl_concept)
+    resource = create(:resource)
+    concept.resources << resource
+
+    JitPlConcept.any_instance.expects(:write_serialization).once
+    resource.serialize_scripts
+  end
+
+  test 'serialize_scripts writes serialization for concepts attached via misconception' do
+    Rails.application.config.stubs(:levelbuilder_mode).returns true
+    concept = create(:jit_pl_concept)
+    misconception = create(:jit_pl_misconception, jit_pl_concept: concept)
+    resource = create(:resource)
+    misconception.resources << resource
+
+    JitPlConcept.any_instance.expects(:write_serialization).once
+    resource.serialize_scripts
+  end
+
+  test 'serialize_scripts writes serialization once for a concept attached both directly and via misconception' do
+    Rails.application.config.stubs(:levelbuilder_mode).returns true
+    concept = create(:jit_pl_concept)
+    misconception = create(:jit_pl_misconception, jit_pl_concept: concept)
+    resource = create(:resource)
+    concept.resources << resource
+    misconception.resources << resource
+
+    JitPlConcept.any_instance.expects(:write_serialization).once
+    resource.serialize_scripts
+  end
+
   test 'creates new resource when copying to a course version without a matching resource' do
     course_version = create(:course_version)
     resource = create(:resource, name: 'Fake Handout', url: 'handout.fake', course_version: course_version)


### PR DESCRIPTION
This extends my previous PR #71499 to allow Misconceptions to be added to Concepts. A new "Misconceptions" section is added to the Concept edit page. Each Misconception may have Resources attached. These Misconceptions are supported in seeding as part of the parent Concept's JSON file.

Screenshot:
<img width="1025" height="844" alt="image" src="https://github.com/user-attachments/assets/4cc453d1-ef8b-4216-a202-17a6fac3029c" />

## Links
[Shaping notes](https://docs.google.com/document/d/1ujBIOA3juQyZVvHGPINYSlW4a8qRBMrILPBuBFL67Fc/edit?tab=t.0#heading=h.ve4hvhc3rrvg)
Data model PR: #71132 

## Testing story
Unit tests have been added to the new backend functionality. I also performed an end-to-end test creating Concepts with Misconceptions through the UI, deleting them from the database, and then re-seeding them to make sure they came back as expected.



## Deployment notes
<!-- Delete this section if it's a standard merge-and-deploy.
     Otherwise: migrations, feature flags, coordination, caching impacts, etc. -->



## Privacy and security
<!-- Delete this section if there is no privacy/security impact.
     Otherwise: new PII, auth changes, API surface changes, etc. -->

