### PR TITLE
Fix adhocs by removing secrets

### DIFF
--- a/config/adhoc.yml.erb
+++ b/config/adhoc.yml.erb
@@ -36,9 +36,6 @@ db_credential_admin: !StackSecret
 db_credential_writer: !StackSecret
 db_credential_reader: !StackSecret
 
-demo_student_ids: {}
-demo_section_unit_name: ""
-demo_section_unit_group_name: ""
 
 openai_student_learning_api_key: !Secret
 

--- a/config/adhoc.yml.erb
+++ b/config/adhoc.yml.erb
@@ -36,9 +36,9 @@ db_credential_admin: !StackSecret
 db_credential_writer: !StackSecret
 db_credential_reader: !StackSecret
 
-demo_student_ids:
-demo_section_unit_name: !StackSecret
-demo_section_unit_group_name: !StackSecret
+demo_student_ids: {}
+demo_section_unit_name: ""
+demo_section_unit_group_name: ""
 
 openai_student_learning_api_key: !Secret
 


### PR DESCRIPTION
Fix adhocs failing to build by removing requirements on secrets. These can be defined in config in the future when needed.

## Links
https://codedotorg.slack.com/archives/C046G4TRLEN/p1777328974129789