### PR TITLE
Make createRoot default (with option for legacy) when using createReactRoot

### DIFF
--- a/apps/src/StudioApp.js
+++ b/apps/src/StudioApp.js
@@ -378,7 +378,10 @@ StudioApp.prototype.init = function (config) {
           })}
         />
       </Provider>,
-      document.body.appendChild(document.createElement('div'))
+      document.body.appendChild(document.createElement('div')),
+      {
+        legacyReactDomRender: true,
+      }
     );
   }
 
@@ -632,7 +635,10 @@ StudioApp.prototype.init = function (config) {
         levelId={config.serverLevelId}
         unitId={config.serverScriptId}
       />,
-      startDialogDiv
+      startDialogDiv,
+      {
+        legacyReactDomRender: true,
+      }
     );
   }
 
@@ -762,7 +768,9 @@ StudioApp.prototype.getSettingsHandler = function () {
       id: 'settings-modal',
     });
 
-    createReactRoot(React.createElement(SettingsModal), contentDiv);
+    createReactRoot(React.createElement(SettingsModal), contentDiv, {
+      legacyReactDomRender: true,
+    });
     dialog.show();
   };
 };
@@ -783,7 +791,10 @@ StudioApp.prototype.getVersionHistoryHandler = function (config) {
         selectedVersion: queryParams('version'),
         isReadOnly: !!config.readonlyWorkspace,
       }),
-      contentDiv
+      contentDiv,
+      {
+        legacyReactDomRender: true,
+      }
     );
 
     dialog.show();
@@ -1072,7 +1083,9 @@ StudioApp.prototype.renderShareFooter_ = function (container) {
     channel: project.getCurrentId(),
   };
 
-  createReactRoot(<SmallFooter {...reactProps} />, footerDiv);
+  createReactRoot(<SmallFooter {...reactProps} />, footerDiv, {
+    legacyReactDomRender: true,
+  });
 };
 
 /**
@@ -2346,7 +2359,10 @@ StudioApp.prototype.handleHideSource_ = function (options) {
               appType: project.getStandaloneApp(),
               isLegacyShare: !!options.isLegacyShare,
             }),
-            div
+            div,
+            {
+              legacyReactDomRender: true,
+            }
           );
         }
       }
@@ -3154,7 +3170,9 @@ StudioApp.prototype.displayWorkspaceAlert = function (
     },
     alertContents
   );
-  createReactRoot(workspaceAlert, container[0]);
+  createReactRoot(workspaceAlert, container[0], {
+    legacyReactDomRender: true,
+  });
 
   return container[0];
 };
@@ -3193,7 +3211,9 @@ StudioApp.prototype.displayPlayspaceAlert = function (type, alertContents) {
   }
 
   const playspaceAlert = React.createElement(Alert, alertProps, alertContents);
-  createReactRoot(playspaceAlert, renderElement);
+  createReactRoot(playspaceAlert, renderElement, {
+    legacyReactDomRender: true,
+  });
 
   return renderElement;
 };

--- a/apps/src/accounts/AddParentEmailController.js
+++ b/apps/src/accounts/AddParentEmailController.js
@@ -57,7 +57,10 @@ export default class AddParentEmailController {
         handleCancel={this.hideAddParentEmailModal}
         currentParentEmail={this.formParentEmailField.val()}
       />,
-      this.mountPoint
+      this.mountPoint,
+      {
+        legacyReactDomRender: true,
+      }
     );
   };
 

--- a/apps/src/accounts/AddPasswordController.js
+++ b/apps/src/accounts/AddPasswordController.js
@@ -22,7 +22,10 @@ export default class AddPasswordController {
         userAge={this.userAge}
         userUsState={this.userUsState}
       />,
-      this.mountPoint
+      this.mountPoint,
+      {
+        legacyReactDomRender: true,
+      }
     );
   };
 

--- a/apps/src/accounts/ChangeUserTypeController.js
+++ b/apps/src/accounts/ChangeUserTypeController.js
@@ -93,7 +93,10 @@ export default class ChangeUserTypeController {
         handleSubmit={this.submitUserTypeChange}
         handleCancel={this.hideChangeUserTypeModal}
       />,
-      this.mountPoint
+      this.mountPoint,
+      {
+        legacyReactDomRender: true,
+      }
     );
   }
 

--- a/apps/src/accounts/ManageLinkedAccountsController.js
+++ b/apps/src/accounts/ManageLinkedAccountsController.js
@@ -38,7 +38,10 @@ export default class ManageLinkedAccountsController {
       <Provider store={store}>
         <ManageLinkedAccounts />
       </Provider>,
-      mountPoint
+      mountPoint,
+      {
+        legacyReactDomRender: true,
+      }
     );
   }
 }

--- a/apps/src/aiDifferentiation/aiDiffUtils.js
+++ b/apps/src/aiDifferentiation/aiDiffUtils.js
@@ -19,7 +19,10 @@ export function displayDifferentiationChat() {
       <Provider store={getStore()}>
         <AiDiffFloatingActionButton context={context} />
       </Provider>,
-      aiDiffFabMountPoint
+      aiDiffFabMountPoint,
+      {
+        legacyReactDomRender: true,
+      }
     );
   }
 }

--- a/apps/src/ailab/Ailab.js
+++ b/apps/src/ailab/Ailab.js
@@ -132,7 +132,10 @@ Ailab.prototype.init = function (config) {
     <Provider store={getStore()}>
       <AilabView onMount={onMount} />
     </Provider>,
-    document.getElementById(config.containerId)
+    document.getElementById(config.containerId),
+    {
+      legacyReactDomRender: true,
+    }
   );
 };
 

--- a/apps/src/applab/applab.js
+++ b/apps/src/applab/applab.js
@@ -246,7 +246,10 @@ function renderFooterInSharedGame() {
       menuItems={menuItems}
       phoneFooter={true}
     />,
-    footerDiv
+    footerDiv,
+    {
+      legacyReactDomRender: true,
+    }
   );
 }
 
@@ -941,7 +944,10 @@ Applab.render = function () {
     <Provider store={getStore()}>
       <AppLabView {...nextProps} />
     </Provider>,
-    Applab.reactMountPoint_
+    Applab.reactMountPoint_,
+    {
+      legacyReactDomRender: true,
+    }
   );
 };
 

--- a/apps/src/applab/designMode.js
+++ b/apps/src/applab/designMode.js
@@ -1698,7 +1698,10 @@ designMode.renderDesignWorkspace = function (element) {
     <Provider store={getStore()}>
       <DesignWorkspace {...props} />
     </Provider>,
-    designWorkspace
+    designWorkspace,
+    {
+      legacyReactDomRender: true,
+    }
   );
 };
 

--- a/apps/src/blockTooltips/DropletBlockTooltipManager.js
+++ b/apps/src/blockTooltips/DropletBlockTooltipManager.js
@@ -156,7 +156,10 @@ DropletBlockTooltipManager.prototype.installTooltipsForCurrentCategoryBlocks_ =
                       }}
                       sourceCode={library.source}
                     />,
-                    document.querySelector('#libraryFunctionTooltipModal')
+                    document.querySelector('#libraryFunctionTooltipModal'),
+                    {
+                      legacyReactDomRender: true,
+                    }
                   );
                 }
               });

--- a/apps/src/bounce/bounce.js
+++ b/apps/src/bounce/bounce.js
@@ -869,7 +869,10 @@ Bounce.init = function (config) {
         onMount={onMount}
       />
     </Provider>,
-    document.getElementById(config.containerId)
+    document.getElementById(config.containerId),
+    {
+      legacyReactDomRender: true,
+    }
   );
 };
 

--- a/apps/src/code-studio/assets/show.js
+++ b/apps/src/code-studio/assets/show.js
@@ -81,7 +81,10 @@ function showAssetManager(assetChosen, typeFilter, onClose, options) {
       currentValue: options.currentValue,
       currentImageType: options.currentImageType,
     }),
-    codeDiv
+    codeDiv,
+    {
+      legacyReactDomRender: true,
+    }
   );
 
   dialog.show();

--- a/apps/src/code-studio/header.js
+++ b/apps/src/code-studio/header.js
@@ -123,7 +123,10 @@ header.build = function (
           scriptData={scriptData}
         />
       </Provider>,
-      document.querySelector('.header_level')
+      document.querySelector('.header_level'),
+      {
+        legacyReactDomRender: true,
+      }
     );
     // Only render sign in callout if the course is CSF and the user is
     // not signed in
@@ -145,7 +148,10 @@ header.build = function (
 
       createReactRoot(
         <SignInCalloutWrapper />,
-        document.querySelector('.signin_callout_wrapper')
+        document.querySelector('.signin_callout_wrapper'),
+        {
+          legacyReactDomRender: true,
+        }
       );
     }
   });
@@ -161,7 +167,10 @@ header.buildProjectInfoOnly = function (currentLevelId) {
     <Provider store={store}>
       <HeaderMiddle projectInfoOnly={true} />
     </Provider>,
-    document.querySelector('.header_level')
+    document.querySelector('.header_level'),
+    {
+      legacyReactDomRender: true,
+    }
   );
 };
 
@@ -172,7 +181,10 @@ header.buildScriptNameOnly = function (scriptNameData) {
     <Provider store={getStore()}>
       <HeaderMiddle scriptNameData={scriptNameData} scriptNameOnly={true} />
     </Provider>,
-    document.querySelector('.header_level')
+    document.querySelector('.header_level'),
+    {
+      legacyReactDomRender: true,
+    }
   );
 };
 

--- a/apps/src/code-studio/headerShare.js
+++ b/apps/src/code-studio/headerShare.js
@@ -59,7 +59,10 @@ export function shareProject(shareUrl) {
           userSharingDisabled={appOptions.userSharingDisabled}
         />
       </Provider>,
-      dialogDom
+      dialogDom,
+      {
+        legacyReactDomRender: true,
+      }
     );
 
     getStore().dispatch(showShareDialog());

--- a/apps/src/code-studio/initApp/loadApp.js
+++ b/apps/src/code-studio/initApp/loadApp.js
@@ -167,7 +167,10 @@ export function setupApp(appOptions) {
               dialog.hide();
             }}
           />,
-          body
+          body,
+          {
+            legacyReactDomRender: true,
+          }
         );
         const dialog = new LegacyDialog({
           body: body,

--- a/apps/src/code-studio/initApp/renderAbusive.js
+++ b/apps/src/code-studio/initApp/renderAbusive.js
@@ -28,7 +28,10 @@ export default (project, tosText) => {
       isOwner: project.isOwner(),
       canViewFlaggedProject: project.canViewFlaggedProject(),
     }),
-    document.getElementById('codeApp')
+    document.getElementById('codeApp'),
+    {
+      legacyReactDomRender: true,
+    }
   );
 
   // update admin box (if it exists) with abuse info

--- a/apps/src/code-studio/initApp/renderProjectNotFound.js
+++ b/apps/src/code-studio/initApp/renderProjectNotFound.js
@@ -19,7 +19,13 @@ export function ProjectNotFoundAlert() {
 }
 
 export default () => {
-  createReactRoot(<ProjectNotFoundAlert />, document.getElementById('codeApp'));
+  createReactRoot(
+    <ProjectNotFoundAlert />,
+    document.getElementById('codeApp'),
+    {
+      legacyReactDomRender: true,
+    }
+  );
 };
 
 const styles = {

--- a/apps/src/code-studio/initApp/renderVersionNotFound.js
+++ b/apps/src/code-studio/initApp/renderVersionNotFound.js
@@ -19,7 +19,13 @@ export function VersionNotFoundAlert() {
 }
 
 export default () => {
-  createReactRoot(<VersionNotFoundAlert />, document.getElementById('codeApp'));
+  createReactRoot(
+    <VersionNotFoundAlert />,
+    document.getElementById('codeApp'),
+    {
+      legacyReactDomRender: true,
+    }
+  );
 };
 
 const styles = {

--- a/apps/src/code-studio/initSigninState.js
+++ b/apps/src/code-studio/initSigninState.js
@@ -51,7 +51,10 @@ export default function initSigninState(userType, under13) {
       <Provider store={store}>
         <SignInOrAgeDialog />
       </Provider>,
-      div
+      div,
+      {
+        legacyReactDomRender: true,
+      }
     );
     document.body.appendChild(div);
   });

--- a/apps/src/code-studio/initializeCodeMirror.js
+++ b/apps/src/code-studio/initializeCodeMirror.js
@@ -85,7 +85,10 @@ function initializeCodeMirror(target, mode, options = {}) {
               instructionsText: editor.getValue(),
               theme: 'Dark',
             }),
-            previewElement
+            previewElement,
+            {
+              legacyReactDomRender: true,
+            }
           );
         } else if (game === 'Aichat' || game === 'Music') {
           createReactRoot(
@@ -93,14 +96,20 @@ function initializeCodeMirror(target, mode, options = {}) {
               instructionsText: editor.getValue(),
               theme: 'Light',
             }),
-            previewElement
+            previewElement,
+            {
+              legacyReactDomRender: true,
+            }
           );
         } else {
           createReactRoot(
             React.createElement(SafeMarkdown, {
               markdown: editor.getValue(),
             }),
-            previewElement
+            previewElement,
+            {
+              legacyReactDomRender: true,
+            }
           );
         }
       };

--- a/apps/src/code-studio/initializeCodeMirror6.ts
+++ b/apps/src/code-studio/initializeCodeMirror6.ts
@@ -225,7 +225,10 @@ function initializeCodeMirror6(
           instructionsText: adapter.getValue(),
           theme: 'Dark',
         }),
-        previewElement
+        previewElement,
+        {
+          legacyReactDomRender: true,
+        }
       );
     } else if (game === 'Aichat' || game === 'Music') {
       createReactRoot(
@@ -233,14 +236,20 @@ function initializeCodeMirror6(
           instructionsText: adapter.getValue(),
           theme: 'Light',
         }),
-        previewElement
+        previewElement,
+        {
+          legacyReactDomRender: true,
+        }
       );
     } else {
       createReactRoot(
         React.createElement(SafeMarkdown, {
           markdown: adapter.getValue(),
         }),
-        previewElement
+        previewElement,
+        {
+          legacyReactDomRender: true,
+        }
       );
     }
   };

--- a/apps/src/code-studio/levels/dialogHelper.js
+++ b/apps/src/code-studio/levels/dialogHelper.js
@@ -31,7 +31,9 @@ export function showDialog(component, callback, onHidden) {
     return;
   }
   const div = document.createElement('div');
-  createReactRoot(component, div);
+  createReactRoot(component, div, {
+    legacyReactDomRender: true,
+  });
   const content = div.childNodes[0];
   const dialog = new LegacyDialog({
     // Content is a div with a specific expected structure. See LegacyDialog.
@@ -166,7 +168,10 @@ export function processResults(onComplete, beforeHook) {
                 dialog.hide();
               }}
             />,
-            body
+            body,
+            {
+              legacyReactDomRender: true,
+            }
           );
           const dialog = new LegacyDialog({
             body: body,

--- a/apps/src/code-studio/pairing.js
+++ b/apps/src/code-studio/pairing.js
@@ -22,7 +22,10 @@ export default {
               pairingDialog = dialog;
             }}
           />,
-          container
+          container,
+          {
+            legacyReactDomRender: true,
+          }
         );
       }
       if (pairingDialog) {

--- a/apps/src/code-studio/progress.js
+++ b/apps/src/code-studio/progress.js
@@ -35,7 +35,9 @@ function showDisabledBubblesModal() {
   const div = $('<div>');
   $(document.body).append(div);
 
-  createReactRoot(<DisabledBubblesModal />, div[0]);
+  createReactRoot(<DisabledBubblesModal />, div[0], {
+    legacyReactDomRender: true,
+  });
 }
 
 /**
@@ -57,7 +59,9 @@ progress.showDisabledBubblesAlert = function () {
   });
   $(document.body).append(div);
 
-  createReactRoot(<DisabledBubblesAlert />, div[0]);
+  createReactRoot(<DisabledBubblesAlert />, div[0], {
+    legacyReactDomRender: true,
+  });
 };
 
 /**

--- a/apps/src/code-studio/teacherPanelHelpers.js
+++ b/apps/src/code-studio/teacherPanelHelpers.js
@@ -28,7 +28,10 @@ export function renderTeacherPanel(
         />
       </InstructorsOnly>
     </Provider>,
-    div
+    div,
+    {
+      legacyReactDomRender: true,
+    }
   );
   document.body.appendChild(div);
 }

--- a/apps/src/code-studio/videos.js
+++ b/apps/src/code-studio/videos.js
@@ -535,7 +535,10 @@ function showFallbackPlayerCaptionLink(inDialog) {
   if (mountPoint) {
     createReactRoot(
       <FallbackPlayerCaptionDialogLink inDialog={inDialog} />,
-      mountPoint
+      mountPoint,
+      {
+        legacyReactDomRender: true,
+      }
     );
   }
 }

--- a/apps/src/codebridge/Editor/addToAiTutorField.tsx
+++ b/apps/src/codebridge/Editor/addToAiTutorField.tsx
@@ -72,7 +72,10 @@ export const getAddToAiTutorField = (
             dom.className = moduleStyles.aiTutorTooltip;
             createReactRoot(
               <AddToAiTutorChatButton saveSelectionContext={saveSelection} />,
-              dom
+              dom,
+              {
+                legacyReactDomRender: true,
+              }
             );
             return {dom};
           },

--- a/apps/src/craft/agent/craft.js
+++ b/apps/src/craft/agent/craft.js
@@ -413,7 +413,10 @@ export default class Craft {
           <PlayerSelectionDialog players={[CHARACTER_STEVE, CHARACTER_ALEX]} />
         </div>
       </Provider>,
-      document.getElementById(config.containerId)
+      document.getElementById(config.containerId),
+      {
+        legacyReactDomRender: true,
+      }
     );
   }
 

--- a/apps/src/craft/aquatic/craft.js
+++ b/apps/src/craft/aquatic/craft.js
@@ -327,7 +327,10 @@ Craft.init = function (config) {
         <PlayerSelectionDialog players={[CHARACTER_STEVE, CHARACTER_ALEX]} />
       </div>
     </Provider>,
-    document.getElementById(config.containerId)
+    document.getElementById(config.containerId),
+    {
+      legacyReactDomRender: true,
+    }
   );
 };
 

--- a/apps/src/craft/code-connection/craft.js
+++ b/apps/src/craft/code-connection/craft.js
@@ -565,7 +565,10 @@ export default class Craft {
           onMount={onMount}
         />
       </Provider>,
-      document.getElementById(config.containerId)
+      document.getElementById(config.containerId),
+      {
+        legacyReactDomRender: true,
+      }
     );
   }
 

--- a/apps/src/craft/designer/craft.js
+++ b/apps/src/craft/designer/craft.js
@@ -469,7 +469,10 @@ Craft.init = function (config) {
         />
       </div>
     </Provider>,
-    document.getElementById(config.containerId)
+    document.getElementById(config.containerId),
+    {
+      legacyReactDomRender: true,
+    }
   );
 };
 

--- a/apps/src/craft/simple/craft.js
+++ b/apps/src/craft/simple/craft.js
@@ -465,7 +465,10 @@ Craft.init = function (config) {
         <PlayerSelectionDialog players={[CHARACTER_STEVE, CHARACTER_ALEX]} />
       </div>
     </Provider>,
-    document.getElementById(config.containerId)
+    document.getElementById(config.containerId),
+    {
+      legacyReactDomRender: true,
+    }
   );
 };
 

--- a/apps/src/dance/Dance.js
+++ b/apps/src/dance/Dance.js
@@ -216,7 +216,10 @@ Dance.prototype.init = function (config) {
         />
       </ErrorBoundary>
     </Provider>,
-    document.getElementById(config.containerId)
+    document.getElementById(config.containerId),
+    {
+      legacyReactDomRender: true,
+    }
   );
 };
 

--- a/apps/src/feedback.js
+++ b/apps/src/feedback.js
@@ -289,7 +289,10 @@ FeedbackUtils.prototype.displayFeedback = function (
       >
         {displayShowCode && this.getShowCodeComponent_(options, true)}
       </ChallengeDialog>,
-      container
+      container,
+      {
+        legacyReactDomRender: true,
+      }
     );
     return;
   }
@@ -567,7 +570,10 @@ FeedbackUtils.prototype.getFeedbackButtons_ = function (options) {
       assetUrl={this.studioApp_.assetUrl}
       freePlay={options.freePlay}
     />,
-    buttons
+    buttons,
+    {
+      legacyReactDomRender: true,
+    }
   );
 
   return buttons;
@@ -934,7 +940,9 @@ FeedbackUtils.prototype.createSharingDiv = function (options) {
 
       var qrCode = sharingDiv.querySelector('#send-to-phone-qr-code');
       var annotatedShareLink = options.shareLink + '?qr=true';
-      createReactRoot(<QRCode value={annotatedShareLink} size={90} />, qrCode);
+      createReactRoot(<QRCode value={annotatedShareLink} size={90} />, qrCode, {
+        legacyReactDomRender: true,
+      });
 
       if (sharingPhone && options.isUS) {
         var phone = $(sharingDiv.querySelector('#phone'));
@@ -988,7 +996,10 @@ FeedbackUtils.prototype.createSharingDiv = function (options) {
       <Provider store={getStore()}>
         <DownloadReplayVideoButton onError={onDownloadError} />
       </Provider>,
-      downloadReplayVideoContainer
+      downloadReplayVideoContainer,
+      {
+        legacyReactDomRender: true,
+      }
     );
   }
 
@@ -998,7 +1009,9 @@ FeedbackUtils.prototype.createSharingDiv = function (options) {
 FeedbackUtils.prototype.getShowCodeElement_ = function (options) {
   const showCodeDiv = document.createElement('div');
   showCodeDiv.setAttribute('id', 'show-code');
-  createReactRoot(this.getShowCodeComponent_(options), showCodeDiv);
+  createReactRoot(this.getShowCodeComponent_(options), showCodeDiv, {
+    legacyReactDomRender: true,
+  });
 
   // If the jQuery details polyfill is available, use it on the
   // newly-created details element. If the details polyfill is not
@@ -1158,7 +1171,10 @@ FeedbackUtils.prototype.showGeneratedCode = function (appStrings) {
       />
       <DialogButtons ok={true} />
     </div>,
-    codeDiv
+    codeDiv,
+    {
+      legacyReactDomRender: true,
+    }
   );
 
   var dialog = this.createModalDialog({
@@ -1246,7 +1262,10 @@ FeedbackUtils.prototype.showSimpleDialog = function (options) {
         isDangerCancel={!!options.isDangerCancel}
       />
     </div>,
-    contentDiv
+    contentDiv,
+    {
+      legacyReactDomRender: true,
+    }
   );
 
   var dialog = this.createModalDialog({
@@ -1296,7 +1315,9 @@ FeedbackUtils.prototype.showToggleBlocksError = function () {
   contentDiv.innerHTML = msg.toggleBlocksErrorMsg();
 
   var buttons = document.createElement('div');
-  createReactRoot(<DialogButtons ok={true} />, buttons);
+  createReactRoot(<DialogButtons ok={true} />, buttons, {
+    legacyReactDomRender: true,
+  });
   contentDiv.appendChild(buttons);
 
   var dialog = this.createModalDialog({

--- a/apps/src/fish/Fish.js
+++ b/apps/src/fish/Fish.js
@@ -113,7 +113,10 @@ Fish.prototype.init = function (config) {
     <Provider store={getStore()}>
       <FishView onMount={onMount} />
     </Provider>,
-    document.getElementById(config.containerId)
+    document.getElementById(config.containerId),
+    {
+      legacyReactDomRender: true,
+    }
   );
 };
 

--- a/apps/src/flappy/flappy.js
+++ b/apps/src/flappy/flappy.js
@@ -680,7 +680,10 @@ Flappy.init = function (config) {
         onMount={onMount}
       />
     </Provider>,
-    document.getElementById(config.containerId)
+    document.getElementById(config.containerId),
+    {
+      legacyReactDomRender: true,
+    }
   );
 };
 

--- a/apps/src/globalEdition/regionSwitchConfirm.js
+++ b/apps/src/globalEdition/regionSwitchConfirm.js
@@ -10,6 +10,9 @@ document.addEventListener('DOMContentLoaded', () => {
       code={getScriptData('code')}
       name={getScriptData('name')}
     />,
-    document.getElementById('global-edition-region-switch-confirm-container')
+    document.getElementById('global-edition-region-switch-confirm-container'),
+    {
+      legacyReactDomRender: true,
+    }
   );
 });

--- a/apps/src/javalab/Javalab.js
+++ b/apps/src/javalab/Javalab.js
@@ -342,7 +342,10 @@ Javalab.prototype.init = function (config) {
         />
       </BackpackAPIContext.Provider>
     </Provider>,
-    document.getElementById(config.containerId)
+    document.getElementById(config.containerId),
+    {
+      legacyReactDomRender: true,
+    }
   );
 
   window.addEventListener('beforeunload', this.beforeUnload.bind(this));

--- a/apps/src/jigsaw/jigsaw.js
+++ b/apps/src/jigsaw/jigsaw.js
@@ -201,7 +201,10 @@ Jigsaw.init = function (config) {
         onMount={onMount}
       />
     </Provider>,
-    document.getElementById(config.containerId)
+    document.getElementById(config.containerId),
+    {
+      legacyReactDomRender: true,
+    }
   );
 };
 

--- a/apps/src/lab2/header/lab2HeaderShare.js
+++ b/apps/src/lab2/header/lab2HeaderShare.js
@@ -37,7 +37,10 @@ export function shareLab2Project(dialogId, finishUrl) {
           finishUrl={finishUrl}
         />
       </Provider>,
-      dialogDom
+      dialogDom,
+      {
+        legacyReactDomRender: true,
+      }
     );
 
     getStore().dispatch(showShareDialog());

--- a/apps/src/maze/maze.js
+++ b/apps/src/maze/maze.js
@@ -221,7 +221,10 @@ module.exports = class Maze {
           onMount={studioApp().init.bind(studioApp(), config)}
         />
       </Provider>,
-      document.getElementById(config.containerId)
+      document.getElementById(config.containerId),
+      {
+        legacyReactDomRender: true,
+      }
     );
   }
 

--- a/apps/src/music/blockly/FieldChord.ts
+++ b/apps/src/music/blockly/FieldChord.ts
@@ -191,7 +191,10 @@ export default class FieldChord extends BlocklyCore.Field {
         initValue: this.getValue(),
         onChange: this.onValueChange,
       }),
-      this.newDiv
+      this.newDiv,
+      {
+        legacyReactDomRender: true,
+      }
     );
   }
 

--- a/apps/src/music/blockly/FieldPattern.js
+++ b/apps/src/music/blockly/FieldPattern.js
@@ -118,7 +118,10 @@ class FieldPattern extends BlocklyCore.Field {
         onChange={this.onValueChange}
         lengthMeasures={1}
       />,
-      this.newDiv_
+      this.newDiv_,
+      {
+        legacyReactDomRender: true,
+      }
     );
   }
 

--- a/apps/src/music/blockly/FieldPatternAi.js
+++ b/apps/src/music/blockly/FieldPatternAi.js
@@ -118,7 +118,10 @@ class FieldPatternAi extends BlocklyCore.Field {
           this.setValue(value);
         }}
       />,
-      this.newDiv_
+      this.newDiv_,
+      {
+        legacyReactDomRender: true,
+      }
     );
   }
 

--- a/apps/src/music/blockly/FieldSounds.js
+++ b/apps/src/music/blockly/FieldSounds.js
@@ -180,7 +180,10 @@ class FieldSounds extends BlocklyCore.Field {
         }}
         onSelect={value => this.setValue(value)}
       />,
-      this.newDiv_
+      this.newDiv_,
+      {
+        legacyReactDomRender: true,
+      }
     );
   }
 

--- a/apps/src/music/blockly/FieldTune.ts
+++ b/apps/src/music/blockly/FieldTune.ts
@@ -242,7 +242,10 @@ export default class FieldTune extends BlocklyCore.Field {
         onChange: this.onValueChange,
         lengthMeasures: 1,
       }),
-      this.newDiv
+      this.newDiv,
+      {
+        legacyReactDomRender: true,
+      }
     );
   }
 

--- a/apps/src/netsim/NetSimRouterLogModal.js
+++ b/apps/src/netsim/NetSimRouterLogModal.js
@@ -260,7 +260,10 @@ NetSimRouterLogModal.prototype.render = function () {
       renderedRowLimit={MAXIMUM_ROWS_IN_FULL_RENDER}
       teacherView={this.teacherView_}
     />,
-    this.rootDiv_[0]
+    this.rootDiv_[0],
+    {
+      legacyReactDomRender: true,
+    }
   );
 };
 

--- a/apps/src/netsim/netsim.js
+++ b/apps/src/netsim/netsim.js
@@ -278,7 +278,10 @@ NetSim.prototype.init = function (config) {
         onMount={onMount}
       />
     </Provider>,
-    document.getElementById(config.containerId)
+    document.getElementById(config.containerId),
+    {
+      legacyReactDomRender: true,
+    }
   );
 };
 

--- a/apps/src/p5lab/P5Lab.js
+++ b/apps/src/p5lab/P5Lab.js
@@ -509,7 +509,10 @@ export default class P5Lab {
               labType={this.getLabType()}
             />
           </Provider>,
-          document.getElementById(config.containerId)
+          document.getElementById(config.containerId),
+          {
+            legacyReactDomRender: true,
+          }
         )
       );
 

--- a/apps/src/publicKeyCryptography/main.js
+++ b/apps/src/publicKeyCryptography/main.js
@@ -21,7 +21,10 @@ function initialize(options) {
     ) : (
       <ModuloClockWidget />
     ),
-    document.getElementById('public-key-cryptography-mount')
+    document.getElementById('public-key-cryptography-mount'),
+    {
+      legacyReactDomRender: true,
+    }
   );
 }
 

--- a/apps/src/regionalPartnerMiniContact/regionalPartnerMiniContact.js
+++ b/apps/src/regionalPartnerMiniContact/regionalPartnerMiniContact.js
@@ -34,7 +34,10 @@ window.showRegionalPartnerMiniContact = function () {
           apiEndpoint="/dashboardapi/v1/pd/regional_partner_mini_contacts/"
           sourcePageId={sourcePageId}
         />,
-        regionalPartnerMiniContactElement[0]
+        regionalPartnerMiniContactElement[0],
+        {
+          legacyReactDomRender: true,
+        }
       );
     });
 };
@@ -55,6 +58,9 @@ window.showRegionalPartnerMiniContactPopupLink = function () {
       {isButton && <button type="button">{linkText}</button>}
       {!isButton && linkText}
     </RegionalPartnerMiniContactPopupLink>,
-    regionalPartnerMiniContactPopupLinkElement[0]
+    regionalPartnerMiniContactPopupLinkElement[0],
+    {
+      legacyReactDomRender: true,
+    }
   );
 };

--- a/apps/src/shareWarnings.js
+++ b/apps/src/shareWarnings.js
@@ -109,6 +109,9 @@ exports.checkSharedAppWarnings = function (options) {
       handleClose={handleClose}
       handleTooYoung={handleShareWarningsTooYoung}
     />,
-    document.body.appendChild(document.createElement('div'))
+    document.body.appendChild(document.createElement('div')),
+    {
+      legacyReactDomRender: true,
+    }
   );
 };

--- a/apps/src/sites/studio/pages/admin_users/mass_delete_student_progress.js
+++ b/apps/src/sites/studio/pages/admin_users/mass_delete_student_progress.js
@@ -6,6 +6,8 @@ import {createReactRoot} from '@cdo/apps/util/createReactRoot';
 document.addEventListener('DOMContentLoaded', function () {
   const mountPoint = document.getElementById('mass-delete-container');
   if (mountPoint) {
-    createReactRoot(<MassDeleteContainer />, mountPoint);
+    createReactRoot(<MassDeleteContainer />, mountPoint, {
+      legacyReactDomRender: true,
+    });
   }
 });

--- a/apps/src/sites/studio/pages/ai_iteration/tools.js
+++ b/apps/src/sites/studio/pages/ai_iteration/tools.js
@@ -8,6 +8,9 @@ $(document).ready(() => {
   const aiIterationToolsData = getScriptData('aiIterationToolsData');
   createReactRoot(
     <DatasetMaker studentWorkAccess={aiIterationToolsData.studentWorkAccess} />,
-    document.getElementById('ai-iteration-tools')
+    document.getElementById('ai-iteration-tools'),
+    {
+      legacyReactDomRender: true,
+    }
   );
 });

--- a/apps/src/sites/studio/pages/aidiff_exit_tickets/show.js
+++ b/apps/src/sites/studio/pages/aidiff_exit_tickets/show.js
@@ -17,6 +17,9 @@ function displayExitTicket() {
       updated={new Date(exitTicketData['updated_at'])}
       content={exitTicketData['content']}
     />,
-    document.getElementById('show-container')
+    document.getElementById('show-container'),
+    {
+      legacyReactDomRender: true,
+    }
   );
 }

--- a/apps/src/sites/studio/pages/aidiff_lesson_hooks/show.js
+++ b/apps/src/sites/studio/pages/aidiff_lesson_hooks/show.js
@@ -17,6 +17,9 @@ function displayLessonHook() {
       updated={new Date(lessonHookData['updated_at'])}
       content={lessonHookData['content']['lesson_hook']}
     />,
-    document.getElementById('show-container')
+    document.getElementById('show-container'),
+    {
+      legacyReactDomRender: true,
+    }
   );
 }

--- a/apps/src/sites/studio/pages/certificates/batch.js
+++ b/apps/src/sites/studio/pages/certificates/batch.js
@@ -17,6 +17,9 @@ $(document).ready(function () {
       initialStudentNames={studentNames}
       imageUrl={imageUrl}
     />,
-    document.getElementById('certificate-batch')
+    document.getElementById('certificate-batch'),
+    {
+      legacyReactDomRender: true,
+    }
   );
 });

--- a/apps/src/sites/studio/pages/certificates/show.js
+++ b/apps/src/sites/studio/pages/certificates/show.js
@@ -19,6 +19,9 @@ $(document).ready(function () {
         imageAlt={imageAlt}
       />
     </Provider>,
-    document.getElementById('certificate-share')
+    document.getElementById('certificate-share'),
+    {
+      legacyReactDomRender: true,
+    }
   );
 });

--- a/apps/src/sites/studio/pages/code-studio.js
+++ b/apps/src/sites/studio/pages/code-studio.js
@@ -120,7 +120,10 @@ $(document).ready(function () {
           isDialogOpen={gdprData.show_gdpr_dialog}
           currentUserId={gdprData.current_user_id}
         />,
-        document.getElementById('gdpr-dialog')
+        document.getElementById('gdpr-dialog'),
+        {
+          legacyReactDomRender: true,
+        }
       );
     }
   }

--- a/apps/src/sites/studio/pages/codeprojects_preview/page_not_found.js
+++ b/apps/src/sites/studio/pages/codeprojects_preview/page_not_found.js
@@ -6,6 +6,9 @@ import PageNotFound from '@cdo/apps/weblab2/htmlPreview/PageNotFound';
 document.addEventListener('DOMContentLoaded', () => {
   createReactRoot(
     <PageNotFound />,
-    document.getElementById('page-not-found-container')
+    document.getElementById('page-not-found-container'),
+    {
+      legacyReactDomRender: true,
+    }
   );
 });

--- a/apps/src/sites/studio/pages/codeprojects_preview/show.js
+++ b/apps/src/sites/studio/pages/codeprojects_preview/show.js
@@ -9,6 +9,9 @@ window.ReactDOM = require('react-dom');
 document.addEventListener('DOMContentLoaded', () => {
   createReactRoot(
     <InnerHTMLPreview />,
-    document.getElementById('codeprojects-preview-container')
+    document.getElementById('codeprojects-preview-container'),
+    {
+      legacyReactDomRender: true,
+    }
   );
 });

--- a/apps/src/sites/studio/pages/congrats/index.js
+++ b/apps/src/sites/studio/pages/congrats/index.js
@@ -89,6 +89,9 @@ $(document).ready(function () {
         isEnglish={isEnglish}
       />
     </Provider>,
-    document.getElementById('congrats-container')
+    document.getElementById('congrats-container'),
+    {
+      legacyReactDomRender: true,
+    }
   );
 });

--- a/apps/src/sites/studio/pages/course_offerings/edit.js
+++ b/apps/src/sites/studio/pages/course_offerings/edit.js
@@ -29,6 +29,9 @@ function showCourseOfferingEditor() {
       videos={videos}
       facilitatorsCourses={facilitatorsCourses}
     />,
-    document.getElementById('course_offering_editor')
+    document.getElementById('course_offering_editor'),
+    {
+      legacyReactDomRender: true,
+    }
   );
 }

--- a/apps/src/sites/studio/pages/courses/code.js
+++ b/apps/src/sites/studio/pages/courses/code.js
@@ -23,6 +23,9 @@ function initPage() {
     <Provider store={store}>
       <CourseRollup objectToRollUp={'Code'} course={courseSummary} />
     </Provider>,
-    document.getElementById('roll_up')
+    document.getElementById('roll_up'),
+    {
+      legacyReactDomRender: true,
+    }
   );
 }

--- a/apps/src/sites/studio/pages/courses/edit.js
+++ b/apps/src/sites/studio/pages/courses/edit.js
@@ -91,6 +91,9 @@ function showCourseEditor() {
         }
       />
     </Provider>,
-    document.getElementById('course_editor')
+    document.getElementById('course_editor'),
+    {
+      legacyReactDomRender: true,
+    }
   );
 }

--- a/apps/src/sites/studio/pages/courses/new.js
+++ b/apps/src/sites/studio/pages/courses/new.js
@@ -11,6 +11,9 @@ $(document).ready(() => {
       versionYearOptions={getScriptData('versionYearOptions')}
       familiesCourseTypes={getScriptData('familiesCourseTypes')}
     />,
-    document.getElementById('form')
+    document.getElementById('form'),
+    {
+      legacyReactDomRender: true,
+    }
   );
 });

--- a/apps/src/sites/studio/pages/courses/resources.js
+++ b/apps/src/sites/studio/pages/courses/resources.js
@@ -19,6 +19,9 @@ function initPage() {
     <Provider store={store}>
       <CourseRollup objectToRollUp={'Resources'} course={courseSummary} />
     </Provider>,
-    document.getElementById('roll_up')
+    document.getElementById('roll_up'),
+    {
+      legacyReactDomRender: true,
+    }
   );
 }

--- a/apps/src/sites/studio/pages/courses/show.js
+++ b/apps/src/sites/studio/pages/courses/show.js
@@ -108,7 +108,10 @@ function showCourseOverview() {
         aiChatToolsDependency={courseSummary.ai_chat_tools_dependency}
       />
     </Provider>,
-    document.getElementById('course_overview')
+    document.getElementById('course_overview'),
+    {
+      legacyReactDomRender: true,
+    }
   );
   tooltipifyVocabulary();
   displayDifferentiationChat(scriptData);
@@ -130,7 +133,10 @@ function displayDifferentiationChat(scriptData) {
           scriptName={scriptData.course_summary.name}
         />
       </Provider>,
-      aiDiffFabMountPoint
+      aiDiffFabMountPoint,
+      {
+        legacyReactDomRender: true,
+      }
     );
   }
 }

--- a/apps/src/sites/studio/pages/courses/standards.js
+++ b/apps/src/sites/studio/pages/courses/standards.js
@@ -19,6 +19,9 @@ function initPage() {
     <Provider store={store}>
       <CourseRollup objectToRollUp={'Standards'} course={courseSummary} />
     </Provider>,
-    document.getElementById('roll_up')
+    document.getElementById('roll_up'),
+    {
+      legacyReactDomRender: true,
+    }
   );
 }

--- a/apps/src/sites/studio/pages/courses/vocab.js
+++ b/apps/src/sites/studio/pages/courses/vocab.js
@@ -19,6 +19,9 @@ function initPage() {
     <Provider store={store}>
       <CourseRollup objectToRollUp={'Vocabulary'} course={courseSummary} />
     </Provider>,
-    document.getElementById('roll_up')
+    document.getElementById('roll_up'),
+    {
+      legacyReactDomRender: true,
+    }
   );
 }

--- a/apps/src/sites/studio/pages/curriculum_catalog/index.js
+++ b/apps/src/sites/studio/pages/curriculum_catalog/index.js
@@ -45,7 +45,10 @@ $(document).ready(function () {
         curriculaTaught={curriculaTaught}
       />
     </Provider>,
-    document.getElementById('curriculum-catalog-container')
+    document.getElementById('curriculum-catalog-container'),
+    {
+      legacyReactDomRender: true,
+    }
   );
   displayDifferentiationChat();
 });

--- a/apps/src/sites/studio/pages/data_docs/edit.js
+++ b/apps/src/sites/studio/pages/data_docs/edit.js
@@ -18,6 +18,9 @@ $(document).ready(() => {
         originalDataDocContent={dataDocContent}
       />
     </Provider>,
-    document.getElementById('edit-data-doc')
+    document.getElementById('edit-data-doc'),
+    {
+      legacyReactDomRender: true,
+    }
   );
 });

--- a/apps/src/sites/studio/pages/data_docs/edit_all.js
+++ b/apps/src/sites/studio/pages/data_docs/edit_all.js
@@ -9,6 +9,9 @@ $(() => {
   const dataDocs = getScriptData('dataDocs');
   createReactRoot(
     <DataDocEditAll dataDocs={dataDocs} />,
-    document.getElementById('edit-all-data-docs')
+    document.getElementById('edit-all-data-docs'),
+    {
+      legacyReactDomRender: true,
+    }
   );
 });

--- a/apps/src/sites/studio/pages/data_docs/index.js
+++ b/apps/src/sites/studio/pages/data_docs/index.js
@@ -8,6 +8,9 @@ $(() => {
   const dataDocs = getScriptData('dataDocs');
   createReactRoot(
     <DataDocIndex dataDocs={dataDocs} />,
-    document.getElementById('see-data-docs')
+    document.getElementById('see-data-docs'),
+    {
+      legacyReactDomRender: true,
+    }
   );
 });

--- a/apps/src/sites/studio/pages/data_docs/new.js
+++ b/apps/src/sites/studio/pages/data_docs/new.js
@@ -12,6 +12,9 @@ $(document).ready(() => {
     <Provider store={store}>
       <NewDataDocForm />
     </Provider>,
-    document.getElementById('form')
+    document.getElementById('form'),
+    {
+      legacyReactDomRender: true,
+    }
   );
 });

--- a/apps/src/sites/studio/pages/data_docs/show.js
+++ b/apps/src/sites/studio/pages/data_docs/show.js
@@ -8,6 +8,9 @@ $(() => {
   const {dataDocName, dataDocContent} = getScriptData('dataDoc');
   createReactRoot(
     <DataDocView dataDocName={dataDocName} dataDocContent={dataDocContent} />,
-    document.getElementById('view-data-doc')
+    document.getElementById('view-data-doc'),
+    {
+      legacyReactDomRender: true,
+    }
   );
 });

--- a/apps/src/sites/studio/pages/datasets/edit_manifest.js
+++ b/apps/src/sites/studio/pages/datasets/edit_manifest.js
@@ -17,7 +17,10 @@ $(document).ready(function () {
     <Provider store={store}>
       <ManifestEditor />
     </Provider>,
-    document.querySelector('.manifest_editor')
+    document.querySelector('.manifest_editor'),
+    {
+      legacyReactDomRender: true,
+    }
   );
   const codeMirrorArea = document.getElementsByTagName('textarea')[0];
   initializeCodeMirror6(codeMirrorArea, 'json', {

--- a/apps/src/sites/studio/pages/datasets/index.js
+++ b/apps/src/sites/studio/pages/datasets/index.js
@@ -9,6 +9,9 @@ $(document).ready(function () {
   const liveDatasets = getScriptData('liveDatasets');
   createReactRoot(
     <DatasetList datasets={datasets} liveDatasets={liveDatasets} />,
-    document.querySelector('.datasets')
+    document.querySelector('.datasets'),
+    {
+      legacyReactDomRender: true,
+    }
   );
 });

--- a/apps/src/sites/studio/pages/datasets/show.js
+++ b/apps/src/sites/studio/pages/datasets/show.js
@@ -32,6 +32,9 @@ $(document).ready(function () {
     <Provider store={store}>
       <Dataset isLive={isLive} />
     </Provider>,
-    document.querySelector('.dataset')
+    document.querySelector('.dataset'),
+    {
+      legacyReactDomRender: true,
+    }
   );
 });

--- a/apps/src/sites/studio/pages/devise/registrations/account_type.js
+++ b/apps/src/sites/studio/pages/devise/registrations/account_type.js
@@ -9,6 +9,9 @@ $(document).ready(() => {
   const isSignedOut = getScriptData('isSignedOut');
   createReactRoot(
     <AccountType isSignedOut={isSignedOut} />,
-    document.getElementById('account-type')
+    document.getElementById('account-type'),
+    {
+      legacyReactDomRender: true,
+    }
   );
 });

--- a/apps/src/sites/studio/pages/devise/registrations/edit.js
+++ b/apps/src/sites/studio/pages/devise/registrations/edit.js
@@ -49,7 +49,10 @@ $(document).ready(() => {
       <Provider store={store}>
         <MigrateToMultiAuth />
       </Provider>,
-      migrateMultiAuthMountPoint
+      migrateMultiAuthMountPoint,
+      {
+        legacyReactDomRender: true,
+      }
     );
   }
 
@@ -59,7 +62,10 @@ $(document).ready(() => {
   if (accountInformationMountPoint) {
     createReactRoot(
       <AccountInformation {...scriptData} />,
-      accountInformationMountPoint
+      accountInformationMountPoint,
+      {
+        legacyReactDomRender: true,
+      }
     );
   }
 
@@ -68,7 +74,10 @@ $(document).ready(() => {
   if (schoolInformationMountPoint) {
     createReactRoot(
       <SchoolInformation {...scriptData} />,
-      schoolInformationMountPoint
+      schoolInformationMountPoint,
+      {
+        legacyReactDomRender: true,
+      }
     );
   }
 
@@ -120,7 +129,10 @@ $(document).ready(() => {
         formId={'lti-sync-settings-form'}
         lmsName={lmsName}
       />,
-      ltiSyncSettingsMountPoint
+      ltiSyncSettingsMountPoint,
+      {
+        legacyReactDomRender: true,
+      }
     );
   }
 
@@ -154,7 +166,10 @@ $(document).ready(() => {
         )}
         usState={lockoutLinkedAccountsMountPoint.getAttribute('data-us-state')}
       />,
-      lockoutLinkedAccountsMountPoint
+      lockoutLinkedAccountsMountPoint,
+      {
+        legacyReactDomRender: true,
+      }
     );
   }
 
@@ -166,7 +181,10 @@ $(document).ready(() => {
       <Provider store={store}>
         <TurnOffAiDiff />
       </Provider>,
-      turnOffAiDiffMountPoint
+      turnOffAiDiffMountPoint,
+      {
+        legacyReactDomRender: true,
+      }
     );
   }
 
@@ -196,7 +214,10 @@ $(document).ready(() => {
         hasStudents={dependentStudentsCount > 0}
         isAdmin={isAdmin}
       />,
-      deleteAccountMountPoint
+      deleteAccountMountPoint,
+      {
+        legacyReactDomRender: true,
+      }
     );
   }
 

--- a/apps/src/sites/studio/pages/devise/registrations/finish_student_account.js
+++ b/apps/src/sites/studio/pages/devise/registrations/finish_student_account.js
@@ -18,6 +18,9 @@ $(document).ready(() => {
       countryCode={countryCode}
       usStateOptions={usStateOptions}
     />,
-    document.getElementById('finish-student-account-root')
+    document.getElementById('finish-student-account-root'),
+    {
+      legacyReactDomRender: true,
+    }
   );
 });

--- a/apps/src/sites/studio/pages/devise/registrations/finish_teacher_account.js
+++ b/apps/src/sites/studio/pages/devise/registrations/finish_teacher_account.js
@@ -15,6 +15,9 @@ $(document).ready(() => {
       countryCode={countryCode}
       redirectUrl={redirectUrl}
     />,
-    document.getElementById('finish-teacher-account-root')
+    document.getElementById('finish-teacher-account-root'),
+    {
+      legacyReactDomRender: true,
+    }
   );
 });

--- a/apps/src/sites/studio/pages/devise/registrations/login_type.js
+++ b/apps/src/sites/studio/pages/devise/registrations/login_type.js
@@ -13,6 +13,9 @@ $(document).ready(() => {
       isSignedOut={isSignedOut}
       passwordMinLength={passwordMinLength}
     />,
-    document.getElementById('login-type-selection')
+    document.getElementById('login-type-selection'),
+    {
+      legacyReactDomRender: true,
+    }
   );
 });

--- a/apps/src/sites/studio/pages/devise/registrations/personalization_information.js
+++ b/apps/src/sites/studio/pages/devise/registrations/personalization_information.js
@@ -6,6 +6,9 @@ import {createReactRoot} from '@cdo/apps/util/createReactRoot';
 $(document).ready(() => {
   createReactRoot(
     <PersonalizationCollectorContainer />,
-    document.getElementById('personalization-information')
+    document.getElementById('personalization-information'),
+    {
+      legacyReactDomRender: true,
+    }
   );
 });

--- a/apps/src/sites/studio/pages/foorm/forms/editor.js
+++ b/apps/src/sites/studio/pages/foorm/forms/editor.js
@@ -33,7 +33,10 @@ $(document).ready(function () {
         categories={scriptData.formCategories}
       />
     </Provider>,
-    document.getElementById('editor-container')
+    document.getElementById('editor-container'),
+    {
+      legacyReactDomRender: true,
+    }
   );
 });
 

--- a/apps/src/sites/studio/pages/foorm/libraries/editor.js
+++ b/apps/src/sites/studio/pages/foorm/libraries/editor.js
@@ -33,7 +33,10 @@ $(document).ready(function () {
         categories={scriptData.libraryCategories}
       />
     </Provider>,
-    document.getElementById('editor-container')
+    document.getElementById('editor-container'),
+    {
+      legacyReactDomRender: true,
+    }
   );
 });
 

--- a/apps/src/sites/studio/pages/foorm/preview/index.js
+++ b/apps/src/sites/studio/pages/foorm/preview/index.js
@@ -7,6 +7,9 @@ import getScriptData from '@cdo/apps/util/getScriptData';
 document.addEventListener('DOMContentLoaded', function (event) {
   createReactRoot(
     <FoormPreviewIndex {...getScriptData('props')} />,
-    document.getElementById('application-container')
+    document.getElementById('application-container'),
+    {
+      legacyReactDomRender: true,
+    }
   );
 });

--- a/apps/src/sites/studio/pages/foorm/preview/name.js
+++ b/apps/src/sites/studio/pages/foorm/preview/name.js
@@ -9,6 +9,9 @@ import 'survey-react/survey.css';
 document.addEventListener('DOMContentLoaded', function (event) {
   createReactRoot(
     <Foorm {...getScriptData('props')} />,
-    document.getElementById('application-container')
+    document.getElementById('application-container'),
+    {
+      legacyReactDomRender: true,
+    }
   );
 });

--- a/apps/src/sites/studio/pages/foorm/simple_survey_forms/show.js
+++ b/apps/src/sites/studio/pages/foorm/simple_survey_forms/show.js
@@ -9,6 +9,9 @@ import 'survey-react/survey.css';
 document.addEventListener('DOMContentLoaded', function (event) {
   createReactRoot(
     <Foorm {...getScriptData('props')} />,
-    document.getElementById('application-container')
+    document.getElementById('application-container'),
+    {
+      legacyReactDomRender: true,
+    }
   );
 });

--- a/apps/src/sites/studio/pages/gates/logged_out.js
+++ b/apps/src/sites/studio/pages/gates/logged_out.js
@@ -6,6 +6,9 @@ import {createReactRoot} from '@cdo/apps/util/createReactRoot';
 document.addEventListener('DOMContentLoaded', function () {
   createReactRoot(
     <LinkAccountPage />,
-    document.getElementById('logged-out-page')
+    document.getElementById('logged-out-page'),
+    {
+      legacyReactDomRender: true,
+    }
   );
 });

--- a/apps/src/sites/studio/pages/gates/teacher_account_required.js
+++ b/apps/src/sites/studio/pages/gates/teacher_account_required.js
@@ -6,6 +6,9 @@ import {createReactRoot} from '@cdo/apps/util/createReactRoot';
 document.addEventListener('DOMContentLoaded', function () {
   createReactRoot(
     <TeacherAccountRequiredPage />,
-    document.getElementById('teacher-account-required-page')
+    document.getElementById('teacher-account-required-page'),
+    {
+      legacyReactDomRender: true,
+    }
   );
 });

--- a/apps/src/sites/studio/pages/home/_homepage.js
+++ b/apps/src/sites/studio/pages/home/_homepage.js
@@ -46,6 +46,9 @@ function showHomepage() {
         />
       </div>
     </Provider>,
-    document.getElementById('homepage-container')
+    document.getElementById('homepage-container'),
+    {
+      legacyReactDomRender: true,
+    }
   );
 }

--- a/apps/src/sites/studio/pages/images/new.js
+++ b/apps/src/sites/studio/pages/images/new.js
@@ -4,5 +4,7 @@ import UploadImageForm from '@cdo/apps/levelbuilder/lesson-editor/UploadImageFor
 import {createReactRoot} from '@cdo/apps/util/createReactRoot';
 
 $(document).ready(() => {
-  createReactRoot(<UploadImageForm />, document.getElementById('form'));
+  createReactRoot(<UploadImageForm />, document.getElementById('form'), {
+    legacyReactDomRender: true,
+  });
 });

--- a/apps/src/sites/studio/pages/jit_pl_concepts/edit.js
+++ b/apps/src/sites/studio/pages/jit_pl_concepts/edit.js
@@ -29,6 +29,9 @@ $(document).ready(() => {
         originalMisconceptions={misconceptions || []}
       />
     </Provider>,
-    document.getElementById('edit-jit-pl-concept')
+    document.getElementById('edit-jit-pl-concept'),
+    {
+      legacyReactDomRender: true,
+    }
   );
 });

--- a/apps/src/sites/studio/pages/jit_pl_concepts/edit_all.js
+++ b/apps/src/sites/studio/pages/jit_pl_concepts/edit_all.js
@@ -9,6 +9,9 @@ $(() => {
 
   createReactRoot(
     <JitPlConceptEditAll jitPlConcepts={jitPlConcepts} />,
-    document.getElementById('edit-all-jit-pl-concepts')
+    document.getElementById('edit-all-jit-pl-concepts'),
+    {
+      legacyReactDomRender: true,
+    }
   );
 });

--- a/apps/src/sites/studio/pages/jit_pl_concepts/new.js
+++ b/apps/src/sites/studio/pages/jit_pl_concepts/new.js
@@ -12,6 +12,9 @@ $(document).ready(() => {
     <Provider store={store}>
       <NewJitPlConceptForm />
     </Provider>,
-    document.getElementById('new-jit-pl-concept-form')
+    document.getElementById('new-jit-pl-concept-form'),
+    {
+      legacyReactDomRender: true,
+    }
   );
 });

--- a/apps/src/sites/studio/pages/layouts/_initial_section_creation_interstitial.js
+++ b/apps/src/sites/studio/pages/layouts/_initial_section_creation_interstitial.js
@@ -23,6 +23,9 @@ document.addEventListener('DOMContentLoaded', () => {
     <Provider store={store}>
       <InitialSectionCreationInterstitial />
     </Provider>,
-    mountPoint
+    mountPoint,
+    {
+      legacyReactDomRender: true,
+    }
   );
 });

--- a/apps/src/sites/studio/pages/layouts/_school_info_confirmation_dialog.js
+++ b/apps/src/sites/studio/pages/layouts/_school_info_confirmation_dialog.js
@@ -24,6 +24,9 @@ document.addEventListener('DOMContentLoaded', () => {
 
   createReactRoot(
     <SchoolInfoConfirmationDialog scriptData={scriptData} onClose={unmount} />,
-    mountPoint
+    mountPoint,
+    {
+      legacyReactDomRender: true,
+    }
   );
 });

--- a/apps/src/sites/studio/pages/layouts/_school_info_interstitial.js
+++ b/apps/src/sites/studio/pages/layouts/_school_info_interstitial.js
@@ -24,6 +24,9 @@ document.addEventListener('DOMContentLoaded', () => {
 
   createReactRoot(
     <SchoolInfoInterstitial scriptData={scriptData} onClose={unmount} />,
-    mountPoint
+    mountPoint,
+    {
+      legacyReactDomRender: true,
+    }
   );
 });

--- a/apps/src/sites/studio/pages/layouts/_section_creation_celebration_dialog.js
+++ b/apps/src/sites/studio/pages/layouts/_section_creation_celebration_dialog.js
@@ -9,5 +9,7 @@ document.addEventListener('DOMContentLoaded', () => {
   document.body.appendChild(mountPoint);
 
   updateQueryParam('showSectionCreationDialog', undefined, true);
-  createReactRoot(<SectionCreationCelebrationDialog />, mountPoint);
+  createReactRoot(<SectionCreationCelebrationDialog />, mountPoint, {
+    legacyReactDomRender: true,
+  });
 });

--- a/apps/src/sites/studio/pages/layouts/_small_footer.js
+++ b/apps/src/sites/studio/pages/layouts/_small_footer.js
@@ -8,5 +8,8 @@ import getScriptData from '@cdo/apps/util/getScriptData';
 // the DOM immediately after the necessary #page-small-footer markup.
 createReactRoot(
   <SmallFooter {...getScriptData('smallfooter')} />,
-  document.getElementById('page-small-footer')
+  document.getElementById('page-small-footer'),
+  {
+    legacyReactDomRender: true,
+  }
 );

--- a/apps/src/sites/studio/pages/lessons/edit.js
+++ b/apps/src/sites/studio/pages/lessons/edit.js
@@ -75,6 +75,9 @@ $(document).ready(function () {
         <ExpandableImageDialog />
       </div>
     </Provider>,
-    document.getElementById('edit-container')
+    document.getElementById('edit-container'),
+    {
+      legacyReactDomRender: true,
+    }
   );
 });

--- a/apps/src/sites/studio/pages/lessons/practice.js
+++ b/apps/src/sites/studio/pages/lessons/practice.js
@@ -12,6 +12,9 @@ $(document).ready(() => {
     <Provider store={getStore()}>
       <LessonPractice lessonPracticeData={lessonPracticeData} />
     </Provider>,
-    document.getElementById('lesson-practice-container')
+    document.getElementById('lesson-practice-container'),
+    {
+      legacyReactDomRender: true,
+    }
   );
 });

--- a/apps/src/sites/studio/pages/lessons/show.js
+++ b/apps/src/sites/studio/pages/lessons/show.js
@@ -110,7 +110,10 @@ function displayLessonOverview() {
     <Provider store={store}>
       <LessonOverview lesson={lessonData} activities={activities} />
     </Provider>,
-    document.getElementById('show-container')
+    document.getElementById('show-container'),
+    {
+      legacyReactDomRender: true,
+    }
   );
 }
 
@@ -130,7 +133,10 @@ function prepareExpandableImageDialog() {
     <Provider store={getStore()}>
       <ExpandableImageDialog />
     </Provider>,
-    container
+    container,
+    {
+      legacyReactDomRender: true,
+    }
   );
 }
 
@@ -153,7 +159,10 @@ function displayDifferentiationChat() {
           scriptName={lessonName}
         />
       </Provider>,
-      aiDiffFabMountPoint
+      aiDiffFabMountPoint,
+      {
+        legacyReactDomRender: true,
+      }
     );
   }
 }
@@ -173,7 +182,10 @@ const renderCopyLessonButton = () => {
         lessonName={lessonName}
         buttonText="Copy"
       />,
-      element
+      element,
+      {
+        legacyReactDomRender: true,
+      }
     );
   }
 };

--- a/apps/src/sites/studio/pages/lessons/student_lesson_plan.js
+++ b/apps/src/sites/studio/pages/lessons/student_lesson_plan.js
@@ -40,7 +40,10 @@ async function displayLessonOverview() {
     <Provider store={store}>
       <StudentLessonOverview lesson={lessonData} />
     </Provider>,
-    document.getElementById('show-container')
+    document.getElementById('show-container'),
+    {
+      legacyReactDomRender: true,
+    }
   );
 }
 
@@ -60,6 +63,9 @@ function prepareExpandableImageDialog() {
     <Provider store={getStore()}>
       <ExpandableImageDialog />
     </Provider>,
-    container
+    container,
+    {
+      legacyReactDomRender: true,
+    }
   );
 }

--- a/apps/src/sites/studio/pages/levels-lab2-main.js
+++ b/apps/src/sites/studio/pages/levels-lab2-main.js
@@ -5,5 +5,7 @@ import Lab2 from '@cdo/apps/lab2/views/Lab2';
 import {createReactRoot} from '@cdo/apps/util/createReactRoot';
 
 $(document).ready(function () {
-  createReactRoot(<Lab2 />, document.getElementById('lab2-container'));
+  createReactRoot(<Lab2 />, document.getElementById('lab2-container'), {
+    legacyReactDomRender: true,
+  });
 });

--- a/apps/src/sites/studio/pages/levels/_bubble_choice.js
+++ b/apps/src/sites/studio/pages/levels/_bubble_choice.js
@@ -18,5 +18,8 @@ reportTeacherReviewingStudentNonLabLevel();
 
 createReactRoot(
   <BubbleChoice level={level} />,
-  document.querySelector('#bubble-choice')
+  document.querySelector('#bubble-choice'),
+  {
+    legacyReactDomRender: true,
+  }
 );

--- a/apps/src/sites/studio/pages/levels/_contract_match.js
+++ b/apps/src/sites/studio/pages/levels/_contract_match.js
@@ -318,7 +318,10 @@ $(window).load(function () {
         contractForm = instance;
       }}
     />,
-    document.getElementById('contractForm')
+    document.getElementById('contractForm'),
+    {
+      legacyReactDomRender: true,
+    }
   );
 
   /**

--- a/apps/src/sites/studio/pages/levels/_curriculum_reference.js
+++ b/apps/src/sites/studio/pages/levels/_curriculum_reference.js
@@ -23,7 +23,10 @@ $(document).ready(() => {
         <h1>{referenceGuide.display_name}</h1>
         <ReferenceGuide referenceGuide={referenceGuide} />
       </>,
-      refGuideElement
+      refGuideElement,
+      {
+        legacyReactDomRender: true,
+      }
     );
   }
 

--- a/apps/src/sites/studio/pages/levels/_free_response.js
+++ b/apps/src/sites/studio/pages/levels/_free_response.js
@@ -24,7 +24,10 @@ $(document).ready(() => {
           <SummaryEntryPoint scriptData={scriptData} />
         </InstructorsOnly>
       </Provider>,
-      container
+      container,
+      {
+        legacyReactDomRender: true,
+      }
     );
   });
 
@@ -36,7 +39,10 @@ $(document).ready(() => {
 
     createReactRoot(
       React.createElement(SafeMarkdown, container.dataset, null),
-      container
+      container,
+      {
+        legacyReactDomRender: true,
+      }
     );
   });
 
@@ -56,7 +62,10 @@ $(document).ready(() => {
         showUnderageWarning={!appOptions.is13Plus}
         {...attachmentsProps}
       />,
-      attachmentsMountPoint
+      attachmentsMountPoint,
+      {
+        legacyReactDomRender: true,
+      }
     );
   }
 });

--- a/apps/src/sites/studio/pages/levels/_level_group.js
+++ b/apps/src/sites/studio/pages/levels/_level_group.js
@@ -43,7 +43,10 @@ $(document).ready(() => {
             <SummaryEntryPoint scriptData={getScriptData('summaryinfo')} />
           </InstructorsOnly>
         </Provider>,
-        container
+        container,
+        {
+          legacyReactDomRender: true,
+        }
       );
     });
   }

--- a/apps/src/sites/studio/pages/levels/_single_multi.js
+++ b/apps/src/sites/studio/pages/levels/_single_multi.js
@@ -19,7 +19,10 @@ $(document).ready(() => {
           <SummaryEntryPoint scriptData={getScriptData('summaryinfo')} />
         </InstructorsOnly>
       </Provider>,
-      container
+      container,
+      {
+        legacyReactDomRender: true,
+      }
     );
   });
 });

--- a/apps/src/sites/studio/pages/levels/_summary.js
+++ b/apps/src/sites/studio/pages/levels/_summary.js
@@ -23,7 +23,10 @@ $(document).ready(() => {
         <SummaryTopLinks scriptData={scriptData} />
       </InstructorsOnly>
     </Provider>,
-    document.getElementById('summary-top-links')
+    document.getElementById('summary-top-links'),
+    {
+      legacyReactDomRender: true,
+    }
   );
 
   createReactRoot(
@@ -32,7 +35,10 @@ $(document).ready(() => {
       scriptData={scriptData}
       isLevelGroup={isLevelGroup}
     />,
-    document.getElementById('summary-responses')
+    document.getElementById('summary-responses'),
+    {
+      legacyReactDomRender: true,
+    }
   );
 
   // Predict levels are a lab2 feature that replace contained levels.
@@ -48,7 +54,10 @@ $(document).ready(() => {
           question={scriptData.levels[0].properties.long_instructions}
           predictSettings={scriptData.levels[0].properties.predict_settings}
         />,
-        predictQuestionContainer
+        predictQuestionContainer,
+        {
+          legacyReactDomRender: true,
+        }
       );
     }
 
@@ -57,7 +66,10 @@ $(document).ready(() => {
         <UnconnectedPredictSolution
           predictSettings={scriptData.levels[0].properties.predict_settings}
         />,
-        correctAnswerContainer
+        correctAnswerContainer,
+        {
+          legacyReactDomRender: true,
+        }
       );
     }
   }

--- a/apps/src/sites/studio/pages/levels/_teacher_panel.js
+++ b/apps/src/sites/studio/pages/levels/_teacher_panel.js
@@ -69,6 +69,9 @@ function renderTeacherContentToggle(store) {
         <TeacherContentToggle isBlocklyOrDroplet={isBlocklyOrDroplet} />
       </InstructorsOnly>
     </Provider>,
-    element
+    element,
+    {
+      legacyReactDomRender: true,
+    }
   );
 }

--- a/apps/src/sites/studio/pages/levels/editors/_applab.js
+++ b/apps/src/sites/studio/pages/levels/editors/_applab.js
@@ -144,6 +144,9 @@ $(document).ready(function () {
     <DataLibrary />,
     $('<div></div>')
       .insertAfter(`label[for="level_data_library_tables"]`)
-      .get(0)
+      .get(0),
+    {
+      legacyReactDomRender: true,
+    }
   );
 });

--- a/apps/src/sites/studio/pages/levels/editors/_navigation_sidebar.js
+++ b/apps/src/sites/studio/pages/levels/editors/_navigation_sidebar.js
@@ -6,6 +6,8 @@ import {createReactRoot} from '@cdo/apps/util/createReactRoot';
 document.addEventListener('DOMContentLoaded', () => {
   const mountPoint = document.getElementById('table-of-contents-mount-point');
   if (mountPoint) {
-    createReactRoot(<NavigationSidebar />, mountPoint);
+    createReactRoot(<NavigationSidebar />, mountPoint, {
+      legacyReactDomRender: true,
+    });
   }
 });

--- a/apps/src/sites/studio/pages/levels/editors/fields/_ai_tutor_prompt_settings.js
+++ b/apps/src/sites/studio/pages/levels/editors/fields/_ai_tutor_prompt_settings.js
@@ -15,6 +15,9 @@ $(document).ready(function () {
       promptSettings={promptSettings}
       legacyMode={legacyMode}
     />,
-    document.getElementById('ai-tutor-prompt-settings-editor')
+    document.getElementById('ai-tutor-prompt-settings-editor'),
+    {
+      legacyReactDomRender: true,
+    }
   );
 });

--- a/apps/src/sites/studio/pages/levels/editors/fields/_aichat_settings.js
+++ b/apps/src/sites/studio/pages/levels/editors/fields/_aichat_settings.js
@@ -10,6 +10,9 @@ $(document).ready(function () {
 
   createReactRoot(
     <EditAichatSettings initialSettings={initialSettings} />,
-    document.getElementById('aichat-settings-editor')
+    document.getElementById('aichat-settings-editor'),
+    {
+      legacyReactDomRender: true,
+    }
   );
 });

--- a/apps/src/sites/studio/pages/levels/editors/fields/_bubble_choice_sublevel.js
+++ b/apps/src/sites/studio/pages/levels/editors/fields/_bubble_choice_sublevel.js
@@ -13,6 +13,9 @@ $(document).ready(function () {
       initialImageUrl={imageUrlInput.val()}
       showPreview
     />,
-    $('#upload-image-button').get(0)
+    $('#upload-image-button').get(0),
+    {
+      legacyReactDomRender: true,
+    }
   );
 });

--- a/apps/src/sites/studio/pages/levels/editors/fields/_child_level_bubble_choice_fields.js
+++ b/apps/src/sites/studio/pages/levels/editors/fields/_child_level_bubble_choice_fields.js
@@ -10,6 +10,9 @@ $(document).ready(function () {
 
   createReactRoot(
     <EditChildLevelSettings initialChildLevelSettings={childLevels} />,
-    document.getElementById('child-level-bubble-choice-editor')
+    document.getElementById('child-level-bubble-choice-editor'),
+    {
+      legacyReactDomRender: true,
+    }
   );
 });

--- a/apps/src/sites/studio/pages/levels/editors/fields/_droplet.js
+++ b/apps/src/sites/studio/pages/levels/editors/fields/_droplet.js
@@ -37,6 +37,9 @@ if (data.original_palette && !fieldConfig.codeFunctions.hideWhen) {
     />,
     $('<div></div>')
       .insertAfter(`label[for="${fieldConfig.codeFunctions.codemirror}"]`)
-      .get(0)
+      .get(0),
+    {
+      legacyReactDomRender: true,
+    }
   );
 }

--- a/apps/src/sites/studio/pages/levels/editors/fields/_exemplar.js
+++ b/apps/src/sites/studio/pages/levels/editors/fields/_exemplar.js
@@ -19,6 +19,9 @@ $(document).ready(function () {
         initialExemplarSettings={exemplarSettings}
       />
     </div>,
-    document.getElementById('exemplar-settings-editor')
+    document.getElementById('exemplar-settings-editor'),
+    {
+      legacyReactDomRender: true,
+    }
   );
 });

--- a/apps/src/sites/studio/pages/levels/editors/fields/_music_level_data.js
+++ b/apps/src/sites/studio/pages/levels/editors/fields/_music_level_data.js
@@ -9,6 +9,9 @@ $(document).ready(function () {
   const initialLevelData = getScriptData('musicleveldata');
   createReactRoot(
     <EditMusicLevelData initialLevelData={initialLevelData} />,
-    document.getElementById('music-level-data-editor')
+    document.getElementById('music-level-data-editor'),
+    {
+      legacyReactDomRender: true,
+    }
   );
 });

--- a/apps/src/sites/studio/pages/levels/editors/fields/_navigation_sidebar.js
+++ b/apps/src/sites/studio/pages/levels/editors/fields/_navigation_sidebar.js
@@ -6,6 +6,8 @@ import {createReactRoot} from '@cdo/apps/util/createReactRoot';
 document.addEventListener('DOMContentLoaded', () => {
   const mountPoint = document.getElementById('table-of-contents-mount-point');
   if (mountPoint) {
-    createReactRoot(<NavigationSidebar />, mountPoint);
+    createReactRoot(<NavigationSidebar />, mountPoint, {
+      legacyReactDomRender: true,
+    });
   }
 });

--- a/apps/src/sites/studio/pages/levels/editors/fields/_neighborhood_settings.js
+++ b/apps/src/sites/studio/pages/levels/editors/fields/_neighborhood_settings.js
@@ -10,6 +10,9 @@ $(document).ready(function () {
 
   createReactRoot(
     <EditNeighborhoodSettings initialMaze={initialMaze} />,
-    document.getElementById('neighborhood-settings-editor')
+    document.getElementById('neighborhood-settings-editor'),
+    {
+      legacyReactDomRender: true,
+    }
   );
 });

--- a/apps/src/sites/studio/pages/levels/editors/fields/_panels.js
+++ b/apps/src/sites/studio/pages/levels/editors/fields/_panels.js
@@ -12,6 +12,9 @@ $(document).ready(function () {
 
   createReactRoot(
     <EditPanels initialPanels={initialPanels} levelName={levelName} />,
-    document.getElementById('panels-editor')
+    document.getElementById('panels-editor'),
+    {
+      legacyReactDomRender: true,
+    }
   );
 });

--- a/apps/src/sites/studio/pages/levels/editors/fields/_predict_settings.js
+++ b/apps/src/sites/studio/pages/levels/editors/fields/_predict_settings.js
@@ -10,6 +10,9 @@ $(document).ready(function () {
 
   createReactRoot(
     <EditPredictSettings initialSettings={initialSettings} />,
-    document.getElementById('predict-settings-editor')
+    document.getElementById('predict-settings-editor'),
+    {
+      legacyReactDomRender: true,
+    }
   );
 });

--- a/apps/src/sites/studio/pages/levels/editors/fields/_product_tour_settings.js
+++ b/apps/src/sites/studio/pages/levels/editors/fields/_product_tour_settings.js
@@ -14,6 +14,9 @@ $(document).ready(function () {
       initialSettings={initialSettings}
       appName={appName}
     />,
-    document.getElementById('product-tour-settings-editor')
+    document.getElementById('product-tour-settings-editor'),
+    {
+      legacyReactDomRender: true,
+    }
   );
 });

--- a/apps/src/sites/studio/pages/levels/editors/fields/_skill_evaluations.js
+++ b/apps/src/sites/studio/pages/levels/editors/fields/_skill_evaluations.js
@@ -22,6 +22,9 @@ $(document).ready(function () {
         aiPromptModificationInput.val(newInstructions)
       }
     />,
-    document.getElementById('skill-evaluation-settings-editor')
+    document.getElementById('skill-evaluation-settings-editor'),
+    {
+      legacyReactDomRender: true,
+    }
   );
 });

--- a/apps/src/sites/studio/pages/levels/editors/fields/_starter_assets.js
+++ b/apps/src/sites/studio/pages/levels/editors/fields/_starter_assets.js
@@ -10,6 +10,9 @@ $(document).ready(function () {
 
   createReactRoot(
     <EditStarterAssets levelName={levelName} />,
-    document.getElementById('starter-assets-editor')
+    document.getElementById('starter-assets-editor'),
+    {
+      legacyReactDomRender: true,
+    }
   );
 });

--- a/apps/src/sites/studio/pages/levels/editors/fields/_validations.js
+++ b/apps/src/sites/studio/pages/levels/editors/fields/_validations.js
@@ -18,6 +18,9 @@ $(document).ready(function () {
       levelName={levelName}
       appName={appName}
     />,
-    document.getElementById('validations-editor')
+    document.getElementById('validations-editor'),
+    {
+      legacyReactDomRender: true,
+    }
   );
 });

--- a/apps/src/sites/studio/pages/levels/editors/fields/_widget2.js
+++ b/apps/src/sites/studio/pages/levels/editors/fields/_widget2.js
@@ -10,6 +10,9 @@ $(document).ready(function () {
   const widget2Ids = getScriptData('widget2ids') || [];
   createReactRoot(
     <EditWidget2 initialValue={initialValue} widget2Ids={widget2Ids} />,
-    document.getElementById('widget2_editor')
+    document.getElementById('widget2_editor'),
+    {
+      legacyReactDomRender: true,
+    }
   );
 });

--- a/apps/src/sites/studio/pages/levels/show.js
+++ b/apps/src/sites/studio/pages/levels/show.js
@@ -46,7 +46,10 @@ function initPage() {
         scriptName={config.script_name}
         courseName={config.course_name}
       />,
-      redirectDialogMountPoint
+      redirectDialogMountPoint,
+      {
+        legacyReactDomRender: true,
+      }
     );
   }
 
@@ -79,7 +82,10 @@ function initPage() {
             canDefaultOpen={false}
           />
         </Provider>,
-        aiDiffFabMountPoint
+        aiDiffFabMountPoint,
+        {
+          legacyReactDomRender: true,
+        }
       );
     }
   };
@@ -129,7 +135,10 @@ function initPage() {
             levelType={levelType}
           />
         </Provider>,
-        rubricFabMountPoint
+        rubricFabMountPoint,
+        {
+          legacyReactDomRender: true,
+        }
       );
     } else {
       renderAiDiffButton();

--- a/apps/src/sites/studio/pages/lti/v1/account_linking/landing.js
+++ b/apps/src/sites/studio/pages/lti/v1/account_linking/landing.js
@@ -40,6 +40,9 @@ document.addEventListener('DOMContentLoaded', () => {
     <LtiProviderContext.Provider value={ltiProviderContext}>
       <LtiLinkAccountPage />
     </LtiProviderContext.Provider>,
-    mountPoint
+    mountPoint,
+    {
+      legacyReactDomRender: true,
+    }
   );
 });

--- a/apps/src/sites/studio/pages/lti/v1/dynamic_registration.js
+++ b/apps/src/sites/studio/pages/lti/v1/dynamic_registration.js
@@ -22,6 +22,9 @@ document.addEventListener('DOMContentLoaded', () => {
       registrationID={registrationID}
       lmsName={lmsName}
     />,
-    mountPoint
+    mountPoint,
+    {
+      legacyReactDomRender: true,
+    }
   );
 });

--- a/apps/src/sites/studio/pages/lti/v1/iframe.js
+++ b/apps/src/sites/studio/pages/lti/v1/iframe.js
@@ -24,6 +24,9 @@ document.addEventListener('DOMContentLoaded', () => {
 
   createReactRoot(
     <LtiIframePage logoUrl={logoUrl} authUrl={authUrl} />,
-    mountPoint
+    mountPoint,
+    {
+      legacyReactDomRender: true,
+    }
   );
 });

--- a/apps/src/sites/studio/pages/lti/v1/sync_course.js
+++ b/apps/src/sites/studio/pages/lti/v1/sync_course.js
@@ -31,6 +31,9 @@ document.addEventListener('DOMContentLoaded', () => {
       disableRosterSyncButtonEnabled
       lmsName={lmsName}
     />,
-    mountPoint
+    mountPoint,
+    {
+      legacyReactDomRender: true,
+    }
   );
 });

--- a/apps/src/sites/studio/pages/lti/v1/upgrade_account.js
+++ b/apps/src/sites/studio/pages/lti/v1/upgrade_account.js
@@ -23,6 +23,9 @@ document.addEventListener('DOMContentLoaded', () => {
 
   createReactRoot(
     <LtiUpgradeAccountDialog isOpen formData={formData} onClose={onClose} />,
-    mountPoint
+    mountPoint,
+    {
+      legacyReactDomRender: true,
+    }
   );
 });

--- a/apps/src/sites/studio/pages/maker/setup.js
+++ b/apps/src/sites/studio/pages/maker/setup.js
@@ -10,6 +10,9 @@ $(function () {
     <Provider store={getStore()}>
       <SetupGuide />
     </Provider>,
-    document.getElementById('maker-setup')
+    document.getElementById('maker-setup'),
+    {
+      legacyReactDomRender: true,
+    }
   );
 });

--- a/apps/src/sites/studio/pages/musiclab/embed.js
+++ b/apps/src/sites/studio/pages/musiclab/embed.js
@@ -15,6 +15,9 @@ $(document).ready(function () {
     <Provider store={getStore()}>
       <MiniMusicPlayer projects={projects} libraryName="launch2024" />
     </Provider>,
-    document.getElementById('musiclab-container')
+    document.getElementById('musiclab-container'),
+    {
+      legacyReactDomRender: true,
+    }
   );
 });

--- a/apps/src/sites/studio/pages/musiclab/gallery.js
+++ b/apps/src/sites/studio/pages/musiclab/gallery.js
@@ -11,6 +11,9 @@ $(document).ready(function () {
 
   createReactRoot(
     <MiniMusicPlayer projects={channelIds} libraryName="launch2024" />,
-    document.getElementById('musiclab-container')
+    document.getElementById('musiclab-container'),
+    {
+      legacyReactDomRender: true,
+    }
   );
 });

--- a/apps/src/sites/studio/pages/musiclab/menu.js
+++ b/apps/src/sites/studio/pages/musiclab/menu.js
@@ -7,6 +7,9 @@ import {createReactRoot} from '@cdo/apps/util/createReactRoot';
 $(document).ready(function () {
   createReactRoot(
     <MusicMenu />,
-    document.getElementById('musiclab-menu-container')
+    document.getElementById('musiclab-menu-container'),
+    {
+      legacyReactDomRender: true,
+    }
   );
 });

--- a/apps/src/sites/studio/pages/pd/application/principal_approval_application/new.js
+++ b/apps/src/sites/studio/pages/pd/application/principal_approval_application/new.js
@@ -7,6 +7,9 @@ import getScriptData from '@cdo/apps/util/getScriptData';
 document.addEventListener('DOMContentLoaded', function (event) {
   createReactRoot(
     <PrincipalApprovalApplication {...getScriptData('props')} />,
-    document.getElementById('application-container')
+    document.getElementById('application-container'),
+    {
+      legacyReactDomRender: true,
+    }
   );
 });

--- a/apps/src/sites/studio/pages/pd/application/teacher_application/new.js
+++ b/apps/src/sites/studio/pages/pd/application/teacher_application/new.js
@@ -7,6 +7,9 @@ import getScriptData from '@cdo/apps/util/getScriptData';
 document.addEventListener('DOMContentLoaded', function (event) {
   createReactRoot(
     <TeacherApplication {...getScriptData('props')} />,
-    document.getElementById('application-container')
+    document.getElementById('application-container'),
+    {
+      legacyReactDomRender: true,
+    }
   );
 });

--- a/apps/src/sites/studio/pages/pd/application_dashboard/index.js
+++ b/apps/src/sites/studio/pages/pd/application_dashboard/index.js
@@ -7,6 +7,9 @@ import getScriptData from '@cdo/apps/util/getScriptData';
 document.addEventListener('DOMContentLoaded', function () {
   createReactRoot(
     <ApplicationDashboard {...getScriptData('props')} />,
-    document.getElementById('application-container')
+    document.getElementById('application-container'),
+    {
+      legacyReactDomRender: true,
+    }
   );
 });

--- a/apps/src/sites/studio/pages/pd/international_opt_in/new.js
+++ b/apps/src/sites/studio/pages/pd/international_opt_in/new.js
@@ -7,6 +7,9 @@ import getScriptData from '@cdo/apps/util/getScriptData';
 document.addEventListener('DOMContentLoaded', function (event) {
   createReactRoot(
     <InternationalOptIn {...getScriptData('props')} />,
-    document.getElementById('application-container')
+    document.getElementById('application-container'),
+    {
+      legacyReactDomRender: true,
+    }
   );
 });

--- a/apps/src/sites/studio/pages/pd/pre_workshop_survey/new.js
+++ b/apps/src/sites/studio/pages/pd/pre_workshop_survey/new.js
@@ -7,6 +7,9 @@ import getScriptData from '@cdo/apps/util/getScriptData';
 document.addEventListener('DOMContentLoaded', function (event) {
   createReactRoot(
     <PreWorkshopSurvey {...getScriptData('props')} />,
-    document.getElementById('application-container')
+    document.getElementById('application-container'),
+    {
+      legacyReactDomRender: true,
+    }
   );
 });

--- a/apps/src/sites/studio/pages/pd/professional_learning/index.js
+++ b/apps/src/sites/studio/pages/pd/professional_learning/index.js
@@ -33,7 +33,10 @@ $(() => {
         coursesAsFacilitator={landingPageData['courses_as_facilitator']}
       />
     </Provider>,
-    document.getElementById('pl-landing-page-container')
+    document.getElementById('pl-landing-page-container'),
+    {
+      legacyReactDomRender: true,
+    }
   );
   displayDifferentiationChat();
 });

--- a/apps/src/sites/studio/pages/pd/professional_learning/regional_workshop_catalog.js
+++ b/apps/src/sites/studio/pages/pd/professional_learning/regional_workshop_catalog.js
@@ -13,6 +13,9 @@ $(() => {
       nationalWorkshops={nationalWorkshops}
       zipFromSchoolInfo={zipFromSchoolInfo}
     />,
-    document.getElementById('regional-workshop-catalog')
+    document.getElementById('regional-workshop-catalog'),
+    {
+      legacyReactDomRender: true,
+    }
   );
 });

--- a/apps/src/sites/studio/pages/pd/professional_learning/self_paced_pl_catalog.js
+++ b/apps/src/sites/studio/pages/pd/professional_learning/self_paced_pl_catalog.js
@@ -16,6 +16,9 @@ $(() => {
       selfPacedPLCourseOfferings={selfPacedPLCourseOfferings}
       studentsCourseOfferings={studentsCourseOfferings}
     />,
-    document.getElementById('self-paced-pl-catalog')
+    document.getElementById('self-paced-pl-catalog'),
+    {
+      legacyReactDomRender: true,
+    }
   );
 });

--- a/apps/src/sites/studio/pages/pd/professional_learning/workshops/index.js
+++ b/apps/src/sites/studio/pages/pd/professional_learning/workshops/index.js
@@ -23,6 +23,9 @@ document.addEventListener('DOMContentLoaded', function () {
       {...userInfoParams}
       userEnrollment={userEnrollmentParams}
     />,
-    document.getElementById('workshop-container')
+    document.getElementById('workshop-container'),
+    {
+      legacyReactDomRender: true,
+    }
   );
 });

--- a/apps/src/sites/studio/pages/pd/regional_partner_mini_contact/new.js
+++ b/apps/src/sites/studio/pages/pd/regional_partner_mini_contact/new.js
@@ -7,6 +7,9 @@ import getScriptData from '@cdo/apps/util/getScriptData';
 document.addEventListener('DOMContentLoaded', function (event) {
   createReactRoot(
     <RegionalPartnerMiniContact {...getScriptData('props')} />,
-    document.getElementById('application-container')
+    document.getElementById('application-container'),
+    {
+      legacyReactDomRender: true,
+    }
   );
 });

--- a/apps/src/sites/studio/pages/pd/teachercon_survey/new.js
+++ b/apps/src/sites/studio/pages/pd/teachercon_survey/new.js
@@ -7,6 +7,9 @@ import getScriptData from '@cdo/apps/util/getScriptData';
 document.addEventListener('DOMContentLoaded', function (event) {
   createReactRoot(
     <TeacherconSurvey {...getScriptData('props')} />,
-    document.getElementById('application-container')
+    document.getElementById('application-container'),
+    {
+      legacyReactDomRender: true,
+    }
   );
 });

--- a/apps/src/sites/studio/pages/pd/workshop_daily_survey/new_general_foorm.js
+++ b/apps/src/sites/studio/pages/pd/workshop_daily_survey/new_general_foorm.js
@@ -9,6 +9,9 @@ import 'survey-react/survey.css';
 document.addEventListener('DOMContentLoaded', function (event) {
   createReactRoot(
     <Foorm {...getScriptData('props')} />,
-    document.getElementById('application-container')
+    document.getElementById('application-container'),
+    {
+      legacyReactDomRender: true,
+    }
   );
 });

--- a/apps/src/sites/studio/pages/pd/workshop_dashboard/index.js
+++ b/apps/src/sites/studio/pages/pd/workshop_dashboard/index.js
@@ -7,6 +7,9 @@ import getScriptData from '@cdo/apps/util/getScriptData';
 document.addEventListener('DOMContentLoaded', function () {
   createReactRoot(
     <WorkshopDashboard {...getScriptData('props')} />,
-    document.getElementById('workshop-container')
+    document.getElementById('workshop-container'),
+    {
+      legacyReactDomRender: true,
+    }
   );
 });

--- a/apps/src/sites/studio/pages/pd/workshop_enrollment/cancel.js
+++ b/apps/src/sites/studio/pages/pd/workshop_enrollment/cancel.js
@@ -7,6 +7,9 @@ import getScriptData from '@cdo/apps/util/getScriptData';
 document.addEventListener('DOMContentLoaded', function () {
   createReactRoot(
     <EnrollmentCancelButton {...getScriptData('props')} />,
-    document.getElementById('workshop-container')
+    document.getElementById('workshop-container'),
+    {
+      legacyReactDomRender: true,
+    }
   );
 });

--- a/apps/src/sites/studio/pages/pd/workshop_enrollment/join.js
+++ b/apps/src/sites/studio/pages/pd/workshop_enrollment/join.js
@@ -21,6 +21,9 @@ document.addEventListener('DOMContentLoaded', function () {
       workshopInfo={workshopInfoParams}
       userInfo={userInfoParams.userInfo}
     />,
-    document.getElementById('join-workshop-container')
+    document.getElementById('join-workshop-container'),
+    {
+      legacyReactDomRender: true,
+    }
   );
 });

--- a/apps/src/sites/studio/pages/peer_reviews/dashboard.js
+++ b/apps/src/sites/studio/pages/peer_reviews/dashboard.js
@@ -10,6 +10,9 @@ document.addEventListener('DOMContentLoaded', function () {
       courseList={getScriptData('courseList')}
       courseUnitMap={getScriptData('courseUnitMap')}
     />,
-    document.getElementById('dashboard-container')
+    document.getElementById('dashboard-container'),
+    {
+      legacyReactDomRender: true,
+    }
   );
 });

--- a/apps/src/sites/studio/pages/plc/user_course_enrollments/index.js
+++ b/apps/src/sites/studio/pages/plc/user_course_enrollments/index.js
@@ -9,5 +9,8 @@ createReactRoot(
   <ProfessionalLearningCourseProgress
     deeperLearningCourseData={userCourseEnrollmentData}
   />,
-  document.getElementById('user-course-enrollment-container')
+  document.getElementById('user-course-enrollment-container'),
+  {
+    legacyReactDomRender: true,
+  }
 );

--- a/apps/src/sites/studio/pages/policy_compliance/child_account_consent.js
+++ b/apps/src/sites/studio/pages/policy_compliance/child_account_consent.js
@@ -22,6 +22,9 @@ $(document).ready(function () {
       studentId={studentId}
       usState={usState}
     />,
-    element
+    element,
+    {
+      legacyReactDomRender: true,
+    }
   );
 });

--- a/apps/src/sites/studio/pages/policy_compliance/parental_permission/_banner.js
+++ b/apps/src/sites/studio/pages/policy_compliance/parental_permission/_banner.js
@@ -11,6 +11,9 @@ document.addEventListener('DOMContentLoaded', () => {
     <Provider store={getStore()}>
       <ParentalPermissionBanner lockoutDate={getScriptData('lockoutDate')} />
     </Provider>,
-    document.getElementById('parental-permission-banner-container')
+    document.getElementById('parental-permission-banner-container'),
+    {
+      legacyReactDomRender: true,
+    }
   );
 });

--- a/apps/src/sites/studio/pages/policy_compliance/parental_permission/_modal.js
+++ b/apps/src/sites/studio/pages/policy_compliance/parental_permission/_modal.js
@@ -81,7 +81,10 @@ document.addEventListener('DOMContentLoaded', () => {
           inSection={getScriptData('inSection')}
         />
       </Provider>,
-      document.getElementById('parental-permission-modal-container')
+      document.getElementById('parental-permission-modal-container'),
+      {
+        legacyReactDomRender: true,
+      }
     );
   };
 

--- a/apps/src/sites/studio/pages/print_certificates/batch.js
+++ b/apps/src/sites/studio/pages/print_certificates/batch.js
@@ -9,6 +9,9 @@ $(document).ready(function () {
   const {imageUrls} = certificateData;
   createReactRoot(
     <PrintCertificateBatch imageUrls={imageUrls} />,
-    document.getElementById('print-certificate-batch')
+    document.getElementById('print-certificate-batch'),
+    {
+      legacyReactDomRender: true,
+    }
   );
 });

--- a/apps/src/sites/studio/pages/programming_classes/edit.js
+++ b/apps/src/sites/studio/pages/programming_classes/edit.js
@@ -28,6 +28,9 @@ $(document).ready(() => {
         <ExpandableImageDialog />
       </>
     </Provider>,
-    document.getElementById('edit-container')
+    document.getElementById('edit-container'),
+    {
+      legacyReactDomRender: true,
+    }
   );
 });

--- a/apps/src/sites/studio/pages/programming_classes/new.js
+++ b/apps/src/sites/studio/pages/programming_classes/new.js
@@ -12,6 +12,9 @@ $(document).ready(() => {
     <NewProgrammingClassForm
       programmingEnvironmentsForSelect={programmingEnvironmentsForSelect}
     />,
-    document.getElementById('form')
+    document.getElementById('form'),
+    {
+      legacyReactDomRender: true,
+    }
   );
 });

--- a/apps/src/sites/studio/pages/programming_classes/show.js
+++ b/apps/src/sites/studio/pages/programming_classes/show.js
@@ -47,6 +47,9 @@ $(document).ready(() => {
         <ExpandableImageDialog />
       </>
     </Provider>,
-    document.getElementById('show-container')
+    document.getElementById('show-container'),
+    {
+      legacyReactDomRender: true,
+    }
   );
 });

--- a/apps/src/sites/studio/pages/programming_environments/edit.js
+++ b/apps/src/sites/studio/pages/programming_environments/edit.js
@@ -25,6 +25,9 @@ $(document).ready(() => {
         <ExpandableImageDialog />
       </>
     </Provider>,
-    document.getElementById('edit-container')
+    document.getElementById('edit-container'),
+    {
+      legacyReactDomRender: true,
+    }
   );
 });

--- a/apps/src/sites/studio/pages/programming_environments/index.js
+++ b/apps/src/sites/studio/pages/programming_environments/index.js
@@ -10,6 +10,9 @@ $(document).ready(() => {
     <ProgrammingEnvironmentIndex
       programmingEnvironments={programmingEnvironments}
     />,
-    document.getElementById('container')
+    document.getElementById('container'),
+    {
+      legacyReactDomRender: true,
+    }
   );
 });

--- a/apps/src/sites/studio/pages/programming_environments/new.js
+++ b/apps/src/sites/studio/pages/programming_environments/new.js
@@ -6,6 +6,9 @@ import {createReactRoot} from '@cdo/apps/util/createReactRoot';
 $(document).ready(() => {
   createReactRoot(
     <NewProgrammingEnvironmentForm />,
-    document.getElementById('form')
+    document.getElementById('form'),
+    {
+      legacyReactDomRender: true,
+    }
   );
 });

--- a/apps/src/sites/studio/pages/programming_environments/show.js
+++ b/apps/src/sites/studio/pages/programming_environments/show.js
@@ -27,6 +27,9 @@ $(document).ready(() => {
         programmingEnvironment={programmingEnvironment}
       />
     </PageContainer>,
-    document.getElementById('container')
+    document.getElementById('container'),
+    {
+      legacyReactDomRender: true,
+    }
   );
 });

--- a/apps/src/sites/studio/pages/programming_expressions/edit.js
+++ b/apps/src/sites/studio/pages/programming_expressions/edit.js
@@ -35,6 +35,9 @@ $(document).ready(() => {
         <ExpandableImageDialog />
       </>
     </Provider>,
-    document.getElementById('edit-container')
+    document.getElementById('edit-container'),
+    {
+      legacyReactDomRender: true,
+    }
   );
 });

--- a/apps/src/sites/studio/pages/programming_expressions/index.js
+++ b/apps/src/sites/studio/pages/programming_expressions/index.js
@@ -13,6 +13,9 @@ $(document).ready(() => {
       programmingEnvironments={programmingEnvironments}
       allCategories={allCategories}
     />,
-    document.getElementById('container')
+    document.getElementById('container'),
+    {
+      legacyReactDomRender: true,
+    }
   );
 });

--- a/apps/src/sites/studio/pages/programming_expressions/new.js
+++ b/apps/src/sites/studio/pages/programming_expressions/new.js
@@ -12,6 +12,9 @@ $(document).ready(() => {
     <NewProgrammingExpressionForm
       programmingEnvironmentsForSelect={programmingEnvironmentsForSelect}
     />,
-    document.getElementById('form')
+    document.getElementById('form'),
+    {
+      legacyReactDomRender: true,
+    }
   );
 });

--- a/apps/src/sites/studio/pages/programming_expressions/show.js
+++ b/apps/src/sites/studio/pages/programming_expressions/show.js
@@ -51,6 +51,9 @@ $(document).ready(() => {
         <ExpandableImageDialog />
       </>
     </Provider>,
-    document.getElementById('show-container')
+    document.getElementById('show-container'),
+    {
+      legacyReactDomRender: true,
+    }
   );
 });

--- a/apps/src/sites/studio/pages/programming_methods/edit.js
+++ b/apps/src/sites/studio/pages/programming_methods/edit.js
@@ -26,6 +26,9 @@ $(document).ready(() => {
         <ExpandableImageDialog />
       </>
     </Provider>,
-    document.getElementById('edit-container')
+    document.getElementById('edit-container'),
+    {
+      legacyReactDomRender: true,
+    }
   );
 });

--- a/apps/src/sites/studio/pages/projects/featured.js
+++ b/apps/src/sites/studio/pages/projects/featured.js
@@ -17,6 +17,9 @@ $(document).ready(function () {
       bookmarkedFeaturedProjects={bookmarkedFeaturedProjects}
       archivedFeaturedProjects={archivedFeaturedProjects}
     />,
-    document.getElementById('featured-projects-container')
+    document.getElementById('featured-projects-container'),
+    {
+      legacyReactDomRender: true,
+    }
   );
 });

--- a/apps/src/sites/studio/pages/projects/index.js
+++ b/apps/src/sites/studio/pages/projects/index.js
@@ -53,7 +53,10 @@ $(document).ready(() => {
         </div>
       </div>
     </Provider>,
-    document.querySelector('#projects-page')
+    document.querySelector('#projects-page'),
+    {
+      legacyReactDomRender: true,
+    }
   );
   displayDifferentiationChat();
 });

--- a/apps/src/sites/studio/pages/reference_guides/edit.js
+++ b/apps/src/sites/studio/pages/reference_guides/edit.js
@@ -34,6 +34,9 @@ $(() => {
         editAllUrl={editAllUrl}
       />
     </Provider>,
-    document.getElementById('show-container')
+    document.getElementById('show-container'),
+    {
+      legacyReactDomRender: true,
+    }
   );
 });

--- a/apps/src/sites/studio/pages/reference_guides/edit_all.js
+++ b/apps/src/sites/studio/pages/reference_guides/edit_all.js
@@ -12,6 +12,9 @@ $(() => {
       referenceGuides={referenceGuides}
       baseUrl={baseUrl}
     />,
-    document.getElementById('show-container')
+    document.getElementById('show-container'),
+    {
+      legacyReactDomRender: true,
+    }
   );
 });

--- a/apps/src/sites/studio/pages/reference_guides/new.js
+++ b/apps/src/sites/studio/pages/reference_guides/new.js
@@ -8,6 +8,9 @@ $(document).ready(() => {
   const baseUrl = getScriptData('baseUrl');
   createReactRoot(
     <NewReferenceGuideForm baseUrl={baseUrl} />,
-    document.getElementById('form')
+    document.getElementById('form'),
+    {
+      legacyReactDomRender: true,
+    }
   );
 });

--- a/apps/src/sites/studio/pages/reference_guides/show.js
+++ b/apps/src/sites/studio/pages/reference_guides/show.js
@@ -14,6 +14,9 @@ $(() => {
       referenceGuides={referenceGuides}
       baseUrl={baseUrl}
     />,
-    document.getElementById('show-container')
+    document.getElementById('show-container'),
+    {
+      legacyReactDomRender: true,
+    }
   );
 });

--- a/apps/src/sites/studio/pages/report_abuse/report_abuse_form.js
+++ b/apps/src/sites/studio/pages/report_abuse/report_abuse_form.js
@@ -19,6 +19,9 @@ $(document).ready(function () {
     : document.referrer;
   createReactRoot(
     <ReportAbuseForm {...props} />,
-    document.getElementById('report-abuse-form')
+    document.getElementById('report-abuse-form'),
+    {
+      legacyReactDomRender: true,
+    }
   );
 });

--- a/apps/src/sites/studio/pages/rubrics/edit.js
+++ b/apps/src/sites/studio/pages/rubrics/edit.js
@@ -18,6 +18,9 @@ $(document).ready(() => {
       rubric={rubric}
       aiRubricS3Config={aiRubricS3Config}
     />,
-    document.getElementById('form')
+    document.getElementById('form'),
+    {
+      legacyReactDomRender: true,
+    }
   );
 });

--- a/apps/src/sites/studio/pages/rubrics/new.js
+++ b/apps/src/sites/studio/pages/rubrics/new.js
@@ -18,6 +18,9 @@ $(document).ready(() => {
       lessonId={lessonId}
       aiRubricS3Config={aiRubricS3Config}
     />,
-    document.getElementById('form')
+    document.getElementById('form'),
+    {
+      legacyReactDomRender: true,
+    }
   );
 });

--- a/apps/src/sites/studio/pages/scripts/code.js
+++ b/apps/src/sites/studio/pages/scripts/code.js
@@ -23,6 +23,9 @@ function initPage() {
     <Provider store={store}>
       <UnitRollup objectToRollUp={'Code'} unit={unitSummary} />
     </Provider>,
-    document.getElementById('roll_up')
+    document.getElementById('roll_up'),
+    {
+      legacyReactDomRender: true,
+    }
   );
 }

--- a/apps/src/sites/studio/pages/scripts/edit.js
+++ b/apps/src/sites/studio/pages/scripts/edit.js
@@ -98,7 +98,10 @@ export default function initPage(unitEditorData) {
         }
       />
     </Provider>,
-    document.querySelector('.edit_container')
+    document.querySelector('.edit_container'),
+    {
+      legacyReactDomRender: true,
+    }
   );
 }
 

--- a/apps/src/sites/studio/pages/scripts/lesson_extras.js
+++ b/apps/src/sites/studio/pages/scripts/lesson_extras.js
@@ -34,5 +34,8 @@ createReactRoot(
       showLessonExtrasWarning={viewer.show_lesson_extras_warning}
     />
   </Provider>,
-  document.querySelector('#lesson-extras')
+  document.querySelector('#lesson-extras'),
+  {
+    legacyReactDomRender: true,
+  }
 );

--- a/apps/src/sites/studio/pages/scripts/new.js
+++ b/apps/src/sites/studio/pages/scripts/new.js
@@ -4,5 +4,7 @@ import NewUnitForm from '@cdo/apps/levelbuilder/unit-editor/NewUnitForm';
 import {createReactRoot} from '@cdo/apps/util/createReactRoot';
 
 $(document).ready(() => {
-  createReactRoot(<NewUnitForm />, document.getElementById('form'));
+  createReactRoot(<NewUnitForm />, document.getElementById('form'), {
+    legacyReactDomRender: true,
+  });
 });

--- a/apps/src/sites/studio/pages/scripts/resources.js
+++ b/apps/src/sites/studio/pages/scripts/resources.js
@@ -19,6 +19,9 @@ function initPage() {
     <Provider store={store}>
       <UnitRollup objectToRollUp={'Resources'} unit={unitSummary} />
     </Provider>,
-    document.getElementById('roll_up')
+    document.getElementById('roll_up'),
+    {
+      legacyReactDomRender: true,
+    }
   );
 }

--- a/apps/src/sites/studio/pages/scripts/show.js
+++ b/apps/src/sites/studio/pages/scripts/show.js
@@ -154,7 +154,10 @@ function initPage() {
         showAiAssessmentsAnnouncement={showAiAssessmentsAnnouncement}
       />
     </Provider>,
-    mountPoint
+    mountPoint,
+    {
+      legacyReactDomRender: true,
+    }
   );
 
   tooltipifyVocabulary();
@@ -206,7 +209,10 @@ function displayDifferentiationChat(scriptData) {
           scriptName={scriptData.name}
         />
       </Provider>,
-      aiDiffFabMountPoint
+      aiDiffFabMountPoint,
+      {
+        legacyReactDomRender: true,
+      }
     );
   }
 }

--- a/apps/src/sites/studio/pages/scripts/standards.js
+++ b/apps/src/sites/studio/pages/scripts/standards.js
@@ -19,6 +19,9 @@ function initPage() {
     <Provider store={store}>
       <UnitRollup objectToRollUp={'Standards'} unit={unitSummary} />
     </Provider>,
-    document.getElementById('roll_up')
+    document.getElementById('roll_up'),
+    {
+      legacyReactDomRender: true,
+    }
   );
 }

--- a/apps/src/sites/studio/pages/scripts/vocab.js
+++ b/apps/src/sites/studio/pages/scripts/vocab.js
@@ -19,6 +19,9 @@ function initPage() {
     <Provider store={store}>
       <UnitRollup objectToRollUp={'Vocabulary'} unit={unitSummary} />
     </Provider>,
-    document.getElementById('roll_up')
+    document.getElementById('roll_up'),
+    {
+      legacyReactDomRender: true,
+    }
   );
 }

--- a/apps/src/sites/studio/pages/sections/new.js
+++ b/apps/src/sites/studio/pages/sections/new.js
@@ -26,7 +26,10 @@ $(document).ready(() => {
         defaultRedirectUrl={defaultRedirectUrl}
       />
     </div>,
-    document.getElementById('form')
+    document.getElementById('form'),
+    {
+      legacyReactDomRender: true,
+    }
   );
   displayDifferentiationChat();
 });

--- a/apps/src/sites/studio/pages/sessions/lockout.js
+++ b/apps/src/sites/studio/pages/sessions/lockout.js
@@ -24,6 +24,9 @@ $(document).ready(function () {
         inSection={'true' === element.getAttribute('data-in-section')}
       />
     </Provider>,
-    element
+    element,
+    {
+      legacyReactDomRender: true,
+    }
   );
 });

--- a/apps/src/sites/studio/pages/skills/index.js
+++ b/apps/src/sites/studio/pages/skills/index.js
@@ -12,6 +12,9 @@ $(document).ready(() => {
       skills={skillsData.skills}
       levels={skillsData.levels}
     />,
-    document.getElementById('skills')
+    document.getElementById('skills'),
+    {
+      legacyReactDomRender: true,
+    }
   );
 });

--- a/apps/src/sites/studio/pages/sprite_management/default_sprites_editor.js
+++ b/apps/src/sites/studio/pages/sprite_management/default_sprites_editor.js
@@ -6,6 +6,9 @@ import {createReactRoot} from '@cdo/apps/util/createReactRoot';
 $(document).ready(function () {
   createReactRoot(
     <DefaultSpritesEditor />,
-    document.getElementById('default-sprites-editor-container')
+    document.getElementById('default-sprites-editor-container'),
+    {
+      legacyReactDomRender: true,
+    }
   );
 });

--- a/apps/src/sites/studio/pages/sprite_management/release_default_sprites_to_production.js
+++ b/apps/src/sites/studio/pages/sprite_management/release_default_sprites_to_production.js
@@ -6,6 +6,9 @@ import {createReactRoot} from '@cdo/apps/util/createReactRoot';
 $(document).ready(function () {
   createReactRoot(
     <ReleaseDefaultSprites />,
-    document.getElementById('release-default-sprites-to-production-container')
+    document.getElementById('release-default-sprites-to-production-container'),
+    {
+      legacyReactDomRender: true,
+    }
   );
 });

--- a/apps/src/sites/studio/pages/sprite_management/select_start_animations.js
+++ b/apps/src/sites/studio/pages/sprite_management/select_start_animations.js
@@ -9,6 +9,9 @@ $(document).ready(function () {
   const useAllSprites = query['library'] === 'all';
   createReactRoot(
     <SelectStartAnimations useAllSprites={useAllSprites} />,
-    document.getElementById('select_start_animations')
+    document.getElementById('select_start_animations'),
+    {
+      legacyReactDomRender: true,
+    }
   );
 });

--- a/apps/src/sites/studio/pages/sprite_management/sprite_management_directory.js
+++ b/apps/src/sites/studio/pages/sprite_management/sprite_management_directory.js
@@ -6,6 +6,9 @@ import {createReactRoot} from '@cdo/apps/util/createReactRoot';
 $(document).ready(function () {
   createReactRoot(
     <SpriteManagementDirectory />,
-    document.getElementById('sprite-management-directory-container')
+    document.getElementById('sprite-management-directory-container'),
+    {
+      legacyReactDomRender: true,
+    }
   );
 });

--- a/apps/src/sites/studio/pages/sprite_management/sprite_upload.js
+++ b/apps/src/sites/studio/pages/sprite_management/sprite_upload.js
@@ -6,6 +6,9 @@ import {createReactRoot} from '@cdo/apps/util/createReactRoot';
 $(document).ready(function () {
   createReactRoot(
     <SpriteUpload />,
-    document.getElementById('sprite-upload-container')
+    document.getElementById('sprite-upload-container'),
+    {
+      legacyReactDomRender: true,
+    }
   );
 });

--- a/apps/src/sites/studio/pages/teacher_dashboard/parent_letter.js
+++ b/apps/src/sites/studio/pages/teacher_dashboard/parent_letter.js
@@ -49,6 +49,9 @@ window.addEventListener('DOMContentLoaded', function () {
         loginTypeName={scriptData.section.login_type_name}
       />
     </Provider>,
-    mountPoint
+    mountPoint,
+    {
+      legacyReactDomRender: true,
+    }
   );
 });

--- a/apps/src/sites/studio/pages/teacher_dashboard/show.js
+++ b/apps/src/sites/studio/pages/teacher_dashboard/show.js
@@ -103,7 +103,10 @@ $(document).ready(function () {
       )}
       <FlashHandler flash={flash} autoHideDuration={FLASH_DURATION} />
     </Provider>,
-    document.getElementById('teacher-dashboard')
+    document.getElementById('teacher-dashboard'),
+    {
+      legacyReactDomRender: true,
+    }
   );
   displayDifferentiationChat();
 });

--- a/apps/src/sites/studio/pages/teacher_feedbacks/index.js
+++ b/apps/src/sites/studio/pages/teacher_feedbacks/index.js
@@ -16,6 +16,9 @@ function showFeedback() {
     <Provider store={getStore()}>
       <AllFeedbacks feedbacksByLevel={feedbackData.all_feedbacks_by_level} />
     </Provider>,
-    document.getElementById('feedback-container')
+    document.getElementById('feedback-container'),
+    {
+      legacyReactDomRender: true,
+    }
   );
 }

--- a/apps/src/sites/studio/pages/vocabularies/edit.js
+++ b/apps/src/sites/studio/pages/vocabularies/edit.js
@@ -29,6 +29,9 @@ $(document).ready(function () {
         courseName={courseName}
       />
     </Provider>,
-    document.getElementById('vocabularies-table')
+    document.getElementById('vocabularies-table'),
+    {
+      legacyReactDomRender: true,
+    }
   );
 });

--- a/apps/src/sites/studio/pages/weblab_host/network_check.js
+++ b/apps/src/sites/studio/pages/weblab_host/network_check.js
@@ -10,6 +10,9 @@ $(document).ready(function () {
 
   createReactRoot(
     <WebLabNetworkCheck studioUrl={brambleConfig.studioUrl} />,
-    document.getElementById('weblab-network-check-container')
+    document.getElementById('weblab-network-check-container'),
+    {
+      legacyReactDomRender: true,
+    }
   );
 });

--- a/apps/src/storage/getColumnDropdown.js
+++ b/apps/src/storage/getColumnDropdown.js
@@ -22,7 +22,10 @@ function openModal(type, callback, table) {
         element.parentNode.removeChild(element);
       }}
     />,
-    document.querySelector('#modalDiv')
+    document.querySelector('#modalDiv'),
+    {
+      legacyReactDomRender: true,
+    }
   );
 }
 

--- a/apps/src/studio/studio.js
+++ b/apps/src/studio/studio.js
@@ -2402,7 +2402,10 @@ Studio.init = function (config) {
     <Provider store={getStore()}>
       <AppView visualizationColumn={visualizationColumn} onMount={onMount} />
     </Provider>,
-    document.getElementById(config.containerId)
+    document.getElementById(config.containerId),
+    {
+      legacyReactDomRender: true,
+    }
   );
 };
 
@@ -5926,7 +5929,10 @@ Studio.askForInput = function (question, callback) {
 
   createReactRoot(
     <InputPrompt question={question} onInputReceived={onInputReceived} />,
-    target
+    target,
+    {
+      legacyReactDomRender: true,
+    }
   );
 };
 

--- a/apps/src/submitHelper.js
+++ b/apps/src/submitHelper.js
@@ -120,7 +120,10 @@ function showConfirmationDialog(config) {
       confirmText={commonMsg.dialogOK()}
       cancelText={commonMsg.dialogCancel()}
     />,
-    buttons
+    buttons,
+    {
+      legacyReactDomRender: true,
+    }
   );
   contentDiv.appendChild(buttons);
 

--- a/apps/src/templates/utils/expandableImages.js
+++ b/apps/src/templates/utils/expandableImages.js
@@ -43,7 +43,10 @@ export function renderExpandableImages(node, showImageDialog) {
           showImageDialog(expandableImg.dataset.url, expandableImg.textContent)
         }
       />,
-      expandableImg
+      expandableImg,
+      {
+        legacyReactDomRender: true,
+      }
     );
   }
 }

--- a/apps/src/turtle/artist.js
+++ b/apps/src/turtle/artist.js
@@ -428,7 +428,10 @@ Artist.prototype.init = function (config) {
           onMount={onMount.bind(this)}
         />
       </Provider>,
-      document.getElementById(config.containerId)
+      document.getElementById(config.containerId),
+      {
+        legacyReactDomRender: true,
+      }
     );
   });
 };

--- a/apps/src/util/createReactRoot.tsx
+++ b/apps/src/util/createReactRoot.tsx
@@ -4,9 +4,16 @@ import '@code-dot-org/component-library-styles/primitiveColors.css';
 import {ThemeProvider as MuiThemeProvider} from '@mui/material/styles';
 import React, {ReactElement} from 'react';
 import ReactDOM from 'react-dom';
+import {createRoot, Root} from 'react-dom/client';
 
 import {getCurrentBrand, getMuiThemeForBrand} from './brand';
 import {SiteConfigProvider} from './SiteConfigContext';
+
+interface CreateReactRootOptions {
+  legacyReactDomRender?: boolean;
+}
+
+const rootsByContainer = new WeakMap<Element, Root>();
 
 /**
  * Global bootstrapper function that wraps rendered DOM trees with configured providers
@@ -16,10 +23,12 @@ import {SiteConfigProvider} from './SiteConfigContext';
  *
  * @param component - The React component to render
  * @param container - The container element or selector to render into
+ * @param options - Optional rendering behavior overrides
  */
 export function createReactRoot(
   component: ReactElement,
-  container: Element | string
+  container: Element | string,
+  options?: CreateReactRootOptions
 ): void {
   const containerElement =
     typeof container === 'string'
@@ -34,11 +43,22 @@ export function createReactRoot(
 
   const brand = getCurrentBrand();
   const theme = getMuiThemeForBrand(brand);
-
-  ReactDOM.render(
+  const wrappedComponent = (
     <SiteConfigProvider config={{brand}}>
       <MuiThemeProvider theme={theme}>{component}</MuiThemeProvider>
-    </SiteConfigProvider>,
-    containerElement
+    </SiteConfigProvider>
   );
+
+  if (options?.legacyReactDomRender) {
+    ReactDOM.render(wrappedComponent, containerElement);
+    return;
+  }
+
+  let root = rootsByContainer.get(containerElement);
+  if (!root) {
+    root = createRoot(containerElement);
+    rootsByContainer.set(containerElement, root);
+  }
+
+  root.render(wrappedComponent);
 }

--- a/apps/src/util/createReactRoot.tsx
+++ b/apps/src/util/createReactRoot.tsx
@@ -9,7 +9,7 @@ import {createRoot, Root} from 'react-dom/client';
 import {getCurrentBrand, getMuiThemeForBrand} from './brand';
 import {SiteConfigProvider} from './SiteConfigContext';
 
-interface CreateReactRootOptions {
+interface Options {
   legacyReactDomRender?: boolean;
 }
 
@@ -23,12 +23,12 @@ const rootsByContainer = new WeakMap<Element, Root>();
  *
  * @param component - The React component to render
  * @param container - The container element or selector to render into
- * @param options - Optional rendering behavior overrides
+ * @param options - Option to override default to use legacy rendering behavior
  */
 export function createReactRoot(
   component: ReactElement,
   container: Element | string,
-  options?: CreateReactRootOptions
+  options?: Options
 ): void {
   const containerElement =
     typeof container === 'string'

--- a/apps/src/weblab/WebLab.js
+++ b/apps/src/weblab/WebLab.js
@@ -240,7 +240,10 @@ WebLab.prototype.init = function (config) {
         onMount={() => this.onMount(config)}
       />
     </Provider>,
-    document.getElementById(config.containerId)
+    document.getElementById(config.containerId),
+    {
+      legacyReactDomRender: true,
+    }
   );
 
   window.addEventListener('beforeunload', this.beforeUnload.bind(this));


### PR DESCRIPTION
Despite our move to React 18, we are currently still using the legacy `ReacDOM.render` API to create React entrypoints, rather than the more modern `createRoot` API.

This change makes `createRoot` the default in our aptly named `createReactRoot` wrapper, and adds a legacy option for our existing callsites. This will a) get us on the new API by default as developers write new code, and b) enable us to migrate incrementally to the new API.

There's no expected behavior change in this PR.

Codex found/modified the callsites in this PR, but as validation, my file search came up with 219 files with the text `createReactRoot`. 213 are changed here, 5 were test files that just stubbed createReactRoot and didn't need to be updated, and one was a readme, so things added up at least.

I thought about whether we could add a less verbose option name (or just make it a third arg that you don't have to name when calling), but I kind of liked that the legacy bit is in your face in each callsite, which might be good for getting these switched over.

## Links

- Slack discussion: https://codedotorg.slack.com/archives/C0T0PNTM3/p1774460718902039?thread_ts=1774365732.796279&cid=C0T0PNTM3