### PR TITLE
[RE-106-2] Use semantic styles for teacher homepage section cards

### DIFF
--- a/apps/src/templates/studioHomepages/teacherHomepageV2/JoinLink/JoinLinkCopyButton.tsx
+++ b/apps/src/templates/studioHomepages/teacherHomepageV2/JoinLink/JoinLinkCopyButton.tsx
@@ -97,7 +97,11 @@ const JoinLinkCopyButton: React.FC<JoinLinkCopyButtonProps> = ({
             </span>
           </TooltipOverlay>
         )}
-        {showCopiedMsg && <span>{i18n.copySectionCodeSuccess()}</span>}
+        {showCopiedMsg && (
+          <Typography variant="body3" component="span">
+            {i18n.copySectionCodeSuccess()}
+          </Typography>
+        )}
       </div>
     )
   ) : (

--- a/apps/src/templates/studioHomepages/teacherHomepageV2/JoinLink/joinLinkCopyButton.module.scss
+++ b/apps/src/templates/studioHomepages/teacherHomepageV2/JoinLink/joinLinkCopyButton.module.scss
@@ -1,4 +1,3 @@
-@import 'color';
 @import '@code-dot-org/component-library-styles/font';
 
 .sectionCodeBox {
@@ -28,7 +27,7 @@
   }
 
   button {
-    color: var(--brand-teal-50);
+    color: var(--text-brand-teal-primary);
     margin: 0;
     margin-inline-start: 5px;
     padding: 0 0 4px 0;
@@ -39,12 +38,12 @@
 }
 
 .sectionCodeTextHidden {
-  color: var(--brand-teal-50);
+  color: var(--text-brand-teal-primary);
 }
 
 .noSectionCode {
   margin-left: 5px;
-  color: $teal;
+  color: var(--text-brand-teal-primary);
   text-decoration: none;
   cursor: pointer;
 }

--- a/apps/src/templates/studioHomepages/teacherHomepageV2/LinkOption.tsx
+++ b/apps/src/templates/studioHomepages/teacherHomepageV2/LinkOption.tsx
@@ -1,4 +1,5 @@
 import FontAwesomeV6Icon from '@code-dot-org/component-library/fontAwesomeV6Icon';
+import {Typography} from '@mui/material';
 import React, {useMemo} from 'react';
 // import {useNavigate, NavigateFunction, Link} from 'react-router-dom';
 import {Link} from 'react-router-dom';
@@ -46,7 +47,9 @@ const LinkOption: React.FC<LinkElementProps> = ({
           {iconName && (
             <FontAwesomeV6Icon iconName={iconName} iconStyle="solid" />
           )}
-          <span>{label}</span>
+          <Typography variant="body2" component="span">
+            {label}
+          </Typography>
         </Link>
       ) : (
         <a

--- a/apps/src/templates/studioHomepages/teacherHomepageV2/LinkOption.tsx
+++ b/apps/src/templates/studioHomepages/teacherHomepageV2/LinkOption.tsx
@@ -65,13 +65,21 @@ const LinkOption: React.FC<LinkElementProps> = ({
           }}
         >
           {labelStyle === 'b' ? (
-            <span>
+            <Typography component="span" variant="body2">
               <b>{label}</b>
-            </span>
+            </Typography>
           ) : labelStyle === 'i' ? (
-            <span style={{paddingLeft: '1em'}}>{label}</span>
+            <Typography
+              component="span"
+              variant="body2"
+              style={{paddingLeft: '1em'}}
+            >
+              {label}
+            </Typography>
           ) : (
-            <span>{label}</span>
+            <Typography component="span" variant="body2">
+              {label}
+            </Typography>
           )}
         </a>
       )}

--- a/apps/src/templates/studioHomepages/teacherHomepageV2/SectionOptionsDropdown.tsx
+++ b/apps/src/templates/studioHomepages/teacherHomepageV2/SectionOptionsDropdown.tsx
@@ -143,7 +143,9 @@ const SectionOptionsDropdown: React.FC<SectionOptionsDropdownProps> = ({
             onClick={() => onDeleteClick(onDeleteClickCallback, section.id)}
           >
             <FontAwesomeV6Icon iconName="trash" iconStyle="solid" />
-            <span>{i18n.delete()}</span>
+            <Typography variant="body2" component="span">
+              {i18n.delete()}
+            </Typography>
           </button>
         </li>
       );

--- a/apps/src/templates/studioHomepages/teacherHomepageV2/SectionOptionsDropdown.tsx
+++ b/apps/src/templates/studioHomepages/teacherHomepageV2/SectionOptionsDropdown.tsx
@@ -1,5 +1,6 @@
 import {CustomDropdown} from '@code-dot-org/component-library/dropdown';
 import FontAwesomeV6Icon from '@code-dot-org/component-library/fontAwesomeV6Icon';
+import {Typography} from '@mui/material';
 import React, {useMemo} from 'react';
 
 import RailsAuthenticityToken from '@cdo/apps/lib/util/RailsAuthenticityToken';
@@ -109,7 +110,9 @@ const SectionOptionsDropdown: React.FC<SectionOptionsDropdownProps> = ({
           onClick={onClickPrintCerts}
         >
           <FontAwesomeV6Icon iconName="file-certificate" iconStyle="solid" />
-          <span>{i18n.certificates()}</span>
+          <Typography variant="body2" component="span">
+            {i18n.certificates()}
+          </Typography>
         </button>
       </li>,
       <li key={'archive'}>
@@ -123,9 +126,9 @@ const SectionOptionsDropdown: React.FC<SectionOptionsDropdownProps> = ({
             iconName={section.hidden ? 'window-restore' : 'box-archive'}
             iconStyle="solid"
           />
-          <span>
+          <Typography variant="body2" component="span">
             {section.hidden ? i18n.restoreClassSection() : i18n.archive()}
-          </span>
+          </Typography>
         </button>
       </li>,
     ];

--- a/apps/src/templates/studioHomepages/teacherHomepageV2/teacherHomepage.module.scss
+++ b/apps/src/templates/studioHomepages/teacherHomepageV2/teacherHomepage.module.scss
@@ -1,6 +1,3 @@
-@use '@code-dot-org/component-library-styles/typography.module.scss' as
-  typography;
-@import 'color';
 @import 'https://fonts.googleapis.com/css2?family=Noto+Color+Emoji&display=swap';
 
 // TeacherHomepage
@@ -57,9 +54,9 @@
 
 // SectionCard
 .sectionCardWrapper {
-  border: 1px solid var(--neutral-gray-20);
+  border: 1px solid var(--borders-neutral-primary);
   border-radius: 4px;
-  background-color: var(--neutral-gray-5);
+  background-color: var(--background-neutral-secondary);
   display: flex;
   flex-direction: column;
   width: 100%;
@@ -68,7 +65,7 @@
 
 .sectionCardHeader {
   padding: 16px;
-  border-bottom: 1px solid var(--neutral-gray-20);
+  border-bottom: 1px solid var(--borders-neutral-primary);
   display: flex;
   flex-direction: row;
   justify-content: space-between;
@@ -137,7 +134,7 @@
   display: flex;
   align-items: center;
   cursor: pointer;
-  color: var(--neutral-base-black);
+  color: var(--text-neutral-primary);
 
   padding: 0.5rem 1rem 0.5rem 0.75rem;
   gap: 0.75rem;
@@ -147,7 +144,7 @@
   }
 
   &:hover {
-    color: var(--neutral-base-black);
+    color: var(--text-neutral-secondary);
     text-decoration: none;
   }
 
@@ -156,12 +153,6 @@
     line-height: 125%;
     width: 1.5rem;
     text-align: center;
-  }
-
-  span {
-    @include typography.body-two;
-    color: inherit;
-    margin-bottom: 0;
   }
 }
 
@@ -175,7 +166,7 @@
 
   a:hover {
     text-decoration: none;
-    background-color: var(--neutral-gray-10);
+    background-color: var(--background-neutral-tertiary);
   }
 }
 
@@ -207,19 +198,19 @@
   justify-content: space-between;
   margin: 0;
   border-radius: 4px;
-  background-color: var(--sentiment-success-10);
+  background-color: var(--background-success-extra-light);
 }
 
 .studentAddedAlertIcon {
-  color: var(--sentiment-success-50);
+  color: var(--background-success-primary);
 }
 
 // Task Button
 .taskButtons {
-  border: 1px solid var(--neutral-gray-40);
+  border: 1px solid var(--borders-neutral-strong);
   display: flex;
   flex-direction: row;
-  background-color: var(--neutral-base-white);
+  background-color: var(--background-neutral-primary);
   gap: 8px;
   height: 38px;
   padding: 0 12px;
@@ -242,19 +233,19 @@
 }
 
 .taskButtonIcons {
-  color: var(--brand-teal-50);
+  color: var(--text-brand-teal-primary);
 }
 
 .taskButtonArrow {
-  color: var(--neutral-gray-80);
+  color: var(--text-neutral-quaternary);
 }
 
 // CourseContentDropdown
 .courseContentDropdownContainer {
   display: flex;
   flex-direction: column;
-  background-color: var(--neutral-base-white);
-  border: 1px solid var(--neutral-gray-20);
+  background-color: var(--background-neutral-primary);
+  border: 1px solid var(--borders-neutral-primary);
   border-radius: 4px;
   padding: 12px;
   gap: 8px;
@@ -289,13 +280,13 @@
   align-items: center;
   justify-content: space-between;
   margin: 0;
-  border: 1px dashed var(--brand-purple-50);
+  border: 1px dashed var(--borders-brand-purple-primary);
   border-radius: 4px;
-  background-color: var(--neutral-gray-5);
+  background-color: var(--background-neutral-secondary);
 }
 
 .emptyStateButtonIcon {
-  color: var(--brand-purple-50);
+  color: var(--text-brand-purple-primary);
 }
 
 .emptyImage {
@@ -443,7 +434,7 @@
   gap: 16px;
   border-width: 3px;
   border-style: solid;
-  border-color: var(--brand-purple-50);
+  border-color: var(--borders-brand-purple-primary);
   text-align: center;
 }
 
@@ -459,7 +450,7 @@
 }
 
 .onboardingChecklistCheckIcon {
-  color: var(--sentiment-success-50);
+  color: var(--text-success-primary);
   font-size: 16px;
   display: flex;
   align-items: center;

--- a/dashboard/app/assets/stylesheets/scaffolds.scss
+++ b/dashboard/app/assets/stylesheets/scaffolds.scss
@@ -1,7 +1,7 @@
 @import "color";
 
 body {
-  background-color: $white;
+  background-color: var(--background-neutral-primary, $white);
   color: $default_text;
   font-size: 13px;
   line-height: 18px;


### PR DESCRIPTION
## What changed
- updated the teacher homepage section card styles to use semantic design-system color tokens instead of legacy neutral and brand variables
- switched teacher homepage action/link labels to MUI `Typography` spans so the text styling comes from the design system instead of local span rules
- updated the join-link copy button success text to use DS typography and semantic teal text tokens
- aligned the Rails scaffold body background fallback with the semantic neutral background token

Before:
<img width="1242" height="940" alt="Знімок екрана 2026-04-15 о 18 08 53" src="https://github.com/user-attachments/assets/03abf81a-dfaf-46d8-a5f5-e9c8eae4581a" />
<img width="1244" height="964" alt="Знімок екрана 2026-04-15 о 18 09 22" src="https://github.com/user-attachments/assets/e246ec9b-a32c-4cb3-8461-b2ed1c60f0d0" />

After:
<img width="2494" height="2900" alt="image" src="https://github.com/user-attachments/assets/992ead00-77bb-4b67-b38a-cd3816ed843e" />
<img width="2494" height="1904" alt="image" src="https://github.com/user-attachments/assets/22117f03-4298-4791-b4c0-27c563757d2d" />
<img width="876" height="472" alt="Знімок екрана 2026-04-15 о 18 10 11" src="https://github.com/user-attachments/assets/b9b1ef0a-9c55-4234-9d49-89766def4c16" />


## Why
The teacher homepage section cards and related actions were still mixing older color variables and local text styling with newer design-system patterns. That made the page harder to keep visually consistent as more of the teacher experience moves onto semantic tokens and shared typography.

## Impact
- teacher homepage section cards, task buttons, empty states, and related links now inherit design-system semantic colors more consistently
- teacher homepage action labels no longer depend on local span typography rules
- the scaffold body background uses the semantic neutral background token with a variable fallback

## Validation
- `yarn test:unit test/unit/templates/studioHomepages/teacherHomepageV2/TeacherHomepageTest.tsx`
- `./tools/hooks/pre-commit`

## Notes
- this is a style-token and typography cleanup; it does not change teacher homepage behavior or flows
