### PR TITLE
switch LTI HB error to Sentry

### DIFF
--- a/apps/src/simpleSignUp/lti/sync/LtiSectionSyncDialog.story.tsx
+++ b/apps/src/simpleSignUp/lti/sync/LtiSectionSyncDialog.story.tsx
@@ -100,6 +100,6 @@ Error.args = {
   isOpen: true,
   syncResult: {
     error: 'no_integration',
-    honeybadger_id: 'some-honeybadger-id',
+    error_id: 'some-error-id',
   },
 };

--- a/apps/src/simpleSignUp/lti/sync/LtiSectionSyncDialog.tsx
+++ b/apps/src/simpleSignUp/lti/sync/LtiSectionSyncDialog.tsx
@@ -82,10 +82,10 @@ export default function LtiSectionSyncDialog({
             markdown={errorMessage}
           />
         ))}
-        {syncResult.honeybadger_id && (
+        {syncResult.error_id && (
           <Typography variant="body4" gutterBottom>
             {i18n.ltiSectionSyncDialogErrorCode({
-              code: syncResult.honeybadger_id,
+              code: syncResult.error_id,
             })}
           </Typography>
         )}

--- a/apps/src/simpleSignUp/lti/sync/types.ts
+++ b/apps/src/simpleSignUp/lti/sync/types.ts
@@ -20,7 +20,7 @@ export interface LtiSectionSyncResult {
   error?: string;
   message?: string;
   course_name?: string;
-  honeybadger_id?: string;
+  error_id?: string;
 }
 
 export interface LtiSectionSyncDialogProps {

--- a/dashboard/app/controllers/lti_v1_controller.rb
+++ b/dashboard/app/controllers/lti_v1_controller.rb
@@ -257,11 +257,9 @@ class LtiV1Controller < ApplicationController
   end
 
   def render_sync_course_error(reason, status, error = nil, message: nil)
-    # We want to log the error to Honeybadger, as we don't expect this to happen
-    # often.
-    honeybadger_id = Honeybadger.notify(
+    error_id = Sentry.capture_message(
       'LTI roster sync error',
-      context: {
+      extra: {
         reason:,
         details: message,
       }
@@ -272,11 +270,11 @@ class LtiV1Controller < ApplicationController
         reason:,
         status:,
         error:,
-        honeybadger_id:,
+        error_id:,
       }
     )
     @lti_section_sync_result = {error: error, message: message}
-    @lti_section_sync_result[:honeybadger_id] = honeybadger_id if honeybadger_id
+    @lti_section_sync_result[:error_id] = error_id if error_id
     return respond_to do |format|
       format.html do
         render lti_v1_sync_course_path, status: status

--- a/dashboard/app/controllers/lti_v1_controller.rb
+++ b/dashboard/app/controllers/lti_v1_controller.rb
@@ -257,13 +257,7 @@ class LtiV1Controller < ApplicationController
   end
 
   def render_sync_course_error(reason, status, error = nil, message: nil)
-    error_id = Sentry.capture_message(
-      'LTI roster sync error',
-      extra: {
-        reason:,
-        details: message,
-      }
-    )
+    error_id = capture_sync_course_error_id(reason, message)
     Clients::LtiLogger.log_event(
       message,
       {
@@ -281,6 +275,18 @@ class LtiV1Controller < ApplicationController
       end
       format.json {render json: @lti_section_sync_result, status: status}
     end
+  end
+
+  def capture_sync_course_error_id(reason, message)
+    return unless Observability::Sentry.enabled? && defined?(::Sentry)
+
+    ::Sentry.capture_message(
+      'LTI roster sync error',
+      extra: {
+        reason:,
+        details: message,
+      }
+    )
   end
 
   # GET /lti/v1/sync_course

--- a/dashboard/app/controllers/lti_v1_controller.rb
+++ b/dashboard/app/controllers/lti_v1_controller.rb
@@ -278,9 +278,7 @@ class LtiV1Controller < ApplicationController
   end
 
   def capture_sync_course_error_id(reason, message)
-    return unless Observability::Sentry.enabled? && defined?(::Sentry)
-
-    ::Sentry.capture_message(
+    Observability::Errors.capture_message(
       'LTI roster sync error',
       extra: {
         reason:,

--- a/dashboard/app/controllers/lti_v1_controller.rb
+++ b/dashboard/app/controllers/lti_v1_controller.rb
@@ -278,13 +278,15 @@ class LtiV1Controller < ApplicationController
   end
 
   def capture_sync_course_error_id(reason, message)
-    Observability::Errors.capture_message(
+    event = Observability::Errors.capture_message(
       'LTI roster sync error',
       extra: {
         reason:,
         details: message,
       }
     )
+
+    event&.event_id
   end
 
   # GET /lti/v1/sync_course

--- a/dashboard/test/controllers/lti_v1_controller_test.rb
+++ b/dashboard/test/controllers/lti_v1_controller_test.rb
@@ -758,45 +758,6 @@ class LtiV1ControllerTest < ActionDispatch::IntegrationTest
         LtiV1Controller.any_instance.expects(:render_sync_course_error).with("Missing lti_integration_id.", :bad_request, 'missing_param')
         sync_course
       end
-
-      it 'returns an error_id in the json response' do
-        error_id = 'sentry-event-id'
-        sign_in user
-
-        Sentry.expects(:capture_message).with do |message, options|
-          assert_equal 'LTI roster sync error', message
-          assert_equal(
-            {
-              reason: 'Missing lti_integration_id.',
-              details: nil,
-            },
-            options[:extra]
-          )
-          true
-        end.returns(error_id)
-
-        Clients::LtiLogger.expects(:log_event).with(
-          nil,
-          {
-            reason: 'Missing lti_integration_id.',
-            status: :bad_request,
-            error: 'missing_param',
-            error_id:,
-          }
-        )
-
-        get '/lti/v1/sync_course', params: params, as: :json
-
-        assert_response :bad_request
-        assert_equal(
-          {
-            'error' => 'missing_param',
-            'message' => nil,
-            'error_id' => error_id,
-          },
-          JSON.parse(@response.body)
-        )
-      end
     end
 
     context 'when context or nrps_url is missing' do

--- a/dashboard/test/controllers/lti_v1_controller_test.rb
+++ b/dashboard/test/controllers/lti_v1_controller_test.rb
@@ -758,6 +758,45 @@ class LtiV1ControllerTest < ActionDispatch::IntegrationTest
         LtiV1Controller.any_instance.expects(:render_sync_course_error).with("Missing lti_integration_id.", :bad_request, 'missing_param')
         sync_course
       end
+
+      it 'returns an error_id in the json response' do
+        error_id = 'sentry-event-id'
+        sign_in user
+
+        Sentry.expects(:capture_message).with do |message, options|
+          assert_equal 'LTI roster sync error', message
+          assert_equal(
+            {
+              reason: 'Missing lti_integration_id.',
+              details: nil,
+            },
+            options[:extra]
+          )
+          true
+        end.returns(error_id)
+
+        Clients::LtiLogger.expects(:log_event).with(
+          nil,
+          {
+            reason: 'Missing lti_integration_id.',
+            status: :bad_request,
+            error: 'missing_param',
+            error_id:,
+          }
+        )
+
+        get '/lti/v1/sync_course', params: params, as: :json
+
+        assert_response :bad_request
+        assert_equal(
+          {
+            'error' => 'missing_param',
+            'message' => nil,
+            'error_id' => error_id,
+          },
+          JSON.parse(@response.body)
+        )
+      end
     end
 
     context 'when context or nrps_url is missing' do


### PR DESCRIPTION
The Honeybadger errors in the LtiV1Controller have been unreliably logging the correct HB ID. This PR switches to using Sentry instead, where we will hopefully see the ID more reliably logged. I also renamed the variable to the vendor-agnostic `error_id`. Some parts of the front-end code is touched because we display the error ID to the user for more helpful Zendesk reporting.

## Links
[JIRA](https://codedotorg.atlassian.net/browse/P20-1873)

## Testing story
<!-- How was this tested? Manual steps, adhoc links, automated tests, or why testing isn't needed. -->



## Deployment notes
<!-- Delete this section if it's a standard merge-and-deploy.
     Otherwise: migrations, feature flags, coordination, caching impacts, etc. -->



## Privacy and security
<!-- Delete this section if there is no privacy/security impact.
     Otherwise: new PII, auth changes, API surface changes, etc. -->

