### PR TITLE
Fix instructions drawer not restored to full height with React 18

### DIFF
--- a/apps/src/lab2/views/components/Instructions/ResourcePanel/AiTutorChatWithInstructionsDrawer/AiTutorChatWithInstructionDrawer.tsx
+++ b/apps/src/lab2/views/components/Instructions/ResourcePanel/AiTutorChatWithInstructionsDrawer/AiTutorChatWithInstructionDrawer.tsx
@@ -141,13 +141,6 @@ const AiTutorChatWithInstructionDrawer: React.FunctionComponent<
     setIsCollapsed(isCollapsedByDefault);
   }, [isCollapsedByDefault]);
 
-  // Reset so that when drawer is expanded again, we set height from content.
-  useEffect(() => {
-    if (isCollapsed) {
-      hasSetInitialHeightFromContentRef.current = false;
-    }
-  }, [isCollapsed]);
-
   // Keep ref in sync with current height.
   useEffect(() => {
     rawInstructionsHeightRef.current = rawInstructionsHeight;
@@ -157,8 +150,11 @@ const AiTutorChatWithInstructionDrawer: React.FunctionComponent<
   // (e.g., details elements expanded/collapsed), and set the drawer height to match.
   useEffect(() => {
     // Skip if instructions drawer is collapsed (unmounted).
+    // Reset the flag in cleanup so the next expand always restores full height.
     if (isCollapsed) {
-      return;
+      return () => {
+        hasSetInitialHeightFromContentRef.current = false;
+      };
     }
 
     const instructionsContentElement = instructionsContentRef.current;
@@ -200,6 +196,8 @@ const AiTutorChatWithInstructionDrawer: React.FunctionComponent<
 
     return () => {
       resizeObserver.disconnect();
+      // Reset so the next expand always restores full height from content.
+      hasSetInitialHeightFromContentRef.current = false;
     };
   }, [setRawInstructionsHeight, isCollapsed]);
 


### PR DESCRIPTION
This PR fixes a regression in the Web Lab 2 AI Tutor instructions drawer after the upgrade to React 18. If a user collapses the instructions drawer, when they click to expand, the drawer does not expand to full height.

The root cause appears to be that in React 18, `useEffect` fires synchronously when it's the result of a discrete input. https://github.com/reactwg/react-18/discussions/128 "A discrete input is a type of event where the result of one event can affect the behavior of the next, like clicks or presses. Multiple discrete events cannot be batched or throttled without affecting program behavior."

I used Claude Sonnet 4.6 to implement this fix and help me understand why this bug manifests in React 18 but not in React 17. It took quite a lot of (re-)prompting to get to what seems to be the root cause. Interestingly, it initially took ~20 min to come up with fix (usually responses takes <1-3 min) and additional time with lots of iteration with responses that include:

<img width="631" height="54" alt="Screenshot 2026-03-26 at 8 04 19 AM" src="https://github.com/user-attachments/assets/78e01647-786d-4b4c-b0ba-ec4fb58bd7cd" />

<img width="623" height="60" alt="Screenshot 2026-03-26 at 8 04 05 AM" src="https://github.com/user-attachments/assets/9ee29287-56b5-451b-8271-60184aa6a8db" />
😆 


BEFORE this PR update (currently on `prod`):

In React 17, when the user collapses the instructions drawer, and then clicks on expand:
1. React updates DOM (instructions drawer mounts with height: 0, button text changes to "Hide Instructions")
2. Browser paints — user sees the button change but drawer is invisible (height: 0)
3. Effect at https://github.com/code-dot-org/code-dot-org/blob/4bad661828611c29119c1fee29beb0bc5444a2fe/apps/src/lab2/views/components/Instructions/ResourcePanel/AiTutorChatWithInstructionsDrawer/AiTutorChatWithInstructionDrawer.tsx#L158  runs (after paint): calls updateMaxHeight() -> calls `setRawInstructionsHeight(fullHeight)` at https://github.com/code-dot-org/code-dot-org/blob/4bad661828611c29119c1fee29beb0bc5444a2fe/apps/src/lab2/views/components/Instructions/ResourcePanel/AiTutorChatWithInstructionsDrawer/AiTutorChatWithInstructionDrawer.tsx#L177, sets flag to true, then sets up `ResizeObserver`
4. `setRawInstructionsHeight` triggers a re-render -> `rawInstructionsHeight` updates -> effect at https://github.com/code-dot-org/code-dot-org/blob/4bad661828611c29119c1fee29beb0bc5444a2fe/apps/src/lab2/views/components/Instructions/ResourcePanel/AiTutorChatWithInstructionsDrawer/AiTutorChatWithInstructionDrawer.tsx#L152 runs and syncs `rawInstructionsHeightRef.current` to the new value → `adjustChatHeight` runs and sets `instructionsHeight` to correct value
5. Browser paints again - user now sees the drawer at full height
6. Next browser frame: `ResizeObserver`'s initial callback fires ->  `rawInstructionsHeightRef.current` is already up to date ->  else branch runs correctly 

The key is that the `ResizeObserver `is only set up in step 3 (after the first paint). So its initial callback can't fire until step 6 (the next frame), by which point step 4 has already completed and the ref is synced.

In React 18, when the expand is triggered by a click (a "discrete input"):
1. React updates DOM (instructions drawer mounts with height: 0, button text changes to "Hide Instructions")

2. Effect at line 158 runs synchronously before the browser paints (React 18 change for clicks):
Calls `updateMaxHeight()`
`hasSetInitialHeightFromContentRef.current = false` -> queues `setRawInstructionsHeight(fullHeight)` at line 177
Sets `hasSetInitialHeightFromContentRef.current = true`
Sets up `ResizeObserver` (`.observe()` called)

3. Browser layout step runs (before paint) -> `ResizeObserver`'s initial callback fires immediately in this same frame:
`hasSetInitialHeightFromContentRef.current = true` -> goes to else branch
`rawInstructionsHeightRef.current` is stale (the `setRawInstructionsHeight` from step 2 hasn't been applied yet - it's still queued)
`contentHeight < currentHeight` (`currentHeight` assigned stale ref `rawInstructionsHeightRef.current`) is `false` -> does nothing

4. Browser paints - user sees drawer still at height: 0 (or wrong height)

5. Queued `setRawInstructionsHeight(fullHeight)` finally applies -> re-render -> `rawInstructionsHeight` changes 
-> `adjustChatHeight runs` -> ResizeObserver fires again because drawer size changed -> more competing state updates -> cascade of renders that settle at the wrong height (~16px)

The core problem: in step 2 the effect runs before paint, but the state update it queues doesn't apply until after paint (step 5). The ResizeObserver fires in between (step 3) with stale data.

This PR moves the  resetting of `hasSetInitialHeightFromContentRef.current = false` to the effect cleanup, so it runs synchronously when the drawer closes - before any new effect setup can run on the next expand. 
This guarantees that when `updateMaxHeight` executes on expand, `hasSetInitialHeightFromContentRef.current` is always `false` and it hits the `!hasSetInitialHeightFromContentRef.current` branch and calls `setRawInstructionsHeight(fullHeight)` - much more simple.

## Before update

https://github.com/user-attachments/assets/86b8991d-e56e-4429-8a34-d324bcca13c0


## After update



https://github.com/user-attachments/assets/578a2834-6d96-4d56-8107-a18aee8d1fa6



<!--
  Summary of the change: background, motivation, and context.
  Include screenshots, videos, or before/after comparisons for UI changes.
-->



## Links
<!-- Jira tickets, design docs, Slack threads, related PRs, etc. -->

- Jira: https://codedotorg.atlassian.net/browse/AFL-537

## Testing story
<!-- How was this tested? Manual steps, adhoc links, automated tests, or why testing isn't needed. -->

Tested locally and see that update fixes issue.

## Deployment notes
<!-- Delete this section if it's a standard merge-and-deploy.
     Otherwise: migrations, feature flags, coordination, caching impacts, etc. -->



## Privacy and security
<!-- Delete this section if there is no privacy/security impact.
     Otherwise: new PII, auth changes, API surface changes, etc. -->

