### PR TITLE
Wire up brand router logo on project share pages

### DIFF
--- a/dashboard/app/views/layouts/_header.html.haml
+++ b/dashboard/app/views/layouts/_header.html.haml
@@ -76,9 +76,9 @@
       .header_left
         .header_logo
           - if current_user
-            = link_to(image_tag(Cdo::Brand.logo_filename(request), alt: Cdo::Brand.logo_alt_text(request)), home_path, {id: "logo_home_link"})
+            = link_to(image_tag(Cdo::Brand.header_logo_filename(request), alt: Cdo::Brand.logo_alt_text(request)), home_path, {id: "logo_home_link"})
           - else
-            = link_to(image_tag(Cdo::Brand.logo_filename(request), alt: Cdo::Brand.logo_alt_text(request)), Cdo::Brand.marketing_url(ge_region: request.ge_region), {id: "logo_home_link"})
+            = link_to(image_tag(Cdo::Brand.header_logo_filename(request), alt: Cdo::Brand.logo_alt_text(request)), Cdo::Brand.marketing_url(ge_region: request.ge_region), {id: "logo_home_link"})
 
       .header_middle{dir: locale_dir}
         - if should_show_progress || level

--- a/dashboard/app/views/layouts/_logo.html.haml
+++ b/dashboard/app/views/layouts/_logo.html.haml
@@ -1,6 +1,6 @@
 %div{id: 'main-logo'}
   %div{id: 'logo-container'}
     - if current_user
-      = link_to(image_tag('logo.svg'), '/home', {id: "logo-img", alt: I18n.t(:code_org_logo_alt)})
+      = link_to(image_tag(Cdo::Brand.logo_filename(request)), '/home', {id: "logo-img", alt: Cdo::Brand.logo_alt_text(request)})
     - else
-      = link_to(image_tag('logo.svg'), CDO.code_org_url, {id: "logo-img", alt: I18n.t(:code_org_logo_alt)})
+      = link_to(image_tag(Cdo::Brand.logo_filename(request)), CDO.code_org_url, {id: "logo-img", alt: Cdo::Brand.logo_alt_text(request)})

--- a/dashboard/test/lib/brand_test.rb
+++ b/dashboard/test/lib/brand_test.rb
@@ -50,7 +50,14 @@ class BrandTest < ActiveSupport::TestCase
     DCDO.stubs(:get).with('brand-router-enabled', false).returns(true)
     request = mock_request(params: {'brand' => 'codeai'})
     assert_equal 'logo.svg', Cdo::Brand.logo_filename(request)
-    assert_equal 'logo-inverse.svg', Cdo::Brand.logo_filename
+    assert_equal 'logo.svg', Cdo::Brand.logo_filename
+  end
+
+  test 'header_logo_filename returns correct value per brand' do
+    DCDO.stubs(:get).with('brand-router-enabled', false).returns(true)
+    request = mock_request(params: {'brand' => 'codeai'})
+    assert_equal 'logo.svg', Cdo::Brand.header_logo_filename(request)
+    assert_equal 'logo-inverse.svg', Cdo::Brand.header_logo_filename
   end
 
   test 'legal_name returns correct value per brand' do

--- a/lib/cdo/brand.rb
+++ b/lib/cdo/brand.rb
@@ -17,7 +17,8 @@ module Cdo
     # Brand configurations keyed by brand code
     BRANDS = {
       BRAND_CODE_ORG => {
-        logo_filename: 'logo-inverse.svg',
+        logo_filename: 'logo.svg',
+        header_logo_filename: 'logo-inverse.svg',
         logo_alt_key: :code_org_logo_alt,
         favicon: 'favicon.ico',
         legal_name: 'Code.org',
@@ -25,6 +26,7 @@ module Cdo
       },
       BRAND_CODEAI => {
         logo_filename: 'logo.svg',
+        header_logo_filename: 'logo.svg',
         logo_alt_key: :code_org_logo_alt,
         favicon: 'favicon.ico',
         legal_name: 'Code.ai',
@@ -50,9 +52,14 @@ module Cdo
       BRANDS[brand_code] || BRANDS[BRAND_CODE_ORG]
     end
 
-    # Get the logo filename for the current brand
+    # Get the logo filename for the current brand (used on share pages)
     def self.logo_filename(request = nil)
       current_brand_configuration(request)[:logo_filename]
+    end
+
+    # Get the header logo filename for the current brand (used in the site header)
+    def self.header_logo_filename(request = nil)
+      current_brand_configuration(request)[:header_logo_filename]
     end
 
     # Get the I18n key for the logo alt text


### PR DESCRIPTION
## Summary
- **Split `logo_filename` into two brand config keys**: `logo_filename` (share pages) and `header_logo_filename` (site header), since these contexts require different logo variants (e.g. inverted logo for the dark header background).
- **Wired up the share page logo partial** (`_logo.html.haml`) to use `Cdo::Brand.logo_filename(request)` instead of a hardcoded `'logo.svg'`, so the correct brand logo is displayed on project share pages (e.g. `/projects/pythonlab/...`, `/projects/applab/...`).
- **Updated `_header.html.haml`** to use the new `header_logo_filename` accessor.
- **Added tests** for the new `header_logo_filename` method.

## Context
The `_logo.html.haml` partial (used exclusively on share pages) was hardcoded to `'logo.svg'` and did not consult the brand router at all. The site header already used `Cdo::Brand.logo_filename`, but both contexts shared the same config value, which doesn't work since the header needs an inverted logo variant for its dark background.

## Test plan
- [x] Visit a project share page (e.g. `/projects/applab/<id>`) with `?brand=codeai` — should show the codeai logo
- [x] Visit a project share page with `?brand=code` — should show the code.org logo
- [x] Visit a regular page (non-share) — header logo should still render correctly for both brands
- [x] `bundle exec ruby -Itest test/lib/brand_test.rb` passes (10 tests, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)