### PR TITLE
touch up Device Farm mobile permissions

### DIFF
--- a/aws/cloudformation/cloud_formation_stack.yml.erb
+++ b/aws/cloudformation/cloud_formation_stack.yml.erb
@@ -669,12 +669,10 @@ Resources:
                   - 'devicefarm:ListNetworkProfiles'
                   - 'devicefarm:ListDevicePools'
                   - 'devicefarm:ListRemoteAccessSessions'
-                  - 'devicefarm:ScheduleRun'
                   - 'devicefarm:StopRun'
                   - 'devicefarm:StopJob'
                   - 'devicefarm:StopRemoteAccessSession'
                   - 'devicefarm:CreateUpload'
-                  - 'devicefarm:CreateRemoteAccessSession'
                   - 'devicefarm:DeleteRun'
                   - 'devicefarm:DeleteUpload'
                   - 'devicefarm:DeleteRemoteAccessSession'
@@ -689,8 +687,11 @@ Resources:
                   - !Sub 'arn:aws:devicefarm:*:${AWS::AccountId}:networkprofile:*'
                   - !Sub 'arn:aws:devicefarm:*:${AWS::AccountId}:session:*'
                   - !Sub 'arn:aws:devicefarm:*:${AWS::AccountId}:artifact:*'
-              # Device-level and account-wide list actions are not resource-scopable
-              # (devices are AWS-managed and have no account in their ARN).
+              # Actions evaluated against AWS-managed device ARNs (no account
+              # ID in the ARN) or against account-wide list endpoints — neither
+              # is resource-scopable. CreateRemoteAccessSession and ScheduleRun
+              # take a deviceArn parameter and IAM evaluates them against the
+              # device resource, not the project.
               - Effect: Allow
                 Action:
                   - 'devicefarm:GetDevice'
@@ -698,6 +699,8 @@ Resources:
                   - 'devicefarm:ListProjects'
                   - 'devicefarm:ListOfferings'
                   - 'devicefarm:ListOfferingPromotions'
+                  - 'devicefarm:CreateRemoteAccessSession'
+                  - 'devicefarm:ScheduleRun'
                 Resource: '*'
 <% end -%>
       ManagedPolicyArns:


### PR DESCRIPTION
Follow-up from #72364. That PR attempted to add all device farm permissions needed to run UI tests via device farm during the DTT. While testing that PR out, we got a new error:
```
User: arn:aws:sts::475661607190:assumed-role/test-DaemonRole-1FYX95VQO53I7/i-0b3a2b77baca571ff is not authorized to perform: devicefarm:CreateRemoteAccessSession on resource: arn:aws:devicefarm:us-west-2::device:EEED8AB9E08F4B6C862F982EDA0A0C34 because no identity-based policy allows the devicefarm:CreateRemoteAccessSession action (Aws::DeviceFarm::Errors::AccessDeniedException)
```

The fix is to tweak the previously applied permissions to apply to the right resources. See extended commit description and code comments for details.

## Testing story
syntax validation:
- cfn lint and stack validation are passing
- deploy to adhoc succeeded

permissions validation:
- [x] `ubuntu@adhoc-aws-df-permissions:~/adhoc$ bundle exec rake test:devicefarm_ui` passing, with local modifications to hit test-studio and only run against one feature
- [x] `ubuntu@adhoc-aws-df-permissions:~/adhoc$ bundle exec rake test:devicefarm_mobile_ui` passing against all features. this very likely hits the `stop_mobile_session` codepath, which might not get hit when running against a single feature
- ignoring failing UI tests in drone run because they aren't really relevant to this change

## Deployment notes
- merge as normal. cloudformation stack will update during next DTT