### PR TITLE
Onboarding - Add backend connection to completed tours

### DIFF
--- a/apps/src/sharedComponents/productTour/useOnboardingTour.ts
+++ b/apps/src/sharedComponents/productTour/useOnboardingTour.ts
@@ -42,7 +42,6 @@ const useOnboardingTour = ({
 
     tour.on('complete', () => {
       trySetSessionStorage(sessionStorageKey, '');
-      // TODO: persist completion to backend
       onComplete?.();
     });
 

--- a/apps/src/templates/studioHomepages/teacherHomepageV2/useCreateSectionTour.ts
+++ b/apps/src/templates/studioHomepages/teacherHomepageV2/useCreateSectionTour.ts
@@ -1,5 +1,6 @@
 import {createShepherdTour} from '@cdo/apps/sharedComponents/productTour/shepherdTourFactory';
 import useOnboardingTour from '@cdo/apps/sharedComponents/productTour/useOnboardingTour';
+import HttpClient from '@cdo/apps/util/HttpClient';
 import {tryGetSessionStorage, trySetSessionStorage} from '@cdo/apps/utils';
 
 import {
@@ -9,6 +10,15 @@ import {
 
 export const CREATE_SECTION_ONBOARDING_STEP_KEY =
   'createSectionOnboardingCurrentStep';
+
+const recordTourCompletion = () => {
+  HttpClient.post(
+    '/dashboardapi/v1/user_product_tours',
+    JSON.stringify({tour_name: 'create_class_section'}),
+    true,
+    {'Content-Type': 'application/json'}
+  ).catch(err => console.error('Failed to record tour completion:', err));
+};
 
 // Call this on pages that the tour navigates to (e.g. sections/new).
 // It runs outside React so it works regardless of render mode.
@@ -29,7 +39,10 @@ export const resumeCreateSectionOnboardingTour = (
 
   const clearStep = () =>
     trySetSessionStorage(CREATE_SECTION_ONBOARDING_STEP_KEY, '');
-  tour.on('complete', clearStep);
+  tour.on('complete', () => {
+    clearStep();
+    recordTourCompletion();
+  });
   tour.on('cancel', clearStep);
 
   // Resume at the saved step if it belongs to this page, otherwise start

--- a/apps/src/templates/studioHomepages/teacherHomepageV2/useCreateSectionTour.ts
+++ b/apps/src/templates/studioHomepages/teacherHomepageV2/useCreateSectionTour.ts
@@ -11,7 +11,7 @@ import {
 export const CREATE_SECTION_ONBOARDING_STEP_KEY =
   'createSectionOnboardingCurrentStep';
 
-const recordTourCompletion = () => {
+export const recordTourCompletion = () => {
   HttpClient.post(
     '/dashboardapi/v1/user_product_tours',
     JSON.stringify({tour_name: 'create_class_section'}),

--- a/apps/test/unit/templates/studioHomepages/teacherHomepageV2/useCreateSectionTourTest.ts
+++ b/apps/test/unit/templates/studioHomepages/teacherHomepageV2/useCreateSectionTourTest.ts
@@ -1,0 +1,72 @@
+import {renderHook} from '@testing-library/react-hooks';
+
+import useOnboardingTour, {
+  UseOnboardingTourProps,
+} from '@cdo/apps/sharedComponents/productTour/useOnboardingTour';
+import useCreateSectionTour from '@cdo/apps/templates/studioHomepages/teacherHomepageV2/useCreateSectionTour';
+import HttpClient from '@cdo/apps/util/HttpClient';
+
+jest.mock('@cdo/apps/util/HttpClient', () => ({
+  post: jest.fn(),
+}));
+
+jest.mock('@cdo/apps/sharedComponents/productTour/useOnboardingTour', () =>
+  jest.fn()
+);
+
+jest.mock(
+  '@cdo/apps/templates/studioHomepages/teacherHomepageV2/createSectionOnboarding',
+  () => ({
+    createHomepageSteps: jest.fn().mockReturnValue([]),
+    createSectionsNewSteps: jest.fn().mockReturnValue([]),
+  })
+);
+
+const mockUseOnboardingTour = useOnboardingTour as jest.MockedFunction<
+  typeof useOnboardingTour
+>;
+const mockHttpClientPost = HttpClient.post as jest.MockedFunction<
+  typeof HttpClient.post
+>;
+
+describe('useCreateSectionTour', () => {
+  let capturedProps: UseOnboardingTourProps;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseOnboardingTour.mockImplementation(
+      (props: UseOnboardingTourProps) => {
+        capturedProps = props;
+        return {tour: {} as never};
+      }
+    );
+  });
+
+  it('calls HttpClient.post with correct args when onComplete fires', async () => {
+    mockHttpClientPost.mockResolvedValue(new Response());
+
+    renderHook(() => useCreateSectionTour(false));
+
+    expect(capturedProps.onComplete).toBeDefined();
+    capturedProps.onComplete!();
+
+    expect(mockHttpClientPost).toHaveBeenCalledWith(
+      '/dashboardapi/v1/user_product_tours',
+      JSON.stringify({tour_name: 'create_class_section'}),
+      true,
+      {'Content-Type': 'application/json'}
+    );
+  });
+
+  it('does not throw when the backend call fails', async () => {
+    mockHttpClientPost.mockRejectedValue(new Error('network error'));
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    renderHook(() => useCreateSectionTour(false));
+    capturedProps.onComplete!();
+
+    // Allow the rejected promise to settle without throwing
+    await Promise.resolve();
+    expect(console.error).toHaveBeenCalled();
+  });
+});

--- a/apps/test/unit/templates/studioHomepages/teacherHomepageV2/useCreateSectionTourTest.ts
+++ b/apps/test/unit/templates/studioHomepages/teacherHomepageV2/useCreateSectionTourTest.ts
@@ -1,54 +1,23 @@
-import {renderHook} from '@testing-library/react-hooks';
-
-import useOnboardingTour, {
-  UseOnboardingTourProps,
-} from '@cdo/apps/sharedComponents/productTour/useOnboardingTour';
-import useCreateSectionTour from '@cdo/apps/templates/studioHomepages/teacherHomepageV2/useCreateSectionTour';
+import {recordTourCompletion} from '@cdo/apps/templates/studioHomepages/teacherHomepageV2/useCreateSectionTour';
 import HttpClient from '@cdo/apps/util/HttpClient';
 
 jest.mock('@cdo/apps/util/HttpClient', () => ({
   post: jest.fn(),
 }));
 
-jest.mock('@cdo/apps/sharedComponents/productTour/useOnboardingTour', () =>
-  jest.fn()
-);
-
-jest.mock(
-  '@cdo/apps/templates/studioHomepages/teacherHomepageV2/createSectionOnboarding',
-  () => ({
-    createHomepageSteps: jest.fn().mockReturnValue([]),
-    createSectionsNewSteps: jest.fn().mockReturnValue([]),
-  })
-);
-
-const mockUseOnboardingTour = useOnboardingTour as jest.MockedFunction<
-  typeof useOnboardingTour
->;
 const mockHttpClientPost = HttpClient.post as jest.MockedFunction<
   typeof HttpClient.post
 >;
 
-describe('useCreateSectionTour', () => {
-  let capturedProps: UseOnboardingTourProps;
-
+describe('recordTourCompletion', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    mockUseOnboardingTour.mockImplementation(
-      (props: UseOnboardingTourProps) => {
-        capturedProps = props;
-        return {tour: {} as never};
-      }
-    );
   });
 
-  it('calls HttpClient.post with correct args when onComplete fires', async () => {
+  it('calls HttpClient.post with correct args', () => {
     mockHttpClientPost.mockResolvedValue(new Response());
 
-    renderHook(() => useCreateSectionTour(false));
-
-    expect(capturedProps.onComplete).toBeDefined();
-    capturedProps.onComplete!();
+    recordTourCompletion();
 
     expect(mockHttpClientPost).toHaveBeenCalledWith(
       '/dashboardapi/v1/user_product_tours',
@@ -62,10 +31,8 @@ describe('useCreateSectionTour', () => {
     mockHttpClientPost.mockRejectedValue(new Error('network error'));
     jest.spyOn(console, 'error').mockImplementation(() => {});
 
-    renderHook(() => useCreateSectionTour(false));
-    capturedProps.onComplete!();
+    recordTourCompletion();
 
-    // Allow the rejected promise to settle without throwing
     await Promise.resolve();
     expect(console.error).toHaveBeenCalled();
   });

--- a/dashboard/app/controllers/api/v1/user_product_tours_controller.rb
+++ b/dashboard/app/controllers/api/v1/user_product_tours_controller.rb
@@ -1,0 +1,19 @@
+class Api::V1::UserProductToursController < Api::V1::JSONApiController
+  def create
+    return head :unauthorized unless current_user
+
+    tour_name = params.require(:tour_name)
+    record = UserProductTour.find_or_initialize_by(user: current_user, tour_name: tour_name)
+
+    unless record.persisted?
+      record.completed_at = Time.now.utc
+      unless record.save
+        return render json: {errors: record.errors.full_messages}, status: :unprocessable_entity
+      end
+    end
+
+    head :ok
+  rescue ActiveRecord::RecordNotUnique
+    head :ok
+  end
+end

--- a/dashboard/config/routes.rb
+++ b/dashboard/config/routes.rb
@@ -1248,8 +1248,6 @@ Dashboard::Application.routes.draw do
     # Routes used by donor teacher banner
     post '/dashboardapi/v1/users/:user_id/dismiss_donor_teacher_banner', to: 'api/v1/users#dismiss_donor_teacher_banner'
 
-    post '/dashboardapi/v1/user_product_tours', to: 'api/v1/user_product_tours#create'
-
     # Routes used by teacher scores
     post '/dashboardapi/v1/teacher_scores', to: 'api/v1/teacher_scores#score_lessons_for_section'
     get '/dashboardapi/v1/teacher_scores/:section_id/:script_id', to: 'api/v1/teacher_scores#get_teacher_scores_for_script', defaults: {format: 'json'}

--- a/dashboard/config/routes.rb
+++ b/dashboard/config/routes.rb
@@ -1248,6 +1248,8 @@ Dashboard::Application.routes.draw do
     # Routes used by donor teacher banner
     post '/dashboardapi/v1/users/:user_id/dismiss_donor_teacher_banner', to: 'api/v1/users#dismiss_donor_teacher_banner'
 
+    post '/dashboardapi/v1/user_product_tours', to: 'api/v1/user_product_tours#create'
+
     # Routes used by teacher scores
     post '/dashboardapi/v1/teacher_scores', to: 'api/v1/teacher_scores#score_lessons_for_section'
     get '/dashboardapi/v1/teacher_scores/:section_id/:script_id', to: 'api/v1/teacher_scores#get_teacher_scores_for_script', defaults: {format: 'json'}

--- a/dashboard/config/routes.rb
+++ b/dashboard/config/routes.rb
@@ -1240,6 +1240,7 @@ Dashboard::Application.routes.draw do
     get '/dashboardapi/v1/schools/:school_district_id/:school_type', to: 'api/v1/schools#index', defaults: {format: 'json'}
     get '/dashboardapi/v1/schools/:id', to: 'api/v1/schools#show', defaults: {format: 'json'}
 
+    post '/dashboardapi/v1/user_product_tours', to: 'api/v1/user_product_tours#create'
     post '/dashboardapi/v1/users/:user_id/verify_captcha', to: 'api/v1/users#verify_captcha'
 
     # Routes used by census

--- a/dashboard/test/controllers/api/v1/user_product_tours_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/user_product_tours_controller_test.rb
@@ -25,7 +25,7 @@ class Api::V1::UserProductToursControllerTest < ActionDispatch::IntegrationTest
   test 'repeat completion is idempotent and returns 200' do
     teacher = create(:teacher)
     sign_in teacher
-    create(:user_product_tour, user: teacher, tour_name: UserProductTour::CREATE_CLASS_SECTION)
+    UserProductTour.create!(user: teacher, tour_name: UserProductTour::CREATE_CLASS_SECTION, completed_at: Time.now.utc)
 
     assert_no_difference 'UserProductTour.count' do
       post '/dashboardapi/v1/user_product_tours',

--- a/dashboard/test/controllers/api/v1/user_product_tours_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/user_product_tours_controller_test.rb
@@ -1,0 +1,46 @@
+require 'test_helper'
+
+class Api::V1::UserProductToursControllerTest < ActionDispatch::IntegrationTest
+  test 'unauthenticated request returns 401' do
+    post '/dashboardapi/v1/user_product_tours',
+      params: {tour_name: UserProductTour::CREATE_CLASS_SECTION}, as: :json
+
+    assert_response :unauthorized
+  end
+
+  test 'first-time completion creates a record and returns 200' do
+    teacher = create(:teacher)
+    sign_in teacher
+
+    assert_difference 'UserProductTour.count', 1 do
+      post '/dashboardapi/v1/user_product_tours',
+        params: {tour_name: UserProductTour::CREATE_CLASS_SECTION}, as: :json
+    end
+
+    assert_response :ok
+    record = UserProductTour.find_by!(user: teacher, tour_name: UserProductTour::CREATE_CLASS_SECTION)
+    refute_nil record.completed_at
+  end
+
+  test 'repeat completion is idempotent and returns 200' do
+    teacher = create(:teacher)
+    sign_in teacher
+    create(:user_product_tour, user: teacher, tour_name: UserProductTour::CREATE_CLASS_SECTION)
+
+    assert_no_difference 'UserProductTour.count' do
+      post '/dashboardapi/v1/user_product_tours',
+        params: {tour_name: UserProductTour::CREATE_CLASS_SECTION}, as: :json
+    end
+
+    assert_response :ok
+  end
+
+  test 'invalid tour name returns 422' do
+    sign_in create(:teacher)
+
+    post '/dashboardapi/v1/user_product_tours',
+      params: {tour_name: 'not_a_real_tour'}, as: :json
+
+    assert_response :unprocessable_entity
+  end
+end

--- a/dashboard/test/factories/factories.rb
+++ b/dashboard/test/factories/factories.rb
@@ -2447,4 +2447,10 @@ FactoryBot.define do
     read_at {nil}
     is_dismissed {false}
   end
+
+  factory :user_product_tour do
+    association :user
+    tour_name {UserProductTour::CREATE_CLASS_SECTION}
+    completed_at {Time.now.utc}
+  end
 end

--- a/dashboard/test/factories/factories.rb
+++ b/dashboard/test/factories/factories.rb
@@ -2447,10 +2447,4 @@ FactoryBot.define do
     read_at {nil}
     is_dismissed {false}
   end
-
-  factory :user_product_tour do
-    association :user
-    tour_name {UserProductTour::CREATE_CLASS_SECTION}
-    completed_at {Time.now.utc}
-  end
 end


### PR DESCRIPTION
Creates a new UserProductTour record when a user finishes the "Create a section" tour.  

Future PR: 
- Modify UI so that the "Create a section" tour shows as completed after the user has completed the tour.


## Links
<!-- Jira tickets, design docs, Slack threads, related PRs, etc. -->

- Jira:

## How AI was used
This was my first time using open spec to create something for a larger project.   I was more interested to see how it did and it did an OK job with still some clean-up work needed on the back end.  One of the things I appreciate about using this tool was how it adds tests right away - something I am not always so disciplined at. 

