### PR TITLE
allow_other_host on target link redirect

### DIFF
--- a/dashboard/app/controllers/lti_v1_controller.rb
+++ b/dashboard/app/controllers/lti_v1_controller.rb
@@ -227,7 +227,7 @@ class LtiV1Controller < ApplicationController
           redirect_to lti_v1_deep_linking_path(deep_linking_settings:) and return
         end
 
-        redirect_to destination_url
+        redirect_to destination_url, allow_other_host: true
       else
         user = Services::Lti.initialize_lti_user(decoded_jwt)
         # PartialRegistration removes the email address, so store it in a local variable first


### PR DESCRIPTION
Adds allow_other_hosts to the LTI redirect while we decide what to do about redirects to the marketing sites.

## Links
<!-- Jira tickets, design docs, Slack threads, related PRs, etc. -->

- Jira:

## Testing story
<!-- How was this tested? Manual steps, adhoc links, automated tests, or why testing isn't needed. -->



## Deployment notes
<!-- Delete this section if it's a standard merge-and-deploy.
     Otherwise: migrations, feature flags, coordination, caching impacts, etc. -->



## Privacy and security
<!-- Delete this section if there is no privacy/security impact.
     Otherwise: new PII, auth changes, API surface changes, etc. -->

