### PR TITLE
JSON Video - Make `box-sizing: border-box;` the default

### DIFF
--- a/apps/src/jsonVideo/jsonVideoElement.js
+++ b/apps/src/jsonVideo/jsonVideoElement.js
@@ -424,6 +424,9 @@ export class JsonVideo extends HTMLElement {
             <html>
             <head>
                 <style>
+                    *, *::before, *::after {
+                        box-sizing: border-box;
+                    }
                     body { margin: 0; overflow: hidden; background: transparent; }
                 </style>
             </head>


### PR DESCRIPTION
## Summary

This PR adds `border-box;` as the default value for [box-sizing ](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/box-sizing) for content within the JSON video.

## Details

The original default value for [box-sizing ](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/box-sizing) is `content-box` which means if you set padding on a parent and then make the child `100%` width or height it will be `100% `of the parent's size, not what you might expect which could be the available space taking into account the padding.  

Most designers/developers reset `box-sizing` globally to the much more friendly and modern `border-box` which allows the percent width/height to take its border and parent's padding into account so that 100% actually fits in available space.  This PR sets this globally for all elements within the JSON video so authors don't have to set it on every element (too tedious).  If for some reason they want to set a different value they can do that with custom CSS.

**_Content with `width: 100%;` before:_**
<img width="700" alt="image (3)" src="https://github.com/user-attachments/assets/816c5020-974c-40ee-9247-73ca8d38dd61" />


**_Content with `width: 100%;` after:_**

<img width="700" height="394" alt="box-sizing-border-box" src="https://github.com/user-attachments/assets/972baf58-918e-49c6-b0fa-7e5a79766b07" />
