### PR TITLE
Sketch2: support uploading images in start/exemplar modes

### DIFF
--- a/apps/src/sketchlab/reactFlow/ReactFlowSketchLabView.tsx
+++ b/apps/src/sketchlab/reactFlow/ReactFlowSketchLabView.tsx
@@ -282,6 +282,7 @@ function ReactFlowSketchLabViewInner({
             <ReactFlowCanvas
               key={mountKey}
               updateSources={updateSources}
+              levelName={levelProperties.name}
               initialNodes={initialNodes}
               initialEdges={initialEdges}
               initialViewport={initialViewport}

--- a/apps/src/sketchlab/reactFlow/components/ReactFlowCanvas.tsx
+++ b/apps/src/sketchlab/reactFlow/components/ReactFlowCanvas.tsx
@@ -87,6 +87,7 @@ export interface ReactFlowCanvasProps {
   updateSources: ReturnType<
     typeof useSources<ReactFlowSketchLabSources>
   >['updateSources'];
+  levelName: string;
   initialNodes: SketchlabReactFlowNode[];
   initialEdges: SketchlabReactFlowEdge[];
   initialViewport: SketchlabReactFlowSource['viewport'];
@@ -98,6 +99,7 @@ export const SKETCHLAB_CONTAINER_CLASS = 'sketchlab-react-flow-container';
 
 export default function ReactFlowCanvas({
   updateSources,
+  levelName,
   initialNodes,
   initialEdges,
   initialViewport,
@@ -560,7 +562,9 @@ export default function ReactFlowCanvas({
           onFocusCapture={handleFocusCapture}
           onBlur={handleContainerBlur}
         >
-          {!readOnly && <Toolbar onAddNode={handleAddNode} />}
+          {!readOnly && (
+            <Toolbar onAddNode={handleAddNode} levelName={levelName} />
+          )}
           <div aria-live="assertive" className={styles.srOnly}>
             {connectAnnouncement}
           </div>

--- a/apps/src/sketchlab/reactFlow/components/Toolbar.tsx
+++ b/apps/src/sketchlab/reactFlow/components/Toolbar.tsx
@@ -2,6 +2,10 @@ import FontAwesomeV6Icon from '@code-dot-org/component-library/fontAwesomeV6Icon
 import {IconButton, Paper, Tooltip} from '@mui/material';
 import React, {ChangeEvent, useCallback, useId} from 'react';
 
+import {
+  getAppOptionsEditingExemplar,
+  getIsStartMode,
+} from '@cdo/apps/lab2/projects/utils';
 import useHiddenFileInput from '@cdo/apps/util/hooks/useHiddenFileInput';
 import HttpClient from '@cdo/apps/util/HttpClient';
 import {useAppSelector} from '@cdo/apps/util/reduxHooks';
@@ -14,9 +18,10 @@ import styles from './toolbar.module.scss';
 
 interface ToolbarProps {
   onAddNode: (request: AddNodeRequest) => void;
+  levelName: string;
 }
 
-export default function Toolbar({onAddNode}: ToolbarProps) {
+export default function Toolbar({onAddNode, levelName}: ToolbarProps) {
   const channelId = useAppSelector(state => state.lab.channel?.id) ?? '';
   // Use a stable ID prefix for accessibility.
   const uid = useId();
@@ -31,16 +36,34 @@ export default function Toolbar({onAddNode}: ToolbarProps) {
   const onFileSelected = useCallback(
     async (event: ChangeEvent<HTMLInputElement>) => {
       const file = event.target.files?.[0];
-      if (!file || !channelId) {
+      if (!file) {
+        return;
+      }
+
+      const isStarterAssetOrExemplar = !!(
+        getIsStartMode() || getAppOptionsEditingExemplar()
+      );
+      if (!isStarterAssetOrExemplar && !channelId) {
         return;
       }
 
       const extension = file.name.split('.').pop() ?? 'png';
       const filename = `${createUuid()}.${extension}`;
-      const uploadUrl = `${ASSET_PATH_PREFIX}/${channelId}/${filename}`;
+      const uploadUrl = isStarterAssetOrExemplar
+        ? `/level_starter_assets/${encodeURIComponent(
+            levelName
+          )}/uuid/${filename}`
+        : `${ASSET_PATH_PREFIX}/${channelId}/${filename}`;
 
       try {
-        await HttpClient.put(uploadUrl, file);
+        if (isStarterAssetOrExemplar) {
+          const bodyData = new FormData();
+          bodyData.append('files[]', file);
+          await HttpClient.post(uploadUrl, bodyData, true);
+        } else {
+          await HttpClient.put(uploadUrl, file);
+        }
+
         onAddNode({
           type: 'image',
           data: {src: uploadUrl, altText: file.name.replace(/\.[^.]+$/, '')},
@@ -49,7 +72,7 @@ export default function Toolbar({onAddNode}: ToolbarProps) {
         console.error('Failed to upload image:', error);
       }
     },
-    [channelId, onAddNode]
+    [channelId, levelName, onAddNode]
   );
 
   const [openFileInput, FileInput] = useHiddenFileInput(


### PR DESCRIPTION
Supports adding images in start and exemplar modes. Reuses similar functionality designed for the initial version of Sketch Lab.

## Links

- Jira: https://codedotorg.atlassian.net/browse/AFL-619

## Testing story

Tested manually that I could upload images and read them in both start mode and exemplar modes. Also confirmed that I could still upload images to a specific project (ie, the existing flow).