### PR TITLE
Web Lab 2: add button to allow rejecting changes when writing commit message

### DIFF
--- a/apps/src/aiComponentLibrary/aiTutorVersionActions/AiTutorVersionActions.tsx
+++ b/apps/src/aiComponentLibrary/aiTutorVersionActions/AiTutorVersionActions.tsx
@@ -173,7 +173,7 @@ const AiTutorVersionActions: React.FC<AiTutorVersionActionsProps> = ({
             >
               <MuiIconButton
                 variant="outlined"
-                color="secondary"
+                color="tertiary"
                 size="small"
                 onClick={handleReject}
                 type="button"

--- a/apps/src/aiComponentLibrary/aiTutorVersionActions/AiTutorVersionActions.tsx
+++ b/apps/src/aiComponentLibrary/aiTutorVersionActions/AiTutorVersionActions.tsx
@@ -1,5 +1,6 @@
 import FontAwesomeV6Icon from '@code-dot-org/component-library/fontAwesomeV6Icon';
-import {Button as MuiButton} from '@mui/material';
+import {WithTooltip} from '@code-dot-org/component-library/tooltip';
+import {Button as MuiButton, IconButton as MuiIconButton} from '@mui/material';
 import React, {useState, useCallback, useEffect, useLayoutEffect} from 'react';
 
 import AiTutorVersionFileChip from '@cdo/apps/aiComponentLibrary/aiTutorVersionFileChip/AiTutorVersionFileChip';
@@ -146,19 +147,42 @@ const AiTutorVersionActions: React.FC<AiTutorVersionActionsProps> = ({
             />
             This is what you'll see in the version history.
           </div>
-          <MuiButton
-            variant="contained"
-            color="primary"
-            size="small"
-            className={moduleStyles.saveAiTutorVersionButton}
-            id="save-ai-tutor-version-button"
-            disabled={isSaving || commitDescription.trim() === ''}
-            onClick={handleSaveAiTutorVersion}
-            type="button"
-            startIcon={<FontAwesomeV6Icon iconName="save" iconStyle="solid" />}
-          >
-            Accept and save version
-          </MuiButton>
+          <div className={moduleStyles.saveAiTutorVersionActions}>
+            <MuiButton
+              variant="contained"
+              color="primary"
+              size="small"
+              className={moduleStyles.saveAiTutorVersionButton}
+              id="save-ai-tutor-version-button"
+              disabled={isSaving || commitDescription.trim() === ''}
+              onClick={handleSaveAiTutorVersion}
+              type="button"
+              startIcon={
+                <FontAwesomeV6Icon iconName="save" iconStyle="solid" />
+              }
+            >
+              Accept and save version
+            </MuiButton>
+            <WithTooltip
+              tooltipProps={{
+                text: 'Cancel AI Changes',
+                size: 's',
+                tooltipId: 'cancel-ai-tutor-version-tooltip',
+                direction: 'onBottom',
+              }}
+            >
+              <MuiIconButton
+                variant="outlined"
+                color="secondary"
+                size="small"
+                onClick={handleReject}
+                type="button"
+                aria-label="Cancel AI Changes"
+              >
+                <FontAwesomeV6Icon iconName="xmark" iconStyle="solid" />
+              </MuiIconButton>
+            </WithTooltip>
+          </div>
         </div>
       )}
     </div>

--- a/apps/src/aiComponentLibrary/aiTutorVersionActions/AiTutorVersionActions.tsx
+++ b/apps/src/aiComponentLibrary/aiTutorVersionActions/AiTutorVersionActions.tsx
@@ -165,9 +165,9 @@ const AiTutorVersionActions: React.FC<AiTutorVersionActionsProps> = ({
             </MuiButton>
             <WithTooltip
               tooltipProps={{
-                text: 'Cancel AI Changes',
+                text: 'Reject AI Changes',
                 size: 's',
-                tooltipId: 'cancel-ai-tutor-version-tooltip',
+                tooltipId: 'secondary-reject-ai-tutor-version-tooltip',
                 direction: 'onBottom',
               }}
             >
@@ -177,7 +177,7 @@ const AiTutorVersionActions: React.FC<AiTutorVersionActionsProps> = ({
                 size="small"
                 onClick={handleReject}
                 type="button"
-                aria-label="Cancel AI Changes"
+                aria-label="Reject AI Changes"
               >
                 <FontAwesomeV6Icon iconName="xmark" iconStyle="solid" />
               </MuiIconButton>

--- a/apps/src/aiComponentLibrary/aiTutorVersionActions/ai-tutor-version-actions.module.scss
+++ b/apps/src/aiComponentLibrary/aiTutorVersionActions/ai-tutor-version-actions.module.scss
@@ -62,11 +62,10 @@
 
 .saveAiTutorVersionButton {
   flex: 1;
-  height: 32px;
-  box-sizing: border-box;
 }
 
 .saveAiTutorVersionActions {
   display: flex;
+  align-items: center;
   gap: 8px;
 }

--- a/apps/src/aiComponentLibrary/aiTutorVersionActions/ai-tutor-version-actions.module.scss
+++ b/apps/src/aiComponentLibrary/aiTutorVersionActions/ai-tutor-version-actions.module.scss
@@ -61,7 +61,12 @@
 }
 
 .saveAiTutorVersionButton {
-  width: 100%;
+  flex: 1;
   height: 32px;
   box-sizing: border-box;
+}
+
+.saveAiTutorVersionActions {
+  display: flex;
+  gap: 8px;
 }


### PR DESCRIPTION
Adds a button that allows rejecting changes once you've hit the initial "Accept" button in AI Tutor (but haven't written a commit message yet).

https://github.com/user-attachments/assets/6db48801-2231-4fef-816c-b513cd285430

## Links

- Jira: https://codedotorg.atlassian.net/browse/AFL-526
- Slack discussion: https://codedotorg.slack.com/archives/C09EHQE4DGD/p1775252682795329

## Testing story

Tested manually (see video above).