### PR TITLE
Fix resizing of JS Debugger in App Lab

### DIFF
--- a/apps/src/lib/tools/jsdebugger/JsDebugger.jsx
+++ b/apps/src/lib/tools/jsdebugger/JsDebugger.jsx
@@ -268,7 +268,7 @@ class JsDebugger extends React.Component {
 
   onMouseDownDebugResizeBar = event => {
     // When we see a mouse down in the resize bar, start tracking mouse moves:
-    const eventSourceElm = event.srcElement || event.target;
+    const eventSourceElm = event.srcElement || event.currentTarget;
     if (eventSourceElm.id === 'debugResizeBar') {
       this._draggingDebugResizeBar = true;
       document.body.addEventListener(
@@ -344,7 +344,7 @@ class JsDebugger extends React.Component {
 
   onMouseDownWatchersResizeBar = event => {
     // When we see a mouse down in the resize bar, start tracking mouse moves:
-    const eventSourceElm = event.srcElement || event.target;
+    const eventSourceElm = event.srcElement || event.currentTarget;
     if (eventSourceElm.id === 'watchersResizeBar') {
       this._draggingWatchersResizeBar = true;
       document.body.addEventListener(

--- a/apps/src/lib/tools/jsdebugger/JsDebugger.jsx
+++ b/apps/src/lib/tools/jsdebugger/JsDebugger.jsx
@@ -267,24 +267,17 @@ class JsDebugger extends React.Component {
   onTransitionEnd = () => this.setState({transitionType: null});
 
   onMouseDownDebugResizeBar = event => {
-    // When we see a mouse down in the resize bar, start tracking mouse moves:
-    const eventSourceElm = event.srcElement || event.currentTarget;
-    if (eventSourceElm.id === 'debugResizeBar') {
-      this._draggingDebugResizeBar = true;
+    this._draggingDebugResizeBar = true;
+    document.body.addEventListener('mousemove', this.onMouseMoveDebugResizeBar);
+    const mouseMoveTouchEventName = dom.getTouchEventName('mousemove');
+    if (mouseMoveTouchEventName) {
       document.body.addEventListener(
-        'mousemove',
+        mouseMoveTouchEventName,
         this.onMouseMoveDebugResizeBar
       );
-      const mouseMoveTouchEventName = dom.getTouchEventName('mousemove');
-      if (mouseMoveTouchEventName) {
-        document.body.addEventListener(
-          mouseMoveTouchEventName,
-          this.onMouseMoveDebugResizeBar
-        );
-      }
-
-      event.preventDefault();
     }
+
+    event.preventDefault();
   };
 
   setDebugHeight = height => {
@@ -343,24 +336,20 @@ class JsDebugger extends React.Component {
   };
 
   onMouseDownWatchersResizeBar = event => {
-    // When we see a mouse down in the resize bar, start tracking mouse moves:
-    const eventSourceElm = event.srcElement || event.currentTarget;
-    if (eventSourceElm.id === 'watchersResizeBar') {
-      this._draggingWatchersResizeBar = true;
+    this._draggingWatchersResizeBar = true;
+    document.body.addEventListener(
+      'mousemove',
+      this.onMouseMoveWatchersResizeBar
+    );
+    const mouseMoveTouchEventName = dom.getTouchEventName('mousemove');
+    if (mouseMoveTouchEventName) {
       document.body.addEventListener(
-        'mousemove',
+        mouseMoveTouchEventName,
         this.onMouseMoveWatchersResizeBar
       );
-      const mouseMoveTouchEventName = dom.getTouchEventName('mousemove');
-      if (mouseMoveTouchEventName) {
-        document.body.addEventListener(
-          mouseMoveTouchEventName,
-          this.onMouseMoveWatchersResizeBar
-        );
-      }
-
-      event.preventDefault();
     }
+
+    event.preventDefault();
   };
 
   onMouseUpWatchersResizeBar = () => {


### PR DESCRIPTION
We regressed resizing of the JS Debugger when we added a new `i` tag for some FontAwesome work here: https://github.com/code-dot-org/code-dot-org/pull/71646

The problem was introduced because the logic uses the `event.target` to get the ID, which is now the new inner `i` element instead of the element with id `debugResizeBar`. This could also be fixed by just switching from target to currentTarget (currentTarget returns the ID of the element with the click handler attached), but to simplify things, I remove an unnecessary (🤞 ) if statement that gates logic based on the source element ID, which is guaranteed because these handlers are tied to the source elements with the given ID. I have the simpler version in an initial commit, if folks prefer that.

## Links

- [Slack discussion](https://codedotorg.slack.com/archives/C03DBDN67B7/p1775229299587869)

## Testing story

Tested manually that I can now resize the debugger area via drag.