### PR TITLE
Remove bot icon from AI Tutor and AI Chat Lab assistant messages

### DIFF
--- a/apps/src/aiComponentLibrary/chatMessage/ChatMessage.tsx
+++ b/apps/src/aiComponentLibrary/chatMessage/ChatMessage.tsx
@@ -96,7 +96,7 @@ const ChatMessage: React.FunctionComponent<ChatMessageProps> = ({
     >
       <div className={moduleStyles.grid}>
         {isAssistant && isTA && (
-          <div className={moduleStyles.botIconWrapper}>
+          <div className={moduleStyles.botIconTAOverlayContainer}>
             <div className={classNames(moduleStyles.botIconContainer)}>
               <img
                 src={aiBotOutlineIcon}

--- a/apps/src/aiComponentLibrary/chatMessage/ChatMessage.tsx
+++ b/apps/src/aiComponentLibrary/chatMessage/ChatMessage.tsx
@@ -95,13 +95,8 @@ const ChatMessage: React.FunctionComponent<ChatMessageProps> = ({
       )}
     >
       <div className={moduleStyles.grid}>
-        {isAssistant && (
-          <div
-            className={classNames(
-              moduleStyles.botIconWrapper,
-              isTA && moduleStyles.botIconContainerWithOverlay
-            )}
-          >
+        {isAssistant && isTA && (
+          <div className={moduleStyles.botIconWrapper}>
             <div className={classNames(moduleStyles.botIconContainer)}>
               <img
                 src={aiBotOutlineIcon}
@@ -152,7 +147,12 @@ const ChatMessage: React.FunctionComponent<ChatMessageProps> = ({
         </div>
         {footer && (
           <div
-            className={classNames(isAssistant && moduleStyles.assistantFooter)}
+            className={classNames(
+              isAssistant &&
+                (isTA
+                  ? moduleStyles.assistantFooterBotIcon
+                  : moduleStyles.assistantFooterNoBotIcon)
+            )}
           >
             {footer}
           </div>

--- a/apps/src/aiComponentLibrary/chatMessage/chat-message.module.scss
+++ b/apps/src/aiComponentLibrary/chatMessage/chat-message.module.scss
@@ -108,7 +108,7 @@ $vertical-gap: 0.375rem;
   justify-content: flex-end;
 }
 
-.botIconWrapper {
+.botIconTAOverlayContainer {
   grid-column: 1;
   align-self: end;
   position: relative;

--- a/apps/src/aiComponentLibrary/chatMessage/chat-message.module.scss
+++ b/apps/src/aiComponentLibrary/chatMessage/chat-message.module.scss
@@ -111,6 +111,10 @@ $vertical-gap: 0.375rem;
 .botIconWrapper {
   grid-column: 1;
   align-self: end;
+  position: relative;
+  display: flex;
+  padding-right: $icon-overlay-padding-right;
+  padding-top: 3px;
 }
 
 .botIconContainer {
@@ -125,15 +129,13 @@ $vertical-gap: 0.375rem;
   margin-bottom: 0;
 }
 
-.botIconContainerWithOverlay {
-  position: relative;
-  display: flex;
-  padding-right: $icon-overlay-padding-right;
-  padding-top: 3px;
+.assistantFooterBotIcon {
+  grid-column: 2;
 }
 
-.assistantFooter {
-  grid-column: 2;
+// Without the bot column, align footer with the message (column 1), not column 2.
+.assistantFooterNoBotIcon {
+  grid-column: 1;
 }
 
 .botIcon {


### PR DESCRIPTION
<!--
  Summary of the change: background, motivation, and context.
  Include screenshots, videos, or before/after comparisons for UI changes.
-->
This PR removes the AI Both icon from assistant messages in AI Tutor, AI Chat lab, but NOT AI TA. [See Slack thread](https://codedotorg.slack.com/archives/C03DBDN67B7/p1774629807395199). This will allow more space in the chat workspace for content.






## Links
<!-- Jira tickets, design docs, Slack threads, related PRs, etc. -->

- Jira: https://codedotorg.atlassian.net/browse/AFL-528

## Testing story
<!-- How was this tested? Manual steps, adhoc links, automated tests, or why testing isn't needed. -->
Tested locally in AI Tutor in Web Lab 2, AI Chat Lab, and confirmed no change in AI TA.

### Before update

Assistant message in Web Lab 2 (with bot icon):

<img width="344" height="220" alt="weblab2-before" src="https://github.com/user-attachments/assets/a49073fc-13d8-4afc-82b6-689c9227d163" />


Assistant message in AI Chat Lab (with bot icon):

<img width="538" height="100" alt="aichat-before" src="https://github.com/user-attachments/assets/dc66f77b-b54c-45c5-b19c-7aa7e1638885" />

### After update

Assistant message in Web Lab 2 (no bot icon):

<img width="360" height="692" alt="weblab2-after" src="https://github.com/user-attachments/assets/eaba4178-5ea3-435e-8fe7-b996f443ff51" />

Assistant message in AI Chat Lab (no bot icon):

<img width="524" height="604" alt="aichat-after" src="https://github.com/user-attachments/assets/26db3a1c-c922-4c5d-9f8a-cdf1a9c29b11" />

AI TA (no change):

<img width="679" height="703" alt="aita-after-no-change" src="https://github.com/user-attachments/assets/c5421280-3a4d-4104-915d-e0f7eb66d2d3" />




## Deployment notes
<!-- Delete this section if it's a standard merge-and-deploy.
     Otherwise: migrations, feature flags, coordination, caching impacts, etc. -->



## Privacy and security
<!-- Delete this section if there is no privacy/security impact.
     Otherwise: new PII, auth changes, API surface changes, etc. -->

