### PR TITLE
Updates Teal across site to high contrast teal

### DIFF
--- a/apps/src/aiDifferentiation/ai-differentiation.module.scss
+++ b/apps/src/aiDifferentiation/ai-differentiation.module.scss
@@ -724,7 +724,7 @@ html body .sidebarActionTooltip {
   }
 
   &Blue {
-    border: 1px solid var(--borders-brand-teal-primary, #0093a4);
+    border: 1px solid var(--borders-brand-teal-primary, #00818F);
     background: var(--background-brand-teal-extra-light, #e0f8f9);
   }
 
@@ -745,14 +745,14 @@ html body .sidebarActionTooltip {
   align-items: center;
   gap: 8px;
   border-radius: 4px;
-  background: var(--background-brand-teal-primary, #0093a4);
+  background: var(--background-brand-teal-primary, #00818F);
   z-index: 1;
   p {
     color: $neutral_white;
     margin: 0;
   }
   &Blue {
-    background: var(--background-brand-teal-primary, #0093a4);
+    background: var(--background-brand-teal-primary, #00818F);
   }
 
   &Red {

--- a/apps/src/aiDifferentiation/personalization/components/PersonalizationProgressBar.tsx
+++ b/apps/src/aiDifferentiation/personalization/components/PersonalizationProgressBar.tsx
@@ -41,7 +41,7 @@ const PersonalizationProgressBar: React.FC<PersonalizationProgressBarProps> = ({
             borderRadius: '6.25rem',
             [`& .${linearProgressClasses.bar}`]: {
               borderRadius: '6.25rem',
-              backgroundColor: 'var(--background-brand-teal-primary, #0093A4)',
+              backgroundColor: 'var(--background-brand-teal-primary, #00818F)',
             },
           }}
         />

--- a/apps/src/code-studio/pd/workshop_dashboard/workshops/surveys/constants.ts
+++ b/apps/src/code-studio/pd/workshop_dashboard/workshops/surveys/constants.ts
@@ -17,7 +17,7 @@ export const COLOR_MAP = new Map([
   ['green', 'var(--sentiment-success-50, #3EA33E)'],
   ['orange', 'var(--accent-orange-50, #FFB42E)'],
   ['red', 'var(--accent-strawberry-50, #ED6060)'],
-  ['teal', 'var(--brand-teal-50, #0093A4)'],
+  ['teal', 'var(--brand-teal-50, #00818F)'],
   ['purple', 'var(--brand-purple-50, #8c52ba)'],
   ['aqua', 'var(--brand-aqua-50, #3cfff7)'],
 ] as const);

--- a/apps/src/levelbuilder/lesson-editor/LevelToken.jsx
+++ b/apps/src/levelbuilder/lesson-editor/LevelToken.jsx
@@ -276,7 +276,7 @@ const styles = {
     display: 'table-cell',
     color: 'white',
     background: color.teal,
-    border: '1px solid #0093a4',
+    border: '1px solid #00818F',
     boxShadow: 'inset 0 1px 0 0 rgba(255, 255, 255, 0.6)',
     padding: '7px 13px',
     cursor: 'pointer',

--- a/apps/src/levelbuilder/unit-editor/LessonToken.jsx
+++ b/apps/src/levelbuilder/unit-editor/LessonToken.jsx
@@ -221,7 +221,7 @@ const styles = {
     display: 'table-cell',
     color: 'white',
     background: color.teal,
-    border: '1px solid #0093a4',
+    border: '1px solid #00818F',
     boxShadow: 'inset 0 1px 0 0 rgba(255, 255, 255, 0.6)',
     padding: '7px 13px',
     cursor: 'pointer',

--- a/apps/src/simpleSignUp/lti/sync/LtiSectionSyncDialog.tsx
+++ b/apps/src/simpleSignUp/lti/sync/LtiSectionSyncDialog.tsx
@@ -333,7 +333,7 @@ const styles: {[key: string]: CSSProperties} = {
   tableHeaderCenter: {
     textAlign: 'center',
     backgroundColor: 'transparent',
-    color: '#0093a4',
+    color: '#00818F',
     fontSize: '13px',
     fontWeight: 500,
     paddingLeft: 0,
@@ -341,7 +341,7 @@ const styles: {[key: string]: CSSProperties} = {
   tableHeaderLeft: {
     textAlign: 'left',
     backgroundColor: 'transparent',
-    color: '#0093a4',
+    color: '#00818F',
     fontSize: '13px',
     fontWeight: 500,
     paddingLeft: 0,
@@ -356,7 +356,7 @@ const styles: {[key: string]: CSSProperties} = {
   },
   courseNameLabel: {
     fontWeight: 500,
-    color: '#0093a4',
+    color: '#00818F',
     marginRight: '10px',
   },
   courseNameText: {

--- a/dashboard/app/assets/stylesheets/application.scss
+++ b/dashboard/app/assets/stylesheets/application.scss
@@ -47,7 +47,7 @@ $selectUserTypeButtonBackgroundColor: #fff;
 $selectUserTypeButtonTextColor: #000;
 $selectUserTypeButtonBackgroundColorHover: #ddd;
 $selectUserTypeButtonTextColorHover: #000;
-$selectUserTypeButtonBackgroundColorSelected: #0093a4;
+$selectUserTypeButtonBackgroundColorSelected: #00818f;
 $selectUserTypeButtonTextColorSelected: #fff;
 
 $contrastTealHeader: #00818f;

--- a/dashboard/app/views/levels/edit.html.haml
+++ b/dashboard/app/views/levels/edit.html.haml
@@ -79,7 +79,7 @@
           = check_box_tag 'reset', '1', true
         -# We added the button for these 3 lab types because they all use the same start_sources route for editing start code.
         - if [Pythonlab, Javalab, Weblab2].include?(@level.class)
-          = f.submit 'Save, publish, and go to edit start code', {:class => 'publishLevel', :name => "redirect_start_mode", :style => "background-color: #0093A4; margin-bottom: 10px; margin-right:8px; height: 35px"}
+          = f.submit 'Save, publish, and go to edit start code', {:class => 'publishLevel', :name => "redirect_start_mode", :style => "background-color: #00818F; margin-bottom: 10px; margin-right:8px; height: 35px"}
         = f.submit 'Save and publish your completed work', {:class => 'publishLevel', :style => "background-color: #f0c14b; margin-bottom: 10px; height: 35px"}
 
         %div{style: "display: flex; flex-direction: column; padding: 10px 10px 0px 10px"}

--- a/frontend/packages/component-library-styles/primitiveColors.css
+++ b/frontend/packages/component-library-styles/primitiveColors.css
@@ -62,7 +62,7 @@
   --brand-teal-30: #85cad1;
   --brand-teal-40: #50b2bd;
   --brand-teal-5: #e0f8f9;
-  --brand-teal-50: #0093a4;
+  --brand-teal-50: #00818f;
   --brand-teal-60: #008493;
   --brand-teal-65: #00818f;
   --brand-teal-70: #007785;

--- a/shared/css/color.scss
+++ b/shared/css/color.scss
@@ -21,7 +21,7 @@ $white: #fff;
 $default_blue: #3670b3;
 
 $dark_teal: #0094a3;
-$teal: #0093a4;
+$teal: #00818F;
 $applab_button_teal: #1abc9c;
 $light_teal: #59cad3;
 $lightish_teal: #80d6de;
@@ -192,7 +192,7 @@ $classlink_brand_color: #0a4d7f;
 // ===----===----===---- Design system colors: ----===----===----===
 
 $light_primary_100: #BFE4E8;
-$light_primary_500: #0093A4;
+$light_primary_500: #00818F;
 $light_primary_700: #007785;
 
 $light_secondary_100: #E2D4EE;

--- a/shared/css/course-explorer.scss
+++ b/shared/css/course-explorer.scss
@@ -122,7 +122,7 @@ $color_border_invisible: rgba(170, 170, 170, 0);
     margin-right: 10px;
 
     a {
-      color: #0093a4;
+      color: #00818F;
     }
   }
   div {


### PR DESCRIPTION
Yes, I understand we are going through a rebrand soon. However, our VPAT is happening now, and fixing this teal discrepancy is easy money. 

To find these files, I searched for our brand teal hex code and replaced with our high contrast teal hex (ignoring .svg, .level, .external and .json). I think the big wins will be brand-teal-50 (which fixes border-primary and background-primary too). I know this isn't *quite right because it's not a strict 50 (more like a 65) but this fix is the easiest/cleanest in the context of our impending rebrand.

This update will make the teal across our site match our header. Consider this a followup to https://github.com/code-dot-org/code-dot-org/pull/70782.



## Links
<!-- Jira tickets, design docs, Slack threads, related PRs, etc. -->

- Jira:

## Testing story
<!-- How was this tested? Manual steps, adhoc links, automated tests, or why testing isn't needed. -->



## Deployment notes
<!-- Delete this section if it's a standard merge-and-deploy.
     Otherwise: migrations, feature flags, coordination, caching impacts, etc. -->



## Privacy and security
<!-- Delete this section if there is no privacy/security impact.
     Otherwise: new PII, auth changes, API surface changes, etc. -->

