### PR TITLE
feat(newrelic): gate New Relic Browser loader

### DIFF
--- a/dashboard/app/views/layouts/application.html.haml
+++ b/dashboard/app/views/layouts/application.html.haml
@@ -19,10 +19,11 @@
       = tag 'meta', property: 'description', content: @page_description
     - if @canonical_url
       = tag 'link', rel: 'canonical', href: @canonical_url
-    - begin
-      = ::NewRelic::Agent.browser_timing_header
-    - rescue
-      = ''
+    - if DCDO.get('frontend-newrelic-enabled', true)
+      - begin
+        = ::NewRelic::Agent.browser_timing_header
+      - rescue
+        = ''
     - if view_options[:responsive_content]
       = tag :meta, name: 'viewport', content: 'width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=1.0, user-scalable=no'
     - else

--- a/lib/dynamic_config/dcdo.rb
+++ b/lib/dynamic_config/dcdo.rb
@@ -69,6 +69,7 @@ class DCDOBase < DynamicConfigBase
       'brand-router-enabled': DCDO.get('brand-router-enabled', false),
       'ai-gateway-enabled': DCDO.get('ai-gateway-enabled', true),
       'frontend-observability-enabled': DCDO.get('frontend-observability-enabled', false),
+      'frontend-newrelic-enabled': DCDO.get('frontend-newrelic-enabled', true),
       'onboarding-enabled': DCDO.get('onboarding-enabled', false),
       'ai-diff-drawer': DCDO.get('ai-diff-drawer', false),
       'language-deprecation-warning-enabled': DCDO.get('language-deprecation-warning-enabled', false),


### PR DESCRIPTION
Wraps `::NewRelic::Agent.browser_timing_header` in application.html.haml behind `DCDO.get('frontend-newrelic-enabled', true)` so we can disable the RUM snippet at runtime without a deploy. Default true preserves current behavior on rollout.

All existing `window.newrelic` call sites are null-safe and require no changes; suppressing the loader leaves them as silent no-ops.

Verified on http://adhoc-stephen-sentry1-studio.cdn-code.org/users/sign_in

<!--
  Summary of the change: background, motivation, and context.
  Include screenshots, videos, or before/after comparisons for UI changes.
-->



## Links
<!-- Jira tickets, design docs, Slack threads, related PRs, etc. -->

- Jira:

## Testing story
<!-- How was this tested? Manual steps, adhoc links, automated tests, or why testing isn't needed. -->



## Deployment notes
<!-- Delete this section if it's a standard merge-and-deploy.
     Otherwise: migrations, feature flags, coordination, caching impacts, etc. -->



## Privacy and security
<!-- Delete this section if there is no privacy/security impact.
     Otherwise: new PII, auth changes, API surface changes, etc. -->

