### PR TITLE
weblab1: revert code only needed until june 1, 2026 to work around browser caches: MERGE IF AFTER JUN 1!

### DIFF
--- a/dashboard/legacy/middleware/files_api.rb
+++ b/dashboard/legacy/middleware/files_api.rb
@@ -258,26 +258,19 @@ class FilesApi < Sinatra::Base
       attachment(filename)
     end
 
-    project = Projects.new(get_storage_id).get(encrypted_channel_id) if valid_encrypted_channel_id(encrypted_channel_id)
-    project_type = project[:projectType]&.downcase if project
-
-    # we always fetch weblab1 html files to ensure they still pass our latest no-js validations
-    if_modified_since = html_file?(filename) && project_type == 'weblab' ? nil : env['HTTP_IF_MODIFIED_SINCE']
-
-    result = buckets.get(encrypted_channel_id, filename, if_modified_since, request.GET['version'])
+    result = buckets.get(encrypted_channel_id, filename, env['HTTP_IF_MODIFIED_SINCE'], request.GET['version'])
     not_found if result[:status] == 'NOT_FOUND'
     not_modified if result[:status] == 'NOT_MODIFIED'
+    last_modified result[:last_modified]
 
     metadata = result[:metadata]
     abuse_score = [metadata['abuse_score'].to_i, metadata['abuse-score'].to_i].max
+    project = Projects.new(get_storage_id).get(encrypted_channel_id)
+    project_type = project[:projectType]&.downcase if project
     not_found if abuse_score >= SharedConstants::ABUSE_CONSTANTS.ABUSE_THRESHOLD && !can_view_flagged_assets?(encrypted_channel_id)
     not_found if profanity_privacy_violation?(filename, result[:body], project_type) && !can_view_flagged_assets?(encrypted_channel_id)
     not_found if code_projects_domain_root_route && !codeprojects_can_view?(encrypted_channel_id)
     not_found if html_file?(filename) && !valid_html_file?(encrypted_channel_id, filename, result[:body].string)
-
-    # clients still get a 304 Not Modified from us if their cache is fresh,
-    # even if we had to fetch html from s3 to validate it
-    last_modified result[:last_modified]
 
     if code_projects_domain_root_route && html?(response.headers)
       return "<head>\n<script>\nvar encrypted_channel_id='#{encrypted_channel_id}';\n</script>\n<script async src='/weblab/footer.js'></script>\n<link rel='stylesheet' href='/weblab/footer.css'></head>\n" << result[:body].string

--- a/dashboard/legacy/test/middleware/test_files.rb
+++ b/dashboard/legacy/test/middleware/test_files.rb
@@ -240,16 +240,7 @@ class FilesTest < FilesApiTestBase
     @api.get_object(filename)
     assert not_found?
 
-    @api.get_object(filename, '', {'HTTP_IF_MODIFIED_SINCE' => Time.now.httpdate})
-    assert not_found?
-
     get "/projects/weblab/#{@channel_id}/", '', {'HTTP_HOST' => CDO.canonical_hostname('codeprojects.org')}
-    assert not_found?
-
-    get "/projects/weblab/#{@channel_id}/", '', {
-      'HTTP_HOST' => CDO.canonical_hostname('codeprojects.org'),
-      'HTTP_IF_MODIFIED_SINCE' => Time.now.httpdate
-    }
     assert not_found?
 
     Projects.any_instance.unstub(:get)


### PR DESCRIPTION
This is a "in 2 mos merge this PR" followup to #71722 and #71725.

Per #71722, all the code in that PR (+ #71725, a fix-forward with a missing line) except ONE LINE is just working around student's having "disallowed HTML files" still in their browser cache.

So we have code complicating `files_api` from those PRs, that's totally irrrelevant after Jun 1 of 2025 (say). This PR reverts all but the single line that should stay permanently (until weblab1 is deprecated in 🙏 1 year or so).

BASICALLY: if its after jun1 of 2025, MERGE THIS PR to simplify files_api from temporaryily needed crud.