### PR TITLE
condense "Copy Failing Rerun Commands" payload into one command per browser

### DIFF
--- a/dashboard/test/ui/test_status.haml
+++ b/dashboard/test/ui/test_status.haml
@@ -40,6 +40,11 @@
           %div.failure.bar
           %div.pending.bar
           %div.clear-both
+      - rerun_flags = ['--html']
+      - rerun_flags << '--eyes' if type == 'Eyes'
+      - rerun_flags << '--device-farm' if device_farm
+      - rerun_flags << '--db' if force_db_access
+      - rerun_command_prefix = "bundle exec ./runner.rb #{rerun_flags.join(' ')}"
       - browser_features.map {|browser, _| browser['name'] || 'UnknownBrowser'}.uniq.sort.map do |browser|
         %h3= browser
         %div{id: "#{browser}-progress"}
@@ -59,11 +64,7 @@
                 %td.status
                 %td.log-link
                 %td.rerun-command
-                  - rerun_flags = ['--html']
-                  - rerun_flags << '--eyes' if type == 'Eyes'
-                  - rerun_flags << '--device-farm' if device_farm
-                  - rerun_flags << '--db' if force_db_access
-                  - rerun_command = "bundle exec ./runner.rb #{rerun_flags.join(' ')} -c #{browser} -f #{feature} &"
+                  - rerun_command = "#{rerun_command_prefix} -c #{browser} -f #{feature} &"
                   %button.copy-button{'data-clipboard-text': rerun_command}= "Copy Rerun Cmd"
       %div#help-text
         %p
@@ -85,4 +86,5 @@
     %input#api-origin{type: 'hidden', value: api_origin}
     %input#s3-bucket{type: 'hidden', value: s3_bucket}
     %input#s3-prefix{type: 'hidden', value: s3_prefix}
+    %input#rerun-command-prefix{type: 'hidden', value: rerun_command_prefix}
     %script{src: 'test_status.js'}

--- a/dashboard/test/ui/test_status.js
+++ b/dashboard/test/ui/test_status.js
@@ -180,10 +180,14 @@ new Clipboard("#copy-failing-rerun-button", {
       const { browser, feature } = row.dataset;
       (featuresByBrowser[browser] ||= []).push(feature);
     });
+    // --parallel 20 so a multi-feature rerun actually runs in parallel.
+    // runner.rb caps the worker count at the number of features, so the
+    // upper bound only kicks in past 20. We stop at 20 to avoid
+    // overwhelming Saucelabs / Device Farm.
     return Object.entries(featuresByBrowser)
       .map(
         ([browser, features]) =>
-          `${RERUN_COMMAND_PREFIX} -c ${browser} -f ${features.join(",")} &`
+          `${RERUN_COMMAND_PREFIX} --parallel 20 -c ${browser} -f ${features.join(",")} &`
       )
       .join(" \\\n");
   },

--- a/dashboard/test/ui/test_status.js
+++ b/dashboard/test/ui/test_status.js
@@ -20,6 +20,7 @@ const TEST_TYPE = document.querySelector("#test-type").value;
 const API_ORIGIN = document.querySelector("#api-origin").value;
 const S3_BUCKET = document.querySelector("#s3-bucket").value;
 const S3_PREFIX = document.querySelector("#s3-prefix").value;
+const RERUN_COMMAND_PREFIX = document.querySelector("#rerun-command-prefix").value;
 
 // Simple constants
 const STATUS_PENDING = "PENDING";
@@ -165,16 +166,27 @@ Test.prototype.publicLogUrl = function () {
 
 // Connect up "Copy Rerun Command" buttons
 new Clipboard("button.copy-button");
-// Each per-row rerun command already ends with `&` to background the run.
-// Join with ` \<newline>` so when the user pastes the block into a shell, the
-// shell treats it as one line-continued input — giving the user a chance to
-// review and hit Enter rather than executing each command on paste.
+// Build one rerun command per failing browser, folding all of that browser's
+// failing features into a single comma-joined `-f` list. runner.rb's `-c` and
+// `-f` form a Cartesian product, so we *must* keep one command per browser
+// rather than one big multi-browser command. Multiple browsers' commands are
+// joined with ` \<newline>` so the whole block pastes into the shell as one
+// line-continued input (review, then press Enter) instead of firing each
+// backgrounded command immediately on paste.
 new Clipboard("#copy-failing-rerun-button", {
-  text: () =>
-    Array.from(
-      document.querySelectorAll("tr.FAILED td.rerun-command button.copy-button"),
-      (btn) => btn.getAttribute("data-clipboard-text")
-    ).join(" \\\n"),
+  text: () => {
+    const featuresByBrowser = {};
+    document.querySelectorAll("tr.FAILED").forEach((row) => {
+      const { browser, feature } = row.dataset;
+      (featuresByBrowser[browser] ||= []).push(feature);
+    });
+    return Object.entries(featuresByBrowser)
+      .map(
+        ([browser, features]) =>
+          `${RERUN_COMMAND_PREFIX} -c ${browser} -f ${features.join(",")} &`
+      )
+      .join(" \\\n");
+  },
 });
 
 function keyify(str) {


### PR DESCRIPTION
Follow-on to https://github.com/code-dot-org/code-dot-org/pull/72567 .

Previously the new Copy Failing Rerun Commands button emitted one bundle exec ./runner.rb invocation per failing row. This can be annoying because it produces quite a lot of status page messages in the slack channel, and it's hard to spot when all rerun commands have completed:

https://github.com/user-attachments/assets/ea268ad8-8ce5-4dc2-b785-14a866d9290e

This PR folds all of a browser's failing features into a single comma-joined -f list so triagers paste one runner.rb command (per browser) instead of N. On the common single-browser status pages this collapses to exactly one command. Multi-browser pages get one command per browser, joined with the existing " \<newline>" so the block still pastes as one line-continued shell input.

We must keep one command per browser rather than fold across browsers too: runner.rb takes the Cartesian product of -c and -f, so a single multi-browser command would re-run combinations that weren't failing.

Hoists the rerun-command prefix out of the per-row loop in the haml and exposes it on the page as a hidden input, mirroring the existing test-type / api-origin / s3-bucket / s3-prefix pattern.

## Testing story
manually tested a bunch of combinations of the following variables:
- one browser vs two browsers
- different passing/failing features for each browser
- executing all reruns causes the status page to turn green, and the Copy button becomes disabled
- `--eyes`, `--db`, and `--device-farm` flags are all passed through to individual and multi rerun button commands
- no change to per-row Copy Rerun Cmd button output

## Screenshots

## single browser

<img width="1597" height="425" alt="Screenshot 2026-05-07 at 2 03 30 PM" src="https://github.com/user-attachments/assets/d2bd9165-90d1-432c-9699-3222c7583003" />

## multiple browsers

<img width="1724" height="580" alt="Screenshot 2026-05-07 at 1 58 18 PM" src="https://github.com/user-attachments/assets/9712276b-344b-4ea5-a8a8-18ddc3585454" />
