### PR TITLE
Fix `UnsafeRedirectError` in `discourse_sso_controller`

### DIFF
--- a/dashboard/app/controllers/discourse_sso_controller.rb
+++ b/dashboard/app/controllers/discourse_sso_controller.rb
@@ -40,6 +40,6 @@ class DiscourseSsoController < ApplicationController
     sso.add_groups = add_groups.join(',')
     sso.remove_groups = remove_groups.join(',')
 
-    redirect_to sso.to_url(sso.return_sso_url)
+    redirect_to sso.to_url(sso.return_sso_url), allow_other_host: true
   end
 end


### PR DESCRIPTION
Follow-up to https://github.com/code-dot-org/code-dot-org/pull/71164, like https://github.com/code-dot-org/code-dot-org/pull/71780 but for a route we want to be able to redirect to our Discourse forum
