### PR TITLE
AI Tutor+: update access to /tutor

### DIFF
--- a/apps/src/aiTutor/views/lessonDeepDive/LessonDeepDiveContainer.tsx
+++ b/apps/src/aiTutor/views/lessonDeepDive/LessonDeepDiveContainer.tsx
@@ -62,7 +62,7 @@ const LessonDeepDiveContainer: FC<LessonDeepDiveContainerProps> = ({
     setReflectionData(data);
   }, []);
 
-  if (!experiments.isEnabled(experiments.LESSON_TUTOR)) {
+  if (!experiments.isEnabledAllowingQueryString(experiments.LESSON_TUTOR)) {
     return null;
   }
 

--- a/apps/src/code-studio/components/progress/LessonProgress.jsx
+++ b/apps/src/code-studio/components/progress/LessonProgress.jsx
@@ -158,7 +158,7 @@ class LessonProgress extends Component {
     const showLessonTutorBubble =
       lessonTutorPath &&
       hasLessonPlan &&
-      experiments.isEnabled(experiments.LESSON_TUTOR);
+      experiments.isEnabledAllowingQueryString(experiments.LESSON_TUTOR);
 
     let levels = this.props.levels;
 

--- a/apps/src/templates/progress/ProgressLesson.jsx
+++ b/apps/src/templates/progress/ProgressLesson.jsx
@@ -208,7 +208,9 @@ class ProgressLesson extends React.Component {
                   </MuiButton>
                 )}
                 {showLessonTutorButton &&
-                  experiments.isEnabled(experiments.LESSON_TUTOR) && (
+                  experiments.isEnabledAllowingQueryString(
+                    experiments.LESSON_TUTOR
+                  ) && (
                     <MuiButton
                       href={lesson.lessonTutorPath}
                       variant="contained"

--- a/apps/src/templates/progress/SummaryProgressRow.jsx
+++ b/apps/src/templates/progress/SummaryProgressRow.jsx
@@ -151,7 +151,9 @@ function SummaryProgressRow({
                 </MuiButton>
               )}
               {showLessonTutorButton &&
-                experiments.isEnabled(experiments.LESSON_TUTOR) && (
+                experiments.isEnabledAllowingQueryString(
+                  experiments.LESSON_TUTOR
+                ) && (
                   <MuiButton
                     href={lesson.lessonTutorPath}
                     variant="contained"

--- a/dashboard/app/controllers/lessons_controller.rb
+++ b/dashboard/app/controllers/lessons_controller.rb
@@ -3,7 +3,7 @@ class LessonsController < ApplicationController
 
   skip_authorize_resource only: :level_properties_by_id
 
-  before_action :require_levelbuilder_mode_or_test_env, except: [:index, :show, :student_lesson_plan, :level_properties, :level_properties_by_id]
+  before_action :require_levelbuilder_mode_or_test_env, except: [:index, :show, :student_lesson_plan, :level_properties, :level_properties_by_id, :tutor]
   before_action :disallow_legacy_script_levels, only: [:edit, :update]
   before_action :disable_session_for_cached_pages, only: [:show]
   before_action :redirect_to_canonical_path, only: [:show, :student_lesson_plan]

--- a/dashboard/app/models/ability.rb
+++ b/dashboard/app/models/ability.rb
@@ -367,7 +367,7 @@ class Ability
       end
     end
 
-    can [:read, :show_by_id, :student_lesson_plan, :level_properties, :level_properties_by_id], Lesson do |lesson, context_unit_group|
+    can [:read, :show_by_id, :student_lesson_plan, :level_properties, :level_properties_by_id, :tutor], Lesson do |lesson, context_unit_group|
       script = lesson.script
       unit_group = context_unit_group || script.original_unit_group
       can?(:read, script, unit_group)


### PR DESCRIPTION
Locally I was testing `/lesson/<lesson-id>/tutor` with an account that had levelbuilder permissions and `levelbuilder_mode: true` in my locals.yml. This was effectively covering up a bug with access to /tutor which should be available to all signed in users regardless of permissions across all environments. This fixes the issue making the feature more widely available for internal testing. You do still need to have the experiment flag set, which you can now do with just `?lesson-tutor=1` 