### PR TITLE
Tutor Cleanup: Remove ai_tutor_enabled from sections table

### DIFF
--- a/apps/src/templates/studioHomepages/teacherHomepageV2/DemoSectionCard.tsx
+++ b/apps/src/templates/studioHomepages/teacherHomepageV2/DemoSectionCard.tsx
@@ -127,7 +127,6 @@ const DemoSectionCard: React.FC<DemoSectionCardProps> = ({showHiddenOnly}) => {
       participantType: preset.participantType,
       loginType: preset.loginType as Section['loginType'],
       grades: [],
-      aiTutorEnabled: false,
       lessonExtras: false,
       pairingAllowed: true,
       providerManaged: false,

--- a/dashboard/app/models/sections/clever_section.rb
+++ b/dashboard/app/models/sections/clever_section.rb
@@ -24,7 +24,6 @@
 #  properties           :text(65535)
 #  participant_type     :string(255)      default("student"), not null
 #  lti_integration_id   :bigint
-#  ai_tutor_enabled     :boolean          default(FALSE)
 #  avatar_color         :integer
 #  avatar_emoji         :integer
 #  ai_chat_access_level :string(255)      default("disabled")

--- a/dashboard/app/models/sections/email_section.rb
+++ b/dashboard/app/models/sections/email_section.rb
@@ -24,7 +24,6 @@
 #  properties           :text(65535)
 #  participant_type     :string(255)      default("student"), not null
 #  lti_integration_id   :bigint
-#  ai_tutor_enabled     :boolean          default(FALSE)
 #  avatar_color         :integer
 #  avatar_emoji         :integer
 #  ai_chat_access_level :string(255)      default("disabled")

--- a/dashboard/app/models/sections/google_classroom_section.rb
+++ b/dashboard/app/models/sections/google_classroom_section.rb
@@ -24,7 +24,6 @@
 #  properties           :text(65535)
 #  participant_type     :string(255)      default("student"), not null
 #  lti_integration_id   :bigint
-#  ai_tutor_enabled     :boolean          default(FALSE)
 #  avatar_color         :integer
 #  avatar_emoji         :integer
 #  ai_chat_access_level :string(255)      default("disabled")

--- a/dashboard/app/models/sections/lti_v1_section.rb
+++ b/dashboard/app/models/sections/lti_v1_section.rb
@@ -24,7 +24,6 @@
 #  properties           :text(65535)
 #  participant_type     :string(255)      default("student"), not null
 #  lti_integration_id   :bigint
-#  ai_tutor_enabled     :boolean          default(FALSE)
 #  avatar_color         :integer
 #  avatar_emoji         :integer
 #  ai_chat_access_level :string(255)      default("disabled")

--- a/dashboard/app/models/sections/omni_auth_section.rb
+++ b/dashboard/app/models/sections/omni_auth_section.rb
@@ -24,7 +24,6 @@
 #  properties           :text(65535)
 #  participant_type     :string(255)      default("student"), not null
 #  lti_integration_id   :bigint
-#  ai_tutor_enabled     :boolean          default(FALSE)
 #  avatar_color         :integer
 #  avatar_emoji         :integer
 #  ai_chat_access_level :string(255)      default("disabled")

--- a/dashboard/app/models/sections/picture_section.rb
+++ b/dashboard/app/models/sections/picture_section.rb
@@ -24,7 +24,6 @@
 #  properties           :text(65535)
 #  participant_type     :string(255)      default("student"), not null
 #  lti_integration_id   :bigint
-#  ai_tutor_enabled     :boolean          default(FALSE)
 #  avatar_color         :integer
 #  avatar_emoji         :integer
 #  ai_chat_access_level :string(255)      default("disabled")

--- a/dashboard/app/models/sections/section.rb
+++ b/dashboard/app/models/sections/section.rb
@@ -24,7 +24,6 @@
 #  properties           :text(65535)
 #  participant_type     :string(255)      default("student"), not null
 #  lti_integration_id   :bigint
-#  ai_tutor_enabled     :boolean          default(FALSE)
 #  avatar_color         :integer
 #  avatar_emoji         :integer
 #  ai_chat_access_level :string(255)      default("disabled")

--- a/dashboard/app/models/sections/word_section.rb
+++ b/dashboard/app/models/sections/word_section.rb
@@ -24,7 +24,6 @@
 #  properties           :text(65535)
 #  participant_type     :string(255)      default("student"), not null
 #  lti_integration_id   :bigint
-#  ai_tutor_enabled     :boolean          default(FALSE)
 #  avatar_color         :integer
 #  avatar_emoji         :integer
 #  ai_chat_access_level :string(255)      default("disabled")

--- a/dashboard/db/migrate/20260423120000_remove_ai_tutor_enabled_from_sections.rb
+++ b/dashboard/db/migrate/20260423120000_remove_ai_tutor_enabled_from_sections.rb
@@ -1,0 +1,5 @@
+class RemoveAiTutorEnabledFromSections < ActiveRecord::Migration[7.0]
+  def change
+    remove_column :sections, :ai_tutor_enabled, :boolean, default: false
+  end
+end

--- a/dashboard/db/schema.rb
+++ b/dashboard/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2026_04_20_120000) do
+ActiveRecord::Schema[7.0].define(version: 2026_04_23_120000) do
   create_table "activities", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "user_id"
     t.integer "level_id"
@@ -2272,7 +2272,6 @@ ActiveRecord::Schema[7.0].define(version: 2026_04_20_120000) do
     t.text "properties"
     t.string "participant_type", default: "student", null: false
     t.bigint "lti_integration_id"
-    t.boolean "ai_tutor_enabled", default: false
     t.integer "avatar_color"
     t.integer "avatar_emoji"
     t.string "ai_chat_access_level", default: "disabled"


### PR DESCRIPTION
<!--
  Summary of the change: background, motivation, and context.
  Include screenshots, videos, or before/after comparisons for UI changes.
-->

migration to remove the `ai_tutor_enabled` column from the `section` table since it's no longer used. 

Follow up of #72271

## Links
<!-- Jira tickets, design docs, Slack threads, related PRs, etc. -->

- task: https://www.figma.com/board/47n4NNAkS9lV2KbKhPiJSp/AI-Tutor-Permissions-Dumplink?node-id=2181-244&t=nJDq6MWqUw3IGcSH-4

## Testing story
<!-- How was this tested? Manual steps, adhoc links, automated tests, or why testing isn't needed. -->

drone

## Deployment notes
<!-- Delete this section if it's a standard merge-and-deploy.
     Otherwise: migrations, feature flags, coordination, caching impacts, etc. -->

all referencing code and models have already been removed, this is just the final cleanup
