### PR TITLE
Add lesson_insight baseline query count test

### DIFF
--- a/dashboard/test/controllers/student_snapshots_controller_test.rb
+++ b/dashboard/test/controllers/student_snapshots_controller_test.rb
@@ -431,8 +431,6 @@ class StudentSnapshotsControllerTest < ActionController::TestCase
   end
 
   # Baseline query count without lesson insight caching.
-  # This number should decrease once caching is implemented (Stage 2).
-  # Run with: bundle exec spring testunit ./test/controllers/student_snapshots_controller_test.rb
   test "lesson_insight baseline query count" do
     teacher = create(:authorized_teacher)
     student = create(:student)

--- a/dashboard/test/controllers/student_snapshots_controller_test.rb
+++ b/dashboard/test/controllers/student_snapshots_controller_test.rb
@@ -430,6 +430,54 @@ class StudentSnapshotsControllerTest < ActionController::TestCase
     assert_equal 'unsubmitted', responses[0]['response']['status']
   end
 
+  # Baseline query count without lesson insight caching.
+  # This number should decrease once caching is implemented (Stage 2).
+  # Run with: bundle exec spring testunit ./test/controllers/student_snapshots_controller_test.rb
+  test "lesson_insight baseline query count" do
+    teacher = create(:authorized_teacher)
+    student = create(:student)
+    section = create(:section, user: teacher)
+    create(:follower, user: teacher, student_user: student, section: section)
+
+    # A regular (non-assessment) level the student has attempted.
+    free_response_level = create(:free_response, name: 'FR Level Snapshot')
+    create(:script_level, script: @unit, lesson: @lesson1, levels: [free_response_level])
+    create(:user_level, user: student, script: @unit, level: free_response_level,
+      level_source: create(:level_source, data: 'my answer')
+    )
+
+    # A CFU (multi-choice) level with a correct student response.
+    multi_level = create(:multi, name: 'Multi Level Snapshot',
+      properties: {questions: [{text: 'Q?'}], answers: [{text: 'A', correct: true}]}
+    )
+    create(:script_level, script: @unit, lesson: @lesson1,
+      progression: 'Check Your Understanding', levels: [multi_level]
+    )
+    create(:user_level, user: student, script: @unit, level: multi_level,
+      level_source: create(:level_source, data: '0')
+    )
+
+    fake_response = mock
+    fake_response.stubs(:code).returns(200)
+    fake_response.stubs(:body).returns(
+      {'choices' => [{'message' => {'content' => '{}'}}]}.to_json
+    )
+    AiStudentSnapshotHelper::Client.any_instance.stubs(:request_lesson_insight).returns(fake_response)
+
+    sign_in teacher
+
+    assert_queries(27) do
+      get :lesson_insight, params: {
+        lesson_id:  @lesson1.id,
+        unit_id:    @unit.id,
+        student_id: student.id,
+        section_id: section.id
+      }
+    end
+
+    assert_response :success
+  end
+
   test "cfu_responses endpoint tracks submitted status for LevelGroup CFUs" do
     multi_level_answers = [
       {"text" => "answer 1", "correct" => false},


### PR DESCRIPTION
Records the pre-caching DB query count for the lesson_insight controller action with OpenAI stubbed out. This is just a baseline before we implement storing and fetching Lesson Insights. Both the call to generate the insight and even the calls related to determining the staleness of the lesson insight use quite a lot of queries so I'm using these tests to prevent unnecessary creep of the load of this call. (That said, 27 isn't too bad.)

You can see what I'm imagining for these tests in [my catch-all branch](https://github.com/code-dot-org/code-dot-org/pull/71690/changes#diff-7c6321930be361b4d9a4542bc88addc1a4648bde0d124560b0833cfe4333267e). (This branch will never be merged.)

Open to feedback about whether this is useful or not!