### PR TITLE
Update `eyes_selenium` to 6.12.28

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -119,7 +119,7 @@ group :development, :test do
 
   # For UI testing.
   gem 'cucumber'
-  gem 'eyes_selenium', '~> 4.0'
+  gem 'eyes_selenium', '>= 6.0.4' # required for Ruby 3.2 support
   gem 'fakefs', '~> 2.5.0', require: false
   gem 'minitest', '~> 5.15'
   gem 'minitest-around'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -364,8 +364,6 @@ GEM
     crowdin-api (1.10.0)
       open-uri (>= 0.1.0, < 0.2.0)
       rest-client (>= 2.0.0, < 2.2.0)
-    css_parser (1.21.1)
-      addressable
     csv (3.3.0)
     cucumber (3.1.1)
       builder (>= 2.1.2)
@@ -422,22 +420,14 @@ GEM
     eventmachine (1.2.7)
     execjs (2.7.0)
     exifr (1.2.5)
-    eyes_core (4.6.3)
-      colorize
-      eyes_universal (~> 3.3.3)
-      faraday
-      faraday-cookie_jar
-      faraday_middleware
+    eyes_core (6.10.1)
+      eyes_universal (= 4.59.1)
       oj
-      sorted_set
       websocket
-    eyes_selenium (4.6.3)
-      crass
-      css_parser
-      eyes_core (= 4.6.3)
-      selenium-webdriver (>= 3)
-      state_machine
-    eyes_universal (3.3.3)
+    eyes_selenium (6.12.28)
+      eyes_core (= 6.10.1)
+      selenium-webdriver (>= 3, < 5)
+    eyes_universal (4.59.1)
     factory_bot (6.2.1)
       activesupport (>= 5.0.0)
     factory_bot_rails (6.2.0)
@@ -460,9 +450,6 @@ GEM
       faraday-rack (~> 1.0)
       faraday-retry (~> 1.0)
       ruby2_keywords (>= 0.0.4)
-    faraday-cookie_jar (0.0.7)
-      faraday (>= 0.8.0)
-      http-cookie (~> 1.0.0)
     faraday-em_http (1.0.0)
     faraday-em_synchrony (1.0.0)
     faraday-excon (1.1.0)
@@ -474,8 +461,6 @@ GEM
     faraday-patron (1.0.0)
     faraday-rack (1.0.0)
     faraday-retry (1.0.3)
-    faraday_middleware (1.2.1)
-      faraday (~> 1.0)
     ffi (1.17.0)
     ffi-compiler (1.3.2)
       ffi (>= 1.15.5)
@@ -1128,7 +1113,6 @@ GEM
     sshkit (1.20.0)
       net-scp (>= 1.1.2)
       net-ssh (>= 2.8.0)
-    state_machine (1.2.0)
     statsig (2.5.5)
       concurrent-ruby (~> 1.1)
       connection_pool (~> 2.4, >= 2.4.1)
@@ -1279,7 +1263,7 @@ DEPENDENCIES
   dotiw
   drb
   execjs
-  eyes_selenium (~> 4.0)
+  eyes_selenium (>= 6.0.4)
   factory_bot_rails (~> 6.2)
   fakefs (~> 2.5.0)
   faker (~> 3.4)

--- a/dashboard/test/ui/features/support/dashboard_helpers.rb
+++ b/dashboard/test/ui/features/support/dashboard_helpers.rb
@@ -1,5 +1,6 @@
 require 'cdo/cdo_cli'
 require 'cdo/rack/cookie_dcdo'
+require 'public_suffix'
 
 module DashboardHelpers
   include CdoCli


### PR DESCRIPTION
Another attempt at https://github.com/code-dot-org/code-dot-org/pull/71433, this time targeting the most recent version rather than the earliest possible version with Ruby 3.2 support.

The last attempt revealed several flakiness issues with v6.0.4 (mostly `EOFError` and `ECONNRESET` errors). I unfortunately still haven't been able to track down the provenance of that flakiness, but some manual experimentation on an adhoc indicates that it doesn't manifest on this version. It does cause one new error (see comment below), and many of the failures we saw in the DTT with the last attempt did not manifest in any other environment, but I think this represents enough of a potential improvement that it's worth seeing how it works in the DTT.

We could alternatively [target v6.12.10](https://github.com/code-dot-org/code-dot-org/pull/71987), which is the most-recent version which does not introduce any new errors. In the interest of being as up to date as possible, I recommend we try this one first, and only fall back to that earlier version if we see any issues with this one.

## Links

See slack thread [here](https://codedotorg.slack.com/archives/C03CK49G9/p1775251915155639) for more details

## Testing story

As before, tested on an adhoc on which I manually ran `rake ci:seed_ui_test`, made [a few local code edits](https://gist.github.com/Hamms/2dfa1334445f972f34ec00cf97e223d1), and added saucelabs and applitools auth info to `locals.yml`. I ran all eyes tests on our current version of `eyes_selenium`, accepted the baselines, updated the gem to this version, and ran tests again.

## Deployment notes

As before, we should consider this deployment highly speculative; plan to merge when it will be nondisruptive for the pipeline to be blocked off for a couple hours, and be prepared to carefully monitor flakiness as well as accept new baselines.