### PR TITLE
AI Chat: Analytics for dictation time

### DIFF
--- a/apps/src/aiComponentLibrary/userMessageEditor/UserMessageEditor.tsx
+++ b/apps/src/aiComponentLibrary/userMessageEditor/UserMessageEditor.tsx
@@ -6,7 +6,9 @@ import React, {useState, useMemo, useEffect, useRef, useCallback} from 'react';
 import {AnalyticsProperties} from '@cdo/apps/aichat/types';
 import {commonI18n} from '@cdo/apps/types/locale';
 
-import SpeechToTextButton from './speechToTextButton/SpeechToTextButton';
+import SpeechToTextButton, {
+  type SpeechToTextAnalytics,
+} from './speechToTextButton/SpeechToTextButton';
 
 import moduleStyles from './user-message-editor.module.scss';
 
@@ -29,6 +31,7 @@ export interface UserMessageEditorProps {
   editorContainerClassName?: string;
   customPlaceholder?: string;
   speechToTextEnabled?: boolean;
+  onSpeechToTextFinished?: (analytics: SpeechToTextAnalytics) => void;
   onPaste?: (event: React.ClipboardEvent<HTMLTextAreaElement>) => void;
   children?: React.ReactNode;
 }
@@ -49,6 +52,7 @@ const UserMessageEditor = React.forwardRef<
       customPlaceholder,
       showSubmitLabel = false,
       speechToTextEnabled = false,
+      onSpeechToTextFinished,
       onPaste,
       children,
     },
@@ -171,11 +175,12 @@ const UserMessageEditor = React.forwardRef<
           <div className={moduleStyles.actionButtons}>
             {speechToTextEnabled && (
               <SpeechToTextButton
-                onTranscribed={text => {
+                onTranscribed={(text, analytics) => {
                   onChange(`${userMessage ? userMessage + ' ' : ''}${text}`);
                   setIsRecording(false);
                   setSpeechToTextCount(c => c + 1);
                   setLastDictationCleared(false);
+                  onSpeechToTextFinished?.(analytics);
                 }}
                 onRecordStart={() => setIsRecording(true)}
                 disabled={disabled}

--- a/apps/src/aiComponentLibrary/userMessageEditor/speechToTextButton/SpeechToTextButton.tsx
+++ b/apps/src/aiComponentLibrary/userMessageEditor/speechToTextButton/SpeechToTextButton.tsx
@@ -15,8 +15,11 @@ const unknownErrorMessage = 'An unknown error occurred.';
 const recordingTimeoutMs = 60000;
 
 export interface SpeechToTextAnalytics {
+  /** Amount of time the user spent recording audio. */
   recordTimeSeconds: number;
+  /** Total amount of time from the start of recording to the end of transcription. */
   totalTimeSeconds: number;
+  /** Whether the recording ended due to a timeout. */
   timedOut: boolean;
 }
 

--- a/apps/src/aiComponentLibrary/userMessageEditor/speechToTextButton/SpeechToTextButton.tsx
+++ b/apps/src/aiComponentLibrary/userMessageEditor/speechToTextButton/SpeechToTextButton.tsx
@@ -14,8 +14,14 @@ import styles from './styles.module.scss';
 const unknownErrorMessage = 'An unknown error occurred.';
 const recordingTimeoutMs = 60000;
 
+export interface SpeechToTextAnalytics {
+  recordTimeSeconds: number;
+  totalTimeSeconds: number;
+  timedOut: boolean;
+}
+
 interface SpeechToTextButtonProps {
-  onTranscribed: (text: string) => void;
+  onTranscribed: (text: string, analytics: SpeechToTextAnalytics) => void;
   onRecordStart?: () => void;
   disabled?: boolean;
 }
@@ -30,6 +36,7 @@ const SpeechToTextButton: React.FC<SpeechToTextButtonProps> = ({
   const [errorMessage, setErrorMessage] = useState<string>();
   const timeoutRef = useRef<NodeJS.Timeout>();
   const recorderRef = useRef<AudioRecorder>(new AudioRecorder());
+  const startTimeRef = useRef<number>(Date.now());
 
   const onStartRecording = async () => {
     if (timeoutRef.current) {
@@ -41,7 +48,11 @@ const SpeechToTextButton: React.FC<SpeechToTextButtonProps> = ({
       if (startState === 'Started') {
         setIsRecording(true);
         onRecordStart?.();
-        timeoutRef.current = setTimeout(onEndRecording, recordingTimeoutMs);
+        startTimeRef.current = Date.now();
+        timeoutRef.current = setTimeout(
+          () => onEndRecording(true),
+          recordingTimeoutMs
+        );
       } else {
         setErrorMessage(
           startState === 'PermissionDenied'
@@ -55,7 +66,7 @@ const SpeechToTextButton: React.FC<SpeechToTextButtonProps> = ({
     }
   };
 
-  const onEndRecording = async () => {
+  const onEndRecording = async (timedOut = false) => {
     if (timeoutRef.current) {
       clearTimeout(timeoutRef.current);
     }
@@ -63,10 +74,14 @@ const SpeechToTextButton: React.FC<SpeechToTextButtonProps> = ({
     setIsTranscribing(true);
     try {
       const audio = await recorderRef.current.stop();
+      const recordTimeSeconds = (Date.now() - startTimeRef.current) / 1000;
+
       const aichatClientApi = await getClientApi();
       const text = await aichatClientApi.transcribeAudio(audio);
+      const totalTimeSeconds = (Date.now() - startTimeRef.current) / 1000;
+
       setIsTranscribing(false);
-      onTranscribed(text);
+      onTranscribed(text, {recordTimeSeconds, totalTimeSeconds, timedOut});
     } catch (error) {
       console.error(error);
       setErrorMessage(unknownErrorMessage);
@@ -126,7 +141,7 @@ const SpeechToTextButton: React.FC<SpeechToTextButtonProps> = ({
             <MuiIconButton
               variant="outlined"
               size="extraSmall"
-              onClick={isRecording ? onEndRecording : onStartRecording}
+              onClick={isRecording ? () => onEndRecording() : onStartRecording}
               disabled={!canRecord || isTranscribing || disabled}
               color={isRecording ? 'white' : 'secondary'}
               className={classNames(isRecording && styles.recording)}

--- a/apps/src/aichat/views/UserChatMessageEditor.tsx
+++ b/apps/src/aichat/views/UserChatMessageEditor.tsx
@@ -2,15 +2,18 @@ import {extension as mimeToExtension} from 'mime-types';
 import React, {useCallback, useEffect, useRef, useState} from 'react';
 
 import {useAiChatDisabled} from '@cdo/apps/aichat/context/aiChatDisabledContext';
+import {type SpeechToTextAnalytics} from '@cdo/apps/aiComponentLibrary/userMessageEditor/speechToTextButton/SpeechToTextButton';
 import UserMessageEditor from '@cdo/apps/aiComponentLibrary/userMessageEditor/UserMessageEditor';
 import AiTutorEnglishOnlyWarning from '@cdo/apps/aiTutor/views/AiTutorEnglishOnlyWarning';
 import {isViewingAiTutorVersionFileUpdates} from '@cdo/apps/lab2/redux/lab2ReduxSelectors';
+import {EVENTS} from '@cdo/apps/metrics/AnalyticsConstants';
 import experiments from '@cdo/apps/util/experiments';
 import {useAppDispatch, useAppSelector} from '@cdo/apps/util/reduxHooks';
 
 import supportsClientApi from '../api/supportsClientApi';
 import {
   selectIsWaitingForChatResponse,
+  sendAnalytics,
   submitChatContents,
   uploadFiles,
 } from '../redux';
@@ -184,6 +187,15 @@ const UserChatMessageEditor: React.FunctionComponent<
     [canUploadFiles, buildAssetUrl, dispatch, acceptedFileTypes]
   );
 
+  const onSpeechToTextFinished = useCallback(
+    (analytics: SpeechToTextAnalytics) => {
+      if (speechToTextEnabled) {
+        dispatch(sendAnalytics(EVENTS.AICHAT_DICTATION_COMPLETED, analytics));
+      }
+    },
+    [dispatch, speechToTextEnabled]
+  );
+
   return (
     <>
       {chatButtons && chatButtons.length > 0 && !chatDisabled && (
@@ -200,6 +212,7 @@ const UserChatMessageEditor: React.FunctionComponent<
         disabled={disabled}
         editorContainerClassName={editorContainerClassName}
         speechToTextEnabled={speechToTextEnabled}
+        onSpeechToTextFinished={onSpeechToTextFinished}
         onPaste={onPaste}
         ref={inputRef}
       >

--- a/apps/src/metrics/AnalyticsConstants.js
+++ b/apps/src/metrics/AnalyticsConstants.js
@@ -497,6 +497,7 @@ const EVENTS = {
   AICHAT_MULTIMODAL_UPLOAD_STAGED: 'User stages multimodal assets',
   AICHAT_UNSUPPORTED_MODEL_SELECTED:
     'User had previously selected a model that is no longer supported',
+  AICHAT_DICTATION_COMPLETED: 'User completes dictation in aichat',
 
   // AI chat response copied. Shared across features; check event properties for usage and clientType
   // to determine feature.


### PR DESCRIPTION
Adds timing analytics for dictation in AI Chat (speech to text) under the event `'User completes dictation in aichat'`
- recordingTimeSeconds: amount of time the user spent recording audio
- totalTimeSeconds: total time the user spent recording + the roundtrip transcription time
- timedOut: whether the recording stopped due to automatic timeout.

<img width="1326" height="69" alt="Screenshot 2026-04-09 at 1 51 49 PM" src="https://github.com/user-attachments/assets/f1c081bb-04ca-4d87-abb7-9c52fa0929c3" />


## Links
- Jira: https://codedotorg.atlassian.net/browse/SL-1640