### PR TITLE
Fix checkbox and slider style regressions after MUI ThemeProvider enablement

### DIFF
--- a/frontend/packages/component-library/src/checkbox/checkbox.module.scss
+++ b/frontend/packages/component-library/src/checkbox/checkbox.module.scss
@@ -30,6 +30,7 @@
 
     & + i {
       vertical-align: bottom;
+      box-sizing: content-box;
 
       &::before {
         display: inline-block;

--- a/frontend/packages/component-library/src/slider/slider.module.scss
+++ b/frontend/packages/component-library/src/slider/slider.module.scss
@@ -199,7 +199,10 @@ $slider-aqua-track-disabled-color: var(--background-neutral-disabled);
 // Slider Colors
 .slider-black {
   .sliderLabelSection {
-    color: var(--text-neutral-primary);
+    label,
+    span {
+      color: var(--text-neutral-primary);
+    }
   }
 
   .sliderMainContainer {
@@ -261,7 +264,10 @@ $slider-aqua-track-disabled-color: var(--background-neutral-disabled);
   &.isDisabled {
     // Using .isDisabled here because :has(input[type='range']:disabled) is not working here
     .sliderLabelSection {
-      color: var(--text-neutral-disabled);
+      label,
+      span {
+        color: var(--text-neutral-disabled);
+      }
     }
 
     .sliderMainContainer {
@@ -287,7 +293,10 @@ $slider-aqua-track-disabled-color: var(--background-neutral-disabled);
 
 .slider-brand {
   .sliderLabelSection {
-    color: var(--text-neutral-primary);
+    label,
+    span {
+      color: var(--text-neutral-primary);
+    }
   }
 
   .sliderMainContainer {
@@ -349,7 +358,10 @@ $slider-aqua-track-disabled-color: var(--background-neutral-disabled);
   &.isDisabled {
     // Using .isDisabled here because :has(input[type='range']:disabled) is not working here
     .sliderLabelSection {
-      color: var(--text-neutral-disabled);
+      label,
+      span {
+        color: var(--text-neutral-disabled);
+      }
     }
 
     .sliderMainContainer {
@@ -375,7 +387,10 @@ $slider-aqua-track-disabled-color: var(--background-neutral-disabled);
 
 .slider-white {
   .sliderLabelSection {
-    color: var(--text-neutral-inverse);
+    label,
+    span {
+      color: var(--text-neutral-inverse);
+    }
   }
 
   .sliderMainContainer {
@@ -437,7 +452,10 @@ $slider-aqua-track-disabled-color: var(--background-neutral-disabled);
   &.isDisabled {
     // Using .isDisabled here because :has(input[type='range']:disabled) is not working here
     .sliderLabelSection {
-      color: var(--neutral-gray-80);
+      label,
+      span {
+        color: var(--neutral-gray-80);
+      }
     }
 
     .sliderMainContainer {
@@ -463,7 +481,10 @@ $slider-aqua-track-disabled-color: var(--background-neutral-disabled);
 
 .slider-aqua {
   .sliderLabelSection {
-    color: var(--text-neutral-primary);
+    label,
+    span {
+      color: var(--text-neutral-primary);
+    }
   }
 
   .sliderMainContainer {
@@ -525,7 +546,10 @@ $slider-aqua-track-disabled-color: var(--background-neutral-disabled);
   &.isDisabled {
     // Using .isDisabled here because :has(input[type='range']:disabled) is not working here
     .sliderLabelSection {
-      color: var(--text-neutral-disabled);
+      label,
+      span {
+        color: var(--text-neutral-disabled);
+      }
     }
 
     .sliderMainContainer {


### PR DESCRIPTION
## Summary
- **Checkbox**: Add `box-sizing: content-box` to the checkbox icon to fix sizing regression caused by MUI's global `border-box` reset.
- **Slider**: Target `label` and `span` elements directly within `.sliderLabelSection` for color overrides, preventing MUI's inherited styles from overriding our design tokens.

These are minor visual regressions found after merging #71644 (Enable MUI ThemeProvider by default in design-system-storybook).

## Test plan
- [x] Verify checkbox renders at correct size in Storybook
- [x] Verify slider label colors are correct across all color variants (black, brand, white, aqua) in both enabled and disabled states

🤖 Generated with [Claude Code](https://claude.com/claude-code)