### PR TITLE
remove course A from catalog ui tests

### DIFF
--- a/dashboard/lib/tasks/seed.rake
+++ b/dashboard/lib/tasks/seed.rake
@@ -497,6 +497,7 @@ namespace :seed do
   timed_task_with_logging course_offerings_ui_tests: :environment do
     %w(
       ui-test-artist
+      ui-test-csf
       ui-test-course
       ui-test-csa-family-script
       ui-test-original-course

--- a/dashboard/test/ui/config/course_offerings/ui-test-csf.json
+++ b/dashboard/test/ui/config/course_offerings/ui-test-csf.json
@@ -12,10 +12,10 @@
   "school_subject": null,
   "device_compatibility": "{\"computer\":\"ideal\",\"chromebook\":\"not_recommended\",\"tablet\":\"not_recommended\",\"mobile\":\"incompatible\",\"no_device\":\"incompatible\"}",
   "description": null,
-  "professional_learning_program": null,
+  "professional_learning_program": "https://code.org/professional-development-workshops",
   "video": null,
   "published_date": null,
-  "self_paced_pl_course_offering_key": null,
+  "self_paced_pl_course_offering_key": "k5-onlinepd",
   "ai_teaching_assistant_available": false,
   "facilitator_course_permissions": [
 

--- a/dashboard/test/ui/config/course_offerings/ui-test-csf.json
+++ b/dashboard/test/ui/config/course_offerings/ui-test-csf.json
@@ -1,11 +1,11 @@
 {
   "key": "ui-test-csf",
-  "display_name": "ui-test-csf",
+  "display_name": "UI Test CSF",
   "is_featured": false,
   "assignable": true,
   "curriculum_type": "Course",
   "marketing_initiative": "CSF",
-  "grade_levels": null,
+  "grade_levels": "K",
   "header": null,
   "image": null,
   "cs_topic": null,

--- a/dashboard/test/ui/features/acquisition_products/curriculum_catalog.feature
+++ b/dashboard/test/ui/features/acquisition_products/curriculum_catalog.feature
@@ -53,9 +53,9 @@ Feature: Curriculum Catalog Page
   @no_mobile
   Scenario: Signed-out user can navigate to facilitator led workshop through expanded card
     Given I am on "http://studio.code.org/catalog"
-    And I wait until element "h4:contains(CS Fundamentals: Course A)" is visible
+    And I wait until element "h4:contains(UI Test CSF)" is visible
 
-    And I click selector "[aria-label='View details about CS Fundamentals: Course A']"
+    And I click selector "[aria-label='View details about UI Test CSF']"
     Then I wait until element "a:contains(Facilitator led workshops)" is visible
     And I click selector "a:contains(Facilitator led workshops)"
     Then I wait for jquery to load
@@ -65,17 +65,17 @@ Feature: Curriculum Catalog Page
   Scenario: On expanded card, Signed-in teacher sees professional learning section
     Given I create a teacher named "Teacher Tom"
     Given I am on "http://studio.code.org/catalog"
-    And I wait until element "h4:contains(CS Fundamentals: Course A)" is visible
-    And I click selector "[aria-label='View details about CS Fundamentals: Course A']"
-    And I scroll the "h4:contains(CS Fundamentals: Course A)" element into view
+    And I wait until element "h4:contains(UI Test CSF)" is visible
+    And I click selector "[aria-label='View details about UI Test CSF']"
+    And I scroll the "h4:contains(UI Test CSF)" element into view
     And I wait until element "h4:contains(Professional Learning)" is visible
 
   @no_mobile
   Scenario: On expanded card, Signed-in student does not see professional learning section
     Given I create a student named "Student Sam"
     Given I am on "http://studio.code.org/catalog"
-    And I wait until element "h4:contains(CS Fundamentals: Course A)" is visible
-    And I click selector "[aria-label='View details about CS Fundamentals: Course A']"
+    And I wait until element "h4:contains(UI Test CSF)" is visible
+    And I click selector "[aria-label='View details about UI Test CSF']"
     And I wait until element "h4:contains(Professional Learning)" is not visible
 
   # Expanded Card Assign button scenarios


### PR DESCRIPTION
As part of the effort to remove ui test dependencies on production courses, this PR makes catalog UI tests depend on ui-test-csf instead of coursea. For background, see: [partitioned curriculum data proposal](https://docs.google.com/document/d/1iiJXtPODakjuZ7-2yKJ941H56dcyUmUFtWa7zGgqKdw/edit?tab=t.0#heading=h.qx67631q1z2d)

Done in this PR:
- fix up the course offering for `ui-test-csf` so that it is properly seeded in test, appears in the catalog, and links to PL
- update the existing curriculum catalog scenarios to use ui-test-csf rather than coursea

## Testing story
- I am mostly relying on drone for coverage of the ui tests affected by this change
- there will probably also be some diffs in the catalog UI tests during DTT, as this PR should cause UI Test CSF to start appearing in the catalog