### PR TITLE
AI Tutor: Add Statsig logging for LessonTutorProgressBubble click

### DIFF
--- a/apps/src/code-studio/components/progress/LessonProgress.jsx
+++ b/apps/src/code-studio/components/progress/LessonProgress.jsx
@@ -31,6 +31,8 @@ class LessonProgress extends Component {
     lessonExtrasUrl: PropTypes.string,
     hasLessonPlan: PropTypes.bool,
     lessonTutorPath: PropTypes.string,
+    lessonId: PropTypes.number,
+    userId: PropTypes.number,
     isLessonExtras: PropTypes.bool,
     width: PropTypes.number,
     setDesiredWidth: PropTypes.func,
@@ -151,8 +153,11 @@ class LessonProgress extends Component {
       hasLessonPlan,
       lessonTutorPath,
       lessonName,
+      lessonId,
+      userId,
       navigateToLevelId,
       currentLevel,
+      currentLevelId,
     } = this.props;
 
     const showLessonTutorBubble =
@@ -227,7 +232,13 @@ class LessonProgress extends Component {
             )}
             {showLessonTutorBubble && (
               <div>
-                <LessonTutorProgressBubble lessonTutorPath={lessonTutorPath} />
+                <LessonTutorProgressBubble
+                  lessonTutorPath={lessonTutorPath}
+                  lessonId={lessonId}
+                  levelId={currentLevelId}
+                  lessonName={lessonName}
+                  userId={userId}
+                />
               </div>
             )}
           </div>
@@ -314,6 +325,8 @@ export default connect(
       state.progress,
       state.progress.currentLessonId
     ),
+    lessonId: state.progress.currentLessonId,
+    userId: state.currentUser.userId,
     isLessonExtras: state.progress.isLessonExtras,
     currentPageNumber: state.progress.currentPageNumber,
     currentLevelId: state.progress.currentLevelId,

--- a/apps/src/metrics/AnalyticsConstants.js
+++ b/apps/src/metrics/AnalyticsConstants.js
@@ -392,6 +392,7 @@ const EVENTS = {
     'Signed In User Clicks Help Menu Option',
   HEADER_LESSON_NAME_CLICKED: 'Header Lesson Name Clicked',
   HEADER_PROGRESS_BUBBLE_LINK_CLICKED: 'Header Progress Bubble Link Clicked',
+  LESSON_TUTOR_PROGRESS_BUBBLE_CLICK: 'Lesson Tutor Progress Bubble Click',
   HEADER_UNIT_DETAILS_TOGGLED: 'Header Unit Details Toggled',
 
   // Header Create menu - signed in

--- a/apps/src/templates/progress/LessonTutorProgressBubble.jsx
+++ b/apps/src/templates/progress/LessonTutorProgressBubble.jsx
@@ -4,13 +4,30 @@ import PropTypes from 'prop-types';
 import React, {useState, useRef} from 'react';
 import ReactTooltip from 'react-tooltip';
 
+import {EVENTS} from '@cdo/apps/metrics/AnalyticsConstants';
+import analyticsReporter from '@cdo/apps/metrics/AnalyticsReporter';
 import color from '@cdo/apps/util/color';
 
 const ICON_SIZE = 16;
 
-export default function LessonTutorProgressBubble({lessonTutorPath}) {
+export default function LessonTutorProgressBubble({
+  lessonTutorPath,
+  lessonId,
+  levelId,
+  lessonName,
+  userId,
+}) {
   const [isHovering, setIsHovering] = useState(false);
   const tooltipId = useRef(_.uniqueId()).current;
+
+  const handleClick = () => {
+    analyticsReporter.sendEvent(EVENTS.LESSON_TUTOR_PROGRESS_BUBBLE_CLICK, {
+      lessonId,
+      levelId,
+      lessonName,
+      userId,
+    });
+  };
 
   return (
     <a
@@ -21,6 +38,7 @@ export default function LessonTutorProgressBubble({lessonTutorPath}) {
       title="Lesson Tutor"
       target="_blank"
       rel="noopener noreferrer"
+      onClick={handleClick}
       onMouseEnter={() => setIsHovering(true)}
       onMouseLeave={() => setIsHovering(false)}
     >
@@ -41,4 +59,8 @@ export default function LessonTutorProgressBubble({lessonTutorPath}) {
 
 LessonTutorProgressBubble.propTypes = {
   lessonTutorPath: PropTypes.string.isRequired,
+  lessonId: PropTypes.number,
+  levelId: PropTypes.string,
+  lessonName: PropTypes.string,
+  userId: PropTypes.number,
 };


### PR DESCRIPTION
## Trello card
https://trello.com/c/b9ZHjVQL/64-statsig-logging-for-ai-tutor-level-header-bubble-click

## Summary
- Adds `LESSON_TUTOR_PROGRESS_BUBBLE_CLICK` event to `AnalyticsConstants.js`
- Fires `analyticsReporter.sendEvent` when user clicks the bot icon in `LessonTutorProgressBubble`
- Threads `lessonId`, `levelId`, `lessonName`, and `userId` from Redux state through `LessonProgress` down to the bubble component

## Test plan
- [x] Open a level with the Lesson Tutor bubble visible (requires `LESSON_TUTOR` experiment enabled and `hasLessonPlan: true`)
- [x] Open browser dev console and click the bot icon
- [x] Confirm a `Lesson Tutor Progress Bubble Click` Statsig event appears in the console log with the correct `lessonId`, `levelId`, `lessonName`, and `userId` fields
- [x] Screenshot the event log and attach to this PR

<img width="383" height="73" alt="Screenshot 2026-04-16 at 5 27 56 PM" src="https://github.com/user-attachments/assets/5ca7a221-e536-4c1e-9ba3-10d5da9c7597" />


🤖 Generated with [Claude Code](https://claude.com/claude-code)