### PR TITLE
Check for co-teacher from provider API

### DIFF
--- a/dashboard/app/controllers/api_controller.rb
+++ b/dashboard/app/controllers/api_controller.rb
@@ -97,10 +97,12 @@ class ApiController < ApplicationController
     course_name = params[:courseName].to_s
     section = CleverSection.find_by(code: CleverSection.code_for_section(course_id))
 
+    # If the section exists and the user isn't already an instructor,
+    # check Clever to see if they're listed as a co-teacher before
+    # fetching the student roster.
+    return head :forbidden if section.present? && !section_instructor?(section) && !clever_teacher_for_course?(course_id)
+
     query_clever_service("sections/#{course_id}/users?role=student") do |students|
-      # If the section exists and the user isn't already an instructor,
-      # check Clever to see if they're listed as a co-teacher.
-      return head :forbidden if section.present? && !section_instructor?(section) && !clever_teacher_for_course?(course_id)
       section = CleverSection.from_service(course_id, current_user.id, students, course_name)
       render json: section.summarize
     end
@@ -680,9 +682,8 @@ class ApiController < ApplicationController
     clever_uid = current_user.uid_for_provider(AuthenticationOption::CLEVER).to_s
     return false if clever_uid.empty?
 
-    tokens = current_user.oauth_tokens_for_provider(AuthenticationOption::CLEVER)
-    client = Clients::CleverRest.new(oauth_token: tokens[:oauth_token])
-    teachers = client.get("sections/#{course_id}/users?role=teacher").fetch('data', [])
+    response = query_clever_service("sections/#{course_id}/users?role=teacher")
+    teachers = response&.fetch('data', []) || []
     teachers.any? {|teacher| teacher.dig('data', 'id').to_s == clever_uid}
   end
 

--- a/dashboard/app/controllers/api_controller.rb
+++ b/dashboard/app/controllers/api_controller.rb
@@ -682,8 +682,9 @@ class ApiController < ApplicationController
     clever_uid = current_user.uid_for_provider(AuthenticationOption::CLEVER).to_s
     return false if clever_uid.empty?
 
-    response = query_clever_service("sections/#{course_id}/users?role=teacher")
-    teachers = response&.fetch('data', []) || []
+    tokens = current_user.oauth_tokens_for_provider(AuthenticationOption::CLEVER)
+    client = Clients::CleverRest.new(oauth_token: tokens[:oauth_token])
+    teachers = client.get("sections/#{course_id}/users?role=teacher").fetch('data', [])
     teachers.any? {|teacher| teacher.dig('data', 'id').to_s == clever_uid}
   end
 

--- a/dashboard/app/controllers/api_controller.rb
+++ b/dashboard/app/controllers/api_controller.rb
@@ -96,9 +96,11 @@ class ApiController < ApplicationController
     course_id = params[:courseId].to_s
     course_name = params[:courseName].to_s
     section = CleverSection.find_by(code: CleverSection.code_for_section(course_id))
-    return head :forbidden if section.present? && !section_instructor?(section)
 
     query_clever_service("sections/#{course_id}/users?role=student") do |students|
+      # If the section exists and the user isn't already an instructor,
+      # check Clever to see if they're listed as a co-teacher.
+      return head :forbidden if section.present? && !section_instructor?(section) && !clever_teacher_for_course?(course_id)
       section = CleverSection.from_service(course_id, current_user.id, students, course_name)
       render json: section.summarize
     end
@@ -117,9 +119,12 @@ class ApiController < ApplicationController
     course_id = params[:courseId].to_s
     course_name = params[:courseName].to_s
     section = GoogleClassroomSection.find_by(code: GoogleClassroomSection.code_for_section(course_id))
-    return head :forbidden if section.present? && !section_instructor?(section)
 
     query_google_classroom_service do |service|
+      # If the section exists and the user isn't already an instructor,
+      # check Google Classroom to see if they're listed as a co-teacher.
+      return head :forbidden if section.present? && !section_instructor?(section) && !google_teacher_for_course?(service, course_id)
+
       students = []
       next_page_token = nil
       loop do
@@ -654,6 +659,31 @@ class ApiController < ApplicationController
   private def section_instructor?(section)
     return false unless current_user
     section&.instructors&.exists?(id: current_user.id)
+  end
+
+  private def google_teacher_for_course?(service, course_id)
+    google_uid = current_user.uid_for_provider(AuthenticationOption::GOOGLE).to_s
+    return false if google_uid.empty?
+
+    next_page_token = nil
+    loop do
+      response = service.list_course_teachers(course_id, page_token: next_page_token)
+      teachers = response.teachers || []
+      return true if teachers.any? {|teacher| teacher.user_id.to_s == google_uid}
+      next_page_token = response.next_page_token
+      break unless next_page_token
+    end
+    false
+  end
+
+  private def clever_teacher_for_course?(course_id)
+    clever_uid = current_user.uid_for_provider(AuthenticationOption::CLEVER).to_s
+    return false if clever_uid.empty?
+
+    tokens = current_user.oauth_tokens_for_provider(AuthenticationOption::CLEVER)
+    client = Clients::CleverRest.new(oauth_token: tokens[:oauth_token])
+    teachers = client.get("sections/#{course_id}/users?role=teacher").fetch('data', [])
+    teachers.any? {|teacher| teacher.dig('data', 'id').to_s == clever_uid}
   end
 
   # Gets progress-related app_options for the given script and level for the

--- a/dashboard/test/controllers/api_controller_test.rb
+++ b/dashboard/test/controllers/api_controller_test.rb
@@ -1606,11 +1606,15 @@ class ApiControllerTest < ActionController::TestCase
     assert_response :forbidden
   end
 
-  test 'import_google_classroom is Forbidden when section exists and current user is not an instructor' do
+  test 'import_google_classroom is Forbidden when section exists and current user is not an instructor or Google co-teacher' do
     mock_service = mock('Google::Apis::ClassroomV1::ClassroomService')
     course_id = Random.hex(10)
+    mock_teachers_response = mock('Google::Apis::ClassroomV1::ListTeachersResponse')
+    mock_teachers_response.stubs(:teachers).returns([])
+    mock_teachers_response.stubs(:next_page_token).returns(nil)
 
     ApiController.any_instance.stubs(:query_google_classroom_service).yields(mock_service)
+    mock_service.stubs(:list_course_teachers).returns(mock_teachers_response)
     mock_service.expects(:list_course_students).never
     GoogleClassroomSection.expects(:from_service).never
 
@@ -1627,6 +1631,45 @@ class ApiControllerTest < ActionController::TestCase
     get :import_google_classroom, params: {courseId: course_id, courseName: 'Existing Section'}
 
     assert_response :forbidden
+  end
+
+  test 'import_google_classroom allows import when user is not an instructor but is a Google Classroom co-teacher' do
+    mock_service = mock('Google::Apis::ClassroomV1::ClassroomService')
+    mock_students_response = mock('Google::Apis::ClassroomV1::ListStudentsResponse')
+    course_id = Random.hex(10)
+    course_name = 'Existing Google Section'
+    students = []
+    section_owner = create(:teacher)
+    teacher = create(:teacher, :with_google_authentication_option)
+    imported_section = mock('GoogleClassroomSection')
+    imported_section.stubs(:summarize).returns({section_id: Random.hex(10)})
+
+    create(
+      :section,
+      user: section_owner,
+      login_type: Section::LOGIN_TYPE_GOOGLE_CLASSROOM,
+      code: GoogleClassroomSection.code_for_section(course_id)
+    )
+
+    google_uid = teacher.uid_for_provider(AuthenticationOption::GOOGLE)
+    mock_teacher = mock('teacher')
+    mock_teacher.stubs(:user_id).returns(google_uid)
+    mock_teachers_response = mock('Google::Apis::ClassroomV1::ListTeachersResponse')
+    mock_teachers_response.stubs(:teachers).returns([mock_teacher])
+    mock_teachers_response.stubs(:next_page_token).returns(nil)
+
+    mock_students_response.stubs(:students).returns(students)
+    mock_students_response.stubs(:next_page_token).returns(nil)
+
+    ApiController.any_instance.stubs(:query_google_classroom_service).yields(mock_service)
+    mock_service.expects(:list_course_teachers).with(course_id, page_token: nil).returns(mock_teachers_response)
+    mock_service.expects(:list_course_students).with(course_id, page_token: nil).returns(mock_students_response)
+    GoogleClassroomSection.expects(:from_service).with(course_id, teacher.id, students, course_name).returns(imported_section)
+    sign_in teacher
+
+    get :import_google_classroom, params: {courseId: course_id, courseName: course_name}
+
+    assert_response :ok
   end
 
   test 'import_google_classroom allows first import when section does not exist' do
@@ -1684,8 +1727,12 @@ class ApiControllerTest < ActionController::TestCase
     assert_response :ok
   end
 
-  test 'import_clever_classroom is Forbidden when section exists and current user is not an instructor' do
+  test 'import_clever_classroom is Forbidden when section exists and current user is not an instructor or Clever co-teacher' do
     course_id = Random.hex(10)
+
+    mock_clever_client = mock('Clients::CleverRest')
+    Clients::CleverRest.stubs(:new).returns(mock_clever_client)
+    mock_clever_client.stubs(:get).with("sections/#{course_id}/users?role=teacher").returns({'data' => []})
 
     ApiController.any_instance.stubs(:query_clever_service).yields([])
     CleverSection.expects(:from_service).never
@@ -1703,6 +1750,39 @@ class ApiControllerTest < ActionController::TestCase
     get :import_clever_classroom, params: {courseId: course_id, courseName: 'Existing Section'}
 
     assert_response :forbidden
+  end
+
+  test 'import_clever_classroom allows import when user is not an instructor but is a Clever co-teacher' do
+    course_id = Random.hex(10)
+    course_name = 'Existing Clever Section'
+    students = []
+    section_owner = create(:teacher)
+    teacher = create(:teacher, :with_clever_authentication_option)
+    imported_section = mock('CleverSection')
+    imported_section.stubs(:summarize).returns({section_id: Random.hex(10)})
+
+    create(
+      :section,
+      user: section_owner,
+      login_type: Section::LOGIN_TYPE_CLEVER,
+      code: CleverSection.code_for_section(course_id)
+    )
+
+    clever_uid = teacher.uid_for_provider(AuthenticationOption::CLEVER)
+    mock_clever_client = mock('Clients::CleverRest')
+    Clients::CleverRest.stubs(:new).returns(mock_clever_client)
+    mock_clever_client.stubs(:get).with("sections/#{course_id}/users?role=teacher").returns({
+                                                                                              'data' => [{'data' => {'id' => clever_uid}}]
+                                                                                            }
+)
+
+    ApiController.any_instance.stubs(:query_clever_service).yields(students)
+    CleverSection.expects(:from_service).with(course_id, teacher.id, students, course_name).returns(imported_section)
+    sign_in teacher
+
+    get :import_clever_classroom, params: {courseId: course_id, courseName: course_name}
+
+    assert_response :ok
   end
 
   test 'import_clever_classroom allows first import when section does not exist' do


### PR DESCRIPTION
When fixing a bug related to Google Classroom/Clever section syncing ([PR](https://github.com/code-dot-org/code-dot-org/pull/71128)), it also introduced a regression where co-teachers where not automatically updated in our system. This PR changes logic to allow existing co-teacher [promotion logic](https://github.com/code-dot-org/code-dot-org/blob/staging/dashboard/app/models/sections/omni_auth_section.rb#L53-L56) to be reached, by checking if a user is listed as an instructor via the Google/Clever APIs. This API path will only be hit once, after which they will be a `section_instructor` in our system, and subsequent syncs won't hit the API request.

<!--
  Summary of the change: background, motivation, and context.
  Include screenshots, videos, or before/after comparisons for UI changes.
-->



## Links
<!-- Jira tickets, design docs, Slack threads, related PRs, etc. -->

- Jira: https://codedotorg.atlassian.net/browse/P20-1849

## Testing story
<!-- How was this tested? Manual steps, adhoc links, automated tests, or why testing isn't needed. -->



## Deployment notes
<!-- Delete this section if it's a standard merge-and-deploy.
     Otherwise: migrations, feature flags, coordination, caching impacts, etc. -->



## Privacy and security
<!-- Delete this section if there is no privacy/security impact.
     Otherwise: new PII, auth changes, API surface changes, etc. -->

