### PR TITLE
Update header font sizes for free-response questions

### DIFF
--- a/dashboard/app/assets/stylesheets/application.scss
+++ b/dashboard/app/assets/stylesheets/application.scss
@@ -2719,15 +2719,6 @@ a.download-video {
   li {
     font-size: 16px;
   }
-  h1 {
-    font-size: 32px;
-  }
-  h2 {
-    font-size: 22px;
-  }
-  h3, h4 {
-    font-size: 18px;
-  }
 }
 
 

--- a/dashboard/app/assets/stylesheets/application.scss
+++ b/dashboard/app/assets/stylesheets/application.scss
@@ -2739,15 +2739,15 @@ a.download-video {
   }
 
   h1 {
-    font-size: 32px;
+    font-size: 37px;
   }
 
   h2 {
-    font-size: 22px;
+    font-size: 25px;
   }
 
   h3, h4 {
-    font-size: 18px;
+    font-size: 21px;
   }
 }
 
@@ -2923,15 +2923,15 @@ a.download-video {
   }
 
   h1 {
-    font-size: 32px;
+    font-size: 37px;
   }
 
   h2 {
-    font-size: 22px;
+    font-size: 25px;
   }
 
   h3, h4 {
-    font-size: 18px;
+    font-size: 21px;
   }
 }
 

--- a/dashboard/app/assets/stylesheets/application.scss
+++ b/dashboard/app/assets/stylesheets/application.scss
@@ -2720,13 +2720,13 @@ a.download-video {
     font-size: 16px;
   }
   h1 {
-    font-size: 37px;
+    font-size: 32px;
   }
   h2 {
-    font-size: 25px;
+    font-size: 22px;
   }
-  h3 {
-    font-size: 21px;
+  h3, h4 {
+    font-size: 18px;
   }
 }
 
@@ -2739,19 +2739,15 @@ a.download-video {
   }
 
   h1 {
-    font-size: 37px;
+    font-size: 32px;
   }
 
   h2 {
-    font-size: 25px;
+    font-size: 22px;
   }
 
-  h3 {
-    font-size: 21px;
-  }
-
-  h4 {
-    font-size: 21px;
+  h3, h4 {
+    font-size: 18px;
   }
 }
 
@@ -2927,19 +2923,15 @@ a.download-video {
   }
 
   h1 {
-    font-size: 37px;
+    font-size: 32px;
   }
 
   h2 {
-    font-size: 25px;
+    font-size: 22px;
   }
 
-  h3 {
-    font-size: 21px;
-  }
-
-  h4 {
-    font-size: 21px;
+  h3, h4 {
+    font-size: 18px;
   }
 }
 


### PR DESCRIPTION
<!--
  Summary of the change: background, motivation, and context.
  Include screenshots, videos, or before/after comparisons for UI changes.
-->
This PR updates the font sizes for `h1`, `h2`, and `h3` for free response levels following up  https://github.com/code-dot-org/code-dot-org/pull/72667. Free response questions are included in the instructions panel in legacy labs, so we remove overwriting the header font sizes for `.free-response`. However the default `p` font size remains `16px` as preferred by the T&L team.

This essentially reverts https://github.com/code-dot-org/code-dot-org/pull/72667 other than the styling for `li`.

### Before update

<img width="1114" height="320" alt="37px" src="https://github.com/user-attachments/assets/22597785-3b86-497c-bc64-362f3ce8a762" />

### After update

<img width="1114" height="304" alt="18px" src="https://github.com/user-attachments/assets/c9cfaf37-4d36-41ad-bf0b-9364023b8ac1" />


## Links
<!-- Jira tickets, design docs, Slack threads, related PRs, etc. -->

- Jira:

## Testing story
<!-- How was this tested? Manual steps, adhoc links, automated tests, or why testing isn't needed. -->



## Deployment notes
<!-- Delete this section if it's a standard merge-and-deploy.
     Otherwise: migrations, feature flags, coordination, caching impacts, etc. -->



## Privacy and security
<!-- Delete this section if there is no privacy/security impact.
     Otherwise: new PII, auth changes, API surface changes, etc. -->

