### PR TITLE
move available credits check

### DIFF
--- a/dashboard/app/helpers/ai_lesson_summary_podcasts_helper.rb
+++ b/dashboard/app/helpers/ai_lesson_summary_podcasts_helper.rb
@@ -4,14 +4,12 @@ module AiLessonSummaryPodcastsHelper
   PODCAST_FOLDER = 'podcasts/'
 
   def self.create_and_save_to_s3(lesson_id, user_id)
-    if client.available_credits
-      script = AiLessonSummariesHelper.retrieve_and_save_ai_lesson_summary(lesson_id, user_id, true)[:script]
-      filename = PODCAST_FOLDER + 'lesson_' + lesson_id.to_s + '_podcast.mp3'
+    script = AiLessonSummariesHelper.retrieve_and_save_ai_lesson_summary(lesson_id, user_id, true)[:script]
+    filename = PODCAST_FOLDER + 'lesson_' + lesson_id.to_s + '_podcast.mp3'
 
-      unless AWS::S3.exists_in_bucket(PODCAST_BUCKET, filename)
-        podcast = get_podcast_from_script(script)
-        AWS::S3.upload_to_bucket(PODCAST_BUCKET, filename, podcast, no_random: true)
-      end
+    if !AWS::S3.exists_in_bucket(PODCAST_BUCKET, filename) && client.available_credits
+      podcast = get_podcast_from_script(script)
+      AWS::S3.upload_to_bucket(PODCAST_BUCKET, filename, podcast, no_random: true)
     end
   end
 

--- a/dashboard/test/helpers/ai_lesson_summary_podcasts_helper_test.rb
+++ b/dashboard/test/helpers/ai_lesson_summary_podcasts_helper_test.rb
@@ -429,12 +429,13 @@ class AiLessonSummaryPodcastsHelperTest < ActionView::TestCase
   # create_and_save_to_s3 tests
   # *****
 
-  test "create_and_save_to_s3 skips all processing when credits unavailable" do
+  test "create_and_save_to_s3 skips generating podcast when credits unavailable" do
     mock_client = mock('client')
     mock_client.stubs(:available_credits).returns(false)
     AiLessonSummaryPodcastsHelper.stubs(:client).returns(mock_client)
 
-    AiLessonSummariesHelper.expects(:retrieve_and_save_ai_lesson_summary).never
+    AiLessonSummariesHelper.stubs(:retrieve_and_save_ai_lesson_summary).with(42, 1, true).
+      returns({script: @test_script})
     AWS::S3.expects(:upload_to_bucket).never
 
     AiLessonSummaryPodcastsHelper.create_and_save_to_s3(42, 1)


### PR DESCRIPTION
This update moves the check for available Elevenlabs credits so that it doesn't block our backend from retrieving existing podcast transcripts if the podcast has already been generated.

## Links
<!-- Jira tickets, design docs, Slack threads, related PRs, etc. -->

- Jira:

## Testing story
<!-- How was this tested? Manual steps, adhoc links, automated tests, or why testing isn't needed. -->



## Deployment notes
<!-- Delete this section if it's a standard merge-and-deploy.
     Otherwise: migrations, feature flags, coordination, caching impacts, etc. -->



## Privacy and security
<!-- Delete this section if there is no privacy/security impact.
     Otherwise: new PII, auth changes, API surface changes, etc. -->

