### PR TITLE
[Dance] Fix age dropdown label WCAG violation

### DIFF
--- a/apps/src/templates/AgeDialog.jsx
+++ b/apps/src/templates/AgeDialog.jsx
@@ -104,7 +104,7 @@ class AgeDialog extends Component {
           <div>
             <div style={styles.middle}>
               <div style={styles.middleCell}>
-                {i18n.provideAge()}
+                <label htmlFor="uitest-age-selector">{i18n.provideAge()}</label>
                 <div style={styles.age}>
                   <AgeDropdown
                     style={styles.dropdown}


### PR DESCRIPTION
The Age dropdown label was not programmatically tied to the dropdown. This adds an htmlfor to the existing label so that a screenreader user can tell what the label is for. 

Thanks @dju90 for the start!

Before:

https://github.com/user-attachments/assets/8a3eca90-db73-4261-9859-a299b94b609e



After:

https://github.com/user-attachments/assets/8c1ed4fa-0352-4215-a31c-f4cae5cc9d4e



## Links

- Jira: https://codedotorg.atlassian.net/browse/SL-1666

## Testing story
<!-- How was this tested? Manual steps, adhoc links, automated tests, or why testing isn't needed. -->



## Deployment notes
<!-- Delete this section if it's a standard merge-and-deploy.
     Otherwise: migrations, feature flags, coordination, caching impacts, etc. -->



## Privacy and security
<!-- Delete this section if there is no privacy/security impact.
     Otherwise: new PII, auth changes, API surface changes, etc. -->

