### PR TITLE
Update UI browser testing matrix for 26-27 school year

### DIFF
--- a/dashboard/test/ui/browsers.json
+++ b/dashboard/test/ui/browsers.json
@@ -5,7 +5,7 @@
     "name": "iPhone",
     "platformName": "iOS",
     "browserName": "Safari",
-    "appium:platformVersion": "17.0",
+    "appium:platformVersion": "18.6",
     "appium:deviceName": "iPhone Simulator",
     "appium:automationName": "XCUITest",
     "appium:mobile": true,
@@ -17,7 +17,7 @@
     "name": "iPad",
     "platformName": "iOS",
     "browserName": "Safari",
-    "appium:platformVersion": "17.0",
+    "appium:platformVersion": "18.6",
     "appium:deviceName": "iPad Simulator",
     "appium:mobile": true,
     "appium:automationName": "XCUITest",
@@ -28,7 +28,7 @@
   {
     "name": "Chrome",
     "browserName": "chrome",
-    "browserVersion": "109",
+    "browserVersion": "138",
     "platformName": "Windows 10",
     "sauce:options": {
       "screenResolution": "1280x1024",
@@ -38,13 +38,13 @@
   {
     "name": "Safari",
     "browserName": "Safari",
-    "browserVersion": "17",
-    "platformName": "macOS 13"
+    "browserVersion": "18",
+    "platformName": "macOS 15"
   },
   {
     "name": "Firefox",
     "browserName": "firefox",
-    "browserVersion": "115",
+    "browserVersion": "128",
     "platformName": "Windows 11"
   }
 ]


### PR DESCRIPTION
## Summary

Updates our SauceLabs automated test browser matrix to align with our School Year 26-27 browser support strategy. We officially support browsers and operating systems representing p95 of studio.code.org traffic (excluding US traffic to better serve global audience expansion).

### Changes

| Browser | Previous | Updated |
|---------|----------|---------|
| iPhone (Mobile Safari) | iOS 17.0 | iOS 18.6 |
| iPad (Mobile Safari) | iOS 17.0 | iOS 18.6 |
| Chrome | 109 on Windows 10 | 138 on Windows 10 |
| Safari | 17 on macOS 13 | 18 on macOS 15 |
| Firefox | 115 on Windows 11 | 128 on Windows 11 |

### Rationale

- **iOS 18**: All prior iOS versions are EOL and outside p95 of non-US usage.
- **Chrome 138**: Versions 103 and 109 are EOL devices no longer receiving updates (~2% of traffic). The next oldest version in p95 is 138.
- **Safari 18**: Aligns with the iOS 18 minimum and current macOS support.
- **macOS 15**: Upgraded to latest available on SauceLabs (Sequoia) that supports Safari 18 (macOS 26 on SauceLabs only supports Safari 26)
- **Firefox 128**: Current Extended Support Release (ESR) base, which shows up in traffic from schools running managed Firefox installs.

### Not included (future considerations)

- **Edge testing** (v139+) — represents 15%+ of users, worth considering as a separate effort.
- **Android testing** — equivalent user share to iOS, may warrant adding mobile-size tests.

## Test plan

Simplest way to verify this change is to let it hit the DTT and be prepared to revert if unexpected failures arise.