### PR TITLE
Revert changes to dashboard/config/scripts_json/aif1-v2-2025.script_json

### DIFF
--- a/dashboard/config/scripts_json/aif1-v2-2025.script_json
+++ b/dashboard/config/scripts_json/aif1-v2-2025.script_json
@@ -21,7 +21,7 @@
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2026-04-29 23:25:16 UTC",
+    "serialized_at": "2026-05-01 13:34:41 UTC",
     "hide_within_course": false,
     "published_state": null,
     "instruction_type": null,
@@ -7438,12 +7438,84 @@
       }
     },
     {
+      "name": "[KEY] AI Audit",
+      "url": "https://docs.google.com/document/d/1KWiPmB-kVpuTPXPSq2xXnhdQfoMkgSYgaJRKFPeI_NA/edit?usp=drivesdk",
+      "key": "_key_ai_audit",
+      "properties": {
+        "audience": "Verified Teacher",
+        "type": "Answer Key"
+      },
+      "seeding_key": {
+        "resource.key": "_key_ai_audit"
+      }
+    },
+    {
+      "name": "[KEY] AI in the Community",
+      "url": "https://docs.google.com/document/d/1otRrV4we_4C2ld5Krnu6nHQI53GVghfJdeCbIIERHb8/edit?usp=drivesdk",
+      "key": "_key_ai_in_the_community",
+      "properties": {
+        "audience": "Verified Teacher",
+        "type": "Answer Key"
+      },
+      "seeding_key": {
+        "resource.key": "_key_ai_in_the_community"
+      }
+    },
+    {
+      "name": "[KEY] AI Remix Challenge",
+      "url": "https://docs.google.com/document/d/180EZ4dZE1EaSQbHU1XFJlHpO_2qAOIjfW1E4LVmldEA/edit?usp=drivesdk",
+      "key": "_key_ai_remix_challenge",
+      "properties": {
+        "audience": "Verified Teacher",
+        "type": "Answer Key"
+      },
+      "seeding_key": {
+        "resource.key": "_key_ai_remix_challenge"
+      }
+    },
+    {
+      "name": "[KEY] Collaborate on a Product Launch",
+      "url": "https://docs.google.com/document/d/18YzrwjTx_RgEEsiGDQ7OdMjJLjKG0eaXO9Ut8ESDxxA/edit?usp=drive_link",
+      "key": "_key_collaborate_on_a_product_launch",
+      "properties": {
+        "audience": "Verified Teacher",
+        "embeddability_type": "embed_and_resource_dropdown",
+        "type": "Answer Key"
+      },
+      "seeding_key": {
+        "resource.key": "_key_collaborate_on_a_product_launch"
+      }
+    },
+    {
+      "name": "[KEY] Examining AI Contradictions",
+      "url": "https://docs.google.com/document/d/1Xv6Wd1D7OjiW3mhw4jo97pG6NIhJFrrAHYpIMszpicI/edit?usp=drivesdk",
+      "key": "_key_examining_ai_contradictions",
+      "properties": {
+        "audience": "Verified Teacher",
+        "type": "Answer Key"
+      },
+      "seeding_key": {
+        "resource.key": "_key_examining_ai_contradictions"
+      }
+    },
+    {
+      "name": "[KEY] Hallucination Case Studies",
+      "url": "https://docs.google.com/document/d/1P7WjuDzEZsNGJdqIZ8yYqzbW4sEZMD1pSuvFWva8R-w/edit?usp=drivesdk",
+      "key": "_key_hallucination_case_studies",
+      "properties": {
+        "audience": "Verified Teacher",
+        "type": "Answer Key"
+      },
+      "seeding_key": {
+        "resource.key": "_key_hallucination_case_studies"
+      }
+    },
+    {
       "name": "[KEY] Problem Solving with AI Unit Guide Exemplar",
       "url": "https://docs.google.com/document/d/1OxuvJnC9V7752RI-HQ72vcF5UFuk_iCb1n0H0p1qlgQ/edit?usp=drivesdk",
       "key": "_key_problem_solving_with_ai_unit_guide_exemplar",
       "properties": {
-        "audience": "Verified Teacher",
-        "embeddability_type": "embed_and_resource_dropdown",
+        "audience": "Teacher",
         "type": "Answer Key"
       },
       "seeding_key": {
@@ -7455,12 +7527,25 @@
       "url": "https://docs.google.com/presentation/d/1MA0vjQjQ4Zt_d7guVgg7czccfiX8iuxVS6r-Qp0xVZE/edit?usp=drive_link",
       "key": "ai_as_a_co-creator",
       "properties": {
-        "audience": "Teacher",
+        "audience": "Verified Teacher",
         "embeddability_type": "embed_and_resource_dropdown",
         "type": "Slides"
       },
       "seeding_key": {
         "resource.key": "ai_as_a_co-creator"
+      }
+    },
+    {
+      "name": "AI Audit",
+      "url": "https://docs.google.com/document/d/1AWjOcaVEHH6Ac4AvFvkzW7q2YRMmgviebXg5H8zi5WM/edit?usp=drivesdk",
+      "key": "ai_audit",
+      "properties": {
+        "audience": "Student",
+        "include_in_pdf": true,
+        "type": "Activity Guide"
+      },
+      "seeding_key": {
+        "resource.key": "ai_audit"
       }
     },
     {
@@ -7474,12 +7559,61 @@
       }
     },
     {
+      "name": "AI In Grocery Stores - 1 ",
+      "url": "https://drive.google.com/file/d/1-MykYtR1K7qzncS7F7v34_2kCkJCa7DN/view",
+      "key": "ai_in_grocery_stores_-_1",
+      "properties": {
+        "audience": "Student",
+        "type": "Resource"
+      },
+      "seeding_key": {
+        "resource.key": "ai_in_grocery_stores_-_1"
+      }
+    },
+    {
+      "name": "AI in the Community",
+      "url": "https://docs.google.com/document/d/1swk3Ytu52zPLdffHXsKMbNDrTTI87NIX9nZzSHQtBag/edit?usp=drivesdk",
+      "key": "ai_in_the_community",
+      "properties": {
+        "audience": "Student",
+        "include_in_pdf": true,
+        "type": "Activity Guide"
+      },
+      "seeding_key": {
+        "resource.key": "ai_in_the_community"
+      }
+    },
+    {
+      "name": "AI Remix Challenge",
+      "url": "https://docs.google.com/document/d/1tm3V4fSes25EiVYMKfYIGgFVe8ZZykhVanhopJeHeVs/edit?usp=drivesdk",
+      "key": "ai_remix_challenge",
+      "properties": {
+        "audience": "Student",
+        "include_in_pdf": true,
+        "type": "Activity Guide"
+      },
+      "seeding_key": {
+        "resource.key": "ai_remix_challenge"
+      }
+    },
+    {
+      "name": "AI’s Hottest New Job Pays Up to $250K a Year. So I Applied. | WSJ ",
+      "url": "https://www.youtube.com/watch?v=whkge1rEamU",
+      "key": "ai_s_hottest_new_job_pays_up_to_250k_a_year_so_i_applied_wsj_",
+      "properties": {
+        "audience": "Student",
+        "type": "Video"
+      },
+      "seeding_key": {
+        "resource.key": "ai_s_hottest_new_job_pays_up_to_250k_a_year_so_i_applied_wsj_"
+      }
+    },
+    {
       "name": "AI's Role in Society",
       "url": "https://docs.google.com/presentation/d/1PqMz7P4nIgD_znshzS-gzsY07Fp8QPTfxzWXEDg73R8/edit?usp=drivesdk",
       "key": "ai_s_role_in_society",
       "properties": {
-        "audience": "Teacher",
-        "embeddability_type": "embed_and_resource_dropdown",
+        "audience": "Verified Teacher",
         "type": "Slides"
       },
       "seeding_key": {
@@ -7491,7 +7625,7 @@
       "url": "https://docs.google.com/presentation/d/1tKxRI-XuS2Rxtv6PdqaKci171_VBuQOsoJ1GgYOqTms/edit?usp=drive_link",
       "key": "ai_s_wild_imagination",
       "properties": {
-        "audience": "Teacher",
+        "audience": "Verified Teacher",
         "embeddability_type": "embed_and_resource_dropdown",
         "type": "Slides"
       },
@@ -7562,7 +7696,7 @@
       "url": "https://docs.google.com/presentation/d/1gyURTFdK9kO7Txo1SJN6I4zsGx8Yq4Mp5xB2cHl5T48/edit?usp=drive_link",
       "key": "beyond_words",
       "properties": {
-        "audience": "Teacher",
+        "audience": "Verified Teacher",
         "embeddability_type": "embed_and_resource_dropdown",
         "type": "Slides"
       },
@@ -7571,16 +7705,54 @@
       }
     },
     {
+      "name": "Collaborate on a Product Launch",
+      "url": "https://docs.google.com/document/d/1DVcGVVtJlZkDlP2v-JGoFNcGLcCqvEh7RTpjRGmfDjU/edit?usp=drive_link",
+      "key": "collaborate_on_a_product_launch",
+      "properties": {
+        "audience": "Student",
+        "embeddability_type": "embed_and_resource_dropdown",
+        "include_in_pdf": true,
+        "type": "Activity Guide"
+      },
+      "seeding_key": {
+        "resource.key": "collaborate_on_a_product_launch"
+      }
+    },
+    {
+      "name": "Create a Game Using AI",
+      "url": "https://www.youtube.com/shorts/WVWayzc07Ug?si=5o6-VsfhK2XMcEN5",
+      "key": "create_a_game_using_ai",
+      "properties": {
+        "audience": "Student",
+        "type": "Video"
+      },
+      "seeding_key": {
+        "resource.key": "create_a_game_using_ai"
+      }
+    },
+    {
       "name": "Debugging and Refining Outputs",
       "url": "https://docs.google.com/presentation/d/1_GITEwQ6Ek6PXwnL5bzDtZaqZ8yFNFJWpJ_z0r6IxEc/edit?usp=drivesdk",
       "key": "debugging_and_refining_outputs",
       "properties": {
-        "audience": "Teacher",
-        "embeddability_type": "embed_and_resource_dropdown",
+        "audience": "Verified Teacher",
         "type": "Slides"
       },
       "seeding_key": {
         "resource.key": "debugging_and_refining_outputs"
+      }
+    },
+    {
+      "name": "Examining AI Contradictions",
+      "url": "https://docs.google.com/document/d/1h9wgXbJZFF6FMUopFYq-SqhExAi7Yn4E2QBAuv9_oV0/edit?usp=drivesdk",
+      "key": "examining_ai_contradictions",
+      "properties": {
+        "audience": "Student",
+        "include_in_pdf": true,
+        "type": "Activity Guide"
+      },
+      "seeding_key": {
+        "resource.key": "examining_ai_contradictions"
       }
     },
     {
@@ -7608,12 +7780,74 @@
       }
     },
     {
+      "name": "Hallucination Case Studies",
+      "url": "https://docs.google.com/document/d/1sULqyWw0YVmt_n3XNSwuTJqGhUqB2HQtDVnr2Ufrf3o/edit?usp=drivesdk",
+      "key": "hallucination_case_studies",
+      "properties": {
+        "audience": "Student",
+        "include_in_pdf": true,
+        "type": "Activity Guide"
+      },
+      "seeding_key": {
+        "resource.key": "hallucination_case_studies"
+      }
+    },
+    {
+      "name": "How Chatbots and Large Language Models Work",
+      "url": "https://www.youtube.com/watch?v=X-AWdfSFCHQ",
+      "key": "how_chatbots_and_large_language_models_work",
+      "properties": {
+        "audience": "Student",
+        "type": "Video"
+      },
+      "seeding_key": {
+        "resource.key": "how_chatbots_and_large_language_models_work"
+      }
+    },
+    {
+      "name": "Jigsaw Articles",
+      "url": "https://docs.google.com/document/d/1Ts7OnRbtooAKrlj92wMV76XE_PANXwENCMIFz7gFUPM/edit?usp=drivesdk",
+      "key": "jigsaw_articles",
+      "properties": {
+        "audience": "Student",
+        "include_in_pdf": true,
+        "type": "Handout"
+      },
+      "seeding_key": {
+        "resource.key": "jigsaw_articles"
+      }
+    },
+    {
+      "name": "Ownership and AI Stations",
+      "url": "https://docs.google.com/document/d/1BBvvbW5e3rCXOLsvZ58fHR2SNNzHU27uSnBsXxUDUsY/edit?usp=drivesdk",
+      "key": "ownership_and_ai_stations",
+      "properties": {
+        "audience": "Student",
+        "include_in_pdf": true,
+        "type": "Activity Guide"
+      },
+      "seeding_key": {
+        "resource.key": "ownership_and_ai_stations"
+      }
+    },
+    {
+      "name": "Ownership and AI Stations",
+      "url": "https://docs.google.com/document/d/1Eh2TASGZ7z0Wncry96Yg1ZZgiPQOOpUqizRQY8RnxO0/edit?usp=drivesdk",
+      "key": "ownership_and_ai_stations_1",
+      "properties": {
+        "audience": "Teacher",
+        "type": "Resource"
+      },
+      "seeding_key": {
+        "resource.key": "ownership_and_ai_stations_1"
+      }
+    },
+    {
       "name": "Ownership, Ethics, and Creativity",
       "url": "https://docs.google.com/presentation/d/1hfLB28TgJrTpmcq8pl58Gv5-xqhoSe9ijoYT1JIZy08/edit?usp=drivesdk",
       "key": "ownership_ethics_and_creativity",
       "properties": {
-        "audience": "Teacher",
-        "embeddability_type": "embed_and_resource_dropdown",
+        "audience": "Verified Teacher",
         "type": "Slides"
       },
       "seeding_key": {
@@ -7621,12 +7855,49 @@
       }
     },
     {
+      "name": "Plan a Perfect Trip with ChatGPT",
+      "url": "https://www.youtube.com/watch?v=J3Oh2-cVrgs",
+      "key": "plan_a_perfect_trip_with_chatgpt",
+      "properties": {
+        "audience": "Student",
+        "type": "Video"
+      },
+      "seeding_key": {
+        "resource.key": "plan_a_perfect_trip_with_chatgpt"
+      }
+    },
+    {
+      "name": "Problem Solving with AI",
+      "url": "https://www.youtube.com/watch?v=O_VjO1cx-No",
+      "key": "problem_solving_with_ai",
+      "properties": {
+        "audience": "Student",
+        "download_url": "https://videos.code.org/levelbuilder/ai2025problemsolving_2_compressed-mp4.mp4",
+        "type": "Video"
+      },
+      "seeding_key": {
+        "resource.key": "problem_solving_with_ai"
+      }
+    },
+    {
+      "name": "Problem Solving with AI Unit Guide",
+      "url": "https://docs.google.com/document/d/1a57BJiBmJaU_gTddB_IyAbjiU_8HDfcK3hGluNkuDXg/edit?usp=drivesdk",
+      "key": "problem_solving_with_ai_unit_guide",
+      "properties": {
+        "audience": "Student",
+        "include_in_pdf": true,
+        "type": "Activity Guide"
+      },
+      "seeding_key": {
+        "resource.key": "problem_solving_with_ai_unit_guide"
+      }
+    },
+    {
       "name": "Remixing, Creativity, and Originality",
       "url": "https://docs.google.com/presentation/d/1MMdn2ei6iupAF8z0Tz9vHqpMPywMp0VMsvWSnW-HqQ8/edit?usp=drivesdk",
       "key": "remixing_creativity_and_originality",
       "properties": {
-        "audience": "Teacher",
-        "embeddability_type": "embed_and_resource_dropdown",
+        "audience": "Verified Teacher",
         "type": "Slides"
       },
       "seeding_key": {
@@ -7638,8 +7909,7 @@
       "url": "https://docs.google.com/presentation/d/1jBJaed7pHhh3Q5jlh0twHxXj6bMPf4v5PB3HnvAYM2w/edit?usp=drivesdk",
       "key": "smart_or_just_predictable_",
       "properties": {
-        "audience": "Teacher",
-        "embeddability_type": "embed_and_resource_dropdown",
+        "audience": "Verified Teacher",
         "type": "Slides"
       },
       "seeding_key": {
@@ -7651,8 +7921,7 @@
       "url": "https://docs.google.com/presentation/d/1g31o1jws2MNSrNvh-hC4O9t_RNmo0CKO3-pUqVathsY/edit?usp=drivesdk",
       "key": "talking_to_machines",
       "properties": {
-        "audience": "Teacher",
-        "embeddability_type": "embed_and_resource_dropdown",
+        "audience": "Verified Teacher",
         "type": "Slides"
       },
       "seeding_key": {
@@ -7664,7 +7933,7 @@
       "url": "https://docs.google.com/presentation/d/1EPF_2RbK2-Xu3Wm0AtonWjlt5egSrmiVQm1XlkQ18KE/edit?usp=drive_link",
       "key": "the_ai_s_brain",
       "properties": {
-        "audience": "Teacher",
+        "audience": "Verified Teacher",
         "embeddability_type": "embed_and_resource_dropdown",
         "type": "Slides"
       },
@@ -7677,8 +7946,7 @@
       "url": "https://docs.google.com/presentation/d/1aB64LHdkG6gd2iXMQOFhWyzDEiFR2FU8RD2Ixbbs6f0/edit?usp=drivesdk",
       "key": "uncovering_contradictions",
       "properties": {
-        "audience": "Teacher",
-        "embeddability_type": "embed_and_resource_dropdown",
+        "audience": "Verified Teacher",
         "type": "Slides"
       },
       "seeding_key": {
@@ -7690,12 +7958,24 @@
       "url": "https://docs.google.com/presentation/d/1ANcnbmp1suC5qroS7YZdZbhFsrM8J3rWWgaFyqTniNs/edit?usp=drive_link",
       "key": "understanding_bias",
       "properties": {
-        "audience": "Teacher",
+        "audience": "Verified Teacher",
         "embeddability_type": "embed_and_resource_dropdown",
         "type": "Slides"
       },
       "seeding_key": {
         "resource.key": "understanding_bias"
+      }
+    },
+    {
+      "name": "UNICEF Youth Advocate Ayshka on Mental Health",
+      "url": "https://youtu.be/zsiMg1zRdWU?si=hcMihJqh28_QfkwD",
+      "key": "unicef_youth_advocate_ayshka_on_mental_health",
+      "properties": {
+        "audience": "Student",
+        "type": "Video"
+      },
+      "seeding_key": {
+        "resource.key": "unicef_youth_advocate_ayshka_on_mental_health"
       }
     },
     {
@@ -7706,6 +7986,19 @@
       },
       "seeding_key": {
         "resource.key": "unit_guide"
+      }
+    },
+    {
+      "name": "Unplugged Neural Networks",
+      "url": "https://docs.google.com/document/d/168FsA22aT-Tup4H9OHIvffToo6N2PDSL8u07AgdJgec/edit?usp=drivesdk",
+      "key": "unplugged_neural_networks",
+      "properties": {
+        "audience": "Student",
+        "include_in_pdf": true,
+        "type": "Activity Guide"
+      },
+      "seeding_key": {
+        "resource.key": "unplugged_neural_networks"
       }
     },
     {
@@ -7725,7 +8018,31 @@
     {
       "seeding_key": {
         "lesson.key": "Lesson 10: Remixing, Creativity, and Originality",
+        "resource.key": "_key_ai_remix_challenge"
+      }
+    },
+    {
+      "seeding_key": {
+        "lesson.key": "Lesson 10: Remixing, Creativity, and Originality",
         "resource.key": "_key_problem_solving_with_ai_unit_guide_exemplar"
+      }
+    },
+    {
+      "seeding_key": {
+        "lesson.key": "Lesson 10: Remixing, Creativity, and Originality",
+        "resource.key": "ai_remix_challenge"
+      }
+    },
+    {
+      "seeding_key": {
+        "lesson.key": "Lesson 10: Remixing, Creativity, and Originality",
+        "resource.key": "create_a_game_using_ai"
+      }
+    },
+    {
+      "seeding_key": {
+        "lesson.key": "Lesson 10: Remixing, Creativity, and Originality",
+        "resource.key": "problem_solving_with_ai_unit_guide"
       }
     },
     {
@@ -7743,7 +8060,31 @@
     {
       "seeding_key": {
         "lesson.key": "Lesson 11: Ownership, Ethics, and Creativity",
+        "resource.key": "ownership_and_ai_stations"
+      }
+    },
+    {
+      "seeding_key": {
+        "lesson.key": "Lesson 11: Ownership, Ethics, and Creativity",
+        "resource.key": "ownership_and_ai_stations_1"
+      }
+    },
+    {
+      "seeding_key": {
+        "lesson.key": "Lesson 11: Ownership, Ethics, and Creativity",
         "resource.key": "ownership_ethics_and_creativity"
+      }
+    },
+    {
+      "seeding_key": {
+        "lesson.key": "Lesson 11: Ownership, Ethics, and Creativity",
+        "resource.key": "problem_solving_with_ai_unit_guide"
+      }
+    },
+    {
+      "seeding_key": {
+        "lesson.key": "Lesson 12: AI's Role in Society",
+        "resource.key": "_key_ai_in_the_community"
       }
     },
     {
@@ -7755,7 +8096,31 @@
     {
       "seeding_key": {
         "lesson.key": "Lesson 12: AI's Role in Society",
+        "resource.key": "ai_in_grocery_stores_-_1"
+      }
+    },
+    {
+      "seeding_key": {
+        "lesson.key": "Lesson 12: AI's Role in Society",
+        "resource.key": "ai_in_the_community"
+      }
+    },
+    {
+      "seeding_key": {
+        "lesson.key": "Lesson 12: AI's Role in Society",
         "resource.key": "ai_s_role_in_society"
+      }
+    },
+    {
+      "seeding_key": {
+        "lesson.key": "Lesson 12: AI's Role in Society",
+        "resource.key": "problem_solving_with_ai_unit_guide"
+      }
+    },
+    {
+      "seeding_key": {
+        "lesson.key": "Lesson 12: AI's Role in Society",
+        "resource.key": "unicef_youth_advocate_ayshka_on_mental_health"
       }
     },
     {
@@ -7791,6 +8156,24 @@
     {
       "seeding_key": {
         "lesson.key": "Lesson 1: Talking to Machines",
+        "resource.key": "plan_a_perfect_trip_with_chatgpt"
+      }
+    },
+    {
+      "seeding_key": {
+        "lesson.key": "Lesson 1: Talking to Machines",
+        "resource.key": "problem_solving_with_ai"
+      }
+    },
+    {
+      "seeding_key": {
+        "lesson.key": "Lesson 1: Talking to Machines",
+        "resource.key": "problem_solving_with_ai_unit_guide"
+      }
+    },
+    {
+      "seeding_key": {
+        "lesson.key": "Lesson 1: Talking to Machines",
         "resource.key": "talking_to_machines"
       }
     },
@@ -7808,8 +8191,26 @@
     },
     {
       "seeding_key": {
+        "lesson.key": "Lesson 2: Beyond Words",
+        "resource.key": "problem_solving_with_ai_unit_guide"
+      }
+    },
+    {
+      "seeding_key": {
         "lesson.key": "Lesson 3: The AI's Brain",
         "resource.key": "_key_problem_solving_with_ai_unit_guide_exemplar"
+      }
+    },
+    {
+      "seeding_key": {
+        "lesson.key": "Lesson 3: The AI's Brain",
+        "resource.key": "how_chatbots_and_large_language_models_work"
+      }
+    },
+    {
+      "seeding_key": {
+        "lesson.key": "Lesson 3: The AI's Brain",
+        "resource.key": "problem_solving_with_ai_unit_guide"
       }
     },
     {
@@ -7820,8 +8221,20 @@
     },
     {
       "seeding_key": {
+        "lesson.key": "Lesson 3: The AI's Brain",
+        "resource.key": "unplugged_neural_networks"
+      }
+    },
+    {
+      "seeding_key": {
         "lesson.key": "Lesson 4: Smart or Just Predictable?",
         "resource.key": "_key_problem_solving_with_ai_unit_guide_exemplar"
+      }
+    },
+    {
+      "seeding_key": {
+        "lesson.key": "Lesson 4: Smart or Just Predictable?",
+        "resource.key": "problem_solving_with_ai_unit_guide"
       }
     },
     {
@@ -7833,7 +8246,25 @@
     {
       "seeding_key": {
         "lesson.key": "Lesson 5: Uncovering Contradictions",
+        "resource.key": "_key_examining_ai_contradictions"
+      }
+    },
+    {
+      "seeding_key": {
+        "lesson.key": "Lesson 5: Uncovering Contradictions",
         "resource.key": "_key_problem_solving_with_ai_unit_guide_exemplar"
+      }
+    },
+    {
+      "seeding_key": {
+        "lesson.key": "Lesson 5: Uncovering Contradictions",
+        "resource.key": "examining_ai_contradictions"
+      }
+    },
+    {
+      "seeding_key": {
+        "lesson.key": "Lesson 5: Uncovering Contradictions",
+        "resource.key": "problem_solving_with_ai_unit_guide"
       }
     },
     {
@@ -7845,13 +8276,37 @@
     {
       "seeding_key": {
         "lesson.key": "Lesson 6: Understanding Bias",
+        "resource.key": "_key_ai_audit"
+      }
+    },
+    {
+      "seeding_key": {
+        "lesson.key": "Lesson 6: Understanding Bias",
         "resource.key": "_key_problem_solving_with_ai_unit_guide_exemplar"
       }
     },
     {
       "seeding_key": {
         "lesson.key": "Lesson 6: Understanding Bias",
+        "resource.key": "ai_audit"
+      }
+    },
+    {
+      "seeding_key": {
+        "lesson.key": "Lesson 6: Understanding Bias",
+        "resource.key": "problem_solving_with_ai_unit_guide"
+      }
+    },
+    {
+      "seeding_key": {
+        "lesson.key": "Lesson 6: Understanding Bias",
         "resource.key": "understanding_bias"
+      }
+    },
+    {
+      "seeding_key": {
+        "lesson.key": "Lesson 7: AI's Wild Imagination",
+        "resource.key": "_key_hallucination_case_studies"
       }
     },
     {
@@ -7868,6 +8323,24 @@
     },
     {
       "seeding_key": {
+        "lesson.key": "Lesson 7: AI's Wild Imagination",
+        "resource.key": "hallucination_case_studies"
+      }
+    },
+    {
+      "seeding_key": {
+        "lesson.key": "Lesson 7: AI's Wild Imagination",
+        "resource.key": "jigsaw_articles"
+      }
+    },
+    {
+      "seeding_key": {
+        "lesson.key": "Lesson 7: AI's Wild Imagination",
+        "resource.key": "problem_solving_with_ai_unit_guide"
+      }
+    },
+    {
+      "seeding_key": {
         "lesson.key": "Lesson 8: Debugging and Refining Outputs",
         "resource.key": "_key_problem_solving_with_ai_unit_guide_exemplar"
       }
@@ -7875,7 +8348,25 @@
     {
       "seeding_key": {
         "lesson.key": "Lesson 8: Debugging and Refining Outputs",
+        "resource.key": "ai_s_hottest_new_job_pays_up_to_250k_a_year_so_i_applied_wsj_"
+      }
+    },
+    {
+      "seeding_key": {
+        "lesson.key": "Lesson 8: Debugging and Refining Outputs",
         "resource.key": "debugging_and_refining_outputs"
+      }
+    },
+    {
+      "seeding_key": {
+        "lesson.key": "Lesson 8: Debugging and Refining Outputs",
+        "resource.key": "problem_solving_with_ai_unit_guide"
+      }
+    },
+    {
+      "seeding_key": {
+        "lesson.key": "Lesson 9: AI as a Co-Creator",
+        "resource.key": "_key_collaborate_on_a_product_launch"
       }
     },
     {
@@ -7888,6 +8379,18 @@
       "seeding_key": {
         "lesson.key": "Lesson 9: AI as a Co-Creator",
         "resource.key": "ai_as_a_co-creator"
+      }
+    },
+    {
+      "seeding_key": {
+        "lesson.key": "Lesson 9: AI as a Co-Creator",
+        "resource.key": "collaborate_on_a_product_launch"
+      }
+    },
+    {
+      "seeding_key": {
+        "lesson.key": "Lesson 9: AI as a Co-Creator",
+        "resource.key": "problem_solving_with_ai_unit_guide"
       }
     }
   ],
@@ -7939,10 +8442,328 @@
 
   ],
   "vocabularies": [
-
+    {
+      "key": "abstraction",
+      "word": "abstraction",
+      "definition": "focusing on the important information and ignoring irrelevant details",
+      "properties": {
+      },
+      "seeding_key": {
+        "vocabulary.key": "abstraction"
+      }
+    },
+    {
+      "key": "ai_bias",
+      "word": "AI bias",
+      "definition": "when a model favors certain information over others",
+      "properties": {
+      },
+      "seeding_key": {
+        "vocabulary.key": "ai_bias"
+      }
+    },
+    {
+      "key": "alignment",
+      "word": "alignment",
+      "definition": "ensuring an AI system’s goals and outputs match human values, fairness, and safety",
+      "properties": {
+      },
+      "seeding_key": {
+        "vocabulary.key": "alignment"
+      }
+    },
+    {
+      "key": "artificial_intelligence_ai_",
+      "word": "artificial intelligence (AI)",
+      "definition": "a technology that mimics human intelligence, performing tasks such as understanding language, recognizing patterns, and making decisions",
+      "properties": {
+      },
+      "seeding_key": {
+        "vocabulary.key": "artificial_intelligence_ai_"
+      }
+    },
+    {
+      "key": "attribution",
+      "word": "attribution",
+      "definition": "the act of giving credit to the original creator of a work, especially in the context of using or referencing their material",
+      "properties": {
+      },
+      "seeding_key": {
+        "vocabulary.key": "attribution"
+      }
+    },
+    {
+      "key": "co_creating",
+      "word": "co-creating",
+      "definition": "humans and AI working together, with humans providing creativity and direction, while AI assists by processing data, generating suggestions, or automating tasks",
+      "properties": {
+      },
+      "seeding_key": {
+        "vocabulary.key": "co_creating"
+      }
+    },
+    {
+      "key": "context",
+      "word": "context",
+      "definition": "additional information or data surrounding a prompt or query that helps the AI generate more accurate and relevant responses",
+      "properties": {
+      },
+      "seeding_key": {
+        "vocabulary.key": "context"
+      }
+    },
+    {
+      "key": "contradiction",
+      "word": "contradiction",
+      "definition": "when an AI generates conflicting or opposing responses based on a similar input, making it impossible for both responses to be correct at the same time",
+      "properties": {
+      },
+      "seeding_key": {
+        "vocabulary.key": "contradiction"
+      }
+    },
+    {
+      "key": "copyright",
+      "word": "copyright",
+      "definition": "the legal right granted to the creator of an original work to use, distribute, and modify it",
+      "properties": {
+      },
+      "seeding_key": {
+        "vocabulary.key": "copyright"
+      }
+    },
+    {
+      "key": "ethics",
+      "word": "ethics",
+      "definition": "a guide for responsible choices about emerging technologies, ensuring privacy, consent, and safety for everyone",
+      "properties": {
+      },
+      "seeding_key": {
+        "vocabulary.key": "ethics"
+      }
+    },
+    {
+      "key": "hallucination",
+      "word": "hallucination",
+      "definition": "when the model makes up false or misleading information that sounds real but isn’t true",
+      "properties": {
+      },
+      "seeding_key": {
+        "vocabulary.key": "hallucination"
+      }
+    },
+    {
+      "key": "large_language_model_llm_",
+      "word": "large language model (LLM)",
+      "definition": "a general purpose form of AI that is trained on a very, very large body of knowledge",
+      "properties": {
+      },
+      "seeding_key": {
+        "vocabulary.key": "large_language_model_llm_"
+      }
+    },
+    {
+      "key": "multimodal_model",
+      "word": "multimodal model",
+      "definition": "an AI system that can process information from multiple types of input",
+      "properties": {
+      },
+      "seeding_key": {
+        "vocabulary.key": "multimodal_model"
+      }
+    },
+    {
+      "key": "neural_network",
+      "word": "neural network",
+      "definition": "an interconnected network that makes decisions using weights and hidden layers. It is used to represent the relationship between words",
+      "properties": {
+      },
+      "seeding_key": {
+        "vocabulary.key": "neural_network"
+      }
+    },
+    {
+      "key": "probability",
+      "word": "probability",
+      "definition": "the likelihood that a specific outcome might occur",
+      "properties": {
+      },
+      "seeding_key": {
+        "vocabulary.key": "probability"
+      }
+    },
+    {
+      "key": "prompt",
+      "word": "prompt",
+      "definition": "a question, instruction, scenario, or statement provided by the user to guide the AI's response",
+      "properties": {
+      },
+      "seeding_key": {
+        "vocabulary.key": "prompt"
+      }
+    },
+    {
+      "key": "prompt_engineering",
+      "word": "prompt engineering",
+      "definition": "the process of creating precise and effective prompts to guide generative AI models",
+      "properties": {
+      },
+      "seeding_key": {
+        "vocabulary.key": "prompt_engineering"
+      }
+    },
+    {
+      "key": "training",
+      "word": "training",
+      "definition": "the process of teaching an AI model by exposing it to large amounts of data, allowing it to learn patterns, improve accuracy, and refine its predictions over time",
+      "properties": {
+      },
+      "seeding_key": {
+        "vocabulary.key": "training"
+      }
+    },
+    {
+      "key": "training_data",
+      "word": "training data",
+      "definition": "the structured or unstructured information, such as text, images, or code, used to train an AI model and shape its ability to recognize patterns and generate accurate responses",
+      "properties": {
+      },
+      "seeding_key": {
+        "vocabulary.key": "training_data"
+      }
+    },
+    {
+      "key": "transparency",
+      "word": "transparency",
+      "definition": "the practice of openly disclosing how something works, especially in terms of decision-making, data use, or AI processes",
+      "properties": {
+      },
+      "seeding_key": {
+        "vocabulary.key": "transparency"
+      }
+    }
   ],
   "lessons_vocabularies": [
-
+    {
+      "seeding_key": {
+        "lesson.key": "Lesson 11: Ownership, Ethics, and Creativity",
+        "vocabulary.key": "attribution"
+      }
+    },
+    {
+      "seeding_key": {
+        "lesson.key": "Lesson 11: Ownership, Ethics, and Creativity",
+        "vocabulary.key": "copyright"
+      }
+    },
+    {
+      "seeding_key": {
+        "lesson.key": "Lesson 11: Ownership, Ethics, and Creativity",
+        "vocabulary.key": "ethics"
+      }
+    },
+    {
+      "seeding_key": {
+        "lesson.key": "Lesson 11: Ownership, Ethics, and Creativity",
+        "vocabulary.key": "transparency"
+      }
+    },
+    {
+      "seeding_key": {
+        "lesson.key": "Lesson 1: Talking to Machines",
+        "vocabulary.key": "abstraction"
+      }
+    },
+    {
+      "seeding_key": {
+        "lesson.key": "Lesson 1: Talking to Machines",
+        "vocabulary.key": "artificial_intelligence_ai_"
+      }
+    },
+    {
+      "seeding_key": {
+        "lesson.key": "Lesson 1: Talking to Machines",
+        "vocabulary.key": "probability"
+      }
+    },
+    {
+      "seeding_key": {
+        "lesson.key": "Lesson 1: Talking to Machines",
+        "vocabulary.key": "prompt"
+      }
+    },
+    {
+      "seeding_key": {
+        "lesson.key": "Lesson 2: Beyond Words",
+        "vocabulary.key": "multimodal_model"
+      }
+    },
+    {
+      "seeding_key": {
+        "lesson.key": "Lesson 3: The AI's Brain",
+        "vocabulary.key": "large_language_model_llm_"
+      }
+    },
+    {
+      "seeding_key": {
+        "lesson.key": "Lesson 3: The AI's Brain",
+        "vocabulary.key": "neural_network"
+      }
+    },
+    {
+      "seeding_key": {
+        "lesson.key": "Lesson 3: The AI's Brain",
+        "vocabulary.key": "training"
+      }
+    },
+    {
+      "seeding_key": {
+        "lesson.key": "Lesson 3: The AI's Brain",
+        "vocabulary.key": "training_data"
+      }
+    },
+    {
+      "seeding_key": {
+        "lesson.key": "Lesson 4: Smart or Just Predictable?",
+        "vocabulary.key": "hallucination"
+      }
+    },
+    {
+      "seeding_key": {
+        "lesson.key": "Lesson 5: Uncovering Contradictions",
+        "vocabulary.key": "context"
+      }
+    },
+    {
+      "seeding_key": {
+        "lesson.key": "Lesson 5: Uncovering Contradictions",
+        "vocabulary.key": "contradiction"
+      }
+    },
+    {
+      "seeding_key": {
+        "lesson.key": "Lesson 6: Understanding Bias",
+        "vocabulary.key": "ai_bias"
+      }
+    },
+    {
+      "seeding_key": {
+        "lesson.key": "Lesson 6: Understanding Bias",
+        "vocabulary.key": "alignment"
+      }
+    },
+    {
+      "seeding_key": {
+        "lesson.key": "Lesson 8: Debugging and Refining Outputs",
+        "vocabulary.key": "prompt_engineering"
+      }
+    },
+    {
+      "seeding_key": {
+        "lesson.key": "Lesson 9: AI as a Co-Creator",
+        "vocabulary.key": "co_creating"
+      }
+    }
   ],
   "lessons_programming_expressions": [
 
@@ -8464,9 +9285,6 @@
     }
   ],
   "lessons_opportunity_standards": [
-
-  ],
-  "jit_pl_concepts_lessons": [
 
   ],
   "rubrics": [


### PR DESCRIPTION
Reverts the changes to dashboard/config/scripts_json/aif1-v2-2025.script_json from 17804006b10cee75492aa19cdbef3291a313eaef, as requested in [Slack](https://codedotorg.slack.com/archives/C0T0PNTM3/p1777600837948589). I used Claude to help me get the right command here (aside: LLMs are surprisingly awful at git) and we got to `git show 17804006b10cee75492aa19cdbef3291a313eaef -- dashboard/config/scripts_json/aif1-v2-2025.script_json | git apply -R` which seems to do what I expect!

The only thing that isn't a revert is the serialized_at timestamp. That timestamp is roughly the time I did the revert so that we regenerate the PDFs.
