### PR TITLE
[MERGE AFTER 5/8] Flip Sketch Lab to React Flow

### DIFF
--- a/apps/src/lab2/productTours/productToursPerLab.ts
+++ b/apps/src/lab2/productTours/productToursPerLab.ts
@@ -96,7 +96,7 @@ export function isTourAvailableOnLevel(
   if (!isAvailableForLab) {
     return false;
   }
-  // The Sketch Lab intro tour is only currently available for excalidraw-based
+  // The Sketch Lab tour(s) are only currently available for excalidraw-based
   // Sketch lab.
   // TODO: remove excalidraw tour https://codedotorg.atlassian.net/browse/AFL-641
   if (

--- a/apps/src/lab2/productTours/productToursPerLab.ts
+++ b/apps/src/lab2/productTours/productToursPerLab.ts
@@ -96,11 +96,12 @@ export function isTourAvailableOnLevel(
   if (!isAvailableForLab) {
     return false;
   }
-  // While we are developing the new sketch lab, skip any product tours when the
-  // experiment is on.
+  // The Sketch Lab intro tour is only currently available for excalidraw-based
+  // Sketch lab.
+  // TODO: remove excalidraw tour https://codedotorg.atlassian.net/browse/AFL-641
   if (
     levelProperties.appName === 'sketchlab' &&
-    experiments.isEnabledAllowingQueryString('sketch2')
+    !experiments.isEnabledAllowingQueryString(experiments.EXCALIDRAW)
   ) {
     return false;
   }

--- a/apps/src/sketchlab/SketchlabView.tsx
+++ b/apps/src/sketchlab/SketchlabView.tsx
@@ -13,7 +13,9 @@ import ReactFlowSketchLabView, {
 
 export default function SketchlabView(props: LabProps<LevelProperties>) {
   // Legacy version of Sketch Lab is behind a flag for now, so we can check on old behavior.
-  const useExcalidraw = experiments.isEnabledAllowingQueryString('excalidraw');
+  const useExcalidraw = experiments.isEnabledAllowingQueryString(
+    experiments.EXCALIDRAW
+  );
   const defaultSources = useExcalidraw
     ? DEFAULT_SOURCES
     : REACT_FLOW_DEFAULT_SOURCES;

--- a/apps/src/sketchlab/SketchlabView.tsx
+++ b/apps/src/sketchlab/SketchlabView.tsx
@@ -12,13 +12,14 @@ import ReactFlowSketchLabView, {
 } from './reactFlow/ReactFlowSketchLabView';
 
 export default function SketchlabView(props: LabProps<LevelProperties>) {
-  const useReactFlow = experiments.isEnabledAllowingQueryString('sketch2');
-  const defaultSources = useReactFlow
-    ? REACT_FLOW_DEFAULT_SOURCES
-    : DEFAULT_SOURCES;
-  const InnerView = useReactFlow
-    ? ReactFlowSketchLabView
-    : ExcalidrawSketchLabView;
+  // Legacy version of Sketch Lab is behind a flag for now, so we can check on old behavior.
+  const useExcalidraw = experiments.isEnabledAllowingQueryString('excalidraw');
+  const defaultSources = useExcalidraw
+    ? DEFAULT_SOURCES
+    : REACT_FLOW_DEFAULT_SOURCES;
+  const InnerView = useExcalidraw
+    ? ExcalidrawSketchLabView
+    : ReactFlowSketchLabView;
 
   return (
     <SourcesContainer

--- a/apps/src/util/experiments.js
+++ b/apps/src/util/experiments.js
@@ -71,6 +71,8 @@ experiments.ONBOARDING = 'onboarding';
 experiments.AI_DIFF_DRAWER = 'ai-diff-drawer';
 // Route all Gemini model traffic through the AI gateway instead of the Rails backend
 experiments.USE_AI_GATEWAY = 'useAiGateway';
+// Legacy version of Sketch Lab. This should be removed once the new version is fully stable.
+experiments.EXCALIDRAW = 'excalidraw';
 
 /**
  * This was a gamified version of the finish dialog, built in 2018,

--- a/apps/test/unit/lab2/productTours/productToursPerLabTest.ts
+++ b/apps/test/unit/lab2/productTours/productToursPerLabTest.ts
@@ -4,12 +4,26 @@ import {
   ProductTour,
 } from '@cdo/apps/lab2/productTours/productToursPerLab';
 import {LevelProperties} from '@cdo/apps/lab2/types';
+import experiments from '@cdo/apps/util/experiments';
 
 const makeLevelProperties = (
   appName: string,
   overrides: Partial<LevelProperties> = {}
 ): LevelProperties =>
   ({appName, id: 0, name: 'test', ...overrides} as LevelProperties);
+
+// Sketch Lab tours are gated on the EXCALIDRAW experiment. Default to
+// enabled so the non-gating tests can focus on tour-selection logic;
+// individual tests below override this to verify the gating itself.
+beforeEach(() => {
+  jest
+    .spyOn(experiments, 'isEnabledAllowingQueryString')
+    .mockImplementation(key => key === experiments.EXCALIDRAW);
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
 
 describe('isTourEnabledOnLevel', () => {
   describe('when the tour is not available for the lab', () => {
@@ -114,6 +128,32 @@ describe('isTourEnabledOnLevel', () => {
           })
         )
       ).toBe(true);
+    });
+  });
+
+  describe('when the lab is sketchlab', () => {
+    it('returns true when the EXCALIDRAW experiment is enabled', () => {
+      jest
+        .spyOn(experiments, 'isEnabledAllowingQueryString')
+        .mockImplementation(key => key === experiments.EXCALIDRAW);
+      expect(
+        isTourEnabledOnLevel(
+          ProductTour.SketchlabIntro,
+          makeLevelProperties('sketchlab')
+        )
+      ).toBe(true);
+    });
+
+    it('returns false when the EXCALIDRAW experiment is not enabled', () => {
+      jest
+        .spyOn(experiments, 'isEnabledAllowingQueryString')
+        .mockReturnValue(false);
+      expect(
+        isTourEnabledOnLevel(
+          ProductTour.SketchlabIntro,
+          makeLevelProperties('sketchlab')
+        )
+      ).toBe(false);
     });
   });
 


### PR DESCRIPTION
This PR flips sketch lab to use react flow by default. I've kept excalidraw around behind the experiment flag `excalidraw` so we can check on old behavior if needed.

## Links

- Jira: [AFL-637](https://codedotorg.atlassian.net/browse/AFL-637)

## Testing story
Tested locally that react flow is now the default in sketch lab


