### PR TITLE
Enable Ruby YJIT

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -90,7 +90,7 @@ steps:
 
   - name: unit-tests
     # see: docker/ci/Dockerfile
-    image: codedotorg/cdo-ci:1.19
+    image: codedotorg/cdo-ci:yjit
     pull: always
     environment:
       CI_JOB: 'unit_tests'
@@ -212,7 +212,7 @@ steps:
 
   - name: ui-tests
     # see: docker/ci/Dockerfile
-    image: codedotorg/cdo-ci:1.19
+    image: codedotorg/cdo-ci:yjit
     pull: always
     volumes:
       - name: mysql
@@ -297,7 +297,7 @@ steps:
   # snapshot of the fully-built project and resulting database, but don't
   # actually run the tests.
   - name: prepare-cacheable-build
-    image: codedotorg/cdo-ci:1.19
+    image: codedotorg/cdo-ci:yjit
     pull: always
     environment:
       CI_JOB: 'prepare_cacheable_build'
@@ -344,6 +344,6 @@ trigger:
 
 ---
 kind: signature
-hmac: 94099b2e7d920d508596699178953a73f541da4646b72e0703b27d82a8084940
+hmac: a1abdba89017ece6c85dd2032c90da0cf8e14c2fc17b946e8f0ab90e8b652404
 
 ...

--- a/bin/restart-active-job-workers
+++ b/bin/restart-active-job-workers
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+ENV['RUBYOPT'] = [ENV.fetch('RUBYOPT', nil), '--yjit'].compact.join(' ')
 require_relative '../deployment'
 require 'cdo/active_job_backend'
 

--- a/cookbooks/cdo-apps/attributes/default.rb
+++ b/cookbooks/cdo-apps/attributes/default.rb
@@ -5,7 +5,8 @@ default['cdo-apps'] = {
       RUBY_GC_HEAP_FREE_SLOTS: 600_000, # Default is 4096
       RUBY_GC_MALLOC_LIMIT_MAX: 134_217_728, # 128MB, default is 32MB
       RUBY_GC_OLDMALLOC_LIMIT_MAX: 300_000_000, # 300MB, default is 128MB
-      RUBY_GC_HEAP_OLDOBJECT_LIMIT_FACTOR: 3 # Default is 2.0
+      RUBY_GC_HEAP_OLDOBJECT_LIMIT_FACTOR: 3, # Default is 2.0
+      RUBYOPT: '--yjit'
     }
   },
 

--- a/docker/ci/Dockerfile
+++ b/docker/ci/Dockerfile
@@ -19,6 +19,7 @@ ENV \
     LANG=C.UTF-8 \
     TZ=Etc/UTC \
     DEBIAN_FRONTEND=noninteractive \
+    RUBYOPT=--yjit \
     USER=ci \
     GROUP=ci
 


### PR DESCRIPTION
Enable Ruby [YJIT](https://github.com/shopify/yjit) to potentially reduce compute costs. In Ruby 3.2, this consumes more memory and may need to be deployed along with #72383 (Ruby 3.3 YJIT does not increase memory utilization as much).

## Testing story
`bundle exec rake adhoc:start RAILS_ENV=adhoc STACK_NAME=adhoc-yjit`


## Deployment notes
<!-- Delete this section if it's a standard merge-and-deploy.
     Otherwise: migrations, feature flags, coordination, caching impacts, etc. -->



## Privacy and security
<!-- Delete this section if there is no privacy/security impact.
     Otherwise: new PII, auth changes, API surface changes, etc. -->

