### PR TITLE
fix(i18n): return fallback from `es` to `es-MX`

### DIFF
--- a/dashboard/config/application.rb
+++ b/dashboard/config/application.rb
@@ -158,6 +158,8 @@ module Dashboard
       Cdo::I18n::LOCALE_ALIASES.each do |short_locale, normalized_locale|
         I18n.fallbacks.map(short_locale.to_sym => normalized_locale.to_sym)
       end
+
+      I18n.fallbacks.map(es: :'es-MX')
     end
 
     config.assets.gzip = false # cloudfront gzips everything for us on the fly.


### PR DESCRIPTION
<img src="https://github.com/user-attachments/assets/f7e3c374-824b-4f7e-8118-646d50a177b0" />

## Links
- Related PR: https://github.com/code-dot-org/code-dot-org/pull/72068