### PR TITLE
Convert model output image file to png then save/moderate

### DIFF
--- a/apps/src/aichat/api/client/generateChatResponse.ts
+++ b/apps/src/aichat/api/client/generateChatResponse.ts
@@ -1,4 +1,4 @@
-import {type ModelMessage} from 'ai';
+import {type GeneratedFile, type ModelMessage} from 'ai';
 
 import {ACCEPTED_IMAGE_MEDIA_TYPES} from '@cdo/apps/aichat/constants';
 import {generateText} from '@cdo/apps/aiGateway';
@@ -21,6 +21,37 @@ import {
 } from './helpers/messageHelpers';
 import {getModel} from './helpers/modelHelpers';
 import {isTextSafe, getImageModerationStatus} from './helpers/safetyHelpers';
+
+// Converts any browser-renderable image to PNG via canvas.
+// Used with model-generated images since Vercel AI SDK doesn't currently expose output format configuration.
+// Also, Vercel AI SDK does not always report media type accurately (seen from HoneyBadger Azure error reports).
+const convertToPng = (file: GeneratedFile): Promise<File> =>
+  new Promise((resolve, reject) => {
+    const blob = new Blob([new Uint8Array(file.uint8Array)], {
+      type: file.mediaType,
+    });
+    const img = new Image();
+    const url = URL.createObjectURL(blob);
+    img.onload = () => {
+      const canvas = document.createElement('canvas');
+      canvas.width = img.naturalWidth;
+      canvas.height = img.naturalHeight;
+      canvas.getContext('2d')?.drawImage(img, 0, 0);
+      URL.revokeObjectURL(url);
+      canvas.toBlob(pngBlob => {
+        if (!pngBlob) {
+          reject(new Error('canvas toBlob failed'));
+          return;
+        }
+        resolve(new File([pngBlob], 'generated.png', {type: 'image/png'}));
+      }, 'image/png');
+    };
+    img.onerror = () => {
+      URL.revokeObjectURL(url);
+      reject(new Error('image load failed'));
+    };
+    img.src = url;
+  });
 
 /**
  * Performs all the steps necessary to generate a chat response:
@@ -88,27 +119,32 @@ export async function generateChatResponse(
     if (file.uint8Array.length === 0) {
       return {response: text, status: AiRequestExecutionStatus.FAILURE};
     }
-    let asset: ChatAsset;
-    try {
-      asset = await generatedFileToAsset(
-        file,
-        buildAssetUrl,
-        ACCEPTED_IMAGE_MEDIA_TYPES // Currently only image files are supported.
-      );
-    } catch (error) {
-      // Log and skip files with unsupported or unrecognized media types so the
-      // text response is still returned to the user.
-      Lab2Registry.getInstance()
-        .getMetricsReporter()
-        .logError('Skipping unsupported generated file type', error as Error);
-      continue;
-    }
-    assets.push(asset);
+    // Currently only image files are supported.
     if (file.mediaType.startsWith('image/')) {
+      // Gemini API output format is not configurable, so we convert to PNG for consistent asset storage and moderation.
+      const fileToSave = await convertToPng(file);
+
+      let asset: ChatAsset;
+      try {
+        asset = await generatedFileToAsset(
+          fileToSave,
+          buildAssetUrl,
+          ACCEPTED_IMAGE_MEDIA_TYPES
+        );
+      } catch (error) {
+        // Log and skip files with unsupported or unrecognized media types so the
+        // text response is still returned to the user.
+        Lab2Registry.getInstance()
+          .getMetricsReporter()
+          .logError('Skipping unsupported generated file type', error as Error);
+        continue;
+      }
+      assets.push(asset);
+
       sendLab2AnalyticsEvent(EVENTS.MODEL_OUTPUT_IMAGE_CREATED);
       // Check generated images for safety.
       const imageModerationStatus = await getImageModerationStatus(
-        file,
+        fileToSave,
         buildAssetUrl(asset)
       );
       if (imageModerationStatus === 'flagged') {

--- a/apps/src/aichat/api/client/generateChatResponse.ts
+++ b/apps/src/aichat/api/client/generateChatResponse.ts
@@ -102,6 +102,9 @@ export async function generateChatResponse(
     }
     assets.push(asset);
     if (file.mediaType.startsWith('image/')) {
+      if (file.uint8Array.length === 0) {
+        return {response: text, status: AiRequestExecutionStatus.FAILURE};
+      }
       sendLab2AnalyticsEvent(EVENTS.MODEL_OUTPUT_IMAGE_CREATED);
       // Check generated images for safety.
       const imageModerationStatus = await getImageModerationStatus(

--- a/apps/src/aichat/api/client/generateChatResponse.ts
+++ b/apps/src/aichat/api/client/generateChatResponse.ts
@@ -85,6 +85,9 @@ export async function generateChatResponse(
   // Upload generated assets, if any.
   const assets: ChatAsset[] = [];
   for (const file of files) {
+    if (file.uint8Array.length === 0) {
+      return {response: text, status: AiRequestExecutionStatus.FAILURE};
+    }
     let asset: ChatAsset;
     try {
       asset = await generatedFileToAsset(
@@ -102,9 +105,6 @@ export async function generateChatResponse(
     }
     assets.push(asset);
     if (file.mediaType.startsWith('image/')) {
-      if (file.uint8Array.length === 0) {
-        return {response: text, status: AiRequestExecutionStatus.FAILURE};
-      }
       sendLab2AnalyticsEvent(EVENTS.MODEL_OUTPUT_IMAGE_CREATED);
       // Check generated images for safety.
       const imageModerationStatus = await getImageModerationStatus(

--- a/apps/src/aichat/api/client/generateChatResponse.ts
+++ b/apps/src/aichat/api/client/generateChatResponse.ts
@@ -27,16 +27,22 @@ import {isTextSafe, getImageModerationStatus} from './helpers/safetyHelpers';
 // Also, Vercel AI SDK does not always report media type accurately (seen from HoneyBadger Azure error reports).
 const convertToPng = (file: GeneratedFile): Promise<File> =>
   new Promise((resolve, reject) => {
-    const blob = new Blob([new Uint8Array(file.uint8Array)], {
-      type: file.mediaType,
-    });
+    // Omit MIME type so the browser detects format from bytes.
+    // file.mediaType can be inaccurate (observed in production);
+    const blob = new Blob([new Uint8Array(file.uint8Array)]);
     const img = new Image();
     const url = URL.createObjectURL(blob);
     img.onload = () => {
       const canvas = document.createElement('canvas');
       canvas.width = img.naturalWidth;
       canvas.height = img.naturalHeight;
-      canvas.getContext('2d')?.drawImage(img, 0, 0);
+      const context = canvas.getContext('2d');
+      if (!context) {
+        URL.revokeObjectURL(url);
+        reject(new Error('canvas 2d context creation failed'));
+        return;
+      }
+      context.drawImage(img, 0, 0);
       URL.revokeObjectURL(url);
       canvas.toBlob(pngBlob => {
         if (!pngBlob) {
@@ -122,7 +128,15 @@ export async function generateChatResponse(
     // Currently only image files are supported.
     if (file.mediaType.startsWith('image/')) {
       // Gemini API output format is not configurable, so we convert to PNG for consistent asset storage and moderation.
-      const fileToSave = await convertToPng(file);
+      let fileToSave: File;
+      try {
+        fileToSave = await convertToPng(file);
+      } catch (error) {
+        Lab2Registry.getInstance()
+          .getMetricsReporter()
+          .logError('PNG conversion failed for generated file', error as Error);
+        continue;
+      }
 
       let asset: ChatAsset;
       try {

--- a/apps/src/aichat/api/client/helpers/fileHelpers.ts
+++ b/apps/src/aichat/api/client/helpers/fileHelpers.ts
@@ -1,4 +1,4 @@
-import {type FilePart, type GeneratedFile} from 'ai';
+import {type FilePart} from 'ai';
 import {
   extension as mimeToExtension,
   lookup as extensionToMime,
@@ -62,43 +62,25 @@ export async function assetToFilePart(
 }
 
 /**
- * Converts a model generated file to a ChatAsset by uploading the file's contents to the user's project.
+ * Uploads a browser File to the user's project and returns a ChatAsset.
  */
 export async function generatedFileToAsset(
-  file: GeneratedFile,
+  file: File,
   buildAssetUrl: (asset: ChatAsset) => string,
   accepts: string[]
 ): Promise<ChatAsset> {
-  const {filename, fileBuffer} = prepareGeneratedFile(file, accepts);
+  const extension = convertMediaTypeToExtension(file.type, accepts);
+  const filename = `generated-file-${createUuid()}.${extension}`;
   const asset: ChatAsset = {
     filename,
     source: AssetSource.PROJECT,
   };
   const assetUrl = buildAssetUrl(asset);
+  const fileBuffer = new Uint8Array(await file.arrayBuffer());
 
-  // Upload file contents to assetUrl
   await HttpClient.put(assetUrl, fileBuffer, true, {
-    'Content-Type': file.mediaType,
+    'Content-Type': file.type,
   });
 
   return asset;
-}
-
-interface PreparedFile {
-  filename: string;
-  fileBuffer: Uint8Array<ArrayBuffer>;
-  mediaType: string;
-}
-
-/**
- * Extracts the buffer and derives filename/extension from a model-generated file.
- */
-export function prepareGeneratedFile(
-  file: GeneratedFile,
-  accepts: string[]
-): PreparedFile {
-  const fileBuffer = file.uint8Array.slice();
-  const extension = convertMediaTypeToExtension(file.mediaType, accepts);
-  const filename = `generated-file-${createUuid()}.${extension}`;
-  return {filename, fileBuffer, mediaType: file.mediaType};
 }

--- a/apps/src/aichat/api/client/helpers/safetyHelpers.ts
+++ b/apps/src/aichat/api/client/helpers/safetyHelpers.ts
@@ -1,14 +1,12 @@
-import {type GeneratedFile, Output} from 'ai';
+import {Output} from 'ai';
 import z from 'zod/v3';
 
-import {ACCEPTED_IMAGE_MEDIA_TYPES} from '@cdo/apps/aichat/constants';
 import {generateText} from '@cdo/apps/aiGateway';
 import {EVENTS} from '@cdo/apps/metrics/AnalyticsConstants';
 import {ValueOf} from '@cdo/apps/types/utils';
 import {moderateImage} from '@cdo/apps/util/moderateImage';
 import {AiChatModelIds} from '@cdo/generated-scripts/sharedConstants';
 
-import {prepareGeneratedFile} from './fileHelpers';
 import {getModel} from './modelHelpers';
 
 const outputSchema = Output.object({
@@ -56,18 +54,12 @@ export async function isTextSafe(
 }
 
 export async function getImageModerationStatus(
-  file: GeneratedFile,
+  file: File,
   assetUrl: string
 ): Promise<'safe' | 'flagged' | 'error'> {
-  const {filename, fileBuffer, mediaType} = prepareGeneratedFile(
-    file,
-    ACCEPTED_IMAGE_MEDIA_TYPES
-  );
-  const image = new File([fileBuffer], filename, {type: mediaType});
-  const moderationStatus = await moderateImage(image, 'aichat', {
+  return moderateImage(file, 'aichat', {
     moderateEvent: EVENTS.MODERATE_MODEL_OUTPUT_IMAGE_AZURE,
     flaggedEvent: EVENTS.FLAGGED_MODEL_OUTPUT_IMAGE_AZURE,
     assetUrl,
   });
-  return moderationStatus;
 }

--- a/dashboard/legacy/middleware/files_api.rb
+++ b/dashboard/legacy/middleware/files_api.rb
@@ -1084,6 +1084,10 @@ class FilesApi < Sinatra::Base
 
     # Read the raw bytes and wrap in an IO.
     raw = request.body.read
+    if raw.empty?
+      status 400
+      return {error: 'No image data provided.'}.to_json
+    end
     image_stream = StringIO.new(raw)
 
     # Determine MIME type (e.g. "image/png", "image/jpeg").

--- a/dashboard/legacy/test/middleware/test_files.rb
+++ b/dashboard/legacy/test/middleware/test_files.rb
@@ -940,6 +940,14 @@ class FilesTest < FilesApiTestBase
     assert_equal({'error' => 'Unsupported image type. Only PNG, JPEG, and GIF files are allowed.'}, JSON.parse(last_response.body))
   end
 
+  def test_moderate_image_empty_body_returns_400
+    ImageModeration.expects(:moderate_image).never
+    header 'CONTENT_TYPE', 'image/png'
+    post '/v3/images/moderate', ''
+    assert_equal 400, last_response.status
+    assert_equal({'error' => 'No image data provided.'}, JSON.parse(last_response.body))
+  end
+
   private def delete_all_files(bucket)
     delete_all_objects(CDO.files_s3_bucket, bucket)
   end

--- a/lib/cdo/image_moderation.rb
+++ b/lib/cdo/image_moderation.rb
@@ -44,7 +44,7 @@ module ImageModeration
     if raw_data.bytesize > MAX_MODERATION_SIZE
       # Scale factor is approximate: file size is not strictly proportional to pixel
       # count for compressed formats, so scale conservatively to stay under the limit.
-      scale = Math.sqrt(MAX_MODERATION_SIZE.to_f / raw_data.bytesize) * 0.9
+      scale = Math.sqrt(MAX_MODERATION_SIZE.to_f / raw_data.bytesize) * 0.85
       new_w = (width * scale).floor
       new_h = (height * scale).floor
       image.resize "#{new_w}x#{new_h}!"

--- a/lib/cdo/image_moderation.rb
+++ b/lib/cdo/image_moderation.rb
@@ -6,6 +6,8 @@ require 'stringio'
 module ImageModeration
   # Azure AI Content Safety requires both dimensions to be at least this many pixels.
   MIN_MODERATION_DIMENSION = 50
+  # Downscale images when either side exceeds this (Azure and ImageMagick limits on very large rasters).
+  MAX_MODERATION_DIMENSION = 7200
   # Azure AI Content Safety requires images to be at most 4MB.
   MAX_MODERATION_SIZE = 4 * 1024 * 1024
 
@@ -30,6 +32,7 @@ module ImageModeration
 
   # Scales images to meet Azure AI Content Safety dimension and size requirements.
   # Scales up images smaller than MIN_MODERATION_DIMENSION on either dimension.
+  # Scales down images larger than MAX_MODERATION_DIMENSION on either dimension.
   # Scales down images larger than MAX_MODERATION_SIZE.
   # On errors, passes the original bytes through so Azure can still be tried.
   def self.scale_image_for_moderation_if_needed(image_data, content_type)
@@ -48,16 +51,24 @@ module ImageModeration
       return [StringIO.new(image.to_blob), content_type]
     end
 
-    if width >= MIN_MODERATION_DIMENSION && height >= MIN_MODERATION_DIMENSION
-      return StringIO.new(raw_data), content_type
+    if width < MIN_MODERATION_DIMENSION || height < MIN_MODERATION_DIMENSION
+      # Scale up images smaller than MIN_MODERATION_DIMENSION on either dimension using MiniMagick's
+      # ^ (minimum bounding box): scale up so both dimensions are at least MIN_MODERATION_DIMENSION,
+      # preserving aspect ratio (short side hits the minimum, long side may exceed it).
+      image.resize "#{MIN_MODERATION_DIMENSION}x#{MIN_MODERATION_DIMENSION}^"
+      image.format 'png'
+      return [StringIO.new(image.to_blob), 'image/png']
     end
 
-    scale = [MIN_MODERATION_DIMENSION.to_f / width, MIN_MODERATION_DIMENSION.to_f / height].max
-    new_w = (width * scale).ceil
-    new_h = (height * scale).ceil
-    image.resize "#{new_w}x#{new_h}!"
-    image.format 'png'
-    [StringIO.new(image.to_blob), 'image/png']
+    if width > MAX_MODERATION_DIMENSION || height > MAX_MODERATION_DIMENSION
+      # Scale down images larger than MAX_MODERATION_DIMENSION on either dimension using MiniMagick's
+      # > (maximum bounding box): scale down to fit within MAX_MODERATION_DIMENSION on each side,
+      # preserving aspect ratio (long side hits the maximum, short side may be smaller).
+      image.resize "#{MAX_MODERATION_DIMENSION}x#{MAX_MODERATION_DIMENSION}>"
+      return [StringIO.new(image.to_blob), content_type]
+    end
+
+    [StringIO.new(raw_data), content_type]
   rescue MiniMagick::Invalid, MiniMagick::Error
     [StringIO.new(raw_data), content_type]
   end

--- a/lib/cdo/image_moderation.rb
+++ b/lib/cdo/image_moderation.rb
@@ -6,6 +6,8 @@ require 'stringio'
 module ImageModeration
   # Azure AI Content Safety requires both dimensions to be at least this many pixels.
   MIN_MODERATION_DIMENSION = 50
+  # Azure AI Content Safety requires images to be at most 4MB.
+  MAX_MODERATION_SIZE = 4 * 1024 * 1024
 
   # @param [IO] image_data - binary image data to be rated
   # @param [String] content_type - image/gif, image/jpeg, image/png
@@ -26,13 +28,26 @@ module ImageModeration
     nil
   end
 
+  # Scales images to meet Azure AI Content Safety dimension and size requirements.
   # Scales up images smaller than MIN_MODERATION_DIMENSION on either dimension.
+  # Scales down images larger than MAX_MODERATION_SIZE.
   # On errors, passes the original bytes through so Azure can still be tried.
   def self.scale_image_for_moderation_if_needed(image_data, content_type)
     raw_data = image_data.read
     image = MiniMagick::Image.read(raw_data)
     width = image.width
     height = image.height
+
+    if raw_data.bytesize > MAX_MODERATION_SIZE
+      # Scale factor is approximate: file size is not strictly proportional to pixel
+      # count for compressed formats, so scale conservatively to stay under the limit.
+      scale = Math.sqrt(MAX_MODERATION_SIZE.to_f / raw_data.bytesize) * 0.9
+      new_w = (width * scale).floor
+      new_h = (height * scale).floor
+      image.resize "#{new_w}x#{new_h}!"
+      return [StringIO.new(image.to_blob), content_type]
+    end
+
     if width >= MIN_MODERATION_DIMENSION && height >= MIN_MODERATION_DIMENSION
       return StringIO.new(raw_data), content_type
     end

--- a/lib/cdo/image_moderation.rb
+++ b/lib/cdo/image_moderation.rb
@@ -41,23 +41,15 @@ module ImageModeration
     width = image.width
     height = image.height
 
-    if raw_data.bytesize > MAX_MODERATION_SIZE
-      # Scale factor is approximate: file size is not strictly proportional to pixel
-      # count for compressed formats, so scale conservatively to stay under the limit.
-      scale = Math.sqrt(MAX_MODERATION_SIZE.to_f / raw_data.bytesize) * 0.85
-      new_w = (width * scale).floor
-      new_h = (height * scale).floor
-      image.resize "#{new_w}x#{new_h}!"
-      return [StringIO.new(image.to_blob), content_type]
-    end
-
     if width < MIN_MODERATION_DIMENSION || height < MIN_MODERATION_DIMENSION
       # Scale up images smaller than MIN_MODERATION_DIMENSION on either dimension using MiniMagick's
       # ^ (minimum bounding box): scale up so both dimensions are at least MIN_MODERATION_DIMENSION,
       # preserving aspect ratio (short side hits the minimum, long side may exceed it).
       image.resize "#{MIN_MODERATION_DIMENSION}x#{MIN_MODERATION_DIMENSION}^"
       image.format 'png'
-      return [StringIO.new(image.to_blob), 'image/png']
+      raw_data = image.to_blob
+      width = image.width
+      height = image.height
     end
 
     if width > MAX_MODERATION_DIMENSION || height > MAX_MODERATION_DIMENSION
@@ -65,7 +57,19 @@ module ImageModeration
       # > (maximum bounding box): scale down to fit within MAX_MODERATION_DIMENSION on each side,
       # preserving aspect ratio (long side hits the maximum, short side may be smaller).
       image.resize "#{MAX_MODERATION_DIMENSION}x#{MAX_MODERATION_DIMENSION}>"
-      return [StringIO.new(image.to_blob), content_type]
+      raw_data = image.to_blob
+      width = image.width
+      height = image.height
+    end
+
+    if raw_data.bytesize > MAX_MODERATION_SIZE
+      # Scale factor is approximate: file size is not strictly proportional to pixel
+      # count for compressed formats, so scale conservatively to stay under the limit.
+      scale = Math.sqrt(MAX_MODERATION_SIZE.to_f / raw_data.bytesize) * 0.85
+      new_w = (width * scale).floor
+      new_h = (height * scale).floor
+      image.resize "#{new_w}x#{new_h}!"
+      raw_data = image.to_blob
     end
 
     [StringIO.new(raw_data), content_type]

--- a/lib/test/cdo/test_image_moderation.rb
+++ b/lib/test/cdo/test_image_moderation.rb
@@ -60,6 +60,34 @@ class ImageModerationTest < Minitest::Test
     assert_equal sample, ImageModeration.moderate_image(StringIO.new(blob), 'image/png')
   end
 
+  def test_scales_down_wide_images_exceeding_max_dimension
+    blob = tiny_png_blob(7300, 100)
+    io, ct = ImageModeration.scale_image_for_moderation_if_needed(StringIO.new(blob), 'image/png')
+    assert_equal 'image/png', ct
+    out = MiniMagick::Image.read(io.read)
+    assert_operator out.width, :<=, ImageModeration::MAX_MODERATION_DIMENSION
+    assert_operator out.height, :<=, ImageModeration::MAX_MODERATION_DIMENSION
+    assert_operator out.width, :>=, ImageModeration::MIN_MODERATION_DIMENSION
+    assert_operator out.height, :>=, ImageModeration::MIN_MODERATION_DIMENSION
+  end
+
+  def test_scales_down_tall_images_exceeding_max_dimension
+    blob = tiny_png_blob(100, 7300)
+    io, ct = ImageModeration.scale_image_for_moderation_if_needed(StringIO.new(blob), 'image/png')
+    assert_equal 'image/png', ct
+    out = MiniMagick::Image.read(io.read)
+    assert_operator out.width, :<=, ImageModeration::MAX_MODERATION_DIMENSION
+    assert_operator out.height, :<=, ImageModeration::MAX_MODERATION_DIMENSION
+  end
+
+  def test_scales_down_large_real_image_exceeding_max_byte_size
+    # A synthetic 2000x2000 uncompressed BMP is well over 4MB.
+    blob = large_png_blob_over_max_size
+    io, ct = ImageModeration.scale_image_for_moderation_if_needed(StringIO.new(blob), 'image/png')
+    assert_operator io.read.bytesize, :<=, ImageModeration::MAX_MODERATION_SIZE
+    assert_equal 'image/png', ct
+  end
+
   def test_returns_nil_when_moderation_fails
     test_err = AzureAiContentSafety::RequestFailed.new('Test error')
     AzureAiContentSafety.any_instance.expects(:moderate_image).raises(test_err)
@@ -73,6 +101,23 @@ class ImageModerationTest < Minitest::Test
       MiniMagick::Tool::Convert.new do |c|
         c.size "#{width}x#{height}"
         c << 'xc:white'
+        c << f.path
+      end
+      File.binread(f.path)
+    end
+  end
+
+  # Produces an uncompressed PNG large enough to exceed MAX_MODERATION_SIZE.
+  # A 1500x1500 noise image encodes to ~6-7MB without compression.
+  private def large_png_blob_over_max_size
+    Tempfile.create(%w[large .png]) do |f|
+      MiniMagick::Tool::Convert.new do |c|
+        c.size '1500x1500'
+        # plasma:fractal is an ImageMagick build-in image generator that produceds
+        # a ranndomly colored plasma grident. It results in enough pixel variation to defeat
+        # PNG's compression algorithm so we can produce a large image that exceeds MAX_MODERATION_SIZE.
+        c << 'plasma:fractal'
+        c.compress 'None'
         c << f.path
       end
       File.binread(f.path)

--- a/lib/test/cdo/test_image_moderation.rb
+++ b/lib/test/cdo/test_image_moderation.rb
@@ -112,7 +112,7 @@ class ImageModerationTest < Minitest::Test
     Tempfile.create(%w[large .png]) do |f|
       MiniMagick::Tool::Convert.new do |c|
         c.size '1500x1500'
-        # plasma:fractal is an ImageMagick build-in image generator that produces
+        # plasma:fractal is an ImageMagick built-in image generator that produces
         # a randomly colored plasma gradient. It results in enough pixel variation to defeat
         # PNG's compression algorithm so we can produce a large image that exceeds MAX_MODERATION_SIZE.
         c << 'plasma:fractal'

--- a/lib/test/cdo/test_image_moderation.rb
+++ b/lib/test/cdo/test_image_moderation.rb
@@ -81,7 +81,6 @@ class ImageModerationTest < Minitest::Test
   end
 
   def test_scales_down_large_real_image_exceeding_max_byte_size
-    # A synthetic 2000x2000 uncompressed BMP is well over 4MB.
     blob = large_png_blob_over_max_size
     io, ct = ImageModeration.scale_image_for_moderation_if_needed(StringIO.new(blob), 'image/png')
     assert_operator io.read.bytesize, :<=, ImageModeration::MAX_MODERATION_SIZE
@@ -113,8 +112,8 @@ class ImageModerationTest < Minitest::Test
     Tempfile.create(%w[large .png]) do |f|
       MiniMagick::Tool::Convert.new do |c|
         c.size '1500x1500'
-        # plasma:fractal is an ImageMagick build-in image generator that produceds
-        # a ranndomly colored plasma grident. It results in enough pixel variation to defeat
+        # plasma:fractal is an ImageMagick build-in image generator that produces
+        # a randomly colored plasma gradient. It results in enough pixel variation to defeat
         # PNG's compression algorithm so we can produce a large image that exceeds MAX_MODERATION_SIZE.
         c << 'plasma:fractal'
         c.compress 'None'

--- a/lib/test/cdo/test_image_moderation.rb
+++ b/lib/test/cdo/test_image_moderation.rb
@@ -87,6 +87,32 @@ class ImageModerationTest < Minitest::Test
     assert_equal 'image/png', ct
   end
 
+  # Extreme-ratio image: one side below MIN, the other above MAX.
+  # e.g. 8000x40 -> MIN upscale brings it to ~10000x50, then MAX downscale
+  # brings it to ~7200x36. Both MAX constraints must be satisfied; MIN is
+  # not achievable on the short side after the MAX downscale for such ratios.
+  def test_extreme_ratio_image_satisfies_max_dimension_constraints
+    blob = tiny_png_blob(8000, 40)
+    io, ct = ImageModeration.scale_image_for_moderation_if_needed(StringIO.new(blob), 'image/png')
+    assert_equal 'image/png', ct
+    out = MiniMagick::Image.read(io.read)
+    assert_operator out.width, :<=, ImageModeration::MAX_MODERATION_DIMENSION
+    assert_operator out.height, :<=, ImageModeration::MAX_MODERATION_DIMENSION
+  end
+
+  # Image that exceeds both MAX_MODERATION_DIMENSION and MAX_MODERATION_SIZE.
+  # Verifies both downscaling passes run sequentially and all constraints are met.
+  def test_oversized_dimension_and_bytes_satisfies_all_constraints
+    blob = large_png_blob_over_max_size_and_dimension
+    io, ct = ImageModeration.scale_image_for_moderation_if_needed(StringIO.new(blob), 'image/png')
+    assert_equal 'image/png', ct
+    bytes = io.read
+    out = MiniMagick::Image.read(bytes)
+    assert_operator out.width, :<=, ImageModeration::MAX_MODERATION_DIMENSION
+    assert_operator out.height, :<=, ImageModeration::MAX_MODERATION_DIMENSION
+    assert_operator bytes.bytesize, :<=, ImageModeration::MAX_MODERATION_SIZE
+  end
+
   def test_returns_nil_when_moderation_fails
     test_err = AzureAiContentSafety::RequestFailed.new('Test error')
     AzureAiContentSafety.any_instance.expects(:moderate_image).raises(test_err)
@@ -115,6 +141,21 @@ class ImageModerationTest < Minitest::Test
         # plasma:fractal is an ImageMagick built-in image generator that produces
         # a randomly colored plasma gradient. It results in enough pixel variation to defeat
         # PNG's compression algorithm so we can produce a large image that exceeds MAX_MODERATION_SIZE.
+        c << 'plasma:fractal'
+        c.compress 'None'
+        c << f.path
+      end
+      File.binread(f.path)
+    end
+  end
+
+  # Produces an uncompressed PNG that exceeds both MAX_MODERATION_DIMENSION (7200px)
+  # and MAX_MODERATION_SIZE (4MB). 7300x400 plasma:fractal at ~8.7MB uncompressed
+  # exercises the sequential dimension-then-size downscaling path.
+  private def large_png_blob_over_max_size_and_dimension
+    Tempfile.create(%w[large_wide .png]) do |f|
+      MiniMagick::Tool::Convert.new do |c|
+        c.size '7300x400'
         c << 'plasma:fractal'
         c.compress 'None'
         c << f.path


### PR DESCRIPTION
<!--
  Summary of the change: background, motivation, and context.
  Include screenshots, videos, or before/after comparisons for UI changes.
-->
This PR converts model-generated images to PNG files to avoid the following reported error:

```
AzureAiContentSafety::RequestFailed: Request to Azure AI Content Safety failed with status 400
The image format is not supported. Please double check the API definition.
```
[Example report](https://app.honeybadger.io/projects/3240/faults/129339498/01KP4CNPG274JY00165N0V3KF0?page=0)

We use Vercel AI SDK for client implementation of generating assistant responses when Gemini Flash Image 2.5 model is selected. Currently, the media type is included in the returned generated file, but seems to not always match the actual file type as we return early if the file extension is not supported at:
https://github.com/code-dot-org/code-dot-org/blob/382b9588828265163e487d272b3ed15d0268c2cf/apps/src/util/moderateImage.ts#L49-L54

But we are still reporting errors that 'the image format is not supported'. 

So this PR converts browser-renderable images to PNG files before saving to project assets and moderating.



## Links
<!-- Jira tickets, design docs, Slack threads, related PRs, etc. -->

- Jira: https://codedotorg.atlassian.net/browse/SL-1670
- https://codedotorg.atlassian.net/browse/SL-1648

## Testing story
<!-- How was this tested? Manual steps, adhoc links, automated tests, or why testing isn't needed. -->

Tested locally on `aichat` levels with Gemini 2.5 Flash Image model selected. No change for user.

## Deployment notes
<!-- Delete this section if it's a standard merge-and-deploy.
     Otherwise: migrations, feature flags, coordination, caching impacts, etc. -->



## Privacy and security
<!-- Delete this section if there is no privacy/security impact.
     Otherwise: new PII, auth changes, API surface changes, etc. -->

