### PR TITLE
AI Chat - Add development AWS secret for Azure AI Image moderation key

### DIFF
--- a/config/development.yml.erb
+++ b/config/development.yml.erb
@@ -73,6 +73,9 @@ elevenlabs_api_key: !Secret
 google_gemini_ai_chat_lab_api_key: !Secret
 google_gemini_ai_tutor_api_key: !Secret
 
+# Azure AI Content Safety
+azure_ai_content_safety_key: !Secret
+
 # AI Gateway
 ai_gateway_auth_key: !Secret
 ai_gateway_auth_public_key: !Secret

--- a/locals.yml.default
+++ b/locals.yml.default
@@ -15,6 +15,7 @@
 #ta_langfuse_public_key: localoverride
 #google_gemini_ai_chat_lab_api_key: localoverride
 #google_gemini_ai_tutor_api_key: localoverride
+#azure_ai_content_safety_key: localoverride
 #ai_gateway_auth_key: localoverride
 #ai_gateway_auth_public_key: localoverride
 #ai_gateway_auth_key_passphrase: localoverride


### PR DESCRIPTION
This PR adds a `!Secret` config for the Azure AI Image moderation key in the development environment and provides a commented-out local override for `locals.yml.default` for external developers.

<img width="2662" height="1522" alt="Screenshot 2026-04-14 at 1 13 27 PM" src="https://github.com/user-attachments/assets/567d1567-4187-497f-b394-b4096bd22a3d" />

_**Failing image generation before this change**_

Before this PR (and actually adding the development secret to AWS Secret Manager), a developer wouldn't be able to test image gen locally without manually adding the key to their `locals.yml`.  Now the `locals.yml` route would only be needed for external developers.

## Links
Slack conversation [here](https://codedotorg.slack.com/archives/C043ZKQ4BS6/p1776186727763239)
