### PR TITLE
make teacher_dashboard/assessment_feedback_download.feature use new ui-test-csp-survey unit

### DIFF
--- a/dashboard/config/locales/scripts/en.yml
+++ b/dashboard/config/locales/scripts/en.yml
@@ -27231,6 +27231,17 @@ en:
           description_short: ''
           description: ''
           student_description: ''
+        ui-test-csp-survey:
+          lessons:
+            lesson-1:
+              name: Survey
+          lesson_groups: {}
+          name: ui-test-csp-survey
+          title: UI Test CSP Survey
+          description_audience: ''
+          description_short: ''
+          description: ''
+          student_description: ''
         pl-facilitators-aif2-intro-2026:
           lessons: {}
           lesson_groups: {}

--- a/dashboard/test/ui/config/courses/ui-test-csp-2017.course
+++ b/dashboard/test/ui/config/courses/ui-test-csp-2017.course
@@ -2,10 +2,11 @@
   "name": "ui-test-csp-2017",
   "script_names": [
     "ui-test-csp1-2017",
-    "ui-test-csp2-2017"
+    "ui-test-csp2-2017",
+    "ui-test-csp-survey"
   ],
   "original_script_names": [
-
+    "ui-test-csp-survey"
   ],
   "published_state": "stable",
   "instruction_type": "teacher_led",

--- a/dashboard/test/ui/config/courses/ui-test-csp-2019.course
+++ b/dashboard/test/ui/config/courses/ui-test-csp-2019.course
@@ -2,7 +2,8 @@
   "name": "ui-test-csp-2019",
   "script_names": [
     "ui-test-csp1-2019",
-    "ui-test-csp2-2019"
+    "ui-test-csp2-2019",
+    "ui-test-csp-survey"
   ],
   "original_script_names": [
 

--- a/dashboard/test/ui/config/scripts_json/ui-test-csp-survey.script_json
+++ b/dashboard/test/ui/config/scripts_json/ui-test-csp-survey.script_json
@@ -1,0 +1,153 @@
+{
+  "script": {
+    "name": "ui-test-csp-survey",
+    "wrapup_video_id": null,
+    "login_required": false,
+    "properties": {
+      "is_migrated": true
+    },
+    "new_name": null,
+    "family_name": null,
+    "serialized_at": "2026-04-02 20:24:04 UTC",
+    "hide_within_course": false,
+    "published_state": "in_development",
+    "instruction_type": null,
+    "instructor_audience": null,
+    "participant_audience": null,
+    "seeding_key": {
+      "script.name": "ui-test-csp-survey"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "ui-test-csp-survey"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "lesson-1",
+      "name": "Survey",
+      "absolute_position": 1,
+      "lockable": false,
+      "has_lesson_plan": true,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "lesson-1",
+        "lesson_group.key": "",
+        "script.name": "ui-test-csp-survey"
+      }
+    }
+  ],
+  "lesson_activities": [
+    {
+      "key": "7cd052b2-7adc-45b7-b954-3afe287b736d",
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_activity.key": "7cd052b2-7adc-45b7-b954-3afe287b736d",
+        "lesson.key": "lesson-1",
+        "lesson_group.key": "",
+        "script.name": "ui-test-csp-survey"
+      }
+    }
+  ],
+  "activity_sections": [
+    {
+      "key": "9eea6be9-1d59-4d12-ab24-fe6c9e55af6f",
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "activity_section.key": "9eea6be9-1d59-4d12-ab24-fe6c9e55af6f",
+        "lesson_activity.key": "7cd052b2-7adc-45b7-b954-3afe287b736d"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "activity_section_position": 1,
+      "assessment": true,
+      "properties": {
+      },
+      "bonus": false,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Test anonymous student survey"
+        ],
+        "lesson.key": "lesson-1",
+        "lesson_group.key": "",
+        "script.name": "ui-test-csp-survey",
+        "activity_section.key": "9eea6be9-1d59-4d12-ab24-fe6c9e55af6f"
+      },
+      "level_keys": [
+        "Test anonymous student survey"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "Test anonymous student survey",
+        "script_level.level_keys": [
+          "Test anonymous student survey"
+        ],
+        "lesson.key": "lesson-1",
+        "lesson_group.key": "",
+        "script.name": "ui-test-csp-survey",
+        "activity_section.key": "9eea6be9-1d59-4d12-ab24-fe6c9e55af6f"
+      }
+    }
+  ],
+  "resources": [
+
+  ],
+  "lessons_resources": [
+
+  ],
+  "scripts_resources": [
+
+  ],
+  "scripts_student_resources": [
+
+  ],
+  "vocabularies": [
+
+  ],
+  "lessons_vocabularies": [
+
+  ],
+  "lessons_programming_expressions": [
+
+  ],
+  "objectives": [
+
+  ],
+  "lessons_standards": [
+
+  ],
+  "lessons_opportunity_standards": [
+
+  ],
+  "rubrics": [
+
+  ],
+  "learning_goals": [
+
+  ],
+  "learning_goal_evidence_levels": [
+
+  ]
+}

--- a/dashboard/test/ui/features/teacher_tools/teacher_dashboard/assessment_feedback_download.feature
+++ b/dashboard/test/ui/features/teacher_tools/teacher_dashboard/assessment_feedback_download.feature
@@ -8,18 +8,9 @@ Feature: Using the assessments tab in the teacher dashboard to get feedback for 
     # Assign a unit with a survey but no assessment
     When I sign in as "Teacher_Sally"
     Then I am on "http://studio.code.org/teacher_dashboard/home"
-    Then I click selector "#section-options-dropdown-dropdown-button" once I see it
-    And I click selector "#ui-test-Section-settings" once I see it
-    And I press the first "input[name='grades[]']" element
-    And I wait until element "button:contains(High School)" is visible
-    And I click selector "button:contains(High School)"
-    And I press the first "input[name='Computer Science Principles']" element
-    And I wait until element "#assignment-version-year" is visible
-    And I press "assignment-version-year"
-    And I click selector ".assignment-version-title:contains('25-'26)" once I see it
-    And I wait until element "#uitest-secondary-assignment" is visible
-    And I select the "Intro to App Design" option in dropdown "uitest-secondary-assignment"
-    And I press the first "#uitest-save-section-changes" element to load a new page
+    And I assign my section in row 1 to course "csp-2025" unit 3
+    And I reload the page
+    And I click selector "a:contains(View progress)" once I see it
 
     # Progress tab
     And I wait until element "#unit-selector-v2" is visible

--- a/dashboard/test/ui/features/teacher_tools/teacher_dashboard/assessment_feedback_download.feature
+++ b/dashboard/test/ui/features/teacher_tools/teacher_dashboard/assessment_feedback_download.feature
@@ -8,7 +8,7 @@ Feature: Using the assessments tab in the teacher dashboard to get feedback for 
     # Assign a unit with a survey but no assessment
     When I sign in as "Teacher_Sally"
     Then I am on "http://studio.code.org/teacher_dashboard/home"
-    And I assign my section in row 1 to course "csp-2025" unit 3
+    And I assign my section in row 1 to course "ui-test-csp-2019" unit 3
     And I reload the page
     And I click selector "a:contains(View progress)" once I see it
 

--- a/dashboard/test/ui/features/teacher_tools/teacher_dashboard/assessment_feedback_download.feature
+++ b/dashboard/test/ui/features/teacher_tools/teacher_dashboard/assessment_feedback_download.feature
@@ -7,8 +7,6 @@ Feature: Using the assessments tab in the teacher dashboard to get feedback for 
   Scenario: Assessments tab has feedback download
     # Assign a unit with a survey but no assessment
     When I sign in as "Teacher_Sally"
-    Then I am on "http://studio.code.org/courses/allthethingscourse/units/1/lessons/18/levels/15"
-    And I wait for the lab page to fully load
     Then I am on "http://studio.code.org/teacher_dashboard/home"
     Then I click selector "#section-options-dropdown-dropdown-button" once I see it
     And I click selector "#ui-test-Section-settings" once I see it


### PR DESCRIPTION
the goal of this PR is to move ui tests off of production courses. for background, see [partitioned curriculum data proposal](https://docs.google.com/document/d/1iiJXtPODakjuZ7-2yKJ941H56dcyUmUFtWa7zGgqKdw/edit?tab=t.0#heading=h.qx67631q1z2d)

Done in this PR:
- a bit of refactoring to clean up the original test (similar to https://github.com/code-dot-org/code-dot-org/pull/71829)
- create `ui-test-csp-survey` unit and add it to the `ui-test-csp-2017` and `ui-test-csp-2019` courses
- point the test at the new survey unit

Ideally, I'd use a generic course like ui-test-survey, but it turns out that using the ui-test-csp course is necessary because assessment downloads are gated on marketing initiative: https://github.com/code-dot-org/code-dot-org/blob/1ff52b5467b30bb00149d6e93a18089e03e3f71a/dashboard/app/models/unit.rb#L161

## Testing story
- updated UI test should be adequately covered by the drone run
- no expected changes to curriculum catalog eyes tests since this unit is being added to an existing course offering

