### PR TITLE
Cut Chrome/Firefox/iPhone/iPad UI tests over to Device Farm

### DIFF
--- a/dashboard/test/ui/README.md
+++ b/dashboard/test/ui/README.md
@@ -18,7 +18,16 @@ Review all supported tags in [ci.rake](https://github.com/code-dot-org/code-dot-
 
 ### DTT (CD) Tests
 
-The UI tests run as part of our deployment during the Deploy To Test (DTT). In this scenario, the full suite of tests is run against all browsers configured in "browsers_saucelabs.json"
+The UI tests run as part of our deployment during the Deploy To Test (DTT) via `rake test:ui_all`, which dispatches four suites in parallel against two providers:
+
+| Suite | Provider | Browsers |
+|-------|----------|----------|
+| Safari | SauceLabs | `Safari` (`browsers_saucelabs.json`) |
+| Chrome + Firefox | AWS Device Farm | `Chrome`, `Firefox` (`browsers_device_farm.json`) |
+| Mobile | AWS Device Farm | `iPhone`, `iPad` (`browsers_device_farm.json`) |
+| Eyes | SauceLabs | `Chrome`, `iPhone` (Applitools visual diff, `@eyes` / `@eyes_mobile`) |
+
+Each suite uploads its own status page (`test_status_{Safari,Chrome_Firefox,Mobile,Eyes}.html`) to the test machine and to S3. Provider names ("SauceLabs", "Device Farm") are not surfaced in Slack messages or status page headings -- the suite label is what oncall sees.
 
 ## Local Setup
 

--- a/dashboard/test/ui/README.md
+++ b/dashboard/test/ui/README.md
@@ -22,12 +22,12 @@ The UI tests run as part of our deployment during the Deploy To Test (DTT) via `
 
 | Suite | Provider | Browsers |
 |-------|----------|----------|
-| Safari | SauceLabs | `Safari` (`browsers_saucelabs.json`) |
-| Chrome + Firefox | AWS Device Farm | `Chrome`, `Firefox` (`browsers_device_farm.json`) |
-| Mobile | AWS Device Farm | `iPhone`, `iPad` (`browsers_device_farm.json`) |
+| Safari UI | SauceLabs | `Safari` (`browsers_saucelabs.json`) |
+| Chrome + Firefox UI | AWS Device Farm | `Chrome`, `Firefox` (`browsers_device_farm.json`) |
+| Mobile UI | AWS Device Farm | `iPhone`, `iPad` (`browsers_device_farm.json`) |
 | Eyes | SauceLabs | `Chrome`, `iPhone` (Applitools visual diff, `@eyes` / `@eyes_mobile`) |
 
-Each suite uploads its own status page (`test_status_{Safari,Chrome_Firefox,Mobile,Eyes}.html`) to the test machine and to S3. Provider names ("SauceLabs", "Device Farm") are not surfaced in Slack messages or status page headings -- the suite label is what oncall sees.
+Each suite uploads its own status page (`test_status_{Safari_UI,Chrome_Firefox_UI,Mobile_UI,Eyes}.html`) to the test machine and to S3. Provider names ("SauceLabs", "Device Farm") are not surfaced in Slack messages or status page headings -- the suite label is what oncall sees.
 
 ## Local Setup
 

--- a/dashboard/test/ui/README.md
+++ b/dashboard/test/ui/README.md
@@ -22,10 +22,10 @@ The UI tests run as part of our deployment during the Deploy To Test (DTT) via `
 
 | Suite | Provider | Browsers |
 |-------|----------|----------|
-| Safari UI | SauceLabs | `Safari` (`browsers_saucelabs.json`) |
-| Chrome + Firefox UI | AWS Device Farm | `Chrome`, `Firefox` (`browsers_device_farm.json`) |
-| Mobile UI | AWS Device Farm | `iPhone`, `iPad` (`browsers_device_farm.json`) |
-| Eyes | SauceLabs | `Chrome`, `iPhone` (Applitools visual diff, `@eyes` / `@eyes_mobile`) |
+| Safari UI | SauceLabs | `macOS Safari` (`browsers_saucelabs.json`) |
+| Chrome + Firefox UI | AWS Device Farm | `Windows Chrome`, `Windows Firefox` (`browsers_device_farm.json`) |
+| Mobile UI | AWS Device Farm | `iPhone Safari`, `iPad Safari` (`browsers_device_farm.json`) |
+| Eyes | SauceLabs | `Windows Chrome`, `iPhone Safari` (Applitools visual diff, `@eyes` / `@eyes_mobile`) |
 
 Each suite uploads its own status page (`test_status_{Safari_UI,Chrome_Firefox_UI,Mobile_UI,Eyes}.html`) to the test machine and to S3. Provider names ("SauceLabs", "Device Farm") are not surfaced in Slack messages or status page headings -- the suite label is what oncall sees.
 

--- a/dashboard/test/ui/runner.rb
+++ b/dashboard/test/ui/runner.rb
@@ -400,26 +400,19 @@ def test_type
   eyes? ? 'Eyes' : 'UI'
 end
 
-# Human-readable test-run label used in Slack/log report headers. Device
-# Farm desktop, mobile, and combined runs are dispatched as separate
-# runner.rb invocations against separate concurrency quotas; without a
-# distinguishing prefix the per-suite report messages from a single DTT
-# look identical in #infra-test. SauceLabs runs are left as just the
-# bare test_type for now -- the 'Sauce Labs' prefix lands in the Device
-# Farm launch PR.
+# Human-readable suite label used in Slack/log report headers and as
+# the status page <title> and <h1>. The provider (SauceLabs / Device
+# Farm) is no longer surfaced -- oncall sees a label that names the
+# suite by its browsers. Eyes runs are always "Eyes" (eyes only runs
+# on SauceLabs today). Non-eyes runs derive the label from their
+# active browser configs:
+#   -c Safari          => "Safari"
+#   -c Chrome,Firefox  => "Chrome + Firefox"
+#   -c iPhone,iPad     => "Mobile"
 def test_type_label
-  return test_type unless $options.device_farm
-  any_mobile = $browsers.any? {|b| mobile_browser?(b)}
-  all_mobile = $browsers.all? {|b| mobile_browser?(b)}
-  device_farm_kind =
-    if all_mobile
-      'Mobile'
-    elsif any_mobile
-      'Combined'
-    else
-      'Desktop'
-    end
-  "Device Farm #{device_farm_kind} #{test_type}"
+  return test_type if eyes?
+  return 'Mobile' if $browsers.all? {|b| mobile_browser?(b)}
+  $browsers.map {|b| b['name']}.uniq.sort.join(' + ')
 end
 
 def eyes?
@@ -500,17 +493,12 @@ end
 # cross-page navigation row at the top of each status page. Each entry's
 # :filename must equal the value status_page_filename returns when that
 # page is being generated, so the active entry can be rendered unlinked.
-# For now, the UI Test Status page will render this as:
-#
-#   UI Test Status | <a href="...">Eyes Test Status</a>
-#
-# TODO(device-farm-launch): rename the UI entry's filename to
-# 'test_status_UI_sauce_labs.html', update status_page_filename below to
-# match for the SauceLabs branch, and add device farm desktop/mobile
-# entries.
+# The four entries are the four suites rake test:ui_all dispatches.
 STATUS_PAGES_NAVIGATION = [
-  {filename: 'test_status_UI.html',   display_name: 'UI Test Status'},
-  {filename: 'test_status_Eyes.html', display_name: 'Eyes Test Status'},
+  {filename: 'test_status_Safari.html',         display_name: 'Safari'},
+  {filename: 'test_status_Chrome_Firefox.html', display_name: 'Chrome + Firefox'},
+  {filename: 'test_status_Mobile.html',         display_name: 'Mobile'},
+  {filename: 'test_status_Eyes.html',           display_name: 'Eyes'},
 ].freeze
 
 def status_pages_navigation
@@ -525,24 +513,15 @@ def status_pages_navigation
   end
 end
 
+# Status page filename per suite. Eyes keeps a stable name across
+# providers (we only run eyes on SauceLabs). Other suites name their
+# page after the suite label so the four ui_all suites
+# (Safari, Chrome+Firefox, Mobile, Eyes) get unique pages and don't
+# overwrite each other in the shared S3 prefix or in
+# dashboard/public/ui_test/.
 def status_page_filename
-  # SauceLabs runs keep the unqualified name. Device Farm runs are
-  # split into desktop/mobile/combined buckets so a desktop and a
-  # mobile run (which use separate concurrency quotas and are
-  # typically invoked as separate runner.rb commands) don't overwrite
-  # each other's status page in the shared S3 prefix.
-  return "test_status_#{test_type}.html" unless $options.device_farm
-  any_mobile = $browsers.any? {|b| mobile_browser?(b)}
-  all_mobile = $browsers.all? {|b| mobile_browser?(b)}
-  device_farm_kind =
-    if all_mobile
-      'mobile'
-    elsif any_mobile
-      'combined'
-    else
-      'desktop'
-    end
-  "test_status_#{test_type}_device_farm_#{device_farm_kind}.html"
+  return 'test_status_Eyes.html' if eyes?
+  "test_status_#{test_type_label.tr(' +', '_').squeeze('_')}.html"
 end
 
 # Returns a permalink URL for the Test Status Page, assuming we can upload it to S3
@@ -597,10 +576,7 @@ end
 def test_run_identifier(browser, feature)
   feature_name = feature.gsub(/.*features\//, '').gsub('.feature', '').tr('/', '_')
   browser_name = browser_name_or_unknown(browser)
-  # _df distinguishes Device Farm output from concurrent SauceLabs runs
-  # against the same browser+feature during the migration. Drop after we
-  # cut over fully to DF (or to a SauceLabs-only/DF-only steady state).
-  "#{browser_name}_#{feature_name}" + (eyes? ? '_eyes' : '') + ($options.device_farm ? '_df' : '')
+  "#{browser_name}_#{feature_name}" + (eyes? ? '_eyes' : '')
 end
 
 def browser_name_or_unknown(browser)

--- a/dashboard/test/ui/runner.rb
+++ b/dashboard/test/ui/runner.rb
@@ -405,14 +405,15 @@ end
 # Farm) is no longer surfaced -- oncall sees a label that names the
 # suite by its browsers. Eyes runs are always "Eyes" (eyes only runs
 # on SauceLabs today). Non-eyes runs derive the label from their
-# active browser configs:
-#   -c Safari          => "Safari"
-#   -c Chrome,Firefox  => "Chrome + Firefox"
-#   -c iPhone,iPad     => "Mobile"
+# active browser configs and append "UI" so it's clear the suite is
+# UI tests:
+#   -c Safari          => "Safari UI"
+#   -c Chrome,Firefox  => "Chrome + Firefox UI"
+#   -c iPhone,iPad     => "Mobile UI"
 def test_type_label
   return test_type if eyes?
-  return 'Mobile' if $browsers.all? {|b| mobile_browser?(b)}
-  $browsers.map {|b| b['name']}.uniq.sort.join(' + ')
+  return 'Mobile UI' if $browsers.all? {|b| mobile_browser?(b)}
+  "#{$browsers.map {|b| b['name']}.uniq.sort.join(' + ')} UI"
 end
 
 def eyes?
@@ -495,10 +496,10 @@ end
 # page is being generated, so the active entry can be rendered unlinked.
 # The four entries are the four suites rake test:ui_all dispatches.
 STATUS_PAGES_NAVIGATION = [
-  {filename: 'test_status_Safari.html',         display_name: 'Safari'},
-  {filename: 'test_status_Chrome_Firefox.html', display_name: 'Chrome + Firefox'},
-  {filename: 'test_status_Mobile.html',         display_name: 'Mobile'},
-  {filename: 'test_status_Eyes.html',           display_name: 'Eyes'},
+  {filename: 'test_status_Safari_UI.html',         display_name: 'Safari UI'},
+  {filename: 'test_status_Chrome_Firefox_UI.html', display_name: 'Chrome + Firefox UI'},
+  {filename: 'test_status_Mobile_UI.html',         display_name: 'Mobile UI'},
+  {filename: 'test_status_Eyes.html',              display_name: 'Eyes'},
 ].freeze
 
 def status_pages_navigation
@@ -516,8 +517,8 @@ end
 # Status page filename per suite. Eyes keeps a stable name across
 # providers (we only run eyes on SauceLabs). Other suites name their
 # page after the suite label so the four ui_all suites
-# (Safari, Chrome+Firefox, Mobile, Eyes) get unique pages and don't
-# overwrite each other in the shared S3 prefix or in
+# (Safari UI, Chrome + Firefox UI, Mobile UI, Eyes) get unique pages
+# and don't overwrite each other in the shared S3 prefix or in
 # dashboard/public/ui_test/.
 def status_page_filename
   return 'test_status_Eyes.html' if eyes?

--- a/dashboard/test/ui/test_status.haml
+++ b/dashboard/test/ui/test_status.haml
@@ -78,7 +78,6 @@
           The UI test directory on the test machine is `~/test/dashboard/test/ui`.
 
     %input#test-type{type: 'hidden', value: type}
-    %input#device-farm{type: 'hidden', value: device_farm ? 'true' : 'false'}
     %input#api-origin{type: 'hidden', value: api_origin}
     %input#s3-bucket{type: 'hidden', value: s3_bucket}
     %input#s3-prefix{type: 'hidden', value: s3_prefix}

--- a/dashboard/test/ui/test_status.js
+++ b/dashboard/test/ui/test_status.js
@@ -17,7 +17,6 @@ const RUN_START_TIME = new Date(
   document.querySelector("#start-time").textContent
 );
 const TEST_TYPE = document.querySelector("#test-type").value;
-const DEVICE_FARM = document.querySelector("#device-farm").value === "true";
 const API_ORIGIN = document.querySelector("#api-origin").value;
 const S3_BUCKET = document.querySelector("#s3-bucket").value;
 const S3_PREFIX = document.querySelector("#s3-prefix").value;
@@ -28,10 +27,8 @@ const STATUS_FAILED = "FAILED";
 const STATUS_SUCCEEDED = "SUCCEEDED";
 
 // Derived constants
-// Mirrors test_run_identifier in runner.rb: <browser>_<feature>[_eyes][_df].
-// Concurrent SauceLabs and Device Farm runs of the same browser+feature
-// upload to distinct S3 keys, so this status page only matches its own.
-const S3_KEY_SUFFIX = `${/eyes/i.test(TEST_TYPE) ? "_eyes" : ""}${DEVICE_FARM ? "_df" : ""}_output.html`;
+// Mirrors test_run_identifier in runner.rb: <browser>_<feature>[_eyes].
+const S3_KEY_SUFFIX = `${/eyes/i.test(TEST_TYPE) ? "_eyes" : ""}_output.html`;
 const API_BASEPATH = `${API_ORIGIN}/api/v1/test_logs`;
 
 // Grab DOM references

--- a/lib/rake/test.rake
+++ b/lib/rake/test.rake
@@ -31,36 +31,40 @@ namespace :test do
     TestRunUtils.run_local_ui_test
   end
 
-  timed_task_with_logging :regular_ui do
-    ChatClient.log 'Running <b>dashboard</b> UI tests...'
+  timed_task_with_logging :saucelabs_ui do
+    ChatClient.log 'Running <b>dashboard</b> Safari UI tests...'
     failed_browser_count = RakeUtils.system_with_chat_logging(
       "cd #{dashboard_dir('test/ui')} &&",
       'bundle', 'exec', './runner.rb',
+      '-c', 'Safari',
       '-d', CDO.site_host('studio.code.org'),
       '-p', CDO.site_host('code.org'),
       '--db', # Ensure features that require database access are run even if the server name isn't "test"
-      '--parallel', '50',
+      '--parallel', '15',
       '--magic_retry',
       '--with-status-page',
       '--fail_fast',
       '--saucelabs-priority 0'
     )
     if failed_browser_count == 0
-      message = '┬──┬ ﻿ノ( ゜-゜ノ) UI tests for <b>dashboard</b> succeeded.'
+      message = '┬──┬ ﻿ノ( ゜-゜ノ) Safari UI tests for <b>dashboard</b> succeeded.'
       ChatClient.log message
       ChatClient.message 'server operations', message, color: 'green'
     else
-      message = "(╯°□°）╯︵ ┻━┻ UI tests for <b>dashboard</b> failed on #{failed_browser_count} browser(s)."
+      message = "(╯°□°）╯︵ ┻━┻ Safari UI tests for <b>dashboard</b> failed on #{failed_browser_count} browser(s)."
       ChatClient.log message, color: 'red'
       ChatClient.message 'server operations', message, color: 'red', notify: 1
-      raise "UI tests failed"
+      raise "Safari UI tests failed"
     end
   end
 
   # Runs a single group of UI tests against AWS Device Farm. Shared body
-  # between :devicefarm_desktop_ui and :devicefarm_mobile_ui.
+  # between :devicefarm_desktop_ui and :devicefarm_mobile_ui. The label
+  # carries through to Slack messages and status page headings; "Device
+  # Farm" is no longer surfaced to oncall (provider is an implementation
+  # detail).
   def run_devicefarm_ui(config:, parallel:, label:)
-    ChatClient.log "Running <b>dashboard</b> UI tests on AWS Device Farm (#{label})..."
+    ChatClient.log "Running <b>dashboard</b> #{label} UI tests..."
     failed_browser_count = RakeUtils.system_with_chat_logging(
       "cd #{dashboard_dir('test/ui')} &&",
       'bundle', 'exec', './runner.rb',
@@ -75,21 +79,21 @@ namespace :test do
       '--fail_fast'
     )
     if failed_browser_count == 0
-      message = "┬──┬ ﻿ノ( ゜-゜ノ) Device Farm UI tests for <b>dashboard</b> (#{label}) succeeded."
+      message = "┬──┬ ﻿ノ( ゜-゜ノ) #{label} UI tests for <b>dashboard</b> succeeded."
       ChatClient.log message
       ChatClient.message 'server operations', message, color: 'green'
     else
-      message = "(╯°□°）╯︵ ┻━┻ Device Farm UI tests for <b>dashboard</b> (#{label}) failed on #{failed_browser_count} browser(s)."
+      message = "(╯°□°）╯︵ ┻━┻ #{label} UI tests for <b>dashboard</b> failed on #{failed_browser_count} browser(s)."
       ChatClient.log message, color: 'red'
       ChatClient.message 'server operations', message, color: 'red', notify: 1
-      raise "Device Farm UI (#{label}) tests failed"
+      raise "#{label} UI tests failed"
     end
   end
 
   timed_task_with_logging :devicefarm_desktop_ui do
     # As of April 2026, our concurrency limit for desktop browser sessions in
     # Device Farm within our prod AWS account is 150.
-    run_devicefarm_ui(config: 'Chrome,Firefox', parallel: 50, label: 'desktop')
+    run_devicefarm_ui(config: 'Chrome,Firefox', parallel: 50, label: 'Chrome + Firefox')
   end
 
   timed_task_with_logging :devicefarm_mobile_ui do
@@ -97,18 +101,7 @@ namespace :test do
     # mobile devices in Device Farm within our prod AWS account is 80. However,
     # the devices take so long to spin up and shut down that we can saturate our
     # Device Farm concurrency by setting parallelism equal to half of that limit.
-    run_devicefarm_ui(config: 'iPhone,iPad', parallel: 40, label: 'mobile')
-  end
-
-  # Runs desktop and mobile Device Farm UI suites in parallel threads so
-  # they use their independent concurrency quotas. Kept separate from
-  # regular_ui and intentionally not wired into ui_all -- currently used
-  # for manual trial runs against the test machine
-  # (bundle exec rake test:devicefarm_ui).
-  timed_task_with_logging :devicefarm_ui do
-    Parallel.each([:devicefarm_desktop_ui, :devicefarm_mobile_ui], in_threads: 2) do |target|
-      Rake::Task["test:#{target}"].invoke
-    end
+    run_devicefarm_ui(config: 'iPhone,iPad', parallel: 40, label: 'Mobile')
   end
 
   timed_task_with_logging :eyes_ui do
@@ -173,10 +166,15 @@ namespace :test do
     Lighthouse.report CDO.studio_url('', CDO.default_scheme)
   end
 
-  # Run the eyes tests and ui test suites in parallel. If one of these suites
-  # raises, allow the other suite to complete, then make sure this task raises.
+  # Run the four deploy-time UI suites in parallel: SauceLabs Safari and
+  # Eyes alongside the Device Farm desktop (Chrome+Firefox) and mobile
+  # (iPhone+iPad) suites. If one suite raises, allow the others to
+  # complete, then make sure this task raises.
   timed_task_with_logging :ui_all do
-    Parallel.each([:eyes_ui, :regular_ui], in_threads: 3) do |target|
+    Parallel.each(
+      [:eyes_ui, :saucelabs_ui, :devicefarm_desktop_ui, :devicefarm_mobile_ui],
+      in_threads: 4,
+    ) do |target|
       Rake::Task["test:#{target}"].invoke
     end
   end


### PR DESCRIPTION
Starts running UI tests in Device Farm alongside SauceLabs within `rake test:ui_all`. Renames the SauceLabs UI task `regular_ui` to `saucelabs_ui`, drops its parallelism from 50 to 15, and narrows it to `-c Safari` since Chrome/Firefox/iPhone/iPad now run on Device Farm. Removes the unused `devicefarm_ui` combined task.

Reframes the user-visible labeling so oncall sees suites by the browsers they cover, not the provider:
  - `saucelabs_ui            => "Safari UI"`
  - `devicefarm_desktop_ui   => "Chrome + Firefox UI"`
  - `devicefarm_mobile_ui    => "Mobile UI"`
  - `eyes_ui                 => "Eyes"`

slack message and status page prefixes also now derive from the active browser configs (Safari, Chrome + Firefox, etc) instead of the device_farm flag, making it easier to find test failures for a certain browser without having to remember whether it runs on SauceLabs or Device Farm. The cross-page navigation row also now links to all 4 pages.

The `_df` disambiguator in the `_output.html` filenames is no longer needed and has been removed.

## Screenshots

### status page navigation

https://github.com/user-attachments/assets/12e2e319-3c2e-45cf-8480-88863fef7a89

### slack output

<img width="969" height="236" alt="Screenshot 2026-05-05 at 2 48 14 PM" src="https://github.com/user-attachments/assets/8fb71f18-3a04-4b35-b7d4-81dddf4a59bb" />

## Testing story
- tested locally against test-studio.code.org and just one feature file (see screen recording) via locally modified version of this command: `Dave-M4:~/src/cdo (test *)$ bundle exec rake test:ui_all`
  - clicked through resulting status pages to verify status page nav linkage, rerun cmds, and saucelabs + device farm links in cucumber logs.
- after merging https://github.com/code-dot-org/code-dot-org/pull/72453, I ran `rake test:devicefarm_ui` on the test machine. All Device Farm Desktop UI tests passed ([slack](https://codedotorg.slack.com/archives/C03CM903Y/p1778012226057409)). 2 Mobile UI tests failed ([slack](https://codedotorg.slack.com/archives/C03CM903Y/p1778012617269179)), but then passed after a total of 3 reruns.

## Deployment notes

to do on the test machine after DTT:
- [x] verify linkage between new status pages
- [x] remove old `test_status*.html` pages, to ensure no one is relying on old bookmarks
- [x] run `bin/reset_flakiness`, to clear out the slew of errors from multiple saucelabs problems in the past week