### PR TITLE
Implement allowlist for target_link_uri

### DIFF
--- a/dashboard/app/controllers/lti_v1_controller.rb
+++ b/dashboard/app/controllers/lti_v1_controller.rb
@@ -183,7 +183,11 @@ class LtiV1Controller < ApplicationController
         nrps_url: nrps_url,
       }
 
-      destination_url = "#{target_link_uri}?#{redirect_params.to_query}"
+      unless Policies::Lti.allowed_target_link_uri?(target_link_uri)
+        return log_unauthorized('Invalid target_link_uri', {target_link_uri: target_link_uri})
+      end
+
+      destination_url = build_destination_url(target_link_uri, redirect_params)
       session[:user_return_to] = destination_url
 
       if user
@@ -445,6 +449,13 @@ class LtiV1Controller < ApplicationController
 
   private def generate_random_string(length)
     SecureRandom.alphanumeric length
+  end
+
+  private def build_destination_url(target_link_uri, redirect_params)
+    uri = URI.parse(target_link_uri)
+    existing_query_params = Rack::Utils.parse_nested_query(uri.query.to_s)
+    uri.query = existing_query_params.merge(redirect_params.stringify_keys).to_query
+    uri.to_s
   end
 
   private def log_unauthorized(event, attributes = {})

--- a/dashboard/lib/policies/lti.rb
+++ b/dashboard/lib/policies/lti.rb
@@ -32,7 +32,6 @@ class Policies::Lti
   DEFAULT_TARGET_LINK_URI = CDO.studio_url('/lti/v1/sync_course', CDO.default_scheme).freeze
   ALLOWED_TARGET_LINK_URI_DOMAINS = {
     'code.org' => true,
-    'studio.code.org' => true,
     'csforall.org' => true,
   }.freeze
 
@@ -210,8 +209,12 @@ class Policies::Lti
     uri = URI.parse(target_link_uri.to_s)
     return false unless uri.is_a?(URI::HTTP)
 
+    host = uri.host.to_s.downcase
+    return false if host.blank?
+
     ALLOWED_TARGET_LINK_URI_DOMAINS.keys.any? do |domain|
-      uri.host == domain || uri.host.end_with?(".#{domain}")
+      normalized_domain = domain.downcase
+      host == normalized_domain || host.end_with?(".#{normalized_domain}")
     end
   rescue URI::InvalidURIError
     false

--- a/dashboard/lib/policies/lti.rb
+++ b/dashboard/lib/policies/lti.rb
@@ -30,10 +30,12 @@ class Policies::Lti
   JWT_CLIENT_ASSERTION_TYPE = 'urn:ietf:params:oauth:client-assertion-type:jwt-bearer'
   JWT_ISSUER = CDO.studio_url('', CDO.default_scheme).freeze
   DEFAULT_TARGET_LINK_URI = CDO.studio_url('/lti/v1/sync_course', CDO.default_scheme).freeze
-  ALLOWED_TARGET_LINK_URI_DOMAINS = {
-    'code.org' => true,
-    'csforall.org' => true,
-  }.freeze
+  ALLOWED_TARGET_LINK_URI_DOMAINS = Set.new(
+    [
+      'code.org',
+      'csforall.org',
+    ]
+).freeze
 
   MEMBERSHIP_CONTAINER_CONTENT_TYPE = 'application/vnd.ims.lti-nrps.v2.membershipcontainer+json'
   TEACHER_ROLES = Set.new(['http://purl.imsglobal.org/vocab/lis/v1/institution/person#Instructor',
@@ -212,7 +214,7 @@ class Policies::Lti
     host = uri.host.to_s.downcase
     return false if host.blank?
 
-    ALLOWED_TARGET_LINK_URI_DOMAINS.keys.any? do |domain|
+    ALLOWED_TARGET_LINK_URI_DOMAINS.any? do |domain|
       normalized_domain = domain.downcase
       host == normalized_domain || host.end_with?(".#{normalized_domain}")
     end

--- a/dashboard/lib/policies/lti.rb
+++ b/dashboard/lib/policies/lti.rb
@@ -33,6 +33,7 @@ class Policies::Lti
   ALLOWED_TARGET_LINK_URI_DOMAINS = {
     'code.org' => true,
     'studio.code.org' => true,
+    'csforall.org' => true,
   }.freeze
 
   MEMBERSHIP_CONTAINER_CONTENT_TYPE = 'application/vnd.ims.lti-nrps.v2.membershipcontainer+json'

--- a/dashboard/lib/policies/lti.rb
+++ b/dashboard/lib/policies/lti.rb
@@ -30,6 +30,10 @@ class Policies::Lti
   JWT_CLIENT_ASSERTION_TYPE = 'urn:ietf:params:oauth:client-assertion-type:jwt-bearer'
   JWT_ISSUER = CDO.studio_url('', CDO.default_scheme).freeze
   DEFAULT_TARGET_LINK_URI = CDO.studio_url('/lti/v1/sync_course', CDO.default_scheme).freeze
+  ALLOWED_TARGET_LINK_URI_DOMAINS = {
+    'code.org' => true,
+    'studio.code.org' => true,
+  }.freeze
 
   MEMBERSHIP_CONTAINER_CONTENT_TYPE = 'application/vnd.ims.lti-nrps.v2.membershipcontainer+json'
   TEACHER_ROLES = Set.new(['http://purl.imsglobal.org/vocab/lis/v1/institution/person#Instructor',
@@ -199,6 +203,17 @@ class Policies::Lti
   def self.find_platform_name_by_issuer(issuer)
     platform_name, _ = LMS_PLATFORMS.find {|_, platform| platform[:issuer] == issuer}
     platform_name.to_s
+  end
+
+  def self.allowed_target_link_uri?(target_link_uri)
+    uri = URI.parse(target_link_uri.to_s)
+    return false unless uri.is_a?(URI::HTTP)
+
+    ALLOWED_TARGET_LINK_URI_DOMAINS.keys.any? do |domain|
+      uri.host == domain || uri.host.end_with?(".#{domain}")
+    end
+  rescue URI::InvalidURIError
+    false
   end
 
   # Returns the email provided by the LMS when creating the User through LTI

--- a/dashboard/lib/policies/lti.rb
+++ b/dashboard/lib/policies/lti.rb
@@ -30,6 +30,8 @@ class Policies::Lti
   JWT_CLIENT_ASSERTION_TYPE = 'urn:ietf:params:oauth:client-assertion-type:jwt-bearer'
   JWT_ISSUER = CDO.studio_url('', CDO.default_scheme).freeze
   DEFAULT_TARGET_LINK_URI = CDO.studio_url('/lti/v1/sync_course', CDO.default_scheme).freeze
+  # For security reasons, we only allow target_link_uris that are on domains we control.
+  # This is to prevent abuse of our LTI integration to launch unexpected URLs.
   ALLOWED_TARGET_LINK_URI_DOMAINS = Set.new(
     [
       'code.org',

--- a/dashboard/test/controllers/lti_v1_controller_test.rb
+++ b/dashboard/test/controllers/lti_v1_controller_test.rb
@@ -493,6 +493,30 @@ class LtiV1ControllerTest < ActionDispatch::IntegrationTest
     assert_nil session[:user_return_to]
   end
 
+  test 'auth - hostless target_link_uri returns unauthorized' do
+    payload = get_valid_payload
+    payload[:'https://purl.imsglobal.org/spec/lti/claim/target_link_uri'] = 'https://'
+    jwt = create_jwt_and_stub(payload)
+    create_preexisting_user(payload)
+
+    post '/lti/v1/authenticate', params: {id_token: jwt, state: @state}
+
+    assert_response :unauthorized
+    assert_nil session[:user_return_to]
+  end
+
+  test 'auth - non-http target_link_uri returns unauthorized' do
+    payload = get_valid_payload
+    payload[:'https://purl.imsglobal.org/spec/lti/claim/target_link_uri'] = 'javascript:alert(1)'
+    jwt = create_jwt_and_stub(payload)
+    create_preexisting_user(payload)
+
+    post '/lti/v1/authenticate', params: {id_token: jwt, state: @state}
+
+    assert_response :unauthorized
+    assert_nil session[:user_return_to]
+  end
+
   test 'auth - error raised for issued at time in future' do
     payload = get_valid_payload
     payload[:iat] = 3.days.from_now.to_i

--- a/dashboard/test/controllers/lti_v1_controller_test.rb
+++ b/dashboard/test/controllers/lti_v1_controller_test.rb
@@ -481,6 +481,18 @@ class LtiV1ControllerTest < ActionDispatch::IntegrationTest
     assert_response :unauthorized
   end
 
+  test 'auth - off-site target_link_uri returns unauthorized' do
+    payload = get_valid_payload
+    payload[:'https://purl.imsglobal.org/spec/lti/claim/target_link_uri'] = 'https://example.com/launch'
+    jwt = create_jwt_and_stub(payload)
+    create_preexisting_user(payload)
+
+    post '/lti/v1/authenticate', params: {id_token: jwt, state: @state}
+
+    assert_response :unauthorized
+    assert_nil session[:user_return_to]
+  end
+
   test 'auth - error raised for issued at time in future' do
     payload = get_valid_payload
     payload[:iat] = 3.days.from_now.to_i

--- a/dashboard/test/controllers/lti_v1_controller_test.rb
+++ b/dashboard/test/controllers/lti_v1_controller_test.rb
@@ -572,6 +572,28 @@ class LtiV1ControllerTest < ActionDispatch::IntegrationTest
     # could confirm more things here
   end
 
+  test 'auth - given target_link_uri with existing query params, redirect preserves and merges params' do
+    payload = get_valid_payload
+    payload[:'https://purl.imsglobal.org/spec/lti/claim/target_link_uri'] = "#{CDO.studio_url('/courses', CDO.default_scheme)}?foo=bar"
+    jwt = create_jwt_and_stub(payload)
+    create_preexisting_user(payload)
+
+    post '/lti/v1/authenticate', params: {id_token: jwt, state: @state}
+
+    assert_response :redirect
+    redirected_uri = URI.parse(@response.redirect_url)
+    query_params = Rack::Utils.parse_nested_query(redirected_uri.query)
+    deployment = LtiDeployment.find_by(deployment_id: @deployment_id)
+
+    assert_equal URI.parse(payload[:'https://purl.imsglobal.org/spec/lti/claim/target_link_uri']).path, redirected_uri.path
+    assert_equal 'bar', query_params['foo']
+    assert_equal @integration.id.to_s, query_params['lti_integration_id']
+    assert_equal deployment.id.to_s, query_params['deployment_id']
+    assert_equal payload[Policies::Lti::LTI_CONTEXT_CLAIM][:id], query_params['context_id']
+    assert_equal payload[Policies::Lti::LTI_RESOURCE_LINK_CLAIM][:id], query_params['rlid']
+    assert_equal payload[Policies::Lti::LTI_NRPS_CLAIM][:context_memberships_url], query_params['nrps_url']
+  end
+
   test 'auth - given a deployment_id not in our system yet, create LtiDeployment' do
     payload = get_valid_payload
     jwt = create_jwt_and_stub(payload)


### PR DESCRIPTION
This PR implements functionality that denies domains that are not explicitly allowed in the `target_link_uri` claim in the JWT the `LtiV1Controller#Authenticate` controller action receives. This is to mitigate the risk of wide open redirects.

<!--
  Summary of the change: background, motivation, and context.
  Include screenshots, videos, or before/after comparisons for UI changes.
-->



## Links
<!-- Jira tickets, design docs, Slack threads, related PRs, etc. -->

- Jira: https://codedotorg.atlassian.net/browse/P20-1838

## Testing story
<!-- How was this tested? Manual steps, adhoc links, automated tests, or why testing isn't needed. -->



## Deployment notes
<!-- Delete this section if it's a standard merge-and-deploy.
     Otherwise: migrations, feature flags, coordination, caching impacts, etc. -->



## Privacy and security
<!-- Delete this section if there is no privacy/security impact.
     Otherwise: new PII, auth changes, API surface changes, etc. -->

