### PR TITLE
Web Lab 2: add documentation link

### DIFF
--- a/apps/src/codebridge/InfoPanel/InfoPanel.tsx
+++ b/apps/src/codebridge/InfoPanel/InfoPanel.tsx
@@ -130,6 +130,15 @@ export const InfoPanel: React.FunctionComponent<InfoPanelProps> = ({
     }
   };
 
+  const documentationUrl = useMemo(() => {
+    if (appName === 'pythonlab') {
+      return '/docs/ide/pythonlab';
+    } else if (appName === 'weblab2') {
+      return '/docs/ide/weblab2';
+    }
+    return undefined;
+  }, [appName]);
+
   return (
     <div style={style} className={className}>
       <ResourcePanel
@@ -153,9 +162,7 @@ export const InfoPanel: React.FunctionComponent<InfoPanelProps> = ({
         aiTutorMultimodalEnabled={aiTutorMultimodalEnabled}
         aiTutorChatButtonData={aiTutorChatButtonData}
         aiTutorResponseSchemaSettings={aiTutorResponseSchemaSettings}
-        documentationUrl={
-          appName === 'pythonlab' ? '/docs/ide/pythonlab' : undefined // For now, only python lab supports documentation.
-        }
+        documentationUrl={documentationUrl}
         backpackProps={backpackProps}
         onImageFlagged={onImageFlagged}
         hasInstructionsDrawer={appName === 'weblab2'}


### PR DESCRIPTION
Adds the documentation button to web lab 2 that links to /docs/ide/weblab2.

## Screenshot
<img width="396" height="241" alt="Screenshot 2026-04-09 at 1 01 42 PM" src="https://github.com/user-attachments/assets/8e3edd94-4348-4901-ac6c-9d1690853b34" />


## Links

- Jira: [AFL-556](https://codedotorg.atlassian.net/browse/AFL-556)

## Testing story
Tested locally



