### PR TITLE
Update share dialog with warning when source code is flagged

### DIFF
--- a/apps/src/code-studio/components/ShareAllowedDialog.jsx
+++ b/apps/src/code-studio/components/ShareAllowedDialog.jsx
@@ -97,7 +97,7 @@ class ShareAllowedDialog extends React.Component {
     replayVideoUnavailable: false,
     hasBeenCopied: false,
     isLoadingAccountAndProjectAge: false,
-    showSharingDisabledDialog: false,
+    showSharingDisallowedDialog: false,
   };
 
   componentDidMount() {
@@ -120,8 +120,8 @@ class ShareAllowedDialog extends React.Component {
       recordShare('SHARING_DIALOG_OPEN', this.props.appType);
       this.setState({hasBeenCopied: false});
 
-      if (this.sharingDisabled()) {
-        this.setState({showSharingDisabledDialog: true});
+      if (this.sharingDisallowedWhileSignedIn()) {
+        this.setState({showSharingDisallowedDialog: true});
       }
     }
   }
@@ -136,6 +136,9 @@ class ShareAllowedDialog extends React.Component {
     this.props.userSharingDisabled &&
     OPEN_ENDED_LEGACY_PROJECT_TYPES.includes(this.props.appType);
 
+  sharingDisallowedWhileSignedIn = () =>
+    this.sharingDisabled() || this.hasPrivacyProfanityViolation();
+
   hasPrivacyProfanityViolation = () => this.props.hasPrivacyProfanityViolation;
 
   close = () => {
@@ -143,7 +146,7 @@ class ShareAllowedDialog extends React.Component {
     this.props.onClose();
     this.setState({
       replayVideoUnavailable: false,
-      showSharingDisabledDialog: false,
+      showSharingDisallowedDialog: false,
     });
   };
 
@@ -261,18 +264,27 @@ class ShareAllowedDialog extends React.Component {
 
     return (
       <div>
-        {this.sharingDisabled() && this.state.showSharingDisabledDialog && (
-          <Dialog
-            title={i18n.sharingDisabledTitle()}
-            description={i18n.sharingBlockedByTeacherOpenEndedProjects()}
-            primaryButtonProps={{
-              onClick: this.close,
-              text: i18n.ok(),
-              id: 'uitest-sharing-disabled-button',
-            }}
-          />
-        )}
-        {!this.sharingDisabled() && (
+        {this.sharingDisallowedWhileSignedIn() &&
+          this.state.showSharingDisallowedDialog && (
+            <Dialog
+              title={
+                this.sharingDisabled()
+                  ? i18n.sharingDisabledTitle()
+                  : 'Sharing is not allowed'
+              }
+              description={
+                this.sharingDisabled()
+                  ? i18n.sharingBlockedByTeacherOpenEndedProjects()
+                  : 'This project is unable to be shared because it contains content that is flagged. Please update your project or contact support@code.org if you believe this is an error.'
+              }
+              primaryButtonProps={{
+                onClick: this.close,
+                text: i18n.ok(),
+                id: 'uitest-sharing-disabled-button',
+              }}
+            />
+          )}
+        {!this.sharingDisallowedWhileSignedIn() && (
           <BaseDialog
             style={styles.modal}
             isOpen={isOpen}
@@ -295,16 +307,6 @@ class ShareAllowedDialog extends React.Component {
                           `Abuse error for project at url: ${shareUrl}`
                         )}`,
                       }),
-                    }}
-                    className="alert-error"
-                    style={styles.abuseStyle}
-                    textStyle={styles.abuseTextStyle}
-                  />
-                )}
-                {this.hasPrivacyProfanityViolation() && (
-                  <AbuseError
-                    i18n={{
-                      tos: i18n.policyViolation(),
                     }}
                     className="alert-error"
                     style={styles.abuseStyle}
@@ -553,7 +555,7 @@ export default connect(
     exportApp: state.pageConstants?.exportApp,
     isOpen: state.shareDialog.isOpen,
     inRestrictedShareMode: state.project.inRestrictedShareMode,
-    showSharingDisabledDialog: state.shareDialog.showSharingDisabledDialog,
+    showSharingDisallowedDialog: state.shareDialog.showSharingDisallowedDialog,
     hasPrivacyProfanityViolation: state.project.hasPrivacyProfanityViolation,
   }),
   dispatch => ({

--- a/apps/src/code-studio/components/ShareAllowedDialog.jsx
+++ b/apps/src/code-studio/components/ShareAllowedDialog.jsx
@@ -84,6 +84,7 @@ class ShareAllowedDialog extends React.Component {
     canShareSocial: PropTypes.bool.isRequired,
     userSharingDisabled: PropTypes.bool,
     inRestrictedShareMode: PropTypes.bool,
+    hasPrivacyProfanityViolation: PropTypes.bool,
   };
 
   state = {
@@ -134,6 +135,8 @@ class ShareAllowedDialog extends React.Component {
   sharingDisabled = () =>
     this.props.userSharingDisabled &&
     OPEN_ENDED_LEGACY_PROJECT_TYPES.includes(this.props.appType);
+
+  hasPrivacyProfanityViolation = () => this.props.hasPrivacyProfanityViolation;
 
   close = () => {
     recordShare('SHARING_CLOSE_ESCAPE', this.props.appType);
@@ -292,6 +295,16 @@ class ShareAllowedDialog extends React.Component {
                           `Abuse error for project at url: ${shareUrl}`
                         )}`,
                       }),
+                    }}
+                    className="alert-error"
+                    style={styles.abuseStyle}
+                    textStyle={styles.abuseTextStyle}
+                  />
+                )}
+                {this.hasPrivacyProfanityViolation() && (
+                  <AbuseError
+                    i18n={{
+                      tos: i18n.policyViolation(),
                     }}
                     className="alert-error"
                     style={styles.abuseStyle}
@@ -541,6 +554,7 @@ export default connect(
     isOpen: state.shareDialog.isOpen,
     inRestrictedShareMode: state.project.inRestrictedShareMode,
     showSharingDisabledDialog: state.shareDialog.showSharingDisabledDialog,
+    hasPrivacyProfanityViolation: state.project.hasPrivacyProfanityViolation,
   }),
   dispatch => ({
     onClose: () => dispatch(hideShareDialog()),

--- a/apps/src/code-studio/initApp/project.js
+++ b/apps/src/code-studio/initApp/project.js
@@ -23,6 +23,7 @@ import {
   workspaceAlertTypes,
   displayWorkspaceAlert,
   refreshInRestrictedShareMode,
+  refreshHasPrivacyProfanityViolation,
   refreshTeacherHasConfirmedUploadWarning,
 } from '../projectRedux';
 import {queryParams, hasQueryParam, updateQueryParam} from '../utils';
@@ -2047,6 +2048,9 @@ function fetchPrivacyProfanityViolations(resolve) {
     // data.has_violation is 0 or true, coerce to a boolean.
     currentHasPrivacyProfanityViolation =
       (data && !!data.has_violation) || currentHasPrivacyProfanityViolation;
+    if (currentHasPrivacyProfanityViolation) {
+      getStore().dispatch(refreshHasPrivacyProfanityViolation());
+    }
     resolve();
     if (err) {
       // Throw an error so that things like New Relic see this. This shouldn't

--- a/apps/src/code-studio/projectRedux.ts
+++ b/apps/src/code-studio/projectRedux.ts
@@ -9,6 +9,7 @@ export interface ProjectState {
   showTryAgainDialog: boolean;
   workspaceAlert: WorkspaceAlert | null;
   inRestrictedShareMode: boolean;
+  hasPrivacyProfanityViolation: boolean;
   teacherHasConfirmedUploadWarning: boolean;
 }
 
@@ -42,6 +43,7 @@ const initialState: ProjectState = {
   showTryAgainDialog: false,
   workspaceAlert: null,
   inRestrictedShareMode: false,
+  hasPrivacyProfanityViolation: false,
   teacherHasConfirmedUploadWarning: false,
 };
 
@@ -95,6 +97,10 @@ const projectReduxSlice = createSlice({
     refreshInRestrictedShareMode: state => {
       state.inRestrictedShareMode = dashboard.project.inRestrictedShareMode();
     },
+    refreshHasPrivacyProfanityViolation: state => {
+      state.hasPrivacyProfanityViolation =
+        dashboard.project.hasPrivacyProfanityViolation();
+    },
     refreshTeacherHasConfirmedUploadWarning: state => {
       state.teacherHasConfirmedUploadWarning =
         dashboard.project.teacherHasConfirmedUploadWarning();
@@ -115,6 +121,7 @@ export const {
   setNameFailure,
   unsetNameFailure,
   refreshInRestrictedShareMode,
+  refreshHasPrivacyProfanityViolation,
   refreshTeacherHasConfirmedUploadWarning,
 } = projectReduxSlice.actions;
 

--- a/apps/test/unit/code-studio/components/ShareAllowedDialogTest.jsx
+++ b/apps/test/unit/code-studio/components/ShareAllowedDialogTest.jsx
@@ -1,0 +1,103 @@
+import {render, screen} from '@testing-library/react';
+import React from 'react';
+import {Provider} from 'react-redux';
+
+import {UnconnectedShareAllowedDialog as ShareAllowedDialog} from '@cdo/apps/code-studio/components/ShareAllowedDialog';
+import shareDialogReducer from '@cdo/apps/code-studio/components/shareDialogRedux';
+import {getStore, registerReducers} from '@cdo/apps/redux';
+
+const DEFAULT_PROPS = {
+  shareUrl: 'https://studio.code.org/projects/spritelab/abc123',
+  isAbusive: false,
+  isOpen: false,
+  channelId: 'abc123',
+  appType: 'spritelab',
+  onClickPopup: () => {},
+  onClose: () => {},
+  canShareSocial: false,
+  inRestrictedShareMode: false,
+};
+
+function renderWithStore(props) {
+  registerReducers({shareDialog: shareDialogReducer});
+  const store = getStore();
+  return render(
+    <Provider store={store}>
+      <ShareAllowedDialog {...DEFAULT_PROPS} {...props} />
+    </Provider>
+  );
+}
+
+// Renders the dialog closed then re-renders open, triggering componentDidUpdate
+// which sets showSharingDisallowedDialog state on the isOpen false->true transition.
+function renderAndOpen(props) {
+  const {rerender} = renderWithStore({...props, isOpen: false});
+  rerender(
+    <Provider store={getStore()}>
+      <ShareAllowedDialog {...DEFAULT_PROPS} {...props} isOpen={true} />
+    </Provider>
+  );
+}
+
+describe('ShareAllowedDialog', () => {
+  describe('privacy/profanity violation dialog', () => {
+    it('shows "Sharing is not allowed" title when hasPrivacyProfanityViolation is true', () => {
+      renderAndOpen({hasPrivacyProfanityViolation: true});
+      expect(screen.getByText('Sharing is not allowed')).toBeInTheDocument();
+    });
+
+    it('shows flagged content message when hasPrivacyProfanityViolation is true', () => {
+      renderAndOpen({hasPrivacyProfanityViolation: true});
+      expect(
+        screen.getByText(
+          /This project is unable to be shared because it contains content that is flagged/
+        )
+      ).toBeInTheDocument();
+    });
+
+    it('hides the main share panel when hasPrivacyProfanityViolation is true', () => {
+      renderAndOpen({hasPrivacyProfanityViolation: true});
+      expect(
+        screen.queryByText(/Copy Link to Project/i)
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  describe('teacher-disabled sharing dialog', () => {
+    it('does not show the profanity violation message when only userSharingDisabled', () => {
+      renderAndOpen({appType: 'applab', userSharingDisabled: true});
+      expect(
+        screen.queryByText(
+          /This project is unable to be shared because it contains content that is flagged/
+        )
+      ).not.toBeInTheDocument();
+    });
+
+    it('hides the main share panel when userSharingDisabled is true for an open-ended project type', () => {
+      renderAndOpen({appType: 'applab', userSharingDisabled: true});
+      expect(
+        screen.queryByText(/Copy Link to Project/i)
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  describe('normal share dialog', () => {
+    it('shows the main share panel when no violation and sharing not disabled', () => {
+      renderAndOpen({
+        hasPrivacyProfanityViolation: false,
+        userSharingDisabled: false,
+      });
+      expect(screen.getByText(/Copy Link to Project/i)).toBeInTheDocument();
+    });
+
+    it('does not show the disallowed dialog when no violation', () => {
+      renderAndOpen({
+        hasPrivacyProfanityViolation: false,
+        userSharingDisabled: false,
+      });
+      expect(
+        screen.queryByText('Sharing is not allowed')
+      ).not.toBeInTheDocument();
+    });
+  });
+});


### PR DESCRIPTION
This PR updates the share dialog for legacy lab projects when source code is flagged by WebPurify. Similar to https://github.com/code-dot-org/code-dot-org/pull/66382, when the source code is flagged and a user is signed in, we display a modal letting users that project is not shareable. 

As contrast, the `ShareDisallowedDialog` is displayed when a user is not signed in and a button is displayed to create an account.

## Before update

https://github.com/user-attachments/assets/2c106b42-1874-4f30-80e9-d09e51c9bdb7


## After update


https://github.com/user-attachments/assets/c507cfa6-9968-4adb-a04b-042791eec1b5




<!--
  Summary of the change: background, motivation, and context.
  Include screenshots, videos, or before/after comparisons for UI changes.
-->



## Links
<!-- Jira tickets, design docs, Slack threads, related PRs, etc. -->

- Jira: https://codedotorg.atlassian.net/browse/SL-1358

## Testing story
<!-- How was this tested? Manual steps, adhoc links, automated tests, or why testing isn't needed. -->

Tested locally in Sprite Lab (lab whose source code is moderated).



## Deployment notes
<!-- Delete this section if it's a standard merge-and-deploy.
     Otherwise: migrations, feature flags, coordination, caching impacts, etc. -->



## Privacy and security
<!-- Delete this section if there is no privacy/security impact.
     Otherwise: new PII, auth changes, API surface changes, etc. -->

