### PR TITLE
feat(observability): enable Sentry and OpenTelemetry on levelbuilder

### DIFF
--- a/config/levelbuilder.yml.erb
+++ b/config/levelbuilder.yml.erb
@@ -24,3 +24,9 @@ active_job_backend_rolling_restart_in_n_batches: 2
 
 # HoC/HoAI tracking configuration
 hoc_tracking_enabled: false
+
+# Enables OpenTelemetry instrumentation
+enable_opentelemetry: true
+
+# Enables Sentry error reporting and tracing.
+enable_sentry: true


### PR DESCRIPTION
Adds Sentry error reporting and OpenTelemetry tracing to the `levelbuilder` rack environment, bringing it in line with `staging` and `production`. Crashes in both the puma web server and the delayed_job backend workers on `levelbuilder-studio.code.org` will now surface in Sentry with trace context attached, so curriculum-team-facing bugs are diagnosable instead of silent.

## What the engine does for us

```mermaid
flowchart LR
    subgraph levelbuilder["levelbuilder rack env"]
        direction TB
        puma["puma (web)"]
        dj["delayed_job workers (backend)"]
        rake["rake / runner"]
    end

    puma -->|Rails boot| engine
    dj   -->|Rails boot| engine
    rake -->|Rails boot| engine

    subgraph engine["Observability::Engine"]
        sentry_init["observability.sentry initializer"]
        otel_init["observability.opentelemetry initializer"]
        otel_init --> sentry_init
    end

    sentry_init -->|errors + traces over HTTPS| sentry[("Sentry")]
    otel_init   -->|OTLP/HTTP| collector["cdo-otel-collector (local)"]
    collector   -->|OTLP/HTTP| sentry
```

## Error flow

```mermaid
sequenceDiagram
    participant Web as puma worker
    participant Job as delayed_job worker
    participant SR as sentry-rails
    participant Sentry

    Web->>SR: raises ActionController::* or app error
    SR->>Sentry: capture_exception (with OTel trace context)
    Job->>SR: ActiveJob perform raises
    SR->>Sentry: capture_exception (job class, args sanitized)
    Note over Sentry: events grouped per Rails project DSN<br/>(levelbuilder/cdo/dashboard_sentry_dsn)
```