### PR TITLE
Font size updates for free-response levels

### DIFF
--- a/dashboard/app/assets/stylesheets/application.scss
+++ b/dashboard/app/assets/stylesheets/application.scss
@@ -2718,7 +2718,6 @@ a.download-video {
 .free-response {
   li {
     font-size: 16px;
-    line-height: 24px;
   }
   h1 {
     font-size: 37px;

--- a/dashboard/app/assets/stylesheets/application.scss
+++ b/dashboard/app/assets/stylesheets/application.scss
@@ -2701,7 +2701,22 @@ a.download-video {
   }
 }
 
-.text-match, .free-response, .peer-review {
+.text-match, .peer-review {
+  p, label {
+    font-size: 16px;
+    line-height: 24px;
+  }
+
+  #markdown {
+    // By default, nothing in the page body is selectable.
+    // On text-match levels there may be a reason to paste part of the
+    // level markdown (the question) into the answer box, so we want it
+    // to be selectable.
+    @include selectable;
+  }
+}
+
+.free-response {
   p, label, li {
     font-size: 16px;
     line-height: 24px;
@@ -2718,6 +2733,7 @@ a.download-video {
   h3 {
     font-size: 21px;
   }
+
   #markdown {
     // By default, nothing in the page body is selectable.
     // On text-match levels there may be a reason to paste part of the
@@ -2726,6 +2742,7 @@ a.download-video {
     @include selectable;
   }
 }
+
 
 .external .content-level {
   overflow: hidden;

--- a/dashboard/app/assets/stylesheets/application.scss
+++ b/dashboard/app/assets/stylesheets/application.scss
@@ -2702,9 +2702,21 @@ a.download-video {
 }
 
 .text-match, .free-response, .peer-review {
-  p, label {
+  p, label, li {
     font-size: 16px;
     line-height: 24px;
+  }
+
+  h1 {
+    font-size: 37px;
+  }
+
+  h2 {
+    font-size: 25px;
+  }
+
+  h3 {
+    font-size: 21px;
   }
   #markdown {
     // By default, nothing in the page body is selectable.

--- a/dashboard/app/assets/stylesheets/application.scss
+++ b/dashboard/app/assets/stylesheets/application.scss
@@ -2701,7 +2701,7 @@ a.download-video {
   }
 }
 
-.text-match, .peer-review {
+.text-match, .free-response, .peer-review {
   p, label {
     font-size: 16px;
     line-height: 24px;
@@ -2716,7 +2716,7 @@ a.download-video {
 }
 
 .free-response {
-  p, label, li {
+  li {
     font-size: 16px;
     line-height: 24px;
   }
@@ -2728,13 +2728,6 @@ a.download-video {
   }
   h3 {
     font-size: 21px;
-  }
-  #markdown {
-    // By default, nothing in the page body is selectable.
-    // On text-match levels there may be a reason to paste part of the
-    // level markdown (the question) into the answer box, so we want it
-    // to be selectable.
-    @include selectable;
   }
 }
 

--- a/dashboard/app/assets/stylesheets/application.scss
+++ b/dashboard/app/assets/stylesheets/application.scss
@@ -2706,7 +2706,6 @@ a.download-video {
     font-size: 16px;
     line-height: 24px;
   }
-
   #markdown {
     // By default, nothing in the page body is selectable.
     // On text-match levels there may be a reason to paste part of the
@@ -2721,19 +2720,15 @@ a.download-video {
     font-size: 16px;
     line-height: 24px;
   }
-
   h1 {
     font-size: 37px;
   }
-
   h2 {
     font-size: 25px;
   }
-
   h3 {
     font-size: 21px;
   }
-
   #markdown {
     // By default, nothing in the page body is selectable.
     // On text-match levels there may be a reason to paste part of the


### PR DESCRIPTION
This PR updates the font-size for `li`, `h1`, `h2`, and `h3` elements in free-response level types. `p` elements were already the proper font-size, but the code-mirroring styling is not rendering the correct font-size. A follow-up ticket was created to track that work. This was discovered during the CodeConnect hack-ai-thon. 

## Links

- Follow-up Jira: [AFL-646](https://codedotorg.atlassian.net/browse/AFL-646)

## Testing story

**Before**

<img width="900" height="480" alt="Screenshot 2026-05-13 at 11 23 03 AM" src="https://github.com/user-attachments/assets/602e0688-6326-482e-851c-6d681756b06b" />


<img width="898" height="432" alt="Screenshot 2026-05-13 at 11 23 12 AM" src="https://github.com/user-attachments/assets/19be6140-0a49-4b19-8ccd-3d2f7cd54a9c" />

**After**
<img width="915" height="525" alt="Screenshot 2026-05-13 at 11 21 27 AM" src="https://github.com/user-attachments/assets/2e43d362-46ad-4e22-b71d-730057a74e29" />

<img width="904" height="352" alt="Screenshot 2026-05-13 at 11 22 04 AM" src="https://github.com/user-attachments/assets/b2070c46-9171-4b89-ac9f-b8aca15b9753" />

