### PR TITLE
Fix Violations of and Reenable `Style/SuperArguments` and `Style/SuperWithArgsParentheses`

### DIFF
--- a/.config/rubocop/todo.yml
+++ b/.config/rubocop/todo.yml
@@ -417,16 +417,6 @@ Style/StringConcatenation:
 Style/StringLiteralsInInterpolation:
   Enabled: false
 
-# Offense count: 30
-# This cop supports safe autocorrection (--autocorrect).
-Style/SuperArguments:
-  Enabled: false
-
-# Offense count: 9
-# This cop supports safe autocorrection (--autocorrect).
-Style/SuperWithArgsParentheses:
-  Enabled: false
-
 # Offense count: 31
 # This cop supports safe autocorrection (--autocorrect).
 # Configuration parameters: EnforcedStyle, AllowSafeAssignment.

--- a/cookbooks/cdo-repository/libraries/git.rb
+++ b/cookbooks/cdo-repository/libraries/git.rb
@@ -11,7 +11,7 @@ module Cdo
   module Provider
     class Git < Chef::Provider::Git
       def initialize(new_resource, run_context)
-        super new_resource, run_context
+        super
         # `checkout_branch` is always `false`, since this provider always skips the extra checkout step.
         new_resource.enable_checkout false
       end

--- a/dashboard/app/helpers/aichat_ruby_types.rb
+++ b/dashboard/app/helpers/aichat_ruby_types.rb
@@ -238,7 +238,7 @@ module AichatRubyTypes
           kwargs.each do |name, value|
             AichatRubyTypes.assert_value_is_type(value, value_type, name)
           end
-          super(**kwargs)
+          super
         end
       end
 
@@ -274,7 +274,7 @@ module AichatRubyTypes
           types.each do |name, type|
             AichatRubyTypes.assert_value_is_type(kwargs[name], type, name)
           end
-          super(**kwargs)
+          super
         end
       end
 

--- a/dashboard/app/mailers/pd/application/teacher_application_mailer.rb
+++ b/dashboard/app/mailers/pd/application/teacher_application_mailer.rb
@@ -161,7 +161,7 @@ module Pd::Application
 
     # Remove empty params. This can happen when the regional partner contact info is missing
     protected def mail(params)
-      super params.compact
+      super(params.compact)
     end
   end
 end

--- a/dashboard/app/models/concerns/pd/facilitator_specific_form.rb
+++ b/dashboard/app/models/concerns/pd/facilitator_specific_form.rb
@@ -87,7 +87,7 @@ module Pd::FacilitatorSpecificForm
       hash[field][facilitator] = hash.delete(field_name)
     end
 
-    super(hash)
+    super
   end
 
   # Get a summary of the form data hash specific to a facilitator

--- a/dashboard/app/models/levels/blockly.rb
+++ b/dashboard/app/models/levels/blockly.rb
@@ -112,7 +112,7 @@ class Blockly < Level
   end
 
   def to_xml(options = {})
-    xml_node = Nokogiri::XML(super(options))
+    xml_node = Nokogiri::XML(super)
     Nokogiri::XML::Builder.with(xml_node.at(type)) do |xml|
       xml.blocks do
         xml_blocks.each do |attr|
@@ -125,7 +125,7 @@ class Blockly < Level
 
   def load_level_xml(xml_node)
     block_nodes = xml_blocks.count > 0 ? xml_node.xpath(xml_blocks.map {|x| '//' + x}.join(' | ')).map(&:remove) : []
-    level_properties = super(xml_node)
+    level_properties = super
     block_nodes.each do |attr_node|
       level_properties[attr_node.name] = attr_node.child.serialize(save_with: XML_OPTIONS).strip
     end
@@ -908,7 +908,7 @@ class Blockly < Level
 
   # Clear 'is_project_level' from cloned levels
   def clone_with_name(name, editor_experiment: nil)
-    level = super(name, editor_experiment: editor_experiment)
+    level = super
     level.update!(is_project_level: false)
     level
   end

--- a/dashboard/app/models/levels/bubble_choice.rb
+++ b/dashboard/app/models/levels/bubble_choice.rb
@@ -296,7 +296,7 @@ class BubbleChoice < DSLDefined
   end
 
   def clone_with_suffix(new_suffix, editor_experiment: nil)
-    level = super(new_suffix, editor_experiment: editor_experiment)
+    level = super
 
     level.rewrite_dsl_file(BubbleChoiceDSL.serialize(level))
     level
@@ -304,7 +304,7 @@ class BubbleChoice < DSLDefined
 
   def self.setup(data, md5)
     sublevel_names = data[:properties].delete(:sublevels)
-    level = super(data, md5)
+    level = super
     level.setup_sublevels(sublevel_names)
     level
   end

--- a/dashboard/app/models/levels/dsl_defined.rb
+++ b/dashboard/app/models/levels/dsl_defined.rb
@@ -206,7 +206,7 @@ class DSLDefined < Level
     if params[:dsl_text].present?
       self.class.create_from_level_builder({dsl_text: params.delete(:dsl_text)}, params, name)
     else
-      super(params)
+      super
     end
   end
 

--- a/dashboard/app/models/levels/grid.rb
+++ b/dashboard/app/models/levels/grid.rb
@@ -87,6 +87,6 @@ class Grid < Blockly
       prop = level_hash['properties']
       prop[maze_type] = prop[maze_type].to_json if prop[maze_type].is_a?(Array)
     end
-    super(level_hash)
+    super
   end
 end

--- a/dashboard/app/models/levels/level_group.rb
+++ b/dashboard/app/models/levels/level_group.rb
@@ -121,7 +121,7 @@ class LevelGroup < DSLDefined
   end
 
   def self.setup(data, md5)
-    level = super(data, md5)
+    level = super
 
     levels_and_texts_by_page = data[:pages].map do |page|
       page[:levels].map do |level_name|
@@ -161,7 +161,7 @@ class LevelGroup < DSLDefined
 
   def assign_attributes(params)
     @pages = nil
-    super(params)
+    super
   end
 
   def plc_evaluation?

--- a/dashboard/app/models/levels/unplugged.rb
+++ b/dashboard/app/models/levels/unplugged.rb
@@ -39,7 +39,7 @@ class Unplugged < Level
     }
     update_i18n(new_attributes[:name], i18n_strings)
 
-    super(new_attributes)
+    super
   end
 
   def title

--- a/dashboard/app/models/pd/survey_question.rb
+++ b/dashboard/app/models/pd/survey_question.rb
@@ -45,7 +45,7 @@ module Pd
     end
 
     def questions=(value)
-      super(value)
+      super
       @form_questions = nil
     end
 

--- a/dashboard/config/initializers/no_transform_paths.rb
+++ b/dashboard/config/initializers/no_transform_paths.rb
@@ -10,7 +10,7 @@ module Cdo
     ).freeze
 
     def serve(request, filepath, content_headers)
-      status, headers, body = super(request, filepath, content_headers)
+      status, headers, body = super
       new_headers = filter_headers(request.path_info, headers)
       return [status, new_headers, body]
     end

--- a/dashboard/config/initializers/refresh_activemodel_cached_attributes.rb
+++ b/dashboard/config/initializers/refresh_activemodel_cached_attributes.rb
@@ -21,7 +21,7 @@ module Cdo
     end
 
     def assign_attributes(new_attributes)
-      super(new_attributes)
+      super
     rescue ActiveModel::UnknownAttributeError
       if new_database_migration_since_initialization?
         # Update migration count so we only try this refresh once.
@@ -36,7 +36,7 @@ module Cdo
         @attributes = self.class._default_attributes.deep_dup
 
         # Try again now that our attributes cache is accurately mirroring the database.
-        super(new_attributes)
+        super
       else
         raise
       end

--- a/dashboard/config/initializers/trackable.rb
+++ b/dashboard/config/initializers/trackable.rb
@@ -1,6 +1,6 @@
 module OverrideUpdateTrackedFields
   def update_tracked_fields(request)
-    super(request)
+    super
     if persisted? && id
       SignIn.create(
         user_id: id,

--- a/dashboard/legacy/middleware/helpers/animation_bucket.rb
+++ b/dashboard/legacy/middleware/helpers/animation_bucket.rb
@@ -5,7 +5,7 @@ require 'cdo/firehose'
 #
 class AnimationBucket < BucketHelper
   def initialize
-    super CDO.animations_s3_bucket, CDO.animations_s3_directory
+    super(CDO.animations_s3_bucket, CDO.animations_s3_directory)
   end
 
   def allowed_file_types

--- a/dashboard/legacy/middleware/helpers/asset_bucket.rb
+++ b/dashboard/legacy/middleware/helpers/asset_bucket.rb
@@ -10,7 +10,7 @@ class AssetBucket < BucketHelper
   end
 
   def initialize
-    super CDO.assets_s3_bucket, CDO.assets_s3_directory
+    super(CDO.assets_s3_bucket, CDO.assets_s3_directory)
   end
 
   def allowed_file_types

--- a/dashboard/legacy/middleware/helpers/file_bucket.rb
+++ b/dashboard/legacy/middleware/helpers/file_bucket.rb
@@ -6,7 +6,7 @@ class FileBucket < BucketHelper
   MAXIMUM_FILENAME_LENGTH = 512
 
   def initialize
-    super CDO.files_s3_bucket, CDO.files_s3_directory
+    super(CDO.files_s3_bucket, CDO.files_s3_directory)
   end
 
   def allowed_file_type?(extension)
@@ -45,7 +45,7 @@ class FileBucket < BucketHelper
   def copy_files(src_channel, dest_channel, options = {})
     # copy everything except the manifest
     options[:exclude_filenames] = [MANIFEST_FILENAME]
-    result = super src_channel, dest_channel, options
+    result = super
     # return right away if there are no files in the source project
     return [] if result.empty?
 

--- a/dashboard/legacy/middleware/helpers/library_bucket.rb
+++ b/dashboard/legacy/middleware/helpers/library_bucket.rb
@@ -3,7 +3,7 @@
 #
 class LibraryBucket < BucketHelper
   def initialize
-    super CDO.libraries_s3_bucket, CDO.libraries_s3_directory
+    super(CDO.libraries_s3_bucket, CDO.libraries_s3_directory)
   end
 
   def allowed_file_types

--- a/dashboard/legacy/middleware/helpers/source_bucket.rb
+++ b/dashboard/legacy/middleware/helpers/source_bucket.rb
@@ -9,7 +9,7 @@ MAIN_JSON_FILENAME = 'main.json'.freeze unless defined? MAIN_JSON_FILENAME
 #
 class SourceBucket < BucketHelper
   def initialize
-    super CDO.sources_s3_bucket, CDO.sources_s3_directory
+    super(CDO.sources_s3_bucket, CDO.sources_s3_directory)
   end
 
   def allowed_file_name?(filename)
@@ -33,7 +33,7 @@ class SourceBucket < BucketHelper
   # Copies the animations at the given version and makes them the current version.
   def restore_previous_version(encrypted_channel_id, filename, version_id, user_id)
     # In most cases fall back on the generic restore behavior.
-    return super(encrypted_channel_id, filename, version_id, user_id) unless filename == MAIN_JSON_FILENAME
+    return super unless filename == MAIN_JSON_FILENAME
 
     owner_id, storage_app_id = get_storage_id_and_project_id(encrypted_channel_id)
     key = s3_path owner_id, storage_app_id, filename

--- a/dashboard/legacy/middleware/net_sim_api.rb
+++ b/dashboard/legacy/middleware/net_sim_api.rb
@@ -62,7 +62,7 @@ class NetSimApi < Sinatra::Base
   @@overridden_redis = nil
 
   def initialize(app = nil)
-    super(app)
+    super
   end
 
   # Return a new RedisTable instance for the given shard_id and table_name.

--- a/dashboard/lib/pd/summary/teacher_summary.rb
+++ b/dashboard/lib/pd/summary/teacher_summary.rb
@@ -2,7 +2,7 @@ module Pd::Summary
   class TeacherSummary
     TeacherAttendanceTotal = Struct.new(:days, :hours) do
       def initialize(days = 0, hours = 0)
-        super(days, hours)
+        super
       end
 
       def add_session(hours)

--- a/dashboard/test/testing/lock_thread.rb
+++ b/dashboard/test/testing/lock_thread.rb
@@ -2,7 +2,7 @@
 # https://github.com/rails/rails/pull/28083
 module ConnectionPoolLockThread
   def initialize(spec)
-    super(spec)
+    super
     @lock_thread = false
   end
 

--- a/dashboard/test/testing/setup_all_and_teardown_all.rb
+++ b/dashboard/test/testing/setup_all_and_teardown_all.rb
@@ -33,7 +33,7 @@ module ActiveSupport
           @instance = run_callbacks :setup_all
           # @time is set by `time_it`, and needs to be removed before the instance is reused.
           @instance.remove_instance_variable :@time
-          super(reporter, options)
+          super
           run_callbacks :teardown_all
         end
 

--- a/lib/cdo/aws/s3.rb
+++ b/lib/cdo/aws/s3.rb
@@ -37,7 +37,7 @@ module AWS
     # An exception class used to wrap the underlying Amazon NoSuchKey exception.
     class NoSuchKey < RuntimeError
       def initialize(message = nil)
-        super(message)
+        super
       end
     end
 

--- a/lib/cdo/cloud_formation/cdo_app.rb
+++ b/lib/cdo/cloud_formation/cdo_app.rb
@@ -51,7 +51,7 @@ module Cdo::CloudFormation
     def initialize(**options)
       options[:stack_name]  ||= CDO.stack_name
       options[:filename]    ||= 'cloud_formation_stack.yml.erb'
-      super(**options)
+      super
       options = @options = OpenStruct.new(options)
 
       # For adhoc stacks only (for now), preserve initial options via 'Op:' CloudFormation tags

--- a/lib/cdo/form.rb
+++ b/lib/cdo/form.rb
@@ -5,7 +5,7 @@ class Form2 < OpenStruct
     params = params.dup
     params[:data] = JSON.parse(params[:data]) if params[:data].present?
     params[:processed_data] = JSON.parse(params[:processed_data]) if params[:processed_data].present?
-    super params
+    super
   end
 
   def self.from_row(row)

--- a/lib/cdo/i18n/plugins/interpolation_l10n.rb
+++ b/lib/cdo/i18n/plugins/interpolation_l10n.rb
@@ -32,7 +32,7 @@ module Cdo
         # Overrides the protected method +I18n::Backend::Base#interpolate+ to localize interpolation values.
         # @see https://github.com/ruby-i18n/i18n/blob/v1.14.1/lib/i18n/backend/base.rb#L181-L200
         protected def interpolate(locale, subject, values = ::I18n::EMPTY_HASH)
-          super locale, subject, localize_interpolation_values(locale, values)
+          super(locale, subject, localize_interpolation_values(locale, values))
         rescue StandardError
           super
         end
@@ -40,7 +40,7 @@ module Cdo
         # Overrides the protected method +I18n::Backend::Base#deep_interpolate+ to localize interpolation values.
         # @see https://github.com/ruby-i18n/i18n/blob/v1.14.1/lib/i18n/backend/base.rb#L202-L224
         protected def deep_interpolate(locale, data, values = ::I18n::EMPTY_HASH)
-          super locale, data, localize_interpolation_values(locale, values)
+          super(locale, data, localize_interpolation_values(locale, values))
         rescue StandardError
           super
         end

--- a/lib/cdo/i18n_backend.rb
+++ b/lib/cdo/i18n_backend.rb
@@ -14,7 +14,7 @@ module Cdo
           options = SmartTranslate.get_smart_translate_options(locale, key, options)
         end
 
-        super(locale, key, options)
+        super
       end
 
       def self.get_smart_translate_options(locale, key, options = ::I18n::EMPTY_HASH)
@@ -122,7 +122,7 @@ module Cdo
       end
 
       def translate(locale, key, options = ::I18n::EMPTY_HASH)
-        result = super(locale, key, options)
+        result = super
         return result if options[:safe_interpolation] == false
 
         # Log unused interpolation arguments to honeybadger; these are likely

--- a/lib/cdo/local_development/s3_emulation/cdo_sound_library/hoc_song_meta/populate.rb
+++ b/lib/cdo/local_development/s3_emulation/cdo_sound_library/hoc_song_meta/populate.rb
@@ -69,7 +69,7 @@ class CdoSoundLibrary::HocSongMeta::Populate
 
   # Hook into the populate call to produce the appropriate mp3 as well.
   def populate(path = nil)
-    data = super(path)
+    data = super
 
     unless path.nil? || path.include?('songManifest') || path.include?('testManifest')
       # This is song metadata so we want some song as well

--- a/lib/cdo/pegasus/actionview_sinatra.rb
+++ b/lib/cdo/pegasus/actionview_sinatra.rb
@@ -55,7 +55,7 @@ module ActionViewSinatra
     def render(options = {}, locals = {})
       # save locals hash for access by the locals method
       @locals = locals
-      super(options, locals)
+      super
     rescue ActionView::Template::Error => exception
       # allow templates to throw a Sinatra::NotFound error to trigger a 404
       raise exception.cause if exception.cause.is_a?(Sinatra::NotFound)

--- a/lib/cdo/rack/request.rb
+++ b/lib/cdo/rack/request.rb
@@ -15,7 +15,7 @@ module Cdo
     end
 
     def trusted_proxy?(ip)
-      super(ip) || TRUSTED_PROXIES.any? do |proxy|
+      super || TRUSTED_PROXIES.any? do |proxy|
         proxy.include?(ip)
       rescue
         false


### PR DESCRIPTION
### [Style/SuperArguments](https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/SuperArguments):

> Checks for redundant argument forwarding when calling super with arguments identical to the method definition.

When `super` is called without arguments it mirrors the method's arguments, and this Cop just enforces that we use that functionality consistently. I'm slightly torn about this one; I do in general prefer explicit over implicit, even when it makes things slightly more verbose. But in this case, I think the value of aligning with standards outweights the potential for obfuscation.

### [Style/SuperWithArgsParentheses](https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/SuperWithArgsParentheses):

> Enforces the presence of parentheses in `super` containing arguments.

This one seems like a clear win on the "explicit is better than implicit" front!

What do y'all think? I'm happy to consider alternatives to either or both of these