### PR TITLE
Revert "Bump postcss from 8.5.6 to 8.5.10 in /frontend"

### DIFF
--- a/frontend/packages/component-library/package.json
+++ b/frontend/packages/component-library/package.json
@@ -450,7 +450,7 @@
     "jest": "^29.7.0",
     "jest-environment-jsdom": "^29.7.0",
     "jscodeshift": "^0.15.2",
-    "postcss": "^8.5.10",
+    "postcss": "^8.4.49",
     "postcss-modules": "^6.0.1",
     "react": "catalog:",
     "react-dom": "catalog:",

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -1165,7 +1165,7 @@ __metadata:
     jest-environment-jsdom: "npm:^29.7.0"
     jscodeshift: "npm:^0.15.2"
     lodash: "npm:^4.17.21"
-    postcss: "npm:^8.5.10"
+    postcss: "npm:^8.4.49"
     postcss-modules: "npm:^6.0.1"
     react: "catalog:"
     react-dom: "catalog:"
@@ -16042,7 +16042,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"postcss@npm:^8.5.1, postcss@npm:^8.5.6":
+"postcss@npm:^8.4.49, postcss@npm:^8.5.1, postcss@npm:^8.5.6":
   version: 8.5.6
   resolution: "postcss@npm:8.5.6"
   dependencies:
@@ -16050,17 +16050,6 @@ __metadata:
     picocolors: "npm:^1.1.1"
     source-map-js: "npm:^1.2.1"
   checksum: 10c0/5127cc7c91ed7a133a1b7318012d8bfa112da9ef092dddf369ae699a1f10ebbd89b1b9f25f3228795b84585c72aabd5ced5fc11f2ba467eedf7b081a66fad024
-  languageName: node
-  linkType: hard
-
-"postcss@npm:^8.5.10":
-  version: 8.5.13
-  resolution: "postcss@npm:8.5.13"
-  dependencies:
-    nanoid: "npm:^3.3.11"
-    picocolors: "npm:^1.1.1"
-    source-map-js: "npm:^1.2.1"
-  checksum: 10c0/3aa7c8cbdfbfd99b34406a433cef56d164dd135fc9cb9e63d487cc363291f877a55ec7b8ff6ec15348c17c2d98a43be46bfad671e6340403041a3e79f70c2f2f
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Reverts code-dot-org/code-dot-org#72380

There are 18 subtle eyes diffs that are not passing on re-run, which I'm pretty sure root cause back to this gem version update. I'm going to revert to see if that clears the pipeline and then we can decide how to proceed from there. 