### PR TITLE
weblab1 server: refuse to save `on*` attrs

### DIFF
--- a/dashboard/legacy/middleware/files_api.rb
+++ b/dashboard/legacy/middleware/files_api.rb
@@ -363,7 +363,13 @@ class FilesApi < Sinatra::Base
       '//' + tag_dup
     end
 
-    Nokogiri::HTML(body).xpath(*disallowed_tag_selectors).empty?
+    # no HTML event handler attributes (on*), e.g. onclick, onsubmit, etc
+    disallow_on_attrs_selector = '//*[@*[starts-with(name(), "on")]]'
+
+    Nokogiri::HTML(body).xpath(
+      *disallowed_tag_selectors,
+      disallow_on_attrs_selector,
+    ).empty?
   end
 
   # Determine whether or not a file is a valid HTML file.

--- a/dashboard/legacy/test/middleware/test_files.rb
+++ b/dashboard/legacy/test/middleware/test_files.rb
@@ -921,3 +921,14 @@ class FilesTest < FilesApiTestBase
     delete_all_file_versions 'manifest.json'
   end
 end
+
+class FilesApiHtmlValidationTest < Minitest::Test
+  def test_valid_html_content_disallows_on_attrs
+    DCDO.stubs(:get).with('disallowed_html_tags', []).returns(['script', 'meta[http-equiv]'])
+
+    api = FilesApi.allocate
+
+    assert api.valid_html_content?('<div></div>')
+    refute api.valid_html_content?('<button onclick="alert(1)">Click me</button>')
+  end
+end


### PR DESCRIPTION
# Math time is over 🧮

I believe that, combined with tracking down and deleting the existing "bad weblab1 projects" (see: [#71689 for a batch search and destroy script](https://github.com/code-dot-org/code-dot-org/pull/71689) which can be run after this is merged), this change will prevent weblab1 from being an issue until it is deprecated in a year.  It prevents new "math homework" style exploits from being saved.

Its not as profound as a modern CSP approach, which would apply instantly w/o filtering existing projects, but it also doesn't require modifying legacy code that a CSP would break. This lets us get back to focusing on new feature work (your move degens).

## Technical details

HTML event handler attributes (onclick, onsubmit, etc etc) in weblab1 provide an easy way to run javascript. I have no idea why we blocked script tags back in the day, but not these. There's more than a 100 `on*` handlers, so rather than listing them, this PR blocks all attrs starting with `on`. I couldn't find a single valid (non script running) attribute this blocks.

## Impementation notes

1) This PR refuses to save new HTML weblab1 projects containing problematic event handler attrs, but it **does NOT remove the problematic projects that already exist**. See automated delete script in #71689 , running that will take a while, maybe even a week?
2) There's an optional client-side companion PR #71686 which implements client side UX for filtering in the editor, not just "save error when you include an on* attribute". This is much more complicated because the client side doesn't have an easy way to filter a pattern, so we list every attribute. I recommend NOT merging that PR, why give people trying to bypass our system nice UX for quick iterative feedback?

UPDATE: we decided to merge #71686, because it blocks students loading these attrs for themselves locally w/o being able to save/share. This still let you paste math time into your local browser and play.