### PR TITLE
Codebridge: make add file button state conditional on readonly permanence

### DIFF
--- a/apps/src/codebridge/FileBrowser/FileBrowserHeaderPopUpButton.tsx
+++ b/apps/src/codebridge/FileBrowser/FileBrowserHeaderPopUpButton.tsx
@@ -17,7 +17,13 @@ import {
   usePrompts,
 } from './hooks';
 
-export const FileBrowserHeaderPopUpButton = () => {
+interface FileBrowserHeaderPopUpButtonProps {
+  disabled?: boolean;
+}
+
+export const FileBrowserHeaderPopUpButton = ({
+  disabled,
+}: FileBrowserHeaderPopUpButtonProps) => {
   const {openNewFilePrompt, openNewFolderPrompt} = usePrompts();
   const {
     config: {validMimeTypes, supportedFileTypes},
@@ -52,6 +58,7 @@ export const FileBrowserHeaderPopUpButton = () => {
         iconName="plus"
         alignment="left"
         id="uitest-files-plus"
+        disabled={disabled}
         ariaLabel={codebridgeI18n.manageFiles()}
       >
         {!isWidget2SourcesMode && (

--- a/apps/src/codebridge/Workspace/Workspace.tsx
+++ b/apps/src/codebridge/Workspace/Workspace.tsx
@@ -19,7 +19,8 @@ import {
 import {getAppOptionsEditBlocks} from '@cdo/apps/lab2/projects/utils';
 import {
   isProjectTemplateLevel,
-  isReadOnlyWorkspace,
+  isPermanentlyReadOnlyWorkspace,
+  isTemporarilyReadOnlyWorkspace,
 } from '@cdo/apps/lab2/redux/lab2ReduxSelectors';
 import TeacherViewingStudentProjectAlert from '@cdo/apps/lab2/views/alerts/teacherViewingStudentProject';
 import PanelContainer from '@cdo/apps/lab2/views/components/PanelContainer';
@@ -53,7 +54,8 @@ const Workspace: React.FunctionComponent<WorkspaceProps> = ({
   const teacherViewingStudent = Boolean(
     useAppSelector(state => state.progress.viewAsUserId)
   );
-  const isReadOnly = useAppSelector(isReadOnlyWorkspace);
+  const isPermanentlyReadOnly = useAppSelector(isPermanentlyReadOnlyWorkspace);
+  const isTemporarilyReadOnly = useAppSelector(isTemporarilyReadOnlyWorkspace);
 
   const showLockedFilesBanner = useAppSelector(
     state => state.codebridgeWorkspace.showLockedFilesBanner
@@ -143,8 +145,10 @@ const Workspace: React.FunctionComponent<WorkspaceProps> = ({
               </Typography>
             )}
             <div className={moduleStyles.fileBrowserHeaderButtons}>
-              {showFileBrowser && !isReadOnly && (
-                <FileBrowserHeaderPopUpButton />
+              {showFileBrowser && !isPermanentlyReadOnly && (
+                <FileBrowserHeaderPopUpButton
+                  disabled={isTemporarilyReadOnly}
+                />
               )}
               <ToggleFileBrowserButton />
             </div>

--- a/apps/src/lab2/redux/lab2ReduxSelectors.ts
+++ b/apps/src/lab2/redux/lab2ReduxSelectors.ts
@@ -46,11 +46,9 @@ export const isPermanentlyReadOnlyWorkspace = (state: RootState) => {
   return !isOwner || isFrozen || isWidgetView;
 };
 
-// This may depend on more factors, such as share.
-export const isReadOnlyWorkspace = (state: RootState) => {
-  // Start with the permanently read-only check.
-  const isPermanentlyReadOnly = isPermanentlyReadOnlyWorkspace(state);
-
+// Returns true if the workspace is temporarily read-only.
+// This includes runtime and version states, but excludes permanent states like ownership.
+export const isTemporarilyReadOnlyWorkspace = (state: RootState) => {
   const isEditMode = !!getAppOptionsEditBlocks();
   const isEditingExemplar = getAppOptionsEditingExemplar();
 
@@ -70,7 +68,6 @@ export const isReadOnlyWorkspace = (state: RootState) => {
     shouldBeReadonlyWhileRunning(state);
 
   return (
-    isPermanentlyReadOnly ||
     isRunningAndReadonly ||
     hasSubmitted ||
     isViewingOldVersion ||
@@ -78,6 +75,11 @@ export const isReadOnlyWorkspace = (state: RootState) => {
     readOnlyPredictLevel
   );
 };
+
+// This may depend on more factors, such as share.
+export const isReadOnlyWorkspace = (state: RootState) =>
+  isPermanentlyReadOnlyWorkspace(state) ||
+  isTemporarilyReadOnlyWorkspace(state);
 
 // If the level should show an exemplar link, the exemplar link is the current url
 // with the query parameter exemplar=true at the end.


### PR DESCRIPTION
This change makes the hiding and disabling of the add file button associated with "permanent" and "temporary" readonly states, respectively.

Primary motivation here was to make the button visible and disabled when mid-accept/reject, which it does.

## Links

- Jira: https://codedotorg.atlassian.net/browse/AFL-595
- Slack discussion: https://codedotorg.slack.com/archives/C09EHQE4DGD/p1777324496797889

## Testing story

Tested manually playing with a few of these states (mid-accept/reject, viewing old version).