### PR TITLE
Gracefully Handle `UnsafeRedirectError`s

### DIFF
--- a/dashboard/app/controllers/application_controller.rb
+++ b/dashboard/app/controllers/application_controller.rb
@@ -115,6 +115,15 @@ class ApplicationController < ActionController::Base
     render_404
   end
 
+  # Unsafe redirects can happen for a variety of reasons; including unexpected
+  # attempts to redirect to an external domain, typos in the path for internal
+  # redirects, and simple malformed URIs. In the interest of simplicity,
+  # respond to all with a simple 404.
+  rescue_from ActionController::Redirecting::UnsafeRedirectError do |exception|
+    Rails.logger.warn("Unsafe redirection: #{exception}")
+    render_404
+  end
+
   def render_404
     respond_to do |format|
       format.html {render template: 'errors/not_found', layout: 'layouts/application', status: :not_found}

--- a/dashboard/test/controllers/application_controller_test.rb
+++ b/dashboard/test/controllers/application_controller_test.rb
@@ -204,6 +204,14 @@ class ApplicationControllerTest < ActionDispatch::IntegrationTest
     end
   end
 
+  describe 'exception handling' do
+    it 'gracefully handles UnsafeRedirectErrors' do
+      Rails.logger.expects(:warn).once
+      get home_set_locale_path, params: {locale: 'ar-SA', user_return_to: '../invalid/path'}
+      assert_response :not_found
+    end
+  end
+
   # Assert that the response is not a redirection to the given path.
   private def refute_redirect_to(expected_path)
     return unless response.redirect_url


### PR DESCRIPTION
We've had some time to monitor the new UnsafeRedirectErrors that we've been getting since enabling that protection, and (with the exception of one potential LTI issue that we're keeping an eye on) we're confident that none of them represent valid use cases that we'd like to support.

We would therefore like to turn down the volume on reporting these errors, and log them as warnings rather than contribute to HoneyBadger noise.

## Links

Follow-up to https://github.com/code-dot-org/code-dot-org/pull/71164

## Testing story

Added a new unit test