### PR TITLE
Add secrets for authentication with new Pardot instance

### DIFF
--- a/config.yml.erb
+++ b/config.yml.erb
@@ -141,6 +141,8 @@ pardot_password:
 pardot_user_key:
 pardot_username:
 pardot_private_key:
+pardot_client_id:
+pardot_client_secret:
 
 # Honeybadger
 honeybadger_api_token:

--- a/config/production.yml.erb
+++ b/config/production.yml.erb
@@ -3,6 +3,8 @@ pardot_password: !Secret
 pardot_user_key: !Secret
 pardot_username: !Secret
 pardot_private_key: !Secret
+pardot_client_id: !Secret
+pardot_client_secret: !Secret
 pd_teacher_application_list_secret_key: !Secret
 pledge_map_table_id: !Secret
 


### PR DESCRIPTION
We have been asked to move away from a JWT tokens and to client API credentials. This requires a different set of secrets: instead of `pardot_private_key` we instead need `pardot_client_id` and `pardot_client_secret`. This PR adds the config for these new secrets. The secrets already exist in Secret Manager for production (the only environment that actually needs these values).

`pardot_private_key` is defined in `config/development.yml.erb` but I'm not sure that's really necessary as local environments should not be connecting to the Pardot service. I decided not to include the new secrets in `development.yml.erb`, at least for now.

