### PR TITLE
AI Chat: save images to backpack + overflow menu

### DIFF
--- a/apps/src/aichat/views/ChatMessageView.tsx
+++ b/apps/src/aichat/views/ChatMessageView.tsx
@@ -22,6 +22,7 @@ import {
 } from '../types';
 import {UserAddedSelectionContextItem} from '../types/userAddedSelectionContext';
 
+import AssetImageOverflowMenu from './assets/AssetImageOverflowMenu';
 import FilePreview from './assets/FilePreview';
 import FlagResponseButton from './FlagResponseButton';
 import CleanFeedbackFooter from './teacherFeedback/CleanFeedbackFooter';
@@ -196,7 +197,7 @@ const MessageHeader: React.FC<MessageHeaderProps> = ({
   teacherFlaggedHidden,
   isFlaggedInTeacherView,
 }) => {
-  const hasAssets = assets && buildAssetUrl;
+  const hasAssets = !!assets && !!buildAssetUrl;
   const hasUserAddedSelectionContext = !!userAddedSelectionContext?.length;
 
   if ((!hasAssets && !hasUserAddedSelectionContext) || teacherFlaggedHidden) {
@@ -211,27 +212,37 @@ const MessageHeader: React.FC<MessageHeaderProps> = ({
         assets.map(asset => {
           const filename = asset.filename;
           const url = buildAssetUrl(asset);
+          const isPdf = filename.endsWith('.pdf');
           return (
-            <button
-              key={filename}
-              type="button"
-              className={styles.assetButton}
-              onClick={() => window.open(url, '_blank')}
-            >
-              {filename.endsWith('.pdf') ? (
-                <FilePreview type="pdf" filename={filename} url={url} />
-              ) : (
-                <img
-                  alt=""
-                  className={classNames(
-                    styles.imagePreview,
-                    isAssistant && styles.assistant,
-                    isFlaggedInTeacherView && styles.teacherFlaggedImagePreview
-                  )}
-                  src={url}
+            <div key={filename} className={styles.assetImageWrapper}>
+              <button
+                type="button"
+                className={styles.assetButton}
+                onClick={() => window.open(url, '_blank')}
+              >
+                {isPdf ? (
+                  <FilePreview type="pdf" filename={filename} url={url} />
+                ) : (
+                  <img
+                    alt=""
+                    className={classNames(
+                      styles.imagePreview,
+                      isAssistant && styles.assistant,
+                      isFlaggedInTeacherView &&
+                        styles.teacherFlaggedImagePreview
+                    )}
+                    src={url}
+                  />
+                )}
+              </button>
+              {!isPdf && (
+                <AssetImageOverflowMenu
+                  url={url}
+                  filename={filename}
+                  id={`asset-image-options-${filename}`}
                 />
               )}
-            </button>
+            </div>
           );
         })}
       {hasUserAddedSelectionContext &&

--- a/apps/src/aichat/views/assets/AssetImageOverflowMenu.tsx
+++ b/apps/src/aichat/views/assets/AssetImageOverflowMenu.tsx
@@ -1,5 +1,6 @@
 import {PopUpButton} from '@codebridge/PopUpButton/PopUpButton';
 import {PopUpButtonOption} from '@codebridge/PopUpButton/PopUpButtonOption';
+import {uniqueFileName} from '@codebridge/utils';
 import React, {useCallback} from 'react';
 
 import {addChatEvent} from '@cdo/apps/aichat/redux';
@@ -70,19 +71,6 @@ const downloadToBlob = (blob: Blob, filename: string): void => {
   URL.revokeObjectURL(objectUrl);
 };
 
-// Returns "<base>.<ext>", or "<base>-2.<ext>", "<base>-3.<ext>", ... when the
-// initial name collides with an existing file.
-const dedupedName = (base: string, ext: string, existing: string[]): string => {
-  const taken = new Set(existing);
-  let candidate = `${base}.${ext}`;
-  let i = 2;
-  while (taken.has(candidate)) {
-    candidate = `${base}-${i}.${ext}`;
-    i += 1;
-  }
-  return candidate;
-};
-
 const AssetImageOverflowMenu: React.FC<AssetImageOverflowMenuProps> = ({
   url,
   filename,
@@ -136,7 +124,8 @@ const AssetImageOverflowMenu: React.FC<AssetImageOverflowMenuProps> = ({
     async (backpackApi: BackpackClientApi) => {
       try {
         const files = await backpackApi.getFileList();
-        const targetName = dedupedName(dateTimeName(), ext, files);
+        const baseName = `${dateTimeName()}.${ext}`;
+        const targetName = uniqueFileName(baseName, files, '-');
         await backpackApi.saveCodebridgeFileFromUrl(targetName, url);
       } catch {
         showBackpackError();

--- a/apps/src/aichat/views/assets/AssetImageOverflowMenu.tsx
+++ b/apps/src/aichat/views/assets/AssetImageOverflowMenu.tsx
@@ -1,0 +1,183 @@
+import {PopUpButton} from '@codebridge/PopUpButton/PopUpButton';
+import {PopUpButtonOption} from '@codebridge/PopUpButton/PopUpButtonOption';
+import React, {useCallback} from 'react';
+
+import {addChatEvent} from '@cdo/apps/aichat/redux';
+import {getNewRemoveId} from '@cdo/apps/aichat/redux/utils';
+import {useBackpackAPIContext} from '@cdo/apps/sharedComponents/backpack/BackpackAPIContext';
+import BackpackClientApi from '@cdo/apps/sharedComponents/backpack/BackpackClientApi';
+import HttpClient from '@cdo/apps/util/HttpClient';
+import {useAppDispatch} from '@cdo/apps/util/reduxHooks';
+
+import styles from './asset-image-overflow-menu.module.scss';
+
+interface AssetImageOverflowMenuProps {
+  url: string;
+  filename: string;
+  /** Stable ID for the trigger button. Must be unique on the page. */
+  id: string;
+}
+
+const DEFAULT_EXT = 'png';
+
+const MONTH_ABBR = [
+  'Jan',
+  'Feb',
+  'Mar',
+  'Apr',
+  'May',
+  'Jun',
+  'Jul',
+  'Aug',
+  'Sep',
+  'Oct',
+  'Nov',
+  'Dec',
+];
+
+const extFromFilename = (filename: string): string => {
+  const dot = filename.lastIndexOf('.');
+  return dot > 0 ? filename.slice(dot + 1).toLowerCase() : '';
+};
+
+const extFromUrl = (url: string): string => {
+  const path = url.split('?')[0];
+  const dot = path.lastIndexOf('.');
+  return dot >= 0 ? path.slice(dot + 1).toLowerCase() : '';
+};
+
+// Creates a filename like "May-6-0930am"
+const dateTimeName = (now: Date = new Date()): string => {
+  const month = MONTH_ABBR[now.getMonth()];
+  const day = now.getDate();
+  const rawHour = now.getHours();
+  const ampm = rawHour < 12 ? 'am' : 'pm';
+  const hour12 = rawHour % 12 || 12;
+  const hh = String(hour12).padStart(2, '0');
+  const mm = String(now.getMinutes()).padStart(2, '0');
+  return `${month}-${day}-${hh}${mm}${ampm}`;
+};
+
+// TODO: replace with a shared util.
+const downloadToBlob = (blob: Blob, filename: string): void => {
+  const objectUrl = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = objectUrl;
+  a.download = filename;
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+  URL.revokeObjectURL(objectUrl);
+};
+
+// Returns "<base>.<ext>", or "<base>-2.<ext>", "<base>-3.<ext>", ... when the
+// initial name collides with an existing file.
+const dedupedName = (base: string, ext: string, existing: string[]): string => {
+  const taken = new Set(existing);
+  let candidate = `${base}.${ext}`;
+  let i = 2;
+  while (taken.has(candidate)) {
+    candidate = `${base}-${i}.${ext}`;
+    i += 1;
+  }
+  return candidate;
+};
+
+const AssetImageOverflowMenu: React.FC<AssetImageOverflowMenuProps> = ({
+  url,
+  filename,
+  id,
+}) => {
+  const backpackContext = useBackpackAPIContext();
+  const backpackApi = backpackContext?.primaryApi;
+  const dispatch = useAppDispatch();
+
+  const ext = extFromFilename(filename) || extFromUrl(url) || DEFAULT_EXT;
+
+  const showBackpackError = useCallback(() => {
+    dispatch(
+      addChatEvent({
+        removeId: getNewRemoveId(),
+        text: "Couldn't save image to your Backpack. Please try again.",
+        notificationType: 'error',
+        timestamp: Date.now(),
+      })
+    );
+  }, [dispatch]);
+
+  const onCopy = useCallback(async () => {
+    try {
+      const response = await HttpClient.get(url);
+      const blob = await response.blob();
+      await navigator.clipboard.write([new ClipboardItem({[blob.type]: blob})]);
+    } catch {
+      try {
+        // On failure, fall back to copying the URL itself.
+        await navigator.clipboard.writeText(url);
+      } catch {
+        // nothing else to try
+      }
+    }
+  }, [url]);
+
+  const onDownload = useCallback(async () => {
+    const downloadName = `${dateTimeName()}.${ext}`;
+    try {
+      const response = await HttpClient.get(url);
+      const blob = await response.blob();
+      downloadToBlob(blob, downloadName);
+    } catch {
+      // Fall back to a direct link.
+      window.open(url, '_blank', 'noopener,noreferrer');
+    }
+  }, [url, ext]);
+
+  const onSaveToBackpack = useCallback(
+    async (backpackApi: BackpackClientApi) => {
+      try {
+        const files = await backpackApi.getFileList();
+        const targetName = dedupedName(dateTimeName(), ext, files);
+        await backpackApi.saveCodebridgeFileFromUrl(targetName, url);
+      } catch {
+        showBackpackError();
+      }
+    },
+    [url, ext, showBackpackError]
+  );
+
+  return (
+    <div
+      className={styles.container}
+      // Stop clicks from bubbling to the parent <button>.
+      onClick={e => e.stopPropagation()}
+    >
+      <PopUpButton
+        iconName="ellipsis-vertical"
+        alignment="right"
+        id={id}
+        ariaLabel="Image options"
+        className={styles.menuButton}
+      >
+        <PopUpButtonOption
+          iconName="copy"
+          labelText="Copy"
+          clickHandler={onCopy}
+        />
+        <PopUpButtonOption
+          iconName="download"
+          labelText="Download"
+          clickHandler={onDownload}
+        />
+        {backpackApi && (
+          <PopUpButtonOption
+            iconName="backpack"
+            labelText="Save to Backpack"
+            clickHandler={() => onSaveToBackpack(backpackApi)}
+          />
+        )}
+      </PopUpButton>
+    </div>
+  );
+};
+
+export default AssetImageOverflowMenu;

--- a/apps/src/aichat/views/assets/asset-image-overflow-menu.module.scss
+++ b/apps/src/aichat/views/assets/asset-image-overflow-menu.module.scss
@@ -12,13 +12,14 @@
 .menuButton {
   width: 24px;
   height: 24px;
-  background-color: rgb(0 0 0 / 0.55);
-  color: var(--text-neutral-white-fixed);
+  background-color: #{"rgb(from var(--background-neutral-primary) r g b / 0.75)"};
+  color: var(--text-neutral-primary);
 
   &:hover,
   &:focus-visible {
-    background-color: rgb(0 0 0 / 0.75);
-    color: var(--text-neutral-white-fixed);
+    background-color: var(--background-neutral-primary);
+    color: var(--text-neutral-primary);
+    box-shadow: 0 1px 4px rgb(0 0 0 / 0.4);
   }
 
   i {

--- a/apps/src/aichat/views/assets/asset-image-overflow-menu.module.scss
+++ b/apps/src/aichat/views/assets/asset-image-overflow-menu.module.scss
@@ -1,0 +1,27 @@
+.container {
+  position: absolute;
+  top: 4px;
+  right: 4px;
+  z-index: 1;
+  // Wrapper sets this var to 1 on hover/focus-within. Falls back to 1 so the
+  // component remains visible when used outside a hover-aware container.
+  opacity: var(--overflow-menu-opacity, 1);
+  transition: opacity 0.15s ease;
+}
+
+.menuButton {
+  width: 24px;
+  height: 24px;
+  background-color: rgb(0 0 0 / 0.55);
+  color: var(--text-neutral-white-fixed);
+
+  &:hover,
+  &:focus-visible {
+    background-color: rgb(0 0 0 / 0.75);
+    color: var(--text-neutral-white-fixed);
+  }
+
+  i {
+    font-size: 0.875rem;
+  }
+}

--- a/apps/src/aichat/views/chatWorkspace.module.scss
+++ b/apps/src/aichat/views/chatWorkspace.module.scss
@@ -209,3 +209,16 @@ $tabs-default-spacing: 4px;
 
   @include focus-styles;
 }
+
+.assetImageWrapper {
+  position: relative;
+  display: inline-flex;
+  align-self: end;
+
+  --overflow-menu-opacity: 0;
+
+  &:hover,
+  &:focus-within {
+    --overflow-menu-opacity: 1;
+  }
+}

--- a/apps/src/codebridge/FileBrowser/prompts/openSaveToBackpackPrompt.tsx
+++ b/apps/src/codebridge/FileBrowser/prompts/openSaveToBackpackPrompt.tsx
@@ -1,4 +1,4 @@
-import {getFileNameWithNumberSuffix} from '@codebridge/utils';
+import {uniqueFileName} from '@codebridge/utils';
 import React from 'react';
 
 import BackpackErrorAlertBody from '@cdo/apps/codebridge/FileBrowser/BackpackErrorAlertBody';
@@ -52,10 +52,7 @@ export const openSaveToBackpackPrompt = async ({
       // Check if filename is a duplicate of a saved file in backpack.
       const isDuplicateFileName = filenames.includes(file.name);
 
-      let fileNameCopy = file.name;
-      while (filenames.includes(fileNameCopy)) {
-        fileNameCopy = getFileNameWithNumberSuffix(fileNameCopy);
-      }
+      const fileNameCopy = uniqueFileName(file.name, filenames);
 
       const dialog = isDuplicateFileName
         ? {

--- a/apps/src/codebridge/PopUpButton/PopUpButton.tsx
+++ b/apps/src/codebridge/PopUpButton/PopUpButton.tsx
@@ -240,6 +240,7 @@ export const PopUpButton = ({
                 return event.key === 'Tab' && event.shiftKey;
               },
               clickOutsideDeactivates: true,
+              preventScroll: true,
               fallbackFocus: initialFocusId
                 ? `#${initialFocusId}`
                 : '#fallback-element',

--- a/apps/src/codebridge/utils/getFileNameWithNumberSuffix.ts
+++ b/apps/src/codebridge/utils/getFileNameWithNumberSuffix.ts
@@ -3,22 +3,28 @@
  * includes file extension.
  * If the original filename ends with a number (e.g., "file_1.py"), the function
  * increments the number (e.g., "file_2.py").
- * If there is no number suffix is present, it appends "_1" before the file extension.
+ * If there is no number suffix present, it appends "_1" before the file extension.
  * (e.g., "file.py" -> "file_1.py").
  * @param filename - the original filename which includes the file extension
+ * @param separator - the character used to delimit the number suffix (default "_")
  * @returns new file name with number suffix
  */
-export const getFileNameWithNumberSuffix = (filename: string) => {
+export const getFileNameWithNumberSuffix = (
+  filename: string,
+  separator: string = '_'
+) => {
   const parts = filename.split('.');
   const fileExtension = parts.pop();
   const originalName = parts.join('.');
-  const nameParts = originalName.split('_');
+  const nameParts = originalName.split(separator);
   const lastPart = nameParts[nameParts.length - 1];
-  const numberSuffix = parseInt(lastPart, 10); // NaN if not a number.
+  // Check strictly for a number suffix.
+  const numberSuffix = /^\d+$/.test(lastPart) ? parseInt(lastPart, 10) : NaN;
   let newNumber = 1;
   if (Number.isInteger(numberSuffix)) {
     newNumber = numberSuffix + 1;
     nameParts.pop(); // Remove the existing number suffix before adding new number suffix.
   }
-  return `${nameParts.join('_')}_${newNumber}.${fileExtension}`;
+  const newName = `${nameParts.join(separator)}${separator}${newNumber}`;
+  return `${newName}.${fileExtension}`;
 };

--- a/apps/src/codebridge/utils/index.ts
+++ b/apps/src/codebridge/utils/index.ts
@@ -21,6 +21,7 @@ export * from './getPossibleDestinationFoldersForFolder';
 export * from './hasPreview';
 export * from './repairOpenFiles';
 export * from './sortFilesByName';
+export * from './uniqueFileName';
 export * from './validateBackpackFileName';
 export * from './validateFileName';
 export * from './validateFolderMove';

--- a/apps/src/codebridge/utils/uniqueFileName.ts
+++ b/apps/src/codebridge/utils/uniqueFileName.ts
@@ -1,0 +1,19 @@
+import {getFileNameWithNumberSuffix} from './getFileNameWithNumberSuffix';
+
+/**
+ * Returns the input filename if it does not collide with any name in
+ * `existing`. Otherwise, increments a numeric suffix until the result is
+ * unique.
+ */
+export const uniqueFileName = (
+  filename: string,
+  existing: string[],
+  separator = '_'
+): string => {
+  const taken = new Set(existing);
+  let candidate = filename;
+  while (taken.has(candidate)) {
+    candidate = getFileNameWithNumberSuffix(candidate, separator);
+  }
+  return candidate;
+};

--- a/apps/src/lab2/views/components/Instructions/ResourcePanel/Backpack/BackpackPanel.tsx
+++ b/apps/src/lab2/views/components/Instructions/ResourcePanel/Backpack/BackpackPanel.tsx
@@ -33,6 +33,13 @@ interface BackpackPanelProps extends BackpackProps {
 
 const PRIMARY_BACKPACK_KEY = 'PRIMARY';
 
+// No-op transition for the Snackbar's transition slot
+// since the transition is handled by the inner TransitionGroup and Fade
+const SnackbarPassthrough = React.forwardRef<
+  HTMLDivElement,
+  {children?: React.ReactNode}
+>(({children}, ref) => <div ref={ref}>{children}</div>);
+
 type AlertConfig = {id: number; type: 'success' | 'danger'; message: string};
 const ALERT_AUTO_HIDE_MS = 3000;
 let nextAlertId = 0;
@@ -304,7 +311,7 @@ const BackpackPanel: React.FC<BackpackPanelProps> = ({
     <div className={moduleStyles.backpackPanelWithFiles}>
       <Snackbar
         open
-        slots={{transition: React.Fragment}}
+        slots={{transition: SnackbarPassthrough}}
         className={moduleStyles.alertContainer}
       >
         <TransitionGroup className={moduleStyles.alertList}>

--- a/apps/src/sharedComponents/backpack/BackpackClientApi.ts
+++ b/apps/src/sharedComponents/backpack/BackpackClientApi.ts
@@ -52,13 +52,12 @@ export default class BackpackClientApi {
     return !!this.channelId;
   }
 
-  fetchChannelId(callback: () => void) {
-    HttpClient.fetchJson<{channel: string}>(
+  async fetchChannelId(callback?: () => void) {
+    const response = await HttpClient.fetchJson<{channel: string}>(
       `/backpacks/channel/${this.appType}`
-    ).then(response => {
-      this.channelId = response.value.channel;
-      callback();
-    });
+    );
+    this.channelId = response.value.channel;
+    callback?.();
   }
 
   // Fetch a file from the backpack, and return the file contents via callback (or call onError on failure).
@@ -104,33 +103,31 @@ export default class BackpackClientApi {
   }
 
   async getFileList(
-    onError: ErrorCallback,
-    onSuccess: (filenames: string[]) => void
-  ) {
-    if (!this.channelId && this.appType === 'javalab') {
-      onError();
-      return;
-    }
-    const fetchFiles = async () => {
-      try {
-        const response = await HttpClient.fetchJson<FileMetadata[]>(
-          rootUrl(this.channelId!)
-        );
-        const filenames = response.value.map(fileData => fileData.filename);
-        onSuccess(filenames);
-      } catch (error) {
-        onError(error as Error);
+    onError?: ErrorCallback,
+    onSuccess?: (filenames: string[]) => void
+  ): Promise<string[]> {
+    try {
+      // Only fetch channel id if we don't yet have it. Javalab includes backpack channel_id
+      // in appOptions but lab2 labs (e.g., pythonlab) do not use appOptions.
+      if (!this.channelId) {
+        if (this.appType === 'javalab') {
+          throw new Error('Missing backpack channel id for javalab');
+        }
+        await this.fetchChannelId();
       }
-    };
-
-    // Only fetch channel id if we don't yet have it. Javalab includes backpack channel_id
-    // in appOptions but lab2 labs (e.g., pythonlab) do not use appOptions.
-    if (!this.channelId) {
-      this.fetchChannelId(() => {
-        fetchFiles();
-      });
-    } else {
-      fetchFiles();
+      const response = await HttpClient.fetchJson<FileMetadata[]>(
+        rootUrl(this.channelId!)
+      );
+      const filenames = response.value.map(fileData => fileData.filename);
+      onSuccess?.(filenames);
+      return filenames;
+    } catch (error) {
+      if (onError) {
+        onError(error as Error);
+        return [];
+      } else {
+        throw error;
+      }
     }
   }
 
@@ -188,14 +185,13 @@ export default class BackpackClientApi {
   async saveCodebridgeFileFromUrl(
     filename: string,
     fileUrl: string,
-    onError: ErrorCallback,
-    onSuccess: () => void
+    onError?: ErrorCallback,
+    onSuccess?: () => void
   ) {
-    if (!this.channelId) {
-      onError();
-      return;
-    }
     try {
+      if (!this.channelId) {
+        throw new Error('Missing channel id for backpack');
+      }
       const fileResponse = await HttpClient.get(fileUrl);
       if (fileResponse.ok) {
         const responseBlob = await fileResponse.blob();
@@ -208,13 +204,17 @@ export default class BackpackClientApi {
         );
       }
     } catch (error) {
-      onError(error as Error);
-      return;
+      if (onError) {
+        onError(error as Error);
+        return;
+      } else {
+        throw error;
+      }
     }
     Object.values(this.eventListeners).forEach(listener =>
       listener(BackpackEvent.FileAdded, filename)
     );
-    onSuccess();
+    onSuccess?.();
   }
 
   async saveBlobFile(

--- a/apps/test/unit/code-studio/components/backpack/BackpackClientApiTest.ts
+++ b/apps/test/unit/code-studio/components/backpack/BackpackClientApiTest.ts
@@ -191,6 +191,84 @@ describe('BackpackClientApi (jest)', () => {
       expect(successCallback).not.toHaveBeenCalled();
     });
 
+    it('saveCodebridgeFileFromUrl resolves without callbacks', async () => {
+      (HttpClient.get as jest.Mock).mockResolvedValueOnce({
+        ok: true,
+        blob: jest
+          .fn()
+          .mockResolvedValueOnce(new Blob(['data'], {type: 'text/plain'})),
+      });
+      setPutResolveOnce();
+
+      await expect(
+        backpackClientApi.saveCodebridgeFileFromUrl(
+          'fromUrl.txt',
+          'https://example.com/file.txt'
+        )
+      ).resolves.toBeUndefined();
+
+      expect(HttpClient.put).toHaveBeenCalledTimes(1);
+    });
+
+    it('saveCodebridgeFileFromUrl throws error if no error callback and GET fails', async () => {
+      (HttpClient.get as jest.Mock).mockRejectedValueOnce(new Error('network'));
+
+      await expect(
+        backpackClientApi.saveCodebridgeFileFromUrl(
+          'fromUrl.txt',
+          'https://example.com/file.txt'
+        )
+      ).rejects.toThrow('network');
+      expect(HttpClient.put).not.toHaveBeenCalled();
+    });
+
+    it('getFileList returns with filenames', async () => {
+      (HttpClient.fetchJson as jest.Mock).mockResolvedValueOnce({
+        value: [
+          {filename: 'a.png', size: 1, timestamp: 't'},
+          {filename: 'b.png', size: 1, timestamp: 't'},
+        ],
+      });
+
+      const filenames = await backpackClientApi.getFileList();
+
+      expect(filenames).toEqual(['a.png', 'b.png']);
+    });
+
+    it('getFileList calls onSuccess with filenames', async () => {
+      (HttpClient.fetchJson as jest.Mock).mockResolvedValueOnce({
+        value: [{filename: 'a.png', size: 1, timestamp: 't'}],
+      });
+
+      await backpackClientApi.getFileList(errorCallback, successCallback);
+
+      expect(successCallback).toHaveBeenCalledWith(['a.png']);
+      expect(errorCallback).not.toHaveBeenCalled();
+    });
+
+    it('getFileList resolves to [] and calls onError when fetch fails', async () => {
+      (HttpClient.fetchJson as jest.Mock).mockRejectedValueOnce(
+        new Error('boom')
+      );
+
+      const filenames = await backpackClientApi.getFileList(
+        errorCallback,
+        successCallback
+      );
+
+      expect(filenames).toEqual([]);
+      expect(errorCallback).toHaveBeenCalledTimes(1);
+      expect(successCallback).not.toHaveBeenCalled();
+    });
+
+    it('getFileList rejects when no error callback and fetch fails', async () => {
+      (HttpClient.fetchJson as jest.Mock).mockRejectedValueOnce(
+        new Error('boom')
+      );
+
+      await expect(backpackClientApi.getFileList()).rejects.toThrow('boom');
+    });
+
     it('fetch file calls success callback on successful fetch', async () => {
       setGetResolveOnce('file contents');
 
@@ -227,9 +305,9 @@ describe('BackpackClientApi (jest)', () => {
     it('save fetches channel id', async () => {
       const fetchChannelIdSpy = jest
         .spyOn(backpackClientApi, 'fetchChannelId')
-        .mockImplementation((cb: () => void) => {
+        .mockImplementation(async (cb?: () => void) => {
           backpackClientApi.channelId = channelId;
-          cb();
+          cb?.();
         });
 
       setPutResolveOnce();
@@ -249,10 +327,38 @@ describe('BackpackClientApi (jest)', () => {
       fetchChannelIdSpy.mockRestore();
     });
 
-    it('get files calls error callback', () => {
-      backpackClientApi.getFileList(errorCallback, successCallback);
+    it('getFileList calls error callback for javalab without channel id', async () => {
+      await backpackClientApi.getFileList(errorCallback, successCallback);
       expect(errorCallback).toHaveBeenCalledTimes(1);
       expect(successCallback).not.toHaveBeenCalled();
+    });
+
+    it('getFileList rejects for javalab without channel id and no error callback', async () => {
+      await expect(backpackClientApi.getFileList()).rejects.toThrow(
+        'Missing backpack channel id for javalab'
+      );
+    });
+
+    it('saveCodebridgeFileFromUrl calls error callback when channel id missing', async () => {
+      await backpackClientApi.saveCodebridgeFileFromUrl(
+        'a.txt',
+        'https://example.com/a.txt',
+        errorCallback,
+        successCallback
+      );
+      expect(errorCallback).toHaveBeenCalledTimes(1);
+      expect(successCallback).not.toHaveBeenCalled();
+      expect(HttpClient.get).not.toHaveBeenCalled();
+      expect(HttpClient.put).not.toHaveBeenCalled();
+    });
+
+    it('saveCodebridgeFileFromUrl rejects when channel id missing and no error callback', async () => {
+      await expect(
+        backpackClientApi.saveCodebridgeFileFromUrl(
+          'a.txt',
+          'https://example.com/a.txt'
+        )
+      ).rejects.toThrow('Missing channel id for backpack');
     });
 
     it('fetch file calls error callback', async () => {
@@ -260,6 +366,29 @@ describe('BackpackClientApi (jest)', () => {
       await Promise.resolve();
       expect(errorCallback).toHaveBeenCalledTimes(1);
       expect(successCallback).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('without provided channel id (non-javalab)', () => {
+    beforeEach(() => {
+      backpackClientApi = new BackpackClientApi('pythonlab', null);
+    });
+
+    it('getFileList auto-fetches channel id and resolves with filenames', async () => {
+      const fetchChannelIdSpy = jest
+        .spyOn(backpackClientApi, 'fetchChannelId')
+        .mockImplementation(async () => {
+          backpackClientApi.channelId = channelId;
+        });
+      (HttpClient.fetchJson as jest.Mock).mockResolvedValueOnce({
+        value: [{filename: 'a.png', size: 1, timestamp: 't'}],
+      });
+
+      const filenames = await backpackClientApi.getFileList();
+
+      expect(fetchChannelIdSpy).toHaveBeenCalledTimes(1);
+      expect(filenames).toEqual(['a.png']);
+      fetchChannelIdSpy.mockRestore();
     });
   });
 });

--- a/apps/test/unit/codebridge/utils/getFileNameWithNumberSuffixTest.ts
+++ b/apps/test/unit/codebridge/utils/getFileNameWithNumberSuffixTest.ts
@@ -13,4 +13,11 @@ describe('getFileNameWithNumberSuffix', function () {
       'test_file_3.py'
     );
   });
+  it('honors a custom separator', function () {
+    expect(getFileNameWithNumberSuffix('main.py', '-')).toBe('main-1.py');
+    expect(getFileNameWithNumberSuffix('main-1.py', '-')).toBe('main-2.py');
+    expect(getFileNameWithNumberSuffix('May-6-0930am.png', '-')).toBe(
+      'May-6-0930am-1.png'
+    );
+  });
 });

--- a/apps/test/unit/codebridge/utils/uniqueFileNameTest.ts
+++ b/apps/test/unit/codebridge/utils/uniqueFileNameTest.ts
@@ -1,0 +1,26 @@
+import {uniqueFileName} from '@codebridge/utils';
+
+describe('uniqueFileName', function () {
+  it('returns the input unchanged when there is no collision', function () {
+    expect(uniqueFileName('image.png', [])).toBe('image.png');
+    expect(uniqueFileName('image.png', ['other.png'])).toBe('image.png');
+  });
+
+  it('appends an underscore-separated suffix on collision by default', function () {
+    expect(uniqueFileName('main.py', ['main.py'])).toBe('main_1.py');
+    expect(
+      uniqueFileName('main.py', ['main.py', 'main_1.py', 'main_2.py'])
+    ).toBe('main_3.py');
+  });
+
+  it('honors a custom separator', function () {
+    expect(uniqueFileName('image.png', ['image.png'], '-')).toBe('image-1.png');
+    expect(
+      uniqueFileName(
+        'image.png',
+        ['image.png', 'image-1.png', 'image-2.png'],
+        '-'
+      )
+    ).toBe('image-3.png');
+  });
+});


### PR DESCRIPTION
Enables saving AI Chat images to the lab's backpack (and more) through a new overflow menu accessible by a three-dot overlay button on images in the chat. The menu also includes options for copying and downloading.

The overflow menu and button are built using Codebridge's existing `PopupButton` and `PopupButtonOption` components.

I also included a few tweaks to the Backpack Client API to make it easier to use in an async/await context (rather than having to pass in callbacks). However, callbacks are still supported so this doesn't affect existing users.

Demo (including keyboard nav):

https://github.com/user-attachments/assets/3151cc73-cfba-4d69-84a0-02c8ad7315ab

Error notification if saving to backpack or fetching backpack metadata fails:

<img width="580" height="785" alt="Screenshot 2026-05-06 at 11 51 09 AM" src="https://github.com/user-attachments/assets/6c6f3999-e081-4cbb-a072-dee9b5c882d5" />

## Links
<!-- Jira tickets, design docs, Slack threads, related PRs, etc. -->

- Jira: https://codedotorg.atlassian.net/browse/SL-1691

## Testing story
Tested with AI Chat lab levels (technically this works with AI Tutor as well but only for user-added images).