### PR TITLE
allow forgery protection in the test environment

### DIFF
--- a/dashboard/config/environments/test.rb
+++ b/dashboard/config/environments/test.rb
@@ -43,6 +43,9 @@ Dashboard::Application.configure do
   # Raise exceptions instead of rendering exception templates.
   config.action_dispatch.show_exceptions = true
 
+  # Disable request forgery protection in unit tests only.
+  config.action_controller.allow_forgery_protection = !ENV['UNIT_TEST']
+
   # Tell Action Mailer not to deliver emails to the real world.
   # The :test delivery method accumulates sent emails in the
   # ActionMailer::Base.deliveries array.

--- a/dashboard/config/environments/test.rb
+++ b/dashboard/config/environments/test.rb
@@ -43,9 +43,6 @@ Dashboard::Application.configure do
   # Raise exceptions instead of rendering exception templates.
   config.action_dispatch.show_exceptions = true
 
-  # Disable request forgery protection in test environment.
-  config.action_controller.allow_forgery_protection = false
-
   # Tell Action Mailer not to deliver emails to the real world.
   # The :test delivery method accumulates sent emails in the
   # ActionMailer::Base.deliveries array.

--- a/dashboard/test/test_helper.rb
+++ b/dashboard/test/test_helper.rb
@@ -60,6 +60,8 @@ require 'rails/test_help'
 # Raise exceptions instead of rendering exception templates.
 Dashboard::Application.config.action_dispatch.show_exceptions = false
 
+Dashboard::Application.config.action_controller.allow_forgery_protection = false
+
 require 'dynamic_config/gatekeeper'
 require 'dynamic_config/dcdo'
 require 'testing/setup_all_and_teardown_all'
@@ -94,8 +96,6 @@ class ActiveSupport::TestCase
     Dashboard::Application.config.action_controller.perform_caching = false
     # as in, I still need to clear the cache even though we are not 'performing' caching
     Rails.cache.clear
-
-    Dashboard::Application.config.action_controller.allow_forgery_protection = false
 
     # clear log of 'delivered' mails
     ActionMailer::Base.deliveries.clear

--- a/dashboard/test/test_helper.rb
+++ b/dashboard/test/test_helper.rb
@@ -95,6 +95,8 @@ class ActiveSupport::TestCase
     # as in, I still need to clear the cache even though we are not 'performing' caching
     Rails.cache.clear
 
+    Dashboard::Application.config.action_controller.allow_forgery_protection = false
+
     # clear log of 'delivered' mails
     ActionMailer::Base.deliveries.clear
 

--- a/dashboard/test/test_helper.rb
+++ b/dashboard/test/test_helper.rb
@@ -60,8 +60,6 @@ require 'rails/test_help'
 # Raise exceptions instead of rendering exception templates.
 Dashboard::Application.config.action_dispatch.show_exceptions = false
 
-Dashboard::Application.config.action_controller.allow_forgery_protection = false
-
 require 'dynamic_config/gatekeeper'
 require 'dynamic_config/dcdo'
 require 'testing/setup_all_and_teardown_all'

--- a/dashboard/test/ui/features/teacher_tools/certificates/csf_certificates.feature
+++ b/dashboard/test/ui/features/teacher_tools/certificates/csf_certificates.feature
@@ -2,7 +2,7 @@ Feature: After completing a CSF course, the student is directed to a congratulat
 
   Scenario: CSF uncustomized dashboard certificate pages
     Given I create a student named "Student1"
-    And I sign in as "Student1"
+    And I sign in as "Student1" and go home
     And I complete course "ui-test-csf" unit 1
     And I am on "http://studio.code.org/congrats"
     Then I wait until element "#uitest-certificate" is visible
@@ -25,7 +25,7 @@ Feature: After completing a CSF course, the student is directed to a congratulat
   Scenario: CSF certificate pages
     When I open my eyes to test "CSF certificate pages"
     And I create a student named "Student1"
-    And I sign in as "Student1"
+    And I sign in as "Student1" and go home
     And I complete course "ui-test-csf" unit 1
 
     When I am on "http://studio.code.org/congrats/ui-test-csf"

--- a/dashboard/test/ui/features/teacher_tools/instructions/feedback_tab.feature
+++ b/dashboard/test/ui/features/teacher_tools/instructions/feedback_tab.feature
@@ -28,7 +28,7 @@ Scenario: As teacher, when viewing a level with student work,
 feedback can be submitted and displayed. If there is a mini rubric, teacher can give feedback on rubric.
 If a teacher on a level with mini rubric can see the rubric without viewing student work.
 Otherwise don't show feedback tab
-  Then I sign in as "Teacher_Lillian"
+  Then I sign in as "Teacher_Lillian" and go home
   And I give user "Teacher_Lillian" authorized teacher permission
 
   #Not automatically visible on contained levels with no mini rubric

--- a/dashboard/test/ui/features/teacher_tools/instructions/feedback_tab_eyes.feature
+++ b/dashboard/test/ui/features/teacher_tools/instructions/feedback_tab_eyes.feature
@@ -25,7 +25,7 @@ Feature: Feedback Tab Visibility
   If a teacher on a level with mini rubric can see the rubric without viewing student work.
   Otherwise don't show feedback tab
     When I open my eyes to test "teacher giving student feedback"
-    And I sign in as "Teacher_Lillian"
+    And I sign in as "Teacher_Lillian" and go home
     And I give user "Teacher_Lillian" authorized teacher permission
 
     And I am on "http://studio.code.org/courses/allthethingscourse/units/1/lessons/38/levels/1"

--- a/dashboard/test/ui/features/teacher_tools/instructor_in_training/instructor_in_training_universal_instructor.feature
+++ b/dashboard/test/ui/features/teacher_tools/instructor_in_training/instructor_in_training_universal_instructor.feature
@@ -4,7 +4,7 @@ Feature: Self Paced PL Instructor in Training - Universal Instructor
   @properties_encryption_key
   Scenario: View Instructor In Training Applab Level as Universal Instructor
     Given I create a teacher named "Universal Instructor"
-    And I sign in as "Universal Instructor"
+    And I sign in as "Universal Instructor" and go home
     And I get universal instructor access
     Then I am on "http://studio.code.org/courses/alltheselfpacedplthings/units/1/lessons/1/levels/1"
     And I wait for the lab page to fully load
@@ -19,7 +19,7 @@ Feature: Self Paced PL Instructor in Training - Universal Instructor
   @no_mobile
   Scenario: View Instructor In Training Dance Level as Universal Instructor
     Given I create a teacher named "Universal Instructor"
-    And I sign in as "Universal Instructor"
+    And I sign in as "Universal Instructor" and go home
     And I get universal instructor access
     Then I am on "http://studio.code.org/courses/alltheselfpacedplthings/units/1/lessons/1/levels/2"
     And I dismiss the hoc guide dialog
@@ -35,7 +35,7 @@ Feature: Self Paced PL Instructor in Training - Universal Instructor
   @properties_encryption_key
   Scenario: View Instructor In Training Free Response Level as Universal Instructor
     Given I create a teacher named "Universal Instructor"
-    And I sign in as "Universal Instructor"
+    And I sign in as "Universal Instructor" and go home
     And I get universal instructor access
     Then I am on "http://studio.code.org/courses/alltheselfpacedplthings/units/1/lessons/1/levels/3"
 
@@ -48,7 +48,7 @@ Feature: Self Paced PL Instructor in Training - Universal Instructor
   @no_mobile
   Scenario: View Instructor In Training External Level as Universal Instructor
     Given I create a teacher named "Universal Instructor"
-    And I sign in as "Universal Instructor"
+    And I sign in as "Universal Instructor" and go home
     And I get universal instructor access
     Then I am on "http://studio.code.org/courses/alltheselfpacedplthings/units/1/lessons/1/levels/6"
 
@@ -61,7 +61,7 @@ Feature: Self Paced PL Instructor in Training - Universal Instructor
   @no_mobile
   Scenario: View Instructor In Training Bubble Choice Level as Universal Instructor
     Given I create a teacher named "Universal Instructor"
-    And I sign in as "Universal Instructor"
+    And I sign in as "Universal Instructor" and go home
     And I get universal instructor access
     Then I am on "http://studio.code.org/courses/alltheselfpacedplthings/units/1/lessons/1/levels/7"
 
@@ -75,7 +75,7 @@ Feature: Self Paced PL Instructor in Training - Universal Instructor
   @properties_encryption_key
   Scenario: View Instructor In Training LevelGroup Level as Universal Instructor
     Given I create a teacher named "Universal Instructor"
-    And I sign in as "Universal Instructor"
+    And I sign in as "Universal Instructor" and go home
     And I get universal instructor access
     Then I am on "http://studio.code.org/courses/alltheselfpacedplthings/units/1/lessons/2/levels/1"
 

--- a/dashboard/test/ui/features/teacher_tools/plc_course_unit_navigation.feature
+++ b/dashboard/test/ui/features/teacher_tools/plc_course_unit_navigation.feature
@@ -3,7 +3,7 @@ Feature: Basic navigation for PLC stuff
 
 Background:
   Given I create a teacher named "Test Deeper Learning Participant"
-  And I sign in as "Test Deeper Learning Participant"
+  And I sign in as "Test Deeper Learning Participant" and go home
   And I get facilitator access
   And I am enrolled in a plc course
   Given I am on "http://studio.code.org/courses/All%20The%20PLC%20Things"


### PR DESCRIPTION
During the site outage on wednesday, users could not login using email and password and received a 422 response. the problem was reproducible on staging and production, but not test. one takeaway is that the problem could have been detected and prevented in tests if the test environment was configured to be more similarly to prod. in this case, we suspect that the `allow_forgery_protection` setting was the key difference.

Rails sets this value to false in test, by setting it explicitly to false in dashboard/config/environments/test.rb. We want this value to be true (same as production) in UI tests, but false in unit tests (the true intent of the rails default).

Done in this PR:
- set allow_request_forgery to in the test environment, except in unit tests
- fix failing UI tests, typically by adding a page navigation after a user signs in and before issuing any XHR requests to test_controller.rb

## Testing story
- passing drone run should provide good coverage of ui and eyes tests, since we run eyes tests in CI and just skip the actually visual diffs.
- low risk to unit tests since we are not changing this value there.

