### PR TITLE
Grant device farm permissions to test daemon role

### DIFF
--- a/aws/cloudformation/cloud_formation_stack.yml.erb
+++ b/aws/cloudformation/cloud_formation_stack.yml.erb
@@ -629,7 +629,6 @@ Resources:
                   - 'devicefarm:ListTestGridSessionActions'
                   - 'devicefarm:ListTestGridSessionArtifacts'
                   - 'devicefarm:ListTestGridSessions'
-                  - 'devicefarm:StopTestGridSession'
                 Resource:
                   - !Sub 'arn:aws:devicefarm:*:${AWS::AccountId}:testgrid-project:*'
                   - !Sub 'arn:aws:devicefarm:*:${AWS::AccountId}:testgrid-session:*'

--- a/aws/cloudformation/cloud_formation_stack.yml.erb
+++ b/aws/cloudformation/cloud_formation_stack.yml.erb
@@ -638,6 +638,68 @@ Resources:
                 Action:
                   - 'devicefarm:ListTestGridProjects'
                 Resource: '*'
+        # Mobile Device Farm access for UI test runners on the test daemon.
+        # Covers the run lifecycle: read project/run/job/suite/test/upload
+        # state, schedule and stop runs, manage uploads, and drive remote
+        # access sessions. Erring on the side of broader access — trim later
+        # if a tighter set proves sufficient.
+        - PolicyName: DaemonDeviceFarmMobilePolicy
+          PolicyDocument:
+            Statement:
+              # Resource-scoped actions on Device Farm resources owned by this account.
+              - Effect: Allow
+                Action:
+                  - 'devicefarm:GetProject'
+                  - 'devicefarm:GetRun'
+                  - 'devicefarm:GetJob'
+                  - 'devicefarm:GetSuite'
+                  - 'devicefarm:GetTest'
+                  - 'devicefarm:GetUpload'
+                  - 'devicefarm:GetDevicePool'
+                  - 'devicefarm:GetDevicePoolCompatibility'
+                  - 'devicefarm:GetNetworkProfile'
+                  - 'devicefarm:GetRemoteAccessSession'
+                  - 'devicefarm:ListJobs'
+                  - 'devicefarm:ListSuites'
+                  - 'devicefarm:ListTests'
+                  - 'devicefarm:ListArtifacts'
+                  - 'devicefarm:ListSamples'
+                  - 'devicefarm:ListUniqueProblems'
+                  - 'devicefarm:ListUploads'
+                  - 'devicefarm:ListRuns'
+                  - 'devicefarm:ListNetworkProfiles'
+                  - 'devicefarm:ListDevicePools'
+                  - 'devicefarm:ListRemoteAccessSessions'
+                  - 'devicefarm:ScheduleRun'
+                  - 'devicefarm:StopRun'
+                  - 'devicefarm:StopJob'
+                  - 'devicefarm:StopRemoteAccessSession'
+                  - 'devicefarm:CreateUpload'
+                  - 'devicefarm:CreateRemoteAccessSession'
+                  - 'devicefarm:DeleteRun'
+                  - 'devicefarm:DeleteUpload'
+                  - 'devicefarm:DeleteRemoteAccessSession'
+                Resource:
+                  - !Sub 'arn:aws:devicefarm:*:${AWS::AccountId}:project:*'
+                  - !Sub 'arn:aws:devicefarm:*:${AWS::AccountId}:run:*'
+                  - !Sub 'arn:aws:devicefarm:*:${AWS::AccountId}:job:*'
+                  - !Sub 'arn:aws:devicefarm:*:${AWS::AccountId}:suite:*'
+                  - !Sub 'arn:aws:devicefarm:*:${AWS::AccountId}:test:*'
+                  - !Sub 'arn:aws:devicefarm:*:${AWS::AccountId}:upload:*'
+                  - !Sub 'arn:aws:devicefarm:*:${AWS::AccountId}:devicepool:*'
+                  - !Sub 'arn:aws:devicefarm:*:${AWS::AccountId}:networkprofile:*'
+                  - !Sub 'arn:aws:devicefarm:*:${AWS::AccountId}:session:*'
+                  - !Sub 'arn:aws:devicefarm:*:${AWS::AccountId}:artifact:*'
+              # Device-level and account-wide list actions are not resource-scopable
+              # (devices are AWS-managed and have no account in their ARN).
+              - Effect: Allow
+                Action:
+                  - 'devicefarm:GetDevice'
+                  - 'devicefarm:ListDevices'
+                  - 'devicefarm:ListProjects'
+                  - 'devicefarm:ListOfferings'
+                  - 'devicefarm:ListOfferingPromotions'
+                Resource: '*'
 <% end -%>
       ManagedPolicyArns:
         - !Ref CDOPolicy

--- a/aws/cloudformation/cloud_formation_stack.yml.erb
+++ b/aws/cloudformation/cloud_formation_stack.yml.erb
@@ -613,6 +613,32 @@ Resources:
                   - dms:StartReplicationTask
                 Resource: !Sub "arn:aws:dms:${AWS::Region}:${AWS::AccountId}:task:*"
 <% end -%>
+<% if rack_env?(:test) -%>
+        # AWS Device Farm (Test Grid) access for UI test runners on the test daemon.
+        # Scoped to Test Grid only — this is a Selenium/WebDriver replacement
+        # evaluation for Saucelabs and does not need mobile Device Farm actions.
+        - PolicyName: DaemonDeviceFarmPolicy
+          PolicyDocument:
+            Statement:
+              # Resource-scoped actions: operate on a specific project or session.
+              - Effect: Allow
+                Action:
+                  - 'devicefarm:CreateTestGridUrl'
+                  - 'devicefarm:GetTestGridProject'
+                  - 'devicefarm:GetTestGridSession'
+                  - 'devicefarm:ListTestGridSessionActions'
+                  - 'devicefarm:ListTestGridSessionArtifacts'
+                  - 'devicefarm:ListTestGridSessions'
+                  - 'devicefarm:StopTestGridSession'
+                Resource:
+                  - !Sub 'arn:aws:devicefarm:*:${AWS::AccountId}:testgrid-project:*'
+                  - !Sub 'arn:aws:devicefarm:*:${AWS::AccountId}:testgrid-session:*'
+              # List actions are not resource-scopable by AWS and must use "*".
+              - Effect: Allow
+                Action:
+                  - 'devicefarm:ListTestGridProjects'
+                Resource: '*'
+<% end -%>
       ManagedPolicyArns:
         - !Ref CDOPolicy
         - !ImportValue IAM-SessionPermissions


### PR DESCRIPTION
This PR addresses the following error when running the new `rake test:devicefarm_ui` task:
```
User: arn:aws:sts::475661607190:assumed-role/test-DaemonRole-1FYX95VQO53I7/i-0b3a2b77baca571ff is not authorized to perform: devicefarm:GetDevice on resource: arn:aws:devicefarm:us-west-2::device:EEED8AB9E08F4B6C862F982EDA0A0C34 because no identity-based policy allows the devicefarm:GetDevice action (Aws::DeviceFarm::Errors::AccessDeniedException)
```

See [slack](https://codedotorg.slack.com/archives/C03CK49G9/p1777302002267349?thread_ts=1776294655.268559&cid=C03CK49G9) and for full context. This is loosely based on #72169 which solved a similar problem for drone workers, except that this PR also includes mobile permissions (not currently needed in drone).

## Testing story
- no new issues detected via cfn-lint:
```
[09:55:04] Dave-M4:~/src/cdo (grant-device-farm-permissions-to-test-daemon-role)$ brew install cfn-lint
[09:46:56] Dave-M4:~/src/cdo (grant-device-farm-permissions-to-test-daemon-role)$ bundle exec rake stack:lint RAILS_ENV=test
<same warnings as before>
```
- passes stack validation:
```
$ bundle exec rake stack:validate RAILS_ENV=test
Finished stack:environment (less than a minute)
Pending update for stack `test`:
Modify DaemonRole [AWS::IAM::Role] Properties (Policies)
Finished stack:validate (less than a minute)
```
- successful deploy to  adhoc, with temporary changes to apply these permissions in adhoc rather than test env


## Deployment notes
- merge these changes, wait for staging to rebuild cookbooks, deploy cookbook changes to test, then validate original rake task is working on the test machine.