### PR TITLE
AI student podcast backend, part 2

### DIFF
--- a/dashboard/app/helpers/ai_student_podcasts_helper.rb
+++ b/dashboard/app/helpers/ai_student_podcasts_helper.rb
@@ -1,0 +1,213 @@
+class OpenaiStudentPodcastTimeout < StandardError; end
+
+module AiStudentPodcastsHelper
+  ELEVENLABS_MODEL = "eleven_v3"
+  OPENAI_MODEL = SharedConstants::EVALUATE_STUDENT_LEARNING_MODEL_VERSION
+  PODCAST_BUCKET = CDO.dashboard_hostname.split('.').reverse.join('.') + '.user-content'
+  PODCAST_FOLDER = 'student_podcasts/'
+  VOICE_ID_DAN = "0sqkv877qKv8jUXFfsXj"
+  VOICE_ID_SAM = "w7LY6CndrQObaTsPvYeB"
+
+  def self.create_and_save_to_s3(student_podcast_data)
+    filename = s3_filename(student_podcast_data.id)
+    return if AWS::S3.exists_in_bucket(PODCAST_BUCKET, filename)
+    return unless elevenlabs_client.available_credits
+
+    podcast_script = if student_podcast_data.podcast_script
+                       student_podcast_data.podcast_script
+                     else
+                       generate_podcast_script(student_podcast_data)
+                     end
+
+    podcast = get_podcast_from_script(podcast_script)
+    AWS::S3.upload_to_bucket(PODCAST_BUCKET, filename, podcast, no_random: true)
+  end
+
+  def self.retrieve_podcast_from_s3(student_podcast_id)
+    AWS::S3.download_from_bucket(PODCAST_BUCKET, s3_filename(student_podcast_id))
+  end
+
+  VOICE_ID_MAP = {
+    'Dan' => VOICE_ID_DAN,
+    'Sam' => VOICE_ID_SAM
+  }.freeze
+
+  def self.resolve_voice_ids(podcast_script)
+    parsed = JSON.parse(podcast_script)
+    parsed.map do |entry|
+      entry.merge('voice_id' => VOICE_ID_MAP.fetch(entry['voice_id'], entry['voice_id']))
+    end
+  end
+
+  def self.generate_podcast_script(student_podcast_data)
+    objective_ids = student_podcast_data.objective_ids
+    existing_script_podcast = AiStudentPodcast.
+      joins(:ai_student_podcast_objectives).
+      where(lesson_id: student_podcast_data.lesson_id).
+      where.not(podcast_script: nil).
+      group('ai_student_podcasts.id').
+      having(
+        'COUNT(ai_student_podcast_objectives.objective_id) = ? AND SUM(ai_student_podcast_objectives.objective_id IN (?)) = ?',
+        objective_ids.size,
+        objective_ids,
+        objective_ids.size
+      ).
+      first
+
+    if existing_script_podcast
+      student_podcast_data.podcast_script = existing_script_podcast.podcast_script
+      student_podcast_data.save!
+      return existing_script_podcast.podcast_script
+    end
+
+    prompt = AiSystemPrompts::StudentPodcastPromptHelper.get_openai_system_prompt(student_podcast_data.lesson_id, objective_ids, student_podcast_data.user_id)
+
+    begin
+      response = openai_client.request_podcast_script(prompt)
+    rescue Net::ReadTimeout, Net::OpenTimeout
+      raise OpenaiStudentPodcastTimeout.new("Timeout waiting for OpenAI client to return student podcast script")
+    rescue StandardError => exception
+      raise StandardError.new("Error generating AI student podcast script: #{exception.message}")
+    end
+
+    raise StandardError.new("Received status code #{response.code} when generating AI student podcast script: #{response.body}") unless response.code == 200
+
+    content = JSON.parse(response.body).dig('choices', 0, 'message', 'content')
+    podcast_script = JSON.parse(content).fetch('script').to_json
+    student_podcast_data.podcast_script = podcast_script
+    student_podcast_data.save!
+    return podcast_script
+  end
+
+  def self.get_podcast_from_script(podcast_script)
+    begin
+      response = elevenlabs_client.request_podcast(resolve_voice_ids(podcast_script))
+    rescue Net::OpenTimeout, Net::ReadTimeout
+      raise StandardError.new("Timeout waiting for AI client to return student podcast")
+    rescue StandardError => exception
+      raise StandardError.new("Error processing AI student podcast: #{exception.message}")
+    end
+
+    if response.code == 200
+      return response.body
+    else
+      raise StandardError.new("Error processing AI student podcast: status code #{response.code}: #{response.body}")
+    end
+  end
+
+  class ElevenlabsClient
+    attr_accessor :api_key, :model
+
+    ELEVENLABS_URL = "https://api.elevenlabs.io/v1/text-to-dialogue"
+    ELEVENLABS_SUBSCRIPTION_URL = "https://api.elevenlabs.io/v1/user/subscription"
+
+    def initialize(api_key, model)
+      @api_key = api_key
+      @model = model
+    end
+
+    def available_credits
+      headers = {
+        "Content-Type" => "application/json",
+        "xi-api-key" => @api_key
+      }
+
+      user_response = HTTParty.get(
+        ELEVENLABS_SUBSCRIPTION_URL,
+        headers: headers,
+        timeout: 180,
+      )
+
+      subscription_info = JSON.parse(user_response.body)
+
+      subscription_info['character_count'] < subscription_info['character_limit'] * 0.95
+    end
+
+    def request_podcast(prompt)
+      headers = {
+        "Content-Type" => "application/json",
+        "xi-api-key" => @api_key
+      }
+
+      data = {
+        model_id: @model,
+        inputs: prompt
+      }
+
+      HTTParty.post(
+        ELEVENLABS_URL,
+        headers: headers,
+        body: data.to_json,
+        timeout: 180,
+      )
+    end
+  end
+
+  class OpenaiClient
+    attr_accessor :api_key, :model
+
+    OPENAI_URL = "https://api.openai.com/v1/chat/completions"
+
+    def initialize(api_key, model)
+      @api_key = api_key
+      @model = model
+    end
+
+    def request_podcast_script(prompt)
+      headers = {
+        "Content-Type" => "application/json",
+        "Authorization" => "Bearer #{@api_key}"
+      }
+
+      data = {
+        model: @model,
+        messages: [{role: "system", content: prompt}],
+        response_format: {
+          type: "json_schema",
+          json_schema: {
+            name: "student_podcast_script",
+            schema: {
+              type: "object",
+              properties: {
+                script: {
+                  type: "array",
+                  items: {
+                    type: "object",
+                    properties: {
+                      voice_id: {type: "string", enum: %w[Dan Sam]},
+                      text: {type: "string"}
+                    },
+                    required: %w[voice_id text],
+                    additionalProperties: false
+                  }
+                }
+              },
+              required: ["script"],
+              additionalProperties: false
+            }
+          }
+        }
+      }
+
+      HTTParty.post(
+        OPENAI_URL,
+        headers: headers,
+        body: data.to_json,
+        open_timeout: DCDO.get('openai_http_open_timeout', 5),
+        read_timeout: DCDO.get('openai_http_read_timeout', 30)
+      )
+    end
+  end
+
+  def self.elevenlabs_client
+    ElevenlabsClient.new(CDO.elevenlabs_api_key, ELEVENLABS_MODEL)
+  end
+
+  def self.openai_client
+    OpenaiClient.new(CDO.openai_lesson_summaries_api_key, OPENAI_MODEL)
+  end
+
+  def self.s3_filename(student_podcast_id)
+    PODCAST_FOLDER + 'student_podcast_' + student_podcast_id.to_s + '.mp3'
+  end
+end

--- a/dashboard/test/helpers/ai_student_podcasts_helper_test.rb
+++ b/dashboard/test/helpers/ai_student_podcasts_helper_test.rb
@@ -1,0 +1,364 @@
+require 'test_helper'
+
+class AiStudentPodcastsHelperTest < ActionView::TestCase
+  setup do
+    @user = create(:student)
+    @other_user = create(:student)
+    @lesson = create(:lesson)
+    @objective = create(:objective)
+    @extra_objective = create(:objective)
+    @podcast = AiStudentPodcast.create!(user_id: @user.id, lesson_id: @lesson.id)
+    @podcast.ai_student_podcast_objectives.create!(objective_id: @objective.id)
+
+    @openai_api_key = 'test-openai-key'
+    @elevenlabs_api_key = 'test-elevenlabs-key'
+
+    CDO.stubs(:openai_lesson_summaries_api_key).returns(@openai_api_key)
+    CDO.stubs(:elevenlabs_api_key).returns(@elevenlabs_api_key)
+    CDO.stubs(:dashboard_hostname).returns('test.code.org')
+
+    DCDO.stubs(:get).with('openai_http_open_timeout', 5).returns(5)
+    DCDO.stubs(:get).with('openai_http_read_timeout', 30).returns(30)
+  end
+
+  teardown do
+    AiStudentPodcast.where(user_id: @user.id).destroy_all
+  end
+
+  # *****
+  # generate_podcast_script tests
+  # *****
+
+  test "generate_podcast_script saves script to the podcast record and returns it on success" do
+    script_array = [
+      {'voice_id' => 'Dan', 'text' => 'Hi there.'},
+      {'voice_id' => 'Sam', 'text' => 'Hello!'}
+    ]
+    openai_body = {
+      choices: [{message: {content: {script: script_array}.to_json}}]
+    }.to_json
+
+    AiSystemPrompts::StudentPodcastPromptHelper.stubs(:get_openai_system_prompt).
+      with(@lesson.id, [@objective.id], @user.id).returns('prompt text')
+
+    mock_response = mock('response')
+    mock_response.stubs(:code).returns(200)
+    mock_response.stubs(:body).returns(openai_body)
+    mock_client = mock('client')
+    mock_client.expects(:request_podcast_script).with('prompt text').returns(mock_response)
+    AiStudentPodcastsHelper::OpenaiClient.expects(:new).returns(mock_client)
+
+    result = AiStudentPodcastsHelper.generate_podcast_script(@podcast)
+
+    assert_equal script_array, JSON.parse(result)
+    assert_equal script_array, JSON.parse(@podcast.reload.podcast_script)
+  end
+
+  test "generate_podcast_script reuses an existing matching script from another user and skips OpenAI" do
+    other_podcast = AiStudentPodcast.create!(
+      user_id: @other_user.id,
+      lesson_id: @lesson.id,
+      podcast_script: [{'voice_id' => 'Dan', 'text' => 'shared'}].to_json
+    )
+    other_podcast.ai_student_podcast_objectives.create!(objective_id: @objective.id)
+
+    AiStudentPodcastsHelper::OpenaiClient.expects(:new).never
+    AiSystemPrompts::StudentPodcastPromptHelper.expects(:get_openai_system_prompt).never
+
+    result = AiStudentPodcastsHelper.generate_podcast_script(@podcast)
+
+    assert_equal other_podcast.podcast_script, result
+    assert_equal other_podcast.podcast_script, @podcast.reload.podcast_script
+  end
+
+  test "generate_podcast_script ignores existing podcasts whose objective set differs" do
+    other_podcast = AiStudentPodcast.create!(
+      user_id: @other_user.id,
+      lesson_id: @lesson.id,
+      podcast_script: 'should-not-be-used'
+    )
+    other_podcast.ai_student_podcast_objectives.create!(objective_id: @objective.id)
+    other_podcast.ai_student_podcast_objectives.create!(objective_id: @extra_objective.id)
+
+    AiSystemPrompts::StudentPodcastPromptHelper.stubs(:get_openai_system_prompt).returns('prompt')
+    fresh_script = [{'voice_id' => 'Sam', 'text' => 'fresh'}].to_json
+    openai_body = {choices: [{message: {content: {script: JSON.parse(fresh_script)}.to_json}}]}.to_json
+    mock_response = mock('response')
+    mock_response.stubs(:code).returns(200)
+    mock_response.stubs(:body).returns(openai_body)
+    mock_client = mock('client')
+    mock_client.expects(:request_podcast_script).returns(mock_response)
+    AiStudentPodcastsHelper::OpenaiClient.expects(:new).returns(mock_client)
+
+    result = AiStudentPodcastsHelper.generate_podcast_script(@podcast)
+
+    assert_equal fresh_script, result
+  end
+
+  test "generate_podcast_script raises OpenaiStudentPodcastTimeout on read timeout" do
+    AiSystemPrompts::StudentPodcastPromptHelper.stubs(:get_openai_system_prompt).returns('prompt')
+    mock_client = mock('client')
+    mock_client.expects(:request_podcast_script).raises(Net::ReadTimeout)
+    AiStudentPodcastsHelper::OpenaiClient.expects(:new).returns(mock_client)
+
+    assert_raises(OpenaiStudentPodcastTimeout) do
+      AiStudentPodcastsHelper.generate_podcast_script(@podcast)
+    end
+  end
+
+  test "generate_podcast_script raises StandardError on non-200 response" do
+    AiSystemPrompts::StudentPodcastPromptHelper.stubs(:get_openai_system_prompt).returns('prompt')
+    mock_response = mock('response')
+    mock_response.stubs(:code).returns(500)
+    mock_response.stubs(:body).returns('boom')
+    mock_client = mock('client')
+    mock_client.expects(:request_podcast_script).returns(mock_response)
+    AiStudentPodcastsHelper::OpenaiClient.expects(:new).returns(mock_client)
+
+    error = assert_raises(StandardError) do
+      AiStudentPodcastsHelper.generate_podcast_script(@podcast)
+    end
+    assert_includes error.message, 'status code 500'
+  end
+
+  # *****
+  # create_and_save_to_s3 tests
+  # *****
+
+  test "create_and_save_to_s3 short-circuits without generating script when file already exists in S3" do
+    AWS::S3.stubs(:exists_in_bucket).returns(true)
+    AWS::S3.expects(:upload_to_bucket).never
+    AiStudentPodcastsHelper::ElevenlabsClient.any_instance.expects(:available_credits).never
+    AiStudentPodcastsHelper.expects(:generate_podcast_script).never
+    AiStudentPodcastsHelper.expects(:get_podcast_from_script).never
+
+    AiStudentPodcastsHelper.create_and_save_to_s3(@podcast)
+  end
+
+  test "create_and_save_to_s3 short-circuits without generating script when ElevenLabs credits unavailable" do
+    AWS::S3.stubs(:exists_in_bucket).returns(false)
+    AiStudentPodcastsHelper::ElevenlabsClient.any_instance.stubs(:available_credits).returns(false)
+    AWS::S3.expects(:upload_to_bucket).never
+    AiStudentPodcastsHelper.expects(:generate_podcast_script).never
+    AiStudentPodcastsHelper.expects(:get_podcast_from_script).never
+
+    AiStudentPodcastsHelper.create_and_save_to_s3(@podcast)
+  end
+
+  test "create_and_save_to_s3 generates script, fetches mp3, and uploads when S3 file missing and credits available" do
+    AWS::S3.stubs(:exists_in_bucket).returns(false)
+    AiStudentPodcastsHelper::ElevenlabsClient.any_instance.stubs(:available_credits).returns(true)
+    generated_script = [{voice_id: 'Dan', text: 'hello'}].to_json
+
+    AiStudentPodcastsHelper.expects(:generate_podcast_script).
+      with(@podcast).returns(generated_script)
+    AiStudentPodcastsHelper.expects(:get_podcast_from_script).
+      with(generated_script).returns('mp3-bytes')
+    AWS::S3.expects(:upload_to_bucket).with(
+      AiStudentPodcastsHelper::PODCAST_BUCKET,
+      AiStudentPodcastsHelper.s3_filename(@podcast.id),
+      'mp3-bytes',
+      no_random: true
+    )
+
+    AiStudentPodcastsHelper.create_and_save_to_s3(@podcast)
+  end
+
+  test "create_and_save_to_s3 reuses an existing podcast_script and skips OpenAI when one is already saved" do
+    existing_script = [{voice_id: 'Dan', text: 'reused'}].to_json
+    @podcast.update!(podcast_script: existing_script)
+    AWS::S3.stubs(:exists_in_bucket).returns(false)
+    AiStudentPodcastsHelper::ElevenlabsClient.any_instance.stubs(:available_credits).returns(true)
+
+    AiStudentPodcastsHelper.expects(:generate_podcast_script).never
+    AiStudentPodcastsHelper.expects(:get_podcast_from_script).
+      with(existing_script).returns('mp3-bytes')
+    AWS::S3.expects(:upload_to_bucket).with(
+      AiStudentPodcastsHelper::PODCAST_BUCKET,
+      AiStudentPodcastsHelper.s3_filename(@podcast.id),
+      'mp3-bytes',
+      no_random: true
+    )
+
+    AiStudentPodcastsHelper.create_and_save_to_s3(@podcast)
+  end
+
+  # *****
+  # retrieve_podcast_from_s3 tests
+  # *****
+
+  test "retrieve_podcast_from_s3 delegates to AWS::S3.download_from_bucket" do
+    AWS::S3.expects(:download_from_bucket).with(
+      AiStudentPodcastsHelper::PODCAST_BUCKET,
+      AiStudentPodcastsHelper.s3_filename(42)
+    ).returns('mp3-bytes')
+
+    assert_equal 'mp3-bytes', AiStudentPodcastsHelper.retrieve_podcast_from_s3(42)
+  end
+
+  # *****
+  # resolve_voice_ids tests
+  # *****
+
+  test "resolve_voice_ids maps Dan and Sam to their ElevenLabs voice IDs" do
+    script = [
+      {'voice_id' => 'Dan', 'text' => 'a'},
+      {'voice_id' => 'Sam', 'text' => 'b'}
+    ].to_json
+
+    result = AiStudentPodcastsHelper.resolve_voice_ids(script)
+
+    assert_equal AiStudentPodcastsHelper::VOICE_ID_DAN, result[0]['voice_id']
+    assert_equal AiStudentPodcastsHelper::VOICE_ID_SAM, result[1]['voice_id']
+    assert_equal 'a', result[0]['text']
+  end
+
+  test "resolve_voice_ids passes through unknown voice_id values unchanged" do
+    script = [{'voice_id' => 'Unknown', 'text' => 'x'}].to_json
+
+    result = AiStudentPodcastsHelper.resolve_voice_ids(script)
+
+    assert_equal 'Unknown', result[0]['voice_id']
+  end
+
+  # *****
+  # get_podcast_from_script tests (ElevenLabs)
+  # *****
+
+  test "get_podcast_from_script returns response body on 200" do
+    script = [{'voice_id' => 'Dan', 'text' => 'hi'}].to_json
+    mock_response = mock('response')
+    mock_response.stubs(:code).returns(200)
+    mock_response.stubs(:body).returns('mp3-bytes')
+    mock_client = mock('client')
+    mock_client.expects(:request_podcast).returns(mock_response)
+    AiStudentPodcastsHelper::ElevenlabsClient.expects(:new).returns(mock_client)
+
+    assert_equal 'mp3-bytes', AiStudentPodcastsHelper.get_podcast_from_script(script)
+  end
+
+  test "get_podcast_from_script raises on non-200 ElevenLabs response" do
+    script = [{'voice_id' => 'Dan', 'text' => 'hi'}].to_json
+    mock_response = mock('response')
+    mock_response.stubs(:code).returns(429)
+    mock_response.stubs(:body).returns('rate limited')
+    mock_client = mock('client')
+    mock_client.expects(:request_podcast).returns(mock_response)
+    AiStudentPodcastsHelper::ElevenlabsClient.expects(:new).returns(mock_client)
+
+    error = assert_raises(StandardError) do
+      AiStudentPodcastsHelper.get_podcast_from_script(script)
+    end
+    assert_includes error.message, 'status code 429'
+  end
+
+  test "get_podcast_from_script wraps timeouts as StandardError" do
+    script = [{'voice_id' => 'Dan', 'text' => 'hi'}].to_json
+    mock_client = mock('client')
+    mock_client.expects(:request_podcast).raises(Net::OpenTimeout)
+    AiStudentPodcastsHelper::ElevenlabsClient.expects(:new).returns(mock_client)
+
+    error = assert_raises(StandardError) do
+      AiStudentPodcastsHelper.get_podcast_from_script(script)
+    end
+    assert_includes error.message, 'Timeout'
+  end
+
+  # *****
+  # s3_filename tests
+  # *****
+
+  test "s3_filename returns folder-prefixed mp3 filename including the podcast id" do
+    assert_equal 'student_podcasts/student_podcast_42.mp3',
+      AiStudentPodcastsHelper.s3_filename(42)
+  end
+
+  # *****
+  # ElevenlabsClient tests
+  # *****
+
+  test "ElevenlabsClient initialize stores api_key and model" do
+    client = AiStudentPodcastsHelper::ElevenlabsClient.new('key', 'model')
+    assert_equal 'key', client.api_key
+    assert_equal 'model', client.model
+  end
+
+  test "ElevenlabsClient available_credits returns true when usage is under 95% of the character limit" do
+    mock_response = mock('response')
+    mock_response.stubs(:body).returns({character_count: 949, character_limit: 1000}.to_json)
+    HTTParty.expects(:get).with(
+      AiStudentPodcastsHelper::ElevenlabsClient::ELEVENLABS_SUBSCRIPTION_URL,
+      headers: {"Content-Type" => "application/json", "xi-api-key" => @elevenlabs_api_key},
+      timeout: 180
+    ).returns(mock_response)
+
+    client = AiStudentPodcastsHelper::ElevenlabsClient.new(@elevenlabs_api_key, AiStudentPodcastsHelper::ELEVENLABS_MODEL)
+    assert client.available_credits
+  end
+
+  test "ElevenlabsClient available_credits returns false when usage is at or above 95% of the character limit" do
+    mock_response = mock('response')
+    mock_response.stubs(:body).returns({character_count: 950, character_limit: 1000}.to_json)
+    HTTParty.stubs(:get).returns(mock_response)
+
+    client = AiStudentPodcastsHelper::ElevenlabsClient.new(@elevenlabs_api_key, AiStudentPodcastsHelper::ELEVENLABS_MODEL)
+    refute client.available_credits
+  end
+
+  test "ElevenlabsClient request_podcast POSTs JSON to the text-to-dialogue endpoint" do
+    prompt = [{voice_id: 'abc', text: 'hi'}]
+    expected_headers = {
+      "Content-Type" => "application/json",
+      "xi-api-key" => @elevenlabs_api_key
+    }
+    expected_body = {
+      model_id: AiStudentPodcastsHelper::ELEVENLABS_MODEL,
+      inputs: prompt
+    }.to_json
+
+    HTTParty.expects(:post).with(
+      AiStudentPodcastsHelper::ElevenlabsClient::ELEVENLABS_URL,
+      headers: expected_headers,
+      body: expected_body,
+      timeout: 180
+    ).returns(mock('response'))
+
+    AiStudentPodcastsHelper::ElevenlabsClient.new(@elevenlabs_api_key, AiStudentPodcastsHelper::ELEVENLABS_MODEL).
+      request_podcast(prompt)
+  end
+
+  # *****
+  # OpenaiClient tests
+  # *****
+
+  test "OpenaiClient initialize stores api_key and model" do
+    client = AiStudentPodcastsHelper::OpenaiClient.new('key', 'model')
+    assert_equal 'key', client.api_key
+    assert_equal 'model', client.model
+  end
+
+  test "OpenaiClient request_podcast_script POSTs to OpenAI chat completions with structured output schema" do
+    HTTParty.stubs(:post) do |url, options|
+      assert_equal AiStudentPodcastsHelper::OpenaiClient::OPENAI_URL, url
+      assert_equal "Bearer #{@openai_api_key}", options[:headers]['Authorization']
+      assert_equal 'application/json', options[:headers]['Content-Type']
+
+      body = JSON.parse(options[:body])
+      assert_equal AiStudentPodcastsHelper::OPENAI_MODEL, body['model']
+      assert_equal 'system', body['messages'].first['role']
+      assert_equal 'prompt-here', body['messages'].first['content']
+
+      schema = body['response_format']['json_schema']['schema']
+      assert_equal 'object', schema['type']
+      assert_equal ['script'], schema['required']
+      item_props = schema['properties']['script']['items']['properties']
+      assert_equal %w[Dan Sam], item_props['voice_id']['enum']
+      assert_equal 'string', item_props['text']['type']
+
+      mock('response')
+    end
+
+    AiStudentPodcastsHelper::OpenaiClient.new(@openai_api_key, AiStudentPodcastsHelper::OPENAI_MODEL).
+      request_podcast_script('prompt-here')
+  end
+end


### PR DESCRIPTION
Adds AiStudentPodcastsHelper, which generates a podcast script via OpenAI and converts it to audio via ElevenLabs, then uploads the result to S3. The helper short-circuits when an mp3 already exists in S3, when an existing podcast record already has a saved script, when another user has already generated a script for the same lesson + objective set, or when ElevenLabs credits are exhausted. Includes inner OpenaiClient and ElevenlabsClient HTTP wrappers.

## Links
[Tech Spec](https://docs.google.com/document/d/11PaNckag4LLh18f_MQcc92h-9FMqb3Pi8yGa1NtumaI/edit?tab=t.0)

## Testing story
Added unit test coverage

## Deployment notes
<!-- Delete this section if it's a standard merge-and-deploy.
     Otherwise: migrations, feature flags, coordination, caching impacts, etc. -->



## Privacy and security
<!-- Delete this section if there is no privacy/security impact.
     Otherwise: new PII, auth changes, API surface changes, etc. -->

