### PR TITLE
Speculative deflake for TeacherDeleterTest

### DIFF
--- a/dashboard/test/lib/inactivity_cleanup/teacher_deleter_test.rb
+++ b/dashboard/test/lib/inactivity_cleanup/teacher_deleter_test.rb
@@ -195,7 +195,7 @@ class InactivityCleanup::TeacherDeleterTest < ActiveSupport::TestCase
       end
     end
 
-    context 'when provided :inactive_since is before then last account activity' do
+    context 'when provided :inactive_since is before the last account activity' do
       let(:described_instance_args) {{inactive_since: (account.current_sign_in_at || account.created_at) - 1.minute}}
 
       it_behaves_like 'ignores account'

--- a/dashboard/test/lib/inactivity_cleanup/teacher_deleter_test.rb
+++ b/dashboard/test/lib/inactivity_cleanup/teacher_deleter_test.rb
@@ -195,6 +195,28 @@ class InactivityCleanup::TeacherDeleterTest < ActiveSupport::TestCase
       end
     end
 
+    context 'when provided :inactive_since is before then last account activity' do
+      let(:described_instance_args) {{inactive_since: (account.current_sign_in_at || account.created_at) - 1.minute}}
+
+      it_behaves_like 'ignores account'
+    end
+
+    context 'when provided :limit is less than inactive account total' do
+      let(:described_instance_args) {{limit: 1}}
+
+      let!(:account2) {create(:teacher, created_at: InactivityCleanup::INACTIVITY_THRESHOLD.ago)}
+      let!(:user_data_retention_status2) {create(:user_data_retention_status, user: account2, deletion_warning_email_sent_at:)}
+
+      it_behaves_like 'deletes account'
+
+      it 'ignores second account' do
+        _ {delete_inactive_teachers}.wont_change -> {account2.reload.deleted?}
+        _(described_instance.send(:inactive_users)).must_equal [account2]
+        _(described_instance.num_errors).must_equal 0
+        _(described_instance.processed_user_ids).wont_include account2.id
+      end
+    end
+
     context 'when dry_run' do
       let(:described_instance_args) {{dry_run: true}}
 
@@ -234,40 +256,6 @@ class InactivityCleanup::TeacherDeleterTest < ActiveSupport::TestCase
           Dry run, no accounts actually deleted
         MSG
       end
-    end
-
-    context 'when provided :inactive_since is before then last account activity' do
-      let(:described_instance_args) {{inactive_since: (account.current_sign_in_at || account.created_at) - 1.minute}}
-
-      it_behaves_like 'ignores account'
-    end
-
-    context 'when provided :limit is less than inactive account total' do
-      let(:described_instance_args) {{limit: 1}}
-
-      let!(:account2) {create(:teacher, created_at: InactivityCleanup::INACTIVITY_THRESHOLD.ago)}
-      let!(:user_data_retention_status2) {create(:user_data_retention_status, user: account2, deletion_warning_email_sent_at:)}
-
-      it_behaves_like 'deletes account'
-
-      it 'ignores second account' do
-        _ {delete_inactive_teachers}.wont_change -> {account2.reload.deleted?}
-        _(described_instance.send(:inactive_users)).must_equal [account2]
-        _(described_instance.num_errors).must_equal 0
-        _(described_instance.processed_user_ids).wont_include account2.id
-      end
-    end
-
-    context 'when deletion warning email was not sent' do
-      let(:deletion_warning_email_sent_at) {nil}
-
-      it_behaves_like 'ignores account'
-    end
-
-    context 'when deletion warning email was sent but we are still within the grace period' do
-      let(:deletion_warning_email_sent_at) {InactivityCleanup::TeacherDeleter::DELETION_WARNING_GRACE_PERIOD.ago + 1.minute}
-
-      it_behaves_like 'ignores account'
     end
   end
 end

--- a/dashboard/test/lib/inactivity_cleanup/teacher_deleter_test.rb
+++ b/dashboard/test/lib/inactivity_cleanup/teacher_deleter_test.rb
@@ -142,8 +142,8 @@ class InactivityCleanup::TeacherDeleterTest < ActiveSupport::TestCase
       it_behaves_like 'deletes account'
     end
 
-    context 'when teacher has been signed in longer than allowed period' do
-      let!(:account) {create(:teacher, current_sign_in_at: InactivityCleanup::INACTIVITY_THRESHOLD.ago)}
+    context 'when teacher has not signed in since the inactivity threshold' do
+      let!(:account) {create(:teacher, current_sign_in_at: InactivityCleanup::INACTIVITY_THRESHOLD.ago - 1.minute)}
 
       it_behaves_like 'deletes account'
     end
@@ -264,8 +264,8 @@ class InactivityCleanup::TeacherDeleterTest < ActiveSupport::TestCase
       it_behaves_like 'ignores account'
     end
 
-    context 'when deletion warning email was sent earlier than grace period threshold' do
-      let(:deletion_warning_email_sent_at) {InactivityCleanup::TeacherDeleter::DELETION_WARNING_GRACE_PERIOD.ago}
+    context 'when deletion warning email was sent but we are still within the grace period' do
+      let(:deletion_warning_email_sent_at) {InactivityCleanup::TeacherDeleter::DELETION_WARNING_GRACE_PERIOD.ago + 1.minute}
 
       it_behaves_like 'ignores account'
     end

--- a/dashboard/test/lib/inactivity_cleanup/teacher_deleter_test.rb
+++ b/dashboard/test/lib/inactivity_cleanup/teacher_deleter_test.rb
@@ -160,8 +160,8 @@ class InactivityCleanup::TeacherDeleterTest < ActiveSupport::TestCase
       it_behaves_like 'ignores account'
     end
 
-    context 'when deletion warning email was sent earlier than grace period threshold' do
-      let(:deletion_warning_email_sent_at) {InactivityCleanup::TeacherDeleter::DELETION_WARNING_GRACE_PERIOD.ago}
+    context 'when deletion warning email was sent but we are still within the grace period' do
+      let(:deletion_warning_email_sent_at) {InactivityCleanup::TeacherDeleter::DELETION_WARNING_GRACE_PERIOD.ago + 1.minute}
 
       it_behaves_like 'ignores account'
     end


### PR DESCRIPTION
Clarifies the test description and attempts to deflake by adding a 1-minute delta, ensuring the timestamp never ends up being exactly equal to the grace period const.


## Links
[JIRA](https://codedotorg.atlassian.net/browse/P20-1831)

## Testing story
<!-- How was this tested? Manual steps, adhoc links, automated tests, or why testing isn't needed. -->



## Deployment notes
<!-- Delete this section if it's a standard merge-and-deploy.
     Otherwise: migrations, feature flags, coordination, caching impacts, etc. -->



## Privacy and security
<!-- Delete this section if there is no privacy/security impact.
     Otherwise: new PII, auth changes, API surface changes, etc. -->

