### PR TITLE
Clear PartialRegistration when Continue selected on LTI account linking page

### DIFF
--- a/dashboard/app/controllers/lti/v1/account_linking_controller.rb
+++ b/dashboard/app/controllers/lti/v1/account_linking_controller.rb
@@ -68,6 +68,7 @@ module Lti
           current_user.lms_landing_opted_out = true
           current_user.verify_teacher! if Policies::Lti.unverified_teacher?(current_user)
           current_user.save!
+          PartialRegistration.delete(session)
         elsif PartialRegistration.in_progress?(session)
           partial_user = User.new_with_session(ActionController::Parameters.new, session)
           partial_user.lms_landing_opted_out = true

--- a/dashboard/app/controllers/omniauth_callbacks_controller.rb
+++ b/dashboard/app/controllers/omniauth_callbacks_controller.rb
@@ -646,7 +646,13 @@ class OmniauthCallbacksController < Devise::OmniauthCallbacksController
   # Determine whether to link a new LTI auth option to an existing account
   # Not to be confused with the connect_provider flow
   private def should_link_accounts?
-    Policies::Lti.lti_registration_in_progress?(session) && !account_linking_locked?
+    return false unless Policies::Lti.lti_registration_in_progress?(session)
+    return false if current_user&.lms_landing_opted_out
+
+    partial_user = User.new_with_session(ActionController::Parameters.new, session)
+    return false if partial_user&.lms_landing_opted_out
+
+    !account_linking_locked?
   end
 
   # For linking new LTI auth options to existing accounts

--- a/dashboard/test/controllers/lti/v1/account_linking_controller_test.rb
+++ b/dashboard/test/controllers/lti/v1/account_linking_controller_test.rb
@@ -115,6 +115,7 @@ class Lti::V1::AccountLinkingControllerTest < ActionController::TestCase
     context 'when signed in' do
       before do
         sign_in user
+        PartialRegistration.persist_attributes(session, user)
       end
 
       it 'opts the user out of lms landing' do
@@ -122,6 +123,12 @@ class Lti::V1::AccountLinkingControllerTest < ActionController::TestCase
 
         user.reload
         _(user.lms_landing_opted_out).must_equal true
+      end
+
+      it 'clears partial registration from the session' do
+        new_account_request
+
+        _(PartialRegistration.in_progress?(session)).must_be_nil
       end
 
       it 'verifies the teacher' do
@@ -139,6 +146,13 @@ class Lti::V1::AccountLinkingControllerTest < ActionController::TestCase
 
         partial_user = User.new_with_session(ActionController::Parameters.new, session)
         _(partial_user.lms_landing_opted_out).must_equal true
+      end
+
+      it 'keeps partial registration in the session' do
+        PartialRegistration.persist_attributes(session, user)
+        new_account_request
+
+        _(PartialRegistration.in_progress?(session)).must_equal true
       end
     end
 

--- a/dashboard/test/controllers/omniauth_callbacks_controller_test.rb
+++ b/dashboard/test/controllers/omniauth_callbacks_controller_test.rb
@@ -1827,6 +1827,55 @@ class OmniauthCallbacksControllerTest < ActionController::TestCase
     end
   end
 
+  test 'opted-out LTI partial registration does not trigger account linking' do
+    user = create(:teacher)
+    lti_integration = create(:lti_integration)
+    provider_auth_option = create(
+      :authentication_option,
+      user: user,
+      email: user.email,
+      hashed_email: user.hashed_email,
+      credential_type: AuthenticationOption::GOOGLE,
+      authentication_id: SecureRandom.uuid,
+      data: {
+        oauth_token: 'some-google-token',
+        oauth_refresh_token: 'some-google-refresh-token',
+        oauth_token_expiration: '999999'
+      }.to_json
+    )
+    partial_lti_teacher = create(:teacher, lms_landing_opted_out: true)
+    partial_lti_teacher.authentication_options = [
+      AuthenticationOption.new(
+        authentication_id: Services::Lti::AuthIdGenerator.new(
+          {iss: lti_integration.issuer, aud: lti_integration.client_id, sub: 'foo'}
+        ).call,
+        credential_type: AuthenticationOption::LTI_V1,
+        email: user.email,
+      )
+    ]
+
+    @controller.stubs(:account_linking_lock_reason).with(user).returns(nil)
+    @request.env['omniauth.auth'] = generate_auth_user_hash(
+      provider: AuthenticationOption::GOOGLE,
+      uid: provider_auth_option.authentication_id
+    )
+    @request.env['omniauth.params'] = {}
+    PartialRegistration.persist_attributes(session, partial_lti_teacher)
+
+    Metrics::Events.expects(:log_event).with(
+      has_entries(
+        user: user,
+        event_name: 'lti_account_linked'
+      )
+    ).never
+
+    get :google_oauth2
+
+    user.reload
+    _(user.authentication_options.count).must_equal 2
+    _(user.lti_user_identities.count).must_equal 0
+  end
+
   describe '#register_new_user' do
     let(:domain) {'testdomain.com'}
     let(:disallowed_domains) {{domain => {provider_exceptions: ['clever']}}}


### PR DESCRIPTION
When the user successfully links their LTI login to an existing account, we clear the `PartialRegistration` in the account linking service. However, if they instead select to continue with a new roster-synced account, we set their `lms_landing_opted_out` flag but leave the `PartialRegistration`. If they subsequently add an OAuth login to their account prior to the `PartialRegistration` cache expiring, then hit the OAuth login route for that provider, the `OmniauthCallbacksController` will recognize them as still in the account linking flow, and pass their user object into the account linking. This inadvertently deletes their account and actually sort of unlinks it, because the account they had previously linked their OAuth login to is now gone.

Repro steps:

- Sync an LTI course, creating students
- Launch as one of the students, selecting Continue from the account linking page
- In the same session, go to Account Settings and link Clever
- From the Clever dashboard, launch the tool (or otherwise hit the OAuth login route)
- You should get hit with an error, and your account will effectively be unlinked.

More info in the JIRA attachments, including the Statsig event log for the user that hit this error in prod, showing the breadcrumbs that lead to these repro steps.

This PR fixes the bug by:
- Clearing the `PartialRegistration` after the user selects Continue
- Hardening the `should_link_accounts?` check in OmniauthCallbackController, so that it respects the `lms_landing_opted_out` flag.

## Links
[JIRA](https://codedotorg.atlassian.net/browse/P20-1834)

## Testing story
<!-- How was this tested? Manual steps, adhoc links, automated tests, or why testing isn't needed. -->



## Deployment notes
<!-- Delete this section if it's a standard merge-and-deploy.
     Otherwise: migrations, feature flags, coordination, caching impacts, etc. -->



## Privacy and security
<!-- Delete this section if there is no privacy/security impact.
     Otherwise: new PII, auth changes, API surface changes, etc. -->

