### PR TITLE
AI Chat: disallow non-image uploads for image model

### DIFF
--- a/apps/src/aichat/constants.ts
+++ b/apps/src/aichat/constants.ts
@@ -40,8 +40,6 @@ export const RESET_CONVERSATION_CUSTOMIZATION_UPDATES = [
 // Maximum number of files that can be attached to a chat message in multimodal mode.
 export const MAX_NUM_FILES = 5;
 export const MAX_FILE_SIZE_MB = 5;
-// Allowed file types for upload in multimodal mode.
-export const ACCEPTED_FILE_TYPES = ['.jpg', '.jpeg', '.png', '.pdf'];
 
 export const FAQ_LINK =
   'https://support.code.org/hc/en-us/articles/30162711193741-AI-Chat-Lab-FAQ';

--- a/apps/src/aichat/redux/thunks/submitChatContents.ts
+++ b/apps/src/aichat/redux/thunks/submitChatContents.ts
@@ -21,10 +21,7 @@ import {NetworkError} from '@cdo/apps/util/HttpClient';
 import {AppDispatch} from '@cdo/apps/util/reduxHooks';
 import {createUuid} from '@cdo/apps/utils';
 import {Weblab2LevelProperties} from '@cdo/apps/weblab2/types';
-import {
-  AiChatModelIds,
-  AiInteractionStatus as Status,
-} from '@cdo/generated-scripts/sharedConstants';
+import {AiInteractionStatus as Status} from '@cdo/generated-scripts/sharedConstants';
 
 import {postAichatCompletionMessage} from '../../aichatApi';
 import {performClientApiChatCompletion} from '../../api/performClientApiChatCompletion';
@@ -186,21 +183,11 @@ export const submitChatContents = createAsyncThunk(
           (levelProperties as AichatLevelProperties)?.aichatSettings
             ?.levelSystemPrompt;
 
-        let filteredChatEvents: CompletedChatMessage[] =
-          chatEventsCurrent.filter(isCompletedChatMessage);
-
-        if (
-          modelParameters.selectedModelId ===
-          AiChatModelIds.GEMINI_2_5_FLASH_IMAGE
-        ) {
-          filteredChatEvents = filteredChatEvents.filter(
-            message => message.status === Status.OK
-          );
-        }
-
         messages = await performClientApiChatCompletion(
           newUserMessage,
-          filteredChatEvents,
+          chatEventsCurrent
+            .filter(isCompletedChatMessage)
+            .filter(event => event.status === Status.OK),
           modelParameters,
           aichatContext,
           (asset: ChatAsset) =>

--- a/apps/src/aichat/utils.ts
+++ b/apps/src/aichat/utils.ts
@@ -78,8 +78,11 @@ export const getAllowedFileTypes = (
   if (!model || !model.multimodal) {
     return [];
   }
+  // Currently, our system only supports moderating images files. For the
+  // Gemini 2.5 Flash Image model, we have stricter input criteria so only
+  // safe image uploads are allowed. For other multimodal models, we don't
+  // do any input moderation, and allow both image and PDF uploads.
   const images = ['.jpg', '.jpeg', '.png'];
-  // We currently only allow uploading images for image models.
   return modelId === AiChatModelIds.GEMINI_2_5_FLASH_IMAGE
     ? images
     : [...images, '.pdf'];

--- a/apps/src/aichat/utils.ts
+++ b/apps/src/aichat/utils.ts
@@ -1,4 +1,8 @@
-import {MAX_NAME_LENGTH} from './constants';
+import {AiChatModelIds} from '@cdo/generated-scripts/sharedConstants';
+
+import {ValueOf} from '../types/utils';
+
+import {MAX_NAME_LENGTH, modelDescriptions} from './constants';
 import {AiCustomizations, ChatAsset, ToxicityCheckedField} from './types';
 import {FIELDS_CHECKED_FOR_TOXICITY} from './views/modelCustomization/constants';
 
@@ -61,4 +65,22 @@ export const getLineReferenceText = (lineReference: {
   return lineReference.start === lineReference.end
     ? `(${lineReference.start})`
     : `(${lineReference.start}-${lineReference.end})`;
+};
+
+/**
+ * Returns a list of allowed file types to upload for the given model ID.
+ * If the model does not support multimodal input, returns an empty list.
+ */
+export const getAllowedFileTypes = (
+  modelId: ValueOf<typeof AiChatModelIds>
+) => {
+  const model = modelDescriptions.find(model => model.id === modelId);
+  if (!model || !model.multimodal) {
+    return [];
+  }
+  const images = ['.jpg', '.jpeg', '.png'];
+  // We currently only allow uploading images for image models.
+  return modelId === AiChatModelIds.GEMINI_2_5_FLASH_IMAGE
+    ? images
+    : [...images, '.pdf'];
 };

--- a/apps/src/aichat/views/UserChatMessageEditor.tsx
+++ b/apps/src/aichat/views/UserChatMessageEditor.tsx
@@ -8,7 +8,6 @@ import experiments from '@cdo/apps/util/experiments';
 import {useAppDispatch, useAppSelector} from '@cdo/apps/util/reduxHooks';
 
 import supportsClientApi from '../api/supportsClientApi';
-import {ACCEPTED_FILE_TYPES} from '../constants';
 import {
   selectIsWaitingForChatResponse,
   submitChatContents,
@@ -20,6 +19,7 @@ import {
   ModelParameters,
   AnalyticsProperties,
 } from '../types';
+import {getAllowedFileTypes} from '../utils';
 
 import UploadButton, {UploadButtonProps} from './assets/UploadButton';
 
@@ -150,20 +150,27 @@ const UserChatMessageEditor: React.FunctionComponent<
     supportsClientApi(modelParameters.selectedModelId) ||
     experiments.isEnabledAllowingQueryString('enable-speech-to-text');
 
+  const acceptedFileTypes = getAllowedFileTypes(
+    modelParameters.selectedModelId
+  );
+
+  const canUploadFiles =
+    multimodalAvailable && buildAssetUrl && acceptedFileTypes.length > 0;
+
   const onPaste = useCallback(
     (e: React.ClipboardEvent<HTMLTextAreaElement>) => {
-      if (!multimodalAvailable || !buildAssetUrl) {
+      if (!canUploadFiles) {
         return;
       }
       const files = Array.from(e.clipboardData.items)
         .filter(({type}) =>
-          ACCEPTED_FILE_TYPES.includes(`.${mimeToExtension(type) || ''}`)
+          acceptedFileTypes.includes(`.${mimeToExtension(type) || ''}`)
         )
         .map(item => item.getAsFile())
         .filter(item => item !== null);
       dispatch(uploadFiles({files, buildAssetUrl}));
     },
-    [multimodalAvailable, buildAssetUrl, dispatch]
+    [canUploadFiles, buildAssetUrl, dispatch, acceptedFileTypes]
   );
 
   return (
@@ -185,13 +192,14 @@ const UserChatMessageEditor: React.FunctionComponent<
         onPaste={onPaste}
         ref={inputRef}
       >
-        {multimodalAvailable && buildAssetUrl && levelName && (
+        {canUploadFiles && levelName && (
           <div className={moduleStyles.buttonRow}>
             <UploadButton
               isDisabled={!!uploadDisabled || disabled}
               levelName={levelName}
               hasStarterAssets={hasStarterAssets}
               buildAssetUrl={buildAssetUrl}
+              acceptedFileTypes={acceptedFileTypes}
             />
           </div>
         )}

--- a/apps/src/aichat/views/assets/UploadButton.tsx
+++ b/apps/src/aichat/views/assets/UploadButton.tsx
@@ -12,7 +12,7 @@ import {EVENTS} from '@cdo/apps/metrics/AnalyticsConstants';
 import useHiddenFileInput from '@cdo/apps/util/hooks/useHiddenFileInput';
 import {useAppDispatch, useAppSelector} from '@cdo/apps/util/reduxHooks';
 
-import {ACCEPTED_FILE_TYPES, MAX_NUM_FILES} from '../../constants';
+import {MAX_NUM_FILES} from '../../constants';
 import {addStagedFile, sendAnalytics, uploadFiles} from '../../redux';
 import {AssetSource, ChatAsset} from '../../types';
 
@@ -20,6 +20,7 @@ export interface UploadButtonProps {
   isDisabled: boolean;
   levelName: string;
   buildAssetUrl: (asset: ChatAsset) => string;
+  acceptedFileTypes: string[];
   hasStarterAssets?: boolean;
   showLabel?: boolean;
 }
@@ -28,6 +29,7 @@ const UploadButton: React.FC<UploadButtonProps> = ({
   isDisabled,
   levelName,
   buildAssetUrl,
+  acceptedFileTypes,
   hasStarterAssets = false,
   showLabel = true,
 }) => {
@@ -76,7 +78,7 @@ const UploadButton: React.FC<UploadButtonProps> = ({
 
   const [openFileInput, FileInput] = useHiddenFileInput(
     onUploadFiles,
-    ACCEPTED_FILE_TYPES.join(','),
+    acceptedFileTypes.join(','),
     true
   );
 


### PR DESCRIPTION
Prevents users from uploading non-image files to the gemini 2.5 flash image model. This only restricts new file uploads; existing non-image files in a user's chat history are unchanged and not filtered out. Discussed this with @dju90 and we're okay keeping this to prevent disrupting students' chat history and context, as we don't expect this to be a huge attack vector.

As noted in the JIRA, this could eventually evolve into a more configurable per-level allowlist, but for now, this is simply checked based on model ID.

## Links
- Jira: https://codedotorg.atlassian.net/browse/SL-1643

## Testing story
Tested locally.