### PR TITLE
Memoize URL results for animation picker to avoid rerenders

### DIFF
--- a/apps/src/p5lab/AnimationPicker/AnimationPicker.jsx
+++ b/apps/src/p5lab/AnimationPicker/AnimationPicker.jsx
@@ -33,6 +33,20 @@ var msg = require('@cdo/locale');
 // though our error message says 100KB, to help users avoid confusion.
 const MAX_UPLOAD_SIZE = 101000;
 
+let cachedSelectedAnimationsByUrl = null;
+let cachedSelectedAnimationsList = [];
+
+function getSelectedAnimations(state) {
+  const selectedAnimationsByUrl = state.animationPicker.selectedAnimations;
+  if (selectedAnimationsByUrl === cachedSelectedAnimationsByUrl) {
+    return cachedSelectedAnimationsList;
+  }
+
+  cachedSelectedAnimationsByUrl = selectedAnimationsByUrl;
+  cachedSelectedAnimationsList = Object.values(selectedAnimationsByUrl);
+  return cachedSelectedAnimationsList;
+}
+
 export const PICKER_TYPE = makeEnum(
   'spritelab',
   'gamelab',
@@ -314,7 +328,7 @@ export default connect(
     uploadInProgress: state.animationPicker.uploadInProgress,
     uploadError: state.animationPicker.uploadError,
     playAnimations: !state.pageConstants.allAnimationsSingleFrame,
-    selectedAnimations: Object.values(state.animationPicker.selectedAnimations),
+    selectedAnimations: getSelectedAnimations(state),
     uploadWarningShowing: state.animationPicker.uploadWarningShowing,
     uploadsEnabled: state.animationPicker.uploadsEnabled,
   }),


### PR DESCRIPTION
Alice noticed an error related to repeated rendering on the Sprite Lab standalone project:

<img width="1366" height="56" alt="image" src="https://github.com/user-attachments/assets/a1f5e86a-2a9f-4876-881f-e0139680d105" />

Debugging with React DevTools showed the AnimationPicker rendering repeatedly. The problem appears to be related to recomputing an array on each rerender, which produces a loop of rerender -> change -> rerender -> ... It doesn't appear to be infinite when testing manually (renders ~100 times for me before stopping), but this change results in that no longer happening.

<img width="1680" height="346" alt="image" src="https://github.com/user-attachments/assets/4f694573-804b-4dd4-933e-3f07c28395b7" />

## Testing story

Tested manually that after this change, I no longer saw the error message that Alice observed. The animation picker appeared to continue to function as expected.