### PR TITLE
Update `eyes_selenium` to 5.0.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -119,7 +119,7 @@ group :development, :test do
 
   # For UI testing.
   gem 'cucumber'
-  gem 'eyes_selenium', '~> 4.0'
+  gem 'eyes_selenium', '~> 5.0'
   gem 'fakefs', '~> 2.5.0', require: false
   gem 'minitest', '~> 5.15'
   gem 'minitest-around'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -422,22 +422,22 @@ GEM
     eventmachine (1.2.7)
     execjs (2.7.0)
     exifr (1.2.5)
-    eyes_core (4.6.3)
+    eyes_core (5.0.0)
       colorize
-      eyes_universal (~> 3.3.3)
+      eyes_universal (~> 3.6.0)
       faraday
       faraday-cookie_jar
       faraday_middleware
       oj
       sorted_set
       websocket
-    eyes_selenium (4.6.3)
+    eyes_selenium (5.0.0)
       crass
       css_parser
-      eyes_core (= 4.6.3)
+      eyes_core (= 5.0.0)
       selenium-webdriver (>= 3)
       state_machine
-    eyes_universal (3.3.3)
+    eyes_universal (3.6.0)
     factory_bot (6.2.1)
       activesupport (>= 5.0.0)
     factory_bot_rails (6.2.0)
@@ -460,9 +460,9 @@ GEM
       faraday-rack (~> 1.0)
       faraday-retry (~> 1.0)
       ruby2_keywords (>= 0.0.4)
-    faraday-cookie_jar (0.0.7)
+    faraday-cookie_jar (0.0.8)
       faraday (>= 0.8.0)
-      http-cookie (~> 1.0.0)
+      http-cookie (>= 1.0.0)
     faraday-em_http (1.0.0)
     faraday-em_synchrony (1.0.0)
     faraday-excon (1.1.0)
@@ -1279,7 +1279,7 @@ DEPENDENCIES
   dotiw
   drb
   execjs
-  eyes_selenium (~> 4.0)
+  eyes_selenium (~> 5.0)
   factory_bot_rails (~> 6.2)
   fakefs (~> 2.5.0)
   faker (~> 3.4)


### PR DESCRIPTION
Part of our ongoing work to get it updated to `>= 6.0.4`, to pick up Ruby 3.2 compatibility. We get several `EOFError` and `ECONNRESET` errors on 6.x that we don't get on 4.x. Manual testing indicates that we also don't get the errors on 5.x, so as a stepping stone we target that to reduce our scope while we debug what's going wrong on 6.x

See https://github.com/code-dot-org/code-dot-org/pull/71920 for more details.

<!--
  Summary of the change: background, motivation, and context.
  Include screenshots, videos, or before/after comparisons for UI changes.
-->



## Links
<!-- Jira tickets, design docs, Slack threads, related PRs, etc. -->

- Jira:

## Testing story
<!-- How was this tested? Manual steps, adhoc links, automated tests, or why testing isn't needed. -->



## Deployment notes
<!-- Delete this section if it's a standard merge-and-deploy.
     Otherwise: migrations, feature flags, coordination, caching impacts, etc. -->



## Privacy and security
<!-- Delete this section if there is no privacy/security impact.
     Otherwise: new PII, auth changes, API surface changes, etc. -->

