### PR TITLE
AI Tutor: Statsig logging for each card click in InterventionBox

### DIFF
--- a/apps/src/aiTutor/views/lessonDeepDive/InterventionBox.tsx
+++ b/apps/src/aiTutor/views/lessonDeepDive/InterventionBox.tsx
@@ -162,7 +162,7 @@ const InterventionBox: FC<InterventionBoxProps> = ({
                 className={`${styles.navItem} ${
                   isActive ? card.activeColorClass : ''
                 }`}
-                onClick={() => handleCardSelect(card.id)}
+                onClick={() => setSelected(card.id)}
                 aria-label={card.label}
                 aria-current={isActive ? 'page' : undefined}
               >

--- a/apps/src/aiTutor/views/lessonDeepDive/InterventionBox.tsx
+++ b/apps/src/aiTutor/views/lessonDeepDive/InterventionBox.tsx
@@ -1,9 +1,13 @@
 import FontAwesomeV6Icon from '@code-dot-org/component-library/fontAwesomeV6Icon';
 import {Typography} from '@mui/material';
 import {createTheme, ThemeProvider} from '@mui/material/styles';
-import React, {FC, useState} from 'react';
+import React, {FC, useCallback, useState} from 'react';
 
 const lightTheme = createTheme({palette: {mode: 'light'}});
+
+import {sendLab2AnalyticsEvent} from '@cdo/apps/lab2/utils';
+import {EVENTS} from '@cdo/apps/metrics/AnalyticsConstants';
+import {useAppSelector} from '@cdo/apps/util/reduxHooks';
 
 import LessonDeepDiveTutorChat from './LessonDeepDiveTutorChat';
 import PodcastsBox from './PodcastsBox';
@@ -78,6 +82,23 @@ const InterventionBox: FC<InterventionBoxProps> = ({
   reflectionData,
 }) => {
   const [selected, setSelected] = useState<CardId | null>(null);
+  const userId = useAppSelector(state => state.currentUser.userId);
+
+  const handleCardSelect = useCallback(
+    (cardId: CardId) => {
+      setSelected(cardId);
+      sendLab2AnalyticsEvent(
+        EVENTS.AI_TUTOR_LESSON_DEEP_DIVE_MODALITY_CLICKED,
+        {
+          modality: cardId,
+          lessonId,
+          lessonName,
+          userId,
+        }
+      );
+    },
+    [lessonId, lessonName, userId]
+  );
 
   return (
     <div className={styles.container}>
@@ -100,7 +121,7 @@ const InterventionBox: FC<InterventionBoxProps> = ({
                   key={card.id}
                   type="button"
                   className={`${styles.card} ${card.colorClass}`}
-                  onClick={() => setSelected(card.id)}
+                  onClick={() => handleCardSelect(card.id)}
                   aria-label={card.label}
                 >
                   <FontAwesomeV6Icon iconName={card.icon} />
@@ -141,7 +162,7 @@ const InterventionBox: FC<InterventionBoxProps> = ({
                 className={`${styles.navItem} ${
                   isActive ? card.activeColorClass : ''
                 }`}
-                onClick={() => setSelected(card.id)}
+                onClick={() => handleCardSelect(card.id)}
                 aria-label={card.label}
                 aria-current={isActive ? 'page' : undefined}
               >

--- a/apps/src/aiTutor/views/lessonDeepDive/InterventionBox.tsx
+++ b/apps/src/aiTutor/views/lessonDeepDive/InterventionBox.tsx
@@ -5,8 +5,8 @@ import React, {FC, useCallback, useState} from 'react';
 
 const lightTheme = createTheme({palette: {mode: 'light'}});
 
-import {sendLab2AnalyticsEvent} from '@cdo/apps/lab2/utils';
 import {EVENTS} from '@cdo/apps/metrics/AnalyticsConstants';
+import analyticsReporter from '@cdo/apps/metrics/AnalyticsReporter';
 import {useAppSelector} from '@cdo/apps/util/reduxHooks';
 
 import LessonDeepDiveTutorChat from './LessonDeepDiveTutorChat';
@@ -87,7 +87,7 @@ const InterventionBox: FC<InterventionBoxProps> = ({
   const handleCardSelect = useCallback(
     (cardId: CardId) => {
       setSelected(cardId);
-      sendLab2AnalyticsEvent(
+      analyticsReporter.sendEvent(
         EVENTS.AI_TUTOR_LESSON_DEEP_DIVE_MODALITY_CLICKED,
         {
           modality: cardId,

--- a/apps/src/metrics/AnalyticsConstants.js
+++ b/apps/src/metrics/AnalyticsConstants.js
@@ -328,6 +328,8 @@ const EVENTS = {
   AI_TUTOR_CODE_SNIPPET_ADDED_TO_CONTEXT:
     'AI Tutor Code Snippet Added to Context',
   AI_TUTOR_FILE_ADDED_TO_CONTEXT: 'AI Tutor File Added to Context',
+  AI_TUTOR_LESSON_DEEP_DIVE_MODALITY_CLICKED:
+    'AI Tutor Lesson Deep Dive Modality Clicked',
 
   // Javalab
   JAVALAB_TEST_BUTTON_CLICK: 'Javalab Test Button Clicked',


### PR DESCRIPTION
### Rationale for change 
We want to get a sense for which modality students are opting into from this screen 
<img width="1108" height="907" alt="Screenshot 2026-04-17 at 1 16 42 PM" src="https://github.com/user-attachments/assets/74bc6e26-ded1-4088-8c32-5ede7c8ec8e9" />

### Summary of change 
This PR adds Statsig logging for card clicks into each modality

### Evidence the change does what we want 
<img width="377" height="87" alt="Screenshot 2026-04-17 at 1 15 55 PM" src="https://github.com/user-attachments/assets/0b1a4d5f-1ba9-4966-84e0-d617fca757f4" />
<img width="378" height="84" alt="Screenshot 2026-04-17 at 1 15 06 PM" src="https://github.com/user-attachments/assets/5b42982c-701a-4248-a239-0e29cbf25fe5" />
<img width="371" height="85" alt="Screenshot 2026-04-17 at 1 14 31 PM" src="https://github.com/user-attachments/assets/3a24f1c3-b166-463f-9735-aef11de337be" />
<img width="366" height="78" alt="Screenshot 2026-04-17 at 1 14 18 PM" src="https://github.com/user-attachments/assets/df283a10-03d6-4a2a-a090-2fd27dabde03" />

### Follow up 
Next we want to add Statsig logging for navigating between modalities in the footer. 

👩🏼‍💻 Generated by Erin

--------------------------------------------------------------

## Trello card
https://trello.com/c/60QEgmpo/5-statsig-logging-for-each-card-click-in-interventionbox

## Summary
- Adds new event constant `AI_TUTOR_LESSON_DEEP_DIVE_MODALITY_CLICKED` to `AnalyticsConstants.js`
- Logs that event via `sendLab2AnalyticsEvent` each time a user selects a modality (flashcards, chat, videos, podcasts) from InterventionBox, including from the bottom nav
- Payload includes `modality`, `lessonId`, `lessonName`, and `userId` (from Redux `state.currentUser.userId`)

## Test plan
- [x] Open the lesson deep dive tutor as a logged-in student
- [x] Click each of the four modality cards (flashcards, chat, videos, podcasts) and verify events appear in Statsig with correct metadata
- [x] Confirm `lessonId`, `lessonName`, and `userId` are populated correctly in the event payload

🤖 Generated with [Claude Code](https://claude.com/claude-code)