### PR TITLE
argocd-bootstrap.tf: restore bin/argocd-bootstrap (k8s/reorg)

### DIFF
--- a/k8s/tofu/codeai-k8s/cluster-infra-argocd/argocd-bootstrap.tf
+++ b/k8s/tofu/codeai-k8s/cluster-infra-argocd/argocd-bootstrap.tf
@@ -1,8 +1,9 @@
 #===============================================================
 # Bootstrap Argo CD itself from the default branch of k8s-gitops.
 #
-# After this initial install, Argo CD will self-manage the same chart
-# from apps/infra/argocd/chart in the gitops repo.
+# The Ruby entrypoint owns the bootstrap-side Helm lifecycle:
+#   - apply: install/bootstrap only; refuse Helm upgrades of an existing Argo
+#   - destroy: reconcile Helm to latest git, then let Helm own final uninstall
 #===============================================================
 
 data "github_repository" "k8s_gitops" {
@@ -14,55 +15,83 @@ data "github_branch" "k8s_gitops_default" {
   branch     = data.github_repository.k8s_gitops.default_branch
 }
 
-resource "terraform_data" "argocd_bootstrap_checkout" {
-  triggers_replace = [
-    data.github_repository.k8s_gitops.default_branch,
-    data.github_branch.k8s_gitops_default.sha,
+removed {
+  from = terraform_data.argocd_bootstrap_checkout
+
+  lifecycle {
+    destroy = false
+  }
+}
+
+removed {
+  from = helm_release.argocd_bootstrap
+
+  lifecycle {
+    destroy = false
+  }
+}
+
+# We bootsrap ArgoCD onto the cluster using helm. Why not use helm_release in tofu
+# you ask? Why do this script monstrosity? Because ArgoCD actually manages itself
+# after bootstrap, including upgrades etc. But it cannot delete itself because it
+# stumbles and wedges as it deletes itself using itself. So we need helm to do the
+# final deletion. OK, fine, helm_release would do that...right?
+#
+# BUT, ArgoCD has been upgrading and changing itself for... years? So the release
+# might not delete all the NEW shaped pods etc in ArgoCD 2037 space edition.
+#
+# As a result, before the final `helm uninstall` we FIRST need to download the
+# latest version of the chart (same version ArgoCD uses for itself), and helm upgrade.
+# And to do that, my friends, requires a script. So its all script. Ugh, but whatevs,
+# bootstrap is a little weird.
+resource "terraform_data" "argocd_bootstrap" {
+  input = {
+    repo_url                           = "https://github.com/code-dot-org/k8s-gitops.git"
+    default_branch                     = data.github_repository.k8s_gitops.default_branch
+    argocd_chart_path                  = "apps/infra/argocd/chart"
+    release_name                       = "argocd"
+    namespace                          = "argocd"
+    cluster_name                       = local.cluster_name
+    cluster_region                     = local.cluster_region
+    cluster_endpoint                   = local.cluster_endpoint
+    cluster_certificate_authority_data = data.terraform_remote_state.cluster.outputs.cluster_certificate_authority_data
+  }
+
+  depends_on = [
+    terraform_data.legacy_helm_releases_complete,
   ]
 
   provisioner "local-exec" {
     command = <<-EOT
-      set -euo pipefail
-
-      checkout_dir='${path.module}/.terraform/argocd-bootstrap-checkout'
-
-      rm -rf "$checkout_dir"
-      mkdir -p "$(dirname "$checkout_dir")"
-
-      git clone \
-        --depth 1 \
-        --branch '${data.github_repository.k8s_gitops.default_branch}' \
-        --filter=blob:none \
-        --sparse \
-        https://github.com/code-dot-org/k8s-gitops.git \
-        "$checkout_dir"
-
-      git -C "$checkout_dir" sparse-checkout set apps/infra/argocd
+      '${path.module}/bin/argocd-bootstrap' \
+        apply \
+        --repo-url '${self.input.repo_url}' \
+        --default-branch '${self.input.default_branch}' \
+        --argocd-chart-path '${self.input.argocd_chart_path}' \
+        --release-name '${self.input.release_name}' \
+        --namespace '${self.input.namespace}' \
+        --cluster-name '${self.input.cluster_name}' \
+        --cluster-region '${self.input.cluster_region}' \
+        --cluster-endpoint '${self.input.cluster_endpoint}' \
+        --cluster-certificate-authority-data '${self.input.cluster_certificate_authority_data}'
     EOT
   }
 
   provisioner "local-exec" {
-    when    = destroy
-    command = "rm -rf '${path.module}/.terraform/argocd-bootstrap-checkout'"
+    when = destroy
+
+    command = <<-EOT
+      '${path.module}/bin/argocd-bootstrap' \
+        destroy \
+        --repo-url '${self.input.repo_url}' \
+        --default-branch '${self.input.default_branch}' \
+        --argocd-chart-path '${self.input.argocd_chart_path}' \
+        --release-name '${self.input.release_name}' \
+        --namespace '${self.input.namespace}' \
+        --cluster-name '${self.input.cluster_name}' \
+        --cluster-region '${self.input.cluster_region}' \
+        --cluster-endpoint '${self.input.cluster_endpoint}' \
+        --cluster-certificate-authority-data '${self.input.cluster_certificate_authority_data}'
+    EOT
   }
-}
-
-resource "helm_release" "argocd_bootstrap" {
-  name             = "argocd"
-  chart            = "${path.module}/.terraform/argocd-bootstrap-checkout/apps/infra/argocd/chart"
-  namespace        = "argocd"
-  create_namespace = true
-  values = [
-    yamlencode({
-      _bootstrap = {
-        k8s_gitops_revision = data.github_branch.k8s_gitops_default.sha
-      }
-    })
-  ]
-
-  lifecycle {
-    ignore_changes = all
-  }
-
-  depends_on = [terraform_data.argocd_bootstrap_checkout]
 }

--- a/k8s/tofu/codeai-k8s/cluster-infra-argocd/bin/argocd-bootstrap
+++ b/k8s/tofu/codeai-k8s/cluster-infra-argocd/bin/argocd-bootstrap
@@ -1,0 +1,178 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require "fileutils"
+require "json"
+require "open3"
+require "optparse"
+require "tempfile"
+require "time"
+require "tmpdir"
+
+HELM_TIMEOUT = "10m"
+MODULE_DIR = File.expand_path("..", __dir__)
+
+$options = {}
+
+usage = "usage: #{File.basename($PROGRAM_NAME)} <apply|destroy> --repo-url VALUE --default-branch VALUE --argocd-chart-path VALUE --release-name VALUE --namespace VALUE --cluster-name VALUE --cluster-region VALUE --cluster-endpoint VALUE --cluster-certificate-authority-data VALUE"
+mode = ARGV.shift or abort(usage)
+%w[apply destroy].include?(mode) or abort(usage)
+
+OptionParser.new do |opts|
+  opts.on("--repo-url VALUE") {|value| $options[:repo_url] = value}
+  opts.on("--default-branch VALUE") {|value| $options[:default_branch] = value}
+  opts.on("--argocd-chart-path VALUE") {|value| $options[:argocd_chart_path] = value}
+  opts.on("--release-name VALUE") {|value| $options[:release_name] = value}
+  opts.on("--namespace VALUE") {|value| $options[:namespace] = value}
+  opts.on("--cluster-name VALUE") {|value| $options[:cluster_name] = value}
+  opts.on("--cluster-region VALUE") {|value| $options[:cluster_region] = value}
+  opts.on("--cluster-endpoint VALUE") {|value| $options[:cluster_endpoint] = value}
+  opts.on("--cluster-certificate-authority-data VALUE") {|value| $options[:cluster_certificate_authority_data] = value}
+end.parse!(ARGV)
+
+def main(mode)
+  checkout_dir, revision = git_checkout
+
+  if mode == "apply"
+    run_apply(checkout_dir, revision)
+  else
+    run_destroy(checkout_dir, revision)
+  end
+end
+
+# Apply mode bootstraps Argo only: install if missing, but never Helm-upgrade an existing release.
+def run_apply(checkout_dir, revision)
+  if helm_release_exists?
+    log("Helm release '#{$options.fetch(:release_name)}' already exists; refusing Helm upgrade during apply")
+  else
+    log("Installing Helm release '#{$options.fetch(:release_name)}' from git revision #{revision}")
+    helm_upgrade_install!(checkout_dir, revision)
+  end
+end
+
+# Destroy mode is the only place allowed to refresh Helm state before teardown.
+def run_destroy(checkout_dir, revision)
+  if helm_release_exists?
+    log("Refreshing Helm release '#{$options.fetch(:release_name)}' from git revision #{revision} before destroy")
+    helm_upgrade_install!(checkout_dir, revision)
+  elsif !kubectl_success?("get", "crd", "applications.argoproj.io", "applicationsets.argoproj.io")
+    log("Helm release '#{$options.fetch(:release_name)}' and Argo CRDs are already absent; nothing to do")
+    return
+  end
+
+  if helm_release_exists?
+    log("Uninstalling Helm release '#{$options.fetch(:release_name)}'")
+    helm("uninstall", $options.fetch(:release_name), "--namespace", $options.fetch(:namespace), "--wait", "--timeout", HELM_TIMEOUT)
+  else
+    log("Helm release '#{$options.fetch(:release_name)}' already absent; skipping Helm uninstall")
+  end
+end
+
+def run!(*command)
+  stdout, stderr, status = Open3.capture3(*command)
+  return stdout if status.success?
+
+  message = stderr.empty? ? stdout : stderr
+  abort("command failed: #{command.join(' ')}\n#{message}")
+end
+
+def log(message) = puts "[#{Time.now.iso8601}] #{message}"
+def helm(*args) = run!("helm", "--kubeconfig", kubeconfig, *args)
+def kubectl(*args) = run!("kubectl", "--kubeconfig", kubeconfig, *args)
+def kubectl_success?(*args) = Open3.capture3("kubectl", "--kubeconfig", kubeconfig, *args).last.success?
+def helm_release_exists? = Open3.capture3("helm", "--kubeconfig", kubeconfig, "status", $options.fetch(:release_name), "--namespace", $options.fetch(:namespace)).last.success?
+
+def helm_upgrade_install!(checkout_dir, revision)
+  helm(
+    "upgrade",
+    $options.fetch(:release_name),
+    File.join(checkout_dir, $options.fetch(:argocd_chart_path)),
+    "--install",
+    "--namespace", $options.fetch(:namespace),
+    "--create-namespace",
+    "--wait",
+    "--timeout", HELM_TIMEOUT,
+    "--set-string", "_bootstrap.k8s_gitops_revision=#{revision}",
+  )
+end
+
+def git_checkout
+  terraform_dir = File.join(MODULE_DIR, ".terraform")
+  FileUtils.mkdir_p(terraform_dir)
+
+  checkout_root = Dir.mktmpdir("argocd-bootstrap-", terraform_dir)
+  checkout_dir = File.join(checkout_root, "checkout")
+
+  log("Cloning #{$options.fetch(:repo_url)} branch #{$options.fetch(:default_branch)}")
+  run!(
+    "git", "clone",
+    "--depth", "1",
+    "--branch", $options.fetch(:default_branch),
+    "--filter=blob:none",
+    "--sparse",
+    $options.fetch(:repo_url),
+    checkout_dir,
+  )
+  run!(
+    "git", "-C", checkout_dir, "sparse-checkout", "set",
+    File.dirname($options.fetch(:argocd_chart_path)),
+  )
+
+  revision = run!("git", "-C", checkout_dir, "rev-parse", "HEAD").strip
+  log("Checked out git revision #{revision}")
+  [checkout_dir, revision]
+end
+
+def kubeconfig
+  return $kubeconfig if $kubeconfig
+
+  token_json = run!(
+    "aws", "eks", "get-token",
+    "--region", $options.fetch(:cluster_region),
+    "--cluster-name", $options.fetch(:cluster_name),
+    "--output", "json",
+  )
+  token = JSON.parse(token_json).dig("status", "token") or abort("aws eks get-token returned no token")
+
+  $kubeconfig_file = Tempfile.new("argocd-bootstrap-kubeconfig")
+  $kubeconfig_file.write(<<~YAML)
+    apiVersion: v1
+    kind: Config
+    clusters:
+    - name: cluster
+      cluster:
+        certificate-authority-data: #{$options.fetch(:cluster_certificate_authority_data)}
+        server: #{$options.fetch(:cluster_endpoint)}
+    contexts:
+    - name: context
+      context:
+        cluster: cluster
+        namespace: #{$options.fetch(:namespace)}
+        user: user
+    current-context: context
+    users:
+    - name: user
+      user:
+        token: #{token}
+  YAML
+  $kubeconfig_file.flush
+
+  $kubeconfig = $kubeconfig_file.path
+end
+
+ARGV.empty? or abort(usage)
+
+missing_options = %i[
+  repo_url
+  default_branch
+  argocd_chart_path
+  release_name
+  namespace
+  cluster_name
+  cluster_region
+  cluster_endpoint
+  cluster_certificate_authority_data
+].reject {|key| $options.key?(key)}
+missing_options.empty? or abort("missing required options: #{missing_options.join(', ')}")
+
+main(mode)


### PR DESCRIPTION
This PR preserves the Ruby-owned Argo bootstrap branch on a side branch so it can be reviewed or revived later without keeping it on `k8s/reorg`. We rolled `k8s/reorg` back to the simpler `helm_release` path for the next real full apply/destroy cycle, but the script branch is still worth keeping as a concrete alternative because it captured one real design idea: bootstrap-only apply, and a destroy-only attempt to refresh Helm state from the latest `k8s-gitops` chart before final uninstall.

What went wrong in the test run is now clear from the logs. The destroy-side `bin/argocd-bootstrap` path ran `helm upgrade --install` before `helm uninstall`, and that reconcile was not a drop-in operation against a live self-managed Argo install. It failed on two separate fronts. First, the live Argo install was already managing the same resources, and the reconcile hit field-manager ownership conflicts against `argocd-controller` on `argocd-notifications-secret`, the repo secrets (`repo-code-dot-org`, `repo-k8s-gitops`, `repo-kargo-charts`), `Deployment/argocd-applicationset-controller`, `Deployment/argocd-repo-server`, and `StatefulSet/argocd-application-controller`. Second, the cluster was dirty from an earlier cleanup mistake, so the reconcile also failed validation on the Argo ingress because the AWS load balancer webhook had no endpoints (`no endpoints available for "aws-load-balancer-webhook-service"`). The combined result is that the script branch is not merge-ready as-is: its pre-destroy Helm reconcile assumption is too optimistic once Argo has been self-managing the same release.

Technical changes:
- restore `terraform_data.argocd_bootstrap` as the Argo bootstrap owner in `k8s/tofu/codeai-k8s/cluster-infra-argocd/argocd-bootstrap.tf`
- restore `k8s/tofu/codeai-k8s/cluster-infra-argocd/bin/argocd-bootstrap`
- keep the script contract that `apply` installs/bootstrap only and refuses Helm upgrades of an existing release
- keep the script contract that `destroy` is the only mode allowed to attempt a Helm refresh before uninstall
- preserve this design in a reviewable branch while the main line returns to the simpler `helm_release` baseline