### PR TITLE
Ceara/tutor scramble practice problem

### DIFF
--- a/apps/src/aiTutor/views/lessonDeepDive/DraggableOptionCard.tsx
+++ b/apps/src/aiTutor/views/lessonDeepDive/DraggableOptionCard.tsx
@@ -1,0 +1,57 @@
+import {useSortable} from '@dnd-kit/sortable';
+import {CSS} from '@dnd-kit/utilities';
+import {Typography} from '@mui/material';
+import classNames from 'classnames';
+import React from 'react';
+
+import styles from './practice-problems.module.scss';
+
+interface DraggableOptionProps {
+  option: string;
+  id: string;
+  correct: boolean;
+  showAnswer: boolean;
+}
+
+export const DraggableOptionCard: React.FC<DraggableOptionProps> = ({
+  option,
+  id,
+  correct,
+  showAnswer,
+}) => {
+  const {attributes, listeners, setNodeRef, transform, transition, isDragging} =
+    useSortable({id});
+
+  const style = {
+    transform: CSS.Translate.toString(transform),
+    transition,
+    zIndex: isDragging ? 1 : undefined,
+  };
+
+  return (
+    <li
+      {...attributes}
+      {...listeners}
+      className={styles.sectionCardWrapper}
+      ref={setNodeRef}
+      style={{cursor: isDragging ? 'grabbing' : 'inherit', ...style}}
+      aria-labelledby={`section-card-title-${option}`}
+    >
+      <div
+        className={classNames([
+          styles.card,
+          styles.carddraggable,
+          showAnswer
+            ? correct
+              ? styles.cardcorrect
+              : styles.cardincorrect
+            : null,
+        ])}
+      >
+        <Typography variant="body1" className={styles.cardLabel}>
+          {option}
+        </Typography>
+      </div>
+    </li>
+  );
+};

--- a/apps/src/aiTutor/views/lessonDeepDive/PracticeBox.tsx
+++ b/apps/src/aiTutor/views/lessonDeepDive/PracticeBox.tsx
@@ -5,10 +5,11 @@ import React, {FC, useCallback, useState} from 'react';
 // import matchJson from '@cdo/static/tutor/match_example.json';
 import multiSingleJson from '@cdo/static/tutor/multiple_choice_example.json';
 import multiMultiJson from '@cdo/static/tutor/multiple_choice_multi_select.json';
-// import scrambleJson from '@cdo/static/tutor/scramble_example.json';
+import scrambleJson from '@cdo/static/tutor/scramble_example.json';
 // import sortJson from '@cdo/static/tutor/sort_example.json';
 
 import PracticeMultipleChoice from './PracticeMultipleChoice';
+import PracticeScramble from './PracticeScramble';
 import {LessonDeepDiveData, PracticeProblem} from './types';
 
 import styles from './practice-problems.module.scss';
@@ -16,7 +17,7 @@ import styles from './practice-problems.module.scss';
 const PracticeProblems: PracticeProblem[] = [
   multiMultiJson as PracticeProblem,
   multiSingleJson as PracticeProblem,
-  // scrambleJson as PracticeProblem,
+  scrambleJson as PracticeProblem,
   // matchJson as PracticeProblem,
   // sortJson as PracticeProblem,
 ];
@@ -59,6 +60,16 @@ const PracticeBox: FC<PracticeBoxProps> = ({
       case 'multiple_choice_multi_select':
         return (
           <PracticeMultipleChoice
+            problem={PracticeProblems[index]}
+            key={PracticeProblems[index].id}
+            submitted={isSubmitted}
+            submitCallback={setIsSubmitted}
+            correctCallback={setIsCorrect}
+          />
+        );
+      case 'scramble':
+        return (
+          <PracticeScramble
             problem={PracticeProblems[index]}
             key={PracticeProblems[index].id}
             submitted={isSubmitted}

--- a/apps/src/aiTutor/views/lessonDeepDive/PracticeScramble.tsx
+++ b/apps/src/aiTutor/views/lessonDeepDive/PracticeScramble.tsx
@@ -122,7 +122,6 @@ const PracticeScramble: FC<PracticeScrambleProps> = ({
               onClick={() => {
                 submitCallback(true);
                 correctCallback(isCorrect);
-                console.log('clicked submit button');
               }}
             >
               <Typography variant="body1" className={styles.cardLabel}>

--- a/apps/src/aiTutor/views/lessonDeepDive/PracticeScramble.tsx
+++ b/apps/src/aiTutor/views/lessonDeepDive/PracticeScramble.tsx
@@ -16,7 +16,7 @@ import {
   verticalListSortingStrategy,
 } from '@dnd-kit/sortable';
 import {Typography} from '@mui/material';
-import React, {FC, useEffect, useState} from 'react';
+import React, {FC, useState} from 'react';
 
 import {DraggableOptionCard} from './DraggableOptionCard';
 import {PracticeProblem, ScrambleSolution} from './types';
@@ -45,11 +45,6 @@ const PracticeScramble: FC<PracticeScrambleProps> = ({
   const [sortableOptions, setSortableOptions] = useState<string[]>(
     sortedOptions.map(s => s.option).sort(() => Math.random() - 0.5)
   );
-
-  useEffect(() => {
-    console.log(`sorted: ${sortedOptions.map(s => s.option)}`);
-    console.log(`sortable: ${sortableOptions}`);
-  }, [sortedOptions, sortableOptions]);
 
   const isCorrect = () => {
     for (let i = 0; i < sortableOptions.length; i++) {

--- a/apps/src/aiTutor/views/lessonDeepDive/PracticeScramble.tsx
+++ b/apps/src/aiTutor/views/lessonDeepDive/PracticeScramble.tsx
@@ -1,0 +1,144 @@
+import {
+  Active,
+  closestCenter,
+  DndContext,
+  DragEndEvent,
+  KeyboardSensor,
+  Over,
+  PointerSensor,
+  useSensor,
+  useSensors,
+} from '@dnd-kit/core';
+import {
+  arrayMove,
+  SortableContext,
+  sortableKeyboardCoordinates,
+  verticalListSortingStrategy,
+} from '@dnd-kit/sortable';
+import {Typography} from '@mui/material';
+import React, {FC, useEffect, useState} from 'react';
+
+import {DraggableOptionCard} from './DraggableOptionCard';
+import {PracticeProblem, ScrambleSolution} from './types';
+
+import styles from './practice-problems.module.scss';
+
+interface PracticeScrambleProps {
+  problem: PracticeProblem;
+  submitted: boolean;
+  submitCallback: React.Dispatch<React.SetStateAction<boolean>>;
+  correctCallback: React.Dispatch<React.SetStateAction<boolean>>;
+}
+
+const PracticeScramble: FC<PracticeScrambleProps> = ({
+  problem,
+  submitted,
+  submitCallback,
+  correctCallback,
+}) => {
+  const sortedOptions = (
+    problem.solution.map(s => {
+      return {...s};
+    }) as ScrambleSolution[]
+  ).sort((a, b) => a.correct - b.correct);
+
+  const [sortableOptions, setSortableOptions] = useState<string[]>(
+    sortedOptions.map(s => s.option).sort(() => Math.random() - 0.5)
+  );
+
+  useEffect(() => {
+    console.log(`sorted: ${sortedOptions.map(s => s.option)}`);
+    console.log(`sortable: ${sortableOptions}`);
+  }, [sortedOptions, sortableOptions]);
+
+  const isCorrect = () => {
+    for (let i = 0; i < sortableOptions.length; i++) {
+      if (sortableOptions[i] !== sortedOptions[i].option) {
+        return false;
+      }
+    }
+    return true;
+  };
+
+  function moveOption(
+    active: Active,
+    over: Over
+  ): React.SetStateAction<string[]> {
+    return items => {
+      const oldIndex = items.indexOf(active.id as string);
+      const newIndex = items.indexOf(over.id as string);
+      return arrayMove(items, oldIndex, newIndex);
+    };
+  }
+
+  const sensors = useSensors(
+    useSensor(PointerSensor, {
+      activationConstraint: {distance: 10},
+    }),
+    useSensor(KeyboardSensor, {
+      coordinateGetter: sortableKeyboardCoordinates,
+    })
+  );
+
+  const handleDragEnd = React.useCallback(
+    (event: DragEndEvent) => {
+      const {active, over} = event;
+
+      if (over && active.id !== over.id) {
+        setSortableOptions(moveOption(active, over));
+      }
+    },
+    [setSortableOptions]
+  );
+
+  return (
+    <div className={styles.container}>
+      <div className={styles.content}>
+        <div className={styles.prompt}>
+          <Typography variant="h4" sx={{fontSize: {xs: '1.5rem', sm: '2rem'}}}>
+            {problem.problem_text}
+          </Typography>
+          <div className={styles.optionsContainer}>
+            <DndContext
+              sensors={sensors}
+              collisionDetection={closestCenter}
+              onDragEnd={handleDragEnd}
+            >
+              <SortableContext
+                items={sortableOptions}
+                strategy={verticalListSortingStrategy}
+              >
+                <ol className={styles.optionsContainer}>
+                  {sortableOptions.map((option, index) => (
+                    <DraggableOptionCard
+                      key={option}
+                      option={option}
+                      id={option}
+                      correct={option === sortedOptions[index].option}
+                      showAnswer={submitted}
+                    />
+                  ))}
+                </ol>
+              </SortableContext>
+            </DndContext>
+            <button
+              type="button"
+              disabled={submitted}
+              onClick={() => {
+                submitCallback(true);
+                correctCallback(isCorrect);
+                console.log('clicked submit button');
+              }}
+            >
+              <Typography variant="body1" className={styles.cardLabel}>
+                Submit
+              </Typography>
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default PracticeScramble;

--- a/apps/src/aiTutor/views/lessonDeepDive/practice-problems.module.scss
+++ b/apps/src/aiTutor/views/lessonDeepDive/practice-problems.module.scss
@@ -28,6 +28,7 @@
   width: 100%;
   max-width: 400px;
   padding: 24px 0;
+  list-style-type: none;
 }
 
 .card {
@@ -40,6 +41,13 @@
   border-radius: 4px;
   cursor: pointer;
   transition: filter 0.15s ease, transform 0.15s ease;
+
+  &draggable {
+    margin: 5px;
+    padding: 10px;
+    border: 1px solid;
+    border-color: $lightest_gray;
+  }
 
   &selected {
     border: 4px solid;

--- a/apps/src/aiTutor/views/lessonDeepDive/types.ts
+++ b/apps/src/aiTutor/views/lessonDeepDive/types.ts
@@ -6,12 +6,27 @@ export type LessonDeepDiveData = {
   objectives: {id: string; description: string}[];
 };
 
+export type MultiSolution = {
+  option: string;
+  correct: boolean;
+};
+
+export type ScrambleSolution = {
+  option: string;
+  correct: number;
+};
+
+export type MatchSolution = {
+  option: string;
+  correct: string;
+};
+
 export type PracticeProblem = {
   id: number;
   type: string;
   active: boolean;
   problem_text: string;
-  solution: {option: string; correct: string | number | boolean}[];
+  solution: (MultiSolution | ScrambleSolution | MatchSolution)[];
 };
 
 export const PracticeProblemTypes = {


### PR DESCRIPTION
Adds a scramble practice problem UI to the Tutor+ UI, using the sample json from this PR: https://github.com/code-dot-org/code-dot-org/pull/71948

This uses draggable elements in an ordered list, then on submit compares the order to the solution to determine if it's correct. On submit, elements in the correct position are outlined in green, and elements in the incorrect position are outlined in red. The initial order of elements is randomized.

Video example with the wrong answer:

https://github.com/user-attachments/assets/e0e710c8-937d-4ec3-b16c-5146355833fa


## Links
<!-- Jira tickets, design docs, Slack threads, related PRs, etc. -->

- Jira:

## Testing story
<!-- How was this tested? Manual steps, adhoc links, automated tests, or why testing isn't needed. -->



## Deployment notes
<!-- Delete this section if it's a standard merge-and-deploy.
     Otherwise: migrations, feature flags, coordination, caching impacts, etc. -->



## Privacy and security
<!-- Delete this section if there is no privacy/security impact.
     Otherwise: new PII, auth changes, API surface changes, etc. -->

