### PR TITLE
k8s: add generic scheduling knobs

### DIFF
--- a/k8s/helm/templates/dashboard/_dashboard.yaml
+++ b/k8s/helm/templates/dashboard/_dashboard.yaml
@@ -175,6 +175,21 @@ spec:
         runAsGroup: {{ .Values.user.gid }}
         fsGroup: {{ .Values.user.gid }}
 
+      {{- with .Values.scheduling.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+
+      {{- with .Values.scheduling.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+
+      {{- with .Values.scheduling.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+
       {{- if $isJob }}
       restartPolicy: {{ .restartPolicy | default "Never" }}
       {{- end }}

--- a/k8s/helm/values.yaml
+++ b/k8s/helm/values.yaml
@@ -34,6 +34,11 @@ autoscaling:
   maxReplicas: 1
   replicasWhenAutoscaleDisabled: 1
 
+scheduling:
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+
 dashboardJob:
   enabled: false
   name: zsh


### PR DESCRIPTION
This pulls the EKS Auto Mode scheduling work out of local `staging` and into its own reviewable branch. The change adds the basic Helm values and template wiring needed to express generic scheduling constraints without dragging the unrelated local merge commit along with it.

Technical changes:
- add scheduling value knobs in `k8s/helm/values.yaml`
- wire those values into `k8s/helm/templates/dashboard/_dashboard.yaml`
- publish the extracted commit on `k8s/eks-auto-mode` for review against `staging`