### PR TITLE
Fix flaky TeacherHomepageTest

### DIFF
--- a/apps/test/unit/templates/studioHomepages/teacherHomepageV2/TeacherHomepageTest.tsx
+++ b/apps/test/unit/templates/studioHomepages/teacherHomepageV2/TeacherHomepageTest.tsx
@@ -94,7 +94,9 @@ describe('TeacherHomepage', () => {
   beforeEach(() => {
     fetchSpy = jest.spyOn(HttpClient, 'fetchJson');
     postSpy = jest.spyOn(HttpClient, 'post');
-    sendEventSpy = jest.spyOn(analyticsReporter, 'sendEvent');
+    sendEventSpy = jest
+      .spyOn(analyticsReporter, 'sendEvent')
+      .mockImplementation(() => {});
     jquerySpy = jest.spyOn($, 'getJSON');
     stubRedux();
     fetchSpy.mockImplementation((url: string) => {
@@ -223,8 +225,7 @@ describe('TeacherHomepage', () => {
 
     await screen.findByText('Picture password', {}, {timeout: 5000});
     expect(document.querySelector('.uitest-new-section-dialog')).not.toBeNull();
-    // This is a hail mary quick flakiness mitigation attempt. If we see continued failures, we should look for underlying causes.
-  }, 25000);
+  }, 10000);
 
   it('teaching/archived toggle', async () => {
     renderComponent();


### PR DESCRIPTION
I hit this failure a couple more times on Drone runs so decided to the let Claude take a crack at it. 

## Trello card
https://trello.com/c/LU6DURSp/11-fix-flaky-teacherhomepagetest

## Summary
- Root cause: `jest.spyOn(analyticsReporter, 'sendEvent')` without `.mockImplementation()` calls through to the real `sendEvent`, which calls `StatsigReporter.sendEvent`, which schedules async network flushes to `api.statsig.com`
- Those requests raced against the 5 s jest timeout and intermittently pushed `'teaching/archived toggle'` over the limit; after tests they kept the worker process alive (the leak warning)
- Fix: add `.mockImplementation(() => {})` so the spy records calls without triggering Statsig — `'teaching/archived toggle'` now takes ~2.7 s instead of ~3.3 s on a warm machine, with no jitter from network I/O
- Remove the "hail mary" comment on `'create section button opens popup'`; reduce its timeout from 25 s to 10 s now that the cause is gone (test runs in ~750 ms)

## Test plan
- [x] All 9 TeacherHomepage tests pass locally (previously 3 tests were skipped with extended timeouts)
- [x] `'teaching/archived toggle'` completes in ~2.7 s (was ~3.3 s, nondeterministically slower in CI)
- [x] Full drone run to confirm no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)