### PR TITLE
fix seed crash when destroying outdated models from id-less join tables

### DIFF
--- a/dashboard/lib/services/script_seed.rb
+++ b/dashboard/lib/services/script_seed.rb
@@ -799,7 +799,7 @@ module Services
         if model_class.primary_key
           model_class.destroy(should_keep[false].pluck(:id))
         else
-          should_keep[false].each {|record| model_class.where(record.attributes.compact).delete_all}
+          puts "WARNING: skipping destroy of #{should_keep[false].size} outdated #{model_class.name} records (table has no primary key)"
         end
       end
       should_keep[true]

--- a/dashboard/lib/services/script_seed.rb
+++ b/dashboard/lib/services/script_seed.rb
@@ -795,7 +795,13 @@ module Services
     def self.destroy_outdated_objects(model_class, all_objects, imported_objects, seed_context)
       objects_to_keep_by_seeding_key = imported_objects.index_by {|o| o.seeding_key(seed_context)}
       should_keep = all_objects.group_by {|o| objects_to_keep_by_seeding_key.include?(o.seeding_key(seed_context))}
-      model_class.destroy(should_keep[false].pluck(:id)) if should_keep.include?(false)
+      if should_keep.include?(false)
+        if model_class.primary_key
+          model_class.destroy(should_keep[false].pluck(:id))
+        else
+          should_keep[false].each {|record| model_class.where(record.attributes.compact).delete_all}
+        end
+      end
       should_keep[true]
     end
 


### PR DESCRIPTION
`destroy_outdated_objects` assumes every model has an `id` primary key, `calling pluck(:id)` and `destroy(ids)`. For `id: false` join tables like `levels_script_levels` this raises `ActiveRecord::UnknownPrimaryKey`.

The bug is latent — it only surfaces when a level is actually removed from a previously-seeded script, which happened for the first time with ai-generated-design-2026 in the current production deploy.

For models without a primary key, delete by matching on row attributes instead of by id.

**Alternatively** perhaps we could skip deletion from tables without primary keys? Is there a cascading delete that covers this case?

## Links
<!-- Jira tickets, design docs, Slack threads, related PRs, etc. -->

- Jira:

## Testing story
<!-- How was this tested? Manual steps, adhoc links, automated tests, or why testing isn't needed. -->



## Deployment notes
<!-- Delete this section if it's a standard merge-and-deploy.
     Otherwise: migrations, feature flags, coordination, caching impacts, etc. -->



## Privacy and security
<!-- Delete this section if there is no privacy/security impact.
     Otherwise: new PII, auth changes, API surface changes, etc. -->

