### PR TITLE
Fix Zero ETL Monitoring Job

### DIFF
--- a/bin/cron/monitor_mysql_to_redshift_zeroetl_integration
+++ b/bin/cron/monitor_mysql_to_redshift_zeroetl_integration
@@ -1,7 +1,9 @@
 #!/usr/bin/env ruby
 
 require_relative 'only_one'
-require_relative '../../dashboard/config/environment'
+abort 'Script already running' unless only_one_running?(__FILE__)
+
+require_relative '../../deployment'
 require 'cdo/aws/redshift'
 require 'cdo/chat_client'
 
@@ -49,7 +51,7 @@ def main
     alert("Zero-ETL Table Sync Alert (#{ENVIRONMENT_TYPE})*\nTable `#{table['schema_name']}.#{table['table_name']}` failed to sync.\nDetails: #{table.to_json}")
   end
 rescue => exception
-  alert("💥 *Zero-ETL Monitor Script Failed (#{ENVIRONMENT_TYPE})*\nException: #{exception.message}")
+  alert("Zero-ETL Monitor Script Failed (#{ENVIRONMENT_TYPE})*\nException: #{exception.message}")
   raise exception
 end
 

--- a/bin/cron/monitor_mysql_to_redshift_zeroetl_integration
+++ b/bin/cron/monitor_mysql_to_redshift_zeroetl_integration
@@ -38,7 +38,7 @@ def main
   # Check Table-level sync status.
   # https://docs.aws.amazon.com/redshift/latest/dg/r_SVV_INTEGRATION_TABLE_STATE.html
   # Possible values: `Synced`, `Failed`, `Deleted`, `ResyncRequired`, `ResyncInitiated`, and `DroppedSource`.
-  table_query = <<~SQL
+  table_sync_status_query = <<~SQL
     SELECT *
     FROM SVV_INTEGRATION_TABLE_STATE
     WHERE target_database = '#{TARGET_DB}'
@@ -46,9 +46,32 @@ def main
       AND table_state != 'ResyncInitiated';
   SQL
 
-  tables = redshift.execute(table_query)
-  tables.each do |table|
-    alert("Zero-ETL Table Sync Alert (#{ENVIRONMENT_TYPE})*\nTable `#{table['schema_name']}.#{table['table_name']}` failed to sync.\nDetails: #{table.to_json}")
+  error_tables = redshift.execute(table_sync_status_query)
+  if error_tables.any?
+    summary_lines = error_tables.map {|table| "• `#{table['schema_name']}.#{table['table_name']}` (#{table['table_state']})"}
+
+    header = "Zero-ETL Sync Failure Summary (#{ENVIRONMENT_TYPE})*\n"
+    header += "#{error_tables.size} tables are failing to synchronize:\n"
+    header += summary_lines.join("\n")
+    header += "Details for up to 3 randomly selected error tables:\n"
+
+    alert(header)
+
+    # Output details about up to 3 randomly selected tables that are failing to sync via Zero ETL.
+    error_tables.sample(3).each do |table|
+      message = <<~MSG
+        *Zero-ETL Table Sync Alert (#{ENVIRONMENT_TYPE})*
+        *Table:* `#{table['schema_name']}.#{table['table_name']}`
+        *State:* `#{table['table_state']}`
+
+        *Error Reason:*
+        > #{table['reason']}
+
+        _Last Updated: #{table['last_updated_timestamp']}_
+        _Integration ID: #{table['integration_id']}_
+      MSG
+      alert(message)
+    end
   end
 rescue => exception
   alert("Zero-ETL Monitor Script Failed (#{ENVIRONMENT_TYPE})*\nException: #{exception.message}")

--- a/bin/cron/monitor_mysql_to_redshift_zeroetl_integration
+++ b/bin/cron/monitor_mysql_to_redshift_zeroetl_integration
@@ -48,7 +48,7 @@ def main
 
   error_tables = redshift.execute(table_sync_status_query)
   if error_tables.any?
-    summary_lines = error_tables.map {|table| "• `#{table['schema_name']}.#{table['table_name']}` (#{table['table_state']})"}
+    summary_lines = error_tables.map {|table| "• `#{table['schema_name']}.#{table['table_name']}` (#{table['table_state']})\n"}
 
     header = "Zero-ETL Sync Failure Summary (#{ENVIRONMENT_TYPE})*\n"
     header += "#{error_tables.size} tables are failing to synchronize:\n"

--- a/cookbooks/cdo-apps/templates/default/crontab.erb
+++ b/cookbooks/cdo-apps/templates/default/crontab.erb
@@ -76,7 +76,7 @@
       # This should be run shortly after the commit_content job run on levelbuilder.
       cronjob at:'*/2 * * * *', do:deploy_dir('bin', 'cron', 'deploy_to_test')
       cronjob at:'*/5 * * * *', do:deploy_dir('bin', 'snapshot')
-      cronjob at:'* 1 * * *', do:deploy_dir('bin', 'cron', 'monitor_mysql_to_redshift_zeroetl_integration')
+      cronjob at:'0 * * * *', do:deploy_dir('bin', 'cron', 'monitor_mysql_to_redshift_zeroetl_integration')
     end
 
     if node.chef_environment == 'levelbuilder'

--- a/cookbooks/cdo-apps/templates/default/crontab.erb
+++ b/cookbooks/cdo-apps/templates/default/crontab.erb
@@ -76,7 +76,7 @@
       # This should be run shortly after the commit_content job run on levelbuilder.
       cronjob at:'*/2 * * * *', do:deploy_dir('bin', 'cron', 'deploy_to_test')
       cronjob at:'*/5 * * * *', do:deploy_dir('bin', 'snapshot')
-      cronjob at:'0 * * * *', do:deploy_dir('bin', 'cron', 'monitor_mysql_to_redshift_zeroetl_integration')
+      cronjob at:'30 19 * * *', do:deploy_dir('bin', 'cron', 'monitor_mysql_to_redshift_zeroetl_integration')
     end
 
     if node.chef_environment == 'levelbuilder'
@@ -107,7 +107,7 @@
       cronjob at:'5 12 * * *', do:deploy_dir('bin', 'cron', 'applab_datasets', 'daily_weather')
       cronjob at:'0 12 * * *', do:deploy_dir('bin', 'cron', 'applab_datasets', 'spotify')
       cronjob at:'00 23 * * *', do:deploy_dir('bin', 'cron', 'export_mysql_database_to_redshift')
-      cronjob at:'* 1 * * *', do:deploy_dir('bin', 'cron', 'monitor_mysql_to_redshift_zeroetl_integration')
+      cronjob at:'30 19 * * *', do:deploy_dir('bin', 'cron', 'monitor_mysql_to_redshift_zeroetl_integration') # Once a day roughly after the legacy DMS export completes.
       cronjob at:'0 0 * * *', do:deploy_dir('bin', 'cron', 'build_contact_rollups_v2')
       cronjob at:'0 2 * * *', do:deploy_dir('bin', 'cron', 'hoc_student_name_cleanup')
       cronjob at:'0 0 * * *', do:deploy_dir('bin', 'cron', 'send_permission_email_reminders')

--- a/dashboard/config/environments/test.rb
+++ b/dashboard/config/environments/test.rb
@@ -68,7 +68,7 @@ Dashboard::Application.configure do
   # Set to :debug to see everything in the log.
   config.log_level = :info
 
-  if CDO.running_web_application?
+  if CDO.test_system?
     # Use default logging formatter so that PID and timestamp are not suppressed.
     config.log_formatter = Logger::Formatter.new
 

--- a/dashboard/config/environments/test.rb
+++ b/dashboard/config/environments/test.rb
@@ -68,7 +68,7 @@ Dashboard::Application.configure do
   # Set to :debug to see everything in the log.
   config.log_level = :info
 
-  if CDO.test_system?
+  if CDO.test_system? && !ENV['UNIT_TEST']
     # Use default logging formatter so that PID and timestamp are not suppressed.
     config.log_formatter = Logger::Formatter.new
 

--- a/lib/cdo/aws/redshift.rb
+++ b/lib/cdo/aws/redshift.rb
@@ -94,11 +94,10 @@ module Cdo
 
         resp.records.each do |row|
           values = row.map do |field|
-            # Explicitly check .nil? instead of .present? to prevent 'false' booleans from evaluating to 'nil'.
             if field.is_null
               nil
             elsif !field.string_value.nil?
-              field.string_value
+              field.string_value.strip # Trim trailing spaces from fixed width CHAR or BPCHAR columns, common in system tables.
             elsif !field.long_value.nil?
               field.long_value
             elsif !field.boolean_value.nil?


### PR DESCRIPTION
Now that the Zero ETL Monitoring Job has been in place for a few days, fix / adjust how it works:

- Calls to `CDO.log` were not streaming to CloudWatch on the managed test server. Fix `test` logging to work in any execution context (web application server, ActiveJob, cron job, rails console, etc.) on the managed test server except unit tests.
- Change cron schedule to once a day, roughly timed for when the legacy daily Database Migration Service export completes (~12:30PM PDT). Executing hourly is too noisy.
- Improve formatting of error logging

## Testing story
checked out these files from this feature branch to the test server, intentionally caused 4 tables to fail Zero ETL sync, and executed the job. Output was formatted as expected:
```
Zero-ETL Sync Failure Summary (test)*
4 tables are failing to synchronize:
• `dashboard_test.stages_standards` (Failed)

• `dashboard_test.levels_skills` (Failed)

• `dashboard_test.level_source_images` (Failed)

• `dashboard_test.lessons_vocabularies` (Failed)
Details for up to 3 randomly selected error tables:

*Zero-ETL Table Sync Alert (test)*
*Table:* `dashboard_test.levels_skills`
*State:* `Failed`

*Error Reason:*
> Amazon Redshift cannot replicate table 'dashboard_test.levels_skills' because the table is missing a primary key. Add primary key(s) to the source table and the table will resynchronize automatically.

_Last Updated: 2026-04-02 18:31:31.604594_
_Integration ID: [REDACTED]_

*Zero-ETL Table Sync Alert (test)*
*Table:* `dashboard_test.level_source_images`
*State:* `Failed`

*Error Reason:*
> Amazon Redshift cannot replicate table 'dashboard_test.level_source_images' because column 'image' uses unsupported data type 'mediumblob' in Aurora MySQL. Modify your integration to exclude this table in the filter, or drop column 'image' from source table and run 'ALTER DATABASE test_learningplatform_mysql_zeroetl INTEGRATION REFRESH TABLE dashboard_test.level_source_images' to synchronize this table.

_Last Updated: 2026-03-27 22:07:44.697818_
_Integration ID: [REDACTED]_

*Zero-ETL Table Sync Alert (test)*
*Table:* `dashboard_test.stages_standards`
*State:* `Failed`

*Error Reason:*
> Amazon Redshift cannot replicate table 'dashboard_test.stages_standards' because the table is missing a primary key. Add primary key(s) to the source table and the table will resynchronize automatically.

_Last Updated: 2026-04-02 18:31:31.605345_
_Integration ID: [REDACTED]_
```



## Deployment notes
<!-- Delete this section if it's a standard merge-and-deploy.
     Otherwise: migrations, feature flags, coordination, caching impacts, etc. -->



## Privacy and security
<!-- Delete this section if there is no privacy/security impact.
     Otherwise: new PII, auth changes, API surface changes, etc. -->

