### PR TITLE
Exclude archived sections when calculating ai_chat_access_level

### DIFF
--- a/dashboard/app/models/concerns/user/ai_accessible.rb
+++ b/dashboard/app/models/concerns/user/ai_accessible.rb
@@ -57,10 +57,10 @@ module User::AiAccessible
   end
 
   private def in_section_with_ai_chat_access_enabled?
-    sections_as_student.any? {|s| s.ai_chat_access_level == AI_CHAT_ACCESS_LEVELS[:ENABLED]}
+    sections_as_student.any? {|s| !s.hidden && s.ai_chat_access_level == AI_CHAT_ACCESS_LEVELS[:ENABLED]}
   end
 
   private def in_section_with_ai_chat_access_essential_only?
-    sections_as_student.any? {|s| s.ai_chat_access_level == AI_CHAT_ACCESS_LEVELS[:ESSENTIAL_ONLY]}
+    sections_as_student.any? {|s| !s.hidden && s.ai_chat_access_level == AI_CHAT_ACCESS_LEVELS[:ESSENTIAL_ONLY]}
   end
 end

--- a/dashboard/test/models/concerns/user/ai_accessible_test.rb
+++ b/dashboard/test/models/concerns/user/ai_accessible_test.rb
@@ -128,6 +128,24 @@ class UserAiAccessibleTest < ActiveSupport::TestCase
         _ai_chat_access_level.must_equal Section::AI_CHAT_ACCESS_LEVELS[:ENABLED]
       end
     end
+
+    context 'when student is in a hidden (archived) section with ENABLED access' do
+      it 'returns DISABLED' do
+        hidden_section = create(:section, ai_chat_access_level: Section::AI_CHAT_ACCESS_LEVELS[:ENABLED], hidden: true)
+        allow(user).to receive(:teachers).and_return([qualified_teacher])
+        allow(user).to receive(:sections_as_student).and_return([hidden_section])
+        _ai_chat_access_level.must_equal Section::AI_CHAT_ACCESS_LEVELS[:DISABLED]
+      end
+    end
+
+    context 'when student is in a hidden (archived) section with ESSENTIAL_ONLY access' do
+      it 'returns DISABLED' do
+        hidden_section = create(:section, ai_chat_access_level: Section::AI_CHAT_ACCESS_LEVELS[:ESSENTIAL_ONLY], hidden: true)
+        allow(user).to receive(:teachers).and_return([qualified_teacher])
+        allow(user).to receive(:sections_as_student).and_return([hidden_section])
+        _ai_chat_access_level.must_equal Section::AI_CHAT_ACCESS_LEVELS[:DISABLED]
+      end
+    end
   end
 
   describe '#can_access_aichat_chat_completion?' do


### PR DESCRIPTION
<!--
  Summary of the change: background, motivation, and context.
  Include screenshots, videos, or before/after comparisons for UI changes.
-->

For calculating a student's access level, we check the access level settings of the sections they are in. If the only enabled ones are archived, the student should not have their ai chat access enabled.

## Links
<!-- Jira tickets, design docs, Slack threads, related PRs, etc. -->

- Jira: https://codedotorg.atlassian.net/browse/TEACHING-167

## Testing story
<!-- How was this tested? Manual steps, adhoc links, automated tests, or why testing isn't needed. -->

UTs