### PR TITLE
fix(observability): restore full span count to OTel collector 

### DIFF
--- a/dashboard/engines/observability/lib/observability/engine.rb
+++ b/dashboard/engines/observability/lib/observability/engine.rb
@@ -9,11 +9,11 @@ module Observability
     # all initializers during initialize!. The Engine class body runs when
     # Bundler.require loads the engine in config/application.rb, which is before
     # Rails.application.initialize! is called.
-    # Guard on UNIT_TEST to avoid loading Sentry in unit test runs where the
-    # DSN is unconfigured and background threads are unwanted. All other processes
-    # (workers, cron, rake, console) get observability.
-    # sentry-opentelemetry is only needed when both integrations are active.
-    if CDO.enable_sentry && !ENV['UNIT_TEST']
+    # Skip in unit test runs where the DSN is unconfigured and background
+    # threads are unwanted. All other processes (workers, cron, rake, console)
+    # get observability. sentry-opentelemetry is only needed when both
+    # integrations are active.
+    if CDO.enable_sentry && !CDO.unit_test
       require 'sentry-ruby'
       require 'sentry-rails'
       require 'sentry-opentelemetry' if CDO.enable_opentelemetry

--- a/dashboard/engines/observability/lib/observability/opentelemetry.rb
+++ b/dashboard/engines/observability/lib/observability/opentelemetry.rb
@@ -15,6 +15,13 @@ module Observability
       # (e.g. detach/attach mismatches, double-finish on spans).
       ENV['OTEL_LOG_LEVEL'] ||= 'fatal'
 
+      # Always sample every span so the full span volume reaches the collector.
+      # The default parentbased_always_on sampler would drop spans whose remote
+      # parent carries traceparent: sampled=0 (e.g. unsampled frontend sessions),
+      # causing Prometheus spanmetrics to undercount. Sampling decisions for the
+      # APM backend are made at the collector, not here.
+      ENV['OTEL_TRACES_SAMPLER'] ||= 'always_on'
+
       ::OpenTelemetry::SDK.configure do |c|
         c.service_name = 'dashboard'
 

--- a/dashboard/engines/observability/lib/observability/opentelemetry.rb
+++ b/dashboard/engines/observability/lib/observability/opentelemetry.rb
@@ -2,10 +2,9 @@
 
 module Observability
   module OpenTelemetry
-    # Sets up OpenTelemetry tracing. Runs in all processes except unit test runners
-    # (detected via UNIT_TEST env var set in dashboard/test/test_helper.rb).
+    # Sets up OpenTelemetry tracing. Runs in all processes except unit test runners.
     def self.setup
-      return unless CDO.enable_opentelemetry && !ENV['UNIT_TEST']
+      return unless CDO.enable_opentelemetry && !CDO.unit_test
 
       require 'opentelemetry/sdk'
       require 'opentelemetry/instrumentation/all'

--- a/dashboard/engines/observability/lib/observability/sentry.rb
+++ b/dashboard/engines/observability/lib/observability/sentry.rb
@@ -2,12 +2,11 @@
 
 module Observability
   module Sentry
-    # Sets up Sentry error tracking. Runs in all processes except unit test runners
-    # (detected via UNIT_TEST env var set in dashboard/test/test_helper.rb).
+    # Sets up Sentry error tracking. Runs in all processes except unit test runners.
     # When OpenTelemetry is also enabled, the OTLP integration is activated so
     # errors are correlated with traces.
     def self.setup
-      return unless CDO.enable_sentry && !ENV['UNIT_TEST']
+      return unless CDO.enable_sentry && !CDO.unit_test
 
       if CDO.dashboard_sentry_dsn.blank?
         CDO.log.warn '[observability] enable_sentry is true but dashboard_sentry_dsn is not configured; skipping Sentry setup'

--- a/dashboard/engines/observability/test/lib/observability/opentelemetry_test.rb
+++ b/dashboard/engines/observability/test/lib/observability/opentelemetry_test.rb
@@ -10,7 +10,7 @@ require 'opentelemetry-sdk'
 describe Observability::OpenTelemetry do
   before do
     CDO.stubs(:enable_opentelemetry).returns(false)
-    # ENV['UNIT_TEST'] is nil in engine test runs — enabled path is active by default
+    CDO.stubs(:unit_test).returns(false)
   end
 
   describe '.setup' do
@@ -20,19 +20,18 @@ describe Observability::OpenTelemetry do
       end
     end
 
-    describe 'when UNIT_TEST is set' do
+    describe 'when CDO.unit_test is true' do
       before do
         CDO.stubs(:enable_opentelemetry).returns(true)
-        ENV['UNIT_TEST'] = 'true'
+        CDO.stubs(:unit_test).returns(true)
       end
-      after {ENV.delete('UNIT_TEST')}
 
       it 'returns without configuring the SDK' do
         _(Observability::OpenTelemetry.setup).must_be_nil
       end
     end
 
-    describe 'when both CDO.enable_opentelemetry is true and UNIT_TEST is not set' do
+    describe 'when CDO.enable_opentelemetry is true and CDO.unit_test is false' do
       before do
         CDO.stubs(:enable_opentelemetry).returns(true)
         OpenTelemetry::SDK.stubs(:configure)

--- a/dashboard/engines/observability/test/lib/observability/opentelemetry_test.rb
+++ b/dashboard/engines/observability/test/lib/observability/opentelemetry_test.rb
@@ -1,6 +1,11 @@
 # frozen_string_literal: true
 
 require 'test_helper'
+# opentelemetry-sdk is not auto-required during Rails boot (the require lives inside
+# Observability::OpenTelemetry.setup, gated by running_web_application?). Pre-require
+# it here so constants are available for stubbing regardless of which test_helper
+# is on the load path.
+require 'opentelemetry-sdk'
 
 describe Observability::OpenTelemetry do
   before do
@@ -45,6 +50,22 @@ describe Observability::OpenTelemetry do
         fake_config.stubs(:add_span_processor)
         OpenTelemetry::SDK.expects(:configure).yields(fake_config)
         Observability::OpenTelemetry.setup
+      end
+
+      describe 'OTEL_TRACES_SAMPLER' do
+        after {ENV.delete('OTEL_TRACES_SAMPLER')}
+
+        it 'sets OTEL_TRACES_SAMPLER to always_on' do
+          ENV.delete('OTEL_TRACES_SAMPLER')
+          Observability::OpenTelemetry.setup
+          _(ENV.fetch('OTEL_TRACES_SAMPLER', nil)).must_equal 'always_on'
+        end
+
+        it 'does not override an existing OTEL_TRACES_SAMPLER' do
+          ENV['OTEL_TRACES_SAMPLER'] = 'parentbased_always_on'
+          Observability::OpenTelemetry.setup
+          _(ENV.fetch('OTEL_TRACES_SAMPLER', nil)).must_equal 'parentbased_always_on'
+        end
       end
 
       describe 'OTEL_LOG_LEVEL' do

--- a/dashboard/engines/observability/test/lib/observability/sentry_test.rb
+++ b/dashboard/engines/observability/test/lib/observability/sentry_test.rb
@@ -1,12 +1,16 @@
 # frozen_string_literal: true
 
 require 'test_helper'
+# sentry-ruby is not auto-required during Rails boot (the require lives inside
+# Observability::Sentry.setup, gated by running_web_application?). Pre-require
+# it here so the Sentry constant is available for stubbing.
+require 'sentry-ruby'
 
 describe Observability::Sentry do
   before do
-    CDO.enable_sentry = false
-    CDO.enable_opentelemetry = false
-    CDO.dashboard_sentry_dsn = nil
+    CDO.stubs(:enable_sentry).returns(false)
+    CDO.stubs(:enable_opentelemetry).returns(false)
+    CDO.stubs(:dashboard_sentry_dsn).returns(nil)
     # ENV['UNIT_TEST'] is nil in engine test runs — enabled path is active by default
   end
 
@@ -19,7 +23,7 @@ describe Observability::Sentry do
 
     describe 'when UNIT_TEST is set' do
       before do
-        CDO.enable_sentry = true
+        CDO.stubs(:enable_sentry).returns(true)
         ENV['UNIT_TEST'] = 'true'
       end
       after {ENV.delete('UNIT_TEST')}
@@ -31,12 +35,12 @@ describe Observability::Sentry do
 
     describe 'when CDO.enable_sentry is true and UNIT_TEST is not set' do
       before do
-        CDO.enable_sentry = true
-        CDO.dashboard_sentry_dsn = 'https://key@sentry.example.com/1'
+        CDO.stubs(:enable_sentry).returns(true)
+        CDO.stubs(:dashboard_sentry_dsn).returns('https://key@sentry.example.com/1')
       end
 
       describe 'when dashboard_sentry_dsn is blank' do
-        before {CDO.dashboard_sentry_dsn = nil}
+        before {CDO.stubs(:dashboard_sentry_dsn).returns(nil)}
 
         it 'does not initialize Sentry' do
           Sentry.expects(:init).never
@@ -66,7 +70,7 @@ describe Observability::Sentry do
       end
 
       describe 'when CDO.enable_opentelemetry is true' do
-        before {CDO.enable_opentelemetry = true}
+        before {CDO.stubs(:enable_opentelemetry).returns(true)}
 
         it 'enables the OTLP integration and defers exporting and propagation to the collector' do
           mock_otlp = mock('otlp_config')

--- a/dashboard/engines/observability/test/lib/observability/sentry_test.rb
+++ b/dashboard/engines/observability/test/lib/observability/sentry_test.rb
@@ -11,7 +11,7 @@ describe Observability::Sentry do
     CDO.stubs(:enable_sentry).returns(false)
     CDO.stubs(:enable_opentelemetry).returns(false)
     CDO.stubs(:dashboard_sentry_dsn).returns(nil)
-    # ENV['UNIT_TEST'] is nil in engine test runs — enabled path is active by default
+    CDO.stubs(:unit_test).returns(false)
   end
 
   describe '.setup' do
@@ -21,19 +21,18 @@ describe Observability::Sentry do
       end
     end
 
-    describe 'when UNIT_TEST is set' do
+    describe 'when CDO.unit_test is true' do
       before do
         CDO.stubs(:enable_sentry).returns(true)
-        ENV['UNIT_TEST'] = 'true'
+        CDO.stubs(:unit_test).returns(true)
       end
-      after {ENV.delete('UNIT_TEST')}
 
       it 'returns without initializing Sentry' do
         _(Observability::Sentry.setup).must_be_nil
       end
     end
 
-    describe 'when CDO.enable_sentry is true and UNIT_TEST is not set' do
+    describe 'when CDO.enable_sentry is true and CDO.unit_test is false' do
       before do
         CDO.stubs(:enable_sentry).returns(true)
         CDO.stubs(:dashboard_sentry_dsn).returns('https://key@sentry.example.com/1')

--- a/dashboard/engines/observability/test/test_helper.rb
+++ b/dashboard/engines/observability/test/test_helper.rb
@@ -17,20 +17,16 @@ require 'opentelemetry-sdk'
 require 'sentry-ruby'
 
 # Stub the CDO global config object referenced by both setup modules.
-# All flags default to false so nothing activates accidentally.
+# Flags are nil by default (falsy) so nothing activates accidentally.
 # Individual tests set the values they need in before blocks.
 module CDO
   class << self
-    attr_accessor :enable_opentelemetry, :enable_sentry, :dashboard_sentry_dsn
+    attr_accessor :enable_opentelemetry, :enable_sentry, :dashboard_sentry_dsn, :unit_test
 
     def log
       @log ||= Logger.new(IO::NULL)
     end
   end
-
-  self.enable_opentelemetry = false
-  self.enable_sentry = false
-  self.dashboard_sentry_dsn = nil
 end
 
 require 'observability'

--- a/lib/cdo/test_run_utils.rb
+++ b/lib/cdo/test_run_utils.rb
@@ -162,6 +162,14 @@ module TestRunUtils
     end
   end
 
+  def self.run_dashboard_observability_engine_tests
+    Dir.chdir(dashboard_dir) do
+      ChatClient.wrap('dashboard observability engine tests') do
+        RakeUtils.system_stream_output "RAILS_ENV=#{rack_env}", "RACK_ENV=#{rack_env}", 'bundle', 'exec', 'rails', 'test', dashboard_engines_dir('observability', 'test')
+      end
+    end
+  end
+
   def self.run_pegasus_tests
     Dir.chdir(pegasus_dir) do
       ChatClient.wrap('pegasus tests') do

--- a/lib/rake/test.rake
+++ b/lib/rake/test.rake
@@ -165,6 +165,15 @@ namespace :test do
     ENV.delete 'USE_PEGASUS_UNITTEST_DB'
   end
 
+  timed_task_with_logging :dashboard_observability_engine_qa do
+    # isolate unit tests from the pegasus_test DB
+    ENV['USE_PEGASUS_UNITTEST_DB'] = '1'
+    ENV['TEST_ENV_NUMBER'] = '1'
+    TestRunUtils.run_dashboard_observability_engine_tests
+    ENV.delete 'TEST_ENV_NUMBER'
+    ENV.delete 'USE_PEGASUS_UNITTEST_DB'
+  end
+
   timed_task_with_logging :shared_qa do
     # isolate unit tests from the pegasus_test DB
     ENV['USE_PEGASUS_UNITTEST_DB'] = '1'
@@ -209,6 +218,7 @@ namespace :test do
     :dashboard_legacy_qa,
     :dashboard_hoc_legacy_engine_qa,
     :dashboard_cdo_contentful_engine_qa,
+    :dashboard_observability_engine_qa,
     :lib_qa,
     :bin_qa,
     :ui_live
@@ -235,6 +245,11 @@ namespace :test do
   desc 'Runs dashboard hoc_legacy engine tests.'
   timed_task_with_logging :dashboard_hoc_legacy_engine do
     TestRunUtils.run_dashboard_hoc_legacy_engine_tests
+  end
+
+  desc 'Runs dashboard observability engine tests.'
+  timed_task_with_logging :dashboard_observability_engine do
+    TestRunUtils.run_dashboard_observability_engine_tests
   end
 
   desc 'Runs pegasus tests.'
@@ -353,6 +368,16 @@ namespace :test do
       end
     end
 
+    desc 'Runs dashboard observability engine tests'
+    timed_task_with_logging :dashboard_observability_engine do
+      run_tests_if_changed(
+        'dashboard observability engine',
+        %w[Gemfile Gemfile.lock dashboard/engines/observability/**/*],
+      ) do
+        TestRunUtils.run_dashboard_observability_engine_tests
+      end
+    end
+
     desc 'Runs pegasus tests if pegasus might have changed from staging.'
     timed_task_with_logging :pegasus do
       run_tests_if_changed(
@@ -448,6 +473,7 @@ namespace :test do
       :dashboard_legacy,
       :dashboard_cdo_contentful_engine,
       :dashboard_hoc_legacy_engine,
+      :dashboard_observability_engine,
       :pegasus,
       :shared,
       :lib,
@@ -469,6 +495,7 @@ namespace :test do
     :dashboard_legacy,
     :dashboard_cdo_contentful_engine,
     :dashboard_hoc_legacy_engine,
+    :dashboard_observability_engine,
     :pegasus,
     :shared,
     :lib,


### PR DESCRIPTION
## Reland of #72084 + test fix

This PR relands #72084 (reverted in #72288) together with a fix for the engine-test failure that triggered the revert. PR #72283 attempted a different fix for the same problem but was closed in favor of this cleaner approach.

### Fix

Swap the raw `ENV['UNIT_TEST']` check for `CDO.unit_test`, which is defined in `config.yml.erb` as `!!ENV['UNIT_TEST']`. Same runtime behavior, but the tests can now stub `CDO.unit_test` directly in `before` blocks — the same pattern already used for `CDO.enable_opentelemetry` and `CDO.enable_sentry` in those files — making the tests independent of whatever the process environment happens to be.

Additional cleanup from PR review:

- Dropped comments annotating `CDO.unit_test` as "a proxy for the UNIT_TEST env var" — hiding that detail is the point of the CDO config object.
- Removed the contradictory `self.unit_test = false` default from the engine's stub CDO helper (we *are* in unit tests when that helper loads).

---

## Why

Release v2026-04-08.0 enabled the frontend Sentry observability and sampling DCDO flags. After that deploy, Rack span counts in Prometheus (via `spanmetrics/rack_prometheus`) dropped proportionally to the fraction of unsampled browser sessions.

### Root cause

The Sentry JS SDK propagates a W3C `traceparent` header on every request. For sessions it does not sample it sets `sampled=0`. The OTel Ruby SDK's default sampler — `parentbased_always_on` — respects the remote parent's sampled bit and drops the server-side span entirely. Dropped spans never reach the `BatchSpanProcessor` or the collector, so neither the Prometheus spanmetrics pipeline nor the Sentry APM pipeline receives them.

`sentry-opentelemetry` 6.5.0 does not install a custom sampler; it only registers a `SpanProcessor` and (when `setup_propagator: true`) a propagator. Because `config.otlp.setup_propagator = false` is set, the Sentry propagator — which would have forced `trace_flags: SAMPLED` unconditionally — is inactive. The W3C propagator is used instead and faithfully carries `sampled=0` into the SDK sampler.

### Collector pipeline topology

The collector receives all spans from a single `otlp` receiver and fans them into two independent pipelines. Both are starved when the SDK drops spans upstream.

```mermaid
graph TD
    SDK["Rails OTel SDK\n(BatchSpanProcessor)"]
    R["otlp receiver"]
    P1["traces pipeline"]
    P2["traces/rack_prometheus pipeline"]
    PS["probabilistic_sampler\n(0.1%)"]
    F["filter/rack_prometheus\n(Rack spans only)"]
    SM["spanmetrics/rack_prometheus\nconnector"]
    Sentry["Sentry APM"]
    AMP["Amazon Managed\nPrometheus"]

    SDK -->|OTLP| R
    R --> P1
    R --> P2
    P1 --> PS --> Sentry
    P2 --> F --> SM --> AMP
```

### Before fix — unsampled session

```mermaid
sequenceDiagram
    participant B as Browser (unsampled)
    participant R as Rails OTel SDK
    participant C as Collector

    B->>R: GET /dashboard + traceparent: sampled=0
    Note over R: parentbased_always_on sees sampled=0<br/>→ span dropped, never created
    R--xC: no span exported
    Note over C: both traces and rack_prometheus<br/>pipelines receive nothing
```

### After fix — unsampled session

```mermaid
sequenceDiagram
    participant B as Browser (unsampled)
    participant R as Rails OTel SDK
    participant C as Collector
    participant AMP as Prometheus
    participant S as Sentry

    B->>R: GET /dashboard + traceparent: sampled=0
    Note over R: ALWAYS_ON ignores sampled bit<br/>→ span recorded and exported
    R->>C: span via OTLP
    C->>AMP: Rack spanmetric (100% volume)
    Note over S: probabilistic_sampler decides<br/>APM routing independently (0.1%)
```

## Change

One line in `Observability::OpenTelemetry.setup`:

```ruby
ENV['OTEL_TRACES_SAMPLER'] ||= 'always_on'
```

This overrides the SDK default before `use_all` is called. `sentry-opentelemetry` does not overwrite the sampler after this point. Sampling decisions for the APM backend are delegated entirely to the collector's `probabilistic_sampler`.

Also wires the observability engine into the CI test runner (`test_run_utils.rb`, `test.rake`) which was missing while `hoc_legacy` and `cdo_contentful` engines were present. The `changed:` task is scoped to engine files only, matching the `cdo_contentful` pattern.

## Test plan

Verified on adhoc that when a trace is set with zero sampling flag `-00`, the trace still appears.

## Followups

- **Honor frontend sampling for end-to-end traceability.** Today `config.otlp.setup_propagator = false` so the Sentry propagator is inactive and `sampled=0` carries no meaning on the backend. A followup should evaluate re-enabling the Sentry propagator (or a custom one) so that spans whose frontend parent was sampled are routed to Sentry as connected traces, while spans from unsampled sessions still reach Prometheus but are excluded from APM. This is the "better end-to-end traceability" goal and requires care to not re-introduce the span-drop regression.
- **`probabilistic_sampler` rate review.** At 0.1% the Sentry APM pipeline sees very few traces. Once the volume regression is confirmed fixed, revisit whether a higher rate or tail-based sampling is warranted.
