### PR TITLE
Copy weblab docs for weblab2

### DIFF
--- a/dashboard/config/programming_environments/weblab2.json
+++ b/dashboard/config/programming_environments/weblab2.json
@@ -1,0 +1,20 @@
+{
+  "name": "weblab2",
+  "published": false,
+  "editor_language": "html/css",
+  "title": "Web Lab",
+  "categories": [
+    {
+      "key": "html_tags",
+      "name": "HTML Tags",
+      "color": "#fff176",
+      "position": 0
+    },
+    {
+      "key": "css_properties",
+      "name": "CSS Properties",
+      "color": "#d3e965",
+      "position": 1
+    }
+  ]
+}

--- a/dashboard/config/programming_expressions/weblab2/a.json
+++ b/dashboard/config/programming_expressions/weblab2/a.json
@@ -1,0 +1,40 @@
+{
+  "key": "A",
+  "name": "Hyperlink",
+  "category": "HTML Tags",
+  "category_key": "html_tags",
+  "content": "# Hyperlink\n\nThis tag is used to  add hyperlinks to your web page.The link tag `<a>`  is used both for linking to external web pages and for linking to  individual HTML documents  on the same website. This link requires one attribute:\n* `href` -  Tells where the browser should navigate to.",
+  "examples": [
+    {
+      "name": "Links as References",
+      "description": "Using a link to refer to an outside source for more information",
+      "code": "```\n<html>\r\n\t<body>\r\n    \t<h2>Katherine Johnson</h2>\r\n        <p>\r\n          Katherine Johnson was an American mathematician whose calculations as a NASA employee were critical to the success of the first U.S. missions to space.\r\n        </p>\r\n        <a href=\"https://www.nasa.gov/content/katherine-johnson-biography\">Click Here to learn more about Katherine Johnson</a>\r\n    </body>\r\n</html>\n```",
+      "app": "",
+      "image": "https://curriculum.code.org/media/katherine.png",
+      "app_display_type": "codeFromCodeField",
+      "embed_app_with_code_height": 310
+    },
+    {
+      "name": "External Website",
+      "description": "Using `<a>` for linking to an external web page.",
+      "code": "```\n<a href=\"https://code.org/\">Visit Code.org!</a>\n```",
+      "app": "",
+      "image": null,
+      "app_display_type": "codeFromCodeField",
+      "embed_app_with_code_height": 310
+    },
+    {
+      "name": "Page on the Same Website",
+      "description": "Using `<a>` for linking  individual HTML documents  on the same website",
+      "code": "```\n<a href=\"books.html\">Books</a>\n```",
+      "app": "",
+      "image": null,
+      "app_display_type": "codeFromCodeField",
+      "embed_app_with_code_height": 310
+    }
+  ],
+  "external_documentation": "http://www.w3schools.com/tags/tag_a.asp",
+  "short_description": "Hyperlink\nThis tag is used to  add hyperlinks to your web page.The link tag &lt;a&gt;  is used both for linking to external web pages and for linking to  individual HTML documents  on the same website. This link requires one attribute:\n* href -  Tells where the browser should navigate to.",
+  "syntax": "<a></a>",
+  "tips": "* The link text is the part that will be visible to the reader.\r\n* A link does not have to be text. A link can be an image or any other HTML element.\r\n"
+}

--- a/dashboard/config/programming_expressions/weblab2/background-color.json
+++ b/dashboard/config/programming_expressions/weblab2/background-color.json
@@ -1,0 +1,40 @@
+{
+  "key": "background-color",
+  "name": "Background Color",
+  "category": "CSS Properties",
+  "category_key": "css_properties",
+  "content": "# Background Color\r\n\r\nThe [`background-color`(#d3e965)](/docs/weblab/background-color/) property specifies the background color of an element. Color values can be defined with HEX, RGB, or color name. ",
+  "examples": [
+    {
+      "name": "Background with Color Names",
+      "description": "Setting the background with a color Name.",
+      "code": "```\nbody {\r\n  background-color: blue;\r\n}\n```",
+      "app": "",
+      "image": null,
+      "app_display_type": "codeFromCodeField",
+      "embed_app_with_code_height": 310
+    },
+    {
+      "name": "Background Color in RGB",
+      "description": "Setting the background color with an RGB value.",
+      "code": "```\nbody {\r\n  background-color: rgb(100, 70, 200);\r\n}\n```",
+      "app": "",
+      "image": null,
+      "app_display_type": "codeFromCodeField",
+      "embed_app_with_code_height": 310
+    },
+    {
+      "name": "Background Color in Hex",
+      "description": "Setting the background color with a HEX value.",
+      "code": "```\nbody {\r\n  background-color: #92a8d1;\r\n}\n```",
+      "app": "",
+      "image": null,
+      "app_display_type": "codeFromCodeField",
+      "embed_app_with_code_height": 310
+    }
+  ],
+  "external_documentation": "http://www.w3schools.com/cssref/pr_background-color.asp",
+  "short_description": "Background Color\nThe background-color property specifies the background color of an element. Color values can be defined with HEX, RGB, or color name. ",
+  "syntax": "background-color: value;",
+  "tips": "* The default background color is transparent.\r\n* The background of an element is the total size of the element, including padding and border (but not the margin).\r\n* Use a background color and a text color that makes the text readable.\r\n"
+}

--- a/dashboard/config/programming_expressions/weblab2/background-color.json
+++ b/dashboard/config/programming_expressions/weblab2/background-color.json
@@ -3,7 +3,7 @@
   "name": "Background Color",
   "category": "CSS Properties",
   "category_key": "css_properties",
-  "content": "# Background Color\r\n\r\nThe [`background-color`(#d3e965)](/docs/weblab/background-color/) property specifies the background color of an element. Color values can be defined with HEX, RGB, or color name. ",
+  "content": "# Background Color\r\n\r\nThe [`background-color`(#d3e965)](/docs/ide/weblab2/expressions/background-color/) property specifies the background color of an element. Color values can be defined with HEX, RGB, or color name. ",
   "examples": [
     {
       "name": "Background with Color Names",

--- a/dashboard/config/programming_expressions/weblab2/body.json
+++ b/dashboard/config/programming_expressions/weblab2/body.json
@@ -1,0 +1,22 @@
+{
+  "key": "body",
+  "name": "Body",
+  "category": "HTML Tags",
+  "category_key": "html_tags",
+  "content": "# Body\r\n\r\nThe` <body>` tag defines the main content of the HTML document that will be directly visible on your web page. This body tag ` <body>` contains all the content of an HTML document, such as headings, paragraphs, images, hyperlinks, tables, lists, etc.",
+  "examples": [
+    {
+      "name": "",
+      "description": "Using `<body>` to create a simple webpage.",
+      "code": "```\n\r\n<html>\r\n<head>\r\n  <title>Title of the document</title>\r\n</head>\r\n\r\n<body>\r\n  <h1>This is a heading</h1>\r\n  <p>This is a paragraph.</p>\r\n</body>\r\n\r\n</html>\r\n\n```",
+      "app": "",
+      "image": null,
+      "app_display_type": "codeFromCodeField",
+      "embed_app_with_code_height": 310
+    }
+  ],
+  "external_documentation": "http://www.w3schools.com/tags/tag_body.asp",
+  "short_description": "Body\nThe &lt;body&gt; tag defines the main content of the HTML document that will be directly visible on your web page. This body tag  &lt;body&gt; contains all the content of an HTML document, such as headings, paragraphs, images, hyperlinks, tables, lists, etc.",
+  "syntax": "<body></body>",
+  "tips": "* There is *only* one `<body>` element in an HTML document.\r\n* The  `<body>` tag should be placed under the closing `</head>` tag.\r\n* All the contents of an HTML document, such as headings, images, lists, etc should go inside the `<body>` tag.\r\n* No content should be written after the closing `</body>` tag. \r\n"
+}

--- a/dashboard/config/programming_expressions/weblab2/border-bottom.json
+++ b/dashboard/config/programming_expressions/weblab2/border-bottom.json
@@ -1,0 +1,22 @@
+{
+  "key": "border-bottom",
+  "name": "Border Bottom",
+  "category": "CSS Properties",
+  "category_key": "css_properties",
+  "content": "# Border Bottom\r\n\r\nThe [`border-bottom`(#d3e965)](/docs/weblab/border-bottom/) property specifies the width, line style, and color of the bottom border of an element. It is a shorthand property for setting in one declaration the width, the style, and the color of an element’s bottom border.",
+  "examples": [
+    {
+      "name": "Border Bottom Property",
+      "description": "Setting the style of the bottom border of `<h1>` for different elements.",
+      "code": "```\nh1 {\r\n  border-bottom: 5px solid red;\r\n}\n```",
+      "app": "",
+      "image": null,
+      "app_display_type": "codeFromCodeField",
+      "embed_app_with_code_height": 310
+    }
+  ],
+  "external_documentation": "http://www.w3schools.com/cssref/pr_border-bottom.asp",
+  "short_description": "Border Bottom\nThe border-bottom property specifies the width, line style, and color of the bottom border of an element. It is a shorthand property for setting in one declaration the width, the style, and the color of an element’s bottom border.",
+  "syntax": "border-bottom: border-width border-style border-color;",
+  "tips": "* If [`border-style`(#d3e965)](/docs/weblab/border-style/) is not provided, the default is no border.\r\n* If no [`border-color`(#d3e965)](/docs/weblab/border-color/) is chosen, the border color will match the color of the text.\r\n* If [`border-width`(#d3e965)](/docs/weblab/border-width/) is not provided, the default is medium."
+}

--- a/dashboard/config/programming_expressions/weblab2/border-bottom.json
+++ b/dashboard/config/programming_expressions/weblab2/border-bottom.json
@@ -3,7 +3,7 @@
   "name": "Border Bottom",
   "category": "CSS Properties",
   "category_key": "css_properties",
-  "content": "# Border Bottom\r\n\r\nThe [`border-bottom`(#d3e965)](/docs/weblab/border-bottom/) property specifies the width, line style, and color of the bottom border of an element. It is a shorthand property for setting in one declaration the width, the style, and the color of an element’s bottom border.",
+  "content": "# Border Bottom\r\n\r\nThe [`border-bottom`(#d3e965)](/docs/ide/weblab2/expressions/border-bottom/) property specifies the width, line style, and color of the bottom border of an element. It is a shorthand property for setting in one declaration the width, the style, and the color of an element’s bottom border.",
   "examples": [
     {
       "name": "Border Bottom Property",
@@ -18,5 +18,5 @@
   "external_documentation": "http://www.w3schools.com/cssref/pr_border-bottom.asp",
   "short_description": "Border Bottom\nThe border-bottom property specifies the width, line style, and color of the bottom border of an element. It is a shorthand property for setting in one declaration the width, the style, and the color of an element’s bottom border.",
   "syntax": "border-bottom: border-width border-style border-color;",
-  "tips": "* If [`border-style`(#d3e965)](/docs/weblab/border-style/) is not provided, the default is no border.\r\n* If no [`border-color`(#d3e965)](/docs/weblab/border-color/) is chosen, the border color will match the color of the text.\r\n* If [`border-width`(#d3e965)](/docs/weblab/border-width/) is not provided, the default is medium."
+  "tips": "* If [`border-style`(#d3e965)](/docs/ide/weblab2/expressions/border-style/) is not provided, the default is no border.\r\n* If no [`border-color`(#d3e965)](/docs/ide/weblab2/expressions/border-color/) is chosen, the border color will match the color of the text.\r\n* If [`border-width`(#d3e965)](/docs/ide/weblab2/expressions/border-width/) is not provided, the default is medium."
 }

--- a/dashboard/config/programming_expressions/weblab2/border-color.json
+++ b/dashboard/config/programming_expressions/weblab2/border-color.json
@@ -1,0 +1,31 @@
+{
+  "key": "border-color",
+  "name": "Border Color",
+  "category": "CSS Properties",
+  "category_key": "css_properties",
+  "content": "# Border Color\r\nThe [`border-color`(#d3e965)](/docs/weblab/border-color/) property specifies the color of an element's four borders. It is a shorthand for choosing  the top, right, bottom, and left border color simultaneously. When one value is specified, it applies the same color to all four sides.",
+  "examples": [
+    {
+      "name": "Red Borders",
+      "description": "Set all four borders of a `<h1>` element to red.",
+      "code": "```\nh1{\r\n  border-style: solid;\r\n  border-color: red;\r\n}\r\n\n```",
+      "app": "",
+      "image": null,
+      "app_display_type": "codeFromCodeField",
+      "embed_app_with_code_height": 310
+    },
+    {
+      "name": "Different Border Colors",
+      "description": "Setting the four borders of a `<h1>` Element to different colors.",
+      "code": "```\nh1{\r\n  border-style: solid;\r\n  border-color: red green blue purple;\r\n}\n```",
+      "app": "",
+      "image": null,
+      "app_display_type": "codeFromCodeField",
+      "embed_app_with_code_height": 310
+    }
+  ],
+  "external_documentation": "http://www.w3schools.com/cssref/pr_border-color.asp",
+  "short_description": "Border Color\nThe border-color property specifies the color of an element's four borders. It is a shorthand for choosing  the top, right, bottom, and left border color simultaneously. When one value is specified, it applies the same color to all four sides.",
+  "syntax": "border-color: value;",
+  "tips": "* Always declare the [`border-style`(#d3e965)](/docs/weblab/border-style/) property before the [`border-color`(#d3e965)](/docs/weblab/border-color/) property."
+}

--- a/dashboard/config/programming_expressions/weblab2/border-color.json
+++ b/dashboard/config/programming_expressions/weblab2/border-color.json
@@ -3,7 +3,7 @@
   "name": "Border Color",
   "category": "CSS Properties",
   "category_key": "css_properties",
-  "content": "# Border Color\r\nThe [`border-color`(#d3e965)](/docs/weblab/border-color/) property specifies the color of an element's four borders. It is a shorthand for choosing  the top, right, bottom, and left border color simultaneously. When one value is specified, it applies the same color to all four sides.",
+  "content": "# Border Color\r\nThe [`border-color`(#d3e965)](/docs/ide/weblab2/expressions/border-color/) property specifies the color of an element's four borders. It is a shorthand for choosing  the top, right, bottom, and left border color simultaneously. When one value is specified, it applies the same color to all four sides.",
   "examples": [
     {
       "name": "Red Borders",
@@ -27,5 +27,5 @@
   "external_documentation": "http://www.w3schools.com/cssref/pr_border-color.asp",
   "short_description": "Border Color\nThe border-color property specifies the color of an element's four borders. It is a shorthand for choosing  the top, right, bottom, and left border color simultaneously. When one value is specified, it applies the same color to all four sides.",
   "syntax": "border-color: value;",
-  "tips": "* Always declare the [`border-style`(#d3e965)](/docs/weblab/border-style/) property before the [`border-color`(#d3e965)](/docs/weblab/border-color/) property."
+  "tips": "* Always declare the [`border-style`(#d3e965)](/docs/ide/weblab2/expressions/border-style/) property before the [`border-color`(#d3e965)](/docs/ide/weblab2/expressions/border-color/) property."
 }

--- a/dashboard/config/programming_expressions/weblab2/border-left.json
+++ b/dashboard/config/programming_expressions/weblab2/border-left.json
@@ -1,0 +1,22 @@
+{
+  "key": "border-left",
+  "name": "Border Left",
+  "category": "CSS Properties",
+  "category_key": "css_properties",
+  "content": "# Border Left\r\n\r\nThe [`border-left`(#d3e965)](/docs/weblab/border-left/) property specifies the width, line style, and color of the left border of an element. It is a shorthand property for setting in one declaration the width, the style, and the color of an element's left border.",
+  "examples": [
+    {
+      "name": "Border Left Property",
+      "description": "Set the style of the left border of `<h1>` for different elements.",
+      "code": "```\nh1 {\r\n  border-left: 5px solid red;\r\n}\n```",
+      "app": "",
+      "image": null,
+      "app_display_type": "codeFromCodeField",
+      "embed_app_with_code_height": 310
+    }
+  ],
+  "external_documentation": "http://www.w3schools.com/cssref/pr_border-left.asp",
+  "short_description": "Border Left\nThe border-left property specifies the width, line style, and color of the left border of an element. It is a shorthand property for setting in one declaration the width, the style, and the color of an element's left border.",
+  "syntax": "border-left: border-width border-style border-color;",
+  "tips": "* If [`border-style`(#d3e965)](/docs/weblab/border-style/) is not provided, the default is no border.\r\n* If no [`border-color`(#d3e965)](/docs/weblab/border-color/) is chosen, the border color will match the current text color.\r\n* If [`border-width`(#d3e965)](/docs/weblab/border-width/) is not provided, the default is `medium`."
+}

--- a/dashboard/config/programming_expressions/weblab2/border-left.json
+++ b/dashboard/config/programming_expressions/weblab2/border-left.json
@@ -3,7 +3,7 @@
   "name": "Border Left",
   "category": "CSS Properties",
   "category_key": "css_properties",
-  "content": "# Border Left\r\n\r\nThe [`border-left`(#d3e965)](/docs/weblab/border-left/) property specifies the width, line style, and color of the left border of an element. It is a shorthand property for setting in one declaration the width, the style, and the color of an element's left border.",
+  "content": "# Border Left\r\n\r\nThe [`border-left`(#d3e965)](/docs/ide/weblab2/expressions/border-left/) property specifies the width, line style, and color of the left border of an element. It is a shorthand property for setting in one declaration the width, the style, and the color of an element's left border.",
   "examples": [
     {
       "name": "Border Left Property",
@@ -18,5 +18,5 @@
   "external_documentation": "http://www.w3schools.com/cssref/pr_border-left.asp",
   "short_description": "Border Left\nThe border-left property specifies the width, line style, and color of the left border of an element. It is a shorthand property for setting in one declaration the width, the style, and the color of an element's left border.",
   "syntax": "border-left: border-width border-style border-color;",
-  "tips": "* If [`border-style`(#d3e965)](/docs/weblab/border-style/) is not provided, the default is no border.\r\n* If no [`border-color`(#d3e965)](/docs/weblab/border-color/) is chosen, the border color will match the current text color.\r\n* If [`border-width`(#d3e965)](/docs/weblab/border-width/) is not provided, the default is `medium`."
+  "tips": "* If [`border-style`(#d3e965)](/docs/ide/weblab2/expressions/border-style/) is not provided, the default is no border.\r\n* If no [`border-color`(#d3e965)](/docs/ide/weblab2/expressions/border-color/) is chosen, the border color will match the current text color.\r\n* If [`border-width`(#d3e965)](/docs/ide/weblab2/expressions/border-width/) is not provided, the default is `medium`."
 }

--- a/dashboard/config/programming_expressions/weblab2/border-radius.json
+++ b/dashboard/config/programming_expressions/weblab2/border-radius.json
@@ -1,0 +1,31 @@
+{
+  "key": "border-radius",
+  "name": "Border Radius",
+  "category": "CSS Properties",
+  "category_key": "css_properties",
+  "content": "# Border Radius\r\n\r\nThe [`border-radius`(#d3e965)](/docs/weblab/border-radius/) property specifies the radius of the element's corners; it allows you to add rounded corners to elements. This property can have from one to four values. The four values for each radius are given in the order `top-left`, `top-right`, `bottom-right`, `bottom-left`. When one value is specified, it applies the same radius to all four corners.",
+  "examples": [
+    {
+      "name": "Rounded Corners in Pixels",
+      "description": "Set rounded corners in pixels for a `<h1>` element.",
+      "code": "```\nh1 {\r\n  border: 2px solid red;\r\n  border-radius: 25px;\r\n}\r\n\n```",
+      "app": "",
+      "image": null,
+      "app_display_type": "codeFromCodeField",
+      "embed_app_with_code_height": 310
+    },
+    {
+      "name": "Rounded Corners as a Percentage",
+      "description": "Set rounded corners in percent for a `<h1>` element.",
+      "code": "```\nh1 {\r\n  border: 2px solid red;\r\n  border-radius: 20%;\r\n}\n```",
+      "app": "",
+      "image": null,
+      "app_display_type": "codeFromCodeField",
+      "embed_app_with_code_height": 310
+    }
+  ],
+  "external_documentation": "http://www.w3schools.com/cssref/css3_pr_border-radius.asp",
+  "short_description": "Border Radius\nThe border-radius property specifies the radius of the element's corners; it allows you to add rounded corners to elements. This property can have from one to four values. The four values for each radius are given in the order top-left, top-right, bottom-right, bottom-left. When one value is specified, it applies the same radius to all four corners.",
+  "syntax": "border-radius: value;",
+  "tips": "* You can give any element \"rounded corners\" by applying a [`border-radius`(#d3e965)](/docs/weblab/border-radius/).\r\n* The default value is 0.\r\n* The shape of the corners can be defined in pixels or percent. "
+}

--- a/dashboard/config/programming_expressions/weblab2/border-radius.json
+++ b/dashboard/config/programming_expressions/weblab2/border-radius.json
@@ -3,7 +3,7 @@
   "name": "Border Radius",
   "category": "CSS Properties",
   "category_key": "css_properties",
-  "content": "# Border Radius\r\n\r\nThe [`border-radius`(#d3e965)](/docs/weblab/border-radius/) property specifies the radius of the element's corners; it allows you to add rounded corners to elements. This property can have from one to four values. The four values for each radius are given in the order `top-left`, `top-right`, `bottom-right`, `bottom-left`. When one value is specified, it applies the same radius to all four corners.",
+  "content": "# Border Radius\r\n\r\nThe [`border-radius`(#d3e965)](/docs/ide/weblab2/expressions/border-radius/) property specifies the radius of the element's corners; it allows you to add rounded corners to elements. This property can have from one to four values. The four values for each radius are given in the order `top-left`, `top-right`, `bottom-right`, `bottom-left`. When one value is specified, it applies the same radius to all four corners.",
   "examples": [
     {
       "name": "Rounded Corners in Pixels",
@@ -27,5 +27,5 @@
   "external_documentation": "http://www.w3schools.com/cssref/css3_pr_border-radius.asp",
   "short_description": "Border Radius\nThe border-radius property specifies the radius of the element's corners; it allows you to add rounded corners to elements. This property can have from one to four values. The four values for each radius are given in the order top-left, top-right, bottom-right, bottom-left. When one value is specified, it applies the same radius to all four corners.",
   "syntax": "border-radius: value;",
-  "tips": "* You can give any element \"rounded corners\" by applying a [`border-radius`(#d3e965)](/docs/weblab/border-radius/).\r\n* The default value is 0.\r\n* The shape of the corners can be defined in pixels or percent. "
+  "tips": "* You can give any element \"rounded corners\" by applying a [`border-radius`(#d3e965)](/docs/ide/weblab2/expressions/border-radius/).\r\n* The default value is 0.\r\n* The shape of the corners can be defined in pixels or percent. "
 }

--- a/dashboard/config/programming_expressions/weblab2/border-right.json
+++ b/dashboard/config/programming_expressions/weblab2/border-right.json
@@ -1,0 +1,22 @@
+{
+  "key": "border-right",
+  "name": "Border Right",
+  "category": "CSS Properties",
+  "category_key": "css_properties",
+  "content": "# Border Right\r\n\r\nThe [`border-right`(#d3e965)](/docs/weblab/border-right/) property specifies the width, line style, and color of the right border of an element. It is a shorthand property for setting in one declaration the width, the style, and the color of an element's right border.",
+  "examples": [
+    {
+      "name": "Border Right Property",
+      "description": "Setting the style of the right border of `<h1>` for different elements.",
+      "code": "```\nh1 {\r\n  border-right: 5px solid red;\r\n}\n```",
+      "app": "",
+      "image": null,
+      "app_display_type": "codeFromCodeField",
+      "embed_app_with_code_height": 310
+    }
+  ],
+  "external_documentation": "http://www.w3schools.com/cssref/pr_border-right.asp",
+  "short_description": "Border Right\nThe border-right property specifies the width, line style, and color of the right border of an element. It is a shorthand property for setting in one declaration the width, the style, and the color of an element's right border.",
+  "syntax": "border-right: value;",
+  "tips": "* If [`border-style`(#d3e965)](/docs/weblab/border-style/) is not provided, the default is no border.\r\n* If no [`border-color`(#d3e965)](/docs/weblab/border-color/) is chosen, the border color will match the current text color.\r\n* If [`border-width`(#d3e965)](/docs/weblab/border-width/) is not provided, the default is `medium`."
+}

--- a/dashboard/config/programming_expressions/weblab2/border-right.json
+++ b/dashboard/config/programming_expressions/weblab2/border-right.json
@@ -3,7 +3,7 @@
   "name": "Border Right",
   "category": "CSS Properties",
   "category_key": "css_properties",
-  "content": "# Border Right\r\n\r\nThe [`border-right`(#d3e965)](/docs/weblab/border-right/) property specifies the width, line style, and color of the right border of an element. It is a shorthand property for setting in one declaration the width, the style, and the color of an element's right border.",
+  "content": "# Border Right\r\n\r\nThe [`border-right`(#d3e965)](/docs/ide/weblab2/expressions/border-right/) property specifies the width, line style, and color of the right border of an element. It is a shorthand property for setting in one declaration the width, the style, and the color of an element's right border.",
   "examples": [
     {
       "name": "Border Right Property",
@@ -18,5 +18,5 @@
   "external_documentation": "http://www.w3schools.com/cssref/pr_border-right.asp",
   "short_description": "Border Right\nThe border-right property specifies the width, line style, and color of the right border of an element. It is a shorthand property for setting in one declaration the width, the style, and the color of an element's right border.",
   "syntax": "border-right: value;",
-  "tips": "* If [`border-style`(#d3e965)](/docs/weblab/border-style/) is not provided, the default is no border.\r\n* If no [`border-color`(#d3e965)](/docs/weblab/border-color/) is chosen, the border color will match the current text color.\r\n* If [`border-width`(#d3e965)](/docs/weblab/border-width/) is not provided, the default is `medium`."
+  "tips": "* If [`border-style`(#d3e965)](/docs/ide/weblab2/expressions/border-style/) is not provided, the default is no border.\r\n* If no [`border-color`(#d3e965)](/docs/ide/weblab2/expressions/border-color/) is chosen, the border color will match the current text color.\r\n* If [`border-width`(#d3e965)](/docs/ide/weblab2/expressions/border-width/) is not provided, the default is `medium`."
 }

--- a/dashboard/config/programming_expressions/weblab2/border-style.json
+++ b/dashboard/config/programming_expressions/weblab2/border-style.json
@@ -1,0 +1,31 @@
+{
+  "key": "border-style",
+  "name": "Border Style",
+  "category": "CSS Properties",
+  "category_key": "css_properties",
+  "content": "#  Border Style\r\n\r\nThe [`border-style`(#d3e965)](/docs/weblab/border-style/) property specifies the line style for all four sides of an element's border. It is a shorthand for top, right, bottom, and left border style respectively. When one value is specified, it applies the same border style to all four sides. There are various border style values, such as `solid`, `dashed`, `dotted`, `double`, `groove`, etc.",
+  "examples": [
+    {
+      "name": "Dashed Border ",
+      "description": "Setting a dashed border for all four sides of a `<h1>` element.",
+      "code": "```\nh1 {\r\n  border-style: dashed;\r\n}\n```",
+      "app": "",
+      "image": null,
+      "app_display_type": "codeFromCodeField",
+      "embed_app_with_code_height": 310
+    },
+    {
+      "name": "Different Border Styles",
+      "description": "Setting different borders on each side of a` <h1>` element.",
+      "code": "```\nh1 {\r\n  border-style: dotted solid dashed double;\r\n}\n```",
+      "app": "",
+      "image": null,
+      "app_display_type": "codeFromCodeField",
+      "embed_app_with_code_height": 310
+    }
+  ],
+  "external_documentation": "http://www.w3schools.com/cssref/pr_border-style.asp",
+  "short_description": "Border Style\nThe border-style property specifies the line style for all four sides of an element's border. It is a shorthand for top, right, bottom, and left border style respectively. When one value is specified, it applies the same border style to all four sides. There are various border style values, such as solid, dashed, dotted, double, groove, etc.",
+  "syntax": "border-style: value;",
+  "tips": "* The default value specifies no border.\r\n* The border style property can take one to four values at a time.\r\n* Always declare the border style property before applying any other CSS border properties."
+}

--- a/dashboard/config/programming_expressions/weblab2/border-style.json
+++ b/dashboard/config/programming_expressions/weblab2/border-style.json
@@ -3,7 +3,7 @@
   "name": "Border Style",
   "category": "CSS Properties",
   "category_key": "css_properties",
-  "content": "#  Border Style\r\n\r\nThe [`border-style`(#d3e965)](/docs/weblab/border-style/) property specifies the line style for all four sides of an element's border. It is a shorthand for top, right, bottom, and left border style respectively. When one value is specified, it applies the same border style to all four sides. There are various border style values, such as `solid`, `dashed`, `dotted`, `double`, `groove`, etc.",
+  "content": "#  Border Style\r\n\r\nThe [`border-style`(#d3e965)](/docs/ide/weblab2/expressions/border-style/) property specifies the line style for all four sides of an element's border. It is a shorthand for top, right, bottom, and left border style respectively. When one value is specified, it applies the same border style to all four sides. There are various border style values, such as `solid`, `dashed`, `dotted`, `double`, `groove`, etc.",
   "examples": [
     {
       "name": "Dashed Border ",

--- a/dashboard/config/programming_expressions/weblab2/border-top.json
+++ b/dashboard/config/programming_expressions/weblab2/border-top.json
@@ -1,0 +1,22 @@
+{
+  "key": "border-top",
+  "name": "Border Top",
+  "category": "CSS Properties",
+  "category_key": "css_properties",
+  "content": "# Border Top\r\n\r\nThe [`border-top`(#d3e965)](/docs/weblab/border-top/) property specifies the width, line style, and color of the top border of an element. It is a shorthand property for setting in one declaration the width, the style, and the color of an element's top border.",
+  "examples": [
+    {
+      "name": "Border Top Property",
+      "description": "Setting the top border of a `<h1>`  for different elements.",
+      "code": "```\nh1 {\r\n  border-top: 5px solid red;\r\n}\n```",
+      "app": "",
+      "image": null,
+      "app_display_type": "codeFromCodeField",
+      "embed_app_with_code_height": 310
+    }
+  ],
+  "external_documentation": "http://www.w3schools.com/cssref/pr_border-top.asp",
+  "short_description": "Border Top\nThe border-top property specifies the width, line style, and color of the top border of an element. It is a shorthand property for setting in one declaration the width, the style, and the color of an element's top border.",
+  "syntax": "border-top: border-width border-style border-color;",
+  "tips": "* If [`border-style`(#d3e965)](/docs/weblab/border-style/) is not provided, the default is no border.\r\n* If no [`border-color`(#d3e965)](/docs/weblab/border-color/) is chosen, the border will match the current text color.\r\n* If [`border-width`(#d3e965)](/docs/weblab/border-width/) is not provided, the default is medium."
+}

--- a/dashboard/config/programming_expressions/weblab2/border-top.json
+++ b/dashboard/config/programming_expressions/weblab2/border-top.json
@@ -3,7 +3,7 @@
   "name": "Border Top",
   "category": "CSS Properties",
   "category_key": "css_properties",
-  "content": "# Border Top\r\n\r\nThe [`border-top`(#d3e965)](/docs/weblab/border-top/) property specifies the width, line style, and color of the top border of an element. It is a shorthand property for setting in one declaration the width, the style, and the color of an element's top border.",
+  "content": "# Border Top\r\n\r\nThe [`border-top`(#d3e965)](/docs/ide/weblab2/expressions/border-top/) property specifies the width, line style, and color of the top border of an element. It is a shorthand property for setting in one declaration the width, the style, and the color of an element's top border.",
   "examples": [
     {
       "name": "Border Top Property",
@@ -18,5 +18,5 @@
   "external_documentation": "http://www.w3schools.com/cssref/pr_border-top.asp",
   "short_description": "Border Top\nThe border-top property specifies the width, line style, and color of the top border of an element. It is a shorthand property for setting in one declaration the width, the style, and the color of an element's top border.",
   "syntax": "border-top: border-width border-style border-color;",
-  "tips": "* If [`border-style`(#d3e965)](/docs/weblab/border-style/) is not provided, the default is no border.\r\n* If no [`border-color`(#d3e965)](/docs/weblab/border-color/) is chosen, the border will match the current text color.\r\n* If [`border-width`(#d3e965)](/docs/weblab/border-width/) is not provided, the default is medium."
+  "tips": "* If [`border-style`(#d3e965)](/docs/ide/weblab2/expressions/border-style/) is not provided, the default is no border.\r\n* If no [`border-color`(#d3e965)](/docs/ide/weblab2/expressions/border-color/) is chosen, the border will match the current text color.\r\n* If [`border-width`(#d3e965)](/docs/ide/weblab2/expressions/border-width/) is not provided, the default is medium."
 }

--- a/dashboard/config/programming_expressions/weblab2/border-width.json
+++ b/dashboard/config/programming_expressions/weblab2/border-width.json
@@ -1,0 +1,31 @@
+{
+  "key": "border-width",
+  "name": "Border Width",
+  "category": "CSS Properties",
+  "category_key": "css_properties",
+  "content": "# Border Width\r\n\r\nThe `border- width` property specifies the width of all four sides of an element's border.  It is a shorthand for top, right, bottom, and left border width respectively. When one value is specified, it applies the same width to all four sides.The width can be set as a specific size (in px, pt, cm, em, etc) or by using one of the three predefined values: `thin`, ` medium`, or `thick`.",
+  "examples": [
+    {
+      "name": "Width Using a Predefined Value",
+      "description": "Setting the width of the four sides of  a`<h1>` element  border to thick.",
+      "code": "```\nh1 {\r\n  border-style: solid;\r\n  border-width: thick;\r\n}\n```",
+      "app": "",
+      "image": null,
+      "app_display_type": "codeFromCodeField",
+      "embed_app_with_code_height": 310
+    },
+    {
+      "name": "Different Border Widths",
+      "description": "Setting the width of the four sides of a `<h1>` element border to four values (top border, right border, bottom border, and the left border respectively).",
+      "code": "```\nh1 {\r\n  border-style: solid;\r\n  border-width: 25px 10px 4px 35px;\r\n}\n```",
+      "app": "",
+      "image": null,
+      "app_display_type": "codeFromCodeField",
+      "embed_app_with_code_height": 310
+    }
+  ],
+  "external_documentation": "http://www.w3schools.com/cssref/pr_border-width.asp",
+  "short_description": "Border Width\nThe border- width property specifies the width of all four sides of an element's border.  It is a shorthand for top, right, bottom, and left border width respectively. When one value is specified, it applies the same width to all four sides.The width can be set as a specific size (in px, pt, cm, em, etc) or by using one of the three predefined values: thin,  medium, or thick.",
+  "syntax": "border-width: value;",
+  "tips": "* The default border width is medium.\r\n* The border width property can take one to four values at a time.\r\n* Always set the [`border-style`(#d3e965)](/docs/weblab/border-style/) property before the [`border-width`(#d3e965)](/docs/weblab/border-width/) property."
+}

--- a/dashboard/config/programming_expressions/weblab2/border-width.json
+++ b/dashboard/config/programming_expressions/weblab2/border-width.json
@@ -27,5 +27,5 @@
   "external_documentation": "http://www.w3schools.com/cssref/pr_border-width.asp",
   "short_description": "Border Width\nThe border- width property specifies the width of all four sides of an element's border.  It is a shorthand for top, right, bottom, and left border width respectively. When one value is specified, it applies the same width to all four sides.The width can be set as a specific size (in px, pt, cm, em, etc) or by using one of the three predefined values: thin,  medium, or thick.",
   "syntax": "border-width: value;",
-  "tips": "* The default border width is medium.\r\n* The border width property can take one to four values at a time.\r\n* Always set the [`border-style`(#d3e965)](/docs/weblab/border-style/) property before the [`border-width`(#d3e965)](/docs/weblab/border-width/) property."
+  "tips": "* The default border width is medium.\r\n* The border width property can take one to four values at a time.\r\n* Always set the [`border-style`(#d3e965)](/docs/ide/weblab2/expressions/border-style/) property before the [`border-width`(#d3e965)](/docs/ide/weblab2/expressions/border-width/) property."
 }

--- a/dashboard/config/programming_expressions/weblab2/border.json
+++ b/dashboard/config/programming_expressions/weblab2/border.json
@@ -1,0 +1,22 @@
+{
+  "key": "border",
+  "name": "Border",
+  "category": "CSS Properties",
+  "category_key": "css_properties",
+  "content": "# Border\n\nThe [`Border`(#d3e965)](/docs/weblab/border/) property specifies the style, width, and color of an element's border. It is a shorthand property for [`border: border-width border-style border-color;`(#d3e965)](/docs/weblab/border/).",
+  "examples": [
+    {
+      "name": "Border Property",
+      "description": "Setting a `<h1>` element to a solid red border of 5 pixels width. ",
+      "code": "```\nh1 {\r\n  border: 5px solid red;\r\n}\n```",
+      "app": "",
+      "image": null,
+      "app_display_type": "codeFromCodeField",
+      "embed_app_with_code_height": 310
+    }
+  ],
+  "external_documentation": "https://www.w3schools.com/cssref/pr_border.asp",
+  "short_description": "Border\nThe border property specifies the style, width, and color of an element's border. It is a shorthand property for border-width, border-style, and border-color.",
+  "syntax": "border: border-width border-style border-color;",
+  "tips": "* If [`border-style`(#d3e965)](/docs/weblab/border-style/) value  is not provided, the default is no border.\r\n* If no [`border-color`(#d3e965)](/docs/weblab/border-color/) value is chosen, the border color will match the color of the text.\r\n* If [`border-width`(#d3e965)](/docs/weblab/border-width/) value is not provided, the default is `medium`."
+}

--- a/dashboard/config/programming_expressions/weblab2/border.json
+++ b/dashboard/config/programming_expressions/weblab2/border.json
@@ -3,7 +3,7 @@
   "name": "Border",
   "category": "CSS Properties",
   "category_key": "css_properties",
-  "content": "# Border\n\nThe [`Border`(#d3e965)](/docs/weblab/border/) property specifies the style, width, and color of an element's border. It is a shorthand property for [`border: border-width border-style border-color;`(#d3e965)](/docs/weblab/border/).",
+  "content": "# Border\n\nThe [`Border`(#d3e965)](/docs/ide/weblab2/expressions/border/) property specifies the style, width, and color of an element's border. It is a shorthand property for [`border: border-width border-style border-color;`(#d3e965)](/docs/ide/weblab2/expressions/border/).",
   "examples": [
     {
       "name": "Border Property",
@@ -18,5 +18,5 @@
   "external_documentation": "https://www.w3schools.com/cssref/pr_border.asp",
   "short_description": "Border\nThe border property specifies the style, width, and color of an element's border. It is a shorthand property for border-width, border-style, and border-color.",
   "syntax": "border: border-width border-style border-color;",
-  "tips": "* If [`border-style`(#d3e965)](/docs/weblab/border-style/) value  is not provided, the default is no border.\r\n* If no [`border-color`(#d3e965)](/docs/weblab/border-color/) value is chosen, the border color will match the color of the text.\r\n* If [`border-width`(#d3e965)](/docs/weblab/border-width/) value is not provided, the default is `medium`."
+  "tips": "* If [`border-style`(#d3e965)](/docs/ide/weblab2/expressions/border-style/) value  is not provided, the default is no border.\r\n* If no [`border-color`(#d3e965)](/docs/ide/weblab2/expressions/border-color/) value is chosen, the border color will match the color of the text.\r\n* If [`border-width`(#d3e965)](/docs/ide/weblab2/expressions/border-width/) value is not provided, the default is `medium`."
 }

--- a/dashboard/config/programming_expressions/weblab2/color.json
+++ b/dashboard/config/programming_expressions/weblab2/color.json
@@ -1,0 +1,40 @@
+{
+  "key": "color",
+  "name": "Color",
+  "category": "CSS Properties",
+  "category_key": "css_properties",
+  "content": "# Color\nThe color property specifies the color of text. There are [140 color names](https://www.w3schools.com/colors/colors_names.asp) predefined in the HTML and CSS color specification, such as blue, red, coral, brown, etc. Colors also can be specified in various formats; the RGB colors and the HEX colors are the most used ones. ",
+  "examples": [
+    {
+      "name": "Color in HEX",
+      "description": "Setting the text color for a `<h1>` element to polo blue using a HEX value.",
+      "code": "```\nh1 {\n   color: #92a8d1;\n}\n```",
+      "app": "",
+      "image": null,
+      "app_display_type": "codeFromCodeField",
+      "embed_app_with_code_height": 310
+    },
+    {
+      "name": "RGB Color",
+      "description": "Setting the text color of a` <h1>` to crimson using an RGB value.",
+      "code": "```\nh1 {\r\n  color: rgb(220, 20, 60);\r\n}\n```",
+      "app": "",
+      "image": null,
+      "app_display_type": "codeFromCodeField",
+      "embed_app_with_code_height": 310
+    },
+    {
+      "name": "Color Name",
+      "description": "Setting the text color for a `<p>` element to green.",
+      "code": "```\np {\n  color: green;\n}\n\n```",
+      "app": "",
+      "image": null,
+      "app_display_type": "codeFromCodeField",
+      "embed_app_with_code_height": 310
+    }
+  ],
+  "external_documentation": "http://www.w3schools.com/cssref/pr_text_color.asp",
+  "short_description": "Color\nThe color property specifies the color of text. There are 140 color names predefined in the HTML and CSS color specification, such as blue, red, coral, brown, etc. Colors also can be specified in various formats; the RGB colors and the HEX colors are the most used ones. ",
+  "syntax": "color: value;",
+  "tips": "* Make sure to choose a background color combined with a text color that makes the text readable"
+}

--- a/dashboard/config/programming_expressions/weblab2/comment.json
+++ b/dashboard/config/programming_expressions/weblab2/comment.json
@@ -1,0 +1,22 @@
+{
+  "key": "comment",
+  "name": "Comment",
+  "category": "HTML Tags",
+  "category_key": "html_tags",
+  "content": "# Comment\r\n\r\nComments in HTML begin with `<!--` and ends with `-->`. A comment is a piece of code which is ignored by any web browser. ",
+  "examples": [
+    {
+      "name": "",
+      "description": "Using comments as reminders3",
+      "code": "```\n<h1> All About Me</h1>\r\n<!--Remember to add more content here.-->\r\n\n```",
+      "app": "",
+      "image": null,
+      "app_display_type": "codeFromCodeField",
+      "embed_app_with_code_height": 310
+    }
+  ],
+  "external_documentation": "http://www.w3schools.com/tags/tag_comment.asp",
+  "short_description": "Comment\nComments in HTML begin with &lt;!-- and ends with --&gt;. A comment is a piece of code which is ignored by any web browser. ",
+  "syntax": "<!-- Your comment here-->",
+  "tips": "* Any content placed within the `<!--` and `-->` tags will be completely ignored by the browser.\r\n* It is a good practice to add comments into your HTML code to help you and others understand your code and increase code readability."
+}

--- a/dashboard/config/programming_expressions/weblab2/div.json
+++ b/dashboard/config/programming_expressions/weblab2/div.json
@@ -1,0 +1,22 @@
+{
+  "key": "div",
+  "name": "Div",
+  "category": "HTML Tags",
+  "category_key": "html_tags",
+  "content": "# Div\r\n\r\nThe  div tag `<div>`  divides the HTML document into sections of content. This div tag `<div>` is used to group together HTML elements, allowing you to apply CSS styles to many elements at once.\r\n",
+  "examples": [
+    {
+      "name": "",
+      "description": "Using `<div>` to group (`<h4>`, `<p>`, `<ul>`) to be styled as red.",
+      "code": "```\n<div style = \"color:red\">\r\n  <h4>This is first group</h4>\r\n  <p>Following is a list of vegetables</p>\r\n  <ul>\r\n    <li>Beetroot</li>\r\n    <li>Ginger</li>\r\n  </ul>\r\n </div>\r\n\n```",
+      "app": "",
+      "image": null,
+      "app_display_type": "codeFromCodeField",
+      "embed_app_with_code_height": 310
+    }
+  ],
+  "external_documentation": "http://www.w3schools.com/tags/tag_div.asp",
+  "short_description": "Div\nThe  div tag &lt;div&gt;  divides the HTML document into sections of content. This div tag &lt;div&gt; is used to group together HTML elements, allowing you to apply CSS styles to many elements at once.",
+  "syntax": "<div></div>",
+  "tips": "* Use `<div>` to set a section in an HTML document and groups elements for formatting with class or id attributes.\r\n* Any sort of content can be put inside the `<div>` tags, such as text, list, images, etc. \r\n"
+}

--- a/dashboard/config/programming_expressions/weblab2/doctype.json
+++ b/dashboard/config/programming_expressions/weblab2/doctype.json
@@ -1,0 +1,22 @@
+{
+  "key": "doctype",
+  "name": "Doctype",
+  "category": "HTML Tags",
+  "category_key": "html_tags",
+  "content": "# Doctype\r\n\r\nAll HTML documents must start with a `<!DOCTYPE>` declaration. This `<!DOCTYPE>` tag tells the browser what version of HTML the page is written in.",
+  "examples": [
+    {
+      "name": "",
+      "description": "Using `<!DOCTYPE>`  to declare the version of HTML the page is written in.",
+      "code": "```\n<!DOCTYPE html>\r\n<html>\r\n<head>\r\n<title>Title of the document</title>\r\n</head>\r\n\r\n<body>\r\nThe content of the document......\r\n</body>\r\n\r\n</html>\r\n\n```",
+      "app": "",
+      "image": null,
+      "app_display_type": "codeFromCodeField",
+      "embed_app_with_code_height": 310
+    }
+  ],
+  "external_documentation": "http://www.w3schools.com/tags/tag_doctype.asp",
+  "short_description": "Doctype\nAll HTML documents must start with a &lt;!DOCTYPE&gt; declaration. This &lt;!DOCTYPE&gt; tag tells the browser what version of HTML the page is written in.",
+  "syntax": "<!DOCTYPE>",
+  "tips": "* The `<!DOCTYPE>` is the very first line in the HTML document.\r\n* The `<!DOCTYPE>` *does not* need a closing tag."
+}

--- a/dashboard/config/programming_expressions/weblab2/float.json
+++ b/dashboard/config/programming_expressions/weblab2/float.json
@@ -1,0 +1,22 @@
+{
+  "key": "float",
+  "name": "Float",
+  "category": "CSS Properties",
+  "category_key": "css_properties",
+  "content": "#  Float\r\n\r\nThe [`Float`(#d3e965)](/docs/weblab/float/) property places an element on the left or right side of the screen and allows text and other elements to wrap around it. \r\n",
+  "examples": [
+    {
+      "name": "",
+      "description": "Setting an image to float to the right.",
+      "code": "```\nimg {\r\n  float: right;\r\n}\n```",
+      "app": "",
+      "image": null,
+      "app_display_type": "codeFromCodeField",
+      "embed_app_with_code_height": 310
+    }
+  ],
+  "external_documentation": "http://www.w3schools.com/cssref/pr_class_float.asp",
+  "short_description": "Float\nThe float property places an element on the left or right side of the screen and allows text and other elements to wrap around it. ",
+  "syntax": "float: value;",
+  "tips": "* The float's default value is `none` (no float); the element will follow the normal flow of the page.\r\n* The float property can be used for web page layouts and wrapping text around images."
+}

--- a/dashboard/config/programming_expressions/weblab2/float.json
+++ b/dashboard/config/programming_expressions/weblab2/float.json
@@ -3,7 +3,7 @@
   "name": "Float",
   "category": "CSS Properties",
   "category_key": "css_properties",
-  "content": "#  Float\r\n\r\nThe [`Float`(#d3e965)](/docs/weblab/float/) property places an element on the left or right side of the screen and allows text and other elements to wrap around it. \r\n",
+  "content": "#  Float\r\n\r\nThe [`Float`(#d3e965)](/docs/ide/weblab2/expressions/float/) property places an element on the left or right side of the screen and allows text and other elements to wrap around it. \r\n",
   "examples": [
     {
       "name": "",

--- a/dashboard/config/programming_expressions/weblab2/font-family.json
+++ b/dashboard/config/programming_expressions/weblab2/font-family.json
@@ -1,0 +1,22 @@
+{
+  "key": "font-family",
+  "name": "Font Family",
+  "category": "CSS Properties",
+  "category_key": "css_properties",
+  "content": "# Font Family\r\nThe [`font-family`(#d3e965)](/docs/weblab/font-family/) property specifies the font for an element. There are two types of font family names:\r\n* `family-name` - The name of a [`font-family`(#d3e965)](/docs/weblab/font-family/), like `times`, `courier`, `arial`, etc.\r\n* `generic-family` - The name of a `generic-family`, like `serif`, `sans-serif`, `cursive`, `fantasy`, `monospace`.",
+  "examples": [
+    {
+      "name": "Multiple Font Families",
+      "description": "Setting  the font of a `<p>` element.",
+      "code": "```\np{\r\n  font-family: Arial, Helvetica, sans-serif;\r\n}\n```",
+      "app": "",
+      "image": null,
+      "app_display_type": "codeFromCodeField",
+      "embed_app_with_code_height": 310
+    }
+  ],
+  "external_documentation": "http://www.w3schools.com/cssref/pr_font_font-family.asp",
+  "short_description": "Font Family\nThe font-family property specifies the font for an element. There are two types of font family names:\n family-name - The name of a font-family, like times, courier, arial, etc.\n generic-family - The name of a generic-family, like serif, sans-serif, cursive, fantasy, monospace.",
+  "syntax": "font-family: value;",
+  "tips": "* You can specify a list of fonts, from highest priority to lowest. If the browser does not support the first font, it tries the next font.\r\n* When listing multiple font families, make sure to separate each value with a comma."
+}

--- a/dashboard/config/programming_expressions/weblab2/font-family.json
+++ b/dashboard/config/programming_expressions/weblab2/font-family.json
@@ -3,7 +3,7 @@
   "name": "Font Family",
   "category": "CSS Properties",
   "category_key": "css_properties",
-  "content": "# Font Family\r\nThe [`font-family`(#d3e965)](/docs/weblab/font-family/) property specifies the font for an element. There are two types of font family names:\r\n* `family-name` - The name of a [`font-family`(#d3e965)](/docs/weblab/font-family/), like `times`, `courier`, `arial`, etc.\r\n* `generic-family` - The name of a `generic-family`, like `serif`, `sans-serif`, `cursive`, `fantasy`, `monospace`.",
+  "content": "# Font Family\r\nThe [`font-family`(#d3e965)](/docs/ide/weblab2/expressions/font-family/) property specifies the font for an element. There are two types of font family names:\r\n* `family-name` - The name of a [`font-family`(#d3e965)](/docs/ide/weblab2/expressions/font-family/), like `times`, `courier`, `arial`, etc.\r\n* `generic-family` - The name of a `generic-family`, like `serif`, `sans-serif`, `cursive`, `fantasy`, `monospace`.",
   "examples": [
     {
       "name": "Multiple Font Families",

--- a/dashboard/config/programming_expressions/weblab2/font-size.json
+++ b/dashboard/config/programming_expressions/weblab2/font-size.json
@@ -1,0 +1,22 @@
+{
+  "key": "font-size",
+  "name": "Font Size",
+  "category": "CSS Properties",
+  "category_key": "css_properties",
+  "content": "# Font Size\r\n\r\nThe [`font-size`(#d3e965)](/docs/weblab/font-size/) property specifies the size of a font.",
+  "examples": [
+    {
+      "name": "Changing the Font Size",
+      "description": "Setting the font size of a` <p>` element to 12px.",
+      "code": "```\np {\r\n  font-size: 12px; \r\n}\n```",
+      "app": "",
+      "image": null,
+      "app_display_type": "codeFromCodeField",
+      "embed_app_with_code_height": 310
+    }
+  ],
+  "external_documentation": "http://www.w3schools.com/cssref/pr_font_font-size.asp",
+  "short_description": "Font Size\nThe font-size property specifies the size of a font.",
+  "syntax": "font-size: value;",
+  "tips": "* The default font size is medium (16px)."
+}

--- a/dashboard/config/programming_expressions/weblab2/font-size.json
+++ b/dashboard/config/programming_expressions/weblab2/font-size.json
@@ -3,7 +3,7 @@
   "name": "Font Size",
   "category": "CSS Properties",
   "category_key": "css_properties",
-  "content": "# Font Size\r\n\r\nThe [`font-size`(#d3e965)](/docs/weblab/font-size/) property specifies the size of a font.",
+  "content": "# Font Size\r\n\r\nThe [`font-size`(#d3e965)](/docs/ide/weblab2/expressions/font-size/) property specifies the size of a font.",
   "examples": [
     {
       "name": "Changing the Font Size",

--- a/dashboard/config/programming_expressions/weblab2/h.json
+++ b/dashboard/config/programming_expressions/weblab2/h.json
@@ -1,0 +1,31 @@
+{
+  "key": "h",
+  "name": "Heading",
+  "category": "HTML Tags",
+  "category_key": "html_tags",
+  "content": "# Heading\r\nThis tag is used to create different sized section titles throughout a web page. The `<h1>` through` <h6>` tags are used to create headings on a page, where `<h1>` is the largest and `<h6>` is the smallest.\r\n",
+  "examples": [
+    {
+      "name": "Largest and smallest headings",
+      "description": "Using `<h1>` and `<h6>` tags to create the largest and smallest headings.",
+      "code": "```\n<h1>This heading is the largest in terms of font size.</h1>\r\n<h6>This heading is the smallest in terms of font size.</h6>\n```",
+      "app": "",
+      "image": null,
+      "app_display_type": "codeFromCodeField",
+      "embed_app_with_code_height": 310
+    },
+    {
+      "name": "Tile and subtitle",
+      "description": "Using `<h1>` and `<h2>` to create a title and a subtitle. ",
+      "code": "```\n<h1>Choosing a Pet</h1>\r\n<p>This page will help you choose between a dog, turtle, or a bird</p>\r\n<h2>Dogs</h2>\r\n<p>Dogs are the most work, but they are also the most fun.  You have to walk them every day, but they love you and will always play with you.</p>\r\n\n```",
+      "app": "",
+      "image": null,
+      "app_display_type": "codeFromCodeField",
+      "embed_app_with_code_height": 310
+    }
+  ],
+  "external_documentation": "http://www.w3schools.com/tags/tag_hn.asp",
+  "short_description": "Heading\nThis tag is used to create different sized section titles throughout a web page. The &lt;h1&gt; through &lt;h6&gt; tags are used to create headings on a page, where &lt;h1&gt; is the largest and &lt;h6&gt; is the smallest.",
+  "syntax": "<h1></h1>",
+  "tips": "* There are different sized headings which are marked by the number in the heading tag. They go from `<h1>` to `<h6>`.\r\n* The `<h1>` tag is the largest font size.\r\n* The `<h6>` tag is the smallest font size.\r\n"
+}

--- a/dashboard/config/programming_expressions/weblab2/head.json
+++ b/dashboard/config/programming_expressions/weblab2/head.json
@@ -1,0 +1,22 @@
+{
+  "key": "head",
+  "name": "Head",
+  "category": "HTML Tags",
+  "category_key": "html_tags",
+  "content": "# Head\r\n\r\nThis tag is used as a container for metadata: metadata is data about the HTML document, such as document title, character set, style sheets, links, and scripts.",
+  "examples": [
+    {
+      "name": "",
+      "description": "Using `<head>`to contain metadata about the HTML document.",
+      "code": "```\n<html>\n  <head>\n    <meta charset=\"utf-8\">\n    <title>HTML Basics </title>\n    <link rel=\"stylesheet\" href=\"style.css\" type=\"text/css\" />\n  </head>\n  </body>\n</html>\n\n```",
+      "app": "",
+      "image": null,
+      "app_display_type": "codeFromCodeField",
+      "embed_app_with_code_height": 310
+    }
+  ],
+  "external_documentation": "http://www.w3schools.com/tags/tag_head.asp",
+  "short_description": "Head\nThis tag is used as a container for metadata: metadata is data about the HTML document, such as document title, character set, style sheets, links, and scripts.",
+  "syntax": "<head></head>",
+  "tips": "* Make sure you *don’t* put any content in the `<head>` tag.\r\n* The `<head>` is placed inside the `<html>` tags and before  the `<body>` tags."
+}

--- a/dashboard/config/programming_expressions/weblab2/height.json
+++ b/dashboard/config/programming_expressions/weblab2/height.json
@@ -1,0 +1,31 @@
+{
+  "key": "height",
+  "name": "Height",
+  "category": "CSS Properties",
+  "category_key": "css_properties",
+  "content": "# Height\n\nThe [`Height`(#d3e965)](/docs/weblab/height/) property specifies the height of the content area of an element. The height of an element does not include padding, borders, or margins. Height can be defined in percentage (of the width of the containing block), pixels, cm, etc.",
+  "examples": [
+    {
+      "name": " Height in pixels",
+      "description": "\r\nSet the height of a `<p>` element to 100 px.\r\n",
+      "code": "```\np{\r\n  height: 100px;\r\n}\r\n\n```",
+      "app": "",
+      "image": null,
+      "app_display_type": "codeFromCodeField",
+      "embed_app_with_code_height": 310
+    },
+    {
+      "name": " Height as a percentage",
+      "description": "Setting the height of an `<img>` element using a percent value.\r\n",
+      "code": "```\nimg {\r\n  width: 50%;\r\n}\r\n\n```",
+      "app": "",
+      "image": null,
+      "app_display_type": "codeFromCodeField",
+      "embed_app_with_code_height": 310
+    }
+  ],
+  "external_documentation": "http://www.w3schools.com/cssref/pr_dim_height.asp",
+  "short_description": "Height\nThe height property specifies the height of the content area of an element. The height of an element does not include padding, borders, or margins. Height can be defined in percentage (of the width of the containing block), pixels, cm, etc.",
+  "syntax": "height: value;",
+  "tips": "* The height property does not include padding, borders, or margins.\r\n* The default value of the height is auto: the element will automatically adjust its height to allow its content to be displayed correctly."
+}

--- a/dashboard/config/programming_expressions/weblab2/height.json
+++ b/dashboard/config/programming_expressions/weblab2/height.json
@@ -3,7 +3,7 @@
   "name": "Height",
   "category": "CSS Properties",
   "category_key": "css_properties",
-  "content": "# Height\n\nThe [`Height`(#d3e965)](/docs/weblab/height/) property specifies the height of the content area of an element. The height of an element does not include padding, borders, or margins. Height can be defined in percentage (of the width of the containing block), pixels, cm, etc.",
+  "content": "# Height\n\nThe [`Height`(#d3e965)](/docs/ide/weblab2/expressions/height/) property specifies the height of the content area of an element. The height of an element does not include padding, borders, or margins. Height can be defined in percentage (of the width of the containing block), pixels, cm, etc.",
   "examples": [
     {
       "name": " Height in pixels",

--- a/dashboard/config/programming_expressions/weblab2/html.json
+++ b/dashboard/config/programming_expressions/weblab2/html.json
@@ -1,0 +1,22 @@
+{
+  "key": "html",
+  "name": "HTML",
+  "category": "HTML Tags",
+  "category_key": "html_tags",
+  "content": "# HTML\n\nThe HTML element is the top-level element of an HTML document. This HTML tag `<html>` is the container for all other HTML elements (except for the `<!DOCTYPE>` tag).",
+  "examples": [
+    {
+      "name": "",
+      "description": "Using the `<html>` tag to write a simple HTML document.",
+      "code": "```\n<!DOCTYPE html>\r\n<html>\r\n  <head>\r\n    <title>Title of the document</title>\r\n  </head>\r\n  <body>\r\n    <h1>HTML Tag</h1>\r\n    <p>The HTML element is the top-level element of an HTML document.</p>\r\n  </body>\r\n</html>\r\n\n```",
+      "app": "",
+      "image": null,
+      "app_display_type": "codeFromCodeField",
+      "embed_app_with_code_height": 310
+    }
+  ],
+  "external_documentation": "http://www.w3schools.com/tags/tag_html.asp",
+  "short_description": "HTML\nThe HTML element is the top-level element of an HTML document. This HTML tag &lt;html&gt; is the container for all other HTML elements (except for the &lt;!DOCTYPE&gt; tag).",
+  "syntax": "<html></html>",
+  "tips": "* The `<html>` tag is placed right under the <!DOCTYPE> tag.\r\n* The `<html>` tag requires a starting and end tag.\r\n* The `<html>` contains every other tab that makes up the webpage. That’s why the closing tag `</html>` is all the way at the bottom. \r\n"
+}

--- a/dashboard/config/programming_expressions/weblab2/img.json
+++ b/dashboard/config/programming_expressions/weblab2/img.json
@@ -1,0 +1,40 @@
+{
+  "key": "img",
+  "name": "Image",
+  "category": "HTML Tags",
+  "category_key": "html_tags",
+  "content": "# Image\r\n\r\nThis tag is used to embed  images into a web page. This image tag `<img>` has two required attributes:\r\n* `src` - Specifies the path to the image\r\n* `alt` - Specifies an alternate text for the image, if the image for some reason cannot be displayed. \r\n* [`Height`(#d3e965)](/docs/weblab/height/) - Specifies the height of the image in pixels.\r\n* [`Width`(#d3e965)](/docs/weblab/width/) - Specifies the width of the image in pixels.\r\n",
+  "examples": [
+    {
+      "name": "Using Images With Text",
+      "description": "You can use images to help visualize what you're describing. In this example, an image is used to show the first computer bug discovered by Grace Hopper",
+      "code": "```\n<html>\r\n<body>\r\n    <h1>\r\n      Grace Hopper Info\r\n    </h1>\r\n    <p>\r\n      Grace Hopper was a computer scientist in the United States Navy. She developed one of the first programming languages. She also discovered the first computer 'bug'. It was a literal bug in the machine.\r\n    </p>\r\n    <h2>\r\n      The First Computer Bug\r\n    </h2>\r\n    <img src=\"https://archive.computerhistory.org/resources/still-image/Hopper-Grace/hopper-grace.finds_bug.102640477.lg.jpg\" alt=\"Computer Bug\" />\r\n  </body>\r\n</html>\r\n\r\n\n```",
+      "app": "",
+      "image": "https://curriculum.code.org/media/computer-bug_Small.png",
+      "app_display_type": "codeFromCodeField",
+      "embed_app_with_code_height": 310
+    },
+    {
+      "name": " Local Image",
+      "description": "Using `<img>` to embed an image into a web page",
+      "code": "```\n<img src=\"dog.jpg\" alt=\"My Dog\" width=\"500\" height=\"600\">\n```",
+      "app": "",
+      "image": null,
+      "app_display_type": "codeFromCodeField",
+      "embed_app_with_code_height": 310
+    },
+    {
+      "name": "Image on Another Website",
+      "description": "Using `<img>` when the source of an image is a URL",
+      "code": "```\n<img src=\"https://pbs.twimg.com/profile_images/1267892245362913281/2rm_VB9z.png\" alt=\"CODE\" width=\"500\" height=\"600\">\n```",
+      "app": "",
+      "image": null,
+      "app_display_type": "codeFromCodeField",
+      "embed_app_with_code_height": 310
+    }
+  ],
+  "external_documentation": "http://www.w3schools.com/tags/tag_img.asp",
+  "short_description": "Image\nThis tag is used to embed  images into a web page. This image tag &lt;img&gt; has two required attributes:\n src - Specifies the path to the image\n alt - Specifies an alternate text for the image, if the image for some reason cannot be displayed. \n height - Specifies the height of the image in pixels.\n width - Specifies the width of the image in pixels.",
+  "syntax": "<img >",
+  "tips": "* This `<img>` tag must not contain any content, and it does not require a closing tag.\r\n* Make sure to put quotation marks around your image filename.\r\n* The common extensions of an image file are .jpg, .jpeg, and .png, and the source of an image could also be a URL.\r\n* Make sure to give your image file a name that describes what the image is about. \r\n"
+}

--- a/dashboard/config/programming_expressions/weblab2/img.json
+++ b/dashboard/config/programming_expressions/weblab2/img.json
@@ -3,7 +3,7 @@
   "name": "Image",
   "category": "HTML Tags",
   "category_key": "html_tags",
-  "content": "# Image\r\n\r\nThis tag is used to embed  images into a web page. This image tag `<img>` has two required attributes:\r\n* `src` - Specifies the path to the image\r\n* `alt` - Specifies an alternate text for the image, if the image for some reason cannot be displayed. \r\n* [`Height`(#d3e965)](/docs/weblab/height/) - Specifies the height of the image in pixels.\r\n* [`Width`(#d3e965)](/docs/weblab/width/) - Specifies the width of the image in pixels.\r\n",
+  "content": "# Image\r\n\r\nThis tag is used to embed  images into a web page. This image tag `<img>` has two required attributes:\r\n* `src` - Specifies the path to the image\r\n* `alt` - Specifies an alternate text for the image, if the image for some reason cannot be displayed. \r\n* [`Height`(#d3e965)](/docs/ide/weblab2/expressions/height/) - Specifies the height of the image in pixels.\r\n* [`Width`(#d3e965)](/docs/ide/weblab2/expressions/width/) - Specifies the width of the image in pixels.\r\n",
   "examples": [
     {
       "name": "Using Images With Text",

--- a/dashboard/config/programming_expressions/weblab2/li.json
+++ b/dashboard/config/programming_expressions/weblab2/li.json
@@ -1,0 +1,31 @@
+{
+  "key": "li",
+  "name": "List Item",
+  "category": "HTML Tags",
+  "category_key": "html_tags",
+  "content": "# List Item\n\nThis tag is used to create a list. The list tag `<li>` must be contained in an ordered list (`<ol>`) with bullets) or an unordered list (`<ul>`) with numbers).",
+  "examples": [
+    {
+      "name": "Ordered List",
+      "description": "Using `<li>` within an ordered list",
+      "code": "```\n<ol>\r\n  <li>Tea</li> \r\n  <li>Milk</li>\r\n  <li>Water</li>\r\n</ol>\n```",
+      "app": "",
+      "image": null,
+      "app_display_type": "codeFromCodeField",
+      "embed_app_with_code_height": 310
+    },
+    {
+      "name": "Unordered List",
+      "description": "Using `<li>` within an unordered list",
+      "code": "```\n<ul>\r\n  <li>Tea</li>\r\n  <li>Milk</li>\r\n  <li>Water</li>\r\n</ul>\n```",
+      "app": "",
+      "image": null,
+      "app_display_type": "codeFromCodeField",
+      "embed_app_with_code_height": 310
+    }
+  ],
+  "external_documentation": "http://www.w3schools.com/tags/tag_li.asp",
+  "short_description": "List Item\nThis tag is used to create a list. The list tag &lt;li&gt; must be contained in an ordered list (&lt;ol&gt; with numbers) or an unordered list (&lt;ul&gt; with bullets).",
+  "syntax": "<li></li>",
+  "tips": "* Try to indent your `</li>` tags so it's clear they are contained in the `<ul>` or `<ol>` tags.\n* Make sure to start your list with either a `<ul>` or a `<ol>`. If you just use `<li></li>` without `<ul>` or `<ol>` the rendered result will be a unordered list with bullet icons preceding each list item.\n* The list items can contain content other than text such as lists of videos, images, songs, or hyperlinks. "
+}

--- a/dashboard/config/programming_expressions/weblab2/link.json
+++ b/dashboard/config/programming_expressions/weblab2/link.json
@@ -1,0 +1,22 @@
+{
+  "key": "link",
+  "name": "Link",
+  "category": "HTML Tags",
+  "category_key": "html_tags",
+  "content": "# Link\r\n\r\nThis link tag `<link>` is typically used to link CSS to HTML for external stylesheets. The link tag is used to define a link between a HTML document and an external resource. ",
+  "examples": [
+    {
+      "name": "Linking to a Stylesheet",
+      "description": "Using `<link>` to link an HTML document to a style sheet (\"style.css\").",
+      "code": "```\n<head>\r\n   <link rel=\"stylesheet\" href=\"style.css\">\r\n</head>\r\n\n```",
+      "app": "",
+      "image": null,
+      "app_display_type": "codeFromCodeField",
+      "embed_app_with_code_height": 310
+    }
+  ],
+  "external_documentation": "http://www.w3schools.com/tags/tag_link.asp",
+  "short_description": "Link\nThis link tag &lt;link&gt; is typically used to link CSS to HTML for external stylesheets. The link tag is used to define a link between a HTML document and an external resource. ",
+  "syntax": "<link></link>",
+  "tips": "* The link tag `<link>`  goes inside the `<head>` tag.\r\n* The link tag `<link>` allows you to import a stylesheet into your HTML document to control the appearance of all web pages.\r\n"
+}

--- a/dashboard/config/programming_expressions/weblab2/margin.json
+++ b/dashboard/config/programming_expressions/weblab2/margin.json
@@ -1,0 +1,31 @@
+{
+  "key": "margin",
+  "name": "Margin",
+  "category": "CSS Properties",
+  "category_key": "css_properties",
+  "content": "# Margin\r\n\r\nThe [`Margin`(#d3e965)](/docs/weblab/margin/) property specifies the margin area on all four sides of an element. It is a shorthand for `margin-top`, `margin-right`, `margin-bottom`, and `margin-left`. When one value is specified, it applies the same margin to all four sides.\r\n",
+  "examples": [
+    {
+      "name": " Single Margin Value",
+      "description": "Using the shorthand property to set the margin for all four sides of a `<p>` element to 40 pixels.\r\n",
+      "code": "```\np {\r\n  margin: 40px;\r\n}\r\n\n```",
+      "app": "",
+      "image": null,
+      "app_display_type": "codeFromCodeField",
+      "embed_app_with_code_height": 310
+    },
+    {
+      "name": "Multiple Margin Values",
+      "description": "Setting multiple margin values for the four sides of  a `<p> `element.\r\n* The top margin is 10px.\r\n* The right margin is 5px.\r\n* The bottom margin is 15px.\r\n* The left margin is 20px.\r\n",
+      "code": "```\np {\r\n margin: 10px 5px 15px 20px;\r\n}\r\n\n```",
+      "app": "",
+      "image": null,
+      "app_display_type": "codeFromCodeField",
+      "embed_app_with_code_height": 310
+    }
+  ],
+  "external_documentation": "http://www.w3schools.com/cssref/pr_margin.asp",
+  "short_description": "Margin\nThe margin property specifies the margin area on all four sides of an element. It is a shorthand for margin-top, margin-right, margin-bottom, and margin-left. When one value is specified, it applies the same margin to all four sides.",
+  "syntax": "margin: value;",
+  "tips": "* Margins create extra space *around* an element. In contrast, padding creates extra space *inside* an element.\r\nThe default margin value is 0.\r\n* You can specify the margin for the individual sides of an element using the CSS `margin-top`, `margin-right`, `margin-bottom`, and `margin-left` properties, respectively.\r\n"
+}

--- a/dashboard/config/programming_expressions/weblab2/margin.json
+++ b/dashboard/config/programming_expressions/weblab2/margin.json
@@ -3,7 +3,7 @@
   "name": "Margin",
   "category": "CSS Properties",
   "category_key": "css_properties",
-  "content": "# Margin\r\n\r\nThe [`Margin`(#d3e965)](/docs/weblab/margin/) property specifies the margin area on all four sides of an element. It is a shorthand for `margin-top`, `margin-right`, `margin-bottom`, and `margin-left`. When one value is specified, it applies the same margin to all four sides.\r\n",
+  "content": "# Margin\r\n\r\nThe [`Margin`(#d3e965)](/docs/ide/weblab2/expressions/margin/) property specifies the margin area on all four sides of an element. It is a shorthand for `margin-top`, `margin-right`, `margin-bottom`, and `margin-left`. When one value is specified, it applies the same margin to all four sides.\r\n",
   "examples": [
     {
       "name": " Single Margin Value",

--- a/dashboard/config/programming_expressions/weblab2/meta.json
+++ b/dashboard/config/programming_expressions/weblab2/meta.json
@@ -1,0 +1,31 @@
+{
+  "key": "meta",
+  "name": "Meta",
+  "category": "HTML Tags",
+  "category_key": "html_tags",
+  "content": "# Meta\r\n\r\nMetadata is information about data. This meta  tag `<meta>` is used to provide information about HTML documents such as page description, author of the document, and keywords.\r\n",
+  "examples": [
+    {
+      "name": "Web Page Description",
+      "description": "Using `<meta>` to provide a short description about the document.",
+      "code": "```\n<head>\r\n  <meta name = \"description\" \r\n    content = \"This section is an example answer.” />\r\n</head>\r\n\n```",
+      "app": "",
+      "image": null,
+      "app_display_type": "codeFromCodeField",
+      "embed_app_with_code_height": 310
+    },
+    {
+      "name": "Revision Details",
+      "description": "Using `<meta>` to give the information about the last updated document. ",
+      "code": "```\n<head>\r\n  <meta name = \"revised detail\" \r\n    content = \"last updated time\"/>\r\n</head>\r\n\n```",
+      "app": "",
+      "image": null,
+      "app_display_type": "codeFromCodeField",
+      "embed_app_with_code_height": 310
+    }
+  ],
+  "external_documentation": "http://www.w3schools.com/tags/tag_meta.asp",
+  "short_description": "Meta\nMetadata is information about data. This meta  tag &lt;meta&gt; is used to provide information about HTML documents such as page description, author of the document, and keywords.",
+  "syntax": "<meta>",
+  "tips": "* The meta tag *does not* require a closing tag.\r\n* The meta tag always goes inside the `<head>` element and doesn't affect the document's physical appearance.\r\n* A web document can include one or more meta tags.\r\n"
+}

--- a/dashboard/config/programming_expressions/weblab2/ol.json
+++ b/dashboard/config/programming_expressions/weblab2/ol.json
@@ -1,0 +1,31 @@
+{
+  "key": "ol",
+  "name": "Ordered List",
+  "category": "HTML Tags",
+  "category_key": "html_tags",
+  "content": "# Ordered List\r\n\r\nThis tag is used to create  a set of numbered items. An ordered list element has the tag `<ol>` . This is an abbreviation for Ordered List. Each item in the list is marked by a list item element `<li>`.",
+  "examples": [
+    {
+      "name": "Ordered List",
+      "description": "Using `<ol>` to make an ordered list",
+      "code": "```\n<ol>\r\n  <li>Tea</li> \r\n  <li>Milk</li>\r\n  <li>Water</li>\r\n</ol>\r\n\n```",
+      "app": "",
+      "image": null,
+      "app_display_type": "codeFromCodeField",
+      "embed_app_with_code_height": 310
+    },
+    {
+      "name": "Steps to Make Horchata",
+      "description": "Listing out the steps to make horchata",
+      "code": "```\n<html>\r\n\t<body>\r\n      <h1>How to Make Horchata</h1>\r\n\r\n      <ol>\r\n        <li>Combine rice, cinnamon sticks, sugar, and water</li>\r\n        <li>Cover and refrigerate for 8 hours</li>\r\n        <li>Blend until smooth</li>\r\n        <li>Strain into a large bowl. Serve over ice</li>\r\n      </ol>\r\n\t</body>\r\n</html>\n```",
+      "app": "",
+      "image": "https://curriculum.code.org/media/horchata.png",
+      "app_display_type": "codeFromCodeField",
+      "embed_app_with_code_height": 310
+    }
+  ],
+  "external_documentation": "http://www.w3schools.com/tags/tag_ol.asp",
+  "short_description": "Ordered List\nThis tag is used to create  a set of numbered items. An ordered list element has the tag &lt;ol&gt; . This is an abbreviation for Ordered List. Each item in the list is marked by a list item element &lt;li&gt;.",
+  "syntax": "<ol></ol>",
+  "tips": "* To make the ordered list, write the ordered list tags `<ol> </ol>`. Next, add your list items inside the ordered list tags. To make each list item, use the list item tags `<li> </li>` and type your content inside the tags.\r\n* Try to indent your `</li>` tags so it's clear they are contained in the `<ol>` tag.\r\n* The list items can contain content other than text such as lists of videos, images, songs, or hyperlinks. \r\n"
+}

--- a/dashboard/config/programming_expressions/weblab2/p.json
+++ b/dashboard/config/programming_expressions/weblab2/p.json
@@ -1,0 +1,31 @@
+{
+  "key": "P",
+  "name": "Paragraph",
+  "category": "HTML Tags",
+  "category_key": "html_tags",
+  "content": "# Paragraph\r\n\r\nThe `<p>` tag is used to  define a paragraph of text.\r\n",
+  "examples": [
+    {
+      "name": "Multiple Short Paragraphs",
+      "description": "Using `<p>` to define a paragraph",
+      "code": "```\n<p>My favorite animals are birds.</p>\r\n<p>My favorite sport is baseball.</p>\r\n\n```",
+      "app": "",
+      "image": null,
+      "app_display_type": "codeFromCodeField",
+      "embed_app_with_code_height": 310
+    },
+    {
+      "name": "Single Longer Paragraph",
+      "description": "Using `<p>` to define a paragraph of multiple lines.",
+      "code": "```\n<p>\nSoccer is an awesome sport because you get to play on a team with all your friends. My favorite players are Megan Rapinoe from the United States, and Marta from Brazil.\n</p>\n\n```",
+      "app": "",
+      "image": null,
+      "app_display_type": "codeFromCodeField",
+      "embed_app_with_code_height": 310
+    }
+  ],
+  "external_documentation": "http://www.w3schools.com/tags/tag_p.asp",
+  "short_description": "Paragraph\nThe &lt;p&gt; tag is used to  define a paragraph of text.",
+  "syntax": "<p></p>",
+  "tips": "* We can use the `<p>` tag to write several paragraphs. \r\n* We can use the `<p>` tag to write a paragraph of multiple lines.\r\n"
+}

--- a/dashboard/config/programming_expressions/weblab2/pad.json
+++ b/dashboard/config/programming_expressions/weblab2/pad.json
@@ -1,0 +1,31 @@
+{
+  "key": "pad",
+  "name": "Padding",
+  "category": "CSS Properties",
+  "category_key": "css_properties",
+  "content": "# Padding\r\n\r\nThe [`Padding`(#d3e965)](/docs/weblab/pad/) property specifies how much space should appear between the content of an element and its border. It is a shorthand for `padding-top`, `padding-right`, `padding-bottom`, and `padding-left`. ",
+  "examples": [
+    {
+      "name": "Single Padding Value",
+      "description": "Using the shorthand property to set the padding for all four sides of a `<p>` element to 40 pixels.",
+      "code": "```\np {\r\n  padding: 40px;\r\n}\r\n\n```",
+      "app": "",
+      "image": null,
+      "app_display_type": "codeFromCodeField",
+      "embed_app_with_code_height": 310
+    },
+    {
+      "name": "Multiple Padding Values",
+      "description": "Setting multiple padding values for the four sides of  a `<p> `element.\r\n* The top padding is 10px.\r\n* The right padding is 5px.\r\n* The bottom padding is 15px.\r\n* The left padding is 20px.\r\n",
+      "code": "```\np {\r\n  padding: 10px 5px 15px 20px;\r\n}\r\n\n```",
+      "app": "",
+      "image": null,
+      "app_display_type": "codeFromCodeField",
+      "embed_app_with_code_height": 310
+    }
+  ],
+  "external_documentation": "http://www.w3schools.com/cssref/pr_padding.asp",
+  "short_description": "Padding\nThe padding property specifies how much space should appear between the content of an element and its border. It is a shorthand for padding-top, padding-right, padding-bottom, and padding-left. ",
+  "syntax": "padding: value;",
+  "tips": "* The default padding value is 0.\r\n* When one value is specified, it applies the same padding to all four sides.\r\n* You can specify the paddings for the individual sides of an element using the CSS `padding-top`, `padding-right`, `padding-bottom`, and the `padding-left` properties, respectively.\r\n"
+}

--- a/dashboard/config/programming_expressions/weblab2/pad.json
+++ b/dashboard/config/programming_expressions/weblab2/pad.json
@@ -3,7 +3,7 @@
   "name": "Padding",
   "category": "CSS Properties",
   "category_key": "css_properties",
-  "content": "# Padding\r\n\r\nThe [`Padding`(#d3e965)](/docs/weblab/pad/) property specifies how much space should appear between the content of an element and its border. It is a shorthand for `padding-top`, `padding-right`, `padding-bottom`, and `padding-left`. ",
+  "content": "# Padding\r\n\r\nThe [`Padding`(#d3e965)](/docs/ide/weblab2/expressions/pad/) property specifies how much space should appear between the content of an element and its border. It is a shorthand for `padding-top`, `padding-right`, `padding-bottom`, and `padding-left`. ",
   "examples": [
     {
       "name": "Single Padding Value",

--- a/dashboard/config/programming_expressions/weblab2/pseudo-classes.json
+++ b/dashboard/config/programming_expressions/weblab2/pseudo-classes.json
@@ -1,0 +1,40 @@
+{
+  "key": "pseudo-classes",
+  "name": "Pseudo Classes",
+  "category": "CSS Properties",
+  "category_key": "css_properties",
+  "content": "# Pseudo Classes\r\n\r\nThe [`pseudo-classes`(#d3e965)](/docs/weblab/pseudo-classes/) property is used to add special effects to some selectors. This property can be used mainly to:\r\n* Style an element when a user mouses over it.\r\n* Style visited and unvisited links differently.\r\n",
+  "examples": [
+    {
+      "name": "Unvisited Link",
+      "description": "Using the `:link` pseudo-class on a link `<a>` element to change color.",
+      "code": "```\na:link {\r\n  color: blue;\r\n}\n```",
+      "app": "",
+      "image": null,
+      "app_display_type": "codeFromCodeField",
+      "embed_app_with_code_height": 310
+    },
+    {
+      "name": " Mouse Over Link",
+      "description": "Using the `:hover` pseudo-class on a link`<a>` element to change color.",
+      "code": "```\na:hover {\r\n  color: green;\r\n}\r\n\n```",
+      "app": "",
+      "image": null,
+      "app_display_type": "codeFromCodeField",
+      "embed_app_with_code_height": 310
+    },
+    {
+      "name": "Visited Link",
+      "description": "Using the `:visited link` pseudo-class on a link`<a>` element to change color.",
+      "code": "```\na:visited link {\r\n  color: green;\r\n}\r\n\n```",
+      "app": "",
+      "image": null,
+      "app_display_type": "codeFromCodeField",
+      "embed_app_with_code_height": 310
+    }
+  ],
+  "external_documentation": "http://www.w3schools.com/Css/css_pseudo_classes.asp",
+  "short_description": "Pseudo Classes\nThe pseudo-classes property is used to add special effects to some selectors. This property can be used mainly to:\n Style an element when a user mouses over it.\n Style visited and unvisited links differently.",
+  "syntax": "selector:pseudo-class {property: value;}",
+  "tips": "* `Pseudo-class` are different from CSS classes but they can be combined.\r\n* [`Pseudo-classes`(#d3e965)](/docs/weblab/pseudo-classes/) help you cut down on excess classes in your markup.\r\n\r\n"
+}

--- a/dashboard/config/programming_expressions/weblab2/pseudo-classes.json
+++ b/dashboard/config/programming_expressions/weblab2/pseudo-classes.json
@@ -3,7 +3,7 @@
   "name": "Pseudo Classes",
   "category": "CSS Properties",
   "category_key": "css_properties",
-  "content": "# Pseudo Classes\r\n\r\nThe [`pseudo-classes`(#d3e965)](/docs/weblab/pseudo-classes/) property is used to add special effects to some selectors. This property can be used mainly to:\r\n* Style an element when a user mouses over it.\r\n* Style visited and unvisited links differently.\r\n",
+  "content": "# Pseudo Classes\r\n\r\nThe [`pseudo-classes`(#d3e965)](/docs/ide/weblab2/expressions/pseudo-classes/) property is used to add special effects to some selectors. This property can be used mainly to:\r\n* Style an element when a user mouses over it.\r\n* Style visited and unvisited links differently.\r\n",
   "examples": [
     {
       "name": "Unvisited Link",
@@ -36,5 +36,5 @@
   "external_documentation": "http://www.w3schools.com/Css/css_pseudo_classes.asp",
   "short_description": "Pseudo Classes\nThe pseudo-classes property is used to add special effects to some selectors. This property can be used mainly to:\n Style an element when a user mouses over it.\n Style visited and unvisited links differently.",
   "syntax": "selector:pseudo-class {property: value;}",
-  "tips": "* `Pseudo-class` are different from CSS classes but they can be combined.\r\n* [`Pseudo-classes`(#d3e965)](/docs/weblab/pseudo-classes/) help you cut down on excess classes in your markup.\r\n\r\n"
+  "tips": "* `Pseudo-class` are different from CSS classes but they can be combined.\r\n* [`Pseudo-classes`(#d3e965)](/docs/ide/weblab2/expressions/pseudo-classes/) help you cut down on excess classes in your markup.\r\n\r\n"
 }

--- a/dashboard/config/programming_expressions/weblab2/rgb-color.json
+++ b/dashboard/config/programming_expressions/weblab2/rgb-color.json
@@ -1,0 +1,22 @@
+{
+  "key": "rgb-color",
+  "name": "RGB Color",
+  "category": "CSS Properties",
+  "category_key": "css_properties",
+  "content": "# RGB Color\r\n\r\nThe `rgb()` function specifies colors using the Red-green-blue (RGB) model. An RGB color value is specified with three parameters: `rgb(red, green, blue)`. Each parameter defines the intensity of that color and can be an integer between 0 and 255 or a percentage value from 0% to 100%.\r\n",
+  "examples": [
+    {
+      "name": "RGB Color",
+      "description": "Setting the text color of a` <h1>` to crimson.",
+      "code": "```\nh1 {\r\n  Color: rgb(220, 20, 60);\r\n}\r\n\n```",
+      "app": "",
+      "image": null,
+      "app_display_type": "codeFromCodeField",
+      "embed_app_with_code_height": 310
+    }
+  ],
+  "external_documentation": "http://www.w3schools.com/cssref/pr_text_color.asp",
+  "short_description": "RGB Color\nThe rgb() function specifies colors using the Red-green-blue (RGB) model. An RGB color value is specified with three parameters: rgb(red, green, blue). Each parameter defines the intensity of that color and can be an integer between 0 and 255 or a percentage value from 0% to 100%.",
+  "syntax": "rgb(red, green, blue);",
+  "tips": "* `rgb(0,0,255)` value is rendered as blue.\r\n* `rgb(255,0,0)` value is rendered as red.\r\n* `rgb(0,255,0)` value is rendered as green.\r\n"
+}

--- a/dashboard/config/programming_expressions/weblab2/style.json
+++ b/dashboard/config/programming_expressions/weblab2/style.json
@@ -1,0 +1,31 @@
+{
+  "key": "style",
+  "name": "Style",
+  "category": "HTML Tags",
+  "category_key": "html_tags",
+  "content": "# Style\r\n\r\nThe tag is used for declaring style rules within an HTML document. This style tag `<style>` is used to style all sorts of all aspects of our web page such as fonts, sizes, and layouts. \r\n",
+  "examples": [
+    {
+      "name": "Style",
+      "description": "Using `<style>`to apply a simple style sheet to an HTML document",
+      "code": "```\n<style>\r\n  h1 {color:red;}\r\n  p {color:blue;}\r\n</style>\r\n\n```",
+      "app": "",
+      "image": null,
+      "app_display_type": "codeFromCodeField",
+      "embed_app_with_code_height": 310
+    },
+    {
+      "name": "Text Align Property",
+      "description": "Aligning all paragraphs with the right side of the page.",
+      "code": "```\np {\r\n  text-align: right;\r\n}\r\n\n```",
+      "app": "",
+      "image": null,
+      "app_display_type": "codeFromCodeField",
+      "embed_app_with_code_height": 310
+    }
+  ],
+  "external_documentation": "http://www.w3schools.com/tags/tag_style.asp",
+  "short_description": "Style\nThe tag is used for declaring style rules within an HTML document. This style tag &lt;style&gt; is used to style all sorts of all aspects of our web page such as fonts, sizes, and layouts. ",
+  "syntax": "<style>",
+  "tips": "* Each HTML document can contain multiple `<style>` tags.\r\n* Each `<style>` tag must be located between the `<head></head>` tags."
+}

--- a/dashboard/config/programming_expressions/weblab2/text-align.json
+++ b/dashboard/config/programming_expressions/weblab2/text-align.json
@@ -1,0 +1,33 @@
+{
+  "key": "text-align",
+  "name": "Text Align",
+  "category": "CSS Properties",
+  "category_key": "css_properties",
+  "content": "# Text Align\nThe [`text-align`(#d3e965)](/docs/weblab/text-align/) property specifies the horizontal alignment of text inside an element. This property is used to align inline content such as text within a block-level element.",
+  "examples": [
+    {
+      "name": "Centering Text in a Paragraph",
+      "description": "This centers all the text inside the paragraph.",
+      "code": "```\np {\n  text-align: center;\n}\n```",
+      "embed_app_with_code_height": "310"
+    },
+    {
+      "name": "Justifying Text in a Block of Content",
+      "description": "This spreads the text out so both the left and right edges are aligned.",
+      "code": "```\ndiv {\n  text-align: justify;\n}\n```",
+      "embed_app_with_code_height": "310"
+    }
+  ],
+  "external_documentation": "http://www.w3schools.com/cssref/pr_text_text-align.asp",
+  "palette_params": [
+    {
+      "name": "value",
+      "type": "String",
+      "required": true,
+      "description": "Possible values include:\n\n- **`left`** – Aligns text to the left. *(Default for left-to-right languages)*\n- **`right`** – Aligns text to the right.\n- **`center`** – Centers the text.\n- **`justify`** – Stretches the lines so that each line has equal width (like in newspapers).\n"
+    }
+  ],
+  "short_description": "Text Align\nThe text-align property specifies the horizontal alignment of text in an element. It is used to align text to the left, right, center, or justify it within its containing element.",
+  "syntax": "text-align: value;",
+  "tips": "- [`text-align`(#d3e965)](/docs/weblab/text-align/) is used to align **text inside a container**, like a paragraph (`<p>`) or heading (`<h1>`).\n\n- `justify` spreads text evenly across a line, creating a clean, newspaper-style look.\n\n- The default alignment is usually `left` (in English and other left-to-right languages).\n\n- If you're writing in a right-to-left language (like Arabic or Hebrew), the default may be `right`."
+}

--- a/dashboard/config/programming_expressions/weblab2/text-align.json
+++ b/dashboard/config/programming_expressions/weblab2/text-align.json
@@ -3,7 +3,7 @@
   "name": "Text Align",
   "category": "CSS Properties",
   "category_key": "css_properties",
-  "content": "# Text Align\nThe [`text-align`(#d3e965)](/docs/weblab/text-align/) property specifies the horizontal alignment of text inside an element. This property is used to align inline content such as text within a block-level element.",
+  "content": "# Text Align\nThe [`text-align`(#d3e965)](/docs/ide/weblab2/expressions/text-align/) property specifies the horizontal alignment of text inside an element. This property is used to align inline content such as text within a block-level element.",
   "examples": [
     {
       "name": "Centering Text in a Paragraph",
@@ -29,5 +29,5 @@
   ],
   "short_description": "Text Align\nThe text-align property specifies the horizontal alignment of text in an element. It is used to align text to the left, right, center, or justify it within its containing element.",
   "syntax": "text-align: value;",
-  "tips": "- [`text-align`(#d3e965)](/docs/weblab/text-align/) is used to align **text inside a container**, like a paragraph (`<p>`) or heading (`<h1>`).\n\n- `justify` spreads text evenly across a line, creating a clean, newspaper-style look.\n\n- The default alignment is usually `left` (in English and other left-to-right languages).\n\n- If you're writing in a right-to-left language (like Arabic or Hebrew), the default may be `right`."
+  "tips": "- [`text-align`(#d3e965)](/docs/ide/weblab2/expressions/text-align/) is used to align **text inside a container**, like a paragraph (`<p>`) or heading (`<h1>`).\n\n- `justify` spreads text evenly across a line, creating a clean, newspaper-style look.\n\n- The default alignment is usually `left` (in English and other left-to-right languages).\n\n- If you're writing in a right-to-left language (like Arabic or Hebrew), the default may be `right`."
 }

--- a/dashboard/config/programming_expressions/weblab2/text-dec.json
+++ b/dashboard/config/programming_expressions/weblab2/text-dec.json
@@ -1,0 +1,27 @@
+{
+  "key": "Text-Dec",
+  "name": "Text Decoration",
+  "category": "CSS Properties",
+  "category_key": "css_properties",
+  "content": "# Text Decoration\n\nThe [`text-decoration: value;`(#d3e965)](/docs/weblab/Text-Dec/) property specifies the appearance of decorative lines on text. The most common text-decoration are:\n\n* `text-decoration-line` -  Sets the kind of text decoration to use such as, underline, overline, line-through. \n* `text-decoration-color` -  Sets the color of the text decoration.\n* `text-decoration-style` -  Sets the style of the text decoration such as `solid`, `wavy`, `dotted`, `dashed`, or `double`.\n",
+  "examples": [
+    {
+      "name": "Multiple Text Decorations",
+      "description": "Setting different text decorations for a `<h1>` element. ",
+      "code": "```\nh2 {\n  text-decoration: underline overline wavy blue;\n}\n```",
+      "app_display_type": "codeFromCodeField",
+      "embed_app_with_code_height": "310"
+    },
+    {
+      "name": "Overline text decoration",
+      "description": "Setting an overline text decoration for a `<h1>` element. ",
+      "code": "```\nh1 {\n  text-decoration: overline;\n}\n```",
+      "app_display_type": "codeFromCodeField",
+      "embed_app_with_code_height": "310"
+    }
+  ],
+  "external_documentation": "http://www.w3schools.com/cssref/pr_text_text-decoration.asp",
+  "short_description": "Text Decoration\nThe text-decoration property specifies the appearance of decorative lines on text. The most common text-decoration are:",
+  "syntax": "text-decoration: value;",
+  "tips": "* You may combine different kinds of text decorative in one statement.\n* The default value is no text decoration. "
+}

--- a/dashboard/config/programming_expressions/weblab2/text-dec.json
+++ b/dashboard/config/programming_expressions/weblab2/text-dec.json
@@ -3,7 +3,7 @@
   "name": "Text Decoration",
   "category": "CSS Properties",
   "category_key": "css_properties",
-  "content": "# Text Decoration\n\nThe [`text-decoration: value;`(#d3e965)](/docs/weblab/Text-Dec/) property specifies the appearance of decorative lines on text. The most common text-decoration are:\n\n* `text-decoration-line` -  Sets the kind of text decoration to use such as, underline, overline, line-through. \n* `text-decoration-color` -  Sets the color of the text decoration.\n* `text-decoration-style` -  Sets the style of the text decoration such as `solid`, `wavy`, `dotted`, `dashed`, or `double`.\n",
+  "content": "# Text Decoration\n\nThe [`text-decoration: value;`(#d3e965)](/docs/ide/weblab2/expressions/Text-Dec/) property specifies the appearance of decorative lines on text. The most common text-decoration are:\n\n* `text-decoration-line` -  Sets the kind of text decoration to use such as, underline, overline, line-through. \n* `text-decoration-color` -  Sets the color of the text decoration.\n* `text-decoration-style` -  Sets the style of the text decoration such as `solid`, `wavy`, `dotted`, `dashed`, or `double`.\n",
   "examples": [
     {
       "name": "Multiple Text Decorations",

--- a/dashboard/config/programming_expressions/weblab2/title.json
+++ b/dashboard/config/programming_expressions/weblab2/title.json
@@ -1,0 +1,22 @@
+{
+  "key": "title",
+  "name": "Title",
+  "category": "HTML Tags",
+  "category_key": "html_tags",
+  "content": "# Title\r\n\r\nThis tag is used to define the tile of the web page. The title of the page is shown in the browser's title bar, in bookmarks, and in the search result.\r\n",
+  "examples": [
+    {
+      "name": "Title",
+      "description": "Using `<title>` to define a title for an HTML document.",
+      "code": "```\n<head>\r\n  <title>HTML Elements Reference</title>\r\n</head>\r\n\n```",
+      "app": "",
+      "image": null,
+      "app_display_type": "codeFromCodeField",
+      "embed_app_with_code_height": 310
+    }
+  ],
+  "external_documentation": "http://www.w3schools.com/tags/tag_title.asp",
+  "short_description": "Title\nThis tag is used to define the tile of the web page. The title of the page is shown in the browser's title bar, in bookmarks, and in the search result.",
+  "syntax": "<title></title>",
+  "tips": "* The title of your web page *does not* show up inside your web page. The title is displayed in the browser's title bar or search engine results pages. **Note:** The title of your web page won't be viewable while you are editing it on Code.org. To see the title, click the Share button, then copy and open the link.\r\n* The tile must be text-only.\r\n* The title tag `<title>` is *different* than the heading `<h1>` tag."
+}

--- a/dashboard/config/programming_expressions/weblab2/ul.json
+++ b/dashboard/config/programming_expressions/weblab2/ul.json
@@ -1,0 +1,31 @@
+{
+  "key": "ul",
+  "name": "Unordered List",
+  "category": "HTML Tags",
+  "category_key": "html_tags",
+  "content": "# Unordered List\r\n\r\nThis tag is used to create  a set of bulleted items.  An unordered list element has the tag `<ul>`. This is an abbreviation for Unordered List. Each item in the list is marked by a list item element `<li>`.",
+  "examples": [
+    {
+      "name": "Unordered List",
+      "description": "Using `<ul>` to make an unordered list",
+      "code": "```\n<ul>\r\n  <li>Tea</li>\r\n  <li>Milk</li>\r\n  <li>Water</li>\r\n</ul>\r\n\n```",
+      "app": "",
+      "image": null,
+      "app_display_type": "codeFromCodeField",
+      "embed_app_with_code_height": 310
+    },
+    {
+      "name": "Boba Flavors",
+      "description": "A list of possible flavors to include in boba tea.",
+      "code": "```\n<html>\r\n\t<body>\r\n    \t<h1>Boba Flavor Choices</h1>\r\n        <ul>\r\n          <li>Lychee</li>\r\n          <li>Mango</li>\r\n          <li>Passion Fruit</li>\r\n          <li>Peach</li>\r\n          <li>Plum</li>\r\n          <li>Strawberry</li>\r\n        </ul>\r\n\t</body>\r\n</html>\n```",
+      "app": "",
+      "image": "https://curriculum.code.org/media/boba.png",
+      "app_display_type": "codeFromCodeField",
+      "embed_app_with_code_height": 310
+    }
+  ],
+  "external_documentation": "http://www.w3schools.com/tags/tag_ul.asp",
+  "short_description": "Unordered List\nThis tag is used to create  a set of bulleted items.  An unordered list element has the tag &lt;ul&gt;. This is an abbreviation for Unordered List. Each item in the list is marked by a list item element &lt;li&gt;.",
+  "syntax": "<ul></ul>",
+  "tips": "* To make the unordered list, write the unordered list tags `<ul> </ul>`. Next, add your list items inside the unordered list tags. To make each list item, use the list item tags `<li> </li>` and write the list item inside the tags.\r\n* Try to indent your `</li>` tags so it's clear they are contained in the `<ul>`  tag.\r\n* The list items can contain content other than text such as lists of videos, images, songs, or hyperlinks. \r\n"
+}

--- a/dashboard/config/programming_expressions/weblab2/width.json
+++ b/dashboard/config/programming_expressions/weblab2/width.json
@@ -1,0 +1,31 @@
+{
+  "key": "width",
+  "name": "Width",
+  "category": "CSS Properties",
+  "category_key": "css_properties",
+  "content": "# Width\r\n\r\nThe [`Width`(#d3e965)](/docs/weblab/width/) property specifies the width of the content area of an element. The width of an element does not include padding, borders, or margins. Width can be defined in percent of the containing block, pixels, cm, etc.\r\n",
+  "examples": [
+    {
+      "name": "Width as a percentage",
+      "description": "Set the width of an `<img>` element using a percent value.",
+      "code": "```\nimg {\n  width: 50%;\n}\n\n```",
+      "app": "",
+      "image": null,
+      "app_display_type": "codeFromCodeField",
+      "embed_app_with_code_height": 310
+    },
+    {
+      "name": "Width in pixels",
+      "description": "Setting the width of a `<p>` element to 300 pixels.",
+      "code": "```\np {\n  width: 300px;\n}\n\n```",
+      "app": "",
+      "image": null,
+      "app_display_type": "codeFromCodeField",
+      "embed_app_with_code_height": 310
+    }
+  ],
+  "external_documentation": "http://www.w3schools.com/cssref/pr_dim_width.asp",
+  "short_description": "Width\nThe width property specifies the width of the content area of an element. The width of an element does not include padding, borders, or margins. Width can be defined in percent of the containing block, pixels, cm, etc.",
+  "syntax": "width: value;",
+  "tips": "* The [`Width`(#d3e965)](/docs/weblab/width/) property does not include padding, borders, or margins.\r\n* The default value of the width is auto: The element will automatically adjust its width to allow its content to be displayed correctly."
+}

--- a/dashboard/config/programming_expressions/weblab2/width.json
+++ b/dashboard/config/programming_expressions/weblab2/width.json
@@ -3,7 +3,7 @@
   "name": "Width",
   "category": "CSS Properties",
   "category_key": "css_properties",
-  "content": "# Width\r\n\r\nThe [`Width`(#d3e965)](/docs/weblab/width/) property specifies the width of the content area of an element. The width of an element does not include padding, borders, or margins. Width can be defined in percent of the containing block, pixels, cm, etc.\r\n",
+  "content": "# Width\r\n\r\nThe [`Width`(#d3e965)](/docs/ide/weblab2/expressions/width/) property specifies the width of the content area of an element. The width of an element does not include padding, borders, or margins. Width can be defined in percent of the containing block, pixels, cm, etc.\r\n",
   "examples": [
     {
       "name": "Width as a percentage",
@@ -27,5 +27,5 @@
   "external_documentation": "http://www.w3schools.com/cssref/pr_dim_width.asp",
   "short_description": "Width\nThe width property specifies the width of the content area of an element. The width of an element does not include padding, borders, or margins. Width can be defined in percent of the containing block, pixels, cm, etc.",
   "syntax": "width: value;",
-  "tips": "* The [`Width`(#d3e965)](/docs/weblab/width/) property does not include padding, borders, or margins.\r\n* The default value of the width is auto: The element will automatically adjust its width to allow its content to be displayed correctly."
+  "tips": "* The [`Width`(#d3e965)](/docs/ide/weblab2/expressions/width/) property does not include padding, borders, or margins.\r\n* The default value of the width is auto: The element will automatically adjust its width to allow its content to be displayed correctly."
 }


### PR DESCRIPTION
As we prepare to launch weblab2, we need to create documentation for the lab. There was a request to copy weblab documentation for weblab2, see [here](https://codedotorg.slack.com/archives/C045UAX4WKH/p1775069186156519).

To generate this PR, locally I:
- created a new ProgrammingEnvironment `weblab2`
- copied the categories in `config/programming_environments/weblab.json` to the same field in `config/programming_environments/weblab2.json`
- ran `mkdir config/programming_expressions/weblab2/` then `cp config/programming_expressions/weblab/* config/programming_expressions/weblab2/` to copy all the programming expressions over (weblab has no programming classes)
- ran `bundle exec rake seed:code_docs` to seed the new objects
- spot checked that the new objects showed up as expected and were indeed different objects in our database (ie I edited one weblab2 doc and confirmed the edit didn't appear in the corresponding weblab doc)

Next step is to merge this PR to get this into levelbuilder so it can be edited!