### PR TITLE
update s3 location

### DIFF
--- a/dashboard/app/jobs/concerns/ai_rubric_config.rb
+++ b/dashboard/app/jobs/concerns/ai_rubric_config.rb
@@ -6,7 +6,7 @@ class AiRubricConfig
   #
   # Basic validation of the new AI config is done by UI tests, or can be done locally
   # by running `AiRubricConfig.validate_ai_config` from the rails console.
-  S3_AI_RELEASE_PATH = 'teaching_assistant/releases/2024-09-05-lesson-7-release/'.freeze
+  S3_AI_RELEASE_PATH = 'teaching_assistant/releases/2026-04-06-claude-4-update/'.freeze
 
   # For testing purposes, we can raise this error to simulate a missing key
   class StubNoSuchKey < StandardError


### PR DESCRIPTION
This PR updates the S3 location for AI rubric evaluation files to the new release at `cdo-ai/teaching_assistant/releases/2026-04-06-claude-4-update`

This update is connected to [this PR on aiproxy](https://github.com/code-dot-org/aiproxy/pull/108) that updates the model to Claude Sonnet 4.5

## Links
<!-- Jira tickets, design docs, Slack threads, related PRs, etc. -->

- Jira:

## Testing story
<!-- How was this tested? Manual steps, adhoc links, automated tests, or why testing isn't needed. -->



## Deployment notes
<!-- Delete this section if it's a standard merge-and-deploy.
     Otherwise: migrations, feature flags, coordination, caching impacts, etc. -->



## Privacy and security
<!-- Delete this section if there is no privacy/security impact.
     Otherwise: new PII, auth changes, API surface changes, etc. -->

