### PR TITLE
DSCO migration: UnitCalendar colors, typography, icons

### DIFF
--- a/apps/src/code-studio/components/progress/UnitCalendarGrid.jsx
+++ b/apps/src/code-studio/components/progress/UnitCalendarGrid.jsx
@@ -1,4 +1,5 @@
 import FontAwesomeV6Icon from '@code-dot-org/component-library/fontAwesomeV6Icon';
+import {Typography} from '@mui/material';
 import _ from 'lodash';
 import PropTypes from 'prop-types';
 import React from 'react';
@@ -90,7 +91,9 @@ export default function UnitCalendarGrid({
           {schedule.map((week, index) => (
             <tr key={`week-${index}`}>
               <td className={styles.weekColumn}>
-                {i18n.weekLabel({number: index + 1})}
+                <Typography variant="label1" sx={{color: 'inherit'}}>
+                  {i18n.weekLabel({number: index + 1})}
+                </Typography>
               </td>
               <td className={styles.scheduleColumn}>
                 {renderWeek(week, index + 1)}
@@ -102,7 +105,11 @@ export default function UnitCalendarGrid({
       <table className={styles.key}>
         <tbody>
           <tr>
-            <td className={styles.weekColumn}>Key</td>
+            <td className={styles.weekColumn}>
+              <Typography variant="label1" sx={{color: 'inherit'}}>
+                Key
+              </Typography>
+            </td>
             <td className={styles.scheduleColumn}>
               <div className={styles.keySection}>
                 <div className={styles.keyCell}>
@@ -114,7 +121,9 @@ export default function UnitCalendarGrid({
                     }}
                     className={styles.keyIcon}
                   />
-                  {i18n.instructionalLesson()}
+                  <Typography variant="body2">
+                    {i18n.instructionalLesson()}
+                  </Typography>
                 </div>
                 <div className={styles.keyCell}>
                   <FontAwesomeV6Icon
@@ -124,14 +133,16 @@ export default function UnitCalendarGrid({
                     }}
                     className={styles.keyIcon}
                   />
-                  {i18n.assessment()}
+                  <Typography variant="body2">{i18n.assessment()}</Typography>
                 </div>
                 <div className={styles.keyCell}>
                   <FontAwesomeV6Icon
                     iconName="scissors"
                     className={styles.keyIcon}
                   />
-                  {i18n.unpluggedLesson()}
+                  <Typography variant="body2">
+                    {i18n.unpluggedLesson()}
+                  </Typography>
                 </div>
               </div>
             </td>

--- a/apps/src/code-studio/components/progress/UnitCalendarGrid.jsx
+++ b/apps/src/code-studio/components/progress/UnitCalendarGrid.jsx
@@ -121,7 +121,7 @@ export default function UnitCalendarGrid({
                     }}
                     className={styles.keyIcon}
                   />
-                  <Typography variant="body2">
+                  <Typography variant="body2" component="span">
                     {i18n.instructionalLesson()}
                   </Typography>
                 </div>
@@ -133,14 +133,19 @@ export default function UnitCalendarGrid({
                     }}
                     className={styles.keyIcon}
                   />
-                  <Typography variant="body2">{i18n.assessment()}</Typography>
+                  <Typography variant="body2" component="span">
+                    {i18n.assessment()}
+                  </Typography>
                 </div>
                 <div className={styles.keyCell}>
                   <FontAwesomeV6Icon
                     iconName="scissors"
+                    style={{
+                      color: 'var(--text-neutral-primary)',
+                    }}
                     className={styles.keyIcon}
                   />
-                  <Typography variant="body2">
+                  <Typography variant="body2" component="span">
                     {i18n.unpluggedLesson()}
                   </Typography>
                 </div>

--- a/apps/src/code-studio/components/progress/UnitCalendarGrid.jsx
+++ b/apps/src/code-studio/components/progress/UnitCalendarGrid.jsx
@@ -4,7 +4,6 @@ import React from 'react';
 
 import FontAwesome from '@cdo/apps/legacySharedComponents/FontAwesome';
 import {unitCalendarLesson} from '@cdo/apps/templates/progress/unitCalendarLessonShapes';
-import color from '@cdo/apps/util/color';
 import i18n from '@cdo/locale';
 
 import UnitCalendarLessonChunk from './UnitCalendarLessonChunk';
@@ -111,7 +110,7 @@ export default function UnitCalendarGrid({
                     icon="square"
                     iconStyle="regular"
                     style={{
-                      color: color.teal,
+                      color: 'var(--text-brand-teal-primary)',
                     }}
                     className={styles.keyIcon}
                   />
@@ -121,7 +120,7 @@ export default function UnitCalendarGrid({
                   <FontAwesome
                     icon="circle-check"
                     style={{
-                      color: color.purple,
+                      color: 'var(--text-brand-purple-primary)',
                     }}
                     className={styles.keyIcon}
                   />

--- a/apps/src/code-studio/components/progress/UnitCalendarGrid.jsx
+++ b/apps/src/code-studio/components/progress/UnitCalendarGrid.jsx
@@ -1,8 +1,8 @@
+import FontAwesomeV6Icon from '@code-dot-org/component-library/fontAwesomeV6Icon';
 import _ from 'lodash';
 import PropTypes from 'prop-types';
 import React from 'react';
 
-import FontAwesome from '@cdo/apps/legacySharedComponents/FontAwesome';
 import {unitCalendarLesson} from '@cdo/apps/templates/progress/unitCalendarLessonShapes';
 import i18n from '@cdo/locale';
 
@@ -106,8 +106,8 @@ export default function UnitCalendarGrid({
             <td className={styles.scheduleColumn}>
               <div className={styles.keySection}>
                 <div className={styles.keyCell}>
-                  <FontAwesome
-                    icon="square"
+                  <FontAwesomeV6Icon
+                    iconName="square"
                     iconStyle="regular"
                     style={{
                       color: 'var(--text-brand-teal-primary)',
@@ -117,8 +117,8 @@ export default function UnitCalendarGrid({
                   {i18n.instructionalLesson()}
                 </div>
                 <div className={styles.keyCell}>
-                  <FontAwesome
-                    icon="circle-check"
+                  <FontAwesomeV6Icon
+                    iconName="circle-check"
                     style={{
                       color: 'var(--text-brand-purple-primary)',
                     }}
@@ -127,7 +127,10 @@ export default function UnitCalendarGrid({
                   {i18n.assessment()}
                 </div>
                 <div className={styles.keyCell}>
-                  <FontAwesome icon="scissors" className={styles.keyIcon} />
+                  <FontAwesomeV6Icon
+                    iconName="scissors"
+                    className={styles.keyIcon}
+                  />
                   {i18n.unpluggedLesson()}
                 </div>
               </div>

--- a/apps/src/code-studio/components/progress/UnitCalendarLessonChunk.jsx
+++ b/apps/src/code-studio/components/progress/UnitCalendarLessonChunk.jsx
@@ -1,9 +1,9 @@
+import FontAwesomeV6Icon from '@code-dot-org/component-library/fontAwesomeV6Icon';
 import PropTypes from 'prop-types';
 import React, {Component} from 'react';
 import ReactTooltip from 'react-tooltip';
 
 import fontConstants from '@cdo/apps/fontConstants';
-import FontAwesome from '@cdo/apps/legacySharedComponents/FontAwesome';
 import {unitCalendarLessonChunk} from '@cdo/apps/templates/progress/unitCalendarLessonShapes';
 
 class UnitCalendarLessonChunk extends Component {
@@ -73,8 +73,8 @@ class UnitCalendarLessonChunk extends Component {
           <div style={styles.boxContent}>
             {(assessment || unplugged) && (
               <div key={`lesson-${id}`} style={styles.iconSection}>
-                <FontAwesome
-                  icon="check-circle"
+                <FontAwesomeV6Icon
+                  iconName="check-circle"
                   style={{
                     color: isHover
                       ? 'var(--text-neutral-white-fixed)'
@@ -82,8 +82,8 @@ class UnitCalendarLessonChunk extends Component {
                     visibility: assessment ? 'visible' : 'hidden',
                   }}
                 />
-                <FontAwesome
-                  icon="scissors"
+                <FontAwesomeV6Icon
+                  iconName="scissors"
                   style={{
                     visibility: unplugged ? 'visible' : 'hidden',
                   }}

--- a/apps/src/code-studio/components/progress/UnitCalendarLessonChunk.jsx
+++ b/apps/src/code-studio/components/progress/UnitCalendarLessonChunk.jsx
@@ -1,9 +1,9 @@
 import FontAwesomeV6Icon from '@code-dot-org/component-library/fontAwesomeV6Icon';
+import {Typography} from '@mui/material';
 import PropTypes from 'prop-types';
 import React, {Component} from 'react';
 import ReactTooltip from 'react-tooltip';
 
-import fontConstants from '@cdo/apps/fontConstants';
 import {unitCalendarLessonChunk} from '@cdo/apps/templates/progress/unitCalendarLessonShapes';
 
 class UnitCalendarLessonChunk extends Component {
@@ -90,7 +90,13 @@ class UnitCalendarLessonChunk extends Component {
                 />
               </div>
             )}
-            <div style={styles.titleText}>{displayTitle}</div>
+            <Typography
+              variant="body3"
+              component="div"
+              sx={{color: 'inherit', ...styles.titleText}}
+            >
+              {displayTitle}
+            </Typography>
           </div>
         )}
         {smallChunk && (
@@ -99,7 +105,9 @@ class UnitCalendarLessonChunk extends Component {
             role="tooltip"
             effect="solid"
           >
-            <div>{title}</div>
+            <Typography variant="body3" component="div">
+              {title}
+            </Typography>
           </ReactTooltip>
         )}
       </a>
@@ -119,7 +127,6 @@ const styles = {
     alignItems: 'center',
     justifyContent: 'center',
     textAlign: 'center',
-    ...fontConstants['main-font-regular'],
     height: '100%',
   },
   assessment: {

--- a/apps/src/code-studio/components/progress/UnitCalendarLessonChunk.jsx
+++ b/apps/src/code-studio/components/progress/UnitCalendarLessonChunk.jsx
@@ -5,7 +5,6 @@ import ReactTooltip from 'react-tooltip';
 import fontConstants from '@cdo/apps/fontConstants';
 import FontAwesome from '@cdo/apps/legacySharedComponents/FontAwesome';
 import {unitCalendarLessonChunk} from '@cdo/apps/templates/progress/unitCalendarLessonShapes';
-import color from '@cdo/apps/util/color';
 
 class UnitCalendarLessonChunk extends Component {
   static propTypes = {
@@ -77,7 +76,9 @@ class UnitCalendarLessonChunk extends Component {
                 <FontAwesome
                   icon="check-circle"
                   style={{
-                    color: isHover ? color.white : color.purple,
+                    color: isHover
+                      ? 'var(--text-neutral-white-fixed)'
+                      : 'var(--text-brand-purple-primary)',
                     visibility: assessment ? 'visible' : 'hidden',
                   }}
                 />
@@ -109,7 +110,7 @@ class UnitCalendarLessonChunk extends Component {
 const styles = {
   box: {
     margin: 5,
-    color: '#333',
+    color: 'var(--text-neutral-primary)',
     textDecorationLine: 'none',
     boxSizing: 'border-box',
   },
@@ -122,20 +123,20 @@ const styles = {
     height: '100%',
   },
   assessment: {
-    border: '2px solid ' + color.purple,
+    border: '2px solid var(--borders-brand-purple-primary)',
   },
   assessmentHover: {
-    border: '2px solid ' + color.purple,
-    backgroundColor: color.purple,
-    color: 'white',
+    border: '2px solid var(--borders-brand-purple-primary)',
+    backgroundColor: 'var(--background-brand-purple-primary)',
+    color: 'var(--text-neutral-white-fixed)',
   },
   instructional: {
-    border: '2px solid ' + color.teal,
+    border: '2px solid var(--borders-brand-teal-primary)',
   },
   instructionalHover: {
-    border: '2px solid ' + color.teal,
-    backgroundColor: color.teal,
-    color: color.white,
+    border: '2px solid var(--borders-brand-teal-primary)',
+    backgroundColor: 'var(--background-brand-teal-primary)',
+    color: 'var(--text-neutral-white-fixed)',
   },
   isNotStart: {
     borderLeftStyle: 'dashed',

--- a/apps/src/code-studio/components/progress/unit-calendar.module.scss
+++ b/apps/src/code-studio/components/progress/unit-calendar.module.scss
@@ -1,19 +1,17 @@
-@import 'color';
-
 .weekColumn {
   width: 100px;
   min-width: 100px;
-  background-color: $purple;
-  color: white;
+  background-color: var(--background-brand-purple-primary);
+  color: var(--text-neutral-white-fixed);
   text-align: center;
-  border: 1px solid + $purple;
+  border: 1px solid var(--borders-brand-purple-primary);
   border-collapse: collapse;
   font-weight: bold;
   min-height: 50px;
 }
 
 .scheduleColumn {
-  border: 1px solid $purple;
+  border: 1px solid var(--borders-brand-purple-primary);
   border-collapse: collapse;
   display: flex;
   min-height: 50px;
@@ -23,11 +21,11 @@
 .table {
   border-collapse: collapse;
   width: 100%;
-  border: 1px solid $purple;
+  border: 1px solid var(--borders-brand-purple-primary);
 }
 
 .key {
-  border: 1px solid $purple;
+  border: 1px solid var(--borders-brand-purple-primary);
   border-collapse: collapse;
   width: 100%;
   margin-top: 20px;
@@ -42,6 +40,7 @@
   width: 90%;
   align-items: center;
   font-size: 15px;
+  color: var(--text-neutral-primary);
 }
 
 .keyCell {

--- a/apps/src/code-studio/components/progress/unit-calendar.module.scss
+++ b/apps/src/code-studio/components/progress/unit-calendar.module.scss
@@ -6,7 +6,6 @@
   text-align: center;
   border: 1px solid var(--borders-brand-purple-primary);
   border-collapse: collapse;
-  font-weight: bold;
   min-height: 50px;
 }
 
@@ -39,8 +38,6 @@
   display: flex;
   width: 90%;
   align-items: center;
-  font-size: 15px;
-  color: var(--text-neutral-primary);
 }
 
 .keyCell {

--- a/apps/src/templates/teacherNavigation/UnitCalendar.tsx
+++ b/apps/src/templates/teacherNavigation/UnitCalendar.tsx
@@ -187,6 +187,7 @@ const UnitCalendar: React.FC = () => {
               <div className={styles.calendarDropdown}>
                 <SimpleDropdown
                   name="minutesPerWeek"
+                  className={styles.calendarMinutesPerWeekDropdown}
                   onChange={event => handleDropdownChange(event.target.value)}
                   items={weeklyMinutesOptions}
                   selectedValue={weeklyInstructionalMinutes}

--- a/apps/src/templates/teacherNavigation/UnitCalendar.tsx
+++ b/apps/src/templates/teacherNavigation/UnitCalendar.tsx
@@ -1,5 +1,4 @@
 import {SimpleDropdown} from '@code-dot-org/component-library/dropdown';
-import {Typography} from '@mui/material';
 import React, {useState, useEffect} from 'react';
 import {useSelector} from 'react-redux';
 
@@ -178,24 +177,14 @@ const UnitCalendar: React.FC = () => {
           <div>
             <div className={styles.calendarDropdowns}>
               <div className={styles.calendarDropdown}>
-                <Typography
-                  variant="label1"
-                  className={styles.calendarDropdownDescription}
-                >
-                  {i18n.lessonsFor()}
-                </Typography>
                 <UnitSelectorV2
                   className={styles.calendarUnitDropdown}
                   filterToSelectedCourse={true}
+                  labelText={i18n.lessonsFor()}
+                  isLabelVisible
                 />
               </div>
               <div className={styles.calendarDropdown}>
-                <Typography
-                  variant="label1"
-                  className={styles.calendarDropdownDescription}
-                >
-                  {i18n.instructionalMinutesPerWeek()}
-                </Typography>
                 <SimpleDropdown
                   name="minutesPerWeek"
                   onChange={event => handleDropdownChange(event.target.value)}
@@ -203,8 +192,7 @@ const UnitCalendar: React.FC = () => {
                   selectedValue={weeklyInstructionalMinutes}
                   size="s"
                   dropdownTextThickness="thin"
-                  labelText="minutes per week dropdown"
-                  isLabelVisible={false}
+                  labelText={i18n.instructionalMinutesPerWeek()}
                   color="gray"
                 />
               </div>

--- a/apps/src/templates/teacherNavigation/UnitCalendar.tsx
+++ b/apps/src/templates/teacherNavigation/UnitCalendar.tsx
@@ -1,4 +1,5 @@
 import {SimpleDropdown} from '@code-dot-org/component-library/dropdown';
+import {Typography} from '@mui/material';
 import React, {useState, useEffect} from 'react';
 import {useSelector} from 'react-redux';
 
@@ -177,18 +178,24 @@ const UnitCalendar: React.FC = () => {
           <div>
             <div className={styles.calendarDropdowns}>
               <div className={styles.calendarDropdown}>
-                <div className={styles.calendarDropdownDescription}>
+                <Typography
+                  variant="label1"
+                  className={styles.calendarDropdownDescription}
+                >
                   {i18n.lessonsFor()}
-                </div>
+                </Typography>
                 <UnitSelectorV2
                   className={styles.calendarUnitDropdown}
                   filterToSelectedCourse={true}
                 />
               </div>
               <div className={styles.calendarDropdown}>
-                <div className={styles.calendarDropdownDescription}>
+                <Typography
+                  variant="label1"
+                  className={styles.calendarDropdownDescription}
+                >
                   {i18n.instructionalMinutesPerWeek()}
-                </div>
+                </Typography>
                 <SimpleDropdown
                   name="minutesPerWeek"
                   onChange={event => handleDropdownChange(event.target.value)}

--- a/apps/src/templates/teacherNavigation/teacher-navigation.module.scss
+++ b/apps/src/templates/teacherNavigation/teacher-navigation.module.scss
@@ -182,10 +182,6 @@ h2.skeletonHeaderSectionName {
   align-items: center;
 }
 
-.calendarDropdownDescription {
-  margin-right: 10px;
-}
-
 .emptyClassroomDiv {
   margin: 24px 64px 82px 64px;
   text-align: center;

--- a/apps/src/templates/teacherNavigation/teacher-navigation.module.scss
+++ b/apps/src/templates/teacherNavigation/teacher-navigation.module.scss
@@ -183,9 +183,7 @@ h2.skeletonHeaderSectionName {
 }
 
 .calendarDropdownDescription {
-  font-weight: bold;
   margin-right: 10px;
-  color: var(--text-neutral-primary);
 }
 
 .emptyClassroomDiv {

--- a/apps/src/templates/teacherNavigation/teacher-navigation.module.scss
+++ b/apps/src/templates/teacherNavigation/teacher-navigation.module.scss
@@ -182,6 +182,12 @@ h2.skeletonHeaderSectionName {
   align-items: center;
 }
 
+.calendarMinutesPerWeekDropdown {
+  > div {
+    width: 100%;
+  }
+}
+
 .emptyClassroomDiv {
   margin: 24px 64px 82px 64px;
   text-align: center;

--- a/apps/src/templates/teacherNavigation/teacher-navigation.module.scss
+++ b/apps/src/templates/teacherNavigation/teacher-navigation.module.scss
@@ -185,6 +185,7 @@ h2.skeletonHeaderSectionName {
 .calendarDropdownDescription {
   font-weight: bold;
   margin-right: 10px;
+  color: var(--text-neutral-primary);
 }
 
 .emptyClassroomDiv {

--- a/apps/test/unit/code-studio/components/progress/UnitCalendarLessonChunkTest.jsx
+++ b/apps/test/unit/code-studio/components/progress/UnitCalendarLessonChunkTest.jsx
@@ -1,3 +1,4 @@
+import FontAwesomeV6Icon from '@code-dot-org/component-library/fontAwesomeV6Icon';
 import {shallow} from 'enzyme'; // eslint-disable-line no-restricted-imports
 import React from 'react';
 import ReactTooltip from 'react-tooltip';
@@ -198,9 +199,9 @@ describe('UnitCalendarLessonChunk', () => {
       />
     );
 
-    expect(wrapper.find('FontAwesome').at(0).prop('style')['visibility']).toBe(
-      'hidden'
-    );
+    expect(
+      wrapper.find(FontAwesomeV6Icon).at(0).prop('style')['visibility']
+    ).toBe('hidden');
   });
 
   it('hides unplugged icon if not unplugged', () => {
@@ -216,8 +217,8 @@ describe('UnitCalendarLessonChunk', () => {
       />
     );
 
-    expect(wrapper.find('FontAwesome').at(1).prop('style')['visibility']).toBe(
-      'hidden'
-    );
+    expect(
+      wrapper.find(FontAwesomeV6Icon).at(1).prop('style')['visibility']
+    ).toBe('hidden');
   });
 });

--- a/apps/test/unit/code-studio/components/progress/UnitCalendarLessonChunkTest.jsx
+++ b/apps/test/unit/code-studio/components/progress/UnitCalendarLessonChunkTest.jsx
@@ -3,7 +3,6 @@ import React from 'react';
 import ReactTooltip from 'react-tooltip';
 
 import UnitCalendarLessonChunk from '@cdo/apps/code-studio/components/progress/UnitCalendarLessonChunk';
-import color from '@cdo/apps/util/color';
 
 const sampleLessonChunk = {
   id: 1,
@@ -33,9 +32,11 @@ describe('UnitCalendarLessonChunk', () => {
     );
 
     expect(wrapper.find('a').prop('style')['border']).toBe(
-      '2px solid ' + color.purple
+      '2px solid var(--borders-brand-purple-primary)'
     );
-    expect(wrapper.find('a').prop('style')['color']).toBe('#333');
+    expect(wrapper.find('a').prop('style')['color']).toBe(
+      'var(--text-neutral-primary)'
+    );
   });
 
   it('is purple background with white text when is assessment and being hovered', () => {
@@ -52,12 +53,14 @@ describe('UnitCalendarLessonChunk', () => {
     );
 
     expect(wrapper.find('a').prop('style')['border']).toBe(
-      '2px solid ' + color.purple
+      '2px solid var(--borders-brand-purple-primary)'
     );
     expect(wrapper.find('a').prop('style')['backgroundColor']).toBe(
-      color.purple
+      'var(--background-brand-purple-primary)'
     );
-    expect(wrapper.find('a').prop('style')['color']).toBe('white');
+    expect(wrapper.find('a').prop('style')['color']).toBe(
+      'var(--text-neutral-white-fixed)'
+    );
   });
 
   it('is teal border with grey text when is assessment', () => {
@@ -74,9 +77,11 @@ describe('UnitCalendarLessonChunk', () => {
     );
 
     expect(wrapper.find('a').prop('style')['border']).toBe(
-      '2px solid ' + color.teal
+      '2px solid var(--borders-brand-teal-primary)'
     );
-    expect(wrapper.find('a').prop('style')['color']).toBe('#333');
+    expect(wrapper.find('a').prop('style')['color']).toBe(
+      'var(--text-neutral-primary)'
+    );
   });
 
   it('is teal background with white text when is assessment and being hovered', () => {
@@ -93,10 +98,14 @@ describe('UnitCalendarLessonChunk', () => {
     );
 
     expect(wrapper.find('a').prop('style')['border']).toBe(
-      '2px solid ' + color.teal
+      '2px solid var(--borders-brand-teal-primary)'
     );
-    expect(wrapper.find('a').prop('style')['backgroundColor']).toBe(color.teal);
-    expect(wrapper.find('a').prop('style')['color']).toBe(color.white);
+    expect(wrapper.find('a').prop('style')['backgroundColor']).toBe(
+      'var(--background-brand-teal-primary)'
+    );
+    expect(wrapper.find('a').prop('style')['color']).toBe(
+      'var(--text-neutral-white-fixed)'
+    );
   });
 
   it('has dashed left border when not isStart', () => {

--- a/apps/test/unit/code-studio/components/progress/UnitCalendarLessonChunkTest.jsx
+++ b/apps/test/unit/code-studio/components/progress/UnitCalendarLessonChunkTest.jsx
@@ -1,4 +1,5 @@
 import FontAwesomeV6Icon from '@code-dot-org/component-library/fontAwesomeV6Icon';
+import {Typography} from '@mui/material';
 import {shallow} from 'enzyme'; // eslint-disable-line no-restricted-imports
 import React from 'react';
 import ReactTooltip from 'react-tooltip';
@@ -155,7 +156,11 @@ describe('UnitCalendarLessonChunk', () => {
     );
 
     expect(
-      wrapper.containsMatchingElement(<div>{sampleLessonChunk.title}</div>)
+      wrapper.containsMatchingElement(
+        <Typography variant="body3" component="div">
+          {sampleLessonChunk.title}
+        </Typography>
+      )
     ).toBe(false);
   });
 
@@ -174,13 +179,17 @@ describe('UnitCalendarLessonChunk', () => {
 
     expect(
       wrapper.containsMatchingElement(
-        <div>{sampleLessonChunk.lessonNumber}</div>
+        <Typography variant="body3" component="div">
+          {sampleLessonChunk.lessonNumber}
+        </Typography>
       )
     ).toBe(true);
     expect(
       wrapper.containsMatchingElement(
         <ReactTooltip>
-          <div>{sampleLessonChunk.title}</div>
+          <Typography variant="body3" component="div">
+            {sampleLessonChunk.title}
+          </Typography>
         </ReactTooltip>
       )
     ).toBe(true);


### PR DESCRIPTION
## Summary
- Migrate the teacher-dashboard Calendar page (`UnitCalendar` + the shared `UnitCalendarGrid` / `UnitCalendarLessonChunk`, which also back `UnitCalendarDialog`) to the design system.
- Replace legacy color constants (`$purple`, `color.purple`, `color.teal`, `color.white`, `#333`) with semantic tokens from `colors.css`, picking the family per CSS property (`background-*` / `borders-*` / `text-*`).
- Swap the deprecated `@cdo/apps/legacySharedComponents/FontAwesome` for DSCO's `FontAwesomeV6Icon` on every icon in these components.
- Migrate plain text to MUI `Typography`: `label1` for the week headers and dropdown labels (via each dropdown's built-in `labelText` prop), `body2` for the Key row labels, `body3` for per-lesson title/tooltip text. Drop now-redundant CSS (`font-weight: bold`, `font-size: 15px`, `fontConstants['main-font-regular']`, the orphaned `.calendarDropdownDescription` class).

Before:
<img width="3456" height="2608" alt="image" src="https://github.com/user-attachments/assets/b5b285a5-9d3c-43b0-a4e9-db1e10ed5fcc" />

After:
<img width="3456" height="2514" alt="image" src="https://github.com/user-attachments/assets/4b0d4086-0e2c-49d9-a349-e83b81f21460" />
<img width="3456" height="2514" alt="image" src="https://github.com/user-attachments/assets/0f608bac-dc33-4a92-8ca2-66f4996ea154" />


## Out of scope
Per our convention for page-level DSCO migrations, buttons and dropdowns are not re-themed here (separate initiative). The two dropdowns on this page are already DSCO (`SimpleDropdown` / `UnitSelectorV2`); only their `labelText` was moved inline.

## Test plan
- [x] `yarn test:unit test/unit/code-studio/components/progress/UnitCalendarLessonChunkTest.jsx test/unit/code-studio/components/progress/UnitCalendarGridTest.jsx test/unit/code-studio/components/progress/UnitCalendarDialogTest.jsx test/unit/templates/teacherNavigation/UnitCalendarTest.tsx` — 21/21 pass
- [x] `yarn run typecheck` clean
- [x] `./tools/hooks/pre-commit` clean
- [x] Visual check at `/teacher_dashboard/sections/:id/calendar` under `data-brand="codeai"` — every surface that was previously teal/purple/dark should now go pink (audit for any remaining non-semantic colors).
- [x] Visual check on staging with no `data-brand` override — look identical to pre-migration.
- [x] Confirm hover states on lesson chunks (background + text invert to purple/teal with white text).

🤖 Generated with [Claude Code](https://claude.com/claude-code)