### PR TITLE
Adds localization of Droplet level comments/categories.

### DIFF
--- a/apps/src/StudioApp.js
+++ b/apps/src/StudioApp.js
@@ -2485,6 +2485,15 @@ StudioApp.prototype.handleEditCode_ = function (config) {
     config.dropletConfig
   );
 
+  // Localize the droplet palette categories
+  fullDropletPalette.forEach(
+    info =>
+      (info.name = localization.translate(info.name, [
+        'droplet',
+        'droplet-palette',
+      ]))
+  );
+
   // Create a child element of codeTextbox to instantiate droplet on, because
   // droplet sets css properties on its wrapper that would interfere with our
   // layout otherwise.
@@ -2492,6 +2501,8 @@ StudioApp.prototype.handleEditCode_ = function (config) {
   const codeTextbox = document.getElementById('codeTextbox');
   const dropletCodeTextbox = document.createElement('div');
   dropletCodeTextbox.setAttribute('id', 'dropletCodeTextbox');
+  // Do not translate the contents. We will do that manually.
+  dropletCodeTextbox.setAttribute('data-notranslate', '');
   codeTextbox.appendChild(dropletCodeTextbox);
 
   this.editor = new droplet.Editor(dropletCodeTextbox, {
@@ -2595,6 +2606,7 @@ StudioApp.prototype.handleEditCode_ = function (config) {
   if (config.level.dropletTooltipsDisabled) {
     this.dropletTooltipManager.setTooltipsEnabled(false);
   }
+
   this.dropletTooltipManager.registerBlocks();
 
   // Bind listener to palette/toolbox 'Hide' and 'Show' links
@@ -2626,8 +2638,20 @@ StudioApp.prototype.handleEditCode_ = function (config) {
   var startBlocks = config.level.lastAttempt || config.level.startBlocks;
   if (startBlocks) {
     try {
-      // Don't pass CRLF pairs to droplet until they fix CR handling:
-      this.editor.setValue(startBlocks.replace(/\r\n/g, '\n'));
+      // Try to localize the comments in start droplet code
+      // Also, ensures we don't pass CRLF pairs to droplet until they fix CR handling:
+      const localizedStartCode = startBlocks
+        .split(/\r\n|\n/)
+        .map(line =>
+          line.startsWith('//')
+            ? `//${localization.translate(line.substring(2), [
+                'comment',
+                'droplet',
+              ])}`
+            : line
+        )
+        .join('\n');
+      this.editor.setValue(localizedStartCode);
       // When adding content via setValue, the aceEditor cursor gets set to be
       // at the end of the file. For mysterious reasons we've been unable to
       // understand, we end up with some pretty funky render issues if the first


### PR DESCRIPTION
Supports localization of CSD Unit 3 (gamelab) and other Droplet-powered levels

This manually localizes the categories (Drawing to Dibujo) and then comments. In the following screenshot, it is using the new TMS to render those strings out:

<img width="1277" height="473" alt="image" src="https://github.com/user-attachments/assets/173fd6b1-b403-4fae-bd73-d90cef33785d" />

## Testing

To enable localizejs you need to enable the frontend experiment via `? enableExperiments=localizejs` and refresh the page twice. or manually: `window.localStorage.setItem('experimentsList', '[{"key": "localizejs"}]')`

Then go to specifically CSD 2024 Unit 3 for the levels that have some Spanish translations already.

## Links
<!-- Jira tickets, design docs, Slack threads, related PRs, etc. -->

- Jira: Part of [GEPW-7](https://codedotorg.atlassian.net/browse/GEPW-7)

