### PR TITLE
Revert "disable forgery protection in test env"

### DIFF
--- a/dashboard/config/environments/test.rb
+++ b/dashboard/config/environments/test.rb
@@ -43,8 +43,8 @@ Dashboard::Application.configure do
   # Raise exceptions instead of rendering exception templates.
   config.action_dispatch.show_exceptions = true
 
-  # Disable request forgery protection in test environment.
-  config.action_controller.allow_forgery_protection = false
+  # Disable request forgery protection in unit tests only.
+  config.action_controller.allow_forgery_protection = !ENV['UNIT_TEST']
 
   # Tell Action Mailer not to deliver emails to the real world.
   # The :test delivery method accumulates sent emails in the

--- a/dashboard/config/environments/test.rb
+++ b/dashboard/config/environments/test.rb
@@ -43,8 +43,9 @@ Dashboard::Application.configure do
   # Raise exceptions instead of rendering exception templates.
   config.action_dispatch.show_exceptions = true
 
-  # Disable request forgery protection in unit tests only.
-  config.action_controller.allow_forgery_protection = !ENV['UNIT_TEST']
+  # Enable request forgery protection in the test environment. Unit tests
+  # disable it at the runtime layer in test_helper.rb.
+  config.action_controller.allow_forgery_protection = true
 
   # Tell Action Mailer not to deliver emails to the real world.
   # The :test delivery method accumulates sent emails in the

--- a/dashboard/test/test_helper.rb
+++ b/dashboard/test/test_helper.rb
@@ -36,6 +36,12 @@ Rails.application&.reload_routes! if defined?(Rails) && defined?(Rails.applicati
 
 require File.expand_path('../../config/environment', __FILE__)
 
+# Disable CSRF protection for unit tests. We cannot target the config layer
+# from this file because Spring may have already loaded the Rails application,
+# copying `config.action_controller` onto ActionController::Base. Set the
+# runtime attribute directly instead.
+ActionController::Base.allow_forgery_protection = false
+
 if CDO.test_system? && !ENV.fetch('TEST_ENV_NUMBER', nil)
   # Raise rather than silently correcting the error, because it's possible that the data in
   # dashboard_test has already been corrupted by the time we get here. If we find that we're


### PR DESCRIPTION
Reverts code-dot-org/code-dot-org#72059, restoring #71860.

The problem with the original PR is that the rails environment loads before test_helper.rb when unit tests are run by developers using spring. The naive approach of setting rails config within test helper does not work because the action controller config has already been copied onto  ActionController::Base. the new solution is to wait for the rails env to be loaded in test helper, and then override the setting directly on ActionController::Base.