### PR TITLE
GEPW-10: Fix missing `Cdo::GlobalEdition.current_region` value

### DIFF
--- a/dashboard/lib/middleware/global_edition.rb
+++ b/dashboard/lib/middleware/global_edition.rb
@@ -197,6 +197,8 @@ module Middleware
             new_locale:,
           },
         )
+      ensure
+        Cdo::GlobalEdition.current_region = request.cookies[REGION_KEY].presence
       end
 
       private def existing_route?(path = original_path_info)

--- a/lib/cdo/rack/request.rb
+++ b/lib/cdo/rack/request.rb
@@ -151,7 +151,7 @@ module Cdo
     end
 
     def ge_region
-      RequestStore.store[Cdo::GlobalEdition::REGION_KEY]
+      Cdo::GlobalEdition.current_region
     end
 
     # Initialize a private instance of the SessionStore used in Dashboard, so


### PR DESCRIPTION
## Before
<img alt="before" src="https://github.com/user-attachments/assets/30d589c1-315f-4533-a3a9-fb5d5255a64e" />

## After
<img alt="after" src="https://github.com/user-attachments/assets/f9523b4f-cb0a-4774-9391-2545ca1ead64" />

## Links
- JIRA task: [GEPW-10](https://codedotorg.atlassian.net/browse/GEPW-10)
- Related PR: https://github.com/code-dot-org/code-dot-org/pull/71688