### PR TITLE
Revert "[Design2-341-6] Replace DSCO Typography with MUI Typography in component-library"

### DIFF
--- a/frontend/packages/component-library/MIGRATION_STATUS.md
+++ b/frontend/packages/component-library/MIGRATION_STATUS.md
@@ -101,11 +101,7 @@ When creating a completely new MUI component for the design system (i.e. not mig
 
 ## Internal Dependency Blockers
 
-The following DSCO components use `Button` or `Typography` internally, blocking full removal of those deprecated components. These need the "inside-out replacement" (step 3 above) before we can delete the DSCO source.
-
-> **Typography**: All internal consumers have been migrated to MUI `Typography`. The DSCO Typography source can now be deleted once any remaining `/apps` consumers are confirmed migrated.
->
-> **TODO**: Investigate `frontend/packages/component-library-styles/typography.module.scss`. This file provides SCSS mixins (`heading-xxl`, `body-one`, `body-two`, etc.) and CSS module classes that are still **widely consumed** (~100+ files): ~23 SCSS files in `component-library/src/`, ~62 files in `apps/src/`, and indirectly via `component-library-styles/mixins.scss` (which uses the `body-two`/`body-three`/`body-four` mixins for field helper styles). There is also a manual copy at `shared/css/typography.scss`. Determine whether these SCSS mixins can be replaced by MUI Typography theme overrides or if they must coexist, and plan accordingly.
+The following DSCO components still use `Button` or `Typography` internally, blocking full removal of those deprecated components. These need the "inside-out replacement" (step 3 above) before we can delete the DSCO source.
 
 ### Button internal consumers (8)
 
@@ -120,19 +116,19 @@ The following DSCO components use `Button` or `Typography` internally, blocking 
 | `CheckboxDropdown` | Not Started      |
 | `Video`            | N/A              |
 
-### Typography internal consumers (11) — **All Done**
+### Typography internal consumers (11)
 
-| DSCO Component         | Migration Status   |
-| ---------------------- | ------------------ |
-| `Checkbox`             | **Done**           |
-| `RadioButton`          | **Done**           |
-| `Toggle`               | **Done**           |
-| `Accordion`            | **Done**           |
-| `ActionBlock`          | **Done**           |
-| `FullWidthActionBlock` | **Done**           |
-| `Dialog`               | **Done**           |
-| `HeroBanner`           | **Done** (was N/A) |
-| `Modal`                | **Done**           |
-| `Popover`              | **Done**           |
-| `SimpleList`           | **Done**           |
-| `Video`                | **Done** (was N/A) |
+| DSCO Component         | Migration Status |
+| ---------------------- | ---------------- |
+| `Checkbox`             | Not Started      |
+| `RadioButton`          | Not Started      |
+| `Toggle`               | Not Started      |
+| `Accordion`            | Not Started      |
+| `ActionBlock`          | Not Started      |
+| `FullWidthActionBlock` | Not Started      |
+| `Dialog`               | Not Started      |
+| `HeroBanner`           | N/A              |
+| `Modal`                | Not Started      |
+| `Popover`              | Not Started      |
+| `SimpleList`           | Not Started      |
+| `Video`                | N/A              |

--- a/frontend/packages/component-library/src/accordion/Accordion.tsx
+++ b/frontend/packages/component-library/src/accordion/Accordion.tsx
@@ -1,8 +1,8 @@
-import {Typography} from '@mui/material';
 import classNames from 'classnames';
 import {HTMLAttributes, ReactNode} from 'react';
 
 import FontAwesomeV6Icon from '@/fontAwesomeV6Icon';
+import {BodyTwoText, StrongText} from '@/typography';
 
 import moduleStyles from './accordion.module.scss';
 
@@ -45,18 +45,16 @@ const Accordion: React.FC<AccordionProps> = ({
       <details key={id}>
         <summary>
           {typeof label === 'string' ? (
-            <Typography variant="body2" gutterBottom>
-              <Typography variant="strong">{label}</Typography>
-            </Typography>
+            <BodyTwoText>
+              <StrongText>{label}</StrongText>
+            </BodyTwoText>
           ) : (
             label
           )}
           <FontAwesomeV6Icon iconName="chevron-down" />
         </summary>
         {typeof content === 'string' ? (
-          <Typography variant="body2" gutterBottom>
-            {content}
-          </Typography>
+          <BodyTwoText>{content}</BodyTwoText>
         ) : (
           content
         )}

--- a/frontend/packages/component-library/src/actionBlock/ActionBlock.tsx
+++ b/frontend/packages/component-library/src/actionBlock/ActionBlock.tsx
@@ -1,8 +1,14 @@
-import {Typography} from '@mui/material';
 import classNames from 'classnames';
 
 import {LinkButton, LinkButtonProps} from '@/button';
 import Image, {ImageProps} from '@/image';
+import {
+  Heading3,
+  BodyThreeText,
+  OverlineTwoText,
+  StrongText,
+  BodyFourText,
+} from '@/typography';
 import Video, {VideoProps} from '@/video';
 
 import {ActionBlockProps, ActionBlockWrapperProps} from './types';
@@ -35,14 +41,10 @@ export const getVideo = (VideoComponent?: typeof Video, video?: VideoProps) => {
 export const getDetail = (details?: {label: string; description: string}) => {
   if (!details) return null;
   return (
-    <Typography
-      className={classNames(moduleStyles.detail)}
-      variant="body3"
-      gutterBottom
-    >
-      <Typography variant="strong">{`${details.label}: `}</Typography>
+    <BodyThreeText className={classNames(moduleStyles.detail)}>
+      <StrongText>{`${details.label}: `}</StrongText>
       {details.description}
-    </Typography>
+    </BodyThreeText>
   );
 };
 
@@ -81,13 +83,7 @@ export const getButtons = (
 
 export const getTag = (tag: string) => {
   return (
-    <Typography
-      className={classNames(moduleStyles.tag)}
-      variant="body4"
-      gutterBottom
-    >
-      {tag}
-    </Typography>
+    <BodyFourText className={classNames(moduleStyles.tag)}>{tag}</BodyFourText>
   );
 };
 
@@ -149,30 +145,20 @@ export const ActionBlock: React.FC<ActionBlockProps> = ({
       <div>
         {tag && getTag(tag)}
         {overline && (
-          <Typography
-            className={classNames(moduleStyles.overline)}
-            variant="overline2"
-            gutterBottom
-          >
+          <OverlineTwoText className={classNames(moduleStyles.overline)}>
             {overline}
-          </Typography>
+          </OverlineTwoText>
         )}
-        <Typography
+        <Heading3
           className={classNames(moduleStyles.title)}
-          component="h3"
-          variant="h4"
-          gutterBottom
+          visualAppearance={'heading-md'}
         >
           {title}
-        </Typography>
+        </Heading3>
         {video ? getVideo(VideoComponent, video) : image && getImage(image)}
-        <Typography
-          className={classNames(moduleStyles.description)}
-          variant="body3"
-          gutterBottom
-        >
+        <BodyThreeText className={classNames(moduleStyles.description)}>
           {description}
-        </Typography>
+        </BodyThreeText>
         {details && getDetail(details)}
       </div>
       {primaryButton && getButtons(primaryButton, secondaryButton)}

--- a/frontend/packages/component-library/src/actionBlock/fullWidthActionBlock/FullWidthActionBlock.tsx
+++ b/frontend/packages/component-library/src/actionBlock/fullWidthActionBlock/FullWidthActionBlock.tsx
@@ -1,5 +1,6 @@
-import {Typography} from '@mui/material';
 import classNames from 'classnames';
+
+import {Heading3, BodyThreeText, OverlineTwoText} from '@/typography';
 
 import {
   ActionBlockWrapper,
@@ -52,29 +53,19 @@ export const FullWidthActionBlock: React.FC<ActionBlockProps> = ({
       {video ? getVideo(VideoComponent, video) : image && getImage(image)}
       <div>
         {overline && (
-          <Typography
-            className={classNames(moduleStyles.overline)}
-            variant="overline2"
-            gutterBottom
-          >
+          <OverlineTwoText className={classNames(moduleStyles.overline)}>
             {overline}
-          </Typography>
+          </OverlineTwoText>
         )}
-        <Typography
+        <Heading3
           className={classNames(moduleStyles.title)}
-          component="h3"
-          variant="h5"
-          gutterBottom
+          visualAppearance={'heading-sm'}
         >
           {title}
-        </Typography>
-        <Typography
-          className={classNames(moduleStyles.description)}
-          variant="body3"
-          gutterBottom
-        >
+        </Heading3>
+        <BodyThreeText className={classNames(moduleStyles.description)}>
           {description}
-        </Typography>
+        </BodyThreeText>
         {details && getDetail(details)}
         {primaryButton && getButtons(primaryButton, secondaryButton)}
       </div>

--- a/frontend/packages/component-library/src/breadcrumbs/stories/Breadcrumbs.story.tsx
+++ b/frontend/packages/component-library/src/breadcrumbs/stories/Breadcrumbs.story.tsx
@@ -28,6 +28,7 @@ export default {
         ],
       },
     },
+    useMui: true,
     componentSubtitle: 'Renders navigation breadcrumbs',
   },
 } as Meta;

--- a/frontend/packages/component-library/src/button/stories/Button.story.tsx
+++ b/frontend/packages/component-library/src/button/stories/Button.story.tsx
@@ -11,6 +11,9 @@ export default {
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
   // @ts-ignore-next-line
   component: Button.type,
+  parameters: {
+    useMui: true,
+  },
 } as Meta;
 
 //

--- a/frontend/packages/component-library/src/button/stories/MuiButton.story.tsx
+++ b/frontend/packages/component-library/src/button/stories/MuiButton.story.tsx
@@ -17,6 +17,7 @@ export default {
   title: 'DesignSystem/Button/MuiButton',
   component: MuiButton,
   parameters: {
+    useMui: true,
     docs: {
       description: {
         component:

--- a/frontend/packages/component-library/src/carousel/stories/Carousel.story.tsx
+++ b/frontend/packages/component-library/src/carousel/stories/Carousel.story.tsx
@@ -1,4 +1,3 @@
-import {Typography} from '@mui/material';
 import image1 from '@public/images/action-block-01.png';
 import image2 from '@public/images/action-block-02.png';
 import image3 from '@public/images/action-block-03.png';
@@ -9,6 +8,7 @@ import type {Meta, StoryFn} from '@storybook/react-vite';
 import {within, expect, userEvent} from 'storybook/test';
 
 import ActionBlock from '@/actionBlock';
+import {Heading2} from '@/typography';
 import Video from '@/video';
 
 import Carousel, {CarouselProps} from '../index';
@@ -47,9 +47,7 @@ const createBasicSlide = (index: number) => (
     key={index}
   >
     <div style={{margin: '0 auto'}}>
-      <Typography variant="h2" gutterBottom>
-        This is slide {index.toString()}
-      </Typography>
+      <Heading2>This is slide {index.toString()}</Heading2>
     </div>
   </div>
 );

--- a/frontend/packages/component-library/src/checkbox/Checkbox.tsx
+++ b/frontend/packages/component-library/src/checkbox/Checkbox.tsx
@@ -1,4 +1,3 @@
-import {Typography} from '@mui/material';
 import classnames from 'classnames';
 import {
   useRef,
@@ -10,6 +9,7 @@ import {
 
 import {componentSizeToBodyTextSizeMap} from '@/common/constants';
 import {ComponentSizeXSToL} from '@/common/types';
+import Typography from '@/typography';
 
 import moduleStyles from './checkbox.module.scss';
 
@@ -107,12 +107,13 @@ const Checkbox: React.FunctionComponent<CheckboxProps> = ({
       <i className="fa-solid" />
       {label && (
         <Typography
+          semanticTag="span"
           className={classnames(
             moduleStyles.checkboxLabel,
             moduleStyles[`checkboxLabel-${textThickness}`],
           )}
-          variant={bodyTextSize}
-          component="span"
+          visualAppearance={bodyTextSize}
+          noMargin
         >
           {label}
         </Typography>

--- a/frontend/packages/component-library/src/common/constants/index.ts
+++ b/frontend/packages/component-library/src/common/constants/index.ts
@@ -4,21 +4,18 @@
 
 import {ComponentSizeXSToL, DropdownColor} from '@/common/types';
 import {FontAwesomeV6IconProps} from '@/fontAwesomeV6Icon';
-
-/** MUI Typography body variants used for component label/copy sizing */
-export type BodyTextSizeVariant = 'body1' | 'body2' | 'body3' | 'body4';
+import {VisualAppearance} from '@/typography';
 
 /**
- * Map of component size to body text size (MUI Typography variant).
- * Use with <Typography variant={componentSizeToBodyTextSizeMap[size]} />.
+ *  This is the map of component size to body text size (visualAppearance)
  */
 export const componentSizeToBodyTextSizeMap: {
-  [key in ComponentSizeXSToL]: BodyTextSizeVariant;
+  [key in ComponentSizeXSToL]: VisualAppearance;
 } = {
-  l: 'body1',
-  m: 'body2',
-  s: 'body3',
-  xs: 'body4',
+  l: 'body-one',
+  m: 'body-two',
+  s: 'body-three',
+  xs: 'body-four',
 };
 
 export const dropdownColors: {[key in DropdownColor]: DropdownColor} = {

--- a/frontend/packages/component-library/src/dialog/Dialog.tsx
+++ b/frontend/packages/component-library/src/dialog/Dialog.tsx
@@ -1,9 +1,9 @@
-import {Typography} from '@mui/material';
 import classnames from 'classnames';
 import {HTMLAttributes, ReactNode} from 'react';
 
 import {Button, ButtonProps} from '@/button';
 import FontAwesomeV6Icon, {FontAwesomeV6IconProps} from '@/fontAwesomeV6Icon';
+import {BodyTwoText, Heading2} from '@/typography';
 
 import CustomDialog from './CustomDialog';
 
@@ -86,18 +86,14 @@ const Dialog: React.FunctionComponent<DialogProps> = ({
   >
     <div className={moduleStyles.dialogTextSection}>
       {imageUrl && <img src={imageUrl} alt="Dialog" />}
-      <Typography variant="h2" gutterBottom>
-        {title}
-      </Typography>
+      <Heading2>{title}</Heading2>
       {description && (
-        <Typography
+        <BodyTwoText
           id="dsco-dialog-description"
           className={moduleStyles.dialogContent}
-          variant="body2"
-          gutterBottom
         >
           {description}
-        </Typography>
+        </BodyTwoText>
       )}
       {customContent}
     </div>

--- a/frontend/packages/component-library/src/header/stories/Header.story.tsx
+++ b/frontend/packages/component-library/src/header/stories/Header.story.tsx
@@ -20,6 +20,7 @@ export default {
         ],
       },
     },
+    useMui: true,
   },
 } as Meta;
 

--- a/frontend/packages/component-library/src/heroBanner/HeroBanner.tsx
+++ b/frontend/packages/component-library/src/heroBanner/HeroBanner.tsx
@@ -1,4 +1,3 @@
-import {Typography} from '@mui/material';
 import classNames from 'classnames';
 import {ReactNode, HTMLAttributes} from 'react';
 
@@ -8,6 +7,7 @@ import {Theme} from '@/common/contexts';
 import {FontAwesomeV6IconProps} from '@/fontAwesomeV6Icon';
 import Image, {ImageProps} from '@/image';
 import {LinkProps} from '@/link';
+import {Heading1, BodyOneText, BodyTwoText} from '@/typography';
 import Video, {VideoProps} from '@/video';
 
 import moduleStyles from './heroBanner.module.scss';
@@ -122,21 +122,11 @@ const HeroBanner: React.FC<HeroBannerProps> = ({
       <div className={classNames(moduleStyles.heroBannerContainer)}>
         <div className={moduleStyles.heroBannerTextContainer}>
           <div>
-            <Typography variant="h1" gutterBottom>
-              {heading}
-            </Typography>
+            <Heading1>{heading}</Heading1>
 
-            {subHeading && (
-              <Typography variant="body1" gutterBottom>
-                {subHeading}
-              </Typography>
-            )}
+            {subHeading && <BodyOneText>{subHeading}</BodyOneText>}
 
-            {description && (
-              <Typography variant="body2" gutterBottom>
-                {description}
-              </Typography>
-            )}
+            {description && <BodyTwoText>{description}</BodyTwoText>}
 
             {partner && (
               <span className={moduleStyles.heroBannerPartnerContainer}>

--- a/frontend/packages/component-library/src/list/simpleList/SimpleList.tsx
+++ b/frontend/packages/component-library/src/list/simpleList/SimpleList.tsx
@@ -1,10 +1,10 @@
-import {Typography} from '@mui/material';
 import classNames from 'classnames';
 import {Key, ReactNode, HTMLAttributes} from 'react';
 
 import {componentSizeToBodyTextSizeMap} from '@/common/constants';
 import {ComponentSizeXSToL} from '@/common/types';
 import FontAwesomeV6Icon, {FontAwesomeV6IconProps} from '@/fontAwesomeV6Icon';
+import Typography from '@/typography';
 
 import moduleStyles from './simpleList.module.scss';
 
@@ -79,10 +79,9 @@ const SimpleList: React.FC<SimpleListProps> = ({
         />
 
         <Typography
+          semanticTag="span"
           className={moduleStyles.simpleListItemLabel}
-          component="span"
-          gutterBottom
-          variant={componentSizeToBodyTextSizeMap[size]}
+          visualAppearance={componentSizeToBodyTextSizeMap[size]}
         >
           {label}
         </Typography>

--- a/frontend/packages/component-library/src/modal/Modal.tsx
+++ b/frontend/packages/component-library/src/modal/Modal.tsx
@@ -1,9 +1,9 @@
-import {Typography} from '@mui/material';
 import classnames from 'classnames';
 import {HTMLAttributes, ReactNode} from 'react';
 
 import {GenericButton, GenericButtonProps} from '@/button';
 import CustomDialog from '@/dialog/CustomDialog';
+import {BodyTwoText, Heading3} from '@/typography';
 
 import moduleStyles from './modal.module.scss';
 
@@ -94,9 +94,7 @@ const Modal: React.FunctionComponent<ModalProps> = ({
       {...HTMLAttributes}
     >
       <div className={moduleStyles.modalTitleSection}>
-        <Typography variant="h3" gutterBottom>
-          {title}
-        </Typography>
+        <Heading3>{title}</Heading3>
       </div>
       <hr />
       <div
@@ -107,14 +105,12 @@ const Modal: React.FunctionComponent<ModalProps> = ({
       >
         {imageUrl && <img src={imageUrl} alt={imageAlt || ''} />}
         {description && (
-          <Typography
+          <BodyTwoText
             id="dsco-dialog-description"
             className={moduleStyles.modalDescription}
-            variant="body2"
-            gutterBottom
           >
             {description}
-          </Typography>
+          </BodyTwoText>
         )}
         {customContent}
       </div>

--- a/frontend/packages/component-library/src/notification-banner/stories/NotificationBanner.story.tsx
+++ b/frontend/packages/component-library/src/notification-banner/stories/NotificationBanner.story.tsx
@@ -11,6 +11,7 @@ export default {
   title: 'DesignSystem/NotificationBanner',
   component: NotificationBanner,
   parameters: {
+    useMui: true,
     docs: {
       description: {
         component:

--- a/frontend/packages/component-library/src/popover/Popover.tsx
+++ b/frontend/packages/component-library/src/popover/Popover.tsx
@@ -1,10 +1,10 @@
-import {Typography} from '@mui/material';
 import classnames from 'classnames';
 import {HTMLAttributes, ReactNode, forwardRef} from 'react';
 
 import CloseButton from '@/closeButton';
 import {ComponentPlacementDirection, ComponentSizeXSToL} from '@/common/types';
 import FontAwesomeV6Icon, {FontAwesomeV6IconProps} from '@/fontAwesomeV6Icon';
+import {BodyTwoText, Heading5} from '@/typography';
 
 import moduleStyles from './popover.module.scss';
 
@@ -89,6 +89,7 @@ const Popover = forwardRef<HTMLDivElement, PopoverProps>(
             <img src={image.src} alt={image.alt} />
           </div>
         )}
+
         <div className={moduleStyles.informationalSection}>
           {icon && (
             <div className={moduleStyles.iconSection}>
@@ -97,12 +98,8 @@ const Popover = forwardRef<HTMLDivElement, PopoverProps>(
           )}
           <div className={moduleStyles.contentSection}>
             <div className={moduleStyles.textSection}>
-              <Typography variant="h5" gutterBottom>
-                {title}
-              </Typography>
-              <Typography variant="body2" gutterBottom>
-                {content}
-              </Typography>
+              <Heading5>{title}</Heading5>
+              <BodyTwoText>{content}</BodyTwoText>
               {children}
             </div>
             {buttons && (

--- a/frontend/packages/component-library/src/radioButton/RadioButton.tsx
+++ b/frontend/packages/component-library/src/radioButton/RadioButton.tsx
@@ -1,9 +1,9 @@
-import {Typography} from '@mui/material';
 import classnames from 'classnames';
 import {memo, ChangeEvent, InputHTMLAttributes} from 'react';
 
 import {componentSizeToBodyTextSizeMap} from '@/common/constants';
 import {ComponentSizeXSToL} from '@/common/types';
+import Typography from '@/typography';
 
 import moduleStyles from './radioButton.module.scss';
 
@@ -76,12 +76,13 @@ const RadioButton: React.FunctionComponent<RadioButtonProps> = ({
       <i className={moduleStyles.radioIcon} />
       {label && (
         <Typography
+          semanticTag="span"
           className={classnames(
             moduleStyles.radioButtonLabel,
             moduleStyles[`radioButtonLabel-${textThickness}`],
           )}
-          variant={bodyTextSize}
-          component="span"
+          visualAppearance={bodyTextSize}
+          noMargin
         >
           {label}
         </Typography>

--- a/frontend/packages/component-library/src/toggle/Toggle.tsx
+++ b/frontend/packages/component-library/src/toggle/Toggle.tsx
@@ -1,9 +1,9 @@
-import {Typography} from '@mui/material';
 import classnames from 'classnames';
 import {ChangeEvent, HTMLAttributes, memo} from 'react';
 
 import {componentSizeToBodyTextSizeMap} from '@/common/constants';
 import {ComponentSizeXSToL} from '@/common/types';
+import Typography from '@/typography';
 
 import moduleStyles from './toggle.module.scss';
 
@@ -68,8 +68,9 @@ const Toggle: React.FunctionComponent<ToggleProps> = ({
           <span />
         </span>
       </div>
+
       {label && (
-        <Typography component="span" variant={bodyTextSize} gutterBottom>
+        <Typography semanticTag="span" visualAppearance={bodyTextSize}>
           {label}
         </Typography>
       )}

--- a/frontend/packages/component-library/src/typography/stories/Typography.story.tsx
+++ b/frontend/packages/component-library/src/typography/stories/Typography.story.tsx
@@ -1,11 +1,28 @@
-import {Typography} from '@mui/material';
-import type {TypographyProps} from '@mui/material/Typography';
 import type {Meta, StoryObj} from '@storybook/react-vite';
+
+import Typography, {
+  StrongText,
+  EmText,
+  BodyOneText,
+  BodyTwoText,
+  BodyThreeText,
+  BodyFourText,
+  OverlineOneText,
+  OverlineTwoText,
+  OverlineThreeText,
+  Heading1,
+  Heading2,
+  Heading3,
+  Heading4,
+  Heading5,
+  Heading6,
+  Figcaption,
+} from '../index';
 
 export default {
   title: 'DesignSystem/Typography',
   component: Typography,
-} as Meta<typeof Typography>;
+} as Meta;
 
 type Story = StoryObj<typeof Typography>;
 
@@ -18,62 +35,64 @@ type Story = StoryObj<typeof Typography>;
  */
 export const Playground: Story = {
   args: {
-    component: 'p',
-    variant: 'body2',
+    semanticTag: 'p',
+    visualAppearance: 'body-two',
     children: 'This is a dynamic Typography Component.',
-  } as TypographyProps,
+  },
 };
 
 export const AllTypographyElements: Story = {
   render: () => (
     <>
-      <Typography variant="h1" gutterBottom>
+      <Typography semanticTag="h1" visualAppearance="heading-xxl">
         This is a Typography Component. (H1)
       </Typography>
-      <Typography variant="h2" gutterBottom>
+      <Typography semanticTag="h2" visualAppearance="heading-xl">
         This is a Typography Component. (H2)
       </Typography>
-      <Typography variant="h3" gutterBottom>
+      <Typography semanticTag="h3" visualAppearance="heading-lg">
         This is a Typography Component. (H3)
       </Typography>
-      <Typography variant="h4" gutterBottom>
+      <Typography semanticTag="h4" visualAppearance="heading-md">
         This is a Typography Component. (H4)
       </Typography>
-      <Typography variant="h5" gutterBottom>
+      <Typography semanticTag="h5" visualAppearance="heading-sm">
         This is a Typography Component. (H5)
       </Typography>
-      <Typography variant="h6" gutterBottom>
+      <Typography semanticTag="h6" visualAppearance="heading-xs">
         This is a Typography Component. (H6)
       </Typography>
-      <Typography variant="body1" gutterBottom>
+      <Typography semanticTag="p" visualAppearance="body-one">
         This is a Typography Component. (body-one)
       </Typography>
-      <Typography variant="body2" gutterBottom>
+      <Typography semanticTag="p" visualAppearance="body-two">
         This is a Typography Component. (body-two)
       </Typography>
-      <Typography variant="body3" gutterBottom>
+      <Typography semanticTag="p" visualAppearance="body-three">
         This is a Typography Component. (body-three)
       </Typography>
-      <Typography variant="body4" gutterBottom>
+      <Typography semanticTag="p" visualAppearance="body-four">
         This is a Typography Component. (body-four)
       </Typography>
-      <Typography variant="overline1" gutterBottom>
+      <Typography semanticTag="p" visualAppearance="overline-one">
         This is a Typography Component. (overline-one)
       </Typography>
-      <Typography variant="overline2" gutterBottom>
+      <Typography semanticTag="p" visualAppearance="overline-two">
         This is a Typography Component. (overline-two)
       </Typography>
-      <Typography variant="overline3" gutterBottom>
+      <Typography semanticTag="p" visualAppearance="overline-three">
         This is a Typography Component. (overline-three)
       </Typography>
-      <Typography variant="em">This is a Typography Component. (em)</Typography>
-      <Typography variant="strong">
+      <Typography semanticTag="em" visualAppearance="em">
+        This is a Typography Component. (em)
+      </Typography>
+      <Typography semanticTag="strong" visualAppearance="strong">
         This is a Typography Component. (strong)
       </Typography>
-      <Typography variant="figcaption" gutterBottom>
+      <Typography semanticTag="figcaption" visualAppearance="figcaption">
         This is a Typography Component. (figcaption)
       </Typography>
-      <Typography component="div" variant="body2" gutterBottom>
+      <Typography semanticTag="div" visualAppearance="body-two">
         <p>
           This is a Typography Component that wraps text elements. (div)
           <br />
@@ -98,24 +117,12 @@ export const AllTypographyElements: Story = {
 export const Headings: Story = {
   render: () => (
     <>
-      <Typography variant="h1" gutterBottom>
-        This is a Typography Component. (H1)
-      </Typography>
-      <Typography variant="h2" gutterBottom>
-        This is a Typography Component. (H2)
-      </Typography>
-      <Typography variant="h3" gutterBottom>
-        This is a Typography Component. (H3)
-      </Typography>
-      <Typography variant="h4" gutterBottom>
-        This is a Typography Component. (H4)
-      </Typography>
-      <Typography variant="h5" gutterBottom>
-        This is a Typography Component. (H5)
-      </Typography>
-      <Typography variant="h6" gutterBottom>
-        This is a Typography Component. (H6)
-      </Typography>
+      <Heading1>This is a Typography Component. (H1)</Heading1>
+      <Heading2>This is a Typography Component. (H2)</Heading2>
+      <Heading3>This is a Typography Component. (H3)</Heading3>
+      <Heading4>This is a Typography Component. (H4)</Heading4>
+      <Heading5>This is a Typography Component. (H5)</Heading5>
+      <Heading6>This is a Typography Component. (H6)</Heading6>
     </>
   ),
 };
@@ -123,18 +130,12 @@ export const Headings: Story = {
 export const BodyTexts: Story = {
   render: () => (
     <>
-      <Typography variant="body1" gutterBottom>
-        This is a Typography Component. (body-one)
-      </Typography>
-      <Typography variant="body2" gutterBottom>
-        This is a Typography Component. (body-two)
-      </Typography>
-      <Typography variant="body3" gutterBottom>
+      <BodyOneText>This is a Typography Component. (body-one)</BodyOneText>
+      <BodyTwoText>This is a Typography Component. (body-two)</BodyTwoText>
+      <BodyThreeText>
         This is a Typography Component. (body-three)
-      </Typography>
-      <Typography variant="body4" gutterBottom>
-        This is a Typography Component. (body-four)
-      </Typography>
+      </BodyThreeText>
+      <BodyFourText>This is a Typography Component. (body-four)</BodyFourText>
     </>
   ),
 };
@@ -142,15 +143,15 @@ export const BodyTexts: Story = {
 export const OverlineTexts: Story = {
   render: () => (
     <>
-      <Typography variant="overline1" gutterBottom>
+      <OverlineOneText>
         This is a Typography Component. (overline-one)
-      </Typography>
-      <Typography variant="overline2" gutterBottom>
+      </OverlineOneText>
+      <OverlineTwoText>
         This is a Typography Component. (overline-two)
-      </Typography>
-      <Typography variant="overline3" gutterBottom>
+      </OverlineTwoText>
+      <OverlineThreeText>
         This is a Typography Component. (overline-three)
-      </Typography>
+      </OverlineThreeText>
     </>
   ),
 };
@@ -158,13 +159,9 @@ export const OverlineTexts: Story = {
 export const OtherTexts: Story = {
   render: () => (
     <>
-      <Typography variant="em">This is a Typography Component. (em)</Typography>
-      <Typography variant="strong">
-        This is a Typography Component. (strong)
-      </Typography>
-      <Typography variant="figcaption" gutterBottom>
-        This is a Typography Component. (figcaption)
-      </Typography>
+      <EmText>This is a Typography Component. (em)</EmText>
+      <StrongText>This is a Typography Component. (strong)</StrongText>
+      <Figcaption>This is a Typography Component. (figcaption)</Figcaption>
     </>
   ),
 };
@@ -172,17 +169,17 @@ export const OtherTexts: Story = {
 export const TextWrapper: Story = {
   render: () => (
     <>
-      <Typography component="div" variant="h3" gutterBottom>
+      <Typography semanticTag="div" visualAppearance="heading-lg">
         <h1>h1 child styled as an h3</h1>
       </Typography>
-      <Typography component="div" variant="body1" gutterBottom>
+      <Typography semanticTag="div" visualAppearance="body-one">
         <p>paragraph element child, styled as body-one</p>
         <ul>
           <li>child list items</li>
           <li>are also styled as body-one</li>
         </ul>
       </Typography>
-      <Typography component="div" variant="body3" gutterBottom>
+      <Typography semanticTag="div" visualAppearance="body-three">
         <p>
           paragraph element child here containing <strong>bold</strong> and{' '}
           <em>emphasized</em> inline elements, styled as body-three
@@ -195,14 +192,14 @@ export const TextWrapper: Story = {
 export const CustomUsageExamples: Story = {
   render: () => (
     <>
-      <Typography component="h1" variant="h3" gutterBottom>
+      <Heading1 visualAppearance="heading-lg">
         (Heading1 as Heading3) This is a Typography Component. (H1 as H3)
-      </Typography>
-      <Typography component="h2" variant="body1" gutterBottom>
+      </Heading1>
+      <Typography semanticTag="h2" visualAppearance="body-one">
         (Heading2 as body-one) This is a Typography Component. (H2 as
         p.body-one)
       </Typography>
-      <Typography component="h3" variant="h5" gutterBottom>
+      <Typography semanticTag="h3" visualAppearance="heading-sm">
         (Heading3 as Heading5) This is a Typography Component. (H3 as H5)
       </Typography>
     </>
@@ -212,24 +209,22 @@ export const CustomUsageExamples: Story = {
 export const RichTextExamples: Story = {
   render: () => (
     <>
-      <Typography variant="body2" gutterBottom>
-        <Typography variant="em">This is a body-two em text</Typography>
-      </Typography>
-      <Typography variant="body2" gutterBottom>
-        <Typography variant="strong">This is a body-two strong text</Typography>
-      </Typography>
-      <Typography variant="body2" gutterBottom>
-        <Typography variant="strong">
-          <Typography variant="em">
-            This is a body-two strong em text
-          </Typography>
-        </Typography>
-      </Typography>
-      <Typography variant="em">This is an em text</Typography>
-      <Typography variant="strong">This is a strong text</Typography>
-      <Typography variant="em">
-        <Typography variant="strong">This is a strong em text</Typography>
-      </Typography>
+      <BodyTwoText>
+        <EmText>This is a body-two em text</EmText>
+      </BodyTwoText>
+      <BodyTwoText>
+        <StrongText>This is a body-two strong text</StrongText>
+      </BodyTwoText>
+      <BodyTwoText>
+        <StrongText>
+          <EmText>This is a body-two strong em text</EmText>
+        </StrongText>
+      </BodyTwoText>
+      <EmText>This is an em text</EmText>
+      <StrongText>This is a strong text</StrongText>
+      <EmText>
+        <StrongText>This is a strong em text</StrongText>
+      </EmText>
     </>
   ),
 };
@@ -238,13 +233,13 @@ export const ElementsWithNoMargin: Story = {
   render: () => (
     <>
       <hr />
-      <Typography variant="h6">Heading without margins</Typography>
+      <Heading6 noMargin>Heading without margins</Heading6>
       <hr />
-      <Typography variant="body2">Paragraph without margins</Typography>
+      <BodyTwoText noMargin>Paragraph without margins</BodyTwoText>
       <hr />
-      <Typography variant="strong">Strong text without margins</Typography>
+      <StrongText noMargin>Strong text without margins</StrongText>
       <hr />
-      <Typography variant="em">Italic text without margins</Typography>
+      <EmText noMargin>Italic text without margins</EmText>
       <hr />
     </>
   ),

--- a/frontend/packages/component-library/src/video/Video.tsx
+++ b/frontend/packages/component-library/src/video/Video.tsx
@@ -1,4 +1,3 @@
-import {Typography} from '@mui/material';
 import classNames from 'classnames';
 import {useState} from 'react';
 import ReactPlayer from 'react-player';
@@ -7,6 +6,7 @@ import type {VideoObject} from 'schema-dts';
 
 import {Button, LinkButton} from '@/button';
 import FontAwesomeV6Icon from '@/fontAwesomeV6Icon';
+import {BodyTwoText, BodyThreeText, Figcaption, StrongText} from '@/typography';
 import Facade from '@/video/Facade';
 import NativeVideo from '@/video/NativeVideo';
 import {RenderState, VideoProps} from '@/video/types';
@@ -126,14 +126,12 @@ const Video: React.FC<VideoProps> = ({
               iconName="exclamation-circle"
               iconStyle="solid"
             />
-            <Typography variant="body2" gutterBottom>
-              <Typography variant="strong">
-                {errorHeading || 'Video unavailable'}
-              </Typography>
-            </Typography>
-            <Typography variant="body3" gutterBottom>
+            <BodyTwoText>
+              <StrongText>{errorHeading || 'Video unavailable'}</StrongText>
+            </BodyTwoText>
+            <BodyThreeText>
               {errorBody || 'This video is blocked on your network.'}
-            </Typography>
+            </BodyThreeText>
           </div>
         );
       case 'cookie-blocked':
@@ -143,15 +141,15 @@ const Video: React.FC<VideoProps> = ({
               iconName="exclamation-circle"
               iconStyle="solid"
             />
-            <Typography variant="body2" gutterBottom>
-              <Typography variant="strong">
+            <BodyTwoText>
+              <StrongText>
                 {errorHeading || 'Cookie consent required'}
-              </Typography>
-            </Typography>
-            <Typography variant="body3" gutterBottom>
+              </StrongText>
+            </BodyTwoText>
+            <BodyThreeText>
               {errorBody ||
                 'Please enable "Functional Cookies" and refresh the page to play this video.'}
-            </Typography>
+            </BodyThreeText>
             <Button
               className={moduleStyles.cookieConsentButton}
               onClick={() => {
@@ -170,11 +168,7 @@ const Video: React.FC<VideoProps> = ({
     >
       <div className={moduleStyles.videoWrapper}>{getVideoPlayer()}</div>
       <div className={moduleStyles.footer}>
-        {showCaption && (
-          <Typography variant="figcaption" gutterBottom>
-            {videoTitle}
-          </Typography>
-        )}
+        {showCaption && <Figcaption>{videoTitle}</Figcaption>}
         {videoFallback && (
           <LinkButton
             className={moduleStyles.download}
@@ -192,6 +186,7 @@ const Video: React.FC<VideoProps> = ({
           />
         )}
       </div>
+
       {/* JSON-LD for structured data. Needed for Google SEO.
       (see https://developers.google.com/search/docs/appearance/structured-data/video#json-ld) */}
       {videoTitle && posterThumbnail && uploadDate && (


### PR DESCRIPTION
Reverts code-dot-org/code-dot-org#70963

I believe this PR was causing this eyes diff:
<img width="1696" height="539" alt="image" src="https://github.com/user-attachments/assets/c8dd933e-b125-4dc6-be96-4332ba4bb39f" />

I was able to also re-create this issue directly on [test](https://test-studio.code.org/catalog)

<img width="953" height="692" alt="image" src="https://github.com/user-attachments/assets/4978759c-1aa7-4ee3-8bee-631834a6978c" />
