### PR TITLE
Sketch Lab 2: Enable duplication of edges with real nodes

### DIFF
--- a/apps/src/sketchlab/reactFlow/hooks/useCopyPaste.ts
+++ b/apps/src/sketchlab/reactFlow/hooks/useCopyPaste.ts
@@ -7,9 +7,18 @@ import type {
 } from '@cdo/apps/lab2/types';
 import {createUuid} from '@cdo/apps/utils';
 
-import {PASTE_OFFSET_PX} from '../constants';
+import {
+  DEFAULT_NODE_HEIGHT,
+  DEFAULT_NODE_WIDTH,
+  PASTE_OFFSET_PX,
+} from '../constants';
 import type {ClipboardContents} from '../context';
 import type {TabOrderEntry} from '../utils/computeTabOrder';
+import {
+  createLineAnchorAtHandle,
+  getHandleFlowPosition,
+  lineAnchorHandleId,
+} from '../utils/lineAnchors';
 
 interface UseCopyPasteOptions {
   nodes: SketchlabReactFlowNode[];
@@ -60,24 +69,61 @@ export function useCopyPaste({
     [nodes]
   );
 
-  // A line edge is stored as two hidden lineAnchor nodes plus the edge
-  // connecting them — all three must travel together in the clipboard.
-  // TODO: enable copy/paste of an edge attached to one or two real nodes.
+  // A line is stored as an edge with two nodes - the nodes are either anchor nodes or real nodes.
+  // all three elements must travel together in the clipboard.
+  // When an endpoint is a real (non-anchor) node, a new anchor node is
+  // created at that node's handle position so we can duplicate the free-standing anchor node.
   const buildLineEdgeClipboard = useCallback(
     (edgeId: string): ClipboardContents | null => {
       const edge = edges.find(e => e.id === edgeId);
-      if (!edge) return null;
-      const sourceAnchor = nodes.find(n => n.id === edge.source);
-      const targetAnchor = nodes.find(n => n.id === edge.target);
-      if (
-        sourceAnchor?.type !== 'lineAnchor' ||
-        targetAnchor?.type !== 'lineAnchor'
-      ) {
-        return null;
-      }
-      return {nodes: [sourceAnchor, targetAnchor], edges: [edge]};
+      if (!edge || edge.data?.locked) return null;
+
+      const resolveEndpointAnchor = (
+        nodeId: string,
+        handleId: string | null | undefined,
+        role: 'source' | 'target'
+      ) => {
+        const node = nodes.find(n => n.id === nodeId);
+        if (!node) return null;
+        if (node.type === 'lineAnchor') return node;
+        const handlePos = getHandleFlowPosition(
+          nodeId,
+          handleId ?? undefined,
+          screenToFlowPosition
+        );
+        const position = handlePos ?? {
+          x: node.position.x + (node.width ?? DEFAULT_NODE_WIDTH) / 2,
+          y: node.position.y + (node.height ?? DEFAULT_NODE_HEIGHT) / 2,
+        };
+        return createLineAnchorAtHandle(position, role);
+      };
+
+      const sourceAnchor = resolveEndpointAnchor(
+        edge.source,
+        edge.sourceHandle,
+        'source'
+      );
+      const targetAnchor = resolveEndpointAnchor(
+        edge.target,
+        edge.targetHandle,
+        'target'
+      );
+      if (!sourceAnchor || !targetAnchor) return null;
+
+      // Point edge endpoints at the clipboard anchor IDs.
+      const edgeWithAnchorNodes = {
+        ...edge,
+        source: sourceAnchor.id,
+        target: targetAnchor.id,
+        sourceHandle: lineAnchorHandleId('source'),
+        targetHandle: lineAnchorHandleId('target'),
+      };
+      return {
+        nodes: [sourceAnchor, targetAnchor],
+        edges: [edgeWithAnchorNodes],
+      };
     },
-    [nodes, edges]
+    [nodes, edges, screenToFlowPosition]
   );
 
   // Toolbar action: duplicate a node in-place with 'stagger' chaining, i.e., each duplicate is
@@ -107,7 +153,7 @@ export function useCopyPaste({
     [buildNodeClipboard, setNodes]
   );
 
-  // Toolbar action: duplicate a line edge (both anchor nodes + the edge).
+  // Toolbar action: duplicate a line.
   const duplicateLine = useCallback(
     (edgeId: string) => {
       const source =
@@ -170,21 +216,29 @@ export function useCopyPaste({
         const contents = buildLineEdgeClipboard(entry.id);
         if (!contents) return;
         writeClipboard(contents);
-        // Deleting the anchor nodes removes the line edge automatically.
         const lineEdge = edges.find(e => e.id === entry.id);
         if (lineEdge) {
-          deleteElements({
-            nodes: [{id: lineEdge.source}, {id: lineEdge.target}],
-          });
+          // Only delete lineAnchor endpoints — real nodes are independent objects.
+          // Deleting anchor nodes removes the edge automatically; for real-node
+          // endpoints we delete the edge directly.
+          const anchorIds = [lineEdge.source, lineEdge.target].filter(
+            id => nodes.find(n => n.id === id)?.type === 'lineAnchor'
+          );
+          if (anchorIds.length > 0) {
+            deleteElements({nodes: anchorIds.map(id => ({id}))});
+          } else {
+            deleteElements({edges: [{id: entry.id}]});
+          }
         }
       }
     },
     [
-      edges,
       buildNodeClipboard,
-      buildLineEdgeClipboard,
       writeClipboard,
       deleteElements,
+      buildLineEdgeClipboard,
+      edges,
+      nodes,
     ]
   );
 


### PR DESCRIPTION
<!--
  Summary of the change: background, motivation, and context.
  Include screenshots, videos, or before/after comparisons for UI changes.
-->
This PR updates `duplicateLine` so that lines that do not have two anchor nodes, i.e. are connected to 'real' nodes (shape, text or image nodes) can also be duplicated. 




## Links
<!-- Jira tickets, design docs, Slack threads, related PRs, etc. -->

- Jira: https://codedotorg.atlassian.net/browse/AFL-628

## Testing story
<!-- How was this tested? Manual steps, adhoc links, automated tests, or why testing isn't needed. -->

Tested locally:

Screencast of duplicating lines connected to 'real' nodes (not anchor nodes):

https://github.com/user-attachments/assets/e8d0e714-43d7-4803-9be2-99747898fe48




## Deployment notes
<!-- Delete this section if it's a standard merge-and-deploy.
     Otherwise: migrations, feature flags, coordination, caching impacts, etc. -->



## Privacy and security
<!-- Delete this section if there is no privacy/security impact.
     Otherwise: new PII, auth changes, API surface changes, etc. -->

