### PR TITLE
Add infrastructure repo to the GH Action IAM role

### DIFF
--- a/aws/cloudformation/iam.yml.erb
+++ b/aws/cloudformation/iam.yml.erb
@@ -1037,10 +1037,11 @@ roles.each do |name, config| %>
             Condition:
               StringEquals:
                 token.actions.githubusercontent.com:aud: sts.amazonaws.com
-              StringEquals:
                 token.actions.githubusercontent.com:sub:
                   - "repo:code-dot-org/code-dot-org:environment:open-tofu-plan"
                   - "repo:code-dot-org/code-dot-org:environment:open-tofu-apply"
+                  - "repo:code-dot-org/infrastructure:environment:open-tofu-plan"
+                  - "repo:code-dot-org/infrastructure:environment:open-tofu-apply"
       Policies:
         - PolicyName: OpenTofuStateAccess
           PolicyDocument:


### PR DESCRIPTION
This PR adds the `infrastructure` repo and matching environments as `code-dot-org` to the `github-actions-code-dot-org` IAM role. Claude also suggested removing the duplicated `StringEquals` key and move all `aud` and `sub` values under a single key.

<!--
  Summary of the change: background, motivation, and context.
  Include screenshots, videos, or before/after comparisons for UI changes.
-->



## Links
<!-- Jira tickets, design docs, Slack threads, related PRs, etc. -->

- Jira:

## Testing story
<!-- How was this tested? Manual steps, adhoc links, automated tests, or why testing isn't needed. -->



## Deployment notes
<!-- Delete this section if it's a standard merge-and-deploy.
     Otherwise: migrations, feature flags, coordination, caching impacts, etc. -->



## Privacy and security
<!-- Delete this section if there is no privacy/security impact.
     Otherwise: new PII, auth changes, API surface changes, etc. -->

