### PR TITLE
Web Lab 2 accept-reject: Open in full preview mode when preview icon clicked

### DIFF
--- a/apps/src/aiComponentLibrary/aiTutorVersionFileChip/AiTutorVersionFileChip.tsx
+++ b/apps/src/aiComponentLibrary/aiTutorVersionFileChip/AiTutorVersionFileChip.tsx
@@ -10,7 +10,11 @@ import {sendLab2AnalyticsEvent} from '@cdo/apps/lab2/utils';
 import {getFileExtension} from '@cdo/apps/lab2/utils/multiFileSourceUtils';
 import {EVENTS} from '@cdo/apps/metrics/AnalyticsConstants';
 import {useAppDispatch, useAppSelector} from '@cdo/apps/util/reduxHooks';
-import {setAiFilePathToPreview} from '@cdo/apps/weblab2/weblab2Redux';
+import {ViewMode} from '@cdo/apps/weblab2/types';
+import {
+  setAiFilePathToPreview,
+  setViewMode,
+} from '@cdo/apps/weblab2/weblab2Redux';
 
 import moduleStyles from './ai-tutor-version-file-chip.module.scss';
 
@@ -49,6 +53,7 @@ const AiTutorVersionFileChip: React.FC<AiTutorVersionFileChipProps> = ({
     const filePath =
       folderPath === '' ? file.name : folderPath + '/' + file.name;
     dispatch(setAiFilePathToPreview({path: filePath, timestamp: Date.now()}));
+    dispatch(setViewMode(ViewMode.PREVIEW));
     sendLab2AnalyticsEvent(
       EVENTS.AI_TUTOR_VERSION_FILE_PREVIEW_BUTTON_CLICKED,
       {


### PR DESCRIPTION
<!--
  Summary of the change: background, motivation, and context.
  Include screenshots, videos, or before/after comparisons for UI changes.
-->
This PR updates the preview button displayed in Web Lab 2 AI Tutor workspace when user is prompted to either accept or reject AI tutor changes. Currently on prod, selecting the button updates the file that is previewed in the HTML preview - the view mode is maintained.

Now the view mode will be updated to Preview view mode, i.e., full screen. A user can still select other view modes afterwards to examine the code.

## Before update

https://github.com/user-attachments/assets/b217733f-378b-417f-a6c4-1eafca12ff3b



## After update



https://github.com/user-attachments/assets/ac2a35b8-f566-4781-b5d8-d1251483bd8b



## Links
<!-- Jira tickets, design docs, Slack threads, related PRs, etc. -->

- Jira: https://codedotorg.atlassian.net/browse/AFL-525
- [Slack thread](https://codedotorg.slack.com/archives/C06JELCAPT9/p1773761349939219?thread_ts=1773756935.626279&cid=C06JELCAPT9)
## Testing story
<!-- How was this tested? Manual steps, adhoc links, automated tests, or why testing isn't needed. -->

Tested locally in `weblab2` levels.

## Deployment notes
<!-- Delete this section if it's a standard merge-and-deploy.
     Otherwise: migrations, feature flags, coordination, caching impacts, etc. -->



## Privacy and security
<!-- Delete this section if there is no privacy/security impact.
     Otherwise: new PII, auth changes, API surface changes, etc. -->

