### PR TITLE
add arm64-darwin-25 and x86_64-linux platforms to Gemfile.lock

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -18,6 +18,9 @@ GIT
     image_optim_pack (0.5.0)
       fspath (>= 2.1, < 4)
       image_optim (~> 0.19)
+    image_optim_pack (0.5.0-x86_64-linux)
+      fspath (>= 2.1, < 4)
+      image_optim (~> 0.19)
 
 GIT
   remote: https://github.com/code-dot-org/lograge.git
@@ -462,6 +465,8 @@ GEM
     faraday-rack (1.0.0)
     faraday-retry (1.0.3)
     ffi (1.17.0)
+    ffi (1.17.0-arm64-darwin)
+    ffi (1.17.0-x86_64-linux-gnu)
     ffi-compiler (1.3.2)
       ffi (>= 1.15.5)
       rake
@@ -493,6 +498,12 @@ GEM
     google-apis-youtube_v3 (0.25.0)
       google-apis-core (>= 0.9.1, < 2.a)
     google-protobuf (4.33.6)
+      bigdecimal
+      rake (>= 13)
+    google-protobuf (4.33.6-arm64-darwin)
+      bigdecimal
+      rake (>= 13)
+    google-protobuf (4.33.6-x86_64-linux-gnu)
       bigdecimal
       rake (>= 13)
     google_drive (3.0.7)
@@ -578,6 +589,8 @@ GEM
       addressable (~> 2.8)
       childprocess (~> 5.0)
     libv8-node (18.16.0.0)
+    libv8-node (18.16.0.0-arm64-darwin)
+    libv8-node (18.16.0.0-x86_64-linux)
     listen (3.8.0)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
@@ -658,6 +671,10 @@ GEM
     nio4r (2.7.0)
     nokogiri (1.18.10)
       mini_portile2 (~> 2.8.2)
+      racc (~> 1.4)
+    nokogiri (1.18.10-arm64-darwin)
+      racc (~> 1.4)
+    nokogiri (1.18.10-x86_64-linux-gnu)
       racc (~> 1.4)
     oauth2 (2.0.9)
       faraday (>= 0.17.3, < 3.0)
@@ -1200,7 +1217,9 @@ GEM
     zlib (3.1.1)
 
 PLATFORMS
+  arm64-darwin-25
   ruby
+  x86_64-linux
 
 DEPENDENCIES
   abbrev


### PR DESCRIPTION
the goal of this PR is to eliminate os-specific diffs from showing up on both mac and linux after running bundle install. for example:
```diff
[12:28:58] Dave-M4:~/src/cdo (gbabey/aws-device-farm *)$ git diff
diff --git a/Gemfile.lock b/Gemfile.lock
index e44ac079a89..52c00ca0812 100644
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -464,7 +464,7 @@ GEM
     faraday-patron (1.0.0)
     faraday-rack (1.0.0)
     faraday-retry (1.0.3)
-    ffi (1.17.0)
+    ffi (1.17.0-arm64-darwin)
     ffi-compiler (1.3.2)
       ffi (>= 1.15.5)
       rake
@@ -495,7 +495,7 @@ GEM
       google-apis-core (>= 0.9.1, < 2.a)
     google-apis-youtube_v3 (0.25.0)
       google-apis-core (>= 0.9.1, < 2.a)
-    google-protobuf (4.33.6)
+    google-protobuf (4.33.6-arm64-darwin)
...
 PLATFORMS
-  ruby
+  arm64-darwin-25
```

this happens because developer systems are pulling down prebuilt binaries for their own architecture rather than compiling these gems from scratch.

the solution is to explicitly add common developer machine architectures to the lockfile. this was done via: 
```
bundle lock --add-platform x86_64-linux arm64-darwin-25 ruby
```

## Alternatives considered

one alternative would be to expect developers to use `BUNDLE_FORCE_RUBY_PLATFORM=true bundle install`, which forces local compilation rather than pulling down OS-specific binaries. however, this takes longer to run and has historically led to debugging of compiler params when local compilation fails.

## Testing story
-  `bundle install` is passing on mac and linux
-  on mac, `bundle lock --add-platform arm64-darwin-25` no longer produces a diff (this was the closest I could  come to a repro step to illustrate the problem is fixed)
- TBD whether this eliminates the problem in practice