### PR TITLE
Remove Radium from TeacherContentToggle

### DIFF
--- a/apps/src/code-studio/components/TeacherContentToggle.js
+++ b/apps/src/code-studio/components/TeacherContentToggle.js
@@ -1,6 +1,5 @@
 import $ from 'jquery';
 import PropTypes from 'prop-types';
-import Radium from 'radium'; // eslint-disable-line no-restricted-imports
 import React from 'react';
 import {connect} from 'react-redux';
 
@@ -99,11 +98,19 @@ class TeacherContentToggle extends React.Component {
       <div style={styles.container}>
         <div style={contentStyle} ref="content" />
         <div
-          style={[frameStyle, !showLockedLessonMessage && styles.hidden]}
+          style={
+            showLockedLessonMessage
+              ? frameStyle
+              : {...frameStyle, ...styles.hidden}
+          }
           ref="lockMessage"
         />
         <div
-          style={[frameStyle, !showHiddenLessonMessage && styles.hidden]}
+          style={
+            showHiddenLessonMessage
+              ? frameStyle
+              : {...frameStyle, ...styles.hidden}
+          }
           ref="hiddenMessage"
         />
       </div>
@@ -120,7 +127,7 @@ const styles = {
   },
 };
 
-export const UnconnectedTeacherContentToggle = Radium(TeacherContentToggle);
+export const UnconnectedTeacherContentToggle = TeacherContentToggle;
 
 // Exported so that it can be tested
 export const mapStateToProps = state => {


### PR DESCRIPTION
## Trello card
https://trello.com/c/V4tl5zTF/9-remove-radium-from-apps-src-code-studio-components-teachercontenttogglejs

## Summary
- Removes `radium` import and `Radium()` `TeacherContentToggle.js`
- Replaces Radium's array-merge style syntax (`[baseStyle, condStyle]`) with plain object spread: `showX ? baseStyle : {...baseStyle, ...hiddenStyle}`
- `UnconnectedTeacherContentToggle` export is now the bare class instead of `Radium(TeacherContentToggle)`
- All 13 existing unit tests pass without modification

## Where to verify
`TeacherContentToggle` renders in the teacher panel on any level page. Log in as a teacher and visit any student level, then toggle **View as → Student** to exercise the locked/hidden lesson overlay behavior:

**`/s/csp1-2023/lessons/1/levels/1`** (or any unit with a lockable lesson)

Check that:
- The level content is visible by default in instructor view
- Switching "View as Student" on a locked lesson shows the lock message overlay
- Switching "View as Student" on a hidden lesson shows the hidden message overlay

## Test plan
- [ ] Visit a level page as a teacher, confirm normal instructor view renders correctly
- [ ] Toggle "View as Student" with a locked lesson — lock overlay should appear
- [ ] Toggle "View as Student" with a hidden lesson — hidden overlay should appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)