### PR TITLE
add arm64-darwin-25 to Observability engine bundle platforms

### DIFF
--- a/dashboard/engines/observability/Gemfile.lock
+++ b/dashboard/engines/observability/Gemfile.lock
@@ -97,6 +97,9 @@ GEM
     erubi (1.13.0)
     globalid (1.1.0)
       activesupport (>= 5.0)
+    google-protobuf (4.33.6-arm64-darwin)
+      bigdecimal
+      rake (>= 13)
     google-protobuf (4.33.6-x86_64-linux-gnu)
       bigdecimal
       rake (>= 13)
@@ -130,6 +133,8 @@ GEM
     net-smtp (0.3.3)
       net-protocol
     nio4r (2.7.0)
+    nokogiri (1.18.10-arm64-darwin)
+      racc (~> 1.4)
     nokogiri (1.18.10-x86_64-linux-gnu)
       racc (~> 1.4)
     opentelemetry-api (1.8.0)
@@ -359,6 +364,7 @@ GEM
     zeitwerk (2.6.18)
 
 PLATFORMS
+  arm64-darwin-25
   x86_64-linux-gnu
 
 DEPENDENCIES


### PR DESCRIPTION
Fixes the same diff issue from https://github.com/code-dot-org/code-dot-org/pull/72131, but for the Observability rails engine.

Accomplished using:
```
bundle lock --add-platform arm64-darwin-25
```

## Links
<!-- Jira tickets, design docs, Slack threads, related PRs, etc. -->

- Jira:

## Testing story
<!-- How was this tested? Manual steps, adhoc links, automated tests, or why testing isn't needed. -->



## Deployment notes
<!-- Delete this section if it's a standard merge-and-deploy.
     Otherwise: migrations, feature flags, coordination, caching impacts, etc. -->



## Privacy and security
<!-- Delete this section if there is no privacy/security impact.
     Otherwise: new PII, auth changes, API surface changes, etc. -->

