### PR TITLE
add section search to admin panel

### DIFF
--- a/dashboard/app/controllers/admin_users_controller.rb
+++ b/dashboard/app/controllers/admin_users_controller.rb
@@ -167,6 +167,23 @@ class AdminUsersController < ApplicationController
     end
   end
 
+  # GET /admin/user_sections
+  # This page takes an optional user_identifier param and renders a page with
+  # the non-hidden sections where the user is a student.
+  def user_sections_form
+    set_target_user_from_identifier(params[:user_identifier])
+
+    if @target_user
+      @sections_list = Section.
+        joins(:followers).
+        includes(:user).
+        where(followers: {student_user_id: @target_user.id}).
+        visible.
+        distinct.
+        order('sections.created_at ASC')
+    end
+  end
+
   # PUT /admin/user_project
   # This page takes a user_id and channel param and un-deletes the project and then refreshes the user_projects_form
   def user_project_restore_form

--- a/dashboard/app/views/admin_users/user_sections_form.html.haml
+++ b/dashboard/app/views/admin_users/user_sections_form.html.haml
@@ -1,0 +1,51 @@
+%h1 User Sections
+
+%p This page allows an admin to view non-hidden sections where a user is enrolled as a student. The sections are sorted by created_at in ascending order. All times in UTC.
+
+:ruby
+  def format_time(datetime)
+    datetime.try(:strftime, '%F %T')
+  end
+
+= form_tag url_for(action: 'user_sections_form'), method: 'get', class: 'form-inline', enforce_utf8: false do
+  = text_field_tag :user_identifier, params[:user_identifier], class: 'form-control', placeholder: 'user id, email, or username', size: 80
+  %button.btn{type: 'submit'}
+    %i.fa.fa-search
+
+-if @target_user
+  %h2 User information
+  %table.table.table-hover.table-condensed
+    %thead
+      %th Id
+      %th Email
+      %th Name
+      %th User type
+      %th Current sign in at
+      %th Created at
+    %tbody
+      %tr
+        %td= @target_user.id
+        %td= @target_user.email
+        %td= @target_user.name
+        %td= @target_user.user_type
+        %td= format_time(@target_user.current_sign_in_at)
+        %td= format_time(@target_user.created_at)
+
+  %h2 Sections
+  %table.table.table-hover.table-condensed
+    %thead
+      %th Created At
+      %th Updated At
+      %th Section Name
+      %th Login Type
+      %th Teacher Email
+    %tbody
+      - @sections_list.each do |section|
+        %tr
+          %td= format_time(section.created_at)
+          %td= format_time(section.updated_at)
+          %td= section.name
+          %td= section.login_type
+          %td= section.user&.email
+
+= render partial: 'home/admin'

--- a/dashboard/app/views/home/_admin.html.haml
+++ b/dashboard/app/views/home/_admin.html.haml
@@ -11,6 +11,7 @@
       %li= link_to 'Find Users', find_students_admin_search_index_path
       %li= link_to 'User progress', user_progress_form_path
       %li= link_to 'User projects', user_projects_form_path
+      %li= link_to 'User sections', user_sections_form_path
       %li= link_to 'Gatekeeper', gatekeeper_path
       %li= link_to 'DCDO', dcdo_path
       %li= link_to 'Grant Permissions/Privileges', permissions_form_path

--- a/dashboard/config/routes.rb
+++ b/dashboard/config/routes.rb
@@ -739,6 +739,7 @@ Dashboard::Application.routes.draw do
         post :studio_person_add_email_to_emails
         get :user_progress, action: 'user_progress_form', as: 'user_progress_form'
         get :user_projects, action: 'user_projects_form', as: 'user_projects_form'
+        get :user_sections, action: 'user_sections_form', as: 'user_sections_form'
         put :user_project, action: 'user_project_restore_form', as: 'user_project_restore_form'
         get :delete_progress, action: 'delete_progress_form', as: 'delete_progress_form'
         post :delete_progress

--- a/dashboard/test/controllers/admin_users_controller_test.rb
+++ b/dashboard/test/controllers/admin_users_controller_test.rb
@@ -637,6 +637,75 @@ class AdminUsersControllerTest < ActionController::TestCase
     assert_select "table:nth-of-type(3) tbody tr", 1
   end
 
+  generate_admin_only_tests_for :user_sections_form
+
+  test 'user_sections finds user by id' do
+    sign_in @admin
+    get :user_sections_form, params: {user_identifier: @not_admin.id.to_s}
+    assert_select 'h2', 'User information'
+  end
+
+  test 'user_sections finds user by username' do
+    sign_in @admin
+    get :user_sections_form, params: {user_identifier: @not_admin.username}
+    assert_select 'h2', 'User information'
+  end
+
+  test 'user_sections finds user by email' do
+    sign_in @admin
+    get :user_sections_form, params: {user_identifier: @not_admin.email}
+    assert_select 'h2', 'User information'
+  end
+
+  test 'user_sections shows error for non-existent user' do
+    sign_in @admin
+    get :user_sections_form, params: {user_identifier: "bogus_name"}
+    assert_select '.alert-danger', 'User not found'
+  end
+
+  test 'user_sections returns visible sections sorted by created_at with owner email' do
+    student = create(:student)
+    owner_one = create(:teacher, email: 'owner_one@example.com')
+    owner_two = create(:teacher, email: 'owner_two@example.com')
+    co_teacher = create(:teacher, email: 'co_teacher@example.com')
+
+    older_section = create(
+      :section,
+      user: owner_one,
+      name: 'Older Section',
+      login_type: Section::LOGIN_TYPE_WORD,
+      created_at: 3.days.ago,
+      updated_at: 2.days.ago
+    )
+    newer_section = create(
+      :section,
+      user: owner_two,
+      name: 'Newer Section',
+      login_type: Section::LOGIN_TYPE_EMAIL,
+      created_at: 1.day.ago,
+      updated_at: 12.hours.ago
+    )
+    hidden_section = create(:section, user: owner_one, hidden: true, name: 'Hidden Section')
+
+    create(:section_instructor, section: older_section, instructor: co_teacher)
+    create(:follower, section: newer_section, student_user: student)
+    create(:follower, section: older_section, student_user: student)
+    create(:follower, section: hidden_section, student_user: student)
+
+    sign_in @admin
+    get :user_sections_form, params: {user_identifier: student.id.to_s}
+
+    assert_equal [older_section.id, newer_section.id], assigns(:sections_list).map(&:id)
+    assert_select "table", 2
+    assert_select "table:nth-of-type(2) tbody tr", 2
+    assert_select "table:nth-of-type(2) tbody tr td", text: 'Older Section'
+    assert_select "table:nth-of-type(2) tbody tr td", text: 'Newer Section'
+    assert_select "table:nth-of-type(2) tbody tr td", text: 'owner_one@example.com'
+    assert_select "table:nth-of-type(2) tbody tr td", text: 'owner_two@example.com'
+    assert_select "table:nth-of-type(2) tbody tr td", text: 'co_teacher@example.com', count: 0
+    assert_select "table:nth-of-type(2) tbody tr td", text: 'Hidden Section', count: 0
+  end
+
   generate_admin_only_tests_for :permissions_form
 
   test 'find user for non-existent email displays no user error' do


### PR DESCRIPTION
Adds admin panel functionality to search for a student's sections. This should make the requests for teacher emails a self-serve process for CX.

## Links
<!-- Jira tickets, design docs, Slack threads, related PRs, etc. -->

- Jira:

## Testing story
<!-- How was this tested? Manual steps, adhoc links, automated tests, or why testing isn't needed. -->



## Deployment notes
<!-- Delete this section if it's a standard merge-and-deploy.
     Otherwise: migrations, feature flags, coordination, caching impacts, etc. -->



## Privacy and security
<!-- Delete this section if there is no privacy/security impact.
     Otherwise: new PII, auth changes, API surface changes, etc. -->

