### PR TITLE
[WebLab] Bring Developer Console errors to new WebLab debugger console

### DIFF
--- a/apps/src/weblab2/htmlPreview/htmlParsingHelpers.ts
+++ b/apps/src/weblab2/htmlPreview/htmlParsingHelpers.ts
@@ -55,11 +55,44 @@ const consoleOverrideScript = `
       return originalMethod.apply(console, arguments);
     };
   });
+  window.onerror = function(message, source, lineno) {
+    const filename = source ? source.split('/').pop() : 'unknown';
+    try {
+      channel.postMessage({type: "CONSOLE_LOG", level: "error",
+        args: [message + ' (' + filename + ', line ' + lineno + ')']});
+    } catch(e) {}
+    return false;
+  };
+  window.addEventListener('unhandledrejection', function(event) {
+    const reason = event.reason
+      ? (event.reason.message || String(event.reason))
+      : 'Unhandled Promise rejection';
+    try {
+      channel.postMessage({type: "CONSOLE_LOG", level: "error", args: [reason]});
+    } catch(e) {}
+  });
+  const tagNames = {
+    img: 'image', script: 'script', link: 'stylesheet',
+    audio: 'audio', video: 'video'
+  };
+  window.addEventListener('error', function(event) {
+    if (event.target && event.target !== window) {
+      const tag = event.target.tagName ? event.target.tagName.toLowerCase() : 'resource';
+      const filename =
+        (event.target.src || event.target.href || 'unknown').split('/').pop();
+      try {
+        channel.postMessage({type: "CONSOLE_LOG", level: "error",
+          args: [(tagNames[tag] || tag) + ' not found: ' + filename]});
+      } catch(e) {}
+    }
+  }, true);
 })();
 `;
 
-// Adds a script to the document that overrides console methods (log, warn, error, info)
-// and broadcasts the serialized arguments via BroadcastChannel so the parent can capture them.
+// Adds a script to the document that intercepts console output and JS errors,
+// broadcasting them via BroadcastChannel so the parent frame can display them.
+// Captures console.log/warn/error/info, uncaught JS errors, unhandled Promise
+// rejections, and failed resource loads (images, scripts, stylesheets, etc.).
 export const addConsoleOverrideToDocument = (doc: Document) => {
   const script = doc.createElement('script');
   script.textContent = consoleOverrideScript;

--- a/apps/src/weblab2/htmlPreview/htmlParsingHelpers.ts
+++ b/apps/src/weblab2/htmlPreview/htmlParsingHelpers.ts
@@ -55,14 +55,6 @@ const consoleOverrideScript = `
       return originalMethod.apply(console, arguments);
     };
   });
-  window.onerror = function(message, source, lineno) {
-    const filename = source ? source.split('/').pop() : 'unknown';
-    try {
-      channel.postMessage({type: "CONSOLE_LOG", level: "error",
-        args: [message + ' (' + filename + ', line ' + lineno + ')']});
-    } catch(e) {}
-    return false;
-  };
   window.addEventListener('unhandledrejection', function(event) {
     const reason = event.reason
       ? (event.reason.message || String(event.reason))
@@ -72,8 +64,8 @@ const consoleOverrideScript = `
     } catch(e) {}
   });
   const tagNames = {
-    img: 'image', script: 'script', link: 'stylesheet',
-    audio: 'audio', video: 'video'
+    img: 'Image', script: 'Script', link: 'Stylesheet',
+    audio: 'Audio', video: 'Video'
   };
   window.addEventListener('error', function(event) {
     if (event.target && event.target !== window) {
@@ -83,6 +75,12 @@ const consoleOverrideScript = `
       try {
         channel.postMessage({type: "CONSOLE_LOG", level: "error",
           args: [(tagNames[tag] || tag) + ' not found: ' + filename]});
+      } catch(e) {}
+    } else {
+      const filename = event.filename ? event.filename.split('/').pop() : 'unknown';
+      try {
+        channel.postMessage({type: "CONSOLE_LOG", level: "error",
+          args: [event.message + ' (' + filename + ', line ' + event.lineno + ')']});
       } catch(e) {}
     }
   }, true);

--- a/apps/src/weblab2/htmlPreview/htmlParsingHelpers.ts
+++ b/apps/src/weblab2/htmlPreview/htmlParsingHelpers.ts
@@ -50,36 +50,37 @@ const consoleOverrideScript = `
       const args = [];
       for (let i = 0; i < arguments.length; i++) { args.push(serialize(arguments[i])); }
       try {
-        channel.postMessage({type: "CONSOLE_LOG", level: method, args: args});
+        channel.postMessage({type: "${ProjectServiceWorkerMessageType.CONSOLE_LOG}", level: method, args: args});
       } catch(e) {}
       return originalMethod.apply(console, arguments);
     };
   });
   window.addEventListener('unhandledrejection', function(event) {
-    const reason = event.reason
-      ? (event.reason.message || String(event.reason))
-      : 'Unhandled Promise rejection';
+    const reason = event.reason !== undefined
+      ? serialize(event.reason) : 'Unhandled Promise rejection';
     try {
-      channel.postMessage({type: "CONSOLE_LOG", level: "error", args: [reason]});
+      channel.postMessage({type: "${ProjectServiceWorkerMessageType.CONSOLE_LOG}", level: "error", args: [reason]});
     } catch(e) {}
   });
   const tagNames = {
-    img: 'Image', script: 'Script', link: 'Stylesheet',
-    audio: 'Audio', video: 'Video'
+    img: 'Image', script: 'Script', audio: 'Audio', video: 'Video'
   };
   window.addEventListener('error', function(event) {
     if (event.target && event.target !== window) {
       const tag = event.target.tagName ? event.target.tagName.toLowerCase() : 'resource';
+      const resourceType = tag === 'link'
+        ? (event.target.rel && event.target.rel.includes('stylesheet') ? 'Stylesheet' : 'Link resource')
+        : (tagNames[tag] || tag);
       const filename =
         (event.target.src || event.target.href || 'unknown').split('/').pop();
       try {
-        channel.postMessage({type: "CONSOLE_LOG", level: "error",
-          args: [(tagNames[tag] || tag) + ' not found: ' + filename]});
+        channel.postMessage({type: "${ProjectServiceWorkerMessageType.CONSOLE_LOG}", level: "error",
+          args: [resourceType + ' not found: ' + filename]});
       } catch(e) {}
     } else {
       const filename = event.filename ? event.filename.split('/').pop() : 'unknown';
       try {
-        channel.postMessage({type: "CONSOLE_LOG", level: "error",
+        channel.postMessage({type: "${ProjectServiceWorkerMessageType.CONSOLE_LOG}", level: "error",
           args: [event.message + ' (' + filename + ', line ' + event.lineno + ')']});
       } catch(e) {}
     }


### PR DESCRIPTION
This PR surfaces Console errors to the WebLab debug console. After some discussion in [this slack thread](https://codedotorg.slack.com/archives/C09EHQE4DGD/p1775076676327869), I decided to add these as-is for now (though they can be spam-like as they happen every preview reload) and add a [followup ticket](https://codedotorg.atlassian.net/browse/SL-1654) that will bundle and count the console outputs. 


<img width="943" height="262" alt="Screenshot 2026-04-01 at 8 42 15 PM" src="https://github.com/user-attachments/assets/7e191362-43f4-4f44-874c-4c41830ca6a9" />

Before:

https://github.com/user-attachments/assets/b20fb7fe-fb93-4530-b1fc-efdf51e43bc3


After:

https://github.com/user-attachments/assets/39d7c401-b9d1-48db-9c0d-89291301674c





## Links

- Jira: https://codedotorg.atlassian.net/browse/AFL-530

## Testing story
<!-- How was this tested? Manual steps, adhoc links, automated tests, or why testing isn't needed. -->



## Deployment notes
<!-- Delete this section if it's a standard merge-and-deploy.
     Otherwise: migrations, feature flags, coordination, caching impacts, etc. -->



## Privacy and security
<!-- Delete this section if there is no privacy/security impact.
     Otherwise: new PII, auth changes, API surface changes, etc. -->

