### PR TITLE
Fix misleading expand/collapse icons in levelbuilder

### DIFF
--- a/apps/src/levelbuilder/CollapsibleEditorSection.jsx
+++ b/apps/src/levelbuilder/CollapsibleEditorSection.jsx
@@ -21,7 +21,7 @@ export default function CollapsibleEditorSection(props) {
             className={style.headerButton}
           >
             <FontAwesome
-              icon={collapsed ? 'expand' : 'compress'}
+              icon={collapsed ? 'chevron-right' : 'chevron-down'}
               className={style.collapsibleEditorSectionIcon}
             />
             {title}

--- a/apps/src/levelbuilder/lesson-editor/ActivityCard.jsx
+++ b/apps/src/levelbuilder/lesson-editor/ActivityCard.jsx
@@ -113,7 +113,9 @@ class ActivityCard extends Component {
               {hasLessonPlan && (
                 <div>
                   <FontAwesome
-                    icon={this.props.collapsed ? 'chevron-right' : 'chevron-down'}
+                    icon={
+                      this.props.collapsed ? 'chevron-right' : 'chevron-down'
+                    }
                     onClick={this.props.handleCollapse}
                   />
                   <label style={styles.labelAndInput}>

--- a/apps/src/levelbuilder/lesson-editor/ActivityCard.jsx
+++ b/apps/src/levelbuilder/lesson-editor/ActivityCard.jsx
@@ -113,7 +113,7 @@ class ActivityCard extends Component {
               {hasLessonPlan && (
                 <div>
                   <FontAwesome
-                    icon={this.props.collapsed ? 'expand' : 'compress'}
+                    icon={this.props.collapsed ? 'chevron-right' : 'chevron-down'}
                     onClick={this.props.handleCollapse}
                   />
                   <label style={styles.labelAndInput}>

--- a/apps/test/unit/levelbuilder/CollapsibleEditorSectionTest.jsx
+++ b/apps/test/unit/levelbuilder/CollapsibleEditorSectionTest.jsx
@@ -26,7 +26,7 @@ describe('CollapsibleEditorSection', () => {
     expect(wrapper.find('span').length).to.equal(1);
     let icon = wrapper.find('FontAwesome');
     expect(icon.length).to.equal(1);
-    expect(icon.props().icon).to.include('compress');
+    expect(icon.props().icon).to.include('chevron-down');
 
     const editorsWrapper = wrapper.children().last();
     expect(editorsWrapper.props().className).to.include(
@@ -54,10 +54,10 @@ describe('CollapsibleEditorSection', () => {
     );
 
     let icon = wrapper.find('FontAwesome');
-    expect(icon.props().icon).to.include('compress');
+    expect(icon.props().icon).to.include('chevron-down');
 
     wrapper.find('button').simulate('click');
 
-    expect(wrapper.find('FontAwesome').props().icon).to.include('expand');
+    expect(wrapper.find('FontAwesome').props().icon).to.include('chevron-right');
   });
 });

--- a/apps/test/unit/levelbuilder/CollapsibleEditorSectionTest.jsx
+++ b/apps/test/unit/levelbuilder/CollapsibleEditorSectionTest.jsx
@@ -58,6 +58,8 @@ describe('CollapsibleEditorSection', () => {
 
     wrapper.find('button').simulate('click');
 
-    expect(wrapper.find('FontAwesome').props().icon).to.include('chevron-right');
+    expect(wrapper.find('FontAwesome').props().icon).to.include(
+      'chevron-right'
+    );
   });
 });


### PR DESCRIPTION
## Summary

- Replace `expand`/`compress` FontAwesome icons with `chevron-right`/`chevron-down` in levelbuilder's collapsible section components
- The FA v4→v7 migration changed these icons from intuitive collapse/expand arrows to four-arrow fullscreen glyphs, which confused curriculum authors
- Only levelbuilder (internal tool) is affected — student/teacher-facing UI uses the same icon names but for actual fullscreen toggling where the glyph is correct

## Changed files

- `apps/src/levelbuilder/CollapsibleEditorSection.jsx` — used in course editor, script editor, and other settings pages
- `apps/src/levelbuilder/lesson-editor/ActivityCard.jsx` — used in lesson editor activity cards

## Test plan

- [ ] Visit `/courses/csd-2025/edit` and verify section headers (Basic Settings, Course Type Settings, etc.) show chevron icons that toggle between right-pointing (collapsed) and down-pointing (expanded)
- [ ] Visit a lesson editor page and verify activity cards show the same chevron behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)