### PR TITLE
[Lab2] Refactor of Drag and Drop File Keyboard Interactions

### DIFF
--- a/apps/src/codebridge/FileBrowser/Draggable.tsx
+++ b/apps/src/codebridge/FileBrowser/Draggable.tsx
@@ -6,11 +6,16 @@ import {DragDataType} from './types';
 
 import moduleStyles from './styles/filebrowser.module.scss';
 
-// Provides the dnd-kit aria-describedby ID down to the label button in ItemRow
-// so screen readers announce drag instructions when the button is focused.
-export const DragDescriptionContext = React.createContext<string | undefined>(
-  undefined
-);
+type DragAriaAttributes = {
+  'aria-describedby': string | undefined;
+  'aria-roledescription': string;
+  'aria-pressed': true | undefined;
+};
+
+// Threads dnd-kit ARIA attributes down to the label button in ItemRow.
+export const DragDescriptionContext = React.createContext<
+  DragAriaAttributes | undefined
+>(undefined);
 
 type DraggableProps = {
   children: React.ReactNode;
@@ -46,7 +51,13 @@ export const Draggable: React.FunctionComponent<DraggableProps> = ({
     },
     React.createElement(
       DragDescriptionContext.Provider,
-      {value: attributes['aria-describedby']},
+      {
+        value: {
+          'aria-describedby': attributes['aria-describedby'],
+          'aria-roledescription': attributes['aria-roledescription'],
+          'aria-pressed': attributes['aria-pressed'] as true | undefined,
+        },
+      },
       children
     )
   );

--- a/apps/src/codebridge/FileBrowser/Draggable.tsx
+++ b/apps/src/codebridge/FileBrowser/Draggable.tsx
@@ -6,39 +6,24 @@ import {DragDataType} from './types';
 
 import moduleStyles from './styles/filebrowser.module.scss';
 
-/*
-  This component adds draggable functionality to files/folders in the file browser. The intent is that the user can drag a file into a new folder as well
-  as drag a folder into a new parent folder.
-
-  Should be used as a wrapper component around the contents which should be draggable, and can be given an html tag as a string to define the rendered component
-  on the page (defaults to 'div')
-*/
+// Provides the dnd-kit aria-describedby ID down to the label button in ItemRow
+// so screen readers announce drag instructions when the button is focused.
+export const DragDescriptionContext = React.createContext<string | undefined>(
+  undefined
+);
 
 type DraggableProps = {
   children: React.ReactNode;
   data: DragDataType;
   Component?: keyof JSX.IntrinsicElements;
   className?: string;
-  onKeyDown?: (event: React.KeyboardEvent) => void;
 };
 
-/**
- * A React component that makes its children draggable using the `useDraggable` hook. Should wrap around a FileBrowserRow.
- * If you -don't- want a row to be draggable, but still want a wrapper, you can wrap it in NotDraggable, below.
- *
- * @param props - The props for the `Draggable` component.
- * @param props.children - The content to be made draggable.
- * @param props.data - An object containing data associated with the draggable element. data must be of type DragDataType.
- * @param props.Component - (Optional) The underlying HTML element to use as the draggable container.
- *                         - Defaults to `'div'`.
- * @returns A React element with the provided children, styled for dragging and handling drag events.
- */
 export const Draggable: React.FunctionComponent<DraggableProps> = ({
   children,
   data,
   Component = 'div',
   className,
-  onKeyDown,
 }: DraggableProps) => {
   const draggableId = `${data.type}-${data.id}-draggable`;
   const {attributes, listeners, setNodeRef, transform} = useDraggable({
@@ -51,56 +36,32 @@ export const Draggable: React.FunctionComponent<DraggableProps> = ({
       }
     : undefined;
 
-  // Call the provided onKeyDown function if it exists,
-  // then call the listeners.onKeyDown function if it exists.
-  // This allows for custom keyboard handling while still
-  // allowing the default keyboard handling provided by dnd-kit.
-  const handleKeyDown = (event: React.KeyboardEvent) => {
-    if (onKeyDown) {
-      onKeyDown(event);
-    }
-    if (listeners?.onKeyDown) {
-      listeners?.onKeyDown(event);
-    }
-  };
-
   return React.createElement(
     Component,
     {
       ref: setNodeRef,
-      style: style,
+      style,
       className: classNames(moduleStyles.draggable, className),
       ...listeners,
-      ...attributes,
-      onKeyDown: handleKeyDown,
     },
-    children
+    React.createElement(
+      DragDescriptionContext.Provider,
+      {value: attributes['aria-describedby']},
+      children
+    )
   );
 };
 
 type NotDraggableProps = {
   children: React.ReactNode;
-  onKeyDown?: (event: React.KeyboardEvent) => void;
 };
 
 export const NotDraggable: React.FunctionComponent<NotDraggableProps> = ({
   children,
-  onKeyDown,
 }: NotDraggableProps) => {
-  const handleKeyDown = (event: React.KeyboardEvent) => {
-    if (onKeyDown) {
-      onKeyDown(event);
-    }
-  };
-
   return React.createElement(
     'div',
-    {
-      onKeyDown: handleKeyDown,
-      className: moduleStyles.notDraggable,
-      tabIndex: 0,
-      role: 'button',
-    },
+    {className: moduleStyles.notDraggable},
     children
   );
 };

--- a/apps/src/codebridge/FileBrowser/FileBrowser.tsx
+++ b/apps/src/codebridge/FileBrowser/FileBrowser.tsx
@@ -218,7 +218,7 @@ export const FileBrowser = React.memo(() => {
               >
                 {/* role="list" needed: list-style:none strips VoiceOver semantics */}
                 {/* eslint-disable-next-line jsx-a11y/no-redundant-roles */}
-                <ul
+                <ol
                   id="uitest-files-list"
                   className={moduleStyles.folder}
                   role="list"
@@ -230,7 +230,7 @@ export const FileBrowser = React.memo(() => {
                     files={source.files}
                     appName={appName}
                   />
-                </ul>
+                </ol>
               </Droppable>
             </DndDataContextProvider>
           </DndContext>

--- a/apps/src/codebridge/FileBrowser/FileBrowser.tsx
+++ b/apps/src/codebridge/FileBrowser/FileBrowser.tsx
@@ -14,10 +14,10 @@ import {
   DragOverEvent,
   DragEndEvent,
   DragCancelEvent,
+  KeyboardSensor,
   PointerSensor,
   useSensor,
   useSensors,
-  KeyboardSensor,
 } from '@dnd-kit/core';
 import {restrictToVerticalAxis} from '@dnd-kit/modifiers';
 import classNames from 'classnames';
@@ -216,14 +216,21 @@ export const FileBrowser = React.memo(() => {
                   }
                 )}
               >
-                <div id="uitest-files-list" className={moduleStyles.folder}>
+                {/* role="list" needed: list-style:none strips VoiceOver semantics */}
+                {/* eslint-disable-next-line jsx-a11y/no-redundant-roles */}
+                <ul
+                  id="uitest-files-list"
+                  className={moduleStyles.folder}
+                  role="list"
+                  aria-label={codebridgeI18n.filesHeader()}
+                >
                   <InnerFileBrowser
                     parentId={DEFAULT_FOLDER_ID}
                     folders={source.folders}
                     files={source.files}
                     appName={appName}
                   />
-                </div>
+                </ul>
               </Droppable>
             </DndDataContextProvider>
           </DndContext>

--- a/apps/src/codebridge/FileBrowser/FileBrowser.tsx
+++ b/apps/src/codebridge/FileBrowser/FileBrowser.tsx
@@ -197,7 +197,8 @@ export const FileBrowser = React.memo(() => {
             accessibility={{
               announcements,
               screenReaderInstructions: {
-                draggable: codebridgeI18n.dragAndDropInstructionsFolders(),
+                draggable:
+                  'Press m to pick up, arrow keys to move, m, space, or enter to drop, escape to cancel.',
               },
             }}
           >

--- a/apps/src/codebridge/FileBrowser/FileBrowserRow/FileRowIcon.tsx
+++ b/apps/src/codebridge/FileBrowser/FileBrowserRow/FileRowIcon.tsx
@@ -25,6 +25,7 @@ export const FileRowIcon: FileBrowserIconComponentType = ({item}) => {
       iconName={iconName}
       iconStyle={iconStyle}
       className={iconClassName}
+      aria-hidden
     />
   );
 };

--- a/apps/src/codebridge/FileBrowser/FileBrowserRow/FolderRowIcon.tsx
+++ b/apps/src/codebridge/FileBrowser/FileBrowserRow/FolderRowIcon.tsx
@@ -18,6 +18,7 @@ export const FolderRowIcon: FileBrowserIconComponentType = ({item}) => {
       iconName={folderItem.open ? 'folder-open' : 'folder'}
       iconStyle={'solid'}
       className={moduleStyles.rowIcon}
+      aria-hidden
     />
   );
 };

--- a/apps/src/codebridge/FileBrowser/FileBrowserRow/ItemRow.tsx
+++ b/apps/src/codebridge/FileBrowser/FileBrowserRow/ItemRow.tsx
@@ -1,9 +1,11 @@
 import {PopUpButton} from '@codebridge/PopUpButton/PopUpButton';
 import {PopUpButtonOption} from '@codebridge/PopUpButton/PopUpButtonOption';
 import classNames from 'classnames';
-import React from 'react';
+import React, {useContext} from 'react';
 
 import codebridgeI18n from '@cdo/apps/codebridge/locale';
+
+import {DragDescriptionContext} from '../Draggable';
 
 import {ItemRowProps} from './types';
 
@@ -36,15 +38,22 @@ export const ItemRow: React.FunctionComponent<ItemRowProps> = ({
   openFunction,
   className,
 }) => {
+  const dragDescribedBy = useContext(DragDescriptionContext);
+
   return (
     <div
       className={classNames(moduleStyles.row, className)}
       id={`uitest-file-${item.id}-row`}
     >
-      <div className={moduleStyles.label} onClick={() => openFunction(item.id)}>
+      <button
+        type="button"
+        className={moduleStyles.label}
+        onClick={() => openFunction(item.id)}
+        aria-describedby={dragDescribedBy}
+      >
         <IconComponent item={item} />
         <NameComponent item={item} />
-      </div>
+      </button>
       {enableMenu && (
         <PopUpButton
           iconName="ellipsis-v"

--- a/apps/src/codebridge/FileBrowser/FileBrowserRow/ItemRow.tsx
+++ b/apps/src/codebridge/FileBrowser/FileBrowserRow/ItemRow.tsx
@@ -38,7 +38,7 @@ export const ItemRow: React.FunctionComponent<ItemRowProps> = ({
   openFunction,
   className,
 }) => {
-  const dragDescribedBy = useContext(DragDescriptionContext);
+  const dragAriaAttributes = useContext(DragDescriptionContext);
 
   return (
     <div
@@ -49,7 +49,9 @@ export const ItemRow: React.FunctionComponent<ItemRowProps> = ({
         type="button"
         className={moduleStyles.label}
         onClick={() => openFunction(item.id)}
-        aria-describedby={dragDescribedBy}
+        aria-describedby={dragAriaAttributes?.['aria-describedby']}
+        aria-roledescription={dragAriaAttributes?.['aria-roledescription']}
+        aria-pressed={dragAriaAttributes?.['aria-pressed']}
       >
         <IconComponent item={item} />
         <NameComponent item={item} />

--- a/apps/src/codebridge/FileBrowser/InnerFileBrowser.tsx
+++ b/apps/src/codebridge/FileBrowser/InnerFileBrowser.tsx
@@ -5,10 +5,9 @@ import React from 'react';
 
 import {START_SOURCES} from '@cdo/apps/lab2/constants';
 import {getAppOptionsEditBlocks} from '@cdo/apps/lab2/projects/utils';
-import {setActiveFileThunk} from '@cdo/apps/lab2/redux/lab2ProjectReduxThunks';
 import {isReadOnlyWorkspace} from '@cdo/apps/lab2/redux/lab2ReduxSelectors';
 import {MultiFileSource, ProjectFileType} from '@cdo/apps/lab2/types';
-import {useAppDispatch, useAppSelector} from '@cdo/apps/util/reduxHooks';
+import {useAppSelector} from '@cdo/apps/util/reduxHooks';
 
 import {useDndDataContext} from './DnDDataContextProvider';
 import {NotDraggable, Draggable} from './Draggable';
@@ -38,7 +37,6 @@ const InnerFileBrowser = React.memo(
       f => f.type === ProjectFileType.VALIDATION
     );
     const isReadOnly = useAppSelector(isReadOnlyWorkspace);
-    const dispatch = useAppDispatch();
 
     return (
       <>
@@ -51,7 +49,7 @@ const InnerFileBrowser = React.memo(
               <Droppable
                 data={{id: f.id}}
                 key={f.id + f.open}
-                Component="div"
+                Component="li"
                 className={classNames(moduleStyles.droppableArea, {
                   [moduleStyles.acceptingDrop]: f.id === dropData?.id,
                 })}
@@ -69,14 +67,16 @@ const InnerFileBrowser = React.memo(
                     enableMenu={!isReadOnly && !dragData?.id}
                   />
                   {f.open && (
-                    <div className={moduleStyles.folder}>
+                    // role="list" needed: list-style:none strips VoiceOver semantics
+                    // eslint-disable-next-line jsx-a11y/no-redundant-roles
+                    <ul className={moduleStyles.folder} role="list">
                       <InnerFileBrowser
                         folders={folders}
                         parentId={f.id}
                         files={files}
                         appName={appName}
                       />
-                    </div>
+                    </ul>
                   )}
                 </MaybeDraggable>
               </Droppable>
@@ -98,18 +98,14 @@ const InnerFileBrowser = React.memo(
             };
             const MaybeDraggable = isDraggingLocked ? NotDraggable : Draggable;
             return (
-              <MaybeDraggable
-                data={{id: f.id, type: DragType.FILE, parentId: f.folderId}}
-                key={f.id}
-                Component="div"
-                onKeyDown={event => {
-                  if (event.key === 'Enter' || event.key === ' ') {
-                    dispatch(setActiveFileThunk(f.id));
-                  }
-                }}
-              >
-                <FileRow {...fileRowProps} />
-              </MaybeDraggable>
+              <li key={f.id}>
+                <MaybeDraggable
+                  data={{id: f.id, type: DragType.FILE, parentId: f.folderId}}
+                  Component="div"
+                >
+                  <FileRow {...fileRowProps} />
+                </MaybeDraggable>
+              </li>
             );
           })}
       </>

--- a/apps/src/codebridge/FileBrowser/InnerFileBrowser.tsx
+++ b/apps/src/codebridge/FileBrowser/InnerFileBrowser.tsx
@@ -69,14 +69,14 @@ const InnerFileBrowser = React.memo(
                   {f.open && (
                     // role="list" needed: list-style:none strips VoiceOver semantics
                     // eslint-disable-next-line jsx-a11y/no-redundant-roles
-                    <ul className={moduleStyles.folder} role="list">
+                    <ol className={moduleStyles.folder} role="list">
                       <InnerFileBrowser
                         folders={folders}
                         parentId={f.id}
                         files={files}
                         appName={appName}
                       />
-                    </ul>
+                    </ol>
                   )}
                 </MaybeDraggable>
               </Droppable>

--- a/apps/src/codebridge/FileBrowser/styles/filebrowser.module.scss
+++ b/apps/src/codebridge/FileBrowser/styles/filebrowser.module.scss
@@ -64,8 +64,8 @@
   }
 }
 
-// list-style:none removes bullets but causes VoiceOver/Safari to strip list
-// semantics; every <ul> using this class must carry role="list" to restore them.
+// list-style:none removes default markers; role="list" on every <ol> using this
+// class restores the VoiceOver/Safari semantics that list-style:none strips.
 .folder {
   list-style: none;
   padding: 0;

--- a/apps/src/codebridge/FileBrowser/styles/filebrowser.module.scss
+++ b/apps/src/codebridge/FileBrowser/styles/filebrowser.module.scss
@@ -64,8 +64,16 @@
   }
 }
 
+// list-style:none removes bullets but causes VoiceOver/Safari to strip list
+// semantics; every <ul> using this class must carry role="list" to restore them.
+.folder {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
 // Adds indent and border when a folder or file is in a folder
-.fileBrowser div.folder div.folder {
+.fileBrowser .folder .folder {
   padding-inline-start: 8px;
 
   .row:not(.dragging) {
@@ -84,7 +92,7 @@
   }
 }
 
-.fileBrowser div.folder div span.button-bar {
+.fileBrowser .folder div span.button-bar {
   display: flex;
   justify-content: flex-start;
   flex-direction: column;
@@ -92,11 +100,11 @@
   white-space: nowrap;
 }
 
-.fileBrowser div.folder div span.button-bar span:hover {
+.fileBrowser .folder div span.button-bar span:hover {
   background-color: var(--background-neutral-quaternary);
 }
 
-.fileBrowser div.folder div span.button-bar span {
+.fileBrowser .folder div span.button-bar span {
   display: grid;
   grid-template-columns: 15px auto;
 }
@@ -123,11 +131,9 @@ button.button-kebab {
   }
 }
 
-// This allows the ellipsis to display when its button host is hovered on or has focus
+// This allows the ellipsis to display when the row is hovered or contains focus
 .row:hover > .button-kebab,
-.notDraggable:focus-within > .row > .button-kebab,
-.draggable:hover > .button-kebab,
-.draggable:focus > .row > .button-kebab,
+.row:focus-within > .button-kebab,
 button.button-kebab:focus {
   opacity: 1;
 }
@@ -149,7 +155,24 @@ button.button-kebab:focus {
 .label {
   display: flex;
   justify-content: flex-start;
+  align-items: center;
+  align-self: stretch;
   overflow: hidden;
+  flex: 1;
+  // Button reset — ensures <button> renders identically to the old <div>
+  appearance: none;
+  -webkit-appearance: none;
+  background: none;
+  border: none;
+  padding: 0;
+  margin: 0;
+  cursor: pointer;
+  color: inherit;
+  font: inherit;
+  line-height: inherit;
+  text-align: start;
+  min-width: 0;
+  box-sizing: border-box;
 
   i {
     color: var(--text-neutral-tertiary);
@@ -193,8 +216,7 @@ button.button-kebab:focus {
   cursor: grabbing;
 }
 
-.notDraggable:focus-visible,
-.draggable:focus-visible {
+.label:focus-visible {
   outline: var(--borders-brand-teal-primary) solid 2px;
   outline-offset: -2px;
   border-radius: 0.375rem;

--- a/apps/src/codebridge/FileTabs/FileTabs.tsx
+++ b/apps/src/codebridge/FileTabs/FileTabs.tsx
@@ -28,7 +28,6 @@ import {
 } from '@dnd-kit/sortable';
 import React, {useMemo, useState} from 'react';
 
-import i18n from '@cdo/apps/codebridge/locale';
 import {
   closeFileThunk,
   rearrangeFilesThunk,
@@ -154,7 +153,8 @@ export const FileTabs = React.memo(() => {
         accessibility={{
           announcements,
           screenReaderInstructions: {
-            draggable: i18n.dragAndDropInstructionsTabs(),
+            draggable:
+              'Press m to pick up, arrow keys to move, m, space, or enter to drop, escape to cancel.',
           },
         }}
       >


### PR DESCRIPTION
## Summary

Fixes two WCAG violations in the Codebridge file browser that affected every project with files.

**WCAG 4.1.2 — Nested interactive controls (dnd-kit)**

dnd-kit's `useDraggable` spreads `attributes` onto the drag wrapper, which includes `role="button"` and `tabIndex`. This made every file and folder row a focusable `role="button"` element containing the kebab menu `<button>`, violating 4.1.2. `NotDraggable` had the same problem with hardcoded `role="button"` and `tabIndex: 0`.

Changes:
- Removed `...attributes` from `Draggable`'s element props. The wrapper div is now a plain, non-interactive container.
- Added `DragDescriptionContext`: threads dnd-kit's `aria-describedby` ID from `Draggable` down via React context, so the label button announces drag instructions when focused.
- Removed `role="button"`, `tabIndex`, and `onKeyDown` from `NotDraggable`.
- Label in `ItemRow` changed from `<div onClick>` to `<button type="button" aria-describedby>`. Native `<button>` handles Enter/Space for opening files and toggling folders, and properly announces list context to VoiceOver.
- Updated screenreader keyboard nav drag and drop instructions to be shorter and simpler (especially because they are read on every file and folder)

**WCAG 1.3.1 — List semantics not announced by VoiceOver**

Files and folders were rendered in a `<div>`, giving VoiceOver no list structure. Additionally, `list-style: none` causes Safari/VoiceOver to strip list semantics from list elements unless `role="list"` is explicitly present.

Changes:
- Root container changed from `<div>` to `<ol role="list" aria-label="Files">`. Files and folders are sorted alphabetically, making `<ol>` the correct semantic element.
- Nested open-folder containers changed from `<div>` to `<ol role="list">`.
- Folder `Droppable` renders as `Component="li"`; file items wrapped in `<li>`, giving the lists valid `<li>` direct children.
- `.folder` CSS class: `list-style: none; padding: 0; margin: 0;` with `role="list"` on each `<ol>` to restore the VoiceOver semantics that `list-style: none` strips.
- CSS selectors updated from `div.folder` to `.folder` to match the new `<ol>` elements.
- With native `<button>` inside `<li>` inside `<ol role="list">`, VoiceOver announces "Files, list, N items" during Tab navigation.

**Icon accessibility**
- `aria-hidden` added to `FileRowIcon` and `FolderRowIcon`. These icons are decorative — the filename provides the accessible name.

**Focus and keyboard improvements**
- Focus outline moved from `.draggable:focus-visible` / `.notDraggable:focus-visible` to `.label:focus-visible`, so focus is shown on the interactive element.
- Kebab visibility simplified to `.row:hover` and `.row:focus-within`, replacing the old wrapper-focused selectors.
- `.label` button reset ensures `<button>` renders identically to the old `<div>` (removes browser default margins, padding, font, appearance).

## Test plan

- [x] Tab through the file browser with VoiceOver on Safari — should announce "Files, list, N items" on first item
- [x] Enter/Space on a file opens it; Enter/Space on a folder toggles it open/closed
- [x] Press 'm' on a focused item to drag; arrow keys to move; 'm'/Enter/Space to drop; Escape to cancel; screen reader announces each step (pre-existing behavior — verify no regression)
- [x] Kebab menu appears on hover and keyboard focus
- [x] File and folder icons not announced by screen reader (decorative)
- [x] No bullets or numbers visible on list items
- [x] Read-only workspace: items render correctly, no drag handles
- [x] Nested folders: open a folder, Tab into its contents — VoiceOver should announce a nested list context
- [x] Mouse drag still works end-to-end (pointer sensor wasn't touched but worth confirming)
- [x] Clicking a folder opens it; clicking again closes it
- [x] Kebab menu options all still fire correctly (rename, delete, etc.)
- [x] Verify all WCAG violations for nested controls in this area disappear on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Video of a bunch of the interactions for posterity:

https://github.com/user-attachments/assets/f4401e3c-ea8c-4ec3-974a-6f95cb6562dc



- Jira: https://codedotorg.atlassian.net/browse/SL-1686
- https://codedotorg.atlassian.net/browse/SL-1689
- VPAT: https://axeauditor.dequecloud.com/test-run/dad68808-2a69-11f1-8768-0b2b032555fe/issues?sortField=ordinal&sortDir=asc&filter%5Bstatus%5D=open&filter%5Bpage_number%5D=3



## Deployment notes
<!-- Delete this section if it's a standard merge-and-deploy.
     Otherwise: migrations, feature flags, coordination, caching impacts, etc. -->



## Privacy and security
<!-- Delete this section if there is no privacy/security impact.
     Otherwise: new PII, auth changes, API surface changes, etc. -->

