### PR TITLE
add appropriate classes to markdown and instructions previews

### DIFF
--- a/dashboard/app/assets/stylesheets/application.scss
+++ b/dashboard/app/assets/stylesheets/application.scss
@@ -2721,7 +2721,8 @@ a.download-video {
   }
 }
 
-
+#level_markdown_textarea_preview.external.content-level,
+#level_long_instructions_preview.external.content-level,
 .external .content-level {
   overflow: hidden;
 

--- a/dashboard/app/views/levels/editors/fields/_dsl_fields.html.haml
+++ b/dashboard/app/views/levels/editors/fields/_dsl_fields.html.haml
@@ -39,7 +39,18 @@
       %p Edit Markdown:
 
       %textarea#level_markdown_textarea
-      #level_markdown_textarea_preview
+      #level_markdown_textarea_preview{
+        class: [
+          @level.is_a?(TextMatch) && 'text-match',
+          @level.is_a?(External) && 'external',
+          @level.is_a?(External) && 'content-level',
+          @level.is_a?(PeerReview) && 'peer-review',
+          @level.is_a?(Multi) && 'multi',
+          @level.is_a?(Match) && 'match',
+          @level.is_a?(BubbleChoice) && 'bubble-choice',
+          @level.is_a?(CurriculumReference) && 'curriculum-reference',
+        ]
+      }
 
   - if @level.is_a?(BubbleChoice)
     %h4 Tip: Lab2

--- a/dashboard/app/views/levels/editors/fields/_long_instructions.html.haml
+++ b/dashboard/app/views/levels/editors/fields/_long_instructions.html.haml
@@ -9,7 +9,13 @@
     to provide more in-depth (and more vertically intrusive) instruction.
 
   %div{ style: 'border: 8px solid rgb(239, 239, 239)' }
-    #level_long_instructions_preview{ style: 'padding: 20px' }
+    #level_long_instructions_preview{
+      class: [
+        @level.is_a?(FreeResponse) && 'free-response',
+        @level.is_a?(StandaloneVideo) && 'standalone-video',
+      ],
+      style: 'padding: 20px'
+    }
     %div{ style: 'background-color: rgb(239, 239, 239); padding-top: 12px' }
       ~ f.text_area :long_instructions, rows: 4
 


### PR DESCRIPTION
During the Hackathon at code connect, it was discovered that the instructions/markdown preview in level editing doesn't properly render for levels with specific styling. This PR adds styling for those specific level types.

## Links
- Jira: [AFL-646](https://codedotorg.atlassian.net/browse/AFL-646)

## Testing story
### Before
<img width="758" height="893" alt="image" src="https://github.com/user-attachments/assets/327d472d-5db3-40c8-87cc-8020e8a29029" />

### After
#### Free-respose level
<img width="756" height="919" alt="image" src="https://github.com/user-attachments/assets/1d7355f9-12d1-47d3-9f83-84bfc5bddd7b" />

#### External level
<img width="816" height="504" alt="image" src="https://github.com/user-attachments/assets/db12d879-75d1-4f92-8480-10d48035bdcb" />

#### Standalone video level
<img width="804" height="451" alt="image" src="https://github.com/user-attachments/assets/50c7c856-c653-4fa7-ab75-7f040d504218" />


#### AI Lab level (with correct smaller font size)
<img width="772" height="546" alt="image" src="https://github.com/user-attachments/assets/10abe0ca-9644-43b3-ab93-8d5f073fa535" />

#### Bubble Choice Level (with correct smaller font size)
<img width="812" height="435" alt="image" src="https://github.com/user-attachments/assets/42c2c1c2-94f4-4454-b875-596aacde42f5" />


## Deployment notes
May cause eyes diffs

