### PR TITLE
Migrate /catalog page to semantic colors and design-system icons

### DIFF
--- a/apps/src/templates/curriculumCatalog/CurriculumCatalog.jsx
+++ b/apps/src/templates/curriculumCatalog/CurriculumCatalog.jsx
@@ -7,6 +7,7 @@
 import CurriculumCatalogCard from '@cdo/apps/templates/curriculumCatalog/CurriculumCatalogCard';
 /* eslint-enable import/order */
 
+import CloseButton from '@code-dot-org/component-library/closeButton';
 import HeroBanner from '@code-dot-org/component-library/heroBanner';
 import {Typography} from '@mui/material';
 import PropTypes from 'prop-types';
@@ -304,13 +305,10 @@ const CurriculumCatalog = ({
             <Typography variant="body2" gutterBottom>
               {assignSuccessMessage}
             </Typography>
-            <button
+            <CloseButton
               aria-label="close success message"
               onClick={handleCloseAssignSuccessMessage}
-              type="button"
-            >
-              <strong>X</strong>
-            </button>
+            />
           </div>
         </div>
       )}

--- a/apps/src/templates/curriculumCatalog/CurriculumCatalogCard.jsx
+++ b/apps/src/templates/curriculumCatalog/CurriculumCatalogCard.jsx
@@ -1,3 +1,4 @@
+import FontAwesomeV6Icon from '@code-dot-org/component-library/fontAwesomeV6Icon';
 import {Button as MuiButton, Typography} from '@mui/material';
 import classNames from 'classnames';
 import {concat, intersection} from 'lodash';
@@ -6,7 +7,6 @@ import React, {useEffect, useState} from 'react';
 import {createPortal} from 'react-dom';
 import {connect} from 'react-redux';
 
-import FontAwesome from '@cdo/apps/legacySharedComponents/FontAwesome';
 import {EVENTS} from '@cdo/apps/metrics/AnalyticsConstants';
 import analyticsReporter from '@cdo/apps/metrics/AnalyticsReporter';
 import CardLabels from '@cdo/apps/templates/curriculumCatalog/CardLabels';
@@ -289,11 +289,11 @@ const CustomizableCurriculumCatalogCard = ({
           </Typography>
           <div className={style.wideCardAspects}>
             <div className={style.iconWithDescription}>
-              <FontAwesome icon="user" className="fa-solid" />
+              <FontAwesomeV6Icon iconName="user" iconStyle="solid" />
               <p>{gradeRange}</p>
             </div>
             <div className={style.iconWithDescription}>
-              <FontAwesome icon="clock" className="fa-solid" />
+              <FontAwesomeV6Icon iconName="clock" iconStyle="solid" />
               <p>{duration}</p>
             </div>
           </div>
@@ -305,20 +305,20 @@ const CustomizableCurriculumCatalogCard = ({
           <div className={style.labelsAndTranslatabilityContainer}>
             <CardLabels subjectsAndTopics={subjectsAndTopics} />
             {!isEnglish && isTranslated && (
-              <FontAwesome
-                icon="language"
-                className="fa-solid"
+              <FontAwesomeV6Icon
+                iconName="language"
+                iconStyle="solid"
                 title={translationIconTitle}
               />
             )}
           </div>
           <h4>{courseDisplayName}</h4>
           <div className={style.iconWithDescription}>
-            <FontAwesome icon="user" className="fa-solid" />
+            <FontAwesomeV6Icon iconName="user" iconStyle="solid" />
             <p>{gradeRange}</p>
           </div>
           <div className={style.iconWithDescription}>
-            <FontAwesome icon="clock" className="fa-solid" />
+            <FontAwesomeV6Icon iconName="clock" iconStyle="solid" />
             <p>{duration}</p>
           </div>
         </div>

--- a/apps/src/templates/curriculumCatalog/CurriculumCatalogFilters.jsx
+++ b/apps/src/templates/curriculumCatalog/CurriculumCatalogFilters.jsx
@@ -1,9 +1,9 @@
+import FontAwesomeV6Icon from '@code-dot-org/component-library/fontAwesomeV6Icon';
 import Toggle from '@code-dot-org/component-library/toggle';
 import {Typography} from '@mui/material';
 import PropTypes from 'prop-types';
 import React, {useState, useEffect, useCallback} from 'react';
 
-import FontAwesome from '@cdo/apps/legacySharedComponents/FontAwesome';
 import {EVENTS} from '@cdo/apps/metrics/AnalyticsConstants';
 import analyticsReporter from '@cdo/apps/metrics/AnalyticsReporter';
 import CourseOfferingsFilters from '@cdo/apps/templates/courseOfferings/filters/CourseOfferingsFilters';
@@ -193,9 +193,10 @@ const CurriculumCatalogFilters = ({
                 numCurricula: numFilteredTranslatedCurricula,
                 language: languageNativeName,
               })}
-              <FontAwesome
-                icon="language"
-                className={`fa-solid ${style.iconVerticalCenter}`}
+              <FontAwesomeV6Icon
+                iconName="language"
+                iconStyle="solid"
+                className={style.iconVerticalCenter}
                 title={i18n.courseInYourLanguage()}
               />
             </Typography>

--- a/apps/src/templates/curriculumCatalog/ExpandedCurriculumCatalogCard.jsx
+++ b/apps/src/templates/curriculumCatalog/ExpandedCurriculumCatalogCard.jsx
@@ -1,11 +1,8 @@
+import CloseButton from '@code-dot-org/component-library/closeButton';
 import FontAwesomeV6Icon from '@code-dot-org/component-library/fontAwesomeV6Icon';
 import Link from '@code-dot-org/component-library/link';
 import {TextLink} from '@dsco_/link';
-import {
-  Button as MuiButton,
-  IconButton as MuiIconButton,
-  Typography,
-} from '@mui/material';
+import {Button as MuiButton, Typography} from '@mui/material';
 import PropTypes from 'prop-types';
 import React, {useEffect, useRef} from 'react';
 
@@ -331,16 +328,11 @@ const ExpandedCurriculumCatalogCard = ({
             </div>
             <div className={style.relatedCurriculaContainer}>
               <div className={style.closeButtonContainer}>
-                <MuiIconButton
+                <CloseButton
                   onClick={onClose}
-                  variant="text"
-                  color="secondary"
-                  size="medium"
-                  className={style.closeButton}
                   aria-label="Close Button"
-                >
-                  <FontAwesomeV6Icon iconName="xmark" iconStyle="solid" />
-                </MuiIconButton>
+                  size="l"
+                />
               </div>
               {recommendedSimilarCurriculum && (
                 <div className={style.relatedContainer}>

--- a/apps/src/templates/curriculumCatalog/ExpandedCurriculumCatalogCard.jsx
+++ b/apps/src/templates/curriculumCatalog/ExpandedCurriculumCatalogCard.jsx
@@ -9,7 +9,6 @@ import {
 import PropTypes from 'prop-types';
 import React, {useEffect, useRef} from 'react';
 
-import FontAwesome from '@cdo/apps/legacySharedComponents/FontAwesome';
 import {EVENTS} from '@cdo/apps/metrics/AnalyticsConstants';
 import analyticsReporter from '@cdo/apps/metrics/AnalyticsReporter';
 import {AiChatToolsDependency} from '@cdo/generated-scripts/sharedConstants';
@@ -130,19 +129,19 @@ const ExpandedCurriculumCatalogCard = ({
               </Typography>
               <div className={style.infoContainer}>
                 <div className={style.iconWithDescription}>
-                  <FontAwesome icon="user" className="fa-solid" />
+                  <FontAwesomeV6Icon iconName="user" iconStyle="solid" />
                   <Typography variant="body2" gutterBottom>
                     {gradeRange}
                   </Typography>
                 </div>
                 <div className={style.iconWithDescription}>
-                  <FontAwesome icon="clock" className="fa-solid" />
+                  <FontAwesomeV6Icon iconName="clock" iconStyle="solid" />
                   <Typography variant="body2" gutterBottom>
                     {duration}
                   </Typography>
                 </div>
                 <div className={style.iconWithDescription}>
-                  <FontAwesome icon="book" className="fa-solid" />
+                  <FontAwesomeV6Icon iconName="book" iconStyle="solid" />
                   <Typography
                     className={style.subjectsText}
                     variant="body2"
@@ -222,9 +221,9 @@ const ExpandedCurriculumCatalogCard = ({
                             text={i18n.facilitatorLedWorkshops()}
                             href={professionalLearningProgram}
                             icon={
-                              <FontAwesome
-                                icon="arrow-up-right-from-square"
-                                className="fa-solid"
+                              <FontAwesomeV6Icon
+                                iconName="arrow-up-right-from-square"
+                                iconStyle="solid"
                               />
                             }
                           />
@@ -238,9 +237,9 @@ const ExpandedCurriculumCatalogCard = ({
                             text={i18n.selfPacedPl()}
                             href={selfPacedPlCourseOfferingPath}
                             icon={
-                              <FontAwesome
-                                icon="arrow-up-right-from-square"
-                                className="fa-solid"
+                              <FontAwesomeV6Icon
+                                iconName="arrow-up-right-from-square"
+                                iconStyle="solid"
                               />
                             }
                           />
@@ -255,11 +254,10 @@ const ExpandedCurriculumCatalogCard = ({
                   device =>
                     devices[device] !== '' && (
                       <div key={device} className={style.iconWithDescription}>
-                        <FontAwesome
-                          icon={iconData[devices[device]].icon}
-                          className={`fa-solid ${
-                            iconData[devices[device]].color
-                          }`}
+                        <FontAwesomeV6Icon
+                          iconName={iconData[devices[device]].icon}
+                          iconStyle="solid"
+                          className={iconData[devices[device]].color}
                         />
                         <Typography variant="body2" gutterBottom>
                           {device !== 'no_device'

--- a/apps/src/templates/curriculumCatalog/curriculum_catalog_card.module.scss
+++ b/apps/src/templates/curriculumCatalog/curriculum_catalog_card.module.scss
@@ -35,18 +35,18 @@ $container-width: 309px;
   display: flex;
   flex-flow: column;
   height: 100%;
-  border: 1px solid $neutral_dark20;
+  border: 1px solid var(--borders-neutral-primary);
   border-top: 0;
   border-radius: 0 0 $border-radius $border-radius;
   padding: 1.25em 1em;
 
   i {
-    color: $neutral_dark80;
+    color: var(--text-neutral-quaternary);
   }
 
   h4 {
     margin-bottom: 0.75em;
-    color: $neutral_dark;
+    color: var(--text-neutral-primary);
 
     // Shows max two lines before truncating with ellipsis
     // See https://css-tricks.com/line-clampin/
@@ -77,7 +77,7 @@ $container-width: 309px;
   > p {
     font-size: 0.875em;
     margin: 0;
-    color: $neutral_dark;
+    color: var(--text-neutral-primary);
   }
 
   i {
@@ -147,13 +147,13 @@ $container-width: 309px;
   }
 
   .arrowContainer:before {
-    background: $neutral_light;
+    background: var(--background-neutral-secondary);
   }
 }
 
 .expandedCard {
   .curriculumInfoContainer {
-    border-color: $neutral-dark !important;
+    border-color: var(--borders-neutral-solid) !important;
   }
 }
 
@@ -192,7 +192,7 @@ button.buttonFlex {
 
   .expandedCard {
     .curriculumInfoContainer {
-      border-color: $neutral_dark20 !important;
+      border-color: var(--borders-neutral-primary) !important;
     }
   }
 
@@ -216,8 +216,8 @@ button.buttonFlex {
   flex: 1 0 0;
   width: 100%;
   border-radius: 4px;
-  border: 1px solid $neutral_dark;
-  background: $neutral_white;
+  border: 1px solid var(--borders-neutral-solid);
+  background: var(--background-neutral-primary);
 
   img {
     min-height: 320px;

--- a/apps/src/templates/curriculumCatalog/curriculum_catalog_card.module.scss
+++ b/apps/src/templates/curriculumCatalog/curriculum_catalog_card.module.scss
@@ -41,7 +41,7 @@ $container-width: 309px;
   padding: 1.25em 1em;
 
   i {
-    color: var(--text-neutral-quaternary);
+    color: var(--text-neutral-secondary);
   }
 
   h4 {

--- a/apps/src/templates/curriculumCatalog/expanded_curriculum_catalog_card.module.scss
+++ b/apps/src/templates/curriculumCatalog/expanded_curriculum_catalog_card.module.scss
@@ -59,7 +59,7 @@ $container-width: 960px;
 
   i {
     text-decoration: none;
-    color: $neutral_dark80;
+    color: var(--text-neutral-quaternary);
     font-size: 20px;
   }
 }
@@ -94,23 +94,23 @@ $container-width: 960px;
 
 .expandedCardContainer {
   position: relative;
-  background-color: $neutral_white;
-  border: 1px solid $neutral_dark;
+  background-color: var(--background-neutral-primary);
+  border: 1px solid var(--borders-neutral-solid);
   border-radius: 4px;
   width: $container-width;
   box-sizing: border-box;
 }
 
 .circleCheck {
-  color: $product_affirmative_default !important;
+  color: var(--text-success-primary) !important;
 }
 
 .circleXmark {
-  color: $product_negative_default !important;
+  color: var(--text-error-primary) !important;
 }
 
 .triangleExclamation {
-  color: $product_caution_default !important;
+  color: var(--text-warning-primary) !important;
 }
 
 .flexDivider {
@@ -118,7 +118,7 @@ $container-width: 960px;
 }
 
 .horizontalDivider {
-  border-top: 1px solid $neutral_dark20;
+  border-top: 1px solid var(--borders-neutral-primary);
 }
 
 .iconStyle {
@@ -138,18 +138,18 @@ $container-width: 960px;
   > p {
     font-size: 0.875rem;
     margin: 0;
-    color: $neutral_dark;
+    color: var(--text-neutral-primary);
   }
 
   i {
     font-size: 0.875rem;
-    color: $neutral_dark80;
+    color: var(--text-neutral-quaternary);
     line-height: 1.48;
   }
 }
 
 .aiBotIcon.aiBotIcon {
-  color: $light_aqua_700;
+  color: var(--text-brand-aqua-primary);
   font-size: 1rem;
 }
 
@@ -177,12 +177,12 @@ p.subjectsText {
 .professionalLearningContainer,
 .relatedContainer {
   a {
-    color: $brand_secondary_default !important;
+    color: var(--text-brand-purple-primary) !important;
     text-decoration: underline !important;
   }
 
   a:hover {
-    color: $brand_secondary_dark !important;
+    color: var(--text-brand-purple-secondary) !important;
     text-decoration: none !important;
   }
 }
@@ -194,14 +194,14 @@ p.subjectsText {
     width: 100%;
     text-wrap: wrap;
     margin-top: 8px;
-    color: $brand_secondary_default;
+    color: var(--text-brand-purple-primary);
     text-decoration: none !important;
     font-size: 12px;
     text-align: center;
   }
 
   .relatedCurriculaLink:hover {
-    color: $brand_secondary_dark;
+    color: var(--text-brand-purple-secondary);
   }
 
   h4 {
@@ -219,7 +219,7 @@ p.subjectsText {
 }
 
 .relatedCurriculaContainer {
-  background-color: $neutral_light;
+  background-color: var(--background-neutral-secondary);
   width: 224px;
   padding: 16px;
   border-radius: 0 4px 4px 0;
@@ -238,11 +238,11 @@ p.subjectsText {
 
   a {
     text-decoration: none;
-    color: $neutral_dark !important;
+    color: var(--text-neutral-primary) !important;
   }
 
   a:hover {
-    color: $brand_secondary_default !important;
+    color: var(--text-brand-purple-primary) !important;
   }
 
   p {
@@ -252,7 +252,7 @@ p.subjectsText {
 }
 
 .thickDivider {
-  border-top: 2px solid $neutral_dark20;
+  border-top: 2px solid var(--borders-neutral-primary);
 }
 
 .videoContainer {
@@ -264,7 +264,7 @@ p.subjectsText {
   position: relative;
   max-width: 600px;
   height: auto;
-  border: 1px solid $neutral_white;
+  border: 1px solid var(--background-neutral-primary);
   padding-top: 16px;
   box-sizing: border-box;
 }
@@ -273,15 +273,15 @@ p.subjectsText {
   position: absolute;
   width: 20px;
   height: 20px;
-  border-top: 1px solid $neutral_dark;
-  border-left: 1px solid $neutral_dark;
+  border-top: 1px solid var(--borders-neutral-solid);
+  border-left: 1px solid var(--borders-neutral-solid);
   top: 100%;
   left: 54.5%;
   margin-left: -25px;
   content: '';
   transform: rotate(45deg);
   margin-top: -9px;
-  background: $neutral_white;
+  background: var(--background-neutral-primary);
   z-index: 1;
 }
 

--- a/apps/src/templates/curriculumCatalog/expanded_curriculum_catalog_card.module.scss
+++ b/apps/src/templates/curriculumCatalog/expanded_curriculum_catalog_card.module.scss
@@ -39,29 +39,6 @@ $container-width: 960px;
   display: flex;
   justify-content: end;
   line-height: normal;
-
-  button.closeButton {
-    background: none;
-    border: none;
-    padding: 0;
-    margin: 0;
-    outline: none;
-    height: auto;
-  }
-
-  button:active {
-    border: none !important;
-  }
-
-  button:hover {
-    background-color: transparent;
-  }
-
-  i {
-    text-decoration: none;
-    color: var(--text-neutral-quaternary);
-    font-size: 20px;
-  }
 }
 
 .compatibilityContainer {
@@ -143,7 +120,7 @@ $container-width: 960px;
 
   i {
     font-size: 0.875rem;
-    color: var(--text-neutral-quaternary);
+    color: var(--text-neutral-secondary);
     line-height: 1.48;
   }
 }
@@ -264,7 +241,7 @@ p.subjectsText {
   position: relative;
   max-width: 600px;
   height: auto;
-  border: 1px solid var(--borders-neutral-solid);
+  border: 1px solid transparent;
   padding-top: 16px;
   box-sizing: border-box;
 }

--- a/apps/src/templates/curriculumCatalog/no_sections_to_assign_dialog.module.scss
+++ b/apps/src/templates/curriculumCatalog/no_sections_to_assign_dialog.module.scss
@@ -1,4 +1,3 @@
-@import "color.scss";
 @import "breakpoints";
 
 .dialogContainer {
@@ -7,7 +6,7 @@
   flex-flow: column;
 
   hr {
-    border: 1px solid $neutral_dark;
+    border: 1px solid var(--borders-neutral-solid);
     margin: 1rem 0;
   }
 

--- a/apps/style/code-studio/curriculum_catalog_container.module.scss
+++ b/apps/style/code-studio/curriculum_catalog_container.module.scss
@@ -1,5 +1,3 @@
-@use 'color.scss';
-
 $container-width: 309px;
 
 :global(#curriculum-catalog-container) {
@@ -21,10 +19,10 @@ $container-width: 309px;
 .assignSuccessMessageContainer {
   display: flex;
   min-width: 250px;
-  background-color: color.$bootstrap_success_background;
+  background-color: var(--background-success-light);
   text-align: center;
   border-radius: 5px;
-  border-color: color.$bootstrap_success_border;
+  border-color: var(--borders-success-light);
   position: fixed;
   z-index: 4;
   top: 70px;
@@ -40,7 +38,7 @@ $container-width: 309px;
 
   p {
     margin: 16px;
-    color: color.$bootstrap_success_text;
+    color: var(--text-success-secondary);
   }
 }
 


### PR DESCRIPTION
## Summary
- Replace legacy SCSS color vars (`$neutral_*`, `$brand_secondary_*`, `$product_*`, `$light_aqua_700`, `$bootstrap_success_*`) on the `/catalog` page with semantic `var(--…)` tokens from `colors.css`, matching the family to the CSS property (`--background-…` / `--text-…` / `--borders-…`).
- Swap `@cdo/apps/legacySharedComponents/FontAwesome` for the DSCO `FontAwesomeV6Icon` across `CurriculumCatalog`, `CurriculumCatalogCard`, `CurriculumCatalogFilters`, and `ExpandedCurriculumCatalogCard`.
- Replace the inline `<button><strong>X</strong></button>` close affordance on the assign-success toast with the DSCO `CloseButton`.
- Buttons and dropdowns left untouched — handled under a separate initiative.

Before:
<img width="3456" height="5674" alt="image" src="https://github.com/user-attachments/assets/9bc2c6a6-386a-4698-a6f9-81d36e6e42ac" />
<img width="1189" height="660" alt="Знімок екрана 2026-05-15 о 14 46 02" src="https://github.com/user-attachments/assets/df8d80d3-6279-4385-9bc1-20919c984882" />


After:
<img width="3456" height="5674" alt="image" src="https://github.com/user-attachments/assets/8aaa1ecb-09ee-402b-a92f-5d330b53e489" />
<img width="1177" height="681" alt="Знімок екрана 2026-05-15 о 14 45 58" src="https://github.com/user-attachments/assets/6d1165dc-279a-40b9-ad98-6e4246f75cd1" />


## Test plan
- [ ] `./tools/hooks/pre-commit` clean
- [ ] `yarn run typecheck` (from `apps/`) clean
- [ ] Visit `/catalog` signed-out, as a student, and as a teacher; cards, filters, expanded card, "no results" view, and assign-success toast all render correctly
- [ ] Toggle non-English locale and confirm the translated-language toggle + language icon still render
- [ ] Open an expanded card and verify device-compatibility icons (success/error/warning) and AI-bot aqua icon are colored correctly
- [ ] Trigger assign-success toast and confirm DSCO `CloseButton` dismisses it

🤖 Generated with [Claude Code](https://claude.com/claude-code)