### PR TITLE
Update image moderation thresholds

### DIFF
--- a/apps/src/aichat/api/client/helpers/safetyHelpers.ts
+++ b/apps/src/aichat/api/client/helpers/safetyHelpers.ts
@@ -74,7 +74,7 @@ export async function getImageModerationStatus(
       flaggedEvent: EVENTS.FLAGGED_MODEL_OUTPUT_IMAGE_AZURE,
       assetUrl,
     },
-    true // isModelOutput = true
+    {Violence: 2}
   );
   return moderationStatus;
 }

--- a/apps/src/aichat/api/client/helpers/safetyHelpers.ts
+++ b/apps/src/aichat/api/client/helpers/safetyHelpers.ts
@@ -66,10 +66,15 @@ export async function getImageModerationStatus(
     SafeAndSupportedImageTypes
   );
   const image = new File([fileBuffer], filename, {type: mediaType});
-  const moderationStatus = await moderateImage(image, 'aichat', {
-    moderateEvent: EVENTS.MODERATE_MODEL_OUTPUT_IMAGE_AZURE,
-    flaggedEvent: EVENTS.FLAGGED_MODEL_OUTPUT_IMAGE_AZURE,
-    assetUrl,
-  });
+  const moderationStatus = await moderateImage(
+    image,
+    'aichat',
+    {
+      moderateEvent: EVENTS.MODERATE_MODEL_OUTPUT_IMAGE_AZURE,
+      flaggedEvent: EVENTS.FLAGGED_MODEL_OUTPUT_IMAGE_AZURE,
+      assetUrl,
+    },
+    true // isModelOutput = true
+  );
   return moderationStatus;
 }

--- a/apps/src/util/moderateImage.ts
+++ b/apps/src/util/moderateImage.ts
@@ -13,13 +13,20 @@ const LABS_WITH_IMAGE_MODERATION = [
   'game_design',
 ];
 
+type CategoryName = 'Hate' | 'SelfHarm' | 'Sexual' | 'Violence';
+type SeverityThresholds = Partial<Record<CategoryName, number>>;
+type CategoryAnalysis = {
+  category: CategoryName;
+  severity: number;
+};
+
 // Severity level blocked by category for AI Content Safety.
 // If any category's severity level is greater than or equal to the severity level blocked value,
 // the image is flagged. If all categories' severity levels are less than the severity level blocked value,
 // the image is 'ok'
 // The severity value increases with the severity of the input content:
 // 0 (safe), 2 (low), 4 (medium), 6 (high)
-const CATEGORY_SEVERITY_LEVEL_BLOCKED: Record<string, number> = {
+const CATEGORY_SEVERITY_LEVEL_BLOCKED: Record<CategoryName, number> = {
   Hate: 2,
   SelfHarm: 2,
   Sexual: 2,
@@ -42,7 +49,7 @@ export const moderateImage = async (
     flaggedEvent = EVENTS.FLAGGED_CUSTOM_IMAGE,
     assetUrl,
   }: AnalyticsData,
-  isModelOutput?: boolean
+  overrideSeverityThresholds?: SeverityThresholds
 ): Promise<'safe' | 'flagged' | 'error'> => {
   const imageType = file.type || '';
   if (
@@ -72,14 +79,14 @@ export const moderateImage = async (
 
     MetricsReporter.incrementCounter('ModerateCustomImage.Success', dimensions);
 
-    const categorySeverityLevelBlocked: Record<string, number> = {
+    const categorySeverityLevelBlocked: Record<CategoryName, number> = {
       ...CATEGORY_SEVERITY_LEVEL_BLOCKED,
-      ...(isModelOutput && {Violence: 2}),
+      ...overrideSeverityThresholds,
     };
     const categories = json?.categoriesAnalysis;
     if (
       categories?.every(
-        (category: {severity: number; category: string}) =>
+        (category: CategoryAnalysis) =>
           category?.severity < categorySeverityLevelBlocked[category?.category]
       )
     ) {

--- a/apps/src/util/moderateImage.ts
+++ b/apps/src/util/moderateImage.ts
@@ -23,7 +23,7 @@ const CATEGORY_SEVERITY_LEVEL_BLOCKED: Record<string, number> = {
   Hate: 2,
   SelfHarm: 2,
   Sexual: 2,
-  Violence: 2,
+  Violence: 4,
 };
 
 interface AnalyticsData {

--- a/apps/src/util/moderateImage.ts
+++ b/apps/src/util/moderateImage.ts
@@ -17,7 +17,7 @@ type CategoryName = 'Hate' | 'SelfHarm' | 'Sexual' | 'Violence';
 type SeverityThresholds = Partial<Record<CategoryName, number>>;
 type CategoryAnalysis = {
   category: CategoryName;
-  severity: number;
+  severity: 0 | 2 | 4 | 6;
 };
 
 // Severity level blocked by category for AI Content Safety.

--- a/apps/src/util/moderateImage.ts
+++ b/apps/src/util/moderateImage.ts
@@ -41,7 +41,8 @@ export const moderateImage = async (
     moderateEvent = EVENTS.MODERATE_CUSTOM_IMAGE,
     flaggedEvent = EVENTS.FLAGGED_CUSTOM_IMAGE,
     assetUrl,
-  }: AnalyticsData
+  }: AnalyticsData,
+  isModelOutput?: boolean
 ): Promise<'safe' | 'flagged' | 'error'> => {
   const imageType = file.type || '';
   if (
@@ -71,12 +72,15 @@ export const moderateImage = async (
 
     MetricsReporter.incrementCounter('ModerateCustomImage.Success', dimensions);
 
+    const categorySeverityLevelBlocked: Record<string, number> = {
+      ...CATEGORY_SEVERITY_LEVEL_BLOCKED,
+      ...(isModelOutput && {Violence: 2}),
+    };
     const categories = json?.categoriesAnalysis;
     if (
       categories?.every(
         (category: {severity: number; category: string}) =>
-          category?.severity <
-          CATEGORY_SEVERITY_LEVEL_BLOCKED[category?.category]
+          category?.severity < categorySeverityLevelBlocked[category?.category]
       )
     ) {
       return 'safe';


### PR DESCRIPTION
<!--
  Summary of the change: background, motivation, and context.
  Include screenshots, videos, or before/after comparisons for UI changes.
-->
We've been receiving Zendesk tickets reporting that projects are being blocked due to flagged images. But these images seem acceptable according to the teacher users. We recently migrated from Azure Content Moderator to Azure AI Content Safety service. The deprecated service only moderated according to adult/racy categories. The new service is moderating across four categories (Violence, Sexual, SelfHarm, and Hate). Currently the threshold is `2`, i.e., low for all four categories.
The vast majority (~90-95%) of flagged images are due to a Violence rating of severity level `2`. Two recent examples of user-uploaded images rated with Violence severity level `2` are below.

<img width="300" alt="instructions" src="https://github.com/user-attachments/assets/98edd5cb-98e4-497f-b34e-2ea7ee01cf49" />

<img width="300" alt="duck" src="https://github.com/user-attachments/assets/4c45a690-57d9-4d5e-814f-88f04251704e" />


Considering that we historically have not moderated images in the Violence category and we've received 'quite a few over the past couple months' and 'we have seen quite a large increase in tickets about project flagging, to the point that I would say up to maybe even 30% of tickets are about this' according to Customer Service, we're updating the Violence threshold to `4` for user-uploaded images.

However, we are maintaining a Violence threshold of `2` for model-generated images.
Here are two model-generated images with a rating Violence `2`:

<img width="300" alt="brain" src="https://github.com/user-attachments/assets/c8dc56bd-58e3-4f04-85bd-353fa97aa97c" />

<img width="300" alt="reality" src="https://github.com/user-attachments/assets/58e0e722-f5c1-40a9-9ee0-006f14d6b497" />




## Links
<!-- Jira tickets, design docs, Slack threads, related PRs, etc. -->

- Jira: https://codedotorg.atlassian.net/browse/SL-1680
- [Slack thread](https://codedotorg.slack.com/archives/C03DBDN67B7/p1776712660562599)

## Testing story
<!-- How was this tested? Manual steps, adhoc links, automated tests, or why testing isn't needed. -->



## Deployment notes
<!-- Delete this section if it's a standard merge-and-deploy.
     Otherwise: migrations, feature flags, coordination, caching impacts, etc. -->



## Privacy and security
<!-- Delete this section if there is no privacy/security impact.
     Otherwise: new PII, auth changes, API surface changes, etc. -->

