### PR TITLE
[Blockly Dance Party AI] Restore generated dancer Icon

### DIFF
--- a/apps/src/dance/blockly/blocks.js
+++ b/apps/src/dance/blockly/blocks.js
@@ -123,11 +123,7 @@ const customInputTypes = {
       currentInputRow
         .appendField(inputConfig.label)
         .appendField(
-          new CdoFieldImage(
-            [[getGeneratedDancerHeadUrl(), GENERATED_DANCER]],
-            40,
-            40
-          ),
+          new CdoFieldImage(getGeneratedDancerHeadUrl(), 40, 40),
           inputConfig.name
         );
     },


### PR DESCRIPTION
**Regression introduced in:** #71119 ("Remove custom field classes from wrapper")

### What broke

The `generatedDancerImage` custom input type was added in #71119 with the wrong constructor call:

new CdoFieldImage([[getGeneratedDancerHeadUrl(), GENERATED_DANCER]], 40, 40)
CdoFieldImage expects a URL string as its first argument — not an array. This caused the image to fail to render, leaving the block without its dancer icon.

### Why the fix is correct
The [url, codeValue] format belongs to CdoFieldImageDropdown, where each option needs both a display image and a serialized code value. CdoFieldImage just displays a fixed image, and generateCode already hardcodes "GENERATED_DANCER" as the return value regardless of the field's value.

Before (no dancer icon): 

<img width="1625" height="809" alt="Screenshot 2026-03-27 at 5 17 15 PM" src="https://github.com/user-attachments/assets/0263b043-304e-406f-9387-0c1b334bcd64" />


After (has correct dancer icon):

<img width="2996" height="1604" alt="Screenshot 2026-03-27 at 5 12 16 PM" src="https://github.com/user-attachments/assets/6d61fed0-2c64-4712-be7b-03f15d4f1711" />



## Links

- Jira: https://codedotorg.atlassian.net/browse/SL-1647

## Testing story
<!-- How was this tested? Manual steps, adhoc links, automated tests, or why testing isn't needed. -->



## Deployment notes
<!-- Delete this section if it's a standard merge-and-deploy.
     Otherwise: migrations, feature flags, coordination, caching impacts, etc. -->



## Privacy and security
<!-- Delete this section if there is no privacy/security impact.
     Otherwise: new PII, auth changes, API surface changes, etc. -->

