### PR TITLE
AI Gateway Client: Add HTTP Error log Helper

### DIFF
--- a/apps/src/aiComponentLibrary/userMessageEditor/UserMessageEditor.tsx
+++ b/apps/src/aiComponentLibrary/userMessageEditor/UserMessageEditor.tsx
@@ -183,6 +183,7 @@ const UserMessageEditor = React.forwardRef<
                   onSpeechToTextFinished?.(analytics);
                 }}
                 onRecordStart={() => setIsRecording(true)}
+                onRecordEnd={() => setIsRecording(false)}
                 disabled={disabled}
               />
             )}

--- a/apps/src/aiComponentLibrary/userMessageEditor/speechToTextButton/SpeechToTextButton.tsx
+++ b/apps/src/aiComponentLibrary/userMessageEditor/speechToTextButton/SpeechToTextButton.tsx
@@ -26,12 +26,14 @@ export interface SpeechToTextAnalytics {
 interface SpeechToTextButtonProps {
   onTranscribed: (text: string, analytics: SpeechToTextAnalytics) => void;
   onRecordStart?: () => void;
+  onRecordEnd?: () => void;
   disabled?: boolean;
 }
 
 const SpeechToTextButton: React.FC<SpeechToTextButtonProps> = ({
   onTranscribed,
   onRecordStart,
+  onRecordEnd,
   disabled,
 }) => {
   const [isRecording, setIsRecording] = useState(false);
@@ -90,6 +92,7 @@ const SpeechToTextButton: React.FC<SpeechToTextButtonProps> = ({
       setErrorMessage(unknownErrorMessage);
     } finally {
       setIsTranscribing(false);
+      onRecordEnd?.();
     }
   };
 

--- a/apps/src/aiGateway/generateText.ts
+++ b/apps/src/aiGateway/generateText.ts
@@ -2,6 +2,7 @@ import {generateText, type GenerateTextResult} from 'ai';
 
 import HttpClient from '../util/HttpClient';
 
+import {getErrorLogData} from './logHelper';
 import {AI_GATEWAY_URL, fetchAccessToken, getModelString} from './shared';
 
 type SDKOptions = Parameters<typeof generateText>[0];
@@ -100,7 +101,9 @@ const generateTextThroughGateway = async <
 
     return rehydrateAIResponse<TOOLS, OUTPUT>(data);
   } catch (error) {
-    console.error('Fetch error:', error);
+    getErrorLogData(error).then(data => {
+      console.error('Fetch error in generateTextThroughGateway:', data);
+    });
     throw error;
   }
 };

--- a/apps/src/aiGateway/generateText.ts
+++ b/apps/src/aiGateway/generateText.ts
@@ -101,9 +101,8 @@ const generateTextThroughGateway = async <
 
     return rehydrateAIResponse<TOOLS, OUTPUT>(data);
   } catch (error) {
-    getErrorLogData(error).then(data => {
-      console.error('Fetch error in generateTextThroughGateway:', data);
-    });
+    const logData = await getErrorLogData(error);
+    console.error('Fetch error in generateTextThroughGateway:', logData);
     throw error;
   }
 };

--- a/apps/src/aiGateway/logHelper.ts
+++ b/apps/src/aiGateway/logHelper.ts
@@ -1,0 +1,31 @@
+import {NetworkError} from '@cdo/apps/util/HttpClient';
+/**
+ * Resolves the most descriptive representation of an error for logging.
+ * If it's a NetworkError, it attempts to safely extract the response body.
+ */
+export const getErrorLogData = async (error: unknown) => {
+  if (error instanceof NetworkError && error.response) {
+    try {
+      // Clone to avoid disturbing the original stream.
+      const bodyText = await error.response.clone().text();
+      let parsedBody;
+      try {
+        parsedBody = JSON.parse(bodyText);
+      } catch {
+        parsedBody = bodyText; // Fallback to raw text if not JSON.
+      }
+
+      return {
+        type: 'NetworkError',
+        status: error.response.status,
+        url: error.response.url,
+        body: parsedBody,
+        error, // Included for stack trace.
+      };
+    } catch (e) {
+      return {type: 'NetworkError (Unreadable Body)', error};
+    }
+  }
+  // Default return for standard Errors.
+  return {type: 'GenericError', error};
+};

--- a/apps/src/aiGateway/transcribe.ts
+++ b/apps/src/aiGateway/transcribe.ts
@@ -5,6 +5,7 @@ import {
 
 import HttpClient from '../util/HttpClient';
 
+import {getErrorLogData} from './logHelper';
 import {AI_GATEWAY_URL, fetchAccessToken, getModelString} from './shared';
 
 type TranscribeOptions = Parameters<typeof transcribe>[0];
@@ -15,26 +16,33 @@ type TranscribeOptions = Parameters<typeof transcribe>[0];
 async function transcribeThroughGateway(
   options: TranscribeOptions
 ): Promise<TranscriptionResult> {
-  const {model, audio, ...restOptions} = options;
+  try {
+    const {model, audio, ...restOptions} = options;
 
-  const token = await fetchAccessToken();
+    const token = await fetchAccessToken();
 
-  const formData = new FormData();
-  formData.append('token', token);
-  const audioBlob = await audioToBlob(audio);
-  formData.append('audio', audioBlob, 'audio');
-  formData.append('model', getModelString(model));
+    const formData = new FormData();
+    formData.append('token', token);
+    const audioBlob = await audioToBlob(audio);
+    formData.append('audio', audioBlob, 'audio');
+    formData.append('model', getModelString(model));
 
-  for (const [key, value] of Object.entries(restOptions)) {
-    formData.append(key, String(value));
+    for (const [key, value] of Object.entries(restOptions)) {
+      formData.append(key, String(value));
+    }
+
+    const response = await HttpClient.post(
+      `${AI_GATEWAY_URL}/transcribe`,
+      formData
+    );
+
+    return await response.json();
+  } catch (error) {
+    getErrorLogData(error).then(data => {
+      console.error('Fetch error in transcribeThroughGateway:', data);
+    });
+    throw error;
   }
-
-  const response = await HttpClient.post(
-    `${AI_GATEWAY_URL}/transcribe`,
-    formData
-  );
-
-  return await response.json();
 }
 
 async function audioToBlob(audio: TranscribeOptions['audio']): Promise<Blob> {

--- a/apps/src/aiGateway/transcribe.ts
+++ b/apps/src/aiGateway/transcribe.ts
@@ -38,9 +38,8 @@ async function transcribeThroughGateway(
 
     return await response.json();
   } catch (error) {
-    getErrorLogData(error).then(data => {
-      console.error('Fetch error in transcribeThroughGateway:', data);
-    });
+    const logData = getErrorLogData(error);
+    console.error('Fetch error in transcribeThroughGateway:', logData);
     throw error;
   }
 }


### PR DESCRIPTION
Added a little (local) helper to the gateway client directory (could be moved to utils if we want to use more generally) to surface the actual response.  Before this the error was just logged as a string and even if you wrapped it in `{}` before logging the actual response body was caught up in a response object that you otherwise had to `Store as a global variable` and then access by typing `await temp1.response.text().then(console.log);` in the console.  This improves developer ergonomics greatly.

Error response body is surfaced cleanly using this helper:
<img width="1274" height="830" alt="Screenshot 2026-04-22 at 6 27 34 PM" src="https://github.com/user-attachments/assets/0317cd75-2373-42a3-b591-0189c41c7fbb" />
