### PR TITLE
add sentry error wrapper

### DIFF
--- a/dashboard/engines/observability/README.md
+++ b/dashboard/engines/observability/README.md
@@ -24,6 +24,8 @@ Traces are exported to the local OpenTelemetry Collector via OTLP. The collector
 
 Only activates when `CDO.enable_sentry` is true **and** the process is a web server (`CDO.running_web_application?`). This prevents Sentry from initializing during rake tasks, migrations, and test runners. When `CDO.enable_opentelemetry` is also enabled, Sentry's OTLP integration is turned on so errors include trace context. When OpenTelemetry is off, the OTLP integration is disabled.
 
+Main Dashboard code should capture errors via `Observability::Errors.capture_exception` and `Observability::Errors.capture_message`, not by referencing `Sentry` directly.
+
 ## Testing
 
 Tests live in `test/` and mirror the `lib/` structure. Run them from the engine root:

--- a/dashboard/engines/observability/lib/observability/engine.rb
+++ b/dashboard/engines/observability/lib/observability/engine.rb
@@ -2,6 +2,7 @@
 
 require_relative 'opentelemetry'
 require_relative 'sentry'
+require_relative 'errors'
 
 module Observability
   class Engine < ::Rails::Engine

--- a/dashboard/engines/observability/lib/observability/errors.rb
+++ b/dashboard/engines/observability/lib/observability/errors.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module Observability
+  module Errors
+    def self.capture_exception(exception, **options, &block)
+      return unless Sentry.enabled? && defined?(::Sentry)
+
+      ::Sentry.capture_exception(exception, **options, &block)
+    end
+
+    def self.capture_message(message, **options, &block)
+      return unless Sentry.enabled? && defined?(::Sentry)
+
+      ::Sentry.capture_message(message, **options, &block)
+    end
+  end
+end

--- a/dashboard/engines/observability/test/lib/observability/errors_test.rb
+++ b/dashboard/engines/observability/test/lib/observability/errors_test.rb
@@ -4,8 +4,7 @@ require 'test_helper'
 
 describe Observability::Errors do
   before do
-    CDO.stubs(:enable_sentry).returns(false)
-    CDO.stubs(:unit_test).returns(false)
+    Observability::Sentry.stubs(:enabled?).returns(false)
   end
 
   describe '.capture_exception' do
@@ -18,7 +17,7 @@ describe Observability::Errors do
     end
 
     it 'delegates to Sentry when Sentry is enabled' do
-      CDO.stubs(:enable_sentry).returns(true)
+      Observability::Sentry.stubs(:enabled?).returns(true)
 
       Sentry.expects(:capture_exception).with(exception, tags: {source: 'test'})
       Observability::Errors.capture_exception(exception, tags: {source: 'test'})
@@ -35,7 +34,7 @@ describe Observability::Errors do
     end
 
     it 'delegates to Sentry when Sentry is enabled' do
-      CDO.stubs(:enable_sentry).returns(true)
+      Observability::Sentry.stubs(:enabled?).returns(true)
 
       Sentry.expects(:capture_message).with(error_message, level: :warning)
       Observability::Errors.capture_message(error_message, level: :warning)

--- a/dashboard/engines/observability/test/lib/observability/errors_test.rb
+++ b/dashboard/engines/observability/test/lib/observability/errors_test.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+describe Observability::Errors do
+  before do
+    CDO.stubs(:enable_sentry).returns(false)
+    CDO.stubs(:unit_test).returns(false)
+  end
+
+  describe '.capture_exception' do
+    let(:exception) {RuntimeError.new('test error')}
+
+    it 'returns without calling Sentry when Sentry is disabled' do
+      Sentry.expects(:capture_exception).never
+
+      _(Observability::Errors.capture_exception(exception)).must_be_nil
+    end
+
+    it 'delegates to Sentry when Sentry is enabled' do
+      CDO.stubs(:enable_sentry).returns(true)
+
+      Sentry.expects(:capture_exception).with(exception, tags: {source: 'test'})
+      Observability::Errors.capture_exception(exception, tags: {source: 'test'})
+    end
+  end
+
+  describe '.capture_message' do
+    let(:error_message) {'test error'}
+
+    it 'returns without calling Sentry when Sentry is disabled' do
+      Sentry.expects(:capture_message).never
+
+      _(Observability::Errors.capture_message(error_message)).must_be_nil
+    end
+
+    it 'delegates to Sentry when Sentry is enabled' do
+      CDO.stubs(:enable_sentry).returns(true)
+
+      Sentry.expects(:capture_message).with(error_message, level: :warning)
+      Observability::Errors.capture_message(error_message, level: :warning)
+    end
+  end
+end


### PR DESCRIPTION
Adds a module to the Observability engine to expose Sentry error capturing methods. This lets us log errors in a vendor-agnostic way.

## Links
<!-- Jira tickets, design docs, Slack threads, related PRs, etc. -->

- Jira:

## Testing story
<!-- How was this tested? Manual steps, adhoc links, automated tests, or why testing isn't needed. -->



## Deployment notes
<!-- Delete this section if it's a standard merge-and-deploy.
     Otherwise: migrations, feature flags, coordination, caching impacts, etc. -->



## Privacy and security
<!-- Delete this section if there is no privacy/security impact.
     Otherwise: new PII, auth changes, API surface changes, etc. -->

