### PR TITLE
Sketch2: consolidate lines and arrows

### DIFF
--- a/apps/src/sketchlab/reactFlow/components/ReactFlowCanvas.tsx
+++ b/apps/src/sketchlab/reactFlow/components/ReactFlowCanvas.tsx
@@ -412,7 +412,7 @@ export default function ReactFlowCanvas({
         return addEdge(
           {
             ...connection,
-            ...defaultLineEdgeFields({arrow: true}),
+            ...defaultLineEdgeFields(),
           },
           currentEdges
         );
@@ -493,7 +493,7 @@ export default function ReactFlowCanvas({
           id: createUuid(),
           source: sourceAnchor.id,
           target: targetAnchor.id,
-          ...defaultLineEdgeFields({arrow: true}), // default to arrow styling
+          ...defaultLineEdgeFields(),
         };
 
         setNodes(currentNodes => [...currentNodes, sourceAnchor, targetAnchor]);

--- a/apps/src/sketchlab/reactFlow/components/ReactFlowCanvas.tsx
+++ b/apps/src/sketchlab/reactFlow/components/ReactFlowCanvas.tsx
@@ -473,8 +473,8 @@ export default function ReactFlowCanvas({
         y: window.innerHeight / 2 + stagger,
       });
 
-      // For lines/arrows, create two hidden anchor nodes and connect them.
-      if (type === 'line' || type === 'arrow') {
+      // For lines, create two hidden anchor nodes and connect them.
+      if (type === 'line') {
         const sourceAnchor = createLineAnchorAtHandle(
           {
             x: centerPosition.x - LINE_DEFAULT_LENGTH_PX / 2,
@@ -493,7 +493,7 @@ export default function ReactFlowCanvas({
           id: createUuid(),
           source: sourceAnchor.id,
           target: targetAnchor.id,
-          ...defaultLineEdgeFields({arrow: type === 'arrow'}),
+          ...defaultLineEdgeFields({arrow: true}), // default to arrow styling
         };
 
         setNodes(currentNodes => [...currentNodes, sourceAnchor, targetAnchor]);

--- a/apps/src/sketchlab/reactFlow/components/ReactFlowCanvas.tsx
+++ b/apps/src/sketchlab/reactFlow/components/ReactFlowCanvas.tsx
@@ -34,6 +34,10 @@ import {
   type ToolbarTarget,
 } from '../context';
 import LineEdgeToolbar from '../elementToolbars/LineEdgeToolbar';
+import {
+  DEFAULT_LINE_WIDTH,
+  DEFAULT_STROKE_COLOR,
+} from '../elementToolbars/toolbarPalettes';
 import {useCopyPaste} from '../hooks/useCopyPaste';
 import {useFocusManagement} from '../hooks/useFocusManagement';
 import {useKeyboardNavigation} from '../hooks/useKeyboardNavigation';
@@ -630,11 +634,11 @@ export default function ReactFlowCanvas({
               defaultEdgeOptions={{
                 type: 'straight',
                 style: {
-                  stroke: 'var(--sketchlab-stroke-default)',
-                  strokeWidth: 1,
+                  stroke: DEFAULT_STROKE_COLOR,
+                  strokeWidth: DEFAULT_LINE_WIDTH,
                 },
               }}
-              defaultMarkerColor={'var(--sketchlab-stroke-default)'}
+              defaultMarkerColor={DEFAULT_STROKE_COLOR}
             >
               {openLineEdge && (
                 <LineEdgeToolbar

--- a/apps/src/sketchlab/reactFlow/components/ReactFlowCanvas.tsx
+++ b/apps/src/sketchlab/reactFlow/components/ReactFlowCanvas.tsx
@@ -627,6 +627,14 @@ export default function ReactFlowCanvas({
               disableKeyboardA11y={false}
               autoPanOnNodeFocus={false} // We manage viewport on focus manually in useFocusManagement.
               zIndexMode={'manual'}
+              defaultEdgeOptions={{
+                type: 'straight',
+                style: {
+                  stroke: 'var(--sketchlab-stroke-default)',
+                  strokeWidth: 1,
+                },
+              }}
+              defaultMarkerColor={'var(--sketchlab-stroke-default)'}
             >
               {openLineEdge && (
                 <LineEdgeToolbar

--- a/apps/src/sketchlab/reactFlow/components/Toolbar.tsx
+++ b/apps/src/sketchlab/reactFlow/components/Toolbar.tsx
@@ -154,24 +154,11 @@ export default function Toolbar({onAddNode, levelName}: ToolbarProps) {
         </IconButton>
       </Tooltip>
 
-      <Tooltip title="Add line" placement="right">
-        <IconButton
-          aria-label="Add line"
-          id={`${uid}-line`}
-          onClick={() => onAddNode({type: 'line'})}
-          size="small"
-          color="tertiary"
-          variant="outlined"
-        >
-          <FontAwesomeV6Icon iconName="minus" />
-        </IconButton>
-      </Tooltip>
-
       <Tooltip title="Add arrow" placement="right">
         <IconButton
           aria-label="Add arrow"
           id={`${uid}-arrow`}
-          onClick={() => onAddNode({type: 'arrow'})}
+          onClick={() => onAddNode({type: 'line'})}
           size="small"
           color="tertiary"
           variant="outlined"

--- a/apps/src/sketchlab/reactFlow/elementToolbars/LineEdgeToolbar.tsx
+++ b/apps/src/sketchlab/reactFlow/elementToolbars/LineEdgeToolbar.tsx
@@ -2,12 +2,12 @@ import FontAwesomeV6Icon from '@code-dot-org/component-library/fontAwesomeV6Icon
 import {IconButton, Tooltip, Typography} from '@mui/material';
 import {useReactFlow} from '@xyflow/react';
 import classNames from 'classnames';
-import React from 'react';
+import React, {useMemo} from 'react';
 
 import {SketchlabReactFlowEdge} from '@cdo/apps/lab2/types';
 
 import {useClipboard} from '../context';
-import {isArrowEdge} from '../utils/lineEdges';
+import {ArrowHeadValue} from '../types';
 import {newBackZIndex, newFrontZIndex} from '../utils/stacking';
 
 import ActionsGroup from './ActionsGroup';
@@ -94,15 +94,15 @@ interface LineEdgeToolbarProps {
   onSetLocked: (value: boolean) => void;
 }
 
-type ArrowHeadValue = 'start' | 'end' | 'both';
-
 const ARROW_HEAD_OPTIONS: readonly LineOption[] = [
+  {value: 'none', label: 'None'},
   {value: 'start', label: 'Start'},
   {value: 'end', label: 'End'},
   {value: 'both', label: 'Both'},
 ] as const;
 
 const ARROW_HEAD_ICONS: Record<ArrowHeadValue, string> = {
+  none: 'minus',
   start: 'arrow-left-long',
   end: 'arrow-right-long',
   both: 'arrows-left-right',
@@ -139,14 +139,20 @@ export default function LineEdgeToolbar({
   )
     ? selectedStrokeStyle
     : DEFAULT_LINE_STROKE_STYLE;
-  const hasStartArrow = !!edge.markerStart;
-  const hasEndArrow = !!edge.markerEnd;
-  const selectedArrowHeads: ArrowHeadValue = hasStartArrow
-    ? hasEndArrow
-      ? 'both'
-      : 'start'
-    : 'end';
-  const showArrowHeadOptions = isArrowEdge(edge);
+
+  const selectedArrowHeads = useMemo(() => {
+    const hasStartArrow = !!edge.markerStart;
+    const hasEndArrow = !!edge.markerEnd;
+    if (hasStartArrow && hasEndArrow) {
+      return 'both';
+    } else if (hasStartArrow) {
+      return 'start';
+    } else if (hasEndArrow) {
+      return 'end';
+    } else {
+      return 'none';
+    }
+  }, [edge.markerStart, edge.markerEnd]);
 
   const {duplicateLine} = useClipboard();
 
@@ -202,20 +208,18 @@ export default function LineEdgeToolbar({
               renderLinePreview(2, option.value as LinePreviewStyle)
             }
           />
-          {showArrowHeadOptions && (
-            <LineOptionGroup
-              groupLabel="Arrow heads"
-              options={ARROW_HEAD_OPTIONS}
-              selectedValue={selectedArrowHeads}
-              onSelect={value => onSelectArrowHeads(value as ArrowHeadValue)}
-              ariaLabelPrefix="Arrow heads"
-              getButtonContent={option => (
-                <FontAwesomeV6Icon
-                  iconName={ARROW_HEAD_ICONS[option.value as ArrowHeadValue]}
-                />
-              )}
-            />
-          )}
+          <LineOptionGroup
+            groupLabel="Arrow heads"
+            options={ARROW_HEAD_OPTIONS}
+            selectedValue={selectedArrowHeads}
+            onSelect={value => onSelectArrowHeads(value as ArrowHeadValue)}
+            ariaLabelPrefix="Arrow heads"
+            getButtonContent={option => (
+              <FontAwesomeV6Icon
+                iconName={ARROW_HEAD_ICONS[option.value as ArrowHeadValue]}
+              />
+            )}
+          />
           <ActionsGroup
             onDelete={() => deleteElements({edges: [{id: edge.id}]})}
             onLock={() => onSetLocked(true)}

--- a/apps/src/sketchlab/reactFlow/elementToolbars/LineEdgeToolbar.tsx
+++ b/apps/src/sketchlab/reactFlow/elementToolbars/LineEdgeToolbar.tsx
@@ -108,7 +108,6 @@ const ARROW_HEAD_ICONS: Record<ArrowHeadValue, string> = {
   both: 'arrows-left-right',
 };
 
-// Shared edge toolbar for both plain lines and arrows.
 export default function LineEdgeToolbar({
   edge,
   anchorNodeId,

--- a/apps/src/sketchlab/reactFlow/hooks/useConnectMode.ts
+++ b/apps/src/sketchlab/reactFlow/hooks/useConnectMode.ts
@@ -107,7 +107,7 @@ export function useConnectMode({
             source: connectingFrom,
             target: targetNodeId,
             ...handles,
-            ...defaultLineEdgeFields({arrow: true}),
+            ...defaultLineEdgeFields(),
           },
           currentEdges
         );

--- a/apps/src/sketchlab/reactFlow/hooks/useLineToolbar.ts
+++ b/apps/src/sketchlab/reactFlow/hooks/useLineToolbar.ts
@@ -11,8 +11,7 @@ import {
   LineStrokeStyleValue,
   strokeDasharrayFromStyle,
 } from '../elementToolbars/toolbarPalettes';
-
-type ArrowHeadValue = 'start' | 'end' | 'both';
+import {ArrowHeadValue} from '../types';
 
 interface UseLineToolbarOptions {
   edges: SketchlabReactFlowEdge[];

--- a/apps/src/sketchlab/reactFlow/types.ts
+++ b/apps/src/sketchlab/reactFlow/types.ts
@@ -54,8 +54,7 @@ export type AddNodeRequest =
   | {type: 'shape'; data: ShapeNodeData}
   | {type: 'text'; data: TextNodeData}
   | {type: 'image'; data: ImageNodeData}
-  | {type: 'line'}
-  | {type: 'arrow'};
+  | {type: 'line'};
 
 export type ShapeNodeType = Node<ShapeNodeData, 'shape'>;
 export type TextNodeType = Node<TextNodeData, 'text'>;
@@ -66,3 +65,5 @@ export type SketchLabNode =
   | TextNodeType
   | ImageNodeType
   | LineAnchorNodeType;
+
+export type ArrowHeadValue = 'none' | 'start' | 'end' | 'both';

--- a/apps/src/sketchlab/reactFlow/utils/lineEdges.ts
+++ b/apps/src/sketchlab/reactFlow/utils/lineEdges.ts
@@ -7,22 +7,20 @@ import {
 } from '../elementToolbars/toolbarPalettes';
 
 // Default visual fields shared by every line edge.
-// `arrow: true` adds the end-arrow marker;`arrow: false` omits it.
-export function defaultLineEdgeFields({arrow}: {arrow: boolean}) {
+// Defaults to a solid line with an arrow at the end.
+export function defaultLineEdgeFields() {
   return {
     type: 'straight',
     style: {
       stroke: DEFAULT_STROKE_COLOR,
       strokeWidth: DEFAULT_LINE_WIDTH,
     },
-    ...(arrow && {
-      markerEnd: {
-        type: MarkerType.ArrowClosed,
-        color: DEFAULT_STROKE_COLOR,
-        width: ARROW_MARKER_WIDTH_PX,
-        height: ARROW_MARKER_HEIGHT_PX,
-        strokeWidth: DEFAULT_LINE_WIDTH,
-      },
-    }),
+    markerEnd: {
+      type: MarkerType.ArrowClosed,
+      color: DEFAULT_STROKE_COLOR,
+      width: ARROW_MARKER_WIDTH_PX,
+      height: ARROW_MARKER_HEIGHT_PX,
+      strokeWidth: DEFAULT_LINE_WIDTH,
+    },
   };
 }

--- a/apps/src/sketchlab/reactFlow/utils/lineEdges.ts
+++ b/apps/src/sketchlab/reactFlow/utils/lineEdges.ts
@@ -1,16 +1,10 @@
 import {MarkerType} from '@xyflow/react';
 
-import {SketchlabReactFlowEdge} from '@cdo/apps/lab2/types';
-
 import {ARROW_MARKER_HEIGHT_PX, ARROW_MARKER_WIDTH_PX} from '../constants';
 import {
   DEFAULT_LINE_WIDTH,
   DEFAULT_STROKE_COLOR,
 } from '../elementToolbars/toolbarPalettes';
-
-export function isArrowEdge(edge: SketchlabReactFlowEdge): boolean {
-  return Boolean(edge.markerStart || edge.markerEnd);
-}
 
 // Default visual fields shared by every line edge.
 // `arrow: true` adds the end-arrow marker;`arrow: false` omits it.


### PR DESCRIPTION
This PR does two follow ups to #72517:
- Main work: consolidate lines and arrows into a single option in the main toolbar. That option is labelled 'arrow', as it is a line with an arrow on one end. 
- Small update so edges without styling have the same defaults as our default styling. This makes it so edges created in start code before my PR won't be very light gray and wavy (but see follow-ups for more on this).

For lines/arrows, in code I'm referring to them as 'lines' that can either have arrows on either end or not. This is consistent with the naming before, and I think 'line' encapsulates 'line with arrow', while 'arrow' does not include 'line'. The toolbar for lines now has 4 arrow head options, the new one being 'none'.

## Lines/Arrows
### Toolbar screenshot
<img width="720" height="660" alt="Screenshot 2026-05-06 at 3 18 43 PM" src="https://github.com/user-attachments/assets/c75a4b49-af7b-4c8a-9d6a-8be1f85d9ca6" />

### Toolbar in action

https://github.com/user-attachments/assets/ce1874ac-6ad2-465c-81c4-c53522d11f21


## Default edge styling
### Before
<img width="745" height="694" alt="Screenshot 2026-05-06 at 3 19 29 PM" src="https://github.com/user-attachments/assets/f0e13861-3489-4f8f-b73f-5647ec18e895" />

### After 
<img width="745" height="694" alt="Screenshot 2026-05-06 at 3 19 41 PM" src="https://github.com/user-attachments/assets/d190a9d1-b47c-46fd-9eea-d0ba51c1edeb" />


## Links

- Jira: [AFL-627](https://codedotorg.atlassian.net/browse/AFL-627)

## Testing story
Tested locally.


## Follow ups
I made the choice to have edges default to the default line styling for consistency, since now they are interchangeable. But we have a follow-up ticket to add edge styling in so we can get curvy lines again if desired: [AFL-634](https://codedotorg.atlassian.net/browse/AFL-634)
