### PR TITLE
Instructions: adjust in-drawer padding

### DIFF
--- a/apps/src/lab2/views/components/Instructions/ResourcePanel/AiTutorChatWithInstructionsDrawer/ai-tutor-chat-with-instructions-drawer.module.scss
+++ b/apps/src/lab2/views/components/Instructions/ResourcePanel/AiTutorChatWithInstructionsDrawer/ai-tutor-chat-with-instructions-drawer.module.scss
@@ -9,7 +9,7 @@
 .instructionsDrawer {
   position: relative;
   flex-shrink: 0;
-  padding: 8px;
+  padding: 10px;
   background: var(--background-neutral-primary);
   border-radius: 4px;
   box-sizing: border-box;


### PR DESCRIPTION
This adjusts the padding on the instructions in-drawer when in the AI Tutor tab, to match the padding when in the Instructions tab, so that the instructions don't shift by 2px when switching between tabs.

### before

https://github.com/user-attachments/assets/79745cfb-c9ac-44f6-9ad3-9b1ae811593e

### after

https://github.com/user-attachments/assets/843e3fcb-2b6b-43da-8b01-90ca0b1de123

