### PR TITLE
GEPW-21: Hide Teacher Promotions right panel on GE regional pages

### DIFF
--- a/apps/src/templates/studioHomepages/teacherHomepageV2/TeacherPromotions.tsx
+++ b/apps/src/templates/studioHomepages/teacherHomepageV2/TeacherPromotions.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 
+import GlobalEditionWrapper from '@cdo/apps/templates/GlobalEditionWrapper';
 import HttpClient from '@cdo/apps/util/HttpClient';
 import {trySetLocalStorage, tryGetLocalStorage} from '@cdo/apps/utils';
 
@@ -105,7 +106,7 @@ const TeacherPromotions: React.FC = () => {
   );
 
   return (
-    <ul className={styles.promotions}>
+    <ul id="ui-test-teacher-promotions" className={styles.promotions}>
       {isLoading ? (
         <SkeletonTeacherPromo />
       ) : (
@@ -122,4 +123,27 @@ const TeacherPromotions: React.FC = () => {
   );
 };
 
-export default TeacherPromotions;
+/**
+ * This is a version of the curriculum catalog that is overridable by a regional
+ * configuration.
+ *
+ * This is done via a configuration in, for instance, /config/global_editions/fa.yml
+ * via a paths rule such as:
+ *
+ * ```
+ * pages:
+ *   # Home dashboards
+ *   - path: /
+ *     components:
+ *       TeacherPromotions: false
+ * ```
+ */
+const RegionalTeacherPromotions = (props: object = {}) => (
+  <GlobalEditionWrapper
+    componentId="TeacherPromotions"
+    component={TeacherPromotions}
+    props={props}
+  />
+);
+
+export default RegionalTeacherPromotions;

--- a/apps/src/templates/studioHomepages/teacherHomepageV2/teacherHomepage.module.scss
+++ b/apps/src/templates/studioHomepages/teacherHomepageV2/teacherHomepage.module.scss
@@ -28,6 +28,10 @@
   width: 100%;
   max-width: 800px;
   min-width: 500px;
+
+  &:last-child {
+    max-width: none;
+  }
 }
 
 .headerButtonRow {

--- a/config/global_editions/fa.yml
+++ b/config/global_editions/fa.yml
@@ -157,6 +157,8 @@ pages:
         # versions that are translated
         courseFilters:
           language: fa-IR
+      # Hide the right panel with "New Features", "Announcements", etc.
+      TeacherPromotions: false
   # Teacher dashboard
   - path: /teacher_dashboard
     components:

--- a/dashboard/test/ui/features/platform/global_edition/fa/personal_project_gallery.feature
+++ b/dashboard/test/ui/features/platform/global_edition/fa/personal_project_gallery.feature
@@ -4,8 +4,8 @@
 Feature: Global Edition - Farsi MVP - Personal Project Gallery
 
   Background:
-    Given I create a teacher-associated student named "Lillian"
-    And I use a cookie to mock the DCDO key "global_edition_enabled" as "true"
+    Given Global Edition is enabled
+    And I create a teacher-associated student named "Lillian"
 
   Scenario: The student sees only the projects available in Farsi MVP
     Given I am on "http://studio.code.org/projects"

--- a/dashboard/test/ui/features/platform/global_edition/fa/pl_landing_page.feature
+++ b/dashboard/test/ui/features/platform/global_edition/fa/pl_landing_page.feature
@@ -3,8 +3,7 @@
 Feature: Global Edition - Farsi MVP - Professional Learning landing page
 
   Background:
-    Given I am on "http://studio.code.org"
-    And I use a cookie to mock the DCDO key "global_edition_enabled" as "true"
+    Given Global Edition is enabled
 
   @eyes
   Scenario: New teacher without PL history sees relevant content sections for Farsi MVP

--- a/dashboard/test/ui/features/platform/global_edition/fa/sign_in_page.feature
+++ b/dashboard/test/ui/features/platform/global_edition/fa/sign_in_page.feature
@@ -2,9 +2,8 @@
 Feature: Global Edition - Farsi MVP - Sign In page
 
   Background:
-    Given I am on "http://studio.code.org"
-    And I use a cookie to mock the DCDO key "global_edition_enabled" as "true"
-    And I select the "فارسی" option in dropdown "locale" to load a new page
+    Given Global Edition is enabled
+    And I switch to the Global Edition region "fa"
 
   @eyes
   Scenario: I see the Farsi MVP Sign In page

--- a/dashboard/test/ui/features/platform/global_edition/fa/sign_up_page.feature
+++ b/dashboard/test/ui/features/platform/global_edition/fa/sign_up_page.feature
@@ -2,9 +2,8 @@
 Feature: Global Edition - Farsi MVP - Sign Up page
 
   Background:
-    Given I am on "http://studio.code.org"
-    And I use a cookie to mock the DCDO key "global_edition_enabled" as "true"
-    And I select the "فارسی" option in dropdown "locale" to load a new page
+    Given Global Edition is enabled
+    And I switch to the Global Edition region "fa"
 
   @eyes
   Scenario: I see the Farsi MVP Sign In page

--- a/dashboard/test/ui/features/platform/global_edition/fa/signed_out.feature
+++ b/dashboard/test/ui/features/platform/global_edition/fa/signed_out.feature
@@ -3,8 +3,7 @@
 @no_mobile
 Feature: Global Edition - Farsi Headers when Signed Out
   Background:
-    Given I am on "http://studio.code.org"
-    And I use a cookie to mock the DCDO key "global_edition_enabled" as "true"
+    Given Global Edition is enabled
     And I set the language cookie
 
   Scenario: Signed out user should see the correct header links on Dashboard

--- a/dashboard/test/ui/features/platform/global_edition/fa/teacher_dashboard.feature
+++ b/dashboard/test/ui/features/platform/global_edition/fa/teacher_dashboard.feature
@@ -1,0 +1,16 @@
+@chrome
+@no_mobile
+Feature: Global Edition - Farsi MVP - Teacher Dashboard
+
+  Background:
+    Given I am on "http://studio.code.org"
+    And I use a cookie to mock the DCDO key "global_edition_enabled" as "true"
+
+  Scenario: Teacher does not see Teacher Promotion right panel
+    Given I create a teacher named "New Teacher"
+
+    When I sign in as "New Teacher" and go home
+    Then I wait until element "#ui-test-teacher-promotions" is visible
+
+    When I select the "فارسی" option in dropdown "locale" to load a new page
+    Then I wait until element "#ui-test-teacher-promotions" is not visible

--- a/dashboard/test/ui/features/platform/global_edition/fa/teacher_dashboard.feature
+++ b/dashboard/test/ui/features/platform/global_edition/fa/teacher_dashboard.feature
@@ -3,14 +3,17 @@
 Feature: Global Edition - Farsi MVP - Teacher Dashboard
 
   Background:
-    Given I am on "http://studio.code.org"
-    And I use a cookie to mock the DCDO key "global_edition_enabled" as "true"
+    Given Global Edition is enabled
 
   Scenario: Teacher does not see Teacher Promotion right panel
     Given I create a teacher named "New Teacher"
+    And I sign in as "New Teacher" and go home
 
-    When I sign in as "New Teacher" and go home
-    Then I wait until element "#ui-test-teacher-promotions" is visible
+    When I am on "http://studio.code.org/teacher_dashboard/home"
+    Then I wait until element "#teacher-home-header" is visible
+    And I wait until element "#ui-test-teacher-promotions" is visible
 
-    When I select the "فارسی" option in dropdown "locale" to load a new page
-    Then I wait until element "#ui-test-teacher-promotions" is not visible
+    When I switch to the Global Edition region "fa"
+    Then I wait until current URL contains "http://studio.code.org/fa/teacher_dashboard/home"
+    And I wait until element "#teacher-home-header" is visible
+    And I wait until element "#ui-test-teacher-promotions" is not visible

--- a/dashboard/test/ui/features/platform/global_edition/region_select.feature
+++ b/dashboard/test/ui/features/platform/global_edition/region_select.feature
@@ -2,8 +2,7 @@
 Feature: Global Edition - Region Select
 
   Background:
-    Given I am on "http://studio.code.org"
-    And I use a cookie to mock the DCDO key "global_edition_enabled" as "true"
+    Given Global Edition is enabled
 
   Scenario: User can switch between the international and regional versions using the language selector on a Studio page
     Given I am on "http://studio.code.org/users/sign_in"

--- a/dashboard/test/ui/features/platform/global_edition/region_switch_confirm.feature
+++ b/dashboard/test/ui/features/platform/global_edition/region_switch_confirm.feature
@@ -3,12 +3,12 @@
 Feature: Global Edition - Region Switch Confirm Modal
 
   Background:
-    Given I clear session storage
-    And Global Edition is enabled
+    Given Global Edition is enabled
     And I use a cookie to mock the DCDO key "global_edition_region_switch_confirm_enabled_in" as "["fa"]"
 
   Scenario: The modal is shown on studio.code.org (Studio) domain
     Given I am on "http://studio.code.org"
+    And I clear session storage
     And I am in Iran
     And I reload the page
     Then I wait until element "#global-edition-region-switch-confirm.fade.in[role='dialog']" is visible

--- a/dashboard/test/ui/features/platform/global_edition/region_switch_confirm.feature
+++ b/dashboard/test/ui/features/platform/global_edition/region_switch_confirm.feature
@@ -3,9 +3,8 @@
 Feature: Global Edition - Region Switch Confirm Modal
 
   Background:
-    Given I am on "http://studio.code.org"
-    And I clear session storage
-    And I use a cookie to mock the DCDO key "global_edition_enabled" as "true"
+    Given I clear session storage
+    And Global Edition is enabled
     And I use a cookie to mock the DCDO key "global_edition_region_switch_confirm_enabled_in" as "["fa"]"
 
   Scenario: The modal is shown on studio.code.org (Studio) domain

--- a/dashboard/test/ui/features/step_definitions/global_edition_steps.rb
+++ b/dashboard/test/ui/features/step_definitions/global_edition_steps.rb
@@ -1,0 +1,19 @@
+require 'uri'
+require 'rack/utils'
+
+Given 'Global Edition is enabled' do
+  steps <<-STEPS
+    Given I am on "http://studio.code.org"
+    And I use a cookie to mock the DCDO key "global_edition_enabled" as "true"
+  STEPS
+end
+
+When 'I switch to the Global Edition region {string}' do |region_code|
+  uri = URI(@browser.current_url.presence || 'http://studio.code.org')
+
+  params = Rack::Utils.parse_nested_query(uri.query)
+  params['ge_region'] = region_code
+  uri.query = Rack::Utils.build_query(params)
+
+  steps %Q[When I am on "#{uri}"]
+end

--- a/dashboard/test/ui/features/step_definitions/pd.rb
+++ b/dashboard/test/ui/features/step_definitions/pd.rb
@@ -275,7 +275,7 @@ end
 And 'I visit Farsi version of Professional Learning Lending page' do
   steps <<~GHERKIN
     When I am on "http://studio.code.org/my-professional-learning"
-    And I select the "فارسی" option in dropdown "locale" to load a new page
+    And I switch to the Global Edition region "fa"
     Then I wait until current URL contains "http://studio.code.org/fa/my-professional-learning"
     And element "h1:contains(یادگیری پیشرفته)" is visible
     And element "a[href*='/educate/professional-learning']" is not visible


### PR DESCRIPTION
## US Teacher Dashboard
<img alt="teacher-dashboard-default" src="https://github.com/user-attachments/assets/a7bb4a19-306c-419c-8640-452fe16ea436" />

## GE (Farsi) Teacher Dashboard
<img width="1278" height="701" alt="teacher-dashboard-farsi-mvp" src="https://github.com/user-attachments/assets/e86cf4ae-09cd-4376-8382-58ec7ac44440" />

## Links
- JIRA task: [GEPW-21](https://codedotorg.atlassian.net/browse/GEPW-21)
- Related PR: #64826