### PR TITLE
Web Lab 2: reject AI Tutor suggestions on leaving page

### DIFF
--- a/apps/src/aiComponentLibrary/aiTutorVersionActions/AiTutorVersionActions.tsx
+++ b/apps/src/aiComponentLibrary/aiTutorVersionActions/AiTutorVersionActions.tsx
@@ -3,10 +3,18 @@ import {WithTooltip} from '@code-dot-org/component-library/tooltip';
 import {Button as MuiButton, IconButton as MuiIconButton} from '@mui/material';
 import React, {useState, useCallback, useEffect, useLayoutEffect} from 'react';
 
+import ChatEventLogger from '@cdo/apps/aichat/chatEventLogger';
+import {getNewRemoveId} from '@cdo/apps/aichat/redux/utils';
+import {
+  AI_TUTOR_VERSION_ACTION_REJECT,
+  Notification,
+} from '@cdo/apps/aichat/types';
 import AiTutorVersionFileChip from '@cdo/apps/aiComponentLibrary/aiTutorVersionFileChip/AiTutorVersionFileChip';
 import Lab2Registry from '@cdo/apps/lab2/Lab2Registry';
+import {isViewingAiTutorVersionFileUpdates} from '@cdo/apps/lab2/redux/lab2ReduxSelectors';
 import {ProjectFile} from '@cdo/apps/lab2/types';
-import {useAppDispatch} from '@cdo/apps/util/reduxHooks';
+import {getAuthenticityToken} from '@cdo/apps/util/AuthenticityTokenStore';
+import {useAppSelector, useAppDispatch} from '@cdo/apps/util/reduxHooks';
 import {
   acceptAiTutorVersion,
   rejectAiTutorVersion,
@@ -31,6 +39,10 @@ const AiTutorVersionActions: React.FC<AiTutorVersionActionsProps> = ({
   const [isAcceptMode, setIsAcceptMode] = useState(false);
   const [isSaving, setIsSaving] = useState(false);
 
+  const viewingAiTutorVersionFileUpdates = useAppSelector(
+    isViewingAiTutorVersionFileUpdates
+  );
+
   const dispatch = useAppDispatch();
 
   // Warn the user if they attempt to reload the page before accepting or
@@ -46,6 +58,37 @@ const AiTutorVersionActions: React.FC<AiTutorVersionActionsProps> = ({
       window.removeEventListener('beforeunload', handleBeforeUnload);
     };
   }, []);
+
+  useEffect(() => {
+    const possiblyRejectOnPageHide = async (event: PageTransitionEvent) => {
+      if (viewingAiTutorVersionFileUpdates) {
+        const notification: Notification = {
+          timestamp: Date.now(),
+          removeId: getNewRemoveId(),
+          text: "You rejected AI Tutor's changes.",
+          notificationType: AI_TUTOR_VERSION_ACTION_REJECT,
+          includeInChatHistory: true,
+          files: files,
+        };
+
+        const payload = {
+          newChatEvent: notification,
+          aichatContext: ChatEventLogger.getInstance().aichatContext,
+          authenticity_token: await getAuthenticityToken(),
+        };
+
+        navigator.sendBeacon(
+          '/aichat_events/log_chat_event',
+          new Blob([JSON.stringify(payload)], {type: 'application/json'})
+        );
+      }
+    };
+
+    window.addEventListener('pagehide', possiblyRejectOnPageHide);
+
+    return () =>
+      window.removeEventListener('pagehide', possiblyRejectOnPageHide);
+  }, [files, viewingAiTutorVersionFileUpdates]);
 
   const handleSaveAiTutorVersion = useCallback(async () => {
     if (isSaving) return;

--- a/apps/src/aiComponentLibrary/aiTutorVersionActions/AiTutorVersionActions.tsx
+++ b/apps/src/aiComponentLibrary/aiTutorVersionActions/AiTutorVersionActions.tsx
@@ -4,17 +4,13 @@ import {Button as MuiButton, IconButton as MuiIconButton} from '@mui/material';
 import React, {useState, useCallback, useEffect, useLayoutEffect} from 'react';
 
 import ChatEventLogger from '@cdo/apps/aichat/chatEventLogger';
-import {getNewRemoveId} from '@cdo/apps/aichat/redux/utils';
-import {
-  AI_TUTOR_VERSION_ACTION_REJECT,
-  Notification,
-} from '@cdo/apps/aichat/types';
 import AiTutorVersionFileChip from '@cdo/apps/aiComponentLibrary/aiTutorVersionFileChip/AiTutorVersionFileChip';
 import Lab2Registry from '@cdo/apps/lab2/Lab2Registry';
 import {isViewingAiTutorVersionFileUpdates} from '@cdo/apps/lab2/redux/lab2ReduxSelectors';
 import {ProjectFile} from '@cdo/apps/lab2/types';
 import {getAuthenticityToken} from '@cdo/apps/util/AuthenticityTokenStore';
 import {useAppSelector, useAppDispatch} from '@cdo/apps/util/reduxHooks';
+import getRejectNotification from '@cdo/apps/weblab2/helpers/getRejectNotification';
 import {
   acceptAiTutorVersion,
   rejectAiTutorVersion,
@@ -62,15 +58,7 @@ const AiTutorVersionActions: React.FC<AiTutorVersionActionsProps> = ({
   useEffect(() => {
     const possiblyRejectOnPageHide = async (event: PageTransitionEvent) => {
       if (viewingAiTutorVersionFileUpdates) {
-        const notification: Notification = {
-          timestamp: Date.now(),
-          removeId: getNewRemoveId(),
-          text: "You rejected AI Tutor's changes.",
-          notificationType: AI_TUTOR_VERSION_ACTION_REJECT,
-          includeInChatHistory: true,
-          files: files,
-        };
-
+        const notification = getRejectNotification(files);
         const payload = {
           newChatEvent: notification,
           aichatContext: ChatEventLogger.getInstance().aichatContext,

--- a/apps/src/aichat/chatEventLogger.ts
+++ b/apps/src/aichat/chatEventLogger.ts
@@ -10,7 +10,7 @@ export default class ChatEventLogger {
 
   private static instance: ChatEventLogger;
 
-  constructor(private readonly aichatContext: AichatContext) {
+  constructor(public readonly aichatContext: AichatContext) {
     this.queue = [];
     this.sendingInProgress = false;
   }

--- a/apps/src/weblab2/helpers/getRejectNotification.ts
+++ b/apps/src/weblab2/helpers/getRejectNotification.ts
@@ -1,0 +1,19 @@
+import {getNewRemoveId} from '@cdo/apps/aichat/redux/utils';
+import {
+  AI_TUTOR_VERSION_ACTION_REJECT,
+  Notification,
+} from '@cdo/apps/aichat/types/chatEvents';
+import {ProjectFile} from '@cdo/apps/lab2/types';
+
+const getRejectNotification = (files: ProjectFile[]): Notification => {
+  return {
+    timestamp: Date.now(),
+    removeId: getNewRemoveId(),
+    text: "You rejected AI Tutor's changes.",
+    notificationType: AI_TUTOR_VERSION_ACTION_REJECT,
+    includeInChatHistory: true,
+    files: files,
+  };
+};
+
+export default getRejectNotification;

--- a/apps/src/weblab2/weblab2ReduxThunks.ts
+++ b/apps/src/weblab2/weblab2ReduxThunks.ts
@@ -4,7 +4,6 @@ import {addChatEvent} from '@cdo/apps/aichat/redux/thunks/addChatEvent';
 import {getNewRemoveId} from '@cdo/apps/aichat/redux/utils';
 import {
   AI_TUTOR_VERSION_ACTION_ACCEPT,
-  AI_TUTOR_VERSION_ACTION_REJECT,
   Notification,
 } from '@cdo/apps/aichat/types/chatEvents';
 import Lab2Registry from '@cdo/apps/lab2/Lab2Registry';
@@ -28,6 +27,7 @@ import HttpClient from '@cdo/apps/util/HttpClient';
 import {AppDispatch} from '@cdo/apps/util/reduxHooks';
 import {AI_SAVED_COMMENT} from '@cdo/apps/weblab2/constants';
 
+import getRejectNotification from './helpers/getRejectNotification';
 import {setAiFilePathToPreview} from './weblab2Redux';
 
 /**
@@ -170,14 +170,7 @@ export const rejectAiTutorVersion = createAsyncThunk<
   const source = state.lab2Project.projectSources?.source as MultiFileSource;
 
   // Add reject notification.
-  const notification: Notification = {
-    timestamp: Date.now(),
-    removeId: getNewRemoveId(),
-    text: "You rejected AI Tutor's changes.",
-    notificationType: AI_TUTOR_VERSION_ACTION_REJECT,
-    includeInChatHistory: true,
-    files: files,
-  };
+  const notification = getRejectNotification(files);
   thunkAPI.dispatch(addChatEvent(notification));
   sendLab2AnalyticsEvent(EVENTS.AI_TUTOR_VERSION_REJECTED, {
     numFiles: files.length.toString(),


### PR DESCRIPTION
Currently, if you do not accept or reject changes proposed by AI Tutor and navigate away from the page, you do not see anything in the chat history that indicates that you rejected the change when you return. The code in the editor is consistent with rejecting the change (ie, we don't persist the AI Tutor suggested changes). Thus, the update here is that a "reject" event is logged when you navigate away from the page if you're in the middle of the accept/reject flow.

<img width="1618" height="846" alt="image (1)" src="https://github.com/user-attachments/assets/164de42e-33a2-4a7a-b37d-3a5bac1d293b" />

There are a couple of things I do here that I don't see in our code base (listen for `pagehide` event, use `navigator.sendBeacon` to send the request), which is never a good sign 😅. I'm hoping this is the right direction, but here's a bit more info on how I landed on those solutions in case folks have better ideas.

I looked at a couple of alternative events to listen to:
- `unload`: big red warning in docs saying not to use this. [Docs link](https://developer.mozilla.org/en-US/docs/Web/API/Window/unload_event).
- `visibilitychange`: gets set to hidden when you change tabs, which we wouldn't want this event to fire. [Docs link](https://developer.mozilla.org/en-US/docs/Web/API/Document/visibilitychange_event).

I also considered alternatives for "how do you make sure a request is actually made after the page closes?":
- there's a `keepalive` option you can use on a fetch request to have it persist beyond the page closing, but it is not compatible with the version of Firefox that we currently support (but only a few versions away, so maybe we can use it soon!) [Docs link](https://developer.mozilla.org/en-US/docs/Web/API/Request/keepalive).

## Links

- Jira: https://codedotorg.atlassian.net/browse/AFL-543
- Slack discussion: https://codedotorg.slack.com/archives/C09EHQE4DGD/p1775690786380639

## Testing story

I tested manually that I saw the reject notification when refreshed the page after navigating away mid-accept/reject.

 ## Follow-up work

We also want to add a custom dialog if a student tries to navigate to another lab2 level mid-accept/reject, which I'll do in a separate PR.