### PR TITLE
AI Tutor: lesson deep dive welcome page 

### DIFF
--- a/apps/src/aiTutor/views/lessonDeepDive/FizzyButton.tsx
+++ b/apps/src/aiTutor/views/lessonDeepDive/FizzyButton.tsx
@@ -1,0 +1,68 @@
+import React, {FC, useCallback, useEffect, useRef} from 'react';
+
+import styles from './lesson-deep-dive-container.module.scss';
+
+interface FizzyButtonProps {
+  onClick: () => void;
+  ariaLabel: string;
+  children: React.ReactNode;
+}
+
+const FizzyButton: FC<FizzyButtonProps> = ({onClick, ariaLabel, children}) => {
+  const buttonRef = useRef<HTMLButtonElement>(null);
+  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  const createBubble = useCallback(() => {
+    const btn = buttonRef.current;
+    if (!btn) return;
+    const rect = btn.getBoundingClientRect();
+    const size = Math.random() * 9 + 4;
+    const bubble = document.createElement('span');
+    bubble.className = styles.fizzBubble;
+    bubble.style.width = `${size}px`;
+    bubble.style.height = `${size}px`;
+    bubble.style.left = `${rect.left + Math.random() * rect.width}px`;
+    bubble.style.top = `${rect.bottom - size}px`;
+    bubble.style.animationDuration = `${Math.random() * 1.8 + 1.2}s`;
+    bubble.style.setProperty('--fizz-drift', `${(Math.random() - 0.5) * 50}px`);
+    const hue = Math.random() * 360;
+    bubble.style.background = `radial-gradient(circle at 30% 30%, hsl(${hue} 100% 88%), hsl(${hue} 80% 55%))`;
+    document.body.appendChild(bubble);
+    bubble.addEventListener('animationend', () => bubble.remove(), {once: true});
+  }, []);
+
+  const handleMouseEnter = useCallback(() => {
+    createBubble();
+    intervalRef.current = setInterval(createBubble, 80);
+  }, [createBubble]);
+
+  const handleMouseLeave = useCallback(() => {
+    if (intervalRef.current !== null) {
+      clearInterval(intervalRef.current);
+      intervalRef.current = null;
+    }
+  }, []);
+
+  useEffect(
+    () => () => {
+      if (intervalRef.current !== null) clearInterval(intervalRef.current);
+    },
+    []
+  );
+
+  return (
+    <button
+      ref={buttonRef}
+      type="button"
+      className={`${styles.arrowButton} ${styles.fizzyButton}`}
+      onClick={onClick}
+      aria-label={ariaLabel}
+      onMouseEnter={handleMouseEnter}
+      onMouseLeave={handleMouseLeave}
+    >
+      {children}
+    </button>
+  );
+};
+
+export default FizzyButton;

--- a/apps/src/aiTutor/views/lessonDeepDive/FizzyButton.tsx
+++ b/apps/src/aiTutor/views/lessonDeepDive/FizzyButton.tsx
@@ -28,7 +28,9 @@ const FizzyButton: FC<FizzyButtonProps> = ({onClick, ariaLabel, children}) => {
     const hue = Math.random() * 360;
     bubble.style.background = `radial-gradient(circle at 30% 30%, hsl(${hue} 100% 88%), hsl(${hue} 80% 55%))`;
     document.body.appendChild(bubble);
-    bubble.addEventListener('animationend', () => bubble.remove(), {once: true});
+    bubble.addEventListener('animationend', () => bubble.remove(), {
+      once: true,
+    });
   }, []);
 
   const handleMouseEnter = useCallback(() => {

--- a/apps/src/aiTutor/views/lessonDeepDive/LessonDeepDiveContainer.tsx
+++ b/apps/src/aiTutor/views/lessonDeepDive/LessonDeepDiveContainer.tsx
@@ -1,5 +1,5 @@
 import {createTheme, ThemeProvider} from '@mui/material/styles';
-import React, {FC, useCallback, useState} from 'react';
+import React, {FC, useCallback, useEffect, useRef, useState} from 'react';
 
 import experiments from '@cdo/apps/util/experiments';
 
@@ -7,8 +7,8 @@ const darkTheme = createTheme({
   palette: {
     mode: 'dark',
     background: {
-      default: '#1a1a2e',
-      paper: '#25253f',
+      default: '#121212',
+      paper: '#1c1c1c',
     },
     text: {
       primary: '#e8e8f2',
@@ -17,7 +17,7 @@ const darkTheme = createTheme({
     primary: {
       main: '#6b9fd4',
     },
-    divider: '#2e2e50',
+    divider: '#242424',
   },
 });
 
@@ -27,10 +27,75 @@ import PracticeBox from './PracticeBox';
 import ReflectionBox from './ReflectionBox';
 import TutorSummaryBox from './TutorSummaryBox';
 import {LessonDeepDiveData, ReflectionData} from './types';
+import WelcomeBox from './WelcomeBox';
 
 import styles from './lesson-deep-dive-container.module.scss';
 
+const FizzyButton: FC<{
+  onClick: () => void;
+  ariaLabel: string;
+  children: React.ReactNode;
+}> = ({onClick, ariaLabel, children}) => {
+  const buttonRef = useRef<HTMLButtonElement>(null);
+  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  const createBubble = useCallback(() => {
+    const btn = buttonRef.current;
+    if (!btn) return;
+    const rect = btn.getBoundingClientRect();
+    const size = Math.random() * 9 + 4;
+    const bubble = document.createElement('span');
+    bubble.className = styles.fizzBubble;
+    bubble.style.width = `${size}px`;
+    bubble.style.height = `${size}px`;
+    bubble.style.left = `${rect.left + Math.random() * rect.width}px`;
+    bubble.style.top = `${rect.bottom - size}px`;
+    bubble.style.animationDuration = `${Math.random() * 1.8 + 1.2}s`;
+    bubble.style.setProperty('--fizz-drift', `${(Math.random() - 0.5) * 50}px`);
+    const hue = Math.random() * 360;
+    bubble.style.background = `radial-gradient(circle at 30% 30%, hsl(${hue}, 100%, 88%), hsl(${hue}, 80%, 55%))`;
+    document.body.appendChild(bubble);
+    bubble.addEventListener('animationend', () => bubble.remove(), {
+      once: true,
+    });
+  }, []);
+
+  const handleMouseEnter = useCallback(() => {
+    createBubble();
+    intervalRef.current = setInterval(createBubble, 80);
+  }, [createBubble]);
+
+  const handleMouseLeave = useCallback(() => {
+    if (intervalRef.current !== null) {
+      clearInterval(intervalRef.current);
+      intervalRef.current = null;
+    }
+  }, []);
+
+  useEffect(
+    () => () => {
+      if (intervalRef.current !== null) clearInterval(intervalRef.current);
+    },
+    []
+  );
+
+  return (
+    <button
+      ref={buttonRef}
+      type="button"
+      className={`${styles.arrowButton} ${styles.fizzyButton}`}
+      onClick={onClick}
+      aria-label={ariaLabel}
+      onMouseEnter={handleMouseEnter}
+      onMouseLeave={handleMouseLeave}
+    >
+      {children}
+    </button>
+  );
+};
+
 const BOX_IDS = [
+  'welcome',
   'lesson-summary',
   'reflection',
   'intervention',
@@ -71,6 +136,8 @@ const LessonDeepDiveContainer: FC<LessonDeepDiveContainerProps> = ({
 
   const renderBox = () => {
     switch (BOX_IDS[currentIndex]) {
+      case 'welcome':
+        return <WelcomeBox />;
       case 'lesson-summary':
         return (
           <LessonSummaryBox
@@ -144,12 +211,7 @@ const LessonDeepDiveContainer: FC<LessonDeepDiveContainerProps> = ({
 
         {!isLast && (
           <div className={styles.bottomNav}>
-            <button
-              type="button"
-              className={styles.arrowButton}
-              onClick={goToNext}
-              aria-label="Next"
-            >
+            <FizzyButton onClick={goToNext} ariaLabel="Next">
               <svg
                 width="24"
                 height="24"
@@ -165,7 +227,7 @@ const LessonDeepDiveContainer: FC<LessonDeepDiveContainerProps> = ({
                   strokeLinejoin="round"
                 />
               </svg>
-            </button>
+            </FizzyButton>
           </div>
         )}
       </div>

--- a/apps/src/aiTutor/views/lessonDeepDive/LessonDeepDiveContainer.tsx
+++ b/apps/src/aiTutor/views/lessonDeepDive/LessonDeepDiveContainer.tsx
@@ -1,5 +1,5 @@
 import {createTheme, ThemeProvider} from '@mui/material/styles';
-import React, {FC, useCallback, useEffect, useRef, useState} from 'react';
+import React, {FC, useCallback, useState} from 'react';
 
 import experiments from '@cdo/apps/util/experiments';
 
@@ -21,6 +21,7 @@ const darkTheme = createTheme({
   },
 });
 
+import FizzyButton from './FizzyButton';
 import InterventionBox from './InterventionBox';
 import LessonSummaryBox from './LessonSummaryBox';
 import PracticeBox from './PracticeBox';
@@ -30,69 +31,6 @@ import {LessonDeepDiveData, ReflectionData} from './types';
 import WelcomeBox from './WelcomeBox';
 
 import styles from './lesson-deep-dive-container.module.scss';
-
-const FizzyButton: FC<{
-  onClick: () => void;
-  ariaLabel: string;
-  children: React.ReactNode;
-}> = ({onClick, ariaLabel, children}) => {
-  const buttonRef = useRef<HTMLButtonElement>(null);
-  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
-
-  const createBubble = useCallback(() => {
-    const btn = buttonRef.current;
-    if (!btn) return;
-    const rect = btn.getBoundingClientRect();
-    const size = Math.random() * 9 + 4;
-    const bubble = document.createElement('span');
-    bubble.className = styles.fizzBubble;
-    bubble.style.width = `${size}px`;
-    bubble.style.height = `${size}px`;
-    bubble.style.left = `${rect.left + Math.random() * rect.width}px`;
-    bubble.style.top = `${rect.bottom - size}px`;
-    bubble.style.animationDuration = `${Math.random() * 1.8 + 1.2}s`;
-    bubble.style.setProperty('--fizz-drift', `${(Math.random() - 0.5) * 50}px`);
-    const hue = Math.random() * 360;
-    bubble.style.background = `radial-gradient(circle at 30% 30%, hsl(${hue}, 100%, 88%), hsl(${hue}, 80%, 55%))`;
-    document.body.appendChild(bubble);
-    bubble.addEventListener('animationend', () => bubble.remove(), {
-      once: true,
-    });
-  }, []);
-
-  const handleMouseEnter = useCallback(() => {
-    createBubble();
-    intervalRef.current = setInterval(createBubble, 80);
-  }, [createBubble]);
-
-  const handleMouseLeave = useCallback(() => {
-    if (intervalRef.current !== null) {
-      clearInterval(intervalRef.current);
-      intervalRef.current = null;
-    }
-  }, []);
-
-  useEffect(
-    () => () => {
-      if (intervalRef.current !== null) clearInterval(intervalRef.current);
-    },
-    []
-  );
-
-  return (
-    <button
-      ref={buttonRef}
-      type="button"
-      className={`${styles.arrowButton} ${styles.fizzyButton}`}
-      onClick={onClick}
-      aria-label={ariaLabel}
-      onMouseEnter={handleMouseEnter}
-      onMouseLeave={handleMouseLeave}
-    >
-      {children}
-    </button>
-  );
-};
 
 const BOX_IDS = [
   'welcome',

--- a/apps/src/aiTutor/views/lessonDeepDive/WelcomeBox.tsx
+++ b/apps/src/aiTutor/views/lessonDeepDive/WelcomeBox.tsx
@@ -1,0 +1,41 @@
+import FontAwesomeV6Icon from '@code-dot-org/component-library/fontAwesomeV6Icon';
+import React, {FC} from 'react';
+
+import styles from './welcome-box.module.scss';
+
+const WelcomeBox: FC = () => (
+  <div className={styles.container}>
+    <p className={styles.sentence}>
+      {"Let's see how you "}
+      <span className={styles.wordWindow}>
+        <span className={styles.wordTrack}>
+          <span className={`${styles.word} ${styles.wordCoded}`}>coded</span>
+          <span className={`${styles.word} ${styles.wordPrompted}`}>
+            prompted
+          </span>
+          <span className={`${styles.word} ${styles.wordDesigned}`}>
+            designed
+          </span>
+          <span className={`${styles.word} ${styles.wordDebated}`}>
+            debated
+          </span>
+          <span className={`${styles.word} ${styles.wordCreated}`}>
+            created
+          </span>
+          <span className={`${styles.word} ${styles.wordDebugged}`}>
+            debugged
+          </span>
+          <span className={`${styles.word} ${styles.wordProblemSolved}`}>
+            problem solved
+          </span>
+        </span>
+      </span>
+      <span className={styles.todayLine}>
+        today
+        <FontAwesomeV6Icon iconName={'sparkle'} />
+      </span>
+    </p>
+  </div>
+);
+
+export default WelcomeBox;

--- a/apps/src/aiTutor/views/lessonDeepDive/intervention-box.module.scss
+++ b/apps/src/aiTutor/views/lessonDeepDive/intervention-box.module.scss
@@ -76,7 +76,7 @@
   display: flex;
   flex-direction: row;
   align-items: stretch;
-  border-top: 1px solid #2e2e50;
+  border-top: 1px solid #242424;
   flex-shrink: 0;
 }
 
@@ -97,7 +97,7 @@
   transition: background-color 0.15s ease, color 0.15s ease;
 
   &:hover {
-    background-color: #2a2a48;
+    background-color: #1e1e1e;
     color: #e8e8f2;
   }
 
@@ -135,21 +135,21 @@
 // ── Active nav item colors (dark-theme tints, all pass WCAG AA) ───────────────
 
 .activeCardTeal {
-  background-color: #0d2620;
+  background-color: #0a1a10;
   color: #6dd4b4; // 5.4:1 on bg
 }
 
 .activeCardPurple {
-  background-color: #1e1435;
+  background-color: #120c20;
   color: #c09ee0; // 8:1 on bg
 }
 
 .activeCardOrange {
-  background-color: #2b1600;
+  background-color: #180d00;
   color: #f09850; // 6.3:1 on bg
 }
 
 .activeCardBlue {
-  background-color: #0c1e38;
+  background-color: #0a1628;
   color: #7ab3e8; // 5.2:1 on bg
 }

--- a/apps/src/aiTutor/views/lessonDeepDive/lesson-deep-dive-container.module.scss
+++ b/apps/src/aiTutor/views/lessonDeepDive/lesson-deep-dive-container.module.scss
@@ -7,7 +7,7 @@ $header-height: 50px;
   height: calc(100vh - #{$header-height});
   width: 100%;
   overflow: hidden;
-  background-color: #1a1a2e;
+  background-color: #121212;
   color: #e8e8f2;
 }
 
@@ -28,7 +28,7 @@ $header-height: 50px;
   align-items: center;
   justify-content: center;
   padding: 8px 16px;
-  border-bottom: 1px solid #2e2e50;
+  border-bottom: 1px solid #242424;
   flex-shrink: 0;
 }
 
@@ -37,8 +37,23 @@ $header-height: 50px;
   align-items: center;
   justify-content: center;
   padding: 8px 16px;
-  border-top: 1px solid #2e2e50;
+  border-top: 1px solid #242424;
   flex-shrink: 0;
+}
+
+@keyframes fizz-rise {
+  0% {
+    transform: translateY(0) translateX(0) scale(1);
+    opacity: 0.85;
+  }
+  60% {
+    opacity: 0.35;
+  }
+  100% {
+    /* stylelint-disable-next-line plugin/no-unsupported-browser-features */
+    transform: translateY(-95vh) translateX(var(--fizz-drift, 0)) scale(0.1);
+    opacity: 0;
+  }
 }
 
 .arrowButton {
@@ -60,7 +75,7 @@ $header-height: 50px;
   }
 
   &:hover {
-    background-color: #2a2a48;
+    background-color: #1e1e1e;
     color: #e8e8f2;
   }
 
@@ -68,6 +83,18 @@ $header-height: 50px;
     outline: 2px solid #6b9fd4;
     outline-offset: 2px;
   }
+}
+
+.fizzyButton {
+  position: relative;
+}
+
+.fizzBubble {
+  position: fixed;
+  border-radius: 50%;
+  pointer-events: none;
+  z-index: 9999;
+  animation: fizz-rise ease-out forwards;
 }
 
 .pageIndicator {

--- a/apps/src/aiTutor/views/lessonDeepDive/welcome-box.module.scss
+++ b/apps/src/aiTutor/views/lessonDeepDive/welcome-box.module.scss
@@ -1,0 +1,152 @@
+// Each word slot: height + margin-bottom. The clip window height matches
+// word height exactly so the gap is hidden between transitions.
+$word-h: 5rem;
+$word-gap: 2rem;
+$slot: 7rem; // $word-h + $word-gap
+
+// 7 words, 14s loop. Each word visible for 11% (~1.5s), slide takes 3% (~0.4s)
+// with a smooth cubic-bezier. The timing-function is set on the keyframe that
+// *starts* each slide so it applies only to that outgoing transition.
+// Last word gets a slightly longer hold (15.99%) before the instant snap back.
+@keyframes word-flip {
+  0% {
+    margin-top: 0;
+  }
+  11% {
+    margin-top: 0;
+    animation-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+  }
+  14% {
+    margin-top: -#{$slot};
+  }
+  25% {
+    margin-top: -#{$slot};
+    animation-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+  }
+  28% {
+    margin-top: calc(#{$slot} * -2);
+  }
+  39% {
+    margin-top: calc(#{$slot} * -2);
+    animation-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+  }
+  42% {
+    margin-top: calc(#{$slot} * -3);
+  }
+  53% {
+    margin-top: calc(#{$slot} * -3);
+    animation-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+  }
+  56% {
+    margin-top: calc(#{$slot} * -4);
+  }
+  67% {
+    margin-top: calc(#{$slot} * -4);
+    animation-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+  }
+  70% {
+    margin-top: calc(#{$slot} * -5);
+  }
+  81% {
+    margin-top: calc(#{$slot} * -5);
+    animation-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+  }
+  84% {
+    margin-top: calc(#{$slot} * -6);
+  }
+  99.99% {
+    margin-top: calc(#{$slot} * -6);
+  }
+  100% {
+    margin-top: 0; // instant snap back to start
+  }
+}
+
+.container {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+}
+
+.sentence {
+  font-size: 2rem;
+  font-weight: 700;
+  color: #fff;
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  justify-content: center;
+  text-align: center;
+  gap: 0.35em;
+  line-height: 1.4;
+  margin: 0 auto;
+  padding: 0;
+  max-width: 375px;
+}
+
+// Clip window — shows exactly one word at a time.
+.wordWindow {
+  display: inline-block;
+  height: $word-h;
+  overflow: hidden;
+  vertical-align: middle;
+}
+
+// Animated track — all words stacked, slides up via margin-top.
+.wordTrack {
+  display: block;
+  animation: word-flip 14s linear infinite;
+}
+
+.word {
+  display: block;
+  box-sizing: border-box;
+  height: $word-h;
+  margin-bottom: $word-gap;
+  padding: 0.05em 0.4em;
+  border-radius: 0.2em;
+  color: #fff;
+  font-weight: 700;
+  line-height: $word-h;
+  white-space: nowrap;
+  text-align: center;
+}
+
+.todayLine {
+  width: 100%; // forces a new row in the flex-wrap sentence
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.3em;
+}
+
+// Rainbow colors spaced evenly across the hue wheel (72° apart),
+// matching the random-hue bubbles in the down-nav fizzy effect.
+.wordCoded {
+  background-color: hsl(5deg 85% 58%);
+}
+
+.wordPrompted {
+  background-color: hsl(35deg 90% 52%);
+}
+
+.wordDesigned {
+  background-color: hsl(145deg 65% 42%);
+}
+
+.wordDebated {
+  background-color: hsl(215deg 85% 60%);
+}
+
+.wordCreated {
+  background-color: hsl(285deg 72% 62%);
+}
+
+.wordDebugged {
+  background-color: hsl(175deg 72% 40%);
+}
+
+.wordProblemSolved {
+  background-color: hsl(55deg 88% 45%);
+}


### PR DESCRIPTION
The AI Tutor+ experience starts with a welcome screen. 

This is what it looks like in the [prototype](https://claude.ai/artifacts/latest/91d8ba58-2f83-4c6e-81bf-ef5be4f0f613)
<img width="1345" height="926" alt="Screenshot 2026-04-14 at 2 35 41 PM" src="https://github.com/user-attachments/assets/5d2e5cb3-727a-4aa4-b182-dcde5108b43e" />

Since many of the lessons aren't based only on "coding", I wanted to try out a more generic welcome sentence. To accomplish this idea, I added an animation that rotates through a handful of verbs that are a broadly applicable.   

https://github.com/user-attachments/assets/101ead8c-62d5-4dc8-bf56-5bf01f1ad3ae

Then, because I was on an animation kick, I riffed on the "deep dive" idea and added a multicolor bubbles "fizz effect" on-hover to the down navigation button. 

