### PR TITLE
Fix (a11y): Associate Age label with dropdown in AgeDialog

### DIFF
--- a/apps/src/dance/SongSelector.tsx
+++ b/apps/src/dance/SongSelector.tsx
@@ -77,7 +77,7 @@ const SongSelector: React.FC<SongSelectorProps> = ({
       id="song-selector-wrapper"
       className={moduleStyles.songSelectorWrapper}
     >
-      <label>
+      <label htmlFor="song_selector">
         <b>{commonI18n.selectSong()}</b>
       </label>
 

--- a/apps/src/templates/AgeDialog.jsx
+++ b/apps/src/templates/AgeDialog.jsx
@@ -106,6 +106,7 @@ class AgeDialog extends Component {
               <div style={styles.middleCell}>
                 {i18n.provideAge()}
                 <div style={styles.age}>
+                  <label htmlFor="uitest-age-selector">{i18n.age()}</label>
                   <AgeDropdown
                     style={styles.dropdown}
                     ref={element => (this.ageDropdown = element)}


### PR DESCRIPTION
## Summary
Adds `htmlFor="uitest-age-selector"` to the visible "Age" label in `AgeDialog`, associating it with the age `<select>` control.

## Problem
The visible "Age" label was not programmatically associated with the dropdown, causing a WCAG 2.5.3 (Label in Name) violation. Speech input users could not activate the control by voice, and screen readers would not announce the label when focusing the dropdown.

## Changes
- `apps/src/templates/AgeDialog.tsx` — wrap `AgeDropdown` with a `<label>` using `htmlFor="uitest-age-selector"` and the existing `i18n.age()` locale string

### Before
<img width="889" height="261" alt="image" src="https://github.com/user-attachments/assets/4fb50be9-2a5b-4f64-bc08-68076fe070ab" />

### After
<img width="883" height="285" alt="image" src="https://github.com/user-attachments/assets/f06bb721-e3b0-4c9b-ae7a-062b88a691db" />
