### PR TITLE
Add sentry user_id

### DIFF
--- a/dashboard/engines/observability/app/controllers/concerns/observability/sentry/user_context.rb
+++ b/dashboard/engines/observability/app/controllers/concerns/observability/sentry/user_context.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module Observability
+  module Sentry
+    module UserContext
+      extend ActiveSupport::Concern
+
+      included do
+        before_action :set_user_context
+      end
+
+      private def set_user_context
+        ::Sentry.set_user(id: current_user.id.to_s) if current_user
+      end
+    end
+  end
+end

--- a/dashboard/engines/observability/app/controllers/concerns/observability/sentry/user_context.rb
+++ b/dashboard/engines/observability/app/controllers/concerns/observability/sentry/user_context.rb
@@ -10,7 +10,8 @@ module Observability
       end
 
       private def set_user_context
-        ::Sentry.set_user(id: current_user.id.to_s) if current_user
+        user = request.env['warden']&.user(scope: :user, run_callbacks: false)
+        ::Sentry.set_user(id: user.id) if user.present?
       end
     end
   end

--- a/dashboard/engines/observability/app/controllers/concerns/observability/sentry/user_context.rb
+++ b/dashboard/engines/observability/app/controllers/concerns/observability/sentry/user_context.rb
@@ -19,9 +19,9 @@ module Observability
       # Also skip for Devise session controller actions, since calling current_user in those methods
       # can cause unintended side effects with the Rails session and CSRF tokens.
       private def skip_sentry_user_context?
-        return true if unauthenticated_request?
+        return true if controller_name == 'sessions' && %w[new create destroy reset].include?(action_name)
 
-        controller_name == 'sessions' && %w[new create destroy reset].include?(action_name)
+        unauthenticated_request?
       end
 
       # This method intentionally checks using the Warden authenticated? method rather than relying

--- a/dashboard/engines/observability/app/controllers/concerns/observability/sentry/user_context.rb
+++ b/dashboard/engines/observability/app/controllers/concerns/observability/sentry/user_context.rb
@@ -10,8 +10,24 @@ module Observability
       end
 
       private def set_user_context
-        user = request.env['warden']&.user(scope: :user, run_callbacks: false)
-        ::Sentry.set_user(id: user.id) if user.present?
+        return if skip_sentry_user_context?
+
+        ::Sentry.set_user(id: current_user.id)
+      end
+
+      # If the user isn't logged in, we skip trying to log the user context to Sentry.
+      # Also skip for Devise session controller actions, since calling current_user in those methods
+      # can cause unintended side effects with the Rails session and CSRF tokens.
+      private def skip_sentry_user_context?
+        return true if unauthenticated_request?
+
+        controller_name == 'sessions' && %w[new create destroy reset].include?(action_name)
+      end
+
+      # This method intentionally checks using the Warden authenticated? method rather than relying
+      # on the Devise current_user helper, which calls warden.authenticate under certain circumstances.
+      private def unauthenticated_request?
+        !request.env['warden']&.authenticated?(:user)
       end
     end
   end

--- a/dashboard/engines/observability/app/controllers/concerns/observability/sentry/user_context.rb
+++ b/dashboard/engines/observability/app/controllers/concerns/observability/sentry/user_context.rb
@@ -27,7 +27,7 @@ module Observability
       # This method intentionally checks using the Warden authenticated? method rather than relying
       # on the Devise current_user helper, which calls warden.authenticate under certain circumstances.
       private def unauthenticated_request?
-        !request.env['warden']&.authenticated?(:user)
+        request.env['warden']&.authenticated?(:user) != true
       end
     end
   end

--- a/dashboard/engines/observability/lib/observability/engine.rb
+++ b/dashboard/engines/observability/lib/observability/engine.rb
@@ -16,6 +16,12 @@ module Observability
       require 'sentry-ruby'
       require 'sentry-rails'
       require 'sentry-opentelemetry' if CDO.enable_opentelemetry
+
+      config.to_prepare do
+        ActiveSupport.on_load(:action_controller) do
+          include Observability::Sentry::UserContext
+        end
+      end
     end
 
     initializer 'observability.opentelemetry' do

--- a/dashboard/engines/observability/test/lib/observability/sentry_test.rb
+++ b/dashboard/engines/observability/test/lib/observability/sentry_test.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'test_helper'
+require_relative '../../../app/controllers/concerns/observability/sentry/user_context'
 
 describe Observability::Sentry do
   before do
@@ -77,5 +78,41 @@ describe Observability::Sentry do
         end
       end
     end
+  end
+end
+
+describe Observability::Sentry::UserContext do
+  before do
+    # This engine test runs without the dashboard application's ApplicationController.
+    # rubocop:disable Rails/ApplicationController
+    @controller_class = Class.new(ActionController::Base) do
+      include Observability::Sentry::UserContext
+
+      attr_accessor :current_user
+    end
+    # rubocop:enable Rails/ApplicationController
+    @controller = @controller_class.new
+  end
+
+  it 'registers set_user_context as a before_action' do
+    before_action_filters = @controller_class._process_action_callbacks.select do |callback|
+      callback.kind == :before
+    end.map(&:filter)
+
+    _(before_action_filters).must_include :set_user_context
+  end
+
+  it 'sets the Sentry user when current_user is present' do
+    @controller.current_user = stub(id: 123)
+
+    Sentry.expects(:set_user).with(id: '123')
+
+    @controller.send(:set_user_context)
+  end
+
+  it 'does not set the Sentry user when current_user is nil' do
+    Sentry.expects(:set_user).never
+
+    @controller.send(:set_user_context)
   end
 end

--- a/dashboard/engines/observability/test/lib/observability/sentry_test.rb
+++ b/dashboard/engines/observability/test/lib/observability/sentry_test.rb
@@ -87,13 +87,10 @@ describe Observability::Sentry::UserContext do
     # rubocop:disable Rails/ApplicationController
     @controller_class = Class.new(ActionController::Base) do
       include Observability::Sentry::UserContext
-
-      def current_user
-        raise 'current_user should not be called from Observability::Sentry::UserContext'
-      end
     end
     # rubocop:enable Rails/ApplicationController
     @controller = @controller_class.new
+    @controller.stubs(:devise_controller?).returns(false)
   end
 
   it 'registers set_user_context as a before_action' do
@@ -104,21 +101,23 @@ describe Observability::Sentry::UserContext do
     _(before_action_filters).must_include :set_user_context
   end
 
-  it 'sets the Sentry user from warden session user without callbacks' do
+  it 'sets the Sentry user from current_user on authenticated requests' do
     user = stub(id: SecureRandom.random_number(1..1000))
     warden = mock('warden')
-    warden.expects(:user).with(scope: :user, run_callbacks: false).returns(user)
+    warden.expects(:authenticated?).with(:user).returns(true)
     @controller.stubs(:request).returns(stub(env: {'warden' => warden}))
+    @controller.stubs(:current_user).returns(user)
 
     Sentry.expects(:set_user).with(id: user.id)
 
     @controller.send(:set_user_context)
   end
 
-  it 'does not set the Sentry user when no warden user is present' do
+  it 'does not set the Sentry user when the request is not authenticated' do
     warden = mock('warden')
-    warden.expects(:user).with(scope: :user, run_callbacks: false).returns(nil)
+    warden.expects(:authenticated?).with(:user).returns(false)
     @controller.stubs(:request).returns(stub(env: {'warden' => warden}))
+    @controller.expects(:current_user).never
 
     Sentry.expects(:set_user).never
 
@@ -127,6 +126,29 @@ describe Observability::Sentry::UserContext do
 
   it 'does not set the Sentry user when warden is unavailable' do
     @controller.stubs(:request).returns(stub(env: {}))
+    @controller.expects(:current_user).never
+
+    Sentry.expects(:set_user).never
+
+    @controller.send(:set_user_context)
+  end
+
+  it 'does not set the Sentry user on signed-out Devise requests' do
+    warden = mock('warden')
+    warden.expects(:authenticated?).with(:user).returns(false)
+    @controller.stubs(:request).returns(stub(env: {'warden' => warden}))
+    @controller.stubs(:devise_controller?).returns(true)
+    @controller.expects(:current_user).never
+
+    Sentry.expects(:set_user).never
+
+    @controller.send(:set_user_context)
+  end
+
+  it 'does not set the Sentry user on Devise session create' do
+    @controller.stubs(:action_name).returns('create')
+    @controller.stubs(:controller_name).returns('sessions')
+    @controller.expects(:current_user).never
 
     Sentry.expects(:set_user).never
 

--- a/dashboard/engines/observability/test/lib/observability/sentry_test.rb
+++ b/dashboard/engines/observability/test/lib/observability/sentry_test.rb
@@ -88,7 +88,9 @@ describe Observability::Sentry::UserContext do
     @controller_class = Class.new(ActionController::Base) do
       include Observability::Sentry::UserContext
 
-      attr_accessor :current_user
+      def current_user
+        raise 'current_user should not be called from Observability::Sentry::UserContext'
+      end
     end
     # rubocop:enable Rails/ApplicationController
     @controller = @controller_class.new
@@ -102,15 +104,30 @@ describe Observability::Sentry::UserContext do
     _(before_action_filters).must_include :set_user_context
   end
 
-  it 'sets the Sentry user when current_user is present' do
-    @controller.current_user = stub(id: 123)
+  it 'sets the Sentry user from warden session user without callbacks' do
+    user = stub(id: SecureRandom.random_number(1..1000))
+    warden = mock('warden')
+    warden.expects(:user).with(scope: :user, run_callbacks: false).returns(user)
+    @controller.stubs(:request).returns(stub(env: {'warden' => warden}))
 
-    Sentry.expects(:set_user).with(id: '123')
+    Sentry.expects(:set_user).with(id: user.id)
 
     @controller.send(:set_user_context)
   end
 
-  it 'does not set the Sentry user when current_user is nil' do
+  it 'does not set the Sentry user when no warden user is present' do
+    warden = mock('warden')
+    warden.expects(:user).with(scope: :user, run_callbacks: false).returns(nil)
+    @controller.stubs(:request).returns(stub(env: {'warden' => warden}))
+
+    Sentry.expects(:set_user).never
+
+    @controller.send(:set_user_context)
+  end
+
+  it 'does not set the Sentry user when warden is unavailable' do
+    @controller.stubs(:request).returns(stub(env: {}))
+
     Sentry.expects(:set_user).never
 
     @controller.send(:set_user_context)


### PR DESCRIPTION
Re-adds user_id to Sentry in a way that avoids calling `current_user` in routes where it could be problematic. [The first PR](https://github.com/code-dot-org/code-dot-org/pull/71757) that introduced this functionality caused a breakage in the email login route, due to `current_user` calling `warden.authenticate` and rotating the CSRF token. 

This PR is more careful about running `current_user`; instead of checking `current_user` for every request, it skips the following scenarios entirely:
- Unauthenticated requests, since we don't have a `user_id` anyway
- `new`, `create`, `destroy`, and `reset` actions in the `SessionsController`. Avoiding `current_user` in the `:before_action` for these routes should prevent the 422s we saw when the original PR was shipped.

I also tried avoiding `current_user` entirely, but it ended up breaking other session-related functionality. You can get the user directly from warden using `request.env['warden']&.user(scope: :user, run_callbacks: false)`, which avoids running callbacks like `clean_csrf` - but this ends up breaking subsequent callbacks later in the request. Rather than dive into debugging that, I figured it was simpler to just use the `current_user` helper, which is the recommended way to access the logged-in user in Devise.

## Links
[JIRA](https://codedotorg.atlassian.net/browse/P20-1847)

## Testing story
<!-- How was this tested? Manual steps, adhoc links, automated tests, or why testing isn't needed. -->



## Deployment notes
<!-- Delete this section if it's a standard merge-and-deploy.
     Otherwise: migrations, feature flags, coordination, caching impacts, etc. -->



## Privacy and security
<!-- Delete this section if there is no privacy/security impact.
     Otherwise: new PII, auth changes, API surface changes, etc. -->

