### PR TITLE
Read image bytes to get actual content type in image moderation (backend)

### DIFF
--- a/lib/cdo/image_moderation.rb
+++ b/lib/cdo/image_moderation.rb
@@ -51,6 +51,7 @@ module ImageModeration
       # ^ (minimum bounding box): scale up so both dimensions are at least MIN_MODERATION_DIMENSION,
       # preserving aspect ratio (short side hits the minimum, long side may exceed it).
       image.resize "#{MIN_MODERATION_DIMENSION}x#{MIN_MODERATION_DIMENSION}^"
+      raw_data = image.to_blob
     end
 
     if image.width > MAX_MODERATION_DIMENSION || image.height > MAX_MODERATION_DIMENSION
@@ -60,8 +61,9 @@ module ImageModeration
       # Note that if an image has an extreme aspect ratio, the smaller side may be scaled up in branch above,
       # but then scaled down here to a smaller dimension than MIN_MODERATION_DIMENSION on one side (very unlikely scenario).
       image.resize "#{MAX_MODERATION_DIMENSION}x#{MAX_MODERATION_DIMENSION}>"
+      raw_data = image.to_blob
     end
-    raw_data = image.to_blob
+
     if raw_data.bytesize > MAX_MODERATION_SIZE
       # Scale factor is approximate: file size is not strictly proportional to pixel
       # count for compressed formats, so scale conservatively to stay under the limit.
@@ -72,7 +74,7 @@ module ImageModeration
       raw_data = image.to_blob
     end
 
-    [StringIO.new(raw_data), content_type]
+    [StringIO.new(raw_data), actual_type]
   rescue MiniMagick::Invalid, MiniMagick::Error
     [StringIO.new(raw_data), actual_type]
   end

--- a/lib/cdo/image_moderation.rb
+++ b/lib/cdo/image_moderation.rb
@@ -21,7 +21,7 @@ module ImageModeration
     end
 
     moderation_io, moderation_type = scale_image_for_moderation_if_needed(image_data, content_type)
-    if moderation_type != content_type
+    if !moderation_type.nil? && moderation_type != content_type
       Honeybadger.notify("Actual content type differs from reported content type in image moderation", context: {reported_content_type: content_type, actual_content_type: moderation_type})
     end
     raise AzureAiContentSafety::UnsupportedContentType, "Unrecognized image format (reported: #{content_type})" if moderation_type.nil?

--- a/lib/cdo/image_moderation.rb
+++ b/lib/cdo/image_moderation.rb
@@ -45,37 +45,29 @@ module ImageModeration
     raw_data = image_data.read
     actual_type = get_actual_content_type(raw_data)
     image = MiniMagick::Image.read(raw_data)
-    width = image.width
-    height = image.height
 
-    if width < MIN_MODERATION_DIMENSION || height < MIN_MODERATION_DIMENSION
+    if image.width < MIN_MODERATION_DIMENSION || image.height < MIN_MODERATION_DIMENSION
       # Scale up images smaller than MIN_MODERATION_DIMENSION on either dimension using MiniMagick's
       # ^ (minimum bounding box): scale up so both dimensions are at least MIN_MODERATION_DIMENSION,
       # preserving aspect ratio (short side hits the minimum, long side may exceed it).
       image.resize "#{MIN_MODERATION_DIMENSION}x#{MIN_MODERATION_DIMENSION}^"
-      raw_data = image.to_blob
-      width = image.width
-      height = image.height
     end
 
-    if width > MAX_MODERATION_DIMENSION || height > MAX_MODERATION_DIMENSION
+    if image.width > MAX_MODERATION_DIMENSION || image.height > MAX_MODERATION_DIMENSION
       # Scale down images larger than MAX_MODERATION_DIMENSION on either dimension using MiniMagick's
       # > (maximum bounding box): scale down to fit within MAX_MODERATION_DIMENSION on each side,
       # preserving aspect ratio (long side hits the maximum, short side may be smaller).
       # Note that if an image has an extreme aspect ratio, the smaller side may be scaled up in branch above,
       # but then scaled down here to a smaller dimension than MIN_MODERATION_DIMENSION on one side (very unlikely scenario).
       image.resize "#{MAX_MODERATION_DIMENSION}x#{MAX_MODERATION_DIMENSION}>"
-      raw_data = image.to_blob
-      width = image.width
-      height = image.height
     end
-
+    raw_data = image.to_blob
     if raw_data.bytesize > MAX_MODERATION_SIZE
       # Scale factor is approximate: file size is not strictly proportional to pixel
       # count for compressed formats, so scale conservatively to stay under the limit.
       scale = Math.sqrt(MAX_MODERATION_SIZE.to_f / raw_data.bytesize) * 0.85
-      new_w = (width * scale).floor
-      new_h = (height * scale).floor
+      new_w = (image.width * scale).floor
+      new_h = (image.height * scale).floor
       image.resize "#{new_w}x#{new_h}!"
       raw_data = image.to_blob
     end

--- a/lib/cdo/image_moderation.rb
+++ b/lib/cdo/image_moderation.rb
@@ -21,10 +21,10 @@ module ImageModeration
     end
 
     moderation_io, moderation_type = scale_image_for_moderation_if_needed(image_data, content_type)
-    raise AzureAiContentSafety::UnsupportedContentType, "Unrecognized image format (reported: #{content_type})" if moderation_type.nil?
     if moderation_type != content_type
-      Honeybadger.notify("Actual content type differs from reported content type", context: {reported_content_type: content_type, actual_content_type: moderation_type})
+      Honeybadger.notify("Actual content type differs from reported content type in image moderation", context: {reported_content_type: content_type, actual_content_type: moderation_type})
     end
+    raise AzureAiContentSafety::UnsupportedContentType, "Unrecognized image format (reported: #{content_type})" if moderation_type.nil?
     AzureAiContentSafety.new(
       endpoint: CDO.azure_ai_content_safety_endpoint,
       api_key: CDO.azure_ai_content_safety_key

--- a/lib/cdo/image_moderation.rb
+++ b/lib/cdo/image_moderation.rb
@@ -17,33 +17,56 @@ module ImageModeration
     end
 
     moderation_io, moderation_type = scale_image_for_moderation_if_needed(image_data, content_type)
+    raise AzureAiContentSafety::UnsupportedContentType, "Unrecognized image format (reported: #{content_type})" if moderation_type.nil?
+    if moderation_type != content_type
+      Honeybadger.notify("Actual content type differs from reported content type", context: {reported_content_type: content_type, actual_content_type: moderation_type})
+    end
     AzureAiContentSafety.new(
       endpoint: CDO.azure_ai_content_safety_endpoint,
       api_key: CDO.azure_ai_content_safety_key
     ).moderate_image(moderation_io, moderation_type)
   rescue AzureAiContentSafety::AzureError => exception
-    Honeybadger.notify(exception)
+    Honeybadger.notify(exception, context: {reported_content_type: content_type, actual_content_type: moderation_type})
     nil
   end
 
   # Scales up images smaller than MIN_MODERATION_DIMENSION on either dimension.
   # On errors, passes the original bytes through so Azure can still be tried.
+  # Uses magic-byte sniffing to determine actual content type, overriding the
+  # reported content_type value which may be incorrect.
   def self.scale_image_for_moderation_if_needed(image_data, content_type)
     raw_data = image_data.read
+    actual_type = get_actual_content_type(raw_data)
     image = MiniMagick::Image.read(raw_data)
     width = image.width
     height = image.height
     if width >= MIN_MODERATION_DIMENSION && height >= MIN_MODERATION_DIMENSION
-      return StringIO.new(raw_data), content_type
+      return StringIO.new(raw_data), actual_type
     end
 
     scale = [MIN_MODERATION_DIMENSION.to_f / width, MIN_MODERATION_DIMENSION.to_f / height].max
     new_w = (width * scale).ceil
     new_h = (height * scale).ceil
     image.resize "#{new_w}x#{new_h}!"
-    image.format 'png'
-    [StringIO.new(image.to_blob), 'image/png']
+    [StringIO.new(image.to_blob), actual_type]
   rescue MiniMagick::Invalid, MiniMagick::Error
-    [StringIO.new(raw_data), content_type]
+    [StringIO.new(raw_data), actual_type]
+  end
+
+  # Returns the MIME type of image bytes by inspecting magic bytes.
+  # Returns nil only when the format is completely unrecognizable.
+  # Recognizes Azure-accepted types (png, gif, jpeg) and common
+  # unsupported ones (webp, heic, heif) so error context is informative.
+  def self.get_actual_content_type(bytes)
+    return 'image/png'  if bytes.start_with?("\x89PNG\r\n\x1a\n".b)
+    return 'image/gif'  if bytes.match?(/\AGIF8[79]a/n)
+    return 'image/jpeg' if bytes.start_with?("\xff\xd8\xff".b)
+    return 'image/webp' if bytes.start_with?('RIFF'.b) && bytes.byteslice(8, 4) == 'WEBP'
+    # HEIC/HEIF: ISO Base Media File Format — ftyp box at offset 4 with a heic/heif brand.
+    if bytes.bytesize >= 12 && bytes.byteslice(4, 4) == 'ftyp'
+      return 'image/heic' if %w[heic heix hevm hevx heim heis].include?(bytes.byteslice(8, 4))
+      return 'image/heif' if %w[mif1 msf1].include?(bytes.byteslice(8, 4))
+    end
+    nil
   end
 end

--- a/lib/test/cdo/test_image_moderation.rb
+++ b/lib/test/cdo/test_image_moderation.rb
@@ -25,11 +25,12 @@ class ImageModerationTest < Minitest::Test
   end
 
   def test_uses_azure_when_api_key_present
+    blob = tiny_png_blob(100, 100)
     sample = {'categoriesAnalysis' => []}
     AzureAiContentSafety.any_instance.expects(:moderate_image).with do |io, ct|
-      io.read == 'fake-image-body' && ct == @content_type
+      io.read == blob && ct == 'image/png'
     end.returns(sample).once
-    assert_equal sample, ImageModeration.moderate_image(@image_body, @content_type)
+    assert_equal sample, ImageModeration.moderate_image(StringIO.new(blob), 'image/png')
   end
 
   def test_scales_small_images_before_azure
@@ -114,10 +115,70 @@ class ImageModerationTest < Minitest::Test
   end
 
   def test_returns_nil_when_moderation_fails
+    blob = tiny_png_blob(100, 100)
     test_err = AzureAiContentSafety::RequestFailed.new('Test error')
     AzureAiContentSafety.any_instance.expects(:moderate_image).raises(test_err)
-    Honeybadger.expects(:notify).once.with(test_err)
-    assert_nil ImageModeration.moderate_image(@image_body, @content_type)
+    Honeybadger.expects(:notify).once.with(
+      test_err,
+      context: {reported_content_type: 'image/png', actual_content_type: 'image/png'}
+    )
+    assert_nil ImageModeration.moderate_image(StringIO.new(blob), 'image/png')
+  end
+
+  def test_returns_nil_for_unrecognized_image_format
+    AzureAiContentSafety.expects(:new).never
+    Honeybadger.expects(:notify).once
+    assert_nil ImageModeration.moderate_image(StringIO.new('not-an-image'), 'any')
+  end
+
+  def test_get_actual_content_type_png
+    bytes = "\x89PNG\r\n\x1a\nrest".b
+    assert_equal 'image/png', ImageModeration.get_actual_content_type(bytes)
+  end
+
+  def test_get_actual_content_type_jpeg
+    bytes = "\xff\xd8\xff\xe0rest".b
+    assert_equal 'image/jpeg', ImageModeration.get_actual_content_type(bytes)
+  end
+
+  def test_get_actual_content_type_gif
+    assert_equal 'image/gif', ImageModeration.get_actual_content_type("GIF87aXX".b)
+  end
+
+  def test_get_actual_content_type_webp
+    bytes = ("RIFF\x00\x00\x00\x00WEBP".b)
+    assert_equal 'image/webp', ImageModeration.get_actual_content_type(bytes)
+  end
+
+  def test_get_actual_content_type_heic
+    bytes = ("\x00\x00\x00\x18ftypheic".b)
+    assert_equal 'image/heic', ImageModeration.get_actual_content_type(bytes)
+  end
+
+  def test_get_actual_content_type_heif
+    bytes = ("\x00\x00\x00\x18ftypmif1".b)
+    assert_equal 'image/heif', ImageModeration.get_actual_content_type(bytes)
+  end
+
+  def test_get_actual_content_type_unknown_returns_nil
+    assert_nil ImageModeration.get_actual_content_type("not-an-image".b)
+  end
+
+  def test_sniff_overrides_wrong_content_type
+    blob = tiny_png_blob(100, 100)
+    sample = {'categoriesAnalysis' => []}
+    captured_type = nil
+    AzureAiContentSafety.any_instance.expects(:moderate_image).with do |_io, ct|
+      captured_type = ct
+      true
+    end.returns(sample).once
+    Honeybadger.expects(:notify).once.with(
+      "Actual content type differs from reported content type",
+      context: {reported_content_type: 'any', actual_content_type: 'image/png'}
+    )
+
+    ImageModeration.moderate_image(StringIO.new(blob), 'any')
+    assert_equal 'image/png', captured_type
   end
 
   # Tempfile is unlinked when the block returns (see Tempfile.create).

--- a/lib/test/cdo/test_image_moderation.rb
+++ b/lib/test/cdo/test_image_moderation.rb
@@ -173,7 +173,7 @@ class ImageModerationTest < Minitest::Test
       true
     end.returns(sample).once
     Honeybadger.expects(:notify).once.with(
-      "Actual content type differs from reported content type",
+      "Actual content type differs from reported content type in image moderation",
       context: {reported_content_type: 'any', actual_content_type: 'image/png'}
     )
 


### PR DESCRIPTION
<!--
  Summary of the change: background, motivation, and context.
  Include screenshots, videos, or before/after comparisons for UI changes.
-->
This PR addresses the following Azure error reported on HoneyBadger:
```
AzureAiContentSafety::RequestFailed: Request to Azure AI Content Safety failed with status 400
The image format is not supported. Please double check the API definition.
```
[Example report](https://app.honeybadger.io/projects/3240/faults/129339498/01KP4CNPG274JY00165N0V3KF0?page=0)

It follows up the recent migration to AI Content Safety https://github.com/code-dot-org/code-dot-org/pull/71878 and other steps to resolve Azure errors https://github.com/code-dot-org/code-dot-org/pull/72099.

Initially, I proposed converting model-generated images to PNG files to avoid these errors in `generateChatResponse.ts`. https://github.com/code-dot-org/code-dot-org/pull/72108

But I think a simpler approach would be to get the actual content type of the image file when already reading the image bytes (we do this when deciding if scaling is needed before being moderated due to size constraints). Then we can see what type of image is being produced by the Gemini 2.5 Flash Image model. Currently, the model supports the following image types: image/png, image/jpeg, image/webp, image/heic, image/heif. See https://docs.cloud.google.com/vertex-ai/generative-ai/docs/models/gemini/2-5-flash-image.

Because Azure AI Content Safety doesn't accept `webp`, `heic`, or `heif`, we only allow `png` or `jpeg` files to be sent to the moderation endpoint.

https://github.com/code-dot-org/code-dot-org/blob/382b9588828265163e487d272b3ed15d0268c2cf/apps/src/util/moderateImage.ts#L49-L54


But we somehow are still getting Azure errors about unsupported type so perhaps Vercel is not reporting the content type of generated images correctly. This PR adds HB reports if the actual content type is different from the reported type of the image file, and also include in the context the reported and actual content type if we receive the `AzureAiContentSafety::RequestFailed: Request to Azure AI Content Safety failed with status 400
The image format is not supported. ` error.



## Links
<!-- Jira tickets, design docs, Slack threads, related PRs, etc. -->

- Jira: https://codedotorg.atlassian.net/browse/SL-1670

## Testing story
<!-- How was this tested? Manual steps, adhoc links, automated tests, or why testing isn't needed. -->

Added unit tests.

## Deployment notes
<!-- Delete this section if it's a standard merge-and-deploy.
     Otherwise: migrations, feature flags, coordination, caching impacts, etc. -->



## Privacy and security
<!-- Delete this section if there is no privacy/security impact.
     Otherwise: new PII, auth changes, API surface changes, etc. -->

