### PR TITLE
Remove link from PL section name and code on My Professional Learning page

### DIFF
--- a/apps/src/templates/studioHomepages/SectionsAsStudentTable.jsx
+++ b/apps/src/templates/studioHomepages/SectionsAsStudentTable.jsx
@@ -124,13 +124,7 @@ class SectionsAsStudentTable extends React.Component {
               className="test-row"
             >
               <td style={{...styles.col, ...styles.sectionNameCol}}>
-                {this.props.isPlSections ? (
-                  <a style={styles.link} href={teacherDashboardUrl(section.id)}>
-                    {section.name}
-                  </a>
-                ) : (
-                  <div>{section.name}</div>
-                )}
+                <div>{section.name}</div>
               </td>
               <td style={{...styles.col, ...styles.courseCol}}>
                 <a href={section.linkToAssigned} style={styles.link}>

--- a/apps/src/templates/studioHomepages/SectionsAsStudentTable.jsx
+++ b/apps/src/templates/studioHomepages/SectionsAsStudentTable.jsx
@@ -4,7 +4,6 @@ import {connect} from 'react-redux';
 
 import fontConstants from '@cdo/apps/fontConstants';
 import Button from '@cdo/apps/legacySharedComponents/Button';
-import {teacherDashboardUrl} from '@cdo/apps/templates/teacherDashboard/urlHelpers';
 import color from '@cdo/apps/util/color';
 import {SectionLoginType} from '@cdo/generated-scripts/sharedConstants';
 import i18n from '@cdo/locale';
@@ -30,16 +29,7 @@ class SectionsAsStudentTable extends React.Component {
     } else if (section.login_type === SectionLoginType.google_classroom) {
       return i18n.loginTypeGoogleClassroom();
     } else {
-      return this.props.isPlSections ? (
-        <a
-          style={plTableLayoutStyles.sectionCodeLink}
-          href={teacherDashboardUrl(`${section.id}/login_info`)}
-        >
-          {section.code}
-        </a>
-      ) : (
-        section.code
-      );
+      return section.code;
     }
   }
 


### PR DESCRIPTION
The section name and code in the joined PL sections table on /my-professional-learning linked to the teacher dashboard, which is confusing. Making them plain text for now.

<img width="1302" height="437" alt="image" src="https://github.com/user-attachments/assets/398049d6-82bf-4d66-9253-a275276882b0" />


<!--
  Summary of the change: background, motivation, and context.
  Include screenshots, videos, or before/after comparisons for UI changes.
-->



## Links
<!-- Jira tickets, design docs, Slack threads, related PRs, etc. -->

- Jira:

## Testing story
<!-- How was this tested? Manual steps, adhoc links, automated tests, or why testing isn't needed. -->



## Deployment notes
<!-- Delete this section if it's a standard merge-and-deploy.
     Otherwise: migrations, feature flags, coordination, caching impacts, etc. -->



## Privacy and security
<!-- Delete this section if there is no privacy/security impact.
     Otherwise: new PII, auth changes, API surface changes, etc. -->

