### PR TITLE
[Codebridge] Adds text wrapping for txt files

### DIFF
--- a/apps/src/codebridge/Editor/Editor.tsx
+++ b/apps/src/codebridge/Editor/Editor.tsx
@@ -162,10 +162,11 @@ export const Editor = ({langMapping, editableFileTypes}: EditorProps) => {
             },
           })
         );
-      } else if (fileExt === 'md') {
-        // Wrap lines for markdown files.
-        extensions.push(EditorView.lineWrapping);
       }
+    }
+    if (fileExt === 'md' || fileExt === 'txt') {
+      // Wrap lines for markdown and plain text files.
+      extensions.push(EditorView.lineWrapping);
     }
     if (hasUnifiedDiffView) {
       // For new files that don't exist in the original version, we still want


### PR DESCRIPTION
This makes text wrapping possible for WebLab 2 .txt files. Because txt files aren't in the language mapping (it doesn't appear there is a language plugin for txt), we had to pull this else case out one step. Aside from that, it's a one line change!

Before:

https://github.com/user-attachments/assets/9ec1decb-d3f2-4202-b7fa-d93afb187850



After:

https://github.com/user-attachments/assets/fc906939-a5cf-46f8-8b99-1743de2dadbe




## Links

- Jira: https://codedotorg.atlassian.net/browse/AFL-538

## Testing story
<!-- How was this tested? Manual steps, adhoc links, automated tests, or why testing isn't needed. -->



## Deployment notes
<!-- Delete this section if it's a standard merge-and-deploy.
     Otherwise: migrations, feature flags, coordination, caching impacts, etc. -->



## Privacy and security
<!-- Delete this section if there is no privacy/security impact.
     Otherwise: new PII, auth changes, API surface changes, etc. -->

