### PR TITLE
Migration to add indices to ai_lesson_summaries table

### DIFF
--- a/dashboard/app/models/ai_lesson_summary.rb
+++ b/dashboard/app/models/ai_lesson_summary.rb
@@ -10,6 +10,11 @@
 #  updated_at     :datetime         not null
 #  script         :text(65535)
 #
+# Indexes
+#
+#  index_ai_lesson_summaries_on_lesson_id              (lesson_id)
+#  index_ai_lesson_summaries_on_user_id_and_lesson_id  (user_id,lesson_id)
+#
 class AiLessonSummary < ApplicationRecord
   belongs_to :user
   belongs_to :lesson

--- a/dashboard/db/migrate/20260512120000_add_indices_to_ai_lesson_summaries.rb
+++ b/dashboard/db/migrate/20260512120000_add_indices_to_ai_lesson_summaries.rb
@@ -1,0 +1,11 @@
+class AddIndicesToAiLessonSummaries < ActiveRecord::Migration[6.1]
+  def change
+    # Most queries filter by both user_id and lesson_id (controller lookups,
+    # find_or_create_by). Leftmost prefix also covers has_many :ai_lesson_summaries
+    # on User, which filters by user_id alone.
+    add_index :ai_lesson_summaries, [:user_id, :lesson_id]
+
+    # Helper queries lesson_id without a user filter when reusing existing scripts.
+    add_index :ai_lesson_summaries, :lesson_id
+  end
+end

--- a/dashboard/db/schema.rb
+++ b/dashboard/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2026_05_06_120000) do
+ActiveRecord::Schema[7.0].define(version: 2026_05_12_120000) do
   create_table "activities", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "user_id"
     t.integer "level_id"
@@ -59,6 +59,8 @@ ActiveRecord::Schema[7.0].define(version: 2026_05_06_120000) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.text "script"
+    t.index ["lesson_id"], name: "index_ai_lesson_summaries_on_lesson_id"
+    t.index ["user_id", "lesson_id"], name: "index_ai_lesson_summaries_on_user_id_and_lesson_id"
   end
 
   create_table "ai_student_podcast_objectives", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|


### PR DESCRIPTION
This migration adds a shared index on user_id and lesson_id and an individual lesson_id to reduce database load

## Links
<!-- Jira tickets, design docs, Slack threads, related PRs, etc. -->
[Slack thread](https://codedotorg.slack.com/archives/C045UAX4WKH/p1778271270398169)
- Jira: [TEACHING-204](https://codedotorg.atlassian.net/browse/TEACHING-204)

## Testing story
<!-- How was this tested? Manual steps, adhoc links, automated tests, or why testing isn't needed. -->



## Deployment notes
<!-- Delete this section if it's a standard merge-and-deploy.
     Otherwise: migrations, feature flags, coordination, caching impacts, etc. -->



## Privacy and security
<!-- Delete this section if there is no privacy/security impact.
     Otherwise: new PII, auth changes, API surface changes, etc. -->

