### PR TITLE
Sentry user_id via Warden hook

### DIFF
--- a/dashboard/config/initializers/sentry.rb
+++ b/dashboard/config/initializers/sentry.rb
@@ -1,0 +1,5 @@
+if Observability::Sentry.enabled?
+  Warden::Manager.after_fetch(scope: :user) do |user, _auth, _opts|
+    Observability::Sentry.set_user_id(user.id)
+  end
+end

--- a/dashboard/engines/observability/lib/observability/engine.rb
+++ b/dashboard/engines/observability/lib/observability/engine.rb
@@ -13,7 +13,7 @@ module Observability
     # threads are unwanted. All other processes (workers, cron, rake, console)
     # get observability. sentry-opentelemetry is only needed when both
     # integrations are active.
-    if CDO.enable_sentry && !CDO.unit_test
+    if Sentry.enabled?
       require 'sentry-ruby'
       require 'sentry-rails'
       require 'sentry-opentelemetry' if CDO.enable_opentelemetry

--- a/dashboard/engines/observability/lib/observability/sentry.rb
+++ b/dashboard/engines/observability/lib/observability/sentry.rb
@@ -5,8 +5,13 @@ module Observability
     # Sets up Sentry error tracking. Runs in all processes except unit test runners.
     # When OpenTelemetry is also enabled, the OTLP integration is activated so
     # errors are correlated with traces.
+
+    def self.enabled?
+      CDO.enable_sentry && !CDO.unit_test
+    end
+
     def self.setup
-      return unless CDO.enable_sentry && !CDO.unit_test
+      return unless enabled?
 
       if CDO.dashboard_sentry_dsn.blank?
         CDO.log.warn '[observability] enable_sentry is true but dashboard_sentry_dsn is not configured; skipping Sentry setup'
@@ -29,6 +34,11 @@ module Observability
           config.otlp.setup_propagator = false             # keep existing propagation
         end
       end
+    end
+
+    # Sets the user_id in the Sentry context. Intended to be called from a Warden after_fetch hook.
+    def self.set_user_id(id)
+      ::Sentry.set_user(id:)
     end
   end
 end


### PR DESCRIPTION
Alternate implementation of https://github.com/code-dot-org/code-dot-org/pull/72113. Accomplishes the same goal of adding the user_id to Sentry, but using a Warden `after_fetch` hook instead of a controller `before_action` callback. Very safe as far as preventing the CSRF issue we experienced with the original before_action implementation, and potentially marginally safer than the implementation in the other PR, since this doesn't touch anything at the controller level.


## Links
[JIRA](https://codedotorg.atlassian.net/browse/P20-1847)

## Testing story
<!-- How was this tested? Manual steps, adhoc links, automated tests, or why testing isn't needed. -->



## Deployment notes
<!-- Delete this section if it's a standard merge-and-deploy.
     Otherwise: migrations, feature flags, coordination, caching impacts, etc. -->



## Privacy and security
<!-- Delete this section if there is no privacy/security impact.
     Otherwise: new PII, auth changes, API surface changes, etc. -->

