### PR TITLE
Temporarily Increase Drone Runner Instance Size

### DIFF
--- a/aws/cloudformation/drone-stack.yml
+++ b/aws/cloudformation/drone-stack.yml
@@ -36,7 +36,7 @@ Parameters:
   WorkerInstanceType:
     Type: String
     Description: EC2 Instance Type that Autoscaler provisions to run Builds.
-    Default: m7i.4xlarge
+    Default: m7i.8xlarge # temporarily increase from m7i.4xlarge to unblock devs while infra investigates OOM errors
   WorkerSubnetId:
     Type: AWS::EC2::Subnet::Id
     Description: Existing VPC Subnet Id where ECS EC2 Instances hosting Drone Runner ("worker") containers will be provisioned.


### PR DESCRIPTION
We've been getting some persistent OOM errors when running Dashboard unit tests in Drone. The infrastructure team is actively investigating, and we absolutely want to avoid a long-term situation where our tests require more than 64G of memory in order to run successfully. But in the short term, so that drone continues to work for developers while we're figuring out how to reduce memory consumption, we bump up to 128G.

## Deployment notes

As usual for this stack, once approved I will manually update the stack from this new template via the AWS web console.

## Links

See thread [here](https://codedotorg.slack.com/archives/C046G4TRLEN/p1775734382709949) for more details