### PR TITLE
Add new fields to BubbleChoice.serialize

### DIFF
--- a/dashboard/app/dsl/bubble_choice_dsl.rb
+++ b/dashboard/app/dsl/bubble_choice_dsl.rb
@@ -72,7 +72,6 @@ class BubbleChoiceDSL < ContentDSL
     end
 
     # Serialize additional properties, separated by a blank line from sublevels.
-    # uses_lab2 must come before standalone, since standalone requires uses_lab2.
     extra_lines = []
     extra_lines << "custom_mode '#{level.custom_mode}'" if level.custom_mode.present?
     extra_lines << "uses_lab2" if level.uses_lab2

--- a/dashboard/app/dsl/bubble_choice_dsl.rb
+++ b/dashboard/app/dsl/bubble_choice_dsl.rb
@@ -71,6 +71,18 @@ class BubbleChoiceDSL < ContentDSL
       new_dsl += "\nlevel '#{sublevel.name}'"
     end
 
+    # Serialize additional properties, separated by a blank line from sublevels.
+    # uses_lab2 must come before standalone, since standalone requires uses_lab2.
+    extra_lines = []
+    extra_lines << "custom_mode '#{level.custom_mode}'" if level.custom_mode.present?
+    extra_lines << "uses_lab2" if level.uses_lab2
+    extra_lines << "hide_letters_lab2" if level.hide_letters_lab2
+    extra_lines << "standalone" if level.is_project_level
+    extra_lines << "navigation_type '#{level.navigation_type}'" if level.navigation_type.present?
+    extra_lines << "finish_dialog '#{escape(level.finish_dialog)}'" if level.finish_dialog.present?
+    extra_lines << "hide_share_and_remix '#{level.hide_share_and_remix}'" unless level.hide_share_and_remix.nil?
+    new_dsl += "\n\n#{extra_lines.join("\n")}" if extra_lines.any?
+
     new_dsl += "\n"
     new_dsl
   end

--- a/dashboard/test/dsl/bubble_choice_dsl_test.rb
+++ b/dashboard/test/dsl/bubble_choice_dsl_test.rb
@@ -83,6 +83,88 @@ class BubbleChoiceDslTest < ActiveSupport::TestCase
     assert_equal output_dsl, BubbleChoiceDSL.serialize(bubble_choice)
   end
 
+  test 'create then serialize with uses_lab2 returns original DSL' do
+    input_dsl = <<~DSL
+      name 'bubble choice'
+      display_name 'My Level'
+      description 'My Description'
+
+      sublevels
+      level 'bubble choice level 1'
+      level 'bubble choice level 2'
+
+      uses_lab2
+    DSL
+
+    bubble_choice = BubbleChoice.create_from_level_builder({}, {name: 'bubble choice', dsl_text: input_dsl})
+    assert bubble_choice.uses_lab2
+    assert_equal input_dsl, BubbleChoiceDSL.serialize(bubble_choice)
+  end
+
+  test 'create then serialize with all lab2 properties returns original DSL' do
+    input_dsl = <<~DSL
+      name 'bubble choice'
+      display_name 'My Level'
+      description 'My Description'
+
+      sublevels
+      level 'bubble choice level 1'
+      level 'bubble choice level 2'
+
+      custom_mode 'music_dance_ai'
+      uses_lab2
+      hide_letters_lab2
+      standalone
+      navigation_type 'next_level'
+      finish_dialog 'hoai2025'
+      hide_share_and_remix 'false'
+    DSL
+
+    bubble_choice = BubbleChoice.create_from_level_builder({}, {name: 'bubble choice', dsl_text: input_dsl})
+    assert bubble_choice.uses_lab2
+    assert bubble_choice.hide_letters_lab2
+    assert bubble_choice.is_project_level
+    assert_equal 'music_dance_ai', bubble_choice.custom_mode
+    assert_equal 'next_level', bubble_choice.navigation_type
+    assert_equal 'hoai2025', bubble_choice.finish_dialog
+    assert_equal 'false', bubble_choice.hide_share_and_remix
+    assert_equal input_dsl, BubbleChoiceDSL.serialize(bubble_choice)
+  end
+
+  test 'create then serialize with navigation_type and finish_dialog returns original DSL' do
+    input_dsl = <<~DSL
+      name 'bubble choice'
+
+      sublevels
+      level 'bubble choice level 1'
+
+      uses_lab2
+      navigation_type 'next_level'
+      finish_dialog 'hoai2025'
+    DSL
+
+    bubble_choice = BubbleChoice.create_from_level_builder({}, {name: 'bubble choice', dsl_text: input_dsl})
+    assert_equal 'next_level', bubble_choice.navigation_type
+    assert_equal 'hoai2025', bubble_choice.finish_dialog
+    assert_equal input_dsl, BubbleChoiceDSL.serialize(bubble_choice)
+  end
+
+  test 'serialize escapes single quotes in finish_dialog' do
+    input_dsl = <<~DSL
+      name 'bubble choice'
+
+      sublevels
+      level 'bubble choice level 1'
+
+      uses_lab2
+      finish_dialog 'Author\\'s Dialog'
+    DSL
+
+    bubble_choice = BubbleChoice.create_from_level_builder({}, {name: 'bubble choice', dsl_text: input_dsl})
+    assert_equal "Author's Dialog", bubble_choice.finish_dialog
+    assert_equal input_dsl, BubbleChoiceDSL.serialize(bubble_choice)
+  end
+
   test 'escape method escapes single quotes' do
     result = BubbleChoiceDSL.escape("foo'bar")
     assert_equal "foo\\'bar", result

--- a/dashboard/test/dsl/bubble_choice_dsl_test.rb
+++ b/dashboard/test/dsl/bubble_choice_dsl_test.rb
@@ -113,22 +113,6 @@ class BubbleChoiceDslTest < ActiveSupport::TestCase
     assert_equal input_dsl, BubbleChoiceDSL.serialize(bubble_choice)
   end
 
-  test 'serialize escapes single quotes in finish_dialog' do
-    input_dsl = <<~DSL
-      name 'bubble choice'
-
-      sublevels
-      level 'bubble choice level 1'
-
-      uses_lab2
-      finish_dialog 'Author\\'s Dialog'
-    DSL
-
-    bubble_choice = BubbleChoice.create_from_level_builder({}, {name: 'bubble choice', dsl_text: input_dsl})
-    assert_equal "Author's Dialog", bubble_choice.finish_dialog
-    assert_equal input_dsl, BubbleChoiceDSL.serialize(bubble_choice)
-  end
-
   test 'escape method escapes single quotes' do
     result = BubbleChoiceDSL.escape("foo'bar")
     assert_equal "foo\\'bar", result

--- a/dashboard/test/dsl/bubble_choice_dsl_test.rb
+++ b/dashboard/test/dsl/bubble_choice_dsl_test.rb
@@ -83,24 +83,6 @@ class BubbleChoiceDslTest < ActiveSupport::TestCase
     assert_equal output_dsl, BubbleChoiceDSL.serialize(bubble_choice)
   end
 
-  test 'create then serialize with uses_lab2 returns original DSL' do
-    input_dsl = <<~DSL
-      name 'bubble choice'
-      display_name 'My Level'
-      description 'My Description'
-
-      sublevels
-      level 'bubble choice level 1'
-      level 'bubble choice level 2'
-
-      uses_lab2
-    DSL
-
-    bubble_choice = BubbleChoice.create_from_level_builder({}, {name: 'bubble choice', dsl_text: input_dsl})
-    assert bubble_choice.uses_lab2
-    assert_equal input_dsl, BubbleChoiceDSL.serialize(bubble_choice)
-  end
-
   test 'create then serialize with all lab2 properties returns original DSL' do
     input_dsl = <<~DSL
       name 'bubble choice'
@@ -128,24 +110,6 @@ class BubbleChoiceDslTest < ActiveSupport::TestCase
     assert_equal 'next_level', bubble_choice.navigation_type
     assert_equal 'hoai2025', bubble_choice.finish_dialog
     assert_equal 'false', bubble_choice.hide_share_and_remix
-    assert_equal input_dsl, BubbleChoiceDSL.serialize(bubble_choice)
-  end
-
-  test 'create then serialize with navigation_type and finish_dialog returns original DSL' do
-    input_dsl = <<~DSL
-      name 'bubble choice'
-
-      sublevels
-      level 'bubble choice level 1'
-
-      uses_lab2
-      navigation_type 'next_level'
-      finish_dialog 'hoai2025'
-    DSL
-
-    bubble_choice = BubbleChoice.create_from_level_builder({}, {name: 'bubble choice', dsl_text: input_dsl})
-    assert_equal 'next_level', bubble_choice.navigation_type
-    assert_equal 'hoai2025', bubble_choice.finish_dialog
     assert_equal input_dsl, BubbleChoiceDSL.serialize(bubble_choice)
   end
 


### PR DESCRIPTION
A few properties were missing from BubbleChoice.serialize, which caused them to be dropped when we copied scripts and lessons. These properties were:
- uses_lab2
- navigation_type
- hide_letters_lab2
- custom_mode
- standalone
- finish_dialog
- hide_share_and_remix

This PR adds them into the serialize method, separated by a newline from the sublevels list.

