### PR TITLE
tighten Resource scope on mobile device farm policy

### DIFF
--- a/aws/cloudformation/cloud_formation_stack.yml.erb
+++ b/aws/cloudformation/cloud_formation_stack.yml.erb
@@ -669,10 +669,12 @@ Resources:
                   - 'devicefarm:ListNetworkProfiles'
                   - 'devicefarm:ListDevicePools'
                   - 'devicefarm:ListRemoteAccessSessions'
+                  - 'devicefarm:ScheduleRun'
                   - 'devicefarm:StopRun'
                   - 'devicefarm:StopJob'
                   - 'devicefarm:StopRemoteAccessSession'
                   - 'devicefarm:CreateUpload'
+                  - 'devicefarm:CreateRemoteAccessSession'
                   - 'devicefarm:DeleteRun'
                   - 'devicefarm:DeleteUpload'
                   - 'devicefarm:DeleteRemoteAccessSession'
@@ -687,20 +689,27 @@ Resources:
                   - !Sub 'arn:aws:devicefarm:*:${AWS::AccountId}:networkprofile:*'
                   - !Sub 'arn:aws:devicefarm:*:${AWS::AccountId}:session:*'
                   - !Sub 'arn:aws:devicefarm:*:${AWS::AccountId}:artifact:*'
-              # Actions evaluated against AWS-managed device ARNs (no account
-              # ID in the ARN) or against account-wide list endpoints — neither
-              # is resource-scopable. CreateRemoteAccessSession and ScheduleRun
-              # take a deviceArn parameter and IAM evaluates them against the
-              # device resource, not the project.
+              # Actions targeting AWS-managed device resources. Device ARNs
+              # contain no account ID — e.g.
+              # arn:aws:devicefarm:us-west-2::device:UUID — so they cannot
+              # appear in any account-scoped pattern. AWS was observed
+              # evaluating CreateRemoteAccessSession against the deviceArn
+              # parameter in addition to the project (which is covered by
+              # the account-scoped statement above).
               - Effect: Allow
                 Action:
                   - 'devicefarm:GetDevice'
+                  - 'devicefarm:CreateRemoteAccessSession'
+                Resource: 'arn:aws:devicefarm:*::device:*'
+              # Account-wide list endpoints. AWS's service authorization
+              # reference assigns these no resource type, so they can only
+              # be granted on '*'.
+              - Effect: Allow
+                Action:
                   - 'devicefarm:ListDevices'
                   - 'devicefarm:ListProjects'
                   - 'devicefarm:ListOfferings'
                   - 'devicefarm:ListOfferingPromotions'
-                  - 'devicefarm:CreateRemoteAccessSession'
-                  - 'devicefarm:ScheduleRun'
                 Resource: '*'
 <% end -%>
       ManagedPolicyArns:


### PR DESCRIPTION
Splits the previous `Resource: '*'` statement into three based on a line-by-line check against the AWS service authorization reference:

- ScheduleRun and CreateRemoteAccessSession move back into the account-scoped statement, which satisfies the project-level IAM check both actions document.
- A new statement scopes GetDevice and CreateRemoteAccessSession to `arn:aws:devicefarm:*::device:*` — AWS-managed device ARNs have no account ID, so they can't appear in account-scoped patterns, but they don't need full `'*'` either. `CreateRemoteAccessSession` appears in both statements because IAM evaluates it against both the project and device ARNs.
- `'*'` is reserved for the four account-wide List endpoints (`ListDevices`, `ListProjects`, `ListOfferings`, `ListOfferingPromotions`) that AWS leaves un-typed.

## Testing story
<!-- How was this tested? Manual steps, adhoc links, automated tests, or why testing isn't needed. -->



## Deployment notes
