### PR TITLE
AI Gateway - Discard stale pre-fetched Turnstile tokens

### DIFF
--- a/apps/src/aiGateway/turnstile/constants.ts
+++ b/apps/src/aiGateway/turnstile/constants.ts
@@ -3,6 +3,9 @@ export const TURNSTILE_SCRIPT_URL =
 export const CONTAINER_ID = 'turnstile-container';
 export const TURNSTILE_SITE_KEY = '0x4AAAAAACva3yXFGIuj6pR8';
 export const CHALLENGE_TIMEOUT_MS = 30_000;
+// Turnstile tokens expire after ~5 minutes. Discard a pre-fetched token
+// after 4 minutes so a stale one is never sent to the server.
+export const TOKEN_MAX_AGE_MS = 4 * 60 * 1000;
 // How long to wait for the probe Worker to respond before concluding it was
 // paused by the DevTools debugger. The Worker posts a message in microseconds
 // when not paused, so 100 ms is an unambiguous signal — and short enough

--- a/apps/src/aiGateway/turnstile/manager.ts
+++ b/apps/src/aiGateway/turnstile/manager.ts
@@ -2,6 +2,7 @@ import {
   CHALLENGE_TIMEOUT_MS,
   CONTAINER_ID,
   LOG,
+  TOKEN_MAX_AGE_MS,
   TURNSTILE_SITE_KEY,
 } from './constants';
 import {debuggerWillPauseInAnonymousScope} from './debuggerProbe';
@@ -38,6 +39,10 @@ export class TurnstileManager {
   // Cleared to null immediately when taken so a concurrent synchronous caller
   // cannot claim the same one-time-use token.
   private nextTokenPromise: Promise<string> | null = null;
+
+  // Timestamp (Date.now()) recorded when nextTokenPromise resolved. Used to
+  // detect tokens older than TOKEN_MAX_AGE_MS before they are consumed.
+  private nextTokenResolvedAt: number | null = null;
 
   private widgetId: string | null = null;
 
@@ -135,11 +140,26 @@ export class TurnstileManager {
 
   private getToken(): Promise<string> {
     if (this.nextTokenPromise) {
-      console.log(`${LOG} Pre-fetch hit — returning in-progress token`);
-      const p = this.nextTokenPromise;
-      this.nextTokenPromise = null;
-      this.schedulePrefetch();
-      return p;
+      const age =
+        this.nextTokenResolvedAt !== null
+          ? Date.now() - this.nextTokenResolvedAt
+          : null;
+      if (age !== null && age > TOKEN_MAX_AGE_MS) {
+        console.log(
+          `${LOG} Pre-fetch token stale (${(age / 1000).toFixed(0)}s old) — discarding and starting fresh`
+        );
+        this.nextTokenPromise = null;
+        this.nextTokenResolvedAt = null;
+      } else {
+        console.log(
+          `${LOG} Pre-fetch hit — returning in-progress token${age !== null ? ` (${(age / 1000).toFixed(0)}s old)` : ' (pending)'}`
+        );
+        const p = this.nextTokenPromise;
+        this.nextTokenPromise = null;
+        this.nextTokenResolvedAt = null;
+        this.schedulePrefetch();
+        return p;
+      }
     }
 
     console.log(`${LOG} Pre-fetch miss — enqueueing fresh challenge`);
@@ -161,6 +181,7 @@ export class TurnstileManager {
     this.nextTokenPromise = p;
     p.then(
       token => {
+        this.nextTokenResolvedAt = Date.now();
         console.log(
           `${LOG} Pre-fetch resolved — token ready (len=${token.length})`
         );
@@ -172,7 +193,10 @@ export class TurnstileManager {
           `${LOG} Pre-fetch failed — clearing nextTokenPromise:`,
           err
         );
-        if (this.nextTokenPromise === p) this.nextTokenPromise = null;
+        if (this.nextTokenPromise === p) {
+          this.nextTokenPromise = null;
+          this.nextTokenResolvedAt = null;
+        }
       }
     );
   }

--- a/apps/test/unit/aiGateway/turnstile/turnstileTest.ts
+++ b/apps/test/unit/aiGateway/turnstile/turnstileTest.ts
@@ -57,6 +57,14 @@ describe('fetchTurnstileTokenIfEnabled', () => {
   });
 });
 
+// Typed view of TurnstileManager's private internals used only in tests.
+type TurnstileManagerPrivates = {
+  nextTokenPromise: Promise<string> | null;
+  nextTokenResolvedAt: number | null;
+  getToken: () => Promise<string>;
+  runSerializedChallenge: () => Promise<string>;
+};
+
 describe('TurnstileManager stale pre-fetch', () => {
   beforeEach(() => {
     document.body.innerHTML = '';
@@ -68,17 +76,14 @@ describe('TurnstileManager stale pre-fetch', () => {
   });
 
   it('discards a pre-fetched token older than TOKEN_MAX_AGE_MS and runs a fresh challenge', async () => {
-    const manager = TurnstileManager.getInstance();
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const m = manager as any;
+    const m = TurnstileManager.getInstance() as unknown as TurnstileManagerPrivates;
 
     const freshToken = 'fresh-token';
     const freshChallenge = jest.fn().mockResolvedValue(freshToken);
     jest.spyOn(m, 'runSerializedChallenge').mockImplementation(freshChallenge);
 
     // Simulate a stale pre-fetched token that resolved TOKEN_MAX_AGE_MS + 1s ago.
-    const staleToken = 'stale-token';
-    m.nextTokenPromise = Promise.resolve(staleToken);
+    m.nextTokenPromise = Promise.resolve('stale-token');
     m.nextTokenResolvedAt = Date.now() - TOKEN_MAX_AGE_MS - 1000;
 
     const result = await m.getToken();
@@ -88,9 +93,7 @@ describe('TurnstileManager stale pre-fetch', () => {
   });
 
   it('uses a pre-fetched token that is still within TOKEN_MAX_AGE_MS', async () => {
-    const manager = TurnstileManager.getInstance();
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const m = manager as any;
+    const m = TurnstileManager.getInstance() as unknown as TurnstileManagerPrivates;
 
     const freshChallenge = jest.fn().mockResolvedValue('ignored');
     jest.spyOn(m, 'runSerializedChallenge').mockImplementation(freshChallenge);

--- a/apps/test/unit/aiGateway/turnstile/turnstileTest.ts
+++ b/apps/test/unit/aiGateway/turnstile/turnstileTest.ts
@@ -1,4 +1,5 @@
 import {TurnstileManager} from '@cdo/apps/aiGateway/turnstile/manager';
+import {TOKEN_MAX_AGE_MS} from '@cdo/apps/aiGateway/turnstile/constants';
 import {
   fetchTurnstileTokenIfEnabled,
   turnstileHeaders,
@@ -53,6 +54,73 @@ describe('fetchTurnstileTokenIfEnabled', () => {
 
     expect(getInstanceSpy).toHaveBeenCalled();
     expect(result).toBe(mockToken);
+  });
+});
+
+describe('TurnstileManager stale pre-fetch', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '';
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('discards a pre-fetched token older than TOKEN_MAX_AGE_MS and runs a fresh challenge', async () => {
+    const manager = TurnstileManager.getInstance();
+    const m = manager as unknown as {
+      nextTokenPromise: Promise<string> | null;
+      nextTokenResolvedAt: number | null;
+      getToken: () => Promise<string>;
+    };
+
+    const freshToken = 'fresh-token';
+    const freshChallenge = jest.fn().mockResolvedValue(freshToken);
+    jest
+      .spyOn(
+        manager as unknown as {runSerializedChallenge: () => Promise<string>},
+        'runSerializedChallenge' as never
+      )
+      .mockImplementation(freshChallenge);
+
+    // Simulate a stale pre-fetched token that resolved TOKEN_MAX_AGE_MS + 1s ago.
+    const staleToken = 'stale-token';
+    m.nextTokenPromise = Promise.resolve(staleToken);
+    m.nextTokenResolvedAt = Date.now() - TOKEN_MAX_AGE_MS - 1000;
+
+    const result = await m.getToken();
+
+    expect(result).toBe(freshToken);
+    expect(freshChallenge).toHaveBeenCalledTimes(1);
+  });
+
+  it('uses a pre-fetched token that is still within TOKEN_MAX_AGE_MS', async () => {
+    const manager = TurnstileManager.getInstance();
+    const m = manager as unknown as {
+      nextTokenPromise: Promise<string> | null;
+      nextTokenResolvedAt: number | null;
+      getToken: () => Promise<string>;
+    };
+
+    const freshChallenge = jest.fn();
+    jest
+      .spyOn(
+        manager as unknown as {runSerializedChallenge: () => Promise<string>},
+        'runSerializedChallenge' as never
+      )
+      .mockImplementation(freshChallenge);
+
+    const validToken = 'valid-token';
+    m.nextTokenPromise = Promise.resolve(validToken);
+    m.nextTokenResolvedAt = Date.now() - 60_000; // 1 minute old — well within limit
+
+    const result = await m.getToken();
+
+    expect(result).toBe(validToken);
+    // runSerializedChallenge called once for the scheduled pre-fetch, not to
+    // replace the valid token.
+    expect(freshChallenge).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/apps/test/unit/aiGateway/turnstile/turnstileTest.ts
+++ b/apps/test/unit/aiGateway/turnstile/turnstileTest.ts
@@ -90,7 +90,8 @@ describe('TurnstileManager stale pre-fetch', () => {
     const result = await m.getToken();
 
     expect(result).toBe(freshToken);
-    expect(freshChallenge).toHaveBeenCalledTimes(1);
+    // call #1: fresh challenge replacing stale token; call #2: schedulePrefetch after delivery
+    expect(freshChallenge).toHaveBeenCalledTimes(2);
   });
 
   it('uses a pre-fetched token that is still within TOKEN_MAX_AGE_MS', async () => {

--- a/apps/test/unit/aiGateway/turnstile/turnstileTest.ts
+++ b/apps/test/unit/aiGateway/turnstile/turnstileTest.ts
@@ -69,20 +69,12 @@ describe('TurnstileManager stale pre-fetch', () => {
 
   it('discards a pre-fetched token older than TOKEN_MAX_AGE_MS and runs a fresh challenge', async () => {
     const manager = TurnstileManager.getInstance();
-    const m = manager as unknown as {
-      nextTokenPromise: Promise<string> | null;
-      nextTokenResolvedAt: number | null;
-      getToken: () => Promise<string>;
-    };
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const m = manager as any;
 
     const freshToken = 'fresh-token';
     const freshChallenge = jest.fn().mockResolvedValue(freshToken);
-    jest
-      .spyOn(
-        manager as unknown as {runSerializedChallenge: () => Promise<string>},
-        'runSerializedChallenge' as never
-      )
-      .mockImplementation(freshChallenge);
+    jest.spyOn(m, 'runSerializedChallenge').mockImplementation(freshChallenge);
 
     // Simulate a stale pre-fetched token that resolved TOKEN_MAX_AGE_MS + 1s ago.
     const staleToken = 'stale-token';
@@ -97,19 +89,11 @@ describe('TurnstileManager stale pre-fetch', () => {
 
   it('uses a pre-fetched token that is still within TOKEN_MAX_AGE_MS', async () => {
     const manager = TurnstileManager.getInstance();
-    const m = manager as unknown as {
-      nextTokenPromise: Promise<string> | null;
-      nextTokenResolvedAt: number | null;
-      getToken: () => Promise<string>;
-    };
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const m = manager as any;
 
-    const freshChallenge = jest.fn();
-    jest
-      .spyOn(
-        manager as unknown as {runSerializedChallenge: () => Promise<string>},
-        'runSerializedChallenge' as never
-      )
-      .mockImplementation(freshChallenge);
+    const freshChallenge = jest.fn().mockResolvedValue('ignored');
+    jest.spyOn(m, 'runSerializedChallenge').mockImplementation(freshChallenge);
 
     const validToken = 'valid-token';
     m.nextTokenPromise = Promise.resolve(validToken);


### PR DESCRIPTION
## Summary

Add token age tracking to the Turnstile pre-fetch mechanism to prevent using tokens that are older than 4 minutes. Turnstile tokens expire after ~5 minutes, so this ensures we never send a stale token to the worker.

### Changes

- Added `TOKEN_MAX_AGE_MS` constant (4 minutes) to `constants.ts`
- Track `nextTokenResolvedAt` timestamp in `TurnstileManager` to record when a pre-fetched token resolves
- Modified `getToken()` to check token age and discard tokens older than `TOKEN_MAX_AGE_MS`, triggering a fresh challenge instead
- Updated logging to show token age when available
- Clear `nextTokenResolvedAt` when discarding or consuming tokens

## Testing

Added comprehensive unit tests covering:
- Discarding pre-fetched tokens older than `TOKEN_MAX_AGE_MS` and running a fresh challenge
- Using pre-fetched tokens that are still within the age limit

All existing tests continue to pass.

## Deployment notes

No special deployment considerations. This is a defensive change that prevents potential token expiration issues without affecting the normal pre-fetch flow.

https://claude.ai/code/session_018DrDDaQ8zye3sYBgXFe7qf