### PR TITLE
Teacher auto-verification for Clever, Classlink

### DIFF
--- a/dashboard/app/controllers/api_controller.rb
+++ b/dashboard/app/controllers/api_controller.rb
@@ -139,7 +139,7 @@ class ApiController < ApplicationController
       section = GoogleClassroomSection.from_service(course_id, current_user.id, students, course_name)
 
       # If a teacher passes the criteria for becoming verified, upgrade them here
-      if section && Policies::User.verified_teacher_candidate?(current_user)
+      if section && Policies::User.google_verified_teacher_candidate?(current_user)
         current_user.verify_teacher!
       end
 

--- a/dashboard/app/controllers/omniauth_callbacks_controller.rb
+++ b/dashboard/app/controllers/omniauth_callbacks_controller.rb
@@ -8,8 +8,6 @@ require 'policies/devise/email_domains'
 class OmniauthCallbacksController < Devise::OmniauthCallbacksController
   include UsersHelper
 
-  OAUTH_AUTO_VERIFICATION_SESSION_KEY = :oauth_teacher_auto_verification
-
   skip_before_action :clear_sign_up_session_vars
 
   before_action :check_account_linking_lock
@@ -277,22 +275,20 @@ class OmniauthCallbacksController < Devise::OmniauthCallbacksController
       prepare_locale_cookie u
     end
 
-    store_oauth_auto_verification! user, AuthenticationOption::CLASSLINK
-
     register_new_user(user, AuthenticationOption::CLASSLINK)
   end
 
   private def sign_in_classlink(user)
     prepare_locale_cookie user
     user.update_oauth_credential_tokens auth_hash
-    auto_verify_oauth_teacher! user, AuthenticationOption::CLASSLINK
+    auto_verify_teacher! user
     sign_in_user user
   end
 
   private def sign_in_clever(user)
     prepare_locale_cookie user
     user.update_oauth_credential_tokens auth_hash
-    auto_verify_oauth_teacher! user, AuthenticationOption::CLEVER
+    auto_verify_teacher! user
     sign_in_user user
   end
 
@@ -323,8 +319,6 @@ class OmniauthCallbacksController < Devise::OmniauthCallbacksController
       u.user_type = user_type
       prepare_locale_cookie u
     end
-
-    store_oauth_auto_verification! user, AuthenticationOption::CLEVER
 
     register_new_user(user, AuthenticationOption::CLEVER)
   end
@@ -466,13 +460,8 @@ class OmniauthCallbacksController < Devise::OmniauthCallbacksController
     auth
   end
 
-  private def auto_verify_oauth_teacher!(user, provider)
-    user.verify_teacher! if Policies::User.oauth_verified_teacher_candidate?(user, auth_hash, provider:)
-  end
-
-  private def store_oauth_auto_verification!(user, provider)
-    session[OAUTH_AUTO_VERIFICATION_SESSION_KEY] =
-      Policies::User.oauth_verified_teacher_candidate?(user, auth_hash, provider:)
+  private def auto_verify_teacher!(user)
+    user.verify_teacher! if user.teacher? && !user.verified_teacher?
   end
 
   # Moves non-standard attributes from the extra ClassLink OAuth data and puts it in the location we

--- a/dashboard/app/controllers/omniauth_callbacks_controller.rb
+++ b/dashboard/app/controllers/omniauth_callbacks_controller.rb
@@ -8,7 +8,7 @@ require 'policies/devise/email_domains'
 class OmniauthCallbacksController < Devise::OmniauthCallbacksController
   include UsersHelper
 
-  CLEVER_AUTO_VERIFICATION_SESSION_KEY = :clever_teacher_auto_verification
+  OAUTH_AUTO_VERIFICATION_SESSION_KEY = :oauth_teacher_auto_verification
 
   skip_before_action :clear_sign_up_session_vars
 
@@ -277,19 +277,22 @@ class OmniauthCallbacksController < Devise::OmniauthCallbacksController
       prepare_locale_cookie u
     end
 
+    store_oauth_auto_verification! user, AuthenticationOption::CLASSLINK
+
     register_new_user(user, AuthenticationOption::CLASSLINK)
   end
 
   private def sign_in_classlink(user)
     prepare_locale_cookie user
     user.update_oauth_credential_tokens auth_hash
+    auto_verify_oauth_teacher! user, AuthenticationOption::CLASSLINK
     sign_in_user user
   end
 
   private def sign_in_clever(user)
     prepare_locale_cookie user
     user.update_oauth_credential_tokens auth_hash
-    verify_clever_teacher! user
+    auto_verify_oauth_teacher! user, AuthenticationOption::CLEVER
     sign_in_user user
   end
 
@@ -321,8 +324,7 @@ class OmniauthCallbacksController < Devise::OmniauthCallbacksController
       prepare_locale_cookie u
     end
 
-    session[CLEVER_AUTO_VERIFICATION_SESSION_KEY] =
-      Policies::User.clever_verified_teacher_candidate?(user, auth_hash)
+    store_oauth_auto_verification! user, AuthenticationOption::CLEVER
 
     register_new_user(user, AuthenticationOption::CLEVER)
   end
@@ -464,8 +466,13 @@ class OmniauthCallbacksController < Devise::OmniauthCallbacksController
     auth
   end
 
-  private def verify_clever_teacher!(user)
-    user.verify_teacher! if Policies::User.clever_verified_teacher_candidate?(user, auth_hash)
+  private def auto_verify_oauth_teacher!(user, provider)
+    user.verify_teacher! if Policies::User.oauth_verified_teacher_candidate?(user, auth_hash, provider:)
+  end
+
+  private def store_oauth_auto_verification!(user, provider)
+    session[OAUTH_AUTO_VERIFICATION_SESSION_KEY] =
+      Policies::User.oauth_verified_teacher_candidate?(user, auth_hash, provider:)
   end
 
   # Moves non-standard attributes from the extra ClassLink OAuth data and puts it in the location we

--- a/dashboard/app/controllers/omniauth_callbacks_controller.rb
+++ b/dashboard/app/controllers/omniauth_callbacks_controller.rb
@@ -8,6 +8,8 @@ require 'policies/devise/email_domains'
 class OmniauthCallbacksController < Devise::OmniauthCallbacksController
   include UsersHelper
 
+  CLEVER_AUTO_VERIFICATION_SESSION_KEY = :clever_teacher_auto_verification
+
   skip_before_action :clear_sign_up_session_vars
 
   before_action :check_account_linking_lock
@@ -287,6 +289,7 @@ class OmniauthCallbacksController < Devise::OmniauthCallbacksController
   private def sign_in_clever(user)
     prepare_locale_cookie user
     user.update_oauth_credential_tokens auth_hash
+    verify_clever_teacher! user
     sign_in_user user
   end
 
@@ -317,6 +320,9 @@ class OmniauthCallbacksController < Devise::OmniauthCallbacksController
       u.user_type = user_type
       prepare_locale_cookie u
     end
+
+    session[CLEVER_AUTO_VERIFICATION_SESSION_KEY] =
+      Policies::User.clever_verified_teacher_candidate?(user, auth_hash)
 
     register_new_user(user, AuthenticationOption::CLEVER)
   end
@@ -456,6 +462,10 @@ class OmniauthCallbacksController < Devise::OmniauthCallbacksController
     clever_data = OmniAuth::AuthHash.new(dob: dob, gender: gender, user_type: user_type)
     auth.info&.merge!(clever_data)
     auth
+  end
+
+  private def verify_clever_teacher!(user)
+    user.verify_teacher! if Policies::User.clever_verified_teacher_candidate?(user, auth_hash)
   end
 
   # Moves non-standard attributes from the extra ClassLink OAuth data and puts it in the location we

--- a/dashboard/app/controllers/registrations_controller.rb
+++ b/dashboard/app/controllers/registrations_controller.rb
@@ -112,6 +112,7 @@ class RegistrationsController < Devise::RegistrationsController
   # Cancels the in-progress partial user registration and redirects to sign-up page.
   #
   def cancel
+    session.delete(OmniauthCallbacksController::CLEVER_AUTO_VERIFICATION_SESSION_KEY)
     PartialRegistration.delete(session)
     redirect_to new_user_registration_path
   end
@@ -165,6 +166,13 @@ class RegistrationsController < Devise::RegistrationsController
     end
 
     if current_user && current_user.errors.blank?
+      if session[:sign_up_type] == AuthenticationOption::CLEVER &&
+          session.delete(OmniauthCallbacksController::CLEVER_AUTO_VERIFICATION_SESSION_KEY)
+        current_user.verify_teacher! if current_user.teacher? && !current_user.verified_teacher?
+      else
+        session.delete(OmniauthCallbacksController::CLEVER_AUTO_VERIFICATION_SESSION_KEY)
+      end
+
       if current_user.teacher?
         begin
           MailJet.create_contact_and_add_to_welcome_series(current_user, I18n.locale.to_s)

--- a/dashboard/app/controllers/registrations_controller.rb
+++ b/dashboard/app/controllers/registrations_controller.rb
@@ -221,19 +221,6 @@ class RegistrationsController < Devise::RegistrationsController
     end
   end
 
-  # Auto-verify teachers who sign up using a school-owned login type: Clever, Classlink or LTI.
-  # Google Classroom teachers are not auto-verified at sign-up, but will be after they sync
-  # their first section. This proves they are a roster-bearing user, which is evidence of them being a real teacher.
-  private def auto_verify_teacher!(user)
-    return unless user.teacher? && !user.verified_teacher?
-
-    is_school_owned = user.authentication_options.any? do |auth_option|
-      AuthenticationOption::SCHOOL_OWNED_CREDENTIAL_TYPES.include?(auth_option.credential_type)
-    end
-
-    user.verify_teacher! if is_school_owned
-  end
-
   #
   # GET /users/to_destroy
   #
@@ -722,5 +709,18 @@ class RegistrationsController < Devise::RegistrationsController
 
   private def assign_redirect_url
     @redirect_url = session[:user_return_to] || @redirect_url
+  end
+
+  # Auto-verify teachers who sign up using a school-owned login type: Clever, Classlink or LTI.
+  # Google Classroom teachers are not auto-verified at sign-up, but will be after they sync
+  # their first section. This proves they are a roster-bearing user, which is evidence of them being a real teacher.
+  private def auto_verify_teacher!(user)
+    return unless user.teacher? && !user.verified_teacher?
+
+    is_school_owned = user.authentication_options.any? do |auth_option|
+      AuthenticationOption::SCHOOL_OWNED_CREDENTIAL_TYPES.include?(auth_option.credential_type)
+    end
+
+    user.verify_teacher! if is_school_owned
   end
 end

--- a/dashboard/app/controllers/registrations_controller.rb
+++ b/dashboard/app/controllers/registrations_controller.rb
@@ -112,7 +112,7 @@ class RegistrationsController < Devise::RegistrationsController
   # Cancels the in-progress partial user registration and redirects to sign-up page.
   #
   def cancel
-    session.delete(OmniauthCallbacksController::CLEVER_AUTO_VERIFICATION_SESSION_KEY)
+    session.delete(OmniauthCallbacksController::OAUTH_AUTO_VERIFICATION_SESSION_KEY)
     PartialRegistration.delete(session)
     redirect_to new_user_registration_path
   end
@@ -166,11 +166,11 @@ class RegistrationsController < Devise::RegistrationsController
     end
 
     if current_user && current_user.errors.blank?
-      if session[:sign_up_type] == AuthenticationOption::CLEVER &&
-          session.delete(OmniauthCallbacksController::CLEVER_AUTO_VERIFICATION_SESSION_KEY)
+      if [AuthenticationOption::CLEVER, AuthenticationOption::CLASSLINK].include?(session[:sign_up_type]) &&
+          session.delete(OmniauthCallbacksController::OAUTH_AUTO_VERIFICATION_SESSION_KEY)
         current_user.verify_teacher! if current_user.teacher? && !current_user.verified_teacher?
       else
-        session.delete(OmniauthCallbacksController::CLEVER_AUTO_VERIFICATION_SESSION_KEY)
+        session.delete(OmniauthCallbacksController::OAUTH_AUTO_VERIFICATION_SESSION_KEY)
       end
 
       if current_user.teacher?

--- a/dashboard/app/controllers/registrations_controller.rb
+++ b/dashboard/app/controllers/registrations_controller.rb
@@ -112,7 +112,6 @@ class RegistrationsController < Devise::RegistrationsController
   # Cancels the in-progress partial user registration and redirects to sign-up page.
   #
   def cancel
-    session.delete(OmniauthCallbacksController::OAUTH_AUTO_VERIFICATION_SESSION_KEY)
     PartialRegistration.delete(session)
     redirect_to new_user_registration_path
   end
@@ -166,12 +165,7 @@ class RegistrationsController < Devise::RegistrationsController
     end
 
     if current_user && current_user.errors.blank?
-      if [AuthenticationOption::CLEVER, AuthenticationOption::CLASSLINK].include?(session[:sign_up_type]) &&
-          session.delete(OmniauthCallbacksController::OAUTH_AUTO_VERIFICATION_SESSION_KEY)
-        current_user.verify_teacher! if current_user.teacher? && !current_user.verified_teacher?
-      else
-        session.delete(OmniauthCallbacksController::OAUTH_AUTO_VERIFICATION_SESSION_KEY)
-      end
+      auto_verify_school_owned_oauth_teacher! current_user
 
       if current_user.teacher?
         begin
@@ -227,6 +221,16 @@ class RegistrationsController < Devise::RegistrationsController
         session: session,
       )
     end
+  end
+
+  private def auto_verify_school_owned_oauth_teacher!(user)
+    return unless user.teacher? && !user.verified_teacher?
+
+    school_owned_oauth_provider_used = user.authentication_options.any? do |auth_option|
+      [AuthenticationOption::CLEVER, AuthenticationOption::CLASSLINK].include?(auth_option.credential_type)
+    end
+
+    user.verify_teacher! if school_owned_oauth_provider_used
   end
 
   #

--- a/dashboard/app/controllers/registrations_controller.rb
+++ b/dashboard/app/controllers/registrations_controller.rb
@@ -165,8 +165,6 @@ class RegistrationsController < Devise::RegistrationsController
     end
 
     if current_user && current_user.errors.blank?
-      auto_verify_school_owned_oauth_teacher! current_user
-
       if current_user.teacher?
         begin
           MailJet.create_contact_and_add_to_welcome_series(current_user, I18n.locale.to_s)
@@ -187,8 +185,8 @@ class RegistrationsController < Devise::RegistrationsController
       storage_id = take_storage_id_ownership_from_cookie(current_user.id)
       current_user.generate_progress_from_storage_id(storage_id, locale: I18n.locale) if storage_id
       PartialRegistration.delete session
+      auto_verify_teacher! current_user
       if Policies::Lti.lti? current_user
-        current_user.verify_teacher! if Policies::Lti.unverified_teacher?(current_user)
         if session[:lti_deployment_id] && current_user.lti_user_identities.any?
           deployment = LtiDeployment.find_by(id: session[:lti_deployment_id])
           lti_identity = current_user.lti_user_identities.find_by(lti_integration_id: deployment.lti_integration_id)
@@ -223,14 +221,17 @@ class RegistrationsController < Devise::RegistrationsController
     end
   end
 
-  private def auto_verify_school_owned_oauth_teacher!(user)
+  # Auto-verify teachers who sign up using a school-owned login type: Clever, Classlink or LTI.
+  # Google Classroom teachers are not auto-verified at sign-up, but will be after they sync
+  # their first section. This proves they are a roster-bearing user, which is evidence of them being a real teacher.
+  private def auto_verify_teacher!(user)
     return unless user.teacher? && !user.verified_teacher?
 
-    school_owned_oauth_provider_used = user.authentication_options.any? do |auth_option|
-      [AuthenticationOption::CLEVER, AuthenticationOption::CLASSLINK].include?(auth_option.credential_type)
+    school_owned? = user.authentication_options.any? do |auth_option|
+      AuthenticationOption::SCHOOL_OWNED_CREDENTIAL_TYPES.include?(auth_option.credential_type)
     end
 
-    user.verify_teacher! if school_owned_oauth_provider_used
+    user.verify_teacher! if school_owned?
   end
 
   #

--- a/dashboard/app/controllers/registrations_controller.rb
+++ b/dashboard/app/controllers/registrations_controller.rb
@@ -718,7 +718,7 @@ class RegistrationsController < Devise::RegistrationsController
     return unless user.teacher? && !user.verified_teacher?
 
     is_school_owned = user.authentication_options.any? do |auth_option|
-      AuthenticationOption::SCHOOL_OWNED_CREDENTIAL_TYPES.include?(auth_option.credential_type)
+      Policies::User::SCHOOL_OWNED_TYPES.include?(auth_option.credential_type)
     end
 
     user.verify_teacher! if is_school_owned

--- a/dashboard/app/controllers/registrations_controller.rb
+++ b/dashboard/app/controllers/registrations_controller.rb
@@ -227,11 +227,11 @@ class RegistrationsController < Devise::RegistrationsController
   private def auto_verify_teacher!(user)
     return unless user.teacher? && !user.verified_teacher?
 
-    school_owned? = user.authentication_options.any? do |auth_option|
+    is_school_owned = user.authentication_options.any? do |auth_option|
       AuthenticationOption::SCHOOL_OWNED_CREDENTIAL_TYPES.include?(auth_option.credential_type)
     end
 
-    user.verify_teacher! if school_owned?
+    user.verify_teacher! if is_school_owned
   end
 
   #

--- a/dashboard/app/models/authentication_option.rb
+++ b/dashboard/app/models/authentication_option.rb
@@ -84,6 +84,12 @@ class AuthenticationOption < ApplicationRecord
     MICROSOFT
   ].freeze
 
+  SCHOOL_OWNED_CREDENTIAL_TYPES = [
+    CLEVER,
+    LTI_V1,
+    CLASSLINK,
+  ].freeze
+
   module Clever
     VERSION = {
       v3: 'v3',

--- a/dashboard/app/models/authentication_option.rb
+++ b/dashboard/app/models/authentication_option.rb
@@ -84,12 +84,6 @@ class AuthenticationOption < ApplicationRecord
     MICROSOFT
   ].freeze
 
-  SCHOOL_OWNED_CREDENTIAL_TYPES = [
-    CLEVER,
-    LTI_V1,
-    CLASSLINK,
-  ].freeze
-
   module Clever
     VERSION = {
       v3: 'v3',

--- a/dashboard/lib/policies/user.rb
+++ b/dashboard/lib/policies/user.rb
@@ -39,16 +39,16 @@ class Policies::User
   # - Be a teacher
   # - Not already be verified
   # - Have the provider-specific teacher role in the auth payload
-  def self.oauth_verified_teacher_candidate?(user, auth, provider:)
+  def self.oauth_verified_teacher_candidate?(user:, auth_hash:, provider:)
     return false unless user.teacher?
     return false if user.verified_teacher?
 
     case provider
     when AuthenticationOption::CLEVER
-      roles = auth&.dig(:extra, :raw_info, :canonical, :data, :roles)
+      roles = auth_hash&.dig(:extra, :raw_info, :canonical, :data, :roles)
       roles.respond_to?(:key?) && (roles.key?(:teacher) || roles.key?('teacher'))
     when AuthenticationOption::CLASSLINK
-      auth&.dig(:extra, :raw_info, :role).to_s.casecmp?(User::TYPE_TEACHER)
+      auth_hash&.dig(:extra, :raw_info, :role).to_s.casecmp?(User::TYPE_TEACHER)
     else
       false
     end

--- a/dashboard/lib/policies/user.rb
+++ b/dashboard/lib/policies/user.rb
@@ -34,6 +34,19 @@ class Policies::User
     !is_google_email
   end
 
+  # Determines if a user should be auto-verified from a Clever OAuth callback.
+  # In order to be a Clever verification candidate, the user must:
+  # - Be a teacher
+  # - Not already be verified
+  # - Have an explicit Clever teacher role in the auth payload
+  def self.clever_verified_teacher_candidate?(user, auth)
+    return false unless user.teacher?
+    return false if user.verified_teacher?
+
+    roles = auth&.dig(:extra, :raw_info, :canonical, :data, :roles)
+    roles.respond_to?(:key?) && (roles.key?(:teacher) || roles.key?('teacher'))
+  end
+
   def self.in_usa?(country_code)
     %w[US RD].include?(country_code)
   end

--- a/dashboard/lib/policies/user.rb
+++ b/dashboard/lib/policies/user.rb
@@ -3,7 +3,11 @@ class Policies::User
 
   # Authentication option types which we always consider to be "owned" by the school
   # the student attends because the school has admin control of the account.
-  SCHOOL_OWNED_TYPES = Set[AuthenticationOption::CLEVER, AuthenticationOption::LTI_V1].freeze
+  SCHOOL_OWNED_TYPES = Set[
+    AuthenticationOption::CLEVER,
+    AuthenticationOption::LTI_V1,
+    AuthenticationOption::CLASSLINK,
+  ].freeze
 
   # Login types that are always considered personal logins.
   PERSONAL_LOGIN_TYPES = Set[AuthenticationOption::EMAIL, AuthenticationOption::FACEBOOK].freeze
@@ -24,7 +28,7 @@ class Policies::User
   # In order to be a verified teacher candidate, the user must:
   # - Successfully sync a Google Classroom
   # - Have a google_oauth2 Authentication Option
-  # - Have a non-google/non-gmail email domain attached to that googele_oauth2 authentication option
+  # - Have a non-google/non-gmail email domain attached to that google_oauth2 authentication option
   def self.google_verified_teacher_candidate?(user)
     return false if user.verified_teacher?
     google_ao = user.authentication_options.find_by(credential_type: AuthenticationOption::GOOGLE)

--- a/dashboard/lib/policies/user.rb
+++ b/dashboard/lib/policies/user.rb
@@ -20,12 +20,12 @@ class Policies::User
     attributes.merge('authentication_options_attributes' => authentication_options).compact
   end
 
-  # Determines if a user passes some of the criteria to be a verified teacher.
+  # Determines if a Google user passes the criteria to be a verified teacher.
   # In order to be a verified teacher candidate, the user must:
   # - Successfully sync a Google Classroom
   # - Have a google_oauth2 Authentication Option
   # - Have a non-google/non-gmail email domain attached to that googele_oauth2 authentication option
-  def self.verified_teacher_candidate?(user)
+  def self.google_verified_teacher_candidate?(user)
     return false if user.verified_teacher?
     google_ao = user.authentication_options.find_by(credential_type: AuthenticationOption::GOOGLE)
     return false unless google_ao
@@ -34,17 +34,24 @@ class Policies::User
     !is_google_email
   end
 
-  # Determines if a user should be auto-verified from a Clever OAuth callback.
-  # In order to be a Clever verification candidate, the user must:
+  # Determines if a user should be auto-verified when authenticated via a school-owned provider.
+  # In order to be an OAuth verification candidate, the user must:
   # - Be a teacher
   # - Not already be verified
-  # - Have an explicit Clever teacher role in the auth payload
-  def self.clever_verified_teacher_candidate?(user, auth)
+  # - Have the provider-specific teacher role in the auth payload
+  def self.oauth_verified_teacher_candidate?(user, auth, provider:)
     return false unless user.teacher?
     return false if user.verified_teacher?
 
-    roles = auth&.dig(:extra, :raw_info, :canonical, :data, :roles)
-    roles.respond_to?(:key?) && (roles.key?(:teacher) || roles.key?('teacher'))
+    case provider
+    when AuthenticationOption::CLEVER
+      roles = auth&.dig(:extra, :raw_info, :canonical, :data, :roles)
+      roles.respond_to?(:key?) && (roles.key?(:teacher) || roles.key?('teacher'))
+    when AuthenticationOption::CLASSLINK
+      auth&.dig(:extra, :raw_info, :role).to_s.casecmp?(User::TYPE_TEACHER)
+    else
+      false
+    end
   end
 
   def self.in_usa?(country_code)

--- a/dashboard/lib/policies/user.rb
+++ b/dashboard/lib/policies/user.rb
@@ -34,26 +34,6 @@ class Policies::User
     !is_google_email
   end
 
-  # Determines if a user should be auto-verified when authenticated via a school-owned provider.
-  # In order to be an OAuth verification candidate, the user must:
-  # - Be a teacher
-  # - Not already be verified
-  # - Have the provider-specific teacher role in the auth payload
-  def self.oauth_verified_teacher_candidate?(user:, auth_hash:, provider:)
-    return false unless user.teacher?
-    return false if user.verified_teacher?
-
-    case provider
-    when AuthenticationOption::CLEVER
-      roles = auth_hash&.dig(:extra, :raw_info, :canonical, :data, :roles)
-      roles.respond_to?(:key?) && (roles.key?(:teacher) || roles.key?('teacher'))
-    when AuthenticationOption::CLASSLINK
-      auth_hash&.dig(:extra, :raw_info, :role).to_s.casecmp?(User::TYPE_TEACHER)
-    else
-      false
-    end
-  end
-
   def self.in_usa?(country_code)
     %w[US RD].include?(country_code)
   end

--- a/dashboard/test/controllers/omniauth_callbacks_controller_test.rb
+++ b/dashboard/test/controllers/omniauth_callbacks_controller_test.rb
@@ -1693,6 +1693,59 @@ class OmniauthCallbacksControllerTest < ActionController::TestCase
         classlink_req
         _(existing_user.id).must_equal signed_in_user_id
       end
+
+      it 'verifies an unverified teacher' do
+        refute existing_user.verified_teacher?
+
+        assert_difference('UserPermission.count', 1) do
+          classlink_req
+        end
+
+        assert User.find(existing_user.id).verified_teacher?
+      end
+    end
+
+    context 'when authorizing with existing verified teacher' do
+      subject(:existing_user) {create(:authorized_teacher, :classlink_sso_provider, uid: TEST_CLASSLINK_AUTH_HASH.uid)}
+      let(:classlink_req) {get :classlink}
+
+      before do
+        request.env['omniauth.auth'] = TEST_CLASSLINK_AUTH_HASH
+        request.env['omniauth.params'] = {}
+        existing_user
+      end
+
+      it 'does not duplicate verification' do
+        assert_no_difference('UserPermission.count') do
+          classlink_req
+        end
+
+        assert User.find(existing_user.id).verified_teacher?
+      end
+    end
+
+    context 'when authorizing with existing student' do
+      subject(:existing_user) {create(:student, :classlink_sso_provider, uid: TEST_CLASSLINK_AUTH_HASH.uid)}
+      let(:student_auth_hash) do
+        auth_hash = TEST_CLASSLINK_AUTH_HASH.dup
+        auth_hash.extra.raw_info.role = 'Student'
+        auth_hash
+      end
+      let(:classlink_req) {get :classlink}
+
+      before do
+        request.env['omniauth.auth'] = student_auth_hash
+        request.env['omniauth.params'] = {}
+        existing_user
+      end
+
+      it 'does not verify the student' do
+        assert_no_difference('UserPermission.count') do
+          classlink_req
+        end
+
+        refute User.find(existing_user.id).verified_teacher?
+      end
     end
   end
 

--- a/dashboard/test/controllers/omniauth_callbacks_controller_test.rb
+++ b/dashboard/test/controllers/omniauth_callbacks_controller_test.rb
@@ -416,6 +416,7 @@ class OmniauthCallbacksControllerTest < ActionController::TestCase
       uid: user.primary_contact_info.authentication_id
     @request.env['omniauth.auth'] = auth
     @request.env['omniauth.params'] = {}
+    user.expects(:verify_teacher!).never
     assert_does_not_create(User) do
       get :clever
     end
@@ -457,6 +458,7 @@ class OmniauthCallbacksControllerTest < ActionController::TestCase
     auth.extra[:raw_info][:canonical] = {data: {roles: {teacher: {legacy_id: '123456'}}}}
     @request.env['omniauth.auth'] = auth
     @request.env['omniauth.params'] = {}
+    user.expects(:verify_teacher!).never
 
     assert_no_difference('UserPermission.count') do
       get :clever
@@ -1705,7 +1707,7 @@ class OmniauthCallbacksControllerTest < ActionController::TestCase
       end
     end
 
-    context 'when authorizing with existing verified teacher' do
+    context 'when teacher already verified' do
       subject(:existing_user) {create(:authorized_teacher, :classlink_sso_provider, uid: TEST_CLASSLINK_AUTH_HASH.uid)}
       let(:classlink_req) {get :classlink}
 
@@ -1716,6 +1718,7 @@ class OmniauthCallbacksControllerTest < ActionController::TestCase
       end
 
       it 'does not duplicate verification' do
+        existing_user.expects(:verify_teacher!).never
         assert_no_difference('UserPermission.count') do
           classlink_req
         end
@@ -1724,7 +1727,7 @@ class OmniauthCallbacksControllerTest < ActionController::TestCase
       end
     end
 
-    context 'when authorizing with existing student' do
+    context 'when student' do
       subject(:existing_user) {create(:student, :classlink_sso_provider, uid: TEST_CLASSLINK_AUTH_HASH.uid)}
       let(:student_auth_hash) do
         auth_hash = TEST_CLASSLINK_AUTH_HASH.dup
@@ -1740,6 +1743,7 @@ class OmniauthCallbacksControllerTest < ActionController::TestCase
       end
 
       it 'does not verify the student' do
+        existing_user.expects(:verify_teacher!).never
         assert_no_difference('UserPermission.count') do
           classlink_req
         end

--- a/dashboard/test/controllers/omniauth_callbacks_controller_test.rb
+++ b/dashboard/test/controllers/omniauth_callbacks_controller_test.rb
@@ -425,6 +425,68 @@ class OmniauthCallbacksControllerTest < ActionController::TestCase
     assert_equal user.id, signed_in_user_id
   end
 
+  test 'clever: verifies unverified teacher on sign in with Clever teacher role' do
+    user = create(:teacher, :with_clever_authentication_option)
+    clever_auth_option = user.authentication_options.find_by(credential_type: AuthenticationOption::CLEVER)
+    refute user.verified_teacher?
+
+    auth = generate_auth_user_hash(
+      provider: AuthenticationOption::CLEVER,
+      uid: clever_auth_option.authentication_id
+    )
+    auth.extra[:raw_info][:canonical] = {data: {roles: {teacher: {legacy_id: '123456'}}}}
+    @request.env['omniauth.auth'] = auth
+    @request.env['omniauth.params'] = {}
+
+    assert_difference('UserPermission.count', 1) do
+      get :clever
+    end
+
+    assert_equal user.id, signed_in_user_id
+    assert User.find(user.id).verified_teacher?
+  end
+
+  test 'clever: does not duplicate verification for already verified teacher on sign in' do
+    user = create(:authorized_teacher, :with_clever_authentication_option)
+    clever_auth_option = user.authentication_options.find_by(credential_type: AuthenticationOption::CLEVER)
+
+    auth = generate_auth_user_hash(
+      provider: AuthenticationOption::CLEVER,
+      uid: clever_auth_option.authentication_id
+    )
+    auth.extra[:raw_info][:canonical] = {data: {roles: {teacher: {legacy_id: '123456'}}}}
+    @request.env['omniauth.auth'] = auth
+    @request.env['omniauth.params'] = {}
+
+    assert_no_difference('UserPermission.count') do
+      get :clever
+    end
+
+    assert_equal user.id, signed_in_user_id
+    assert User.find(user.id).verified_teacher?
+  end
+
+  test 'clever: does not verify unverified teacher on sign in with Clever staff role' do
+    user = create(:teacher, :with_clever_authentication_option)
+    clever_auth_option = user.authentication_options.find_by(credential_type: AuthenticationOption::CLEVER)
+    refute user.verified_teacher?
+
+    auth = generate_auth_user_hash(
+      provider: AuthenticationOption::CLEVER,
+      uid: clever_auth_option.authentication_id
+    )
+    auth.extra[:raw_info][:canonical] = {data: {roles: {staff: {legacy_id: '123456'}}}}
+    @request.env['omniauth.auth'] = auth
+    @request.env['omniauth.params'] = {}
+
+    assert_no_difference('UserPermission.count') do
+      get :clever
+    end
+
+    assert_equal user.id, signed_in_user_id
+    refute User.find(user.id).verified_teacher?
+  end
+
   test 'clever: signs in user and updates auth option if user is found by legacy_id' do
     legacy_id = SecureRandom.alphanumeric(10)
     user = create(:teacher, :with_clever_authentication_option)

--- a/dashboard/test/controllers/omniauth_callbacks_controller_test.rb
+++ b/dashboard/test/controllers/omniauth_callbacks_controller_test.rb
@@ -466,7 +466,7 @@ class OmniauthCallbacksControllerTest < ActionController::TestCase
     assert User.find(user.id).verified_teacher?
   end
 
-  test 'clever: does not verify unverified teacher on sign in with Clever staff role' do
+  test 'clever: verifies unverified teacher on sign in with Clever staff role' do
     user = create(:teacher, :with_clever_authentication_option)
     clever_auth_option = user.authentication_options.find_by(credential_type: AuthenticationOption::CLEVER)
     refute user.verified_teacher?
@@ -479,12 +479,12 @@ class OmniauthCallbacksControllerTest < ActionController::TestCase
     @request.env['omniauth.auth'] = auth
     @request.env['omniauth.params'] = {}
 
-    assert_no_difference('UserPermission.count') do
+    assert_difference('UserPermission.count', 1) do
       get :clever
     end
 
     assert_equal user.id, signed_in_user_id
-    refute User.find(user.id).verified_teacher?
+    assert User.find(user.id).verified_teacher?
   end
 
   test 'clever: signs in user and updates auth option if user is found by legacy_id' do

--- a/dashboard/test/controllers/registrations_controller_test.rb
+++ b/dashboard/test/controllers/registrations_controller_test.rb
@@ -533,26 +533,28 @@ class RegistrationsControllerTest < ActionController::TestCase
   end
 
   test 'verifies lti users if they are a teacher' do
-    lti_teacher_params = @default_params.update(user_type: 'teacher', email_preference_opt_in: 'yes')
-    Policies::Lti.expects(:lti?).returns(true).at_least(1)
-    Services::Lti.expects(:create_lti_user_identity).returns(:lti_user_identity).at_least(1)
+    teacher = create(:teacher, :with_lti_auth)
     Queries::Lti.expects(:get_lms_name_from_user).returns('test-lms')
-    lti_teacher_params = set_up_partial_registration(lti_teacher_params)
-    post :create, params: {user: lti_teacher_params}
+    Services::PartialRegistration::UserBuilder.stubs(:call).returns(teacher)
 
-    assert assigns(:user).verified_teacher?
+    assert_difference('UserPermission.count', 1) do
+      post :create, params: {user: @default_params}
+    end
+
+    assert teacher.reload.verified_teacher?
   end
 
   test 'do not verify lti users if they are a student' do
-    Policies::Lti.expects(:lti?).returns(true).at_least(1)
-    Services::Lti.expects(:create_lti_user_identity).returns(:lti_user_identity).at_least(1)
+    student = create(:student, :with_lti_auth)
     Queries::Lti.expects(:get_lms_name_from_user).returns('test-lms')
+    student.expects(:verify_teacher!).never
+    Services::PartialRegistration::UserBuilder.stubs(:call).returns(student)
 
-    student_params = set_up_partial_registration(@default_params)
-    post :create, params: {user: student_params}
+    assert_no_difference('UserPermission.count') do
+      post :create, params: {user: @default_params}
+    end
 
-    assigns(:user).expects(:verify_teacher!).never
-    refute assigns(:user).verified_teacher?
+    refute student.reload.verified_teacher?
   end
 
   test 'create verifies teacher with Clever authentication option' do

--- a/dashboard/test/controllers/registrations_controller_test.rb
+++ b/dashboard/test/controllers/registrations_controller_test.rb
@@ -557,13 +557,13 @@ class RegistrationsControllerTest < ActionController::TestCase
 
   test 'create does not verify non-Clever sign up when Clever auto-verification marker is present' do
     teacher_params = set_up_partial_registration(@default_params.update(user_type: 'teacher', age: '', email_preference_opt_in: true))
-    session[OmniauthCallbacksController::CLEVER_AUTO_VERIFICATION_SESSION_KEY] = true
+    session[OmniauthCallbacksController::OAUTH_AUTO_VERIFICATION_SESSION_KEY] = true
     session[:sign_up_type] = AuthenticationOption::GOOGLE
 
     post :create, params: {user: teacher_params}
 
     refute assigns(:user).verified_teacher?
-    assert_nil session[OmniauthCallbacksController::CLEVER_AUTO_VERIFICATION_SESSION_KEY]
+    assert_nil session[OmniauthCallbacksController::OAUTH_AUTO_VERIFICATION_SESSION_KEY]
   end
 
   test 'adds LtiUserIdentity to LtiDeployment if LTI user' do

--- a/dashboard/test/controllers/registrations_controller_test.rb
+++ b/dashboard/test/controllers/registrations_controller_test.rb
@@ -555,15 +555,55 @@ class RegistrationsControllerTest < ActionController::TestCase
     refute assigns(:user).verified_teacher?
   end
 
-  test 'create does not verify non-Clever sign up when Clever auto-verification marker is present' do
-    teacher_params = set_up_partial_registration(@default_params.update(user_type: 'teacher', age: '', email_preference_opt_in: true))
-    session[OmniauthCallbacksController::OAUTH_AUTO_VERIFICATION_SESSION_KEY] = true
-    session[:sign_up_type] = AuthenticationOption::GOOGLE
+  test 'create verifies teacher with Clever authentication option' do
+    teacher = create(:teacher)
+    create(
+      :authentication_option,
+      user: teacher,
+      email: teacher.email,
+      hashed_email: teacher.hashed_email,
+      credential_type: AuthenticationOption::CLEVER,
+      authentication_id: SecureRandom.uuid
+    )
+    teacher.reload
+    Services::PartialRegistration::UserBuilder.stubs(:call).returns(teacher)
 
-    post :create, params: {user: teacher_params}
+    assert_difference('UserPermission.count', 1) do
+      post :create, params: {user: @default_params}
+    end
 
-    refute assigns(:user).verified_teacher?
-    assert_nil session[OmniauthCallbacksController::OAUTH_AUTO_VERIFICATION_SESSION_KEY]
+    assert teacher.reload.verified_teacher?
+  end
+
+  test 'create verifies teacher with ClassLink authentication option' do
+    teacher = create(:teacher)
+    create(
+      :authentication_option,
+      user: teacher,
+      email: teacher.email,
+      hashed_email: teacher.hashed_email,
+      credential_type: AuthenticationOption::CLASSLINK,
+      authentication_id: SecureRandom.uuid
+    )
+    teacher.reload
+    Services::PartialRegistration::UserBuilder.stubs(:call).returns(teacher)
+
+    assert_difference('UserPermission.count', 1) do
+      post :create, params: {user: @default_params}
+    end
+
+    assert teacher.reload.verified_teacher?
+  end
+
+  test 'create does not verify teacher without Clever or ClassLink authentication option' do
+    teacher = create(:teacher, :with_google_authentication_option)
+    Services::PartialRegistration::UserBuilder.stubs(:call).returns(teacher)
+
+    assert_no_difference('UserPermission.count') do
+      post :create, params: {user: @default_params}
+    end
+
+    refute teacher.reload.verified_teacher?
   end
 
   test 'adds LtiUserIdentity to LtiDeployment if LTI user' do

--- a/dashboard/test/controllers/registrations_controller_test.rb
+++ b/dashboard/test/controllers/registrations_controller_test.rb
@@ -555,6 +555,17 @@ class RegistrationsControllerTest < ActionController::TestCase
     refute assigns(:user).verified_teacher?
   end
 
+  test 'create does not verify non-Clever sign up when Clever auto-verification marker is present' do
+    teacher_params = set_up_partial_registration(@default_params.update(user_type: 'teacher', age: '', email_preference_opt_in: true))
+    session[OmniauthCallbacksController::CLEVER_AUTO_VERIFICATION_SESSION_KEY] = true
+    session[:sign_up_type] = AuthenticationOption::GOOGLE
+
+    post :create, params: {user: teacher_params}
+
+    refute assigns(:user).verified_teacher?
+    assert_nil session[OmniauthCallbacksController::CLEVER_AUTO_VERIFICATION_SESSION_KEY]
+  end
+
   test 'adds LtiUserIdentity to LtiDeployment if LTI user' do
     integration = create(:lti_integration, issuer: 'test', client_id: '123456')
     deployment = create(:lti_deployment, deployment_id: '1234', lti_integration: integration)

--- a/dashboard/test/integration/omniauth/classlink_test.rb
+++ b/dashboard/test/integration/omniauth/classlink_test.rb
@@ -1,0 +1,113 @@
+require 'test_helper'
+require_relative './utils'
+
+module OmniauthCallbacksControllerTests
+  class ClasslinkTest < ActionDispatch::IntegrationTest
+    include OmniauthCallbacksControllerTests::Utils
+
+    setup do
+      stub_firehose
+    end
+
+    test "teacher sign-up" do
+      auth_hash = mock_oauth
+
+      post user_classlink_omniauth_authorize_path
+      assert_does_not_create(User) do
+        get user_classlink_omniauth_callback_path
+      end
+      assert_response :success
+      assert_template 'omniauth/redirect'
+      assert PartialRegistration.in_progress? session
+
+      assert_creates(User) {finish_sign_up auth_hash, User::TYPE_TEACHER}
+      refute PartialRegistration.in_progress? session
+
+      created_user = User.find signed_in_user_id
+      assert_valid_teacher created_user, expected_email: 'auth_test@code.org'
+      assert created_user.verified_teacher?
+      assert_equal 1, created_user.permissions.where(permission: UserPermission::AUTHORIZED_TEACHER).count
+      assert_credentials auth_hash, created_user
+    ensure
+      created_user&.destroy!
+    end
+
+    test "student sign-up does not auto-verify" do
+      auth_hash = mock_oauth role: 'Student'
+
+      post user_classlink_omniauth_authorize_path
+      assert_does_not_create(User) do
+        get user_classlink_omniauth_callback_path
+      end
+      assert_response :success
+      assert_template 'omniauth/redirect'
+      assert PartialRegistration.in_progress? session
+
+      assert_creates(User) {finish_sign_up auth_hash, User::TYPE_STUDENT}
+      refute PartialRegistration.in_progress? session
+
+      created_user = User.find signed_in_user_id
+      assert_valid_student created_user, expected_email: 'auth_test@code.org'
+      refute created_user.verified_teacher?
+      assert_credentials auth_hash, created_user
+    ensure
+      created_user&.destroy!
+    end
+
+    test "teacher sign-in" do
+      auth_hash = mock_oauth
+
+      teacher = create(:teacher, :classlink_sso_provider, uid: auth_hash.uid)
+
+      sign_in_through_classlink
+      assert_redirected_to '/home'
+      assert_equal I18n.t('auth.signed_in'), flash[:notice]
+
+      assert_equal teacher.id, signed_in_user_id
+      teacher.reload
+      assert teacher.verified_teacher?
+      assert_credentials auth_hash, teacher
+    end
+
+    test "student sign-in does not auto-verify" do
+      auth_hash = mock_oauth role: 'Student'
+
+      student = create(:student, :classlink_sso_provider, uid: auth_hash.uid)
+
+      sign_in_through_classlink
+      assert_redirected_to '/'
+      follow_redirect!
+      assert_redirected_to '/home'
+      assert_equal I18n.t('auth.signed_in'), flash[:notice]
+
+      assert_equal student.id, signed_in_user_id
+      student.reload
+      refute student.verified_teacher?
+      assert_credentials auth_hash, student
+    end
+
+    private def mock_oauth(role: 'Teacher')
+      auth_hash = generate_auth_hash(
+        provider: AuthenticationOption::CLASSLINK,
+        user_type: nil,
+        email: "#{role.downcase}@school.test"
+      )
+      auth_hash.extra = OmniAuth::AuthHash.new(
+        raw_info: {
+          email: auth_hash.info.email,
+          display_name: 'Teacher Test',
+          first_name: 'Teacher',
+          last_name: 'Test',
+          role: role,
+          state_name: 'New Jersey',
+        }
+      )
+
+      mock_oauth_for AuthenticationOption::CLASSLINK, auth_hash
+    end
+
+    private def sign_in_through_classlink
+      sign_in_through AuthenticationOption::CLASSLINK
+    end
+  end
+end

--- a/dashboard/test/integration/omniauth/clever_test.rb
+++ b/dashboard/test/integration/omniauth/clever_test.rb
@@ -63,7 +63,7 @@ module OmniauthCallbacksControllerTests
       created_user&.destroy!
     end
 
-    test "staff sign-up does not auto-verify" do
+    test "staff sign-up" do
       auth_hash = mock_oauth clever_role: :staff
 
       post user_clever_omniauth_authorize_path
@@ -79,7 +79,8 @@ module OmniauthCallbacksControllerTests
 
       created_user = User.find signed_in_user_id
       assert_valid_teacher created_user, expected_email: auth_hash.info.email
-      refute created_user.verified_teacher?
+      assert created_user.verified_teacher?
+      assert_equal 1, created_user.permissions.where(permission: UserPermission::AUTHORIZED_TEACHER).count
       assert_credentials auth_hash, created_user
     ensure
       created_user&.destroy!
@@ -116,7 +117,7 @@ module OmniauthCallbacksControllerTests
       assert_credentials auth_hash, teacher
     end
 
-    test "staff sign-in does not auto-verify" do
+    test "staff sign-in" do
       auth_hash = mock_oauth clever_role: :staff
 
       teacher = create(:teacher, :clever_sso_provider, uid: auth_hash.uid)
@@ -127,7 +128,7 @@ module OmniauthCallbacksControllerTests
 
       assert_equal teacher.id, signed_in_user_id
       teacher.reload
-      refute teacher.verified_teacher?
+      assert teacher.verified_teacher?
       assert_credentials auth_hash, teacher
     end
 

--- a/dashboard/test/integration/omniauth/clever_test.rb
+++ b/dashboard/test/integration/omniauth/clever_test.rb
@@ -56,6 +56,30 @@ module OmniauthCallbacksControllerTests
 
       created_user = User.find signed_in_user_id
       assert_valid_teacher created_user, expected_email: auth_hash.info.email
+      assert created_user.verified_teacher?
+      assert_equal 1, created_user.permissions.where(permission: UserPermission::AUTHORIZED_TEACHER).count
+      assert_credentials auth_hash, created_user
+    ensure
+      created_user&.destroy!
+    end
+
+    test "staff sign-up does not auto-verify" do
+      auth_hash = mock_oauth clever_role: :staff
+
+      post user_clever_omniauth_authorize_path
+      assert_does_not_create(User) do
+        get user_clever_omniauth_callback_path
+      end
+      assert_response :success
+      assert_template 'omniauth/redirect'
+      assert PartialRegistration.in_progress? session
+
+      assert_creates(User) {finish_sign_up auth_hash, User::TYPE_TEACHER}
+      refute PartialRegistration.in_progress? session
+
+      created_user = User.find signed_in_user_id
+      assert_valid_teacher created_user, expected_email: auth_hash.info.email
+      refute created_user.verified_teacher?
       assert_credentials auth_hash, created_user
     ensure
       created_user&.destroy!
@@ -88,15 +112,55 @@ module OmniauthCallbacksControllerTests
 
       assert_equal teacher.id, signed_in_user_id
       teacher.reload
+      assert teacher.verified_teacher?
+      assert_credentials auth_hash, teacher
+    end
+
+    test "staff sign-in does not auto-verify" do
+      auth_hash = mock_oauth clever_role: :staff
+
+      teacher = create(:teacher, :clever_sso_provider, uid: auth_hash.uid)
+
+      sign_in_through_clever
+      assert_redirected_to '/home'
+      assert_equal I18n.t('auth.signed_in'), flash[:notice]
+
+      assert_equal teacher.id, signed_in_user_id
+      teacher.reload
+      refute teacher.verified_teacher?
       assert_credentials auth_hash, teacher
     end
 
     private def mock_oauth(override_params = {})
-      mock_oauth_for AuthenticationOption::CLEVER, generate_auth_hash(
+      clever_role = override_params.delete(:clever_role)
+      auth_hash = generate_auth_hash(
         {
           provider: AuthenticationOption::CLEVER
         }.merge(override_params)
       )
+
+      auth_hash.extra = OmniAuth::AuthHash.new(
+        raw_info: {
+          canonical: {
+            data: {
+              roles: clever_roles_for(clever_role || override_params[:user_type])
+            }
+          }
+        }
+      )
+
+      mock_oauth_for AuthenticationOption::CLEVER, auth_hash
+    end
+
+    private def clever_roles_for(clever_role)
+      case clever_role
+      when :staff
+        {staff: {legacy_id: SecureRandom.uuid}}
+      when User::TYPE_TEACHER
+        {teacher: {legacy_id: SecureRandom.uuid}}
+      else
+        {student: {}}
+      end
     end
 
     # The user signs in through Clever, which hits the oauth callback

--- a/dashboard/test/lib/policies/user_test.rb
+++ b/dashboard/test/lib/policies/user_test.rb
@@ -60,51 +60,51 @@ class Policies::UserTest < ActiveSupport::TestCase
 
   test 'oauth_verified_teacher_candidate? returns true for unverified Clever teacher' do
     teacher = create(:teacher)
-    auth = OmniAuth::AuthHash.new(extra: {raw_info: {canonical: {data: {roles: {teacher: {}}}}}})
+    auth_hash = OmniAuth::AuthHash.new(extra: {raw_info: {canonical: {data: {roles: {teacher: {}}}}}})
 
-    assert Policies::User.oauth_verified_teacher_candidate?(teacher, auth, provider: AuthenticationOption::CLEVER)
+    assert Policies::User.oauth_verified_teacher_candidate?(user: teacher, auth_hash:, provider: AuthenticationOption::CLEVER)
   end
 
   test 'oauth_verified_teacher_candidate? returns false for Clever staff role' do
     teacher = create(:teacher)
-    auth = OmniAuth::AuthHash.new(extra: {raw_info: {canonical: {data: {roles: {staff: {}}}}}})
+    auth_hash = OmniAuth::AuthHash.new(extra: {raw_info: {canonical: {data: {roles: {staff: {}}}}}})
 
-    refute Policies::User.oauth_verified_teacher_candidate?(teacher, auth, provider: AuthenticationOption::CLEVER)
+    refute Policies::User.oauth_verified_teacher_candidate?(user: teacher, auth_hash:, provider: AuthenticationOption::CLEVER)
   end
 
   test 'oauth_verified_teacher_candidate? returns false for Clever student' do
     student = create(:student)
-    auth = OmniAuth::AuthHash.new(extra: {raw_info: {canonical: {data: {roles: {teacher: {}}}}}})
+    auth_hash = OmniAuth::AuthHash.new(extra: {raw_info: {canonical: {data: {roles: {teacher: {}}}}}})
 
-    refute Policies::User.oauth_verified_teacher_candidate?(student, auth, provider: AuthenticationOption::CLEVER)
+    refute Policies::User.oauth_verified_teacher_candidate?(user: student, auth_hash:, provider: AuthenticationOption::CLEVER)
   end
 
   test 'oauth_verified_teacher_candidate? returns false for already verified Clever teacher' do
     teacher = create(:authorized_teacher)
-    auth = OmniAuth::AuthHash.new(extra: {raw_info: {canonical: {data: {roles: {teacher: {}}}}}})
+    auth_hash = OmniAuth::AuthHash.new(extra: {raw_info: {canonical: {data: {roles: {teacher: {}}}}}})
 
-    refute Policies::User.oauth_verified_teacher_candidate?(teacher, auth, provider: AuthenticationOption::CLEVER)
+    refute Policies::User.oauth_verified_teacher_candidate?(user: teacher, auth_hash:, provider: AuthenticationOption::CLEVER)
   end
 
   test 'oauth_verified_teacher_candidate? returns true for unverified ClassLink teacher' do
     teacher = create(:teacher)
-    auth = OmniAuth::AuthHash.new(extra: {raw_info: {role: 'Teacher'}})
+    auth_hash = OmniAuth::AuthHash.new(extra: {raw_info: {role: 'Teacher'}})
 
-    assert Policies::User.oauth_verified_teacher_candidate?(teacher, auth, provider: AuthenticationOption::CLASSLINK)
+    assert Policies::User.oauth_verified_teacher_candidate?(user: teacher, auth_hash:, provider: AuthenticationOption::CLASSLINK)
   end
 
   test 'oauth_verified_teacher_candidate? returns false for ClassLink student' do
     teacher = create(:teacher)
-    auth = OmniAuth::AuthHash.new(extra: {raw_info: {role: 'Student'}})
+    auth_hash = OmniAuth::AuthHash.new(extra: {raw_info: {role: 'Student'}})
 
-    refute Policies::User.oauth_verified_teacher_candidate?(teacher, auth, provider: AuthenticationOption::CLASSLINK)
+    refute Policies::User.oauth_verified_teacher_candidate?(user: teacher, auth_hash:, provider: AuthenticationOption::CLASSLINK)
   end
 
   test 'oauth_verified_teacher_candidate? returns false for already verified ClassLink teacher' do
     teacher = create(:authorized_teacher)
-    auth = OmniAuth::AuthHash.new(extra: {raw_info: {role: 'Teacher'}})
+    auth_hash = OmniAuth::AuthHash.new(extra: {raw_info: {role: 'Teacher'}})
 
-    refute Policies::User.oauth_verified_teacher_candidate?(teacher, auth, provider: AuthenticationOption::CLASSLINK)
+    refute Policies::User.oauth_verified_teacher_candidate?(user: teacher, auth_hash:, provider: AuthenticationOption::CLASSLINK)
   end
 
   describe '.personal_account?' do

--- a/dashboard/test/lib/policies/user_test.rb
+++ b/dashboard/test/lib/policies/user_test.rb
@@ -58,55 +58,6 @@ class Policies::UserTest < ActiveSupport::TestCase
     end
   end
 
-  test 'oauth_verified_teacher_candidate? returns true for unverified Clever teacher' do
-    teacher = create(:teacher)
-    auth_hash = OmniAuth::AuthHash.new(extra: {raw_info: {canonical: {data: {roles: {teacher: {}}}}}})
-
-    assert Policies::User.oauth_verified_teacher_candidate?(user: teacher, auth_hash:, provider: AuthenticationOption::CLEVER)
-  end
-
-  test 'oauth_verified_teacher_candidate? returns false for Clever staff role' do
-    teacher = create(:teacher)
-    auth_hash = OmniAuth::AuthHash.new(extra: {raw_info: {canonical: {data: {roles: {staff: {}}}}}})
-
-    refute Policies::User.oauth_verified_teacher_candidate?(user: teacher, auth_hash:, provider: AuthenticationOption::CLEVER)
-  end
-
-  test 'oauth_verified_teacher_candidate? returns false for Clever student' do
-    student = create(:student)
-    auth_hash = OmniAuth::AuthHash.new(extra: {raw_info: {canonical: {data: {roles: {teacher: {}}}}}})
-
-    refute Policies::User.oauth_verified_teacher_candidate?(user: student, auth_hash:, provider: AuthenticationOption::CLEVER)
-  end
-
-  test 'oauth_verified_teacher_candidate? returns false for already verified Clever teacher' do
-    teacher = create(:authorized_teacher)
-    auth_hash = OmniAuth::AuthHash.new(extra: {raw_info: {canonical: {data: {roles: {teacher: {}}}}}})
-
-    refute Policies::User.oauth_verified_teacher_candidate?(user: teacher, auth_hash:, provider: AuthenticationOption::CLEVER)
-  end
-
-  test 'oauth_verified_teacher_candidate? returns true for unverified ClassLink teacher' do
-    teacher = create(:teacher)
-    auth_hash = OmniAuth::AuthHash.new(extra: {raw_info: {role: 'Teacher'}})
-
-    assert Policies::User.oauth_verified_teacher_candidate?(user: teacher, auth_hash:, provider: AuthenticationOption::CLASSLINK)
-  end
-
-  test 'oauth_verified_teacher_candidate? returns false for ClassLink student' do
-    teacher = create(:teacher)
-    auth_hash = OmniAuth::AuthHash.new(extra: {raw_info: {role: 'Student'}})
-
-    refute Policies::User.oauth_verified_teacher_candidate?(user: teacher, auth_hash:, provider: AuthenticationOption::CLASSLINK)
-  end
-
-  test 'oauth_verified_teacher_candidate? returns false for already verified ClassLink teacher' do
-    teacher = create(:authorized_teacher)
-    auth_hash = OmniAuth::AuthHash.new(extra: {raw_info: {role: 'Teacher'}})
-
-    refute Policies::User.oauth_verified_teacher_candidate?(user: teacher, auth_hash:, provider: AuthenticationOption::CLASSLINK)
-  end
-
   describe '.personal_account?' do
     subject(:personal_account?) {Policies::User.personal_account?(user)}
 

--- a/dashboard/test/lib/policies/user_test.rb
+++ b/dashboard/test/lib/policies/user_test.rb
@@ -35,55 +35,76 @@ class Policies::UserTest < ActiveSupport::TestCase
     end
   end
 
-  test 'verified_teacher_candidate? should return true when criteria is met' do
+  test 'google_verified_teacher_candidate? should return true when criteria is met' do
     # Google Authentication Option present, and has non-gmail/non-googlemail email,
     # criteria met
     teacher = create(:teacher, :with_google_authentication_option)
-    assert_equal true, Policies::User.verified_teacher_candidate?(teacher)
+    assert_equal true, Policies::User.google_verified_teacher_candidate?(teacher)
   end
 
-  test 'verified_teacher_candidate? should return false when criteria is not met' do
+  test 'google_verified_teacher_candidate? should return false when criteria is not met' do
     teacher = create(:teacher)
     # Google Authentication Option not present, criteria not met
-    assert_equal false, Policies::User.verified_teacher_candidate?(teacher)
+    assert_equal false, Policies::User.google_verified_teacher_candidate?(teacher)
     # Google Authentication Option has a gmail email, criteria not met
     create(:google_authentication_option, user: teacher, email: 'test@gmail.com')
-    assert_equal false, Policies::User.verified_teacher_candidate?(teacher)
+    assert_equal false, Policies::User.google_verified_teacher_candidate?(teacher)
   end
 
-  test 'verified_teacher_candidate? should return false when teacher is already verified' do
+  test 'google_verified_teacher_candidate? should return false when teacher is already verified' do
     teacher = create(:teacher, :with_google_authentication_option)
-    assert_changes -> {Policies::User.verified_teacher_candidate?(teacher)}, from: true, to: false do
+    assert_changes -> {Policies::User.google_verified_teacher_candidate?(teacher)}, from: true, to: false do
       teacher.verify_teacher!
     end
   end
 
-  test 'clever_verified_teacher_candidate? returns true for unverified teacher with Clever teacher role' do
+  test 'oauth_verified_teacher_candidate? returns true for unverified Clever teacher' do
     teacher = create(:teacher)
     auth = OmniAuth::AuthHash.new(extra: {raw_info: {canonical: {data: {roles: {teacher: {}}}}}})
 
-    assert Policies::User.clever_verified_teacher_candidate?(teacher, auth)
+    assert Policies::User.oauth_verified_teacher_candidate?(teacher, auth, provider: AuthenticationOption::CLEVER)
   end
 
-  test 'clever_verified_teacher_candidate? returns false for Clever staff role' do
+  test 'oauth_verified_teacher_candidate? returns false for Clever staff role' do
     teacher = create(:teacher)
     auth = OmniAuth::AuthHash.new(extra: {raw_info: {canonical: {data: {roles: {staff: {}}}}}})
 
-    refute Policies::User.clever_verified_teacher_candidate?(teacher, auth)
+    refute Policies::User.oauth_verified_teacher_candidate?(teacher, auth, provider: AuthenticationOption::CLEVER)
   end
 
-  test 'clever_verified_teacher_candidate? returns false for student' do
+  test 'oauth_verified_teacher_candidate? returns false for Clever student' do
     student = create(:student)
     auth = OmniAuth::AuthHash.new(extra: {raw_info: {canonical: {data: {roles: {teacher: {}}}}}})
 
-    refute Policies::User.clever_verified_teacher_candidate?(student, auth)
+    refute Policies::User.oauth_verified_teacher_candidate?(student, auth, provider: AuthenticationOption::CLEVER)
   end
 
-  test 'clever_verified_teacher_candidate? returns false for already verified teacher' do
+  test 'oauth_verified_teacher_candidate? returns false for already verified Clever teacher' do
     teacher = create(:authorized_teacher)
     auth = OmniAuth::AuthHash.new(extra: {raw_info: {canonical: {data: {roles: {teacher: {}}}}}})
 
-    refute Policies::User.clever_verified_teacher_candidate?(teacher, auth)
+    refute Policies::User.oauth_verified_teacher_candidate?(teacher, auth, provider: AuthenticationOption::CLEVER)
+  end
+
+  test 'oauth_verified_teacher_candidate? returns true for unverified ClassLink teacher' do
+    teacher = create(:teacher)
+    auth = OmniAuth::AuthHash.new(extra: {raw_info: {role: 'Teacher'}})
+
+    assert Policies::User.oauth_verified_teacher_candidate?(teacher, auth, provider: AuthenticationOption::CLASSLINK)
+  end
+
+  test 'oauth_verified_teacher_candidate? returns false for ClassLink student' do
+    teacher = create(:teacher)
+    auth = OmniAuth::AuthHash.new(extra: {raw_info: {role: 'Student'}})
+
+    refute Policies::User.oauth_verified_teacher_candidate?(teacher, auth, provider: AuthenticationOption::CLASSLINK)
+  end
+
+  test 'oauth_verified_teacher_candidate? returns false for already verified ClassLink teacher' do
+    teacher = create(:authorized_teacher)
+    auth = OmniAuth::AuthHash.new(extra: {raw_info: {role: 'Teacher'}})
+
+    refute Policies::User.oauth_verified_teacher_candidate?(teacher, auth, provider: AuthenticationOption::CLASSLINK)
   end
 
   describe '.personal_account?' do

--- a/dashboard/test/lib/policies/user_test.rb
+++ b/dashboard/test/lib/policies/user_test.rb
@@ -58,6 +58,34 @@ class Policies::UserTest < ActiveSupport::TestCase
     end
   end
 
+  test 'clever_verified_teacher_candidate? returns true for unverified teacher with Clever teacher role' do
+    teacher = create(:teacher)
+    auth = OmniAuth::AuthHash.new(extra: {raw_info: {canonical: {data: {roles: {teacher: {}}}}}})
+
+    assert Policies::User.clever_verified_teacher_candidate?(teacher, auth)
+  end
+
+  test 'clever_verified_teacher_candidate? returns false for Clever staff role' do
+    teacher = create(:teacher)
+    auth = OmniAuth::AuthHash.new(extra: {raw_info: {canonical: {data: {roles: {staff: {}}}}}})
+
+    refute Policies::User.clever_verified_teacher_candidate?(teacher, auth)
+  end
+
+  test 'clever_verified_teacher_candidate? returns false for student' do
+    student = create(:student)
+    auth = OmniAuth::AuthHash.new(extra: {raw_info: {canonical: {data: {roles: {teacher: {}}}}}})
+
+    refute Policies::User.clever_verified_teacher_candidate?(student, auth)
+  end
+
+  test 'clever_verified_teacher_candidate? returns false for already verified teacher' do
+    teacher = create(:authorized_teacher)
+    auth = OmniAuth::AuthHash.new(extra: {raw_info: {canonical: {data: {roles: {teacher: {}}}}}})
+
+    refute Policies::User.clever_verified_teacher_candidate?(teacher, auth)
+  end
+
   describe '.personal_account?' do
     subject(:personal_account?) {Policies::User.personal_account?(user)}
 


### PR DESCRIPTION
Auto-verifies Clever and Classlink teachers on sign-up and sign-in. Sign-up will ensure any new teachers are automatically verified, and sign-in will backfill any unverified Clever and Classlink teachers created prior to this change.

Side changes:
- Moves the auto-verification for LTI signups into the same new method for Clever and Classlink
- Renames the Google Classroom-specific auto-verification method to `google_verified_teacher_candidate?` to differentiate it from the other logins. If we ever decide to relax requirements around GC verification, we can roll this functionality into the auto-verification for other providers.

## Links
[JIRA](https://codedotorg.atlassian.net/browse/P20-1840)

## Testing story
<!-- How was this tested? Manual steps, adhoc links, automated tests, or why testing isn't needed. -->



## Deployment notes
<!-- Delete this section if it's a standard merge-and-deploy.
     Otherwise: migrations, feature flags, coordination, caching impacts, etc. -->



## Privacy and security
<!-- Delete this section if there is no privacy/security impact.
     Otherwise: new PII, auth changes, API surface changes, etc. -->

