### PR TITLE
Fix courses assigned only to archived sections throwing 500s

### DIFF
--- a/dashboard/app/controllers/courses_controller.rb
+++ b/dashboard/app/controllers/courses_controller.rb
@@ -54,7 +54,7 @@ class CoursesController < ApplicationController
       return
     end
 
-    if current_user&.user_type == "teacher" && current_user.sections_instructed.any? {|s| s.course_id == @unit_group.id} && TeacherDashboardUtils.can_redirect_to_teacher_dashboard?(current_user)
+    if current_user&.user_type == "teacher" && current_user.sections_instructed.any? {|s| !s.hidden && s.course_id == @unit_group.id} && TeacherDashboardUtils.can_redirect_to_teacher_dashboard?(current_user)
       section_id = params[:section_id] || current_user.sections_instructed.select {|s| !s.hidden && s.course_id == @unit_group.id}.last.id
       if section_id
         redirect_to "/teacher_dashboard/sections/#{section_id}/courses/#{@unit_group.name}"

--- a/dashboard/app/controllers/scripts_controller.rb
+++ b/dashboard/app/controllers/scripts_controller.rb
@@ -41,7 +41,7 @@ class ScriptsController < ApplicationController
         end
         return
       end
-      if current_user&.user_type == "teacher" && current_user.sections_instructed.any? {|s| s.script_id == @script.id || s.unit_group&.id == @course&.id}
+      if current_user&.user_type == "teacher" && current_user.sections_instructed.any? {|s| !s.hidden && (s.script_id == @script.id || s.unit_group&.id == @course&.id)}
         most_recent_section = current_user.sections_instructed.select {|s| !s.hidden && (s.script_id == @script.id || s.unit_group&.id == @course.id)}.last
         section_id = params[:section_id]
         section_id ||= most_recent_section&.id

--- a/dashboard/test/controllers/courses_controller_test.rb
+++ b/dashboard/test/controllers/courses_controller_test.rb
@@ -477,6 +477,16 @@ class CoursesControllerTest < ActionController::TestCase
     assert_redirected_to "http://test.host/teacher_dashboard/sections/#{@pilot_pl_section.id}/courses/#{@pilot_pl_unit_group.name}"
   end
 
+  test 'teacher with only a hidden section for the course is not redirected to teacher dashboard' do
+    teacher = create(:teacher)
+    create(:section, :hidden, user: teacher, unit_group: @unit_group_regular)
+    sign_in teacher
+
+    get :show, params: {course_name: @unit_group_regular.name}
+
+    assert_response :success
+  end
+
   test_user_gets_response_for(:show, response: :success, user: -> {@pilot_student},
                               params: -> {{course_name: @pilot_unit_group.name}}, name: 'pilot student can view pilot course'
   ) do

--- a/dashboard/test/controllers/scripts_controller_test.rb
+++ b/dashboard/test/controllers/scripts_controller_test.rb
@@ -163,6 +163,17 @@ class ScriptsControllerTest < ActionController::TestCase
     assert_response :forbidden
   end
 
+  test "teacher with only a hidden section for the unit is not redirected to teacher dashboard" do
+    unit = create(:script, :in_single_unit_course)
+    teacher = create(:teacher)
+    hidden_section = create(:section, :hidden, user: teacher, script: unit)
+    sign_in teacher
+
+    get :show, params: {id: unit.name, section_id: hidden_section.id}
+
+    refute_match %r{/teacher_dashboard/sections/}, response.location.to_s
+  end
+
   test "should use unit name as param where unit name is words but looks like a number" do
     unit = create(:script, :in_single_unit_course, name: '15-16')
     get :show, params: {id: "15-16"}


### PR DESCRIPTION
Seeing sad bee 500s when going to the course page
<img width="1425" height="760" alt="image" src="https://github.com/user-attachments/assets/06a7f67f-8cde-4a28-b0e0-f621f71e0996" />

Caused by trying to redirect, but then filtering out the archived/hidden section and not having a valid object.

This was introduced recently in this PR: https://github.com/code-dot-org/code-dot-org/pull/71766/changes


## Links
Slack convo: https://codedotorg.slack.com/archives/C0T0PNTM3/p1776104842981279
