### PR TITLE
update teacher dashboard ui tests to use lockable lesson in allthethings course

### DIFF
--- a/dashboard/test/ui/features/teacher_tools/teacher_dashboard/teacher_dashboard_assessments1.feature
+++ b/dashboard/test/ui/features/teacher_tools/teacher_dashboard/teacher_dashboard_assessments1.feature
@@ -7,18 +7,9 @@ Feature: Using the assessments tab in the teacher dashboard
     # Assign a unit with a survey but no assessment
     When I sign in as "Teacher_Sally" and go home
     And I get levelbuilder access
-    And I click selector "#section-options-dropdown-dropdown-button" once I see it
-    And I click selector "#ui-test-Section-settings"
-    And I press the first "input[name='grades[]']" element
-    And I wait until element "button:contains(High School)" is visible
-    And I click selector "button:contains(High School)"
-    And I press the first "input[name='Computer Science Principles']" element
-    And I wait until element "#assignment-version-year" is visible
-    And I press "assignment-version-year"
-    And I click selector ".assignment-version-title:contains('24-'25)" once I see it
-    And I wait until element "#uitest-secondary-assignment" is visible
-    And I select the "CS Principles Post-Course Survey" option in dropdown "uitest-secondary-assignment"
-    And I press the first "#uitest-save-section-changes" element to load a new page
+    And I assign my section in row 1 to course "allthethingscourse" unit 1
+    And I reload the page
+    And I click selector "a:contains(View progress)" once I see it
 
     # Progress tab
     And I wait until element "#unit-selector-v2" is visible
@@ -26,4 +17,6 @@ Feature: Using the assessments tab in the teacher dashboard
     # Assessments tab
     And I click selector "#ui-test-teacher-sidebar a:contains(Assessments)" once I see it
     And I wait until element "#unit-selector-v2" is visible
+    And I wait until element "#assessment-selector" is visible
+    And I select the "Anonymous student survey 2" option in dropdown "assessment-selector"
     Then I wait until element "div:contains(this survey is anonymous)" is visible

--- a/dashboard/test/ui/features/teacher_tools/teacher_dashboard/teacher_dashboard_assessments2.feature
+++ b/dashboard/test/ui/features/teacher_tools/teacher_dashboard/teacher_dashboard_assessments2.feature
@@ -14,36 +14,36 @@ Feature: Using the assessments tab in the teacher dashboard
     And I join the section
 
     When I sign in as "Teacher_Sally" and go home
-    And I am on "http://studio.code.org/courses/csp-2024/units/11"
-    And I wait until element "span:contains(Course Survey)" is visible
-    And I open the lesson lock dialog
+    And I am on "http://studio.code.org/courses/allthethingscourse/units/1"
+    And I wait until element "span:contains(Example CSP Assessment)" is visible
+    And I open the lesson lock dialog for lockable lesson 3
     And I unlock the lesson for students
     And I wait until element ".modal-backdrop" is gone
 
     And I sign in as "Sally" and go home
-    And I submit the assessment on "http://studio.code.org/courses/csp-2024/units/11/lockable/1/levels/1/page/5"
+    And I submit the assessment on "http://studio.code.org/courses/allthethingscourse/units/1/lockable/3/levels/1/page/3"
 
     And I sign in as "Student2" and go home
-    And I submit the assessment on "http://studio.code.org/courses/csp-2024/units/11/lockable/1/levels/1/page/5"
+    And I submit the assessment on "http://studio.code.org/courses/allthethingscourse/units/1/lockable/3/levels/1/page/3"
 
     And I sign in as "Student3" and go home
-    And I submit the assessment on "http://studio.code.org/courses/csp-2024/units/11/lockable/1/levels/1/page/5"
+    And I submit the assessment on "http://studio.code.org/courses/allthethingscourse/units/1/lockable/3/levels/1/page/3"
 
     And I sign in as "Student4" and go home
-    And I submit the assessment on "http://studio.code.org/courses/csp-2024/units/11/lockable/1/levels/1/page/5"
+    And I submit the assessment on "http://studio.code.org/courses/allthethingscourse/units/1/lockable/3/levels/1/page/3"
 
     And I sign in as "Student5" and go home
-    And I submit the assessment on "http://studio.code.org/courses/csp-2024/units/11/lockable/1/levels/1/page/5"
+    And I submit the assessment on "http://studio.code.org/courses/allthethingscourse/units/1/lockable/3/levels/1/page/3"
 
     # Assign a unit with an unlocked survey
     When I sign in as "Teacher_Sally" and go home
     And I get levelbuilder access
-    And I assign my section in row 1 to course "csp-2024" unit 11
+    And I assign my section in row 1 to course "allthethingscourse" unit 1
     And I reload the page
     And I click selector "a:contains(View progress)" once I see it
 
     # Progress tab
-    And I wait until element "#unit-selector-v2" contains text "CS Principles Post-Course Survey"
+    And I wait until element "#unit-selector-v2" contains text "All the Things!"
 
     # Assessments tab
     And I click selector "#ui-test-teacher-sidebar a:contains(Assessments)" once I see it

--- a/dashboard/test/ui/features/teacher_tools/teacher_dashboard/teacher_dashboard_assessments2.feature
+++ b/dashboard/test/ui/features/teacher_tools/teacher_dashboard/teacher_dashboard_assessments2.feature
@@ -22,7 +22,7 @@ Feature: Using the assessments tab in the teacher dashboard
 
     And I sign in as "Sally" and go home
     And I submit the assessment on "http://studio.code.org/courses/csp-2024/units/11/lockable/1/levels/1/page/5"
-    
+
     And I sign in as "Student2" and go home
     And I submit the assessment on "http://studio.code.org/courses/csp-2024/units/11/lockable/1/levels/1/page/5"
 
@@ -38,17 +38,9 @@ Feature: Using the assessments tab in the teacher dashboard
     # Assign a unit with an unlocked survey
     When I sign in as "Teacher_Sally" and go home
     And I get levelbuilder access
-    And I click selector "#section-options-dropdown-dropdown-button" once I see it
-    And I click selector "#ui-test-Section-settings"
-    And I press the first "input[name='grades[]']" element
-    And I wait until element "button:contains(High School)" is visible
-    And I click selector "button:contains(High School)"
-    And I press the first "input[name='Computer Science Principles']" element
-    And I wait until element "#assignment-version-year" is visible
-    And I press "assignment-version-year"
-    And I click selector ".assignment-version-title:contains('24-'25)" once I see it
-    And I select the "CS Principles Post-Course Survey" option in dropdown "uitest-secondary-assignment"
-    And I press the first "#uitest-save-section-changes" element to load a new page
+    And I assign my section in row 1 to course "csp-2024" unit 11
+    And I reload the page
+    And I click selector "a:contains(View progress)" once I see it
 
     # Progress tab
     And I wait until element "#unit-selector-v2" contains text "CS Principles Post-Course Survey"


### PR DESCRIPTION
the goal of this PR is to move ui tests off of production courses. for background, see [partitioned curriculum data proposal](https://docs.google.com/document/d/1iiJXtPODakjuZ7-2yKJ941H56dcyUmUFtWa7zGgqKdw/edit?tab=t.0#heading=h.qx67631q1z2d)

This PR moves the teacher dashboard assessment tests off of csp and onto allthethings.