### PR TITLE
Web Lab: catch buffer.from error

### DIFF
--- a/apps/src/weblab/CdoBramble.js
+++ b/apps/src/weblab/CdoBramble.js
@@ -496,7 +496,7 @@ export default class CdoBramble {
       })
       .fail((_xhr, _textStatus, err) => {
         console.error(`CdoBramble unable to download file at ${url}. ${err}`);
-        callback(null, err);
+        callback(null, err || 'Unknown error');
       });
   }
 

--- a/apps/src/weblab/CdoBramble.js
+++ b/apps/src/weblab/CdoBramble.js
@@ -469,19 +469,21 @@ export default class CdoBramble {
   }
 
   writeFileData(path, data, callback) {
-    this.fileSystem().writeFile(
-      path,
-      Buffer.from(data),
-      {encoding: null},
-      err => {
-        err &&
-          console.error(
-            `CdoBramble unable to write ${path} to Bramble. ${err}`
-          );
+    let buffer;
+    try {
+      buffer = Buffer.from(data);
+    } catch (err) {
+      console.error(`CdoBramble unable to write ${path} to Bramble. ${err}`);
+      callback(err);
+      return;
+    }
 
-        callback(err);
-      }
-    );
+    this.fileSystem().writeFile(path, buffer, {encoding: null}, err => {
+      err &&
+        console.error(`CdoBramble unable to write ${path} to Bramble. ${err}`);
+
+      callback(err);
+    });
   }
 
   downloadFile(url, callback) {

--- a/apps/test/unit/weblab/CdoBrambleTest.js
+++ b/apps/test/unit/weblab/CdoBrambleTest.js
@@ -834,6 +834,47 @@ describe('CdoBramble', () => {
     });
   });
 
+  describe('writeFileData', () => {
+    let writeFileStub;
+
+    beforeEach(() => {
+      writeFileStub = sinon.stub();
+      sinon.stub(cdoBramble, 'fileSystem').returns({writeFile: writeFileStub});
+    });
+
+    afterEach(() => {
+      sinon.restore();
+    });
+
+    it('logs and calls callback with TypeError when data is a plain object', () => {
+      const callbackSpy = sinon.spy();
+
+      cdoBramble.writeFileData(
+        '/project/123/index.html',
+        {someKey: 'someValue'},
+        callbackSpy
+      );
+
+      expect(callbackSpy).to.have.been.calledOnce;
+      expect(callbackSpy.firstCall.args[0]?.name).to.equal('TypeError');
+      expect(console.error).to.have.been.calledOnce;
+    });
+
+    it('does not throw when data is a string', done => {
+      writeFileStub.callsFake((_path, _data, _opts, callback) =>
+        callback(null)
+      );
+      cdoBramble.writeFileData(
+        '/project/123/index.html',
+        '<html></html>',
+        err => {
+          expect(err).to.be.null;
+          done();
+        }
+      );
+    });
+  });
+
   describe('getConcatenatedCodeString', () => {
     beforeEach(() => {
       const openDocuments = [


### PR DESCRIPTION
We are seeing the following error on prod web lab projects that are being blocked by recent changes:
`Uncaught TypeError: The first argument must be one of type string, Buffer, ArrayBuffer, Array, or Array-like Object. Received type object`.
The error points to `CdoBramble.js`, in `writeFileData`. We still want to block these projects, but don't want to crash the page. Unfortunately I can't repro this locally, as locally the response seems to be different from prod.

However, this fix should resolve the thrown error and is very safe. I added unit tests to reproduce the behavior seen on prod and confirmed they now behave as expected.

## Links
- [Slack](https://codedotorg.slack.com/archives/C03DBDN67B7/p1775231644224799)

## Testing story
Tested via unit tests as I could not repro.


