### PR TITLE
Show friendly Argo links for dashboard ingress

### DIFF
--- a/k8s/helm/templates/dashboard/ingress.yaml
+++ b/k8s/helm/templates/dashboard/ingress.yaml
@@ -2,6 +2,13 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ include "cdo.fullname" (merge (dict "component" "dashboard") .) }}
+  {{- $locals := index .Values "locals.yml" | default (dict) }}
+  {{- $overrideDashboard := index $locals "override_dashboard" | default "" }}
+  {{- if $overrideDashboard }}
+  annotations:
+    argocd.argoproj.io/ignore-default-links: "true"
+    link.argocd.argoproj.io/external-link: {{ printf "https://%s/" $overrideDashboard | quote }}
+  {{- end }}
   labels:
     {{ include "cdo.labels" (merge (dict "component" "dashboard") .) | nindent 4 }}
     code.ai/dns-name: {{ .Values.dnsName }}

--- a/k8s/kustomize/base/dashboard-ingress.yaml
+++ b/k8s/kustomize/base/dashboard-ingress.yaml
@@ -2,6 +2,9 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: cdo-dashboard
+  annotations:
+    argocd.argoproj.io/ignore-default-links: "true"
+    link.argocd.argoproj.io/external-link: https://studio-development.k8s.code.org/
   labels:
     app.kubernetes.io/component: dashboard
     code.ai/dns-name: studio-development


### PR DESCRIPTION
Argo CD currently surfaces the raw ELB hostname for the dashboard ingress, which is not the URL people actually use and can be misleading when HTTP or internal-facing addresses are involved. This teaches the ingress resources to advertise the ExternalDNS-backed hostname instead, so the Argo UI points people at the real entrypoint.

Technical changes:
- add Argo external-link annotations to the Helm dashboard ingress when `locals.yml.override_dashboard` is set
- hide Argo's autogenerated default ingress links in that Helm path so the friendly HTTPS URL wins
- add the same Argo link annotations to the kustomize base dashboard ingress for the development path