### PR TITLE
Speculative Revert "Stub writes for datasets/datablock tests to avoid serializing to disk"

### DIFF
--- a/dashboard/test/controllers/datablock_storage_controller_test.rb
+++ b/dashboard/test/controllers/datablock_storage_controller_test.rb
@@ -13,6 +13,9 @@ class DatablockStorageControllerTest < ActionDispatch::IntegrationTest
   setup do
     sign_in @student
     Cdo::Throttle.stubs(:throttle).returns(false)
+    # stub writes so none of the models serialize to disk during testing
+    # alsdfjasldk
+    File.stubs(:write)
   end
 
   def _url(action)

--- a/dashboard/test/controllers/datablock_storage_controller_test.rb
+++ b/dashboard/test/controllers/datablock_storage_controller_test.rb
@@ -13,8 +13,6 @@ class DatablockStorageControllerTest < ActionDispatch::IntegrationTest
   setup do
     sign_in @student
     Cdo::Throttle.stubs(:throttle).returns(false)
-    # stub writes so none of the models serialize to disk during testing
-    File.stubs(:write)
   end
 
   def _url(action)

--- a/dashboard/test/controllers/datablock_storage_controller_test.rb
+++ b/dashboard/test/controllers/datablock_storage_controller_test.rb
@@ -14,13 +14,8 @@ class DatablockStorageControllerTest < ActionDispatch::IntegrationTest
     sign_in @student
     Cdo::Throttle.stubs(:throttle).returns(false)
     # stub writes so none of the models serialize to disk during testing
+    # alsdfjasldk
     File.stubs(:write)
-  end
-
-  teardown do
-    # Explicitly unstub; we're not sure why, but we get a memory leak in Drone
-    # otherwise
-    File.unstub(:write)
   end
 
   def _url(action)

--- a/dashboard/test/controllers/datablock_storage_controller_test.rb
+++ b/dashboard/test/controllers/datablock_storage_controller_test.rb
@@ -14,8 +14,13 @@ class DatablockStorageControllerTest < ActionDispatch::IntegrationTest
     sign_in @student
     Cdo::Throttle.stubs(:throttle).returns(false)
     # stub writes so none of the models serialize to disk during testing
-    # alsdfjasldk
     File.stubs(:write)
+  end
+
+  teardown do
+    # Explicitly unstub; we're not sure why, but we get a memory leak in Drone
+    # otherwise
+    File.unstub(:write)
   end
 
   def _url(action)

--- a/dashboard/test/controllers/datablock_storage_controller_test.rb
+++ b/dashboard/test/controllers/datablock_storage_controller_test.rb
@@ -13,9 +13,6 @@ class DatablockStorageControllerTest < ActionDispatch::IntegrationTest
   setup do
     sign_in @student
     Cdo::Throttle.stubs(:throttle).returns(false)
-    # stub writes so none of the models serialize to disk during testing
-    # alsdfjasldk
-    File.stubs(:write)
   end
 
   def _url(action)

--- a/dashboard/test/controllers/datasets_controller_test.rb
+++ b/dashboard/test/controllers/datasets_controller_test.rb
@@ -2,9 +2,6 @@ require 'test_helper'
 
 class DatasetsControllerTest < ActionController::TestCase
   setup do
-    # stub writes so none of the models serialize to disk during testing
-    File.stubs(:write)
-
     @levelbuilder = create(:levelbuilder)
     Rails.application.config.stubs(:levelbuilder_mode).returns true
     sign_in @levelbuilder

--- a/dashboard/test/controllers/datasets_controller_test.rb
+++ b/dashboard/test/controllers/datasets_controller_test.rb
@@ -2,6 +2,10 @@ require 'test_helper'
 
 class DatasetsControllerTest < ActionController::TestCase
   setup do
+    # stub writes so none of the models serialize to disk during testing
+    # aldkjfasl
+    File.stubs(:write)
+
     @levelbuilder = create(:levelbuilder)
     Rails.application.config.stubs(:levelbuilder_mode).returns true
     sign_in @levelbuilder

--- a/dashboard/test/controllers/datasets_controller_test.rb
+++ b/dashboard/test/controllers/datasets_controller_test.rb
@@ -3,7 +3,6 @@ require 'test_helper'
 class DatasetsControllerTest < ActionController::TestCase
   setup do
     # stub writes so none of the models serialize to disk during testing
-    # aldkjfasl
     File.stubs(:write)
 
     @levelbuilder = create(:levelbuilder)
@@ -29,6 +28,12 @@ class DatasetsControllerTest < ActionController::TestCase
         }
       ]
     }
+  end
+
+  teardown do
+    # Explicitly unstub; we're not sure why, but we get a memory leak in Drone
+    # otherwise
+    File.unstub(:write)
   end
 
   test 'update_manifest: can update manifest' do

--- a/dashboard/test/controllers/datasets_controller_test.rb
+++ b/dashboard/test/controllers/datasets_controller_test.rb
@@ -2,10 +2,6 @@ require 'test_helper'
 
 class DatasetsControllerTest < ActionController::TestCase
   setup do
-    # stub writes so none of the models serialize to disk during testing
-    # aldkjfasl
-    File.stubs(:write)
-
     @levelbuilder = create(:levelbuilder)
     Rails.application.config.stubs(:levelbuilder_mode).returns true
     sign_in @levelbuilder

--- a/dashboard/test/controllers/datasets_controller_test.rb
+++ b/dashboard/test/controllers/datasets_controller_test.rb
@@ -3,6 +3,7 @@ require 'test_helper'
 class DatasetsControllerTest < ActionController::TestCase
   setup do
     # stub writes so none of the models serialize to disk during testing
+    # aldkjfasl
     File.stubs(:write)
 
     @levelbuilder = create(:levelbuilder)
@@ -28,12 +29,6 @@ class DatasetsControllerTest < ActionController::TestCase
         }
       ]
     }
-  end
-
-  teardown do
-    # Explicitly unstub; we're not sure why, but we get a memory leak in Drone
-    # otherwise
-    File.unstub(:write)
   end
 
   test 'update_manifest: can update manifest' do


### PR DESCRIPTION
Reverts code-dot-org/code-dot-org#71978 to see if it helps at all with the weird Drone issues we've been seeing lately

I have no idea why this might be the cause, but I did notice recently that I had some unexpected failures when trying to similarly stub a `FileUtils` method. Possibly there's some issue with core utils like this not getting unstubbed correctly?