### PR TITLE
Remove Radium from EqualColumns

### DIFF
--- a/apps/src/publicKeyCryptography/EqualColumns.jsx
+++ b/apps/src/publicKeyCryptography/EqualColumns.jsx
@@ -1,6 +1,5 @@
 /** @file Arranges child components as columns of equal width, filling available space */
 import PropTypes from 'prop-types';
-import Radium from 'radium'; // eslint-disable-line no-restricted-imports
 import React from 'react';
 
 import {AnyChildren} from './types';
@@ -40,4 +39,4 @@ class EqualColumns extends React.Component {
   }
 }
 
-export default Radium(EqualColumns);
+export default EqualColumns;


### PR DESCRIPTION
Radium is deprecated, still trucking on removing all the references...

Checked with human 👀 
<img width="1533" height="536" alt="Screenshot 2026-04-17 at 9 03 59 AM" src="https://github.com/user-attachments/assets/f1d339b7-dfbe-4cbd-8b3f-bb2bc5883d53" />

------------------------------------
## Trello card
https://trello.com/c/IRCw21QN/8-remove-radium-from-apps-src-publickeycryptography-equalcolumnsjsx

## Summary
- Removes `radium` import and `Radium()` HoC wrapper from `EqualColumns.jsx`
- No style regressions expected: the component uses only static inline styles (float, width, margin) with no Radium-specific features (`:hover`, `@media`, etc.)

## Where to verify
The `EqualColumns` component renders inside `PublicKeyCryptographyWidget`, used on the AllTheThings Public Key Cryptography level:

**`/s/allthethings/lessons/33/levels/1`**

Check that Alice, Eve, and Bob columns still lay out correctly side-by-side on that page.

## Test plan
- [x] Visit `/s/allthethings/lessons/33/levels/1`
- [x] Confirm the three-column layout (Alice, Eve, Bob) renders without regression
- [x] Confirm no console errors related to Radium or styles

🤖 Generated with [Claude Code](https://claude.com/claude-code)