### PR TITLE
Add pseudocode and example to AI tutor response properties

### DIFF
--- a/apps/src/aichat/redux/thunks/sendAnalytics.ts
+++ b/apps/src/aichat/redux/thunks/sendAnalytics.ts
@@ -25,7 +25,8 @@ export const sendAnalytics =
       const allProperties = {
         ...properties,
         clientType,
-        aiTutorMode: labState.levelProperties?.aiTutorMode,
+        aiTutorAnswerTypes:
+          labState.levelProperties?.aiTutorPromptSettings?.answerTypes, // Should we replace with aiTutorPromptSettings? (answerTypes and answerTypeCustomizations)
         appType: labState.levelProperties?.appName,
         levelId: labState.levelProperties?.id,
         levelName: labState.levelProperties?.name,

--- a/apps/src/aichat/redux/thunks/sendAnalytics.ts
+++ b/apps/src/aichat/redux/thunks/sendAnalytics.ts
@@ -26,7 +26,7 @@ export const sendAnalytics =
         ...properties,
         clientType,
         aiTutorAnswerTypes:
-          labState.levelProperties?.aiTutorPromptSettings?.answerTypes, // Should we replace with aiTutorPromptSettings? (answerTypes and answerTypeCustomizations)
+          labState.levelProperties?.aiTutorPromptSettings?.answerTypes,
         appType: labState.levelProperties?.appName,
         levelId: labState.levelProperties?.id,
         levelName: labState.levelProperties?.name,

--- a/apps/src/aichat/views/FlagResponseButton.tsx
+++ b/apps/src/aichat/views/FlagResponseButton.tsx
@@ -34,7 +34,9 @@ const FlagResponseButton: React.FC<{
       : legacyLabData.serverLevelId,
     scriptId: labData ? labData.scriptId : legacyLabData.serverScriptId,
     userId: user.userId,
-    aiTutorMode: labData ? labData.levelProperties?.aiTutorMode : undefined,
+    aiTutorAnswerTypes: labData
+      ? labData.levelProperties?.aiTutorPromptSettings?.answerTypes
+      : undefined,
     levelSystemPrompt: labData
       ? labData.levelProperties?.levelSystemPrompt
       : undefined,

--- a/apps/src/lab2/types.ts
+++ b/apps/src/lab2/types.ts
@@ -19,6 +19,7 @@ import {ComponentType, LazyExoticComponent} from 'react';
 
 import {BlockDefinition} from '@cdo/apps/blockly/types';
 import {LevelPredictSettings} from '@cdo/apps/lab2/levelEditors/types';
+import {AiTutorPromptSettings} from '@cdo/apps/weblab2/types';
 
 import {lab2EntryPoints} from '../../lab2EntryPoints';
 
@@ -249,6 +250,7 @@ export interface LevelProperties {
   widgetView?: boolean;
   widgetViewAllowShowCode?: boolean;
   aiTutorMode?: string;
+  aiTutorPromptSettings?: AiTutorPromptSettings;
   levelSystemPrompt?: string;
   // Properties added for parity with non-lab2 AI Tutor levels
   aiTutorAvailable?: boolean;

--- a/apps/src/weblab2/helpers/aiTutorStructuredResponseHelper.ts
+++ b/apps/src/weblab2/helpers/aiTutorStructuredResponseHelper.ts
@@ -153,12 +153,8 @@ export const formatCopyPasteResponse = (response: any): string => {
   }
 
   formattedResponse += formatSection('Explanation', response.explanation);
-  if (response.answerType === 'pseudocode') {
-    formattedResponse += formatSection('Pseudocode', response.pseudocode);
-  }
-  if (response.answerType === 'example') {
-    formattedResponse += formatSection('Example', response.example);
-  }
+  formattedResponse += formatSection('Pseudocode', response.pseudocode);
+  formattedResponse += formatSection('Example', response.example);
   formattedResponse += formatSection('Next Steps', response.nextSteps);
   formattedResponse += formatSection('Questions', response.questions);
 

--- a/apps/src/weblab2/helpers/aiTutorStructuredResponseHelper.ts
+++ b/apps/src/weblab2/helpers/aiTutorStructuredResponseHelper.ts
@@ -64,7 +64,7 @@ const getAnswerJsonSchema = (): JsonObjectSchema => {
       pseudocode: {
         type: 'string',
         description:
-          "Pseudocode for the code or plain-text answer to the student's question. Use markdown.",
+          'Pseudocode in plain English only (no JS). Wrap the pseudocode in a markdown fenced code block with language tag `text` so newlines and indentation are preserved. Use markdown outside the block only if needed.',
       },
       example: {
         type: 'string',

--- a/apps/src/weblab2/helpers/aiTutorStructuredResponseHelper.ts
+++ b/apps/src/weblab2/helpers/aiTutorStructuredResponseHelper.ts
@@ -61,6 +61,16 @@ const getAnswerJsonSchema = (): JsonObjectSchema => {
         description:
           'short list to confirm ambiguous details. Format as markdown bullets.',
       },
+      pseudocode: {
+        type: 'string',
+        description:
+          "Pseudocode for the code or plain-text answer to the student's question. Use markdown.",
+      },
+      example: {
+        type: 'string',
+        description:
+          "1-2 concrete example(s) of the code or plain-text answer(s) to the student's question. Use markdown.",
+      },
     },
     // We return tutorMode and goal but do not show them to the student.
     // These are used to help guide the AI's response.
@@ -71,6 +81,8 @@ const getAnswerJsonSchema = (): JsonObjectSchema => {
       'assumptions',
       'code',
       'explanation',
+      'pseudocode',
+      'example',
       'nextSteps',
       'questions',
     ],
@@ -141,6 +153,12 @@ export const formatCopyPasteResponse = (response: any): string => {
   }
 
   formattedResponse += formatSection('Explanation', response.explanation);
+  if (response.tutorMode === 'pseudocode') {
+    formattedResponse += formatSection('Pseudocode', response.pseudocode);
+  }
+  if (response.tutorMode === 'example') {
+    formattedResponse += formatSection('Example', response.example);
+  }
   formattedResponse += formatSection('Next Steps', response.nextSteps);
   formattedResponse += formatSection('Questions', response.questions);
 

--- a/apps/src/weblab2/helpers/aiTutorStructuredResponseHelper.ts
+++ b/apps/src/weblab2/helpers/aiTutorStructuredResponseHelper.ts
@@ -14,7 +14,7 @@ const getAnswerJsonSchema = (): JsonObjectSchema => {
   return {
     type: 'object',
     properties: {
-      tutorMode: {
+      answerType: {
         type: 'string',
         enum: [...AI_TUTOR_ANSWER_TYPES],
       },
@@ -72,11 +72,11 @@ const getAnswerJsonSchema = (): JsonObjectSchema => {
           "1-2 concrete example(s) of the code or plain-text answer(s) to the student's question. Use markdown.",
       },
     },
-    // We return tutorMode and goal but do not show them to the student.
+    // We return answerType and goal but do not show them to the student.
     // These are used to help guide the AI's response.
-    required: ['tutorMode', 'nextSteps', 'code', 'explanation', 'goal'],
+    required: ['answerType', 'nextSteps', 'code', 'explanation', 'goal'],
     propertyOrdering: [
-      'tutorMode',
+      'answerType',
       'goal',
       'assumptions',
       'code',
@@ -136,7 +136,7 @@ const formatSection = (title: string, content?: string): string => {
   return content ? `**${title}**\n\n${content}\n\n` : '';
 };
 
-// This is used when the AI Tutor response's tutorMode is not 'buildHTML', 'buildCSS', nor 'buildJavaScript'.
+// This is used when the AI Tutor response's answerType is not 'buildHTML', 'buildCSS', nor 'buildJavaScript'.
 // Parsed json comes in as 'any', but it follows the structure defined in getAnswerJsonSchemaAcceptReject().
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const formatCopyPasteResponse = (response: any): string => {
@@ -153,10 +153,10 @@ export const formatCopyPasteResponse = (response: any): string => {
   }
 
   formattedResponse += formatSection('Explanation', response.explanation);
-  if (response.tutorMode === 'pseudocode') {
+  if (response.answerType === 'pseudocode') {
     formattedResponse += formatSection('Pseudocode', response.pseudocode);
   }
-  if (response.tutorMode === 'example') {
+  if (response.answerType === 'example') {
     formattedResponse += formatSection('Example', response.example);
   }
   formattedResponse += formatSection('Next Steps', response.nextSteps);
@@ -176,7 +176,7 @@ type AcceptRejectFormattedResponse = {
   answerType: string;
 };
 
-// This is used when the AI Tutor response's tutorMode is 'buildHTML', 'buildCSS', or 'buildJavaScript'.
+// This is used when the AI Tutor response's answerType is 'buildHTML', 'buildCSS', or 'buildJavaScript'.
 // Parsed json comes in as 'any', but it follows the structure defined in acceptRejectJsonSchema.
 export const formatAcceptRejectResponse = (
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -189,7 +189,7 @@ export const formatAcceptRejectResponse = (
       name: codeFile.filename,
       contents: codeFile.sourceCode,
     })),
-    answerType: response.tutorMode,
+    answerType: response.answerType,
   };
 };
 

--- a/apps/src/weblab2/prompts/answerTypeContracts/pseudocode.md
+++ b/apps/src/weblab2/prompts/answerTypeContracts/pseudocode.md
@@ -1,5 +1,6 @@
 ### pseudocode
 - **Guarantee:** Provide clear, **structured pseudocode using plain English** and indentation to express logic, sequence, and decisions. Never include actual JavaScript syntax, keywords, or runnable elements.
+- **Layout:** Preserve newlines and meaningful whitespace (line breaks, indentation, blank lines between steps). Wrap the pseudocode in a **markdown fenced code block** and put `text` on the opening fence line (after the backticks) so the chat UI preserves layout; the block must still be **plain English only**—a layout container, not programming code.
 - Must use natural language (no JS syntax, keywords, or punctuation such as {} or ;).
 - Should describe intent and flow (steps, loops, conditions, outcomes).
 - Never include any runnable or token-complete JavaScript.

--- a/apps/src/weblab2/types.ts
+++ b/apps/src/weblab2/types.ts
@@ -44,6 +44,7 @@ export const AI_TUTOR_ANSWER_TYPES = [
 
 export type AiTutorAnswerType = (typeof AI_TUTOR_ANSWER_TYPES)[number];
 
+// These are no longer used and replaced by answerTypes, but are kept for backwards compatibility.
 export type AiTutorMode =
   | 'suggest'
   | 'outline'


### PR DESCRIPTION
<!--
  Summary of the change: background, motivation, and context.
  Include screenshots, videos, or before/after comparisons for UI changes.
-->
This PR adds 'pseudocode' and 'example' properties to the AI Tutor JSON schema, and displays if the model response returns `answerType` 'pseudocode' or 'example', respectively.

I also updated the JSON schema property `tutorMode` to `answerType` since we are now using modular prompts and the Statsig report to include the list of answer types instead of the deprecated tutor mode.


## Links
<!-- Jira tickets, design docs, Slack threads, related PRs, etc. -->

- Jira: https://codedotorg.atlassian.net/browse/AFL-540
- [Slack thread about statsig report update](https://codedotorg.slack.com/archives/C09EHQE4DGD/p1775145395831979)

## Testing story
<!-- How was this tested? Manual steps, adhoc links, automated tests, or why testing isn't needed. -->

I tested locally on `weblab2` levels and explicitly request pseudocode and examples.

### Before update

<img width="402" height="501" alt="Screenshot 2026-03-26 at 9 07 50 PM" src="https://github.com/user-attachments/assets/cf54fa90-5aca-4d87-84a4-fdf427553b94" />

<img width="744" height="692" alt="Screenshot 2026-03-26 at 9 16 40 PM" src="https://github.com/user-attachments/assets/a321cd49-93bb-49d5-b42b-c5127333e86b" />

### After update

https://github.com/user-attachments/assets/12b3ede6-19ee-4669-8ea8-8d80d29e0e49




## Deployment notes
<!-- Delete this section if it's a standard merge-and-deploy.
     Otherwise: migrations, feature flags, coordination, caching impacts, etc. -->



## Privacy and security
<!-- Delete this section if there is no privacy/security impact.
     Otherwise: new PII, auth changes, API surface changes, etc. -->

