### PR TITLE
Backpack: display alerts as auto-dismissing toasts

### DIFF
--- a/apps/src/aichat/redux/slice.ts
+++ b/apps/src/aichat/redux/slice.ts
@@ -34,6 +34,7 @@ import {
   ChatMessage,
   isPendingOrCompletedChatMessage,
   CompletedChatMessage,
+  UploadStatus,
 } from '../types';
 
 import {AichatState} from './state';
@@ -295,23 +296,22 @@ const aichatSlice = createSlice({
       state,
       action: PayloadAction<{
         key: string;
-        status:
-          | 'uploaded'
-          | 'uploadFailed'
-          | 'sizeLimitExceeded'
-          | 'imageFileFlagged';
+        status: UploadStatus;
+        hideAlert?: boolean;
       }>
     ) {
-      const {key, status} = action.payload;
+      const {key, status, hideAlert} = action.payload;
       if (status === 'uploaded') {
         const fileIndex = state.stagedFiles.findIndex(file => file.key === key);
         if (fileIndex !== -1) {
           state.stagedFiles[fileIndex].status = 'uploaded';
         }
       } else {
-        // Remove from staged files and set alert
+        // Remove from staged files and set alert (unless hidden)
         state.stagedFiles = state.stagedFiles.filter(file => file.key !== key);
-        state.stagedFilesAlert = status;
+        if (!hideAlert) {
+          state.stagedFilesAlert = status;
+        }
       }
     },
     stagedFilesLimitExceeded(state) {

--- a/apps/src/aichat/redux/thunks/uploadFiles.ts
+++ b/apps/src/aichat/redux/thunks/uploadFiles.ts
@@ -5,11 +5,10 @@ import {moderateImage} from '@cdo/apps/util/moderateImage';
 import {createAppAsyncThunk} from '@cdo/apps/util/reduxHooks';
 
 import {MAX_FILE_SIZE_MB, MAX_NUM_FILES} from '../../constants';
-import {AssetSource, ChatAsset} from '../../types';
+import {AssetSource, ChatAsset, UploadStatus} from '../../types';
 import {
   addStagedFile,
   clearStagedFilesAlert,
-  removeStagedFile,
   stagedFilesLimitExceeded,
   stagedFileUploadFinished,
 } from '../slice';
@@ -21,12 +20,18 @@ export const uploadFiles = createAppAsyncThunk<
   {
     files: File[];
     buildAssetUrl: (asset: ChatAsset) => string;
-    /** Called instead of showing the in-chat flagged-file error when a file fails moderation. */
-    onFileFlagged?: (filename: string) => void;
+    /** Callback invoked when an upload finishes. If provided, the in-chat alert UI will be hidden for non-successful uploads. */
+    onUploadFinished?: (status: UploadStatus) => void;
   }
 >(
   'aichat/uploadFiles',
-  async ({files, buildAssetUrl, onFileFlagged}, {dispatch, getState}) => {
+  async ({files, buildAssetUrl, onUploadFinished}, {dispatch, getState}) => {
+    const notifyUploadFinished = (key: string, status: UploadStatus) => {
+      dispatch(
+        stagedFileUploadFinished({key, status, hideAlert: !!onUploadFinished})
+      );
+      onUploadFinished?.(status);
+    };
     const numStagedFiles = getState().aichat.stagedFiles.length;
     const numAllowedFiles = MAX_NUM_FILES - numStagedFiles;
 
@@ -60,12 +65,7 @@ export const uploadFiles = createAppAsyncThunk<
     for (const [key, asset, file] of allowedFiles) {
       if (file.size > MAX_FILE_SIZE_MB * 1024 * 1024) {
         sizeLimitExceededCount += 1;
-        dispatch(
-          stagedFileUploadFinished({
-            key,
-            status: 'sizeLimitExceeded',
-          })
-        );
+        notifyUploadFinished(key, 'sizeLimitExceeded');
         continue; // Skip uploading this file if it exceeds the size limit.
       }
 
@@ -75,15 +75,7 @@ export const uploadFiles = createAppAsyncThunk<
         const moderationResult = await moderateImage(file, 'aichat', {});
         if (moderationResult === 'flagged') {
           imageFlaggedCount += 1;
-          if (onFileFlagged) {
-            // Caller owns the error UI; remove the pending staged entry.
-            dispatch(removeStagedFile(key));
-            onFileFlagged(file.name);
-          } else {
-            dispatch(
-              stagedFileUploadFinished({key, status: 'imageFileFlagged'})
-            );
-          }
+          notifyUploadFinished(key, 'imageFileFlagged');
           continue;
         }
         fileCountImage += 1;
@@ -92,8 +84,7 @@ export const uploadFiles = createAppAsyncThunk<
       try {
         await HttpClient.put(buildAssetUrl(asset), file);
         uploadSuccessCount += 1;
-
-        dispatch(stagedFileUploadFinished({key, status: 'uploaded'}));
+        notifyUploadFinished(key, 'uploaded');
       } catch (error) {
         let status: 'sizeLimitExceeded' | 'uploadFailed' = 'uploadFailed';
         if (error instanceof NetworkError && error.response.status === 413) {
@@ -109,13 +100,7 @@ export const uploadFiles = createAppAsyncThunk<
               filename: file.name,
             });
         }
-
-        dispatch(
-          stagedFileUploadFinished({
-            key,
-            status,
-          })
-        );
+        notifyUploadFinished(key, status);
       }
     }
 

--- a/apps/src/aichat/types/assets.ts
+++ b/apps/src/aichat/types/assets.ts
@@ -9,3 +9,9 @@ export enum AssetSource {
   LEVEL = 'level',
   LEVEL_UUID = 'level_uuid',
 }
+
+export type UploadStatus =
+  | 'uploaded'
+  | 'uploadFailed'
+  | 'sizeLimitExceeded'
+  | 'imageFileFlagged';

--- a/apps/src/aichat/views/ChatWorkspace.tsx
+++ b/apps/src/aichat/views/ChatWorkspace.tsx
@@ -11,7 +11,6 @@ import React, {
   useImperativeHandle,
 } from 'react';
 
-import {isModelUpdate, WorkspaceTeacherViewTab} from '@cdo/apps/aichat/types';
 import {useAppDispatch, useAppSelector} from '@cdo/apps/util/reduxHooks';
 import usePrevious from '@cdo/apps/util/usePrevious';
 import {AiChatClientTypes} from '@cdo/generated-scripts/sharedConstants';
@@ -40,6 +39,9 @@ import {
   ChatAsset,
   ChatButtonAndKey,
   ModelParameters,
+  isModelUpdate,
+  UploadStatus,
+  WorkspaceTeacherViewTab,
 } from '../types';
 import {getAssetUrl, getShortName} from '../utils';
 
@@ -53,11 +55,13 @@ import moduleStyles from './chatWorkspace.module.scss';
 /** Handle for interacting with the Chat Workspace */
 export interface ChatWorkspaceHandle {
   /**
-   * Uploads files to the chat message. If `onFileFlagged` is provided it is
-   * called (instead of showing the in-chat error) when a file fails content
-   * moderation, letting the caller customize the error UI.
+   * Uploads files to the chat message.
+   * @param onUploadFinished Optional callback allowing callers to notify external components of the file status.
    */
-  addFiles: (files: File[], onFileFlagged?: (filename: string) => void) => void;
+  addFiles: (
+    files: File[],
+    onUploadFinished?: (status: UploadStatus) => void
+  ) => void;
 }
 
 interface ChatWorkspaceProps {
@@ -352,9 +356,9 @@ const ChatWorkspace = forwardRef<ChatWorkspaceHandle, ChatWorkspaceProps>(
     useImperativeHandle(
       ref,
       () => ({
-        addFiles: (files, onFileFlagged) => {
+        addFiles: (files, onUploadFinished) => {
           if (canUploadAssets) {
-            dispatch(uploadFiles({files, buildAssetUrl, onFileFlagged}));
+            dispatch(uploadFiles({files, buildAssetUrl, onUploadFinished}));
           }
         },
       }),

--- a/apps/src/aichatLab/views/AichatView.tsx
+++ b/apps/src/aichatLab/views/AichatView.tsx
@@ -309,15 +309,26 @@ const AichatView: React.FunctionComponent<LabProps<AichatLevelProperties>> = ({
       addFileHandler: async params => {
         const {fileName, getFile, notifySuccess, notifyError} = params;
         const file = await getFile();
-        chatWorkspaceRef.current?.addFiles([file], flaggedFilename =>
-          notifyError(
-            `${flaggedFilename} has been flagged by our content moderation policy and has not been added to your chat message.`
-          )
-        );
-        notifySuccess(
-          'new',
-          `${fileName} has been added to your chat message.`
-        );
+        chatWorkspaceRef.current?.addFiles([file], status => {
+          if (status === 'uploaded') {
+            notifySuccess(
+              'new',
+              `${fileName} has been added to your chat message.`
+            );
+          } else if (status === 'imageFileFlagged') {
+            notifyError(
+              `${fileName} has been flagged by our content moderation policy and has not been added to your chat message.`
+            );
+          } else if (status === 'sizeLimitExceeded') {
+            notifyError(
+              `${fileName} exceeds the maximum file size limit and has not been added to your chat message. Please try a smaller file.`
+            );
+          } else {
+            notifyError(
+              `There was an error uploading ${fileName}. Please try again.`
+            );
+          }
+        });
       },
       validateFileName: (fileName: string) => ({
         newFileName: fileName,

--- a/apps/src/lab2/views/components/Instructions/ResourcePanel/Backpack/BackpackPanel.tsx
+++ b/apps/src/lab2/views/components/Instructions/ResourcePanel/Backpack/BackpackPanel.tsx
@@ -1,7 +1,8 @@
 import Alert from '@code-dot-org/component-library/alert';
 import FontAwesomeV6Icon from '@code-dot-org/component-library/fontAwesomeV6Icon';
-import {Typography, Button as MuiButton} from '@mui/material';
+import {Typography, Button as MuiButton, Snackbar, Fade} from '@mui/material';
 import React, {useCallback, useEffect, useMemo, useState} from 'react';
+import {TransitionGroup} from 'react-transition-group';
 
 import Lab2Registry from '@cdo/apps/lab2/Lab2Registry';
 import {ProjectType} from '@cdo/apps/lab2/types';
@@ -30,8 +31,11 @@ interface BackpackPanelProps extends BackpackProps {
   ) => void;
 }
 
-type AlertConfig = {type: 'success' | 'danger'; message: string};
 const PRIMARY_BACKPACK_KEY = 'PRIMARY';
+
+type AlertConfig = {id: number; type: 'success' | 'danger'; message: string};
+const ALERT_AUTO_HIDE_MS = 3000;
+let nextAlertId = 0;
 
 const BackpackPanel: React.FC<BackpackPanelProps> = ({
   validateFileName,
@@ -110,12 +114,18 @@ const BackpackPanel: React.FC<BackpackPanelProps> = ({
     [primaryBackpackApi, secondaryBackpackApis]
   );
 
+  const removeAlert = useCallback((id: number) => {
+    setAlertList(prevAlerts => prevAlerts.filter(alert => alert.id !== id));
+  }, []);
+
   const addAlert = useCallback(
     (type: 'success' | 'danger', message: string) => {
-      setAlertList(prevAlerts => [...prevAlerts, {type, message}]);
+      const id = nextAlertId++;
+      setAlertList(prevAlerts => [...prevAlerts, {id, type, message}]);
       openPanelCallback();
+      setTimeout(() => removeAlert(id), ALERT_AUTO_HIDE_MS);
     },
-    [openPanelCallback]
+    [openPanelCallback, removeAlert]
   );
 
   useEffect(() => {
@@ -273,10 +283,7 @@ const BackpackPanel: React.FC<BackpackPanelProps> = ({
         key={fileName}
         fileName={fileName}
         backpackApi={backpackApi}
-        addAlert={(type, message) => {
-          setAlertList(prevAlerts => [...prevAlerts, {type, message}]);
-          openPanelCallback();
-        }}
+        addAlert={addAlert}
         validateFileName={validateFileName}
         saveFileToProject={saveFileToProject}
         createNewProjectFile={createNewProjectFile}
@@ -295,20 +302,27 @@ const BackpackPanel: React.FC<BackpackPanelProps> = ({
 
   return (
     <div className={moduleStyles.backpackPanelWithFiles}>
+      <Snackbar
+        open
+        slots={{transition: React.Fragment}}
+        className={moduleStyles.alertContainer}
+      >
+        <TransitionGroup className={moduleStyles.alertList}>
+          {alertList.map(({id, type, message}) => (
+            <Fade key={id} mountOnEnter unmountOnExit>
+              <div>
+                <Alert
+                  type={type}
+                  text={message}
+                  size="s"
+                  onClose={() => removeAlert(id)}
+                />
+              </div>
+            </Fade>
+          ))}
+        </TransitionGroup>
+      </Snackbar>
       <div className={moduleStyles.fileListContainer}>
-        {alertList.map((alert, index) => (
-          <Alert
-            type={alert.type}
-            text={alert.message}
-            key={index}
-            size="s"
-            onClose={() => {
-              const newList = [...alertList];
-              newList.splice(index, 1);
-              setAlertList(newList);
-            }}
-          />
-        ))}
         {isBackpackEmpty && (
           <BackpackMessage
             type="neutral"

--- a/apps/src/lab2/views/components/Instructions/ResourcePanel/Backpack/backpack-panel.module.scss
+++ b/apps/src/lab2/views/components/Instructions/ResourcePanel/Backpack/backpack-panel.module.scss
@@ -25,7 +25,7 @@
   gap: 8px;
 
   > * {
-    box-shadow: 0 2px 2px 0 rgba(0 0 0 0.07), 0 4px 7px 0 rgba(0 0 0 0.07);
+    box-shadow: 0 2px 2px 0 rgb(0 0 0 / 0.07), 0 4px 7px 0 rgb(0 0 0 / 0.07);
   }
 }
 

--- a/apps/src/lab2/views/components/Instructions/ResourcePanel/Backpack/backpack-panel.module.scss
+++ b/apps/src/lab2/views/components/Instructions/ResourcePanel/Backpack/backpack-panel.module.scss
@@ -1,4 +1,5 @@
 .backpackPanelWithFiles {
+  position: relative;
   display: flex;
   padding: var(--padding-p-xxs, 8px);
   flex-direction: column;
@@ -9,6 +10,23 @@
   overflow-y: auto;
   overflow-x: hidden;
   box-sizing: border-box;
+}
+
+.alertContainer {
+  left: 8px;
+  right: 8px;
+  bottom: 8px;
+  position: absolute;
+}
+
+.alertList {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+
+  > * {
+    box-shadow: 0 2px 2px 0 rgba(0 0 0 0.07), 0 4px 7px 0 rgba(0 0 0 0.07);
+  }
 }
 
 .fileListContainer {


### PR DESCRIPTION
Displays the backpack alerts as auto-dismissing toasts so they're always visible even when the backpack list goes beyond the window height.


https://github.com/user-attachments/assets/376f70de-836f-4e78-826e-339293e12f17

Alert in weblab2:

<img width="1512" height="947" alt="Screenshot 2026-04-30 at 11 50 26 AM" src="https://github.com/user-attachments/assets/268cf686-292e-499e-babf-1578327f2cd4" />

## Links
https://codedotorg.slack.com/archives/C03DBDN67B7/p1777416678480789

## Testing story
Tested with AI Chat Lab and Weblab2
