### PR TITLE
Report to HoneyBadger if moderation API keys missing

### DIFF
--- a/apps/src/util/experiments.js
+++ b/apps/src/util/experiments.js
@@ -65,8 +65,6 @@ experiments.ACCEPT_REJECT_SPLIT_DIFF = 'accept-reject-split-diff';
 experiments.STUDENT_SNAPSHOT = 'student-snapshot';
 // Show the lesson/<lesson_id>/tutor page as a home for a AI Tutor+
 experiments.LESSON_TUTOR = 'lesson-tutor';
-// Enable AI Content Safety image moderation
-experiments.AI_CONTENT_SAFETY = 'ai-content-safety';
 // Enable Onboarding experiments
 experiments.ONBOARDING = 'onboarding';
 // Enable AI Diff Chat Drawer

--- a/lib/cdo/image_moderation.rb
+++ b/lib/cdo/image_moderation.rb
@@ -11,7 +11,10 @@ module ImageModeration
   # @param [String] content_type - image/gif, image/jpeg, image/png
   # @return [Hash, nil] categoriesAnalysis response from Azure, or nil on error
   def self.moderate_image(image_data, content_type)
-    return nil unless CDO.azure_ai_content_safety_key
+    unless CDO.azure_ai_content_safety_key
+      Honeybadger.notify("Azure AI Content Safety API key is missing", context: {endpoint: CDO.azure_ai_content_safety_endpoint})
+      return nil
+    end
 
     moderation_io, moderation_type = scale_image_for_moderation_if_needed(image_data, content_type)
     AzureAiContentSafety.new(

--- a/lib/cdo/web_purify.rb
+++ b/lib/cdo/web_purify.rb
@@ -56,7 +56,10 @@ module WebPurify
   # @param [Array[String]] language_codes The set of languages to search for profanity in.
   # @return [Array<String>, nil] The profanities (if any) or nil (if none).
   def self.find_potential_profanities(text, language_codes = ['en'])
-    return nil unless CDO.webpurify_key && Gatekeeper.allows('webpurify', default: true)
+    unless CDO.webpurify_key && Gatekeeper.allows('webpurify', default: true)
+      Honeybadger.notify("WebPurify API key is missing or disabled", context: {endpoint: CDO.webpurify_api_endpoint})
+      return nil
+    end
     return nil if text.nil?
 
     # This is an artificial limit to prevent us from profanity-checking a file up to 5MB (the project size limit)

--- a/lib/test/cdo/test_image_moderation.rb
+++ b/lib/test/cdo/test_image_moderation.rb
@@ -17,6 +17,10 @@ class ImageModerationTest < Minitest::Test
   def test_returns_nil_when_missing_api_key
     CDO.stubs(azure_ai_content_safety_key: nil)
     AzureAiContentSafety.expects(:new).never
+    Honeybadger.expects(:notify).once.with(
+      "Azure AI Content Safety API key is missing",
+      context: {endpoint: CDO.azure_ai_content_safety_endpoint}
+    )
     assert_nil ImageModeration.moderate_image(@image_body, @content_type)
   end
 

--- a/lib/test/cdo/test_web_purify.rb
+++ b/lib/test/cdo/test_web_purify.rb
@@ -6,13 +6,25 @@ class WebPurifyTest < Minitest::Test
   include SetupTest
 
   def setup
-    CDO.stubs(webpurify_key: 'mocksecret')
+    CDO.stubs(
+      webpurify_key: 'mocksecret',
+      webpurify_api_endpoint: 'https://fake.webpurify.endpoint'
+    )
   end
 
   # Do additional VCR configuration so as to prevent the CDO.webpurify_key from being logged to the
   # YML cassette, instead replacing it with a placeholder string.
   VCR.configure do |c|
     c.filter_sensitive_data('<API_KEY>') {CDO.webpurify_key}
+  end
+
+  def test_returns_nil_when_missing_api_key
+    CDO.stubs(webpurify_key: nil)
+    Honeybadger.expects(:notify).once.with(
+      "WebPurify API key is missing or disabled",
+      context: {endpoint: CDO.webpurify_api_endpoint}
+    )
+    assert_nil WebPurify.find_potential_profanities('some text')
   end
 
   def test_chunk_text_for_webpurify


### PR DESCRIPTION
<!--
  Summary of the change: background, motivation, and context.
  Include screenshots, videos, or before/after comparisons for UI changes.
-->
This PR reports to HoneyBadger if the AI Content Safety or Web Purify keys are missing. Note that HoneyBadger does not send reports in dev and adhoc environments. Keys are in place for other (bas) envs (`prod`, `test`, `levelbuilder`, `staging`).
Also includes a small experiments constant clean-up.






## Links
<!-- Jira tickets, design docs, Slack threads, related PRs, etc. -->

- Prior PR discussion: https://github.com/code-dot-org/code-dot-org/pull/71878#discussion_r3034155412
- [Slack thread](https://codedotorg.slack.com/archives/C046G4TRLEN/p1775574156832229)

## Testing story
<!-- How was this tested? Manual steps, adhoc links, automated tests, or why testing isn't needed. -->



## Deployment notes
<!-- Delete this section if it's a standard merge-and-deploy.
     Otherwise: migrations, feature flags, coordination, caching impacts, etc. -->



## Privacy and security
<!-- Delete this section if there is no privacy/security impact.
     Otherwise: new PII, auth changes, API surface changes, etc. -->

