### PR TITLE
update PODCAST_BUCKET

### DIFF
--- a/dashboard/app/helpers/ai_lesson_summary_podcasts_helper.rb
+++ b/dashboard/app/helpers/ai_lesson_summary_podcasts_helper.rb
@@ -1,6 +1,6 @@
 module AiLessonSummaryPodcastsHelper
   MODEL = "eleven_v3"
-  PODCAST_BUCKET = 'org.code.autoscale-prod-studio.user-content'
+  PODCAST_BUCKET = CDO.dashboard_hostname.split('.').reverse.join('.') + '.user-content'
   PODCAST_FOLDER = 'podcasts/'
 
   def self.create_and_save_to_s3(lesson_id, user_id)


### PR DESCRIPTION
This updates the PODCAST_BUCKET constant in AiLessonSummaryPodcastsHelper to use the current hostname as the basis for the bucket name, based on the naming conventions used in S3.

## Links
<!-- Jira tickets, design docs, Slack threads, related PRs, etc. -->

- Jira:

## Testing story
<!-- How was this tested? Manual steps, adhoc links, automated tests, or why testing isn't needed. -->



## Deployment notes
<!-- Delete this section if it's a standard merge-and-deploy.
     Otherwise: migrations, feature flags, coordination, caching impacts, etc. -->



## Privacy and security
<!-- Delete this section if there is no privacy/security impact.
     Otherwise: new PII, auth changes, API surface changes, etc. -->

