### PR TITLE
reduce saucelabs concurrency during DTT to 65

### DIFF
--- a/lib/rake/test.rake
+++ b/lib/rake/test.rake
@@ -39,7 +39,7 @@ namespace :test do
       '-d', CDO.site_host('studio.code.org'),
       '-p', CDO.site_host('code.org'),
       '--db', # Ensure features that require database access are run even if the server name isn't "test"
-      '--parallel', '120',
+      '--parallel', '50',
       '--magic_retry',
       '--with-status-page',
       '--fail_fast',
@@ -125,7 +125,7 @@ namespace :test do
       '--magic_retry',
       '--with-status-page',
       '-f', eyes_features.join(","),
-      '--parallel', '20'
+      '--parallel', '15'
     )
     if failed_browser_count == 0
       message = '⊙‿⊙ Eyes tests for <b>dashboard</b> succeeded, no changes detected.'


### PR DESCRIPTION
## To be merged only if DTTs are consistently failing as a result of a reduction/enforcement of saucelabs concurrency.

Seems like this is happening now. See [slack](https://codedotorg.slack.com/archives/C03CM903Y/p1777925808788829)

## Background

Our new contract with SauceLabs reduces our max concurrent sessions from 200 to 65. Today the DTT runs with a concurrency of ~140 (recently reduced from 200), with additional concurrency being used by drone runs. Saucelabs sessions created in the DTT have priority over those created in drone runs.

We're in the process of moving some of our UI / Eyes tests from Sauce Labs to an equivalent service in AWS Device Farm. If Sauce Labs takes a hard line on the new concurrency level before we're ready to migrate,then this PR provides an immediate way to stay under the limit so we can hopefully get passing (but slower) DTTs in the interim.

Saucelabs concurrency can be viewed here: https://app.saucelabs.com/analytics/usage/vdc?org_id=af05cdf0f8df4cc28c817f378f5ef53b&start=last7Days&end=today&resourceType=total_virtual_machine concurrency has already been dropped to 65, but as of April 30 is not being strictly enforced.

## Description

This PR drops our parallel usage of saucelabs browser sessions during the DTT from 140 to 65:
- UI tests: 120 --> 50
- Eyes tests: 20 --> 15

The parallelism split between eyes and regular UI tests is an eyeball estimate to try and get both test suites to pass (in parallel) in about the same amount of time, but has not been verified.

## Testing story
- syntax is easy enough to validate by inspection
- we will have to wait and see if this solves the concurrency issue
- timing assumptions have also not been validated

## Follow-up work

here are some ideas to try if UI tests are still failing during DTT with concurrency-related issues:
1. simply rerun any failing scenarios once DTT is over and more concurrency is available
2. rerun `rake test:regular_ui` and `rake `test:eyes_ui` separately / sequentially on the test machine, using lower `--parallel` number (esp for regular_ui) if needed
3. reach out to our saucelabs support or sales rep (see [slack](https://codedotorg.slack.com/archives/C0T0PNTM3/p1777475126805099?thread_ts=1777395009.251139&cid=C0T0PNTM3) for contact info)

if the DTT is slow (which it will likely be):
- consider looking at how long each test suite (eyes_ui + regular_ui) takes to pass, and rebalancing the parallelism between the two runs while still keeping  the total under 65.