### PR TITLE
Bump to bramble v0.1.32

### DIFF
--- a/dashboard/app/controllers/weblab_host_controller.rb
+++ b/dashboard/app/controllers/weblab_host_controller.rb
@@ -1,5 +1,5 @@
 class WeblabHostController < ApplicationController
-  BRAMBLE_URL = 'https://downloads.computinginthecore.org/bramble_0.1.31'
+  BRAMBLE_URL = 'https://downloads.computinginthecore.org/bramble_0.1.32'
   BRAMBLE_LOCALHOST_URL = 'http://127.0.0.1:8000/src'
   STUDIO_URL = CDO.studio_url('', CDO.default_scheme)
 


### PR DESCRIPTION
This bumps our bramble version to include changes from [this PR](https://github.com/code-dot-org/bramble/pull/23). I've created the S3 bucket with this version's changes already, which `BRAMBLE_URL` pulls from. 

## Testing story
Confirmed with this change we see the updated version of bramble being used.


## Deployment notes
The corresponding [bramble PR](https://github.com/code-dot-org/bramble/pull/24) to bump the version is just for accounting; these PRs can be merged in any order. See the bramble readme for more information.
