### PR TITLE
Add teacher to MailJet contact list on course assignment

### DIFF
--- a/dashboard/app/models/sections/section.rb
+++ b/dashboard/app/models/sections/section.rb
@@ -263,7 +263,6 @@ class Section < ApplicationRecord
   def add_teacher_to_mailjet_course_list
     return unless saved_change_to_course_id? && course_id.present? && teacher.present?
 
-    unit_group = UnitGroup.get_from_cache(course_id)
     return unless unit_group
 
     MailJet.create_contact_and_add_to_course_list(teacher, unit_group.name)

--- a/dashboard/app/models/sections/section.rb
+++ b/dashboard/app/models/sections/section.rb
@@ -40,6 +40,7 @@
 
 require 'full-name-splitter'
 require 'cdo/code_generation'
+require 'cdo/mailjet'
 require 'cdo/safe_names'
 require 'policies/lti'
 
@@ -262,9 +263,7 @@ class Section < ApplicationRecord
   after_save :add_teacher_to_mailjet_course_list
   def add_teacher_to_mailjet_course_list
     return unless saved_change_to_course_id? && course_id.present? && teacher.present?
-
     return unless unit_group
-
     MailJet.create_contact_and_add_to_course_list(teacher, unit_group.name)
   rescue => exception
     Honeybadger.notify(exception)

--- a/dashboard/app/models/sections/section.rb
+++ b/dashboard/app/models/sections/section.rb
@@ -259,6 +259,18 @@ class Section < ApplicationRecord
     add_instructor(user)
   end
 
+  after_save :add_teacher_to_mailjet_course_list
+  def add_teacher_to_mailjet_course_list
+    return unless saved_change_to_course_id? && course_id.present? && teacher.present?
+
+    unit_group = UnitGroup.get_from_cache(course_id)
+    return unless unit_group
+
+    MailJet.create_contact_and_add_to_course_list(teacher, unit_group.name)
+  rescue => exception
+    Honeybadger.notify(exception)
+  end
+
   # return a version of self.students in which all students' names are
   # shortened to their first name (if unique) or their first name plus
   # the minimum number of letters in their last name needed to uniquely

--- a/dashboard/test/models/sections/section_test.rb
+++ b/dashboard/test/models/sections/section_test.rb
@@ -1677,4 +1677,30 @@ class SectionTest < ActiveSupport::TestCase
       end
     end
   end
+
+  test 'add_teacher_to_mailjet_course_list is called when matching course is assigned' do
+    unit_group = create(:unit_group, name: 'hoai-web-design-pilot-v2')
+    section = create(:section, teacher: @teacher)
+
+    MailJet.expects(:create_contact_and_add_to_course_list).with(@teacher, 'hoai-web-design-pilot-v2').once
+
+    section.update!(course_id: unit_group.id)
+  end
+
+  test 'add_teacher_to_mailjet_course_list is not called when course_id does not change' do
+    unit_group = create(:unit_group, name: 'hoai-web-design-pilot-v2')
+    section = create(:section, teacher: @teacher, course_id: unit_group.id)
+
+    MailJet.expects(:create_contact_and_add_to_course_list).never
+
+    section.update!(name: 'new-name')
+  end
+
+  test 'add_teacher_to_mailjet_course_list is called on section create with matching course' do
+    unit_group = create(:unit_group, name: 'hoai-web-design-pilot-v2')
+
+    MailJet.expects(:create_contact_and_add_to_course_list).with(@teacher, 'hoai-web-design-pilot-v2').once
+
+    create(:section, teacher: @teacher, course_id: unit_group.id)
+  end
 end

--- a/lib/cdo/mailjet.rb
+++ b/lib/cdo/mailjet.rb
@@ -76,6 +76,21 @@ module MailJet
     add_to_contact_list(contact, contact_list_id)
   end
 
+  def self.create_contact_and_add_to_course_list(user, unit_group_name)
+    return unless enabled?
+
+    return unless user&.id.present?
+    return unless user.teacher?
+
+    list_key = MAILJET_COURSE_ASSIGNMENT_CONTACT_LISTS[unit_group_name]
+    return unless list_key
+
+    contact = find_or_create_contact(user.email, user.name)
+
+    contact_list_id = CONTACT_LISTS[list_key][subaccount.to_sym][:default]
+    add_to_contact_list(contact, contact_list_id)
+  end
+
   def self.find_or_create_contact(email, name)
     return nil unless enabled?
     return nil unless valid_email?(email)

--- a/lib/cdo/mailjet.rb
+++ b/lib/cdo/mailjet.rb
@@ -89,7 +89,12 @@ module MailJet
     return unless contact_list_id
 
     contact = find_or_create_contact(user.email, user.name)
-    add_to_contact_list(contact, contact_list_id)
+
+    begin
+      add_to_contact_list(contact, contact_list_id)
+    rescue Mailjet::ApiError => exception
+      raise unless exception.message.include?('A duplicate ListRecipient already exists.')
+    end
   end
 
   def self.find_or_create_contact(email, name)

--- a/lib/cdo/mailjet.rb
+++ b/lib/cdo/mailjet.rb
@@ -85,9 +85,10 @@ module MailJet
     list_key = MAILJET_COURSE_ASSIGNMENT_CONTACT_LISTS[unit_group_name]
     return unless list_key
 
-    contact = find_or_create_contact(user.email, user.name)
+    contact_list_id = CONTACT_LISTS.dig(list_key, subaccount.to_sym, :default)
+    return unless contact_list_id
 
-    contact_list_id = CONTACT_LISTS[list_key][subaccount.to_sym][:default]
+    contact = find_or_create_contact(user.email, user.name)
     add_to_contact_list(contact, contact_list_id)
   end
 

--- a/lib/cdo/shared_constants/mailjet_constants.rb
+++ b/lib/cdo/shared_constants/mailjet_constants.rb
@@ -107,12 +107,6 @@ module MailjetConstants
       production: {
         default: 0, # TODO: Replace with actual MailJet list ID
       },
-      staging: {
-        default: 0, # TODO: Replace with actual MailJet list ID
-      },
-      development: {
-        default: 0, # TODO: Replace with actual MailJet list ID
-      },
     }
   }
 

--- a/lib/cdo/shared_constants/mailjet_constants.rb
+++ b/lib/cdo/shared_constants/mailjet_constants.rb
@@ -103,9 +103,9 @@ module MailjetConstants
         'es-MX': 10_443_295,
       },
     },
-    hoai_web_design: {
+    intro_web_lab: {
       production: {
-        default: 0, # TODO: Replace with actual MailJet list ID
+        default: 10_488_233,
       },
     }
   }
@@ -113,6 +113,6 @@ module MailjetConstants
   # Maps UnitGroup name to CONTACT_LISTS key. When a teacher assigns one of
   # these courses to a section, they are added to the corresponding contact list.
   MAILJET_COURSE_ASSIGNMENT_CONTACT_LISTS = {
-    'hoai-web-design-pilot-v2' => :hoai_web_design,
+    'intro-to-web-lab' => :intro_web_lab,
   }.freeze
 end

--- a/lib/cdo/shared_constants/mailjet_constants.rb
+++ b/lib/cdo/shared_constants/mailjet_constants.rb
@@ -102,6 +102,23 @@ module MailjetConstants
         default: 10_443_291,
         'es-MX': 10_443_295,
       },
+    },
+    hoai_web_design: {
+      production: {
+        default: 0, # TODO: Replace with actual MailJet list ID
+      },
+      staging: {
+        default: 0, # TODO: Replace with actual MailJet list ID
+      },
+      development: {
+        default: 0, # TODO: Replace with actual MailJet list ID
+      },
     }
   }
+
+  # Maps UnitGroup name to CONTACT_LISTS key. When a teacher assigns one of
+  # these courses to a section, they are added to the corresponding contact list.
+  MAILJET_COURSE_ASSIGNMENT_CONTACT_LISTS = {
+    'hoai-web-design-pilot-v2' => :hoai_web_design,
+  }.freeze
 end

--- a/lib/test/cdo/test_mailjet.rb
+++ b/lib/test/cdo/test_mailjet.rb
@@ -273,6 +273,48 @@ class MailJetTest < Minitest::Test
     MailJet.delete_contact(email)
   end
 
+  def test_create_contact_and_add_to_course_list
+    email = 'fake.email@test.xx'
+
+    user = mock
+    user.stubs(:id).returns(1)
+    user.stubs(:email).returns(email)
+    user.stubs(:name).returns('Fake Name')
+    user.stubs(:teacher?).returns(true)
+
+    mock_contact = mock('Mailjet::Contact')
+    mock_contact.stubs(:id).returns(123)
+
+    MailJet.expects(:find_or_create_contact).with(email, user.name).returns(mock_contact)
+
+    MailJet.stubs(:subaccount).returns('development')
+    MailJet.expects(:add_to_contact_list).with(mock_contact, MailJet::CONTACT_LISTS[:hoai_web_design][:development][:default])
+
+    MailJet.create_contact_and_add_to_course_list(user, 'hoai-web-design-pilot-v2')
+  end
+
+  def test_create_contact_and_add_to_course_list_non_teacher
+    user = mock
+    user.stubs(:id).returns(1)
+    user.stubs(:teacher?).returns(false)
+
+    MailJet.expects(:find_or_create_contact).never
+    MailJet.expects(:add_to_contact_list).never
+
+    MailJet.create_contact_and_add_to_course_list(user, 'hoai-web-design-pilot-v2')
+  end
+
+  def test_create_contact_and_add_to_course_list_unmapped_unit_group
+    user = mock
+    user.stubs(:id).returns(1)
+    user.stubs(:teacher?).returns(true)
+
+    MailJet.expects(:find_or_create_contact).never
+    MailJet.expects(:add_to_contact_list).never
+
+    MailJet.create_contact_and_add_to_course_list(user, 'some-other-course')
+  end
+
   def test_add_to_contact_list
     contact = mock('Mailjet::Contact')
     contact.stubs(:id).returns(123)

--- a/lib/test/cdo/test_mailjet.rb
+++ b/lib/test/cdo/test_mailjet.rb
@@ -287,10 +287,10 @@ class MailJetTest < Minitest::Test
 
     MailJet.expects(:find_or_create_contact).with(email, user.name).returns(mock_contact)
 
-    MailJet.stubs(:subaccount).returns('development')
-    MailJet.expects(:add_to_contact_list).with(mock_contact, MailJet::CONTACT_LISTS[:hoai_web_design][:development][:default])
+    MailJet.stubs(:subaccount).returns('production')
+    MailJet.expects(:add_to_contact_list).with(mock_contact, MailJet::CONTACT_LISTS[:intro_web_lab][:production][:default])
 
-    MailJet.create_contact_and_add_to_course_list(user, 'hoai-web-design-pilot-v2')
+    MailJet.create_contact_and_add_to_course_list(user, 'intro-to-web-lab')
   end
 
   def test_create_contact_and_add_to_course_list_non_teacher
@@ -301,7 +301,7 @@ class MailJetTest < Minitest::Test
     MailJet.expects(:find_or_create_contact).never
     MailJet.expects(:add_to_contact_list).never
 
-    MailJet.create_contact_and_add_to_course_list(user, 'hoai-web-design-pilot-v2')
+    MailJet.create_contact_and_add_to_course_list(user, 'intro-to-web-lab')
   end
 
   def test_create_contact_and_add_to_course_list_unmapped_unit_group


### PR DESCRIPTION
When a teacher assigns the new HoAI tutorial, Intro to Web Lab, to a section, they are added to a MailJet contact list via an after_save callback on the Section model.

We will use this contact list to automate a follow-up email a week or so after they assign it. Dani will be responsible for setting that up in MailJet.

I tested this locally by setting up a contact list in the development subaccount of MailJet and confirming that assigning a test course (as the real one isn't ready yet) successfully put the user in the contact list. There is a bit more abstraction here than I'd like, so I'll confirm this change when this PR _and_ the tutorial are both live.

