### PR TITLE
AI Chat: clear recording flag on error

### DIFF
--- a/apps/src/aiComponentLibrary/userMessageEditor/UserMessageEditor.tsx
+++ b/apps/src/aiComponentLibrary/userMessageEditor/UserMessageEditor.tsx
@@ -183,6 +183,7 @@ const UserMessageEditor = React.forwardRef<
                   onSpeechToTextFinished?.(analytics);
                 }}
                 onRecordStart={() => setIsRecording(true)}
+                onRecordEnd={() => setIsRecording(false)}
                 disabled={disabled}
               />
             )}

--- a/apps/src/aiComponentLibrary/userMessageEditor/speechToTextButton/SpeechToTextButton.tsx
+++ b/apps/src/aiComponentLibrary/userMessageEditor/speechToTextButton/SpeechToTextButton.tsx
@@ -26,12 +26,14 @@ export interface SpeechToTextAnalytics {
 interface SpeechToTextButtonProps {
   onTranscribed: (text: string, analytics: SpeechToTextAnalytics) => void;
   onRecordStart?: () => void;
+  onRecordEnd?: () => void;
   disabled?: boolean;
 }
 
 const SpeechToTextButton: React.FC<SpeechToTextButtonProps> = ({
   onTranscribed,
   onRecordStart,
+  onRecordEnd,
   disabled,
 }) => {
   const [isRecording, setIsRecording] = useState(false);
@@ -90,6 +92,7 @@ const SpeechToTextButton: React.FC<SpeechToTextButtonProps> = ({
       setErrorMessage(unknownErrorMessage);
     } finally {
       setIsTranscribing(false);
+      onRecordEnd?.();
     }
   };
 


### PR DESCRIPTION
@edcodedotorg noticed a bug where if we hit an error while attempting to record or transcribe in speech to text (e.g. 4xx error on the gateway), the chat editor remains disabled. This fix clears the recording state so the editor can be used.

## Testing story
@edcodedotorg tested this on his branch which had a reproducible gateway error.
