### PR TITLE
Moderate user-uploaded images in AI Chat lab

### DIFF
--- a/apps/src/aichat/redux/slice.ts
+++ b/apps/src/aichat/redux/slice.ts
@@ -365,7 +365,11 @@ const aichatSlice = createSlice({
       state,
       action: PayloadAction<{
         key: string;
-        status: 'uploaded' | 'uploadFailed' | 'sizeLimitExceeded';
+        status:
+          | 'uploaded'
+          | 'uploadFailed'
+          | 'sizeLimitExceeded'
+          | 'imageFileFlagged';
       }>
     ) {
       const {key, status} = action.payload;

--- a/apps/src/aichat/redux/state.ts
+++ b/apps/src/aichat/redux/state.ts
@@ -81,6 +81,7 @@ export interface AichatState extends AiDiffChatState {
     | 'uploadFailed'
     | 'fileLimitExceeded'
     | 'sizeLimitExceeded'
+    | 'imageFileFlagged'
     | undefined;
   // If the user has a sent a message on this level
   hasSentMessage: boolean;

--- a/apps/src/aichat/redux/thunks/uploadFiles.ts
+++ b/apps/src/aichat/redux/thunks/uploadFiles.ts
@@ -48,7 +48,7 @@ export const uploadFiles = createAppAsyncThunk<
     let uploadSuccessCount = 0;
     let sizeLimitExceededCount = 0;
     let uploadFailureCount = 0;
-    let imageFileFlagged = false;
+    let imageFlaggedCount = 0;
     let fileCountPdf = 0;
     let fileCountImage = 0;
     for (const [key, asset, file] of allowedFiles) {
@@ -66,14 +66,14 @@ export const uploadFiles = createAppAsyncThunk<
       if (file.name.endsWith('.pdf')) {
         fileCountPdf += 1;
       } else {
-        fileCountImage += 1;
         // Moderate images before uploading.
         const moderationResult = await moderateImage(file, 'aichat', {});
         if (moderationResult === 'flagged') {
-          imageFileFlagged = true;
+          imageFlaggedCount += 1;
           dispatch(stagedFileUploadFinished({key, status: 'imageFileFlagged'}));
           continue;
         }
+        fileCountImage += 1;
       }
 
       try {
@@ -113,7 +113,7 @@ export const uploadFiles = createAppAsyncThunk<
         fileCountFailureSizeLimitExceeded: sizeLimitExceededCount,
         fileCountFailureUnknownCause: uploadFailureCount,
         fileCountFailureNumberExceeded: Math.max(excessFileCount, 0),
-        imageFileFlagged: imageFileFlagged,
+        imageFlaggedNotStagedCount: imageFlaggedCount,
         fileCountImage,
         fileCountPdf,
       })

--- a/apps/src/aichat/redux/thunks/uploadFiles.ts
+++ b/apps/src/aichat/redux/thunks/uploadFiles.ts
@@ -68,9 +68,7 @@ export const uploadFiles = createAppAsyncThunk<
       } else {
         fileCountImage += 1;
         // Moderate images before uploading.
-        const moderationResult = await moderateImage(file, 'aichat', {
-          assetUrl: buildAssetUrl(asset),
-        });
+        const moderationResult = await moderateImage(file, 'aichat', {});
         if (moderationResult === 'flagged') {
           imageFileFlagged = true;
           dispatch(stagedFileUploadFinished({key, status: 'imageFileFlagged'}));

--- a/apps/src/aichat/redux/thunks/uploadFiles.ts
+++ b/apps/src/aichat/redux/thunks/uploadFiles.ts
@@ -1,6 +1,7 @@
 import Lab2Registry from '@cdo/apps/lab2/Lab2Registry';
 import {EVENTS} from '@cdo/apps/metrics/AnalyticsConstants';
 import HttpClient, {NetworkError} from '@cdo/apps/util/HttpClient';
+import {moderateImage} from '@cdo/apps/util/moderateImage';
 import {createAppAsyncThunk} from '@cdo/apps/util/reduxHooks';
 
 import {MAX_FILE_SIZE_MB, MAX_NUM_FILES} from '../../constants';
@@ -47,6 +48,7 @@ export const uploadFiles = createAppAsyncThunk<
     let uploadSuccessCount = 0;
     let sizeLimitExceededCount = 0;
     let uploadFailureCount = 0;
+    let imageFileFlagged = false;
     let fileCountPdf = 0;
     let fileCountImage = 0;
     for (const [key, asset, file] of allowedFiles) {
@@ -65,6 +67,15 @@ export const uploadFiles = createAppAsyncThunk<
         fileCountPdf += 1;
       } else {
         fileCountImage += 1;
+        // Moderate images before uploading.
+        const moderationResult = await moderateImage(file, 'aichat', {
+          assetUrl: buildAssetUrl(asset),
+        });
+        if (moderationResult === 'flagged') {
+          imageFileFlagged = true;
+          dispatch(stagedFileUploadFinished({key, status: 'imageFlagged'}));
+          continue;
+        }
       }
 
       try {
@@ -104,6 +115,7 @@ export const uploadFiles = createAppAsyncThunk<
         fileCountFailureSizeLimitExceeded: sizeLimitExceededCount,
         fileCountFailureUnknownCause: uploadFailureCount,
         fileCountFailureNumberExceeded: Math.max(excessFileCount, 0),
+        imageFileFlagged: imageFileFlagged,
         fileCountImage,
         fileCountPdf,
       })

--- a/apps/src/aichat/redux/thunks/uploadFiles.ts
+++ b/apps/src/aichat/redux/thunks/uploadFiles.ts
@@ -73,7 +73,7 @@ export const uploadFiles = createAppAsyncThunk<
         });
         if (moderationResult === 'flagged') {
           imageFileFlagged = true;
-          dispatch(stagedFileUploadFinished({key, status: 'imageFlagged'}));
+          dispatch(stagedFileUploadFinished({key, status: 'imageFileFlagged'}));
           continue;
         }
       }

--- a/apps/src/aichat/views/assets/StagedFilesPreview.tsx
+++ b/apps/src/aichat/views/assets/StagedFilesPreview.tsx
@@ -29,6 +29,10 @@ const alerts = {
     `AI Chat supports a maximum file size of ${MAX_FILE_SIZE_MB}MB. Please try a smaller file.`,
     'danger',
   ] as const,
+  imageFileFlagged: [
+    'One or more of your images has been flagged by our content moderation policy and has not been attached.',
+    'danger',
+  ] as const,
 } satisfies {[key: string]: [string, AlertProps['type']]};
 
 interface StagedFilesPreviewProps {

--- a/apps/src/aichat/views/assets/StagedFilesPreview.tsx
+++ b/apps/src/aichat/views/assets/StagedFilesPreview.tsx
@@ -30,7 +30,7 @@ const alerts = {
     'danger',
   ] as const,
   imageFileFlagged: [
-    'One or more of your images has been flagged by our content moderation policy and has not been attached.',
+    'One or more of your images have been flagged by our content moderation policy and have not been attached.',
     'danger',
   ] as const,
 } satisfies {[key: string]: [string, AlertProps['type']]};

--- a/apps/src/aichat/views/assets/StagedFilesPreview.tsx
+++ b/apps/src/aichat/views/assets/StagedFilesPreview.tsx
@@ -59,31 +59,33 @@ const StagedFilesPreview: React.FC<StagedFilesPreviewProps> = ({
 
   return (
     <div className={styles.container}>
-      <div className={styles.row}>
-        {stagedFiles.map(({key, asset, status}) => {
-          const filename = asset.filename;
-          return (
-            <FilePreview
-              key={key}
-              type={filename.endsWith('.pdf') ? 'pdf' : 'image'}
-              url={`${buildAssetUrl(asset)}?t=${key}`}
-              filename={filename}
-              isUploading={status === 'uploading'}
-              onRemove={() => dispatch(removeStagedFile(key))}
-              onLoadError={() => {
-                dispatch(
-                  stagedFileUploadFinished({key, status: 'uploadFailed'})
-                );
-                Lab2Registry.getInstance()
-                  .getMetricsReporter()
-                  .logError('Error loading staged file', undefined, {
-                    asset,
-                  });
-              }}
-            />
-          );
-        })}
-      </div>
+      {stagedFiles.length > 0 && (
+        <div className={styles.row}>
+          {stagedFiles.map(({key, asset, status}) => {
+            const filename = asset.filename;
+            return (
+              <FilePreview
+                key={key}
+                type={filename.endsWith('.pdf') ? 'pdf' : 'image'}
+                url={`${buildAssetUrl(asset)}?t=${key}`}
+                filename={filename}
+                isUploading={status === 'uploading'}
+                onRemove={() => dispatch(removeStagedFile(key))}
+                onLoadError={() => {
+                  dispatch(
+                    stagedFileUploadFinished({key, status: 'uploadFailed'})
+                  );
+                  Lab2Registry.getInstance()
+                    .getMetricsReporter()
+                    .logError('Error loading staged file', undefined, {
+                      asset,
+                    });
+                }}
+              />
+            );
+          })}
+        </div>
+      )}
       {alertMessage && style && (
         <Alert
           type={style}

--- a/apps/test/unit/aichat/redux/thunks/uploadFilesTest.ts
+++ b/apps/test/unit/aichat/redux/thunks/uploadFilesTest.ts
@@ -1,0 +1,146 @@
+import {sendAnalytics} from '@cdo/apps/aichat/redux/thunks/sendAnalytics';
+import {uploadFiles} from '@cdo/apps/aichat/redux/thunks/uploadFiles';
+import {AssetSource, ChatAsset} from '@cdo/apps/aichat/types';
+import {RootState} from '@cdo/apps/types/redux';
+import HttpClient from '@cdo/apps/util/HttpClient';
+import {moderateImage} from '@cdo/apps/util/moderateImage';
+
+jest.mock('@cdo/apps/util/HttpClient');
+jest.mock('@cdo/apps/util/moderateImage', () => ({
+  moderateImage: jest.fn(),
+}));
+jest.mock('@cdo/apps/aichat/redux/thunks/sendAnalytics', () => ({
+  sendAnalytics: jest.fn(),
+}));
+jest.mock('@cdo/apps/lab2/Lab2Registry', () => ({
+  default: {
+    getInstance: () => ({
+      getMetricsReporter: () => ({logError: jest.fn()}),
+    }),
+  },
+}));
+
+const mockHttpClient = HttpClient as jest.Mocked<typeof HttpClient>;
+const mockModerateImage = moderateImage as jest.Mock;
+const mockSendAnalytics = sendAnalytics as jest.Mock;
+
+const makeFile = (name: string, type = 'image/png', size = 100): File =>
+  Object.defineProperty(new File(['x'.repeat(size)], name, {type}), 'size', {
+    value: size,
+  });
+
+const buildAssetUrl = (asset: ChatAsset) => `/files/${asset.filename}`;
+
+const makeGetState = (numStagedFiles = 0) =>
+  (() => ({
+    aichat: {stagedFiles: Array(numStagedFiles).fill(null)},
+  })) as unknown as () => RootState;
+
+describe('uploadFiles', () => {
+  let dispatch: jest.Mock;
+
+  beforeEach(() => {
+    dispatch = jest.fn();
+    mockHttpClient.put.mockResolvedValue({} as Response);
+    mockModerateImage.mockResolvedValue('ok');
+    mockSendAnalytics.mockReturnValue(jest.fn());
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('image moderation', () => {
+    it('does not call HttpClient.put for a flagged image', async () => {
+      mockModerateImage.mockResolvedValue('flagged');
+      const file = makeFile('photo.png');
+
+      await uploadFiles({files: [file], buildAssetUrl})(
+        dispatch,
+        makeGetState(),
+        undefined
+      );
+
+      expect(mockHttpClient.put).not.toHaveBeenCalled();
+    });
+
+    it('dispatches stagedFileUploadFinished with imageFileFlagged for a flagged image', async () => {
+      mockModerateImage.mockResolvedValue('flagged');
+      const file = makeFile('photo.png');
+
+      await uploadFiles({files: [file], buildAssetUrl})(
+        dispatch,
+        makeGetState(),
+        undefined
+      );
+
+      const calls = dispatch.mock.calls.map(([action]) => action);
+      expect(calls).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            payload: expect.objectContaining({status: 'imageFileFlagged'}),
+          }),
+        ])
+      );
+    });
+
+    it('still uploads non-flagged files when one file is flagged', async () => {
+      mockModerateImage
+        .mockResolvedValueOnce('flagged')
+        .mockResolvedValueOnce('ok');
+      const flaggedFile = makeFile('bad.png');
+      const cleanFile = makeFile('good.png');
+
+      await uploadFiles({files: [flaggedFile, cleanFile], buildAssetUrl})(
+        dispatch,
+        makeGetState(),
+        undefined
+      );
+
+      expect(mockHttpClient.put).toHaveBeenCalledTimes(1);
+      expect(mockHttpClient.put).toHaveBeenCalledWith(
+        buildAssetUrl({filename: 'good.png', source: AssetSource.PROJECT}),
+        cleanFile
+      );
+    });
+
+    it('skips moderation for PDF files', async () => {
+      const pdfFile = makeFile('doc.pdf', 'application/pdf');
+
+      await uploadFiles({files: [pdfFile], buildAssetUrl})(
+        dispatch,
+        makeGetState(),
+        undefined
+      );
+
+      expect(mockModerateImage).not.toHaveBeenCalled();
+      expect(mockHttpClient.put).toHaveBeenCalledTimes(1);
+    });
+
+    it('uploads the image when moderation returns ok', async () => {
+      mockModerateImage.mockResolvedValue('ok');
+      const file = makeFile('photo.png');
+
+      await uploadFiles({files: [file], buildAssetUrl})(
+        dispatch,
+        makeGetState(),
+        undefined
+      );
+
+      expect(mockHttpClient.put).toHaveBeenCalledTimes(1);
+    });
+
+    it('uploads the image when moderation is skipped', async () => {
+      mockModerateImage.mockResolvedValue('skipped');
+      const file = makeFile('photo.png');
+
+      await uploadFiles({files: [file], buildAssetUrl})(
+        dispatch,
+        makeGetState(),
+        undefined
+      );
+
+      expect(mockHttpClient.put).toHaveBeenCalledTimes(1);
+    });
+  });
+});


### PR DESCRIPTION
<!--
  Summary of the change: background, motivation, and context.
  Include screenshots, videos, or before/after comparisons for UI changes.
-->
This PR adds moderation to user-uploaded images in AI Chat Lab. A user can currently upload an image via the 'Add file' button in the user chat message editor or by copying and pasting to the editor. Both of these pathways use the redux thunk `uploadFiles` so the call to moderation was added there. Note that starter assets are added to the message editor by a different pathway (using `StarterAssetsDialog`) so are NOT moderated.
https://github.com/code-dot-org/code-dot-org/blob/02721ddcc9c5da0720b3830c7b85655e4b10ab6e/apps/src/aichat/views/assets/UploadButton.tsx#L151-L152


The number of flagged images that were attempted to be staged is included in the Statsig report 'User stages multimodal assets'.

## Links
<!-- Jira tickets, design docs, Slack threads, related PRs, etc. -->

- Jira: https://codedotorg.atlassian.net/browse/SL-1641
- [Slack thread](https://codedotorg.slack.com/archives/C0ACVGPJ0AY/p1775487023544669)

## Testing story
<!-- How was this tested? Manual steps, adhoc links, automated tests, or why testing isn't needed. -->

I attempted to upload multiple images and those that were flagged were not attached while those that were 'safe' were attached and the alert was displayed.

### After update

User uploading images via 'Add file' button (first flagged, and then flagged and safe) when there are no starter assets on the level: 

https://github.com/user-attachments/assets/46aec9bc-51b8-448b-ac04-148432fc55fe


User uploading images via copy/paste:

https://github.com/user-attachments/assets/a312fdd2-4337-460f-864d-7e185426bc3a



User uploading images via 'Add file' button (first flagged, and then flagged and safe) when there are starter assets on the level: 


https://github.com/user-attachments/assets/a89e155a-ebd4-4fa6-ae30-1772ebb5cf79


Screencast video of statsig report sent when user attempts to upload flagged images:


https://github.com/user-attachments/assets/ee3de5b9-4779-48e8-9bfd-cab86fa405b4




## Deployment notes
<!-- Delete this section if it's a standard merge-and-deploy.
     Otherwise: migrations, feature flags, coordination, caching impacts, etc. -->



## Privacy and security
<!-- Delete this section if there is no privacy/security impact.
     Otherwise: new PII, auth changes, API surface changes, etc. -->

