### PR TITLE
Lab2: don't send success report for lab2 bubble choice

### DIFF
--- a/apps/src/lab2/progress/continueOrFinishLesson.ts
+++ b/apps/src/lab2/progress/continueOrFinishLesson.ts
@@ -20,15 +20,17 @@ export default (): ThunkAction<void, RootState, undefined, AnyAction> =>
       return;
     }
 
-    // If there are no validation conditions and the level is not submittable or a predict level,
+    // If there are no validation conditions and the level is not submittable, predict, or bubble choice level,
     // go ahead and send a success report when we continue.
     // For validated levels, success reports are managed by the ProgressContainer and ProgressManager.
     // For submittable levels, success reports are handled by the submit button.
     // For predict levels, success reports are handled by clicking run after writing a prediction.
+    // For bubble choice levels, we only record progress on sublevels.
     if (
       !getState().lab.validationState.hasConditions &&
       !levelProperties.submittable &&
-      !levelProperties.predictSettings?.isPredictLevel
+      !levelProperties.predictSettings?.isPredictLevel &&
+      levelProperties.appName !== 'bubble_choice'
     ) {
       // Wait for the success report to complete before handling navigation,
       // as navigation could cause a page reload (either switching to a non-lab2 level


### PR DESCRIPTION
We had a UI bug in Lab2 where clicking Continue on bubble choice levels would turn the progress bubble green, even when no work had been completed on a sublevel. This was a transient UI bug only; upon refreshing it would go away and we would (correctly) display the bubble status based on the highest progress sublevel. Bug here was that we were emitting a success report for the bubble choice level type on the "Continue" action when we didn't need to.

https://github.com/user-attachments/assets/59ba3925-6a05-498d-884a-ca20d905e908

## Links
https://codedotorg.atlassian.net/browse/SL-1655

## Testing story
Tested locally on the AID and mix and move script.