### PR TITLE
Add useMemo back into imports where auto-merge removed it

### DIFF
--- a/apps/src/aichat/views/ChatEventsList.tsx
+++ b/apps/src/aichat/views/ChatEventsList.tsx
@@ -1,7 +1,7 @@
 import FontAwesomeV6Icon from '@code-dot-org/component-library/fontAwesomeV6Icon';
 import {IconButton as MuiIconButton} from '@mui/material';
 import classNames from 'classnames';
-import React, {useEffect, useRef, useState, useCallback} from 'react';
+import React, {useEffect, useRef, useState, useCallback, useMemo} from 'react';
 
 import {useAiChatDisabled} from '@cdo/apps/aichat/context/aiChatDisabledContext';
 import {Role} from '@cdo/apps/aiComponentLibrary/chatMessage/types';


### PR DESCRIPTION
<!--
  Summary of the change: background, motivation, and context.
  Include screenshots, videos, or before/after comparisons for UI changes.
-->

Auto-merge between #71760 and #71791 caused useMemo to be removed from react imports. One PR removed the last usage of useMemo along with the now unused import, the other added a new usage of useMemo in, making the import necessary again.  This PR adds back in the import to fix the build.


## Links
<!-- Jira tickets, design docs, Slack threads, related PRs, etc. -->

- [slack discussion](https://codedotorg.slack.com/archives/C0T0PNTM3/p1775156983052049)

## Testing story
<!-- How was this tested? Manual steps, adhoc links, automated tests, or why testing isn't needed. -->

ran yarn build
