### PR TITLE
Fix visibility of white text in light mode when editing and shape label styling

### DIFF
--- a/apps/src/sketchlab/reactFlow/nodes/ShapeNode.tsx
+++ b/apps/src/sketchlab/reactFlow/nodes/ShapeNode.tsx
@@ -161,13 +161,26 @@ function ShapeNode({id, data, selected}: NodeProps<ShapeNodeType>) {
 
   const labelStyle: React.CSSProperties = useMemo(() => {
     const style: React.CSSProperties = {};
-    if (data.fontColor) {
+    if (data.fontColor && !isEditing) {
       style.color = data.fontColor;
     }
     style.fontSize = fontSizePx(data.fontSize);
     style.textAlign = data.textAlign ?? DEFAULT_TEXT_ALIGN;
+    if (shapeType === 'rectangle') {
+      style.padding = '4px 8px';
+    } else if (shapeType === 'circle') {
+      style.padding = '12%';
+    } else if (shapeType === 'triangle') {
+      // Triangle apex is at top; push text toward the wider base.
+      style.paddingTop = '30%';
+      style.paddingLeft = '20%';
+      style.paddingRight = '20%';
+      style.paddingBottom = '5%';
+    } else if (shapeType === 'diamond') {
+      style.padding = '20% 15%';
+    }
     return style;
-  }, [data.fontColor, data.fontSize, data.textAlign]);
+  }, [data.fontColor, data.fontSize, data.textAlign, isEditing, shapeType]);
 
   const rotation = data.rotation ?? DEFAULT_ROTATION;
   const rotatableStyle: React.CSSProperties = useMemo(
@@ -208,7 +221,7 @@ function ShapeNode({id, data, selected}: NodeProps<ShapeNodeType>) {
         {/* Text label: click or enter to start editing */}
         <div
           ref={labelRef}
-          className={classNames(styles.text, isEditing && 'nodrag nopan')}
+          className={classNames(styles.label, isEditing && 'nodrag nopan')}
           style={labelStyle}
           contentEditable={isEditing}
           suppressContentEditableWarning

--- a/apps/src/sketchlab/reactFlow/nodes/shape-node.module.scss
+++ b/apps/src/sketchlab/reactFlow/nodes/shape-node.module.scss
@@ -40,7 +40,7 @@
   transform: translate(-50%, -50%);
   cursor: default;
   user-select: none;
-  max-width: 90%;
+  width: 100%;
   min-width: 40px;
   min-height: 20px;
   box-sizing: border-box;

--- a/apps/src/sketchlab/reactFlow/nodes/shape-node.module.scss
+++ b/apps/src/sketchlab/reactFlow/nodes/shape-node.module.scss
@@ -38,12 +38,12 @@
   top: 50%;
   left: 50%;
   transform: translate(-50%, -50%);
-  width: 100%;
   cursor: default;
   user-select: none;
   max-width: 90%;
   min-width: 40px;
   min-height: 20px;
+  box-sizing: border-box;
   word-break: normal;
   white-space: pre-wrap;
   overflow-wrap: anywhere;


### PR DESCRIPTION
<!--
  Summary of the change: background, motivation, and context.
  Include screenshots, videos, or before/after comparisons for UI changes.
-->
This PR updates a shape node's label's font color so that when editing, the text is always visible. Currently, if a user is in light mode and the text is white, text is not visible because the editor background is white. So we update the font color to the selected color only if the user is not editing. If the user is in edit mode, then we use the theme's CSS colors.

This PR also updates the styling of the label placement depending on the node shape and includes fixing an error I introduced in the last commit of https://github.com/code-dot-org/code-dot-org/pull/72493 - correcting the style name.



## Links
<!-- Jira tickets, design docs, Slack threads, related PRs, etc. -->

- Jira: https://codedotorg.atlassian.net/browse/AFL-620

## Testing story
<!-- How was this tested? Manual steps, adhoc links, automated tests, or why testing isn't needed. -->

Tested locally in Sketch Lab levels.

### Before update

Screencast of editing white text within Shape Node in light mode:


https://github.com/user-attachments/assets/d2030436-0949-4719-a971-00d7f445486f



### After update


Screencast of editing white text within Shape Node in light mode:

https://github.com/user-attachments/assets/e26a5668-d784-402c-ad07-eb97f06c2f7e

In dark mode:


https://github.com/user-attachments/assets/ffd224dc-8e1e-47d4-8ad1-c965fbbe8a4d



Screencast of editing triangle's label. Notice text is placed more towards center of shape:

https://github.com/user-attachments/assets/11252203-885d-4e9d-b1f9-153b7e1abd49





## Deployment notes
<!-- Delete this section if it's a standard merge-and-deploy.
     Otherwise: migrations, feature flags, coordination, caching impacts, etc. -->



## Privacy and security
<!-- Delete this section if there is no privacy/security impact.
     Otherwise: new PII, auth changes, API surface changes, etc. -->

