### PR TITLE
Upgrade `jemalloc` to 5.3.1

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -90,7 +90,7 @@ steps:
 
   - name: unit-tests
     # see: docker/ci/Dockerfile
-    image: codedotorg/cdo-ci:1.19
+    image: codedotorg/cdo-ci:jemalloc-5.3
     pull: always
     environment:
       CI_JOB: 'unit_tests'
@@ -212,7 +212,7 @@ steps:
 
   - name: ui-tests
     # see: docker/ci/Dockerfile
-    image: codedotorg/cdo-ci:1.19
+    image: codedotorg/cdo-ci:jemalloc-5.3
     pull: always
     volumes:
       - name: mysql
@@ -297,7 +297,7 @@ steps:
   # snapshot of the fully-built project and resulting database, but don't
   # actually run the tests.
   - name: prepare-cacheable-build
-    image: codedotorg/cdo-ci:1.19
+    image: codedotorg/cdo-ci:jemalloc-5.3
     pull: always
     environment:
       CI_JOB: 'prepare_cacheable_build'
@@ -344,6 +344,6 @@ trigger:
 
 ---
 kind: signature
-hmac: 94099b2e7d920d508596699178953a73f541da4646b72e0703b27d82a8084940
+hmac: df04757615bfe9b30dea6b629792d36d22d4a6feeba2ba629babb1cd3e1731e9
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -90,7 +90,7 @@ steps:
 
   - name: unit-tests
     # see: docker/ci/Dockerfile
-    image: codedotorg/cdo-ci:jemalloc-5.3
+    image: codedotorg/cdo-ci:jemalloc-5.3.1
     pull: always
     environment:
       CI_JOB: 'unit_tests'
@@ -212,7 +212,7 @@ steps:
 
   - name: ui-tests
     # see: docker/ci/Dockerfile
-    image: codedotorg/cdo-ci:jemalloc-5.3
+    image: codedotorg/cdo-ci:jemalloc-5.3.1
     pull: always
     volumes:
       - name: mysql
@@ -297,7 +297,7 @@ steps:
   # snapshot of the fully-built project and resulting database, but don't
   # actually run the tests.
   - name: prepare-cacheable-build
-    image: codedotorg/cdo-ci:jemalloc-5.3
+    image: codedotorg/cdo-ci:jemalloc-5.3.1
     pull: always
     environment:
       CI_JOB: 'prepare_cacheable_build'
@@ -344,6 +344,6 @@ trigger:
 
 ---
 kind: signature
-hmac: df04757615bfe9b30dea6b629792d36d22d4a6feeba2ba629babb1cd3e1731e9
+hmac: 374099557d002df91a2fdd2479063c44e87f622f92831bb567c8ad4dd5832953
 
 ...

--- a/bin/restart-active-job-workers
+++ b/bin/restart-active-job-workers
@@ -1,4 +1,13 @@
 #!/usr/bin/env ruby
+
+# Use jemalloc if available (installed by cdo-jemalloc cookbook on production instances).
+jemalloc_lib = '/usr/local/lib/libjemalloc.so.2'
+if File.exist?(jemalloc_lib)
+  ENV['LD_PRELOAD'] = jemalloc_lib
+  # Keep these settings in sync with how Chef configures `jemalloc`: `cookbooks/cdo-jemalloc/attributes/default.rb`
+  ENV['MALLOC_CONF'] ||= 'narenas:2,background_thread:true,dirty_decay_ms:500,muzzy_decay_ms:0'
+end
+
 require_relative '../deployment'
 require 'cdo/active_job_backend'
 

--- a/cookbooks/cdo-jemalloc/attributes/default.rb
+++ b/cookbooks/cdo-jemalloc/attributes/default.rb
@@ -1,5 +1,5 @@
-default['cdo-jemalloc']['version'] = '5.3.0'
-default['cdo-jemalloc']['checksum'] = '2db82d1e7119df3e71b7640219b6dfe84789bc0537983c3b7ac4f7189aecfeaa'
+default['cdo-jemalloc']['version'] = '5.3.1'
+default['cdo-jemalloc']['checksum'] = '3826bc80232f22ed5c4662f3034f799ca316e819103bdc7bb99018a421706f92'
 default['cdo-jemalloc']['lib'] = '/usr/local/lib/libjemalloc.so.2'
 
 # See:

--- a/cookbooks/cdo-jemalloc/attributes/default.rb
+++ b/cookbooks/cdo-jemalloc/attributes/default.rb
@@ -7,6 +7,7 @@ default['cdo-jemalloc']['lib'] = '/usr/local/lib/libjemalloc.so.2'
 # http://jemalloc.net/jemalloc.3.html
 # To convert this attributes hash to a malloc_conf string, run:
 # node['cdo-jemalloc']['malloc_conf'].map {|x| x.join(':')}.join(',')
+# Any changes to MALLOC_CONF must also be applied to our Docker image: `docker/ci/Dockerfile`
 default['cdo-jemalloc']['malloc_conf'] = {
   # Maximum number of arenas to use for automatic multiplexing of threads and arenas.
   # The default is four times the number of CPUs, or one if there is a single CPU.

--- a/cookbooks/cdo-jemalloc/attributes/default.rb
+++ b/cookbooks/cdo-jemalloc/attributes/default.rb
@@ -1,5 +1,5 @@
-default['cdo-jemalloc']['version'] = '5.1.0'
-default['cdo-jemalloc']['checksum'] = '5396e61cc6103ac393136c309fae09e44d74743c86f90e266948c50f3dbb7268'
+default['cdo-jemalloc']['version'] = '5.3.0'
+default['cdo-jemalloc']['checksum'] = '2db82d1e7119df3e71b7640219b6dfe84789bc0537983c3b7ac4f7189aecfeaa'
 default['cdo-jemalloc']['lib'] = '/usr/local/lib/libjemalloc.so.2'
 
 # See:
@@ -31,6 +31,9 @@ default['cdo-jemalloc']['malloc_conf'] = {
   # (usually at the cost of more CPU cycles spent on purging), and vice versa.
   #
   # Suggested: tune the values based on the desired trade-offs.
-  dirty_decay_ms: 1_000, # Default 10_000
-  muzzy_decay_ms: 0 # Default 10_000
+  dirty_decay_ms: 500, # Default 10_000
+  muzzy_decay_ms: 0, # Default 10_000
+
+  # Abort on invalid MALLOC_CONF options rather than silently ignoring them.
+  abort_conf: true
 }

--- a/cookbooks/cdo-jemalloc/attributes/default.rb
+++ b/cookbooks/cdo-jemalloc/attributes/default.rb
@@ -7,7 +7,8 @@ default['cdo-jemalloc']['lib'] = '/usr/local/lib/libjemalloc.so.2'
 # http://jemalloc.net/jemalloc.3.html
 # To convert this attributes hash to a malloc_conf string, run:
 # node['cdo-jemalloc']['malloc_conf'].map {|x| x.join(':')}.join(',')
-# Any changes to MALLOC_CONF must also be applied to our Docker image: `docker/ci/Dockerfile`
+# Any changes to MALLOC_CONF must also be applied to our Docker continuous integration builds:
+#   `docker/ci/scripts/prepare_ci_env.sh`
 default['cdo-jemalloc']['malloc_conf'] = {
   # Maximum number of arenas to use for automatic multiplexing of threads and arenas.
   # The default is four times the number of CPUs, or one if there is a single CPU.

--- a/docker/README.md
+++ b/docker/README.md
@@ -79,19 +79,15 @@ Sign in to Docker Hub through the command line; when prompted, enter the passwor
 docker login -u codedotorg
 ```
 
-Build a full image to your local machine
+Build an x86 image and tag it with an incremented version number. Our CI
+containers run on x86 (linux/amd64), so the `--platform` flag is required
+when building on ARM machines (such as those using Apple Silicon).
 
 ```
-docker build .
+docker buildx build . --platform linux/amd64 -t codedotorg/cdo-ci:<version>
 ```
 
-Tag the new image with an incremented version number. You can get the image id from the end of the build log or from `docker image list`.
-
-```
-docker tag <image_id> codedotorg/cdo-ci:<version>
-```
-
-Upload the image to docker hub (supply the version used in the previous step)
+Upload the image to docker hub
 
 ```
 docker push codedotorg/cdo-ci:<version>

--- a/docker/ci/Dockerfile
+++ b/docker/ci/Dockerfile
@@ -217,11 +217,6 @@ RUN curl -sSLOJ https://github.com/jemalloc/jemalloc/releases/download/5.3.1/jem
     cd .. && \
     rm -rf jemalloc-5.3.1 jemalloc-5.3.1.tar.bz2
 
-# Keep MALLOC_CONF configuration up to date with Chef provisioned Instances: `cookbooks/cdo-jemalloc/attributes/default.rb`
-ENV \
-    LD_PRELOAD=/usr/local/lib/libjemalloc.so.2 \
-    MALLOC_CONF=narenas:2,background_thread:true,dirty_decay_ms:500,muzzy_decay_ms:0
-
 USER ${USER}
 
 WORKDIR /home/${USER}

--- a/docker/ci/Dockerfile
+++ b/docker/ci/Dockerfile
@@ -207,15 +207,15 @@ RUN mkdir sauce_connect && \
 
 # Install jemalloc (matching production config in cookbooks/cdo-jemalloc).
 # Until we upgrade to Ubuntu 24 (which ships jemalloc 5.3 as an apt package), we'll have to compile from source.
-RUN curl -sSLOJ https://github.com/jemalloc/jemalloc/releases/download/5.3.0/jemalloc-5.3.0.tar.bz2 && \
-    echo '2db82d1e7119df3e71b7640219b6dfe84789bc0537983c3b7ac4f7189aecfeaa  jemalloc-5.3.0.tar.bz2' | sha256sum -c && \
-    tar -xjf jemalloc-5.3.0.tar.bz2 && \
-    cd jemalloc-5.3.0 && \
+RUN curl -sSLOJ https://github.com/jemalloc/jemalloc/releases/download/5.3.1/jemalloc-5.3.1.tar.bz2 && \
+    echo '3826bc80232f22ed5c4662f3034f799ca316e819103bdc7bb99018a421706f92  jemalloc-5.3.1.tar.bz2' | sha256sum -c && \
+    tar -xjf jemalloc-5.3.1.tar.bz2 && \
+    cd jemalloc-5.3.1 && \
     ./configure && \
     make -j"$(nproc)" && \
     make install && \
     cd .. && \
-    rm -rf jemalloc-5.3.0 jemalloc-5.3.0.tar.bz2
+    rm -rf jemalloc-5.3.1 jemalloc-5.3.1.tar.bz2
 
 # Keep MALLOC_CONF configuration up to date with Chef provisioned Instances: `cookbooks/cdo-jemalloc/attributes/default.rb`
 ENV \

--- a/docker/ci/Dockerfile
+++ b/docker/ci/Dockerfile
@@ -205,6 +205,23 @@ RUN mkdir sauce_connect && \
     cd .. && \
     rm -rf sauce_connect
 
+# Install jemalloc (matching production config in cookbooks/cdo-jemalloc).
+# Until we upgrade to Ubuntu 24 (which ships jemalloc 5.3 as an apt package), we'll have to compile from source.
+RUN curl -sSLOJ https://github.com/jemalloc/jemalloc/releases/download/5.3.0/jemalloc-5.3.0.tar.bz2 && \
+    echo '2db82d1e7119df3e71b7640219b6dfe84789bc0537983c3b7ac4f7189aecfeaa  jemalloc-5.3.0.tar.bz2' | sha256sum -c && \
+    tar -xjf jemalloc-5.3.0.tar.bz2 && \
+    cd jemalloc-5.3.0 && \
+    ./configure && \
+    make -j"$(nproc)" && \
+    make install && \
+    cd .. && \
+    rm -rf jemalloc-5.3.0 jemalloc-5.3.0.tar.bz2
+
+# Keep MALLOC_CONF configuration up to date with Chef provisioned Instances: `cookbooks/cdo-jemalloc/attributes/default.rb`
+ENV \
+    LD_PRELOAD=/usr/local/lib/libjemalloc.so.2 \
+    MALLOC_CONF=narenas:2,background_thread:true,dirty_decay_ms:500,muzzy_decay_ms:0
+
 USER ${USER}
 
 WORKDIR /home/${USER}

--- a/docker/ci/scripts/prepare_ci_env.sh
+++ b/docker/ci/scripts/prepare_ci_env.sh
@@ -14,6 +14,12 @@ export RACK_ENV=test
 export DISABLE_SPRING=1
 export LD_LIBRARY_PATH=/usr/local/lib
 
+# Enable jemalloc for memory optimization (and parity with Chef-provisioned systems).
+# Configuration based on cookbooks/cdo-jemalloc/attributes/default.rb, except
+# background_thread:true which breaks chromedriver (https://issues.chromium.org/issues/378077860).
+export LD_PRELOAD=/usr/local/lib/libjemalloc.so.2
+export MALLOC_CONF=narenas:2,thp:never,dirty_decay_ms:500,muzzy_decay_ms:0
+
 # Number of parallel processes for dashboard ruby unit tests,
 # optimized for drone m7i.4xlarge workers with 16 vCPUs and 64 GB RAM.
 # We ran into OOM errors with 7, and get a persistent unexplained failure in


### PR DESCRIPTION
Upgrade from `jemalloc` 5.1.0 --> 5.3.1, enable it in continuous integration builds. (and also improve our Docker build instructions to explicitly target x86)

- We are currently using a [release from 2018](https://github.com/jemalloc/jemalloc/releases/tag/5.1.0). Keeping up to date on foundational components reduces risks of security vulnerabilities and compatibility issues.
- jemalloc 5.3.1 has [numerous optimizations and improvements](https://github.com/jemalloc/jemalloc/compare/5.1.0...5.3.1) over 5.1.0
- In conjunction with enabling YJIT #72384 (which in Ruby 3.2 consumes more memory), this may help us reduce compute costs.

Also configure `jemalloc` to purge freed pages faster (dirty_decay_ms = 500).


## Testing story
`bundle exec rake adhoc:start RAILS_ENV=adhoc STACK_NAME=adhoc-upgrade-jemalloc`


## Deployment notes
<!-- Delete this section if it's a standard merge-and-deploy.
     Otherwise: migrations, feature flags, coordination, caching impacts, etc. -->



## Privacy and security
<!-- Delete this section if there is no privacy/security impact.
     Otherwise: new PII, auth changes, API surface changes, etc. -->

