### PR TITLE
Fix redaction of section names with deleted section owner

### DIFF
--- a/dashboard/app/models/sections/section.rb
+++ b/dashboard/app/models/sections/section.rb
@@ -257,7 +257,7 @@ class Section < ApplicationRecord
 
   after_save :ensure_owner_is_active_instructor
   def ensure_owner_is_active_instructor
-    return if user.blank?
+    return if user.blank? || user.deleted?
 
     add_instructor(user)
   end

--- a/dashboard/test/lib/services/user/pii_scrubber_test.rb
+++ b/dashboard/test/lib/services/user/pii_scrubber_test.rb
@@ -58,6 +58,7 @@ class Services::User::PiiScrubberTest < ActiveSupport::TestCase
     end
 
     it 'redacts section names' do
+      section
       scrub_pii
       user.sections_owned.with_deleted.each do |section|
         _(section.reload.name).must_equal Services::User::PiiScrubber::REDACTED_STRING


### PR DESCRIPTION
The PII scrubber has been hitting some errors scrubbing certain section names. When the section is saved after redacting the name, it runs the [ensure_owner_is_active_instructor](https://github.com/code-dot-org/code-dot-org/blob/staging/dashboard/app/models/sections/section.rb#L259-L263) validation, which attempts to add the owner if they don't already have a SectionInstructor record for the section. Since the owner is already deleted in this case, the validation errors out.

This PR fixes the issue by adding a guard in the validation to short-circuit if the user is deleted. It also fixes the relevant test, which wasn't actually saving the section because the `let` was never called. This meant the test was simply doing a no-op instead of redacting the section name.

## Links
[JIRA](https://codedotorg.atlassian.net/browse/P20-1857)

## Testing story
<!-- How was this tested? Manual steps, adhoc links, automated tests, or why testing isn't needed. -->



## Deployment notes
<!-- Delete this section if it's a standard merge-and-deploy.
     Otherwise: migrations, feature flags, coordination, caching impacts, etc. -->



## Privacy and security
<!-- Delete this section if there is no privacy/security impact.
     Otherwise: new PII, auth changes, API surface changes, etc. -->

