### PR TITLE
Adds special case for 'Not {word}' translation in AI for Oceans.

### DIFF
--- a/apps/src/fish/Fish.js
+++ b/apps/src/fish/Fish.js
@@ -150,7 +150,20 @@ Fish.prototype.initMLActivities = function () {
 
   // Localize
   const msg = Object.entries(fishMsg).reduce((acc, [key, msgFunction]) => {
-    acc[key] = (...args) => localization.translate(msgFunction(...args));
+    acc[key] = (...args) => {
+      if (key === 'notWord') {
+        // 'Not {word}' is too ambiguous and it contains the previously translated
+        // word inline. So we're always trying to translate "Not azul", etc, and
+        // that's not appropriate. A dynamic phrase catches too many other things.
+        // Therefore, we specialize this string as "Not {oceans-word:X}" which we
+        // can uniquely match and translate in the TMS.
+        return localization
+          .translate(`Not oceans-word:${args[0]['word']}`, ['oceans'])
+          .replace('oceans-word:', '');
+      } else {
+        return localization.translate(msgFunction(...args), ['oceans']);
+      }
+    };
     return acc;
   }, {});
 


### PR DESCRIPTION
The `Not {word}` localization string always substituted in the already translated word into the sentence. So the localization engine is trying to translate 'Not azul', etc, which obviously confuses it. I can go on to the localization service and make a regular expression to mask out the word so it doesn't translate it. So I can go "no no, this string is actually 'Not {word}'" again and it will not tough the dynamic part and just translate the stuff around it. However, that means it is translating basically one word and allowing anything after it, which matches things like "Not really what I'm trying to match against", etc.

This special cases it by prefixing the pre-translated word with a token we can create a much more unique regex to match and then strip it out again once it gets the final translation. So, "Not azul" would become "Not oceans-word:azul" which gets masked on the TMS side as "Not {{oceans-adjective}}" and then translated as "No es {{oceans-adjective}}" or whatever. When our system gets that translated string, the localization library resubstitutes the swapped out word, so it becomes "No es oceans-word:azul" which we strip out the control token to make `No es azul`.

Perfecto.

This is a rare worst case: a short string with pretranslated content embedded... hard to mask out the parts we don't want translated and still have the string have enough context.

## Localize

Creates this string, which I've already supplied, masked out to make it a dynamic phrase, and translated into `es-LA`:

<img width="1259" height="507" alt="image" src="https://github.com/user-attachments/assets/1571265b-88d3-4293-8082-61c7327f4c40" />

## Links
<!-- Jira tickets, design docs, Slack threads, related PRs, etc. -->

- Slack: [Slack](https://codedotorg.slack.com/archives/C0AP279DWTY/p1774548070844899)