### PR TITLE
AI Chat: remove Gemini 3 preview from available models

### DIFF
--- a/apps/src/lab2/levelEditors/aichatSettings/ModelSelectionFields.tsx
+++ b/apps/src/lab2/levelEditors/aichatSettings/ModelSelectionFields.tsx
@@ -114,9 +114,12 @@ const ModelSelectionFields: React.FunctionComponent = () => {
             <>
               <Typography variant="body4" gutterBottom>
                 <i>
-                  Enables multimodal chat. Note that the list of models must
-                  include a multimodal model for this feature to be available to
-                  students (currently only GPT 4o-mini).
+                  Enables multimodal chat (allow uploading files and receiving
+                  images, if possible).
+                  <br />
+                  <b>IMPORTANT:</b> If using an image model like Gemini 2.5
+                  Flash Image, this setting MUST be enabled for generated images
+                  to appear in the chat.
                 </i>
               </Typography>
               <div className={moduleStyles.fieldRow}>

--- a/apps/static/aichat/modelDescriptions.json
+++ b/apps/static/aichat/modelDescriptions.json
@@ -14,28 +14,21 @@
   },
   {
     "id": "gemini-2.5-flash-lite",
-    "name": "[EXPERIMENTAL, LEVELBUILDER USE ONLY] Gemini 2.5 Flash-Lite",
+    "name": "Gemini 2.5 Flash-Lite",
     "overview": "...",
     "trainingData": "...",
     "multimodal": true
   },
   {
     "id": "gemini-2.5-flash",
-    "name": "[EXPERIMENTAL, LEVELBUILDER USE ONLY] Gemini 2.5 Flash",
+    "name": "Gemini 2.5 Flash",
     "overview": "...",
     "trainingData": "...",
     "multimodal": true
   },
   {
     "id": "gemini-2.5-flash-image",
-    "name": "[EXPERIMENTAL, LEVELBUILDER USE ONLY] Gemini 2.5 Flash Image",
-    "overview": "...",
-    "trainingData": "...",
-    "multimodal": true
-  },
-  {
-    "id": "gemini-3-pro-preview",
-    "name": "[EXPERIMENTAL, LEVELBUILDER USE ONLY] Gemini 3 Pro Preview",
+    "name": "Gemini 2.5 Flash Image",
     "overview": "...",
     "trainingData": "...",
     "multimodal": true

--- a/dashboard/app/jobs/aichat_request_chat_completion_job.rb
+++ b/dashboard/app/jobs/aichat_request_chat_completion_job.rb
@@ -50,7 +50,6 @@ class AichatRequestChatCompletionJob < ApplicationJob
       SharedConstants::AI_CHAT_MODEL_IDS[:GEMINI_2_5_FLASH],
       SharedConstants::AI_CHAT_MODEL_IDS[:GEMINI_2_5_PRO],
       SharedConstants::AI_CHAT_MODEL_IDS[:GEMINI_2_5_FLASH_LITE],
-      SharedConstants::AI_CHAT_MODEL_IDS[:GEMINI_3_PRO_PREVIEW],
     ].include? model_id
   end
 

--- a/lib/cdo/shared_constants.rb
+++ b/lib/cdo/shared_constants.rb
@@ -832,7 +832,6 @@ module SharedConstants
     GEMINI_2_5_FLASH: "gemini-2.5-flash",
     GEMINI_2_5_FLASH_LITE: "gemini-2.5-flash-lite",
     GEMINI_2_5_PRO: "gemini-2.5-pro",
-    GEMINI_3_PRO_PREVIEW: "gemini-3-pro-preview",
     GEMINI_2_5_FLASH_IMAGE: "gemini-2.5-flash-image",
   }
 


### PR DESCRIPTION
Removes Gemini 3.0 Preview from the list of available models. Gemini 3.0 preview has been discontinued (in favor of 3.1), and as of https://github.com/code-dot-org/code-dot-org/pull/71759, we don't have any levels that specifically make use of the Gemini 3.x model.

Note: will only merge this after https://github.com/code-dot-org/code-dot-org/pull/71759 has made it to production to avoid potentially breaking pilot levels.

Also dropped the [EXPERIMENTAL, LEVELBUILDER ONLY] prefix and updated the model selection text:

<img width="787" height="498" alt="Screenshot 2026-03-30 at 11 00 21 AM" src="https://github.com/user-attachments/assets/4668d057-8c5d-48ff-8417-1fe272867367" />