### PR TITLE
AI Chat: add execution metrics for client API

### DIFF
--- a/apps/src/aichat/api/performClientApiChatCompletion.ts
+++ b/apps/src/aichat/api/performClientApiChatCompletion.ts
@@ -1,4 +1,6 @@
 import {Role} from '@cdo/apps/aiComponentLibrary/chatMessage/types';
+import Lab2Registry from '@cdo/apps/lab2/Lab2Registry';
+import {getTypedKeys} from '@cdo/apps/types/utils';
 import {
   AiInteractionStatus,
   AiRequestExecutionStatus,
@@ -17,6 +19,8 @@ import {
   createAichatRequest,
   updateAichatRequest,
 } from './client/helpers/aichatRequestHelpers';
+
+const metricPrefix = 'AichatClientApi';
 
 /**
  * Performs client-side chat completion submission flow, which involves creating a new AichatRequest record,
@@ -43,6 +47,13 @@ export async function performClientApiChatCompletion(
 
   const clientApi = await getClientApi();
 
+  const metricsReporter = Lab2Registry.getInstance().getMetricsReporter();
+  const startTime = Date.now();
+  const metricDimensions = [
+    {name: 'ModelId', value: modelParameters.selectedModelId},
+  ];
+  metricsReporter.incrementCounter(`${metricPrefix}.Start`, metricDimensions);
+
   const {response, assets, status} = await clientApi.generateChatResponse(
     newMessage,
     storedMessages,
@@ -50,6 +61,22 @@ export async function performClientApiChatCompletion(
     buildAssetUrl,
     levelSystemPrompt
   );
+
+  metricsReporter.reportLoadTime(
+    `${metricPrefix}.Latency`,
+    Date.now() - startTime,
+    metricDimensions
+  );
+
+  const statusName =
+    getTypedKeys(AiRequestExecutionStatus).find(
+      key => AiRequestExecutionStatus[key] === status
+    ) || 'UNKNOWN';
+
+  metricsReporter.incrementCounter(`${metricPrefix}.Finish`, [
+    ...metricDimensions,
+    {name: 'ExecutionStatus', value: statusName},
+  ]);
 
   await updateAichatRequest(requestId, status, response);
 


### PR DESCRIPTION
This adds execution metrics to the AI Chat client API call, analogous to the ActiveJob-metrics we report for all other models (see [here](https://github.com/code-dot-org/code-dot-org/blob/d87663ea41191cab8e7f7e22bc71fbaf5dd2cd6c/dashboard/app/jobs/aichat_request_chat_completion_job.rb#L127-L186)). I used a different prefix (`AichatClientApi`) to differentiate these from the ActiveJob ones, but they use the same format:
- `AichatClientApi.Start`: counter when request is initiated
- `AichatClientApi.Latency`: total time (ms) the request took
- `AichatClientApi.Finish`: counter for when the request finishes with an `ExecutionStatus` dimension.

The main reason I added these is to have some sort of parallel visibility into the client API's performance; notably, our existing alarms for other models use these metrics emitted by the job code (Finish events with status dimension 'FAILURE' / start events). However, I'm more than happy to discuss this; for one, Cloudflare already has decent observability on the worker and gateway side. My sense is that we'd use these in tandem (kind of like how we would use ActiveJob-specific and Sagmemaker-specific metrics and/or Honeybadger to track down errors), but do let me know if y'all have any other ideas!



If it's helpful, here's how I'm thinking about the overall AI Chat metrics landscape (once this and https://github.com/code-dot-org/code-dot-org/pull/71714 are merged). From outermost layer to inner:

### --- Browser Layer ---
- `Aichat.ChatCompletionRequestInitiated`, `AichatModelResponseTime`, `Aichat.ChatCompletionErrorRateLimited`, `Aichat.ChatCompletionErrorUnhandled`
- Grouped by Model ID and Browser dimensions
- Provides us visibility into the browser's performance; i.e. closest to what the user actually saw (in terms of end-to-end latency, error rates)
- More generic error groupings
  - Caveat: today, only _unhandled_ JS/network failures are considered browser failures (network outage, rate limiting, etc). If there is a downstream error (OpenAI is down so safety checks are failing), then this is _not_ considered an error by the browser; this is handled in the ActiveJob layer and reported to Honeybadger & Cloudwatch there. Should it also trigger a browser failure or is that redundant?
- **Used for alarms today (not model-specific)**

### --- "Proxy" Layer ---

#### AI Client API (using AI Gateway) [this PR]
- Metrics listed above
- Only relevant for models using the client API (currently just gemini flash 2.5 image)
- Grouped by Model ID and Browser dimensions
- Still provides us a pretty clear picture of what's happening on the browser's side since this request is made from the client directly.
- Insight into exactly what execution status a request ended up with (failure, model profanity, user profanity, etc).
- Latency specific to the client API request (doesn't include updating the AichatRequest model on dashboard).


#### Rails/ActiveJob
- `AichatRequestChatCompletionJob.Start`, `*.ExecutionTime`, `*.Finish`
- Grouped by Model ID
- Similar to the client API section above; insight into the execution status and how long the downstream AI request actually took (including safety checks).
- **Used for alarms today (model-specific)**

### --- "Service"/"Infra" Layer ---

#### Cloudflare Metrics
- Viewed separately in Cloudflare - worker, gateway metrics, errors, etc

#### Sagemaker
- AWS Sagemaker namespace specific metrics (invocation counts, CPU/GPU utilization, error codes)
- Only relevant for Mistral 7B (while it's still on Sagemaker).
- Can help us drill into the underlying error rates and latency within the Sagemaker layer. 