### PR TITLE
Update `eyes_selenium` to 6.12.10

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -119,7 +119,7 @@ group :development, :test do
 
   # For UI testing.
   gem 'cucumber'
-  gem 'eyes_selenium', '~> 4.0'
+  gem 'eyes_selenium', '6.12.10' # >=6.0.4 is required for Ruby 3.2, <6.12.11 is required to avoid NameError flakiness
   gem 'fakefs', '~> 2.5.0', require: false
   gem 'minitest', '~> 5.15'
   gem 'minitest-around'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -422,22 +422,22 @@ GEM
     eventmachine (1.2.7)
     execjs (2.7.0)
     exifr (1.2.5)
-    eyes_core (4.6.3)
+    eyes_core (6.9.10)
       colorize
-      eyes_universal (~> 3.3.3)
+      eyes_universal (= 4.53.2)
       faraday
       faraday-cookie_jar
       faraday_middleware
       oj
       sorted_set
       websocket
-    eyes_selenium (4.6.3)
+    eyes_selenium (6.12.10)
       crass
       css_parser
-      eyes_core (= 4.6.3)
+      eyes_core (= 6.9.10)
       selenium-webdriver (>= 3)
-      state_machine
-    eyes_universal (3.3.3)
+      state_machines
+    eyes_universal (4.53.2)
     factory_bot (6.2.1)
       activesupport (>= 5.0.0)
     factory_bot_rails (6.2.0)
@@ -460,9 +460,9 @@ GEM
       faraday-rack (~> 1.0)
       faraday-retry (~> 1.0)
       ruby2_keywords (>= 0.0.4)
-    faraday-cookie_jar (0.0.7)
+    faraday-cookie_jar (0.0.8)
       faraday (>= 0.8.0)
-      http-cookie (~> 1.0.0)
+      http-cookie (>= 1.0.0)
     faraday-em_http (1.0.0)
     faraday-em_synchrony (1.0.0)
     faraday-excon (1.1.0)
@@ -1128,7 +1128,7 @@ GEM
     sshkit (1.20.0)
       net-scp (>= 1.1.2)
       net-ssh (>= 2.8.0)
-    state_machine (1.2.0)
+    state_machines (0.20.0)
     statsig (2.5.5)
       concurrent-ruby (~> 1.1)
       connection_pool (~> 2.4, >= 2.4.1)
@@ -1279,7 +1279,7 @@ DEPENDENCIES
   dotiw
   drb
   execjs
-  eyes_selenium (~> 4.0)
+  eyes_selenium (= 6.12.10)
   factory_bot_rails (~> 6.2)
   fakefs (~> 2.5.0)
   faker (~> 3.4)


### PR DESCRIPTION
Alternative to https://github.com/code-dot-org/code-dot-org/pull/71977; targets the most recent version which avoids the unexplained NameError we see in 6.12.28

Notably, 6.12.11 is the version which [removed the `css_parser`, `crass`, and `state_machines` dependencies from `eyes_selenium`](https://gist.github.com/Hamms/63541ebddb8042000aad46902a4dcf7f#file-6-12-10-vs-6-12-11-diff-L28-L37), as well as three `faraday` dependencies from `eyes_core`



<!--
  Summary of the change: background, motivation, and context.
  Include screenshots, videos, or before/after comparisons for UI changes.
-->



## Links
<!-- Jira tickets, design docs, Slack threads, related PRs, etc. -->

- Jira:

## Testing story
<!-- How was this tested? Manual steps, adhoc links, automated tests, or why testing isn't needed. -->



## Deployment notes
<!-- Delete this section if it's a standard merge-and-deploy.
     Otherwise: migrations, feature flags, coordination, caching impacts, etc. -->



## Privacy and security
<!-- Delete this section if there is no privacy/security impact.
     Otherwise: new PII, auth changes, API surface changes, etc. -->

