### PR TITLE
Ensures that student_lesson_plan mimics the behavior of lessons/show for block rendering.

### DIFF
--- a/apps/src/sites/studio/pages/lessons/student_lesson_plan.js
+++ b/apps/src/sites/studio/pages/lessons/student_lesson_plan.js
@@ -10,10 +10,12 @@ import {registerReducers} from '@cdo/apps/redux';
 import instructionsDialog from '@cdo/apps/redux/instructionsDialog';
 import ExpandableImageDialog from '@cdo/apps/templates/lessonOverview/ExpandableImageDialog';
 import StudentLessonOverview from '@cdo/apps/templates/lessonOverview/StudentLessonOverview';
+import {prepareBlocklyForEmbeddingAllEnvironments} from '@cdo/apps/templates/utils/embeddedBlocklyUtils';
 import {createReactRoot} from '@cdo/apps/util/createReactRoot';
 import getScriptData from '@cdo/apps/util/getScriptData';
 
 $(document).ready(function () {
+  prepareBlocklyForEmbeddingAllEnvironments();
   displayLessonOverview();
   prepareExpandableImageDialog();
 });

--- a/dashboard/app/views/lessons/student_lesson_plan.html.haml
+++ b/dashboard/app/views/lessons/student_lesson_plan.html.haml
@@ -1,5 +1,11 @@
 %link{href: asset_path('css/lessons.css'), rel: 'stylesheet', type: 'text/css'}
-%script{src: webpack_asset_path('js/lessons/student_lesson_plan.js'), data: {lesson: @lesson_data.to_json, scriptName: @script_name.to_json}}
+/ TODO: Add an explicit "associated programming environment" property to levels,
+// so we only load the locale strings and block definitions needed for that environment.
+// Currently we always include music and Sprite Lab assets for embedded blocks for code docs.
+%script{src: webpack_asset_path("js/#{js_locale}/music_locale.js")}
+%script{src: webpack_asset_path('js/lessons/student_lesson_plan.js'), data: {lesson: @lesson_data.to_json, scriptName: @script_name.to_json, customBlocksConfig: Block.for('GamelabJr').to_json}}
+%script{src: webpack_asset_path('js/blockly.js')}
+%script{src: webpack_asset_path("js/#{js_locale}/blockly_locale.js")}
 
 = render partial: 'shared/emulate_print_media'
 


### PR DESCRIPTION
Student lesson plans did not render their blocks when illustrating the new blocks on the page. Normal lesson plan pages successfully render them. So, this just copies that functionality to the affected page.

**Before**:

<img width="767" height="357" alt="image" src="https://github.com/user-attachments/assets/30f8ba78-100f-4d0e-9227-4d1af9edd2f9" />

**After**:

<img width="822" height="357" alt="image" src="https://github.com/user-attachments/assets/19748b4a-812f-421c-96b5-638c4a7a0c24" />

## Links
<!-- Jira tickets, design docs, Slack threads, related PRs, etc. -->

- Jira: [SL-1692](https://codedotorg.atlassian.net/browse/SL-1692)

## Testing story
<!-- How was this tested? Manual steps, adhoc links, automated tests, or why testing isn't needed. -->

Manually visited the page before and after the change.