### PR TITLE
AI Chat - Refactor aichatContext into its own singleton

### DIFF
--- a/apps/src/aiComponentLibrary/aiTutorVersionActions/AiTutorVersionActions.tsx
+++ b/apps/src/aiComponentLibrary/aiTutorVersionActions/AiTutorVersionActions.tsx
@@ -3,7 +3,7 @@ import {WithTooltip} from '@code-dot-org/component-library/tooltip';
 import {Button as MuiButton, IconButton as MuiIconButton} from '@mui/material';
 import React, {useState, useCallback, useEffect, useLayoutEffect} from 'react';
 
-import ChatEventLogger from '@cdo/apps/aichat/chatEventLogger';
+import AichatContextManager from '@cdo/apps/aichat/aichatContextManager';
 import AiTutorVersionFileChip from '@cdo/apps/aiComponentLibrary/aiTutorVersionFileChip/AiTutorVersionFileChip';
 import Lab2Registry from '@cdo/apps/lab2/Lab2Registry';
 import {isViewingAiTutorVersionFileUpdates} from '@cdo/apps/lab2/redux/lab2ReduxSelectors';
@@ -61,7 +61,7 @@ const AiTutorVersionActions: React.FC<AiTutorVersionActionsProps> = ({
         const notification = getRejectNotification(files);
         const payload = {
           newChatEvent: notification,
-          aichatContext: ChatEventLogger.getInstance().aichatContext,
+          aichatContext: AichatContextManager.getContext(),
           authenticity_token: await getAuthenticityToken(),
         };
 

--- a/apps/src/aiGateway/shared.ts
+++ b/apps/src/aiGateway/shared.ts
@@ -1,4 +1,4 @@
-import ChatEventLogger from '../aichat/chatEventLogger';
+import AichatContextManager from '../aichat/aichatContextManager';
 import HttpClient from '../util/HttpClient';
 
 export const AI_GATEWAY_URL = `https://ai-gateway.code.org`;
@@ -7,7 +7,7 @@ export async function fetchAccessToken() {
   const response = await HttpClient.post(
     '/ai_gateway/access_token',
     JSON.stringify({
-      aichatContext: ChatEventLogger.getInstance().aichatContext,
+      aichatContext: AichatContextManager.getContext(),
     }),
     true,
     {

--- a/apps/src/aichat/aichatContextManager.ts
+++ b/apps/src/aichat/aichatContextManager.ts
@@ -1,0 +1,28 @@
+import {AichatContext} from './types';
+
+export default class AichatContextManager {
+  private static instance: AichatContextManager;
+
+  aichatContext?: AichatContext;
+
+  private static getInstance(): AichatContextManager {
+    if (!AichatContextManager.instance) {
+      AichatContextManager.instance = new AichatContextManager();
+    }
+    return AichatContextManager.instance;
+  }
+
+  public static setContext(context: AichatContext) {
+    this.getInstance().aichatContext = context;
+  }
+
+  public static getContext(): AichatContext {
+    const instance = this.getInstance();
+    if (!instance.aichatContext) {
+      throw new Error(
+        'Called AichatContextManager.getContext(), but never called setContext() first.'
+      );
+    }
+    return instance.aichatContext;
+  }
+}

--- a/apps/src/aichat/chatEventLogger.ts
+++ b/apps/src/aichat/chatEventLogger.ts
@@ -2,7 +2,8 @@ import Lab2Registry from '@cdo/apps/lab2/Lab2Registry';
 import {NetworkError} from '@cdo/apps/util/HttpClient';
 
 import {postLogChatEvent} from './aichatApi';
-import {ChatEvent, AichatContext} from './types';
+import AichatContextManager from './aichatContextManager';
+import {ChatEvent} from './types';
 
 export default class ChatEventLogger {
   private queue: ChatEvent[];
@@ -10,20 +11,16 @@ export default class ChatEventLogger {
 
   private static instance: ChatEventLogger;
 
-  constructor(public readonly aichatContext: AichatContext) {
+  constructor() {
     this.queue = [];
     this.sendingInProgress = false;
   }
 
   public static getInstance(): ChatEventLogger {
     if (ChatEventLogger.instance === undefined) {
-      throw new Error('ChatEventLogger was not initialized with API context.');
+      ChatEventLogger.instance = new ChatEventLogger();
     }
     return ChatEventLogger.instance;
-  }
-
-  public static initialize(context: AichatContext) {
-    ChatEventLogger.instance = new ChatEventLogger(context);
   }
 
   public logChatEvent(chatEvent: ChatEvent) {
@@ -34,13 +31,14 @@ export default class ChatEventLogger {
   }
 
   private async sendChatEvent() {
+    const aichatContext = AichatContextManager.getContext();
     // Send aichat events to the server to be logged.
     while (this.queue.length > 0) {
       const chatEvent = this.queue.shift(); // Remove the first element from the queue.
       if (chatEvent) {
         this.sendingInProgress = true;
         try {
-          await postLogChatEvent(chatEvent, this.aichatContext);
+          await postLogChatEvent(chatEvent, aichatContext);
         } catch (error) {
           // Only send log report if not a 403 error.
           if (

--- a/apps/src/aichat/views/AichatView.tsx
+++ b/apps/src/aichat/views/AichatView.tsx
@@ -26,7 +26,6 @@ import {useAppDispatch, useAppSelector} from '@cdo/apps/util/reduxHooks';
 import {tryGetLocalStorage, trySetLocalStorage} from '@cdo/apps/utils';
 import {AiChatClientTypes} from '@cdo/generated-scripts/sharedConstants';
 
-import ChatEventLogger from '../chatEventLogger';
 import {ModalTypes} from '../constants';
 import {LevelPropertiesContext} from '../levelPropertiesContext';
 import {
@@ -95,7 +94,6 @@ const AichatView: React.FunctionComponent<LabProps<AichatLevelProperties>> = ({
   );
 
   const logLevelActivity = useLevelActivityMetrics(levelProperties);
-  const scriptId = useAppSelector(state => state.progress.scriptId);
 
   const isLevelbuilder = useAppSelector(state =>
     state.lab.permissions?.includes(PERMISSIONS.LEVELBUILDER)
@@ -123,16 +121,6 @@ const AichatView: React.FunctionComponent<LabProps<AichatLevelProperties>> = ({
       dispatch(onSaveFail());
     });
   }, [projectManager, dispatch]);
-
-  // Initialize the ChatEventLogger with the current context, whenever it updates.
-  useEffect(() => {
-    ChatEventLogger.initialize({
-      clientType: AiChatClientTypes.AI_CHAT_LAB,
-      currentLevelId: parseInt(currentLevelId || ''),
-      scriptId,
-      channelId,
-    });
-  }, [currentLevelId, scriptId, channelId]);
 
   useEffect(() => {
     dispatch(clearHasSetInitialCustomizations());

--- a/apps/src/aichat/views/AichatView.tsx
+++ b/apps/src/aichat/views/AichatView.tsx
@@ -103,6 +103,8 @@ const AichatView: React.FunctionComponent<LabProps<AichatLevelProperties>> = ({
     state => state.aichat.hasSetInitialCustomizations
   );
 
+  const chatWorkspaceInitialized = hasSetInitialCustomizations;
+
   const projectManager = Lab2Registry.getInstance().getProjectManager();
   // Attach save listeners whenever the project manager updates
   useEffect(() => {
@@ -133,13 +135,20 @@ const AichatView: React.FunctionComponent<LabProps<AichatLevelProperties>> = ({
     dispatch(
       initializeAiCustomizations(studentAiCustomizations, levelAichatSettings)
     );
-    dispatch(
-      addChatEvent({
-        timestamp: Date.now(),
-        descriptionKey: 'LOAD_LEVEL',
-      })
-    );
   }, [dispatch, initialSources, levelAichatSettings]);
+
+  useEffect(() => {
+    // ChatWorkspaceLogger is intialized in ChatWorkspace so we need to wait on it.
+    // Logging fronm AichatView could be cleaned up to avoid this fragile timing.
+    if (chatWorkspaceInitialized) {
+      dispatch(
+        addChatEvent({
+          timestamp: Date.now(),
+          descriptionKey: 'LOAD_LEVEL',
+        })
+      );
+    }
+  }, [dispatch, chatWorkspaceInitialized]);
 
   useEffect(() => {
     const modalToShow = () => {
@@ -352,7 +361,7 @@ const AichatView: React.FunctionComponent<LabProps<AichatLevelProperties>> = ({
               headerClassName={moduleStyles.panelHeader}
               rightHeaderContent={<AiChatHeaderButtons />}
             >
-              {hasSetInitialCustomizations && (
+              {chatWorkspaceInitialized && (
                 <ChatWorkspace
                   modelParameters={modelParameters}
                   clientType={AiChatClientTypes.AI_CHAT_LAB}

--- a/apps/src/aichat/views/ChatWorkspace.tsx
+++ b/apps/src/aichat/views/ChatWorkspace.tsx
@@ -9,7 +9,7 @@ import {useAppDispatch, useAppSelector} from '@cdo/apps/util/reduxHooks';
 import usePrevious from '@cdo/apps/util/usePrevious';
 import {AiChatClientTypes} from '@cdo/generated-scripts/sharedConstants';
 
-import ChatEventLogger from '../chatEventLogger';
+import AichatContextManager from '../aichatContextManager';
 import {
   modelDescriptions,
   RESET_CONVERSATION_CUSTOMIZATION_UPDATES,
@@ -148,7 +148,7 @@ const ChatWorkspace: React.FunctionComponent<ChatWorkspaceProps> = ({
 
   // Initialize the ChatEventLogger with the current context, whenever it updates.
   useEffect(() => {
-    ChatEventLogger.initialize({
+    AichatContextManager.setContext({
       clientType,
       currentLevelId: parseInt(currentLevelId || ''),
       scriptId,

--- a/apps/test/unit/aichat/ChatEventLoggerTest.ts
+++ b/apps/test/unit/aichat/ChatEventLoggerTest.ts
@@ -1,4 +1,5 @@
 import * as aichatApi from '@cdo/apps/aichat/aichatApi';
+import AichatContextManager from '@cdo/apps/aichat/aichatContextManager';
 import ChatEventLogger from '@cdo/apps/aichat/chatEventLogger';
 import {AichatContext, CompletedChatMessage} from '@cdo/apps/aichat/types';
 import {Role} from '@cdo/apps/aiComponentLibrary/chatMessage/types';
@@ -27,7 +28,8 @@ describe('ChatEventLogger', () => {
       scriptId: 321,
       channelId: 'abc123',
     };
-    chatEventLogger = new ChatEventLogger(aichatContext);
+    AichatContextManager.setContext(aichatContext);
+    chatEventLogger = ChatEventLogger.getInstance();
   });
 
   afterEach(() => {


### PR DESCRIPTION
This PR refactors aichatContext out of ChatEventLogger and into its own singleton.  This allows access to aichatContext without going through the logger which felt off: `ChatEventLogger.getInstance().aichatContext`


## Links
Discussion on slack is [here](https://codedotorg.slack.com/archives/C06FELVTV0Q/p1776354514396109).

