### PR TITLE
DSCO migration: SectionsSetUpContainer subheader help link → MUI Button

### DIFF
--- a/apps/src/templates/sectionsRefresh/SectionsSetUpContainer.jsx
+++ b/apps/src/templates/sectionsRefresh/SectionsSetUpContainer.jsx
@@ -423,11 +423,9 @@ export default function SectionsSetUpContainer({
           >
             {i18n.setUpClassSectionsSubheader()}
           </Typography>
-          <Typography variant="body2" gutterBottom>
-            <a onClick={onURLClick} className={moduleStyles.textPopUp}>
-              {i18n.setUpClassSectionsSubheaderLink()}
-            </a>
-          </Typography>
+          <MuiButton color="primary" variant="text" onClick={onURLClick}>
+            {i18n.setUpClassSectionsSubheaderLink()}
+          </MuiButton>
         </>
       )}
       {renderChildAccountPolicyNotification()}

--- a/apps/test/unit/templates/sectionsRefresh/SectionsSetUpContainerTest.jsx
+++ b/apps/test/unit/templates/sectionsRefresh/SectionsSetUpContainerTest.jsx
@@ -40,7 +40,7 @@ describe('SectionsSetUpContainer', () => {
   it('renders headers and button', () => {
     const wrapper = shallow(<SectionsSetUpContainer {...DEFAULT_PROPS} />);
 
-    expect(wrapper.find(MuiButton).length).to.equal(4);
+    expect(wrapper.find(MuiButton).length).to.equal(5);
     expect(wrapper.find(MuiButton).last().props().children).to.equal(
       'Finish creating sections'
     );
@@ -116,13 +116,15 @@ describe('SectionsSetUpContainer', () => {
   it('updates caret direction when Add Coteachers is clicked', () => {
     const wrapper = shallow(<SectionsSetUpContainer {...DEFAULT_PROPS} />);
 
+    // at(0) is the subheader help link (no startIcon); the expandable section
+    // toggles start at at(1): Add Coteachers, then at(2) Advanced Settings.
     const caretIcon = button => button.props().startIcon.props.iconName;
-    expect(caretIcon(wrapper.find(MuiButton).at(0))).to.equal('caret-right');
+    expect(caretIcon(wrapper.find(MuiButton).at(1))).to.equal('caret-right');
     wrapper
       .find(MuiButton)
-      .at(0)
+      .at(1)
       .simulate('click', {preventDefault: () => {}});
-    expect(caretIcon(wrapper.find(MuiButton).at(0))).to.equal('caret-down');
+    expect(caretIcon(wrapper.find(MuiButton).at(1))).to.equal('caret-down');
   });
 
   it('renders advanced settings', () => {
@@ -130,7 +132,7 @@ describe('SectionsSetUpContainer', () => {
 
     wrapper
       .find(MuiButton)
-      .at(1)
+      .at(2)
       .simulate('click', {preventDefault: () => {}});
 
     expect(wrapper.find('AdvancedSettingToggles').length).to.equal(1);
@@ -140,12 +142,12 @@ describe('SectionsSetUpContainer', () => {
     const wrapper = shallow(<SectionsSetUpContainer {...DEFAULT_PROPS} />);
 
     const caretIcon = button => button.props().startIcon.props.iconName;
-    expect(caretIcon(wrapper.find(MuiButton).at(0))).to.equal('caret-right');
+    expect(caretIcon(wrapper.find(MuiButton).at(1))).to.equal('caret-right');
     wrapper
       .find(MuiButton)
-      .at(1)
+      .at(2)
       .simulate('click', {preventDefault: () => {}});
-    expect(caretIcon(wrapper.find(MuiButton).at(1))).to.equal('caret-down');
+    expect(caretIcon(wrapper.find(MuiButton).at(2))).to.equal('caret-down');
   });
 
   it('validates the form when save is clicked', () => {

--- a/apps/test/unit/templates/sectionsRefresh/SectionsSetUpContainerTest.jsx
+++ b/apps/test/unit/templates/sectionsRefresh/SectionsSetUpContainerTest.jsx
@@ -1,3 +1,4 @@
+import Link from '@code-dot-org/component-library/link';
 import {Button as MuiButton} from '@mui/material';
 import {shallow} from 'enzyme'; // eslint-disable-line no-restricted-imports
 import React from 'react';
@@ -40,10 +41,21 @@ describe('SectionsSetUpContainer', () => {
   it('renders headers and button', () => {
     const wrapper = shallow(<SectionsSetUpContainer {...DEFAULT_PROPS} />);
 
-    expect(wrapper.find(MuiButton).length).to.equal(5);
+    expect(wrapper.find(MuiButton).length).to.equal(4);
     expect(wrapper.find(MuiButton).last().props().children).to.equal(
       'Finish creating sections'
     );
+  });
+
+  it('renders the "Why create a class section" Link to the support article', () => {
+    const wrapper = shallow(<SectionsSetUpContainer {...DEFAULT_PROPS} />);
+    const link = wrapper.find(Link);
+
+    expect(link.length).to.equal(1);
+    expect(link.prop('href')).to.include(
+      'support.code.org/hc/en-us/articles/115000488132'
+    );
+    expect(link.prop('openInNewTab')).to.equal(true);
   });
 
   it('renders edit header and save button', () => {


### PR DESCRIPTION
Picks up a leftover legacy pattern in the create-section flow (`apps/src/templates/sectionsRefresh/`) that wasn't covered by the earlier Section Settings pass (#72542).

Before:
<img width="1073" height="246" alt="Знімок екрана 2026-05-11 о 12 54 26" src="https://github.com/user-attachments/assets/533a089e-3e06-44fc-874b-7f41bdcfe4b5" />

After:
<img width="1040" height="333" alt="Знімок екрана 2026-05-28 о 17 54 51" src="https://github.com/user-attachments/assets/aeb8a247-fdc2-400d-85b4-4b1ca345f923" />

https://github.com/user-attachments/assets/f925e854-18d6-4c0f-b342-68b3d7530b3f





## Scope

- **`SectionsSetUpContainer`** — replace the raw `<a onClick>` subheader help link (rendered inside a `<Typography body2>`) with an MUI `Button variant="text"`. Matches the rest of the migrated sectionsRefresh surface and gives the link a real button semantic + keyboard activation instead of an anchor-with-no-href.
- **Test follow-up** — the new MUI Button bumps the `MuiButton` count from 4 to 5 in `SectionsSetUpContainerTest.jsx` and shifts the `at()` indexes used by the caret toggle tests. Counts and indexes updated; comment added pointing the next reader at the new `at(0)` (subheader link, no `startIcon`).

The Assessments-page DSCO migration lives in a separate PR (see Links below).

## Links
- Jira:

## Testing story
- [x] `yarn run typecheck` (apps/) — clean
- [x] `./tools/hooks/pre-commit` — clean
- [x] `yarn test:unit test/unit/templates/sectionsRefresh/SectionsSetUpContainerTest.jsx` — 18/18 pass
- [ ] Manual visual smoke at `/home` "+ New section"
- [ ] Drone run + UI tests

## Deployment notes
Standard merge-and-deploy.

## Privacy and security
None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)