### PR TITLE
AI Tutor: json videos migration and model

### DIFF
--- a/dashboard/app/models/json_video.rb
+++ b/dashboard/app/models/json_video.rb
@@ -1,0 +1,25 @@
+# == Schema Information
+#
+# Table name: json_videos
+#
+#  id          :bigint           not null, primary key
+#  key         :string(255)      not null
+#  description :string(255)
+#  s3_uri      :string(255)      not null
+#  lab         :string(255)
+#  version     :integer          not null
+#  audience    :string(255)      not null
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#
+# Indexes
+#
+#  index_json_videos_on_key  (key) UNIQUE
+#
+
+class JSONVideo < ApplicationRecord
+  validates :key, presence: true, uniqueness: true
+  validates :s3_uri, presence: true
+  validates :version, presence: true
+  validates :audience, presence: true
+end

--- a/dashboard/db/migrate/20260414104541_create_json_videos.rb
+++ b/dashboard/db/migrate/20260414104541_create_json_videos.rb
@@ -1,0 +1,16 @@
+class CreateJSONVideos < ActiveRecord::Migration[7.0]
+  def change
+    create_table :json_videos do |t|
+      t.string :key, null: false
+      t.string :description
+      t.string :s3_uri, null: false
+      t.string :lab
+      t.integer :version, null: false
+      t.string :audience, null: false
+
+      t.timestamps
+    end
+
+    add_index :json_videos, :key, unique: true
+  end
+end

--- a/dashboard/db/schema.rb
+++ b/dashboard/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2026_04_07_175945) do
+ActiveRecord::Schema[7.0].define(version: 2026_04_14_104541) do
   create_table "activities", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "user_id"
     t.integer "level_id"
@@ -919,6 +919,18 @@ ActiveRecord::Schema[7.0].define(version: 2026_04_07_175945) do
     t.bigint "resource_id", null: false
     t.index ["jit_pl_teaching_tip_id", "resource_id"], name: "index_teaching_tips_resources_on_tip_and_resource_ids", unique: true
     t.index ["resource_id", "jit_pl_teaching_tip_id"], name: "index_teaching_tips_resources_on_resource_and_tip_ids", unique: true
+  end
+
+  create_table "json_videos", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+    t.string "key", null: false
+    t.string "description"
+    t.string "s3_uri", null: false
+    t.string "lab"
+    t.integer "version", null: false
+    t.string "audience", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["key"], name: "index_json_videos_on_key", unique: true
   end
 
   create_table "learning_goal_ai_evaluation_feedbacks", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|


### PR DESCRIPTION
There's now a pipeline for generating JSON videos to use as supplements to the curriculum! https://github.com/code-dot-org/code-dot-org/pull/71975 Right now the example videos are stored in `apps/static/jsonVideos` and are limited to a handful of Python programming topics, but ultimately we want to be generating more videos and using them in more places. 

The 3 currently planned use cases for these videos are: 
- AI Tutor in a level can recommend a video to help a student complete the level or better understand the level content
- AI Tutor+ can recommend a video in the lesson "deep dive" space to help a student review or clarify their understanding of the lesson content https://github.com/code-dot-org/code-dot-org/pull/71947
- TA can recommend just-in-time professional development videos to support teachers in more deeply understanding the material and our product 

To ensure that the AI assistants have enough information to serve the correct video at the right time we're adding jsonVideos as a model in our database so we can reference videos and associate them with other entities, such as LessonObjectives or PLConcepts. 

The actual JSON for the video will be stored in S3 (ongoing discussion of exactly where [here](https://codedotorg.slack.com/archives/C03CK49G9/p1776096644678789)). For the immediate use case of showing videos in AI Tutor+ lesson "deep dive", Curriculum will generate the videos and add them to an csv that we will use to seed JSON videos.

Future work for AI Tutor+: 
- join table between JsonVideos and Objectives 
- csv upload of lesson videos 
- seed json videos from csv
- store lesson videos in s3 
- fetch lesson videos on load of AI Tutor+
- play recommended video based target Objective based on student reflection and lesson progress 