### PR TITLE
Populate name contact properties on course-list signup

### DIFF
--- a/lib/cdo/mailjet.rb
+++ b/lib/cdo/mailjet.rb
@@ -91,7 +91,6 @@ module MailJet
     contact = find_or_create_contact(user.email, user.name)
     update_contact_fields(contact,
       [
-        {name: 'firstname', value: user.name}, # existing templates use 'firstname'
         {name: 'given_name', value: user.given_name},
         {name: 'family_name', value: user.family_name},
         {name: 'display_name', value: user.name},

--- a/lib/cdo/mailjet.rb
+++ b/lib/cdo/mailjet.rb
@@ -89,6 +89,15 @@ module MailJet
     return unless contact_list_id
 
     contact = find_or_create_contact(user.email, user.name)
+    update_contact_fields(contact,
+      [
+        {name: 'firstname', value: user.name}, # existing templates use 'firstname'
+        {name: 'given_name', value: user.given_name},
+        {name: 'family_name', value: user.family_name},
+        {name: 'display_name', value: user.name},
+        {name: 'sign_up_date', value: user.created_at.to_datetime.rfc3339}
+      ]
+    )
 
     begin
       add_to_contact_list(contact, contact_list_id)

--- a/lib/test/cdo/test_mailjet.rb
+++ b/lib/test/cdo/test_mailjet.rb
@@ -275,22 +275,85 @@ class MailJetTest < Minitest::Test
 
   def test_create_contact_and_add_to_course_list
     email = 'fake.email@test.xx'
+    sign_up_time = Time.now.to_datetime
 
     user = mock
     user.stubs(:id).returns(1)
     user.stubs(:email).returns(email)
     user.stubs(:name).returns('Fake Name')
+    user.stubs(:given_name).returns('Fake')
+    user.stubs(:family_name).returns('Name')
     user.stubs(:teacher?).returns(true)
+    user.stubs(:created_at).returns(sign_up_time)
 
+    mock_contact_id = 123
     mock_contact = mock('Mailjet::Contact')
-    mock_contact.stubs(:id).returns(123)
+    mock_contact.stubs(:id).returns(mock_contact_id)
 
     MailJet.expects(:find_or_create_contact).with(email, user.name).returns(mock_contact)
+
+    mock_contactdata = mock('Mailjet::Contactdata')
+    Mailjet::Contactdata.expects(:find).with(mock_contact_id).returns(mock_contactdata)
+    mock_contactdata.expects(:update_attributes).with(data: [{name: 'firstname', value: 'Fake Name'}])
+    mock_contactdata.expects(:update_attributes).with(data: [{name: 'given_name', value: 'Fake'}])
+    mock_contactdata.expects(:update_attributes).with(data: [{name: 'family_name', value: 'Name'}])
+    mock_contactdata.expects(:update_attributes).with(data: [{name: 'display_name', value: 'Fake Name'}])
+    mock_contactdata.expects(:update_attributes).with(data: [{name: 'sign_up_date', value: sign_up_time.rfc3339}])
 
     MailJet.stubs(:subaccount).returns('production')
     MailJet.expects(:add_to_contact_list).with(mock_contact, MailJet::CONTACT_LISTS[:intro_web_lab][:production][:default])
 
     MailJet.create_contact_and_add_to_course_list(user, 'intro-to-web-lab')
+  end
+
+  def test_create_contact_and_add_to_course_list_swallows_duplicate_list_recipient
+    email = 'fake.email@test.xx'
+    sign_up_time = Time.now.to_datetime
+
+    user = mock
+    user.stubs(:id).returns(1)
+    user.stubs(:email).returns(email)
+    user.stubs(:name).returns('Fake Name')
+    user.stubs(:given_name).returns('Fake')
+    user.stubs(:family_name).returns('Name')
+    user.stubs(:teacher?).returns(true)
+    user.stubs(:created_at).returns(sign_up_time)
+
+    mock_contact = mock('Mailjet::Contact')
+    mock_contact.stubs(:id).returns(123)
+
+    MailJet.expects(:find_or_create_contact).with(email, user.name).returns(mock_contact)
+    MailJet.stubs(:update_contact_fields)
+    MailJet.stubs(:subaccount).returns('production')
+    MailJet.expects(:add_to_contact_list).raises(Mailjet::ApiError.new(400, 'A duplicate ListRecipient already exists.', nil, nil, nil))
+
+    MailJet.create_contact_and_add_to_course_list(user, 'intro-to-web-lab')
+  end
+
+  def test_create_contact_and_add_to_course_list_reraises_other_api_errors
+    email = 'fake.email@test.xx'
+    sign_up_time = Time.now.to_datetime
+
+    user = mock
+    user.stubs(:id).returns(1)
+    user.stubs(:email).returns(email)
+    user.stubs(:name).returns('Fake Name')
+    user.stubs(:given_name).returns('Fake')
+    user.stubs(:family_name).returns('Name')
+    user.stubs(:teacher?).returns(true)
+    user.stubs(:created_at).returns(sign_up_time)
+
+    mock_contact = mock('Mailjet::Contact')
+    mock_contact.stubs(:id).returns(123)
+
+    MailJet.expects(:find_or_create_contact).with(email, user.name).returns(mock_contact)
+    MailJet.stubs(:update_contact_fields)
+    MailJet.stubs(:subaccount).returns('production')
+    MailJet.expects(:add_to_contact_list).raises(Mailjet::ApiError.new(500, 'Something else went wrong.', nil, nil, nil))
+
+    assert_raises(Mailjet::ApiError) do
+      MailJet.create_contact_and_add_to_course_list(user, 'intro-to-web-lab')
+    end
   end
 
   def test_create_contact_and_add_to_course_list_non_teacher

--- a/lib/test/cdo/test_mailjet.rb
+++ b/lib/test/cdo/test_mailjet.rb
@@ -294,7 +294,6 @@ class MailJetTest < Minitest::Test
 
     mock_contactdata = mock('Mailjet::Contactdata')
     Mailjet::Contactdata.expects(:find).with(mock_contact_id).returns(mock_contactdata)
-    mock_contactdata.expects(:update_attributes).with(data: [{name: 'firstname', value: 'Fake Name'}])
     mock_contactdata.expects(:update_attributes).with(data: [{name: 'given_name', value: 'Fake'}])
     mock_contactdata.expects(:update_attributes).with(data: [{name: 'family_name', value: 'Name'}])
     mock_contactdata.expects(:update_attributes).with(data: [{name: 'display_name', value: 'Fake Name'}])


### PR DESCRIPTION
The course-list contact flow added in #72076 added users to a MailJet list but did not populate their name fields. I mirrored what is passed through for the welcome series here, but added `given_name` and `family_name`, new fields added since the welcome series. 

In a follow-up, I'll add these fields to the welcome series flow too, but there's a little bit of time sensitivity around this change, so I didn't want to bloat it too much (though see my inline comment about tests).


Here's an example of the contact fields for a new user after this change (note: I since removed firstname):

<img width="1327" height="386" alt="Screenshot 2026-04-17 174009" src="https://github.com/user-attachments/assets/2e2e0e21-bf24-43ab-9876-9e242bb2aa45" />
