### PR TITLE
Add Content Security Policy for codeprojects html file get

### DIFF
--- a/dashboard/legacy/middleware/files_api.rb
+++ b/dashboard/legacy/middleware/files_api.rb
@@ -280,6 +280,7 @@ class FilesApi < Sinatra::Base
     last_modified result[:last_modified]
 
     if code_projects_domain_root_route && html?(response.headers)
+      response.headers['Content-Security-Policy'] = "connect-src 'self'"
       return "<head>\n<script>\nvar encrypted_channel_id='#{encrypted_channel_id}';\n</script>\n<script async src='/weblab/footer.js'></script>\n<link rel='stylesheet' href='/weblab/footer.css'></head>\n" << result[:body].string
     end
 


### PR DESCRIPTION
This adds a Content Security Policy of connect-src: 'self' to files returned from codeprojects (i.e. the web lab share page). We need 'self' so that the footer still works, but can block all other connections. This code is only exercised on the web lab share page, as evidenced by it also being where we add the footer.

## Testing story
I confirmed after this change external links on the share page don't work. The footer links still work as expected.

