### PR TITLE
Expose codeMirror wrapper so applab level edit page can add/modify available maker blocks

### DIFF
--- a/apps/src/code-studio/initializeCodeMirror6.ts
+++ b/apps/src/code-studio/initializeCodeMirror6.ts
@@ -214,6 +214,13 @@ function initializeCodeMirror6(
     },
   };
 
+  // Expose the editor adapter on the original textarea for pages that need to
+  // access the instance directly after initialization.
+  const textareaNode = node as HTMLTextAreaElement & {
+    codeMirror?: CodeMirrorLegacyAdapter;
+  };
+  textareaNode.codeMirror = adapter;
+
   const updatePreview = () => {
     if (!previewElement) {
       return;

--- a/apps/src/sites/studio/pages/levels/editors/_applab.js
+++ b/apps/src/sites/studio/pages/levels/editors/_applab.js
@@ -35,24 +35,13 @@ $(document).ready(function () {
     if (!editor) {
       return;
     }
-    const currentFunctions = JSON.parse(editor.getValue());
-    let functionsWithMaker;
+    const functionsWithMaker = JSON.parse(editor.getValue() || '{}');
     if ($(this).val() === 'circuitPlayground') {
       // Load the circuitPlayground and maker blocks.
-      functionsWithMaker = Object.assign(
-        {},
-        currentFunctions,
-        makerBlocks,
-        circuitBlocks
-      );
+      Object.assign(functionsWithMaker, makerBlocks, circuitBlocks);
     } else if ($(this).val() === 'microbit') {
       // Load the microbit and maker blocks
-      functionsWithMaker = Object.assign(
-        {},
-        currentFunctions,
-        makerBlocks,
-        microbitBlocks
-      );
+      Object.assign(functionsWithMaker, makerBlocks, microbitBlocks);
     }
     editor.setValue(JSON.stringify(functionsWithMaker, null, ' '));
   });

--- a/apps/src/sites/studio/pages/levels/editors/_applab.js
+++ b/apps/src/sites/studio/pages/levels/editors/_applab.js
@@ -39,9 +39,24 @@ $(document).ready(function () {
     if ($(this).val() === 'circuitPlayground') {
       // Load the circuitPlayground and maker blocks.
       Object.assign(functionsWithMaker, makerBlocks, circuitBlocks);
+      Object.keys(microbitBlocks).forEach(
+        func => delete functionsWithMaker[func]
+      );
     } else if ($(this).val() === 'microbit') {
-      // Load the microbit and maker blocks
+      // Load the microbit and maker blocks.
       Object.assign(functionsWithMaker, makerBlocks, microbitBlocks);
+      Object.keys(circuitBlocks).forEach(
+        func => delete functionsWithMaker[func]
+      );
+    } else {
+      // Remove all maker blocks and microbit and circuit playground blocks
+      Object.keys(makerBlocks).forEach(func => delete functionsWithMaker[func]);
+      Object.keys(microbitBlocks).forEach(
+        func => delete functionsWithMaker[func]
+      );
+      Object.keys(circuitBlocks).forEach(
+        func => delete functionsWithMaker[func]
+      );
     }
     editor.setValue(JSON.stringify(functionsWithMaker, null, ' '));
   });

--- a/apps/src/sites/studio/pages/levels/editors/_applab.js
+++ b/apps/src/sites/studio/pages/levels/editors/_applab.js
@@ -28,9 +28,13 @@ $(document).ready(function () {
       block => (circuitBlocks[block.func] = null)
     );
 
-    const editor = $('#level_code_functions')
-      .siblings()
-      .filter('.CodeMirror')[0].CodeMirror;
+    const codeFunctionsTextarea = document.getElementById(
+      'level_code_functions'
+    );
+    const editor = codeFunctionsTextarea?.codeMirror;
+    if (!editor) {
+      return;
+    }
     const currentFunctions = JSON.parse(editor.getValue());
     let functionsWithMaker;
     if ($(this).val() === 'circuitPlayground') {
@@ -50,7 +54,7 @@ $(document).ready(function () {
         microbitBlocks
       );
     }
-    editor.getDoc().setValue(JSON.stringify(functionsWithMaker, null, ' '));
+    editor.setValue(JSON.stringify(functionsWithMaker, null, ' '));
   });
 
   const styles = {

--- a/apps/src/sites/studio/pages/levels/editors/_applab.js
+++ b/apps/src/sites/studio/pages/levels/editors/_applab.js
@@ -25,10 +25,10 @@ $(document).ready(function () {
     configCircuitPlayground.blocks.forEach(
       block => (circuitBlocks[block.func] = null)
     );
-    const microbitOnlyFuncs = Object.keys(microbitBlocks).filter(
+    const microbitNonMakerFuncs = Object.keys(microbitBlocks).filter(
       func => !(func in makerBlocks)
     );
-    const circuitOnlyFuncs = Object.keys(circuitBlocks).filter(
+    const circuitNonMakerFuncs = Object.keys(circuitBlocks).filter(
       func => !(func in makerBlocks)
     );
 
@@ -43,11 +43,19 @@ $(document).ready(function () {
     if ($(this).val() === 'circuitPlayground') {
       // Load Circuit Playground blocks (includes shared Maker blocks).
       Object.assign(functionsWithMaker, circuitBlocks);
-      microbitOnlyFuncs.forEach(func => delete functionsWithMaker[func]);
+      microbitNonMakerFuncs.forEach(func => {
+        if (!(func in circuitBlocks)) {
+          delete functionsWithMaker[func];
+        }
+      });
     } else if ($(this).val() === 'microbit') {
       // Load micro:bit blocks (includes shared Maker blocks).
       Object.assign(functionsWithMaker, microbitBlocks);
-      circuitOnlyFuncs.forEach(func => delete functionsWithMaker[func]);
+      circuitNonMakerFuncs.forEach(func => {
+        if (!(func in microbitBlocks)) {
+          delete functionsWithMaker[func];
+        }
+      });
     } else {
       // Remove all board blocks (including shared Maker blocks).
       Object.keys(microbitBlocks).forEach(

--- a/apps/src/sites/studio/pages/levels/editors/_applab.js
+++ b/apps/src/sites/studio/pages/levels/editors/_applab.js
@@ -17,19 +17,21 @@ $(document).ready(function () {
 
     // Setting block values to null to match the expected behavior in code_functions.
     // Board type only affects default pin examples, not function names.
-    let makerBlocks = {};
-    getMakerBlocks(null).forEach(block => (makerBlocks[block.func] = null));
+    let sharedMakerBlocks = {};
+    getMakerBlocks(null).forEach(
+      block => (sharedMakerBlocks[block.func] = null)
+    );
     let microbitBlocks = {};
     configMicrobit.blocks.forEach(block => (microbitBlocks[block.func] = null));
     let circuitBlocks = {};
     configCircuitPlayground.blocks.forEach(
       block => (circuitBlocks[block.func] = null)
     );
-    const microbitNonMakerFuncs = Object.keys(microbitBlocks).filter(
-      func => !(func in makerBlocks)
+    const microbitNonSharedMakerFuncs = Object.keys(microbitBlocks).filter(
+      func => !(func in sharedMakerBlocks)
     );
-    const circuitNonMakerFuncs = Object.keys(circuitBlocks).filter(
-      func => !(func in makerBlocks)
+    const circuitNonSharedMakerFuncs = Object.keys(circuitBlocks).filter(
+      func => !(func in sharedMakerBlocks)
     );
 
     const codeFunctionsTextarea = document.getElementById(
@@ -39,33 +41,29 @@ $(document).ready(function () {
     if (!editor) {
       return;
     }
-    const functionsWithMaker = JSON.parse(editor.getValue() || '{}');
+    const codeFunctions = JSON.parse(editor.getValue() || '{}');
     if ($(this).val() === 'circuitPlayground') {
       // Load Circuit Playground blocks (includes shared Maker blocks).
-      Object.assign(functionsWithMaker, circuitBlocks);
-      microbitNonMakerFuncs.forEach(func => {
+      Object.assign(codeFunctions, circuitBlocks);
+      microbitNonSharedMakerFuncs.forEach(func => {
         if (!(func in circuitBlocks)) {
-          delete functionsWithMaker[func];
+          delete codeFunctions[func];
         }
       });
     } else if ($(this).val() === 'microbit') {
       // Load micro:bit blocks (includes shared Maker blocks).
-      Object.assign(functionsWithMaker, microbitBlocks);
-      circuitNonMakerFuncs.forEach(func => {
+      Object.assign(codeFunctions, microbitBlocks);
+      circuitNonSharedMakerFuncs.forEach(func => {
         if (!(func in microbitBlocks)) {
-          delete functionsWithMaker[func];
+          delete codeFunctions[func];
         }
       });
     } else {
       // Remove all board blocks (including shared Maker blocks).
-      Object.keys(microbitBlocks).forEach(
-        func => delete functionsWithMaker[func]
-      );
-      Object.keys(circuitBlocks).forEach(
-        func => delete functionsWithMaker[func]
-      );
+      Object.keys(microbitBlocks).forEach(func => delete codeFunctions[func]);
+      Object.keys(circuitBlocks).forEach(func => delete codeFunctions[func]);
     }
-    editor.setValue(JSON.stringify(functionsWithMaker, null, ' '));
+    editor.setValue(JSON.stringify(codeFunctions, null, ' '));
   });
 
   const styles = {

--- a/apps/src/sites/studio/pages/levels/editors/_applab.js
+++ b/apps/src/sites/studio/pages/levels/editors/_applab.js
@@ -63,7 +63,14 @@ $(document).ready(function () {
       Object.keys(microbitBlocks).forEach(func => delete codeFunctions[func]);
       Object.keys(circuitBlocks).forEach(func => delete codeFunctions[func]);
     }
-    editor.setValue(JSON.stringify(codeFunctions, null, ' '));
+
+    // If there are no blocks, set the editor to an empty string instead of an empty object,
+    // as our block config will use all blocks if code_functions is empty, but no blocks if code_functions is an empty object.
+    const editorValue =
+      Object.keys(codeFunctions).length === 0
+        ? ''
+        : JSON.stringify(codeFunctions, null, ' ');
+    editor.setValue(editorValue);
   });
 
   const styles = {

--- a/apps/src/sites/studio/pages/levels/editors/_applab.js
+++ b/apps/src/sites/studio/pages/levels/editors/_applab.js
@@ -5,7 +5,6 @@ import React from 'react';
 import {
   configMicrobit,
   configCircuitPlayground,
-  getMakerBlocks,
 } from '@cdo/apps/maker/dropletConfig';
 import color from '@cdo/apps/util/color';
 import {createReactRoot} from '@cdo/apps/util/createReactRoot';
@@ -13,19 +12,21 @@ import getScriptData from '@cdo/apps/util/getScriptData';
 
 $(document).ready(function () {
   $('#level_makerlab_enabled').change(function () {
-    // Get the set of blocks for the Maker Category, the Circuit Category, and the Micro:bit category
+    // Get the set of blocks for the Circuit Category and the Micro:bit category.
+    // Each set already includes shared Maker blocks.
 
     // Setting block values to null to match the expected behavior in code_functions.
-    // The maker type given here sets the defaultPin in the example block. Since we are just using the function name,
-    // which doesn't include a pin parameter, we could use any block type.
-    const configMaker = getMakerBlocks(null);
-    let makerBlocks = {};
-    configMaker.forEach(block => (makerBlocks[block.func] = null));
     let microbitBlocks = {};
     configMicrobit.blocks.forEach(block => (microbitBlocks[block.func] = null));
     let circuitBlocks = {};
     configCircuitPlayground.blocks.forEach(
       block => (circuitBlocks[block.func] = null)
+    );
+    const microbitOnlyFuncs = Object.keys(microbitBlocks).filter(
+      func => !(func in circuitBlocks)
+    );
+    const circuitOnlyFuncs = Object.keys(circuitBlocks).filter(
+      func => !(func in microbitBlocks)
     );
 
     const codeFunctionsTextarea = document.getElementById(
@@ -37,20 +38,15 @@ $(document).ready(function () {
     }
     const functionsWithMaker = JSON.parse(editor.getValue() || '{}');
     if ($(this).val() === 'circuitPlayground') {
-      // Load the circuitPlayground and maker blocks.
-      Object.assign(functionsWithMaker, makerBlocks, circuitBlocks);
-      Object.keys(microbitBlocks).forEach(
-        func => delete functionsWithMaker[func]
-      );
+      // Load the Circuit Playground set (includes shared Maker blocks).
+      Object.assign(functionsWithMaker, circuitBlocks);
+      microbitOnlyFuncs.forEach(func => delete functionsWithMaker[func]);
     } else if ($(this).val() === 'microbit') {
-      // Load the microbit and maker blocks.
-      Object.assign(functionsWithMaker, makerBlocks, microbitBlocks);
-      Object.keys(circuitBlocks).forEach(
-        func => delete functionsWithMaker[func]
-      );
+      // Load the micro:bit set (includes shared Maker blocks).
+      Object.assign(functionsWithMaker, microbitBlocks);
+      circuitOnlyFuncs.forEach(func => delete functionsWithMaker[func]);
     } else {
-      // Remove all maker blocks and microbit and circuit playground blocks
-      Object.keys(makerBlocks).forEach(func => delete functionsWithMaker[func]);
+      // Remove all micro:bit and Circuit Playground blocks (including shared Maker blocks).
       Object.keys(microbitBlocks).forEach(
         func => delete functionsWithMaker[func]
       );

--- a/apps/src/sites/studio/pages/levels/editors/_applab.js
+++ b/apps/src/sites/studio/pages/levels/editors/_applab.js
@@ -5,6 +5,7 @@ import React from 'react';
 import {
   configMicrobit,
   configCircuitPlayground,
+  getMakerBlocks,
 } from '@cdo/apps/maker/dropletConfig';
 import color from '@cdo/apps/util/color';
 import {createReactRoot} from '@cdo/apps/util/createReactRoot';
@@ -12,10 +13,12 @@ import getScriptData from '@cdo/apps/util/getScriptData';
 
 $(document).ready(function () {
   $('#level_makerlab_enabled').change(function () {
-    // Get the set of blocks for the Circuit Category and the Micro:bit category.
-    // Each set already includes shared Maker blocks.
+    // Get shared Maker blocks and board-specific block sets.
 
     // Setting block values to null to match the expected behavior in code_functions.
+    // Board type only affects default pin examples, not function names.
+    let makerBlocks = {};
+    getMakerBlocks(null).forEach(block => (makerBlocks[block.func] = null));
     let microbitBlocks = {};
     configMicrobit.blocks.forEach(block => (microbitBlocks[block.func] = null));
     let circuitBlocks = {};
@@ -23,10 +26,10 @@ $(document).ready(function () {
       block => (circuitBlocks[block.func] = null)
     );
     const microbitOnlyFuncs = Object.keys(microbitBlocks).filter(
-      func => !(func in circuitBlocks)
+      func => !(func in makerBlocks)
     );
     const circuitOnlyFuncs = Object.keys(circuitBlocks).filter(
-      func => !(func in microbitBlocks)
+      func => !(func in makerBlocks)
     );
 
     const codeFunctionsTextarea = document.getElementById(
@@ -38,15 +41,15 @@ $(document).ready(function () {
     }
     const functionsWithMaker = JSON.parse(editor.getValue() || '{}');
     if ($(this).val() === 'circuitPlayground') {
-      // Load the Circuit Playground set (includes shared Maker blocks).
+      // Load Circuit Playground blocks (includes shared Maker blocks).
       Object.assign(functionsWithMaker, circuitBlocks);
       microbitOnlyFuncs.forEach(func => delete functionsWithMaker[func]);
     } else if ($(this).val() === 'microbit') {
-      // Load the micro:bit set (includes shared Maker blocks).
+      // Load micro:bit blocks (includes shared Maker blocks).
       Object.assign(functionsWithMaker, microbitBlocks);
       circuitOnlyFuncs.forEach(func => delete functionsWithMaker[func]);
     } else {
-      // Remove all micro:bit and Circuit Playground blocks (including shared Maker blocks).
+      // Remove all board blocks (including shared Maker blocks).
       Object.keys(microbitBlocks).forEach(
         func => delete functionsWithMaker[func]
       );

--- a/dashboard/app/views/levels/editors/fields/_droplet.html.haml
+++ b/dashboard/app/views/levels/editors/fields/_droplet.html.haml
@@ -10,7 +10,7 @@
     = render partial: 'levels/editors/fields/checkboxes', locals: {f: f, field_name: :execute_palette_apis_only, description: "Execute palette APIs only"}
     = render partial: 'levels/editors/fields/checkboxes', locals: {f: f, field_name: :beginner_mode, description: "Beginner mode for loops"}
     .field
-      = f.label :makerlab_enabled, 'Select Maker API:'
+      = f.label :makerlab_enabled, 'Select Maker API (note: selecting an API will add/remove appropriate blocks from the Droplet palette below)'
       -# Old level format - @level.makerlab_enabled = true/false
       -# New level format - @level.makerlab_enabled = 'circuitPlayground', 'microbit', ''
       -# When converting old format to new format, 'true' -> 'circuitPlayground'


### PR DESCRIPTION
We have a bug on the App Lab level edit page currently where some functionality that existed to append micro:bit or Circuit Playground-specific blocks to the available set of blocks failed since we switched the block config editor to CodeMirror6.

The functionality was a bit confusing / maybe didn't quite work as I would expect, so I made a few other changes 😬 :
- Handle empty JSON in the block config.
- When switching between micro:bit <-> CP, actively remove blocks for the other board.
- When switching to no API enabled, remove all maker blocks.
- Remove some redundant logic that was supposed to house shared maker blocks because the "board-specific" block lists already included these blocks.

More confusion caused because there are blocks with the same names in the micro:bit and Circuit Playground-"specific" lists 🙃 , so made sure not to remove those when switching between CP and micro:bit.

https://github.com/user-attachments/assets/8ae5f7c8-afe0-4f9a-9074-a7f0d8f84737

## Testing story

Tested manually (see video above). I highlighted some of the different possible cases (board-specific blocks, maker blocks, etc). I didn't highlight this in the video, but an example of a block that appears in both board-"specific" lists is `onBoardEvent`, which is retained when switching between boards.