### PR TITLE
Lesson editor: fix stuck vocab delete modal

### DIFF
--- a/apps/src/levelbuilder/lesson-editor/VocabulariesEditor.jsx
+++ b/apps/src/levelbuilder/lesson-editor/VocabulariesEditor.jsx
@@ -147,16 +147,16 @@ class VocabulariesEditor extends Component {
     return {options: vocabularies};
   };
 
-  handleRemoveVocabularyDialogClose = () => {
+  handleDeleteVocabularyDialogClose = () => {
     this.setState({
       confirmRemovalDialogOpen: false,
       vocabularyForRemoval: null,
     });
   };
 
-  handleRemoveVocabularyConfirm = () => {
+  handleDeleteVocabularyConfirm = () => {
     this.props.removeVocabulary(this.state.vocabularyForRemoval.key);
-    this.handleRemoveVocabularyDialogClose();
+    this.handleDeleteVocabularyDialogClose();
   };
 
   render() {


### PR DESCRIPTION
This is a simple case of a name getting changed (in 08bc38633bb) and our test coverage not catching it. 🫠 That said, these tests are still in enzyme (which I didn't know we could even support?!) so I didn't add an additional test.

I tested this locally and can now remove vocab as expected.

See https://codedotorg.slack.com/archives/C045UAX4WKH/p1777567372579719 for the bug report.

Claude's description of this change (I thought this task was going to be more complex...Claude was definitely overkill here):



