### PR TITLE
Fix timing-related UI test failures on local chromedriver

### DIFF
--- a/dashboard/test/ui/features/star_labs/applab/clipping.feature
+++ b/dashboard/test/ui/features/star_labs/applab/clipping.feature
@@ -6,4 +6,5 @@ Feature: App Lab Clipping
     And I wait for the lab page to fully load
     Then I reload the page
     And I switch to design mode
+    And I wait until element "#designModeViz.clip-content" is visible
     And selector "#designModeViz" has class "clip-content"

--- a/dashboard/test/ui/features/step_definitions/authoredHints.rb
+++ b/dashboard/test/ui/features/step_definitions/authoredHints.rb
@@ -20,7 +20,7 @@ end
 
 When /^I view the next authored hint$/ do
   steps <<-STEPS
-    When I press "lightbulb"
+    When I click selector "#lightbulb"
     And I wait until element ".csf-top-instructions button:contains(Yes)" is visible
     And I click selector ".csf-top-instructions button:contains(Yes)"
   STEPS

--- a/dashboard/test/ui/features/teacher_tools/authored_hints.feature
+++ b/dashboard/test/ui/features/teacher_tools/authored_hints.feature
@@ -29,5 +29,5 @@ Scenario: View Authored Hints
   And the hint lightbulb shows no hints available
 
   # Finally, verify that further clicking the lightbulb has no effect
-  When I press "lightbulb"
+  When I click selector "#lightbulb"
   Then element ".csf-top-instructions button:contains(Yes)" does not exist

--- a/dashboard/test/ui/features/teacher_tools/version_history.feature
+++ b/dashboard/test/ui/features/teacher_tools/version_history.feature
@@ -50,6 +50,7 @@ Scenario: Teacher can view own versions
 
   And I wait for 1.5 seconds
   And I ensure droplet is in text mode
+  And I wait until element "#resetButton" is visible
   And I add another version to the project
   And element ".project_updated_at" eventually contains text "Saved"
 


### PR DESCRIPTION
## Background

- today in drone, we first run each UI test in local chromedriver. then, if it fails, we rerun it in saucelabs.  
- the first drone run on https://github.com/code-dot-org/code-dot-org/pull/72203 shows there are 9 ui tests that consistently fail with local chromedriver. these are presumably passing in saucelabs most of the time on rerun.

## Description

This PR fixes some UI test failures which show up in Chromedriver but not Saucelabs:
- FAILED: LocalBrowser_teacher_tools_version_history  <a href='https://cucumber-logs.s3.amazonaws.com/circle/53548/LocalBrowser_teacher_tools_version_history_output.html?versionId=KMg7kTMs_icnhSOm9AG8lP5emgQjfqB9'>☁ Log on S3</a>
- FAILED: LocalBrowser_teacher_tools_contextual_hints  <a href='https://cucumber-logs.s3.amazonaws.com/circle/53548/LocalBrowser_teacher_tools_contextual_hints_output.html?versionId=t4X51KFCaQ1jmJxlw9UrYby9b7yW9W8X'>☁ Log on S3</a>
- FAILED: LocalBrowser_teacher_tools_authored_hints <a href='https://cucumber-logs.s3.amazonaws.com/circle/53548/LocalBrowser_teacher_tools_authored_hints_output.html?versionId=APtWGwZ_uvfcBmFfIXJRX8dSFg.TVxUH'>☁ Log on S3</a>
- FAILED: LocalBrowser_star_labs_applab_clipping  <a href='https://cucumber-logs.s3.amazonaws.com/circle/53548/LocalBrowser_star_labs_applab_clipping_output.html?versionId=3En6US56Y5gkxnZOtvcqpJlz82PxbW5k'>☁ Log on S3</a>

Done in this PR:

Add waits and use jQuery click for steps that were racing on local chromedriver:

- version_history: wait for `#resetButton` before second add-another-version
- authored_hints, contextual_hints: swap Selenium native click for jQuery click on `#lightbulb`.  When the hint content is showing in `.csf-top-instructions`, Selenium's interactability check fails on the lightbulb even though jQuery `:visible` reports it visible. Clicking via `$('#lightbulb')[0].click()` still fires React's delegated click handler (on `.prompt-icon-cell`, the parent) and avoids the Selenium check.
- applab clipping: wait for `#designModeViz.clip-content` instead of asserting the class synchronously after switching to design mode

## Testing story
- I flipped through the chromedriver failures ("failed once") in the drone logs for this PR, and all of the modified tests are passing on the first run
- I patched these changes into https://github.com/code-dot-org/code-dot-org/pull/72203, and confirmed that all 4 of the tests listed above were previously failing consistently on chromedriver and are now passing on the first try.