### PR TITLE
[AI Tutor] Fix copy chat bug

### DIFF
--- a/apps/src/aichat/views/aiChatHeaderButtons/CopyChatHistoryButton.tsx
+++ b/apps/src/aichat/views/aiChatHeaderButtons/CopyChatHistoryButton.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import {useSelector} from 'react-redux';
 
 import {selectAllVisibleMessages, sendAnalytics} from '@cdo/apps/aichat/redux';
 import IconButtonWithTooltip from '@cdo/apps/lab2/views/components/IconButtonWithTooltip';
@@ -11,15 +10,17 @@ import {AiInteractionStatus as Status} from '@cdo/generated-scripts/sharedConsta
 import {timestampToDateTime} from '../../redux/utils';
 import {
   ChatEvent,
+  ChatEventDescriptionKey,
   isChatMessage,
   isModelUpdate,
   isNotification,
+  isUserActionEvent,
   WorkspaceTeacherViewTab,
 } from '../../types';
 import {AI_CUSTOMIZATIONS_LABELS} from '../modelCustomization/constants';
 
 const CopyChatHistoryButton: React.FunctionComponent = () => {
-  const visibleMessages = useSelector(selectAllVisibleMessages);
+  const visibleMessages = useAppSelector(selectAllVisibleMessages);
   const studentChatHistory = useAppSelector(
     state => state.aichat.studentChatHistory
   );
@@ -83,6 +84,16 @@ function chatEventToFormattedString(chatEvent: ChatEvent) {
 
   if (isNotification(chatEvent)) {
     return `[${formattedTimestamp} - Notification] ${chatEvent.text}`;
+  }
+
+  if (isUserActionEvent(chatEvent)) {
+    const descriptions: {[key in ChatEventDescriptionKey]: string} = {
+      CLEAR_CHAT: 'The user cleared the chat workspace.',
+      LOAD_LEVEL: 'The user loaded the level.',
+    };
+    return `[${formattedTimestamp} - User Action] ${
+      descriptions[chatEvent.descriptionKey]
+    }`;
   }
 }
 

--- a/apps/src/aichat/views/aiChatHeaderButtons/CopyChatHistoryButton.tsx
+++ b/apps/src/aichat/views/aiChatHeaderButtons/CopyChatHistoryButton.tsx
@@ -5,7 +5,7 @@ import {selectAllVisibleMessages, sendAnalytics} from '@cdo/apps/aichat/redux';
 import IconButtonWithTooltip from '@cdo/apps/lab2/views/components/IconButtonWithTooltip';
 import {EVENTS} from '@cdo/apps/metrics/AnalyticsConstants';
 import copyToClipboard from '@cdo/apps/util/copyToClipboard';
-import {useAppDispatch} from '@cdo/apps/util/reduxHooks';
+import {useAppDispatch, useAppSelector} from '@cdo/apps/util/reduxHooks';
 import {AiInteractionStatus as Status} from '@cdo/generated-scripts/sharedConstants';
 
 import {timestampToDateTime} from '../../redux/utils';
@@ -14,11 +14,23 @@ import {
   isChatMessage,
   isModelUpdate,
   isNotification,
+  WorkspaceTeacherViewTab,
 } from '../../types';
 import {AI_CUSTOMIZATIONS_LABELS} from '../modelCustomization/constants';
 
 const CopyChatHistoryButton: React.FunctionComponent = () => {
-  const messages = useSelector(selectAllVisibleMessages);
+  const visibleMessages = useSelector(selectAllVisibleMessages);
+  const studentChatHistory = useAppSelector(
+    state => state.aichat.studentChatHistory
+  );
+  const selectedTab = useAppSelector(
+    state => state.aichat.chatWorkspaceSelectedTab
+  );
+  const isViewingStudentHistory =
+    selectedTab === WorkspaceTeacherViewTab.STUDENT_CHAT_HISTORY;
+  const messages = isViewingStudentHistory
+    ? studentChatHistory
+    : visibleMessages;
   const dispatch = useAppDispatch();
 
   const handleCopy = () => {

--- a/apps/test/unit/aichat/views/aiChatHeaderButtons/CopyChatHistoryButtonTest.tsx
+++ b/apps/test/unit/aichat/views/aiChatHeaderButtons/CopyChatHistoryButtonTest.tsx
@@ -1,0 +1,134 @@
+import {render, screen, fireEvent} from '@testing-library/react';
+import React from 'react';
+import '@testing-library/jest-dom';
+
+import {AichatState} from '@cdo/apps/aichat/redux';
+import {
+  CompletedChatMessage,
+  WorkspaceTeacherViewTab,
+} from '@cdo/apps/aichat/types';
+import CopyChatHistoryButton from '@cdo/apps/aichat/views/aiChatHeaderButtons/CopyChatHistoryButton';
+import {Role} from '@cdo/apps/aiComponentLibrary/chatMessage/types';
+import copyToClipboard from '@cdo/apps/util/copyToClipboard';
+import {AiInteractionStatus} from '@cdo/generated-scripts/sharedConstants';
+
+// Intercept clipboard writes so tests can assert on the copied text.
+jest.mock('@cdo/apps/util/copyToClipboard');
+
+const mockDispatch = jest.fn();
+
+// mockState is mutated per-test to simulate different redux store shapes.
+let mockState: {aichat: Partial<AichatState>};
+
+// Route all useSelector / useAppSelector calls through mockState instead of a real store.
+jest.mock('react-redux', () => ({
+  ...jest.requireActual('react-redux'),
+  useSelector: (selector: (s: unknown) => unknown) => selector(mockState),
+}));
+
+jest.mock('@cdo/apps/util/reduxHooks', () => ({
+  ...jest.requireActual('@cdo/apps/util/reduxHooks'),
+  useAppSelector: (selector: (s: unknown) => unknown) => selector(mockState),
+  useAppDispatch: () => mockDispatch,
+}));
+
+const userMessage: CompletedChatMessage = {
+  role: Role.USER,
+  chatMessageText: 'Hello from user',
+  status: AiInteractionStatus.OK,
+  timestamp: 1000000,
+  requestId: 1,
+};
+
+const botMessage: CompletedChatMessage = {
+  role: Role.ASSISTANT,
+  chatMessageText: 'Hello from bot',
+  status: AiInteractionStatus.OK,
+  timestamp: 2000000,
+  requestId: 2,
+};
+
+const studentHistoryMessage: CompletedChatMessage & {id: number} = {
+  role: Role.USER,
+  chatMessageText: 'Student message',
+  status: AiInteractionStatus.OK,
+  timestamp: 3000000,
+  requestId: 3,
+  id: 100,
+};
+
+describe('CopyChatHistoryButton', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockState = {
+      aichat: {
+        chatEventsPast: [],
+        chatEventsCurrent: [],
+        studentChatHistory: [],
+        chatWorkspaceSelectedTab: null,
+      },
+    };
+  });
+
+  // When not viewing a student, the button copies the teacher's own chat events.
+  it('copies own visible messages when not viewing a student', () => {
+    mockState.aichat.chatEventsPast = [userMessage];
+    mockState.aichat.chatEventsCurrent = [botMessage];
+    mockState.aichat.chatWorkspaceSelectedTab = null;
+
+    render(<CopyChatHistoryButton />);
+    fireEvent.click(screen.getByRole('button'));
+
+    expect(copyToClipboard).toHaveBeenCalledTimes(1);
+    const copied = (copyToClipboard as jest.Mock).mock.calls[0][0] as string;
+    expect(copied).toContain('Hello from user');
+    expect(copied).toContain('Hello from bot');
+    expect(copied).not.toContain('Student message');
+  });
+
+  // When a teacher is viewing a student's chat in read only, copy those
+  // messages, not the teacher's own.
+  it('copies student chat history when on the student history tab', () => {
+    mockState.aichat.chatEventsPast = [userMessage];
+    mockState.aichat.chatEventsCurrent = [botMessage];
+    mockState.aichat.studentChatHistory = [studentHistoryMessage];
+    mockState.aichat.chatWorkspaceSelectedTab =
+      WorkspaceTeacherViewTab.STUDENT_CHAT_HISTORY;
+
+    render(<CopyChatHistoryButton />);
+    fireEvent.click(screen.getByRole('button'));
+
+    expect(copyToClipboard).toHaveBeenCalledTimes(1);
+    const copied = (copyToClipboard as jest.Mock).mock.calls[0][0] as string;
+    expect(copied).toContain('Student message');
+    expect(copied).not.toContain('Hello from user');
+    expect(copied).not.toContain('Hello from bot');
+  });
+
+  // When a teacher is "viewing as" student a la teacher panel,
+  // copy the teacher's own messages.
+  it('copies own messages when teacher is viewing as student', () => {
+    mockState.aichat.chatEventsPast = [userMessage];
+    mockState.aichat.studentChatHistory = [studentHistoryMessage];
+    mockState.aichat.chatWorkspaceSelectedTab =
+      WorkspaceTeacherViewTab.TEST_STUDENT_MODEL;
+
+    render(<CopyChatHistoryButton />);
+    fireEvent.click(screen.getByRole('button'));
+
+    expect(copyToClipboard).toHaveBeenCalledTimes(1);
+    const copied = (copyToClipboard as jest.Mock).mock.calls[0][0] as string;
+    expect(copied).toContain('Hello from user');
+    expect(copied).not.toContain('Student message');
+  });
+
+  // Copies an empty string rather than erroring with an empty chat.
+  it('copies an empty string when there are no messages', () => {
+    render(<CopyChatHistoryButton />);
+    fireEvent.click(screen.getByRole('button'));
+
+    expect(copyToClipboard).toHaveBeenCalledTimes(1);
+    const copied = (copyToClipboard as jest.Mock).mock.calls[0][0] as string;
+    expect(copied).toBe('');
+  });
+});

--- a/apps/test/unit/aichat/views/aiChatHeaderButtons/CopyChatHistoryButtonTest.tsx
+++ b/apps/test/unit/aichat/views/aiChatHeaderButtons/CopyChatHistoryButtonTest.tsx
@@ -5,6 +5,7 @@ import '@testing-library/jest-dom';
 import {AichatState} from '@cdo/apps/aichat/redux';
 import {
   CompletedChatMessage,
+  UserActionEvent,
   WorkspaceTeacherViewTab,
 } from '@cdo/apps/aichat/types';
 import CopyChatHistoryButton from '@cdo/apps/aichat/views/aiChatHeaderButtons/CopyChatHistoryButton';
@@ -20,12 +21,7 @@ const mockDispatch = jest.fn();
 // mockState is mutated per-test to simulate different redux store shapes.
 let mockState: {aichat: Partial<AichatState>};
 
-// Route all useSelector / useAppSelector calls through mockState instead of a real store.
-jest.mock('react-redux', () => ({
-  ...jest.requireActual('react-redux'),
-  useSelector: (selector: (s: unknown) => unknown) => selector(mockState),
-}));
-
+// Route all useAppSelector calls through mockState instead of a real store.
 jest.mock('@cdo/apps/util/reduxHooks', () => ({
   ...jest.requireActual('@cdo/apps/util/reduxHooks'),
   useAppSelector: (selector: (s: unknown) => unknown) => selector(mockState),
@@ -55,6 +51,12 @@ const studentHistoryMessage: CompletedChatMessage & {id: number} = {
   timestamp: 3000000,
   requestId: 3,
   id: 100,
+};
+
+const clearChatEvent: UserActionEvent & {id: number} = {
+  descriptionKey: 'CLEAR_CHAT',
+  timestamp: 4000000,
+  id: 101,
 };
 
 describe('CopyChatHistoryButton', () => {
@@ -120,6 +122,24 @@ describe('CopyChatHistoryButton', () => {
     const copied = (copyToClipboard as jest.Mock).mock.calls[0][0] as string;
     expect(copied).toContain('Hello from user');
     expect(copied).not.toContain('Student message');
+  });
+
+  // UserActionEvents (e.g. CLEAR_CHAT) appear in teacher-facing student history
+  // and must be included in the copied text.
+  it('includes UserActionEvents when copying student chat history', () => {
+    mockState.aichat.studentChatHistory = [
+      studentHistoryMessage,
+      clearChatEvent,
+    ];
+    mockState.aichat.chatWorkspaceSelectedTab =
+      WorkspaceTeacherViewTab.STUDENT_CHAT_HISTORY;
+
+    render(<CopyChatHistoryButton />);
+    fireEvent.click(screen.getByRole('button'));
+
+    const copied = (copyToClipboard as jest.Mock).mock.calls[0][0] as string;
+    expect(copied).toContain('Student message');
+    expect(copied).toContain('The user cleared the chat workspace.');
   });
 
   // Copies an empty string rather than erroring with an empty chat.

--- a/apps/test/unit/aichat/views/aiChatHeaderButtons/CopyChatHistoryButtonTest.tsx
+++ b/apps/test/unit/aichat/views/aiChatHeaderButtons/CopyChatHistoryButtonTest.tsx
@@ -5,7 +5,7 @@ import '@testing-library/jest-dom';
 import {AichatState} from '@cdo/apps/aichat/redux';
 import {
   CompletedChatMessage,
-  UserActionEvent,
+  ServerChatEvent,
   WorkspaceTeacherViewTab,
 } from '@cdo/apps/aichat/types';
 import CopyChatHistoryButton from '@cdo/apps/aichat/views/aiChatHeaderButtons/CopyChatHistoryButton';
@@ -44,7 +44,7 @@ const botMessage: CompletedChatMessage = {
   requestId: 2,
 };
 
-const studentHistoryMessage: CompletedChatMessage & {id: number} = {
+const studentHistoryMessage: ServerChatEvent = {
   role: Role.USER,
   chatMessageText: 'Student message',
   status: AiInteractionStatus.OK,
@@ -53,7 +53,7 @@ const studentHistoryMessage: CompletedChatMessage & {id: number} = {
   id: 100,
 };
 
-const clearChatEvent: UserActionEvent & {id: number} = {
+const clearChatEvent: ServerChatEvent = {
   descriptionKey: 'CLEAR_CHAT',
   timestamp: 4000000,
   id: 101,


### PR DESCRIPTION
The AI tutor copy chat button didn't know to look at the student's chat history instead of the teacher's own. Now, the copy chat will either copy the student's chat (if viewing read only student code), or their own chat (on the level in the context of a section with 'view as student' in the teacher panel, or on the level themselves. 

If a student has cleared their chat workspace, their copy button will give them an empty copy. However, the teacher viewing the student code who copies a workspace will see the previous chat history and a line for 'the student cleared the workspace'. 

I added tests to cover these cases as well. 

Before:

https://github.com/user-attachments/assets/8fe69dfc-85ed-480a-9f70-4781658cc93a




After:

https://github.com/user-attachments/assets/3bfba541-8cf0-42a4-ba2f-fc2113c84855



## Links

- Jira: https://codedotorg.atlassian.net/browse/AFL-551

## Testing story
<!-- How was this tested? Manual steps, adhoc links, automated tests, or why testing isn't needed. -->



## Deployment notes
<!-- Delete this section if it's a standard merge-and-deploy.
     Otherwise: migrations, feature flags, coordination, caching impacts, etc. -->



## Privacy and security
<!-- Delete this section if there is no privacy/security impact.
     Otherwise: new PII, auth changes, API surface changes, etc. -->

