### PR TITLE
Kaitie/add resoruces button

### DIFF
--- a/apps/src/code-studio/components/progress/MiniView.jsx
+++ b/apps/src/code-studio/components/progress/MiniView.jsx
@@ -38,7 +38,7 @@ function MiniView(props) {
           ...(hasGroups && styles.groupView),
         }}
       >
-        <ProgressTable minimal={minimal} />
+        <ProgressTable minimal={minimal} isOnLevelView={true} />
         <GoogleClassroomAttributionLabel />
       </div>
     );

--- a/apps/src/templates/progress/DetailProgressTable.jsx
+++ b/apps/src/templates/progress/DetailProgressTable.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 
 import ProgressLesson from './ProgressLesson';
@@ -10,6 +11,7 @@ import {groupedLessonsType} from './progressTypes';
 export default class DetailProgressTable extends React.Component {
   static propTypes = {
     groupedLesson: groupedLessonsType.isRequired,
+    isOnLevelView: PropTypes.bool,
   };
 
   render() {
@@ -25,6 +27,7 @@ export default class DetailProgressTable extends React.Component {
             key={index}
             lesson={lesson}
             levels={levelsByLesson[index]}
+            isOnLevelView={this.props.isOnLevelView}
           />
         ))}
       </div>

--- a/apps/src/templates/progress/LessonGroup.jsx
+++ b/apps/src/templates/progress/LessonGroup.jsx
@@ -24,6 +24,7 @@ class LessonGroup extends React.Component {
     groupedLesson: groupedLessonsType.isRequired,
     isPlc: PropTypes.bool.isRequired,
     isSummaryView: PropTypes.bool.isRequired,
+    isOnLevelView: PropTypes.bool,
 
     // redux provided
     scriptId: PropTypes.number,
@@ -118,7 +119,10 @@ class LessonGroup extends React.Component {
               [styles.contentsBlue]: isPlc,
             })}
           >
-            <TableType groupedLesson={this.props.groupedLesson} />
+            <TableType
+              groupedLesson={this.props.groupedLesson}
+              isOnLevelView={this.props.isOnLevelView}
+            />
           </div>
         )}
       </div>

--- a/apps/src/templates/progress/ProgressLesson.jsx
+++ b/apps/src/templates/progress/ProgressLesson.jsx
@@ -26,6 +26,7 @@ class ProgressLesson extends React.Component {
   static propTypes = {
     lesson: lessonType.isRequired,
     levels: PropTypes.arrayOf(levelWithProgressType).isRequired,
+    isOnLevelView: PropTypes.bool,
 
     // redux provided
     scriptId: PropTypes.number,
@@ -83,6 +84,7 @@ class ProgressLesson extends React.Component {
       selectedSectionId,
       isRtl,
       unitHasUnnumberedLessons,
+      isOnLevelView,
     } = this.props;
 
     if (!isVisible) {
@@ -189,7 +191,8 @@ class ProgressLesson extends React.Component {
               <span>{title}</span>
             </div>
             {viewAs === ViewType.Participant &&
-              lesson.student_lesson_plan_html_url && (
+              lesson.student_lesson_plan_html_url &&
+              !isOnLevelView && (
                 <Button
                   __useDeprecatedTag
                   className="ui-test-lesson-resources"

--- a/apps/src/templates/progress/ProgressTable.jsx
+++ b/apps/src/templates/progress/ProgressTable.jsx
@@ -21,6 +21,7 @@ class ProgressTable extends React.Component {
     isSummaryView: PropTypes.bool.isRequired,
     groupedLessons: PropTypes.arrayOf(groupedLessonsType).isRequired,
     minimal: PropTypes.bool,
+    isOnLevelView: PropTypes.bool,
   };
 
   componentDidMount() {
@@ -39,7 +40,8 @@ class ProgressTable extends React.Component {
   }
 
   render() {
-    const {isSummaryView, isPlc, groupedLessons, minimal} = this.props;
+    const {isSummaryView, isPlc, groupedLessons, minimal, isOnLevelView} =
+      this.props;
 
     if (
       groupedLessons.length === 1 &&
@@ -53,6 +55,7 @@ class ProgressTable extends React.Component {
             <SummaryProgressTable
               groupedLesson={groupedLessons[0]}
               minimal={minimal}
+              isOnLevelView={isOnLevelView}
             />
           </div>
           <div style={isSummaryView ? styles.hidden : {}}>
@@ -69,6 +72,7 @@ class ProgressTable extends React.Component {
               isPlc={isPlc}
               groupedLesson={group}
               isSummaryView={isSummaryView}
+              isOnLevelView={isOnLevelView}
             />
           ))}
         </div>

--- a/apps/src/templates/progress/SummaryProgressRow.jsx
+++ b/apps/src/templates/progress/SummaryProgressRow.jsx
@@ -29,6 +29,7 @@ function SummaryProgressRow({
   lessonIsLockedForAllStudents,
   unitHasUnnumberedLessons,
   viewAs,
+  isOnLevelView,
 }) {
   // The parent component filters out hidden SummaryProgressRows from the student view,
   // this check is just to ensure it won't be rendered if it should be hidden for students
@@ -127,7 +128,7 @@ function SummaryProgressRow({
             )}
             {lesson.isFocusArea && <FocusAreaIndicator />}
           </div>
-          {lesson.student_lesson_plan_html_url && (
+          {lesson.student_lesson_plan_html_url && !isOnLevelView && (
             <Button
               __useDeprecatedTag
               className="ui-test-lesson-resources"
@@ -149,6 +150,7 @@ SummaryProgressRow.propTypes = {
   dark: PropTypes.bool.isRequired,
   lesson: lessonType.isRequired,
   levels: PropTypes.arrayOf(levelWithProgressType).isRequired,
+  isOnLevelView: PropTypes.bool,
 
   // from redux
   viewAs: PropTypes.oneOf(Object.keys(ViewType)),

--- a/apps/src/templates/progress/SummaryProgressRow.jsx
+++ b/apps/src/templates/progress/SummaryProgressRow.jsx
@@ -127,19 +127,18 @@ function SummaryProgressRow({
             )}
             {lesson.isFocusArea && <FocusAreaIndicator />}
           </div>
-          {viewAs === ViewType.Participant &&
-            lesson.student_lesson_plan_html_url && (
-              <Button
-                __useDeprecatedTag
-                className="ui-test-lesson-resources"
-                href={lesson.student_lesson_plan_html_url}
-                text={i18n.lessonResources()}
-                icon="file-text"
-                color="white"
-                target="_blank"
-                style={styles.buttonStyle}
-              />
-            )}
+          {lesson.student_lesson_plan_html_url && (
+            <Button
+              __useDeprecatedTag
+              className="ui-test-lesson-resources"
+              href={lesson.student_lesson_plan_html_url}
+              text={i18n.lessonResources()}
+              icon="file-text"
+              color="white"
+              target="_blank"
+              style={styles.buttonStyle}
+            />
+          )}
         </div>
       </td>
     </tr>

--- a/apps/src/templates/progress/SummaryProgressRow.jsx
+++ b/apps/src/templates/progress/SummaryProgressRow.jsx
@@ -6,6 +6,7 @@ import ReactTooltip from 'react-tooltip';
 
 import {ViewType} from '@cdo/apps/code-studio/viewAsRedux';
 import fontConstants from '@cdo/apps/fontConstants';
+import Button from '@cdo/apps/legacySharedComponents/Button';
 import FontAwesome from '@cdo/apps/legacySharedComponents/FontAwesome';
 import color from '@cdo/apps/util/color';
 import i18n from '@cdo/locale';
@@ -112,17 +113,34 @@ function SummaryProgressRow({
           ...(isLockedForUser && styles.fadedCol),
         }}
       >
-        {levels.length === 0 ? (
-          i18n.lessonContainsNoLevels()
-        ) : (
-          <ProgressBubbleSet
-            levels={levels}
-            disabled={isLockedForUser}
-            style={lesson.isFocusArea ? styles.focusAreaMargin : undefined}
-            lessonName={lesson.name}
-          />
-        )}
-        {lesson.isFocusArea && <FocusAreaIndicator />}
+        <div style={styles.col2Content}>
+          <div style={styles.col2Left}>
+            {levels.length === 0 ? (
+              i18n.lessonContainsNoLevels()
+            ) : (
+              <ProgressBubbleSet
+                levels={levels}
+                disabled={isLockedForUser}
+                style={lesson.isFocusArea ? styles.focusAreaMargin : undefined}
+                lessonName={lesson.name}
+              />
+            )}
+            {lesson.isFocusArea && <FocusAreaIndicator />}
+          </div>
+          {viewAs === ViewType.Participant &&
+            lesson.student_lesson_plan_html_url && (
+              <Button
+                __useDeprecatedTag
+                className="ui-test-lesson-resources"
+                href={lesson.student_lesson_plan_html_url}
+                text={i18n.lessonResources()}
+                icon="file-text"
+                color="white"
+                target="_blank"
+                style={styles.buttonStyle}
+              />
+            )}
+        </div>
       </td>
     </tr>
   );
@@ -171,6 +189,18 @@ export const styles = {
     width: '100%',
     paddingLeft: 20,
     paddingRight: 20,
+  },
+  col2Content: {
+    display: 'flex',
+    alignItems: 'center',
+    width: '100%',
+  },
+  col2Left: {
+    flex: 1,
+  },
+  buttonStyle: {
+    marginLeft: 10,
+    boxShadow: 'none',
   },
   // When we set our opacity on the row element instead of on individual tds,
   // there are weird interactions with our tooltips in Chrome, and borders end

--- a/apps/src/templates/progress/SummaryProgressTable.jsx
+++ b/apps/src/templates/progress/SummaryProgressTable.jsx
@@ -13,13 +13,14 @@ class SummaryProgressTable extends React.Component {
   static propTypes = {
     groupedLesson: groupedLessonsType.isRequired,
     minimal: PropTypes.bool,
+    isOnLevelView: PropTypes.bool,
 
     // redux provided
     lessonIsVisible: PropTypes.func.isRequired,
   };
 
   render() {
-    const {minimal} = this.props;
+    const {minimal, isOnLevelView} = this.props;
     const {lessons, levelsByLesson} = this.props.groupedLesson;
 
     if (lessons.length !== levelsByLesson.length) {
@@ -53,6 +54,7 @@ class SummaryProgressTable extends React.Component {
                   levels={levelsByLesson[item.unfilteredIndex]}
                   lesson={item.lesson}
                   dark={filteredIndex % 2 === 1}
+                  isOnLevelView={isOnLevelView}
                 />
               ))
           }

--- a/apps/test/unit/templates/progress/ProgressLessonTest.js
+++ b/apps/test/unit/templates/progress/ProgressLessonTest.js
@@ -330,6 +330,7 @@ describe('ProgressLesson', () => {
       />
     );
     expect(wrapper.find('Button').length).toEqual(0);
+    delete myLesson.student_lesson_plan_html_url;
   });
 
   it('does not show Lesson Resources button when viewing as a instructor and student_lesson_plan_html_url is not null', () => {

--- a/apps/test/unit/templates/progress/ProgressLessonTest.js
+++ b/apps/test/unit/templates/progress/ProgressLessonTest.js
@@ -318,6 +318,20 @@ describe('ProgressLesson', () => {
     expect(wrapper.find('Button').length).toEqual(0);
   });
 
+  it('does not show Lesson Resources button when viewing as a participant and student_lesson_plan_html_url is not null, and isOnLevelView is true', () => {
+    let myLesson = defaultProps.lesson;
+    myLesson.student_lesson_plan_html_url = 'test-url';
+    const wrapper = shallow(
+      <ProgressLesson
+        {...defaultProps}
+        lesson={myLesson}
+        viewAs={ViewType.Participant}
+        isOnLevelView={true}
+      />
+    );
+    expect(wrapper.find('Button').length).toEqual(0);
+  });
+
   it('does not show Lesson Resources button when viewing as a instructor and student_lesson_plan_html_url is not null', () => {
     let myLesson = defaultProps.lesson;
     myLesson.student_lesson_plan_html_url = 'test-url';

--- a/apps/test/unit/templates/progress/SummaryProgressRowTest.js
+++ b/apps/test/unit/templates/progress/SummaryProgressRowTest.js
@@ -81,6 +81,30 @@ describe('SummaryProgressRow', () => {
       );
     });
 
+    it('shows lesson resources button when lesson has student_lesson_plan_html_url', () => {
+      const lessonWithUrl = {
+        ...fakeLesson('Maze', 1, false, 3),
+        student_lesson_plan_html_url: 'https://example.com/lesson-plan',
+      };
+      const wrapper = setUp({
+        lesson: lessonWithUrl,
+        viewAs: ViewType.Participant,
+      });
+
+      const button = wrapper.find('Button');
+      expect(button).toHaveLength(1);
+      expect(button.props().href).toEqual('https://example.com/lesson-plan');
+      expect(button.props().className).toEqual('ui-test-lesson-resources');
+    });
+
+    it('does not show lesson resources button when lesson has no student_lesson_plan_html_url', () => {
+      const wrapper = setUp({
+        viewAs: ViewType.Participant,
+      });
+
+      expect(wrapper.find('Button')).toHaveLength(0);
+    });
+
     it('has a lock icon when lockable and locked for user', () => {
       const wrapper = setUp({
         lesson: fakeLesson('Maze', 1, true),
@@ -176,6 +200,19 @@ describe('SummaryProgressRow', () => {
       });
 
       expect(wrapper.find('FontAwesome').at(0).props().icon).toEqual('unlock');
+    });
+
+    it('does not show lesson resources button when viewing as instructor', () => {
+      const lessonWithUrl = {
+        ...fakeLesson('Maze', 1, false, 3),
+        student_lesson_plan_html_url: 'https://example.com/lesson-plan',
+      };
+      const wrapper = setUp({
+        lesson: lessonWithUrl,
+        viewAs: ViewType.Instructor,
+      });
+
+      expect(wrapper.find('Button')).toHaveLength(0);
     });
   });
 });

--- a/apps/test/unit/templates/progress/SummaryProgressRowTest.js
+++ b/apps/test/unit/templates/progress/SummaryProgressRowTest.js
@@ -102,6 +102,20 @@ describe('SummaryProgressRow', () => {
       expect(wrapper.find('Button')).toHaveLength(0);
     });
 
+    it('does not show lesson resources button when lesson has student_lesson_plan_html_url and isOnLevelView is true', () => {
+      const lessonWithUrl = {
+        ...fakeLesson('Maze', 1, false, 3),
+        student_lesson_plan_html_url: 'https://example.com/lesson-plan',
+      };
+      const wrapper = setUp({
+        lesson: lessonWithUrl,
+        isOnLevelView: true,
+      });
+
+      const button = wrapper.find('Button');
+      expect(button).toHaveLength(0);
+    });
+
     it('has a lock icon when lockable and locked for user', () => {
       const wrapper = setUp({
         lesson: fakeLesson('Maze', 1, true),

--- a/apps/test/unit/templates/progress/SummaryProgressRowTest.js
+++ b/apps/test/unit/templates/progress/SummaryProgressRowTest.js
@@ -31,6 +31,41 @@ describe('SummaryProgressRow', () => {
     expect(wrapper.props().id).toEqual('summary-progress-row-3');
   });
 
+  it('shows lesson resources button when lesson has student_lesson_plan_html_url', () => {
+    const lessonWithUrl = {
+      ...fakeLesson('Maze', 1, false, 3),
+      student_lesson_plan_html_url: 'https://example.com/lesson-plan',
+    };
+    const wrapper = setUp({
+      lesson: lessonWithUrl,
+    });
+
+    const button = wrapper.find('Button');
+    expect(button).toHaveLength(1);
+    expect(button.props().href).toEqual('https://example.com/lesson-plan');
+    expect(button.props().className).toEqual('ui-test-lesson-resources');
+  });
+
+  it('does not show lesson resources button when lesson has no student_lesson_plan_html_url', () => {
+    const wrapper = setUp();
+
+    expect(wrapper.find('Button')).toHaveLength(0);
+  });
+
+  it('does not show lesson resources button when lesson has student_lesson_plan_html_url and isOnLevelView is true', () => {
+    const lessonWithUrl = {
+      ...fakeLesson('Maze', 1, false, 3),
+      student_lesson_plan_html_url: 'https://example.com/lesson-plan',
+    };
+    const wrapper = setUp({
+      lesson: lessonWithUrl,
+      isOnLevelView: true,
+    });
+
+    const button = wrapper.find('Button');
+    expect(button).toHaveLength(0);
+  });
+
   describe('when viewing as Participant', () => {
     it('will not render if the lesson is hidden for students', () => {
       const wrapper = setUp({
@@ -79,41 +114,6 @@ describe('SummaryProgressRow', () => {
       expect(wrapper.find('Connect(ProgressBubbleSet)').props().disabled).toBe(
         true
       );
-    });
-
-    it('shows lesson resources button when lesson has student_lesson_plan_html_url', () => {
-      const lessonWithUrl = {
-        ...fakeLesson('Maze', 1, false, 3),
-        student_lesson_plan_html_url: 'https://example.com/lesson-plan',
-      };
-      const wrapper = setUp({
-        lesson: lessonWithUrl,
-      });
-
-      const button = wrapper.find('Button');
-      expect(button).toHaveLength(1);
-      expect(button.props().href).toEqual('https://example.com/lesson-plan');
-      expect(button.props().className).toEqual('ui-test-lesson-resources');
-    });
-
-    it('does not show lesson resources button when lesson has no student_lesson_plan_html_url', () => {
-      const wrapper = setUp();
-
-      expect(wrapper.find('Button')).toHaveLength(0);
-    });
-
-    it('does not show lesson resources button when lesson has student_lesson_plan_html_url and isOnLevelView is true', () => {
-      const lessonWithUrl = {
-        ...fakeLesson('Maze', 1, false, 3),
-        student_lesson_plan_html_url: 'https://example.com/lesson-plan',
-      };
-      const wrapper = setUp({
-        lesson: lessonWithUrl,
-        isOnLevelView: true,
-      });
-
-      const button = wrapper.find('Button');
-      expect(button).toHaveLength(0);
     });
 
     it('has a lock icon when lockable and locked for user', () => {

--- a/apps/test/unit/templates/progress/SummaryProgressRowTest.js
+++ b/apps/test/unit/templates/progress/SummaryProgressRowTest.js
@@ -88,7 +88,6 @@ describe('SummaryProgressRow', () => {
       };
       const wrapper = setUp({
         lesson: lessonWithUrl,
-        viewAs: ViewType.Participant,
       });
 
       const button = wrapper.find('Button');
@@ -98,9 +97,7 @@ describe('SummaryProgressRow', () => {
     });
 
     it('does not show lesson resources button when lesson has no student_lesson_plan_html_url', () => {
-      const wrapper = setUp({
-        viewAs: ViewType.Participant,
-      });
+      const wrapper = setUp();
 
       expect(wrapper.find('Button')).toHaveLength(0);
     });
@@ -200,19 +197,6 @@ describe('SummaryProgressRow', () => {
       });
 
       expect(wrapper.find('FontAwesome').at(0).props().icon).toEqual('unlock');
-    });
-
-    it('does not show lesson resources button when viewing as instructor', () => {
-      const lessonWithUrl = {
-        ...fakeLesson('Maze', 1, false, 3),
-        student_lesson_plan_html_url: 'https://example.com/lesson-plan',
-      };
-      const wrapper = setUp({
-        lesson: lessonWithUrl,
-        viewAs: ViewType.Instructor,
-      });
-
-      expect(wrapper.find('Button')).toHaveLength(0);
     });
   });
 });


### PR DESCRIPTION
Re-doing [this](https://github.com/code-dot-org/code-dot-org/pull/71613) PR after needing to revert it due to the button showing up on the level pages.


Adds "Lesson Resources" button to collapsed view.

Note I DMed Tess to get a thumbs up on this look.  The tradeoff is that on smaller screens the bubbles will wrap more frequently.

BEFORE:
<img width="1010" height="710" alt="image" src="https://github.com/user-attachments/assets/8dc61d7a-f99e-4451-875f-d69050a0c866" />


AFTER:
<img width="889" height="646" alt="image" src="https://github.com/user-attachments/assets/1fd99b21-35d3-4467-9a1a-c1db060067a1" />




## Links
[Ticket](https://codedotorg.atlassian.net/browse/TEACHING-116)

## Testing story
Added to exisiting tests.

Will notify DOTD that this will cause eyes tests diffs.
