### PR TITLE
AI Tutor: lesson deep dive reflection form saves reflections on submit

### DIFF
--- a/apps/src/aiTutor/reflectionsApi.ts
+++ b/apps/src/aiTutor/reflectionsApi.ts
@@ -31,8 +31,6 @@ export const saveUserLessonObjectiveReflection = async (
     body: JSON.stringify({objective_id: objectiveId, reflection}),
   });
   if (!response.ok) {
-    throw new Error(
-      `Failed to save objective reflection: ${response.status}`
-    );
+    throw new Error(`Failed to save objective reflection: ${response.status}`);
   }
 };

--- a/apps/src/aiTutor/reflectionsApi.ts
+++ b/apps/src/aiTutor/reflectionsApi.ts
@@ -1,0 +1,38 @@
+import {getAuthenticityToken} from '@cdo/apps/util/AuthenticityTokenStore';
+
+export const saveUserLessonReflection = async (
+  lessonId: number,
+  success: string,
+  struggle: string
+): Promise<void> => {
+  const response = await fetch('/user_lesson_reflections', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'X-CSRF-Token': await getAuthenticityToken(),
+    },
+    body: JSON.stringify({lesson_id: lessonId, success, struggle}),
+  });
+  if (!response.ok) {
+    throw new Error(`Failed to save lesson reflection: ${response.status}`);
+  }
+};
+
+export const saveUserLessonObjectiveReflection = async (
+  objectiveId: string,
+  reflection: string
+): Promise<void> => {
+  const response = await fetch('/user_lesson_objective_reflections', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'X-CSRF-Token': await getAuthenticityToken(),
+    },
+    body: JSON.stringify({objective_id: objectiveId, reflection}),
+  });
+  if (!response.ok) {
+    throw new Error(
+      `Failed to save objective reflection: ${response.status}`
+    );
+  }
+};

--- a/apps/src/aiTutor/views/lessonDeepDive/LessonDeepDiveContainer.tsx
+++ b/apps/src/aiTutor/views/lessonDeepDive/LessonDeepDiveContainer.tsx
@@ -70,7 +70,12 @@ const LessonDeepDiveContainer: FC<LessonDeepDiveContainerProps> = ({
           />
         );
       case 'reflection':
-        return <ReflectionBox objectives={lessonDeepDiveData.objectives} />;
+        return (
+          <ReflectionBox
+            lessonId={lessonDeepDiveData.lessonId}
+            objectives={lessonDeepDiveData.objectives}
+          />
+        );
       case 'intervention':
         return (
           <InterventionBox

--- a/apps/src/aiTutor/views/lessonDeepDive/LessonObjectiveReflection.tsx
+++ b/apps/src/aiTutor/views/lessonDeepDive/LessonObjectiveReflection.tsx
@@ -1,15 +1,19 @@
 import {Typography} from '@mui/material';
-import React, {FC, useState} from 'react';
+import React, {FC} from 'react';
 
 import {LessonObjectiveReflectionValues} from '@cdo/generated-scripts/sharedConstants';
 
 import {LessonDeepDiveData} from './types';
 
+import styles from './reflection.module.scss';
+
 const REFLECTION_VALUES = Object.values(LessonObjectiveReflectionValues);
-type ReflectionValue = (typeof REFLECTION_VALUES)[number] | null;
+export type ReflectionValue = (typeof REFLECTION_VALUES)[number];
 
 interface LessonObjectiveReflectionProps {
   objective: LessonDeepDiveData['objectives'][number];
+  selected: ReflectionValue | null;
+  onSelectionChange: (objectiveId: string, value: ReflectionValue) => void;
 }
 
 const BUTTONS: {value: ReflectionValue; emoji: string; label: string}[] = [
@@ -24,34 +28,31 @@ const BUTTONS: {value: ReflectionValue; emoji: string; label: string}[] = [
 
 const LessonObjectiveReflection: FC<LessonObjectiveReflectionProps> = ({
   objective,
-}) => {
-  const [selected, setSelected] = useState<ReflectionValue>(null);
-
-  return (
-    <div style={{display: 'flex', alignItems: 'center', gap: '0.5rem'}}>
-      <Typography variant="h6" component="h6" style={{margin: 0, flex: 1}}>
-        {objective.description}
-      </Typography>
-      {BUTTONS.map(({value, emoji, label}) => (
-        <button
-          key={value}
-          type="button"
-          onClick={() => setSelected(value)}
-          aria-label={label}
-          aria-pressed={selected === value}
-          style={{
-            fontSize: '1.5rem',
-            background: 'none',
-            border: 'none',
-            cursor: 'pointer',
-            opacity: selected === null || selected === value ? 1 : 0.4,
-          }}
-        >
-          {emoji}
-        </button>
-      ))}
-    </div>
-  );
-};
+  selected,
+  onSelectionChange,
+}) => (
+  <div className={styles.objectiveRow}>
+    <Typography
+      variant="h6"
+      component="h6"
+      className={styles.objectiveDescription}
+    >
+      {objective.description}
+    </Typography>
+    {BUTTONS.map(({value, emoji, label}) => (
+      <button
+        key={value}
+        type="button"
+        onClick={() => onSelectionChange(objective.id, value)}
+        aria-label={label}
+        aria-pressed={selected === value}
+        className={styles.emojiButton}
+        style={{opacity: selected === null || selected === value ? 1 : 0.4}}
+      >
+        {emoji}
+      </button>
+    ))}
+  </div>
+);
 
 export default LessonObjectiveReflection;

--- a/apps/src/aiTutor/views/lessonDeepDive/LessonReflection.tsx
+++ b/apps/src/aiTutor/views/lessonDeepDive/LessonReflection.tsx
@@ -1,44 +1,43 @@
 import {TextField, Typography} from '@mui/material';
-import React, {FC, useState} from 'react';
+import React, {FC} from 'react';
 
-const LessonReflection: FC = () => {
-  const [success, setSuccess] = useState('');
-  const [confused, setConfused] = useState('');
+interface LessonReflectionProps {
+  success: string;
+  struggle: string;
+  onSuccessChange: (value: string) => void;
+  onStruggleChange: (value: string) => void;
+}
 
-  return (
-    <div>
-      <Typography
-        variant="body1"
-        component="label"
-        htmlFor="reflection-success"
-      >
-        A moment I felt successful today...
-      </Typography>
-      <TextField
-        id="reflection-success"
-        multiline
-        fullWidth
-        minRows={4}
-        value={success}
-        onChange={e => setSuccess(e.target.value)}
-      />
-      <Typography
-        variant="body1"
-        component="label"
-        htmlFor="reflection-confused"
-      >
-        Something I&apos;m still confused about or working on...
-      </Typography>
-      <TextField
-        id="reflection-confused"
-        multiline
-        fullWidth
-        minRows={4}
-        value={confused}
-        onChange={e => setConfused(e.target.value)}
-      />
-    </div>
-  );
-};
+const LessonReflection: FC<LessonReflectionProps> = ({
+  success,
+  struggle,
+  onSuccessChange,
+  onStruggleChange,
+}) => (
+  <div>
+    <Typography variant="body1" component="label" htmlFor="reflection-success">
+      A moment I felt successful today...
+    </Typography>
+    <TextField
+      id="reflection-success"
+      multiline
+      fullWidth
+      minRows={4}
+      value={success}
+      onChange={e => onSuccessChange(e.target.value)}
+    />
+    <Typography variant="body1" component="label" htmlFor="reflection-struggle">
+      Something I&apos;m still confused about or working on...
+    </Typography>
+    <TextField
+      id="reflection-struggle"
+      multiline
+      fullWidth
+      minRows={4}
+      value={struggle}
+      onChange={e => onStruggleChange(e.target.value)}
+    />
+  </div>
+);
 
 export default LessonReflection;

--- a/apps/src/aiTutor/views/lessonDeepDive/ReflectionBox.tsx
+++ b/apps/src/aiTutor/views/lessonDeepDive/ReflectionBox.tsx
@@ -38,7 +38,11 @@ const ReflectionBox: FC<ReflectionBoxProps> = ({lessonId, objectives}) => {
     setIsSubmitting(true);
     try {
       const objectiveSaves = objectives
-        .filter(o => objectiveReflections[o.id] !== null)
+        .filter(
+          o =>
+            objectiveReflections[o.id] !== null &&
+            objectiveReflections[o.id] !== undefined
+        )
         .map(o =>
           saveUserLessonObjectiveReflection(
             o.id,

--- a/apps/src/aiTutor/views/lessonDeepDive/ReflectionBox.tsx
+++ b/apps/src/aiTutor/views/lessonDeepDive/ReflectionBox.tsx
@@ -1,35 +1,93 @@
 import {Button, Typography} from '@mui/material';
-import React, {FC} from 'react';
+import React, {FC, useCallback, useState} from 'react';
 
-import LessonObjectiveReflection from './LessonObjectiveReflection';
+import {
+  saveUserLessonObjectiveReflection,
+  saveUserLessonReflection,
+} from '@cdo/apps/aiTutor/reflectionsApi';
+
+import LessonObjectiveReflection, {
+  ReflectionValue,
+} from './LessonObjectiveReflection';
 import LessonReflection from './LessonReflection';
 import {LessonDeepDiveData} from './types';
 
+import styles from './reflection.module.scss';
+
 interface ReflectionBoxProps {
+  lessonId: number;
   objectives: LessonDeepDiveData['objectives'];
 }
 
-const ReflectionBox: FC<ReflectionBoxProps> = ({objectives}) => (
-  <div>
-    <Typography variant="h2" sx={{fontSize: {xs: '1.5rem', sm: '2rem'}}}>
-      Reflection
-    </Typography>
-    <Typography variant="body1">
-      How do you feel about each of the learning objectives for this lesson?
-    </Typography>
-    {objectives.map(objective => (
-      <LessonObjectiveReflection key={objective.id} objective={objective} />
-    ))}
-    <LessonReflection />
-    <Button
-      variant="contained"
-      type="button"
-      fullWidth
-      sx={{marginTop: '5px', textTransform: 'none'}}
-    >
-      Submit Reflection
-    </Button>
-  </div>
-);
+const ReflectionBox: FC<ReflectionBoxProps> = ({lessonId, objectives}) => {
+  const [objectiveReflections, setObjectiveReflections] = useState<
+    Record<string, ReflectionValue | null>
+  >({});
+  const [success, setSuccess] = useState('');
+  const [struggle, setStruggle] = useState('');
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const handleSelectionChange = useCallback(
+    (objectiveId: string, value: ReflectionValue) => {
+      setObjectiveReflections(prev => ({...prev, [objectiveId]: value}));
+    },
+    []
+  );
+
+  const handleSubmit = useCallback(async () => {
+    setIsSubmitting(true);
+    try {
+      const objectiveSaves = objectives
+        .filter(o => objectiveReflections[o.id] !== null)
+        .map(o =>
+          saveUserLessonObjectiveReflection(
+            o.id,
+            objectiveReflections[o.id] as ReflectionValue
+          )
+        );
+      await Promise.all([
+        saveUserLessonReflection(lessonId, success, struggle),
+        ...objectiveSaves,
+      ]);
+    } finally {
+      setIsSubmitting(false);
+    }
+  }, [lessonId, success, struggle, objectives, objectiveReflections]);
+
+  return (
+    <div>
+      <Typography variant="h2" className={styles.reflectionHeading}>
+        Reflection
+      </Typography>
+      <Typography variant="body1">
+        How do you feel about each of the learning objectives for this lesson?
+      </Typography>
+      {objectives.map(objective => (
+        <LessonObjectiveReflection
+          key={objective.id}
+          objective={objective}
+          selected={objectiveReflections[objective.id] ?? null}
+          onSelectionChange={handleSelectionChange}
+        />
+      ))}
+      <LessonReflection
+        success={success}
+        struggle={struggle}
+        onSuccessChange={setSuccess}
+        onStruggleChange={setStruggle}
+      />
+      <Button
+        variant="contained"
+        type="button"
+        fullWidth
+        disabled={isSubmitting}
+        onClick={handleSubmit}
+        className={styles.submitButton}
+      >
+        Submit Reflection
+      </Button>
+    </div>
+  );
+};
 
 export default ReflectionBox;

--- a/apps/src/aiTutor/views/lessonDeepDive/reflection.module.scss
+++ b/apps/src/aiTutor/views/lessonDeepDive/reflection.module.scss
@@ -1,0 +1,35 @@
+// ── ReflectionBox ─────────────────────────────────────────────────────────────
+
+.reflectionHeading {
+  font-size: 1.5rem;
+
+  @media (min-width: 600px) {
+    font-size: 2rem;
+  }
+}
+
+.submitButton {
+  margin-top: 5px;
+  // Override MUI Button default uppercase
+  text-transform: none !important;
+}
+
+// ── LessonObjectiveReflection ─────────────────────────────────────────────────
+
+.objectiveRow {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.objectiveDescription {
+  margin: 0;
+  flex: 1;
+}
+
+.emojiButton {
+  font-size: 1.5rem;
+  background: none;
+  border: none;
+  cursor: pointer;
+}

--- a/apps/src/aiTutor/views/lessonDeepDive/types.ts
+++ b/apps/src/aiTutor/views/lessonDeepDive/types.ts
@@ -1,4 +1,5 @@
 export type LessonDeepDiveData = {
+  lessonId: number;
   lessonName: string;
   lessonSummary: string;
   vocabulary: {id: string; word: string; definition: string}[];

--- a/apps/test/unit/aiTutor/views/lessonDeepDive/ReflectionBoxTest.tsx
+++ b/apps/test/unit/aiTutor/views/lessonDeepDive/ReflectionBoxTest.tsx
@@ -1,0 +1,126 @@
+import {render, screen, fireEvent, act} from '@testing-library/react';
+import '@testing-library/jest-dom';
+import React from 'react';
+
+import ReflectionBox from '@cdo/apps/aiTutor/views/lessonDeepDive/ReflectionBox';
+
+jest.mock('@cdo/apps/aiTutor/reflectionsApi', () => ({
+  saveUserLessonReflection: jest.fn(),
+  saveUserLessonObjectiveReflection: jest.fn(),
+}));
+
+import {
+  saveUserLessonReflection,
+  saveUserLessonObjectiveReflection,
+} from '@cdo/apps/aiTutor/reflectionsApi';
+
+const saveReflectionMock = saveUserLessonReflection as jest.Mock;
+const saveObjectiveMock = saveUserLessonObjectiveReflection as jest.Mock;
+
+const LESSON_ID = 42;
+const OBJECTIVES = [
+  {id: '1', description: 'Objective one'},
+  {id: '2', description: 'Objective two'},
+];
+
+function renderReflectionBox() {
+  render(<ReflectionBox lessonId={LESSON_ID} objectives={OBJECTIVES} />);
+}
+
+describe('ReflectionBox submit button', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    saveReflectionMock.mockResolvedValue(undefined);
+    saveObjectiveMock.mockResolvedValue(undefined);
+  });
+
+  it('renders the submit button', () => {
+    renderReflectionBox();
+    expect(
+      screen.getByRole('button', {name: /submit reflection/i})
+    ).toBeInTheDocument();
+  });
+
+  it('calls saveUserLessonReflection with lessonId, success, and struggle on submit', async () => {
+    renderReflectionBox();
+
+    fireEvent.change(screen.getByLabelText(/moment i felt successful/i), {
+      target: {value: 'I understood loops'},
+    });
+    fireEvent.change(screen.getByLabelText(/still confused/i), {
+      target: {value: 'Recursion is hard'},
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', {name: /submit reflection/i}));
+    });
+
+    expect(saveReflectionMock).toHaveBeenCalledWith(
+      LESSON_ID,
+      'I understood loops',
+      'Recursion is hard'
+    );
+  });
+
+  it('does not call saveUserLessonObjectiveReflection when no objectives are selected', async () => {
+    renderReflectionBox();
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', {name: /submit reflection/i}));
+    });
+
+    expect(saveObjectiveMock).not.toHaveBeenCalled();
+  });
+
+  it('calls saveUserLessonObjectiveReflection only for selected objectives', async () => {
+    renderReflectionBox();
+
+    // Click Confident for the first objective only
+    fireEvent.click(screen.getAllByRole('button', {name: /confident/i})[0]);
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', {name: /submit reflection/i}));
+    });
+
+    expect(saveObjectiveMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls saveUserLessonObjectiveReflection for each selected objective', async () => {
+    renderReflectionBox();
+
+    fireEvent.click(screen.getAllByRole('button', {name: /confident/i})[0]);
+    fireEvent.click(screen.getAllByRole('button', {name: /lost/i})[1]);
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', {name: /submit reflection/i}));
+    });
+
+    expect(saveObjectiveMock).toHaveBeenCalledTimes(2);
+    expect(saveObjectiveMock).toHaveBeenCalledWith('1', 'confident');
+    expect(saveObjectiveMock).toHaveBeenCalledWith('2', 'lost');
+  });
+
+  it('disables the submit button while submitting and re-enables after', async () => {
+    let resolveSubmit: () => void;
+    saveReflectionMock.mockReturnValue(
+      new Promise<void>(resolve => {
+        resolveSubmit = resolve;
+      })
+    );
+
+    renderReflectionBox();
+    const button = screen.getByRole('button', {name: /submit reflection/i});
+
+    await act(async () => {
+      fireEvent.click(button);
+    });
+
+    expect(button).toBeDisabled();
+
+    await act(async () => {
+      resolveSubmit!();
+    });
+
+    expect(button).not.toBeDisabled();
+  });
+});

--- a/apps/test/unit/aiTutor/views/lessonDeepDive/ReflectionBoxTest.tsx
+++ b/apps/test/unit/aiTutor/views/lessonDeepDive/ReflectionBoxTest.tsx
@@ -2,17 +2,16 @@ import {render, screen, fireEvent, act} from '@testing-library/react';
 import '@testing-library/jest-dom';
 import React from 'react';
 
+import {
+  saveUserLessonReflection,
+  saveUserLessonObjectiveReflection,
+} from '@cdo/apps/aiTutor/reflectionsApi';
 import ReflectionBox from '@cdo/apps/aiTutor/views/lessonDeepDive/ReflectionBox';
 
 jest.mock('@cdo/apps/aiTutor/reflectionsApi', () => ({
   saveUserLessonReflection: jest.fn(),
   saveUserLessonObjectiveReflection: jest.fn(),
 }));
-
-import {
-  saveUserLessonReflection,
-  saveUserLessonObjectiveReflection,
-} from '@cdo/apps/aiTutor/reflectionsApi';
 
 const saveReflectionMock = saveUserLessonReflection as jest.Mock;
 const saveObjectiveMock = saveUserLessonObjectiveReflection as jest.Mock;

--- a/dashboard/app/controllers/lessons_controller.rb
+++ b/dashboard/app/controllers/lessons_controller.rb
@@ -100,6 +100,7 @@ class LessonsController < ApplicationController
       l.has_lesson_plan && l.relative_position == params[:lesson_position].to_i
     end
     @lesson_deep_dive_data = {
+      lessonId: @lesson.id,
       lessonName: @lesson.localized_name,
       lessonSummary: @lesson.properties['student_overview'] || '',
       vocabulary: @lesson.vocabularies.map {|v| {id: v.id, word: v.word, definition: v.definition}},


### PR DESCRIPTION
When a user submits the reflection form, we now save UserLessonReflections and UserLessonObjectiveReflections successfully. Stitches together the UI from https://github.com/code-dot-org/code-dot-org/pull/71902 and the backend from https://github.com/code-dot-org/code-dot-org/pull/71868

This is the network tab showing successful saves: 
<img width="490" height="93" alt="Screenshot 2026-04-06 at 11 15 18 AM" src="https://github.com/user-attachments/assets/fe651341-1f3d-4f6b-98f3-a7829b7aa416" />

And here they are in the database: 
<img width="817" height="621" alt="Screenshot 2026-04-06 at 11 20 46 AM" src="https://github.com/user-attachments/assets/52a0e504-b16e-44bc-a845-9232e2a64bea" />
<img width="846" height="282" alt="Screenshot 2026-04-06 at 11 21 16 AM" src="https://github.com/user-attachments/assets/8d42e798-7ce2-48de-9ac5-d03dc9d65014" />
