### PR TITLE
Skip iOS in Text to Speech UI test

### DIFF
--- a/dashboard/test/ui/features/teacher_tools/text_to_speech.feature
+++ b/dashboard/test/ui/features/teacher_tools/text_to_speech.feature
@@ -3,6 +3,10 @@
 # "Media resource could not be decoded" errors
 Feature: Text To Speech
 
+# The TTS player isn't showing up (in some situations?) on iOS devices on iOS 17+.
+# Skipping this test on iPad and iPhone
+# to unblock upgrading Sauce Labs tests to use iOS 17 until this is fixed.
+@no_mobile
 Scenario: Check that TTS player is displayed
   Given I am a student
   And I am on "http://studio.code.org/courses/allthettsthings/units/1/lessons/1/levels/1"


### PR DESCRIPTION
We'd like to move our Sauce Labs tests onto iOS 17. One test is failing on iOS 17, so skipping it to unblock that upgrade. This behavior is already present in production, so it doesn't feel like we're introducing any badness to skip it. We should fix it though!

Slack discussion has a bit more info on theorized cause. I did play with this a little in in Sauce Labs to see if there was an easy fix, but I couldn't immediately figure out how to resolve it. It was tricky because I was trying to test audio output, but you can't get audio output via device emulation in Sauce Labs 🙃 .

## Links

- Slack discussion: https://codedotorg.slack.com/archives/C0T0PNTM3/p1774982764202139?thread_ts=1774897746.954159&cid=C0T0PNTM3