### PR TITLE
fix(Gemfile): restore removed google-protobuf dependencies

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -500,6 +500,12 @@ GEM
       google-apis-core (>= 0.9.1, < 2.a)
     google-apis-youtube_v3 (0.25.0)
       google-apis-core (>= 0.9.1, < 2.a)
+    google-protobuf (4.33.6)
+      bigdecimal
+      rake (>= 13)
+    google-protobuf (4.33.6-arm64-darwin)
+      bigdecimal
+      rake (>= 13)
     google-protobuf (4.33.6-x86_64-linux-gnu)
       bigdecimal
       rake (>= 13)


### PR DESCRIPTION
Restore the removed `google-protobuf` gem dependencies, causing unexpected `Gemfile.lock` changes: https://github.com/code-dot-org/code-dot-org/commit/502033bb024b671576335ad8d8ddc71955aa2419#diff-89cade48462044ee1b672dc5f4c3ec250fbd29effcd8932096a23c1283c6731f

```
code-dot-org % git diff Gemfile.lock
diff --git a/Gemfile.lock b/Gemfile.lock
index b8ba8e91882..de5b798536d 100644
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -467,7 +467,6 @@ GEM
     faraday-patron (1.0.0)
     faraday-rack (1.0.0)
     faraday-retry (1.0.3)
-    ffi (1.17.0)
     ffi (1.17.0-arm64-darwin)
     ffi (1.17.0-x86_64-linux-gnu)
     ffi-compiler (1.3.2)
@@ -500,6 +499,9 @@ GEM
       google-apis-core (>= 0.9.1, < 2.a)
     google-apis-youtube_v3 (0.25.0)
       google-apis-core (>= 0.9.1, < 2.a)
+    google-protobuf (4.33.6-arm64-darwin)
+      bigdecimal
+      rake (>= 13)
     google-protobuf (4.33.6-x86_64-linux-gnu)
       bigdecimal
       rake (>= 13)
@@ -585,7 +587,6 @@ GEM
     launchy (3.0.1)
       addressable (~> 2.8)
       childprocess (~> 5.0)
-    libv8-node (18.16.0.0)
     libv8-node (18.16.0.0-arm64-darwin)
     libv8-node (18.16.0.0-x86_64-linux)
     listen (3.8.0)
@@ -620,7 +621,6 @@ GEM
     mime-types-data (3.2023.0218.1)
     mini_magick (4.12.0)
     mini_mime (1.1.2)
-    mini_portile2 (2.8.9)
     mini_racer (0.8.0)
       libv8-node (~> 18.16.0.0)
     minitest (5.18.0)
@@ -666,9 +666,6 @@ GEM
     netrc (0.11.0)
     newrelic_rpm (8.16.0)
     nio4r (2.7.0)
-    nokogiri (1.18.10)
-      mini_portile2 (~> 2.8.2)
-      racc (~> 1.4)
     nokogiri (1.18.10-arm64-darwin)
       racc (~> 1.4)
     nokogiri (1.18.10-x86_64-linux-gnu)
@@ -1215,7 +1212,6 @@ GEM

 PLATFORMS
   arm64-darwin-25
-  ruby
   x86_64-linux
```