### PR TITLE
Handle Signet::AuthorizationError in Google Classroom API calls

### DIFF
--- a/dashboard/app/controllers/api_controller.rb
+++ b/dashboard/app/controllers/api_controller.rb
@@ -641,7 +641,7 @@ class ApiController < ApplicationController
 
     begin
       yield service
-    rescue Google::Apis::ClientError, Google::Apis::AuthorizationError => exception
+    rescue Google::Apis::ClientError, Google::Apis::AuthorizationError, Signet::AuthorizationError => exception
       render status: :forbidden, json: {error: exception}
     end
   end

--- a/dashboard/test/controllers/api_controller_test.rb
+++ b/dashboard/test/controllers/api_controller_test.rb
@@ -1566,6 +1566,22 @@ class ApiControllerTest < ActionController::TestCase
     assert_equal true, teacher.verified_teacher?
   end
 
+  test 'google_classrooms returns Forbidden when Signet::AuthorizationError is raised' do
+    teacher = create(:teacher, :with_google_authentication_option)
+    sign_in teacher
+
+    mock_service = mock('Google::Apis::ClassroomV1::ClassroomService')
+    mock_service.stubs(:authorization=)
+    mock_service.stubs(:list_courses).raises(Signet::AuthorizationError.new('Authorization failed.'))
+
+    mock_client = mock('Signet::OAuth2::Client')
+    Signet::OAuth2::Client.stubs(:new).returns(mock_client)
+    Google::Apis::ClassroomV1::ClassroomService.stubs(:new).returns(mock_service)
+
+    get :google_classrooms
+    assert_response :forbidden
+  end
+
   test 'import_google_classroom is Forbidden when section exists and current user is not an instructor' do
     mock_service = mock('Google::Apis::ClassroomV1::ClassroomService')
     course_id = Random.hex(10)


### PR DESCRIPTION
 I was investigating [this HoneyBadger error](https://app.honeybadger.io/projects/3240/faults/128178589) and it seems to be due to us not handling the Signet::AuthorizationError, which ends up bubbling up as a result.

<!--
  Summary of the change: background, motivation, and context.
  Include screenshots, videos, or before/after comparisons for UI changes.
-->



## Links
<!-- Jira tickets, design docs, Slack threads, related PRs, etc. -->

- Jira:

## Testing story
<!-- How was this tested? Manual steps, adhoc links, automated tests, or why testing isn't needed. -->



## Deployment notes
<!-- Delete this section if it's a standard merge-and-deploy.
     Otherwise: migrations, feature flags, coordination, caching impacts, etc. -->



## Privacy and security
<!-- Delete this section if there is no privacy/security impact.
     Otherwise: new PII, auth changes, API surface changes, etc. -->

