### PR TITLE
Stop seeding courses A, B, C in ui tests + add null checks to catalog card

### DIFF
--- a/apps/src/templates/curriculumCatalog/CurriculumCatalog.jsx
+++ b/apps/src/templates/curriculumCatalog/CurriculumCatalog.jsx
@@ -108,15 +108,15 @@ const CurriculumCatalog = ({
       getRecommendedSimilarCurriculum(key);
     const newRecommendedStretchCurriculum = getRecommendedStretchCurriculum(
       key,
-      newRecommendedSimilarCurriculum.key
+      newRecommendedSimilarCurriculum?.key
     );
 
     analyticsReporter.sendEvent(EVENTS.RECOMMENDED_CATALOG_CURRICULUM_SHOWN, {
       current_curriculum_offering: key,
       recommended_similar_curriculum_offering:
-        newRecommendedSimilarCurriculum.key,
+        newRecommendedSimilarCurriculum?.key,
       recommended_stretch_curriculum_offering:
-        newRecommendedStretchCurriculum.key,
+        newRecommendedStretchCurriculum?.key,
     });
 
     setRecommendedSimilarCurriculum(newRecommendedSimilarCurriculum);
@@ -177,7 +177,7 @@ const CurriculumCatalog = ({
       curriculaTaught
     );
     const recommendedCurriculum =
-      similarCurriculumKey === recommendations[0].key
+      similarCurriculumKey === recommendations[0]?.key
         ? recommendations[1]
         : recommendations[0];
 

--- a/apps/src/templates/curriculumCatalog/ExpandedCurriculumCatalogCard.jsx
+++ b/apps/src/templates/curriculumCatalog/ExpandedCurriculumCatalogCard.jsx
@@ -363,19 +363,25 @@ const ExpandedCurriculumCatalogCard = ({
                     href={`#${curriculumCatalogCardIdPrefix}${recommendedSimilarCurriculum.key}`}
                     onClick={handleClickRecommendedSimilarCurriculum}
                   />
-                  <img
-                    id="stretchCurriculumImage"
-                    src={recommendedStretchCurriculum.image || defaultImageSrc}
-                    alt={recommendedStretchCurriculum.display_name}
-                  />
-                  <Link
-                    id="stretchCurriculumButton"
-                    name={recommendedStretchCurriculum.display_name}
-                    className={style.relatedCurriculaLink}
-                    text={recommendedStretchCurriculum.display_name}
-                    href={`#${curriculumCatalogCardIdPrefix}${recommendedStretchCurriculum.key}`}
-                    onClick={handleClickRecommendedStretchCurriculum}
-                  />
+                  {recommendedStretchCurriculum && (
+                    <>
+                      <img
+                        id="stretchCurriculumImage"
+                        src={
+                          recommendedStretchCurriculum.image || defaultImageSrc
+                        }
+                        alt={recommendedStretchCurriculum.display_name}
+                      />
+                      <Link
+                        id="stretchCurriculumButton"
+                        name={recommendedStretchCurriculum.display_name}
+                        className={style.relatedCurriculaLink}
+                        text={recommendedStretchCurriculum.display_name}
+                        href={`#${curriculumCatalogCardIdPrefix}${recommendedStretchCurriculum.key}`}
+                        onClick={handleClickRecommendedStretchCurriculum}
+                      />
+                    </>
+                  )}
                 </div>
               )}
             </div>

--- a/dashboard/lib/tasks/seed.rake
+++ b/dashboard/lib/tasks/seed.rake
@@ -81,11 +81,6 @@ namespace :seed do
     allthethings
     allthettsthings
     artist
-    coursea-2017
-    courseb-2017
-    coursec-2017
-    coursea-2019
-    coursec-2019
     csd3-2023
     interactive-games-animations-2023
     focus-on-creativity3-2023
@@ -303,11 +298,6 @@ namespace :seed do
        alltheselfpacedplthings
        allthettsthings
        artist
-       coursea-2017
-       courseb-2017
-       coursec-2017
-       coursea-2019
-       coursec-2019
        csp-ap
        interactive-games-animations-2023
        interactive-games-animations-2024


### PR DESCRIPTION
A few recent PRs have moved ui tests off of CSF courses A, B, C. this PR stops seeding those courses in ui tests, and then fixes one issue with the curriculum catalog tests which was exposed by the disappearing units.

## Testing story
- no immediate eyes diffs for removing units because these units will temporarily remain in the ui test DB on the test machine
- `[reset db]` commit tag ensures that UI tests run against a DB that is generated from scratch, without pulling in courses A, B, C from the drone cache

## Deployment notes
- after merging, remove CSF courses / units from the database on the test machine, which will cause diffs in the curriculum catalog eyes tests when Courses A-F disappear from there.