### PR TITLE
Web Lab 2: scroll to bottom of chat window on accept AI Tutor suggestion

### DIFF
--- a/apps/src/aiComponentLibrary/aiTutorVersionActions/AiTutorVersionActions.tsx
+++ b/apps/src/aiComponentLibrary/aiTutorVersionActions/AiTutorVersionActions.tsx
@@ -1,6 +1,6 @@
 import FontAwesomeV6Icon from '@code-dot-org/component-library/fontAwesomeV6Icon';
 import {Button as MuiButton} from '@mui/material';
-import React, {useState, useCallback, useEffect} from 'react';
+import React, {useState, useCallback, useEffect, useLayoutEffect} from 'react';
 
 import AiTutorVersionFileChip from '@cdo/apps/aiComponentLibrary/aiTutorVersionFileChip/AiTutorVersionFileChip';
 import Lab2Registry from '@cdo/apps/lab2/Lab2Registry';
@@ -15,7 +15,7 @@ import moduleStyles from './ai-tutor-version-actions.module.scss';
 
 interface AiTutorVersionActionsProps {
   files: ProjectFile[];
-  onRequestScrollToBottom?: () => void;
+  onRequestScrollToBottom: () => void;
 }
 
 /**
@@ -67,12 +67,13 @@ const AiTutorVersionActions: React.FC<AiTutorVersionActionsProps> = ({
     dispatch(rejectAiTutorVersion(files));
   }, [dispatch, files]);
 
-  const handleEnterAcceptMode = useCallback(() => {
-    setIsAcceptMode(true);
-    if (onRequestScrollToBottom) {
-      window.requestAnimationFrame(onRequestScrollToBottom);
+  // Scroll to the bottom of the page when switching to accept mode,
+  // so that the commit description input and save button are visible to the user.
+  useLayoutEffect(() => {
+    if (isAcceptMode) {
+      onRequestScrollToBottom();
     }
-  }, [onRequestScrollToBottom]);
+  }, [isAcceptMode, onRequestScrollToBottom]);
 
   return (
     <div className={moduleStyles.container}>
@@ -105,7 +106,7 @@ const AiTutorVersionActions: React.FC<AiTutorVersionActionsProps> = ({
             color="primary"
             size="small"
             className={moduleStyles.actionButton}
-            onClick={handleEnterAcceptMode}
+            onClick={() => setIsAcceptMode(true)}
             type="button"
             startIcon={
               <FontAwesomeV6Icon

--- a/apps/src/aiComponentLibrary/aiTutorVersionActions/AiTutorVersionActions.tsx
+++ b/apps/src/aiComponentLibrary/aiTutorVersionActions/AiTutorVersionActions.tsx
@@ -15,6 +15,7 @@ import moduleStyles from './ai-tutor-version-actions.module.scss';
 
 interface AiTutorVersionActionsProps {
   files: ProjectFile[];
+  onRequestScrollToBottom?: () => void;
 }
 
 /**
@@ -23,6 +24,7 @@ interface AiTutorVersionActionsProps {
  */
 const AiTutorVersionActions: React.FC<AiTutorVersionActionsProps> = ({
   files,
+  onRequestScrollToBottom,
 }) => {
   const [commitDescription, setCommitDescription] = useState('');
   const [isAcceptMode, setIsAcceptMode] = useState(false);
@@ -96,7 +98,12 @@ const AiTutorVersionActions: React.FC<AiTutorVersionActionsProps> = ({
             color="primary"
             size="small"
             className={moduleStyles.actionButton}
-            onClick={() => setIsAcceptMode(true)}
+            onClick={() => {
+              setIsAcceptMode(true);
+              if (onRequestScrollToBottom) {
+                window.requestAnimationFrame(onRequestScrollToBottom);
+              }
+            }}
             type="button"
             startIcon={
               <FontAwesomeV6Icon

--- a/apps/src/aiComponentLibrary/aiTutorVersionActions/AiTutorVersionActions.tsx
+++ b/apps/src/aiComponentLibrary/aiTutorVersionActions/AiTutorVersionActions.tsx
@@ -67,6 +67,13 @@ const AiTutorVersionActions: React.FC<AiTutorVersionActionsProps> = ({
     dispatch(rejectAiTutorVersion(files));
   }, [dispatch, files]);
 
+  const handleEnterAcceptMode = useCallback(() => {
+    setIsAcceptMode(true);
+    if (onRequestScrollToBottom) {
+      window.requestAnimationFrame(onRequestScrollToBottom);
+    }
+  }, [onRequestScrollToBottom]);
+
   return (
     <div className={moduleStyles.container}>
       <div className={moduleStyles.fileList}>
@@ -98,12 +105,7 @@ const AiTutorVersionActions: React.FC<AiTutorVersionActionsProps> = ({
             color="primary"
             size="small"
             className={moduleStyles.actionButton}
-            onClick={() => {
-              setIsAcceptMode(true);
-              if (onRequestScrollToBottom) {
-                window.requestAnimationFrame(onRequestScrollToBottom);
-              }
-            }}
+            onClick={handleEnterAcceptMode}
             type="button"
             startIcon={
               <FontAwesomeV6Icon

--- a/apps/src/aichat/views/ChatEventsList.tsx
+++ b/apps/src/aichat/views/ChatEventsList.tsx
@@ -99,7 +99,7 @@ const ChatEventsList: React.FunctionComponent<ChatEventsListProps> = ({
   const hasChatHistory = events.length > 0;
   const resolvedLastMessagePostText = useMemo(() => {
     if (renderLastMessagePostText) {
-      return renderLastMessagePostText(() => scrollToLastMessage());
+      return renderLastMessagePostText(scrollToLastMessage);
     }
     return lastMessagePostText;
   }, [lastMessagePostText, renderLastMessagePostText, scrollToLastMessage]);

--- a/apps/src/aichat/views/ChatEventsList.tsx
+++ b/apps/src/aichat/views/ChatEventsList.tsx
@@ -25,6 +25,9 @@ interface ChatEventsListProps {
   buildAssetUrl?: (asset: ChatAsset) => string;
   hasInstructionsDrawer?: boolean;
   lastMessagePostText?: React.ReactNode;
+  renderLastMessagePostText?: (
+    onRequestScrollToBottom: () => void
+  ) => React.ReactNode;
 }
 
 /**
@@ -38,6 +41,7 @@ const ChatEventsList: React.FunctionComponent<ChatEventsListProps> = ({
   buildAssetUrl,
   hasInstructionsDrawer,
   lastMessagePostText,
+  renderLastMessagePostText,
 }) => {
   const {chatDisabled, chatDisabledMessage} = useAiChatDisabled();
   const [isInChatNavigationMode, setIsInChatNavigationMode] = useState(false);
@@ -93,14 +97,20 @@ const ChatEventsList: React.FunctionComponent<ChatEventsListProps> = ({
   };
 
   const hasChatHistory = events.length > 0;
+  const resolvedLastMessagePostText = useMemo(() => {
+    if (renderLastMessagePostText) {
+      return renderLastMessagePostText(() => scrollToLastMessage());
+    }
+    return lastMessagePostText;
+  }, [lastMessagePostText, renderLastMessagePostText, scrollToLastMessage]);
 
   const lastChatMessageIndex = useMemo(() => {
-    if (!lastMessagePostText) return -1;
+    if (!resolvedLastMessagePostText) return -1;
     for (let i = events.length - 1; i >= 0; i--) {
       if (isChatMessage(events[i])) return i;
     }
     return -1;
-  }, [events, lastMessagePostText]);
+  }, [events, resolvedLastMessagePostText]);
 
   useEffect(() => {
     const container = conversationContainerRef.current;
@@ -217,7 +227,9 @@ const ChatEventsList: React.FunctionComponent<ChatEventsListProps> = ({
                   buildAssetUrl={buildAssetUrl}
                   clientType={clientType}
                   modelParameters={modelParameters}
-                  postText={isLastChatMessage ? lastMessagePostText : undefined}
+                  postText={
+                    isLastChatMessage ? resolvedLastMessagePostText : undefined
+                  }
                   ref={isLastEvent ? finalEventRef : undefined}
                   tabIndex={isInChatNavigationMode ? 0 : -1}
                   onKeyDown={e => {

--- a/apps/src/aichat/views/ChatEventsList.tsx
+++ b/apps/src/aichat/views/ChatEventsList.tsx
@@ -24,7 +24,6 @@ interface ChatEventsListProps {
   isTeacherView?: boolean;
   buildAssetUrl?: (asset: ChatAsset) => string;
   hasInstructionsDrawer?: boolean;
-  lastMessagePostText?: React.ReactNode;
   renderLastMessagePostText?: (
     onRequestScrollToBottom: () => void
   ) => React.ReactNode;
@@ -40,7 +39,6 @@ const ChatEventsList: React.FunctionComponent<ChatEventsListProps> = ({
   isTeacherView,
   buildAssetUrl,
   hasInstructionsDrawer,
-  lastMessagePostText,
   renderLastMessagePostText,
 }) => {
   const {chatDisabled, chatDisabledMessage} = useAiChatDisabled();
@@ -97,12 +95,12 @@ const ChatEventsList: React.FunctionComponent<ChatEventsListProps> = ({
   };
 
   const hasChatHistory = events.length > 0;
+
   const resolvedLastMessagePostText = useMemo(() => {
     if (renderLastMessagePostText) {
       return renderLastMessagePostText(scrollToLastMessage);
     }
-    return lastMessagePostText;
-  }, [lastMessagePostText, renderLastMessagePostText, scrollToLastMessage]);
+  }, [renderLastMessagePostText, scrollToLastMessage]);
 
   const lastChatMessageIndex = useMemo(() => {
     if (!resolvedLastMessagePostText) return -1;

--- a/apps/src/aichat/views/ChatWorkspace.tsx
+++ b/apps/src/aichat/views/ChatWorkspace.tsx
@@ -66,6 +66,9 @@ interface ChatWorkspaceProps {
 
   // Optional content to render after the last chat message (e.g. lab-specific actions).
   lastMessagePostText?: React.ReactNode;
+  renderLastMessagePostText?: (
+    onRequestScrollToBottom: () => void
+  ) => React.ReactNode;
 }
 
 /**
@@ -85,6 +88,7 @@ const ChatWorkspace: React.FunctionComponent<ChatWorkspaceProps> = ({
   logLevelActivity,
   hasInstructionsDrawer,
   lastMessagePostText,
+  renderLastMessagePostText,
 }) => {
   const {chatDisabled, chatDisabledMessage} = useAiChatDisabled();
   const canDisplayAssets = !!levelName && !!channelId;
@@ -320,6 +324,7 @@ const ChatWorkspace: React.FunctionComponent<ChatWorkspaceProps> = ({
           modelParameters={modelParameters}
           hasInstructionsDrawer={hasInstructionsDrawer}
           lastMessagePostText={lastMessagePostText}
+          renderLastMessagePostText={renderLastMessagePostText}
         />
       )}
       <div className={moduleStyles.footer}>

--- a/apps/src/aichat/views/ChatWorkspace.tsx
+++ b/apps/src/aichat/views/ChatWorkspace.tsx
@@ -65,7 +65,6 @@ interface ChatWorkspaceProps {
   hasInstructionsDrawer?: boolean;
 
   // Optional content to render after the last chat message (e.g. lab-specific actions).
-  lastMessagePostText?: React.ReactNode;
   renderLastMessagePostText?: (
     onRequestScrollToBottom: () => void
   ) => React.ReactNode;
@@ -87,7 +86,6 @@ const ChatWorkspace: React.FunctionComponent<ChatWorkspaceProps> = ({
   responseCallback,
   logLevelActivity,
   hasInstructionsDrawer,
-  lastMessagePostText,
   renderLastMessagePostText,
 }) => {
   const {chatDisabled, chatDisabledMessage} = useAiChatDisabled();
@@ -323,7 +321,6 @@ const ChatWorkspace: React.FunctionComponent<ChatWorkspaceProps> = ({
           clientType={clientType}
           modelParameters={modelParameters}
           hasInstructionsDrawer={hasInstructionsDrawer}
-          lastMessagePostText={lastMessagePostText}
           renderLastMessagePostText={renderLastMessagePostText}
         />
       )}

--- a/apps/src/lab2/views/components/AiTutorChat.tsx
+++ b/apps/src/lab2/views/components/AiTutorChat.tsx
@@ -100,10 +100,15 @@ const AiTutorChat: React.FunctionComponent<AiTutorChatProps> = ({
     );
   }
 
-  const lastMessagePostText =
-    viewingAiTutorVersionFileUpdates && versionFiles ? (
-      <AiTutorVersionActions files={versionFiles} />
-    ) : undefined;
+  const renderLastMessagePostText =
+    viewingAiTutorVersionFileUpdates && versionFiles
+      ? (onRequestScrollToBottom: () => void) => (
+          <AiTutorVersionActions
+            files={versionFiles}
+            onRequestScrollToBottom={onRequestScrollToBottom}
+          />
+        )
+      : undefined;
 
   return (
     <div className={moduleStyles.container}>
@@ -118,7 +123,7 @@ const AiTutorChat: React.FunctionComponent<AiTutorChatProps> = ({
         hideModelChangeMessage={true}
         responseCallback={aiTutorResponseSchemaSettings?.responseCallback}
         hasInstructionsDrawer={hasInstructionsDrawer}
-        lastMessagePostText={lastMessagePostText}
+        renderLastMessagePostText={renderLastMessagePostText}
       />
     </div>
   );

--- a/apps/src/lab2/views/components/AiTutorChat.tsx
+++ b/apps/src/lab2/views/components/AiTutorChat.tsx
@@ -3,7 +3,7 @@ import FontAwesomeV6Icon, {
 } from '@code-dot-org/component-library/fontAwesomeV6Icon';
 import {Button as MuiButton} from '@mui/material';
 import classNames from 'classnames';
-import React, {useMemo} from 'react';
+import React, {useCallback, useMemo} from 'react';
 
 import {
   ChatButtonClickHandler,
@@ -92,6 +92,21 @@ const AiTutorChat: React.FunctionComponent<AiTutorChatProps> = ({
     }));
   }, [aiTutorChatButtonData]);
 
+  const renderAiTutorVersionActions = useCallback(
+    (onRequestScrollToBottom: () => void) => (
+      <AiTutorVersionActions
+        files={versionFiles!}
+        onRequestScrollToBottom={onRequestScrollToBottom}
+      />
+    ),
+    [versionFiles]
+  );
+
+  const renderLastMessagePostText =
+    viewingAiTutorVersionFileUpdates && versionFiles
+      ? renderAiTutorVersionActions
+      : undefined;
+
   if (loading || !modelParameters) {
     return (
       <div className={moduleStyles.loading}>
@@ -99,16 +114,6 @@ const AiTutorChat: React.FunctionComponent<AiTutorChatProps> = ({
       </div>
     );
   }
-
-  const renderLastMessagePostText =
-    viewingAiTutorVersionFileUpdates && versionFiles
-      ? (onRequestScrollToBottom: () => void) => (
-          <AiTutorVersionActions
-            files={versionFiles}
-            onRequestScrollToBottom={onRequestScrollToBottom}
-          />
-        )
-      : undefined;
 
   return (
     <div className={moduleStyles.container}>


### PR DESCRIPTION
After accepting an AI Tutor suggestion, there's an additional input you need to fill out before the suggestion is fully accepted. That input is not scrolled into view prior to this change -- this PR scrolls it into view. 

https://github.com/user-attachments/assets/89d1b297-c2ab-4d81-b40b-76d84a77d288

## Links

- Jira: https://codedotorg.atlassian.net/browse/AFL-521

## Testing story

Tested manually (see video above).