### PR TITLE
Lab2/Codebridge projects: add separate field for edits since last version save

### DIFF
--- a/apps/src/lab2/redux/lab2ProjectRedux.ts
+++ b/apps/src/lab2/redux/lab2ProjectRedux.ts
@@ -108,9 +108,6 @@ const projectSlice = createSlice({
     setRestoredOldVersion(state, action: PayloadAction<boolean>) {
       state.restoredOldVersion = action.payload;
     },
-    setHasEdited(state, action: PayloadAction<boolean>) {
-      state.hasEdited = action.payload;
-    },
     resetHasEditedSinceLastVersionSave(state) {
       state.hasEditedSinceLastVersionSave = false;
     },
@@ -494,7 +491,6 @@ export const {
   setViewingAiTutorVersion,
   setRestoredOldVersion,
   resetProjectMetadata,
-  setHasEdited,
   resetHasEditedSinceLastVersionSave,
   setSource,
   setProjectTooLarge,

--- a/apps/src/lab2/redux/lab2ProjectRedux.ts
+++ b/apps/src/lab2/redux/lab2ProjectRedux.ts
@@ -50,6 +50,11 @@ const initialState: Lab2ProjectState = {
   projectSourceLevelId: undefined,
 };
 
+function markEdited(state: Lab2ProjectState) {
+  state.hasEdited = true;
+  state.hasEditedSinceLastVersionSave = true;
+}
+
 // SLICE
 
 const projectSlice = createSlice({
@@ -132,8 +137,7 @@ const projectSlice = createSlice({
             url: action.payload.url,
           }),
         };
-        state.hasEdited = true;
-        state.hasEditedSinceLastVersionSave = true;
+        markEdited(state);
       }
     },
     createNewExternalFile(
@@ -160,8 +164,7 @@ const projectSlice = createSlice({
           ...state.projectSources,
           source: newSource,
         };
-        state.hasEdited = true;
-        state.hasEditedSinceLastVersionSave = true;
+        markEdited(state);
       }
     },
     renameFile(
@@ -190,8 +193,7 @@ const projectSlice = createSlice({
             },
           },
         };
-        state.hasEdited = true;
-        state.hasEditedSinceLastVersionSave = true;
+        markEdited(state);
       }
     },
     saveFile(
@@ -223,8 +225,7 @@ const projectSlice = createSlice({
             },
           },
         };
-        state.hasEdited = true;
-        state.hasEditedSinceLastVersionSave = true;
+        markEdited(state);
       }
     },
     setFileType(
@@ -253,8 +254,7 @@ const projectSlice = createSlice({
             },
           },
         };
-        state.hasEdited = true;
-        state.hasEditedSinceLastVersionSave = true;
+        markEdited(state);
       }
     },
     activateFile(state, action: PayloadAction<FileId>) {
@@ -301,8 +301,7 @@ const projectSlice = createSlice({
           ...state.projectSources,
           source: deleteResult.newSource,
         };
-        state.hasEdited = true;
-        state.hasEditedSinceLastVersionSave = true;
+        markEdited(state);
       }
     },
     moveFile(
@@ -332,8 +331,7 @@ const projectSlice = createSlice({
             },
           },
         };
-        state.hasEdited = true;
-        state.hasEditedSinceLastVersionSave = true;
+        markEdited(state);
       }
     },
     moveFolder(
@@ -363,8 +361,7 @@ const projectSlice = createSlice({
             },
           },
         };
-        state.hasEdited = true;
-        state.hasEditedSinceLastVersionSave = true;
+        markEdited(state);
       }
     },
     createNewFolder(
@@ -380,8 +377,7 @@ const projectSlice = createSlice({
             action.payload.parentId
           ),
         };
-        state.hasEdited = true;
-        state.hasEditedSinceLastVersionSave = true;
+        markEdited(state);
       }
     },
     toggleOpenFolder(state, action: PayloadAction<FolderId>) {
@@ -424,8 +420,7 @@ const projectSlice = createSlice({
           ...state.projectSources,
           source: deleteResult.newSource,
         };
-        state.hasEdited = true;
-        state.hasEditedSinceLastVersionSave = true;
+        markEdited(state);
       }
     },
     renameFolder(
@@ -455,8 +450,7 @@ const projectSlice = createSlice({
             },
           },
         };
-        state.hasEdited = true;
-        state.hasEditedSinceLastVersionSave = true;
+        markEdited(state);
       }
     },
     rearrangeFiles(state, action: PayloadAction<FileId[]>) {

--- a/apps/src/lab2/redux/lab2ProjectRedux.ts
+++ b/apps/src/lab2/redux/lab2ProjectRedux.ts
@@ -29,6 +29,7 @@ export interface Lab2ProjectState {
   viewingAiTutorVersion?: boolean;
   restoredOldVersion: boolean;
   hasEdited: boolean;
+  hasEditedSinceLastVersionSave: boolean;
   projectTooLarge: boolean;
   lastSavedLabConfig: LabConfig | undefined;
   projectSourceLevelId: number | undefined;
@@ -43,6 +44,7 @@ const initialState: Lab2ProjectState = {
   viewingAiTutorVersion: false,
   restoredOldVersion: false,
   hasEdited: false,
+  hasEditedSinceLastVersionSave: false,
   projectTooLarge: false,
   lastSavedLabConfig: undefined,
   projectSourceLevelId: undefined,
@@ -104,6 +106,9 @@ const projectSlice = createSlice({
     setHasEdited(state, action: PayloadAction<boolean>) {
       state.hasEdited = action.payload;
     },
+    resetHasEditedSinceLastVersionSave(state) {
+      state.hasEditedSinceLastVersionSave = false;
+    },
     setProjectTooLarge(state, action: PayloadAction<boolean>) {
       state.projectTooLarge = action.payload;
     },
@@ -128,6 +133,7 @@ const projectSlice = createSlice({
           }),
         };
         state.hasEdited = true;
+        state.hasEditedSinceLastVersionSave = true;
       }
     },
     createNewExternalFile(
@@ -155,6 +161,7 @@ const projectSlice = createSlice({
           source: newSource,
         };
         state.hasEdited = true;
+        state.hasEditedSinceLastVersionSave = true;
       }
     },
     renameFile(
@@ -184,6 +191,7 @@ const projectSlice = createSlice({
           },
         };
         state.hasEdited = true;
+        state.hasEditedSinceLastVersionSave = true;
       }
     },
     saveFile(
@@ -216,6 +224,7 @@ const projectSlice = createSlice({
           },
         };
         state.hasEdited = true;
+        state.hasEditedSinceLastVersionSave = true;
       }
     },
     setFileType(
@@ -245,6 +254,7 @@ const projectSlice = createSlice({
           },
         };
         state.hasEdited = true;
+        state.hasEditedSinceLastVersionSave = true;
       }
     },
     activateFile(state, action: PayloadAction<FileId>) {
@@ -292,6 +302,7 @@ const projectSlice = createSlice({
           source: deleteResult.newSource,
         };
         state.hasEdited = true;
+        state.hasEditedSinceLastVersionSave = true;
       }
     },
     moveFile(
@@ -322,6 +333,7 @@ const projectSlice = createSlice({
           },
         };
         state.hasEdited = true;
+        state.hasEditedSinceLastVersionSave = true;
       }
     },
     moveFolder(
@@ -352,6 +364,7 @@ const projectSlice = createSlice({
           },
         };
         state.hasEdited = true;
+        state.hasEditedSinceLastVersionSave = true;
       }
     },
     createNewFolder(
@@ -368,6 +381,7 @@ const projectSlice = createSlice({
           ),
         };
         state.hasEdited = true;
+        state.hasEditedSinceLastVersionSave = true;
       }
     },
     toggleOpenFolder(state, action: PayloadAction<FolderId>) {
@@ -411,6 +425,7 @@ const projectSlice = createSlice({
           source: deleteResult.newSource,
         };
         state.hasEdited = true;
+        state.hasEditedSinceLastVersionSave = true;
       }
     },
     renameFolder(
@@ -441,6 +456,7 @@ const projectSlice = createSlice({
           },
         };
         state.hasEdited = true;
+        state.hasEditedSinceLastVersionSave = true;
       }
     },
     rearrangeFiles(state, action: PayloadAction<FileId[]>) {
@@ -461,6 +477,7 @@ const projectSlice = createSlice({
       // Reset the state that needs to be reset manually on level change.
       // Project source is handled elsewhere.
       state.hasEdited = false;
+      state.hasEditedSinceLastVersionSave = false;
       state.versionDetails = undefined;
       state.viewingOldVersion = false;
       state.restoredOldVersion = false;
@@ -484,6 +501,7 @@ export const {
   setRestoredOldVersion,
   resetProjectMetadata,
   setHasEdited,
+  resetHasEditedSinceLastVersionSave,
   setSource,
   setProjectTooLarge,
   createNewFile,

--- a/apps/src/lab2/views/components/Instructions/ResourcePanel/VersionHistory/VersionHistoryPanel.tsx
+++ b/apps/src/lab2/views/components/Instructions/ResourcePanel/VersionHistory/VersionHistoryPanel.tsx
@@ -13,7 +13,7 @@ import {
   setProjectSource,
   setViewingOldVersion,
   setRestoredOldVersion,
-  setHasEdited,
+  resetHasEditedSinceLastVersionSave,
 } from '@cdo/apps/lab2/redux/lab2ProjectRedux';
 import {
   loadVersion,
@@ -111,7 +111,9 @@ const VersionHistoryPanel: React.FunctionComponent<
   const projectSources = useAppSelector(
     state => state.lab2Project.projectSources
   );
-  const hasEdited = useAppSelector(state => state.lab2Project.hasEdited);
+  const hasEditedSinceLastVersionSave = useAppSelector(
+    state => state.lab2Project.hasEditedSinceLastVersionSave
+  );
 
   // Ex: "Jun 5, 3:30 PM"
   const dateFormatter = useMemo(() => {
@@ -372,7 +374,7 @@ const VersionHistoryPanel: React.FunctionComponent<
     sendLab2AnalyticsEvent(EVENTS.LAB2_VERSION_COMMITTED, {
       versionId: selectedVersion,
     });
-    dispatch(setHasEdited(false));
+    dispatch(resetHasEditedSinceLastVersionSave());
     successfulProjectResetCleanUp(true);
     setVersionSaved(true);
   }, [dispatch, selectedVersion, successfulProjectResetCleanUp]);
@@ -474,14 +476,17 @@ const VersionHistoryPanel: React.FunctionComponent<
           restoreDisabled={disabled || versionLoading}
           alwaysShowAutoSaves={alwaysShowAutoSaves}
         >
-          {isLatest && hasEdited && !viewingOldVersion && !viewAsUserId && (
-            <SaveVersionPanel
-              projectSources={projectSources}
-              onSuccess={handleSaveVersionSuccess}
-              disabled={disabled || versionLoading}
-              buttonLabel={saveButtonLabel || lab2I18n.saveCurrentVersion()}
-            />
-          )}
+          {isLatest &&
+            hasEditedSinceLastVersionSave &&
+            !viewingOldVersion &&
+            !viewAsUserId && (
+              <SaveVersionPanel
+                projectSources={projectSources}
+                onSuccess={handleSaveVersionSuccess}
+                disabled={disabled || versionLoading}
+                buttonLabel={saveButtonLabel || lab2I18n.saveCurrentVersion()}
+              />
+            )}
         </VersionHistoryRow>
       );
     },
@@ -493,7 +498,7 @@ const VersionHistoryPanel: React.FunctionComponent<
       viewingOldVersion,
       restoreSelectedVersion,
       versionLoading,
-      hasEdited,
+      hasEditedSinceLastVersionSave,
       projectSources,
       handleSaveVersionSuccess,
       alwaysShowAutoSaves,

--- a/apps/test/unit/lab2/redux/lab2ProjectReduxTest.ts
+++ b/apps/test/unit/lab2/redux/lab2ProjectReduxTest.ts
@@ -17,6 +17,7 @@ import reducer, {
   renameFolder,
   rearrangeFiles,
   resetProjectMetadata,
+  resetHasEditedSinceLastVersionSave,
   Lab2ProjectState,
   createNewExternalFile,
 } from '@cdo/apps/lab2/redux/lab2ProjectRedux';
@@ -111,6 +112,7 @@ describe('lab2ProjectRedux', () => {
       expect(newFile?.folderId).toBe(DEFAULT_FOLDER_ID);
       expect(newFile?.contents).toBe('Add your changes to newFile.txt');
       expect(state.hasEdited).toBe(true);
+      expect(state.hasEditedSinceLastVersionSave).toBe(true);
     });
 
     it('should create a new file in specific folder with custom contents', () => {
@@ -137,6 +139,7 @@ describe('lab2ProjectRedux', () => {
       expect(newFile?.folderId).toBe('1');
       expect(newFile?.contents).toBe('print("hello world")');
       expect(state.hasEdited).toBe(true);
+      expect(state.hasEditedSinceLastVersionSave).toBe(true);
     });
 
     it('should not create file when project sources is undefined', () => {
@@ -175,6 +178,7 @@ describe('lab2ProjectRedux', () => {
       expect(newFile?.contents).toBe('');
       expect(newFile?.url).toBe(fileUrl);
       expect(state.hasEdited).toBe(true);
+      expect(state.hasEditedSinceLastVersionSave).toBe(true);
     });
 
     it('should create a new external file in specific folder', () => {
@@ -203,6 +207,7 @@ describe('lab2ProjectRedux', () => {
       expect(newFile?.contents).toBe('');
       expect(newFile?.url).toBe(fileUrl);
       expect(state.hasEdited).toBe(true);
+      expect(state.hasEditedSinceLastVersionSave).toBe(true);
     });
 
     it('should not create file when project sources is undefined', () => {
@@ -233,6 +238,7 @@ describe('lab2ProjectRedux', () => {
         (state.projectSources!.source as MultiFileSource).files['1'].name
       ).toBe('renamed.html');
       expect(state.hasEdited).toBe(true);
+      expect(state.hasEditedSinceLastVersionSave).toBe(true);
     });
 
     it('should not rename if file does not exist', () => {
@@ -278,6 +284,7 @@ describe('lab2ProjectRedux', () => {
         (state.projectSources!.source as MultiFileSource).files['1'].contents
       ).toBe(newContents);
       expect(state.hasEdited).toBe(true);
+      expect(state.hasEditedSinceLastVersionSave).toBe(true);
     });
 
     it('should not save if file does not exist', () => {
@@ -322,6 +329,7 @@ describe('lab2ProjectRedux', () => {
         (state.projectSources!.source as MultiFileSource).files['1'].type
       ).toBe(ProjectFileType.VALIDATION);
       expect(state.hasEdited).toBe(true);
+      expect(state.hasEditedSinceLastVersionSave).toBe(true);
     });
 
     it('should not set type if file does not exist', () => {
@@ -363,6 +371,7 @@ describe('lab2ProjectRedux', () => {
         (state.projectSources!.source as MultiFileSource).files['2'].active
       ).toBe(true);
       expect(state.hasEdited).toBe(false); // Activating doesn't count as edit
+      expect(state.hasEditedSinceLastVersionSave).toBe(false);
     });
 
     it('should not activate when project sources is undefined', () => {
@@ -387,6 +396,7 @@ describe('lab2ProjectRedux', () => {
       expect(newSource.openFiles).toEqual(['2']);
       expect(newSource.files['2'].active).toBe(true);
       expect(state.hasEdited).toBe(false); // Closing doesn't count as edit
+      expect(state.hasEditedSinceLastVersionSave).toBe(false);
     });
 
     it('should not close when project sources is undefined', () => {
@@ -412,6 +422,7 @@ describe('lab2ProjectRedux', () => {
       expect(newSource.openFiles).toEqual(['2']);
       expect(newSource.files['2'].active).toBe(true);
       expect(state.hasEdited).toBe(true);
+      expect(state.hasEditedSinceLastVersionSave).toBe(true);
     });
 
     it('should not delete if file does not exist', () => {
@@ -452,6 +463,7 @@ describe('lab2ProjectRedux', () => {
         (state.projectSources!.source as MultiFileSource).files['1'].folderId
       ).toBe('1');
       expect(state.hasEdited).toBe(true);
+      expect(state.hasEditedSinceLastVersionSave).toBe(true);
     });
 
     it('should not move if file does not exist', () => {
@@ -501,6 +513,7 @@ describe('lab2ProjectRedux', () => {
         (state.projectSources!.source as MultiFileSource).folders['2'].parentId
       ).toBe(DEFAULT_FOLDER_ID);
       expect(state.hasEdited).toBe(true);
+      expect(state.hasEditedSinceLastVersionSave).toBe(true);
     });
 
     it('should not move if folder does not exist', () => {
@@ -550,6 +563,7 @@ describe('lab2ProjectRedux', () => {
       expect(newFolder).toBeDefined();
       expect(newFolder?.parentId).toBe(DEFAULT_FOLDER_ID);
       expect(state.hasEdited).toBe(true);
+      expect(state.hasEditedSinceLastVersionSave).toBe(true);
     });
 
     it('should create new folder in specific parent', () => {
@@ -573,6 +587,7 @@ describe('lab2ProjectRedux', () => {
       expect(newFolder).toBeDefined();
       expect(newFolder?.parentId).toBe('1');
       expect(state.hasEdited).toBe(true);
+      expect(state.hasEditedSinceLastVersionSave).toBe(true);
     });
 
     it('should not create folder when project sources is undefined', () => {
@@ -603,6 +618,7 @@ describe('lab2ProjectRedux', () => {
         (state.projectSources!.source as MultiFileSource).folders['1'].open
       ).toBe(true);
       expect(state.hasEdited).toBe(false); // Toggling doesn't count as edit
+      expect(state.hasEditedSinceLastVersionSave).toBe(false);
     });
 
     it('should toggle folder from open to closed', () => {
@@ -622,6 +638,7 @@ describe('lab2ProjectRedux', () => {
         (state.projectSources!.source as MultiFileSource).folders['1'].open
       ).toBe(false);
       expect(state.hasEdited).toBe(false);
+      expect(state.hasEditedSinceLastVersionSave).toBe(false);
     });
 
     it('should not toggle if folder does not exist', () => {
@@ -680,6 +697,7 @@ describe('lab2ProjectRedux', () => {
       expect(newSource.folders['1']).toBeUndefined();
       expect(newSource.files['1'].active).toBe(true);
       expect(state.hasEdited).toBe(true);
+      expect(state.hasEditedSinceLastVersionSave).toBe(true);
     });
 
     it('should not delete if folder does not exist', () => {
@@ -720,6 +738,7 @@ describe('lab2ProjectRedux', () => {
         (state.projectSources!.source as MultiFileSource).folders['1'].name
       ).toBe('renamedFolder');
       expect(state.hasEdited).toBe(true);
+      expect(state.hasEditedSinceLastVersionSave).toBe(true);
     });
 
     it('should not rename if folder does not exist', () => {
@@ -766,6 +785,7 @@ describe('lab2ProjectRedux', () => {
         (state.projectSources!.source as MultiFileSource).openFiles
       ).toEqual(['2', '1']);
       expect(state.hasEdited).toBe(false); // Rearranging doesn't count as edit
+      expect(state.hasEditedSinceLastVersionSave).toBe(false);
     });
 
     it('should not rearrange when project sources is undefined', () => {
@@ -779,6 +799,7 @@ describe('lab2ProjectRedux', () => {
       const stateWithMetadata = {
         ...initialState,
         hasEdited: true,
+        hasEditedSinceLastVersionSave: true,
         viewingOldVersion: true,
         restoredOldVersion: true,
         projectSources: undefined,
@@ -787,8 +808,29 @@ describe('lab2ProjectRedux', () => {
       const state = reducer(stateWithMetadata, resetProjectMetadata());
 
       expect(state.hasEdited).toBe(false);
+      expect(state.hasEditedSinceLastVersionSave).toBe(false);
       expect(state.viewingOldVersion).toBe(false);
       expect(state.restoredOldVersion).toBe(false);
+    });
+  });
+
+  describe('resetHasEditedSinceLastVersionSave', () => {
+    it('should reset hasEditedSinceLastVersionSave without affecting hasEdited', () => {
+      const initialProjectSources = createMockProjectSources();
+      const stateAfterEdit = reducer(
+        {...initialState, projectSources: initialProjectSources},
+        saveFile({fileId: '1', contents: '<h1>Updated</h1>'})
+      );
+      expect(stateAfterEdit.hasEdited).toBe(true);
+      expect(stateAfterEdit.hasEditedSinceLastVersionSave).toBe(true);
+
+      const state = reducer(
+        stateAfterEdit,
+        resetHasEditedSinceLastVersionSave()
+      );
+
+      expect(state.hasEditedSinceLastVersionSave).toBe(false);
+      expect(state.hasEdited).toBe(true);
     });
   });
 });

--- a/apps/test/unit/lab2/redux/lab2ProjectReduxTest.ts
+++ b/apps/test/unit/lab2/redux/lab2ProjectReduxTest.ts
@@ -83,6 +83,7 @@ const initialState: Lab2ProjectState = {
   projectSourceBeforeAiTutorVersion: undefined,
   restoredOldVersion: false,
   hasEdited: false,
+  hasEditedSinceLastVersionSave: false,
   projectTooLarge: false,
   lastSavedLabConfig: undefined,
   projectSourceLevelId: undefined,

--- a/apps/test/unit/lab2/views/components/Instructions/ResourcePanel/VersionHistory/VersionHistoryPanelTest.tsx
+++ b/apps/test/unit/lab2/views/components/Instructions/ResourcePanel/VersionHistory/VersionHistoryPanelTest.tsx
@@ -12,6 +12,9 @@ import lab, {setChannel} from '@cdo/apps/lab2/lab2Redux';
 import Lab2Registry from '@cdo/apps/lab2/Lab2Registry';
 import ProjectManager from '@cdo/apps/lab2/projects/ProjectManager';
 import lab2Project, {
+  createNewFile,
+  setHasEdited,
+  setProjectSource,
   setViewingOldVersion,
 } from '@cdo/apps/lab2/redux/lab2ProjectRedux';
 import lab2System from '@cdo/apps/lab2/redux/systemRedux';
@@ -369,6 +372,87 @@ describe('VersionHistoryPanel', () => {
     if (restoreButton) {
       expect(restoreButton).toBeDisabled();
     }
+  });
+
+  describe('save version panel', () => {
+    const SOURCE_WITH_FILE = {
+      source: {
+        files: {
+          file1: {id: 'file1', name: 'index.html', contents: '<p>hi</p>'},
+        },
+        folders: {},
+        openFiles: ['file1'],
+      },
+    };
+
+    it('does not show save version panel when hasEdited is true but hasEditedSinceLastVersionSave is false', async () => {
+      // setHasEdited only sets hasEdited, not hasEditedSinceLastVersionSave
+      store.dispatch(setHasEdited(true));
+      renderDefault();
+
+      await waitFor(
+        () => expect(mockedProjectManager.getVersionList).toHaveBeenCalled(),
+        {timeout: 2000}
+      );
+
+      expect(
+        screen.queryByPlaceholderText('Describe your changes')
+      ).not.toBeInTheDocument();
+    });
+
+    it('shows save version panel after an edit action sets hasEditedSinceLastVersionSave', async () => {
+      store.dispatch(setProjectSource(SOURCE_WITH_FILE));
+      // createNewFile sets both hasEdited and hasEditedSinceLastVersionSave
+      store.dispatch(createNewFile({fileName: 'style.css'}));
+
+      renderDefault();
+
+      await waitFor(
+        () => expect(mockedProjectManager.getVersionList).toHaveBeenCalled(),
+        {timeout: 2000}
+      );
+
+      expect(
+        screen.getByPlaceholderText('Describe your changes')
+      ).toBeInTheDocument();
+    });
+
+    it('hides save version panel after saving a version but keeps hasEdited true', async () => {
+      mockedProjectManager = {
+        ...mockedProjectManager,
+        save: jest.fn(() => Promise.resolve()),
+        getCurrentVersionId: jest.fn(() => null),
+      } as unknown as jest.Mocked<ProjectManager>;
+      Lab2Registry.getInstance().setProjectManager(mockedProjectManager);
+
+      store.dispatch(setProjectSource(SOURCE_WITH_FILE));
+      store.dispatch(createNewFile({fileName: 'style.css'}));
+
+      renderDefault();
+
+      await waitFor(
+        () => expect(mockedProjectManager.getVersionList).toHaveBeenCalled(),
+        {timeout: 2000}
+      );
+
+      const textarea = screen.getByPlaceholderText('Describe your changes');
+      const user = userEvent.setup();
+      await user.type(textarea, 'my changes');
+
+      const saveButton = screen.getByRole('button', {
+        name: /save current version/i,
+      });
+      await user.click(saveButton);
+
+      await waitFor(() => {
+        expect(
+          screen.queryByPlaceholderText('Describe your changes')
+        ).not.toBeInTheDocument();
+      });
+
+      // hasEdited must remain true — it tracks edits for the whole session
+      expect(store.getState().lab2Project.hasEdited).toBe(true);
+    });
   });
 
   it('collapses and expands auto-save groups when collapse button is clicked', async () => {

--- a/apps/test/unit/lab2/views/components/Instructions/ResourcePanel/VersionHistory/VersionHistoryPanelTest.tsx
+++ b/apps/test/unit/lab2/views/components/Instructions/ResourcePanel/VersionHistory/VersionHistoryPanelTest.tsx
@@ -13,7 +13,7 @@ import Lab2Registry from '@cdo/apps/lab2/Lab2Registry';
 import ProjectManager from '@cdo/apps/lab2/projects/ProjectManager';
 import lab2Project, {
   createNewFile,
-  setHasEdited,
+  resetHasEditedSinceLastVersionSave,
   setProjectSource,
   setViewingOldVersion,
 } from '@cdo/apps/lab2/redux/lab2ProjectRedux';
@@ -386,8 +386,9 @@ describe('VersionHistoryPanel', () => {
     };
 
     it('does not show save version panel when hasEdited is true but hasEditedSinceLastVersionSave is false', async () => {
-      // setHasEdited only sets hasEdited, not hasEditedSinceLastVersionSave
-      store.dispatch(setHasEdited(true));
+      store.dispatch(setProjectSource(SOURCE_WITH_FILE));
+      store.dispatch(createNewFile({fileName: 'style.css'}));
+      store.dispatch(resetHasEditedSinceLastVersionSave());
       renderDefault();
 
       await waitFor(


### PR DESCRIPTION
I noticed we were resetting hasEdited when a version history save occurs ([reference](https://github.com/code-dot-org/code-dot-org/blob/86d2ef7fbadd7251e8493511fb78aa9f30b5cbeb/apps/src/lab2/views/components/Instructions/ResourcePanel/VersionHistory/VersionHistoryPanel.tsx#L375)). This was so we could show/hide the version history save panel if there hadn't been edits since the last save. However, `hasEdited` is also used in Python Lab and Web Lab 2 to determine if the user can submit on a submittable level, and will soon be used in Web Lab 2 to gate continue. Currently, the following undesirable behavior occurs:
- User opens submittable level
- Submit button is disabled
- User changes code (and runs in python lab)
- Submit button is enabled
- User saves their code in the version history panel
- Submit button is disabled again with the confusing directive to edit your code.

This adds a separate field for tracking edits since last version save that is now used to determine whether or not to show the save panel.

## Before

https://github.com/user-attachments/assets/7c2949ea-8f46-4e25-8865-72d06a08df2e


## After

https://github.com/user-attachments/assets/917c2227-d82a-46c4-b072-0b6493bc07ca



## Links

- Jira: pre-work for [AFL-548](https://codedotorg.atlassian.net/browse/AFL-548)

## Testing story
Tested locally and added/updated unit tests.


