### PR TITLE
Bump bramble to v0.1.33

### DIFF
--- a/dashboard/app/controllers/weblab_host_controller.rb
+++ b/dashboard/app/controllers/weblab_host_controller.rb
@@ -4,7 +4,7 @@ class WeblabHostController < ApplicationController
   STUDIO_URL = CDO.studio_url('', CDO.default_scheme)
 
   def index
-    @dev_mode = false # Change to true to point to Bramble running on localhost
+    @dev_mode = true # Change to true to point to Bramble running on localhost
     @bramble_base_url = @dev_mode ? BRAMBLE_LOCALHOST_URL : BRAMBLE_URL
     @studio_url = STUDIO_URL
     @skip_files = params[:skip_files] == "true" # Special case for checking that Bramble can be initialized without loading files

--- a/dashboard/app/controllers/weblab_host_controller.rb
+++ b/dashboard/app/controllers/weblab_host_controller.rb
@@ -1,10 +1,10 @@
 class WeblabHostController < ApplicationController
-  BRAMBLE_URL = 'https://downloads.computinginthecore.org/bramble_0.1.32'
+  BRAMBLE_URL = 'https://downloads.computinginthecore.org/bramble_0.1.33'
   BRAMBLE_LOCALHOST_URL = 'http://127.0.0.1:8000/src'
   STUDIO_URL = CDO.studio_url('', CDO.default_scheme)
 
   def index
-    @dev_mode = true # Change to true to point to Bramble running on localhost
+    @dev_mode = false # Change to true to point to Bramble running on localhost
     @bramble_base_url = @dev_mode ? BRAMBLE_LOCALHOST_URL : BRAMBLE_URL
     @studio_url = STUDIO_URL
     @skip_files = params[:skip_files] == "true" # Special case for checking that Bramble can be initialized without loading files


### PR DESCRIPTION
This bumps our bramble version to include recent changes. I've created the S3 bucket with this version's changes already, which BRAMBLE_URL pulls from.

## Testing story

Confirmed with this change we see the updated version of bramble being used.

## Deployment notes

The corresponding https://github.com/code-dot-org/bramble/pull/26 to bump the version is just for accounting; these PRs can be merged in any order. See the bramble readme for more information.
