### PR TITLE
increase eyes parallelism to 20 during DTT

### DIFF
--- a/lib/rake/test.rake
+++ b/lib/rake/test.rake
@@ -118,7 +118,7 @@ namespace :test do
       '--magic_retry',
       '--with-status-page',
       '-f', eyes_features.join(","),
-      '--parallel', '15'
+      '--parallel', '20'
     )
     if failed_browser_count == 0
       message = '⊙‿⊙ Eyes tests for <b>dashboard</b> succeeded, no changes detected.'

--- a/lib/rake/test.rake
+++ b/lib/rake/test.rake
@@ -40,7 +40,7 @@ namespace :test do
       '-d', CDO.site_host('studio.code.org'),
       '-p', CDO.site_host('code.org'),
       '--db', # Ensure features that require database access are run even if the server name isn't "test"
-      '--parallel', '20',
+      '--parallel', '20', # The total saucelabs concurrency budget is 65
       '--magic_retry',
       '--with-status-page',
       '--fail_fast',
@@ -118,7 +118,7 @@ namespace :test do
       '--magic_retry',
       '--with-status-page',
       '-f', eyes_features.join(","),
-      '--parallel', '20'
+      '--parallel', '20' # The total saucelabs concurrency budget is 65
     )
     if failed_browser_count == 0
       message = '⊙‿⊙ Eyes tests for <b>dashboard</b> succeeded, no changes detected.'


### PR DESCRIPTION
Similar to https://github.com/code-dot-org/code-dot-org/pull/72536 . The eyes test run is now the long pole during some DTTs, and we have headroom before we hit saucelabs concurrency limits. so, increase the parallelism used by eyes tests during DTT from 15 to 20.

the budget of 65 concurrent saucelabs run is now allocated as follows during DTT:
- 20 for Safari (mac) UI tests
- 20 for Eyes (Chrome) UI tests
- 25 for drone and local reruns

UI tests during DTT are run with higher priority. if we find that drone runs are frequently failing with concurrency errors during DTT, we can consider revisiting this.

## Testing story
- no explicit testing. saucelabs performance varies over time, so we'll wait and see how the run times are looking over the next few days.