### PR TITLE
Remove deprecated Azure content moderator key refs

### DIFF
--- a/config.yml.erb
+++ b/config.yml.erb
@@ -207,10 +207,6 @@ crowdin_project_test_mapping:
   codeorg-restricted: codeorg-restricted-test
   hour-of-code: hour-of-code-test
 
-# Azure Content Moderator
-azure_content_moderation_endpoint: https://eastus.api.cognitive.microsoft.com/contentmoderator
-azure_content_moderation_key:
-
 # Azure AI Content Safety
 azure_ai_content_safety_endpoint: https://cdo-ai-content-safety.cognitiveservices.azure.com
 azure_ai_content_safety_key: !Secret

--- a/config/production.yml.erb
+++ b/config/production.yml.erb
@@ -1,4 +1,3 @@
-azure_content_moderation_key: !Secret
 discourse_sso_secret: !Secret
 pardot_password: !Secret
 pardot_user_key: !Secret

--- a/config/test.yml.erb
+++ b/config/test.yml.erb
@@ -8,7 +8,6 @@
 github_webhook_secret: !Secret
 slack_set_last_dtt_green_token: !Secret
 slack_start_build_token: !Secret
-azure_content_moderation_key: !Secret
 saucelabs_authkey: !Secret
 saucelabs_username: !Secret
 puma_control_server_token: !Secret


### PR DESCRIPTION
<!--
  Summary of the change: background, motivation, and context.
  Include screenshots, videos, or before/after comparisons for UI changes.
-->
Follow-up to https://github.com/code-dot-org/code-dot-org/pull/71878 - remove no longer used api keys.


## Links
<!-- Jira tickets, design docs, Slack threads, related PRs, etc. -->

- Jira:

## Testing story
<!-- How was this tested? Manual steps, adhoc links, automated tests, or why testing isn't needed. -->



## Deployment notes
<!-- Delete this section if it's a standard merge-and-deploy.
     Otherwise: migrations, feature flags, coordination, caching impacts, etc. -->



## Privacy and security
<!-- Delete this section if there is no privacy/security impact.
     Otherwise: new PII, auth changes, API surface changes, etc. -->

