### PR TITLE
install aws-sdk-devicefarm gem in all environments

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -119,7 +119,6 @@ group :development, :test do
   gem 'timecop', '>= 0.9.4' # required for Ruby 3.1 support
 
   # For UI testing.
-  gem 'aws-sdk-devicefarm'
   gem 'cucumber'
   gem 'eyes_selenium', '>= 6.0.4' # required for Ruby 3.2 support
   gem 'fakefs', '~> 2.5.0', require: false
@@ -273,6 +272,7 @@ gem 'aws-sdk-cloudwatchlogs'
 gem 'aws-sdk-comprehend'
 gem 'aws-sdk-core', '>= 3.239.2'
 gem 'aws-sdk-databasemigrationservice'
+gem 'aws-sdk-devicefarm'
 gem 'aws-sdk-dynamodb'
 gem 'aws-sdk-ec2', '~> 1.424.0' # required for Ruby 3.2 support
 gem 'aws-sdk-firehose'


### PR DESCRIPTION
https://github.com/code-dot-org/code-dot-org/pull/72241 only installed the device farm gem in development and test, because these are the environments where we run ui tests. however, that PR broke the staging build due to device farm code getting run in the staging environment (despite not running any ui tests). See [slack](https://codedotorg.slack.com/archives/C0T0PNTM3/p1776987668874429) for details including stack trace. This PR fixes the issue by installing the device farm gem in every environment.

## Testing story

patched onto the staging machine and confirmed it unblocked the build