### PR TITLE
Revert "Move text compression widget to CodeMirror6"

### DIFF
--- a/apps/src/code-studio/initializeCodeMirror6.ts
+++ b/apps/src/code-studio/initializeCodeMirror6.ts
@@ -9,25 +9,14 @@ import {
   lintGutter,
   linter,
 } from '@codemirror/lint';
-import {
-  EditorState,
-  Extension,
-  StateEffect,
-  StateField,
-} from '@codemirror/state';
-import {
-  Decoration,
-  DecorationSet,
-  EditorView,
-  ViewUpdate,
-  lineNumbers,
-} from '@codemirror/view';
+import {EditorState, Extension} from '@codemirror/state';
+import {EditorView, ViewUpdate} from '@codemirror/view';
 import js from '@eslint/js';
 import * as eslint from 'eslint-linter-browserify';
 import globals from 'globals';
 import React from 'react';
 
-import {editorConfigWithoutLineNumbers} from '@cdo/apps/codemirror/editorConfig';
+import {editorConfig} from '@cdo/apps/codemirror/editorConfig';
 import {createReactRoot} from '@cdo/apps/util/createReactRoot';
 
 import MainInstructionsPreview from '../lab2/views/components/Instructions/MainInstructionsPreview';
@@ -52,7 +41,6 @@ interface CodeMirrorLegacyAdapter {
   getWrapperElement: () => HTMLElement;
   getCursor: () => number;
   setCursor: (position: number) => void;
-  setErrorLineIndexes: (lineIndexes: number[]) => void;
   on: (event: string, listener: (...args: unknown[]) => void) => void;
 }
 
@@ -64,14 +52,11 @@ interface Options {
     es5?: boolean;
     disableRecommendedJsConfig?: boolean;
   };
-  lineNumberFormatter?: (line: number) => string;
-  lineHighlightClassName?: string;
-  themeStyles?: Record<string, Record<string, string | number>>;
   preview?: string | Element;
   game?: string;
 }
 
-type EditorMode = 'text' | 'javascript' | 'json' | 'markdown' | 'xml' | 'html';
+type EditorMode = 'javascript' | 'json' | 'markdown' | 'xml' | 'html';
 
 const levelbuilderEditorTheme = EditorView.theme({
   '&': {
@@ -80,47 +65,11 @@ const levelbuilderEditorTheme = EditorView.theme({
   },
 });
 
-const setErrorLineIndexesEffect = StateEffect.define<number[]>();
-
-function createErrorLineDecorations(
-  state: EditorState,
-  lineIndexes: number[],
-  className: string
-): DecorationSet {
-  const decorations = lineIndexes
-    .filter(index => index >= 0 && index < state.doc.lines)
-    .map(index => {
-      const line = state.doc.line(index + 1);
-      return Decoration.line({class: className}).range(line.from);
-    });
-  return Decoration.set(decorations, true);
+interface Options {
+  callback?: (editor: CodeMirrorLegacyAdapter, update: ViewUpdate) => void;
 }
 
-const createErrorLineHighlightField = (className: string) =>
-  StateField.define<DecorationSet>({
-    create() {
-      return Decoration.none;
-    },
-    update(decorations, transaction) {
-      const lineIndexesEffect = transaction.effects.find(e =>
-        e.is(setErrorLineIndexesEffect)
-      );
-      if (lineIndexesEffect) {
-        return createErrorLineDecorations(
-          transaction.state,
-          lineIndexesEffect.value,
-          className
-        );
-      }
-      if (transaction.docChanged) {
-        return decorations.map(transaction.changes);
-      }
-      return decorations;
-    },
-    provide: field => EditorView.decorations.from(field),
-  });
-
-const languageExtensionMap: Partial<Record<EditorMode, Extension>> = {
+const languageExtensionMap: Record<EditorMode, Extension> = {
   javascript: javascript(),
   json: json(),
   markdown: markdown(),
@@ -128,8 +77,8 @@ const languageExtensionMap: Partial<Record<EditorMode, Extension>> = {
   html: html(),
 };
 
-function getLanguageExtension(mode: EditorMode): Extension | null {
-  return languageExtensionMap[mode] || null;
+function getLanguageExtension(mode: EditorMode): Extension {
+  return languageExtensionMap[mode];
 }
 
 const getLintExtension = (
@@ -201,7 +150,7 @@ function resolvePreviewElement(
  * initializeCodeMirror6 syncs a textarea on the page with a full-featured
  * CodeMirror6 editor.
  * @param {!string|!Element} target - element or id of element to replace.
- * @param {!string} mode - editor syntax mode (`text` disables language/lint extensions)
+ * @param {!string} mode - editor syntax mode
  * @param {Object} options - misc optional arguments
  * @param {function} [options.callback] - onChange callback for editor
  * @param {onUpdateLinting} [options.onUpdateLinting] - callback that receives linting errors on each update.
@@ -220,23 +169,10 @@ function initializeCodeMirror6(
 ): CodeMirrorLegacyAdapter {
   const node = resolveTarget(target);
 
-  const {
-    callback,
-    attachments,
-    onUpdateLinting,
-    lineNumberFormatter,
-    lineHighlightClassName,
-    themeStyles,
-    preview,
-    game,
-  } = options;
+  const {callback, attachments, onUpdateLinting, preview, game} = options;
   const changeListeners: Array<() => void> = [];
   const dropListeners: Array<(event: DragEvent) => void> = [];
-  const languageExtension = getLanguageExtension(mode);
   const lintExtension = getLintExtension(mode, options.lintConfig);
-  const errorLineHighlightField = lineHighlightClassName
-    ? createErrorLineHighlightField(lineHighlightClassName)
-    : null;
 
   const editorContainer = document.createElement('div');
   node.style.display = 'none';
@@ -264,17 +200,6 @@ function initializeCodeMirror6(
     setCursor(position) {
       editor.dispatch({
         selection: {anchor: position},
-      });
-    },
-    setErrorLineIndexes(lineIndexes) {
-      if (!lineHighlightClassName) {
-        console.warn(
-          'Please provide a lineHighlightClassName to enable error line highlighting.'
-        );
-        return;
-      }
-      editor.dispatch({
-        effects: setErrorLineIndexesEffect.of(lineIndexes),
       });
     },
     on(event, listener) {
@@ -321,15 +246,10 @@ function initializeCodeMirror6(
   };
 
   const extensions: Extension[] = [
-    ...editorConfigWithoutLineNumbers,
-    lineNumbers(
-      lineNumberFormatter ? {formatNumber: lineNumberFormatter} : undefined
-    ),
-    ...(languageExtension ? [languageExtension] : []),
+    ...editorConfig,
+    getLanguageExtension(mode),
     levelbuilderEditorTheme,
-    ...(themeStyles ? [EditorView.theme(themeStyles)] : []),
     EditorView.lineWrapping,
-    ...(errorLineHighlightField ? [errorLineHighlightField] : []),
     ...(onUpdateLinting && lintExtension ? [lintExtension, lintGutter()] : []),
     EditorView.domEventHandlers({
       drop(event) {

--- a/apps/src/codemirror/editorConfig.ts
+++ b/apps/src/codemirror/editorConfig.ts
@@ -34,7 +34,8 @@ const autocompleteKeybindings = [{key: 'Tab', run: acceptCompletion}];
 // Extensions for codemirror. Based on @codemirror/basic-setup, with javascript-specific
 // extensions removed (lint, autocomplete). This is the base configuration for all codemirror
 // editors on the site. Any changes here will impact Java Lab, Python Lab, and Web Lab 2.
-const editorConfigWithoutLineNumbers = [
+const editorConfig = [
+  lineNumbers(),
   highlightSpecialChars(),
   history(),
   drawSelection(),
@@ -61,6 +62,4 @@ const editorConfigWithoutLineNumbers = [
   EditorState.tabSize.of(2),
 ];
 
-const editorConfig = [lineNumbers(), ...editorConfigWithoutLineNumbers];
-
-export {editorConfig, editorConfigWithoutLineNumbers};
+export {editorConfig};

--- a/apps/src/sites/studio/pages/levels/_widget.js
+++ b/apps/src/sites/studio/pages/levels/_widget.js
@@ -6,7 +6,6 @@ import $ from 'jquery';
 import React from 'react';
 
 import {setupApp} from '@cdo/apps/code-studio/initApp/loadApp';
-import initializeCodeMirror6 from '@cdo/apps/code-studio/initializeCodeMirror6';
 import {registerGetResult} from '@cdo/apps/code-studio/levels/codeStudioLevels';
 import {
   showDialog,
@@ -42,7 +41,7 @@ function setupWidgetLevel() {
 }
 
 // Add globals
-window.initializeCodeMirror6 = initializeCodeMirror6;
+window.CodeMirror = require('codemirror');
 window.dashboard = window.dashboard || {};
 window.dashboard.widget = {
   setupWidgetLevel: setupWidgetLevel,

--- a/dashboard/public/text-compression/text-compression.html
+++ b/dashboard/public/text-compression/text-compression.html
@@ -88,8 +88,20 @@
     #data .error {
       color: #c00;
     }
-    mark {
+    mark, .CodeMirror-gutters {
       background-color: #ff9;
+    }
+    .CodeMirror-linenumber {
+      color: #000;
+      text-align: center;
+    }
+    .CodeMirror {
+      font-size: 14pt;
+      line-height: 1.4em;
+      min-height: 200px;
+    }
+    .dict-error {
+      background-color: #f99;
     }
     #selfEnteredPoem {
       box-sizing: border-box;
@@ -147,5 +159,21 @@
     </table>
   </div>
   <script type="text/javascript" src="/text-compression/text-compression.js"></script>
+  <!--[if IE 9]>
+  <script>
+    function fixIE9 () {
+      var $widgetMain = $('#widgetMain');
+      $('#widgetMainWrapper')
+          .css('position', 'absolute')
+          .css('top', $widgetMain.position().top)
+          .css('width', $widgetMain.width())
+          .css('height', $widgetMain.height());
+      $('.CodeMirror').height($('#symbolEditorWrapper').height());
+      editor.refresh();
+    }
+    $(document).ready(fixIE9);
+    $(window).resize(fixIE9);
+  </script>
+  <![endif]-->
 </body>
 </html>

--- a/dashboard/public/text-compression/text-compression.js
+++ b/dashboard/public/text-compression/text-compression.js
@@ -1,4 +1,4 @@
-/* global $ Dialog */
+/* global $ Dialog CodeMirror */
 
 (function() {
   var FIRST_SYMBOL = 0x2600; // ☀
@@ -124,14 +124,15 @@
     var poemDisplay = poemText;
     var dict = editor.getValue().split("\n").slice(0, MAX_DICT_ENTRIES);
     var errorInDictionary = false;
-    var errorLineIndexes = [];
 
     var validRules = dict.map(function (rule, index) {
+      var line = editor.getLineHandle(index);
       if (new RegExp('[' + dictEntries[index] + '-\\u' + LAST_SYMBOL.toString(16) + ']').test(rule)) {
+        editor.addLineClass(line, 'wrap', 'dict-error');
         errorInDictionary = true;
-        errorLineIndexes.push(index);
         return '';
       }
+      editor.removeLineClass(line, 'wrap', 'dict-error');
       return rule;
     });
 
@@ -144,7 +145,6 @@
     compressedPoemSize = poemDisplay.length;
     document.getElementById("compressedPoem").innerHTML = poemDisplay.replace(
       new RegExp('[' + SYMBOL_REGEX + ']+', "g"), "<mark>$&</mark>");
-    editor.setErrorLineIndexes(errorLineIndexes);
     calculateData(errorInDictionary);
   }
 
@@ -165,62 +165,21 @@
 
   var poemSelect = document.getElementById("poemsList");
   $('#writeYourOwn').click(showWriteYourOwnDialog);
-
-  var themeStyles = {
-    '&': {
-      height: '100%',
-      fontSize: '14pt',
-      lineHeight: '1.4em',
-      minHeight: '200px',
-    },
-    '.cm-gutters': {
-      backgroundColor: '#ff9',
-    },
-    '.cm-lineNumbers .cm-gutterElement': {
-      color: '#000',
-      textAlign: 'center',
-      boxSizing: 'content-box',
-    },
-    '.cm-scroller': {
-      overflow: 'auto'
-    },
-    '.cm-line.dict-error': {
-      backgroundColor: '#f99'
+  window.editor = CodeMirror.fromTextArea($dictionary[0], {
+    lineNumbers: true,
+    lineWrapping: true,
+    firstLineNumber: 0,
+    lineNumberFormatter: function (line) {
+      return dictEntries[line] || '';
     }
-  };
-
-  window.editor = window.initializeCodeMirror6($dictionary[0], 'text', {
-    lineNumberFormatter: function (lineNumber) {
-      return dictEntries[lineNumber - 1] || '';
-    },
-    lineHighlightClassName: 'dict-error',
-    themeStyles: themeStyles,
   });
-
   editor.on("change", compress);
-
-  var editorMount = editor.getWrapperElement().parentElement;
-  if (editorMount) {
-    editorMount.style.height = '100%';
-    editorMount.style.width = '100%';
-  }
-
-  editor.getWrapperElement().addEventListener("keydown", function (e) {
+  editor.on("keypress", function (cm, e) {
     if (e.keyCode === 32) {
-      e.preventDefault();
-      var cursorPosition = editor.getCursor();
-      var currentValue = editor.getValue();
-      editor.setValue(
-        currentValue.slice(0, cursorPosition) +
-          '_' +
-          currentValue.slice(cursorPosition)
-      );
-      editor.setCursor(cursorPosition + 1);
+      CodeMirror.e_stop(e);
+      cm.replaceSelection('_');
     }
   });
-
-  editor.getWrapperElement().style.width = '100%';
-  editor.getWrapperElement().style.height = '100%';
-
+  editor.setSize('100%', '100%');
   poemChanged();
 })();


### PR DESCRIPTION
Reverts code-dot-org/code-dot-org#71502

A few suspicious widget tests failing in the latest DTT, reverting speculatively: https://codedotorg.slack.com/archives/C0T0PNTM3/p1774897746954159