### PR TITLE
feat(component-library): add SignedInUserButton to Header

### DIFF
--- a/frontend/apps/studio/entrypoints/application.tsx
+++ b/frontend/apps/studio/entrypoints/application.tsx
@@ -5,6 +5,7 @@ import {createRoot} from 'react-dom/client';
 import {initializeCore} from '@code-dot-org/core';
 import {localizationPlugin} from '@code-dot-org/core/plugins/localization';
 import {observabilityPlugin} from '@code-dot-org/core/plugins/observability';
+import {injectFontAwesome} from '@code-dot-org/fonts';
 
 import router from '@/modules/router';
 
@@ -13,8 +14,8 @@ const mount = document.getElementById('vite-root');
 
 if (typeof window !== 'undefined') {
   initializeCore({plugins: [localizationPlugin, observabilityPlugin]});
+  injectFontAwesome();
 }
-console.log(window.__CODE_STUDIO__);
 
 if (mount) {
   const root = createRoot(mount);

--- a/frontend/packages/component-library/src/header/Header.tsx
+++ b/frontend/packages/component-library/src/header/Header.tsx
@@ -9,6 +9,8 @@ import {
 } from '@mui/material';
 import {FunctionComponent} from 'react';
 
+import SignedInUserButton, {UserAuthProp} from './SignedInUserButton';
+
 interface MenuItem {
   label: string;
   href: string;
@@ -19,6 +21,7 @@ export interface HeaderProps {
   /** Site logo image source */
   logoImageUrl: string;
   menuItems: MenuItem[];
+  userAuth?: UserAuthProp;
 }
 
 const styles = {
@@ -66,6 +69,7 @@ const Header: FunctionComponent<HeaderProps> = ({
   logoImageUrl,
   brandName,
   menuItems,
+  userAuth,
 }) => {
   return (
     <Box component="header">
@@ -105,6 +109,19 @@ const Header: FunctionComponent<HeaderProps> = ({
                 </ListItem>
               ))}
           </List>
+          {userAuth && (
+            <Box
+              sx={{
+                marginLeft: 'auto',
+                display: 'flex',
+                alignItems: 'center',
+                paddingRight: 2,
+                backgroundColor: 'var(--background-brand-teal-primary)',
+              }}
+            >
+              <SignedInUserButton userAuth={userAuth} />
+            </Box>
+          )}
         </Toolbar>
       </AppBar>
     </Box>

--- a/frontend/packages/component-library/src/header/SignedInUserButton.tsx
+++ b/frontend/packages/component-library/src/header/SignedInUserButton.tsx
@@ -1,7 +1,12 @@
-import {Box, Button, Menu, MenuItem} from '@mui/material';
-import {FunctionComponent, MouseEvent, useState} from 'react';
+import {Box} from '@mui/material';
+import {FunctionComponent} from 'react';
 
-import FontAwesomeV6Icon from '../fontAwesomeV6Icon';
+import {useDropdownContext} from '@/common/contexts/DropdownContext';
+import CustomDropdown from '@/dropdown/CustomDropdown';
+import FontAwesomeV6Icon from '@/fontAwesomeV6Icon';
+import Link from '@/link/Link';
+
+import moduleStyles from './signedInUserButton.module.scss';
 
 export type UserAuthProp =
   | {isSignedIn: false}
@@ -11,8 +16,6 @@ export interface SignedInUserButtonProps {
   userAuth: UserAuthProp;
 }
 
-const menuId = 'signed-in-user-menu';
-
 const SUB_MENU_ITEMS = [
   {label: 'My projects', href: '/projects'},
   // TODO: wire up pair programming URL
@@ -21,94 +24,87 @@ const SUB_MENU_ITEMS = [
   {label: 'Sign out', href: '/users/sign_out'},
 ] as const;
 
-const styles = {
-  button: {
-    // Use && to generate .cls.cls specificity, beating MUI's internal
-    // per-variant/per-color overrides which sit at single-class specificity.
-    '&&': {
-      typography: 'body3',
-      backgroundColor: 'var(--background-brand-teal-primary)',
-      color: 'white',
-      border: '1px solid white',
-      borderRadius: '4px',
-      boxShadow: 'none',
-      textTransform: 'none' as const,
-      maxWidth: '120px',
-      minWidth: 0,
-      paddingLeft: '1rem',
-      paddingRight: '0.5rem',
-    },
-    '&&:hover, &&:active, &&:focus-visible': {
-      backgroundColor: 'var(--background-brand-teal-primary)',
-      color: 'white',
-      boxShadow: 'none',
-    },
-    '&& .MuiButton-endIcon': {color: 'white'},
-  },
-  firstName: {
-    overflow: 'hidden',
-    textOverflow: 'ellipsis',
-    whiteSpace: 'nowrap' as const,
+// Rendered inside DropdownProviderWrapper so useDropdownContext resolves.
+// Must be at module scope — inlining creates a new component type per render (remounts).
+const ChevronIcon = () => {
+  const {activeDropdownName} = useDropdownContext();
+  const icon =
+    activeDropdownName === 'signed-in-user' ? 'chevron-up' : 'chevron-down';
+  return <FontAwesomeV6Icon iconName={icon} iconStyle="solid" />;
+};
+
+// Use && to generate .cls.cls specificity, beating MUI's internal
+// per-variant/per-color overrides which sit at single-class specificity.
+const triggerSx = {
+  '&&': {
+    typography: 'body3',
+    backgroundColor: 'var(--background-brand-teal-primary)',
+    color: 'white',
+    border: '1px solid white',
+    borderRadius: '4px',
+    boxShadow: 'none',
+    textTransform: 'none' as const,
+    maxWidth: '120px',
     minWidth: 0,
-    flex: '1 1 auto',
+    paddingLeft: '1rem',
+    paddingRight: '0.5rem',
   },
-} as const;
+  '&&:hover, &&:active, &&:focus-visible': {
+    backgroundColor: 'var(--background-brand-teal-primary)',
+    color: 'white',
+    boxShadow: 'none',
+  },
+  '&& .MuiButton-endIcon': {color: 'white'},
+};
 
 const SignedInUserButton: FunctionComponent<SignedInUserButtonProps> = ({
   userAuth,
 }) => {
-  const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
-  const open = anchorEl !== null;
-
   if (!userAuth.isSignedIn) {
     return null;
   }
 
-  const handleClick = (e: MouseEvent<HTMLButtonElement>) => {
-    setAnchorEl(e.currentTarget);
-  };
-
-  const handleClose = () => setAnchorEl(null);
-
   return (
-    <>
-      <Button
-        disableElevation
-        aria-label="Account menu"
-        aria-controls={open ? menuId : undefined}
-        aria-haspopup="true"
-        aria-expanded={open ? 'true' : undefined}
-        onClick={handleClick}
-        sx={styles.button}
-        endIcon={
-          <FontAwesomeV6Icon iconName={open ? 'chevron-up' : 'chevron-down'} />
-        }
-      >
-        <Box component="span" sx={styles.firstName}>
-          {userAuth.firstName}
-        </Box>
-      </Button>
-      <Menu
-        id={menuId}
-        anchorEl={anchorEl}
-        open={open}
-        onClose={handleClose}
-        anchorOrigin={{vertical: 'bottom', horizontal: 'right'}}
-        transformOrigin={{vertical: 'top', horizontal: 'right'}}
-      >
-        {SUB_MENU_ITEMS.map(item => (
-          <MenuItem
-            key={item.label}
-            component="a"
-            href={item.href}
-            onClick={handleClose}
-            sx={{typography: 'body3'}}
+    <CustomDropdown
+      name="signed-in-user"
+      labelText={userAuth.firstName}
+      size="m"
+      menuPlacement="right"
+      aria-label="Account menu"
+      useMuiButtonAsTrigger
+      triggerButtonProps={{
+        'aria-label': 'Account menu',
+        disableElevation: true,
+        sx: triggerSx,
+        endIcon: <ChevronIcon />,
+        children: (
+          <Box
+            component="span"
+            sx={{
+              overflow: 'hidden',
+              textOverflow: 'ellipsis',
+              whiteSpace: 'nowrap',
+              minWidth: 0,
+              flex: '1 1 auto',
+            }}
           >
-            {item.label}
-          </MenuItem>
+            {userAuth.firstName}
+          </Box>
+        ),
+      }}
+    >
+      <ul>
+        {SUB_MENU_ITEMS.map(item => (
+          <li key={item.label}>
+            <Link
+              text={item.label}
+              href={item.href}
+              className={moduleStyles.menuItem}
+            />
+          </li>
         ))}
-      </Menu>
-    </>
+      </ul>
+    </CustomDropdown>
   );
 };
 

--- a/frontend/packages/component-library/src/header/SignedInUserButton.tsx
+++ b/frontend/packages/component-library/src/header/SignedInUserButton.tsx
@@ -1,0 +1,115 @@
+import {Box, Button, Menu, MenuItem} from '@mui/material';
+import {FunctionComponent, MouseEvent, useState} from 'react';
+
+import FontAwesomeV6Icon from '../fontAwesomeV6Icon';
+
+export type UserAuthProp =
+  | {isSignedIn: false}
+  | {isSignedIn: true; firstName: string};
+
+export interface SignedInUserButtonProps {
+  userAuth: UserAuthProp;
+}
+
+const menuId = 'signed-in-user-menu';
+
+const SUB_MENU_ITEMS = [
+  {label: 'My projects', href: '/projects'},
+  // TODO: wire up pair programming URL
+  {label: 'Pair programming', href: '#'},
+  {label: 'Account settings', href: '/users/edit'},
+  {label: 'Sign out', href: '/users/sign_out'},
+] as const;
+
+const styles = {
+  button: {
+    // Use && to generate .cls.cls specificity, beating MUI's internal
+    // per-variant/per-color overrides which sit at single-class specificity.
+    '&&': {
+      typography: 'body3',
+      backgroundColor: 'var(--background-brand-teal-primary)',
+      color: 'white',
+      border: '1px solid white',
+      borderRadius: '4px',
+      boxShadow: 'none',
+      textTransform: 'none' as const,
+      maxWidth: '120px',
+      minWidth: 0,
+      paddingLeft: '1rem',
+      paddingRight: '0.5rem',
+    },
+    '&&:hover, &&:active, &&:focus-visible': {
+      backgroundColor: 'var(--background-brand-teal-primary)',
+      color: 'white',
+      boxShadow: 'none',
+    },
+    '&& .MuiButton-endIcon': {color: 'white'},
+  },
+  firstName: {
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+    whiteSpace: 'nowrap' as const,
+    minWidth: 0,
+    flex: '1 1 auto',
+  },
+} as const;
+
+const SignedInUserButton: FunctionComponent<SignedInUserButtonProps> = ({
+  userAuth,
+}) => {
+  const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
+  const open = anchorEl !== null;
+
+  if (!userAuth.isSignedIn) {
+    return null;
+  }
+
+  const handleClick = (e: MouseEvent<HTMLButtonElement>) => {
+    setAnchorEl(e.currentTarget);
+  };
+
+  const handleClose = () => setAnchorEl(null);
+
+  return (
+    <>
+      <Button
+        disableElevation
+        aria-label="Account menu"
+        aria-controls={open ? menuId : undefined}
+        aria-haspopup="true"
+        aria-expanded={open ? 'true' : undefined}
+        onClick={handleClick}
+        sx={styles.button}
+        endIcon={
+          <FontAwesomeV6Icon iconName={open ? 'chevron-up' : 'chevron-down'} />
+        }
+      >
+        <Box component="span" sx={styles.firstName}>
+          {userAuth.firstName}
+        </Box>
+      </Button>
+      <Menu
+        id={menuId}
+        anchorEl={anchorEl}
+        open={open}
+        onClose={handleClose}
+        anchorOrigin={{vertical: 'bottom', horizontal: 'right'}}
+        transformOrigin={{vertical: 'top', horizontal: 'right'}}
+      >
+        {SUB_MENU_ITEMS.map(item => (
+          <MenuItem
+            key={item.label}
+            component="a"
+            href={item.href}
+            onClick={handleClose}
+            sx={{typography: 'body3'}}
+          >
+            {item.label}
+          </MenuItem>
+        ))}
+      </Menu>
+    </>
+  );
+};
+
+export default SignedInUserButton;

--- a/frontend/packages/component-library/src/header/index.ts
+++ b/frontend/packages/component-library/src/header/index.ts
@@ -1,1 +1,5 @@
 export {default, type HeaderProps} from './Header';
+export {
+  default as SignedInUserButton,
+  type UserAuthProp,
+} from './SignedInUserButton';

--- a/frontend/packages/component-library/src/header/signedInUserButton.module.scss
+++ b/frontend/packages/component-library/src/header/signedInUserButton.module.scss
@@ -1,0 +1,17 @@
+// Double-class specificity [0,2,0] beats the Link module's single-class
+// link-body-common mixin that applies semi-bold.
+.menuItem.menuItem {
+  display: block;
+  width: 100%;
+  padding: 0.5rem 1rem;
+  font-weight: normal;
+  text-decoration: none;
+  color: var(--text-neutral-primary);
+  white-space: nowrap;
+
+  &:visited,
+  &:hover,
+  &:active {
+    color: var(--text-neutral-primary);
+  }
+}

--- a/frontend/packages/component-library/src/header/stories/Header.story.tsx
+++ b/frontend/packages/component-library/src/header/stories/Header.story.tsx
@@ -29,7 +29,7 @@ const Template: StoryFn<HeaderProps> = (args: HeaderProps) => (
 
 export const Default = Template.bind({});
 
-const SIGNED_OUT_MENU_ITEMS = [
+const MENU_ITEMS = [
   {label: 'Learn', href: '/students'},
   {label: 'Teach', href: '/teach'},
   {label: 'Districts', href: '/administrators'},
@@ -41,5 +41,20 @@ const SIGNED_OUT_MENU_ITEMS = [
 
 Default.args = {
   logoImageUrl: logoImage,
-  menuItems: SIGNED_OUT_MENU_ITEMS,
+  menuItems: MENU_ITEMS,
+  userAuth: {isSignedIn: true, firstName: 'Coder'},
+};
+
+export const SignedInLongName = Template.bind({});
+SignedInLongName.args = {
+  logoImageUrl: logoImage,
+  menuItems: MENU_ITEMS,
+  userAuth: {isSignedIn: true, firstName: 'Bartholomew-Maximilian'},
+};
+
+export const SignedOut = Template.bind({});
+SignedOut.args = {
+  logoImageUrl: logoImage,
+  menuItems: MENU_ITEMS,
+  userAuth: {isSignedIn: false},
 };


### PR DESCRIPTION
Add SignedInUserButton component that renders a MUI Button with dropdown menu (My projects, Pair programming, Account settings, Sign out) when a user is signed in. Wire it into Header via optional userAuth prop; add Storybook stories for signed-in, signed-in with long name, and signed-out states. Export component and UserAuthProp type from header index.

<img width="274" height="262" alt="image" src="https://github.com/user-attachments/assets/c22d2912-b0be-4950-97e4-9bded2391e1e" />
