### PR TITLE
Fix flaky assessment feedback test

### DIFF
--- a/dashboard/test/ui/features/teacher_tools/teacher_dashboard/assessment_feedback_download.feature
+++ b/dashboard/test/ui/features/teacher_tools/teacher_dashboard/assessment_feedback_download.feature
@@ -45,6 +45,8 @@ Feature: Using the assessments tab in the teacher dashboard to get feedback for 
     And I click selector "button:contains(Hour of Code)"
     And I press the first "input[name='UI Test Artist']" element
     And I press the first "#uitest-save-section-changes" element
+    And I wait for 5 seconds
+    And I wait for jquery to load
     And I wait until element "h1:contains(Progress)" is visible
 
     # Assessments tab


### PR DESCRIPTION
The Assessment Feedback test has been very flaky.

https://cucumber-logs.s3.amazonaws.com/test/test/Firefox_teacher_tools_teacher_dashboard_assessment_feedback_download_output.html?versionId=brMvGlaLCffTKEJ3Rrori5Ogu5R23bLM


The error comes from:
```
And I press the first "#uitest-save-section-changes" element
And I wait until element "h1:contains(Progress)" is visible
```

The first loads a new page and if the second line happens after the next page starts loading, but before jquery loads, it errors out with `ReferenceError: $ is not defined (Selenium::WebDriver::Error::JavascriptError)`.

This PR adds a small wait for the page to start loading and then a wait for jquery to load before checking the progress header



## Links
Slack discussion https://codedotorg.slack.com/archives/C0T0PNTM3/p1775136632756769
