### PR TITLE
Appropriately handle ArgumentError: invalid base64 in project routing

### DIFF
--- a/dashboard/legacy/middleware/helpers/projects.rb
+++ b/dashboard/legacy/middleware/helpers/projects.rb
@@ -75,7 +75,7 @@ class Projects
   def get(channel_id)
     begin
       owner, project_id = get_storage_id_and_project_id(channel_id)
-    rescue
+    rescue ArgumentError, OpenSSL::Cipher::CipherError
       raise NotFound, "channel `#{channel_id}` not found"
     end
     row = @table.where(id: project_id).exclude(state: 'deleted').first

--- a/dashboard/legacy/middleware/helpers/projects.rb
+++ b/dashboard/legacy/middleware/helpers/projects.rb
@@ -75,7 +75,8 @@ class Projects
   def get(channel_id)
     begin
       owner, project_id = get_storage_id_and_project_id(channel_id)
-    rescue ArgumentError, OpenSSL::Cipher::CipherError
+    rescue ArgumentError, OpenSSL::Cipher::CipherError => exception
+      CDO.log.warn "Error while decrypting channel_id in projects#get. Channel id: #{channel_id}, Exception: #{exception.message}"
       raise NotFound, "channel `#{channel_id}` not found"
     end
     row = @table.where(id: project_id).exclude(state: 'deleted').first

--- a/dashboard/legacy/middleware/helpers/projects.rb
+++ b/dashboard/legacy/middleware/helpers/projects.rb
@@ -73,7 +73,11 @@ class Projects
   end
 
   def get(channel_id)
-    owner, project_id = get_storage_id_and_project_id(channel_id)
+    begin
+      owner, project_id = get_storage_id_and_project_id(channel_id)
+    rescue
+      raise NotFound, "channel `#{channel_id}` not found"
+    end
     row = @table.where(id: project_id).exclude(state: 'deleted').first
     raise NotFound, "channel `#{channel_id}` not found" unless row
 

--- a/dashboard/legacy/test/middleware/test_channels_base64_error.rb
+++ b/dashboard/legacy/test/middleware/test_channels_base64_error.rb
@@ -20,6 +20,7 @@ class ChannelsBase64ErrorTest < Minitest::Test
   end
 
   private def run_test_cases(channel_id)
+    # We explicitly 404 on GET requests, because those are where users can input invalid channel IDs.
     @channels.get "/v3/channels/#{channel_id}"
     assert_equal 404, @channels.last_response.status
 

--- a/dashboard/legacy/test/middleware/test_channels_base64_error.rb
+++ b/dashboard/legacy/test/middleware/test_channels_base64_error.rb
@@ -24,9 +24,9 @@ class ChannelsBase64ErrorTest < Minitest::Test
     assert_equal 404, @channels.last_response.status
 
     @channels.post "/v3/channels/#{channel_id}", {}.to_json, 'CONTENT_TYPE' => 'application/json;charset=utf-8'
-    assert_equal 404, @channels.last_response.status
+    assert_equal 400, @channels.last_response.status
 
     @channels.delete "/v3/channels/#{channel_id}"
-    assert_equal 404, @channels.last_response.status
+    assert_equal 400, @channels.last_response.status
   end
 end

--- a/dashboard/legacy/test/middleware/test_channels_base64_error.rb
+++ b/dashboard/legacy/test/middleware/test_channels_base64_error.rb
@@ -21,12 +21,12 @@ class ChannelsBase64ErrorTest < Minitest::Test
 
   private def run_test_cases(channel_id)
     @channels.get "/v3/channels/#{channel_id}"
-    assert_equal 400, @channels.last_response.status
+    assert_equal 404, @channels.last_response.status
 
     @channels.post "/v3/channels/#{channel_id}", {}.to_json, 'CONTENT_TYPE' => 'application/json;charset=utf-8'
-    assert_equal 400, @channels.last_response.status
+    assert_equal 404, @channels.last_response.status
 
     @channels.delete "/v3/channels/#{channel_id}"
-    assert_equal 400, @channels.last_response.status
+    assert_equal 404, @channels.last_response.status
   end
 end


### PR DESCRIPTION
If a user puts an invalid channel id in a /projects url, we throw an ArgumentError, which goes to [honeybadger](https://app.honeybadger.io/projects/3240/faults/126523974). This isn't anything wrong on our end, so let's return a 404 instead.

## Links
- [slack](https://codedotorg.slack.com/archives/C0T0PNTM3/p1775250876804619?thread_ts=1775244306.109279&cid=C0T0PNTM3)

## Testing story
Tested that before this change, an invalid url would return an argument error, but after it 404s.


