### PR TITLE
Fix broken manifest edit link in levelbuilder

### DIFF
--- a/apps/src/storage/levelbuilder/DatasetList.jsx
+++ b/apps/src/storage/levelbuilder/DatasetList.jsx
@@ -48,7 +48,7 @@ class DatasetList extends React.Component {
         <p>
           After adding a new dataset, you'll need to{' '}
           <a href="../data_docs/edit">add documentation</a> and{' '}
-          <a href="./manifest/edit">edit the manifest</a>.
+          <a href="/datasets/manifest/edit">edit the manifest</a>.
         </p>
       </div>
     );


### PR DESCRIPTION
<!--
  Summary of the change: background, motivation, and context.
  Include screenshots, videos, or before/after comparisons for UI changes.
-->

It looks like folks are using [this doc](https://docs.google.com/document/d/1zYSFBQFDawhrYpTzYglFhVEALHXc6tjBSXn_aOgVlkY/edit?tab=t.0) anyway which links to the right page for editing the manifest but there's a link at the bottom of the datasets page in levelbuilder that was broken and bothering me so here I fixed it.

## Testing story
<!-- How was this tested? Manual steps, adhoc links, automated tests, or why testing isn't needed. -->

<img width="956" height="475" alt="image" src="https://github.com/user-attachments/assets/8e92ea80-b53b-4a1c-8eae-e392c53e0b39" />


