### PR TITLE
Duplicate so that copied element does not overlap and pasted to the right

### DIFF
--- a/apps/src/sketchlab/reactFlow/constants.ts
+++ b/apps/src/sketchlab/reactFlow/constants.ts
@@ -22,8 +22,7 @@ export const LINE_RECONNECT_SNAP_RADIUS_PX = 20;
 // Milliseconds to debounce project saves after canvas changes.
 export const SAVE_DEBOUNCE_MS = 300;
 
-// How far to offset pasted/duplicated elements from their original position.
-export const PASTE_OFFSET_PX = 20;
+export const DEFAULT_PASTE_OFFSET_PX = 30;
 
 // S3 asset path prefix for project files.
 export const ASSET_PATH_PREFIX = '/v3/assets';

--- a/apps/src/sketchlab/reactFlow/hooks/useCopyPaste.ts
+++ b/apps/src/sketchlab/reactFlow/hooks/useCopyPaste.ts
@@ -140,8 +140,8 @@ export function useCopyPaste({
         ...node,
         id: createUuid(),
         position: {
-          x: node.position.x + PASTE_OFFSET_PX,
-          y: node.position.y + PASTE_OFFSET_PX,
+          x: node.position.x + (node.width ?? DEFAULT_NODE_WIDTH),
+          y: node.position.y,
         },
       }));
 

--- a/apps/src/sketchlab/reactFlow/hooks/useCopyPaste.ts
+++ b/apps/src/sketchlab/reactFlow/hooks/useCopyPaste.ts
@@ -32,6 +32,20 @@ interface UseCopyPasteOptions {
   ) => void;
 }
 
+// Returns the handle-to-handle horizontal span of a line clipboard's anchor
+// nodes. Uses anchorHandleFlowPosition rather than raw position.x because
+// source and target anchors offset their top-left corners differently.
+function lineHorizontalSpanFromClipboardNodes(
+  clipboardNodes: SketchlabReactFlowNode[]
+): number {
+  const handleXs = clipboardNodes.map(n =>
+    n.type === 'lineAnchor'
+      ? anchorHandleFlowPosition(n.position, n.data.lineAnchorRole).x
+      : n.position.x
+  );
+  return Math.max(...handleXs) - Math.min(...handleXs);
+}
+
 export function useCopyPaste({
   nodes,
   edges,
@@ -162,20 +176,13 @@ export function useCopyPaste({
           : buildLineEdgeClipboard(edgeId);
       if (!source) return;
 
-      const handleXs = source.nodes.map(n =>
-        n.type === 'lineAnchor'
-          ? anchorHandleFlowPosition(n.position, n.data.lineAnchorRole).x
-          : n.position.x
+      const lineHorizontalSpan = lineHorizontalSpanFromClipboardNodes(
+        source.nodes
       );
-      const lineHorizontalDisplacement =
-        Math.max(...handleXs) - Math.min(...handleXs);
       // For lines, we want to offset the pasted line by the horizontal displacement of the original line.
       // If the line's horizontal displacement is less than the default offset, use the default offset so that lines
       // that are vertical or almost vertical aren't too close to each other.
-      const offsetX = Math.max(
-        lineHorizontalDisplacement,
-        DEFAULT_PASTE_OFFSET_PX
-      );
+      const offsetX = Math.max(lineHorizontalSpan, DEFAULT_PASTE_OFFSET_PX);
 
       const idMap = new Map<string, string>();
       const newNodes = source.nodes.map(node => {
@@ -274,13 +281,10 @@ export function useCopyPaste({
     } else {
       const isLine = contents.edges.length > 0;
       if (isLine) {
-        const handleXs = contents.nodes.map(n =>
-          n.type === 'lineAnchor'
-            ? anchorHandleFlowPosition(n.position, n.data.lineAnchorRole).x
-            : n.position.x
+        const lineHorizontalSpan = lineHorizontalSpanFromClipboardNodes(
+          contents.nodes
         );
-        const lineWidth = Math.max(...handleXs) - Math.min(...handleXs);
-        deltaX = Math.max(lineWidth, DEFAULT_PASTE_OFFSET_PX);
+        deltaX = Math.max(lineHorizontalSpan, DEFAULT_PASTE_OFFSET_PX);
       } else {
         deltaX = anchorNode
           ? anchorNode.width ?? DEFAULT_NODE_WIDTH

--- a/apps/src/sketchlab/reactFlow/hooks/useCopyPaste.ts
+++ b/apps/src/sketchlab/reactFlow/hooks/useCopyPaste.ts
@@ -15,6 +15,7 @@ import {
 import type {ClipboardContents} from '../context';
 import type {TabOrderEntry} from '../utils/computeTabOrder';
 import {
+  anchorHandleFlowPosition,
   createLineAnchorAtHandle,
   getHandleFlowPosition,
   lineAnchorHandleId,
@@ -161,9 +162,13 @@ export function useCopyPaste({
           : buildLineEdgeClipboard(edgeId);
       if (!source) return;
 
-      const xPositions = source.nodes.map(n => n.position.x);
+      const handleXs = source.nodes.map(n =>
+        n.type === 'lineAnchor'
+          ? anchorHandleFlowPosition(n.position, n.data.lineAnchorRole).x
+          : n.position.x
+      );
       const lineHorizontalDisplacement =
-        Math.max(...xPositions) - Math.min(...xPositions);
+        Math.max(...handleXs) - Math.min(...handleXs);
       // For lines, we want to offset the pasted line by the horizontal displacement of the original line.
       // If the line's horizontal displacement is less than the default offset, use the default offset so that lines
       // that are vertical or almost vertical aren't too close to each other.
@@ -269,8 +274,12 @@ export function useCopyPaste({
     } else {
       const isLine = contents.edges.length > 0;
       if (isLine) {
-        const xs = contents.nodes.map(n => n.position.x);
-        const lineWidth = Math.max(...xs) - Math.min(...xs);
+        const handleXs = contents.nodes.map(n =>
+          n.type === 'lineAnchor'
+            ? anchorHandleFlowPosition(n.position, n.data.lineAnchorRole).x
+            : n.position.x
+        );
+        const lineWidth = Math.max(...handleXs) - Math.min(...handleXs);
         deltaX = Math.max(lineWidth, DEFAULT_PASTE_OFFSET_PX);
       } else {
         deltaX = anchorNode

--- a/apps/src/sketchlab/reactFlow/hooks/useCopyPaste.ts
+++ b/apps/src/sketchlab/reactFlow/hooks/useCopyPaste.ts
@@ -10,7 +10,7 @@ import {createUuid} from '@cdo/apps/utils';
 import {
   DEFAULT_NODE_HEIGHT,
   DEFAULT_NODE_WIDTH,
-  PASTE_OFFSET_PX,
+  DEFAULT_PASTE_OFFSET_PX,
 } from '../constants';
 import type {ClipboardContents} from '../context';
 import type {TabOrderEntry} from '../utils/computeTabOrder';
@@ -126,8 +126,7 @@ export function useCopyPaste({
     [nodes, edges, screenToFlowPosition]
   );
 
-  // Toolbar action: duplicate a node in-place with 'stagger' chaining, i.e., each duplicate is
-  // offset by PASTE_OFFSET_PX in both dimensions.
+  // Toolbar action: duplicate a node in-place but each duplicate is offset by the width of the node horizontally.
   const duplicateNode = useCallback(
     (nodeId: string) => {
       const source =
@@ -162,6 +161,17 @@ export function useCopyPaste({
           : buildLineEdgeClipboard(edgeId);
       if (!source) return;
 
+      const xPositions = source.nodes.map(n => n.position.x);
+      const lineHorizontalDisplacement =
+        Math.max(...xPositions) - Math.min(...xPositions);
+      // For lines, we want to offset the pasted line by the horizontal displacement of the original line.
+      // If the line's horizontal displacement is less than the default offset, use the default offset so that lines
+      // that are vertical or almost vertical aren't too close to each other.
+      const offsetX = Math.max(
+        lineHorizontalDisplacement,
+        DEFAULT_PASTE_OFFSET_PX
+      );
+
       const idMap = new Map<string, string>();
       const newNodes = source.nodes.map(node => {
         const newId = createUuid();
@@ -170,8 +180,8 @@ export function useCopyPaste({
           ...node,
           id: newId,
           position: {
-            x: node.position.x + PASTE_OFFSET_PX,
-            y: node.position.y + PASTE_OFFSET_PX,
+            x: node.position.x + offsetX,
+            y: node.position.y,
           },
         };
       });
@@ -254,11 +264,11 @@ export function useCopyPaste({
     const deltaX =
       mousePos && anchorNode
         ? mousePos.x - anchorNode.position.x
-        : PASTE_OFFSET_PX;
+        : DEFAULT_PASTE_OFFSET_PX;
     const deltaY =
       mousePos && anchorNode
         ? mousePos.y - anchorNode.position.y
-        : PASTE_OFFSET_PX;
+        : DEFAULT_PASTE_OFFSET_PX;
 
     const idMap = new Map<string, string>();
     const newNodes = contents.nodes.map(node => {

--- a/apps/src/sketchlab/reactFlow/hooks/useCopyPaste.ts
+++ b/apps/src/sketchlab/reactFlow/hooks/useCopyPaste.ts
@@ -257,18 +257,28 @@ export function useCopyPaste({
     if (!contents) return;
 
     // When the mouse is over the canvas, paste with the first node at the
-    // cursor. When the mouse is outside (keyboard-only path), fall back to
-    // a fixed offset so pasted elements don't stack on originals.
+    // cursor. When the mouse is outside (keyboard-only path), offset to the
+    // right by the element's width (node) or horizontal span (line).
     const mousePos = mousePositionRef.current;
     const anchorNode = contents.nodes[0];
-    const deltaX =
-      mousePos && anchorNode
-        ? mousePos.x - anchorNode.position.x
-        : DEFAULT_PASTE_OFFSET_PX;
-    const deltaY =
-      mousePos && anchorNode
-        ? mousePos.y - anchorNode.position.y
-        : DEFAULT_PASTE_OFFSET_PX;
+    let deltaX: number;
+    let deltaY: number;
+    if (mousePos && anchorNode) {
+      deltaX = mousePos.x - anchorNode.position.x;
+      deltaY = mousePos.y - anchorNode.position.y;
+    } else {
+      const isLine = contents.edges.length > 0;
+      if (isLine) {
+        const xs = contents.nodes.map(n => n.position.x);
+        const lineWidth = Math.max(...xs) - Math.min(...xs);
+        deltaX = Math.max(lineWidth, DEFAULT_PASTE_OFFSET_PX);
+      } else {
+        deltaX = anchorNode
+          ? anchorNode.width ?? DEFAULT_NODE_WIDTH
+          : DEFAULT_PASTE_OFFSET_PX;
+      }
+      deltaY = 0;
+    }
 
     const idMap = new Map<string, string>();
     const newNodes = contents.nodes.map(node => {


### PR DESCRIPTION
<!--
  Summary of the change: background, motivation, and context.
  Include screenshots, videos, or before/after comparisons for UI changes.
-->
This PR updates duplication of elements (nodes and edges) so that the duplicate is offset horizontally by the width of the node of the horizontal span of the edge (includes lines/arrows).
This will help resolve difficulty in selecting elements when they overlap.




## Links
<!-- Jira tickets, design docs, Slack threads, related PRs, etc. -->

- Jira: https://codedotorg.atlassian.net/browse/AFL-643
- [Slack thread](https://codedotorg.slack.com/archives/C06JELCAPT9/p1778251279397399?thread_ts=1778248806.407789&cid=C06JELCAPT9)

## Testing story
<!-- How was this tested? Manual steps, adhoc links, automated tests, or why testing isn't needed. -->

Tested locally in Sketch Lab levels.


### Before update

https://github.com/user-attachments/assets/932e0ffb-2d74-4b71-b956-a4bd4181d929




### After update

Duplicating shapes and lines - now duplicate is shifted horizontally to the right so not overlapping

https://github.com/user-attachments/assets/edb3f907-b531-482c-a9e0-44234dddbb32


Using keyboard navigation and keyboard shortcut for copy/paste. If hand/cursor is offscreen, element is pasted horizontally. But if onscreen, then pasted where hand cursor is.


https://github.com/user-attachments/assets/aebeed9c-91fd-426d-9c79-f9da5b68bd99




## Deployment notes
<!-- Delete this section if it's a standard merge-and-deploy.
     Otherwise: migrations, feature flags, coordination, caching impacts, etc. -->



## Privacy and security
<!-- Delete this section if there is no privacy/security impact.
     Otherwise: new PII, auth changes, API surface changes, etc. -->

