### PR TITLE
fix(fonts): reduce priority of noto math

### DIFF
--- a/frontend/packages/component-library-styles/fontVariables.css
+++ b/frontend/packages/component-library-styles/fontVariables.css
@@ -9,27 +9,27 @@
  */
 
 :root {
-  --font-family-main: 'Figtree', 'Noto Sans', 'Noto Sans Math',
-    'Noto Sans Arabic', 'Noto Sans Armenian', 'Noto Sans Bengali',
+  --font-family-main: 'Figtree', 'Noto Sans', 'Noto Sans Arabic',
+    'Noto Sans Armenian', 'Noto Sans Bengali', 'Noto Sans SC', 'Noto Sans TC',
+    'Noto Sans Devanagari', 'Noto Sans Georgian', 'Noto Sans Hebrew',
+    'Noto Sans JP', 'Noto Sans Kannada', 'Noto Sans Khmer', 'Noto Sans KR',
+    'Noto Sans Myanmar', 'Noto Sans Sinhala', 'Noto Sans Tamil',
+    'Noto Sans Telugu', 'Noto Sans Thai', 'Noto Sans Thaana', 'Noto Sans Math',
+    sans-serif;
+  --font-family-barlow-semi-condensed-semibold: 'Barlow Semi Condensed Semibold',
+    'Noto Sans', 'Noto Sans Arabic', 'Noto Sans Armenian', 'Noto Sans Bengali',
     'Noto Sans SC', 'Noto Sans TC', 'Noto Sans Devanagari',
     'Noto Sans Georgian', 'Noto Sans Hebrew', 'Noto Sans JP',
     'Noto Sans Kannada', 'Noto Sans Khmer', 'Noto Sans KR', 'Noto Sans Myanmar',
     'Noto Sans Sinhala', 'Noto Sans Tamil', 'Noto Sans Telugu',
-    'Noto Sans Thai', 'Noto Sans Thaana', sans-serif;
-  --font-family-barlow-semi-condensed-semibold: 'Barlow Semi Condensed Semibold',
-    'Noto Sans', 'Noto Sans Math', 'Noto Sans Arabic', 'Noto Sans Armenian',
-    'Noto Sans Bengali', 'Noto Sans SC', 'Noto Sans TC', 'Noto Sans Devanagari',
-    'Noto Sans Georgian', 'Noto Sans Hebrew', 'Noto Sans JP',
-    'Noto Sans Kannada', 'Noto Sans Khmer', 'Noto Sans KR', 'Noto Sans Myanmar',
-    'Noto Sans Sinhala', 'Noto Sans Tamil', 'Noto Sans Telugu',
-    'Noto Sans Thai', 'Noto Sans Thaana', sans-serif;
+    'Noto Sans Thai', 'Noto Sans Thaana', 'Noto Sans Math', sans-serif;
   --font-family-barlow-semi-condensed-medium: 'Barlow Semi Condensed Medium',
-    'Noto Sans', 'Noto Sans Math', 'Noto Sans Arabic', 'Noto Sans Armenian',
-    'Noto Sans Bengali', 'Noto Sans SC', 'Noto Sans TC', 'Noto Sans Devanagari',
+    'Noto Sans', 'Noto Sans Arabic', 'Noto Sans Armenian', 'Noto Sans Bengali',
+    'Noto Sans SC', 'Noto Sans TC', 'Noto Sans Devanagari',
     'Noto Sans Georgian', 'Noto Sans Hebrew', 'Noto Sans JP',
     'Noto Sans Kannada', 'Noto Sans Khmer', 'Noto Sans KR', 'Noto Sans Myanmar',
     'Noto Sans Sinhala', 'Noto Sans Tamil', 'Noto Sans Telugu',
-    'Noto Sans Thai', 'Noto Sans Thaana', sans-serif;
+    'Noto Sans Thai', 'Noto Sans Thaana', 'Noto Sans Math', sans-serif;
   --font-weight-thin: 100;
   --font-weight-extra-light: 200;
   --font-weight-light: 300;

--- a/frontend/packages/component-library/src/themes/code.org/constants/fonts.ts
+++ b/frontend/packages/component-library/src/themes/code.org/constants/fonts.ts
@@ -1,7 +1,7 @@
 export const BARLOW_FONT = 'Barlow Semi Condensed Semibold';
 export const FIGTREE_FONT = 'Figtree';
 export const NOTO_FONT =
-  'Noto Sans, Noto Sans Math, Noto Sans Arabic, Noto Sans Armenian, Noto Sans Bengali, Noto Sans SC, Noto Sans TC, Noto Sans Devanagari, Noto Sans Georgian, Noto Sans Hebrew, Noto Sans JP, Noto Sans Kannada, Noto Sans Khmer, Noto Sans KR, Noto Sans Myanmar, Noto Sans Sinhala, Noto Sans Tamil, Noto Sans Telugu, Noto Sans Thai, Noto Sans Thaana';
+  'Noto Sans, Noto Sans Arabic, Noto Sans Armenian, Noto Sans Bengali, Noto Sans SC, Noto Sans TC, Noto Sans Devanagari, Noto Sans Georgian, Noto Sans Hebrew, Noto Sans JP, Noto Sans Kannada, Noto Sans Khmer, Noto Sans KR, Noto Sans Myanmar, Noto Sans Sinhala, Noto Sans Tamil, Noto Sans Telugu, Noto Sans Thai, Noto Sans Thaana, Noto Sans Math';
 
 // Create a font stack
 export const createFontStack = (font: string, fallback: string) => {

--- a/shared/css/font.scss
+++ b/shared/css/font.scss
@@ -11,10 +11,10 @@
 
 $figtree-font: 'Figtree';
 $metropolis-font: 'Metropolis';
-$noto-sans-fonts: 'Noto Sans', 'Noto Sans Math', 'Noto Sans Arabic', 'Noto Sans Armenian', 'Noto Sans Bengali',
+$noto-sans-fonts: 'Noto Sans', 'Noto Sans Arabic', 'Noto Sans Armenian', 'Noto Sans Bengali',
 'Noto Sans SC', 'Noto Sans TC', 'Noto Sans Devanagari', 'Noto Sans Georgian', 'Noto Sans Hebrew', 'Noto Sans JP',
 'Noto Sans Kannada', 'Noto Sans Khmer', 'Noto Sans KR', 'Noto Sans Myanmar', 'Noto Sans Sinhala',
-'Noto Sans Tamil', 'Noto Sans Telugu', 'Noto Sans Thai', 'Noto Sans Thaana';
+'Noto Sans Tamil', 'Noto Sans Telugu', 'Noto Sans Thai', 'Noto Sans Thaana', 'Noto Sans Math';
 
 $main-font: $figtree-font, $noto-sans-fonts, sans-serif;
 


### PR DESCRIPTION
Noto Sans Math is unexpectedly causing arabic script fonts to be broken. The previous increase of Noto Sans Math was in #61825 but the Noto Sans SC bug seems to have been fixed since then. As such, downgrade Noto Sans Math so that Noto Sans Arabic can takeover.

## Blockly logic

<img width="1766" height="1098" alt="image" src="https://github.com/user-attachments/assets/a54c9ec3-1fe4-4608-b9bd-cca52b932aa3" />

Confirmed that mathematical operatorsstill renders with Noto Sans Math (the Noto Sans SC bug does not occur)

## Arabic Script

<img width="1067" height="664" alt="image" src="https://github.com/user-attachments/assets/0e8fcc84-190a-45a9-90b9-eb90fba6c004" />

Confirmed arabic font is used instead of math.