### PR TITLE
bypass podcast generation if inadequate credits remain

### DIFF
--- a/dashboard/app/helpers/ai_lesson_summary_podcasts_helper.rb
+++ b/dashboard/app/helpers/ai_lesson_summary_podcasts_helper.rb
@@ -4,12 +4,14 @@ module AiLessonSummaryPodcastsHelper
   PODCAST_FOLDER = 'podcasts/'
 
   def self.create_and_save_to_s3(lesson_id, user_id)
-    script = AiLessonSummariesHelper.retrieve_and_save_ai_lesson_summary(lesson_id, user_id, true)[:script]
-    filename = PODCAST_FOLDER + 'lesson_' + lesson_id.to_s + '_podcast.mp3'
+    if client.available_credits
+      script = AiLessonSummariesHelper.retrieve_and_save_ai_lesson_summary(lesson_id, user_id, true)[:script]
+      filename = PODCAST_FOLDER + 'lesson_' + lesson_id.to_s + '_podcast.mp3'
 
-    unless AWS::S3.exists_in_bucket(PODCAST_BUCKET, filename)
-      podcast = get_podcast_from_script(script)
-      AWS::S3.upload_to_bucket(PODCAST_BUCKET, filename, podcast, no_random: true)
+      unless AWS::S3.exists_in_bucket(PODCAST_BUCKET, filename)
+        podcast = get_podcast_from_script(script)
+        AWS::S3.upload_to_bucket(PODCAST_BUCKET, filename, podcast, no_random: true)
+      end
     end
   end
 
@@ -38,11 +40,30 @@ module AiLessonSummaryPodcastsHelper
     attr_accessor :api_key, :model
 
     VOICE_ID = "Fc5CaIGWKvLHapoOSM2K"
-    ELEVENLABS_URL = "https://api.elevenlabs.io/v1/text-to-speech/#{VOICE_ID}?output_format=mp3_44100_128"
+    ELEVENLABS_BASE_URL = "https://api.elevenlabs.io/v1"
+    ELEVENLABS_SUBSCRIPTION_PATH = "/user/subscription"
+    ELEVENLABS_TTS_PATH = "/text-to-speech/#{VOICE_ID}?output_format=mp3_44100_128"
 
     def initialize(api_key, model)
       @api_key = api_key
       @model = model
+    end
+
+    def available_credits
+      headers = {
+        "Content-Type" => "application/json",
+        "xi-api-key" => @api_key
+      }
+
+      user_response = HTTParty.get(
+        ELEVENLABS_BASE_URL + ELEVENLABS_SUBSCRIPTION_PATH,
+        headers: headers,
+        timeout: 180,
+      )
+
+      subscription_info = JSON.parse(user_response.body)
+
+      subscription_info['character_count'] < subscription_info['character_limit'] * 0.95
     end
 
     def request_podcast(prompt)
@@ -57,7 +78,7 @@ module AiLessonSummaryPodcastsHelper
       }
 
       HTTParty.post(
-        ELEVENLABS_URL,
+        ELEVENLABS_URL + ELEVENLABS_TTS_PATH,
         headers: headers,
         body: data.to_json,
         timeout: 180,

--- a/dashboard/app/helpers/ai_lesson_summary_podcasts_helper.rb
+++ b/dashboard/app/helpers/ai_lesson_summary_podcasts_helper.rb
@@ -78,7 +78,7 @@ module AiLessonSummaryPodcastsHelper
       }
 
       HTTParty.post(
-        ELEVENLABS_URL + ELEVENLABS_TTS_PATH,
+        ELEVENLABS_BASE_URL + ELEVENLABS_TTS_PATH,
         headers: headers,
         body: data.to_json,
         timeout: 180,

--- a/dashboard/test/helpers/ai_lesson_summary_podcasts_helper_test.rb
+++ b/dashboard/test/helpers/ai_lesson_summary_podcasts_helper_test.rb
@@ -121,8 +121,10 @@ class AiLessonSummaryPodcastsHelperTest < ActionView::TestCase
 
   test "Client has correct constants" do
     assert_equal "Fc5CaIGWKvLHapoOSM2K", AiLessonSummaryPodcastsHelper::Client::VOICE_ID
-    assert_equal "https://api.elevenlabs.io/v1/text-to-speech/Fc5CaIGWKvLHapoOSM2K?output_format=mp3_44100_128",
-                 AiLessonSummaryPodcastsHelper::Client::ELEVENLABS_URL
+    assert_equal "https://api.elevenlabs.io/v1", AiLessonSummaryPodcastsHelper::Client::ELEVENLABS_BASE_URL
+    assert_equal "/user/subscription", AiLessonSummaryPodcastsHelper::Client::ELEVENLABS_SUBSCRIPTION_PATH
+    assert_equal "/text-to-speech/Fc5CaIGWKvLHapoOSM2K?output_format=mp3_44100_128",
+                 AiLessonSummaryPodcastsHelper::Client::ELEVENLABS_TTS_PATH
   end
 
   # *****
@@ -370,5 +372,124 @@ class AiLessonSummaryPodcastsHelperTest < ActionView::TestCase
     end
 
     assert_includes error.message, "status code 500"
+  end
+
+  test "get_podcast_from_script handles Net::OpenTimeout error" do
+    mock_client = mock('client')
+    mock_client.expects(:request_podcast).raises(Net::OpenTimeout)
+    AiLessonSummaryPodcastsHelper::Client.expects(:new).returns(mock_client)
+
+    error = assert_raises(StandardError) do
+      AiLessonSummaryPodcastsHelper.get_podcast_from_script(@test_script)
+    end
+
+    assert_equal "Timeout waiting for AI client to return lesson summary podcast", error.message
+  end
+
+  # *****
+  # Client class tests - available_credits method
+  # *****
+
+  test "Client available_credits returns true when under 95% usage" do
+    client = AiLessonSummaryPodcastsHelper::Client.new(@api_key, @model)
+
+    mock_response = mock('response')
+    mock_response.stubs(:body).returns(JSON.generate({'character_count' => 900, 'character_limit' => 1000}))
+
+    HTTParty.expects(:get).with(
+      "https://api.elevenlabs.io/v1/user/subscription",
+      headers: @expected_headers,
+      timeout: 180
+    ).returns(mock_response)
+
+    assert client.available_credits
+  end
+
+  test "Client available_credits returns false when at or above 95% usage" do
+    client = AiLessonSummaryPodcastsHelper::Client.new(@api_key, @model)
+
+    mock_response = mock('response')
+    mock_response.stubs(:body).returns(JSON.generate({'character_count' => 950, 'character_limit' => 1000}))
+
+    HTTParty.stubs(:get).returns(mock_response)
+
+    refute client.available_credits
+  end
+
+  test "Client available_credits returns false when exactly at 95% usage" do
+    client = AiLessonSummaryPodcastsHelper::Client.new(@api_key, @model)
+
+    mock_response = mock('response')
+    mock_response.stubs(:body).returns(JSON.generate({'character_count' => 95, 'character_limit' => 100}))
+
+    HTTParty.stubs(:get).returns(mock_response)
+
+    refute client.available_credits
+  end
+
+  # *****
+  # create_and_save_to_s3 tests
+  # *****
+
+  test "create_and_save_to_s3 skips all processing when credits unavailable" do
+    mock_client = mock('client')
+    mock_client.stubs(:available_credits).returns(false)
+    AiLessonSummaryPodcastsHelper.stubs(:client).returns(mock_client)
+
+    AiLessonSummariesHelper.expects(:retrieve_and_save_ai_lesson_summary).never
+    AWS::S3.expects(:upload_to_bucket).never
+
+    AiLessonSummaryPodcastsHelper.create_and_save_to_s3(42, 1)
+  end
+
+  test "create_and_save_to_s3 generates and uploads podcast when credits available and file absent" do
+    mock_client = mock('client')
+    mock_client.stubs(:available_credits).returns(true)
+    AiLessonSummaryPodcastsHelper.stubs(:client).returns(mock_client)
+
+    AiLessonSummariesHelper.stubs(:retrieve_and_save_ai_lesson_summary).with(42, 1, true).
+      returns({script: @test_script})
+    AWS::S3.stubs(:exists_in_bucket).returns(false)
+    AiLessonSummaryPodcastsHelper.stubs(:get_podcast_from_script).returns(@test_audio_data)
+
+    expected_filename = 'podcasts/lesson_42_podcast.mp3'
+    AWS::S3.expects(:upload_to_bucket).with(
+      AiLessonSummaryPodcastsHelper::PODCAST_BUCKET,
+      expected_filename,
+      @test_audio_data,
+      no_random: true
+    )
+
+    AiLessonSummaryPodcastsHelper.create_and_save_to_s3(42, 1)
+  end
+
+  test "create_and_save_to_s3 skips upload when file already exists in S3" do
+    mock_client = mock('client')
+    mock_client.stubs(:available_credits).returns(true)
+    AiLessonSummaryPodcastsHelper.stubs(:client).returns(mock_client)
+
+    AiLessonSummariesHelper.stubs(:retrieve_and_save_ai_lesson_summary).returns({script: @test_script})
+    AWS::S3.stubs(:exists_in_bucket).returns(true)
+
+    AWS::S3.expects(:upload_to_bucket).never
+
+    AiLessonSummaryPodcastsHelper.create_and_save_to_s3(42, 1)
+  end
+
+  # *****
+  # retrieve_podcast_from_s3 tests
+  # *****
+
+  test "retrieve_podcast_from_s3 downloads from correct bucket and path" do
+    expected_filename = 'podcasts/lesson_42_podcast.mp3'
+
+    AWS::S3.expects(:download_from_bucket).with(
+      AiLessonSummaryPodcastsHelper::PODCAST_BUCKET,
+      expected_filename
+    ).returns(@test_audio_data)
+
+    result = AiLessonSummaryPodcastsHelper.retrieve_podcast_from_s3(42)
+
+    assert_equal @test_audio_data, result
   end
 end

--- a/dashboard/test/helpers/ai_lesson_summary_podcasts_helper_test.rb
+++ b/dashboard/test/helpers/ai_lesson_summary_podcasts_helper_test.rb
@@ -12,7 +12,7 @@ class AiLessonSummaryPodcastsHelperTest < ActionView::TestCase
     # Mock CDO constant
     CDO.stubs(:elevenlabs_api_key).returns(@api_key)
 
-    @expected_url = "https://api.elevenlabs.io/v1/text-to-speech/#{@voice_id}?output_format=mp3_44100_128"
+    @expected_tts_url = "https://api.elevenlabs.io/v1/text-to-speech/#{@voice_id}?output_format=mp3_44100_128"
     @expected_headers = {
       "Content-Type" => "application/json",
       "xi-api-key" => @api_key
@@ -141,7 +141,7 @@ class AiLessonSummaryPodcastsHelperTest < ActionView::TestCase
 
     # Expect HTTParty.post to be called with correct parameters
     HTTParty.expects(:post).with(
-      @expected_url,
+      @expected_tts_url,
       headers: @expected_headers,
       body: @expected_body,
       timeout: 180
@@ -159,8 +159,7 @@ class AiLessonSummaryPodcastsHelperTest < ActionView::TestCase
     HTTParty.stubs(:post).returns(mock_response)
 
     # Capture the actual headers sent
-    HTTParty.expects(:post).with do |url, options|
-      puts url
+    HTTParty.expects(:post).with do |_url, options|
       headers = options[:headers]
       headers["Content-Type"] == "application/json" &&
         headers["xi-api-key"] == @api_key
@@ -176,8 +175,7 @@ class AiLessonSummaryPodcastsHelperTest < ActionView::TestCase
     HTTParty.stubs(:post).returns(mock_response)
 
     # Capture the actual body sent
-    HTTParty.expects(:post).with do |url, options|
-      puts url
+    HTTParty.expects(:post).with do |_url, options|
       body_data = JSON.parse(options[:body])
       body_data["model_id"] == @model &&
         body_data["text"] == @test_script
@@ -192,7 +190,7 @@ class AiLessonSummaryPodcastsHelperTest < ActionView::TestCase
     mock_response = mock('response')
 
     # Expect HTTParty.post to be called with the exact URL
-    HTTParty.expects(:post).with(@expected_url, anything).returns(mock_response)
+    HTTParty.expects(:post).with(@expected_tts_url, anything).returns(mock_response)
 
     client.request_podcast(@test_script)
   end
@@ -208,7 +206,7 @@ class AiLessonSummaryPodcastsHelperTest < ActionView::TestCase
     mock_response.stubs(:body).returns(@test_audio_data)
 
     HTTParty.expects(:post).with(
-      @expected_url,
+      @expected_tts_url,
       headers: @expected_headers,
       body: @expected_body,
       timeout: 180
@@ -295,7 +293,7 @@ class AiLessonSummaryPodcastsHelperTest < ActionView::TestCase
     }.to_json
 
     HTTParty.expects(:post).with(
-      @expected_url,
+      @expected_tts_url,
       headers: @expected_headers,
       body: expected_body,
       timeout: 180


### PR DESCRIPTION
This update adds a check to make sure we have available Elevenlabs credits before attempting to generate new lesson summary podcasts. Currently, we are getting a lot of Honeybadger errors any time our credits are low. After this update, the task exits silently if there are not enough credits.

## Links
[TEACHING-178](https://codedotorg.atlassian.net/browse/TEACHING-178)

- Jira:

## Testing story
Updated unit tests to account for new podcast generation logic



## Deployment notes
<!-- Delete this section if it's a standard merge-and-deploy.
     Otherwise: migrations, feature flags, coordination, caching impacts, etc. -->



## Privacy and security
<!-- Delete this section if there is no privacy/security impact.
     Otherwise: new PII, auth changes, API surface changes, etc. -->

