### PR TITLE
update lesson extras ui test to use ui-test-csf

### DIFF
--- a/dashboard/test/ui/config/scripts_json/ui-test-csf.script_json
+++ b/dashboard/test/ui/config/scripts_json/ui-test-csf.script_json
@@ -5,11 +5,12 @@
     "login_required": false,
     "properties": {
       "curriculum_umbrella": "CSF",
-      "is_migrated": true
+      "is_migrated": true,
+      "lesson_extras_available": true
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2026-03-25 02:51:33 UTC",
+    "serialized_at": "2026-03-25 22:44:56 UTC",
     "hide_within_course": false,
     "published_state": "in_development",
     "instruction_type": null,
@@ -117,6 +118,27 @@
       "level_keys": [
         "contained_single_multi"
       ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "activity_section_position": 3,
+      "assessment": false,
+      "properties": {
+      },
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Standalone_Artist_9"
+        ],
+        "lesson.key": "lesson-1",
+        "lesson_group.key": "",
+        "script.name": "ui-test-csf",
+        "activity_section.key": "2dda9127-3cc5-4874-b697-59af6f22da1e"
+      },
+      "level_keys": [
+        "Standalone_Artist_9"
+      ]
     }
   ],
   "levels_script_levels": [
@@ -137,6 +159,18 @@
         "level.key": "contained_single_multi",
         "script_level.level_keys": [
           "contained_single_multi"
+        ],
+        "lesson.key": "lesson-1",
+        "lesson_group.key": "",
+        "script.name": "ui-test-csf",
+        "activity_section.key": "2dda9127-3cc5-4874-b697-59af6f22da1e"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Standalone_Artist_9",
+        "script_level.level_keys": [
+          "Standalone_Artist_9"
         ],
         "lesson.key": "lesson-1",
         "lesson_group.key": "",

--- a/dashboard/test/ui/features/teacher_tools/lesson_extras_teacher_panel.feature
+++ b/dashboard/test/ui/features/teacher_tools/lesson_extras_teacher_panel.feature
@@ -8,7 +8,7 @@ Feature: Lesson extras teacher panel
     Then I save the section id from row 0 of the section table
 
     # Lesson extras overview page
-    Then I navigate to the course "coursea-2019" unit 1 lesson 12 lesson extras page for the section I saved
+    Then I navigate to the course "ui-test-csf" unit 1 lesson 1 lesson extras page for the section I saved
     And I wait until element "#teacher-panel-container" is visible
     And check that the URL contains "section_id="
     And I wait until element ".uitest-sectionselect:contains(Untitled Section)" is visible

--- a/lib/rake/ci.rake
+++ b/lib/rake/ci.rake
@@ -126,7 +126,7 @@ namespace :ci do
     end
     RakeUtils.wait_for_url('http://localhost-studio.code.org:3000')
     Dir.chdir('dashboard/test/ui') do
-      container_features = `find ./features -name 'lesson_extras_teacher_panel.feature' | sort`.split("\n").map {|f| f[2..]}
+      container_features = `find ./features -name '*.feature' | sort`.split("\n").map {|f| f[2..]}
       eyes_features = `grep -lr '@eyes' features`.split("\n")
       container_eyes_features = container_features & eyes_features
       # Use --local to configure the UI tests to run against localhost and

--- a/lib/rake/ci.rake
+++ b/lib/rake/ci.rake
@@ -126,7 +126,7 @@ namespace :ci do
     end
     RakeUtils.wait_for_url('http://localhost-studio.code.org:3000')
     Dir.chdir('dashboard/test/ui') do
-      container_features = `find ./features -name '*.feature' | sort`.split("\n").map {|f| f[2..]}
+      container_features = `find ./features -name 'lesson_extras_teacher_panel.feature' | sort`.split("\n").map {|f| f[2..]}
       eyes_features = `grep -lr '@eyes' features`.split("\n")
       container_eyes_features = container_features & eyes_features
       # Use --local to configure the UI tests to run against localhost and


### PR DESCRIPTION
Moves lesson extras ui test off of coursea and onto ui-test-csf.

## Testing story

drone provides adequate coverage of ui-test-only change