### PR TITLE
Revert "Move `start-build` Endpoint to Dashboard"

### DIFF
--- a/dashboard/app/controllers/dev_controller.rb
+++ b/dashboard/app/controllers/dev_controller.rb
@@ -1,42 +1,18 @@
 require 'cdo/github'
 require 'cdo/developers_topic'
 
+CHECK_DTS_ACTIONS = [
+  'opened',
+  'reopened',
+  'edited',
+  'synchronize',
+].freeze
+
 # Controller actions used for internal developer tools
 class DevController < ApplicationController
   # Disable Rails' layout and CSRF verification for these API routes
   layout false
   skip_before_action :verify_authenticity_token
-
-  BUILD_STARTED_PATH = deploy_dir('build-started').freeze
-  CHECK_DTS_ACTIONS = [
-    'opened',
-    'reopened',
-    'edited',
-    'synchronize',
-  ].freeze
-
-  def start_build
-    # Forbidden in production because it's a dev route
-    # Forbidden in development because it won't work anyway
-    return head :forbidden if rack_env?(:development, :production)
-    return head :forbidden unless ActiveSupport::SecurityUtils.secure_compare(
-      params[:token] || '', CDO.slack_start_build_token
-    )
-
-    # Don't create build-started if it already exists; let the requester know.
-    if File.file?(BUILD_STARTED_PATH)
-      return render plain: "I can't do that #{params[:user_name]} - a build is already queued"
-    end
-
-    # Create the build-started file so a new build will start within one minute
-    FileUtils.touch(BUILD_STARTED_PATH)
-
-    # Notify the room
-    return render json: {
-      text: "#{rack_env.to_s.capitalize} build restarted by #{params[:user_name]}",
-      response_type: 'in_channel'
-    }
-  end
 
   def check_dts
     return head :forbidden unless rack_env?(:staging)

--- a/dashboard/config/routes.rb
+++ b/dashboard/config/routes.rb
@@ -1072,10 +1072,7 @@ Dashboard::Application.routes.draw do
       end
     end
     if rack_env?(:staging, :test)
-      scope path: '/api/dev', controller: :dev do
-        post 'check-dts', action: 'check_dts'
-        post 'start-build', action: 'start_build'
-      end
+      post '/api/dev/check-dts', to: 'dev#check_dts'
     end
 
     namespace :api do

--- a/dashboard/test/controllers/dev_controller_test.rb
+++ b/dashboard/test/controllers/dev_controller_test.rb
@@ -1,7 +1,6 @@
 require 'test_helper'
 
 FAKE_GITHUB_WEBHOOK_SECRET = 'fake-github-secret'.freeze
-FAKE_SLACK_SLASH_TOKEN = 'fake-start-build-token'.freeze
 GITHUB_PAYLOAD = {
   action: 'opened',
   pull_request: {
@@ -13,81 +12,10 @@ GITHUB_PAYLOAD = {
 GITHUB_PARAMS = {
   payload: GITHUB_PAYLOAD.to_json,
 }.freeze
-SLACK_PARAMS = {
-  token: FAKE_SLACK_SLASH_TOKEN,
-  user_name: 'Dave'
-}.freeze
 
 class DevControllerTest < ActionDispatch::IntegrationTest
   setup do
     CDO.stubs(github_webhook_secret: FAKE_GITHUB_WEBHOOK_SECRET)
-    CDO.stubs(slack_start_build_token: FAKE_SLACK_SLASH_TOKEN)
-    # File.stubs(:file?).with(DevController::BUILD_STARTED_PATH).returns(false)
-    FileUtils.stubs(:touch).with(DevController::BUILD_STARTED_PATH)
-  end
-
-  test 'start-build is forbidden on production and development' do
-    [:production, :development].each do |forbidden_env|
-      with_rack_env(forbidden_env) do
-        FileUtils.expects(:touch).never
-        post '/api/dev/start-build', params: SLACK_PARAMS
-        assert_response :forbidden
-      end
-    end
-  end
-
-  test 'start-build is allowed on most environments' do
-    [:staging, :test, :adhoc, :levelbuilder].each do |allowed_env|
-      with_rack_env(allowed_env) do
-        FileUtils.expects(:touch).once
-        post '/api/dev/start-build', params: SLACK_PARAMS
-        assert_response :success
-      end
-    end
-  end
-
-  test 'start-build is forbidden with a missing or incorrect token' do
-    with_rack_env(:staging) do
-      post('/api/dev/start-build', params: {user_name: 'Dave'})
-      assert_response :forbidden
-
-      post(
-        '/api/dev/start-build',
-        params: {
-          token: 'incorrect-token',
-          user_name: 'Dave'
-        }
-      )
-      assert_response :forbidden
-    end
-  end
-
-  test 'start-build generates a start_build file if none exists' do
-    with_rack_env(:test) do
-      FileUtils.expects(:touch).once
-      post '/api/dev/start-build', params: SLACK_PARAMS
-
-      # Check appropriate response to whole room, too
-      assert_response :success
-      response_body = JSON.parse(response.body)
-      assert_equal 'Test build restarted by Dave', response_body['text']
-      assert_equal 'in_channel', response_body['response_type']
-    end
-  end
-
-  test 'start-build succeeds without action if start_build exists' do
-    with_rack_env(:test) do
-      File.stubs(:file?).with(DevController::BUILD_STARTED_PATH).returns(true)
-      FileUtils.expects(:touch).never
-      post '/api/dev/start-build', params: SLACK_PARAMS
-
-      # Check response to requester
-      assert_response :success
-      assert_equal(
-        "I can't do that Dave - a build is already queued",
-        response.body
-      )
-    end
   end
 
   test 'check-dts is forbidden on non-staging environments' do

--- a/pegasus/routes/dev/dev_routes.rb
+++ b/pegasus/routes/dev/dev_routes.rb
@@ -1,5 +1,35 @@
+require 'cdo/developers_topic'
 require 'cdo/github'
 require 'cdo/test_server_status'
+
+BUILD_STARTED_PATH = deploy_dir('build-started').freeze
+# Used to restart builds on staging/test via Slack slash commands.
+post '/api/dev/start-build' do
+  # Forbidden in production because it's a dev route
+  # Forbidden in development because it won't work anyway
+  forbidden! if [:development, :production].include? rack_env
+
+  dont_cache
+
+  forbidden! unless params[:token] == CDO.slack_start_build_token
+
+  # Don't create build-started if it already exists; let the requester know.
+  if File.file?(BUILD_STARTED_PATH)
+    return "I can't do that #{params[:user_name]} - a build is already queued"
+  end
+
+  # Create the build-started file so a new build will start within one minute
+  system "touch #{BUILD_STARTED_PATH}"
+
+  # Notify the room
+  content_type :json
+  JSON.pretty_generate(
+    {
+      text: "#{rack_env.to_s.capitalize} build restarted by #{params[:user_name]}",
+      response_type: 'in_channel'
+    }
+  )
+end
 
 post '/api/dev/set-last-dtt-green' do
   forbidden! unless rack_env == :test

--- a/pegasus/test/test_dev_routes.rb
+++ b/pegasus/test/test_dev_routes.rb
@@ -5,6 +5,7 @@ require_relative '../../lib/cdo/github'
 require_relative '../../lib/cdo/infra_test_topic'
 require_relative 'fixtures/mock_pegasus'
 
+BUILD_STARTED_PATH = deploy_dir('build-started').freeze
 FAKE_SLACK_SLASH_TOKEN = 'fake-start-build-token'.freeze
 
 class DevRoutesTest < Minitest::Test
@@ -17,6 +18,134 @@ class DevRoutesTest < Minitest::Test
     def make_test_pegasus
       mock_session = Rack::MockSession.new(MockPegasus.new, 'studio.code.org')
       Rack::Test::Session.new(mock_session)
+    end
+
+    describe '/api/dev/start-build' do
+      def assert_forbidden_on_rack_env(forbidden_env)
+        with_rack_env(forbidden_env) do
+          pegasus = make_test_pegasus
+
+          pegasus.post '/api/dev/start-build', DEFAULT_PARAMS
+          assert_equal 403, pegasus.last_response.status
+          refute File.file? BUILD_STARTED_PATH
+        end
+      end
+
+      def assert_allowed_on_rack_env(allowed_env)
+        with_rack_env(allowed_env) do
+          pegasus = make_test_pegasus
+          begin
+            pegasus.post '/api/dev/start-build', DEFAULT_PARAMS
+            assert_equal 200, pegasus.last_response.status
+          ensure
+            system "rm -f #{BUILD_STARTED_PATH}"
+          end
+        end
+      end
+
+      before do
+        $log.level = Logger::ERROR
+
+        # Fake slack token for tests
+        CDO.stubs(slack_start_build_token: FAKE_SLACK_SLASH_TOKEN)
+
+        # Should have no build-started file at the beginning of tests
+        system "rm -f #{BUILD_STARTED_PATH}"
+        refute File.file?(BUILD_STARTED_PATH),
+          'Precondition failure: File start-build should not exist.'
+      end
+
+      it 'is forbidden on production environments' do
+        assert_forbidden_on_rack_env :production
+      end
+
+      it 'is forbidden on development environments' do
+        assert_forbidden_on_rack_env :development
+      end
+
+      it 'is allowed on staging' do
+        assert_allowed_on_rack_env(:staging)
+      end
+
+      it 'is allowed on test' do
+        assert_allowed_on_rack_env(:test)
+      end
+
+      it 'is allowed on adhoc' do
+        assert_allowed_on_rack_env(:adhoc)
+      end
+
+      it 'is allowed on levelbuilder' do
+        assert_allowed_on_rack_env(:levelbuilder)
+      end
+
+      it 'is forbidden with a missing token' do
+        with_rack_env(:staging) do
+          pegasus = make_test_pegasus
+          pegasus.post(
+            '/api/dev/start-build',
+            {user_name: 'Dave'}
+          )
+          assert_equal 403, pegasus.last_response.status
+        end
+      end
+
+      it 'is forbidden with an incorrect token' do
+        with_rack_env(:staging) do
+          pegasus = make_test_pegasus
+          pegasus.post(
+            '/api/dev/start-build',
+            {
+              token: 'incorrect-token',
+              user_name: 'Dave'
+            }
+          )
+          assert_equal 403, pegasus.last_response.status
+        end
+      end
+
+      it 'generates a start_build file if none exists' do
+        with_rack_env(:test) do
+          pegasus = make_test_pegasus
+          begin
+            refute File.file? BUILD_STARTED_PATH
+            pegasus.post '/api/dev/start-build', DEFAULT_PARAMS
+            assert File.file? BUILD_STARTED_PATH
+
+            # Check appropriate response to whole room, too
+            assert_equal 200, pegasus.last_response.status
+            response_body = JSON.parse(pegasus.last_response.body)
+            assert_equal 'Test build restarted by Dave', response_body['text']
+            assert_equal 'in_channel', response_body['response_type']
+          ensure
+            system "rm -f #{BUILD_STARTED_PATH}"
+          end
+        end
+      end
+
+      it 'succeeds without action if start_build exists' do
+        with_rack_env(:test) do
+          pegasus = make_test_pegasus
+          begin
+            system "touch #{BUILD_STARTED_PATH}"
+            assert File.file? BUILD_STARTED_PATH
+            original_modify_time = File.mtime(BUILD_STARTED_PATH)
+
+            pegasus.post '/api/dev/start-build', DEFAULT_PARAMS
+            assert File.file? BUILD_STARTED_PATH
+            assert_equal original_modify_time, File.mtime(BUILD_STARTED_PATH)
+
+            # Check response to requester
+            assert_equal 200, pegasus.last_response.status
+            assert_equal(
+              "I can't do that Dave - a build is already queued",
+              pegasus.last_response.body
+            )
+          ensure
+            system "rm -f #{BUILD_STARTED_PATH}"
+          end
+        end
+      end
     end
 
     describe 'api/dev/set-last-dtt-green' do


### PR DESCRIPTION
Reverts code-dot-org/code-dot-org#71710

Caused some unexpected errors in the DTT; reverting to unblock the pipeline while I debug

See slack thread [here](https://codedotorg.slack.com/archives/C0T0PNTM3/p1774902471163499)