### PR TITLE
Sketch2 node toolbar: use ref to return focus

### DIFF
--- a/apps/src/sketchlab/reactFlow/nodes/ImageNode.tsx
+++ b/apps/src/sketchlab/reactFlow/nodes/ImageNode.tsx
@@ -18,6 +18,7 @@ function ImageNode({id, data, selected}: NodeProps<ImageNodeType>) {
   const [isEditingAlt, setIsEditingAlt] = useState(false);
   const [altValue, setAltValue] = useState('');
   const cancelledRef = useRef(false);
+  const nodeRef = useRef<HTMLDivElement>(null);
 
   const {src, altText} = data;
   const showHandles = data.showHandles !== false;
@@ -64,14 +65,18 @@ function ImageNode({id, data, selected}: NodeProps<ImageNodeType>) {
   );
 
   return (
-    <div className={styles.imageNode} aria-label={altText || 'Image node'}>
+    <div
+      ref={nodeRef}
+      className={styles.imageNode}
+      aria-label={altText || 'Image node'}
+    >
       <NodeResizer
         isVisible={selected}
         minWidth={MIN_NODE_WIDTH}
         minHeight={MIN_NODE_HEIGHT}
       />
 
-      <ImageNodeToolbar nodeId={id} />
+      <ImageNodeToolbar nodeId={id} nodeElementRef={nodeRef} />
 
       <img src={src} alt={altText} className={styles.image} draggable={false} />
 

--- a/apps/src/sketchlab/reactFlow/nodes/ShapeNode.tsx
+++ b/apps/src/sketchlab/reactFlow/nodes/ShapeNode.tsx
@@ -73,6 +73,7 @@ function ShapeNode({id, data, selected}: NodeProps<ShapeNodeType>) {
   const readOnly = useSketchLabReadOnly();
   const {updateNodeData} = useReactFlow();
   const [isEditing, setIsEditing] = useState(false);
+  const nodeRef = useRef<HTMLDivElement>(null);
   const labelRef = useRef<HTMLDivElement>(null);
 
   const {shapeType, label, backgroundColor, strokeColor} = data;
@@ -145,6 +146,7 @@ function ShapeNode({id, data, selected}: NodeProps<ShapeNodeType>) {
 
   return (
     <div
+      ref={nodeRef}
       className={styles.shapeNode}
       aria-label={`${shapeType} shape: ${label}`}
       onDoubleClick={startEditing}
@@ -155,7 +157,7 @@ function ShapeNode({id, data, selected}: NodeProps<ShapeNodeType>) {
         minHeight={MIN_NODE_HEIGHT}
       />
 
-      <ShapeNodeToolbar nodeId={id} />
+      <ShapeNodeToolbar nodeId={id} nodeElementRef={nodeRef} />
 
       {/* Background shape */}
       {isRectangle ? (

--- a/apps/src/sketchlab/reactFlow/nodes/TextNode.tsx
+++ b/apps/src/sketchlab/reactFlow/nodes/TextNode.tsx
@@ -15,6 +15,7 @@ function TextNode({id, data, selected}: NodeProps<TextNodeType>) {
   const readOnly = useSketchLabReadOnly();
   const {updateNodeData} = useReactFlow();
   const [isEditing, setIsEditing] = useState(false);
+  const nodeRef = useRef<HTMLDivElement>(null);
   const textRef = useRef<HTMLDivElement>(null);
 
   const {text} = data;
@@ -74,6 +75,7 @@ function TextNode({id, data, selected}: NodeProps<TextNodeType>) {
 
   return (
     <div
+      ref={nodeRef}
       className={styles.textNode}
       aria-label={`Text: ${text}`}
       onDoubleClick={startEditing}
@@ -84,7 +86,7 @@ function TextNode({id, data, selected}: NodeProps<TextNodeType>) {
         minHeight={MIN_NODE_HEIGHT}
       />
 
-      <TextNodeToolbar nodeId={id} />
+      <TextNodeToolbar nodeId={id} nodeElementRef={nodeRef} />
 
       <div
         ref={textRef}

--- a/apps/src/sketchlab/reactFlow/nodes/nodeToolbars/ImageNodeToolbar.tsx
+++ b/apps/src/sketchlab/reactFlow/nodes/nodeToolbars/ImageNodeToolbar.tsx
@@ -8,7 +8,7 @@ import {useNodeToolbarData} from './useNodeToolbarData';
 
 interface ImageNodeToolbarProps {
   nodeId: string;
-  nodeElementRef: React.RefObject<HTMLDivElement | null>;
+  nodeElementRef: React.RefObject<HTMLDivElement>;
 }
 
 export default function ImageNodeToolbar({

--- a/apps/src/sketchlab/reactFlow/nodes/nodeToolbars/ImageNodeToolbar.tsx
+++ b/apps/src/sketchlab/reactFlow/nodes/nodeToolbars/ImageNodeToolbar.tsx
@@ -8,14 +8,22 @@ import {useNodeToolbarData} from './useNodeToolbarData';
 
 interface ImageNodeToolbarProps {
   nodeId: string;
+  nodeElementRef: React.RefObject<HTMLDivElement | null>;
 }
 
-export default function ImageNodeToolbar({nodeId}: ImageNodeToolbarProps) {
+export default function ImageNodeToolbar({
+  nodeId,
+  nodeElementRef,
+}: ImageNodeToolbarProps) {
   const {data, patchNodeData} = useNodeToolbarData<ImageNodeType>(nodeId);
   const handlesVisible = data.showHandles !== false;
 
   return (
-    <NodeToolbarShell nodeId={nodeId} ariaLabel="Image options">
+    <NodeToolbarShell
+      nodeId={nodeId}
+      nodeElementRef={nodeElementRef}
+      ariaLabel="Image options"
+    >
       <HandleVisibilityToggle
         visible={handlesVisible}
         onToggle={() => patchNodeData({showHandles: !handlesVisible})}

--- a/apps/src/sketchlab/reactFlow/nodes/nodeToolbars/NodeToolbarShell.tsx
+++ b/apps/src/sketchlab/reactFlow/nodes/nodeToolbars/NodeToolbarShell.tsx
@@ -20,12 +20,14 @@ const CONTROLS_WIDTH_PX = 60;
 
 interface NodeToolbarShellProps {
   nodeId: string;
+  nodeElementRef: React.RefObject<HTMLDivElement | null>;
   ariaLabel: string;
   children: React.ReactNode;
 }
 
 export default function NodeToolbarShell({
   nodeId,
+  nodeElementRef,
   ariaLabel,
   children,
 }: NodeToolbarShellProps) {
@@ -66,11 +68,8 @@ export default function NodeToolbarShell({
   }, [isVisible, getViewport, setViewport]);
 
   const returnFocusToNode = useCallback(() => {
-    const nodeElement = document.querySelector<HTMLElement>(
-      `.react-flow__node[data-id="${nodeId}"]`
-    );
-    nodeElement?.focus();
-  }, [nodeId]);
+    nodeElementRef.current?.closest<HTMLElement>('.react-flow__node')?.focus();
+  }, [nodeElementRef]);
 
   const handleClose = useCallback(() => {
     closeNodeToolbar();

--- a/apps/src/sketchlab/reactFlow/nodes/nodeToolbars/NodeToolbarShell.tsx
+++ b/apps/src/sketchlab/reactFlow/nodes/nodeToolbars/NodeToolbarShell.tsx
@@ -20,7 +20,7 @@ const CONTROLS_WIDTH_PX = 60;
 
 interface NodeToolbarShellProps {
   nodeId: string;
-  nodeElementRef: React.RefObject<HTMLDivElement | null>;
+  nodeElementRef: React.RefObject<HTMLDivElement>;
   ariaLabel: string;
   children: React.ReactNode;
 }

--- a/apps/src/sketchlab/reactFlow/nodes/nodeToolbars/ShapeNodeToolbar.tsx
+++ b/apps/src/sketchlab/reactFlow/nodes/nodeToolbars/ShapeNodeToolbar.tsx
@@ -19,16 +19,24 @@ import {useNodeToolbarData} from './useNodeToolbarData';
 
 interface ShapeNodeToolbarProps {
   nodeId: string;
+  nodeElementRef: React.RefObject<HTMLDivElement | null>;
 }
 
-export default function ShapeNodeToolbar({nodeId}: ShapeNodeToolbarProps) {
+export default function ShapeNodeToolbar({
+  nodeId,
+  nodeElementRef,
+}: ShapeNodeToolbarProps) {
   const {data, patchNodeData} = useNodeToolbarData<ShapeNodeType>(nodeId);
 
   const {backgroundColor, strokeColor, fontSize, fontColor} = data;
   const handlesVisible = data.showHandles !== false;
 
   return (
-    <NodeToolbarShell nodeId={nodeId} ariaLabel="Shape style">
+    <NodeToolbarShell
+      nodeId={nodeId}
+      nodeElementRef={nodeElementRef}
+      ariaLabel="Shape style"
+    >
       <SwatchGroup
         groupLabel="Background"
         swatches={BACKGROUND_PALETTE}

--- a/apps/src/sketchlab/reactFlow/nodes/nodeToolbars/ShapeNodeToolbar.tsx
+++ b/apps/src/sketchlab/reactFlow/nodes/nodeToolbars/ShapeNodeToolbar.tsx
@@ -19,7 +19,7 @@ import {useNodeToolbarData} from './useNodeToolbarData';
 
 interface ShapeNodeToolbarProps {
   nodeId: string;
-  nodeElementRef: React.RefObject<HTMLDivElement | null>;
+  nodeElementRef: React.RefObject<HTMLDivElement>;
 }
 
 export default function ShapeNodeToolbar({

--- a/apps/src/sketchlab/reactFlow/nodes/nodeToolbars/TextNodeToolbar.tsx
+++ b/apps/src/sketchlab/reactFlow/nodes/nodeToolbars/TextNodeToolbar.tsx
@@ -16,7 +16,7 @@ import {useNodeToolbarData} from './useNodeToolbarData';
 
 interface TextNodeToolbarProps {
   nodeId: string;
-  nodeElementRef: React.RefObject<HTMLDivElement | null>;
+  nodeElementRef: React.RefObject<HTMLDivElement>;
 }
 
 export default function TextNodeToolbar({

--- a/apps/src/sketchlab/reactFlow/nodes/nodeToolbars/TextNodeToolbar.tsx
+++ b/apps/src/sketchlab/reactFlow/nodes/nodeToolbars/TextNodeToolbar.tsx
@@ -16,16 +16,24 @@ import {useNodeToolbarData} from './useNodeToolbarData';
 
 interface TextNodeToolbarProps {
   nodeId: string;
+  nodeElementRef: React.RefObject<HTMLDivElement | null>;
 }
 
-export default function TextNodeToolbar({nodeId}: TextNodeToolbarProps) {
+export default function TextNodeToolbar({
+  nodeId,
+  nodeElementRef,
+}: TextNodeToolbarProps) {
   const {data, patchNodeData} = useNodeToolbarData<TextNodeType>(nodeId);
 
   const {fontSize, fontColor} = data;
   const handlesVisible = data.showHandles !== false;
 
   return (
-    <NodeToolbarShell nodeId={nodeId} ariaLabel="Text style">
+    <NodeToolbarShell
+      nodeId={nodeId}
+      nodeElementRef={nodeElementRef}
+      ariaLabel="Text style"
+    >
       <FontSizeGroup
         selectedValue={fontSize ?? DEFAULT_FONT_SIZE}
         onSelect={value => patchNodeData({fontSize: value as FontSizeValue})}


### PR DESCRIPTION
Small follow up to #72285 to use refs to help with returning focus to a node after escaping/closing the node toolbar menu. We still need a query because we don't own the actual element being focused, but this elements a document query.


## Testing story
Tested locally, no visible changes here.


