### PR TITLE
Add asset URL for flagged user-uploaded image attempts in Statsig reports

### DIFF
--- a/apps/src/codebridge/FileBrowser/hooks/useFileUploader.tsx
+++ b/apps/src/codebridge/FileBrowser/hooks/useFileUploader.tsx
@@ -42,26 +42,33 @@ export const useFileUploader = (
   // Skip moderating images that are added by levelbuilders in start mode.
   const onImageFlaggedWithOverride = isStartMode ? undefined : onImageFlagged;
 
-  const uploadExternalFile = useCallback(
-    async (file: File) => {
+  const generateUploadUrl = useCallback(
+    (file: File): string => {
       const uuid = createUuid();
       const fileType = file.name.split('.').pop();
-
       if (isStartMode || isEditingExemplar) {
-        const bodyData = new FormData();
-        bodyData.append('files[]', file);
-
         const encodedLevelName = encodeURIComponent(name);
-        const url = `/level_starter_assets/${encodedLevelName}/uuid/${uuid}.${fileType}`;
-        await HttpClient.post(url, bodyData, true);
-        return url;
+        return `/level_starter_assets/${encodedLevelName}/uuid/${uuid}.${fileType}`;
       } else {
-        const url = `/v3/assets/${channelId}/${uuid}.${fileType}`;
-        await HttpClient.put(url, file);
-        return url;
+        return `/v3/assets/${channelId}/${uuid}.${fileType}`;
       }
     },
     [channelId, isStartMode, isEditingExemplar, name]
+  );
+
+  const uploadExternalFile = useCallback(
+    async (file: File, precomputedUrl?: string) => {
+      const url = precomputedUrl ?? generateUploadUrl(file);
+      if (isStartMode || isEditingExemplar) {
+        const bodyData = new FormData();
+        bodyData.append('files[]', file);
+        await HttpClient.post(url, bodyData, true);
+      } else {
+        await HttpClient.put(url, file);
+      }
+      return url;
+    },
+    [generateUploadUrl, isStartMode, isEditingExemplar]
   );
 
   const sendAnalyticsEvent = useCallback(
@@ -103,6 +110,9 @@ export const useFileUploader = (
     sendAnalyticsEvent,
     validateFileName,
     uploadExternalFile,
+    generateUploadUrl: onImageFlaggedWithOverride
+      ? generateUploadUrl
+      : undefined,
     onImageFlagged: onImageFlaggedWithOverride,
     ...lab2FileUploaderArgs,
   });

--- a/apps/src/lab2/hooks/useFileUploader.tsx
+++ b/apps/src/lab2/hooks/useFileUploader.tsx
@@ -21,7 +21,11 @@ export type FileUploaderProps = {
     flagged?: boolean
   ) => void;
   errorCallback: (error: string, callbackArgs?: unknown) => void;
-  uploadExternalFile: (file: File) => Promise<string>;
+  uploadExternalFile: (file: File, precomputedUrl?: string) => Promise<string>;
+  // If provided, called before moderation to pre-compute the upload URL so it
+  // can be included in the flagged analytics event. Must be consistent with
+  // the URL that uploadExternalFile will use when passed the same value.
+  generateUploadUrl?: (file: File) => string;
   validateFileName?: (fileName: string) => string | undefined;
   multiple?: boolean;
   validMimeTypes?: string[];
@@ -102,6 +106,7 @@ export const useFileUploader = ({
   errorCallback,
   validMimeTypes,
   uploadExternalFile,
+  generateUploadUrl,
   validateFileName = () => undefined,
   sendAnalyticsEvent = () => {},
   multiple = true,
@@ -173,21 +178,27 @@ export const useFileUploader = ({
         };
       } else {
         try {
+          // Pre-compute the upload URL before moderation so it can be
+          // included in the flagged analytics event. Both the flagged and safe
+          // upload paths reuse this value to guarantee URL consistency.
+          const precomputedUrl = generateUploadUrl?.(file);
+
           if (onImageFlagged) {
             const ext = file.name.split('.').pop()?.toLowerCase() || '';
             const moderationStatus = await moderateImage(file, appName, {
               uploaderType: 'Lab2FileUploader',
+              assetUrl: precomputedUrl,
             });
             if (moderationStatus === 'flagged') {
               const uploadFunction = async () => {
-                const url = await uploadExternalFile(file);
+                const url = await uploadExternalFile(file, precomputedUrl);
                 sendAnalyticsEvent(analyticsEvents.UPLOAD_SUCCEEDED, {
                   fileName: file.name,
                   fileType: file.name.split('.').pop()?.toLowerCase() || '',
                 });
                 callback(file.name, '', url, callbackArgs.current, true);
               };
-              // FlagedImageModal will be shown to the user and user can choose to upload the image or not.
+              // FlaggedImageModal will be shown to the user and user can choose to upload the image or not.
               onImageFlagged(file, ext, uploadFunction);
               return;
             }
@@ -195,7 +206,7 @@ export const useFileUploader = ({
 
           // For non-text files that are not moderated (eg, files uploaded in start mode by levelbuilders)
           // and images that are deemed safe, upload directly to assets.
-          const url = await uploadExternalFile(file);
+          const url = await uploadExternalFile(file, precomputedUrl);
           sendAnalyticsEvent(analyticsEvents.UPLOAD_SUCCEEDED, {
             fileName: file.name,
             fileType: file.name.split('.').pop()?.toLowerCase() || '',
@@ -215,6 +226,7 @@ export const useFileUploader = ({
     validMimeTypes,
     callback,
     uploadExternalFile,
+    generateUploadUrl,
     appName,
     onImageFlagged,
   ]);

--- a/apps/src/lab2/views/components/Instructions/ResourcePanel/Backpack/saveToBackpackHelper.tsx
+++ b/apps/src/lab2/views/components/Instructions/ResourcePanel/Backpack/saveToBackpackHelper.tsx
@@ -172,6 +172,7 @@ export const fetchAndSaveFile = async ({
 
       const moderationStatus = await moderateImage(file, appName ?? '', {
         uploaderType: 'Lab2FileUploader',
+        assetUrl: uploadUrl,
       });
       if (moderationStatus === 'flagged') {
         // Callback function so if user accepts flagged image, we can save the image to the project.

--- a/apps/src/p5lab/AnimationPicker/AnimationPicker.jsx
+++ b/apps/src/p5lab/AnimationPicker/AnimationPicker.jsx
@@ -106,11 +106,24 @@ class AnimationPicker extends React.Component {
     showFlaggedModal: false,
     pendingUploadData: null,
     flaggedModalError: null,
-    // Computed once per dialog open so the URL is stable across re-renders
-    // and accessible at moderation time (before the upload occurs).
+    // Stable for the duration of one open cycle; regenerated on each
+    // visible false ->true transition so subsequent opens get a fresh URL.
     uploadUrl:
       '/v3/animations/' + this.props.channelId + '/' + createUuid() + '.png',
   };
+
+  componentDidUpdate(prevProps) {
+    if (!prevProps.visible && this.props.visible) {
+      this.setState({
+        uploadUrl:
+          '/v3/animations/' +
+          this.props.channelId +
+          '/' +
+          createUuid() +
+          '.png',
+      });
+    }
+  }
 
   onUploadClick = () => this.refs.uploader.openFileChooser();
 
@@ -297,6 +310,7 @@ class AnimationPicker extends React.Component {
         style={styles.dialog}
       >
         <HiddenUploader
+          key={this.state.uploadUrl}
           ref="uploader"
           toUrl={this.state.uploadUrl}
           allowedExtensions={this.props.allowedExtensions}

--- a/apps/src/p5lab/AnimationPicker/AnimationPicker.jsx
+++ b/apps/src/p5lab/AnimationPicker/AnimationPicker.jsx
@@ -106,6 +106,10 @@ class AnimationPicker extends React.Component {
     showFlaggedModal: false,
     pendingUploadData: null,
     flaggedModalError: null,
+    // Computed once per dialog open so the URL is stable across re-renders
+    // and accessible at moderation time (before the upload occurs).
+    uploadUrl:
+      '/v3/animations/' + this.props.channelId + '/' + createUuid() + '.png',
   };
 
   onUploadClick = () => this.refs.uploader.openFileChooser();
@@ -217,7 +221,7 @@ class AnimationPicker extends React.Component {
         this.props.projectType,
         {
           uploaderType: 'AnimationPicker',
-          assetUrl: data.url,
+          assetUrl: this.state.uploadUrl,
         }
       );
       if (moderationStatus === 'flagged') {
@@ -294,13 +298,7 @@ class AnimationPicker extends React.Component {
       >
         <HiddenUploader
           ref="uploader"
-          toUrl={
-            '/v3/animations/' +
-            this.props.channelId +
-            '/' +
-            createUuid() +
-            '.png'
-          }
+          toUrl={this.state.uploadUrl}
           allowedExtensions={this.props.allowedExtensions}
           onUploadStart={this.handleModeratedUploadStart}
           onUploadDone={this.props.onUploadDone}

--- a/apps/src/p5lab/AnimationPicker/AnimationPicker.jsx
+++ b/apps/src/p5lab/AnimationPicker/AnimationPicker.jsx
@@ -217,6 +217,7 @@ class AnimationPicker extends React.Component {
         this.props.projectType,
         {
           uploaderType: 'AnimationPicker',
+          assetUrl: data.url,
         }
       );
       if (moderationStatus === 'flagged') {


### PR DESCRIPTION
<!--
  Summary of the change: background, motivation, and context.
  Include screenshots, videos, or before/after comparisons for UI changes.
-->
This PR adds asset URL to metadata sent alongside the Statsig report when a user attempts to upload a flagged image.
Note that the asset URL is NOT included for flagged images that a user attempts to upload in AI Chat Lab because we do not save flagged images in the user's project's assets.




## Links
<!-- Jira tickets, design docs, Slack threads, related PRs, etc. -->

- Jira: https://codedotorg.atlassian.net/browse/SL-1681
- [Slack thread](https://codedotorg.slack.com/archives/C03DBDN67B7/p1776712660562599)

## Testing story
<!-- How was this tested? Manual steps, adhoc links, automated tests, or why testing isn't needed. -->

Tested in Web Lab 2 (including adding from Backpack), Sprite Lab levels.

Screencast of uploading image in Web Lab 2 level:


https://github.com/user-attachments/assets/ec85c469-6749-460b-95b4-fcadc674056e



Screencast of adding image from backpack in Web Lab 2:

https://github.com/user-attachments/assets/e2649e95-1340-4a1e-acae-5951b0984e99



Screencast of uploading image in Sprite Lab project:



https://github.com/user-attachments/assets/cef7893c-5be1-44f8-8bbf-439501807496




## Deployment notes
<!-- Delete this section if it's a standard merge-and-deploy.
     Otherwise: migrations, feature flags, coordination, caching impacts, etc. -->



## Privacy and security
<!-- Delete this section if there is no privacy/security impact.
     Otherwise: new PII, auth changes, API surface changes, etc. -->

