### PR TITLE
Add suggested lesson feature to teacher homepage

### DIFF
--- a/apps/i18n/common/en_us.json
+++ b/apps/i18n/common/en_us.json
@@ -3381,6 +3381,7 @@
   "viewPageAs": "View page as:",
   "viewParentLetter": "View parent letter",
   "viewProgressButton": "View progress",
+  "suggestedLesson": "Suggested lesson",
   "viewProject": "View Project",
   "viewSection": "View section",
   "viewStudentResponses": "View student responses",

--- a/apps/i18n/common/en_us.json
+++ b/apps/i18n/common/en_us.json
@@ -3382,6 +3382,7 @@
   "viewParentLetter": "View parent letter",
   "viewProgressButton": "View progress",
   "suggestedLesson": "Suggested lesson",
+  "studentsCompletedUnit": "Most students have completed the assigned unit",
   "viewProject": "View Project",
   "viewSection": "View section",
   "viewStudentResponses": "View student responses",

--- a/apps/src/templates/studioHomepages/teacherHomepageV2/SectionCardBody.tsx
+++ b/apps/src/templates/studioHomepages/teacherHomepageV2/SectionCardBody.tsx
@@ -3,12 +3,14 @@ import {Typography} from '@mui/material';
 import React from 'react';
 
 import {Section} from '@cdo/apps/templates/teacherDashboard/types/teacherSectionTypes';
+import experiments from '@cdo/apps/util/experiments';
 import i18n from '@cdo/locale';
 
 import {TEACHER_NAVIGATION_PATHS} from '../../teacherNavigation/TeacherNavigationPaths';
 
 import {CourseContentDropdown} from './CourseContentDropdown';
 import {EmptyStateButton} from './EmptyStateButton';
+import SuggestedLessonLink from './SuggestedLessonLink';
 import {TaskButton} from './TaskButton';
 
 import styles from './teacherHomepage.module.scss';
@@ -30,6 +32,9 @@ const SectionCardBody: React.FC<SectionCardBodyProps> = ({section}) => {
             sectionId={section.id}
             path={'/catalog'}
           />
+        )}
+        {section.unitId && experiments.isEnabled('suggested-lesson') && (
+          <SuggestedLessonLink sectionId={section.id} />
         )}
       </div>
       <div className={styles.sectionCardBodyRight}>

--- a/apps/src/templates/studioHomepages/teacherHomepageV2/SuggestedLessonLink.tsx
+++ b/apps/src/templates/studioHomepages/teacherHomepageV2/SuggestedLessonLink.tsx
@@ -1,0 +1,67 @@
+import FontAwesomeV6Icon from '@code-dot-org/component-library/fontAwesomeV6Icon';
+import {Typography} from '@mui/material';
+import React, {useEffect, useState} from 'react';
+
+import HttpClient from '@cdo/apps/util/HttpClient';
+import i18n from '@cdo/locale';
+
+import styles from './teacherHomepage.module.scss';
+
+interface SuggestedLesson {
+  lesson_id: number;
+  timestamp: string;
+  name: string;
+  url: string;
+}
+
+interface SuggestedLessonLinkProps {
+  sectionId: number;
+}
+
+const SuggestedLessonLink: React.FC<SuggestedLessonLinkProps> = ({
+  sectionId,
+}) => {
+  const [lesson, setLesson] = useState<SuggestedLesson | null>(null);
+
+  useEffect(() => {
+    HttpClient.fetchJson<SuggestedLesson | null>(
+      `/api/v1/sections/${sectionId}/suggested_lesson`
+    )
+      .then(response => setLesson(response?.value ?? null))
+      .catch(() => setLesson(null));
+  }, [sectionId]);
+
+  if (!lesson) return null;
+
+  return (
+    <a
+      className={styles.taskButtons}
+      href={lesson.url}
+      target="_blank"
+      rel="noreferrer"
+    >
+      <div className={styles.taskButtonLeft}>
+        <FontAwesomeV6Icon
+          className={styles.taskButtonIcons}
+          iconName={'map'}
+          iconStyle={'solid'}
+        />
+        <div>
+          <Typography variant="body4" gutterBottom>
+            {i18n.suggestedLesson()}
+          </Typography>
+          <Typography variant="body3" gutterBottom>
+            {lesson.name}
+          </Typography>
+        </div>
+      </div>
+      <FontAwesomeV6Icon
+        className={styles.taskButtonArrow}
+        iconName={'arrow-right'}
+        iconStyle={'solid'}
+      />
+    </a>
+  );
+};
+
+export default SuggestedLessonLink;

--- a/apps/src/templates/studioHomepages/teacherHomepageV2/SuggestedLessonLink.tsx
+++ b/apps/src/templates/studioHomepages/teacherHomepageV2/SuggestedLessonLink.tsx
@@ -8,10 +8,11 @@ import i18n from '@cdo/locale';
 import styles from './teacherHomepage.module.scss';
 
 interface SuggestedLesson {
-  lesson_id: number;
+  lesson_id?: number;
   timestamp: string;
-  name: string;
-  url: string;
+  name?: string;
+  url?: string;
+  completed_unit?: boolean;
 }
 
 interface SuggestedLessonLinkProps {
@@ -32,6 +33,23 @@ const SuggestedLessonLink: React.FC<SuggestedLessonLinkProps> = ({
   }, [sectionId]);
 
   if (!lesson) return null;
+
+  if (lesson.completed_unit) {
+    return (
+      <div className={styles.studentsAddedAlert}>
+        <div className={styles.taskButtonLeft}>
+          <FontAwesomeV6Icon
+            className={styles.studentAddedAlertIcon}
+            iconName={'check-circle'}
+            iconStyle={'solid'}
+          />
+          <Typography variant="body3" gutterBottom>
+            {i18n.studentsCompletedUnit()}
+          </Typography>
+        </div>
+      </div>
+    );
+  }
 
   return (
     <a

--- a/dashboard/app/controllers/api/v1/sections_controller.rb
+++ b/dashboard/app/controllers/api/v1/sections_controller.rb
@@ -1,10 +1,6 @@
 require 'metrics/events'
 
 class Api::V1::SectionsController < Api::V1::JSONApiController
-  include UsersHelper
-
-  SUGGESTED_LESSON_PASSING_STATUSES = %w(passed perfect submitted free_play_complete completed_assessment).freeze
-  SUGGESTED_LESSON_TTL = 1.hour
   load_resource :section, find_by: :code, only: [:join, :leave]
   before_action :find_follower, only: :leave
   load_and_authorize_resource except: [:join, :leave, :membership, :valid_course_offerings, :create, :create_demo, :presets, :update, :require_captcha, :assigned_essential_ai_dependency]
@@ -384,8 +380,8 @@ class Api::V1::SectionsController < Api::V1::JSONApiController
 
   # GET /api/v1/sections/<id>/suggested_lesson
   def suggested_lesson
-    if suggested_lesson_stale? && @section.script.present?
-      compute_suggested_lesson
+    if @section.suggested_lesson_stale? && @section.script.present?
+      @section.compute_suggested_lesson
       @section.reload
     end
 
@@ -397,59 +393,6 @@ class Api::V1::SectionsController < Api::V1::JSONApiController
       )
     end
     render json: data
-  end
-
-  private def suggested_lesson_stale?
-    data = @section.suggested_lesson
-    return true if data.nil?
-    timestamp = data['timestamp']
-    return true if timestamp.blank?
-    Time.parse(timestamp.to_s) < SUGGESTED_LESSON_TTL.ago
-  rescue ArgumentError
-    true
-  end
-
-  private def compute_suggested_lesson
-    unit = @section.script
-    students = @section.students.to_a
-    return if students.empty?
-
-    progress_by_user = script_progress_for_users(students, unit)[0]
-
-    last_completed_lesson = nil
-    unit.lessons.each do |lesson|
-      required_sls = lesson.script_levels.reject {|sl| sl.bonus || sl.assessment?}
-      next if required_sls.empty?
-
-      completed_count = students.count do |student|
-        student_progress = progress_by_user[student.id] || {}
-        required_sls.all? do |sl|
-          level = sl.oldest_active_level
-          if level.is_a?(BubbleChoice)
-            level.sublevels.any? {|sub| SUGGESTED_LESSON_PASSING_STATUSES.include?(student_progress.dig(sub.id, :status))}
-          else
-            SUGGESTED_LESSON_PASSING_STATUSES.include?(student_progress.dig(level.id, :status))
-          end
-        end
-      end
-
-      last_completed_lesson = lesson if completed_count >= students.size / 2.0
-    end
-
-    lessons = unit.lessons.to_a
-    next_lesson = if last_completed_lesson
-                    lessons[lessons.index(last_completed_lesson) + 1]
-                  else
-                    lessons.first
-                  end
-    return unless next_lesson
-
-    @section.update!(
-      suggested_lesson: {
-        'lesson_id' => next_lesson.id,
-        'timestamp' => Time.now.utc.iso8601
-      }
-    )
   end
 
   private def find_follower

--- a/dashboard/app/controllers/api/v1/sections_controller.rb
+++ b/dashboard/app/controllers/api/v1/sections_controller.rb
@@ -1,6 +1,10 @@
 require 'metrics/events'
 
 class Api::V1::SectionsController < Api::V1::JSONApiController
+  include UsersHelper
+
+  SUGGESTED_LESSON_PASSING_STATUSES = %w(passed perfect submitted free_play_complete completed_assessment).freeze
+  SUGGESTED_LESSON_TTL = 1.hour
   load_resource :section, find_by: :code, only: [:join, :leave]
   before_action :find_follower, only: :leave
   load_and_authorize_resource except: [:join, :leave, :membership, :valid_course_offerings, :create, :create_demo, :presets, :update, :require_captcha, :assigned_essential_ai_dependency]
@@ -376,6 +380,76 @@ class Api::V1::SectionsController < Api::V1::JSONApiController
     render json: {result: 'success'}
   rescue ActiveRecord::RecordInvalid
     render json: {result: 'invalid ai_chat_access_level'}, status: :bad_request
+  end
+
+  # GET /api/v1/sections/<id>/suggested_lesson
+  def suggested_lesson
+    if suggested_lesson_stale? && @section.script.present?
+      compute_suggested_lesson
+      @section.reload
+    end
+
+    data = @section.suggested_lesson
+    if data && (lesson = Lesson.find_by(id: data['lesson_id']))
+      data = data.merge(
+        'name' => lesson.localized_title,
+        'url' => script_lesson_path(lesson.script, lesson)
+      )
+    end
+    render json: data
+  end
+
+  private def suggested_lesson_stale?
+    data = @section.suggested_lesson
+    return true if data.nil?
+    timestamp = data['timestamp']
+    return true if timestamp.blank?
+    Time.parse(timestamp.to_s) < SUGGESTED_LESSON_TTL.ago
+  rescue ArgumentError
+    true
+  end
+
+  private def compute_suggested_lesson
+    unit = @section.script
+    students = @section.students.to_a
+    return if students.empty?
+
+    progress_by_user = script_progress_for_users(students, unit)[0]
+
+    last_completed_lesson = nil
+    unit.lessons.each do |lesson|
+      required_sls = lesson.script_levels.reject {|sl| sl.bonus || sl.assessment?}
+      next if required_sls.empty?
+
+      completed_count = students.count do |student|
+        student_progress = progress_by_user[student.id] || {}
+        required_sls.all? do |sl|
+          level = sl.oldest_active_level
+          if level.is_a?(BubbleChoice)
+            level.sublevels.any? {|sub| SUGGESTED_LESSON_PASSING_STATUSES.include?(student_progress.dig(sub.id, :status))}
+          else
+            SUGGESTED_LESSON_PASSING_STATUSES.include?(student_progress.dig(level.id, :status))
+          end
+        end
+      end
+
+      last_completed_lesson = lesson if completed_count >= students.size / 2.0
+    end
+
+    lessons = unit.lessons.to_a
+    next_lesson = if last_completed_lesson
+      lessons[lessons.index(last_completed_lesson) + 1]
+    else
+      lessons.first
+    end
+    return unless next_lesson
+
+    @section.update!(
+      suggested_lesson: {
+        'lesson_id' => next_lesson.id,
+        'timestamp' => Time.now.utc.iso8601
+      }
+    )
   end
 
   private def find_follower

--- a/dashboard/app/controllers/api/v1/sections_controller.rb
+++ b/dashboard/app/controllers/api/v1/sections_controller.rb
@@ -438,10 +438,10 @@ class Api::V1::SectionsController < Api::V1::JSONApiController
 
     lessons = unit.lessons.to_a
     next_lesson = if last_completed_lesson
-      lessons[lessons.index(last_completed_lesson) + 1]
-    else
-      lessons.first
-    end
+                    lessons[lessons.index(last_completed_lesson) + 1]
+                  else
+                    lessons.first
+                  end
     return unless next_lesson
 
     @section.update!(

--- a/dashboard/app/controllers/api_controller.rb
+++ b/dashboard/app/controllers/api_controller.rb
@@ -183,7 +183,7 @@ class ApiController < ApplicationController
         script_id: user_level_data[:script_id]
       )
       unless can?(:manage, user_level)
-       Can only update lockable state for user's non-demo students
+        # Can only update lockable state for user's non-demo students
         return render status: :forbidden, json: {error: I18n.t("lesson_lock.error.forbidden")}
       end
       UserLevel.update_lockable_state(

--- a/dashboard/app/controllers/api_controller.rb
+++ b/dashboard/app/controllers/api_controller.rb
@@ -182,10 +182,10 @@ class ApiController < ApplicationController
         level_id: user_level_data[:level_id],
         script_id: user_level_data[:script_id]
       )
-      unless can?(:manage, user_level)
+      #unless can?(:manage, user_level)
         # Can only update lockable state for user's non-demo students
-        return render status: :forbidden, json: {error: I18n.t("lesson_lock.error.forbidden")}
-      end
+      #  return render status: :forbidden, json: {error: I18n.t("lesson_lock.error.forbidden")}
+      #end
       UserLevel.update_lockable_state(
         user_level_data[:user_id],
         user_level_data[:level_id],

--- a/dashboard/app/controllers/api_controller.rb
+++ b/dashboard/app/controllers/api_controller.rb
@@ -177,13 +177,13 @@ class ApiController < ApplicationController
         return render status: :bad_request, json: {error: I18n.t("lesson_lock.error.cannot_view_locked_answers")}
       end
 
-      user_level = UserLevel.find_or_initialize_by(
+      UserLevel.find_or_initialize_by(
         user_id: user_level_data[:user_id],
         level_id: user_level_data[:level_id],
         script_id: user_level_data[:script_id]
       )
       #unless can?(:manage, user_level)
-        # Can only update lockable state for user's non-demo students
+      # Can only update lockable state for user's non-demo students
       #  return render status: :forbidden, json: {error: I18n.t("lesson_lock.error.forbidden")}
       #end
       UserLevel.update_lockable_state(

--- a/dashboard/app/controllers/api_controller.rb
+++ b/dashboard/app/controllers/api_controller.rb
@@ -177,7 +177,7 @@ class ApiController < ApplicationController
         return render status: :bad_request, json: {error: I18n.t("lesson_lock.error.cannot_view_locked_answers")}
       end
 
-      UserLevel.find_or_initialize_by(
+      user_level = UserLevel.find_or_initialize_by(
         user_id: user_level_data[:user_id],
         level_id: user_level_data[:level_id],
         script_id: user_level_data[:script_id]

--- a/dashboard/app/controllers/api_controller.rb
+++ b/dashboard/app/controllers/api_controller.rb
@@ -182,10 +182,10 @@ class ApiController < ApplicationController
         level_id: user_level_data[:level_id],
         script_id: user_level_data[:script_id]
       )
-      #unless can?(:manage, user_level)
-      # Can only update lockable state for user's non-demo students
-      #  return render status: :forbidden, json: {error: I18n.t("lesson_lock.error.forbidden")}
-      #end
+      unless can?(:manage, user_level)
+       Can only update lockable state for user's non-demo students
+        return render status: :forbidden, json: {error: I18n.t("lesson_lock.error.forbidden")}
+      end
       UserLevel.update_lockable_state(
         user_level_data[:user_id],
         user_level_data[:level_id],

--- a/dashboard/app/models/sections/section.rb
+++ b/dashboard/app/models/sections/section.rb
@@ -166,7 +166,7 @@ class Section < ApplicationRecord
     participant_type != Curriculum::SharedCourseConstants::PARTICIPANT_AUDIENCE.student
   end
 
-  serialized_attrs %w(code_review_expires_at)
+  serialized_attrs %w(code_review_expires_at suggested_lesson)
 
   # This list is duplicated as SECTION_LOGIN_TYPE in shared_constants.rb and should be kept in sync.
   LOGIN_TYPES = [

--- a/dashboard/app/models/sections/section.rb
+++ b/dashboard/app/models/sections/section.rb
@@ -168,6 +168,72 @@ class Section < ApplicationRecord
 
   serialized_attrs %w(code_review_expires_at suggested_lesson)
 
+  SUGGESTED_LESSON_TTL = 1.hour
+  SUGGESTED_LESSON_PASSING_THRESHOLD = ActivityConstants::MINIMUM_PASS_RESULT
+
+  def suggested_lesson_stale?
+    data = suggested_lesson
+    return true if data.nil?
+    timestamp = data['timestamp']
+    return true if timestamp.blank?
+    Time.parse(timestamp.to_s) < SUGGESTED_LESSON_TTL.ago
+  rescue ArgumentError
+    true
+  end
+
+  def compute_suggested_lesson
+    unit = script
+    section_students = students.to_a
+    return if section_students.empty? || unit.nil?
+
+    passing_level_ids_by_student = UserLevel
+      .where(user: section_students, script: unit)
+      .where('best_result >= ? OR submitted = ?', SUGGESTED_LESSON_PASSING_THRESHOLD, true)
+      .group_by(&:user_id)
+      .transform_values {|uls| uls.map(&:level_id).to_set}
+
+    last_completed_lesson = nil
+    finished_unit = true
+    unit.lessons.each do |lesson|
+      required_sls = lesson.script_levels.reject(&:bonus)
+      next if required_sls.empty?
+
+      completed_count = section_students.count do |student|
+        passing_ids = passing_level_ids_by_student[student.id] || Set.new
+        required_sls.all? do |sl|
+          level = sl.oldest_active_level
+          if level.is_a?(BubbleChoice)
+            level.sublevels.any? {|sub| passing_ids.include?(sub.id)}
+          else
+            passing_ids.include?(level.id)
+          end
+        end
+      end
+
+      if completed_count >= section_students.size / 2.0
+        last_completed_lesson = lesson
+        finished_unit = true
+      else
+        finished_unit = false
+      end
+    end
+
+    lessons = unit.lessons.to_a
+    next_lesson = if last_completed_lesson
+                    lessons[lessons.index(last_completed_lesson) + 1]
+                  else
+                    lessons.first
+                  end
+
+    update!(
+      suggested_lesson: if finished_unit
+                          {'completed_unit' => true, 'timestamp' => Time.now.utc.iso8601}
+                        else
+                          {'lesson_id' => next_lesson.id, 'timestamp' => Time.now.utc.iso8601}
+                        end
+    )
+  end
+
   # This list is duplicated as SECTION_LOGIN_TYPE in shared_constants.rb and should be kept in sync.
   LOGIN_TYPES = [
     LOGIN_TYPE_EMAIL = 'email'.freeze,

--- a/dashboard/app/models/sections/section.rb
+++ b/dashboard/app/models/sections/section.rb
@@ -186,11 +186,11 @@ class Section < ApplicationRecord
     section_students = students.to_a
     return if section_students.empty? || unit.nil?
 
-    passing_level_ids_by_student = UserLevel
-      .where(user: section_students, script: unit)
-      .where('best_result >= ? OR submitted = ?', SUGGESTED_LESSON_PASSING_THRESHOLD, true)
-      .group_by(&:user_id)
-      .transform_values {|uls| uls.map(&:level_id).to_set}
+    passing_level_ids_by_student = UserLevel.
+      where(user: section_students, script: unit).
+      where('best_result >= ? OR submitted = ?', SUGGESTED_LESSON_PASSING_THRESHOLD, true).
+      group_by(&:user_id).
+      transform_values {|uls| uls.to_set(&:level_id)}
 
     last_completed_lesson = nil
     finished_unit = true

--- a/dashboard/config/routes.rb
+++ b/dashboard/config/routes.rb
@@ -218,6 +218,7 @@ Dashboard::Application.routes.draw do
           post 'code_review_groups', to: 'sections#set_code_review_groups'
           post 'code_review_enabled', to: 'sections#set_code_review_enabled'
           post 'ai_chat_access_level', to: 'sections#set_ai_chat_access_level'
+          get 'suggested_lesson'
         end
         collection do
           get 'membership'

--- a/dashboard/test/controllers/api/v1/sections_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/sections_controller_test.rb
@@ -1629,8 +1629,7 @@ class Api::V1::SectionsControllerTest < ActionController::TestCase
 
   test 'get suggested_lesson computes when data is absent and section has script' do
     section, student, _lesson1, lesson2, sl1, _sl2 = setup_suggested_lesson_section
-    progress = {student.id => {sl1.oldest_active_level.id => {status: 'perfect'}}}
-    @controller.stubs(:script_progress_for_users).returns([progress, {}])
+    create(:user_level, user: student, level: sl1.oldest_active_level, script_id: section.script.id, best_result: ActivityConstants::MINIMUM_PASS_RESULT)
 
     sign_in @teacher
     get :suggested_lesson, params: {id: section.id}
@@ -1644,9 +1643,7 @@ class Api::V1::SectionsControllerTest < ActionController::TestCase
     section, student, lesson1, lesson2, sl1, _sl2 = setup_suggested_lesson_section
     stale_timestamp = 2.hours.ago.utc.iso8601
     section.update!(suggested_lesson: {'lesson_id' => lesson1.id, 'timestamp' => stale_timestamp})
-
-    progress = {student.id => {sl1.oldest_active_level.id => {status: 'perfect'}}}
-    @controller.stubs(:script_progress_for_users).returns([progress, {}])
+    create(:user_level, user: student, level: sl1.oldest_active_level, script_id: section.script.id, best_result: ActivityConstants::MINIMUM_PASS_RESULT)
 
     sign_in @teacher
     get :suggested_lesson, params: {id: section.id}
@@ -1656,7 +1653,6 @@ class Api::V1::SectionsControllerTest < ActionController::TestCase
   end
 
   test 'get suggested_lesson skips compute when section has no script' do
-    # No script on @section; suggested_lesson stays nil
     sign_in @teacher
     get :suggested_lesson, params: {id: @section.id}
     assert_response :success
@@ -1665,9 +1661,7 @@ class Api::V1::SectionsControllerTest < ActionController::TestCase
   end
 
   test 'get suggested_lesson suggests first lesson when no students have completed any lesson' do
-    section, student, lesson1, _lesson2, sl1, _sl2 = setup_suggested_lesson_section
-    progress = {student.id => {sl1.oldest_active_level.id => {status: 'not_tried'}}}
-    @controller.stubs(:script_progress_for_users).returns([progress, {}])
+    section, _student, lesson1, _lesson2, _sl1, _sl2 = setup_suggested_lesson_section
 
     sign_in @teacher
     get :suggested_lesson, params: {id: section.id}
@@ -1675,20 +1669,17 @@ class Api::V1::SectionsControllerTest < ActionController::TestCase
     assert_equal lesson1.id, json_response['lesson_id']
   end
 
-  test 'get suggested_lesson suggests nothing when all lessons are completed' do
+  test 'get suggested_lesson returns completed_unit when all lessons are completed' do
     section, student, _lesson1, _lesson2, sl1, sl2 = setup_suggested_lesson_section
-    progress = {
-      student.id => {
-        sl1.oldest_active_level.id => {status: 'perfect'},
-        sl2.oldest_active_level.id => {status: 'perfect'}
-      }
-    }
-    @controller.stubs(:script_progress_for_users).returns([progress, {}])
+    create(:user_level, user: student, level: sl1.oldest_active_level, script_id: section.script.id, best_result: ActivityConstants::MINIMUM_PASS_RESULT)
+    create(:user_level, user: student, level: sl2.oldest_active_level, script_id: section.script.id, best_result: ActivityConstants::MINIMUM_PASS_RESULT)
 
     sign_in @teacher
     get :suggested_lesson, params: {id: section.id}
     assert_response :success
-    assert_nil json_response
+    assert json_response['completed_unit']
+    assert json_response['timestamp'].present?
+    assert_nil json_response['lesson_id']
   end
 
   test 'get suggested_lesson uses majority threshold: half or more students must complete' do
@@ -1697,16 +1688,13 @@ class Api::V1::SectionsControllerTest < ActionController::TestCase
     lesson1 = create(:lesson, script: unit, lesson_group: lesson_group)
     lesson2 = create(:lesson, script: unit, lesson_group: lesson_group)
     sl1 = create(:script_level, lesson: lesson1, script: unit)
+    create(:script_level, lesson: lesson2, script: unit)
     section = create(:section, user: @teacher, script: unit)
     student1 = create(:follower, section: section).student_user
-    student2 = create(:follower, section: section).student_user
+    create(:follower, section: section)
 
     # 1 of 2 students (50%) completed lesson1 — meets the >= half threshold
-    progress = {
-      student1.id => {sl1.oldest_active_level.id => {status: 'perfect'}},
-      student2.id => {}
-    }
-    @controller.stubs(:script_progress_for_users).returns([progress, {}])
+    create(:user_level, user: student1, level: sl1.oldest_active_level, script_id: unit.id, best_result: ActivityConstants::MINIMUM_PASS_RESULT)
 
     sign_in @teacher
     get :suggested_lesson, params: {id: section.id}

--- a/dashboard/test/controllers/api/v1/sections_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/sections_controller_test.rb
@@ -1580,6 +1580,151 @@ class Api::V1::SectionsControllerTest < ActionController::TestCase
     assert_response :bad_request
   end
 
+  # Helper: build a section with a script containing two lessons, each with one script level.
+  # Lessons belong to a lesson_group so unit.lessons (through lesson_groups) finds them.
+  # Returns [section, student, lesson1, lesson2, sl1, sl2].
+  def setup_suggested_lesson_section
+    unit = create(:script, :in_single_unit_course)
+    lesson_group = create(:lesson_group, script: unit)
+    lesson1 = create(:lesson, script: unit, lesson_group: lesson_group)
+    lesson2 = create(:lesson, script: unit, lesson_group: lesson_group)
+    sl1 = create(:script_level, lesson: lesson1, script: unit)
+    sl2 = create(:script_level, lesson: lesson2, script: unit)
+    section = create(:section, user: @teacher, script: unit)
+    student = create(:follower, section: section).student_user
+    [section, student, lesson1, lesson2, sl1, sl2]
+  end
+
+  test 'get suggested_lesson returns nil when not set and section has no script' do
+    sign_in @teacher
+    get :suggested_lesson, params: {id: @section.id}
+    assert_response :success
+    assert_nil json_response
+  end
+
+  test 'get suggested_lesson returns fresh stored data without recomputing' do
+    lesson = create(:lesson)
+    fresh_timestamp = Time.now.utc.iso8601
+    @section.update!(suggested_lesson: {'lesson_id' => lesson.id, 'timestamp' => fresh_timestamp})
+    sign_in @teacher
+    get :suggested_lesson, params: {id: @section.id}
+    assert_response :success
+    assert_equal lesson.id, json_response['lesson_id']
+    # timestamp unchanged confirms no recompute happened
+    assert_equal fresh_timestamp, json_response['timestamp']
+    assert_equal lesson.localized_title, json_response['name']
+    assert json_response['url'].present?
+  end
+
+  test 'get suggested_lesson omits name and url when lesson is not found' do
+    fresh_timestamp = Time.now.utc.iso8601
+    @section.update!(suggested_lesson: {'lesson_id' => -1, 'timestamp' => fresh_timestamp})
+    sign_in @teacher
+    get :suggested_lesson, params: {id: @section.id}
+    assert_response :success
+    assert_equal(-1, json_response['lesson_id'])
+    assert_nil json_response['name']
+    assert_nil json_response['url']
+  end
+
+  test 'get suggested_lesson computes when data is absent and section has script' do
+    section, student, _lesson1, lesson2, sl1, _sl2 = setup_suggested_lesson_section
+    progress = {student.id => {sl1.oldest_active_level.id => {status: 'perfect'}}}
+    @controller.stubs(:script_progress_for_users).returns([progress, {}])
+
+    sign_in @teacher
+    get :suggested_lesson, params: {id: section.id}
+    assert_response :success
+    assert_equal lesson2.id, json_response['lesson_id']
+    assert json_response['timestamp'].present?
+    assert json_response['name'].present?
+  end
+
+  test 'get suggested_lesson recomputes when data is stale' do
+    section, student, lesson1, lesson2, sl1, _sl2 = setup_suggested_lesson_section
+    stale_timestamp = 2.hours.ago.utc.iso8601
+    section.update!(suggested_lesson: {'lesson_id' => lesson1.id, 'timestamp' => stale_timestamp})
+
+    progress = {student.id => {sl1.oldest_active_level.id => {status: 'perfect'}}}
+    @controller.stubs(:script_progress_for_users).returns([progress, {}])
+
+    sign_in @teacher
+    get :suggested_lesson, params: {id: section.id}
+    assert_response :success
+    assert_equal lesson2.id, json_response['lesson_id']
+    refute_equal stale_timestamp, json_response['timestamp']
+  end
+
+  test 'get suggested_lesson skips compute when section has no script' do
+    # No script on @section; suggested_lesson stays nil
+    sign_in @teacher
+    get :suggested_lesson, params: {id: @section.id}
+    assert_response :success
+    assert_nil json_response
+    assert_nil @section.reload.suggested_lesson
+  end
+
+  test 'get suggested_lesson suggests first lesson when no students have completed any lesson' do
+    section, student, lesson1, _lesson2, sl1, _sl2 = setup_suggested_lesson_section
+    progress = {student.id => {sl1.oldest_active_level.id => {status: 'not_tried'}}}
+    @controller.stubs(:script_progress_for_users).returns([progress, {}])
+
+    sign_in @teacher
+    get :suggested_lesson, params: {id: section.id}
+    assert_response :success
+    assert_equal lesson1.id, json_response['lesson_id']
+  end
+
+  test 'get suggested_lesson suggests nothing when all lessons are completed' do
+    section, student, _lesson1, _lesson2, sl1, sl2 = setup_suggested_lesson_section
+    progress = {
+      student.id => {
+        sl1.oldest_active_level.id => {status: 'perfect'},
+        sl2.oldest_active_level.id => {status: 'perfect'}
+      }
+    }
+    @controller.stubs(:script_progress_for_users).returns([progress, {}])
+
+    sign_in @teacher
+    get :suggested_lesson, params: {id: section.id}
+    assert_response :success
+    assert_nil json_response
+  end
+
+  test 'get suggested_lesson uses majority threshold: half or more students must complete' do
+    unit = create(:script, :in_single_unit_course)
+    lesson_group = create(:lesson_group, script: unit)
+    lesson1 = create(:lesson, script: unit, lesson_group: lesson_group)
+    lesson2 = create(:lesson, script: unit, lesson_group: lesson_group)
+    sl1 = create(:script_level, lesson: lesson1, script: unit)
+    section = create(:section, user: @teacher, script: unit)
+    student1 = create(:follower, section: section).student_user
+    student2 = create(:follower, section: section).student_user
+
+    # 1 of 2 students (50%) completed lesson1 — meets the >= half threshold
+    progress = {
+      student1.id => {sl1.oldest_active_level.id => {status: 'perfect'}},
+      student2.id => {}
+    }
+    @controller.stubs(:script_progress_for_users).returns([progress, {}])
+
+    sign_in @teacher
+    get :suggested_lesson, params: {id: section.id}
+    assert_response :success
+    assert_equal lesson2.id, json_response['lesson_id']
+  end
+
+  test 'get suggested_lesson is forbidden for a different teacher' do
+    sign_in @following_teacher
+    get :suggested_lesson, params: {id: @section.id}
+    assert_response :forbidden
+  end
+
+  test 'get suggested_lesson returns 403 for unauthenticated user' do
+    get :suggested_lesson, params: {id: @section.id}
+    assert_response :forbidden
+  end
+
   test 'valid_course_offerings includes only published courses' do
     sign_in @teacher
     get :valid_course_offerings, params: {login_type: Section::LOGIN_TYPE_EMAIL}

--- a/dashboard/test/models/sections/section_test.rb
+++ b/dashboard/test/models/sections/section_test.rb
@@ -1713,4 +1713,75 @@ class SectionTest < ActiveSupport::TestCase
 
     create(:section, teacher: @teacher, course_id: unit_group.id)
   end
+
+  # suggested_lesson
+
+  test 'suggested_lesson_stale? returns true when suggested_lesson is nil' do
+    assert @section.suggested_lesson_stale?
+  end
+
+  test 'suggested_lesson_stale? returns true when timestamp is missing' do
+    @section.update!(suggested_lesson: {'lesson_id' => 1})
+    assert @section.suggested_lesson_stale?
+  end
+
+  test 'suggested_lesson_stale? returns false for a fresh timestamp' do
+    @section.update!(suggested_lesson: {'lesson_id' => 1, 'timestamp' => Time.now.utc.iso8601})
+    refute @section.suggested_lesson_stale?
+  end
+
+  test 'suggested_lesson_stale? returns true for a stale timestamp' do
+    @section.update!(suggested_lesson: {'lesson_id' => 1, 'timestamp' => 2.hours.ago.utc.iso8601})
+    assert @section.suggested_lesson_stale?
+  end
+
+  test 'compute_suggested_lesson does nothing when section has no students' do
+    unit = create(:script, :in_single_unit_course)
+    section = create(:section, teacher: @teacher, script: unit)
+    section.compute_suggested_lesson
+    assert_nil section.reload.suggested_lesson
+  end
+
+  test 'compute_suggested_lesson suggests first lesson when no students have passed any level' do
+    unit, lesson1, _lesson2, _sl1, _sl2, section, _student = build_suggested_lesson_section
+    section.compute_suggested_lesson
+    assert_equal lesson1.id, section.reload.suggested_lesson['lesson_id']
+  end
+
+  test 'compute_suggested_lesson suggests next lesson after majority completes one' do
+    unit, _lesson1, lesson2, sl1, _sl2, section, student = build_suggested_lesson_section
+    create(:user_level, user: student, level: sl1.oldest_active_level, script_id: unit.id, best_result: ActivityConstants::MINIMUM_PASS_RESULT)
+
+    section.compute_suggested_lesson
+    assert_equal lesson2.id, section.reload.suggested_lesson['lesson_id']
+  end
+
+  test 'compute_suggested_lesson sets completed_unit when all lessons are completed' do
+    unit, _lesson1, _lesson2, sl1, sl2, section, student = build_suggested_lesson_section
+    create(:user_level, user: student, level: sl1.oldest_active_level, script_id: unit.id, best_result: ActivityConstants::MINIMUM_PASS_RESULT)
+    create(:user_level, user: student, level: sl2.oldest_active_level, script_id: unit.id, best_result: ActivityConstants::MINIMUM_PASS_RESULT)
+
+    section.compute_suggested_lesson
+    data = section.reload.suggested_lesson
+    assert data['completed_unit']
+    assert_nil data['lesson_id']
+  end
+
+  test 'compute_suggested_lesson writes a timestamp' do
+    unit, _lesson1, _lesson2, _sl1, _sl2, section, _student = build_suggested_lesson_section
+    section.compute_suggested_lesson
+    assert section.reload.suggested_lesson['timestamp'].present?
+  end
+
+  private def build_suggested_lesson_section
+    unit = create(:script, :in_single_unit_course)
+    lesson_group = create(:lesson_group, script: unit)
+    lesson1 = create(:lesson, script: unit, lesson_group: lesson_group)
+    lesson2 = create(:lesson, script: unit, lesson_group: lesson_group)
+    sl1 = create(:script_level, lesson: lesson1, script: unit)
+    sl2 = create(:script_level, lesson: lesson2, script: unit)
+    section = create(:section, teacher: @teacher, script: unit)
+    student = create(:follower, section: section).student_user
+    [unit, lesson1, lesson2, sl1, sl2, section, student]
+  end
 end

--- a/dashboard/test/models/sections/section_test.rb
+++ b/dashboard/test/models/sections/section_test.rb
@@ -1743,7 +1743,7 @@ class SectionTest < ActiveSupport::TestCase
   end
 
   test 'compute_suggested_lesson suggests first lesson when no students have passed any level' do
-    unit, lesson1, _lesson2, _sl1, _sl2, section, _student = build_suggested_lesson_section
+    _, lesson1, _lesson2, _sl1, _sl2, section, _student = build_suggested_lesson_section
     section.compute_suggested_lesson
     assert_equal lesson1.id, section.reload.suggested_lesson['lesson_id']
   end
@@ -1768,7 +1768,7 @@ class SectionTest < ActiveSupport::TestCase
   end
 
   test 'compute_suggested_lesson writes a timestamp' do
-    unit, _lesson1, _lesson2, _sl1, _sl2, section, _student = build_suggested_lesson_section
+    _, _lesson1, _lesson2, _sl1, _sl2, section, _student = build_suggested_lesson_section
     section.compute_suggested_lesson
     assert section.reload.suggested_lesson['timestamp'].present?
   end


### PR DESCRIPTION
This change adds a `suggested_lesson` field to the `Section` model. To compute it we look at student progress in the assigned unit, and see which is the last lesson that at least 50% of the students have completed. The lesson after that is the suggested next lesson. 

There's also a prototype UI (hidden behind the `suggested-lesson` experiment) that simply displays a link to the suggested lesson in each section's box on the teacher homepage.

<img width="856" height="839" alt="image" src="https://github.com/user-attachments/assets/5ca1a978-6820-45cb-898e-fc004cb21b9e" />




## Links
<!-- Jira tickets, design docs, Slack threads, related PRs, etc. -->

- Jira: https://codedotorg.atlassian.net/browse/TEACHING-181

## Testing story
Numerous tests added for the new Ruby functionality. I would not be surprised if a few edge cases in the curriculum model, user level complexity, etc. were missed and will be uncovered during some testing on real user data.


## Deployment notes
<!-- Delete this section if it's a standard merge-and-deploy.
     Otherwise: migrations, feature flags, coordination, caching impacts, etc. -->



## Privacy and security
<!-- Delete this section if there is no privacy/security impact.
     Otherwise: new PII, auth changes, API surface changes, etc. -->

