### PR TITLE
feat(code-gen): add `frontend` pkg and lab gen

### DIFF
--- a/frontend/.prettierignore
+++ b/frontend/.prettierignore
@@ -2,3 +2,6 @@
 apps
 packages
 *.lock
+
+# Generator templates use Handlebars syntax that prettier cannot parse correctly
+turbo/generators/templates/

--- a/frontend/AGENTS.md
+++ b/frontend/AGENTS.md
@@ -78,6 +78,20 @@ modifying that area — not before every edit.
 | Rails config injection, `SiteConfig`, meta tag        | `docs/conventions/tech.md`           |
 | `packages/core` singletons, boot, or `./api` sub-path | `packages/core/docs/architecture.md` |
 
+## Generator ↔ conventions coupling
+
+`turbo/generators/config.ts` (and its `turbo/generators/templates/` directory)
+and `docs/conventions/packages.md` are **tightly coupled** — they must always
+describe the same scaffold structure.
+
+**Rule:** When you change either, you MUST update the other:
+
+- Changing a template (file content, deps, scripts, etc.) → update `docs/conventions/packages.md`
+- Changing the convention docs (scaffold structure, file list, naming) → update the relevant templates
+
+This coupling is intentional: the docs describe what the generator produces, and
+the generator enforces what the docs specify.
+
 Key rules that apply everywhere:
 
 - Always `yarn`, never `npx`. Turbo is invoked through workspace scripts.

--- a/frontend/apps/design-system-storybook/package.json
+++ b/frontend/apps/design-system-storybook/package.json
@@ -26,7 +26,7 @@
     "prettier": "prettier --check .",
     "prettier:fix": "prettier --write .",
     "storybook": "storybook dev -p 6006",
-    "test": "vitest",
+    "test": "vitest --run",
     "test-storybook": "vitest --project=storybook",
     "test:ui:ci": "bash ./scripts/test-storybook.sh",
     "test:ui:local": "test-storybook --url http://localhost:6006",

--- a/frontend/docs/conventions/packages.md
+++ b/frontend/docs/conventions/packages.md
@@ -5,7 +5,14 @@ Applies to all packages under `frontend/packages/` and `frontend/packages/labs/`
 Labs (`packages/labs/*`) are standalone React apps that render a curriculum experience.
 Libraries (`packages/*`) are shared utilities consumed by labs and Studio.
 
-**Scaffolded by:** `yarn turbo gen package` (library) or `yarn turbo gen lab` (lab — generator not yet implemented, see scaffolding steps below)
+**Scaffolded by:** `yarn turbo gen package` (library) or `yarn turbo gen lab` (lab)
+
+Run from `frontend/`. The generator creates all scaffold files and, for labs,
+also registers the lab in Studio.
+
+> **Convention coupling:** `turbo/generators/config.ts` and this file are tightly
+> coupled. When you update a generator template, update this file too, and vice
+> versa. See `AGENTS.md` at the `frontend/` root for the enforcement rule.
 
 ## Why
 
@@ -93,15 +100,14 @@ Labs (`packages/labs/*`) are standalone React apps that are also consumed as laz
 
 ### Scaffolding a new lab
 
-1. Create `frontend/packages/labs/<name>/` mirroring the music lab file structure
-2. In `package.json`: set `name` to `@code-dot-org/<name>-lab`; do not add `"type": "module"`
-3. In `vite.config.ts`: update the `name` field in `build.lib`
-4. Use `.mjs` for `eslint.config.mjs` (music lab has `.js`; `.mjs` is the convention)
-5. Register in Studio — three files:
-   - `apps/studio/src/modules/labs/config/labs.ts` — add `'<name>'` to `AVAILABLE_LABS`
-   - `apps/studio/src/modules/labs/router/getLabEntrypoint.ts` — add `['<name>']: lazy(() => import('@code-dot-org/<name>-lab'))`
-   - `apps/studio/package.json` — add `"@code-dot-org/<name>-lab": "workspace:*"` to `dependencies`
-6. Run `yarn install` then `yarn release:dryrun` from `frontend/`
+Run from `frontend/`:
+
+```bash
+yarn turbo gen lab
+```
+
+The generator creates all scaffold files and automatically registers the lab in
+Studio (updates `labs.ts`, `getLabEntrypoint.ts`, and `apps/studio/package.json`).
 
 The lab is then reachable at `/app/projects/<name>/:channelId/edit`.
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -36,6 +36,8 @@
   "devDependencies": {
     "@axe-core/playwright": "^4.10.1",
     "@eslint/js": "catalog:",
+    "@turbo/gen": "^2.6.3",
+    "@types/node": "catalog:",
     "eslint": "catalog:",
     "lint-staged": "catalog:",
     "prettier": "catalog:",

--- a/frontend/packages/labs/music/package.json
+++ b/frontend/packages/labs/music/package.json
@@ -4,8 +4,9 @@
   "private": true,
   "exports": {
     ".": {
-      "import": "./dist/App.js",
-      "require": "./dist/App.cjs"
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.cjs",
+      "types": "./dist/index.d.ts"
     }
   },
   "scripts": {

--- a/frontend/packages/labs/music/src/index.ts
+++ b/frontend/packages/labs/music/src/index.ts
@@ -1,0 +1,1 @@
+export {default} from './App';

--- a/frontend/turbo.json
+++ b/frontend/turbo.json
@@ -16,10 +16,18 @@
       "dependsOn": ["build", "lint", "test"]
     },
     "lint": {
-      "dependsOn": ["^lint", "prettier", "stylelint", "typecheck", "//#format"]
+      "dependsOn": [
+        "build",
+        "^lint",
+        "prettier",
+        "stylelint",
+        "typecheck",
+        "//#format"
+      ]
     },
     "lint:fix": {
       "dependsOn": [
+        "build",
         "^lint:fix",
         "prettier:fix",
         "stylelint:fix",

--- a/frontend/turbo/generators/.prettierignore
+++ b/frontend/turbo/generators/.prettierignore
@@ -1,0 +1,1 @@
+templates/

--- a/frontend/turbo/generators/AGENTS.md
+++ b/frontend/turbo/generators/AGENTS.md
@@ -1,0 +1,12 @@
+# turbo/generators/
+
+Turborepo code generators for the `frontend/` monorepo.
+
+## Convention coupling
+
+`config.ts` (and all files in `templates/`) are tightly coupled with
+`docs/conventions/packages.md`. They must always describe the same scaffold
+structure.
+
+**Rule:** When you change a template or `config.ts`, update
+`docs/conventions/packages.md` too, and vice versa.

--- a/frontend/turbo/generators/README.md
+++ b/frontend/turbo/generators/README.md
@@ -1,0 +1,30 @@
+# turbo/generators/
+
+Turborepo code generators for scaffolding new packages and labs in the
+`frontend/` workspace.
+
+## Usage
+
+Run from `frontend/`:
+
+```bash
+yarn turbo gen package   # scaffold a new TypeScript library under packages/<name>/
+yarn turbo gen lab       # scaffold a new React lab under packages/labs/<name>/
+```
+
+Both generators prompt for a package name and description, then create all
+scaffold files. The `lab` generator also registers the lab in Studio
+(`labs.ts`, `getLabEntrypoint.ts`, `apps/studio/package.json`).
+
+After generation, both generators automatically run:
+
+1. `yarn install` — links the new workspace package
+2. `yarn lint:fix` — formats generated files
+3. `yarn release:dryrun` — verifies the scaffold builds, lints, and passes
+   type-checking
+
+## Convention coupling
+
+`config.ts` and `templates/` are tightly coupled with
+`docs/conventions/packages.md`. See `AGENTS.md` in this directory for the
+rule.

--- a/frontend/turbo/generators/config.ts
+++ b/frontend/turbo/generators/config.ts
@@ -1,0 +1,255 @@
+/**
+ * Turborepo code generators for frontend/ packages.
+ *
+ * CONVENTION COUPLING: This file and its templates/ directory are tightly
+ * coupled with docs/conventions/packages.md. When you update a template,
+ * update docs/conventions/packages.md too, and vice versa.
+ * See frontend/AGENTS.md for the enforcement rule.
+ *
+ *   yarn turbo gen package  — new TypeScript library under packages/<name>/
+ *   yarn turbo gen lab      — new React lab under packages/labs/<name>/
+ */
+import {execSync} from 'node:child_process';
+import type {PlopTypes} from '@turbo/gen';
+
+export default function generator(plop: PlopTypes.NodePlopAPI): void {
+  // turbo sets getDestBasePath() to the workspace root (directory with turbo.json)
+  const workspace = plop.getDestBasePath();
+
+  // Post-generation tasks: install new package, format, then verify.
+  const postGenerationActions: PlopTypes.ActionType[] = [
+    () => {
+      execSync('yarn install', {cwd: workspace, stdio: 'inherit'});
+      return 'yarn install complete';
+    },
+    () => {
+      execSync('yarn lint:fix', {cwd: workspace, stdio: 'inherit'});
+      return 'yarn lint:fix complete';
+    },
+    () => {
+      execSync('yarn release:dryrun', {cwd: workspace, stdio: 'inherit'});
+      return 'yarn release:dryrun complete';
+    },
+  ];
+
+  // ─── package generator ───────────────────────────────────────────────────
+  plop.setGenerator('package', {
+    description:
+      'Scaffold a new TypeScript library package under packages/<name>/',
+    prompts: [
+      {
+        type: 'input',
+        name: 'name',
+        message:
+          'Package name (kebab-case, e.g. my-utils — no @code-dot-org/ prefix):',
+        validate: (value: string) => {
+          if (!/^[a-z][a-z0-9-]*$/.test(value))
+            return 'Must be kebab-case (lowercase, hyphens, start with a letter).';
+          if (value.startsWith('@'))
+            return 'Omit the @code-dot-org/ prefix — it is added automatically.';
+          return true;
+        },
+      },
+      {
+        type: 'input',
+        name: 'description',
+        message: 'Short description:',
+        validate: (v: string) =>
+          v.trim().length > 0 || 'Description is required.',
+      },
+    ],
+    actions: [
+      {
+        type: 'add',
+        path: '{{turbo.paths.workspace}}/packages/{{name}}/package.json',
+        templateFile: 'templates/package/package.json.hbs',
+      },
+      {
+        type: 'add',
+        path: '{{turbo.paths.workspace}}/packages/{{name}}/vite.config.ts',
+        templateFile: 'templates/package/vite.config.ts.hbs',
+      },
+      {
+        type: 'add',
+        path: '{{turbo.paths.workspace}}/packages/{{name}}/tsconfig.json',
+        templateFile: 'templates/package/tsconfig.json.hbs',
+      },
+      {
+        type: 'add',
+        path: '{{turbo.paths.workspace}}/packages/{{name}}/eslint.config.mjs',
+        templateFile: 'templates/package/eslint.config.mjs.hbs',
+      },
+      {
+        type: 'add',
+        path: '{{turbo.paths.workspace}}/packages/{{name}}/.lintstagedrc.mjs',
+        templateFile: 'templates/package/.lintstagedrc.mjs.hbs',
+      },
+      {
+        type: 'add',
+        path: '{{turbo.paths.workspace}}/packages/{{name}}/vitest.config.ts',
+        templateFile: 'templates/package/vitest.config.ts.hbs',
+      },
+      {
+        type: 'add',
+        path: '{{turbo.paths.workspace}}/packages/{{name}}/src/index.ts',
+        templateFile: 'templates/package/src/index.ts.hbs',
+      },
+      {
+        type: 'add',
+        path: '{{turbo.paths.workspace}}/packages/{{name}}/src/__tests__/index.test.ts',
+        templateFile: 'templates/package/src/__tests__/index.test.ts.hbs',
+      },
+      {
+        type: 'add',
+        path: '{{turbo.paths.workspace}}/packages/{{name}}/.gitignore',
+        templateFile: 'templates/package/.gitignore.hbs',
+      },
+      {
+        type: 'add',
+        path: '{{turbo.paths.workspace}}/packages/{{name}}/README.md',
+        templateFile: 'templates/package/README.md.hbs',
+      },
+      // Studio integration — studio/package.json: add workspace dep after the
+      // last @code-dot-org workspace:* entry (before non-@code-dot-org deps)
+      {
+        type: 'modify',
+        path: '{{turbo.paths.workspace}}/apps/studio/package.json',
+        pattern:
+          /("@code-dot-org\/[^"]+": "workspace:\*"),(\n\s+")(?!@code-dot-org)/,
+        template: '$1,\n    "@code-dot-org/{{name}}": "workspace:*",$2',
+      },
+      ...postGenerationActions,
+    ],
+  });
+
+  // ─── lab generator ───────────────────────────────────────────────────────
+  plop.setGenerator('lab', {
+    description:
+      'Scaffold a new React lab under packages/labs/<name>/ and register it in Studio',
+    prompts: [
+      {
+        type: 'input',
+        name: 'name',
+        message:
+          'Lab name (kebab-case, e.g. dance — no -lab suffix; it is added automatically):',
+        validate: (value: string) => {
+          if (!/^[a-z][a-z0-9-]*$/.test(value))
+            return 'Must be kebab-case (lowercase, hyphens, start with a letter).';
+          if (value.endsWith('-lab'))
+            return 'Omit the -lab suffix — it is added automatically.';
+          return true;
+        },
+      },
+      {
+        type: 'input',
+        name: 'description',
+        message: 'Short description:',
+        validate: (v: string) =>
+          v.trim().length > 0 || 'Description is required.',
+      },
+    ],
+    actions: [
+      // Lab scaffold files
+      {
+        type: 'add',
+        path: '{{turbo.paths.workspace}}/packages/labs/{{name}}/package.json',
+        templateFile: 'templates/lab/package.json.hbs',
+      },
+      {
+        type: 'add',
+        path: '{{turbo.paths.workspace}}/packages/labs/{{name}}/vite.config.ts',
+        templateFile: 'templates/lab/vite.config.ts.hbs',
+      },
+      {
+        type: 'add',
+        path: '{{turbo.paths.workspace}}/packages/labs/{{name}}/tsconfig.json',
+        templateFile: 'templates/lab/tsconfig.json.hbs',
+      },
+      {
+        type: 'add',
+        path: '{{turbo.paths.workspace}}/packages/labs/{{name}}/tsconfig.app.json',
+        templateFile: 'templates/lab/tsconfig.app.json.hbs',
+      },
+      {
+        type: 'add',
+        path: '{{turbo.paths.workspace}}/packages/labs/{{name}}/tsconfig.node.json',
+        templateFile: 'templates/lab/tsconfig.node.json.hbs',
+      },
+      {
+        type: 'add',
+        path: '{{turbo.paths.workspace}}/packages/labs/{{name}}/eslint.config.mjs',
+        templateFile: 'templates/lab/eslint.config.mjs.hbs',
+      },
+      {
+        type: 'add',
+        path: '{{turbo.paths.workspace}}/packages/labs/{{name}}/.lintstagedrc.mjs',
+        templateFile: 'templates/lab/.lintstagedrc.mjs.hbs',
+      },
+      {
+        type: 'add',
+        path: '{{turbo.paths.workspace}}/packages/labs/{{name}}/src/App.tsx',
+        templateFile: 'templates/lab/src/App.tsx.hbs',
+      },
+      {
+        type: 'add',
+        path: '{{turbo.paths.workspace}}/packages/labs/{{name}}/src/index.ts',
+        templateFile: 'templates/lab/src/index.ts.hbs',
+      },
+      {
+        type: 'add',
+        path: '{{turbo.paths.workspace}}/packages/labs/{{name}}/src/main.tsx',
+        templateFile: 'templates/lab/src/main.tsx.hbs',
+      },
+      {
+        type: 'add',
+        path: '{{turbo.paths.workspace}}/packages/labs/{{name}}/index.html',
+        templateFile: 'templates/lab/index.html.hbs',
+      },
+      {
+        type: 'add',
+        path: '{{turbo.paths.workspace}}/packages/labs/{{name}}/.gitignore',
+        templateFile: 'templates/lab/.gitignore.hbs',
+      },
+      {
+        type: 'add',
+        path: '{{turbo.paths.workspace}}/packages/labs/{{name}}/README.md',
+        templateFile: 'templates/lab/README.md.hbs',
+      },
+      {
+        type: 'add',
+        path: '{{turbo.paths.workspace}}/packages/labs/{{name}}/vitest.config.ts',
+        templateFile: 'templates/lab/vitest.config.ts.hbs',
+      },
+      {
+        type: 'add',
+        path: '{{turbo.paths.workspace}}/packages/labs/{{name}}/src/__tests__/App.test.tsx',
+        templateFile: 'templates/lab/src/__tests__/App.test.tsx.hbs',
+      },
+      // Studio integration — labs.ts: append name to AVAILABLE_LABS array
+      {
+        type: 'modify',
+        path: '{{turbo.paths.workspace}}/apps/studio/src/modules/labs/config/labs.ts',
+        pattern: /(export const AVAILABLE_LABS = \[[^\]]*?)(\] as const;)/,
+        template: "$1, '{{name}}'$2",
+      },
+      // Studio integration — getLabEntrypoint.ts: append lazy import entry
+      {
+        type: 'modify',
+        path: '{{turbo.paths.workspace}}/apps/studio/src/modules/labs/router/getLabEntrypoint.ts',
+        pattern: /(const LabEntrypoints: LabEntrypointMap = \{[\s\S]*?)(\};)/,
+        template:
+          "$1  ['{{name}}']: lazy(() => import('@code-dot-org/{{name}}-lab')),\n$2",
+      },
+      // Studio integration — studio/package.json: add workspace dep after the
+      // last @code-dot-org workspace:* entry (before non-@code-dot-org deps)
+      {
+        type: 'modify',
+        path: '{{turbo.paths.workspace}}/apps/studio/package.json',
+        pattern:
+          /("@code-dot-org\/[^"]+": "workspace:\*"),(\n\s+")(?!@code-dot-org)/,
+        template: '$1,\n    "@code-dot-org/{{name}}-lab": "workspace:*",$2',
+      },
+      ...postGenerationActions,
+    ],
+  });
+}

--- a/frontend/turbo/generators/templates/lab/.gitignore.hbs
+++ b/frontend/turbo/generators/templates/lab/.gitignore.hbs
@@ -1,0 +1,24 @@
+# Logs
+logs
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+lerna-debug.log*
+
+node_modules
+dist
+dist-ssr
+*.local
+
+# Editor directories and files
+.vscode/*
+!.vscode/extensions.json
+.idea
+.DS_Store
+*.suo
+*.ntvs*
+*.njsproj
+*.sln
+*.sw?

--- a/frontend/turbo/generators/templates/lab/.lintstagedrc.mjs.hbs
+++ b/frontend/turbo/generators/templates/lab/.lintstagedrc.mjs.hbs
@@ -1,0 +1,6 @@
+import baseConfig from '@code-dot-org/lint-config/lint-staged/lintstagedrc.mjs';
+
+/**
+ * @type {import('lint-staged').Configuration}
+ */
+export default baseConfig;

--- a/frontend/turbo/generators/templates/lab/README.md.hbs
+++ b/frontend/turbo/generators/templates/lab/README.md.hbs
@@ -1,0 +1,3 @@
+# @code-dot-org/{{name}}-lab
+
+{{description}}

--- a/frontend/turbo/generators/templates/lab/eslint.config.mjs.hbs
+++ b/frontend/turbo/generators/templates/lab/eslint.config.mjs.hbs
@@ -1,0 +1,4 @@
+import cdoReactConfig from '@code-dot-org/lint-config/eslint/react.mjs';
+import {globalIgnores} from 'eslint/config';
+
+export default [globalIgnores(['dist']), ...cdoReactConfig];

--- a/frontend/turbo/generators/templates/lab/index.html.hbs
+++ b/frontend/turbo/generators/templates/lab/index.html.hbs
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>{{name}}</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/frontend/turbo/generators/templates/lab/package.json.hbs
+++ b/frontend/turbo/generators/templates/lab/package.json.hbs
@@ -1,0 +1,58 @@
+{
+  "name": "@code-dot-org/{{name}}-lab",
+  "version": "0.0.0",
+  "private": true,
+  "description": "{{description}}",
+  "homepage": "https://github.com/code-dot-org/code-dot-org/blob/staging/frontend/packages/labs/{{name}}/#readme",
+  "bugs": {"url": "https://github.com/code-dot-org/code-dot-org/issues"},
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/code-dot-org/code-dot-org.git",
+    "directory": "frontend/packages/labs/{{name}}"
+  },
+  "license": "SEE LICENSE IN LICENSE",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.cjs"
+    }
+  },
+  "scripts": {
+    "build": "vite build && tsc --noEmit",
+    "dev": "vite",
+    "lint": "eslint .",
+    "lint:fix": "eslint --fix .",
+    "prettier": "prettier --check .",
+    "prettier:fix": "prettier --write .",
+    "preview": "vite preview",
+    "test": "vitest --run",
+    "typecheck": "tsc --noEmit"
+  },
+  "prettier": "@code-dot-org/lint-config/prettier/index.mjs",
+  "dependencies": {
+    "@code-dot-org/core": "workspace:*"
+  },
+  "devDependencies": {
+    "@code-dot-org/lint-config": "workspace:*",
+    "@testing-library/react": "catalog:",
+    "@types/node": "catalog:",
+    "@types/react": "^19.2.5",
+    "@types/react-dom": "^19.2.3",
+    "@vitejs/plugin-react": "catalog:",
+    "eslint": "catalog:",
+    "jsdom": "^26.0.0",
+    "prettier": "catalog:",
+    "react": "^19.2.0",
+    "react-dom": "^19.2.0",
+    "typescript": "catalog:",
+    "vite": "catalog:",
+    "vite-plugin-dts": "catalog:",
+    "vite-plugin-externalize-deps": "catalog:",
+    "vitest": "^4.0.17"
+  },
+  "peerDependencies": {
+    "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+    "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
+  }
+}

--- a/frontend/turbo/generators/templates/lab/src/App.tsx.hbs
+++ b/frontend/turbo/generators/templates/lab/src/App.tsx.hbs
@@ -1,0 +1,9 @@
+function App() {
+  return (
+    <div>
+      <h1>{{pascalCase name}} Lab</h1>
+    </div>
+  );
+}
+
+export default App;

--- a/frontend/turbo/generators/templates/lab/src/__tests__/App.test.tsx.hbs
+++ b/frontend/turbo/generators/templates/lab/src/__tests__/App.test.tsx.hbs
@@ -1,0 +1,7 @@
+import {render} from '@testing-library/react';
+import App from '../App';
+
+it('renders without crashing', () => {
+  const {container} = render(<App />);
+  expect(container).toBeTruthy();
+});

--- a/frontend/turbo/generators/templates/lab/src/index.ts.hbs
+++ b/frontend/turbo/generators/templates/lab/src/index.ts.hbs
@@ -1,0 +1,1 @@
+export { default } from './App';

--- a/frontend/turbo/generators/templates/lab/src/main.tsx.hbs
+++ b/frontend/turbo/generators/templates/lab/src/main.tsx.hbs
@@ -1,0 +1,13 @@
+import {StrictMode} from 'react';
+import {createRoot} from 'react-dom/client';
+import {initializeCodeStudioConfig} from '@code-dot-org/core';
+
+import App from './App.tsx';
+
+initializeCodeStudioConfig();
+
+createRoot(document.getElementById('root')!).render(
+  <StrictMode>
+    <App />
+  </StrictMode>,
+);

--- a/frontend/turbo/generators/templates/lab/tsconfig.app.json.hbs
+++ b/frontend/turbo/generators/templates/lab/tsconfig.app.json.hbs
@@ -1,0 +1,7 @@
+{
+  "extends": "@code-dot-org/lint-config/typescript/tsconfig.vite.app.json",
+  "compilerOptions": {
+    "baseUrl": "."
+  },
+  "include": ["src"]
+}

--- a/frontend/turbo/generators/templates/lab/tsconfig.json.hbs
+++ b/frontend/turbo/generators/templates/lab/tsconfig.json.hbs
@@ -1,0 +1,7 @@
+{
+  "files": [],
+  "references": [
+    {"path": "./tsconfig.app.json"},
+    {"path": "./tsconfig.node.json"}
+  ]
+}

--- a/frontend/turbo/generators/templates/lab/tsconfig.node.json.hbs
+++ b/frontend/turbo/generators/templates/lab/tsconfig.node.json.hbs
@@ -1,0 +1,7 @@
+{
+  "extends": "@code-dot-org/lint-config/typescript/tsconfig.vite.node.json",
+  "compilerOptions": {
+    "baseUrl": "."
+  },
+  "include": ["vite.config.ts"]
+}

--- a/frontend/turbo/generators/templates/lab/vite.config.ts.hbs
+++ b/frontend/turbo/generators/templates/lab/vite.config.ts.hbs
@@ -1,18 +1,13 @@
-import {defineConfig} from 'vite';
 import react from '@vitejs/plugin-react';
-import {externalizeDeps} from 'vite-plugin-externalize-deps';
+import {defineConfig} from 'vite';
 import dts from 'vite-plugin-dts';
+import {externalizeDeps} from 'vite-plugin-externalize-deps';
 
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [
-    // Enable React support
     react(),
-    // Generate Typescript declaration files using the Vite default tsconfig
     dts({tsconfigPath: './tsconfig.app.json'}),
-    // Ensure dependencies are externalized for library build
-    // Libraries such as react, react-dom, lodash, etc. should not be bundled by the library.
-    // Instead, they are expected to be provided by the host application.
     externalizeDeps(),
   ],
   server: {
@@ -21,9 +16,11 @@ export default defineConfig({
   build: {
     lib: {
       entry: ['src/index.ts'],
-      name: 'music-lab',
+      name: '{{name}}-lab',
       formats: ['es', 'cjs'],
     },
+    // NOTE: We output .mjs for ESM because package.json type is not 'module'.
+    // This is required for compatibility with usage in `apps`, which expects .mjs for ESM imports.
     rollupOptions: {
       output: [
         {

--- a/frontend/turbo/generators/templates/lab/vitest.config.ts.hbs
+++ b/frontend/turbo/generators/templates/lab/vitest.config.ts.hbs
@@ -1,0 +1,10 @@
+import react from '@vitejs/plugin-react';
+import {defineConfig} from 'vitest/config';
+
+export default defineConfig({
+  plugins: [react()],
+  test: {
+    globals: true,
+    environment: 'jsdom',
+  },
+});

--- a/frontend/turbo/generators/templates/package/.gitignore.hbs
+++ b/frontend/turbo/generators/templates/package/.gitignore.hbs
@@ -1,0 +1,24 @@
+# Logs
+logs
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+lerna-debug.log*
+
+node_modules
+dist
+dist-ssr
+*.local
+
+# Editor directories and files
+.vscode/*
+!.vscode/extensions.json
+.idea
+.DS_Store
+*.suo
+*.ntvs*
+*.njsproj
+*.sln
+*.sw?

--- a/frontend/turbo/generators/templates/package/.lintstagedrc.mjs.hbs
+++ b/frontend/turbo/generators/templates/package/.lintstagedrc.mjs.hbs
@@ -1,0 +1,6 @@
+import baseConfig from '@code-dot-org/lint-config/lint-staged/lintstagedrc.mjs';
+
+/**
+ * @type {import('lint-staged').Configuration}
+ */
+export default baseConfig;

--- a/frontend/turbo/generators/templates/package/README.md.hbs
+++ b/frontend/turbo/generators/templates/package/README.md.hbs
@@ -1,0 +1,3 @@
+# @code-dot-org/{{name}}
+
+{{description}}

--- a/frontend/turbo/generators/templates/package/eslint.config.mjs.hbs
+++ b/frontend/turbo/generators/templates/package/eslint.config.mjs.hbs
@@ -1,0 +1,4 @@
+import cdoReactConfig from '@code-dot-org/lint-config/eslint/react.mjs';
+import {globalIgnores} from 'eslint/config';
+
+export default [globalIgnores(['dist']), ...cdoReactConfig];

--- a/frontend/turbo/generators/templates/package/package.json.hbs
+++ b/frontend/turbo/generators/templates/package/package.json.hbs
@@ -1,0 +1,47 @@
+{
+  "name": "@code-dot-org/{{name}}",
+  "version": "0.0.0",
+  "private": true,
+  "description": "{{description}}",
+  "homepage": "https://github.com/code-dot-org/code-dot-org/blob/staging/frontend/packages/{{name}}/#readme",
+  "bugs": {"url": "https://github.com/code-dot-org/code-dot-org/issues"},
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/code-dot-org/code-dot-org.git",
+    "directory": "frontend/packages/{{name}}"
+  },
+  "license": "SEE LICENSE IN LICENSE",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.cjs"
+    }
+  },
+  "scripts": {
+    "build": "vite build && tsc --noEmit",
+    "dev": "vite",
+    "lint": "eslint .",
+    "lint:fix": "eslint --fix .",
+    "prettier": "prettier --check .",
+    "prettier:fix": "prettier --write .",
+    "test": "vitest --run",
+    "typecheck": "tsc --noEmit"
+  },
+  "prettier": "@code-dot-org/lint-config/prettier/index.mjs",
+  "devDependencies": {
+    "@code-dot-org/lint-config": "workspace:*",
+    "@types/node": "catalog:",
+    "eslint": "catalog:",
+    "prettier": "catalog:",
+    "react": "^19.2.0",
+    "typescript": "catalog:",
+    "vite": "catalog:",
+    "vite-plugin-dts": "catalog:",
+    "vite-plugin-externalize-deps": "catalog:",
+    "vitest": "^4.0.17"
+  },
+  "peerDependencies": {
+    "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
+  }
+}

--- a/frontend/turbo/generators/templates/package/src/__tests__/index.test.ts.hbs
+++ b/frontend/turbo/generators/templates/package/src/__tests__/index.test.ts.hbs
@@ -1,0 +1,5 @@
+import * as api from '../index';
+
+it('exports a public API', () => {
+  expect(api).toBeDefined();
+});

--- a/frontend/turbo/generators/templates/package/src/index.ts.hbs
+++ b/frontend/turbo/generators/templates/package/src/index.ts.hbs
@@ -1,0 +1,2 @@
+// Public API for @code-dot-org/{{name}}
+// Export all public symbols from this file.

--- a/frontend/turbo/generators/templates/package/tsconfig.json.hbs
+++ b/frontend/turbo/generators/templates/package/tsconfig.json.hbs
@@ -1,0 +1,7 @@
+{
+  "extends": "@code-dot-org/lint-config/typescript/tsconfig.vite.app.json",
+  "compilerOptions": {
+    "baseUrl": "."
+  },
+  "include": ["src"]
+}

--- a/frontend/turbo/generators/templates/package/vite.config.ts.hbs
+++ b/frontend/turbo/generators/templates/package/vite.config.ts.hbs
@@ -1,0 +1,43 @@
+import path from 'node:path';
+import type {OutputOptions} from 'rollup';
+import {defineConfig} from 'vite';
+import dts from 'vite-plugin-dts';
+import {externalizeDeps} from 'vite-plugin-externalize-deps';
+
+function getRollupOutputConfig(format: 'es' | 'cjs'): OutputOptions {
+  return {
+    format,
+    exports: 'auto',
+    entryFileNames: format === 'es' ? '[name].mjs' : '[name].cjs',
+    preserveModules: true,
+    preserveModulesRoot: 'src',
+  };
+}
+
+// https://vite.dev/config/
+export default defineConfig({
+  plugins: [
+    dts({
+      tsconfigPath: './tsconfig.json',
+      rollupTypes: false,
+      entryRoot: 'src',
+      insertTypesEntry: false,
+      exclude: ['**/__tests__/**', '**/*.test.tsx'],
+    }),
+    externalizeDeps(),
+  ],
+  resolve: {
+    alias: {'@': path.resolve(__dirname, './src')},
+  },
+  build: {
+    sourcemap: true,
+    cssCodeSplit: true,
+    lib: {
+      entry: ['src/index.ts'],
+      name: '{{name}}',
+    },
+    rollupOptions: {
+      output: [getRollupOutputConfig('es'), getRollupOutputConfig('cjs')],
+    },
+  },
+});

--- a/frontend/turbo/generators/templates/package/vitest.config.ts.hbs
+++ b/frontend/turbo/generators/templates/package/vitest.config.ts.hbs
@@ -1,0 +1,7 @@
+import {defineConfig} from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    globals: true,
+  },
+});

--- a/frontend/turbo/generators/tsconfig.json
+++ b/frontend/turbo/generators/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "types": ["node"]
+  },
+  "include": ["config.ts"]
+}

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -1442,6 +1442,8 @@ __metadata:
   dependencies:
     "@axe-core/playwright": "npm:^4.10.1"
     "@eslint/js": "catalog:"
+    "@turbo/gen": "npm:^2.6.3"
+    "@types/node": "catalog:"
     eslint: "catalog:"
     lint-staged: "catalog:"
     prettier: "catalog:"
@@ -2896,6 +2898,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@inquirer/ansi@npm:^1.0.2":
+  version: 1.0.2
+  resolution: "@inquirer/ansi@npm:1.0.2"
+  checksum: 10c0/8e408cc628923aa93402e66657482ccaa2ad5174f9db526d9a8b443f9011e9cd8f70f0f534f5fe3857b8a9df3bce1e25f66c96f666d6750490bd46e2b4f3b829
+  languageName: node
+  linkType: hard
+
 "@inquirer/checkbox@npm:^4.0.1":
   version: 4.1.2
   resolution: "@inquirer/checkbox@npm:4.1.2"
@@ -2932,6 +2941,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@inquirer/checkbox@npm:^4.3.2":
+  version: 4.3.2
+  resolution: "@inquirer/checkbox@npm:4.3.2"
+  dependencies:
+    "@inquirer/ansi": "npm:^1.0.2"
+    "@inquirer/core": "npm:^10.3.2"
+    "@inquirer/figures": "npm:^1.0.15"
+    "@inquirer/type": "npm:^3.0.10"
+    yoctocolors-cjs: "npm:^2.1.3"
+  peerDependencies:
+    "@types/node": ">=18"
+  peerDependenciesMeta:
+    "@types/node":
+      optional: true
+  checksum: 10c0/771d23bc6b16cd5c21a4f1073e98e306147f90c0e2487fe887ee054b8bf86449f1f9e6e6f9c218c1aa45ae3be2533197d53654abe9c0545981aebb0920d5f471
+  languageName: node
+  linkType: hard
+
 "@inquirer/confirm@npm:^5.0.1":
   version: 5.1.6
   resolution: "@inquirer/confirm@npm:5.1.6"
@@ -2944,6 +2971,21 @@ __metadata:
     "@types/node":
       optional: true
   checksum: 10c0/57b667f8096ec261504b613656e7b7718a238a73e059870a2b8e97c3127bc50085251100ed371250733b7cc5cd68122d8694d6a04a46de95d08bb590a8437b11
+  languageName: node
+  linkType: hard
+
+"@inquirer/confirm@npm:^5.1.21":
+  version: 5.1.21
+  resolution: "@inquirer/confirm@npm:5.1.21"
+  dependencies:
+    "@inquirer/core": "npm:^10.3.2"
+    "@inquirer/type": "npm:^3.0.10"
+  peerDependencies:
+    "@types/node": ">=18"
+  peerDependenciesMeta:
+    "@types/node":
+      optional: true
+  checksum: 10c0/a95bbdbb17626c484735a4193ed6b6a6fbb078cf62116ec8e1667f647e534dd6618e688ecc7962585efcc56881b544b8c53db3914599bbf2ab842e7f224b0fca
   languageName: node
   linkType: hard
 
@@ -3004,6 +3046,27 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@inquirer/core@npm:^10.3.2":
+  version: 10.3.2
+  resolution: "@inquirer/core@npm:10.3.2"
+  dependencies:
+    "@inquirer/ansi": "npm:^1.0.2"
+    "@inquirer/figures": "npm:^1.0.15"
+    "@inquirer/type": "npm:^3.0.10"
+    cli-width: "npm:^4.1.0"
+    mute-stream: "npm:^2.0.0"
+    signal-exit: "npm:^4.1.0"
+    wrap-ansi: "npm:^6.2.0"
+    yoctocolors-cjs: "npm:^2.1.3"
+  peerDependencies:
+    "@types/node": ">=18"
+  peerDependenciesMeta:
+    "@types/node":
+      optional: true
+  checksum: 10c0/f0f27e07fe288e01e3949b4ad216c19751f025ce77c610366e08d8b0f7a135d064dc074732031d251584b454c576f1e5c849e4abe259186dd5d4974c8f85c13e
+  languageName: node
+  linkType: hard
+
 "@inquirer/editor@npm:^4.0.1":
   version: 4.2.7
   resolution: "@inquirer/editor@npm:4.2.7"
@@ -3017,6 +3080,22 @@ __metadata:
     "@types/node":
       optional: true
   checksum: 10c0/8570bd5992dab031b7eea498941a728fbbada04072ce64192c46987a6d6e91669f9dd846049b5c49e87de01efd292fb2137606aafd7eee33e047864b2989d87f
+  languageName: node
+  linkType: hard
+
+"@inquirer/editor@npm:^4.2.23":
+  version: 4.2.23
+  resolution: "@inquirer/editor@npm:4.2.23"
+  dependencies:
+    "@inquirer/core": "npm:^10.3.2"
+    "@inquirer/external-editor": "npm:^1.0.3"
+    "@inquirer/type": "npm:^3.0.10"
+  peerDependencies:
+    "@types/node": ">=18"
+  peerDependenciesMeta:
+    "@types/node":
+      optional: true
+  checksum: 10c0/aa02028ee35ae039a4857b6a9490d295a1b3558f042e7454dee0aa36fbc83ac25586a2dfe0b46a5ea7ea151e3f5cb97a8ee6229131b4619f3b3466ad74b9519f
   languageName: node
   linkType: hard
 
@@ -3052,6 +3131,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@inquirer/expand@npm:^4.0.23":
+  version: 4.0.23
+  resolution: "@inquirer/expand@npm:4.0.23"
+  dependencies:
+    "@inquirer/core": "npm:^10.3.2"
+    "@inquirer/type": "npm:^3.0.10"
+    yoctocolors-cjs: "npm:^2.1.3"
+  peerDependencies:
+    "@types/node": ">=18"
+  peerDependenciesMeta:
+    "@types/node":
+      optional: true
+  checksum: 10c0/294c92652760c3d1a46c4b900a99fd553ea9e5734ba261d4e71d7b8499d86a8b15e38a2467ddb7c95c197daf7e472bdab209fc3f7c38cbc70842cd291f4ce39d
+  languageName: node
+  linkType: hard
+
 "@inquirer/expand@npm:^4.0.8":
   version: 4.0.8
   resolution: "@inquirer/expand@npm:4.0.8"
@@ -3068,10 +3163,32 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@inquirer/external-editor@npm:^1.0.3":
+  version: 1.0.3
+  resolution: "@inquirer/external-editor@npm:1.0.3"
+  dependencies:
+    chardet: "npm:^2.1.1"
+    iconv-lite: "npm:^0.7.0"
+  peerDependencies:
+    "@types/node": ">=18"
+  peerDependenciesMeta:
+    "@types/node":
+      optional: true
+  checksum: 10c0/82951cb7f3762dd78cca2ea291396841e3f4adfe26004b5badfed1cec4b6a04bb567dff94d0e41b35c61bdd7957317c64c22f58074d14b238d44e44d9e420019
+  languageName: node
+  linkType: hard
+
 "@inquirer/figures@npm:^1.0.10":
   version: 1.0.10
   resolution: "@inquirer/figures@npm:1.0.10"
   checksum: 10c0/013b0eef03706d5ff8847c1ab1a12643edfb3d1902a5353bfe626999bc3b46653f8317d011a9dd4e831d3f2bfef3da84104a1fda4db0de0f4938122f5c70362e
+  languageName: node
+  linkType: hard
+
+"@inquirer/figures@npm:^1.0.15":
+  version: 1.0.15
+  resolution: "@inquirer/figures@npm:1.0.15"
+  checksum: 10c0/6e39a040d260ae234ae220180b7994ff852673e20be925f8aa95e78c7934d732b018cbb4d0ec39e600a410461bcb93dca771e7de23caa10630d255692e440f69
   languageName: node
   linkType: hard
 
@@ -3105,6 +3222,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@inquirer/input@npm:^4.3.1":
+  version: 4.3.1
+  resolution: "@inquirer/input@npm:4.3.1"
+  dependencies:
+    "@inquirer/core": "npm:^10.3.2"
+    "@inquirer/type": "npm:^3.0.10"
+  peerDependencies:
+    "@types/node": ">=18"
+  peerDependenciesMeta:
+    "@types/node":
+      optional: true
+  checksum: 10c0/9e81d6ae56e5b59f96475ae1327e7e7beeef0d917b83762e0c2ed5a75239ad6b1a39fc05553ce45fe6f6de49681dade8704b5f1c11c2f555663a74d0ac998af3
+  languageName: node
+  linkType: hard
+
 "@inquirer/number@npm:^3.0.1":
   version: 3.0.9
   resolution: "@inquirer/number@npm:3.0.9"
@@ -3117,6 +3249,21 @@ __metadata:
     "@types/node":
       optional: true
   checksum: 10c0/5569d570fa539263324d3651f8fc3fe451e4a5d8d7799b8576abb3246eefbabc15a48ff4f2ef3353238aa42c01815cd761b5a148a236943b73e03e969a4a7ac7
+  languageName: node
+  linkType: hard
+
+"@inquirer/number@npm:^3.0.23":
+  version: 3.0.23
+  resolution: "@inquirer/number@npm:3.0.23"
+  dependencies:
+    "@inquirer/core": "npm:^10.3.2"
+    "@inquirer/type": "npm:^3.0.10"
+  peerDependencies:
+    "@types/node": ">=18"
+  peerDependenciesMeta:
+    "@types/node":
+      optional: true
+  checksum: 10c0/3944a524be2a2e0834822a0e483f2e2fd56ad597b5feeca2155b956821f88e22e07ce3816f66113b040601636ed7146865aee7d7afb2a06939acc77491330ccc
   languageName: node
   linkType: hard
 
@@ -3148,6 +3295,22 @@ __metadata:
     "@types/node":
       optional: true
   checksum: 10c0/7e2a7bc48715d933f8826112a41237905ce3ce7839b286a7d68079cda351db17c6e868727902061588f5baa75dd203e66ba1f265646bfe440da572d17d5c21eb
+  languageName: node
+  linkType: hard
+
+"@inquirer/password@npm:^4.0.23":
+  version: 4.0.23
+  resolution: "@inquirer/password@npm:4.0.23"
+  dependencies:
+    "@inquirer/ansi": "npm:^1.0.2"
+    "@inquirer/core": "npm:^10.3.2"
+    "@inquirer/type": "npm:^3.0.10"
+  peerDependencies:
+    "@types/node": ">=18"
+  peerDependenciesMeta:
+    "@types/node":
+      optional: true
+  checksum: 10c0/9fd3d0462d02735bb1521c4e221d057a94d9aaac308e9a192e59d6c1e8efc707c2376ab627151d589bc3633f6b14b74b60b91c3d473a32adfd100ef1f6cfdef7
   languageName: node
   linkType: hard
 
@@ -3184,6 +3347,29 @@ __metadata:
   peerDependencies:
     "@types/node": ">=18"
   checksum: 10c0/bf72a25de8c53267de740cf4bb9639b95e5c9da3890ca59303bfba0adab11276d8ae53dc831f456acd31d257c959db2b05ed26c2a90cde7eab04737d158d6e94
+  languageName: node
+  linkType: hard
+
+"@inquirer/prompts@npm:^7.10.1":
+  version: 7.10.1
+  resolution: "@inquirer/prompts@npm:7.10.1"
+  dependencies:
+    "@inquirer/checkbox": "npm:^4.3.2"
+    "@inquirer/confirm": "npm:^5.1.21"
+    "@inquirer/editor": "npm:^4.2.23"
+    "@inquirer/expand": "npm:^4.0.23"
+    "@inquirer/input": "npm:^4.3.1"
+    "@inquirer/number": "npm:^3.0.23"
+    "@inquirer/password": "npm:^4.0.23"
+    "@inquirer/rawlist": "npm:^4.1.11"
+    "@inquirer/search": "npm:^3.2.2"
+    "@inquirer/select": "npm:^4.4.2"
+  peerDependencies:
+    "@types/node": ">=18"
+  peerDependenciesMeta:
+    "@types/node":
+      optional: true
+  checksum: 10c0/eac309cc75712bc94fc8b6761d6a736786ca1942cf9c90805b2a6049a05ce6131bcfb3aa703d1dbe66874d1b78c2b446044ad9735a2bb76743b8ddcb3dcb4d2a
   languageName: node
   linkType: hard
 
@@ -3242,6 +3428,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@inquirer/rawlist@npm:^4.1.11":
+  version: 4.1.11
+  resolution: "@inquirer/rawlist@npm:4.1.11"
+  dependencies:
+    "@inquirer/core": "npm:^10.3.2"
+    "@inquirer/type": "npm:^3.0.10"
+    yoctocolors-cjs: "npm:^2.1.3"
+  peerDependencies:
+    "@types/node": ">=18"
+  peerDependenciesMeta:
+    "@types/node":
+      optional: true
+  checksum: 10c0/33792b40cd0fbf77f547c9c4805087dd1188342c6a5ca512c73b0b6c4d132225fc5ae8bc4fd5035309484da3698a90fcef17aad100b9ae57624fda7b07d92227
+  languageName: node
+  linkType: hard
+
 "@inquirer/search@npm:^3.0.1":
   version: 3.0.9
   resolution: "@inquirer/search@npm:3.0.9"
@@ -3273,6 +3475,23 @@ __metadata:
     "@types/node":
       optional: true
   checksum: 10c0/408b68a8986f343e4d4e2e804b64525a23c0222c16ce523f5a93e4c6acb7c118c022315accd5fa40b3f3b2e8973974414b087ed20bc02cf5e96b3334f981af62
+  languageName: node
+  linkType: hard
+
+"@inquirer/search@npm:^3.2.2":
+  version: 3.2.2
+  resolution: "@inquirer/search@npm:3.2.2"
+  dependencies:
+    "@inquirer/core": "npm:^10.3.2"
+    "@inquirer/figures": "npm:^1.0.15"
+    "@inquirer/type": "npm:^3.0.10"
+    yoctocolors-cjs: "npm:^2.1.3"
+  peerDependencies:
+    "@types/node": ">=18"
+  peerDependenciesMeta:
+    "@types/node":
+      optional: true
+  checksum: 10c0/e7849663a51fe95e3ce99d274c815b8dc8933d6a5ddcaaf6130bf43f5f10316062c9f7a37c2923a14b8dcd09d202b0bb9cc3eaf0adb0336f6a704ea52e03ef8c
   languageName: node
   linkType: hard
 
@@ -3309,6 +3528,36 @@ __metadata:
     "@types/node":
       optional: true
   checksum: 10c0/da45822570ead39470df7b5d6d802ca73bb7b4bc766f42d5b77fe6c8f5a1225cf853ceb85e0a7ad491dded362b766fd80fd45623d7e1b512a0bec0e17fe3b246
+  languageName: node
+  linkType: hard
+
+"@inquirer/select@npm:^4.4.2":
+  version: 4.4.2
+  resolution: "@inquirer/select@npm:4.4.2"
+  dependencies:
+    "@inquirer/ansi": "npm:^1.0.2"
+    "@inquirer/core": "npm:^10.3.2"
+    "@inquirer/figures": "npm:^1.0.15"
+    "@inquirer/type": "npm:^3.0.10"
+    yoctocolors-cjs: "npm:^2.1.3"
+  peerDependencies:
+    "@types/node": ">=18"
+  peerDependenciesMeta:
+    "@types/node":
+      optional: true
+  checksum: 10c0/6978a5a92928b4d439dd6b688f2db51fd49be209f24be224bb81ed8f75b76e0715e79bdb05dab2a33bbdc7091c779a99f8603fe0ca199f059528ca2b1d0d4944
+  languageName: node
+  linkType: hard
+
+"@inquirer/type@npm:^3.0.10":
+  version: 3.0.10
+  resolution: "@inquirer/type@npm:3.0.10"
+  peerDependencies:
+    "@types/node": ">=18"
+  peerDependenciesMeta:
+    "@types/node":
+      optional: true
+  checksum: 10c0/a846c7a570e3bf2657d489bcc5dcdc3179d24c7323719de1951dcdb722400ac76e5b2bfe9765d0a789bc1921fac810983d7999f021f30a78a6a174c23fc78dc9
   languageName: node
   linkType: hard
 
@@ -6008,6 +6257,18 @@ __metadata:
   version: 7.0.2
   resolution: "@tsconfig/vite-react@npm:7.0.2"
   checksum: 10c0/cc63685e4f7b70a2ca34becb81939dad3f852f5640b6072aeeb2671b41f8bd1d80746ac7438c166090d6f22ca41db89282238e09a8877b8ac495c9fb0fa58257
+  languageName: node
+  linkType: hard
+
+"@turbo/gen@npm:^2.6.3":
+  version: 2.9.1
+  resolution: "@turbo/gen@npm:2.9.1"
+  dependencies:
+    "@inquirer/prompts": "npm:^7.10.1"
+    esbuild: "npm:^0.25.0"
+  bin:
+    gen: dist/cli.js
+  checksum: 10c0/61191574761986d7bf220eff72077c316ae0634b1d087e9e39d6bb35ba80bcd19831d7df2d91b7477ce82917e2aa1ff793d70a170fce34cb89777e8085dc764f
   languageName: node
   linkType: hard
 
@@ -8814,6 +9075,13 @@ __metadata:
   version: 0.7.0
   resolution: "chardet@npm:0.7.0"
   checksum: 10c0/96e4731b9ec8050cbb56ab684e8c48d6c33f7826b755802d14e3ebfdc51c57afeece3ea39bc6b09acc359e4363525388b915e16640c1378053820f5e70d0f27d
+  languageName: node
+  linkType: hard
+
+"chardet@npm:^2.1.1":
+  version: 2.1.1
+  resolution: "chardet@npm:2.1.1"
+  checksum: 10c0/d8391dd412338442b3de0d3a488aa9327f8bcf74b62b8723d6bd0b85c4084d50b731320e0a7c710edb1d44de75969995d2784b80e4c13b004a6c7a0db4c6e793
   languageName: node
   linkType: hard
 
@@ -12804,6 +13072,15 @@ __metadata:
   dependencies:
     safer-buffer: "npm:>= 2.1.2 < 3"
   checksum: 10c0/c6886a24cc00f2a059767440ec1bc00d334a89f250db8e0f7feb4961c8727118457e27c495ba94d082e51d3baca378726cd110aaf7ded8b9bbfd6a44760cf1d4
+  languageName: node
+  linkType: hard
+
+"iconv-lite@npm:^0.7.0":
+  version: 0.7.2
+  resolution: "iconv-lite@npm:0.7.2"
+  dependencies:
+    safer-buffer: "npm:>= 2.1.2 < 3.0.0"
+  checksum: 10c0/3c228920f3bd307f56bf8363706a776f4a060eb042f131cd23855ceca962951b264d0997ab38a1ad340e1c5df8499ed26e1f4f0db6b2a2ad9befaff22f14b722
   languageName: node
   linkType: hard
 
@@ -21631,6 +21908,13 @@ __metadata:
   version: 2.1.2
   resolution: "yoctocolors-cjs@npm:2.1.2"
   checksum: 10c0/a0e36eb88fea2c7981eab22d1ba45e15d8d268626e6c4143305e2c1628fa17ebfaa40cd306161a8ce04c0a60ee0262058eab12567493d5eb1409780853454c6f
+  languageName: node
+  linkType: hard
+
+"yoctocolors-cjs@npm:^2.1.3":
+  version: 2.1.3
+  resolution: "yoctocolors-cjs@npm:2.1.3"
+  checksum: 10c0/584168ef98eb5d913473a4858dce128803c4a6cd87c0f09e954fa01126a59a33ab9e513b633ad9ab953786ed16efdd8c8700097a51635aafaeed3fef7712fa79
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This PR adds the ability to generate new non-lab packages (such as libraries) and new labs using established conventions in the frontend directory. This helps to enable the frontend be able to more rapidly build out modules and use them in both `apps` and `studio`.

<!--
  Summary of the change: background, motivation, and context.
  Include screenshots, videos, or before/after comparisons for UI changes.
-->



## Links
<!-- Jira tickets, design docs, Slack threads, related PRs, etc. -->

- Jira:

## Testing story
<!-- How was this tested? Manual steps, adhoc links, automated tests, or why testing isn't needed. -->



## Deployment notes
<!-- Delete this section if it's a standard merge-and-deploy.
     Otherwise: migrations, feature flags, coordination, caching impacts, etc. -->



## Privacy and security
<!-- Delete this section if there is no privacy/security impact.
     Otherwise: new PII, auth changes, API surface changes, etc. -->

