### PR TITLE
fix(i18n): resolve incorrect dashboard file locales

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -188,7 +188,7 @@ gem 'gemoji'
 # Authentication and permissions.
 gem 'cancancan', '~> 3.5.0'
 gem 'devise', '~> 4.9.0'
-gem 'devise_invitable', '~> 2.0.2'
+gem 'devise_invitable', '~> 2.0.12'
 
 gem 'omniauth-classlink', '~> 0.3.1'
 gem 'omniauth-clever', '~> 3.0.0', github: 'code-dot-org/omniauth-clever', tag: 'v3.0.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -408,7 +408,7 @@ GEM
       railties (>= 4.1.0)
       responders
       warden (~> 1.2.3)
-    devise_invitable (2.0.6)
+    devise_invitable (2.0.12)
       actionmailer (>= 5.0)
       devise (>= 4.6)
     diff-lcs (1.6.0)
@@ -1282,7 +1282,7 @@ DEPENDENCIES
   database_cleaner-active_record (~> 2.1.0)
   delayed_job_active_record (~> 4.1)
   devise (~> 4.9.0)
-  devise_invitable (~> 2.0.2)
+  devise_invitable (~> 2.0.12)
   dotiw
   drb
   execjs

--- a/dashboard/config/locales/progressions/ps-AF.yml
+++ b/dashboard/config/locales/progressions/ps-AF.yml
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b52375e1724a7f217a2667da524f7bb31e2f4ae1105bb4f0089d2c0548c8c165
-size 3588
+oid sha256:44db30d92243a411f049b5216d6bbb89b1b88bc31c2d214c0ade72e961ded64f
+size 3591

--- a/dashboard/config/locales/progressions/tg-TJ.yml
+++ b/dashboard/config/locales/progressions/tg-TJ.yml
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:79e0c6db7b0052e1634a82f6a6f4146041f99383b76f21e0ecf1a09e578221ea
-size 2960
+oid sha256:0c1ea79aee3cdd4f77b708661c5823bb967a8f0b96a2253260d213dd6687db05
+size 2963

--- a/dashboard/config/locales/slides/tg-TJ.yml
+++ b/dashboard/config/locales/slides/tg-TJ.yml
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c96825c38316fa13d9dc44f59a72ff1c7275e0747c974a68f01c13150457e6c3
-size 264
+oid sha256:1925f367c4fe4c12e062812bcc55a17e0c6d5093b35282ea377dbc8a49f9ef61
+size 267

--- a/dashboard/config/locales/slides/zu-ZA.yml
+++ b/dashboard/config/locales/slides/zu-ZA.yml
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:590c7691edfeb50c7f45cc211507909826f7949cbe791498e205d45a0a95a115
+oid sha256:40f3fd98817b961559d8bbaa93ceee3bfdd944508060f3841dcfcdf2e13d323a
 size 79


### PR DESCRIPTION
```
INVALID I18N: File ".rbenv/versions/3.2.11/lib/ruby/gems/3.2.0/gems/devise_invitable-2.0.6/config/locales/pt-BR.yml" contains translations for unexpected locale
       valid: [:"pt-BR", :pt, :"en-US", :en]
    expected: :"pt-BR"
  unexpected: [:pt_BR]
```

```
INVALID I18N: File "dashboard/config/locales/progressions/ps-AF.yml" contains translations for unexpected locale
       valid: [:"ps-AF", :ps, :"en-US", :en]
    expected: :"ps-AF"
  unexpected: [:lt]
```

```
INVALID I18N: File "dashboard/config/locales/progressions/tg-TJ.yml" contains translations for unexpected locale
       valid: [:"tg-TJ", :tg, :"en-US", :en]
    expected: :"tg-TJ"
  unexpected: [:mi]

```

```
INVALID I18N: File "dashboard/config/locales/slides/tg-TJ.yml" contains translations for unexpected locale
       valid: [:"tg-TJ", :tg, :"en-US", :en]
    expected: :"tg-TJ"
  unexpected: [:dv]
```

```
INVALID I18N: File "dashboard/config/locales/slides/zu-ZA.yml" contains translations for unexpected locale
       valid: [:"zu-ZA", :zu, :"en-US", :en]
    expected: :"zu-ZA"
  unexpected: [:"en-GB"]
```

## Links
- Related PR: https://github.com/scambra/devise_invitable/pull/924
