### PR TITLE
scrub only sections_owned

### DIFF
--- a/dashboard/lib/services/user/pii_scrubber.rb
+++ b/dashboard/lib/services/user/pii_scrubber.rb
@@ -161,7 +161,7 @@ module Services
 
       private def scrub_sections
         if user.teacher?
-          user.sections.with_deleted.find_each do |section|
+          user.sections_owned.with_deleted.find_each do |section|
             section.update!(name: REDACTED_STRING)
           end
         end

--- a/dashboard/test/lib/services/user/pii_scrubber_test.rb
+++ b/dashboard/test/lib/services/user/pii_scrubber_test.rb
@@ -59,8 +59,25 @@ class Services::User::PiiScrubberTest < ActiveSupport::TestCase
 
     it 'redacts section names' do
       scrub_pii
-      user.sections.with_deleted.each do |section|
+      user.sections_owned.with_deleted.each do |section|
         _(section.reload.name).must_equal Services::User::PiiScrubber::REDACTED_STRING
+      end
+    end
+
+    context 'when user is a co-instructor for another teacher\'s section' do
+      let(:soft_deleted_user) {false}
+      let(:other_teacher) {create(:teacher)}
+      let(:co_taught_section) {create(:section, user: other_teacher, name: 'Shared Section')}
+
+      before do
+        co_taught_section
+        create(:section_instructor, section: co_taught_section, instructor: user, status: :active)
+        user.update_column(:deleted_at, Time.zone.now)
+      end
+
+      it 'does not redact sections co-instructed but not owned by the user' do
+        scrub_pii
+        _(co_taught_section.reload.name).must_equal 'Shared Section'
       end
     end
 


### PR DESCRIPTION
The PII scrubber has been erroring out for a user with `Validation failed: User must be a teacher"`. It looks to me like the issue is that it's trying to update some sections where the teacher is a co-instructor, but not an owner. Since the intent of the scrubber is to only touch sections that the teacher owns, this PR attempts to fix the issue by referencing `sections_owned` instead of `sections`. This is the proper relation to reference now that co-instructors exist.

While I'm not 100% sure this will fix the validation error, it is a functional fix that needs to happen anyway.


## Links
[JIRA](https://codedotorg.atlassian.net/browse/P20-1856)

## Testing story
<!-- How was this tested? Manual steps, adhoc links, automated tests, or why testing isn't needed. -->



## Deployment notes
<!-- Delete this section if it's a standard merge-and-deploy.
     Otherwise: migrations, feature flags, coordination, caching impacts, etc. -->



## Privacy and security
<!-- Delete this section if there is no privacy/security impact.
     Otherwise: new PII, auth changes, API surface changes, etc. -->

