### PR TITLE
Revert "Validate rubric script level"

### DIFF
--- a/dashboard/app/models/rubric.rb
+++ b/dashboard/app/models/rubric.rb
@@ -30,14 +30,6 @@ class Rubric < ApplicationRecord
     lesson.script_levels.find {|sl| sl.levels.include?(level)}
   end
 
-  validate :validate_lesson_and_level
-  def validate_lesson_and_level
-    unless get_script_level
-      url = "https://levelbuilder-studio.code.org/s/#{lesson&.script&.name}/lessons/#{lesson&.relative_position}/edit"
-      errors.add(:base, "Rubric #{id} lesson #{lesson_id} does not include level #{level_id}. Please go to: #{url} --> Edit Rubric and select a valid level.")
-    end
-  end
-
   def summarize
     script_level = get_script_level
     {

--- a/dashboard/config/scripts_json/ai-generated-design-2026.script_json
+++ b/dashboard/config/scripts_json/ai-generated-design-2026.script_json
@@ -7586,7 +7586,7 @@
       }
     },
     {
-      "level_name": "ai-generated-design-lesson3-level1-explore_2026",
+      "level_name": "ai-generated-design-lesson3-level2-challenges_2026",
       "s3_config_dir": null,
       "seeding_key": {
         "lesson.key": "Lesson 3: Build Your First Web Page with AI",

--- a/dashboard/config/scripts_json/ai-generated-design-2026.script_json
+++ b/dashboard/config/scripts_json/ai-generated-design-2026.script_json
@@ -7586,7 +7586,7 @@
       }
     },
     {
-      "level_name": "ai-generated-design-lesson3-level2-challenges_2026",
+      "level_name": "ai-generated-design-lesson3-level1-explore_2026",
       "s3_config_dir": null,
       "seeding_key": {
         "lesson.key": "Lesson 3: Build Your First Web Page with AI",

--- a/dashboard/test/factories/factories.rb
+++ b/dashboard/test/factories/factories.rb
@@ -2190,13 +2190,6 @@ FactoryBot.define do
     association :lesson
     association :level
 
-    before(:create) do |rubric|
-      unless rubric.lesson.script_levels.any? {|sl| sl.levels.include?(rubric.level)}
-        create(:script_level, script: rubric.lesson.script, lesson: rubric.lesson, levels: [rubric.level])
-        rubric.lesson.reload
-      end
-    end
-
     trait :with_learning_goals do
       transient do
         num_learning_goals {2}

--- a/dashboard/test/models/levels/level_test.rb
+++ b/dashboard/test/models/levels/level_test.rb
@@ -1491,21 +1491,20 @@ class LevelTest < ActiveSupport::TestCase
     other_script = create(:script, :in_single_unit_course, tts: true)
     lesson_group = create(:lesson_group, script: script)
     lesson = create(:lesson, script: script, lesson_group: lesson_group)
-    other_lesson_group = create(:lesson_group, script: other_script)
-    other_lesson = create(:lesson, script: other_script, lesson_group: other_lesson_group)
     parent_level = create(:bubble_choice_level, name: 'parent bubble choice 2')
     child_level = create(:music, name: 'music sublevel 2')
     parent_level.child_levels << child_level
     create(:rubric, level: parent_level, lesson: lesson)
-    # Child is accessed from other_script, not the script with the rubric
+    # Parent is in other_script, not the script with the rubric
+    create(:script_level, script: other_script, levels: [parent_level])
     script_level = create(
       :script_level,
-      lesson: other_lesson,
-      script: other_script,
+      lesson: lesson,
+      script: script,
       levels: [child_level]
     )
 
-    properties = child_level.summarize_for_lab2_properties(other_script, script_level).stringify_keys
+    properties = child_level.summarize_for_lab2_properties(script, script_level).stringify_keys
 
     assert_nil properties["showRubric"]
   end


### PR DESCRIPTION
Reverts code-dot-org/code-dot-org#72055, because it broke staging. it appears that the validation fails during seeding when the DB contains an invalid level, even if there is a valid level name to replace it with in the .script_json file.