### PR TITLE
Ignore address hits for project share blocking

### DIFF
--- a/dashboard/legacy/middleware/files_api.rb
+++ b/dashboard/legacy/middleware/files_api.rb
@@ -461,10 +461,7 @@ class FilesApi < Sinatra::Base
         details = exception.message.empty? ? nil : exception.message
         return json_bad_request(details)
       end
-      # TODO(JillianK): we are temporarily ignoring address share failures because our address detection is very broken.
-      # Once we have a better geocoding solution in H1, we should start filtering for addresses again.
-      # Additional context: https://codedotorg.atlassian.net/browse/STAR-1361
-      if share_failure && share_failure[:type] != ShareFiltering::FailureType::ADDRESS
+      if share_failure
         details_key = share_failure.type == ShareFiltering::FailureType::PROFANITY ? "profaneWords" : "pIIWords"
         details = {details_key => [share_failure.content]}
         return json_bad_request(details)

--- a/dashboard/legacy/middleware/helpers/profanity_privacy_helper.rb
+++ b/dashboard/legacy/middleware/helpers/profanity_privacy_helper.rb
@@ -19,7 +19,7 @@ BLOCKLY_SOURCE_FILENAME = 'main.json'.freeze unless defined? BLOCKLY_SOURCE_FILE
 def profanity_privacy_violation?(filename, body, project_type)
   return false unless filename == BLOCKLY_SOURCE_FILENAME
   share_failure = share_failure_from_body body, request.locale, project_type
-  !!share_failure
+  share_failure && share_failure.type != ShareFiltering::FailureType::ADDRESS
 end
 
 def channel_policy_violation?(channel_id)

--- a/dashboard/legacy/middleware/helpers/profanity_privacy_helper.rb
+++ b/dashboard/legacy/middleware/helpers/profanity_privacy_helper.rb
@@ -19,7 +19,7 @@ BLOCKLY_SOURCE_FILENAME = 'main.json'.freeze unless defined? BLOCKLY_SOURCE_FILE
 def profanity_privacy_violation?(filename, body, project_type)
   return false unless filename == BLOCKLY_SOURCE_FILENAME
   share_failure = share_failure_from_body body, request.locale, project_type
-  share_failure && share_failure.type != ShareFiltering::FailureType::ADDRESS
+  !!share_failure
 end
 
 def channel_policy_violation?(channel_id)

--- a/dashboard/legacy/test/middleware/test_sources.rb
+++ b/dashboard/legacy/test/middleware/test_sources.rb
@@ -274,36 +274,6 @@ class SourcesTest < FilesApiTestBase
     delete_all_source_versions(filename)
   end
 
-  def test_address_violation_does_not_block_channel_backed_project_sharing
-    filename = MAIN_JSON
-    file_data = File.read(File.expand_path('../../fixtures/privacy-profanity/playlab-normal-source.json', __FILE__))
-    file_headers = {'CONTENT_TYPE' => 'application/json'}
-    address = '1600 Pennsylvania Ave NW, Washington, DC 20500'
-    Projects.any_instance.stubs(:get).returns({projectType: 'playlab'})
-    Geocoder.stubs(:find_potential_street_address).returns(address)
-    @api.put_object(filename, file_data, file_headers)
-    assert successful?
-
-    with_session(:non_owner) do
-      non_owner_api = FilesApiTestHelper.new(current_session, 'sources', @channel)
-      non_owner_api.get_object(filename)
-      assert successful?
-    end
-
-    policy_check_response = @api.channel_policy_violation
-    assert successful?
-    assert_equal false, JSON.parse(policy_check_response)['has_violation']
-
-    get "/v3/channels/#{@channel}/share-failure"
-    assert successful?
-    response = JSON.parse(last_response.body)
-    assert_nil response['share_failure']
-
-    assert_newrelic_metrics []
-
-    delete_all_source_versions(filename)
-  end
-
   def test_replace_version
     CDO.expects(:log).never
 

--- a/dashboard/legacy/test/middleware/test_sources.rb
+++ b/dashboard/legacy/test/middleware/test_sources.rb
@@ -274,6 +274,42 @@ class SourcesTest < FilesApiTestBase
     delete_all_source_versions(filename)
   end
 
+  def test_address_violation_does_not_block_channel_backed_project_sharing
+    filename = MAIN_JSON
+    file_data = File.read(File.expand_path('../../fixtures/privacy-profanity/playlab-normal-source.json', __FILE__))
+    file_headers = {'CONTENT_TYPE' => 'application/json'}
+    address = '1600 Pennsylvania Ave NW, Washington, DC 20500'
+    Projects.any_instance.stubs(:get).returns({projectType: 'playlab'})
+    Geocoder.stubs(:find_potential_street_address).returns(address)
+    @api.put_object(filename, file_data, file_headers)
+    assert successful?
+
+    with_session(:non_owner) do
+      non_owner_api = FilesApiTestHelper.new(current_session, 'sources', @channel)
+      non_owner_api.get_object(filename)
+      assert successful?
+    end
+
+    policy_check_response = @api.channel_policy_violation
+    assert successful?
+    assert_equal false, JSON.parse(policy_check_response)['has_violation']
+
+    get "/v3/channels/#{@channel}/share-failure"
+    assert successful?
+    expected_response = {
+      'share_failure' => {
+        'message' => "It looks like there is a street address in it. Try changing the text.",
+        'contents' => address,
+        'type' => 'address'
+      }
+    }
+    assert_equal_expected_keys expected_response, JSON.parse(last_response.body)
+
+    assert_newrelic_metrics []
+
+    delete_all_source_versions(filename)
+  end
+
   def test_replace_version
     CDO.expects(:log).never
 

--- a/dashboard/legacy/test/middleware/test_sources.rb
+++ b/dashboard/legacy/test/middleware/test_sources.rb
@@ -296,14 +296,8 @@ class SourcesTest < FilesApiTestBase
 
     get "/v3/channels/#{@channel}/share-failure"
     assert successful?
-    expected_response = {
-      'share_failure' => {
-        'message' => "It looks like there is a street address in it. Try changing the text.",
-        'contents' => address,
-        'type' => 'address'
-      }
-    }
-    assert_equal_expected_keys expected_response, JSON.parse(last_response.body)
+    response = JSON.parse(last_response.body)
+    assert_nil response['share_failure']
 
     assert_newrelic_metrics []
 

--- a/dashboard/test/controllers/activities_controller_test.rb
+++ b/dashboard/test/controllers/activities_controller_test.rb
@@ -835,6 +835,23 @@ class ActivitiesControllerTest < ActionController::TestCase
     assert_equal_expected_keys expected_response, JSON.parse(@response.body)
   end
 
+  test 'sharing program with street address is allowed' do
+    Geocoder.stubs(:find_potential_street_address).returns('1600 Pennsylvania Ave NW, Washington, DC 20500')
+
+    assert_creates(LevelSource) do
+      post :milestone,
+        params: @milestone_params.merge(
+          script_level_id: @playlab_script_level.id,
+          course_id: @playlab_script.original_unit_group_id,
+          program: studio_program_with_text('1600 Pennsylvania Ave NW, Washington, DC 20500')
+        )
+    end
+    assert_response :success
+    response = JSON.parse(@response.body)
+    assert_nil response['share_failure']
+    refute_nil response['level_source']
+  end
+
   test 'sharing when gatekeeper has disabled sharing does not work' do
     Gatekeeper.set('shareEnabled', where: {script_name: @playlab_script.name}, value: false)
 

--- a/lib/cdo/share_filtering.rb
+++ b/lib/cdo/share_filtering.rb
@@ -184,10 +184,14 @@ module ShareFiltering
     raise PIIFilterException.new("Phone Number PII Filter Violation", share_failure) if share_failure && exceptions
     return share_failure if share_failure
 
-    street_address = Geocoder.find_potential_street_address(text)
-    share_failure = ShareFailure.new(FailureType::ADDRESS, street_address) if street_address
-    raise PIIFilterException.new("Address PII Filter Violation", share_failure) if share_failure && exceptions
-    return share_failure if share_failure
+    # Address filtering is disabled for now because the geocoder-based detector
+    # has too many false positives on student project text.
+    # See https://codedotorg.atlassian.net/browse/SL-1698.
+    #
+    # street_address = Geocoder.find_potential_street_address(text)
+    # share_failure = ShareFailure.new(FailureType::ADDRESS, street_address) if street_address
+    # raise PIIFilterException.new("Address PII Filter Violation", share_failure) if share_failure && exceptions
+    # return share_failure if share_failure
 
     nil
   end

--- a/lib/cdo/share_filtering.rb
+++ b/lib/cdo/share_filtering.rb
@@ -182,16 +182,16 @@ module ShareFiltering
     phone_number = RegexpUtils.find_potential_phone_number(text)
     share_failure = ShareFailure.new(FailureType::PHONE, phone_number) if phone_number
     raise PIIFilterException.new("Phone Number PII Filter Violation", share_failure) if share_failure && exceptions
-    return share_failure if share_failure
 
-    # Address filtering is disabled for now because the geocoder-based detector
+    # TODO: Address filtering is disabled for now because the geocoder-based detector
     # has too many false positives on student project text.
     # See https://codedotorg.atlassian.net/browse/SL-1698.
     #
     # street_address = Geocoder.find_potential_street_address(text)
     # share_failure = ShareFailure.new(FailureType::ADDRESS, street_address) if street_address
     # raise PIIFilterException.new("Address PII Filter Violation", share_failure) if share_failure && exceptions
-    # return share_failure if share_failure
+
+    return share_failure if share_failure
 
     nil
   end

--- a/lib/cdo/share_filtering.rb
+++ b/lib/cdo/share_filtering.rb
@@ -182,6 +182,7 @@ module ShareFiltering
     phone_number = RegexpUtils.find_potential_phone_number(text)
     share_failure = ShareFailure.new(FailureType::PHONE, phone_number) if phone_number
     raise PIIFilterException.new("Phone Number PII Filter Violation", share_failure) if share_failure && exceptions
+    return share_failure if share_failure
 
     # TODO: Address filtering is disabled for now because the geocoder-based detector
     # has too many false positives on student project text.

--- a/lib/test/cdo/test_share_filtering.rb
+++ b/lib/test/cdo/test_share_filtering.rb
@@ -80,23 +80,8 @@ class ShareFilteringTest < Minitest::Test
       'My Street Address',
       '1600 Pennsylvania Ave NW, Washington, DC 20500'
     )
-    assert_equal(
-      ShareFailure.new(
-        ShareFiltering::FailureType::ADDRESS,
-        '1600 Pennsylvania Ave NW, Washington, DC 20500'
-      ),
-      ShareFiltering.find_share_failure(program, 'en', 'playlab')
-    )
-
-    assert_equal(
-      ShareFailure.new(
-        ShareFiltering::FailureType::ADDRESS,
-        '1600 Pennsylvania Ave NW, Washington, DC 20500'
-      ),
-      assert_raises(PIIFilterException) do
-        ShareFiltering.find_share_failure(program, 'en', 'playlab', exceptions: true)
-      end.share_failure
-    )
+    assert_nil ShareFiltering.find_share_failure(program, 'en', 'playlab')
+    assert_nil ShareFiltering.find_share_failure(program, 'en', 'playlab', exceptions: true)
   end
 
   def test_find_share_failure_with_phone_number


### PR DESCRIPTION
Disable address detection in share filtering for now.

The current geocoder-based address filter has a high false-positive rate on student project text, so this change removes `ADDRESS` from active PII detection in `ShareFiltering.find_pii_failure` while leaving the old code commented out with a short `TODO` and a pointer to follow-up work.

This also removes now-redundant address-specific exceptions in downstream share-filter policy code, so the behavior is defined in one place instead of several.

## Links

- Jira: [SL-1698](https://codedotorg.atlassian.net/browse/SL-1698)
- Slack: [student-learning thread about project share false positives](https://codedotorg.slack.com/archives/C03DBDN67B7/p1763490191346999)
- Slack: [ai-in-product thread about Geocoder false positives and possible alternatives](https://codedotorg.slack.com/archives/C04VD4ZB6BT/p1741195538157579)

## Testing story

TODO: Run locally

## Privacy and security

This reduces the set of PII types actively filtered in share filtering by disabling address detection.

Email and phone filtering remain enabled. No new PII is collected, stored, or exposed. This change is intended to reduce false positives from the current geocoder-based address detector.
