### PR TITLE
Sketch Lab 2: Add ability to zoom out more

### DIFF
--- a/apps/src/sketchlab/reactFlow/components/ReactFlowCanvas.tsx
+++ b/apps/src/sketchlab/reactFlow/components/ReactFlowCanvas.tsx
@@ -25,6 +25,7 @@ import {
   DEFAULT_NODE_WIDTH,
   LINE_DEFAULT_LENGTH_PX,
   LINE_RECONNECT_SNAP_RADIUS_PX,
+  MIN_ZOOM,
   SAVE_DEBOUNCE_MS,
 } from '../constants';
 import {
@@ -613,6 +614,7 @@ export default function ReactFlowCanvas({
               onReconnectEnd={handleReconnectEnd}
               onNodeDragStop={handleNodeDragStop}
               isValidConnection={isValidConnection}
+              minZoom={MIN_ZOOM}
               connectionRadius={LINE_RECONNECT_SNAP_RADIUS_PX}
               nodeTypes={NODE_TYPES}
               onMoveEnd={handleMoveEnd}

--- a/apps/src/sketchlab/reactFlow/constants.ts
+++ b/apps/src/sketchlab/reactFlow/constants.ts
@@ -30,3 +30,5 @@ export const ASSET_PATH_PREFIX = '/v3/assets';
 
 export const ARROW_MARKER_WIDTH_PX = 14;
 export const ARROW_MARKER_HEIGHT_PX = 14;
+
+export const MIN_ZOOM = 0.1;


### PR DESCRIPTION
<!--
  Summary of the change: background, motivation, and context.
  Include screenshots, videos, or before/after comparisons for UI changes.
-->
This PR updates the React Flow version of Sketch Lab so that `minZoom` is updated to `0.1` from `0.5` (the default).  This allows a user to zoom out more which is helpful since some of the Sketch Lab levels contain a lot of content and without zoom, a user has to pan the canvas to be able to see all the elements.


## Links
<!-- Jira tickets, design docs, Slack threads, related PRs, etc. -->

- Jira: https://codedotorg.atlassian.net/browse/AFL-640

## Testing story
<!-- How was this tested? Manual steps, adhoc links, automated tests, or why testing isn't needed. -->

Screencast video:
Before on levelbuilder (current state) and after update locally:

https://github.com/user-attachments/assets/c9858b93-f150-4108-9e3e-1623c3be093e




## Deployment notes
<!-- Delete this section if it's a standard merge-and-deploy.
     Otherwise: migrations, feature flags, coordination, caching impacts, etc. -->



## Privacy and security
<!-- Delete this section if there is no privacy/security impact.
     Otherwise: new PII, auth changes, API surface changes, etc. -->

