### PR TITLE
feat(metrics): gate browser-events egress in MetricsReporter via DCDO

### DIFF
--- a/apps/src/metrics/MetricsReporter.ts
+++ b/apps/src/metrics/MetricsReporter.ts
@@ -148,6 +148,10 @@ class MetricsReporter {
       return;
     }
 
+    if (!DCDO.get('browser-events-enabled', true)) {
+      return;
+    }
+
     try {
       await this.metricsApi.sendLogs([payload]);
     } catch (error) {
@@ -187,6 +191,10 @@ class MetricsReporter {
   private async sendMetrics(metrics: MetricDatum[]) {
     if (!this.isReportingEnabled()) {
       this.fallbackLog(metrics);
+      return;
+    }
+
+    if (!DCDO.get('browser-events-enabled', true)) {
       return;
     }
 

--- a/apps/test/unit/metrics/MetricsReporterTest.ts
+++ b/apps/test/unit/metrics/MetricsReporterTest.ts
@@ -1,0 +1,101 @@
+import * as Observability from '@code-dot-org/core/plugins/observability';
+
+import DCDO from '@cdo/apps/dcdo';
+import DashboardMetricsApi from '@cdo/apps/metrics/DashboardMetricsApi';
+import {MetricsApi} from '@cdo/apps/metrics/MetricsApi';
+import MetricsReporter from '@cdo/apps/metrics/MetricsReporter';
+
+jest.mock('@code-dot-org/core/plugins/observability', () => ({
+  logger: {info: jest.fn(), warn: jest.fn(), error: jest.fn()},
+  metrics: {count: jest.fn()},
+}));
+
+jest.mock('@cdo/apps/dcdo', () => ({
+  __esModule: true,
+  default: {get: jest.fn()},
+}));
+
+/**
+ * isDevelopmentEnvironment uses window.location.hostname ('localhost' in jsdom),
+ * which causes shouldReport() to return false and skip all gate logic. Mock to
+ * false so tests reach the browser-events-enabled gate code paths.
+ */
+jest.mock('@cdo/apps/utils', () => ({
+  isDevelopmentEnvironment: jest.fn().mockReturnValue(false),
+}));
+
+jest.mock('@cdo/apps/util/browser-detector', () => ({
+  getBrowserName: jest.fn().mockReturnValue('Chrome'),
+}));
+
+jest.mock('@cdo/apps/metrics/DashboardMetricsApi', () => ({
+  __esModule: true,
+  default: jest.fn().mockReturnValue({
+    sendLogs: jest.fn().mockResolvedValue(null),
+    sendMetricData: jest.fn().mockResolvedValue(null),
+  }),
+}));
+
+/** The mock api instance wired into the MetricsReporter singleton at module init. */
+const mockApi = (DashboardMetricsApi as jest.Mock).mock.results[0]
+  .value as jest.Mocked<MetricsApi>;
+
+describe('MetricsReporter', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    localStorage.clear();
+  });
+
+  describe('browser-events-enabled gate', () => {
+    it('calls sendLogs when gate is true (log path)', () => {
+      (DCDO.get as jest.Mock).mockReturnValue(true);
+      MetricsReporter.logInfo('hello');
+      expect(mockApi.sendLogs).toHaveBeenCalledTimes(1);
+    });
+
+    it('suppresses sendLogs and does not mutate localStorage when gate is false (log path)', () => {
+      (DCDO.get as jest.Mock).mockReturnValue(false);
+      MetricsReporter.logInfo('hello');
+      expect(mockApi.sendLogs).not.toHaveBeenCalled();
+      expect(
+        localStorage.getItem('cdo-metrics-reporter-last-check-time')
+      ).toBeNull();
+    });
+
+    it('calls sendMetricData when gate is true (metric path)', () => {
+      (DCDO.get as jest.Mock).mockReturnValue(true);
+      MetricsReporter.publishMetric('M', 1, 'Count');
+      expect(mockApi.sendMetricData).toHaveBeenCalledTimes(1);
+    });
+
+    it('suppresses sendMetricData when gate is false (metric path)', () => {
+      (DCDO.get as jest.Mock).mockReturnValue(false);
+      MetricsReporter.publishMetric('M', 1, 'Count');
+      expect(mockApi.sendMetricData).not.toHaveBeenCalled();
+    });
+
+    it('sends to the observability logger and suppresses sendLogs when Sentry is on and gate is off', () => {
+      (DCDO.get as jest.Mock).mockImplementation(
+        (key: string, defaultValue: unknown) => {
+          if (key === 'frontend-observability-enabled') return true;
+          if (key === 'browser-events-enabled') return false;
+          return defaultValue;
+        }
+      );
+      MetricsReporter.logError('boom');
+      expect(Observability.logger.error).toHaveBeenCalledWith(
+        'boom',
+        expect.any(Object)
+      );
+      expect(mockApi.sendLogs).not.toHaveBeenCalled();
+    });
+
+    it('invokes sendLogs when browser-events-enabled is unset (defaults to true)', () => {
+      (DCDO.get as jest.Mock).mockImplementation(
+        (_key: string, defaultValue: unknown) => defaultValue
+      );
+      MetricsReporter.logInfo('hello');
+      expect(mockApi.sendLogs).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/lib/dynamic_config/dcdo.rb
+++ b/lib/dynamic_config/dcdo.rb
@@ -70,6 +70,7 @@ class DCDOBase < DynamicConfigBase
       'ai-gateway-enabled': DCDO.get('ai-gateway-enabled', true),
       'frontend-observability-enabled': DCDO.get('frontend-observability-enabled', false),
       'frontend-newrelic-enabled': DCDO.get('frontend-newrelic-enabled', true),
+      'browser-events-enabled': DCDO.get('browser-events-enabled', true),
       'onboarding-enabled': DCDO.get('onboarding-enabled', false),
       'ai-diff-drawer': DCDO.get('ai-diff-drawer', false),
       'language-deprecation-warning-enabled': DCDO.get('language-deprecation-warning-enabled', false),


### PR DESCRIPTION
Add a runtime DCDO gate `browser-events-enabled` over the client-side egress to `BrowserEventsController`,
so we can wind down the legacy browser-events pipeline (MetricsReporter →
DashboardMetricsApi → Rails → CloudWatch) by flipping a flag rather than
shipping code. 

## Why

We are migrating frontend metrics and logs to Sentry (via
`@code-dot-org/core/plugins/observability`) so we can retire the custom
browser-events pipeline that today terminates at `BrowserEventsController`
(`POST /browser_events/put_logs`, `POST /browser_events/put_metric_data`).

This PR adds a client-side switch so calls never leave the page
when the gate is off, enabling a no-deploy cutover once Sentry is verified
to cover the use cases we still care about.

## What changed

- **DCDO key `browser-events-enabled`** (default `true`). Default-true makes
  the deploy a no-op and the cutover a DCDO flip.
- **`apps/src/metrics/MetricsReporter.ts`**: two short-circuits, one in
  `log()` and one in `sendMetrics()`, each placed after the existing
  `isReportingEnabled()` 401-backoff check and immediately before the
  `await this.metricsApi.send*(...)` call. When the gate is off: no network
  call, no fallback log, no 401-backoff state mutation.
- **`lib/dynamic_config/dcdo.rb`**: published `browser-events-enabled`
  through `DCDOBase#frontend_config` (grouped with
  `frontend-observability-enabled`) so `apps/src/dcdo.js` can read it.
- **`apps/test/unit/metrics/MetricsReporterTest.ts`** (new): six tests
  covering gate true/false × log/metric paths, the orthogonality scenario
  (Sentry on + gate off), and the default-when-unset scenario.

No change to `BrowserEventsController`, its routes, or its existing
server-side `Gatekeeper`/`DCDO` precondition. The two gates are independent
and orthogonal — operators are expected to enable observability first,
verify Sentry ingestion, then flip `browser-events-enabled=false`.

## Egress flow

```mermaid
flowchart TD
    A[Caller: logError / publishMetric] --> B[MetricsReporter]
    B --> C{frontend-observability-enabled?}
    C -->|true| D[Observability.logger / metrics.count<br/>Sentry]
    C -->|false| E[isReportingEnabled?<br/>401-backoff]
    D --> E
    E -->|false| F[fallbackLog &amp; return]
    E -->|true| G{browser-events-enabled?<br/>default true}
    G -->|true| H[DashboardMetricsApi.sendLogs / sendMetricData]
    G -->|false| I[return — no network call]
    H --> J[POST /browser_events/*<br/>BrowserEventsController]
```

## Testing story

Verified on Adhoc.