### PR TITLE
Sketch2: support basic arrows

### DIFF
--- a/apps/src/lab2/types.ts
+++ b/apps/src/lab2/types.ts
@@ -122,9 +122,6 @@ export interface SketchlabReactFlowEdge {
   sourceHandle?: string;
   targetHandle?: string;
   type?: string;
-  data?: {
-    isArrow?: boolean;
-  };
   markerStart?: EdgeMarkerType;
   markerEnd?: EdgeMarkerType;
 }

--- a/apps/src/lab2/types.ts
+++ b/apps/src/lab2/types.ts
@@ -122,6 +122,10 @@ export interface SketchlabReactFlowEdge {
   sourceHandle?: string;
   targetHandle?: string;
   type?: string;
+  data?: {
+    isArrow?: boolean;
+  };
+  markerStart?: EdgeMarkerType;
   markerEnd?: EdgeMarkerType;
 }
 

--- a/apps/src/sketchlab/reactFlow/components/ReactFlowCanvas.tsx
+++ b/apps/src/sketchlab/reactFlow/components/ReactFlowCanvas.tsx
@@ -72,6 +72,9 @@ const NODE_TYPES = {
 const NEW_NODE_STAGGER_PX = 20;
 const FOCUS_DELAY_MS = 100;
 const LINE_DEFAULT_LENGTH_PX = 220;
+const LINE_ANCHOR_SIZE_PX = 10;
+const ARROW_MARKER_WIDTH_PX = 14;
+const ARROW_MARKER_HEIGHT_PX = 14;
 
 export interface ReactFlowCanvasProps {
   updateSources: ReturnType<
@@ -380,8 +383,8 @@ export default function ReactFlowCanvas({
         y: window.innerHeight / 2 + stagger,
       });
 
-      // For lines, we create two hidden nodes and connecting anchors between them.
-      if (type === 'line') {
+      // For lines/arrows, create two hidden anchor nodes and connect them.
+      if (type === 'line' || type === 'arrow') {
         const sourceAnchorId = createUuid();
         const targetAnchorId = createUuid();
         const lineEdgeId = createUuid();
@@ -422,6 +425,15 @@ export default function ReactFlowCanvas({
           source: sourceAnchorId,
           target: targetAnchorId,
           type: 'straight',
+          ...(type === 'arrow' && {
+            markerEnd: {
+              type: MarkerType.ArrowClosed,
+              color: DEFAULT_STROKE_COLOR,
+              width: ARROW_MARKER_WIDTH_PX,
+              height: ARROW_MARKER_HEIGHT_PX,
+              strokeWidth: DEFAULT_LINE_WIDTH,
+            },
+          }),
           style: {
             stroke: DEFAULT_STROKE_COLOR,
             strokeWidth: DEFAULT_LINE_WIDTH,

--- a/apps/src/sketchlab/reactFlow/components/ReactFlowCanvas.tsx
+++ b/apps/src/sketchlab/reactFlow/components/ReactFlowCanvas.tsx
@@ -27,6 +27,7 @@ import {
   DEFAULT_NODE_HEIGHT,
   DEFAULT_NODE_WIDTH,
   LINE_ANCHOR_SIZE_PX,
+  LINE_DEFAULT_LENGTH_PX,
   SAVE_DEBOUNCE_MS,
 } from '../constants';
 import {
@@ -73,8 +74,7 @@ const NODE_TYPES = {
 // Offset added per new node so they don't stack exactly on top of each other.
 const NEW_NODE_STAGGER_PX = 20;
 const FOCUS_DELAY_MS = 100;
-const LINE_DEFAULT_LENGTH_PX = 220;
-const LINE_ANCHOR_SIZE_PX = 10;
+
 export interface ReactFlowCanvasProps {
   updateSources: ReturnType<
     typeof useSources<ReactFlowSketchLabSources>

--- a/apps/src/sketchlab/reactFlow/components/ReactFlowCanvas.tsx
+++ b/apps/src/sketchlab/reactFlow/components/ReactFlowCanvas.tsx
@@ -22,6 +22,8 @@ import {useSources} from '@cdo/apps/lab2/views/SourcesContainer';
 import {createUuid} from '@cdo/apps/utils';
 
 import {
+  ARROW_MARKER_HEIGHT_PX,
+  ARROW_MARKER_WIDTH_PX,
   DEFAULT_NODE_HEIGHT,
   DEFAULT_NODE_WIDTH,
   LINE_ANCHOR_SIZE_PX,
@@ -73,9 +75,6 @@ const NEW_NODE_STAGGER_PX = 20;
 const FOCUS_DELAY_MS = 100;
 const LINE_DEFAULT_LENGTH_PX = 220;
 const LINE_ANCHOR_SIZE_PX = 10;
-const ARROW_MARKER_WIDTH_PX = 14;
-const ARROW_MARKER_HEIGHT_PX = 14;
-
 export interface ReactFlowCanvasProps {
   updateSources: ReturnType<
     typeof useSources<ReactFlowSketchLabSources>
@@ -426,6 +425,7 @@ export default function ReactFlowCanvas({
           target: targetAnchorId,
           type: 'straight',
           ...(type === 'arrow' && {
+            data: {isArrow: true},
             markerEnd: {
               type: MarkerType.ArrowClosed,
               color: DEFAULT_STROKE_COLOR,
@@ -500,6 +500,7 @@ export default function ReactFlowCanvas({
     setLineEdgeColor,
     setLineEdgeWidth,
     setLineEdgeStrokeStyle,
+    setLineEdgeArrowHeads,
   } = useLineToolbar({
     edges,
     nodes,
@@ -567,6 +568,9 @@ export default function ReactFlowCanvas({
                 }
                 onSelectStrokeStyle={value =>
                   setLineEdgeStrokeStyle(openLineEdge.id, value)
+                }
+                onSelectArrowHeads={value =>
+                  setLineEdgeArrowHeads(openLineEdge.id, value)
                 }
               />
             )}

--- a/apps/src/sketchlab/reactFlow/components/ReactFlowCanvas.tsx
+++ b/apps/src/sketchlab/reactFlow/components/ReactFlowCanvas.tsx
@@ -425,7 +425,6 @@ export default function ReactFlowCanvas({
           target: targetAnchorId,
           type: 'straight',
           ...(type === 'arrow' && {
-            data: {isArrow: true},
             markerEnd: {
               type: MarkerType.ArrowClosed,
               color: DEFAULT_STROKE_COLOR,

--- a/apps/src/sketchlab/reactFlow/components/Toolbar.tsx
+++ b/apps/src/sketchlab/reactFlow/components/Toolbar.tsx
@@ -144,6 +144,19 @@ export default function Toolbar({onAddNode}: ToolbarProps) {
         </IconButton>
       </Tooltip>
 
+      <Tooltip title="Add arrow" placement="right">
+        <IconButton
+          aria-label="Add arrow"
+          id={`${uid}-arrow`}
+          onClick={() => onAddNode({type: 'arrow'})}
+          size="small"
+          color="tertiary"
+          variant="outlined"
+        >
+          <FontAwesomeV6Icon iconName="arrow-right-long" />
+        </IconButton>
+      </Tooltip>
+
       <Tooltip title="Add image" placement="right">
         <IconButton
           aria-label="Add image"

--- a/apps/src/sketchlab/reactFlow/constants.ts
+++ b/apps/src/sketchlab/reactFlow/constants.ts
@@ -12,3 +12,6 @@ export const SAVE_DEBOUNCE_MS = 300;
 
 // S3 asset path prefix for project files.
 export const ASSET_PATH_PREFIX = '/v3/assets';
+
+export const ARROW_MARKER_WIDTH_PX = 14;
+export const ARROW_MARKER_HEIGHT_PX = 14;

--- a/apps/src/sketchlab/reactFlow/constants.ts
+++ b/apps/src/sketchlab/reactFlow/constants.ts
@@ -7,6 +7,8 @@ export const MIN_NODE_HEIGHT = 60;
 // Side length of the hidden node that anchors a line endpoint.
 export const LINE_ANCHOR_SIZE_PX = 10;
 
+export const LINE_DEFAULT_LENGTH_PX = 220;
+
 // Milliseconds to debounce project saves after canvas changes.
 export const SAVE_DEBOUNCE_MS = 300;
 

--- a/apps/src/sketchlab/reactFlow/elementToolbars/LineEdgeToolbar.tsx
+++ b/apps/src/sketchlab/reactFlow/elementToolbars/LineEdgeToolbar.tsx
@@ -100,6 +100,7 @@ const ARROW_HEAD_ICONS: Record<ArrowHeadValue, string> = {
   both: 'arrows-left-right',
 };
 
+// Shared edge toolbar for both plain lines and arrows.
 export default function LineEdgeToolbar({
   edge,
   anchorNodeId,
@@ -134,6 +135,7 @@ export default function LineEdgeToolbar({
     : 'end';
   const showArrowHeadOptions =
     edge.data?.isArrow || hasStartArrow || hasEndArrow;
+
   const renderLinePreview = (
     width: number,
     lineStyle: LinePreviewStyle

--- a/apps/src/sketchlab/reactFlow/elementToolbars/LineEdgeToolbar.tsx
+++ b/apps/src/sketchlab/reactFlow/elementToolbars/LineEdgeToolbar.tsx
@@ -1,3 +1,4 @@
+import FontAwesomeV6Icon from '@code-dot-org/component-library/fontAwesomeV6Icon';
 import {IconButton, Tooltip, Typography} from '@mui/material';
 import classNames from 'classnames';
 import React from 'react';
@@ -82,7 +83,22 @@ interface LineEdgeToolbarProps {
   onSelectColor: (value: string) => void;
   onSelectWidth: (value: number) => void;
   onSelectStrokeStyle: (value: LineStrokeStyleValue) => void;
+  onSelectArrowHeads: (value: ArrowHeadValue) => void;
 }
+
+type ArrowHeadValue = 'start' | 'end' | 'both';
+
+const ARROW_HEAD_OPTIONS: readonly LineOption[] = [
+  {value: 'start', label: 'Start'},
+  {value: 'end', label: 'End'},
+  {value: 'both', label: 'Both'},
+] as const;
+
+const ARROW_HEAD_ICONS: Record<ArrowHeadValue, string> = {
+  start: 'arrow-left-long',
+  end: 'arrow-right-long',
+  both: 'arrows-left-right',
+};
 
 export default function LineEdgeToolbar({
   edge,
@@ -90,6 +106,7 @@ export default function LineEdgeToolbar({
   onSelectColor,
   onSelectWidth,
   onSelectStrokeStyle,
+  onSelectArrowHeads,
 }: LineEdgeToolbarProps) {
   const selectedValue =
     (typeof edge.style?.stroke === 'string' && edge.style.stroke) ||
@@ -108,6 +125,15 @@ export default function LineEdgeToolbar({
   )
     ? selectedStrokeStyle
     : DEFAULT_LINE_STROKE_STYLE;
+  const hasStartArrow = !!edge.markerStart;
+  const hasEndArrow = !!edge.markerEnd;
+  const selectedArrowHeads: ArrowHeadValue = hasStartArrow
+    ? hasEndArrow
+      ? 'both'
+      : 'start'
+    : 'end';
+  const showArrowHeadOptions =
+    edge.data?.isArrow || hasStartArrow || hasEndArrow;
   const renderLinePreview = (
     width: number,
     lineStyle: LinePreviewStyle
@@ -154,6 +180,20 @@ export default function LineEdgeToolbar({
           renderLinePreview(2, option.value as LinePreviewStyle)
         }
       />
+      {showArrowHeadOptions && (
+        <LineOptionGroup
+          groupLabel="Arrow heads"
+          options={ARROW_HEAD_OPTIONS}
+          selectedValue={selectedArrowHeads}
+          onSelect={value => onSelectArrowHeads(value as ArrowHeadValue)}
+          ariaLabelPrefix="Arrow heads"
+          getButtonContent={option => (
+            <FontAwesomeV6Icon
+              iconName={ARROW_HEAD_ICONS[option.value as ArrowHeadValue]}
+            />
+          )}
+        />
+      )}
     </ToolbarShell>
   );
 }

--- a/apps/src/sketchlab/reactFlow/elementToolbars/LineEdgeToolbar.tsx
+++ b/apps/src/sketchlab/reactFlow/elementToolbars/LineEdgeToolbar.tsx
@@ -5,6 +5,8 @@ import React from 'react';
 
 import {SketchlabReactFlowEdge} from '@cdo/apps/lab2/types';
 
+import {isArrowEdge} from '../utils/lineEdges';
+
 import SwatchGroup from './SwatchGroup';
 import {
   DEFAULT_LINE_STROKE_STYLE,
@@ -133,8 +135,7 @@ export default function LineEdgeToolbar({
       ? 'both'
       : 'start'
     : 'end';
-  const showArrowHeadOptions =
-    edge.data?.isArrow || hasStartArrow || hasEndArrow;
+  const showArrowHeadOptions = isArrowEdge(edge);
 
   const renderLinePreview = (
     width: number,

--- a/apps/src/sketchlab/reactFlow/hooks/useLineToolbar.ts
+++ b/apps/src/sketchlab/reactFlow/hooks/useLineToolbar.ts
@@ -187,7 +187,6 @@ export function useLineToolbar({
 
           return {
             ...edge,
-            data: {...edge.data, isArrow: true},
             markerStart:
               arrowHeads === 'start' || arrowHeads === 'both'
                 ? marker

--- a/apps/src/sketchlab/reactFlow/hooks/useLineToolbar.ts
+++ b/apps/src/sketchlab/reactFlow/hooks/useLineToolbar.ts
@@ -1,3 +1,4 @@
+import {MarkerType} from '@xyflow/react';
 import React, {useCallback, useMemo} from 'react';
 
 import {
@@ -5,12 +6,17 @@ import {
   SketchlabReactFlowNode,
 } from '@cdo/apps/lab2/types';
 
+import {ARROW_MARKER_HEIGHT_PX, ARROW_MARKER_WIDTH_PX} from '../constants';
 import {ToolbarTarget} from '../context';
 import {
+  DEFAULT_LINE_WIDTH,
+  DEFAULT_STROKE_COLOR,
   LineStrokeStyleValue,
   strokeDasharrayFromStyle,
 } from '../elementToolbars/toolbarPalettes';
 import {isLineEdge} from '../utils/lineEdges';
+
+type ArrowHeadValue = 'start' | 'end' | 'both';
 
 interface UseLineToolbarOptions {
   edges: SketchlabReactFlowEdge[];
@@ -85,12 +91,24 @@ export function useLineToolbar({
           if (edge.id !== edgeId) {
             return edge;
           }
+          const markerStart =
+            edge.markerStart && typeof edge.markerStart !== 'string'
+              ? edge.markerStart
+              : undefined;
           const markerEnd =
             edge.markerEnd && typeof edge.markerEnd !== 'string'
               ? edge.markerEnd
               : undefined;
           return {
             ...edge,
+            ...(markerStart
+              ? {
+                  markerStart: {
+                    ...markerStart,
+                    ...markerPatch,
+                  },
+                }
+              : {}),
             ...(markerEnd
               ? {
                   markerEnd: {
@@ -143,11 +161,54 @@ export function useLineToolbar({
     [updateLineEdgeStyle]
   );
 
+  const setLineEdgeArrowHeads = useCallback(
+    (edgeId: string, arrowHeads: ArrowHeadValue) => {
+      setEdges(currentEdges =>
+        currentEdges.map(edge => {
+          if (edge.id !== edgeId) {
+            return edge;
+          }
+
+          const strokeColor =
+            typeof edge.style?.stroke === 'string'
+              ? edge.style.stroke
+              : DEFAULT_STROKE_COLOR;
+          const strokeWidth = Number(edge.style?.strokeWidth);
+          const markerStrokeWidth = Number.isFinite(strokeWidth)
+            ? strokeWidth
+            : DEFAULT_LINE_WIDTH;
+          const marker = {
+            type: MarkerType.ArrowClosed,
+            color: strokeColor,
+            width: ARROW_MARKER_WIDTH_PX,
+            height: ARROW_MARKER_HEIGHT_PX,
+            strokeWidth: markerStrokeWidth,
+          };
+
+          return {
+            ...edge,
+            data: {...edge.data, isArrow: true},
+            markerStart:
+              arrowHeads === 'start' || arrowHeads === 'both'
+                ? marker
+                : undefined,
+            markerEnd:
+              arrowHeads === 'end' || arrowHeads === 'both'
+                ? marker
+                : undefined,
+          };
+        })
+      );
+    },
+    [setEdges]
+  );
+
   return {
     handleEdgeClick,
     openLineEdge,
     setLineEdgeColor,
     setLineEdgeWidth,
     setLineEdgeStrokeStyle,
+    setLineEdgeArrowHeads,
   };
 }

--- a/apps/src/sketchlab/reactFlow/hooks/useLineToolbar.ts
+++ b/apps/src/sketchlab/reactFlow/hooks/useLineToolbar.ts
@@ -80,22 +80,66 @@ export function useLineToolbar({
 
   const setLineEdgeColor = useCallback(
     (edgeId: string, strokeColor: string) => {
-      updateLineEdgeStyle(edgeId, currentStyle => ({
-        ...currentStyle,
-        stroke: strokeColor,
-      }));
+      setEdges(currentEdges =>
+        currentEdges.map(edge => {
+          if (edge.id !== edgeId) {
+            return edge;
+          }
+          const markerEnd =
+            edge.markerEnd && typeof edge.markerEnd !== 'string'
+              ? edge.markerEnd
+              : undefined;
+          return {
+            ...edge,
+            style: {
+              ...edge.style,
+              stroke: strokeColor,
+            },
+            ...(markerEnd
+              ? {
+                  markerEnd: {
+                    ...markerEnd,
+                    color: strokeColor,
+                  },
+                }
+              : {}),
+          };
+        })
+      );
     },
-    [updateLineEdgeStyle]
+    [setEdges]
   );
 
   const setLineEdgeWidth = useCallback(
     (edgeId: string, strokeWidth: number) => {
-      updateLineEdgeStyle(edgeId, currentStyle => ({
-        ...currentStyle,
-        strokeWidth,
-      }));
+      setEdges(currentEdges =>
+        currentEdges.map(edge => {
+          if (edge.id !== edgeId) {
+            return edge;
+          }
+          const markerEnd =
+            edge.markerEnd && typeof edge.markerEnd !== 'string'
+              ? edge.markerEnd
+              : undefined;
+          return {
+            ...edge,
+            style: {
+              ...edge.style,
+              strokeWidth,
+            },
+            ...(markerEnd
+              ? {
+                  markerEnd: {
+                    ...markerEnd,
+                    strokeWidth,
+                  },
+                }
+              : {}),
+          };
+        })
+      );
     },
-    [updateLineEdgeStyle]
+    [setEdges]
   );
 
   const setLineEdgeStrokeStyle = useCallback(

--- a/apps/src/sketchlab/reactFlow/hooks/useLineToolbar.ts
+++ b/apps/src/sketchlab/reactFlow/hooks/useLineToolbar.ts
@@ -78,8 +78,8 @@ export function useLineToolbar({
     [setEdges]
   );
 
-  const setLineEdgeColor = useCallback(
-    (edgeId: string, strokeColor: string) => {
+  const updateLineEdgeMarker = useCallback(
+    (edgeId: string, markerPatch: {color?: string; strokeWidth?: number}) => {
       setEdges(currentEdges =>
         currentEdges.map(edge => {
           if (edge.id !== edgeId) {
@@ -91,15 +91,11 @@ export function useLineToolbar({
               : undefined;
           return {
             ...edge,
-            style: {
-              ...edge.style,
-              stroke: strokeColor,
-            },
             ...(markerEnd
               ? {
                   markerEnd: {
                     ...markerEnd,
-                    color: strokeColor,
+                    ...markerPatch,
                   },
                 }
               : {}),
@@ -110,36 +106,26 @@ export function useLineToolbar({
     [setEdges]
   );
 
+  const setLineEdgeColor = useCallback(
+    (edgeId: string, strokeColor: string) => {
+      updateLineEdgeStyle(edgeId, currentStyle => ({
+        ...currentStyle,
+        stroke: strokeColor,
+      }));
+      updateLineEdgeMarker(edgeId, {color: strokeColor});
+    },
+    [updateLineEdgeStyle, updateLineEdgeMarker]
+  );
+
   const setLineEdgeWidth = useCallback(
     (edgeId: string, strokeWidth: number) => {
-      setEdges(currentEdges =>
-        currentEdges.map(edge => {
-          if (edge.id !== edgeId) {
-            return edge;
-          }
-          const markerEnd =
-            edge.markerEnd && typeof edge.markerEnd !== 'string'
-              ? edge.markerEnd
-              : undefined;
-          return {
-            ...edge,
-            style: {
-              ...edge.style,
-              strokeWidth,
-            },
-            ...(markerEnd
-              ? {
-                  markerEnd: {
-                    ...markerEnd,
-                    strokeWidth,
-                  },
-                }
-              : {}),
-          };
-        })
-      );
+      updateLineEdgeStyle(edgeId, currentStyle => ({
+        ...currentStyle,
+        strokeWidth,
+      }));
+      updateLineEdgeMarker(edgeId, {strokeWidth});
     },
-    [setEdges]
+    [updateLineEdgeStyle, updateLineEdgeMarker]
   );
 
   const setLineEdgeStrokeStyle = useCallback(

--- a/apps/src/sketchlab/reactFlow/types.ts
+++ b/apps/src/sketchlab/reactFlow/types.ts
@@ -45,7 +45,8 @@ export type AddNodeRequest =
   | {type: 'shape'; data: ShapeNodeData}
   | {type: 'text'; data: TextNodeData}
   | {type: 'image'; data: ImageNodeData}
-  | {type: 'line'};
+  | {type: 'line'}
+  | {type: 'arrow'};
 
 export type ShapeNodeType = Node<ShapeNodeData, 'shape'>;
 export type TextNodeType = Node<TextNodeData, 'text'>;

--- a/apps/src/sketchlab/reactFlow/utils/lineEdges.ts
+++ b/apps/src/sketchlab/reactFlow/utils/lineEdges.ts
@@ -11,3 +11,7 @@ export function isLineEdge(
   const targetNode = nodes.find(node => node.id === edge.target);
   return sourceNode?.type === 'lineAnchor' && targetNode?.type === 'lineAnchor';
 }
+
+export function isArrowEdge(edge: SketchlabReactFlowEdge): boolean {
+  return Boolean(edge.markerStart || edge.markerEnd);
+}


### PR DESCRIPTION
Adds an arrow option to our main shapes menu. This aligns with Excalidraw, but in theory could just be an option in the line toolbox? I like it as a standalone option though.

https://github.com/user-attachments/assets/24f176d0-9a64-4373-ac69-5d9d5cfc42c8

## Testing story

Tested manually (see above).