### PR TITLE
Add user search by email to admin tooling

### DIFF
--- a/dashboard/app/controllers/admin_users_controller.rb
+++ b/dashboard/app/controllers/admin_users_controller.rb
@@ -367,13 +367,16 @@ class AdminUsersController < ApplicationController
 
   # GET /admin/lookup_by_email
   def lookup_by_email_form
-    email = params[:email]
+    email = params[:email].to_s.strip.downcase
     if email.present?
       hashed_email = AuthenticationOption.hash_email(email)
-      auth_options = AuthenticationOption.where(hashed_email: hashed_email)
-      user_ids = auth_options.pluck(:user_id).uniq
+      matched_auth_options = AuthenticationOption.where(hashed_email: hashed_email)
+      user_ids = matched_auth_options.distinct.pluck(:user_id)
+      all_auth_options_for_users = AuthenticationOption.where(user_id: user_ids)
       @users = restricted_users.where(id: user_ids)
-      @credential_types_by_user = auth_options.group_by(&:user_id).transform_values {|opts| opts.map(&:credential_type)}
+      @credential_types_by_user = all_auth_options_for_users.group_by(&:user_id).transform_values do |opts|
+        opts.map(&:credential_type)
+      end
     end
   end
 

--- a/dashboard/app/controllers/admin_users_controller.rb
+++ b/dashboard/app/controllers/admin_users_controller.rb
@@ -14,6 +14,7 @@ class AdminUsersController < ApplicationController
     email
     primary_contact_info_id
     name
+    username
     user_type
     current_sign_in_at
     sign_in_count

--- a/dashboard/app/controllers/admin_users_controller.rb
+++ b/dashboard/app/controllers/admin_users_controller.rb
@@ -365,6 +365,18 @@ class AdminUsersController < ApplicationController
     redirect_to studio_person_form_path
   end
 
+  # GET /admin/lookup_by_email
+  def lookup_by_email_form
+    email = params[:email]
+    if email.present?
+      hashed_email = AuthenticationOption.hash_email(email)
+      auth_options = AuthenticationOption.where(hashed_email: hashed_email)
+      user_ids = auth_options.pluck(:user_id).uniq
+      @users = restricted_users.where(id: user_ids)
+      @credential_types_by_user = auth_options.group_by(&:user_id).transform_values {|opts| opts.map(&:credential_type)}
+    end
+  end
+
   # GET /admin/mass_delete_student_progress
   def mass_delete_student_progress
   end

--- a/dashboard/app/views/admin_users/lookup_by_email_form.html.haml
+++ b/dashboard/app/views/admin_users/lookup_by_email_form.html.haml
@@ -1,0 +1,42 @@
+%h1 Lookup User Accounts by Email
+
+#application-container
+  = show_flashes.html_safe
+
+%p Enter an email address to find all user accounts sharing that email (searched by hashed email via AuthenticationOption).
+= form_tag url_for(action: 'lookup_by_email_form'), method: 'get', class: 'form-inline', enforce_utf8: false do
+  = text_field_tag :email, params[:email], class: 'form-control', placeholder: 'email address', size: 50
+  %button.btn{type: 'submit'}
+    %i.fa.fa-search
+
+- if params[:email].present?
+  - if @users.present?
+    %p
+      Found
+      = @users.length
+      user account(s) with this email.
+    %table.table.table-hover.table-condensed.table-auto-width
+      %thead
+        %th ID
+        %th Email
+        %th Name
+        %th User Type
+        %th Credential Types
+        %th Recent Sign In
+        %th Sign In Count
+        %th Created At
+      %tbody
+        - @users.each do |user|
+          %tr
+            %td= link_to user.id, permissions_form_path(search_term: user.id)
+            %td= user.email
+            %td= user.name
+            %td= user.user_type
+            %td= @credential_types_by_user[user.id]&.join(', ')
+            %td= user.current_sign_in_at.try(:strftime, '%F')
+            %td= user.sign_in_count
+            %td= user.created_at.strftime('%F')
+  - else
+    %p No user accounts found with that email.
+
+= render partial: 'home/admin'

--- a/dashboard/app/views/admin_users/lookup_by_email_form.html.haml
+++ b/dashboard/app/views/admin_users/lookup_by_email_form.html.haml
@@ -20,6 +20,7 @@
         %th ID
         %th Email
         %th Name
+        %th Username
         %th User Type
         %th Credential Types
         %th Recent Sign In
@@ -31,6 +32,7 @@
             %td= link_to user.id, permissions_form_path(search_term: user.id)
             %td= user.email
             %td= user.name
+            %td= user.username
             %td= user.user_type
             %td= @credential_types_by_user[user.id]&.join(', ')
             %td= user.current_sign_in_at.try(:strftime, '%F')

--- a/dashboard/app/views/admin_users/lookup_by_email_form.html.haml
+++ b/dashboard/app/views/admin_users/lookup_by_email_form.html.haml
@@ -9,8 +9,8 @@
   %button.btn{type: 'submit'}
     %i.fa.fa-search
 
-- if params[:email].present?
-  - if @users.present?
+-if params[:email].present?
+  -if @users.present?
     %p
       Found
       = @users.length
@@ -36,7 +36,7 @@
             %td= user.current_sign_in_at.try(:strftime, '%F')
             %td= user.sign_in_count
             %td= user.created_at.strftime('%F')
-  - else
+  -else
     %p No user accounts found with that email.
 
 = render partial: 'home/admin'

--- a/dashboard/app/views/home/_admin.html.haml
+++ b/dashboard/app/views/home/_admin.html.haml
@@ -9,6 +9,7 @@
       %li= link_to 'Account Repair', account_repair_form_path
       %li= link_to 'Look up section', lookup_section_admin_search_index_path
       %li= link_to 'Find Users', find_students_admin_search_index_path
+      %li= link_to 'Find Users by Email', lookup_by_email_form_path
       %li= link_to 'User progress', user_progress_form_path
       %li= link_to 'User projects', user_projects_form_path
       %li= link_to 'Gatekeeper', gatekeeper_path

--- a/dashboard/app/views/home/_admin.html.haml
+++ b/dashboard/app/views/home/_admin.html.haml
@@ -9,7 +9,7 @@
       %li= link_to 'Account Repair', account_repair_form_path
       %li= link_to 'Look up section', lookup_section_admin_search_index_path
       %li= link_to 'Find Users', find_students_admin_search_index_path
-      %li= link_to 'Find Users by Email', lookup_by_email_form_path
+      %li= link_to 'Find All Users by Email', lookup_by_email_form_path
       %li= link_to 'User progress', user_progress_form_path
       %li= link_to 'User projects', user_projects_form_path
       %li= link_to 'Gatekeeper', gatekeeper_path

--- a/dashboard/config/routes.rb
+++ b/dashboard/config/routes.rb
@@ -742,6 +742,7 @@ Dashboard::Application.routes.draw do
         put :user_project, action: 'user_project_restore_form', as: 'user_project_restore_form'
         get :delete_progress, action: 'delete_progress_form', as: 'delete_progress_form'
         post :delete_progress
+        get :lookup_by_email, action: 'lookup_by_email_form', as: 'lookup_by_email_form'
         get 'mass-delete-student-progress', action: 'mass_delete_student_progress'
         post :convert_usernames_to_ids
         post :delete_user_progress

--- a/dashboard/test/controllers/admin_users_controller_test.rb
+++ b/dashboard/test/controllers/admin_users_controller_test.rb
@@ -793,4 +793,76 @@ class AdminUsersControllerTest < ActionController::TestCase
   end
 
   generate_admin_only_tests_for :studio_person_form
+
+  generate_admin_only_tests_for :lookup_by_email_form
+
+  test 'lookup_by_email_form renders without results when no email param given' do
+    sign_in @admin
+    get :lookup_by_email_form
+    assert_response :success
+    assert_select 'table', 0
+  end
+
+  test 'lookup_by_email_form shows no results message for unknown email' do
+    sign_in @admin
+    get :lookup_by_email_form, params: {email: 'nobody@example.com'}
+    assert_response :success
+    assert_select 'table', 0
+    assert_select 'p', text: /No user accounts found/
+  end
+
+  test 'lookup_by_email_form finds user by email' do
+    sign_in @admin
+    get :lookup_by_email_form, params: {email: @not_admin.email}
+    assert_response :success
+    assert_select 'tbody tr', 1
+    assert_select 'td', text: @not_admin.id.to_s
+  end
+
+  test 'lookup_by_email_form shows credential_type for found user' do
+    sign_in @admin
+    get :lookup_by_email_form, params: {email: @not_admin.email}
+    assert_response :success
+    assert_select 'td', text: AuthenticationOption::EMAIL
+  end
+
+  test 'lookup_by_email_form finds multiple users sharing the same hashed email' do
+    email = 'shared@example.com'
+    user1 = create(:teacher, email: email)
+    # Create a second user with a Clever auth option for the same email.
+    # Clever is an UNTRUSTED_EMAIL_CREDENTIAL_TYPE so uniqueness validation is skipped,
+    # allowing two users to share the same hashed_email in authentication_options.
+    user2 = create(:teacher)
+    create(:authentication_option,
+      user: user2,
+      email: email,
+      credential_type: AuthenticationOption::CLEVER,
+      authentication_id: "clever_#{user2.id}"
+    )
+
+    sign_in @admin
+    get :lookup_by_email_form, params: {email: email}
+    assert_response :success
+    assert_select 'tbody tr', 2
+    assert_select 'td', text: user1.id.to_s
+    assert_select 'td', text: user2.id.to_s
+  end
+
+  test 'lookup_by_email_form shows all credential_types for a user with multiple auth options' do
+    email = 'multi_auth@example.com'
+    user = create(:teacher, email: email)
+    create(:authentication_option,
+      user: user,
+      email: email,
+      credential_type: AuthenticationOption::CLEVER,
+      authentication_id: "clever_#{user.id}"
+    )
+
+    sign_in @admin
+    get :lookup_by_email_form, params: {email: email}
+    assert_response :success
+    assert_select 'tbody tr', 1
+    assert_select 'td', text: /email/
+    assert_select 'td', text: /clever/
+  end
 end


### PR DESCRIPTION
Add the ability to lookup all user accounts tied to an email in the admin tools. This is helpful when trying to determine if a user is having issues due to multiple accounts. This differs from the existing Find Users admin tool, which only returns the first account it finds, not _all_ accounts attached to an email.

<!--
  Summary of the change: background, motivation, and context.
  Include screenshots, videos, or before/after comparisons for UI changes.
-->



## Links
<!-- Jira tickets, design docs, Slack threads, related PRs, etc. -->

- Jira:

## Testing story
<!-- How was this tested? Manual steps, adhoc links, automated tests, or why testing isn't needed. -->



## Deployment notes
<!-- Delete this section if it's a standard merge-and-deploy.
     Otherwise: migrations, feature flags, coordination, caching impacts, etc. -->



## Privacy and security
<!-- Delete this section if there is no privacy/security impact.
     Otherwise: new PII, auth changes, API surface changes, etc. -->

