### PR TITLE
disable extendedDebugging option in Chrome browser config for saucelabs

### DIFF
--- a/dashboard/test/ui/browsers_saucelabs.json
+++ b/dashboard/test/ui/browsers_saucelabs.json
@@ -31,8 +31,7 @@
     "browserVersion": "138",
     "platformName": "Windows 10",
     "sauce:options": {
-      "screenResolution": "1280x1024",
-      "extendedDebugging": true
+      "screenResolution": "1280x1024"
     }
   },
   {


### PR DESCRIPTION
see [slack](https://codedotorg.slack.com/archives/C0T0PNTM3/p1778072698871589?thread_ts=1777395009.251139&cid=C0T0PNTM3). the `extendedDebugging` setting in saucelabs is not typically needed and can cause performance slowdown, so we're going to try removing it.

## Testing story
- [x] passing drone run
- [x] patched onto `test` and got a green DTT

