### PR TITLE
iOS 17 in Sauce Labs

### DIFF
--- a/dashboard/test/ui/browsers.json
+++ b/dashboard/test/ui/browsers.json
@@ -4,8 +4,8 @@
   {
     "name": "iPhone",
     "platformName": "iOS",
-    "appium:platformVersion": "16.2",
-    "browserName": "safari",
+    "browserName": "Safari",
+    "appium:platformVersion": "17.0",
     "appium:deviceName": "iPhone Simulator",
     "appium:automationName": "XCUITest",
     "appium:mobile": true,
@@ -16,8 +16,8 @@
   {
     "name": "iPad",
     "platformName": "iOS",
-    "appium:platformVersion": "14.5",
-    "browserName": "safari",
+    "browserName": "Safari",
+    "appium:platformVersion": "17.0",
     "appium:deviceName": "iPad Simulator",
     "appium:mobile": true,
     "appium:automationName": "XCUITest",


### PR DESCRIPTION
We have a PR that we had to revert because of issues in our Sauce Labs versions of iOS (fine on newer versions): https://github.com/code-dot-org/code-dot-org/pull/71769

Darin advised that we are safe to move to iOS 17 per our latest usage data, so doing that here!

## Links

- [Slack discussion](https://codedotorg.slack.com/archives/C0T0PNTM3/p1774965258271039?thread_ts=1774897746.954159&cid=C0T0PNTM3)
- Config updates (including capitalized "Safari") found via Sauce Labs "Platform Configurator": https://saucelabs.com/platform-configurator

## Testing story

Tests passing via the [test ios] flag.