### PR TITLE
 React Flow Sketch Lab: move shape node label padding to CSS classes

### DIFF
--- a/apps/src/sketchlab/reactFlow/nodes/ShapeNode.tsx
+++ b/apps/src/sketchlab/reactFlow/nodes/ShapeNode.tsx
@@ -147,6 +147,9 @@ function ShapeNode({id, data, selected}: NodeProps<ShapeNodeType>) {
   );
 
   const isRectangle = shapeType === 'rectangle';
+  const isCircle = shapeType === 'circle';
+  const isTriangle = shapeType === 'triangle';
+  const isDiamond = shapeType === 'diamond';
 
   const rectangleStyle: React.CSSProperties = useMemo(() => {
     const style: React.CSSProperties = {};
@@ -166,21 +169,8 @@ function ShapeNode({id, data, selected}: NodeProps<ShapeNodeType>) {
     }
     style.fontSize = fontSizePx(data.fontSize);
     style.textAlign = data.textAlign ?? DEFAULT_TEXT_ALIGN;
-    if (shapeType === 'rectangle') {
-      style.padding = '4px 8px';
-    } else if (shapeType === 'circle') {
-      style.padding = '12%';
-    } else if (shapeType === 'triangle') {
-      // Triangle apex is at top; push text toward the wider base.
-      style.paddingTop = '30%';
-      style.paddingLeft = '20%';
-      style.paddingRight = '20%';
-      style.paddingBottom = '5%';
-    } else if (shapeType === 'diamond') {
-      style.padding = '20% 15%';
-    }
     return style;
-  }, [data.fontColor, data.fontSize, data.textAlign, isEditing, shapeType]);
+  }, [data.fontColor, data.fontSize, data.textAlign, isEditing]);
 
   const rotation = data.rotation ?? DEFAULT_ROTATION;
   const rotatableStyle: React.CSSProperties = useMemo(
@@ -221,7 +211,14 @@ function ShapeNode({id, data, selected}: NodeProps<ShapeNodeType>) {
         {/* Text label: click or enter to start editing */}
         <div
           ref={labelRef}
-          className={classNames(styles.label, isEditing && 'nodrag nopan')}
+          className={classNames(
+            styles.label,
+            isEditing && 'nodrag nopan',
+            isCircle && styles.circleLabel,
+            isTriangle && styles.triangleLabel,
+            isDiamond && styles.diamondLabel,
+            isRectangle && styles.rectangleLabel
+          )}
           style={labelStyle}
           contentEditable={isEditing}
           suppressContentEditableWarning

--- a/apps/src/sketchlab/reactFlow/nodes/shape-node.module.scss
+++ b/apps/src/sketchlab/reactFlow/nodes/shape-node.module.scss
@@ -33,6 +33,25 @@
   box-sizing: border-box;
 }
 
+.circleLabel {
+  padding: 12%;
+}
+
+.triangleLabel {
+  padding-top: 30%;
+  padding-left: 20%;
+  padding-right: 20%;
+  padding-bottom: 5%;
+}
+
+.diamondLabel {
+  padding: 20% 15%;
+}
+
+.rectangleLabel {
+  padding: 4px 8px;
+}
+
 .label {
   position: absolute;
   top: 50%;
@@ -58,7 +77,7 @@
     user-select: text;
     outline: 2px solid var(--borders-info-primary);
     border-radius: 2px;
-    padding: 2px 4px;
+    padding: 4px;
     min-width: 40px;
     background: var(--background-neutral-primary);
     color: var(--text-neutral-primary);


### PR DESCRIPTION
<!--
  Summary of the change: background, motivation, and context.
  Include screenshots, videos, or before/after comparisons for UI changes.
-->
This PR is a fast follow-up to https://github.com/code-dot-org/code-dot-org/pull/72523 and moves shape-specific label styling to CSS classes. In contrast, other styling like `fontColor` and `textAlign` come from the node's `data` so we update in code since these are runtime values. Shape label padding is dependent on `shapeType` which is a static property set at creation and never changes.     



## Links
<!-- Jira tickets, design docs, Slack threads, related PRs, etc. -->

- Follow-up to https://github.com/code-dot-org/code-dot-org/pull/72523#discussion_r3191200638

## Testing story
<!-- How was this tested? Manual steps, adhoc links, automated tests, or why testing isn't needed. -->

Tested locally. No change other than slightly more padding in edit mode (top/bottom padding increased from 2px -> 4px).

<img width="1160" height="682" alt="Screenshot 2026-05-05 at 4 11 19 PM" src="https://github.com/user-attachments/assets/74a1149f-b61d-483c-9a79-4b6d4f5d3a61" />




## Deployment notes
<!-- Delete this section if it's a standard merge-and-deploy.
     Otherwise: migrations, feature flags, coordination, caching impacts, etc. -->



## Privacy and security
<!-- Delete this section if there is no privacy/security impact.
     Otherwise: new PII, auth changes, API surface changes, etc. -->

