### PR TITLE
Small refactor of moderateImage util function

### DIFF
--- a/apps/src/aichat/api/client/generateChatResponse.ts
+++ b/apps/src/aichat/api/client/generateChatResponse.ts
@@ -113,10 +113,7 @@ export async function generateChatResponse(
           response: text,
           status: AiRequestExecutionStatus.MODEL_IMAGE_FLAGGED,
         };
-      } else if (
-        imageModerationStatus === 'error' ||
-        imageModerationStatus === 'skipped'
-      ) {
+      } else if (imageModerationStatus === 'error') {
         return {
           response: text,
           status: AiRequestExecutionStatus.FAILURE,

--- a/apps/src/aichat/api/client/helpers/safetyHelpers.ts
+++ b/apps/src/aichat/api/client/helpers/safetyHelpers.ts
@@ -58,7 +58,7 @@ export async function isTextSafe(
 export async function getImageModerationStatus(
   file: GeneratedFile,
   assetUrl: string
-): Promise<'ok' | 'flagged' | 'skipped' | 'error'> {
+): Promise<'safe' | 'flagged' | 'error'> {
   const {filename, fileBuffer, mediaType} = prepareGeneratedFile(
     file,
     ACCEPTED_IMAGE_MEDIA_TYPES

--- a/apps/src/util/moderateImage.ts
+++ b/apps/src/util/moderateImage.ts
@@ -45,13 +45,13 @@ export const moderateImage = async (
     flaggedEvent = EVENTS.FLAGGED_CUSTOM_IMAGE,
     assetUrl,
   }: AnalyticsData
-): Promise<'ok' | 'flagged' | 'skipped' | 'error'> => {
+): Promise<'safe' | 'flagged' | 'error'> => {
   const fileExtension = mimeToExtension(file.type) || '';
   if (
     !LABS_WITH_IMAGE_MODERATION.includes(appName ?? '') ||
     !ALLOWED_IMAGE_FILE_EXTENSIONS.includes(fileExtension)
   ) {
-    return 'skipped';
+    return 'error';
   }
   const dimensions = [
     {name: 'UploaderType', value: uploaderType},
@@ -82,7 +82,7 @@ export const moderateImage = async (
           CATEGORY_SEVERITY_LEVEL_BLOCKED[category?.category]
       )
     ) {
-      return 'ok';
+      return 'safe';
     }
 
     MetricsReporter.incrementCounter('ModerateCustomImage.Flagged', dimensions);

--- a/apps/test/unit/aichat/redux/thunks/uploadFilesTest.ts
+++ b/apps/test/unit/aichat/redux/thunks/uploadFilesTest.ts
@@ -42,7 +42,7 @@ describe('uploadFiles', () => {
   beforeEach(() => {
     dispatch = jest.fn();
     mockHttpClient.put.mockResolvedValue({} as Response);
-    mockModerateImage.mockResolvedValue('ok');
+    mockModerateImage.mockResolvedValue('safe');
     mockSendAnalytics.mockReturnValue(jest.fn());
   });
 
@@ -87,7 +87,7 @@ describe('uploadFiles', () => {
     it('still uploads non-flagged files when one file is flagged', async () => {
       mockModerateImage
         .mockResolvedValueOnce('flagged')
-        .mockResolvedValueOnce('ok');
+        .mockResolvedValueOnce('safe');
       const flaggedFile = makeFile('bad.png');
       const cleanFile = makeFile('good.png');
 
@@ -117,8 +117,8 @@ describe('uploadFiles', () => {
       expect(mockHttpClient.put).toHaveBeenCalledTimes(1);
     });
 
-    it('uploads the image when moderation returns ok', async () => {
-      mockModerateImage.mockResolvedValue('ok');
+    it('uploads the image when moderation returns safe', async () => {
+      mockModerateImage.mockResolvedValue('safe');
       const file = makeFile('photo.png');
 
       await uploadFiles({files: [file], buildAssetUrl})(
@@ -130,8 +130,8 @@ describe('uploadFiles', () => {
       expect(mockHttpClient.put).toHaveBeenCalledTimes(1);
     });
 
-    it('uploads the image when moderation is skipped', async () => {
-      mockModerateImage.mockResolvedValue('skipped');
+    it('uploads the image when moderation returns error', async () => {
+      mockModerateImage.mockResolvedValue('error');
       const file = makeFile('photo.png');
 
       await uploadFiles({files: [file], buildAssetUrl})(


### PR DESCRIPTION
<!--
  Summary of the change: background, motivation, and context.
  Include screenshots, videos, or before/after comparisons for UI changes.
-->
Follow-up to https://github.com/code-dot-org/code-dot-org/pull/71962#discussion_r3047388705, this PR updates the `moderateImage` util function so there are 3 return types (instead of 4): 'safe', 'flagged', or 'error'.
'ok' is renamed as 'safe'.

'skipped' is removed and absorbed into 'error' so now 'error' is returned when:
- the function was called with a disallowed file type or lab whose images are not moderated (like Sketch Lab),
- the `json` returned was `null` (occurs if [API key is missing ](https://github.com/code-dot-org/code-dot-org/blob/8846f520dbfa6fcd8a857a65bf4becd464c44a3c/lib/cdo/image_moderation.rb#L14) or an [Azure error rescued](https://github.com/code-dot-org/code-dot-org/blob/8846f520dbfa6fcd8a857a65bf4becd464c44a3c/lib/cdo/image_moderation.rb#L24)),
- or a request or parse error was caught.

If 'error' is returned in Sprite Lab or Web Lab 2, a user can proceed with uploading their image. But in AI Chat Lab, if 'error' is returned for an model-generated image, the assistant response is blocked.


## Links
<!-- Jira tickets, design docs, Slack threads, related PRs, etc. -->

- Jira: https://codedotorg.atlassian.net/browse/SL-1664

## Testing story
<!-- How was this tested? Manual steps, adhoc links, automated tests, or why testing isn't needed. -->

Tested locally uploading images in `weblab2`, `aichat` (uploading and image generation), `spritelab` levels. No change in functionality.


## Deployment notes
<!-- Delete this section if it's a standard merge-and-deploy.
     Otherwise: migrations, feature flags, coordination, caching impacts, etc. -->



## Privacy and security
<!-- Delete this section if there is no privacy/security impact.
     Otherwise: new PII, auth changes, API surface changes, etc. -->

