### PR TITLE
fix(i18n): resolve locale fallback test issue

### DIFF
--- a/dashboard/test/integration/language_test.rb
+++ b/dashboard/test/integration/language_test.rb
@@ -50,8 +50,6 @@ class LanguageTest < ActionDispatch::IntegrationTest
 
         _ {I18n.backend.store_translations(locale, {i18n_string_key: 'locale_str'})}.
           must_change -> {I18n.t(:i18n_string_key, locale:)}, from: 'fallback_str', to: 'locale_str'
-      ensure
-        I18n.backend.reload!
       end
     end
   end

--- a/dashboard/test/integration/language_test.rb
+++ b/dashboard/test/integration/language_test.rb
@@ -45,11 +45,16 @@ class LanguageTest < ActionDispatch::IntegrationTest
   describe 'fallbacks' do
     Cdo::I18n::LOCALE_FALLBACKS.each do |locale, fallback|
       it "from #{locale.inspect} to #{fallback.inspect}" do
-        _ {I18n.backend.store_translations(fallback, {i18n_string_key: 'fallback_str'})}.
-          must_change -> {I18n.t(:i18n_string_key, locale:, default: 'default_str')}, from: 'default_str', to: 'fallback_str'
+        i18n_string_key = :"i18n_string_key_#{locale}"
 
-        _ {I18n.backend.store_translations(locale, {i18n_string_key: 'locale_str'})}.
-          must_change -> {I18n.t(:i18n_string_key, locale:)}, from: 'fallback_str', to: 'locale_str'
+        _(I18n.fallbacks[locale].first).must_equal locale.to_sym
+        _(I18n.fallbacks[locale].third).must_equal fallback.to_sym
+
+        _ {I18n.backend.store_translations(fallback, {i18n_string_key => 'fallback_str'})}.
+          must_change -> {I18n.t(i18n_string_key, locale:, default: 'default_str')}, from: 'default_str', to: 'fallback_str'
+
+        _ {I18n.backend.store_translations(locale, {i18n_string_key => 'locale_str'})}.
+          must_change -> {I18n.t(i18n_string_key, locale:)}, from: 'fallback_str', to: 'locale_str'
       end
     end
   end

--- a/dashboard/test/integration/language_test.rb
+++ b/dashboard/test/integration/language_test.rb
@@ -45,7 +45,6 @@ class LanguageTest < ActionDispatch::IntegrationTest
   describe 'fallbacks' do
     Cdo::I18n::LOCALE_FALLBACKS.each do |locale, fallback|
       it "from #{locale.inspect} to #{fallback.inspect}" do
-        skip 'Mysterious Drone failure, wilkie to investigate'
         _ {I18n.backend.store_translations(fallback, {i18n_string_key: 'fallback_str'})}.
           must_change -> {I18n.t(:i18n_string_key, locale:, default: 'default_str')}, from: 'default_str', to: 'fallback_str'
 


### PR DESCRIPTION
```
======== FAIL["test_0002_from \"es-ES\" to \"es-MX\"", "LanguageTest::fallbacks", 331.05629633900026]
--
test_0002_from "es-ES" to "es-MX"#LanguageTest::fallbacks (331.06s)
#<Proc:0x00007f7bf80b0d08 /drone/src/dashboard/test/integration/language_test.rb:49 (lambda)> didn't change.
Expected "default_str" to not be equal to "default_str".
test/integration/language_test.rb:48:in `block (3 levels) in <class:LanguageTest>'
test/testing/setup_all_and_teardown_all.rb:36:in `run'
```

## Links
- Related PR: https://github.com/code-dot-org/code-dot-org/pull/72422
- Drone build: https://drone.cdn-code.org/code-dot-org/code-dot-org/55001/1/5