### PR TITLE
stop seeding all csd courses and units in ui tests

### DIFF
--- a/dashboard/lib/tasks/seed.rake
+++ b/dashboard/lib/tasks/seed.rake
@@ -81,16 +81,7 @@ namespace :seed do
     allthethings
     allthettsthings
     artist
-    csd3-2023
-    interactive-games-animations-2023
-    focus-on-creativity3-2023
-    focus-on-coding3-2023
-    csd3-2024
-    interactive-games-animations-2024
-    focus-on-creativity3-2024
-    focus-on-coding3-2024
     customizing-llms-2024
-    csd3-2025
     dance
     events
     flappy
@@ -274,8 +265,6 @@ namespace :seed do
        alltheselfpacedplthings
        allthettsthings
        artist
-       interactive-games-animations-2023
-       interactive-games-animations-2024
        customizing-llms-2024
        dance
        events

--- a/dashboard/test/ui/config/course_offerings/ui-test-csf.json
+++ b/dashboard/test/ui/config/course_offerings/ui-test-csf.json
@@ -6,7 +6,7 @@
   "curriculum_type": "Course",
   "marketing_initiative": "CSF",
   "grade_levels": "K",
-  "header": null,
+  "header": "csf",
   "image": null,
   "cs_topic": null,
   "school_subject": null,

--- a/dashboard/test/ui/features/teacher_tools/rubrics/ai_evaluate_student_code.feature
+++ b/dashboard/test/ui/features/teacher_tools/rubrics/ai_evaluate_student_code.feature
@@ -4,6 +4,11 @@
 Feature: Evaluate student code against rubrics using AI
   # Make sure AI config files in S3 are parseable. Do this in a UI test because
   # we do not allow S3 access in unit tests. Only needs to be run in 1 browser.
+  #
+  # Note that this only covers units which we are seeding in our ui tests, no
+  # longer includes all production courses. Full validation of production
+  # courses is done by the `rake seed:validate_ai_rubrics` task during the
+  # deploy to staging.
   @chrome
   Scenario: Validate Rubric AI Config
     Given I validate rubric ai config for all lessons

--- a/dashboard/test/ui/features/teacher_tools/teacher_dashboard/teacher_dashboard_local_nav_v2.feature
+++ b/dashboard/test/ui/features/teacher_tools/teacher_dashboard/teacher_dashboard_local_nav_v2.feature
@@ -22,8 +22,8 @@ Feature: Using the V2 teacher dashboard local navigation
 
     And I press the first "input[name='grades[]']" element
 
-    And I click selector "button:contains(Middle School)" once I see it
-    And I click selector "input[name='Interactive Animations and Games']" once I see it
+    And I click selector "button:contains(Elementary School)" once I see it
+    And I click selector "input[name='UI Test CSF']" once I see it
 
     And I press backspace to clear element "#uitest-section-name-setup"
     And I press keys "Sally's Super Section" for element "#uitest-section-name-setup"
@@ -35,7 +35,7 @@ Feature: Using the V2 teacher dashboard local navigation
 
     And I wait until element "#ui-test-skeleton-progress-column" is not visible
 
-    And I wait until element "#unit-selector-v2" contains text "Interactive Animations and Games"
+    And I wait until element "#unit-selector-v2" contains text "UI Test CSF"
     Then element "#uitest-sidebar-section-dropdown" contains text "Sally's Super Section"
     Then element "#uitest-sidebar-section-dropdown" does not contain text "All the Things Section"
 


### PR DESCRIPTION
The exciting conclusion of all the ai rubric validation PRs is that we get to stop seeding CSD courses in UI Tests 🎉 

Done in this PR:
- stop seeding CSD courses, which includes all production courses that use ai-enabled rubrics
- move one remaining ui test off of the standalone CSD course `interactive-games-animations-2024`
- update comment on "Validate Rubric AI Config" ui test scenario

Depends on
- https://github.com/code-dot-org/code-dot-org/pull/71994
- https://github.com/code-dot-org/code-dot-org/pull/72016

For background, see: 
- https://github.com/code-dot-org/code-dot-org/pull/71016

## Testing story
- drone unit tests passed on 7258da0
- drone ui tests passed with `[reset db]` on 628fe99
- drone unit tests have been extremely unreliable in the past 24 hours, so I'm proposing merging without final green checkmark.
- some eyes diffs are expected as "Interactive Animations and Games" disappears from the course catalog: https://test-studio.code.org/catalog?marketingInitiative=csd 
  - --> EDIT: but only after this course is manually removed from the database on the test machine

