### PR TITLE
Add missing properties to cloned 2026 bubblechoice levels

### DIFF
--- a/bin/oneoff/migrate_bubble_choice_properties.rb
+++ b/bin/oneoff/migrate_bubble_choice_properties.rb
@@ -1,0 +1,112 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Migrate missing BubbleChoice properties from 2025 DSL files to their
+# 2026 and 2025_v2 counterparts.
+#
+# The BubbleChoiceDSL.serialize method had a bug that omitted 7 properties
+# when cloning curriculum. This script copies those properties from the
+# 2025 source files to cloned targets.
+#
+# Usage:
+#   ruby bin/oneoff/migrate_bubble_choice_properties.rb          # dry run
+#   ruby bin/oneoff/migrate_bubble_choice_properties.rb --write  # apply changes
+
+SCRIPTS_DIR = File.expand_path('../../dashboard/config/scripts', __dir__)
+WRITE_MODE = ARGV.include?('--write')
+
+PROPERTIES = %w[uses_lab2 hide_letters_lab2 custom_mode navigation_type standalone finish_dialog hide_share_and_remix].freeze
+PROPERTY_REGEX = /\A(#{PROPERTIES.join('|')})(\s+'[^']*')?\s*\z/
+CANONICAL_ORDER = %w[custom_mode uses_lab2 hide_letters_lab2 standalone navigation_type finish_dialog hide_share_and_remix].freeze
+
+def extract_properties(content)
+  content.lines.filter_map do |line|
+    stripped = line.strip
+    stripped.match?(PROPERTY_REGEX) ? stripped : nil
+  end
+end
+
+def find_counterparts(source_path)
+  base = source_path.sub(/_2025\.bubble_choice$/, '')
+  targets = Dir.glob("#{base}_2026*.bubble_choice") +
+    Dir.glob("#{base}_2025_v2*.bubble_choice")
+  targets.sort
+end
+
+def sort_properties(props)
+  props.sort_by {|p| CANONICAL_ORDER.index(p.split(/\s+/).first) || 999}
+end
+
+def append_properties(target_content, missing_props)
+  sorted = sort_properties(missing_props)
+  target_content.rstrip + "\n\n" + sorted.join("\n") + "\n"
+end
+
+# --- Main ---
+
+puts WRITE_MODE ? "=== WRITE MODE ===" : "=== DRY RUN === (pass --write to apply changes)"
+puts
+
+source_files = Dir.glob(File.join(SCRIPTS_DIR, '*_2025.bubble_choice')).sort
+stats = {scanned: 0, counterparts: 0, updated: 0, up_to_date: 0, no_counterpart: 0, no_props: 0, errors: 0}
+
+source_files.each do |source_path|
+  stats[:scanned] += 1
+  source_name = File.basename(source_path)
+
+  begin
+    source_content = File.read(source_path)
+    source_props = extract_properties(source_content)
+
+    if source_props.empty?
+      stats[:no_props] += 1
+      next
+    end
+
+    counterparts = find_counterparts(source_path)
+    if counterparts.empty?
+      stats[:no_counterpart] += 1
+      next
+    end
+
+    counterparts.each do |target_path|
+      stats[:counterparts] += 1
+      target_name = File.basename(target_path)
+      target_content = File.read(target_path)
+      target_props = extract_properties(target_content)
+      target_keywords = target_props.map {|p| p.split(/\s+/).first}
+
+      missing = source_props.reject {|p| target_keywords.include?(p.split(/\s+/).first)}
+      if missing.empty?
+        stats[:up_to_date] += 1
+        puts "[skip] #{target_name} (already has all properties)"
+        next
+      end
+
+      new_content = append_properties(target_content, missing)
+      puts "[update] #{source_name} -> #{target_name}"
+      missing.each {|p| puts "           + #{p}"}
+
+      if WRITE_MODE
+        File.write(target_path, new_content)
+        stats[:updated] += 1
+      end
+    end
+  rescue => exception
+    stats[:errors] += 1
+    puts "[error] #{source_name}: #{exception.message}"
+  end
+end
+
+puts
+puts "--- Summary ---"
+puts "Source files scanned:       #{stats[:scanned]}"
+puts "  with target properties:   #{stats[:scanned] - stats[:no_props]}"
+puts "  without target properties:#{stats[:no_props]}"
+puts "Counterpart files found:    #{stats[:counterparts]}"
+puts "  needing update:           #{WRITE_MODE ? stats[:updated] : stats[:counterparts] - stats[:up_to_date]}"
+puts "  already up-to-date:       #{stats[:up_to_date]}"
+puts "No counterpart found:       #{stats[:no_counterpart]}"
+puts "Errors:                     #{stats[:errors]}"
+puts
+puts WRITE_MODE ? "CHANGES WRITTEN TO DISK" : "DRY RUN - no files were modified"

--- a/dashboard/config/scripts/ai_and_algorithmic_decisions_lesson10_level4_2026.bubble_choice
+++ b/dashboard/config/scripts/ai_and_algorithmic_decisions_lesson10_level4_2026.bubble_choice
@@ -6,3 +6,5 @@ sublevels
 level 'ai-and-algorithmic-decisions-lesson10-level4a_2026'
 level 'ai-and-algorithmic-decisions-lesson10-level4b_2026'
 level 'ai-and-algorithmic-decisions-lesson10-level4c_2026'
+
+uses_lab2

--- a/dashboard/config/scripts/ai_and_algorithmic_decisions_lesson10_level5_2026.bubble_choice
+++ b/dashboard/config/scripts/ai_and_algorithmic_decisions_lesson10_level5_2026.bubble_choice
@@ -13,3 +13,5 @@ level 'ai-and-algorithmic-decisions-lesson10-level5a_2026'
 level 'ai-and-algorithmic-decisions-lesson10-level5b_2026'
 level 'ai-and-algorithmic-decisions-lesson10-level5c_2026'
 level 'ai-and-algorithmic-decisions-lesson10-level5d_2026'
+
+uses_lab2

--- a/dashboard/config/scripts/ai_and_algorithmic_decisions_lesson11_level1_2026.bubble_choice
+++ b/dashboard/config/scripts/ai_and_algorithmic_decisions_lesson11_level1_2026.bubble_choice
@@ -7,3 +7,5 @@ level 'ai-and-algorithmic-decisions-lesson11-level1a_2026'
 level 'ai-and-algorithmic-decisions-lesson11-level1b_2026'
 level 'ai-and-algorithmic-decisions-lesson11-level1c_2026'
 level 'ai-and-algorithmic-decisions-lesson11-level1d_2026'
+
+uses_lab2

--- a/dashboard/config/scripts/ai_and_algorithmic_decisions_lesson1_level7_2026.bubble_choice
+++ b/dashboard/config/scripts/ai_and_algorithmic_decisions_lesson1_level7_2026.bubble_choice
@@ -6,3 +6,5 @@ sublevels
 level 'ai-and-algorithmic-decisions-lesson1-level7a_2026'
 level 'ai-and-algorithmic-decisions-lesson1-level7b_2026'
 level 'ai-and-algorithmic-decisions-lesson1-level7c_2026'
+
+uses_lab2

--- a/dashboard/config/scripts/ai_and_algorithmic_decisions_lesson2_level2_2026.bubble_choice
+++ b/dashboard/config/scripts/ai_and_algorithmic_decisions_lesson2_level2_2026.bubble_choice
@@ -6,3 +6,5 @@ sublevels
 level 'ai-and-algorithmic-decisions-lesson2-level2a_2026'
 level 'ai-and-algorithmic-decisions-lesson2-level2b_2026'
 level 'ai-and-algorithmic-decisions-lesson2-level2c_2026'
+
+uses_lab2

--- a/dashboard/config/scripts/ai_and_algorithmic_decisions_lesson3_level10_2026.bubble_choice
+++ b/dashboard/config/scripts/ai_and_algorithmic_decisions_lesson3_level10_2026.bubble_choice
@@ -6,3 +6,5 @@ sublevels
 level 'ai-and-algorithmic-decisions-lesson3-level10a_2026'
 level 'ai-and-algorithmic-decisions-lesson3-level10b_2026'
 level 'ai-and-algorithmic-decisions-lesson3-level10c_2026'
+
+uses_lab2

--- a/dashboard/config/scripts/ai_and_algorithmic_decisions_lesson5_level1_2026.bubble_choice
+++ b/dashboard/config/scripts/ai_and_algorithmic_decisions_lesson5_level1_2026.bubble_choice
@@ -5,3 +5,5 @@ description 'Simulate conditional decision-making using Sketch Lab or AI Chat.'
 sublevels
 level 'ai-and-algorithmic-decisions-lesson5-level1a_2026'
 level 'ai-and-algorithmic-decisions-lesson5-level1b_2026'
+
+uses_lab2

--- a/dashboard/config/scripts/ai_and_algorithmic_decisions_lesson6_level4_2026.bubble_choice
+++ b/dashboard/config/scripts/ai_and_algorithmic_decisions_lesson6_level4_2026.bubble_choice
@@ -6,3 +6,5 @@ sublevels
 level 'ai-and-algorithmic-decisions-lesson6-level4a_2026'
 level 'ai-and-algorithmic-decisions-lesson6-level4b_2026'
 level 'ai-and-algorithmic-decisions-lesson6-level4c_2026'
+
+uses_lab2

--- a/dashboard/config/scripts/ai_and_algorithmic_decisions_lesson7_level2_2026.bubble_choice
+++ b/dashboard/config/scripts/ai_and_algorithmic_decisions_lesson7_level2_2026.bubble_choice
@@ -6,3 +6,5 @@ sublevels
 level 'ai-and-algorithmic-decisions-lesson7-level2a_2026'
 level 'ai-and-algorithmic-decisions-lesson7-level2b_2026'
 level 'ai-and-algorithmic-decisions-lesson7-level2c_2026'
+
+uses_lab2

--- a/dashboard/config/scripts/ai_and_algorithmic_decisions_lesson7_level3_2026.bubble_choice
+++ b/dashboard/config/scripts/ai_and_algorithmic_decisions_lesson7_level3_2026.bubble_choice
@@ -7,3 +7,5 @@ level 'ai-and-algorithmic-decisions-lesson7-level3a_2026'
 level 'ai-and-algorithmic-decisions-lesson7-level3b_2026'
 level 'ai-and-algorithmic-decisions-lesson7-level3c_2026'
 level 'ai-and-algorithmic-decisions-lesson7-level3d_2026'
+
+uses_lab2

--- a/dashboard/config/scripts/ai_and_algorithmic_decisions_lesson8_level4_2026.bubble_choice
+++ b/dashboard/config/scripts/ai_and_algorithmic_decisions_lesson8_level4_2026.bubble_choice
@@ -6,3 +6,6 @@ sublevels
 level 'ai-and-algorithmic-decisions-lesson8-level4a_2026'
 level 'ai-and-algorithmic-decisions-lesson8-level4b_2026'
 level 'ai-and-algorithmic-decisions-lesson8-level4c_2026'
+level 'ai-and-algorithmic-decisions-lesson8-level4d_2026'
+
+uses_lab2

--- a/dashboard/config/scripts/ai_and_algorithmic_decisions_lesson9_level9_2026.bubble_choice
+++ b/dashboard/config/scripts/ai_and_algorithmic_decisions_lesson9_level9_2026.bubble_choice
@@ -8,3 +8,5 @@ level 'ai-and-algorithmic-decisions-lesson9-level9b_2026'
 level 'ai-and-algorithmic-decisions-lesson9-level9c_2026'
 level 'ai-and-algorithmic-decisions-lesson9-level9d_2026'
 level 'ai-and-algorithmic-decisions-lesson9-level9e_2026'
+
+uses_lab2

--- a/dashboard/config/scripts/ai_generated_design_lesson10_level1_2026.bubble_choice
+++ b/dashboard/config/scripts/ai_generated_design_lesson10_level1_2026.bubble_choice
@@ -5,3 +5,5 @@ description 'Use Sketch Lab to design a wireframe for your web pages. Use AI Cha
 sublevels
 level 'ai-generated-design-lesson10-level1a_2026'
 level 'ai-generated-design-lesson10-level1b_2026'
+
+uses_lab2

--- a/dashboard/config/scripts/ai_generated_design_lesson6_level8_2026.bubble_choice
+++ b/dashboard/config/scripts/ai_generated_design_lesson6_level8_2026.bubble_choice
@@ -7,3 +7,5 @@ level 'ai-generated-design-lesson6-level8a_2026'
 level 'ai-generated-design-lesson6-level8b_2026'
 level 'ai-generated-design-lesson6-level8c_2026'
 level 'ai-generated-design-lesson6-level8d_2026'
+
+uses_lab2

--- a/dashboard/config/scripts/computer_systems_lesson11_level1_v2_2026.bubble_choice
+++ b/dashboard/config/scripts/computer_systems_lesson11_level1_v2_2026.bubble_choice
@@ -7,3 +7,5 @@ level 'computer-systems-lesson11-level1a_v2_2026'
 level 'computer-systems-lesson11-level1b_v2_2026'
 level 'computer-systems-lesson11-level1c_v2_2026'
 level 'computer-systems-lesson11-level1d_v2_2026'
+
+uses_lab2

--- a/dashboard/config/scripts/computer_systems_lesson13_level1_v2_2026.bubble_choice
+++ b/dashboard/config/scripts/computer_systems_lesson13_level1_v2_2026.bubble_choice
@@ -7,3 +7,5 @@ level 'computer-systems-lesson13-level1a_v2_2026'
 level 'computer-systems-lesson13-level1b_v2_2026'
 level 'computer-systems-lesson13-level1c_v2_2026'
 level 'computer-systems-lesson13-level1d_v2_2026'
+
+uses_lab2

--- a/dashboard/config/scripts/computer_systems_lesson1_level10_v2_2026.bubble_choice
+++ b/dashboard/config/scripts/computer_systems_lesson1_level10_v2_2026.bubble_choice
@@ -6,3 +6,5 @@ sublevels
 level 'computer-systems-lesson1-level10a_v2_2026'
 level 'computer-systems-lesson1-level10b_v2_2026'
 level 'computer-systems-lesson1-level10c_v2_2026'
+
+uses_lab2

--- a/dashboard/config/scripts/computer_systems_lesson1_level11_v2_2026.bubble_choice
+++ b/dashboard/config/scripts/computer_systems_lesson1_level11_v2_2026.bubble_choice
@@ -6,3 +6,5 @@ sublevels
 level 'computer-systems-lesson1-level11a_v2_2026'
 level 'computer-systems-lesson1-level11b_v2_2026'
 level 'computer-systems-lesson1-level11c_v2_2026'
+
+uses_lab2

--- a/dashboard/config/scripts/computer_systems_lesson1_level2_v2_2026.bubble_choice
+++ b/dashboard/config/scripts/computer_systems_lesson1_level2_v2_2026.bubble_choice
@@ -14,3 +14,5 @@ level 'computer-systems-lesson1-level2a_v2_2026'
 level 'computer-systems-lesson1-level2b_v2_2026'
 level 'computer-systems-lesson1-level2c_v2_2026'
 level 'computer-systems-lesson1-level2d_v2_2026'
+
+uses_lab2

--- a/dashboard/config/scripts/computer_systems_lesson1_level3_v2_2026.bubble_choice
+++ b/dashboard/config/scripts/computer_systems_lesson1_level3_v2_2026.bubble_choice
@@ -14,3 +14,5 @@ level 'computer-systems-lesson1-level3a_v2_2026'
 level 'computer-systems-lesson1-level3b_v2_2026'
 level 'computer-systems-lesson1-level3c_v2_2026'
 level 'computer-systems-lesson1-level3d_v2_2026'
+
+uses_lab2

--- a/dashboard/config/scripts/computer_systems_lesson1_level4_v2_2026.bubble_choice
+++ b/dashboard/config/scripts/computer_systems_lesson1_level4_v2_2026.bubble_choice
@@ -14,3 +14,5 @@ level 'computer-systems-lesson1-level4a_v2_2026'
 level 'computer-systems-lesson1-level4b_v2_2026'
 level 'computer-systems-lesson1-level4c_v2_2026'
 level 'computer-systems-lesson1-level4d_v2_2026'
+
+uses_lab2

--- a/dashboard/config/scripts/computer_systems_lesson1_level5_v2_2026.bubble_choice
+++ b/dashboard/config/scripts/computer_systems_lesson1_level5_v2_2026.bubble_choice
@@ -14,3 +14,5 @@ level 'computer-systems-lesson1-level5a_v2_2026'
 level 'computer-systems-lesson1-level5b_v2_2026'
 level 'computer-systems-lesson1-level5c_v2_2026'
 level 'computer-systems-lesson1-level5d_v2_2026'
+
+uses_lab2

--- a/dashboard/config/scripts/computer_systems_lesson1_level6_v2_2026.bubble_choice
+++ b/dashboard/config/scripts/computer_systems_lesson1_level6_v2_2026.bubble_choice
@@ -14,3 +14,5 @@ level 'computer-systems-lesson1-level6a_v2_2026'
 level 'computer-systems-lesson1-level6b_v2_2026'
 level 'computer-systems-lesson1-level6c_v2_2026'
 level 'computer-systems-lesson1-level6d_v2_2026'
+
+uses_lab2

--- a/dashboard/config/scripts/computer_systems_lesson1_level7_v2_2026.bubble_choice
+++ b/dashboard/config/scripts/computer_systems_lesson1_level7_v2_2026.bubble_choice
@@ -14,3 +14,5 @@ level 'computer-systems-lesson1-level7a_v2_2026'
 level 'computer-systems-lesson1-level7b_v2_2026'
 level 'computer-systems-lesson1-level7c_v2_2026'
 level 'computer-systems-lesson1-level7d_v2_2026'
+
+uses_lab2

--- a/dashboard/config/scripts/computer_systems_lesson1_level8_v2_2026.bubble_choice
+++ b/dashboard/config/scripts/computer_systems_lesson1_level8_v2_2026.bubble_choice
@@ -14,3 +14,5 @@ level 'computer-systems-lesson1-level8a_v2_2026'
 level 'computer-systems-lesson1-level8b_v2_2026'
 level 'computer-systems-lesson1-level8c_v2_2026'
 level 'computer-systems-lesson1-level8d_v2_2026'
+
+uses_lab2

--- a/dashboard/config/scripts/computer_systems_lesson1_level9_v2_2026.bubble_choice
+++ b/dashboard/config/scripts/computer_systems_lesson1_level9_v2_2026.bubble_choice
@@ -14,3 +14,5 @@ level 'computer-systems-lesson1-level9a_v2_2026'
 level 'computer-systems-lesson1-level9b_v2_2026'
 level 'computer-systems-lesson1-level9c_v2_2026'
 level 'computer-systems-lesson1-level9d_v2_2026'
+
+uses_lab2

--- a/dashboard/config/scripts/computer_systems_lesson2_level4_v2_2026.bubble_choice
+++ b/dashboard/config/scripts/computer_systems_lesson2_level4_v2_2026.bubble_choice
@@ -7,3 +7,5 @@ level 'computer-systems-lesson2-level4a_2025-launch_v2_2026'
 level 'computer-systems-lesson2-level4b_2025-launch_v2_2026'
 level 'computer-systems-lesson2-level4c_2025-launch_v2_2026'
 level 'computer-systems-lesson2-level4d_2025-launch_v2_2026'
+
+uses_lab2

--- a/dashboard/config/scripts/computer_systems_lesson3_level3_v2_2026.bubble_choice
+++ b/dashboard/config/scripts/computer_systems_lesson3_level3_v2_2026.bubble_choice
@@ -7,3 +7,5 @@ level 'computer-systems-lesson3-level3a_v2_2026'
 level 'computer-systems-lesson3-level3c_v2_2026'
 level 'computer-systems-lesson3-level3b_v2_2026'
 level 'computer-systems-lesson3-level3d_v2_2026'
+
+uses_lab2

--- a/dashboard/config/scripts/computer_systems_lesson3_level4_v2_2026.bubble_choice
+++ b/dashboard/config/scripts/computer_systems_lesson3_level4_v2_2026.bubble_choice
@@ -7,3 +7,5 @@ level 'computer-systems-troubleshoot-choiceB_v2_2026'
 level 'computer-systems-troubleshoot-choiceC_v2_2026'
 level 'computer-systems-troubleshoot-choiceD_v2_2026'
 level 'computer-systems-troubleshoot-choiceE_v2_2026'
+
+uses_lab2

--- a/dashboard/config/scripts/computer_systems_lesson3_level5_v2_2026.bubble_choice
+++ b/dashboard/config/scripts/computer_systems_lesson3_level5_v2_2026.bubble_choice
@@ -8,3 +8,5 @@ level 'computer-systems-lesson3-level5b_v2_2026'
 level 'computer-systems-lesson3-level5c_v2_2026'
 level 'computer-systems-lesson3-level5d_v2_2026'
 level 'computer-systems-lesson3-level5e_v2_2026'
+
+uses_lab2

--- a/dashboard/config/scripts/computer_systems_lesson6_level2_v2_2026.bubble_choice
+++ b/dashboard/config/scripts/computer_systems_lesson6_level2_v2_2026.bubble_choice
@@ -10,3 +10,5 @@ level 'computer-systems-lesson6-level2d_v2_2026'
 level 'computer-systems-lesson6-level2e_v2_2026'
 level 'computer-systems-lesson6-level2f_v2_2026'
 level 'computer-systems-lesson6-level2g_2025-launch_v2_2026'
+
+uses_lab2

--- a/dashboard/config/scripts/computer_systems_lesson8_level2_v3_2026.bubble_choice
+++ b/dashboard/config/scripts/computer_systems_lesson8_level2_v3_2026.bubble_choice
@@ -10,3 +10,5 @@ level 'computer-systems-lesson8-level2d_v2_2026'
 level 'computer-systems-lesson8-level2e_v2_2026'
 level 'computer-systems-lesson8-level2f_v2_2026'
 level 'computer-systems-lesson8-level2g_v2_2026'
+
+uses_lab2

--- a/dashboard/config/scripts/computer_systems_lesson9_level1_v2_2026.bubble_choice
+++ b/dashboard/config/scripts/computer_systems_lesson9_level1_v2_2026.bubble_choice
@@ -7,3 +7,5 @@ level 'computer-systems-lesson9-level1a_v2_2026'
 level 'computer-systems-lesson9-level1b_v2_2026'
 level 'computer-systems-lesson9-level1c_v2_2026'
 level 'computer-systems-lesson9-level1d_v2_2026'
+
+uses_lab2

--- a/dashboard/config/scripts/csd_u2l10_l1_2025_v2.bubble_choice
+++ b/dashboard/config/scripts/csd_u2l10_l1_2025_v2.bubble_choice
@@ -8,3 +8,5 @@ level 'CSD U2L10-L1b_2025-v2'
 level 'CSD U2L10-L1c_2025-v2'
 level 'CSD U2L10-L1d_2025-v2'
 level 'CSD U2L10-L1e_2025-v2'
+
+uses_lab2

--- a/dashboard/config/scripts/csd_u2l10_l1_2026.bubble_choice
+++ b/dashboard/config/scripts/csd_u2l10_l1_2026.bubble_choice
@@ -8,3 +8,5 @@ level 'CSD U2L10-L1b_2026'
 level 'CSD U2L10-L1c_2026'
 level 'CSD U2L10-L1d_2026'
 level 'CSD U2L10-L1e_2026'
+
+uses_lab2

--- a/dashboard/config/scripts/csd_u2l10_l2_2025_v2.bubble_choice
+++ b/dashboard/config/scripts/csd_u2l10_l2_2025_v2.bubble_choice
@@ -7,3 +7,5 @@ level 'CSD U2L10-L2a_2025-v2'
 level 'CSD U2L10-L2b_2025-v2'
 level 'CSD U2L10-L2c_2025-v2'
 level 'CSD U2L10-L2d_2025-v2'
+
+uses_lab2

--- a/dashboard/config/scripts/csd_u2l10_l2_2026.bubble_choice
+++ b/dashboard/config/scripts/csd_u2l10_l2_2026.bubble_choice
@@ -7,3 +7,5 @@ level 'CSD U2L10-L2a_2026'
 level 'CSD U2L10-L2b_2026'
 level 'CSD U2L10-L2c_2026'
 level 'CSD U2L10-L2d_2026'
+
+uses_lab2

--- a/dashboard/config/scripts/csd_u2l10_l3_2025_v2.bubble_choice
+++ b/dashboard/config/scripts/csd_u2l10_l3_2025_v2.bubble_choice
@@ -7,3 +7,5 @@ level 'CSD U2L10-L3a_2025-v2'
 level 'CSD U2L10-L3b_2025-v2'
 level 'CSD U2L10-L3c_2025-v2'
 level 'CSD U2L10-L3d_2025-v2'
+
+uses_lab2

--- a/dashboard/config/scripts/csd_u2l10_l3_2026.bubble_choice
+++ b/dashboard/config/scripts/csd_u2l10_l3_2026.bubble_choice
@@ -7,3 +7,5 @@ level 'CSD U2L10-L3a_2026'
 level 'CSD U2L10-L3b_2026'
 level 'CSD U2L10-L3c_2026'
 level 'CSD U2L10-L3d_2026'
+
+uses_lab2

--- a/dashboard/config/scripts/csd_u2l10_l4_2025_v2.bubble_choice
+++ b/dashboard/config/scripts/csd_u2l10_l4_2025_v2.bubble_choice
@@ -7,3 +7,5 @@ level 'CSD U2L10-L4a_2025-v2'
 level 'CSD U2L10-L4b_2025-v2'
 level 'CSD U2L10-L4c_2025-v2'
 level 'CSD U2L10-L4d_2025-v2'
+
+uses_lab2

--- a/dashboard/config/scripts/csd_u2l10_l4_2026.bubble_choice
+++ b/dashboard/config/scripts/csd_u2l10_l4_2026.bubble_choice
@@ -7,3 +7,5 @@ level 'CSD U2L10-L4a_2026'
 level 'CSD U2L10-L4b_2026'
 level 'CSD U2L10-L4c_2026'
 level 'CSD U2L10-L4d_2026'
+
+uses_lab2

--- a/dashboard/config/scripts/csd_u2l10_l5_2025_v2.bubble_choice
+++ b/dashboard/config/scripts/csd_u2l10_l5_2025_v2.bubble_choice
@@ -7,3 +7,5 @@ level 'CSD U2L10-L5a_2025-v2'
 level 'CSD U2L10-L5b_2025-v2'
 level 'CSD U2L10-L5c_2025-v2'
 level 'CSD U2L10-L5d_2025-v2'
+
+uses_lab2

--- a/dashboard/config/scripts/csd_u2l10_l5_2026.bubble_choice
+++ b/dashboard/config/scripts/csd_u2l10_l5_2026.bubble_choice
@@ -7,3 +7,5 @@ level 'CSD U2L10-L5a_2026'
 level 'CSD U2L10-L5b_2026'
 level 'CSD U2L10-L5c_2026'
 level 'CSD U2L10-L5d_2026'
+
+uses_lab2

--- a/dashboard/config/scripts/csd_u2l11_l5_2025_v2.bubble_choice
+++ b/dashboard/config/scripts/csd_u2l11_l5_2025_v2.bubble_choice
@@ -6,3 +6,5 @@ sublevels
 level 'CSD U2L11-L5a_2025-v2'
 level 'CSD U2L11-L5b_2025-v2'
 level 'CSD U2L11-L5c_2025-v2'
+
+uses_lab2

--- a/dashboard/config/scripts/csd_u2l11_l5_2026.bubble_choice
+++ b/dashboard/config/scripts/csd_u2l11_l5_2026.bubble_choice
@@ -6,3 +6,5 @@ sublevels
 level 'CSD U2L11-L5a_2026'
 level 'CSD U2L11-L5b_2026'
 level 'CSD U2L11-L5c_2026'
+
+uses_lab2

--- a/dashboard/config/scripts/csd_u2l11_l8_2025_v2.bubble_choice
+++ b/dashboard/config/scripts/csd_u2l11_l8_2025_v2.bubble_choice
@@ -6,3 +6,5 @@ sublevels
 level 'CSD U2L11-L8a_2025-v2'
 level 'CSD U2L11-L8b_2025-v2'
 level 'CSD U2L11-L8c_2025-v2'
+
+uses_lab2

--- a/dashboard/config/scripts/csd_u2l11_l8_2026.bubble_choice
+++ b/dashboard/config/scripts/csd_u2l11_l8_2026.bubble_choice
@@ -6,3 +6,5 @@ sublevels
 level 'CSD U2L11-L8a_2026'
 level 'CSD U2L11-L8b_2026'
 level 'CSD U2L11-L8c_2026'
+
+uses_lab2

--- a/dashboard/config/scripts/csd_u2l12_l6_2025_v2.bubble_choice
+++ b/dashboard/config/scripts/csd_u2l12_l6_2025_v2.bubble_choice
@@ -7,3 +7,5 @@ level 'CSD U2L12-L6a_2025-v2'
 level 'CSD U2L12-L6b_2025-v2'
 level 'CSD U2L12-L6c_2025-v2'
 level 'CSD U2L12-L6d_2025-v2'
+
+uses_lab2

--- a/dashboard/config/scripts/csd_u2l12_l6_2026.bubble_choice
+++ b/dashboard/config/scripts/csd_u2l12_l6_2026.bubble_choice
@@ -7,3 +7,5 @@ level 'CSD U2L12-L6a_2026'
 level 'CSD U2L12-L6b_2026'
 level 'CSD U2L12-L6c_2026'
 level 'CSD U2L12-L6d_2026'
+
+uses_lab2

--- a/dashboard/config/scripts/csd_u2l12_l9_2025_v2.bubble_choice
+++ b/dashboard/config/scripts/csd_u2l12_l9_2025_v2.bubble_choice
@@ -9,3 +9,5 @@ level 'CSD U2L12-L9c_2025-v2'
 level 'CSD U2L12-L9d_2025-v2'
 level 'CSD U2L12-L9e_2025-v2'
 level 'CSD U2L12-L9f_2025-v2'
+
+uses_lab2

--- a/dashboard/config/scripts/csd_u2l12_l9_2026.bubble_choice
+++ b/dashboard/config/scripts/csd_u2l12_l9_2026.bubble_choice
@@ -9,3 +9,5 @@ level 'CSD U2L12-L9c_2026'
 level 'CSD U2L12-L9d_2026'
 level 'CSD U2L12-L9e_2026'
 level 'CSD U2L12-L9f_2026'
+
+uses_lab2

--- a/dashboard/config/scripts/csd_u2l13_l6_2025_v2.bubble_choice
+++ b/dashboard/config/scripts/csd_u2l13_l6_2025_v2.bubble_choice
@@ -7,3 +7,5 @@ level 'CSD U2L13-L6a_2025-v2'
 level 'CSD U2L13-L6b_2025-v2'
 level 'CSD U2L13-L6c_2025-v2'
 level 'CSD U2L13-L6d_2025-v2'
+
+uses_lab2

--- a/dashboard/config/scripts/csd_u2l13_l6_2026.bubble_choice
+++ b/dashboard/config/scripts/csd_u2l13_l6_2026.bubble_choice
@@ -7,3 +7,5 @@ level 'CSD U2L13-L6a_2026'
 level 'CSD U2L13-L6b_2026'
 level 'CSD U2L13-L6c_2026'
 level 'CSD U2L13-L6d_2026'
+
+uses_lab2

--- a/dashboard/config/scripts/csd_u2l13_l9_2025_v2.bubble_choice
+++ b/dashboard/config/scripts/csd_u2l13_l9_2025_v2.bubble_choice
@@ -7,3 +7,5 @@ level 'CSD U2L13-L9a_2025-v2'
 level 'CSD U2L13-L9b_2025-v2'
 level 'CSD U2L13-L9c_2025-v2'
 level 'CSD U2L13-L9d_2025-v2'
+
+uses_lab2

--- a/dashboard/config/scripts/csd_u2l13_l9_2026.bubble_choice
+++ b/dashboard/config/scripts/csd_u2l13_l9_2026.bubble_choice
@@ -7,3 +7,5 @@ level 'CSD U2L13-L9a_2026'
 level 'CSD U2L13-L9b_2026'
 level 'CSD U2L13-L9c_2026'
 level 'CSD U2L13-L9d_2026'
+
+uses_lab2

--- a/dashboard/config/scripts/csd_u2l14_l1_2025_v2.bubble_choice
+++ b/dashboard/config/scripts/csd_u2l14_l1_2025_v2.bubble_choice
@@ -6,3 +6,5 @@ sublevels
 level 'CSD U2L14-L1a_2025-v2'
 level 'CSD U2L14-L1b_2025-v2'
 level 'CSD U2L14-L1c_2025-v2'
+
+uses_lab2

--- a/dashboard/config/scripts/csd_u2l14_l1_2026.bubble_choice
+++ b/dashboard/config/scripts/csd_u2l14_l1_2026.bubble_choice
@@ -6,3 +6,5 @@ sublevels
 level 'CSD U2L14-L1a_2026'
 level 'CSD U2L14-L1b_2026'
 level 'CSD U2L14-L1c_2026'
+
+uses_lab2

--- a/dashboard/config/scripts/csd_u2l14_l2_2025_v2.bubble_choice
+++ b/dashboard/config/scripts/csd_u2l14_l2_2025_v2.bubble_choice
@@ -7,3 +7,5 @@ level 'CSD U2L14-L2a_2025-v2'
 level 'CSD U2L14-L2b_2025-v2'
 level 'CSD U2L14-L2c_2025-v2'
 level 'CSD U2L14-L2d_2025-v2'
+
+uses_lab2

--- a/dashboard/config/scripts/csd_u2l14_l2_2026.bubble_choice
+++ b/dashboard/config/scripts/csd_u2l14_l2_2026.bubble_choice
@@ -7,3 +7,5 @@ level 'CSD U2L14-L2a_2026'
 level 'CSD U2L14-L2b_2026'
 level 'CSD U2L14-L2c_2026'
 level 'CSD U2L14-L2d_2026'
+
+uses_lab2

--- a/dashboard/config/scripts/csd_u2l14_l3_2025_v2.bubble_choice
+++ b/dashboard/config/scripts/csd_u2l14_l3_2025_v2.bubble_choice
@@ -8,3 +8,5 @@ level 'CSD U2L14-L3b_2025-v2'
 level 'CSD U2L14-L3c_2025-v2'
 level 'CSD U2L14-L3d_2025-v2'
 level 'CSD U2L14-L3e_2025-v2'
+
+uses_lab2

--- a/dashboard/config/scripts/csd_u2l14_l3_2026.bubble_choice
+++ b/dashboard/config/scripts/csd_u2l14_l3_2026.bubble_choice
@@ -8,3 +8,5 @@ level 'CSD U2L14-L3b_2026'
 level 'CSD U2L14-L3c_2026'
 level 'CSD U2L14-L3d_2026'
 level 'CSD U2L14-L3e_2026'
+
+uses_lab2

--- a/dashboard/config/scripts/csd_u2l17_l5_2025_v2.bubble_choice
+++ b/dashboard/config/scripts/csd_u2l17_l5_2025_v2.bubble_choice
@@ -5,3 +5,5 @@ description 'Practice your new skills here.'
 sublevels
 level 'CSD U2L17-L5a_2025-v2'
 level 'CSD U2L17-L5b_2025-v2'
+
+uses_lab2

--- a/dashboard/config/scripts/csd_u2l17_l5_2026.bubble_choice
+++ b/dashboard/config/scripts/csd_u2l17_l5_2026.bubble_choice
@@ -5,3 +5,5 @@ description 'Practice your new skills here.'
 sublevels
 level 'CSD U2L17-L5a_2026'
 level 'CSD U2L17-L5b_2026'
+
+uses_lab2

--- a/dashboard/config/scripts/csd_u2l17_l8_2025_v2.bubble_choice
+++ b/dashboard/config/scripts/csd_u2l17_l8_2025_v2.bubble_choice
@@ -6,3 +6,5 @@ sublevels
 level 'CSD U2L17-L8a_2025-v2'
 level 'CSD U2L17-L8b_2025-v2'
 level 'CSD U2L17-L8c_2025-v2'
+
+uses_lab2

--- a/dashboard/config/scripts/csd_u2l17_l8_2026.bubble_choice
+++ b/dashboard/config/scripts/csd_u2l17_l8_2026.bubble_choice
@@ -6,3 +6,5 @@ sublevels
 level 'CSD U2L17-L8a_2026'
 level 'CSD U2L17-L8b_2026'
 level 'CSD U2L17-L8c_2026'
+
+uses_lab2

--- a/dashboard/config/scripts/csd_u2l18_l6_2025_v2.bubble_choice
+++ b/dashboard/config/scripts/csd_u2l18_l6_2025_v2.bubble_choice
@@ -7,3 +7,5 @@ level 'CSD U2L18-L6a_2025-v2'
 level 'CSD U2L18-L6b_2025-v2'
 level 'CSD U2L18-L6c_2025-v2'
 level 'CSD U2L18-L6d_2025-v2'
+
+uses_lab2

--- a/dashboard/config/scripts/csd_u2l18_l6_2026.bubble_choice
+++ b/dashboard/config/scripts/csd_u2l18_l6_2026.bubble_choice
@@ -7,3 +7,5 @@ level 'CSD U2L18-L6a_2026'
 level 'CSD U2L18-L6b_2026'
 level 'CSD U2L18-L6c_2026'
 level 'CSD U2L18-L6d_2026'
+
+uses_lab2

--- a/dashboard/config/scripts/csd_u2l18_l9_2025_v2.bubble_choice
+++ b/dashboard/config/scripts/csd_u2l18_l9_2025_v2.bubble_choice
@@ -7,3 +7,5 @@ level 'CSD U2L18-L9a_2025-v2'
 level 'CSD U2L18-L9b_2025-v2'
 level 'CSD U2L18-L9c_2025-v2'
 level 'CSD U2L18-L9d_2025-v2'
+
+uses_lab2

--- a/dashboard/config/scripts/csd_u2l18_l9_2026.bubble_choice
+++ b/dashboard/config/scripts/csd_u2l18_l9_2026.bubble_choice
@@ -7,3 +7,5 @@ level 'CSD U2L18-L9a_2026'
 level 'CSD U2L18-L9b_2026'
 level 'CSD U2L18-L9c_2026'
 level 'CSD U2L18-L9d_2026'
+
+uses_lab2

--- a/dashboard/config/scripts/csd_u2l1_l1_2025_v2.bubble_choice
+++ b/dashboard/config/scripts/csd_u2l1_l1_2025_v2.bubble_choice
@@ -8,3 +8,6 @@ level 'CSD U2L1-L1b_2025-v2'
 level 'CSD U2L1-L1c_2025-v2'
 level 'CSD U2L1-L1d_2025-v2'
 level 'CSD U2L1-L1e_2025-v2'
+
+uses_lab2
+hide_letters_lab2

--- a/dashboard/config/scripts/csd_u2l1_l1_2026.bubble_choice
+++ b/dashboard/config/scripts/csd_u2l1_l1_2026.bubble_choice
@@ -8,3 +8,6 @@ level 'CSD U2L1-L1b_2026'
 level 'CSD U2L1-L1c_2026'
 level 'CSD U2L1-L1d_2026'
 level 'CSD U2L1-L1e_2026'
+
+uses_lab2
+hide_letters_lab2

--- a/dashboard/config/scripts/csd_u2l2_l6_2025_v2.bubble_choice
+++ b/dashboard/config/scripts/csd_u2l2_l6_2025_v2.bubble_choice
@@ -6,3 +6,5 @@ sublevels
 level 'CSD U2L2-L6a_2025-v2'
 level 'CSD U2L2-L6b_2025-v2'
 level 'CSD U2L2-L6c_2025-v2'
+
+uses_lab2

--- a/dashboard/config/scripts/csd_u2l2_l6_2026.bubble_choice
+++ b/dashboard/config/scripts/csd_u2l2_l6_2026.bubble_choice
@@ -6,3 +6,5 @@ sublevels
 level 'CSD U2L2-L6a_2026'
 level 'CSD U2L2-L6b_2026'
 level 'CSD U2L2-L6c_2026'
+
+uses_lab2

--- a/dashboard/config/scripts/csd_u2l3_l11_2025_v2.bubble_choice
+++ b/dashboard/config/scripts/csd_u2l3_l11_2025_v2.bubble_choice
@@ -9,3 +9,5 @@ level 'CSD U2L3-L11c_2025-v2'
 level 'CSD U2L3-L11d_2025-v2'
 level 'CSD U2L3-L11e_2025-v2'
 level 'CSD U2L3-L11f_2025-v2'
+
+uses_lab2

--- a/dashboard/config/scripts/csd_u2l3_l11_2026.bubble_choice
+++ b/dashboard/config/scripts/csd_u2l3_l11_2026.bubble_choice
@@ -9,3 +9,5 @@ level 'CSD U2L3-L11c_2026'
 level 'CSD U2L3-L11d_2026'
 level 'CSD U2L3-L11e_2026'
 level 'CSD U2L3-L11f_2026'
+
+uses_lab2

--- a/dashboard/config/scripts/csd_u2l5_l1_2025_v2.bubble_choice
+++ b/dashboard/config/scripts/csd_u2l5_l1_2025_v2.bubble_choice
@@ -10,3 +10,5 @@ level 'CSD U2L5-L1d_2025-v2'
 level 'CSD U2L5-L1e_2025-v2'
 level 'CSD U2L5-L1f_2025-v2'
 level 'CSD U2L5-L1g_2025-v2'
+
+uses_lab2

--- a/dashboard/config/scripts/csd_u2l5_l1_2026.bubble_choice
+++ b/dashboard/config/scripts/csd_u2l5_l1_2026.bubble_choice
@@ -10,3 +10,5 @@ level 'CSD U2L5-L1d_2026'
 level 'CSD U2L5-L1e_2026'
 level 'CSD U2L5-L1f_2026'
 level 'CSD U2L5-L1g_2026'
+
+uses_lab2

--- a/dashboard/config/scripts/csd_u2l6_l12_2025_v2.bubble_choice
+++ b/dashboard/config/scripts/csd_u2l6_l12_2025_v2.bubble_choice
@@ -9,3 +9,5 @@ level 'CSD U2L6-L12c_2025-v2'
 level 'CSD U2L6-L12d_2025-v2'
 level 'CSD U2L6-L12e_2025-v2'
 level 'CSD U2L6-L12f_2025-v2'
+
+uses_lab2

--- a/dashboard/config/scripts/csd_u2l6_l12_2026.bubble_choice
+++ b/dashboard/config/scripts/csd_u2l6_l12_2026.bubble_choice
@@ -9,3 +9,5 @@ level 'CSD U2L6-L12c_2026'
 level 'CSD U2L6-L12d_2026'
 level 'CSD U2L6-L12e_2026'
 level 'CSD U2L6-L12f_2026'
+
+uses_lab2

--- a/dashboard/config/scripts/csd_u2l6_l9_2025_v2.bubble_choice
+++ b/dashboard/config/scripts/csd_u2l6_l9_2025_v2.bubble_choice
@@ -11,3 +11,5 @@ level 'CSD U2L6-L9e_2025-v2'
 level 'CSD U2L6-L9f_2025-v2'
 level 'CSD U2L6-L9g_2025-v2'
 level 'CSD U2L6-L9h_2025-v2'
+
+uses_lab2

--- a/dashboard/config/scripts/csd_u2l6_l9_2026.bubble_choice
+++ b/dashboard/config/scripts/csd_u2l6_l9_2026.bubble_choice
@@ -11,3 +11,5 @@ level 'CSD U2L6-L9e_2026'
 level 'CSD U2L6-L9f_2026'
 level 'CSD U2L6-L9g_2026'
 level 'CSD U2L6-L9h_2026'
+
+uses_lab2

--- a/dashboard/config/scripts/csd_u2l8_l10_2025_v2.bubble_choice
+++ b/dashboard/config/scripts/csd_u2l8_l10_2025_v2.bubble_choice
@@ -8,3 +8,5 @@ level 'CSD U2L8-L10b_2025-v2'
 level 'CSD U2L8-L10c_2025-v2'
 level 'CSD U2L8-L10d_2025-v2'
 level 'CSD U2L8-L10e_2025-v2'
+
+uses_lab2

--- a/dashboard/config/scripts/csd_u2l8_l10_2026.bubble_choice
+++ b/dashboard/config/scripts/csd_u2l8_l10_2026.bubble_choice
@@ -8,3 +8,5 @@ level 'CSD U2L8-L10b_2026'
 level 'CSD U2L8-L10c_2026'
 level 'CSD U2L8-L10d_2026'
 level 'CSD U2L8-L10e_2026'
+
+uses_lab2

--- a/dashboard/config/scripts/csd_u2l8_l7_2025_v2.bubble_choice
+++ b/dashboard/config/scripts/csd_u2l8_l7_2025_v2.bubble_choice
@@ -10,3 +10,5 @@ level 'CSD U2L8-L7d_2025-v2'
 level 'CSD U2L8-L7e_2025-v2'
 level 'CSD U2L8-L7f_2025-v2'
 level 'CSD U2L8-L7g_2025-v2'
+
+uses_lab2

--- a/dashboard/config/scripts/csd_u2l8_l7_2026.bubble_choice
+++ b/dashboard/config/scripts/csd_u2l8_l7_2026.bubble_choice
@@ -10,3 +10,5 @@ level 'CSD U2L8-L7d_2026'
 level 'CSD U2L8-L7e_2026'
 level 'CSD U2L8-L7f_2026'
 level 'CSD U2L8-L7g_2026'
+
+uses_lab2

--- a/dashboard/config/scripts/csd_u2l9_l10_2025_v2.bubble_choice
+++ b/dashboard/config/scripts/csd_u2l9_l10_2025_v2.bubble_choice
@@ -10,3 +10,5 @@ level 'CSD U2L9-L10d_2025-v2'
 level 'CSD U2L9-L10e_2025-v2'
 level 'CSD U2L9-L10f_2025-v2'
 level 'CSD U2L9-L10g_2025-v2'
+
+uses_lab2

--- a/dashboard/config/scripts/csd_u2l9_l10_2026.bubble_choice
+++ b/dashboard/config/scripts/csd_u2l9_l10_2026.bubble_choice
@@ -10,3 +10,5 @@ level 'CSD U2L9-L10d_2026'
 level 'CSD U2L9-L10e_2026'
 level 'CSD U2L9-L10f_2026'
 level 'CSD U2L9-L10g_2026'
+
+uses_lab2

--- a/dashboard/config/scripts/csd_u2l9_l7_2025_v2.bubble_choice
+++ b/dashboard/config/scripts/csd_u2l9_l7_2025_v2.bubble_choice
@@ -9,3 +9,5 @@ level 'CSD U2L9-L7c_2025-v2'
 level 'CSD U2L9-L7d_2025-v2'
 level 'CSD U2L9-L7e_2025-v2'
 level 'CSD U2L9-L7f_2025-v2'
+
+uses_lab2

--- a/dashboard/config/scripts/csd_u2l9_l7_2026.bubble_choice
+++ b/dashboard/config/scripts/csd_u2l9_l7_2026.bubble_choice
@@ -9,3 +9,5 @@ level 'CSD U2L9-L7c_2026'
 level 'CSD U2L9-L7d_2026'
 level 'CSD U2L9-L7e_2026'
 level 'CSD U2L9-L7f_2026'
+
+uses_lab2

--- a/dashboard/config/scripts/data_science_ch1_lesson10_level10_v2_2026.bubble_choice
+++ b/dashboard/config/scripts/data_science_ch1_lesson10_level10_v2_2026.bubble_choice
@@ -5,3 +5,5 @@ sublevels
 level 'data-science-ch1-lesson10-level10b_v2_2026'
 level 'data-science-ch1-lesson10-level10d_v2_2026'
 level 'data-science-ch1-lesson10-level10e_v2_2026'
+
+uses_lab2

--- a/dashboard/config/scripts/data_science_ch1_lesson4_level1_choice_v2_2026.bubble_choice
+++ b/dashboard/config/scripts/data_science_ch1_lesson4_level1_choice_v2_2026.bubble_choice
@@ -9,3 +9,5 @@ level 'data-science-ch1-lesson4-level3_v2_2026'
 level 'data-science-ch1-lesson4-level4_v2_2026'
 level 'data-science-ch1-lesson4-level5_v2_2026'
 level 'data-science-ch1-lesson4-level6_v2_2026'
+
+uses_lab2

--- a/dashboard/config/scripts/data_science_ch1_lesson6_level3_v2_2026.bubble_choice
+++ b/dashboard/config/scripts/data_science_ch1_lesson6_level3_v2_2026.bubble_choice
@@ -12,3 +12,5 @@ sublevels
 level 'data-science-ch1-lesson6-level3a_v2_2026'
 level 'data-science-ch1-lesson6-level3b_v2_2026'
 level 'data-science-ch1-lesson6-level3c_v2_2026'
+
+uses_lab2

--- a/dashboard/config/scripts/data_science_ch1_lesson9_level2_choice_v2_2026.bubble_choice
+++ b/dashboard/config/scripts/data_science_ch1_lesson9_level2_choice_v2_2026.bubble_choice
@@ -7,3 +7,5 @@ level 'data-science-ch1-lesson9-level2a_2025-launch_v2_2026'
 level 'data-science-ch1-lesson9-level2b_2025-launch_v2_2026'
 level 'data-science-ch1-lesson9-level2c_2025-launch_v2_2026'
 level 'data-science-ch1-lesson9-level2d_2025-launch_v2_2026'
+
+uses_lab2

--- a/dashboard/config/scripts/data_science_u1_lesson12_level2_v2_2026.bubble_choice
+++ b/dashboard/config/scripts/data_science_u1_lesson12_level2_v2_2026.bubble_choice
@@ -9,3 +9,5 @@ level 'data-science-u1-lesson12-level2d_v2_2026'
 level 'data-science-u1-lesson12-level2e_v2_2026'
 level 'data-science-u1-lesson12-level2f_v2_2026'
 level 'data-science-u1-lesson12-level2g_v2_2026'
+
+uses_lab2

--- a/dashboard/config/scripts/networks_internet_lesson11_level1_v2_2026.bubble_choice
+++ b/dashboard/config/scripts/networks_internet_lesson11_level1_v2_2026.bubble_choice
@@ -7,3 +7,5 @@ level 'networks-internet-lesson11-level1a_v2_2026'
 level 'networks-internet-lesson11-level1b_v2_2026'
 level 'networks-internet-lesson11-level1c_v2_2026'
 level 'networks-internet-lesson11-level1d_v2_2026'
+
+uses_lab2

--- a/dashboard/config/scripts/networks_internet_lesson7_level6_v2_2026.bubble_choice
+++ b/dashboard/config/scripts/networks_internet_lesson7_level6_v2_2026.bubble_choice
@@ -7,3 +7,5 @@ level 'networks-internet-lesson7-level6a_v2_2026'
 level 'networks-internet-lesson7-level6b_v2_2026'
 level 'networks-internet-lesson7-level6c_v2_2026'
 level 'networks-internet-lesson7-level6d_v2_2026'
+
+uses_lab2

--- a/dashboard/config/scripts/problem_solving_with_ai_lesson12_level1_v2_2026.bubble_choice
+++ b/dashboard/config/scripts/problem_solving_with_ai_lesson12_level1_v2_2026.bubble_choice
@@ -7,3 +7,5 @@ level 'problem-solving-with-ai-lesson12-level1a_v2_2026'
 level 'problem-solving-with-ai-lesson12-level1b_v2_2026'
 level 'problem-solving-with-ai-lesson12-level1c_v2_2026'
 level 'problem-solving-with-ai-lesson12-level1d_v2_2026'
+
+uses_lab2

--- a/dashboard/config/scripts/problem_solving_with_ai_lesson12_level2_v2_2026.bubble_choice
+++ b/dashboard/config/scripts/problem_solving_with_ai_lesson12_level2_v2_2026.bubble_choice
@@ -7,3 +7,5 @@ level 'problem-solving-with-ai-lesson12-level2a_v2_2026'
 level 'problem-solving-with-ai-lesson12-level2b_v2_2026'
 level 'problem-solving-with-ai-lesson12-level2c_v2_2026'
 level 'problem-solving-with-ai-lesson12-level2d_v2_2026'
+
+uses_lab2

--- a/dashboard/config/scripts/problem_solving_with_ai_lesson3_level1_v2_2026.bubble_choice
+++ b/dashboard/config/scripts/problem_solving_with_ai_lesson3_level1_v2_2026.bubble_choice
@@ -6,3 +6,5 @@ sublevels
 level 'problem-solving-with-ai-lesson3-level1a_v2_2026'
 level 'problem-solving-with-ai-lesson3-level1b_v2_2026'
 level 'problem-solving-with-ai-lesson3-level1c_v2_2026'
+
+uses_lab2

--- a/dashboard/config/scripts/problem_solving_with_ai_lesson3_level2_v2_2026.bubble_choice
+++ b/dashboard/config/scripts/problem_solving_with_ai_lesson3_level2_v2_2026.bubble_choice
@@ -6,3 +6,5 @@ sublevels
 level 'problem-solving-with-ai-lesson3-level2a_v2_2026'
 level 'problem-solving-with-ai-lesson3-level2b_v2_2026'
 level 'problem-solving-with-ai-lesson3-level2c_v2_2026'
+
+uses_lab2

--- a/dashboard/config/scripts/problem_solving_with_ai_lesson3_level3_v2_2026.bubble_choice
+++ b/dashboard/config/scripts/problem_solving_with_ai_lesson3_level3_v2_2026.bubble_choice
@@ -6,3 +6,5 @@ sublevels
 level 'problem-solving-with-ai-lesson3-level3a_v2_2026'
 level 'problem-solving-with-ai-lesson3-level3b_v2_2026'
 level 'problem-solving-with-ai-lesson3-level3c_v2_2026'
+
+uses_lab2

--- a/dashboard/config/scripts/problem_solving_with_ai_lesson5_level3_v2_2026.bubble_choice
+++ b/dashboard/config/scripts/problem_solving_with_ai_lesson5_level3_v2_2026.bubble_choice
@@ -7,3 +7,5 @@ level 'test-problem-solving-with-ai-lesson5-level3-choice1_v2_2026'
 level 'test-problem-solving-with-ai-lesson5-level3-choice3_v2_2026'
 level 'test-problem-solving-with-ai-lesson5-level3-choice4_v2_2026'
 level 'test-problem-solving-with-ai-lesson5-level3-choice5_v2_2026'
+
+uses_lab2

--- a/dashboard/config/scripts/problem_solving_with_ai_lesson5_level4_v2_2026.bubble_choice
+++ b/dashboard/config/scripts/problem_solving_with_ai_lesson5_level4_v2_2026.bubble_choice
@@ -7,3 +7,5 @@ level 'test-problem-solving-with-ai-lesson5-level4-choice1_v2_2026'
 level 'test-problem-solving-with-ai-lesson5-level4-choice3_v2_2026'
 level 'test-problem-solving-with-ai-lesson5-level4-choice4_v2_2026'
 level 'test-problem-solving-with-ai-lesson5-level4-choice5_v2_2026'
+
+uses_lab2

--- a/dashboard/config/scripts/problem_solving_with_ai_lesson6_level3_v2_2026.bubble_choice
+++ b/dashboard/config/scripts/problem_solving_with_ai_lesson6_level3_v2_2026.bubble_choice
@@ -6,3 +6,5 @@ sublevels
 level 'problem-solving-with-ai-lesson6-level3a_v2_2026'
 level 'problem-solving-with-ai-lesson6-level3b_v2_2026'
 level 'problem-solving-with-ai-lesson6-level3c_v2_2026'
+
+uses_lab2

--- a/dashboard/config/scripts/problem_solving_with_ai_lesson6_level4_v2_2026.bubble_choice
+++ b/dashboard/config/scripts/problem_solving_with_ai_lesson6_level4_v2_2026.bubble_choice
@@ -6,3 +6,5 @@ sublevels
 level 'problem-solving-with-ai-lesson6-level4a_v2_2026'
 level 'problem-solving-with-ai-lesson6-level4b_v2_2026'
 level 'problem-solving-with-ai-lesson6-level4c_v2_2026'
+
+uses_lab2

--- a/dashboard/config/scripts/test_problem_solving_with_ai_lesson1_level6_v2_2026.bubble_choice
+++ b/dashboard/config/scripts/test_problem_solving_with_ai_lesson1_level6_v2_2026.bubble_choice
@@ -7,3 +7,5 @@ level 'test-problem-solving-with-ai-lesson1-level6-choice1_v2_2026'
 level 'test-problem-solving-with-ai-lesson1-level6-choice2_v2_2026'
 level 'test-problem-solving-with-ai-lesson1-level6-choice3_v2_2026'
 level 'test-problem-solving-with-ai-lesson1-level6-choice4_v2_2026'
+
+uses_lab2

--- a/dashboard/config/scripts/test_problem_solving_with_ai_lesson2_level4_v2_2026.bubble_choice
+++ b/dashboard/config/scripts/test_problem_solving_with_ai_lesson2_level4_v2_2026.bubble_choice
@@ -7,3 +7,5 @@ level 'test-problem-solving-with-ai-lesson2-level4-choice1_v2_2026'
 level 'test-problem-solving-with-ai-lesson2-level4-choice2_v2_2026'
 level 'test-problem-solving-with-ai-lesson2-level4-choice3_v2_2026'
 level 'test-problem-solving-with-ai-lesson2-level4-choice4_v2_2026'
+
+uses_lab2


### PR DESCRIPTION
When cloning units or lessons, a bunch of BubbleChoice properties related to lab2 got dropped. The fix for this is in a different PR. This PR instead attempts to backfill all the missing properties.

When we copy levels, we generally update the suffix of the level name. In the last round of copying, we did two sets of level copies: one that appended `_2025-v2` to level names (for LTS CSD) and one that appended `_2026` to level names (for the 2026 versions of various courses). Because of this fairly rigid convention, we could find the 2025 bubble choice levels, find the corresponding `_2025-v2` and `_2026` levels, and check if they're consistent.

I fed that into Claude and had it write a script for me (in this PR). I reviewed this script, though not as carefully as I might with code that would be run on our application servers. This was the summary output I got from Claude:
```
  --- Summary ---
  Source files scanned:       902
    with target properties:   146
    without target properties:756
  Counterpart files found:    113
    needing update:           107
    already up-to-date:       6
  No counterpart found:       62
  Errors:                     0
 ```

Almost all of the updates just appended `uses_lab2` but a couple levels also got `hide_letters_lab2`.



