### PR TITLE
Revamp UI test status pages

### DIFF
--- a/dashboard/test/ui/runner.rb
+++ b/dashboard/test/ui/runner.rb
@@ -576,6 +576,7 @@ def generate_status_page(suite_start_time)
         s3_bucket: S3_LOGS_BUCKET,
         s3_prefix: S3_LOGS_PREFIX,
         type: test_type,
+        type_label: test_type_label,
         git_branch: GIT_BRANCH,
         commit_hash: COMMIT_HASH,
         start_time: suite_start_time,

--- a/dashboard/test/ui/runner.rb
+++ b/dashboard/test/ui/runner.rb
@@ -474,6 +474,35 @@ def server_status_page_url
   CDO.studio_url('/ui_test/' + status_page_filename, scheme_for_environment, ge_region: nil)
 end
 
+# Ordered list of UI/Eyes test status pages used to render the
+# cross-page navigation row at the top of each status page. Each entry's
+# :filename must equal the value status_page_filename returns when that
+# page is being generated, so the active entry can be rendered unlinked.
+# For now, the UI Test Status page will render this as:
+#
+#   UI Test Status | <a href="...">Eyes Test Status</a>
+#
+# TODO(device-farm-launch): rename the UI entry's filename to
+# 'test_status_UI_sauce_labs.html', update status_page_filename below to
+# match for the SauceLabs branch, and add device farm desktop/mobile
+# entries.
+STATUS_PAGES_NAVIGATION = [
+  {filename: 'test_status_UI.html',   display_name: 'UI Test Status'},
+  {filename: 'test_status_Eyes.html', display_name: 'Eyes Test Status'},
+].freeze
+
+def status_pages_navigation
+  # Include the navigation row on any status pages generated during the DTT,
+  # so that the oncall engineer can quickly find all the pages they need to
+  # check for UI test failures.
+  return nil unless GIT_BRANCH == 'test'
+  STATUS_PAGES_NAVIGATION.map do |page|
+    page.merge(
+      url: CDO.studio_url("/ui_test/#{page[:filename]}", scheme_for_environment, ge_region: nil)
+    )
+  end
+end
+
 def status_page_filename
   # SauceLabs runs keep the unqualified name. Device Farm runs are
   # split into desktop/mobile/combined buckets so a desktop and a
@@ -530,7 +559,9 @@ def generate_status_page(suite_start_time)
         start_time: suite_start_time,
         browser_features: browser_features,
         device_farm: $options.device_farm,
-        force_db_access: $options.force_db_access
+        force_db_access: $options.force_db_access,
+        status_pages: status_pages_navigation,
+        current_status_page_filename: status_page_filename
       }
     )
   )

--- a/dashboard/test/ui/runner.rb
+++ b/dashboard/test/ui/runner.rb
@@ -400,6 +400,28 @@ def test_type
   eyes? ? 'Eyes' : 'UI'
 end
 
+# Human-readable test-run label used in Slack/log report headers. Device
+# Farm desktop, mobile, and combined runs are dispatched as separate
+# runner.rb invocations against separate concurrency quotas; without a
+# distinguishing prefix the per-suite report messages from a single DTT
+# look identical in #infra-test. SauceLabs runs are left as just the
+# bare test_type for now -- the 'Sauce Labs' prefix lands in the Device
+# Farm launch PR.
+def test_type_label
+  return test_type unless $options.device_farm
+  any_mobile = $browsers.any? {|b| mobile_browser?(b)}
+  all_mobile = $browsers.all? {|b| mobile_browser?(b)}
+  device_farm_kind =
+    if all_mobile
+      'Mobile'
+    elsif any_mobile
+      'Combined'
+    else
+      'Desktop'
+    end
+  "Device Farm #{device_farm_kind} #{test_type}"
+end
+
 def eyes?
   $options.run_eyes_tests
 end
@@ -419,7 +441,7 @@ def applitools_batch_url
 end
 
 def report_tests_starting
-  ChatClient.log "Starting #{browser_features.count} <b>dashboard</b> #{test_type} tests in #{$options.parallel_limit} threads..."
+  ChatClient.log "Starting #{browser_features.count} <b>dashboard</b> #{test_type_label} tests in #{$options.parallel_limit} threads..."
   if eyes?
     ChatClient.log "Batching eyes tests as <a href=\"#{applitools_batch_url}\">#{ENV.fetch('BATCH_NAME', nil)}</a>."
   end
@@ -455,16 +477,16 @@ def report_tests_finished(start_time, run_results, run_status_page_url = nil)
 
   ChatClient.log "Skipped tests tagged with: #{skipped_tags.to_a.join(', ')}"
 
-  test_report =  "\n#{test_type.upcase} TEST REPORT: #{failures.any? ? '*❌ FAILED*' : '*✅ PASSED*'}\n"
+  test_report =  "\n#{test_type_label.upcase} TEST REPORT: #{failures.any? ? '*❌ FAILED*' : '*✅ PASSED*'}\n"
   test_report += "\n#{failures.count}x failed features:\n" + failures.map {|failure| "• #{failure}\n"}.join if failures.any?
   test_report += "\n"
   test_report += "Applitools Eyes Results:\n#{applitools_batch_url}\n\n" if applitools_batch_url
-  test_report += "#{test_type} Test Status Page (permalink for this run):\n#{run_status_page_url}\n\n" if run_status_page_url
-  test_report += "#{test_type} Test Status Page (for this server, *if you're lost start here*):\n#{server_status_page_url}\n\n" unless CI::Utils.running_on_ci?
+  test_report += "#{test_type_label} Test Status Page (permalink for this run):\n#{run_status_page_url}\n\n" if run_status_page_url
+  test_report += "#{test_type_label} Test Status Page (for this server, *if you're lost start here*):\n#{server_status_page_url}\n\n" unless CI::Utils.running_on_ci?
   test_report += "\n"
   test_report += "#{suite_success_count} passed. #{failures.count} failed. Test count: #{run_results.count}. Duration: #{RakeUtils.format_duration(suite_duration)}. Total successful reruns of flaky tests: #{total_flaky_successful_reruns}.\n"
   test_report += "\n"
-  test_report += "\n*#{test_type.upcase}* TESTS #{failures.any? ? 'FAILED' : 'PASSED'}\n\n"
+  test_report += "\n*#{test_type_label.upcase}* TESTS #{failures.any? ? 'FAILED' : 'PASSED'}\n\n"
 
   ChatClient.log test_report, color: 'purple'
 end
@@ -530,10 +552,10 @@ def upload_status_page_to_s3(status_page_path = File.join(UI_TEST_DIR, status_pa
 
   return LOG_UPLOADER.upload_file(status_page_path, {content_type: 'text/html'})
 rescue Aws::Sigv4::Errors::MissingCredentialsError
-  ChatClient.log "No AWS credentials set, skipping upload of the '#{test_type} Test Status Page' to S3"
+  ChatClient.log "No AWS credentials set, skipping upload of the '#{test_type_label} Test Status Page' to S3"
   nil
 rescue Exception => exception
-  ChatClient.log "WARNING: exception raised while attempting to upload the '#{test_type} Test Status Page' to S3:\n#{exception.class}: #{exception}\n#{exception.backtrace&.first(5)&.join("\n")}"
+  ChatClient.log "WARNING: exception raised while attempting to upload the '#{test_type_label} Test Status Page' to S3:\n#{exception.class}: #{exception}\n#{exception.backtrace&.first(5)&.join("\n")}"
   nil
 end
 
@@ -566,8 +588,8 @@ def generate_status_page(suite_start_time)
     )
   )
   run_status_page_url = upload_status_page_to_s3(status_page_path)
-  ChatClient.log "#{test_type} Test Status Page (permalink for this run):\n#{run_status_page_url}\n\n" if run_status_page_url
-  ChatClient.log "#{test_type} Test Status Page (for this server):\n#{server_status_page_url}\n\n" unless CI::Utils.running_on_ci?
+  ChatClient.log "#{test_type_label} Test Status Page (permalink for this run):\n#{run_status_page_url}\n\n" if run_status_page_url
+  ChatClient.log "#{test_type_label} Test Status Page (for this server):\n#{server_status_page_url}\n\n" unless CI::Utils.running_on_ci?
   return run_status_page_url
 end
 

--- a/dashboard/test/ui/test_status.css
+++ b/dashboard/test/ui/test_status.css
@@ -2,6 +2,10 @@ body {
   font-family: Futura, "Trebuchet MS", Arial, sans-serif;
 }
 
+h1 {
+  clear: both;
+}
+
 h2 {
   font-family: monospace;
   font-size: 1.1em;

--- a/dashboard/test/ui/test_status.haml
+++ b/dashboard/test/ui/test_status.haml
@@ -14,6 +14,15 @@
         %button#auto-refresh-button Pause Auto-Refresh
         %button#hide-succeeded-button Hide Succeeded
       %h1= "#{type} Test Status"
+      - if status_pages
+        %h2#status-pages-nav
+          - status_pages.each_with_index do |page, idx|
+            - if idx > 0
+              |
+            - if page[:filename] == current_status_page_filename
+              %span= page[:display_name]
+            - else
+              %a{href: page[:url]}= page[:display_name]
       %h2
         %a#git-branch{href: "https://github.com/code-dot-org/code-dot-org/tree/#{git_branch}", data: {branch: git_branch}}= git_branch
         |

--- a/dashboard/test/ui/test_status.haml
+++ b/dashboard/test/ui/test_status.haml
@@ -2,7 +2,7 @@
 %html{lang: "en"}
   %head
     %meta{charset: "utf-8"}/
-    %title= "#{type} Test Status"
+    %title= "#{type_label} Test Status"
     %link{:rel => :stylesheet, :type => :"text/css", :href => "test_status.css"}
     %script{src: 'https://cdn.jsdelivr.net/lodash/4.13.1/lodash.min.js'}
     %script{src: 'https://cdn.jsdelivr.net/clipboard.js/1.5.13/clipboard.min.js'}
@@ -13,7 +13,7 @@
         %button#refresh-button Refresh
         %button#auto-refresh-button Pause Auto-Refresh
         %button#hide-succeeded-button Hide Succeeded
-      %h1= "#{type} Test Status"
+      %h1= "#{type_label} Test Status"
       - if status_pages
         %h2#status-pages-nav
           - status_pages.each_with_index do |page, idx|


### PR DESCRIPTION
## Background

Our concurrency limit on Sauce Labs has been reduced and our DTTs now take twice as long to complete. To mitigate this issue, we are moving some of our UI tests from Sauce Labs to Device Farm:
- move regular UI tests on Chrome, Firefox, iPad Safari, and iPhone Safari to Device Farm ASAP
- keep macOS Safari on Sauce Labs indefinitely because Device Farm does not support macOS Safari
- keep Eyes tests on Sauce Labs for now. TBD whether to move them to Device Farm later.

[Past PRs](https://github.com/code-dot-org/code-dot-org/issues?q=label%3A%22device%20farm%22) set up the infrastructure for running on Device Farm and getting all tests passing there, except for a few tagged with `@no_device_farm`. 

## Description

This PR makes some visual and usability improvements to our UI / Eyes test status pages to ease the upcoming transition to Device Farm. Device Farm pages get new prefixes now -- Sauce Labs will get new prefixes once we actually launch Device Farm into the mix.

Device Farm is still not part of the DTT, but we are running the full device farm test suites manually on the test machine and generating slack output in `#infra-test` as a result. After this PR merges, oncall engineers can still just ignore anything in slack related to Device Farm. 

### new status bar

Existing UI / Eyes status pages get a new status bar that provides linkage between all relevant status pages:
<img width="1292" height="479" alt="Screenshot 2026-04-30 at 10 22 24 PM" src="https://github.com/user-attachments/assets/ab08deea-dd46-4bf7-abdb-c9b95d970760" />

There are only two entries right now (above), which might make the status bar seem a bit pointless. However, this will be a bigger help once there are 4 status pages to look at:
```
Sauce Labs UI | Device Farm Desktop UI | Device Farm Mobile UI | Eyes
```
This should help developers become aware of and locate the new status pages.

### status page disambiguation

manual runs of the device farm test suites on the test machine generate slack messages and status pages which look very similar to the messages/pages generated by the actual DTT. This PR adds the "Device Farm" prefix in both places:

<img width="1002" height="240" alt="Screenshot 2026-04-30 at 10 20 57 PM" src="https://github.com/user-attachments/assets/5cc5ff75-ed2a-44fd-8914-2a2602929e02" />
<img width="1075" height="543" alt="Screenshot 2026-04-30 at 11 29 49 PM" src="https://github.com/user-attachments/assets/8bd553cb-b687-4f41-bd2c-97065b8a88ab" />

## Testing story

- the status page images above were generated using a branch named `test` on my local machine in order to trigger the logic to generate the new status bar. 
- after merge, I'll verify the correct linkage between status pages on the test machine.
