### PR TITLE
stop using interactive-games-animations-2024 course in ui tests

### DIFF
--- a/dashboard/config/locales/courses/en.yml
+++ b/dashboard/config/locales/courses/en.yml
@@ -6826,6 +6826,12 @@ en:
           description_student: ''
           description_teacher: ''
           version_title: "'19-'20"
+        ui-test-csp-2025:
+          title: UI Test CSP
+          description_short: ''
+          description_student: ''
+          description_teacher: ''
+          version_title: "'25-'26"
         teaching-aif-design-build-ai-facilitators-2026:
           title: 'Teaching AIF: Designing & Building with AI'
           description_short: ''

--- a/dashboard/config/locales/courses/en.yml
+++ b/dashboard/config/locales/courses/en.yml
@@ -6832,6 +6832,12 @@ en:
           description_student: ''
           description_teacher: ''
           version_title: "'25-'26"
+        ui-test-csd-2025:
+          title: UI Test CSD
+          description_short: ''
+          description_student: ''
+          description_teacher: ''
+          version_title: "'25-'26"
         teaching-aif-design-build-ai-facilitators-2026:
           title: 'Teaching AIF: Designing & Building with AI'
           description_short: ''

--- a/dashboard/config/locales/scripts/en.yml
+++ b/dashboard/config/locales/scripts/en.yml
@@ -27213,6 +27213,12 @@ en:
               name: Lesson One
             lesson-2:
               name: Design Mode
+            lesson-3:
+              name: Lesson Three
+            lesson-4:
+              name: Extended Lesson
+            lesson-5:
+              name: Final Project
           lesson_groups: {}
           name: ui-test-csp1-2019
           title: Applab

--- a/dashboard/config/locales/scripts/en.yml
+++ b/dashboard/config/locales/scripts/en.yml
@@ -20788,8 +20788,14 @@ en:
           description: This is the teacher overview for Single Unit 2025.
           student_description: This is the student overview for Single Unit 2025.
         ui-test-single-unit-2026:
-          lessons: {}
-          lesson_groups: {}
+          lessons:
+            lesson-1:
+              name: Lesson One
+            lesson-2:
+              name: Lesson Two
+          lesson_groups:
+            lessonGroup-2:
+              display_name: Chapter One
           name: ui-test-single-unit-2026
           title: Single Unit 2026
           description_audience: ''

--- a/dashboard/config/locales/scripts/en.yml
+++ b/dashboard/config/locales/scripts/en.yml
@@ -27248,6 +27248,17 @@ en:
           description_short: ''
           description: ''
           student_description: ''
+        ui-test-csd1-2025:
+          lessons:
+            lesson-1:
+              name: Lesson One
+          lesson_groups: {}
+          name: ui-test-csd1-2025
+          title: Problem Solving
+          description_audience: ''
+          description_short: ''
+          description: ''
+          student_description: ''
         pl-facilitators-aif2-intro-2026:
           lessons: {}
           lesson_groups: {}

--- a/dashboard/test/ui/config/course_offerings/ui-test-csd.json
+++ b/dashboard/test/ui/config/course_offerings/ui-test-csd.json
@@ -1,0 +1,23 @@
+{
+  "key": "ui-test-csd",
+  "display_name": "UI Test CSD",
+  "is_featured": false,
+  "assignable": true,
+  "curriculum_type": "Course",
+  "marketing_initiative": "CSD",
+  "grade_levels": "10",
+  "header": null,
+  "image": null,
+  "cs_topic": null,
+  "school_subject": null,
+  "device_compatibility": "{\"computer\":\"ideal\",\"chromebook\":\"not_recommended\",\"tablet\":\"not_recommended\",\"mobile\":\"incompatible\",\"no_device\":\"incompatible\"}",
+  "description": null,
+  "professional_learning_program": null,
+  "video": null,
+  "published_date": null,
+  "self_paced_pl_course_offering_key": null,
+  "ai_teaching_assistant_available": false,
+  "facilitator_course_permissions": [
+
+  ]
+}

--- a/dashboard/test/ui/config/courses/ui-test-csd-2025.course
+++ b/dashboard/test/ui/config/courses/ui-test-csd-2025.course
@@ -1,0 +1,24 @@
+{
+  "name": "ui-test-csd-2025",
+  "script_names": [
+    "ui-test-csd1-2025"
+  ],
+  "original_script_names": [
+    "ui-test-csd1-2025"
+  ],
+  "published_state": "stable",
+  "instruction_type": "teacher_led",
+  "participant_audience": "student",
+  "instructor_audience": "teacher",
+  "properties": {
+    "family_name": "ui-test-csd",
+    "numbered_units": "auto",
+    "version_year": "2025"
+  },
+  "resources": [
+
+  ],
+  "student_resources": [
+
+  ]
+}

--- a/dashboard/test/ui/config/courses/ui-test-csp-2025.course
+++ b/dashboard/test/ui/config/courses/ui-test-csp-2025.course
@@ -1,0 +1,26 @@
+{
+  "name": "ui-test-csp-2025",
+  "script_names": [
+    "ui-test-csp1-2019",
+    "ui-test-csp2-2019",
+    "ui-test-csp-survey"
+  ],
+  "original_script_names": [
+
+  ],
+  "published_state": "stable",
+  "instruction_type": "teacher_led",
+  "participant_audience": "student",
+  "instructor_audience": "teacher",
+  "properties": {
+    "family_name": "ui-test-csp",
+    "numbered_units": "auto",
+    "version_year": "2025"
+  },
+  "resources": [
+
+  ],
+  "student_resources": [
+
+  ]
+}

--- a/dashboard/test/ui/config/scripts_json/ui-test-csd1-2025.script_json
+++ b/dashboard/test/ui/config/scripts_json/ui-test-csd1-2025.script_json
@@ -1,0 +1,314 @@
+{
+  "script": {
+    "name": "ui-test-csd1-2025",
+    "wrapup_video_id": null,
+    "login_required": false,
+    "properties": {
+      "is_migrated": true
+    },
+    "new_name": null,
+    "family_name": null,
+    "serialized_at": "2026-04-08 22:03:05 UTC",
+    "hide_within_course": false,
+    "published_state": "in_development",
+    "instruction_type": null,
+    "instructor_audience": null,
+    "participant_audience": null,
+    "seeding_key": {
+      "script.name": "ui-test-csd1-2025"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "ui-test-csd1-2025"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "lesson-1",
+      "name": "Lesson One",
+      "absolute_position": 1,
+      "lockable": false,
+      "has_lesson_plan": true,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "lesson-1",
+        "lesson_group.key": "",
+        "script.name": "ui-test-csd1-2025"
+      }
+    }
+  ],
+  "lesson_activities": [
+    {
+      "key": "2af9b629-5965-4b80-8fc1-f5dcc343b310",
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_activity.key": "2af9b629-5965-4b80-8fc1-f5dcc343b310",
+        "lesson.key": "lesson-1",
+        "lesson_group.key": "",
+        "script.name": "ui-test-csd1-2025"
+      }
+    }
+  ],
+  "activity_sections": [
+    {
+      "key": "ac3730d4-511d-4e64-8c76-4c28f148a73f",
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "activity_section.key": "ac3730d4-511d-4e64-8c76-4c28f148a73f",
+        "lesson_activity.key": "2af9b629-5965-4b80-8fc1-f5dcc343b310"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "activity_section_position": 1,
+      "assessment": false,
+      "properties": {
+      },
+      "bonus": false,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Sprites scene sprites_allthethings"
+        ],
+        "lesson.key": "lesson-1",
+        "lesson_group.key": "",
+        "script.name": "ui-test-csd1-2025",
+        "activity_section.key": "ac3730d4-511d-4e64-8c76-4c28f148a73f"
+      },
+      "level_keys": [
+        "CSD U3 Sprites scene sprites_allthethings"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "activity_section_position": 2,
+      "assessment": true,
+      "properties": {
+      },
+      "bonus": false,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Sprites scene challenge_allthethings"
+        ],
+        "lesson.key": "lesson-1",
+        "lesson_group.key": "",
+        "script.name": "ui-test-csd1-2025",
+        "activity_section.key": "ac3730d4-511d-4e64-8c76-4c28f148a73f"
+      },
+      "level_keys": [
+        "CSD U3 Sprites scene challenge_allthethings"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Sprites scene sprites_allthethings",
+        "script_level.level_keys": [
+          "CSD U3 Sprites scene sprites_allthethings"
+        ],
+        "lesson.key": "lesson-1",
+        "lesson_group.key": "",
+        "script.name": "ui-test-csd1-2025",
+        "activity_section.key": "ac3730d4-511d-4e64-8c76-4c28f148a73f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Sprites scene challenge_allthethings",
+        "script_level.level_keys": [
+          "CSD U3 Sprites scene challenge_allthethings"
+        ],
+        "lesson.key": "lesson-1",
+        "lesson_group.key": "",
+        "script.name": "ui-test-csd1-2025",
+        "activity_section.key": "ac3730d4-511d-4e64-8c76-4c28f148a73f"
+      }
+    }
+  ],
+  "resources": [
+
+  ],
+  "lessons_resources": [
+
+  ],
+  "scripts_resources": [
+
+  ],
+  "scripts_student_resources": [
+
+  ],
+  "vocabularies": [
+
+  ],
+  "lessons_vocabularies": [
+
+  ],
+  "lessons_programming_expressions": [
+
+  ],
+  "objectives": [
+
+  ],
+  "lessons_standards": [
+
+  ],
+  "lessons_opportunity_standards": [
+
+  ],
+  "rubrics": [
+    {
+      "level_name": "CSD U3 Sprites scene challenge_allthethings",
+      "s3_config_dir": "allthethings-L48",
+      "seeding_key": {
+        "lesson.key": "lesson-1",
+        "lesson_group.key": "",
+        "script.name": "ui-test-csd1-2025"
+      }
+    }
+  ],
+  "learning_goals": [
+    {
+      "key": "3cb946e1-fd84-452d-8a1d-e56253c6a0e0",
+      "position": 1,
+      "learning_goal": "Code Quality",
+      "ai_enabled": false,
+      "tips": null,
+      "seeding_key": {
+        "learning_goal.key": "3cb946e1-fd84-452d-8a1d-e56253c6a0e0",
+        "lesson.key": "lesson-1",
+        "lesson_group.key": "",
+        "script.name": "ui-test-csd1-2025"
+      }
+    },
+    {
+      "key": "effc0330-65f6-4768-b995-fe3f9ed60a45",
+      "position": 2,
+      "learning_goal": "Sprites",
+      "ai_enabled": true,
+      "tips": null,
+      "seeding_key": {
+        "learning_goal.key": "effc0330-65f6-4768-b995-fe3f9ed60a45",
+        "lesson.key": "lesson-1",
+        "lesson_group.key": "",
+        "script.name": "ui-test-csd1-2025"
+      }
+    }
+  ],
+  "learning_goal_evidence_levels": [
+    {
+      "understanding": 0,
+      "teacher_description": "Code is messy or non-existent",
+      "ai_prompt": "",
+      "seeding_key": {
+        "understanding": 0,
+        "learning_goal.key": "3cb946e1-fd84-452d-8a1d-e56253c6a0e0",
+        "lesson.key": "lesson-1",
+        "lesson_group.key": "",
+        "script.name": "ui-test-csd1-2025"
+      }
+    },
+    {
+      "understanding": 1,
+      "teacher_description": "Code is readable but disorganized",
+      "ai_prompt": "",
+      "seeding_key": {
+        "understanding": 1,
+        "learning_goal.key": "3cb946e1-fd84-452d-8a1d-e56253c6a0e0",
+        "lesson.key": "lesson-1",
+        "lesson_group.key": "",
+        "script.name": "ui-test-csd1-2025"
+      }
+    },
+    {
+      "understanding": 2,
+      "teacher_description": "Code is readable and well organized, with a couple of small issues",
+      "ai_prompt": "",
+      "seeding_key": {
+        "understanding": 2,
+        "learning_goal.key": "3cb946e1-fd84-452d-8a1d-e56253c6a0e0",
+        "lesson.key": "lesson-1",
+        "lesson_group.key": "",
+        "script.name": "ui-test-csd1-2025"
+      }
+    },
+    {
+      "understanding": 3,
+      "teacher_description": "Code is readable and well organized, with no quality issues",
+      "ai_prompt": "",
+      "seeding_key": {
+        "understanding": 3,
+        "learning_goal.key": "3cb946e1-fd84-452d-8a1d-e56253c6a0e0",
+        "lesson.key": "lesson-1",
+        "lesson_group.key": "",
+        "script.name": "ui-test-csd1-2025"
+      }
+    },
+    {
+      "understanding": 0,
+      "teacher_description": "No sprites used",
+      "ai_prompt": "",
+      "seeding_key": {
+        "understanding": 0,
+        "learning_goal.key": "effc0330-65f6-4768-b995-fe3f9ed60a45",
+        "lesson.key": "lesson-1",
+        "lesson_group.key": "",
+        "script.name": "ui-test-csd1-2025"
+      }
+    },
+    {
+      "understanding": 1,
+      "teacher_description": "A single sprite used with no attempt to modify it",
+      "ai_prompt": "",
+      "seeding_key": {
+        "understanding": 1,
+        "learning_goal.key": "effc0330-65f6-4768-b995-fe3f9ed60a45",
+        "lesson.key": "lesson-1",
+        "lesson_group.key": "",
+        "script.name": "ui-test-csd1-2025"
+      }
+    },
+    {
+      "understanding": 2,
+      "teacher_description": "Two or more sprites used but no properties changed",
+      "ai_prompt": "",
+      "seeding_key": {
+        "understanding": 2,
+        "learning_goal.key": "effc0330-65f6-4768-b995-fe3f9ed60a45",
+        "lesson.key": "lesson-1",
+        "lesson_group.key": "",
+        "script.name": "ui-test-csd1-2025"
+      }
+    },
+    {
+      "understanding": 3,
+      "teacher_description": "Two or more sprites used with at least one property changed",
+      "ai_prompt": "",
+      "seeding_key": {
+        "understanding": 3,
+        "learning_goal.key": "effc0330-65f6-4768-b995-fe3f9ed60a45",
+        "lesson.key": "lesson-1",
+        "lesson_group.key": "",
+        "script.name": "ui-test-csd1-2025"
+      }
+    }
+  ]
+}

--- a/dashboard/test/ui/config/scripts_json/ui-test-csp1-2019.script_json
+++ b/dashboard/test/ui/config/scripts_json/ui-test-csp1-2019.script_json
@@ -5,11 +5,13 @@
     "login_required": false,
     "properties": {
       "curriculum_umbrella": "CSP",
-      "is_migrated": true
+      "is_migrated": true,
+      "show_calendar": true,
+      "weekly_instructional_minutes": 225
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2026-04-01 00:47:23 UTC",
+    "serialized_at": "2026-04-08 21:33:55 UTC",
     "hide_within_course": false,
     "published_state": "in_development",
     "instruction_type": null,
@@ -62,6 +64,51 @@
         "lesson_group.key": "",
         "script.name": "ui-test-csp1-2019"
       }
+    },
+    {
+      "key": "lesson-3",
+      "name": "Lesson Three",
+      "absolute_position": 3,
+      "lockable": false,
+      "has_lesson_plan": true,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "lesson-3",
+        "lesson_group.key": "",
+        "script.name": "ui-test-csp1-2019"
+      }
+    },
+    {
+      "key": "lesson-4",
+      "name": "Extended Lesson",
+      "absolute_position": 4,
+      "lockable": false,
+      "has_lesson_plan": true,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "lesson-4",
+        "lesson_group.key": "",
+        "script.name": "ui-test-csp1-2019"
+      }
+    },
+    {
+      "key": "lesson-5",
+      "name": "Final Project",
+      "absolute_position": 5,
+      "lockable": false,
+      "has_lesson_plan": true,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "lesson-5",
+        "lesson_group.key": "",
+        "script.name": "ui-test-csp1-2019"
+      }
     }
   ],
   "lesson_activities": [
@@ -69,6 +116,7 @@
       "key": "68e2f806-ca0e-4e18-88e5-b37c327c0b21",
       "position": 1,
       "properties": {
+        "duration": 45
       },
       "seeding_key": {
         "lesson_activity.key": "68e2f806-ca0e-4e18-88e5-b37c327c0b21",
@@ -81,10 +129,65 @@
       "key": "c54a0af3-b779-48da-a6ab-5b14516972fd",
       "position": 1,
       "properties": {
+        "duration": 45
       },
       "seeding_key": {
         "lesson_activity.key": "c54a0af3-b779-48da-a6ab-5b14516972fd",
         "lesson.key": "lesson-2",
+        "lesson_group.key": "",
+        "script.name": "ui-test-csp1-2019"
+      }
+    },
+    {
+      "key": "f60f4a8a-031e-46f7-bb87-5697b11152f2",
+      "position": 1,
+      "properties": {
+        "duration": 45
+      },
+      "seeding_key": {
+        "lesson_activity.key": "f60f4a8a-031e-46f7-bb87-5697b11152f2",
+        "lesson.key": "lesson-3",
+        "lesson_group.key": "",
+        "script.name": "ui-test-csp1-2019"
+      }
+    },
+    {
+      "key": "4e12e65f-5591-40e5-b691-9ea9551ff3d3",
+      "position": 1,
+      "properties": {
+        "duration": 30,
+        "name": "Activity One"
+      },
+      "seeding_key": {
+        "lesson_activity.key": "4e12e65f-5591-40e5-b691-9ea9551ff3d3",
+        "lesson.key": "lesson-4",
+        "lesson_group.key": "",
+        "script.name": "ui-test-csp1-2019"
+      }
+    },
+    {
+      "key": "bc154c41-0838-4d38-aee0-75185e075c38",
+      "position": 2,
+      "properties": {
+        "duration": 60,
+        "name": "Activity Two"
+      },
+      "seeding_key": {
+        "lesson_activity.key": "bc154c41-0838-4d38-aee0-75185e075c38",
+        "lesson.key": "lesson-4",
+        "lesson_group.key": "",
+        "script.name": "ui-test-csp1-2019"
+      }
+    },
+    {
+      "key": "a36dac52-aee0-474b-862a-d84daf4296b9",
+      "position": 1,
+      "properties": {
+        "duration": 225
+      },
+      "seeding_key": {
+        "lesson_activity.key": "a36dac52-aee0-474b-862a-d84daf4296b9",
+        "lesson.key": "lesson-5",
         "lesson_group.key": "",
         "script.name": "ui-test-csp1-2019"
       }
@@ -109,6 +212,46 @@
       "seeding_key": {
         "activity_section.key": "79216b13-add9-4004-aacf-7c1e04373e9f",
         "lesson_activity.key": "c54a0af3-b779-48da-a6ab-5b14516972fd"
+      }
+    },
+    {
+      "key": "bd07567f-c9e1-4ae0-8009-213332be1a90",
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "activity_section.key": "bd07567f-c9e1-4ae0-8009-213332be1a90",
+        "lesson_activity.key": "f60f4a8a-031e-46f7-bb87-5697b11152f2"
+      }
+    },
+    {
+      "key": "806d9762-111a-47d4-86db-d456f8ba4d9a",
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "activity_section.key": "806d9762-111a-47d4-86db-d456f8ba4d9a",
+        "lesson_activity.key": "4e12e65f-5591-40e5-b691-9ea9551ff3d3"
+      }
+    },
+    {
+      "key": "e33e7929-f319-4f87-852b-3627c77bef96",
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "activity_section.key": "e33e7929-f319-4f87-852b-3627c77bef96",
+        "lesson_activity.key": "bc154c41-0838-4d38-aee0-75185e075c38"
+      }
+    },
+    {
+      "key": "cc992f78-3240-4d74-ace9-fbf0d1025b76",
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "activity_section.key": "cc992f78-3240-4d74-ace9-fbf0d1025b76",
+        "lesson_activity.key": "a36dac52-aee0-474b-862a-d84daf4296b9"
       }
     }
   ],

--- a/dashboard/test/ui/config/scripts_json/ui-test-single-unit-2026.script_json
+++ b/dashboard/test/ui/config/scripts_json/ui-test-single-unit-2026.script_json
@@ -8,7 +8,7 @@
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2026-04-08 22:17:46 UTC",
+    "serialized_at": "2026-04-08 22:31:48 UTC",
     "hide_within_course": false,
     "published_state": null,
     "instruction_type": null,
@@ -35,7 +35,7 @@
   "lessons": [
     {
       "key": "lesson-1",
-      "name": "Lesson One",
+      "name": "Artist",
       "absolute_position": 1,
       "lockable": false,
       "has_lesson_plan": true,
@@ -65,16 +65,188 @@
     }
   ],
   "lesson_activities": [
-
+    {
+      "key": "a022442d-6ee6-4aa2-b098-af39c3e5e1a0",
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_activity.key": "a022442d-6ee6-4aa2-b098-af39c3e5e1a0",
+        "lesson.key": "lesson-1",
+        "lesson_group.key": "lessonGroup-2",
+        "script.name": "ui-test-single-unit-2026"
+      }
+    },
+    {
+      "key": "def8762f-7709-4326-8b94-d77e295db141",
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_activity.key": "def8762f-7709-4326-8b94-d77e295db141",
+        "lesson.key": "lesson-2",
+        "lesson_group.key": "lessonGroup-2",
+        "script.name": "ui-test-single-unit-2026"
+      }
+    }
   ],
   "activity_sections": [
-
+    {
+      "key": "976cf2fe-3366-4645-8767-0eb301cffb3a",
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "activity_section.key": "976cf2fe-3366-4645-8767-0eb301cffb3a",
+        "lesson_activity.key": "a022442d-6ee6-4aa2-b098-af39c3e5e1a0"
+      }
+    },
+    {
+      "key": "31e0cd50-e60a-42a8-97db-6ab842333079",
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "activity_section.key": "31e0cd50-e60a-42a8-97db-6ab842333079",
+        "lesson_activity.key": "def8762f-7709-4326-8b94-d77e295db141"
+      }
+    }
   ],
   "script_levels": [
-
+    {
+      "chapter": 1,
+      "position": 1,
+      "activity_section_position": 1,
+      "assessment": false,
+      "properties": {
+      },
+      "bonus": false,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "K-1 Artist1 1"
+        ],
+        "lesson.key": "lesson-1",
+        "lesson_group.key": "lessonGroup-2",
+        "script.name": "ui-test-single-unit-2026",
+        "activity_section.key": "976cf2fe-3366-4645-8767-0eb301cffb3a"
+      },
+      "level_keys": [
+        "K-1 Artist1 1"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "activity_section_position": 2,
+      "assessment": false,
+      "properties": {
+      },
+      "bonus": false,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Standalone_Artist_9"
+        ],
+        "lesson.key": "lesson-1",
+        "lesson_group.key": "lessonGroup-2",
+        "script.name": "ui-test-single-unit-2026",
+        "activity_section.key": "976cf2fe-3366-4645-8767-0eb301cffb3a"
+      },
+      "level_keys": [
+        "Standalone_Artist_9"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 1,
+      "activity_section_position": 1,
+      "assessment": false,
+      "properties": {
+      },
+      "bonus": false,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "flappy_1"
+        ],
+        "lesson.key": "lesson-2",
+        "lesson_group.key": "lessonGroup-2",
+        "script.name": "ui-test-single-unit-2026",
+        "activity_section.key": "31e0cd50-e60a-42a8-97db-6ab842333079"
+      },
+      "level_keys": [
+        "flappy_1"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 2,
+      "activity_section_position": 2,
+      "assessment": false,
+      "properties": {
+      },
+      "bonus": false,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "flappy_11"
+        ],
+        "lesson.key": "lesson-2",
+        "lesson_group.key": "lessonGroup-2",
+        "script.name": "ui-test-single-unit-2026",
+        "activity_section.key": "31e0cd50-e60a-42a8-97db-6ab842333079"
+      },
+      "level_keys": [
+        "flappy_11"
+      ]
+    }
   ],
   "levels_script_levels": [
-
+    {
+      "seeding_key": {
+        "level.key": "K-1 Artist1 1",
+        "script_level.level_keys": [
+          "K-1 Artist1 1"
+        ],
+        "lesson.key": "lesson-1",
+        "lesson_group.key": "lessonGroup-2",
+        "script.name": "ui-test-single-unit-2026",
+        "activity_section.key": "976cf2fe-3366-4645-8767-0eb301cffb3a"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Standalone_Artist_9",
+        "script_level.level_keys": [
+          "Standalone_Artist_9"
+        ],
+        "lesson.key": "lesson-1",
+        "lesson_group.key": "lessonGroup-2",
+        "script.name": "ui-test-single-unit-2026",
+        "activity_section.key": "976cf2fe-3366-4645-8767-0eb301cffb3a"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "flappy_1",
+        "script_level.level_keys": [
+          "flappy_1"
+        ],
+        "lesson.key": "lesson-2",
+        "lesson_group.key": "lessonGroup-2",
+        "script.name": "ui-test-single-unit-2026",
+        "activity_section.key": "31e0cd50-e60a-42a8-97db-6ab842333079"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "flappy_11",
+        "script_level.level_keys": [
+          "flappy_11"
+        ],
+        "lesson.key": "lesson-2",
+        "lesson_group.key": "lessonGroup-2",
+        "script.name": "ui-test-single-unit-2026",
+        "activity_section.key": "31e0cd50-e60a-42a8-97db-6ab842333079"
+      }
+    }
   ],
   "resources": [
 

--- a/dashboard/test/ui/config/scripts_json/ui-test-single-unit-2026.script_json
+++ b/dashboard/test/ui/config/scripts_json/ui-test-single-unit-2026.script_json
@@ -8,7 +8,8 @@
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2025-01-27 16:04:33 UTC",
+    "serialized_at": "2026-04-08 22:17:46 UTC",
+    "hide_within_course": false,
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,
@@ -19,19 +20,49 @@
   },
   "lesson_groups": [
     {
-      "key": "",
-      "user_facing": false,
+      "key": "lessonGroup-2",
+      "user_facing": true,
       "position": 1,
       "properties": {
+        "display_name": "Chapter One"
       },
       "seeding_key": {
-        "lesson_group.key": "",
+        "lesson_group.key": "lessonGroup-2",
         "script.name": "ui-test-single-unit-2026"
       }
     }
   ],
   "lessons": [
-
+    {
+      "key": "lesson-1",
+      "name": "Lesson One",
+      "absolute_position": 1,
+      "lockable": false,
+      "has_lesson_plan": true,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "lesson-1",
+        "lesson_group.key": "lessonGroup-2",
+        "script.name": "ui-test-single-unit-2026"
+      }
+    },
+    {
+      "key": "lesson-2",
+      "name": "Lesson Two",
+      "absolute_position": 2,
+      "lockable": false,
+      "has_lesson_plan": true,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "lesson-2",
+        "lesson_group.key": "lessonGroup-2",
+        "script.name": "ui-test-single-unit-2026"
+      }
+    }
   ],
   "lesson_activities": [
 

--- a/dashboard/test/ui/features/teacher_tools/rubrics/ai_assessments_announcement.feature
+++ b/dashboard/test/ui/features/teacher_tools/rubrics/ai_assessments_announcement.feature
@@ -8,7 +8,7 @@ Feature: Announcement for AI Assessments
     Then I wait until element "#uitest-no-ai-assessments-announcement" is visible
 
     # announcement visible on ai unit
-    When I am on "http://studio.code.org/courses/interactive-games-animations-2024/units/1"
+    When I am on "http://studio.code.org/courses/ui-test-csd-2025/units/1"
     Then I wait until element "#uitest-ai-assessments-announcement" is visible
 
     # announcement is not visible after closing
@@ -22,10 +22,10 @@ Feature: Announcement for AI Assessments
 
   Scenario: Teacher views announcement and clicks learn more
     Given I am a teacher
-    When I am on "http://studio.code.org/courses/interactive-games-animations-2024/units/1"
+    When I am on "http://studio.code.org/courses/ui-test-csd-2025/units/1"
     Then I wait until element "#uitest-ai-assessments-announcement" is visible
 
     # announcement is not visible after clicking button to navigate
     When I click selector "#uitest-ai-assessments-announcement .learn-more-button" to load a new page
-    And I am on "http://studio.code.org/courses/interactive-games-animations-2024/units/1"
+    And I am on "http://studio.code.org/courses/ui-test-csd-2025/units/1"
     Then I wait until element "#uitest-no-ai-assessments-announcement" is visible

--- a/dashboard/test/ui/features/teacher_tools/teacher_dashboard/calendar_eyes.feature
+++ b/dashboard/test/ui/features/teacher_tools/teacher_dashboard/calendar_eyes.feature
@@ -5,7 +5,7 @@ Feature: Calendar page - Eyes
   Scenario: Lesson materials page
     When I open my eyes to test "calendar page"
     Given I create an authorized teacher-associated student named "Sally"
-    Given I am assigned to course "interactive-games-animations-2024" unit 1 with teacher "Teacher_Sally"
+    Given I am assigned to course "ui-test-csp-2025" unit 1 with teacher "Teacher_Sally"
 
     When I sign in as "Teacher_Sally" and go home
     And I get levelbuilder access
@@ -18,7 +18,7 @@ Feature: Calendar page - Eyes
     And I wait until element "#uitest-spinner" is not visible
 
     And I wait until element "div:contains('Instructional minutes per week')" is visible
-    And I wait until element "div:contains('Lesson 1: Programming for a Purpose')" is visible
+    And I wait until element "div:contains('Lesson 1: Intro')" is visible
 
     Then I see no difference for "calendar"
 

--- a/dashboard/test/ui/features/teacher_tools/teacher_dashboard/local_nav_v2_standalone_eyes.feature
+++ b/dashboard/test/ui/features/teacher_tools/teacher_dashboard/local_nav_v2_standalone_eyes.feature
@@ -7,7 +7,7 @@ Feature: V2 teacher dashboard local navigation - single-unit course - Eyes
   Scenario: Local navigation on single-unit course
     When I open my eyes to test "teacher local nav v2 - single-unit course overview"
     Given I create an authorized teacher-associated student named "Sally"
-    Given I am assigned to course "interactive-games-animations-2024" unit 1 with teacher "Teacher_Sally"
+    Given I am assigned to course "ui-test-single-unit-course-2026" unit 1 with teacher "Teacher_Sally"
 
     Given I sign in as "Teacher_Sally" and go home
     And I get levelbuilder access
@@ -15,7 +15,7 @@ Feature: V2 teacher dashboard local navigation - single-unit course - Eyes
     When I click selector "#task-button-View-progress-New-Section" once I see it
     Given I wait until element "#ui-test-teacher-sidebar" is visible
     Given I click selector "#ui-test-teacher-sidebar a:contains('Course')" once I see it
-    And I wait until element "h1:contains('Interactive Animations and Games')" is visible
+    And I wait until element "h1:contains('Single Unit 2026')" is visible
     Then I see no difference for "unit overview"
 
     Then I click selector "#uitest-view-as-student" once I see it

--- a/dashboard/test/ui/features/teacher_tools/teacher_dashboard/teacher_dashboard_local_nav_v2_eyes.feature
+++ b/dashboard/test/ui/features/teacher_tools/teacher_dashboard/teacher_dashboard_local_nav_v2_eyes.feature
@@ -21,7 +21,7 @@ Feature: Using the V2 teacher dashboard local navigation - Eyes
     When I sign in as "Teacher_Sally" and go home
     And I get levelbuilder access
 
-    And I create a new student section assigned to course "interactive-games-animations-2024" unit 1 and save the section
+    And I create a new student section assigned to course "ui-test-single-unit-course-2026" unit 1 and save the section
     Given I create a student named "Talia"
     And I join the section
 
@@ -32,7 +32,7 @@ Feature: Using the V2 teacher dashboard local navigation - Eyes
     And I wait until element "h6:contains(Icon Key)" is visible
     And I wait until element "#ui-test-progress-table-v2" is visible
     And I wait until element "#ui-test-skeleton-progress-column" is not visible
-    And I scroll to "#ui-test-lesson-header-10"
+    And I scroll to "#ui-test-lesson-header-1"
     Then I see no difference for "progress v2 - first section"
 
     Then I select the "New Section" option in dropdown "uitest-sidebar-section-dropdown"
@@ -44,6 +44,7 @@ Feature: Using the V2 teacher dashboard local navigation - Eyes
 
     And I close my eyes
 
+  @skip
   @properties_encryption_key
   Scenario: Local navigation on Unit and Course overview pages
     When I open my eyes to test "teacher local nav v2 - unit/course overview"

--- a/dashboard/test/ui/features/teacher_tools/teacher_dashboard/teacher_dashboard_local_nav_v2_eyes.feature
+++ b/dashboard/test/ui/features/teacher_tools/teacher_dashboard/teacher_dashboard_local_nav_v2_eyes.feature
@@ -44,7 +44,6 @@ Feature: Using the V2 teacher dashboard local navigation - Eyes
 
     And I close my eyes
 
-  @skip
   @properties_encryption_key
   Scenario: Local navigation on Unit and Course overview pages
     When I open my eyes to test "teacher local nav v2 - unit/course overview"

--- a/dashboard/test/ui/features/teacher_tools/teacher_dashboard/teacher_homepage_v2.feature
+++ b/dashboard/test/ui/features/teacher_tools/teacher_dashboard/teacher_homepage_v2.feature
@@ -7,7 +7,7 @@ Feature: Using the teacher homepage
     And I get levelbuilder access
 
     # Create a section with a course
-    And I create a new student section assigned to course "interactive-games-animations-2024" unit 1 and save the section
+    And I create a new student section assigned to course "ui-test-single-unit-course-2026" unit 1 and save the section
 
     # Create a student to join the second section
     And I create a student named "Bobby"
@@ -53,7 +53,7 @@ Feature: Using the teacher homepage
     And I click "#ui-test-teaching"
     Then I wait until element "#section-options-dropdown-dropdown-button" is visible
 
-Scenario: Teacher can delete a section from the section options dropdown
+  Scenario: Teacher can delete a section from the section options dropdown
     Given I am a teacher
     And I create a new student section
     And I am on "http://studio.code.org/teacher_dashboard/home"
@@ -91,7 +91,7 @@ Scenario: Teacher can delete a section from the section options dropdown
     Given I create a teacher named "Teacher Hank"
     And I sign in as "Teacher Hank" and go home
     And I get levelbuilder access
-    And I create a new student section assigned to course "interactive-games-animations-2024" unit 1 and save the section
+    And I create a new student section assigned to course "ui-test-single-unit-course-2026" unit 1 and save the section
     Then I create a student named "Bobby"
     And I sign in as "Bobby"
     And I join the section
@@ -102,7 +102,7 @@ Scenario: Teacher can delete a section from the section options dropdown
 
   Scenario: Teacher can view lesson materials from the "View lesson materials" button on the section card
     Given I am a teacher
-    And I create a new student section assigned to course "interactive-games-animations-2024" unit 1
+    And I create a new student section assigned to course "ui-test-single-unit-course-2026" unit 1
     And I am on "http://studio.code.org/teacher_dashboard/home"
     Then I click "#task-button-View-lesson-materials-New-Section" once it exists
     Then I wait until element "h1:contains(Lesson Materials)" is visible
@@ -118,7 +118,7 @@ Scenario: Teacher can delete a section from the section options dropdown
     And I create a new student section
 
     # Create a section with a course
-    And I create a new student section assigned to course "interactive-games-animations-2024" unit 1 and save the section
+    And I create a new student section assigned to course "ui-test-single-unit-course-2026" unit 1 and save the section
 
     # Create a student to join the second section
     Given I create a student named "Bobby"


### PR DESCRIPTION
Moves ui tests off of interactive-games-animations-2024. For background, see [partitioned curriculum data proposal](https://docs.google.com/document/d/1iiJXtPODakjuZ7-2yKJ941H56dcyUmUFtWa7zGgqKdw/edit?tab=t.0#heading=h.qx67631q1z2d).

Done in this PR:
- move calendar_eyes test onto new ui-test-csp-2025 course. calendar requires a course with version year 2021 or later, and a unit with `show_calendar` set. I added more lessons to make the calendar diff look more interesting:
<img width="964" height="373" alt="Screenshot 2026-04-08 at 4 17 21 PM" src="https://github.com/user-attachments/assets/a6224664-ee9f-4ebb-88f4-f1c40191657b" />

- move ai assessments announcement test to new ui-test-csd course. the code explicitly checks for the CSD marketing initiative, and also that the unit has at least one ai-enabled rubric.

- point three teacher dashboard feature files at `ui-test-single-unit-course-2026`. I had to add some lesson content to this course to make the right things show up in the teacher dashboard.


## Testing story
- since we are just adding and not removing any units in this PR, drone should provide adequate coverage for the regular ui tests
- a few eyes diffs are expected to show up during DTT:
  - directly modified:  calendar_eyes.feature, teacher_homepage_v2.feature, teacher_dashboard_local_nav_v2_eyes.feature, local_nav_v2_standalone_eyes.feature
  - indirect diffs: new `UI Test CSD` course card may appear in in course catalog