### PR TITLE
AI Gateway Client -Enable behind experiment flag for Gemini models (Tutor + ChatLab)

### DIFF
--- a/apps/src/aichat/api/client/helpers/modelHelpers.ts
+++ b/apps/src/aichat/api/client/helpers/modelHelpers.ts
@@ -5,6 +5,8 @@ import {type LanguageModel} from 'ai';
 import {ValueOf} from '@cdo/apps/types/utils';
 import {AiChatModelIds} from '@cdo/generated-scripts/sharedConstants';
 
+type ModelId = ValueOf<typeof AiChatModelIds>;
+
 const googleProvider = createGoogleGenerativeAI({
   apiKey: '',
 });
@@ -13,19 +15,28 @@ const openAiProvider = createOpenAI({
   apiKey: '',
 });
 
+// All models served via the Google provider. isGeminiModel is derived from this
+// list, so adding a model here is the only change needed to extend gateway support.
+const googleModelIds: ModelId[] = [
+  AiChatModelIds.GEMINI_2_5_FLASH_IMAGE,
+  AiChatModelIds.GEMINI_2_5_FLASH,
+  AiChatModelIds.GEMINI_2_0_FLASH,
+  AiChatModelIds.GEMINI_2_5_PRO,
+  AiChatModelIds.GEMINI_2_5_FLASH_LITE,
+];
+
 const modelMap: {
-  [key in ValueOf<typeof AiChatModelIds>]?: LanguageModel;
+  [key in ModelId]?: LanguageModel;
 } = {
-  [AiChatModelIds.GEMINI_2_5_FLASH_IMAGE]: googleProvider(
-    AiChatModelIds.GEMINI_2_5_FLASH_IMAGE
-  ),
-  [AiChatModelIds.GEMINI_2_5_FLASH]: googleProvider(
-    AiChatModelIds.GEMINI_2_5_FLASH
-  ),
+  ...Object.fromEntries(googleModelIds.map(id => [id, googleProvider(id)])),
   [AiChatModelIds.CHATGPT]: openAiProvider(AiChatModelIds.CHATGPT),
 };
 
-export function getModel(modelId: ValueOf<typeof AiChatModelIds>) {
+export function isGeminiModel(modelId: ModelId): boolean {
+  return googleModelIds.includes(modelId);
+}
+
+export function getModel(modelId: ModelId) {
   if (!modelMap[modelId]) {
     throw new Error('Unsupported model ID: ' + modelId);
   }

--- a/apps/src/aichat/api/supportsClientApi.ts
+++ b/apps/src/aichat/api/supportsClientApi.ts
@@ -1,5 +1,5 @@
-import experiments from '@cdo/apps/util/experiments';
 import {ValueOf} from '@cdo/apps/types/utils';
+import experiments from '@cdo/apps/util/experiments';
 import {AiChatModelIds} from '@cdo/generated-scripts/sharedConstants';
 
 import {isGeminiModel} from './client/helpers/modelHelpers';

--- a/apps/src/aichat/api/supportsClientApi.ts
+++ b/apps/src/aichat/api/supportsClientApi.ts
@@ -11,6 +11,6 @@ export default function supportsClientApi(modelId: ModelId) {
   if (modelId === AiChatModelIds.GEMINI_2_5_FLASH_IMAGE) return true;
   return (
     isGeminiModel(modelId) &&
-    experiments.isEnabledAllowingQueryString('useAiGateway')
+    experiments.isEnabledAllowingQueryString(experiments.USE_AI_GATEWAY)
   );
 }

--- a/apps/src/aichat/api/supportsClientApi.ts
+++ b/apps/src/aichat/api/supportsClientApi.ts
@@ -1,9 +1,16 @@
+import experiments from '@cdo/apps/util/experiments';
 import {ValueOf} from '@cdo/apps/types/utils';
 import {AiChatModelIds} from '@cdo/generated-scripts/sharedConstants';
 
+import {isGeminiModel} from './client/helpers/modelHelpers';
+
 type ModelId = ValueOf<typeof AiChatModelIds>;
-const supportedModels: ModelId[] = [AiChatModelIds.GEMINI_2_5_FLASH_IMAGE];
 
 export default function supportsClientApi(modelId: ModelId) {
-  return supportedModels.includes(modelId);
+  // FLASH_IMAGE has no Rails backend support, so it always routes through the gateway.
+  if (modelId === AiChatModelIds.GEMINI_2_5_FLASH_IMAGE) return true;
+  return (
+    isGeminiModel(modelId) &&
+    experiments.isEnabledAllowingQueryString('useAiGateway')
+  );
 }

--- a/apps/src/util/experiments.js
+++ b/apps/src/util/experiments.js
@@ -69,6 +69,8 @@ experiments.LESSON_TUTOR = 'lesson-tutor';
 experiments.ONBOARDING = 'onboarding';
 // Enable AI Diff Chat Drawer
 experiments.AI_DIFF_DRAWER = 'ai-diff-drawer';
+// Route all Gemini model traffic through the AI gateway instead of the Rails backend
+experiments.USE_AI_GATEWAY = 'useAiGateway';
 
 /**
  * This was a gamified version of the finish dialog, built in 2018,


### PR DESCRIPTION
## Summary

<img width="1109" height="866" alt="Screenshot 2026-04-24 at 11 48 41 AM" src="https://github.com/user-attachments/assets/beb55d96-ea4a-4f27-a55c-edc10f795778" /><br>

The AI gateway is already the path for `gemini-2.5-flash-image` (which has no
Rails fallback). This PR extends gateway coverage to all remaining Gemini models
behind the `useAiGateway` experiment, making the gateway the standard path for
all Gemini inference across AI Chat Lab and AI Tutor (WebLab2, PythonLab, legacy
labs). When the experiment is off, everything behaves as before.  This experiment can be coupled with the `useTurnstile` experiment for the full planned gateway pipeline/experience.

Models now routed through the gateway when the experiment is on:
- `gemini-2.5-flash`
- `gemini-2.0-flash`
- `gemini-2.5-pro`
- `gemini-2.5-flash-lite`

## Changes

- **`modelHelpers.ts`** — introduces `googleModelIds` as the single source of
  truth for Google-provider models. The model map is built from it, and the new
  exported `isGeminiModel()` predicate is a straight membership check against
  the same list. Adding a future Gemini model is a one-line change here.
- **`supportsClientApi.ts`** — uses `isGeminiModel` + `useAiGateway` experiment
  check. `gemini-2.5-flash-image` short-circuits to `true` unconditionally as
  before.
- **`experiments.js`** — adds `USE_AI_GATEWAY = 'useAiGateway'` constant.

## Enabling the experiment

**One page load** (not persisted):
```
?useAiGateway=1
```

**Persistent** (stored in localStorage):
```
?enableExperiments=useAiGateway
```

**Disable** (clears it from localStorage):
```
?disableExperiments=useAiGateway
```

## Testing with Turnstile (hidden CAPTCHA)

`useTurnstile` enables Cloudflare Turnstile bot protection on gateway requests.
To test the full production-like path with both active:

**One page load:**
```
?useAiGateway=1&useTurnstile=1
```

**Persistent:**
```
?enableExperiments=useAiGateway,useTurnstile
```

Without `useTurnstile`, gateway requests skip the Turnstile
challenge. Enabling it exercises the complete auth flow: JWT access token from
`/ai_gateway/access_token` plus Turnstile token, both sent to
`https://ai-gateway.code.org`.