### PR TITLE
Sketch2: fix duplicated actions section of toolbar

### DIFF
--- a/apps/src/sketchlab/reactFlow/elementToolbars/LineEdgeToolbar.tsx
+++ b/apps/src/sketchlab/reactFlow/elementToolbars/LineEdgeToolbar.tsx
@@ -219,21 +219,18 @@ export default function LineEdgeToolbar({
           <ActionsGroup
             onDelete={() => deleteElements({edges: [{id: edge.id}]})}
             onLock={() => onSetLocked(true)}
+            onDuplicate={() => duplicateLine(edge.id)}
+            onBringToFront={() => {
+              const items = [...getNodes(), ...getEdges()];
+              updateEdge(edge.id, {zIndex: newFrontZIndex(items, edge.id)});
+            }}
+            onSendToBack={() => {
+              const items = [...getNodes(), ...getEdges()];
+              updateEdge(edge.id, {zIndex: newBackZIndex(items, edge.id)});
+            }}
           />
         </>
       )}
-      <ActionsGroup
-        onDelete={() => deleteElements({edges: [{id: edge.id}]})}
-        onDuplicate={() => duplicateLine(edge.id)}
-        onBringToFront={() => {
-          const items = [...getNodes(), ...getEdges()];
-          updateEdge(edge.id, {zIndex: newFrontZIndex(items, edge.id)});
-        }}
-        onSendToBack={() => {
-          const items = [...getNodes(), ...getEdges()];
-          updateEdge(edge.id, {zIndex: newBackZIndex(items, edge.id)});
-        }}
-      />
     </ToolbarShell>
   );
 }


### PR DESCRIPTION
Resolving a merge conflict accidentally duplicated the "Actions" section of the line toolbar. This change unifies the two into one section, including locking and layering functionality.

## Testing story

Tested manually in regular and start mode.