### PR TITLE
use 8 parallel workers and 16GB RAM by default for optimized apps build

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -289,7 +289,7 @@ steps:
       # DRONE_REPO_OWNER = organization name (e.g., "code-dot-org")
       # DRONE_REPO_NAME = repository name (e.g., "code-dot-org")
       - AUTHENTICATED_GITHUB_URL="https://$GITHUB_TOKEN@github.com/$DRONE_REPO_OWNER/$DRONE_REPO_NAME.git"
-      - git clone --branch $DRONE_BRANCH $AUTHENTICATED_GITHUB_URL .
+      - git clone --branch $DRONE_SOURCE_BRANCH $AUTHENTICATED_GITHUB_URL .
 
   # Do all the work necessary to run UI tests so we can capture a complete
   # snapshot of the fully-built project and resulting database, but don't
@@ -320,7 +320,7 @@ steps:
       - name: mysql
         path: /var/lib/mysql
     settings:
-      filename: cache-staging-ci-build.tar.gz
+      filename: cache-staging-ci-build-PR-71877.tar.gz
       endpoint: s3://cdo-drone
       rebuild: true
       debug: true
@@ -339,9 +339,10 @@ trigger:
     - "staging-next"
   event:
     - push
+    - pull_request
 
 ---
 kind: signature
-hmac: 8380ec279dc40128beca1b341a9fff3212255c2a343d9fed59c9c839ab095669
+hmac: 8c8d9f538a5113f2ad6bcc244b46d46946255ec5e44ad30d41fb67671e29c275
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -289,7 +289,7 @@ steps:
       # DRONE_REPO_OWNER = organization name (e.g., "code-dot-org")
       # DRONE_REPO_NAME = repository name (e.g., "code-dot-org")
       - AUTHENTICATED_GITHUB_URL="https://$GITHUB_TOKEN@github.com/$DRONE_REPO_OWNER/$DRONE_REPO_NAME.git"
-      - git clone --branch $DRONE_SOURCE_BRANCH $AUTHENTICATED_GITHUB_URL .
+      - git clone --branch $DRONE_BRANCH $AUTHENTICATED_GITHUB_URL .
 
   # Do all the work necessary to run UI tests so we can capture a complete
   # snapshot of the fully-built project and resulting database, but don't
@@ -320,7 +320,7 @@ steps:
       - name: mysql
         path: /var/lib/mysql
     settings:
-      filename: cache-staging-ci-build-PR-71877.tar.gz
+      filename: cache-staging-ci-build.tar.gz
       endpoint: s3://cdo-drone
       rebuild: true
       debug: true
@@ -339,10 +339,9 @@ trigger:
     - "staging-next"
   event:
     - push
-    - pull_request
 
 ---
 kind: signature
-hmac: 8c8d9f538a5113f2ad6bcc244b46d46946255ec5e44ad30d41fb67671e29c275
+hmac: 8380ec279dc40128beca1b341a9fff3212255c2a343d9fed59c9c839ab095669
 
 ...

--- a/apps/build-in-parallel.sh
+++ b/apps/build-in-parallel.sh
@@ -3,14 +3,15 @@
 # parallelism and memory settings for optimal CI performance.
 #
 # Environment variables:
-#   APPS_BUILD_WORKERS - Number of workers for thread-loader and TerserPlugin (default: 4)
-#   APPS_BUILD_MAX_MEMORY - Max memory in MB for Node.js heap (default: 10240 MB / 10 GB)
+#   APPS_BUILD_WORKERS - Number of workers for thread-loader and TerserPlugin (default: 10)
+#   APPS_BUILD_MAX_MEMORY - Max memory in MB for Node.js heap (default: 16384 MB / 16 GB)
 
 set -e
 
-# Default values optimized for local development
-DEFAULT_WORKERS=4
-DEFAULT_MAX_MEMORY=10240
+# Default values optimized to run on staging and drone (m7i.4xlarge).
+# The test machine also runs the apps build and is much larger.
+DEFAULT_WORKERS=10
+DEFAULT_MAX_MEMORY=16384
 
 # Read environment variables or use defaults
 APPS_BUILD_WORKERS=${APPS_BUILD_WORKERS:-$DEFAULT_WORKERS}

--- a/apps/build-in-parallel.sh
+++ b/apps/build-in-parallel.sh
@@ -3,14 +3,14 @@
 # parallelism and memory settings for optimal CI performance.
 #
 # Environment variables:
-#   APPS_BUILD_WORKERS - Number of workers for thread-loader and TerserPlugin (default: 10)
+#   APPS_BUILD_WORKERS - Number of workers for thread-loader and TerserPlugin (default: 8)
 #   APPS_BUILD_MAX_MEMORY - Max memory in MB for Node.js heap (default: 16384 MB / 16 GB)
 
 set -e
 
 # Default values optimized to run on staging and drone (m7i.4xlarge).
 # The test machine also runs the apps build and is much larger.
-DEFAULT_WORKERS=10
+DEFAULT_WORKERS=8
 DEFAULT_MAX_MEMORY=16384
 
 # Read environment variables or use defaults

--- a/docker/ci/scripts/prepare_ci_env.sh
+++ b/docker/ci/scripts/prepare_ci_env.sh
@@ -18,11 +18,6 @@ export LD_LIBRARY_PATH=/usr/local/lib
 # optimized for drone m7i.4xlarge workers with 16 vCPUs and 64 GB RAM.
 export PARALLEL_TEST_PROCESSORS=7
 
-# Apps build parallelization settings for CI
-# optimized for drone m7i.4xlarge workers with 16 vCPUs and 64 GB RAM.
-export APPS_BUILD_WORKERS=10
-export APPS_BUILD_MAX_MEMORY=16384
-
 # Install in deployment mode, both to better mirror the test server and to make
 # caching easier.
 bundle config set --local deployment 'true'


### PR DESCRIPTION
the staging build has been failing recently during the `yarn build:dist` step, and the question was raised as to why these failures were not being caught in drone, which also runs the same command. one contributing factor is that drone uses different build parameters for number of workers and amount of memory.

Done in this PR:
- eliminate special casing for drone
- update default build params to match the ones drone had been using
- reduce number of workers to eliminate failures on custom adhocs

## Testing story

`yarn clean && yarn build:dist` results with varying values of `APPS_BUILD_WORKERS` (minimum 2 runs per scenario):

| environment | instance type | 8 workers | 10 workers |
|--------|--------|--------|--------|
| drone | m7i.4xlarge | pass | pass |
| default adhoc | t5.2xlarge | pass | pass |
| custom adhoc | m7i.4xlarge | pass | fail |
| staging | m7i.4xlarge | ? | ? |
| test | m5.24xlarge | ? | ? | 

based on the passing run on custom adhoc, I'm proposing we ship this change without first testing on staging.

## Deployment notes
- monitor for build failures when this change is deployed to staging