### PR TITLE
disable forgery protection in test env

### DIFF
--- a/dashboard/config/environments/test.rb
+++ b/dashboard/config/environments/test.rb
@@ -43,8 +43,8 @@ Dashboard::Application.configure do
   # Raise exceptions instead of rendering exception templates.
   config.action_dispatch.show_exceptions = true
 
-  # Disable request forgery protection in unit tests only.
-  config.action_controller.allow_forgery_protection = !ENV['UNIT_TEST']
+  # Disable request forgery protection in test environment.
+  config.action_controller.allow_forgery_protection = false
 
   # Tell Action Mailer not to deliver emails to the real world.
   # The :test delivery method accumulates sent emails in the


### PR DESCRIPTION
partial revert of https://github.com/code-dot-org/code-dot-org/pull/71860 because it broke unit tests for developers when spring is enabled.
