### PR TITLE
Fix instructions drawer bug for slow CPU

### DIFF
--- a/apps/src/lab2/views/components/Instructions/ResourcePanel/AiTutorChatWithInstructionsDrawer/useInstructionsDrawer.ts
+++ b/apps/src/lab2/views/components/Instructions/ResourcePanel/AiTutorChatWithInstructionsDrawer/useInstructionsDrawer.ts
@@ -236,9 +236,11 @@ export const useInstructionsDrawer = ({
       }
     };
 
-    updateMaxHeight();
-
     // Watch for size changes (e.g., when details elements expand/collapse).
+    // The initial ResizeObserver callback also drives the first height measurement:
+    // it fires after browser layout, guaranteeing accurate scrollHeight on all
+    // devices including slow ones where effects run before the browser lays out
+    // newly-mounted content (React 18 discrete-event effect timing).
     const resizeObserver = new ResizeObserver(() => {
       updateMaxHeight();
       updateScrollFade();


### PR DESCRIPTION
This PR fixes a bug with the AI Tutor instructions drawer on slower computers (like Chromebooks).

In React 18, effects triggered by click events run synchronously before the brower's layout step. So when the effect calls `updateMaxHeight` directly, it reads `instructionsContentElement.scrollHeight` before the browser has computed layout for the mounted instructions content. On a fast CPU this isn't an issue, but on a slower computer like a Chromebook the browser hasn't finished the layout by the time the effect fires so `scrollHeight` has not been updated so returns `0` or a small value and the drawer gets set to ~30px.
Since `hasSetInitialHeightFromContentRef` is set to `true` in that first call, the later`ResizeObserver` callback then fires after browser layout and goes to else branch and drawer is locked at ~30 px.

The fix is to move the direct call to `updateMaxHeight` and let the `ResizeObserver`'s initial callback handle the first measurement. These callback fire after layout so `scrollHeight` is always accurate. 




<!--
  Summary of the change: background, motivation, and context.
  Include screenshots, videos, or before/after comparisons for UI changes.
-->



## Links
<!-- Jira tickets, design docs, Slack threads, related PRs, etc. -->

- Jira: https://codedotorg.atlassian.net/browse/SL-1671
- Slack thread report: https://codedotorg.slack.com/archives/C03DBDN67B7/p1776267708316739?thread_ts=1774473202.485899&cid=C03DBDN67B7

## Testing story
<!-- How was this tested? Manual steps, adhoc links, automated tests, or why testing isn't needed. -->

Tested locally and throttled CPU speed by 4x.

## Before update

https://github.com/user-attachments/assets/e9bf9c6b-1e6a-4f49-b3ec-86265862b140


## After update


https://github.com/user-attachments/assets/5c093da1-72ad-4b66-8e18-a903c45cf751






## Deployment notes
<!-- Delete this section if it's a standard merge-and-deploy.
     Otherwise: migrations, feature flags, coordination, caching impacts, etc. -->



## Privacy and security
<!-- Delete this section if there is no privacy/security impact.
     Otherwise: new PII, auth changes, API surface changes, etc. -->

