### PR TITLE
Stop attempting to delete AI chat requests temporarily

### DIFF
--- a/bin/cron/delete_old_ai_chat_data
+++ b/bin/cron/delete_old_ai_chat_data
@@ -23,8 +23,10 @@ def main
   deleted_event_count = DASHBOARD_DB_LONG_TIMEOUT[:aichat_events].where {created_at < Time.now - 90.days}.delete
   ChatClient.message('cron-daily', "Deleted #{deleted_event_count} AichatEvent records")
 
-  deleted_request_count = DASHBOARD_DB_LONG_TIMEOUT[:aichat_requests].where {created_at < Time.now - 91.days}.delete
-  ChatClient.message('cron-daily', "Deleted #{deleted_request_count} AichatRequest records")
+  # Stop doing this temporarily because of database issues.
+  # Work tracked here: https://codedotorg.atlassian.net/browse/SL-1696
+  # deleted_request_count = DASHBOARD_DB_LONG_TIMEOUT[:aichat_requests].where {created_at < Time.now - 91.days}.delete
+  # ChatClient.message('cron-daily', "Deleted #{deleted_request_count} AichatRequest records")
 end
 
 main


### PR DESCRIPTION
Attempting to delete AI chat data caused db issues. It's not working anyway, so pausing until we can fix.

## Links

- Discussion 1: https://codedotorg.slack.com/archives/C0T0PNTM3/p1778199818755469
- Discussion 2: https://codedotorg.slack.com/archives/C03DBDN67B7/p1775682526200409