### PR TITLE
Adds localization of legacy init()-based custom blocks.

### DIFF
--- a/apps/src/StudioApp.js
+++ b/apps/src/StudioApp.js
@@ -16,6 +16,7 @@ import {
   highlightBlock,
   loadBlocksToWorkspace,
   processToolboxXml,
+  localizeBlockInitDefinition,
 } from '@cdo/apps/blockly/utils';
 import {addCallouts} from '@cdo/apps/code-studio/callouts';
 import {createLibraryClosure} from '@cdo/apps/code-studio/components/libraries/libraryParser';
@@ -551,7 +552,10 @@ StudioApp.prototype.init = function (config) {
   // TODO (cpirich): implement block count for droplet (for now, blockly only)
   if (this.isUsingBlockly()) {
     // Hook the blockly environment into the localization engine
-    if (experiments.isEnabledAllowingQueryString(experiments.LOCALIZEJS)) {
+    if (
+      localization.isLocalizeJS() ||
+      experiments.isEnabledAllowingQueryString(experiments.LOCALIZEJS)
+    ) {
       localization.on('change', info => {
         const blockDefinitions =
           BlocklyUtils.getBlockDefinitionsForUpdatedLocale(info.rtl);
@@ -559,6 +563,14 @@ StudioApp.prototype.init = function (config) {
           blockly: Blockly,
           blockDefinitions,
           customInputTypes: Blockly.SourceCustomInputTypes,
+        });
+
+        // Also localize the base init blocks
+        Object.entries(BlocklyCore.Blocks).forEach(([key, blockDefinition]) => {
+          if (blockDefinition.init) {
+            BlocklyCore.Blocks[key] =
+              localizeBlockInitDefinition(blockDefinition);
+          }
         });
         BlocklyUtils.refreshWorkspacesForUpdatedLocale(info.rtl);
       });

--- a/apps/src/StudioApp.js
+++ b/apps/src/StudioApp.js
@@ -15,6 +15,7 @@ import {
   appendSharedFunctionsToState,
   highlightBlock,
   loadBlocksToWorkspace,
+  localizeBlockStrings,
   processToolboxXml,
   localizeBlockInitDefinition,
 } from '@cdo/apps/blockly/utils';
@@ -1348,7 +1349,7 @@ StudioApp.prototype.initReadonly = function (options) {
  * @param {string} source Text representation of blocks (XML or JSON).
  */
 StudioApp.prototype.loadBlocks = function (source) {
-  loadBlocksToWorkspace(Blockly.mainBlockSpace, source);
+  loadBlocksToWorkspace(Blockly.mainBlockSpace, localizeBlockStrings(source));
 };
 
 /**

--- a/apps/src/block_utils.js
+++ b/apps/src/block_utils.js
@@ -933,6 +933,8 @@ exports.createJsWrapperBlockCreator = function (
 
     blockly.Blocks[blockName] = {
       helpUrl: getHelpUrl(docFunc), // optional param
+      // blockText defined blocks are already localized
+      isLocalized: true,
       init: function () {
         this.setStyle(style || BlockStyles.DEFAULT);
 

--- a/apps/src/blockly/addons/cdoFieldDropdown.ts
+++ b/apps/src/blockly/addons/cdoFieldDropdown.ts
@@ -29,6 +29,7 @@ export default class CdoFieldDropdown extends BlocklyCore.FieldDropdown {
     }
     super(menuGenerator, validator, config);
   }
+
   /**
    * Ensure that the input value is a valid language-neutral option.
    * @param newValue The input value.
@@ -104,6 +105,18 @@ export default class CdoFieldDropdown extends BlocklyCore.FieldDropdown {
     // Currently, we support the `config` attribute if `config` is stored in xml, but not in json.
     // The config is handled by `fromXml`.
     this.fromXml(field);
+  }
+
+  /**
+   * Updates to ensure that the popup div does not translate the items.
+   */
+  showEditor_(e?: MouseEvent) {
+    super.showEditor_(e);
+
+    const root = Blockly.DropDownDiv.getContentDiv();
+    for (const item of root.querySelectorAll('.blocklyMenuItemContent')) {
+      item.setAttribute('data-notranslate', 'true');
+    }
   }
 
   /**

--- a/apps/src/blockly/addons/cdoFieldProcedureName.ts
+++ b/apps/src/blockly/addons/cdoFieldProcedureName.ts
@@ -1,0 +1,75 @@
+import * as BlocklyCore from 'blockly/core';
+
+import localization from '@cdo/apps/localization';
+
+import {BLOCK_TYPES} from '../constants';
+import {
+  isTranslatable,
+  onRegistryChange,
+} from '../utils/localization/procedureNameRegistry';
+
+const BEHAVIOR_PREFIX = '[behavior]';
+
+/**
+ * Holds the canonical (author-given) procedure or behavior name as its value,
+ * while rendering a translated form when the name is registered as
+ * translatable. Used by procedures_callnoreturn and behavior_get for their
+ * NAME field so that:
+ *   - serialization (extraState, saveExtraState) sees only the canonical name
+ *   - getProcedureModel / findProcedureModel_ lookups key on the canonical name
+ *   - level solution-matching still compares canonical strings
+ *   - the student sees a translated label when the curriculum declares one
+ *
+ * FieldLabel semantics are preserved: the field is not serializable on its own
+ * (the block's extraState carries the name), and setFieldValue('NAME', x) still
+ * stores x as-is.
+ */
+export default class CdoFieldProcedureName extends BlocklyCore.FieldLabel {
+  private localeListener_?: () => void;
+  private registryUnsubscribe_?: () => void;
+
+  protected override getDisplayText_(): string {
+    const canonical = (this.getValue() as string | null) ?? '';
+    if (!canonical || !isTranslatable(canonical)) {
+      return canonical;
+    }
+    // Behavior names share the same English strings as procedures ("walk",
+    // "jump", etc.) but need distinct translator entries because the target
+    // wording can differ. Send a prefixed source with an extra label and
+    // strip the prefix if the translator kept it; if they dropped it, trust
+    // the returned text verbatim.
+    if (this.getSourceBlock()?.type === BLOCK_TYPES.behaviorGet) {
+      const translated = localization.translate(
+        `${BEHAVIOR_PREFIX} ${canonical}`,
+        ['blockly-procedure-name', 'blockly-behavior']
+      );
+      if (translated.startsWith(BEHAVIOR_PREFIX)) {
+        return translated.slice(BEHAVIOR_PREFIX.length).trim();
+      }
+      return translated;
+    }
+    return localization.translate(canonical, ['blockly-procedure-name']);
+  }
+
+  override initView(): void {
+    super.initView();
+    this.localeListener_ = () => this.forceRerender();
+    localization.on('change', this.localeListener_);
+    // Pick up names that arrive after this field first rendered — e.g.,
+    // flyout/toolbox caller blocks whose definition registers only once the
+    // hidden workspace finishes loading.
+    this.registryUnsubscribe_ = onRegistryChange(() => this.forceRerender());
+  }
+
+  override dispose(): void {
+    if (this.localeListener_) {
+      localization.off('change', this.localeListener_);
+      this.localeListener_ = undefined;
+    }
+    if (this.registryUnsubscribe_) {
+      this.registryUnsubscribe_();
+      this.registryUnsubscribe_ = undefined;
+    }
+    super.dispose();
+  }
+}

--- a/apps/src/blockly/blocklyWrapper.ts
+++ b/apps/src/blockly/blocklyWrapper.ts
@@ -36,6 +36,7 @@ import CdoFieldDropdown from './addons/cdoFieldDropdown';
 import CdoFieldLabel from './addons/cdoFieldLabel';
 import CdoFieldNumber from './addons/cdoFieldNumber';
 import CdoFieldParameter from './addons/cdoFieldParameter';
+import CdoFieldProcedureName from './addons/cdoFieldProcedureName';
 import CdoFieldVariable from './addons/cdoFieldVariable';
 import initializeGenerator from './addons/cdoGenerator';
 import {gestureOverrides} from './addons/cdoGesture';
@@ -111,6 +112,7 @@ import {
   setThemeAndRenderBlocks,
   strip,
 } from './utils';
+import {handleFinishedLoading as registerCurriculumProcedureNames} from './utils/localization/procedureNameRegistry';
 
 const options: {contextMenu: true; shortcut: true} = {
   contextMenu: true,
@@ -230,6 +232,7 @@ function initializeBlocklyWrapper(blocklyInstance: BlocklyCoreInstance) {
     ['field_label', CdoFieldLabel],
     ['field_number', CdoFieldNumber],
     ['field_parameter', CdoFieldParameter],
+    ['field_procedure_name', CdoFieldProcedureName],
     ['field_variable', CdoFieldVariable],
   ];
   // Tell Blockly to use our custom versions of fields
@@ -733,6 +736,10 @@ function initializeBlocklyWrapper(blocklyInstance: BlocklyCoreInstance) {
     // blocks back to the correct positions after a browser window resize.
     // See: https://github.com/google/blockly/issues/8637
     workspace.addChangeListener(storeWorkspaceWidth);
+    // On initial load, record the procedure/behavior definition names that
+    // came with the level so their caller blocks can render a translated
+    // display while continuing to store and key on the canonical name.
+    workspace.addChangeListener(registerCurriculumProcedureNames);
     // Jigsaw blocks have additional path SVGs that need to be filled with
     // a pattern image.
     if (optOptionsExtended.isJigsaw) {
@@ -793,6 +800,9 @@ function initializeBlocklyWrapper(blocklyInstance: BlocklyCoreInstance) {
     const hiddenDefinitionWorkspace =
       new Blockly.Workspace() as ExtendedWorkspace;
     hiddenDefinitionWorkspace.addChangeListener(disableOrphans);
+    hiddenDefinitionWorkspace.addChangeListener(
+      registerCurriculumProcedureNames
+    );
     // The hidden definition workspace is not rendered, so do not try to add
     // svg frames around the definitions.
     hiddenDefinitionWorkspace.noFunctionBlockFrame = true;

--- a/apps/src/blockly/blocklyWrapper.ts
+++ b/apps/src/blockly/blocklyWrapper.ts
@@ -840,7 +840,6 @@ function initializeBlocklyWrapper(blocklyInstance: BlocklyCoreInstance) {
   // various Blockly metadata that gets installed. These are used by the
   // updateLocale(), localizeVariables(), etc, functions to translate a
   // variety of both custom and built-in Blockly content.
-  blocklyWrapper.SourceMsg = {};
   blocklyWrapper.SourceVariables = {};
   blocklyWrapper.SourceCustomBlocks = {
     blockDefinitionsByName: {},

--- a/apps/src/blockly/customBlocks/behaviorBlocks.ts
+++ b/apps/src/blockly/customBlocks/behaviorBlocks.ts
@@ -79,7 +79,7 @@ export const blocks = BlocklyCore.common.createBlockDefinitionsFromJsonArray([
     message0: '%1 %2',
     args0: [
       {
-        type: 'field_label',
+        type: 'field_procedure_name',
         name: 'NAME',
         text: '%{BKY_UNNAMED_KEY}',
       },

--- a/apps/src/blockly/customBlocks/proceduresBlocks.ts
+++ b/apps/src/blockly/customBlocks/proceduresBlocks.ts
@@ -80,7 +80,7 @@ export const blocks = BlocklyCore.common.createBlockDefinitionsFromJsonArray([
     type: BLOCK_TYPES.procedureCall,
     message0: '%1 %2',
     args0: [
-      {type: 'field_label', name: 'NAME', text: '%{BKY_UNNAMED_KEY}'},
+      {type: 'field_procedure_name', name: 'NAME', text: '%{BKY_UNNAMED_KEY}'},
       {
         type: 'input_dummy',
         name: 'TOPROW',

--- a/apps/src/blockly/types.ts
+++ b/apps/src/blockly/types.ts
@@ -22,6 +22,7 @@ export interface BlockDefinition {
 
 export interface BlockConfig {
   args: arg[];
+  sourceArgs?: arg[];
   blockText: string;
   color: [number, number, number];
   func: string;

--- a/apps/src/blockly/types.ts
+++ b/apps/src/blockly/types.ts
@@ -153,8 +153,6 @@ export interface BlocklyWrapperType extends BlocklyCoreType {
     [name: string]: BlocklyCore.ShortcutRegistry.KeyboardShortcut | undefined;
   };
   extraScrollHeight?: number;
-  /** Maintains the original English forms of Msg.* strings */
-  SourceMsg: {[key: string]: string};
   /** Maintains the original English names of provided variables in flyouts, toolboxes, etc */
   SourceVariables: {[key: string]: string};
   /** Keeps track of the original inputTypes passed in when predefined in level metadata */

--- a/apps/src/blockly/utils/index.ts
+++ b/apps/src/blockly/utils/index.ts
@@ -13,6 +13,7 @@ export * from './fields/sounds';
 export * from './fields/validators';
 export * from './legacy/blockLimits';
 export * from './localization/blockDefinitions';
+export * from './localization/blockStrings';
 export * from './localization/locale';
 export * from './localization/variables';
 export * from './serialization/hooks';

--- a/apps/src/blockly/utils/localization/blockDefinitions.ts
+++ b/apps/src/blockly/utils/localization/blockDefinitions.ts
@@ -72,6 +72,14 @@ type BlockInitDefinition = (typeof BlocklyCore.Blocks)[string];
 export function localizeBlockInitDefinition(
   blockDefinition: BlockInitDefinition
 ): BlockInitDefinition {
+  // We can ensure that this function does not happen for any blocks
+  // we localize in a different way. Behaviors and other custom blocks
+  // eventually get an init() function structure, but we localize with
+  // the extra context beforehand.
+  if (blockDefinition.isLocalized) {
+    return blockDefinition;
+  }
+
   // Detect if we have already wrapped this block
   if (blockDefinition.oldInit) {
     // Reset it
@@ -92,9 +100,7 @@ export function localizeBlockInitDefinition(
 function localizeBlockInPlace(block: BlocklyCore.Block): void {
   localizeTooltipInPlace(block);
   for (const input of block.inputList) {
-    for (const field of input.fieldRow) {
-      localizeFieldInPlace(field);
-    }
+    localizeInputInPlace(block, input);
   }
 }
 
@@ -116,18 +122,152 @@ function localizeTooltipInPlace(block: BlocklyCore.Block): void {
   // localization when its init runs.
 }
 
-function localizeFieldInPlace(field: BlocklyCore.Field): void {
-  if (field instanceof BlocklyCore.FieldLabel) {
-    const text = field.getText();
-    if (text) {
-      field.setValue(translate(text, BLOCK_LABELS));
+/**
+ * Groups an input's fieldRow into a single translatable message and reshuffles
+ * the row based on where the translator places the %N placeholders.
+ *
+ * Label text runs between non-label fields are concatenated into text
+ * fragments; every non-label field becomes a %N placeholder in authored
+ * order. For value and statement inputs, the downstream connection slot is
+ * exposed as a trailing %N as well, so translators see the full sentence
+ * (e.g. `"do %1"` where %1 is the statement block that will connect).
+ *
+ * The translator receives e.g. `"repeat until %1"` and can return
+ * `"%1 まで繰り返す"` — the image/dropdown at %1 then moves accordingly.
+ * Connection slots are an exception: Blockly always renders a connection
+ * at the end of its input, so moving its %N in translation gives the
+ * translator context without actually reordering the connection.
+ *
+ * Runs during init, before the block is rendered, so fieldRow can be spliced
+ * directly without DOM teardown. Field names on the preserved non-label
+ * fields survive unchanged, so `getFieldValue('DIR')` and friends still work.
+ *
+ * Dropdown options are translated in a separate pass so their internal text
+ * gets retargeted regardless of the surrounding sentence.
+ */
+function localizeInputInPlace(
+  block: BlocklyCore.Block,
+  input: BlocklyCore.Input
+): void {
+  // Translate dropdown options up-front; this is independent of grouping.
+  for (const field of input.fieldRow) {
+    if (field instanceof BlocklyCore.FieldDropdown) {
+      localizeDropdownInPlace(field);
     }
+  }
+
+  // Bucket fields into text fragments (labels) and %N args (everything else).
+  const existingLabels: BlocklyCore.FieldLabel[] = [];
+  const args: BlocklyCore.Field[] = [];
+  const parts: string[] = [];
+  let buf = '';
+  for (const field of input.fieldRow) {
+    if (field instanceof BlocklyCore.FieldLabel) {
+      buf += field.getText();
+      existingLabels.push(field);
+    } else {
+      if (buf) {
+        parts.push(buf);
+        buf = '';
+      }
+      args.push(field);
+      parts.push(`%${args.length}`);
+    }
+  }
+  if (buf) {
+    parts.push(buf);
+  }
+
+  // Nothing translatable in this row — pure non-label fields (e.g. a lone
+  // dropdown). Dropdown options were already handled above.
+  if (existingLabels.length === 0) {
     return;
   }
-  if (field instanceof BlocklyCore.FieldDropdown) {
-    localizeDropdownInPlace(field);
+
+  // Value and statement inputs have a downstream connection slot that renders
+  // after the fieldRow. Expose it as a trailing %N placeholder so translators
+  // see the full sentence (e.g. `"do %2"` for a statement input labeled "do").
+  // Blockly renders the connection at the row's end regardless of where the
+  // translator places this %N, so on the rebuild side the connection index is
+  // simply consumed without emitting a field.
+  const connectionIndex = input.connection ? args.length : -1;
+  if (connectionIndex >= 0) {
+    parts.push(`%${connectionIndex + 1}`);
+  }
+
+  const message = parts.join(' ');
+  if (!message) {
     return;
   }
+
+  const translated = translate(message, BLOCK_LABELS);
+
+  // Walk the translated message, emitting text fragments and %N references
+  // in whatever order the translator produced.
+  type Segment = {kind: 'text'; text: string} | {kind: 'arg'; index: number};
+  const segments: Segment[] = [];
+  const consumed = new Set<number>();
+  const placeholder = /%(\d+)/g;
+  let cursor = 0;
+  let match: RegExpExecArray | null;
+  while ((match = placeholder.exec(translated)) !== null) {
+    const pre = translated.slice(cursor, match.index);
+    if (pre) segments.push({kind: 'text', text: pre});
+    const index = Number(match[1]) - 1;
+    if (index === connectionIndex) {
+      // Connection slot: consume it so it isn't backfilled, but don't emit
+      // a fieldRow entry. Blockly will render the connection at the row end.
+      consumed.add(index);
+    } else if (index >= 0 && index < args.length && !consumed.has(index)) {
+      segments.push({kind: 'arg', index});
+      consumed.add(index);
+    }
+    cursor = match.index + match[0].length;
+  }
+  const tail = translated.slice(cursor);
+  if (tail) segments.push({kind: 'text', text: tail});
+
+  // If the translator dropped any %N, tack those fields on at the end so
+  // the block never silently loses an input's dropdown or image.
+  for (let i = 0; i < args.length; i++) {
+    if (!consumed.has(i)) {
+      segments.push({kind: 'arg', index: i});
+    }
+  }
+
+  // Build the new fieldRow, reusing existing label instances where we can.
+  // This preserves FieldLabel subclass behavior (e.g. CdoFieldLabel's
+  // fixedSize) when the translated message has the same number of text
+  // segments as the original had labels — which is the common case.
+  const rebuilt: BlocklyCore.Field[] = [];
+  let labelCursor = 0;
+  for (const seg of segments) {
+    if (seg.kind === 'text') {
+      if (labelCursor < existingLabels.length) {
+        const label = existingLabels[labelCursor++];
+        label.setValue(seg.text);
+        rebuilt.push(label);
+      } else {
+        rebuilt.push(mountLabel(block, seg.text));
+      }
+    } else {
+      rebuilt.push(args[seg.index]);
+    }
+  }
+
+  // Pre-render, so direct array mutation is sufficient; no DOM teardown.
+  input.fieldRow.length = 0;
+  input.fieldRow.push(...rebuilt);
+}
+
+function mountLabel(
+  block: BlocklyCore.Block,
+  text: string
+): BlocklyCore.FieldLabel {
+  const field = new BlocklyCore.FieldLabel(text);
+  // setSourceBlock throws if already bound; this instance is freshly minted.
+  field.setSourceBlock(block);
+  return field;
 }
 
 function localizeDropdownInPlace(field: BlocklyCore.FieldDropdown): void {

--- a/apps/src/blockly/utils/localization/blockDefinitions.ts
+++ b/apps/src/blockly/utils/localization/blockDefinitions.ts
@@ -11,6 +11,16 @@ const TOOLTIP_LABELS = ['blockly-block', 'blockly-tooltip'];
  * we add a prefix to them so they can be translated with context.
  */
 function translate(text: string, labels: string[]) {
+  // Ignore things that are effectively numbers
+  if (isFinite(+(text || NaN))) {
+    return text;
+  }
+
+  // Ignore hex colors
+  if (text.match(/^#[0-9a-fA-F]{6}$/)) {
+    return text;
+  }
+
   if (text.length < 4) {
     const result = localization.translate(`[block] ${text}`, labels);
     if (result.startsWith('[block]')) {
@@ -157,12 +167,18 @@ function localizeInputInPlace(
   }
 
   // Bucket fields into text fragments (labels) and %N args (everything else).
+  // A *named* FieldLabel (e.g. NAME on a procedures_callnoreturn, PARAMS on a
+  // procedures_defnoreturn) holds dynamic block state that the block's own
+  // deserialize/mutator path writes into later — its initial text is a
+  // placeholder (often `%{BKY_UNNAMED_KEY}` → "unnamed"), not authored copy.
+  // Those must flow through as %N args so we neither translate the placeholder
+  // nor clobber the field's value, and so the rebuild can't drop them.
   const existingLabels: BlocklyCore.FieldLabel[] = [];
   const args: BlocklyCore.Field[] = [];
   const parts: string[] = [];
   let buf = '';
   for (const field of input.fieldRow) {
-    if (field instanceof BlocklyCore.FieldLabel) {
+    if (field instanceof BlocklyCore.FieldLabel && !field.name) {
       buf += field.getText();
       existingLabels.push(field);
     } else {
@@ -248,6 +264,7 @@ function localizeInputInPlace(
         label.setValue(seg.text);
         rebuilt.push(label);
       } else {
+        console.log('creating new label', seg.text);
         rebuilt.push(mountLabel(block, seg.text));
       }
     } else {

--- a/apps/src/blockly/utils/localization/blockDefinitions.ts
+++ b/apps/src/blockly/utils/localization/blockDefinitions.ts
@@ -279,7 +279,6 @@ function localizeInputInPlace(
         label.setValue(seg.text);
         rebuilt.push(label);
       } else {
-        console.log('creating new label', seg.text);
         rebuilt.push(mountLabel(block, seg.text));
       }
     } else {

--- a/apps/src/blockly/utils/localization/blockDefinitions.ts
+++ b/apps/src/blockly/utils/localization/blockDefinitions.ts
@@ -10,7 +10,14 @@ const TOOLTIP_LABELS = ['blockly-block', 'blockly-tooltip'];
  * Wraps localization.translate so that for short labels that are a single word,
  * we add a prefix to them so they can be translated with context.
  */
-function translate(text: string, labels: string[]) {
+export function translate(
+  text: string,
+  labels: string[],
+  forcePrefix: boolean = false
+) {
+  // Ensure a default set of labels
+  labels = Array.from(new Set(labels.concat(BLOCK_LABELS)));
+
   // Ignore things that are effectively numbers
   if (isFinite(+(text || NaN))) {
     return text;
@@ -21,7 +28,7 @@ function translate(text: string, labels: string[]) {
     return text;
   }
 
-  if (text.length < 4) {
+  if (text.length < 4 || forcePrefix) {
     const result = localization.translate(`[block] ${text}`, labels);
     if (result.startsWith('[block]')) {
       return result.substring(7).trim();
@@ -160,8 +167,16 @@ function localizeInputInPlace(
   input: BlocklyCore.Input
 ): void {
   // Translate dropdown options up-front; this is independent of grouping.
+  // FieldVariable (and its subclasses — e.g. CdoFieldVariable, CdoFieldParameter)
+  // is a FieldDropdown subclass, but its "options" aren't authored text —
+  // they're the workspace's variable map. Calling setOptions on one clobbers
+  // that internal state and init() throws, which CdoBlockSerializer catches
+  // and replaces with an "unknown block". Leave variable-bearing fields alone.
   for (const field of input.fieldRow) {
-    if (field instanceof BlocklyCore.FieldDropdown) {
+    if (
+      field instanceof BlocklyCore.FieldDropdown &&
+      !(field instanceof BlocklyCore.FieldVariable)
+    ) {
       localizeDropdownInPlace(field);
     }
   }

--- a/apps/src/blockly/utils/localization/blockDefinitions.ts
+++ b/apps/src/blockly/utils/localization/blockDefinitions.ts
@@ -1,5 +1,25 @@
+import * as BlocklyCore from 'blockly/core';
+
 import {BlockJson} from '@cdo/apps/blockly/types';
 import localization from '@cdo/apps/localization';
+
+const BLOCK_LABELS = ['blockly-block'];
+const TOOLTIP_LABELS = ['blockly-block', 'blockly-tooltip'];
+
+/**
+ * Wraps localization.translate so that for short labels that are a single word,
+ * we add a prefix to them so they can be translated with context.
+ */
+function translate(text: string, labels: string[]) {
+  if (text.length < 4) {
+    const result = localization.translate(`[block] ${text}`, labels);
+    if (result.startsWith('[block]')) {
+      return result.substring(7).trim();
+    }
+  }
+
+  return localization.translate(text, labels);
+}
 
 /**
  * Localizes a modern block definition and returns the localized form of it.
@@ -9,23 +29,143 @@ export function localizeBlockDefinition(blockDefinition: BlockJson): BlockJson {
     ...blockDefinition,
     tooltip:
       blockDefinition.tooltip !== undefined
-        ? localization.translate(blockDefinition.tooltip)
+        ? translate(blockDefinition.tooltip, TOOLTIP_LABELS)
         : undefined,
     message0:
       blockDefinition.message0 !== undefined
-        ? localization.translate(blockDefinition.message0, ['blockly-block'])
+        ? translate(blockDefinition.message0, BLOCK_LABELS)
         : undefined,
     message1:
       blockDefinition.message1 !== undefined
-        ? localization.translate(blockDefinition.message1, ['blockly-block'])
+        ? translate(blockDefinition.message1, BLOCK_LABELS)
         : undefined,
     message2:
       blockDefinition.message2 !== undefined
-        ? localization.translate(blockDefinition.message2, ['blockly-block'])
+        ? translate(blockDefinition.message2, BLOCK_LABELS)
         : undefined,
     message3:
       blockDefinition.message3 !== undefined
-        ? localization.translate(blockDefinition.message3, ['blockly-block'])
+        ? translate(blockDefinition.message3, BLOCK_LABELS)
         : undefined,
   };
+}
+
+type BlockInitDefinition = (typeof BlocklyCore.Blocks)[string];
+
+/**
+ * Wraps an init()-style block definition so that after the original init runs,
+ * any authored display text on the constructed block is routed through the
+ * localizer.
+ *
+ * Covers the surface that pre-json init blocks actually expose:
+ *   - tooltip set via setTooltip(), either as a literal string or as a
+ *     function returning a string (both forms preserved)
+ *   - label fields (FieldLabel and subclasses, e.g. CdoFieldLabel), whether
+ *     added via appendField('text') or via new FieldLabel(...)
+ *   - dropdown option display text (FieldDropdown and subclasses). Static
+ *     array generators are snapshotted and rewritten; function generators
+ *     are wrapped so every invocation retranslates.
+ *
+ * Fields without authored text (images, numbers, text inputs, checkboxes,
+ * variables) are left alone.
+ */
+export function localizeBlockInitDefinition(
+  blockDefinition: BlockInitDefinition
+): BlockInitDefinition {
+  // Detect if we have already wrapped this block
+  if (blockDefinition.oldInit) {
+    // Reset it
+    blockDefinition.init = blockDefinition.oldInit;
+  }
+
+  const originalInit = blockDefinition.init;
+  return {
+    ...blockDefinition,
+    oldInit: originalInit,
+    init: function () {
+      originalInit.call(this);
+      localizeBlockInPlace(this as BlocklyCore.Block);
+    },
+  };
+}
+
+function localizeBlockInPlace(block: BlocklyCore.Block): void {
+  localizeTooltipInPlace(block);
+  for (const input of block.inputList) {
+    for (const field of input.fieldRow) {
+      localizeFieldInPlace(field);
+    }
+  }
+}
+
+function localizeTooltipInPlace(block: BlocklyCore.Block): void {
+  const tooltip = block.tooltip;
+  if (typeof tooltip === 'string') {
+    if (tooltip.length > 0) {
+      block.setTooltip(translate(tooltip, TOOLTIP_LABELS));
+    }
+  } else if (typeof tooltip === 'function') {
+    block.setTooltip(() => {
+      const resolved = tooltip();
+      return typeof resolved === 'string'
+        ? translate(resolved, TOOLTIP_LABELS)
+        : resolved;
+    });
+  }
+  // Object-form tooltips delegate to another block; that block handles its own
+  // localization when its init runs.
+}
+
+function localizeFieldInPlace(field: BlocklyCore.Field): void {
+  if (field instanceof BlocklyCore.FieldLabel) {
+    const text = field.getText();
+    if (text) {
+      field.setValue(translate(text, BLOCK_LABELS));
+    }
+    return;
+  }
+  if (field instanceof BlocklyCore.FieldDropdown) {
+    localizeDropdownInPlace(field);
+    return;
+  }
+}
+
+function localizeDropdownInPlace(field: BlocklyCore.FieldDropdown): void {
+  const translateOption = (
+    option: BlocklyCore.MenuOption
+  ): BlocklyCore.MenuOption => {
+    if (option === 'separator') {
+      return option;
+    }
+    const [display, value] = option;
+    if (typeof display === 'string') {
+      return [translate(display, BLOCK_LABELS), value];
+    }
+    // ImageProperties / HTMLElement options carry no translatable text.
+    return option;
+  };
+
+  // setOptions() resets the selected value to the first option, so snapshot
+  // the current selection and restore it once the new options are installed.
+  const currentValue = field.getValue();
+
+  if (field.isOptionListDynamic()) {
+    // menuGenerator_ is protected; the cast is the documented escape hatch
+    // for preserving dynamic-dropdown semantics.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const original = (field as any).menuGenerator_ as
+      | BlocklyCore.MenuGeneratorFunction
+      | undefined;
+    if (original) {
+      field.setOptions(function (this: BlocklyCore.FieldDropdown) {
+        return original.call(this).map(translateOption);
+      });
+    }
+  } else {
+    field.setOptions(field.getOptions(false).map(translateOption));
+  }
+
+  if (currentValue !== null && currentValue !== undefined) {
+    field.setValue(currentValue);
+  }
 }

--- a/apps/src/blockly/utils/localization/blockStrings.ts
+++ b/apps/src/blockly/utils/localization/blockStrings.ts
@@ -1,0 +1,323 @@
+import localization from '@cdo/apps/localization';
+
+const LOCALIZE_BLOCK_STRINGS_BLOCKS = [
+  'gamelab_showTitleScreen',
+  'gamelab_spriteSayTime',
+  'gamelab_spriteSay',
+  'gamelab_setPrompt',
+  'gamelab_printText',
+  'gamelab_setPromptWithChoices',
+];
+
+const LOCALIZE_BLOCK_JOIN_BLOCKS = ['gamelab_textJoin'];
+
+const LOCALIZE_BLOCK_JOIN_VARIABLE_BLOCKS = ['gamelab_textVariableJoin'];
+
+const STRING_LABELS = ['blockly-block', 'gamelab-string'];
+
+// A flattened piece of a textJoin chain: either a static text run or a
+// placeholder for a variable-join block. For variable tokens we retain the
+// original block element so its mutations, titles, and attributes can be
+// re-emitted in the reassembled chain.
+type ChainToken = {kind: 'text'; text: string} | {kind: 'var'; block: Element};
+
+function directChildren(el: Element, tagName: string): Element[] {
+  return Array.from(el.children).filter(
+    c => c.tagName.toLowerCase() === tagName.toLowerCase()
+  );
+}
+
+function inputBlock(valueEl: Element): Element | null {
+  return directChildren(valueEl, 'block')[0] || null;
+}
+
+// Blockly XML has two equivalent spellings for field elements: <title> in the
+// older dialect (as in example.xml) and <field> in the modern dialect (as in
+// example2.xml). A single document generally uses one consistently, but we
+// accept either on reads and emit whichever the document is already using.
+const FIELD_TAGS = ['field', 'title'];
+
+function findField(el: Element, name: string): Element | null {
+  for (const child of Array.from(el.children)) {
+    if (
+      FIELD_TAGS.includes(child.tagName.toLowerCase()) &&
+      child.getAttribute('name') === name
+    ) {
+      return child;
+    }
+  }
+  return null;
+}
+
+function fieldText(el: Element, name: string): string {
+  return findField(el, name)?.textContent || '';
+}
+
+function setFieldText(el: Element, name: string, value: string): void {
+  const field = findField(el, name);
+  if (field) {
+    field.textContent = value;
+  }
+}
+
+// Detect the field spelling the document uses so rebuilt chains match.
+function detectFieldTag(doc: Document): string {
+  return doc.querySelector('field') ? 'field' : 'title';
+}
+
+// Follow the TEXT2 value input to the next block in the chain.
+function nextChainBlock(el: Element): Element | null {
+  for (const value of directChildren(el, 'value')) {
+    if (value.getAttribute('name') === 'TEXT2') {
+      return inputBlock(value);
+    }
+  }
+  return null;
+}
+
+// Walk the textJoin / textVariableJoin / text chain and produce an ordered
+// stream of text runs and variable placeholders.
+function flattenChain(block: Element): ChainToken[] {
+  const tokens: ChainToken[] = [];
+  let current: Element | null = block;
+  while (current) {
+    const type = current.getAttribute('type') || '';
+    if (LOCALIZE_BLOCK_JOIN_BLOCKS.includes(type)) {
+      tokens.push({kind: 'text', text: fieldText(current, 'TEXT1')});
+      current = nextChainBlock(current);
+    } else if (LOCALIZE_BLOCK_JOIN_VARIABLE_BLOCKS.includes(type)) {
+      tokens.push({kind: 'var', block: current});
+      current = nextChainBlock(current);
+    } else if (type === 'text') {
+      tokens.push({kind: 'text', text: fieldText(current, 'TEXT')});
+      current = null;
+    } else {
+      // Anything else (variables_get, a function call, etc.) ends flattening
+      // since we cannot safely re-emit it inside a rebuilt chain.
+      current = null;
+    }
+  }
+  return normalizeTokens(tokens);
+}
+
+// Merge adjacent text runs and guarantee the sequence begins and ends with a
+// text token so the builder can always pair them with variable tokens.
+function normalizeTokens(tokens: ChainToken[]): ChainToken[] {
+  const merged: ChainToken[] = [];
+  for (const tok of tokens) {
+    const prev = merged[merged.length - 1];
+    if (tok.kind === 'text' && prev && prev.kind === 'text') {
+      prev.text += tok.text;
+    } else {
+      merged.push(tok);
+    }
+  }
+  if (merged.length === 0 || merged[0].kind !== 'text') {
+    merged.unshift({kind: 'text', text: ''});
+  }
+  if (merged[merged.length - 1].kind !== 'text') {
+    merged.push({kind: 'text', text: ''});
+  }
+  return merged;
+}
+
+// Render the token stream as a source string with %1, %2, ... in place of
+// variable tokens. Returns the string alongside the ordered variable blocks
+// those placeholders refer to.
+function chainToSourceString(tokens: ChainToken[]): {
+  source: string;
+  vars: Element[];
+} {
+  const vars: Element[] = [];
+  const pieces: string[] = [];
+  for (const tok of tokens) {
+    if (tok.kind === 'text') {
+      pieces.push(tok.text);
+    } else {
+      vars.push(tok.block);
+      pieces.push(`%${vars.length}`);
+    }
+  }
+  return {source: pieces.join(''), vars};
+}
+
+// Split a translated string back into tokens, resolving %N against the
+// ordered variable blocks from the original chain.
+function parseTranslated(translated: string, vars: Element[]): ChainToken[] {
+  const tokens: ChainToken[] = [];
+  const regex = /%(\d+)/g;
+  let lastIndex = 0;
+  let match: RegExpExecArray | null;
+  while ((match = regex.exec(translated)) !== null) {
+    tokens.push({
+      kind: 'text',
+      text: translated.slice(lastIndex, match.index),
+    });
+    const idx = parseInt(match[1], 10) - 1;
+    if (idx >= 0 && idx < vars.length) {
+      tokens.push({kind: 'var', block: vars[idx]});
+    } else {
+      // Placeholder is out of range; keep the raw %N so a developer notices.
+      tokens.push({kind: 'text', text: match[0]});
+    }
+    lastIndex = regex.lastIndex;
+  }
+  tokens.push({kind: 'text', text: translated.slice(lastIndex)});
+  return normalizeTokens(tokens);
+}
+
+// Shallow-clone a variable-join block, preserving its attributes and field
+// children but dropping the TEXT2 continuation so the caller can splice in
+// the new continuation from the rebuilt chain.
+function cloneVarHeader(block: Element): Element {
+  const clone = block.cloneNode(false) as Element;
+  for (const child of Array.from(block.children)) {
+    const tag = child.tagName.toLowerCase();
+    if (FIELD_TAGS.includes(tag) || tag === 'mutation') {
+      clone.appendChild(child.cloneNode(true));
+    }
+  }
+  return clone;
+}
+
+function makeTextBlock(doc: Document, fieldTag: string, text: string): Element {
+  const block = doc.createElement('block');
+  block.setAttribute('type', 'text');
+  const field = doc.createElement(fieldTag);
+  field.setAttribute('name', 'TEXT');
+  field.textContent = text;
+  block.appendChild(field);
+  return block;
+}
+
+// Recursively build a new chain from a normalized token stream. Tokens always
+// arrive as text, (var, text)*, so each recursive step consumes a (text, var)
+// pair and descends into the remainder, or terminates with a lone text block.
+function buildChain(
+  doc: Document,
+  fieldTag: string,
+  tokens: ChainToken[]
+): Element {
+  if (tokens.length === 1 && tokens[0].kind === 'text') {
+    return makeTextBlock(doc, fieldTag, tokens[0].text);
+  }
+
+  const first = tokens[0];
+  const varTok = tokens[1];
+  const rest = tokens.slice(2);
+  const firstText = first.kind === 'text' ? first.text : '';
+
+  const joinBlock = doc.createElement('block');
+  joinBlock.setAttribute('type', LOCALIZE_BLOCK_JOIN_BLOCKS[0]);
+  const field1 = doc.createElement(fieldTag);
+  field1.setAttribute('name', 'TEXT1');
+  field1.textContent = firstText;
+  joinBlock.appendChild(field1);
+
+  const outerValue = doc.createElement('value');
+  outerValue.setAttribute('name', 'TEXT2');
+
+  const varHeader =
+    varTok && varTok.kind === 'var'
+      ? cloneVarHeader(varTok.block)
+      : doc.createElement('block');
+  const innerValue = doc.createElement('value');
+  innerValue.setAttribute('name', 'TEXT2');
+  innerValue.appendChild(buildChain(doc, fieldTag, rest));
+  varHeader.appendChild(innerValue);
+
+  outerValue.appendChild(varHeader);
+  joinBlock.appendChild(outerValue);
+  return joinBlock;
+}
+
+function replaceInputBlock(valueEl: Element, newBlock: Element): void {
+  const existing = inputBlock(valueEl);
+  if (existing) {
+    valueEl.replaceChild(newBlock, existing);
+  } else {
+    valueEl.appendChild(newBlock);
+  }
+}
+
+function localizeValueInput(
+  valueEl: Element,
+  doc: Document,
+  fieldTag: string,
+  translations: Map<string, string>,
+  processed: Set<Element>
+): void {
+  const innerBlock = inputBlock(valueEl);
+  if (!innerBlock) return;
+  const type = innerBlock.getAttribute('type') || '';
+
+  if (type === 'text') {
+    const source = fieldText(innerBlock, 'TEXT');
+    if (source === '') return;
+    const translated = localization.translate(source, STRING_LABELS);
+    setFieldText(innerBlock, 'TEXT', translated);
+    translations.set(source, translated);
+    processed.add(innerBlock);
+    return;
+  }
+
+  if (LOCALIZE_BLOCK_JOIN_BLOCKS.includes(type)) {
+    const tokens = flattenChain(innerBlock);
+    const {source, vars} = chainToSourceString(tokens);
+    if (source === '') return;
+    const translated = localization.translate(source, STRING_LABELS);
+    const rebuilt = buildChain(
+      doc,
+      fieldTag,
+      parseTranslated(translated, vars)
+    );
+    replaceInputBlock(valueEl, rebuilt);
+  }
+}
+
+/**
+ * Takes the XML that is meant to be serialized and replaces the string
+ * inputs to certain blocks, defined by the LOCALIZE_BLOCK_STRINGS_BLOCKS
+ * array, with translated versions of those strings. It returns the reformed
+ * XML so that it is what gets serialized instead.
+ *
+ * Plain <block type="text"> inputs to qualifying blocks drive the set of
+ * translatable strings. After processing those, we propagate their
+ * translations to any other <block type="text"> in the program whose TEXT
+ * matches a known source string, so identical literals stay consistent
+ * regardless of where the user wired them.
+ */
+export function localizeBlockStrings(xml: string): string {
+  const parser = new DOMParser();
+  const doc = parser.parseFromString(xml, 'text/xml');
+  if (doc.querySelector('parsererror')) {
+    return xml;
+  }
+
+  const fieldTag = detectFieldTag(doc);
+  const translations = new Map<string, string>();
+  const processed = new Set<Element>();
+
+  for (const block of Array.from(doc.querySelectorAll('block'))) {
+    const type = block.getAttribute('type') || '';
+    if (!LOCALIZE_BLOCK_STRINGS_BLOCKS.includes(type)) continue;
+    for (const valueEl of directChildren(block, 'value')) {
+      localizeValueInput(valueEl, doc, fieldTag, translations, processed);
+    }
+  }
+
+  // Propagate the translations we already performed to every other plain
+  // text block in the program. Only exact-match sources are translated:
+  // we never send a fresh string, so asset names and other literals that
+  // happen to live in text blocks pass through untouched.
+  for (const block of Array.from(doc.querySelectorAll('block[type="text"]'))) {
+    if (processed.has(block)) continue;
+    const source = fieldText(block, 'TEXT');
+    const translated = translations.get(source);
+    if (translated !== undefined && translated !== source) {
+      setFieldText(block, 'TEXT', translated);
+    }
+  }
+
+  return new XMLSerializer().serializeToString(doc);
+}

--- a/apps/src/blockly/utils/localization/locale.ts
+++ b/apps/src/blockly/utils/localization/locale.ts
@@ -65,10 +65,17 @@ export function getBlockDefinitionsForUpdatedLocale(
         // Deep clone the argument
         args[i] = {...args[i]};
 
-        args[i].options = arg.options.map(([text, ...rest]) => [
-          localization.translate(text, ['blockly-block']),
-          ...rest,
-        ]);
+        args[i].options = arg.options.map(item => {
+          // Sometimes the options list is just an array of strings rather than
+          // a tuple of a label and an id. This is typically true of grid/image
+          // dropdowns.
+          if (!Array.isArray(item)) {
+            return item;
+          }
+
+          const [text, ...rest] = item;
+          return [localization.translate(text, ['blockly-block']), ...rest];
+        });
       }
     });
 

--- a/apps/src/blockly/utils/localization/locale.ts
+++ b/apps/src/blockly/utils/localization/locale.ts
@@ -25,10 +25,19 @@ export function getBlockDefinitionsForUpdatedLocale(
   )) {
     const blockDefinition =
       Blockly.SourceCustomBlocks.blockDefinitionsByName[blockName];
+
+    if (!blockDefinition.config.sourceArgs) {
+      blockDefinition.config.sourceArgs = blockDefinition.config.args;
+    }
+
+    blockDefinition.config.args = blockDefinition.config.sourceArgs || [];
+
     Blockly.SourceCustomBlocks.blockTexts[blockName] ||=
       blockDefinition.config.blockText;
+
     const oldBlockText = Blockly.SourceCustomBlocks.blockTexts[blockName];
     let newBlockText: string = oldBlockText;
+
     if (blockDefinition.config.returnType === 'Behavior') {
       newBlockText = localization.translate(`[behavior] ${oldBlockText}`, [
         'blockly-block',
@@ -47,14 +56,34 @@ export function getBlockDefinitionsForUpdatedLocale(
       newBlockText = localization.translate(oldBlockText, ['blockly-block']);
     }
 
-    // Unfreeze the block definition to add the new translation strings
-    Blockly.SourceCustomBlocks.blockDefinitionsByName[blockName] = {
+    const args = blockDefinition.config.args
+      ? [...blockDefinition.config.args]
+      : blockDefinition.config.args;
+
+    (args || []).forEach((arg, i) => {
+      if (arg.options) {
+        // Deep clone the argument
+        args[i] = {...args[i]};
+
+        args[i].options = arg.options.map(([text, ...rest]) => [
+          localization.translate(text, ['blockly-block']),
+          ...rest,
+        ]);
+      }
+    });
+
+    const newDefinition = {
       ...blockDefinition,
       config: {
         ...blockDefinition.config,
+        ...(args ? {args} : {}),
         blockText: newBlockText,
       },
     };
+
+    // Unfreeze the block definition to add the new translation strings
+    Blockly.SourceCustomBlocks.blockDefinitionsByName[blockName] =
+      newDefinition;
   }
 
   return Object.values(Blockly.SourceCustomBlocks.blockDefinitionsByName);

--- a/apps/src/blockly/utils/localization/locale.ts
+++ b/apps/src/blockly/utils/localization/locale.ts
@@ -17,14 +17,6 @@ export function getBlockDefinitionsForUpdatedLocale(
   // Call into our localization engine to get the new blocks and refresh all active
   // workspaces.
 
-  // Copy over new localization keys for the normal blocks in 'Msg'
-  for (const [key, value] of Object.entries(Blockly.Msg || {})) {
-    Blockly.SourceMsg[key] ||= value;
-    Blockly.Msg[key] = localization.translate(Blockly.SourceMsg[key], [
-      'blockly-block',
-    ]);
-  }
-
   // Go through custom and shared blocks to translate the blockText there
   // This means recreating the block init() functions with updated block
   // configurations.

--- a/apps/src/blockly/utils/localization/procedureNameRegistry.ts
+++ b/apps/src/blockly/utils/localization/procedureNameRegistry.ts
@@ -1,0 +1,138 @@
+import * as BlocklyCore from 'blockly/core';
+
+import {
+  BLOCK_TYPES,
+  PROCEDURE_DEFINITION_TYPES,
+} from '@cdo/apps/blockly/constants';
+
+/**
+ * Tracks which procedure/behavior names originated from curriculum-authored
+ * content and are therefore eligible for display-time translation on their
+ * caller blocks (procedures_callnoreturn, gamelab_behavior_get). Names the
+ * student types via the function editor never enter this set — they render
+ * verbatim.
+ *
+ * Populated from the initial workspace state when Blockly fires
+ * FINISHED_LOADING on the main and hidden definition workspaces, and from the
+ * main workspace's flyout (for caller blocks placed in the level's toolbox
+ * XML). Registrations after that point — e.g., a student creating a new
+ * procedure — are not auto-captured.
+ */
+const translatable = new Set<string>();
+
+type RegistryListener = () => void;
+const listeners = new Set<RegistryListener>();
+let notifyQueued = false;
+
+// Coalesce bursts of markTranslatable calls (e.g., a single scan adding
+// many names) into one listener notification per microtask.
+function notifySoon(): void {
+  if (notifyQueued) {
+    return;
+  }
+  notifyQueued = true;
+  queueMicrotask(() => {
+    notifyQueued = false;
+    for (const listener of listeners) {
+      listener();
+    }
+  });
+}
+
+export function onRegistryChange(listener: RegistryListener): () => void {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+export function isTranslatable(name: string): boolean {
+  return translatable.has(name);
+}
+
+export function markTranslatable(name: string): void {
+  if (name && !translatable.has(name)) {
+    translatable.add(name);
+    notifySoon();
+  }
+}
+
+export function clearTranslatable(): void {
+  if (translatable.size === 0) {
+    return;
+  }
+  translatable.clear();
+  notifySoon();
+}
+
+// Scans procedure/behavior DEFINITION blocks only. Appropriate for the main
+// and hidden definition workspaces where caller NAME values can legitimately
+// be student-renamed copies and must not be auto-registered.
+function scanDefinitions(
+  workspace: BlocklyCore.Workspace | null | undefined
+): void {
+  if (!workspace) {
+    return;
+  }
+  for (const block of workspace.getAllBlocks(false)) {
+    if (PROCEDURE_DEFINITION_TYPES.includes(block.type)) {
+      const name = block.getFieldValue('NAME');
+      if (name) {
+        markTranslatable(name);
+      }
+    }
+  }
+}
+
+const FLYOUT_TRANSLATABLE_TYPES: readonly string[] = [
+  ...PROCEDURE_DEFINITION_TYPES,
+  BLOCK_TYPES.procedureCall,
+  BLOCK_TYPES.behaviorGet,
+];
+
+// Scans a flyout workspace. Flyout blocks are curriculum-authored by
+// construction (students don't edit the flyout), so caller NAME values on
+// procedure_callnoreturn and gamelab_behavior_get are also safe to register —
+// this is how a behaviorGet placed in a level's toolboxBlocks XML gets its
+// name registered without needing a matching definition elsewhere.
+function scanFlyout(workspace: BlocklyCore.Workspace | null | undefined): void {
+  if (!workspace) {
+    return;
+  }
+  for (const block of workspace.getAllBlocks(false)) {
+    if (FLYOUT_TRANSLATABLE_TYPES.includes(block.type)) {
+      const name = block.getFieldValue('NAME');
+      if (name) {
+        markTranslatable(name);
+      }
+    }
+  }
+}
+
+/**
+ * Change listener. On FINISHED_LOADING, scans the emitting workspace for
+ * procedure/behavior definition blocks, the hidden definition workspace for
+ * the same, and the emitting workspace's flyout (if it has one) for both
+ * definitions and caller blocks. Attached to the main workspace and the
+ * hidden definition workspace in blocklyWrapper.inject.
+ */
+export function handleFinishedLoading(
+  event: BlocklyCore.Events.Abstract
+): void {
+  if (
+    event.type !== BlocklyCore.Events.FINISHED_LOADING ||
+    !event.workspaceId
+  ) {
+    return;
+  }
+  const workspace = BlocklyCore.Workspace.getById(event.workspaceId);
+  scanDefinitions(workspace);
+  scanDefinitions(Blockly.getHiddenDefinitionWorkspace?.());
+
+  // Flyout contents don't flow through the main/hidden serialization path,
+  // but a level's toolbox XML can place caller blocks directly there. Scan
+  // once per load to pick those up.
+  const svgWorkspace = workspace as BlocklyCore.WorkspaceSvg | null;
+  const flyoutWorkspace = svgWorkspace?.getFlyout?.()?.getWorkspace();
+  scanFlyout(flyoutWorkspace);
+}

--- a/apps/src/lab2/views/ExtraLinksModal.tsx
+++ b/apps/src/lab2/views/ExtraLinksModal.tsx
@@ -159,7 +159,7 @@ const ExtraLinksModal: React.FunctionComponent<ExtraLinksModalProps> = ({
       {Object.entries(levelLinkData.links).map(([listTitle, links]) => (
         // Levels can be part of level groups (sublevels) and/or can be a template level
         // so we list these here as well.
-        <div key={`${listTitle}-div`}>
+        <div data-notranslate="true" key={`${listTitle}-div`}>
           <Typography key={`${listTitle}-title`} variant="strong">
             {listTitle}
           </Typography>
@@ -498,12 +498,12 @@ const ScriptLevelPathLinks: React.FunctionComponent<
   }
   return (
     <>
-      <Typography variant="strong">
+      <Typography data-notranslate="true" variant="strong">
         This level is in {Object.entries(scriptLevelPathLinks).length} scripts:
       </Typography>
       <ul>
         {scriptLevelPathLinks.map(link => (
-          <li key={link.path}>
+          <li data-notranslate="true" key={link.path}>
             <a href={'/s/' + link.script}>{link.script}</a> as{' '}
             <a href={link.path}>{link.path}</a>
           </li>
@@ -525,13 +525,13 @@ const ParentLevelPathLinks: React.FunctionComponent<
   }
   return (
     <>
-      <Typography variant="strong">
+      <Typography data-notranslate="true" variant="strong">
         This level is in {Object.entries(parentLevelPathLinks).length} other
         levels:
       </Typography>
       <ul>
         {parentLevelPathLinks.map(link => (
-          <li key={link.path}>
+          <li data-notranslate="true" key={link.path}>
             {link.kind} in <a href={link.path}>{link.level_name}</a> (position{' '}
             {link.position})
           </li>

--- a/apps/src/lab2/views/components/Instructions/ResourcePanel/VersionHistory/VersionHistoryRow.tsx
+++ b/apps/src/lab2/views/components/Instructions/ResourcePanel/VersionHistory/VersionHistoryRow.tsx
@@ -95,6 +95,7 @@ const VersionHistoryRow: React.FunctionComponent<
       <div className={moduleStyles.versionContent}>
         <div className={moduleStyles.versionHeader}>
           <RadioButton
+            data-notranslate="true"
             className={moduleStyles.versionLabel}
             name={versionId}
             value={versionId}

--- a/apps/src/p5lab/spritelab/CoreLibrary.js
+++ b/apps/src/p5lab/spritelab/CoreLibrary.js
@@ -13,6 +13,7 @@ import {formatForPlayspace} from '../utils';
 
 import commands from './commands/index';
 import {MAX_NUM_SPRITES, SPRITE_WARNING_BUFFER} from './constants';
+import {unlocalizeColor} from './localizedColors';
 
 export default class CoreLibrary {
   constructor(p5, jsInterpreter) {
@@ -90,7 +91,8 @@ export default class CoreLibrary {
 
   drawBackground() {
     if (typeof this.background === 'string') {
-      this.p5.background(this.background);
+      // Determine if we should reverse the localization of the color
+      this.p5.background(unlocalizeColor(this.background));
     } else {
       this.p5.background('white');
     }

--- a/apps/src/p5lab/spritelab/SpritelabInput.jsx
+++ b/apps/src/p5lab/spritelab/SpritelabInput.jsx
@@ -160,7 +160,11 @@ class SpritelabInput extends React.Component {
     }
 
     return (
-      <div id="spritelabInputArea" style={styles.container}>
+      <div
+        id="spritelabInputArea"
+        data-notranslate="true"
+        style={styles.container}
+      >
         <div style={styles.prompt}>
           {numPrompts > 1 && (
             <span style={styles.circle} className="fa-stack">

--- a/apps/src/p5lab/spritelab/TextConsole.jsx
+++ b/apps/src/p5lab/spritelab/TextConsole.jsx
@@ -146,7 +146,7 @@ export default class TextConsole extends React.Component {
 
   render() {
     return (
-      <div>
+      <div data-notranslate="true">
         <Transition in={this.state.open} timeout={1000}>
           {state => (
             <div

--- a/apps/src/p5lab/spritelab/blocks.js
+++ b/apps/src/p5lab/spritelab/blocks.js
@@ -21,6 +21,7 @@ import {
   parseSoundPathString,
   registerCustomProcedureBlocks,
   soundField,
+  translate,
 } from '@cdo/apps/blockly/utils';
 import {SVG_NS} from '@cdo/apps/constants';
 import {spriteLabPointers} from '@cdo/apps/p5lab/spritelab/blockly/constants';
@@ -223,20 +224,52 @@ const customInputTypes = {
       } else {
         switch (block.type) {
           case 'gamelab_clickedSpritePointer':
-            block.shortString = spritelabMsg.clicked();
-            block.longString = spritelabMsg.clickedSprite();
+            block.shortString = translate(
+              spritelabMsg.clicked(),
+              ['blockly-spritelab'],
+              true
+            );
+            block.longString = translate(
+              spritelabMsg.clickedSprite(),
+              ['blockly-spritelab'],
+              true
+            );
             break;
           case 'gamelab_newSpritePointer':
-            block.shortString = spritelabMsg.new();
-            block.longString = spritelabMsg.newSprite();
+            block.shortString = translate(
+              spritelabMsg.new(),
+              ['blockly-spritelab'],
+              true
+            );
+            block.longString = translate(
+              spritelabMsg.newSprite(),
+              ['blockly-spritelab'],
+              true
+            );
             break;
           case 'gamelab_subjectSpritePointer':
-            block.shortString = spritelabMsg.subject();
-            block.longString = spritelabMsg.subjectSprite();
+            block.shortString = translate(
+              spritelabMsg.subject(),
+              ['blockly-spritelab'],
+              true
+            );
+            block.longString = translate(
+              spritelabMsg.subjectSprite(),
+              ['blockly-spritelab'],
+              true
+            );
             break;
           case 'gamelab_objectSpritePointer':
-            block.shortString = spritelabMsg.object();
-            block.longString = spritelabMsg.objectSprite();
+            block.shortString = translate(
+              spritelabMsg.object(),
+              ['blockly-spritelab'],
+              true
+            );
+            block.longString = translate(
+              spritelabMsg.objectSprite(),
+              ['blockly-spritelab'],
+              true
+            );
             break;
           default:
             // unsupported block for spritePointer, leave the block text blank

--- a/apps/src/p5lab/spritelab/localizedColors.ts
+++ b/apps/src/p5lab/spritelab/localizedColors.ts
@@ -1,0 +1,192 @@
+import localization from '@cdo/apps/localization';
+
+const HTML_COLORS = [
+  'aliceblue',
+  'antiquewhite',
+  'aqua',
+  'aquamarine',
+  'azure',
+  'beige',
+  'bisque',
+  'black',
+  'blanchedalmond',
+  'blue',
+  'blueviolet',
+  'brown',
+  'burlywood',
+  'cadetblue',
+  'chartreuse',
+  'chocolate',
+  'coral',
+  'cornflowerblue',
+  'cornsilk',
+  'crimson',
+  'cyan',
+  'darkblue',
+  'darkcyan',
+  'darkgoldenrod',
+  'darkgray',
+  'darkgreen',
+  'darkkhaki',
+  'darkmagenta',
+  'darkolivegreen',
+  'darkorange',
+  'darkorchid',
+  'darkred',
+  'darksalmon',
+  'darkseagreen',
+  'darkslateblue',
+  'darkslategray',
+  'darkturquoise',
+  'darkviolet',
+  'deeppink',
+  'deepskyblue',
+  'dimgray',
+  'dodgerblue',
+  'feldspar',
+  'firebrick',
+  'floralwhite',
+  'forestgreen',
+  'fuchsia',
+  'gainsboro',
+  'ghostwhite',
+  'gold',
+  'goldenrod',
+  'gray',
+  'green',
+  'greenyellow',
+  'honeydew',
+  'hotpink',
+  'indianred',
+  'indigo',
+  'ivory',
+  'khaki',
+  'lavender',
+  'lavenderblush',
+  'lawngreen',
+  'lemonchiffon',
+  'lightblue',
+  'lightcoral',
+  'lightcyan',
+  'lightgoldenrodyellow',
+  'lightgrey',
+  'lightgreen',
+  'lightpink',
+  'lightsalmon',
+  'lightseagreen',
+  'lightskyblue',
+  'lightslateblue',
+  'lightslategray',
+  'lightsteelblue',
+  'lightyellow',
+  'lime',
+  'limegreen',
+  'linen',
+  'magenta',
+  'maroon',
+  'mediumaquamarine',
+  'mediumblue',
+  'mediumorchid',
+  'mediumpurple',
+  'mediumseagreen',
+  'mediumslateblue',
+  'mediumspringgreen',
+  'mediumturquoise',
+  'mediumvioletred',
+  'midnightblue',
+  'mintcream',
+  'mistyrose',
+  'moccasin',
+  'navajowhite',
+  'navy',
+  'oldlace',
+  'olive',
+  'olivedrab',
+  'orange',
+  'orangered',
+  'orchid',
+  'palegoldenrod',
+  'palegreen',
+  'paleturquoise',
+  'palevioletred',
+  'papayawhip',
+  'peachpuff',
+  'peru',
+  'pink',
+  'plum',
+  'powderblue',
+  'purple',
+  'red',
+  'rosybrown',
+  'royalblue',
+  'saddlebrown',
+  'salmon',
+  'sandybrown',
+  'seagreen',
+  'seashell',
+  'sienna',
+  'silver',
+  'skyblue',
+  'slateblue',
+  'slategray',
+  'snow',
+  'springgreen',
+  'steelblue',
+  'tan',
+  'teal',
+  'thistle',
+  'tomato',
+  'turquoise',
+  'violet',
+  'violetred',
+  'wheat',
+  'white',
+  'whitesmoke',
+  'yellow',
+  'yellowgreen',
+];
+
+export type LocalizedColorCache = {
+  [localizedColor: string]: string;
+};
+
+/**
+ * This is the localized color cache that maps locales to mappings from a
+ * localized color name to the standard html color name.
+ */
+export const localizedColorCache: {
+  [locale: string]: LocalizedColorCache;
+} = {};
+
+/**
+ * This gives us a hash that maps localized color names to the standard html
+ * color name.
+ */
+export const localizedColors: (locale?: string) => LocalizedColorCache = (
+  locale?: string
+) => {
+  locale ||= localization.locale;
+  if (!localizedColorCache[locale]) {
+    localizedColorCache[locale] = Object.fromEntries(
+      HTML_COLORS.map(htmlColor => [
+        localization.translate(htmlColor, ['html-color']),
+        htmlColor,
+      ])
+    );
+  }
+
+  return localizedColorCache[localization.locale];
+};
+
+/**
+ * This will return the real html color string for any localized html color
+ * name that we can determine for the current locale.
+ */
+export const unlocalizeColor = (localizedColor: string, locale?: string) => {
+  // Ignore hex colors
+  if (localizedColor.match(/^#[0-9a-fA-F]{6}$/)) {
+    return localizedColor;
+  }
+
+  return localizedColors(locale)[localizedColor] || localizedColor;
+};

--- a/apps/src/templates/SafeMarkdown.jsx
+++ b/apps/src/templates/SafeMarkdown.jsx
@@ -15,6 +15,8 @@ import rehypeSanitize from 'rehype-sanitize';
 import remarkRehype from 'remark-rehype';
 import unified from 'unified';
 
+import localization from '@cdo/apps/localization';
+
 import {WeakMapPlus} from '../util/dataStructures/WeakMapPlus';
 
 import externalLinks from './plugins/externalLinks';
@@ -143,6 +145,13 @@ const localizationComponentWrappers = {
   },
   p: function (props) {
     return <p {...props} data-isolate="true" />;
+  },
+  code: function ({children, ...props}) {
+    return (
+      <code {...props} data-notranslate="true">
+        {localization.translate(children)}
+      </code>
+    );
   },
 };
 

--- a/apps/src/templates/SafeMarkdown.jsx
+++ b/apps/src/templates/SafeMarkdown.jsx
@@ -147,11 +147,7 @@ const localizationComponentWrappers = {
     return <p {...props} data-isolate="true" />;
   },
   code: function ({children, ...props}) {
-    return (
-      <code {...props} data-notranslate="true">
-        {localization.translate(children)}
-      </code>
-    );
+    return <code {...props}>{localization.translate(children)}</code>;
   },
 };
 

--- a/apps/src/templates/feedback/GeneratedCode.jsx
+++ b/apps/src/templates/feedback/GeneratedCode.jsx
@@ -18,7 +18,7 @@ export default class GeneratedCode extends React.Component {
         </div>
 
         {/* code container should be LTR even in RTL mode */}
-        <pre className="generatedCode" dir="ltr">
+        <pre data-notranslate="true" className="generatedCode" dir="ltr">
           {this.props.code}
         </pre>
       </div>

--- a/apps/src/templates/shareFailure.html.ejs
+++ b/apps/src/templates/shareFailure.html.ejs
@@ -8,6 +8,6 @@ var shareFailure = locals.shareFailure;
 
 <% if (shareFailure.contents) { %>
   <div class="share-fail-excerpt">
-    <pre class="generatedCode"><%= shareFailure.contents %></pre>
+    <pre class="generatedCode" data-notranslate="true"><%= shareFailure.contents %></pre>
   </div>
 <% } %>

--- a/dashboard/app/views/shared/_extra_links.html.haml
+++ b/dashboard/app/views/shared/_extra_links.html.haml
@@ -1,4 +1,4 @@
-.extra-links
+.extra-links{data: {notranslate: 'true'}}
   %h4
     Extra Links:
     %a{id: 'levelbuilder-menu-toggle', href: '#', onclick: 'return extraLinksClick()'} [hide/show]


### PR DESCRIPTION
This adds a few things to blockly localization which enables full translation of all units of CSF:
* Stops translating the blockly field_dropdown div since we translate those in the block definitions
* Creates a new blockly field to handle specifically function names as labels so that function names can be localized. This includes behavior names in spritelab, since those are just fancy functions.
* Has a convenience method to translate legacy blocks that are defined with `init()` function instead of a JSON definition
* Has a convenience method to translate block sources to look for string inputs and joins to form "isolated" strings and reform them. This allows us to handle "Hello, {{var}}!" strings in some of the gamelab example projects.

String Interpolation Improvements

<img width="630" height="167" alt="image" src="https://github.com/user-attachments/assets/e75a0f54-9435-469d-8401-d9a8b5b7bd0b" />

<img width="565" height="315" alt="image" src="https://github.com/user-attachments/assets/a1b9411b-0238-4d5c-a886-041a578e6015" />

<img width="848" height="185" alt="image" src="https://github.com/user-attachments/assets/cbf4b390-8ae1-4b61-aeae-2024292920ef" />

* Handles HTML colors that are strings used to change colors in p5-powered levels. So, we now can 'unlocalize' the color names to a canonical HTML color. 'azul' becomes 'blue' and now the chatbot example and the guidance for the generic p5 project where it tells you what the html colors are works as intended while being localized.

<img width="473" height="326" alt="image" src="https://github.com/user-attachments/assets/c5b73695-753c-463c-a690-b7aefa60fd33" />

<img width="464" height="525" alt="image" src="https://github.com/user-attachments/assets/ec7163e9-0abc-41d2-a8d3-7d6a4c73bf22" />

Convenience things it adds:
* Stops translating the 'extra links' modals and panels and such
* Stops translating the input field and console output for p5/gamelab/spritelab
* Stops translating the version history fields relating to the date, etc

## Links
<!-- Jira tickets, design docs, Slack threads, related PRs, etc. -->

- Jira: [GEPW-20](https://codedotorg.atlassian.net/browse/GEPW-20)

## Testing story

I have gone through and performed every level in CSF 2024 and ensured that the level is translated and machine translated all of the content in the 32 languages. Everything works and the levels are completable.