### PR TITLE
Supplies the INFINITE_LOOP_TRAP to the normal blockly generator.

### DIFF
--- a/apps/src/maze/blocks.js
+++ b/apps/src/maze/blocks.js
@@ -440,6 +440,9 @@ exports.install = function (blockly, blockInstallOptions) {
     return 'while (' + argument + ') {\n' + branch + '}\n';
   };
 
+  // Inject the infinite loop trap into controls_repeat_ext
+  generator.INFINITE_LOOP_TRAP = INFINITE_LOOP_TRAP;
+
   blockly.Blocks.maze_untilBlockedOrNotClear.DIRECTIONS = [
     [msg.whileMsg() + ' ' + msg.pilePresent(), 'pilePresent'],
     [msg.whileMsg() + ' ' + msg.holePresent(), 'holePresent'],


### PR DESCRIPTION
The infinite loop traps only exist on custom blocks and not on the normal Blockly supplied loop. Meaning that a loop that uses a counter (`controls_repeat_ext`) will crash the page and cause a very nasty situation where the page loops endlessly and stalls the tab.

One affected level: https://studio.code.org/courses/express-2025/units/1/lessons/28/levels/8

This is the reproduction:

<img width="861" height="528" alt="image" src="https://github.com/user-attachments/assets/c04c2fb4-a7c0-4a33-8b58-87df12fbf661" />

This fix adds our `INFINITE_LOOP_TRAP` shim to the Blockly generator. They already do the same thing the same way as us, so all we have to do is tell the generator what shim we want. We could actually change all of our uses to use `generator.addLoopTrap()` to conform completely as a follow-up.

We would likely want to null out the INFINITE_LOOP_TRAP when the level switches, but we always do a page refresh in this legacy lab type, so it isn't necessarily right now to do anything more complicated. We already augment the blocks and generators without a reasonable way of reversing them for these levels so... C'est la vie.

## Links
<!-- Jira tickets, design docs, Slack threads, related PRs, etc. -->

- Jira: [SL-1690](https://codedotorg.atlassian.net/browse/SL-1690)

## Testing story
<!-- How was this tested? Manual steps, adhoc links, automated tests, or why testing isn't needed. -->

Manually reconstructed the repro and it failed immediately when I pressed run and allowed me to reset.