### PR TITLE
AI Tutor: Only signed in users can access lesson tutor 

### DIFF
--- a/dashboard/app/controllers/lessons_controller.rb
+++ b/dashboard/app/controllers/lessons_controller.rb
@@ -4,6 +4,7 @@ class LessonsController < ApplicationController
   skip_authorize_resource only: :level_properties_by_id
 
   before_action :require_levelbuilder_mode_or_test_env, except: [:index, :show, :student_lesson_plan, :level_properties, :level_properties_by_id, :tutor]
+  before_action :authenticate_user!, only: [:tutor]
   before_action :disallow_legacy_script_levels, only: [:edit, :update]
   before_action :disable_session_for_cached_pages, only: [:show]
   before_action :redirect_to_canonical_path, only: [:show, :student_lesson_plan]

--- a/dashboard/app/controllers/lessons_controller.rb
+++ b/dashboard/app/controllers/lessons_controller.rb
@@ -107,12 +107,12 @@ class LessonsController < ApplicationController
       lessonSummary: @lesson.properties['student_overview'] || '',
       vocabulary: @lesson.vocabularies.map {|v| {id: v.id, word: v.word, definition: v.definition}},
       objectives: @lesson.objectives.map {|o| {id: o.id, description: o.description}},
-      assessmentAnalysis: lesson_assessment_analysis(@lesson.id, current_user.id),
+      assessmentAnalysis: lesson_assessment_analysis(@lesson.id, current_user&.id),
       jsonVideos: json_videos.map {|v| {key: v.key, url: content_json_video_url(v.key), description: v.description}},
-      progressCounts: lesson_progress_status(@lesson.id, current_user.id).transform_keys do |k|
+      progressCounts: lesson_progress_status(@lesson.id, current_user&.id).transform_keys do |k|
         k.to_s.camelize(:lower).to_sym
       end,
-      timeSpentSeconds: lesson_time_spent(@lesson.id, current_user.id)
+      timeSpentSeconds: lesson_time_spent(@lesson.id, current_user&.id)
     }
   end
 

--- a/dashboard/test/controllers/lessons_controller_test.rb
+++ b/dashboard/test/controllers/lessons_controller_test.rb
@@ -121,6 +121,11 @@ class LessonsControllerTest < ActionController::TestCase
   test_user_gets_response_for :student_lesson_plan, params: -> {{course_course_name: @pl_login_req_course.name, unit_position: 1, lesson_position: @pl_login_req_script.lessons[0].relative_position}}, user: :facilitator, response: :success, name: 'facilitator can view student lesson plan on pl script where login is required'
   test_user_gets_response_for :student_lesson_plan, params: -> {{course_course_name: @pl_login_req_course.name, unit_position: 1, lesson_position: @pl_login_req_script.lessons[0].relative_position}}, user: :levelbuilder, response: :success, name: 'levelbuilder can view student lesson plan on pl script where login is required'
 
+  # signed out users are redirected to sign in for tutor
+  test_user_gets_response_for :tutor, params: -> {{course_course_name: @course.name, unit_position: 1, lesson_position: @lesson.relative_position}}, user: nil, response: :redirect, name: 'signed out user is redirected to sign in for tutor'
+  test_user_gets_response_for :tutor, params: -> {{course_course_name: @course.name, unit_position: 1, lesson_position: @lesson.relative_position}}, user: :student, response: :success, name: 'student can view tutor'
+  test_user_gets_response_for :tutor, params: -> {{course_course_name: @course.name, unit_position: 1, lesson_position: @lesson.relative_position}}, user: :teacher, response: :success, name: 'teacher can view tutor'
+
   # limit access to lesson plans in pilots
   test_user_gets_response_for :show, response: :not_found, user: nil,
                               params: -> {{course_course_name: @pilot_course.name, unit_position: 1, position: @pilot_script.lessons[0].relative_position}},

--- a/dashboard/test/helpers/student_work_helper_test.rb
+++ b/dashboard/test/helpers/student_work_helper_test.rb
@@ -85,6 +85,19 @@ class StudentWorkHelperTest < ActionView::TestCase
     assert_includes entry, :student_response
   end
 
+  test "returns unattempted entries when student_id is nil (signed-out user)" do
+    multi = create(:multi)
+    make_assessment_script_level(multi)
+
+    result = lesson_assessment_analysis(@lesson.id, nil)
+
+    assert_equal 1, result.length
+    entry = result.first
+    assert_equal 0, entry[:attempts]
+    assert_equal false, entry[:correct]
+    assert_equal "No attempt yet", entry[:student_response]
+  end
+
   test "non-assessment script levels are excluded" do
     create(:script_level, levels: [create(:multi)], lesson: @lesson, script: @script,
       activity_section: @lesson.activity_sections.first


### PR DESCRIPTION
Despite the Lesson Tutor not being available anywhere yet, we were getting [HoneyBadger errors](https://app.honeybadger.io/projects/3240/faults/129676576#notice-summary) for signed out users trying to access the feature. This PR adds two changes to prevent this issue. Primarily, we now authenticate the user in the lessons_controller when trying to access the tutor action. Next, we safeguard against making the calls in the student_work_controller if there isn't a user_id (this isn't strictly necessary since we shouldn't hit this scenario in the current implementation, but it defensively prevents issues should other features re-use these functions). 


https://github.com/user-attachments/assets/58e6c732-d376-430f-b743-948d1aae36f3



