### PR TITLE
add missing return in LTI account linker

### DIFF
--- a/dashboard/app/controllers/lti/v1/account_linking_controller.rb
+++ b/dashboard/app/controllers/lti/v1/account_linking_controller.rb
@@ -33,7 +33,7 @@ module Lti
 
       # POST /lti/v1/account_linking/link_email
       def link_email
-        head :bad_request unless PartialRegistration.in_progress?(session)
+        return head :bad_request unless PartialRegistration.in_progress?(session)
         params.require([:email, :password])
         existing_user = User.find_by_email_or_hashed_email(params[:email])
         if existing_user&.admin?

--- a/dashboard/test/controllers/lti/v1/account_linking_controller_test.rb
+++ b/dashboard/test/controllers/lti/v1/account_linking_controller_test.rb
@@ -101,6 +101,19 @@ class Lti::V1::AccountLinkingControllerTest < ActionController::TestCase
     post :link_email, params: {email: @user.email, password: 'password'}
   end
 
+  test 'returns bad request when partial registration is not in progress' do
+    PartialRegistration.stubs(:in_progress?).returns(false)
+
+    post :link_email, params: {
+      email: @user.email,
+      password: 'password',
+      lti_provider: 'test-provider',
+      lms_name: 'test-lms',
+    }
+
+    assert_response :bad_request
+  end
+
   describe '#new_account' do
     subject(:new_account_request) {post :new_account}
     let(:user) {create(:teacher, :with_lti_authentication_option)}


### PR DESCRIPTION
The `link_email` route occasionally throws a [double render error](https://app.honeybadger.io/projects/3240/faults/122593602). This adds a return statement so that the method exits immediately with a 400.

## Links
[JIRA](https://codedotorg.atlassian.net/browse/P20-1593)

## Testing story
<!-- How was this tested? Manual steps, adhoc links, automated tests, or why testing isn't needed. -->



## Deployment notes
<!-- Delete this section if it's a standard merge-and-deploy.
     Otherwise: migrations, feature flags, coordination, caching impacts, etc. -->



## Privacy and security
<!-- Delete this section if there is no privacy/security impact.
     Otherwise: new PII, auth changes, API surface changes, etc. -->

