### PR TITLE
Fix bugs with archived sections

### DIFF
--- a/apps/src/templates/teacherNavigation/TeacherNavigationBar.tsx
+++ b/apps/src/templates/teacherNavigation/TeacherNavigationBar.tsx
@@ -56,10 +56,16 @@ const TeacherNavigationBar: React.FC<{
   );
 
   useEffect(() => {
-    const updatedSectionArray = sectionOrder
+    const sectionIds =
+      !selectedSection || _.includes(sectionOrder, selectedSection.id)
+        ? sectionOrder
+        : [selectedSection.id, ...sectionOrder];
+    const updatedSectionArray = sectionIds
       .map(sectionId => sections[sectionId] || null)
       .filter(section => section !== null)
-      .filter(section => !section.hidden)
+      .filter(section => {
+        return !(section.hidden && section.id !== selectedSection?.id);
+      })
       .map(section => ({
         value: section.id.toString(),
         text: section.name,

--- a/apps/test/unit/templates/studioHomepages/teacherHomepageV2/CourseContentDropdownTest.tsx
+++ b/apps/test/unit/templates/studioHomepages/teacherHomepageV2/CourseContentDropdownTest.tsx
@@ -96,7 +96,7 @@ describe('CourseContentDropdown', () => {
   const lessons = [
     {
       text: "Unit 3 - Interactive Animations and Games ('24-'25)",
-      value: '/courses/csd-2024/units/3',
+      value: '/teacher_dashboard/sections/11/courses/csd-2024/units/3',
     },
     {
       text: '1: Programming for a Purpose',
@@ -188,7 +188,7 @@ describe('CourseContentDropdown', () => {
     expect(sendEventSpy).toHaveBeenCalledWith(
       EVENTS.SECTION_CARD_JUMP_TO_UNIT_OVERVIEW_CLICKED,
       {
-        lesson: '/courses/csd-2024/units/3',
+        lesson: '/teacher_dashboard/sections/11/courses/csd-2024/units/3',
       }
     );
   });

--- a/apps/test/unit/templates/teacherNavigation/TeacherNavigationBarTest.jsx
+++ b/apps/test/unit/templates/teacherNavigation/TeacherNavigationBarTest.jsx
@@ -320,6 +320,15 @@ describe('TeacherNavigationBar', () => {
     expect(loadSelectedSectionSpy).toHaveBeenCalledWith('14');
   });
 
+  test('hidden section not in sectionOrder is shown when selected', async () => {
+    renderDefault(15);
+    const dropdown = await screen.findByRole('combobox');
+
+    expect(dropdown).toHaveValue('15');
+    screen.getByText('hidden');
+    expect(loadSelectedSectionSpy).toHaveBeenCalledWith('15');
+  });
+
   test('AI settings tab displayed when teacher has access', async () => {
     renderDefault(16, `/teacher_dashboard/sections/16/unit/csa1-2022`, true);
     await screen.findByText('Course Content');

--- a/dashboard/app/controllers/courses_controller.rb
+++ b/dashboard/app/controllers/courses_controller.rb
@@ -55,7 +55,7 @@ class CoursesController < ApplicationController
     end
 
     if current_user&.user_type == "teacher" && current_user.sections_instructed.any? {|s| s.course_id == @unit_group.id} && TeacherDashboardUtils.can_redirect_to_teacher_dashboard?(current_user)
-      section_id = params[:section_id] || current_user.sections_instructed.select {|s| s.course_id == @unit_group.id}.last.id
+      section_id = params[:section_id] || current_user.sections_instructed.select {|s| !s.hidden && s.course_id == @unit_group.id}.last.id
       if section_id
         redirect_to "/teacher_dashboard/sections/#{section_id}/courses/#{@unit_group.name}"
         return

--- a/dashboard/app/controllers/scripts_controller.rb
+++ b/dashboard/app/controllers/scripts_controller.rb
@@ -42,7 +42,7 @@ class ScriptsController < ApplicationController
         return
       end
       if current_user&.user_type == "teacher" && current_user.sections_instructed.any? {|s| s.script_id == @script.id || s.unit_group&.id == @course&.id}
-        most_recent_section = current_user.sections_instructed.select {|s| s.script_id == @script.id || s.unit_group&.id == @course.id}.last
+        most_recent_section = current_user.sections_instructed.select {|s| !s.hidden && (s.script_id == @script.id || s.unit_group&.id == @course.id)}.last
         section_id = params[:section_id]
         section_id ||= most_recent_section&.id
         if section_id

--- a/dashboard/app/controllers/sections_controller.rb
+++ b/dashboard/app/controllers/sections_controller.rb
@@ -70,7 +70,12 @@ class SectionsController < ApplicationController
       unit = Unit.get_from_cache(section.script_id)
       unit_group = UnitGroup.get_from_cache(section.course_id)
       unit_group_unit = Queries::Courses.unit_group_unit(unit, unit_group)
-      lessons << {text: unit.title_for_display(unit_group_unit: unit_group_unit).sub(" - ", ": "), value: unit.link(unit_group_unit: unit_group_unit)}
+      unit_path = if unit_group_unit && unit_group
+                    "/teacher_dashboard/sections/#{section.id}/courses/#{unit_group.name}/units/#{unit_group_unit.position}"
+                  else
+                    "/teacher_dashboard/sections/#{section.id}/courses"
+                  end
+      lessons << {text: unit.title_for_display(unit_group_unit: unit_group_unit).sub(" - ", ": "), value: unit_path}
       unit.lesson_groups.each do |lesson_group|
         lessons.concat(lesson_group.lessons.select(&:has_lesson_plan).map do |lesson|
           path =

--- a/dashboard/test/controllers/sections_controller_test.rb
+++ b/dashboard/test/controllers/sections_controller_test.rb
@@ -271,7 +271,7 @@ class SectionsControllerTest < ActionController::TestCase
     get :retrieve_lessons_for_dropdown, params: {id: @flappy_section.id}
     assert_response :success
     response_json = JSON.parse(@response.body)
-    assert_equal response_json, [{"text"=>"Flappy Code", "value"=>"/courses/flappy/units/1"}, {"text"=>"Flappy Code", "value"=>"/courses/flappy/units/1/lessons/1/levels/1"}]
+    assert_equal response_json, [{"text"=>"Flappy Code", "value"=>"/teacher_dashboard/sections/#{@flappy_section.id}/courses/flappy/units/1"}, {"text"=>"Flappy Code", "value"=>"/courses/flappy/units/1/lessons/1/levels/1"}]
   end
 
   describe '#retrieve_lessons_for_dropdown' do
@@ -304,8 +304,8 @@ class SectionsControllerTest < ActionController::TestCase
       _(response_unit[:text]).must_equal unit.title_for_display(unit_group_unit: unit_group_unit)
     end
 
-    it 'returns unit path' do
-      _(response_unit[:value]).must_equal "/courses/#{unit_group.name}/units/#{unit_position}"
+    it 'returns unit teacher dashboard path' do
+      _(response_unit[:value]).must_equal "/teacher_dashboard/sections/#{section.id}/courses/#{unit_group.name}/units/#{unit_position}"
     end
 
     it 'returns lesson name' do


### PR DESCRIPTION
Fixes a few bugs with archived sections:

* When a user goes to the teacher dashboard for an archived section, the archived section was not an option in the selected section dropdown. This caused the section selector to show a different section than what was selected. I also meant that when there was only one non-archived section that the user could not go to their unarchived section because the only non-archived section was selected.
  * Fixed this bug by adding the selected section, even if it is hidden, to the selection dropdown
* On the homepage, the `go to unit` button would go to the un-assigned unit page and rely on redirects to go to the teacher dashboard. This meant that it would select the first section that had the course assigned instead of the section that you are clicking `go to unit` for.
  * Fixed this bug by returning a link to the teacher dashboard unit page instead of the unassigned unit page
* Finally, the redirect from the unassigned to an assigned version of the unit and course pages would take the first section, regardless of if it is archived.
  * Fixed this by redirecting to the first un-archived section with the course/unit assigned.



## Links
[Zendesk ticket](https://codeorg.zendesk.com/agent/tickets/582458)
