### PR TITLE
create ui-test-csp courses and units

### DIFF
--- a/dashboard/config/locales/courses/en.yml
+++ b/dashboard/config/locales/courses/en.yml
@@ -6802,6 +6802,30 @@ en:
           description_student: ''
           description_teacher: ''
           version_title: ''
+        ui-test-csp-2017:
+          title: UI Test CSP
+          description_short: ''
+          description_student: ''
+          description_teacher: ''
+          version_title: "'17-'18"
+        ui-test-original-csp-2017:
+          title: UI Test Original CSP ('17-'18)
+          description_short: unpublished, original course version which owns the csp units. this helps catch modular curriculum bugs in ui tests.
+          description_student: ''
+          description_teacher: ''
+          version_title: "'17-'18"
+        ui-test-original-csp-2019:
+          title: UI Test Original CSP ('19-'20)
+          description_short: unpublished, original course version which owns the csp units. this helps catch modular curriculum bugs in ui tests.
+          description_student: ''
+          description_teacher: ''
+          version_title: "'19-'20"
+        ui-test-csp-2019:
+          title: UI Test CSP
+          description_short: ''
+          description_student: ''
+          description_teacher: ''
+          version_title: "'19-'20"
         teaching-aif-design-build-ai-facilitators-2026:
           title: 'Teaching AIF: Designing & Building with AI'
           description_short: ''

--- a/dashboard/config/locales/scripts/en.yml
+++ b/dashboard/config/locales/scripts/en.yml
@@ -27183,6 +27183,54 @@ en:
           description_short: ''
           description: ''
           student_description: ''
+        ui-test-csp1-2017:
+          lessons:
+            lesson-1:
+              name: Lesson One
+            lesson-2:
+              name: Design Mode
+          lesson_groups: {}
+          name: ui-test-csp1-2017
+          title: Applab
+          description_audience: ''
+          description_short: ''
+          description: ''
+          student_description: ''
+        ui-test-csp2-2017:
+          lessons:
+            lesson-1:
+              name: Lesson One
+          lesson_groups: {}
+          name: ui-test-csp2-2017
+          title: Gamelab
+          description_audience: ''
+          description_short: ''
+          description: ''
+          student_description: ''
+        ui-test-csp1-2019:
+          lessons:
+            lesson-1:
+              name: Lesson One
+            lesson-2:
+              name: Design Mode
+          lesson_groups: {}
+          name: ui-test-csp1-2019
+          title: Applab
+          description_audience: ''
+          description_short: ''
+          description: ''
+          student_description: ''
+        ui-test-csp2-2019:
+          lessons:
+            lesson-1:
+              name: Lesson One
+          lesson_groups: {}
+          name: ui-test-csp2-2019
+          title: Gamelab
+          description_audience: ''
+          description_short: ''
+          description: ''
+          student_description: ''
         pl-facilitators-aif2-intro-2026:
           lessons: {}
           lesson_groups: {}

--- a/dashboard/test/ui/config/course_offerings/ui-test-csp.json
+++ b/dashboard/test/ui/config/course_offerings/ui-test-csp.json
@@ -1,0 +1,23 @@
+{
+  "key": "ui-test-csp",
+  "display_name": "UI Test CSP",
+  "is_featured": false,
+  "assignable": true,
+  "curriculum_type": "Course",
+  "marketing_initiative": "CSP",
+  "grade_levels": "10,11,12",
+  "header": "teacher_led",
+  "image": null,
+  "cs_topic": null,
+  "school_subject": null,
+  "device_compatibility": "{\"computer\":\"ideal\",\"chromebook\":\"not_recommended\",\"tablet\":\"not_recommended\",\"mobile\":\"incompatible\",\"no_device\":\"incompatible\"}",
+  "description": null,
+  "professional_learning_program": null,
+  "video": null,
+  "published_date": null,
+  "self_paced_pl_course_offering_key": null,
+  "ai_teaching_assistant_available": false,
+  "facilitator_course_permissions": [
+
+  ]
+}

--- a/dashboard/test/ui/config/course_offerings/ui-test-original-csp.json
+++ b/dashboard/test/ui/config/course_offerings/ui-test-original-csp.json
@@ -1,0 +1,21 @@
+{
+  "key": "ui-test-original-csp",
+  "display_name": "ui-test-original-csp",
+  "is_featured": false,
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null,
+  "image": null,
+  "cs_topic": null,
+  "school_subject": null,
+  "device_compatibility": null,
+  "description": null,
+  "professional_learning_program": null,
+  "video": null,
+  "published_date": null,
+  "self_paced_pl_course_offering_key": null,
+  "ai_teaching_assistant_available": false,
+  "facilitator_course_permissions": null
+}

--- a/dashboard/test/ui/config/courses/ui-test-csp-2017.course
+++ b/dashboard/test/ui/config/courses/ui-test-csp-2017.course
@@ -1,0 +1,25 @@
+{
+  "name": "ui-test-csp-2017",
+  "script_names": [
+    "ui-test-csp1-2017",
+    "ui-test-csp2-2017"
+  ],
+  "original_script_names": [
+
+  ],
+  "published_state": "stable",
+  "instruction_type": "teacher_led",
+  "participant_audience": "student",
+  "instructor_audience": "teacher",
+  "properties": {
+    "family_name": "ui-test-csp",
+    "numbered_units": "auto",
+    "version_year": "2017"
+  },
+  "resources": [
+
+  ],
+  "student_resources": [
+
+  ]
+}

--- a/dashboard/test/ui/config/courses/ui-test-csp-2019.course
+++ b/dashboard/test/ui/config/courses/ui-test-csp-2019.course
@@ -1,0 +1,25 @@
+{
+  "name": "ui-test-csp-2019",
+  "script_names": [
+    "ui-test-csp1-2019",
+    "ui-test-csp2-2019"
+  ],
+  "original_script_names": [
+
+  ],
+  "published_state": "stable",
+  "instruction_type": "teacher_led",
+  "participant_audience": "student",
+  "instructor_audience": "teacher",
+  "properties": {
+    "family_name": "ui-test-csp",
+    "numbered_units": "auto",
+    "version_year": "2019"
+  },
+  "resources": [
+
+  ],
+  "student_resources": [
+
+  ]
+}

--- a/dashboard/test/ui/config/courses/ui-test-original-csp-2017.course
+++ b/dashboard/test/ui/config/courses/ui-test-original-csp-2017.course
@@ -1,0 +1,26 @@
+{
+  "name": "ui-test-original-csp-2017",
+  "script_names": [
+    "ui-test-csp1-2017",
+    "ui-test-csp2-2017"
+  ],
+  "original_script_names": [
+    "ui-test-csp1-2017",
+    "ui-test-csp2-2017"
+  ],
+  "published_state": "in_development",
+  "instruction_type": "teacher_led",
+  "participant_audience": "student",
+  "instructor_audience": "teacher",
+  "properties": {
+    "family_name": "ui-test-original-csp",
+    "numbered_units": "auto",
+    "version_year": "2017"
+  },
+  "resources": [
+
+  ],
+  "student_resources": [
+
+  ]
+}

--- a/dashboard/test/ui/config/courses/ui-test-original-csp-2019.course
+++ b/dashboard/test/ui/config/courses/ui-test-original-csp-2019.course
@@ -1,0 +1,26 @@
+{
+  "name": "ui-test-original-csp-2019",
+  "script_names": [
+    "ui-test-csp1-2019",
+    "ui-test-csp2-2019"
+  ],
+  "original_script_names": [
+    "ui-test-csp1-2019",
+    "ui-test-csp2-2019"
+  ],
+  "published_state": "in_development",
+  "instruction_type": "teacher_led",
+  "participant_audience": "student",
+  "instructor_audience": "teacher",
+  "properties": {
+    "family_name": "ui-test-original-csp",
+    "numbered_units": "auto",
+    "version_year": "2019"
+  },
+  "resources": [
+
+  ],
+  "student_resources": [
+
+  ]
+}

--- a/dashboard/test/ui/config/scripts_json/ui-test-csp1-2017.script_json
+++ b/dashboard/test/ui/config/scripts_json/ui-test-csp1-2017.script_json
@@ -1,0 +1,224 @@
+{
+  "script": {
+    "name": "ui-test-csp1-2017",
+    "wrapup_video_id": null,
+    "login_required": false,
+    "properties": {
+      "curriculum_umbrella": "CSP",
+      "is_migrated": true
+    },
+    "new_name": null,
+    "family_name": null,
+    "serialized_at": "2026-04-01 00:47:34 UTC",
+    "hide_within_course": false,
+    "published_state": "in_development",
+    "instruction_type": null,
+    "instructor_audience": null,
+    "participant_audience": null,
+    "seeding_key": {
+      "script.name": "ui-test-csp1-2017"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "ui-test-csp1-2017"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "lesson-1",
+      "name": "Intro",
+      "absolute_position": 1,
+      "lockable": false,
+      "has_lesson_plan": true,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "lesson-1",
+        "lesson_group.key": "",
+        "script.name": "ui-test-csp1-2017"
+      }
+    },
+    {
+      "key": "lesson-2",
+      "name": "Design Mode",
+      "absolute_position": 2,
+      "lockable": false,
+      "has_lesson_plan": true,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "lesson-2",
+        "lesson_group.key": "",
+        "script.name": "ui-test-csp1-2017"
+      }
+    }
+  ],
+  "lesson_activities": [
+    {
+      "key": "b452091a-ec7c-4747-a78c-bc3cc03a493f",
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_activity.key": "b452091a-ec7c-4747-a78c-bc3cc03a493f",
+        "lesson.key": "lesson-1",
+        "lesson_group.key": "",
+        "script.name": "ui-test-csp1-2017"
+      }
+    },
+    {
+      "key": "ca905df1-658c-476b-8269-0f2d3fc2f205",
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_activity.key": "ca905df1-658c-476b-8269-0f2d3fc2f205",
+        "lesson.key": "lesson-2",
+        "lesson_group.key": "",
+        "script.name": "ui-test-csp1-2017"
+      }
+    }
+  ],
+  "activity_sections": [
+    {
+      "key": "de9bb4e2-d2fe-4f9c-9625-6b67cdc23473",
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "activity_section.key": "de9bb4e2-d2fe-4f9c-9625-6b67cdc23473",
+        "lesson_activity.key": "b452091a-ec7c-4747-a78c-bc3cc03a493f"
+      }
+    },
+    {
+      "key": "506741c2-cfc9-4571-9ebe-b05a9f19e69b",
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "activity_section.key": "506741c2-cfc9-4571-9ebe-b05a9f19e69b",
+        "lesson_activity.key": "ca905df1-658c-476b-8269-0f2d3fc2f205"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "activity_section_position": 1,
+      "assessment": false,
+      "properties": {
+      },
+      "bonus": false,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Applab test"
+        ],
+        "lesson.key": "lesson-1",
+        "lesson_group.key": "",
+        "script.name": "ui-test-csp1-2017",
+        "activity_section.key": "de9bb4e2-d2fe-4f9c-9625-6b67cdc23473"
+      },
+      "level_keys": [
+        "Applab test"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 1,
+      "activity_section_position": 1,
+      "assessment": false,
+      "properties": {
+      },
+      "bonus": false,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "allthethings design mode elements"
+        ],
+        "lesson.key": "lesson-2",
+        "lesson_group.key": "",
+        "script.name": "ui-test-csp1-2017",
+        "activity_section.key": "506741c2-cfc9-4571-9ebe-b05a9f19e69b"
+      },
+      "level_keys": [
+        "allthethings design mode elements"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "Applab test",
+        "script_level.level_keys": [
+          "Applab test"
+        ],
+        "lesson.key": "lesson-1",
+        "lesson_group.key": "",
+        "script.name": "ui-test-csp1-2017",
+        "activity_section.key": "de9bb4e2-d2fe-4f9c-9625-6b67cdc23473"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "allthethings design mode elements",
+        "script_level.level_keys": [
+          "allthethings design mode elements"
+        ],
+        "lesson.key": "lesson-2",
+        "lesson_group.key": "",
+        "script.name": "ui-test-csp1-2017",
+        "activity_section.key": "506741c2-cfc9-4571-9ebe-b05a9f19e69b"
+      }
+    }
+  ],
+  "resources": [
+
+  ],
+  "lessons_resources": [
+
+  ],
+  "scripts_resources": [
+
+  ],
+  "scripts_student_resources": [
+
+  ],
+  "vocabularies": [
+
+  ],
+  "lessons_vocabularies": [
+
+  ],
+  "lessons_programming_expressions": [
+
+  ],
+  "objectives": [
+
+  ],
+  "lessons_standards": [
+
+  ],
+  "lessons_opportunity_standards": [
+
+  ],
+  "rubrics": [
+
+  ],
+  "learning_goals": [
+
+  ],
+  "learning_goal_evidence_levels": [
+
+  ]
+}

--- a/dashboard/test/ui/config/scripts_json/ui-test-csp1-2019.script_json
+++ b/dashboard/test/ui/config/scripts_json/ui-test-csp1-2019.script_json
@@ -1,0 +1,224 @@
+{
+  "script": {
+    "name": "ui-test-csp1-2019",
+    "wrapup_video_id": null,
+    "login_required": false,
+    "properties": {
+      "curriculum_umbrella": "CSP",
+      "is_migrated": true
+    },
+    "new_name": null,
+    "family_name": null,
+    "serialized_at": "2026-04-01 00:47:23 UTC",
+    "hide_within_course": false,
+    "published_state": "in_development",
+    "instruction_type": null,
+    "instructor_audience": null,
+    "participant_audience": null,
+    "seeding_key": {
+      "script.name": "ui-test-csp1-2019"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "ui-test-csp1-2019"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "lesson-1",
+      "name": "Intro",
+      "absolute_position": 1,
+      "lockable": false,
+      "has_lesson_plan": true,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "lesson-1",
+        "lesson_group.key": "",
+        "script.name": "ui-test-csp1-2019"
+      }
+    },
+    {
+      "key": "lesson-2",
+      "name": "Design Mode",
+      "absolute_position": 2,
+      "lockable": false,
+      "has_lesson_plan": true,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "lesson-2",
+        "lesson_group.key": "",
+        "script.name": "ui-test-csp1-2019"
+      }
+    }
+  ],
+  "lesson_activities": [
+    {
+      "key": "68e2f806-ca0e-4e18-88e5-b37c327c0b21",
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_activity.key": "68e2f806-ca0e-4e18-88e5-b37c327c0b21",
+        "lesson.key": "lesson-1",
+        "lesson_group.key": "",
+        "script.name": "ui-test-csp1-2019"
+      }
+    },
+    {
+      "key": "c54a0af3-b779-48da-a6ab-5b14516972fd",
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_activity.key": "c54a0af3-b779-48da-a6ab-5b14516972fd",
+        "lesson.key": "lesson-2",
+        "lesson_group.key": "",
+        "script.name": "ui-test-csp1-2019"
+      }
+    }
+  ],
+  "activity_sections": [
+    {
+      "key": "d3ebc079-87e6-4afc-8506-d607fe2c7a2a",
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "activity_section.key": "d3ebc079-87e6-4afc-8506-d607fe2c7a2a",
+        "lesson_activity.key": "68e2f806-ca0e-4e18-88e5-b37c327c0b21"
+      }
+    },
+    {
+      "key": "79216b13-add9-4004-aacf-7c1e04373e9f",
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "activity_section.key": "79216b13-add9-4004-aacf-7c1e04373e9f",
+        "lesson_activity.key": "c54a0af3-b779-48da-a6ab-5b14516972fd"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "activity_section_position": 1,
+      "assessment": false,
+      "properties": {
+      },
+      "bonus": false,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Applab test"
+        ],
+        "lesson.key": "lesson-1",
+        "lesson_group.key": "",
+        "script.name": "ui-test-csp1-2019",
+        "activity_section.key": "d3ebc079-87e6-4afc-8506-d607fe2c7a2a"
+      },
+      "level_keys": [
+        "Applab test"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 1,
+      "activity_section_position": 1,
+      "assessment": false,
+      "properties": {
+      },
+      "bonus": false,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "allthethings design mode elements"
+        ],
+        "lesson.key": "lesson-2",
+        "lesson_group.key": "",
+        "script.name": "ui-test-csp1-2019",
+        "activity_section.key": "79216b13-add9-4004-aacf-7c1e04373e9f"
+      },
+      "level_keys": [
+        "allthethings design mode elements"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "Applab test",
+        "script_level.level_keys": [
+          "Applab test"
+        ],
+        "lesson.key": "lesson-1",
+        "lesson_group.key": "",
+        "script.name": "ui-test-csp1-2019",
+        "activity_section.key": "d3ebc079-87e6-4afc-8506-d607fe2c7a2a"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "allthethings design mode elements",
+        "script_level.level_keys": [
+          "allthethings design mode elements"
+        ],
+        "lesson.key": "lesson-2",
+        "lesson_group.key": "",
+        "script.name": "ui-test-csp1-2019",
+        "activity_section.key": "79216b13-add9-4004-aacf-7c1e04373e9f"
+      }
+    }
+  ],
+  "resources": [
+
+  ],
+  "lessons_resources": [
+
+  ],
+  "scripts_resources": [
+
+  ],
+  "scripts_student_resources": [
+
+  ],
+  "vocabularies": [
+
+  ],
+  "lessons_vocabularies": [
+
+  ],
+  "lessons_programming_expressions": [
+
+  ],
+  "objectives": [
+
+  ],
+  "lessons_standards": [
+
+  ],
+  "lessons_opportunity_standards": [
+
+  ],
+  "rubrics": [
+
+  ],
+  "learning_goals": [
+
+  ],
+  "learning_goal_evidence_levels": [
+
+  ]
+}

--- a/dashboard/test/ui/config/scripts_json/ui-test-csp2-2017.script_json
+++ b/dashboard/test/ui/config/scripts_json/ui-test-csp2-2017.script_json
@@ -1,0 +1,154 @@
+{
+  "script": {
+    "name": "ui-test-csp2-2017",
+    "wrapup_video_id": null,
+    "login_required": false,
+    "properties": {
+      "curriculum_umbrella": "CSP",
+      "is_migrated": true
+    },
+    "new_name": null,
+    "family_name": null,
+    "serialized_at": "2026-04-01 00:43:13 UTC",
+    "hide_within_course": false,
+    "published_state": "in_development",
+    "instruction_type": null,
+    "instructor_audience": null,
+    "participant_audience": null,
+    "seeding_key": {
+      "script.name": "ui-test-csp2-2017"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "ui-test-csp2-2017"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "lesson-1",
+      "name": "Lesson One",
+      "absolute_position": 1,
+      "lockable": false,
+      "has_lesson_plan": true,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "lesson-1",
+        "lesson_group.key": "",
+        "script.name": "ui-test-csp2-2017"
+      }
+    }
+  ],
+  "lesson_activities": [
+    {
+      "key": "4aa47cd9-da57-4574-bfe6-329cd83c19ff",
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_activity.key": "4aa47cd9-da57-4574-bfe6-329cd83c19ff",
+        "lesson.key": "lesson-1",
+        "lesson_group.key": "",
+        "script.name": "ui-test-csp2-2017"
+      }
+    }
+  ],
+  "activity_sections": [
+    {
+      "key": "9455ea03-7c01-4633-9c5a-220b884ad835",
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "activity_section.key": "9455ea03-7c01-4633-9c5a-220b884ad835",
+        "lesson_activity.key": "4aa47cd9-da57-4574-bfe6-329cd83c19ff"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "activity_section_position": 1,
+      "assessment": false,
+      "properties": {
+      },
+      "bonus": false,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "gamelab free play"
+        ],
+        "lesson.key": "lesson-1",
+        "lesson_group.key": "",
+        "script.name": "ui-test-csp2-2017",
+        "activity_section.key": "9455ea03-7c01-4633-9c5a-220b884ad835"
+      },
+      "level_keys": [
+        "gamelab free play"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "gamelab free play",
+        "script_level.level_keys": [
+          "gamelab free play"
+        ],
+        "lesson.key": "lesson-1",
+        "lesson_group.key": "",
+        "script.name": "ui-test-csp2-2017",
+        "activity_section.key": "9455ea03-7c01-4633-9c5a-220b884ad835"
+      }
+    }
+  ],
+  "resources": [
+
+  ],
+  "lessons_resources": [
+
+  ],
+  "scripts_resources": [
+
+  ],
+  "scripts_student_resources": [
+
+  ],
+  "vocabularies": [
+
+  ],
+  "lessons_vocabularies": [
+
+  ],
+  "lessons_programming_expressions": [
+
+  ],
+  "objectives": [
+
+  ],
+  "lessons_standards": [
+
+  ],
+  "lessons_opportunity_standards": [
+
+  ],
+  "rubrics": [
+
+  ],
+  "learning_goals": [
+
+  ],
+  "learning_goal_evidence_levels": [
+
+  ]
+}

--- a/dashboard/test/ui/config/scripts_json/ui-test-csp2-2019.script_json
+++ b/dashboard/test/ui/config/scripts_json/ui-test-csp2-2019.script_json
@@ -1,0 +1,154 @@
+{
+  "script": {
+    "name": "ui-test-csp2-2019",
+    "wrapup_video_id": null,
+    "login_required": false,
+    "properties": {
+      "curriculum_umbrella": "CSP",
+      "is_migrated": true
+    },
+    "new_name": null,
+    "family_name": null,
+    "serialized_at": "2026-04-01 00:42:59 UTC",
+    "hide_within_course": false,
+    "published_state": "in_development",
+    "instruction_type": null,
+    "instructor_audience": null,
+    "participant_audience": null,
+    "seeding_key": {
+      "script.name": "ui-test-csp2-2019"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "ui-test-csp2-2019"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "lesson-1",
+      "name": "Lesson One",
+      "absolute_position": 1,
+      "lockable": false,
+      "has_lesson_plan": true,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "lesson-1",
+        "lesson_group.key": "",
+        "script.name": "ui-test-csp2-2019"
+      }
+    }
+  ],
+  "lesson_activities": [
+    {
+      "key": "f84a75be-46cb-4544-8107-bac0543553ef",
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_activity.key": "f84a75be-46cb-4544-8107-bac0543553ef",
+        "lesson.key": "lesson-1",
+        "lesson_group.key": "",
+        "script.name": "ui-test-csp2-2019"
+      }
+    }
+  ],
+  "activity_sections": [
+    {
+      "key": "9cef51be-6575-4477-847e-7556068b6678",
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "activity_section.key": "9cef51be-6575-4477-847e-7556068b6678",
+        "lesson_activity.key": "f84a75be-46cb-4544-8107-bac0543553ef"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "activity_section_position": 1,
+      "assessment": false,
+      "properties": {
+      },
+      "bonus": false,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "gamelab free play"
+        ],
+        "lesson.key": "lesson-1",
+        "lesson_group.key": "",
+        "script.name": "ui-test-csp2-2019",
+        "activity_section.key": "9cef51be-6575-4477-847e-7556068b6678"
+      },
+      "level_keys": [
+        "gamelab free play"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "gamelab free play",
+        "script_level.level_keys": [
+          "gamelab free play"
+        ],
+        "lesson.key": "lesson-1",
+        "lesson_group.key": "",
+        "script.name": "ui-test-csp2-2019",
+        "activity_section.key": "9cef51be-6575-4477-847e-7556068b6678"
+      }
+    }
+  ],
+  "resources": [
+
+  ],
+  "lessons_resources": [
+
+  ],
+  "scripts_resources": [
+
+  ],
+  "scripts_student_resources": [
+
+  ],
+  "vocabularies": [
+
+  ],
+  "lessons_vocabularies": [
+
+  ],
+  "lessons_programming_expressions": [
+
+  ],
+  "objectives": [
+
+  ],
+  "lessons_standards": [
+
+  ],
+  "lessons_opportunity_standards": [
+
+  ],
+  "rubrics": [
+
+  ],
+  "learning_goals": [
+
+  ],
+  "learning_goal_evidence_levels": [
+
+  ]
+}


### PR DESCRIPTION

creates the following:
- ui-test-csp course offering
- courses ui-test-csp-2017 and 2019
- two units for each course

the course offering has the right settings to show up in the course catalog (screenshot below) and in the assignment dropdown (demonstrated by ui tests in https://github.com/code-dot-org/code-dot-org/pull/71816). 

screenshots:
<img width="1114" height="986" alt="Screenshot 2026-03-31 at 9 54 00 PM" src="https://github.com/user-attachments/assets/d25f34b9-004f-4530-aa92-b221b6c2f17d" />
<img width="1177" height="567" alt="Screenshot 2026-03-31 at 9 52 51 PM" src="https://github.com/user-attachments/assets/f73586cc-dcce-4e82-b3f2-f5c51b1da40d" />
<img width="1237" height="611" alt="Screenshot 2026-03-31 at 9 53 03 PM" src="https://github.com/user-attachments/assets/3b96dce6-1a41-47fe-9625-2a7a399d0352" />

## Testing story
- #71816 verifies that this is getting seeded properly in drone ui tests

