### PR TITLE
Tutor Cleanup: Remove AI_TUTOR_ACCESS from UserPermission model

### DIFF
--- a/dashboard/app/models/user_permission.rb
+++ b/dashboard/app/models/user_permission.rb
@@ -44,9 +44,6 @@ class UserPermission < ApplicationRecord
     PROGRAM_MANAGER = 'program_manager'.freeze,
     # Grants ability to be the instructor of any course no matter instructor_audience
     UNIVERSAL_INSTRUCTOR = 'universal_instructor'.freeze,
-    # DEPRECATED. DO NOT USE.
-    # TODO: Clean up artifacts of this permission in all envs before removing it from the model.
-    AI_TUTOR_ACCESS = 'ai_tutor_access'.freeze,
     #  Grants access to an internal tool to pull AI-evaluated samples of student work
     STUDENT_WORK_ACCESS = 'student_work_access'.freeze,
   ].freeze


### PR DESCRIPTION
<!--
  Summary of the change: background, motivation, and context.
  Include screenshots, videos, or before/after comparisons for UI changes.
-->

Remove AI_TUTOR_ACCESS from the UserPermission model. This permission was deprecated in #68406. 

## Links
<!-- Jira tickets, design docs, Slack threads, related PRs, etc. -->

- Jira: https://codedotorg.atlassian.net/browse/LABS-1637

## Testing story
<!-- How was this tested? Manual steps, adhoc links, automated tests, or why testing isn't needed. -->

drone

## Deployment notes
<!-- Delete this section if it's a standard merge-and-deploy.
     Otherwise: migrations, feature flags, coordination, caching impacts, etc. -->

Ran the following in all envs console to clean up artifacts. 
```ruby
scope = UserPermission.where(permission: UserPermission::AI_TUTOR_ACCESS)
puts "Deleting #{scope.count} user_permissions"
scope.destroy_all
```

deleted 
56 from prod, 
0 from test, 
2 from staging, 
9 from levelbuilder