### PR TITLE
AI Tutor: Add Statsig logging for when a student navigates between modalities

### DIFF
--- a/apps/src/aiTutor/views/lessonDeepDive/InterventionBox.tsx
+++ b/apps/src/aiTutor/views/lessonDeepDive/InterventionBox.tsx
@@ -1,9 +1,13 @@
 import FontAwesomeV6Icon from '@code-dot-org/component-library/fontAwesomeV6Icon';
 import {Typography} from '@mui/material';
 import {createTheme, ThemeProvider} from '@mui/material/styles';
-import React, {FC, useState} from 'react';
+import React, {FC, useCallback, useState} from 'react';
 
 const lightTheme = createTheme({palette: {mode: 'light'}});
+
+import {EVENTS} from '@cdo/apps/metrics/AnalyticsConstants';
+import analyticsReporter from '@cdo/apps/metrics/AnalyticsReporter';
+import {useAppSelector} from '@cdo/apps/util/reduxHooks';
 
 import LessonDeepDiveTutorChat from './LessonDeepDiveTutorChat';
 import PodcastsBox from './PodcastsBox';
@@ -78,6 +82,26 @@ const InterventionBox: FC<InterventionBoxProps> = ({
   reflectionData,
 }) => {
   const [selected, setSelected] = useState<CardId | null>(null);
+  const userId = useAppSelector(state => state.currentUser.userId);
+
+  const handleNavSelect = useCallback(
+    (toCardId: CardId) => {
+      if (selected && selected !== toCardId) {
+        analyticsReporter.sendEvent(
+          EVENTS.AI_TUTOR_LESSON_DEEP_DIVE_MODALITY_NAVIGATION,
+          {
+            from: selected,
+            to: toCardId,
+            lessonId,
+            lessonName,
+            userId,
+          }
+        );
+      }
+      setSelected(toCardId);
+    },
+    [selected, lessonId, lessonName, userId]
+  );
 
   return (
     <div className={styles.container}>
@@ -141,7 +165,7 @@ const InterventionBox: FC<InterventionBoxProps> = ({
                 className={`${styles.navItem} ${
                   isActive ? card.activeColorClass : ''
                 }`}
-                onClick={() => setSelected(card.id)}
+                onClick={() => handleNavSelect(card.id)}
                 aria-label={card.label}
                 aria-current={isActive ? 'page' : undefined}
               >

--- a/apps/src/metrics/AnalyticsConstants.js
+++ b/apps/src/metrics/AnalyticsConstants.js
@@ -328,6 +328,8 @@ const EVENTS = {
   AI_TUTOR_CODE_SNIPPET_ADDED_TO_CONTEXT:
     'AI Tutor Code Snippet Added to Context',
   AI_TUTOR_FILE_ADDED_TO_CONTEXT: 'AI Tutor File Added to Context',
+  AI_TUTOR_LESSON_DEEP_DIVE_MODALITY_NAVIGATION:
+    'AI Tutor Lesson Deep Dive Modality Navigation',
 
   // Javalab
   JAVALAB_TEST_BUTTON_CLICK: 'Javalab Test Button Clicked',


### PR DESCRIPTION
## Trello card
https://trello.com/c/BdwvVXsQ/18-add-statsig-logging-for-when-a-student-navigates-between-modalities-in-the-nav-menu

## Summary
- Added `AI_TUTOR_LESSON_DEEP_DIVE_MODALITY_NAVIGATION` event constant to `AnalyticsConstants.js`
- Added `handleNavSelect` handler to `InterventionBox` that fires the event when a student clicks a bottom-nav button to switch to a different modality
- Event payload includes `from` (current modality), `to` (destination modality), `lessonId`, `lessonName`, `userId`
- Event only fires on actual navigation (clicking a different modality); clicking the already-active tab does not log

## Test plan
Open the AI Tutor on a lesson, open DevTools → Statsig reporter, then verify each combination:

- [x] flashcards → chat
- [x] flashcards → videos
- [x] flashcards → podcasts
- [x] chat → flashcards
- [x] chat → videos
- [x] chat → podcasts
- [x] videos → flashcards
- [x] videos → chat
- [x] videos → podcasts
- [x] podcasts → flashcards
- [x] podcasts → chat
- [x] podcasts → videos
- [x] Clicking the already-active tab does **not** fire an event
- [x] Verify `from`, `to`, `lessonId`, `lessonName`, and `userId` are all present and accurate in each logged event

🤖 Generated with [Claude Code](https://claude.com/claude-code)