### PR TITLE
Slightly speed up initial_page_views2

### DIFF
--- a/dashboard/test/ui/features/initial_page_views2.feature
+++ b/dashboard/test/ui/features/initial_page_views2.feature
@@ -18,6 +18,7 @@ Feature: Looking at a few things with Applitools Eyes - Part 2
     And I sign out
     Examples:
       | url                                                                            | test_name                         | user_type |
+      | http://studio.code.org/projects/applab/new                                     | new applab project                | student   |
       | http://studio.code.org/                                                        | logged in student studio homepage | student   |
       | http://studio.code.org/courses/allthethingscourse/units/1                      | logged in script progress         | student   |
       | http://studio.code.org/courses/allthethingscourse/units/1/lessons/34/levels/1  | unplugged video level             | student   |

--- a/dashboard/test/ui/features/initial_page_views2.feature
+++ b/dashboard/test/ui/features/initial_page_views2.feature
@@ -18,7 +18,6 @@ Feature: Looking at a few things with Applitools Eyes - Part 2
     And I sign out
     Examples:
       | url                                                                            | test_name                         | user_type |
-      | http://studio.code.org/projects/applab/new                                     | new applab project                | student   |
       | http://studio.code.org/                                                        | logged in student studio homepage | student   |
       | http://studio.code.org/courses/allthethingscourse/units/1                      | logged in script progress         | student   |
       | http://studio.code.org/courses/allthethingscourse/units/1/lessons/34/levels/1  | unplugged video level             | student   |

--- a/dashboard/test/ui/features/initial_page_views2.feature
+++ b/dashboard/test/ui/features/initial_page_views2.feature
@@ -20,7 +20,6 @@ Feature: Looking at a few things with Applitools Eyes - Part 2
       | url                                                                            | test_name                         | user_type |
       | http://studio.code.org/projects/applab/new                                     | new applab project                | student   |
       | http://studio.code.org/                                                        | logged in student studio homepage | student   |
-      | http://studio.code.org/                                                        | logged in teacher studio homepage | teacher   |
       | http://studio.code.org/courses/allthethingscourse/units/1                      | logged in script progress         | student   |
       | http://studio.code.org/courses/allthethingscourse/units/1/lessons/34/levels/1  | unplugged video level             | student   |
       | http://studio.code.org/courses/allthethingscourse/units/1/lessons/18/levels/14 | no iframe in dsl                  | student   |

--- a/dashboard/test/ui/features/star_labs/applab/eyes2.feature
+++ b/dashboard/test/ui/features/star_labs/applab/eyes2.feature
@@ -7,6 +7,7 @@ Scenario: Applab visualization scaling
   When I open my eyes to test "Applab visualization scaling"
   And I am on "http://studio.code.org/projects/applab/new"
   And I wait for the lab page to fully load
+  And I see no difference for "initial load"
   And I switch to design mode
 
   Then I drag a TEXT_AREA into the app

--- a/dashboard/test/ui/features/star_labs/applab/eyes2.feature
+++ b/dashboard/test/ui/features/star_labs/applab/eyes2.feature
@@ -7,7 +7,6 @@ Scenario: Applab visualization scaling
   When I open my eyes to test "Applab visualization scaling"
   And I am on "http://studio.code.org/projects/applab/new"
   And I wait for the lab page to fully load
-  And I see no difference for "initial load"
   And I switch to design mode
 
   Then I drag a TEXT_AREA into the app


### PR DESCRIPTION
I noticed the test `initial_page_view2` was taking almost 10 minutes to run. 

This PR removes one test case that is already tested in [teacher_homepage_v2.feature](https://github.com/code-dot-org/code-dot-org/blob/staging/dashboard/test/ui/features/teacher_tools/teacher_dashboard/teacher_homepage_v2.feature#L131)
