### PR TITLE
chore(newrelic): disable New Relic in prod

### DIFF
--- a/config/production.yml.erb
+++ b/config/production.yml.erb
@@ -19,7 +19,6 @@ sinatra_session_secret: !Secret
 db_credential_admin: {"username":"ACCESS_DISABLED", "password":"ACCESS_DISABLED"}
 <% end %>
 
-newrelic_logging: true
 stack_name: autoscale-prod
 solr_server:                            solr.code.org
 use_pusher:                             true


### PR DESCRIPTION
Removes newrelic_logging: true from production.yml.erb. This allows CDO.newrelic_logging to default to false, which gates the require 'newrelic_rpm' call in dashboard/config/application.rb, preventing the New Relic agent from loading on the backend server.
