### PR TITLE
Modify bubble choice for Lab2 to be a-tags instead of buttons

### DIFF
--- a/apps/src/bubbleChoice/BubbleChoice.tsx
+++ b/apps/src/bubbleChoice/BubbleChoice.tsx
@@ -132,7 +132,11 @@ const BubbleChoice: React.FC<LabProps<BubbleChoiceLevelProperties>> = ({
     return level;
   };
 
-  const navigateToSublevel = (sublevel: BubbleChoiceSublevel) => {
+  const navigateToSublevel = (
+    event: React.MouseEvent<HTMLAnchorElement>,
+    sublevel: BubbleChoiceSublevel
+  ) => {
+    event.preventDefault(); // Prevent default link navigation
     if (currentLessonId) {
       dispatch(navigateToLevelId(sublevel.level_id));
     } else {
@@ -171,9 +175,9 @@ const BubbleChoice: React.FC<LabProps<BubbleChoiceLevelProperties>> = ({
           }}
         >
           {levelBubbleChoice.sublevels.map((sublevel, index) => (
-            <button
-              type="button"
+            <a
               key={index}
+              href={sublevel.url}
               className={classNames(
                 'uitest-bubble-choice',
                 styles.sublevelButton
@@ -181,8 +185,10 @@ const BubbleChoice: React.FC<LabProps<BubbleChoiceLevelProperties>> = ({
               style={{
                 width: imageWidth,
                 height: imageWidth / aspectRatio,
+                display: 'block',
+                textDecoration: 'none',
               }}
-              onClick={() => navigateToSublevel(sublevel)}
+              onClick={event => navigateToSublevel(event, sublevel)}
             >
               <div
                 className={styles.sublevelImageContainer}
@@ -221,7 +227,7 @@ const BubbleChoice: React.FC<LabProps<BubbleChoiceLevelProperties>> = ({
                   />
                 )}
               </div>
-            </button>
+            </a>
           ))}
         </div>
       </div>

--- a/apps/src/bubbleChoice/BubbleChoice.tsx
+++ b/apps/src/bubbleChoice/BubbleChoice.tsx
@@ -138,7 +138,6 @@ const BubbleChoice: React.FC<LabProps<BubbleChoiceLevelProperties>> = ({
   ) => {
     event.preventDefault(); // Prevent default link navigation
     if (currentLessonId) {
-      console.log('before dispatch');
       dispatch(navigateToLevelId(sublevel.level_id));
     } else {
       window.location.href = sublevel.url;
@@ -188,6 +187,7 @@ const BubbleChoice: React.FC<LabProps<BubbleChoiceLevelProperties>> = ({
                 height: imageWidth / aspectRatio,
                 textDecoration: 'none',
               }}
+              aria-label={sublevel.display_name}
               onClick={event => navigateToSublevel(event, sublevel)}
             >
               <div

--- a/apps/src/bubbleChoice/BubbleChoice.tsx
+++ b/apps/src/bubbleChoice/BubbleChoice.tsx
@@ -138,6 +138,7 @@ const BubbleChoice: React.FC<LabProps<BubbleChoiceLevelProperties>> = ({
   ) => {
     event.preventDefault(); // Prevent default link navigation
     if (currentLessonId) {
+      console.log('before dispatch');
       dispatch(navigateToLevelId(sublevel.level_id));
     } else {
       window.location.href = sublevel.url;
@@ -185,7 +186,6 @@ const BubbleChoice: React.FC<LabProps<BubbleChoiceLevelProperties>> = ({
               style={{
                 width: imageWidth,
                 height: imageWidth / aspectRatio,
-                display: 'block',
                 textDecoration: 'none',
               }}
               onClick={event => navigateToSublevel(event, sublevel)}


### PR DESCRIPTION
Levelbuilder users were frustrated by the way that Bubble Choice levels worked in Lab2 (see thread below).  This changes the way the bubble choices are displayed so that they can right click to navigate

Video comparing the old and new behavior:

https://github.com/user-attachments/assets/ecb8e462-0703-48c3-af59-3b068437d3fa





Checked for:

- Resizing
- Tab navigatable
- Solves the issue





## Links
[Prior PR ](https://github.com/code-dot-org/code-dot-org/pull/65384)- no mention of button vs a-tags
[Thread request](https://codedotorg.slack.com/archives/C045UAX4WKH/p1774572420698109)

Video of the problem

https://github.com/user-attachments/assets/c75d6def-08a3-4548-8fb2-b9e456082857



## Testing story
I could not find any unit tests for this.  I will notify DOTD about eyes tests issues, but they should be minimal...

