### PR TITLE
Make emoji and avatar color default to random on section creation

### DIFF
--- a/apps/src/templates/sectionsRefresh/SectionsSetUpContainer.jsx
+++ b/apps/src/templates/sectionsRefresh/SectionsSetUpContainer.jsx
@@ -1,5 +1,6 @@
 import {Typography} from '@mui/material';
 import classnames from 'classnames';
+import _ from 'lodash';
 import PropTypes from 'prop-types';
 import React, {useState, useCallback, useRef} from 'react';
 import {Provider} from 'react-redux';
@@ -23,6 +24,11 @@ import {
   SectionLoginType,
 } from '@cdo/generated-scripts/sharedConstants';
 import i18n from '@cdo/locale';
+
+import {
+  COLORS,
+  EMOJIS,
+} from '../studioHomepages/teacherHomepageV2/sectionAvatars/avatarConstants';
 
 import AdvancedSettingToggles from './AdvancedSettingToggles';
 import {getCoteacherMetricInfoFromSection} from './coteacherSettings/CoteacherUtils';
@@ -53,6 +59,8 @@ const useSections = section => {
             lessonExtras: true,
             aiTutorEnabled: false,
             course: {textToSpeechEnabled: false, lessonExtrasAvailable: false},
+            avatar_color: _.random(0, COLORS.length - 1), // Pick a random avatar color from the 20 options
+            avatar_emoji: _.random(0, EMOJIS.length - 1), // Pick a random avatar emoji from the 21 options
           },
         ]
   );

--- a/apps/src/templates/studioHomepages/teacherHomepageV2/sectionAvatars/SectionAvatar.tsx
+++ b/apps/src/templates/studioHomepages/teacherHomepageV2/sectionAvatars/SectionAvatar.tsx
@@ -13,18 +13,20 @@ interface SectonAvatarProps {
 }
 
 const SectionAvatar: React.FC<SectonAvatarProps> = ({color, emoji, size}) => {
+  const safeColor = color >= 0 && color < COLORS.length ? color : 0;
+  const safeEmoji = emoji >= 0 && emoji < EMOJIS.length ? emoji : 0;
   return (
     <div
       className={classNames(
         styles.sectionAvatar,
         styles[`sectionAvatar-${size}`]
       )}
-      style={{backgroundColor: COLORS[color]}}
-      aria-label={`${COLOR_LABELS[color]}, ${EMOJI_LABELS[emoji]}`}
-      title={`${COLOR_LABELS[color]} ${EMOJI_LABELS[emoji]}`}
+      style={{backgroundColor: COLORS[safeColor]}}
+      aria-label={`${COLOR_LABELS[safeColor]}, ${EMOJI_LABELS[safeEmoji]}`}
+      title={`${COLOR_LABELS[safeColor]} ${EMOJI_LABELS[safeEmoji]}`}
       role="img"
     >
-      {EMOJIS[emoji]}
+      {EMOJIS[safeEmoji]}
     </div>
   );
 };

--- a/apps/test/unit/templates/sectionsRefresh/SectionsSetUpContainerTest.jsx
+++ b/apps/test/unit/templates/sectionsRefresh/SectionsSetUpContainerTest.jsx
@@ -4,6 +4,10 @@ import sinon from 'sinon'; // eslint-disable-line no-restricted-imports
 
 import * as utils from '@cdo/apps/code-studio/utils';
 import SectionsSetUpContainer from '@cdo/apps/templates/sectionsRefresh/SectionsSetUpContainer';
+import {
+  COLORS,
+  EMOJIS,
+} from '@cdo/apps/templates/studioHomepages/teacherHomepageV2/sectionAvatars/avatarConstants';
 import * as windowUtils from '@cdo/apps/utils';
 
 import {expect} from '../../../util/reconfiguredChai'; // eslint-disable-line no-restricted-imports
@@ -20,6 +24,16 @@ describe('SectionsSetUpContainer', () => {
     const wrapper = shallow(<SectionsSetUpContainer {...DEFAULT_PROPS} />);
 
     expect(wrapper.find('SingleSectionSetUp').length).to.equal(1);
+  });
+
+  it('initializes with random avatar_color and avatar_emoji within valid range', () => {
+    const wrapper = shallow(<SectionsSetUpContainer {...DEFAULT_PROPS} />);
+    const section = wrapper.find('SingleSectionSetUp').prop('section');
+
+    expect(section.avatar_color).to.be.at.least(0);
+    expect(section.avatar_color).to.be.below(COLORS.length);
+    expect(section.avatar_emoji).to.be.at.least(0);
+    expect(section.avatar_emoji).to.be.below(EMOJIS.length);
   });
 
   it('renders headers and button', () => {


### PR DESCRIPTION
Based on this slack thread, this PR makes the initial values for emoji and color for section avatars random. Previously it was always the first index, which was color red and emoji fire

Recording showing me refreshing a few times.
https://github.com/user-attachments/assets/e2406062-28a5-4d14-9dc4-f96bdea39473
