### PR TITLE
Allow for teacher preverification via pilot

### DIFF
--- a/dashboard/app/models/concerns/user/ai_accessible.rb
+++ b/dashboard/app/models/concerns/user/ai_accessible.rb
@@ -3,6 +3,8 @@ module User::AiAccessible
   extend ActiveSupport::Concern
   include SharedConstants
 
+  TEACHER_PREVERIFICATION_PILOT = 'teacher-preverification'.freeze
+
   # Chat apis trust the client to decide if it can access chat features
   # This allows us the flexibility to do things like experiment with new
   # lab types with low friction.
@@ -17,7 +19,7 @@ module User::AiAccessible
   end
 
   def teacher_can_access_aichat?
-    teacher? && (verified_instructor? || oauth? || Policies::Lti.lti?(self))
+    teacher? && (verified_instructor? || oauth? || Policies::Lti.lti?(self) || SingleUserExperiment.enabled?(user: self, experiment_name: TEACHER_PREVERIFICATION_PILOT))
   end
 
   def ai_chat_access_level

--- a/dashboard/test/models/concerns/user/ai_accessible_test.rb
+++ b/dashboard/test/models/concerns/user/ai_accessible_test.rb
@@ -55,6 +55,27 @@ class UserAiAccessibleTest < ActiveSupport::TestCase
       _teacher_can_access_aichat?.must_equal true
     end
 
+    it 'returns true for teacher in the preverification pilot' do
+      allow(user).to receive(:teacher?).and_return(true)
+      create(
+        :single_user_experiment,
+        min_user_id: user.id,
+        name: User::AiAccessible::TEACHER_PREVERIFICATION_PILOT
+      )
+
+      _teacher_can_access_aichat?.must_equal true
+    end
+
+    it 'returns false for student in the preverification pilot' do
+      create(
+        :single_user_experiment,
+        min_user_id: user.id,
+        name: User::AiAccessible::TEACHER_PREVERIFICATION_PILOT
+      )
+
+      _teacher_can_access_aichat?.must_equal false
+    end
+
     it 'returns false if none of the conditions are met' do
       _teacher_can_access_aichat?.must_equal false
     end


### PR DESCRIPTION
<!--
  Summary of the change: background, motivation, and context.
  Include screenshots, videos, or before/after comparisons for UI changes.
-->

For our HoAI style weblab2 tutorial, we want to reduce the barrier to entry for folks to join webinars and do the tutorial. Since teacher verification can take days, we are implementing a pilot to allow for preverification in webinars. 

## Links
<!-- Jira tickets, design docs, Slack threads, related PRs, etc. -->

- Jira: https://codedotorg.atlassian.net/browse/TEACHING-162
- Slack: https://codedotorg.slack.com/archives/C08S29NDZ5E/p1775471848872289

## Testing story
<!-- How was this tested? Manual steps, adhoc links, automated tests, or why testing isn't needed. -->



## Deployment notes
<!-- Delete this section if it's a standard merge-and-deploy.
     Otherwise: migrations, feature flags, coordination, caching impacts, etc. -->



## Privacy and security
<!-- Delete this section if there is no privacy/security impact.
     Otherwise: new PII, auth changes, API surface changes, etc. -->

