### PR TITLE
UI tests: Chrome 138

### DIFF
--- a/dashboard/test/ui/browsers_saucelabs.json
+++ b/dashboard/test/ui/browsers_saucelabs.json
@@ -28,7 +28,7 @@
   {
     "name": "Chrome",
     "browserName": "chrome",
-    "browserVersion": "109",
+    "browserVersion": "138",
     "platformName": "Windows 10",
     "sauce:options": {
       "screenResolution": "1280x1024",


### PR DESCRIPTION
It appears that SauceLabs bumped their internal ChromeDriver version to 143, which broke many UI tests which were running on Chrome 109.  This bumps our UI tests to use Chrome 138 which works with that version, and is also the version we already intended to recommend for the next school year. 