### PR TITLE
Move @mui/material to peerDependencies in component-library

### DIFF
--- a/apps/src/types/mui.d.ts
+++ b/apps/src/types/mui.d.ts
@@ -1,11 +1,15 @@
 /**
  * MUI type overrides for apps
  *
- * IMPORTANT: This file contains manually copied type augmentations from:
+ * This file contains type augmentations that were manually copied from:
  *   frontend/packages/component-library/src/themes/code.org/types.d.ts
  *
- * When Button/IconButton/Breadcrumbs type augmentations change in component-library,
- * they must be manually copied here to keep apps in sync.
+ * Now that @mui/material is a peerDependency of the component-library (rather
+ * than a devDependency), both packages resolve to the same physical MUI copy.
+ * This means the augmentations from the component-library should propagate
+ * automatically, and the manually copied Button/IconButton/Breadcrumbs
+ * augmentations below may no longer be necessary. They are kept for now and
+ * can be cleaned up in a follow-up PR.
  *
  * This file also includes apps-specific Typography type augmentations.
  */

--- a/apps/yarn.lock
+++ b/apps/yarn.lock
@@ -3923,6 +3923,7 @@ __metadata:
     react-player: "npm:^3.4.0"
     react-schemaorg: "npm:^2.0.0"
   peerDependencies:
+    "@mui/material": ^7.3.2
     classnames: ^2.5.1
     react: ">=16"
     react-dom: ">=16"

--- a/frontend/packages/component-library/MIGRATION_STATUS.md
+++ b/frontend/packages/component-library/MIGRATION_STATUS.md
@@ -71,7 +71,7 @@ export const STYLE_OVERRIDES: Components<Theme> = {
 
 ## Type Augmentations
 
-Custom MUI type augmentations are defined in `src/themes/code.org/types.d.ts` and must be manually synced to `apps/src/types/mui.d.ts` (TypeScript module augmentation doesn't cross package boundaries in this monorepo).
+Custom MUI type augmentations are defined in `src/themes/code.org/types.d.ts`. Now that `@mui/material` is a `peerDependency` (not a `devDependency`), both this package and `apps/` resolve to the same physical MUI copy, so augmentations should propagate automatically. The manually copied augmentations in `apps/src/types/mui.d.ts` are kept for now but may no longer be necessary and can be cleaned up in a follow-up PR.
 
 ## How to Migrate a Component
 

--- a/frontend/packages/component-library/package.json
+++ b/frontend/packages/component-library/package.json
@@ -424,7 +424,6 @@
     "@code-dot-org/component-library-styles": "workspace:*",
     "@code-dot-org/fonts": "workspace:*",
     "@code-dot-org/lint-config": "workspace:*",
-    "@mui/material": "^7.3.2",
     "@release-it/conventional-changelog": "^10.0.0",
     "@swc/core": "^1.9.3",
     "@swc/jest": "^0.2.37",
@@ -467,6 +466,7 @@
     "vite-plugin-lib-inject-css": "^2.2.2"
   },
   "peerDependencies": {
+    "@mui/material": "^7.3.2",
     "classnames": "^2.5.1",
     "react": ">=16",
     "react-dom": ">=16",

--- a/frontend/packages/component-library/src/themes/code.org/types.d.ts
+++ b/frontend/packages/component-library/src/themes/code.org/types.d.ts
@@ -1,17 +1,14 @@
 /**
  * Type declarations to extend MUI's Button, IconButton, and Breadcrumbs components with custom sizes and colors
  *
- * IMPORTANT: These type augmentations must be manually copied to apps/src/types/mui.d.ts
- * when they change. Right now, TypeScript module augmentation doesn't work across package boundaries
- * in this monorepo setup, so manual synchronization is required.
+ * Now that @mui/material is declared as a peerDependency (not a devDependency),
+ * both this package and apps/ resolve to the same physical @mui/material copy.
+ * This means TypeScript module augmentations defined here should propagate
+ * automatically to apps/ without manual synchronization.
  *
- * To update apps types:
- * 1. Make changes to this file
- * 2. Copy the Button, IconButton, and Breadcrumbs declare module blocks to apps/src/types/mui.d.ts
- * 3. Keep the source reference comment in apps/src/types/mui.d.ts pointing to this file
- *
- * If at any point we find a solution for sharing this without
- * need of manually syncing the types - you're welcome to update this!
+ * NOTE: apps/src/types/mui.d.ts still contains a manually copied version of
+ * these augmentations from before this fix. That duplication is harmless but
+ * can be cleaned up in a follow-up PR once we confirm everything works.
  */
 
 import '@mui/material/styles';

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -1279,7 +1279,6 @@ __metadata:
     "@code-dot-org/component-library-styles": "workspace:*"
     "@code-dot-org/fonts": "workspace:*"
     "@code-dot-org/lint-config": "workspace:*"
-    "@mui/material": "npm:^7.3.2"
     "@release-it/conventional-changelog": "npm:^10.0.0"
     "@swc/core": "npm:^1.9.3"
     "@swc/jest": "npm:^0.2.37"
@@ -1324,6 +1323,7 @@ __metadata:
     vite-plugin-externalize-deps: "catalog:"
     vite-plugin-lib-inject-css: "npm:^2.2.2"
   peerDependencies:
+    "@mui/material": ^7.3.2
     classnames: ^2.5.1
     react: ">=16"
     react-dom: ">=16"
@@ -4073,42 +4073,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@mui/material@npm:^7.3.2, @mui/material@npm:^7.3.5":
-  version: 7.3.5
-  resolution: "@mui/material@npm:7.3.5"
-  dependencies:
-    "@babel/runtime": "npm:^7.28.4"
-    "@mui/core-downloads-tracker": "npm:^7.3.5"
-    "@mui/system": "npm:^7.3.5"
-    "@mui/types": "npm:^7.4.8"
-    "@mui/utils": "npm:^7.3.5"
-    "@popperjs/core": "npm:^2.11.8"
-    "@types/react-transition-group": "npm:^4.4.12"
-    clsx: "npm:^2.1.1"
-    csstype: "npm:^3.1.3"
-    prop-types: "npm:^15.8.1"
-    react-is: "npm:^19.2.0"
-    react-transition-group: "npm:^4.4.5"
-  peerDependencies:
-    "@emotion/react": ^11.5.0
-    "@emotion/styled": ^11.3.0
-    "@mui/material-pigment-css": ^7.3.5
-    "@types/react": ^17.0.0 || ^18.0.0 || ^19.0.0
-    react: ^17.0.0 || ^18.0.0 || ^19.0.0
-    react-dom: ^17.0.0 || ^18.0.0 || ^19.0.0
-  peerDependenciesMeta:
-    "@emotion/react":
-      optional: true
-    "@emotion/styled":
-      optional: true
-    "@mui/material-pigment-css":
-      optional: true
-    "@types/react":
-      optional: true
-  checksum: 10c0/363ff79d0eaf8044510529bf8d143d7e6f5298297dcfbd0816c5caf49e9514bde6b187b0e135cc1d73ac2ecfec1b06d3fea3bba952e7d8d0bfc997d0510fff8a
-  languageName: node
-  linkType: hard
-
 "@mui/material@npm:^7.3.4":
   version: 7.3.4
   resolution: "@mui/material@npm:7.3.4"
@@ -4142,6 +4106,42 @@ __metadata:
     "@types/react":
       optional: true
   checksum: 10c0/bd6ad058c3505bb8b680113ade6ac2cb20b21f7bc6a53c202c89a950b3570586e16646a7a04930ef6ea707a77000440d73b246301ff0d09380b2fb392452b678
+  languageName: node
+  linkType: hard
+
+"@mui/material@npm:^7.3.5":
+  version: 7.3.5
+  resolution: "@mui/material@npm:7.3.5"
+  dependencies:
+    "@babel/runtime": "npm:^7.28.4"
+    "@mui/core-downloads-tracker": "npm:^7.3.5"
+    "@mui/system": "npm:^7.3.5"
+    "@mui/types": "npm:^7.4.8"
+    "@mui/utils": "npm:^7.3.5"
+    "@popperjs/core": "npm:^2.11.8"
+    "@types/react-transition-group": "npm:^4.4.12"
+    clsx: "npm:^2.1.1"
+    csstype: "npm:^3.1.3"
+    prop-types: "npm:^15.8.1"
+    react-is: "npm:^19.2.0"
+    react-transition-group: "npm:^4.4.5"
+  peerDependencies:
+    "@emotion/react": ^11.5.0
+    "@emotion/styled": ^11.3.0
+    "@mui/material-pigment-css": ^7.3.5
+    "@types/react": ^17.0.0 || ^18.0.0 || ^19.0.0
+    react: ^17.0.0 || ^18.0.0 || ^19.0.0
+    react-dom: ^17.0.0 || ^18.0.0 || ^19.0.0
+  peerDependenciesMeta:
+    "@emotion/react":
+      optional: true
+    "@emotion/styled":
+      optional: true
+    "@mui/material-pigment-css":
+      optional: true
+    "@types/react":
+      optional: true
+  checksum: 10c0/363ff79d0eaf8044510529bf8d143d7e6f5298297dcfbd0816c5caf49e9514bde6b187b0e135cc1d73ac2ecfec1b06d3fea3bba952e7d8d0bfc997d0510fff8a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

- Moves `@mui/material` from `devDependencies` to `peerDependencies` in `@code-dot-org/component-library`
- Updates documentation comments in type augmentation files and migration docs to reflect the fix
- No code logic, build config, or import changes — only `package.json` dependency classification and doc comments

## Problem

The component-library declared `@mui/material` as a `devDependency`, which caused two separate physical copies to be installed:
- `apps/node_modules/@mui/material`
- `frontend/packages/component-library/node_modules/@mui/material`

Because TypeScript module augmentations (custom colors like `'tertiary'`, sizes like `'extraSmall'`) are scoped to the physical module they augment, augmentations defined in one package didn't apply to the other's MUI copy. This required manual synchronization of type declarations between `apps/src/types/mui.d.ts` and `src/themes/code.org/types.d.ts`, and led to workaround types like `ComponentLibraryButtonProps`.

## Fix

By making `@mui/material` a `peerDependency`, both packages resolve to the same physical copy (the one in `apps/node_modules/`). Module augmentations now propagate automatically across package boundaries.

The build config (`vite.config.ts`) already uses `externalizeDeps()` which externalizes `peerDependencies`, so no build changes are needed.

## What's NOT in this PR

- Deletion of the now-redundant manually-copied augmentations in `apps/src/types/mui.d.ts` (follow-up PR)
- Deletion of `ComponentLibraryButtonProps` workaround types (follow-up PR)

## Test plan

- [ ] Verify `yarn install` succeeds (MUI resolves from `apps/node_modules/`)
- [ ] Verify `yarn run typecheck` passes in `apps/`
- [ ] Verify component-library builds successfully (`vite build`)
- [ ] Verify CI (drone) passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)