### PR TITLE
Remove dark mode support from Tabs component

### DIFF
--- a/frontend/packages/component-library/src/tabs/Tabs.tsx
+++ b/frontend/packages/component-library/src/tabs/Tabs.tsx
@@ -25,8 +25,6 @@ export interface TabsProps {
    * (```_tabGroup``` is ONLY for internal DSCO usage for now.
    *  If you need to use it - go to TabGroup component) */
   type?: 'primary' | 'secondary' | '_tabGroup';
-  /** Mode (color) of Tabs */
-  mode?: 'light' | 'dark';
   /** Size of Tabs */
   size?: ComponentSizeXSToL;
   /** Custom className for Tabs container */
@@ -66,7 +64,6 @@ const Tabs: React.FunctionComponent<TabsProps> = ({
   tabPanelsContainerClassName,
   hidePanels,
   type = 'primary',
-  mode = 'light',
   size = 'm',
 }) => {
   const [selectedTabValue, setSelectedValue] = useState(
@@ -111,7 +108,6 @@ const Tabs: React.FunctionComponent<TabsProps> = ({
           moduleStyles.tabs,
           moduleStyles[`tabs-${size}`],
           moduleStyles[`tabs-${type}`],
-          moduleStyles[`tabs-${mode}`],
           tabsContainerClassName,
         )}
         id={tabsContainerId}

--- a/frontend/packages/component-library/src/tabs/stories/Tabs.story.tsx
+++ b/frontend/packages/component-library/src/tabs/stories/Tabs.story.tsx
@@ -20,11 +20,7 @@ export default {
           },
           {
             // Disable color-contrast rule for Tabs.
-            // We decided to ignore this rule for now since one issue is about teal,
-            // and the other seems to be white tabs failing bc they are on a white background,
-            // but that variant will only be used on a dark background so should be fine.
-            // Since that is one of the variants that will eventually go away for theming,
-            // we're not too worried about them.
+            // We decided to ignore this rule for now since one issue is about teal.
             id: 'color-contrast',
             enabled: false,
           },
@@ -241,109 +237,6 @@ GroupOfTypesOfTabs.args = {
       name: 'secondary_tabs',
       tabs: [
         {value: 'tab1', text: 'Tab 1', tabContent: <div>Tab 1 Content</div>},
-        {
-          value: 'tab2',
-          text: 'Tab 2',
-          tabContent: <div>Tab 2 Content</div>,
-        },
-        {
-          value: 'tab3',
-          text: 'Tab 3',
-          tabContent: <div>Tab 3 Content</div>,
-        },
-      ],
-      defaultSelectedTabValue: 'tab1',
-      onChange: () => null,
-      type: 'secondary',
-    },
-  ],
-};
-
-export const GroupOfModesOfTabs = MultipleTemplate.bind({});
-GroupOfModesOfTabs.args = {
-  components: [
-    {
-      name: 'primary_light_tabs',
-      mode: 'light',
-      tabs: [
-        {
-          value: 'tab1',
-          text: 'Tab 1',
-          tabContent: <div>Tab 1 Content(Primary Light)</div>,
-        },
-        {
-          value: 'tab2',
-          text: 'Tab 2',
-          tabContent: <div>Tab 2 Content</div>,
-        },
-        {
-          value: 'tab3',
-          text: 'Tab 3',
-          tabContent: <div>Tab 3 Content</div>,
-        },
-      ],
-      defaultSelectedTabValue: 'tab1',
-      onChange: () => null,
-      type: 'primary',
-    },
-    {
-      name: 'primary_dark_tabs',
-      mode: 'dark',
-      tabs: [
-        {
-          value: 'tab1',
-          text: 'Tab 1',
-          tabContent: <div>Tab 1 Content(Primary Dark)</div>,
-        },
-        {
-          value: 'tab2',
-          text: 'Tab 2',
-          tabContent: <div>Tab 2 Content</div>,
-        },
-        {
-          value: 'tab3',
-          text: 'Tab 3',
-          tabContent: <div>Tab 3 Content</div>,
-        },
-      ],
-      defaultSelectedTabValue: 'tab1',
-      onChange: () => null,
-      type: 'primary',
-    },
-
-    {
-      name: 'secondary_light_tabs',
-      mode: 'light',
-      tabs: [
-        {
-          value: 'tab1',
-          text: 'Tab 1',
-          tabContent: <div>Tab 1 Content (Secondary Light)</div>,
-        },
-        {
-          value: 'tab2',
-          text: 'Tab 2',
-          tabContent: <div>Tab 2 Content</div>,
-        },
-        {
-          value: 'tab3',
-          text: 'Tab 3',
-          tabContent: <div>Tab 3 Content</div>,
-        },
-      ],
-      defaultSelectedTabValue: 'tab1',
-      onChange: () => null,
-      type: 'secondary',
-    },
-    {
-      name: 'secondary_dark_tabs',
-      mode: 'dark',
-      tabs: [
-        {
-          value: 'tab1',
-          text: 'Tab 1',
-          tabContent: <div>Tab 1 Content (Secondary Dark)</div>,
-        },
         {
           value: 'tab2',
           text: 'Tab 2',
@@ -724,62 +617,6 @@ GroupOfTabsWithClosableTabs.args = {
       defaultSelectedTabValue: 'tab1',
       onChange: () => null,
       type: 'secondary',
-    },
-    {
-      name: 'primary_tabs_with_closable_tabs_dark',
-      tabs: [
-        {
-          value: 'tab1',
-          text: 'Tab 1',
-          tabContent: <div>Tab 1 Content</div>,
-          isClosable: true,
-        },
-        {
-          value: 'tab2',
-          text: 'Tab 2',
-          tabContent: <div>Tab 2 Content</div>,
-          isClosable: true,
-        },
-        {
-          value: 'tab3',
-          text: 'Tab 3',
-          tabContent: <div>Tab 3 Content</div>,
-          isClosable: true,
-        },
-      ],
-      defaultSelectedTabValue: 'tab1',
-      onChange: () => null,
-      type: 'primary',
-      mode: 'dark',
-    },
-    {
-      name: 'secondary_tabs_with_closable_tabs_dark',
-      tabs: [
-        {
-          value: 'tab1',
-          text: 'Tab 1',
-          tabContent: <div>Tab 1 Content</div>,
-          isClosable: true,
-        },
-        {
-          value: 'tab2',
-          text: 'Tab 2',
-          iconLeft: {iconName: 'check', iconStyle: 'solid'},
-          iconRight: {iconName: 'check', iconStyle: 'solid'},
-          tabContent: <div>Tab 2 Content</div>,
-          isClosable: true,
-        },
-        {
-          value: 'tab3',
-          text: 'Tab 3',
-          tabContent: <div>Tab 3 Content</div>,
-          isClosable: true,
-        },
-      ],
-      defaultSelectedTabValue: 'tab1',
-      onChange: () => null,
-      type: 'secondary',
-      mode: 'dark',
     },
   ],
 };

--- a/frontend/packages/component-library/src/tabs/tabs.module.scss
+++ b/frontend/packages/component-library/src/tabs/tabs.module.scss
@@ -59,79 +59,39 @@
     border-radius: 0;
   }
 
-  &.tabs-light {
-    ul::after {
-      border-color: var(--borders-neutral-primary);
-    }
-
-    li button[role='tab'] {
-      color: var(--text-neutral-tertiary);
-
-      &:hover {
-        color: var(--text-brand-teal-primary);
-        border: none;
-        border-bottom: 2px solid var(--borders-brand-teal-primary);
-      }
-
-      &:focus-visible {
-        color: var(--text-brand-teal-primary);
-        outline: 2px solid var(--borders-brand-teal-primary);
-      }
-
-      &:active:not(:disabled) {
-        color: var(--text-neutral-primary);
-        border: none !important;
-        border-bottom: 2px solid var(--borders-brand-teal-primary) !important;
-      }
-
-      &.selectedTab {
-        color: var(--text-neutral-primary);
-        border-bottom: 2px solid var(--borders-brand-teal-primary);
-      }
-
-      &:disabled {
-        cursor: not-allowed;
-        color: var(--text-neutral-disabled);
-        border: none !important;
-      }
-    }
+  ul::after {
+    border-color: var(--borders-neutral-primary);
   }
 
-  &.tabs-dark {
-    ul::after {
-      border-color: var(--borders-neutral-primary);
+  li button[role='tab'] {
+    color: var(--text-neutral-tertiary);
+
+    &:hover {
+      color: var(--text-brand-teal-primary);
+      border: none;
+      border-bottom: 2px solid var(--borders-brand-teal-primary);
     }
 
-    li button[role='tab'] {
-      color: var(--neutral-gray-20);
+    &:focus-visible {
+      color: var(--text-brand-teal-primary);
+      outline: 2px solid var(--borders-brand-teal-primary);
+    }
 
-      &:hover {
-        color: var(--text-neutral-inverse);
-        border: none;
-        border-bottom: 2px solid var(--borders-brand-teal-primary);
-      }
+    &:active:not(:disabled) {
+      color: var(--text-neutral-primary);
+      border: none !important;
+      border-bottom: 2px solid var(--borders-brand-teal-primary) !important;
+    }
 
-      &:focus-visible {
-        color: var(--text-neutral-inverse);
-        outline: 2px solid var(--borders-brand-teal-primary);
-      }
+    &.selectedTab {
+      color: var(--text-neutral-primary);
+      border-bottom: 2px solid var(--borders-brand-teal-primary);
+    }
 
-      &:active:not(:disabled) {
-        color: var(--text-neutral-inverse);
-        border: none !important;
-        border-bottom: 2px solid var(--borders-brand-teal-primary) !important;
-      }
-
-      &.selectedTab {
-        color: var(--text-neutral-inverse);
-        border-bottom: 2px solid var(--borders-brand-teal-primary);
-      }
-
-      &:disabled {
-        cursor: not-allowed;
-        color: var(--neutral-gray-80);
-        border: none !important;
-      }
+    &:disabled {
+      cursor: not-allowed;
+      color: var(--text-neutral-disabled);
+      border: none !important;
     }
   }
 }
@@ -142,111 +102,55 @@
     border-radius: 0.25rem 0.25rem 0 0;
   }
 
-  &.tabs-light {
-    ul::after {
-      border-color: var(--borders-neutral-primary);
-    }
-
-    li button[role='tab'] {
-      color: var(--text-neutral-tertiary);
-      background-color: var(--background-neutral-secondary);
-      border: 1px solid var(--borders-neutral-primary);
-
-      &:hover {
-        color: var(--text-neutral-primary);
-        background-color: var(--background-neutral-tertiary);
-        border: 1px solid var(--borders-neutral-primary);
-      }
-
-      &:focus-visible {
-        color: var(--text-neutral-white-fixed);
-        background-color: var(--background-brand-teal-primary);
-        border-color: transparent;
-        border-left: none;
-        border-right: none;
-        border-bottom-color: var(--borders-neutral-primary);
-        outline: 2px solid var(--borders-brand-teal-primary);
-        outline-offset: 2px;
-
-        &:not(.selectedTab, :active) button {
-          color: var(--text-neutral-white-fixed);
-        }
-      }
-
-      &:active:not(:disabled) {
-        color: var(--text-brand-teal-primary);
-        background-color: var(--background-neutral-primary);
-        border: 1px solid var(--borders-neutral-primary) !important;
-        border-bottom-color: transparent !important;
-      }
-
-      &.selectedTab {
-        color: var(--text-brand-teal-primary);
-        background-color: var(--background-neutral-primary);
-        border: 1px solid var(--borders-neutral-primary);
-        border-bottom-color: transparent;
-      }
-
-      &:disabled {
-        cursor: not-allowed;
-        color: var(--text-neutral-disabled);
-        background-color: var(--background-neutral-secondary);
-        border: 1px solid var(--borders-neutral-disabled);
-      }
-    }
+  ul::after {
+    border-color: var(--borders-neutral-primary);
   }
 
-  &.tabs-dark {
-    ul::after {
-      border-color: var(--neutral-gray-80);
+  li button[role='tab'] {
+    color: var(--text-neutral-tertiary);
+    background-color: var(--background-neutral-secondary);
+    border: 1px solid var(--borders-neutral-primary);
+
+    &:hover {
+      color: var(--text-neutral-primary);
+      background-color: var(--background-neutral-tertiary);
+      border: 1px solid var(--borders-neutral-primary);
     }
 
-    li button[role='tab'] {
-      color: var(--neutral-gray-20);
-      background-color: var(--neutral-gray-95);
-      border: 1px solid var(--neutral-gray-80);
+    &:focus-visible {
+      color: var(--text-neutral-white-fixed);
+      background-color: var(--background-brand-teal-primary);
+      border-color: transparent;
+      border-left: none;
+      border-right: none;
+      border-bottom-color: var(--borders-neutral-primary);
+      outline: 2px solid var(--borders-brand-teal-primary);
+      outline-offset: 2px;
 
-      &:hover {
+      &:not(.selectedTab, :active) button {
         color: var(--text-neutral-white-fixed);
-        background-color: var(--neutral-gray-90);
-        border: 1px solid var(--neutral-gray-80);
       }
+    }
 
-      &:focus-visible {
-        color: var(--text-neutral-white-fixed);
-        background-color: var(--background-brand-teal-primary);
-        border-color: transparent;
-        border-left: none;
-        border-right: none;
-        border-bottom-color: var(--borders-neutral-primary);
-        outline: 2px solid var(--borders-brand-teal-primary);
-        outline-offset: 2px;
+    &:active:not(:disabled) {
+      color: var(--text-brand-teal-primary);
+      background-color: var(--background-neutral-primary);
+      border: 1px solid var(--borders-neutral-primary) !important;
+      border-bottom-color: transparent !important;
+    }
 
-        &:not(.selectedTab) button {
-          color: var(--text-neutral-white-fixed);
-        }
-      }
+    &.selectedTab {
+      color: var(--text-brand-teal-primary);
+      background-color: var(--background-neutral-primary);
+      border: 1px solid var(--borders-neutral-primary);
+      border-bottom-color: transparent;
+    }
 
-      &:active:not(:disabled) {
-        color: var(--text-neutral-white-fixed);
-        background-color: var(--background-neutral-primary-inverse);
-        border: 1px solid var(--neutral-gray-80) !important;
-        border-bottom-color: transparent !important;
-      }
-
-      &.selectedTab {
-        color: var(--text-neutral-white-fixed);
-        background-color: var(--background-neutral-primary-inverse);
-        border: 1px solid var(--neutral-gray-80);
-        border-bottom-color: transparent;
-      }
-
-      &:disabled {
-        cursor: not-allowed;
-        color: var(--neutral-gray-80);
-        background-color: var(--neutral-gray-95);
-        border: 1px solid var(--neutral-gray-80);
-      }
+    &:disabled {
+      cursor: not-allowed;
+      color: var(--text-neutral-disabled);
+      background-color: var(--background-neutral-secondary);
+      border: 1px solid var(--borders-neutral-disabled);
     }
   }
 }


### PR DESCRIPTION
## Summary
- Remove the `mode` prop (`'light' | 'dark'`) from the `Tabs` component — no callers use it
- Delete all `tabs-dark` SCSS blocks for both primary and secondary tab types
- Unwrap `tabs-light` styles so light-mode colors apply unconditionally (~100 lines removed)

## Test plan
- [ ] Verify existing Tabs unit tests pass (`frontend/packages/component-library` test suite)
- [ ] Visual check: primary and secondary tabs render identically to before (they were always using light mode)

🤖 Generated with [Claude Code](https://claude.com/claude-code)