### PR TITLE
AI Tutor: create_user_lesson_reflections migration

### DIFF
--- a/dashboard/db/migrate/20260330175427_create_user_lesson_reflections.rb
+++ b/dashboard/db/migrate/20260330175427_create_user_lesson_reflections.rb
@@ -1,0 +1,16 @@
+class CreateUserLessonReflections < ActiveRecord::Migration[7.0]
+  def change
+    create_table :user_lesson_reflections, charset: "utf8mb4", collation: "utf8mb4_unicode_ci" do |t|
+      t.integer :lesson_id, null: false
+      t.bigint :student_id, null: false
+      t.text :success
+      t.text :struggle
+
+      t.timestamps
+    end
+
+    add_index :user_lesson_reflections, :lesson_id
+    add_index :user_lesson_reflections, :student_id
+    add_index :user_lesson_reflections, [:lesson_id, :student_id]
+  end
+end

--- a/dashboard/db/schema.rb
+++ b/dashboard/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2026_03_18_191529) do
+ActiveRecord::Schema[7.0].define(version: 2026_03_30_175427) do
   create_table "activities", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "user_id"
     t.integer "level_id"
@@ -2526,6 +2526,18 @@ ActiveRecord::Schema[7.0].define(version: 2026_03_18_191529) do
     t.decimal "longitude", precision: 9, scale: 6
     t.index ["indexed_at"], name: "index_user_geos_on_indexed_at"
     t.index ["user_id"], name: "index_user_geos_on_user_id"
+  end
+
+  create_table "user_lesson_reflections", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+    t.integer "lesson_id", null: false
+    t.bigint "student_id", null: false
+    t.text "success"
+    t.text "struggle"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["lesson_id", "student_id"], name: "index_user_lesson_reflections_on_lesson_id_and_student_id"
+    t.index ["lesson_id"], name: "index_user_lesson_reflections_on_lesson_id"
+    t.index ["student_id"], name: "index_user_lesson_reflections_on_student_id"
   end
 
   create_table "user_level_interactions", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|


### PR DESCRIPTION
The AI Tutor+ lesson deep dive is going to include a "Reflection" area that includes the student's overall reflection on the lesson (one "success" and one "struggle" open text box) and a quick indication of how the student felt about each lesson objective. 

<img width="1480" height="488" alt="Screenshot 2026-03-30 at 2 01 11 PM" src="https://github.com/user-attachments/assets/7736f5da-ce45-44ac-b6f5-ce7fa4e3231e" />

This PR sets up the migration for a UserLessonReflection table that will store the student's answers in the struggle and success open text boxes. An additional PR will have the migration to store lesson objective specific reflections. 