### PR TITLE
DSCO migration: Assessments page (`/teacher_dashboard/sections/:id/assessments`)

### DIFF
--- a/apps/src/templates/sectionAssessments/FeedbackDownload.jsx
+++ b/apps/src/templates/sectionAssessments/FeedbackDownload.jsx
@@ -1,21 +1,19 @@
-import classNames from 'classnames';
+import FontAwesomeV6Icon from '@code-dot-org/component-library/fontAwesomeV6Icon';
+import {Button as MuiButton} from '@mui/material';
 import PropTypes from 'prop-types';
 import React, {Component} from 'react';
 import {CSVLink} from 'react-csv';
 import {connect} from 'react-redux';
 
-import Button from '@cdo/apps/legacySharedComponents/Button';
-import FontAwesome from '@cdo/apps/legacySharedComponents/FontAwesome';
 import {getSelectedScriptFriendlyName} from '@cdo/apps/redux/unitSelectionRedux';
 import SafeMarkdown from '@cdo/apps/templates/SafeMarkdown';
 import {
   getExportableFeedbackData,
   isCurrentScriptCSD,
 } from '@cdo/apps/templates/sectionAssessments/sectionAssessmentsRedux';
-import color from '@cdo/apps/util/color';
 import i18n from '@cdo/locale';
 
-import moduleStyles from '@cdo/apps/legacySharedComponents/button.module.scss';
+import moduleStyles from './feedback-download.module.scss';
 
 const CSV_FEEDBACK_RUBRIC_HEADERS = [
   {label: i18n.studentName(), key: 'studentName'},
@@ -74,17 +72,12 @@ class FeedbackDownload extends Component {
   render() {
     const {sectionName, exportableFeedbackData, scriptName} = this.props;
 
-    // These allow the CSVLink to be styled as a button
-    let className = classNames(
-      moduleStyles.main,
-      moduleStyles[Button.ButtonColor.gray],
-      moduleStyles['default']
-    );
-
     return (
-      <div>
-        <CSVLink
-          role="button"
+      <div className={moduleStyles.feedbackDownloadContainer}>
+        <MuiButton
+          component={CSVLink}
+          variant="outlined"
+          startIcon={<FontAwesomeV6Icon iconName="download" />}
           filename={i18n.feedbackDownloadFileName({
             sectionName: sectionName,
             scriptName: scriptName,
@@ -92,11 +85,9 @@ class FeedbackDownload extends Component {
           })}
           data={exportableFeedbackData}
           headers={this.headers}
-          style={styles.buttonContainer}
-          className={className}
         >
           {i18n.downloadFeedbackCSV()}
-        </CSVLink>
+        </MuiButton>
         <div>
           <SafeMarkdown
             markdown={i18n.feedbackDownloadOverview({
@@ -105,7 +96,10 @@ class FeedbackDownload extends Component {
             })}
           />
           <p>
-            <FontAwesome icon="check-circle" style={styles.icon} />
+            <FontAwesomeV6Icon
+              iconName="check-circle"
+              className={moduleStyles.checkIcon}
+            />
             {i18n.feedbackDownloadRecommendation()}
           </p>
         </div>
@@ -113,17 +107,6 @@ class FeedbackDownload extends Component {
     );
   }
 }
-
-const styles = {
-  icon: {
-    color: color.purple,
-    paddingRight: 5,
-  },
-  buttonContainer: {
-    padding: '12px 24px',
-    lineHeight: '10px',
-  },
-};
 
 export const UnconnectedFeedbackDownload = FeedbackDownload;
 

--- a/apps/src/templates/sectionAssessments/FreeResponseDetailsDialog.jsx
+++ b/apps/src/templates/sectionAssessments/FreeResponseDetailsDialog.jsx
@@ -1,11 +1,9 @@
+import Dialog from '@code-dot-org/component-library/dialog';
 import PropTypes from 'prop-types';
 import React, {Component} from 'react';
 import {connect} from 'react-redux';
 
-import Button from '@cdo/apps/legacySharedComponents/Button';
-import BaseDialog from '@cdo/apps/templates/BaseDialog';
 import SafeMarkdown from '@cdo/apps/templates/SafeMarkdown';
-import DialogFooter from '@cdo/apps/templates/teacherDashboard/DialogFooter';
 import i18n from '@cdo/locale';
 
 import {getCurrentQuestion} from './sectionAssessmentsRedux';
@@ -18,41 +16,25 @@ class FreeResponseDetailsDialog extends Component {
   };
 
   render() {
-    // Questions are in markdown format and should not display as plain text in the dialog.
+    const {isDialogOpen, closeDialog, questionAndAnswers} = this.props;
+
+    if (!isDialogOpen) return null;
 
     return (
-      <BaseDialog
-        useUpdatedStyles
-        isOpen={this.props.isDialogOpen}
-        style={styles.dialog}
-        handleClose={this.props.closeDialog}
-      >
-        <h2>{i18n.questionText()}</h2>
-        <div style={styles.instructions}>
-          <SafeMarkdown markdown={this.props.questionAndAnswers.question} />
-        </div>
-        <DialogFooter>
-          <Button
-            text={i18n.done()}
-            onClick={this.props.closeDialog}
-            color={Button.ButtonColor.gray}
-          />
-        </DialogFooter>
-      </BaseDialog>
+      <Dialog
+        title={i18n.questionText()}
+        customContent={<SafeMarkdown markdown={questionAndAnswers.question} />}
+        onClose={closeDialog}
+        primaryButtonProps={{
+          onClick: closeDialog,
+          variant: 'contained',
+          color: 'primary',
+          children: i18n.done(),
+        }}
+      />
     );
   }
 }
-
-const styles = {
-  dialog: {
-    paddingLeft: 20,
-    paddingRight: 20,
-    paddingBottom: 20,
-  },
-  instructions: {
-    marginTop: 20,
-  },
-};
 
 export const UnconnectedFreeResponseDetailsDialog = FreeResponseDetailsDialog;
 

--- a/apps/src/templates/sectionAssessments/FreeResponsesAssessmentsContainer.jsx
+++ b/apps/src/templates/sectionAssessments/FreeResponsesAssessmentsContainer.jsx
@@ -54,10 +54,12 @@ class FreeResponsesAssessmentsContainer extends Component {
             {freeResponseQuestions.map((question, index) => (
               <div key={index}>
                 <div className={moduleStyles.questionLabel}>
-                  {`${question.questionNumber}. ${question.questionText.slice(
-                    0,
-                    QUESTION_CHARACTER_LIMIT
-                  )}`}
+                  <Typography variant="body3">
+                    {`${question.questionNumber}. ${question.questionText.slice(
+                      0,
+                      QUESTION_CHARACTER_LIMIT
+                    )}`}
+                  </Typography>
                   {question.questionText.length >= QUESTION_CHARACTER_LIMIT && (
                     <Link
                       size="s"

--- a/apps/src/templates/sectionAssessments/FreeResponsesAssessmentsContainer.jsx
+++ b/apps/src/templates/sectionAssessments/FreeResponsesAssessmentsContainer.jsx
@@ -1,3 +1,5 @@
+import Link from '@code-dot-org/component-library/link';
+import {Typography} from '@mui/material';
 import PropTypes from 'prop-types';
 import React, {Component} from 'react';
 import {connect} from 'react-redux';
@@ -15,6 +17,8 @@ import {
   currentStudentHasResponses,
   setQuestionIndex,
 } from './sectionAssessmentsRedux';
+
+import moduleStyles from './free-responses-container.module.scss';
 
 export const freeResponseSummaryPropType = PropTypes.shape({
   questionText: PropTypes.string,
@@ -43,23 +47,29 @@ class FreeResponsesAssessmentsContainer extends Component {
         {(studentId === ALL_STUDENT_FILTER || currentStudentHasResponses) && (
           <div>
             {freeResponseQuestions.length > 0 && (
-              <h2>{i18n.studentFreeResponseAnswers()}</h2>
+              <Typography variant="h2">
+                {i18n.studentFreeResponseAnswers()}
+              </Typography>
             )}
             {freeResponseQuestions.map((question, index) => (
               <div key={index}>
-                <div style={styles.text}>
+                <div className={moduleStyles.questionLabel}>
                   {`${question.questionNumber}. ${question.questionText.slice(
                     0,
                     QUESTION_CHARACTER_LIMIT
                   )}`}
                   {question.questionText.length >= QUESTION_CHARACTER_LIMIT && (
-                    <a
-                      onClick={() => {
+                    <Link
+                      size="s"
+                      onClick={e => {
+                        // Link defaults href to "#"; suppress the page-top jump
+                        // since this opens a modal rather than navigating.
+                        e.preventDefault();
                         this.selectQuestion(question.questionNumber - 1);
                       }}
                     >
-                      <span>{i18n.seeFullQuestion()}</span>
-                    </a>
+                      {i18n.seeFullQuestion()}
+                    </Link>
                   )}
                 </div>
                 <FreeResponsesAssessmentsTable
@@ -73,14 +83,6 @@ class FreeResponsesAssessmentsContainer extends Component {
     );
   }
 }
-
-const styles = {
-  text: {
-    font: 10,
-    paddingTop: 20,
-    paddingBottom: 20,
-  },
-};
 
 export const UnconnectedFreeResponsesAssessmentsContainer =
   FreeResponsesAssessmentsContainer;

--- a/apps/src/templates/sectionAssessments/FreeResponsesAssessmentsTable.jsx
+++ b/apps/src/templates/sectionAssessments/FreeResponsesAssessmentsTable.jsx
@@ -1,3 +1,4 @@
+import {Typography} from '@mui/material';
 import orderBy from 'lodash/orderBy';
 import PropTypes from 'prop-types';
 import React, {Component} from 'react';
@@ -51,11 +52,13 @@ class FreeResponsesAssessmentsTable extends Component {
   responseCellFormatter = (response, {rowData, rowIndex}) => {
     return (
       <div>
-        {response && <div className={moduleStyles.response}>{response}</div>}
+        {response && (
+          <Typography variant="body3" className={moduleStyles.response}>
+            {response}
+          </Typography>
+        )}
         {!response && (
-          <div className={moduleStyles.noResponse}>
-            {i18n.emptyFreeResponse()}
-          </div>
+          <Typography vartiant="body3">{i18n.emptyFreeResponse()}</Typography>
         )}
       </div>
     );

--- a/apps/src/templates/sectionAssessments/FreeResponsesAssessmentsTable.jsx
+++ b/apps/src/templates/sectionAssessments/FreeResponsesAssessmentsTable.jsx
@@ -4,7 +4,6 @@ import React, {Component} from 'react';
 import * as Table from 'reactabular-table';
 import * as sort from 'sortabular';
 
-import color from '@cdo/apps/util/color';
 import i18n from '@cdo/locale';
 
 import {tableLayoutStyles, sortableOptions} from '../tables/tableConstants';
@@ -12,7 +11,7 @@ import wrappedSortable from '../tables/wrapped_sortable';
 
 import {freeResponsesDataPropType} from './assessmentDataShapes';
 
-const PADDING = 15;
+import moduleStyles from './free-responses-table.module.scss';
 
 export const COLUMNS = {
   NAME: 0,
@@ -52,9 +51,11 @@ class FreeResponsesAssessmentsTable extends Component {
   responseCellFormatter = (response, {rowData, rowIndex}) => {
     return (
       <div>
-        {response && <div style={styles.response}>{response}</div>}
+        {response && <div className={moduleStyles.response}>{response}</div>}
         {!response && (
-          <div style={styles.noResponse}>{i18n.emptyFreeResponse()}</div>
+          <div className={moduleStyles.noResponse}>
+            {i18n.emptyFreeResponse()}
+          </div>
         )}
       </div>
     );
@@ -67,19 +68,15 @@ class FreeResponsesAssessmentsTable extends Component {
         header: {
           label: i18n.studentName(),
           props: {
-            style: {
-              ...tableLayoutStyles.headerCell,
-              ...styles.studentNameColumnHeader,
-            },
+            style: tableLayoutStyles.headerCell,
+            className: moduleStyles.studentNameHeaderCell,
           },
           transforms: [sortable],
         },
         cell: {
           props: {
-            style: {
-              ...tableLayoutStyles.cell,
-              ...styles.studentNameColumnCell,
-            },
+            style: tableLayoutStyles.cell,
+            className: moduleStyles.studentNameCell,
           },
         },
       },
@@ -87,12 +84,7 @@ class FreeResponsesAssessmentsTable extends Component {
         property: 'response',
         header: {
           label: i18n.response(),
-          props: {
-            style: {
-              ...tableLayoutStyles.headerCell,
-              ...styles.responseHeaderCell,
-            },
-          },
+          props: {style: tableLayoutStyles.headerCell},
         },
         cell: {
           formatters: [this.responseCellFormatter],
@@ -127,28 +119,5 @@ class FreeResponsesAssessmentsTable extends Component {
     );
   }
 }
-
-const styles = {
-  studentNameColumnHeader: {
-    padding: PADDING,
-  },
-  studentNameColumnCell: {
-    textOverflow: 'ellipsis',
-    whiteSpace: 'nowrap',
-    overflow: 'hidden',
-    maxWidth: 200,
-    padding: PADDING,
-    verticalAlign: 'top',
-  },
-  responseColumnHeader: {
-    padding: PADDING,
-  },
-  noResponse: {
-    color: color.lighter_gray,
-  },
-  response: {
-    whiteSpace: 'pre-wrap',
-  },
-};
 
 export default FreeResponsesAssessmentsTable;

--- a/apps/src/templates/sectionAssessments/FreeResponsesSurveyContainer.jsx
+++ b/apps/src/templates/sectionAssessments/FreeResponsesSurveyContainer.jsx
@@ -1,3 +1,5 @@
+import Link from '@code-dot-org/component-library/link';
+import {Typography} from '@mui/material';
 import PropTypes from 'prop-types';
 import React, {Component} from 'react';
 import {connect} from 'react-redux';
@@ -10,6 +12,8 @@ import {
   getSurveyFreeResponseQuestions,
   setQuestionIndex,
 } from './sectionAssessmentsRedux';
+
+import moduleStyles from './free-responses-container.module.scss';
 
 const freeResponseQuestionsPropType = PropTypes.shape({
   questionNumber: PropTypes.number,
@@ -33,22 +37,30 @@ class FreeResponsesSurveyContainer extends Component {
     const {freeResponsesByQuestion} = this.props;
     return (
       <div>
-        <h2>{i18n.studentFreeResponseAnswers()}</h2>
+        <Typography variant="h2">
+          {i18n.studentFreeResponseAnswers()}
+        </Typography>
         {freeResponsesByQuestion.map((question, index) => (
           <div key={index}>
-            <div style={styles.text}>
-              {`${question.questionNumber}. ${question.questionText.slice(
-                0,
-                QUESTION_CHARACTER_LIMIT
-              )}`}
+            <div className={moduleStyles.questionLabel}>
+              <Typography variant="body3">
+                {`${question.questionNumber}. ${question.questionText.slice(
+                  0,
+                  QUESTION_CHARACTER_LIMIT
+                )}`}
+              </Typography>
               {question.questionText.length >= QUESTION_CHARACTER_LIMIT && (
-                <a
-                  onClick={() => {
+                <Link
+                  size="s"
+                  onClick={e => {
+                    // Link defaults href to "#"; suppress the page-top jump
+                    // since this opens a modal rather than navigating.
+                    e.preventDefault();
                     this.selectQuestion(question.questionNumber - 1);
                   }}
                 >
-                  <span>{i18n.seeFullQuestion()}</span>
-                </a>
+                  {i18n.seeFullQuestion()}
+                </Link>
               )}
             </div>
             <FreeResponsesSurveyTable freeResponses={question.answers} />
@@ -58,14 +70,6 @@ class FreeResponsesSurveyContainer extends Component {
     );
   }
 }
-
-const styles = {
-  text: {
-    font: 10,
-    paddingTop: 20,
-    paddingBottom: 20,
-  },
-};
 
 export const UnconnectedFreeResponsesSurveyContainer =
   FreeResponsesSurveyContainer;

--- a/apps/src/templates/sectionAssessments/FreeResponsesSurveyTable.jsx
+++ b/apps/src/templates/sectionAssessments/FreeResponsesSurveyTable.jsx
@@ -1,10 +1,10 @@
+import {Typography} from '@mui/material';
 import orderBy from 'lodash/orderBy';
 import PropTypes from 'prop-types';
 import React, {Component} from 'react';
 import * as Table from 'reactabular-table';
 import * as sort from 'sortabular';
 
-import color from '@cdo/apps/util/color';
 import i18n from '@cdo/locale';
 
 import {tableLayoutStyles, sortableOptions} from '../tables/tableConstants';
@@ -51,9 +51,9 @@ class FreeResponsesSurveyTable extends Component {
   studentResponseColumnFormatter = (response, {rowIndex}) => {
     return (
       <div>
-        {response && <div>{response}</div>}
+        {response && <Typography variant="body3">{response}</Typography>}
         {!response && (
-          <div style={styles.noResponse}>{i18n.emptyFreeResponse()}</div>
+          <Typography variant="body3">{i18n.emptyFreeResponse()}</Typography>
         )}
       </div>
     );
@@ -100,11 +100,5 @@ class FreeResponsesSurveyTable extends Component {
     );
   }
 }
-
-const styles = {
-  noResponse: {
-    color: color.lighter_gray,
-  },
-};
 
 export default FreeResponsesSurveyTable;

--- a/apps/src/templates/sectionAssessments/MatchAssessmentsOverviewContainer.jsx
+++ b/apps/src/templates/sectionAssessments/MatchAssessmentsOverviewContainer.jsx
@@ -1,3 +1,5 @@
+import Link from '@code-dot-org/component-library/link';
+import {Typography} from '@mui/material';
 import PropTypes from 'prop-types';
 import React, {Component} from 'react';
 import {connect} from 'react-redux';
@@ -15,6 +17,8 @@ import {
   ALL_STUDENT_FILTER,
   setQuestionIndex,
 } from './sectionAssessmentsRedux';
+
+import moduleStyles from './match-overview-container.module.scss';
 
 class MatchAssessmentsOverviewContainer extends Component {
   static propTypes = {
@@ -43,26 +47,30 @@ class MatchAssessmentsOverviewContainer extends Component {
       <div>
         {questionAnswerData.length > 0 && studentId === ALL_STUDENT_FILTER && (
           <div>
-            <h2>
+            <Typography variant="h2">
               {i18n.matchQuestionsOverview({
                 numSubmissions: totalStudentSubmissions,
                 numStudents: totalStudentCount,
               })}
-            </h2>
+            </Typography>
             {questionAnswerData.map((question, index) => (
               <div key={index}>
-                <div style={styles.text}>
+                <div className={moduleStyles.questionLabel}>
                   {`${question.questionNumber}. ${question.question.slice(
                     0,
                     QUESTION_CHARACTER_LIMIT
                   )}`}
-                  <a
-                    onClick={() => {
+                  <Link
+                    size="s"
+                    onClick={e => {
+                      // Link defaults href to "#"; suppress the page-top jump
+                      // since this opens a modal rather than navigating.
+                      e.preventDefault();
                       this.selectQuestion(question.questionNumber - 1);
                     }}
                   >
-                    <span>{i18n.seeFullQuestion()}</span>
-                  </a>
+                    {i18n.seeFullQuestion()}
+                  </Link>
                 </div>
                 <MatchAssessmentsOverviewTable
                   questionAnswerData={question.options}
@@ -75,14 +83,6 @@ class MatchAssessmentsOverviewContainer extends Component {
     );
   }
 }
-
-const styles = {
-  text: {
-    font: 10,
-    paddingTop: 20,
-    paddingBottom: 20,
-  },
-};
 
 export const UnconnectedMatchAssessmentsOverviewContainer =
   MatchAssessmentsOverviewContainer;

--- a/apps/src/templates/sectionAssessments/MatchAssessmentsOverviewTable.jsx
+++ b/apps/src/templates/sectionAssessments/MatchAssessmentsOverviewTable.jsx
@@ -16,6 +16,8 @@ import {optionDataPropTypeMatch} from './assessmentDataShapes';
 import PercentAnsweredCell from './PercentAnsweredCell';
 import {setQuestionIndex} from './sectionAssessmentsRedux';
 
+import moduleStyles from './match-overview-table.module.scss';
+
 export const COLUMNS = {
   OPTION: 0,
 };
@@ -159,11 +161,11 @@ class MatchAssessmentsOverviewTable extends Component {
       props: {
         style: {
           ...tableLayoutStyles.cell,
-          ...styles.questionCell,
           maxWidth:
             styleConstants['content-width'] -
             numAnswers * (ANSWER_COLUMN_WIDTH + PADDING),
         },
+        className: moduleStyles.optionCell,
       },
     },
   });
@@ -239,11 +241,6 @@ const styles = {
   notAnsweredCell: {
     padding: 0,
     height: 40,
-  },
-  questionCell: {
-    overflow: 'hidden',
-    textOverflow: 'ellipsis',
-    whiteSpace: 'nowrap',
   },
 };
 

--- a/apps/src/templates/sectionAssessments/MatchByStudentContainer.jsx
+++ b/apps/src/templates/sectionAssessments/MatchByStudentContainer.jsx
@@ -1,3 +1,5 @@
+import Link from '@code-dot-org/component-library/link';
+import {Typography} from '@mui/material';
 import PropTypes from 'prop-types';
 import React, {Component} from 'react';
 import {connect} from 'react-redux';
@@ -17,6 +19,8 @@ import {
   currentStudentHasResponses,
   setQuestionIndex,
 } from './sectionAssessmentsRedux';
+
+import moduleStyles from './match-by-student-container.module.scss';
 
 class MatchByStudentContainer extends Component {
   static propTypes = {
@@ -44,26 +48,30 @@ class MatchByStudentContainer extends Component {
       <div>
         {studentId !== ALL_STUDENT_FILTER && currentStudentHasResponses && (
           <div>
-            <h2>
+            <Typography variant="h2">
               {i18n.matchStudentOverview({
                 studentName: studentAnswerData.name,
               })}
-            </h2>
+            </Typography>
             {matchStructure.map((question, index) => (
               <div key={index}>
-                <div style={styles.text}>
+                <div className={moduleStyles.questionLabel}>
                   {`${question.questionNumber}. ${question.question.slice(
                     0,
                     QUESTION_CHARACTER_LIMIT
                   )}`}
                   {question.question.length >= QUESTION_CHARACTER_LIMIT && (
-                    <a
-                      onClick={() => {
+                    <Link
+                      size="s"
+                      onClick={e => {
+                        // Link defaults href to "#"; suppress the page-top jump
+                        // since this opens a modal rather than navigating.
+                        e.preventDefault();
                         this.selectQuestion(question.questionNumber - 1);
                       }}
                     >
-                      <span>{i18n.seeFullQuestion()}</span>
-                    </a>
+                      {i18n.seeFullQuestion()}
+                    </Link>
                   )}
                 </div>
                 <MatchByStudentTable
@@ -78,14 +86,6 @@ class MatchByStudentContainer extends Component {
     );
   }
 }
-
-const styles = {
-  text: {
-    font: 10,
-    paddingTop: 20,
-    paddingBottom: 20,
-  },
-};
 
 export const UnconnectedMatchByStudentContainer = MatchByStudentContainer;
 

--- a/apps/src/templates/sectionAssessments/MatchByStudentTable.jsx
+++ b/apps/src/templates/sectionAssessments/MatchByStudentTable.jsx
@@ -14,6 +14,8 @@ import {
 } from './assessmentDataShapes';
 import PercentAnsweredCell from './PercentAnsweredCell';
 
+import moduleStyles from './match-by-student-table.module.scss';
+
 export const COLUMNS = {
   OPTION: 0,
   STUDENT_ANSWER: 1,
@@ -88,10 +90,8 @@ class MatchByStudentTable extends Component {
         cell: {
           formatters: [this.optionCellFormatter],
           props: {
-            style: {
-              ...tableLayoutStyles.cell,
-              ...styles.optionCell,
-            },
+            style: tableLayoutStyles.cell,
+            className: moduleStyles.optionCell,
           },
         },
       },
@@ -189,12 +189,6 @@ const styles = {
   },
   answerColumnCell: {
     width: ANSWER_COLUMN_WIDTH,
-  },
-  optionCell: {
-    overflow: 'hidden',
-    textOverflow: 'ellipsis',
-    whiteSpace: 'nowrap',
-    maxWidth: 470,
   },
 };
 

--- a/apps/src/templates/sectionAssessments/MatchDetailsDialog.jsx
+++ b/apps/src/templates/sectionAssessments/MatchDetailsDialog.jsx
@@ -1,15 +1,15 @@
+import Dialog from '@code-dot-org/component-library/dialog';
 import PropTypes from 'prop-types';
 import React, {Component} from 'react';
 import {connect} from 'react-redux';
 
-import Button from '@cdo/apps/legacySharedComponents/Button';
-import BaseDialog from '@cdo/apps/templates/BaseDialog';
 import SafeMarkdown from '@cdo/apps/templates/SafeMarkdown';
-import DialogFooter from '@cdo/apps/templates/teacherDashboard/DialogFooter';
 import i18n from '@cdo/locale';
 
 import {matchDetailsQuestionPropType} from './assessmentDataShapes';
 import {getCurrentQuestion, QuestionType} from './sectionAssessmentsRedux';
+
+import moduleStyles from './details-dialog.module.scss';
 
 class MatchDetailsDialog extends Component {
   static propTypes = {
@@ -18,82 +18,66 @@ class MatchDetailsDialog extends Component {
     questionAndAnswers: matchDetailsQuestionPropType,
   };
 
-  render() {
+  renderContent() {
     const {questionAndAnswers} = this.props;
 
+    if (questionAndAnswers.questionType !== QuestionType.MATCH) {
+      return null;
+    }
+
     return (
-      <BaseDialog
-        useUpdatedStyles
-        isOpen={this.props.isDialogOpen}
-        style={styles.dialog}
-        handleClose={this.props.closeDialog}
-      >
-        {questionAndAnswers.questionType === QuestionType.MATCH && (
-          <div>
-            <h2>{i18n.questionDetails()}</h2>
-            <div style={styles.instructions}>
-              <SafeMarkdown markdown={questionAndAnswers.question} />
-            </div>
-            {questionAndAnswers.answers &&
-              questionAndAnswers.options &&
-              questionAndAnswers.answers.length > 0 && (
-                <table>
-                  <thead>
-                    <tr>
-                      <th>{i18n.option()}</th>
-                      <th>{i18n.answer()}</th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    {questionAndAnswers.answers.map((answer, index) => {
-                      return (
-                        <tr key={index}>
-                          <td>
-                            <div style={styles.answers}>
-                              <SafeMarkdown
-                                markdown={questionAndAnswers.options[index]}
-                              />
-                            </div>
-                          </td>
-                          <td>
-                            <div style={styles.answers}>
-                              <SafeMarkdown markdown={answer} />
-                            </div>
-                          </td>
-                        </tr>
-                      );
-                    })}
-                  </tbody>
-                </table>
-              )}
-          </div>
-        )}
-        <DialogFooter>
-          <Button
-            text={i18n.done()}
-            onClick={this.props.closeDialog}
-            color={Button.ButtonColor.gray}
-          />
-        </DialogFooter>
-      </BaseDialog>
+      <div>
+        <SafeMarkdown markdown={questionAndAnswers.question} />
+        {questionAndAnswers.answers &&
+          questionAndAnswers.options &&
+          questionAndAnswers.answers.length > 0 && (
+            <table className={moduleStyles.matchTable}>
+              <thead>
+                <tr>
+                  <th>{i18n.option()}</th>
+                  <th>{i18n.answer()}</th>
+                </tr>
+              </thead>
+              <tbody>
+                {questionAndAnswers.answers.map((answer, index) => (
+                  <tr key={index}>
+                    <td>
+                      <SafeMarkdown
+                        markdown={questionAndAnswers.options[index]}
+                      />
+                    </td>
+                    <td>
+                      <SafeMarkdown markdown={answer} />
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          )}
+      </div>
+    );
+  }
+
+  render() {
+    const {isDialogOpen, closeDialog} = this.props;
+
+    if (!isDialogOpen) return null;
+
+    return (
+      <Dialog
+        title={i18n.questionDetails()}
+        customContent={this.renderContent()}
+        onClose={closeDialog}
+        primaryButtonProps={{
+          onClick: closeDialog,
+          variant: 'contained',
+          color: 'primary',
+          children: i18n.done(),
+        }}
+      />
     );
   }
 }
-
-const styles = {
-  dialog: {
-    paddingLeft: 20,
-    paddingRight: 20,
-    paddingBottom: 20,
-  },
-  instructions: {
-    marginTop: 20,
-  },
-  answers: {
-    float: 'left',
-    width: 250,
-  },
-};
 
 export const UnconnectedMatchDetailsDialog = MatchDetailsDialog;
 

--- a/apps/src/templates/sectionAssessments/MultipleChoiceAssessmentsOverviewContainer.jsx
+++ b/apps/src/templates/sectionAssessments/MultipleChoiceAssessmentsOverviewContainer.jsx
@@ -1,3 +1,4 @@
+import {Typography} from '@mui/material';
 import PropTypes from 'prop-types';
 import React, {Component} from 'react';
 import {connect} from 'react-redux';
@@ -32,12 +33,12 @@ class MultipleChoiceAssessmentsOverviewContainer extends Component {
       <div>
         {questionAnswerData.length > 0 && studentId === ALL_STUDENT_FILTER && (
           <div>
-            <h2>
+            <Typography variant="h2" component="h2" gutterBottom>
               {i18n.multipleChoiceQuestionsOverview({
                 numSubmissions: totalStudentSubmissions,
                 numStudents: totalStudentCount,
               })}
-            </h2>
+            </Typography>
             <MultipleChoiceAssessmentsOverviewTable
               questionAnswerData={questionAnswerData}
               openDialog={this.props.openDialog}

--- a/apps/src/templates/sectionAssessments/MultipleChoiceAssessmentsOverviewTable.jsx
+++ b/apps/src/templates/sectionAssessments/MultipleChoiceAssessmentsOverviewTable.jsx
@@ -1,3 +1,4 @@
+import Link from '@code-dot-org/component-library/link';
 import orderBy from 'lodash/orderBy';
 import PropTypes from 'prop-types';
 import React, {Component} from 'react';
@@ -6,7 +7,6 @@ import * as Table from 'reactabular-table';
 import * as sort from 'sortabular';
 
 import styleConstants from '@cdo/apps/styleConstants';
-import color from '@cdo/apps/util/color';
 import i18n from '@cdo/locale';
 
 import {tableLayoutStyles, sortableOptions} from '../tables/tableConstants';
@@ -15,6 +15,8 @@ import wrappedSortable from '../tables/wrapped_sortable';
 import {multipleChoiceDataPropType} from './assessmentDataShapes';
 import PercentAnsweredCell from './PercentAnsweredCell';
 import {setQuestionIndex} from './sectionAssessmentsRedux';
+
+import moduleStyles from './multiple-choice-overview-table.module.scss';
 
 export const COLUMNS = {
   QUESTION: 0,
@@ -100,12 +102,18 @@ class MultipleChoiceAssessmentsOverviewTable extends Component {
   ) => {
     return (
       <div>
-        <a
-          style={styles.link}
-          onClick={() => this.selectQuestion(rowData.questionNumber - 1)}
+        <Link
+          size="s"
+          className={moduleStyles.questionLink}
+          onClick={e => {
+            // Link defaults href to "#"; suppress the page-top jump since this
+            // really opens a modal rather than navigating.
+            e.preventDefault();
+            this.selectQuestion(rowData.questionNumber - 1);
+          }}
         >
           {`${rowData.questionNumber}. ${question}`}
-        </a>
+        </Link>
       </div>
     );
   };
@@ -231,13 +239,6 @@ const styles = {
   notAnsweredCell: {
     padding: 0,
     height: 40,
-  },
-  link: {
-    color: color.teal,
-    display: 'block',
-    overflow: 'hidden',
-    textOverflow: 'ellipsis',
-    whiteSpace: 'nowrap',
   },
 };
 

--- a/apps/src/templates/sectionAssessments/MultipleChoiceByStudentContainer.jsx
+++ b/apps/src/templates/sectionAssessments/MultipleChoiceByStudentContainer.jsx
@@ -1,3 +1,4 @@
+import {Typography} from '@mui/material';
 import PropTypes from 'prop-types';
 import React, {Component} from 'react';
 import {connect} from 'react-redux';
@@ -35,11 +36,11 @@ class MultipleChoiceByStudentContainer extends Component {
       <div>
         {studentId !== ALL_STUDENT_FILTER && currentStudentHasResponses && (
           <div>
-            <h2>
+            <Typography variant="h2">
               {i18n.multipleChoiceStudentOverview({
                 studentName: studentAnswerData.name,
               })}
-            </h2>
+            </Typography>
             <MultipleChoiceByStudentTable
               questionAnswerData={multipleChoiceStructure}
               studentAnswerData={studentAnswerData}

--- a/apps/src/templates/sectionAssessments/MultipleChoiceByStudentTable.jsx
+++ b/apps/src/templates/sectionAssessments/MultipleChoiceByStudentTable.jsx
@@ -15,6 +15,8 @@ import {
 } from './assessmentDataShapes';
 import PercentAnsweredCell from './PercentAnsweredCell';
 
+import moduleStyles from './multiple-choice-by-student-table.module.scss';
+
 export const COLUMNS = {
   QUESTION: 0,
   STUDENT_ANSWER: 1,
@@ -93,10 +95,8 @@ class MultipleChoiceByStudentTable extends Component {
         cell: {
           formatters: [this.questionCellFormatter],
           props: {
-            style: {
-              ...tableLayoutStyles.cell,
-              ...styles.questionCell,
-            },
+            style: tableLayoutStyles.cell,
+            className: moduleStyles.questionCell,
           },
         },
       },
@@ -185,12 +185,6 @@ const styles = {
   },
   answerColumnCell: {
     width: ANSWER_COLUMN_WIDTH,
-  },
-  questionCell: {
-    overflow: 'hidden',
-    textOverflow: 'ellipsis',
-    whiteSpace: 'nowrap',
-    maxWidth: 470,
   },
 };
 

--- a/apps/src/templates/sectionAssessments/MultipleChoiceDetailsDialog.jsx
+++ b/apps/src/templates/sectionAssessments/MultipleChoiceDetailsDialog.jsx
@@ -1,13 +1,10 @@
+import Dialog from '@code-dot-org/component-library/dialog';
+import FontAwesomeV6Icon from '@code-dot-org/component-library/fontAwesomeV6Icon';
 import PropTypes from 'prop-types';
 import React, {Component} from 'react';
 import {connect} from 'react-redux';
 
-import Button from '@cdo/apps/legacySharedComponents/Button';
-import FontAwesome from '@cdo/apps/legacySharedComponents/FontAwesome';
-import BaseDialog from '@cdo/apps/templates/BaseDialog';
 import SafeMarkdown from '@cdo/apps/templates/SafeMarkdown';
-import DialogFooter from '@cdo/apps/templates/teacherDashboard/DialogFooter';
-import color from '@cdo/apps/util/color';
 import i18n from '@cdo/locale';
 
 import MultipleChoiceByQuestionTable from './MultipleChoiceByQuestionTable';
@@ -17,6 +14,8 @@ import {
   QuestionType,
 } from './sectionAssessmentsRedux';
 
+import moduleStyles from './details-dialog.module.scss';
+
 class MultipleChoiceDetailsDialog extends Component {
   static propTypes = {
     isDialogOpen: PropTypes.bool.isRequired,
@@ -25,94 +24,69 @@ class MultipleChoiceDetailsDialog extends Component {
     studentAnswers: PropTypes.array,
   };
 
-  render() {
+  renderContent() {
     const {questionAndAnswers, studentAnswers} = this.props;
 
-    // Questions are in markdown format and should not display as plain text in the dialog.
+    if (questionAndAnswers.questionType !== QuestionType.MULTI) {
+      return null;
+    }
 
     return (
-      <BaseDialog
-        useUpdatedStyles
-        isOpen={this.props.isDialogOpen}
-        style={styles.dialog}
-        handleClose={this.props.closeDialog}
-      >
-        {questionAndAnswers.questionType === QuestionType.MULTI && (
-          <div>
-            <h2>{i18n.questionDetails()}</h2>
-            <div style={styles.instructions}>
-              <SafeMarkdown markdown={questionAndAnswers.question} />
-            </div>
-            {questionAndAnswers.answers &&
-              questionAndAnswers.answers.length > 0 && (
-                <div>
-                  {questionAndAnswers.answers.map((answer, index) => {
-                    return (
-                      <div key={index} style={styles.answerBlock}>
-                        <div style={styles.iconSpace}>
-                          {answer.correct && (
-                            <FontAwesome
-                              icon="check-circle"
-                              style={styles.icon}
-                            />
-                          )}
-                          {!answer.correct && <span>&nbsp;</span>}
-                        </div>
-                        <div style={styles.answerLetter}>{answer.letter}</div>
-                        <div style={styles.answers} />
-                        <SafeMarkdown markdown={answer.text} />
-                        <div style={{clear: 'both'}} />
-                      </div>
-                    );
-                  })}
+      <div>
+        <SafeMarkdown
+          className={moduleStyles.multipleChoiceDetailsQuestion}
+          markdown={questionAndAnswers.question}
+        />
+        {questionAndAnswers.answers &&
+          questionAndAnswers.answers.length > 0 && (
+            <div>
+              {questionAndAnswers.answers.map((answer, index) => (
+                <div key={index} className={moduleStyles.answerBlock}>
+                  <div className={moduleStyles.iconColumn}>
+                    {answer.correct && (
+                      <FontAwesomeV6Icon
+                        iconName="check-circle"
+                        className={moduleStyles.correctIcon}
+                      />
+                    )}
+                  </div>
+                  <div className={moduleStyles.answerLetter}>
+                    {answer.letter}
+                  </div>
+                  <div className={moduleStyles.answerBody}>
+                    <SafeMarkdown markdown={answer.text} />
+                  </div>
                 </div>
-              )}
-            {studentAnswers && studentAnswers.length > 0 && (
-              <MultipleChoiceByQuestionTable studentAnswers={studentAnswers} />
-            )}
-          </div>
+              ))}
+            </div>
+          )}
+        {studentAnswers && studentAnswers.length > 0 && (
+          <MultipleChoiceByQuestionTable studentAnswers={studentAnswers} />
         )}
-        <DialogFooter>
-          <Button
-            text={i18n.done()}
-            onClick={this.props.closeDialog}
-            color={Button.ButtonColor.gray}
-          />
-        </DialogFooter>
-      </BaseDialog>
+      </div>
+    );
+  }
+
+  render() {
+    const {isDialogOpen, closeDialog} = this.props;
+
+    if (!isDialogOpen) return null;
+
+    return (
+      <Dialog
+        title={i18n.questionDetails()}
+        customContent={this.renderContent()}
+        onClose={closeDialog}
+        primaryButtonProps={{
+          onClick: closeDialog,
+          variant: 'contained',
+          color: 'primary',
+          children: i18n.done(),
+        }}
+      />
     );
   }
 }
-
-const styles = {
-  dialog: {
-    paddingLeft: 20,
-    paddingRight: 20,
-    paddingBottom: 20,
-  },
-  instructions: {
-    marginTop: 20,
-  },
-  answers: {
-    float: 'left',
-    width: 550,
-  },
-  icon: {
-    color: color.level_perfect,
-  },
-  iconSpace: {
-    width: 40,
-    float: 'left',
-  },
-  answerBlock: {
-    width: '100%',
-  },
-  answerLetter: {
-    width: 30,
-    float: 'left',
-    fontWeight: 'bold',
-  },
-};
 
 export const UnconnectedMultipleChoiceDetailsDialog =
   MultipleChoiceDetailsDialog;

--- a/apps/src/templates/sectionAssessments/MultipleChoiceSurveyOverviewContainer.jsx
+++ b/apps/src/templates/sectionAssessments/MultipleChoiceSurveyOverviewContainer.jsx
@@ -1,3 +1,4 @@
+import {Typography} from '@mui/material';
 import PropTypes from 'prop-types';
 import React, {Component} from 'react';
 import {connect} from 'react-redux';
@@ -26,12 +27,12 @@ class MultipleChoiceSurveyOverviewContainer extends Component {
     } = this.props;
     return (
       <div>
-        <h2>
+        <Typography variant="h2">
           {i18n.multipleChoiceQuestionsOverview({
             numSubmissions: totalStudentSubmissions,
             numStudents: totalStudentCount,
           })}
-        </h2>
+        </Typography>
         {multipleChoiceSurveyData.length > 0 && (
           <MultipleChoiceSurveyOverviewTable
             multipleChoiceSurveyData={multipleChoiceSurveyData}

--- a/apps/src/templates/sectionAssessments/MultipleChoiceSurveyOverviewTable.jsx
+++ b/apps/src/templates/sectionAssessments/MultipleChoiceSurveyOverviewTable.jsx
@@ -1,10 +1,10 @@
+import Link from '@code-dot-org/component-library/link';
 import orderBy from 'lodash/orderBy';
 import PropTypes from 'prop-types';
 import React, {Component} from 'react';
 import * as Table from 'reactabular-table';
 import * as sort from 'sortabular';
 
-import color from '@cdo/apps/util/color';
 import i18n from '@cdo/locale';
 
 import {tableLayoutStyles, sortableOptions} from '../tables/tableConstants';
@@ -96,12 +96,17 @@ class MultipleChoiceSurveyOverviewTable extends Component {
   ) => {
     return (
       <div>
-        <a
-          style={styles.link}
-          onClick={() => this.selectQuestion(rowData.questionNumber - 1)}
+        <Link
+          size="s"
+          onClick={e => {
+            // Link defaults href to "#"; suppress the page-top jump since this
+            // really opens a modal rather than navigating.
+            e.preventDefault();
+            this.selectQuestion(rowData.questionNumber - 1);
+          }}
         >
           {`${rowData.questionNumber}. ${question}`}
-        </a>
+        </Link>
       </div>
     );
   };
@@ -251,9 +256,6 @@ const styles = {
   },
   questionCell: {
     height: MIN_ROW_HEIGHT,
-  },
-  link: {
-    color: color.teal,
   },
 };
 

--- a/apps/src/templates/sectionAssessments/MultipleChoiceSurveyQuestionDialog.jsx
+++ b/apps/src/templates/sectionAssessments/MultipleChoiceSurveyQuestionDialog.jsx
@@ -1,14 +1,13 @@
+import Dialog from '@code-dot-org/component-library/dialog';
 import PropTypes from 'prop-types';
 import React, {Component} from 'react';
 
-import Button from '@cdo/apps/legacySharedComponents/Button';
-import BaseDialog from '@cdo/apps/templates/BaseDialog';
 import SafeMarkdown from '@cdo/apps/templates/SafeMarkdown';
-import DialogFooter from '@cdo/apps/templates/teacherDashboard/DialogFooter';
-import color from '@cdo/apps/util/color';
 import i18n from '@cdo/locale';
 
 import {multipleChoiceDataPropType} from './assessmentDataShapes';
+
+import moduleStyles from './details-dialog.module.scss';
 
 class MultipleChoiceSurveyQuestionDialog extends Component {
   static propTypes = {
@@ -17,84 +16,54 @@ class MultipleChoiceSurveyQuestionDialog extends Component {
     questionData: multipleChoiceDataPropType.isRequired,
   };
 
-  render() {
+  renderContent() {
     const {questionData} = this.props;
 
-    // Questions are in markdown format and should not display as plain text in the dialog.
+    return (
+      <div>
+        <SafeMarkdown
+          className={moduleStyles.multipleChoiceDetailsQuestion}
+          markdown={questionData.question}
+        />
+        {questionData.answers && questionData.answers.length > 0 && (
+          <div>
+            {questionData.answers.map((answer, index) => (
+              <div key={index} className={moduleStyles.answerBlock}>
+                <div className={moduleStyles.answerLetter}>
+                  {answer.multipleChoiceOption}
+                </div>
+                <div className={moduleStyles.answerBody}>
+                  <SafeMarkdown
+                    markdown={`${answer.text} (${answer.percentAnswered}%)`}
+                  />
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    );
+  }
+
+  render() {
+    const {isDialogOpen, closeDialog} = this.props;
+
+    if (!isDialogOpen) return null;
 
     return (
-      <BaseDialog
-        useUpdatedStyles
-        isOpen={this.props.isDialogOpen}
-        style={styles.dialog}
-        handleClose={this.props.closeDialog}
-      >
-        <div>
-          <h2>{i18n.questionDetails()}</h2>
-          <div style={styles.instructions}>
-            <SafeMarkdown markdown={questionData.question} />
-          </div>
-          {questionData.answers && questionData.answers.length > 0 && (
-            <div>
-              {questionData.answers.map((answer, index) => {
-                return (
-                  <div key={index} style={styles.answerBlock}>
-                    <div style={styles.answerLetter}>
-                      {answer.multipleChoiceOption}
-                    </div>
-                    <div style={styles.answers} />
-                    <SafeMarkdown
-                      markdown={
-                        answer.text + ' (' + answer.percentAnswered + '%)'
-                      }
-                    />
-                    <div style={{clear: 'both'}} />
-                  </div>
-                );
-              })}
-            </div>
-          )}
-        </div>
-        <DialogFooter>
-          <Button
-            text={i18n.done()}
-            onClick={this.props.closeDialog}
-            color={Button.ButtonColor.gray}
-          />
-        </DialogFooter>
-      </BaseDialog>
+      <Dialog
+        title={i18n.questionDetails()}
+        customContent={this.renderContent()}
+        onClose={closeDialog}
+        primaryButtonProps={{
+          onClick: closeDialog,
+          variant: 'contained',
+          color: 'primary',
+          children: i18n.done(),
+        }}
+      />
     );
   }
 }
-
-const styles = {
-  dialog: {
-    paddingLeft: 20,
-    paddingRight: 20,
-    paddingBottom: 20,
-  },
-  instructions: {
-    marginTop: 20,
-  },
-  answers: {
-    float: 'left',
-    width: 550,
-  },
-  icon: {
-    color: color.level_perfect,
-  },
-  iconSpace: {
-    width: 40,
-    float: 'left',
-  },
-  answerBlock: {
-    width: '100%',
-  },
-  answerLetter: {
-    width: 30,
-    float: 'left',
-    fontWeight: 'bold',
-  },
-};
 
 export default MultipleChoiceSurveyQuestionDialog;

--- a/apps/src/templates/sectionAssessments/PercentAnsweredCell.jsx
+++ b/apps/src/templates/sectionAssessments/PercentAnsweredCell.jsx
@@ -1,13 +1,23 @@
+import FontAwesomeV6Icon from '@code-dot-org/component-library/fontAwesomeV6Icon';
 import PropTypes from 'prop-types';
 import React, {Component} from 'react';
 
-import fontConstants from '@cdo/apps/fontConstants';
-import FontAwesome from '@cdo/apps/legacySharedComponents/FontAwesome';
-import color from '@cdo/apps/util/color';
+import moduleStyles from './percent-answered-cell.module.scss';
 
 function calculateOpacity(answered) {
   return (answered + 10) / 100;
 }
+
+const defaultMainLayoutStyle = {
+  border: 'none',
+  display: 'flex',
+  justifyContent: 'space-between',
+  flexDirection: 'row',
+  alignItems: 'center',
+  boxSizing: 'border-box',
+  height: '100%',
+  padding: 10,
+};
 
 class PercentAnsweredCell extends Component {
   static propTypes = {
@@ -27,19 +37,25 @@ class PercentAnsweredCell extends Component {
       : `rgba(255, 99, 71, ${opacity})`;
   };
 
+  renderCorrectIcon() {
+    if (!this.props.isCorrectAnswer) return null;
+    return (
+      <FontAwesomeV6Icon
+        iconName="check-circle"
+        className={moduleStyles.correctIcon}
+      />
+    );
+  }
+
   render() {
-    const {percentValue, isCorrectAnswer, displayAnswer} = this.props;
+    const {percentValue, displayAnswer} = this.props;
 
     // Display a cell with letters for answers.
     if (displayAnswer) {
       return (
-        <div style={styles.main}>
-          <div style={styles.value}>{displayAnswer}</div>
-          <div style={styles.icon}>
-            {isCorrectAnswer && (
-              <FontAwesome icon="check-circle" style={styles.icon} />
-            )}
-          </div>
+        <div style={defaultMainLayoutStyle}>
+          <div className={moduleStyles.value}>{displayAnswer}</div>
+          {this.renderCorrectIcon()}
         </div>
       );
     }
@@ -50,43 +66,19 @@ class PercentAnsweredCell extends Component {
     };
     return (
       <div style={{...this.props.mainLayoutStyle, ...backgroundCSS}}>
-        <div style={{...styles.value, ...this.props.valueLayoutStyle}}>
+        <div className={moduleStyles.value} style={this.props.valueLayoutStyle}>
           {percentValue >= 0 && <span>{`${percentValue}%`}</span>}
           {percentValue < 0 && <span>{'-'}</span>}
         </div>
-        <div style={styles.icon}>
-          {isCorrectAnswer && (
-            <FontAwesome icon="check-circle" style={styles.icon} />
-          )}
-        </div>
+        {this.renderCorrectIcon()}
       </div>
     );
   }
 }
 
-const styles = {
-  main: {
-    border: 'none',
-    display: 'flex',
-    justifyContent: 'space-between',
-    flexDirection: 'row',
-    alignItems: 'center',
-    boxSizing: 'border-box',
-    height: '100%',
-    padding: 10,
-  },
-  icon: {
-    color: color.level_perfect,
-  },
-  value: {
-    color: color.charcoal,
-    ...fontConstants['main-font-semi-bold'],
-  },
-};
-
 PercentAnsweredCell.defaultProps = {
   percentValue: -1,
-  mainLayoutStyle: styles.main,
+  mainLayoutStyle: defaultMainLayoutStyle,
   valueLayoutStyle: {marginRight: 10},
 };
 

--- a/apps/src/templates/sectionAssessments/SectionAssessments.jsx
+++ b/apps/src/templates/sectionAssessments/SectionAssessments.jsx
@@ -1,9 +1,11 @@
+import FontAwesomeV6Icon from '@code-dot-org/component-library/fontAwesomeV6Icon';
+import {Typography, Button as MuiButton} from '@mui/material';
 import PropTypes from 'prop-types';
 import React, {Component} from 'react';
 import {CSVLink} from 'react-csv';
 import {connect} from 'react-redux';
 
-import FontAwesome from '@cdo/apps/legacySharedComponents/FontAwesome';
+import Spinner from '@cdo/apps/sharedComponents/Spinner';
 import SafeMarkdown from '@cdo/apps/templates/SafeMarkdown';
 import {
   asyncLoadAssessments,
@@ -17,8 +19,6 @@ import {
 } from '@cdo/apps/templates/sectionAssessments/sectionAssessmentsRedux';
 import UnitSelectorV2 from '@cdo/apps/templates/teacherDashboardShared/UnitSelectorV2';
 import i18n from '@cdo/locale';
-
-import {h3Style} from '../../legacySharedComponents/Headings';
 
 import AssessmentSelector from './AssessmentSelector';
 import FeedbackDownload from './FeedbackDownload';
@@ -34,6 +34,8 @@ import MultipleChoiceDetailsDialog from './MultipleChoiceDetailsDialog';
 import MultipleChoiceSurveyOverviewContainer from './MultipleChoiceSurveyOverviewContainer';
 import StudentSelector from './StudentSelector';
 import SubmissionStatusAssessmentsContainer from './SubmissionStatusAssessmentsContainer';
+
+import moduleStyles from './section-assessments.module.scss';
 
 const CSV_ASSESSMENT_HEADERS = [
   {label: i18n.name(), key: 'studentName'},
@@ -165,18 +167,18 @@ class SectionAssessments extends Component {
     return (
       // eslint-disable-next-line react/forbid-dom-props
       <div data-testid={'assessments-tab'}>
-        <div style={styles.selectors}>
-          <div style={styles.unitSelection}>
-            <div style={{...h3Style, ...styles.header}}>
+        <div className={moduleStyles.selectors}>
+          <div className={moduleStyles.unitSelection}>
+            <Typography variant="h4" className={moduleStyles.header}>
               {i18n.selectACourse()}
-            </div>
+            </Typography>
             <UnitSelectorV2 v1Styles />
           </div>
           {!isLoading && assessmentList.length > 0 && (
-            <div style={styles.assessmentSelection}>
-              <div style={{...h3Style, ...styles.header}}>
+            <div className={moduleStyles.assessmentSelection}>
+              <Typography variant="h4" className={moduleStyles.header}>
                 {i18n.selectAssessment()}
-              </div>
+              </Typography>
               <AssessmentSelector
                 assessmentList={assessmentList}
                 assessmentId={assessmentId}
@@ -186,32 +188,39 @@ class SectionAssessments extends Component {
           )}
         </div>
         {!isLoading && assessmentList.length > 0 && (
-          <div style={styles.tableContent}>
+          <div className={moduleStyles.tableContent}>
             {/* Assessments */}
             {!isCurrentAssessmentSurvey &&
               !isCurrentAssessmentFeedbackOption && (
                 <div>
-                  <div style={{...h3Style, ...styles.header}}>
+                  <Typography variant="h4" className={moduleStyles.header}>
                     {i18n.selectStudent()}
-                  </div>
+                  </Typography>
                   <StudentSelector
                     studentList={studentList}
                     studentId={studentId}
                     onChange={this.onSelectStudent}
                   />
                   {totalStudentSubmissions > 0 && (
-                    <div style={styles.download}>
-                      <CSVLink
+                    <div className={moduleStyles.download}>
+                      <MuiButton
+                        component={CSVLink}
+                        size="small"
+                        variant="text"
+                        color="secondary"
+                        startIcon={<FontAwesomeV6Icon iconName="download" />}
                         filename="assessments.csv"
                         data={exportableData}
                         headers={CSV_ASSESSMENT_HEADERS}
                       >
-                        <div>{i18n.downloadAssessmentCSV()}</div>
-                      </CSVLink>
+                        {i18n.downloadAssessmentCSV()}
+                      </MuiButton>
                     </div>
                   )}
                   {totalStudentSubmissions <= 0 && (
-                    <div>{i18n.emptyAssessmentSubmissions()}</div>
+                    <Typography variant="body3" gutterBottom>
+                      {i18n.emptyAssessmentSubmissions()}
+                    </Typography>
                   )}
                   <SubmissionStatusAssessmentsContainer />
                   {totalStudentSubmissions > 0 && (
@@ -242,13 +251,18 @@ class SectionAssessments extends Component {
               <div>
                 {totalStudentSubmissions > 0 && (
                   <div>
-                    <CSVLink
-                      filename="surveys.csv"
-                      data={exportableData}
-                      headers={CSV_SURVEY_HEADERS}
-                    >
-                      <div>{i18n.downloadAssessmentCSV()}</div>
-                    </CSVLink>
+                    <div className={moduleStyles.download}>
+                      <MuiButton
+                        component={CSVLink}
+                        variant="text"
+                        startIcon={<FontAwesomeV6Icon iconName="download" />}
+                        filename="surveys.csv"
+                        data={exportableData}
+                        headers={CSV_SURVEY_HEADERS}
+                      >
+                        {i18n.downloadAssessmentCSV()}
+                      </MuiButton>
+                    </div>
                     <MultipleChoiceSurveyOverviewContainer />
                     <FreeResponsesSurveyContainer
                       openDialog={this.showFreeResponseDetailDialog}
@@ -275,47 +289,17 @@ class SectionAssessments extends Component {
           </div>
         )}
         {isLoading && (
-          <div style={styles.loading}>
-            <FontAwesome icon="spinner" className="fa-pulse fa-3x" />
+          <div>
+            <Spinner size="large" />
           </div>
         )}
         {!isLoading && assessmentList.length === 0 && (
-          <div style={styles.empty}>{i18n.noAssessments()}</div>
+          <Typography variant="body3">{i18n.noAssessments()}</Typography>
         )}
       </div>
     );
   }
 }
-
-const styles = {
-  header: {
-    marginBottom: 0,
-  },
-  tableContent: {
-    marginTop: 10,
-    clear: 'both',
-  },
-  selectors: {
-    clear: 'both',
-  },
-  unitSelection: {
-    float: 'left',
-    marginRight: 20,
-  },
-  assessmentSelection: {
-    float: 'left',
-    marginBottom: 10,
-  },
-  download: {
-    marginTop: 10,
-  },
-  loading: {
-    clear: 'both',
-  },
-  empty: {
-    clear: 'both',
-  },
-};
 
 export const UnconnectedSectionAssessments = SectionAssessments;
 

--- a/apps/src/templates/sectionAssessments/SubmissionStatusAssessmentsContainer.jsx
+++ b/apps/src/templates/sectionAssessments/SubmissionStatusAssessmentsContainer.jsx
@@ -1,10 +1,10 @@
-import classNames from 'classnames';
+import FontAwesomeV6Icon from '@code-dot-org/component-library/fontAwesomeV6Icon';
+import {Typography, Button as MuiButton} from '@mui/material';
 import PropTypes from 'prop-types';
 import React, {Component} from 'react';
 import {CSVLink} from 'react-csv';
 import {connect} from 'react-redux';
 
-import Button from '@cdo/apps/legacySharedComponents/Button';
 import i18n from '@cdo/locale';
 
 import {studentOverviewDataPropType} from './assessmentDataShapes';
@@ -14,7 +14,7 @@ import {
 } from './sectionAssessmentsRedux';
 import SubmissionStatusAssessmentsTable from './SubmissionStatusAssessmentsTable';
 
-import moduleStyles from '@cdo/apps/legacySharedComponents/button.module.scss';
+import moduleStyles from './submission-status.module.scss';
 
 export const studentExportableDataPropType = PropTypes.shape({
   studentName: PropTypes.string.isRequired,
@@ -43,27 +43,24 @@ class SubmissionStatusAssessmentsContainer extends Component {
   };
 
   render() {
-    // These allow the CSVLink to be styled as a button
-    let className = classNames(
-      moduleStyles.main,
-      moduleStyles[Button.ButtonColor.gray],
-      moduleStyles['default']
-    );
-
     return (
       <div>
-        <div style={styles.buttonContainer}>
-          <h2>{i18n.studentOverviewTableHeader()}</h2>
-          <CSVLink
-            role="button"
+        <div className={moduleStyles.header}>
+          <Typography variant="h2">
+            {i18n.studentOverviewTableHeader()}
+          </Typography>
+          <MuiButton
+            component={CSVLink}
+            size="small"
+            variant="outlined"
+            color="secondary"
+            startIcon={<FontAwesomeV6Icon iconName="download" />}
             filename="assessments-submission-status.csv"
             data={this.props.studentExportableData}
             headers={CSV_SUBMISSION_STATUS_HEADERS}
-            style={styles.button}
-            className={className}
           >
             {i18n.downloadCSV()}
-          </CSVLink>
+          </MuiButton>
         </div>
         <SubmissionStatusAssessmentsTable
           localeCode={this.props.localeCode}
@@ -73,20 +70,6 @@ class SubmissionStatusAssessmentsContainer extends Component {
     );
   }
 }
-
-const styles = {
-  buttonContainer: {
-    display: 'flex',
-    flexDirection: 'row',
-    justifyContent: 'space-between',
-    alignItems: 'flex-end',
-  },
-  button: {
-    padding: '12px 24px',
-    lineHeight: '10px',
-    marginBottom: '5px',
-  },
-};
 
 export const UnconnectedSubmissionStatusAssessmentsContainer =
   SubmissionStatusAssessmentsContainer;

--- a/apps/src/templates/sectionAssessments/SubmissionStatusAssessmentsTable.jsx
+++ b/apps/src/templates/sectionAssessments/SubmissionStatusAssessmentsTable.jsx
@@ -1,18 +1,20 @@
+import FontAwesomeV6Icon from '@code-dot-org/component-library/fontAwesomeV6Icon';
+import Link from '@code-dot-org/component-library/link';
+import {Typography} from '@mui/material';
 import orderBy from 'lodash/orderBy';
 import PropTypes from 'prop-types';
 import React, {Component} from 'react';
 import * as Table from 'reactabular-table';
 import * as sort from 'sortabular';
 
-import fontConstants from '@cdo/apps/fontConstants';
-import FontAwesome from '@cdo/apps/legacySharedComponents/FontAwesome';
-import color from '@cdo/apps/util/color';
 import i18n from '@cdo/locale';
 
 import {tableLayoutStyles, sortableOptions} from '../tables/tableConstants';
 import wrappedSortable from '../tables/wrapped_sortable';
 
 import {studentOverviewDataPropType} from './assessmentDataShapes';
+
+import moduleStyles from './submission-status-table.module.scss';
 
 const TABLE_WIDTH = tableLayoutStyles.table.width;
 const TABLE_COLUMN_WIDTHS = {
@@ -78,12 +80,18 @@ class SubmissionStatusAssessmentsTable extends Component {
   nameCellFormatter = (name, {rowData}) => {
     if (rowData.url) {
       return (
-        <a href={rowData.url} style={styles.studentNameColumn}>
+        <Link size="s" href={rowData.url}>
           {name}
-        </a>
+        </Link>
       );
     } else {
-      return name;
+      return (
+        <Typography variant="body3">
+          <Typography variant="strong" component="strong">
+            {name}
+          </Typography>
+        </Typography>
+      );
     }
   };
 
@@ -116,12 +124,18 @@ class SubmissionStatusAssessmentsTable extends Component {
     }
 
     return (
-      <div style={styles.main} className="timestampCell">
-        <div style={styles.text}>{submissionTimeStampContent}</div>
+      // `timestampCell` is kept as a global class hook for the test suite,
+      // which selects by `.timestampCell` to verify sort order.
+      <div className={`timestampCell ${moduleStyles.timestampCell}`}>
+        <Typography variant="body3" className={moduleStyles.timestampText}>
+          {submissionTimeStampContent}
+        </Typography>
         {isSubmitted && (
-          <div style={styles.icon}>
-            <FontAwesome id="checkmark" icon="check-circle" />
-          </div>
+          <FontAwesomeV6Icon
+            id="checkmark"
+            iconName="check-circle"
+            className={moduleStyles.submittedIcon}
+          />
         )}
       </div>
     );
@@ -146,7 +160,6 @@ class SubmissionStatusAssessmentsTable extends Component {
           props: {
             style: {
               ...tableLayoutStyles.cell,
-              ...styles.studentNameColumn,
             },
           },
         },
@@ -261,30 +274,5 @@ class SubmissionStatusAssessmentsTable extends Component {
     );
   }
 }
-
-const styles = {
-  main: {
-    border: 'none',
-    display: 'flex',
-    justifyContent: 'space-between',
-    flexDirection: 'row',
-    alignItems: 'center',
-  },
-  icon: {
-    color: color.purple,
-    fontSize: 16,
-  },
-  text: {
-    marginRight: 5,
-  },
-  headerLabels: {
-    color: color.charcoal,
-    ...fontConstants['main-font-semi-bold'],
-  },
-  studentNameColumn: {
-    color: color.teal,
-    ...fontConstants['main-font-semi-bold'],
-  },
-};
 
 export default SubmissionStatusAssessmentsTable;

--- a/apps/src/templates/sectionAssessments/SubmissionStatusAssessmentsTable.jsx
+++ b/apps/src/templates/sectionAssessments/SubmissionStatusAssessmentsTable.jsx
@@ -86,7 +86,7 @@ class SubmissionStatusAssessmentsTable extends Component {
       );
     } else {
       return (
-        <Typography variant="body3">
+        <Typography variant="body3" component="span">
           <Typography variant="strong" component="strong">
             {name}
           </Typography>

--- a/apps/src/templates/sectionAssessments/details-dialog.module.scss
+++ b/apps/src/templates/sectionAssessments/details-dialog.module.scss
@@ -1,0 +1,42 @@
+.answerBlock {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  width: 100%;
+  margin-bottom: 8px;
+}
+
+.multipleChoiceDetailsQuestion {
+  margin-bottom: 1rem;
+}
+
+.iconColumn {
+  width: 20px;
+  flex-shrink: 0;
+}
+
+.correctIcon {
+  color: var(--text-success-primary);
+}
+
+.answerLetter {
+  width: 30px;
+  flex-shrink: 0;
+  font-weight: bold;
+}
+
+.answerBody {
+  flex: 1;
+}
+
+.matchTable {
+  width: 100%;
+  border-collapse: collapse;
+
+  th,
+  td {
+    text-align: left;
+    padding: 8px;
+    vertical-align: top;
+  }
+}

--- a/apps/src/templates/sectionAssessments/feedback-download.module.scss
+++ b/apps/src/templates/sectionAssessments/feedback-download.module.scss
@@ -1,0 +1,8 @@
+.feedbackDownloadContainer {
+margin-block: 10px;
+}
+
+.checkIcon {
+  color: var(--text-brand-purple-primary);
+  padding-right: 5px;
+}

--- a/apps/src/templates/sectionAssessments/free-responses-container.module.scss
+++ b/apps/src/templates/sectionAssessments/free-responses-container.module.scss
@@ -1,0 +1,4 @@
+.questionLabel {
+  padding-top: 20px;
+  padding-bottom: 20px;
+}

--- a/apps/src/templates/sectionAssessments/free-responses-table.module.scss
+++ b/apps/src/templates/sectionAssessments/free-responses-table.module.scss
@@ -1,0 +1,20 @@
+.studentNameHeaderCell {
+  padding: 15px;
+}
+
+.studentNameCell {
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  overflow: hidden;
+  max-width: 200px;
+  padding: 15px;
+  vertical-align: top;
+}
+
+.response {
+  white-space: pre-wrap;
+}
+
+.noResponse {
+  color: var(--text-neutral-secondary);
+}

--- a/apps/src/templates/sectionAssessments/match-by-student-container.module.scss
+++ b/apps/src/templates/sectionAssessments/match-by-student-container.module.scss
@@ -1,0 +1,4 @@
+.questionLabel {
+  padding-top: 20px;
+  padding-bottom: 20px;
+}

--- a/apps/src/templates/sectionAssessments/match-by-student-table.module.scss
+++ b/apps/src/templates/sectionAssessments/match-by-student-table.module.scss
@@ -1,0 +1,6 @@
+.optionCell {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  max-width: 470px;
+}

--- a/apps/src/templates/sectionAssessments/match-overview-container.module.scss
+++ b/apps/src/templates/sectionAssessments/match-overview-container.module.scss
@@ -1,0 +1,4 @@
+.questionLabel {
+  padding-top: 20px;
+  padding-bottom: 20px;
+}

--- a/apps/src/templates/sectionAssessments/match-overview-table.module.scss
+++ b/apps/src/templates/sectionAssessments/match-overview-table.module.scss
@@ -1,0 +1,5 @@
+.optionCell {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}

--- a/apps/src/templates/sectionAssessments/multiple-choice-by-student-table.module.scss
+++ b/apps/src/templates/sectionAssessments/multiple-choice-by-student-table.module.scss
@@ -1,0 +1,6 @@
+.questionCell {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  max-width: 470px;
+}

--- a/apps/src/templates/sectionAssessments/multiple-choice-overview-table.module.scss
+++ b/apps/src/templates/sectionAssessments/multiple-choice-overview-table.module.scss
@@ -1,0 +1,6 @@
+.questionLink {
+  display: block;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}

--- a/apps/src/templates/sectionAssessments/percent-answered-cell.module.scss
+++ b/apps/src/templates/sectionAssessments/percent-answered-cell.module.scss
@@ -1,0 +1,8 @@
+.value {
+  color: var(--text-neutral-primary);
+  font-weight: 600;
+}
+
+.correctIcon {
+  color: var(--text-success-primary);
+}

--- a/apps/src/templates/sectionAssessments/section-assessments.module.scss
+++ b/apps/src/templates/sectionAssessments/section-assessments.module.scss
@@ -1,0 +1,18 @@
+.selectors {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 20px;
+  align-items: flex-start;
+}
+
+.header {
+  margin-bottom: 0;
+}
+
+.tableContent {
+  margin-top: 10px;
+}
+
+.download {
+  margin-top: 10px;
+}

--- a/apps/src/templates/sectionAssessments/submission-status-table.module.scss
+++ b/apps/src/templates/sectionAssessments/submission-status-table.module.scss
@@ -1,0 +1,16 @@
+.timestampCell {
+  border: none;
+  display: flex;
+  justify-content: space-between;
+  flex-direction: row;
+  align-items: center;
+}
+
+.timestampText {
+  margin-right: 5px;
+}
+
+.submittedIcon {
+  color: var(--text-brand-purple-primary);
+  font-size: 16px;
+}

--- a/apps/src/templates/sectionAssessments/submission-status.module.scss
+++ b/apps/src/templates/sectionAssessments/submission-status.module.scss
@@ -1,0 +1,7 @@
+.header {
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  align-items: flex-end;
+  margin-bottom: 1rem;
+}

--- a/apps/test/unit/templates/sectionAssessments/FeedbackDownloadTest.jsx
+++ b/apps/test/unit/templates/sectionAssessments/FeedbackDownloadTest.jsx
@@ -1,3 +1,4 @@
+import {Button as MuiButton} from '@mui/material';
 import {shallow} from 'enzyme'; // eslint-disable-line no-restricted-imports
 import React from 'react';
 import {CSVLink} from 'react-csv';
@@ -22,31 +23,39 @@ const hasHeader = (headers, headerLabel) => {
   return headers.find(header => header['label'] === headerLabel) !== undefined;
 };
 
+// CSVLink is now mounted as the `component` prop on MuiButton; csv-generation
+// props (headers, filename, data) are passed through MuiButton and forwarded.
+const downloadButton = wrapper => {
+  const button = wrapper.find(MuiButton);
+  expect(button.props().component).toBe(CSVLink);
+  return button;
+};
+
 describe('FeedbackDownload', () => {
   it('passes rubric headers to CSVLink if isCurrentScriptCSD is true', () => {
     const wrapper = setUp({isCurrentScriptCSD: true});
 
-    const headers = wrapper.find(CSVLink).props().headers;
+    const headers = downloadButton(wrapper).props().headers;
     expect(hasHeader(headers, i18n.performanceLevel())).toBe(true);
     expect(hasHeader(headers, i18n.performanceLevelDetails())).toBe(true);
   });
 
   it('does not pass rubric headers to CSVLink if isCurrentScriptCSD is false', () => {
     const wrapper = setUp({isCurrentScriptCSD: false});
-    const headers = wrapper.find(CSVLink).props().headers;
+    const headers = downloadButton(wrapper).props().headers;
     expect(hasHeader(headers, i18n.performanceLevel())).toBe(false);
     expect(hasHeader(headers, i18n.performanceLevelDetails())).toBe(false);
   });
 
   it('passes review state header to CSVLink', () => {
     const wrapper = setUp();
-    const headers = wrapper.find(CSVLink).props().headers;
+    const headers = downloadButton(wrapper).props().headers;
     expect(hasHeader(headers, i18n.reviewState())).toBe(true);
   });
 
   it('passes expected file name to CSVLink', () => {
     const wrapper = setUp();
-    const fileName = wrapper.find(CSVLink).props().filename;
+    const fileName = downloadButton(wrapper).props().filename;
     expect(fileName.includes('Feedback for My Section in Script Name on')).toBe(
       true
     );


### PR DESCRIPTION
Pulls the entire teacher-dashboard Assessments page (`apps/src/templates/sectionAssessments/`) off legacy primitives onto DSCO + MUI. Sibling to the in-flight `sectionsRefresh` help-link PR (#72633), which covers a different surface (the create-section flow).

Before: 
<img width="3456" height="2514" alt="image" src="https://github.com/user-attachments/assets/fb13928c-bf76-4af9-b02f-c8748945598c" />

After:
<img width="3456" height="2514" alt="image" src="https://github.com/user-attachments/assets/66bb5f75-9677-4688-a967-cffcd69427a7" />

<img width="3456" height="2514" alt="image" src="https://github.com/user-attachments/assets/26da5b78-4db3-4847-b831-9297d032e034" />


<img width="883" height="793" alt="Знімок екрана 2026-05-15 о 11 13 17" src="https://github.com/user-attachments/assets/389ef672-967a-4bd7-b4ed-099fa9084ed1" />
<img width="903" height="813" alt="Знімок екрана 2026-05-15 о 09 47 49" src="https://github.com/user-attachments/assets/7c4e3e7e-f2ef-4ed0-b84f-c5eb88649f5b" />
<img width="892" height="798" alt="Знімок екрана 2026-05-15 о 09 47 40" src="https://github.com/user-attachments/assets/822aca2a-2c83-4c71-9e0f-9f5b51b13f76" />
<img width="799" height="307" alt="Знімок екрана 2026-05-15 о 09 36 30" src="https://github.com/user-attachments/assets/6af16db5-75ae-415f-8f6b-568c8d2c31cb" />
<img width="905" height="425" alt="Знімок екрана 2026-05-15 о 09 22 42" src="https://github.com/user-attachments/assets/1a26abe0-465a-47b2-8542-08d6c6b64de9" />
<img width="820" height="397" alt="Знімок екрана 2026-05-15 о 09 22 39" src="https://github.com/user-attachments/assets/aa7230d8-fece-4d59-bd1f-4b57ab2974d0" />
<img width="892" height="434" alt="Знімок екрана 2026-05-15 о 09 14 16" src="https://github.com/user-attachments/assets/fc3e4633-7a5d-442d-a562-b77e3abc8594" />
<img width="923" height="603" alt="Знімок екрана 2026-05-14 о 18 18 50" src="https://github.com/user-attachments/assets/98ff5dd3-af0d-49db-942d-3af604eb361f" />
<img width="906" height="907" alt="Знімок екрана 2026-05-14 о 18 18 45" src="https://github.com/user-attachments/assets/7060bb16-1c99-4fef-ae3d-ecf597492092" />
<img width="911" height="547" alt="Знімок екрана 2026-05-14 о 18 08 57" src="https://github.com/user-attachments/assets/2213d97d-add1-4c56-a9c9-994801bf7aa1" />
<img width="890" height="629" alt="Знімок екрана 2026-05-14 о 17 57 35" src="https://github.com/user-attachments/assets/13909eed-d19a-412a-bbf7-aa8ee63597d5" />
<img width="887" height="503" alt="Знімок екрана 2026-05-14 о 17 30 20" src="https://github.com/user-attachments/assets/f9499efe-97d4-45f0-84bf-6df099293d1a" />
<img width="889" height="833" alt="Знімок екрана 2026-05-14 о 17 09 18" src="https://github.com/user-attachments/assets/8b31f45f-6be9-4a96-8ea9-a2a24c3e9596" />
<img width="949" height="465" alt="Знімок екрана 2026-05-14 о 16 57 09" src="https://github.com/user-attachments/assets/9d2f4726-1ca7-401e-8ed3-4c000e384288" />
<img width="985" height="611" alt="Знімок екрана 2026-05-14 о 16 45 13" src="https://github.com/user-attachments/assets/419426d8-1907-485a-b183-6e89c1ea3f90" />



## Scope

Source files migrated:

- **`SectionAssessments` page chrome** — three section headings (Select a course / assessment / student) → MUI `<Typography>`; `<FontAwesome icon="spinner" />` → shared `<Spinner size="large" />`; float-based unit/assessment selector row → flex container; two CSV download links → `<MuiButton component={CSVLink} variant="text" startIcon={<FontAwesomeV6Icon iconName="download" />}>` with `filename` / `data` / `headers` flowing through.
- **`SubmissionStatusAssessmentsContainer`** — `<h2>` → MUI `<Typography variant="h2">`; CSVLink + legacy `Button.ButtonColor.gray` className hack → MUI `Button` with `component={CSVLink}` + download icon; inline `styles.buttonContainer` flex row → SCSS module.
- **`SubmissionStatusAssessmentsTable`** — legacy `FontAwesome` check-circle → `FontAwesomeV6Icon`; `color.purple` (submitted-status icon) → `var(--text-brand-purple-primary)`; `color.teal` + `fontConstants['main-font-semi-bold']` on student-name links → `var(--text-brand-teal-primary)` + `font-weight: 600`; inline `styles` block (flex layout, ellipsis, font emphasis) → SCSS module. `.timestampCell` global class kept as a test-suite selector.
- **`FeedbackDownload`** — CSVLink smuggling legacy button SCSS classes onto an anchor → `MuiButton component={CSVLink} variant="outlined"`; legacy `FontAwesome` check-circle + `color.purple` → `FontAwesomeV6Icon` + `var(--text-brand-purple-primary)`; new SCSS module replaces inline padding/lineHeight kludges. `FeedbackDownloadTest` updated to find through `MuiButton` and confirm `props().component === CSVLink`.
- **Three details dialogs** (`FreeResponseDetailsDialog`, `MultipleChoiceDetailsDialog`, `MatchDetailsDialog`) — legacy `BaseDialog` + `DialogFooter` + `Button.ButtonColor.gray` → DSCO `Dialog` with `title` / `customContent` / `primaryButtonProps`. `isOpen` prop → conditional render. `MultipleChoiceDetailsDialog` additionally: legacy `FontAwesome` check-circle → `FontAwesomeV6Icon` with `var(--text-success-primary)` (replacing `color.level_perfect`); float-based answer rows → flex in shared `details-dialog.module.scss`. `MatchDetailsDialog`: float-based answer-table cell wrappers → proper table cell padding.
- **`MultipleChoiceAssessmentsOverviewTable`** — `<a style={styles.link} onClick>` (anchor-as-button) → DSCO `<Link>` with `preventDefault`; ellipsis truncation moved to SCSS module.
- **`PercentAnsweredCell`** — legacy `FontAwesome` check-circle → `FontAwesomeV6Icon`; `color.level_perfect` → `var(--text-success-primary)`; `color.charcoal` + `fontConstants['main-font-semi-bold']` (value text) → `var(--text-neutral-primary)` + `font-weight: 600` via SCSS module; redundant `<div>` wrapper around the icon dropped. `mainLayoutStyle` / `valueLayoutStyle` prop API preserved — `MultipleChoiceSurveyOverviewTable` still passes both.
- **`MultipleChoiceByStudentContainer` / Table** — `<h2>` → `Typography`; question-cell ellipsis truncation moved to SCSS module, applied via reactabular `props.className`.
- **`MatchAssessmentsOverviewContainer` / Table** — `<h2>` → `Typography`; fake-button "See full question" anchor → DSCO `Link` + `preventDefault`; inline `styles.text` (with silently broken `font: 10` shorthand — dropped) → SCSS module; option-cell ellipsis → SCSS module via reactabular `props.className`.
- **`MatchByStudentContainer` / Table** — same shape as `MatchAssessmentsOverview*` migration.
- **`FreeResponsesAssessmentsContainer` / Table** — same heading/link/SCSS pattern. Table additionally: `color.lighter_gray` for empty-response placeholder → `var(--text-neutral-secondary)`; student-name column padding + ellipsis + max-width move to SCSS classes via reactabular `props.className`. Removed dead-code spread of `styles.responseHeaderCell` (typo — the styles object only defined `responseColumnHeader`, so the spread was a no-op).
- **`MultipleChoiceSurveyOverviewContainer` / Table** — `<h2>` → `Typography`; question link → DSCO `Link` + `preventDefault`; the table opens the existing `MultipleChoiceSurveyQuestionDialog`, which is also migrated.
- **`MultipleChoiceSurveyQuestionDialog`** — `BaseDialog` + legacy `Button` → DSCO `Dialog` with `title` / `customContent` / `primaryButtonProps`; float-based answer rows → flex via the shared `details-dialog.module.scss`. Empty spacer div and `clear: both` recovery div both dropped.
- **`FreeResponsesSurveyContainer` / Table** — same shape as the assessments-side versions; reuses `free-responses-container.module.scss` + `free-responses-table.module.scss` from the assessments migration.

New SCSS modules: `section-assessments`, `submission-status`, `submission-status-table`, `feedback-download`, `details-dialog`, `multiple-choice-overview-table`, `percent-answered-cell`, `multiple-choice-by-student-table`, `match-overview-container`, `match-overview-table`, `match-by-student-container`, `match-by-student-table`, `free-responses-container`, `free-responses-table`.

## Links
- Jira:
- Sibling DSCO migration (sectionsRefresh help link): #72633

## Testing story
- [x] `yarn run typecheck` (apps/) — clean after every commit
- [x] Targeted unit tests that exist for migrated files run green:
  - `SubmissionStatusAssessmentsTableTest` (5/6 — the 6th is a pre-existing locale-dependent timestamp flake, not a regression; the test right below it is already marked `xit` with the same root cause)
  - `FeedbackDownloadTest` (4/4)
  - `MatchAssessmentOverviewTableTest` (1/1)
  - `MultipleChoiceAssessmentOverviewTableTest` (1/1)
  - `FreeResponsesAssessmentsTableTest` (2/2)
  - `FreeResponsesSurveyTableTest` (2/2)
- [ ] Some existing tests will need follow-up to match the new component shape (enzyme `find(<LegacyComponent>)` patterns where the legacy node is now nested inside an MUI / DSCO wrapper). Will land as follow-up commits on this branch.
- [ ] Manual visual smoke at `/teacher_dashboard/sections/:id/assessments` covering: empty + loading state, unit/assessment/student selection, CSV downloads (assessments / surveys / feedback / submission-status), all three details dialogs, survey question dialog, free-response and match views in both overview and per-student modes.
- [ ] Drone run + UI tests.
- [ ] Eyes baseline updates likely needed — heading typography, button styling, and dialog chrome all shift visually.

## Deployment notes
Standard merge-and-deploy.

## Privacy and security
None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)