### PR TITLE
Sketch2: tab order/selection fixes

### DIFF
--- a/apps/src/sketchlab/reactFlow/AGENTS.md
+++ b/apps/src/sketchlab/reactFlow/AGENTS.md
@@ -17,5 +17,5 @@ tool for making interactive diagrams, used by students in grades 6-12.
 - We hard-code user-facing English strings. The old way of using i18n you see in other folders is deprecated.
 - Use human-readable variable names. Prefer names such as `newWidth` over `newW`, or `element` or `e`.
 - Use constants for any magic numbers.
-- Ensure eslint passes.
+- Ensure eslint passes. Run `./tools/hooks/pre-commit` from the repo root after making changes to verify.
 - CSS module names should be in kebab-case.

--- a/apps/src/sketchlab/reactFlow/components/ReactFlowCanvas.tsx
+++ b/apps/src/sketchlab/reactFlow/components/ReactFlowCanvas.tsx
@@ -105,10 +105,6 @@ export default function ReactFlowCanvas({
       readOnly,
     });
 
-  const handlePaneClick = useCallback(() => {
-    setLastFocusedEntry(null);
-  }, [setLastFocusedEntry]);
-
   // Clear selection when focus leaves the canvas container entirely
   // (e.g. clicking outside or tabbing out of the canvas).
   const handleContainerBlur = useCallback(
@@ -126,64 +122,55 @@ export default function ReactFlowCanvas({
   // overwritten when RF reconciles tabIndex={0} on focusable nodes).
   // Also applies connect-source styling and aria-selected via React
   // rather than direct DOM classList manipulation.
-  const displayNodes = useMemo(
-    () =>
-      nodes.map(node => {
-        const isTabTarget =
-          activeEntry?.type === 'node' && activeEntry.id === node.id;
-        const isSelected =
-          nodeOrEdgeFocused &&
-          lastFocusedEntry?.type === 'node' &&
-          lastFocusedEntry.id === node.id;
+  const {displayNodes, displayEdges} = useMemo(() => {
+    const applyDisplayProps = (
+      item: SketchlabReactFlowEdge | SketchlabReactFlowNode,
+      kind: 'node' | 'edge'
+    ) => {
+      const isTabTarget =
+        activeEntry?.type === kind && activeEntry.id === item.id;
+      const isSelected =
+        nodeOrEdgeFocused &&
+        lastFocusedEntry?.type === kind &&
+        lastFocusedEntry.id === item.id;
+      return {
+        selected: isSelected && !readOnly,
+        domAttributes: {tabIndex: isTabTarget ? 0 : -1},
+      };
+    };
+
+    return {
+      displayNodes: nodes.map(node => {
         const isConnectSource = connectingFrom === node.id;
+        const {selected, domAttributes} = applyDisplayProps(node, 'node');
         return {
           ...node,
-          selected: isSelected && !readOnly,
+          selected,
           className: isConnectSource ? styles.connectSource : undefined,
           domAttributes: {
-            tabIndex: isTabTarget ? 0 : -1,
+            ...domAttributes,
             ...(isConnectSource && {'aria-selected': true}),
           },
         };
       }),
-    [
-      nodes,
-      activeEntry?.type,
-      activeEntry?.id,
-      nodeOrEdgeFocused,
-      lastFocusedEntry?.type,
-      lastFocusedEntry?.id,
-      connectingFrom,
-      readOnly,
-    ]
-  );
-  // TODO: Add meaningful ariaLabel to edges using node labels instead of
-  // raw IDs (React Flow defaults to "Edge from {sourceId} to {targetId}").
-  const displayEdges = useMemo(
-    () =>
-      edges.map(edge => {
-        const isTabTarget =
-          activeEntry?.type === 'edge' && activeEntry.id === edge.id;
-        const isSelected =
-          nodeOrEdgeFocused &&
-          lastFocusedEntry?.type === 'edge' &&
-          lastFocusedEntry.id === edge.id;
-        return {
-          ...edge,
-          selected: isSelected && !readOnly,
-          domAttributes: {tabIndex: isTabTarget ? 0 : -1},
-        };
-      }),
-    [
-      edges,
-      activeEntry?.type,
-      activeEntry?.id,
-      nodeOrEdgeFocused,
-      lastFocusedEntry?.type,
-      lastFocusedEntry?.id,
-      readOnly,
-    ]
-  );
+      // TODO: Add meaningful ariaLabel to edges using node labels instead of
+      // raw IDs (React Flow defaults to "Edge from {sourceId} to {targetId}").
+      displayEdges: edges.map(edge => ({
+        ...edge,
+        ...applyDisplayProps(edge, 'edge'),
+      })),
+    };
+  }, [
+    nodes,
+    edges,
+    activeEntry?.type,
+    activeEntry?.id,
+    nodeOrEdgeFocused,
+    lastFocusedEntry?.type,
+    lastFocusedEntry?.id,
+    connectingFrom,
+    readOnly,
+  ]);
 
   // Debounced save: sync ReactFlow state back to project sources.
   const saveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -290,7 +277,6 @@ export default function ReactFlowCanvas({
           onEdgesChange={onEdgesChange}
           onConnect={onConnect}
           nodeTypes={NODE_TYPES}
-          onPaneClick={handlePaneClick}
           onMoveEnd={handleMoveEnd}
           defaultViewport={initialViewport}
           fitView={!initialViewport}
@@ -302,6 +288,8 @@ export default function ReactFlowCanvas({
           elementsSelectable={!readOnly}
           nodesFocusable={true}
           edgesFocusable={true}
+          // Even though we manage tab order, we keep React Flow's keyboard A11y on because
+          // it manages things like moving nodes with arrow keys.
           disableKeyboardA11y={false}
           autoPanOnNodeFocus={false} // We manage viewport on focus manually in useFocusManagement.
         >

--- a/apps/src/sketchlab/reactFlow/components/ReactFlowCanvas.tsx
+++ b/apps/src/sketchlab/reactFlow/components/ReactFlowCanvas.tsx
@@ -77,10 +77,11 @@ export default function ReactFlowCanvas({
   const {screenToFlowPosition} = useReactFlow();
   const addedNodeCountRef = useRef(0);
 
-  const {tabOrder, activeEntry, setActiveTabEntry} = useTabOrder(
-    nodes as SketchlabReactFlowNode[],
-    edges as SketchlabReactFlowEdge[]
-  );
+  const {tabOrder, activeEntry, activeTabEntry, setActiveTabEntry} =
+    useTabOrder(
+      nodes as SketchlabReactFlowNode[],
+      edges as SketchlabReactFlowEdge[]
+    );
 
   const {focusEntry, handleFocusCapture} = useFocusManagement(
     tabOrder,
@@ -97,6 +98,33 @@ export default function ReactFlowCanvas({
       readOnly,
     });
 
+  // Filter out React Flow's internal selection changes. We manage
+  // selection via activeTabEntry so that visual indicators (NodeResizer,
+  // edge highlight) stay in sync with keyboard/click focus.
+  const handleNodesChange = useCallback(
+    (changes: Parameters<typeof onNodesChange>[0]) => {
+      const filtered = changes.filter(change => change.type !== 'select');
+      if (filtered.length > 0) {
+        onNodesChange(filtered);
+      }
+    },
+    [onNodesChange]
+  );
+
+  const handleEdgesChange = useCallback(
+    (changes: Parameters<typeof onEdgesChange>[0]) => {
+      const filtered = changes.filter(change => change.type !== 'select');
+      if (filtered.length > 0) {
+        onEdgesChange(filtered);
+      }
+    },
+    [onEdgesChange]
+  );
+
+  const handlePaneClick = useCallback(() => {
+    setActiveTabEntry(null);
+  }, [setActiveTabEntry]);
+
   // Apply roving tabindex through React Flow's domAttributes so it
   // survives React Flow re-renders (direct DOM manipulation gets
   // overwritten when RF reconciles tabIndex={0} on focusable nodes).
@@ -105,30 +133,39 @@ export default function ReactFlowCanvas({
   const displayNodes = useMemo(
     () =>
       nodes.map(node => {
-        const isActive =
+        const isTabTarget =
           activeEntry?.type === 'node' && activeEntry.id === node.id;
+        const isFocused =
+          activeTabEntry?.type === 'node' && activeTabEntry.id === node.id;
         const isConnectSource = connectingFrom === node.id;
         return {
           ...node,
+          selected: isFocused,
           className: isConnectSource ? styles.connectSource : undefined,
           domAttributes: {
-            tabIndex: isActive ? 0 : -1,
+            tabIndex: isTabTarget ? 0 : -1,
             ...(isConnectSource && {'aria-selected': true}),
           },
         };
       }),
-    [nodes, activeEntry, connectingFrom]
+    [nodes, activeEntry, activeTabEntry, connectingFrom]
   );
   // TODO: Add meaningful ariaLabel to edges using node labels instead of
   // raw IDs (React Flow defaults to "Edge from {sourceId} to {targetId}").
   const displayEdges = useMemo(
     () =>
       edges.map(edge => {
-        const isActive =
+        const isTabTarget =
           activeEntry?.type === 'edge' && activeEntry.id === edge.id;
-        return {...edge, domAttributes: {tabIndex: isActive ? 0 : -1}};
+        const isFocused =
+          activeTabEntry?.type === 'edge' && activeTabEntry.id === edge.id;
+        return {
+          ...edge,
+          selected: isFocused,
+          domAttributes: {tabIndex: isTabTarget ? 0 : -1},
+        };
       }),
-    [edges, activeEntry]
+    [edges, activeEntry, activeTabEntry]
   );
 
   // Debounced save: sync ReactFlow state back to project sources.
@@ -231,10 +268,11 @@ export default function ReactFlowCanvas({
         <ReactFlow
           nodes={displayNodes}
           edges={displayEdges}
-          onNodesChange={readOnly ? undefined : onNodesChange}
-          onEdgesChange={readOnly ? undefined : onEdgesChange}
+          onNodesChange={readOnly ? undefined : handleNodesChange}
+          onEdgesChange={readOnly ? undefined : handleEdgesChange}
           onConnect={readOnly ? undefined : onConnect}
           nodeTypes={NODE_TYPES}
+          onPaneClick={readOnly ? undefined : handlePaneClick}
           onMoveEnd={readOnly ? undefined : handleMoveEnd}
           defaultViewport={initialViewport}
           fitView={!initialViewport}

--- a/apps/src/sketchlab/reactFlow/components/ReactFlowCanvas.tsx
+++ b/apps/src/sketchlab/reactFlow/components/ReactFlowCanvas.tsx
@@ -98,29 +98,6 @@ export default function ReactFlowCanvas({
       readOnly,
     });
 
-  // Filter out React Flow's internal selection changes. We manage
-  // selection via lastFocusedEntry so that visual indicators (NodeResizer,
-  // edge highlight) stay in sync with keyboard/click focus.
-  const handleNodesChange = useCallback(
-    (changes: Parameters<typeof onNodesChange>[0]) => {
-      const filtered = changes.filter(change => change.type !== 'select');
-      if (filtered.length > 0) {
-        onNodesChange(filtered);
-      }
-    },
-    [onNodesChange]
-  );
-
-  const handleEdgesChange = useCallback(
-    (changes: Parameters<typeof onEdgesChange>[0]) => {
-      const filtered = changes.filter(change => change.type !== 'select');
-      if (filtered.length > 0) {
-        onEdgesChange(filtered);
-      }
-    },
-    [onEdgesChange]
-  );
-
   const handlePaneClick = useCallback(() => {
     setLastFocusedEntry(null);
   }, [setLastFocusedEntry]);
@@ -280,8 +257,8 @@ export default function ReactFlowCanvas({
         <ReactFlow
           nodes={displayNodes}
           edges={displayEdges}
-          onNodesChange={readOnly ? undefined : handleNodesChange}
-          onEdgesChange={readOnly ? undefined : handleEdgesChange}
+          onNodesChange={readOnly ? undefined : onNodesChange}
+          onEdgesChange={readOnly ? undefined : onEdgesChange}
           onConnect={readOnly ? undefined : onConnect}
           nodeTypes={NODE_TYPES}
           onPaneClick={readOnly ? undefined : handlePaneClick}

--- a/apps/src/sketchlab/reactFlow/components/ReactFlowCanvas.tsx
+++ b/apps/src/sketchlab/reactFlow/components/ReactFlowCanvas.tsx
@@ -125,6 +125,17 @@ export default function ReactFlowCanvas({
     setActiveTabEntry(null);
   }, [setActiveTabEntry]);
 
+  // Clear selection when focus leaves the canvas container entirely
+  // (e.g. clicking outside or tabbing out of the canvas).
+  const handleContainerBlur = useCallback(
+    (event: React.FocusEvent) => {
+      if (!event.currentTarget.contains(event.relatedTarget as Node)) {
+        setActiveTabEntry(null);
+      }
+    },
+    [setActiveTabEntry]
+  );
+
   // Apply roving tabindex through React Flow's domAttributes so it
   // survives React Flow re-renders (direct DOM manipulation gets
   // overwritten when RF reconciles tabIndex={0} on focusable nodes).
@@ -260,6 +271,7 @@ export default function ReactFlowCanvas({
         )}
         onKeyDownCapture={handleKeyDown}
         onFocusCapture={handleFocusCapture}
+        onBlur={handleContainerBlur}
       >
         {!readOnly && <Toolbar onAddNode={handleAddNode} />}
         <div aria-live="assertive" className={styles.srOnly}>

--- a/apps/src/sketchlab/reactFlow/components/ReactFlowCanvas.tsx
+++ b/apps/src/sketchlab/reactFlow/components/ReactFlowCanvas.tsx
@@ -77,16 +77,23 @@ export default function ReactFlowCanvas({
   const {screenToFlowPosition} = useReactFlow();
   const addedNodeCountRef = useRef(0);
 
-  const {tabOrder, activeEntry, lastFocusedEntry, setLastFocusedEntry} =
-    useTabOrder(
-      nodes as SketchlabReactFlowNode[],
-      edges as SketchlabReactFlowEdge[]
-    );
+  const {
+    tabOrder,
+    activeEntry,
+    lastFocusedEntry,
+    setLastFocusedEntry,
+    nodeOrEdgeFocused,
+    setNodeOrEdgeFocused,
+  } = useTabOrder(
+    nodes as SketchlabReactFlowNode[],
+    edges as SketchlabReactFlowEdge[]
+  );
 
   const {focusEntry, handleFocusCapture} = useFocusManagement(
     tabOrder,
     edges as SketchlabReactFlowEdge[],
-    setLastFocusedEntry
+    setLastFocusedEntry,
+    setNodeOrEdgeFocused
   );
 
   const {connectingFrom, connectAnnouncement, handleKeyDown} =
@@ -108,9 +115,10 @@ export default function ReactFlowCanvas({
     (event: React.FocusEvent) => {
       if (!event.currentTarget.contains(event.relatedTarget as Node)) {
         setLastFocusedEntry(null);
+        setNodeOrEdgeFocused(false);
       }
     },
-    [setLastFocusedEntry]
+    [setLastFocusedEntry, setNodeOrEdgeFocused]
   );
 
   // Apply roving tabindex through React Flow's domAttributes so it
@@ -123,12 +131,14 @@ export default function ReactFlowCanvas({
       nodes.map(node => {
         const isTabTarget =
           activeEntry?.type === 'node' && activeEntry.id === node.id;
-        const isFocused =
-          lastFocusedEntry?.type === 'node' && lastFocusedEntry.id === node.id;
+        const isSelected =
+          nodeOrEdgeFocused &&
+          lastFocusedEntry?.type === 'node' &&
+          lastFocusedEntry.id === node.id;
         const isConnectSource = connectingFrom === node.id;
         return {
           ...node,
-          selected: isFocused && !readOnly,
+          selected: isSelected && !readOnly,
           className: isConnectSource ? styles.connectSource : undefined,
           domAttributes: {
             tabIndex: isTabTarget ? 0 : -1,
@@ -140,6 +150,7 @@ export default function ReactFlowCanvas({
       nodes,
       activeEntry?.type,
       activeEntry?.id,
+      nodeOrEdgeFocused,
       lastFocusedEntry?.type,
       lastFocusedEntry?.id,
       connectingFrom,
@@ -153,18 +164,21 @@ export default function ReactFlowCanvas({
       edges.map(edge => {
         const isTabTarget =
           activeEntry?.type === 'edge' && activeEntry.id === edge.id;
-        const isFocused =
-          lastFocusedEntry?.type === 'edge' && lastFocusedEntry.id === edge.id;
+        const isSelected =
+          nodeOrEdgeFocused &&
+          lastFocusedEntry?.type === 'edge' &&
+          lastFocusedEntry.id === edge.id;
         return {
           ...edge,
-          selected: isFocused && !readOnly,
+          selected: isSelected && !readOnly,
           domAttributes: {tabIndex: isTabTarget ? 0 : -1},
         };
       }),
     [
       edges,
       activeEntry?.type,
-      activeEntry.id,
+      activeEntry?.id,
+      nodeOrEdgeFocused,
       lastFocusedEntry?.type,
       lastFocusedEntry?.id,
       readOnly,

--- a/apps/src/sketchlab/reactFlow/components/ReactFlowCanvas.tsx
+++ b/apps/src/sketchlab/reactFlow/components/ReactFlowCanvas.tsx
@@ -125,13 +125,13 @@ export default function ReactFlowCanvas({
   const {displayNodes, displayEdges} = useMemo(() => {
     const applyDisplayProps = (
       item: SketchlabReactFlowEdge | SketchlabReactFlowNode,
-      kind: 'node' | 'edge'
+      type: 'node' | 'edge'
     ) => {
       const isTabTarget =
-        activeEntry?.type === kind && activeEntry.id === item.id;
+        activeEntry?.type === type && activeEntry.id === item.id;
       const isSelected =
         nodeOrEdgeFocused &&
-        lastFocusedEntry?.type === kind &&
+        lastFocusedEntry?.type === type &&
         lastFocusedEntry.id === item.id;
       return {
         selected: isSelected && !readOnly,

--- a/apps/src/sketchlab/reactFlow/components/ReactFlowCanvas.tsx
+++ b/apps/src/sketchlab/reactFlow/components/ReactFlowCanvas.tsx
@@ -128,7 +128,7 @@ export default function ReactFlowCanvas({
         const isConnectSource = connectingFrom === node.id;
         return {
           ...node,
-          selected: isFocused,
+          selected: isFocused && !readOnly,
           className: isConnectSource ? styles.connectSource : undefined,
           domAttributes: {
             tabIndex: isTabTarget ? 0 : -1,
@@ -136,7 +136,15 @@ export default function ReactFlowCanvas({
           },
         };
       }),
-    [nodes, activeEntry, lastFocusedEntry, connectingFrom]
+    [
+      nodes,
+      activeEntry?.type,
+      activeEntry?.id,
+      lastFocusedEntry?.type,
+      lastFocusedEntry?.id,
+      connectingFrom,
+      readOnly,
+    ]
   );
   // TODO: Add meaningful ariaLabel to edges using node labels instead of
   // raw IDs (React Flow defaults to "Edge from {sourceId} to {targetId}").
@@ -149,11 +157,18 @@ export default function ReactFlowCanvas({
           lastFocusedEntry?.type === 'edge' && lastFocusedEntry.id === edge.id;
         return {
           ...edge,
-          selected: isFocused,
+          selected: isFocused && !readOnly,
           domAttributes: {tabIndex: isTabTarget ? 0 : -1},
         };
       }),
-    [edges, activeEntry, lastFocusedEntry]
+    [
+      edges,
+      activeEntry?.type,
+      activeEntry.id,
+      lastFocusedEntry?.type,
+      lastFocusedEntry?.id,
+      readOnly,
+    ]
   );
 
   // Debounced save: sync ReactFlow state back to project sources.
@@ -257,12 +272,12 @@ export default function ReactFlowCanvas({
         <ReactFlow
           nodes={displayNodes}
           edges={displayEdges}
-          onNodesChange={readOnly ? undefined : onNodesChange}
-          onEdgesChange={readOnly ? undefined : onEdgesChange}
-          onConnect={readOnly ? undefined : onConnect}
+          onNodesChange={onNodesChange}
+          onEdgesChange={onEdgesChange}
+          onConnect={onConnect}
           nodeTypes={NODE_TYPES}
-          onPaneClick={readOnly ? undefined : handlePaneClick}
-          onMoveEnd={readOnly ? undefined : handleMoveEnd}
+          onPaneClick={handlePaneClick}
+          onMoveEnd={handleMoveEnd}
           defaultViewport={initialViewport}
           fitView={!initialViewport}
           colorMode={colorMode}

--- a/apps/src/sketchlab/reactFlow/components/ReactFlowCanvas.tsx
+++ b/apps/src/sketchlab/reactFlow/components/ReactFlowCanvas.tsx
@@ -77,7 +77,7 @@ export default function ReactFlowCanvas({
   const {screenToFlowPosition} = useReactFlow();
   const addedNodeCountRef = useRef(0);
 
-  const {tabOrder, activeEntry, activeTabEntry, setActiveTabEntry} =
+  const {tabOrder, activeEntry, lastFocusedEntry, setLastFocusedEntry} =
     useTabOrder(
       nodes as SketchlabReactFlowNode[],
       edges as SketchlabReactFlowEdge[]
@@ -86,7 +86,7 @@ export default function ReactFlowCanvas({
   const {focusEntry, handleFocusCapture} = useFocusManagement(
     tabOrder,
     edges as SketchlabReactFlowEdge[],
-    setActiveTabEntry
+    setLastFocusedEntry
   );
 
   const {connectingFrom, connectAnnouncement, handleKeyDown} =
@@ -99,7 +99,7 @@ export default function ReactFlowCanvas({
     });
 
   // Filter out React Flow's internal selection changes. We manage
-  // selection via activeTabEntry so that visual indicators (NodeResizer,
+  // selection via lastFocusedEntry so that visual indicators (NodeResizer,
   // edge highlight) stay in sync with keyboard/click focus.
   const handleNodesChange = useCallback(
     (changes: Parameters<typeof onNodesChange>[0]) => {
@@ -122,18 +122,18 @@ export default function ReactFlowCanvas({
   );
 
   const handlePaneClick = useCallback(() => {
-    setActiveTabEntry(null);
-  }, [setActiveTabEntry]);
+    setLastFocusedEntry(null);
+  }, [setLastFocusedEntry]);
 
   // Clear selection when focus leaves the canvas container entirely
   // (e.g. clicking outside or tabbing out of the canvas).
   const handleContainerBlur = useCallback(
     (event: React.FocusEvent) => {
       if (!event.currentTarget.contains(event.relatedTarget as Node)) {
-        setActiveTabEntry(null);
+        setLastFocusedEntry(null);
       }
     },
-    [setActiveTabEntry]
+    [setLastFocusedEntry]
   );
 
   // Apply roving tabindex through React Flow's domAttributes so it
@@ -147,7 +147,7 @@ export default function ReactFlowCanvas({
         const isTabTarget =
           activeEntry?.type === 'node' && activeEntry.id === node.id;
         const isFocused =
-          activeTabEntry?.type === 'node' && activeTabEntry.id === node.id;
+          lastFocusedEntry?.type === 'node' && lastFocusedEntry.id === node.id;
         const isConnectSource = connectingFrom === node.id;
         return {
           ...node,
@@ -159,7 +159,7 @@ export default function ReactFlowCanvas({
           },
         };
       }),
-    [nodes, activeEntry, activeTabEntry, connectingFrom]
+    [nodes, activeEntry, lastFocusedEntry, connectingFrom]
   );
   // TODO: Add meaningful ariaLabel to edges using node labels instead of
   // raw IDs (React Flow defaults to "Edge from {sourceId} to {targetId}").
@@ -169,14 +169,14 @@ export default function ReactFlowCanvas({
         const isTabTarget =
           activeEntry?.type === 'edge' && activeEntry.id === edge.id;
         const isFocused =
-          activeTabEntry?.type === 'edge' && activeTabEntry.id === edge.id;
+          lastFocusedEntry?.type === 'edge' && lastFocusedEntry.id === edge.id;
         return {
           ...edge,
           selected: isFocused,
           domAttributes: {tabIndex: isTabTarget ? 0 : -1},
         };
       }),
-    [edges, activeEntry, activeTabEntry]
+    [edges, activeEntry, lastFocusedEntry]
   );
 
   // Debounced save: sync ReactFlow state back to project sources.

--- a/apps/src/sketchlab/reactFlow/hooks/useFocusManagement.ts
+++ b/apps/src/sketchlab/reactFlow/hooks/useFocusManagement.ts
@@ -22,7 +22,8 @@ const PAN_DURATION_MS = 200;
 export function useFocusManagement(
   tabOrder: TabOrderEntry[],
   edges: SketchlabReactFlowEdge[],
-  setLastFocusedEntry: (entry: TabOrderEntry | null) => void
+  setLastFocusedEntry: (entry: TabOrderEntry | null) => void,
+  setNodeOrEdgeFocused: (focused: boolean) => void
 ) {
   const {fitView, getZoom} = useReactFlow();
 
@@ -63,6 +64,7 @@ export function useFocusManagement(
   const focusEntry = useCallback(
     (entry: TabOrderEntry) => {
       setLastFocusedEntry(entry);
+      setNodeOrEdgeFocused(true);
       const selector =
         entry.type === 'node'
           ? `.react-flow__node[data-id="${entry.id}"]`
@@ -72,7 +74,7 @@ export function useFocusManagement(
       element.focus();
       panToEntryIfNeeded(entry, element);
     },
-    [panToEntryIfNeeded, setLastFocusedEntry]
+    [panToEntryIfNeeded, setLastFocusedEntry, setNodeOrEdgeFocused]
   );
 
   const handleFocusCapture = useCallback(
@@ -80,6 +82,7 @@ export function useFocusManagement(
       const entry = getEntryFromDOM(event.target as HTMLElement);
       if (entry && tabOrder.some(tabEntry => entriesMatch(tabEntry, entry))) {
         setLastFocusedEntry(entry);
+        setNodeOrEdgeFocused(true);
         // Pan the focused element into view when it is off-screen.
         // Deferred so it runs after React Flow finishes processing the
         // focus event internally; calling fitView synchronously here
@@ -95,13 +98,13 @@ export function useFocusManagement(
           }
         });
       } else {
-        // Focus moved to a non-node/edge element within the container
-        // (e.g. Controls buttons, toolbar). Clear selection so visual
-        // indicators like NodeResizer don't persist on the previous node.
-        setLastFocusedEntry(null);
+        // Focus moved to a non-node/edge element (e.g. Controls buttons,
+        // toolbar). Clear visual selection but preserve lastFocusedEntry
+        // so the roving tabindex target stays correct for shift-tab.
+        setNodeOrEdgeFocused(false);
       }
     },
-    [tabOrder, setLastFocusedEntry, panToEntryIfNeeded]
+    [tabOrder, setLastFocusedEntry, setNodeOrEdgeFocused, panToEntryIfNeeded]
   );
 
   return {focusEntry, handleFocusCapture};

--- a/apps/src/sketchlab/reactFlow/hooks/useFocusManagement.ts
+++ b/apps/src/sketchlab/reactFlow/hooks/useFocusManagement.ts
@@ -22,7 +22,7 @@ const PAN_DURATION_MS = 200;
 export function useFocusManagement(
   tabOrder: TabOrderEntry[],
   edges: SketchlabReactFlowEdge[],
-  setActiveTabEntry: (entry: TabOrderEntry | null) => void
+  setLastFocusedEntry: (entry: TabOrderEntry | null) => void
 ) {
   const {fitView, getZoom} = useReactFlow();
 
@@ -62,7 +62,7 @@ export function useFocusManagement(
 
   const focusEntry = useCallback(
     (entry: TabOrderEntry) => {
-      setActiveTabEntry(entry);
+      setLastFocusedEntry(entry);
       const selector =
         entry.type === 'node'
           ? `.react-flow__node[data-id="${entry.id}"]`
@@ -72,14 +72,14 @@ export function useFocusManagement(
       element.focus();
       panToEntryIfNeeded(entry, element);
     },
-    [panToEntryIfNeeded, setActiveTabEntry]
+    [panToEntryIfNeeded, setLastFocusedEntry]
   );
 
   const handleFocusCapture = useCallback(
     (event: React.FocusEvent) => {
       const entry = getEntryFromDOM(event.target as HTMLElement);
       if (entry && tabOrder.some(tabEntry => entriesMatch(tabEntry, entry))) {
-        setActiveTabEntry(entry);
+        setLastFocusedEntry(entry);
         // Pan the focused element into view when it is off-screen.
         // Deferred so it runs after React Flow finishes processing the
         // focus event internally; calling fitView synchronously here
@@ -98,10 +98,10 @@ export function useFocusManagement(
         // Focus moved to a non-node/edge element within the container
         // (e.g. Controls buttons, toolbar). Clear selection so visual
         // indicators like NodeResizer don't persist on the previous node.
-        setActiveTabEntry(null);
+        setLastFocusedEntry(null);
       }
     },
-    [tabOrder, setActiveTabEntry, panToEntryIfNeeded]
+    [tabOrder, setLastFocusedEntry, panToEntryIfNeeded]
   );
 
   return {focusEntry, handleFocusCapture};

--- a/apps/src/sketchlab/reactFlow/hooks/useFocusManagement.ts
+++ b/apps/src/sketchlab/reactFlow/hooks/useFocusManagement.ts
@@ -22,7 +22,7 @@ const PAN_DURATION_MS = 200;
 export function useFocusManagement(
   tabOrder: TabOrderEntry[],
   edges: SketchlabReactFlowEdge[],
-  setActiveTabEntry: (entry: TabOrderEntry) => void
+  setActiveTabEntry: (entry: TabOrderEntry | null) => void
 ) {
   const {fitView, getZoom} = useReactFlow();
 
@@ -94,6 +94,11 @@ export function useFocusManagement(
             panToEntryIfNeeded(entry, element);
           }
         });
+      } else {
+        // Focus moved to a non-node/edge element within the container
+        // (e.g. Controls buttons, toolbar). Clear selection so visual
+        // indicators like NodeResizer don't persist on the previous node.
+        setActiveTabEntry(null);
       }
     },
     [tabOrder, setActiveTabEntry, panToEntryIfNeeded]

--- a/apps/src/sketchlab/reactFlow/hooks/useFocusManagement.ts
+++ b/apps/src/sketchlab/reactFlow/hooks/useFocusManagement.ts
@@ -26,6 +26,40 @@ export function useFocusManagement(
 ) {
   const {fitView, getZoom} = useReactFlow();
 
+  /** Pan the viewport so that `entry` is fully visible, if it isn't already. */
+  const panToEntryIfNeeded = useCallback(
+    (entry: TabOrderEntry, element: HTMLElement) => {
+      const container = element.closest<HTMLElement>('.react-flow');
+      if (!container) return;
+      const containerRect = container.getBoundingClientRect();
+      const elementRect = element.getBoundingClientRect();
+      const notFullyVisible =
+        elementRect.left < containerRect.left ||
+        elementRect.right > containerRect.right ||
+        elementRect.top < containerRect.top ||
+        elementRect.bottom > containerRect.bottom;
+      if (!notFullyVisible) return;
+      const zoom = getZoom();
+      if (entry.type === 'edge') {
+        const edge = edges.find(e => e.id === entry.id);
+        if (edge) {
+          fitView({
+            nodes: [{id: edge.source}, {id: edge.target}],
+            duration: PAN_DURATION_MS,
+            maxZoom: zoom,
+          });
+        }
+      } else {
+        fitView({
+          nodes: [{id: entry.id}],
+          duration: PAN_DURATION_MS,
+          maxZoom: zoom,
+        });
+      }
+    },
+    [edges, fitView, getZoom]
+  );
+
   const focusEntry = useCallback(
     (entry: TabOrderEntry) => {
       setActiveTabEntry(entry);
@@ -36,37 +70,9 @@ export function useFocusManagement(
       const element = document.querySelector<HTMLElement>(selector);
       if (!element) return;
       element.focus();
-      const container = element.closest<HTMLElement>('.react-flow');
-      if (container) {
-        const containerRect = container.getBoundingClientRect();
-        const elementRect = element.getBoundingClientRect();
-        const notFullyVisible =
-          elementRect.left < containerRect.left ||
-          elementRect.right > containerRect.right ||
-          elementRect.top < containerRect.top ||
-          elementRect.bottom > containerRect.bottom;
-        if (notFullyVisible) {
-          const zoom = getZoom();
-          if (entry.type === 'edge') {
-            const edge = edges.find(e => e.id === entry.id);
-            if (edge) {
-              fitView({
-                nodes: [{id: edge.source}, {id: edge.target}],
-                duration: PAN_DURATION_MS,
-                maxZoom: zoom,
-              });
-            }
-          } else {
-            fitView({
-              nodes: [{id: entry.id}],
-              duration: PAN_DURATION_MS,
-              maxZoom: zoom,
-            });
-          }
-        }
-      }
+      panToEntryIfNeeded(entry, element);
     },
-    [edges, fitView, getZoom, setActiveTabEntry]
+    [panToEntryIfNeeded, setActiveTabEntry]
   );
 
   const handleFocusCapture = useCallback(
@@ -74,9 +80,23 @@ export function useFocusManagement(
       const entry = getEntryFromDOM(event.target as HTMLElement);
       if (entry && tabOrder.some(tabEntry => entriesMatch(tabEntry, entry))) {
         setActiveTabEntry(entry);
+        // Pan the focused element into view when it is off-screen.
+        // Deferred so it runs after React Flow finishes processing the
+        // focus event internally; calling fitView synchronously here
+        // gets overridden by React Flow's state reconciliation.
+        requestAnimationFrame(() => {
+          const selector =
+            entry.type === 'node'
+              ? `.react-flow__node[data-id="${entry.id}"]`
+              : `.react-flow__edge[data-id="${entry.id}"]`;
+          const element = document.querySelector<HTMLElement>(selector);
+          if (element) {
+            panToEntryIfNeeded(entry, element);
+          }
+        });
       }
     },
-    [tabOrder, setActiveTabEntry]
+    [tabOrder, setActiveTabEntry, panToEntryIfNeeded]
   );
 
   return {focusEntry, handleFocusCapture};

--- a/apps/src/sketchlab/reactFlow/hooks/useFocusManagement.ts
+++ b/apps/src/sketchlab/reactFlow/hooks/useFocusManagement.ts
@@ -63,14 +63,14 @@ export function useFocusManagement(
 
   const focusEntry = useCallback(
     (entry: TabOrderEntry) => {
-      setLastFocusedEntry(entry);
-      setNodeOrEdgeFocused(true);
       const selector =
         entry.type === 'node'
           ? `.react-flow__node[data-id="${entry.id}"]`
           : `.react-flow__edge[data-id="${entry.id}"]`;
       const element = document.querySelector<HTMLElement>(selector);
       if (!element) return;
+      setLastFocusedEntry(entry);
+      setNodeOrEdgeFocused(true);
       element.focus();
       panToEntryIfNeeded(entry, element);
     },

--- a/apps/src/sketchlab/reactFlow/hooks/useTabOrder.ts
+++ b/apps/src/sketchlab/reactFlow/hooks/useTabOrder.ts
@@ -23,17 +23,16 @@ export function useTabOrder(
 ) {
   const tabOrder = useMemo(() => computeTabOrder(nodes, edges), [nodes, edges]);
 
-  const [activeTabEntry, setActiveTabEntry] = useState<TabOrderEntry | null>(
-    null
-  );
+  const [lastFocusedEntry, setLastFocusedEntry] =
+    useState<TabOrderEntry | null>(null);
 
   // The entry that should have tabIndex 0. Falls back to the first in
   // order when nothing has been focused yet or the active element was
   // deleted (derived — no effect needed).
   const isActiveValid =
-    activeTabEntry &&
-    tabOrder.some(entry => entriesMatch(entry, activeTabEntry));
-  const activeEntry = isActiveValid ? activeTabEntry : tabOrder[0] ?? null;
+    lastFocusedEntry &&
+    tabOrder.some(entry => entriesMatch(entry, lastFocusedEntry));
+  const activeEntry = isActiveValid ? lastFocusedEntry : tabOrder[0] ?? null;
 
-  return {tabOrder, activeEntry, activeTabEntry, setActiveTabEntry};
+  return {tabOrder, activeEntry, lastFocusedEntry, setLastFocusedEntry};
 }

--- a/apps/src/sketchlab/reactFlow/hooks/useTabOrder.ts
+++ b/apps/src/sketchlab/reactFlow/hooks/useTabOrder.ts
@@ -26,6 +26,12 @@ export function useTabOrder(
   const [lastFocusedEntry, setLastFocusedEntry] =
     useState<TabOrderEntry | null>(null);
 
+  // True when a node or edge currently has DOM focus. Tracked separately
+  // from lastFocusedEntry so the roving tabindex target persists when
+  // focus moves to non-element UI (e.g. Controls) while the visual
+  // selection (selected prop) can be cleared independently.
+  const [nodeOrEdgeFocused, setNodeOrEdgeFocused] = useState(false);
+
   // The entry that should have tabIndex 0. Falls back to the first in
   // order when nothing has been focused yet or the active element was
   // deleted (derived — no effect needed).
@@ -34,5 +40,12 @@ export function useTabOrder(
     tabOrder.some(entry => entriesMatch(entry, lastFocusedEntry));
   const activeEntry = isActiveValid ? lastFocusedEntry : tabOrder[0] ?? null;
 
-  return {tabOrder, activeEntry, lastFocusedEntry, setLastFocusedEntry};
+  return {
+    tabOrder,
+    activeEntry,
+    lastFocusedEntry,
+    setLastFocusedEntry,
+    nodeOrEdgeFocused,
+    setNodeOrEdgeFocused,
+  };
 }

--- a/apps/src/sketchlab/reactFlow/hooks/useTabOrder.ts
+++ b/apps/src/sketchlab/reactFlow/hooks/useTabOrder.ts
@@ -35,5 +35,5 @@ export function useTabOrder(
     tabOrder.some(entry => entriesMatch(entry, activeTabEntry));
   const activeEntry = isActiveValid ? activeTabEntry : tabOrder[0] ?? null;
 
-  return {tabOrder, activeEntry, setActiveTabEntry};
+  return {tabOrder, activeEntry, activeTabEntry, setActiveTabEntry};
 }


### PR DESCRIPTION
This PR includes a few fixes for tab order and node selection in the react flow implementation in sketch lab:
- If the first node in the tab order was offscreen, we wouldn't pan to it.
- The last 'selected' node would maintain a selected state (for nodes, that was a drag outline and for edges they would stay slightly darker) if the user moved off the canvas. 
- If you got to the end of the tab order and went to the control buttons, then tabbed backwards you would end up at the beginning of the tab order again.

These issues are now fixed, and I did a bit of cleanup of unneeded logic. 


## Links

- Jira: [AFL-571](https://codedotorg.atlassian.net/browse/AFL-571)
 
## Testing story
Tested locally.


