### PR TITLE
Consistently Wait for Header Animation

### DIFF
--- a/dashboard/test/ui/features/eyes.feature
+++ b/dashboard/test/ui/features/eyes.feature
@@ -58,7 +58,6 @@ Scenario:
 
   Then I am on "http://studio.code.org/courses/allthethingscourse/units/1/lessons/2/levels/1/lang/ar-sa"
   And I wait for the lab page to fully load
-  And The header is finished animating
   And I see no difference for "maze RTL"
   Given I am on "http://studio.code.org/reset_session/lang/en"
   And I wait for 2 seconds

--- a/dashboard/test/ui/features/eyes.feature
+++ b/dashboard/test/ui/features/eyes.feature
@@ -58,6 +58,7 @@ Scenario:
 
   Then I am on "http://studio.code.org/courses/allthethingscourse/units/1/lessons/2/levels/1/lang/ar-sa"
   And I wait for the lab page to fully load
+  And The header is finished animating
   And I see no difference for "maze RTL"
   Given I am on "http://studio.code.org/reset_session/lang/en"
   And I wait for 2 seconds

--- a/dashboard/test/ui/features/step_definitions/steps.rb
+++ b/dashboard/test/ui/features/step_definitions/steps.rb
@@ -212,7 +212,6 @@ When /^I wait for the lab page to fully load$/ do
     When I wait to see "#runButton"
     And I wait to see ".header_user"
     And I close the instructions overlay if it exists
-    And The header is finished animating
   GHERKIN
 end
 

--- a/dashboard/test/ui/features/step_definitions/steps.rb
+++ b/dashboard/test/ui/features/step_definitions/steps.rb
@@ -212,6 +212,7 @@ When /^I wait for the lab page to fully load$/ do
     When I wait to see "#runButton"
     And I wait to see ".header_user"
     And I close the instructions overlay if it exists
+    And The header is finished animating
   GHERKIN
 end
 

--- a/dashboard/test/ui/features/teacher_tools/submittable_eyes.feature
+++ b/dashboard/test/ui/features/teacher_tools/submittable_eyes.feature
@@ -22,7 +22,6 @@ Scenario: Submittable level
 Scenario: Lockable level
   When I open my eyes to test "lockable level"
   Then I am on "http://studio.code.org/courses/allthethingscourse/units/1"
-  And The header is finished animating
   And I see no difference for "course overview"
   And I scroll our lockable lesson into view
   And I see no difference for "course overview with locked level in view"


### PR DESCRIPTION
We frequently have flaky eyes tests failing with diffs in the progress header. Many of these are likely because the header has a quick fade-in animation which we aren't properly waiting for.

Fortunately, we already have a cucumber step defined to wait for this animation: https://github.com/code-dot-org/code-dot-org/blob/91d3f61c973e1a57e6c788cb4655cf6c7f1c055a/dashboard/test/ui/features/step_definitions/eyes_steps.rb#L74-L80

We just aren't currently using it in very many places.

This PR proposes we add this step to the catchall "I wait for the lab page to fully load" step, which we do use extensively. This should significantly deflake several of our tests, and probably make a lot of ignore regions that we've manually added over the years unnecessary.

Follow-up to https://github.com/code-dot-org/code-dot-org/pull/72944