### PR TITLE
Sketch2: add start and exemplar modes

### DIFF
--- a/apps/src/sketchlab/reactFlow/ReactFlowSketchLabView.tsx
+++ b/apps/src/sketchlab/reactFlow/ReactFlowSketchLabView.tsx
@@ -5,6 +5,7 @@ import {ReactFlowProvider} from '@xyflow/react';
 import '@xyflow/react/dist/style.css';
 import React, {useCallback, useEffect, useState} from 'react';
 
+import useLevelEditMode from '@cdo/apps/lab2/hooks/useLevelEditMode';
 import useThemeSetting from '@cdo/apps/lab2/hooks/useThemeSetting';
 import {useVerticalLayout} from '@cdo/apps/lab2/hooks/useVerticalLayout';
 import {isReadOnlyWorkspace} from '@cdo/apps/lab2/redux/lab2ReduxSelectors';
@@ -85,6 +86,20 @@ function ReactFlowSketchLabViewInner({
 
   const teacherViewingStudent = Boolean(
     useAppSelector(state => state.progress.viewAsUserId)
+  );
+
+  const WorkspaceAlert = useLevelEditMode<LevelProperties>(
+    levelProperties.id,
+    !!levelProperties.projectTemplateLevelName,
+    useCallback(
+      mode => {
+        return {
+          [mode === 'start' ? 'start_sources' : 'exemplar_sources']:
+            currentSources,
+        };
+      },
+      [currentSources]
+    )
   );
 
   const {
@@ -175,6 +190,7 @@ function ReactFlowSketchLabViewInner({
             colorMode={colorMode}
             readOnly={readonlyWorkspace}
           />
+          {WorkspaceAlert}
         </PanelContainer>
       </div>
     </div>

--- a/dashboard/config/levels/custom/sketchlab/allthethings sketchlab 5.level
+++ b/dashboard/config/levels/custom/sketchlab/allthethings sketchlab 5.level
@@ -96,9 +96,47 @@
           "zoom": 2
         }
       }
+    },
+    "exemplar_sources": {
+      "source": {
+        "nodes": [
+          {
+            "id": "7669b7ac-6c88-48e4-82b8-adc51255a92c",
+            "type": "shape",
+            "position": {
+              "x": 909,
+              "y": 465.5
+            },
+            "data": {
+              "shapeType": "circle",
+              "label": "here's an exemplar!"
+            },
+            "style": {
+              "width": 160,
+              "height": 120
+            },
+            "measured": {
+              "width": 160,
+              "height": 120
+            },
+            "selected": true,
+            "domAttributes": {
+              "tabIndex": 0
+            }
+          }
+        ],
+        "edges": [
+
+        ],
+        "viewport": {
+          "x": -843.5,
+          "y": -502,
+          "zoom": 2
+        }
+      }
     }
   },
   "published": true,
-  "audit_log": "[{\"changed_at\":\"2026-04-21T15:01:15.829-07:00\",\"changed\":[\"cloned from \\\"allthethings sketchlab 1\\\"\"],\"cloned_from\":\"allthethings sketchlab 1\"},{\"changed_at\":\"2026-04-21 15:01:55 -0700\",\"changed\":[\"long_instructions\"],\"changed_by_id\":2,\"changed_by_email\":\"molly+levelbuilder@code.org\"},{\"changed_at\":\"2026-04-21 15:07:12 -0700\",\"changed\":[],\"changed_by_id\":2,\"changed_by_email\":\"molly+levelbuilder@code.org\"}]"
+  "audit_log": "[{\"changed_at\":\"2026-04-21T15:01:15.829-07:00\",\"changed\":[\"cloned from \\\"allthethings sketchlab 1\\\"\"],\"cloned_from\":\"allthethings sketchlab 1\"},{\"changed_at\":\"2026-04-21 15:01:55 -0700\",\"changed\":[\"long_instructions\"],\"changed_by_id\":2,\"changed_by_email\":\"molly+levelbuilder@code.org\"},{\"changed_at\":\"2026-04-21 15:07:12 -0700\",\"changed\":[],\"changed_by_id\":2,\"changed_by_email\":\"molly+levelbuilder@code.org\"},{\"changed_at\":\"2026-04-21 15:12:54 -0700\",\"changed\":[],\"changed_by_id\":2,\"changed_by_email\":\"molly+levelbuilder@code.org\"}]"
 }]]></config>
 </Sketchlab>

--- a/dashboard/config/levels/custom/sketchlab/allthethings sketchlab 5.level
+++ b/dashboard/config/levels/custom/sketchlab/allthethings sketchlab 5.level
@@ -1,0 +1,104 @@
+<Sketchlab>
+  <config><![CDATA[{
+  "game_id": 75,
+  "created_at": "2026-04-21T22:01:15.000Z",
+  "level_num": "custom",
+  "user_id": 1,
+  "properties": {
+    "encrypted": "false",
+    "long_instructions": "This is an allthethings sketch lab level that uses the React Flow version of start sources.",
+    "start_sources": {
+      "source": {
+        "nodes": [
+          {
+            "id": "c3320c9f-6810-463d-9206-0579cda04bf1",
+            "type": "shape",
+            "position": {
+              "x": 533,
+              "y": 465.5
+            },
+            "data": {
+              "shapeType": "rectangle",
+              "label": "here are some start sources!"
+            },
+            "style": {
+              "width": 160,
+              "height": 120
+            },
+            "measured": {
+              "width": 160,
+              "height": 120
+            },
+            "selected": true,
+            "domAttributes": {
+              "tabIndex": 0
+            }
+          },
+          {
+            "id": "27e8f16c-3cf2-42bd-839a-f694f73ab815",
+            "type": "shape",
+            "position": {
+              "x": 373.25,
+              "y": 334.25
+            },
+            "data": {
+              "shapeType": "circle",
+              "label": ""
+            },
+            "style": {
+              "width": 160,
+              "height": 120
+            },
+            "measured": {
+              "width": 160,
+              "height": 120
+            },
+            "dragging": false,
+            "selected": false
+          },
+          {
+            "id": "1a62511b-1009-4782-a549-d8a6c9f2ed5f",
+            "type": "shape",
+            "position": {
+              "x": 730.75,
+              "y": 628.75
+            },
+            "data": {
+              "shapeType": "triangle",
+              "label": ""
+            },
+            "style": {
+              "width": 160,
+              "height": 120
+            },
+            "measured": {
+              "width": 160,
+              "height": 120
+            },
+            "dragging": false
+          }
+        ],
+        "edges": [
+          {
+            "source": "27e8f16c-3cf2-42bd-839a-f694f73ab815",
+            "sourceHandle": "right-source",
+            "target": "c3320c9f-6810-463d-9206-0579cda04bf1",
+            "targetHandle": "top-target",
+            "markerEnd": {
+              "type": "arrowclosed"
+            },
+            "id": "xy-edge__27e8f16c-3cf2-42bd-839a-f694f73ab815right-source-c3320c9f-6810-463d-9206-0579cda04bf1top-target"
+          }
+        ],
+        "viewport": {
+          "x": -467.5,
+          "y": -502,
+          "zoom": 2
+        }
+      }
+    }
+  },
+  "published": true,
+  "audit_log": "[{\"changed_at\":\"2026-04-21T15:01:15.829-07:00\",\"changed\":[\"cloned from \\\"allthethings sketchlab 1\\\"\"],\"cloned_from\":\"allthethings sketchlab 1\"},{\"changed_at\":\"2026-04-21 15:01:55 -0700\",\"changed\":[\"long_instructions\"],\"changed_by_id\":2,\"changed_by_email\":\"molly+levelbuilder@code.org\"},{\"changed_at\":\"2026-04-21 15:07:12 -0700\",\"changed\":[],\"changed_by_id\":2,\"changed_by_email\":\"molly+levelbuilder@code.org\"}]"
+}]]></config>
+</Sketchlab>

--- a/dashboard/config/scripts_json/allthethings.script_json
+++ b/dashboard/config/scripts_json/allthethings.script_json
@@ -12,7 +12,7 @@
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2026-01-05 19:21:09 UTC",
+    "serialized_at": "2026-04-21 22:06:04 UTC",
     "hide_within_course": false,
     "published_state": null,
     "instruction_type": null,
@@ -2675,6 +2675,9 @@
       "activity_section_position": 10,
       "assessment": false,
       "properties": {
+        "level_keys": [
+          "Standalone_Artist_9"
+        ]
       },
       "bonus": false,
       "seeding_key": {
@@ -3080,6 +3083,9 @@
       "activity_section_position": 2,
       "assessment": false,
       "properties": {
+        "level_keys": [
+          "flappy_11"
+        ]
       },
       "bonus": false,
       "seeding_key": {
@@ -3125,6 +3131,9 @@
       "activity_section_position": 2,
       "assessment": false,
       "properties": {
+        "level_keys": [
+          "bounce_12"
+        ]
       },
       "bonus": false,
       "seeding_key": {
@@ -4634,6 +4643,9 @@
       "activity_section_position": 4,
       "assessment": false,
       "properties": {
+        "level_keys": [
+          "MC_HOC_2017_FP20x20"
+        ]
       },
       "bonus": false,
       "seeding_key": {
@@ -4655,6 +4667,9 @@
       "activity_section_position": 5,
       "assessment": false,
       "properties": {
+        "level_keys": [
+          "Overworld Free Play 20x20"
+        ]
       },
       "bonus": false,
       "seeding_key": {
@@ -4676,6 +4691,9 @@
       "activity_section_position": 6,
       "assessment": false,
       "properties": {
+        "level_keys": [
+          "MC HOC 2016 Level 10"
+        ]
       },
       "bonus": false,
       "seeding_key": {
@@ -7838,6 +7856,27 @@
     },
     {
       "chapter": 232,
+      "position": 5,
+      "activity_section_position": 5,
+      "assessment": false,
+      "properties": {
+      },
+      "bonus": false,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "allthethings sketchlab 5"
+        ],
+        "lesson.key": "lesson-57",
+        "lesson_group.key": "",
+        "script.name": "allthethings",
+        "activity_section.key": "b0e19c6d-9bd3-4227-93b2-397e925b9139"
+      },
+      "level_keys": [
+        "allthethings sketchlab 5"
+      ]
+    },
+    {
+      "chapter": 233,
       "position": 1,
       "activity_section_position": 1,
       "assessment": false,
@@ -10762,6 +10801,18 @@
     },
     {
       "seeding_key": {
+        "level.key": "allthethings sketchlab 5",
+        "script_level.level_keys": [
+          "allthethings sketchlab 5"
+        ],
+        "lesson.key": "lesson-57",
+        "lesson_group.key": "",
+        "script.name": "allthethings",
+        "activity_section.key": "b0e19c6d-9bd3-4227-93b2-397e925b9139"
+      }
+    },
+    {
+      "seeding_key": {
         "level.key": "csf_safety_in_my_online_neighborhood2022_2025",
         "script_level.level_keys": [
           "csf_safety_in_my_online_neighborhood2022_2025"
@@ -10801,6 +10852,9 @@
 
   ],
   "lessons_opportunity_standards": [
+
+  ],
+  "jit_pl_concepts_lessons": [
 
   ],
   "rubrics": [


### PR DESCRIPTION
This enables start and exemplar modes when the `sketch2=true` flag is on. This was super easy thanks to an existing lab2 hook 🎉 The vast majority of the lines of this PR are adding a new level using sketch2 start sources and a sketch2 exemplar.

## Screenshots
### Start Mode
<img width="1710" height="985" alt="Screenshot 2026-04-21 at 3 16 06 PM" src="https://github.com/user-attachments/assets/6fa8d4dc-0791-4aac-9ce6-e8a6337ef0ce" />

### Exemplar Mode
<img width="1710" height="985" alt="Screenshot 2026-04-21 at 3 15 43 PM" src="https://github.com/user-attachments/assets/2abfdd89-3634-4c28-9ed1-a79c64844962" />



## Links

- Jira: [AFL-580](https://codedotorg.atlassian.net/browse/AFL-580), [AFL-579](https://codedotorg.atlassian.net/browse/AFL-579)

## Testing story
Tested locally.



## Deployment notes
This will cause some eyes diffs thanks to a new allthethings level.
