### PR TITLE
Sketch2: support varied line widths and strokes

### DIFF
--- a/apps/src/sketchlab/reactFlow/components/ReactFlowCanvas.tsx
+++ b/apps/src/sketchlab/reactFlow/components/ReactFlowCanvas.tsx
@@ -32,7 +32,10 @@ import {
   type ToolbarTarget,
 } from '../context';
 import LineEdgeToolbar from '../elementToolbars/LineEdgeToolbar';
-import {DEFAULT_STROKE_COLOR} from '../elementToolbars/toolbarPalettes';
+import {
+  DEFAULT_LINE_WIDTH,
+  DEFAULT_STROKE_COLOR,
+} from '../elementToolbars/toolbarPalettes';
 import {useFocusManagement} from '../hooks/useFocusManagement';
 import {useKeyboardNavigation} from '../hooks/useKeyboardNavigation';
 import {useLineEdgeDrag} from '../hooks/useLineEdgeDrag';
@@ -419,7 +422,10 @@ export default function ReactFlowCanvas({
           source: sourceAnchorId,
           target: targetAnchorId,
           type: 'straight',
-          style: {stroke: DEFAULT_STROKE_COLOR},
+          style: {
+            stroke: DEFAULT_STROKE_COLOR,
+            strokeWidth: DEFAULT_LINE_WIDTH,
+          },
         };
 
         setNodes(currentNodes => [...currentNodes, sourceAnchor, targetAnchor]);
@@ -476,7 +482,13 @@ export default function ReactFlowCanvas({
     [readOnly, openToolbar, nodes]
   );
 
-  const {handleEdgeClick, openLineEdge, setLineEdgeColor} = useLineToolbar({
+  const {
+    handleEdgeClick,
+    openLineEdge,
+    setLineEdgeColor,
+    setLineEdgeWidth,
+    setLineEdgeStrokeStyle,
+  } = useLineToolbar({
     edges,
     nodes,
     readOnly,
@@ -537,6 +549,12 @@ export default function ReactFlowCanvas({
                 anchorNodeId={openLineEdge.source}
                 onSelectColor={value =>
                   setLineEdgeColor(openLineEdge.id, value)
+                }
+                onSelectWidth={value =>
+                  setLineEdgeWidth(openLineEdge.id, value)
+                }
+                onSelectStrokeStyle={value =>
+                  setLineEdgeStrokeStyle(openLineEdge.id, value)
                 }
               />
             )}

--- a/apps/src/sketchlab/reactFlow/elementToolbars/LineEdgeToolbar.tsx
+++ b/apps/src/sketchlab/reactFlow/elementToolbars/LineEdgeToolbar.tsx
@@ -19,6 +19,61 @@ import ToolbarShell from './ToolbarShell';
 
 import styles from './element-toolbar.module.scss';
 
+interface LineOption {
+  value: string | number;
+  label: string;
+}
+
+interface LineOptionGroupProps {
+  groupLabel: string;
+  options: readonly LineOption[];
+  selectedValue: string | number;
+  onSelect: (value: string | number) => void;
+  ariaLabelPrefix: string;
+  getButtonText?: (option: LineOption) => React.ReactNode;
+}
+
+function LineOptionGroup({
+  groupLabel,
+  options,
+  selectedValue,
+  onSelect,
+  ariaLabelPrefix,
+  getButtonText,
+}: LineOptionGroupProps) {
+  return (
+    <div className={styles.group} role="group" aria-label={groupLabel}>
+      <Typography
+        variant="overline3"
+        className={styles.groupLabel}
+        aria-hidden="true"
+      >
+        {groupLabel}
+      </Typography>
+      <div className={styles.lineStyleButtons}>
+        {options.map(option => {
+          const isSelected = selectedValue === option.value;
+          return (
+            <Tooltip key={option.value} title={option.label} placement="top">
+              <IconButton
+                size="small"
+                className={classNames(styles.lineStyleButton, {
+                  [styles.lineStyleButtonSelected]: isSelected,
+                })}
+                aria-label={`${ariaLabelPrefix}: ${option.label}`}
+                aria-pressed={isSelected}
+                onClick={() => onSelect(option.value)}
+              >
+                {getButtonText ? getButtonText(option) : option.label}
+              </IconButton>
+            </Tooltip>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
 interface LineEdgeToolbarProps {
   edge: SketchlabReactFlowEdge;
   anchorNodeId: string;
@@ -64,64 +119,21 @@ export default function LineEdgeToolbar({
         selectedValue={selectedValue}
         onSelect={onSelectColor}
       />
-      <div className={styles.group} role="group" aria-label="Line width">
-        <Typography
-          variant="overline3"
-          className={styles.groupLabel}
-          aria-hidden="true"
-        >
-          Line width
-        </Typography>
-        <div className={styles.lineStyleButtons}>
-          {LINE_WIDTH_OPTIONS.map(option => {
-            const isSelected = selectedWidthValue === option.value;
-            return (
-              <Tooltip key={option.value} title={option.label} placement="top">
-                <IconButton
-                  size="small"
-                  className={classNames(styles.lineStyleButton, {
-                    [styles.lineStyleButtonSelected]: isSelected,
-                  })}
-                  aria-label={`Line width: ${option.label}`}
-                  aria-pressed={isSelected}
-                  onClick={() => onSelectWidth(option.value)}
-                >
-                  {option.value}
-                </IconButton>
-              </Tooltip>
-            );
-          })}
-        </div>
-      </div>
-      <div className={styles.group} role="group" aria-label="Stroke style">
-        <Typography
-          variant="overline3"
-          className={styles.groupLabel}
-          aria-hidden="true"
-        >
-          Stroke style
-        </Typography>
-        <div className={styles.lineStyleButtons}>
-          {LINE_STROKE_STYLE_OPTIONS.map(option => {
-            const isSelected = selectedStrokeStyleValue === option.value;
-            return (
-              <Tooltip key={option.value} title={option.label} placement="top">
-                <IconButton
-                  size="small"
-                  className={classNames(styles.lineStyleButton, {
-                    [styles.lineStyleButtonSelected]: isSelected,
-                  })}
-                  aria-label={`Stroke style: ${option.label}`}
-                  aria-pressed={isSelected}
-                  onClick={() => onSelectStrokeStyle(option.value)}
-                >
-                  {option.label}
-                </IconButton>
-              </Tooltip>
-            );
-          })}
-        </div>
-      </div>
+      <LineOptionGroup
+        groupLabel="Line width"
+        options={LINE_WIDTH_OPTIONS}
+        selectedValue={selectedWidthValue}
+        onSelect={value => onSelectWidth(value as number)}
+        ariaLabelPrefix="Line width"
+        getButtonText={option => option.value}
+      />
+      <LineOptionGroup
+        groupLabel="Stroke style"
+        options={LINE_STROKE_STYLE_OPTIONS}
+        selectedValue={selectedStrokeStyleValue}
+        onSelect={value => onSelectStrokeStyle(value as LineStrokeStyleValue)}
+        ariaLabelPrefix="Stroke style"
+      />
     </ToolbarShell>
   );
 }

--- a/apps/src/sketchlab/reactFlow/elementToolbars/LineEdgeToolbar.tsx
+++ b/apps/src/sketchlab/reactFlow/elementToolbars/LineEdgeToolbar.tsx
@@ -24,13 +24,15 @@ interface LineOption {
   label: string;
 }
 
+type LinePreviewStyle = 'solid' | 'dashed' | 'dotted';
+
 interface LineOptionGroupProps {
   groupLabel: string;
   options: readonly LineOption[];
   selectedValue: string | number;
   onSelect: (value: string | number) => void;
   ariaLabelPrefix: string;
-  getButtonText?: (option: LineOption) => React.ReactNode;
+  getButtonContent?: (option: LineOption) => React.ReactNode;
 }
 
 function LineOptionGroup({
@@ -39,7 +41,7 @@ function LineOptionGroup({
   selectedValue,
   onSelect,
   ariaLabelPrefix,
-  getButtonText,
+  getButtonContent,
 }: LineOptionGroupProps) {
   return (
     <div className={styles.group} role="group" aria-label={groupLabel}>
@@ -64,7 +66,7 @@ function LineOptionGroup({
                 aria-pressed={isSelected}
                 onClick={() => onSelect(option.value)}
               >
-                {getButtonText ? getButtonText(option) : option.label}
+                {getButtonContent ? getButtonContent(option) : option.label}
               </IconButton>
             </Tooltip>
           );
@@ -106,6 +108,19 @@ export default function LineEdgeToolbar({
   )
     ? selectedStrokeStyle
     : DEFAULT_LINE_STROKE_STYLE;
+  const renderLinePreview = (
+    width: number,
+    lineStyle: LinePreviewStyle
+  ): React.ReactNode => (
+    <span
+      aria-hidden="true"
+      className={styles.linePreview}
+      style={{
+        borderTopWidth: width,
+        borderTopStyle: lineStyle,
+      }}
+    />
+  );
 
   return (
     <ToolbarShell
@@ -125,7 +140,9 @@ export default function LineEdgeToolbar({
         selectedValue={selectedWidthValue}
         onSelect={value => onSelectWidth(value as number)}
         ariaLabelPrefix="Line width"
-        getButtonText={option => option.value}
+        getButtonContent={option =>
+          renderLinePreview(option.value as number, 'solid')
+        }
       />
       <LineOptionGroup
         groupLabel="Stroke style"
@@ -133,6 +150,9 @@ export default function LineEdgeToolbar({
         selectedValue={selectedStrokeStyleValue}
         onSelect={value => onSelectStrokeStyle(value as LineStrokeStyleValue)}
         ariaLabelPrefix="Stroke style"
+        getButtonContent={option =>
+          renderLinePreview(2, option.value as LinePreviewStyle)
+        }
       />
     </ToolbarShell>
   );

--- a/apps/src/sketchlab/reactFlow/elementToolbars/LineEdgeToolbar.tsx
+++ b/apps/src/sketchlab/reactFlow/elementToolbars/LineEdgeToolbar.tsx
@@ -1,25 +1,56 @@
+import {IconButton, Tooltip, Typography} from '@mui/material';
+import classNames from 'classnames';
 import React from 'react';
 
 import {SketchlabReactFlowEdge} from '@cdo/apps/lab2/types';
 
 import SwatchGroup from './SwatchGroup';
-import {DEFAULT_STROKE_COLOR, STROKE_FONT_PALETTE} from './toolbarPalettes';
+import {
+  DEFAULT_LINE_STROKE_STYLE,
+  DEFAULT_LINE_WIDTH,
+  DEFAULT_STROKE_COLOR,
+  LineStrokeStyleValue,
+  LINE_STROKE_STYLE_OPTIONS,
+  LINE_WIDTH_OPTIONS,
+  strokeStyleFromDasharray,
+  STROKE_FONT_PALETTE,
+} from './toolbarPalettes';
 import ToolbarShell from './ToolbarShell';
+
+import styles from './element-toolbar.module.scss';
 
 interface LineEdgeToolbarProps {
   edge: SketchlabReactFlowEdge;
   anchorNodeId: string;
   onSelectColor: (value: string) => void;
+  onSelectWidth: (value: number) => void;
+  onSelectStrokeStyle: (value: LineStrokeStyleValue) => void;
 }
 
 export default function LineEdgeToolbar({
   edge,
   anchorNodeId,
   onSelectColor,
+  onSelectWidth,
+  onSelectStrokeStyle,
 }: LineEdgeToolbarProps) {
   const selectedValue =
     (typeof edge.style?.stroke === 'string' && edge.style.stroke) ||
     DEFAULT_STROKE_COLOR;
+  const selectedWidth = Number(edge.style?.strokeWidth);
+  const selectedWidthValue = LINE_WIDTH_OPTIONS.some(
+    option => option.value === selectedWidth
+  )
+    ? selectedWidth
+    : DEFAULT_LINE_WIDTH;
+  const selectedStrokeStyle = strokeStyleFromDasharray(
+    edge.style?.strokeDasharray
+  );
+  const selectedStrokeStyleValue = LINE_STROKE_STYLE_OPTIONS.some(
+    option => option.value === selectedStrokeStyle
+  )
+    ? selectedStrokeStyle
+    : DEFAULT_LINE_STROKE_STYLE;
 
   return (
     <ToolbarShell
@@ -33,6 +64,64 @@ export default function LineEdgeToolbar({
         selectedValue={selectedValue}
         onSelect={onSelectColor}
       />
+      <div className={styles.group} role="group" aria-label="Line width">
+        <Typography
+          variant="overline3"
+          className={styles.groupLabel}
+          aria-hidden="true"
+        >
+          Line width
+        </Typography>
+        <div className={styles.lineStyleButtons}>
+          {LINE_WIDTH_OPTIONS.map(option => {
+            const isSelected = selectedWidthValue === option.value;
+            return (
+              <Tooltip key={option.value} title={option.label} placement="top">
+                <IconButton
+                  size="small"
+                  className={classNames(styles.lineStyleButton, {
+                    [styles.lineStyleButtonSelected]: isSelected,
+                  })}
+                  aria-label={`Line width: ${option.label}`}
+                  aria-pressed={isSelected}
+                  onClick={() => onSelectWidth(option.value)}
+                >
+                  {option.value}
+                </IconButton>
+              </Tooltip>
+            );
+          })}
+        </div>
+      </div>
+      <div className={styles.group} role="group" aria-label="Stroke style">
+        <Typography
+          variant="overline3"
+          className={styles.groupLabel}
+          aria-hidden="true"
+        >
+          Stroke style
+        </Typography>
+        <div className={styles.lineStyleButtons}>
+          {LINE_STROKE_STYLE_OPTIONS.map(option => {
+            const isSelected = selectedStrokeStyleValue === option.value;
+            return (
+              <Tooltip key={option.value} title={option.label} placement="top">
+                <IconButton
+                  size="small"
+                  className={classNames(styles.lineStyleButton, {
+                    [styles.lineStyleButtonSelected]: isSelected,
+                  })}
+                  aria-label={`Stroke style: ${option.label}`}
+                  aria-pressed={isSelected}
+                  onClick={() => onSelectStrokeStyle(option.value)}
+                >
+                  {option.label}
+                </IconButton>
+              </Tooltip>
+            );
+          })}
+        </div>
+      </div>
     </ToolbarShell>
   );
 }

--- a/apps/src/sketchlab/reactFlow/elementToolbars/element-toolbar.module.scss
+++ b/apps/src/sketchlab/reactFlow/elementToolbars/element-toolbar.module.scss
@@ -191,12 +191,10 @@
   border: 1px solid var(--borders-neutral-primary);
   background-color: var(--background-neutral-primary);
   color: var(--text-neutral-primary);
-  font-size: 12px;
-  font-weight: 600;
   border-radius: 6px;
-  min-width: 24px;
+  min-width: 36px;
   height: 24px;
-  padding: 0 6px;
+  padding: 0 8px;
 
   &:hover {
     background-color: var(--background-neutral-secondary);
@@ -206,4 +204,11 @@
 .lineStyleButtonSelected {
   background-color: var(--background-neutral-secondary);
   border-color: var(--text-neutral-primary);
+}
+
+.linePreview {
+  display: inline-block;
+  width: 16px;
+  border-top-color: currentColor;
+  border-top-style: solid;
 }

--- a/apps/src/sketchlab/reactFlow/elementToolbars/element-toolbar.module.scss
+++ b/apps/src/sketchlab/reactFlow/elementToolbars/element-toolbar.module.scss
@@ -180,3 +180,30 @@
   background-color: var(--background-neutral-secondary);
   border-color: var(--text-neutral-primary);
 }
+
+.lineStyleButtons {
+  display: flex;
+  flex-direction: row;
+  gap: 4px;
+}
+
+.lineStyleButton {
+  border: 1px solid var(--borders-neutral-primary);
+  background-color: var(--background-neutral-primary);
+  color: var(--text-neutral-primary);
+  font-size: 12px;
+  font-weight: 600;
+  border-radius: 6px;
+  min-width: 24px;
+  height: 24px;
+  padding: 0 6px;
+
+  &:hover {
+    background-color: var(--background-neutral-secondary);
+  }
+}
+
+.lineStyleButtonSelected {
+  background-color: var(--background-neutral-secondary);
+  border-color: var(--text-neutral-primary);
+}

--- a/apps/src/sketchlab/reactFlow/elementToolbars/toolbarPalettes.ts
+++ b/apps/src/sketchlab/reactFlow/elementToolbars/toolbarPalettes.ts
@@ -38,10 +38,29 @@ export const FONT_SIZE_OPTIONS = [
 
 export type FontSizeValue = (typeof FONT_SIZE_OPTIONS)[number]['value'];
 
+export const LINE_WIDTH_OPTIONS = [
+  {value: 1, label: 'Thin'},
+  {value: 3, label: 'Medium'},
+  {value: 5, label: 'Thick'},
+] as const;
+
+export type LineWidthValue = (typeof LINE_WIDTH_OPTIONS)[number]['value'];
+
+export const LINE_STROKE_STYLE_OPTIONS = [
+  {value: 'solid', label: 'Solid'},
+  {value: 'dashed', label: 'Dashed'},
+  {value: 'dotted', label: 'Dotted'},
+] as const;
+
+export type LineStrokeStyleValue =
+  (typeof LINE_STROKE_STYLE_OPTIONS)[number]['value'];
+
 export const DEFAULT_BACKGROUND_COLOR = 'transparent';
 export const DEFAULT_STROKE_COLOR = 'var(--sketchlab-stroke-default)';
 export const DEFAULT_FONT_COLOR = 'var(--sketchlab-stroke-default)';
 export const DEFAULT_FONT_SIZE: FontSizeValue = 'medium';
+export const DEFAULT_LINE_WIDTH: LineWidthValue = 1;
+export const DEFAULT_LINE_STROKE_STYLE: LineStrokeStyleValue = 'solid';
 
 export function fontSizePx(value: string | undefined): number | undefined {
   const match = FONT_SIZE_OPTIONS.find(option => option.value === value);
@@ -49,4 +68,30 @@ export function fontSizePx(value: string | undefined): number | undefined {
     match?.px ||
     FONT_SIZE_OPTIONS.find(option => option.value === DEFAULT_FONT_SIZE)?.px
   );
+}
+
+export function strokeDasharrayFromStyle(
+  style: LineStrokeStyleValue
+): string | undefined {
+  if (style === 'dashed') {
+    return '8 4';
+  }
+  if (style === 'dotted') {
+    return '2 4';
+  }
+  return undefined;
+}
+
+export function strokeStyleFromDasharray(
+  dasharray: string | number | undefined
+): LineStrokeStyleValue {
+  const normalizedDasharray =
+    typeof dasharray === 'number' ? `${dasharray}` : dasharray;
+  if (normalizedDasharray === strokeDasharrayFromStyle('dashed')) {
+    return 'dashed';
+  }
+  if (normalizedDasharray === strokeDasharrayFromStyle('dotted')) {
+    return 'dotted';
+  }
+  return DEFAULT_LINE_STROKE_STYLE;
 }

--- a/apps/src/sketchlab/reactFlow/hooks/useLineToolbar.ts
+++ b/apps/src/sketchlab/reactFlow/hooks/useLineToolbar.ts
@@ -57,55 +57,60 @@ export function useLineToolbar({
     return edge;
   }, [openToolbarTarget, edges, nodes]);
 
-  const setLineEdgeColor = useCallback(
-    (edgeId: string, strokeColor: string) => {
-      setEdges(currentEdges =>
-        currentEdges.map(edge =>
-          edge.id === edgeId
-            ? {
-                ...edge,
-                style: {...edge.style, stroke: strokeColor},
-              }
-            : edge
-        )
-      );
-    },
-    [setEdges]
-  );
-
-  const setLineEdgeWidth = useCallback(
-    (edgeId: string, strokeWidth: number) => {
-      setEdges(currentEdges =>
-        currentEdges.map(edge =>
-          edge.id === edgeId
-            ? {
-                ...edge,
-                style: {...edge.style, strokeWidth},
-              }
-            : edge
-        )
-      );
-    },
-    [setEdges]
-  );
-
-  const setLineEdgeStrokeStyle = useCallback(
-    (edgeId: string, strokeStyle: LineStrokeStyleValue) => {
-      const strokeDasharray = strokeDasharrayFromStyle(strokeStyle);
+  const updateLineEdgeStyle = useCallback(
+    (
+      edgeId: string,
+      updateStyle: (currentStyle: React.CSSProperties) => React.CSSProperties
+    ) => {
       setEdges(currentEdges =>
         currentEdges.map(edge => {
           if (edge.id !== edgeId) {
             return edge;
           }
-          const nextStyle = {...edge.style, strokeDasharray};
-          if (!strokeDasharray) {
-            delete nextStyle.strokeDasharray;
-          }
-          return {...edge, style: nextStyle};
+          const currentStyle = {...edge.style};
+          return {
+            ...edge,
+            style: updateStyle(currentStyle),
+          };
         })
       );
     },
     [setEdges]
+  );
+
+  const setLineEdgeColor = useCallback(
+    (edgeId: string, strokeColor: string) => {
+      updateLineEdgeStyle(edgeId, currentStyle => ({
+        ...currentStyle,
+        stroke: strokeColor,
+      }));
+    },
+    [updateLineEdgeStyle]
+  );
+
+  const setLineEdgeWidth = useCallback(
+    (edgeId: string, strokeWidth: number) => {
+      updateLineEdgeStyle(edgeId, currentStyle => ({
+        ...currentStyle,
+        strokeWidth,
+      }));
+    },
+    [updateLineEdgeStyle]
+  );
+
+  const setLineEdgeStrokeStyle = useCallback(
+    (edgeId: string, strokeStyle: LineStrokeStyleValue) => {
+      const strokeDasharray = strokeDasharrayFromStyle(strokeStyle);
+      updateLineEdgeStyle(edgeId, currentStyle => {
+        if (!strokeDasharray) {
+          const styleWithoutDasharray = {...currentStyle};
+          delete styleWithoutDasharray.strokeDasharray;
+          return styleWithoutDasharray;
+        }
+        return {...currentStyle, strokeDasharray};
+      });
+    },
+    [updateLineEdgeStyle]
   );
 
   return {

--- a/apps/src/sketchlab/reactFlow/hooks/useLineToolbar.ts
+++ b/apps/src/sketchlab/reactFlow/hooks/useLineToolbar.ts
@@ -6,6 +6,10 @@ import {
 } from '@cdo/apps/lab2/types';
 
 import {ToolbarTarget} from '../context';
+import {
+  LineStrokeStyleValue,
+  strokeDasharrayFromStyle,
+} from '../elementToolbars/toolbarPalettes';
 import {isLineEdge} from '../utils/lineEdges';
 
 interface UseLineToolbarOptions {
@@ -69,5 +73,46 @@ export function useLineToolbar({
     [setEdges]
   );
 
-  return {handleEdgeClick, openLineEdge, setLineEdgeColor};
+  const setLineEdgeWidth = useCallback(
+    (edgeId: string, strokeWidth: number) => {
+      setEdges(currentEdges =>
+        currentEdges.map(edge =>
+          edge.id === edgeId
+            ? {
+                ...edge,
+                style: {...edge.style, strokeWidth},
+              }
+            : edge
+        )
+      );
+    },
+    [setEdges]
+  );
+
+  const setLineEdgeStrokeStyle = useCallback(
+    (edgeId: string, strokeStyle: LineStrokeStyleValue) => {
+      const strokeDasharray = strokeDasharrayFromStyle(strokeStyle);
+      setEdges(currentEdges =>
+        currentEdges.map(edge => {
+          if (edge.id !== edgeId) {
+            return edge;
+          }
+          const nextStyle = {...edge.style, strokeDasharray};
+          if (!strokeDasharray) {
+            delete nextStyle.strokeDasharray;
+          }
+          return {...edge, style: nextStyle};
+        })
+      );
+    },
+    [setEdges]
+  );
+
+  return {
+    handleEdgeClick,
+    openLineEdge,
+    setLineEdgeColor,
+    setLineEdgeWidth,
+    setLineEdgeStrokeStyle,
+  };
 }


### PR DESCRIPTION
Adds options to the line toolbar to vary line widths and stroke.

https://github.com/user-attachments/assets/c4bcfe7e-229b-421d-b78a-7bf0432cb89b

## Testing story

Tested manually via mouse and keyboard (see above).