### PR TITLE
Remove Build Time Dependency on LaunchPad.net

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -90,7 +90,7 @@ steps:
 
   - name: unit-tests
     # see: docker/ci/Dockerfile
-    image: codedotorg/cdo-ci:1.20
+    image: codedotorg/cdo-ci:remove-ppa
     pull: always
     environment:
       CI_JOB: 'unit_tests'
@@ -212,7 +212,7 @@ steps:
 
   - name: ui-tests
     # see: docker/ci/Dockerfile
-    image: codedotorg/cdo-ci:1.20
+    image: codedotorg/cdo-ci:remove-ppa
     pull: always
     volumes:
       - name: mysql
@@ -297,7 +297,7 @@ steps:
   # snapshot of the fully-built project and resulting database, but don't
   # actually run the tests.
   - name: prepare-cacheable-build
-    image: codedotorg/cdo-ci:1.20
+    image: codedotorg/cdo-ci:remove-ppa
     pull: always
     environment:
       CI_JOB: 'prepare_cacheable_build'
@@ -344,6 +344,6 @@ trigger:
 
 ---
 kind: signature
-hmac: 737c499e8c5036a43dfcef713bafadff8d5e604cce81c2d895de471f46250dc2
+hmac: d7e5559ff170793907bec9242dcf47f78378f8861e5ee202562f6ab2726f3698
 
 ...

--- a/cookbooks/cdo-github-access/recipes/default.rb
+++ b/cookbooks/cdo-github-access/recipes/default.rb
@@ -19,12 +19,6 @@
 
 apt_package 'gnupg'
 
-apt_repository 'git-core' do
-  uri          'ppa:git-core/ppa'
-  distribution 'trusty'
-  retries 3
-end
-
 apt_package 'git'
 
 # Install Git LFS, from: https://packagecloud.io/github/git-lfs/install#chef

--- a/cookbooks/cdo-syslog/.kitchen.yml
+++ b/cookbooks/cdo-syslog/.kitchen.yml
@@ -10,9 +10,9 @@ provisioner:
 verifier:
   name: inspec
 platforms:
-- name: ubuntu-18.04
+- name: ubuntu-20.04
   driver:
-    image: dokken/ubuntu-18.04
+    image: dokken/ubuntu-20.04
     pid_one_command: /bin/systemd
   run_list:
   - recipe[apt]

--- a/cookbooks/cdo-syslog/recipes/default.rb
+++ b/cookbooks/cdo-syslog/recipes/default.rb
@@ -3,12 +3,6 @@
 # Recipe:: default
 #
 
-include_recipe 'apt'
-apt_repository 'rsyslog' do
-  uri 'ppa:adiscon/v8-stable'
-  distribution node['lsb']['codename']
-  retries 3
-end
 apt_package %w(rsyslog) do
   action :upgrade
 end

--- a/docker/ci/Dockerfile
+++ b/docker/ci/Dockerfile
@@ -72,7 +72,8 @@ FROM base AS primary-layer
 #########################################################
 
 # MAINLINE UBUNTU PACKAGE DEPS SHOULD BE ADDED HERE
-RUN apt-get install -y --no-install-recommends \
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
     apt-transport-https \
     ca-certificates \
     enscript \
@@ -91,7 +92,6 @@ RUN apt-get install -y --no-install-recommends \
     python \
     python-dev \
     python3-pip \
-    software-properties-common \
     sudo \
     tar \
     tzdata \
@@ -135,11 +135,6 @@ RUN usermod -d /var/lib/mysql/ mysql
 #
 #  ERROR 2002 (HY000): Can't connect to local MySQL server through socket '/run/mysqld/mysqld.sock' (13) 
 RUN sudo chmod -R 755 /run/mysqld
-
-# we need git >= 2.15 to use git rev-parse --is-shallow-clone feature
-RUN add-apt-repository ppa:git-core/ppa && \
-    apt-get update && \
-    apt-get install -y git>=2.15
 
 # we need git-lfs >= 3.0 to use SSH authentication with git-lfs
 RUN curl -sS https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh | bash && \


### PR DESCRIPTION
https://codedotorg.slack.com/archives/C0T0PNTM3/p1777643535074999

When our Chef cookbooks build / install our web application on AWS EC2 Instances they install `git-core` and `rsyslog` from the Ubuntu Personal Package Archive operated by Canonical. That website (launchpad.net) is currently experiencing [availability issues](https://status.canonical.com), which is causing builds on all our Chef-provisioned systems to fail.

We don't need to install these packages because the versions that ship with Ubuntu 20+ should meet our needs.


## Testing story
`bundle exec rake adhoc:start RAILS_ENV=adhoc STACK_NAME=adhoc-remove-ppa-dependencies`



## Deployment notes




## Privacy and security
<!-- Delete this section if there is no privacy/security impact.
     Otherwise: new PII, auth changes, API surface changes, etc. -->

