### PR TITLE
AI student podcast backend, part 1

### DIFF
--- a/dashboard/app/helpers/ai_system_prompts/student_podcast_prompt_helper.rb
+++ b/dashboard/app/helpers/ai_system_prompts/student_podcast_prompt_helper.rb
@@ -1,0 +1,90 @@
+module AiSystemPrompts::StudentPodcastPromptHelper
+  def self.get_openai_system_prompt(lesson_id, objective_ids, user_id = nil)
+    lesson_plan = get_lesson_materials(lesson_id, objective_ids, user_id)
+    intro = "
+You are an expert computer science teacher for middle and high school. You are writing a script for a conversational podcast between two characters, Dan and Sam. The audience for this podcast is students in your class, with an age range of 12-18. The goal is to help your students review the learning objectives in a lesson after they have completed the lesson. Dan represents the student. He is a curious learner, asks questions, reflects on confusion, and surfaces the student perspective. His tone should be informal and slightly uncertain. Sam represents the teacher. She is a relatable expert on the subject matter, explains concepts clearly, offers analogies, and keeps the conversation grounded.
+
+The podcast should consist of the following short segments:
+1. Intro: Dan and Sam introduce the lesson and the question of the day from the lesson.
+2. Lesson Overview: Sam provides a summary of the most important takeaways from the lesson. If there are discussion or 'Check for Understanding' questions in the lesson, Dan will ask about them and both hosts will discuss how to answer them.
+3. Learning Objectives: One segment per learning objective in the lesson. Dan will introduce each learning objective by asking a question about it. His questions should reflect common student misunderstandings about the material. Sam will provide clear answers and examples in response.
+4. Closing: Dan and Sam will close out the podcast by coming back to the question of the day to discuss and answer it.
+
+The language in each segment should be geared toward students in a middle and high school setting and should be friendly and conversational. Each segment should transition naturally from one to the next Avoid academic or formal language. Use contractions. Keep sentences short. Never introduce a technical term without immediately explaining it in plain language. Do not use passive voice, numbered lists, or academic phrasing in the dialog.
+
+The podcast should use examples from the provided resources, but also offer at least one alternative explanation drawn from everyday experiences familiar to teenagers: games, social media, smartphones, school life. By the end of the podcast, a listener should understand the learning objectives in at least 2 different ways. The podcast should be, at most, 3 minutes long.
+
+The script should be returned as a JSON object with a single 'script' key whose value is a list of dialog objects with the following format:
+{'voice_id': the name of the character speaking (Dan or Sam), 'text': The lines spoken by the character}
+
+Example: {\"script\": [{\"voice_id\": \"Dan\", \"text\": \"...\"}, {\"voice_id\": \"Sam\", \"text\": \"...\"}]}
+"
+
+    prompt = intro + "
+Use the following lesson plan and learning objectives to generate the podcast script:
+
+Lesson Name: #{lesson_plan[:name]}
+Lesson Overview: #{lesson_plan[:overview]}
+Learning Objectives: #{lesson_plan[:objectives].to_json}
+#{'Lesson Purpose: ' + lesson_plan[:purpose] if lesson_plan[:purpose]}
+#{'Assessment Opportunities: ' + lesson_plan[:assessment_opportunities] if lesson_plan[:assessment_opportunities]}
+Standards: #{lesson_plan[:standards].to_json}
+#{'Opportunity Standards: ' + lesson_plan[:opportunity_standards].to_json.to_s if lesson_plan[:opportunity_standards]}
+Activities: #{lesson_plan[:activities].to_json}
+Preparation: #{lesson_plan[:preparation]}
+Vocabulary: #{lesson_plan[:vocabularies].to_json}
+Unit overview: #{lesson_plan[:unit_overview].to_json}
+"
+    prompt
+  end
+
+  def self.get_lesson_materials(lesson_id, objective_ids, user_id = nil)
+    lesson = Lesson.find(lesson_id)
+    user = user_id ? User.find_by(id: user_id) : nil
+    lesson_materials = lesson.summarize_for_lesson_show(user, true)
+    @lesson_plan = {}
+    @lesson_plan[:name] = lesson.name
+    @lesson_plan[:overview] = lesson_materials[:overview]
+    @lesson_plan[:objectives] = []
+    lesson.objectives.each do |o|
+      @lesson_plan[:objectives] << o.description if objective_ids.include?(o.id)
+    end
+    @lesson_plan[:purpose] = lesson.purpose
+    @lesson_plan[:assessment_opportunities] = lesson.assessment_opportunities
+    @lesson_plan[:standards] = []
+    lesson.standards.each do |s|
+      @lesson_plan[:standards] << s.description
+    end
+    @lesson_plan[:opportunity_standards] = []
+    lesson.opportunity_standards.each do |s|
+      @lesson_plan[:opportunity_standards] << s.description
+    end
+    @lesson_plan[:activities] = []
+    lesson_materials[:activities].each do |a|
+      activity = {name: a[:name]}
+      activity[:sections] = []
+      a[:activitySections].each do |section|
+        sect = {description: "", levels: []}
+        sect[:description] = section[:description]
+        section[:scriptLevels].each do |sl|
+          sl[:levels].each do |l|
+            sect[:levels] << l[:longInstructions]
+            l[:containedLevels].each do |cl|
+              sect[:levels] << cl[:longInstructions]
+            end
+          end
+        end
+        activity[:sections] << sect
+      end
+      @lesson_plan[:activities] << activity
+    end
+    @lesson_plan[:preparation] = lesson.preparation
+    @lesson_plan[:vocabularies] = []
+    lesson_materials[:vocabularies].each do |v|
+      @lesson_plan[:vocabularies] << {word: v[:word], definition: v[:definition]}
+    end
+    localized_desc = Unit.find(lesson.script_id)&.localized_description
+    @lesson_plan[:unit_overview] = localized_desc ? Services::MarkdownPreprocessor.process(localized_desc) : nil
+    @lesson_plan
+  end
+end

--- a/dashboard/app/models/ai_student_podcast.rb
+++ b/dashboard/app/models/ai_student_podcast.rb
@@ -11,5 +11,5 @@
 #
 class AiStudentPodcast < ApplicationRecord
   has_many :ai_student_podcast_objectives, dependent: :destroy
-  has_many :objectives, join_table: :ai_student_podcast_objectives
+  has_many :objectives, through: :ai_student_podcast_objectives
 end

--- a/dashboard/app/models/ai_student_podcast_objective.rb
+++ b/dashboard/app/models/ai_student_podcast_objective.rb
@@ -1,0 +1,18 @@
+# == Schema Information
+#
+# Table name: ai_student_podcast_objectives
+#
+#  id                    :bigint           not null, primary key
+#  ai_student_podcast_id :bigint           not null
+#  objective_id          :integer          not null
+#
+# Indexes
+#
+#  index_ai_student_podcast_objectives_on_ai_student_podcast_id  (ai_student_podcast_id)
+#  index_ai_student_podcast_objectives_on_objective_id           (objective_id)
+#  index_ai_student_podcast_objectives_unique                    (ai_student_podcast_id,objective_id) UNIQUE
+#
+class AiStudentPodcastObjective < ApplicationRecord
+  belongs_to :ai_student_podcast
+  belongs_to :objective
+end

--- a/dashboard/test/helpers/ai_system_prompts/student_podcast_prompt_helper_test.rb
+++ b/dashboard/test/helpers/ai_system_prompts/student_podcast_prompt_helper_test.rb
@@ -1,0 +1,96 @@
+require 'test_helper'
+
+class AiSystemPrompts::StudentPodcastPromptHelperTest < ActionView::TestCase
+  setup do
+    @user = create(:teacher)
+    @lesson = create(:lesson,
+      name: 'Loops 101',
+      purpose: 'Students will understand loops',
+      preparation: 'Review variables',
+      assessment_opportunities: 'Observe code',
+      overview: 'A short intro to loops.'
+    )
+
+    I18n.stubs(:t).returns('fake unit description')
+
+    @objective1 = create(:objective, description: 'Define a loop')
+    @objective2 = create(:objective, description: 'Write a for loop')
+    @objective_unused = create(:objective, description: 'Should not be in prompt')
+    @lesson.objectives << [@objective1, @objective2, @objective_unused]
+
+    @standard = create(:standard, description: 'CS.K-2.Algorithms')
+    @lesson.standards << @standard
+
+    @vocab = create(:vocabulary, word: 'Loop', definition: 'Repeated work')
+    @lesson.vocabularies << @vocab
+
+    @activity = create(:lesson_activity, name: 'Loop practice')
+    @lesson.lesson_activities << @activity
+  end
+
+  # *****
+  # get_openai_system_prompt
+  # *****
+
+  test 'get_openai_system_prompt includes lesson basics in the prompt' do
+    prompt = AiSystemPrompts::StudentPodcastPromptHelper.
+      get_openai_system_prompt(@lesson.id, [@objective1.id, @objective2.id], @user.id)
+
+    assert_includes prompt, "Lesson Name: #{@lesson.name}"
+    assert_includes prompt, "Lesson Overview: #{@lesson.overview}"
+    assert_includes prompt, "Lesson Purpose: #{@lesson.purpose}"
+    assert_includes prompt, "Assessment Opportunities: #{@lesson.assessment_opportunities}"
+    assert_includes prompt, "Preparation: #{@lesson.preparation}"
+    assert_includes prompt, 'Standards:'
+    assert_includes prompt, @standard.description
+    assert_includes prompt, 'Vocabulary:'
+    assert_includes prompt, @vocab.word
+    assert_includes prompt, 'Activities:'
+    assert_includes prompt, @activity.name
+  end
+
+  test 'get_openai_system_prompt only includes the requested objective descriptions' do
+    prompt = AiSystemPrompts::StudentPodcastPromptHelper.
+      get_openai_system_prompt(@lesson.id, [@objective1.id], @user.id)
+
+    assert_includes prompt, @objective1.description
+    refute_includes prompt, @objective2.description
+    refute_includes prompt, @objective_unused.description
+  end
+
+  test 'get_openai_system_prompt describes the script JSON envelope expected by OpenaiClient' do
+    prompt = AiSystemPrompts::StudentPodcastPromptHelper.
+      get_openai_system_prompt(@lesson.id, [@objective1.id], @user.id)
+
+    assert_includes prompt, "'script' key"
+    assert_includes prompt, "voice_id"
+    assert_includes prompt, "text"
+  end
+
+  test 'get_openai_system_prompt works when user_id is nil' do
+    assert_nothing_raised do
+      AiSystemPrompts::StudentPodcastPromptHelper.
+        get_openai_system_prompt(@lesson.id, [@objective1.id])
+    end
+  end
+
+  # *****
+  # get_lesson_materials
+  # *****
+
+  test 'get_lesson_materials filters objectives to the requested ids' do
+    materials = AiSystemPrompts::StudentPodcastPromptHelper.
+      get_lesson_materials(@lesson.id, [@objective1.id], @user.id)
+
+    assert_equal [@objective1.description], materials[:objectives]
+  end
+
+  test 'get_lesson_materials looks up the user by user_id and tolerates an unknown id' do
+    User.expects(:find_by).with(id: 999_999).returns(nil)
+
+    assert_nothing_raised do
+      AiSystemPrompts::StudentPodcastPromptHelper.
+        get_lesson_materials(@lesson.id, [@objective1.id], 999_999)
+    end
+  end
+end


### PR DESCRIPTION
This update adds the following:

- student_podcast_prompt_helper.rb: Generates system prompt for student podcast script generation
- Adds model file for ai_student_podcast_objectives join table (table added in previous migration
- updates ai_student_podcast model file to correctly join on ai_student_podcast_objectives

## Links
[Tech Spec](https://docs.google.com/document/d/11PaNckag4LLh18f_MQcc92h-9FMqb3Pi8yGa1NtumaI/edit?tab=t.0)

## Testing story
Adds unit tests for student_podcast_prompt_helper

## Deployment notes
<!-- Delete this section if it's a standard merge-and-deploy.
     Otherwise: migrations, feature flags, coordination, caching impacts, etc. -->



## Privacy and security
<!-- Delete this section if there is no privacy/security impact.
     Otherwise: new PII, auth changes, API surface changes, etc. -->

