### PR TITLE
POC: Load Weblab 1 projects (viewer mode) in weblab2's security sandbox

### DIFF
--- a/apps/src/lab2/projects/sourcesApi.ts
+++ b/apps/src/lab2/projects/sourcesApi.ts
@@ -4,6 +4,11 @@
  */
 
 import HttpClient, {GetResponse} from '@cdo/apps/util/HttpClient';
+import {
+  isWeblab1CompatibilityModeEnabled,
+  loadWeblab1ProjectAsLab2Sources,
+  shouldFallbackToWeblab1Files,
+} from '@cdo/apps/weblab2/weblab1Compatibility';
 
 import {SOURCE_FILE} from '../constants';
 import {SourceResponseValidator} from '../responseValidators';
@@ -22,7 +27,21 @@ export async function get(
   if (versionId) {
     url += `?version=${versionId}`;
   }
-  return HttpClient.fetchJson<ProjectSources>(url, {}, SourceResponseValidator);
+  try {
+    return await HttpClient.fetchJson<ProjectSources>(
+      url,
+      {},
+      SourceResponseValidator
+    );
+  } catch (error) {
+    if (
+      isWeblab1CompatibilityModeEnabled() &&
+      shouldFallbackToWeblab1Files(error)
+    ) {
+      return loadWeblab1ProjectAsLab2Sources(channelId, versionId);
+    }
+    throw error;
+  }
 }
 
 export async function update(

--- a/apps/src/lab2/projects/sourcesApi.ts
+++ b/apps/src/lab2/projects/sourcesApi.ts
@@ -7,6 +7,7 @@ import HttpClient, {GetResponse} from '@cdo/apps/util/HttpClient';
 import {
   isWeblab1CompatibilityModeEnabled,
   loadWeblab1ProjectAsLab2Sources,
+  mainJsonIsLab2CodebridgeShape,
   shouldFallbackToWeblab1Files,
 } from '@cdo/apps/weblab2/weblab1Compatibility';
 
@@ -27,21 +28,36 @@ export async function get(
   if (versionId) {
     url += `?version=${versionId}`;
   }
-  try {
-    return await HttpClient.fetchJson<ProjectSources>(
-      url,
-      {},
-      SourceResponseValidator
-    );
-  } catch (error) {
-    if (
-      isWeblab1CompatibilityModeEnabled() &&
-      shouldFallbackToWeblab1Files(error)
-    ) {
+
+  // WebLab1 compat: inspect raw main.json first. Legacy/WebLab1/App-Lab-shaped
+  // sources are not valid Codebridge MultiFileSource; avoid whack-a-mole ValidationError branches.
+  if (isWeblab1CompatibilityModeEnabled()) {
+    try {
+      const {value: json, response} = await HttpClient.fetchJson<unknown>(
+        url,
+        {},
+        undefined
+      );
+      if (mainJsonIsLab2CodebridgeShape(json)) {
+        try {
+          const value = SourceResponseValidator(
+            json as Record<string, unknown>
+          );
+          return {value, response};
+        } catch {
+          return loadWeblab1ProjectAsLab2Sources(channelId, versionId);
+        }
+      }
       return loadWeblab1ProjectAsLab2Sources(channelId, versionId);
+    } catch (error) {
+      if (shouldFallbackToWeblab1Files(error)) {
+        return loadWeblab1ProjectAsLab2Sources(channelId, versionId);
+      }
+      throw error;
     }
-    throw error;
   }
+
+  return HttpClient.fetchJson<ProjectSources>(url, {}, SourceResponseValidator);
 }
 
 export async function update(

--- a/apps/src/weblab2/htmlPreview/weblab2_project_service_worker.js
+++ b/apps/src/weblab2/htmlPreview/weblab2_project_service_worker.js
@@ -149,9 +149,6 @@ function main() {
       }
       if (url) {
         let fetchUrl = url;
-        if (isStudioRelativeFileUrl(url)) {
-          fetchUrl = codeDotOrgOrigin + url;
-        }
         if (url.startsWith('/level_starter_assets/')) {
           // We fetch level starter assets from the code.org origin for this environment.
           // We use a cache-busting query parameter to ensure that we get the correct response headers,
@@ -161,12 +158,6 @@ function main() {
           fetchUrl = codeDotOrgOrigin + url + cacheBust;
         }
         return await fetch(fetchUrl);
-      }
-      // Inline data URLs (e.g. WebLab1 compat: images loaded via FileReader) must use fetch() so
-      // the response body is decoded bytes. new Response(dataUrlString) sends the literal ASCII
-      // string, which is not valid image/css binary → broken <img> in preview.
-      if (typeof content === 'string' && content.indexOf('data:') === 0) {
-        return await fetch(content);
       }
       return new Response(content, {
         status: 200,
@@ -187,12 +178,6 @@ function main() {
         },
       });
     }
-  }
-
-  function isStudioRelativeFileUrl(url) {
-    // Compatibility mode uses /v3/files/<channel>/<filename> urls from studio.
-    // Route these through the matching studio origin so fetch happens on the correct host.
-    return /^\/v3\/files\/[^/]+\/.+/.test(url);
   }
 }
 

--- a/apps/src/weblab2/htmlPreview/weblab2_project_service_worker.js
+++ b/apps/src/weblab2/htmlPreview/weblab2_project_service_worker.js
@@ -162,6 +162,12 @@ function main() {
         }
         return await fetch(fetchUrl);
       }
+      // Inline data URLs (e.g. WebLab1 compat: images loaded via FileReader) must use fetch() so
+      // the response body is decoded bytes. new Response(dataUrlString) sends the literal ASCII
+      // string, which is not valid image/css binary → broken <img> in preview.
+      if (typeof content === 'string' && content.indexOf('data:') === 0) {
+        return await fetch(content);
+      }
       return new Response(content, {
         status: 200,
         headers: {

--- a/apps/src/weblab2/htmlPreview/weblab2_project_service_worker.js
+++ b/apps/src/weblab2/htmlPreview/weblab2_project_service_worker.js
@@ -149,6 +149,9 @@ function main() {
       }
       if (url) {
         let fetchUrl = url;
+        if (isStudioRelativeFileUrl(url)) {
+          fetchUrl = codeDotOrgOrigin + url;
+        }
         if (url.startsWith('/level_starter_assets/')) {
           // We fetch level starter assets from the code.org origin for this environment.
           // We use a cache-busting query parameter to ensure that we get the correct response headers,
@@ -178,6 +181,12 @@ function main() {
         },
       });
     }
+  }
+
+  function isStudioRelativeFileUrl(url) {
+    // Compatibility mode uses /v3/files/<channel>/<filename> urls from studio.
+    // Route these through the matching studio origin so fetch happens on the correct host.
+    return /^\/v3\/files\/[^/]+\/.+/.test(url);
   }
 }
 

--- a/apps/src/weblab2/weblab1Compatibility.ts
+++ b/apps/src/weblab2/weblab1Compatibility.ts
@@ -1,0 +1,274 @@
+import {DEFAULT_FOLDER_ID} from '@cdo/apps/codebridge/constants';
+import {
+  MultiFileSource,
+  ProjectFile,
+  ProjectFolder,
+  ProjectSources,
+} from '@cdo/apps/lab2/types';
+import HttpClient, {GetResponse, NetworkError} from '@cdo/apps/util/HttpClient';
+
+type Weblab1ManifestEntry = {
+  filename: string;
+  category?: string;
+};
+
+type Weblab1ManifestResponse = {
+  files: Weblab1ManifestEntry[];
+  filesVersionId?: string;
+};
+
+type CompatFile = {
+  filename: string;
+  contents?: string;
+  url?: string;
+};
+
+const WEBLAB1_COMPAT_QUERY_PARAM = 'weblab1_compat';
+const TEXT_FILE_EXTENSIONS = new Set([
+  'html',
+  'htm',
+  'css',
+  'js',
+  'md',
+  'txt',
+  'csv',
+  'json',
+]);
+const IMAGE_FILE_EXTENSIONS = new Set([
+  'jpg',
+  'jpeg',
+  'png',
+  'gif',
+  'webp',
+  'svg',
+  'avif',
+  'bmp',
+  'ico',
+]);
+
+function getFileExtension(filename: string): string {
+  const lastDot = filename.lastIndexOf('.');
+  if (lastDot === -1 || lastDot === filename.length - 1) {
+    return '';
+  }
+  return filename.substring(lastDot + 1).toLowerCase();
+}
+
+function encodeFileName(filename: string) {
+  return encodeURIComponent(filename);
+}
+
+function toCompatFileUrl(
+  channelId: string,
+  filename: string,
+  versionId?: string
+) {
+  const encodedFileName = encodeFileName(filename);
+  const versionSuffix = versionId ? `?version=${versionId}` : '';
+  return `/v3/files/${channelId}/${encodedFileName}${versionSuffix}`;
+}
+
+async function toDataUrl(response: Response): Promise<string> {
+  const blob = await response.blob();
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onloadend = () => {
+      const result = reader.result;
+      if (typeof result === 'string') {
+        resolve(result);
+      } else {
+        reject(new Error('Unable to convert file to data URL'));
+      }
+    };
+    reader.onerror = () => reject(new Error('Unable to read file as data URL'));
+    reader.readAsDataURL(blob);
+  });
+}
+
+function shouldLoadFileContents(entry: Weblab1ManifestEntry): boolean {
+  return TEXT_FILE_EXTENSIONS.has(getFileExtension(entry.filename));
+}
+
+function isImageFile(entry: Weblab1ManifestEntry): boolean {
+  if (entry.category === 'image') {
+    return true;
+  }
+  return IMAGE_FILE_EXTENSIONS.has(getFileExtension(entry.filename));
+}
+
+function parseCompatibilityQueryParam(value: string | null): boolean {
+  if (!value) {
+    return false;
+  }
+  const normalized = value.trim().toLowerCase();
+  return normalized === '1' || normalized === 'true' || normalized === 'yes';
+}
+
+export function isWeblab1CompatibilityModeEnabled(): boolean {
+  if (typeof window === 'undefined') {
+    return false;
+  }
+  const params = new URLSearchParams(window.location.search);
+  return parseCompatibilityQueryParam(params.get(WEBLAB1_COMPAT_QUERY_PARAM));
+}
+
+export function shouldFallbackToWeblab1Files(error: unknown): boolean {
+  return error instanceof NetworkError && error.response.status === 404;
+}
+
+export function buildMultiFileSourceFromWeblab1Files(
+  files: CompatFile[]
+): MultiFileSource {
+  const folders: Record<string, ProjectFolder> = {};
+  const projectFiles: Record<string, ProjectFile> = {};
+  const filePathById: Record<string, string> = {};
+  const folderPathToId = new Map<string, string>([['', DEFAULT_FOLDER_ID]]);
+  let nextFolderId = 1;
+  let nextFileId = 1;
+
+  const sortedFiles = [...files].sort((a, b) =>
+    a.filename.localeCompare(b.filename)
+  );
+
+  sortedFiles.forEach(file => {
+    const normalizedPath = file.filename
+      .split('/')
+      .map(segment => segment.trim())
+      .filter(Boolean)
+      .join('/');
+    if (!normalizedPath) {
+      return;
+    }
+
+    const segments = normalizedPath.split('/');
+    const fileName = segments.pop();
+    if (!fileName) {
+      return;
+    }
+
+    let currentPath = '';
+    let parentId = DEFAULT_FOLDER_ID;
+    segments.forEach(segment => {
+      currentPath = currentPath ? `${currentPath}/${segment}` : segment;
+      let folderId = folderPathToId.get(currentPath);
+      if (!folderId) {
+        folderId = String(nextFolderId++);
+        folders[folderId] = {
+          id: folderId,
+          name: segment,
+          parentId,
+          open: true,
+        };
+        folderPathToId.set(currentPath, folderId);
+      }
+      parentId = folderId;
+    });
+
+    const fileId = String(nextFileId++);
+    projectFiles[fileId] = {
+      id: fileId,
+      name: fileName,
+      contents: file.contents || '',
+      folderId: parentId,
+      url: file.url,
+    };
+    filePathById[fileId] = normalizedPath;
+  });
+
+  const fileIds = Object.keys(projectFiles);
+  const preferredPathPredicates = [
+    (path: string) => path.toLowerCase() === 'index.html',
+    (path: string) => path.toLowerCase().endsWith('/index.html'),
+    (path: string) => path.toLowerCase().endsWith('.html'),
+  ];
+  const activeFileId =
+    preferredPathPredicates
+      .map(predicate => fileIds.find(fileId => predicate(filePathById[fileId])))
+      .find(Boolean) || fileIds[0];
+
+  if (activeFileId) {
+    projectFiles[activeFileId].active = true;
+  }
+
+  return {
+    folders,
+    files: projectFiles,
+    openFiles: activeFileId ? [activeFileId] : [],
+  };
+}
+
+export async function loadWeblab1ProjectAsLab2Sources(
+  channelId: string,
+  versionId?: string
+): Promise<GetResponse<ProjectSources>> {
+  let manifestUrl = `/v3/files/${channelId}`;
+  if (versionId) {
+    manifestUrl += `?version=${versionId}`;
+  }
+  const manifestResponse = await HttpClient.fetchJson<Weblab1ManifestResponse>(
+    manifestUrl
+  );
+  const manifestFiles = manifestResponse.value?.files || [];
+
+  const compatFiles = await Promise.all(
+    manifestFiles.map(async manifestEntry => {
+      const fileUrl = toCompatFileUrl(
+        channelId,
+        manifestEntry.filename,
+        versionId
+      );
+
+      if (isImageFile(manifestEntry)) {
+        try {
+          const response = await HttpClient.get(fileUrl);
+          return {
+            filename: manifestEntry.filename,
+            contents: await toDataUrl(response),
+          };
+        } catch {
+          return {
+            filename: manifestEntry.filename,
+            contents: '',
+            url: fileUrl,
+          };
+        }
+      }
+
+      if (!shouldLoadFileContents(manifestEntry)) {
+        try {
+          const response = await HttpClient.get(fileUrl);
+          return {
+            filename: manifestEntry.filename,
+            contents: await toDataUrl(response),
+          };
+        } catch {
+          return {
+            filename: manifestEntry.filename,
+            contents: '',
+            url: fileUrl,
+          };
+        }
+      }
+
+      try {
+        const response = await HttpClient.get(fileUrl);
+        const contents = await response.text();
+        return {filename: manifestEntry.filename, contents};
+      } catch {
+        // Fall back to URL-based serving if file text retrieval fails.
+        return {
+          filename: manifestEntry.filename,
+          contents: '',
+          url: fileUrl,
+        };
+      }
+    })
+  );
+
+  return {
+    value: {
+      source: buildMultiFileSourceFromWeblab1Files(compatFiles),
+    },
+    response: manifestResponse.response,
+  };
+}

--- a/apps/src/weblab2/weblab1Compatibility.ts
+++ b/apps/src/weblab2/weblab1Compatibility.ts
@@ -1,4 +1,5 @@
 import {DEFAULT_FOLDER_ID} from '@cdo/apps/codebridge/constants';
+import {ValidationError} from '@cdo/apps/lab2/responseValidators';
 import {
   MultiFileSource,
   ProjectFile,
@@ -6,6 +7,9 @@ import {
   ProjectSources,
 } from '@cdo/apps/lab2/types';
 import HttpClient, {GetResponse, NetworkError} from '@cdo/apps/util/HttpClient';
+
+/** Matches {@link responseValidators} when `/v3/sources/.../main.json` returns JSON without `source` (typical for WebLab1-only projects). */
+const MISSING_LAB2_SOURCE_FIELD_MESSAGE = 'Missing required field: source';
 
 type Weblab1ManifestEntry = {
   filename: string;
@@ -113,7 +117,17 @@ export function isWeblab1CompatibilityModeEnabled(): boolean {
 }
 
 export function shouldFallbackToWeblab1Files(error: unknown): boolean {
-  return error instanceof NetworkError && error.response.status === 404;
+  if (error instanceof NetworkError && error.response.status === 404) {
+    return true;
+  }
+  // Lab2 fetch can succeed (200) with JSON that has no `source` — WebLab1 projects do not use main.json.
+  if (
+    error instanceof ValidationError &&
+    error.message === MISSING_LAB2_SOURCE_FIELD_MESSAGE
+  ) {
+    return true;
+  }
+  return false;
 }
 
 export function buildMultiFileSourceFromWeblab1Files(

--- a/apps/src/weblab2/weblab1Compatibility.ts
+++ b/apps/src/weblab2/weblab1Compatibility.ts
@@ -1,5 +1,4 @@
 import {DEFAULT_FOLDER_ID} from '@cdo/apps/codebridge/constants';
-import {ValidationError} from '@cdo/apps/lab2/responseValidators';
 import {
   MultiFileSource,
   ProjectFile,
@@ -8,8 +7,29 @@ import {
 } from '@cdo/apps/lab2/types';
 import HttpClient, {GetResponse, NetworkError} from '@cdo/apps/util/HttpClient';
 
-/** Matches {@link responseValidators} when `/v3/sources/.../main.json` returns JSON without `source` (typical for WebLab1-only projects). */
-const MISSING_LAB2_SOURCE_FIELD_MESSAGE = 'Missing required field: source';
+/**
+ * True when `main.json` already matches Lab2 Codebridge storage: `source` is an
+ * object with `files` and `folders` (not an App Lab JS string, Blockly blob, etc.).
+ * Used in weblab1 compat mode to decide between normal Lab2 validation vs `/v3/files` fallback.
+ */
+export function mainJsonIsLab2CodebridgeShape(body: unknown): boolean {
+  if (body === null || typeof body !== 'object' || Array.isArray(body)) {
+    return false;
+  }
+  const record = body as Record<string, unknown>;
+  const source = record.source;
+  if (source === undefined || source === null) {
+    return false;
+  }
+  if (typeof source === 'string') {
+    return false;
+  }
+  if (typeof source !== 'object' || Array.isArray(source)) {
+    return false;
+  }
+  const multi = source as Record<string, unknown>;
+  return Boolean(multi.files && multi.folders);
+}
 
 type Weblab1ManifestEntry = {
   filename: string;
@@ -116,18 +136,9 @@ export function isWeblab1CompatibilityModeEnabled(): boolean {
   return parseCompatibilityQueryParam(params.get(WEBLAB1_COMPAT_QUERY_PARAM));
 }
 
+/** Used when compat mode fetch throws (e.g. main.json missing). Success-path shape checks use {@link mainJsonIsLab2CodebridgeShape}. */
 export function shouldFallbackToWeblab1Files(error: unknown): boolean {
-  if (error instanceof NetworkError && error.response.status === 404) {
-    return true;
-  }
-  // Lab2 fetch can succeed (200) with JSON that has no `source` — WebLab1 projects do not use main.json.
-  if (
-    error instanceof ValidationError &&
-    error.message === MISSING_LAB2_SOURCE_FIELD_MESSAGE
-  ) {
-    return true;
-  }
-  return false;
+  return error instanceof NetworkError && error.response.status === 404;
 }
 
 export function buildMultiFileSourceFromWeblab1Files(

--- a/apps/src/weblab2/weblab1Compatibility.ts
+++ b/apps/src/weblab2/weblab1Compatibility.ts
@@ -92,23 +92,6 @@ function toCompatFileUrl(
   return `/v3/files/${channelId}/${encodedFileName}${versionSuffix}`;
 }
 
-async function toDataUrl(response: Response): Promise<string> {
-  const blob = await response.blob();
-  return new Promise((resolve, reject) => {
-    const reader = new FileReader();
-    reader.onloadend = () => {
-      const result = reader.result;
-      if (typeof result === 'string') {
-        resolve(result);
-      } else {
-        reject(new Error('Unable to convert file to data URL'));
-      }
-    };
-    reader.onerror = () => reject(new Error('Unable to read file as data URL'));
-    reader.readAsDataURL(blob);
-  });
-}
-
 function shouldLoadFileContents(entry: Weblab1ManifestEntry): boolean {
   return TEXT_FILE_EXTENSIONS.has(getFileExtension(entry.filename));
 }
@@ -243,36 +226,19 @@ export async function loadWeblab1ProjectAsLab2Sources(
         versionId
       );
 
-      if (isImageFile(manifestEntry)) {
-        try {
-          const response = await HttpClient.get(fileUrl);
-          return {
-            filename: manifestEntry.filename,
-            contents: await toDataUrl(response),
-          };
-        } catch {
-          return {
-            filename: manifestEntry.filename,
-            contents: '',
-            url: fileUrl,
-          };
-        }
-      }
-
-      if (!shouldLoadFileContents(manifestEntry)) {
-        try {
-          const response = await HttpClient.get(fileUrl);
-          return {
-            filename: manifestEntry.filename,
-            contents: await toDataUrl(response),
-          };
-        } catch {
-          return {
-            filename: manifestEntry.filename,
-            contents: '',
-            url: fileUrl,
-          };
-        }
+      // Binary assets (images, etc.): do not inline as data URLs. ProjectFile.contents is typed
+      // as string across Lab2/Codebridge; raw bytes would not serialize to main.json anyway. Serve
+      // via `url` so the preview service worker fetches `/v3/files/...` from studio (see
+      // weblab2_project_service_worker.js).
+      if (
+        isImageFile(manifestEntry) ||
+        !shouldLoadFileContents(manifestEntry)
+      ) {
+        return {
+          filename: manifestEntry.filename,
+          contents: '',
+          url: fileUrl,
+        };
       }
 
       try {

--- a/apps/test/unit/weblab2/weblab1CompatibilityTest.ts
+++ b/apps/test/unit/weblab2/weblab1CompatibilityTest.ts
@@ -1,4 +1,5 @@
 import {DEFAULT_FOLDER_ID} from '@cdo/apps/codebridge/constants';
+import {ValidationError} from '@cdo/apps/lab2/responseValidators';
 import {NetworkError} from '@cdo/apps/util/HttpClient';
 import {
   buildMultiFileSourceFromWeblab1Files,
@@ -48,6 +49,20 @@ describe('weblab1Compatibility', () => {
       expect(shouldFallbackToWeblab1Files(new Error('other error'))).toBe(
         false
       );
+    });
+
+    it('returns true when main.json response omits source (ValidationError)', () => {
+      expect(
+        shouldFallbackToWeblab1Files(
+          new ValidationError('Missing required field: source')
+        )
+      ).toBe(true);
+    });
+
+    it('returns false for other ValidationErrors', () => {
+      expect(
+        shouldFallbackToWeblab1Files(new ValidationError('Invalid source code'))
+      ).toBe(false);
     });
   });
 

--- a/apps/test/unit/weblab2/weblab1CompatibilityTest.ts
+++ b/apps/test/unit/weblab2/weblab1CompatibilityTest.ts
@@ -1,9 +1,9 @@
 import {DEFAULT_FOLDER_ID} from '@cdo/apps/codebridge/constants';
-import {ValidationError} from '@cdo/apps/lab2/responseValidators';
 import {NetworkError} from '@cdo/apps/util/HttpClient';
 import {
   buildMultiFileSourceFromWeblab1Files,
   isWeblab1CompatibilityModeEnabled,
+  mainJsonIsLab2CodebridgeShape,
   shouldFallbackToWeblab1Files,
 } from '@cdo/apps/weblab2/weblab1Compatibility';
 
@@ -50,19 +50,32 @@ describe('weblab1Compatibility', () => {
         false
       );
     });
+  });
 
-    it('returns true when main.json response omits source (ValidationError)', () => {
+  describe('mainJsonIsLab2CodebridgeShape', () => {
+    it('returns false for App Lab-shaped main.json (source is JS string)', () => {
       expect(
-        shouldFallbackToWeblab1Files(
-          new ValidationError('Missing required field: source')
-        )
+        mainJsonIsLab2CodebridgeShape({
+          source: 'var x = 1;',
+          html: '<div></div>',
+        })
+      ).toBe(false);
+    });
+
+    it('returns true when source is a MultiFileSource-shaped object', () => {
+      expect(
+        mainJsonIsLab2CodebridgeShape({
+          source: {files: {}, folders: {}},
+        })
       ).toBe(true);
     });
 
-    it('returns false for other ValidationErrors', () => {
-      expect(
-        shouldFallbackToWeblab1Files(new ValidationError('Invalid source code'))
-      ).toBe(false);
+    it('returns false when source is missing', () => {
+      expect(mainJsonIsLab2CodebridgeShape({})).toBe(false);
+    });
+
+    it('returns false when source object lacks files or folders', () => {
+      expect(mainJsonIsLab2CodebridgeShape({source: {files: {}}})).toBe(false);
     });
   });
 

--- a/apps/test/unit/weblab2/weblab1CompatibilityTest.ts
+++ b/apps/test/unit/weblab2/weblab1CompatibilityTest.ts
@@ -126,16 +126,16 @@ describe('weblab1Compatibility', () => {
       expect(source.openFiles).toEqual([activeFiles[0].id]);
     });
 
-    it('preserves data URL file contents for image assets', () => {
-      const dataUrl = 'data:image/png;base64,abc123';
+    it('preserves URL-backed image assets without inlining binary in contents', () => {
+      const fileUrl = '/v3/files/abc123/wrench.jpg';
       const source = buildMultiFileSourceFromWeblab1Files([
-        {filename: 'images/logo.png', contents: dataUrl},
+        {filename: 'images/logo.png', contents: '', url: fileUrl},
       ]);
 
       const onlyFile = Object.values(source.files)[0];
       expect(onlyFile.name).toBe('logo.png');
-      expect(onlyFile.contents).toBe(dataUrl);
-      expect(onlyFile.url).toBeUndefined();
+      expect(onlyFile.contents).toBe('');
+      expect(onlyFile.url).toBe(fileUrl);
     });
   });
 });

--- a/apps/test/unit/weblab2/weblab1CompatibilityTest.ts
+++ b/apps/test/unit/weblab2/weblab1CompatibilityTest.ts
@@ -1,0 +1,113 @@
+import {DEFAULT_FOLDER_ID} from '@cdo/apps/codebridge/constants';
+import {NetworkError} from '@cdo/apps/util/HttpClient';
+import {
+  buildMultiFileSourceFromWeblab1Files,
+  isWeblab1CompatibilityModeEnabled,
+  shouldFallbackToWeblab1Files,
+} from '@cdo/apps/weblab2/weblab1Compatibility';
+
+describe('weblab1Compatibility', () => {
+  describe('isWeblab1CompatibilityModeEnabled', () => {
+    const originalHref = window.location.href;
+
+    afterEach(() => {
+      window.history.replaceState({}, '', originalHref);
+    });
+
+    it('returns true for weblab1_compat=true', () => {
+      window.history.replaceState({}, '', '?weblab1_compat=true');
+
+      expect(isWeblab1CompatibilityModeEnabled()).toBe(true);
+    });
+
+    it('returns false when query param is absent', () => {
+      window.history.replaceState({}, '', '?');
+
+      expect(isWeblab1CompatibilityModeEnabled()).toBe(false);
+    });
+  });
+
+  describe('shouldFallbackToWeblab1Files', () => {
+    it('returns true for 404 network error', () => {
+      const error = new NetworkError(
+        '404 Not Found',
+        new Response(null, {status: 404})
+      );
+      expect(shouldFallbackToWeblab1Files(error)).toBe(true);
+    });
+
+    it('returns false for non-404 network error', () => {
+      const error = new NetworkError(
+        '500 Internal Server Error',
+        new Response(null, {status: 500})
+      );
+      expect(shouldFallbackToWeblab1Files(error)).toBe(false);
+    });
+
+    it('returns false for non-network errors', () => {
+      expect(shouldFallbackToWeblab1Files(new Error('other error'))).toBe(
+        false
+      );
+    });
+  });
+
+  describe('buildMultiFileSourceFromWeblab1Files', () => {
+    it('creates folders and preserves nested paths', () => {
+      const source = buildMultiFileSourceFromWeblab1Files([
+        {
+          filename: 'index.html',
+          contents: '<html></html>',
+        },
+        {
+          filename: 'styles/site.css',
+          contents: 'body {}',
+        },
+        {
+          filename: 'scripts/app.js',
+          contents: 'console.log("hello");',
+        },
+      ]);
+
+      expect(Object.keys(source.files)).toHaveLength(3);
+      expect(Object.keys(source.folders)).toHaveLength(2);
+
+      const styleFile = Object.values(source.files).find(
+        file => file.name === 'site.css'
+      );
+      const scriptFile = Object.values(source.files).find(
+        file => file.name === 'app.js'
+      );
+
+      expect(styleFile).toBeDefined();
+      expect(scriptFile).toBeDefined();
+      expect(styleFile?.folderId).not.toBe(DEFAULT_FOLDER_ID);
+      expect(scriptFile?.folderId).not.toBe(DEFAULT_FOLDER_ID);
+    });
+
+    it('prefers index.html as active/open file when present', () => {
+      const source = buildMultiFileSourceFromWeblab1Files([
+        {filename: 'styles/site.css', contents: 'body {}'},
+        {filename: 'index.html', contents: '<html></html>'},
+      ]);
+
+      const activeFiles = Object.values(source.files).filter(
+        file => file.active
+      );
+      expect(activeFiles).toHaveLength(1);
+      expect(activeFiles[0].name).toBe('index.html');
+      expect(source.openFiles).toEqual([activeFiles[0].id]);
+    });
+
+    it('preserves data URL file contents for image assets', () => {
+      const dataUrl = 'data:image/png;base64,abc123';
+      const source = buildMultiFileSourceFromWeblab1Files([
+        {filename: 'images/logo.png', contents: dataUrl},
+      ]);
+
+      const onlyFile = Object.values(source.files)[0];
+      expect(onlyFile.name).toBe('logo.png');
+      expect(onlyFile.contents).toBe(dataUrl);
+      expect(onlyFile.url).toBeUndefined();
+    });
+  });
+});

--- a/docs/specs/2026-03-26-15-48-22/weblab1-weblab2-viewer-compatibility-poc.md
+++ b/docs/specs/2026-03-26-15-48-22/weblab1-weblab2-viewer-compatibility-poc.md
@@ -65,12 +65,16 @@ This avoids accidental behavior changes and allows controlled experimentation.
 
 ## Data-loading shim
 
-- In Lab2 source loading (`apps/src/lab2/projects/sourcesApi.ts`):
-  1. Try normal Lab2 load from `/v3/sources/:channel/main.json`.
-  2. If request fails with **404** and compatibility mode is enabled:
-     - Load WebLab1 manifest from `/v3/files/:channel`.
-     - Fetch file contents for text-like files.
+- In Lab2 source loading (`apps/src/lab2/projects/sourcesApi.ts`), when compatibility mode is enabled:
+  1. **GET** `/v3/sources/:channel/main.json` as JSON **without** running `SourceResponseValidator` first.
+  2. If the body **already looks like Lab2 Codebridge** (`source` is an object with `files` and `folders`), run the normal validator and return it (same as native WebLab2).
+  3. Otherwise (missing `source`, App Lab–style string `source`, empty object, etc.) **or** if validation throws after a shape match, synthesize from WebLab1:
+     - Load manifest from `/v3/files/:channel`.
+     - Load **text-like** files into `contents`; **binary / images** use **`url: /v3/files/:channel/:filename`** and empty `contents` (same *pattern* as native WebLab2 uses **`/v3/assets/...`** for uploads—path string in `ProjectFile.url`, not inlined base64).
      - Build a synthetic `ProjectSources` with a generated `MultiFileSource`.
+  4. If the **GET** throws **404**, fall back to the same WebLab1 synthesis path.
+
+When compatibility mode is **off**, behavior is unchanged: single `fetchJson` + `SourceResponseValidator`.
 
 ## MultiFile synthesis strategy
 
@@ -84,12 +88,9 @@ This avoids accidental behavior changes and allows controlled experimentation.
 
 ## Preview compatibility
 
-- WebLab2 preview SW currently assumes same-origin project files or level starter assets.
-- Extend SW fetch logic so URL-backed files from compatibility mode that match:
-  - `/v3/files/:channel/:filename`
-  are fetched via environment-appropriate Studio origin (using existing `codeDotOrgOrigin` derivation).
-
-This is needed so URL-backed compatibility files can still resolve in preview context.
+- The project **service worker** (`weblab2_project_service_worker.js`) already serves virtual project files and, when `ProjectFile.url` is set, does **`fetch(url)`** with that path.
+- **Same-origin preview** routing: path-only URLs such as **`/v3/assets/...`** (native WebLab2 uploads) and **`/v3/files/...`** (WebLab1 file API) are intended to resolve on the **preview** origin the same way production WebLab2 already relies on for assets—**no POC-specific changes** to the service worker.
+- **Exception already in the worker:** paths starting with **`/level_starter_assets/`** are still rewritten to the Studio origin (with cache-bust) for CORS/header reasons; that predates this POC.
 
 ---
 
@@ -98,27 +99,21 @@ This is needed so URL-backed compatibility files can still resolve in preview co
 1. **New compatibility module**
    - `apps/src/weblab2/weblab1Compatibility.ts`
    - Adds:
-     - compatibility mode parser,
-     - fallback eligibility check (`404` only),
-     - WebLab1 manifest/file loading,
-     - conversion to synthetic `MultiFileSource`.
+     - compatibility query-param parsing,
+     - **`mainJsonIsLab2CodebridgeShape`** (structural check before validating as Codebridge),
+     - **`shouldFallbackToWeblab1Files`** (network **404** only, for failed `main.json` GET),
+     - WebLab1 manifest + file loading,
+     - conversion to synthetic `MultiFileSource` (text in `contents`, binaries via **`url`** to `/v3/files/...`).
 
-2. **Lab2 source loading fallback**
+2. **Lab2 source loading**
    - `apps/src/lab2/projects/sourcesApi.ts`
-   - Adds guarded fallback path:
-     - normal Lab2 load first,
-     - compatibility conversion on 404 + compat flag.
+   - When compat flag is on: raw `main.json` inspect → valid Codebridge shape uses normal validator; otherwise WebLab1 synthesis; **404** still triggers synthesis.
 
-3. **Preview SW bridge extension**
-   - `apps/src/weblab2/htmlPreview/weblab2_project_service_worker.js`
-   - Adds studio-relative file URL handling for `/v3/files/...` URLs used by compatibility mode.
-
-4. **Initial unit tests**
+3. **Initial unit tests**
    - `apps/test/unit/weblab2/weblab1CompatibilityTest.ts`
-   - Covers:
-     - compat mode query param parsing,
-     - fallback decision behavior,
-     - basic multi-file conversion expectations.
+   - Covers compat param, shape helper, 404 fallback, multi-file / URL-backed file expectations.
+
+**Not part of this POC:** edits to `weblab2_project_service_worker.js` (rely on existing `fetch(url)` behavior for `/v3/files/...` like `/v3/assets/...`).
 
 ---
 
@@ -150,8 +145,8 @@ This is needed so URL-backed compatibility files can still resolve in preview co
    - This is a critical area for deeper validation and likely hardening.
 
 2. **Non-text assets**
-   - Compatibility currently prioritizes text-file materialization.
-   - URL-backed assets and MIME handling may need additional normalization.
+   - Represented with **`url`** pointing at `/v3/files/...` (not inlined data URLs in `contents`).
+   - MIME/extension edge cases may still need validation in the field.
 
 3. **Viewer actions**
    - Share sidebar actions (`View code`, `Make my own`) remain existing behavior.
@@ -235,8 +230,9 @@ This is needed so URL-backed compatibility files can still resolve in preview co
 
 - `apps/src/weblab2/weblab1Compatibility.ts` (new)
 - `apps/src/lab2/projects/sourcesApi.ts`
-- `apps/src/weblab2/htmlPreview/weblab2_project_service_worker.js`
 - `apps/test/unit/weblab2/weblab1CompatibilityTest.ts` (new)
+
+This spec document under `docs/specs/2026-03-26-15-48-22/`.
 
 ---
 
@@ -261,7 +257,7 @@ This is needed so URL-backed compatibility files can still resolve in preview co
 
 ## Requested unknowns / decisions needed
 
-1. Should compatibility mode remain query-param based in near term, or should we auto-detect based on missing `main.json`?
+1. Should compatibility mode remain query-param based in near term, or auto-enable when `main.json` is missing / not Codebridge-shaped (today: explicit param + shape-based branch when param is on)?
 2. In compatibility mode, should "View code" open legacy WebLab1 editor view, WebLab2 read-only code view, or be hidden?
 3. Should "Make my own" point to legacy remix initially, or be disabled until compatibility editing/remix is defined?
 4. Do we require full parity for WebLab1 binary assets in POC, or text-first plus common image support is sufficient?

--- a/docs/specs/2026-03-26-15-48-22/weblab1-weblab2-viewer-compatibility-poc.md
+++ b/docs/specs/2026-03-26-15-48-22/weblab1-weblab2-viewer-compatibility-poc.md
@@ -1,0 +1,268 @@
+# WebLab1 -> WebLab2 Viewer Compatibility POC
+
+## Scope and goal
+
+This spec captures the investigation and proof-of-concept (POC) work to answer:
+
+> Can we serve **WebLab1 projects** inside the **WebLab2 viewer/share experience** (iframe jail + preview pipeline), for project viewing use cases first?
+
+Primary constraints for this POC:
+
+- Viewer/share experience first.
+- Do not require migrating legacy project storage up front.
+- Keep existing WebLab1 editing/remix flows intact.
+- Prefer a compatibility shim over invasive platform changes.
+
+---
+
+## Investigation summary
+
+## What WebLab1 does today (relevant to viewer/share)
+
+- Project share runtime is rooted in legacy `/v3/files/:channel/...` storage.
+- Public share rendering is historically codeprojects-oriented (`/projects/weblab/:channel/...` on codeprojects host).
+- In Studio, WebLab1 uses Bramble host/editor architecture (`apps/src/weblab/*`) and not the Lab2 `main.json` shape.
+- File model:
+  - Manifest: `/v3/files/:channel` (list with filename/category/version metadata).
+  - Per-file content: `/v3/files/:channel/:filename`.
+  - No Lab2 `main.json` multi-file source blob.
+
+## What WebLab2 does today (relevant to viewer/share)
+
+- Expects `/v3/sources/:channel/main.json` with `ProjectSources` and `MultiFileSource` shape.
+- Uses Codebridge and Lab2 project stack (`apps/src/lab2/*` + `apps/src/weblab2/*`).
+- Viewer/share relies on preview subdomain + service worker:
+  - Outer iframe from Studio -> `*.preview.*.codeprojects.org`.
+  - Inner iframe served through SW virtual filesystem.
+  - PostMessage + BroadcastChannel pipeline for file updates, URL bar sync, network panel.
+
+---
+
+## Key architectural differences
+
+1. **Storage shape**
+   - WebLab1: manifest + file objects.
+   - WebLab2: single `main.json` object containing multi-file graph.
+
+2. **Runtime/viewer stack**
+   - WebLab1: Bramble-centered.
+   - WebLab2: Codebridge + preview SW stack.
+
+3. **Routing assumptions**
+   - WebLab1 and WebLab2 are separate project types and routes.
+   - No existing server-side bridge that auto-converts WebLab1 project data into Lab2 source format.
+
+---
+
+## POC design
+
+## Compatibility mode activation
+
+- Introduce a **query-param-gated compatibility mode**:
+  - `?weblab1_compat=true` (also accepts `1` and `yes`).
+
+This avoids accidental behavior changes and allows controlled experimentation.
+
+## Data-loading shim
+
+- In Lab2 source loading (`apps/src/lab2/projects/sourcesApi.ts`):
+  1. Try normal Lab2 load from `/v3/sources/:channel/main.json`.
+  2. If request fails with **404** and compatibility mode is enabled:
+     - Load WebLab1 manifest from `/v3/files/:channel`.
+     - Fetch file contents for text-like files.
+     - Build a synthetic `ProjectSources` with a generated `MultiFileSource`.
+
+## MultiFile synthesis strategy
+
+- Create folders from path segments.
+- Create files with generated IDs, preserving names and hierarchy.
+- Choose active/open file priority:
+  1. `index.html` at root,
+  2. any nested `*/index.html`,
+  3. any `.html`,
+  4. first file fallback.
+
+## Preview compatibility
+
+- WebLab2 preview SW currently assumes same-origin project files or level starter assets.
+- Extend SW fetch logic so URL-backed files from compatibility mode that match:
+  - `/v3/files/:channel/:filename`
+  are fetched via environment-appropriate Studio origin (using existing `codeDotOrgOrigin` derivation).
+
+This is needed so URL-backed compatibility files can still resolve in preview context.
+
+---
+
+## Implemented POC changes (code)
+
+1. **New compatibility module**
+   - `apps/src/weblab2/weblab1Compatibility.ts`
+   - Adds:
+     - compatibility mode parser,
+     - fallback eligibility check (`404` only),
+     - WebLab1 manifest/file loading,
+     - conversion to synthetic `MultiFileSource`.
+
+2. **Lab2 source loading fallback**
+   - `apps/src/lab2/projects/sourcesApi.ts`
+   - Adds guarded fallback path:
+     - normal Lab2 load first,
+     - compatibility conversion on 404 + compat flag.
+
+3. **Preview SW bridge extension**
+   - `apps/src/weblab2/htmlPreview/weblab2_project_service_worker.js`
+   - Adds studio-relative file URL handling for `/v3/files/...` URLs used by compatibility mode.
+
+4. **Initial unit tests**
+   - `apps/test/unit/weblab2/weblab1CompatibilityTest.ts`
+   - Covers:
+     - compat mode query param parsing,
+     - fallback decision behavior,
+     - basic multi-file conversion expectations.
+
+---
+
+## What we decided (and why)
+
+1. **Use fallback adapter, not immediate data migration**
+   - Lower risk and faster validation.
+   - Lets us verify user-facing value before migration complexity.
+
+2. **Gate behavior behind explicit flag**
+   - Prevents surprise regressions.
+   - Enables selective validation and rollout.
+
+3. **Target viewer compatibility first**
+   - Matches desired scope.
+   - Keeps "View code" / "Make my own" existing semantics unchanged for now.
+
+4. **Avoid server route changes in first POC**
+   - Keeps blast radius low.
+   - Confirms feasibility primarily in frontend data+preview pipeline.
+
+---
+
+## Current limitations and risks
+
+1. **File URL encoding + nested path behavior**
+   - `/v3/files/:channel/:filename` endpoint only captures one path segment.
+   - Nested paths need careful handling/encoding assumptions.
+   - This is a critical area for deeper validation and likely hardening.
+
+2. **Non-text assets**
+   - Compatibility currently prioritizes text-file materialization.
+   - URL-backed assets and MIME handling may need additional normalization.
+
+3. **Viewer actions**
+   - Share sidebar actions (`View code`, `Make my own`) remain existing behavior.
+   - No compatibility-specific override added yet.
+
+4. **Test environment noise**
+   - Repo-local environment currently has broad baseline test/typecheck failures unrelated to this POC.
+   - Targeted verification is possible, but full green run is not yet available in this environment.
+
+---
+
+## Validation results so far
+
+- Code compiles at edit-time (no immediate syntax issues in changed files).
+- Full test and typecheck runs in this environment report many unrelated pre-existing failures.
+- New targeted tests were added, but local Jest setup currently requires additional generated locale artifacts before isolated runs can pass in this environment.
+
+---
+
+## Step-by-step implementation plan (next)
+
+## Phase 1: Harden compatibility data adapter
+
+1. Validate nested filename behavior against real WebLab1 projects.
+2. Normalize text vs binary handling:
+   - prefer inlined text content for HTML/CSS/JS/JSON/MD/TXT/CSV,
+   - explicit URL strategy for binary assets.
+3. Add robust URL/path normalization tests:
+   - root files,
+   - nested files,
+   - duplicate names in different folders,
+   - missing `index.html`.
+
+## Phase 2: Viewer UX behavior alignment
+
+1. Decide/implement desired behavior for share sidebar actions in compatibility mode:
+   - `View code`
+   - `Make my own`
+   - `Report abuse`
+2. Ensure branding + left sidebar behavior matches desired WebLab2 experience.
+
+## Phase 3: Route + entry integration options
+
+1. Evaluate best entry strategy:
+   - query-param opt-in only (short term), vs
+   - dedicated compatibility route, vs
+   - server-side lab selection for compatible project types.
+2. Add analytics marker for compatibility-mode usage.
+
+## Phase 4: rollout guardrails
+
+1. Feature-flag wiring (server/experiment level as appropriate).
+2. Add metrics + failure logging around fallback conversion.
+3. Define rollback switch and success criteria.
+
+---
+
+## Investigation details and relevant files
+
+## Core files inspected
+
+- WebLab1:
+  - `apps/src/weblab/WebLab.js`
+  - `dashboard/legacy/middleware/files_api.rb`
+  - `dashboard/legacy/middleware/helpers/file_bucket.rb`
+  - `dashboard/config/routes.rb`
+  - `dashboard/app/controllers/projects_controller.rb`
+
+- WebLab2/Lab2:
+  - `apps/src/weblab2/Weblab2View.tsx`
+  - `apps/src/weblab2/htmlPreview/HTMLPreview.tsx`
+  - `apps/src/weblab2/htmlPreview/InnerHTMLPreview.tsx`
+  - `apps/src/weblab2/htmlPreview/useProjectServiceWorker.ts`
+  - `apps/src/weblab2/htmlPreview/weblab2_project_service_worker.js`
+  - `apps/src/lab2/projects/sourcesApi.ts`
+  - `apps/src/lab2/projects/ProjectManager.ts`
+  - `apps/src/lab2/lab2Redux.ts`
+  - `apps/src/lab2/types.ts`
+
+## Files changed by this POC
+
+- `apps/src/weblab2/weblab1Compatibility.ts` (new)
+- `apps/src/lab2/projects/sourcesApi.ts`
+- `apps/src/weblab2/htmlPreview/weblab2_project_service_worker.js`
+- `apps/test/unit/weblab2/weblab1CompatibilityTest.ts` (new)
+
+---
+
+## To-do list (requested tracking)
+
+## To start immediately
+
+- [ ] Validate compatibility shim against the provided real project URL in a running local environment.
+- [ ] Confirm nested path + asset loading behavior in preview jail.
+- [ ] Decide expected behavior for share sidebar actions in compatibility mode.
+
+## After confirmation (implementation continuation)
+
+- [ ] Harden filename/path encoding and nested file support.
+- [ ] Add/expand compatibility test coverage for file trees and preview path behavior.
+- [ ] Add feature flag / experiment gate beyond query param.
+- [ ] Add event logging/metrics for fallback hit-rate and failures.
+- [ ] Consider optional server-side route convenience for compatibility viewer links.
+- [ ] Document operational rollout and rollback procedure.
+
+---
+
+## Requested unknowns / decisions needed
+
+1. Should compatibility mode remain query-param based in near term, or should we auto-detect based on missing `main.json`?
+2. In compatibility mode, should "View code" open legacy WebLab1 editor view, WebLab2 read-only code view, or be hidden?
+3. Should "Make my own" point to legacy remix initially, or be disabled until compatibility editing/remix is defined?
+4. Do we require full parity for WebLab1 binary assets in POC, or text-first plus common image support is sufficient?
+


### PR DESCRIPTION
# WebLab1 → WebLab2 viewer compatibility (POC)

## Summary

Adds an **optional, query-param-gated** path so **WebLab1 projects** (file manifest + `/v3/files/...` storage) can be loaded in the **WebLab2 / Lab2 viewer** (Codebridge + preview service worker) **without migrating** `main.json` up front. Intended for **viewer/share-style** use first; editing and remix flows stay as they are today.

## Behavior

- **Gate:** `?weblab1_compat=true` (also accepts `1` / `yes`). No param → unchanged Lab2 behavior.
- **Sources load (`sourcesApi.get`):**
  - Fetches `/v3/sources/:channel/main.json` as JSON **without** immediately applying the strict Codebridge validator when compat is on.
  - If the body **already looks like Lab2 Codebridge** (`source` is an object with `files` and `folders`), validates and uses it normally.
  - Otherwise (missing / wrong shape / App Lab–style string `source`, etc.) **synthesizes** `ProjectSources` by reading the WebLab1 **manifest** at `/v3/files/:channel` and file bodies as needed.
- **Binary assets:** Use **`url: /v3/files/:channel/:filename`** and empty `contents`, matching how Lab2 references assets elsewhere. Preview SW resolves those paths against the **Studio** origin from the codeprojects preview host.
- **Service worker:** Ensures studio-relative **`/v3/files/...`** fetches hit the correct environment; handles **data URL** bodies safely if any path still supplies them (defensive).

## Tests

1. I manually set up an adhoc env with this branch:
   - Because our adhocs don't support the `NNN.preview.codeprojects.org` subdomains, you need to set up /etc/hosts file entries and spin up a Chome instance with SSL security disabled
   - This is a recording of the hacks (talked about in Slack) showing this blocks them: https://github.com/user-attachments/assets/7f9b7deb-66fe-4633-8fce-fbe9ecd745c0
1. Unit coverage for compat flag parsing, `mainJsonIsLab2CodebridgeShape`, fallback behavior, and multi-file synthesis (`weblab1CompatibilityTest.ts`).

## Rollout / prod testing

Shipped as **opt-in via query string** so it can go to **production** for **targeted testing** on real WebLab1 channels (e.g. share links with `weblab1_compat=true`) without changing default behavior for all users.

## Future direction (if WebLab1 viewer is deprecated)

If the product decision is to retire the **WebLab1 viewer experience** on **codeprojects**, a natural follow-up is a **server or CDN redirect**, for example:

- From: `https://codeprojects.org/projects/weblab/<channel>` (and/or environment-specific hosts)  
- To: `https://studio.code.org/projects/weblab2/<channel>` (with the same channel id), optionally **appending** `?weblab1_compat=true` until native detection or migration exists.

Exact routing, query preservation, and auth would be defined when that work is scoped; this PR does **not** implement redirects.

## Links
Slack convo 1: https://codedotorg.slack.com/archives/C03DBDN67B7/p1774281660970309?thread_ts=1774037831.027539&cid=C03DBDN67B7

Slack convo 2: https://codedotorg.slack.com/archives/C0AP4AULFV0/p1774662191763089

## Privacy and security

This would add *Strong* security controls around our WebLab 1 projects without needing to change the "edit" mode