### PR TITLE
Add header-only COVID-19 Cases per Country dataset

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -42,7 +42,6 @@ apps/i18n/tts_keys/** !text !filter !merge !diff
 apps/static/aichat/modelDescriptions.json !text !filter !merge !diff
 dashboard/app/assets/javascripts/** !text !filter !merge !diff
 dashboard/app/assets/stylesheets/** !text !filter !merge !diff
-dashboard/config/datablock_storage/datasets/covid-19-cases-per-country.json !text !filter !merge !diff
 dashboard/config/locales/**/*en.yml !text !filter !merge !diff
 dashboard/config/locales/**/*en.json !text !filter !merge !diff
 dashboard/public/**/README.md !text !filter !merge !diff

--- a/.gitattributes
+++ b/.gitattributes
@@ -42,6 +42,7 @@ apps/i18n/tts_keys/** !text !filter !merge !diff
 apps/static/aichat/modelDescriptions.json !text !filter !merge !diff
 dashboard/app/assets/javascripts/** !text !filter !merge !diff
 dashboard/app/assets/stylesheets/** !text !filter !merge !diff
+dashboard/config/datablock_storage/datasets/covid-19-cases-per-country.json !text !filter !merge !diff
 dashboard/config/locales/**/*en.yml !text !filter !merge !diff
 dashboard/config/locales/**/*en.json !text !filter !merge !diff
 dashboard/public/**/README.md !text !filter !merge !diff

--- a/dashboard/config/datablock_storage/datasets/covid-19-cases-per-country.json
+++ b/dashboard/config/datablock_storage/datasets/covid-19-cases-per-country.json
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:662ef9a3db861a95a8b708bea063fbe075286f7689222d740e772771a30bcdd0
-size 130
+oid sha256:ec7837ba2d191babb524402193adeb917202efef87e16bd6ce09fa779a43a338
+size 147

--- a/dashboard/config/datablock_storage/datasets/covid-19-cases-per-country.json
+++ b/dashboard/config/datablock_storage/datasets/covid-19-cases-per-country.json
@@ -1,4 +1,3 @@
-{
-  "table_name": "COVID-19 Cases per Country",
-  "csv": "id,Date,Country,Total Confirmed Cases,Total Recovered,Total Deaths\n1,N/A,N/A,0,0,0\n"
-}
+version https://git-lfs.github.com/spec/v1
+oid sha256:ec7837ba2d191babb524402193adeb917202efef87e16bd6ce09fa779a43a338
+size 147

--- a/dashboard/config/datablock_storage/datasets/covid-19-cases-per-country.json
+++ b/dashboard/config/datablock_storage/datasets/covid-19-cases-per-country.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:662ef9a3db861a95a8b708bea063fbe075286f7689222d740e772771a30bcdd0
+size 130

--- a/dashboard/config/datablock_storage/datasets/covid-19-cases-per-country.json
+++ b/dashboard/config/datablock_storage/datasets/covid-19-cases-per-country.json
@@ -1,3 +1,4 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ec7837ba2d191babb524402193adeb917202efef87e16bd6ce09fa779a43a338
-size 147
+{
+  "table_name": "COVID-19 Cases per Country",
+  "csv": "id,Date,Country,Total Confirmed Cases,Total Recovered,Total Deaths\n1,N/A,N/A,0,0,0\n"
+}


### PR DESCRIPTION
## What changed
Adds `dashboard/config/datablock_storage/datasets/covid-19-cases-per-country.json` back to datablock storage so projects that still reference `COVID-19 Cases per Country` can resolve the shared dataset again.

The seed uses the original table name and column shape, with a single placeholder row so the existing CSV importer does not reject it as empty.

## Why this changed
The live `COVID-19 Cases per Country` dataset was removed in 2024 because the upstream source was stale and broken, but some projects still depend on the shared dataset name.

## Impact
Projects that still point at this shared dataset can import the table again without restoring the old live country data feed.

## Validation
Ran `./tools/hooks/pre-commit`.
Verified the JSON parses.
Verified the CSV columns are:
`id,Date,Country,Total Confirmed Cases,Total Recovered,Total Deaths`.
Verified the seed payload is non-empty for the current importer.

## Dataset JSON
```json
{
  "table_name": "COVID-19 Cases per Country",
  "csv": "id,Date,Country,Total Confirmed Cases,Total Recovered,Total Deaths\n1,N/A,N/A,0,0,0\n"
}
```
