### PR TITLE
Sketch lab: fix for start sources in version history

### DIFF
--- a/apps/src/sketchlab/excalidraw/ExcalidrawSketchLabView.tsx
+++ b/apps/src/sketchlab/excalidraw/ExcalidrawSketchLabView.tsx
@@ -343,6 +343,7 @@ const ExcalidrawSketchLabView: React.FC<LabProps<LevelProperties>> = ({
             settings={[useThemeSetting('sketchlab')]}
             versionHistoryProps={{
               startSources:
+                (levelProperties?.templateSources as ProjectSources) ||
                 (levelProperties?.startSources as ProjectSources) ||
                 DEFAULT_SOURCES,
               onLoadVersion: onLoadVersion,

--- a/apps/src/sketchlab/reactFlow/ReactFlowSketchLabView.tsx
+++ b/apps/src/sketchlab/reactFlow/ReactFlowSketchLabView.tsx
@@ -234,6 +234,7 @@ function ReactFlowSketchLabViewInner({
             settings={[useThemeSetting('sketchlab')]}
             versionHistoryProps={{
               startSources:
+                (levelProperties?.templateSources as ProjectSources) ||
                 (levelProperties?.startSources as ProjectSources) ||
                 REACT_FLOW_DEFAULT_SOURCES,
               onLoadVersion,


### PR DESCRIPTION
For project template backed sketch lab levels, if you clicked 'initial version' in version history it would not load the start sources for the template. The start sources were correctly populated when you clicked the 'start over' button in the header, which is probably why we didn't catch this. This fixes the start sources to be correct in both places. I updated the excalidraw version as well as react flow because why not 🤷‍♀️ This aligns with the logic in [SourcesContainer](https://github.com/code-dot-org/code-dot-org/blob/50c7eec42cef7d61ecbbddb17194a4a43a4ca8b0/apps/src/lab2/views/SourcesContainer.tsx#L131-L134), skipping the start mode check because the version history panel doesn't work in start mode.

