### PR TITLE
Revert "Update `eyes_selenium` to 6.0"

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -119,7 +119,7 @@ group :development, :test do
 
   # For UI testing.
   gem 'cucumber'
-  gem 'eyes_selenium', '~> 6.0.4' # required for Ruby 3.2 support
+  gem 'eyes_selenium', '~> 4.0'
   gem 'fakefs', '~> 2.5.0', require: false
   gem 'minitest', '~> 5.15'
   gem 'minitest-around'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -422,22 +422,22 @@ GEM
     eventmachine (1.2.7)
     execjs (2.7.0)
     exifr (1.2.5)
-    eyes_core (6.0.4)
+    eyes_core (4.6.3)
       colorize
-      eyes_universal (~> 4.7.0)
+      eyes_universal (~> 3.3.3)
       faraday
       faraday-cookie_jar
       faraday_middleware
       oj
       sorted_set
       websocket
-    eyes_selenium (6.0.4)
+    eyes_selenium (4.6.3)
       crass
       css_parser
-      eyes_core (= 6.0.4)
+      eyes_core (= 4.6.3)
       selenium-webdriver (>= 3)
-      state_machines
-    eyes_universal (4.7.0)
+      state_machine
+    eyes_universal (3.3.3)
     factory_bot (6.2.1)
       activesupport (>= 5.0.0)
     factory_bot_rails (6.2.0)
@@ -460,9 +460,9 @@ GEM
       faraday-rack (~> 1.0)
       faraday-retry (~> 1.0)
       ruby2_keywords (>= 0.0.4)
-    faraday-cookie_jar (0.0.8)
+    faraday-cookie_jar (0.0.7)
       faraday (>= 0.8.0)
-      http-cookie (>= 1.0.0)
+      http-cookie (~> 1.0.0)
     faraday-em_http (1.0.0)
     faraday-em_synchrony (1.0.0)
     faraday-excon (1.1.0)
@@ -1128,7 +1128,7 @@ GEM
     sshkit (1.20.0)
       net-scp (>= 1.1.2)
       net-ssh (>= 2.8.0)
-    state_machines (0.20.0)
+    state_machine (1.2.0)
     statsig (2.5.5)
       concurrent-ruby (~> 1.1)
       connection_pool (~> 2.4, >= 2.4.1)
@@ -1279,7 +1279,7 @@ DEPENDENCIES
   dotiw
   drb
   execjs
-  eyes_selenium (~> 6.0.4)
+  eyes_selenium (~> 4.0)
   factory_bot_rails (~> 6.2)
   fakefs (~> 2.5.0)
   faker (~> 3.4)


### PR DESCRIPTION
Reverts code-dot-org/code-dot-org#71433

We confirmed that most (but not all!) of the potential issues encountered in manual testing also manifest in the DTT. Reverting to keep the pipeline unblocked while

See slack thread [here](https://codedotorg.slack.com/archives/C03CK49G9/p1775251915155639) for more details, and test run status page [here](https://cucumber-logs.s3.amazonaws.com/test/test/test_status_Eyes.html?versionId=JGN_BnZdMv7jjRIBBwWC9kBZWvLpOR.V) to identify good repro cases for failing tests