### PR TITLE
Global/localizejs - Localize StandaloneVideo levels

### DIFF
--- a/apps/src/code-studio/videos.js
+++ b/apps/src/code-studio/videos.js
@@ -3,6 +3,7 @@ import _ from 'lodash';
 import React from 'react';
 import videojs from 'video.js';
 
+import localization from '@cdo/apps/localization';
 import {createReactRoot} from '@cdo/apps/util/createReactRoot';
 import i18n from '@cdo/locale';
 
@@ -46,6 +47,23 @@ videos.createVideoWithFallback = function (
   return video;
 };
 
+/**
+ * Ensure that the download link is localized when it is rendered
+ * directly on the page as '.video-link' or something like that.
+ */
+videos.wrapDownloadLink = function (linkElement) {
+  const link = linkElement[0];
+  const downloadSrc = link.getAttribute('href');
+
+  localization.on('change', () => {
+    const updatedDownloadLocalizedSrc = localization.translate(downloadSrc, [
+      'video-url',
+      'fallback-video-url',
+    ]);
+    link?.setAttribute('href', updatedDownloadLocalizedSrc);
+  });
+};
+
 function onVideoEnded() {
   $(MODAL_CLASS).trigger('ended');
 }
@@ -77,14 +95,30 @@ window.onYouTubeIframeAPIReady = function () {
 };
 
 function createVideo(options) {
+  const videoSrc = options.src;
+  const [videoBase, videoQuery] = videoSrc.split('?');
+  const videoLocalizedSrc =
+    localization.translate(videoBase, ['video-url', 'youtube-url']) +
+    (videoQuery ? `?${videoQuery}` : '');
   const videoDiv = $('<iframe id="video"/>').addClass('video-player').attr({
-    src: options.src,
+    src: videoLocalizedSrc,
     allowfullscreen: 'true',
   });
 
   const videoTabContainerDiv = $("<div id='videoTabContainer'></div>").append(
     videoDiv
   );
+
+  localization.on('change', () => {
+    const iframe = videoDiv[0];
+
+    if (iframe) {
+      const updatedVideoLocalizedSrc =
+        localization.translate(videoBase, ['video-url', 'youtube-url']) +
+        (videoQuery ? `?${videoQuery}` : '');
+      iframe.src = updatedVideoLocalizedSrc;
+    }
+  });
 
   return videoTabContainerDiv;
 }
@@ -208,15 +242,31 @@ videos.showVideoDialog = function (options, forceShowVideo) {
     active: lastTab !== null ? lastTab : 0, // Set starting tab.
   });
 
+  const downloadSrc = options.download;
+  const downloadLocalizedSrc = localization.translate(downloadSrc, [
+    'video-url',
+    'fallback-video-url',
+  ]);
+
   var download = $('<a/>')
     .append($('<i class="fa-solid fa-download" />'))
     .addClass('download-video btn')
     .attr('aria-label', 'Download Video')
     .css('float', 'left')
-    .attr('href', options.download);
+    .attr('href', downloadLocalizedSrc);
   if (document.dir === 'rtl') {
     download.css('float', 'right');
   }
+
+  localization.on('change', () => {
+    const link = download[0];
+    const updatedDownloadLocalizedSrc = localization.translate(downloadSrc, [
+      'video-url',
+      'fallback-video-url',
+    ]);
+    link?.setAttribute('href', updatedDownloadLocalizedSrc);
+  });
+
   var nav = $div.find(TAB_NAV_CLASS);
   nav.append(download);
 

--- a/apps/src/sites/studio/pages/levels/_standalone_video.js
+++ b/apps/src/sites/studio/pages/levels/_standalone_video.js
@@ -5,7 +5,10 @@ import ReactDom from 'react-dom';
 
 import {registerGetResult} from '@cdo/apps/code-studio/levels/codeStudioLevels';
 import {onContinue} from '@cdo/apps/code-studio/levels/postOnContinue';
-import {createVideoWithFallback} from '@cdo/apps/code-studio/videos';
+import {
+  createVideoWithFallback,
+  wrapDownloadLink,
+} from '@cdo/apps/code-studio/videos';
 import {reportTeacherReviewingStudentNonLabLevel} from '@cdo/apps/metrics/analyticsUtils';
 import SafeMarkdown from '@cdo/apps/templates/SafeMarkdown';
 import getScriptData from '@cdo/apps/util/getScriptData';
@@ -70,6 +73,9 @@ $(document).ready(() => {
       container
     );
   });
+
+  // Localize the existing rendered out download link
+  wrapDownloadLink($('.video-link a'));
 
   // Do some dynamic sizing of full width videos.
   if (videoFullWidth) {

--- a/apps/src/standaloneVideo/StandaloneVideo.tsx
+++ b/apps/src/standaloneVideo/StandaloneVideo.tsx
@@ -13,6 +13,7 @@ import {
   navigateToNextLevel,
 } from '@cdo/apps/code-studio/progressRedux';
 import {LabProps, VideoLevelData} from '@cdo/apps/lab2/types';
+import localization, {useLocalization} from '@cdo/apps/localization';
 import {useAppDispatch} from '@cdo/apps/util/reduxHooks';
 
 import standaloneVideoLocale from './locale';
@@ -26,14 +27,32 @@ const StandaloneVideo: React.FunctionComponent<LabProps> = ({
   const dispatch = useAppDispatch();
   const levelVideo = levelProperties.levelData as VideoLevelData | undefined;
 
+  useLocalization();
+
   const nextButtonPressed = () => {
     dispatch(sendSuccessReport(levelProperties.appName));
     dispatch(navigateToNextLevel());
   };
 
+  const videoSrc = levelVideo?.src;
+  const [videoBase, videoQuery] = (videoSrc || '').split('?');
+  const localizedVideoSrc = videoSrc
+    ? localization.translate(videoBase, ['video-url', 'youtube-url']) +
+      (videoQuery ? `?${videoQuery}` : '')
+    : videoSrc;
+
+  const downloadSrc = levelVideo?.download;
+  const localizedDownloadSrc = downloadSrc
+    ? localization.translate(downloadSrc, ['video-url', 'fallback-video-url'])
+    : downloadSrc;
+
   return (
     <div id="standalone-video">
-      <Video {...levelVideo}>
+      <Video
+        src={localizedVideoSrc}
+        download={localizedDownloadSrc}
+        thumbnail={levelVideo?.thumbnail}
+      >
         <MuiButton
           variant="contained"
           color="primary"


### PR DESCRIPTION
Adds localization support to the standalone videos for legacy labs (csf / coursea / etc) and lab2 (mix-move-ai-2025)

It does this by wrapping the video `src` and `download` data for a video level in a `localization.translate` call. This will submit those URLs as translatable strings. They can, then, be given 'translations' of new URLs pointing to either youtube links or video files in our videos bucket for `src` and/or `download` respectively.

The youtube links (`src`) are given the `youtube-url` and `video-url` labels in the TMS. Fallback video files (`download`) are given `fallback-video-url` and `video-url` labels in the TMS. This allows us to quickly filter all videos and fallback videos in the TMS to see their availability and discover missing entries.

Here is such an entry in the TMS itself with a given translation that points to a previously uploaded dubbed version of the referenced video:

<img width="897" height="484" alt="image" src="https://github.com/user-attachments/assets/940739f6-7e47-4b96-9898-d382dcff1d03" />

## Links
<!-- Jira tickets, design docs, Slack threads, related PRs, etc. -->

- Jira: [GERW-9](https://codedotorg.atlassian.net/browse/GERW-9)

## Testing story
<!-- How was this tested? Manual steps, adhoc links, automated tests, or why testing isn't needed. -->

Manual testing. See video:

https://github.com/user-attachments/assets/a782d460-c207-4bb3-9d6c-8d8a94af4c4f
