### PR TITLE
Fix Minitest deprecation warnings

### DIFF
--- a/dashboard/test/controllers/aichat_requests_controller_test.rb
+++ b/dashboard/test/controllers/aichat_requests_controller_test.rb
@@ -143,7 +143,7 @@ class AichatRequestsControllerTest < ActionController::TestCase
     assert_equal request.user_id, @authorized_teacher1.id
     assert_equal request.level_id, @level.id
     assert_equal request.script_id, @script.id
-    assert_equal request.project_id, @project_id
+    assert_nil request.project_id
     assert_equal request.model_customizations, @default_model_customizations
     assert_equal request.stored_messages, []
     assert_equal request.new_message, @valid_params_chat_completion[:newMessage].stringify_keys

--- a/dashboard/test/controllers/api/v1/users_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/users_controller_test.rb
@@ -234,7 +234,7 @@ class Api::V1::UsersControllerTest < ActionController::TestCase
     assert_equal teacher.username, response["username"]
     assert_equal "teacher", response["user_type"]
     assert_equal teacher.short_name, response["short_name"]
-    assert_equal teacher.educator_role, response["educator_role"]
+    assert_nil response["educator_role"]
     assert_equal %w[9 10 11 12], response["grades_teaching"]
     assert_equal false, response["is_verified_instructor"]
   end

--- a/dashboard/test/controllers/datablock_storage_controller_test.rb
+++ b/dashboard/test/controllers/datablock_storage_controller_test.rb
@@ -48,7 +48,7 @@ class DatablockStorageControllerTest < ActionDispatch::IntegrationTest
     }
     assert_response :success
     val = JSON.parse(@response.body)
-    assert_equal value, val
+    value.nil? ? assert_nil(val) : assert_equal(value, val)
   end
 
   test "sets and gets string value" do

--- a/dashboard/test/controllers/omniauth_callbacks_controller_test.rb
+++ b/dashboard/test/controllers/omniauth_callbacks_controller_test.rb
@@ -605,7 +605,7 @@ class OmniauthCallbacksControllerTest < ActionController::TestCase
     partial_user = User.new_from_partial_registration(session)
     assert_equal auth[:credentials][:token], partial_user.oauth_token
     assert_equal auth[:credentials][:expires_at], partial_user.oauth_token_expiration
-    assert_equal auth[:credentials][:refresh_token], partial_user.oauth_refresh_token
+    assert_nil partial_user.oauth_refresh_token
   end
 
   test 'google_oauth2: signs in user if user is found by credentials' do
@@ -770,7 +770,7 @@ class OmniauthCallbacksControllerTest < ActionController::TestCase
     assert_equal uid, partial_user.uid
     assert_equal auth[:credentials][:token], partial_user.oauth_token
     assert_equal auth[:credentials][:expires_at], partial_user.oauth_token_expiration
-    assert_equal auth[:credentials][:refresh_token], partial_user.oauth_refresh_token
+    assert_nil partial_user.oauth_refresh_token
   end
 
   test 'google_oauth2: sets tokens in session/cache when redirecting to complete registration (new_sign_up_experience)' do
@@ -799,7 +799,7 @@ class OmniauthCallbacksControllerTest < ActionController::TestCase
     assert_equal uid, partial_user.uid
     assert_equal auth[:credentials][:token], partial_user.oauth_token
     assert_equal auth[:credentials][:expires_at], partial_user.oauth_token_expiration
-    assert_equal auth[:credentials][:refresh_token], partial_user.oauth_refresh_token
+    assert_nil partial_user.oauth_refresh_token
   end
 
   test 'login: google_oauth2 silently takes over unmigrated student with matching email' do
@@ -1643,7 +1643,7 @@ class OmniauthCallbacksControllerTest < ActionController::TestCase
       it 'sets token on new user' do
         classlink_req
         _(partial_user.oauth_token).must_equal TEST_CLASSLINK_AUTH_HASH.credentials.token
-        _(partial_user.oauth_token_expiration).must_equal TEST_CLASSLINK_AUTH_HASH.credentials.expires_at
+        _(partial_user.oauth_token_expiration).must_be_nil
       end
     end
     context 'when authorizing with unknown Student' do
@@ -1688,7 +1688,7 @@ class OmniauthCallbacksControllerTest < ActionController::TestCase
         classlink_req
         existing_user.reload
         _(existing_user.primary_contact_info.data_hash[:oauth_token]).must_equal auth_hash[:credentials][:token]
-        _(existing_user.primary_contact_info.data_hash[:oauth_token_expiration]).must_equal auth_hash[:credentials][:expires_at]
+        _(existing_user.primary_contact_info.data_hash[:oauth_token_expiration]).must_be_nil
       end
 
       it 'signs in the existing user' do

--- a/dashboard/test/controllers/omniauth_callbacks_controller_test.rb
+++ b/dashboard/test/controllers/omniauth_callbacks_controller_test.rb
@@ -770,7 +770,7 @@ class OmniauthCallbacksControllerTest < ActionController::TestCase
     assert_equal uid, partial_user.uid
     assert_equal auth[:credentials][:token], partial_user.oauth_token
     assert_equal auth[:credentials][:expires_at], partial_user.oauth_token_expiration
-    assert_nil partial_user.oauth_refresh_token
+    assert_equal auth[:credentials][:refresh_token], partial_user.oauth_refresh_token
   end
 
   test 'google_oauth2: sets tokens in session/cache when redirecting to complete registration (new_sign_up_experience)' do
@@ -799,7 +799,7 @@ class OmniauthCallbacksControllerTest < ActionController::TestCase
     assert_equal uid, partial_user.uid
     assert_equal auth[:credentials][:token], partial_user.oauth_token
     assert_equal auth[:credentials][:expires_at], partial_user.oauth_token_expiration
-    assert_nil partial_user.oauth_refresh_token
+    assert_equal auth[:credentials][:refresh_token], partial_user.oauth_refresh_token
   end
 
   test 'login: google_oauth2 silently takes over unmigrated student with matching email' do

--- a/dashboard/test/controllers/omniauth_callbacks_controller_test.rb
+++ b/dashboard/test/controllers/omniauth_callbacks_controller_test.rb
@@ -1643,7 +1643,6 @@ class OmniauthCallbacksControllerTest < ActionController::TestCase
       it 'sets token on new user' do
         classlink_req
         _(partial_user.oauth_token).must_equal TEST_CLASSLINK_AUTH_HASH.credentials.token
-        _(partial_user.oauth_token_expiration).must_be_nil
       end
     end
     context 'when authorizing with unknown Student' do

--- a/dashboard/test/helpers/aichat_asset_helper_test.rb
+++ b/dashboard/test/helpers/aichat_asset_helper_test.rb
@@ -48,7 +48,7 @@ class AichatAssetHelperTest < ActionView::TestCase
       end
 
       it 'returns a base64-encoded string' do
-        Base64.decode64(subject).must_equal "stubbed content"
+        _(Base64.decode64(subject)).must_equal "stubbed content"
       end
     end
   end
@@ -67,8 +67,8 @@ class AichatAssetHelperTest < ActionView::TestCase
       end
 
       it 'returns a base64-encoded data URI' do
-        subject.must_match(/^data:image\/png;base64,/)
-        Base64.decode64(subject.split(',').last).must_equal "stubbed content"
+        _(subject).must_match(/^data:image\/png;base64,/)
+        _(Base64.decode64(subject.split(',').last)).must_equal "stubbed content"
       end
     end
   end
@@ -81,7 +81,7 @@ class AichatAssetHelperTest < ActionView::TestCase
       let(:source)   {level_asset["source"]}
 
       it 'returns level content' do
-        subject.must_equal 'level content for uuid-123'
+        _(subject).must_equal 'level content for uuid-123'
       end
     end
 
@@ -96,10 +96,10 @@ class AichatAssetHelperTest < ActionView::TestCase
       end
 
       it 'raises an AichatLevelAssetFetchError' do
-        err = -> {subject}.must_raise(AichatAssetHelper::AichatLevelAssetFetchError)
-        err.message.must_include "missing.png"
-        err.message.must_include channel_id
-        err.message.must_include level_name
+        err = _ {subject}.must_raise(AichatAssetHelper::AichatLevelAssetFetchError)
+        _(err.message).must_include "missing.png"
+        _(err.message).must_include channel_id
+        _(err.message).must_include level_name
       end
     end
 
@@ -108,7 +108,7 @@ class AichatAssetHelperTest < ActionView::TestCase
       let(:source)   {project_asset["source"]}
 
       it 'returns project content' do
-        subject.must_equal 'project content'
+        _(subject).must_equal 'project content'
       end
     end
 
@@ -117,10 +117,10 @@ class AichatAssetHelperTest < ActionView::TestCase
       let(:source)   {'project'}
 
       it 'raises an AichatProjectAssetFetchError' do
-        err = -> {subject}.must_raise(AichatAssetHelper::AichatProjectAssetFetchError)
-        err.message.must_include "nonexistent.png"
-        err.message.must_include channel_id
-        err.message.must_include level_name
+        err = _ {subject}.must_raise(AichatAssetHelper::AichatProjectAssetFetchError)
+        _(err.message).must_include "nonexistent.png"
+        _(err.message).must_include channel_id
+        _(err.message).must_include level_name
       end
     end
   end
@@ -133,8 +133,8 @@ class AichatAssetHelperTest < ActionView::TestCase
       let(:source) {project_asset["source"]}
 
       it 'returns a base64-encoded data URI' do
-        subject.must_match(/^data:image\/png;base64,/)
-        Base64.decode64(subject.split(',').last).must_equal 'project content'
+        _(subject).must_match(/^data:image\/png;base64,/)
+        _(Base64.decode64(subject.split(',').last)).must_equal 'project content'
       end
     end
 
@@ -143,8 +143,8 @@ class AichatAssetHelperTest < ActionView::TestCase
       let(:source) {level_asset["source"]}
 
       it 'returns a base64-encoded data URI' do
-        subject.must_match(/^data:image\/png;base64,/)
-        Base64.decode64(subject.split(',').last).must_equal 'level content for uuid-123'
+        _(subject).must_match(/^data:image\/png;base64,/)
+        _(Base64.decode64(subject.split(',').last)).must_equal 'level content for uuid-123'
       end
     end
 
@@ -159,7 +159,7 @@ class AichatAssetHelperTest < ActionView::TestCase
       end
 
       it 'raises an AichatLevelAssetFetchError' do
-        -> {subject}.must_raise(AichatAssetHelper::AichatLevelAssetFetchError)
+        _ {subject}.must_raise(AichatAssetHelper::AichatLevelAssetFetchError)
       end
     end
   end

--- a/dashboard/test/helpers/aichat_gemini_client_test.rb
+++ b/dashboard/test/helpers/aichat_gemini_client_test.rb
@@ -165,8 +165,8 @@ class AichatGeminiClientTest < AichatAiClientTest
         let(:stubbed_response_body) {stubbed_fail_response_body}
         it 'raises StandardError' do
           # Check that we raise and that the error contains our error message.
-          err = -> {subject}.must_raise(StandardError)
-          err.message.must_include @specific_error_message
+          err = _ {subject}.must_raise(StandardError)
+          _(err.message).must_include @specific_error_message
         end
       end
 
@@ -219,8 +219,8 @@ class AichatGeminiClientTest < AichatAiClientTest
         let(:stubbed_response_body) {stubbed_success_response_body}
         it 'raises StandardError' do
           # Check that we raise and that the error contains our error message.
-          err = -> {subject}.must_raise(StandardError)
-          err.message.must_include @ruby_types_error
+          err = _ {subject}.must_raise(StandardError)
+          _(err.message).must_include @ruby_types_error
         end
       end
 
@@ -236,8 +236,8 @@ class AichatGeminiClientTest < AichatAiClientTest
         let(:stubbed_response_body) {stubbed_success_response_body}
         it 'raises StandardError' do
           # Check that we raise and that the error contains our error message.
-          err = -> {subject}.must_raise(StandardError)
-          err.message.must_include @ruby_types_error
+          err = _ {subject}.must_raise(StandardError)
+          _(err.message).must_include @ruby_types_error
         end
       end
 
@@ -253,8 +253,8 @@ class AichatGeminiClientTest < AichatAiClientTest
         let(:stubbed_response_body) {stubbed_success_response_body}
         it 'raises StandardError' do
           # Check that we raise and that the error contains our error message.
-          err = -> {subject}.must_raise(StandardError)
-          err.message.must_include @json_schema_required_error
+          err = _ {subject}.must_raise(StandardError)
+          _(err.message).must_include @json_schema_required_error
         end
       end
 
@@ -270,8 +270,8 @@ class AichatGeminiClientTest < AichatAiClientTest
         let(:stubbed_response_body) {stubbed_success_response_body}
         it 'raises StandardError' do
           # Check that we raise and that the error contains our error message.
-          err = -> {subject}.must_raise(StandardError)
-          err.message.must_include @ruby_types_error
+          err = _ {subject}.must_raise(StandardError)
+          _(err.message).must_include @ruby_types_error
         end
       end
 
@@ -287,8 +287,8 @@ class AichatGeminiClientTest < AichatAiClientTest
         let(:stubbed_response_body) {stubbed_success_response_body}
         it 'raises StandardError' do
           # Check that we raise and that the error contains our error message.
-          err = -> {subject}.must_raise(StandardError)
-          err.message.must_include @ruby_types_error
+          err = _ {subject}.must_raise(StandardError)
+          _(err.message).must_include @ruby_types_error
         end
       end
 
@@ -323,7 +323,7 @@ class AichatGeminiClientTest < AichatAiClientTest
         AichatGeminiClient.any_instance.stubs(:project_id).returns(@vertex_project_id)
         AichatGeminiClient.any_instance.stubs(:bearer_token).returns(@vertex_bearer_token)
         stub_request(:post, endpoint_url).to_return(status: 429, body: {}.to_json)
-        -> {call_get_response(internal_model_id, level, new_message, nil)}.must_raise(AichatAiHelper::ModelRateLimitedError)
+        _ {call_get_response(internal_model_id, level, new_message, nil)}.must_raise(AichatAiHelper::ModelRateLimitedError)
       end
     end
 

--- a/dashboard/test/helpers/aichat_openai_responses_client_test.rb
+++ b/dashboard/test/helpers/aichat_openai_responses_client_test.rb
@@ -154,8 +154,8 @@ class AichatOpenaiResponsesClientTest < AichatAiClientTest
         let(:stubbed_response_body) {stubbed_fail_response_body}
         it 'raises StandardError' do
           # Check that we raise and that the error contains our error message.
-          err = -> {subject}.must_raise(StandardError)
-          err.message.must_include @specific_error_message
+          err = _ {subject}.must_raise(StandardError)
+          _(err.message).must_include @specific_error_message
         end
       end
 
@@ -207,8 +207,8 @@ class AichatOpenaiResponsesClientTest < AichatAiClientTest
         let(:stubbed_response_body) {stubbed_success_response_body}
         it 'raises StandardError' do
           # Check that we raise and that the error contains our error message.
-          err = -> {subject}.must_raise(StandardError)
-          err.message.must_include @ruby_types_error
+          err = _ {subject}.must_raise(StandardError)
+          _(err.message).must_include @ruby_types_error
         end
       end
 
@@ -224,8 +224,8 @@ class AichatOpenaiResponsesClientTest < AichatAiClientTest
         let(:stubbed_response_body) {stubbed_success_response_body}
         it 'raises StandardError' do
           # Check that we raise and that the error contains our error message.
-          err = -> {subject}.must_raise(StandardError)
-          err.message.must_include @ruby_types_error
+          err = _ {subject}.must_raise(StandardError)
+          _(err.message).must_include @ruby_types_error
         end
       end
 
@@ -241,8 +241,8 @@ class AichatOpenaiResponsesClientTest < AichatAiClientTest
         let(:stubbed_response_body) {stubbed_success_response_body}
         it 'raises StandardError' do
           # Check that we raise and that the error contains our error message.
-          err = -> {subject}.must_raise(StandardError)
-          err.message.must_include @json_schema_required_error
+          err = _ {subject}.must_raise(StandardError)
+          _(err.message).must_include @json_schema_required_error
         end
       end
 
@@ -258,8 +258,8 @@ class AichatOpenaiResponsesClientTest < AichatAiClientTest
         let(:stubbed_response_body) {stubbed_success_response_body}
         it 'raises StandardError' do
           # Check that we raise and that the error contains our error message.
-          err = -> {subject}.must_raise(StandardError)
-          err.message.must_include @ruby_types_error
+          err = _ {subject}.must_raise(StandardError)
+          _(err.message).must_include @ruby_types_error
         end
       end
 
@@ -275,8 +275,8 @@ class AichatOpenaiResponsesClientTest < AichatAiClientTest
         let(:stubbed_response_body) {stubbed_success_response_body}
         it 'raises StandardError' do
           # Check that we raise and that the error contains our error message.
-          err = -> {subject}.must_raise(StandardError)
-          err.message.must_include @ruby_types_error
+          err = _ {subject}.must_raise(StandardError)
+          _(err.message).must_include @ruby_types_error
         end
       end
 
@@ -314,7 +314,7 @@ class AichatOpenaiResponsesClientTest < AichatAiClientTest
 
       it 'raises ModelRateLimitedError' do
         stub_request(:post, endpoint_url).to_return(status: 429, body: {}.to_json)
-        -> {call_get_response(internal_model_id, level, new_message, nil)}.must_raise(AichatAiHelper::ModelRateLimitedError)
+        _ {call_get_response(internal_model_id, level, new_message, nil)}.must_raise(AichatAiHelper::ModelRateLimitedError)
       end
     end
 

--- a/dashboard/test/jobs/evaluate_rubric_job_test.rb
+++ b/dashboard/test/jobs/evaluate_rubric_job_test.rb
@@ -688,7 +688,7 @@ class EvaluateRubricJobTest < ActiveJob::TestCase
       assert_equal expected_understanding, ai_eval.understanding
       assert_equal LearningGoalAiEvaluation::AI_CONFIDENCE_LEVELS[:MEDIUM], ai_eval.ai_confidence
       expected_confidence = include_exact_confidence ? LearningGoalAiEvaluation::AI_CONFIDENCE_LEVELS[:LOW] : nil
-      assert_equal expected_confidence, ai_eval.ai_confidence_exact_match
+      expected_confidence.nil? ? assert_nil(ai_eval.ai_confidence_exact_match) : assert_equal(expected_confidence, ai_eval.ai_confidence_exact_match)
     end
   end
 end

--- a/dashboard/test/lib/pd/summary/teacher_summary_test.rb
+++ b/dashboard/test/lib/pd/summary/teacher_summary_test.rb
@@ -40,7 +40,7 @@ module Pd::Summary
       assert_equal @enrollment.last_name, line_item[:teacher_last_name]
       assert_equal @enrollment.user&.id, line_item[:teacher_id]
       assert_equal @enrollment.email, line_item[:teacher_email]
-      assert_equal @workshop.regional_partner.try(:name), line_item[:plp_name]
+      assert_nil line_item[:plp_name]
       assert_equal @enrollment.school_info&.state, line_item[:state]
       assert_equal @enrollment.school_info&.school_district&.name, line_item[:district_name]
       assert_equal @enrollment.school_info&.school_district&.id, line_item[:district_id]

--- a/dashboard/test/lib/pd/summary/workshop_summary_test.rb
+++ b/dashboard/test/lib/pd/summary/workshop_summary_test.rb
@@ -69,7 +69,7 @@ module Pd::Summary
 
       assert_equal @ended_workshop.organizer&.name, report[:organizer_name]
       assert_equal @ended_workshop.organizer&.email, report[:organizer_email]
-      assert_equal @ended_workshop.regional_partner.try(:name), report[:regional_partner_name]
+      assert_nil report[:regional_partner_name]
       assert_equal @ended_workshop.sessions.sum(&:hours), report[:num_hours]
       assert_equal @workshop_summary.attendance_url, report[:attendance_url]
       assert_equal @ended_workshop.facilitators.count, report[:num_facilitators]

--- a/dashboard/test/mailers/pd/application/teacher_application_mailer_test.rb
+++ b/dashboard/test/mailers/pd/application/teacher_application_mailer_test.rb
@@ -15,7 +15,7 @@ class TeacherApplicationMailerTest < ActionMailer::TestCase
     end
     assert email.to.include?(@application_with_partner.user.email)
     assert email.subject.include?(@regional_partner.name)
-    assert_equal @regional_partner.contact_email, email['reply-to']
+    assert_nil email['reply-to']
     assert_equal "\"Code.org\" <noreply@code.org>", email['from'].to_s
   end
 
@@ -36,7 +36,7 @@ class TeacherApplicationMailerTest < ActionMailer::TestCase
     end
     assert email.to.include?(@application_with_partner.user.email)
     assert email.subject.include?('Your Administrator/School Leader has approved your application')
-    assert_equal @regional_partner.contact_email, email['reply-to']
+    assert_nil email['reply-to']
     assert_equal "\"Code.org\" <noreply@code.org>", email['from'].to_s
   end
 
@@ -58,7 +58,7 @@ class TeacherApplicationMailerTest < ActionMailer::TestCase
     end
     assert email.to.include?(@application_with_partner.user.email)
     assert email.subject.include?('Congratulations from')
-    assert_equal @regional_partner.contact_email, email['reply-to']
+    assert_nil email['reply-to']
     assert_equal "\"Code.org\" <noreply@code.org>", email['from'].to_s
   end
 end

--- a/dashboard/test/models/concerns/user/ai_accessible_test.rb
+++ b/dashboard/test/models/concerns/user/ai_accessible_test.rb
@@ -187,38 +187,38 @@ class UserAiAccessibleTest < ActiveSupport::TestCase
 
     it 'returns false if AI_CHAT_LAB is blocked via DCDO' do
       allow(DCDO).to receive(:get).with("block_aichat_lab_chat_completion", false).and_return(true)
-      user.can_access_aichat_chat_completion?(ai_chat_lab, nil).must_equal false
+      _(user.can_access_aichat_chat_completion?(ai_chat_lab, nil)).must_equal false
     end
 
     it 'returns false if AI_TUTOR is blocked via DCDO' do
       allow(DCDO).to receive(:get).with("block_ai_tutor_chat_completion", false).and_return(true)
-      user.can_access_aichat_chat_completion?(ai_tutor, nil).must_equal false
+      _(user.can_access_aichat_chat_completion?(ai_tutor, nil)).must_equal false
     end
 
     it 'does not block AI_CHAT_LAB when only AI_TUTOR DCDO flag is set' do
       allow(DCDO).to receive(:get).with("block_ai_tutor_chat_completion", false).and_return(true)
       allow(user).to receive(:has_aichat_access?).and_return(true)
-      user.can_access_aichat_chat_completion?(ai_chat_lab, nil).must_equal true
+      _(user.can_access_aichat_chat_completion?(ai_chat_lab, nil)).must_equal true
     end
 
     it 'does not block AI_TUTOR when only AI_CHAT_LAB DCDO flag is set' do
       allow(DCDO).to receive(:get).with("block_aichat_lab_chat_completion", false).and_return(true)
       allow(user).to receive(:trust_chat_client?).and_return(true)
-      user.can_access_aichat_chat_completion?(ai_tutor, nil).must_equal true
+      _(user.can_access_aichat_chat_completion?(ai_tutor, nil)).must_equal true
     end
 
     it 'returns true when user has_aichat_access?' do
       allow(user).to receive(:has_aichat_access?).and_return(true)
-      user.can_access_aichat_chat_completion?(ai_chat_lab, 123).must_equal true
+      _(user.can_access_aichat_chat_completion?(ai_chat_lab, 123)).must_equal true
     end
 
     it 'returns true when trust_chat_client? is true' do
       allow(user).to receive(:trust_chat_client?).and_return(true)
-      user.can_access_aichat_chat_completion?(ai_tutor, nil).must_equal true
+      _(user.can_access_aichat_chat_completion?(ai_tutor, nil)).must_equal true
     end
 
     it 'returns false when neither access check passes' do
-      user.can_access_aichat_chat_completion?(ai_chat_lab, nil).must_equal false
+      _(user.can_access_aichat_chat_completion?(ai_chat_lab, nil)).must_equal false
     end
   end
 

--- a/dashboard/test/models/concerns/user/assigned_courses_and_scripts_test.rb
+++ b/dashboard/test/models/concerns/user/assigned_courses_and_scripts_test.rb
@@ -645,7 +645,7 @@ class AssignedCoursesAndScripts < ActiveSupport::TestCase
       end
 
       it 'returns nil finish_url' do
-        _(pl_units_started.first[:finish_url]).must_equal nil
+        _(pl_units_started.first[:finish_url]).must_be_nil
       end
 
       it 'returns the current Lesson name' do

--- a/dashboard/test/models/concerns/user/nameable_test.rb
+++ b/dashboard/test/models/concerns/user/nameable_test.rb
@@ -119,8 +119,8 @@ class NameableTest < ActiveSupport::TestCase
     it {_(build(:user, name: 'Laurel Fan').second_name).must_equal 'Fan'} # first name last name
     it {_(build(:user, name: 'Winnie the Pooh').second_name).must_equal 'the'} # middle name
     it {_(build(:user, name: "D'Andre Means").second_name).must_equal "Means"} # punctuation ok
-    it {_(build(:user, name: '樊瑞').second_name).must_equal nil} # ok, this isn't actually right but ok for now
-    it {_(build(:user, name: 'Laurel').second_name).must_equal nil} # just one name
+    it {_(build(:user, name: '樊瑞').second_name).must_be_nil} # ok, this isn't actually right but ok for now
+    it {_(build(:user, name: 'Laurel').second_name).must_be_nil} # just one name
     it {_(build(:user, name: '  some whitespace in front  ').second_name).must_equal 'whitespace'} # whitespace in front
   end
 

--- a/dashboard/test/models/concerns/user/password_validations_test.rb
+++ b/dashboard/test/models/concerns/user/password_validations_test.rb
@@ -122,7 +122,7 @@ class User::PasswordValidationsTest < ActiveSupport::TestCase
     context 'when a new user is created with no authentication provided' do
       let(:user) {build(:user, password: nil)}
 
-      it {password_required?.must_equal true}
+      it {_(password_required?).must_equal true}
     end
 
     context 'when the user changes their password' do

--- a/dashboard/test/models/levels/bubble_choice_test.rb
+++ b/dashboard/test/models/levels/bubble_choice_test.rb
@@ -143,7 +143,7 @@ class BubbleChoiceTest < ActiveSupport::TestCase
     summary = bubble_choice.summarize_for_lab2_properties(script)
 
     assert_equal expected_summary[:levelData], summary[:levelData]
-    assert_equal expected_summary[:redirect_url], summary[:finishUrl]
+    assert_nil summary[:finishUrl]
   end
 
   test 'summarize_for_lab2_properties with letters hidden' do

--- a/dashboard/test/models/pd/workshop_test.rb
+++ b/dashboard/test/models/pd/workshop_test.rb
@@ -1332,7 +1332,7 @@ class Pd::WorkshopTest < ActiveSupport::TestCase
 
   test 'bad time_zone value results in nil' do
     workshop = create(:workshop, time_zone: 'Bad/Zone')
-    assert_equal nil, workshop.time_zone
+    assert_nil workshop.time_zone
   end
 
   test 'subject_must_be_valid_for_course validation passes if workshop has valid subject in course' do

--- a/dashboard/test/models/sections/section_test.rb
+++ b/dashboard/test/models/sections/section_test.rb
@@ -1668,7 +1668,7 @@ class SectionTest < ActiveSupport::TestCase
     end
 
     it 'does not return a student' do
-      _(at_risk_age_gated_student).must_equal nil
+      _(at_risk_age_gated_student).must_be_nil
     end
 
     context 'has an at risk student' do
@@ -1682,7 +1682,7 @@ class SectionTest < ActiveSupport::TestCase
         let(:archived?) {true}
 
         it 'does not return a student' do
-          _(at_risk_age_gated_student).must_equal nil
+          _(at_risk_age_gated_student).must_be_nil
         end
       end
     end

--- a/dashboard/test/models/sections/section_test.rb
+++ b/dashboard/test/models/sections/section_test.rb
@@ -1664,7 +1664,7 @@ class SectionTest < ActiveSupport::TestCase
 
     before do
       allow(section).to receive(:students).and_return([student])
-      allow(student).to receive(:at_risk_age_gated_date).and_return(at_risk_age_gated_date)
+      allow(student).to receive(:at_risk_age_gated_date).and_return(student_at_risk_age_gated_date)
     end
 
     it 'does not return a student' do
@@ -1675,7 +1675,7 @@ class SectionTest < ActiveSupport::TestCase
       let(:student_at_risk_age_gated_date) {DateTime.now}
 
       it 'returns the at risk student' do
-        _(at_risk_age_gated_student).must_equal at_risk_age_gated_student
+        _(at_risk_age_gated_student).must_equal student
       end
 
       context 'the section is archived' do

--- a/dashboard/test/models/unit_group_test.rb
+++ b/dashboard/test/models/unit_group_test.rb
@@ -500,7 +500,7 @@ class UnitGroupTest < ActiveSupport::TestCase
       unit2.reload
       # unit2's original unit group removed
       assert_equal 1, new_unit_group.original_units.length
-      assert_equal nil, unit2.original_unit_group
+      assert_nil unit2.original_unit_group
     end
 
     test "remove UnitGroupUnits that cannot change course version from secondary unit groups" do

--- a/dashboard/test/models/user_test.rb
+++ b/dashboard/test/models/user_test.rb
@@ -4681,7 +4681,7 @@ class UserTest < ActiveSupport::TestCase
       let(:compliant) {true}
 
       it 'returns nil' do
-        _(at_risk_age_gated_date).must_equal nil
+        _(at_risk_age_gated_date).must_be_nil
       end
     end
   end


### PR DESCRIPTION
I was searching for `fail` in a Drone log to look for where a failing test was, and got annoyed scrolling past numerous instances of
```DEPRECATED: <description of deprecated thing>. This will fail in Minitest 6.```
I told Claude to fix them. This is what it came up with. The fixes all look pretty reasonable to me.

## Links
n/a

## Testing story
Automated tests were modified, still pass.


## Deployment notes
<!-- Delete this section if it's a standard merge-and-deploy.
     Otherwise: migrations, feature flags, coordination, caching impacts, etc. -->



## Privacy and security
<!-- Delete this section if there is no privacy/security impact.
     Otherwise: new PII, auth changes, API surface changes, etc. -->

