### PR TITLE
Add demo section router and grade plumbing

### DIFF
--- a/apps/src/sites/studio/pages/teacher_dashboard/show.js
+++ b/apps/src/sites/studio/pages/teacher_dashboard/show.js
@@ -31,6 +31,7 @@ import teacherSections, {
 import {setSelectedSectionData} from '@cdo/apps/templates/teacherNavigation/selectedSectionLoader';
 import TeacherNavigationRouter from '@cdo/apps/templates/teacherNavigation/TeacherNavigationRouter';
 import {createReactRoot} from '@cdo/apps/util/createReactRoot';
+import experiments from '@cdo/apps/util/experiments';
 
 // 6 seconds
 const FLASH_DURATION = 6 * 1000;
@@ -94,9 +95,7 @@ $(document).ready(function () {
 
   createReactRoot(
     <Provider store={store}>
-      {sections.length === 0 ? (
-        // If a teacher has no sections, we will send them directly to the homepage to bypass
-        // all of the section loading logic in the TeacherNavigationRouter.
+      {sections.length === 0 && !experiments.isEnabled('demo-section') ? (
         <TeacherHomepage studioUrlPrefix={scriptData.studioUrlPrefix} />
       ) : (
         <TeacherNavigationRouter studioUrlPrefix={scriptData.studioUrlPrefix} />

--- a/apps/src/templates/CurrentUserState.ts
+++ b/apps/src/templates/CurrentUserState.ts
@@ -20,6 +20,7 @@ export interface CurrentUserState {
   userId: number;
   userName: string;
   displayName?: string;
+  gradesTeaching: string[];
   userType: 'unknown' | 'teacher' | 'student';
   userRoleInCourse: CourseRole;
   signInState: SignInState;

--- a/apps/src/templates/currentUserRedux.js
+++ b/apps/src/templates/currentUserRedux.js
@@ -105,6 +105,7 @@ export const setHasSeenHomepageWelcome = hasSeenHomepageWelcome => ({
 const initialState = {
   userId: null,
   userName: null,
+  gradesTeaching: [],
   userType: 'unknown',
   userRoleInCourse: CourseRoles.Unknown,
   signInState: SignInState.Unknown,
@@ -236,6 +237,7 @@ export default function currentUser(state = initialState, action) {
       id,
       username,
       display_name,
+      grades_teaching,
       user_type,
       mute_music,
       under_13,
@@ -271,6 +273,7 @@ export default function currentUser(state = initialState, action) {
       ...state,
       userId: id,
       userName: username,
+      gradesTeaching: grades_teaching || [],
       userType: user_type,
       displayName: display_name,
       isBackgroundMusicMuted: mute_music,

--- a/apps/src/templates/studioHomepages/teacherHomepageV2/pickDemoType.ts
+++ b/apps/src/templates/studioHomepages/teacherHomepageV2/pickDemoType.ts
@@ -1,0 +1,21 @@
+import {DemoType} from '../../teacherDashboard/types/teacherSectionTypes';
+
+export const pickDemoType = (
+  gradesTeaching: string[] | null | undefined
+): DemoType => {
+  const grades = new Set((gradesTeaching || []).map(String));
+
+  if (['9', '10', '11', '12'].some(grade => grades.has(grade))) {
+    return 'high';
+  }
+
+  if (['6', '7', '8'].some(grade => grades.has(grade))) {
+    return 'middle';
+  }
+
+  if (['K', '1', '2', '3', '4', '5'].some(grade => grades.has(grade))) {
+    return 'elementary';
+  }
+
+  return 'high';
+};

--- a/apps/src/templates/teacherDashboard/types/teacherSectionTypes.ts
+++ b/apps/src/templates/teacherDashboard/types/teacherSectionTypes.ts
@@ -54,6 +54,24 @@ export interface Section {
   aiChatAccessLevel?: AiChatAccessLevel;
 }
 
+export type DemoType = 'elementary' | 'middle' | 'high';
+
+export interface DemoPresetCourseRef {
+  name: string;
+  displayName: string;
+}
+
+export interface DemoPresetView {
+  demoType: DemoType;
+  sectionName: string;
+  avatarColor: number;
+  avatarEmoji: number;
+  loginType: string;
+  participantType: string;
+  unit: DemoPresetCourseRef | null;
+  unitGroup: DemoPresetCourseRef | null;
+}
+
 type Course = {
   courseOfferingId: number | null;
   versionId: number | null;
@@ -141,6 +159,22 @@ export interface ServerStudent {
   sectionId: number;
   sharing_disabled: boolean;
   user_type: keyof typeof UserTypes;
+}
+
+export interface ServerDemoPresetCourseRef {
+  name: string;
+  display_name: string;
+}
+
+export interface ServerDemoPresetView {
+  demo_type: DemoType;
+  section_name: string;
+  avatar_color: number;
+  avatar_emoji: number;
+  login_type: string;
+  participant_type: string;
+  unit: ServerDemoPresetCourseRef | null;
+  unit_group: ServerDemoPresetCourseRef | null;
 }
 
 //TODO: better types here

--- a/apps/src/templates/teacherDashboard/types/teacherSectionTypes.ts
+++ b/apps/src/templates/teacherDashboard/types/teacherSectionTypes.ts
@@ -56,7 +56,12 @@ export interface Section {
 
 export type DemoType = 'elementary' | 'middle' | 'high';
 
-export interface DemoPresetObject {
+export interface DemoPresetUnit {
+  name: string;
+  displayName: string;
+}
+
+export interface DemoPresetCourse {
   name: string;
   displayName: string;
 }
@@ -68,8 +73,8 @@ export interface DemoPresetView {
   avatarEmoji: number;
   loginType: string;
   participantType: string;
-  unit: DemoPresetObject | null;
-  unitGroup: DemoPresetObject | null;
+  unit: DemoPresetUnit | null;
+  unitGroup: DemoPresetCourse | null;
 }
 
 type Course = {
@@ -161,7 +166,12 @@ export interface ServerStudent {
   user_type: keyof typeof UserTypes;
 }
 
-export interface ServerDemoPresetObject {
+export interface ServerDemoPresetUnit {
+  name: string;
+  display_name: string;
+}
+
+export interface ServerDemoPresetCourse {
   name: string;
   display_name: string;
 }
@@ -173,8 +183,8 @@ export interface ServerDemoPresetView {
   avatar_emoji: number;
   login_type: string;
   participant_type: string;
-  unit: ServerDemoPresetObject | null;
-  unit_group: ServerDemoPresetObject | null;
+  unit: ServerDemoPresetUnit | null;
+  unit_group: ServerDemoPresetCourse | null;
 }
 
 //TODO: better types here

--- a/apps/src/templates/teacherDashboard/types/teacherSectionTypes.ts
+++ b/apps/src/templates/teacherDashboard/types/teacherSectionTypes.ts
@@ -56,7 +56,7 @@ export interface Section {
 
 export type DemoType = 'elementary' | 'middle' | 'high';
 
-export interface DemoPresetCourseRef {
+export interface DemoPresetObject {
   name: string;
   displayName: string;
 }
@@ -68,8 +68,8 @@ export interface DemoPresetView {
   avatarEmoji: number;
   loginType: string;
   participantType: string;
-  unit: DemoPresetCourseRef | null;
-  unitGroup: DemoPresetCourseRef | null;
+  unit: DemoPresetObject | null;
+  unitGroup: DemoPresetObject | null;
 }
 
 type Course = {
@@ -161,7 +161,7 @@ export interface ServerStudent {
   user_type: keyof typeof UserTypes;
 }
 
-export interface ServerDemoPresetCourseRef {
+export interface ServerDemoPresetObject {
   name: string;
   display_name: string;
 }
@@ -173,8 +173,8 @@ export interface ServerDemoPresetView {
   avatar_emoji: number;
   login_type: string;
   participant_type: string;
-  unit: ServerDemoPresetCourseRef | null;
-  unit_group: ServerDemoPresetCourseRef | null;
+  unit: ServerDemoPresetObject | null;
+  unit_group: ServerDemoPresetObject | null;
 }
 
 //TODO: better types here

--- a/apps/src/templates/teacherDashboard/types/teacherSectionTypes.ts
+++ b/apps/src/templates/teacherDashboard/types/teacherSectionTypes.ts
@@ -71,8 +71,8 @@ export interface DemoPresetView {
   sectionName: string;
   avatarColor: number;
   avatarEmoji: number;
-  loginType: string;
-  participantType: string;
+  loginType: NonNullable<Section['loginType']>;
+  participantType: NonNullable<Section['participantType']>;
   unit: DemoPresetUnit | null;
   unitGroup: DemoPresetCourse | null;
 }
@@ -181,8 +181,8 @@ export interface ServerDemoPresetView {
   section_name: string;
   avatar_color: number;
   avatar_emoji: number;
-  login_type: string;
-  participant_type: string;
+  login_type: NonNullable<Section['loginType']>;
+  participant_type: NonNullable<Section['participantType']>;
   unit: ServerDemoPresetUnit | null;
   unit_group: ServerDemoPresetCourse | null;
 }

--- a/apps/src/templates/teacherNavigation/TeacherNavigationRouter.tsx
+++ b/apps/src/templates/teacherNavigation/TeacherNavigationRouter.tsx
@@ -298,7 +298,7 @@ const TeacherNavigationRouter: React.FC<TeacherNavigationRouterProps> = ({
                 <DashboardSectionSettings
                   redirectUrl={
                     sectionId
-                      ? '/teacher_dashboard' +
+                      ? TEACHER_NAVIGATION_BASE_URL +
                         generatePath(
                           LABELED_TEACHER_NAVIGATION_PATHS.progress.absoluteUrl,
                           {sectionId: sectionId}

--- a/apps/src/templates/teacherNavigation/TeacherNavigationRouter.tsx
+++ b/apps/src/templates/teacherNavigation/TeacherNavigationRouter.tsx
@@ -297,11 +297,13 @@ const TeacherNavigationRouter: React.FC<TeacherNavigationRouterProps> = ({
               element={
                 <DashboardSectionSettings
                   redirectUrl={
-                    '/teacher_dashboard' +
-                    generatePath(
-                      LABELED_TEACHER_NAVIGATION_PATHS.progress.absoluteUrl,
-                      {sectionId: sectionId}
-                    )
+                    sectionId
+                      ? '/teacher_dashboard' +
+                        generatePath(
+                          LABELED_TEACHER_NAVIGATION_PATHS.progress.absoluteUrl,
+                          {sectionId: sectionId}
+                        )
+                      : `${TEACHER_NAVIGATION_BASE_URL}/${TEACHER_NAVIGATION_PATHS.home}`
                   }
                 />
               }

--- a/apps/test/unit/templates/studioHomepages/teacherHomepageV2/pickDemoTypeTest.ts
+++ b/apps/test/unit/templates/studioHomepages/teacherHomepageV2/pickDemoTypeTest.ts
@@ -1,0 +1,21 @@
+import {pickDemoType} from '@cdo/apps/templates/studioHomepages/teacherHomepageV2/pickDemoType';
+
+describe('pickDemoType', () => {
+  it('prefers high school grades', () => {
+    expect(pickDemoType(['5', '8', '10'])).toBe('high');
+  });
+
+  it('falls back to middle school grades when no high school grades exist', () => {
+    expect(pickDemoType(['6', '8'])).toBe('middle');
+  });
+
+  it('returns elementary for elementary-only grades', () => {
+    expect(pickDemoType(['K', '3'])).toBe('elementary');
+  });
+
+  it('defaults to high for empty or missing grade data', () => {
+    expect(pickDemoType([])).toBe('high');
+    expect(pickDemoType(undefined)).toBe('high');
+    expect(pickDemoType(null)).toBe('high');
+  });
+});

--- a/dashboard/app/controllers/api/v1/sections_controller.rb
+++ b/dashboard/app/controllers/api/v1/sections_controller.rb
@@ -3,7 +3,7 @@ require 'metrics/events'
 class Api::V1::SectionsController < Api::V1::JSONApiController
   load_resource :section, find_by: :code, only: [:join, :leave]
   before_action :find_follower, only: :leave
-  load_and_authorize_resource except: [:join, :leave, :membership, :valid_course_offerings, :create, :create_demo, :update, :require_captcha, :assigned_essential_ai_dependency]
+  load_and_authorize_resource except: [:join, :leave, :membership, :valid_course_offerings, :create, :create_demo, :presets, :update, :require_captcha, :assigned_essential_ai_dependency]
   before_action :get_course_and_unit, only: [:create, :update]
 
   skip_before_action :verify_authenticity_token, only: [:update]

--- a/dashboard/app/controllers/api/v1/sections_controller.rb
+++ b/dashboard/app/controllers/api/v1/sections_controller.rb
@@ -152,6 +152,16 @@ class Api::V1::SectionsController < Api::V1::JSONApiController
     end
   end
 
+  # GET /api/v1/sections/demo/presets
+  def presets
+    authorize! :create, Section
+
+    preset_views = Policies::DemoSections.preset_views_for_all_types
+    return head :not_found if preset_views.empty?
+
+    render json: preset_views
+  end
+
   # PATCH /api/v1/sections/<id>
   # Allows you to update a section. Clears any assigned script_id in the process
   def update

--- a/dashboard/app/controllers/api/v1/users_controller.rb
+++ b/dashboard/app/controllers/api/v1/users_controller.rb
@@ -71,6 +71,7 @@ class Api::V1::UsersController < Api::V1::JSONApiController
         ai_differentiation_enabled: !current_user.ai_differentiation_toggled_off?,
         has_completed_ai_differentiation_welcome: current_user.has_completed_ai_differentiation_welcome?,
         educator_role: current_user.educator_role,
+        grades_teaching: current_user.grades_teaching || [],
         sharing_disabled: current_user.sharing_disabled,
         is_levelbuilder: current_user.levelbuilder?,
         ai_chat_access_level: current_user.ai_chat_access_level,

--- a/dashboard/config/routes.rb
+++ b/dashboard/config/routes.rb
@@ -222,6 +222,7 @@ Dashboard::Application.routes.draw do
           get 'valid_course_offerings'
           get 'available_participant_types'
           get 'require_captcha'
+          get 'demo/presets', action: 'presets', as: 'presets'
           post 'demo/:demo_type', action: 'create_demo', as: 'create_demo'
           get 'assigned_essential_ai_dependency'
         end

--- a/dashboard/lib/policies/demo_sections.rb
+++ b/dashboard/lib/policies/demo_sections.rb
@@ -107,8 +107,6 @@ class Policies::DemoSections
     return nil if unit_group_name.blank?
 
     UnitGroup.get_from_cache(unit_group_name)
-  rescue ActiveRecord::RecordNotFound
-    nil
   end
 
   private_class_method :resolve_unit, :resolve_unit_group

--- a/dashboard/lib/policies/demo_sections.rb
+++ b/dashboard/lib/policies/demo_sections.rb
@@ -98,18 +98,18 @@ class Policies::DemoSections
   end
 
   def self.resolve_unit(unit_name)
-    return nil unless unit_name.present?
+    return nil if unit_name.blank?
 
     Unit.get_from_cache(unit_name, raise_exceptions: false)
   end
-  private_class_method :resolve_unit
 
   def self.resolve_unit_group(unit_group_name)
-    return nil unless unit_group_name.present?
+    return nil if unit_group_name.blank?
 
     UnitGroup.get_from_cache(unit_group_name)
   rescue ActiveRecord::RecordNotFound
     nil
   end
-  private_class_method :resolve_unit_group
+
+  private_class_method :resolve_unit, :resolve_unit_group
 end

--- a/dashboard/lib/policies/demo_sections.rb
+++ b/dashboard/lib/policies/demo_sections.rb
@@ -35,8 +35,8 @@ class Policies::DemoSections
       login_type: 'email',
       participant_type: 'student',
       grades: %w[9 10 11 12],
-      unit_name: 'aif-foundations-2026',
-      unit_group_name: 'ai-foundations-exploring-ai-and-cs-2026',
+      unit_name: 'aif2-2025',
+      unit_group_name: 'artificial-intelligence-foundations-2025',
       # Green robot: COLORS[8] = Green, EMOJIS[5] = 🤖
       avatar_color: 8,
       avatar_emoji: 5,
@@ -54,6 +54,37 @@ class Policies::DemoSections
     (ids&.dig(demo_type.to_s) || []).map(&:to_i)
   end
 
+  def self.preset_view(demo_type)
+    preset = get_preset(demo_type)
+    return nil unless preset
+
+    unit = resolve_unit(preset[:unit_name])
+    unit_group = resolve_unit_group(preset[:unit_group_name])
+    return nil if preset[:unit_name].present? && unit.nil?
+    return nil if preset[:unit_group_name].present? && unit_group.nil?
+
+    {
+      demo_type: demo_type.to_s,
+      section_name: preset[:section_name],
+      avatar_color: preset[:avatar_color],
+      avatar_emoji: preset[:avatar_emoji],
+      login_type: preset[:login_type],
+      participant_type: preset[:participant_type],
+      unit: unit && {name: unit.name, display_name: unit.localized_title},
+      unit_group: unit_group && {
+        name: unit_group.name,
+        display_name: unit_group.localized_title,
+      },
+    }
+  end
+
+  def self.preset_views_for_all_types
+    DEMO_TYPES.each_with_object({}) do |demo_type, views|
+      view = preset_view(demo_type)
+      views[demo_type] = view if view
+    end
+  end
+
   def self.all_demo_student_ids
     @all_demo_student_ids ||= DEMO_TYPES.flat_map {|type| demo_student_ids(type)}.to_set
   end
@@ -65,4 +96,20 @@ class Policies::DemoSections
   def self.reset_cache!
     @all_demo_student_ids = nil
   end
+
+  def self.resolve_unit(unit_name)
+    return nil unless unit_name.present?
+
+    Unit.get_from_cache(unit_name, raise_exceptions: false)
+  end
+  private_class_method :resolve_unit
+
+  def self.resolve_unit_group(unit_group_name)
+    return nil unless unit_group_name.present?
+
+    UnitGroup.get_from_cache(unit_group_name)
+  rescue ActiveRecord::RecordNotFound
+    nil
+  end
+  private_class_method :resolve_unit_group
 end

--- a/dashboard/test/controllers/api/v1/sections_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/sections_controller_test.rb
@@ -1704,7 +1704,39 @@ class Api::V1::SectionsControllerTest < ActionController::TestCase
 
     post :create_demo, params: {demo_type: 'high'}
     assert_response :conflict
-    assert_equal 'demo section of type high already exists', returned_json['error']
+    assert_includes JSON.parse(@response.body)['error'], 'high'
+  end
+
+  test 'presets: returns forbidden when not signed in' do
+    get :presets
+    assert_response :forbidden
+  end
+
+  test 'presets: returns the preset projections' do
+    sign_in @teacher
+    create(:unit, name: 'aif2-2025')
+    create(:unit, name: 'csd3-2024')
+    create(:unit, name: 'k5-ai-data-2024')
+    create(:unit_group, name: 'artificial-intelligence-foundations-2025')
+    create(:unit_group, name: 'csd-2024')
+    create(:unit_group, name: 'k5-ai-data-2024')
+
+    get :presets
+
+    assert_response :success
+    response = JSON.parse(@response.body)
+    assert_equal 'High School Practice Section', response['high']['section_name']
+    assert_equal 'aif2-2025', response['high']['unit']['name']
+    assert_equal 'student', response['middle']['participant_type']
+  end
+
+  test 'presets: returns not_found when no preset can be projected' do
+    sign_in @teacher
+    Policies::DemoSections.stubs(:preset_views_for_all_types).returns({})
+
+    get :presets
+
+    assert_response :not_found
   end
 
   private def stub_demo_preset

--- a/dashboard/test/controllers/api/v1/users_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/users_controller_test.rb
@@ -223,7 +223,7 @@ class Api::V1::UsersControllerTest < ActionController::TestCase
   end
 
   test "a get request to get current returns signed in user info" do
-    teacher = create(:teacher)
+    teacher = create(:teacher, grades_teaching: %w[9 10 11 12])
     sign_in(teacher)
     get :current
     assert_response :success
@@ -235,7 +235,19 @@ class Api::V1::UsersControllerTest < ActionController::TestCase
     assert_equal "teacher", response["user_type"]
     assert_equal teacher.short_name, response["short_name"]
     assert_equal teacher.educator_role, response["educator_role"]
+    assert_equal %w[9 10 11 12], response["grades_teaching"]
     assert_equal false, response["is_verified_instructor"]
+  end
+
+  test "a get request to get current returns empty grades_teaching when unset" do
+    teacher = create(:teacher, grades_teaching: nil)
+    sign_in(teacher)
+
+    get :current
+
+    assert_response :success
+    response = JSON.parse(@response.body)
+    assert_equal [], response["grades_teaching"]
   end
 
   test "a get request to get school_name returns school object" do

--- a/dashboard/test/lib/policies/demo_sections_test.rb
+++ b/dashboard/test/lib/policies/demo_sections_test.rb
@@ -57,8 +57,8 @@ class Policies::DemoSectionsTest < ActiveSupport::TestCase
     assert_equal 'email', preset[:login_type]
     assert_equal 'student', preset[:participant_type]
     assert_equal %w[9 10 11 12], preset[:grades]
-    assert_equal 'aif-foundations-2026', preset[:unit_name]
-    assert_equal 'ai-foundations-exploring-ai-and-cs-2026', preset[:unit_group_name]
+    assert_equal 'aif2-2025', preset[:unit_name]
+    assert_equal 'artificial-intelligence-foundations-2025', preset[:unit_group_name]
   end
 
   test 'get_preset returns preset for each demo type' do
@@ -78,6 +78,43 @@ class Policies::DemoSectionsTest < ActiveSupport::TestCase
 
   test 'get_preset returns nil for unknown type' do
     assert_nil Policies::DemoSections.get_preset(:unknown)
+  end
+
+  # preset_view
+
+  test 'preset_view returns a display projection for a valid preset' do
+    unit = create(:unit, name: 'aif2-2025')
+    unit_group = create(:unit_group, name: 'artificial-intelligence-foundations-2025')
+
+    view = Policies::DemoSections.preset_view(:high)
+
+    assert_equal 'high', view[:demo_type]
+    assert_equal 'High School Practice Section', view[:section_name]
+    assert_equal 8, view[:avatar_color]
+    assert_equal 5, view[:avatar_emoji]
+    assert_equal 'email', view[:login_type]
+    assert_equal 'student', view[:participant_type]
+    assert_equal({name: unit.name, display_name: unit.localized_title}, view[:unit])
+    assert_equal(
+      {name: unit_group.name, display_name: unit_group.localized_title},
+      view[:unit_group]
+    )
+  end
+
+  test 'preset_view returns nil when a configured unit cannot be resolved' do
+    Unit.expects(:get_from_cache).with('aif2-2025', raise_exceptions: false).returns(nil)
+
+    assert_nil Policies::DemoSections.preset_view(:high)
+  end
+
+  test 'preset_views_for_all_types skips misconfigured presets' do
+    valid_view = {demo_type: 'middle'}
+
+    Policies::DemoSections.expects(:preset_view).with(:high).returns(nil)
+    Policies::DemoSections.expects(:preset_view).with(:middle).returns(valid_view)
+    Policies::DemoSections.expects(:preset_view).with(:elementary).returns(nil)
+
+    assert_equal({middle: valid_view}, Policies::DemoSections.preset_views_for_all_types)
   end
 
   # demo_student?


### PR DESCRIPTION
- routes the zero-section homepage through the teacher router behind the `demo-section` experiment
- threads `gradesTeaching` into frontend current-user state
- adds the client-side helper that maps `grades_teaching` to `elementary`, `middle`, or `high`
