### PR TITLE
Fix (a11y): associate SongSelector label with select for accessibility

### DIFF
--- a/apps/src/dance/SongSelector.tsx
+++ b/apps/src/dance/SongSelector.tsx
@@ -77,7 +77,7 @@ const SongSelector: React.FC<SongSelectorProps> = ({
       id="song-selector-wrapper"
       className={moduleStyles.songSelectorWrapper}
     >
-      <label>
+      <label htmlFor="song_selector">
         <b>{commonI18n.selectSong()}</b>
       </label>
 


### PR DESCRIPTION
## Summary
Fixes an accessibility issue in the `SongSelector` component where the visible "Select song" label was not programmatically associated with the `<select>` control.

## Problem
The `<label>` element had no `htmlFor` attribute, so assistive technologies and speech input tools could not determine the accessible name of the combo box. This meant speech input users could not activate the control by saying "Select song."

This violates WCAG 2.1 Success Criterion 2.5.3 (Label in Name) and 1.3.1 (Info and Relationships).

## Solution
Added `htmlFor="song_selector"` to the `<label>` in `song-selector.tsx`, explicitly associating it with the `<select id="song_selector">` control.

## Changes
- `apps/src/dance/song-selector.tsx` — added `htmlFor="song_selector"` to `<label>`

## Links
[Deque audit portal issue 2597800](https://axeauditor.dequecloud.com/test-run/dad68808-2a69-11f1-8768-0b2b032555fe/issue/89348af6-2aa8-11f1-877a-436b5efc6e4b?sortField=ordinal&sortDir=asc&filter%5Bidentifier%5D=2.5.3.a&row=1)