### PR TITLE
Disable flaky aidiff UI test scenario

### DIFF
--- a/dashboard/test/ui/features/teacher_tools/ai_diff/ai_differentiation_chat.feature
+++ b/dashboard/test/ui/features/teacher_tools/ai_diff/ai_differentiation_chat.feature
@@ -107,6 +107,7 @@ Feature: Send and receive messages in the AI differentiation chat
     And I click selector "button[aria-label='Give this message a thumbs up']:eq(2)"
     And I wait up to 5 seconds for element "i.fa-regular.fa-thumbs-up:eq(2)" to have css property "color" equal to "rgb(62, 163, 62)"
 
+  @skip
   @chrome
   Scenario: Teacher can disable AI chat feature
     Given I create a teacher named "Stilgar"


### PR DESCRIPTION
I've seen this test fail in ~~two~~ ~~three~~ four different unrelated drone runs today:
- https://drone.cdn-code.org/code-dot-org/code-dot-org/52005/2/5
  - https://cucumber-logs.s3.amazonaws.com/circle/52005/Chrome_teacher_tools_ai_diff_ai_differentiation_chat_output.html?versionId=dF8Wlw0GcLFY9g4fBYd8etPdb86ikJTE

- https://drone.cdn-code.org/code-dot-org/code-dot-org/52021/2/5
  - https://cucumber-logs.s3.amazonaws.com/circle/52021/Chrome_teacher_tools_ai_diff_ai_differentiation_chat_output.html?versionId=a__8.dhD.MKwVxolf4AIOjcuQqmZ8fq5

- https://drone.cdn-code.org/code-dot-org/code-dot-org/52027/2/5

- https://drone.cdn-code.org/code-dot-org/code-dot-org/52031/2/5

the failures look identical:
<img width="1135" height="929" alt="Screenshot 2026-04-01 at 2 13 54 PM" src="https://github.com/user-attachments/assets/4ad7be30-c787-4ac8-92f9-ec7bfb05cb5b" />
