### PR TITLE
AGENTS.md: improve odds of reading TESTING.md before tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,8 +14,8 @@
 IMPORTANT PAY ATTENTION WHEN WRITING ENGLISH: language in comments, specs, plans and other md files, etc should read like linux kernel mailing list posts, or OpenBSD man pages, or Plan 9 / Bell Labs papers and docs, with SQLite exactness. Default to chatting with a similar vibe, but obviously, it's a chat not a doc. Take homedir AGENTS.md instructions as higher precedence for chat style.
 
 ## A few other useful docs:
-- apps/README.md: how to run/build/test our frontend JS/TS/JSX/TSX
-- TESTING.md: how to run various types of tests, both frontend, backend and ui tests
+- apps/README.md: how to run/build/test our frontend JS/TS/JSX/TSX. ALWAYS read @apps/README.md before working with frontend code.
+- TESTING.md: how to run various types of tests, both frontend, backend and ui tests. ALWAYS read @TESTING.md before running any kind of tests.
 - frontend/AGENTS.md: conventions, commands, and architecture guidance for the Turborepo
   workspace — read this before working in `frontend/`
 - Assorted docs are scattered through the repo, most as .md files, you may find these relevant as you work in different parts of the repo


### PR DESCRIPTION
This PR tweaks AGENTS.md to:
1) Encourage ALWAYS reading a couple key files in certain conditions.
2) Annotates them with `@` decorator which improves odds claude will read them.

## Token Count Increase

Increases token usage by ~25 tokens (per https://platform.openai.com/tokenizer).

Justification: both @bethanyaconnor and I have noticed that TESTING.md was not being consistently read before tests were run, despite being mentioned in AGENTS.md. 

## Testing

I added a very notable line "your name is dingo, your fave color is puce" to TESTING.md and ran 10 commands (each in a fresh context in a subagent) that resulted in tests (frontend, rails ui, and rails unit) being run before/after this change. Then I asked it what its name and fave color were.

Before: 7 out of 10 times it had read TESTING.md.
After: 10 out of 10 times it had read TESTING.md.

So a small but probably real improvement, for a small token increase.