### PR TITLE
Sketch2: add more font size options

### DIFF
--- a/apps/src/sketchlab/reactFlow/elementToolbars/FontSizeGroup.tsx
+++ b/apps/src/sketchlab/reactFlow/elementToolbars/FontSizeGroup.tsx
@@ -3,7 +3,12 @@ import {IconButton, Tooltip, Typography} from '@mui/material';
 import classNames from 'classnames';
 import React, {useCallback, useEffect, useState} from 'react';
 
-import {FONT_SIZE_OPTIONS, FontSize, fontSizePx} from './toolbarPalettes';
+import {
+  FONT_SIZE_OPTIONS,
+  FontSize,
+  fontSizePx,
+  MIN_FONT_SIZE_PX,
+} from './toolbarPalettes';
 
 import styles from './element-toolbar.module.scss';
 
@@ -30,9 +35,12 @@ export default function FontSizeGroup({
 
   const commitFontSize = useCallback(
     (text: string): number | null => {
-      const parsedValue = Number.parseInt(text, 10);
+      let parsedValue = Number.parseInt(text, 10);
       if (!Number.isFinite(parsedValue)) {
         return null;
+      }
+      if (parsedValue < MIN_FONT_SIZE_PX) {
+        parsedValue = MIN_FONT_SIZE_PX;
       }
       if (parsedValue !== resolvedPx) {
         onSelect(parsedValue);

--- a/apps/src/sketchlab/reactFlow/elementToolbars/FontSizeGroup.tsx
+++ b/apps/src/sketchlab/reactFlow/elementToolbars/FontSizeGroup.tsx
@@ -5,6 +5,8 @@ import React, {useCallback, useEffect, useState} from 'react';
 
 import {
   clampFontSizePx,
+  FONT_SIZE_MAX,
+  FONT_SIZE_MIN,
   FONT_SIZE_OPTIONS,
   FontSize,
   fontSizePx,
@@ -33,6 +35,21 @@ export default function FontSizeGroup({
     }
   }, [resolvedPx, isFocused]);
 
+  const commitFontSize = useCallback(
+    (text: string): number | null => {
+      const parsedValue = Number.parseInt(text, 10);
+      if (!Number.isFinite(parsedValue)) {
+        return null;
+      }
+      const clampedValue = clampFontSizePx(parsedValue);
+      if (clampedValue !== resolvedPx) {
+        onSelect(clampedValue);
+      }
+      return clampedValue;
+    },
+    [onSelect, resolvedPx]
+  );
+
   const handleInputChange = useCallback(
     (event: React.ChangeEvent<HTMLInputElement>) => {
       const next = event.target.value;
@@ -42,31 +59,16 @@ export default function FontSizeGroup({
       if (next === '') {
         return;
       }
-      const parsed = Number.parseInt(next, 10);
-      if (!Number.isFinite(parsed)) {
-        return;
-      }
-      const clamped = clampFontSizePx(parsed);
-      if (clamped !== resolvedPx) {
-        onSelect(clamped);
-      }
+      commitFontSize(next);
     },
-    [onSelect, resolvedPx]
+    [commitFontSize]
   );
 
   const handleInputBlur = useCallback(() => {
     setIsFocused(false);
-    const parsed = Number.parseInt(inputValue, 10);
-    if (Number.isFinite(parsed)) {
-      const clamped = clampFontSizePx(parsed);
-      setInputValue(String(clamped));
-      if (clamped !== resolvedPx) {
-        onSelect(clamped);
-      }
-    } else {
-      setInputValue(String(resolvedPx));
-    }
-  }, [inputValue, resolvedPx, onSelect]);
+    const clampedValue = commitFontSize(inputValue);
+    setInputValue(String(clampedValue ?? resolvedPx));
+  }, [inputValue, resolvedPx, commitFontSize]);
 
   const handleInputKeyDown = useCallback(
     (event: React.KeyboardEvent<HTMLInputElement>) => {
@@ -117,6 +119,8 @@ export default function FontSizeGroup({
           onKeyDown={handleInputKeyDown}
           size="s"
           className={styles.fontSizeInput}
+          min={FONT_SIZE_MIN}
+          max={FONT_SIZE_MAX}
         />
       </div>
     </div>

--- a/apps/src/sketchlab/reactFlow/elementToolbars/FontSizeGroup.tsx
+++ b/apps/src/sketchlab/reactFlow/elementToolbars/FontSizeGroup.tsx
@@ -38,7 +38,7 @@ export default function FontSizeGroup({
                 aria-pressed={isSelected}
                 onClick={() => onSelect(option.value)}
               >
-                {option.label.charAt(0)}
+                {option.shortLabel}
               </IconButton>
             </Tooltip>
           );

--- a/apps/src/sketchlab/reactFlow/elementToolbars/FontSizeGroup.tsx
+++ b/apps/src/sketchlab/reactFlow/elementToolbars/FontSizeGroup.tsx
@@ -3,14 +3,7 @@ import {IconButton, Tooltip, Typography} from '@mui/material';
 import classNames from 'classnames';
 import React, {useCallback, useEffect, useState} from 'react';
 
-import {
-  clampFontSizePx,
-  FONT_SIZE_MAX,
-  FONT_SIZE_MIN,
-  FONT_SIZE_OPTIONS,
-  FontSize,
-  fontSizePx,
-} from './toolbarPalettes';
+import {FONT_SIZE_OPTIONS, FontSize, fontSizePx} from './toolbarPalettes';
 
 import styles from './element-toolbar.module.scss';
 
@@ -41,11 +34,10 @@ export default function FontSizeGroup({
       if (!Number.isFinite(parsedValue)) {
         return null;
       }
-      const clampedValue = clampFontSizePx(parsedValue);
-      if (clampedValue !== resolvedPx) {
-        onSelect(clampedValue);
+      if (parsedValue !== resolvedPx) {
+        onSelect(parsedValue);
       }
-      return clampedValue;
+      return parsedValue;
     },
     [onSelect, resolvedPx]
   );
@@ -66,8 +58,8 @@ export default function FontSizeGroup({
 
   const handleInputBlur = useCallback(() => {
     setIsFocused(false);
-    const clampedValue = commitFontSize(inputValue);
-    setInputValue(String(clampedValue ?? resolvedPx));
+    const parsedValue = commitFontSize(inputValue);
+    setInputValue(String(parsedValue ?? resolvedPx));
   }, [inputValue, resolvedPx, commitFontSize]);
 
   const handleInputKeyDown = useCallback(
@@ -119,8 +111,6 @@ export default function FontSizeGroup({
           onKeyDown={handleInputKeyDown}
           size="s"
           className={styles.smallInput}
-          min={FONT_SIZE_MIN}
-          max={FONT_SIZE_MAX}
         />
       </div>
     </div>

--- a/apps/src/sketchlab/reactFlow/elementToolbars/FontSizeGroup.tsx
+++ b/apps/src/sketchlab/reactFlow/elementToolbars/FontSizeGroup.tsx
@@ -64,6 +64,7 @@ export default function FontSizeGroup({
 
   const handleInputKeyDown = useCallback(
     (event: React.KeyboardEvent<HTMLInputElement>) => {
+      // Remove focus from the input box on enter.
       if (event.key === 'Enter') {
         event.preventDefault();
         (event.target as HTMLInputElement).blur();

--- a/apps/src/sketchlab/reactFlow/elementToolbars/FontSizeGroup.tsx
+++ b/apps/src/sketchlab/reactFlow/elementToolbars/FontSizeGroup.tsx
@@ -118,7 +118,7 @@ export default function FontSizeGroup({
           onBlur={handleInputBlur}
           onKeyDown={handleInputKeyDown}
           size="s"
-          className={styles.fontSizeInput}
+          className={styles.smallInput}
           min={FONT_SIZE_MIN}
           max={FONT_SIZE_MAX}
         />

--- a/apps/src/sketchlab/reactFlow/elementToolbars/FontSizeGroup.tsx
+++ b/apps/src/sketchlab/reactFlow/elementToolbars/FontSizeGroup.tsx
@@ -1,20 +1,83 @@
+import TextField from '@code-dot-org/component-library/textField';
 import {IconButton, Tooltip, Typography} from '@mui/material';
 import classNames from 'classnames';
-import React from 'react';
+import React, {useCallback, useEffect, useState} from 'react';
 
-import {FONT_SIZE_OPTIONS} from './toolbarPalettes';
+import {
+  clampFontSizePx,
+  FONT_SIZE_OPTIONS,
+  FontSize,
+  fontSizePx,
+} from './toolbarPalettes';
 
 import styles from './element-toolbar.module.scss';
 
 export interface FontSizeGroupProps {
-  selectedValue: string | undefined;
-  onSelect: (value: string) => void;
+  selectedValue: FontSize | undefined;
+  onSelect: (value: FontSize) => void;
 }
 
 export default function FontSizeGroup({
   selectedValue,
   onSelect,
 }: FontSizeGroupProps) {
+  const resolvedPx = fontSizePx(selectedValue) ?? 0;
+  const [inputValue, setInputValue] = useState(String(resolvedPx));
+  const [isFocused, setIsFocused] = useState(false);
+
+  // Sync the input to the resolved px when the underlying value changes from
+  // outside (e.g. a button click) but only while the input isn't being edited.
+  useEffect(() => {
+    if (!isFocused) {
+      setInputValue(String(resolvedPx));
+    }
+  }, [resolvedPx, isFocused]);
+
+  const handleInputChange = useCallback(
+    (event: React.ChangeEvent<HTMLInputElement>) => {
+      const next = event.target.value;
+      setInputValue(next);
+      // Skip committing on partial input so the user can briefly empty the
+      // field without us snapping the size mid-edit.
+      if (next === '') {
+        return;
+      }
+      const parsed = Number.parseInt(next, 10);
+      if (!Number.isFinite(parsed)) {
+        return;
+      }
+      const clamped = clampFontSizePx(parsed);
+      if (clamped !== resolvedPx) {
+        onSelect(clamped);
+      }
+    },
+    [onSelect, resolvedPx]
+  );
+
+  const handleInputBlur = useCallback(() => {
+    setIsFocused(false);
+    const parsed = Number.parseInt(inputValue, 10);
+    if (Number.isFinite(parsed)) {
+      const clamped = clampFontSizePx(parsed);
+      setInputValue(String(clamped));
+      if (clamped !== resolvedPx) {
+        onSelect(clamped);
+      }
+    } else {
+      setInputValue(String(resolvedPx));
+    }
+  }, [inputValue, resolvedPx, onSelect]);
+
+  const handleInputKeyDown = useCallback(
+    (event: React.KeyboardEvent<HTMLInputElement>) => {
+      if (event.key === 'Enter') {
+        event.preventDefault();
+        (event.target as HTMLInputElement).blur();
+      }
+    },
+    []
+  );
+
   return (
     <div className={styles.group} role="group" aria-label="Font size">
       <Typography
@@ -43,6 +106,18 @@ export default function FontSizeGroup({
             </Tooltip>
           );
         })}
+        <TextField
+          name="font-size-px"
+          aria-label="Font size in pixels"
+          inputType="number"
+          value={inputValue}
+          onChange={handleInputChange}
+          onFocus={() => setIsFocused(true)}
+          onBlur={handleInputBlur}
+          onKeyDown={handleInputKeyDown}
+          size="s"
+          className={styles.fontSizeInput}
+        />
       </div>
     </div>
   );

--- a/apps/src/sketchlab/reactFlow/elementToolbars/RotationGroup.tsx
+++ b/apps/src/sketchlab/reactFlow/elementToolbars/RotationGroup.tsx
@@ -132,7 +132,7 @@ export default function RotationGroup({value, onChange}: RotationGroupProps) {
           onBlur={handleInputBlur}
           onKeyDown={handleInputKeyDown}
           size="s"
-          className={styles.rotationInput}
+          className={styles.smallInput}
         />
       </div>
     </div>

--- a/apps/src/sketchlab/reactFlow/elementToolbars/ShapeNodeToolbar.tsx
+++ b/apps/src/sketchlab/reactFlow/elementToolbars/ShapeNodeToolbar.tsx
@@ -17,7 +17,6 @@ import {
   DEFAULT_FONT_SIZE,
   DEFAULT_TEXT_ALIGN,
   DEFAULT_STROKE_COLOR,
-  FontSizeValue,
   STROKE_FONT_PALETTE,
   TextAlignValue,
 } from './toolbarPalettes';
@@ -58,9 +57,7 @@ export default function ShapeNodeToolbar({nodeId}: ShapeNodeToolbarProps) {
           />
           <FontSizeGroup
             selectedValue={fontSize ?? DEFAULT_FONT_SIZE}
-            onSelect={value =>
-              patchNodeData({fontSize: value as FontSizeValue})
-            }
+            onSelect={value => patchNodeData({fontSize: value})}
           />
           <TextAlignGroup
             selectedValue={textAlign ?? DEFAULT_TEXT_ALIGN}

--- a/apps/src/sketchlab/reactFlow/elementToolbars/TextNodeToolbar.tsx
+++ b/apps/src/sketchlab/reactFlow/elementToolbars/TextNodeToolbar.tsx
@@ -14,7 +14,6 @@ import {
   DEFAULT_FONT_COLOR,
   DEFAULT_FONT_SIZE,
   DEFAULT_TEXT_ALIGN,
-  FontSizeValue,
   STROKE_FONT_PALETTE,
   TextAlignValue,
 } from './toolbarPalettes';
@@ -43,9 +42,7 @@ export default function TextNodeToolbar({nodeId}: TextNodeToolbarProps) {
         <>
           <FontSizeGroup
             selectedValue={fontSize ?? DEFAULT_FONT_SIZE}
-            onSelect={value =>
-              patchNodeData({fontSize: value as FontSizeValue})
-            }
+            onSelect={value => patchNodeData({fontSize: value})}
           />
           <TextAlignGroup
             selectedValue={textAlign ?? DEFAULT_TEXT_ALIGN}

--- a/apps/src/sketchlab/reactFlow/elementToolbars/element-toolbar.module.scss
+++ b/apps/src/sketchlab/reactFlow/elementToolbars/element-toolbar.module.scss
@@ -165,25 +165,6 @@
   gap: 4px;
 }
 
-// The DSCO TextField wrapper hard-codes min-width: 18.75rem on its <label>;
-// override the wrapper and the input so the field sits inline with the four
-// IconButtons and fits 2-3 digits plus the native number spinner.
-.fontSizeInput {
-  flex: 0 0 auto;
-  width: 64px;
-  min-width: 0;
-
-  & > label {
-    min-width: 0;
-    width: 64px;
-  }
-
-  input {
-    width: 64px;
-    min-width: 0;
-  }
-}
-
 .fontSizeButton {
   border: 1px solid var(--borders-neutral-primary);
   background-color: var(--background-neutral-primary);
@@ -216,7 +197,7 @@
 // The DSCO TextField wrapper hard-codes min-width: 18.75rem on its <label>;
 // override the wrapper and the input so the field fits 3 digits plus the
 // native number spinner.
-.rotationInput {
+.smallInput {
   flex: 0 0 auto;
   width: 68px;
   min-width: 0;

--- a/apps/src/sketchlab/reactFlow/elementToolbars/element-toolbar.module.scss
+++ b/apps/src/sketchlab/reactFlow/elementToolbars/element-toolbar.module.scss
@@ -161,7 +161,27 @@
 .fontSizeButtons {
   display: flex;
   flex-direction: row;
+  align-items: center;
   gap: 4px;
+}
+
+// The DSCO TextField wrapper hard-codes min-width: 18.75rem on its <label>;
+// override the wrapper and the input so the field sits inline with the four
+// IconButtons and fits 2-3 digits plus the native number spinner.
+.fontSizeInput {
+  flex: 0 0 auto;
+  width: 64px;
+  min-width: 0;
+
+  & > label {
+    min-width: 0;
+    width: 64px;
+  }
+
+  input {
+    width: 64px;
+    min-width: 0;
+  }
 }
 
 .fontSizeButton {

--- a/apps/src/sketchlab/reactFlow/elementToolbars/toolbarPalettes.ts
+++ b/apps/src/sketchlab/reactFlow/elementToolbars/toolbarPalettes.ts
@@ -31,9 +31,10 @@ export const BACKGROUND_PALETTE: ColorSwatch[] = [
 ];
 
 export const FONT_SIZE_OPTIONS = [
-  {value: 'small', label: 'Small', px: 12},
-  {value: 'medium', label: 'Medium', px: 16},
-  {value: 'large', label: 'Large', px: 22},
+  {value: 'small', label: 'Small', px: 12, shortLabel: 'S'},
+  {value: 'medium', label: 'Medium', px: 16, shortLabel: 'M'},
+  {value: 'large', label: 'Large', px: 22, shortLabel: 'L'},
+  {value: 'extra-large', label: 'Extra Large', px: 30, shortLabel: 'XL'},
 ] as const;
 
 export type FontSizeValue = (typeof FONT_SIZE_OPTIONS)[number]['value'];

--- a/apps/src/sketchlab/reactFlow/elementToolbars/toolbarPalettes.ts
+++ b/apps/src/sketchlab/reactFlow/elementToolbars/toolbarPalettes.ts
@@ -42,13 +42,6 @@ export type FontSizeValue = (typeof FONT_SIZE_OPTIONS)[number]['value'];
 // fontSize on a node may be a named preset or a raw pixel number.
 export type FontSize = FontSizeValue | number;
 
-export const FONT_SIZE_MIN = 8;
-export const FONT_SIZE_MAX = 96;
-
-export function clampFontSizePx(n: number): number {
-  return Math.min(FONT_SIZE_MAX, Math.max(FONT_SIZE_MIN, Math.round(n)));
-}
-
 export const LINE_WIDTH_OPTIONS = [
   {value: 1, label: 'Thin'},
   {value: 3, label: 'Medium'},

--- a/apps/src/sketchlab/reactFlow/elementToolbars/toolbarPalettes.ts
+++ b/apps/src/sketchlab/reactFlow/elementToolbars/toolbarPalettes.ts
@@ -39,6 +39,16 @@ export const FONT_SIZE_OPTIONS = [
 
 export type FontSizeValue = (typeof FONT_SIZE_OPTIONS)[number]['value'];
 
+// fontSize on a node may be a named preset or a raw pixel number.
+export type FontSize = FontSizeValue | number;
+
+export const FONT_SIZE_MIN = 8;
+export const FONT_SIZE_MAX = 96;
+
+export function clampFontSizePx(n: number): number {
+  return Math.min(FONT_SIZE_MAX, Math.max(FONT_SIZE_MIN, Math.round(n)));
+}
+
 export const LINE_WIDTH_OPTIONS = [
   {value: 1, label: 'Thin'},
   {value: 3, label: 'Medium'},
@@ -72,7 +82,10 @@ export const DEFAULT_TEXT_ALIGN: TextAlignValue = 'center';
 export const DEFAULT_LINE_WIDTH: LineWidthValue = 1;
 export const DEFAULT_LINE_STROKE_STYLE: LineStrokeStyleValue = 'solid';
 
-export function fontSizePx(value: string | undefined): number | undefined {
+export function fontSizePx(value: FontSize | undefined): number | undefined {
+  if (typeof value === 'number') {
+    return value;
+  }
   const match = FONT_SIZE_OPTIONS.find(option => option.value === value);
   return (
     match?.px ||

--- a/apps/src/sketchlab/reactFlow/elementToolbars/toolbarPalettes.ts
+++ b/apps/src/sketchlab/reactFlow/elementToolbars/toolbarPalettes.ts
@@ -42,6 +42,10 @@ export type FontSizeValue = (typeof FONT_SIZE_OPTIONS)[number]['value'];
 // fontSize on a node may be a named preset or a raw pixel number.
 export type FontSize = FontSizeValue | number;
 
+// We set a minimum font size for sanity-checking but do not set a maximum,
+// since the canvas can be zoomed out.
+export const MIN_FONT_SIZE_PX = 6;
+
 export const LINE_WIDTH_OPTIONS = [
   {value: 1, label: 'Thin'},
   {value: 3, label: 'Medium'},

--- a/apps/src/sketchlab/reactFlow/types.ts
+++ b/apps/src/sketchlab/reactFlow/types.ts
@@ -5,10 +5,7 @@ import type {
   SketchlabReactFlowSource,
 } from '@cdo/apps/lab2/types';
 
-import type {
-  FontSizeValue,
-  TextAlignValue,
-} from './elementToolbars/toolbarPalettes';
+import type {FontSize, TextAlignValue} from './elementToolbars/toolbarPalettes';
 
 export type ShapeType = 'rectangle' | 'triangle' | 'circle' | 'diamond';
 
@@ -30,14 +27,14 @@ export type ShapeNodeData = NodeDataBase & {
   backgroundColor?: string;
   strokeColor?: string;
   fontColor?: string;
-  fontSize?: FontSizeValue;
+  fontSize?: FontSize;
   textAlign?: TextAlignValue;
 };
 
 export type TextNodeData = NodeDataBase & {
   text: string;
   fontColor?: string;
-  fontSize?: FontSizeValue;
+  fontSize?: FontSize;
   textAlign?: TextAlignValue;
 };
 

--- a/apps/src/sketchlab/reactFlow/utils/convertExcalidrawSources.ts
+++ b/apps/src/sketchlab/reactFlow/utils/convertExcalidrawSources.ts
@@ -17,18 +17,7 @@ import {createUuid} from '@cdo/apps/utils';
 
 import {uploadBase64ToUrl} from '../../excalidraw/utils/uploadBase64ToUrl';
 import {ASSET_PATH_PREFIX, LINE_ANCHOR_SIZE_PX} from '../constants';
-import {FontSizeValue} from '../elementToolbars/toolbarPalettes';
 import {ShapeNodeData, ShapeType} from '../types';
-
-// Maps Excalidraw px font size to our small/medium/large bands. The
-// thresholds are midpoints between fontSizePx in toolbarPalettes.ts
-// (small=12, medium=16, large=22, extra-large=30).
-function fontSizeBand(px: number): FontSizeValue {
-  if (px < 14) return 'small';
-  if (px < 19) return 'medium';
-  if (px < 26) return 'large';
-  return 'extra-large';
-}
 
 function shapeTypeFor(el: ExcalidrawElement): ShapeType | null {
   if (el.type === 'rectangle') return 'rectangle';
@@ -104,7 +93,7 @@ export function convertExcalidrawToReactFlow(
       };
       if (label) {
         data.fontColor = label.strokeColor;
-        data.fontSize = fontSizeBand(label.fontSize);
+        data.fontSize = label.fontSize;
       }
       const node: SketchlabReactFlowNode = {
         id: el.id,
@@ -128,7 +117,7 @@ export function convertExcalidrawToReactFlow(
         data: {
           text: el.text,
           fontColor: el.strokeColor,
-          fontSize: fontSizeBand(el.fontSize),
+          fontSize: el.fontSize,
           showHandles: false,
         },
       };

--- a/apps/src/sketchlab/reactFlow/utils/convertExcalidrawSources.ts
+++ b/apps/src/sketchlab/reactFlow/utils/convertExcalidrawSources.ts
@@ -22,11 +22,12 @@ import {ShapeNodeData, ShapeType} from '../types';
 
 // Maps Excalidraw px font size to our small/medium/large bands. The
 // thresholds are midpoints between fontSizePx in toolbarPalettes.ts
-// (small=12, medium=16, large=22).
+// (small=12, medium=16, large=22, extra-large=30).
 function fontSizeBand(px: number): FontSizeValue {
   if (px < 14) return 'small';
   if (px < 19) return 'medium';
-  return 'large';
+  if (px < 26) return 'large';
+  return 'extra-large';
 }
 
 function shapeTypeFor(el: ExcalidrawElement): ShapeType | null {

--- a/apps/test/unit/sketchlab/reactFlow/utils/convertExcalidrawSourcesTest.ts
+++ b/apps/test/unit/sketchlab/reactFlow/utils/convertExcalidrawSourcesTest.ts
@@ -109,7 +109,7 @@ describe('convertExcalidrawToReactFlow', () => {
     expect(nodes[0].data).toEqual({
       text: 'hello',
       fontColor: '#222222',
-      fontSize: 'medium',
+      fontSize: 16,
       showHandles: false,
     });
   });
@@ -134,40 +134,8 @@ describe('convertExcalidrawToReactFlow', () => {
     expect(nodes[0].data).toMatchObject({
       label: 'inside',
       fontColor: '#ff0000',
-      fontSize: 'large',
+      fontSize: 22,
     });
-  });
-
-  it('maps fontSize px into the small/medium/large bands', () => {
-    const source: ExcalidrawSourceWithExternalFiles = {
-      elements: [
-        el({
-          type: 'text',
-          id: 'small',
-          text: '',
-          fontSize: 12,
-          containerId: null,
-        }),
-        el({
-          type: 'text',
-          id: 'medium',
-          text: '',
-          fontSize: 16,
-          containerId: null,
-        }),
-        el({
-          type: 'text',
-          id: 'large',
-          text: '',
-          fontSize: 22,
-          containerId: null,
-        }),
-      ],
-    };
-    const {nodes} = convertExcalidrawToReactFlow(source);
-    expect((nodes[0].data as {fontSize?: string}).fontSize).toBe('small');
-    expect((nodes[1].data as {fontSize?: string}).fontSize).toBe('medium');
-    expect((nodes[2].data as {fontSize?: string}).fontSize).toBe('large');
   });
 
   it('emits image nodes when the file id has an externalFiles url', () => {


### PR DESCRIPTION
This adds an xl font size and a font size input to sketch2. The xl font size is 30px. The minimum allowed font size is 6px, but I did not set a max because the canvas can zoom out so much that a very large font can look normal. It's up to the user to pick the right size for them.

## Screenshot
<img width="720" height="742" alt="Screenshot 2026-05-06 at 1 40 25 PM" src="https://github.com/user-attachments/assets/a2331713-d857-4293-83fc-df03f2207c94" />

## Screen recording

https://github.com/user-attachments/assets/71daf946-ee69-4bcd-9f9a-b94dd18d94e4


## Links

- Jira: [AFL-626](https://codedotorg.atlassian.net/browse/AFL-626)
