### PR TITLE
[Section Setup] Curriculum quick assign top row cleanup

### DIFF
--- a/apps/src/templates/sectionsRefresh/CurriculumQuickAssignTopRow.jsx
+++ b/apps/src/templates/sectionsRefresh/CurriculumQuickAssignTopRow.jsx
@@ -1,6 +1,6 @@
 import classnames from 'classnames';
 import PropTypes from 'prop-types';
-import React, {memo} from 'react';
+import React from 'react';
 
 import Button from '@cdo/apps/legacySharedComponents/Button';
 import i18n from '@cdo/locale';
@@ -16,27 +16,30 @@ export const MARKETING_AUDIENCE = {
   PL: 'pl',
 };
 
-const MarketingAudienceButton = memo(
-  ({selectedMarketingAudience, audience, determineMarketingAudience, text}) => {
-    const isActive = selectedMarketingAudience === audience;
-    const icon = isActive ? 'caret-down' : 'caret-right';
+function MarketingAudienceButton({
+  selectedMarketingAudience,
+  audience,
+  determineMarketingAudience,
+  text,
+}) {
+  const isActive = selectedMarketingAudience === audience;
+  const icon = isActive ? 'caret-down' : 'caret-right';
 
-    return (
-      <Button
-        id={`uitest-${audience}-button`}
-        className={classnames(
-          moduleStyles.buttonStyle,
-          isActive && moduleStyles.activeMarketingAudienceButton
-        )}
-        text={text}
-        size={Button.ButtonSize.large}
-        icon={icon}
-        onClick={() => determineMarketingAudience(audience)}
-        type="button"
-      />
-    );
-  }
-);
+  return (
+    <Button
+      id={`uitest-${audience}-button`}
+      className={classnames(
+        moduleStyles.buttonStyle,
+        isActive && moduleStyles.activeMarketingAudienceButton
+      )}
+      text={text}
+      size={Button.ButtonSize.large}
+      icon={icon}
+      onClick={() => determineMarketingAudience(audience)}
+      type="button"
+    />
+  );
+}
 
 MarketingAudienceButton.propTypes = {
   selectedMarketingAudience: PropTypes.string.isRequired,
@@ -44,8 +47,6 @@ MarketingAudienceButton.propTypes = {
   determineMarketingAudience: PropTypes.func.isRequired,
   text: PropTypes.string.isRequired,
 };
-
-MarketingAudienceButton.displayName = 'MarketingAudienceButton';
 
 export default function CurriculumQuickAssignTopRow({
   showPlOfferings,

--- a/apps/src/templates/sectionsRefresh/CurriculumQuickAssignTopRow.jsx
+++ b/apps/src/templates/sectionsRefresh/CurriculumQuickAssignTopRow.jsx
@@ -1,6 +1,6 @@
 import classnames from 'classnames';
 import PropTypes from 'prop-types';
-import React, {memo, useCallback} from 'react';
+import React, {memo} from 'react';
 
 import Button from '@cdo/apps/legacySharedComponents/Button';
 import i18n from '@cdo/locale';
@@ -21,14 +21,6 @@ const MarketingAudienceButton = memo(
     const isActive = selectedMarketingAudience === audience;
     const icon = isActive ? 'caret-down' : 'caret-right';
 
-    const onClick = useCallback(
-      e => {
-        e.preventDefault();
-        determineMarketingAudience(audience);
-      },
-      [determineMarketingAudience, audience]
-    );
-
     return (
       <Button
         id={`uitest-${audience}-button`}
@@ -39,7 +31,8 @@ const MarketingAudienceButton = memo(
         text={text}
         size={Button.ButtonSize.large}
         icon={icon}
-        onClick={onClick}
+        onClick={() => determineMarketingAudience(audience)}
+        type="button"
       />
     );
   }
@@ -61,16 +54,13 @@ export default function CurriculumQuickAssignTopRow({
 }) {
   // If the given audience is already selected, deselect it.
   // Otherwise, set to this audience
-  const determineMarketingAudience = useCallback(
-    newAudience => {
-      if (newAudience === marketingAudience) {
-        updateMarketingAudience('');
-      } else {
-        updateMarketingAudience(newAudience);
-      }
-    },
-    [marketingAudience, updateMarketingAudience]
-  );
+  const determineMarketingAudience = newAudience => {
+    if (newAudience === marketingAudience) {
+      updateMarketingAudience('');
+    } else {
+      updateMarketingAudience(newAudience);
+    }
+  };
 
   return (
     <div className={moduleStyles.buttonRow}>

--- a/apps/src/templates/sectionsRefresh/SectionsSetUpContainer.jsx
+++ b/apps/src/templates/sectionsRefresh/SectionsSetUpContainer.jsx
@@ -490,10 +490,8 @@ export default function SectionsSetUpContainer({
                 icon="plus"
                 text={i18n.addAnotherClassSection()}
                 color={Button.ButtonColor.neutralDark}
-                onClick={e => {
-                  e.preventDefault();
-                  saveSection(sections[0], true, coteachersToAdd);
-                }}
+                onClick={() => saveSection(sections[0], true, coteachersToAdd)}
+                type="button"
               />
             )}
             <Button
@@ -508,11 +506,11 @@ export default function SectionsSetUpContainer({
               }
               color={Button.ButtonColor.brandSecondaryDefault}
               disabled={isSaveInProgress}
-              onClick={e => {
-                e.preventDefault();
+              onClick={() => {
                 setIsSaveInProgress(true);
                 saveSection(sections[0], false, coteachersToAdd);
               }}
+              type="button"
             />
           </div>
         </>

--- a/apps/src/templates/sectionsRefresh/SectionsSetUpContainer.jsx
+++ b/apps/src/templates/sectionsRefresh/SectionsSetUpContainer.jsx
@@ -124,20 +124,12 @@ export default function SectionsSetUpContainer({
   const caret = isOpen => (isOpen ? 'caret-down' : 'caret-right');
 
   const toggleIsCoteacherOpen = useCallback(
-    e => {
-      e.preventDefault();
-
-      setIsCoteacherOpen(!isCoteacherOpen);
-    },
+    () => setIsCoteacherOpen(!isCoteacherOpen),
     [isCoteacherOpen]
   );
 
   const toggleAdvancedSettingsOpen = useCallback(
-    e => {
-      e.preventDefault();
-
-      setAdvancedSettingsOpen(!advancedSettingsOpen);
-    },
+    () => setAdvancedSettingsOpen(!advancedSettingsOpen),
     [advancedSettingsOpen]
   );
 
@@ -355,6 +347,7 @@ export default function SectionsSetUpContainer({
           styleAsText
           icon={caret(isOpen)}
           onClick={toggleIsOpen}
+          type="button"
         >
           <Typography variant="h3" gutterBottom>
             {sectionTitle()}

--- a/apps/src/templates/sectionsRefresh/SingleSectionSetUp.jsx
+++ b/apps/src/templates/sectionsRefresh/SingleSectionSetUp.jsx
@@ -63,6 +63,7 @@ export default function SingleSectionSetUp({
               className={moduleStyles.classNameTextField}
               value={section.name}
               onChange={e => updateSection('name', e.target.value)}
+              onKeyDown={e => e.key === 'Enter' && e.preventDefault()}
               disabled={isLoading}
             />
           )}

--- a/apps/src/templates/sectionsRefresh/sections-refresh.module.scss
+++ b/apps/src/templates/sectionsRefresh/sections-refresh.module.scss
@@ -90,12 +90,22 @@ label.typographyLabelTwo {
     // !important to overwrite button:active styles in app/assets/stylesheets/application.scss
     border: none !important;
   }
+
+  &:focus-visible {
+    outline: 2px solid $brand_primary_default;
+    outline-offset: 2px;
+    border-radius: 2px;
+  }
 }
 
 .buttonsInRow .buttonStyle.activeMarketingAudienceButton {
   color: $brand_primary_default;
   border-bottom: 2px solid $brand_primary_default;
   border-radius: 0;
+
+  &:focus-visible {
+    border-radius: 2px;
+  }
 }
 
 .buttonsInRow .buttonStyle:hover {

--- a/apps/src/templates/sectionsRefresh/sections-refresh.module.scss
+++ b/apps/src/templates/sectionsRefresh/sections-refresh.module.scss
@@ -206,6 +206,12 @@ button.advancedSettingsButton {
     display: inline-block;
     margin-top: 0.5em;
   }
+
+  &:focus-visible {
+    outline: 2px solid $brand_primary_default;
+    outline-offset: 2px;
+    border-radius: 2px;
+  }
 }
 
 .celebrationDialogBody {


### PR DESCRIPTION
**Summary**

Fixed keyboard interaction bugs in the curriculum quick assign section setup form. All `<button>` elements inside the form were implicitly `type="submit"`, causing Enter keypresses anywhere in the form to activate unintended buttons. This also meant that trying to fill the form using 'Enter' was impossible, requiring users to only use the space key for keyboard navigation, which is non-standard. 

**Changes**

- Added `type="button"` to `MarketingAudienceButton` to prevent implicit form submission — pressing Enter on a radio button in `QuickAssignTable` was shifting focus to the Elementary button because the button defaulted to `type="submit"` inside `SectionsSetUpContainer`'s `<form>`
- Added `type="button"` to the expandable section buttons (co-teacher, advanced settings) to prevent them from toggling on Enter
- Removed now-unnecessary `e.preventDefault()` from `toggleIsCoteacherOpen` and `toggleAdvancedSettingsOpen`
- Added a teal `focus-visible` outline to the marketing audience buttons and advanced settings buttons for consistent keyboard navigation visibility (matching the rest of the page)
- Cleaned up `memo`, `useCallback`, and `e.preventDefault()` from `MarketingAudienceButton` that were no longer serving a purpose
- Fixes save and add a new section, and save section buttons to now work on Enter
- Fixes input field (Section Name) to not try to listen for a form submission on enter

**Test Plan**

- [x] Pressing Enter or Space on a radio button in Quick Assign does not shift focus to the Elementary button
- [x] Pressing Enter or Space on a radio button does not open or close the co-teacher section
- [x] Pressing Enter or Space on a marketing audience button opens/closes that dropdown
- [x] Pressing Enter or Space on an advanced (coteacher) button opens/closes that section
- [x] Keyboard-focusing a marketing audience button shows a teal rounded outline
- [x] Keyboard-focusing an advanced settings button shows a teal rounded outline
- [x] Pressing Enter or Space on submit form buttons works to submit form (but errors if there is a missing section name or no grade chips selected)


## I Did not change:

The chips implementation from the component library only allows chips to be selected via spacebar. I opted not to refactor the component library here, so those and the radio buttons are the only ones that require the spacebar now.

## Links

- Jira: https://codedotorg.atlassian.net/browse/SL-1669

## Testing story
<!-- How was this tested? Manual steps, adhoc links, automated tests, or why testing isn't needed. -->



## Deployment notes
<!-- Delete this section if it's a standard merge-and-deploy.
     Otherwise: migrations, feature flags, coordination, caching impacts, etc. -->



## Privacy and security
<!-- Delete this section if there is no privacy/security impact.
     Otherwise: new PII, auth changes, API surface changes, etc. -->

