### PR TITLE
move aidiff ui tests off of csp

### DIFF
--- a/dashboard/test/ui/features/teacher_tools/ai_diff/ai_differentiation_chat.feature
+++ b/dashboard/test/ui/features/teacher_tools/ai_diff/ai_differentiation_chat.feature
@@ -22,7 +22,7 @@ Feature: Send and receive messages in the AI differentiation chat
     And I wait until element "button:contains(Get Started)" is not visible
 
     #Go to curriculum page
-    And I am on "http://studio.code.org/courses/csp-2025"
+    And I am on "http://studio.code.org/courses/ui-test-artist"
     And I wait until element "#ui-floatingActionButton" is visible
     #wait for pulse to finish
     And I wait for 5 seconds
@@ -80,7 +80,7 @@ Feature: Send and receive messages in the AI differentiation chat
     And I get debug info for the current user
     And I am on "http://studio.code.org/teacher_dashboard/home"
     And element "#sign_in_or_user" contains text "Stilgar"
-    And I am on "http://studio.code.org/courses/csp-2025/units/4"
+    And I am on "http://studio.code.org/courses/ui-test-artist/units/1"
     And I wait until element "#ui-floatingActionButton" is visible
 
     # Teacher sees and skips AI Diff chat welcome

--- a/dashboard/test/ui/features/teacher_tools/ai_diff/ai_differentiation_threads.feature
+++ b/dashboard/test/ui/features/teacher_tools/ai_diff/ai_differentiation_threads.feature
@@ -15,7 +15,7 @@ Feature: Read and create AI diff threads
     And I am on "http://studio.code.org/home"
     And I wait until element "#teacher-home-header" is visible
     And element "#sign_in_or_user" contains text "Stilgar"
-    And I am on "http://studio.code.org/courses/csp-2025/units/4"
+    And I am on "http://studio.code.org/courses/ui-test-artist/units/1"
     And I wait until element "#ui-floatingActionButton" is visible
 
     # Was asked to disable the AITA welcome experience without removing any code.


### PR DESCRIPTION
for background, see [partitioned curriculum data proposal](https://docs.google.com/document/d/1iiJXtPODakjuZ7-2yKJ941H56dcyUmUFtWa7zGgqKdw/edit?tab=t.0#heading=h.qx67631q1z2d)

this PR moves aidiff UI tests off of CSP and onto a dedicated ui test course.

## Testing story
