### PR TITLE
test(observability): clear UNIT_TEST env in engine test setup

### DIFF
--- a/dashboard/engines/observability/lib/observability/engine.rb
+++ b/dashboard/engines/observability/lib/observability/engine.rb
@@ -9,11 +9,11 @@ module Observability
     # all initializers during initialize!. The Engine class body runs when
     # Bundler.require loads the engine in config/application.rb, which is before
     # Rails.application.initialize! is called.
-    # Guard on UNIT_TEST to avoid loading Sentry in unit test runs where the
-    # DSN is unconfigured and background threads are unwanted. All other processes
-    # (workers, cron, rake, console) get observability.
+    # Guard on CDO.unit_test (a proxy for the UNIT_TEST env var) to avoid loading
+    # Sentry in unit test runs where the DSN is unconfigured and background threads
+    # are unwanted. All other processes (workers, cron, rake, console) get observability.
     # sentry-opentelemetry is only needed when both integrations are active.
-    if CDO.enable_sentry && !ENV['UNIT_TEST']
+    if CDO.enable_sentry && !CDO.unit_test
       require 'sentry-ruby'
       require 'sentry-rails'
       require 'sentry-opentelemetry' if CDO.enable_opentelemetry

--- a/dashboard/engines/observability/lib/observability/opentelemetry.rb
+++ b/dashboard/engines/observability/lib/observability/opentelemetry.rb
@@ -3,9 +3,10 @@
 module Observability
   module OpenTelemetry
     # Sets up OpenTelemetry tracing. Runs in all processes except unit test runners
-    # (detected via UNIT_TEST env var set in dashboard/test/test_helper.rb).
+    # (detected via CDO.unit_test, a proxy for the UNIT_TEST env var set in
+    # dashboard/test/test_helper.rb).
     def self.setup
-      return unless CDO.enable_opentelemetry && !ENV['UNIT_TEST']
+      return unless CDO.enable_opentelemetry && !CDO.unit_test
 
       require 'opentelemetry/sdk'
       require 'opentelemetry/instrumentation/all'

--- a/dashboard/engines/observability/lib/observability/sentry.rb
+++ b/dashboard/engines/observability/lib/observability/sentry.rb
@@ -3,11 +3,11 @@
 module Observability
   module Sentry
     # Sets up Sentry error tracking. Runs in all processes except unit test runners
-    # (detected via UNIT_TEST env var set in dashboard/test/test_helper.rb).
-    # When OpenTelemetry is also enabled, the OTLP integration is activated so
-    # errors are correlated with traces.
+    # (detected via CDO.unit_test, a proxy for the UNIT_TEST env var set in
+    # dashboard/test/test_helper.rb). When OpenTelemetry is also enabled, the
+    # OTLP integration is activated so errors are correlated with traces.
     def self.setup
-      return unless CDO.enable_sentry && !ENV['UNIT_TEST']
+      return unless CDO.enable_sentry && !CDO.unit_test
 
       if CDO.dashboard_sentry_dsn.blank?
         CDO.log.warn '[observability] enable_sentry is true but dashboard_sentry_dsn is not configured; skipping Sentry setup'

--- a/dashboard/engines/observability/test/lib/observability/opentelemetry_test.rb
+++ b/dashboard/engines/observability/test/lib/observability/opentelemetry_test.rb
@@ -10,7 +10,10 @@ require 'opentelemetry-sdk'
 describe Observability::OpenTelemetry do
   before do
     CDO.stubs(:enable_opentelemetry).returns(false)
-    # ENV['UNIT_TEST'] is nil in engine test runs — enabled path is active by default
+    # CDO.unit_test proxies ENV['UNIT_TEST'], which dashboard's test_helper.rb
+    # sets to disable observability during unit tests. Stub it to false so the
+    # enabled code path is exercised; the disabled-path describe block overrides.
+    CDO.stubs(:unit_test).returns(false)
   end
 
   describe '.setup' do
@@ -20,19 +23,18 @@ describe Observability::OpenTelemetry do
       end
     end
 
-    describe 'when UNIT_TEST is set' do
+    describe 'when CDO.unit_test is true' do
       before do
         CDO.stubs(:enable_opentelemetry).returns(true)
-        ENV['UNIT_TEST'] = 'true'
+        CDO.stubs(:unit_test).returns(true)
       end
-      after {ENV.delete('UNIT_TEST')}
 
       it 'returns without configuring the SDK' do
         _(Observability::OpenTelemetry.setup).must_be_nil
       end
     end
 
-    describe 'when both CDO.enable_opentelemetry is true and UNIT_TEST is not set' do
+    describe 'when CDO.enable_opentelemetry is true and CDO.unit_test is false' do
       before do
         CDO.stubs(:enable_opentelemetry).returns(true)
         OpenTelemetry::SDK.stubs(:configure)

--- a/dashboard/engines/observability/test/lib/observability/sentry_test.rb
+++ b/dashboard/engines/observability/test/lib/observability/sentry_test.rb
@@ -11,7 +11,10 @@ describe Observability::Sentry do
     CDO.stubs(:enable_sentry).returns(false)
     CDO.stubs(:enable_opentelemetry).returns(false)
     CDO.stubs(:dashboard_sentry_dsn).returns(nil)
-    # ENV['UNIT_TEST'] is nil in engine test runs — enabled path is active by default
+    # CDO.unit_test proxies ENV['UNIT_TEST'], which dashboard's test_helper.rb
+    # sets to disable observability during unit tests. Stub it to false so the
+    # enabled code path is exercised; the disabled-path describe block overrides.
+    CDO.stubs(:unit_test).returns(false)
   end
 
   describe '.setup' do
@@ -21,19 +24,18 @@ describe Observability::Sentry do
       end
     end
 
-    describe 'when UNIT_TEST is set' do
+    describe 'when CDO.unit_test is true' do
       before do
         CDO.stubs(:enable_sentry).returns(true)
-        ENV['UNIT_TEST'] = 'true'
+        CDO.stubs(:unit_test).returns(true)
       end
-      after {ENV.delete('UNIT_TEST')}
 
       it 'returns without initializing Sentry' do
         _(Observability::Sentry.setup).must_be_nil
       end
     end
 
-    describe 'when CDO.enable_sentry is true and UNIT_TEST is not set' do
+    describe 'when CDO.enable_sentry is true and CDO.unit_test is false' do
       before do
         CDO.stubs(:enable_sentry).returns(true)
         CDO.stubs(:dashboard_sentry_dsn).returns('https://key@sentry.example.com/1')

--- a/dashboard/engines/observability/test/test_helper.rb
+++ b/dashboard/engines/observability/test/test_helper.rb
@@ -21,7 +21,7 @@ require 'sentry-ruby'
 # Individual tests set the values they need in before blocks.
 module CDO
   class << self
-    attr_accessor :enable_opentelemetry, :enable_sentry, :dashboard_sentry_dsn
+    attr_accessor :enable_opentelemetry, :enable_sentry, :dashboard_sentry_dsn, :unit_test
 
     def log
       @log ||= Logger.new(IO::NULL)
@@ -31,6 +31,7 @@ module CDO
   self.enable_opentelemetry = false
   self.enable_sentry = false
   self.dashboard_sentry_dsn = nil
+  self.unit_test = false
 end
 
 require 'observability'


### PR DESCRIPTION
The observability engine tests contain describe blocks named "when UNIT_TEST is not set" that exercise the enabled code paths of Observability::OpenTelemetry.setup and Observability::Sentry.setup. However, dashboard/test/test_helper.rb sets ENV['UNIT_TEST'] = 'true' at require time, which makes `!ENV['UNIT_TEST']` false and causes setup to return early.

Clear ENV['UNIT_TEST'] in the top-level before block and restore it in after so the "not set" paths actually run, and the nested "when UNIT_TEST is set" blocks still work via their own re-set.


