### PR TITLE
AI Chat: wait an extra day to delete requests

### DIFF
--- a/bin/cron/delete_old_ai_chat_data
+++ b/bin/cron/delete_old_ai_chat_data
@@ -19,12 +19,12 @@ DASHBOARD_DB_LONG_TIMEOUT = Cdo::Sequel.database_connection_pool(
 # Log the number of records deleted for each table to #cron-daily Slack channel
 # so we can easily monitor the deletion process.
 def main
-  ninety_days_ago = Time.now - 90.days
-
-  deleted_event_count = DASHBOARD_DB_LONG_TIMEOUT[:aichat_events].where {created_at < ninety_days_ago}.delete
+  # Make sure we're deleting Events (90 days old) a day before Requests (91 days old)
+  # to ensure we don't have foreign key constraint issues when deleting Requests that are still referenced by Events.
+  deleted_event_count = DASHBOARD_DB_LONG_TIMEOUT[:aichat_events].where {created_at < Time.now - 90.days}.delete
   ChatClient.message('cron-daily', "Deleted #{deleted_event_count} AichatEvent records")
 
-  deleted_request_count = DASHBOARD_DB_LONG_TIMEOUT[:aichat_requests].where {created_at < ninety_days_ago}.delete
+  deleted_request_count = DASHBOARD_DB_LONG_TIMEOUT[:aichat_requests].where {created_at < Time.now - 91.days}.delete
   ChatClient.message('cron-daily', "Deleted #{deleted_request_count} AichatRequest records")
 end
 

--- a/bin/cron/delete_old_ai_chat_data
+++ b/bin/cron/delete_old_ai_chat_data
@@ -13,8 +13,7 @@ DASHBOARD_DB_LONG_TIMEOUT = Cdo::Sequel.database_connection_pool(
 )
 
 # We want to avoid storing student chat messages any longer than
-# is necessary for analysis to prevent storing excess student PII. This deletes
-# any AichatEvent or AichatRequest older than 90 days.
+# is necessary for analysis to prevent storing excess student PII.
 #
 # Log the number of records deleted for each table to #cron-daily Slack channel
 # so we can easily monitor the deletion process.


### PR DESCRIPTION
We're seeing new errors in our script that deletes 90+ day old AI Chat data related to foreign key constraints: https://app.honeybadger.io/projects/45435/faults/116797157

I'm speculating that this might be a result of our 90 day retention window being too tight between Events (which have a FK dependency on Requests). If we wait an extra day before deleting Requests, I'm hoping we won't have any Events still in the database that depend on a Request that we're trying to delete.

The cronjob might still fail due to timeout issues, but we'll see.

## Testing story

Ran this script manually locally just to see that it didn't delete all records or something (it did not 😅 ).