### PR TITLE
Sync Chrome and chromedriver in CI

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -90,7 +90,7 @@ steps:
 
   - name: unit-tests
     # see: docker/ci/Dockerfile
-    image: codedotorg/cdo-ci:1.21
+    image: codedotorg/cdo-ci:1.22
     pull: always
     environment:
       CI_JOB: 'unit_tests'
@@ -212,7 +212,7 @@ steps:
 
   - name: ui-tests
     # see: docker/ci/Dockerfile
-    image: codedotorg/cdo-ci:1.21
+    image: codedotorg/cdo-ci:1.22
     pull: always
     volumes:
       - name: mysql
@@ -297,7 +297,7 @@ steps:
   # snapshot of the fully-built project and resulting database, but don't
   # actually run the tests.
   - name: prepare-cacheable-build
-    image: codedotorg/cdo-ci:1.21
+    image: codedotorg/cdo-ci:1.22
     pull: always
     environment:
       CI_JOB: 'prepare_cacheable_build'
@@ -344,6 +344,6 @@ trigger:
 
 ---
 kind: signature
-hmac: 74be814fc7cc53487d50b033ff80d47c1477e0ad5d8856b2e52633b0a548d03d
+hmac: 1232b3f73bcef6bf1cce7c0136a564305b18c3fe5ad985d2f15266482cb03645
 
 ...

--- a/docker/ci/Dockerfile
+++ b/docker/ci/Dockerfile
@@ -161,8 +161,8 @@ RUN curl -sSLOJ https://dl.google.com/linux/direct/google-chrome-stable_current_
         "/opt/google/chrome/google-chrome"
 
 # install chromedriver
-RUN export CHROME_STABLE_VERSION=$(curl -s https://googlechromelabs.github.io/chrome-for-testing/last-known-good-versions.json | jq -r .channels.Stable.version) && \
-    curl -sSLOJ "https://storage.googleapis.com/chrome-for-testing-public/$CHROME_STABLE_VERSION/linux64/chromedriver-linux64.zip" && \
+RUN export INSTALLED_CHROME_VERSION=$(google-chrome --version | awk '{print $NF}') && \
+    curl -sSLOJ "https://storage.googleapis.com/chrome-for-testing-public/$INSTALLED_CHROME_VERSION/linux64/chromedriver-linux64.zip" && \
     unzip chromedriver-linux64.zip && \
     mv chromedriver-linux64/chromedriver /usr/local/bin/chromedriver && \
     chmod +x /usr/local/bin/chromedriver && \


### PR DESCRIPTION
Specifically, rather than installing the latest stable version of chromedriver we instead target a version that exactly matches the installed version of the chrome browser, which is likely to be slightly behind. Ideally we would be installing the latest stable version of the chrome browser, too, rather than relying on whatever's in the `.deb`, but as noted in https://github.com/code-dot-org/code-dot-org/pull/64444 that is a much more difficult proposition.

## Links

See thread [here](https://codedotorg.slack.com/archives/C0T0PNTM3/p1778091262918919) for more context

## Testing story

```
ci@15918736a0aa:~$ google-chrome --version
Google Chrome 148.0.7778.96
ci@15918736a0aa:~$ chromedriver --version
ChromeDriver 148.0.7778.96 (8625e066febc721e015ea99842da12901eb7ed73-refs/branch-heads/7778@{#1904})
```