### PR TITLE
Stub writes for datasets/datablock tests to avoid serializing to disk

### DIFF
--- a/dashboard/test/controllers/datablock_storage_controller_test.rb
+++ b/dashboard/test/controllers/datablock_storage_controller_test.rb
@@ -13,6 +13,8 @@ class DatablockStorageControllerTest < ActionDispatch::IntegrationTest
   setup do
     sign_in @student
     Cdo::Throttle.stubs(:throttle).returns(false)
+    # stub writes so none of the models serialize to disk during testing
+    File.stubs(:write)
   end
 
   def _url(action)

--- a/dashboard/test/controllers/datasets_controller_test.rb
+++ b/dashboard/test/controllers/datasets_controller_test.rb
@@ -2,6 +2,9 @@ require 'test_helper'
 
 class DatasetsControllerTest < ActionController::TestCase
   setup do
+    # stub writes so none of the models serialize to disk during testing
+    File.stubs(:write)
+
     @levelbuilder = create(:levelbuilder)
     Rails.application.config.stubs(:levelbuilder_mode).returns true
     sign_in @levelbuilder


### PR DESCRIPTION
Stub writes for datasets/datablock tests to avoid serializing to disk and potentially leaving artifacts behind on the file system

A couple times we've seen leftover stuff on disk on the test machine. These are leftover from our seeding system serializing db changes to disk that don't get properly cleaned up in some failure cases.


## Links
<!-- Jira tickets, design docs, Slack threads, related PRs, etc. -->

-[slack thread](https://codedotorg.slack.com/archives/C0T0PNTM3/p1774889557457999)

## Testing story
<!-- How was this tested? Manual steps, adhoc links, automated tests, or why testing isn't needed. -->

ran the tests