### PR TITLE
migration to update student podcast table

### DIFF
--- a/dashboard/app/models/ai_student_podcast.rb
+++ b/dashboard/app/models/ai_student_podcast.rb
@@ -1,15 +1,15 @@
 # == Schema Information
 #
-# Table name: ai_student_podcast_fragments
+# Table name: ai_student_podcasts
 #
 #  id             :bigint           not null, primary key
 #  user_id        :bigint
 #  lesson_id      :integer
-#  fragment_type  :string(255)
-#  objective_id   :integer
 #  podcast_script :text(65535)
 #  created_at     :datetime         not null
 #  updated_at     :datetime         not null
 #
-class AiStudentPodcastFragment < ApplicationRecord
+class AiStudentPodcast < ApplicationRecord
+  has_many :ai_student_podcast_objectives, dependent: :destroy
+  has_many :objectives, join_table: :ai_student_podcast_objectives
 end

--- a/dashboard/db/migrate/20260506120000_rename_and_refactor_ai_student_podcast_fragments.rb
+++ b/dashboard/db/migrate/20260506120000_rename_and_refactor_ai_student_podcast_fragments.rb
@@ -1,0 +1,20 @@
+class RenameAndRefactorAiStudentPodcastFragments < ActiveRecord::Migration[7.0]
+  def change
+    rename_table :ai_student_podcast_fragments, :ai_student_podcasts
+
+    remove_column :ai_student_podcasts, :fragment_type, :string
+    remove_column :ai_student_podcasts, :objective_id, :integer
+
+    create_table :ai_student_podcast_objectives do |t|
+      t.bigint :ai_student_podcast_id, null: false
+      t.integer :objective_id, null: false
+    end
+
+    add_index :ai_student_podcast_objectives, :ai_student_podcast_id
+    add_index :ai_student_podcast_objectives, :objective_id
+    add_index :ai_student_podcast_objectives,
+      [:ai_student_podcast_id, :objective_id],
+      unique: true,
+      name: 'index_ai_student_podcast_objectives_unique'
+  end
+end

--- a/dashboard/db/schema.rb
+++ b/dashboard/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2026_04_29_120000) do
+ActiveRecord::Schema[7.0].define(version: 2026_05_06_120000) do
   create_table "activities", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "user_id"
     t.integer "level_id"
@@ -61,11 +61,17 @@ ActiveRecord::Schema[7.0].define(version: 2026_04_29_120000) do
     t.text "script"
   end
 
-  create_table "ai_student_podcast_fragments", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "ai_student_podcast_objectives", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+    t.bigint "ai_student_podcast_id", null: false
+    t.integer "objective_id", null: false
+    t.index ["ai_student_podcast_id", "objective_id"], name: "index_ai_student_podcast_objectives_unique", unique: true
+    t.index ["ai_student_podcast_id"], name: "index_ai_student_podcast_objectives_on_ai_student_podcast_id"
+    t.index ["objective_id"], name: "index_ai_student_podcast_objectives_on_objective_id"
+  end
+
+  create_table "ai_student_podcasts", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.bigint "user_id"
     t.integer "lesson_id"
-    t.string "fragment_type"
-    t.integer "objective_id"
     t.text "podcast_script"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false


### PR DESCRIPTION
This migration renames the ai_student_podcast_fragments table to ai_student_podcasts, removes 2 lines, and adds a join table with objectives.

## Links
<!-- Jira tickets, design docs, Slack threads, related PRs, etc. -->

- Jira:

## Testing story
<!-- How was this tested? Manual steps, adhoc links, automated tests, or why testing isn't needed. -->



## Deployment notes
<!-- Delete this section if it's a standard merge-and-deploy.
     Otherwise: migrations, feature flags, coordination, caching impacts, etc. -->



## Privacy and security
<!-- Delete this section if there is no privacy/security impact.
     Otherwise: new PII, auth changes, API surface changes, etc. -->

