### PR TITLE
[VPAT] Fixes 5 wcag violations in arrow keys and pause play

### DIFF
--- a/apps/src/dance/SongSelector.tsx
+++ b/apps/src/dance/SongSelector.tsx
@@ -104,6 +104,7 @@ const SongSelector: React.FC<SongSelectorProps> = ({
         disabled={levelIsRunning}
         color={Button.ButtonColor.neutralDark}
         icon=" fa-solid fa-play-pause"
+        aria-label={songInPreview ? 'Pause' : 'Play'}
         onClick={onPreviewBtnClick}
       />
     </div>

--- a/apps/src/templates/ArrowButtons.jsx
+++ b/apps/src/templates/ArrowButtons.jsx
@@ -2,12 +2,13 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import {connect} from 'react-redux';
 
-// Matches KeyCodes in studio.js: LEFT=37, UP=38, RIGHT=39, DOWN=40
+import {KeyCodes} from '@cdo/apps/constants';
+
 const ARROW_KEY_CODES = {
-  leftButton: 37,
-  upButton: 38,
-  rightButton: 39,
-  downButton: 40,
+  leftButton: KeyCodes.LEFT,
+  upButton: KeyCodes.UP,
+  rightButton: KeyCodes.RIGHT,
+  downButton: KeyCodes.DOWN,
 };
 
 /**
@@ -25,7 +26,8 @@ class ArrowButtons extends React.Component {
     const style = visible ? styles.visible : styles.hidden;
 
     const onKeyDown = e => {
-      if (e.key === 'Enter' || e.key === ' ') {
+      if (e.keyCode === KeyCodes.ENTER || e.keyCode === KeyCodes.SPACE) {
+        e.preventDefault();
         const keyCode = ARROW_KEY_CODES[e.currentTarget.id];
         window.dispatchEvent(
           new KeyboardEvent('keydown', {keyCode, bubbles: true})
@@ -33,7 +35,8 @@ class ArrowButtons extends React.Component {
       }
     };
     const onKeyUp = e => {
-      if (e.key === 'Enter' || e.key === ' ') {
+      if (e.keyCode === KeyCodes.ENTER || e.keyCode === KeyCodes.SPACE) {
+        e.preventDefault();
         const keyCode = ARROW_KEY_CODES[e.currentTarget.id];
         window.dispatchEvent(
           new KeyboardEvent('keyup', {keyCode, bubbles: true})

--- a/apps/src/templates/ArrowButtons.jsx
+++ b/apps/src/templates/ArrowButtons.jsx
@@ -2,6 +2,14 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import {connect} from 'react-redux';
 
+// Matches KeyCodes in studio.js: LEFT=37, UP=38, RIGHT=39, DOWN=40
+const ARROW_KEY_CODES = {
+  leftButton: 37,
+  upButton: 38,
+  rightButton: 39,
+  downButton: 40,
+};
+
 /**
  * A set of arrow buttons
  */
@@ -15,6 +23,24 @@ class ArrowButtons extends React.Component {
   render() {
     const {visible, disabled} = this.props;
     const style = visible ? styles.visible : styles.hidden;
+
+    const onKeyDown = e => {
+      if (e.key === 'Enter' || e.key === ' ') {
+        const keyCode = ARROW_KEY_CODES[e.currentTarget.id];
+        window.dispatchEvent(
+          new KeyboardEvent('keydown', {keyCode, bubbles: true})
+        );
+      }
+    };
+    const onKeyUp = e => {
+      if (e.key === 'Enter' || e.key === ' ') {
+        const keyCode = ARROW_KEY_CODES[e.currentTarget.id];
+        window.dispatchEvent(
+          new KeyboardEvent('keyup', {keyCode, bubbles: true})
+        );
+      }
+    };
+
     return (
       <div style={style} id="soft-buttons">
         <button
@@ -22,6 +48,9 @@ class ArrowButtons extends React.Component {
           id="leftButton"
           disabled={disabled}
           className="arrow"
+          aria-label="Left arrow"
+          onKeyDown={onKeyDown}
+          onKeyUp={onKeyUp}
         >
           <img
             src="/blockly/media/1x1.gif"
@@ -34,6 +63,9 @@ class ArrowButtons extends React.Component {
           id="rightButton"
           disabled={disabled}
           className="arrow"
+          aria-label="Right arrow"
+          onKeyDown={onKeyDown}
+          onKeyUp={onKeyUp}
         >
           <img
             src="/blockly/media/1x1.gif"
@@ -46,6 +78,9 @@ class ArrowButtons extends React.Component {
           id="upButton"
           disabled={disabled}
           className="arrow"
+          aria-label="Up arrow"
+          onKeyDown={onKeyDown}
+          onKeyUp={onKeyUp}
         >
           <img src="/blockly/media/1x1.gif" className="up-btn icon21" alt="" />
         </button>
@@ -54,6 +89,9 @@ class ArrowButtons extends React.Component {
           id="downButton"
           disabled={disabled}
           className="arrow"
+          aria-label="Down arrow"
+          onKeyDown={onKeyDown}
+          onKeyUp={onKeyUp}
         >
           <img
             src="/blockly/media/1x1.gif"


### PR DESCRIPTION
Gives the pause/play button a corresponding aria-label

(Trickier) adds labels and key handlers to the arrow key buttons. I opted to match the exact studio implementation by calling a keyPress to ensure that pressing the buttons with enter behaves the same way as using the arrow keys on a keyboard would. 

Before: A use pressed run and the game starts listening for arrow key presses, but the arrow buttons below the visualization were not navigable. A user could press the arrows with a mouse or press the arrow keys on their own keyboard, but could not navigate to them and use them that way. 

After: Now a user can activate the arrow keys in three ways- by pressing them with a mouse, navigating to them and pressing enter or space, or leaving focus wherever on the page but using their keyboard arrow keys.

PausePlay before:

https://github.com/user-attachments/assets/6f683a71-d3d9-446b-85e3-c7f33f21e794



PausePlay after:

https://github.com/user-attachments/assets/ec93e982-a55d-4021-877c-c5912dd83811

Arrow keys before: (hard to tell, but I'm trying to activate the poorly labeled buttons and nothing happens)

https://github.com/user-attachments/assets/96d44d16-e7c7-4563-9790-226cb577ffb5




Arrow keys after:


https://github.com/user-attachments/assets/b27f9637-c87e-445d-8537-64c62c08e4a3



## Links

- Jira: https://codedotorg.atlassian.net/browse/SL-1673
- https://codedotorg.atlassian.net/browse/SL-1674

## Testing story
<!-- How was this tested? Manual steps, adhoc links, automated tests, or why testing isn't needed. -->



## Deployment notes
<!-- Delete this section if it's a standard merge-and-deploy.
     Otherwise: migrations, feature flags, coordination, caching impacts, etc. -->



## Privacy and security
<!-- Delete this section if there is no privacy/security impact.
     Otherwise: new PII, auth changes, API surface changes, etc. -->

