### PR TITLE
Ceara/tutor match sort problem

### DIFF
--- a/apps/src/aiTutor/views/lessonDeepDive/DraggableOptions.tsx
+++ b/apps/src/aiTutor/views/lessonDeepDive/DraggableOptions.tsx
@@ -1,0 +1,60 @@
+import {useDraggable} from '@dnd-kit/core';
+import {CSS} from '@dnd-kit/utilities';
+import {Typography} from '@mui/material';
+import classNames from 'classnames';
+import React from 'react';
+
+import styles from './practice-problems.module.scss';
+
+interface DraggableOptionProps {
+  id: string;
+  option: string;
+  correct: boolean;
+  showAnswer: boolean;
+}
+
+/**
+ * A React component that makes its children draggable using the `useDraggable` hook. Should wrap around a FileBrowserRow.
+ * If you -don't- want a row to be draggable, but still want a wrapper, you can wrap it in NotDraggable, below.
+ *
+ * @param props - The props for the `Draggable` component.
+ * @param props.children - The content to be made draggable.
+ * @param props.data - An object containing data associated with the draggable element. data must be of type DragDataType.
+ * @param props.Component - (Optional) The underlying HTML element to use as the draggable container.
+ *                         - Defaults to `'div'`.
+ * @returns A React element with the provided children, styled for dragging and handling drag events.
+ */
+export const DraggableOptions: React.FunctionComponent<
+  DraggableOptionProps
+> = ({id, option, correct, showAnswer}) => {
+  const {attributes, listeners, setNodeRef, transform, isDragging} =
+    useDraggable({
+      id: id,
+    });
+  const style = {
+    transform: CSS.Translate.toString(transform),
+    zIndex: isDragging ? 1 : undefined,
+  };
+
+  return (
+    <div
+      {...attributes}
+      {...listeners}
+      ref={setNodeRef}
+      style={{cursor: isDragging ? 'grabbing' : 'inherit', ...style}}
+      aria-labelledby={`section-card-title-${option}`}
+      className={classNames([
+        styles.carddraggableOption,
+        showAnswer
+          ? correct
+            ? styles.cardcorrect
+            : styles.cardincorrect
+          : null,
+      ])}
+    >
+      <Typography variant="body1" className={styles.cardLabel}>
+        {option}
+      </Typography>
+    </div>
+  );
+};

--- a/apps/src/aiTutor/views/lessonDeepDive/DraggableOptions.tsx
+++ b/apps/src/aiTutor/views/lessonDeepDive/DraggableOptions.tsx
@@ -13,17 +13,6 @@ interface DraggableOptionProps {
   showAnswer: boolean;
 }
 
-/**
- * A React component that makes its children draggable using the `useDraggable` hook. Should wrap around a FileBrowserRow.
- * If you -don't- want a row to be draggable, but still want a wrapper, you can wrap it in NotDraggable, below.
- *
- * @param props - The props for the `Draggable` component.
- * @param props.children - The content to be made draggable.
- * @param props.data - An object containing data associated with the draggable element. data must be of type DragDataType.
- * @param props.Component - (Optional) The underlying HTML element to use as the draggable container.
- *                         - Defaults to `'div'`.
- * @returns A React element with the provided children, styled for dragging and handling drag events.
- */
 export const DraggableOptions: React.FunctionComponent<
   DraggableOptionProps
 > = ({id, option, correct, showAnswer}) => {

--- a/apps/src/aiTutor/views/lessonDeepDive/PracticeBox.tsx
+++ b/apps/src/aiTutor/views/lessonDeepDive/PracticeBox.tsx
@@ -2,14 +2,16 @@ import FontAwesomeV6Icon from '@code-dot-org/component-library/fontAwesomeV6Icon
 import {Typography} from '@mui/material';
 import React, {FC, useCallback, useState} from 'react';
 
-// import matchJson from '@cdo/static/tutor/match_example.json';
+import matchJson from '@cdo/static/tutor/match_example.json';
 import multiSingleJson from '@cdo/static/tutor/multiple_choice_example.json';
 import multiMultiJson from '@cdo/static/tutor/multiple_choice_multi_select.json';
 import scrambleJson from '@cdo/static/tutor/scramble_example.json';
-// import sortJson from '@cdo/static/tutor/sort_example.json';
+import sortJson from '@cdo/static/tutor/sort_example.json';
 
+import PracticeMatch from './PracticeMatch';
 import PracticeMultipleChoice from './PracticeMultipleChoice';
 import PracticeScramble from './PracticeScramble';
+import PracticeSort from './PracticeSort';
 import {LessonDeepDiveData, PracticeProblem} from './types';
 
 import styles from './practice-problems.module.scss';
@@ -18,8 +20,8 @@ const PracticeProblems: PracticeProblem[] = [
   multiMultiJson as PracticeProblem,
   multiSingleJson as PracticeProblem,
   scrambleJson as PracticeProblem,
-  // matchJson as PracticeProblem,
-  // sortJson as PracticeProblem,
+  matchJson as PracticeProblem,
+  sortJson as PracticeProblem,
 ];
 
 interface PracticeBoxProps {
@@ -70,6 +72,26 @@ const PracticeBox: FC<PracticeBoxProps> = ({
       case 'scramble':
         return (
           <PracticeScramble
+            problem={PracticeProblems[index]}
+            key={PracticeProblems[index].id}
+            submitted={isSubmitted}
+            submitCallback={setIsSubmitted}
+            correctCallback={setIsCorrect}
+          />
+        );
+      case 'match':
+        return (
+          <PracticeMatch
+            problem={PracticeProblems[index]}
+            key={PracticeProblems[index].id}
+            submitted={isSubmitted}
+            submitCallback={setIsSubmitted}
+            correctCallback={setIsCorrect}
+          />
+        );
+      case 'sort':
+        return (
+          <PracticeSort
             problem={PracticeProblems[index]}
             key={PracticeProblems[index].id}
             submitted={isSubmitted}

--- a/apps/src/aiTutor/views/lessonDeepDive/PracticeMatch.tsx
+++ b/apps/src/aiTutor/views/lessonDeepDive/PracticeMatch.tsx
@@ -1,0 +1,193 @@
+import {
+  Active,
+  closestCenter,
+  DndContext,
+  DragEndEvent,
+  KeyboardSensor,
+  Over,
+  PointerSensor,
+  useSensor,
+  useSensors,
+} from '@dnd-kit/core';
+import {
+  arrayMove,
+  SortableContext,
+  sortableKeyboardCoordinates,
+  verticalListSortingStrategy,
+} from '@dnd-kit/sortable';
+import {Typography} from '@mui/material';
+import React, {FC, useState} from 'react';
+
+import {SortableOptionCard} from './SortableOptionCard';
+import {MatchSolution, PracticeProblem} from './types';
+
+import styles from './practice-problems.module.scss';
+
+interface PracticeMatchProps {
+  problem: PracticeProblem;
+  submitted: boolean;
+  submitCallback: React.Dispatch<React.SetStateAction<boolean>>;
+  correctCallback: React.Dispatch<React.SetStateAction<boolean>>;
+}
+
+const PracticeMatch: FC<PracticeMatchProps> = ({
+  problem,
+  submitted,
+  submitCallback,
+  correctCallback,
+}) => {
+  const solutions = problem.solution.map(s => {
+    return {...s};
+  }) as MatchSolution[];
+
+  const [sortableOptions, setSortableOptions] = useState<string[]>(
+    solutions.map(s => s.option).sort(() => Math.random() - 0.5)
+  );
+
+  const [sortableMatches, setSortableMatches] = useState<string[]>(
+    solutions.map(s => s.correct).sort(() => Math.random() - 0.5)
+  );
+
+  const isCorrect = () => {
+    for (let i = 0; i < sortableOptions.length; i++) {
+      if (
+        solutions.find(
+          ({option, correct}) =>
+            option === sortableOptions[i] && correct === sortableMatches[i]
+        ) === undefined
+      ) {
+        return false;
+      }
+    }
+    return true;
+  };
+
+  function moveOption(
+    active: Active,
+    over: Over
+  ): React.SetStateAction<string[]> {
+    return items => {
+      const oldIndex = items.indexOf(active.id as string);
+      const newIndex = items.indexOf(over.id as string);
+      return arrayMove(items, oldIndex, newIndex);
+    };
+  }
+
+  const sensors = useSensors(
+    useSensor(PointerSensor, {
+      activationConstraint: {distance: 10},
+    }),
+    useSensor(KeyboardSensor, {
+      coordinateGetter: sortableKeyboardCoordinates,
+    })
+  );
+
+  const handleDragEndOption = React.useCallback(
+    (event: DragEndEvent) => {
+      const {active, over} = event;
+
+      if (over && active.id !== over.id && !submitted) {
+        setSortableOptions(moveOption(active, over));
+      }
+    },
+    [setSortableOptions, submitted]
+  );
+
+  const handleDragEndMatch = React.useCallback(
+    (event: DragEndEvent) => {
+      const {active, over} = event;
+
+      if (over && active.id !== over.id && !submitted) {
+        setSortableMatches(moveOption(active, over));
+      }
+    },
+    [setSortableMatches, submitted]
+  );
+
+  return (
+    <div className={styles.container}>
+      <div className={styles.content}>
+        <div className={styles.prompt}>
+          <Typography variant="h4" sx={{fontSize: {xs: '1.5rem', sm: '2rem'}}}>
+            {problem.problem_text}
+          </Typography>
+          <div className={styles.optionsContainer}>
+            <div className={styles.optionsRows}>
+              <DndContext
+                sensors={sensors}
+                collisionDetection={closestCenter}
+                onDragEnd={handleDragEndOption}
+              >
+                <SortableContext
+                  items={sortableOptions}
+                  strategy={verticalListSortingStrategy}
+                >
+                  <ol className={styles.optionsContainer}>
+                    {sortableOptions.map((opt, index) => (
+                      <SortableOptionCard
+                        key={opt}
+                        option={opt}
+                        id={opt}
+                        correct={
+                          solutions.find(
+                            ({option, correct}) =>
+                              option === opt &&
+                              correct === sortableMatches[index]
+                          ) !== undefined
+                        }
+                        showAnswer={submitted}
+                      />
+                    ))}
+                  </ol>
+                </SortableContext>
+              </DndContext>
+
+              <DndContext
+                sensors={sensors}
+                collisionDetection={closestCenter}
+                onDragEnd={handleDragEndMatch}
+              >
+                <SortableContext
+                  items={sortableMatches}
+                  strategy={verticalListSortingStrategy}
+                >
+                  <ol className={styles.optionsContainer}>
+                    {sortableMatches.map((corr, index) => (
+                      <SortableOptionCard
+                        key={corr}
+                        option={corr}
+                        id={corr}
+                        correct={
+                          solutions.find(
+                            ({option, correct}) =>
+                              option === sortableOptions[index] &&
+                              correct === corr
+                          ) !== undefined
+                        }
+                        showAnswer={submitted}
+                      />
+                    ))}
+                  </ol>
+                </SortableContext>
+              </DndContext>
+            </div>
+            <button
+              type="button"
+              disabled={submitted}
+              onClick={() => {
+                submitCallback(true);
+                correctCallback(isCorrect);
+              }}
+            >
+              <Typography variant="body1" className={styles.cardLabel}>
+                Submit
+              </Typography>
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default PracticeMatch;

--- a/apps/src/aiTutor/views/lessonDeepDive/PracticeScramble.tsx
+++ b/apps/src/aiTutor/views/lessonDeepDive/PracticeScramble.tsx
@@ -18,7 +18,7 @@ import {
 import {Typography} from '@mui/material';
 import React, {FC, useState} from 'react';
 
-import {DraggableOptionCard} from './DraggableOptionCard';
+import {SortableOptionCard} from './SortableOptionCard';
 import {PracticeProblem, ScrambleSolution} from './types';
 
 import styles from './practice-problems.module.scss';
@@ -79,11 +79,11 @@ const PracticeScramble: FC<PracticeScrambleProps> = ({
     (event: DragEndEvent) => {
       const {active, over} = event;
 
-      if (over && active.id !== over.id) {
+      if (over && active.id !== over.id && !submitted) {
         setSortableOptions(moveOption(active, over));
       }
     },
-    [setSortableOptions]
+    [setSortableOptions, submitted]
   );
 
   return (
@@ -105,7 +105,7 @@ const PracticeScramble: FC<PracticeScrambleProps> = ({
               >
                 <ol className={styles.optionsContainer}>
                   {sortableOptions.map((option, index) => (
-                    <DraggableOptionCard
+                    <SortableOptionCard
                       key={option}
                       option={option}
                       id={option}

--- a/apps/src/aiTutor/views/lessonDeepDive/PracticeSort.tsx
+++ b/apps/src/aiTutor/views/lessonDeepDive/PracticeSort.tsx
@@ -1,0 +1,175 @@
+import {
+  closestCenter,
+  DndContext,
+  DragEndEvent,
+  KeyboardSensor,
+  PointerSensor,
+  useSensor,
+  useSensors,
+} from '@dnd-kit/core';
+import {sortableKeyboardCoordinates} from '@dnd-kit/sortable';
+import {Typography} from '@mui/material';
+import classNames from 'classnames';
+import React, {FC, useState} from 'react';
+
+import {Droppable} from '@cdo/apps/codebridge/FileBrowser/Droppable';
+
+import {DraggableOptions} from './DraggableOptions';
+import {MatchSolution, PracticeProblem} from './types';
+
+import styles from './practice-problems.module.scss';
+
+interface PracticeSortProps {
+  problem: PracticeProblem;
+  submitted: boolean;
+  submitCallback: React.Dispatch<React.SetStateAction<boolean>>;
+  correctCallback: React.Dispatch<React.SetStateAction<boolean>>;
+}
+
+const PracticeSort: FC<PracticeSortProps> = ({
+  problem,
+  submitted,
+  submitCallback,
+  correctCallback,
+}) => {
+  const solutions = problem.solution.map(s => {
+    return {...s};
+  }) as MatchSolution[];
+
+  const [draggableOptions] = useState<string[]>(
+    solutions.map(s => s.option).sort(() => Math.random() - 0.5)
+  );
+  const [droppableMatches] = useState<string[]>([
+    ...new Set(solutions.map(s => s.correct).sort(() => Math.random() - 0.5)),
+  ]);
+
+  const [dragAndDropPairs, setDragAndDropPairs] = useState<MatchSolution[]>([]);
+
+  const isCorrect = () => {
+    if (solutions.length !== dragAndDropPairs.length) {
+      return false;
+    }
+    for (let i = 0; i < dragAndDropPairs.length; i++) {
+      if (
+        solutions.find(
+          ({option, correct}) =>
+            option === dragAndDropPairs[i].option &&
+            correct === dragAndDropPairs[i].correct
+        ) === undefined
+      ) {
+        return false;
+      }
+    }
+    return true;
+  };
+
+  const sensors = useSensors(
+    useSensor(PointerSensor, {
+      activationConstraint: {distance: 10},
+    }),
+    useSensor(KeyboardSensor, {
+      coordinateGetter: sortableKeyboardCoordinates,
+    })
+  );
+
+  const handleDragEndOption = React.useCallback(
+    (event: DragEndEvent) => {
+      const {active, over} = event;
+
+      if (over && active.id !== over.id && !submitted) {
+        setDragAndDropPairs([
+          ...dragAndDropPairs.filter(
+            sol => sol.option !== (active.id as string)
+          ),
+          {option: active.id as string, correct: over.id as string},
+        ]);
+      }
+    },
+    [dragAndDropPairs, setDragAndDropPairs, submitted]
+  );
+
+  return (
+    <div className={styles.container}>
+      <div className={styles.content}>
+        <div className={styles.prompt}>
+          <Typography variant="h4" sx={{fontSize: {xs: '1.5rem', sm: '2rem'}}}>
+            {problem.problem_text}
+          </Typography>
+          <div className={styles.optionsContainer}>
+            <DndContext
+              sensors={sensors}
+              collisionDetection={closestCenter}
+              onDragEnd={handleDragEndOption}
+            >
+              <div className={styles.optionsRows}>
+                {droppableMatches.map((match, index) => (
+                  <Droppable
+                    key={match}
+                    data={{id: match}}
+                    className={styles.dropZone}
+                  >
+                    <Typography>{match}</Typography>
+                    {dragAndDropPairs
+                      .filter(sol => sol.correct === match)
+                      .map((pair, index) => (
+                        <DraggableOptions
+                          key={pair.option}
+                          option={pair.option}
+                          id={pair.option}
+                          correct={
+                            solutions.find(
+                              ({option, correct}) =>
+                                option === pair.option &&
+                                correct === pair.correct
+                            ) !== undefined
+                          }
+                          showAnswer={submitted}
+                        />
+                      ))}
+                  </Droppable>
+                ))}
+              </div>
+              <div
+                className={classNames([
+                  styles.optionsRows,
+                  styles.optionsRowsWrap,
+                ])}
+              >
+                {draggableOptions
+                  .filter(
+                    opt =>
+                      dragAndDropPairs.find(
+                        ({option, correct}) => option === opt
+                      ) === undefined
+                  )
+                  .map((opt, index) => (
+                    <DraggableOptions
+                      key={opt}
+                      option={opt}
+                      id={opt}
+                      correct={false}
+                      showAnswer={submitted}
+                    />
+                  ))}
+              </div>
+            </DndContext>
+            <button
+              type="button"
+              disabled={submitted}
+              onClick={() => {
+                submitCallback(true);
+                correctCallback(isCorrect);
+              }}
+            >
+              <Typography variant="body1" className={styles.cardLabel}>
+                Submit
+              </Typography>
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default PracticeSort;

--- a/apps/src/aiTutor/views/lessonDeepDive/SortableOptionCard.tsx
+++ b/apps/src/aiTutor/views/lessonDeepDive/SortableOptionCard.tsx
@@ -6,14 +6,14 @@ import React from 'react';
 
 import styles from './practice-problems.module.scss';
 
-interface DraggableOptionProps {
+interface SortableOptionProps {
   option: string;
   id: string;
   correct: boolean;
   showAnswer: boolean;
 }
 
-export const DraggableOptionCard: React.FC<DraggableOptionProps> = ({
+export const SortableOptionCard: React.FC<SortableOptionProps> = ({
   option,
   id,
   correct,

--- a/apps/src/aiTutor/views/lessonDeepDive/practice-problems.module.scss
+++ b/apps/src/aiTutor/views/lessonDeepDive/practice-problems.module.scss
@@ -26,9 +26,40 @@
   flex-direction: column;
   margin: auto;
   width: 100%;
-  max-width: 400px;
+  max-width: 600px;
   padding: 24px 0;
   list-style-type: none;
+}
+
+.optionsRows {
+  display: flex;
+  flex-direction: row;
+  margin: auto;
+  width: 100%;
+  gap: 8px;
+  padding: 24px 0;
+  list-style-type: none;
+
+  &Wrap {
+    flex-wrap: wrap;
+  }
+}
+
+.dropZone {
+  display: flex;
+  flex-direction: column;
+  margin: auto;
+  width: 100%;
+  // max-width: 400px;
+  min-height: 200px;
+  height: stretch;
+  padding: 12px 4px;
+  align-items: center;
+  list-style-type: none;
+  border: 1px solid;
+  border-color: $lightest_gray;
+  flex-grow: 1;
+  flex-basis: 0;
 }
 
 .card {
@@ -47,6 +78,22 @@
     padding: 10px;
     border: 1px solid;
     border-color: $lightest_gray;
+  }
+
+  &draggableOption {
+    display: inline-block;
+    background-color: $dark_slate_gray;
+    border: 1px solid;
+    border-color: $lightest_gray;
+    color: $brand_primary_light;
+    min-width: 30px;
+    text-align: center;
+    border-radius: 100px;
+    white-space: nowrap;
+    margin: 0;
+    padding: 6px 12px;
+    text-wrap: auto;
+    cursor: pointer !important;
   }
 
   &selected {


### PR DESCRIPTION
This add the match and sort practice problems to Tutor+, along with evaluation methods for the questions. Other changes are:
- Renaming the DraggableOptionCard to SortableOptionCard to better reflect that it's using `sortable` from dnd-core
- Adding a DraggableOption element for drag-and-drop to other containers (using `draggable` from dnd-core)
- Disabling drag and drop for elements after Submit has been clicked
- Styling changes to make the practice problem container wider
- Styling change to add wrapping for long option text

Video of match and sort problems:

https://github.com/user-attachments/assets/9c6c6055-0f7a-4a0c-b74f-eedad04385b7


## Links
<!-- Jira tickets, design docs, Slack threads, related PRs, etc. -->

Practice Problem doc: https://docs.google.com/document/d/1za8v6zlnEdfWgfx3mgBQOgKr7k3DLNDG9fXQgd7b5KU/edit?tab=t.0

## Testing story
<!-- How was this tested? Manual steps, adhoc links, automated tests, or why testing isn't needed. -->



## Deployment notes
<!-- Delete this section if it's a standard merge-and-deploy.
     Otherwise: migrations, feature flags, coordination, caching impacts, etc. -->



## Privacy and security
<!-- Delete this section if there is no privacy/security impact.
     Otherwise: new PII, auth changes, API surface changes, etc. -->

