### PR TITLE
fix(otel): set log level to FATAL

### DIFF
--- a/dashboard/engines/observability/lib/observability/opentelemetry.rb
+++ b/dashboard/engines/observability/lib/observability/opentelemetry.rb
@@ -12,7 +12,7 @@ module Observability
       require 'opentelemetry/instrumentation/all'
       require 'opentelemetry-exporter-otlp'
 
-      # Suppress noisy warn-level messages from auto-instrumentation gems by default.
+      # Suppress noisy messages from auto-instrumentation gems by default.
       # (e.g. detach/attach mismatches, double-finish on spans).
       ENV['OTEL_LOG_LEVEL'] ||= 'fatal'
 

--- a/dashboard/engines/observability/lib/observability/opentelemetry.rb
+++ b/dashboard/engines/observability/lib/observability/opentelemetry.rb
@@ -12,6 +12,10 @@ module Observability
       require 'opentelemetry/instrumentation/all'
       require 'opentelemetry-exporter-otlp'
 
+      # Suppress noisy warn-level messages from auto-instrumentation gems by default.
+      # (e.g. detach/attach mismatches, double-finish on spans).
+      ENV['OTEL_LOG_LEVEL'] ||= 'fatal'
+
       ::OpenTelemetry::SDK.configure do |c|
         c.service_name = 'dashboard'
 

--- a/dashboard/engines/observability/test/lib/observability/opentelemetry_test.rb
+++ b/dashboard/engines/observability/test/lib/observability/opentelemetry_test.rb
@@ -4,13 +4,13 @@ require 'test_helper'
 
 describe Observability::OpenTelemetry do
   before do
-    CDO.enable_opentelemetry = false
-    CDO.running_web_application = false
+    CDO.stubs(:enable_opentelemetry).returns(false)
+    CDO.stubs(:running_web_application?).returns(false)
   end
 
   describe '.setup' do
     describe 'when CDO.enable_opentelemetry is false' do
-      before {CDO.running_web_application = true}
+      before {CDO.stubs(:running_web_application?).returns(true)}
 
       it 'returns without configuring the SDK' do
         _(Observability::OpenTelemetry.setup).must_be_nil
@@ -18,7 +18,7 @@ describe Observability::OpenTelemetry do
     end
 
     describe 'when CDO.running_web_application? is false' do
-      before {CDO.enable_opentelemetry = true}
+      before {CDO.stubs(:enable_opentelemetry).returns(true)}
 
       it 'returns without configuring the SDK' do
         _(Observability::OpenTelemetry.setup).must_be_nil
@@ -27,8 +27,9 @@ describe Observability::OpenTelemetry do
 
     describe 'when both CDO.enable_opentelemetry and running_web_application? are true' do
       before do
-        CDO.enable_opentelemetry = true
-        CDO.running_web_application = true
+        CDO.stubs(:enable_opentelemetry).returns(true)
+        CDO.stubs(:running_web_application?).returns(true)
+        OpenTelemetry::SDK.stubs(:configure)
       end
 
       it 'configures the OpenTelemetry SDK' do
@@ -43,6 +44,31 @@ describe Observability::OpenTelemetry do
         fake_config.stubs(:add_span_processor)
         OpenTelemetry::SDK.expects(:configure).yields(fake_config)
         Observability::OpenTelemetry.setup
+      end
+
+      describe 'OTEL_LOG_LEVEL' do
+        after {ENV.delete('OTEL_LOG_LEVEL')}
+
+        it 'sets OTEL_LOG_LEVEL to fatal outside of development' do
+          ENV.delete('OTEL_LOG_LEVEL')
+          Rails.env.stubs(:development?).returns(false)
+          Observability::OpenTelemetry.setup
+          _(ENV.fetch('OTEL_LOG_LEVEL', nil)).must_equal 'fatal'
+        end
+
+        it 'does not set OTEL_LOG_LEVEL in development' do
+          ENV.delete('OTEL_LOG_LEVEL')
+          Rails.env.stubs(:development?).returns(true)
+          Observability::OpenTelemetry.setup
+          _(ENV.fetch('OTEL_LOG_LEVEL', nil)).must_be_nil
+        end
+
+        it 'does not override an existing OTEL_LOG_LEVEL' do
+          ENV['OTEL_LOG_LEVEL'] = 'debug'
+          Rails.env.stubs(:development?).returns(false)
+          Observability::OpenTelemetry.setup
+          _(ENV.fetch('OTEL_LOG_LEVEL', nil)).must_equal 'debug'
+        end
       end
     end
   end

--- a/dashboard/engines/observability/test/lib/observability/opentelemetry_test.rb
+++ b/dashboard/engines/observability/test/lib/observability/opentelemetry_test.rb
@@ -49,23 +49,14 @@ describe Observability::OpenTelemetry do
       describe 'OTEL_LOG_LEVEL' do
         after {ENV.delete('OTEL_LOG_LEVEL')}
 
-        it 'sets OTEL_LOG_LEVEL to fatal outside of development' do
+        it 'sets OTEL_LOG_LEVEL to fatal' do
           ENV.delete('OTEL_LOG_LEVEL')
-          Rails.env.stubs(:development?).returns(false)
           Observability::OpenTelemetry.setup
           _(ENV.fetch('OTEL_LOG_LEVEL', nil)).must_equal 'fatal'
         end
 
-        it 'does not set OTEL_LOG_LEVEL in development' do
-          ENV.delete('OTEL_LOG_LEVEL')
-          Rails.env.stubs(:development?).returns(true)
-          Observability::OpenTelemetry.setup
-          _(ENV.fetch('OTEL_LOG_LEVEL', nil)).must_be_nil
-        end
-
         it 'does not override an existing OTEL_LOG_LEVEL' do
           ENV['OTEL_LOG_LEVEL'] = 'debug'
-          Rails.env.stubs(:development?).returns(false)
           Observability::OpenTelemetry.setup
           _(ENV.fetch('OTEL_LOG_LEVEL', nil)).must_equal 'debug'
         end


### PR DESCRIPTION
There is a bug in the instrumentation gems which sends noisy WARN and ERROR logs. Set the log level to FATAL to suppress these messages.

The following logs are no longer going to appear:

```
OpenTelemetry error: calls to detach should match corresponding calls to attach.
Calling finish on an ended Span.
```

Verified on local dashboard server with OpenTelemetry enabled. Logs appeared before and no longer appear after.

I will independently follow up to see why these errors occurred.