### PR TITLE
increase DTT parallelism for Safari Desktop to 20

### DIFF
--- a/lib/rake/test.rake
+++ b/lib/rake/test.rake
@@ -40,7 +40,7 @@ namespace :test do
       '-d', CDO.site_host('studio.code.org'),
       '-p', CDO.site_host('code.org'),
       '--db', # Ensure features that require database access are run even if the server name isn't "test"
-      '--parallel', '15',
+      '--parallel', '20',
       '--magic_retry',
       '--with-status-page',
       '--fail_fast',


### PR DESCRIPTION
Follow-up from https://github.com/code-dot-org/code-dot-org/pull/72522. My estimates were off, and a parallelism of 15 made Safari the slowest test suite despite us now having a bit of headroom for saucelabs concurrency. Safari took 40 minutes to run in the first DTT with Device Farm, while the next slowest test suite (Mobile UI) took 35 minutes. 

Increase Safari parallelism from 15 to 20, with the expectation that this will speed it up from about 40 minutes to about 30 minutes.

## Testing story
- not explicitly verified -- wait and see how fast it runs before deciding whether to adjust further.