### PR TITLE
Integrate demo card on teacher homepage

### DIFF
--- a/apps/src/templates/studioHomepages/teacherHomepageV2/CourseContentDropdown.tsx
+++ b/apps/src/templates/studioHomepages/teacherHomepageV2/CourseContentDropdown.tsx
@@ -47,20 +47,29 @@ export const CourseContentDropdownBase: React.FC<
   renderCourseAction,
 }) => {
   const [lessonList, setLessonList] = useState<UnitLessonOption[]>([]);
+  const [hasLoadedLessonList, setHasLoadedLessonList] = useState(false);
+
+  useEffect(() => {
+    setLessonList([]);
+    setHasLoadedLessonList(false);
+  }, [lessonSource]);
 
   useEffect(() => {
     const fetchLessonList = async () => {
       HttpClient.fetchJson<UnitLessonOption[]>(
         `/sections/${lessonSource}/retrieve_lessons_for_dropdown`
       )
-        .then(response => setLessonList(response.value))
+        .then(response =>
+          setLessonList(Array.isArray(response.value) ? response.value : [])
+        )
+        .finally(() => setHasLoadedLessonList(true))
         .catch(error => console.error(error));
     };
 
-    if (shouldShowLessonDropdown && lessonList.length === 0) {
+    if (shouldShowLessonDropdown && !hasLoadedLessonList) {
       fetchLessonList();
     }
-  }, [lessonList, lessonSource, shouldShowLessonDropdown]);
+  }, [hasLoadedLessonList, lessonSource, shouldShowLessonDropdown]);
 
   return (
     <div className={styles.courseContentDropdownContainer}>

--- a/apps/src/templates/studioHomepages/teacherHomepageV2/DemoSectionCard.tsx
+++ b/apps/src/templates/studioHomepages/teacherHomepageV2/DemoSectionCard.tsx
@@ -160,7 +160,12 @@ const DemoSectionCard: React.FC<DemoSectionCardProps> = ({
               sectionId: section.id.toString(),
             }
           );
-      navigate(nextPath);
+
+      if (nextPath.startsWith('/')) {
+        window.location.assign(nextPath);
+      } else {
+        navigate(nextPath);
+      }
     } catch (error) {
       if (error instanceof DemoSectionCreationError) {
         setNotice({

--- a/apps/src/templates/studioHomepages/teacherHomepageV2/DemoSectionCard.tsx
+++ b/apps/src/templates/studioHomepages/teacherHomepageV2/DemoSectionCard.tsx
@@ -1,3 +1,4 @@
+import Alert, {alertTypes} from '@code-dot-org/component-library/alert';
 import FontAwesomeV6Icon from '@code-dot-org/component-library/fontAwesomeV6Icon';
 import {IconButton as MuiIconButton, Typography} from '@mui/material';
 import React from 'react';
@@ -12,17 +13,18 @@ import {
 } from '@cdo/apps/templates/teacherDashboard/teacherSectionsRedux';
 import {
   DemoPresetView,
-  DemoType,
   Section,
 } from '@cdo/apps/templates/teacherDashboard/types/teacherSectionTypes';
 import {
   TEACHER_NAVIGATION_PATHS,
   TEACHER_NAVIGATION_SECTIONS_URL,
 } from '@cdo/apps/templates/teacherNavigation/TeacherNavigationPaths';
-import {useAppDispatch} from '@cdo/apps/util/reduxHooks';
+import {useAppDispatch, useAppSelector} from '@cdo/apps/util/reduxHooks';
 import i18n from '@cdo/locale';
 
 import {DemoSectionCourseContentDropdown} from './DemoSectionCourseContentDropdown';
+import {EmptyHomepage} from './EmptyHomepage';
+import {pickDemoType} from './pickDemoType';
 import SectionAvatar from './sectionAvatars/SectionAvatar';
 
 import joinLinkStyles from './JoinLink/joinLinkCopyButton.module.scss';
@@ -34,9 +36,8 @@ type Notice = {
 };
 
 interface DemoSectionCardProps {
-  preset: DemoPresetView;
-  demoType: DemoType;
-  onNotice: (notice: Notice | null) => void;
+  isEnabled: boolean;
+  showHiddenOnly: boolean;
 }
 
 interface DemoAction {
@@ -74,18 +75,34 @@ const buildPrimaryActions = (preset: DemoPresetView): DemoAction[] => {
 };
 
 const DemoSectionCard: React.FC<DemoSectionCardProps> = ({
-  preset,
-  demoType,
-  onNotice,
+  isEnabled,
+  showHiddenOnly,
 }) => {
   const dispatch = useAppDispatch();
   const navigate = useNavigate();
   const [pendingPath, setPendingPath] = React.useState<string | null>(null);
+  const [notice, setNotice] = React.useState<Notice | null>(null);
+  const gradesTeaching = useAppSelector(
+    state => state.currentUser.gradesTeaching
+  );
+  const sections = useAppSelector(state => state.teacherSections.sections);
+  const demoPresets = useAppSelector(
+    state => state.teacherSections.demoPresets
+  );
+  const demoType = React.useMemo(
+    () => pickDemoType(gradesTeaching),
+    [gradesTeaching]
+  );
+  const preset = demoPresets[demoType];
+  const totalSections = Object.keys(sections).length;
   const primaryActions = React.useMemo(
-    () => buildPrimaryActions(preset),
+    () => (preset ? buildPrimaryActions(preset) : []),
     [preset]
   );
-  const demoSection = React.useMemo<Section>(() => {
+  const demoSection = React.useMemo<Section | null>(() => {
+    if (!preset) {
+      return null;
+    }
     const courseDisplayName: string | null =
       preset.unitGroup?.displayName ?? preset.unit?.displayName ?? null;
 
@@ -125,7 +142,7 @@ const DemoSectionCard: React.FC<DemoSectionCardProps> = ({
     }
 
     setPendingPath(pendingKey || path);
-    onNotice(null);
+    setNotice(null);
     analyticsReporter.sendEvent(eventName, {});
 
     try {
@@ -146,12 +163,12 @@ const DemoSectionCard: React.FC<DemoSectionCardProps> = ({
       navigate(nextPath);
     } catch (error) {
       if (error instanceof DemoSectionCreationError) {
-        onNotice({
+        setNotice({
           text: error.message,
           type: error.errorType === 'conflict' ? 'warning' : 'danger',
         });
       } else {
-        onNotice({
+        setNotice({
           text: "Couldn't create your practice section.",
           type: 'danger',
         });
@@ -161,118 +178,147 @@ const DemoSectionCard: React.FC<DemoSectionCardProps> = ({
     }
   };
 
+  if (totalSections !== 0) {
+    return null;
+  }
+
+  if (!isEnabled || !preset) {
+    return <EmptyHomepage showHiddenOnly={showHiddenOnly} />;
+  }
+
   return (
-    <li
-      id="ui-test-demo-section-card"
-      className={styles.sectionCardWrapper}
-      aria-labelledby="demo-section-card-title"
-    >
-      <div className={styles.sectionCardHeader}>
-        <div className={styles.sectionCardHeaderLeft}>
-          <MuiIconButton
-            variant="text"
-            color="tertiary"
-            size="small"
-            onClick={() => {}}
-            aria-label={i18n.dragSection()}
-            type="button"
-            disabled={true}
-          >
-            <FontAwesomeV6Icon iconName="grip-vertical" />
-          </MuiIconButton>
-          <SectionAvatar
-            color={preset.avatarColor}
-            emoji={preset.avatarEmoji}
-            size={'s'}
-          />
-          <div className={styles.sectionCardHeaderText}>
-            <div className={styles.demoSectionTitleRow}>
-              <Typography
-                id="demo-section-card-title"
-                variant="h5"
-                gutterBottom
+    <>
+      {notice && (
+        <Alert
+          type={
+            notice.type === 'warning' ? alertTypes.warning : alertTypes.danger
+          }
+          text={notice.text}
+          className={styles.notificationBanner}
+          onClose={() => setNotice(null)}
+        />
+      )}
+      <ul className={styles.sectionList}>
+        <li
+          id="ui-test-demo-section-card"
+          className={styles.sectionCardWrapper}
+          aria-labelledby="demo-section-card-title"
+        >
+          <div className={styles.sectionCardHeader}>
+            <div className={styles.sectionCardHeaderLeft}>
+              <MuiIconButton
+                variant="text"
+                color="tertiary"
+                size="small"
+                onClick={() => {}}
+                aria-label={i18n.dragSection()}
+                type="button"
+                disabled={true}
               >
-                {preset.sectionName}
-              </Typography>
-              <DemoStudentChip />
-            </div>
-            <div
-              className={joinLinkStyles.sectionCodeBox}
-              data-for="section-code"
-              data-tip
-            >
-              <span className={joinLinkStyles.sectionCodeText}>
-                <Typography variant="overline1" gutterBottom>
-                  <span>{i18n.sectionCodeWithColon()}</span>{' '}
-                  <span className={joinLinkStyles.sectionCodeTextHidden}>
-                    DEMO-123
+                <FontAwesomeV6Icon iconName="grip-vertical" />
+              </MuiIconButton>
+              <SectionAvatar
+                color={preset.avatarColor}
+                emoji={preset.avatarEmoji}
+                size={'s'}
+              />
+              <div className={styles.sectionCardHeaderText}>
+                <div className={styles.demoSectionTitleRow}>
+                  <Typography
+                    id="demo-section-card-title"
+                    variant="h5"
+                    gutterBottom
+                  >
+                    {preset.sectionName}
+                  </Typography>
+                  <DemoStudentChip />
+                </div>
+                <div
+                  className={joinLinkStyles.sectionCodeBox}
+                  data-for="section-code"
+                  data-tip
+                >
+                  <span className={joinLinkStyles.sectionCodeText}>
+                    <Typography variant="overline1" gutterBottom>
+                      <span>{i18n.sectionCodeWithColon()}</span>{' '}
+                      <span className={joinLinkStyles.sectionCodeTextHidden}>
+                        DEMO-123
+                      </span>
+                    </Typography>
                   </span>
-                </Typography>
-              </span>
+                </div>
+              </div>
+            </div>
+            <div className={styles.sectionCardHeaderRight}>
+              <MuiIconButton
+                variant="text"
+                color="tertiary"
+                size="small"
+                className={styles.dropdownButton}
+                aria-label={i18n.sectionOptionsDropdown()}
+                disabled={true}
+              >
+                <FontAwesomeV6Icon
+                  iconName="ellipsis-vertical"
+                  iconStyle="solid"
+                />
+              </MuiIconButton>
             </div>
           </div>
-        </div>
-        <div className={styles.sectionCardHeaderRight}>
-          <MuiIconButton
-            variant="text"
-            color="tertiary"
-            size="small"
-            className={styles.dropdownButton}
-            aria-label={i18n.sectionOptionsDropdown()}
-            disabled={true}
-          >
-            <FontAwesomeV6Icon iconName="ellipsis-vertical" iconStyle="solid" />
-          </MuiIconButton>
-        </div>
-      </div>
-      <div className={styles.sectionCardBody}>
-        <div className={styles.sectionCardBodyLeft}>
-          <DemoSectionCourseContentDropdown
-            section={demoSection}
-            demoType={demoType}
-            disabled={!!pendingPath}
-            beforeNavigate={(path: string, eventName: string) =>
-              handleActionClick(path, eventName, path)
-            }
-          />
-        </div>
-        <div className={styles.sectionCardBodyRight}>
-          {primaryActions.map(action => {
-            const isPending = pendingPath === action.id;
-            return (
-              <button
-                id={`ui-test-demo-section-action-${action.id}`}
-                key={action.id}
-                type="button"
-                className={styles.demoActionButton}
+          <div className={styles.sectionCardBody}>
+            <div className={styles.sectionCardBodyLeft}>
+              <DemoSectionCourseContentDropdown
+                section={demoSection!}
+                demoType={demoType}
                 disabled={!!pendingPath}
-                onClick={() =>
-                  handleActionClick(action.path, action.eventName, action.id)
+                beforeNavigate={(path: string, eventName: string) =>
+                  handleActionClick(path, eventName, path)
                 }
-              >
-                <div className={styles.taskButtonLeft}>
-                  <FontAwesomeV6Icon
-                    className={styles.taskButtonIcons}
-                    iconName={action.icon}
-                    iconStyle={'solid'}
-                  />
-                  <Typography variant="body3" gutterBottom>
-                    {isPending
-                      ? 'Creating practice section...'
-                      : action.buttonText}
-                  </Typography>
-                </div>
-                <FontAwesomeV6Icon
-                  className={styles.taskButtonArrow}
-                  iconName={'arrow-right'}
-                  iconStyle={'solid'}
-                />
-              </button>
-            );
-          })}
-        </div>
-      </div>
-    </li>
+              />
+            </div>
+            <div className={styles.sectionCardBodyRight}>
+              {primaryActions.map(action => {
+                const isPending = pendingPath === action.id;
+                return (
+                  <button
+                    id={`ui-test-demo-section-action-${action.id}`}
+                    key={action.id}
+                    type="button"
+                    className={styles.demoActionButton}
+                    disabled={!!pendingPath}
+                    onClick={() =>
+                      handleActionClick(
+                        action.path,
+                        action.eventName,
+                        action.id
+                      )
+                    }
+                  >
+                    <div className={styles.taskButtonLeft}>
+                      <FontAwesomeV6Icon
+                        className={styles.taskButtonIcons}
+                        iconName={action.icon}
+                        iconStyle={'solid'}
+                      />
+                      <Typography variant="body3" gutterBottom>
+                        {isPending
+                          ? 'Creating practice section...'
+                          : action.buttonText}
+                      </Typography>
+                    </div>
+                    <FontAwesomeV6Icon
+                      className={styles.taskButtonArrow}
+                      iconName={'arrow-right'}
+                      iconStyle={'solid'}
+                    />
+                  </button>
+                );
+              })}
+            </div>
+          </div>
+        </li>
+      </ul>
+    </>
   );
 };
 

--- a/apps/src/templates/studioHomepages/teacherHomepageV2/DemoSectionCard.tsx
+++ b/apps/src/templates/studioHomepages/teacherHomepageV2/DemoSectionCard.tsx
@@ -6,6 +6,7 @@ import {generatePath, useNavigate} from 'react-router-dom';
 
 import {EVENTS} from '@cdo/apps/metrics/AnalyticsConstants.js';
 import analyticsReporter from '@cdo/apps/metrics/AnalyticsReporter';
+import Spinner from '@cdo/apps/sharedComponents/Spinner';
 import DemoStudentChip from '@cdo/apps/templates/DemoStudentChip';
 import {
   createDemoSection,
@@ -36,7 +37,6 @@ type Notice = {
 };
 
 interface DemoSectionCardProps {
-  isEnabled: boolean;
   showHiddenOnly: boolean;
 }
 
@@ -74,10 +74,7 @@ const buildPrimaryActions = (preset: DemoPresetView): DemoAction[] => {
   return actions;
 };
 
-const DemoSectionCard: React.FC<DemoSectionCardProps> = ({
-  isEnabled,
-  showHiddenOnly,
-}) => {
+const DemoSectionCard: React.FC<DemoSectionCardProps> = ({showHiddenOnly}) => {
   const dispatch = useAppDispatch();
   const navigate = useNavigate();
   const [pendingPath, setPendingPath] = React.useState<string | null>(null);
@@ -89,12 +86,23 @@ const DemoSectionCard: React.FC<DemoSectionCardProps> = ({
   const demoPresets = useAppSelector(
     state => state.teacherSections.demoPresets
   );
+  const demoPresetsAreLoaded = useAppSelector(
+    state => state.teacherSections.demoPresetsAreLoaded
+  );
   const demoType = React.useMemo(
     () => pickDemoType(gradesTeaching),
     [gradesTeaching]
   );
   const preset = demoPresets[demoType];
   const totalSections = Object.keys(sections).length;
+  const numSections = React.useMemo(
+    () =>
+      Object.values(sections).filter(
+        section => showHiddenOnly === section.hidden
+      ).length,
+    [sections, showHiddenOnly]
+  );
+  const isLoadingDemoCard = totalSections === 0 && !demoPresetsAreLoaded;
   const primaryActions = React.useMemo(
     () => (preset ? buildPrimaryActions(preset) : []),
     [preset]
@@ -183,11 +191,15 @@ const DemoSectionCard: React.FC<DemoSectionCardProps> = ({
     }
   };
 
-  if (totalSections !== 0) {
+  if (numSections !== 0) {
     return null;
   }
 
-  if (!isEnabled || !preset) {
+  if (isLoadingDemoCard) {
+    return <Spinner size="large" />;
+  }
+
+  if (totalSections !== 0 || !preset) {
     return <EmptyHomepage showHiddenOnly={showHiddenOnly} />;
   }
 

--- a/apps/src/templates/studioHomepages/teacherHomepageV2/DemoSectionCard.tsx
+++ b/apps/src/templates/studioHomepages/teacherHomepageV2/DemoSectionCard.tsx
@@ -2,7 +2,7 @@ import Alert, {alertTypes} from '@code-dot-org/component-library/alert';
 import FontAwesomeV6Icon from '@code-dot-org/component-library/fontAwesomeV6Icon';
 import {IconButton as MuiIconButton, Typography} from '@mui/material';
 import React from 'react';
-import {generatePath, useNavigate} from 'react-router-dom';
+import {generatePath} from 'react-router-dom';
 
 import {EVENTS} from '@cdo/apps/metrics/AnalyticsConstants.js';
 import analyticsReporter from '@cdo/apps/metrics/AnalyticsReporter';
@@ -17,8 +17,8 @@ import {
   Section,
 } from '@cdo/apps/templates/teacherDashboard/types/teacherSectionTypes';
 import {
+  getBasePath,
   TEACHER_NAVIGATION_PATHS,
-  TEACHER_NAVIGATION_SECTIONS_URL,
 } from '@cdo/apps/templates/teacherNavigation/TeacherNavigationPaths';
 import {useAppDispatch, useAppSelector} from '@cdo/apps/util/reduxHooks';
 import i18n from '@cdo/locale';
@@ -76,7 +76,6 @@ const buildPrimaryActions = (preset: DemoPresetView): DemoAction[] => {
 
 const DemoSectionCard: React.FC<DemoSectionCardProps> = ({showHiddenOnly}) => {
   const dispatch = useAppDispatch();
-  const navigate = useNavigate();
   const [pendingPath, setPendingPath] = React.useState<string | null>(null);
   const [notice, setNotice] = React.useState<Notice | null>(null);
   const gradesTeaching = useAppSelector(
@@ -158,22 +157,11 @@ const DemoSectionCard: React.FC<DemoSectionCardProps> = ({showHiddenOnly}) => {
       if (!section) {
         return;
       }
-      const nextPath = path.includes(':sectionId')
-        ? generatePath(path, {sectionId: section.id.toString()})
-        : path.startsWith('/')
+      const nextPath = path.startsWith('/')
         ? path
-        : generatePath(
-            `${TEACHER_NAVIGATION_SECTIONS_URL}/:sectionId/${path}`,
-            {
-              sectionId: section.id.toString(),
-            }
-          );
+        : generatePath(getBasePath(path), {sectionId: section.id.toString()});
 
-      if (nextPath.startsWith('/')) {
-        window.location.assign(nextPath);
-      } else {
-        navigate(nextPath);
-      }
+      window.location.assign(nextPath);
     } catch (error) {
       if (error instanceof DemoSectionCreationError) {
         setNotice({

--- a/apps/src/templates/studioHomepages/teacherHomepageV2/TeacherHomepage.tsx
+++ b/apps/src/templates/studioHomepages/teacherHomepageV2/TeacherHomepage.tsx
@@ -23,10 +23,8 @@ import {
 import CoteacherInviteNotification from '../CoteacherInviteNotification';
 
 import DemoSectionCard from './DemoSectionCard';
-import {EmptyHomepage} from './EmptyHomepage';
 import {Header} from './Header';
 import OnboardingChecklist from './OnboardingChecklist';
-import {pickDemoType} from './pickDemoType';
 import {SectionList} from './SectionList';
 import TeacherHomepagePopups from './TeacherHomepagePopups';
 import TeacherPromotions from './TeacherPromotions';
@@ -43,11 +41,6 @@ interface TeacherHomepageProps {
 interface EssentialAiDependencyResponse {
   has_assigned_essential_ai_dependency: boolean;
 }
-
-type DemoSectionNotice = {
-  text: string;
-  type: 'warning' | 'danger';
-};
 
 const TeacherHomepage: React.FC<TeacherHomepageProps> = ({studioUrlPrefix}) => {
   const isMiniTutorialEnabled =
@@ -79,8 +72,6 @@ const TeacherHomepage: React.FC<TeacherHomepageProps> = ({studioUrlPrefix}) => {
   ] = React.useState<boolean>(false);
 
   const dispatch = useAppDispatch();
-  const [demoSectionNotice, setDemoSectionNotice] =
-    React.useState<DemoSectionNotice | null>(null);
 
   React.useEffect(() => {
     dispatch(asyncLoadTeacherHomepageSectionData());
@@ -213,26 +204,10 @@ const TeacherHomepage: React.FC<TeacherHomepageProps> = ({studioUrlPrefix}) => {
     React.useState<ArchivedToggleOption>('teaching');
 
   const sections = useAppSelector(state => state.teacherSections.sections);
-  const demoPresets = useAppSelector(
-    state => state.teacherSections.demoPresets
-  );
   const demoPresetsAreLoaded = useAppSelector(
     state => state.teacherSections.demoPresetsAreLoaded
   );
-  const gradesTeaching = useAppSelector(
-    state => state.currentUser.gradesTeaching
-  );
   const totalSections = Object.keys(sections).length;
-  const demoType = React.useMemo(
-    () => pickDemoType(gradesTeaching),
-    [gradesTeaching]
-  );
-  const selectedDemoPreset = demoPresets[demoType];
-  const shouldShowDemoSectionCard =
-    isDemoSectionEnabled &&
-    totalSections === 0 &&
-    demoPresetsAreLoaded &&
-    !!selectedDemoPreset;
 
   // The server uses hidden to mean the same thing as archived.
   const showHiddenOnly = selectedArchiveToggle === 'archived';
@@ -296,18 +271,6 @@ const TeacherHomepage: React.FC<TeacherHomepageProps> = ({studioUrlPrefix}) => {
                 }}
               />
             )}
-            {demoSectionNotice && (
-              <Alert
-                type={
-                  demoSectionNotice.type === 'warning'
-                    ? alertTypes.warning
-                    : alertTypes.danger
-                }
-                text={demoSectionNotice.text}
-                className={styles.notificationBanner}
-                onClose={() => setDemoSectionNotice(null)}
-              />
-            )}
             <Header
               selectedArchiveToggle={selectedArchiveToggle}
               setSelectedArchiveToggle={onArchiveToggleChange}
@@ -320,16 +283,11 @@ const TeacherHomepage: React.FC<TeacherHomepageProps> = ({studioUrlPrefix}) => {
             {!!isMiniTutorialEnabled && <OnboardingChecklist />}
             {isDemoSectionEnabled &&
             totalSections === 0 &&
-            !demoPresetsAreLoaded ? null : shouldShowDemoSectionCard ? (
-              <ul className={styles.sectionList}>
-                <DemoSectionCard
-                  demoType={demoType}
-                  onNotice={setDemoSectionNotice}
-                  preset={selectedDemoPreset!}
-                />
-              </ul>
-            ) : numSections === 0 ? (
-              <EmptyHomepage showHiddenOnly={showHiddenOnly} />
+            !demoPresetsAreLoaded ? null : numSections === 0 ? (
+              <DemoSectionCard
+                isEnabled={isDemoSectionEnabled}
+                showHiddenOnly={showHiddenOnly}
+              />
             ) : (
               <SectionList
                 showHiddenOnly={selectedArchiveToggle === 'archived'}

--- a/apps/src/templates/studioHomepages/teacherHomepageV2/TeacherHomepage.tsx
+++ b/apps/src/templates/studioHomepages/teacherHomepageV2/TeacherHomepage.tsx
@@ -7,6 +7,7 @@ import DCDO from '@cdo/apps/dcdo';
 import UserPreferences from '@cdo/apps/lib/util/UserPreferences';
 import {EVENTS} from '@cdo/apps/metrics/AnalyticsConstants.js';
 import analyticsReporter from '@cdo/apps/metrics/AnalyticsReporter';
+import Spinner from '@cdo/apps/sharedComponents/Spinner';
 import {detectNetworkAvailability} from '@cdo/apps/util/detectNetworkAvailability';
 import experiments from '@cdo/apps/util/experiments';
 import HttpClient from '@cdo/apps/util/HttpClient';
@@ -23,6 +24,7 @@ import {
 import CoteacherInviteNotification from '../CoteacherInviteNotification';
 
 import DemoSectionCard from './DemoSectionCard';
+import {EmptyHomepage} from './EmptyHomepage';
 import {Header} from './Header';
 import OnboardingChecklist from './OnboardingChecklist';
 import {SectionList} from './SectionList';
@@ -234,6 +236,8 @@ const TeacherHomepage: React.FC<TeacherHomepageProps> = ({studioUrlPrefix}) => {
     new UserPreferences().setHasDismissedPersonalizationAlert(true);
   };
 
+  const isLoadingDemoCard = totalSections === 0 && !demoPresetsAreLoaded;
+
   return (
     <div className={styles.teacherHomepage}>
       <div className={styles.teacherHomepageBody}>
@@ -281,13 +285,24 @@ const TeacherHomepage: React.FC<TeacherHomepageProps> = ({studioUrlPrefix}) => {
               destructiveLoad={true}
             />
             {!!isMiniTutorialEnabled && <OnboardingChecklist />}
-            {isDemoSectionEnabled &&
-            totalSections === 0 &&
-            !demoPresetsAreLoaded ? null : numSections === 0 ? (
-              <DemoSectionCard
-                isEnabled={isDemoSectionEnabled}
-                showHiddenOnly={showHiddenOnly}
-              />
+            {!isDemoSectionEnabled &&
+              (numSections === 0 ? (
+                <EmptyHomepage showHiddenOnly={showHiddenOnly} />
+              ) : (
+                <SectionList
+                  showHiddenOnly={selectedArchiveToggle === 'archived'}
+                  studioUrlPrefix={studioUrlPrefix}
+                />
+              ))}
+            {isDemoSectionEnabled && numSections === 0 ? (
+              isLoadingDemoCard ? (
+                <Spinner size="large" />
+              ) : (
+                <DemoSectionCard
+                  isEnabled={isDemoSectionEnabled}
+                  showHiddenOnly={showHiddenOnly}
+                />
+              )
             ) : (
               <SectionList
                 showHiddenOnly={selectedArchiveToggle === 'archived'}

--- a/apps/src/templates/studioHomepages/teacherHomepageV2/TeacherHomepage.tsx
+++ b/apps/src/templates/studioHomepages/teacherHomepageV2/TeacherHomepage.tsx
@@ -9,7 +9,6 @@ import {EVENTS} from '@cdo/apps/metrics/AnalyticsConstants.js';
 import analyticsReporter from '@cdo/apps/metrics/AnalyticsReporter';
 import {detectNetworkAvailability} from '@cdo/apps/util/detectNetworkAvailability';
 import experiments from '@cdo/apps/util/experiments';
-import HttpClient from '@cdo/apps/util/HttpClient';
 import {useAppDispatch, useAppSelector} from '@cdo/apps/util/reduxHooks';
 import {tryGetSessionStorage, trySetSessionStorage} from '@cdo/apps/utils';
 import {AiChatAccessLevels} from '@cdo/generated-scripts/sharedConstants';
@@ -18,12 +17,15 @@ import i18n from '@cdo/locale';
 import {
   asyncLoadTeacherHomepageSectionData,
   asyncLoadCoteacherInvite,
+  fetchDemoPresets,
 } from '../../teacherDashboard/teacherSectionsRedux';
 import CoteacherInviteNotification from '../CoteacherInviteNotification';
 
+import DemoSectionCard from './DemoSectionCard';
 import {EmptyHomepage} from './EmptyHomepage';
 import {Header} from './Header';
 import OnboardingChecklist from './OnboardingChecklist';
+import {pickDemoType} from './pickDemoType';
 import {SectionList} from './SectionList';
 import TeacherHomepagePopups from './TeacherHomepagePopups';
 import TeacherPromotions from './TeacherPromotions';
@@ -33,7 +35,6 @@ import styles from './teacherHomepage.module.scss';
 export type ArchivedToggleOption = 'teaching' | 'archived';
 
 const LOGGED_TEACHER_SESSION = 'logged_teacher_session';
-
 interface TeacherHomepageProps {
   studioUrlPrefix: string;
 }
@@ -42,10 +43,16 @@ interface EssentialAiDependencyResponse {
   has_assigned_essential_ai_dependency: boolean;
 }
 
+type DemoSectionNotice = {
+  text: string;
+  type: 'warning' | 'danger';
+};
+
 const TeacherHomepage: React.FC<TeacherHomepageProps> = ({studioUrlPrefix}) => {
   const isMiniTutorialEnabled =
     experiments.isEnabled(experiments.ONBOARDING) ||
     DCDO.get('onboarding-enabled', false);
+  const isDemoSectionEnabled = experiments.isEnabled('demo-section');
 
   const teacherName = useAppSelector(state => state.currentUser.displayName);
   const teacherId = useAppSelector(state => state.currentUser.userId);
@@ -71,9 +78,14 @@ const TeacherHomepage: React.FC<TeacherHomepageProps> = ({studioUrlPrefix}) => {
   ] = React.useState<boolean>(false);
 
   const dispatch = useAppDispatch();
+  const [demoSectionNotice, setDemoSectionNotice] =
+    React.useState<DemoSectionNotice | null>(null);
 
   React.useEffect(() => {
     dispatch(asyncLoadTeacherHomepageSectionData());
+    if (isDemoSectionEnabled) {
+      dispatch(fetchDemoPresets());
+    }
     dispatch(asyncLoadCoteacherInvite());
 
     // Fetch personalization alert dismissal status
@@ -112,7 +124,7 @@ const TeacherHomepage: React.FC<TeacherHomepageProps> = ({studioUrlPrefix}) => {
     };
 
     fetchTeachingProfileData();
-  }, [dispatch]);
+  }, [dispatch, isDemoSectionEnabled]);
 
   const aiChatAccessLevel = useAppSelector(
     state => state.currentUser.aiChatAccessLevel
@@ -200,6 +212,26 @@ const TeacherHomepage: React.FC<TeacherHomepageProps> = ({studioUrlPrefix}) => {
     React.useState<ArchivedToggleOption>('teaching');
 
   const sections = useAppSelector(state => state.teacherSections.sections);
+  const demoPresets = useAppSelector(
+    state => state.teacherSections.demoPresets
+  );
+  const demoPresetsAreLoaded = useAppSelector(
+    state => state.teacherSections.demoPresetsAreLoaded
+  );
+  const gradesTeaching = useAppSelector(
+    state => state.currentUser.gradesTeaching
+  );
+  const totalSections = Object.keys(sections).length;
+  const demoType = React.useMemo(
+    () => pickDemoType(gradesTeaching),
+    [gradesTeaching]
+  );
+  const selectedDemoPreset = demoPresets[demoType];
+  const shouldShowDemoSectionCard =
+    isDemoSectionEnabled &&
+    totalSections === 0 &&
+    demoPresetsAreLoaded &&
+    !!selectedDemoPreset;
 
   // The server uses hidden to mean the same thing as archived.
   const showHiddenOnly = selectedArchiveToggle === 'archived';
@@ -263,6 +295,18 @@ const TeacherHomepage: React.FC<TeacherHomepageProps> = ({studioUrlPrefix}) => {
                 }}
               />
             )}
+            {demoSectionNotice && (
+              <Alert
+                type={
+                  demoSectionNotice.type === 'warning'
+                    ? alertTypes.warning
+                    : alertTypes.danger
+                }
+                text={demoSectionNotice.text}
+                className={styles.notificationBanner}
+                onClose={() => setDemoSectionNotice(null)}
+              />
+            )}
             <Header
               selectedArchiveToggle={selectedArchiveToggle}
               setSelectedArchiveToggle={onArchiveToggleChange}
@@ -273,7 +317,17 @@ const TeacherHomepage: React.FC<TeacherHomepageProps> = ({studioUrlPrefix}) => {
               destructiveLoad={true}
             />
             {!!isMiniTutorialEnabled && <OnboardingChecklist />}
-            {numSections === 0 ? (
+            {isDemoSectionEnabled &&
+            totalSections === 0 &&
+            !demoPresetsAreLoaded ? null : shouldShowDemoSectionCard ? (
+              <ul className={styles.sectionList}>
+                <DemoSectionCard
+                  demoType={demoType}
+                  onNotice={setDemoSectionNotice}
+                  preset={selectedDemoPreset!}
+                />
+              </ul>
+            ) : numSections === 0 ? (
               <EmptyHomepage showHiddenOnly={showHiddenOnly} />
             ) : (
               <SectionList

--- a/apps/src/templates/studioHomepages/teacherHomepageV2/TeacherHomepage.tsx
+++ b/apps/src/templates/studioHomepages/teacherHomepageV2/TeacherHomepage.tsx
@@ -7,7 +7,6 @@ import DCDO from '@cdo/apps/dcdo';
 import UserPreferences from '@cdo/apps/lib/util/UserPreferences';
 import {EVENTS} from '@cdo/apps/metrics/AnalyticsConstants.js';
 import analyticsReporter from '@cdo/apps/metrics/AnalyticsReporter';
-import Spinner from '@cdo/apps/sharedComponents/Spinner';
 import {detectNetworkAvailability} from '@cdo/apps/util/detectNetworkAvailability';
 import experiments from '@cdo/apps/util/experiments';
 import HttpClient from '@cdo/apps/util/HttpClient';
@@ -206,10 +205,6 @@ const TeacherHomepage: React.FC<TeacherHomepageProps> = ({studioUrlPrefix}) => {
     React.useState<ArchivedToggleOption>('teaching');
 
   const sections = useAppSelector(state => state.teacherSections.sections);
-  const demoPresetsAreLoaded = useAppSelector(
-    state => state.teacherSections.demoPresetsAreLoaded
-  );
-  const totalSections = Object.keys(sections).length;
 
   // The server uses hidden to mean the same thing as archived.
   const showHiddenOnly = selectedArchiveToggle === 'archived';
@@ -235,8 +230,6 @@ const TeacherHomepage: React.FC<TeacherHomepageProps> = ({studioUrlPrefix}) => {
     setHasDismissedPersonalizationAlert(true);
     new UserPreferences().setHasDismissedPersonalizationAlert(true);
   };
-
-  const isLoadingDemoCard = totalSections === 0 && !demoPresetsAreLoaded;
 
   return (
     <div className={styles.teacherHomepage}>
@@ -285,27 +278,20 @@ const TeacherHomepage: React.FC<TeacherHomepageProps> = ({studioUrlPrefix}) => {
               destructiveLoad={true}
             />
             {!!isMiniTutorialEnabled && <OnboardingChecklist />}
-            {!isDemoSectionEnabled &&
-              (numSections === 0 ? (
+            {!isDemoSectionEnabled ? (
+              numSections === 0 ? (
                 <EmptyHomepage showHiddenOnly={showHiddenOnly} />
               ) : (
                 <SectionList
-                  showHiddenOnly={selectedArchiveToggle === 'archived'}
+                  showHiddenOnly={showHiddenOnly}
                   studioUrlPrefix={studioUrlPrefix}
                 />
-              ))}
-            {isDemoSectionEnabled && numSections === 0 ? (
-              isLoadingDemoCard ? (
-                <Spinner size="large" />
-              ) : (
-                <DemoSectionCard
-                  isEnabled={isDemoSectionEnabled}
-                  showHiddenOnly={showHiddenOnly}
-                />
               )
+            ) : numSections === 0 ? (
+              <DemoSectionCard showHiddenOnly={showHiddenOnly} />
             ) : (
               <SectionList
-                showHiddenOnly={selectedArchiveToggle === 'archived'}
+                showHiddenOnly={showHiddenOnly}
                 studioUrlPrefix={studioUrlPrefix}
               />
             )}

--- a/apps/src/templates/studioHomepages/teacherHomepageV2/TeacherHomepage.tsx
+++ b/apps/src/templates/studioHomepages/teacherHomepageV2/TeacherHomepage.tsx
@@ -9,6 +9,7 @@ import {EVENTS} from '@cdo/apps/metrics/AnalyticsConstants.js';
 import analyticsReporter from '@cdo/apps/metrics/AnalyticsReporter';
 import {detectNetworkAvailability} from '@cdo/apps/util/detectNetworkAvailability';
 import experiments from '@cdo/apps/util/experiments';
+import HttpClient from '@cdo/apps/util/HttpClient';
 import {useAppDispatch, useAppSelector} from '@cdo/apps/util/reduxHooks';
 import {tryGetSessionStorage, trySetSessionStorage} from '@cdo/apps/utils';
 import {AiChatAccessLevels} from '@cdo/generated-scripts/sharedConstants';

--- a/apps/src/templates/studioHomepages/teacherHomepageV2/TeacherPromotions.tsx
+++ b/apps/src/templates/studioHomepages/teacherHomepageV2/TeacherPromotions.tsx
@@ -67,7 +67,9 @@ const TeacherPromotions: React.FC = () => {
     HttpClient.fetchJson<ServerPromotion[]>(TEACHER_PROMOTION_URL)
       .then(response => response?.value)
       .then(data => {
-        setUnfilteredPromotions(data.map(serverPromotionConverter));
+        setUnfilteredPromotions(
+          Array.isArray(data) ? data.map(serverPromotionConverter) : []
+        );
         setIsLoading(false);
       })
       .catch(error => {

--- a/apps/src/templates/teacherDashboard/teacherSectionsRedux.ts
+++ b/apps/src/templates/teacherDashboard/teacherSectionsRedux.ts
@@ -962,6 +962,7 @@ export const fetchDemoPresets =
       return demoPresets;
     } catch (error) {
       console.error('Error fetching demo section presets:', error);
+      dispatch(setDemoPresetsLoaded(true));
       return {};
     }
   };

--- a/apps/test/unit/templates/studioHomepages/teacherHomepageV2/TeacherHomepageTest.tsx
+++ b/apps/test/unit/templates/studioHomepages/teacherHomepageV2/TeacherHomepageTest.tsx
@@ -280,6 +280,18 @@ describe('TeacherHomepage', () => {
     screen.getByText('Demo');
   }, 10000);
 
+  it('falls back to the empty homepage when the demo section is disabled', async () => {
+    experiments.isEnabled = jest.fn(() => false);
+
+    renderComponent([]);
+
+    await screen.findByText(i18n.emptySectionHeadline());
+
+    expect(screen.queryByText('High School Practice Section')).toBeNull();
+    screen.getByText(i18n.emptySectionHeadline());
+    screen.getByText(i18n.emptyClassSections());
+  });
+
   it('falls back to the empty homepage when demo presets fail to load', async () => {
     fetchSpy.mockImplementation((url: string) => {
       if (url === '/api/v1/sections/demo/presets') {

--- a/apps/test/unit/templates/studioHomepages/teacherHomepageV2/TeacherHomepageTest.tsx
+++ b/apps/test/unit/templates/studioHomepages/teacherHomepageV2/TeacherHomepageTest.tsx
@@ -394,6 +394,50 @@ describe('TeacherHomepage', () => {
     screen.getByText('You haven’t archived any class sections yet.');
   });
 
+  it('shows the teaching empty state instead of the demo card when only archived sections exist', async () => {
+    fetchSpy.mockImplementation((url: string) => {
+      if (url === '/api/v1/sections/demo/presets') {
+        return Promise.resolve({
+          value: {
+            high: {
+              demo_type: 'high',
+              section_name: 'High School Practice Section',
+              avatar_color: 8,
+              avatar_emoji: 5,
+              login_type: 'email',
+              participant_type: 'student',
+              unit: {
+                name: 'aif2-2025',
+                display_name: 'Artificial Intelligence Foundations',
+              },
+              unit_group: {
+                name: 'artificial-intelligence-foundations-2025',
+                display_name: 'Artificial Intelligence Foundations',
+              },
+            },
+          },
+          response: new Response(),
+        });
+      }
+
+      if (url === '/dashboardapi/sections/available_participant_types') {
+        return Promise.resolve({
+          value: {availableParticipantTypes: ['student']},
+          response: new Response(),
+        });
+      }
+
+      return Promise.resolve({value: {}, response: new Response()});
+    });
+
+    renderComponent([serverSections.find(section => section.id === 15)!]);
+    await act(async () => await new Promise(process.nextTick));
+
+    expect(screen.queryByText('High School Practice Section')).toBeNull();
+    screen.getByText("It's a bit empty here...");
+    screen.getByText('You haven’t created any class sections yet.');
+  });
+
   it('displays coteacher invite notification', async () => {
     renderComponent();
     await act(async () => await new Promise(process.nextTick));

--- a/apps/test/unit/templates/studioHomepages/teacherHomepageV2/TeacherHomepageTest.tsx
+++ b/apps/test/unit/templates/studioHomepages/teacherHomepageV2/TeacherHomepageTest.tsx
@@ -29,6 +29,7 @@ import {TEACHER_NAVIGATION_PATHS} from '@cdo/apps/templates/teacherNavigation/Te
 import experiments from '@cdo/apps/util/experiments';
 import HttpClient from '@cdo/apps/util/HttpClient';
 import {trySetSessionStorage} from '@cdo/apps/utils';
+import i18n from '@cdo/locale';
 
 const INITIAL_ROUTE = '/teacher_dashboard/home';
 
@@ -88,6 +89,9 @@ describe('TeacherHomepage', () => {
   const serverSections = sections.map(serverSectionFromSection);
 
   let fetchSpy: jest.SpyInstance;
+  let originalFetch:
+    | ((input: RequestInfo | URL, init?: RequestInit) => Promise<Response>)
+    | undefined;
   let sendEventSpy: jest.SpyInstance;
   let jquerySpy: jest.SpyInstance;
   let postSpy: jest.SpyInstance;
@@ -95,6 +99,12 @@ describe('TeacherHomepage', () => {
 
   beforeEach(() => {
     fetchSpy = jest.spyOn(HttpClient, 'fetchJson');
+    originalFetch = (globalThis as {fetch?: typeof originalFetch}).fetch;
+    (globalThis as unknown as {fetch?: jest.Mock}).fetch = jest
+      .fn()
+      .mockResolvedValue({
+        json: () => Promise.resolve({data: {matchedPersona: true}}),
+      } as Response);
     postSpy = jest.spyOn(HttpClient, 'post');
     sendEventSpy = jest
       .spyOn(analyticsReporter, 'sendEvent')
@@ -124,6 +134,10 @@ describe('TeacherHomepage', () => {
           },
           response: new Response(),
         });
+      } else if (
+        url.match(/^\/sections\/\d+\/retrieve_lessons_for_dropdown$/)
+      ) {
+        return Promise.resolve({value: [], response: new Response()});
       }
       return Promise.resolve({value: {}, response: new Response()});
     });
@@ -161,6 +175,7 @@ describe('TeacherHomepage', () => {
   });
 
   afterEach(() => {
+    (globalThis as {fetch?: typeof originalFetch}).fetch = originalFetch;
     jest.restoreAllMocks();
     experiments.isEnabled = realIsEnabled;
     restoreRedux();
@@ -260,12 +275,10 @@ describe('TeacherHomepage', () => {
     });
 
     renderComponent([]);
-    await act(async () => await new Promise(process.nextTick));
-
-    screen.getByText('High School Practice Section');
+    await screen.findByText('High School Practice Section');
     screen.getByText(/DEMO-123/);
     screen.getByText('Demo');
-  });
+  }, 10000);
 
   it('falls back to the empty homepage when demo presets fail to load', async () => {
     fetchSpy.mockImplementation((url: string) => {
@@ -285,12 +298,11 @@ describe('TeacherHomepage', () => {
     jest.spyOn(console, 'error').mockImplementation(() => {});
 
     renderComponent([]);
-    await act(async () => await new Promise(process.nextTick));
+    await screen.findByText(i18n.emptySectionHeadline());
 
-    expect(
-      screen.queryByText('High School Practice Section')
-    ).not.toBeInTheDocument();
-    screen.getByText('No sections yet');
+    expect(screen.queryByText('High School Practice Section')).toBeNull();
+    screen.getByText(i18n.emptySectionHeadline());
+    screen.getByText(i18n.emptyClassSections());
   });
 
   it('create section button opens popup', async () => {

--- a/apps/test/unit/templates/studioHomepages/teacherHomepageV2/TeacherHomepageTest.tsx
+++ b/apps/test/unit/templates/studioHomepages/teacherHomepageV2/TeacherHomepageTest.tsx
@@ -278,7 +278,7 @@ describe('TeacherHomepage', () => {
     await screen.findByText('High School Practice Section');
     screen.getByText(/DEMO-123/);
     screen.getByText('Demo');
-  }, 10000);
+  });
 
   it('falls back to the empty homepage when the demo section is disabled', async () => {
     experiments.isEnabled = jest.fn(() => false);

--- a/apps/test/unit/templates/studioHomepages/teacherHomepageV2/TeacherHomepageTest.tsx
+++ b/apps/test/unit/templates/studioHomepages/teacherHomepageV2/TeacherHomepageTest.tsx
@@ -26,6 +26,7 @@ import teacherSections, {
 } from '@cdo/apps/templates/teacherDashboard/teacherSectionsRedux';
 import {serverSectionFromSection} from '@cdo/apps/templates/teacherDashboard/teacherSectionsReduxSelectors';
 import {TEACHER_NAVIGATION_PATHS} from '@cdo/apps/templates/teacherNavigation/TeacherNavigationPaths';
+import experiments from '@cdo/apps/util/experiments';
 import HttpClient from '@cdo/apps/util/HttpClient';
 import {trySetSessionStorage} from '@cdo/apps/utils';
 
@@ -90,6 +91,7 @@ describe('TeacherHomepage', () => {
   let sendEventSpy: jest.SpyInstance;
   let jquerySpy: jest.SpyInstance;
   let postSpy: jest.SpyInstance;
+  let realIsEnabled: typeof experiments.isEnabled;
 
   beforeEach(() => {
     fetchSpy = jest.spyOn(HttpClient, 'fetchJson');
@@ -98,6 +100,8 @@ describe('TeacherHomepage', () => {
       .spyOn(analyticsReporter, 'sendEvent')
       .mockImplementation(() => {});
     jquerySpy = jest.spyOn($, 'getJSON');
+    realIsEnabled = experiments.isEnabled;
+    experiments.isEnabled = jest.fn((key: string) => key === 'demo-section');
     stubRedux();
     fetchSpy.mockImplementation((url: string) => {
       if (url === '/dashboardapi/sections/available_participant_types') {
@@ -158,13 +162,20 @@ describe('TeacherHomepage', () => {
 
   afterEach(() => {
     jest.restoreAllMocks();
+    experiments.isEnabled = realIsEnabled;
     restoreRedux();
   });
 
   function renderComponent(initialSections = serverSections) {
     const store = getStore();
     registerReducers({teacherSections, currentUser});
-    store.dispatch(setInitialData({id: 1, display_name: 'Rubber Ducky'}));
+    store.dispatch(
+      setInitialData({
+        id: 1,
+        display_name: 'Rubber Ducky',
+        grades_teaching: ['9', '10'],
+      })
+    );
     store.dispatch(setSections(initialSections));
     return render(
       <Provider store={store}>
@@ -210,6 +221,76 @@ describe('TeacherHomepage', () => {
     screen.getByText('Class Sections');
     screen.getByText('Period 1');
     screen.getByText('Period 4');
+  });
+
+  it('renders the demo section card for zero-section teachers', async () => {
+    fetchSpy.mockImplementation((url: string) => {
+      if (url === '/api/v1/sections/demo/presets') {
+        return Promise.resolve({
+          value: {
+            high: {
+              demo_type: 'high',
+              section_name: 'High School Practice Section',
+              avatar_color: 8,
+              avatar_emoji: 5,
+              login_type: 'email',
+              participant_type: 'student',
+              unit: {
+                name: 'aif2-2025',
+                display_name: 'Artificial Intelligence Foundations',
+              },
+              unit_group: {
+                name: 'artificial-intelligence-foundations-2025',
+                display_name: 'Artificial Intelligence Foundations',
+              },
+            },
+          },
+          response: new Response(),
+        });
+      }
+
+      if (url === '/dashboardapi/sections/available_participant_types') {
+        return Promise.resolve({
+          value: {availableParticipantTypes: ['student']},
+          response: new Response(),
+        });
+      }
+
+      return Promise.resolve({value: {}, response: new Response()});
+    });
+
+    renderComponent([]);
+    await act(async () => await new Promise(process.nextTick));
+
+    screen.getByText('High School Practice Section');
+    screen.getByText(/DEMO-123/);
+    screen.getByText('Demo');
+  });
+
+  it('falls back to the empty homepage when demo presets fail to load', async () => {
+    fetchSpy.mockImplementation((url: string) => {
+      if (url === '/api/v1/sections/demo/presets') {
+        return Promise.reject(new Error('presets failed'));
+      }
+
+      if (url === '/dashboardapi/sections/available_participant_types') {
+        return Promise.resolve({
+          value: {availableParticipantTypes: ['student']},
+          response: new Response(),
+        });
+      }
+
+      return Promise.resolve({value: {}, response: new Response()});
+    });
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    renderComponent([]);
+    await act(async () => await new Promise(process.nextTick));
+
+    expect(
+      screen.queryByText('High School Practice Section')
+    ).not.toBeInTheDocument();
+    screen.getByText('No sections yet');
   });
 
   it('create section button opens popup', async () => {

--- a/apps/test/unit/templates/teacherDashboard/teacherSectionsReduxTest.js
+++ b/apps/test/unit/templates/teacherDashboard/teacherSectionsReduxTest.js
@@ -2128,7 +2128,7 @@ describe('teacherSectionsRedux', () => {
       });
     });
 
-    it('logs preset fetch failures and hides the card data', async () => {
+    it('logs preset fetch failures and marks presets as loaded', async () => {
       const consoleErrorStub = sinon.stub(console, 'error');
       try {
         fetchSpy.rejects(new Error('presets failed'));
@@ -2136,7 +2136,7 @@ describe('teacherSectionsRedux', () => {
         await store.dispatch(fetchDemoPresets());
 
         assert.deepEqual(getState().teacherSections.demoPresets, {});
-        expect(getState().teacherSections.demoPresetsAreLoaded).to.be.false;
+        expect(getState().teacherSections.demoPresetsAreLoaded).to.be.true;
         expect(consoleErrorStub).to.have.been.calledOnce;
       } finally {
         consoleErrorStub.restore();

--- a/config.yml.erb
+++ b/config.yml.erb
@@ -719,7 +719,8 @@ hoc_tracking_enabled: true
 
 # Demo student IDs for demo sections. See Policies::DemoSections for usage.
 demo_student_ids:
+demo_section_unit_name:
+demo_section_unit_group_name:
 
 # Dummy course for attaching resources to just-in-time PL content
 jit_pl_course_name: 'just-in-time-pl'
-

--- a/config/adhoc.yml.erb
+++ b/config/adhoc.yml.erb
@@ -37,6 +37,8 @@ db_credential_writer: !StackSecret
 db_credential_reader: !StackSecret
 
 demo_student_ids:
+demo_section_unit_name: !StackSecret
+demo_section_unit_group_name: !StackSecret
 
 openai_student_learning_api_key: !Secret
 

--- a/dashboard/app/controllers/api/v1/sections_controller.rb
+++ b/dashboard/app/controllers/api/v1/sections_controller.rb
@@ -157,8 +157,6 @@ class Api::V1::SectionsController < Api::V1::JSONApiController
     authorize! :create, Section
 
     preset_views = Policies::DemoSections.preset_views_for_all_types
-    return head :not_found if preset_views.empty?
-
     render json: preset_views
   end
 

--- a/dashboard/lib/policies/demo_sections.rb
+++ b/dashboard/lib/policies/demo_sections.rb
@@ -10,9 +10,7 @@ class Policies::DemoSections
       participant_type: 'student',
       grades: %w[K 1 2 3 4 5],
       unit_name: 'k5-ai-data-2024',
-      unit_display_name: 'AI and Data',
       unit_group_name: 'k5-ai-data-2024',
-      unit_group_display_name: 'AI and Data',
       # Purple cat: COLORS[2] = Purple, EMOJIS[10] = 😺
       avatar_color: 2,
       avatar_emoji: 10,
@@ -25,9 +23,7 @@ class Policies::DemoSections
       participant_type: 'student',
       grades: %w[6 7 8],
       unit_name: 'csd3-2024',
-      unit_display_name: 'Interactive Animations and Games',
       unit_group_name: 'csd-2024',
-      unit_group_display_name: 'CS Discoveries',
       # Pink fire: COLORS[1] = Pink, EMOJIS[0] = 🔥
       avatar_color: 1,
       avatar_emoji: 0,
@@ -40,9 +36,7 @@ class Policies::DemoSections
       participant_type: 'student',
       grades: %w[9 10 11 12],
       unit_name: 'aif2-2025',
-      unit_display_name: 'Artificial Intelligence Foundations',
       unit_group_name: 'artificial-intelligence-foundations-2025',
-      unit_group_display_name: 'Artificial Intelligence Foundations',
       # Green robot: COLORS[8] = Green, EMOJIS[5] = 🤖
       avatar_color: 8,
       avatar_emoji: 5,
@@ -65,7 +59,10 @@ class Policies::DemoSections
     return nil unless preset
 
     unit = resolve_unit(preset[:unit_name])
-    unit_group = resolve_unit_group(preset[:unit_group_name])
+    return nil unless unit
+
+    unit_group = resolve_unit_group(unit)
+    return nil unless unit_group
 
     {
       demo_type: demo_type.to_s,
@@ -74,16 +71,14 @@ class Policies::DemoSections
       avatar_emoji: preset[:avatar_emoji],
       login_type: preset[:login_type],
       participant_type: preset[:participant_type],
-      unit: build_unit_view(
-        unit: unit,
-        name: preset[:unit_name],
-        display_name: preset[:unit_display_name]
-      ),
-      unit_group: build_unit_group_view(
-        unit_group: unit_group,
-        name: preset[:unit_group_name],
-        display_name: preset[:unit_group_display_name]
-      ),
+      unit: {
+        name: unit.name,
+        display_name: unit.localized_title,
+      },
+      unit_group: {
+        name: unit_group.name,
+        display_name: unit_group.localized_title,
+      },
     }
   end
 
@@ -109,33 +104,12 @@ class Policies::DemoSections
   def self.resolve_unit(unit_name)
     return nil if unit_name.blank?
 
-    Unit.get_from_cache(unit_name, raise_exceptions: false)
+    Unit.find_by(name: unit_name)
   end
 
-  def self.resolve_unit_group(unit_group_name)
-    return nil if unit_group_name.blank?
-
-    UnitGroup.get_from_cache(unit_group_name)
+  def self.resolve_unit_group(unit)
+    unit&.get_original_unit_group
   end
 
-  def self.build_unit_view(unit:, name:, display_name:)
-    return nil if name.blank?
-
-    {
-      name: name,
-      display_name: unit&.localized_title || display_name,
-    }
-  end
-
-  def self.build_unit_group_view(unit_group:, name:, display_name:)
-    return nil if name.blank?
-
-    {
-      name: name,
-      display_name: unit_group&.localized_title || display_name,
-    }
-  end
-
-  private_class_method :resolve_unit, :resolve_unit_group,
-    :build_unit_view, :build_unit_group_view
+  private_class_method :resolve_unit, :resolve_unit_group
 end

--- a/dashboard/lib/policies/demo_sections.rb
+++ b/dashboard/lib/policies/demo_sections.rb
@@ -2,6 +2,8 @@
 
 class Policies::DemoSections
   DEMO_TYPES = %i[high middle elementary].freeze
+  DRONE_UNIT_NAME = 'allthethings'
+  DRONE_UNIT_GROUP_NAME = 'original-allthethings-course'
 
   DEMO_SECTION_PRESETS = {
     elementary: {
@@ -46,7 +48,10 @@ class Policies::DemoSections
   }.freeze
 
   def self.get_preset(demo_type)
-    DEMO_SECTION_PRESETS[demo_type.to_sym]
+    preset = DEMO_SECTION_PRESETS[demo_type.to_sym]
+    return nil unless preset
+
+    preset.merge(curriculum_names(preset))
   end
 
   def self.demo_student_ids(demo_type)
@@ -113,5 +118,26 @@ class Policies::DemoSections
     UnitGroup.get_from_cache(unit_group_name)
   end
 
-  private_class_method :resolve_unit, :resolve_unit_group
+  def self.curriculum_names(preset)
+    if CDO.rack_env?(:adhoc)
+      return {
+        unit_name: CDO.demo_section_unit_name,
+        unit_group_name: CDO.demo_section_unit_group_name,
+      }
+    end
+
+    if CDO.ci_webserver?
+      return {
+        unit_name: DRONE_UNIT_NAME,
+        unit_group_name: DRONE_UNIT_GROUP_NAME,
+      }
+    end
+
+    {
+      unit_name: preset[:unit_name],
+      unit_group_name: preset[:unit_group_name],
+    }
+  end
+
+  private_class_method :resolve_unit, :resolve_unit_group, :curriculum_names
 end

--- a/dashboard/lib/policies/demo_sections.rb
+++ b/dashboard/lib/policies/demo_sections.rb
@@ -10,7 +10,9 @@ class Policies::DemoSections
       participant_type: 'student',
       grades: %w[K 1 2 3 4 5],
       unit_name: 'k5-ai-data-2024',
+      unit_display_name: 'AI and Data',
       unit_group_name: 'k5-ai-data-2024',
+      unit_group_display_name: 'AI and Data',
       # Purple cat: COLORS[2] = Purple, EMOJIS[10] = 😺
       avatar_color: 2,
       avatar_emoji: 10,
@@ -23,7 +25,9 @@ class Policies::DemoSections
       participant_type: 'student',
       grades: %w[6 7 8],
       unit_name: 'csd3-2024',
+      unit_display_name: 'Interactive Animations and Games',
       unit_group_name: 'csd-2024',
+      unit_group_display_name: 'CS Discoveries',
       # Pink fire: COLORS[1] = Pink, EMOJIS[0] = 🔥
       avatar_color: 1,
       avatar_emoji: 0,
@@ -36,7 +40,9 @@ class Policies::DemoSections
       participant_type: 'student',
       grades: %w[9 10 11 12],
       unit_name: 'aif2-2025',
+      unit_display_name: 'Artificial Intelligence Foundations',
       unit_group_name: 'artificial-intelligence-foundations-2025',
+      unit_group_display_name: 'Artificial Intelligence Foundations',
       # Green robot: COLORS[8] = Green, EMOJIS[5] = 🤖
       avatar_color: 8,
       avatar_emoji: 5,
@@ -60,8 +66,6 @@ class Policies::DemoSections
 
     unit = resolve_unit(preset[:unit_name])
     unit_group = resolve_unit_group(preset[:unit_group_name])
-    return nil if preset[:unit_name].present? && unit.nil?
-    return nil if preset[:unit_group_name].present? && unit_group.nil?
 
     {
       demo_type: demo_type.to_s,
@@ -70,11 +74,16 @@ class Policies::DemoSections
       avatar_emoji: preset[:avatar_emoji],
       login_type: preset[:login_type],
       participant_type: preset[:participant_type],
-      unit: unit && {name: unit.name, display_name: unit.localized_title},
-      unit_group: unit_group && {
-        name: unit_group.name,
-        display_name: unit_group.localized_title,
-      },
+      unit: build_unit_view(
+        unit: unit,
+        name: preset[:unit_name],
+        display_name: preset[:unit_display_name]
+      ),
+      unit_group: build_unit_group_view(
+        unit_group: unit_group,
+        name: preset[:unit_group_name],
+        display_name: preset[:unit_group_display_name]
+      ),
     }
   end
 
@@ -109,5 +118,24 @@ class Policies::DemoSections
     UnitGroup.get_from_cache(unit_group_name)
   end
 
-  private_class_method :resolve_unit, :resolve_unit_group
+  def self.build_unit_view(unit:, name:, display_name:)
+    return nil if name.blank?
+
+    {
+      name: name,
+      display_name: unit&.localized_title || display_name,
+    }
+  end
+
+  def self.build_unit_group_view(unit_group:, name:, display_name:)
+    return nil if name.blank?
+
+    {
+      name: name,
+      display_name: unit_group&.localized_title || display_name,
+    }
+  end
+
+  private_class_method :resolve_unit, :resolve_unit_group,
+    :build_unit_view, :build_unit_group_view
 end

--- a/dashboard/lib/policies/demo_sections.rb
+++ b/dashboard/lib/policies/demo_sections.rb
@@ -61,7 +61,7 @@ class Policies::DemoSections
     unit = resolve_unit(preset[:unit_name])
     return nil unless unit
 
-    unit_group = resolve_unit_group(unit)
+    unit_group = resolve_unit_group(preset[:unit_group_name])
     return nil unless unit_group
 
     {
@@ -107,8 +107,10 @@ class Policies::DemoSections
     Unit.find_by(name: unit_name)
   end
 
-  def self.resolve_unit_group(unit)
-    unit&.get_original_unit_group
+  def self.resolve_unit_group(unit_group_name)
+    return nil if unit_group_name.blank?
+
+    UnitGroup.find_by(name: unit_group_name)
   end
 
   private_class_method :resolve_unit, :resolve_unit_group

--- a/dashboard/lib/policies/demo_sections.rb
+++ b/dashboard/lib/policies/demo_sections.rb
@@ -104,13 +104,13 @@ class Policies::DemoSections
   def self.resolve_unit(unit_name)
     return nil if unit_name.blank?
 
-    Unit.find_by(name: unit_name)
+    Unit.get_from_cache(unit_name, raise_exceptions: false)
   end
 
   def self.resolve_unit_group(unit_group_name)
     return nil if unit_group_name.blank?
 
-    UnitGroup.find_by(name: unit_group_name)
+    UnitGroup.get_from_cache(unit_group_name)
   end
 
   private_class_method :resolve_unit, :resolve_unit_group

--- a/dashboard/test/controllers/api/v1/sections_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/sections_controller_test.rb
@@ -1714,19 +1714,55 @@ class Api::V1::SectionsControllerTest < ActionController::TestCase
 
   test 'presets: returns the preset projections' do
     sign_in @teacher
-    create(:unit, name: 'aif2-2025')
-    create(:unit, name: 'csd3-2024')
-    create(:unit, name: 'k5-ai-data-2024')
-    create(:unit_group, name: 'artificial-intelligence-foundations-2025')
-    create(:unit_group, name: 'csd-2024')
-    create(:unit_group, name: 'k5-ai-data-2024')
+    high_unit = create(:unit, name: 'fake-high-unit')
+    middle_unit = create(:unit, name: 'fake-middle-unit')
+    high_unit_group = create(:unit_group, name: 'fake-high-course')
+    middle_unit_group = create(:unit_group, name: 'fake-middle-course')
+    create(:unit_group_unit, unit_group: high_unit_group, script: high_unit, position: 1)
+    create(:unit_group_unit, unit_group: middle_unit_group, script: middle_unit, position: 1)
+    Policies::DemoSections.stubs(:preset_views_for_all_types).returns(
+      {
+        high: {
+          demo_type: 'high',
+          section_name: 'Fake High Practice Section',
+          avatar_color: 8,
+          avatar_emoji: 5,
+          login_type: 'email',
+          participant_type: 'student',
+          unit: {
+            name: high_unit.name,
+            display_name: high_unit.localized_title,
+          },
+          unit_group: {
+            name: high_unit_group.name,
+            display_name: high_unit_group.localized_title,
+          },
+        },
+        middle: {
+          demo_type: 'middle',
+          section_name: 'Fake Middle Practice Section',
+          avatar_color: 1,
+          avatar_emoji: 0,
+          login_type: 'word',
+          participant_type: 'student',
+          unit: {
+            name: middle_unit.name,
+            display_name: middle_unit.localized_title,
+          },
+          unit_group: {
+            name: middle_unit_group.name,
+            display_name: middle_unit_group.localized_title,
+          },
+        },
+      }
+    )
 
     get :presets
 
     assert_response :success
     response = JSON.parse(@response.body)
-    assert_equal 'High School Practice Section', response['high']['section_name']
-    assert_equal 'aif2-2025', response['high']['unit']['name']
+    assert_equal 'Fake High Practice Section', response['high']['section_name']
+    assert_equal high_unit.name, response['high']['unit']['name']
     assert_equal 'student', response['middle']['participant_type']
   end
 

--- a/dashboard/test/controllers/api/v1/sections_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/sections_controller_test.rb
@@ -1766,13 +1766,14 @@ class Api::V1::SectionsControllerTest < ActionController::TestCase
     assert_equal 'student', response['middle']['participant_type']
   end
 
-  test 'presets: returns not_found when no preset can be projected' do
+  test 'presets: returns an empty response when no preset can be projected' do
     sign_in @teacher
     Policies::DemoSections.stubs(:preset_views_for_all_types).returns({})
 
     get :presets
 
-    assert_response :not_found
+    assert_response :success
+    assert_equal({}, JSON.parse(@response.body))
   end
 
   private def stub_demo_preset

--- a/dashboard/test/lib/policies/demo_sections_test.rb
+++ b/dashboard/test/lib/policies/demo_sections_test.rb
@@ -85,7 +85,6 @@ class Policies::DemoSectionsTest < ActiveSupport::TestCase
   test 'preset_view returns a display projection for a valid preset' do
     unit = create(:unit, name: 'aif2-2025')
     unit_group = create(:unit_group, name: 'artificial-intelligence-foundations-2025')
-    create(:unit_group_unit, unit_group: unit_group, script: unit, position: 1)
 
     view = Policies::DemoSections.preset_view(:high)
 
@@ -106,7 +105,7 @@ class Policies::DemoSectionsTest < ActiveSupport::TestCase
     assert_nil Policies::DemoSections.preset_view(:high)
   end
 
-  test 'preset_view returns nil when the unit has no original unit group' do
+  test 'preset_view returns nil when the unit group cannot be resolved' do
     create(:unit, name: 'aif2-2025')
 
     assert_nil Policies::DemoSections.preset_view(:high)

--- a/dashboard/test/lib/policies/demo_sections_test.rb
+++ b/dashboard/test/lib/policies/demo_sections_test.rb
@@ -101,10 +101,20 @@ class Policies::DemoSectionsTest < ActiveSupport::TestCase
     )
   end
 
-  test 'preset_view returns nil when a configured unit cannot be resolved' do
+  test 'preset_view falls back to configured metadata when a unit cannot be resolved' do
     Unit.expects(:get_from_cache).with('aif2-2025', raise_exceptions: false).returns(nil)
+    unit_group = create(:unit_group, name: 'artificial-intelligence-foundations-2025')
 
-    assert_nil Policies::DemoSections.preset_view(:high)
+    view = Policies::DemoSections.preset_view(:high)
+
+    assert_equal(
+      {
+        name: 'aif2-2025',
+        display_name: 'Artificial Intelligence Foundations',
+      },
+      view[:unit]
+    )
+    assert_equal unit_group.name, view[:unit_group][:name]
   end
 
   test 'preset_views_for_all_types skips misconfigured presets' do

--- a/dashboard/test/lib/policies/demo_sections_test.rb
+++ b/dashboard/test/lib/policies/demo_sections_test.rb
@@ -85,6 +85,7 @@ class Policies::DemoSectionsTest < ActiveSupport::TestCase
   test 'preset_view returns a display projection for a valid preset' do
     unit = create(:unit, name: 'aif2-2025')
     unit_group = create(:unit_group, name: 'artificial-intelligence-foundations-2025')
+    create(:unit_group_unit, unit_group: unit_group, script: unit, position: 1)
 
     view = Policies::DemoSections.preset_view(:high)
 
@@ -101,20 +102,14 @@ class Policies::DemoSectionsTest < ActiveSupport::TestCase
     )
   end
 
-  test 'preset_view falls back to configured metadata when a unit cannot be resolved' do
-    Unit.expects(:get_from_cache).with('aif2-2025', raise_exceptions: false).returns(nil)
-    unit_group = create(:unit_group, name: 'artificial-intelligence-foundations-2025')
+  test 'preset_view returns nil when the unit cannot be resolved' do
+    assert_nil Policies::DemoSections.preset_view(:high)
+  end
 
-    view = Policies::DemoSections.preset_view(:high)
+  test 'preset_view returns nil when the unit has no original unit group' do
+    create(:unit, name: 'aif2-2025')
 
-    assert_equal(
-      {
-        name: 'aif2-2025',
-        display_name: 'Artificial Intelligence Foundations',
-      },
-      view[:unit]
-    )
-    assert_equal unit_group.name, view[:unit_group][:name]
+    assert_nil Policies::DemoSections.preset_view(:high)
   end
 
   test 'preset_views_for_all_types skips misconfigured presets' do

--- a/dashboard/test/lib/policies/demo_sections_test.rb
+++ b/dashboard/test/lib/policies/demo_sections_test.rb
@@ -61,6 +61,27 @@ class Policies::DemoSectionsTest < ActiveSupport::TestCase
     assert_equal 'artificial-intelligence-foundations-2025', preset[:unit_group_name]
   end
 
+  test 'get_preset uses drone curriculum names on ci webserver' do
+    CDO.stubs(:ci_webserver?).returns(true)
+
+    preset = Policies::DemoSections.get_preset(:high)
+
+    assert_equal 'allthethings', preset[:unit_name]
+    assert_equal 'original-allthethings-course', preset[:unit_group_name]
+  end
+
+  test 'get_preset uses adhoc curriculum names from config' do
+    CDO.stubs(:rack_env?).returns(false)
+    CDO.stubs(:rack_env?).with(:adhoc).returns(true)
+    CDO.stubs(:demo_section_unit_name).returns('adhoc-unit')
+    CDO.stubs(:demo_section_unit_group_name).returns('adhoc-course')
+
+    preset = Policies::DemoSections.get_preset(:high)
+
+    assert_equal 'adhoc-unit', preset[:unit_name]
+    assert_equal 'adhoc-course', preset[:unit_group_name]
+  end
+
   test 'get_preset returns preset for each demo type' do
     Policies::DemoSections::DEMO_TYPES.each do |type|
       preset = Policies::DemoSections.get_preset(type)

--- a/dashboard/test/ui/features/teacher_tools/teacher_dashboard/demo_section_card.feature
+++ b/dashboard/test/ui/features/teacher_tools/teacher_dashboard/demo_section_card.feature
@@ -7,7 +7,9 @@ Feature: Demo section card on the teacher homepage
     Then I wait until element "#ui-test-demo-section-card" is visible
     And element "#ui-test-demo-section-card" contains text "High School Practice Section"
     And element "#ui-test-demo-section-card" contains text "Demo"
-    And element "#ui-test-demo-section-card" contains text "Computing Careers"
+    When I press "go-to-lesson-dropdown-button"
+    Then I wait until element "#go-to-lesson-dropdown" is open
+    And I wait until element "#go-to-lesson-dropdown li" is visible
     When I click "#ui-test-demo-section-action-progress" once it exists
     Then I wait until current URL contains "/teacher_dashboard/sections/"
     And I wait until current URL contains "/progress"

--- a/dashboard/test/ui/features/teacher_tools/teacher_dashboard/demo_section_card.feature
+++ b/dashboard/test/ui/features/teacher_tools/teacher_dashboard/demo_section_card.feature
@@ -3,7 +3,7 @@ Feature: Demo section card on the teacher homepage
 
   Scenario: Teacher with zero sections can create a practice section from the homepage
     Given I am a teacher
-    And I am on "http://studio.code.org/teacher_dashboard/home"
+    And I am on "http://studio.code.org/teacher_dashboard/home?enableExperiments=demo-section"
     Then I wait until element "#ui-test-demo-section-card" is visible
     And element "#ui-test-demo-section-card" has text "High School Practice Section"
     When I click "#ui-test-demo-section-action-progress" once it exists

--- a/dashboard/test/ui/features/teacher_tools/teacher_dashboard/demo_section_card.feature
+++ b/dashboard/test/ui/features/teacher_tools/teacher_dashboard/demo_section_card.feature
@@ -1,0 +1,11 @@
+@no_mobile
+Feature: Demo section card on the teacher homepage
+
+  Scenario: Teacher with zero sections can create a practice section from the homepage
+    Given I am a teacher
+    And I am on "http://studio.code.org/teacher_dashboard/home"
+    Then I wait until element "#ui-test-demo-section-card" is visible
+    And element "#ui-test-demo-section-card" has text "High School Practice Section"
+    When I click "#ui-test-demo-section-action-progress" once it exists
+    Then I wait until current URL contains "/teacher_dashboard/sections/"
+    And I wait until current URL contains "/progress"

--- a/dashboard/test/ui/features/teacher_tools/teacher_dashboard/demo_section_card.feature
+++ b/dashboard/test/ui/features/teacher_tools/teacher_dashboard/demo_section_card.feature
@@ -6,6 +6,8 @@ Feature: Demo section card on the teacher homepage
     And I am on "http://studio.code.org/teacher_dashboard/home?enableExperiments=demo-section"
     Then I wait until element "#ui-test-demo-section-card" is visible
     And element "#ui-test-demo-section-card" contains text "High School Practice Section"
+    And element "#ui-test-demo-section-card" contains text "Demo"
+    And element "#ui-test-demo-section-card" contains text "Computing Careers"
     When I click "#ui-test-demo-section-action-progress" once it exists
     Then I wait until current URL contains "/teacher_dashboard/sections/"
     And I wait until current URL contains "/progress"

--- a/dashboard/test/ui/features/teacher_tools/teacher_dashboard/demo_section_card.feature
+++ b/dashboard/test/ui/features/teacher_tools/teacher_dashboard/demo_section_card.feature
@@ -8,7 +8,6 @@ Feature: Demo section card on the teacher homepage
     And element "#ui-test-demo-section-card" contains text "High School Practice Section"
     And element "#ui-test-demo-section-card" contains text "Demo"
     When I press "go-to-lesson-dropdown-button"
-    Then I wait until element "#go-to-lesson-dropdown" is open
     And I wait until element "#go-to-lesson-dropdown li" is visible
     When I click "#ui-test-demo-section-action-progress" once it exists
     Then I wait until current URL contains "/teacher_dashboard/sections/"

--- a/dashboard/test/ui/features/teacher_tools/teacher_dashboard/demo_section_card.feature
+++ b/dashboard/test/ui/features/teacher_tools/teacher_dashboard/demo_section_card.feature
@@ -5,7 +5,7 @@ Feature: Demo section card on the teacher homepage
     Given I am a teacher
     And I am on "http://studio.code.org/teacher_dashboard/home?enableExperiments=demo-section"
     Then I wait until element "#ui-test-demo-section-card" is visible
-    And element "#ui-test-demo-section-card" has text "High School Practice Section"
+    And element "#ui-test-demo-section-card" contains text "High School Practice Section"
     When I click "#ui-test-demo-section-action-progress" once it exists
     Then I wait until current URL contains "/teacher_dashboard/sections/"
     And I wait until current URL contains "/progress"


### PR DESCRIPTION

- shows the demo section card on the zero-section teacher homepage behind the `demo-section` experiment
- fetches demo preset data when the homepage loads
- falls back to the existing empty-homepage experience when presets are unavailable
- surfaces homepage-level notices for demo create failures
- adds homepage-level unit coverage and a focused UI feature for the zero-section create flow


https://github.com/user-attachments/assets/252cb9d1-7c28-4285-929a-aa8cf6f26d37

