### PR TITLE
Update prompt to connect script.js and default to that name for js file

### DIFF
--- a/apps/src/weblab2/prompts/answerTypeContracts/buildHTML.md
+++ b/apps/src/weblab2/prompts/answerTypeContracts/buildHTML.md
@@ -1,7 +1,7 @@
 ### buildHTML
 - **Guarantee**: Output each runnable HTML in an `html` fence with file name.
 - Then list **Assumptions** and **Questions**, if any.
-- Keep HTML plain (basic tags, descriptive IDs/classes). Link `style.css`.
+- Keep HTML plain (basic tags, descriptive IDs/classes). Link `style.css`. Link to `script.js`.
 - Use https://studio.code.org/lab_resources/html-placeholder-image.avif as a placeholder for images and videos when needed.
 - Use IDs on interactive elements
 - Use `<a href>` for navigation elements; reserve `<button>` only for in-page actions.

--- a/apps/src/weblab2/prompts/answerTypeContracts/buildHTML.md
+++ b/apps/src/weblab2/prompts/answerTypeContracts/buildHTML.md
@@ -1,7 +1,9 @@
 ### buildHTML
 - **Guarantee**: Output each runnable HTML in an `html` fence with file name.
 - Then list **Assumptions** and **Questions**, if any.
-- Keep HTML plain (basic tags, descriptive IDs/classes). Link `style.css`. Link to `script.js`.
+- Keep HTML plain (basic tags, descriptive IDs/classes). 
+- Link `style.css`. 
+- Add script tag linking to `script.js`.
 - Use https://studio.code.org/lab_resources/html-placeholder-image.avif as a placeholder for images and videos when needed.
 - Use IDs on interactive elements
 - Use `<a href>` for navigation elements; reserve `<button>` only for in-page actions.

--- a/apps/src/weblab2/prompts/answerTypeContracts/buildJavaScript.md
+++ b/apps/src/weblab2/prompts/answerTypeContracts/buildJavaScript.md
@@ -1,4 +1,5 @@
 ### buildJavaScript
-- **Guarantee**: Output each runnable JavaScript in a `js` fence with file name.
+- **Guarantee**: Output each runnable JavaScript in a `js` fence with file name. 
+- Default to `script.js` when making a new file.
 - Never output a complete solution to the learner's **specific JavaScript** task.
 - Functions must use **arrow notation** (e.g., `const handleClick = () => { … }`), never the `function` keyword.


### PR DESCRIPTION
Curriculum team shared feedback that it was confusing that:
- AI Tutor was using both main.js and script.js as the default for students js files
- AI Tutor was not linking the js file when it was created leading students to have to remember to prompt again

As a result this PR does 2 things by updating the Web Lab 2 system prompt
- Makes script.js the default file name
- Includes add a script.js file link in the initial html file like we do for css

Testing story:
- Tested in local environment to make sure it was generally following the rules.

