### PR TITLE
Update web lab 2 prompt to prevent invalid code generation

### DIFF
--- a/apps/src/weblab2/helpers/aiTutorPromptGenerator.ts
+++ b/apps/src/weblab2/helpers/aiTutorPromptGenerator.ts
@@ -1,12 +1,19 @@
 import {DEFAULT_ANSWER_TYPES} from '@cdo/apps/weblab2/constants';
 import basePrompt from '@cdo/apps/weblab2/prompts/basePrompt.md';
+import environmentPrompt from '@cdo/apps/weblab2/prompts/environment.md';
 import preReplyCheckAllowJs from '@cdo/apps/weblab2/prompts/preReplyCheckAllowJs.md';
 import preReplyCheckNoJs from '@cdo/apps/weblab2/prompts/preReplyCheckNoJs.md';
 import {
   ANSWER_TYPE_CONTRACTS,
   ANSWER_TYPE_TRIGGERS,
 } from '@cdo/apps/weblab2/prompts/promptMaps';
+import securityIntro from '@cdo/apps/weblab2/prompts/securityIntro.md';
 import {AiTutorAnswerType} from '@cdo/apps/weblab2/types';
+import {
+  AllowedFontHostnames,
+  AllowedHostnameSuffixes,
+  AllowedImageHostnameSuffixes,
+} from '@cdo/generated-scripts/sharedConstants';
 
 type AnswerTypeGroup = {
   heading: string;
@@ -78,6 +85,20 @@ const generateFinalAnswerTypeList = (
   return finalAnswerTypes;
 };
 
+const buildSecuritySection = (): string => {
+  const connectHostnames = AllowedHostnameSuffixes.join(', ');
+  const imageHostnames = AllowedImageHostnameSuffixes.join(', ');
+  const fontHostnames = AllowedFontHostnames.join(', ');
+
+  return [
+    securityIntro.trim(),
+    '## Allowed External URLs',
+    `Allowed connect sources: ${connectHostnames}`,
+    `Allowed image sources: ${imageHostnames}`,
+    `Allowed font sources: ${fontHostnames}`,
+  ].join('\n');
+};
+
 export const generateAiTutorPrompt = (
   answerTypes: AiTutorAnswerType[],
   answerTypeCustomizations?: Partial<Record<AiTutorAnswerType, string>>
@@ -93,6 +114,10 @@ export const generateAiTutorPrompt = (
   const allowJs = parsedAnswerTypes.includes('buildJavaScript');
 
   return [
+    environmentPrompt.trim(),
+    '',
+    buildSecuritySection(),
+    '',
     basePrompt.trim(),
     '',
     '---',

--- a/apps/src/weblab2/prompts/basePrompt.md
+++ b/apps/src/weblab2/prompts/basePrompt.md
@@ -1,23 +1,3 @@
-# Environment
-
-Students are working on an integrated development environment on Code.org which allows them to create HTML, CSS and Javascript applications in the browser. The tool has 3 main areas:
-
-- Resource Panel
-- Files area
-- Preview area
-
-## Resource Panel
-
-This area includes all the instructions, version history and AI Tutor (AI support). This is where the output messages show.
-
-## Files area
-
-Students can add, edit and delete HTML, CSS, JavaScript, image, markdown, text, and csv files to their project.
-
-## Preview area
-
-Students can preview their web application. They can switch between a desktop and mobile view. They can switch pages by typing in the url bar in the preview area. They can make the preview full screen. Changes made to the file area are automatically updated in the preview area.
-
 # Socratic Web Dev Tutor
 
 ## Role & Purpose

--- a/apps/src/weblab2/prompts/environment.md
+++ b/apps/src/weblab2/prompts/environment.md
@@ -1,0 +1,19 @@
+# Environment
+
+Students are working on an integrated development environment on Code.org which allows them to create HTML, CSS and Javascript applications in the browser. The tool has 3 main areas:
+
+- Resource Panel
+- Files area
+- Preview area
+
+## Resource Panel
+
+This area includes all the instructions, version history and AI Tutor (AI support). This is where the output messages show.
+
+## Files area
+
+Students can add, edit and delete HTML, CSS, JavaScript, image, markdown, text, and csv files to their project.
+
+## Preview area
+
+Students can preview their web application. They can switch between a desktop and mobile view. They can switch pages by typing in the url bar in the preview area. They can make the preview full screen. Changes made to the file area are automatically updated in the preview area.

--- a/apps/src/weblab2/prompts/environment.md
+++ b/apps/src/weblab2/prompts/environment.md
@@ -12,7 +12,7 @@ This area includes all the instructions, version history and AI Tutor (AI suppor
 
 ## Files area
 
-Students can add, edit and delete HTML, CSS, JavaScript, image, markdown, text, and CSV files to their project.
+Students can add, edit and delete HTML, CSS, JavaScript, image, markdown, text, JSON, and CSV files to their project.
 
 ## Preview area
 

--- a/apps/src/weblab2/prompts/environment.md
+++ b/apps/src/weblab2/prompts/environment.md
@@ -1,6 +1,6 @@
 # Environment
 
-Students are working on an integrated development environment on Code.org which allows them to create HTML, CSS and Javascript applications in the browser. The tool has 3 main areas:
+Students are working on an integrated development environment on Code.org which allows them to create HTML, CSS and JavaScript applications in the browser. The tool has 3 main areas:
 
 - Resource Panel
 - Files area
@@ -12,8 +12,8 @@ This area includes all the instructions, version history and AI Tutor (AI suppor
 
 ## Files area
 
-Students can add, edit and delete HTML, CSS, JavaScript, image, markdown, text, and csv files to their project.
+Students can add, edit and delete HTML, CSS, JavaScript, image, markdown, text, and CSV files to their project.
 
 ## Preview area
 
-Students can preview their web application. They can switch between a desktop and mobile view. They can switch pages by typing in the url bar in the preview area. They can make the preview full screen. Changes made to the file area are automatically updated in the preview area.
+Students can preview their web application. They can switch between a desktop and mobile view. They can switch pages by typing in the URL bar in the preview area. They can make the preview full screen. Changes made to the file area are automatically updated in the preview area.

--- a/apps/src/weblab2/prompts/preReplyCheckAllowJs.md
+++ b/apps/src/weblab2/prompts/preReplyCheckAllowJs.md
@@ -1,3 +1,7 @@
 ## Pre-Reply Leak Check (must pass before sending)
 - If the user asked for a page/layout/wireframe and your draft reply does **not** include runnable `html` (and `css` if asked/implied), **restart the reply in buildHTML** (and **buildCSS**) mode and output the code first.
 - If the next reply would combine HTML + CSS + JS in one reply → **Stop and pivot** use proper Build mode answer contract with only 1 language at a time.
+- If the draft code contains any external URL (any `http://` or `https://` reference), verify:
+  - It is **not** an `<a href>` link (navigation is blocked by sandbox — remove it or replace with a comment)
+  - It is **not** a `<script src>`
+  - Its hostname (or a parent domain) appears in the **relevant allow-list** for its usage type (connect / image / font) — if not, remove it

--- a/apps/src/weblab2/prompts/preReplyCheckAllowJs.md
+++ b/apps/src/weblab2/prompts/preReplyCheckAllowJs.md
@@ -4,4 +4,5 @@
 - If the draft code contains any external URL (any `http://` or `https://` reference), verify:
   - It is **not** an `<a href>` link (navigation is blocked by sandbox — remove it or replace with a comment)
   - It is **not** a `<script src>`
+  - It is **not** an external `<link rel="stylesheet" href="...">` unless it points to an allowed font provider; otherwise remove it and inline the CSS instead
   - Its hostname (or a parent domain) appears in the **relevant allow-list** for its usage type (connect / image / font) — if not, remove it

--- a/apps/src/weblab2/prompts/preReplyCheckNoJs.md
+++ b/apps/src/weblab2/prompts/preReplyCheckNoJs.md
@@ -1,4 +1,8 @@
 ## Pre-Reply Leak Check (must pass before sending)
+- If the draft code contains any external URL (any `http://` or `https://` reference), verify:
+  - It is **not** an `<a href>` link (navigation is blocked by sandbox — remove it or replace with a comment)
+  - It is **not** a `<script src>`
+  - Its hostname (or a parent domain) appears in the **relevant allow-list** for its usage type (connect / image / font) — if not, remove it
 - If the user asked for a page/layout/wireframe and your draft reply does **not** include runnable `html` (and `css` if asked/implied), **restart the reply in buildHTML** (and **buildCSS**) mode and output the code first.
 - If the next reply would combine HTML + CSS + JS in one reply → **Stop and pivot** use proper Build mode answer contract with only 1 language at a time.
 - If the next reply would:

--- a/apps/src/weblab2/prompts/preReplyCheckNoJs.md
+++ b/apps/src/weblab2/prompts/preReplyCheckNoJs.md
@@ -2,6 +2,7 @@
 - If the draft code contains any external URL (any `http://` or `https://` reference), verify:
   - It is **not** an `<a href>` link (navigation is blocked by sandbox — remove it or replace with a comment)
   - It is **not** a `<script src>`
+  - It is **not** an external `<link rel="stylesheet" href="...">` unless it points to an allowed font provider; otherwise remove it and inline the CSS instead
   - Its hostname (or a parent domain) appears in the **relevant allow-list** for its usage type (connect / image / font) — if not, remove it
 - If the user asked for a page/layout/wireframe and your draft reply does **not** include runnable `html` (and `css` if asked/implied), **restart the reply in buildHTML** (and **buildCSS**) mode and output the code first.
 - If the next reply would combine HTML + CSS + JS in one reply → **Stop and pivot** use proper Build mode answer contract with only 1 language at a time.

--- a/apps/src/weblab2/prompts/preReplyCheckNoJs.md
+++ b/apps/src/weblab2/prompts/preReplyCheckNoJs.md
@@ -1,9 +1,4 @@
 ## Pre-Reply Leak Check (must pass before sending)
-- If the draft code contains any external URL (any `http://` or `https://` reference), verify:
-  - It is **not** an `<a href>` link (navigation is blocked by sandbox — remove it or replace with a comment)
-  - It is **not** a `<script src>`
-  - It is **not** an external `<link rel="stylesheet" href="...">` unless it points to an allowed font provider; otherwise remove it and inline the CSS instead
-  - Its hostname (or a parent domain) appears in the **relevant allow-list** for its usage type (connect / image / font) — if not, remove it
 - If the user asked for a page/layout/wireframe and your draft reply does **not** include runnable `html` (and `css` if asked/implied), **restart the reply in buildHTML** (and **buildCSS**) mode and output the code first.
 - If the next reply would combine HTML + CSS + JS in one reply → **Stop and pivot** use proper Build mode answer contract with only 1 language at a time.
 - If the next reply would:
@@ -11,3 +6,8 @@
     - Include a user literal inside a JS fence, or
     - Provide a single-placeholder, paste-ready JS template,
         → **Stop and pivot** use proper Tutor mode answer contract.
+- If the draft code contains any external URL (any `http://` or `https://` reference), verify:
+  - It is **not** an `<a href>` link (navigation is blocked by sandbox — remove it or replace with a comment)
+  - It is **not** a `<script src>`
+  - It is **not** an external `<link rel="stylesheet" href="...">` unless it points to an allowed font provider; otherwise remove it and inline the CSS instead
+  - Its hostname (or a parent domain) appears in the **relevant allow-list** for its usage type (connect / image / font) — if not, remove it

--- a/apps/src/weblab2/prompts/securityIntro.md
+++ b/apps/src/weblab2/prompts/securityIntro.md
@@ -1,0 +1,14 @@
+# Security
+
+## Sandbox
+The preview tool runs in a sandboxed environment and therefore cannot do everything a standard webpage can do. The sandbox
+allows scripts and forms, but does not allow security concerns such as modals, popups, or opening a new tab. Do not suggest
+code that will not work under this sandbox.
+
+## Content Security Policy
+The preview runs under a Content Security Policy. Only URLs from allowed hostnames are permitted for fetch requests (listed below).
+Subdomains of any of the provided hostnames are also permitted. Linking to any external websites is not allowed, even if
+they are in the allow-list, due to the sandbox restrictions.
+Do not suggest, generate, or include URLs from any other hostnames. If the student asks about a disallowed URL, 
+explain that the tool is designed to only allow resources from trusted hosts to ensure security and privacy. Students can
+contact `support@code.org` to request a new allowed URL.

--- a/apps/src/weblab2/prompts/securityIntro.md
+++ b/apps/src/weblab2/prompts/securityIntro.md
@@ -2,13 +2,24 @@
 
 ## Sandbox
 The preview tool runs in a sandboxed environment and therefore cannot do everything a standard webpage can do. The sandbox
-allows scripts and forms, but does not allow security concerns such as modals, popups, or opening a new tab. Do not suggest
-code that will not work under this sandbox.
+allows scripts and forms, but blocks modals, popups, and opening a new tab. Do not suggest code that will not work under this sandbox.
+
+**Navigation links are blocked by the sandbox.** Do not suggest `<a href="...">` tags pointing to any external URL — clicking them will silently fail. If the student needs to reference an external site, suggest they open it in a separate browser tab themselves.
 
 ## Content Security Policy
-The preview runs under a Content Security Policy. Only URLs from allowed hostnames are permitted for fetch requests (listed below).
-Subdomains of any of the provided hostnames are also permitted. Linking to any external websites is not allowed, even if
-they are in the allow-list, due to the sandbox restrictions.
-Do not suggest, generate, or include URLs from any other hostnames. If the student asks about a disallowed URL, 
+The preview runs under a Content Security Policy (CSP). The CSP controls which external URLs may be used for specific resource types. Subdomains of any listed hostname are also permitted.
+
+**What the CSP allows (use only URLs from the matching allow-list below):**
+- `fetch()` / `XMLHttpRequest` → only from **Allowed connect sources**
+- `<img src="...">` / CSS `background-image` → only from **Allowed image sources**
+- `@font-face` / Google Fonts `<link>` → only from **Allowed font sources**
+
+**What is always blocked, regardless of the allow-list:**
+- `<a href="...">` links to external URLs (blocked by sandbox, not just CSP)
+- `<script src="...">` from external URLs
+- `<link rel="stylesheet" href="...">` from external URLs (except font providers in the font allow-list)
+- Any URL whose hostname (or parent domain) is not in the relevant allow-list
+
+Do not suggest, generate, or include external URLs that are not in the relevant allow-list. If the student asks about a disallowed URL,
 explain that the tool is designed to only allow resources from trusted hosts to ensure security and privacy. Students can
 contact `support@code.org` to request a new allowed URL.

--- a/apps/src/weblab2/prompts/securityIntro.md
+++ b/apps/src/weblab2/prompts/securityIntro.md
@@ -4,7 +4,7 @@
 The preview tool runs in a sandboxed environment and therefore cannot do everything a standard webpage can do. The sandbox
 allows scripts and forms, but blocks modals, popups, and opening a new tab. Do not suggest code that will not work under this sandbox.
 
-**Navigation links are blocked by the sandbox.** Do not suggest `<a href="...">` tags pointing to any external URL — clicking them will silently fail. If the student needs to reference an external site, suggest they open it in a separate browser tab themselves.
+**Navigation links are blocked by the sandbox.** Do not suggest `<a href="...">` tags pointing to any external URL — clicking them will silently fail.
 
 ## Content Security Policy
 The preview runs under a Content Security Policy (CSP). The CSP controls which external URLs may be used for specific resource types. Subdomains of any listed hostname are also permitted.

--- a/apps/test/unit/weblab2/helpers/aiTutorPromptGeneratorTest.ts
+++ b/apps/test/unit/weblab2/helpers/aiTutorPromptGeneratorTest.ts
@@ -192,7 +192,7 @@ describe('generateAiTutorPrompt', () => {
       expect(result).toContain(basePrompt.trim());
       expect(result).toContain(buildHTMLTrigger.trim());
       expect(result).toContain(buildCSSContract.trim());
-      // Default answer types do not include buildJavaScript.
+      // Default answer types list does not include buildJavaScript.
       expect(result).toContain(preReplyCheckNoJs.trim());
     });
   });

--- a/apps/test/unit/weblab2/helpers/aiTutorPromptGeneratorTest.ts
+++ b/apps/test/unit/weblab2/helpers/aiTutorPromptGeneratorTest.ts
@@ -6,9 +6,16 @@ import askTrigger from '@cdo/apps/weblab2/prompts/answerTypeTriggers/ask.md';
 import buildCSSTrigger from '@cdo/apps/weblab2/prompts/answerTypeTriggers/buildCSS.md';
 import buildHTMLTrigger from '@cdo/apps/weblab2/prompts/answerTypeTriggers/buildHTML.md';
 import basePrompt from '@cdo/apps/weblab2/prompts/basePrompt.md';
+import environmentPrompt from '@cdo/apps/weblab2/prompts/environment.md';
 import preReplyCheckAllowJs from '@cdo/apps/weblab2/prompts/preReplyCheckAllowJs.md';
 import preReplyCheckNoJs from '@cdo/apps/weblab2/prompts/preReplyCheckNoJs.md';
+import securityIntro from '@cdo/apps/weblab2/prompts/securityIntro.md';
 import {AiTutorAnswerType} from '@cdo/apps/weblab2/types';
+import {
+  AllowedFontHostnames,
+  AllowedHostnameSuffixes,
+  AllowedImageHostnameSuffixes,
+} from '@cdo/generated-scripts/sharedConstants';
 
 const ALL_ANSWER_TYPES: AiTutorAnswerType[] = [
   'buildHTML',
@@ -26,9 +33,14 @@ const ALL_ANSWER_TYPES: AiTutorAnswerType[] = [
 
 describe('generateAiTutorPrompt', () => {
   describe('fixed sections', () => {
-    it('starts with basePrompt content', () => {
+    it('starts with environmentPrompt content', () => {
       const result = generateAiTutorPrompt(ALL_ANSWER_TYPES);
-      expect(result.startsWith(basePrompt.trim())).toBe(true);
+      expect(result.startsWith(environmentPrompt.trim())).toBe(true);
+    });
+
+    it('includes basePrompt content', () => {
+      const result = generateAiTutorPrompt(ALL_ANSWER_TYPES);
+      expect(result).toContain(basePrompt.trim());
     });
 
     it('ends with preReplyCheckAllowJs content if buildJavaScript answer type is included', () => {
@@ -54,11 +66,42 @@ describe('generateAiTutorPrompt', () => {
       expect(result).toContain('## Mode Answer Contracts');
     });
 
+    it('places environmentPrompt before security section and basePrompt', () => {
+      const result = generateAiTutorPrompt(ALL_ANSWER_TYPES);
+      const envPos = result.indexOf(environmentPrompt.trim());
+      const securityPos = result.indexOf(securityIntro.trim());
+      const basePos = result.indexOf(basePrompt.trim());
+      expect(envPos).toBeLessThan(securityPos);
+      expect(securityPos).toBeLessThan(basePos);
+    });
+
     it('places the Mode Router section before Mode Answer Contracts', () => {
       const result = generateAiTutorPrompt(ALL_ANSWER_TYPES);
       expect(result.indexOf('## Mode Router')).toBeLessThan(
         result.indexOf('## Mode Answer Contracts')
       );
+    });
+  });
+
+  describe('security section', () => {
+    it('includes the securityIntro content', () => {
+      const result = generateAiTutorPrompt(ALL_ANSWER_TYPES);
+      expect(result).toContain(securityIntro.trim());
+    });
+
+    it('includes allowed connect sources from sharedConstants', () => {
+      const result = generateAiTutorPrompt(ALL_ANSWER_TYPES);
+      expect(result).toContain(`${AllowedHostnameSuffixes.join(', ')}`);
+    });
+
+    it('includes allowed image sources from sharedConstants', () => {
+      const result = generateAiTutorPrompt(ALL_ANSWER_TYPES);
+      expect(result).toContain(`${AllowedImageHostnameSuffixes.join(', ')}`);
+    });
+
+    it('includes allowed font sources from sharedConstants', () => {
+      const result = generateAiTutorPrompt(ALL_ANSWER_TYPES);
+      expect(result).toContain(`${AllowedFontHostnames.join(', ')}`);
     });
   });
 
@@ -149,8 +192,8 @@ describe('generateAiTutorPrompt', () => {
       expect(result).toContain(basePrompt.trim());
       expect(result).toContain(buildHTMLTrigger.trim());
       expect(result).toContain(buildCSSContract.trim());
-      // Engineer allows javascript
-      expect(result).toContain(preReplyCheckAllowJs.trim());
+      // Default answer types do not include buildJavaScript.
+      expect(result).toContain(preReplyCheckNoJs.trim());
     });
   });
 });


### PR DESCRIPTION
The tutor would recommend APIs, image sources, and font sources that were blocked by our content security policy. It also will put external links in the project with the expectation that you could open a link from your project, which we block with the iframe sandbox. This refactors and updates the prompt to include the following:
- List of what urls are allowed by the CSP, which is generated programmatically and will update when the constants update.
- Description of what the sandbox blocks
- Pre-reply checks to prevent the tutor from returning code that will break due to the sandbox or CSP.


## Links

- Jira: [AFL-549](https://codedotorg.atlassian.net/browse/AFL-549)

## Testing story
Manually tested that after this change the tutor won't suggest invalid image urls, won't add links to urls not in the allow-list, and will explain why it cannot do external links. I also updated the unit tests for the prompt generator.



