### PR TITLE
fix(geolocation): use more stable ip address

### DIFF
--- a/dashboard/test/ui/features/step_definitions/geolocation_steps.rb
+++ b/dashboard/test/ui/features/step_definitions/geolocation_steps.rb
@@ -12,7 +12,7 @@ Given "I am in Europe" do
   end
 
   # Get an appropriately european IP address
-  location_cookie = '102.177.191.255' # Spain
+  location_cookie = '150.214.39.255' # Spain
   steps %Q[Given I use a cookie to mock my IP address as "#{location_cookie}"]
 end
 


### PR DESCRIPTION
The IP address changed to South Africa breaking the GDPR test. Change to a more stable university in Spain. Longer term, use Cloudfront or other headers to decouple from external parties.

<!--
  Summary of the change: background, motivation, and context.
  Include screenshots, videos, or before/after comparisons for UI changes.
-->



## Links
<!-- Jira tickets, design docs, Slack threads, related PRs, etc. -->

- Jira:

## Testing story
<!-- How was this tested? Manual steps, adhoc links, automated tests, or why testing isn't needed. -->



## Deployment notes
<!-- Delete this section if it's a standard merge-and-deploy.
     Otherwise: migrations, feature flags, coordination, caching impacts, etc. -->



## Privacy and security
<!-- Delete this section if there is no privacy/security impact.
     Otherwise: new PII, auth changes, API surface changes, etc. -->

