### PR TITLE
Sketch2: move zoom controls to bottom right

### DIFF
--- a/apps/src/sketchlab/reactFlow/components/ReactFlowCanvas.tsx
+++ b/apps/src/sketchlab/reactFlow/components/ReactFlowCanvas.tsx
@@ -612,7 +612,7 @@ export default function ReactFlowCanvas({
               />
             )}
             <Background />
-            <Controls />
+            <Controls position="bottom-right" />
           </ReactFlow>
         </div>
       </ToolbarVisibilityProvider>


### PR DESCRIPTION
Moves the zoom controls to the bottom right of the canvas to avoid conflicts with the toolbar we have on the left side.

<img width="3360" height="1650" alt="image" src="https://github.com/user-attachments/assets/c9130026-a85b-4406-9611-a1e04ada9542" />

## Links

- Jira: https://codedotorg.atlassian.net/browse/AFL-623
