### PR TITLE
JSON Video - Add fullscreen support 

### DIFF
--- a/apps/src/jsonVideo/jsonVideoElement.js
+++ b/apps/src/jsonVideo/jsonVideoElement.js
@@ -73,6 +73,7 @@ export class JsonVideo extends HTMLElement {
                     </div>
                     <div style="flex-grow: 1;"></div>
                     <button id="cc-btn" class="control-btn"></button>
+                    <button id="fullscreen-btn" class="control-btn"></button>
                 </div>
                 <div id="progress-container">
                     <input type="range" id="progress-bar" min="0" max="100" value="0" step="0.1">
@@ -96,6 +97,7 @@ export class JsonVideo extends HTMLElement {
       totTime: this.shadowRoot.querySelector('#tot-time'),
       volume: this.shadowRoot.querySelector('#volume-slider'),
       ccBtn: this.shadowRoot.querySelector('#cc-btn'),
+      fullscreenBtn: this.shadowRoot.querySelector('#fullscreen-btn'),
     };
 
     this._bindEvents();
@@ -140,6 +142,20 @@ export class JsonVideo extends HTMLElement {
       this.ui.ccBtn.classList.toggle('disabled', !this._showCaptions);
       this._renderCurrentScene();
     };
+
+    this.ui.fullscreenBtn.onclick = () => this._toggleFullscreen();
+
+    this._onFullscreenChange = () => {
+      const isFs =
+        document.fullscreenElement === this ||
+        document.webkitFullscreenElement === this;
+      this.ui.fullscreenBtn.classList.toggle('fullscreen-active', isFs);
+    };
+    document.addEventListener('fullscreenchange', this._onFullscreenChange);
+    document.addEventListener(
+      'webkitfullscreenchange',
+      this._onFullscreenChange
+    );
 
     this.shadowRoot.querySelector('#video-container').onclick = e => {
       if (
@@ -355,6 +371,25 @@ export class JsonVideo extends HTMLElement {
       m = Math.floor(s / 60),
       sec = s % 60;
     return `${m}:${String(sec).padStart(2, '0')}`;
+  }
+
+  _toggleFullscreen() {
+    if (
+      document.fullscreenElement === this ||
+      document.webkitFullscreenElement === this
+    ) {
+      (document.exitFullscreen || document.webkitExitFullscreen).call(document);
+    } else {
+      (this.requestFullscreen || this.webkitRequestFullscreen).call(this);
+    }
+  }
+
+  disconnectedCallback() {
+    document.removeEventListener('fullscreenchange', this._onFullscreenChange);
+    document.removeEventListener(
+      'webkitfullscreenchange',
+      this._onFullscreenChange
+    );
   }
 
   _calculateDurations() {

--- a/apps/src/jsonVideo/jsonVideoStyles.ts
+++ b/apps/src/jsonVideo/jsonVideoStyles.ts
@@ -204,6 +204,24 @@ iframe {
     display: none !important;
 }
 
+
+/* Fullscreen Button */
+#fullscreen-btn {
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath fill='white' d='M7 14H5v5h5v-2H7v-3zm-2-4h2V7h3V5H5v5zm12 7h-3v2h5v-5h-2v3zM14 5v2h3v3h2V5h-5z'/%3E%3C/svg%3E");
+}
+
+#fullscreen-btn.fullscreen-active {
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath fill='white' d='M5 16h3v3h2v-5H5v2zm3-8H5v2h5V5H8v3zm6 11h2v-3h3v-2h-5v5zm2-11V5h-2v5h5V8h-3z'/%3E%3C/svg%3E");
+}
+
+/* Fullscreen layout */
+:host(:fullscreen),
+:host(:-webkit-full-screen) {
+    aspect-ratio: unset;
+    width: 100%;
+    height: 100%;
+}
+
 /* Progress bar */
 input[type=range] {
     -webkit-appearance: none;


### PR DESCRIPTION
## Summary

This PR adds fullscreen support to the JSON video (player) custom element, allowing users to expand the video player to fill the entire screen. Clicking the fullscreen button brings the user to fullscreen mode and  clicking the button again (or [ESC]) exits:

https://github.com/user-attachments/assets/dd3bad13-8586-4ca2-a9c0-f52a17729098


## Key Changes
- **UI Control**: Added a fullscreen button to the player controls bar
- **Fullscreen Toggle**: Implemented `_toggleFullscreen()` method that handles entering and exiting fullscreen mode with cross-browser support (standard and webkit prefixes)
- **State Management**: Added fullscreen state tracking with visual button feedback via the `fullscreen-active` CSS class
- **Event Handling**: Registered listeners for `fullscreenchange` and `webkitfullscreenchange` events to update button state when fullscreen mode changes
- **Cleanup**: Implemented `disconnectedCallback()` to properly remove event listeners when the component is removed from the DOM
- **Styling**: Added CSS for the fullscreen button with SVG icons for both normal and active states, plus fullscreen layout styles that make the player fill 100% width/height

## Implementation Details
- Uses both standard Fullscreen API and webkit-prefixed variants for broader browser compatibility
- The fullscreen button visually indicates the current state


