### PR TITLE
Fix product tour show/hide logic

### DIFF
--- a/apps/src/lab2/hooks/useHideTourOnTourChange.ts
+++ b/apps/src/lab2/hooks/useHideTourOnTourChange.ts
@@ -12,6 +12,11 @@ const useHideTourOnTourChange = (tour: Tour | null) => {
     if (prevTour && prevTour !== tour) {
       prevTour.hide();
     }
+    return () => {
+      if (tour) {
+        tour.hide();
+      }
+    };
   }, [tour]);
 };
 export default useHideTourOnTourChange;

--- a/apps/src/lab2/hooks/useHideTourOnTourChange.ts
+++ b/apps/src/lab2/hooks/useHideTourOnTourChange.ts
@@ -1,0 +1,19 @@
+import {useEffect, useRef} from 'react';
+import {Tour} from 'shepherd.js';
+
+// Automatically hides the previous tour when the tour instance changes (i.e. on level change).
+// We want to hide tours on level change to avoid showing tours that are no longer relevant.
+// The next level should handle showing any relevant tours.
+const useHideTourOnTourChange = (tour: Tour | null) => {
+  const prevTourRef = useRef<Tour | null>(null);
+
+  useEffect(() => {
+    const prevTour = prevTourRef.current;
+    prevTourRef.current = tour;
+    if (prevTour && prevTour !== tour) {
+      console.log('Tour instance changed, hiding the previous tour');
+      prevTour.hide();
+    }
+  }, [tour]);
+};
+export default useHideTourOnTourChange;

--- a/apps/src/lab2/hooks/useHideTourOnTourChange.ts
+++ b/apps/src/lab2/hooks/useHideTourOnTourChange.ts
@@ -1,7 +1,8 @@
 import {useEffect, useRef} from 'react';
 import {Tour} from 'shepherd.js';
 
-// Automatically hides the previous tour when the tour instance changes (i.e. on level change).
+// Automatically hides the previous tour when the tour instance changes (i.e. on level change),
+// or the component unmounts.
 // This will avoid showing tours that are no longer relevant.
 const useHideTourOnTourChange = (tour: Tour | null) => {
   const prevTourRef = useRef<Tour | null>(null);

--- a/apps/src/lab2/hooks/useHideTourOnTourChange.ts
+++ b/apps/src/lab2/hooks/useHideTourOnTourChange.ts
@@ -1,18 +1,10 @@
-import {useEffect, useRef} from 'react';
+import {useEffect} from 'react';
 import {Tour} from 'shepherd.js';
 
-// Automatically hides the previous tour when the tour instance changes (i.e. on level change),
-// or the component unmounts.
+// Automatically hides the previous tour when the tour instance changes (i.e. on level change).
 // This will avoid showing tours that are no longer relevant.
 const useHideTourOnTourChange = (tour: Tour | null) => {
-  const prevTourRef = useRef<Tour | null>(null);
-
   useEffect(() => {
-    const prevTour = prevTourRef.current;
-    prevTourRef.current = tour;
-    if (prevTour && prevTour !== tour) {
-      prevTour.hide();
-    }
     return () => {
       if (tour) {
         tour.hide();

--- a/apps/src/lab2/hooks/useHideTourOnTourChange.ts
+++ b/apps/src/lab2/hooks/useHideTourOnTourChange.ts
@@ -2,8 +2,7 @@ import {useEffect, useRef} from 'react';
 import {Tour} from 'shepherd.js';
 
 // Automatically hides the previous tour when the tour instance changes (i.e. on level change).
-// We want to hide tours on level change to avoid showing tours that are no longer relevant.
-// The next level should handle showing any relevant tours.
+// This will avoid showing tours that are no longer relevant.
 const useHideTourOnTourChange = (tour: Tour | null) => {
   const prevTourRef = useRef<Tour | null>(null);
 
@@ -11,7 +10,6 @@ const useHideTourOnTourChange = (tour: Tour | null) => {
     const prevTour = prevTourRef.current;
     prevTourRef.current = tour;
     if (prevTour && prevTour !== tour) {
-      console.log('Tour instance changed, hiding the previous tour');
       prevTour.hide();
     }
   }, [tour]);

--- a/apps/src/lab2/hooks/useLab2ProductTour.ts
+++ b/apps/src/lab2/hooks/useLab2ProductTour.ts
@@ -7,6 +7,8 @@ import useProductTour, {
   UseProductTourProps,
 } from '@cdo/apps/sharedComponents/productTour/useProductTour';
 
+import useHideTourOnTourChange from './useHideTourOnTourChange';
+
 // Wrapper around useProductTour that enforces common restrictions for Lab2 tours.
 const useLab2ProductTour = ({
   tourAvailable,
@@ -16,10 +18,13 @@ const useLab2ProductTour = ({
   const viewingExemplar = !!getAppOptionsViewingExemplar();
   const editingExemplar = !!getAppOptionsEditingExemplar();
   const hideTour = isStartMode || viewingExemplar || editingExemplar;
-  return useProductTour({
+  const {tour} = useProductTour({
     tourAvailable: tourAvailable && !hideTour,
     ...useProductTourProps,
   });
+
+  useHideTourOnTourChange(tour);
+  return {tour};
 };
 
 export default useLab2ProductTour;

--- a/apps/src/sharedComponents/productTour/useProductTour.ts
+++ b/apps/src/sharedComponents/productTour/useProductTour.ts
@@ -1,4 +1,4 @@
-import {useMemo} from 'react';
+import {useMemo, useRef} from 'react';
 import Shepherd, {StepOptions, Tour} from 'shepherd.js';
 
 import {tryGetLocalStorage, trySetLocalStorage} from '@cdo/apps/utils';
@@ -30,6 +30,15 @@ const useProductTour = ({
   onCancel,
   additionalStepOptions,
 }: UseProductTourProps) => {
+  // Store callbacks in refs so the tour instance doesn't need to be recreated
+  // when callback identity changes between renders.
+  const onStartRef = useRef(onStart);
+  onStartRef.current = onStart;
+  const onCompleteRef = useRef(onComplete);
+  onCompleteRef.current = onComplete;
+  const onCancelRef = useRef(onCancel);
+  onCancelRef.current = onCancel;
+
   const tour = useMemo(() => {
     const tourSeen = tryGetLocalStorage(localStorageKey, 'no');
     const urlParams = new URLSearchParams(window.location.search);
@@ -50,13 +59,11 @@ const useProductTour = ({
     });
     tour.addSteps(getSteps(tour));
 
-    if (onStart) {
-      tour.on('start', onStart);
-    }
+    tour.on('start', () => onStartRef.current && onStartRef.current());
 
     tour.on('complete', () => {
       trySetLocalStorage(localStorageKey, 'yes');
-      onComplete && onComplete();
+      onCompleteRef.current && onCompleteRef.current();
     });
 
     tour.on('cancel', () => {
@@ -64,18 +71,10 @@ const useProductTour = ({
         ? tour.steps.indexOf(tour.currentStep)
         : 0;
       trySetLocalStorage(localStorageKey, 'yes');
-      onCancel && onCancel(currentIndex);
+      onCancelRef.current && onCancelRef.current(currentIndex);
     });
     return tour;
-  }, [
-    additionalStepOptions,
-    getSteps,
-    localStorageKey,
-    onCancel,
-    onComplete,
-    onStart,
-    tourAvailable,
-  ]);
+  }, [additionalStepOptions, getSteps, localStorageKey, tourAvailable]);
 
   return {tour};
 };

--- a/apps/src/sharedComponents/productTour/useStartTourWhenAvailable.ts
+++ b/apps/src/sharedComponents/productTour/useStartTourWhenAvailable.ts
@@ -1,12 +1,12 @@
 import {useRef, useEffect} from 'react';
 import {Tour} from 'shepherd.js';
 
-// Automatically starts the given tour once it is non-null. Guards against starting the tour multiple times.
+// Automatically starts the given tour once it is non-null. Guards against starting the same tour instance multiple times.
 const useStartTourWhenAvailable = (tour: Tour | null) => {
-  const tourStarted = useRef(false);
+  const startedTourRef = useRef<Tour | null>(null);
   useEffect(() => {
-    if (tour && !tourStarted.current) {
-      tourStarted.current = true;
+    if (tour && startedTourRef.current !== tour) {
+      startedTourRef.current = tour;
       tour.start();
     }
   }, [tour]);

--- a/apps/test/unit/lab2/hooks/useHideTourOnTourChangeTest.ts
+++ b/apps/test/unit/lab2/hooks/useHideTourOnTourChangeTest.ts
@@ -1,0 +1,62 @@
+import {renderHook} from '@testing-library/react-hooks';
+import {Tour} from 'shepherd.js';
+
+import useHideTourOnTourChange from '@cdo/apps/lab2/hooks/useHideTourOnTourChange';
+
+const makeTour = () => ({hide: jest.fn()} as unknown as Tour);
+
+describe('useHideTourOnTourChange', () => {
+  it('does not call hide on initial render', () => {
+    const tour = makeTour();
+    renderHook(() => useHideTourOnTourChange(tour));
+    expect(tour.hide).not.toHaveBeenCalled();
+  });
+
+  it('no errors when tour remains null', () => {
+    const {rerender} = renderHook(() => useHideTourOnTourChange(null));
+    rerender();
+  });
+
+  it('hides the previous tour when the tour instance changes', () => {
+    const tourA = makeTour();
+    const tourB = makeTour();
+    let currentTour: Tour | null = tourA;
+    const {rerender} = renderHook(() => useHideTourOnTourChange(currentTour));
+
+    currentTour = tourB;
+    rerender();
+
+    expect(tourA.hide).toHaveBeenCalledTimes(1);
+    expect(tourB.hide).not.toHaveBeenCalled();
+  });
+
+  it('does not hide when the same tour instance is passed again', () => {
+    const tour = makeTour();
+    const {rerender} = renderHook(() => useHideTourOnTourChange(tour));
+    rerender();
+    expect(tour.hide).not.toHaveBeenCalled();
+  });
+
+  it('hides the previous tour when tour changes from a value to null', () => {
+    const tourA = makeTour();
+    let currentTour: Tour | null = tourA;
+    const {rerender} = renderHook(() => useHideTourOnTourChange(currentTour));
+
+    currentTour = null;
+    rerender();
+
+    expect(tourA.hide).toHaveBeenCalledTimes(1);
+  });
+
+  it('hides the current tour on unmount', () => {
+    const tour = makeTour();
+    const {unmount} = renderHook(() => useHideTourOnTourChange(tour));
+    unmount();
+    expect(tour.hide).toHaveBeenCalledTimes(1);
+  });
+
+  it('no errors on unmount when tour is null', () => {
+    const {unmount} = renderHook(() => useHideTourOnTourChange(null));
+    unmount();
+  });
+});

--- a/apps/test/unit/lab2/hooks/useLab2ProductTourTest.ts
+++ b/apps/test/unit/lab2/hooks/useLab2ProductTourTest.ts
@@ -1,0 +1,127 @@
+import {renderHook} from '@testing-library/react-hooks';
+import {Tour} from 'shepherd.js';
+
+import useHideTourOnTourChange from '@cdo/apps/lab2/hooks/useHideTourOnTourChange';
+import useLab2ProductTour from '@cdo/apps/lab2/hooks/useLab2ProductTour';
+import {
+  getAppOptionsEditingExemplar,
+  getAppOptionsViewingExemplar,
+  getIsStartMode,
+} from '@cdo/apps/lab2/projects/utils';
+import useProductTour from '@cdo/apps/sharedComponents/productTour/useProductTour';
+
+jest.mock('@cdo/apps/sharedComponents/productTour/useProductTour');
+jest.mock('@cdo/apps/lab2/hooks/useHideTourOnTourChange');
+jest.mock('@cdo/apps/lab2/projects/utils');
+
+const mockUseProductTour = useProductTour as jest.MockedFunction<
+  typeof useProductTour
+>;
+const mockUseHideTourOnTourChange =
+  useHideTourOnTourChange as jest.MockedFunction<
+    typeof useHideTourOnTourChange
+  >;
+const mockGetIsStartMode = getIsStartMode as jest.MockedFunction<
+  typeof getIsStartMode
+>;
+const mockGetAppOptionsViewingExemplar =
+  getAppOptionsViewingExemplar as jest.MockedFunction<
+    typeof getAppOptionsViewingExemplar
+  >;
+const mockGetAppOptionsEditingExemplar =
+  getAppOptionsEditingExemplar as jest.MockedFunction<
+    typeof getAppOptionsEditingExemplar
+  >;
+
+const mockTour = {
+  start: jest.fn(),
+  cancel: jest.fn(),
+  hide: jest.fn(),
+} as unknown as Tour;
+
+const defaultProps = {
+  getSteps: jest.fn().mockReturnValue([]),
+  localStorageKey: 'test-tour-seen',
+  tourAvailable: true,
+};
+
+describe('useLab2ProductTour', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetIsStartMode.mockReturnValue(false);
+    mockGetAppOptionsViewingExemplar.mockReturnValue(undefined);
+    mockGetAppOptionsEditingExemplar.mockReturnValue(undefined);
+    mockUseProductTour.mockReturnValue({tour: mockTour});
+    mockUseHideTourOnTourChange.mockReturnValue(undefined);
+  });
+
+  it('returns the tour from useProductTour', () => {
+    const {result} = renderHook(() => useLab2ProductTour(defaultProps));
+    expect(result.current.tour).toBe(mockTour);
+  });
+
+  it('passes tourAvailable through to useProductTour when no restrictions apply', () => {
+    renderHook(() =>
+      useLab2ProductTour({...defaultProps, tourAvailable: true})
+    );
+    expect(mockUseProductTour).toHaveBeenCalledWith(
+      expect.objectContaining({tourAvailable: true})
+    );
+  });
+
+  it('hides tour when in start mode', () => {
+    mockGetIsStartMode.mockReturnValue(true);
+    renderHook(() => useLab2ProductTour(defaultProps));
+    expect(mockUseProductTour).toHaveBeenCalledWith(
+      expect.objectContaining({tourAvailable: false})
+    );
+  });
+
+  it('hides tour when viewing exemplar', () => {
+    mockGetAppOptionsViewingExemplar.mockReturnValue(true);
+    renderHook(() => useLab2ProductTour(defaultProps));
+    expect(mockUseProductTour).toHaveBeenCalledWith(
+      expect.objectContaining({tourAvailable: false})
+    );
+  });
+
+  it('hides tour when editing exemplar', () => {
+    mockGetAppOptionsEditingExemplar.mockReturnValue(true);
+    renderHook(() => useLab2ProductTour(defaultProps));
+    expect(mockUseProductTour).toHaveBeenCalledWith(
+      expect.objectContaining({tourAvailable: false})
+    );
+  });
+
+  it('hides tour when tourAvailable prop is false', () => {
+    renderHook(() =>
+      useLab2ProductTour({...defaultProps, tourAvailable: false})
+    );
+    expect(mockUseProductTour).toHaveBeenCalledWith(
+      expect.objectContaining({tourAvailable: false})
+    );
+  });
+
+  it('calls useHideTourOnTourChange with the tour', () => {
+    renderHook(() => useLab2ProductTour(defaultProps));
+    expect(mockUseHideTourOnTourChange).toHaveBeenCalledWith(mockTour);
+  });
+
+  it('calls useHideTourOnTourChange with null when useProductTour returns null', () => {
+    mockUseProductTour.mockReturnValue({tour: null});
+    renderHook(() => useLab2ProductTour(defaultProps));
+    expect(mockUseHideTourOnTourChange).toHaveBeenCalledWith(null);
+  });
+
+  it('passes through all other useProductTour props', () => {
+    const onStart = jest.fn();
+    const onComplete = jest.fn();
+    const onCancel = jest.fn();
+    renderHook(() =>
+      useLab2ProductTour({...defaultProps, onStart, onComplete, onCancel})
+    );
+    expect(mockUseProductTour).toHaveBeenCalledWith(
+      expect.objectContaining({onStart, onComplete, onCancel})
+    );
+  });
+});

--- a/dashboard/config/levels/custom/weblab2/Weblab2 Lab2 Showcase.level
+++ b/dashboard/config/levels/custom/weblab2/Weblab2 Lab2 Showcase.level
@@ -1,14 +1,50 @@
 <Weblab2>
   <config><![CDATA[{
+  "published": true,
   "game_id": 74,
-  "created_at": "2024-05-08T22:31:57.000Z",
+  "created_at": "2024-05-17T19:56:00.000Z",
   "level_num": "custom",
   "user_id": 6959,
   "properties": {
     "encrypted": "false",
-    "long_instructions": "Add **html** pages and preview them in the right pane.\r\n\r\nAdd **css** pages (and link them to your html).\r\n\r\nUse the file browser to add/rename/delete files, or to add/rename/delete folders (including hierarchically!)"
+    "long_instructions": "Add **html** pages and preview them in the right pane.\r\n\r\nAdd **css** pages (and link them to your html).\r\n\r\nUse the file browser to add/rename/delete files, or to add/rename/delete folders (including hierarchically!)",
+    "offer_browser_tts": "false",
+    "product_tours": [
+      "resource_panel_onboarding"
+    ],
+    "submittable": "false",
+    "hide_share_and_remix": "false",
+    "disable_edit_run_for_submission": "false",
+    "widget_view": "false",
+    "initial_view_mode": "split",
+    "predict_settings": {
+      "isPredictLevel": false,
+      "solution": "",
+      "questionType": "freeResponse",
+      "placeholderText": "",
+      "multipleChoiceOptions": [
+        ""
+      ],
+      "freeResponseHeight": 50,
+      "codeEditableAfterSubmit": false
+    },
+    "ai_tutor_prompt_settings": {
+      "answerTypes": [
+        "buildHTML",
+        "buildCSS",
+        "ask",
+        "hint",
+        "debug",
+        "example",
+        "explainCode",
+        "documentation",
+        "pseudocode",
+        "testCase"
+      ],
+      "answerTypeCustomizations": {
+      }
+    }
   },
-  "published": true,
-  "audit_log": "[{\"changed_at\":\"2024-05-08T15:31:57.601-07:00\",\"changed\":[\"cloned from \\\"Allthethings Weblab2 1\\\"\"],\"cloned_from\":\"Allthethings Weblab2 1\"}]"
+  "audit_log": "[{\"changed_at\":\"2024-05-08T15:31:57.601-07:00\",\"changed\":[\"cloned from \\\"Allthethings Weblab2 1\\\"\"],\"cloned_from\":\"Allthethings Weblab2 1\"},{\"changed_at\":\"2026-04-06 09:12:37 -0700\",\"changed\":[],\"changed_by_id\":2,\"changed_by_email\":\"molly+levelbuilder@code.org\"}]"
 }]]></config>
 </Weblab2>


### PR DESCRIPTION
We found that if you go from a lab2 level without a product tour to one with a product tour, then go back, the product tour still shows up on the level that it does not belong to. This updates the logic to ensure we hide outdated product tours, and adds unit tests (most of the lines here are unit tests). In order to get this working I had to update some of the surrounding logic around starting and creating tours. For creating tours, we use refs for the callbacks so the tours aren't recreated unnecessarily. For starting tours, we previously only tracked if a tour had started at all, but now we check for the current instance being started now that we hide tours that get disposed.

## Before
https://github.com/user-attachments/assets/5b94b45c-99dd-48e1-b37f-0c9634e05783


## After
https://github.com/user-attachments/assets/cab5055a-4669-4f6b-9793-cdd7d1473f49


## Links

- Jira: [AFL-553](https://codedotorg.atlassian.net/browse/AFL-553)

## Testing story
Tested locally and added unit tests. 



