### PR TITLE
Use PL certificate for HoAI PL curriculum

### DIFF
--- a/dashboard/app/models/unit.rb
+++ b/dashboard/app/models/unit.rb
@@ -1194,7 +1194,7 @@ class Unit < ApplicationRecord
   end
 
   def finish_url(unit_group_unit: nil)
-    return hoc_finish_url if hoc_or_hoai?
+    return hoc_finish_url if hoc_or_hoai? && !pl_course?
     return csf_finish_url if csf?
     course = unit_group_unit&.unit_group || get_original_unit_group
     ApplicationController.helpers.course_completion_certificate_url(course_name: course ? course.name : name)

--- a/dashboard/lib/certificate_image.rb
+++ b/dashboard/lib/certificate_image.rb
@@ -294,8 +294,8 @@ class CertificateImage
   def self.course_type(course_name)
     unit_or_unit_group = CurriculumHelper.find_matching_unit_or_unit_group(course_name)
     course_version = unit_or_unit_group&.get_course_version
-    return CERTIFICATE_COURSE_TYPES[:HOC] if course_version&.hoc_or_hoai?
     return CERTIFICATE_COURSE_TYPES[:PL] if course_version&.pl_course?
+    return CERTIFICATE_COURSE_TYPES[:HOC] if course_version&.hoc_or_hoai?
     return CERTIFICATE_COURSE_TYPES[:OTHER] if course_version
     CERTIFICATE_COURSE_TYPES[:HOC]
   end

--- a/dashboard/test/lib/certificate_image_test.rb
+++ b/dashboard/test/lib/certificate_image_test.rb
@@ -100,6 +100,16 @@ class CertificateImageTest < ActiveSupport::TestCase
     assert_equal '\\\\', CertificateImage.escape_image_magick_string('\\')
   end
 
+  def test_hoai_pl_course_returns_pl_certificate_type
+    unit = create(:script)
+    course = create(:single_unit_course, unit: unit, instructor_audience: 'facilitator', participant_audience: 'teacher')
+    cv = create(:course_version, content_root: course)
+    create(:course_offering, course_versions: [cv], key: unit.name, marketing_initiative: 'HOAI')
+    unit.reload
+
+    assert_equal CERTIFICATE_COURSE_TYPES[:PL], CertificateImage.course_type(unit.name)
+  end
+
   def test_hoc_course
     coursea = create(:script, name: "coursea-2021")
     coursea_course = create(:single_unit_course, unit: coursea, name: "coursea-2021", family_name: 'coursea', version_year: '2021')

--- a/dashboard/test/models/unit_test.rb
+++ b/dashboard/test/models/unit_test.rb
@@ -2160,6 +2160,18 @@ class UnitTest < ActiveSupport::TestCase
     end
   end
 
+  test 'finish_url for hoai pl unit returns certificate url, not hoc finish url' do
+    unit = create(:script)
+    course = create(:single_unit_course, unit: unit, instructor_audience: 'facilitator', participant_audience: 'teacher')
+    CourseOffering.add_course_offering(course).update!(marketing_initiative: 'HOAI')
+    unit.reload
+
+    assert unit.hoc_or_hoai?
+    assert unit.pl_course?
+    encoded_course_name = ERB::Util.url_encode(Base64.urlsafe_encode64(course.name))
+    assert_equal "#{CDO.default_scheme}//test-studio.code.org/congrats?s=#{encoded_course_name}", unit.finish_url
+  end
+
   test 'finish_url returns unit group finish url if in a unit group' do
     unit_group = create(:unit_group)
     unit = create(:script)


### PR DESCRIPTION
We got a Zendesk ticket that, after finishing "Mix & Move with AI - Educator's Experience" (the PL counterpart to our HoAI tutorial), users were getting a 404. There's a very long [Slack thread]() on this but the tldr is that we try to serve an HoAI certificate for any courses that are marked as HoAI (like this one). But in the case of PL, we aren't tracking usage so the link 404s. The change in this PR makes it so PL courses are always served the PL finish URL and certificate.


Certificate for "Mix & Move with AI - Educator's Experience":

<img width="1357" height="773" alt="image" src="https://github.com/user-attachments/assets/4ca7a7d4-2dc4-47bc-8c8d-80e9edf499e0" />


An alternate option would be to not mark this curriculum as HoAI. However, that was less desirable because it would mean that this curriculum wouldn't appear under the HoAI filter on the PL course catalog. The change in this PR maintains that filter:

<img width="868" height="710" alt="image" src="https://github.com/user-attachments/assets/535ecfa9-bd26-431b-bb16-881792a25217" />


Feature code (all two lines of it) was written by me; tests were written by Claude and reviewed by me.

