### PR TITLE
Sketch2: bring to back/bring to front

### DIFF
--- a/apps/package.json
+++ b/apps/package.json
@@ -271,7 +271,7 @@
     "@xterm/addon-fit": "^0.10.0",
     "@xterm/addon-image": "^0.8.0",
     "@xterm/xterm": "^5.5.0",
-    "@xyflow/react": "^12.8.1",
+    "@xyflow/react": "^12.10.2",
     "ai": "^6.0.73",
     "aws-sdk": "2.1231.0",
     "blockly": "12.4.1",

--- a/apps/src/sketchlab/reactFlow/components/ReactFlowCanvas.tsx
+++ b/apps/src/sketchlab/reactFlow/components/ReactFlowCanvas.tsx
@@ -562,6 +562,7 @@ export default function ReactFlowCanvas({
             // it manages things like moving nodes with arrow keys.
             disableKeyboardA11y={false}
             autoPanOnNodeFocus={false} // We manage viewport on focus manually in useFocusManagement.
+            zIndexMode={'manual'}
           >
             {openLineEdge && (
               <LineEdgeToolbar

--- a/apps/src/sketchlab/reactFlow/components/ReactFlowCanvas.tsx
+++ b/apps/src/sketchlab/reactFlow/components/ReactFlowCanvas.tsx
@@ -75,6 +75,14 @@ const NODE_TYPES = {
 const NEW_NODE_STAGGER_PX = 20;
 const FOCUS_DELAY_MS = 100;
 
+function stripDisplayFields<T extends object>(item: T): T {
+  const result = {...item} as Record<string, unknown>;
+  delete result.domAttributes;
+  delete result.className;
+  delete result.selected;
+  return result as T;
+}
+
 export interface ReactFlowCanvasProps {
   updateSources: ReturnType<
     typeof useSources<ReactFlowSketchLabSources>
@@ -301,7 +309,18 @@ export default function ReactFlowCanvas({
       clearTimeout(saveTimerRef.current);
     }
     saveTimerRef.current = setTimeout(() => {
-      const source: SketchlabReactFlowSource = {nodes, edges, viewport};
+      // updateNode/updateEdge from useReactFlow round-trip through the
+      // store, which mirrors the displayNodes/displayEdges we render.
+      // That spreads display-only fields (domAttributes — including the
+      // onMouseDown closure on line edges — className, selected) back
+      // into our canonical state. Strip them before persisting so
+      // structuredClone of the source on reload doesn't choke on the
+      // function.
+      const source: SketchlabReactFlowSource = {
+        nodes: nodes.map(stripDisplayFields) as SketchlabReactFlowNode[],
+        edges: edges.map(stripDisplayFields) as SketchlabReactFlowEdge[],
+        viewport,
+      };
       updateSources(prev => ({...prev, source}));
     }, SAVE_DEBOUNCE_MS);
 

--- a/apps/src/sketchlab/reactFlow/components/ReactFlowCanvas.tsx
+++ b/apps/src/sketchlab/reactFlow/components/ReactFlowCanvas.tsx
@@ -309,13 +309,10 @@ export default function ReactFlowCanvas({
       clearTimeout(saveTimerRef.current);
     }
     saveTimerRef.current = setTimeout(() => {
-      // updateNode/updateEdge from useReactFlow round-trip through the
+      // updateNode/updateEdge from useReactFlow round-trips through React Flow's internal
       // store, which mirrors the displayNodes/displayEdges we render.
-      // That spreads display-only fields (domAttributes — including the
-      // onMouseDown closure on line edges — className, selected) back
-      // into our canonical state. Strip them before persisting so
-      // structuredClone of the source on reload doesn't choke on the
-      // function.
+      // That spreads display-only fields (including domAttributes, which can include a function)
+      // back into our state, which can then fail to clone. Strip them before persisting.
       const source: SketchlabReactFlowSource = {
         nodes: nodes.map(stripDisplayFields) as SketchlabReactFlowNode[],
         edges: edges.map(stripDisplayFields) as SketchlabReactFlowEdge[],

--- a/apps/src/sketchlab/reactFlow/elementToolbars/ActionsGroup.tsx
+++ b/apps/src/sketchlab/reactFlow/elementToolbars/ActionsGroup.tsx
@@ -63,7 +63,7 @@ export default function ActionsGroup({
               aria-label="Bring to front"
               onClick={onBringToFront}
             >
-              <FontAwesomeV6Icon iconName="arrow-up-to-line" />
+              <FontAwesomeV6Icon iconName="bring-front" />
             </IconButton>
           </Tooltip>
         )}
@@ -75,7 +75,7 @@ export default function ActionsGroup({
               aria-label="Send to back"
               onClick={onSendToBack}
             >
-              <FontAwesomeV6Icon iconName="arrow-down-to-line" />
+              <FontAwesomeV6Icon iconName="send-back" />
             </IconButton>
           </Tooltip>
         )}

--- a/apps/src/sketchlab/reactFlow/elementToolbars/ActionsGroup.tsx
+++ b/apps/src/sketchlab/reactFlow/elementToolbars/ActionsGroup.tsx
@@ -9,9 +9,16 @@ import styles from './element-toolbar.module.scss';
 interface ActionsGroupProps {
   onDelete?: () => void;
   onLock?: () => void;
+  onBringToFront?: () => void;
+  onSendToBack?: () => void;
 }
 
-export default function ActionsGroup({onDelete, onLock}: ActionsGroupProps) {
+export default function ActionsGroup({
+  onDelete,
+  onLock,
+  onBringToFront,
+  onSendToBack,
+}: ActionsGroupProps) {
   const isStartMode = getIsStartMode();
 
   return (
@@ -45,6 +52,30 @@ export default function ActionsGroup({onDelete, onLock}: ActionsGroupProps) {
               onClick={onLock}
             >
               <FontAwesomeV6Icon iconName="lock" />
+            </IconButton>
+          </Tooltip>
+        )}
+        {onBringToFront && (
+          <Tooltip title="Bring to front" placement="top">
+            <IconButton
+              size="small"
+              className={styles.fontSizeButton}
+              aria-label="Bring to front"
+              onClick={onBringToFront}
+            >
+              <FontAwesomeV6Icon iconName="arrow-up-to-line" />
+            </IconButton>
+          </Tooltip>
+        )}
+        {onSendToBack && (
+          <Tooltip title="Send to back" placement="top">
+            <IconButton
+              size="small"
+              className={styles.fontSizeButton}
+              aria-label="Send to back"
+              onClick={onSendToBack}
+            >
+              <FontAwesomeV6Icon iconName="arrow-down-to-line" />
             </IconButton>
           </Tooltip>
         )}

--- a/apps/src/sketchlab/reactFlow/elementToolbars/ImageNodeToolbar.tsx
+++ b/apps/src/sketchlab/reactFlow/elementToolbars/ImageNodeToolbar.tsx
@@ -1,13 +1,11 @@
-import {useReactFlow} from '@xyflow/react';
 import React from 'react';
 
 import {DEFAULT_ROTATION} from '../constants';
 import {ImageNodeType} from '../types';
-import {nextBackZIndex, nextFrontZIndex} from '../utils/stacking';
 
-import ActionsGroup from './ActionsGroup';
 import HandleVisibilityToggle from './HandleVisibilityToggle';
 import LockedNotice from './LockedNotice';
+import NodeActionsGroup from './NodeActionsGroup';
 import RotationGroup from './RotationGroup';
 import ToolbarShell from './ToolbarShell';
 import {useNodeToolbarData} from './useNodeToolbarData';
@@ -17,7 +15,6 @@ interface ImageNodeToolbarProps {
 }
 
 export default function ImageNodeToolbar({nodeId}: ImageNodeToolbarProps) {
-  const {deleteElements, updateNode, getNodes, getEdges} = useReactFlow();
   const {data, patchNodeData} = useNodeToolbarData<ImageNodeType>(nodeId);
   const handlesVisible = data.showHandles !== false;
 
@@ -35,18 +32,7 @@ export default function ImageNodeToolbar({nodeId}: ImageNodeToolbarProps) {
             value={data.rotation ?? DEFAULT_ROTATION}
             onChange={degrees => patchNodeData({rotation: degrees})}
           />
-          <ActionsGroup
-            onDelete={() => deleteElements({nodes: [{id: nodeId}]})}
-            onLock={() => patchNodeData({locked: true})}
-            onBringToFront={() => {
-              const items = [...getNodes(), ...getEdges()];
-              updateNode(nodeId, {zIndex: nextFrontZIndex(items, nodeId)});
-            }}
-            onSendToBack={() => {
-              const items = [...getNodes(), ...getEdges()];
-              updateNode(nodeId, {zIndex: nextBackZIndex(items, nodeId)});
-            }}
-          />
+          <NodeActionsGroup nodeId={nodeId} />
           <HandleVisibilityToggle
             visible={handlesVisible}
             onToggle={() => patchNodeData({showHandles: !handlesVisible})}

--- a/apps/src/sketchlab/reactFlow/elementToolbars/ImageNodeToolbar.tsx
+++ b/apps/src/sketchlab/reactFlow/elementToolbars/ImageNodeToolbar.tsx
@@ -17,7 +17,7 @@ interface ImageNodeToolbarProps {
 }
 
 export default function ImageNodeToolbar({nodeId}: ImageNodeToolbarProps) {
-  const {deleteElements, updateNode, getNodes} = useReactFlow();
+  const {deleteElements, updateNode, getNodes, getEdges} = useReactFlow();
   const {data, patchNodeData} = useNodeToolbarData<ImageNodeType>(nodeId);
   const handlesVisible = data.showHandles !== false;
 
@@ -39,10 +39,14 @@ export default function ImageNodeToolbar({nodeId}: ImageNodeToolbarProps) {
             onDelete={() => deleteElements({nodes: [{id: nodeId}]})}
             onLock={() => patchNodeData({locked: true})}
             onBringToFront={() =>
-              updateNode(nodeId, {zIndex: nextFrontZIndex(getNodes())})
+              updateNode(nodeId, {
+                zIndex: nextFrontZIndex([...getNodes(), ...getEdges()]),
+              })
             }
             onSendToBack={() =>
-              updateNode(nodeId, {zIndex: nextBackZIndex(getNodes())})
+              updateNode(nodeId, {
+                zIndex: nextBackZIndex([...getNodes(), ...getEdges()]),
+              })
             }
           />
           <HandleVisibilityToggle

--- a/apps/src/sketchlab/reactFlow/elementToolbars/ImageNodeToolbar.tsx
+++ b/apps/src/sketchlab/reactFlow/elementToolbars/ImageNodeToolbar.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 
 import {DEFAULT_ROTATION} from '../constants';
 import {ImageNodeType} from '../types';
+import {moveToEnd, moveToStart} from '../utils/stacking';
 
 import ActionsGroup from './ActionsGroup';
 import HandleVisibilityToggle from './HandleVisibilityToggle';
@@ -16,7 +17,7 @@ interface ImageNodeToolbarProps {
 }
 
 export default function ImageNodeToolbar({nodeId}: ImageNodeToolbarProps) {
-  const {deleteElements} = useReactFlow();
+  const {deleteElements, setNodes} = useReactFlow();
   const {data, patchNodeData} = useNodeToolbarData<ImageNodeType>(nodeId);
   const handlesVisible = data.showHandles !== false;
 
@@ -37,6 +38,12 @@ export default function ImageNodeToolbar({nodeId}: ImageNodeToolbarProps) {
           <ActionsGroup
             onDelete={() => deleteElements({nodes: [{id: nodeId}]})}
             onLock={() => patchNodeData({locked: true})}
+            onBringToFront={() =>
+              setNodes(current => moveToEnd(current, nodeId))
+            }
+            onSendToBack={() =>
+              setNodes(current => moveToStart(current, nodeId))
+            }
           />
           <HandleVisibilityToggle
             visible={handlesVisible}

--- a/apps/src/sketchlab/reactFlow/elementToolbars/ImageNodeToolbar.tsx
+++ b/apps/src/sketchlab/reactFlow/elementToolbars/ImageNodeToolbar.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 
 import {DEFAULT_ROTATION} from '../constants';
 import {ImageNodeType} from '../types';
-import {moveToEnd, moveToStart} from '../utils/stacking';
+import {nextBackZIndex, nextFrontZIndex} from '../utils/stacking';
 
 import ActionsGroup from './ActionsGroup';
 import HandleVisibilityToggle from './HandleVisibilityToggle';
@@ -17,7 +17,7 @@ interface ImageNodeToolbarProps {
 }
 
 export default function ImageNodeToolbar({nodeId}: ImageNodeToolbarProps) {
-  const {deleteElements, setNodes} = useReactFlow();
+  const {deleteElements, updateNode, getNodes} = useReactFlow();
   const {data, patchNodeData} = useNodeToolbarData<ImageNodeType>(nodeId);
   const handlesVisible = data.showHandles !== false;
 
@@ -39,10 +39,10 @@ export default function ImageNodeToolbar({nodeId}: ImageNodeToolbarProps) {
             onDelete={() => deleteElements({nodes: [{id: nodeId}]})}
             onLock={() => patchNodeData({locked: true})}
             onBringToFront={() =>
-              setNodes(current => moveToEnd(current, nodeId))
+              updateNode(nodeId, {zIndex: nextFrontZIndex(getNodes())})
             }
             onSendToBack={() =>
-              setNodes(current => moveToStart(current, nodeId))
+              updateNode(nodeId, {zIndex: nextBackZIndex(getNodes())})
             }
           />
           <HandleVisibilityToggle

--- a/apps/src/sketchlab/reactFlow/elementToolbars/ImageNodeToolbar.tsx
+++ b/apps/src/sketchlab/reactFlow/elementToolbars/ImageNodeToolbar.tsx
@@ -38,16 +38,14 @@ export default function ImageNodeToolbar({nodeId}: ImageNodeToolbarProps) {
           <ActionsGroup
             onDelete={() => deleteElements({nodes: [{id: nodeId}]})}
             onLock={() => patchNodeData({locked: true})}
-            onBringToFront={() =>
-              updateNode(nodeId, {
-                zIndex: nextFrontZIndex([...getNodes(), ...getEdges()]),
-              })
-            }
-            onSendToBack={() =>
-              updateNode(nodeId, {
-                zIndex: nextBackZIndex([...getNodes(), ...getEdges()]),
-              })
-            }
+            onBringToFront={() => {
+              const items = [...getNodes(), ...getEdges()];
+              updateNode(nodeId, {zIndex: nextFrontZIndex(items, nodeId)});
+            }}
+            onSendToBack={() => {
+              const items = [...getNodes(), ...getEdges()];
+              updateNode(nodeId, {zIndex: nextBackZIndex(items, nodeId)});
+            }}
           />
           <HandleVisibilityToggle
             visible={handlesVisible}

--- a/apps/src/sketchlab/reactFlow/elementToolbars/LineEdgeToolbar.tsx
+++ b/apps/src/sketchlab/reactFlow/elementToolbars/LineEdgeToolbar.tsx
@@ -114,7 +114,7 @@ export default function LineEdgeToolbar({
   onSelectStrokeStyle,
   onSelectArrowHeads,
 }: LineEdgeToolbarProps) {
-  const {deleteElements, updateEdge, getEdges} = useReactFlow();
+  const {deleteElements, updateEdge, getNodes, getEdges} = useReactFlow();
   const selectedValue =
     (typeof edge.style?.stroke === 'string' && edge.style.stroke) ||
     DEFAULT_STROKE_COLOR;
@@ -204,10 +204,14 @@ export default function LineEdgeToolbar({
       <ActionsGroup
         onDelete={() => deleteElements({edges: [{id: edge.id}]})}
         onBringToFront={() =>
-          updateEdge(edge.id, {zIndex: nextFrontZIndex(getEdges())})
+          updateEdge(edge.id, {
+            zIndex: nextFrontZIndex([...getNodes(), ...getEdges()]),
+          })
         }
         onSendToBack={() =>
-          updateEdge(edge.id, {zIndex: nextBackZIndex(getEdges())})
+          updateEdge(edge.id, {
+            zIndex: nextBackZIndex([...getNodes(), ...getEdges()]),
+          })
         }
       />
     </ToolbarShell>

--- a/apps/src/sketchlab/reactFlow/elementToolbars/LineEdgeToolbar.tsx
+++ b/apps/src/sketchlab/reactFlow/elementToolbars/LineEdgeToolbar.tsx
@@ -203,16 +203,14 @@ export default function LineEdgeToolbar({
       )}
       <ActionsGroup
         onDelete={() => deleteElements({edges: [{id: edge.id}]})}
-        onBringToFront={() =>
-          updateEdge(edge.id, {
-            zIndex: nextFrontZIndex([...getNodes(), ...getEdges()]),
-          })
-        }
-        onSendToBack={() =>
-          updateEdge(edge.id, {
-            zIndex: nextBackZIndex([...getNodes(), ...getEdges()]),
-          })
-        }
+        onBringToFront={() => {
+          const items = [...getNodes(), ...getEdges()];
+          updateEdge(edge.id, {zIndex: nextFrontZIndex(items, edge.id)});
+        }}
+        onSendToBack={() => {
+          const items = [...getNodes(), ...getEdges()];
+          updateEdge(edge.id, {zIndex: nextBackZIndex(items, edge.id)});
+        }}
       />
     </ToolbarShell>
   );

--- a/apps/src/sketchlab/reactFlow/elementToolbars/LineEdgeToolbar.tsx
+++ b/apps/src/sketchlab/reactFlow/elementToolbars/LineEdgeToolbar.tsx
@@ -7,7 +7,7 @@ import React from 'react';
 import {SketchlabReactFlowEdge} from '@cdo/apps/lab2/types';
 
 import {isArrowEdge} from '../utils/lineEdges';
-import {moveToEnd, moveToStart} from '../utils/stacking';
+import {nextBackZIndex, nextFrontZIndex} from '../utils/stacking';
 
 import ActionsGroup from './ActionsGroup';
 import SwatchGroup from './SwatchGroup';
@@ -114,7 +114,7 @@ export default function LineEdgeToolbar({
   onSelectStrokeStyle,
   onSelectArrowHeads,
 }: LineEdgeToolbarProps) {
-  const {deleteElements, setEdges} = useReactFlow();
+  const {deleteElements, updateEdge, getEdges} = useReactFlow();
   const selectedValue =
     (typeof edge.style?.stroke === 'string' && edge.style.stroke) ||
     DEFAULT_STROKE_COLOR;
@@ -203,8 +203,12 @@ export default function LineEdgeToolbar({
       )}
       <ActionsGroup
         onDelete={() => deleteElements({edges: [{id: edge.id}]})}
-        onBringToFront={() => setEdges(current => moveToEnd(current, edge.id))}
-        onSendToBack={() => setEdges(current => moveToStart(current, edge.id))}
+        onBringToFront={() =>
+          updateEdge(edge.id, {zIndex: nextFrontZIndex(getEdges())})
+        }
+        onSendToBack={() =>
+          updateEdge(edge.id, {zIndex: nextBackZIndex(getEdges())})
+        }
       />
     </ToolbarShell>
   );

--- a/apps/src/sketchlab/reactFlow/elementToolbars/LineEdgeToolbar.tsx
+++ b/apps/src/sketchlab/reactFlow/elementToolbars/LineEdgeToolbar.tsx
@@ -7,7 +7,7 @@ import React from 'react';
 import {SketchlabReactFlowEdge} from '@cdo/apps/lab2/types';
 
 import {isArrowEdge} from '../utils/lineEdges';
-import {nextBackZIndex, nextFrontZIndex} from '../utils/stacking';
+import {newBackZIndex, newFrontZIndex} from '../utils/stacking';
 
 import ActionsGroup from './ActionsGroup';
 import SwatchGroup from './SwatchGroup';
@@ -205,11 +205,11 @@ export default function LineEdgeToolbar({
         onDelete={() => deleteElements({edges: [{id: edge.id}]})}
         onBringToFront={() => {
           const items = [...getNodes(), ...getEdges()];
-          updateEdge(edge.id, {zIndex: nextFrontZIndex(items, edge.id)});
+          updateEdge(edge.id, {zIndex: newFrontZIndex(items, edge.id)});
         }}
         onSendToBack={() => {
           const items = [...getNodes(), ...getEdges()];
-          updateEdge(edge.id, {zIndex: nextBackZIndex(items, edge.id)});
+          updateEdge(edge.id, {zIndex: newBackZIndex(items, edge.id)});
         }}
       />
     </ToolbarShell>

--- a/apps/src/sketchlab/reactFlow/elementToolbars/LineEdgeToolbar.tsx
+++ b/apps/src/sketchlab/reactFlow/elementToolbars/LineEdgeToolbar.tsx
@@ -7,6 +7,7 @@ import React from 'react';
 import {SketchlabReactFlowEdge} from '@cdo/apps/lab2/types';
 
 import {isArrowEdge} from '../utils/lineEdges';
+import {moveToEnd, moveToStart} from '../utils/stacking';
 
 import ActionsGroup from './ActionsGroup';
 import SwatchGroup from './SwatchGroup';
@@ -113,7 +114,7 @@ export default function LineEdgeToolbar({
   onSelectStrokeStyle,
   onSelectArrowHeads,
 }: LineEdgeToolbarProps) {
-  const {deleteElements} = useReactFlow();
+  const {deleteElements, setEdges} = useReactFlow();
   const selectedValue =
     (typeof edge.style?.stroke === 'string' && edge.style.stroke) ||
     DEFAULT_STROKE_COLOR;
@@ -200,7 +201,11 @@ export default function LineEdgeToolbar({
           )}
         />
       )}
-      <ActionsGroup onDelete={() => deleteElements({edges: [{id: edge.id}]})} />
+      <ActionsGroup
+        onDelete={() => deleteElements({edges: [{id: edge.id}]})}
+        onBringToFront={() => setEdges(current => moveToEnd(current, edge.id))}
+        onSendToBack={() => setEdges(current => moveToStart(current, edge.id))}
+      />
     </ToolbarShell>
   );
 }

--- a/apps/src/sketchlab/reactFlow/elementToolbars/NodeActionsGroup.tsx
+++ b/apps/src/sketchlab/reactFlow/elementToolbars/NodeActionsGroup.tsx
@@ -1,7 +1,7 @@
 import {useReactFlow} from '@xyflow/react';
 import React from 'react';
 
-import {nextBackZIndex, nextFrontZIndex} from '../utils/stacking';
+import {newBackZIndex, newFrontZIndex} from '../utils/stacking';
 
 import ActionsGroup from './ActionsGroup';
 
@@ -18,11 +18,11 @@ export default function NodeActionsGroup({nodeId}: NodeActionsGroupProps) {
       onLock={() => updateNodeData(nodeId, {locked: true})}
       onBringToFront={() => {
         const items = [...getNodes(), ...getEdges()];
-        updateNode(nodeId, {zIndex: nextFrontZIndex(items, nodeId)});
+        updateNode(nodeId, {zIndex: newFrontZIndex(items, nodeId)});
       }}
       onSendToBack={() => {
         const items = [...getNodes(), ...getEdges()];
-        updateNode(nodeId, {zIndex: nextBackZIndex(items, nodeId)});
+        updateNode(nodeId, {zIndex: newBackZIndex(items, nodeId)});
       }}
     />
   );

--- a/apps/src/sketchlab/reactFlow/elementToolbars/NodeActionsGroup.tsx
+++ b/apps/src/sketchlab/reactFlow/elementToolbars/NodeActionsGroup.tsx
@@ -1,0 +1,29 @@
+import {useReactFlow} from '@xyflow/react';
+import React from 'react';
+
+import {nextBackZIndex, nextFrontZIndex} from '../utils/stacking';
+
+import ActionsGroup from './ActionsGroup';
+
+interface NodeActionsGroupProps {
+  nodeId: string;
+}
+
+export default function NodeActionsGroup({nodeId}: NodeActionsGroupProps) {
+  const {deleteElements, updateNode, updateNodeData, getNodes, getEdges} =
+    useReactFlow();
+  return (
+    <ActionsGroup
+      onDelete={() => deleteElements({nodes: [{id: nodeId}]})}
+      onLock={() => updateNodeData(nodeId, {locked: true})}
+      onBringToFront={() => {
+        const items = [...getNodes(), ...getEdges()];
+        updateNode(nodeId, {zIndex: nextFrontZIndex(items, nodeId)});
+      }}
+      onSendToBack={() => {
+        const items = [...getNodes(), ...getEdges()];
+        updateNode(nodeId, {zIndex: nextBackZIndex(items, nodeId)});
+      }}
+    />
+  );
+}

--- a/apps/src/sketchlab/reactFlow/elementToolbars/ShapeNodeToolbar.tsx
+++ b/apps/src/sketchlab/reactFlow/elementToolbars/ShapeNodeToolbar.tsx
@@ -75,16 +75,14 @@ export default function ShapeNodeToolbar({nodeId}: ShapeNodeToolbarProps) {
           <ActionsGroup
             onDelete={() => deleteElements({nodes: [{id: nodeId}]})}
             onLock={() => patchNodeData({locked: true})}
-            onBringToFront={() =>
-              updateNode(nodeId, {
-                zIndex: nextFrontZIndex([...getNodes(), ...getEdges()]),
-              })
-            }
-            onSendToBack={() =>
-              updateNode(nodeId, {
-                zIndex: nextBackZIndex([...getNodes(), ...getEdges()]),
-              })
-            }
+            onBringToFront={() => {
+              const items = [...getNodes(), ...getEdges()];
+              updateNode(nodeId, {zIndex: nextFrontZIndex(items, nodeId)});
+            }}
+            onSendToBack={() => {
+              const items = [...getNodes(), ...getEdges()];
+              updateNode(nodeId, {zIndex: nextBackZIndex(items, nodeId)});
+            }}
           />
           <HandleVisibilityToggle
             visible={handlesVisible}

--- a/apps/src/sketchlab/reactFlow/elementToolbars/ShapeNodeToolbar.tsx
+++ b/apps/src/sketchlab/reactFlow/elementToolbars/ShapeNodeToolbar.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 
 import {DEFAULT_ROTATION} from '../constants';
 import {ShapeNodeType} from '../types';
+import {moveToEnd, moveToStart} from '../utils/stacking';
 
 import ActionsGroup from './ActionsGroup';
 import FontSizeGroup from './FontSizeGroup';
@@ -27,7 +28,7 @@ interface ShapeNodeToolbarProps {
 }
 
 export default function ShapeNodeToolbar({nodeId}: ShapeNodeToolbarProps) {
-  const {deleteElements} = useReactFlow();
+  const {deleteElements, setNodes} = useReactFlow();
   const {data, patchNodeData} = useNodeToolbarData<ShapeNodeType>(nodeId);
 
   const {backgroundColor, strokeColor, fontSize, fontColor} = data;
@@ -74,6 +75,12 @@ export default function ShapeNodeToolbar({nodeId}: ShapeNodeToolbarProps) {
           <ActionsGroup
             onDelete={() => deleteElements({nodes: [{id: nodeId}]})}
             onLock={() => patchNodeData({locked: true})}
+            onBringToFront={() =>
+              setNodes(current => moveToEnd(current, nodeId))
+            }
+            onSendToBack={() =>
+              setNodes(current => moveToStart(current, nodeId))
+            }
           />
           <HandleVisibilityToggle
             visible={handlesVisible}

--- a/apps/src/sketchlab/reactFlow/elementToolbars/ShapeNodeToolbar.tsx
+++ b/apps/src/sketchlab/reactFlow/elementToolbars/ShapeNodeToolbar.tsx
@@ -1,14 +1,12 @@
-import {useReactFlow} from '@xyflow/react';
 import React from 'react';
 
 import {DEFAULT_ROTATION} from '../constants';
 import {ShapeNodeType} from '../types';
-import {nextBackZIndex, nextFrontZIndex} from '../utils/stacking';
 
-import ActionsGroup from './ActionsGroup';
 import FontSizeGroup from './FontSizeGroup';
 import HandleVisibilityToggle from './HandleVisibilityToggle';
 import LockedNotice from './LockedNotice';
+import NodeActionsGroup from './NodeActionsGroup';
 import RotationGroup from './RotationGroup';
 import SwatchGroup from './SwatchGroup';
 import {
@@ -28,7 +26,6 @@ interface ShapeNodeToolbarProps {
 }
 
 export default function ShapeNodeToolbar({nodeId}: ShapeNodeToolbarProps) {
-  const {deleteElements, updateNode, getNodes, getEdges} = useReactFlow();
   const {data, patchNodeData} = useNodeToolbarData<ShapeNodeType>(nodeId);
 
   const {backgroundColor, strokeColor, fontSize, fontColor} = data;
@@ -72,18 +69,7 @@ export default function ShapeNodeToolbar({nodeId}: ShapeNodeToolbarProps) {
             value={data.rotation ?? DEFAULT_ROTATION}
             onChange={degrees => patchNodeData({rotation: degrees})}
           />
-          <ActionsGroup
-            onDelete={() => deleteElements({nodes: [{id: nodeId}]})}
-            onLock={() => patchNodeData({locked: true})}
-            onBringToFront={() => {
-              const items = [...getNodes(), ...getEdges()];
-              updateNode(nodeId, {zIndex: nextFrontZIndex(items, nodeId)});
-            }}
-            onSendToBack={() => {
-              const items = [...getNodes(), ...getEdges()];
-              updateNode(nodeId, {zIndex: nextBackZIndex(items, nodeId)});
-            }}
-          />
+          <NodeActionsGroup nodeId={nodeId} />
           <HandleVisibilityToggle
             visible={handlesVisible}
             onToggle={() => patchNodeData({showHandles: !handlesVisible})}

--- a/apps/src/sketchlab/reactFlow/elementToolbars/ShapeNodeToolbar.tsx
+++ b/apps/src/sketchlab/reactFlow/elementToolbars/ShapeNodeToolbar.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 
 import {DEFAULT_ROTATION} from '../constants';
 import {ShapeNodeType} from '../types';
-import {moveToEnd, moveToStart} from '../utils/stacking';
+import {nextBackZIndex, nextFrontZIndex} from '../utils/stacking';
 
 import ActionsGroup from './ActionsGroup';
 import FontSizeGroup from './FontSizeGroup';
@@ -28,7 +28,7 @@ interface ShapeNodeToolbarProps {
 }
 
 export default function ShapeNodeToolbar({nodeId}: ShapeNodeToolbarProps) {
-  const {deleteElements, setNodes} = useReactFlow();
+  const {deleteElements, updateNode, getNodes} = useReactFlow();
   const {data, patchNodeData} = useNodeToolbarData<ShapeNodeType>(nodeId);
 
   const {backgroundColor, strokeColor, fontSize, fontColor} = data;
@@ -76,10 +76,10 @@ export default function ShapeNodeToolbar({nodeId}: ShapeNodeToolbarProps) {
             onDelete={() => deleteElements({nodes: [{id: nodeId}]})}
             onLock={() => patchNodeData({locked: true})}
             onBringToFront={() =>
-              setNodes(current => moveToEnd(current, nodeId))
+              updateNode(nodeId, {zIndex: nextFrontZIndex(getNodes())})
             }
             onSendToBack={() =>
-              setNodes(current => moveToStart(current, nodeId))
+              updateNode(nodeId, {zIndex: nextBackZIndex(getNodes())})
             }
           />
           <HandleVisibilityToggle

--- a/apps/src/sketchlab/reactFlow/elementToolbars/ShapeNodeToolbar.tsx
+++ b/apps/src/sketchlab/reactFlow/elementToolbars/ShapeNodeToolbar.tsx
@@ -28,7 +28,7 @@ interface ShapeNodeToolbarProps {
 }
 
 export default function ShapeNodeToolbar({nodeId}: ShapeNodeToolbarProps) {
-  const {deleteElements, updateNode, getNodes} = useReactFlow();
+  const {deleteElements, updateNode, getNodes, getEdges} = useReactFlow();
   const {data, patchNodeData} = useNodeToolbarData<ShapeNodeType>(nodeId);
 
   const {backgroundColor, strokeColor, fontSize, fontColor} = data;
@@ -76,10 +76,14 @@ export default function ShapeNodeToolbar({nodeId}: ShapeNodeToolbarProps) {
             onDelete={() => deleteElements({nodes: [{id: nodeId}]})}
             onLock={() => patchNodeData({locked: true})}
             onBringToFront={() =>
-              updateNode(nodeId, {zIndex: nextFrontZIndex(getNodes())})
+              updateNode(nodeId, {
+                zIndex: nextFrontZIndex([...getNodes(), ...getEdges()]),
+              })
             }
             onSendToBack={() =>
-              updateNode(nodeId, {zIndex: nextBackZIndex(getNodes())})
+              updateNode(nodeId, {
+                zIndex: nextBackZIndex([...getNodes(), ...getEdges()]),
+              })
             }
           />
           <HandleVisibilityToggle

--- a/apps/src/sketchlab/reactFlow/elementToolbars/TextNodeToolbar.tsx
+++ b/apps/src/sketchlab/reactFlow/elementToolbars/TextNodeToolbar.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 
 import {DEFAULT_ROTATION} from '../constants';
 import {TextNodeType} from '../types';
+import {moveToEnd, moveToStart} from '../utils/stacking';
 
 import ActionsGroup from './ActionsGroup';
 import FontSizeGroup from './FontSizeGroup';
@@ -24,7 +25,7 @@ interface TextNodeToolbarProps {
 }
 
 export default function TextNodeToolbar({nodeId}: TextNodeToolbarProps) {
-  const {deleteElements} = useReactFlow();
+  const {deleteElements, setNodes} = useReactFlow();
   const {data, patchNodeData} = useNodeToolbarData<TextNodeType>(nodeId);
 
   const {fontSize, fontColor} = data;
@@ -59,6 +60,12 @@ export default function TextNodeToolbar({nodeId}: TextNodeToolbarProps) {
           <ActionsGroup
             onDelete={() => deleteElements({nodes: [{id: nodeId}]})}
             onLock={() => patchNodeData({locked: true})}
+            onBringToFront={() =>
+              setNodes(current => moveToEnd(current, nodeId))
+            }
+            onSendToBack={() =>
+              setNodes(current => moveToStart(current, nodeId))
+            }
           />
           <HandleVisibilityToggle
             visible={handlesVisible}

--- a/apps/src/sketchlab/reactFlow/elementToolbars/TextNodeToolbar.tsx
+++ b/apps/src/sketchlab/reactFlow/elementToolbars/TextNodeToolbar.tsx
@@ -60,16 +60,14 @@ export default function TextNodeToolbar({nodeId}: TextNodeToolbarProps) {
           <ActionsGroup
             onDelete={() => deleteElements({nodes: [{id: nodeId}]})}
             onLock={() => patchNodeData({locked: true})}
-            onBringToFront={() =>
-              updateNode(nodeId, {
-                zIndex: nextFrontZIndex([...getNodes(), ...getEdges()]),
-              })
-            }
-            onSendToBack={() =>
-              updateNode(nodeId, {
-                zIndex: nextBackZIndex([...getNodes(), ...getEdges()]),
-              })
-            }
+            onBringToFront={() => {
+              const items = [...getNodes(), ...getEdges()];
+              updateNode(nodeId, {zIndex: nextFrontZIndex(items, nodeId)});
+            }}
+            onSendToBack={() => {
+              const items = [...getNodes(), ...getEdges()];
+              updateNode(nodeId, {zIndex: nextBackZIndex(items, nodeId)});
+            }}
           />
           <HandleVisibilityToggle
             visible={handlesVisible}

--- a/apps/src/sketchlab/reactFlow/elementToolbars/TextNodeToolbar.tsx
+++ b/apps/src/sketchlab/reactFlow/elementToolbars/TextNodeToolbar.tsx
@@ -1,14 +1,12 @@
-import {useReactFlow} from '@xyflow/react';
 import React from 'react';
 
 import {DEFAULT_ROTATION} from '../constants';
 import {TextNodeType} from '../types';
-import {nextBackZIndex, nextFrontZIndex} from '../utils/stacking';
 
-import ActionsGroup from './ActionsGroup';
 import FontSizeGroup from './FontSizeGroup';
 import HandleVisibilityToggle from './HandleVisibilityToggle';
 import LockedNotice from './LockedNotice';
+import NodeActionsGroup from './NodeActionsGroup';
 import RotationGroup from './RotationGroup';
 import SwatchGroup from './SwatchGroup';
 import {
@@ -25,7 +23,6 @@ interface TextNodeToolbarProps {
 }
 
 export default function TextNodeToolbar({nodeId}: TextNodeToolbarProps) {
-  const {deleteElements, updateNode, getNodes, getEdges} = useReactFlow();
   const {data, patchNodeData} = useNodeToolbarData<TextNodeType>(nodeId);
 
   const {fontSize, fontColor} = data;
@@ -57,18 +54,7 @@ export default function TextNodeToolbar({nodeId}: TextNodeToolbarProps) {
             value={data.rotation ?? DEFAULT_ROTATION}
             onChange={degrees => patchNodeData({rotation: degrees})}
           />
-          <ActionsGroup
-            onDelete={() => deleteElements({nodes: [{id: nodeId}]})}
-            onLock={() => patchNodeData({locked: true})}
-            onBringToFront={() => {
-              const items = [...getNodes(), ...getEdges()];
-              updateNode(nodeId, {zIndex: nextFrontZIndex(items, nodeId)});
-            }}
-            onSendToBack={() => {
-              const items = [...getNodes(), ...getEdges()];
-              updateNode(nodeId, {zIndex: nextBackZIndex(items, nodeId)});
-            }}
-          />
+          <NodeActionsGroup nodeId={nodeId} />
           <HandleVisibilityToggle
             visible={handlesVisible}
             onToggle={() => patchNodeData({showHandles: !handlesVisible})}

--- a/apps/src/sketchlab/reactFlow/elementToolbars/TextNodeToolbar.tsx
+++ b/apps/src/sketchlab/reactFlow/elementToolbars/TextNodeToolbar.tsx
@@ -25,7 +25,7 @@ interface TextNodeToolbarProps {
 }
 
 export default function TextNodeToolbar({nodeId}: TextNodeToolbarProps) {
-  const {deleteElements, updateNode, getNodes} = useReactFlow();
+  const {deleteElements, updateNode, getNodes, getEdges} = useReactFlow();
   const {data, patchNodeData} = useNodeToolbarData<TextNodeType>(nodeId);
 
   const {fontSize, fontColor} = data;
@@ -61,10 +61,14 @@ export default function TextNodeToolbar({nodeId}: TextNodeToolbarProps) {
             onDelete={() => deleteElements({nodes: [{id: nodeId}]})}
             onLock={() => patchNodeData({locked: true})}
             onBringToFront={() =>
-              updateNode(nodeId, {zIndex: nextFrontZIndex(getNodes())})
+              updateNode(nodeId, {
+                zIndex: nextFrontZIndex([...getNodes(), ...getEdges()]),
+              })
             }
             onSendToBack={() =>
-              updateNode(nodeId, {zIndex: nextBackZIndex(getNodes())})
+              updateNode(nodeId, {
+                zIndex: nextBackZIndex([...getNodes(), ...getEdges()]),
+              })
             }
           />
           <HandleVisibilityToggle

--- a/apps/src/sketchlab/reactFlow/elementToolbars/TextNodeToolbar.tsx
+++ b/apps/src/sketchlab/reactFlow/elementToolbars/TextNodeToolbar.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 
 import {DEFAULT_ROTATION} from '../constants';
 import {TextNodeType} from '../types';
-import {moveToEnd, moveToStart} from '../utils/stacking';
+import {nextBackZIndex, nextFrontZIndex} from '../utils/stacking';
 
 import ActionsGroup from './ActionsGroup';
 import FontSizeGroup from './FontSizeGroup';
@@ -25,7 +25,7 @@ interface TextNodeToolbarProps {
 }
 
 export default function TextNodeToolbar({nodeId}: TextNodeToolbarProps) {
-  const {deleteElements, setNodes} = useReactFlow();
+  const {deleteElements, updateNode, getNodes} = useReactFlow();
   const {data, patchNodeData} = useNodeToolbarData<TextNodeType>(nodeId);
 
   const {fontSize, fontColor} = data;
@@ -61,10 +61,10 @@ export default function TextNodeToolbar({nodeId}: TextNodeToolbarProps) {
             onDelete={() => deleteElements({nodes: [{id: nodeId}]})}
             onLock={() => patchNodeData({locked: true})}
             onBringToFront={() =>
-              setNodes(current => moveToEnd(current, nodeId))
+              updateNode(nodeId, {zIndex: nextFrontZIndex(getNodes())})
             }
             onSendToBack={() =>
-              setNodes(current => moveToStart(current, nodeId))
+              updateNode(nodeId, {zIndex: nextBackZIndex(getNodes())})
             }
           />
           <HandleVisibilityToggle

--- a/apps/src/sketchlab/reactFlow/elementToolbars/ToolbarShell.tsx
+++ b/apps/src/sketchlab/reactFlow/elementToolbars/ToolbarShell.tsx
@@ -18,6 +18,10 @@ const PAN_DURATION_MS = 200;
 // Width reserved for React Flow's Controls overlay along the left edge
 // so the toolbar doesn't sit underneath it after panning into view.
 const CONTROLS_WIDTH_PX = 60;
+// React Flow normally stacks the toolbar at its anchor node's zIndex + 1.
+// Pin the toolbar to a large constant so it always
+// floats above the canvas regardless of the anchor's zIndex.
+const TOOLBAR_Z_INDEX = 1000;
 
 interface ToolbarShellProps {
   target: ToolbarTarget;
@@ -92,6 +96,7 @@ export default function ToolbarShell({
       position={Position.Left}
       offset={TOOLBAR_OFFSET_PX}
       isVisible={isVisible}
+      style={{zIndex: TOOLBAR_Z_INDEX}}
     >
       <FocusTrap
         active={isVisible && trapFocus}

--- a/apps/src/sketchlab/reactFlow/elementToolbars/ToolbarShell.tsx
+++ b/apps/src/sketchlab/reactFlow/elementToolbars/ToolbarShell.tsx
@@ -21,7 +21,8 @@ const CONTROLS_WIDTH_PX = 60;
 // React Flow normally stacks the toolbar at its anchor node's zIndex + 1.
 // Pin the toolbar to a large constant so it always
 // floats above the canvas regardless of the anchor's zIndex.
-const TOOLBAR_Z_INDEX = 1000;
+// 2147483647 is the max signed 32-bit integer, a commonly used CSS z-index cap.
+const TOOLBAR_Z_INDEX = 2147483647;
 
 interface ToolbarShellProps {
   target: ToolbarTarget;

--- a/apps/src/sketchlab/reactFlow/utils/stacking.ts
+++ b/apps/src/sketchlab/reactFlow/utils/stacking.ts
@@ -1,6 +1,6 @@
 // Helpers for "Bring to front" / "Send to back". With React Flow's
-// zIndexMode="manual", stacking is driven by each item's explicit zIndex,
-// not array order. We pick a value one above the current max (front) or
+// zIndexMode="manual", stacking is driven by each item's explicit zIndex.
+// We pick a value one above the current max (front) or
 // one below the current min (back). Treat undefined zIndex as 0.
 
 interface ZItem {

--- a/apps/src/sketchlab/reactFlow/utils/stacking.ts
+++ b/apps/src/sketchlab/reactFlow/utils/stacking.ts
@@ -1,18 +1,28 @@
-// Reorder helpers for the nodes/edges arrays. React Flow paints later items
-// on top, so moving an element to the end brings it to the front and moving
-// it to the start sends it to the back.
+// Helpers for "Bring to front" / "Send to back". With React Flow's
+// zIndexMode="manual", stacking is driven by each item's explicit zIndex,
+// not array order. We pick a value one above the current max (front) or
+// one below the current min (back). Treat undefined zIndex as 0.
 
-export function moveToEnd<T extends {id: string}>(items: T[], id: string): T[] {
-  const target = items.find(item => item.id === id);
-  if (!target) return items;
-  return [...items.filter(item => item.id !== id), target];
+interface ZItem {
+  zIndex?: number;
 }
 
-export function moveToStart<T extends {id: string}>(
-  items: T[],
-  id: string
-): T[] {
-  const target = items.find(item => item.id === id);
-  if (!target) return items;
-  return [target, ...items.filter(item => item.id !== id)];
+export function nextFrontZIndex(items: readonly ZItem[]): number {
+  let max = 0;
+  for (const item of items) {
+    if (typeof item.zIndex === 'number' && item.zIndex > max) {
+      max = item.zIndex;
+    }
+  }
+  return max + 1;
+}
+
+export function nextBackZIndex(items: readonly ZItem[]): number {
+  let min = 0;
+  for (const item of items) {
+    if (typeof item.zIndex === 'number' && item.zIndex < min) {
+      min = item.zIndex;
+    }
+  }
+  return min - 1;
 }

--- a/apps/src/sketchlab/reactFlow/utils/stacking.ts
+++ b/apps/src/sketchlab/reactFlow/utils/stacking.ts
@@ -1,0 +1,18 @@
+// Reorder helpers for the nodes/edges arrays. React Flow paints later items
+// on top, so moving an element to the end brings it to the front and moving
+// it to the start sends it to the back.
+
+export function moveToEnd<T extends {id: string}>(items: T[], id: string): T[] {
+  const target = items.find(item => item.id === id);
+  if (!target) return items;
+  return [...items.filter(item => item.id !== id), target];
+}
+
+export function moveToStart<T extends {id: string}>(
+  items: T[],
+  id: string
+): T[] {
+  const target = items.find(item => item.id === id);
+  if (!target) return items;
+  return [target, ...items.filter(item => item.id !== id)];
+}

--- a/apps/src/sketchlab/reactFlow/utils/stacking.ts
+++ b/apps/src/sketchlab/reactFlow/utils/stacking.ts
@@ -1,28 +1,56 @@
 // Helpers for "Bring to front" / "Send to back". With React Flow's
 // zIndexMode="manual", stacking is driven by each item's explicit zIndex.
-// We pick a value one above the current max (front) or
-// one below the current min (back). Treat undefined zIndex as 0.
+// Treat undefined zIndex as 0.
+//
+// We exclude the target from the max/min comparison so we only bump the
+// zIndex when the target isn't already strictly above (or below) the rest.
+// If the target already clears the others, return its current value.
 
 interface ZItem {
+  id: string;
   zIndex?: number;
 }
 
-export function nextFrontZIndex(items: readonly ZItem[]): number {
-  let max = 0;
-  for (const item of items) {
-    if (typeof item.zIndex === 'number' && item.zIndex > max) {
-      max = item.zIndex;
-    }
-  }
-  return max + 1;
+function zOf(item: ZItem): number {
+  return item.zIndex ?? 0;
 }
 
-export function nextBackZIndex(items: readonly ZItem[]): number {
-  let min = 0;
+export function nextFrontZIndex(
+  items: readonly ZItem[],
+  targetId: string
+): number {
+  let maxOther: number | null = null;
+  let targetZ = 0;
   for (const item of items) {
-    if (typeof item.zIndex === 'number' && item.zIndex < min) {
-      min = item.zIndex;
+    if (item.id === targetId) {
+      targetZ = zOf(item);
+      continue;
+    }
+    const z = zOf(item);
+    if (maxOther === null || z > maxOther) {
+      maxOther = z;
     }
   }
-  return min - 1;
+  if (maxOther === null) return targetZ;
+  return targetZ > maxOther ? targetZ : maxOther + 1;
+}
+
+export function nextBackZIndex(
+  items: readonly ZItem[],
+  targetId: string
+): number {
+  let minOther: number | null = null;
+  let targetZ = 0;
+  for (const item of items) {
+    if (item.id === targetId) {
+      targetZ = zOf(item);
+      continue;
+    }
+    const z = zOf(item);
+    if (minOther === null || z < minOther) {
+      minOther = z;
+    }
+  }
+  if (minOther === null) return targetZ;
+  return targetZ < minOther ? targetZ : minOther - 1;
 }

--- a/apps/src/sketchlab/reactFlow/utils/stacking.ts
+++ b/apps/src/sketchlab/reactFlow/utils/stacking.ts
@@ -4,14 +4,13 @@
 //
 // We exclude the target from the max/min comparison so we only bump the
 // zIndex when the target isn't already strictly above (or below) the rest.
-// If the target already clears the others, return its current value.
 
 interface ZItem {
   id: string;
   zIndex?: number;
 }
 
-function zOf(item: ZItem): number {
+function getZIndex(item: ZItem): number {
   return item.zIndex ?? 0;
 }
 
@@ -19,38 +18,38 @@ export function nextFrontZIndex(
   items: readonly ZItem[],
   targetId: string
 ): number {
-  let maxOther: number | null = null;
-  let targetZ = 0;
+  let maxOtherZIndex: number | null = null;
+  let targetZIndex = 0;
   for (const item of items) {
     if (item.id === targetId) {
-      targetZ = zOf(item);
+      targetZIndex = getZIndex(item);
       continue;
     }
-    const z = zOf(item);
-    if (maxOther === null || z > maxOther) {
-      maxOther = z;
+    const zIndex = getZIndex(item);
+    if (maxOtherZIndex === null || zIndex > maxOtherZIndex) {
+      maxOtherZIndex = zIndex;
     }
   }
-  if (maxOther === null) return targetZ;
-  return targetZ > maxOther ? targetZ : maxOther + 1;
+  if (maxOtherZIndex === null) return targetZIndex;
+  return targetZIndex > maxOtherZIndex ? targetZIndex : maxOtherZIndex + 1;
 }
 
 export function nextBackZIndex(
   items: readonly ZItem[],
   targetId: string
 ): number {
-  let minOther: number | null = null;
-  let targetZ = 0;
+  let minOtherZIndex: number | null = null;
+  let targetZIndex = 0;
   for (const item of items) {
     if (item.id === targetId) {
-      targetZ = zOf(item);
+      targetZIndex = getZIndex(item);
       continue;
     }
-    const z = zOf(item);
-    if (minOther === null || z < minOther) {
-      minOther = z;
+    const zIndex = getZIndex(item);
+    if (minOtherZIndex === null || zIndex < minOtherZIndex) {
+      minOtherZIndex = zIndex;
     }
   }
-  if (minOther === null) return targetZ;
-  return targetZ < minOther ? targetZ : minOther - 1;
+  if (minOtherZIndex === null) return targetZIndex;
+  return targetZIndex < minOtherZIndex ? targetZIndex : minOtherZIndex - 1;
 }

--- a/apps/src/sketchlab/reactFlow/utils/stacking.ts
+++ b/apps/src/sketchlab/reactFlow/utils/stacking.ts
@@ -14,7 +14,7 @@ function getZIndex(item: ZItem): number {
   return item.zIndex ?? 0;
 }
 
-export function nextFrontZIndex(
+export function newFrontZIndex(
   items: readonly ZItem[],
   targetId: string
 ): number {
@@ -34,7 +34,7 @@ export function nextFrontZIndex(
   return targetZIndex > maxOtherZIndex ? targetZIndex : maxOtherZIndex + 1;
 }
 
-export function nextBackZIndex(
+export function newBackZIndex(
   items: readonly ZItem[],
   targetId: string
 ): number {

--- a/apps/yarn.lock
+++ b/apps/yarn.lock
@@ -9963,23 +9963,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@xyflow/react@npm:^12.8.1":
-  version: 12.8.1
-  resolution: "@xyflow/react@npm:12.8.1"
+"@xyflow/react@npm:^12.10.2":
+  version: 12.10.2
+  resolution: "@xyflow/react@npm:12.10.2"
   dependencies:
-    "@xyflow/system": "npm:0.0.65"
+    "@xyflow/system": "npm:0.0.76"
     classcat: "npm:^5.0.3"
     zustand: "npm:^4.4.0"
   peerDependencies:
     react: ">=17"
     react-dom: ">=17"
-  checksum: 10/448820f48120229090ad78c30207ab36874e58f81365c53a79e34831dacb5cada40b86861b0248934afe06dc0ba471e86d3160953a3ab5e74e3faab4f56c7cb6
+  checksum: 10/92f341f31d50ca1c4886811fca4c1e41e3ce1ebb4f8abf3e7a75af91228866af4ffab7c36d15937fdbd046a5662e4b2e6d6773ef9be977b95074a568bafb0fcf
   languageName: node
   linkType: hard
 
-"@xyflow/system@npm:0.0.65":
-  version: 0.0.65
-  resolution: "@xyflow/system@npm:0.0.65"
+"@xyflow/system@npm:0.0.76":
+  version: 0.0.76
+  resolution: "@xyflow/system@npm:0.0.76"
   dependencies:
     "@types/d3-drag": "npm:^3.0.7"
     "@types/d3-interpolate": "npm:^3.0.4"
@@ -9990,7 +9990,7 @@ __metadata:
     d3-interpolate: "npm:^3.0.1"
     d3-selection: "npm:^3.0.0"
     d3-zoom: "npm:^3.0.0"
-  checksum: 10/1bdb2373166c129f2effb6b542e86fa5c46d33e178283187d01cb3a8e3ffe64c48c9127ba39cf3589249f1242b90807da379f14ba1fd9606780fc103d25f7aeb
+  checksum: 10/6fada3ea584b41007a8f10160046665a940a4302b85f7ccbd2169bf1109a2e070ddbededd3f4f4e2479234e9bb0a500406c7718f6d4b5328575be59bc6655a84
   languageName: node
   linkType: hard
 
@@ -11476,7 +11476,7 @@ __metadata:
     "@xterm/addon-fit": "npm:^0.10.0"
     "@xterm/addon-image": "npm:^0.8.0"
     "@xterm/xterm": "npm:^5.5.0"
-    "@xyflow/react": "npm:^12.8.1"
+    "@xyflow/react": "npm:^12.10.2"
     acorn-import-assertions: "npm:^1.9.0"
     ai: "npm:^6.0.73"
     aws-sdk: "npm:2.1231.0"

--- a/dashboard/config/levels/custom/sketchlab/allthethings sketchlab 5.level
+++ b/dashboard/config/levels/custom/sketchlab/allthethings sketchlab 5.level
@@ -28,10 +28,6 @@
             "measured": {
               "width": 160,
               "height": 120
-            },
-            "selected": true,
-            "domAttributes": {
-              "tabIndex": 0
             }
           },
           {
@@ -53,8 +49,7 @@
               "width": 160,
               "height": 120
             },
-            "dragging": false,
-            "selected": false
+            "dragging": false
           },
           {
             "id": "1a62511b-1009-4782-a549-d8a6c9f2ed5f",
@@ -97,11 +92,64 @@
               "width": 160,
               "height": 120
             },
+            "dragging": false
+          },
+          {
+            "id": "b49a3361-2c78-47be-9920-c4f7efa293e3",
+            "type": "shape",
+            "data": {
+              "shapeType": "circle",
+              "label": "hi"
+            },
+            "position": {
+              "x": 389.1141214032667,
+              "y": 672.5886300492422
+            },
+            "width": 160,
+            "height": 120,
+            "measured": {
+              "width": 160,
+              "height": 120
+            },
+            "dragging": false
+          },
+          {
+            "id": "94f138a3-2d64-461e-807f-1058e9689050",
+            "type": "text",
+            "data": {
+              "text": "text "
+            },
+            "position": {
+              "x": 435.86399618289664,
+              "y": 612.5929574153837
+            },
+            "measured": {
+              "width": 58,
+              "height": 39
+            },
+            "dragging": false
+          },
+          {
+            "id": "127d0050-90d5-4588-a740-21d6c74b7813",
+            "type": "shape",
+            "data": {
+              "shapeType": "rectangle",
+              "label": "background",
+              "backgroundColor": "var(--sketchlab-bg-yellow)"
+            },
+            "position": {
+              "x": 525.4679228438542,
+              "y": 454.4225477443024
+            },
+            "width": 412,
+            "height": 374,
+            "measured": {
+              "width": 412,
+              "height": 374
+            },
             "dragging": false,
-            "selected": true,
-            "domAttributes": {
-              "tabIndex": 0
-            }
+            "resizing": false,
+            "zIndex": -1
           }
         ],
         "edges": [
@@ -117,9 +165,9 @@
           }
         ],
         "viewport": {
-          "x": -6.965315661406294,
-          "y": -343.0092128661571,
-          "zoom": 1.4989996017555476
+          "x": -136.39914051638857,
+          "y": -302.7176662115528,
+          "zoom": 1.2834258975629043
         }
       }
     },
@@ -163,6 +211,6 @@
     }
   },
   "published": true,
-  "audit_log": "[{\"changed_at\":\"2026-04-21T15:01:15.829-07:00\",\"changed\":[\"cloned from \\\"allthethings sketchlab 1\\\"\"],\"cloned_from\":\"allthethings sketchlab 1\"},{\"changed_at\":\"2026-04-21 15:01:55 -0700\",\"changed\":[\"long_instructions\"],\"changed_by_id\":2,\"changed_by_email\":\"molly+levelbuilder@code.org\"},{\"changed_at\":\"2026-04-21 15:07:12 -0700\",\"changed\":[],\"changed_by_id\":2,\"changed_by_email\":\"molly+levelbuilder@code.org\"},{\"changed_at\":\"2026-04-21 15:12:54 -0700\",\"changed\":[],\"changed_by_id\":2,\"changed_by_email\":\"molly+levelbuilder@code.org\"},{\"changed_at\":\"2026-04-28 10:30:43 -0700\",\"changed\":[\"start_sources\"],\"changed_by_id\":2,\"changed_by_email\":\"molly+levelbuilder@code.org\"}]"
+  "audit_log": "[{\"changed_at\":\"2026-04-21T15:01:15.829-07:00\",\"changed\":[\"cloned from \\\"allthethings sketchlab 1\\\"\"],\"cloned_from\":\"allthethings sketchlab 1\"},{\"changed_at\":\"2026-04-21 15:01:55 -0700\",\"changed\":[\"long_instructions\"],\"changed_by_id\":2,\"changed_by_email\":\"molly+levelbuilder@code.org\"},{\"changed_at\":\"2026-04-21 15:07:12 -0700\",\"changed\":[],\"changed_by_id\":2,\"changed_by_email\":\"molly+levelbuilder@code.org\"},{\"changed_at\":\"2026-04-21 15:12:54 -0700\",\"changed\":[],\"changed_by_id\":2,\"changed_by_email\":\"molly+levelbuilder@code.org\"},{\"changed_at\":\"2026-04-28 10:30:43 -0700\",\"changed\":[\"start_sources\"],\"changed_by_id\":2,\"changed_by_email\":\"molly+levelbuilder@code.org\"},{\"changed_at\":\"2026-04-30 13:22:05 -0700\",\"changed\":[\"start_sources\"],\"changed_by_id\":2,\"changed_by_email\":\"molly+levelbuilder@code.org\"},{\"changed_at\":\"2026-05-01 13:18:24 -0700\",\"changed\":[\"start_sources\"],\"changed_by_id\":2,\"changed_by_email\":\"molly+levelbuilder@code.org\"}]"
 }]]></config>
 </Sketchlab>


### PR DESCRIPTION
This adds bring to back/bring to front options for arrows, lines and nodes in sketch2. This utilizes z-index to layer items appropriately. We could extend this further to add "bring forward" and "send backward" a single layer options, but for now this meets our pressing needs. It also gets rid of the default react flow behavior for an element to jump to the front when it's selected.

## Screenshots
<img width="190" height="83" alt="Screenshot 2026-05-01 at 1 17 31 PM" src="https://github.com/user-attachments/assets/e991ad64-6430-443a-b566-b963a5b271b2" />
<img width="190" height="83" alt="Screenshot 2026-05-01 at 1 17 28 PM" src="https://github.com/user-attachments/assets/b661ddc0-6cf7-417a-816c-be8812b5caee" />
<img width="190" height="83" alt="Screenshot 2026-05-01 at 1 17 24 PM" src="https://github.com/user-attachments/assets/31a03c74-9bef-407b-8a57-d960707608fb" />

## Screen recording

https://github.com/user-attachments/assets/77a83854-d8b2-417a-a08b-35edfc732ac0




## Links

- Jira: [AFL-613](https://codedotorg.atlassian.net/browse/AFL-613)

## Testing story
Tested locally.


