### PR TITLE
AI Chat: add model ID dimension to client metrics

### DIFF
--- a/apps/src/aichat/redux/thunks/submitChatContents.ts
+++ b/apps/src/aichat/redux/thunks/submitChatContents.ts
@@ -14,6 +14,7 @@ import {sendProgressReport} from '@cdo/apps/code-studio/progressRedux';
 import {TestResults} from '@cdo/apps/constants';
 import Lab2Registry from '@cdo/apps/lab2/Lab2Registry';
 import {EVENTS} from '@cdo/apps/metrics/AnalyticsConstants';
+import {MetricDimension} from '@cdo/apps/metrics/types';
 import {commonI18n} from '@cdo/apps/types/locale';
 import {RootState} from '@cdo/apps/types/redux';
 import {NetworkError} from '@cdo/apps/util/HttpClient';
@@ -163,10 +164,17 @@ export const submitChatContents = createAsyncThunk(
       ...analyticsProperties,
     };
 
+    const metricDimensions = [
+      {name: 'ModelId', value: modelParameters.selectedModelId},
+    ];
+
     try {
       Lab2Registry.getInstance()
         .getMetricsReporter()
-        .incrementCounter('Aichat.ChatCompletionRequestInitiated');
+        .incrementCounter(
+          'Aichat.ChatCompletionRequestInitiated',
+          metricDimensions
+        );
 
       dispatch(
         sendAnalytics(EVENTS.SUBMIT_AICHAT_REQUEST_INITIATED, eventData)
@@ -219,18 +227,18 @@ export const submitChatContents = createAsyncThunk(
       );
       Lab2Registry.getInstance()
         .getMetricsReporter()
-        .reportLoadTime('AichatModelResponseTime', responseTime, [
-          {
-            name: 'ModelId',
-            value: modelParameters.selectedModelId,
-          },
-        ]);
+        .reportLoadTime(
+          'AichatModelResponseTime',
+          responseTime,
+          metricDimensions
+        );
     } catch (error) {
       await handleChatCompletionError(
         error as Error,
         newUserMessage,
         dispatch,
-        state.progress.viewAsUserId
+        state.progress.viewAsUserId,
+        metricDimensions
       );
       return;
     }
@@ -269,7 +277,8 @@ async function handleChatCompletionError(
   error: Error,
   newUserMessage: PendingChatMessage & {updateId: string},
   dispatch: AppDispatch,
-  viewAsUserId: number | null
+  viewAsUserId: number | null,
+  dimensions: MetricDimension[] = []
 ) {
   // Only send log report if not a 403 error.
   if (!(error instanceof NetworkError && error.response.status === 403)) {
@@ -291,7 +300,7 @@ async function handleChatCompletionError(
   if (error instanceof NetworkError && error.response.status === 429) {
     Lab2Registry.getInstance()
       .getMetricsReporter()
-      .incrementCounter('Aichat.ChatCompletionErrorRateLimited');
+      .incrementCounter('Aichat.ChatCompletionErrorRateLimited', dimensions);
     dispatch(
       addChatEvent({
         removeId: getNewRemoveId(),
@@ -305,7 +314,7 @@ async function handleChatCompletionError(
   } else {
     Lab2Registry.getInstance()
       .getMetricsReporter()
-      .incrementCounter('Aichat.ChatCompletionErrorUnhandled');
+      .incrementCounter('Aichat.ChatCompletionErrorUnhandled', dimensions);
     dispatch(
       addChatEvent({
         role: Role.ASSISTANT,

--- a/apps/src/aichat/redux/thunks/submitChatContents.ts
+++ b/apps/src/aichat/redux/thunks/submitChatContents.ts
@@ -169,12 +169,10 @@ export const submitChatContents = createAsyncThunk(
     ];
 
     try {
-      Lab2Registry.getInstance()
-        .getMetricsReporter()
-        .incrementCounter(
-          'Aichat.ChatCompletionRequestInitiated',
-          metricDimensions
-        );
+      incrementCounter(
+        'Aichat.ChatCompletionRequestInitiated',
+        metricDimensions
+      );
 
       dispatch(
         sendAnalytics(EVENTS.SUBMIT_AICHAT_REQUEST_INITIATED, eventData)
@@ -298,9 +296,7 @@ async function handleChatCompletionError(
   // Display specific error notifications if the user was rate limited (HTTP 429) or not authorized (HTTP 403).
   // Otherwise, display a generic error assistant response.
   if (error instanceof NetworkError && error.response.status === 429) {
-    Lab2Registry.getInstance()
-      .getMetricsReporter()
-      .incrementCounter('Aichat.ChatCompletionErrorRateLimited', dimensions);
+    incrementCounter('Aichat.ChatCompletionErrorRateLimited', dimensions);
     dispatch(
       addChatEvent({
         removeId: getNewRemoveId(),
@@ -312,9 +308,7 @@ async function handleChatCompletionError(
   } else if (error instanceof NetworkError && error.response.status === 403) {
     await notifyErrorUnauthorized(error, 'Chat Completion', dispatch);
   } else {
-    Lab2Registry.getInstance()
-      .getMetricsReporter()
-      .incrementCounter('Aichat.ChatCompletionErrorUnhandled', dimensions);
+    incrementCounter('Aichat.ChatCompletionErrorUnhandled', dimensions);
     dispatch(
       addChatEvent({
         role: Role.ASSISTANT,
@@ -324,4 +318,11 @@ async function handleChatCompletionError(
       })
     );
   }
+}
+
+function incrementCounter(metricName: string, dimensions: MetricDimension[]) {
+  const reporter = Lab2Registry.getInstance().getMetricsReporter();
+  reporter.incrementCounter(metricName, dimensions);
+  // Report without dimensions for an aggregate count.
+  reporter.incrementCounter(metricName);
 }


### PR DESCRIPTION
Adds a `ModelId` dimension to our client-side Cloudwatch AI Chat metrics, namely `Aichat.ChatCompletionRequestInitiated`, `Aichat.ChatCompletionErrorRateLimited`, and `Aichat.ChatCompletionErrorUnhandled` (it was already part of `AichatModelResponseTime`). 

It's been a while since we initially added these; I don't remember exactly why we didn't include the dimension when we first added these metrics, but my guess is: at the time all of our models were on Sagemaker and routed through our ActiveJob architecture, so there wasn't much utility in splitting out the metrics on the client as we could look at model-specific metrics at the ActiveJob/Rails and Sagemaker levels. Now that a) not every model is on Sagemaker (only Mistral 7B is) and b) we have two different API paths the client can hit (our rails backend vs AI Gateway), it's helpful to observe the differences in model performances from the client (i.e. if AI Gateway is down but our rails server is not, only certain models will be affected).

Metrics split out by ModelId dimension in Cloudwatch's explorer:

<img width="1221" height="342" alt="Screenshot 2026-03-26 at 4 01 15 PM" src="https://github.com/user-attachments/assets/1c57a1b0-8bce-4db9-aa79-a0f500a92c70" />

## Testing story
Tested by verifying metrics in cloudwatch.

## Follow-up work
- Update our dashboards to reflect new models and organize by these new dimensions.

