### PR TITLE
Revert "Revert "Migrate teacher course overview page to design system""

### DIFF
--- a/apps/src/code-studio/components/RedirectDialog.jsx
+++ b/apps/src/code-studio/components/RedirectDialog.jsx
@@ -1,9 +1,7 @@
-import {Button as MuiButton} from '@mui/material';
+import Dialog from '@code-dot-org/component-library/dialog';
 import PropTypes from 'prop-types';
 import React from 'react';
 
-import BaseDialog from '@cdo/apps/templates/BaseDialog';
-import DialogFooter from '@cdo/apps/templates/teacherDashboard/DialogFooter';
 import {navigateToHref} from '@cdo/apps/utils';
 import i18n from '@cdo/locale';
 
@@ -14,42 +12,35 @@ const RedirectDialog = ({
   redirectUrl,
   redirectButtonText,
 }) => {
+  if (!isOpen) {
+    return null;
+  }
+
   const redirect = () => {
     navigateToHref(redirectUrl);
   };
 
   return (
-    <BaseDialog
-      useUpdatedStyles
-      isOpen={isOpen}
-      style={styles.dialog}
-      handleClose={handleClose}
-    >
-      <div>
-        <h2 style={styles.dialogHeader}>{i18n.notInRightPlace()}</h2>
-        {details}
-      </div>
-      <DialogFooter>
-        <MuiButton
-          variant="outlined"
-          color="tertiary"
-          size="small"
-          onClick={handleClose}
-          type="button"
-        >
-          {i18n.stayHere()}
-        </MuiButton>
-        <MuiButton
-          variant="contained"
-          color="primary"
-          size="small"
-          onClick={redirect}
-          type="button"
-        >
-          {redirectButtonText}
-        </MuiButton>
-      </DialogFooter>
-    </BaseDialog>
+    <Dialog
+      title={i18n.notInRightPlace()}
+      description={details}
+      onClose={handleClose}
+      primaryButtonProps={{
+        children: redirectButtonText,
+        onClick: redirect,
+        size: 'small',
+        color: 'primary',
+        type: 'button',
+      }}
+      secondaryButtonProps={{
+        children: i18n.stayHere(),
+        onClick: handleClose,
+        size: 'small',
+        color: 'tertiary',
+        variant: 'outlined',
+        type: 'button',
+      }}
+    />
   );
 };
 
@@ -59,15 +50,6 @@ RedirectDialog.propTypes = {
   handleClose: PropTypes.func.isRequired,
   redirectUrl: PropTypes.string.isRequired,
   redirectButtonText: PropTypes.string.isRequired,
-};
-
-const styles = {
-  dialog: {
-    padding: 20,
-  },
-  dialogHeader: {
-    marginTop: 0,
-  },
 };
 
 export default RedirectDialog;

--- a/apps/src/code-studio/components/progress/Announcements.jsx
+++ b/apps/src/code-studio/components/progress/Announcements.jsx
@@ -1,3 +1,5 @@
+import Link from '@code-dot-org/component-library/link';
+import NotificationBanner from '@code-dot-org/component-library/notification-banner';
 import PropTypes from 'prop-types';
 import React, {Component} from 'react';
 
@@ -6,14 +8,50 @@ import {
   VisibilityType,
 } from '@cdo/apps/code-studio/announcementsRedux';
 import {ViewType} from '@cdo/apps/code-studio/viewAsRedux';
-import Notification from '@cdo/apps/sharedComponents/Notification';
 import i18n from '@cdo/locale';
+
+const NOTIFICATION_VARIANT_BY_TYPE = {
+  default: 'primary',
+  information: 'info',
+  success: 'success',
+  failure: 'error',
+  warning: 'warning',
+  course: 'brand',
+  bullhorn: 'info',
+  bullhorn_yellow: 'warning',
+  feedback: 'brand',
+  collaborate: 'primary',
+};
+
+const NOTIFICATION_ICON_BY_TYPE = {
+  default: 'circle-info',
+  information: 'circle-info',
+  success: 'circle-check',
+  failure: 'triangle-exclamation',
+  warning: 'triangle-exclamation',
+  course: 'circle-info',
+  bullhorn: 'bullhorn',
+  bullhorn_yellow: 'triangle-exclamation',
+  feedback: 'envelope',
+  collaborate: 'users',
+};
 
 export default class Announcements extends Component {
   static propTypes = {
     announcements: PropTypes.arrayOf(announcementShape).isRequired,
-    width: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
     viewAs: PropTypes.oneOf(Object.values(ViewType)).isRequired,
+  };
+
+  state = {
+    dismissedKeys: new Set(),
+  };
+
+  dismiss = key => {
+    this.setState(prev => {
+      const dismissedKeys = new Set(prev.dismissedKeys);
+      dismissedKeys.add(key);
+      return {dismissedKeys};
+    });
   };
 
   /*
@@ -40,26 +78,49 @@ export default class Announcements extends Component {
   render() {
     return (
       <div>
-        {this.filteredAnnouncements().map((announcement, index) => (
-          <Notification
-            key={index}
-            type={announcement.type}
-            notice={announcement.notice}
-            details={announcement.details}
-            buttonText={
-              announcement.buttonText === undefined
-                ? i18n.learnMore()
-                : announcement.buttonText
-            }
-            buttonLink={announcement.link}
-            dismissible={
-              announcement.dismissible === undefined
-                ? true
-                : announcement.dismissible
-            }
-            width={this.props.width}
-          />
-        ))}
+        {this.filteredAnnouncements().map((announcement, index) => {
+          const dismissible =
+            announcement.dismissible === undefined
+              ? true
+              : announcement.dismissible;
+          const buttonText =
+            announcement.buttonText === undefined
+              ? i18n.learnMore()
+              : announcement.buttonText;
+          const key = announcement.key || index;
+          if (this.state.dismissedKeys.has(key)) {
+            return null;
+          }
+          return (
+            <NotificationBanner
+              key={key}
+              className="announcement-notification"
+              variant={
+                NOTIFICATION_VARIANT_BY_TYPE[announcement.type] || 'info'
+              }
+              style="filled"
+              title={announcement.notice}
+              description={announcement.details}
+              icon={{
+                iconName:
+                  NOTIFICATION_ICON_BY_TYPE[announcement.type] || 'circle-info',
+                iconStyle: 'solid',
+              }}
+              actions={
+                announcement.link && (
+                  <Link
+                    href={announcement.link}
+                    text={buttonText}
+                    type="secondary"
+                    size="s"
+                    openInNewTab
+                  />
+                )
+              }
+              onClose={dismissible ? () => this.dismiss(key) : undefined}
+            />
+          );
+        })}
       </div>
     );
   }

--- a/apps/src/code-studio/components/progress/Announcements.jsx
+++ b/apps/src/code-studio/components/progress/Announcements.jsx
@@ -1,5 +1,6 @@
 import Link from '@code-dot-org/component-library/link';
 import NotificationBanner from '@code-dot-org/component-library/notification-banner';
+import classNames from 'classnames';
 import PropTypes from 'prop-types';
 import React, {Component} from 'react';
 
@@ -9,6 +10,8 @@ import {
 } from '@cdo/apps/code-studio/announcementsRedux';
 import {ViewType} from '@cdo/apps/code-studio/viewAsRedux';
 import i18n from '@cdo/locale';
+
+import styles from './announcements.module.scss';
 
 const NOTIFICATION_VARIANT_BY_TYPE = {
   default: 'primary',
@@ -94,7 +97,10 @@ export default class Announcements extends Component {
           return (
             <NotificationBanner
               key={key}
-              className="announcement-notification"
+              className={classNames(
+                styles.notificationBanner,
+                'announcement-notification'
+              )}
               variant={
                 NOTIFICATION_VARIANT_BY_TYPE[announcement.type] || 'info'
               }

--- a/apps/src/code-studio/components/progress/announcements.module.scss
+++ b/apps/src/code-studio/components/progress/announcements.module.scss
@@ -1,0 +1,3 @@
+.notificationBanner {
+  margin-bottom: 20px;
+}

--- a/apps/src/templates/Assigned.jsx
+++ b/apps/src/templates/Assigned.jsx
@@ -1,35 +1,22 @@
+import FontAwesomeV6Icon from '@code-dot-org/component-library/fontAwesomeV6Icon';
+import {Typography} from '@mui/material';
 import React, {Component} from 'react';
 
-import fontConstants from '@cdo/apps/fontConstants';
-import FontAwesome from '@cdo/apps/legacySharedComponents/FontAwesome';
-import color from '@cdo/apps/util/color';
 import i18n from '@cdo/locale';
+
+import styles from './assigned.module.scss';
 
 export default class Assigned extends Component {
   render() {
     return (
-      <span style={styles.assigned} className={'uitest-assigned'}>
-        <span style={styles.checkmark}>
-          <FontAwesome icon="check" />
+      <span className={`${styles.assigned} uitest-assigned`}>
+        <span className={styles.checkmark}>
+          <FontAwesomeV6Icon iconName="check" iconStyle="solid" />
         </span>
-        {i18n.assigned()}
+        <Typography variant="body2" component="span">
+          <strong>{i18n.assigned()}</strong>
+        </Typography>
       </span>
     );
   }
 }
-
-const styles = {
-  checkmark: {
-    padding: 5,
-  },
-  assigned: {
-    color: color.level_perfect,
-    fontSize: 16,
-    ...fontConstants['main-font-semi-bold'],
-    lineHeight: '36px',
-    marginLeft: 10,
-    verticalAlign: 'top',
-    display: 'flex',
-    alignItems: 'center',
-  },
-};

--- a/apps/src/templates/MultipleAssignButton.jsx
+++ b/apps/src/templates/MultipleAssignButton.jsx
@@ -1,8 +1,9 @@
+import FontAwesomeV6Icon from '@code-dot-org/component-library/fontAwesomeV6Icon';
+import {Button} from '@mui/material';
 import PropTypes from 'prop-types';
 import React from 'react';
 import {connect} from 'react-redux';
 
-import Button from '@cdo/apps/legacySharedComponents/Button';
 import MultipleSectionsAssigner from '@cdo/apps/templates/MultipleSectionsAssigner';
 import {sectionForDropdownShape} from '@cdo/apps/templates/teacherDashboard/shapes';
 import {
@@ -12,6 +13,8 @@ import {
 import {sectionsForDropdown} from '@cdo/apps/templates/teacherDashboard/teacherSectionsReduxSelectors';
 import {AiChatToolsDependency} from '@cdo/generated-scripts/sharedConstants';
 import i18n from '@cdo/locale';
+
+import styles from './multipleAssignButton.module.scss';
 
 class MultipleAssignButton extends React.Component {
   static propTypes = {
@@ -65,14 +68,17 @@ class MultipleAssignButton extends React.Component {
     } = this.props;
 
     return (
-      <div>
+      <div className={styles.container}>
         <Button
-          color={Button.ButtonColor.brandSecondaryDefault}
-          text={i18n.assignToMultipleSections()}
-          icon="plus"
+          variant="contained"
+          color="primary"
+          startIcon={<FontAwesomeV6Icon iconName="plus" iconStyle="solid" />}
           onClick={this.handleClick}
           id="uitest-multi-assign-button"
-        />
+          size="small"
+        >
+          {i18n.assignToMultipleSections()}
+        </Button>
         {assignmentChoiceDialogOpen && (
           <MultipleSectionsAssigner
             assignmentName={assignmentName}

--- a/apps/src/templates/assigned.module.scss
+++ b/apps/src/templates/assigned.module.scss
@@ -1,0 +1,17 @@
+.assigned {
+  display: flex;
+  align-items: center;
+  color: var(--text-success-primary);
+  font-size: 16px;
+  line-height: 36px;
+  margin-left: 10px;
+  vertical-align: top;
+
+  > span {
+    color: var(--text-success-primary);
+  }
+}
+
+.checkmark {
+  padding: 5px;
+}

--- a/apps/src/templates/courseOverview/CourseOverview.js
+++ b/apps/src/templates/courseOverview/CourseOverview.js
@@ -208,7 +208,12 @@ class CourseOverview extends Component {
         )}
         {showNotification && <VerifiedResourcesNotification />}
         <div className={styles.titleWrapper}>
-          <Typography variant="h2" component="h2" className={styles.title}>
+          <Typography
+            variant="h2"
+            component="h2"
+            gutterBottom
+            className={styles.title}
+          >
             {assignmentFamilyTitle}
           </Typography>
         </div>

--- a/apps/src/templates/courseOverview/CourseOverview.js
+++ b/apps/src/templates/courseOverview/CourseOverview.js
@@ -1,3 +1,6 @@
+import NotificationBanner from '@code-dot-org/component-library/notification-banner';
+import {Typography} from '@mui/material';
+import classNames from 'classnames';
 import $ from 'jquery';
 import PropTypes from 'prop-types';
 import React, {Component} from 'react';
@@ -8,18 +11,12 @@ import {announcementShape} from '@cdo/apps/code-studio/announcementsRedux';
 import Announcements from '@cdo/apps/code-studio/components/progress/Announcements';
 import RedirectDialog from '@cdo/apps/code-studio/components/RedirectDialog';
 import {ViewType} from '@cdo/apps/code-studio/viewAsRedux';
-import fontConstants from '@cdo/apps/fontConstants';
 import {resourceShape} from '@cdo/apps/levelbuilder/shapes';
 import {EVENTS} from '@cdo/apps/metrics/AnalyticsConstants';
 import analyticsReporter from '@cdo/apps/metrics/AnalyticsReporter';
-import Notification, {
-  NotificationType,
-} from '@cdo/apps/sharedComponents/Notification';
-import styleConstants from '@cdo/apps/styleConstants';
 import {SignInState} from '@cdo/apps/templates/currentUserRedux';
 import ParticipantFeedbackNotification from '@cdo/apps/templates/feedback/ParticipantFeedbackNotification';
 import {assignmentCourseVersionShape} from '@cdo/apps/templates/teacherDashboard/shapes';
-import color from '@cdo/apps/util/color';
 import {
   onDismissRedirectDialog,
   dismissedRedirectDialog,
@@ -34,6 +31,10 @@ import SafeMarkdown from '../SafeMarkdown';
 import CourseOverviewActionRow from './CourseOverviewActionRow';
 import CourseScript from './CourseScript';
 import VerifiedResourcesNotification from './VerifiedResourcesNotification';
+
+import styles from './course-overview.module.scss';
+
+const WARNING_ICON = {iconName: 'triangle-exclamation', iconStyle: 'solid'};
 
 class CourseOverview extends Component {
   static propTypes = {
@@ -156,7 +157,7 @@ class CourseOverview extends Component {
     };
 
     return (
-      <div style={styles.main}>
+      <div className={styles.main}>
         {redirectToCourseUrl && !dismissedRedirectDialog(name) && (
           <RedirectDialog
             isOpen={this.state.showRedirectDialog}
@@ -168,27 +169,36 @@ class CourseOverview extends Component {
         )}
         {userId && <ParticipantFeedbackNotification studentId={userId} />}
         {showRedirectWarning && !dismissedRedirectWarning(name) && (
-          <Notification
-            type={NotificationType.warning}
-            notice=""
-            details={i18n.redirectCourseVersionWarningDetails()}
-            dismissible={true}
-            onDismiss={() => onDismissRedirectWarning(name)}
+          <NotificationBanner
+            variant="warning"
+            style="filled"
+            title=""
+            description={i18n.redirectCourseVersionWarningDetails()}
+            icon={WARNING_ICON}
+            onClose={() => onDismissRedirectWarning(name)}
+            className={classNames(
+              styles.notificationBanner,
+              'announcement-notification'
+            )}
           />
         )}
         {showVersionWarning && (
-          <Notification
-            type={NotificationType.warning}
-            notice={i18n.wrongCourseVersionWarningNotice()}
-            details={i18n.wrongCourseVersionWarningDetails()}
-            dismissible={true}
-            onDismiss={this.onDismissVersionWarning}
+          <NotificationBanner
+            variant="warning"
+            style="filled"
+            title={i18n.wrongCourseVersionWarningNotice()}
+            description={i18n.wrongCourseVersionWarningDetails()}
+            icon={WARNING_ICON}
+            onClose={this.onDismissVersionWarning}
+            className={classNames(
+              styles.notificationBanner,
+              'announcement-notification'
+            )}
           />
         )}
         {isSignedIn && (
           <Announcements
             announcements={this.props.announcements}
-            width={styleConstants['content-width']}
             viewAs={viewAs}
             firehoseAnalyticsId={{
               user_id: userId,
@@ -197,8 +207,10 @@ class CourseOverview extends Component {
           />
         )}
         {showNotification && <VerifiedResourcesNotification />}
-        <div style={styles.titleWrapper}>
-          <h1 style={styles.title}>{assignmentFamilyTitle}</h1>
+        <div className={styles.titleWrapper}>
+          <Typography variant="h2" component="h2" className={styles.title}>
+            {assignmentFamilyTitle}
+          </Typography>
         </div>
         <CourseOverviewActionRow
           courseVersionId={courseVersionId}
@@ -218,7 +230,7 @@ class CourseOverview extends Component {
             <RequiresAiChatToolsAlert />
           )}
         <SafeMarkdown
-          style={styles.description}
+          className={styles.description}
           openExternalLinksInNewTab={true}
           markdown={
             viewAs === ViewType.Participant
@@ -247,35 +259,6 @@ class CourseOverview extends Component {
     );
   }
 }
-
-const styles = {
-  main: {
-    width: '100%',
-  },
-  description: {
-    marginBottom: 20,
-  },
-  titleWrapper: {
-    display: 'flex',
-    justifyContent: 'space-between',
-    alignItems: 'flex-end',
-  },
-  title: {
-    display: 'inline-block',
-  },
-  versionWrapper: {
-    display: 'flex',
-    alignItems: 'baseline',
-  },
-  versionLabel: {
-    ...fontConstants['main-font-semi-bold'],
-    fontSize: 15,
-    color: color.charcoal,
-  },
-  versionDropdown: {
-    marginBottom: 13,
-  },
-};
 
 export const UnconnectedCourseOverview = CourseOverview;
 export default connect((state, ownProps) => ({

--- a/apps/src/templates/courseOverview/CourseScript.js
+++ b/apps/src/templates/courseOverview/CourseScript.js
@@ -1,5 +1,7 @@
+import {Button, Typography} from '@mui/material';
+import classNames from 'classnames';
 import PropTypes from 'prop-types';
-import React, {Component} from 'react';
+import React from 'react';
 import {connect} from 'react-redux';
 
 import {
@@ -7,13 +9,10 @@ import {
   toggleHiddenScript,
 } from '@cdo/apps/code-studio/hiddenLessonRedux';
 import {ViewType} from '@cdo/apps/code-studio/viewAsRedux';
-import fontConstants from '@cdo/apps/fontConstants';
-import Button from '@cdo/apps/legacySharedComponents/Button';
 import Assigned from '@cdo/apps/templates/Assigned';
 import SafeMarkdown from '@cdo/apps/templates/SafeMarkdown';
 import {sectionForDropdownShape} from '@cdo/apps/templates/teacherDashboard/shapes';
 import {sectionsForDropdown} from '@cdo/apps/templates/teacherDashboard/teacherSectionsReduxSelectors';
-import color from '@cdo/apps/util/color';
 import experiments from '@cdo/apps/util/experiments';
 import i18n from '@cdo/locale';
 
@@ -21,7 +20,9 @@ import MultipleAssignButton from '../MultipleAssignButton';
 
 import CourseScriptTeacherInfo from './CourseScriptTeacherInfo';
 
-class CourseScript extends Component {
+import styles from './courseScript.module.scss';
+
+class CourseScript extends React.Component {
   static propTypes = {
     title: PropTypes.string,
     name: PropTypes.string,
@@ -60,8 +61,18 @@ class CourseScript extends Component {
   };
 
   onClickHiddenToggle = value => {
-    const {name, selectedSectionId, id, toggleHiddenScript} = this.props;
-    toggleHiddenScript(name, selectedSectionId, id, value === 'hidden');
+    const {name, selectedSectionId, id, hiddenLessonState, toggleHiddenScript} =
+      this.props;
+    const nextHidden = value === 'hidden';
+    const currentHidden = isScriptHiddenForSection(
+      hiddenLessonState,
+      selectedSectionId,
+      id
+    );
+    if (nextHidden === currentHidden) {
+      return;
+    }
+    toggleHiddenScript(name, selectedSectionId, id, nextHidden);
   };
 
   render() {
@@ -117,47 +128,49 @@ class CourseScript extends Component {
     }
     return (
       <div
-        style={{
-          ...styles.main,
-          ...(isHidden && styles.hidden),
-        }}
-        className="uitest-CourseScript"
+        className={classNames(
+          styles.main,
+          isHidden && styles.hidden,
+          'uitest-CourseScript'
+        )}
         data-visibility={isHidden ? 'hidden' : 'visible'}
       >
-        <div style={styles.content}>
-          <div style={styles.title}>{title}</div>
-          <div style={styles.description}>
+        <div className={styles.content}>
+          <Typography variant="h5" component="h5">
+            {title}
+          </Typography>
+          <div className={styles.description}>
             <SafeMarkdown markdown={description} />
           </div>
-          <span style={styles.flex}>
+          <div className={styles.flex}>
             <Button
-              __useDeprecatedTag
-              text={i18n.goToUnit()}
               href={unitPath}
-              color={Button.ButtonColor.gray}
               className="uitest-go-to-unit-button"
-            />
+              variant="outlined"
+              color="secondary"
+              size="small"
+            >
+              {i18n.goToUnit()}
+            </Button>
             {isAssigned && viewAs === ViewType.Participant && <Assigned />}
             {confirmationMessageOpen && (
-              <span style={styles.confirmText}>{i18n.assignSuccess()}</span>
+              <span className={styles.confirmText}>{i18n.assignSuccess()}</span>
             )}
             {viewAs === ViewType.Instructor && showAssignButton && (
-              <div className={styles.assignButton}>
-                <MultipleAssignButton
-                  courseOfferingId={courseOfferingId}
-                  courseVersionId={courseVersionId}
-                  courseId={courseId}
-                  scriptId={id}
-                  assignmentName={title}
-                  reassignConfirm={this.onReassignConfirm}
-                  isAssigningCourseOnly={false}
-                  isSingleUnitCourse={false}
-                  participantAudience={participantAudience}
-                  aiChatToolsDependency={aiChatToolsDependency}
-                />
-              </div>
+              <MultipleAssignButton
+                courseOfferingId={courseOfferingId}
+                courseVersionId={courseVersionId}
+                courseId={courseId}
+                scriptId={id}
+                assignmentName={title}
+                reassignConfirm={this.onReassignConfirm}
+                isAssigningCourseOnly={false}
+                isSingleUnitCourse={false}
+                participantAudience={participantAudience}
+                aiChatToolsDependency={aiChatToolsDependency}
+              />
             )}
-          </span>
+          </div>
         </div>
         {viewAs === ViewType.Instructor && !hasNoSections && (
           <CourseScriptTeacherInfo
@@ -171,47 +184,6 @@ class CourseScript extends Component {
   }
 }
 
-const styles = {
-  main: {
-    display: 'table',
-    width: '100%',
-    height: '100%',
-    background: color.background_gray,
-    borderWidth: 1,
-    borderColor: color.border_gray,
-    borderStyle: 'solid',
-    borderRadius: 2,
-    marginBottom: 12,
-  },
-  content: {
-    padding: 20,
-  },
-  description: {
-    marginTop: 20,
-    marginBottom: 20,
-  },
-  title: {
-    fontSize: 18,
-    ...fontConstants['main-font-semi-bold'],
-  },
-  // TODO: share better with ProgressLesson
-  hidden: {
-    borderStyle: 'dashed',
-    borderWidth: 4,
-    marginTop: 0,
-    marginBottom: 12,
-    marginLeft: 0,
-    marginRight: 0,
-  },
-  flex: {
-    display: 'flex',
-    alignItems: 'center',
-  },
-  confirmText: {
-    marginLeft: 5,
-    marginRight: 5,
-  },
-};
 export const UnconnectedCourseScript = CourseScript;
 
 export default connect(

--- a/apps/src/templates/courseOverview/CourseScriptTeacherInfo.js
+++ b/apps/src/templates/courseOverview/CourseScriptTeacherInfo.js
@@ -1,7 +1,7 @@
+import {WithTooltip} from '@code-dot-org/component-library/tooltip';
 import _ from 'lodash';
 import PropTypes from 'prop-types';
 import React, {Component} from 'react';
-import ReactTooltip from 'react-tooltip';
 
 import HiddenForSectionToggle from '@cdo/apps/templates/progress/HiddenForSectionToggle';
 import TeacherInfoBox from '@cdo/apps/templates/progress/TeacherInfoBox';
@@ -14,30 +14,35 @@ export default class CourseScriptTeacherInfo extends Component {
     onToggleHiddenScript: PropTypes.func.isRequired,
   };
 
+  // Stable per-instance id so `aria-describedby` does not change between
+  // renders and the tooltip doesn't re-mount unnecessarily.
+  tooltipId = _.uniqueId('hidden-script-tooltip-');
+
   render() {
     const {disabled, isHidden, onToggleHiddenScript} = this.props;
 
-    // Note: Students should always have no (owned) sections
-    const tooltipId = _.uniqueId();
+    const toggle = (
+      <HiddenForSectionToggle
+        hidden={isHidden}
+        disabled={disabled}
+        onChange={onToggleHiddenScript}
+      />
+    );
 
     return (
       <TeacherInfoBox>
-        <div data-tip data-for={tooltipId} aria-describedby={tooltipId}>
-          <HiddenForSectionToggle
-            hidden={isHidden}
-            disabled={disabled}
-            onChange={onToggleHiddenScript}
-          />
-        </div>
-        <ReactTooltip
-          id={tooltipId}
-          role="tooltip"
-          wrapper="span"
-          effect="solid"
-          disable={!disabled}
-        >
-          {i18n.hiddenScriptTooltip()}
-        </ReactTooltip>
+        {disabled ? (
+          <WithTooltip
+            tooltipProps={{
+              text: i18n.hiddenScriptTooltip(),
+              tooltipId: this.tooltipId,
+            }}
+          >
+            <div>{toggle}</div>
+          </WithTooltip>
+        ) : (
+          <div>{toggle}</div>
+        )}
       </TeacherInfoBox>
     );
   }

--- a/apps/src/templates/courseOverview/VerifiedResourcesNotification.js
+++ b/apps/src/templates/courseOverview/VerifiedResourcesNotification.js
@@ -1,31 +1,55 @@
+import NotificationBanner from '@code-dot-org/component-library/notification-banner';
+import {Button} from '@mui/material';
+import classNames from 'classnames';
 import PropTypes from 'prop-types';
-import React, {PureComponent} from 'react';
+import React, {useState} from 'react';
 
-import Notification, {
-  NotificationType,
-} from '@cdo/apps/sharedComponents/Notification';
 import i18n from '@cdo/locale';
 
-export default class VerifiedResourcesNotification extends PureComponent {
-  render() {
-    return (
-      <Notification
-        type={NotificationType.warning}
-        notice={i18n.verifiedResourcesNotice()}
-        details={
-          this.props.inLesson
-            ? i18n.verifiedResourcesLessonDetails()
-            : i18n.verifiedResourcesDetails()
-        }
-        buttonText={i18n.learnMore()}
-        buttonLink="https://support.code.org/hc/en-us/articles/115001550131"
-        dismissible={true}
-        width={this.props.width}
-      />
-    );
+import styles from './courseScript.module.scss';
+
+const VERIFIED_RESOURCES_URL =
+  'https://support.code.org/hc/en-us/articles/115001550131';
+
+const VerifiedResourcesNotification = ({inLesson}) => {
+  const [open, setOpen] = useState(true);
+  if (!open) {
+    return null;
   }
-}
+  return (
+    <NotificationBanner
+      variant="warning"
+      style="filled"
+      title={i18n.verifiedResourcesNotice()}
+      className={classNames(
+        styles.verifiedResourcesNotification,
+        'announcement-notification'
+      )}
+      description={
+        inLesson
+          ? i18n.verifiedResourcesLessonDetails()
+          : i18n.verifiedResourcesDetails()
+      }
+      icon={{iconName: 'triangle-exclamation', iconStyle: 'solid'}}
+      onClose={() => setOpen(false)}
+      actions={
+        <Button
+          href={VERIFIED_RESOURCES_URL}
+          variant="outlined"
+          color="secondary"
+          size="small"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          {i18n.learnMore()}
+        </Button>
+      }
+    />
+  );
+};
+
 VerifiedResourcesNotification.propTypes = {
-  width: PropTypes.number,
   inLesson: PropTypes.bool,
 };
+
+export default VerifiedResourcesNotification;

--- a/apps/src/templates/courseOverview/course-overview.module.scss
+++ b/apps/src/templates/courseOverview/course-overview.module.scss
@@ -1,3 +1,26 @@
+.main {
+  width: 100%;
+}
+
+.titleWrapper {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-end;
+}
+
+.title {
+  display: inline-block;
+  color: var(--text-brand-purple-primary);
+}
+
+.description {
+  margin-bottom: 20px;
+}
+
+.notificationBanner {
+  margin-bottom: 20px;
+}
+
 .actionRow {
   display: flex;
   flex-direction: row;
@@ -17,6 +40,7 @@
   .assignButton {
     display: flex;
     flex-direction: column;
-    margin-bottom: 5px;
+    margin-left: 5px;
+    margin-bottom: 10px;
   }
 }

--- a/apps/src/templates/courseOverview/courseScript.module.scss
+++ b/apps/src/templates/courseOverview/courseScript.module.scss
@@ -1,0 +1,39 @@
+@import 'font';
+
+.main {
+  display: table;
+  width: 100%;
+  height: 100%;
+  background-color: var(--background-neutral-secondary);
+  border: 1px solid var(--borders-neutral-primary);
+  border-radius: 2px;
+  margin-bottom: 12px;
+}
+
+.hidden {
+  border: 4px dashed var(--borders-neutral-primary);
+  margin: 0 0 12px 0;
+}
+
+.content {
+  padding: 20px;
+}
+
+.description {
+  margin-top: 20px;
+  margin-bottom: 20px;
+}
+
+.verifiedResourcesNotification {
+  margin-bottom: 20px;
+}
+
+.flex {
+  display: flex;
+  align-items: center;
+}
+
+.confirmText {
+  margin-left: 5px;
+  margin-right: 5px;
+}

--- a/apps/src/templates/lessonOverview/LessonOverview.jsx
+++ b/apps/src/templates/lessonOverview/LessonOverview.jsx
@@ -8,7 +8,6 @@ import {PublishedState} from '@cdo/apps/generated/curriculum/sharedCourseConstan
 import Button from '@cdo/apps/legacySharedComponents/Button';
 import {EVENTS} from '@cdo/apps/metrics/AnalyticsConstants';
 import analyticsReporter from '@cdo/apps/metrics/AnalyticsReporter';
-import styleConstants from '@cdo/apps/styleConstants';
 import CopyrightInfo from '@cdo/apps/templates/CopyrightInfo';
 import VerifiedResourcesNotification from '@cdo/apps/templates/courseOverview/VerifiedResourcesNotification';
 import {SignInState} from '@cdo/apps/templates/currentUserRedux';
@@ -177,17 +176,10 @@ class LessonOverview extends Component {
           </div>
         </div>
         {isSignedIn && (
-          <Announcements
-            announcements={announcements}
-            width={styleConstants['content-width']}
-            viewAs={viewAs}
-          />
+          <Announcements announcements={announcements} viewAs={viewAs} />
         )}
         {displayVerifiedResourcesNotification && (
-          <VerifiedResourcesNotification
-            width={styleConstants['content-width']}
-            inLesson={true}
-          />
+          <VerifiedResourcesNotification inLesson={true} />
         )}
         <h1 className="uitest-lesson-title">{lesson.title}</h1>
         <h2>{i18n.minutesLabel({number: lesson.duration})}</h2>

--- a/apps/src/templates/lessonOverview/StudentLessonOverview.jsx
+++ b/apps/src/templates/lessonOverview/StudentLessonOverview.jsx
@@ -6,7 +6,6 @@ import {announcementShape} from '@cdo/apps/code-studio/announcementsRedux';
 import {levelsForLessonId} from '@cdo/apps/code-studio/progressReduxSelectors';
 import {ViewType} from '@cdo/apps/code-studio/viewAsRedux';
 import Button from '@cdo/apps/legacySharedComponents/Button';
-import styleConstants from '@cdo/apps/styleConstants';
 import {SignInState} from '@cdo/apps/templates/currentUserRedux';
 import EnhancedSafeMarkdown from '@cdo/apps/templates/EnhancedSafeMarkdown';
 import InlineMarkdown from '@cdo/apps/templates/InlineMarkdown';
@@ -78,7 +77,6 @@ class StudentLessonOverview extends Component {
         {isSignedIn && (
           <Announcements
             announcements={announcements}
-            width={styleConstants['content-width']}
             viewAs={ViewType.Participant}
           />
         )}

--- a/apps/src/templates/multipleAssignButton.module.scss
+++ b/apps/src/templates/multipleAssignButton.module.scss
@@ -1,0 +1,3 @@
+.container {
+  margin-inline-start: 5px;
+}

--- a/apps/src/templates/progress/HiddenForSectionToggle.jsx
+++ b/apps/src/templates/progress/HiddenForSectionToggle.jsx
@@ -1,90 +1,56 @@
+import SegmentedButtons from '@code-dot-org/component-library/segmentedButtons';
+import classNames from 'classnames';
 import PropTypes from 'prop-types';
 import React from 'react';
-import {connect} from 'react-redux';
 
-import Button from '@cdo/apps/legacySharedComponents/Button';
 import i18n from '@cdo/locale';
 
+import styles from './hiddenForSectionToggle.module.scss';
+
 /**
- * A component that provides a toggle that goes between visible and hidden that
- * can be used be teachers to hide/show scripts or lesson on a per section basis.
+ * A toggle that goes between visible and hidden. Used by teachers to hide/show
+ * scripts or lessons on a per-section basis.
  */
-class HiddenForSectionToggle extends React.Component {
-  static propTypes = {
-    hidden: PropTypes.bool.isRequired,
-    disabled: PropTypes.bool,
-    onChange: PropTypes.func.isRequired,
-    // Redux
-    isRtl: PropTypes.bool,
-  };
+const HiddenForSectionToggle = ({hidden, disabled, onChange}) => {
+  const buttons = [
+    {
+      label: i18n.visible(),
+      value: 'visible',
+      iconLeft: {iconName: 'eye', iconStyle: 'regular'},
+      disabled,
+    },
+    {
+      label: i18n.hidden(),
+      value: 'hidden',
+      iconLeft: {iconName: 'eye-slash', iconStyle: 'regular'},
+      disabled,
+    },
+  ];
 
-  render() {
-    const {hidden, disabled, onChange, isRtl} = this.props;
+  return (
+    <div
+      className={classNames(
+        styles.toggle,
+        disabled && styles.disabled,
+        'uitest-togglehidden'
+      )}
+    >
+      <SegmentedButtons
+        buttons={buttons}
+        selectedButtonValue={hidden ? 'hidden' : 'visible'}
+        onChange={onChange}
+        size="s"
+      />
+    </div>
+  );
+};
 
-    // Reverse button order if locale is RTL
-    const mainStyle = {
-      ...styles.main,
-      ...(disabled && styles.disabled),
-      ...(isRtl ? styles.reverseButtons : null),
-    };
-
-    return (
-      <div style={mainStyle} className="uitest-togglehidden">
-        <Button
-          onClick={() => !disabled && onChange('visible')}
-          text={i18n.visible()}
-          color={Button.ButtonColor.gray}
-          disabled={!hidden}
-          icon="eye"
-          iconStyleProp="regular"
-          style={{...styles.button, ...styles.leftButton}}
-        />
-        <Button
-          onClick={() => !disabled && onChange('hidden')}
-          text={i18n.hidden()}
-          color={Button.ButtonColor.gray}
-          disabled={hidden}
-          icon="eye-slash"
-          iconStyleProp="regular"
-          style={{...styles.button, ...styles.rightButton}}
-        />
-      </div>
-    );
-  }
-}
-
-const styles = {
-  main: {
-    wrap: 'nowrap',
-    margin: '5px 15px',
-  },
-  disabled: {
-    opacity: 0.5,
-  },
-  button: {
-    display: 'inline-block',
-    paddingLeft: 0,
-    paddingRight: 0,
-    boxSizing: 'border-box',
-    width: '50%',
-    margin: '5px 0px',
-  },
-  leftButton: {
-    borderTopRightRadius: 0,
-    borderBottomRightRadius: 0,
-  },
-  rightButton: {
-    borderTopLeftRadius: 0,
-    borderBottomLeftRadius: 0,
-  },
-  reverseButtons: {
-    display: 'flex',
-    flexDirection: 'row-reverse',
-  },
+HiddenForSectionToggle.propTypes = {
+  hidden: PropTypes.bool.isRequired,
+  disabled: PropTypes.bool,
+  onChange: PropTypes.func.isRequired,
 };
 
 export const UnconnectedHiddenForSectionToggle = HiddenForSectionToggle;
 
-export default connect(state => ({
-  isRtl: state.isRtl,
-}))(HiddenForSectionToggle);
+export default HiddenForSectionToggle;

--- a/apps/src/templates/progress/ProgressLessonTeacherInfo.jsx
+++ b/apps/src/templates/progress/ProgressLessonTeacherInfo.jsx
@@ -43,9 +43,19 @@ class ProgressLessonTeacherInfo extends React.Component {
   }
 
   onClickHiddenToggle(value) {
-    const {unitName, section, lesson, toggleHiddenLesson} = this.props;
+    const {unitName, section, lesson, hiddenLessonState, toggleHiddenLesson} =
+      this.props;
     const sectionId = (section && section.id.toString()) || '';
-    toggleHiddenLesson(unitName, sectionId, lesson.id, value === 'hidden');
+    const nextHidden = value === 'hidden';
+    const currentHidden = isLessonHiddenForSection(
+      hiddenLessonState,
+      sectionId,
+      lesson.id
+    );
+    if (nextHidden === currentHidden) {
+      return;
+    }
+    toggleHiddenLesson(unitName, sectionId, lesson.id, nextHidden);
   }
 
   render() {

--- a/apps/src/templates/progress/TeacherInfoBox.js
+++ b/apps/src/templates/progress/TeacherInfoBox.js
@@ -1,25 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 
-import color from '@cdo/apps/util/color';
-
-const styles = {
-  outer: {
-    display: 'table-cell',
-    verticalAlign: 'top',
-    width: 200,
-    height: '100%',
-    borderRadius: 2,
-  },
-  inner: {
-    backgroundColor: color.lightest_cyan,
-    height: '100%',
-    borderWidth: 1,
-    borderColor: color.cyan,
-    borderStyle: 'solid',
-    textAlign: 'center',
-  },
-};
+import styles from './teacherInfoBox.module.scss';
 
 /**
  * A component that is a simple blue box with info for teachers.
@@ -29,8 +11,8 @@ const TeacherInfoBox = ({children}) => {
     return null;
   }
   return (
-    <div style={styles.outer} className="teacher-info-box">
-      <div style={styles.inner}>{children}</div>
+    <div className={`${styles.outer} teacher-info-box`}>
+      <div className={styles.inner}>{children}</div>
     </div>
   );
 };

--- a/apps/src/templates/progress/hiddenForSectionToggle.module.scss
+++ b/apps/src/templates/progress/hiddenForSectionToggle.module.scss
@@ -1,0 +1,7 @@
+.toggle {
+  margin: 10px 15px;
+}
+
+.disabled {
+  opacity: 0.5;
+}

--- a/apps/src/templates/progress/teacherInfoBox.module.scss
+++ b/apps/src/templates/progress/teacherInfoBox.module.scss
@@ -1,0 +1,14 @@
+.outer {
+  display: table-cell;
+  vertical-align: top;
+  width: 200px;
+  height: 100%;
+  border-radius: 2px;
+}
+
+.inner {
+  height: 100%;
+  border: 1px solid var(--borders-info-primary);
+  background-color: var(--background-info-extra-light);
+  text-align: center;
+}

--- a/apps/test/unit/code-studio/components/progress/AnnouncementsTest.jsx
+++ b/apps/test/unit/code-studio/components/progress/AnnouncementsTest.jsx
@@ -1,9 +1,9 @@
+import NotificationBanner from '@code-dot-org/component-library/notification-banner';
 import {shallow} from 'enzyme'; // eslint-disable-line no-restricted-imports
 import React from 'react';
 
 import Announcements from '@cdo/apps/code-studio/components/progress/Announcements';
 import {ViewType} from '@cdo/apps/code-studio/viewAsRedux';
-import Notification from '@cdo/apps/sharedComponents/Notification';
 
 import {
   fakeStudentAnnouncement,
@@ -25,9 +25,9 @@ const firehoseAnalyticsData = {
 };
 
 describe('Announcements', () => {
-  it('does not show Notifications if no announcements', () => {
+  it('does not show NotificationBanner if no announcements', () => {
     const wrapper = shallow(<Announcements {...defaultProps} />);
-    expect(wrapper.find(Notification).length).toEqual(0);
+    expect(wrapper.find(NotificationBanner).length).toEqual(0);
   });
 
   it('displays old teacher announcement for instructor', () => {
@@ -37,7 +37,7 @@ describe('Announcements', () => {
         announcements={[fakeOldTeacherAnnouncement]}
       />
     );
-    expect(wrapper.find(Notification).length).toEqual(1);
+    expect(wrapper.find(NotificationBanner).length).toEqual(1);
   });
 
   it('does not display old teacher announcement for participant', () => {
@@ -48,7 +48,7 @@ describe('Announcements', () => {
         viewAs={ViewType.Participant}
       />
     );
-    expect(wrapper.find(Notification).length).toEqual(0);
+    expect(wrapper.find(NotificationBanner).length).toEqual(0);
   });
 
   it('displays new teacher announcement for instructor', () => {
@@ -58,33 +58,33 @@ describe('Announcements', () => {
         announcements={[fakeTeacherAnnouncement]}
       />
     );
-    expect(wrapper.find(Notification).length).toEqual(1);
+    expect(wrapper.find(NotificationBanner).length).toEqual(1);
   });
 
-  it('defaults to dismissible and no button text for teacher announcement without dismissible and button text', () => {
+  it('defaults to dismissible and "Learn more" action for announcement without dismissible and button text', () => {
     const wrapper = shallow(
       <Announcements
         {...defaultProps}
         announcements={[fakeTeacherAnnouncement]}
       />
     );
-    expect(wrapper.find(Notification).length).toEqual(1);
-    expect(wrapper.find(Notification).props().dismissible).toEqual(true);
-    expect(wrapper.find(Notification).props().buttonText).toEqual('Learn more');
+    const banner = wrapper.find(NotificationBanner);
+    expect(banner.length).toEqual(1);
+    expect(typeof banner.prop('onClose')).toEqual('function');
+    expect(banner.prop('actions').props.text).toEqual('Learn more');
   });
 
-  it('displays new teacher announcement with dismissible and button text for instructor', () => {
+  it('displays non-dismissible announcement with custom action text', () => {
     const wrapper = shallow(
       <Announcements
         {...defaultProps}
         announcements={[fakeTeacherAnnouncementWithDismissibleAndButtonText]}
       />
     );
-    expect(wrapper.find(Notification).length).toEqual(1);
-    expect(wrapper.find(Notification).props().dismissible).toEqual(false);
-    expect(wrapper.find(Notification).props().buttonText).toEqual(
-      'Push the button'
-    );
+    const banner = wrapper.find(NotificationBanner);
+    expect(banner.length).toEqual(1);
+    expect(banner.prop('onClose')).toBeUndefined();
+    expect(banner.prop('actions').props.text).toEqual('Push the button');
   });
 
   it('has only instructor announcements', () => {
@@ -98,7 +98,7 @@ describe('Announcements', () => {
         ]}
       />
     );
-    expect(wrapper.find(Notification).length).toEqual(2);
+    expect(wrapper.find(NotificationBanner).length).toEqual(2);
   });
 
   it('has participant announcement if necessary', () => {
@@ -109,7 +109,7 @@ describe('Announcements', () => {
         announcements={[fakeStudentAnnouncement]}
       />
     );
-    expect(wrapper.find(Notification).length).toEqual(1);
+    expect(wrapper.find(NotificationBanner).length).toEqual(1);
   });
 
   it('has all participant announcements but no instructor announcements if necessary', () => {
@@ -125,7 +125,7 @@ describe('Announcements', () => {
       />,
       {disableLifecycleMethods: true}
     );
-    expect(wrapper.find(Notification).length).toEqual(2);
+    expect(wrapper.find(NotificationBanner).length).toEqual(2);
   });
 
   it('displays instructor announcement with analytics data', () => {
@@ -136,6 +136,6 @@ describe('Announcements', () => {
         announcements={[fakeTeacherAnnouncement]}
       />
     );
-    expect(wrapper.find(Notification).length).toEqual(1);
+    expect(wrapper.find(NotificationBanner).length).toEqual(1);
   });
 });

--- a/apps/test/unit/templates/MultipleAssignButtonTest.js
+++ b/apps/test/unit/templates/MultipleAssignButtonTest.js
@@ -1,3 +1,4 @@
+import {Button} from '@mui/material';
 import {shallow} from 'enzyme'; // eslint-disable-line no-restricted-imports
 import React from 'react';
 
@@ -30,7 +31,7 @@ describe('MultipleAssignButtonTest', () => {
     const wrapper = setUp();
     expect(wrapper.find('.uitest-assign-button')).toBeDefined();
     expect(wrapper.exists('Connect(MultipleSectionsAssigner)')).toBe(false);
-    wrapper.find('Button').simulate('click');
+    wrapper.find(Button).simulate('click');
     expect(
       wrapper.find('Connect(MultipleSectionsAssigner)').first().props()
         .isAssigningCourseOnly
@@ -42,7 +43,7 @@ describe('MultipleAssignButtonTest', () => {
     const wrapper = setUp({isAssigningCourseOnly: true});
     expect(wrapper.find('.uitest-assign-button')).toBeDefined();
     expect(wrapper.exists('Connect(MultipleSectionsAssigner)')).toBe(false);
-    wrapper.find('Button').simulate('click');
+    wrapper.find(Button).simulate('click');
     expect(
       wrapper.find('Connect(MultipleSectionsAssigner)').first().props()
         .isAssigningCourseOnly

--- a/apps/test/unit/templates/courseOverview/VerifiedResourcesNotificationTest.jsx
+++ b/apps/test/unit/templates/courseOverview/VerifiedResourcesNotificationTest.jsx
@@ -1,3 +1,4 @@
+import NotificationBanner from '@code-dot-org/component-library/notification-banner';
 import {shallow} from 'enzyme'; // eslint-disable-line no-restricted-imports
 import React from 'react';
 
@@ -5,7 +6,6 @@ import VerifiedResourcesNotification from '@cdo/apps/templates/courseOverview/Ve
 
 describe('VerifiedResourcesNotification', () => {
   const defaultProps = {
-    width: 700,
     inLesson: false,
   };
 
@@ -14,7 +14,7 @@ describe('VerifiedResourcesNotification', () => {
       <VerifiedResourcesNotification {...defaultProps} />
     );
 
-    expect(wrapper.find('Connect(Notification)').first().props().details).toBe(
+    expect(wrapper.find(NotificationBanner).first().prop('description')).toBe(
       'This course provides extra resources which are only available to verified teachers.'
     );
   });
@@ -24,7 +24,7 @@ describe('VerifiedResourcesNotification', () => {
       <VerifiedResourcesNotification {...defaultProps} inLesson={true} />
     );
 
-    expect(wrapper.find('Connect(Notification)').first().props().details).toBe(
+    expect(wrapper.find(NotificationBanner).first().prop('description')).toBe(
       'This lesson contains extra resources or levels which are only available to verified teachers.'
     );
   });

--- a/apps/test/unit/templates/progress/HiddenForSectionToggleTest.jsx
+++ b/apps/test/unit/templates/progress/HiddenForSectionToggleTest.jsx
@@ -1,71 +1,60 @@
+import SegmentedButtons from '@code-dot-org/component-library/segmentedButtons';
 import {shallow} from 'enzyme'; // eslint-disable-line no-restricted-imports
 import React from 'react';
 import sinon from 'sinon'; // eslint-disable-line no-restricted-imports
 
-import Button from '@cdo/apps/legacySharedComponents/Button';
-import {UnconnectedHiddenForSectionToggle as HiddenForSectionToggle} from '@cdo/apps/templates/progress/HiddenForSectionToggle';
+import HiddenForSectionToggle from '@cdo/apps/templates/progress/HiddenForSectionToggle';
 import i18n from '@cdo/locale';
 
 import {expect} from '../../../util/deprecatedChai'; // eslint-disable-line no-restricted-imports
 
 describe('HiddenForSectionToggle', () => {
-  it('renders two buttons reflecting hidden state', () => {
+  it('renders SegmentedButtons reflecting hidden state', () => {
     const wrapper = shallow(
       <HiddenForSectionToggle hidden={false} onChange={() => {}} />
     );
-    expect(wrapper).to.containMatchingElement(
-      <div>
-        <Button
-          text={i18n.visible()}
-          color={Button.ButtonColor.gray}
-          disabled={true}
-          icon="eye"
-        />
-        <Button
-          text={i18n.hidden()}
-          color={Button.ButtonColor.gray}
-          disabled={false}
-          icon="eye-slash"
-        />
-      </div>
-    );
+    const segmented = wrapper.find(SegmentedButtons);
+    expect(segmented).to.have.lengthOf(1);
+    expect(segmented.prop('selectedButtonValue')).to.equal('visible');
 
-    // Changing the 'hidden' prop reverses which button is enabled:
+    const buttons = segmented.prop('buttons');
+    expect(buttons).to.have.lengthOf(2);
+    expect(buttons[0]).to.include({label: i18n.visible(), value: 'visible'});
+    expect(buttons[1]).to.include({label: i18n.hidden(), value: 'hidden'});
+
+    // Changing the 'hidden' prop flips which value is selected.
     wrapper.setProps({hidden: true});
-    expect(wrapper).to.containMatchingElement(
-      <div>
-        <Button text={i18n.visible()} disabled={false} />
-        <Button text={i18n.hidden()} disabled={true} />
-      </div>
+    expect(wrapper.find(SegmentedButtons).prop('selectedButtonValue')).to.equal(
+      'hidden'
     );
   });
 
-  it('calls onChange handler when buttons are clicked', () => {
+  it('forwards onChange value from SegmentedButtons', () => {
     const callback = sinon.spy();
     const wrapper = shallow(
       <HiddenForSectionToggle hidden={false} onChange={callback} />
     );
 
-    // Click the first button
-    wrapper.find(Button).at(0).props().onClick();
+    const onChange = wrapper.find(SegmentedButtons).prop('onChange');
+    onChange('visible');
     expect(callback).to.have.been.calledOnce.and.calledWith('visible');
 
     callback.resetHistory();
-
-    // Click the second button
-    wrapper.find(Button).at(1).props().onClick();
+    onChange('hidden');
     expect(callback).to.have.been.calledOnce.and.calledWith('hidden');
   });
 
-  it('does not call onChange when disabled', () => {
-    const callback = sinon.spy();
+  it('disables all buttons when disabled prop is true', () => {
     const wrapper = shallow(
-      <HiddenForSectionToggle hidden={false} onChange={callback} disabled />
+      <HiddenForSectionToggle
+        hidden={false}
+        onChange={() => {}}
+        disabled={true}
+      />
     );
 
-    // Click both buttons
-    wrapper.find(Button).at(0).props().onClick();
-    wrapper.find(Button).at(1).props().onClick();
-    expect(callback).not.to.have.been.called;
+    const buttons = wrapper.find(SegmentedButtons).prop('buttons');
+    expect(buttons[0].disabled).to.equal(true);
+    expect(buttons[1].disabled).to.equal(true);
   });
 });

--- a/apps/test/unit/templates/progress/ProgressLessonTeacherInfoTest.js
+++ b/apps/test/unit/templates/progress/ProgressLessonTeacherInfoTest.js
@@ -282,11 +282,7 @@ describe('ProgressLessonTeacherInfo', () => {
         )
     );
 
-    expect(withSection.find('Connect(HiddenForSectionToggle)').length).toEqual(
-      1
-    );
-    expect(
-      withoutSection.find('Connect(HiddenForSectionToggle)').length
-    ).toEqual(0);
+    expect(withSection.find('HiddenForSectionToggle').length).toEqual(1);
+    expect(withoutSection.find('HiddenForSectionToggle').length).toEqual(0);
   });
 });

--- a/dashboard/test/ui/features/teacher_tools/teacher_dashboard/teacher_dashboard_local_nav_v2_eyes.feature
+++ b/dashboard/test/ui/features/teacher_tools/teacher_dashboard/teacher_dashboard_local_nav_v2_eyes.feature
@@ -60,7 +60,7 @@ Feature: Using the V2 teacher dashboard local navigation - Eyes
     Then I see no difference for "unit overview"
 
     When I click selector "a:contains('allthethingscourse')" once I see it
-    And I wait until element "h1:contains('allthethingscourse')" is visible
+    And I wait until element "h2:contains('allthethingscourse')" is visible
     Then I see no difference for "course overview"
 
     And I close my eyes


### PR DESCRIPTION
Reverts code-dot-org/code-dot-org#72356 to re-apply the teacher course overview design system migration (#72236).

Includes follow-up fixes for the two eyes test regressions that caused the prior revert:

- **Course overview**: title sat flush against the "+ Assign to sections" row. Browser `<h1>` carries `margin-block-end: 0.67em`; MUI `Typography` is `margin: 0`. Restore the gap with `gutterBottom`.
- **Lesson plan**: consecutive announcement banners stacked with no gap. Legacy `Notification` had `marginBottom: 20` in its inner style; the replacement `NotificationBanner` has none. `Announcements` was the one migrated caller missing the margin module — apply the same pattern as `CourseOverview` / `VerifiedResourcesNotification`.

## Test plan
- [ ] Drone eyes tests pass (regressions on Step 1/1 teacher lesson plan and Step 2/2 course overview should clear)
- [x] Manual: course overview shows expected gap between course title and assign action row
- [x] Manual: lesson plan shows expected gaps between stacked announcement banners and the verified-resources notification