### PR TITLE
Add demo section card UI

### DIFF
--- a/apps/src/sites/studio/pages/teacher_dashboard/show.js
+++ b/apps/src/sites/studio/pages/teacher_dashboard/show.js
@@ -31,6 +31,7 @@ import teacherSections, {
 import {setSelectedSectionData} from '@cdo/apps/templates/teacherNavigation/selectedSectionLoader';
 import TeacherNavigationRouter from '@cdo/apps/templates/teacherNavigation/TeacherNavigationRouter';
 import {createReactRoot} from '@cdo/apps/util/createReactRoot';
+import experiments from '@cdo/apps/util/experiments';
 
 // 6 seconds
 const FLASH_DURATION = 6 * 1000;
@@ -94,9 +95,7 @@ $(document).ready(function () {
 
   createReactRoot(
     <Provider store={store}>
-      {sections.length === 0 ? (
-        // If a teacher has no sections, we will send them directly to the homepage to bypass
-        // all of the section loading logic in the TeacherNavigationRouter.
+      {sections.length === 0 && !experiments.isEnabled('demo-section') ? (
         <TeacherHomepage studioUrlPrefix={scriptData.studioUrlPrefix} />
       ) : (
         <TeacherNavigationRouter studioUrlPrefix={scriptData.studioUrlPrefix} />

--- a/apps/src/templates/CurrentUserState.ts
+++ b/apps/src/templates/CurrentUserState.ts
@@ -20,6 +20,7 @@ export interface CurrentUserState {
   userId: number;
   userName: string;
   displayName?: string;
+  gradesTeaching: string[];
   userType: 'unknown' | 'teacher' | 'student';
   userRoleInCourse: CourseRole;
   signInState: SignInState;

--- a/apps/src/templates/currentUserRedux.js
+++ b/apps/src/templates/currentUserRedux.js
@@ -105,6 +105,7 @@ export const setHasSeenHomepageWelcome = hasSeenHomepageWelcome => ({
 const initialState = {
   userId: null,
   userName: null,
+  gradesTeaching: [],
   userType: 'unknown',
   userRoleInCourse: CourseRoles.Unknown,
   signInState: SignInState.Unknown,
@@ -236,6 +237,7 @@ export default function currentUser(state = initialState, action) {
       id,
       username,
       display_name,
+      grades_teaching,
       user_type,
       mute_music,
       under_13,
@@ -271,6 +273,7 @@ export default function currentUser(state = initialState, action) {
       ...state,
       userId: id,
       userName: username,
+      gradesTeaching: grades_teaching || [],
       userType: user_type,
       displayName: display_name,
       isBackgroundMusicMuted: mute_music,

--- a/apps/src/templates/studioHomepages/teacherHomepageV2/CourseContentDropdown.tsx
+++ b/apps/src/templates/studioHomepages/teacherHomepageV2/CourseContentDropdown.tsx
@@ -1,9 +1,13 @@
 import {CustomDropdown} from '@code-dot-org/component-library/dropdown';
+import FontAwesomeV6Icon from '@code-dot-org/component-library/fontAwesomeV6Icon';
 import {Typography} from '@mui/material';
 import React, {useEffect, useState, useMemo} from 'react';
 
 import {EVENTS} from '@cdo/apps/metrics/AnalyticsConstants.js';
-import {Section} from '@cdo/apps/templates/teacherDashboard/types/teacherSectionTypes';
+import {
+  DemoType,
+  Section,
+} from '@cdo/apps/templates/teacherDashboard/types/teacherSectionTypes';
 import HttpClient from '@cdo/apps/util/HttpClient';
 import i18n from '@cdo/locale';
 
@@ -14,6 +18,9 @@ import styles from './teacherHomepage.module.scss';
 
 interface CourseContentDropdownProps {
   section: Section;
+  demoType?: DemoType;
+  disabled?: boolean;
+  onNavigateToPath?: (path: string, eventName: string) => void;
 }
 
 // Interface for the unit lessons dropdown
@@ -29,41 +36,66 @@ interface UnitLessonOptions {
  */
 export const CourseContentDropdown: React.FC<CourseContentDropdownProps> = ({
   section,
+  demoType,
+  disabled = false,
+  onNavigateToPath,
 }) => {
   const [lessonList, setLessonList] = useState<UnitLessonOptions[]>([]);
 
   useEffect(() => {
     const fetchLessonList = async () => {
       HttpClient.fetchJson<UnitLessonOptions[]>(
-        `/sections/${section.id}/retrieve_lessons_for_dropdown`
+        demoType
+          ? `/sections/retrieve_lessons_for_dropdown?demo_type=${demoType}`
+          : `/sections/${section.id}/retrieve_lessons_for_dropdown`
       )
         .then(response => setLessonList(response.value))
         .catch(error => console.error(error));
     };
 
-    if (section.unitId && lessonList.length === 0) {
+    if ((section.unitId || demoType) && lessonList.length === 0) {
       fetchLessonList();
     }
-  }, [section, lessonList]);
+  }, [section, lessonList, demoType]);
 
   const dropdownOptions = useMemo(
     () =>
-      lessonList.map(lesson => (
-        <LinkOption
-          key={lesson.value}
-          value={lesson.value}
-          label={lesson.text}
-          labelStyle={lesson.value.includes('/lessons/') ? 'i' : 'b'}
-          url={lesson.value}
-          eventName={
-            lesson.value.includes('/lessons/')
-              ? EVENTS.SECTION_CARD_JUMP_TO_LESSON_CLICKED
-              : EVENTS.SECTION_CARD_JUMP_TO_UNIT_OVERVIEW_CLICKED
-          }
-          eventOptions={{lesson: lesson.value}}
-        />
-      )),
-    [lessonList]
+      lessonList.map(lesson =>
+        onNavigateToPath ? (
+          <li key={lesson.value}>
+            <button
+              type="button"
+              className={styles.dropdownMenuItem}
+              disabled={disabled}
+              onClick={() =>
+                onNavigateToPath(
+                  lesson.value,
+                  lesson.value.includes('/lessons/')
+                    ? EVENTS.SECTION_CARD_JUMP_TO_LESSON_CLICKED
+                    : EVENTS.SECTION_CARD_JUMP_TO_UNIT_OVERVIEW_CLICKED
+                )
+              }
+            >
+              <span>{lesson.text}</span>
+            </button>
+          </li>
+        ) : (
+          <LinkOption
+            key={lesson.value}
+            value={lesson.value}
+            label={lesson.text}
+            labelStyle={lesson.value.includes('/lessons/') ? 'i' : 'b'}
+            url={lesson.value}
+            eventName={
+              lesson.value.includes('/lessons/')
+                ? EVENTS.SECTION_CARD_JUMP_TO_LESSON_CLICKED
+                : EVENTS.SECTION_CARD_JUMP_TO_UNIT_OVERVIEW_CLICKED
+            }
+            eventOptions={{lesson: lesson.value}}
+          />
+        )
+      ),
+    [lessonList, onNavigateToPath, disabled]
   );
 
   return (
@@ -77,17 +109,45 @@ export const CourseContentDropdown: React.FC<CourseContentDropdownProps> = ({
         <b>{`${i18n.course()}: `}</b>
         {section.courseDisplayName}
       </Typography>
-      {section.unitId ? (
+      {section.unitId || demoType ? (
         <CustomDropdown
           className={styles.courseContentDropdown}
           name="go-to-lesson"
           labelText={i18n.jumpTo()}
           labelType="thin"
-          disabled={lessonList.length === 0}
+          disabled={disabled || lessonList.length === 0}
           size="m"
         >
           <ul>{dropdownOptions}</ul>
         </CustomDropdown>
+      ) : onNavigateToPath ? (
+        <button
+          type="button"
+          className={styles.demoActionButton}
+          disabled={disabled}
+          onClick={() =>
+            onNavigateToPath(
+              `courses/${section.courseVersionName}`,
+              EVENTS.SECTION_CARD_GO_TO_COURSE_BUTTON_CLICKED
+            )
+          }
+        >
+          <div className={styles.taskButtonLeft}>
+            <FontAwesomeV6Icon
+              className={styles.taskButtonIcons}
+              iconName="desktop"
+              iconStyle="solid"
+            />
+            <Typography variant="body3" gutterBottom>
+              {i18n.goToCourse()}
+            </Typography>
+          </div>
+          <FontAwesomeV6Icon
+            className={styles.taskButtonArrow}
+            iconName="arrow-right"
+            iconStyle="solid"
+          />
+        </button>
       ) : (
         <TaskButton
           buttonText={i18n.goToCourse()}

--- a/apps/src/templates/studioHomepages/teacherHomepageV2/CourseContentDropdown.tsx
+++ b/apps/src/templates/studioHomepages/teacherHomepageV2/CourseContentDropdown.tsx
@@ -19,7 +19,6 @@ import styles from './teacherHomepage.module.scss';
 interface CourseContentDropdownProps {
   section: Section;
   demoType?: DemoType;
-  disabled?: boolean;
   onNavigateToPath?: (path: string, eventName: string) => void;
 }
 
@@ -37,7 +36,6 @@ interface UnitLessonOptions {
 export const CourseContentDropdown: React.FC<CourseContentDropdownProps> = ({
   section,
   demoType,
-  disabled = false,
   onNavigateToPath,
 }) => {
   const [lessonList, setLessonList] = useState<UnitLessonOptions[]>([]);
@@ -66,7 +64,6 @@ export const CourseContentDropdown: React.FC<CourseContentDropdownProps> = ({
             <button
               type="button"
               className={styles.dropdownMenuItem}
-              disabled={disabled}
               onClick={() =>
                 onNavigateToPath(
                   lesson.value,
@@ -95,7 +92,7 @@ export const CourseContentDropdown: React.FC<CourseContentDropdownProps> = ({
           />
         )
       ),
-    [lessonList, onNavigateToPath, disabled]
+    [lessonList, onNavigateToPath]
   );
 
   return (
@@ -115,7 +112,7 @@ export const CourseContentDropdown: React.FC<CourseContentDropdownProps> = ({
           name="go-to-lesson"
           labelText={i18n.jumpTo()}
           labelType="thin"
-          disabled={disabled || lessonList.length === 0}
+          disabled={lessonList.length === 0}
           size="m"
         >
           <ul>{dropdownOptions}</ul>
@@ -124,7 +121,6 @@ export const CourseContentDropdown: React.FC<CourseContentDropdownProps> = ({
         <button
           type="button"
           className={styles.demoActionButton}
-          disabled={disabled}
           onClick={() =>
             onNavigateToPath(
               `courses/${section.courseVersionName}`,

--- a/apps/src/templates/studioHomepages/teacherHomepageV2/CourseContentDropdown.tsx
+++ b/apps/src/templates/studioHomepages/teacherHomepageV2/CourseContentDropdown.tsx
@@ -42,10 +42,9 @@ export const CourseContentDropdown: React.FC<CourseContentDropdownProps> = ({
 
   useEffect(() => {
     const fetchLessonList = async () => {
+      const sectionIdOrDemoPreset = demoType || section.id;
       HttpClient.fetchJson<UnitLessonOptions[]>(
-        demoType
-          ? `/sections/retrieve_lessons_for_dropdown?demo_type=${demoType}`
-          : `/sections/${section.id}/retrieve_lessons_for_dropdown`
+        `/sections/${sectionIdOrDemoPreset}/retrieve_lessons_for_dropdown`
       )
         .then(response => setLessonList(response.value))
         .catch(error => console.error(error));

--- a/apps/src/templates/studioHomepages/teacherHomepageV2/CourseContentDropdown.tsx
+++ b/apps/src/templates/studioHomepages/teacherHomepageV2/CourseContentDropdown.tsx
@@ -1,13 +1,9 @@
 import {CustomDropdown} from '@code-dot-org/component-library/dropdown';
-import FontAwesomeV6Icon from '@code-dot-org/component-library/fontAwesomeV6Icon';
 import {Typography} from '@mui/material';
 import React, {useEffect, useState} from 'react';
 
 import {EVENTS} from '@cdo/apps/metrics/AnalyticsConstants.js';
-import {
-  DemoType,
-  Section,
-} from '@cdo/apps/templates/teacherDashboard/types/teacherSectionTypes';
+import {Section} from '@cdo/apps/templates/teacherDashboard/types/teacherSectionTypes';
 import HttpClient from '@cdo/apps/util/HttpClient';
 import i18n from '@cdo/locale';
 
@@ -21,33 +17,28 @@ interface CourseContentDropdownProps {
   disabled?: boolean;
 }
 
-interface DemoSectionCourseContentDropdownProps {
-  section: Section;
-  demoType?: DemoType;
-  disabled?: boolean;
-  beforeNavigate: (path: string, eventName: string) => void;
-}
-
-interface CourseContentDropdownBaseProps {
+export interface CourseContentDropdownBaseProps {
   section: Section;
   disabled: boolean;
-  shouldShowLessonDropdown: boolean;
-  lessonSource: number | DemoType;
+  shouldShowLessonDropdown: boolean | string;
+  lessonSource: number | string;
   renderLessonOption: (lesson: UnitLessonOption) => React.ReactNode;
   renderCourseAction: () => React.ReactNode;
 }
 
-interface UnitLessonOption {
+export interface UnitLessonOption {
   value: string;
   text: string;
 }
 
-const getLessonEventName = (lessonValue: string) =>
+export const getLessonEventName = (lessonValue: string) =>
   lessonValue.includes('/lessons/')
     ? EVENTS.SECTION_CARD_JUMP_TO_LESSON_CLICKED
     : EVENTS.SECTION_CARD_JUMP_TO_UNIT_OVERVIEW_CLICKED;
 
-const CourseContentDropdownBase: React.FC<CourseContentDropdownBaseProps> = ({
+export const CourseContentDropdownBase: React.FC<
+  CourseContentDropdownBaseProps
+> = ({
   section,
   disabled,
   shouldShowLessonDropdown,
@@ -128,64 +119,6 @@ export const CourseContentDropdown: React.FC<CourseContentDropdownProps> = ({
         sectionName={section.name}
         path={`courses/${section.courseVersionName}`}
       />
-    )}
-  />
-);
-
-export const DemoSectionCourseContentDropdown: React.FC<
-  DemoSectionCourseContentDropdownProps
-> = ({section, demoType, disabled = false, beforeNavigate}) => (
-  <CourseContentDropdownBase
-    section={section}
-    disabled={disabled}
-    shouldShowLessonDropdown={Boolean(section.unitId || demoType)}
-    lessonSource={demoType || section.id}
-    renderLessonOption={lesson => (
-      <li key={lesson.value}>
-        {/* Use a button here because demo flows perform work before
-            navigation. The menu item stays keyboard reachable and correctly
-            exposed as an action, while non-demo entries remain real links. */}
-        <button
-          type="button"
-          className={styles.dropdownMenuItem}
-          disabled={disabled}
-          aria-label={`Create demo section and go to '${lesson.text}'`}
-          onClick={() =>
-            beforeNavigate(lesson.value, getLessonEventName(lesson.value))
-          }
-        >
-          <span>{lesson.text}</span>
-        </button>
-      </li>
-    )}
-    renderCourseAction={() => (
-      <button
-        type="button"
-        className={styles.demoActionButton}
-        disabled={disabled}
-        onClick={() =>
-          beforeNavigate(
-            `courses/${section.courseVersionName}`,
-            EVENTS.SECTION_CARD_GO_TO_COURSE_BUTTON_CLICKED
-          )
-        }
-      >
-        <div className={styles.taskButtonLeft}>
-          <FontAwesomeV6Icon
-            className={styles.taskButtonIcons}
-            iconName="desktop"
-            iconStyle="solid"
-          />
-          <Typography variant="body3" gutterBottom>
-            {i18n.goToCourse()}
-          </Typography>
-        </div>
-        <FontAwesomeV6Icon
-          className={styles.taskButtonArrow}
-          iconName="arrow-right"
-          iconStyle="solid"
-        />
-      </button>
     )}
   />
 );

--- a/apps/src/templates/studioHomepages/teacherHomepageV2/CourseContentDropdown.tsx
+++ b/apps/src/templates/studioHomepages/teacherHomepageV2/CourseContentDropdown.tsx
@@ -1,7 +1,7 @@
 import {CustomDropdown} from '@code-dot-org/component-library/dropdown';
 import FontAwesomeV6Icon from '@code-dot-org/component-library/fontAwesomeV6Icon';
 import {Typography} from '@mui/material';
-import React, {useEffect, useState, useMemo} from 'react';
+import React, {useEffect, useState} from 'react';
 
 import {EVENTS} from '@cdo/apps/metrics/AnalyticsConstants.js';
 import {
@@ -18,81 +18,58 @@ import styles from './teacherHomepage.module.scss';
 
 interface CourseContentDropdownProps {
   section: Section;
-  demoType?: DemoType;
-  onNavigateToPath?: (path: string, eventName: string) => void;
+  disabled?: boolean;
 }
 
-// Interface for the unit lessons dropdown
-interface UnitLessonOptions {
+interface DemoSectionCourseContentDropdownProps {
+  section: Section;
+  demoType?: DemoType;
+  disabled?: boolean;
+  beforeNavigate: (path: string, eventName: string) => void;
+}
+
+interface CourseContentDropdownBaseProps {
+  section: Section;
+  disabled: boolean;
+  shouldShowLessonDropdown: boolean;
+  lessonSource: number | DemoType;
+  renderLessonOption: (lesson: UnitLessonOption) => React.ReactNode;
+  renderCourseAction: () => React.ReactNode;
+}
+
+interface UnitLessonOption {
   value: string;
   text: string;
 }
 
-/**
- * CourseContentDropdown component.
- * Used to render a dropdown for selecting a lesson to navigate to.
- * @param section - Section object containing the course display name.
- */
-export const CourseContentDropdown: React.FC<CourseContentDropdownProps> = ({
+const getLessonEventName = (lessonValue: string) =>
+  lessonValue.includes('/lessons/')
+    ? EVENTS.SECTION_CARD_JUMP_TO_LESSON_CLICKED
+    : EVENTS.SECTION_CARD_JUMP_TO_UNIT_OVERVIEW_CLICKED;
+
+const CourseContentDropdownBase: React.FC<CourseContentDropdownBaseProps> = ({
   section,
-  demoType,
-  onNavigateToPath,
+  disabled,
+  shouldShowLessonDropdown,
+  lessonSource,
+  renderLessonOption,
+  renderCourseAction,
 }) => {
-  const [lessonList, setLessonList] = useState<UnitLessonOptions[]>([]);
+  const [lessonList, setLessonList] = useState<UnitLessonOption[]>([]);
 
   useEffect(() => {
     const fetchLessonList = async () => {
-      const sectionIdOrDemoPreset = demoType || section.id;
-      HttpClient.fetchJson<UnitLessonOptions[]>(
-        `/sections/${sectionIdOrDemoPreset}/retrieve_lessons_for_dropdown`
+      HttpClient.fetchJson<UnitLessonOption[]>(
+        `/sections/${lessonSource}/retrieve_lessons_for_dropdown`
       )
         .then(response => setLessonList(response.value))
         .catch(error => console.error(error));
     };
 
-    if ((section.unitId || demoType) && lessonList.length === 0) {
+    if (shouldShowLessonDropdown && lessonList.length === 0) {
       fetchLessonList();
     }
-  }, [section, lessonList, demoType]);
-
-  const dropdownOptions = useMemo(
-    () =>
-      lessonList.map(lesson =>
-        onNavigateToPath ? (
-          <li key={lesson.value}>
-            <button
-              type="button"
-              className={styles.dropdownMenuItem}
-              onClick={() =>
-                onNavigateToPath(
-                  lesson.value,
-                  lesson.value.includes('/lessons/')
-                    ? EVENTS.SECTION_CARD_JUMP_TO_LESSON_CLICKED
-                    : EVENTS.SECTION_CARD_JUMP_TO_UNIT_OVERVIEW_CLICKED
-                )
-              }
-            >
-              <span>{lesson.text}</span>
-            </button>
-          </li>
-        ) : (
-          <LinkOption
-            key={lesson.value}
-            value={lesson.value}
-            label={lesson.text}
-            labelStyle={lesson.value.includes('/lessons/') ? 'i' : 'b'}
-            url={lesson.value}
-            eventName={
-              lesson.value.includes('/lessons/')
-                ? EVENTS.SECTION_CARD_JUMP_TO_LESSON_CLICKED
-                : EVENTS.SECTION_CARD_JUMP_TO_UNIT_OVERVIEW_CLICKED
-            }
-            eventOptions={{lesson: lesson.value}}
-          />
-        )
-      ),
-    [lessonList, onNavigateToPath]
-  );
+  }, [lessonList, lessonSource, shouldShowLessonDropdown]);
 
   return (
     <div className={styles.courseContentDropdownContainer}>
@@ -105,53 +82,110 @@ export const CourseContentDropdown: React.FC<CourseContentDropdownProps> = ({
         <b>{`${i18n.course()}: `}</b>
         {section.courseDisplayName}
       </Typography>
-      {section.unitId || demoType ? (
+      {shouldShowLessonDropdown ? (
         <CustomDropdown
           className={styles.courseContentDropdown}
           name="go-to-lesson"
           labelText={i18n.jumpTo()}
           labelType="thin"
-          disabled={lessonList.length === 0}
+          disabled={disabled || lessonList.length === 0}
           size="m"
         >
-          <ul>{dropdownOptions}</ul>
+          <ul>{lessonList.map(renderLessonOption)}</ul>
         </CustomDropdown>
-      ) : onNavigateToPath ? (
-        <button
-          type="button"
-          className={styles.demoActionButton}
-          onClick={() =>
-            onNavigateToPath(
-              `courses/${section.courseVersionName}`,
-              EVENTS.SECTION_CARD_GO_TO_COURSE_BUTTON_CLICKED
-            )
-          }
-        >
-          <div className={styles.taskButtonLeft}>
-            <FontAwesomeV6Icon
-              className={styles.taskButtonIcons}
-              iconName="desktop"
-              iconStyle="solid"
-            />
-            <Typography variant="body3" gutterBottom>
-              {i18n.goToCourse()}
-            </Typography>
-          </div>
-          <FontAwesomeV6Icon
-            className={styles.taskButtonArrow}
-            iconName="arrow-right"
-            iconStyle="solid"
-          />
-        </button>
       ) : (
-        <TaskButton
-          buttonText={i18n.goToCourse()}
-          icon="desktop"
-          sectionId={section.id}
-          sectionName={section.name}
-          path={`courses/${section.courseVersionName}`}
-        />
+        renderCourseAction()
       )}
     </div>
   );
 };
+
+export const CourseContentDropdown: React.FC<CourseContentDropdownProps> = ({
+  section,
+  disabled = false,
+}) => (
+  <CourseContentDropdownBase
+    section={section}
+    disabled={disabled}
+    shouldShowLessonDropdown={Boolean(section.unitId)}
+    lessonSource={section.id}
+    renderLessonOption={lesson => (
+      <LinkOption
+        key={lesson.value}
+        value={lesson.value}
+        label={lesson.text}
+        labelStyle={lesson.value.includes('/lessons/') ? 'i' : 'b'}
+        url={lesson.value}
+        eventName={getLessonEventName(lesson.value)}
+        eventOptions={{lesson: lesson.value}}
+      />
+    )}
+    renderCourseAction={() => (
+      <TaskButton
+        buttonText={i18n.goToCourse()}
+        icon="desktop"
+        sectionId={section.id}
+        sectionName={section.name}
+        path={`courses/${section.courseVersionName}`}
+      />
+    )}
+  />
+);
+
+export const DemoSectionCourseContentDropdown: React.FC<
+  DemoSectionCourseContentDropdownProps
+> = ({section, demoType, disabled = false, beforeNavigate}) => (
+  <CourseContentDropdownBase
+    section={section}
+    disabled={disabled}
+    shouldShowLessonDropdown={Boolean(section.unitId || demoType)}
+    lessonSource={demoType || section.id}
+    renderLessonOption={lesson => (
+      <li key={lesson.value}>
+        {/* Use a button here because demo flows perform work before
+            navigation. The menu item stays keyboard reachable and correctly
+            exposed as an action, while non-demo entries remain real links. */}
+        <button
+          type="button"
+          className={styles.dropdownMenuItem}
+          disabled={disabled}
+          aria-label={`Create demo section and go to '${lesson.text}'`}
+          onClick={() =>
+            beforeNavigate(lesson.value, getLessonEventName(lesson.value))
+          }
+        >
+          <span>{lesson.text}</span>
+        </button>
+      </li>
+    )}
+    renderCourseAction={() => (
+      <button
+        type="button"
+        className={styles.demoActionButton}
+        disabled={disabled}
+        onClick={() =>
+          beforeNavigate(
+            `courses/${section.courseVersionName}`,
+            EVENTS.SECTION_CARD_GO_TO_COURSE_BUTTON_CLICKED
+          )
+        }
+      >
+        <div className={styles.taskButtonLeft}>
+          <FontAwesomeV6Icon
+            className={styles.taskButtonIcons}
+            iconName="desktop"
+            iconStyle="solid"
+          />
+          <Typography variant="body3" gutterBottom>
+            {i18n.goToCourse()}
+          </Typography>
+        </div>
+        <FontAwesomeV6Icon
+          className={styles.taskButtonArrow}
+          iconName="arrow-right"
+          iconStyle="solid"
+        />
+      </button>
+    )}
+  />
+);

--- a/apps/src/templates/studioHomepages/teacherHomepageV2/DemoSectionCard.tsx
+++ b/apps/src/templates/studioHomepages/teacherHomepageV2/DemoSectionCard.tsx
@@ -22,7 +22,7 @@ import {
 import {useAppDispatch} from '@cdo/apps/util/reduxHooks';
 import i18n from '@cdo/locale';
 
-import {CourseContentDropdown} from './CourseContentDropdown';
+import {DemoSectionCourseContentDropdown} from './DemoSectionCourseContentDropdown';
 import SectionAvatar from './sectionAvatars/SectionAvatar';
 
 import joinLinkStyles from './JoinLink/joinLinkCopyButton.module.scss';
@@ -130,6 +130,9 @@ const DemoSectionCard: React.FC<DemoSectionCardProps> = ({
 
     try {
       const section = await dispatch(createDemoSection(demoType));
+      if (!section) {
+        return;
+      }
       const nextPath = path.includes(':sectionId')
         ? generatePath(path, {sectionId: section.id.toString()})
         : path.startsWith('/')
@@ -145,7 +148,7 @@ const DemoSectionCard: React.FC<DemoSectionCardProps> = ({
       if (error instanceof DemoSectionCreationError) {
         onNotice({
           text: error.message,
-          type: error.code === 'conflict' ? 'warning' : 'danger',
+          type: error.errorType === 'conflict' ? 'warning' : 'danger',
         });
       } else {
         onNotice({
@@ -224,11 +227,11 @@ const DemoSectionCard: React.FC<DemoSectionCardProps> = ({
       </div>
       <div className={styles.sectionCardBody}>
         <div className={styles.sectionCardBodyLeft}>
-          <CourseContentDropdown
+          <DemoSectionCourseContentDropdown
             section={demoSection}
             demoType={demoType}
             disabled={!!pendingPath}
-            onNavigateToPath={(path, eventName) =>
+            beforeNavigate={(path: string, eventName: string) =>
               handleActionClick(path, eventName, path)
             }
           />

--- a/apps/src/templates/studioHomepages/teacherHomepageV2/DemoSectionCard.tsx
+++ b/apps/src/templates/studioHomepages/teacherHomepageV2/DemoSectionCard.tsx
@@ -1,0 +1,276 @@
+import FontAwesomeV6Icon from '@code-dot-org/component-library/fontAwesomeV6Icon';
+import {IconButton as MuiIconButton, Typography} from '@mui/material';
+import React from 'react';
+import {generatePath, useNavigate} from 'react-router-dom';
+
+import {EVENTS} from '@cdo/apps/metrics/AnalyticsConstants.js';
+import analyticsReporter from '@cdo/apps/metrics/AnalyticsReporter';
+import DemoStudentChip from '@cdo/apps/templates/DemoStudentChip';
+import {
+  createDemoSection,
+  DemoSectionCreationError,
+} from '@cdo/apps/templates/teacherDashboard/teacherSectionsRedux';
+import {
+  DemoPresetView,
+  DemoType,
+  Section,
+} from '@cdo/apps/templates/teacherDashboard/types/teacherSectionTypes';
+import {
+  TEACHER_NAVIGATION_PATHS,
+  TEACHER_NAVIGATION_SECTIONS_URL,
+} from '@cdo/apps/templates/teacherNavigation/TeacherNavigationPaths';
+import {useAppDispatch} from '@cdo/apps/util/reduxHooks';
+import i18n from '@cdo/locale';
+
+import {CourseContentDropdown} from './CourseContentDropdown';
+import SectionAvatar from './sectionAvatars/SectionAvatar';
+
+import joinLinkStyles from './JoinLink/joinLinkCopyButton.module.scss';
+import styles from './teacherHomepage.module.scss';
+
+type Notice = {
+  text: string;
+  type: 'warning' | 'danger';
+};
+
+interface DemoSectionCardProps {
+  preset: DemoPresetView;
+  demoType: DemoType;
+  onNotice: (notice: Notice | null) => void;
+}
+
+interface DemoAction {
+  id: string;
+  buttonText: string;
+  icon: string;
+  path: string;
+  eventName: string;
+}
+
+const buildPrimaryActions = (preset: DemoPresetView): DemoAction[] => {
+  const actions: DemoAction[] = [];
+
+  if (preset.unitGroup || preset.unit) {
+    actions.push({
+      id: 'progress',
+      buttonText: i18n.viewProgressButton(),
+      icon: 'chart-line',
+      path: TEACHER_NAVIGATION_PATHS.progress,
+      eventName: EVENTS.SECTION_CARD_VIEW_PROGRESS_CLICKED,
+    });
+  }
+
+  if (preset.unit) {
+    actions.push({
+      id: 'materials',
+      buttonText: i18n.viewLessonMaterialsButton(),
+      icon: 'folder-open',
+      path: TEACHER_NAVIGATION_PATHS.lessonMaterials,
+      eventName: EVENTS.SECTION_CARD_VIEW_LESSON_MATERIALS_CLICKED,
+    });
+  }
+
+  return actions;
+};
+
+const DemoSectionCard: React.FC<DemoSectionCardProps> = ({
+  preset,
+  demoType,
+  onNotice,
+}) => {
+  const dispatch = useAppDispatch();
+  const navigate = useNavigate();
+  const [pendingPath, setPendingPath] = React.useState<string | null>(null);
+  const primaryActions = React.useMemo(
+    () => buildPrimaryActions(preset),
+    [preset]
+  );
+  const demoSection = React.useMemo<Section>(() => {
+    const courseDisplayName: string | null =
+      preset.unitGroup?.displayName ?? preset.unit?.displayName ?? null;
+
+    return {
+      id: 0,
+      name: preset.sectionName,
+      code: 'DEMO-123',
+      hidden: false,
+      courseDisplayName,
+      courseVersionName: preset.unitGroup?.name,
+      unitId: preset.unit ? -1 : null,
+      unitName: preset.unit?.name || null,
+      unitPosition: null,
+      studentCount: 3,
+      participantType: preset.participantType,
+      loginType: preset.loginType as Section['loginType'],
+      grades: [],
+      aiTutorEnabled: false,
+      lessonExtras: false,
+      pairingAllowed: true,
+      providerManaged: false,
+      restrictSection: false,
+      sharingDisabled: false,
+      ttsAutoplayEnabled: false,
+      avatar_color: preset.avatarColor,
+      avatar_emoji: preset.avatarEmoji,
+    };
+  }, [preset]);
+
+  const handleActionClick = async (
+    path: string,
+    eventName: string,
+    pendingKey?: string
+  ) => {
+    if (pendingPath) {
+      return;
+    }
+
+    setPendingPath(pendingKey || path);
+    onNotice(null);
+    analyticsReporter.sendEvent(eventName, {});
+
+    try {
+      const section = await dispatch(createDemoSection(demoType));
+      const nextPath = path.includes(':sectionId')
+        ? generatePath(path, {sectionId: section.id.toString()})
+        : path.startsWith('/')
+        ? path
+        : generatePath(
+            `${TEACHER_NAVIGATION_SECTIONS_URL}/:sectionId/${path}`,
+            {
+              sectionId: section.id.toString(),
+            }
+          );
+      navigate(nextPath);
+    } catch (error) {
+      if (error instanceof DemoSectionCreationError) {
+        onNotice({
+          text: error.message,
+          type: error.code === 'conflict' ? 'warning' : 'danger',
+        });
+      } else {
+        onNotice({
+          text: "Couldn't create your practice section.",
+          type: 'danger',
+        });
+      }
+    } finally {
+      setPendingPath(null);
+    }
+  };
+
+  return (
+    <li
+      id="ui-test-demo-section-card"
+      className={styles.sectionCardWrapper}
+      aria-labelledby="demo-section-card-title"
+    >
+      <div className={styles.sectionCardHeader}>
+        <div className={styles.sectionCardHeaderLeft}>
+          <MuiIconButton
+            variant="text"
+            color="tertiary"
+            size="small"
+            onClick={() => {}}
+            aria-label={i18n.dragSection()}
+            type="button"
+            disabled={true}
+          >
+            <FontAwesomeV6Icon iconName="grip-vertical" />
+          </MuiIconButton>
+          <SectionAvatar
+            color={preset.avatarColor}
+            emoji={preset.avatarEmoji}
+            size={'s'}
+          />
+          <div className={styles.sectionCardHeaderText}>
+            <div className={styles.demoSectionTitleRow}>
+              <Typography
+                id="demo-section-card-title"
+                variant="h5"
+                gutterBottom
+              >
+                {preset.sectionName}
+              </Typography>
+              <DemoStudentChip />
+            </div>
+            <div
+              className={joinLinkStyles.sectionCodeBox}
+              data-for="section-code"
+              data-tip
+            >
+              <span className={joinLinkStyles.sectionCodeText}>
+                <Typography variant="overline1" gutterBottom>
+                  <span>{i18n.sectionCodeWithColon()}</span>{' '}
+                  <span className={joinLinkStyles.sectionCodeTextHidden}>
+                    DEMO-123
+                  </span>
+                </Typography>
+              </span>
+            </div>
+          </div>
+        </div>
+        <div className={styles.sectionCardHeaderRight}>
+          <MuiIconButton
+            variant="text"
+            color="tertiary"
+            size="small"
+            className={styles.dropdownButton}
+            aria-label={i18n.sectionOptionsDropdown()}
+            disabled={true}
+          >
+            <FontAwesomeV6Icon iconName="ellipsis-vertical" iconStyle="solid" />
+          </MuiIconButton>
+        </div>
+      </div>
+      <div className={styles.sectionCardBody}>
+        <div className={styles.sectionCardBodyLeft}>
+          <CourseContentDropdown
+            section={demoSection}
+            demoType={demoType}
+            disabled={!!pendingPath}
+            onNavigateToPath={(path, eventName) =>
+              handleActionClick(path, eventName, path)
+            }
+          />
+        </div>
+        <div className={styles.sectionCardBodyRight}>
+          {primaryActions.map(action => {
+            const isPending = pendingPath === action.id;
+            return (
+              <button
+                id={`ui-test-demo-section-action-${action.id}`}
+                key={action.id}
+                type="button"
+                className={styles.demoActionButton}
+                disabled={!!pendingPath}
+                onClick={() =>
+                  handleActionClick(action.path, action.eventName, action.id)
+                }
+              >
+                <div className={styles.taskButtonLeft}>
+                  <FontAwesomeV6Icon
+                    className={styles.taskButtonIcons}
+                    iconName={action.icon}
+                    iconStyle={'solid'}
+                  />
+                  <Typography variant="body3" gutterBottom>
+                    {isPending
+                      ? 'Creating practice section...'
+                      : action.buttonText}
+                  </Typography>
+                </div>
+                <FontAwesomeV6Icon
+                  className={styles.taskButtonArrow}
+                  iconName={'arrow-right'}
+                  iconStyle={'solid'}
+                />
+              </button>
+            );
+          })}
+        </div>
+      </div>
+    </li>
+  );
+};
+
+export default DemoSectionCard;

--- a/apps/src/templates/studioHomepages/teacherHomepageV2/DemoSectionCourseContentDropdown.tsx
+++ b/apps/src/templates/studioHomepages/teacherHomepageV2/DemoSectionCourseContentDropdown.tsx
@@ -1,0 +1,82 @@
+import FontAwesomeV6Icon from '@code-dot-org/component-library/fontAwesomeV6Icon';
+import {Typography} from '@mui/material';
+import React from 'react';
+
+import {EVENTS} from '@cdo/apps/metrics/AnalyticsConstants.js';
+import {
+  DemoType,
+  Section,
+} from '@cdo/apps/templates/teacherDashboard/types/teacherSectionTypes';
+import i18n from '@cdo/locale';
+
+import {
+  CourseContentDropdownBase,
+  getLessonEventName,
+} from './CourseContentDropdown';
+
+import styles from './teacherHomepage.module.scss';
+
+interface DemoSectionCourseContentDropdownProps {
+  section: Section;
+  demoType?: DemoType;
+  disabled?: boolean;
+  beforeNavigate: (path: string, eventName: string) => void;
+}
+
+export const DemoSectionCourseContentDropdown: React.FC<
+  DemoSectionCourseContentDropdownProps
+> = ({section, demoType, disabled = false, beforeNavigate}) => (
+  <CourseContentDropdownBase
+    section={section}
+    disabled={disabled}
+    shouldShowLessonDropdown={Boolean(section.unitId || demoType)}
+    lessonSource={demoType || section.id}
+    renderLessonOption={lesson => (
+      <li key={lesson.value}>
+        {/* Use a button here because demo flows perform work before
+            navigation. The menu item stays keyboard reachable and correctly
+            exposed as an action, while non-demo entries remain real links. */}
+        <button
+          type="button"
+          className={styles.dropdownMenuItem}
+          disabled={disabled}
+          aria-label={`Create demo section and go to '${lesson.text}'`}
+          onClick={() =>
+            beforeNavigate(lesson.value, getLessonEventName(lesson.value))
+          }
+        >
+          <span>{lesson.text}</span>
+        </button>
+      </li>
+    )}
+    renderCourseAction={() => (
+      <button
+        type="button"
+        className={styles.demoActionButton}
+        disabled={disabled}
+        onClick={() =>
+          beforeNavigate(
+            `courses/${section.courseVersionName}`,
+            EVENTS.SECTION_CARD_GO_TO_COURSE_BUTTON_CLICKED
+          )
+        }
+      >
+        <div className={styles.taskButtonLeft}>
+          <FontAwesomeV6Icon
+            className={styles.taskButtonIcons}
+            iconName="desktop"
+            iconStyle="solid"
+          />
+          <Typography variant="body3" gutterBottom>
+            {i18n.goToCourse()}
+          </Typography>
+        </div>
+        <FontAwesomeV6Icon
+          className={styles.taskButtonArrow}
+          iconName="arrow-right"
+          iconStyle="solid"
+        />
+      </button>
+    )}
+  />
+);

--- a/apps/src/templates/studioHomepages/teacherHomepageV2/SectionList.tsx
+++ b/apps/src/templates/studioHomepages/teacherHomepageV2/SectionList.tsx
@@ -160,34 +160,42 @@ export const SectionList: React.FC<SectionListProps> = ({
     ? hiddenSectionIds
     : sortableSectionIds;
 
+  const renderSectionList = (sectionIds: number[]) => (
+    <ol id="ui-test-section-list" className={styles.sectionList}>
+      {sectionIds.map(id =>
+        sections[id] ? (
+          <SectionCard
+            id={id}
+            key={id}
+            section={sections[id]}
+            onDeleteClickCallback={onDeleteClickCallback}
+            studioUrlPrefix={studioUrlPrefix}
+          />
+        ) : null
+      )}
+    </ol>
+  );
+
   return (
     <div>
       {sectionsAreLoaded ? (
-        <DndContext
-          sensors={sensors}
-          collisionDetection={closestCenter}
-          onDragEnd={handleDragEnd}
-          modifiers={[restrictToVerticalAxis, restrictToParentElement]}
-        >
-          <SortableContext
-            items={sortableSectionIds}
-            strategy={verticalListSortingStrategy}
+        showHiddenOnly ? (
+          renderSectionList(sectionIdsToShow)
+        ) : (
+          <DndContext
+            sensors={sensors}
+            collisionDetection={closestCenter}
+            onDragEnd={handleDragEnd}
+            modifiers={[restrictToVerticalAxis, restrictToParentElement]}
           >
-            <ol id="ui-test-section-list" className={styles.sectionList}>
-              {sectionIdsToShow.map(id =>
-                sections[id] ? (
-                  <SectionCard
-                    id={id}
-                    key={id}
-                    section={sections[id]}
-                    onDeleteClickCallback={onDeleteClickCallback}
-                    studioUrlPrefix={studioUrlPrefix}
-                  />
-                ) : null
-              )}
-            </ol>
-          </SortableContext>
-        </DndContext>
+            <SortableContext
+              items={sortableSectionIds}
+              strategy={verticalListSortingStrategy}
+            >
+              {renderSectionList(sectionIdsToShow)}
+            </SortableContext>
+          </DndContext>
+        )
       ) : (
         <Spinner size="large" />
       )}

--- a/apps/src/templates/studioHomepages/teacherHomepageV2/pickDemoType.ts
+++ b/apps/src/templates/studioHomepages/teacherHomepageV2/pickDemoType.ts
@@ -1,0 +1,21 @@
+import {DemoType} from '../../teacherDashboard/types/teacherSectionTypes';
+
+export const pickDemoType = (
+  gradesTeaching: string[] | null | undefined
+): DemoType => {
+  const grades = new Set((gradesTeaching || []).map(String));
+
+  if (['9', '10', '11', '12'].some(grade => grades.has(grade))) {
+    return 'high';
+  }
+
+  if (['6', '7', '8'].some(grade => grades.has(grade))) {
+    return 'middle';
+  }
+
+  if (['K', '1', '2', '3', '4', '5'].some(grade => grades.has(grade))) {
+    return 'elementary';
+  }
+
+  return 'high';
+};

--- a/apps/src/templates/studioHomepages/teacherHomepageV2/teacherHomepage.module.scss
+++ b/apps/src/templates/studioHomepages/teacherHomepageV2/teacherHomepage.module.scss
@@ -111,6 +111,12 @@
   }
 }
 
+.demoSectionTitleRow {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
 .sectionCardHeaderRight {
   display: flex;
   margin-inline-start: 6px;
@@ -157,6 +163,17 @@
     line-height: 125%;
     width: 1.5rem;
     text-align: center;
+  }
+
+  span {
+    @include typography.body-two;
+    color: inherit;
+    margin-bottom: 0;
+  }
+
+  &:disabled {
+    opacity: 0.7;
+    cursor: wait;
   }
 }
 
@@ -210,7 +227,7 @@
 }
 
 // Task Button
-.taskButtons {
+%task-buttons-base {
   border: 1px solid var(--borders-neutral-strong);
   display: flex;
   flex-direction: row;
@@ -222,6 +239,22 @@
   justify-content: space-between;
   margin: 0;
   border-radius: 4px;
+}
+
+.taskButtons {
+  @extend %task-buttons-base;
+}
+
+.demoActionButton {
+  @extend %task-buttons-base;
+  width: 100%;
+  cursor: pointer;
+  text-align: start;
+
+  &:disabled {
+    cursor: wait;
+    opacity: 0.7;
+  }
 }
 
 .taskButtonLeft {

--- a/apps/src/templates/studioHomepages/teacherHomepageV2/teacherHomepage.module.scss
+++ b/apps/src/templates/studioHomepages/teacherHomepageV2/teacherHomepage.module.scss
@@ -1,3 +1,5 @@
+@use '@code-dot-org/component-library-styles/typography.module.scss' as
+  typography;
 @import 'https://fonts.googleapis.com/css2?family=Noto+Color+Emoji&display=swap';
 
 // TeacherHomepage

--- a/apps/src/templates/teacherDashboard/teacherSectionsRedux.ts
+++ b/apps/src/templates/teacherDashboard/teacherSectionsRedux.ts
@@ -16,7 +16,7 @@ import {EVENTS} from '@cdo/apps/metrics/AnalyticsConstants';
 import analyticsReporter from '@cdo/apps/metrics/AnalyticsReporter';
 import {RootState} from '@cdo/apps/types/redux';
 import experiments from '@cdo/apps/util/experiments';
-import HttpClient from '@cdo/apps/util/HttpClient';
+import HttpClient, {NetworkError} from '@cdo/apps/util/HttpClient';
 import {
   PlGradeValue,
   SectionLoginType,
@@ -37,11 +37,14 @@ import {
 import {
   Classroom,
   CourseOffering,
+  DemoPresetView,
+  DemoType,
   LtiSectionSyncResult,
   OAuthSectionTypeName,
   Section,
   SectionInstructor,
   SectionMap,
+  ServerDemoPresetView,
   ServerOAuthSectionTypeName,
   ServerSection,
   ServerStudent,
@@ -66,6 +69,42 @@ interface CourseOfferingSet {
   [courseOfferingId: number]: CourseOffering;
 }
 
+type DemoPresetMap = Partial<Record<DemoType, DemoPresetView>>;
+type DemoPresetsResponse = Partial<
+  Record<DemoType, ServerDemoPresetView | null>
+>;
+
+const demoPresetFromServerDemoPreset = (
+  demoPreset: ServerDemoPresetView
+): DemoPresetView => ({
+  demoType: demoPreset.demo_type,
+  sectionName: demoPreset.section_name,
+  avatarColor: demoPreset.avatar_color,
+  avatarEmoji: demoPreset.avatar_emoji,
+  loginType: demoPreset.login_type,
+  participantType: demoPreset.participant_type,
+  unit: demoPreset.unit
+    ? {
+        name: demoPreset.unit.name,
+        displayName: demoPreset.unit.display_name,
+      }
+    : null,
+  unitGroup: demoPreset.unit_group
+    ? {
+        name: demoPreset.unit_group.name,
+        displayName: demoPreset.unit_group.display_name,
+      }
+    : null,
+});
+
+export class DemoSectionCreationError extends Error {
+  constructor(public errorType: 'conflict' | 'generic', message: string) {
+    super(message);
+    this.name = 'DemoSectionCreationError';
+    Object.setPrototypeOf(this, DemoSectionCreationError.prototype);
+  }
+}
+
 export interface TeacherSectionState {
   nextTempId: number;
   studioUrl: string;
@@ -85,6 +124,9 @@ export interface TeacherSectionState {
   // assignmentCourseOfferingShape PropType.
   courseOfferings: CourseOfferingSet;
   courseOfferingsAreLoaded: boolean;
+  demoPresets: DemoPresetMap;
+  demoPresetsAreLoaded: boolean;
+  demoSectionCreationInProgress: boolean;
   // The participant types the user can create sections for
   availableParticipantTypes: string[];
   // Mapping from sectionId to section object
@@ -148,6 +190,9 @@ const initialState: TeacherSectionState = {
   // assignmentCourseOfferingShape PropType.
   courseOfferings: [],
   courseOfferingsAreLoaded: false,
+  demoPresets: {},
+  demoPresetsAreLoaded: false,
+  demoSectionCreationInProgress: false,
   // The participant types the user can create sections for
   availableParticipantTypes: [],
   // Mapping from sectionId to section object
@@ -405,6 +450,12 @@ const sectionSlice = createSlice({
     },
     setDemoPresetsLoaded(state, action: PayloadAction<boolean>) {
       state.demoPresetsAreLoaded = action.payload;
+    },
+    startDemoSectionCreation(state) {
+      state.demoSectionCreationInProgress = true;
+    },
+    finishDemoSectionCreation(state) {
+      state.demoSectionCreationInProgress = false;
     },
     setSectionCodeReviewExpiresAt: {
       reducer(

--- a/apps/src/templates/teacherDashboard/teacherSectionsRedux.ts
+++ b/apps/src/templates/teacherDashboard/teacherSectionsRedux.ts
@@ -400,6 +400,12 @@ const sectionSlice = createSlice({
     setAvailableParticipantTypes(state, action: PayloadAction<string[]>) {
       state.availableParticipantTypes = action.payload;
     },
+    setDemoPresets(state, action: PayloadAction<DemoPresetMap>) {
+      state.demoPresets = action.payload;
+    },
+    setDemoPresetsLoaded(state, action: PayloadAction<boolean>) {
+      state.demoPresetsAreLoaded = action.payload;
+    },
     setSectionCodeReviewExpiresAt: {
       reducer(
         state,
@@ -872,6 +878,91 @@ export const asyncLoadTeacherHomepageSectionData =
       });
   };
 
+export const fetchDemoPresets =
+  () =>
+  async (
+    dispatch: ThunkDispatch<RootState, undefined, AnyAction>,
+    getState: () => RootState
+  ): Promise<DemoPresetMap> => {
+    const {
+      teacherSections: {demoPresets, demoPresetsAreLoaded},
+    } = getState();
+
+    if (demoPresetsAreLoaded) {
+      return demoPresets;
+    }
+
+    try {
+      const response = await HttpClient.fetchJson<DemoPresetsResponse>(
+        '/api/v1/sections/demo/presets'
+      );
+      const demoPresets = Object.entries(response.value).reduce<DemoPresetMap>(
+        (presets, [demoType, demoPreset]) => {
+          if (demoPreset) {
+            presets[demoType as DemoType] =
+              demoPresetFromServerDemoPreset(demoPreset);
+          }
+          return presets;
+        },
+        {}
+      );
+      dispatch(setDemoPresets(demoPresets));
+      dispatch(setDemoPresetsLoaded(true));
+      return demoPresets;
+    } catch (error) {
+      console.error('Error fetching demo section presets:', error);
+      return {};
+    }
+  };
+
+export const createDemoSection =
+  (demoType: DemoType) =>
+  async (
+    dispatch: ThunkDispatch<RootState, undefined, AnyAction>,
+    getState: () => RootState
+  ): Promise<Section | void> => {
+    if (getState().teacherSections.demoSectionCreationInProgress) {
+      return;
+    }
+
+    dispatch(startDemoSectionCreation());
+
+    try {
+      const response = await HttpClient.post(
+        `/api/v1/sections/demo/${demoType}`,
+        undefined,
+        true
+      );
+      const serverSection = (await response.json()) as ServerSection;
+      dispatch(setSections([serverSection], false));
+      return sectionFromServerSection(serverSection);
+    } catch (error) {
+      if (error instanceof NetworkError) {
+        if (error.response?.status === 409) {
+          throw new DemoSectionCreationError(
+            'conflict',
+            'You already have a practice section.'
+          );
+        }
+
+        if (error.response?.status === 403) {
+          console.error('Unauthorized to create demo section:', error);
+          throw new DemoSectionCreationError(
+            'generic',
+            "Couldn't create your practice section."
+          );
+        }
+      }
+
+      console.error('Error creating demo section:', error);
+      throw new DemoSectionCreationError(
+        'generic',
+        "Couldn't create your practice section."
+      );
+    } finally {
+      dispatch(finishDemoSectionCreation());
+    }
+  };
 export const asyncLoadSectionData =
   (id: number | void, destructive: boolean | void): SectionThunkAction =>
   dispatch => {
@@ -1198,6 +1289,10 @@ export const {
   setCoteacherInvite,
   setCoteacherInviteForPl,
   setCourseOfferings,
+  setDemoPresets,
+  setDemoPresetsLoaded,
+  startDemoSectionCreation,
+  finishDemoSectionCreation,
   setPageType,
   setRosterProvider,
   setRosterProviderName,

--- a/apps/src/templates/teacherDashboard/types/teacherSectionTypes.ts
+++ b/apps/src/templates/teacherDashboard/types/teacherSectionTypes.ts
@@ -54,6 +54,24 @@ export interface Section {
   aiChatAccessLevel?: AiChatAccessLevel;
 }
 
+export type DemoType = 'elementary' | 'middle' | 'high';
+
+export interface DemoPresetCourseRef {
+  name: string;
+  displayName: string;
+}
+
+export interface DemoPresetView {
+  demoType: DemoType;
+  sectionName: string;
+  avatarColor: number;
+  avatarEmoji: number;
+  loginType: string;
+  participantType: string;
+  unit: DemoPresetCourseRef | null;
+  unitGroup: DemoPresetCourseRef | null;
+}
+
 type Course = {
   courseOfferingId: number | null;
   versionId: number | null;
@@ -141,6 +159,22 @@ export interface ServerStudent {
   sectionId: number;
   sharing_disabled: boolean;
   user_type: keyof typeof UserTypes;
+}
+
+export interface ServerDemoPresetCourseRef {
+  name: string;
+  display_name: string;
+}
+
+export interface ServerDemoPresetView {
+  demo_type: DemoType;
+  section_name: string;
+  avatar_color: number;
+  avatar_emoji: number;
+  login_type: string;
+  participant_type: string;
+  unit: ServerDemoPresetCourseRef | null;
+  unit_group: ServerDemoPresetCourseRef | null;
 }
 
 //TODO: better types here

--- a/apps/src/templates/teacherDashboard/types/teacherSectionTypes.ts
+++ b/apps/src/templates/teacherDashboard/types/teacherSectionTypes.ts
@@ -56,7 +56,12 @@ export interface Section {
 
 export type DemoType = 'elementary' | 'middle' | 'high';
 
-export interface DemoPresetObject {
+export interface DemoPresetUnit {
+  name: string;
+  displayName: string;
+}
+
+export interface DemoPresetCourse {
   name: string;
   displayName: string;
 }
@@ -68,8 +73,8 @@ export interface DemoPresetView {
   avatarEmoji: number;
   loginType: string;
   participantType: string;
-  unit: DemoPresetObject | null;
-  unitGroup: DemoPresetObject | null;
+  unit: DemoPresetUnit | null;
+  unitGroup: DemoPresetCourse | null;
 }
 
 type Course = {
@@ -161,7 +166,12 @@ export interface ServerStudent {
   user_type: keyof typeof UserTypes;
 }
 
-export interface ServerDemoPresetObject {
+export interface ServerDemoPresetUnit {
+  name: string;
+  display_name: string;
+}
+
+export interface ServerDemoPresetCourse {
   name: string;
   display_name: string;
 }
@@ -173,8 +183,8 @@ export interface ServerDemoPresetView {
   avatar_emoji: number;
   login_type: string;
   participant_type: string;
-  unit: ServerDemoPresetObject | null;
-  unit_group: ServerDemoPresetObject | null;
+  unit: ServerDemoPresetUnit | null;
+  unit_group: ServerDemoPresetCourse | null;
 }
 
 //TODO: better types here

--- a/apps/src/templates/teacherDashboard/types/teacherSectionTypes.ts
+++ b/apps/src/templates/teacherDashboard/types/teacherSectionTypes.ts
@@ -56,7 +56,7 @@ export interface Section {
 
 export type DemoType = 'elementary' | 'middle' | 'high';
 
-export interface DemoPresetCourseRef {
+export interface DemoPresetObject {
   name: string;
   displayName: string;
 }
@@ -68,8 +68,8 @@ export interface DemoPresetView {
   avatarEmoji: number;
   loginType: string;
   participantType: string;
-  unit: DemoPresetCourseRef | null;
-  unitGroup: DemoPresetCourseRef | null;
+  unit: DemoPresetObject | null;
+  unitGroup: DemoPresetObject | null;
 }
 
 type Course = {
@@ -161,7 +161,7 @@ export interface ServerStudent {
   user_type: keyof typeof UserTypes;
 }
 
-export interface ServerDemoPresetCourseRef {
+export interface ServerDemoPresetObject {
   name: string;
   display_name: string;
 }
@@ -173,8 +173,8 @@ export interface ServerDemoPresetView {
   avatar_emoji: number;
   login_type: string;
   participant_type: string;
-  unit: ServerDemoPresetCourseRef | null;
-  unit_group: ServerDemoPresetCourseRef | null;
+  unit: ServerDemoPresetObject | null;
+  unit_group: ServerDemoPresetObject | null;
 }
 
 //TODO: better types here

--- a/apps/src/templates/teacherDashboard/types/teacherSectionTypes.ts
+++ b/apps/src/templates/teacherDashboard/types/teacherSectionTypes.ts
@@ -71,8 +71,8 @@ export interface DemoPresetView {
   sectionName: string;
   avatarColor: number;
   avatarEmoji: number;
-  loginType: string;
-  participantType: string;
+  loginType: NonNullable<Section['loginType']>;
+  participantType: NonNullable<Section['participantType']>;
   unit: DemoPresetUnit | null;
   unitGroup: DemoPresetCourse | null;
 }
@@ -181,8 +181,8 @@ export interface ServerDemoPresetView {
   section_name: string;
   avatar_color: number;
   avatar_emoji: number;
-  login_type: string;
-  participant_type: string;
+  login_type: NonNullable<Section['loginType']>;
+  participant_type: NonNullable<Section['participantType']>;
   unit: ServerDemoPresetUnit | null;
   unit_group: ServerDemoPresetCourse | null;
 }

--- a/apps/src/templates/teacherNavigation/TeacherNavigationRouter.tsx
+++ b/apps/src/templates/teacherNavigation/TeacherNavigationRouter.tsx
@@ -298,7 +298,7 @@ const TeacherNavigationRouter: React.FC<TeacherNavigationRouterProps> = ({
                 <DashboardSectionSettings
                   redirectUrl={
                     sectionId
-                      ? '/teacher_dashboard' +
+                      ? TEACHER_NAVIGATION_BASE_URL +
                         generatePath(
                           LABELED_TEACHER_NAVIGATION_PATHS.progress.absoluteUrl,
                           {sectionId: sectionId}

--- a/apps/src/templates/teacherNavigation/TeacherNavigationRouter.tsx
+++ b/apps/src/templates/teacherNavigation/TeacherNavigationRouter.tsx
@@ -297,11 +297,13 @@ const TeacherNavigationRouter: React.FC<TeacherNavigationRouterProps> = ({
               element={
                 <DashboardSectionSettings
                   redirectUrl={
-                    '/teacher_dashboard' +
-                    generatePath(
-                      LABELED_TEACHER_NAVIGATION_PATHS.progress.absoluteUrl,
-                      {sectionId: sectionId}
-                    )
+                    sectionId
+                      ? '/teacher_dashboard' +
+                        generatePath(
+                          LABELED_TEACHER_NAVIGATION_PATHS.progress.absoluteUrl,
+                          {sectionId: sectionId}
+                        )
+                      : `${TEACHER_NAVIGATION_BASE_URL}/${TEACHER_NAVIGATION_PATHS.home}`
                   }
                 />
               }

--- a/apps/test/unit/templates/studioHomepages/teacherHomepageV2/CourseContentDropdownTest.tsx
+++ b/apps/test/unit/templates/studioHomepages/teacherHomepageV2/CourseContentDropdownTest.tsx
@@ -13,6 +13,7 @@ import {EVENTS} from '@cdo/apps/metrics/AnalyticsConstants.js';
 import analyticsReporter from '@cdo/apps/metrics/AnalyticsReporter';
 import {getStore} from '@cdo/apps/redux';
 import {CourseContentDropdown} from '@cdo/apps/templates/studioHomepages/teacherHomepageV2/CourseContentDropdown';
+import {DemoSectionCourseContentDropdown} from '@cdo/apps/templates/studioHomepages/teacherHomepageV2/DemoSectionCourseContentDropdown';
 import {Section} from '@cdo/apps/templates/teacherDashboard/types/teacherSectionTypes';
 import {TEACHER_NAVIGATION_PATHS} from '@cdo/apps/templates/teacherNavigation/TeacherNavigationPaths';
 import HttpClient from '@cdo/apps/util/HttpClient';
@@ -198,7 +199,11 @@ describe('CourseContentDropdown', () => {
   it('uses the demo preset path when demoType is provided', async () => {
     render(
       <Provider store={store}>
-        <CourseContentDropdown section={nonUnitSection} demoType="high" />
+        <DemoSectionCourseContentDropdown
+          section={nonUnitSection}
+          demoType="high"
+          beforeNavigate={() => {}}
+        />
       </Provider>
     );
 

--- a/apps/test/unit/templates/studioHomepages/teacherHomepageV2/CourseContentDropdownTest.tsx
+++ b/apps/test/unit/templates/studioHomepages/teacherHomepageV2/CourseContentDropdownTest.tsx
@@ -171,7 +171,9 @@ describe('CourseContentDropdown', () => {
   it('renders Jump to lesson dropdown when a unit is assigned', async () => {
     renderComponent(unitSection);
     await act(async () => await new Promise(process.nextTick));
-    expect(fetchSpy).toHaveBeenCalled();
+    expect(fetchSpy).toHaveBeenCalledWith(
+      '/sections/11/retrieve_lessons_for_dropdown'
+    );
     const lesson = screen.getByText('4: Shapes and Parameters');
     fireEvent.click(lesson);
     expect(sendEventSpy).toHaveBeenCalledWith(
@@ -190,6 +192,20 @@ describe('CourseContentDropdown', () => {
       {
         lesson: '/teacher_dashboard/sections/11/courses/csd-2024/units/3',
       }
+    );
+  });
+
+  it('uses the demo preset path when demoType is provided', async () => {
+    render(
+      <Provider store={store}>
+        <CourseContentDropdown section={nonUnitSection} demoType="high" />
+      </Provider>
+    );
+
+    await act(async () => await new Promise(process.nextTick));
+
+    expect(fetchSpy).toHaveBeenCalledWith(
+      '/sections/high/retrieve_lessons_for_dropdown'
     );
   });
 });

--- a/apps/test/unit/templates/studioHomepages/teacherHomepageV2/pickDemoTypeTest.ts
+++ b/apps/test/unit/templates/studioHomepages/teacherHomepageV2/pickDemoTypeTest.ts
@@ -1,0 +1,21 @@
+import {pickDemoType} from '@cdo/apps/templates/studioHomepages/teacherHomepageV2/pickDemoType';
+
+describe('pickDemoType', () => {
+  it('prefers high school grades', () => {
+    expect(pickDemoType(['5', '8', '10'])).toBe('high');
+  });
+
+  it('falls back to middle school grades when no high school grades exist', () => {
+    expect(pickDemoType(['6', '8'])).toBe('middle');
+  });
+
+  it('returns elementary for elementary-only grades', () => {
+    expect(pickDemoType(['K', '3'])).toBe('elementary');
+  });
+
+  it('defaults to high for empty or missing grade data', () => {
+    expect(pickDemoType([])).toBe('high');
+    expect(pickDemoType(undefined)).toBe('high');
+    expect(pickDemoType(null)).toBe('high');
+  });
+});

--- a/apps/test/unit/templates/teacherDashboard/teacherSectionsReduxTest.js
+++ b/apps/test/unit/templates/teacherDashboard/teacherSectionsReduxTest.js
@@ -25,6 +25,13 @@ import reducer, {
   cancelEditingSection,
   finishEditingSection,
   asyncLoadSectionData,
+  setDemoPresets,
+  setDemoPresetsLoaded,
+  fetchDemoPresets,
+  createDemoSection,
+  DemoSectionCreationError,
+  startDemoSectionCreation,
+  finishDemoSectionCreation,
   beginImportRosterFlow,
   cancelImportRosterFlow,
   importOrUpdateRoster,
@@ -2061,6 +2068,180 @@ describe('teacherSectionsRedux', () => {
       jest.mock('@cdo/apps/metrics/firehose');
       store.dispatch(assignToSection(11, 2, 2, 3, null));
       expect(analyticsSpy).to.not.be.called;
+    });
+  });
+
+  describe('demo section thunks', () => {
+    let fetchSpy;
+    let postSpy;
+
+    beforeEach(() => {
+      fetchSpy = sinon.stub(HttpClient, 'fetchJson');
+      postSpy = sinon.stub(HttpClient, 'post');
+    });
+
+    afterEach(() => {
+      fetchSpy.restore();
+      postSpy.restore();
+    });
+
+    it('stores fetched demo presets', async () => {
+      fetchSpy.resolves({
+        response: new Response(),
+        value: {
+          high: {
+            demo_type: 'high',
+            section_name: 'High School Practice Section',
+            avatar_color: 8,
+            avatar_emoji: 5,
+            login_type: 'email',
+            participant_type: 'student',
+            unit: {
+              name: 'aif2-2025',
+              display_name: 'Artificial Intelligence Foundations',
+            },
+            unit_group: {
+              name: 'artificial-intelligence-foundations-2025',
+              display_name: 'Artificial Intelligence Foundations',
+            },
+          },
+        },
+      });
+
+      await store.dispatch(fetchDemoPresets());
+
+      assert.deepEqual(getState().teacherSections.demoPresets.high, {
+        demoType: 'high',
+        sectionName: 'High School Practice Section',
+        avatarColor: 8,
+        avatarEmoji: 5,
+        loginType: 'email',
+        participantType: 'student',
+        unit: {
+          name: 'aif2-2025',
+          displayName: 'Artificial Intelligence Foundations',
+        },
+        unitGroup: {
+          name: 'artificial-intelligence-foundations-2025',
+          displayName: 'Artificial Intelligence Foundations',
+        },
+      });
+    });
+
+    it('logs preset fetch failures and hides the card data', async () => {
+      const consoleErrorStub = sinon.stub(console, 'error');
+      try {
+        fetchSpy.rejects(new Error('presets failed'));
+
+        await store.dispatch(fetchDemoPresets());
+
+        assert.deepEqual(getState().teacherSections.demoPresets, {});
+        expect(getState().teacherSections.demoPresetsAreLoaded).to.be.false;
+        expect(consoleErrorStub).to.have.been.calledOnce;
+      } finally {
+        consoleErrorStub.restore();
+      }
+    });
+
+    it('returns cached demo presets after the first load', async () => {
+      store.dispatch(setDemoPresets({high: {demoType: 'high'}}));
+      store.dispatch(setDemoPresetsLoaded(true));
+
+      const demoPresets = await store.dispatch(fetchDemoPresets());
+
+      assert.deepEqual(demoPresets, {high: {demoType: 'high'}});
+      expect(fetchSpy).not.to.have.been.called;
+    });
+
+    it('creates a demo section from the create response', async () => {
+      const serverSection = sections[0];
+      store.dispatch(setDemoPresets({high: {demoType: 'high'}}));
+      postSpy.resolves(
+        new Response(JSON.stringify(serverSection), {
+          status: 200,
+          headers: {'Content-Type': 'application/json'},
+        })
+      );
+
+      const createdSection = await store.dispatch(createDemoSection('high'));
+
+      assert.equal(createdSection.id, serverSection.id);
+      assert.deepEqual(getState().teacherSections.sectionIds, [307]);
+      assert.deepEqual(getState().teacherSections.demoPresets, {
+        high: {demoType: 'high'},
+      });
+      expect(fetchSpy).not.to.have.been.called;
+      expect(getState().teacherSections.demoSectionCreationInProgress).to.be
+        .false;
+    });
+
+    it('returns early when demo section creation is already in progress', async () => {
+      store.dispatch(startDemoSectionCreation());
+
+      const createdSection = await store.dispatch(createDemoSection('high'));
+
+      expect(createdSection).to.be.undefined;
+      expect(postSpy).not.to.have.been.called;
+      expect(getState().teacherSections.demoSectionCreationInProgress).to.be
+        .true;
+    });
+
+    it('throws a typed conflict error without refetching sections', async () => {
+      postSpy.rejects(
+        new NetworkError(
+          '409 Conflict',
+          new Response('{}', {
+            status: 409,
+            headers: {'Content-Type': 'application/json'},
+          })
+        )
+      );
+      await expect(
+        store.dispatch(createDemoSection('high'))
+      ).to.be.rejectedWith(DemoSectionCreationError);
+      assert.deepEqual(getState().teacherSections.sectionIds, []);
+      expect(fetchSpy).not.to.have.been.called;
+      expect(getState().teacherSections.demoSectionCreationInProgress).to.be
+        .false;
+    });
+
+    it('keeps demo presets on forbidden demo creation attempts', async () => {
+      const consoleErrorStub = sinon.stub(console, 'error');
+      try {
+        store.dispatch(setDemoPresets({high: {demoType: 'high'}}));
+        postSpy.rejects(
+          new NetworkError(
+            '403 Forbidden',
+            new Response('{}', {
+              status: 403,
+              headers: {'Content-Type': 'application/json'},
+            })
+          )
+        );
+
+        await expect(
+          store.dispatch(createDemoSection('high'))
+        ).to.be.rejectedWith(DemoSectionCreationError);
+        assert.deepEqual(getState().teacherSections.demoPresets, {
+          high: {demoType: 'high'},
+        });
+        expect(consoleErrorStub).to.have.been.calledOnce;
+        expect(getState().teacherSections.demoSectionCreationInProgress).to.be
+          .false;
+      } finally {
+        consoleErrorStub.restore();
+      }
+    });
+
+    it('can clear the in-progress demo section state', () => {
+      store.dispatch(startDemoSectionCreation());
+      expect(getState().teacherSections.demoSectionCreationInProgress).to.be
+        .true;
+
+      store.dispatch(finishDemoSectionCreation());
+
+      expect(getState().teacherSections.demoSectionCreationInProgress).to.be
+        .false;
     });
   });
 });

--- a/apps/test/unit/templates/teacherDashboard/teacherSectionsReduxTest.js
+++ b/apps/test/unit/templates/teacherDashboard/teacherSectionsReduxTest.js
@@ -55,7 +55,7 @@ import {
   sortedSectionsList,
   sortSectionsList,
 } from '@cdo/apps/templates/teacherDashboard/teacherSectionsReduxSelectors';
-import HttpClient from '@cdo/apps/util/HttpClient';
+import HttpClient, {NetworkError} from '@cdo/apps/util/HttpClient';
 
 import {assert, expect} from '../../../util/reconfiguredChai'; // eslint-disable-line no-restricted-imports
 

--- a/dashboard/app/controllers/api/v1/sections_controller.rb
+++ b/dashboard/app/controllers/api/v1/sections_controller.rb
@@ -3,7 +3,7 @@ require 'metrics/events'
 class Api::V1::SectionsController < Api::V1::JSONApiController
   load_resource :section, find_by: :code, only: [:join, :leave]
   before_action :find_follower, only: :leave
-  load_and_authorize_resource except: [:join, :leave, :membership, :valid_course_offerings, :create, :create_demo, :update, :require_captcha, :assigned_essential_ai_dependency]
+  load_and_authorize_resource except: [:join, :leave, :membership, :valid_course_offerings, :create, :create_demo, :presets, :update, :require_captcha, :assigned_essential_ai_dependency]
   before_action :get_course_and_unit, only: [:create, :update]
 
   skip_before_action :verify_authenticity_token, only: [:update]

--- a/dashboard/app/controllers/api/v1/sections_controller.rb
+++ b/dashboard/app/controllers/api/v1/sections_controller.rb
@@ -152,6 +152,16 @@ class Api::V1::SectionsController < Api::V1::JSONApiController
     end
   end
 
+  # GET /api/v1/sections/demo/presets
+  def presets
+    authorize! :create, Section
+
+    preset_views = Policies::DemoSections.preset_views_for_all_types
+    return head :not_found if preset_views.empty?
+
+    render json: preset_views
+  end
+
   # PATCH /api/v1/sections/<id>
   # Allows you to update a section. Clears any assigned script_id in the process
   def update

--- a/dashboard/app/controllers/api/v1/users_controller.rb
+++ b/dashboard/app/controllers/api/v1/users_controller.rb
@@ -71,6 +71,7 @@ class Api::V1::UsersController < Api::V1::JSONApiController
         ai_differentiation_enabled: !current_user.ai_differentiation_toggled_off?,
         has_completed_ai_differentiation_welcome: current_user.has_completed_ai_differentiation_welcome?,
         educator_role: current_user.educator_role,
+        grades_teaching: current_user.grades_teaching || [],
         sharing_disabled: current_user.sharing_disabled,
         is_levelbuilder: current_user.levelbuilder?,
         ai_chat_access_level: current_user.ai_chat_access_level,

--- a/dashboard/app/controllers/sections_controller.rb
+++ b/dashboard/app/controllers/sections_controller.rb
@@ -64,11 +64,10 @@ class SectionsController < ApplicationController
   end
 
   def retrieve_lessons_for_dropdown
-    if params[:demo_type].present?
-      return head :forbidden unless current_user
+    preset = Policies::DemoSections.get_preset(params[:id])
 
-      preset = Policies::DemoSections.get_preset(params[:demo_type])
-      return head :bad_request unless preset
+    if preset
+      return head :forbidden unless current_user
 
       unit = Unit.get_from_cache(preset[:unit_name], raise_exceptions: false) if preset[:unit_name].present?
       unit_group = UnitGroup.get_from_cache(preset[:unit_group_name]) if preset[:unit_group_name].present?

--- a/dashboard/app/controllers/sections_controller.rb
+++ b/dashboard/app/controllers/sections_controller.rb
@@ -64,16 +64,34 @@ class SectionsController < ApplicationController
   end
 
   def retrieve_lessons_for_dropdown
-    section = Section.find(params[:id])
+    if params[:demo_type].present?
+      return head :forbidden unless current_user
+
+      preset = Policies::DemoSections.get_preset(params[:demo_type])
+      return head :bad_request unless preset
+
+      unit = Unit.get_from_cache(preset[:unit_name], raise_exceptions: false) if preset[:unit_name].present?
+      unit_group =
+        begin
+          UnitGroup.get_from_cache(preset[:unit_group_name]) if preset[:unit_group_name].present?
+        rescue ActiveRecord::RecordNotFound
+          nil
+        end
+      section_id = ':sectionId'
+    else
+      section = Section.find(params[:id])
+      unit = Unit.get_from_cache(section.script_id) if section.script_id
+      unit_group = UnitGroup.get_from_cache(section.course_id) if section.course_id
+      section_id = section.id
+    end
+
     lessons = []
-    if section.script_id
-      unit = Unit.get_from_cache(section.script_id)
-      unit_group = UnitGroup.get_from_cache(section.course_id)
+    if unit
       unit_group_unit = Queries::Courses.unit_group_unit(unit, unit_group)
       unit_path = if unit_group_unit && unit_group
-                    "/teacher_dashboard/sections/#{section.id}/courses/#{unit_group.name}/units/#{unit_group_unit.position}"
+                    "/teacher_dashboard/sections/#{section_id}/courses/#{unit_group.name}/units/#{unit_group_unit.position}"
                   else
-                    "/teacher_dashboard/sections/#{section.id}/courses"
+                    "/teacher_dashboard/sections/#{section_id}/courses"
                   end
       lessons << {text: unit.title_for_display(unit_group_unit: unit_group_unit).sub(" - ", ": "), value: unit_path}
       unit.lesson_groups.each do |lesson_group|

--- a/dashboard/app/controllers/sections_controller.rb
+++ b/dashboard/app/controllers/sections_controller.rb
@@ -71,12 +71,7 @@ class SectionsController < ApplicationController
       return head :bad_request unless preset
 
       unit = Unit.get_from_cache(preset[:unit_name], raise_exceptions: false) if preset[:unit_name].present?
-      unit_group =
-        begin
-          UnitGroup.get_from_cache(preset[:unit_group_name]) if preset[:unit_group_name].present?
-        rescue ActiveRecord::RecordNotFound
-          nil
-        end
+      unit_group = UnitGroup.get_from_cache(preset[:unit_group_name]) if preset[:unit_group_name].present?
       section_id = ':sectionId'
     else
       section = Section.find(params[:id])

--- a/dashboard/config/routes.rb
+++ b/dashboard/config/routes.rb
@@ -192,7 +192,6 @@ Dashboard::Application.routes.draw do
         get :retrieve_lessons_for_dropdown
       end
       collection do
-        get :retrieve_lessons_for_dropdown
         post 'section_instructors_verified'
         post 'archive_all'
       end

--- a/dashboard/config/routes.rb
+++ b/dashboard/config/routes.rb
@@ -192,6 +192,7 @@ Dashboard::Application.routes.draw do
         get :retrieve_lessons_for_dropdown
       end
       collection do
+        get :retrieve_lessons_for_dropdown
         post 'section_instructors_verified'
         post 'archive_all'
       end

--- a/dashboard/config/routes.rb
+++ b/dashboard/config/routes.rb
@@ -222,6 +222,7 @@ Dashboard::Application.routes.draw do
           get 'valid_course_offerings'
           get 'available_participant_types'
           get 'require_captcha'
+          get 'demo/presets', action: 'presets', as: 'presets'
           post 'demo/:demo_type', action: 'create_demo', as: 'create_demo'
           get 'assigned_essential_ai_dependency'
         end

--- a/dashboard/lib/policies/demo_sections.rb
+++ b/dashboard/lib/policies/demo_sections.rb
@@ -107,8 +107,6 @@ class Policies::DemoSections
     return nil if unit_group_name.blank?
 
     UnitGroup.get_from_cache(unit_group_name)
-  rescue ActiveRecord::RecordNotFound
-    nil
   end
 
   private_class_method :resolve_unit, :resolve_unit_group

--- a/dashboard/lib/policies/demo_sections.rb
+++ b/dashboard/lib/policies/demo_sections.rb
@@ -98,18 +98,18 @@ class Policies::DemoSections
   end
 
   def self.resolve_unit(unit_name)
-    return nil unless unit_name.present?
+    return nil if unit_name.blank?
 
     Unit.get_from_cache(unit_name, raise_exceptions: false)
   end
-  private_class_method :resolve_unit
 
   def self.resolve_unit_group(unit_group_name)
-    return nil unless unit_group_name.present?
+    return nil if unit_group_name.blank?
 
     UnitGroup.get_from_cache(unit_group_name)
   rescue ActiveRecord::RecordNotFound
     nil
   end
-  private_class_method :resolve_unit_group
+
+  private_class_method :resolve_unit, :resolve_unit_group
 end

--- a/dashboard/lib/policies/demo_sections.rb
+++ b/dashboard/lib/policies/demo_sections.rb
@@ -35,8 +35,8 @@ class Policies::DemoSections
       login_type: 'email',
       participant_type: 'student',
       grades: %w[9 10 11 12],
-      unit_name: 'aif-foundations-2026',
-      unit_group_name: 'ai-foundations-exploring-ai-and-cs-2026',
+      unit_name: 'aif2-2025',
+      unit_group_name: 'artificial-intelligence-foundations-2025',
       # Green robot: COLORS[8] = Green, EMOJIS[5] = 🤖
       avatar_color: 8,
       avatar_emoji: 5,
@@ -54,6 +54,37 @@ class Policies::DemoSections
     (ids&.dig(demo_type.to_s) || []).map(&:to_i)
   end
 
+  def self.preset_view(demo_type)
+    preset = get_preset(demo_type)
+    return nil unless preset
+
+    unit = resolve_unit(preset[:unit_name])
+    unit_group = resolve_unit_group(preset[:unit_group_name])
+    return nil if preset[:unit_name].present? && unit.nil?
+    return nil if preset[:unit_group_name].present? && unit_group.nil?
+
+    {
+      demo_type: demo_type.to_s,
+      section_name: preset[:section_name],
+      avatar_color: preset[:avatar_color],
+      avatar_emoji: preset[:avatar_emoji],
+      login_type: preset[:login_type],
+      participant_type: preset[:participant_type],
+      unit: unit && {name: unit.name, display_name: unit.localized_title},
+      unit_group: unit_group && {
+        name: unit_group.name,
+        display_name: unit_group.localized_title,
+      },
+    }
+  end
+
+  def self.preset_views_for_all_types
+    DEMO_TYPES.each_with_object({}) do |demo_type, views|
+      view = preset_view(demo_type)
+      views[demo_type] = view if view
+    end
+  end
+
   def self.all_demo_student_ids
     @all_demo_student_ids ||= DEMO_TYPES.flat_map {|type| demo_student_ids(type)}.to_set
   end
@@ -65,4 +96,20 @@ class Policies::DemoSections
   def self.reset_cache!
     @all_demo_student_ids = nil
   end
+
+  def self.resolve_unit(unit_name)
+    return nil unless unit_name.present?
+
+    Unit.get_from_cache(unit_name, raise_exceptions: false)
+  end
+  private_class_method :resolve_unit
+
+  def self.resolve_unit_group(unit_group_name)
+    return nil unless unit_group_name.present?
+
+    UnitGroup.get_from_cache(unit_group_name)
+  rescue ActiveRecord::RecordNotFound
+    nil
+  end
+  private_class_method :resolve_unit_group
 end

--- a/dashboard/test/controllers/api/v1/sections_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/sections_controller_test.rb
@@ -1704,7 +1704,39 @@ class Api::V1::SectionsControllerTest < ActionController::TestCase
 
     post :create_demo, params: {demo_type: 'high'}
     assert_response :conflict
-    assert_equal 'demo section of type high already exists', returned_json['error']
+    assert_includes JSON.parse(@response.body)['error'], 'high'
+  end
+
+  test 'presets: returns forbidden when not signed in' do
+    get :presets
+    assert_response :forbidden
+  end
+
+  test 'presets: returns the preset projections' do
+    sign_in @teacher
+    create(:unit, name: 'aif2-2025')
+    create(:unit, name: 'csd3-2024')
+    create(:unit, name: 'k5-ai-data-2024')
+    create(:unit_group, name: 'artificial-intelligence-foundations-2025')
+    create(:unit_group, name: 'csd-2024')
+    create(:unit_group, name: 'k5-ai-data-2024')
+
+    get :presets
+
+    assert_response :success
+    response = JSON.parse(@response.body)
+    assert_equal 'High School Practice Section', response['high']['section_name']
+    assert_equal 'aif2-2025', response['high']['unit']['name']
+    assert_equal 'student', response['middle']['participant_type']
+  end
+
+  test 'presets: returns not_found when no preset can be projected' do
+    sign_in @teacher
+    Policies::DemoSections.stubs(:preset_views_for_all_types).returns({})
+
+    get :presets
+
+    assert_response :not_found
   end
 
   private def stub_demo_preset

--- a/dashboard/test/controllers/api/v1/users_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/users_controller_test.rb
@@ -223,7 +223,7 @@ class Api::V1::UsersControllerTest < ActionController::TestCase
   end
 
   test "a get request to get current returns signed in user info" do
-    teacher = create(:teacher)
+    teacher = create(:teacher, grades_teaching: %w[9 10 11 12])
     sign_in(teacher)
     get :current
     assert_response :success
@@ -235,7 +235,19 @@ class Api::V1::UsersControllerTest < ActionController::TestCase
     assert_equal "teacher", response["user_type"]
     assert_equal teacher.short_name, response["short_name"]
     assert_equal teacher.educator_role, response["educator_role"]
+    assert_equal %w[9 10 11 12], response["grades_teaching"]
     assert_equal false, response["is_verified_instructor"]
+  end
+
+  test "a get request to get current returns empty grades_teaching when unset" do
+    teacher = create(:teacher, grades_teaching: nil)
+    sign_in(teacher)
+
+    get :current
+
+    assert_response :success
+    response = JSON.parse(@response.body)
+    assert_equal [], response["grades_teaching"]
   end
 
   test "a get request to get school_name returns school object" do

--- a/dashboard/test/controllers/sections_controller_test.rb
+++ b/dashboard/test/controllers/sections_controller_test.rb
@@ -317,6 +317,25 @@ class SectionsControllerTest < ActionController::TestCase
     end
   end
 
+  test 'retrieve_lessons_for_dropdown returns demo preset lesson links for a demo type' do
+    sign_in @teacher
+    unit_group = create(
+      :unit_group,
+      name: 'artificial-intelligence-foundations-2025',
+      published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.stable
+    )
+    unit = create(:unit, :with_levels, name: 'aif2-2025')
+    create(:unit_group_unit, unit_group: unit_group, script: unit, position: 1)
+    unit.lessons.first.update!(has_lesson_plan: true)
+
+    get :retrieve_lessons_for_dropdown, params: {demo_type: 'high'}
+
+    assert_response :success
+    response_json = JSON.parse(@response.body)
+    assert_equal "/teacher_dashboard/sections/:sectionId/courses/artificial-intelligence-foundations-2025/units/1", response_json.first['value']
+    assert_equal "/courses/artificial-intelligence-foundations-2025/units/1/lessons/1/levels/1", response_json.second['value']
+  end
+
   describe 'POST /sections/:id/log_in' do
     subject(:log_in_section) {post :log_in, params: {id: @picture_section.code, **section_params}}
 

--- a/dashboard/test/controllers/sections_controller_test.rb
+++ b/dashboard/test/controllers/sections_controller_test.rb
@@ -328,7 +328,7 @@ class SectionsControllerTest < ActionController::TestCase
     create(:unit_group_unit, unit_group: unit_group, script: unit, position: 1)
     unit.lessons.first.update!(has_lesson_plan: true)
 
-    get :retrieve_lessons_for_dropdown, params: {demo_type: 'high'}
+    get :retrieve_lessons_for_dropdown, params: {id: 'high'}
 
     assert_response :success
     response_json = JSON.parse(@response.body)

--- a/dashboard/test/lib/policies/demo_sections_test.rb
+++ b/dashboard/test/lib/policies/demo_sections_test.rb
@@ -57,8 +57,8 @@ class Policies::DemoSectionsTest < ActiveSupport::TestCase
     assert_equal 'email', preset[:login_type]
     assert_equal 'student', preset[:participant_type]
     assert_equal %w[9 10 11 12], preset[:grades]
-    assert_equal 'aif-foundations-2026', preset[:unit_name]
-    assert_equal 'ai-foundations-exploring-ai-and-cs-2026', preset[:unit_group_name]
+    assert_equal 'aif2-2025', preset[:unit_name]
+    assert_equal 'artificial-intelligence-foundations-2025', preset[:unit_group_name]
   end
 
   test 'get_preset returns preset for each demo type' do
@@ -78,6 +78,43 @@ class Policies::DemoSectionsTest < ActiveSupport::TestCase
 
   test 'get_preset returns nil for unknown type' do
     assert_nil Policies::DemoSections.get_preset(:unknown)
+  end
+
+  # preset_view
+
+  test 'preset_view returns a display projection for a valid preset' do
+    unit = create(:unit, name: 'aif2-2025')
+    unit_group = create(:unit_group, name: 'artificial-intelligence-foundations-2025')
+
+    view = Policies::DemoSections.preset_view(:high)
+
+    assert_equal 'high', view[:demo_type]
+    assert_equal 'High School Practice Section', view[:section_name]
+    assert_equal 8, view[:avatar_color]
+    assert_equal 5, view[:avatar_emoji]
+    assert_equal 'email', view[:login_type]
+    assert_equal 'student', view[:participant_type]
+    assert_equal({name: unit.name, display_name: unit.localized_title}, view[:unit])
+    assert_equal(
+      {name: unit_group.name, display_name: unit_group.localized_title},
+      view[:unit_group]
+    )
+  end
+
+  test 'preset_view returns nil when a configured unit cannot be resolved' do
+    Unit.expects(:get_from_cache).with('aif2-2025', raise_exceptions: false).returns(nil)
+
+    assert_nil Policies::DemoSections.preset_view(:high)
+  end
+
+  test 'preset_views_for_all_types skips misconfigured presets' do
+    valid_view = {demo_type: 'middle'}
+
+    Policies::DemoSections.expects(:preset_view).with(:high).returns(nil)
+    Policies::DemoSections.expects(:preset_view).with(:middle).returns(valid_view)
+    Policies::DemoSections.expects(:preset_view).with(:elementary).returns(nil)
+
+    assert_equal({middle: valid_view}, Policies::DemoSections.preset_views_for_all_types)
   end
 
   # demo_student?


### PR DESCRIPTION
- adds the new `DemoSectionCard` component
- matches the regular section card shell, preview header, and body layout as closely as possible
- shows preset-derived preview data and creates the demo section from the primary body actions

<img width="814" height="236" alt="image" src="https://github.com/user-attachments/assets/922824cf-e5ee-4867-af10-9850f2824275" />


Action menu on the right will be in a future PR
