### PR TITLE
handle false from post_to_slack

### DIFF
--- a/lib/cdo/slack.rb
+++ b/lib/cdo/slack.rb
@@ -42,12 +42,13 @@ module Slack
 
   # Returns a mention tag '<@id>' for a user based on their email.
   # @param email [String] The email of the Slack user.
-  # @raise [ArgumentError] If the email does not correspond to a Slack user.
-  # @return [nil | String] The user (mention) tag for the Slack user.
+  # @raise [RuntimeError] If the Slack API call fails or the email does not
+  #   correspond to a Slack user.
+  # @return [String] The user (mention) tag for the Slack user.
   def self.user_mention_tag(email)
-    members = post_to_slack("https://slack.com/api/users.list")['members']
-    raise "Failed to query users.list" unless members
-    user = members.find {|member| email == member['profile']['email']}
+    response = post_to_slack("https://slack.com/api/users.list")
+    raise "Failed to query users.list" unless response
+    user = response['members'].find {|member| email == member['profile']['email']}
     raise "Slack email #{email} not found" unless user
     "<@#{user['id']}>"
   end

--- a/lib/test/cdo/test_slack.rb
+++ b/lib/test/cdo/test_slack.rb
@@ -48,6 +48,12 @@ class SlackTest < Minitest::Test
     refute Slack.update_topic(FAKE_CHANNEL, FAKE_TOPIC)
   end
 
+  def test_user_mention_tag_with_error_response
+    Slack.stubs(:post_to_slack).returns(false)
+    err = assert_raises(RuntimeError) {Slack.user_mention_tag('user@example.com')}
+    assert_match(/users\.list/, err.message)
+  end
+
   def test_replace_user_links
     Slack.stubs(:get_display_name).returns('elsa')
     assert_equal 'DOTD: @elsa; DTS: yes',


### PR DESCRIPTION
`post_to_slack` returns false when Slack returns `ok:false` or the request `raises. user_mention_tag` indexed the result without checking, so transient Slack failures surfaced as `NoMethodError: undefined method [] for false` instead of the intended `Failed to query users.list` message. Other callers of `post_to_slack` already do this check; this brings `user_mention_tag` in line.

<!--
  Summary of the change: background, motivation, and context.
  Include screenshots, videos, or before/after comparisons for UI changes.
-->



## Links
<!-- Jira tickets, design docs, Slack threads, related PRs, etc. -->

- Jira:

## Testing story
<!-- How was this tested? Manual steps, adhoc links, automated tests, or why testing isn't needed. -->



## Deployment notes
<!-- Delete this section if it's a standard merge-and-deploy.
     Otherwise: migrations, feature flags, coordination, caching impacts, etc. -->



## Privacy and security
<!-- Delete this section if there is no privacy/security impact.
     Otherwise: new PII, auth changes, API surface changes, etc. -->

