### PR TITLE
Enable classlink button on sign-up page

### DIFF
--- a/apps/src/signUpFlow/LoginTypeSelection.tsx
+++ b/apps/src/signUpFlow/LoginTypeSelection.tsx
@@ -333,7 +333,8 @@ const LoginTypeSelection: React.FunctionComponent<{
               type="submit"
               startIcon={
                 <FontAwesomeV6Icon
-                  iconName="fa-kit fa-classlink"
+                  iconFamily="kit"
+                  iconName="classlink"
                   iconStyle="solid"
                 />
               }

--- a/apps/src/signUpFlow/LoginTypeSelection.tsx
+++ b/apps/src/signUpFlow/LoginTypeSelection.tsx
@@ -325,18 +325,25 @@ const LoginTypeSelection: React.FunctionComponent<{
           </form>
           {/* TODO: once the Classlink icon has been added to our Font Awesome account,
               we can uncomment this form */}
-          {/* <form action="/users/auth/classlink" method="POST">
-            <Button
-              text={locale.sign_up_classlink()}
-              onClick={() => selectOauthLoginType('classlink')}
-              iconLeft={{iconName: 'kit fa-classlink', iconStyle: 'solid'}}
+          <form action="/users/auth/classlink" method="POST">
+            <MuiButton
+              variant="contained"
+              color="primary"
+              size="medium"
               className={style.classlinkButton}
-              buttonTagTypeAttribute="submit"
+              onClick={() => selectOauthLoginType('classlink')}
+              type="submit"
+              startIcon={
+                <FontAwesomeV6Icon
+                  iconName="fa-kit fa-classlink"
+                  iconStyle="solid"
+                />
+              }
             >
-              <img src={classlink} alt="" />
-            </Button>
+              {locale.sign_up_classlink()}
+            </MuiButton>
             <input type="hidden" name="authenticity_token" value={authToken} />
-          </form> */}
+          </form>
           <div className={style.greyTextbox}>
             {!isTeacher && (
               <div className={style.iconContainer}>

--- a/apps/src/signUpFlow/LoginTypeSelection.tsx
+++ b/apps/src/signUpFlow/LoginTypeSelection.tsx
@@ -323,8 +323,6 @@ const LoginTypeSelection: React.FunctionComponent<{
             </MuiButton>
             <input type="hidden" name="authenticity_token" value={authToken} />
           </form>
-          {/* TODO: once the Classlink icon has been added to our Font Awesome account,
-              we can uncomment this form */}
           <form action="/users/auth/classlink" method="POST">
             <MuiButton
               variant="contained"

--- a/apps/test/unit/signUpFlow/LoginTypeSelectionTest.tsx
+++ b/apps/test/unit/signUpFlow/LoginTypeSelectionTest.tsx
@@ -106,6 +106,8 @@ describe('LoginTypeSelection', () => {
     screen.getByText(locale.sign_up_google());
     screen.getByText(locale.sign_up_microsoft());
     screen.getByText(locale.sign_up_facebook());
+    screen.getByText(locale.sign_up_clever());
+    screen.getByText(locale.sign_up_classlink());
 
     // Renders inputs and reminder for field validations
     screen.getByText(locale.email_address());

--- a/frontend/packages/component-library/src/fontAwesomeV6Icon/stories/FontAwesomeV6Icon.story.tsx
+++ b/frontend/packages/component-library/src/fontAwesomeV6Icon/stories/FontAwesomeV6Icon.story.tsx
@@ -136,6 +136,11 @@ GroupOfCustomIconsOfFontAwesomeV6Icon.args = {
     },
     {
       iconFamily: 'kit',
+      iconName: 'classlink',
+      title: 'classlink-kit',
+    },
+    {
+      iconFamily: 'kit',
       iconName: 'clever',
       title: 'clever-kit',
     },


### PR DESCRIPTION
PR to enable the "Sign up with Classlink" button on the sign-up page.

## Context

When we enabled Classlink initially, this button was commented out due to not having the Classlink icon in our Font Awesome bundle. It's now included in our dsco assets.

**ClassLink Icon now included**
<img width="1113" height="841" alt="Screenshot 2026-04-22 at 10 30 58 AM" src="https://github.com/user-attachments/assets/0e79bf8f-3faf-46b1-b898-85beb9fe666a" />


## Links
<!-- Jira tickets, design docs, Slack threads, related PRs, etc. -->

- Jira:

## Testing story
<!-- How was this tested? Manual steps, adhoc links, automated tests, or why testing isn't needed. -->



## Deployment notes
<!-- Delete this section if it's a standard merge-and-deploy.
     Otherwise: migrations, feature flags, coordination, caching impacts, etc. -->



## Privacy and security
<!-- Delete this section if there is no privacy/security impact.
     Otherwise: new PII, auth changes, API surface changes, etc. -->

