### PR TITLE
[SpriteLab] Fixes 6 spritelab poetry wcag violations

### DIFF
--- a/apps/src/code-studio/LegacyDialog.js
+++ b/apps/src/code-studio/LegacyDialog.js
@@ -66,7 +66,9 @@ var LegacyDialog = (module.exports = function (options) {
 
   var close = options.close === undefined ? true : options.close;
 
-  var closeLink = $('<div id="x-close"/>')
+  var closeLink = $(
+    '<button id="x-close" type="button" aria-label="Close"></button>'
+  )
     .addClass('x-close')
     .attr('data-dismiss', 'modal');
   this.div = $('<div tabindex="-1"/>').addClass('modal');

--- a/apps/src/templates/instructions/InlineAudio.jsx
+++ b/apps/src/templates/instructions/InlineAudio.jsx
@@ -260,6 +260,7 @@ class InlineAudio extends React.Component {
           style={this.props.style && this.props.style.wrapper}
           onClick={this.toggleAudio}
           type="button"
+          aria-label={this.state.playing ? 'Pause audio' : 'Play audio'}
         >
           <div
             style={

--- a/apps/src/templates/instructions/ScrollButtons.jsx
+++ b/apps/src/templates/instructions/ScrollButtons.jsx
@@ -140,6 +140,7 @@ class ScrollButtons extends React.Component {
         key="scrollUp"
         onClick={this.singleScrollUp}
         onMouseDown={this.continuousScrollStartUp}
+        aria-label="Scroll instructions up"
       >
         <img src="/blockly/media/1x1.gif" className="scroll-up-btn" alt="" />
       </button>
@@ -159,6 +160,7 @@ class ScrollButtons extends React.Component {
           moduleStyles.arrowGlyph,
           moduleStyles.removeButtonStyles
         )}
+        aria-label="Scroll instructions up"
       >
         <FontAwesome
           icon="caret-up"
@@ -183,6 +185,7 @@ class ScrollButtons extends React.Component {
         key="scrollDown"
         onClick={this.singleScrollDown}
         onMouseDown={this.continuousScrollStartDown}
+        aria-label="Scroll instructions down"
       >
         <img src="/blockly/media/1x1.gif" className="scroll-down-btn" alt="" />
       </button>
@@ -203,6 +206,7 @@ class ScrollButtons extends React.Component {
         key="scrollDown"
         onClick={this.singleScrollDown}
         onMouseDown={this.continuousScrollStartDown}
+        aria-label="Scroll instructions down"
       >
         <FontAwesome
           icon="caret-down"

--- a/dashboard/app/assets/stylesheets/application.scss
+++ b/dashboard/app/assets/stylesheets/application.scss
@@ -1622,6 +1622,10 @@ body.iframe_embed_app_and_code {
 
 .x-close {
   @include close-button($cornerOffset: -20px);
+  // Reset native <button> styles so the icon matches the old <div>-based markup.
+  // (background-color already reset by the `background` shorthand in close-button mixin.)
+  border: 0;
+  padding: 0;
 }
 
 .open-link {


### PR DESCRIPTION
This was largely drafted via Claude (though I forced it to check in with every step). 

6 Issues: 

- Two for inline Audio button (no aria label caused it to misunderstand what it was for, so we got one role and one label violation for it). 
- Two for legacy dialog x button (one for video dialog, one for show code dialog)
- Two for instructions scroller buttons (one for up, one for down)

This makes the LegacyDialog close button into a button (with a label) instead of a div, which makes it tab navigable:

Before (no tab stop on the x close):


https://github.com/user-attachments/assets/1b26fa76-2e39-4e13-817e-8442d3b7a94d



After:
 
https://github.com/user-attachments/assets/824354ed-c9e9-429e-a56e-11eea1d99715


It also adds aria labels to the audio button, and instructions scroller buttons:

Before:


https://github.com/user-attachments/assets/4e586130-6bb7-4475-aa59-d451babf9737



After:


https://github.com/user-attachments/assets/c168034e-3783-408e-824a-62b3ede8b4a9





## Links

- Jira: https://codedotorg.atlassian.net/browse/SL-1675
- VPAT: https://axeauditor.dequecloud.com/test-run/dad68808-2a69-11f1-8768-0b2b032555fe/issue/fef0bb1c-2b42-11f1-b71c-336318669890?sortField=ordinal&sortDir=asc&filter%5Bcomponent_number%5D%5B0%5D=1&filter%5Bcomponent_number%5D%5B1%5D=2&filter%5Bpage_number%5D=0&filter%5Bidentifier%5D=4.1.2.a&row=8

## Testing story
<!-- How was this tested? Manual steps, adhoc links, automated tests, or why testing isn't needed. -->



## Deployment notes
<!-- Delete this section if it's a standard merge-and-deploy.
     Otherwise: migrations, feature flags, coordination, caching impacts, etc. -->



## Privacy and security
<!-- Delete this section if there is no privacy/security impact.
     Otherwise: new PII, auth changes, API surface changes, etc. -->

