### PR TITLE
stop seeding production csp courses in ui tests [reset db]

### DIFF
--- a/dashboard/lib/tasks/seed.rake
+++ b/dashboard/lib/tasks/seed.rake
@@ -91,28 +91,6 @@ namespace :seed do
     focus-on-coding3-2024
     customizing-llms-2024
     csd3-2025
-    csp-ap
-    csp1-2024
-    csp2-2024
-    csp3-2024
-    csp4-2024
-    csp5-2024
-    csp6-2024
-    csp7-2024
-    csp8-2024
-    csp9-2024
-    csp10-2024
-    csp-post-survey-2024
-    csp1-2025
-    csp2-2025
-    csp3-2025
-    csp4-2025
-    csp5-2025
-    csp6-2025
-    csp7-2025
-    csp8-2025
-    csp9-2025
-    csp10-2025
     dance
     events
     flappy
@@ -290,15 +268,12 @@ namespace :seed do
   timed_task_with_logging courses_ui_tests: :environment do
     # seed those courses that are needed for UI tests
     %w(allthethingscourse
-       csp-2024
-       csp-2025
        20-hour
        algebra
        allthelessonplans
        alltheselfpacedplthings
        allthettsthings
        artist
-       csp-ap
        interactive-games-animations-2023
        interactive-games-animations-2024
        customizing-llms-2024


### PR DESCRIPTION
after a bunch of previous PRs to remove dependencies on the production csp courses in our ui tests, this PR takes the final step of removing CSP courses and units from the list of things that we seed in our test environment.

## Testing story
- the `[reset db]` flag ensures that drone is running against a freshly seeded database, with no CSP courses sneaking in from the drone build cache

## Deployment notes
1. after this is merged, I'll go in and manually remove these courses from the database on the test machine, which will cause
2. eyes diffs in the catalog eyes tests, because the CSP course card will disappear

