### PR TITLE
Adds italian exception to profanity list.

### DIFF
--- a/lib/cdo/profanity_filter.rb
+++ b/lib/cdo/profanity_filter.rb
@@ -14,7 +14,8 @@ class ProfanityFilter
   # handling them with our custom code, here. Webpurify credentials are in LastPass.
   LANGUAGE_SPECIFIC_ALLOWLIST = {
     fu: %w(it), # past-tense "to be" in Italian
-    fick: %w(sv) # "got" in Swedish
+    fick: %w(sv), # "got" in Swedish
+    nazionale: %w(it), # The word 'national' in Italian
   }
 
   # Look for profanity in a given text, return the first expletive found


### PR DESCRIPTION
Adds `nazionale` as an OK word to the profanity override list for Italian.

## Links
<!-- Jira tickets, design docs, Slack threads, related PRs, etc. -->

- Jira: [SL-1688](https://codedotorg.atlassian.net/browse/SL-1688)
