### PR TITLE
Web Lab 2: disable chat while in accept reject flow

### DIFF
--- a/apps/src/aichat/types/chatComponents.ts
+++ b/apps/src/aichat/types/chatComponents.ts
@@ -24,6 +24,7 @@ export type ChatButtonClickHandler = (
 
 export type ChatButtonProps = {
   onClick: ChatButtonClickHandler;
+  disabled?: boolean;
 };
 
 export type ChatButtonComponent = React.ComponentType<ChatButtonProps>;

--- a/apps/src/aichat/views/UserChatMessageEditor.tsx
+++ b/apps/src/aichat/views/UserChatMessageEditor.tsx
@@ -4,6 +4,7 @@ import React, {useCallback, useEffect, useRef, useState} from 'react';
 import {useAiChatDisabled} from '@cdo/apps/aichat/context/aiChatDisabledContext';
 import UserMessageEditor from '@cdo/apps/aiComponentLibrary/userMessageEditor/UserMessageEditor';
 import AiTutorEnglishOnlyWarning from '@cdo/apps/aiTutor/views/AiTutorEnglishOnlyWarning';
+import {isViewingAiTutorVersionFileUpdates} from '@cdo/apps/lab2/redux/lab2ReduxSelectors';
 import experiments from '@cdo/apps/util/experiments';
 import {useAppDispatch, useAppSelector} from '@cdo/apps/util/reduxHooks';
 
@@ -69,6 +70,10 @@ const UserChatMessageEditor: React.FunctionComponent<
     selectIsWaitingForChatResponse
   );
 
+  const viewingAiTutorVersionFileUpdates = useAppSelector(
+    isViewingAiTutorVersionFileUpdates
+  );
+
   const saveInProgress = useAppSelector(state => state.aichat.saveInProgress);
   const chatAssets = useAppSelector(state =>
     state.aichat.stagedFiles.map(file => file.asset)
@@ -88,6 +93,7 @@ const UserChatMessageEditor: React.FunctionComponent<
     isWaitingForChatResponse ||
     saveInProgress ||
     uploadsPending ||
+    viewingAiTutorVersionFileUpdates ||
     chatDisabled;
 
   const clearUserMessage = () => setUserMessage('');

--- a/apps/src/aichat/views/UserChatMessageEditor.tsx
+++ b/apps/src/aichat/views/UserChatMessageEditor.tsx
@@ -184,7 +184,7 @@ const UserChatMessageEditor: React.FunctionComponent<
       {chatButtons && chatButtons.length > 0 && !chatDisabled && (
         <div className={moduleStyles.chatButtonsContainer}>
           {chatButtons.map(({ChatButton, key}) => (
-            <ChatButton key={key} onClick={handleSubmit} />
+            <ChatButton key={key} onClick={handleSubmit} disabled={disabled} />
           ))}
         </div>
       )}

--- a/apps/src/lab2/views/components/AiTutorChat.tsx
+++ b/apps/src/lab2/views/components/AiTutorChat.tsx
@@ -64,12 +64,19 @@ const AiTutorChat: React.FunctionComponent<AiTutorChatProps> = ({
   const chatButtons = useMemo(() => {
     const chatButtonDataToUse = aiTutorChatButtonData || defaultChatButtonData;
     return chatButtonDataToUse.map(button => ({
-      ChatButton: ({onClick}: {onClick: ChatButtonClickHandler}) => (
+      ChatButton: ({
+        onClick,
+        disabled,
+      }: {
+        onClick: ChatButtonClickHandler;
+        disabled?: boolean;
+      }) => (
         <MuiButton
           variant="outlined"
           color="secondary"
           size="small"
           className={moduleStyles.chatButton}
+          disabled={disabled}
           onClick={() => onClick(button.value, button.analyticsProperties)}
           aria-label={button.label}
           startIcon={


### PR DESCRIPTION
Disables sending more messages to AI Tutor while you're in the middle of the accept/reject flow.

I also disabled ChatButtons (ie the "Give an example", "Show a hint" buttons that appear in some usages of AI Tutor) when the chat message editor is disabled. This isn't strictly necessary for Web Lab 2, but feels appropriate to make consistent with other disabled buttons in the chat editor? That commit is separate though and can be reverted if folks feel like that's a bad idea.

### Updated view (example prompt buttons not actually visible in Web Lab 2)

<img height="400" alt="image" src="https://github.com/user-attachments/assets/345fbb8f-cc19-49fa-83e1-969a25cc11a9" />

## Links

- Jira: https://codedotorg.atlassian.net/browse/AFL-550

## Testing story

Tested manually.