### PR TITLE
update font awesome url to get new classlink icon

### DIFF
--- a/frontend/packages/component-library-styles/font.scss
+++ b/frontend/packages/component-library-styles/font.scss
@@ -112,12 +112,12 @@
    If you are changing the location of these files,
    see the readme in this directory for more detail on manual steps to take when uploading new files.
  */
-$font-awesome-core-url: 'https://dsco.code.org/assets/font-awesome-pro/1764883025/css/fontawesome.min.css';
-$font-awesome-brands-url: 'https://dsco.code.org/assets/font-awesome-pro/1764883025/css/brands.min.css';
-$font-awesome-solid-url: 'https://dsco.code.org/assets/font-awesome-pro/1764883025/css/solid.min.css';
-$font-awesome-regular-url: 'https://dsco.code.org/assets/font-awesome-pro/1764883025/css/regular.min.css';
-$font-awesome-v4-fonts-url: 'https://dsco.code.org/assets/font-awesome-pro/1764883025/css/v4-font-face.min.css';
-$font-awesome-v4-shims-url: 'https://dsco.code.org/assets/font-awesome-pro/1764883025/css/v4-shims.min.css';
-$font-awesome-v4-shims-url: 'https://dsco.code.org/assets/font-awesome-pro/1764883025/css/v4-shims.min.css';
-$font-awesome-duotone-url: 'https://dsco.code.org/assets/font-awesome-pro/1764883025/css/duotone.min.css';
-$font-awesome-custom-icons-url: 'https://dsco.code.org/assets/font-awesome-pro/1764883025/css/custom-icons.min.css';
+$font-awesome-core-url: 'https://dsco.code.org/assets/font-awesome-pro/1771519720/css/fontawesome.min.css';
+$font-awesome-brands-url: 'https://dsco.code.org/assets/font-awesome-pro/1771519720/css/brands.min.css';
+$font-awesome-solid-url: 'https://dsco.code.org/assets/font-awesome-pro/1771519720/css/solid.min.css';
+$font-awesome-regular-url: 'https://dsco.code.org/assets/font-awesome-pro/1771519720/css/regular.min.css';
+$font-awesome-v4-fonts-url: 'https://dsco.code.org/assets/font-awesome-pro/1771519720/css/v4-font-face.min.css';
+$font-awesome-v4-shims-url: 'https://dsco.code.org/assets/font-awesome-pro/1771519720/css/v4-shims.min.css';
+$font-awesome-v4-shims-url: 'https://dsco.code.org/assets/font-awesome-pro/1771519720/css/v4-shims.min.css';
+$font-awesome-duotone-url: 'https://dsco.code.org/assets/font-awesome-pro/1771519720/css/duotone.min.css';
+$font-awesome-custom-icons-url: 'https://dsco.code.org/assets/font-awesome-pro/1771519720/css/custom-icons.min.css';

--- a/frontend/packages/fonts/src/loader/index.ts
+++ b/frontend/packages/fonts/src/loader/index.ts
@@ -15,14 +15,14 @@ export function injectFont(locale: InternationalFontLocale) {
 
 export function injectFontAwesome() {
   const stylesheets = [
-    'https://dsco.code.org/assets/font-awesome-pro/1764883025/css/fontawesome.min.css',
-    'https://dsco.code.org/assets/font-awesome-pro/1764883025/css/brands.min.css',
-    'https://dsco.code.org/assets/font-awesome-pro/1764883025/css/solid.min.css',
-    'https://dsco.code.org/assets/font-awesome-pro/1764883025/css/regular.min.css',
-    'https://dsco.code.org/assets/font-awesome-pro/1764883025/css/v4-font-face.min.css',
-    'https://dsco.code.org/assets/font-awesome-pro/1764883025/css/v4-shims.min.css',
-    'https://dsco.code.org/assets/font-awesome-pro/1764883025/css/duotone.min.css',
-    'https://dsco.code.org/assets/font-awesome-pro/1764883025/css/custom-icons.min.css',
+    'https://dsco.code.org/assets/font-awesome-pro/1771519720/css/fontawesome.min.css',
+    'https://dsco.code.org/assets/font-awesome-pro/1771519720/css/brands.min.css',
+    'https://dsco.code.org/assets/font-awesome-pro/1771519720/css/solid.min.css',
+    'https://dsco.code.org/assets/font-awesome-pro/1771519720/css/regular.min.css',
+    'https://dsco.code.org/assets/font-awesome-pro/1771519720/css/v4-font-face.min.css',
+    'https://dsco.code.org/assets/font-awesome-pro/1771519720/css/v4-shims.min.css',
+    'https://dsco.code.org/assets/font-awesome-pro/1771519720/css/duotone.min.css',
+    'https://dsco.code.org/assets/font-awesome-pro/1771519720/css/custom-icons.min.css',
   ];
 
   stylesheets.forEach(stylesheetHref => {

--- a/shared/css/font.scss
+++ b/shared/css/font.scss
@@ -138,12 +138,12 @@ $code-font: 'Source Code Pro', Monaco, 'Bitstream Vera Sans Mono', 'Lucida Conso
    If you are changing the location of these files,
    see the readme in this directory for more detail on manual steps to take when uploading new files.
  */
-$font-awesome-core-url: 'https://dsco.code.org/assets/font-awesome-pro/1764883025/css/fontawesome.min.css';
-$font-awesome-brands-url: 'https://dsco.code.org/assets/font-awesome-pro/1764883025/css/brands.min.css';
-$font-awesome-solid-url: 'https://dsco.code.org/assets/font-awesome-pro/1764883025/css/solid.min.css';
-$font-awesome-regular-url: 'https://dsco.code.org/assets/font-awesome-pro/1764883025/css/regular.min.css';
-$font-awesome-v4-fonts-url: 'https://dsco.code.org/assets/font-awesome-pro/1764883025/css/v4-font-face.min.css';
-$font-awesome-v4-shims-url: 'https://dsco.code.org/assets/font-awesome-pro/1764883025/css/v4-shims.min.css';
-$font-awesome-v4-shims-url: 'https://dsco.code.org/assets/font-awesome-pro/1764883025/css/v4-shims.min.css';
-$font-awesome-duotone-url: 'https://dsco.code.org/assets/font-awesome-pro/1764883025/css/duotone.min.css';
-$font-awesome-custom-icons-url: 'https://dsco.code.org/assets/font-awesome-pro/1764883025/css/custom-icons.min.css';
+$font-awesome-core-url: 'https://dsco.code.org/assets/font-awesome-pro/1771519720/css/fontawesome.min.css';
+$font-awesome-brands-url: 'https://dsco.code.org/assets/font-awesome-pro/1771519720/css/brands.min.css';
+$font-awesome-solid-url: 'https://dsco.code.org/assets/font-awesome-pro/1771519720/css/solid.min.css';
+$font-awesome-regular-url: 'https://dsco.code.org/assets/font-awesome-pro/1771519720/css/regular.min.css';
+$font-awesome-v4-fonts-url: 'https://dsco.code.org/assets/font-awesome-pro/1771519720/css/v4-font-face.min.css';
+$font-awesome-v4-shims-url: 'https://dsco.code.org/assets/font-awesome-pro/1771519720/css/v4-shims.min.css';
+$font-awesome-v4-shims-url: 'https://dsco.code.org/assets/font-awesome-pro/1771519720/css/v4-shims.min.css';
+$font-awesome-duotone-url: 'https://dsco.code.org/assets/font-awesome-pro/1771519720/css/duotone.min.css';
+$font-awesome-custom-icons-url: 'https://dsco.code.org/assets/font-awesome-pro/1771519720/css/custom-icons.min.css';


### PR DESCRIPTION
<!--
  Summary of the change: background, motivation, and context.
  Include screenshots, videos, or before/after comparisons for UI changes.
-->

This Pr only updated font awesome url to the kit with classLink icon, if you need a newer icons - you need to upload that kit to s3 and then update the font awesome urls once more

## Links
<!-- Jira tickets, design docs, Slack threads, related PRs, etc. -->

- Jira:

## Testing story
<!-- How was this tested? Manual steps, adhoc links, automated tests, or why testing isn't needed. -->



## Deployment notes
<!-- Delete this section if it's a standard merge-and-deploy.
     Otherwise: migrations, feature flags, coordination, caching impacts, etc. -->



## Privacy and security
<!-- Delete this section if there is no privacy/security impact.
     Otherwise: new PII, auth changes, API surface changes, etc. -->

