### PR TITLE
aichat: show student chat history with disabled alert to teachers when chat is disabled

### DIFF
--- a/apps/i18n/lab2/en_us.json
+++ b/apps/i18n/lab2/en_us.json
@@ -26,7 +26,6 @@
   "page": "Page",
   "pages": "Pages",
   "pass": "Pass",
-  "predictTutorDisabledMessage": "AI Tutor is disabled until you submit your prediction.",
   "result": "Result",
   "resourcePanelOnboarding_title": "Resource area",
   "resourcePanelOnboarding_text": "All your helpful resources can be found in the resource area. When starting a level it will always show the instructions tab first.",

--- a/apps/src/Globals.d.ts
+++ b/apps/src/Globals.d.ts
@@ -53,9 +53,6 @@ interface Window {
   appOptions?: {
     level?: {
       aiTutorAvailable?: boolean;
-      predictSettings?: {
-        isPredictLevel?: boolean;
-      };
     };
   };
 }

--- a/apps/src/Globals.d.ts
+++ b/apps/src/Globals.d.ts
@@ -53,6 +53,9 @@ interface Window {
   appOptions?: {
     level?: {
       aiTutorAvailable?: boolean;
+      predictSettings?: {
+        isPredictLevel?: boolean;
+      };
     };
   };
 }

--- a/apps/src/aiTutor/views/legacyLabs/AiTutorContainer.tsx
+++ b/apps/src/aiTutor/views/legacyLabs/AiTutorContainer.tsx
@@ -59,6 +59,18 @@ export const AiTutorContainer: FC<{
     state => selectedSectionSelector(state)?.aiChatAccessLevel
   );
 
+  const aiTutorAvailableForLevel =
+    window?.appOptions?.level?.aiTutorAvailable ?? false;
+
+  const tutorDisabledForSelectedSection =
+    !!sectionAiChatAccessLevel &&
+    !!labState.appType &&
+    !shouldShowAiTutor({
+      appName: labState.appType,
+      tutorLevel: aiTutorAvailableForLevel,
+      aiChatAccessLevel: sectionAiChatAccessLevel,
+    });
+
   const isPredictLevel =
     window?.appOptions?.level?.predictSettings?.isPredictLevel ?? false;
   const awaitingContainedResponse = useAppSelector(
@@ -73,18 +85,6 @@ export const AiTutorContainer: FC<{
     hasSubmittedPredictResponse: !awaitingContainedResponse,
   });
 
-  const aiTutorAvailableForLevel =
-    window?.appOptions?.level?.aiTutorAvailable ?? false;
-
-  const shouldShowTutor =
-    sectionAiChatAccessLevel && labState.appType
-      ? shouldShowAiTutor({
-          appName: labState.appType,
-          tutorLevel: aiTutorAvailableForLevel,
-          aiChatAccessLevel: sectionAiChatAccessLevel,
-        })
-      : false;
-
   const lab: CommonLab | undefined =
     labState.appType === 'weblab' ? window.getWebLab?.() : studioApp()?.config;
 
@@ -92,7 +92,7 @@ export const AiTutorContainer: FC<{
   // student's history so we can decide whether to show the component before
   // ChatWorkspace mounts.
   useEffect(() => {
-    if (!shouldShowTutor && viewAsUserId) {
+    if (tutorDisabledForSelectedSection && viewAsUserId) {
       dispatch(
         fetchUserChatHistory({
           userId: viewAsUserId,
@@ -115,7 +115,8 @@ export const AiTutorContainer: FC<{
     hasEverHadHistory.current = true;
   }
 
-  const isVisible = shouldShowTutor || hasEverHadHistory.current;
+  const isVisible =
+    !tutorDisabledForSelectedSection || hasEverHadHistory.current;
 
   useEffect(() => {
     onLayoutChange({isVisible, isOpen: aiChatOpen});

--- a/apps/src/aiTutor/views/legacyLabs/AiTutorContainer.tsx
+++ b/apps/src/aiTutor/views/legacyLabs/AiTutorContainer.tsx
@@ -5,10 +5,12 @@ import React, {FC, useEffect, useRef, useState} from 'react';
 
 import {shouldShowAiTutor} from '@cdo/apps/aichat/helpers/aiChatAccess';
 import {fetchUserChatHistory} from '@cdo/apps/aichat/redux';
+import {useAiChatDisabledState} from '@cdo/apps/lab2/hooks/useAiChatDisabledState';
 import AiTutorChat from '@cdo/apps/lab2/views/components/AiTutorChat';
 import {LegacyLabsState} from '@cdo/apps/redux/legacyLabs';
 import {singleton as studioApp} from '@cdo/apps/StudioApp';
 import {selectedSectionSelector} from '@cdo/apps/templates/teacherDashboard/teacherSectionsReduxSelectors';
+import {RootState} from '@cdo/apps/types/redux';
 import {useAppDispatch, useAppSelector} from '@cdo/apps/util/reduxHooks';
 import aiBotOutlineIcon from '@cdo/static/ai-bot-outline.png';
 
@@ -56,6 +58,20 @@ export const AiTutorContainer: FC<{
   const sectionAiChatAccessLevel = useAppSelector(
     state => selectedSectionSelector(state)?.aiChatAccessLevel
   );
+
+  const isPredictLevel =
+    window?.appOptions?.level?.predictSettings?.isPredictLevel ?? false;
+  const awaitingContainedResponse = useAppSelector(
+    state =>
+      (state as RootState & {runState: {awaitingContainedResponse: boolean}})
+        .runState.awaitingContainedResponse
+  );
+
+  useAiChatDisabledState({
+    appName: labState.appType,
+    isPredictLevel,
+    hasSubmittedPredictResponse: !awaitingContainedResponse,
+  });
 
   const aiTutorAvailableForLevel =
     window?.appOptions?.level?.aiTutorAvailable ?? false;

--- a/apps/src/aiTutor/views/legacyLabs/AiTutorContainer.tsx
+++ b/apps/src/aiTutor/views/legacyLabs/AiTutorContainer.tsx
@@ -1,12 +1,13 @@
 import FontAwesomeV6Icon from '@code-dot-org/component-library/fontAwesomeV6Icon';
 import {Typography, IconButton as MuiIconButton} from '@mui/material';
 import classNames from 'classnames';
-import React, {FC} from 'react';
+import React, {FC, useEffect, useRef, useState} from 'react';
 
+import {fetchUserChatHistory} from '@cdo/apps/aichat/redux';
 import AiTutorChat from '@cdo/apps/lab2/views/components/AiTutorChat';
 import {LegacyLabsState} from '@cdo/apps/redux/legacyLabs';
 import {singleton as studioApp} from '@cdo/apps/StudioApp';
-import {useAppSelector} from '@cdo/apps/util/reduxHooks';
+import {useAppDispatch, useAppSelector} from '@cdo/apps/util/reduxHooks';
 import aiBotOutlineIcon from '@cdo/static/ai-bot-outline.png';
 
 import {
@@ -38,20 +39,65 @@ interface CommonLab {
 }
 
 export const AiTutorContainer: FC<{
-  toggleAiChat: () => void;
-  aiChatOpen: boolean;
-}> = ({toggleAiChat, aiChatOpen}) => {
+  shouldShowTutor: boolean;
+  onLayoutChange: (state: {isVisible: boolean; isOpen: boolean}) => void;
+}> = ({shouldShowTutor, onLayoutChange}) => {
+  const [aiChatOpen, setAiChatOpen] = useState(false);
+  const dispatch = useAppDispatch();
+
   const labState = useAppSelector(
     (state: {pageConstants: LegacyLabsState}) => state.pageConstants
   );
+
+  // When a teacher is viewing a student, viewAsUserId is set.
+  const viewAsUserId = useAppSelector(state => state.progress.viewAsUserId);
+
+  const lab: CommonLab | undefined =
+    labState.appType === 'weblab' ? window.getWebLab?.() : studioApp()?.config;
+
+  // When chat is disabled but a teacher is viewing a student, eagerly fetch the
+  // student's history so we can decide whether to show the component before
+  // ChatWorkspace mounts.
+  useEffect(() => {
+    if (!shouldShowTutor && viewAsUserId) {
+      dispatch(
+        fetchUserChatHistory({
+          userId: viewAsUserId,
+          isOwnHistory: false,
+          channelId: lab?.channel,
+        })
+      );
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const hasChatHistory = useAppSelector(
+    state => state.aichat.studentChatHistory.length > 0
+  );
+
+  // Use a ref so visibility doesn't flip back to false when ChatWorkspace
+  // calls clearChatMessages on its own mount (before its re-fetch completes).
+  const hasEverHadHistory = useRef(false);
+  if (hasChatHistory) {
+    hasEverHadHistory.current = true;
+  }
+
+  const isVisible = shouldShowTutor || hasEverHadHistory.current;
+
+  useEffect(() => {
+    onLayoutChange({isVisible, isOpen: aiChatOpen});
+  }, [isVisible, aiChatOpen, onLayoutChange]);
+
+  if (!isVisible) {
+    return null;
+  }
+
+  const toggleAiChat = () => setAiChatOpen(open => !open);
 
   const inLevel = !!labState.serverScriptId;
   const allPrompts = inLevel
     ? [...levelPrompts, ...defaultPrompts]
     : [...standaloneProjectPrompts, ...defaultPrompts];
-
-  const lab: CommonLab | undefined =
-    labState.appType === 'weblab' ? window.getWebLab?.() : studioApp()?.config;
 
   const getHiddenContext = async () => {
     const params: AiTutorLegacyLabParams = {

--- a/apps/src/aiTutor/views/legacyLabs/AiTutorContainer.tsx
+++ b/apps/src/aiTutor/views/legacyLabs/AiTutorContainer.tsx
@@ -3,10 +3,12 @@ import {Typography, IconButton as MuiIconButton} from '@mui/material';
 import classNames from 'classnames';
 import React, {FC, useEffect, useRef, useState} from 'react';
 
+import {shouldShowAiTutor} from '@cdo/apps/aichat/helpers/aiChatAccess';
 import {fetchUserChatHistory} from '@cdo/apps/aichat/redux';
 import AiTutorChat from '@cdo/apps/lab2/views/components/AiTutorChat';
 import {LegacyLabsState} from '@cdo/apps/redux/legacyLabs';
 import {singleton as studioApp} from '@cdo/apps/StudioApp';
+import {selectedSectionSelector} from '@cdo/apps/templates/teacherDashboard/teacherSectionsReduxSelectors';
 import {useAppDispatch, useAppSelector} from '@cdo/apps/util/reduxHooks';
 import aiBotOutlineIcon from '@cdo/static/ai-bot-outline.png';
 
@@ -39,9 +41,8 @@ interface CommonLab {
 }
 
 export const AiTutorContainer: FC<{
-  shouldShowTutor: boolean;
   onLayoutChange: (state: {isVisible: boolean; isOpen: boolean}) => void;
-}> = ({shouldShowTutor, onLayoutChange}) => {
+}> = ({onLayoutChange}) => {
   const [aiChatOpen, setAiChatOpen] = useState(false);
   const dispatch = useAppDispatch();
 
@@ -51,6 +52,22 @@ export const AiTutorContainer: FC<{
 
   // When a teacher is viewing a student, viewAsUserId is set.
   const viewAsUserId = useAppSelector(state => state.progress.viewAsUserId);
+
+  const sectionAiChatAccessLevel = useAppSelector(
+    state => selectedSectionSelector(state)?.aiChatAccessLevel
+  );
+
+  const aiTutorAvailableForLevel =
+    window?.appOptions?.level?.aiTutorAvailable ?? false;
+
+  const shouldShowTutor =
+    sectionAiChatAccessLevel && labState.appType
+      ? shouldShowAiTutor({
+          appName: labState.appType,
+          tutorLevel: aiTutorAvailableForLevel,
+          aiChatAccessLevel: sectionAiChatAccessLevel,
+        })
+      : false;
 
   const lab: CommonLab | undefined =
     labState.appType === 'weblab' ? window.getWebLab?.() : studioApp()?.config;

--- a/apps/src/aiTutor/views/legacyLabs/AiTutorContainer.tsx
+++ b/apps/src/aiTutor/views/legacyLabs/AiTutorContainer.tsx
@@ -10,7 +10,6 @@ import AiTutorChat from '@cdo/apps/lab2/views/components/AiTutorChat';
 import {LegacyLabsState} from '@cdo/apps/redux/legacyLabs';
 import {singleton as studioApp} from '@cdo/apps/StudioApp';
 import {selectedSectionSelector} from '@cdo/apps/templates/teacherDashboard/teacherSectionsReduxSelectors';
-import {RootState} from '@cdo/apps/types/redux';
 import {useAppDispatch, useAppSelector} from '@cdo/apps/util/reduxHooks';
 import aiBotOutlineIcon from '@cdo/static/ai-bot-outline.png';
 
@@ -71,18 +70,10 @@ export const AiTutorContainer: FC<{
       aiChatAccessLevel: sectionAiChatAccessLevel,
     });
 
-  const isPredictLevel =
-    window?.appOptions?.level?.predictSettings?.isPredictLevel ?? false;
-  const awaitingContainedResponse = useAppSelector(
-    state =>
-      (state as RootState & {runState: {awaitingContainedResponse: boolean}})
-        .runState.awaitingContainedResponse
-  );
-
   useAiChatDisabledState({
     appName: labState.appType,
-    isPredictLevel,
-    hasSubmittedPredictResponse: !awaitingContainedResponse,
+    isPredictLevel: false,
+    hasSubmittedPredictResponse: false,
   });
 
   const lab: CommonLab | undefined =

--- a/apps/src/aichat/constants.ts
+++ b/apps/src/aichat/constants.ts
@@ -58,3 +58,8 @@ export const ACCEPTED_IMAGE_MEDIA_TYPES = [
   'image/png',
   'image/gif',
 ];
+
+export const AI_CHAT_NOT_AUTHORIZED_TEACHER =
+  'You must be a verified teacher or sign in via Google, Microsoft, Facebook, or an LMS to use and assign this tool.';
+export const AI_CHAT_NOT_AUTHORIZED_STUDENT =
+  'Your teacher has not enabled this tool. Check with your teacher if you think this is an error.';

--- a/apps/src/aichat/context/aiChatDisabledContext.tsx
+++ b/apps/src/aichat/context/aiChatDisabledContext.tsx
@@ -4,6 +4,7 @@ import React, {
   PropsWithChildren,
   useContext,
   useCallback,
+  useEffect,
   useMemo,
   useState,
 } from 'react';
@@ -85,6 +86,10 @@ export const AiChatDisabledProvider: FC<AiChatDisabledProviderProps> = ({
     },
     []
   );
+
+  useEffect(() => {
+    setChatDisabledState({chatDisabled, chatDisabledMessage});
+  }, [chatDisabled, chatDisabledMessage, setChatDisabledState]);
 
   const value = useMemo<AiChatDisabledContextValue>(
     () => ({

--- a/apps/src/aichat/views/ChatEventsList.tsx
+++ b/apps/src/aichat/views/ChatEventsList.tsx
@@ -1,7 +1,7 @@
 import FontAwesomeV6Icon from '@code-dot-org/component-library/fontAwesomeV6Icon';
 import {IconButton as MuiIconButton} from '@mui/material';
 import classNames from 'classnames';
-import React, {useEffect, useRef, useState, useCallback, useMemo} from 'react';
+import React, {useEffect, useRef, useState, useCallback} from 'react';
 
 import {useAiChatDisabled} from '@cdo/apps/aichat/context/aiChatDisabledContext';
 import {Role} from '@cdo/apps/aiComponentLibrary/chatMessage/types';
@@ -92,9 +92,7 @@ const ChatEventsList: React.FunctionComponent<ChatEventsListProps> = ({
     }
   };
 
-  const isTeacherViewEmptyStudentChatHistory = useMemo(() => {
-    return isTeacherView && events.length === 0;
-  }, [isTeacherView, events]);
+  const hasChatHistory = events.length > 0;
 
   useEffect(() => {
     const container = conversationContainerRef.current;
@@ -192,16 +190,14 @@ const ChatEventsList: React.FunctionComponent<ChatEventsListProps> = ({
       )}
     >
       <div className={moduleStyles.messageArea} ref={conversationContainerRef}>
-        {chatDisabled ? (
+        {chatDisabled && !(isTeacherView && hasChatHistory) ? (
           <ChatDisabled message={chatDisabledMessage} />
         ) : (
           <>
             {hasInstructionsDrawer && (
               <div className={moduleStyles.instructionsDrawerInset} />
             )}
-            {isTeacherViewEmptyStudentChatHistory && (
-              <EmptyStudentChatHistory />
-            )}
+            {isTeacherView && !hasChatHistory && <EmptyStudentChatHistory />}
             {events.map((event, index) => {
               const isLastMessage = index === events.length - 1;
               return (

--- a/apps/src/aichat/views/ChatWorkspace.tsx
+++ b/apps/src/aichat/views/ChatWorkspace.tsx
@@ -1,3 +1,4 @@
+import Alert, {alertTypes} from '@code-dot-org/component-library/alert';
 import {FontAwesomeV6IconProps} from '@code-dot-org/component-library/fontAwesomeV6Icon';
 import Tabs, {TabsProps} from '@code-dot-org/component-library/tabs';
 import markdownToTxt from 'markdown-to-txt';
@@ -82,7 +83,7 @@ const ChatWorkspace: React.FunctionComponent<ChatWorkspaceProps> = ({
   logLevelActivity,
   hasInstructionsDrawer,
 }) => {
-  const {chatDisabled} = useAiChatDisabled();
+  const {chatDisabled, chatDisabledMessage} = useAiChatDisabled();
   if (multimodalEnabled && (!levelName || !channelId)) {
     console.warn(
       'Multimodal support requires level name and channel ID. Multimodal features will not be available.'
@@ -234,14 +235,15 @@ const ChatWorkspace: React.FunctionComponent<ChatWorkspaceProps> = ({
 
   const [liveAnnouncement, setLiveAnnouncement] = useState('');
   const chatEvents = selectedStudent ? studentChatHistory : visibleItems;
+  const hasChatHistory = chatEvents.length > 0;
   useEffect(() => {
-    if (chatEvents.length > 0) {
+    if (hasChatHistory) {
       const last = chatEvents[chatEvents.length - 1];
       if ('chatMessageText' in last && last.chatMessageText) {
         setLiveAnnouncement(markdownToTxt(last.chatMessageText));
       }
     }
-  }, [chatEvents]);
+  }, [hasChatHistory, chatEvents]);
 
   const iconValue: FontAwesomeV6IconProps = {
     iconName: 'lock',
@@ -353,6 +355,18 @@ const ChatWorkspace: React.FunctionComponent<ChatWorkspaceProps> = ({
           />
         )}
       </div>
+      {isTeacherView && hasChatHistory && chatDisabled && (
+        <Alert
+          type={alertTypes.info}
+          text={chatDisabledMessage || ''}
+          icon={{
+            className: moduleStyles.chatDisabledAlertIcon,
+            iconName: 'ai-locked',
+            iconFamily: 'kit',
+          }}
+          className={moduleStyles.chatDisabledAlert}
+        />
+      )}
     </div>
   );
 };

--- a/apps/src/aichat/views/chatWorkspace.module.scss
+++ b/apps/src/aichat/views/chatWorkspace.module.scss
@@ -101,6 +101,15 @@ $tabs-default-spacing: 4px;
   }
 }
 
+.chatDisabledAlert {
+  border-radius: 0;
+
+  .chatDisabledAlertIcon.chatDisabledAlertIcon {
+    font-size: 1.25rem;
+    align-self: center;
+  }
+}
+
 .tabsContainer {
   background-color: var(--background-neutral-secondary);
   padding: $tabs-default-spacing $tabs-default-spacing 0 $tabs-default-spacing;

--- a/apps/src/lab2/hooks/useAiChatDisabledState.ts
+++ b/apps/src/lab2/hooks/useAiChatDisabledState.ts
@@ -1,4 +1,4 @@
-import {useEffect} from 'react';
+import {useEffect, useMemo} from 'react';
 
 import {
   AI_CHAT_NOT_AUTHORIZED_STUDENT,
@@ -44,55 +44,64 @@ export function useAiChatDisabledState({
   const enabledForUser = appName
     ? areAiChatToolsEnabled({appName, aiChatAccessLevel: userAccessLevel})
     : false;
-  let disabledState: AiChatDisabledState;
 
-  if (!appName) {
-    disabledState = {chatDisabled: true};
-  } else if (
-    isPredictLevel &&
-    !hasSubmittedPredictResponse &&
-    !getIsStartMode()
-  ) {
+  const disabledState: AiChatDisabledState = useMemo(() => {
+    if (!appName) {
+      return {chatDisabled: true};
+    }
+
     // Disabled on predict levels until the student has submitted a response to avoid spoiling the experience.
-    disabledState = {
-      chatDisabled: true,
-      chatDisabledMessage: 'Chat is disabled until you submit your prediction.',
-    };
-  } else if (isTeacher) {
-    if (
-      enabledForUser &&
-      sectionAccessLevel &&
-      !areAiChatToolsEnabled({
-        appName: appName!,
-        aiChatAccessLevel: sectionAccessLevel,
-      })
-    ) {
+    if (isPredictLevel && !hasSubmittedPredictResponse && !getIsStartMode()) {
+      return {
+        chatDisabled: true,
+        chatDisabledMessage:
+          'Chat is disabled until you submit your prediction.',
+      };
+    }
+
+    if (isTeacher) {
       // If teacher has access but the currently selected section access level doesn't grant access,
       // show the appropriate message to more closely match the student experience.
       // Note: It might not EXACTLY match the student experience, since the student could
       // technically have access from another teacher's section.
-      disabledState = {
-        chatDisabled: true,
-        chatDisabledMessage: 'Chat is disabled for this class section.',
-      };
-    } else if (!enabledForUser) {
+      if (
+        enabledForUser &&
+        sectionAccessLevel &&
+        !areAiChatToolsEnabled({
+          appName: appName!,
+          aiChatAccessLevel: sectionAccessLevel,
+        })
+      ) {
+        return {
+          chatDisabled: true,
+          chatDisabledMessage: 'Chat is disabled for this class section.',
+        };
+      }
       // If the teacher doesn't have access, show the appropriate message to direct the teacher on how to get access.
-      disabledState = {
-        chatDisabled: true,
-        chatDisabledMessage: AI_CHAT_NOT_AUTHORIZED_TEACHER,
-      };
-    } else {
-      disabledState = {chatDisabled: false};
+      if (!enabledForUser) {
+        return {
+          chatDisabled: true,
+          chatDisabledMessage: AI_CHAT_NOT_AUTHORIZED_TEACHER,
+        };
+      }
+      return {chatDisabled: false};
     }
-  } else {
+
     // User is a student.
-    disabledState = enabledForUser
+    return enabledForUser
       ? {chatDisabled: false}
       : {
           chatDisabled: true,
           chatDisabledMessage: AI_CHAT_NOT_AUTHORIZED_STUDENT,
         };
-  }
+  }, [
+    appName,
+    isPredictLevel,
+    hasSubmittedPredictResponse,
+    isTeacher,
+    enabledForUser,
+    sectionAccessLevel,
+  ]);
 
   useEffect(() => {
     setChatDisabledState(disabledState);

--- a/apps/src/lab2/hooks/useAiChatDisabledState.ts
+++ b/apps/src/lab2/hooks/useAiChatDisabledState.ts
@@ -1,0 +1,101 @@
+import {useEffect} from 'react';
+
+import {
+  AI_CHAT_NOT_AUTHORIZED_STUDENT,
+  AI_CHAT_NOT_AUTHORIZED_TEACHER,
+} from '@cdo/apps/aichat/constants';
+import {useAiChatDisabled} from '@cdo/apps/aichat/context/aiChatDisabledContext';
+import {areAiChatToolsEnabled} from '@cdo/apps/aichat/helpers/aiChatAccess';
+import lab2I18n from '@cdo/apps/lab2/locale';
+import {getIsStartMode} from '@cdo/apps/lab2/projects/utils';
+import {selectedSectionSelector} from '@cdo/apps/templates/teacherDashboard/teacherSectionsReduxSelectors';
+import {useAppSelector} from '@cdo/apps/util/reduxHooks';
+
+interface UseAiChatDisabledStateParams {
+  appName?: string;
+  isPredictLevel: boolean;
+  hasSubmittedPredictResponse: boolean;
+}
+
+export interface AiChatDisabledState {
+  chatDisabled: boolean;
+  chatDisabledMessage?: string;
+}
+
+/**
+ * Computes whether AI chat is disabled and what message to show, consolidating:
+ * - which aiChatAccessLevel applies (section override for teachers, or user's own)
+ * - whether the access level permits chat for the current app & access level
+ * - predict level gating
+ * - teacher vs. student messaging
+ */
+export function useAiChatDisabledState({
+  appName,
+  isPredictLevel,
+  hasSubmittedPredictResponse,
+}: UseAiChatDisabledStateParams) {
+  const {setChatDisabledState} = useAiChatDisabled();
+  const isTeacher = useAppSelector(state => state.currentUser.isTeacher);
+  const sectionAccessLevel = useAppSelector(
+    state => selectedSectionSelector(state)?.aiChatAccessLevel
+  );
+  const userAccessLevel = useAppSelector(
+    state => state.currentUser.aiChatAccessLevel
+  );
+  const enabledForUser = appName
+    ? areAiChatToolsEnabled({appName, aiChatAccessLevel: userAccessLevel})
+    : false;
+  let disabledState: AiChatDisabledState;
+
+  if (!appName) {
+    disabledState = {chatDisabled: true};
+  } else if (
+    isPredictLevel &&
+    !hasSubmittedPredictResponse &&
+    !getIsStartMode()
+  ) {
+    // Disabled on predict levels until the student has submitted a response to avoid spoiling the experience.
+    disabledState = {
+      chatDisabled: true,
+      chatDisabledMessage: lab2I18n.predictTutorDisabledMessage(),
+    };
+  } else if (isTeacher) {
+    if (
+      enabledForUser &&
+      sectionAccessLevel &&
+      !areAiChatToolsEnabled({
+        appName: appName!,
+        aiChatAccessLevel: sectionAccessLevel,
+      })
+    ) {
+      // If teacher has access but the currently selected section access level doesn't grant access,
+      // show the appropriate message to more closely match the student experience.
+      // Note: It might not EXACTLY match the student experience, since the student could
+      // technically have access from another teacher's section.
+      disabledState = {
+        chatDisabled: true,
+        chatDisabledMessage: 'Chat is disabled for this class section.',
+      };
+    } else if (!enabledForUser) {
+      // If the teacher doesn't have access, show the appropriate message to direct the teacher on how to get access.
+      disabledState = {
+        chatDisabled: true,
+        chatDisabledMessage: AI_CHAT_NOT_AUTHORIZED_TEACHER,
+      };
+    } else {
+      disabledState = {chatDisabled: false};
+    }
+  } else {
+    // User is a student.
+    disabledState = enabledForUser
+      ? {chatDisabled: false}
+      : {
+          chatDisabled: true,
+          chatDisabledMessage: AI_CHAT_NOT_AUTHORIZED_STUDENT,
+        };
+  }
+
+  useEffect(() => {
+    setChatDisabledState(disabledState);
+  }, [disabledState, setChatDisabledState]);
+}

--- a/apps/src/lab2/hooks/useAiChatDisabledState.ts
+++ b/apps/src/lab2/hooks/useAiChatDisabledState.ts
@@ -6,7 +6,6 @@ import {
 } from '@cdo/apps/aichat/constants';
 import {useAiChatDisabled} from '@cdo/apps/aichat/context/aiChatDisabledContext';
 import {areAiChatToolsEnabled} from '@cdo/apps/aichat/helpers/aiChatAccess';
-import lab2I18n from '@cdo/apps/lab2/locale';
 import {getIsStartMode} from '@cdo/apps/lab2/projects/utils';
 import {selectedSectionSelector} from '@cdo/apps/templates/teacherDashboard/teacherSectionsReduxSelectors';
 import {useAppSelector} from '@cdo/apps/util/reduxHooks';
@@ -57,7 +56,7 @@ export function useAiChatDisabledState({
     // Disabled on predict levels until the student has submitted a response to avoid spoiling the experience.
     disabledState = {
       chatDisabled: true,
-      chatDisabledMessage: lab2I18n.predictTutorDisabledMessage(),
+      chatDisabledMessage: 'Chat is disabled until you submit your prediction.',
     };
   } else if (isTeacher) {
     if (

--- a/apps/src/lab2/views/LabViewsRenderer.tsx
+++ b/apps/src/lab2/views/LabViewsRenderer.tsx
@@ -5,18 +5,12 @@
  */
 import React, {createContext, Suspense, useEffect, useState} from 'react';
 
-import {TEACHER_DISABLED_AI_CHAT_MESSAGE} from '@cdo/apps/aichat/constants';
-import {useAiChatDisabled} from '@cdo/apps/aichat/context/aiChatDisabledContext';
-import {areAiChatToolsEnabled} from '@cdo/apps/aichat/helpers/aiChatAccess';
 import {queryParams} from '@cdo/apps/code-studio/utils';
 import {PERMISSIONS} from '@cdo/apps/lab2/constants';
+import {useAiChatDisabledState} from '@cdo/apps/lab2/hooks/useAiChatDisabledState';
 import {useInitialLabTheme} from '@cdo/apps/lab2/hooks/useInitialLabTheme';
-import lab2I18n from '@cdo/apps/lab2/locale';
 import ProgressContainer from '@cdo/apps/lab2/progress/ProgressContainer';
-import {
-  getAppOptionsViewingExemplar,
-  getIsStartMode,
-} from '@cdo/apps/lab2/projects/utils';
+import {getAppOptionsViewingExemplar} from '@cdo/apps/lab2/projects/utils';
 import {getLabViewPageAction, getIsLabViewBlocked} from '@cdo/apps/lab2/utils';
 import analyticsReporter from '@cdo/apps/metrics/AnalyticsReporter';
 import useRequiredContext from '@cdo/apps/util/hooks/useRequiredContext';
@@ -83,38 +77,11 @@ const LabViewsRenderer: React.FunctionComponent = () => {
     state => state.predictLevel.hasSubmittedResponse
   );
 
-  const aiChatAccessLevel = useAppSelector(
-    state => state.currentUser.aiChatAccessLevel
-  );
-  const {setChatDisabledState} = useAiChatDisabled();
-  useEffect(() => {
-    if (
-      currentAppName &&
-      !areAiChatToolsEnabled({appName: currentAppName, aiChatAccessLevel})
-    ) {
-      setChatDisabledState({
-        chatDisabled: true,
-        chatDisabledMessage: TEACHER_DISABLED_AI_CHAT_MESSAGE,
-      });
-    } else if (
-      isPredictLevel &&
-      !hasSubmittedPredictResponse &&
-      !getIsStartMode()
-    ) {
-      setChatDisabledState({
-        chatDisabled: true,
-        chatDisabledMessage: lab2I18n.predictTutorDisabledMessage(),
-      });
-    } else {
-      setChatDisabledState({chatDisabled: false});
-    }
-  }, [
-    currentAppName,
-    aiChatAccessLevel,
+  useAiChatDisabledState({
+    appName: currentAppName,
     isPredictLevel,
     hasSubmittedPredictResponse,
-    setChatDisabledState,
-  ]);
+  });
 
   const blockLabView = getIsLabViewBlocked(
     pageAction,

--- a/apps/src/templates/instructions/InstructionsWithWorkspace.jsx
+++ b/apps/src/templates/instructions/InstructionsWithWorkspace.jsx
@@ -30,7 +30,7 @@ export class UnwrappedInstructionsWithWorkspace extends React.Component {
     instructionsHeight: PropTypes.number.isRequired,
     setInstructionsMaxHeightAvailable: PropTypes.func.isRequired,
     labType: PropTypes.string,
-    currentUserAiChatAccessLevel: PropTypes.string,
+    aiChatAccessLevel: PropTypes.string,
     isShareView: PropTypes.bool,
   };
 
@@ -113,7 +113,7 @@ export class UnwrappedInstructionsWithWorkspace extends React.Component {
       workspaceStyle,
       instructionsHeight,
       labType,
-      currentUserAiChatAccessLevel,
+      aiChatAccessLevel,
       isShareView,
       children,
     } = this.props;
@@ -127,7 +127,7 @@ export class UnwrappedInstructionsWithWorkspace extends React.Component {
       shouldShowAiTutor({
         appName: labType,
         tutorLevel: aiTutorAvailableForLevel,
-        aiChatAccessLevel: currentUserAiChatAccessLevel,
+        aiChatAccessLevel: aiChatAccessLevel,
       });
 
     const chatContainerSpace = 335; // 325px chat container + 10px margin = 335px
@@ -168,7 +168,7 @@ export default connect(
     instructionsHeight: state.instructions.renderedHeight,
     labType: state.pageConstants.appType,
     isShareView: state.pageConstants.isShareView,
-    currentUserAiChatAccessLevel: state.currentUser.aiChatAccessLevel,
+    aiChatAccessLevel: state.currentUser.aiChatAccessLevel,
   }),
   dispatch => ({
     setInstructionsMaxHeightAvailable(maxHeight) {

--- a/apps/src/templates/instructions/InstructionsWithWorkspace.jsx
+++ b/apps/src/templates/instructions/InstructionsWithWorkspace.jsx
@@ -127,7 +127,7 @@ export class UnwrappedInstructionsWithWorkspace extends React.Component {
       shouldShowAiTutor({
         appName: labType,
         tutorLevel: aiTutorAvailableForLevel,
-        aiChatAccessLevel: aiChatAccessLevel,
+        aiChatAccessLevel,
       });
 
     const chatContainerSpace = 335; // 325px chat container + 10px margin = 335px

--- a/apps/src/templates/instructions/InstructionsWithWorkspace.jsx
+++ b/apps/src/templates/instructions/InstructionsWithWorkspace.jsx
@@ -3,12 +3,8 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import {connect} from 'react-redux';
 
-import {TEACHER_DISABLED_AI_CHAT_MESSAGE} from '@cdo/apps/aichat/constants';
 import {AiChatDisabledProvider} from '@cdo/apps/aichat/context/aiChatDisabledContext';
-import {
-  areAiChatToolsEnabled,
-  shouldShowAiTutor,
-} from '@cdo/apps/aichat/helpers/aiChatAccess';
+import {shouldShowAiTutor} from '@cdo/apps/aichat/helpers/aiChatAccess';
 import {AI_TUTOR_LEGACY_LABS} from '@cdo/apps/aiTutor/views/legacyLabs/constants';
 import {selectedSectionSelector} from '@cdo/apps/templates/teacherDashboard/teacherSectionsReduxSelectors';
 
@@ -35,12 +31,13 @@ export class UnwrappedInstructionsWithWorkspace extends React.Component {
     instructionsHeight: PropTypes.number.isRequired,
     setInstructionsMaxHeightAvailable: PropTypes.func.isRequired,
     labType: PropTypes.string,
-    aiChatAccessLevel: PropTypes.string,
+    sectionAiChatAccessLevel: PropTypes.string,
+    currentUserAiChatAccessLevel: PropTypes.string,
     isShareView: PropTypes.bool,
   };
 
   state = {
-    aiChatOpen: false,
+    tutorLayout: {isVisible: false, isOpen: false},
     // only used so that we can rerender when resized
     windowWidth: undefined,
     windowHeight: undefined,
@@ -100,8 +97,8 @@ export class UnwrappedInstructionsWithWorkspace extends React.Component {
     setInstructionsMaxHeightAvailable(maxInstructionsHeight);
   };
 
-  toggleAiChat = () => {
-    this.setState(prevState => ({aiChatOpen: !prevState.aiChatOpen}));
+  handleLayoutChange = tutorLayout => {
+    this.setState({tutorLayout});
   };
 
   componentDidMount() {
@@ -118,7 +115,8 @@ export class UnwrappedInstructionsWithWorkspace extends React.Component {
       workspaceStyle,
       instructionsHeight,
       labType,
-      aiChatAccessLevel,
+      sectionAiChatAccessLevel,
+      currentUserAiChatAccessLevel,
       isShareView,
       children,
     } = this.props;
@@ -126,27 +124,39 @@ export class UnwrappedInstructionsWithWorkspace extends React.Component {
     const aiTutorAvailableForLevel =
       window?.appOptions?.level?.aiTutorAvailable ?? false;
 
-    const aiChatAccessDisabled = !areAiChatToolsEnabled({
-      appName: labType,
-      aiChatAccessLevel,
-    });
-
-    const showAiTutor =
+    const shouldMountAiTutorContainer =
       !isShareView &&
       AI_TUTOR_LEGACY_LABS.includes(labType) &&
       shouldShowAiTutor({
         appName: labType,
         tutorLevel: aiTutorAvailableForLevel,
-        aiChatAccessLevel,
+        aiChatAccessLevel: currentUserAiChatAccessLevel,
       });
+
+    // dilemma: This should really be owned by the AiTutorContainer but if I move it there we'll always start with
+    // isVisible false which will cause the layout to start without the tutor and then jump when the tutor renders.
+    const shouldShowTutor =
+      shouldMountAiTutorContainer &&
+      (sectionAiChatAccessLevel
+        ? shouldShowAiTutor({
+            appName: labType,
+            tutorLevel: aiTutorAvailableForLevel,
+            aiChatAccessLevel: sectionAiChatAccessLevel,
+          })
+        : true);
+
+    // Use shouldShowTutor as the initial layout value so there's no flash on
+    // first render. tutorLayout.isVisible overrides once AiTutorContainer
+    // reports back (e.g. when chat is disabled but history exists).
+    const isTutorVisible = shouldShowTutor || this.state.tutorLayout.isVisible;
 
     const chatContainerSpace = 335; // 325px chat container + 10px margin = 335px
     const sidebarSpace = 55; // 45px sidebar + 10px margin = 55px
-    const tutorSpace = this.state.aiChatOpen
+    const tutorSpace = this.state.tutorLayout.isOpen
       ? chatContainerSpace
       : sidebarSpace;
 
-    if (showAiTutor) {
+    if (isTutorVisible) {
       instructionsStyle = {...instructionsStyle, right: tutorSpace};
       workspaceStyle = {...workspaceStyle, right: tutorSpace};
     }
@@ -163,18 +173,11 @@ export class UnwrappedInstructionsWithWorkspace extends React.Component {
         >
           {children}
         </CodeWorkspaceContainer>
-        {showAiTutor && (
-          <AiChatDisabledProvider
-            chatDisabled={aiChatAccessDisabled}
-            chatDisabledMessage={
-              aiChatAccessDisabled
-                ? TEACHER_DISABLED_AI_CHAT_MESSAGE
-                : undefined
-            }
-          >
+        {shouldMountAiTutorContainer && (
+          <AiChatDisabledProvider>
             <AiTutorContainer
-              toggleAiChat={this.toggleAiChat}
-              aiChatOpen={this.state.aiChatOpen}
+              shouldShowTutor={shouldShowTutor}
+              onLayoutChange={this.handleLayoutChange}
             />
           </AiChatDisabledProvider>
         )}
@@ -188,10 +191,10 @@ export default connect(
     instructionsHeight: state.instructions.renderedHeight,
     labType: state.pageConstants.appType,
     isShareView: state.pageConstants.isShareView,
-    aiChatAccessLevel:
-      (state.teacherSections
-        ? selectedSectionSelector(state)?.aiChatAccessLevel
-        : undefined) ?? state.currentUser.aiChatAccessLevel,
+    sectionAiChatAccessLevel: state.teacherSections
+      ? selectedSectionSelector(state)?.aiChatAccessLevel
+      : undefined,
+    currentUserAiChatAccessLevel: state.currentUser.aiChatAccessLevel,
   }),
   dispatch => ({
     setInstructionsMaxHeightAvailable(maxHeight) {

--- a/apps/src/templates/instructions/InstructionsWithWorkspace.jsx
+++ b/apps/src/templates/instructions/InstructionsWithWorkspace.jsx
@@ -6,7 +6,6 @@ import {connect} from 'react-redux';
 import {AiChatDisabledProvider} from '@cdo/apps/aichat/context/aiChatDisabledContext';
 import {shouldShowAiTutor} from '@cdo/apps/aichat/helpers/aiChatAccess';
 import {AI_TUTOR_LEGACY_LABS} from '@cdo/apps/aiTutor/views/legacyLabs/constants';
-import {selectedSectionSelector} from '@cdo/apps/templates/teacherDashboard/teacherSectionsReduxSelectors';
 
 import {AiTutorContainer} from '../../aiTutor/views/legacyLabs/AiTutorContainer';
 import {setInstructionsMaxHeightAvailable} from '../../redux/instructions';
@@ -31,7 +30,6 @@ export class UnwrappedInstructionsWithWorkspace extends React.Component {
     instructionsHeight: PropTypes.number.isRequired,
     setInstructionsMaxHeightAvailable: PropTypes.func.isRequired,
     labType: PropTypes.string,
-    sectionAiChatAccessLevel: PropTypes.string,
     currentUserAiChatAccessLevel: PropTypes.string,
     isShareView: PropTypes.bool,
   };
@@ -115,7 +113,6 @@ export class UnwrappedInstructionsWithWorkspace extends React.Component {
       workspaceStyle,
       instructionsHeight,
       labType,
-      sectionAiChatAccessLevel,
       currentUserAiChatAccessLevel,
       isShareView,
       children,
@@ -133,30 +130,13 @@ export class UnwrappedInstructionsWithWorkspace extends React.Component {
         aiChatAccessLevel: currentUserAiChatAccessLevel,
       });
 
-    // dilemma: This should really be owned by the AiTutorContainer but if I move it there we'll always start with
-    // isVisible false which will cause the layout to start without the tutor and then jump when the tutor renders.
-    const shouldShowTutor =
-      shouldMountAiTutorContainer &&
-      (sectionAiChatAccessLevel
-        ? shouldShowAiTutor({
-            appName: labType,
-            tutorLevel: aiTutorAvailableForLevel,
-            aiChatAccessLevel: sectionAiChatAccessLevel,
-          })
-        : true);
-
-    // Use shouldShowTutor as the initial layout value so there's no flash on
-    // first render. tutorLayout.isVisible overrides once AiTutorContainer
-    // reports back (e.g. when chat is disabled but history exists).
-    const isTutorVisible = shouldShowTutor || this.state.tutorLayout.isVisible;
-
     const chatContainerSpace = 335; // 325px chat container + 10px margin = 335px
     const sidebarSpace = 55; // 45px sidebar + 10px margin = 55px
     const tutorSpace = this.state.tutorLayout.isOpen
       ? chatContainerSpace
       : sidebarSpace;
 
-    if (isTutorVisible) {
+    if (this.state.tutorLayout.isVisible) {
       instructionsStyle = {...instructionsStyle, right: tutorSpace};
       workspaceStyle = {...workspaceStyle, right: tutorSpace};
     }
@@ -175,10 +155,7 @@ export class UnwrappedInstructionsWithWorkspace extends React.Component {
         </CodeWorkspaceContainer>
         {shouldMountAiTutorContainer && (
           <AiChatDisabledProvider>
-            <AiTutorContainer
-              shouldShowTutor={shouldShowTutor}
-              onLayoutChange={this.handleLayoutChange}
-            />
+            <AiTutorContainer onLayoutChange={this.handleLayoutChange} />
           </AiChatDisabledProvider>
         )}
       </span>
@@ -191,9 +168,6 @@ export default connect(
     instructionsHeight: state.instructions.renderedHeight,
     labType: state.pageConstants.appType,
     isShareView: state.pageConstants.isShareView,
-    sectionAiChatAccessLevel: state.teacherSections
-      ? selectedSectionSelector(state)?.aiChatAccessLevel
-      : undefined,
     currentUserAiChatAccessLevel: state.currentUser.aiChatAccessLevel,
   }),
   dispatch => ({

--- a/apps/test/unit/templates/instructions/InstructionsWithWorkspaceTest.jsx
+++ b/apps/test/unit/templates/instructions/InstructionsWithWorkspaceTest.jsx
@@ -47,6 +47,7 @@ describe('InstructionsWithWorkspace', () => {
           setInstructionsMaxHeightAvailable={() => {}}
           labType="applab"
           isShareView={true}
+          aiChatAccessLevel="enabled"
         />
       );
       expect(wrapper.find('AiTutorContainer')).toHaveLength(0);
@@ -65,7 +66,7 @@ describe('InstructionsWithWorkspace', () => {
       expect(wrapper.find('AiTutorContainer')).toHaveLength(1);
     });
 
-    it('renders AI tutor when selected section has AI enabled', () => {
+    it('renders AI tutor when AI enabled', () => {
       const wrapper = shallow(
         <InstructionsWithWorkspace
           instructionsHeight={400}
@@ -78,7 +79,7 @@ describe('InstructionsWithWorkspace', () => {
       expect(wrapper.find('AiTutorContainer')).toHaveLength(1);
     });
 
-    it('does not render AI tutor when selected section has AI disabled', () => {
+    it('does not render AI tutor when AI disabled', () => {
       const wrapper = shallow(
         <InstructionsWithWorkspace
           instructionsHeight={400}

--- a/apps/test/unit/templates/instructions/InstructionsWithWorkspaceTest.jsx
+++ b/apps/test/unit/templates/instructions/InstructionsWithWorkspaceTest.jsx
@@ -3,6 +3,7 @@ import $ from 'jquery';
 import React from 'react';
 
 import {UnwrappedInstructionsWithWorkspace as InstructionsWithWorkspace} from '@cdo/apps/templates/instructions/InstructionsWithWorkspace';
+import {AiChatAccessLevels} from '@cdo/generated-scripts/sharedConstants';
 
 describe('InstructionsWithWorkspace', () => {
   it('renders instructions and code workspace', () => {
@@ -47,7 +48,7 @@ describe('InstructionsWithWorkspace', () => {
           setInstructionsMaxHeightAvailable={() => {}}
           labType="applab"
           isShareView={true}
-          aiChatAccessLevel="enabled"
+          aiChatAccessLevel={AiChatAccessLevels.ENABLED}
         />
       );
       expect(wrapper.find('AiTutorContainer')).toHaveLength(0);
@@ -60,7 +61,7 @@ describe('InstructionsWithWorkspace', () => {
           setInstructionsMaxHeightAvailable={() => {}}
           labType="applab"
           isShareView={false}
-          aiChatAccessLevel="enabled"
+          aiChatAccessLevel={AiChatAccessLevels.ENABLED}
         />
       );
       expect(wrapper.find('AiTutorContainer')).toHaveLength(1);
@@ -73,7 +74,7 @@ describe('InstructionsWithWorkspace', () => {
           setInstructionsMaxHeightAvailable={() => {}}
           labType="applab"
           isShareView={false}
-          aiChatAccessLevel="enabled"
+          aiChatAccessLevel={AiChatAccessLevels.ENABLED}
         />
       );
       expect(wrapper.find('AiTutorContainer')).toHaveLength(1);
@@ -86,7 +87,7 @@ describe('InstructionsWithWorkspace', () => {
           setInstructionsMaxHeightAvailable={() => {}}
           labType="applab"
           isShareView={false}
-          aiChatAccessLevel="disabled"
+          aiChatAccessLevel={AiChatAccessLevels.DISABLED}
         />
       );
       expect(wrapper.find('AiTutorContainer')).toHaveLength(0);

--- a/apps/test/unit/templates/instructions/InstructionsWithWorkspaceTest.jsx
+++ b/apps/test/unit/templates/instructions/InstructionsWithWorkspaceTest.jsx
@@ -27,7 +27,7 @@ describe('InstructionsWithWorkspace', () => {
     expect(wrapper.state()).toEqual({
       windowWidth: undefined,
       windowHeight: undefined,
-      aiChatOpen: false,
+      tutorLayout: {isVisible: false, isOpen: false},
     });
   });
 

--- a/i18n/locales/source/blockly-mooc/lab2.json
+++ b/i18n/locales/source/blockly-mooc/lab2.json
@@ -26,7 +26,6 @@
   "page": "Page",
   "pages": "Pages",
   "pass": "Pass",
-  "predictTutorDisabledMessage": "AI Tutor is disabled until you submit your prediction.",
   "result": "Result",
   "resourcePanelOnboarding_title": "Resource area",
   "resourcePanelOnboarding_text": "All your helpful resources can be found in the resource area. When starting a level it will always show the instructions tab first.",


### PR DESCRIPTION
<!--
  Summary of the change: background, motivation, and context.
  Include screenshots, videos, or before/after comparisons for UI changes.
-->

 - When teacher views student chat history that isn't empty, make tutor visible and show the chat history to the teacher.
 - Refactors logic for disabling chat history into a custom hook.
 - Use the custom hook for both legacy and lab2 labs, so there is a consistent experience for when tutor is disabled between the two
   - Hard coding the predict level params to false for now. Supporting disabling in predict levels is out of scope for this change and tracked here: [legacy lab predict levels don't disable tutor](https://codedotorg.atlassian.net/browse/TEACHING-108)

## Links
<!-- Jira tickets, design docs, Slack threads, related PRs, etc. -->

- [Teachers can't view student chat history in legacy tutor when tutor is disabled](https://codedotorg.atlassian.net/browse/TEACHING-133)

## Testing story
<!-- How was this tested? Manual steps, adhoc links, automated tests, or why testing isn't needed. -->

Non-empty chat history while disabled for section:
| legacy labs | lab2 (python lab) | aichat lab |
| - | - | - |
| <img width="481" height="931" alt="image" src="https://github.com/user-attachments/assets/16e8fded-792a-4ca2-8e9a-e76b8ae89b9c" /> | <img width="304" height="1003" alt="image" src="https://github.com/user-attachments/assets/e0b4018a-5518-4306-996e-2be7b71457df" /> | <img width="652" height="981" alt="image" src="https://github.com/user-attachments/assets/c3f8ca9a-651a-459a-9276-b2f2a7094f86" /> | 

Empty chat history while disabled for section:
| legacy labs | lab2 (python lab) | aichat lab |
| - | - | - |
| tutor hidden | <img width="243" height="107" alt="image" src="https://github.com/user-attachments/assets/0a87b18a-a91e-4c69-bf16-ae00874df9b7" /> | <img width="262" height="146" alt="image" src="https://github.com/user-attachments/assets/2d0b2aae-4d9b-4237-afba-ec42959292ee" /> |

 - tutor appears correctly in legacy labs when enabled

## Deployment notes
<!-- Delete this section if it's a standard merge-and-deploy.
     Otherwise: migrations, feature flags, coordination, caching impacts, etc. -->



## Privacy and security
<!-- Delete this section if there is no privacy/security impact.
     Otherwise: new PII, auth changes, API surface changes, etc. -->

