### PR TITLE
Sketch2: add diamond shape

### DIFF
--- a/apps/src/sketchlab/reactFlow/components/Toolbar.tsx
+++ b/apps/src/sketchlab/reactFlow/components/Toolbar.tsx
@@ -105,6 +105,19 @@ export default function Toolbar({onAddNode}: ToolbarProps) {
         </IconButton>
       </Tooltip>
 
+      <Tooltip title="Add diamond" placement="right">
+        <IconButton
+          aria-label="Add diamond"
+          id={`${uid}-diamond`}
+          onClick={() => addShape('diamond')}
+          size="small"
+          color="tertiary"
+          variant="outlined"
+        >
+          <FontAwesomeV6Icon iconName="diamond" />
+        </IconButton>
+      </Tooltip>
+
       <Tooltip title="Add text" placement="right">
         <IconButton
           aria-label="Add text"

--- a/apps/src/sketchlab/reactFlow/nodes/ShapeNode.tsx
+++ b/apps/src/sketchlab/reactFlow/nodes/ShapeNode.tsx
@@ -13,6 +13,8 @@ import styles from './shape-node.module.scss';
 
 // SVG path for an equilateral-ish triangle filling a 100x100 viewBox.
 const TRIANGLE_POINTS = '50,5 95,95 5,95';
+// SVG path for a diamond (rhombus) filling a 100x100 viewBox: top, right, bottom, left.
+const DIAMOND_POINTS = '50,5 95,50 50,95 5,50';
 const SHAPE_BORDER_PX = 2;
 
 interface ShapeSvgProps {
@@ -58,6 +60,25 @@ function ShapeSvg({shapeType, strokeColor, backgroundColor}: ShapeSvgProps) {
       >
         <polygon
           points={TRIANGLE_POINTS}
+          style={{fill, stroke}}
+          strokeWidth={SHAPE_BORDER_PX}
+          vectorEffect="non-scaling-stroke"
+        />
+      </svg>
+    );
+  }
+  if (shapeType === 'diamond') {
+    return (
+      <svg
+        aria-hidden="true"
+        width="100%"
+        height="100%"
+        viewBox="0 0 100 100"
+        preserveAspectRatio="none"
+        className={styles.shapeSvg}
+      >
+        <polygon
+          points={DIAMOND_POINTS}
           style={{fill, stroke}}
           strokeWidth={SHAPE_BORDER_PX}
           vectorEffect="non-scaling-stroke"

--- a/apps/src/sketchlab/reactFlow/types.ts
+++ b/apps/src/sketchlab/reactFlow/types.ts
@@ -7,7 +7,7 @@ import type {
 
 import type {FontSizeValue} from './nodes/nodeToolbars/toolbarPalettes';
 
-export type ShapeType = 'rectangle' | 'triangle' | 'circle';
+export type ShapeType = 'rectangle' | 'triangle' | 'circle' | 'diamond';
 
 export type ReactFlowSketchLabSources = ProjectSources & {
   source: SketchlabReactFlowSource;


### PR DESCRIPTION
Excalidraw supported a diamond shape, so to make conversion between the two easier I added a diamond shape to sketch2.

## Screen shots
### Toolbar with hover
<img width="164" height="406" alt="Screenshot 2026-04-27 at 9 08 20 AM" src="https://github.com/user-attachments/assets/0304567a-9313-472d-8dd1-489f63a77a14" />

### Toolbar and new shape on canvas
<img width="892" height="532" alt="Screenshot 2026-04-27 at 9 08 14 AM" src="https://github.com/user-attachments/assets/bd7eb591-996c-437b-8b4c-09fa8fb187b9" />

## Testing story
Tested locally.


