### PR TITLE
Fix `UnsafeRedirectError` in `omniauth_callbacks_controller`

### DIFF
--- a/dashboard/app/controllers/omniauth_callbacks_controller.rb
+++ b/dashboard/app/controllers/omniauth_callbacks_controller.rb
@@ -583,7 +583,9 @@ class OmniauthCallbacksController < Devise::OmniauthCallbacksController
   private def sign_in_user(user)
     flash.notice = I18n.t('auth.signed_in')
 
-    sign_in_and_redirect user
+    # based on Devise::Controllers::Helpers#sign_in_and_redirect
+    sign_in(:user, user)
+    redirect_to(after_sign_in_path_for(user), allow_other_host: true)
   end
 
   private def email_already_taken(user)


### PR DESCRIPTION
Follow-up to https://github.com/code-dot-org/code-dot-org/pull/71164, in response to [these HoneyBadger errors](https://app.honeybadger.io/projects/3240/faults/129079087/01KN2Q7340P4JPARBNMXJ4D52Y?q=UnsafeRedirectError)

## Links

See the underlying Devise method we're reimplementing [here](https://github.com/heartcombo/devise/blob/1d6658097e364d45b5e059976f1e822eee7d67da/lib/devise/controllers/helpers.rb#L232-L241)

Slack thread [here](https://codedotorg.slack.com/archives/C0T0PNTM3/p1774897514281279) for more context