### PR TITLE
chore(otel): enable in cron and activejobs (and other places)

### DIFF
--- a/dashboard/engines/observability/lib/observability/engine.rb
+++ b/dashboard/engines/observability/lib/observability/engine.rb
@@ -9,10 +9,11 @@ module Observability
     # all initializers during initialize!. The Engine class body runs when
     # Bundler.require loads the engine in config/application.rb, which is before
     # Rails.application.initialize! is called.
-    # Guard on running_web_application? to avoid loading Sentry in rake tasks,
-    # migrations, and other non-web processes where setup() will immediately return.
+    # Guard on UNIT_TEST to avoid loading Sentry in unit test runs where the
+    # DSN is unconfigured and background threads are unwanted. All other processes
+    # (workers, cron, rake, console) get observability.
     # sentry-opentelemetry is only needed when both integrations are active.
-    if CDO.enable_sentry && CDO.running_web_application?
+    if CDO.enable_sentry && !ENV['UNIT_TEST']
       require 'sentry-ruby'
       require 'sentry-rails'
       require 'sentry-opentelemetry' if CDO.enable_opentelemetry

--- a/dashboard/engines/observability/lib/observability/opentelemetry.rb
+++ b/dashboard/engines/observability/lib/observability/opentelemetry.rb
@@ -2,11 +2,10 @@
 
 module Observability
   module OpenTelemetry
-    # Sets up OpenTelemetry tracing. Only runs when CDO.enable_opentelemetry is
-    # true and the process is serving web requests (skips unit test runners,
-    # rake tasks, etc.).
+    # Sets up OpenTelemetry tracing. Runs in all processes except unit test runners
+    # (detected via UNIT_TEST env var set in dashboard/test/test_helper.rb).
     def self.setup
-      return unless CDO.enable_opentelemetry && CDO.running_web_application?
+      return unless CDO.enable_opentelemetry && !ENV['UNIT_TEST']
 
       require 'opentelemetry/sdk'
       require 'opentelemetry/instrumentation/all'

--- a/dashboard/engines/observability/lib/observability/sentry.rb
+++ b/dashboard/engines/observability/lib/observability/sentry.rb
@@ -2,12 +2,12 @@
 
 module Observability
   module Sentry
-    # Sets up Sentry error tracking. Only runs when CDO.enable_sentry is true
-    # and the process is serving web requests (skips rake tasks, test runners, etc.).
+    # Sets up Sentry error tracking. Runs in all processes except unit test runners
+    # (detected via UNIT_TEST env var set in dashboard/test/test_helper.rb).
     # When OpenTelemetry is also enabled, the OTLP integration is activated so
     # errors are correlated with traces.
     def self.setup
-      return unless CDO.enable_sentry && CDO.running_web_application?
+      return unless CDO.enable_sentry && !ENV['UNIT_TEST']
 
       if CDO.dashboard_sentry_dsn.blank?
         CDO.log.warn '[observability] enable_sentry is true but dashboard_sentry_dsn is not configured; skipping Sentry setup'

--- a/dashboard/engines/observability/test/lib/observability/opentelemetry_test.rb
+++ b/dashboard/engines/observability/test/lib/observability/opentelemetry_test.rb
@@ -5,30 +5,31 @@ require 'test_helper'
 describe Observability::OpenTelemetry do
   before do
     CDO.stubs(:enable_opentelemetry).returns(false)
-    CDO.stubs(:running_web_application?).returns(false)
+    # ENV['UNIT_TEST'] is nil in engine test runs — enabled path is active by default
   end
 
   describe '.setup' do
     describe 'when CDO.enable_opentelemetry is false' do
-      before {CDO.stubs(:running_web_application?).returns(true)}
-
       it 'returns without configuring the SDK' do
         _(Observability::OpenTelemetry.setup).must_be_nil
       end
     end
 
-    describe 'when CDO.running_web_application? is false' do
-      before {CDO.stubs(:enable_opentelemetry).returns(true)}
-
-      it 'returns without configuring the SDK' do
-        _(Observability::OpenTelemetry.setup).must_be_nil
-      end
-    end
-
-    describe 'when both CDO.enable_opentelemetry and running_web_application? are true' do
+    describe 'when UNIT_TEST is set' do
       before do
         CDO.stubs(:enable_opentelemetry).returns(true)
-        CDO.stubs(:running_web_application?).returns(true)
+        ENV['UNIT_TEST'] = 'true'
+      end
+      after {ENV.delete('UNIT_TEST')}
+
+      it 'returns without configuring the SDK' do
+        _(Observability::OpenTelemetry.setup).must_be_nil
+      end
+    end
+
+    describe 'when both CDO.enable_opentelemetry is true and UNIT_TEST is not set' do
+      before do
+        CDO.stubs(:enable_opentelemetry).returns(true)
         OpenTelemetry::SDK.stubs(:configure)
       end
 

--- a/dashboard/engines/observability/test/lib/observability/sentry_test.rb
+++ b/dashboard/engines/observability/test/lib/observability/sentry_test.rb
@@ -6,8 +6,8 @@ describe Observability::Sentry do
   before do
     CDO.enable_sentry = false
     CDO.enable_opentelemetry = false
-    CDO.running_web_application = false
     CDO.dashboard_sentry_dsn = nil
+    # ENV['UNIT_TEST'] is nil in engine test runs — enabled path is active by default
   end
 
   describe '.setup' do
@@ -17,18 +17,21 @@ describe Observability::Sentry do
       end
     end
 
-    describe 'when CDO.running_web_application? is false' do
-      before {CDO.enable_sentry = true}
+    describe 'when UNIT_TEST is set' do
+      before do
+        CDO.enable_sentry = true
+        ENV['UNIT_TEST'] = 'true'
+      end
+      after {ENV.delete('UNIT_TEST')}
 
       it 'returns without initializing Sentry' do
         _(Observability::Sentry.setup).must_be_nil
       end
     end
 
-    describe 'when CDO.enable_sentry is true and running_web_application? is true' do
+    describe 'when CDO.enable_sentry is true and UNIT_TEST is not set' do
       before do
         CDO.enable_sentry = true
-        CDO.running_web_application = true
         CDO.dashboard_sentry_dsn = 'https://key@sentry.example.com/1'
       end
 

--- a/dashboard/engines/observability/test/test_helper.rb
+++ b/dashboard/engines/observability/test/test_helper.rb
@@ -23,12 +23,6 @@ module CDO
   class << self
     attr_accessor :enable_opentelemetry, :enable_sentry, :dashboard_sentry_dsn
 
-    def running_web_application?
-      @running_web_application
-    end
-
-    attr_writer :running_web_application
-
     def log
       @log ||= Logger.new(IO::NULL)
     end
@@ -37,7 +31,6 @@ module CDO
   self.enable_opentelemetry = false
   self.enable_sentry = false
   self.dashboard_sentry_dsn = nil
-  self.running_web_application = false
 end
 
 require 'observability'


### PR DESCRIPTION
This PR loosens the restriction on where OpenTelemetry and sentry can be loaded to more than just the web application servers. Originally, it was restricted to test Sentry's impact to the web apps for demonstration purposes. Now that we have enabled Sentry on the servers, we can now use it for error collection in cron and active jobs.

To prevent OpenTelemetry and sentry from activating in unit tests, the `UNIT_TEST` env var (which is set by test_helper) is used.

Additionally, previously OTel produces initialization logs which were noisy. However, those have since been removed by the otel log level.