### PR TITLE
start using device farm to run eyes tests during DTT

### DIFF
--- a/lib/rake/test.rake
+++ b/lib/rake/test.rake
@@ -110,15 +110,16 @@ namespace :test do
     failed_browser_count = RakeUtils.system_with_chat_logging(
       "cd #{dashboard_dir('test/ui')} &&",
       'bundle', 'exec', './runner.rb',
-      '-c', 'Chrome,iPhone',
+      '--device-farm',
+      '-c', 'Chrome',
       '-d', CDO.site_host('studio.code.org'),
       '-p', CDO.site_host('code.org'),
       '--db', # Ensure features that require database access are run even if the server name isn't "test"
       '--eyes',
-      '--magic_retry',
+      '--retry_count', '2',
       '--with-status-page',
       '-f', eyes_features.join(","),
-      '--parallel', '20' # The total saucelabs concurrency budget is 65
+      '--parallel', '20'
     )
     if failed_browser_count == 0
       message = '⊙‿⊙ Eyes tests for <b>dashboard</b> succeeded, no changes detected.'
@@ -129,35 +130,6 @@ namespace :test do
       ChatClient.log message, color: 'red'
       ChatClient.message 'server operations', message, color: 'red', notify: 1
       raise "Eyes tests failed"
-    end
-  end
-
-  timed_task_with_logging :devicefarm_eyes_ui do
-    ChatClient.log 'Running <b>dashboard</b> UI visual tests on AWS Device Farm...'
-    eyes_features = `cd #{dashboard_dir('test/ui')} && find features/ -name "*.feature" | xargs grep -lr '@eyes'`.split("\n")
-    failed_browser_count = RakeUtils.system_with_chat_logging(
-      "cd #{dashboard_dir('test/ui')} &&",
-      'bundle', 'exec', './runner.rb',
-      '--device-farm',
-      '-c', 'Chrome',
-      '-d', CDO.site_host('studio.code.org'),
-      '-p', CDO.site_host('code.org'),
-      '--db', # Ensure features that require database access are run even if the server name isn't "test"
-      '--eyes',
-      '--magic_retry',
-      '--with-status-page',
-      '-f', eyes_features.join(","),
-      '--parallel', '25'
-    )
-    if failed_browser_count == 0
-      message = '⊙‿⊙ Device Farm Eyes tests for <b>dashboard</b> succeeded, no changes detected.'
-      ChatClient.log message
-      ChatClient.message 'server operations', message, color: 'green'
-    else
-      message = 'ಠ_ಠ Device Farm Eyes tests for <b>dashboard</b> failed. See <a href="https://eyes.applitools.com/app/sessions/">the console</a> for results or to modify baselines.'
-      ChatClient.log message, color: 'red'
-      ChatClient.message 'server operations', message, color: 'red', notify: 1
-      raise "Device Farm Eyes tests failed"
     end
   end
 


### PR DESCRIPTION
See [proposal](https://docs.google.com/document/d/1kNNurct5LrFyWpv48P7_JpG8BMI9LyUad3K1pXFNWCI/edit?tab=t.0) to save $ on Device Farm (mobile). The first step for freeing up saucelabs concurrency is to move eyes tests from Sauce Labs to Device Farm.

## Testing story
results from running `rake test:devicefarm_eyes_ui` on the test machine:
- no selenium errors: [device farm eyes results](https://docs.google.com/spreadsheets/d/1zOTgdgVgc2X7HT9LbF8VuzMd0O4DgVaV3g3Y-V8OMNE/edit?gid=0#gid=0)
- I spot checked eyes diffs, and mostly saw small rendering changes that could reasonably result from a browser version bump: https://eyes.applitools.com/app/test-results/00000251623157475754/?accountId=mG4DoRfv0ntEgI3XIYBulrKxlZqrHtGwbP3V103ojvLFU110

## Eyes baseline matching issues

For some reason, the Device Farm diffs are running against Chrome 105 baselines from ~1 year ago (from just before we bumped Chrome from 105 to 109 in https://github.com/code-dot-org/code-dot-org/pull/65884), whereas most of our other baselines in the DTT are from Chrome 109 (generated before the recent bump to Chrome 138). This means that we'll be re-accepting some diffs that were already previously accepted as part of the 105 -> 109 and 109 -> 138 version bumps.

### screenshots

#### DTT, Sauce Labs, Chrome 138 (vs Chrome 109)
result of running `rake test:eyes_ui` on the test machine / test branch as part of the DTT: https://eyes.applitools.com/app/test-results/00000251623131066954/00000251623130498935/steps/2?accountId=mG4DoRfv0ntEgI3XIYBulrKxlZqrHtGwbP3V103ojvLFU110&mode=step-editor

<img width="1837" height="512" alt="Screenshot 2026-05-19 at 11 32 36 AM" src="https://github.com/user-attachments/assets/3611819b-8cb8-491e-b8cd-d012c80f2903" />

<img width="2095" height="423" alt="Screenshot 2026-05-19 at 9 54 43 AM" src="https://github.com/user-attachments/assets/7fed0ce1-729b-4c04-ac38-613d349527d9" />

#### manual, Device Farm, Chrome 148 (vs Chrome 105)
result of manually running `rake test:devicefarm_eyes_ui` on the test machine / test branch: https://eyes.applitools.com/app/test-results/00000251623157475754/00000251623156942237/steps/2?accountId=mG4DoRfv0ntEgI3XIYBulrKxlZqrHtGwbP3V103ojvLFU110&mode=step-editor

<img width="1632" height="489" alt="Screenshot 2026-05-19 at 11 33 05 AM" src="https://github.com/user-attachments/assets/11921167-d713-4985-9e2f-5973504b58af" />

<img width="2083" height="395" alt="Screenshot 2026-05-19 at 9 54 52 AM" src="https://github.com/user-attachments/assets/429f44d5-a161-46d0-a711-d643f3367968" />


### alternatives considered

I looked into a few options and I think just merging and reaccepting is best because at least we'll keep some ignore regions from 1 year ago. the other general alternative is to more specifically name the set of baselines in applitools, causing an initial clean wipe of eyes baselines (and ignore regions), but then giving us slightly more confidence while inspecting visual diffs when we move to Device Farm. To me, the small amount of added confidence does not seem to outweigh the high amount of manual work that it will take to add back ignore regions, but I'm open to pushback.

## Deployment notes
- merge to staging, wait for DTT, then sift through eyes diffs + accept baselines before marking DTT green
