### PR TITLE
Set statsig_stable_id as cookie from URL, set stable_stable_id as param on outbound URLs

### DIFF
--- a/apps/src/metrics/outboundStableId.js
+++ b/apps/src/metrics/outboundStableId.js
@@ -1,8 +1,9 @@
 import cookies from 'js-cookie';
 
-// TODO: should we move these to shared constants?
 const STABLE_ID_KEY = 'statsig_stable_id';
 const TARGET_HOSTNAME = 'code.org';
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
 // Read the statsig_stable_id cookie. Returns null if not set (i.e., user
 // has not given OneTrust C0002 consent).
@@ -30,7 +31,7 @@ function handleOutboundClick(event) {
   }
 
   const stableId = getStableIdFromCookie();
-  if (!stableId) {
+  if (!stableId || !UUID_RE.test(stableId)) {
     return;
   }
 
@@ -38,11 +39,13 @@ function handleOutboundClick(event) {
   anchor.href = url.toString();
 }
 
+let initialized = false;
+
 // Register a single delegated click listener on document.
 export function initOutboundStableId() {
-  if (typeof document === 'undefined') {
+  if (typeof document === 'undefined' || initialized) {
     return;
   }
-  console.log('Initializing outbound stable ID handler');
+  initialized = true;
   document.addEventListener('click', handleOutboundClick);
 }

--- a/apps/src/metrics/outboundStableId.js
+++ b/apps/src/metrics/outboundStableId.js
@@ -1,0 +1,48 @@
+import cookies from 'js-cookie';
+
+// TODO: should we move these to shared constants?
+const STABLE_ID_KEY = 'statsig_stable_id';
+const TARGET_HOSTNAME = 'code.org';
+
+// Read the statsig_stable_id cookie. Returns null if not set (i.e., user
+// has not given OneTrust C0002 consent).
+function getStableIdFromCookie() {
+  return cookies.get(STABLE_ID_KEY) || null;
+}
+
+// Delegated click handler that appends statsig_stable_id to outbound
+// code.org links so the stable ID survives the cross-domain transition.
+function handleOutboundClick(event) {
+  const anchor = event.target.closest('a');
+  if (!anchor) {
+    return;
+  }
+
+  let url;
+  try {
+    url = new URL(anchor.href, window.location.origin);
+  } catch {
+    return;
+  }
+
+  if (url.hostname !== TARGET_HOSTNAME) {
+    return;
+  }
+
+  const stableId = getStableIdFromCookie();
+  if (!stableId) {
+    return;
+  }
+
+  url.searchParams.set(STABLE_ID_KEY, stableId);
+  anchor.href = url.toString();
+}
+
+// Register a single delegated click listener on document.
+export function initOutboundStableId() {
+  if (typeof document === 'undefined') {
+    return;
+  }
+  console.log('Initializing outbound stable ID handler');
+  document.addEventListener('click', handleOutboundClick);
+}

--- a/apps/src/metrics/statsigHelpers.js
+++ b/apps/src/metrics/statsigHelpers.js
@@ -40,21 +40,24 @@ export function stripStableIdParam() {
   window.history.replaceState(window.history.state, '', url.toString());
 }
 
+// Read the cross-domain stable ID passed from code.ai via a data attribute
+// set by Rails in application.html.haml.
+function getParamStableId() {
+  if (typeof document === 'undefined') {
+    return null;
+  }
+  const el = document.querySelector('script[data-statsig-param-id]');
+  return el ? el.dataset.statsigParamId : null;
+}
+
 export function findOrCreateStableId() {
   stripStableIdParam();
 
+  const paramId = getParamStableId();
   const cookieId = cookies.get(STABLE_ID_KEY);
   const localStorageId = localStorage.getItem(LOCAL_STORAGE_KEY);
-  let stableId;
-
-  if (cookieId) {
-    // Prefer the cookie value if it exists
-    stableId = cookieId;
-  } else if (localStorageId) {
-    stableId = localStorageId;
-  } else {
-    stableId = createUuid();
-  }
+  // Prefer cross-domain param, then cookie, then localStorage, then new UUID.
+  const stableId = paramId || cookieId || localStorageId || createUuid();
 
   if (consentAllowsStatsigCookie()) {
     cookies.set(STABLE_ID_KEY, stableId, COOKIE_OPTIONS);

--- a/apps/src/metrics/statsigHelpers.js
+++ b/apps/src/metrics/statsigHelpers.js
@@ -32,7 +32,12 @@ export function stripStableIdParam() {
   if (typeof window === 'undefined') {
     return;
   }
-  const url = new URL(window.location.href);
+  let url;
+  try {
+    url = new URL(window.location.href);
+  } catch {
+    return;
+  }
   if (!url.searchParams.has(STABLE_ID_KEY)) {
     return;
   }

--- a/apps/src/metrics/statsigHelpers.js
+++ b/apps/src/metrics/statsigHelpers.js
@@ -26,7 +26,23 @@ export function getUserType() {
   return user_type_element ? user_type_element.dataset.userType : null;
 }
 
+// Remove statsig_stable_id from the visible URL (set by code.ai cross-domain
+// navigation). The value has already been consumed server-side by Rails.
+export function stripStableIdParam() {
+  if (typeof window === 'undefined') {
+    return;
+  }
+  const url = new URL(window.location.href);
+  if (!url.searchParams.has(STABLE_ID_KEY)) {
+    return;
+  }
+  url.searchParams.delete(STABLE_ID_KEY);
+  window.history.replaceState(window.history.state, '', url.toString());
+}
+
 export function findOrCreateStableId() {
+  stripStableIdParam();
+
   const cookieId = cookies.get(STABLE_ID_KEY);
   const localStorageId = localStorage.getItem(LOCAL_STORAGE_KEY);
   let stableId;

--- a/apps/src/sites/studio/pages/code-studio.js
+++ b/apps/src/sites/studio/pages/code-studio.js
@@ -24,6 +24,7 @@ import {
 import {getStore} from '@cdo/apps/code-studio/redux';
 import initResponsive from '@cdo/apps/code-studio/responsive';
 import {initHamburger} from '@cdo/apps/hamburger/hamburger.js';
+import {initOutboundStableId} from '@cdo/apps/metrics/outboundStableId';
 import GDPRDialog from '@cdo/apps/templates/GDPRDialog';
 import {createReactRoot} from '@cdo/apps/util/createReactRoot';
 // disable import/order rule to import consoleShim after setting store.
@@ -146,3 +147,4 @@ initHamburger();
 initSigninState(userType, under13);
 initResponsive();
 injectFontAwesome();
+initOutboundStableId();

--- a/apps/test/unit/lib/util/outboundStableIdTest.js
+++ b/apps/test/unit/lib/util/outboundStableIdTest.js
@@ -9,16 +9,16 @@ describe('outboundStableId', () => {
   const stableId = '550e8400-e29b-41d4-a716-446655440000';
   let cookieGetStub;
 
+  beforeAll(() => {
+    initOutboundStableId();
+  });
+
   beforeEach(() => {
     cookieGetStub = stub(cookies, 'get');
-    initOutboundStableId();
   });
 
   afterEach(() => {
     cookieGetStub.restore();
-    // Remove the listener by re-adding (we can't easily remove it since
-    // the handler is private). Tests use isolated anchors so stale listeners
-    // on document don't interfere.
   });
 
   function clickAnchor(href) {
@@ -40,6 +40,14 @@ describe('outboundStableId', () => {
 
   it('does nothing when cookie does not exist', () => {
     cookieGetStub.withArgs('statsig_stable_id').returns(undefined);
+    const result = clickAnchor('https://code.org/students');
+    expect(result).to.not.include('statsig_stable_id');
+  });
+
+  it('does not append param when cookie value is not a valid UUID', () => {
+    cookieGetStub
+      .withArgs('statsig_stable_id')
+      .returns('<script>alert(1)</script>');
     const result = clickAnchor('https://code.org/students');
     expect(result).to.not.include('statsig_stable_id');
   });

--- a/apps/test/unit/lib/util/outboundStableIdTest.js
+++ b/apps/test/unit/lib/util/outboundStableIdTest.js
@@ -1,0 +1,96 @@
+import cookies from 'js-cookie';
+import {stub} from 'sinon'; // eslint-disable-line no-restricted-imports
+
+import {initOutboundStableId} from '@cdo/apps/metrics/outboundStableId';
+
+import {expect} from '../../../util/reconfiguredChai'; // eslint-disable-line no-restricted-imports
+
+describe('outboundStableId', () => {
+  const stableId = '550e8400-e29b-41d4-a716-446655440000';
+  let cookieGetStub;
+
+  beforeEach(() => {
+    cookieGetStub = stub(cookies, 'get');
+    initOutboundStableId();
+  });
+
+  afterEach(() => {
+    cookieGetStub.restore();
+    // Remove the listener by re-adding (we can't easily remove it since
+    // the handler is private). Tests use isolated anchors so stale listeners
+    // on document don't interfere.
+  });
+
+  function clickAnchor(href) {
+    const a = document.createElement('a');
+    a.href = href;
+    document.body.appendChild(a);
+    a.click();
+    const result = a.href;
+    a.remove();
+    return result;
+  }
+
+  it('appends statsig_stable_id when cookie exists and link is to code.org', () => {
+    cookieGetStub.withArgs('statsig_stable_id').returns(stableId);
+    const result = clickAnchor('https://code.org/students');
+    expect(result).to.include('statsig_stable_id=' + stableId);
+    expect(result).to.include('code.org/students');
+  });
+
+  it('does nothing when cookie does not exist', () => {
+    cookieGetStub.withArgs('statsig_stable_id').returns(undefined);
+    const result = clickAnchor('https://code.org/students');
+    expect(result).to.not.include('statsig_stable_id');
+  });
+
+  it('does not decorate links to studio.code.org', () => {
+    cookieGetStub.withArgs('statsig_stable_id').returns(stableId);
+    const result = clickAnchor('https://studio.code.org/home');
+    expect(result).to.not.include('statsig_stable_id');
+  });
+
+  it('does not decorate links to support.code.org', () => {
+    cookieGetStub.withArgs('statsig_stable_id').returns(stableId);
+    const result = clickAnchor('https://support.code.org/help');
+    expect(result).to.not.include('statsig_stable_id');
+  });
+
+  it('does not decorate links to external domains', () => {
+    cookieGetStub.withArgs('statsig_stable_id').returns(stableId);
+    const result = clickAnchor('https://google.com');
+    expect(result).to.not.include('statsig_stable_id');
+  });
+
+  it('replaces existing statsig_stable_id param instead of duplicating', () => {
+    cookieGetStub.withArgs('statsig_stable_id').returns(stableId);
+    const result = clickAnchor(
+      'https://code.org/students?statsig_stable_id=old-value'
+    );
+    expect(result).to.include('statsig_stable_id=' + stableId);
+    expect(result).to.not.include('old-value');
+    // Ensure only one occurrence
+    const matches = result.match(/statsig_stable_id/g);
+    expect(matches).to.have.lengthOf(1);
+  });
+
+  it('preserves existing query parameters', () => {
+    cookieGetStub.withArgs('statsig_stable_id').returns(stableId);
+    const result = clickAnchor('https://code.org/students?ref=studio');
+    expect(result).to.include('ref=studio');
+    expect(result).to.include('statsig_stable_id=' + stableId);
+  });
+
+  it('catches clicks on child elements inside an anchor', () => {
+    cookieGetStub.withArgs('statsig_stable_id').returns(stableId);
+    const a = document.createElement('a');
+    a.href = 'https://code.org/about';
+    const span = document.createElement('span');
+    span.textContent = 'About';
+    a.appendChild(span);
+    document.body.appendChild(a);
+    span.click();
+    expect(a.href).to.include('statsig_stable_id=' + stableId);
+    a.remove();
+  });
+});

--- a/apps/test/unit/lib/util/statsigHelpersTest.js
+++ b/apps/test/unit/lib/util/statsigHelpersTest.js
@@ -1,6 +1,8 @@
+import cookies from 'js-cookie';
 import {stub} from 'sinon'; // eslint-disable-line no-restricted-imports
 
 import {
+  findOrCreateStableId,
   formatUserId,
   stripStableIdParam,
 } from '@cdo/apps/metrics/statsigHelpers';
@@ -19,7 +21,6 @@ describe('StatsigReporter', () => {
 
     afterEach(() => {
       replaceStateStub.restore();
-      // Reset location if we changed it
       if (window.location !== originalLocation) {
         delete window.location;
         window.location = originalLocation;
@@ -55,6 +56,42 @@ describe('StatsigReporter', () => {
       window.location = new URL('http://localhost/page?other=bar');
       stripStableIdParam();
       expect(replaceStateStub.called).to.be.false;
+    });
+  });
+
+  describe('findOrCreateStableId with cross-domain param', () => {
+    const paramUuid = '550e8400-e29b-41d4-a716-446655440000';
+    let scriptEl;
+
+    beforeEach(() => {
+      // Simulate the data attribute emitted by Rails
+      scriptEl = document.createElement('script');
+      scriptEl.dataset.statsigParamId = paramUuid;
+      document.head.appendChild(scriptEl);
+      // Stub replaceState to avoid side effects from stripStableIdParam
+      stub(window.history, 'replaceState');
+      // Enable consent so cookies.set is called
+      window.OnetrustActiveGroups = ',C0002,';
+    });
+
+    afterEach(() => {
+      scriptEl.remove();
+      window.history.replaceState.restore();
+      cookies.remove('statsig_stable_id', {path: '/', domain: '.code.org'});
+      localStorage.removeItem('STATSIG_STABLE_ID');
+      delete window.OnetrustActiveGroups;
+    });
+
+    it('returns the param value when data attribute is present', () => {
+      const result = findOrCreateStableId();
+      expect(result).to.equal(paramUuid);
+    });
+
+    it('prefers the data attribute over an existing cookie', () => {
+      // Set a cookie without domain restriction so jsdom can read it
+      cookies.set('statsig_stable_id', 'old-cookie-value');
+      const result = findOrCreateStableId();
+      expect(result).to.equal(paramUuid);
     });
   });
 

--- a/apps/test/unit/lib/util/statsigHelpersTest.js
+++ b/apps/test/unit/lib/util/statsigHelpersTest.js
@@ -1,11 +1,63 @@
 import {stub} from 'sinon'; // eslint-disable-line no-restricted-imports
 
-import {formatUserId} from '@cdo/apps/metrics/statsigHelpers';
+import {
+  formatUserId,
+  stripStableIdParam,
+} from '@cdo/apps/metrics/statsigHelpers';
 import * as utils from '@cdo/apps/utils';
 
 import {expect} from '../../../util/reconfiguredChai'; // eslint-disable-line no-restricted-imports
 
 describe('StatsigReporter', () => {
+  describe('stripStableIdParam', () => {
+    let replaceStateStub;
+    const originalLocation = window.location;
+
+    beforeEach(() => {
+      replaceStateStub = stub(window.history, 'replaceState');
+    });
+
+    afterEach(() => {
+      replaceStateStub.restore();
+      // Reset location if we changed it
+      if (window.location !== originalLocation) {
+        delete window.location;
+        window.location = originalLocation;
+      }
+    });
+
+    it('removes statsig_stable_id from URL and preserves other params', () => {
+      delete window.location;
+      window.location = new URL(
+        'http://localhost/?statsig_stable_id=550e8400-e29b-41d4-a716-446655440000&other=foo'
+      );
+      stripStableIdParam();
+      expect(replaceStateStub.calledOnce).to.be.true;
+      const newUrl = replaceStateStub.firstCall.args[2];
+      expect(newUrl).to.include('other=foo');
+      expect(newUrl).to.not.include('statsig_stable_id');
+    });
+
+    it('removes entire query string when statsig_stable_id is the only param', () => {
+      delete window.location;
+      window.location = new URL(
+        'http://localhost/path?statsig_stable_id=550e8400-e29b-41d4-a716-446655440000'
+      );
+      stripStableIdParam();
+      expect(replaceStateStub.calledOnce).to.be.true;
+      const newUrl = replaceStateStub.firstCall.args[2];
+      expect(newUrl).to.not.include('?');
+      expect(newUrl).to.include('/path');
+    });
+
+    it('does nothing when statsig_stable_id is not in URL', () => {
+      delete window.location;
+      window.location = new URL('http://localhost/page?other=bar');
+      stripStableIdParam();
+      expect(replaceStateStub.called).to.be.false;
+    });
+  });
+
   describe('formatUserId', () => {
     it('prepends environment in test', () => {
       stub(utils, 'getEnvironment').returns('test');

--- a/dashboard/app/controllers/application_controller.rb
+++ b/dashboard/app/controllers/application_controller.rb
@@ -454,9 +454,29 @@ class ApplicationController < ActionController::Base
     redirect_to lti_v1_account_linking_landing_path
   end
 
+  UUID_RE = /\A[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\z/i
+
+  STATSIG_COOKIE_OPTIONS = {
+    domain: '.code.org',
+    path: '/',
+    secure: true,
+    same_site: :lax,
+  }.freeze
+
   # Creates a statsig stable id for use of signed-out user tracking.
   # This cookie is used by the Statsig SDK for both JS and Ruby.
+  #
+  # When a request arrives with a valid statsig_stable_id URL parameter
+  # (e.g. from code.ai cross-domain navigation), adopt that value and
+  # persist it as a cookie so the frontend JS picks it up.
   protected def initialize_statsig_stable_id
+    param_stable_id = params[:statsig_stable_id]
+    if param_stable_id.present? && param_stable_id.match?(UUID_RE)
+      cookies[:statsig_stable_id] = STATSIG_COOKIE_OPTIONS.merge(value: param_stable_id)
+      session[:statsig_stable_id] = param_stable_id
+      return
+    end
+
     existing_stable_id = cookies[:statsig_stable_id]
     session[:statsig_stable_id] = existing_stable_id if existing_stable_id.present?
     session[:statsig_stable_id] ||= SecureRandom.uuid

--- a/dashboard/app/controllers/application_controller.rb
+++ b/dashboard/app/controllers/application_controller.rb
@@ -454,7 +454,7 @@ class ApplicationController < ActionController::Base
     redirect_to lti_v1_account_linking_landing_path
   end
 
-  UUID_RE = /\A[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\z/i
+  UUID_REGEX = /\A[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\z/i
 
   # Creates a statsig stable id for use of signed-out user tracking.
   # This cookie is used by the Statsig SDK for both JS and Ruby.
@@ -466,7 +466,7 @@ class ApplicationController < ActionController::Base
   # existing OneTrust consent-gated path.
   protected def initialize_statsig_stable_id
     param_stable_id = params[:statsig_stable_id]
-    if param_stable_id.present? && param_stable_id.match?(UUID_RE)
+    if param_stable_id.present? && param_stable_id.match?(UUID_REGEX)
       session[:statsig_stable_id] = param_stable_id
       @statsig_param_id = param_stable_id
       return

--- a/dashboard/app/controllers/application_controller.rb
+++ b/dashboard/app/controllers/application_controller.rb
@@ -456,24 +456,19 @@ class ApplicationController < ActionController::Base
 
   UUID_RE = /\A[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\z/i
 
-  STATSIG_COOKIE_OPTIONS = {
-    domain: '.code.org',
-    path: '/',
-    secure: true,
-    same_site: :lax,
-  }.freeze
-
   # Creates a statsig stable id for use of signed-out user tracking.
   # This cookie is used by the Statsig SDK for both JS and Ruby.
   #
   # When a request arrives with a valid statsig_stable_id URL parameter
-  # (e.g. from code.ai cross-domain navigation), adopt that value and
-  # persist it as a cookie so the frontend JS picks it up.
+  # (e.g. from code.ai cross-domain navigation), adopt that value into
+  # the server-side session immediately and pass it to the template via
+  # @statsig_param_id so the frontend JS can set the cookie through the
+  # existing OneTrust consent-gated path.
   protected def initialize_statsig_stable_id
     param_stable_id = params[:statsig_stable_id]
     if param_stable_id.present? && param_stable_id.match?(UUID_RE)
-      cookies[:statsig_stable_id] = STATSIG_COOKIE_OPTIONS.merge(value: param_stable_id)
       session[:statsig_stable_id] = param_stable_id
+      @statsig_param_id = param_stable_id
       return
     end
 

--- a/dashboard/app/controllers/concerns/stable_id_redirect.rb
+++ b/dashboard/app/controllers/concerns/stable_id_redirect.rb
@@ -1,0 +1,21 @@
+module StableIdRedirect
+  extend ActiveSupport::Concern
+
+  STABLE_ID_COOKIE = 'statsig_stable_id'.freeze
+  UUID_FORMAT = /\A[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\z/i
+
+  # Redirect to a path on code.org, appending the statsig_stable_id from
+  # the cookie if present and valid. No cookie = no consent = no param.
+  def redirect_to_code_org(path, **options)
+    url = CDO.code_org_url(path)
+    stable_id = cookies[STABLE_ID_COOKIE]
+    if stable_id.present? && stable_id.match?(UUID_FORMAT)
+      uri = URI.parse(url)
+      params = URI.decode_www_form(uri.query || '')
+      params << [STABLE_ID_COOKIE, stable_id]
+      uri.query = URI.encode_www_form(params)
+      url = uri.to_s
+    end
+    redirect_to url, allow_other_host: true, **options
+  end
+end

--- a/dashboard/app/controllers/concerns/stable_id_redirect.rb
+++ b/dashboard/app/controllers/concerns/stable_id_redirect.rb
@@ -2,16 +2,16 @@ module StableIdRedirect
   extend ActiveSupport::Concern
 
   STABLE_ID_COOKIE = 'statsig_stable_id'.freeze
-  UUID_FORMAT = /\A[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\z/i
 
   # Redirect to a path on code.org, appending the statsig_stable_id from
   # the cookie if present and valid. No cookie = no consent = no param.
   def redirect_to_code_org(path, **options)
     url = CDO.code_org_url(path)
     stable_id = cookies[STABLE_ID_COOKIE]
-    if stable_id.present? && stable_id.match?(UUID_FORMAT)
+    if stable_id.present? && stable_id.match?(ApplicationController::UUID_REGEX)
       uri = URI.parse(url)
       params = URI.decode_www_form(uri.query || '')
+      params.reject! {|key, _value| key == STABLE_ID_COOKIE}
       params << [STABLE_ID_COOKIE, stable_id]
       uri.query = URI.encode_www_form(params)
       url = uri.to_s

--- a/dashboard/app/controllers/courses_redirect_controller.rb
+++ b/dashboard/app/controllers/courses_redirect_controller.rb
@@ -1,0 +1,7 @@
+class CoursesRedirectController < ApplicationController
+  include StableIdRedirect
+
+  def show
+    redirect_to_code_org('/students')
+  end
+end

--- a/dashboard/app/controllers/pd/regional_partner_contact_controller.rb
+++ b/dashboard/app/controllers/pd/regional_partner_contact_controller.rb
@@ -8,6 +8,7 @@ require 'honeybadger/ruby'
 # have saved links that use this controller.
 
 class Pd::RegionalPartnerContactController < ApplicationController
+  include StableIdRedirect
   # GET /pd/regional_partner_contacts/new
   def new
     Honeybadger.notify(
@@ -22,6 +23,6 @@ class Pd::RegionalPartnerContactController < ApplicationController
         referer: request.referer
       }
     )
-    redirect_to CDO.code_org_url('educate/professional-learning/contact-regional-partner')
+    redirect_to_code_org('educate/professional-learning/contact-regional-partner')
   end
 end

--- a/dashboard/app/controllers/videos_controller.rb
+++ b/dashboard/app/controllers/videos_controller.rb
@@ -1,4 +1,6 @@
 class VideosController < ApplicationController
+  include StableIdRedirect
+
   before_action :authenticate_user!, except: [:test]
   before_action :require_levelbuilder_mode, except: [:test, :index]
   check_authorization except: [:test]
@@ -13,7 +15,7 @@ class VideosController < ApplicationController
 
   # This page is currently deprecated, so let's redirect to related content.
   def test
-    redirect_to CDO.code_org_url('/educate/it')
+    redirect_to_code_org('/educate/it')
   end
 
   def index

--- a/dashboard/app/views/layouts/application.html.haml
+++ b/dashboard/app/views/layouts/application.html.haml
@@ -45,6 +45,9 @@
     %script{data: {'statsig-api-client-key-session-replay': CDO.safe_statsig_api_client_key_session_replay}}
     -# for statsig to recognized managed test server
     %script{data: {'managed-test-server': CDO.managed_test_server?.to_s}}
+    -# cross-domain statsig stable id passed from code.ai via URL param
+    - if @statsig_param_id
+      %script{data: {'statsig-param-id': @statsig_param_id}}
     -# user id and type for analytics logging- may not work for cached pages
     %script{data: {'user-id': current_user&.id}}
     %script{data: {'user-type': current_user&.user_type}}

--- a/dashboard/config/routes.rb
+++ b/dashboard/config/routes.rb
@@ -15,7 +15,7 @@ Dashboard::Application.routes.draw do
   get '/robots.txt' => 'robots#index'
 
   # Redirect studio.code.org/courses to code.org/students
-  get "/courses", to: redirect(CDO.code_org_url("/students"))
+  get "/courses", to: "courses_redirect#show"
 
   # Redirect old sign up flow to current sign up flow
   get "/users/sign_up", to: redirect("/users/sign_up/account_type")

--- a/dashboard/legacy/test/middleware/helpers/test_projects.rb
+++ b/dashboard/legacy/test/middleware/helpers/test_projects.rb
@@ -6,17 +6,16 @@ class ProjectsTest < Minitest::Test
   include SetupTest
 
   def test_create_project_returns_uuid
-    uuid_format = /\A[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\z/i
     signedout_storage_id = create_storage_id_for_user(nil)
 
     #If DCDO flag is disabled, create should return old style channel id
     channel_id = Projects.new(signedout_storage_id).create({projectType: 'artist'}, ip: 123)
-    refute uuid_format.match?(channel_id)
+    refute ApplicationController::UUID_REGEX.match?(channel_id)
 
     # If DCDO flag is enabled, create should return a uuid
     DCDO.stubs(:get).with('project-uuid-in-url', false).returns(true)
     channel_id = Projects.new(signedout_storage_id).create({projectType: 'artist'}, ip: 123)
-    assert uuid_format.match?(channel_id)
+    assert ApplicationController::UUID_REGEX.match?(channel_id)
   end
 
   def test_get_anonymous_age_restricted_app

--- a/dashboard/test/controllers/application_controller_test.rb
+++ b/dashboard/test/controllers/application_controller_test.rb
@@ -205,47 +205,69 @@ class ApplicationControllerTest < ActionDispatch::IntegrationTest
   end
 
   describe 'initialize_statsig_stable_id' do
-    it 'sets cookie and session from valid URL param' do
+    it 'does not set cookie from URL param (cookie is set client-side after consent)' do
       uuid = '550e8400-e29b-41d4-a716-446655440000'
       get root_path, params: {statsig_stable_id: uuid}
-      assert_equal uuid, response.cookies['statsig_stable_id']
+      assert_nil response.cookies['statsig_stable_id']
     end
 
-    it 'accepts uppercase UUIDs' do
+    it 'accepts valid UUID param into session' do
+      uuid = '550e8400-e29b-41d4-a716-446655440000'
+      get root_path, params: {statsig_stable_id: uuid}
+      assert_equal uuid, session[:statsig_stable_id]
+    end
+
+    it 'accepts uppercase UUIDs into session' do
       uuid = '550E8400-E29B-41D4-A716-446655440000'
       get root_path, params: {statsig_stable_id: uuid}
-      assert_equal uuid, response.cookies['statsig_stable_id']
+      assert_equal uuid, session[:statsig_stable_id]
     end
 
-    it 'ignores invalid param value' do
+    it 'ignores invalid param and generates a session ID' do
       get root_path, params: {statsig_stable_id: 'not-a-uuid'}
-      assert_nil response.cookies['statsig_stable_id']
+      assert_match ApplicationController::UUID_RE, session[:statsig_stable_id]
     end
 
-    it 'ignores empty param value' do
+    it 'ignores empty param and generates a session ID' do
       get root_path, params: {statsig_stable_id: ''}
-      assert_nil response.cookies['statsig_stable_id']
+      assert_match ApplicationController::UUID_RE, session[:statsig_stable_id]
     end
 
-    it 'overrides existing cookie when valid param is present' do
+    it 'param overrides existing cookie in session' do
       old_uuid = '00000000-0000-0000-0000-000000000001'
       new_uuid = '00000000-0000-0000-0000-000000000002'
       cookies[:statsig_stable_id] = old_uuid
       get root_path, params: {statsig_stable_id: new_uuid}
-      assert_equal new_uuid, response.cookies['statsig_stable_id']
+      assert_equal new_uuid, session[:statsig_stable_id]
     end
 
-    it 'preserves existing cookie when no param is present' do
+    it 'preserves existing cookie value in session when no param' do
       uuid = '550e8400-e29b-41d4-a716-446655440000'
       cookies[:statsig_stable_id] = uuid
       get root_path
-      # No new Set-Cookie header means the existing cookie is untouched
-      assert_nil response.cookies['statsig_stable_id']
+      assert_equal uuid, session[:statsig_stable_id]
     end
 
     it 'rejects script injection attempts' do
       get root_path, params: {statsig_stable_id: '<script>alert(1)</script>'}
-      assert_nil response.cookies['statsig_stable_id']
+      # Session should have a generated UUID, not the injected string
+      refute_equal '<script>alert(1)</script>', session[:statsig_stable_id]
+      assert_match ApplicationController::UUID_RE, session[:statsig_stable_id]
+    end
+
+    it 'emits data attribute in rendered page for valid param' do
+      uuid = '550e8400-e29b-41d4-a716-446655440000'
+      user = create(:teacher)
+      sign_in user
+      get home_teacher_dashboard_path, params: {statsig_stable_id: uuid}
+      assert_includes response.body, "data-statsig-param-id=\"#{uuid}\""
+    end
+
+    it 'does not emit data attribute in rendered page for invalid param' do
+      user = create(:teacher)
+      sign_in user
+      get home_teacher_dashboard_path, params: {statsig_stable_id: 'bad'}
+      refute_includes response.body, 'data-statsig-param-id'
     end
   end
 

--- a/dashboard/test/controllers/application_controller_test.rb
+++ b/dashboard/test/controllers/application_controller_test.rb
@@ -225,12 +225,12 @@ class ApplicationControllerTest < ActionDispatch::IntegrationTest
 
     it 'ignores invalid param and generates a session ID' do
       get root_path, params: {statsig_stable_id: 'not-a-uuid'}
-      assert_match ApplicationController::UUID_RE, session[:statsig_stable_id]
+      assert_match ApplicationController::UUID_REGEX, session[:statsig_stable_id]
     end
 
     it 'ignores empty param and generates a session ID' do
       get root_path, params: {statsig_stable_id: ''}
-      assert_match ApplicationController::UUID_RE, session[:statsig_stable_id]
+      assert_match ApplicationController::UUID_REGEX, session[:statsig_stable_id]
     end
 
     it 'param overrides existing cookie in session' do
@@ -252,7 +252,7 @@ class ApplicationControllerTest < ActionDispatch::IntegrationTest
       get root_path, params: {statsig_stable_id: '<script>alert(1)</script>'}
       # Session should have a generated UUID, not the injected string
       refute_equal '<script>alert(1)</script>', session[:statsig_stable_id]
-      assert_match ApplicationController::UUID_RE, session[:statsig_stable_id]
+      assert_match ApplicationController::UUID_REGEX, session[:statsig_stable_id]
     end
 
     it 'emits data attribute in rendered page for valid param' do

--- a/dashboard/test/controllers/application_controller_test.rb
+++ b/dashboard/test/controllers/application_controller_test.rb
@@ -204,6 +204,51 @@ class ApplicationControllerTest < ActionDispatch::IntegrationTest
     end
   end
 
+  describe 'initialize_statsig_stable_id' do
+    it 'sets cookie and session from valid URL param' do
+      uuid = '550e8400-e29b-41d4-a716-446655440000'
+      get root_path, params: {statsig_stable_id: uuid}
+      assert_equal uuid, response.cookies['statsig_stable_id']
+    end
+
+    it 'accepts uppercase UUIDs' do
+      uuid = '550E8400-E29B-41D4-A716-446655440000'
+      get root_path, params: {statsig_stable_id: uuid}
+      assert_equal uuid, response.cookies['statsig_stable_id']
+    end
+
+    it 'ignores invalid param value' do
+      get root_path, params: {statsig_stable_id: 'not-a-uuid'}
+      assert_nil response.cookies['statsig_stable_id']
+    end
+
+    it 'ignores empty param value' do
+      get root_path, params: {statsig_stable_id: ''}
+      assert_nil response.cookies['statsig_stable_id']
+    end
+
+    it 'overrides existing cookie when valid param is present' do
+      old_uuid = '00000000-0000-0000-0000-000000000001'
+      new_uuid = '00000000-0000-0000-0000-000000000002'
+      cookies[:statsig_stable_id] = old_uuid
+      get root_path, params: {statsig_stable_id: new_uuid}
+      assert_equal new_uuid, response.cookies['statsig_stable_id']
+    end
+
+    it 'preserves existing cookie when no param is present' do
+      uuid = '550e8400-e29b-41d4-a716-446655440000'
+      cookies[:statsig_stable_id] = uuid
+      get root_path
+      # No new Set-Cookie header means the existing cookie is untouched
+      assert_nil response.cookies['statsig_stable_id']
+    end
+
+    it 'rejects script injection attempts' do
+      get root_path, params: {statsig_stable_id: '<script>alert(1)</script>'}
+      assert_nil response.cookies['statsig_stable_id']
+    end
+  end
+
   describe 'exception handling' do
     it 'gracefully handles UnsafeRedirectErrors' do
       Rails.logger.expects(:warn).once

--- a/dashboard/test/controllers/concerns/stable_id_redirect_test.rb
+++ b/dashboard/test/controllers/concerns/stable_id_redirect_test.rb
@@ -1,0 +1,27 @@
+require 'test_helper'
+
+class StableIdRedirectTest < ActionDispatch::IntegrationTest
+  VALID_UUID = '550e8400-e29b-41d4-a716-446655440000'
+
+  describe 'redirect_to_code_org' do
+    it 'appends statsig_stable_id when cookie is present and valid' do
+      cookies[:statsig_stable_id] = VALID_UUID
+      get '/courses'
+      assert_response :redirect
+      assert_includes response.location, "statsig_stable_id=#{VALID_UUID}"
+    end
+
+    it 'does not append param when cookie is absent' do
+      get '/courses'
+      assert_response :redirect
+      refute_includes response.location, 'statsig_stable_id'
+    end
+
+    it 'does not append param when cookie value is invalid' do
+      cookies[:statsig_stable_id] = 'not-a-valid-uuid'
+      get '/courses'
+      assert_response :redirect
+      refute_includes response.location, 'statsig_stable_id'
+    end
+  end
+end

--- a/dashboard/test/controllers/courses_redirect_controller_test.rb
+++ b/dashboard/test/controllers/courses_redirect_controller_test.rb
@@ -1,0 +1,11 @@
+require 'test_helper'
+
+class CoursesRedirectControllerTest < ActionDispatch::IntegrationTest
+  describe 'show' do
+    it 'redirects to code.org/students' do
+      get '/courses'
+      assert_response :redirect
+      assert_includes response.location, '/students'
+    end
+  end
+end


### PR DESCRIPTION
This PR introduces functionality to support a single `statsig_stable_id` across domains. It accomplishes this by passing it as a URL param. If present as a URL parameter on inbound requests it will set it as a cookie which will be used by Statsig with every event sent. 

Additionally, it will also set the same URL param on outbound requests to code.org. It does this by 1) registering a click event handler that intercepts click events and appends the stable id on outbound URLs if === code.org, and 2) introducing a Rails concern that can be used in controllers where we redirect to code.org.

This is to enable cross domain user journey metrics to support UTM attribution tracking. 

It does this with the following changes:

- Add URL param ingestion for statsig_stable_id in ApplicationController#initialize_statsig_stable_id; validates UUID format, passes stable id via script element to the frontend
- Add stripStableIdParam() to statsigHelpers.js to remove the param from the browser URL via history.replaceState after Rails has consumed it
- Add integration tests for param acceptance, rejection, and override behavior
- Add JS unit tests for URL param stripping
- Add functionality to set cookie if OneTrust consent allows
- Add functionality (via Javascript) to intercept click events and set an existing statsig_stable_id as a URL param on outbound requests to code.org
- Add functionality (via Ruby) to set an existing statsig_stable_id as a URL param on redirects to code.org
- UUID validation before persisting inbound or sending outbound

## Additional Context

Currently, a `statsig_stable_id` is set as a cookie by both studio.code.org and code.org, and used for Statsig metric reporting. Both sites have logic to honor an existing ID set by the other site. This enables tracking of users between sites, allowing the RED team to ultimately associate user journeys related to UTM codes.

However in a cross domain world, this will no longer work as cookies are scoped to a domain, and browsers enforce this strictly as part of the same-origin policy.

The most straightforward way to enable a single, unified stable ID between sites is to pass it as a URL param.

## Out of Scope

- This PR assumes the marketing site (code.org) will include a `statsig_stable_id` in all URLs that send users to studio.code.org, as well as be able to accept this param and set it as a cookie. Basically mirror the functionality of this PR

## OpenSpec Docs

### Inbound and JS Outbound Docs

<details>
<summary>OpenSpec Proposal</summary>

## Context

`statsig_stable_id` is a UUID that ties a browser session to Statsig experiments and events. Today it is scoped to `.code.org` (cookie domain), so it works across `studio.code.org` and `code.org`. The new `code.ai` domain cannot read or write `.code.org` cookies, so users navigating from code.ai to studio.code.org get a fresh ID, breaking experiment assignment continuity.

Key files in the current flow:

- `apps/src/metrics/statsigHelpers.js` -- frontend cookie/localStorage read/write
- `dashboard/app/controllers/application_controller.rb#initialize_statsig_stable_id` -- backend cookie-to-session transfer
- `dashboard/config/initializers/devise.rb` -- logout cookie clearing
- `lib/cdo/http_cache.rb` -- CloudFront cookie allowlist

## Goals / Non-Goals

**Goals:**

- Allow code.ai to pass its stable ID to studio.code.org via a URL parameter.
- Persist the parameter value as the existing `statsig_stable_id` cookie so downstream JS and Rails code consumes it without changes.
- Strip the parameter from the browser URL bar to keep URLs clean and prevent leakage.
- Honor OneTrust C0002 consent before writing the cookie.

**Non-Goals:**

- Changing how code.ai generates or stores the stable ID (that is code.ai's concern).
- Modifying the existing `.code.org` cookie-based sharing between studio.code.org and code.org.
- Supporting arbitrary cross-domain ID sync (this is specific to code.ai -> studio.code.org).

## Decisions

### 1. Split responsibility: Rails sets session, JS sets cookie

**Choice**: Rails validates the URL param and immediately writes `session[:statsig_stable_id]` (server-side, not subject to OneTrust). The validated param is passed to the frontend via a `data-statsig-param-id` script tag attribute. The frontend `findOrCreateStableId()` reads this attribute and sets the cookie through the existing consent-gated path.

**Rationale**: The session is stored in Redis and is not a browser cookie, so writing it immediately has no consent implications. Server-side Statsig events get the correct ID from the first request. The cookie (which OneTrust governs) is only written by the frontend after `consentAllowsStatsigCookie()` passes, using the same code path as every other page load. No new consent assumptions are introduced.

**Alternative considered**: Set the cookie directly from Rails. Rejected because it bypasses the OneTrust C0002 consent check that the frontend enforces. Honoring cookie consent is critical.

### 2. Pass the param to JS via a data attribute on a script tag

**Choice**: Add `%script{data: {'statsig-param-id': @statsig_param_id}}` to `application.html.haml` when the param is present, alongside the existing statsig data attributes.

**Rationale**: This follows the established convention used by `data-user-id`, `data-user-type`, `data-statsig-api-client-key`, etc. The frontend already reads these via `document.querySelector`. No new patterns introduced.

### 3. Strip the parameter client-side with `history.replaceState`

**Choice**: A small JS snippet that runs early on page load, checks for `statsig_stable_id` in the query string, removes it, and calls `history.replaceState`.

**Rationale**: Server-side redirect (302) would add a round-trip and complicate caching. `replaceState` is invisible to the user, does not trigger a reload, and does not create a new history entry.

**Alternative considered**: Server-side 302 redirect to the same URL minus the param. Rejected due to the extra round-trip and cache/redirect-loop risk.

### 4. Validate UUID format server-side

**Choice**: Only accept the param if it matches `/\A[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\z/i`.

**Rationale**: Prevents injection of arbitrary strings into the session or data attribute. The existing `SecureRandom.uuid` and `createUuid()` both produce v4 UUIDs, so this is a safe validation.

### 5. URL parameter takes priority over existing cookie

**Choice**: In `findOrCreateStableId()`, the data attribute value (from the URL param) takes priority over an existing cookie or localStorage value.

**Rationale**: The explicit act of navigating from code.ai with a stable ID signals intent to adopt that identity. This lets code.ai "overwrite" a stale studio.code.org cookie if the user has been active on code.ai with a different ID.

## Risks / Trade-offs

- **URL leakage in logs/referrers**: The `statsig_stable_id` param will appear in server access logs and potentially in `Referer` headers for outbound requests on that page load. Mitigation: The stable ID is not PII (it is an opaque UUID). The param is stripped immediately from the browser URL, limiting onward referrer exposure.

- **Cache-key pollution**: If CloudFront varies on the query parameter, cache hit rate drops. Mitigation: The parameter only appears on cross-domain navigation from code.ai, a small fraction of traffic. Dashboard default behavior already varies on session cookies, so pages are effectively uncached per-user anyway.


</details>

<details>
<summary>OpenSpec Design</summary>

## Context

`statsig_stable_id` is a UUID that ties a browser session to Statsig experiments and events. Today it is scoped to `.code.org` (cookie domain), so it works across `studio.code.org` and `code.org`. The new `code.ai` domain cannot read or write `.code.org` cookies, so users navigating from code.ai to studio.code.org get a fresh ID, breaking experiment assignment continuity.

Key files in the current flow:

- `apps/src/metrics/statsigHelpers.js` -- frontend cookie/localStorage read/write
- `dashboard/app/controllers/application_controller.rb#initialize_statsig_stable_id` -- backend cookie-to-session transfer
- `dashboard/config/initializers/devise.rb` -- logout cookie clearing
- `lib/cdo/http_cache.rb` -- CloudFront cookie allowlist

## Goals / Non-Goals

**Goals:**

- Allow code.ai to pass its stable ID to studio.code.org via a URL parameter.
- Persist the parameter value as the existing `statsig_stable_id` cookie so downstream JS and Rails code consumes it without changes.
- Strip the parameter from the browser URL bar to keep URLs clean and prevent leakage.
- Honor OneTrust C0002 consent before writing the cookie.

**Non-Goals:**

- Changing how code.ai generates or stores the stable ID (that is code.ai's concern).
- Modifying the existing `.code.org` cookie-based sharing between studio.code.org and code.org.
- Supporting arbitrary cross-domain ID sync (this is specific to code.ai -> studio.code.org).

## Decisions

### 1. Split responsibility: Rails sets session, JS sets cookie

**Choice**: Rails validates the URL param and immediately writes `session[:statsig_stable_id]` (server-side, not subject to OneTrust). The validated param is passed to the frontend via a `data-statsig-param-id` script tag attribute. The frontend `findOrCreateStableId()` reads this attribute and sets the cookie through the existing consent-gated path.

**Rationale**: The session is stored in Redis and is not a browser cookie, so writing it immediately has no consent implications. Server-side Statsig events get the correct ID from the first request. The cookie (which OneTrust governs) is only written by the frontend after `consentAllowsStatsigCookie()` passes, using the same code path as every other page load. No new consent assumptions are introduced.

**Alternative considered**: Set the cookie directly from Rails. Rejected because it bypasses the OneTrust C0002 consent check that the frontend enforces. Honoring cookie consent is critical.

### 2. Pass the param to JS via a data attribute on a script tag

**Choice**: Add `%script{data: {'statsig-param-id': @statsig_param_id}}` to `application.html.haml` when the param is present, alongside the existing statsig data attributes.

**Rationale**: This follows the established convention used by `data-user-id`, `data-user-type`, `data-statsig-api-client-key`, etc. The frontend already reads these via `document.querySelector`. No new patterns introduced.

### 3. Strip the parameter client-side with `history.replaceState`

**Choice**: A small JS snippet that runs early on page load, checks for `statsig_stable_id` in the query string, removes it, and calls `history.replaceState`.

**Rationale**: Server-side redirect (302) would add a round-trip and complicate caching. `replaceState` is invisible to the user, does not trigger a reload, and does not create a new history entry.

**Alternative considered**: Server-side 302 redirect to the same URL minus the param. Rejected due to the extra round-trip and cache/redirect-loop risk.

### 4. Validate UUID format server-side

**Choice**: Only accept the param if it matches `/\A[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\z/i`.

**Rationale**: Prevents injection of arbitrary strings into the session or data attribute. The existing `SecureRandom.uuid` and `createUuid()` both produce v4 UUIDs, so this is a safe validation.

### 5. URL parameter takes priority over existing cookie

**Choice**: In `findOrCreateStableId()`, the data attribute value (from the URL param) takes priority over an existing cookie or localStorage value.

**Rationale**: The explicit act of navigating from code.ai with a stable ID signals intent to adopt that identity. This lets code.ai "overwrite" a stale studio.code.org cookie if the user has been active on code.ai with a different ID.

## Risks / Trade-offs

- **URL leakage in logs/referrers**: The `statsig_stable_id` param will appear in server access logs and potentially in `Referer` headers for outbound requests on that page load. Mitigation: The stable ID is not PII (it is an opaque UUID). The param is stripped immediately from the browser URL, limiting onward referrer exposure.

- **Cache-key pollution**: If CloudFront varies on the query parameter, cache hit rate drops. Mitigation: The parameter only appears on cross-domain navigation from code.ai, a small fraction of traffic. Dashboard default behavior already varies on session cookies, so pages are effectively uncached per-user anyway.

</details>

### Outbound Redirect Docs

<details>
<summary>OpenSpec Proposal - Outbound Redirect</summary>

## Why

Server-side redirects to code.org (which will become code.ai) drop the `statsig_stable_id` because no controller action runs to read the cookie and append it. The client-side click handler from the `cross-domain-statsig-stable-id` change covers `<a>` tags, but route-level `redirect()` and controller `redirect_to` calls bypass it entirely.

## What Changes

- Extract a reusable `StableIdRedirect` concern that reads `statsig_stable_id` from the cookie (consent-gated: no cookie = no param) and appends it to a given code.org URL.
- Replace the route-level `redirect` for `/courses` with a small controller that uses the concern.
- Update the 2 existing controller `redirect_to` calls to code.org to use the concern's helper.

## Capabilities

### New Capabilities
- `stable-id-redirect`: A Rails concern providing a helper method to append `statsig_stable_id` from the cookie to outbound code.org redirect URLs. Reads from the cookie to honor OneTrust C0002 consent.

### Modified Capabilities

## Impact

- **Routes**: `dashboard/config/routes.rb` -- `/courses` redirect changes from route-level `redirect()` to a controller action.
- **New controller**: `CoursesRedirectController` (or similar) to handle the `/courses` -> `code.org/students` redirect.
- **New concern**: `StableIdRedirect` concern in `app/controllers/concerns/`.
- **Existing controllers**: `videos_controller.rb` and `pd/regional_partner_contact_controller.rb` include the concern and wrap their `redirect_to` URLs.


</details>

<details>
<summary>OpenSpec Design - Outbound Redirect</summary>

## Context

The `cross-domain-statsig-stable-id` change added a client-side click handler that decorates outbound `<a>` links to code.org with `statsig_stable_id`. However, server-side redirects bypass this handler entirely.

Three known server-side redirects go to code.org:

1. `routes.rb:18` -- `get "/courses", to: redirect(CDO.code_org_url("/students"))` (route-level, no controller)
2. `videos_controller.rb:16` -- `redirect_to CDO.code_org_url('/educate/it')`
3. `pd/regional_partner_contact_controller.rb:25` -- `redirect_to CDO.code_org_url('educate/professional-learning/contact-regional-partner')`

The existing concern pattern in this codebase: `dashboard/app/controllers/concerns/` (e.g., `azure_text_to_speech.rb`).

## Goals / Non-Goals

**Goals:**

- Provide a reusable mechanism for appending `statsig_stable_id` to server-side redirects to code.org.
- Read the stable ID from the cookie so OneTrust C0002 consent is honored (no cookie = no param).
- Handle all 3 known redirect sites.

**Non-Goals:**

- Automatically intercepting all future `redirect_to` calls. This is opt-in per call site.
- Handling non-code.org redirects.

## Decisions

### 1. Implement as a controller concern

**Choice**: Create `StableIdRedirect` in `app/controllers/concerns/`. It provides a single helper method `redirect_to_code_org(path)` that builds the code.org URL, appends the stable ID from the cookie if present, and issues the redirect.

**Rationale**: Keeps `ApplicationController` clean. The concern is included only in controllers that need it. Follows the existing pattern (`concerns/azure_text_to_speech.rb`).

**Alternative considered**: Protected method on `ApplicationController`. Rejected because the user prefers a concern, and this functionality is only needed by a few controllers.

### 2. Read stable ID from the cookie, not the session

**Choice**: The helper reads `cookies[:statsig_stable_id]`. If the cookie does not exist, no param is appended.

**Rationale**: The cookie only exists when OneTrust C0002 consent has been given. Reading from the session would bypass consent, since the session is written unconditionally on every request.

### 3. Replace `/courses` route-level redirect with a controller

**Choice**: Create `CoursesRedirectController` that includes the concern and calls `redirect_to_code_org("/students")`.

**Rationale**: Route-level `redirect()` has no access to cookies or session. A controller action gets the full request context.

### 4. Validate UUID before appending

**Choice**: Reuse the same `UUID_RE` pattern from `ApplicationController` to validate the cookie value before appending it to the URL.

**Rationale**: Defense in depth. The cookie value should always be a valid UUID, but validating prevents unexpected strings from leaking into redirect URLs.

## Risks / Trade-offs

- **Extra controller for `/courses`**: Adds a small file, but replaces a route-level redirect that couldn't support the feature. Net complexity is low.
- **Opt-in, not automatic**: Future `redirect_to` calls to code.org won't get the stable ID unless the developer remembers to use the concern. Acceptable given the rarity of these redirects (3 known cases).


</details>


<!--
  Summary of the change: background, motivation, and context.
  Include screenshots, videos, or before/after comparisons for UI changes.
-->



## Links
<!-- Jira tickets, design docs, Slack threads, related PRs, etc. -->

- Jira: https://codedotorg.atlassian.net/browse/P20-1842

## Testing story
<!-- How was this tested? Manual steps, adhoc links, automated tests, or why testing isn't needed. -->



## Deployment notes
<!-- Delete this section if it's a standard merge-and-deploy.
     Otherwise: migrations, feature flags, coordination, caching impacts, etc. -->



## Privacy and security
<!-- Delete this section if there is no privacy/security impact.
     Otherwise: new PII, auth changes, API surface changes, etc. -->

