### PR TITLE
Manually add pokedex dataset for seeding.

### DIFF
--- a/dashboard/config/datablock_storage/datasets/pokedex.json
+++ b/dashboard/config/datablock_storage/datasets/pokedex.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:12d150b919b3bf652bc7232a966a85609ed979f19c54f6929374fd03d940d546
+size 141145


### PR DESCRIPTION
<!--
  Summary of the change: background, motivation, and context.
  Include screenshots, videos, or before/after comparisons for UI changes.
-->

For some reason, the new Pokédex dataset failed to serialize to disk on levelbuilder, and therefore never made it through the pipeline and seeded the new dataset into datablock_storage_tables. The manifest updated properly, so the dataset shows up in the data library in app lab, but fails to import. 

This PR manually adds the dataset to the filesystem to be seeded in prod so the dataset will successfully import from the dataset library in app lab.

## Links
<!-- Jira tickets, design docs, Slack threads, related PRs, etc. -->

- [slack](https://codedotorg.slack.com/archives/C0T0PNTM3/p1775171330858919)

## Testing story
<!-- How was this tested? Manual steps, adhoc links, automated tests, or why testing isn't needed. -->

ran `bundle exec rake seed:datablock_storage` and successfully imported the Pokédex dataset in app lab locally. 

<img width="1356" height="620" alt="image" src="https://github.com/user-attachments/assets/452a4c6c-e5c5-4fb6-b20a-af7aa7886a35" />

## Deployment notes
<!-- Delete this section if it's a standard merge-and-deploy.
     Otherwise: migrations, feature flags, coordination, caching impacts, etc. -->


