### PR TITLE
Add default mime type for webp

### DIFF
--- a/dashboard/legacy/middleware/files_api.rb
+++ b/dashboard/legacy/middleware/files_api.rb
@@ -238,10 +238,12 @@ class FilesApi < Sinatra::Base
     not_found if type.empty?
     unsupported_media_type unless buckets.allowed_file_type?(type)
     type_params = {}
-    # Sinatra does not have a content type for markdown files, so we
-    # add it here.
+    # Sinatra does not have content types for all file extensions we
+    # serve, so we add missing ones here.
     if type == '.md'
       type_params = {default: 'text/markdown'}
+    elsif type == '.webp'
+      type_params = {default: 'image/webp'}
     end
     content_type(type, type_params)
 


### PR DESCRIPTION
<!--
  Summary of the change: background, motivation, and context.
  Include screenshots, videos, or before/after comparisons for UI changes.
-->
After https://github.com/code-dot-org/code-dot-org/pull/72228 was merged to `prod`, we started to see [this HoneyBadger error](https://app.honeybadger.io/projects/3240/faults/129812963) - Sinatra does not know the mime type for a `.webp` file. Similar to when `md` files were accepted in Backpack https://github.com/code-dot-org/code-dot-org/pull/69148, we now provide a `default` parameter for `webp` file type in the `content_type` method.



## Links
<!-- Jira tickets, design docs, Slack threads, related PRs, etc. -->

- Jira: https://codedotorg.atlassian.net/browse/SL-1683

## Testing story
<!-- How was this tested? Manual steps, adhoc links, automated tests, or why testing isn't needed. -->



## Deployment notes
<!-- Delete this section if it's a standard merge-and-deploy.
     Otherwise: migrations, feature flags, coordination, caching impacts, etc. -->



## Privacy and security
<!-- Delete this section if there is no privacy/security impact.
     Otherwise: new PII, auth changes, API surface changes, etc. -->

