### PR TITLE
Reduce Drone Unit Test Parallelization

### DIFF
--- a/docker/ci/scripts/prepare_ci_env.sh
+++ b/docker/ci/scripts/prepare_ci_env.sh
@@ -16,7 +16,7 @@ export LD_LIBRARY_PATH=/usr/local/lib
 
 # Number of parallel processes for dashboard ruby unit tests,
 # optimized for drone m7i.4xlarge workers with 16 vCPUs and 64 GB RAM.
-export PARALLEL_TEST_PROCESSORS=7
+export PARALLEL_TEST_PROCESSORS=6
 
 # Apps build parallelization settings for CI
 # optimized for drone m7i.4xlarge workers with 16 vCPUs and 64 GB RAM.

--- a/docker/ci/scripts/prepare_ci_env.sh
+++ b/docker/ci/scripts/prepare_ci_env.sh
@@ -16,7 +16,8 @@ export LD_LIBRARY_PATH=/usr/local/lib
 
 # Number of parallel processes for dashboard ruby unit tests,
 # optimized for drone m7i.4xlarge workers with 16 vCPUs and 64 GB RAM.
-export PARALLEL_TEST_PROCESSORS=6
+# We ran into OOM errors with 7; targeting 5 so we have a buffer.
+export PARALLEL_TEST_PROCESSORS=5
 
 # Apps build parallelization settings for CI
 # optimized for drone m7i.4xlarge workers with 16 vCPUs and 64 GB RAM.


### PR DESCRIPTION
We've been getting some persistent OOM errors when running Dashboard unit tests in drone; reducing parallelization to accommodate.

<!--
  Summary of the change: background, motivation, and context.
  Include screenshots, videos, or before/after comparisons for UI changes.
-->



## Links

Slack threads [here](https://codedotorg.slack.com/archives/C03CK49G9/p1775773956656069) and [here](https://codedotorg.slack.com/archives/C046G4TRLEN/p1775734382709949)

## Testing story

Will carefully monitor memory usage on this Drone run to confirm we remain within the limit