### PR TITLE
Sketch2: add 'line shape' options

### DIFF
--- a/apps/src/sketchlab/reactFlow/components/ReactFlowCanvas.tsx
+++ b/apps/src/sketchlab/reactFlow/components/ReactFlowCanvas.tsx
@@ -563,6 +563,7 @@ export default function ReactFlowCanvas({
     setLineEdgeColor,
     setLineEdgeWidth,
     setLineEdgeStrokeStyle,
+    setLineEdgeType,
     setLineEdgeArrowHeads,
     setLineEdgeLocked,
   } = useLineToolbar({
@@ -652,6 +653,9 @@ export default function ReactFlowCanvas({
                   }
                   onSelectStrokeStyle={value =>
                     setLineEdgeStrokeStyle(openLineEdge.id, value)
+                  }
+                  onSelectEdgeType={value =>
+                    setLineEdgeType(openLineEdge.id, value)
                   }
                   onSelectArrowHeads={value =>
                     setLineEdgeArrowHeads(openLineEdge.id, value)

--- a/apps/src/sketchlab/reactFlow/components/ReactFlowCanvas.tsx
+++ b/apps/src/sketchlab/reactFlow/components/ReactFlowCanvas.tsx
@@ -35,6 +35,7 @@ import {
 } from '../context';
 import LineEdgeToolbar from '../elementToolbars/LineEdgeToolbar';
 import {
+  DEFAULT_EDGE_TYPE,
   DEFAULT_LINE_WIDTH,
   DEFAULT_STROKE_COLOR,
 } from '../elementToolbars/toolbarPalettes';
@@ -633,7 +634,7 @@ export default function ReactFlowCanvas({
               autoPanOnNodeFocus={false} // We manage viewport on focus manually in useFocusManagement.
               zIndexMode={'manual'}
               defaultEdgeOptions={{
-                type: 'straight',
+                type: DEFAULT_EDGE_TYPE,
                 style: {
                   stroke: DEFAULT_STROKE_COLOR,
                   strokeWidth: DEFAULT_LINE_WIDTH,

--- a/apps/src/sketchlab/reactFlow/elementToolbars/LineEdgeToolbar.tsx
+++ b/apps/src/sketchlab/reactFlow/elementToolbars/LineEdgeToolbar.tsx
@@ -114,9 +114,8 @@ const ARROW_HEAD_ICONS: Record<ArrowHeadValue, string> = {
 
 const EDGE_TYPE_ICONS: Record<EdgeTypeValue, string> = {
   straight: 'minus',
-  default: 'bezier-curve',
-  simplebezier: 'chart-line',
-  smoothstep: 'turn-down-right',
+  default: 'wave-sine',
+  smoothstep: 'corner',
   step: 'wave-square',
 };
 

--- a/apps/src/sketchlab/reactFlow/elementToolbars/LineEdgeToolbar.tsx
+++ b/apps/src/sketchlab/reactFlow/elementToolbars/LineEdgeToolbar.tsx
@@ -14,9 +14,12 @@ import ActionsGroup from './ActionsGroup';
 import LockedNotice from './LockedNotice';
 import SwatchGroup from './SwatchGroup';
 import {
+  DEFAULT_EDGE_TYPE,
   DEFAULT_LINE_STROKE_STYLE,
   DEFAULT_LINE_WIDTH,
   DEFAULT_STROKE_COLOR,
+  EdgeTypeValue,
+  EDGE_TYPE_OPTIONS,
   LineStrokeStyleValue,
   LINE_STROKE_STYLE_OPTIONS,
   LINE_WIDTH_OPTIONS,
@@ -90,6 +93,7 @@ interface LineEdgeToolbarProps {
   onSelectColor: (value: string) => void;
   onSelectWidth: (value: number) => void;
   onSelectStrokeStyle: (value: LineStrokeStyleValue) => void;
+  onSelectEdgeType: (value: EdgeTypeValue) => void;
   onSelectArrowHeads: (value: ArrowHeadValue) => void;
   onSetLocked: (value: boolean) => void;
 }
@@ -108,12 +112,21 @@ const ARROW_HEAD_ICONS: Record<ArrowHeadValue, string> = {
   both: 'arrows-left-right',
 };
 
+const EDGE_TYPE_ICONS: Record<EdgeTypeValue, string> = {
+  straight: 'minus',
+  default: 'bezier-curve',
+  simplebezier: 'chart-line',
+  smoothstep: 'turn-down-right',
+  step: 'wave-square',
+};
+
 export default function LineEdgeToolbar({
   edge,
   anchorNodeId,
   onSelectColor,
   onSelectWidth,
   onSelectStrokeStyle,
+  onSelectEdgeType,
   onSelectArrowHeads,
   onSetLocked,
 }: LineEdgeToolbarProps) {
@@ -138,6 +151,11 @@ export default function LineEdgeToolbar({
   )
     ? selectedStrokeStyle
     : DEFAULT_LINE_STROKE_STYLE;
+  const selectedEdgeTypeValue = EDGE_TYPE_OPTIONS.some(
+    option => option.value === edge.type
+  )
+    ? (edge.type as EdgeTypeValue)
+    : DEFAULT_EDGE_TYPE;
 
   const selectedArrowHeads = useMemo(() => {
     const hasStartArrow = !!edge.markerStart;
@@ -206,6 +224,18 @@ export default function LineEdgeToolbar({
             getButtonContent={option =>
               renderLinePreview(2, option.value as LinePreviewStyle)
             }
+          />
+          <LineOptionGroup
+            groupLabel="Line shape"
+            options={EDGE_TYPE_OPTIONS}
+            selectedValue={selectedEdgeTypeValue}
+            onSelect={value => onSelectEdgeType(value as EdgeTypeValue)}
+            ariaLabelPrefix="Line shape"
+            getButtonContent={option => (
+              <FontAwesomeV6Icon
+                iconName={EDGE_TYPE_ICONS[option.value as EdgeTypeValue]}
+              />
+            )}
           />
           <LineOptionGroup
             groupLabel="Arrow heads"

--- a/apps/src/sketchlab/reactFlow/elementToolbars/toolbarPalettes.ts
+++ b/apps/src/sketchlab/reactFlow/elementToolbars/toolbarPalettes.ts
@@ -63,6 +63,16 @@ export const LINE_STROKE_STYLE_OPTIONS = [
 export type LineStrokeStyleValue =
   (typeof LINE_STROKE_STYLE_OPTIONS)[number]['value'];
 
+export const EDGE_TYPE_OPTIONS = [
+  {value: 'straight', label: 'Straight'},
+  {value: 'default', label: 'Curved'},
+  {value: 'simplebezier', label: 'Bezier'},
+  {value: 'smoothstep', label: 'Rounded step'},
+  {value: 'step', label: 'Step'},
+] as const;
+
+export type EdgeTypeValue = (typeof EDGE_TYPE_OPTIONS)[number]['value'];
+
 export const TEXT_ALIGN_OPTIONS = [
   {value: 'left', label: 'Align left', icon: 'align-left'},
   {value: 'center', label: 'Align center', icon: 'align-center'},
@@ -78,6 +88,7 @@ export const DEFAULT_FONT_SIZE: FontSizeValue = 'medium';
 export const DEFAULT_TEXT_ALIGN: TextAlignValue = 'center';
 export const DEFAULT_LINE_WIDTH: LineWidthValue = 1;
 export const DEFAULT_LINE_STROKE_STYLE: LineStrokeStyleValue = 'solid';
+export const DEFAULT_EDGE_TYPE: EdgeTypeValue = 'straight';
 
 export function fontSizePx(value: FontSize | undefined): number | undefined {
   if (typeof value === 'number') {

--- a/apps/src/sketchlab/reactFlow/elementToolbars/toolbarPalettes.ts
+++ b/apps/src/sketchlab/reactFlow/elementToolbars/toolbarPalettes.ts
@@ -66,7 +66,6 @@ export type LineStrokeStyleValue =
 export const EDGE_TYPE_OPTIONS = [
   {value: 'straight', label: 'Straight'},
   {value: 'default', label: 'Curved'},
-  {value: 'simplebezier', label: 'Bezier'},
   {value: 'smoothstep', label: 'Rounded step'},
   {value: 'step', label: 'Step'},
 ] as const;

--- a/apps/src/sketchlab/reactFlow/hooks/useLineToolbar.ts
+++ b/apps/src/sketchlab/reactFlow/hooks/useLineToolbar.ts
@@ -8,6 +8,7 @@ import {ToolbarTarget} from '../context';
 import {
   DEFAULT_LINE_WIDTH,
   DEFAULT_STROKE_COLOR,
+  EdgeTypeValue,
   LineStrokeStyleValue,
   strokeDasharrayFromStyle,
 } from '../elementToolbars/toolbarPalettes';
@@ -180,6 +181,13 @@ export function useLineToolbar({
     [updateLineEdgeStyle]
   );
 
+  const setLineEdgeType = useCallback(
+    (edgeId: string, edgeType: EdgeTypeValue) => {
+      updateLineEdge(edgeId, edge => ({...edge, type: edgeType}));
+    },
+    [updateLineEdge]
+  );
+
   const setLineEdgeArrowHeads = useCallback(
     (edgeId: string, arrowHeads: ArrowHeadValue) => {
       updateLineEdge(edgeId, edge => {
@@ -226,6 +234,7 @@ export function useLineToolbar({
     setLineEdgeColor,
     setLineEdgeWidth,
     setLineEdgeStrokeStyle,
+    setLineEdgeType,
     setLineEdgeArrowHeads,
     setLineEdgeLocked,
   };

--- a/apps/src/sketchlab/reactFlow/utils/lineEdges.ts
+++ b/apps/src/sketchlab/reactFlow/utils/lineEdges.ts
@@ -2,6 +2,7 @@ import {MarkerType} from '@xyflow/react';
 
 import {ARROW_MARKER_HEIGHT_PX, ARROW_MARKER_WIDTH_PX} from '../constants';
 import {
+  DEFAULT_EDGE_TYPE,
   DEFAULT_LINE_WIDTH,
   DEFAULT_STROKE_COLOR,
 } from '../elementToolbars/toolbarPalettes';
@@ -10,7 +11,7 @@ import {
 // Defaults to a solid line with an arrow at the end.
 export function defaultLineEdgeFields() {
   return {
-    type: 'straight',
+    type: DEFAULT_EDGE_TYPE,
     style: {
       stroke: DEFAULT_STROKE_COLOR,
       strokeWidth: DEFAULT_LINE_WIDTH,


### PR DESCRIPTION
This adds the option for users to set the 'line shape' on a line in sketch 2. The 4 shapes are straight, curved, rounded step, and step. React flow has 2 curved options which to my eye look exactly the same, 'default' and 'simplebezier', so for simplicity I stuck with 'default' as the 'curved' option.

I'm not 100% confident in the 'line shape' name here, so if folks have another idea lmk! I though about 'line style' but that overlaps with 'stroke style'. Also a note for testing: if your line is perfectly straight, the style doesn't do anything, since there's no step or curve to make.

## Screen shot
<img width="322" height="535" alt="Screenshot 2026-05-07 at 9 57 53 AM" src="https://github.com/user-attachments/assets/150a7171-b187-4377-88e6-b47068f5e14e" />

## Screen recording

https://github.com/user-attachments/assets/2f915ae0-4f07-44d3-958a-d1a906f55f30



## Links

- Jira: [AFL-634](https://codedotorg.atlassian.net/browse/AFL-634)

## Testing story
Tested locally.

