### PR TITLE
AI Tutor smoke tests

### DIFF
--- a/apps/src/aichat/redux/thunks/submitChatContents.ts
+++ b/apps/src/aichat/redux/thunks/submitChatContents.ts
@@ -237,9 +237,12 @@ export const submitChatContents = createAsyncThunk(
     dispatch(sendProgressReport('aichat', TestResults.LEVEL_STARTED));
     messages.forEach(message => {
       if (message.role === Role.ASSISTANT) {
-        message.chatMessageText =
-          responseCallback?.(message.chatMessageText) ??
-          message.chatMessageText;
+        // Structured-output callbacks only apply to successful model responses.
+        if (message.status === Status.OK) {
+          message.chatMessageText =
+            responseCallback?.(message.chatMessageText) ??
+            message.chatMessageText;
+        }
         dispatch(addChatEvent(message));
       }
       if (message.role === Role.USER) {

--- a/apps/test/unit/aichat/redux/thunks/submitChatContentsTest.ts
+++ b/apps/test/unit/aichat/redux/thunks/submitChatContentsTest.ts
@@ -1,0 +1,168 @@
+import {configureStore} from '@reduxjs/toolkit';
+
+import {postAichatCompletionMessage} from '@cdo/apps/aichat/aichatApi';
+import {aichatReducer} from '@cdo/apps/aichat/redux/slice';
+import {sendAnalytics} from '@cdo/apps/aichat/redux/thunks/sendAnalytics';
+import {submitChatContents} from '@cdo/apps/aichat/redux/thunks/submitChatContents';
+import {CompletedChatMessage, ModelParameters} from '@cdo/apps/aichat/types';
+import {Role} from '@cdo/apps/aiComponentLibrary/chatMessage/types';
+import {sendProgressReport} from '@cdo/apps/code-studio/progressRedux';
+import {
+  AiChatClientTypes,
+  AiChatModelIds,
+  AiInteractionStatus as Status,
+} from '@cdo/generated-scripts/sharedConstants';
+
+const mockMetricsReporter = {
+  incrementCounter: jest.fn(),
+  reportLoadTime: jest.fn(),
+  logError: jest.fn(),
+};
+
+jest.mock('@cdo/apps/aichat/aichatApi', () => ({
+  postAichatCompletionMessage: jest.fn(),
+}));
+
+jest.mock('@cdo/apps/aichat/helpers/logChatEvent', () => ({
+  logChatEvent: jest.fn(),
+}));
+
+jest.mock('@cdo/apps/code-studio/progressRedux', () => ({
+  sendProgressReport: jest.fn(() => ({type: 'progress/report'})),
+}));
+
+jest.mock('@cdo/apps/aichat/redux/thunks/sendAnalytics', () => ({
+  sendAnalytics: jest.fn(() => ({type: 'analytics/send'})),
+}));
+
+jest.mock('@cdo/apps/lab2/Lab2Registry', () => ({
+  __esModule: true,
+  default: {
+    getInstance: () => ({
+      getMetricsReporter: () => mockMetricsReporter,
+    }),
+  },
+}));
+
+jest.mock('@cdo/apps/utils', () => ({
+  createUuid: jest.fn(() => 'test-update-id'),
+}));
+
+const mockPostAichatCompletionMessage =
+  postAichatCompletionMessage as jest.MockedFunction<
+    typeof postAichatCompletionMessage
+  >;
+const mockSendProgressReport = sendProgressReport as jest.Mock;
+const mockSendAnalytics = sendAnalytics as jest.Mock;
+
+const modelParameters: ModelParameters = {
+  selectedModelId: AiChatModelIds.GEMINI_2_5_FLASH,
+  temperature: 0.5,
+  retrievalContexts: [],
+  systemPrompt: 'system prompt',
+};
+
+const makeStore = () =>
+  configureStore({
+    reducer: {
+      aichat: aichatReducer,
+      progress: (
+        state = {currentLevelId: '1', scriptId: 2, viewAsUserId: null}
+      ) => state,
+      lab: (state = {channel: {id: 'channel-id'}, levelProperties: {}}) =>
+        state,
+    },
+  });
+
+const makeMessages = (
+  assistant: Pick<CompletedChatMessage, 'chatMessageText' | 'status'>
+): CompletedChatMessage[] => [
+  {
+    role: Role.USER,
+    chatMessageText: 'Hello',
+    status: Status.OK,
+    timestamp: 1,
+    requestId: 42,
+    updateId: 'test-update-id',
+  },
+  {
+    role: Role.ASSISTANT,
+    timestamp: 2,
+    requestId: 42,
+    ...assistant,
+  },
+];
+
+describe('submitChatContents', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockSendProgressReport.mockReturnValue({type: 'progress/report'});
+    mockSendAnalytics.mockReturnValue({type: 'analytics/send'});
+  });
+
+  it('applies responseCallback to successful assistant messages', async () => {
+    mockPostAichatCompletionMessage.mockResolvedValue(
+      makeMessages({
+        chatMessageText: '{"answer":"formatted"}',
+        status: Status.OK,
+      })
+    );
+    const responseCallback = jest.fn(() => 'formatted response');
+    const store = makeStore();
+
+    const result = await store.dispatch(
+      submitChatContents({
+        text: 'Hello',
+        modelParameters,
+        clientType: AiChatClientTypes.AI_TUTOR,
+        responseCallback,
+      })
+    );
+
+    expect(submitChatContents.fulfilled.match(result)).toBe(true);
+    expect(responseCallback).toHaveBeenCalledWith('{"answer":"formatted"}');
+    expect(store.getState().aichat.chatEventsCurrent).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          role: Role.ASSISTANT,
+          status: Status.OK,
+          chatMessageText: 'formatted response',
+        }),
+      ])
+    );
+  });
+
+  it('does not apply responseCallback to assistant error messages', async () => {
+    mockPostAichatCompletionMessage.mockResolvedValue(
+      makeMessages({
+        chatMessageText: 'Error: service account missing',
+        status: Status.ERROR,
+      })
+    );
+    const responseCallback = jest.fn(() => {
+      throw new Error('should not parse error text');
+    });
+    const store = makeStore();
+
+    const result = await store.dispatch(
+      submitChatContents({
+        text: 'Hello',
+        modelParameters,
+        clientType: AiChatClientTypes.AI_TUTOR,
+        responseCallback,
+      })
+    );
+
+    expect(submitChatContents.fulfilled.match(result)).toBe(true);
+    expect(responseCallback).not.toHaveBeenCalled();
+    expect(store.getState().aichat.chatEventsCurrent).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          role: Role.ASSISTANT,
+          status: Status.ERROR,
+          chatMessageText: 'Error: service account missing',
+        }),
+      ])
+    );
+  });
+});

--- a/dashboard/test/ui/features/star_labs/ai_tutor/chat.feature
+++ b/dashboard/test/ui/features/star_labs/ai_tutor/chat.feature
@@ -43,9 +43,11 @@ Feature: AI Tutor happy paths across legacy labs and Lab2 resource panels
     And I wait until element "#ui-close-dialog" is not visible
     And I dismiss the teacher panel
     And I wait until element "#instructions-drawer" is visible
-    And I wait until element "#uitest-chat-textarea" is visible
+    And I wait until element "#resource-panel-tab-button-aiTutor" is visible
 
-    When I press keys "Hello" for element "#uitest-chat-textarea"
+    When I click selector "#resource-panel-tab-button-aiTutor"
+    And I wait until element "#uitest-chat-textarea" is visible
+    And I press keys "Hello" for element "#uitest-chat-textarea"
     And I wait until element "#uitest-chat-submit" is enabled
     And I click selector "#uitest-chat-submit"
 

--- a/dashboard/test/ui/features/star_labs/ai_tutor/chat.feature
+++ b/dashboard/test/ui/features/star_labs/ai_tutor/chat.feature
@@ -22,9 +22,6 @@ Feature: AI Tutor happy paths across legacy labs and Lab2 resource panels
 
   Scenario: Chat works in the resource panel AI Tutor tab without the instructions drawer
     Given I am on "http://studio.code.org/courses/allthethingscourse/units/1/lessons/50/levels/1?hideProductTours=true"
-    And I click selector "#ui-close-dialog" once I see it
-    And I wait until element "#ui-close-dialog" is not visible
-    And I dismiss the teacher panel
     And I wait until element "#resource-panel-tab-button-aiTutor" is visible
 
     When I click selector "#resource-panel-tab-button-aiTutor"
@@ -39,9 +36,6 @@ Feature: AI Tutor happy paths across legacy labs and Lab2 resource panels
 
   Scenario: Chat works in the resource panel AI Tutor tab with the instructions drawer
     Given I am on "http://studio.code.org/courses/allthethingscourse/units/1/lessons/51/levels/11?hideProductTours=true"
-    And I click selector "#ui-close-dialog" once I see it
-    And I wait until element "#ui-close-dialog" is not visible
-    And I dismiss the teacher panel
     And I wait until element "#instructions-drawer" is visible
     And I wait until element "#resource-panel-tab-button-aiTutor" is visible
 

--- a/dashboard/test/ui/features/star_labs/ai_tutor/chat.feature
+++ b/dashboard/test/ui/features/star_labs/ai_tutor/chat.feature
@@ -1,4 +1,5 @@
 @no_mobile
+@no_ci
 Feature: AI Tutor smoke tests on legacy labs and Lab2 resource panels
 
   Background:
@@ -18,7 +19,7 @@ Feature: AI Tutor smoke tests on legacy labs and Lab2 resource panels
 
     Then element "[aria-label='User chat message']" has text "Hello"
     And I wait until element "[aria-label='AI bot chat message']" is visible
-    And element "[aria-label='AI bot chat message']" has css property "background-color" equal to "rgb(255, 225, 221)"
+    And element "[aria-label='AI bot chat message']" has css property "background-color" equal to "rgb(235, 255, 254)"
 
   Scenario: Chat works in the resource panel AI Tutor tab in Python Lab
     Given I am on "http://studio.code.org/courses/allthethingscourse/units/1/lessons/50/levels/1?hideProductTours=true"
@@ -32,7 +33,7 @@ Feature: AI Tutor smoke tests on legacy labs and Lab2 resource panels
 
     Then element "[aria-label='User chat message']" has text "Hello"
     And I wait until element "[aria-label='AI bot chat message']" is visible
-    And element "[aria-label='AI bot chat message']" has css property "background-color" equal to "rgb(106, 27, 17)"
+    And element "[aria-label='AI bot chat message']" has css property "background-color" equal to "rgb(4, 119, 115)"
 
   Scenario: Chat works in the resource panel AI Tutor tab in Weblab2
     Given I am on "http://studio.code.org/courses/allthethingscourse/units/1/lessons/51/levels/11?hideProductTours=true"
@@ -47,4 +48,4 @@ Feature: AI Tutor smoke tests on legacy labs and Lab2 resource panels
 
     Then element "[aria-label='User chat message']" has text "Hello"
     And I wait until element "[aria-label='AI bot chat message']" is visible
-    And element "[aria-label='AI bot chat message']" has css property "background-color" equal to "rgb(106, 27, 17)"
+    And element "[aria-label='AI bot chat message']" has css property "background-color" equal to "rgb(4, 119, 115)"

--- a/dashboard/test/ui/features/star_labs/ai_tutor/chat.feature
+++ b/dashboard/test/ui/features/star_labs/ai_tutor/chat.feature
@@ -1,0 +1,54 @@
+@no_mobile
+Feature: AI Tutor happy paths across legacy labs and Lab2 resource panels
+
+  Background:
+    Given I create a teacher named "Simone"
+    And I give user "Simone" authorized teacher permission
+
+  Scenario: Chat works in the legacy labs AI Tutor
+    Given I am on "http://studio.code.org/projects/applab/new?hideProductTours=true"
+    And I wait for the lab page to fully load
+    And I wait until element "[aria-label='Open AI tutor']" is visible
+
+    When I click selector "[aria-label='Open AI tutor']"
+    And I wait until element "#uitest-chat-textarea" is visible
+    And I press keys "Hello" for element "#uitest-chat-textarea"
+    And I wait until element "#uitest-chat-submit" is enabled
+    And I click selector "#uitest-chat-submit"
+
+    Then element "[aria-label='User chat message']" has text "Hello"
+    And I wait until element "[aria-label='AI bot chat message']" is visible
+    And element "[aria-label='AI bot chat message']" has css property "background-color" equal to "rgb(235, 255, 254)"
+
+  Scenario: Chat works in the resource panel AI Tutor tab without the instructions drawer
+    Given I am on "http://studio.code.org/courses/allthethingscourse/units/1/lessons/50/levels/1?hideProductTours=true"
+    And I click selector "#ui-close-dialog" once I see it
+    And I wait until element "#ui-close-dialog" is not visible
+    And I dismiss the teacher panel
+    And I wait until element "#resource-panel-tab-button-aiTutor" is visible
+
+    When I click selector "#resource-panel-tab-button-aiTutor"
+    And I wait until element "#uitest-chat-textarea" is visible
+    And I press keys "Hello" for element "#uitest-chat-textarea"
+    And I wait until element "#uitest-chat-submit" is enabled
+    And I click selector "#uitest-chat-submit"
+
+    Then element "[aria-label='User chat message']" has text "Hello"
+    And I wait until element "[aria-label='AI bot chat message']" is visible
+    And element "[aria-label='AI bot chat message']" has css property "background-color" equal to "rgb(235, 255, 254)"
+
+  Scenario: Chat works in the resource panel AI Tutor tab with the instructions drawer
+    Given I am on "http://studio.code.org/courses/allthethingscourse/units/1/lessons/51/levels/11?hideProductTours=true"
+    And I click selector "#ui-close-dialog" once I see it
+    And I wait until element "#ui-close-dialog" is not visible
+    And I dismiss the teacher panel
+    And I wait until element "#instructions-drawer" is visible
+    And I wait until element "#uitest-chat-textarea" is visible
+
+    When I press keys "Hello" for element "#uitest-chat-textarea"
+    And I wait until element "#uitest-chat-submit" is enabled
+    And I click selector "#uitest-chat-submit"
+
+    Then element "[aria-label='User chat message']" has text "Hello"
+    And I wait until element "[aria-label='AI bot chat message']" is visible
+    And element "[aria-label='AI bot chat message']" has css property "background-color" equal to "rgb(235, 255, 254)"

--- a/dashboard/test/ui/features/star_labs/ai_tutor/chat.feature
+++ b/dashboard/test/ui/features/star_labs/ai_tutor/chat.feature
@@ -18,7 +18,7 @@ Feature: AI Tutor smoke tests on legacy labs and Lab2 resource panels
 
     Then element "[aria-label='User chat message']" has text "Hello"
     And I wait until element "[aria-label='AI bot chat message']" is visible
-    And element "[aria-label='AI bot chat message']" has css property "background-color" equal to "rgb(255, 240, 247)"
+    And element "[aria-label='AI bot chat message']" has css property "background-color" equal to "rgb(255, 225, 221)"
 
   Scenario: Chat works in the resource panel AI Tutor tab in Python Lab
     Given I am on "http://studio.code.org/courses/allthethingscourse/units/1/lessons/50/levels/1?hideProductTours=true"
@@ -32,7 +32,7 @@ Feature: AI Tutor smoke tests on legacy labs and Lab2 resource panels
 
     Then element "[aria-label='User chat message']" has text "Hello"
     And I wait until element "[aria-label='AI bot chat message']" is visible
-    And element "[aria-label='AI bot chat message']" has css property "background-color" equal to "rgb(110, 21, 67)"
+    And element "[aria-label='AI bot chat message']" has css property "background-color" equal to "rgb(106, 27, 17)"
 
   Scenario: Chat works in the resource panel AI Tutor tab in Weblab2
     Given I am on "http://studio.code.org/courses/allthethingscourse/units/1/lessons/51/levels/11?hideProductTours=true"
@@ -47,4 +47,4 @@ Feature: AI Tutor smoke tests on legacy labs and Lab2 resource panels
 
     Then element "[aria-label='User chat message']" has text "Hello"
     And I wait until element "[aria-label='AI bot chat message']" is visible
-    And element "[aria-label='AI bot chat message']" has css property "background-color" equal to "rgb(110, 21, 67)"
+    And element "[aria-label='AI bot chat message']" has css property "background-color" equal to "rgb(106, 27, 17)"

--- a/dashboard/test/ui/features/star_labs/ai_tutor/chat.feature
+++ b/dashboard/test/ui/features/star_labs/ai_tutor/chat.feature
@@ -20,7 +20,7 @@ Feature: AI Tutor happy paths across legacy labs and Lab2 resource panels
     And I wait until element "[aria-label='AI bot chat message']" is visible
     And element "[aria-label='AI bot chat message']" has css property "background-color" equal to "rgb(235, 255, 254)"
 
-  Scenario: Chat works in the resource panel AI Tutor tab without the instructions drawer
+  Scenario: Chat works in the resource panel AI Tutor tab in Python Lab
     Given I am on "http://studio.code.org/courses/allthethingscourse/units/1/lessons/50/levels/1?hideProductTours=true"
     And I wait until element "#resource-panel-tab-button-aiTutor" is visible
 
@@ -32,9 +32,9 @@ Feature: AI Tutor happy paths across legacy labs and Lab2 resource panels
 
     Then element "[aria-label='User chat message']" has text "Hello"
     And I wait until element "[aria-label='AI bot chat message']" is visible
-    And element "[aria-label='AI bot chat message']" has css property "background-color" equal to "rgb(235, 255, 254)"
+    And element "[aria-label='AI bot chat message']" has css property "background-color" equal to "rgb(4, 119, 115)"
 
-  Scenario: Chat works in the resource panel AI Tutor tab with the instructions drawer
+  Scenario: Chat works in the resource panel AI Tutor tab in Weblab2
     Given I am on "http://studio.code.org/courses/allthethingscourse/units/1/lessons/51/levels/11?hideProductTours=true"
     And I wait until element "#instructions-drawer" is visible
     And I wait until element "#resource-panel-tab-button-aiTutor" is visible
@@ -47,4 +47,4 @@ Feature: AI Tutor happy paths across legacy labs and Lab2 resource panels
 
     Then element "[aria-label='User chat message']" has text "Hello"
     And I wait until element "[aria-label='AI bot chat message']" is visible
-    And element "[aria-label='AI bot chat message']" has css property "background-color" equal to "rgb(235, 255, 254)"
+    And element "[aria-label='AI bot chat message']" has css property "background-color" equal to "rgb(4, 119, 115)"

--- a/dashboard/test/ui/features/star_labs/ai_tutor/chat.feature
+++ b/dashboard/test/ui/features/star_labs/ai_tutor/chat.feature
@@ -1,5 +1,5 @@
 @no_mobile
-Feature: AI Tutor happy paths across legacy labs and Lab2 resource panels
+Feature: AI Tutor smoke tests on legacy labs and Lab2 resource panels
 
   Background:
     Given I create a teacher named "Simone"
@@ -18,7 +18,7 @@ Feature: AI Tutor happy paths across legacy labs and Lab2 resource panels
 
     Then element "[aria-label='User chat message']" has text "Hello"
     And I wait until element "[aria-label='AI bot chat message']" is visible
-    And element "[aria-label='AI bot chat message']" has css property "background-color" equal to "rgb(235, 255, 254)"
+    And element "[aria-label='AI bot chat message']" has css property "background-color" equal to "rgb(255, 240, 247)"
 
   Scenario: Chat works in the resource panel AI Tutor tab in Python Lab
     Given I am on "http://studio.code.org/courses/allthethingscourse/units/1/lessons/50/levels/1?hideProductTours=true"
@@ -32,7 +32,7 @@ Feature: AI Tutor happy paths across legacy labs and Lab2 resource panels
 
     Then element "[aria-label='User chat message']" has text "Hello"
     And I wait until element "[aria-label='AI bot chat message']" is visible
-    And element "[aria-label='AI bot chat message']" has css property "background-color" equal to "rgb(4, 119, 115)"
+    And element "[aria-label='AI bot chat message']" has css property "background-color" equal to "rgb(110, 21, 67)"
 
   Scenario: Chat works in the resource panel AI Tutor tab in Weblab2
     Given I am on "http://studio.code.org/courses/allthethingscourse/units/1/lessons/51/levels/11?hideProductTours=true"
@@ -47,4 +47,4 @@ Feature: AI Tutor happy paths across legacy labs and Lab2 resource panels
 
     Then element "[aria-label='User chat message']" has text "Hello"
     And I wait until element "[aria-label='AI bot chat message']" is visible
-    And element "[aria-label='AI bot chat message']" has css property "background-color" equal to "rgb(4, 119, 115)"
+    And element "[aria-label='AI bot chat message']" has css property "background-color" equal to "rgb(110, 21, 67)"


### PR DESCRIPTION
<!--
  Summary of the change: background, motivation, and context.
  Include screenshots, videos, or before/after comparisons for UI changes.
-->

This PR adds UI tests that make sure a verified teacher can successfully chat with ai tutor in weblab2, python lab, and legacy labs.  

In the process of testing these out in drone, I realized that weblab2 never shows an error response in chat when there's an error response (see https://app.saucelabs.com/tests/8e3cb8f504f64cbab087a0ee46675f06#0) so I fixed that as well.

I'm skipping CI for these tests so they only run in DTT so we don't bloat every drone run with 3 more tests that need to wait for llm responses.

## Testing story
<!-- How was this tested? Manual steps, adhoc links, automated tests, or why testing isn't needed. -->

drone doesn't have the right config / secrets, so I temporarily changed the message colors to the error colors to make sure the rest of the test was good >.> 

## Deployment notes
<!-- Delete this section if it's a standard merge-and-deploy.
     Otherwise: migrations, feature flags, coordination, caching impacts, etc. -->

should run just in DTT
