### PR TITLE
Fix `UnsafeRedirectError` in `level_source_controller`

### DIFF
--- a/dashboard/app/controllers/level_sources_controller.rb
+++ b/dashboard/app/controllers/level_sources_controller.rb
@@ -58,7 +58,7 @@ class LevelSourcesController < ApplicationController
     expires_in 10.hours, public: true # cache
 
     if @game.app == Game::ARTIST
-      redirect_to @level_source.level_source_image.s3_framed_url
+      redirect_to @level_source.level_source_image.s3_framed_url, allow_other_host: true
     else
       original_image
     end


### PR DESCRIPTION
Follow-up to https://github.com/code-dot-org/code-dot-org/pull/71164

This PR allows external redirection for one route which we want to be able to redirect [to cloudfront](https://github.com/code-dot-org/code-dot-org/blob/staging/dashboard/app/models/level_source_image.rb#L25)

## Links

See Slack thread [here](https://codedotorg.slack.com/archives/C0T0PNTM3/p1774897514281279) for more context