### PR TITLE
Restore Original Drone Cache

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -300,7 +300,7 @@ steps:
       # DRONE_REPO_OWNER = organization name (e.g., "code-dot-org")
       # DRONE_REPO_NAME = repository name (e.g., "code-dot-org")
       - AUTHENTICATED_GITHUB_URL="https://$GITHUB_TOKEN@github.com/$DRONE_REPO_OWNER/$DRONE_REPO_NAME.git"
-      - git clone --branch $DRONE_BRANCH $AUTHENTICATED_GITHUB_URL .
+      - git clone --branch $DRONE_SOURCE_BRANCH $AUTHENTICATED_GITHUB_URL .
 
   # Do all the work necessary to run UI tests so we can capture a complete
   # snapshot of the fully-built project and resulting database, but don't
@@ -336,10 +336,11 @@ steps:
 
 trigger:
   branch:
-    - "staging"
-    - "staging-next"
+    exclude:
+      - "production"
+      - "levelbuilder"
   event:
-    - push
+    - pull_request
 
 ---
 kind: signature

--- a/.drone.yml
+++ b/.drone.yml
@@ -49,8 +49,7 @@ steps:
   - name: get-cached-staging-build
     image: plugins/s3-cache
     settings:
-      # TODO: restore to cache-staging-ci-build.tar.gz
-      filename: cache-staging-ci-build-external-mysql.tar.gz
+      filename: cache-staging-ci-build.tar.gz
       endpoint: s3://cdo-drone
       restore: true
       debug: true
@@ -172,8 +171,7 @@ steps:
   - name: get-cached-staging-build
     image: plugins/s3-cache
     settings:
-      # TODO: restore to cache-staging-ci-build.tar.gz
-      filename: cache-staging-ci-build-external-mysql.tar.gz
+      filename: cache-staging-ci-build.tar.gz
       endpoint: s3://cdo-drone
       restore: true
       debug: true
@@ -328,8 +326,7 @@ steps:
   - name: cache-staging-ci-build
     image: plugins/s3-cache
     settings:
-      # TODO: restore to cache-staging-ci-build.tar.gz
-      filename: cache-staging-ci-build-external-mysql.tar.gz
+      filename: cache-staging-ci-build.tar.gz
       endpoint: s3://cdo-drone
       rebuild: true
       debug: true
@@ -346,6 +343,6 @@ trigger:
 
 ---
 kind: signature
-hmac: 2589846b59f9c2ec021abb2fd6d2f84fbfff6a7485b8e0df749eed6bd03ff134
+hmac: 8ce0696793d089921698e95d95e86db7a96597b52547e86c5f0553bcd7c66df0
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -300,7 +300,7 @@ steps:
       # DRONE_REPO_OWNER = organization name (e.g., "code-dot-org")
       # DRONE_REPO_NAME = repository name (e.g., "code-dot-org")
       - AUTHENTICATED_GITHUB_URL="https://$GITHUB_TOKEN@github.com/$DRONE_REPO_OWNER/$DRONE_REPO_NAME.git"
-      - git clone --branch $DRONE_SOURCE_BRANCH $AUTHENTICATED_GITHUB_URL .
+      - git clone --branch $DRONE_BRANCH $AUTHENTICATED_GITHUB_URL .
 
   # Do all the work necessary to run UI tests so we can capture a complete
   # snapshot of the fully-built project and resulting database, but don't
@@ -336,11 +336,10 @@ steps:
 
 trigger:
   branch:
-    exclude:
-      - "production"
-      - "levelbuilder"
+    - "staging"
+    - "staging-next"
   event:
-    - pull_request
+    - push
 
 ---
 kind: signature


### PR DESCRIPTION
Follow-up to https://github.com/code-dot-org/code-dot-org/pull/68860, which targeted a temporary cache file to minimize disruption.

I used [a temporary commit](https://github.com/code-dot-org/code-dot-org/commit/f323260e131e7256e0f9d369e2609a829745ec42) to update the original cache file, and the rest of the PR simply targets it.