### PR TITLE
Add check that the student belongs to current user

### DIFF
--- a/dashboard/app/controllers/student_snapshots_controller.rb
+++ b/dashboard/app/controllers/student_snapshots_controller.rb
@@ -165,6 +165,10 @@ class StudentSnapshotsController < ApplicationController
     student = User.find_by(id: student_id)
     return render json: {error: "Can't find Student id=#{student_id}"}, status: :bad_request unless student
 
+    unless student.student_of?(current_user)
+      return render json: {error: "Unauthorized access to student data"}, status: :forbidden
+    end
+
     script = lesson.script
     cfu_responses_data = []
 
@@ -212,6 +216,13 @@ class StudentSnapshotsController < ApplicationController
   def student_code
     lesson = Lesson.find_by(id: params[:lesson_id])
     return render json: {error: "Can't find Lesson id=#{params[:lesson_id]}"}, status: :bad_request unless lesson
+
+    student = User.find_by(id: params[:student_id])
+    return render json: {error: "Can't find Student id=#{params[:student_id]}"}, status: :bad_request unless student
+
+    unless student.student_of?(current_user)
+      return render json: {error: "Unauthorized access to student data"}, status: :forbidden
+    end
 
     # Get the last Pythonlab level for this lesson
     level = lesson.levels.where(type: 'Pythonlab').last

--- a/dashboard/test/controllers/student_snapshots_controller_test.rb
+++ b/dashboard/test/controllers/student_snapshots_controller_test.rb
@@ -2,7 +2,9 @@ require 'test_helper'
 
 class StudentSnapshotsControllerTest < ActionController::TestCase
   setup do
-    sign_in(create(:teacher))
+    @teacher = create(:teacher)
+    sign_in(@teacher)
+    @section = create(:section, user: @teacher)
     @unit = create(:unit, name: 'test-unit')
     @lesson_group = create(:lesson_group, script: @unit)
     @lesson1 = create(:lesson,
@@ -308,6 +310,7 @@ class StudentSnapshotsControllerTest < ActionController::TestCase
 
     # Create a student and a UserLevel with a LevelSource (student answer)
     student = create(:student)
+    create(:follower, user: @teacher, student_user: student, section: @section)
     script = @unit
     level_source = create(:level_source, data: '1')
     create(:user_level, user: student, script: script, level: cfu_level, level_source: level_source, submitted: true)
@@ -343,6 +346,7 @@ class StudentSnapshotsControllerTest < ActionController::TestCase
     cfu_script_level = create(:script_level, script: @unit, lesson: @lesson1, progression: 'Check Your Understanding', levels: [level_group])
 
     student = create(:student)
+    create(:follower, user: @teacher, student_user: student, section: @section)
     script = @unit
 
     # Student submitted the LevelGroup and answered the sublevel.
@@ -394,11 +398,13 @@ class StudentSnapshotsControllerTest < ActionController::TestCase
     create(:script_level, script: @unit, lesson: @lesson1, progression: 'Check Your Understanding', levels: [free_res_cfu_level])
 
     student_with_submitted_levels = create(:student)
+    create(:follower, user: @teacher, student_user: student_with_submitted_levels, section: @section)
     create(:user_level, user: student_with_submitted_levels, script: @unit, level: multi_cfu_level, level_source: create(:level_source, data: '1'))
     create(:user_level, user: student_with_submitted_levels, script: @unit, level: match_cfu_level, level_source: create(:level_source, data: '0,2,1'))
     create(:user_level, user: student_with_submitted_levels, script: @unit, level: free_res_cfu_level, level_source: create(:level_source, data: 'Sample free response text'))
 
     student_with_unsubmitted_levels = create(:student)
+    create(:follower, user: @teacher, student_user: student_with_unsubmitted_levels, section: @section)
     create(:user_level, user: student_with_unsubmitted_levels, script: @unit, level: multi_cfu_level, level_source: create(:level_source, data: '-1'))
     create(:user_level, user: student_with_unsubmitted_levels, script: @unit, level: match_cfu_level, level_source: create(:level_source, data: ''))
     create(:user_level, user: student_with_unsubmitted_levels, script: @unit, level: free_res_cfu_level, level_source: create(:level_source, data: ''))
@@ -510,6 +516,7 @@ class StudentSnapshotsControllerTest < ActionController::TestCase
     create(:script_level, script: @unit, lesson: @lesson1, progression: 'Check Your Understanding', levels: [level_group], assessment: true)
 
     student_with_submitted_levels = create(:student)
+    create(:follower, user: @teacher, student_user: student_with_submitted_levels, section: @section)
     # Even if the LevelGroup has a 'submitted' value of 'false', if the student has submitted each sublevel the response will return 'submitted' as 'true'
     create(:user_level, user: student_with_submitted_levels, script: @unit, level: level_group, submitted: false)
     create(:user_level, user: student_with_submitted_levels, script: @unit, level: multi_cfu_sublevel, level_source: create(:level_source, data: '1'))
@@ -517,6 +524,7 @@ class StudentSnapshotsControllerTest < ActionController::TestCase
     create(:user_level, user: student_with_submitted_levels, script: @unit, level: free_res_cfu_sublevel, level_source: create(:level_source, data: 'Sample free response text'))
 
     student_with_unsubmitted_levels = create(:student)
+    create(:follower, user: @teacher, student_user: student_with_unsubmitted_levels, section: @section)
     create(:user_level, user: student_with_unsubmitted_levels, script: @unit, level: level_group, submitted: false)
     create(:user_level, user: student_with_unsubmitted_levels, script: @unit, level: multi_cfu_sublevel, level_source: create(:level_source, data: '-1'))
     create(:user_level, user: student_with_unsubmitted_levels, script: @unit, level: match_cfu_sublevel, level_source: create(:level_source, data: ''))
@@ -535,5 +543,31 @@ class StudentSnapshotsControllerTest < ActionController::TestCase
     student_response = response_data['cfu_responses'].first
 
     assert_equal false, student_response['submitted']
+  end
+
+  test "cfu_responses endpoint returns forbidden when student does not belong to current teacher" do
+    other_teacher = create(:teacher)
+    student = create(:student)
+    other_section = create(:section, user: other_teacher)
+    create(:follower, user: other_teacher, student_user: student, section: other_section)
+
+    get :cfu_responses, params: {lesson_id: @lesson1.id, student_id: student.id}
+
+    assert_response :forbidden
+    response_data = JSON.parse(response.body)
+    assert_includes response_data['error'], "Unauthorized access to student data"
+  end
+
+  test "student_code endpoint returns forbidden when student does not belong to current teacher" do
+    other_teacher = create(:teacher)
+    student = create(:student)
+    other_section = create(:section, user: other_teacher)
+    create(:follower, user: other_teacher, student_user: student, section: other_section)
+
+    get :student_code, params: {lesson_id: @lesson1.id, student_id: student.id, unit_id: @unit.id}
+
+    assert_response :forbidden
+    response_data = JSON.parse(response.body)
+    assert_includes response_data['error'], "Unauthorized access to student data"
   end
 end

--- a/dashboard/test/controllers/student_snapshots_controller_test.rb
+++ b/dashboard/test/controllers/student_snapshots_controller_test.rb
@@ -558,6 +558,24 @@ class StudentSnapshotsControllerTest < ActionController::TestCase
     assert_includes response_data['error'], "Unauthorized access to student data"
   end
 
+  test "student_code endpoint returns 200 with studentCode shape when student belongs to current teacher" do
+    pythonlab_level = create(:pythonlab, name: 'Test Pythonlab Level')
+    create(:script_level, script: @unit, lesson: @lesson1, levels: [pythonlab_level])
+
+    student = create(:student)
+    create(:follower, user: @teacher, student_user: student, section: @section)
+
+    fake_code = {'main.py' => 'print("hello")'}
+    @controller.stubs(:get_student_code).returns({student_code: fake_code})
+
+    get :student_code, params: {lesson_id: @lesson1.id, student_id: student.id, unit_id: @unit.id}
+
+    assert_response :ok
+    response_data = JSON.parse(response.body)
+    assert response_data.key?('studentCode'), "response should include 'studentCode' key"
+    assert_equal fake_code, response_data['studentCode']
+  end
+
   test "student_code endpoint returns forbidden when student does not belong to current teacher" do
     other_teacher = create(:teacher)
     student = create(:student)


### PR DESCRIPTION
Updated both the impacted paths to check that the student is a student of the logged in user.   Updated tests accordingly.  

Then also checked on staging vs this branch that if a user tried to user the paths changed, they would get an error (see screenshot below for when the path tries to go to a user that is not in the current_user's section).  This was my first time checking this using the console, and it seemed to work ok. 



<img width="518" height="334" alt="image" src="https://github.com/user-attachments/assets/105be930-387e-411d-b6f6-fe0bec7299e2" />


## Links
Addresses[ this issue](https://codedotorg.slack.com/archives/C3MJGK03F/p1776101864154459?thread_ts=1774309599.696309&cid=C3MJGK03F) raised by bug crowd.