### PR TITLE
chore: remove unused apps/src dead files

### DIFF
--- a/apps/src/templates/tutorialTypes.js
+++ b/apps/src/templates/tutorialTypes.js
@@ -1,8 +1,0 @@
-export const tutorialTypes = [
-  'applab',
-  'dance',
-  '2018Minecraft',
-  '2017Minecraft',
-  'pre2017Minecraft',
-  'other',
-];

--- a/apps/src/util/deprecatedLabWarning.js
+++ b/apps/src/util/deprecatedLabWarning.js
@@ -1,6 +1,0 @@
-export var showDeprecatedAlgebraLabWarning = function () {
-  $('#calc-eval-deprecated').show();
-  $('#warning-icon').show();
-  $('#dismiss-icon').show();
-  $('#warning-banner').show();
-};


### PR DESCRIPTION
## Context

This PR was produced by an autonomous **dead-code sweep run by Claude** over `apps/` and `frontend/`. The task is recurrent; each run is capped at 5 files to keep review load manageable. This run surfaced 2 high-confidence candidates — the agent deliberately did not pad the list with weaker ones.

Method:
- Scanned source files under `apps/src/` and `frontend/packages/*/src/` for modules with no importers.
- For each candidate, grepped the full repo (`apps`, `frontend`, `dashboard`, `lib`, `shared`, `pegasus`) across `.js/.jsx/.ts/.tsx/.rb/.haml/.erb/.html/.json/.scss/.yml` for both the module basename and every exported symbol.
- Filtered out webpack/karma/jest entry points, Storybook stories, and files loaded dynamically by Rails views.

## Summary

- Delete `apps/src/util/deprecatedLabWarning.js` (6 lines) — exports `showDeprecatedAlgebraLabWarning`, a jQuery helper that toggles `#calc-eval-deprecated`, `#warning-icon`, `#dismiss-icon`, `#warning-banner`. No importers; no string-based references to the module or the function name anywhere in the repo.
- Delete `apps/src/templates/tutorialTypes.js` (8 lines) — exports a `tutorialTypes` string array (`'applab'`, `'dance'`, Minecraft variants, `'other'`). No importers; no references to the symbol anywhere in the repo.

Net change: 2 files deleted, 14 lines removed, zero behavior change expected.

## Test plan

- [ ] CI green (apps unit + integration, dashboard tests, lint)
- [ ] Drone run surfaces no runtime references via dynamic imports

## Caveats

Static grep cannot see references built at runtime from concatenated strings. If a Rails view or lab config assembles a module path on the fly, that would not appear in this analysis. The candidates here are small, self-contained, and the exported symbols (`showDeprecatedAlgebraLabWarning`, `tutorialTypes`) are distinctive enough that a dynamic reference would still be visible in a grep — none was found.

https://claude.ai/code/session_01F3CxwZ26ZrJLtpgQauk3FD