### PR TITLE
Fix theme CSS selectors to support nested data-theme attributes

### DIFF
--- a/frontend/packages/component-library-styles/colors.css
+++ b/frontend/packages/component-library-styles/colors.css
@@ -135,7 +135,8 @@
 */
 /* stylelint-disable color-hex-length */
 [data-brand='codeai']:root,
-[data-brand='codeai'][data-theme='Light'] {
+[data-brand='codeai'][data-theme='Light'],
+[data-brand='codeai'] [data-theme='Light'] {
   --background-accent-orange-light: #fff0f7;
   --background-accent-orange-primary: #ff69b4;
   --background-accent-orange-strong: #b02e6c;
@@ -246,7 +247,8 @@
 }
 
 /* Alternative brand — Dark theme overrides (ALL pink for visual auditing) */
-[data-brand='codeai'][data-theme='Dark'] {
+[data-brand='codeai'][data-theme='Dark'],
+[data-brand='codeai'] [data-theme='Dark'] {
   --background-accent-orange-light: #6e1543;
   --background-accent-orange-primary: #ff69b4;
   --background-accent-orange-strong: #ff8fc9;


### PR DESCRIPTION
## Summary
- Add descendant selectors for brand theme overrides so that light/dark theme variables apply when `data-theme` is set on a child element, not only when it's on the same element as the brand attribute.
- This prevents parent-level theme definitions from being ignored when a theme is applied at a lower level in the page structure.

## Test plan
- [x] Verify that setting `data-theme` on a nested element correctly applies the expected theme CSS variables
- [x] Verify that existing same-element `data-theme` usage still works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)