### PR TITLE
Mass progress delete - fix for test run

### DIFF
--- a/dashboard/app/controllers/admin_users_controller.rb
+++ b/dashboard/app/controllers/admin_users_controller.rb
@@ -476,7 +476,7 @@ class AdminUsersController < ApplicationController
 
     csv_data = params[:csv_data]
     teacher_id = params[:teacher_id]
-    dry_run = params[:dry_run] == 'true'
+    dry_run = ActiveModel::Type::Boolean.new.cast(params[:dry_run])
 
     if csv_data.blank? || teacher_id.blank?
       render json: {error: 'CSV data and teacher ID are required'}, status: :bad_request

--- a/dashboard/test/controllers/admin_users_controller_test.rb
+++ b/dashboard/test/controllers/admin_users_controller_test.rb
@@ -399,6 +399,24 @@ class AdminUsersControllerTest < ActionController::TestCase
     assert_equal "Dry run completed successfully", response_json['message']
   end
 
+  test "delete_user_progress handles dry_run with string 'true'" do
+    sign_in @admin
+
+    @controller.stubs(:execute_delete_script).returns(true)
+    File.stubs(:read).returns("Dry run output")
+
+    post :delete_user_progress, params: {
+      csv_data: [{student_id: '123', unit_name: 'course1'}],
+      teacher_id: '456',
+      dry_run: 'true'
+    }
+
+    assert_response :success
+    response_json = JSON.parse(response.body)
+    assert_equal true, response_json['dry_run']
+    assert_equal "Dry run completed successfully", response_json['message']
+  end
+
   test "delete_user_progress handles actual deletion" do
     sign_in @admin
 
@@ -410,6 +428,24 @@ class AdminUsersControllerTest < ActionController::TestCase
       csv_data: [{student_id: '123', unit_name: 'course1'}],
       teacher_id: '456',
       dry_run: false
+    }
+
+    assert_response :success
+    response_json = JSON.parse(response.body)
+    assert_equal false, response_json['dry_run']
+    assert_equal "Progress deletion completed successfully", response_json['message']
+  end
+
+  test "delete_user_progress handles actual deletion with string 'false'" do
+    sign_in @admin
+
+    @controller.stubs(:execute_delete_script).returns(true)
+    File.stubs(:read).returns("Deletion output")
+
+    post :delete_user_progress, params: {
+      csv_data: [{student_id: '123', unit_name: 'course1'}],
+      teacher_id: '456',
+      dry_run: 'false'
     }
 
     assert_response :success


### PR DESCRIPTION
In a previous PR we unintentionally broke the test run button.  This fixes that issue.  Note that this will not fix the issue with this feature timing out on production.  That will be fixed in a future PR.



