### PR TITLE
Ceara/aitt aidiff expand general context no sections

### DIFF
--- a/dashboard/app/helpers/ai_diff_bedrock_helper.rb
+++ b/dashboard/app/helpers/ai_diff_bedrock_helper.rb
@@ -93,7 +93,6 @@ module AiDiffBedrockHelper
           },
           retrieval_configuration: {
             vector_search_configuration: {
-              filter: {},
               number_of_results: RETRIEVAL_LIMIT,
             }
           }
@@ -137,7 +136,7 @@ module AiDiffBedrockHelper
       end
     end
 
-    if lesson_number.nil? && unit_num.nil? && course_names.nil?
+    if lesson_number.nil? && unit_num.nil? && course_names.nil? && !section_contexts.empty?
       or_all_filters.push({equals: {key: "scope", value: "general"}})
       section_contexts&.each do |section_context|
         or_all_filters.push({in: {key: "course", value: section_context[:course_names]}})
@@ -186,7 +185,7 @@ module AiDiffBedrockHelper
     config = format_inputs_for_bedrock_request(input, prompt)
     config[:session_id] = session_id unless session_id.nil?
     filter_config = filter_for_context(lesson_number, unit_num, course_name, section_contexts, labs)
-    config[:retrieve_and_generate_configuration][:knowledge_base_configuration][:retrieval_configuration][:vector_search_configuration][:filter] = filter_config
+    config[:retrieve_and_generate_configuration][:knowledge_base_configuration][:retrieval_configuration][:vector_search_configuration][:filter] = filter_config unless filter_config.empty?
 
     attempts = 0
     begin

--- a/dashboard/test/helpers/ai_diff_bedrock_helper_test.rb
+++ b/dashboard/test/helpers/ai_diff_bedrock_helper_test.rb
@@ -92,7 +92,6 @@ User: oh no"
           },
             retrieval_configuration: {
               vector_search_configuration: {
-                filter: {},
                 number_of_results: 10,
               }
             }
@@ -108,7 +107,7 @@ User: oh no"
     course_names = ["test_course"]
     unit_num = 2
     lesson_number = 3
-    section_contexts = nil
+    section_contexts = []
     formatted_input = format_inputs_for_bedrock_request(input, prompt)
     expected_input = {
       input: {
@@ -132,7 +131,6 @@ User: oh no"
           },
           retrieval_configuration: {
             vector_search_configuration: {
-              filter: {},
               number_of_results: 10,
             }
           }
@@ -163,7 +161,7 @@ User: oh no"
     course_names = ["test_course"]
     unit_num = 2
     lesson_number = 3
-    section_contexts = nil
+    section_contexts = []
     formatted_input = format_inputs_for_bedrock_request(input, prompt)
     expected_input = {
       input: {
@@ -187,7 +185,6 @@ User: oh no"
           },
           retrieval_configuration: {
             vector_search_configuration: {
-              filter: {},
               number_of_results: 10,
             }
           }
@@ -223,7 +220,7 @@ User: oh no"
     course_names = ["test_course"]
     unit_num = 2
     lesson_number = nil
-    section_contexts = nil
+    section_contexts = []
     formatted_input = format_inputs_for_bedrock_request(input, prompt)
     expected_input = {
       input: {
@@ -247,7 +244,6 @@ User: oh no"
           },
           retrieval_configuration: {
             vector_search_configuration: {
-              filter: {},
               number_of_results: 10,
             }
           }
@@ -274,7 +270,7 @@ User: oh no"
     course_names = ["test_course"]
     unit_num = nil
     lesson_number = nil
-    section_contexts = nil
+    section_contexts = []
     formatted_input = format_inputs_for_bedrock_request(input, prompt)
     expected_input = {
       input: {
@@ -298,7 +294,6 @@ User: oh no"
           },
           retrieval_configuration: {
             vector_search_configuration: {
-              filter: {},
               number_of_results: 10,
             }
           }
@@ -319,7 +314,7 @@ User: oh no"
     course_names = nil
     unit_num = nil
     lesson_number = nil
-    section_contexts = nil
+    section_contexts = []
     formatted_input = format_inputs_for_bedrock_request(input, prompt)
     expected_input = {
       input: {
@@ -343,16 +338,13 @@ User: oh no"
           },
           retrieval_configuration: {
             vector_search_configuration: {
-              filter: {},
               number_of_results: 10,
             }
           }
         }
       }
     }
-    expected_filter = {
-      equals: {key: "scope", value: "general"}
-    }
+    expected_filter = {}
     assert_equal formatted_input, expected_input
     filter = filter_for_context(lesson_number, unit_num, course_names, section_contexts)
     assert_equal filter, expected_filter
@@ -400,7 +392,6 @@ User: oh no"
           },
           retrieval_configuration: {
             vector_search_configuration: {
-              filter: {},
               number_of_results: 10,
             }
           }


### PR DESCRIPTION
Updating metadata filtering to apply NO filter if we are in the general context and there are no sections assigned. This allows teachers with no sections/ new teacher accounts to use the TA with full context. The filtering behavior on course pages and for teachers with assigned sections remains the same

## Testing story
Updated unit tests for new filtering behavior and tested with a new teacher account

<img width="1237" height="858" alt="Screenshot 2026-04-13 at 11 27 11 AM" src="https://github.com/user-attachments/assets/82920e91-e92e-4a4c-9c71-8b6e6ef70a77" />


## Deployment notes
<!-- Delete this section if it's a standard merge-and-deploy.
     Otherwise: migrations, feature flags, coordination, caching impacts, etc. -->



## Privacy and security
<!-- Delete this section if there is no privacy/security impact.
     Otherwise: new PII, auth changes, API surface changes, etc. -->

